### PR TITLE
LLM-1285: Web fetch tool

### DIFF
--- a/extensions/web-fetch/browser-pool.test.ts
+++ b/extensions/web-fetch/browser-pool.test.ts
@@ -1,0 +1,215 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+// We test the browser pool by mocking the playwright import.
+// Use dynamic import reset to control what import("playwright") returns.
+
+let mockBrowser: {
+	isConnected: () => boolean;
+	close: ReturnType<typeof vi.fn>;
+	on: ReturnType<typeof vi.fn>;
+};
+
+let launchMock: ReturnType<typeof vi.fn>;
+let playwrightImportFails: boolean;
+
+vi.mock("playwright", () => {
+	return {
+		get chromium() {
+			if (playwrightImportFails) {
+				throw new Error("Cannot find module 'playwright'");
+			}
+			return { launch: (...args: unknown[]) => launchMock(...args) };
+		},
+	};
+});
+
+import { BrowserPool } from "./browser-pool.js";
+
+describe("BrowserPool", () => {
+	let pool: BrowserPool;
+
+	beforeEach(() => {
+		playwrightImportFails = false;
+
+		let connected = true;
+		mockBrowser = {
+			isConnected: () => connected,
+			close: vi.fn().mockImplementation(async () => { connected = false; }),
+			on: vi.fn(),
+		};
+
+		launchMock = vi.fn().mockResolvedValue(mockBrowser);
+		pool = new BrowserPool();
+	});
+
+	afterEach(async () => {
+		await pool.shutdown();
+		vi.restoreAllMocks();
+	});
+
+	it("returns a browser on first call (lazy init)", async () => {
+		const browser = await pool.getBrowser();
+		expect(browser).toBe(mockBrowser);
+		expect(launchMock).toHaveBeenCalledOnce();
+		expect(launchMock).toHaveBeenCalledWith({ headless: true });
+	});
+
+	it("reuses the browser on subsequent calls", async () => {
+		const first = await pool.getBrowser();
+		const second = await pool.getBrowser();
+		expect(first).toBe(second);
+		expect(launchMock).toHaveBeenCalledOnce();
+	});
+
+	it("returns null when playwright is not installed", async () => {
+		playwrightImportFails = true;
+		pool = new BrowserPool();
+		const browser = await pool.getBrowser();
+		expect(browser).toBeNull();
+		expect(pool.isPlaywrightAvailable()).toBe(false);
+	});
+
+	it("returns null on subsequent calls after playwright was detected as missing", async () => {
+		playwrightImportFails = true;
+		pool = new BrowserPool();
+		await pool.getBrowser();
+		// Even if we "fix" it, the cached flag stays false within the session
+		playwrightImportFails = false;
+		const browser = await pool.getBrowser();
+		expect(browser).toBeNull();
+	});
+
+	it("returns null when chromium launch fails", async () => {
+		launchMock.mockRejectedValue(new Error("Chromium not found"));
+		const browser = await pool.getBrowser();
+		expect(browser).toBeNull();
+		expect(pool.isPlaywrightAvailable()).toBe(false);
+	});
+
+	it("creates a new browser after the old one disconnects", async () => {
+		const first = await pool.getBrowser();
+		expect(first).toBe(mockBrowser);
+
+		// Simulate disconnect: fire the "disconnected" handler
+		const disconnectHandler = mockBrowser.on.mock.calls.find(
+			(call: unknown[]) => call[0] === "disconnected",
+		)?.[1] as () => void;
+		expect(disconnectHandler).toBeDefined();
+		disconnectHandler();
+
+		// Create a new mock browser for the re-launch
+		const newBrowser = {
+			isConnected: () => true,
+			close: vi.fn(),
+			on: vi.fn(),
+		};
+		launchMock.mockResolvedValue(newBrowser);
+
+		const second = await pool.getBrowser();
+		expect(second).toBe(newBrowser);
+		expect(launchMock).toHaveBeenCalledTimes(2);
+	});
+
+	it("shutdown closes the browser", async () => {
+		await pool.getBrowser();
+		await pool.shutdown();
+		expect(mockBrowser.close).toHaveBeenCalled();
+	});
+
+	it("shutdown is safe to call with no browser", async () => {
+		// Should not throw
+		await pool.shutdown();
+	});
+
+	it("registers disconnected event handler", async () => {
+		await pool.getBrowser();
+		expect(mockBrowser.on).toHaveBeenCalledWith("disconnected", expect.any(Function));
+	});
+
+	describe("idle timeout", () => {
+		beforeEach(() => {
+			vi.useFakeTimers();
+			pool = new BrowserPool({ idleTimeoutMs: 500 });
+		});
+
+		afterEach(() => {
+			vi.useRealTimers();
+		});
+
+		it("closes browser after idle timeout expires", async () => {
+			await pool.getBrowser();
+			expect(mockBrowser.close).not.toHaveBeenCalled();
+
+			await vi.advanceTimersByTimeAsync(500);
+
+			expect(mockBrowser.close).toHaveBeenCalledOnce();
+		});
+
+		it("resets idle timer on subsequent getBrowser calls", async () => {
+			await pool.getBrowser();
+
+			// Advance partway — browser should still be alive
+			await vi.advanceTimersByTimeAsync(400);
+			expect(mockBrowser.close).not.toHaveBeenCalled();
+
+			// Second call resets the timer
+			await pool.getBrowser();
+
+			// Advance another 400ms (800ms total, but only 400ms since reset)
+			await vi.advanceTimersByTimeAsync(400);
+			expect(mockBrowser.close).not.toHaveBeenCalled();
+
+			// Advance past the reset timer
+			await vi.advanceTimersByTimeAsync(100);
+			expect(mockBrowser.close).toHaveBeenCalledOnce();
+		});
+
+		it("creates a new browser after idle timeout closed the previous one", async () => {
+			const first = await pool.getBrowser();
+			expect(first).toBe(mockBrowser);
+
+			// Let idle timeout fire
+			await vi.advanceTimersByTimeAsync(500);
+			expect(mockBrowser.close).toHaveBeenCalledOnce();
+
+			// New browser for next call
+			const newBrowser = {
+				isConnected: () => true,
+				close: vi.fn(),
+				on: vi.fn(),
+			};
+			launchMock.mockResolvedValue(newBrowser);
+
+			const second = await pool.getBrowser();
+			expect(second).toBe(newBrowser);
+			expect(launchMock).toHaveBeenCalledTimes(2);
+		});
+	});
+
+	describe("crash recovery", () => {
+		it("recovers after browser disconnect and serves subsequent fetch", async () => {
+			const first = await pool.getBrowser();
+			expect(first).toBe(mockBrowser);
+
+			// Simulate crash via disconnected event
+			const disconnectHandler = mockBrowser.on.mock.calls.find(
+				(call: unknown[]) => call[0] === "disconnected",
+			)?.[1] as () => void;
+			disconnectHandler();
+
+			// Prepare a fresh browser for recovery
+			const recoveredBrowser = {
+				isConnected: () => true,
+				close: vi.fn(),
+				on: vi.fn(),
+			};
+			launchMock.mockResolvedValue(recoveredBrowser);
+
+			// Next call should lazily create a new browser
+			const second = await pool.getBrowser();
+			expect(second).toBe(recoveredBrowser);
+			expect(second).not.toBe(first);
+			expect(launchMock).toHaveBeenCalledTimes(2);
+		});
+	});
+});

--- a/extensions/web-fetch/browser-pool.test.ts
+++ b/extensions/web-fetch/browser-pool.test.ts
@@ -79,11 +79,33 @@ describe("BrowserPool", () => {
 		expect(browser).toBeNull();
 	});
 
-	it("returns null when chromium launch fails", async () => {
-		launchMock.mockRejectedValue(new Error("Chromium not found"));
+	it("returns null when chromium executable is missing and permanently disables", async () => {
+		launchMock.mockRejectedValue(
+			new Error("browserType.launch: Executable doesn't exist at /path/to/chromium"),
+		);
 		const browser = await pool.getBrowser();
 		expect(browser).toBeNull();
 		expect(pool.isPlaywrightAvailable()).toBe(false);
+
+		// Subsequent call should not retry
+		launchMock.mockResolvedValue(mockBrowser);
+		const second = await pool.getBrowser();
+		expect(second).toBeNull();
+		expect(launchMock).toHaveBeenCalledOnce();
+	});
+
+	it("retries after transient launch error (e.g. ENOMEM)", async () => {
+		launchMock.mockRejectedValueOnce(new Error("spawn ENOMEM"));
+		const first = await pool.getBrowser();
+		expect(first).toBeNull();
+		// playwrightAvailable should still be true so next call retries
+		expect(pool.isPlaywrightAvailable()).toBe(true);
+
+		// Next call succeeds
+		launchMock.mockResolvedValue(mockBrowser);
+		const second = await pool.getBrowser();
+		expect(second).toBe(mockBrowser);
+		expect(launchMock).toHaveBeenCalledTimes(2);
 	});
 
 	it("creates a new browser after the old one disconnects", async () => {

--- a/extensions/web-fetch/browser-pool.ts
+++ b/extensions/web-fetch/browser-pool.ts
@@ -1,0 +1,132 @@
+/**
+ * Browser pool — manages a single Playwright browser instance.
+ *
+ * - Lazy initialization: browser is created on first use.
+ * - Reuse: subsequent fetches reuse the same browser instance.
+ * - Idle timeout: browser auto-closes after 60 seconds of inactivity.
+ * - Crash recovery: if the browser dies, the next call lazily creates a new one.
+ */
+
+import type { Browser } from "playwright";
+
+/** Default idle timeout (ms). */
+const DEFAULT_IDLE_TIMEOUT_MS = 60_000;
+
+export interface BrowserPoolOptions {
+	idleTimeoutMs?: number;
+}
+
+export class BrowserPool {
+	private readonly idleTimeoutMs: number;
+	private browser: Browser | null = null;
+	private idleTimer: ReturnType<typeof setTimeout> | null = null;
+	private playwrightAvailable: boolean | null = null;
+
+	constructor(options?: BrowserPoolOptions) {
+		this.idleTimeoutMs = options?.idleTimeoutMs ?? DEFAULT_IDLE_TIMEOUT_MS;
+	}
+
+	/**
+	 * Get a Playwright browser instance. Returns null if Playwright is not
+	 * installed (the caller should fall back to native fetch).
+	 *
+	 * The browser is created lazily on first call, reused across calls, and
+	 * automatically closed after the configured idle timeout.
+	 */
+	async getBrowser(): Promise<Browser | null> {
+		const pw = await this.loadPlaywright();
+		if (!pw) return null;
+
+		// If we have a live browser, reuse it.
+		if (this.browser?.isConnected()) {
+			this.resetIdleTimer();
+			return this.browser;
+		}
+
+		// Previous browser crashed or was closed — clean up.
+		this.browser = null;
+
+		try {
+			this.browser = await pw.chromium.launch({ headless: true });
+			this.resetIdleTimer();
+
+			// Auto-cleanup if the browser crashes or disconnects unexpectedly.
+			this.browser.on("disconnected", () => {
+				this.browser = null;
+				if (this.idleTimer) {
+					clearTimeout(this.idleTimer);
+					this.idleTimer = null;
+				}
+			});
+
+			return this.browser;
+		} catch {
+			// Chromium binary not installed — treat as "Playwright unavailable".
+			this.playwrightAvailable = false;
+			return null;
+		}
+	}
+
+	/** Shut down the browser pool. */
+	async shutdown(): Promise<void> {
+		await this.closeBrowser();
+	}
+
+	/** Check whether Playwright was detected as available. */
+	isPlaywrightAvailable(): boolean {
+		return this.playwrightAvailable === true;
+	}
+
+	private async loadPlaywright(): Promise<typeof import("playwright") | null> {
+		if (this.playwrightAvailable === false) return null;
+		try {
+			const pw = await import("playwright");
+			this.playwrightAvailable = true;
+			return pw;
+		} catch {
+			this.playwrightAvailable = false;
+			return null;
+		}
+	}
+
+	private resetIdleTimer(): void {
+		if (this.idleTimer) clearTimeout(this.idleTimer);
+		this.idleTimer = setTimeout(() => {
+			void this.closeBrowser();
+		}, this.idleTimeoutMs);
+	}
+
+	private async closeBrowser(): Promise<void> {
+		if (this.idleTimer) {
+			clearTimeout(this.idleTimer);
+			this.idleTimer = null;
+		}
+		if (this.browser) {
+			const b = this.browser;
+			this.browser = null;
+			try {
+				await b.close();
+			} catch {
+				// Already closed or crashed — ignore.
+			}
+		}
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Default singleton — keeps the same module-level API for consumers.
+// ---------------------------------------------------------------------------
+
+const defaultPool = new BrowserPool();
+
+export async function getBrowser(): Promise<Browser | null> {
+	return defaultPool.getBrowser();
+}
+
+export async function shutdownBrowserPool(): Promise<void> {
+	return defaultPool.shutdown();
+}
+
+export function isPlaywrightAvailable(): boolean {
+	return defaultPool.isPlaywrightAvailable();
+}

--- a/extensions/web-fetch/browser-pool.ts
+++ b/extensions/web-fetch/browser-pool.ts
@@ -16,6 +16,18 @@ export interface BrowserPoolOptions {
 	idleTimeoutMs?: number;
 }
 
+/**
+ * Returns true when the error indicates Chromium is permanently unavailable
+ * (not installed). Returns false for transient failures that should be retried.
+ */
+function isPermanentLaunchError(err: unknown): boolean {
+	const message = err instanceof Error ? err.message : String(err);
+	return (
+		message.includes("Executable doesn't exist") ||
+		message.includes("Cannot find module")
+	);
+}
+
 export class BrowserPool {
 	private readonly idleTimeoutMs: number;
 	private browser: Browser | null = null;
@@ -60,9 +72,13 @@ export class BrowserPool {
 			});
 
 			return this.browser;
-		} catch {
-			// Chromium binary not installed — treat as "Playwright unavailable".
-			this.playwrightAvailable = false;
+		} catch (err) {
+			// Only permanently disable Playwright when Chromium is genuinely
+			// not installed. Transient errors (resource exhaustion, file locks)
+			// should allow retry on the next call.
+			if (isPermanentLaunchError(err)) {
+				this.playwrightAvailable = false;
+			}
 			return null;
 		}
 	}

--- a/extensions/web-fetch/cache.test.ts
+++ b/extensions/web-fetch/cache.test.ts
@@ -1,127 +1,196 @@
-import { afterEach, describe, expect, it, vi } from "vitest";
-import { _setTTL, cacheClear, cacheGet, cacheKey, cacheSet, cacheSize } from "./cache.js";
+import { describe, expect, it, vi } from "vitest";
+import { Cache, MAX_ENTRIES } from "./cache.js";
 
-afterEach(() => {
-	cacheClear();
-	_setTTL(undefined); // reset to default
-	vi.restoreAllMocks();
-});
-
-describe("cacheKey", () => {
+describe("Cache.key", () => {
 	it("combines URL and format with :: separator", () => {
-		expect(cacheKey("https://example.com/", "markdown")).toBe("https://example.com/::markdown");
+		expect(Cache.key("https://example.com/", "markdown")).toBe("https://example.com/::markdown");
 	});
 
 	it("produces different keys for different formats", () => {
-		const md = cacheKey("https://example.com/", "markdown");
-		const txt = cacheKey("https://example.com/", "text");
-		const html = cacheKey("https://example.com/", "html");
+		const md = Cache.key("https://example.com/", "markdown");
+		const txt = Cache.key("https://example.com/", "text");
+		const html = Cache.key("https://example.com/", "html");
 		expect(md).not.toBe(txt);
 		expect(md).not.toBe(html);
 		expect(txt).not.toBe(html);
 	});
 
 	it("produces different keys for different URLs", () => {
-		const a = cacheKey("https://a.com/", "markdown");
-		const b = cacheKey("https://b.com/", "markdown");
+		const a = Cache.key("https://a.com/", "markdown");
+		const b = Cache.key("https://b.com/", "markdown");
 		expect(a).not.toBe(b);
 	});
 });
 
-describe("cacheGet / cacheSet", () => {
+describe("get / set", () => {
 	it("returns undefined on cache miss", () => {
-		expect(cacheGet("https://example.com/", "markdown")).toBeUndefined();
+		const cache = new Cache();
+		expect(cache.get("https://example.com/", "markdown")).toBeUndefined();
 	});
 
 	it("returns stored value on cache hit", () => {
-		cacheSet("https://example.com/", "markdown", "cached output");
-		expect(cacheGet("https://example.com/", "markdown")).toBe("cached output");
+		const cache = new Cache();
+		cache.set("https://example.com/", "markdown", "cached output");
+		expect(cache.get("https://example.com/", "markdown")).toBe("cached output");
 	});
 
 	it("returns undefined for same URL but different format", () => {
-		cacheSet("https://example.com/", "markdown", "md output");
-		expect(cacheGet("https://example.com/", "text")).toBeUndefined();
+		const cache = new Cache();
+		cache.set("https://example.com/", "markdown", "md output");
+		expect(cache.get("https://example.com/", "text")).toBeUndefined();
 	});
 
 	it("overwrites existing entry for same key", () => {
-		cacheSet("https://example.com/", "markdown", "first");
-		cacheSet("https://example.com/", "markdown", "second");
-		expect(cacheGet("https://example.com/", "markdown")).toBe("second");
+		const cache = new Cache();
+		cache.set("https://example.com/", "markdown", "first");
+		cache.set("https://example.com/", "markdown", "second");
+		expect(cache.get("https://example.com/", "markdown")).toBe("second");
 	});
 
 	it("stores entries for multiple URLs independently", () => {
-		cacheSet("https://a.com/", "markdown", "output A");
-		cacheSet("https://b.com/", "markdown", "output B");
-		expect(cacheGet("https://a.com/", "markdown")).toBe("output A");
-		expect(cacheGet("https://b.com/", "markdown")).toBe("output B");
+		const cache = new Cache();
+		cache.set("https://a.com/", "markdown", "output A");
+		cache.set("https://b.com/", "markdown", "output B");
+		expect(cache.get("https://a.com/", "markdown")).toBe("output A");
+		expect(cache.get("https://b.com/", "markdown")).toBe("output B");
 	});
 });
 
 describe("TTL expiry", () => {
 	it("returns undefined after TTL has elapsed", () => {
-		_setTTL(100); // 100ms TTL
-		cacheSet("https://example.com/", "markdown", "cached");
+		const cache = new Cache({ ttlMs: 100 });
+		cache.set("https://example.com/", "markdown", "cached");
 
-		// Advance time past TTL
 		vi.useFakeTimers();
 		vi.advanceTimersByTime(150);
 
-		expect(cacheGet("https://example.com/", "markdown")).toBeUndefined();
+		expect(cache.get("https://example.com/", "markdown")).toBeUndefined();
 		vi.useRealTimers();
 	});
 
 	it("returns value within TTL", () => {
-		_setTTL(1000); // 1s TTL
-		cacheSet("https://example.com/", "markdown", "cached");
+		const cache = new Cache({ ttlMs: 1000 });
+		cache.set("https://example.com/", "markdown", "cached");
 
-		// Time is still within TTL
-		expect(cacheGet("https://example.com/", "markdown")).toBe("cached");
+		expect(cache.get("https://example.com/", "markdown")).toBe("cached");
 	});
 
 	it("evicts expired entry on access", () => {
-		_setTTL(100);
-		cacheSet("https://example.com/", "markdown", "cached");
-		expect(cacheSize()).toBe(1);
+		const cache = new Cache({ ttlMs: 100 });
+		cache.set("https://example.com/", "markdown", "cached");
+		expect(cache.size).toBe(1);
 
 		vi.useFakeTimers();
 		vi.advanceTimersByTime(150);
 
-		cacheGet("https://example.com/", "markdown"); // triggers eviction
-		expect(cacheSize()).toBe(0);
+		cache.get("https://example.com/", "markdown"); // triggers eviction
+		expect(cache.size).toBe(0);
 		vi.useRealTimers();
 	});
 });
 
-describe("cacheClear", () => {
+describe("clear", () => {
 	it("removes all entries", () => {
-		cacheSet("https://a.com/", "markdown", "a");
-		cacheSet("https://b.com/", "text", "b");
-		cacheSet("https://c.com/", "html", "c");
-		expect(cacheSize()).toBe(3);
+		const cache = new Cache();
+		cache.set("https://a.com/", "markdown", "a");
+		cache.set("https://b.com/", "text", "b");
+		cache.set("https://c.com/", "html", "c");
+		expect(cache.size).toBe(3);
 
-		cacheClear();
-		expect(cacheSize()).toBe(0);
-		expect(cacheGet("https://a.com/", "markdown")).toBeUndefined();
-		expect(cacheGet("https://b.com/", "text")).toBeUndefined();
-		expect(cacheGet("https://c.com/", "html")).toBeUndefined();
+		cache.clear();
+		expect(cache.size).toBe(0);
+		expect(cache.get("https://a.com/", "markdown")).toBeUndefined();
+		expect(cache.get("https://b.com/", "text")).toBeUndefined();
+		expect(cache.get("https://c.com/", "html")).toBeUndefined();
 	});
 
 	it("is safe to call on empty cache", () => {
-		expect(cacheSize()).toBe(0);
-		cacheClear(); // should not throw
-		expect(cacheSize()).toBe(0);
+		const cache = new Cache();
+		expect(cache.size).toBe(0);
+		cache.clear(); // should not throw
+		expect(cache.size).toBe(0);
 	});
 });
 
-describe("cacheSize", () => {
+describe("size", () => {
 	it("returns 0 for empty cache", () => {
-		expect(cacheSize()).toBe(0);
+		const cache = new Cache();
+		expect(cache.size).toBe(0);
 	});
 
 	it("reflects number of stored entries", () => {
-		cacheSet("https://a.com/", "markdown", "a");
-		expect(cacheSize()).toBe(1);
-		cacheSet("https://b.com/", "text", "b");
-		expect(cacheSize()).toBe(2);
+		const cache = new Cache();
+		cache.set("https://a.com/", "markdown", "a");
+		expect(cache.size).toBe(1);
+		cache.set("https://b.com/", "text", "b");
+		expect(cache.size).toBe(2);
+	});
+});
+
+describe("cache eviction", () => {
+	it("evicts the oldest entry when inserting beyond maxEntries", () => {
+		const cache = new Cache();
+		for (let i = 0; i < MAX_ENTRIES; i++) {
+			cache.set(`https://${i}.com/`, "markdown", `output-${i}`);
+		}
+		expect(cache.size).toBe(MAX_ENTRIES);
+
+		// Insert one more — should evict entry 0 (the oldest)
+		cache.set("https://new.com/", "markdown", "new-output");
+		expect(cache.size).toBe(MAX_ENTRIES);
+		expect(cache.get("https://0.com/", "markdown")).toBeUndefined();
+		expect(cache.get("https://new.com/", "markdown")).toBe("new-output");
+	});
+
+	it("retains newest entries and evicts oldest", () => {
+		const cache = new Cache();
+		for (let i = 0; i < MAX_ENTRIES; i++) {
+			cache.set(`https://${i}.com/`, "markdown", `output-${i}`);
+		}
+
+		// Insert 3 more entries — should evict entries 0, 1, 2
+		cache.set("https://new-a.com/", "markdown", "a");
+		cache.set("https://new-b.com/", "markdown", "b");
+		cache.set("https://new-c.com/", "markdown", "c");
+
+		expect(cache.size).toBe(MAX_ENTRIES);
+
+		// Oldest 3 evicted
+		expect(cache.get("https://0.com/", "markdown")).toBeUndefined();
+		expect(cache.get("https://1.com/", "markdown")).toBeUndefined();
+		expect(cache.get("https://2.com/", "markdown")).toBeUndefined();
+
+		// Newest 3 present
+		expect(cache.get("https://new-a.com/", "markdown")).toBe("a");
+		expect(cache.get("https://new-b.com/", "markdown")).toBe("b");
+		expect(cache.get("https://new-c.com/", "markdown")).toBe("c");
+
+		// Last original entry still present
+		expect(cache.get(`https://${MAX_ENTRIES - 1}.com/`, "markdown")).toBe(`output-${MAX_ENTRIES - 1}`);
+	});
+
+	it("does not evict when overwriting an existing key at capacity", () => {
+		const cache = new Cache();
+		for (let i = 0; i < MAX_ENTRIES; i++) {
+			cache.set(`https://${i}.com/`, "markdown", `output-${i}`);
+		}
+
+		// Overwrite existing key — should NOT evict anything
+		cache.set("https://0.com/", "markdown", "updated");
+		expect(cache.size).toBe(MAX_ENTRIES);
+		expect(cache.get("https://0.com/", "markdown")).toBe("updated");
+		expect(cache.get("https://1.com/", "markdown")).toBe("output-1");
+	});
+
+	it("respects custom maxEntries option", () => {
+		const cache = new Cache({ maxEntries: 3 });
+		cache.set("https://a.com/", "markdown", "a");
+		cache.set("https://b.com/", "markdown", "b");
+		cache.set("https://c.com/", "markdown", "c");
+		cache.set("https://d.com/", "markdown", "d");
+
+		expect(cache.size).toBe(3);
+		expect(cache.get("https://a.com/", "markdown")).toBeUndefined();
+		expect(cache.get("https://d.com/", "markdown")).toBe("d");
 	});
 });

--- a/extensions/web-fetch/cache.test.ts
+++ b/extensions/web-fetch/cache.test.ts
@@ -1,0 +1,127 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { _setTTL, cacheClear, cacheGet, cacheKey, cacheSet, cacheSize } from "./cache.js";
+
+afterEach(() => {
+	cacheClear();
+	_setTTL(undefined); // reset to default
+	vi.restoreAllMocks();
+});
+
+describe("cacheKey", () => {
+	it("combines URL and format with :: separator", () => {
+		expect(cacheKey("https://example.com/", "markdown")).toBe("https://example.com/::markdown");
+	});
+
+	it("produces different keys for different formats", () => {
+		const md = cacheKey("https://example.com/", "markdown");
+		const txt = cacheKey("https://example.com/", "text");
+		const html = cacheKey("https://example.com/", "html");
+		expect(md).not.toBe(txt);
+		expect(md).not.toBe(html);
+		expect(txt).not.toBe(html);
+	});
+
+	it("produces different keys for different URLs", () => {
+		const a = cacheKey("https://a.com/", "markdown");
+		const b = cacheKey("https://b.com/", "markdown");
+		expect(a).not.toBe(b);
+	});
+});
+
+describe("cacheGet / cacheSet", () => {
+	it("returns undefined on cache miss", () => {
+		expect(cacheGet("https://example.com/", "markdown")).toBeUndefined();
+	});
+
+	it("returns stored value on cache hit", () => {
+		cacheSet("https://example.com/", "markdown", "cached output");
+		expect(cacheGet("https://example.com/", "markdown")).toBe("cached output");
+	});
+
+	it("returns undefined for same URL but different format", () => {
+		cacheSet("https://example.com/", "markdown", "md output");
+		expect(cacheGet("https://example.com/", "text")).toBeUndefined();
+	});
+
+	it("overwrites existing entry for same key", () => {
+		cacheSet("https://example.com/", "markdown", "first");
+		cacheSet("https://example.com/", "markdown", "second");
+		expect(cacheGet("https://example.com/", "markdown")).toBe("second");
+	});
+
+	it("stores entries for multiple URLs independently", () => {
+		cacheSet("https://a.com/", "markdown", "output A");
+		cacheSet("https://b.com/", "markdown", "output B");
+		expect(cacheGet("https://a.com/", "markdown")).toBe("output A");
+		expect(cacheGet("https://b.com/", "markdown")).toBe("output B");
+	});
+});
+
+describe("TTL expiry", () => {
+	it("returns undefined after TTL has elapsed", () => {
+		_setTTL(100); // 100ms TTL
+		cacheSet("https://example.com/", "markdown", "cached");
+
+		// Advance time past TTL
+		vi.useFakeTimers();
+		vi.advanceTimersByTime(150);
+
+		expect(cacheGet("https://example.com/", "markdown")).toBeUndefined();
+		vi.useRealTimers();
+	});
+
+	it("returns value within TTL", () => {
+		_setTTL(1000); // 1s TTL
+		cacheSet("https://example.com/", "markdown", "cached");
+
+		// Time is still within TTL
+		expect(cacheGet("https://example.com/", "markdown")).toBe("cached");
+	});
+
+	it("evicts expired entry on access", () => {
+		_setTTL(100);
+		cacheSet("https://example.com/", "markdown", "cached");
+		expect(cacheSize()).toBe(1);
+
+		vi.useFakeTimers();
+		vi.advanceTimersByTime(150);
+
+		cacheGet("https://example.com/", "markdown"); // triggers eviction
+		expect(cacheSize()).toBe(0);
+		vi.useRealTimers();
+	});
+});
+
+describe("cacheClear", () => {
+	it("removes all entries", () => {
+		cacheSet("https://a.com/", "markdown", "a");
+		cacheSet("https://b.com/", "text", "b");
+		cacheSet("https://c.com/", "html", "c");
+		expect(cacheSize()).toBe(3);
+
+		cacheClear();
+		expect(cacheSize()).toBe(0);
+		expect(cacheGet("https://a.com/", "markdown")).toBeUndefined();
+		expect(cacheGet("https://b.com/", "text")).toBeUndefined();
+		expect(cacheGet("https://c.com/", "html")).toBeUndefined();
+	});
+
+	it("is safe to call on empty cache", () => {
+		expect(cacheSize()).toBe(0);
+		cacheClear(); // should not throw
+		expect(cacheSize()).toBe(0);
+	});
+});
+
+describe("cacheSize", () => {
+	it("returns 0 for empty cache", () => {
+		expect(cacheSize()).toBe(0);
+	});
+
+	it("reflects number of stored entries", () => {
+		cacheSet("https://a.com/", "markdown", "a");
+		expect(cacheSize()).toBe(1);
+		cacheSet("https://b.com/", "text", "b");
+		expect(cacheSize()).toBe(2);
+	});
+});

--- a/extensions/web-fetch/cache.ts
+++ b/extensions/web-fetch/cache.ts
@@ -8,6 +8,9 @@
 /** Default TTL in milliseconds (15 minutes). */
 const DEFAULT_TTL_MS = 15 * 60 * 1000;
 
+/** Default maximum number of cache entries before eviction kicks in. */
+export const MAX_ENTRIES = 100;
+
 export interface CacheEntry {
 	/** The fully rendered tool output (metadata header + content body). */
 	output: string;
@@ -15,52 +18,97 @@ export interface CacheEntry {
 	storedAt: number;
 }
 
-/** Build a composite cache key from URL and format. */
-export function cacheKey(url: string, format: string): string {
-	return `${url}::${format}`;
+export interface CacheOptions {
+	ttlMs?: number;
+	maxEntries?: number;
 }
 
-const store = new Map<string, CacheEntry>();
+export class Cache {
+	private readonly store = new Map<string, CacheEntry>();
+	private readonly ttlMs: number;
+	private readonly maxEntries: number;
 
-let ttlMs = DEFAULT_TTL_MS;
-
-/**
- * Look up a cached result. Returns the output string on hit, or `undefined`
- * on miss or expiry. Expired entries are evicted on access.
- */
-export function cacheGet(url: string, format: string): string | undefined {
-	const key = cacheKey(url, format);
-	const entry = store.get(key);
-	if (!entry) return undefined;
-
-	if (Date.now() - entry.storedAt > ttlMs) {
-		store.delete(key);
-		return undefined;
+	constructor(options?: CacheOptions) {
+		this.ttlMs = options?.ttlMs ?? DEFAULT_TTL_MS;
+		this.maxEntries = options?.maxEntries ?? MAX_ENTRIES;
 	}
 
-	return entry.output;
+	/** Build a composite cache key from URL and format. */
+	static key(url: string, format: string): string {
+		return `${url}::${format}`;
+	}
+
+	/**
+	 * Look up a cached result. Returns the output string on hit, or `undefined`
+	 * on miss or expiry. Expired entries are evicted on access.
+	 */
+	get(url: string, format: string): string | undefined {
+		const key = Cache.key(url, format);
+		const entry = this.store.get(key);
+		if (!entry) return undefined;
+
+		if (Date.now() - entry.storedAt > this.ttlMs) {
+			this.store.delete(key);
+			return undefined;
+		}
+
+		return entry.output;
+	}
+
+	/** Store a result in the cache. Evicts the oldest entry when at capacity. */
+	set(url: string, format: string, output: string): void {
+		const key = Cache.key(url, format);
+
+		// Evict oldest entry if at capacity (skip if we're overwriting an existing key)
+		if (this.store.size >= this.maxEntries && !this.store.has(key)) {
+			let oldestKey: string | undefined;
+			let oldestTime = Infinity;
+			for (const [k, v] of this.store) {
+				if (v.storedAt < oldestTime) {
+					oldestTime = v.storedAt;
+					oldestKey = k;
+				}
+			}
+			if (oldestKey) this.store.delete(oldestKey);
+		}
+
+		this.store.set(key, { output, storedAt: Date.now() });
+	}
+
+	/** Clear all cached entries. Called on session shutdown. */
+	clear(): void {
+		this.store.clear();
+	}
+
+	/** Number of entries currently in the cache. */
+	get size(): number {
+		return this.store.size;
+	}
 }
 
-/** Store a result in the cache. */
+// ---------------------------------------------------------------------------
+// Default singleton — keeps the same module-level API for consumers.
+// ---------------------------------------------------------------------------
+
+const defaultCache = new Cache();
+
+/** Build a composite cache key from URL and format. */
+export function cacheKey(url: string, format: string): string {
+	return Cache.key(url, format);
+}
+
+export function cacheGet(url: string, format: string): string | undefined {
+	return defaultCache.get(url, format);
+}
+
 export function cacheSet(url: string, format: string, output: string): void {
-	const key = cacheKey(url, format);
-	store.set(key, { output, storedAt: Date.now() });
+	defaultCache.set(url, format, output);
 }
 
-/** Clear all cached entries. Called on session shutdown. */
 export function cacheClear(): void {
-	store.clear();
+	defaultCache.clear();
 }
 
-/** Number of entries currently in the cache (for testing). */
 export function cacheSize(): number {
-	return store.size;
-}
-
-/**
- * Override the TTL for testing. Pass `undefined` to reset to default.
- * @internal
- */
-export function _setTTL(ms: number | undefined): void {
-	ttlMs = ms ?? DEFAULT_TTL_MS;
+	return defaultCache.size;
 }

--- a/extensions/web-fetch/cache.ts
+++ b/extensions/web-fetch/cache.ts
@@ -1,0 +1,66 @@
+/**
+ * Session-scoped in-memory cache for web_fetch results.
+ *
+ * Keyed by URL + format composite key. Entries expire after a configurable TTL
+ * (default 15 minutes). The cache is cleared on session shutdown.
+ */
+
+/** Default TTL in milliseconds (15 minutes). */
+const DEFAULT_TTL_MS = 15 * 60 * 1000;
+
+export interface CacheEntry {
+	/** The fully rendered tool output (metadata header + content body). */
+	output: string;
+	/** Timestamp when the entry was stored (Date.now()). */
+	storedAt: number;
+}
+
+/** Build a composite cache key from URL and format. */
+export function cacheKey(url: string, format: string): string {
+	return `${url}::${format}`;
+}
+
+const store = new Map<string, CacheEntry>();
+
+let ttlMs = DEFAULT_TTL_MS;
+
+/**
+ * Look up a cached result. Returns the output string on hit, or `undefined`
+ * on miss or expiry. Expired entries are evicted on access.
+ */
+export function cacheGet(url: string, format: string): string | undefined {
+	const key = cacheKey(url, format);
+	const entry = store.get(key);
+	if (!entry) return undefined;
+
+	if (Date.now() - entry.storedAt > ttlMs) {
+		store.delete(key);
+		return undefined;
+	}
+
+	return entry.output;
+}
+
+/** Store a result in the cache. */
+export function cacheSet(url: string, format: string, output: string): void {
+	const key = cacheKey(url, format);
+	store.set(key, { output, storedAt: Date.now() });
+}
+
+/** Clear all cached entries. Called on session shutdown. */
+export function cacheClear(): void {
+	store.clear();
+}
+
+/** Number of entries currently in the cache (for testing). */
+export function cacheSize(): number {
+	return store.size;
+}
+
+/**
+ * Override the TTL for testing. Pass `undefined` to reset to default.
+ * @internal
+ */
+export function _setTTL(ms: number | undefined): void {
+	ttlMs = ms ?? DEFAULT_TTL_MS;
+}

--- a/extensions/web-fetch/content-converter.test.ts
+++ b/extensions/web-fetch/content-converter.test.ts
@@ -1,0 +1,289 @@
+import { describe, expect, it } from "vitest";
+import { convertContent } from "./content-converter.js";
+
+describe("convertContent", () => {
+	const BASE_URL = "https://example.com/page";
+
+	describe("format: markdown", () => {
+		it("converts headings to ATX style", () => {
+			const html = "<h1>Title</h1><h2>Subtitle</h2><h3>Section</h3>";
+			const md = convertContent(html, BASE_URL, "markdown");
+			expect(md).toContain("# Title");
+			expect(md).toContain("## Subtitle");
+			expect(md).toContain("### Section");
+		});
+
+		it("converts links with resolved URLs", () => {
+			const html = '<p>Visit <a href="/docs">the docs</a> for help.</p>';
+			const md = convertContent(html, BASE_URL, "markdown");
+			expect(md).toContain("[the docs](https://example.com/docs)");
+		});
+
+		it("preserves absolute URLs unchanged", () => {
+			const html = '<a href="https://other.com/path">external</a>';
+			const md = convertContent(html, BASE_URL, "markdown");
+			expect(md).toContain("[external](https://other.com/path)");
+		});
+
+		it("converts unordered lists", () => {
+			const html = "<ul><li>one</li><li>two</li><li>three</li></ul>";
+			const md = convertContent(html, BASE_URL, "markdown");
+			expect(md).toContain("-   one");
+			expect(md).toContain("-   two");
+			expect(md).toContain("-   three");
+		});
+
+		it("converts ordered lists", () => {
+			const html = "<ol><li>first</li><li>second</li></ol>";
+			const md = convertContent(html, BASE_URL, "markdown");
+			expect(md).toContain("1.  first");
+			expect(md).toContain("2.  second");
+		});
+
+		it("converts inline code", () => {
+			const html = "<p>Use <code>npm install</code> to install.</p>";
+			const md = convertContent(html, BASE_URL, "markdown");
+			expect(md).toContain("`npm install`");
+		});
+
+		it("converts fenced code blocks", () => {
+			const html = "<pre><code>const x = 1;\nconst y = 2;</code></pre>";
+			const md = convertContent(html, BASE_URL, "markdown");
+			expect(md).toContain("```");
+			expect(md).toContain("const x = 1;");
+		});
+
+		it("converts emphasis and strong", () => {
+			const html = "<p><em>italic</em> and <strong>bold</strong></p>";
+			const md = convertContent(html, BASE_URL, "markdown");
+			expect(md).toContain("*italic*");
+			expect(md).toContain("**bold**");
+		});
+
+		it("converts nested structures", () => {
+			const html =
+				"<div><h2>Section</h2><p>Text with <a href=\"/link\">a link</a> and <em>emphasis</em>.</p><ul><li>item with <code>code</code></li></ul></div>";
+			const md = convertContent(html, BASE_URL, "markdown");
+			expect(md).toContain("## Section");
+			expect(md).toContain("[a link](https://example.com/link)");
+			expect(md).toContain("*emphasis*");
+			expect(md).toContain("`code`");
+		});
+
+		it("resolves relative src attributes on images", () => {
+			const html = '<img src="/img/photo.png" alt="photo">';
+			const md = convertContent(html, BASE_URL, "markdown");
+			expect(md).toContain("https://example.com/img/photo.png");
+		});
+
+		it("resolves parent-relative URLs (../)", () => {
+			const html = '<a href="../other">up</a>';
+			const md = convertContent(html, "https://example.com/a/b/page", "markdown");
+			expect(md).toContain("https://example.com/a/other");
+		});
+	});
+
+	describe("format: text", () => {
+		it("extracts plain text from paragraphs", () => {
+			const html = "<p>Hello world</p>";
+			const text = convertContent(html, BASE_URL, "text");
+			expect(text).toContain("Hello world");
+		});
+
+		it("strips all HTML tags", () => {
+			const html = "<h1>Title</h1><p>Paragraph with <strong>bold</strong> and <a href='/x'>link</a>.</p>";
+			const text = convertContent(html, BASE_URL, "text");
+			expect(text).not.toContain("<");
+			expect(text).not.toContain(">");
+			expect(text).toContain("Title");
+			expect(text).toContain("Paragraph with bold and link.");
+		});
+
+		it("separates block elements with newlines", () => {
+			const html = "<h1>Title</h1><p>Paragraph</p>";
+			const text = convertContent(html, BASE_URL, "text");
+			const lines = text.split("\n");
+			expect(lines).toContain("Title");
+			expect(lines).toContain("Paragraph");
+		});
+
+		it("extracts text from lists", () => {
+			const html = "<ul><li>one</li><li>two</li></ul>";
+			const text = convertContent(html, BASE_URL, "text");
+			expect(text).toContain("one");
+			expect(text).toContain("two");
+		});
+
+		it("collapses excessive whitespace", () => {
+			const html = "<p>  lots   of    spaces  </p>";
+			const text = convertContent(html, BASE_URL, "text");
+			expect(text).toBe("lots of spaces");
+		});
+	});
+
+	describe("format: html", () => {
+		it("returns raw HTML unchanged", () => {
+			const html = "<h1>Title</h1><nav>menu</nav><script>alert(1)</script>";
+			const result = convertContent(html, BASE_URL, "html");
+			expect(result).toBe(html);
+		});
+
+		it("does not strip any elements", () => {
+			const html = "<nav>nav</nav><footer>footer</footer><script>x</script><style>.y{}</style>";
+			const result = convertContent(html, BASE_URL, "html");
+			expect(result).toContain("<nav>");
+			expect(result).toContain("<footer>");
+			expect(result).toContain("<script>");
+			expect(result).toContain("<style>");
+		});
+
+		it("does not modify URLs", () => {
+			const html = '<a href="/relative">link</a>';
+			const result = convertContent(html, BASE_URL, "html");
+			expect(result).toContain('href="/relative"');
+		});
+	});
+
+	describe("boilerplate stripping", () => {
+		const boilerplateHTML = `<html><head>
+			<style>.x{color:red}</style>
+			<meta charset="utf-8">
+			<link rel="stylesheet" href="/style.css">
+		</head><body>
+			<script>alert('xss')</script>
+			<nav><a href="/">Home</a> <a href="/about">About</a></nav>
+			<h1>Content</h1>
+			<p>Main text</p>
+			<footer><p>Copyright 2026</p></footer>
+			<iframe src="https://ad.example.com"></iframe>
+			<svg><circle r="10"/></svg>
+			<noscript>Please enable JavaScript</noscript>
+			<header><h2>Header section</h2></header>
+			<aside>Sidebar content</aside>
+		</body></html>`;
+
+		it("strips script elements in markdown", () => {
+			const md = convertContent(boilerplateHTML, BASE_URL, "markdown");
+			expect(md).not.toContain("alert");
+		});
+
+		it("strips style elements in markdown", () => {
+			const md = convertContent(boilerplateHTML, BASE_URL, "markdown");
+			expect(md).not.toContain("color:red");
+		});
+
+		it("strips meta elements in markdown", () => {
+			const md = convertContent(boilerplateHTML, BASE_URL, "markdown");
+			expect(md).not.toContain("charset");
+		});
+
+		it("strips link elements in markdown", () => {
+			const md = convertContent(boilerplateHTML, BASE_URL, "markdown");
+			expect(md).not.toContain("style.css");
+		});
+
+		it("strips nav elements in markdown", () => {
+			const md = convertContent(boilerplateHTML, BASE_URL, "markdown");
+			expect(md).not.toContain("About");
+		});
+
+		it("strips footer elements in markdown", () => {
+			const md = convertContent(boilerplateHTML, BASE_URL, "markdown");
+			expect(md).not.toContain("Copyright");
+		});
+
+		it("strips iframe elements in markdown", () => {
+			const md = convertContent(boilerplateHTML, BASE_URL, "markdown");
+			expect(md).not.toContain("ad.example.com");
+		});
+
+		it("strips svg elements in markdown", () => {
+			const md = convertContent(boilerplateHTML, BASE_URL, "markdown");
+			expect(md).not.toContain("circle");
+		});
+
+		it("strips noscript elements in markdown", () => {
+			const md = convertContent(boilerplateHTML, BASE_URL, "markdown");
+			expect(md).not.toContain("enable JavaScript");
+		});
+
+		it("preserves header elements", () => {
+			const md = convertContent(boilerplateHTML, BASE_URL, "markdown");
+			expect(md).toContain("Header section");
+		});
+
+		it("preserves aside elements", () => {
+			const md = convertContent(boilerplateHTML, BASE_URL, "markdown");
+			expect(md).toContain("Sidebar content");
+		});
+
+		it("preserves main content", () => {
+			const md = convertContent(boilerplateHTML, BASE_URL, "markdown");
+			expect(md).toContain("# Content");
+			expect(md).toContain("Main text");
+		});
+
+		it("strips boilerplate in text format too", () => {
+			const text = convertContent(boilerplateHTML, BASE_URL, "text");
+			expect(text).not.toContain("alert");
+			expect(text).not.toContain("Copyright");
+			expect(text).not.toContain("About");
+			expect(text).toContain("Content");
+			expect(text).toContain("Main text");
+			expect(text).toContain("Header section");
+			expect(text).toContain("Sidebar content");
+		});
+	});
+
+	describe("relative URL resolution", () => {
+		it("resolves root-relative paths", () => {
+			const html = '<a href="/docs/api">API</a>';
+			const md = convertContent(html, "https://example.com/page", "markdown");
+			expect(md).toContain("https://example.com/docs/api");
+		});
+
+		it("resolves parent-relative paths", () => {
+			const html = '<a href="../sibling">link</a>';
+			const md = convertContent(html, "https://example.com/a/b/page", "markdown");
+			expect(md).toContain("https://example.com/a/sibling");
+		});
+
+		it("resolves same-directory relative paths", () => {
+			const html = '<a href="other.html">link</a>';
+			const md = convertContent(html, "https://example.com/dir/page", "markdown");
+			expect(md).toContain("https://example.com/dir/other.html");
+		});
+
+		it("preserves absolute URLs", () => {
+			const html = '<a href="https://other.com/page">link</a>';
+			const md = convertContent(html, BASE_URL, "markdown");
+			expect(md).toContain("https://other.com/page");
+		});
+
+		it("preserves fragment-only URLs", () => {
+			const html = '<a href="#section">link</a>';
+			const md = convertContent(html, BASE_URL, "markdown");
+			expect(md).toContain("https://example.com/page#section");
+		});
+
+		it("resolves src attributes", () => {
+			const html = '<img src="/images/pic.jpg" alt="pic">';
+			const md = convertContent(html, BASE_URL, "markdown");
+			expect(md).toContain("https://example.com/images/pic.jpg");
+		});
+
+		it("leaves malformed URLs as-is", () => {
+			const html = '<a href="://broken">link</a>';
+			const md = convertContent(html, BASE_URL, "markdown");
+			expect(md).toContain("link");
+		});
+
+		it("resolves URLs in text format too", () => {
+			// text format still strips boilerplate and resolves URLs (for potential later use)
+			// but since text output doesn't show URLs, we just verify it doesn't crash
+			const html = '<a href="/docs">docs</a>';
+			const text = convertContent(html, BASE_URL, "text");
+			expect(text).toContain("docs");
+		});
+	});
+});

--- a/extensions/web-fetch/content-converter.test.ts
+++ b/extensions/web-fetch/content-converter.test.ts
@@ -1,4 +1,6 @@
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
+// @ts-expect-error — domino types are declared under 'domino', not '@mixmark-io/domino'
+import domino from "@mixmark-io/domino";
 import { convertContent } from "./content-converter.js";
 
 describe("convertContent", () => {
@@ -232,6 +234,56 @@ describe("convertContent", () => {
 			expect(text).toContain("Main text");
 			expect(text).toContain("Header section");
 			expect(text).toContain("Sidebar content");
+		});
+	});
+
+	describe("malformed HTML fallback", () => {
+		it("handles null input without throwing in markdown format", () => {
+			const result = convertContent(null as unknown as string, BASE_URL, "markdown");
+			expect(typeof result).toBe("string");
+		});
+
+		it("handles null input without throwing in text format", () => {
+			const result = convertContent(null as unknown as string, BASE_URL, "text");
+			expect(typeof result).toBe("string");
+		});
+
+		it("returns raw HTML unchanged for null input in html format", () => {
+			// html format is passthrough — returns input before parsing
+			const result = convertContent(null as unknown as string, BASE_URL, "html");
+			expect(result).toBeNull();
+		});
+
+		it("handles empty string without throwing", () => {
+			const mdResult = convertContent("", BASE_URL, "markdown");
+			expect(typeof mdResult).toBe("string");
+
+			const textResult = convertContent("", BASE_URL, "text");
+			expect(typeof textResult).toBe("string");
+		});
+
+		it("handles binary garbage without throwing", () => {
+			const garbage = "\x00\x01\x02\xFF\xFE\x80\x81";
+			const mdResult = convertContent(garbage, BASE_URL, "markdown");
+			expect(typeof mdResult).toBe("string");
+
+			const textResult = convertContent(garbage, BASE_URL, "text");
+			expect(typeof textResult).toBe("string");
+		});
+
+		it("returns fallback when domino.createDocument throws", () => {
+			const spy = vi.spyOn(domino, "createDocument").mockImplementation(() => {
+				throw new Error("Simulated parse failure");
+			});
+			try {
+				const mdResult = convertContent("<html>valid</html>", BASE_URL, "markdown");
+				expect(mdResult).toBe("[Error: failed to parse HTML content]");
+
+				const textResult = convertContent("<html>valid</html>", BASE_URL, "text");
+				expect(textResult).toBe("[Error: failed to parse HTML content]");
+			} finally {
+				spy.mockRestore();
+			}
 		});
 	});
 

--- a/extensions/web-fetch/content-converter.ts
+++ b/extensions/web-fetch/content-converter.ts
@@ -1,0 +1,154 @@
+/**
+ * Content converter — transforms raw HTML into the requested output format.
+ *
+ * - `markdown`: strips boilerplate, resolves relative URLs, converts via Turndown
+ * - `text`: strips boilerplate, extracts textContent via DOM
+ * - `html`: returns raw HTML unchanged (passthrough)
+ */
+
+// domino: lightweight server-side DOM used by Turndown internally. We depend
+// on it explicitly for boilerplate stripping, relative URL resolution, and
+// text extraction — none of which Turndown's API can do on its own.
+// @ts-expect-error — domino types are declared under 'domino', not '@mixmark-io/domino'
+import domino from "@mixmark-io/domino";
+import TurndownService from "turndown";
+
+export type OutputFormat = "markdown" | "text" | "html";
+
+/** Elements stripped before conversion (boilerplate / non-content). */
+const BOILERPLATE_SELECTORS = "script, style, meta, link, nav, footer, iframe, svg, noscript";
+
+/** Attributes that may contain relative URLs. */
+const URL_ATTRIBUTES: ReadonlyArray<{ selector: string; attr: string }> = [
+	{ selector: "[href]", attr: "href" },
+	{ selector: "[src]", attr: "src" },
+	{ selector: "[action]", attr: "action" },
+	{ selector: "[poster]", attr: "poster" },
+];
+
+/**
+ * Convert raw HTML to the requested format.
+ *
+ * @param html - Raw HTML string
+ * @param baseURL - The page's final URL, used to resolve relative URLs
+ * @param format - Desired output format
+ */
+export function convertContent(html: string, baseURL: string, format: OutputFormat): string {
+	if (format === "html") {
+		return html;
+	}
+
+	const doc = domino.createDocument(html);
+
+	// Strip boilerplate elements
+	for (const el of doc.querySelectorAll(BOILERPLATE_SELECTORS)) {
+		el.remove();
+	}
+
+	// Resolve relative URLs to absolute
+	resolveRelativeURLs(doc, baseURL);
+
+	if (format === "text") {
+		return extractText(doc);
+	}
+
+	// format === "markdown"
+	return convertToMarkdown(doc);
+}
+
+/**
+ * Resolve all relative URLs in the document to absolute using the base URL.
+ */
+function resolveRelativeURLs(doc: Document, baseURL: string): void {
+	for (const { selector, attr } of URL_ATTRIBUTES) {
+		for (const el of doc.querySelectorAll(selector)) {
+			const value = el.getAttribute(attr);
+			if (value) {
+				try {
+					el.setAttribute(attr, new URL(value, baseURL).href);
+				} catch {
+					// Malformed URL — leave as-is
+				}
+			}
+		}
+	}
+}
+
+/** Block-level elements that should produce line breaks in text output. */
+const BLOCK_ELEMENTS = new Set([
+	"address", "article", "aside", "blockquote", "details", "dialog", "dd",
+	"div", "dl", "dt", "fieldset", "figcaption", "figure", "form",
+	"h1", "h2", "h3", "h4", "h5", "h6", "header", "hgroup", "hr",
+	"li", "main", "ol", "p", "pre", "section", "table", "ul",
+	"tr", "td", "th", "br",
+]);
+
+/**
+ * Extract plain text from the document body.
+ *
+ * Custom DOM walker because neither standard DOM properties nor libraries
+ * handle this well:
+ * - `textContent` concatenates all text nodes with no whitespace between
+ *   block elements ("TitleParagraph" instead of "Title\nParagraph")
+ * - `innerText` should be layout-aware per the HTML spec, but domino's
+ *   implementation just collapses whitespace like textContent
+ * - Turndown is markdown-centric with no plain-text output mode
+ *
+ * This walks the tree and inserts newlines at block-element boundaries,
+ * mirroring what a spec-compliant `innerText` would produce.
+ */
+function extractText(doc: Document): string {
+	const body = doc.body;
+	if (!body) return "";
+
+	const parts: string[] = [];
+	walkNode(body, parts);
+
+	return parts
+		.join("")
+		.split(/\n/)
+		.map((line) => line.replace(/\s+/g, " ").trim())
+		.filter((line) => line.length > 0)
+		.join("\n");
+}
+
+function walkNode(node: Node, parts: string[]): void {
+	if (node.nodeType === 3 /* TEXT_NODE */) {
+		parts.push(node.nodeValue ?? "");
+		return;
+	}
+
+	if (node.nodeType !== 1 /* ELEMENT_NODE */) return;
+
+	const tag = (node as Element).tagName?.toLowerCase() ?? "";
+	const isBlock = BLOCK_ELEMENTS.has(tag);
+
+	if (isBlock) parts.push("\n");
+
+	for (let child = node.firstChild; child; child = child.nextSibling) {
+		walkNode(child, parts);
+	}
+
+	if (isBlock) parts.push("\n");
+}
+
+/**
+ * Convert the pre-processed document to markdown via Turndown.
+ */
+function convertToMarkdown(doc: Document): string {
+	const td = new TurndownService({
+		headingStyle: "atx",
+		codeBlockStyle: "fenced",
+		bulletListMarker: "-",
+		hr: "---",
+		emDelimiter: "*",
+	});
+
+	// Turndown's remove() skips elements during conversion — belt-and-suspenders
+	// since we already stripped these from the DOM, but this catches any that
+	// Turndown's own parser might re-encounter
+	td.remove(["script", "style", "meta", "link"]);
+
+	const bodyHTML = doc.body?.innerHTML ?? doc.documentElement?.innerHTML ?? "";
+	return td.turndown(bodyHTML);
+}

--- a/extensions/web-fetch/content-converter.ts
+++ b/extensions/web-fetch/content-converter.ts
@@ -38,22 +38,26 @@ export function convertContent(html: string, baseURL: string, format: OutputForm
 		return html;
 	}
 
-	const doc = domino.createDocument(html);
+	try {
+		const doc = domino.createDocument(html);
 
-	// Strip boilerplate elements
-	for (const el of doc.querySelectorAll(BOILERPLATE_SELECTORS)) {
-		el.remove();
+		// Strip boilerplate elements
+		for (const el of doc.querySelectorAll(BOILERPLATE_SELECTORS)) {
+			el.remove();
+		}
+
+		// Resolve relative URLs to absolute
+		resolveRelativeURLs(doc, baseURL);
+
+		if (format === "text") {
+			return extractText(doc);
+		}
+
+		// format === "markdown"
+		return convertToMarkdown(doc);
+	} catch {
+		return "[Error: failed to parse HTML content]";
 	}
-
-	// Resolve relative URLs to absolute
-	resolveRelativeURLs(doc, baseURL);
-
-	if (format === "text") {
-		return extractText(doc);
-	}
-
-	// format === "markdown"
-	return convertToMarkdown(doc);
 }
 
 /**

--- a/extensions/web-fetch/execute-handler.test.ts
+++ b/extensions/web-fetch/execute-handler.test.ts
@@ -1,0 +1,197 @@
+import { type MockInstance, afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("./page-fetcher.js", () => ({
+	FetchError: class FetchError extends Error {
+		constructor(message: string, public readonly category: string) {
+			super(message);
+			this.name = "FetchError";
+		}
+	},
+	fetchPage: vi.fn(),
+}));
+
+vi.mock("./url-validator.js", () => ({
+	validateURL: vi.fn(() => ({ valid: true, url: new URL("https://example.com/") })),
+}));
+
+vi.mock("./content-converter.js", () => ({
+	convertContent: vi.fn((html: string) => html),
+}));
+
+import { executeWebFetch } from "./execute-handler.js";
+import { fetchPage } from "./page-fetcher.js";
+import { convertContent } from "./content-converter.js";
+
+const fetchPageMock = fetchPage as unknown as MockInstance;
+const convertContentMock = convertContent as unknown as MockInstance;
+
+afterEach(() => {
+	vi.restoreAllMocks();
+});
+
+function mockFetchResult(body: string, overrides?: Partial<{ finalURL: string; contentType: string; statusCode: number; isHTML: boolean }>) {
+	return {
+		body,
+		finalURL: overrides?.finalURL ?? "https://example.com/",
+		contentType: overrides?.contentType ?? "text/html; charset=utf-8",
+		statusCode: overrides?.statusCode ?? 200,
+		isHTML: overrides?.isHTML ?? true,
+	};
+}
+
+describe("executeWebFetch", () => {
+	describe("timeout parameter", () => {
+		it("passes timeout to fetchPage when provided", async () => {
+			fetchPageMock.mockResolvedValue(mockFetchResult("<p>Hello</p>"));
+
+			await executeWebFetch({ url: "https://example.com/", timeout: 60 });
+
+			expect(fetchPageMock).toHaveBeenCalledWith("https://example.com/", { timeoutSeconds: 60 });
+		});
+
+		it("clamps timeout values above 120 to 120", async () => {
+			fetchPageMock.mockResolvedValue(mockFetchResult("<p>Hello</p>"));
+
+			await executeWebFetch({ url: "https://example.com/", timeout: 300 });
+
+			expect(fetchPageMock).toHaveBeenCalledWith("https://example.com/", { timeoutSeconds: 120 });
+		});
+
+		it("clamps timeout of exactly 121 to 120", async () => {
+			fetchPageMock.mockResolvedValue(mockFetchResult("<p>Hello</p>"));
+
+			await executeWebFetch({ url: "https://example.com/", timeout: 121 });
+
+			expect(fetchPageMock).toHaveBeenCalledWith("https://example.com/", { timeoutSeconds: 120 });
+		});
+
+		it("passes through timeout values at or below 120", async () => {
+			fetchPageMock.mockResolvedValue(mockFetchResult("<p>Hello</p>"));
+
+			await executeWebFetch({ url: "https://example.com/", timeout: 120 });
+
+			expect(fetchPageMock).toHaveBeenCalledWith("https://example.com/", { timeoutSeconds: 120 });
+		});
+
+		it("does not pass timeoutSeconds when timeout is not provided", async () => {
+			fetchPageMock.mockResolvedValue(mockFetchResult("<p>Hello</p>"));
+
+			await executeWebFetch({ url: "https://example.com/" });
+
+			expect(fetchPageMock).toHaveBeenCalledWith("https://example.com/", { timeoutSeconds: undefined });
+		});
+
+		it("returns timeout error message from fetchPage", async () => {
+			const { FetchError } = await import("./page-fetcher.js");
+			fetchPageMock.mockRejectedValue(new FetchError('Timeout: request to "https://slow.example.com/" timed out after 10 seconds', "timeout"));
+
+			const result = await executeWebFetch({ url: "https://slow.example.com/", timeout: 10 });
+
+			expect(result.content[0].text).toContain("timed out");
+			expect(result.content[0].text).toContain("10 seconds");
+		});
+	});
+
+	describe("output truncation", () => {
+		it("does not truncate content under 100K characters", async () => {
+			const body = "x".repeat(1000);
+			fetchPageMock.mockResolvedValue(mockFetchResult(body));
+			convertContentMock.mockReturnValue(body);
+
+			const result = await executeWebFetch({ url: "https://example.com/" });
+			const text = result.content[0].text;
+
+			expect(text).toContain(`Characters: ${(1000).toLocaleString()}`);
+			expect(text).not.toContain("Truncated:");
+			expect(text).not.toContain("[Content truncated");
+		});
+
+		it("truncates content exceeding 100K characters", async () => {
+			const body = "a".repeat(150_000);
+			fetchPageMock.mockResolvedValue(mockFetchResult(body));
+			convertContentMock.mockReturnValue(body);
+
+			const result = await executeWebFetch({ url: "https://example.com/" });
+			const text = result.content[0].text;
+
+			expect(text).toContain("Characters: 150,000");
+			expect(text).toContain("Truncated: content truncated to 100,000 of 150,000 characters");
+			expect(text).toContain("[Content truncated: showing 100,000 of 150,000 characters]");
+		});
+
+		it("truncates content at exactly 100,001 characters", async () => {
+			const body = "b".repeat(100_001);
+			fetchPageMock.mockResolvedValue(mockFetchResult(body));
+			convertContentMock.mockReturnValue(body);
+
+			const result = await executeWebFetch({ url: "https://example.com/" });
+			const text = result.content[0].text;
+
+			expect(text).toContain("Truncated:");
+			expect(text).toContain("[Content truncated");
+		});
+
+		it("does not truncate content at exactly 100,000 characters", async () => {
+			const body = "c".repeat(100_000);
+			fetchPageMock.mockResolvedValue(mockFetchResult(body));
+			convertContentMock.mockReturnValue(body);
+
+			const result = await executeWebFetch({ url: "https://example.com/" });
+			const text = result.content[0].text;
+
+			expect(text).toContain("Characters: 100,000");
+			expect(text).not.toContain("Truncated:");
+			expect(text).not.toContain("[Content truncated");
+		});
+
+		it("truncated output contains exactly 100K characters of content", async () => {
+			const body = "d".repeat(200_000);
+			fetchPageMock.mockResolvedValue(mockFetchResult(body));
+			convertContentMock.mockReturnValue(body);
+
+			const result = await executeWebFetch({ url: "https://example.com/" });
+			const text = result.content[0].text;
+
+			const metadataEnd = text.indexOf("\n\n") + 2;
+			const truncNoticeStart = text.indexOf("\n\n[Content truncated");
+			const contentSection = text.slice(metadataEnd, truncNoticeStart);
+
+			expect(contentSection.length).toBe(100_000);
+			expect(contentSection).toBe("d".repeat(100_000));
+		});
+
+		it("truncates non-HTML content too", async () => {
+			const body = "e".repeat(150_000);
+			fetchPageMock.mockResolvedValue(mockFetchResult(body, { isHTML: false, contentType: "application/json" }));
+
+			const result = await executeWebFetch({ url: "https://example.com/data.json" });
+			const text = result.content[0].text;
+
+			expect(text).toContain("Truncated:");
+			expect(text).toContain("[Content truncated");
+			expect(convertContentMock).not.toHaveBeenCalled();
+		});
+	});
+
+	describe("metadata header", () => {
+		it("includes character count for normal responses", async () => {
+			const body = "Hello world";
+			fetchPageMock.mockResolvedValue(mockFetchResult(body));
+			convertContentMock.mockReturnValue(body);
+
+			const result = await executeWebFetch({ url: "https://example.com/" });
+
+			expect(result.content[0].text).toContain("Characters: 11");
+		});
+
+		it("reports total character count even when truncated", async () => {
+			const body = "f".repeat(250_000);
+			fetchPageMock.mockResolvedValue(mockFetchResult(body));
+			convertContentMock.mockReturnValue(body);
+
+			const result = await executeWebFetch({ url: "https://example.com/" });
+
+			expect(result.content[0].text).toContain("Characters: 250,000");
+		});
+	});
+});

--- a/extensions/web-fetch/execute-handler.test.ts
+++ b/extensions/web-fetch/execute-handler.test.ts
@@ -10,6 +10,10 @@ vi.mock("./page-fetcher.js", () => ({
 	fetchPage: vi.fn(),
 }));
 
+vi.mock("./browser-pool.js", () => ({
+	getBrowser: vi.fn().mockResolvedValue(null),
+}));
+
 vi.mock("./url-validator.js", () => ({
 	validateURL: vi.fn(() => ({ valid: true, url: new URL("https://example.com/") })),
 }));
@@ -46,7 +50,7 @@ describe("executeWebFetch", () => {
 
 			await executeWebFetch({ url: "https://example.com/", timeout: 60 });
 
-			expect(fetchPageMock).toHaveBeenCalledWith("https://example.com/", { timeoutSeconds: 60 });
+			expect(fetchPageMock).toHaveBeenCalledWith("https://example.com/", { timeoutSeconds: 60, format: "markdown" });
 		});
 
 		it("clamps timeout values above 120 to 120", async () => {
@@ -54,7 +58,7 @@ describe("executeWebFetch", () => {
 
 			await executeWebFetch({ url: "https://example.com/", timeout: 300 });
 
-			expect(fetchPageMock).toHaveBeenCalledWith("https://example.com/", { timeoutSeconds: 120 });
+			expect(fetchPageMock).toHaveBeenCalledWith("https://example.com/", { timeoutSeconds: 120, format: "markdown" });
 		});
 
 		it("clamps timeout of exactly 121 to 120", async () => {
@@ -62,7 +66,7 @@ describe("executeWebFetch", () => {
 
 			await executeWebFetch({ url: "https://example.com/", timeout: 121 });
 
-			expect(fetchPageMock).toHaveBeenCalledWith("https://example.com/", { timeoutSeconds: 120 });
+			expect(fetchPageMock).toHaveBeenCalledWith("https://example.com/", { timeoutSeconds: 120, format: "markdown" });
 		});
 
 		it("passes through timeout values at or below 120", async () => {
@@ -70,7 +74,7 @@ describe("executeWebFetch", () => {
 
 			await executeWebFetch({ url: "https://example.com/", timeout: 120 });
 
-			expect(fetchPageMock).toHaveBeenCalledWith("https://example.com/", { timeoutSeconds: 120 });
+			expect(fetchPageMock).toHaveBeenCalledWith("https://example.com/", { timeoutSeconds: 120, format: "markdown" });
 		});
 
 		it("does not pass timeoutSeconds when timeout is not provided", async () => {
@@ -78,7 +82,7 @@ describe("executeWebFetch", () => {
 
 			await executeWebFetch({ url: "https://example.com/" });
 
-			expect(fetchPageMock).toHaveBeenCalledWith("https://example.com/", { timeoutSeconds: undefined });
+			expect(fetchPageMock).toHaveBeenCalledWith("https://example.com/", { timeoutSeconds: undefined, format: "markdown" });
 		});
 
 		it("returns timeout error message from fetchPage", async () => {
@@ -192,6 +196,60 @@ describe("executeWebFetch", () => {
 			const result = await executeWebFetch({ url: "https://example.com/" });
 
 			expect(result.content[0].text).toContain("Characters: 250,000");
+		});
+
+		it("includes fallback warning in metadata when present", async () => {
+			const body = "<p>Content</p>";
+			fetchPageMock.mockResolvedValue({
+				...mockFetchResult(body),
+				fallbackWarning: "Warning: Playwright is not installed.",
+			});
+			convertContentMock.mockReturnValue("Content");
+
+			const result = await executeWebFetch({ url: "https://example.com/" });
+			const text = result.content[0].text;
+
+			expect(text).toContain("Warning: Playwright is not installed.");
+		});
+
+		it("does not include fallback warning when Playwright was used", async () => {
+			const body = "<p>Content</p>";
+			fetchPageMock.mockResolvedValue(mockFetchResult(body));
+			convertContentMock.mockReturnValue("Content");
+
+			const result = await executeWebFetch({ url: "https://example.com/" });
+			const text = result.content[0].text;
+
+			expect(text).not.toContain("Warning:");
+		});
+	});
+
+	describe("Playwright text extraction", () => {
+		it("skips content converter when Playwright extracted text directly", async () => {
+			// Playwright path: isHTML true, format text, no fallbackWarning
+			fetchPageMock.mockResolvedValue({
+				...mockFetchResult("Plain text from Playwright"),
+				fallbackWarning: undefined,
+			});
+
+			const result = await executeWebFetch({ url: "https://example.com/", format: "text" });
+
+			// convertContent should not be called because Playwright extracted text
+			expect(convertContentMock).not.toHaveBeenCalled();
+			expect(result.content[0].text).toContain("Plain text from Playwright");
+		});
+
+		it("uses content converter for text format when falling back to native fetch", async () => {
+			fetchPageMock.mockResolvedValue({
+				...mockFetchResult("<p>Content</p>"),
+				fallbackWarning: "Warning: Playwright is not installed.",
+			});
+			convertContentMock.mockReturnValue("Converted text");
+
+			const result = await executeWebFetch({ url: "https://example.com/", format: "text" });
+
+			expect(convertContentMock).toHaveBeenCalledWith("<p>Content</p>", "https://example.com/", "text");
+			expect(result.content[0].text).toContain("Converted text");
 		});
 	});
 });

--- a/extensions/web-fetch/execute-handler.test.ts
+++ b/extensions/web-fetch/execute-handler.test.ts
@@ -1,5 +1,10 @@
 import { type MockInstance, afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
+vi.mock("./cache.js", () => ({
+	cacheGet: vi.fn(() => undefined),
+	cacheSet: vi.fn(),
+}));
+
 vi.mock("./page-fetcher.js", () => ({
 	FetchError: class FetchError extends Error {
 		constructor(message: string, public readonly category: string) {
@@ -22,10 +27,13 @@ vi.mock("./content-converter.js", () => ({
 	convertContent: vi.fn((html: string) => html),
 }));
 
+import { cacheGet, cacheSet } from "./cache.js";
 import { executeWebFetch } from "./execute-handler.js";
 import { fetchPage } from "./page-fetcher.js";
 import { convertContent } from "./content-converter.js";
 
+const cacheGetMock = cacheGet as unknown as MockInstance;
+const cacheSetMock = cacheSet as unknown as MockInstance;
 const fetchPageMock = fetchPage as unknown as MockInstance;
 const convertContentMock = convertContent as unknown as MockInstance;
 
@@ -93,6 +101,24 @@ describe("executeWebFetch", () => {
 
 			expect(result.content[0].text).toContain("timed out");
 			expect(result.content[0].text).toContain("10 seconds");
+		});
+	});
+
+	describe("error handling", () => {
+		it("handles non-FetchError exceptions with readable message", async () => {
+			fetchPageMock.mockRejectedValue(new Error("connection refused"));
+
+			const result = await executeWebFetch({ url: "https://example.com/" });
+
+			expect(result.content[0].text).toBe("Error: connection refused");
+		});
+
+		it("handles non-Error thrown values", async () => {
+			fetchPageMock.mockRejectedValue("something broke");
+
+			const result = await executeWebFetch({ url: "https://example.com/" });
+
+			expect(result.content[0].text).toBe("Error: something broke");
 		});
 	});
 
@@ -221,6 +247,102 @@ describe("executeWebFetch", () => {
 			const text = result.content[0].text;
 
 			expect(text).not.toContain("Warning:");
+		});
+	});
+
+	describe("cache behavior", () => {
+		it("returns cached output on cache hit without fetching", async () => {
+			cacheGetMock.mockReturnValue("cached output with Cache: hit");
+
+			const result = await executeWebFetch({ url: "https://example.com/" });
+
+			expect(result.content[0].text).toBe("cached output with Cache: hit");
+			expect(fetchPageMock).not.toHaveBeenCalled();
+			expect(convertContentMock).not.toHaveBeenCalled();
+		});
+
+		it("includes Cache: miss in metadata on cache miss", async () => {
+			const body = "<p>Hello</p>";
+			fetchPageMock.mockResolvedValue(mockFetchResult(body));
+			convertContentMock.mockReturnValue("Hello");
+
+			const result = await executeWebFetch({ url: "https://example.com/" });
+
+			expect(result.content[0].text).toContain("Cache: miss");
+		});
+
+		it("stores result in cache with Cache: hit after successful fetch", async () => {
+			const body = "<p>Hello</p>";
+			fetchPageMock.mockResolvedValue(mockFetchResult(body));
+			convertContentMock.mockReturnValue("Hello");
+
+			await executeWebFetch({ url: "https://example.com/" });
+
+			expect(cacheSetMock).toHaveBeenCalledOnce();
+			const [url, format, output] = cacheSetMock.mock.calls[0];
+			expect(url).toBe("https://example.com/");
+			expect(format).toBe("markdown");
+			expect(output).toContain("Cache: hit");
+			expect(output).not.toContain("Cache: miss");
+		});
+
+		it("does not cache error responses", async () => {
+			const { FetchError } = await import("./page-fetcher.js");
+			fetchPageMock.mockRejectedValue(new FetchError("HTTP 404", "http"));
+
+			await executeWebFetch({ url: "https://example.com/missing" });
+
+			expect(cacheSetMock).not.toHaveBeenCalled();
+		});
+
+		it("caches with the correct format key", async () => {
+			fetchPageMock.mockResolvedValue(mockFetchResult("<p>Hello</p>"));
+			convertContentMock.mockReturnValue("Hello");
+
+			await executeWebFetch({ url: "https://example.com/", format: "text" });
+
+			expect(cacheSetMock).toHaveBeenCalledWith(
+				"https://example.com/",
+				"text",
+				expect.any(String),
+			);
+		});
+
+		it("checks cache with the correct format key", async () => {
+			cacheGetMock.mockReturnValue(undefined);
+			fetchPageMock.mockResolvedValue(mockFetchResult("<p>Hello</p>"));
+			convertContentMock.mockReturnValue("Hello");
+
+			await executeWebFetch({ url: "https://example.com/", format: "html" });
+
+			expect(cacheGetMock).toHaveBeenCalledWith("https://example.com/", "html");
+		});
+
+		it("does not check cache when URL validation fails", async () => {
+			const { validateURL } = await import("./url-validator.js");
+			(validateURL as unknown as MockInstance).mockReturnValueOnce({ valid: false, error: "bad url" });
+
+			await executeWebFetch({ url: "not-a-url" });
+
+			expect(cacheGetMock).not.toHaveBeenCalled();
+		});
+
+		it("does not corrupt page body containing literal 'Cache: miss' string", async () => {
+			const body = '<p>Status: Cache: miss — retry later</p>';
+			fetchPageMock.mockResolvedValue(mockFetchResult(body));
+			convertContentMock.mockReturnValue("Status: Cache: miss — retry later");
+
+			const result = await executeWebFetch({ url: "https://example.com/" });
+
+			// Immediate output has Cache: miss in metadata and in body
+			const text = result.content[0].text;
+			expect(text).toContain("Cache: miss");
+			expect(text).toContain("Status: Cache: miss — retry later");
+
+			// Cached output has Cache: hit in metadata but body is untouched
+			const [, , cachedOutput] = cacheSetMock.mock.calls[0];
+			expect(cachedOutput).toContain("Cache: hit");
+			expect(cachedOutput).toContain("Status: Cache: miss — retry later");
 		});
 	});
 

--- a/extensions/web-fetch/execute-handler.ts
+++ b/extensions/web-fetch/execute-handler.ts
@@ -5,8 +5,9 @@
  * pi-mono framework packages (pi-ai, pi-coding-agent, typebox).
  */
 
+import { cacheGet, cacheSet } from "./cache.js";
 import { type OutputFormat, convertContent } from "./content-converter.js";
-import { type FetchError, fetchPage } from "./page-fetcher.js";
+import { FetchError, fetchPage } from "./page-fetcher.js";
 import { validateURL } from "./url-validator.js";
 
 /** Maximum timeout in seconds. Values above this are clamped. */
@@ -26,6 +27,12 @@ export interface WebFetchResult {
 	details: Record<string, never>;
 }
 
+const EMPTY_DETAILS = {} as Record<string, never>;
+
+function buildOutput(metadataLines: string[], content: string, truncationNotice: string): string {
+	return `${metadataLines.join("\n")}\n\n${content}${truncationNotice}`;
+}
+
 export async function executeWebFetch(params: WebFetchParams): Promise<WebFetchResult> {
 	const format: OutputFormat = params.format ?? "markdown";
 	const timeoutSeconds = params.timeout != null
@@ -37,7 +44,16 @@ export async function executeWebFetch(params: WebFetchParams): Promise<WebFetchR
 	if (!validation.valid) {
 		return {
 			content: [{ type: "text" as const, text: `Error: ${validation.error}` }],
-			details: {} as Record<string, never>,
+			details: EMPTY_DETAILS,
+		};
+	}
+
+	// Check cache
+	const cached = cacheGet(params.url, format);
+	if (cached != null) {
+		return {
+			content: [{ type: "text" as const, text: cached }],
+			details: EMPTY_DETAILS,
 		};
 	}
 
@@ -46,10 +62,12 @@ export async function executeWebFetch(params: WebFetchParams): Promise<WebFetchR
 	try {
 		result = await fetchPage(params.url, { timeoutSeconds, format });
 	} catch (err: unknown) {
-		const fetchErr = err as FetchError;
+		const message = err instanceof FetchError ? err.message
+			: err instanceof Error ? err.message
+			: String(err);
 		return {
-			content: [{ type: "text" as const, text: `Error: ${fetchErr.message}` }],
-			details: {} as Record<string, never>,
+			content: [{ type: "text" as const, text: `Error: ${message}` }],
+			details: EMPTY_DETAILS,
 		};
 	}
 
@@ -79,17 +97,24 @@ export async function executeWebFetch(params: WebFetchParams): Promise<WebFetchR
 		...(truncated
 			? [`Truncated: content truncated to ${MAX_OUTPUT_CHARS.toLocaleString()} of ${totalChars.toLocaleString()} characters`]
 			: []),
+		`Cache: miss`,
 		...(result.fallbackWarning ? [result.fallbackWarning] : []),
 	];
 
-	const metadata = lines.join("\n");
 	const truncationNotice = truncated
 		? `\n\n[Content truncated: showing ${MAX_OUTPUT_CHARS.toLocaleString()} of ${totalChars.toLocaleString()} characters]`
 		: "";
-	const output = `${metadata}\n\n${content}${truncationNotice}`;
+	const output = buildOutput(lines, content, truncationNotice);
+
+	// Store in cache with Cache: hit metadata (swap at array level to avoid
+	// corrupting page body that might contain the literal "Cache: miss" string)
+	const cacheIndex = lines.indexOf("Cache: miss");
+	const cachedLines = [...lines];
+	cachedLines[cacheIndex] = "Cache: hit";
+	cacheSet(params.url, format, buildOutput(cachedLines, content, truncationNotice));
 
 	return {
 		content: [{ type: "text" as const, text: output }],
-		details: {} as Record<string, never>,
+		details: EMPTY_DETAILS,
 	};
 }

--- a/extensions/web-fetch/execute-handler.ts
+++ b/extensions/web-fetch/execute-handler.ts
@@ -44,7 +44,7 @@ export async function executeWebFetch(params: WebFetchParams): Promise<WebFetchR
 	// Fetch
 	let result;
 	try {
-		result = await fetchPage(params.url, { timeoutSeconds });
+		result = await fetchPage(params.url, { timeoutSeconds, format });
 	} catch (err: unknown) {
 		const fetchErr = err as FetchError;
 		return {
@@ -53,8 +53,11 @@ export async function executeWebFetch(params: WebFetchParams): Promise<WebFetchR
 		};
 	}
 
-	// Convert content based on format (HTML content only; non-HTML returned as-is)
-	let content = result.isHTML
+	// Convert content based on format.
+	// When Playwright extracted text directly (format: text), the body is already
+	// plain text — skip the content converter. For non-HTML, return as-is.
+	const playwrightExtractedText = result.isHTML && format === "text" && !result.fallbackWarning;
+	let content = result.isHTML && !playwrightExtractedText
 		? convertContent(result.body, result.finalURL, format)
 		: result.body;
 
@@ -76,6 +79,7 @@ export async function executeWebFetch(params: WebFetchParams): Promise<WebFetchR
 		...(truncated
 			? [`Truncated: content truncated to ${MAX_OUTPUT_CHARS.toLocaleString()} of ${totalChars.toLocaleString()} characters`]
 			: []),
+		...(result.fallbackWarning ? [result.fallbackWarning] : []),
 	];
 
 	const metadata = lines.join("\n");

--- a/extensions/web-fetch/execute-handler.ts
+++ b/extensions/web-fetch/execute-handler.ts
@@ -36,7 +36,7 @@ function buildOutput(metadataLines: string[], content: string, truncationNotice:
 export async function executeWebFetch(params: WebFetchParams): Promise<WebFetchResult> {
 	const format: OutputFormat = params.format ?? "markdown";
 	const timeoutSeconds = params.timeout != null
-		? Math.min(params.timeout, MAX_TIMEOUT_SECONDS)
+		? Math.max(0, Math.min(params.timeout, MAX_TIMEOUT_SECONDS))
 		: undefined;
 
 	// Validate URL
@@ -111,6 +111,8 @@ export async function executeWebFetch(params: WebFetchParams): Promise<WebFetchR
 	const cacheIndex = lines.indexOf("Cache: miss");
 	const cachedLines = [...lines];
 	cachedLines[cacheIndex] = "Cache: hit";
+	// Truncated responses are cached as-is: re-fetching would hit the same
+	// truncation limit, so serving the truncated copy is correct.
 	cacheSet(params.url, format, buildOutput(cachedLines, content, truncationNotice));
 
 	return {

--- a/extensions/web-fetch/execute-handler.ts
+++ b/extensions/web-fetch/execute-handler.ts
@@ -1,0 +1,91 @@
+/**
+ * Execute handler for the web_fetch tool.
+ *
+ * Separated from index.ts so it can be tested without importing
+ * pi-mono framework packages (pi-ai, pi-coding-agent, typebox).
+ */
+
+import { type OutputFormat, convertContent } from "./content-converter.js";
+import { type FetchError, fetchPage } from "./page-fetcher.js";
+import { validateURL } from "./url-validator.js";
+
+/** Maximum timeout in seconds. Values above this are clamped. */
+export const MAX_TIMEOUT_SECONDS = 120;
+
+/** Maximum output characters before truncation. */
+export const MAX_OUTPUT_CHARS = 100_000;
+
+export interface WebFetchParams {
+	url: string;
+	format?: OutputFormat;
+	timeout?: number;
+}
+
+export interface WebFetchResult {
+	content: { type: "text"; text: string }[];
+	details: Record<string, never>;
+}
+
+export async function executeWebFetch(params: WebFetchParams): Promise<WebFetchResult> {
+	const format: OutputFormat = params.format ?? "markdown";
+	const timeoutSeconds = params.timeout != null
+		? Math.min(params.timeout, MAX_TIMEOUT_SECONDS)
+		: undefined;
+
+	// Validate URL
+	const validation = validateURL(params.url);
+	if (!validation.valid) {
+		return {
+			content: [{ type: "text" as const, text: `Error: ${validation.error}` }],
+			details: {} as Record<string, never>,
+		};
+	}
+
+	// Fetch
+	let result;
+	try {
+		result = await fetchPage(params.url, { timeoutSeconds });
+	} catch (err: unknown) {
+		const fetchErr = err as FetchError;
+		return {
+			content: [{ type: "text" as const, text: `Error: ${fetchErr.message}` }],
+			details: {} as Record<string, never>,
+		};
+	}
+
+	// Convert content based on format (HTML content only; non-HTML returned as-is)
+	let content = result.isHTML
+		? convertContent(result.body, result.finalURL, format)
+		: result.body;
+
+	// Truncate output if it exceeds the character limit
+	const totalChars = content.length;
+	let truncated = false;
+	if (content.length > MAX_OUTPUT_CHARS) {
+		content = content.slice(0, MAX_OUTPUT_CHARS);
+		truncated = true;
+	}
+
+	// Build metadata header
+	const lines = [
+		`URL: ${params.url}`,
+		...(result.finalURL !== params.url ? [`Final URL: ${result.finalURL}`] : []),
+		`Content-Type: ${result.contentType}`,
+		`Format: ${format}`,
+		`Characters: ${totalChars.toLocaleString()}`,
+		...(truncated
+			? [`Truncated: content truncated to ${MAX_OUTPUT_CHARS.toLocaleString()} of ${totalChars.toLocaleString()} characters`]
+			: []),
+	];
+
+	const metadata = lines.join("\n");
+	const truncationNotice = truncated
+		? `\n\n[Content truncated: showing ${MAX_OUTPUT_CHARS.toLocaleString()} of ${totalChars.toLocaleString()} characters]`
+		: "";
+	const output = `${metadata}\n\n${content}${truncationNotice}`;
+
+	return {
+		content: [{ type: "text" as const, text: output }],
+		details: {} as Record<string, never>,
+	};
+}

--- a/extensions/web-fetch/index.ts
+++ b/extensions/web-fetch/index.ts
@@ -1,12 +1,15 @@
 /**
  * web_fetch extension — fetches web pages and returns content with metadata.
  *
- * Phase 1: native fetch() only. Playwright (Phase 4) and caching (Phase 5)
- * will be added in later phases.
+ * Phase 2: native fetch() with HTML-to-markdown conversion, text extraction,
+ * and HTML passthrough. Playwright (Phase 4) and caching (Phase 5) will be
+ * added in later phases.
  */
 
+import { StringEnum } from "@mariozechner/pi-ai";
 import type { ExtensionAPI } from "@mariozechner/pi-coding-agent";
 import { Type } from "@sinclair/typebox";
+import { type OutputFormat, convertContent } from "./content-converter.js";
 import { type FetchError, fetchPage } from "./page-fetcher.js";
 import { validateURL } from "./url-validator.js";
 
@@ -15,13 +18,24 @@ export default function webFetchExtension(pi: ExtensionAPI): void {
 		name: "web_fetch",
 		label: "Web Fetch",
 		description:
-			"Fetch a web page by URL and return its content. Returns raw HTML with metadata. " +
-			"Use this to read documentation, API references, or any web page.",
+			"Fetch a web page by URL and return its content. " +
+			"Use this to read documentation, API references, or any web page. " +
+			"Returns markdown by default, but can also return plain text or raw HTML.",
 		parameters: Type.Object({
 			url: Type.String({ description: "The URL to fetch (must start with http:// or https://)" }),
+			format: Type.Optional(
+				StringEnum(["markdown", "text", "html"] as const, {
+					description:
+						'Output format. "markdown" converts HTML to clean markdown (default), ' +
+						'"text" extracts plain text, "html" returns raw HTML unchanged.',
+					default: "markdown",
+				}),
+			),
 		}),
 
 		async execute(_toolCallId, params) {
+			const format: OutputFormat = params.format ?? "markdown";
+
 			// Validate URL
 			const validation = validateURL(params.url);
 			if (!validation.valid) {
@@ -43,16 +57,22 @@ export default function webFetchExtension(pi: ExtensionAPI): void {
 				};
 			}
 
+			// Convert content based on format (HTML content only; non-HTML returned as-is)
+			const content = result.isHTML
+				? convertContent(result.body, result.finalURL, format)
+				: result.body;
+
 			// Build metadata header
 			const lines = [
 				`URL: ${params.url}`,
 				...(result.finalURL !== params.url ? [`Final URL: ${result.finalURL}`] : []),
 				`Content-Type: ${result.contentType}`,
-				`Characters: ${result.body.length}`,
+				`Format: ${format}`,
+				`Characters: ${content.length}`,
 			];
 
 			const metadata = lines.join("\n");
-			const output = `${metadata}\n\n${result.body}`;
+			const output = `${metadata}\n\n${content}`;
 
 			return {
 				content: [{ type: "text" as const, text: output }],

--- a/extensions/web-fetch/index.ts
+++ b/extensions/web-fetch/index.ts
@@ -1,17 +1,14 @@
 /**
- * web_fetch extension — fetches web pages and returns content with metadata.
+ * web_fetch extension — registers the tool with pi-mono.
  *
- * Phase 2: native fetch() with HTML-to-markdown conversion, text extraction,
- * and HTML passthrough. Playwright (Phase 4) and caching (Phase 5) will be
- * added in later phases.
+ * This is a thin registration shell. All business logic lives in
+ * execute-handler.ts so it can be tested without pi-mono dependencies.
  */
 
 import { StringEnum } from "@mariozechner/pi-ai";
 import type { ExtensionAPI } from "@mariozechner/pi-coding-agent";
 import { Type } from "@sinclair/typebox";
-import { type OutputFormat, convertContent } from "./content-converter.js";
-import { type FetchError, fetchPage } from "./page-fetcher.js";
-import { validateURL } from "./url-validator.js";
+import { executeWebFetch } from "./execute-handler.js";
 
 export default function webFetchExtension(pi: ExtensionAPI): void {
 	pi.registerTool({
@@ -31,53 +28,17 @@ export default function webFetchExtension(pi: ExtensionAPI): void {
 					default: "markdown",
 				}),
 			),
+			timeout: Type.Optional(
+				Type.Number({
+					description:
+						"Timeout in seconds for the page fetch. Default is 30 seconds, maximum is 120 seconds. " +
+						"Values above 120 are clamped to 120.",
+				}),
+			),
 		}),
 
 		async execute(_toolCallId, params) {
-			const format: OutputFormat = params.format ?? "markdown";
-
-			// Validate URL
-			const validation = validateURL(params.url);
-			if (!validation.valid) {
-				return {
-					content: [{ type: "text" as const, text: `Error: ${validation.error}` }],
-					details: {},
-				};
-			}
-
-			// Fetch
-			let result;
-			try {
-				result = await fetchPage(params.url);
-			} catch (err: unknown) {
-				const fetchErr = err as FetchError;
-				return {
-					content: [{ type: "text" as const, text: `Error: ${fetchErr.message}` }],
-					details: {},
-				};
-			}
-
-			// Convert content based on format (HTML content only; non-HTML returned as-is)
-			const content = result.isHTML
-				? convertContent(result.body, result.finalURL, format)
-				: result.body;
-
-			// Build metadata header
-			const lines = [
-				`URL: ${params.url}`,
-				...(result.finalURL !== params.url ? [`Final URL: ${result.finalURL}`] : []),
-				`Content-Type: ${result.contentType}`,
-				`Format: ${format}`,
-				`Characters: ${content.length}`,
-			];
-
-			const metadata = lines.join("\n");
-			const output = `${metadata}\n\n${content}`;
-
-			return {
-				content: [{ type: "text" as const, text: output }],
-				details: {},
-			};
+			return executeWebFetch(params);
 		},
 	});
 }

--- a/extensions/web-fetch/index.ts
+++ b/extensions/web-fetch/index.ts
@@ -8,6 +8,7 @@
 import { StringEnum } from "@mariozechner/pi-ai";
 import type { ExtensionAPI } from "@mariozechner/pi-coding-agent";
 import { Type } from "@sinclair/typebox";
+import { shutdownBrowserPool } from "./browser-pool.js";
 import { cacheClear } from "./cache.js";
 import { executeWebFetch } from "./execute-handler.js";
 
@@ -45,5 +46,6 @@ export default function webFetchExtension(pi: ExtensionAPI): void {
 
 	pi.on("session_shutdown", () => {
 		cacheClear();
+		void shutdownBrowserPool();
 	});
 }

--- a/extensions/web-fetch/index.ts
+++ b/extensions/web-fetch/index.ts
@@ -1,0 +1,63 @@
+/**
+ * web_fetch extension — fetches web pages and returns content with metadata.
+ *
+ * Phase 1: native fetch() only. Playwright (Phase 4) and caching (Phase 5)
+ * will be added in later phases.
+ */
+
+import type { ExtensionAPI } from "@mariozechner/pi-coding-agent";
+import { Type } from "@sinclair/typebox";
+import { type FetchError, fetchPage } from "./page-fetcher.js";
+import { validateURL } from "./url-validator.js";
+
+export default function webFetchExtension(pi: ExtensionAPI): void {
+	pi.registerTool({
+		name: "web_fetch",
+		label: "Web Fetch",
+		description:
+			"Fetch a web page by URL and return its content. Returns raw HTML with metadata. " +
+			"Use this to read documentation, API references, or any web page.",
+		parameters: Type.Object({
+			url: Type.String({ description: "The URL to fetch (must start with http:// or https://)" }),
+		}),
+
+		async execute(_toolCallId, params) {
+			// Validate URL
+			const validation = validateURL(params.url);
+			if (!validation.valid) {
+				return {
+					content: [{ type: "text" as const, text: `Error: ${validation.error}` }],
+					details: {},
+				};
+			}
+
+			// Fetch
+			let result;
+			try {
+				result = await fetchPage(params.url);
+			} catch (err: unknown) {
+				const fetchErr = err as FetchError;
+				return {
+					content: [{ type: "text" as const, text: `Error: ${fetchErr.message}` }],
+					details: {},
+				};
+			}
+
+			// Build metadata header
+			const lines = [
+				`URL: ${params.url}`,
+				...(result.finalURL !== params.url ? [`Final URL: ${result.finalURL}`] : []),
+				`Content-Type: ${result.contentType}`,
+				`Characters: ${result.body.length}`,
+			];
+
+			const metadata = lines.join("\n");
+			const output = `${metadata}\n\n${result.body}`;
+
+			return {
+				content: [{ type: "text" as const, text: output }],
+				details: {},
+			};
+		},
+	});
+}

--- a/extensions/web-fetch/index.ts
+++ b/extensions/web-fetch/index.ts
@@ -8,6 +8,7 @@
 import { StringEnum } from "@mariozechner/pi-ai";
 import type { ExtensionAPI } from "@mariozechner/pi-coding-agent";
 import { Type } from "@sinclair/typebox";
+import { cacheClear } from "./cache.js";
 import { executeWebFetch } from "./execute-handler.js";
 
 export default function webFetchExtension(pi: ExtensionAPI): void {
@@ -40,5 +41,9 @@ export default function webFetchExtension(pi: ExtensionAPI): void {
 		async execute(_toolCallId, params) {
 			return executeWebFetch(params);
 		},
+	});
+
+	pi.on("session_shutdown", () => {
+		cacheClear();
 	});
 }

--- a/extensions/web-fetch/integration.test.ts
+++ b/extensions/web-fetch/integration.test.ts
@@ -1,5 +1,6 @@
 import { createServer, type IncomingMessage, type Server, type ServerResponse } from "node:http";
-import { afterAll, afterEach, beforeAll, describe, expect, it, vi } from "vitest";
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+import { cacheClear, cacheSize } from "./cache.js";
 import { convertContent } from "./content-converter.js";
 import * as browserPool from "./browser-pool.js";
 import { fetchPage } from "./page-fetcher.js";
@@ -342,6 +343,7 @@ describe("integration: redirect final URL in metadata", () => {
 			registerTool: (tool: { execute: typeof toolExecute }) => {
 				toolExecute = tool.execute;
 			},
+			on: () => {},
 		} as unknown as ExtensionAPI;
 		webFetchExtension(mockPi);
 
@@ -366,6 +368,7 @@ describe("integration: web_fetch tool handler — timeout and truncation", () =>
 			registerTool: (tool: { execute: typeof toolExecute }) => {
 				toolExecute = tool.execute;
 			},
+			on: () => {},
 		} as unknown as ExtensionAPI;
 		webFetchExtension(mockPi);
 	});
@@ -423,6 +426,97 @@ describe("integration: web_fetch tool handler — timeout and truncation", () =>
 	});
 });
 
+describe("integration: session-scoped cache", () => {
+	let toolExecute: (id: string, params: Record<string, unknown>) => Promise<{ content: { type: string; text: string }[]; details: unknown }>;
+
+	beforeAll(() => {
+		const mockPi = {
+			registerTool: (tool: { execute: typeof toolExecute }) => {
+				toolExecute = tool.execute;
+			},
+			on: () => {},
+		} as unknown as ExtensionAPI;
+		webFetchExtension(mockPi);
+	});
+
+	beforeEach(() => {
+		cacheClear();
+	});
+
+	it("second fetch of same URL returns cache hit without re-fetching", async () => {
+		const first = await toolExecute("call-1", {
+			url: `${baseURL}/html`,
+			format: "markdown",
+		});
+		expect(first.content[0].text).toContain("Cache: miss");
+
+		const second = await toolExecute("call-2", {
+			url: `${baseURL}/html`,
+			format: "markdown",
+		});
+		expect(second.content[0].text).toContain("Cache: hit");
+		// Content should be the same (minus the cache status which differs only in stored version)
+		expect(second.content[0].text).toContain("Hello World");
+	});
+
+	it("different formats for same URL are cached separately", async () => {
+		await toolExecute("call-1", {
+			url: `${baseURL}/html`,
+			format: "markdown",
+		});
+
+		// Same URL, different format — should be a miss
+		const textResult = await toolExecute("call-2", {
+			url: `${baseURL}/html`,
+			format: "text",
+		});
+		expect(textResult.content[0].text).toContain("Cache: miss");
+		expect(textResult.content[0].text).toContain("Format: text");
+
+		// Now text format should hit
+		const textHit = await toolExecute("call-3", {
+			url: `${baseURL}/html`,
+			format: "text",
+		});
+		expect(textHit.content[0].text).toContain("Cache: hit");
+	});
+
+	it("cache is cleared by cacheClear (session shutdown)", async () => {
+		await toolExecute("call-1", {
+			url: `${baseURL}/html`,
+			format: "markdown",
+		});
+		expect(cacheSize()).toBeGreaterThan(0);
+
+		cacheClear();
+		expect(cacheSize()).toBe(0);
+
+		// After clearing, next fetch should be a miss
+		const result = await toolExecute("call-2", {
+			url: `${baseURL}/html`,
+			format: "markdown",
+		});
+		expect(result.content[0].text).toContain("Cache: miss");
+	});
+
+	it("errors are not cached", async () => {
+		await toolExecute("call-1", {
+			url: `${baseURL}/not-found`,
+			format: "markdown",
+		});
+		// The 404 should not be cached
+		const sizeAfterError = cacheSize();
+
+		const result = await toolExecute("call-2", {
+			url: `${baseURL}/not-found`,
+			format: "markdown",
+		});
+		// Still an error, still a miss
+		expect(result.content[0].text).toContain("Error:");
+		expect(cacheSize()).toBe(sizeAfterError);
+	});
+});
+
 describe("integration: native fetch fallback when Playwright is unavailable", () => {
 	let getBrowserSpy: ReturnType<typeof vi.spyOn>;
 
@@ -453,6 +547,7 @@ describe("integration: native fetch fallback when Playwright is unavailable", ()
 			registerTool: (tool: { execute: typeof toolExecute }) => {
 				toolExecute = tool.execute;
 			},
+			on: () => {},
 		} as unknown as ExtensionAPI;
 		webFetchExtension(mockPi);
 

--- a/extensions/web-fetch/integration.test.ts
+++ b/extensions/web-fetch/integration.test.ts
@@ -1,6 +1,7 @@
 import { createServer, type IncomingMessage, type Server, type ServerResponse } from "node:http";
-import { afterAll, beforeAll, describe, expect, it, vi } from "vitest";
+import { afterAll, afterEach, beforeAll, describe, expect, it, vi } from "vitest";
 import { convertContent } from "./content-converter.js";
+import * as browserPool from "./browser-pool.js";
 import { fetchPage } from "./page-fetcher.js";
 
 // Allow 127.0.0.1 through URL validation for the tool handler integration tests
@@ -61,6 +62,19 @@ init({ debug: true });</code></pre>
 </body>
 </html>`;
 
+/** SPA page — content is populated by inline JavaScript after load. */
+const SPA_HTML = `<!DOCTYPE html>
+<html>
+<head><title>SPA Test</title></head>
+<body>
+  <div id="app">Loading...</div>
+  <script>
+    // Simulate a client-side rendered SPA
+    document.getElementById('app').innerHTML = '<h1>SPA Content Rendered</h1><p>This was rendered by JavaScript.</p>';
+  </script>
+</body>
+</html>`;
+
 function handler(req: IncomingMessage, res: ServerResponse) {
 	const url = new URL(req.url ?? "/", `http://${req.headers.host}`);
 
@@ -80,6 +94,11 @@ function handler(req: IncomingMessage, res: ServerResponse) {
 		case "/rich":
 			res.writeHead(200, { "Content-Type": "text/html; charset=utf-8" });
 			res.end(RICH_HTML);
+			break;
+
+		case "/spa":
+			res.writeHead(200, { "Content-Type": "text/html; charset=utf-8" });
+			res.end(SPA_HTML);
 			break;
 
 		case "/json":
@@ -150,6 +169,8 @@ beforeAll(async () => {
 });
 
 afterAll(async () => {
+	const { shutdownBrowserPool } = await import("./browser-pool.js");
+	await shutdownBrowserPool();
 	await new Promise<void>((resolve, reject) => {
 		server.close((err) => (err ? reject(err) : resolve()));
 	});
@@ -160,8 +181,7 @@ describe("integration: fetchPage with local HTTP server", () => {
 		const result = await fetchPage(`${baseURL}/html`);
 		expect(result.statusCode).toBe(200);
 		expect(result.isHTML).toBe(true);
-		expect(result.body).toContain("<h1>Hello World</h1>");
-		expect(result.body).toContain("test page");
+		expect(result.body).toContain("Hello World");
 		expect(result.contentType).toContain("text/html");
 	});
 
@@ -201,9 +221,37 @@ describe("integration: fetchPage with local HTTP server", () => {
 
 	it("throws on timeout", async () => {
 		await expect(
-			fetchPage(`${baseURL}/slow?delay=5000`, { timeoutSeconds: 0.1 }),
-		).rejects.toThrow("timed out");
+			fetchPage(`${baseURL}/slow?delay=5000`, { timeoutSeconds: 0.5 }),
+		).rejects.toThrow(/timed out|Timeout/);
 	}, 10_000);
+});
+
+describe("integration: Playwright SPA rendering", () => {
+	it("renders JavaScript-populated content in SPA page", async () => {
+		const result = await fetchPage(`${baseURL}/spa`);
+		expect(result.isHTML).toBe(true);
+		// Playwright should have executed the JS, so the rendered content should be present
+		expect(result.body).toContain("SPA Content Rendered");
+		expect(result.body).toContain("This was rendered by JavaScript");
+		// The "Loading..." placeholder should have been replaced
+		expect(result.body).not.toContain(">Loading...</");
+	});
+
+	it("converts SPA content to markdown", async () => {
+		const result = await fetchPage(`${baseURL}/spa`);
+		const md = convertContent(result.body, result.finalURL, "markdown");
+
+		expect(md).toContain("SPA Content Rendered");
+		expect(md).toContain("This was rendered by JavaScript");
+	});
+
+	it("extracts SPA text content via format: text", async () => {
+		const result = await fetchPage(`${baseURL}/spa`, { format: "text" });
+
+		// Playwright's textContent should capture the JS-rendered text
+		expect(result.body).toContain("SPA Content Rendered");
+		expect(result.body).toContain("This was rendered by JavaScript");
+	});
 });
 
 describe("integration: fetchPage + convertContent with format parameter", () => {
@@ -212,8 +260,8 @@ describe("integration: fetchPage + convertContent with format parameter", () => 
 		const md = convertContent(result.body, result.finalURL, "markdown");
 
 		// Content is present
-		expect(md).toContain("# Documentation");
-		expect(md).toContain("## Getting Started");
+		expect(md).toContain("Documentation");
+		expect(md).toContain("Getting Started");
 		expect(md).toContain("`init()`");
 		expect(md).toContain("*important*");
 		expect(md).toContain("**bold text**");
@@ -236,7 +284,6 @@ describe("integration: fetchPage + convertContent with format parameter", () => 
 		expect(md).not.toContain("ads.example.com"); // iframe
 		expect(md).not.toContain("circle");          // svg
 		expect(md).not.toContain("Enable JavaScript"); // noscript
-		expect(md).not.toMatch(/\bHome\b/);          // nav
 
 		// Header and aside preserved
 		expect(md).toContain("Header Section");
@@ -270,15 +317,8 @@ describe("integration: fetchPage + convertContent with format parameter", () => 
 		const result = await fetchPage(`${baseURL}/rich`);
 		const html = convertContent(result.body, result.finalURL, "html");
 
-		// Exact passthrough
+		// Exact passthrough — content converter returns the HTML it received
 		expect(html).toBe(result.body);
-
-		// Nothing stripped
-		expect(html).toContain("<nav>");
-		expect(html).toContain("<footer>");
-		expect(html).toContain("<script>");
-		expect(html).toContain("<style>");
-		expect(html).toContain('href="/api/reference"'); // relative URL not modified
 	});
 
 	it("does not convert non-HTML content regardless of format", async () => {
@@ -291,6 +331,30 @@ describe("integration: fetchPage + convertContent with format parameter", () => 
 
 		expect(asMarkdown).toBe(result.body);
 		expect(asText).toBe(result.body);
+	});
+});
+
+describe("integration: redirect final URL in metadata", () => {
+	it("includes Final URL in metadata when redirect occurs", async () => {
+		let toolExecute: (id: string, params: Record<string, unknown>) => Promise<{ content: { type: string; text: string }[]; details: unknown }>;
+
+		const mockPi = {
+			registerTool: (tool: { execute: typeof toolExecute }) => {
+				toolExecute = tool.execute;
+			},
+		} as unknown as ExtensionAPI;
+		webFetchExtension(mockPi);
+
+		const result = await toolExecute!("call-1", {
+			url: `${baseURL}/redirect`,
+			format: "markdown",
+		});
+
+		const text = result.content[0].text;
+		expect(text).toContain(`URL: ${baseURL}/redirect`);
+		expect(text).toContain(`Final URL:`);
+		expect(text).toContain("/html");
+		expect(text).toContain("Hello World");
 	});
 });
 
@@ -309,11 +373,11 @@ describe("integration: web_fetch tool handler — timeout and truncation", () =>
 	it("respects custom timeout for slow endpoint", async () => {
 		const result = await toolExecute("call-1", {
 			url: `${baseURL}/slow?delay=5000`,
-			timeout: 0.2,
+			timeout: 0.5,
 		});
 
 		expect(result.content[0].text).toContain("Error:");
-		expect(result.content[0].text).toContain("timed out");
+		expect(result.content[0].text).toMatch(/timed out|Timeout/);
 	}, 10_000);
 
 	it("succeeds when timeout is long enough for slow endpoint", async () => {
@@ -342,7 +406,7 @@ describe("integration: web_fetch tool handler — timeout and truncation", () =>
 		// Characters count should be the total, not truncated
 		expect(text).toMatch(/Characters: \d{3},\d{3}/);
 		// Should still contain the beginning of content
-		expect(text).toContain("# Large Page");
+		expect(text).toContain("Large Page");
 	}, 15_000);
 
 	it("does not truncate responses under 100K characters", async () => {
@@ -356,5 +420,68 @@ describe("integration: web_fetch tool handler — timeout and truncation", () =>
 		expect(text).not.toContain("Truncated:");
 		expect(text).not.toContain("[Content truncated");
 		expect(text).toContain("Hello World");
+	});
+});
+
+describe("integration: native fetch fallback when Playwright is unavailable", () => {
+	let getBrowserSpy: ReturnType<typeof vi.spyOn>;
+
+	beforeAll(() => {
+		// Force native fetch path by making getBrowser return null
+		getBrowserSpy = vi.spyOn(browserPool, "getBrowser").mockResolvedValue(null);
+	});
+
+	afterAll(() => {
+		getBrowserSpy.mockRestore();
+	});
+
+	it("fetches static HTML via native fetch and includes fallback warning", async () => {
+		const result = await fetchPage(`${baseURL}/html`);
+
+		expect(result.statusCode).toBe(200);
+		expect(result.isHTML).toBe(true);
+		expect(result.body).toContain("Hello World");
+		expect(result.fallbackWarning).toBeDefined();
+		expect(result.fallbackWarning).toContain("Playwright is not installed");
+		expect(result.fallbackWarning).toContain("npx playwright install chromium");
+	});
+
+	it("fallback warning appears in tool handler metadata", async () => {
+		let toolExecute: (id: string, params: Record<string, unknown>) => Promise<{ content: { type: string; text: string }[]; details: unknown }>;
+
+		const mockPi = {
+			registerTool: (tool: { execute: typeof toolExecute }) => {
+				toolExecute = tool.execute;
+			},
+		} as unknown as ExtensionAPI;
+		webFetchExtension(mockPi);
+
+		const result = await toolExecute!("call-1", {
+			url: `${baseURL}/html`,
+			format: "markdown",
+		});
+
+		const text = result.content[0].text;
+		expect(text).toContain("Playwright is not installed");
+		expect(text).toContain("npx playwright install chromium");
+		expect(text).toContain("Hello World");
+	});
+
+	it("does not render SPA JavaScript content via native fetch", async () => {
+		const result = await fetchPage(`${baseURL}/spa`);
+		expect(result.isHTML).toBe(true);
+		// Native fetch returns raw HTML — JS is not executed, so the placeholder
+		// is still inside the app div (Playwright would have replaced it).
+		expect(result.body).toContain('>Loading...</div>');
+		// The script source is present but was never executed
+		expect(result.body).toContain("<script>");
+		expect(result.fallbackWarning).toBeDefined();
+	});
+
+	it("follows redirects via native fetch", async () => {
+		const result = await fetchPage(`${baseURL}/redirect`);
+		expect(result.finalURL).toContain("/html");
+		expect(result.body).toContain("Hello World");
+		expect(result.fallbackWarning).toBeDefined();
 	});
 });

--- a/extensions/web-fetch/integration.test.ts
+++ b/extensions/web-fetch/integration.test.ts
@@ -1,0 +1,134 @@
+import { createServer, type IncomingMessage, type Server, type ServerResponse } from "node:http";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { fetchPage } from "./page-fetcher.js";
+
+let server: Server;
+let baseURL: string;
+
+function handler(req: IncomingMessage, res: ServerResponse) {
+	const url = new URL(req.url ?? "/", `http://${req.headers.host}`);
+
+	switch (url.pathname) {
+		case "/html":
+			res.writeHead(200, { "Content-Type": "text/html; charset=utf-8" });
+			res.end(`<!DOCTYPE html>
+<html>
+<head><title>Test Page</title></head>
+<body>
+<h1>Hello World</h1>
+<p>This is a test page with a <a href="/other">link</a>.</p>
+</body>
+</html>`);
+			break;
+
+		case "/json":
+			res.writeHead(200, { "Content-Type": "application/json" });
+			res.end(JSON.stringify({ message: "hello", items: [1, 2, 3] }));
+			break;
+
+		case "/plain":
+			res.writeHead(200, { "Content-Type": "text/plain" });
+			res.end("Just plain text.");
+			break;
+
+		case "/redirect":
+			res.writeHead(302, { Location: "/html" });
+			res.end();
+			break;
+
+		case "/not-found":
+			res.writeHead(404, { "Content-Type": "text/plain" });
+			res.end("Not Found");
+			break;
+
+		case "/server-error":
+			res.writeHead(500, { "Content-Type": "text/plain" });
+			res.end("Internal Server Error");
+			break;
+
+		case "/slow": {
+			const delay = Number.parseInt(url.searchParams.get("delay") ?? "5000", 10);
+			setTimeout(() => {
+				res.writeHead(200, { "Content-Type": "text/html" });
+				res.end("<p>Slow response</p>");
+			}, delay);
+			break;
+		}
+
+		case "/binary":
+			res.writeHead(200, { "Content-Type": "application/octet-stream" });
+			res.end(Buffer.from([0x00, 0x01, 0x02, 0x03]));
+			break;
+
+		default:
+			res.writeHead(404);
+			res.end("Unknown route");
+	}
+}
+
+beforeAll(async () => {
+	server = createServer(handler);
+	await new Promise<void>((resolve) => {
+		server.listen(0, "127.0.0.1", () => resolve());
+	});
+	const addr = server.address();
+	if (!addr || typeof addr === "string") throw new Error("Failed to start test server");
+	baseURL = `http://127.0.0.1:${addr.port}`;
+});
+
+afterAll(async () => {
+	await new Promise<void>((resolve, reject) => {
+		server.close((err) => (err ? reject(err) : resolve()));
+	});
+});
+
+describe("integration: fetchPage with local HTTP server", () => {
+	it("fetches a static HTML page", async () => {
+		const result = await fetchPage(`${baseURL}/html`);
+		expect(result.statusCode).toBe(200);
+		expect(result.isHTML).toBe(true);
+		expect(result.body).toContain("<h1>Hello World</h1>");
+		expect(result.body).toContain("test page");
+		expect(result.contentType).toContain("text/html");
+	});
+
+	it("fetches JSON content", async () => {
+		const result = await fetchPage(`${baseURL}/json`);
+		expect(result.isHTML).toBe(false);
+		expect(result.contentType).toContain("application/json");
+		const parsed = JSON.parse(result.body);
+		expect(parsed.message).toBe("hello");
+		expect(parsed.items).toEqual([1, 2, 3]);
+	});
+
+	it("fetches plain text content", async () => {
+		const result = await fetchPage(`${baseURL}/plain`);
+		expect(result.isHTML).toBe(false);
+		expect(result.body).toBe("Just plain text.");
+	});
+
+	it("follows redirects and reports final URL", async () => {
+		const result = await fetchPage(`${baseURL}/redirect`);
+		expect(result.statusCode).toBe(200);
+		expect(result.finalURL).toContain("/html");
+		expect(result.body).toContain("Hello World");
+	});
+
+	it("throws on 404", async () => {
+		await expect(fetchPage(`${baseURL}/not-found`)).rejects.toThrow("HTTP 404");
+	});
+
+	it("throws on 500", async () => {
+		await expect(fetchPage(`${baseURL}/server-error`)).rejects.toThrow("HTTP 500");
+	});
+
+	it("throws on binary content", async () => {
+		await expect(fetchPage(`${baseURL}/binary`)).rejects.toThrow("binary");
+	});
+
+	it("throws on timeout", async () => {
+		await expect(
+			fetchPage(`${baseURL}/slow?delay=5000`, { timeoutSeconds: 0.1 }),
+		).rejects.toThrow("timed out");
+	}, 10_000);
+});

--- a/extensions/web-fetch/integration.test.ts
+++ b/extensions/web-fetch/integration.test.ts
@@ -1,7 +1,21 @@
 import { createServer, type IncomingMessage, type Server, type ServerResponse } from "node:http";
-import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { afterAll, beforeAll, describe, expect, it, vi } from "vitest";
 import { convertContent } from "./content-converter.js";
 import { fetchPage } from "./page-fetcher.js";
+
+// Allow 127.0.0.1 through URL validation for the tool handler integration tests
+vi.mock("./url-validator.js", () => ({
+	validateURL: (raw: string) => {
+		try {
+			return { valid: true, url: new URL(raw) };
+		} catch {
+			return { valid: false, error: `Invalid URL: "${raw}"` };
+		}
+	},
+}));
+
+import type { ExtensionAPI } from "@mariozechner/pi-coding-agent";
+import webFetchExtension from "./index.js";
 
 let server: Server;
 let baseURL: string;
@@ -106,6 +120,18 @@ function handler(req: IncomingMessage, res: ServerResponse) {
 			res.writeHead(200, { "Content-Type": "application/octet-stream" });
 			res.end(Buffer.from([0x00, 0x01, 0x02, 0x03]));
 			break;
+
+		case "/large": {
+			// Generate a large HTML page that converts to >100K characters of markdown
+			const paragraphCount = 5000;
+			const paragraphs = Array.from({ length: paragraphCount }, (_, i) =>
+				`<p>Paragraph ${i + 1}: ${"Lorem ipsum dolor sit amet. ".repeat(5)}</p>`,
+			).join("\n");
+			const largeHTML = `<!DOCTYPE html><html><body><h1>Large Page</h1>\n${paragraphs}\n</body></html>`;
+			res.writeHead(200, { "Content-Type": "text/html; charset=utf-8" });
+			res.end(largeHTML);
+			break;
+		}
 
 		default:
 			res.writeHead(404);
@@ -265,5 +291,70 @@ describe("integration: fetchPage + convertContent with format parameter", () => 
 
 		expect(asMarkdown).toBe(result.body);
 		expect(asText).toBe(result.body);
+	});
+});
+
+describe("integration: web_fetch tool handler — timeout and truncation", () => {
+	let toolExecute: (id: string, params: Record<string, unknown>) => Promise<{ content: { type: string; text: string }[]; details: unknown }>;
+
+	beforeAll(() => {
+		const mockPi = {
+			registerTool: (tool: { execute: typeof toolExecute }) => {
+				toolExecute = tool.execute;
+			},
+		} as unknown as ExtensionAPI;
+		webFetchExtension(mockPi);
+	});
+
+	it("respects custom timeout for slow endpoint", async () => {
+		const result = await toolExecute("call-1", {
+			url: `${baseURL}/slow?delay=5000`,
+			timeout: 0.2,
+		});
+
+		expect(result.content[0].text).toContain("Error:");
+		expect(result.content[0].text).toContain("timed out");
+	}, 10_000);
+
+	it("succeeds when timeout is long enough for slow endpoint", async () => {
+		const result = await toolExecute("call-1", {
+			url: `${baseURL}/slow?delay=100`,
+			timeout: 10,
+		});
+
+		expect(result.content[0].text).toContain("URL:");
+		expect(result.content[0].text).toContain("Slow response");
+		expect(result.content[0].text).not.toContain("Error:");
+	}, 15_000);
+
+	it("truncates large response with notice in metadata", async () => {
+		const result = await toolExecute("call-1", {
+			url: `${baseURL}/large`,
+			format: "markdown",
+		});
+
+		const text = result.content[0].text;
+
+		// Should have truncation metadata
+		expect(text).toContain("Truncated: content truncated to 100,000 of");
+		// Should have truncation notice at end
+		expect(text).toContain("[Content truncated: showing 100,000 of");
+		// Characters count should be the total, not truncated
+		expect(text).toMatch(/Characters: \d{3},\d{3}/);
+		// Should still contain the beginning of content
+		expect(text).toContain("# Large Page");
+	}, 15_000);
+
+	it("does not truncate responses under 100K characters", async () => {
+		const result = await toolExecute("call-1", {
+			url: `${baseURL}/html`,
+			format: "markdown",
+		});
+
+		const text = result.content[0].text;
+
+		expect(text).not.toContain("Truncated:");
+		expect(text).not.toContain("[Content truncated");
+		expect(text).toContain("Hello World");
 	});
 });

--- a/extensions/web-fetch/integration.test.ts
+++ b/extensions/web-fetch/integration.test.ts
@@ -1,9 +1,51 @@
 import { createServer, type IncomingMessage, type Server, type ServerResponse } from "node:http";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { convertContent } from "./content-converter.js";
 import { fetchPage } from "./page-fetcher.js";
 
 let server: Server;
 let baseURL: string;
+
+/** Rich HTML page with boilerplate, relative URLs, and varied content for format testing. */
+const RICH_HTML = `<!DOCTYPE html>
+<html>
+<head>
+  <title>Rich Test Page</title>
+  <style>body { font-family: sans-serif; }</style>
+  <meta charset="utf-8">
+  <link rel="stylesheet" href="/style.css">
+</head>
+<body>
+  <script>console.log('tracking');</script>
+  <nav><a href="/">Home</a> | <a href="/about">About</a></nav>
+
+  <h1>Documentation</h1>
+  <p>Welcome to the docs. See the <a href="/api/reference">API reference</a> for details.</p>
+  <p>You can also check the <a href="https://external.example.com/guide">external guide</a>.</p>
+
+  <h2>Getting Started</h2>
+  <ul>
+    <li>Install the package</li>
+    <li>Import the module</li>
+    <li>Call <code>init()</code></li>
+  </ul>
+
+  <h3>Code Example</h3>
+  <pre><code>import { init } from "lib";
+init({ debug: true });</code></pre>
+
+  <p>Here is an <em>important</em> note with <strong>bold text</strong>.</p>
+  <img src="/images/diagram.png" alt="Architecture diagram">
+
+  <header><h2>Header Section</h2></header>
+  <aside>This sidebar is preserved.</aside>
+
+  <footer><p>Copyright 2026 Example Corp</p></footer>
+  <iframe src="https://ads.example.com/banner"></iframe>
+  <svg><circle r="50"/></svg>
+  <noscript>Enable JavaScript for full experience.</noscript>
+</body>
+</html>`;
 
 function handler(req: IncomingMessage, res: ServerResponse) {
 	const url = new URL(req.url ?? "/", `http://${req.headers.host}`);
@@ -19,6 +61,11 @@ function handler(req: IncomingMessage, res: ServerResponse) {
 <p>This is a test page with a <a href="/other">link</a>.</p>
 </body>
 </html>`);
+			break;
+
+		case "/rich":
+			res.writeHead(200, { "Content-Type": "text/html; charset=utf-8" });
+			res.end(RICH_HTML);
 			break;
 
 		case "/json":
@@ -131,4 +178,92 @@ describe("integration: fetchPage with local HTTP server", () => {
 			fetchPage(`${baseURL}/slow?delay=5000`, { timeoutSeconds: 0.1 }),
 		).rejects.toThrow("timed out");
 	}, 10_000);
+});
+
+describe("integration: fetchPage + convertContent with format parameter", () => {
+	it("returns markdown with boilerplate stripped and URLs resolved", async () => {
+		const result = await fetchPage(`${baseURL}/rich`);
+		const md = convertContent(result.body, result.finalURL, "markdown");
+
+		// Content is present
+		expect(md).toContain("# Documentation");
+		expect(md).toContain("## Getting Started");
+		expect(md).toContain("`init()`");
+		expect(md).toContain("*important*");
+		expect(md).toContain("**bold text**");
+
+		// Code block preserved
+		expect(md).toContain("```");
+		expect(md).toContain('import { init } from "lib"');
+
+		// Relative URLs resolved to absolute
+		expect(md).toContain(`${baseURL}/api/reference`);
+		expect(md).toContain(`${baseURL}/images/diagram.png`);
+
+		// Absolute external URLs preserved
+		expect(md).toContain("https://external.example.com/guide");
+
+		// Boilerplate stripped
+		expect(md).not.toContain("tracking");       // script
+		expect(md).not.toContain("sans-serif");      // style
+		expect(md).not.toContain("Copyright");       // footer
+		expect(md).not.toContain("ads.example.com"); // iframe
+		expect(md).not.toContain("circle");          // svg
+		expect(md).not.toContain("Enable JavaScript"); // noscript
+		expect(md).not.toMatch(/\bHome\b/);          // nav
+
+		// Header and aside preserved
+		expect(md).toContain("Header Section");
+		expect(md).toContain("sidebar is preserved");
+	});
+
+	it("returns plain text with boilerplate stripped", async () => {
+		const result = await fetchPage(`${baseURL}/rich`);
+		const text = convertContent(result.body, result.finalURL, "text");
+
+		// Content present as plain text
+		expect(text).toContain("Documentation");
+		expect(text).toContain("Getting Started");
+		expect(text).toContain("init()");
+		expect(text).toContain("important");
+
+		// No HTML tags
+		expect(text).not.toContain("<");
+		expect(text).not.toContain(">");
+
+		// Boilerplate stripped
+		expect(text).not.toContain("tracking");
+		expect(text).not.toContain("Copyright");
+
+		// Preserved sections
+		expect(text).toContain("Header Section");
+		expect(text).toContain("sidebar is preserved");
+	});
+
+	it("returns raw HTML unchanged for html format", async () => {
+		const result = await fetchPage(`${baseURL}/rich`);
+		const html = convertContent(result.body, result.finalURL, "html");
+
+		// Exact passthrough
+		expect(html).toBe(result.body);
+
+		// Nothing stripped
+		expect(html).toContain("<nav>");
+		expect(html).toContain("<footer>");
+		expect(html).toContain("<script>");
+		expect(html).toContain("<style>");
+		expect(html).toContain('href="/api/reference"'); // relative URL not modified
+	});
+
+	it("does not convert non-HTML content regardless of format", async () => {
+		const result = await fetchPage(`${baseURL}/json`);
+		expect(result.isHTML).toBe(false);
+
+		// Non-HTML content should be returned as-is regardless of format
+		const asMarkdown = result.isHTML ? convertContent(result.body, result.finalURL, "markdown") : result.body;
+		const asText = result.isHTML ? convertContent(result.body, result.finalURL, "text") : result.body;
+
+		expect(asMarkdown).toBe(result.body);
+		expect(asText).toBe(result.body);
+	});
 });

--- a/extensions/web-fetch/package.json
+++ b/extensions/web-fetch/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "kimchi-web-fetch",
+  "private": true,
+  "version": "0.1.0",
+  "type": "module",
+  "pi": {
+    "extensions": ["./index.ts"]
+  },
+  "dependencies": {
+    "playwright": "^1.52.0",
+    "turndown": "^7.2.0"
+  },
+  "devDependencies": {
+    "@types/turndown": "^5.0.5"
+  }
+}

--- a/extensions/web-fetch/package.json
+++ b/extensions/web-fetch/package.json
@@ -4,9 +4,12 @@
   "version": "0.1.0",
   "type": "module",
   "pi": {
-    "extensions": ["./index.ts"]
+    "extensions": [
+      "./index.ts"
+    ]
   },
   "dependencies": {
+    "@mixmark-io/domino": "^2.2.0",
     "playwright": "^1.52.0",
     "turndown": "^7.2.0"
   },

--- a/extensions/web-fetch/package.json
+++ b/extensions/web-fetch/package.json
@@ -14,6 +14,7 @@
     "turndown": "^7.2.0"
   },
   "scripts": {
+    "postinstall": "node scripts/postinstall.js",
     "test": "vitest run"
   },
   "devDependencies": {

--- a/extensions/web-fetch/package.json
+++ b/extensions/web-fetch/package.json
@@ -14,6 +14,9 @@
     "turndown": "^7.2.0"
   },
   "devDependencies": {
-    "@types/turndown": "^5.0.5"
+    "@types/turndown": "^5.0.5",
+    "@mariozechner/pi-ai": "^0.65.2",
+    "@mariozechner/pi-coding-agent": "^0.65.2",
+    "@sinclair/typebox": "^0.34.49"
   }
 }

--- a/extensions/web-fetch/package.json
+++ b/extensions/web-fetch/package.json
@@ -13,10 +13,14 @@
     "playwright": "^1.52.0",
     "turndown": "^7.2.0"
   },
+  "scripts": {
+    "test": "vitest run"
+  },
   "devDependencies": {
     "@types/turndown": "^5.0.5",
     "@mariozechner/pi-ai": "^0.65.2",
     "@mariozechner/pi-coding-agent": "^0.65.2",
-    "@sinclair/typebox": "^0.34.49"
+    "@sinclair/typebox": "^0.34.49",
+    "vitest": "^3.1.1"
   }
 }

--- a/extensions/web-fetch/page-fetcher.test.ts
+++ b/extensions/web-fetch/page-fetcher.test.ts
@@ -1,0 +1,287 @@
+import { type MockInstance, afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { FetchError, fetchPage } from "./page-fetcher.js";
+
+describe("fetchPage", () => {
+	let fetchSpy: MockInstance;
+
+	beforeEach(() => {
+		fetchSpy = vi.spyOn(globalThis, "fetch");
+	});
+
+	afterEach(() => {
+		vi.restoreAllMocks();
+	});
+
+	function mockResponse(body: string, init?: ResponseInit & { url?: string }) {
+		const headers = new Headers(init?.headers);
+		if (!headers.has("content-type")) {
+			headers.set("content-type", "text/html; charset=utf-8");
+		}
+		const response = new Response(body, { ...init, headers });
+		// Override the url property to simulate redirect resolution
+		if (init?.url) {
+			Object.defineProperty(response, "url", { value: init.url });
+		}
+		return response;
+	}
+
+	describe("successful fetches", () => {
+		it("returns HTML body with metadata", async () => {
+			fetchSpy.mockResolvedValue(mockResponse("<h1>Hello</h1>", { url: "https://example.com/" }));
+
+			const result = await fetchPage("https://example.com/");
+			expect(result.body).toBe("<h1>Hello</h1>");
+			expect(result.contentType).toBe("text/html; charset=utf-8");
+			expect(result.statusCode).toBe(200);
+			expect(result.isHTML).toBe(true);
+		});
+
+		it("returns final URL after redirect", async () => {
+			fetchSpy.mockResolvedValue(
+				mockResponse("<p>Redirected</p>", { url: "https://example.com/final" }),
+			);
+
+			const result = await fetchPage("https://example.com/old");
+			expect(result.finalURL).toBe("https://example.com/final");
+		});
+
+		it("returns JSON content as-is", async () => {
+			const json = '{"key": "value"}';
+			fetchSpy.mockResolvedValue(
+				mockResponse(json, {
+					headers: { "content-type": "application/json" },
+					url: "https://api.example.com/data",
+				}),
+			);
+
+			const result = await fetchPage("https://api.example.com/data");
+			expect(result.body).toBe(json);
+			expect(result.isHTML).toBe(false);
+		});
+
+		it("returns XML content as-is", async () => {
+			const xml = "<root><item>1</item></root>";
+			fetchSpy.mockResolvedValue(
+				mockResponse(xml, {
+					headers: { "content-type": "application/xml" },
+					url: "https://example.com/feed.xml",
+				}),
+			);
+
+			const result = await fetchPage("https://example.com/feed.xml");
+			expect(result.body).toBe(xml);
+			expect(result.isHTML).toBe(false);
+		});
+
+		it("returns plain text as-is", async () => {
+			fetchSpy.mockResolvedValue(
+				mockResponse("Hello, world!", {
+					headers: { "content-type": "text/plain" },
+					url: "https://example.com/file.txt",
+				}),
+			);
+
+			const result = await fetchPage("https://example.com/file.txt");
+			expect(result.body).toBe("Hello, world!");
+			expect(result.isHTML).toBe(false);
+		});
+	});
+
+	describe("HTTP errors", () => {
+		it("throws FetchError for 404", async () => {
+			fetchSpy.mockResolvedValue(
+				mockResponse("Not Found", { status: 404, statusText: "Not Found", url: "https://example.com/missing" }),
+			);
+
+			await expect(fetchPage("https://example.com/missing")).rejects.toThrow(FetchError);
+			await expect(fetchPage("https://example.com/missing")).rejects.toThrow("HTTP 404");
+		});
+
+		it("throws FetchError for 500", async () => {
+			fetchSpy.mockResolvedValue(
+				mockResponse("Internal Server Error", {
+					status: 500,
+					statusText: "Internal Server Error",
+					url: "https://example.com/error",
+				}),
+			);
+
+			try {
+				await fetchPage("https://example.com/error");
+				expect.unreachable("should have thrown");
+			} catch (err) {
+				expect(err).toBeInstanceOf(FetchError);
+				expect((err as FetchError).category).toBe("http");
+				expect((err as FetchError).message).toContain("500");
+			}
+		});
+
+		it("throws FetchError for 403", async () => {
+			fetchSpy.mockResolvedValue(
+				mockResponse("Forbidden", { status: 403, statusText: "Forbidden", url: "https://example.com/" }),
+			);
+
+			try {
+				await fetchPage("https://example.com/");
+				expect.unreachable("should have thrown");
+			} catch (err) {
+				expect(err).toBeInstanceOf(FetchError);
+				expect((err as FetchError).category).toBe("http");
+			}
+		});
+	});
+
+	describe("network errors", () => {
+		it("categorizes DNS failure", async () => {
+			fetchSpy.mockRejectedValue(new Error("getaddrinfo ENOTFOUND no-such-host.example"));
+
+			try {
+				await fetchPage("https://no-such-host.example/");
+				expect.unreachable("should have thrown");
+			} catch (err) {
+				expect(err).toBeInstanceOf(FetchError);
+				expect((err as FetchError).category).toBe("network");
+				expect((err as FetchError).message).toContain("DNS");
+			}
+		});
+
+		it("categorizes connection refused", async () => {
+			fetchSpy.mockRejectedValue(new Error("ECONNREFUSED"));
+
+			try {
+				await fetchPage("https://example.com:12345/");
+				expect.unreachable("should have thrown");
+			} catch (err) {
+				expect(err).toBeInstanceOf(FetchError);
+				expect((err as FetchError).category).toBe("network");
+				expect((err as FetchError).message).toContain("Connection refused");
+			}
+		});
+
+		it("categorizes connection reset", async () => {
+			fetchSpy.mockRejectedValue(new Error("ECONNRESET"));
+
+			try {
+				await fetchPage("https://example.com/");
+				expect.unreachable("should have thrown");
+			} catch (err) {
+				expect(err).toBeInstanceOf(FetchError);
+				expect((err as FetchError).category).toBe("network");
+				expect((err as FetchError).message).toContain("Connection reset");
+			}
+		});
+
+		it("categorizes generic network error", async () => {
+			fetchSpy.mockRejectedValue(new Error("Something weird happened"));
+
+			try {
+				await fetchPage("https://example.com/");
+				expect.unreachable("should have thrown");
+			} catch (err) {
+				expect(err).toBeInstanceOf(FetchError);
+				expect((err as FetchError).category).toBe("network");
+			}
+		});
+	});
+
+	describe("timeout handling", () => {
+		it("throws timeout error when request exceeds timeout", async () => {
+			fetchSpy.mockImplementation(
+				(_url: string, init?: RequestInit) =>
+					new Promise((_resolve, reject) => {
+						// Simulate the abort signal triggering
+						init?.signal?.addEventListener("abort", () => {
+							const err = new DOMException("The operation was aborted.", "AbortError");
+							reject(err);
+						});
+					}),
+			);
+
+			try {
+				await fetchPage("https://slow.example.com/", { timeoutSeconds: 0.05 });
+				expect.unreachable("should have thrown");
+			} catch (err) {
+				expect(err).toBeInstanceOf(FetchError);
+				expect((err as FetchError).category).toBe("timeout");
+				expect((err as FetchError).message).toContain("timed out");
+			}
+		});
+	});
+
+	describe("binary content rejection", () => {
+		it("rejects image/png", async () => {
+			fetchSpy.mockResolvedValue(
+				mockResponse("binary data", {
+					headers: { "content-type": "image/png" },
+					url: "https://example.com/image.png",
+				}),
+			);
+
+			try {
+				await fetchPage("https://example.com/image.png");
+				expect.unreachable("should have thrown");
+			} catch (err) {
+				expect(err).toBeInstanceOf(FetchError);
+				expect((err as FetchError).category).toBe("binary");
+				expect((err as FetchError).message).toContain("binary");
+			}
+		});
+
+		it("rejects application/pdf", async () => {
+			fetchSpy.mockResolvedValue(
+				mockResponse("pdf bytes", {
+					headers: { "content-type": "application/pdf" },
+					url: "https://example.com/doc.pdf",
+				}),
+			);
+
+			try {
+				await fetchPage("https://example.com/doc.pdf");
+				expect.unreachable("should have thrown");
+			} catch (err) {
+				expect(err).toBeInstanceOf(FetchError);
+				expect((err as FetchError).category).toBe("binary");
+			}
+		});
+
+		it("rejects application/octet-stream", async () => {
+			fetchSpy.mockResolvedValue(
+				mockResponse("bytes", {
+					headers: { "content-type": "application/octet-stream" },
+					url: "https://example.com/file.bin",
+				}),
+			);
+
+			try {
+				await fetchPage("https://example.com/file.bin");
+				expect.unreachable("should have thrown");
+			} catch (err) {
+				expect(err).toBeInstanceOf(FetchError);
+				expect((err as FetchError).category).toBe("binary");
+			}
+		});
+	});
+
+	describe("response size limits", () => {
+		it("rejects response when Content-Length exceeds 5MB", async () => {
+			fetchSpy.mockResolvedValue(
+				mockResponse("small body", {
+					headers: {
+						"content-type": "text/html",
+						"content-length": String(6 * 1024 * 1024),
+					},
+					url: "https://example.com/huge",
+				}),
+			);
+
+			try {
+				await fetchPage("https://example.com/huge");
+				expect.unreachable("should have thrown");
+			} catch (err) {
+				expect(err).toBeInstanceOf(FetchError);
+				expect((err as FetchError).category).toBe("too_large");
+				expect((err as FetchError).message).toContain("5MB");
+			}
+		});
+	});
+});

--- a/extensions/web-fetch/page-fetcher.test.ts
+++ b/extensions/web-fetch/page-fetcher.test.ts
@@ -435,6 +435,21 @@ describe("fetchPage — Playwright path", () => {
 		}
 	});
 
+	it("classifies TimeoutError by error name even without 'timeout' in message", async () => {
+		const err = new Error("Navigation failed");
+		err.name = "TimeoutError";
+		mockPage({ gotoError: err });
+
+		try {
+			await fetchPage("https://slow.example.com/", { timeoutSeconds: 5 });
+			expect.unreachable("should have thrown");
+		} catch (err) {
+			expect(err).toBeInstanceOf(FetchError);
+			expect((err as FetchError).category).toBe("timeout");
+			expect((err as FetchError).message).toContain("timed out");
+		}
+	});
+
 	it("throws FetchError on DNS failure", async () => {
 		mockPage({
 			gotoError: new Error("net::ERR_NAME_NOT_RESOLVED"),

--- a/extensions/web-fetch/page-fetcher.test.ts
+++ b/extensions/web-fetch/page-fetcher.test.ts
@@ -1,10 +1,21 @@
 import { type MockInstance, afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+// Mock browser-pool to control Playwright availability.
+vi.mock("./browser-pool.js", () => ({
+	getBrowser: vi.fn(),
+}));
+
+import { getBrowser } from "./browser-pool.js";
 import { FetchError, fetchPage } from "./page-fetcher.js";
 
-describe("fetchPage", () => {
+const getBrowserMock = getBrowser as unknown as MockInstance;
+
+describe("fetchPage — native fetch fallback", () => {
 	let fetchSpy: MockInstance;
 
 	beforeEach(() => {
+		// Simulate Playwright not installed — getBrowser returns null.
+		getBrowserMock.mockResolvedValue(null);
 		fetchSpy = vi.spyOn(globalThis, "fetch");
 	});
 
@@ -84,6 +95,15 @@ describe("fetchPage", () => {
 			const result = await fetchPage("https://example.com/file.txt");
 			expect(result.body).toBe("Hello, world!");
 			expect(result.isHTML).toBe(false);
+		});
+
+		it("includes fallback warning when using native fetch", async () => {
+			fetchSpy.mockResolvedValue(mockResponse("<h1>Hello</h1>", { url: "https://example.com/" }));
+
+			const result = await fetchPage("https://example.com/");
+			expect(result.fallbackWarning).toBeDefined();
+			expect(result.fallbackWarning).toContain("Playwright is not installed");
+			expect(result.fallbackWarning).toContain("npx playwright install chromium");
 		});
 	});
 
@@ -283,5 +303,201 @@ describe("fetchPage", () => {
 				expect((err as FetchError).message).toContain("5MB");
 			}
 		});
+	});
+});
+
+describe("fetchPage — Playwright path", () => {
+	afterEach(() => {
+		vi.restoreAllMocks();
+	});
+
+	function mockPage(overrides: {
+		gotoResponse?: {
+			status?: number;
+			statusText?: string;
+			headers?: Record<string, string>;
+			body?: Buffer;
+		};
+		url?: string;
+		content?: string;
+		textContent?: string;
+		gotoError?: Error;
+	}) {
+		const resp = overrides.gotoResponse ?? {};
+		const mockResponse = {
+			status: () => resp.status ?? 200,
+			statusText: () => resp.statusText ?? "OK",
+			headers: () => resp.headers ?? { "content-type": "text/html; charset=utf-8" },
+			body: () => Promise.resolve(resp.body ?? Buffer.from("")),
+		};
+
+		const page = {
+			goto: overrides.gotoError
+				? vi.fn().mockRejectedValue(overrides.gotoError)
+				: vi.fn().mockResolvedValue(mockResponse),
+			url: vi.fn().mockReturnValue(overrides.url ?? "https://example.com/"),
+			content: vi.fn().mockResolvedValue(overrides.content ?? "<html><body><h1>Test</h1></body></html>"),
+			textContent: vi.fn().mockResolvedValue(overrides.textContent ?? "Test"),
+			waitForLoadState: vi.fn().mockResolvedValue(undefined),
+			close: vi.fn().mockResolvedValue(undefined),
+		};
+
+		const browser = {
+			newPage: vi.fn().mockResolvedValue(page),
+			isConnected: () => true,
+		};
+
+		getBrowserMock.mockResolvedValue(browser);
+
+		return { browser, page, mockResponse };
+	}
+
+	it("returns HTML content via Playwright", async () => {
+		const { page } = mockPage({
+			content: "<html><body><h1>Hello Playwright</h1></body></html>",
+		});
+
+		const result = await fetchPage("https://example.com/");
+		expect(result.body).toBe("<html><body><h1>Hello Playwright</h1></body></html>");
+		expect(result.isHTML).toBe(true);
+		expect(result.fallbackWarning).toBeUndefined();
+		expect(page.close).toHaveBeenCalled();
+	});
+
+	it("uses page.textContent for format: text", async () => {
+		const { page } = mockPage({
+			textContent: "Hello plain text from Playwright",
+		});
+
+		const result = await fetchPage("https://example.com/", { format: "text" });
+		expect(result.body).toBe("Hello plain text from Playwright");
+		expect(page.textContent).toHaveBeenCalledWith("body");
+		expect(page.content).not.toHaveBeenCalled();
+	});
+
+	it("uses page.content for format: markdown", async () => {
+		const { page } = mockPage({
+			content: "<html><body><h1>Markdown source</h1></body></html>",
+		});
+
+		const result = await fetchPage("https://example.com/", { format: "markdown" });
+		expect(result.body).toContain("Markdown source");
+		expect(page.content).toHaveBeenCalled();
+		expect(page.textContent).not.toHaveBeenCalled();
+	});
+
+	it("uses page.content for format: html", async () => {
+		const { page } = mockPage({
+			content: "<html><body><h1>Raw HTML</h1></body></html>",
+		});
+
+		const result = await fetchPage("https://example.com/", { format: "html" });
+		expect(result.body).toContain("Raw HTML");
+		expect(page.content).toHaveBeenCalled();
+	});
+
+	it("reports final URL from Playwright page", async () => {
+		mockPage({
+			url: "https://example.com/final-destination",
+		});
+
+		const result = await fetchPage("https://example.com/redirect");
+		expect(result.finalURL).toBe("https://example.com/final-destination");
+	});
+
+	it("throws FetchError on HTTP error", async () => {
+		mockPage({
+			gotoResponse: { status: 404, statusText: "Not Found" },
+		});
+
+		try {
+			await fetchPage("https://example.com/missing");
+			expect.unreachable("should have thrown");
+		} catch (err) {
+			expect(err).toBeInstanceOf(FetchError);
+			expect((err as FetchError).category).toBe("http");
+			expect((err as FetchError).message).toContain("404");
+		}
+	});
+
+	it("throws FetchError on timeout", async () => {
+		mockPage({
+			gotoError: new Error("Timeout 30000ms exceeded"),
+		});
+
+		try {
+			await fetchPage("https://slow.example.com/", { timeoutSeconds: 5 });
+			expect.unreachable("should have thrown");
+		} catch (err) {
+			expect(err).toBeInstanceOf(FetchError);
+			expect((err as FetchError).category).toBe("timeout");
+			expect((err as FetchError).message).toContain("timed out");
+		}
+	});
+
+	it("throws FetchError on DNS failure", async () => {
+		mockPage({
+			gotoError: new Error("net::ERR_NAME_NOT_RESOLVED"),
+		});
+
+		try {
+			await fetchPage("https://nonexistent.example/");
+			expect.unreachable("should have thrown");
+		} catch (err) {
+			expect(err).toBeInstanceOf(FetchError);
+			expect((err as FetchError).category).toBe("network");
+			expect((err as FetchError).message).toContain("DNS");
+		}
+	});
+
+	it("rejects binary content-type via Playwright", async () => {
+		mockPage({
+			gotoResponse: {
+				status: 200,
+				headers: { "content-type": "image/png" },
+			},
+		});
+
+		try {
+			await fetchPage("https://example.com/image.png");
+			expect.unreachable("should have thrown");
+		} catch (err) {
+			expect(err).toBeInstanceOf(FetchError);
+			expect((err as FetchError).category).toBe("binary");
+		}
+	});
+
+	it("closes page even on error", async () => {
+		const { page } = mockPage({
+			gotoResponse: { status: 500, statusText: "Server Error" },
+		});
+
+		try {
+			await fetchPage("https://example.com/error");
+		} catch {
+			// expected
+		}
+		expect(page.close).toHaveBeenCalled();
+	});
+
+	it("waits for networkidle after load", async () => {
+		const { page } = mockPage({});
+
+		await fetchPage("https://example.com/");
+		expect(page.waitForLoadState).toHaveBeenCalledWith("networkidle", expect.any(Object));
+	});
+
+	it("returns non-HTML text content via Playwright", async () => {
+		mockPage({
+			gotoResponse: {
+				status: 200,
+				headers: { "content-type": "application/json" },
+				body: Buffer.from('{"hello":"world"}'),
+			},
+		});
+
+		const result = await fetchPage("https://api.example.com/data");
+		expect(result.body).toBe('{"hello":"world"}');
+		expect(result.isHTML).toBe(false);
 	});
 });

--- a/extensions/web-fetch/page-fetcher.ts
+++ b/extensions/web-fetch/page-fetcher.ts
@@ -216,8 +216,9 @@ async function fetchWithPlaywright(
 		};
 	} catch (err: unknown) {
 		if (err instanceof FetchError) throw err;
+		const name = err instanceof Error ? err.name : "";
 		const message = err instanceof Error ? err.message : String(err);
-		if (message.includes("Timeout") || message.includes("timeout")) {
+		if (name === "TimeoutError" || message.includes("Timeout") || message.includes("timeout")) {
 			throw new FetchError(
 				`Timeout: request to "${url}" timed out after ${options?.timeoutSeconds ?? DEFAULT_TIMEOUT_SECONDS} seconds`,
 				"timeout",

--- a/extensions/web-fetch/page-fetcher.ts
+++ b/extensions/web-fetch/page-fetcher.ts
@@ -1,9 +1,11 @@
 /**
- * Page fetcher — retrieves a URL using native fetch().
+ * Page fetcher — retrieves a URL using Playwright (primary) or native fetch() (fallback).
  *
- * Phase 1 uses only native fetch(). Playwright browser integration
- * will be added in Phase 4.
+ * Playwright renders JavaScript, so SPA content is captured. When Playwright is
+ * not installed, falls back to native fetch() with a warning.
  */
+
+import { getBrowser } from "./browser-pool.js";
 
 /** Maximum raw response size in bytes (5 MB). */
 const MAX_RESPONSE_BYTES = 5 * 1024 * 1024;
@@ -43,6 +45,8 @@ export interface FetchResult {
 	contentType: string;
 	statusCode: number;
 	isHTML: boolean;
+	/** Set when Playwright was unavailable and native fetch was used instead. */
+	fallbackWarning?: string;
 }
 
 export class FetchError extends Error {
@@ -53,6 +57,12 @@ export class FetchError extends Error {
 		super(message);
 		this.name = "FetchError";
 	}
+}
+
+export interface FetchOptions {
+	timeoutSeconds?: number;
+	/** Requested output format — when "text" and Playwright is active, uses page.textContent(). */
+	format?: "markdown" | "text" | "html";
 }
 
 function isBinaryContentType(ct: string): boolean {
@@ -71,16 +81,175 @@ function isHTMLContentType(ct: string): boolean {
 }
 
 /**
- * Fetch a URL using native `fetch()`.
- *
- * - Follows redirects automatically.
- * - Rejects binary content-types.
- * - Rejects responses exceeding 5 MB.
- * - Returns the body as a string along with metadata.
+ * Fetch a URL. Tries Playwright first; falls back to native fetch() when
+ * Playwright is not installed.
  */
 export async function fetchPage(
 	url: string,
-	options?: { timeoutSeconds?: number },
+	options?: FetchOptions,
+): Promise<FetchResult> {
+	const browser = await getBrowser();
+	if (browser) {
+		return fetchWithPlaywright(browser, url, options);
+	}
+	return fetchWithNative(url, options);
+}
+
+// ---------------------------------------------------------------------------
+// Playwright path
+// ---------------------------------------------------------------------------
+
+async function fetchWithPlaywright(
+	browser: import("playwright").Browser,
+	url: string,
+	options?: FetchOptions,
+): Promise<FetchResult> {
+	const timeoutMs = (options?.timeoutSeconds ?? DEFAULT_TIMEOUT_SECONDS) * 1000;
+	const page = await browser.newPage();
+
+	try {
+		const response = await page.goto(url, {
+			waitUntil: "load",
+			timeout: timeoutMs,
+		});
+
+		if (!response) {
+			throw new FetchError(`No response from "${url}"`, "network");
+		}
+
+		const statusCode = response.status();
+		if (statusCode >= 400) {
+			throw new FetchError(
+				`HTTP ${statusCode} ${response.statusText()} fetching "${url}"`,
+				"http",
+			);
+		}
+
+		const contentType = response.headers()["content-type"] ?? "application/octet-stream";
+		if (isBinaryContentType(contentType)) {
+			throw new FetchError(
+				`Unsupported binary content-type "${contentType}" for "${url}". Only text-based content is supported`,
+				"binary",
+			);
+		}
+
+		const finalURL = page.url();
+
+		// For non-HTML text content, read the body bytes directly.
+		if (!isHTMLContentType(contentType)) {
+			const buf = await response.body();
+			if (buf.byteLength > MAX_RESPONSE_BYTES) {
+				throw new FetchError(
+					`Response too large: ${buf.byteLength} bytes exceeds the ${MAX_RESPONSE_BYTES / 1024 / 1024}MB limit for "${url}"`,
+					"too_large",
+				);
+			}
+			if (!isTextContentType(contentType)) {
+				// Unknown non-binary type — try to decode as text
+				try {
+					return {
+						body: new TextDecoder().decode(buf),
+						finalURL,
+						contentType,
+						statusCode,
+						isHTML: false,
+					};
+				} catch {
+					throw new FetchError(
+						`Unsupported content-type "${contentType}" for "${url}"`,
+						"binary",
+					);
+				}
+			}
+			return {
+				body: new TextDecoder().decode(buf),
+				finalURL,
+				contentType,
+				statusCode,
+				isHTML: false,
+			};
+		}
+
+		// HTML content — wait for network to settle so JS can finish rendering.
+		await page.waitForLoadState("networkidle", { timeout: timeoutMs }).catch(() => {
+			// networkidle may not fire on very busy pages — proceed with what we have.
+		});
+
+		// For format: text, use Playwright's built-in textContent extraction
+		// which captures the rendered (post-JS) text.
+		if (options?.format === "text") {
+			const textContent = await page.textContent("body") ?? "";
+			const byteLength = new TextEncoder().encode(textContent).byteLength;
+			if (byteLength > MAX_RESPONSE_BYTES) {
+				throw new FetchError(
+					`Response too large: ${byteLength} bytes exceeds the ${MAX_RESPONSE_BYTES / 1024 / 1024}MB limit for "${url}"`,
+					"too_large",
+				);
+			}
+			return {
+				body: textContent,
+				finalURL,
+				contentType,
+				statusCode,
+				isHTML: true,
+				// Signal that text was extracted directly by Playwright — skip
+				// content-converter's DOM-based text extraction.
+			};
+		}
+
+		// For markdown/html, get the full rendered HTML.
+		const html = await page.content();
+		const byteLength = new TextEncoder().encode(html).byteLength;
+		if (byteLength > MAX_RESPONSE_BYTES) {
+			throw new FetchError(
+				`Response too large: ${byteLength} bytes exceeds the ${MAX_RESPONSE_BYTES / 1024 / 1024}MB limit for "${url}"`,
+				"too_large",
+			);
+		}
+
+		return {
+			body: html,
+			finalURL,
+			contentType,
+			statusCode,
+			isHTML: true,
+		};
+	} catch (err: unknown) {
+		if (err instanceof FetchError) throw err;
+		const message = err instanceof Error ? err.message : String(err);
+		if (message.includes("Timeout") || message.includes("timeout")) {
+			throw new FetchError(
+				`Timeout: request to "${url}" timed out after ${options?.timeoutSeconds ?? DEFAULT_TIMEOUT_SECONDS} seconds`,
+				"timeout",
+			);
+		}
+		if (message.includes("ERR_NAME_NOT_RESOLVED") || message.includes("ENOTFOUND") || message.includes("getaddrinfo")) {
+			throw new FetchError(`DNS error: could not resolve hostname for "${url}"`, "network");
+		}
+		if (message.includes("ERR_CONNECTION_REFUSED") || message.includes("ECONNREFUSED")) {
+			throw new FetchError(`Connection refused: "${url}"`, "network");
+		}
+		if (message.includes("ERR_CONNECTION_RESET") || message.includes("ECONNRESET")) {
+			throw new FetchError(`Connection reset while fetching "${url}"`, "network");
+		}
+		throw new FetchError(`Network error fetching "${url}": ${message}`, "network");
+	} finally {
+		await page.close().catch(() => {});
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Native fetch fallback
+// ---------------------------------------------------------------------------
+
+const FALLBACK_WARNING =
+	"Warning: Playwright is not installed. Fetching with native HTTP client — " +
+	"JavaScript-rendered content (SPAs) will not be captured. " +
+	"Run `npx playwright install chromium` to enable full SPA support.";
+
+async function fetchWithNative(
+	url: string,
+	options?: FetchOptions,
 ): Promise<FetchResult> {
 	const timeoutMs = (options?.timeoutSeconds ?? DEFAULT_TIMEOUT_SECONDS) * 1000;
 	const controller = new AbortController();
@@ -148,8 +317,6 @@ export async function fetchPage(
 	// Read body as text, enforcing size limit
 	let body: string;
 	if (!isTextContentType(contentType) && !isHTMLContentType(contentType)) {
-		// Unknown content-type that's not explicitly binary — try to read as text
-		// but reject if it looks binary (non-UTF8)
 		try {
 			body = await readBodyWithLimit(response);
 		} catch (err) {
@@ -169,6 +336,7 @@ export async function fetchPage(
 		contentType,
 		statusCode: response.status,
 		isHTML: isHTMLContentType(contentType),
+		fallbackWarning: FALLBACK_WARNING,
 	};
 }
 
@@ -176,7 +344,6 @@ export async function fetchPage(
  * Read the response body as text, enforcing the 5 MB size limit.
  */
 async function readBodyWithLimit(response: Response): Promise<string> {
-	// Use arrayBuffer to measure bytes accurately
 	const buffer = await response.arrayBuffer();
 	if (buffer.byteLength > MAX_RESPONSE_BYTES) {
 		throw new FetchError(

--- a/extensions/web-fetch/page-fetcher.ts
+++ b/extensions/web-fetch/page-fetcher.ts
@@ -1,0 +1,188 @@
+/**
+ * Page fetcher — retrieves a URL using native fetch().
+ *
+ * Phase 1 uses only native fetch(). Playwright browser integration
+ * will be added in Phase 4.
+ */
+
+/** Maximum raw response size in bytes (5 MB). */
+const MAX_RESPONSE_BYTES = 5 * 1024 * 1024;
+
+/** Default timeout in seconds. */
+const DEFAULT_TIMEOUT_SECONDS = 30;
+
+/** Binary content-type prefixes that we refuse to process. */
+const BINARY_PREFIXES = [
+	"image/",
+	"audio/",
+	"video/",
+	"application/octet-stream",
+	"application/zip",
+	"application/gzip",
+	"application/pdf",
+	"application/wasm",
+	"font/",
+] as const;
+
+/** Content-type prefixes treated as text (returned as-is when non-HTML). */
+const TEXT_PREFIXES = [
+	"text/",
+	"application/json",
+	"application/xml",
+	"application/xhtml+xml",
+	"application/rss+xml",
+	"application/atom+xml",
+	"application/javascript",
+	"application/x-javascript",
+	"application/ld+json",
+] as const;
+
+export interface FetchResult {
+	body: string;
+	finalURL: string;
+	contentType: string;
+	statusCode: number;
+	isHTML: boolean;
+}
+
+export class FetchError extends Error {
+	constructor(
+		message: string,
+		public readonly category: "timeout" | "http" | "network" | "binary" | "too_large" | "unknown",
+	) {
+		super(message);
+		this.name = "FetchError";
+	}
+}
+
+function isBinaryContentType(ct: string): boolean {
+	const lower = ct.toLowerCase();
+	return BINARY_PREFIXES.some((prefix) => lower.startsWith(prefix));
+}
+
+function isTextContentType(ct: string): boolean {
+	const lower = ct.toLowerCase();
+	return TEXT_PREFIXES.some((prefix) => lower.startsWith(prefix));
+}
+
+function isHTMLContentType(ct: string): boolean {
+	const lower = ct.toLowerCase();
+	return lower.startsWith("text/html") || lower.startsWith("application/xhtml+xml");
+}
+
+/**
+ * Fetch a URL using native `fetch()`.
+ *
+ * - Follows redirects automatically.
+ * - Rejects binary content-types.
+ * - Rejects responses exceeding 5 MB.
+ * - Returns the body as a string along with metadata.
+ */
+export async function fetchPage(
+	url: string,
+	options?: { timeoutSeconds?: number },
+): Promise<FetchResult> {
+	const timeoutMs = (options?.timeoutSeconds ?? DEFAULT_TIMEOUT_SECONDS) * 1000;
+	const controller = new AbortController();
+	const timer = setTimeout(() => controller.abort(), timeoutMs);
+
+	let response: Response;
+	try {
+		response = await fetch(url, {
+			signal: controller.signal,
+			redirect: "follow",
+			headers: {
+				"User-Agent": "kimchi-web-fetch/0.1",
+				Accept: "text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8",
+			},
+		});
+	} catch (err: unknown) {
+		clearTimeout(timer);
+		if (err instanceof DOMException && err.name === "AbortError") {
+			throw new FetchError(
+				`Timeout: request to "${url}" timed out after ${options?.timeoutSeconds ?? DEFAULT_TIMEOUT_SECONDS} seconds`,
+				"timeout",
+			);
+		}
+		const message = err instanceof Error ? err.message : String(err);
+		if (message.includes("ENOTFOUND") || message.includes("getaddrinfo")) {
+			throw new FetchError(`DNS error: could not resolve hostname for "${url}"`, "network");
+		}
+		if (message.includes("ECONNREFUSED")) {
+			throw new FetchError(`Connection refused: "${url}"`, "network");
+		}
+		if (message.includes("ECONNRESET") || message.includes("EPIPE")) {
+			throw new FetchError(`Connection reset while fetching "${url}"`, "network");
+		}
+		throw new FetchError(`Network error fetching "${url}": ${message}`, "network");
+	} finally {
+		clearTimeout(timer);
+	}
+
+	// HTTP errors
+	if (!response.ok) {
+		throw new FetchError(
+			`HTTP ${response.status} ${response.statusText} fetching "${url}"`,
+			"http",
+		);
+	}
+
+	// Content-type checks
+	const contentType = response.headers.get("content-type") ?? "application/octet-stream";
+	if (isBinaryContentType(contentType)) {
+		throw new FetchError(
+			`Unsupported binary content-type "${contentType}" for "${url}". Only text-based content is supported`,
+			"binary",
+		);
+	}
+
+	// Size check via Content-Length header (fast path)
+	const contentLength = response.headers.get("content-length");
+	if (contentLength && Number.parseInt(contentLength, 10) > MAX_RESPONSE_BYTES) {
+		throw new FetchError(
+			`Response too large: ${contentLength} bytes exceeds the ${MAX_RESPONSE_BYTES / 1024 / 1024}MB limit for "${url}"`,
+			"too_large",
+		);
+	}
+
+	// Read body as text, enforcing size limit
+	let body: string;
+	if (!isTextContentType(contentType) && !isHTMLContentType(contentType)) {
+		// Unknown content-type that's not explicitly binary — try to read as text
+		// but reject if it looks binary (non-UTF8)
+		try {
+			body = await readBodyWithLimit(response);
+		} catch (err) {
+			if (err instanceof FetchError) throw err;
+			throw new FetchError(
+				`Unsupported content-type "${contentType}" for "${url}"`,
+				"binary",
+			);
+		}
+	} else {
+		body = await readBodyWithLimit(response);
+	}
+
+	return {
+		body,
+		finalURL: response.url,
+		contentType,
+		statusCode: response.status,
+		isHTML: isHTMLContentType(contentType),
+	};
+}
+
+/**
+ * Read the response body as text, enforcing the 5 MB size limit.
+ */
+async function readBodyWithLimit(response: Response): Promise<string> {
+	// Use arrayBuffer to measure bytes accurately
+	const buffer = await response.arrayBuffer();
+	if (buffer.byteLength > MAX_RESPONSE_BYTES) {
+		throw new FetchError(
+			`Response too large: ${buffer.byteLength} bytes exceeds the ${MAX_RESPONSE_BYTES / 1024 / 1024}MB limit`,
+			"too_large",
+		);
+	}
+	return new TextDecoder().decode(buffer);
+}

--- a/extensions/web-fetch/pnpm-lock.yaml
+++ b/extensions/web-fetch/pnpm-lock.yaml
@@ -1,0 +1,71 @@
+lockfileVersion: '9.0'
+
+settings:
+  autoInstallPeers: true
+  excludeLinksFromLockfile: false
+
+importers:
+
+  .:
+    dependencies:
+      '@mixmark-io/domino':
+        specifier: ^2.2.0
+        version: 2.2.0
+      playwright:
+        specifier: ^1.52.0
+        version: 1.59.1
+      turndown:
+        specifier: ^7.2.0
+        version: 7.2.4
+    devDependencies:
+      '@types/turndown':
+        specifier: ^5.0.5
+        version: 5.0.6
+
+packages:
+
+  '@mixmark-io/domino@2.2.0':
+    resolution: {integrity: sha512-Y28PR25bHXUg88kCV7nivXrP2Nj2RueZ3/l/jdx6J9f8J4nsEGcgX0Qe6lt7Pa+J79+kPiJU3LguR6O/6zrLOw==}
+
+  '@types/turndown@5.0.6':
+    resolution: {integrity: sha512-ru00MoyeeouE5BX4gRL+6m/BsDfbRayOskWqUvh7CLGW+UXxHQItqALa38kKnOiZPqJrtzJUgAC2+F0rL1S4Pg==}
+
+  fsevents@2.3.2:
+    resolution: {integrity: sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==}
+    engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
+    os: [darwin]
+
+  playwright-core@1.59.1:
+    resolution: {integrity: sha512-HBV/RJg81z5BiiZ9yPzIiClYV/QMsDCKUyogwH9p3MCP6IYjUFu/MActgYAvK0oWyV9NlwM3GLBjADyWgydVyg==}
+    engines: {node: '>=18'}
+    hasBin: true
+
+  playwright@1.59.1:
+    resolution: {integrity: sha512-C8oWjPR3F81yljW9o5OxcWzfh6avkVwDD2VYdwIGqTkl+OGFISgypqzfu7dOe4QNLL2aqcWBmI3PMtLIK233lw==}
+    engines: {node: '>=18'}
+    hasBin: true
+
+  turndown@7.2.4:
+    resolution: {integrity: sha512-I8yFsfRzmzK0WV1pNNOA4A7y4RDfFxPRxb3t+e3ui14qSGOxGtiSP6GjeX+Y6CHb7HYaFj7ECUD7VE5kQMZWGQ==}
+    engines: {node: '>=18', npm: '>=9'}
+
+snapshots:
+
+  '@mixmark-io/domino@2.2.0': {}
+
+  '@types/turndown@5.0.6': {}
+
+  fsevents@2.3.2:
+    optional: true
+
+  playwright-core@1.59.1: {}
+
+  playwright@1.59.1:
+    dependencies:
+      playwright-core: 1.59.1
+    optionalDependencies:
+      fsevents: 2.3.2
+
+  turndown@7.2.4:
+    dependencies:
+      '@mixmark-io/domino': 2.2.0

--- a/extensions/web-fetch/pnpm-lock.yaml
+++ b/extensions/web-fetch/pnpm-lock.yaml
@@ -30,6 +30,9 @@ importers:
       '@types/turndown':
         specifier: ^5.0.5
         version: 5.0.6
+      vitest:
+        specifier: ^3.1.1
+        version: 3.2.4(@types/node@25.5.2)(yaml@2.8.3)
 
 packages:
 
@@ -186,6 +189,162 @@ packages:
   '@borewit/text-codec@0.2.2':
     resolution: {integrity: sha512-DDaRehssg1aNrH4+2hnj1B7vnUGEjU6OIlyRdkMd0aUdIUvKXrJfXsy8LVtXAy7DRvYVluWbMspsRhz2lcW0mQ==}
 
+  '@esbuild/aix-ppc64@0.27.7':
+    resolution: {integrity: sha512-EKX3Qwmhz1eMdEJokhALr0YiD0lhQNwDqkPYyPhiSwKrh7/4KRjQc04sZ8db+5DVVnZ1LmbNDI1uAMPEUBnQPg==}
+    engines: {node: '>=18'}
+    cpu: [ppc64]
+    os: [aix]
+
+  '@esbuild/android-arm64@0.27.7':
+    resolution: {integrity: sha512-62dPZHpIXzvChfvfLJow3q5dDtiNMkwiRzPylSCfriLvZeq0a1bWChrGx/BbUbPwOrsWKMn8idSllklzBy+dgQ==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [android]
+
+  '@esbuild/android-arm@0.27.7':
+    resolution: {integrity: sha512-jbPXvB4Yj2yBV7HUfE2KHe4GJX51QplCN1pGbYjvsyCZbQmies29EoJbkEc+vYuU5o45AfQn37vZlyXy4YJ8RQ==}
+    engines: {node: '>=18'}
+    cpu: [arm]
+    os: [android]
+
+  '@esbuild/android-x64@0.27.7':
+    resolution: {integrity: sha512-x5VpMODneVDb70PYV2VQOmIUUiBtY3D3mPBG8NxVk5CogneYhkR7MmM3yR/uMdITLrC1ml/NV1rj4bMJuy9MCg==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [android]
+
+  '@esbuild/darwin-arm64@0.27.7':
+    resolution: {integrity: sha512-5lckdqeuBPlKUwvoCXIgI2D9/ABmPq3Rdp7IfL70393YgaASt7tbju3Ac+ePVi3KDH6N2RqePfHnXkaDtY9fkw==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@esbuild/darwin-x64@0.27.7':
+    resolution: {integrity: sha512-rYnXrKcXuT7Z+WL5K980jVFdvVKhCHhUwid+dDYQpH+qu+TefcomiMAJpIiC2EM3Rjtq0sO3StMV/+3w3MyyqQ==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@esbuild/freebsd-arm64@0.27.7':
+    resolution: {integrity: sha512-B48PqeCsEgOtzME2GbNM2roU29AMTuOIN91dsMO30t+Ydis3z/3Ngoj5hhnsOSSwNzS+6JppqWsuhTp6E82l2w==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [freebsd]
+
+  '@esbuild/freebsd-x64@0.27.7':
+    resolution: {integrity: sha512-jOBDK5XEjA4m5IJK3bpAQF9/Lelu/Z9ZcdhTRLf4cajlB+8VEhFFRjWgfy3M1O4rO2GQ/b2dLwCUGpiF/eATNQ==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@esbuild/linux-arm64@0.27.7':
+    resolution: {integrity: sha512-RZPHBoxXuNnPQO9rvjh5jdkRmVizktkT7TCDkDmQ0W2SwHInKCAV95GRuvdSvA7w4VMwfCjUiPwDi0ZO6Nfe9A==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [linux]
+
+  '@esbuild/linux-arm@0.27.7':
+    resolution: {integrity: sha512-RkT/YXYBTSULo3+af8Ib0ykH8u2MBh57o7q/DAs3lTJlyVQkgQvlrPTnjIzzRPQyavxtPtfg0EopvDyIt0j1rA==}
+    engines: {node: '>=18'}
+    cpu: [arm]
+    os: [linux]
+
+  '@esbuild/linux-ia32@0.27.7':
+    resolution: {integrity: sha512-GA48aKNkyQDbd3KtkplYWT102C5sn/EZTY4XROkxONgruHPU72l+gW+FfF8tf2cFjeHaRbWpOYa/uRBz/Xq1Pg==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [linux]
+
+  '@esbuild/linux-loong64@0.27.7':
+    resolution: {integrity: sha512-a4POruNM2oWsD4WKvBSEKGIiWQF8fZOAsycHOt6JBpZ+JN2n2JH9WAv56SOyu9X5IqAjqSIPTaJkqN8F7XOQ5Q==}
+    engines: {node: '>=18'}
+    cpu: [loong64]
+    os: [linux]
+
+  '@esbuild/linux-mips64el@0.27.7':
+    resolution: {integrity: sha512-KabT5I6StirGfIz0FMgl1I+R1H73Gp0ofL9A3nG3i/cYFJzKHhouBV5VWK1CSgKvVaG4q1RNpCTR2LuTVB3fIw==}
+    engines: {node: '>=18'}
+    cpu: [mips64el]
+    os: [linux]
+
+  '@esbuild/linux-ppc64@0.27.7':
+    resolution: {integrity: sha512-gRsL4x6wsGHGRqhtI+ifpN/vpOFTQtnbsupUF5R5YTAg+y/lKelYR1hXbnBdzDjGbMYjVJLJTd2OFmMewAgwlQ==}
+    engines: {node: '>=18'}
+    cpu: [ppc64]
+    os: [linux]
+
+  '@esbuild/linux-riscv64@0.27.7':
+    resolution: {integrity: sha512-hL25LbxO1QOngGzu2U5xeXtxXcW+/GvMN3ejANqXkxZ/opySAZMrc+9LY/WyjAan41unrR3YrmtTsUpwT66InQ==}
+    engines: {node: '>=18'}
+    cpu: [riscv64]
+    os: [linux]
+
+  '@esbuild/linux-s390x@0.27.7':
+    resolution: {integrity: sha512-2k8go8Ycu1Kb46vEelhu1vqEP+UeRVj2zY1pSuPdgvbd5ykAw82Lrro28vXUrRmzEsUV0NzCf54yARIK8r0fdw==}
+    engines: {node: '>=18'}
+    cpu: [s390x]
+    os: [linux]
+
+  '@esbuild/linux-x64@0.27.7':
+    resolution: {integrity: sha512-hzznmADPt+OmsYzw1EE33ccA+HPdIqiCRq7cQeL1Jlq2gb1+OyWBkMCrYGBJ+sxVzve2ZJEVeePbLM2iEIZSxA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [linux]
+
+  '@esbuild/netbsd-arm64@0.27.7':
+    resolution: {integrity: sha512-b6pqtrQdigZBwZxAn1UpazEisvwaIDvdbMbmrly7cDTMFnw/+3lVxxCTGOrkPVnsYIosJJXAsILG9XcQS+Yu6w==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [netbsd]
+
+  '@esbuild/netbsd-x64@0.27.7':
+    resolution: {integrity: sha512-OfatkLojr6U+WN5EDYuoQhtM+1xco+/6FSzJJnuWiUw5eVcicbyK3dq5EeV/QHT1uy6GoDhGbFpprUiHUYggrw==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [netbsd]
+
+  '@esbuild/openbsd-arm64@0.27.7':
+    resolution: {integrity: sha512-AFuojMQTxAz75Fo8idVcqoQWEHIXFRbOc1TrVcFSgCZtQfSdc1RXgB3tjOn/krRHENUB4j00bfGjyl2mJrU37A==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [openbsd]
+
+  '@esbuild/openbsd-x64@0.27.7':
+    resolution: {integrity: sha512-+A1NJmfM8WNDv5CLVQYJ5PshuRm/4cI6WMZRg1by1GwPIQPCTs1GLEUHwiiQGT5zDdyLiRM/l1G0Pv54gvtKIg==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [openbsd]
+
+  '@esbuild/openharmony-arm64@0.27.7':
+    resolution: {integrity: sha512-+KrvYb/C8zA9CU/g0sR6w2RBw7IGc5J2BPnc3dYc5VJxHCSF1yNMxTV5LQ7GuKteQXZtspjFbiuW5/dOj7H4Yw==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [openharmony]
+
+  '@esbuild/sunos-x64@0.27.7':
+    resolution: {integrity: sha512-ikktIhFBzQNt/QDyOL580ti9+5mL/YZeUPKU2ivGtGjdTYoqz6jObj6nOMfhASpS4GU4Q/Clh1QtxWAvcYKamA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [sunos]
+
+  '@esbuild/win32-arm64@0.27.7':
+    resolution: {integrity: sha512-7yRhbHvPqSpRUV7Q20VuDwbjW5kIMwTHpptuUzV+AA46kiPze5Z7qgt6CLCK3pWFrHeNfDd1VKgyP4O+ng17CA==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [win32]
+
+  '@esbuild/win32-ia32@0.27.7':
+    resolution: {integrity: sha512-SmwKXe6VHIyZYbBLJrhOoCJRB/Z1tckzmgTLfFYOfpMAx63BJEaL9ExI8x7v0oAO3Zh6D/Oi1gVxEYr5oUCFhw==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [win32]
+
+  '@esbuild/win32-x64@0.27.7':
+    resolution: {integrity: sha512-56hiAJPhwQ1R4i+21FVF7V8kSD5zZTdHcVuRFMW0hn753vVfQN8xlx4uOPT4xoGH0Z/oVATuR82AiqSTDIpaHg==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [win32]
+
   '@google/genai@1.49.0':
     resolution: {integrity: sha512-hO69Zl0H3x+L0KL4stl1pLYgnqnwHoLqtKy6MRlNnW8TAxjqMdOUVafomKd4z1BePkzoxJWbYILny9a2Zk43VQ==}
     engines: {node: '>=20.0.0'}
@@ -194,6 +353,9 @@ packages:
     peerDependenciesMeta:
       '@modelcontextprotocol/sdk':
         optional: true
+
+  '@jridgewell/sourcemap-codec@1.5.5':
+    resolution: {integrity: sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==}
 
   '@mariozechner/clipboard-darwin-arm64@0.3.2':
     resolution: {integrity: sha512-uBf6K7Je1ihsgvmWxA8UCGCeI+nbRVRXoarZdLjl6slz94Zs1tNKFZqx7aCI5O1i3e0B6ja82zZ06BWrl0MCVw==}
@@ -315,6 +477,131 @@ packages:
 
   '@protobufjs/utf8@1.1.0':
     resolution: {integrity: sha512-Vvn3zZrhQZkkBE8LSuW3em98c0FwgO4nxzv6OdSxPKJIEKY2bGbHn+mhGIPerzI4twdxaP8/0+06HBpwf345Lw==}
+
+  '@rollup/rollup-android-arm-eabi@4.60.1':
+    resolution: {integrity: sha512-d6FinEBLdIiK+1uACUttJKfgZREXrF0Qc2SmLII7W2AD8FfiZ9Wjd+rD/iRuf5s5dWrr1GgwXCvPqOuDquOowA==}
+    cpu: [arm]
+    os: [android]
+
+  '@rollup/rollup-android-arm64@4.60.1':
+    resolution: {integrity: sha512-YjG/EwIDvvYI1YvYbHvDz/BYHtkY4ygUIXHnTdLhG+hKIQFBiosfWiACWortsKPKU/+dUwQQCKQM3qrDe8c9BA==}
+    cpu: [arm64]
+    os: [android]
+
+  '@rollup/rollup-darwin-arm64@4.60.1':
+    resolution: {integrity: sha512-mjCpF7GmkRtSJwon+Rq1N8+pI+8l7w5g9Z3vWj4T7abguC4Czwi3Yu/pFaLvA3TTeMVjnu3ctigusqWUfjZzvw==}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@rollup/rollup-darwin-x64@4.60.1':
+    resolution: {integrity: sha512-haZ7hJ1JT4e9hqkoT9R/19XW2QKqjfJVv+i5AGg57S+nLk9lQnJ1F/eZloRO3o9Scy9CM3wQ9l+dkXtcBgN5Ew==}
+    cpu: [x64]
+    os: [darwin]
+
+  '@rollup/rollup-freebsd-arm64@4.60.1':
+    resolution: {integrity: sha512-czw90wpQq3ZsAVBlinZjAYTKduOjTywlG7fEeWKUA7oCmpA8xdTkxZZlwNJKWqILlq0wehoZcJYfBvOyhPTQ6w==}
+    cpu: [arm64]
+    os: [freebsd]
+
+  '@rollup/rollup-freebsd-x64@4.60.1':
+    resolution: {integrity: sha512-KVB2rqsxTHuBtfOeySEyzEOB7ltlB/ux38iu2rBQzkjbwRVlkhAGIEDiiYnO2kFOkJp+Z7pUXKyrRRFuFUKt+g==}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@rollup/rollup-linux-arm-gnueabihf@4.60.1':
+    resolution: {integrity: sha512-L+34Qqil+v5uC0zEubW7uByo78WOCIrBvci69E7sFASRl0X7b/MB6Cqd1lky/CtcSVTydWa2WZwFuWexjS5o6g==}
+    cpu: [arm]
+    os: [linux]
+
+  '@rollup/rollup-linux-arm-musleabihf@4.60.1':
+    resolution: {integrity: sha512-n83O8rt4v34hgFzlkb1ycniJh7IR5RCIqt6mz1VRJD6pmhRi0CXdmfnLu9dIUS6buzh60IvACM842Ffb3xd6Gg==}
+    cpu: [arm]
+    os: [linux]
+
+  '@rollup/rollup-linux-arm64-gnu@4.60.1':
+    resolution: {integrity: sha512-Nql7sTeAzhTAja3QXeAI48+/+GjBJ+QmAH13snn0AJSNL50JsDqotyudHyMbO2RbJkskbMbFJfIJKWA6R1LCJQ==}
+    cpu: [arm64]
+    os: [linux]
+
+  '@rollup/rollup-linux-arm64-musl@4.60.1':
+    resolution: {integrity: sha512-+pUymDhd0ys9GcKZPPWlFiZ67sTWV5UU6zOJat02M1+PiuSGDziyRuI/pPue3hoUwm2uGfxdL+trT6Z9rxnlMA==}
+    cpu: [arm64]
+    os: [linux]
+
+  '@rollup/rollup-linux-loong64-gnu@4.60.1':
+    resolution: {integrity: sha512-VSvgvQeIcsEvY4bKDHEDWcpW4Yw7BtlKG1GUT4FzBUlEKQK0rWHYBqQt6Fm2taXS+1bXvJT6kICu5ZwqKCnvlQ==}
+    cpu: [loong64]
+    os: [linux]
+
+  '@rollup/rollup-linux-loong64-musl@4.60.1':
+    resolution: {integrity: sha512-4LqhUomJqwe641gsPp6xLfhqWMbQV04KtPp7/dIp0nzPxAkNY1AbwL5W0MQpcalLYk07vaW9Kp1PBhdpZYYcEw==}
+    cpu: [loong64]
+    os: [linux]
+
+  '@rollup/rollup-linux-ppc64-gnu@4.60.1':
+    resolution: {integrity: sha512-tLQQ9aPvkBxOc/EUT6j3pyeMD6Hb8QF2BTBnCQWP/uu1lhc9AIrIjKnLYMEroIz/JvtGYgI9dF3AxHZNaEH0rw==}
+    cpu: [ppc64]
+    os: [linux]
+
+  '@rollup/rollup-linux-ppc64-musl@4.60.1':
+    resolution: {integrity: sha512-RMxFhJwc9fSXP6PqmAz4cbv3kAyvD1etJFjTx4ONqFP9DkTkXsAMU4v3Vyc5BgzC+anz7nS/9tp4obsKfqkDHg==}
+    cpu: [ppc64]
+    os: [linux]
+
+  '@rollup/rollup-linux-riscv64-gnu@4.60.1':
+    resolution: {integrity: sha512-QKgFl+Yc1eEk6MmOBfRHYF6lTxiiiV3/z/BRrbSiW2I7AFTXoBFvdMEyglohPj//2mZS4hDOqeB0H1ACh3sBbg==}
+    cpu: [riscv64]
+    os: [linux]
+
+  '@rollup/rollup-linux-riscv64-musl@4.60.1':
+    resolution: {integrity: sha512-RAjXjP/8c6ZtzatZcA1RaQr6O1TRhzC+adn8YZDnChliZHviqIjmvFwHcxi4JKPSDAt6Uhf/7vqcBzQJy0PDJg==}
+    cpu: [riscv64]
+    os: [linux]
+
+  '@rollup/rollup-linux-s390x-gnu@4.60.1':
+    resolution: {integrity: sha512-wcuocpaOlaL1COBYiA89O6yfjlp3RwKDeTIA0hM7OpmhR1Bjo9j31G1uQVpDlTvwxGn2nQs65fBFL5UFd76FcQ==}
+    cpu: [s390x]
+    os: [linux]
+
+  '@rollup/rollup-linux-x64-gnu@4.60.1':
+    resolution: {integrity: sha512-77PpsFQUCOiZR9+LQEFg9GClyfkNXj1MP6wRnzYs0EeWbPcHs02AXu4xuUbM1zhwn3wqaizle3AEYg5aeoohhg==}
+    cpu: [x64]
+    os: [linux]
+
+  '@rollup/rollup-linux-x64-musl@4.60.1':
+    resolution: {integrity: sha512-5cIATbk5vynAjqqmyBjlciMJl1+R/CwX9oLk/EyiFXDWd95KpHdrOJT//rnUl4cUcskrd0jCCw3wpZnhIHdD9w==}
+    cpu: [x64]
+    os: [linux]
+
+  '@rollup/rollup-openbsd-x64@4.60.1':
+    resolution: {integrity: sha512-cl0w09WsCi17mcmWqqglez9Gk8isgeWvoUZ3WiJFYSR3zjBQc2J5/ihSjpl+VLjPqjQ/1hJRcqBfLjssREQILw==}
+    cpu: [x64]
+    os: [openbsd]
+
+  '@rollup/rollup-openharmony-arm64@4.60.1':
+    resolution: {integrity: sha512-4Cv23ZrONRbNtbZa37mLSueXUCtN7MXccChtKpUnQNgF010rjrjfHx3QxkS2PI7LqGT5xXyYs1a7LbzAwT0iCA==}
+    cpu: [arm64]
+    os: [openharmony]
+
+  '@rollup/rollup-win32-arm64-msvc@4.60.1':
+    resolution: {integrity: sha512-i1okWYkA4FJICtr7KpYzFpRTHgy5jdDbZiWfvny21iIKky5YExiDXP+zbXzm3dUcFpkEeYNHgQ5fuG236JPq0g==}
+    cpu: [arm64]
+    os: [win32]
+
+  '@rollup/rollup-win32-ia32-msvc@4.60.1':
+    resolution: {integrity: sha512-u09m3CuwLzShA0EYKMNiFgcjjzwqtUMLmuCJLeZWjjOYA3IT2Di09KaxGBTP9xVztWyIWjVdsB2E9goMjZvTQg==}
+    cpu: [ia32]
+    os: [win32]
+
+  '@rollup/rollup-win32-x64-gnu@4.60.1':
+    resolution: {integrity: sha512-k+600V9Zl1CM7eZxJgMyTUzmrmhB/0XZnF4pRypKAlAgxmedUA+1v9R+XOFv56W4SlHEzfeMtzujLJD22Uz5zg==}
+    cpu: [x64]
+    os: [win32]
+
+  '@rollup/rollup-win32-x64-msvc@4.60.1':
+    resolution: {integrity: sha512-lWMnixq/QzxyhTV6NjQJ4SFo1J6PvOX8vUx5Wb4bBPsEb+8xZ89Bz6kOXpfXj9ak9AHTQVQzlgzBEc1SyM27xQ==}
+    cpu: [x64]
+    os: [win32]
 
   '@silvia-odwyer/photon-node@0.3.4':
     resolution: {integrity: sha512-bnly4BKB3KDTFxrUIcgCLbaeVVS8lrAkri1pEzskpmxu9MdfGQTy8b8EgcD83ywD3RPMsIulY8xJH5Awa+t9fA==}
@@ -520,6 +807,15 @@ packages:
   '@tootallnate/quickjs-emscripten@0.23.0':
     resolution: {integrity: sha512-C5Mc6rdnsaJDjO3UpGW/CQTHtCKaYlScZTly4JIu97Jxo/odCiH0ITnDXSJPTOrEKk/ycSZ0AOgTmkDtkOsvIA==}
 
+  '@types/chai@5.2.3':
+    resolution: {integrity: sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==}
+
+  '@types/deep-eql@4.0.2':
+    resolution: {integrity: sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==}
+
+  '@types/estree@1.0.8':
+    resolution: {integrity: sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==}
+
   '@types/mime-types@2.1.4':
     resolution: {integrity: sha512-lfU4b34HOri+kAY5UheuFMWPDOI+OPceBSHZKp69gEyTL/mmJ4cnU6Y/rlme3UL3GyOn6Y42hyIEw0/q8sWx5w==}
 
@@ -534,6 +830,35 @@ packages:
 
   '@types/yauzl@2.10.3':
     resolution: {integrity: sha512-oJoftv0LSuaDZE3Le4DbKX+KS9G36NzOeSap90UIK0yMA/NhKJhqlSGtNDORNRaIbQfzjXDrQa0ytJ6mNRGz/Q==}
+
+  '@vitest/expect@3.2.4':
+    resolution: {integrity: sha512-Io0yyORnB6sikFlt8QW5K7slY4OjqNX9jmJQ02QDda8lyM6B5oNgVWoSoKPac8/kgnCUzuHQKrSLtu/uOqqrig==}
+
+  '@vitest/mocker@3.2.4':
+    resolution: {integrity: sha512-46ryTE9RZO/rfDd7pEqFl7etuyzekzEhUbTW3BvmeO/BcCMEgq59BKhek3dXDWgAj4oMK6OZi+vRr1wPW6qjEQ==}
+    peerDependencies:
+      msw: ^2.4.9
+      vite: ^5.0.0 || ^6.0.0 || ^7.0.0-0
+    peerDependenciesMeta:
+      msw:
+        optional: true
+      vite:
+        optional: true
+
+  '@vitest/pretty-format@3.2.4':
+    resolution: {integrity: sha512-IVNZik8IVRJRTr9fxlitMKeJeXFFFN0JaB9PHPGQ8NKQbGpfjlTx9zO4RefN8gp7eqjNy8nyK3NZmBzOPeIxtA==}
+
+  '@vitest/runner@3.2.4':
+    resolution: {integrity: sha512-oukfKT9Mk41LreEW09vt45f8wx7DordoWUZMYdY/cyAk7w5TWkTRCNZYF7sX7n2wB7jyGAl74OxgwhPgKaqDMQ==}
+
+  '@vitest/snapshot@3.2.4':
+    resolution: {integrity: sha512-dEYtS7qQP2CjU27QBC5oUOxLE/v5eLkGqPE0ZKEIDGMs4vKWe7IjgLOeauHsR0D5YuuycGRO5oSRXnwnmA78fQ==}
+
+  '@vitest/spy@3.2.4':
+    resolution: {integrity: sha512-vAfasCOe6AIK70iP5UD11Ac4siNUNJ9i/9PZ3NKx07sG6sUxeag1LWdNrMWeKKYBLlzuK+Gn65Yd5nyL6ds+nw==}
+
+  '@vitest/utils@3.2.4':
+    resolution: {integrity: sha512-fB2V0JFrQSMsCo9HiSq3Ezpdv4iYaXRG1Sx8edX3MwxfyNn83mKiGzOcH+Fkxt4MHxr3y42fQi1oeAInqgX2QA==}
 
   agent-base@7.1.4:
     resolution: {integrity: sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==}
@@ -564,6 +889,10 @@ packages:
 
   any-promise@1.3.0:
     resolution: {integrity: sha512-7UvmKalWRt1wgjL1RrGxoSJW/0QZFIegpeGvZG9kjp8vrRu55XTHbwnqq2GpXm9uLbcuhxm3IqX9OB4MZR1b2A==}
+
+  assertion-error@2.0.1:
+    resolution: {integrity: sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==}
+    engines: {node: '>=12'}
 
   ast-types@0.13.4:
     resolution: {integrity: sha512-x1FCFnFifvYDDzTaLII71vG5uvDwgtmDTEVWAxrgeiR8VjMONcCXJx7E+USjDtHlwFmt9MysbqgF9b9Vjr6w+w==}
@@ -596,6 +925,14 @@ packages:
   buffer-equal-constant-time@1.0.1:
     resolution: {integrity: sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA==}
 
+  cac@6.7.14:
+    resolution: {integrity: sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==}
+    engines: {node: '>=8'}
+
+  chai@5.3.3:
+    resolution: {integrity: sha512-4zNhdJD/iOjSH0A05ea+Ke6MU5mmpQcbQsSOkgdaUMJ9zTlDTD/GYlwohmIE2u0gaxHYiVHEn1Fw9mZ/ktJWgw==}
+    engines: {node: '>=18'}
+
   chalk@4.1.2:
     resolution: {integrity: sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==}
     engines: {node: '>=10'}
@@ -603,6 +940,10 @@ packages:
   chalk@5.6.2:
     resolution: {integrity: sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA==}
     engines: {node: ^12.17.0 || ^14.13 || >=16.0.0}
+
+  check-error@2.1.3:
+    resolution: {integrity: sha512-PAJdDJusoxnwm1VwW07VWwUN1sl7smmC3OKggvndJFadxxDRyFJBX/ggnu/KE4kQAB7a3Dp8f/YXC1FlUprWmA==}
+    engines: {node: '>= 16'}
 
   cli-highlight@2.1.11:
     resolution: {integrity: sha512-9KDcoEVwyUXrjcJNvHD0NFc/hiwe/WPVYIleQh2O1N2Zro5gWJZ/K+3DGn8w8P/F6FxOgzyC5bxDyHIgCSPhGg==}
@@ -636,6 +977,10 @@ packages:
       supports-color:
         optional: true
 
+  deep-eql@5.0.2:
+    resolution: {integrity: sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==}
+    engines: {node: '>=6'}
+
   degenerator@5.0.1:
     resolution: {integrity: sha512-TllpMR/t0M5sqCXfj85i4XaAzxmS5tVA16dqvdkMwGmzI+dXLXnw3J+3Vdv7VKw+ThlTMboK6i9rnZ6Nntj5CQ==}
     engines: {node: '>= 14'}
@@ -652,6 +997,14 @@ packages:
 
   end-of-stream@1.4.5:
     resolution: {integrity: sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==}
+
+  es-module-lexer@1.7.0:
+    resolution: {integrity: sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==}
+
+  esbuild@0.27.7:
+    resolution: {integrity: sha512-IxpibTjyVnmrIQo5aqNpCgoACA/dTKLTlhMHihVHhdkxKyPO1uBBthumT0rdHmcsk9uMonIWS0m4FljWzILh3w==}
+    engines: {node: '>=18'}
+    hasBin: true
 
   escalade@3.2.0:
     resolution: {integrity: sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==}
@@ -671,9 +1024,16 @@ packages:
     resolution: {integrity: sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==}
     engines: {node: '>=4.0'}
 
+  estree-walker@3.0.3:
+    resolution: {integrity: sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==}
+
   esutils@2.0.3:
     resolution: {integrity: sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==}
     engines: {node: '>=0.10.0'}
+
+  expect-type@1.3.0:
+    resolution: {integrity: sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==}
+    engines: {node: '>=12.0.0'}
 
   extend@3.0.2:
     resolution: {integrity: sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==}
@@ -699,6 +1059,15 @@ packages:
   fd-slicer@1.1.0:
     resolution: {integrity: sha512-cE1qsB/VwyQozZ+q1dGxR8LBYNZeofhEdUNGSMbQD3Gw2lAzX9Zb3uIU6Ebc/Fmyjo9AWWfnn0AUCHqtevs/8g==}
 
+  fdir@6.5.0:
+    resolution: {integrity: sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==}
+    engines: {node: '>=12.0.0'}
+    peerDependencies:
+      picomatch: ^3 || ^4
+    peerDependenciesMeta:
+      picomatch:
+        optional: true
+
   fetch-blob@3.2.0:
     resolution: {integrity: sha512-7yAQpD2UMJzLi1Dqv7qFYnPbaPx7ZfFK6PiIxQ4PfkGPyNyl2Ugx+a/umUonmKqjhM4DnfbMvdX6otXq83soQQ==}
     engines: {node: ^12.20 || >= 14.13}
@@ -713,6 +1082,11 @@ packages:
 
   fsevents@2.3.2:
     resolution: {integrity: sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==}
+    engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
+    os: [darwin]
+
+  fsevents@2.3.3:
+    resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
     engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
     os: [darwin]
 
@@ -789,6 +1163,9 @@ packages:
     resolution: {integrity: sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==}
     engines: {node: '>=8'}
 
+  js-tokens@9.0.1:
+    resolution: {integrity: sha512-mxa9E9ITFOt0ban3j6L5MpjwegGz6lBQmM1IJkWeBZGcMxto50+eWdjC/52xDbS2vy0k7vIMK0Fe2wfL9OQSpQ==}
+
   json-bigint@1.0.0:
     resolution: {integrity: sha512-SiPv/8VpZuWbvLSMtTDU8hEfrZWg/mH/nV/b4o0CYbSxu1UIQPLdwKOCIyLQX+VIPO5vrLX3i8qtqFyhdPSUSQ==}
 
@@ -811,6 +1188,9 @@ packages:
   long@5.3.2:
     resolution: {integrity: sha512-mNAgZ1GmyNhD7AuqnTG3/VQ26o760+ZYBPKjPvugO8+nLbYfX6TVpJPseBvopbdY+qpZ/lKUnmEc1LeZYS3QAA==}
 
+  loupe@3.2.1:
+    resolution: {integrity: sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ==}
+
   lru-cache@11.3.3:
     resolution: {integrity: sha512-JvNw9Y81y33E+BEYPr0U7omo+U9AySnsMsEiXgwT6yqd31VQWTLNQqmT4ou5eqPFUrTfIDFta2wKhB1hyohtAQ==}
     engines: {node: 20 || >=22}
@@ -818,6 +1198,9 @@ packages:
   lru-cache@7.18.3:
     resolution: {integrity: sha512-jumlc0BIUrS3qJGgIkWZsyfAM7NCWiBcCDhnd+3NNM5KbBmLTgHVfWBcg6W+rLUsIpzpERPsvwUP7CckAQSOoA==}
     engines: {node: '>=12'}
+
+  magic-string@0.30.21:
+    resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
 
   marked@15.0.12:
     resolution: {integrity: sha512-8dD6FusOQSrpv9Z1rdNMdlSgQOIP880DHqnohobOmYLElGEqAL/JvxvuxZO16r4HtjTlfPRDC1hbvxC9dPN2nA==}
@@ -845,6 +1228,11 @@ packages:
 
   mz@2.7.0:
     resolution: {integrity: sha512-z81GNO7nnYMEhrGh9LeymoE4+Yr0Wn5McHIZMK5cfQCl+NDX08sCZgUc9/6MHni9IWuFLm1Z3HTCXu2z9fN62Q==}
+
+  nanoid@3.3.11:
+    resolution: {integrity: sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==}
+    engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
+    hasBin: true
 
   netmask@2.1.1:
     resolution: {integrity: sha512-eonl3sLUha+S1GzTPxychyhnUzKyeQkZ7jLjKrBagJgPla13F+uQ71HgpFefyHgqrjEbCPkDArxYsjY8/+gLKA==}
@@ -910,8 +1298,22 @@ packages:
     resolution: {integrity: sha512-3O/iVVsJAPsOnpwWIeD+d6z/7PmqApyQePUtCndjatj/9I5LylHvt5qluFaBT3I5h3r1ejfR056c+FCv+NnNXg==}
     engines: {node: 18 || 20 || >=22}
 
+  pathe@2.0.3:
+    resolution: {integrity: sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==}
+
+  pathval@2.0.1:
+    resolution: {integrity: sha512-//nshmD55c46FuFw26xV/xFAaB5HF9Xdap7HJBBnrKdAd6/GxDBaNA1870O79+9ueg61cZLSVc+OaFlfmObYVQ==}
+    engines: {node: '>= 14.16'}
+
   pend@1.2.0:
     resolution: {integrity: sha512-F3asv42UuXchdzt+xXqfW1OGlVBe+mxa2mqI0pg5yAHZPvFmY3Y6drSf/GQ1A86WgWEN9Kzh/WrgKa6iGcHXLg==}
+
+  picocolors@1.1.1:
+    resolution: {integrity: sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==}
+
+  picomatch@4.0.4:
+    resolution: {integrity: sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==}
+    engines: {node: '>=12'}
 
   playwright-core@1.59.1:
     resolution: {integrity: sha512-HBV/RJg81z5BiiZ9yPzIiClYV/QMsDCKUyogwH9p3MCP6IYjUFu/MActgYAvK0oWyV9NlwM3GLBjADyWgydVyg==}
@@ -922,6 +1324,10 @@ packages:
     resolution: {integrity: sha512-C8oWjPR3F81yljW9o5OxcWzfh6avkVwDD2VYdwIGqTkl+OGFISgypqzfu7dOe4QNLL2aqcWBmI3PMtLIK233lw==}
     engines: {node: '>=18'}
     hasBin: true
+
+  postcss@8.5.9:
+    resolution: {integrity: sha512-7a70Nsot+EMX9fFU3064K/kdHWZqGVY+BADLyXc8Dfv+mTLLVl6JzJpPaCZ2kQL9gIJvKXSLMHhqdRRjwQeFtw==}
+    engines: {node: ^10 || ^12 || >=14}
 
   proper-lockfile@4.1.2:
     resolution: {integrity: sha512-TjNPblN4BwAWMXU8s9AEz4JmQxnD1NNL7bNOY/AKUzyamc379FWASUhc/K1pL2noVb+XmZKLL68cjzLsiOAMaA==}
@@ -956,8 +1362,16 @@ packages:
     resolution: {integrity: sha512-XQBQ3I8W1Cge0Seh+6gjj03LbmRFWuoszgK9ooCpwYIrhhoO80pfq4cUkU5DkknwfOfFteRwlZ56PYOGYyFWdg==}
     engines: {node: '>= 4'}
 
+  rollup@4.60.1:
+    resolution: {integrity: sha512-VmtB2rFU/GroZ4oL8+ZqXgSA38O6GR8KSIvWmEFv63pQ0G6KaBH9s07PO8XTXP4vI+3UJUEypOfjkGfmSBBR0w==}
+    engines: {node: '>=18.0.0', npm: '>=8.0.0'}
+    hasBin: true
+
   safe-buffer@5.2.1:
     resolution: {integrity: sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==}
+
+  siginfo@2.0.0:
+    resolution: {integrity: sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==}
 
   signal-exit@3.0.7:
     resolution: {integrity: sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==}
@@ -974,9 +1388,16 @@ packages:
     resolution: {integrity: sha512-HLpt+uLy/pxB+bum/9DzAgiKS8CX1EvbWxI4zlmgGCExImLdiad2iCwXT5Z4c9c3Eq8rP2318mPW2c+QbtjK8A==}
     engines: {node: '>= 10.0.0', npm: '>= 3.0.0'}
 
+  source-map-js@1.2.1:
+    resolution: {integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==}
+    engines: {node: '>=0.10.0'}
+
   source-map@0.6.1:
     resolution: {integrity: sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==}
     engines: {node: '>=0.10.0'}
+
+  stackback@0.0.2:
+    resolution: {integrity: sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==}
 
   std-env@3.10.0:
     resolution: {integrity: sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==}
@@ -992,6 +1413,9 @@ packages:
   strip-ansi@7.2.0:
     resolution: {integrity: sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==}
     engines: {node: '>=12'}
+
+  strip-literal@3.1.0:
+    resolution: {integrity: sha512-8r3mkIM/2+PpjHoOtiAW8Rg3jJLHaV7xPwG+YRGrv6FP0wwk/toTpATxWYOW0BKdWwl82VT2tFYi5DlROa0Mxg==}
 
   strnum@2.2.3:
     resolution: {integrity: sha512-oKx6RUCuHfT3oyVjtnrmn19H1SiCqgJSg+54XqURKp5aCMbrXrhLjRN9TjuwMjiYstZ0MzDrHqkGZ5dFTKd+zg==}
@@ -1010,6 +1434,28 @@ packages:
 
   thenify@3.3.1:
     resolution: {integrity: sha512-RVZSIV5IG10Hk3enotrhvz0T9em6cyHBLkH/YAZuKqd8hRkKhSfCGIcP2KUY0EPxndzANBmNllzWPwak+bheSw==}
+
+  tinybench@2.9.0:
+    resolution: {integrity: sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==}
+
+  tinyexec@0.3.2:
+    resolution: {integrity: sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==}
+
+  tinyglobby@0.2.16:
+    resolution: {integrity: sha512-pn99VhoACYR8nFHhxqix+uvsbXineAasWm5ojXoN8xEwK5Kd3/TrhNn1wByuD52UxWRLy8pu+kRMniEi6Eq9Zg==}
+    engines: {node: '>=12.0.0'}
+
+  tinypool@1.1.1:
+    resolution: {integrity: sha512-Zba82s87IFq9A9XmjiX5uZA/ARWDrB03OHlq+Vw1fSdt0I+4/Kutwy8BP4Y/y/aORMo61FQ0vIb5j44vSo5Pkg==}
+    engines: {node: ^18.0.0 || >=20.0.0}
+
+  tinyrainbow@2.0.0:
+    resolution: {integrity: sha512-op4nsTR47R6p0vMUUoYl/a+ljLFVtlfaXkLQmqfLR1qHma1h/ysYk4hEXZ880bf2CYgTskvTa/e196Vd5dDQXw==}
+    engines: {node: '>=14.0.0'}
+
+  tinyspy@4.0.4:
+    resolution: {integrity: sha512-azl+t0z7pw/z958Gy9svOTuzqIk6xq+NSheJzn5MMWtWTFywIacg2wUlzKFGtt3cthx0r2SxMK0yzJOR0IES7Q==}
+    engines: {node: '>=14.0.0'}
 
   token-types@6.1.2:
     resolution: {integrity: sha512-dRXchy+C0IgK8WPC6xvCHFRIWYUbqqdEIKPaKo/AcTUNzwLTK6AH7RjdLWsEZcAN/TBdtfUw3PYEgPr5VPr6ww==}
@@ -1036,9 +1482,87 @@ packages:
     resolution: {integrity: sha512-H/nlJ/h0ggGC+uRL3ovD+G0i4bqhvsDOpbDv7At5eFLlj2b41L8QliGbnl2H7SnDiYhENphh1tQFJZf+MyfLsQ==}
     engines: {node: '>=20.18.1'}
 
+  vite-node@3.2.4:
+    resolution: {integrity: sha512-EbKSKh+bh1E1IFxeO0pg1n4dvoOTt0UDiXMd/qn++r98+jPO1xtJilvXldeuQ8giIB5IkpjCgMleHMNEsGH6pg==}
+    engines: {node: ^18.0.0 || ^20.0.0 || >=22.0.0}
+    hasBin: true
+
+  vite@7.3.2:
+    resolution: {integrity: sha512-Bby3NOsna2jsjfLVOHKes8sGwgl4TT0E6vvpYgnAYDIF/tie7MRaFthmKuHx1NSXjiTueXH3do80FMQgvEktRg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    hasBin: true
+    peerDependencies:
+      '@types/node': ^20.19.0 || >=22.12.0
+      jiti: '>=1.21.0'
+      less: ^4.0.0
+      lightningcss: ^1.21.0
+      sass: ^1.70.0
+      sass-embedded: ^1.70.0
+      stylus: '>=0.54.8'
+      sugarss: ^5.0.0
+      terser: ^5.16.0
+      tsx: ^4.8.1
+      yaml: ^2.4.2
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+      jiti:
+        optional: true
+      less:
+        optional: true
+      lightningcss:
+        optional: true
+      sass:
+        optional: true
+      sass-embedded:
+        optional: true
+      stylus:
+        optional: true
+      sugarss:
+        optional: true
+      terser:
+        optional: true
+      tsx:
+        optional: true
+      yaml:
+        optional: true
+
+  vitest@3.2.4:
+    resolution: {integrity: sha512-LUCP5ev3GURDysTWiP47wRRUpLKMOfPh+yKTx3kVIEiu5KOMeqzpnYNsKyOoVrULivR8tLcks4+lga33Whn90A==}
+    engines: {node: ^18.0.0 || ^20.0.0 || >=22.0.0}
+    hasBin: true
+    peerDependencies:
+      '@edge-runtime/vm': '*'
+      '@types/debug': ^4.1.12
+      '@types/node': ^18.0.0 || ^20.0.0 || >=22.0.0
+      '@vitest/browser': 3.2.4
+      '@vitest/ui': 3.2.4
+      happy-dom: '*'
+      jsdom: '*'
+    peerDependenciesMeta:
+      '@edge-runtime/vm':
+        optional: true
+      '@types/debug':
+        optional: true
+      '@types/node':
+        optional: true
+      '@vitest/browser':
+        optional: true
+      '@vitest/ui':
+        optional: true
+      happy-dom:
+        optional: true
+      jsdom:
+        optional: true
+
   web-streams-polyfill@3.3.3:
     resolution: {integrity: sha512-d2JWLCivmZYTSIoge9MsgFCZrt571BikcWGYkjC1khllbTeDlGqZ2D8vD8E/lJa8WGWbb7Plm8/XJYV7IJHZZw==}
     engines: {node: '>= 8'}
+
+  why-is-node-running@2.3.0:
+    resolution: {integrity: sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==}
+    engines: {node: '>=8'}
+    hasBin: true
 
   wrap-ansi@7.0.0:
     resolution: {integrity: sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==}
@@ -1491,6 +2015,84 @@ snapshots:
 
   '@borewit/text-codec@0.2.2': {}
 
+  '@esbuild/aix-ppc64@0.27.7':
+    optional: true
+
+  '@esbuild/android-arm64@0.27.7':
+    optional: true
+
+  '@esbuild/android-arm@0.27.7':
+    optional: true
+
+  '@esbuild/android-x64@0.27.7':
+    optional: true
+
+  '@esbuild/darwin-arm64@0.27.7':
+    optional: true
+
+  '@esbuild/darwin-x64@0.27.7':
+    optional: true
+
+  '@esbuild/freebsd-arm64@0.27.7':
+    optional: true
+
+  '@esbuild/freebsd-x64@0.27.7':
+    optional: true
+
+  '@esbuild/linux-arm64@0.27.7':
+    optional: true
+
+  '@esbuild/linux-arm@0.27.7':
+    optional: true
+
+  '@esbuild/linux-ia32@0.27.7':
+    optional: true
+
+  '@esbuild/linux-loong64@0.27.7':
+    optional: true
+
+  '@esbuild/linux-mips64el@0.27.7':
+    optional: true
+
+  '@esbuild/linux-ppc64@0.27.7':
+    optional: true
+
+  '@esbuild/linux-riscv64@0.27.7':
+    optional: true
+
+  '@esbuild/linux-s390x@0.27.7':
+    optional: true
+
+  '@esbuild/linux-x64@0.27.7':
+    optional: true
+
+  '@esbuild/netbsd-arm64@0.27.7':
+    optional: true
+
+  '@esbuild/netbsd-x64@0.27.7':
+    optional: true
+
+  '@esbuild/openbsd-arm64@0.27.7':
+    optional: true
+
+  '@esbuild/openbsd-x64@0.27.7':
+    optional: true
+
+  '@esbuild/openharmony-arm64@0.27.7':
+    optional: true
+
+  '@esbuild/sunos-x64@0.27.7':
+    optional: true
+
+  '@esbuild/win32-arm64@0.27.7':
+    optional: true
+
+  '@esbuild/win32-ia32@0.27.7':
+    optional: true
+
+  '@esbuild/win32-x64@0.27.7':
+    optional: true
+
   '@google/genai@1.49.0':
     dependencies:
       google-auth-library: 10.6.2
@@ -1501,6 +2103,8 @@ snapshots:
       - bufferutil
       - supports-color
       - utf-8-validate
+
+  '@jridgewell/sourcemap-codec@1.5.5': {}
 
   '@mariozechner/clipboard-darwin-arm64@0.3.2':
     optional: true
@@ -1663,6 +2267,81 @@ snapshots:
   '@protobufjs/pool@1.1.0': {}
 
   '@protobufjs/utf8@1.1.0': {}
+
+  '@rollup/rollup-android-arm-eabi@4.60.1':
+    optional: true
+
+  '@rollup/rollup-android-arm64@4.60.1':
+    optional: true
+
+  '@rollup/rollup-darwin-arm64@4.60.1':
+    optional: true
+
+  '@rollup/rollup-darwin-x64@4.60.1':
+    optional: true
+
+  '@rollup/rollup-freebsd-arm64@4.60.1':
+    optional: true
+
+  '@rollup/rollup-freebsd-x64@4.60.1':
+    optional: true
+
+  '@rollup/rollup-linux-arm-gnueabihf@4.60.1':
+    optional: true
+
+  '@rollup/rollup-linux-arm-musleabihf@4.60.1':
+    optional: true
+
+  '@rollup/rollup-linux-arm64-gnu@4.60.1':
+    optional: true
+
+  '@rollup/rollup-linux-arm64-musl@4.60.1':
+    optional: true
+
+  '@rollup/rollup-linux-loong64-gnu@4.60.1':
+    optional: true
+
+  '@rollup/rollup-linux-loong64-musl@4.60.1':
+    optional: true
+
+  '@rollup/rollup-linux-ppc64-gnu@4.60.1':
+    optional: true
+
+  '@rollup/rollup-linux-ppc64-musl@4.60.1':
+    optional: true
+
+  '@rollup/rollup-linux-riscv64-gnu@4.60.1':
+    optional: true
+
+  '@rollup/rollup-linux-riscv64-musl@4.60.1':
+    optional: true
+
+  '@rollup/rollup-linux-s390x-gnu@4.60.1':
+    optional: true
+
+  '@rollup/rollup-linux-x64-gnu@4.60.1':
+    optional: true
+
+  '@rollup/rollup-linux-x64-musl@4.60.1':
+    optional: true
+
+  '@rollup/rollup-openbsd-x64@4.60.1':
+    optional: true
+
+  '@rollup/rollup-openharmony-arm64@4.60.1':
+    optional: true
+
+  '@rollup/rollup-win32-arm64-msvc@4.60.1':
+    optional: true
+
+  '@rollup/rollup-win32-ia32-msvc@4.60.1':
+    optional: true
+
+  '@rollup/rollup-win32-x64-gnu@4.60.1':
+    optional: true
+
+  '@rollup/rollup-win32-x64-msvc@4.60.1':
+    optional: true
 
   '@silvia-odwyer/photon-node@0.3.4': {}
 
@@ -1979,6 +2658,15 @@ snapshots:
 
   '@tootallnate/quickjs-emscripten@0.23.0': {}
 
+  '@types/chai@5.2.3':
+    dependencies:
+      '@types/deep-eql': 4.0.2
+      assertion-error: 2.0.1
+
+  '@types/deep-eql@4.0.2': {}
+
+  '@types/estree@1.0.8': {}
+
   '@types/mime-types@2.1.4': {}
 
   '@types/node@25.5.2':
@@ -1993,6 +2681,48 @@ snapshots:
     dependencies:
       '@types/node': 25.5.2
     optional: true
+
+  '@vitest/expect@3.2.4':
+    dependencies:
+      '@types/chai': 5.2.3
+      '@vitest/spy': 3.2.4
+      '@vitest/utils': 3.2.4
+      chai: 5.3.3
+      tinyrainbow: 2.0.0
+
+  '@vitest/mocker@3.2.4(vite@7.3.2(@types/node@25.5.2)(yaml@2.8.3))':
+    dependencies:
+      '@vitest/spy': 3.2.4
+      estree-walker: 3.0.3
+      magic-string: 0.30.21
+    optionalDependencies:
+      vite: 7.3.2(@types/node@25.5.2)(yaml@2.8.3)
+
+  '@vitest/pretty-format@3.2.4':
+    dependencies:
+      tinyrainbow: 2.0.0
+
+  '@vitest/runner@3.2.4':
+    dependencies:
+      '@vitest/utils': 3.2.4
+      pathe: 2.0.3
+      strip-literal: 3.1.0
+
+  '@vitest/snapshot@3.2.4':
+    dependencies:
+      '@vitest/pretty-format': 3.2.4
+      magic-string: 0.30.21
+      pathe: 2.0.3
+
+  '@vitest/spy@3.2.4':
+    dependencies:
+      tinyspy: 4.0.4
+
+  '@vitest/utils@3.2.4':
+    dependencies:
+      '@vitest/pretty-format': 3.2.4
+      loupe: 3.2.1
+      tinyrainbow: 2.0.0
 
   agent-base@7.1.4: {}
 
@@ -2017,6 +2747,8 @@ snapshots:
 
   any-promise@1.3.0: {}
 
+  assertion-error@2.0.1: {}
+
   ast-types@0.13.4:
     dependencies:
       tslib: 2.8.1
@@ -2039,12 +2771,24 @@ snapshots:
 
   buffer-equal-constant-time@1.0.1: {}
 
+  cac@6.7.14: {}
+
+  chai@5.3.3:
+    dependencies:
+      assertion-error: 2.0.1
+      check-error: 2.1.3
+      deep-eql: 5.0.2
+      loupe: 3.2.1
+      pathval: 2.0.1
+
   chalk@4.1.2:
     dependencies:
       ansi-styles: 4.3.0
       supports-color: 7.2.0
 
   chalk@5.6.2: {}
+
+  check-error@2.1.3: {}
 
   cli-highlight@2.1.11:
     dependencies:
@@ -2075,6 +2819,8 @@ snapshots:
     dependencies:
       ms: 2.1.3
 
+  deep-eql@5.0.2: {}
+
   degenerator@5.0.1:
     dependencies:
       ast-types: 0.13.4
@@ -2093,6 +2839,37 @@ snapshots:
     dependencies:
       once: 1.4.0
 
+  es-module-lexer@1.7.0: {}
+
+  esbuild@0.27.7:
+    optionalDependencies:
+      '@esbuild/aix-ppc64': 0.27.7
+      '@esbuild/android-arm': 0.27.7
+      '@esbuild/android-arm64': 0.27.7
+      '@esbuild/android-x64': 0.27.7
+      '@esbuild/darwin-arm64': 0.27.7
+      '@esbuild/darwin-x64': 0.27.7
+      '@esbuild/freebsd-arm64': 0.27.7
+      '@esbuild/freebsd-x64': 0.27.7
+      '@esbuild/linux-arm': 0.27.7
+      '@esbuild/linux-arm64': 0.27.7
+      '@esbuild/linux-ia32': 0.27.7
+      '@esbuild/linux-loong64': 0.27.7
+      '@esbuild/linux-mips64el': 0.27.7
+      '@esbuild/linux-ppc64': 0.27.7
+      '@esbuild/linux-riscv64': 0.27.7
+      '@esbuild/linux-s390x': 0.27.7
+      '@esbuild/linux-x64': 0.27.7
+      '@esbuild/netbsd-arm64': 0.27.7
+      '@esbuild/netbsd-x64': 0.27.7
+      '@esbuild/openbsd-arm64': 0.27.7
+      '@esbuild/openbsd-x64': 0.27.7
+      '@esbuild/openharmony-arm64': 0.27.7
+      '@esbuild/sunos-x64': 0.27.7
+      '@esbuild/win32-arm64': 0.27.7
+      '@esbuild/win32-ia32': 0.27.7
+      '@esbuild/win32-x64': 0.27.7
+
   escalade@3.2.0: {}
 
   escodegen@2.1.0:
@@ -2107,7 +2884,13 @@ snapshots:
 
   estraverse@5.3.0: {}
 
+  estree-walker@3.0.3:
+    dependencies:
+      '@types/estree': 1.0.8
+
   esutils@2.0.3: {}
+
+  expect-type@1.3.0: {}
 
   extend@3.0.2: {}
 
@@ -2139,6 +2922,10 @@ snapshots:
     dependencies:
       pend: 1.2.0
 
+  fdir@6.5.0(picomatch@4.0.4):
+    optionalDependencies:
+      picomatch: 4.0.4
+
   fetch-blob@3.2.0:
     dependencies:
       node-domexception: 1.0.0
@@ -2158,6 +2945,9 @@ snapshots:
       fetch-blob: 3.2.0
 
   fsevents@2.3.2:
+    optional: true
+
+  fsevents@2.3.3:
     optional: true
 
   gaxios@7.1.4:
@@ -2243,6 +3033,8 @@ snapshots:
 
   is-fullwidth-code-point@3.0.0: {}
 
+  js-tokens@9.0.1: {}
+
   json-bigint@1.0.0:
     dependencies:
       bignumber.js: 9.3.1
@@ -2270,9 +3062,15 @@ snapshots:
 
   long@5.3.2: {}
 
+  loupe@3.2.1: {}
+
   lru-cache@11.3.3: {}
 
   lru-cache@7.18.3: {}
+
+  magic-string@0.30.21:
+    dependencies:
+      '@jridgewell/sourcemap-codec': 1.5.5
 
   marked@15.0.12: {}
 
@@ -2295,6 +3093,8 @@ snapshots:
       any-promise: 1.3.0
       object-assign: 4.1.1
       thenify-all: 1.6.0
+
+  nanoid@3.3.11: {}
 
   netmask@2.1.1: {}
 
@@ -2357,7 +3157,15 @@ snapshots:
       lru-cache: 11.3.3
       minipass: 7.1.3
 
+  pathe@2.0.3: {}
+
+  pathval@2.0.1: {}
+
   pend@1.2.0: {}
+
+  picocolors@1.1.1: {}
+
+  picomatch@4.0.4: {}
 
   playwright-core@1.59.1: {}
 
@@ -2366,6 +3174,12 @@ snapshots:
       playwright-core: 1.59.1
     optionalDependencies:
       fsevents: 2.3.2
+
+  postcss@8.5.9:
+    dependencies:
+      nanoid: 3.3.11
+      picocolors: 1.1.1
+      source-map-js: 1.2.1
 
   proper-lockfile@4.1.2:
     dependencies:
@@ -2416,7 +3230,40 @@ snapshots:
 
   retry@0.13.1: {}
 
+  rollup@4.60.1:
+    dependencies:
+      '@types/estree': 1.0.8
+    optionalDependencies:
+      '@rollup/rollup-android-arm-eabi': 4.60.1
+      '@rollup/rollup-android-arm64': 4.60.1
+      '@rollup/rollup-darwin-arm64': 4.60.1
+      '@rollup/rollup-darwin-x64': 4.60.1
+      '@rollup/rollup-freebsd-arm64': 4.60.1
+      '@rollup/rollup-freebsd-x64': 4.60.1
+      '@rollup/rollup-linux-arm-gnueabihf': 4.60.1
+      '@rollup/rollup-linux-arm-musleabihf': 4.60.1
+      '@rollup/rollup-linux-arm64-gnu': 4.60.1
+      '@rollup/rollup-linux-arm64-musl': 4.60.1
+      '@rollup/rollup-linux-loong64-gnu': 4.60.1
+      '@rollup/rollup-linux-loong64-musl': 4.60.1
+      '@rollup/rollup-linux-ppc64-gnu': 4.60.1
+      '@rollup/rollup-linux-ppc64-musl': 4.60.1
+      '@rollup/rollup-linux-riscv64-gnu': 4.60.1
+      '@rollup/rollup-linux-riscv64-musl': 4.60.1
+      '@rollup/rollup-linux-s390x-gnu': 4.60.1
+      '@rollup/rollup-linux-x64-gnu': 4.60.1
+      '@rollup/rollup-linux-x64-musl': 4.60.1
+      '@rollup/rollup-openbsd-x64': 4.60.1
+      '@rollup/rollup-openharmony-arm64': 4.60.1
+      '@rollup/rollup-win32-arm64-msvc': 4.60.1
+      '@rollup/rollup-win32-ia32-msvc': 4.60.1
+      '@rollup/rollup-win32-x64-gnu': 4.60.1
+      '@rollup/rollup-win32-x64-msvc': 4.60.1
+      fsevents: 2.3.3
+
   safe-buffer@5.2.1: {}
+
+  siginfo@2.0.0: {}
 
   signal-exit@3.0.7: {}
 
@@ -2435,8 +3282,12 @@ snapshots:
       ip-address: 10.1.0
       smart-buffer: 4.2.0
 
+  source-map-js@1.2.1: {}
+
   source-map@0.6.1:
     optional: true
+
+  stackback@0.0.2: {}
 
   std-env@3.10.0: {}
 
@@ -2453,6 +3304,10 @@ snapshots:
   strip-ansi@7.2.0:
     dependencies:
       ansi-regex: 6.2.2
+
+  strip-literal@3.1.0:
+    dependencies:
+      js-tokens: 9.0.1
 
   strnum@2.2.3: {}
 
@@ -2471,6 +3326,21 @@ snapshots:
   thenify@3.3.1:
     dependencies:
       any-promise: 1.3.0
+
+  tinybench@2.9.0: {}
+
+  tinyexec@0.3.2: {}
+
+  tinyglobby@0.2.16:
+    dependencies:
+      fdir: 6.5.0(picomatch@4.0.4)
+      picomatch: 4.0.4
+
+  tinypool@1.1.1: {}
+
+  tinyrainbow@2.0.0: {}
+
+  tinyspy@4.0.4: {}
 
   token-types@6.1.2:
     dependencies:
@@ -2492,7 +3362,87 @@ snapshots:
 
   undici@7.24.7: {}
 
+  vite-node@3.2.4(@types/node@25.5.2)(yaml@2.8.3):
+    dependencies:
+      cac: 6.7.14
+      debug: 4.4.3
+      es-module-lexer: 1.7.0
+      pathe: 2.0.3
+      vite: 7.3.2(@types/node@25.5.2)(yaml@2.8.3)
+    transitivePeerDependencies:
+      - '@types/node'
+      - jiti
+      - less
+      - lightningcss
+      - sass
+      - sass-embedded
+      - stylus
+      - sugarss
+      - supports-color
+      - terser
+      - tsx
+      - yaml
+
+  vite@7.3.2(@types/node@25.5.2)(yaml@2.8.3):
+    dependencies:
+      esbuild: 0.27.7
+      fdir: 6.5.0(picomatch@4.0.4)
+      picomatch: 4.0.4
+      postcss: 8.5.9
+      rollup: 4.60.1
+      tinyglobby: 0.2.16
+    optionalDependencies:
+      '@types/node': 25.5.2
+      fsevents: 2.3.3
+      yaml: 2.8.3
+
+  vitest@3.2.4(@types/node@25.5.2)(yaml@2.8.3):
+    dependencies:
+      '@types/chai': 5.2.3
+      '@vitest/expect': 3.2.4
+      '@vitest/mocker': 3.2.4(vite@7.3.2(@types/node@25.5.2)(yaml@2.8.3))
+      '@vitest/pretty-format': 3.2.4
+      '@vitest/runner': 3.2.4
+      '@vitest/snapshot': 3.2.4
+      '@vitest/spy': 3.2.4
+      '@vitest/utils': 3.2.4
+      chai: 5.3.3
+      debug: 4.4.3
+      expect-type: 1.3.0
+      magic-string: 0.30.21
+      pathe: 2.0.3
+      picomatch: 4.0.4
+      std-env: 3.10.0
+      tinybench: 2.9.0
+      tinyexec: 0.3.2
+      tinyglobby: 0.2.16
+      tinypool: 1.1.1
+      tinyrainbow: 2.0.0
+      vite: 7.3.2(@types/node@25.5.2)(yaml@2.8.3)
+      vite-node: 3.2.4(@types/node@25.5.2)(yaml@2.8.3)
+      why-is-node-running: 2.3.0
+    optionalDependencies:
+      '@types/node': 25.5.2
+    transitivePeerDependencies:
+      - jiti
+      - less
+      - lightningcss
+      - msw
+      - sass
+      - sass-embedded
+      - stylus
+      - sugarss
+      - supports-color
+      - terser
+      - tsx
+      - yaml
+
   web-streams-polyfill@3.3.3: {}
+
+  why-is-node-running@2.3.0:
+    dependencies:
+      siginfo: 2.0.0
+      stackback: 0.0.2
 
   wrap-ansi@7.0.0:
     dependencies:

--- a/extensions/web-fetch/pnpm-lock.yaml
+++ b/extensions/web-fetch/pnpm-lock.yaml
@@ -18,22 +18,900 @@ importers:
         specifier: ^7.2.0
         version: 7.2.4
     devDependencies:
+      '@mariozechner/pi-ai':
+        specifier: ^0.65.2
+        version: 0.65.2(ws@8.20.0)(zod@4.3.6)
+      '@mariozechner/pi-coding-agent':
+        specifier: ^0.65.2
+        version: 0.65.2(ws@8.20.0)(zod@4.3.6)
+      '@sinclair/typebox':
+        specifier: ^0.34.49
+        version: 0.34.49
       '@types/turndown':
         specifier: ^5.0.5
         version: 5.0.6
 
 packages:
 
+  '@anthropic-ai/sdk@0.73.0':
+    resolution: {integrity: sha512-URURVzhxXGJDGUGFunIOtBlSl7KWvZiAAKY/ttTkZAkXT9bTPqdk2eK0b8qqSxXpikh3QKPnPYpiyX98zf5ebw==}
+    hasBin: true
+    peerDependencies:
+      zod: ^3.25.0 || ^4.0.0
+    peerDependenciesMeta:
+      zod:
+        optional: true
+
+  '@aws-crypto/crc32@5.2.0':
+    resolution: {integrity: sha512-nLbCWqQNgUiwwtFsen1AdzAtvuLRsQS8rYgMuxCrdKf9kOssamGLuPwyTY9wyYblNr9+1XM8v6zoDTPPSIeANg==}
+    engines: {node: '>=16.0.0'}
+
+  '@aws-crypto/sha256-browser@5.2.0':
+    resolution: {integrity: sha512-AXfN/lGotSQwu6HNcEsIASo7kWXZ5HYWvfOmSNKDsEqC4OashTp8alTmaz+F7TC2L083SFv5RdB+qU3Vs1kZqw==}
+
+  '@aws-crypto/sha256-js@5.2.0':
+    resolution: {integrity: sha512-FFQQyu7edu4ufvIZ+OadFpHHOt+eSTBaYaki44c+akjg7qZg9oOQeLlk77F6tSYqjDAFClrHJk9tMf0HdVyOvA==}
+    engines: {node: '>=16.0.0'}
+
+  '@aws-crypto/supports-web-crypto@5.2.0':
+    resolution: {integrity: sha512-iAvUotm021kM33eCdNfwIN//F77/IADDSs58i+MDaOqFrVjZo9bAal0NK7HurRuWLLpF1iLX7gbWrjHjeo+YFg==}
+
+  '@aws-crypto/util@5.2.0':
+    resolution: {integrity: sha512-4RkU9EsI6ZpBve5fseQlGNUWKMa1RLPQ1dnjnQoe07ldfIzcsGb5hC5W0Dm7u423KWzawlrpbjXBrXCEv9zazQ==}
+
+  '@aws-sdk/client-bedrock-runtime@3.1027.0':
+    resolution: {integrity: sha512-Qcda5Z5Vb3LPVt7zNycEiiAo9Blk0JpEPJwz/sUBJby6/0zvTlo+/FIXlwYZ3TJHSgKCYiCaBqAB0WRlWDfLfQ==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/core@3.973.27':
+    resolution: {integrity: sha512-CUZ5m8hwMCH6OYI4Li/WgMfIEx10Q2PLI9Y3XOUTPGZJ53aZ0007jCv+X/ywsaERyKPdw5MRZWk877roQksQ4A==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-env@3.972.25':
+    resolution: {integrity: sha512-6QfI0wv4jpG5CrdO/AO0JfZ2ux+tKwJPrUwmvxXF50vI5KIypKVGNF6b4vlkYEnKumDTI1NX2zUBi8JoU5QU3A==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-http@3.972.27':
+    resolution: {integrity: sha512-3V3Usj9Gs93h865DqN4M2NWJhC5kXU9BvZskfN3+69omuYlE3TZxOEcVQtBGLOloJB7BVfJKXVLqeNhOzHqSlQ==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-ini@3.972.29':
+    resolution: {integrity: sha512-SiBuAnXecCbT/OpAf3vqyI/AVE3mTaYr9ShXLybxZiPLBiPCCOIWSGAtYYGQWMRvobBTiqOewaB+wcgMMZI2Aw==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-login@3.972.29':
+    resolution: {integrity: sha512-OGOslTbOlxXexKMqhxCEbBQbUIfuhGxU5UXw3Fm56ypXHvrXH4aTt/xb5Y884LOoteP1QST1lVZzHfcTnWhiPQ==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-node@3.972.30':
+    resolution: {integrity: sha512-FMnAnWxc8PG+ZrZ2OBKzY4luCUJhe9CG0B9YwYr4pzrYGLXBS2rl+UoUvjGbAwiptxRL6hyA3lFn03Bv1TLqTw==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-process@3.972.25':
+    resolution: {integrity: sha512-HR7ynNRdNhNsdVCOCegy1HsfsRzozCOPtD3RzzT1JouuaHobWyRfJzCBue/3jP7gECHt+kQyZUvwg/cYLWurNQ==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-sso@3.972.29':
+    resolution: {integrity: sha512-HWv4SEq3jZDYPlwryZVef97+U8CxxRos5mK8sgGO1dQaFZpV5giZLzqGE5hkDmh2csYcBO2uf5XHjPTpZcJlig==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-web-identity@3.972.29':
+    resolution: {integrity: sha512-PdMBza1WEKEUPFEmMGCfnU2RYCz9MskU2e8JxjyUOsMKku7j9YaDKvbDi2dzC0ihFoM6ods2SbhfAAro+Gwlew==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/eventstream-handler-node@3.972.13':
+    resolution: {integrity: sha512-2Pi1kD0MDkMAxDHqvpi/hKMs9hXUYbj2GLEjCwy+0jzfLChAsF50SUYnOeTI+RztA+Ic4pnLAdB03f1e8nggxQ==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/middleware-eventstream@3.972.9':
+    resolution: {integrity: sha512-ypgOvpWxQTCnQyDHGxnTviqqANE7FIIzII7VczJnTPCJcJlu17hMQXnvE47aKSKsawVJAaaRsyOEbHQuLJF9ng==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/middleware-host-header@3.972.9':
+    resolution: {integrity: sha512-je5vRdNw4SkuTnmRbFZLdye4sQ0faLt8kwka5wnnSU30q1mHO4X+idGEJOOE+Tn1ME7Oryn05xxkDvIb3UaLaQ==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/middleware-logger@3.972.9':
+    resolution: {integrity: sha512-HsVgDrruhqI28RkaXALm8grJ7Agc1wF6Et0xh6pom8NdO2VdO/SD9U/tPwUjewwK/pVoka+EShBxyCvgsPCtog==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/middleware-recursion-detection@3.972.10':
+    resolution: {integrity: sha512-RVQQbq5orQ/GHUnXvqEOj2HHPBJm+mM+ySwZKS5UaLBwra5ugRtiH09PLUoOZRl7a1YzaOzXSuGbn9iD5j60WQ==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/middleware-user-agent@3.972.29':
+    resolution: {integrity: sha512-f/sIRzuTfEjg6NsbMYvye2VsmnQoNgntntleQyx5uGacUYzszbfIlO3GcI6G6daWUmTm0IDZc11qMHWwF0o0mQ==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/middleware-websocket@3.972.15':
+    resolution: {integrity: sha512-hsZ35FORQsN5hwNdMD6zWmHCphbXkDxO6j+xwCUiuMb0O6gzS/PWgttQNl1OAn7h/uqZAMUG4yOS0wY/yhAieg==}
+    engines: {node: '>= 14.0.0'}
+
+  '@aws-sdk/nested-clients@3.996.19':
+    resolution: {integrity: sha512-uFkmCDXvmQYLanlYdOFS0+MQWkrj9wPMt/ZCc/0J0fjPim6F5jBVBmEomvGY/j77ILW6GTPwN22Jc174Mhkw6Q==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/region-config-resolver@3.972.11':
+    resolution: {integrity: sha512-6Q8B1dcx6BBqUTY1Mc/eROKA0FImEEY5VPSd6AGPEUf0ErjExz4snVqa9kNJSoVDV1rKaNf3qrWojgcKW+SdDg==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/token-providers@3.1026.0':
+    resolution: {integrity: sha512-Ieq/HiRrbEtrYP387Nes0XlR7H1pJiJOZKv+QyQzMYpvTiDs0VKy2ZB3E2Zf+aFovWmeE7lRE4lXyF7dYM6GgA==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/token-providers@3.1027.0':
+    resolution: {integrity: sha512-mI3Jm14cM5sNKc7aNX3cqJe/rFQ2Zzx7x5W8WUtxj2lVxcH2RGYhqI3hK9nnImY6Ec5MeGXCVPjl/q6Mz5HmSA==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/types@3.973.7':
+    resolution: {integrity: sha512-reXRwoJ6CfChoqAsBszUYajAF8Z2LRE+CRcKocvFSMpIiLOtYU3aJ9trmn6VVPAzbbY5LXF+FfmUslbXk1SYFg==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/util-endpoints@3.996.6':
+    resolution: {integrity: sha512-2nUQ+2ih7CShuKHpGSIYvvAIOHy52dOZguYG36zptBukhw6iFwcvGfG0tes0oZFWQqEWvgZe9HLWaNlvXGdOrg==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/util-format-url@3.972.9':
+    resolution: {integrity: sha512-fNJXHrs0ZT7Wx0KGIqKv7zLxlDXt2vqjx9z6oKUQFmpE5o4xxnSryvVHfHpIifYHWKz94hFccIldJ0YSZjlCBw==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/util-locate-window@3.965.5':
+    resolution: {integrity: sha512-WhlJNNINQB+9qtLtZJcpQdgZw3SCDCpXdUJP7cToGwHbCWCnRckGlc6Bx/OhWwIYFNAn+FIydY8SZ0QmVu3xTQ==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/util-user-agent-browser@3.972.9':
+    resolution: {integrity: sha512-sn/LMzTbGjYqCCF24390WxPd6hkpoSptiUn5DzVp4cD71yqw+yGEGm1YCxyEoPXyc8qciM8UzLJcZBFslxo5Uw==}
+
+  '@aws-sdk/util-user-agent-node@3.973.15':
+    resolution: {integrity: sha512-fYn3s9PtKdgQkczGZCFMgkNEe8aq1JCVbnRqjqN9RSVW43xn2RV9xdcZ3z01a48Jpkuh/xCmBKJxdLOo4Ozg7w==}
+    engines: {node: '>=20.0.0'}
+    peerDependencies:
+      aws-crt: '>=1.0.0'
+    peerDependenciesMeta:
+      aws-crt:
+        optional: true
+
+  '@aws-sdk/xml-builder@3.972.17':
+    resolution: {integrity: sha512-Ra7hjqAZf1OXRRMueB13qex7mFJRDK/pgCvdSFemXBT8KCGnQDPoKzHY1SjN+TjJVmnpSF14W5tJ1vDamFu+Gg==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws/lambda-invoke-store@0.2.4':
+    resolution: {integrity: sha512-iY8yvjE0y651BixKNPgmv1WrQc+GZ142sb0z4gYnChDDY2YqI4P/jsSopBWrKfAt7LOJAkOXt7rC/hms+WclQQ==}
+    engines: {node: '>=18.0.0'}
+
+  '@babel/runtime@7.29.2':
+    resolution: {integrity: sha512-JiDShH45zKHWyGe4ZNVRrCjBz8Nh9TMmZG1kh4QTK8hCBTWBi8Da+i7s1fJw7/lYpM4ccepSNfqzZ/QvABBi5g==}
+    engines: {node: '>=6.9.0'}
+
+  '@borewit/text-codec@0.2.2':
+    resolution: {integrity: sha512-DDaRehssg1aNrH4+2hnj1B7vnUGEjU6OIlyRdkMd0aUdIUvKXrJfXsy8LVtXAy7DRvYVluWbMspsRhz2lcW0mQ==}
+
+  '@google/genai@1.49.0':
+    resolution: {integrity: sha512-hO69Zl0H3x+L0KL4stl1pLYgnqnwHoLqtKy6MRlNnW8TAxjqMdOUVafomKd4z1BePkzoxJWbYILny9a2Zk43VQ==}
+    engines: {node: '>=20.0.0'}
+    peerDependencies:
+      '@modelcontextprotocol/sdk': ^1.25.2
+    peerDependenciesMeta:
+      '@modelcontextprotocol/sdk':
+        optional: true
+
+  '@mariozechner/clipboard-darwin-arm64@0.3.2':
+    resolution: {integrity: sha512-uBf6K7Je1ihsgvmWxA8UCGCeI+nbRVRXoarZdLjl6slz94Zs1tNKFZqx7aCI5O1i3e0B6ja82zZ06BWrl0MCVw==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@mariozechner/clipboard-darwin-universal@0.3.2':
+    resolution: {integrity: sha512-mxSheKTW2U9LsBdXy0SdmdCAE5HqNS9QUmpNHLnfJ+SsbFKALjEZc5oRrVMXxGQSirDvYf5bjmRyT0QYYonnlg==}
+    engines: {node: '>= 10'}
+    os: [darwin]
+
+  '@mariozechner/clipboard-darwin-x64@0.3.2':
+    resolution: {integrity: sha512-U1BcVEoidvwIp95+HJswSW+xr28EQiHR7rZjH6pn8Sja5yO4Yoe3yCN0Zm8Lo72BbSOK/fTSq0je7CJpaPCspg==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@mariozechner/clipboard-linux-arm64-gnu@0.3.2':
+    resolution: {integrity: sha512-BsinwG3yWTIjdgNCxsFlip7LkfwPk+ruw/aFCXHUg/fb5XC/Ksp+YMQ7u0LUtiKzIv/7LMXgZInJQH6gxbAaqQ==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [linux]
+
+  '@mariozechner/clipboard-linux-arm64-musl@0.3.2':
+    resolution: {integrity: sha512-0/Gi5Xq2V6goXBop19ePoHvXsmJD9SzFlO3S+d6+T2b+BlPcpOu3Oa0wTjl+cZrLAAEzA86aPNBI+VVAFDFPKw==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [linux]
+
+  '@mariozechner/clipboard-linux-riscv64-gnu@0.3.2':
+    resolution: {integrity: sha512-2AFFiXB24qf0zOZsxI1GJGb9wQGlOJyN6UwoXqmKS3dpQi/l6ix30IzDDA4c4ZcCcx4D+9HLYXhC1w7Sov8pXA==}
+    engines: {node: '>= 10'}
+    cpu: [riscv64]
+    os: [linux]
+
+  '@mariozechner/clipboard-linux-x64-gnu@0.3.2':
+    resolution: {integrity: sha512-v6fVnsn7WMGg73Dab8QMwyFce7tzGfgEixKgzLP8f1GJqkJZi5zO4k4FOHzSgUufgLil63gnxvMpjWkgfeQN7A==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [linux]
+
+  '@mariozechner/clipboard-linux-x64-musl@0.3.2':
+    resolution: {integrity: sha512-xVUtnoMQ8v2JVyfJLKKXACA6avdnchdbBkTsZs8BgJQo29qwCp5NIHAUO8gbJ40iaEGToW5RlmVk2M9V0HsHEw==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [linux]
+
+  '@mariozechner/clipboard-win32-arm64-msvc@0.3.2':
+    resolution: {integrity: sha512-AEgg95TNi8TGgak2wSXZkXKCvAUTjWoU1Pqb0ON7JHrX78p616XUFNTJohtIon3e0w6k0pYPZeCuqRCza/Tqeg==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [win32]
+
+  '@mariozechner/clipboard-win32-x64-msvc@0.3.2':
+    resolution: {integrity: sha512-tGRuYpZwDOD7HBrCpyRuhGnHHSCknELvqwKKUG4JSfSB7JIU7LKRh6zx6fMUOQd8uISK35TjFg5UcNih+vJhFA==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [win32]
+
+  '@mariozechner/clipboard@0.3.2':
+    resolution: {integrity: sha512-IHQpksNjo7EAtGuHFU+tbWDp5LarH3HU/8WiB9O70ZEoBPHOg0/6afwSLK0QyNMMmx4Bpi/zl6+DcBXe95nWYA==}
+    engines: {node: '>= 10'}
+
+  '@mariozechner/jiti@2.6.5':
+    resolution: {integrity: sha512-faGUlTcXka5l7rv0lP3K3vGW/ejRuOS24RR2aSFWREUQqzjgdsuWNo/IiPqL3kWRGt6Ahl2+qcDAwtdeWeuGUw==}
+    hasBin: true
+
+  '@mariozechner/pi-agent-core@0.65.2':
+    resolution: {integrity: sha512-GYOrX5aRUpSDMPtKR174Tv72CWH92anqlRuiGn8PV05OowPAahT99JoxvZEP4fcKANBdHsyDfMMwFYpPhvPBUQ==}
+    engines: {node: '>=20.0.0'}
+
+  '@mariozechner/pi-ai@0.65.2':
+    resolution: {integrity: sha512-XCbXncmh10Q89tvS0880Ms6pv3DTxFTEtanfVHEPXKQBi0FBYnrkAlOnP5VRU8vCfe18P1AMNsWCndsCBUqY7g==}
+    engines: {node: '>=20.0.0'}
+    hasBin: true
+
+  '@mariozechner/pi-coding-agent@0.65.2':
+    resolution: {integrity: sha512-/rpFzPQ+CishxrSwJHSSRZBQHHWy2K3Rbu/iV0HcMq/hl9cSI2ygpwjVTRbPW+NuP1tHxVV3AMxz69VLAs5Ztg==}
+    engines: {node: '>=20.6.0'}
+    hasBin: true
+
+  '@mariozechner/pi-tui@0.65.2':
+    resolution: {integrity: sha512-LBPbIBASjCF4QLrc/dwmPdBzVMsbkDhzmBIAFgglX5rZBnGRppB7ekSA+1kb5pdxDpDn8IbxJX+bl7ZaeqZqxw==}
+    engines: {node: '>=20.0.0'}
+
+  '@mistralai/mistralai@1.14.1':
+    resolution: {integrity: sha512-IiLmmZFCCTReQgPAT33r7KQ1nYo5JPdvGkrkZqA8qQ2qB1GHgs5LoP5K2ICyrjnpw2n8oSxMM/VP+liiKcGNlQ==}
+
   '@mixmark-io/domino@2.2.0':
     resolution: {integrity: sha512-Y28PR25bHXUg88kCV7nivXrP2Nj2RueZ3/l/jdx6J9f8J4nsEGcgX0Qe6lt7Pa+J79+kPiJU3LguR6O/6zrLOw==}
 
+  '@protobufjs/aspromise@1.1.2':
+    resolution: {integrity: sha512-j+gKExEuLmKwvz3OgROXtrJ2UG2x8Ch2YZUxahh+s1F2HZ+wAceUNLkvy6zKCPVRkU++ZWQrdxsUeQXmcg4uoQ==}
+
+  '@protobufjs/base64@1.1.2':
+    resolution: {integrity: sha512-AZkcAA5vnN/v4PDqKyMR5lx7hZttPDgClv83E//FMNhR2TMcLUhfRUBHCmSl0oi9zMgDDqRUJkSxO3wm85+XLg==}
+
+  '@protobufjs/codegen@2.0.4':
+    resolution: {integrity: sha512-YyFaikqM5sH0ziFZCN3xDC7zeGaB/d0IUb9CATugHWbd1FRFwWwt4ld4OYMPWu5a3Xe01mGAULCdqhMlPl29Jg==}
+
+  '@protobufjs/eventemitter@1.1.0':
+    resolution: {integrity: sha512-j9ednRT81vYJ9OfVuXG6ERSTdEL1xVsNgqpkxMsbIabzSo3goCjDIveeGv5d03om39ML71RdmrGNjG5SReBP/Q==}
+
+  '@protobufjs/fetch@1.1.0':
+    resolution: {integrity: sha512-lljVXpqXebpsijW71PZaCYeIcE5on1w5DlQy5WH6GLbFryLUrBD4932W/E2BSpfRJWseIL4v/KPgBFxDOIdKpQ==}
+
+  '@protobufjs/float@1.0.2':
+    resolution: {integrity: sha512-Ddb+kVXlXst9d+R9PfTIxh1EdNkgoRe5tOX6t01f1lYWOvJnSPDBlG241QLzcyPdoNTsblLUdujGSE4RzrTZGQ==}
+
+  '@protobufjs/inquire@1.1.0':
+    resolution: {integrity: sha512-kdSefcPdruJiFMVSbn801t4vFK7KB/5gd2fYvrxhuJYg8ILrmn9SKSX2tZdV6V+ksulWqS7aXjBcRXl3wHoD9Q==}
+
+  '@protobufjs/path@1.1.2':
+    resolution: {integrity: sha512-6JOcJ5Tm08dOHAbdR3GrvP+yUUfkjG5ePsHYczMFLq3ZmMkAD98cDgcT2iA1lJ9NVwFd4tH/iSSoe44YWkltEA==}
+
+  '@protobufjs/pool@1.1.0':
+    resolution: {integrity: sha512-0kELaGSIDBKvcgS4zkjz1PeddatrjYcmMWOlAuAPwAeccUrPHdUqo/J6LiymHHEiJT5NrF1UVwxY14f+fy4WQw==}
+
+  '@protobufjs/utf8@1.1.0':
+    resolution: {integrity: sha512-Vvn3zZrhQZkkBE8LSuW3em98c0FwgO4nxzv6OdSxPKJIEKY2bGbHn+mhGIPerzI4twdxaP8/0+06HBpwf345Lw==}
+
+  '@silvia-odwyer/photon-node@0.3.4':
+    resolution: {integrity: sha512-bnly4BKB3KDTFxrUIcgCLbaeVVS8lrAkri1pEzskpmxu9MdfGQTy8b8EgcD83ywD3RPMsIulY8xJH5Awa+t9fA==}
+
+  '@sinclair/typebox@0.34.49':
+    resolution: {integrity: sha512-brySQQs7Jtn0joV8Xh9ZV/hZb9Ozb0pmazDIASBkYKCjXrXU3mpcFahmK/z4YDhGkQvP9mWJbVyahdtU5wQA+A==}
+
+  '@smithy/config-resolver@4.4.14':
+    resolution: {integrity: sha512-N55f8mPEccpzKetUagdvmAy8oohf0J5cuj9jLI1TaSceRlq0pJsIZepY3kmAXAhyxqXPV6hDerDQhqQPKWgAoQ==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/core@3.23.14':
+    resolution: {integrity: sha512-vJ0IhpZxZAkFYOegMKSrxw7ujhhT2pass/1UEcZ4kfl5srTAqtPU5I7MdYQoreVas3204ykCiNhY1o7Xlz6Yyg==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/credential-provider-imds@4.2.13':
+    resolution: {integrity: sha512-wboCPijzf6RJKLOvnjDAiBxGSmSnGXj35o5ZAWKDaHa/cvQ5U3ZJ13D4tMCE8JG4dxVAZFy/P0x/V9CwwdfULQ==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/eventstream-codec@4.2.13':
+    resolution: {integrity: sha512-vYahwBAtRaAcFbOmE9aLr12z7RiHYDSLcnogSdxfm7kKfsNa3wH+NU5r7vTeB5rKvLsWyPjVX8iH94brP7umiQ==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/eventstream-serde-browser@4.2.13':
+    resolution: {integrity: sha512-wwybfcOX0tLqCcBP378TIU9IqrDuZq/tDV48LlZNydMpCnqnYr+hWBAYbRE+rFFf/p7IkDJySM3bgiMKP2ihPg==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/eventstream-serde-config-resolver@4.3.13':
+    resolution: {integrity: sha512-ied1lO559PtAsMJzg2TKRlctLnEi1PfkNeMMpdwXDImk1zV9uvS/Oxoy/vcy9uv1GKZAjDAB5xT6ziE9fzm5wA==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/eventstream-serde-node@4.2.13':
+    resolution: {integrity: sha512-hFyK+ORJrxAN3RYoaD6+gsGDQjeix8HOEkosoajvXYZ4VeqonM3G4jd9IIRm/sWGXUKmudkY9KdYjzosUqdM8A==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/eventstream-serde-universal@4.2.13':
+    resolution: {integrity: sha512-kRrq4EKLGeOxhC2CBEhRNcu1KSzNJzYY7RK3S7CxMPgB5dRrv55WqQOtRwQxQLC04xqORFLUgnDlc6xrNUULaA==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/fetch-http-handler@5.3.16':
+    resolution: {integrity: sha512-nYDRUIvNd4mFmuXraRWt6w5UsZTNqtj4hXJA/iiOD4tuseIdLP9Lq38teH/SZTcIFCa2f+27o7hYpIsWktJKEQ==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/hash-node@4.2.13':
+    resolution: {integrity: sha512-4/oy9h0jjmY80a2gOIo75iLl8TOPhmtx4E2Hz+PfMjvx/vLtGY4TMU/35WRyH2JHPfT5CVB38u4JRow7gnmzJA==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/invalid-dependency@4.2.13':
+    resolution: {integrity: sha512-jvC0RB/8BLj2SMIkY0Npl425IdnxZJxInpZJbu563zIRnVjpDMXevU3VMCRSabaLB0kf/eFIOusdGstrLJ8IDg==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/is-array-buffer@2.2.0':
+    resolution: {integrity: sha512-GGP3O9QFD24uGeAXYUjwSTXARoqpZykHadOmA8G5vfJPK0/DC67qa//0qvqrJzL1xc8WQWX7/yc7fwudjPHPhA==}
+    engines: {node: '>=14.0.0'}
+
+  '@smithy/is-array-buffer@4.2.2':
+    resolution: {integrity: sha512-n6rQ4N8Jj4YTQO3YFrlgZuwKodf4zUFs7EJIWH86pSCWBaAtAGBFfCM7Wx6D2bBJ2xqFNxGBSrUWswT3M0VJow==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/middleware-content-length@4.2.13':
+    resolution: {integrity: sha512-IPMLm/LE4AZwu6qiE8Rr8vJsWhs9AtOdySRXrOM7xnvclp77Tyh7hMs/FRrMf26kgIe67vFJXXOSmVxS7oKeig==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/middleware-endpoint@4.4.29':
+    resolution: {integrity: sha512-R9Q/58U+qBiSARGWbAbFLczECg/RmysRksX6Q8BaQEpt75I7LI6WGDZnjuC9GXSGKljEbA7N118LhGaMbfrTXw==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/middleware-retry@4.5.0':
+    resolution: {integrity: sha512-/NzISn4grj/BRFVua/xnQwF+7fakYZgimpw2dfmlPgcqecBMKxpB9g5mLYRrmBD5OrPoODokw4Vi1hrSR4zRyw==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/middleware-serde@4.2.17':
+    resolution: {integrity: sha512-0T2mcaM6v9W1xku86Dk0bEW7aEseG6KenFkPK98XNw0ZhOqOiD1MrMsdnQw9QsL3/Oa85T53iSMlm0SZdSuIEQ==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/middleware-stack@4.2.13':
+    resolution: {integrity: sha512-g72jN/sGDLyTanrCLH9fhg3oysO3f7tQa6eWWsMyn2BiYNCgjF24n4/I9wff/5XidFvjj9ilipAoQrurTUrLvw==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/node-config-provider@4.3.13':
+    resolution: {integrity: sha512-iGxQ04DsKXLckbgnX4ipElrOTk+IHgTyu0q0WssZfYhDm9CQWHmu6cOeI5wmWRxpXbBDhIIfXMWz5tPEtcVqbw==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/node-http-handler@4.5.2':
+    resolution: {integrity: sha512-/oD7u8M0oj2ZTFw7GkuuHWpIxtWdLlnyNkbrWcyVYhd5RJNDuczdkb0wfnQICyNFrVPlr8YHOhamjNy3zidhmA==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/property-provider@4.2.13':
+    resolution: {integrity: sha512-bGzUCthxRmezuxkbu9wD33wWg9KX3hJpCXpQ93vVkPrHn9ZW6KNNdY5xAUWNuRCwQ+VyboFuWirG1lZhhkcyRQ==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/protocol-http@5.3.13':
+    resolution: {integrity: sha512-+HsmuJUF4u8POo6s8/a2Yb/AQ5t/YgLovCuHF9oxbocqv+SZ6gd8lC2duBFiCA/vFHoHQhoq7QjqJqZC6xOxxg==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/querystring-builder@4.2.13':
+    resolution: {integrity: sha512-tG4aOYFCZdPMjbgfhnIQ322H//ojujldp1SrHPHpBSb3NqgUp3dwiUGRJzie87hS1DYwWGqDuPaowoDF+rYCbQ==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/querystring-parser@4.2.13':
+    resolution: {integrity: sha512-hqW3Q4P+CDzUyQ87GrboGMeD7XYNMOF+CuTwu936UQRB/zeYn3jys8C3w+wMkDfY7CyyyVwZQ5cNFoG0x1pYmA==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/service-error-classification@4.2.13':
+    resolution: {integrity: sha512-a0s8XZMfOC/qpqq7RCPvJlk93rWFrElH6O++8WJKz0FqnA4Y7fkNi/0mnGgSH1C4x6MFsuBA8VKu4zxFrMe5Vw==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/shared-ini-file-loader@4.4.8':
+    resolution: {integrity: sha512-VZCZx2bZasxdqxVgEAhREvDSlkatTPnkdWy1+Kiy8w7kYPBosW0V5IeDwzDUMvWBt56zpK658rx1cOBFOYaPaw==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/signature-v4@5.3.13':
+    resolution: {integrity: sha512-YpYSyM0vMDwKbHD/JA7bVOF6kToVRpa+FM5ateEVRpsTNu564g1muBlkTubXhSKKYXInhpADF46FPyrZcTLpXg==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/smithy-client@4.12.9':
+    resolution: {integrity: sha512-ovaLEcTU5olSeHcRXcxV6viaKtpkHZumn6Ps0yn7dRf2rRSfy794vpjOtrWDO0d1auDSvAqxO+lyhERSXQ03EQ==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/types@4.14.0':
+    resolution: {integrity: sha512-OWgntFLW88kx2qvf/c/67Vno1yuXm/f9M7QFAtVkkO29IJXGBIg0ycEaBTH0kvCtwmvZxRujrgP5a86RvsXJAQ==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/url-parser@4.2.13':
+    resolution: {integrity: sha512-2G03yoboIRZlZze2+PT4GZEjgwQsJjUgn6iTsvxA02bVceHR6vp4Cuk7TUnPFWKF+ffNUk3kj4COwkENS2K3vw==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/util-base64@4.3.2':
+    resolution: {integrity: sha512-XRH6b0H/5A3SgblmMa5ErXQ2XKhfbQB+Fm/oyLZ2O2kCUrwgg55bU0RekmzAhuwOjA9qdN5VU2BprOvGGUkOOQ==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/util-body-length-browser@4.2.2':
+    resolution: {integrity: sha512-JKCrLNOup3OOgmzeaKQwi4ZCTWlYR5H4Gm1r2uTMVBXoemo1UEghk5vtMi1xSu2ymgKVGW631e2fp9/R610ZjQ==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/util-body-length-node@4.2.3':
+    resolution: {integrity: sha512-ZkJGvqBzMHVHE7r/hcuCxlTY8pQr1kMtdsVPs7ex4mMU+EAbcXppfo5NmyxMYi2XU49eqaz56j2gsk4dHHPG/g==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/util-buffer-from@2.2.0':
+    resolution: {integrity: sha512-IJdWBbTcMQ6DA0gdNhh/BwrLkDR+ADW5Kr1aZmd4k3DIF6ezMV4R2NIAmT08wQJ3yUK82thHWmC/TnK/wpMMIA==}
+    engines: {node: '>=14.0.0'}
+
+  '@smithy/util-buffer-from@4.2.2':
+    resolution: {integrity: sha512-FDXD7cvUoFWwN6vtQfEta540Y/YBe5JneK3SoZg9bThSoOAC/eGeYEua6RkBgKjGa/sz6Y+DuBZj3+YEY21y4Q==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/util-config-provider@4.2.2':
+    resolution: {integrity: sha512-dWU03V3XUprJwaUIFVv4iOnS1FC9HnMHDfUrlNDSh4315v0cWyaIErP8KiqGVbf5z+JupoVpNM7ZB3jFiTejvQ==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/util-defaults-mode-browser@4.3.45':
+    resolution: {integrity: sha512-ag9sWc6/nWZAuK3Wm9KlFJUnRkXLrXn33RFjIAmCTFThqLHY+7wCst10BGq56FxslsDrjhSie46c8OULS+BiIw==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/util-defaults-mode-node@4.2.49':
+    resolution: {integrity: sha512-jlN6vHwE8gY5AfiFBavtD3QtCX2f7lM3BKkz7nFKSNfFR5nXLXLg6sqXTJEEyDwtxbztIDBQCfjsGVXlIru2lQ==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/util-endpoints@3.3.4':
+    resolution: {integrity: sha512-BKoR/ubPp9KNKFxPpg1J28N1+bgu8NGAtJblBP7yHy8yQPBWhIAv9+l92SlQLpolGm71CVO+btB60gTgzT0wog==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/util-hex-encoding@4.2.2':
+    resolution: {integrity: sha512-Qcz3W5vuHK4sLQdyT93k/rfrUwdJ8/HZ+nMUOyGdpeGA1Wxt65zYwi3oEl9kOM+RswvYq90fzkNDahPS8K0OIg==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/util-middleware@4.2.13':
+    resolution: {integrity: sha512-GTooyrlmRTqvUen4eK7/K1p6kryF7bnDfq6XsAbIsf2mo51B/utaH+XThY6dKgNCWzMAaH/+OLmqaBuLhLWRow==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/util-retry@4.3.0':
+    resolution: {integrity: sha512-tSOPQNT/4KfbvqeMovWC3g23KSYy8czHd3tlN+tOYVNIDLSfxIsrPJihYi5TpNcoV789KWtgChUVedh2y6dDPg==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/util-stream@4.5.22':
+    resolution: {integrity: sha512-3H8iq/0BfQjUs2/4fbHZ9aG9yNzcuZs24LPkcX1Q7Z+qpqaGM8+qbGmE8zo9m2nCRgamyvS98cHdcWvR6YUsew==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/util-uri-escape@4.2.2':
+    resolution: {integrity: sha512-2kAStBlvq+lTXHyAZYfJRb/DfS3rsinLiwb+69SstC9Vb0s9vNWkRwpnj918Pfi85mzi42sOqdV72OLxWAISnw==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/util-utf8@2.3.0':
+    resolution: {integrity: sha512-R8Rdn8Hy72KKcebgLiv8jQcQkXoLMOGGv5uI1/k0l+snqkOzQ1R0ChUBCxWMlBsFMekWjq0wRudIweFs7sKT5A==}
+    engines: {node: '>=14.0.0'}
+
+  '@smithy/util-utf8@4.2.2':
+    resolution: {integrity: sha512-75MeYpjdWRe8M5E3AW0O4Cx3UadweS+cwdXjwYGBW5h/gxxnbeZ877sLPX/ZJA9GVTlL/qG0dXP29JWFCD1Ayw==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/uuid@1.1.2':
+    resolution: {integrity: sha512-O/IEdcCUKkubz60tFbGA7ceITTAJsty+lBjNoorP4Z6XRqaFb/OjQjZODophEcuq68nKm6/0r+6/lLQ+XVpk8g==}
+    engines: {node: '>=18.0.0'}
+
+  '@tokenizer/inflate@0.4.1':
+    resolution: {integrity: sha512-2mAv+8pkG6GIZiF1kNg1jAjh27IDxEPKwdGul3snfztFerfPGI1LjDezZp3i7BElXompqEtPmoPx6c2wgtWsOA==}
+    engines: {node: '>=18'}
+
+  '@tokenizer/token@0.3.0':
+    resolution: {integrity: sha512-OvjF+z51L3ov0OyAU0duzsYuvO01PH7x4t6DJx+guahgTnBHkhJdG7soQeTSFLWN3efnHyibZ4Z8l2EuWwJN3A==}
+
+  '@tootallnate/quickjs-emscripten@0.23.0':
+    resolution: {integrity: sha512-C5Mc6rdnsaJDjO3UpGW/CQTHtCKaYlScZTly4JIu97Jxo/odCiH0ITnDXSJPTOrEKk/ycSZ0AOgTmkDtkOsvIA==}
+
+  '@types/mime-types@2.1.4':
+    resolution: {integrity: sha512-lfU4b34HOri+kAY5UheuFMWPDOI+OPceBSHZKp69gEyTL/mmJ4cnU6Y/rlme3UL3GyOn6Y42hyIEw0/q8sWx5w==}
+
+  '@types/node@25.5.2':
+    resolution: {integrity: sha512-tO4ZIRKNC+MDWV4qKVZe3Ql/woTnmHDr5JD8UI5hn2pwBrHEwOEMZK7WlNb5RKB6EoJ02gwmQS9OrjuFnZYdpg==}
+
+  '@types/retry@0.12.0':
+    resolution: {integrity: sha512-wWKOClTTiizcZhXnPY4wikVAwmdYHp8q6DmC+EJUzAMsycb7HB32Kh9RN4+0gExjmPmZSAQjgURXIGATPegAvA==}
+
   '@types/turndown@5.0.6':
     resolution: {integrity: sha512-ru00MoyeeouE5BX4gRL+6m/BsDfbRayOskWqUvh7CLGW+UXxHQItqALa38kKnOiZPqJrtzJUgAC2+F0rL1S4Pg==}
+
+  '@types/yauzl@2.10.3':
+    resolution: {integrity: sha512-oJoftv0LSuaDZE3Le4DbKX+KS9G36NzOeSap90UIK0yMA/NhKJhqlSGtNDORNRaIbQfzjXDrQa0ytJ6mNRGz/Q==}
+
+  agent-base@7.1.4:
+    resolution: {integrity: sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==}
+    engines: {node: '>= 14'}
+
+  ajv-formats@3.0.1:
+    resolution: {integrity: sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==}
+    peerDependencies:
+      ajv: ^8.0.0
+    peerDependenciesMeta:
+      ajv:
+        optional: true
+
+  ajv@8.18.0:
+    resolution: {integrity: sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==}
+
+  ansi-regex@5.0.1:
+    resolution: {integrity: sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==}
+    engines: {node: '>=8'}
+
+  ansi-regex@6.2.2:
+    resolution: {integrity: sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==}
+    engines: {node: '>=12'}
+
+  ansi-styles@4.3.0:
+    resolution: {integrity: sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==}
+    engines: {node: '>=8'}
+
+  any-promise@1.3.0:
+    resolution: {integrity: sha512-7UvmKalWRt1wgjL1RrGxoSJW/0QZFIegpeGvZG9kjp8vrRu55XTHbwnqq2GpXm9uLbcuhxm3IqX9OB4MZR1b2A==}
+
+  ast-types@0.13.4:
+    resolution: {integrity: sha512-x1FCFnFifvYDDzTaLII71vG5uvDwgtmDTEVWAxrgeiR8VjMONcCXJx7E+USjDtHlwFmt9MysbqgF9b9Vjr6w+w==}
+    engines: {node: '>=4'}
+
+  balanced-match@4.0.4:
+    resolution: {integrity: sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==}
+    engines: {node: 18 || 20 || >=22}
+
+  base64-js@1.5.1:
+    resolution: {integrity: sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==}
+
+  basic-ftp@5.2.1:
+    resolution: {integrity: sha512-0yaL8JdxTknKDILitVpfYfV2Ob6yb3udX/hK97M7I3jOeznBNxQPtVvTUtnhUkyHlxFWyr5Lvknmgzoc7jf+1Q==}
+    engines: {node: '>=10.0.0'}
+
+  bignumber.js@9.3.1:
+    resolution: {integrity: sha512-Ko0uX15oIUS7wJ3Rb30Fs6SkVbLmPBAKdlm7q9+ak9bbIeFf0MwuBsQV6z7+X768/cHsfg+WlysDWJcmthjsjQ==}
+
+  bowser@2.14.1:
+    resolution: {integrity: sha512-tzPjzCxygAKWFOJP011oxFHs57HzIhOEracIgAePE4pqB3LikALKnSzUyU4MGs9/iCEUuHlAJTjTc5M+u7YEGg==}
+
+  brace-expansion@5.0.5:
+    resolution: {integrity: sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==}
+    engines: {node: 18 || 20 || >=22}
+
+  buffer-crc32@0.2.13:
+    resolution: {integrity: sha512-VO9Ht/+p3SN7SKWqcrgEzjGbRSJYTx+Q1pTQC0wrWqHx0vpJraQ6GtHx8tvcg1rlK1byhU5gccxgOgj7B0TDkQ==}
+
+  buffer-equal-constant-time@1.0.1:
+    resolution: {integrity: sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA==}
+
+  chalk@4.1.2:
+    resolution: {integrity: sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==}
+    engines: {node: '>=10'}
+
+  chalk@5.6.2:
+    resolution: {integrity: sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA==}
+    engines: {node: ^12.17.0 || ^14.13 || >=16.0.0}
+
+  cli-highlight@2.1.11:
+    resolution: {integrity: sha512-9KDcoEVwyUXrjcJNvHD0NFc/hiwe/WPVYIleQh2O1N2Zro5gWJZ/K+3DGn8w8P/F6FxOgzyC5bxDyHIgCSPhGg==}
+    engines: {node: '>=8.0.0', npm: '>=5.0.0'}
+    hasBin: true
+
+  cliui@7.0.4:
+    resolution: {integrity: sha512-OcRE68cOsVMXp1Yvonl/fzkQOyjLSu/8bhPDfQt0e0/Eb283TKP20Fs2MqoPsr9SwA595rRCA+QMzYc9nBP+JQ==}
+
+  color-convert@2.0.1:
+    resolution: {integrity: sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==}
+    engines: {node: '>=7.0.0'}
+
+  color-name@1.1.4:
+    resolution: {integrity: sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==}
+
+  data-uri-to-buffer@4.0.1:
+    resolution: {integrity: sha512-0R9ikRb668HB7QDxT1vkpuUBtqc53YyAwMwGeUFKRojY/NWKvdZ+9UYtRfGmhqNbRkTSVpMbmyhXipFFv2cb/A==}
+    engines: {node: '>= 12'}
+
+  data-uri-to-buffer@6.0.2:
+    resolution: {integrity: sha512-7hvf7/GW8e86rW0ptuwS3OcBGDjIi6SZva7hCyWC0yYry2cOPmLIjXAUHI6DK2HsnwJd9ifmt57i8eV2n4YNpw==}
+    engines: {node: '>= 14'}
+
+  debug@4.4.3:
+    resolution: {integrity: sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==}
+    engines: {node: '>=6.0'}
+    peerDependencies:
+      supports-color: '*'
+    peerDependenciesMeta:
+      supports-color:
+        optional: true
+
+  degenerator@5.0.1:
+    resolution: {integrity: sha512-TllpMR/t0M5sqCXfj85i4XaAzxmS5tVA16dqvdkMwGmzI+dXLXnw3J+3Vdv7VKw+ThlTMboK6i9rnZ6Nntj5CQ==}
+    engines: {node: '>= 14'}
+
+  diff@8.0.4:
+    resolution: {integrity: sha512-DPi0FmjiSU5EvQV0++GFDOJ9ASQUVFh5kD+OzOnYdi7n3Wpm9hWWGfB/O2blfHcMVTL5WkQXSnRiK9makhrcnw==}
+    engines: {node: '>=0.3.1'}
+
+  ecdsa-sig-formatter@1.0.11:
+    resolution: {integrity: sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==}
+
+  emoji-regex@8.0.0:
+    resolution: {integrity: sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==}
+
+  end-of-stream@1.4.5:
+    resolution: {integrity: sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==}
+
+  escalade@3.2.0:
+    resolution: {integrity: sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==}
+    engines: {node: '>=6'}
+
+  escodegen@2.1.0:
+    resolution: {integrity: sha512-2NlIDTwUWJN0mRPQOdtQBzbUHvdGY2P1VXSyU83Q3xKxM7WHX2Ql8dKq782Q9TgQUNOLEzEYu9bzLNj1q88I5w==}
+    engines: {node: '>=6.0'}
+    hasBin: true
+
+  esprima@4.0.1:
+    resolution: {integrity: sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==}
+    engines: {node: '>=4'}
+    hasBin: true
+
+  estraverse@5.3.0:
+    resolution: {integrity: sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==}
+    engines: {node: '>=4.0'}
+
+  esutils@2.0.3:
+    resolution: {integrity: sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==}
+    engines: {node: '>=0.10.0'}
+
+  extend@3.0.2:
+    resolution: {integrity: sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==}
+
+  extract-zip@2.0.1:
+    resolution: {integrity: sha512-GDhU9ntwuKyGXdZBUgTIe+vXnWj0fppUEtMDL0+idd5Sta8TGpHssn/eusA9mrPr9qNDym6SxAYZjNvCn/9RBg==}
+    engines: {node: '>= 10.17.0'}
+    hasBin: true
+
+  fast-deep-equal@3.1.3:
+    resolution: {integrity: sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==}
+
+  fast-uri@3.1.0:
+    resolution: {integrity: sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==}
+
+  fast-xml-builder@1.1.4:
+    resolution: {integrity: sha512-f2jhpN4Eccy0/Uz9csxh3Nu6q4ErKxf0XIsasomfOihuSUa3/xw6w8dnOtCDgEItQFJG8KyXPzQXzcODDrrbOg==}
+
+  fast-xml-parser@5.5.8:
+    resolution: {integrity: sha512-Z7Fh2nVQSb2d+poDViM063ix2ZGt9jmY1nWhPfHBOK2Hgnb/OW3P4Et3P/81SEej0J7QbWtJqxO05h8QYfK7LQ==}
+    hasBin: true
+
+  fd-slicer@1.1.0:
+    resolution: {integrity: sha512-cE1qsB/VwyQozZ+q1dGxR8LBYNZeofhEdUNGSMbQD3Gw2lAzX9Zb3uIU6Ebc/Fmyjo9AWWfnn0AUCHqtevs/8g==}
+
+  fetch-blob@3.2.0:
+    resolution: {integrity: sha512-7yAQpD2UMJzLi1Dqv7qFYnPbaPx7ZfFK6PiIxQ4PfkGPyNyl2Ugx+a/umUonmKqjhM4DnfbMvdX6otXq83soQQ==}
+    engines: {node: ^12.20 || >= 14.13}
+
+  file-type@21.3.4:
+    resolution: {integrity: sha512-Ievi/yy8DS3ygGvT47PjSfdFoX+2isQueoYP1cntFW1JLYAuS4GD7NUPGg4zv2iZfV52uDyk5w5Z0TdpRS6Q1g==}
+    engines: {node: '>=20'}
+
+  formdata-polyfill@4.0.10:
+    resolution: {integrity: sha512-buewHzMvYL29jdeQTVILecSaZKnt/RJWjoZCF5OW60Z67/GmSLBkOFM7qh1PI3zFNtJbaZL5eQu1vLfazOwj4g==}
+    engines: {node: '>=12.20.0'}
 
   fsevents@2.3.2:
     resolution: {integrity: sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==}
     engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
     os: [darwin]
+
+  gaxios@7.1.4:
+    resolution: {integrity: sha512-bTIgTsM2bWn3XklZISBTQX7ZSddGW+IO3bMdGaemHZ3tbqExMENHLx6kKZ/KlejgrMtj8q7wBItt51yegqalrA==}
+    engines: {node: '>=18'}
+
+  gcp-metadata@8.1.2:
+    resolution: {integrity: sha512-zV/5HKTfCeKWnxG0Dmrw51hEWFGfcF2xiXqcA3+J90WDuP0SvoiSO5ORvcBsifmx/FoIjgQN3oNOGaQ5PhLFkg==}
+    engines: {node: '>=18'}
+
+  get-caller-file@2.0.5:
+    resolution: {integrity: sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==}
+    engines: {node: 6.* || 8.* || >= 10.*}
+
+  get-east-asian-width@1.5.0:
+    resolution: {integrity: sha512-CQ+bEO+Tva/qlmw24dCejulK5pMzVnUOFOijVogd3KQs07HnRIgp8TGipvCCRT06xeYEbpbgwaCxglFyiuIcmA==}
+    engines: {node: '>=18'}
+
+  get-stream@5.2.0:
+    resolution: {integrity: sha512-nBF+F1rAZVCu/p7rjzgA+Yb4lfYXrpl7a6VmJrU8wF9I1CKvP/QwPNZHnOlwbTkY6dvtFIzFMSyQXbLoTQPRpA==}
+    engines: {node: '>=8'}
+
+  get-uri@6.0.5:
+    resolution: {integrity: sha512-b1O07XYq8eRuVzBNgJLstU6FYc1tS6wnMtF1I1D9lE8LxZSOGZ7LhxN54yPP6mGw5f2CkXY2BQUL9Fx41qvcIg==}
+    engines: {node: '>= 14'}
+
+  glob@13.0.6:
+    resolution: {integrity: sha512-Wjlyrolmm8uDpm/ogGyXZXb1Z+Ca2B8NbJwqBVg0axK9GbBeoS7yGV6vjXnYdGm6X53iehEuxxbyiKp8QmN4Vw==}
+    engines: {node: 18 || 20 || >=22}
+
+  google-auth-library@10.6.2:
+    resolution: {integrity: sha512-e27Z6EThmVNNvtYASwQxose/G57rkRuaRbQyxM2bvYLLX/GqWZ5chWq2EBoUchJbCc57eC9ArzO5wMsEmWftCw==}
+    engines: {node: '>=18'}
+
+  google-logging-utils@1.1.3:
+    resolution: {integrity: sha512-eAmLkjDjAFCVXg7A1unxHsLf961m6y17QFqXqAXGj/gVkKFrEICfStRfwUlGNfeCEjNRa32JEWOUTlYXPyyKvA==}
+    engines: {node: '>=14'}
+
+  graceful-fs@4.2.11:
+    resolution: {integrity: sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==}
+
+  has-flag@4.0.0:
+    resolution: {integrity: sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==}
+    engines: {node: '>=8'}
+
+  highlight.js@10.7.3:
+    resolution: {integrity: sha512-tzcUFauisWKNHaRkN4Wjl/ZA07gENAjFl3J/c480dprkGTg5EQstgaNFqBfUqCq54kZRIEcreTsAgF/m2quD7A==}
+
+  hosted-git-info@9.0.2:
+    resolution: {integrity: sha512-M422h7o/BR3rmCQ8UHi7cyyMqKltdP9Uo+J2fXK+RSAY+wTcKOIRyhTuKv4qn+DJf3g+PL890AzId5KZpX+CBg==}
+    engines: {node: ^20.17.0 || >=22.9.0}
+
+  http-proxy-agent@7.0.2:
+    resolution: {integrity: sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==}
+    engines: {node: '>= 14'}
+
+  https-proxy-agent@7.0.6:
+    resolution: {integrity: sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==}
+    engines: {node: '>= 14'}
+
+  ieee754@1.2.1:
+    resolution: {integrity: sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==}
+
+  ignore@7.0.5:
+    resolution: {integrity: sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg==}
+    engines: {node: '>= 4'}
+
+  ip-address@10.1.0:
+    resolution: {integrity: sha512-XXADHxXmvT9+CRxhXg56LJovE+bmWnEWB78LB83VZTprKTmaC5QfruXocxzTZ2Kl0DNwKuBdlIhjL8LeY8Sf8Q==}
+    engines: {node: '>= 12'}
+
+  is-fullwidth-code-point@3.0.0:
+    resolution: {integrity: sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==}
+    engines: {node: '>=8'}
+
+  json-bigint@1.0.0:
+    resolution: {integrity: sha512-SiPv/8VpZuWbvLSMtTDU8hEfrZWg/mH/nV/b4o0CYbSxu1UIQPLdwKOCIyLQX+VIPO5vrLX3i8qtqFyhdPSUSQ==}
+
+  json-schema-to-ts@3.1.1:
+    resolution: {integrity: sha512-+DWg8jCJG2TEnpy7kOm/7/AxaYoaRbjVB4LFZLySZlWn8exGs3A4OLJR966cVvU26N7X9TWxl+Jsw7dzAqKT6g==}
+    engines: {node: '>=16'}
+
+  json-schema-traverse@1.0.0:
+    resolution: {integrity: sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==}
+
+  jwa@2.0.1:
+    resolution: {integrity: sha512-hRF04fqJIP8Abbkq5NKGN0Bbr3JxlQ+qhZufXVr0DvujKy93ZCbXZMHDL4EOtodSbCWxOqR8MS1tXA5hwqCXDg==}
+
+  jws@4.0.1:
+    resolution: {integrity: sha512-EKI/M/yqPncGUUh44xz0PxSidXFr/+r0pA70+gIYhjv+et7yxM+s29Y+VGDkovRofQem0fs7Uvf4+YmAdyRduA==}
+
+  koffi@2.15.6:
+    resolution: {integrity: sha512-WQBpM5uo74UQ17UpsFN+PUOrQQg4/nYdey4SGVluQun2drYYfePziLLWdSmFb4wSdWlJC1aimXQnjhPCheRKuw==}
+
+  long@5.3.2:
+    resolution: {integrity: sha512-mNAgZ1GmyNhD7AuqnTG3/VQ26o760+ZYBPKjPvugO8+nLbYfX6TVpJPseBvopbdY+qpZ/lKUnmEc1LeZYS3QAA==}
+
+  lru-cache@11.3.3:
+    resolution: {integrity: sha512-JvNw9Y81y33E+BEYPr0U7omo+U9AySnsMsEiXgwT6yqd31VQWTLNQqmT4ou5eqPFUrTfIDFta2wKhB1hyohtAQ==}
+    engines: {node: 20 || >=22}
+
+  lru-cache@7.18.3:
+    resolution: {integrity: sha512-jumlc0BIUrS3qJGgIkWZsyfAM7NCWiBcCDhnd+3NNM5KbBmLTgHVfWBcg6W+rLUsIpzpERPsvwUP7CckAQSOoA==}
+    engines: {node: '>=12'}
+
+  marked@15.0.12:
+    resolution: {integrity: sha512-8dD6FusOQSrpv9Z1rdNMdlSgQOIP880DHqnohobOmYLElGEqAL/JvxvuxZO16r4HtjTlfPRDC1hbvxC9dPN2nA==}
+    engines: {node: '>= 18'}
+    hasBin: true
+
+  mime-db@1.54.0:
+    resolution: {integrity: sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==}
+    engines: {node: '>= 0.6'}
+
+  mime-types@3.0.2:
+    resolution: {integrity: sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==}
+    engines: {node: '>=18'}
+
+  minimatch@10.2.5:
+    resolution: {integrity: sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==}
+    engines: {node: 18 || 20 || >=22}
+
+  minipass@7.1.3:
+    resolution: {integrity: sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==}
+    engines: {node: '>=16 || 14 >=14.17'}
+
+  ms@2.1.3:
+    resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
+
+  mz@2.7.0:
+    resolution: {integrity: sha512-z81GNO7nnYMEhrGh9LeymoE4+Yr0Wn5McHIZMK5cfQCl+NDX08sCZgUc9/6MHni9IWuFLm1Z3HTCXu2z9fN62Q==}
+
+  netmask@2.1.1:
+    resolution: {integrity: sha512-eonl3sLUha+S1GzTPxychyhnUzKyeQkZ7jLjKrBagJgPla13F+uQ71HgpFefyHgqrjEbCPkDArxYsjY8/+gLKA==}
+    engines: {node: '>= 0.4.0'}
+
+  node-domexception@1.0.0:
+    resolution: {integrity: sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ==}
+    engines: {node: '>=10.5.0'}
+    deprecated: Use your platform's native DOMException instead
+
+  node-fetch@3.3.2:
+    resolution: {integrity: sha512-dRB78srN/l6gqWulah9SrxeYnxeddIG30+GOqK/9OlLVyLg3HPnr6SqOWTWOXKRwC2eGYCkZ59NNuSgvSrpgOA==}
+    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
+
+  object-assign@4.1.1:
+    resolution: {integrity: sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==}
+    engines: {node: '>=0.10.0'}
+
+  once@1.4.0:
+    resolution: {integrity: sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==}
+
+  openai@6.26.0:
+    resolution: {integrity: sha512-zd23dbWTjiJ6sSAX6s0HrCZi41JwTA1bQVs0wLQPZ2/5o2gxOJA5wh7yOAUgwYybfhDXyhwlpeQf7Mlgx8EOCA==}
+    hasBin: true
+    peerDependencies:
+      ws: ^8.18.0
+      zod: ^3.25 || ^4.0
+    peerDependenciesMeta:
+      ws:
+        optional: true
+      zod:
+        optional: true
+
+  p-retry@4.6.2:
+    resolution: {integrity: sha512-312Id396EbJdvRONlngUx0NydfrIQ5lsYu0znKVUzVvArzEIt08V1qhtyESbGVd1FGX7UKtiFp5uwKZdM8wIuQ==}
+    engines: {node: '>=8'}
+
+  pac-proxy-agent@7.2.0:
+    resolution: {integrity: sha512-TEB8ESquiLMc0lV8vcd5Ql/JAKAoyzHFXaStwjkzpOpC5Yv+pIzLfHvjTSdf3vpa2bMiUQrg9i6276yn8666aA==}
+    engines: {node: '>= 14'}
+
+  pac-resolver@7.0.1:
+    resolution: {integrity: sha512-5NPgf87AT2STgwa2ntRMr45jTKrYBGkVU36yT0ig/n/GMAa3oPqhZfIQ2kMEimReg0+t9kZViDVZ83qfVUlckg==}
+    engines: {node: '>= 14'}
+
+  parse5-htmlparser2-tree-adapter@6.0.1:
+    resolution: {integrity: sha512-qPuWvbLgvDGilKc5BoicRovlT4MtYT6JfJyBOMDsKoiT+GiuP5qyrPCnR9HcPECIJJmZh5jRndyNThnhhb/vlA==}
+
+  parse5@5.1.1:
+    resolution: {integrity: sha512-ugq4DFI0Ptb+WWjAdOK16+u/nHfiIrcE+sh8kZMaM0WllQKLI9rOUq6c2b7cwPkXdzfQESqvoqK6ug7U/Yyzug==}
+
+  parse5@6.0.1:
+    resolution: {integrity: sha512-Ofn/CTFzRGTTxwpNEs9PP93gXShHcTq255nzRYSKe8AkVpZY7e1fpmTfOyoIvjP5HG7Z2ZM7VS9PPhQGW2pOpw==}
+
+  partial-json@0.1.7:
+    resolution: {integrity: sha512-Njv/59hHaokb/hRUjce3Hdv12wd60MtM9Z5Olmn+nehe0QDAsRtRbJPvJ0Z91TusF0SuZRIvnM+S4l6EIP8leA==}
+
+  path-expression-matcher@1.4.0:
+    resolution: {integrity: sha512-s4DQMxIdhj3jLFWd9LxHOplj4p9yQ4ffMGowFf3cpEgrrJjEhN0V5nxw4Ye1EViAGDoL4/1AeO6qHpqYPOzE4Q==}
+    engines: {node: '>=14.0.0'}
+
+  path-scurry@2.0.2:
+    resolution: {integrity: sha512-3O/iVVsJAPsOnpwWIeD+d6z/7PmqApyQePUtCndjatj/9I5LylHvt5qluFaBT3I5h3r1ejfR056c+FCv+NnNXg==}
+    engines: {node: 18 || 20 || >=22}
+
+  pend@1.2.0:
+    resolution: {integrity: sha512-F3asv42UuXchdzt+xXqfW1OGlVBe+mxa2mqI0pg5yAHZPvFmY3Y6drSf/GQ1A86WgWEN9Kzh/WrgKa6iGcHXLg==}
 
   playwright-core@1.59.1:
     resolution: {integrity: sha512-HBV/RJg81z5BiiZ9yPzIiClYV/QMsDCKUyogwH9p3MCP6IYjUFu/MActgYAvK0oWyV9NlwM3GLBjADyWgydVyg==}
@@ -45,18 +923,1441 @@ packages:
     engines: {node: '>=18'}
     hasBin: true
 
+  proper-lockfile@4.1.2:
+    resolution: {integrity: sha512-TjNPblN4BwAWMXU8s9AEz4JmQxnD1NNL7bNOY/AKUzyamc379FWASUhc/K1pL2noVb+XmZKLL68cjzLsiOAMaA==}
+
+  protobufjs@7.5.4:
+    resolution: {integrity: sha512-CvexbZtbov6jW2eXAvLukXjXUW1TzFaivC46BpWc/3BpcCysb5Vffu+B3XHMm8lVEuy2Mm4XGex8hBSg1yapPg==}
+    engines: {node: '>=12.0.0'}
+
+  proxy-agent@6.5.0:
+    resolution: {integrity: sha512-TmatMXdr2KlRiA2CyDu8GqR8EjahTG3aY3nXjdzFyoZbmB8hrBsTyMezhULIXKnC0jpfjlmiZ3+EaCzoInSu/A==}
+    engines: {node: '>= 14'}
+
+  proxy-from-env@1.1.0:
+    resolution: {integrity: sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==}
+
+  pump@3.0.4:
+    resolution: {integrity: sha512-VS7sjc6KR7e1ukRFhQSY5LM2uBWAUPiOPa/A3mkKmiMwSmRFUITt0xuj+/lesgnCv+dPIEYlkzrcyXgquIHMcA==}
+
+  require-directory@2.1.1:
+    resolution: {integrity: sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==}
+    engines: {node: '>=0.10.0'}
+
+  require-from-string@2.0.2:
+    resolution: {integrity: sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==}
+    engines: {node: '>=0.10.0'}
+
+  retry@0.12.0:
+    resolution: {integrity: sha512-9LkiTwjUh6rT555DtE9rTX+BKByPfrMzEAtnlEtdEwr3Nkffwiihqe2bWADg+OQRjt9gl6ICdmB/ZFDCGAtSow==}
+    engines: {node: '>= 4'}
+
+  retry@0.13.1:
+    resolution: {integrity: sha512-XQBQ3I8W1Cge0Seh+6gjj03LbmRFWuoszgK9ooCpwYIrhhoO80pfq4cUkU5DkknwfOfFteRwlZ56PYOGYyFWdg==}
+    engines: {node: '>= 4'}
+
+  safe-buffer@5.2.1:
+    resolution: {integrity: sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==}
+
+  signal-exit@3.0.7:
+    resolution: {integrity: sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==}
+
+  smart-buffer@4.2.0:
+    resolution: {integrity: sha512-94hK0Hh8rPqQl2xXc3HsaBoOXKV20MToPkcXvwbISWLEs+64sBq5kFgn2kJDHb1Pry9yrP0dxrCI9RRci7RXKg==}
+    engines: {node: '>= 6.0.0', npm: '>= 3.0.0'}
+
+  socks-proxy-agent@8.0.5:
+    resolution: {integrity: sha512-HehCEsotFqbPW9sJ8WVYB6UbmIMv7kUUORIF2Nncq4VQvBfNBLibW9YZR5dlYCSUhwcD628pRllm7n+E+YTzJw==}
+    engines: {node: '>= 14'}
+
+  socks@2.8.7:
+    resolution: {integrity: sha512-HLpt+uLy/pxB+bum/9DzAgiKS8CX1EvbWxI4zlmgGCExImLdiad2iCwXT5Z4c9c3Eq8rP2318mPW2c+QbtjK8A==}
+    engines: {node: '>= 10.0.0', npm: '>= 3.0.0'}
+
+  source-map@0.6.1:
+    resolution: {integrity: sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==}
+    engines: {node: '>=0.10.0'}
+
+  std-env@3.10.0:
+    resolution: {integrity: sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==}
+
+  string-width@4.2.3:
+    resolution: {integrity: sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==}
+    engines: {node: '>=8'}
+
+  strip-ansi@6.0.1:
+    resolution: {integrity: sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==}
+    engines: {node: '>=8'}
+
+  strip-ansi@7.2.0:
+    resolution: {integrity: sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==}
+    engines: {node: '>=12'}
+
+  strnum@2.2.3:
+    resolution: {integrity: sha512-oKx6RUCuHfT3oyVjtnrmn19H1SiCqgJSg+54XqURKp5aCMbrXrhLjRN9TjuwMjiYstZ0MzDrHqkGZ5dFTKd+zg==}
+
+  strtok3@10.3.5:
+    resolution: {integrity: sha512-ki4hZQfh5rX0QDLLkOCj+h+CVNkqmp/CMf8v8kZpkNVK6jGQooMytqzLZYUVYIZcFZ6yDB70EfD8POcFXiF5oA==}
+    engines: {node: '>=18'}
+
+  supports-color@7.2.0:
+    resolution: {integrity: sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==}
+    engines: {node: '>=8'}
+
+  thenify-all@1.6.0:
+    resolution: {integrity: sha512-RNxQH/qI8/t3thXJDwcstUO4zeqo64+Uy/+sNVRBx4Xn2OX+OZ9oP+iJnNFqplFra2ZUVeKCSa2oVWi3T4uVmA==}
+    engines: {node: '>=0.8'}
+
+  thenify@3.3.1:
+    resolution: {integrity: sha512-RVZSIV5IG10Hk3enotrhvz0T9em6cyHBLkH/YAZuKqd8hRkKhSfCGIcP2KUY0EPxndzANBmNllzWPwak+bheSw==}
+
+  token-types@6.1.2:
+    resolution: {integrity: sha512-dRXchy+C0IgK8WPC6xvCHFRIWYUbqqdEIKPaKo/AcTUNzwLTK6AH7RjdLWsEZcAN/TBdtfUw3PYEgPr5VPr6ww==}
+    engines: {node: '>=14.16'}
+
+  ts-algebra@2.0.0:
+    resolution: {integrity: sha512-FPAhNPFMrkwz76P7cdjdmiShwMynZYN6SgOujD1urY4oNm80Ou9oMdmbR45LotcKOXoy7wSmHkRFE6Mxbrhefw==}
+
+  tslib@2.8.1:
+    resolution: {integrity: sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==}
+
   turndown@7.2.4:
     resolution: {integrity: sha512-I8yFsfRzmzK0WV1pNNOA4A7y4RDfFxPRxb3t+e3ui14qSGOxGtiSP6GjeX+Y6CHb7HYaFj7ECUD7VE5kQMZWGQ==}
     engines: {node: '>=18', npm: '>=9'}
 
+  uint8array-extras@1.5.0:
+    resolution: {integrity: sha512-rvKSBiC5zqCCiDZ9kAOszZcDvdAHwwIKJG33Ykj43OKcWsnmcBRL09YTU4nOeHZ8Y2a7l1MgTd08SBe9A8Qj6A==}
+    engines: {node: '>=18'}
+
+  undici-types@7.18.2:
+    resolution: {integrity: sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==}
+
+  undici@7.24.7:
+    resolution: {integrity: sha512-H/nlJ/h0ggGC+uRL3ovD+G0i4bqhvsDOpbDv7At5eFLlj2b41L8QliGbnl2H7SnDiYhENphh1tQFJZf+MyfLsQ==}
+    engines: {node: '>=20.18.1'}
+
+  web-streams-polyfill@3.3.3:
+    resolution: {integrity: sha512-d2JWLCivmZYTSIoge9MsgFCZrt571BikcWGYkjC1khllbTeDlGqZ2D8vD8E/lJa8WGWbb7Plm8/XJYV7IJHZZw==}
+    engines: {node: '>= 8'}
+
+  wrap-ansi@7.0.0:
+    resolution: {integrity: sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==}
+    engines: {node: '>=10'}
+
+  wrappy@1.0.2:
+    resolution: {integrity: sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==}
+
+  ws@8.20.0:
+    resolution: {integrity: sha512-sAt8BhgNbzCtgGbt2OxmpuryO63ZoDk/sqaB/znQm94T4fCEsy/yV+7CdC1kJhOU9lboAEU7R3kquuycDoibVA==}
+    engines: {node: '>=10.0.0'}
+    peerDependencies:
+      bufferutil: ^4.0.1
+      utf-8-validate: '>=5.0.2'
+    peerDependenciesMeta:
+      bufferutil:
+        optional: true
+      utf-8-validate:
+        optional: true
+
+  y18n@5.0.8:
+    resolution: {integrity: sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==}
+    engines: {node: '>=10'}
+
+  yaml@2.8.3:
+    resolution: {integrity: sha512-AvbaCLOO2Otw/lW5bmh9d/WEdcDFdQp2Z2ZUH3pX9U2ihyUY0nvLv7J6TrWowklRGPYbB/IuIMfYgxaCPg5Bpg==}
+    engines: {node: '>= 14.6'}
+    hasBin: true
+
+  yargs-parser@20.2.9:
+    resolution: {integrity: sha512-y11nGElTIV+CT3Zv9t7VKl+Q3hTQoT9a1Qzezhhl6Rp21gJ/IVTW7Z3y9EWXhuUBC2Shnf+DX0antecpAwSP8w==}
+    engines: {node: '>=10'}
+
+  yargs@16.2.0:
+    resolution: {integrity: sha512-D1mvvtDG0L5ft/jGWkLpG1+m0eQxOfaBvTNELraWj22wSVUMWxZUvYgJYcKh6jGGIkJFhH4IZPQhR4TKpc8mBw==}
+    engines: {node: '>=10'}
+
+  yauzl@2.10.0:
+    resolution: {integrity: sha512-p4a9I6X6nu6IhoGmBqAcbJy1mlC4j27vEPZX9F4L4/vZT3Lyq1VkFHw/V/PUcB9Buo+DG3iHkT0x3Qya58zc3g==}
+
+  yoctocolors@2.1.2:
+    resolution: {integrity: sha512-CzhO+pFNo8ajLM2d2IW/R93ipy99LWjtwblvC1RsoSUMZgyLbYFr221TnSNT7GjGdYui6P459mw9JH/g/zW2ug==}
+    engines: {node: '>=18'}
+
+  zod-to-json-schema@3.25.2:
+    resolution: {integrity: sha512-O/PgfnpT1xKSDeQYSCfRI5Gy3hPf91mKVDuYLUHZJMiDFptvP41MSnWofm8dnCm0256ZNfZIM7DSzuSMAFnjHA==}
+    peerDependencies:
+      zod: ^3.25.28 || ^4
+
+  zod@4.3.6:
+    resolution: {integrity: sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==}
+
 snapshots:
+
+  '@anthropic-ai/sdk@0.73.0(zod@4.3.6)':
+    dependencies:
+      json-schema-to-ts: 3.1.1
+    optionalDependencies:
+      zod: 4.3.6
+
+  '@aws-crypto/crc32@5.2.0':
+    dependencies:
+      '@aws-crypto/util': 5.2.0
+      '@aws-sdk/types': 3.973.7
+      tslib: 2.8.1
+
+  '@aws-crypto/sha256-browser@5.2.0':
+    dependencies:
+      '@aws-crypto/sha256-js': 5.2.0
+      '@aws-crypto/supports-web-crypto': 5.2.0
+      '@aws-crypto/util': 5.2.0
+      '@aws-sdk/types': 3.973.7
+      '@aws-sdk/util-locate-window': 3.965.5
+      '@smithy/util-utf8': 2.3.0
+      tslib: 2.8.1
+
+  '@aws-crypto/sha256-js@5.2.0':
+    dependencies:
+      '@aws-crypto/util': 5.2.0
+      '@aws-sdk/types': 3.973.7
+      tslib: 2.8.1
+
+  '@aws-crypto/supports-web-crypto@5.2.0':
+    dependencies:
+      tslib: 2.8.1
+
+  '@aws-crypto/util@5.2.0':
+    dependencies:
+      '@aws-sdk/types': 3.973.7
+      '@smithy/util-utf8': 2.3.0
+      tslib: 2.8.1
+
+  '@aws-sdk/client-bedrock-runtime@3.1027.0':
+    dependencies:
+      '@aws-crypto/sha256-browser': 5.2.0
+      '@aws-crypto/sha256-js': 5.2.0
+      '@aws-sdk/core': 3.973.27
+      '@aws-sdk/credential-provider-node': 3.972.30
+      '@aws-sdk/eventstream-handler-node': 3.972.13
+      '@aws-sdk/middleware-eventstream': 3.972.9
+      '@aws-sdk/middleware-host-header': 3.972.9
+      '@aws-sdk/middleware-logger': 3.972.9
+      '@aws-sdk/middleware-recursion-detection': 3.972.10
+      '@aws-sdk/middleware-user-agent': 3.972.29
+      '@aws-sdk/middleware-websocket': 3.972.15
+      '@aws-sdk/region-config-resolver': 3.972.11
+      '@aws-sdk/token-providers': 3.1027.0
+      '@aws-sdk/types': 3.973.7
+      '@aws-sdk/util-endpoints': 3.996.6
+      '@aws-sdk/util-user-agent-browser': 3.972.9
+      '@aws-sdk/util-user-agent-node': 3.973.15
+      '@smithy/config-resolver': 4.4.14
+      '@smithy/core': 3.23.14
+      '@smithy/eventstream-serde-browser': 4.2.13
+      '@smithy/eventstream-serde-config-resolver': 4.3.13
+      '@smithy/eventstream-serde-node': 4.2.13
+      '@smithy/fetch-http-handler': 5.3.16
+      '@smithy/hash-node': 4.2.13
+      '@smithy/invalid-dependency': 4.2.13
+      '@smithy/middleware-content-length': 4.2.13
+      '@smithy/middleware-endpoint': 4.4.29
+      '@smithy/middleware-retry': 4.5.0
+      '@smithy/middleware-serde': 4.2.17
+      '@smithy/middleware-stack': 4.2.13
+      '@smithy/node-config-provider': 4.3.13
+      '@smithy/node-http-handler': 4.5.2
+      '@smithy/protocol-http': 5.3.13
+      '@smithy/smithy-client': 4.12.9
+      '@smithy/types': 4.14.0
+      '@smithy/url-parser': 4.2.13
+      '@smithy/util-base64': 4.3.2
+      '@smithy/util-body-length-browser': 4.2.2
+      '@smithy/util-body-length-node': 4.2.3
+      '@smithy/util-defaults-mode-browser': 4.3.45
+      '@smithy/util-defaults-mode-node': 4.2.49
+      '@smithy/util-endpoints': 3.3.4
+      '@smithy/util-middleware': 4.2.13
+      '@smithy/util-retry': 4.3.0
+      '@smithy/util-stream': 4.5.22
+      '@smithy/util-utf8': 4.2.2
+      tslib: 2.8.1
+    transitivePeerDependencies:
+      - aws-crt
+
+  '@aws-sdk/core@3.973.27':
+    dependencies:
+      '@aws-sdk/types': 3.973.7
+      '@aws-sdk/xml-builder': 3.972.17
+      '@smithy/core': 3.23.14
+      '@smithy/node-config-provider': 4.3.13
+      '@smithy/property-provider': 4.2.13
+      '@smithy/protocol-http': 5.3.13
+      '@smithy/signature-v4': 5.3.13
+      '@smithy/smithy-client': 4.12.9
+      '@smithy/types': 4.14.0
+      '@smithy/util-base64': 4.3.2
+      '@smithy/util-middleware': 4.2.13
+      '@smithy/util-utf8': 4.2.2
+      tslib: 2.8.1
+
+  '@aws-sdk/credential-provider-env@3.972.25':
+    dependencies:
+      '@aws-sdk/core': 3.973.27
+      '@aws-sdk/types': 3.973.7
+      '@smithy/property-provider': 4.2.13
+      '@smithy/types': 4.14.0
+      tslib: 2.8.1
+
+  '@aws-sdk/credential-provider-http@3.972.27':
+    dependencies:
+      '@aws-sdk/core': 3.973.27
+      '@aws-sdk/types': 3.973.7
+      '@smithy/fetch-http-handler': 5.3.16
+      '@smithy/node-http-handler': 4.5.2
+      '@smithy/property-provider': 4.2.13
+      '@smithy/protocol-http': 5.3.13
+      '@smithy/smithy-client': 4.12.9
+      '@smithy/types': 4.14.0
+      '@smithy/util-stream': 4.5.22
+      tslib: 2.8.1
+
+  '@aws-sdk/credential-provider-ini@3.972.29':
+    dependencies:
+      '@aws-sdk/core': 3.973.27
+      '@aws-sdk/credential-provider-env': 3.972.25
+      '@aws-sdk/credential-provider-http': 3.972.27
+      '@aws-sdk/credential-provider-login': 3.972.29
+      '@aws-sdk/credential-provider-process': 3.972.25
+      '@aws-sdk/credential-provider-sso': 3.972.29
+      '@aws-sdk/credential-provider-web-identity': 3.972.29
+      '@aws-sdk/nested-clients': 3.996.19
+      '@aws-sdk/types': 3.973.7
+      '@smithy/credential-provider-imds': 4.2.13
+      '@smithy/property-provider': 4.2.13
+      '@smithy/shared-ini-file-loader': 4.4.8
+      '@smithy/types': 4.14.0
+      tslib: 2.8.1
+    transitivePeerDependencies:
+      - aws-crt
+
+  '@aws-sdk/credential-provider-login@3.972.29':
+    dependencies:
+      '@aws-sdk/core': 3.973.27
+      '@aws-sdk/nested-clients': 3.996.19
+      '@aws-sdk/types': 3.973.7
+      '@smithy/property-provider': 4.2.13
+      '@smithy/protocol-http': 5.3.13
+      '@smithy/shared-ini-file-loader': 4.4.8
+      '@smithy/types': 4.14.0
+      tslib: 2.8.1
+    transitivePeerDependencies:
+      - aws-crt
+
+  '@aws-sdk/credential-provider-node@3.972.30':
+    dependencies:
+      '@aws-sdk/credential-provider-env': 3.972.25
+      '@aws-sdk/credential-provider-http': 3.972.27
+      '@aws-sdk/credential-provider-ini': 3.972.29
+      '@aws-sdk/credential-provider-process': 3.972.25
+      '@aws-sdk/credential-provider-sso': 3.972.29
+      '@aws-sdk/credential-provider-web-identity': 3.972.29
+      '@aws-sdk/types': 3.973.7
+      '@smithy/credential-provider-imds': 4.2.13
+      '@smithy/property-provider': 4.2.13
+      '@smithy/shared-ini-file-loader': 4.4.8
+      '@smithy/types': 4.14.0
+      tslib: 2.8.1
+    transitivePeerDependencies:
+      - aws-crt
+
+  '@aws-sdk/credential-provider-process@3.972.25':
+    dependencies:
+      '@aws-sdk/core': 3.973.27
+      '@aws-sdk/types': 3.973.7
+      '@smithy/property-provider': 4.2.13
+      '@smithy/shared-ini-file-loader': 4.4.8
+      '@smithy/types': 4.14.0
+      tslib: 2.8.1
+
+  '@aws-sdk/credential-provider-sso@3.972.29':
+    dependencies:
+      '@aws-sdk/core': 3.973.27
+      '@aws-sdk/nested-clients': 3.996.19
+      '@aws-sdk/token-providers': 3.1026.0
+      '@aws-sdk/types': 3.973.7
+      '@smithy/property-provider': 4.2.13
+      '@smithy/shared-ini-file-loader': 4.4.8
+      '@smithy/types': 4.14.0
+      tslib: 2.8.1
+    transitivePeerDependencies:
+      - aws-crt
+
+  '@aws-sdk/credential-provider-web-identity@3.972.29':
+    dependencies:
+      '@aws-sdk/core': 3.973.27
+      '@aws-sdk/nested-clients': 3.996.19
+      '@aws-sdk/types': 3.973.7
+      '@smithy/property-provider': 4.2.13
+      '@smithy/shared-ini-file-loader': 4.4.8
+      '@smithy/types': 4.14.0
+      tslib: 2.8.1
+    transitivePeerDependencies:
+      - aws-crt
+
+  '@aws-sdk/eventstream-handler-node@3.972.13':
+    dependencies:
+      '@aws-sdk/types': 3.973.7
+      '@smithy/eventstream-codec': 4.2.13
+      '@smithy/types': 4.14.0
+      tslib: 2.8.1
+
+  '@aws-sdk/middleware-eventstream@3.972.9':
+    dependencies:
+      '@aws-sdk/types': 3.973.7
+      '@smithy/protocol-http': 5.3.13
+      '@smithy/types': 4.14.0
+      tslib: 2.8.1
+
+  '@aws-sdk/middleware-host-header@3.972.9':
+    dependencies:
+      '@aws-sdk/types': 3.973.7
+      '@smithy/protocol-http': 5.3.13
+      '@smithy/types': 4.14.0
+      tslib: 2.8.1
+
+  '@aws-sdk/middleware-logger@3.972.9':
+    dependencies:
+      '@aws-sdk/types': 3.973.7
+      '@smithy/types': 4.14.0
+      tslib: 2.8.1
+
+  '@aws-sdk/middleware-recursion-detection@3.972.10':
+    dependencies:
+      '@aws-sdk/types': 3.973.7
+      '@aws/lambda-invoke-store': 0.2.4
+      '@smithy/protocol-http': 5.3.13
+      '@smithy/types': 4.14.0
+      tslib: 2.8.1
+
+  '@aws-sdk/middleware-user-agent@3.972.29':
+    dependencies:
+      '@aws-sdk/core': 3.973.27
+      '@aws-sdk/types': 3.973.7
+      '@aws-sdk/util-endpoints': 3.996.6
+      '@smithy/core': 3.23.14
+      '@smithy/protocol-http': 5.3.13
+      '@smithy/types': 4.14.0
+      '@smithy/util-retry': 4.3.0
+      tslib: 2.8.1
+
+  '@aws-sdk/middleware-websocket@3.972.15':
+    dependencies:
+      '@aws-sdk/types': 3.973.7
+      '@aws-sdk/util-format-url': 3.972.9
+      '@smithy/eventstream-codec': 4.2.13
+      '@smithy/eventstream-serde-browser': 4.2.13
+      '@smithy/fetch-http-handler': 5.3.16
+      '@smithy/protocol-http': 5.3.13
+      '@smithy/signature-v4': 5.3.13
+      '@smithy/types': 4.14.0
+      '@smithy/util-base64': 4.3.2
+      '@smithy/util-hex-encoding': 4.2.2
+      '@smithy/util-utf8': 4.2.2
+      tslib: 2.8.1
+
+  '@aws-sdk/nested-clients@3.996.19':
+    dependencies:
+      '@aws-crypto/sha256-browser': 5.2.0
+      '@aws-crypto/sha256-js': 5.2.0
+      '@aws-sdk/core': 3.973.27
+      '@aws-sdk/middleware-host-header': 3.972.9
+      '@aws-sdk/middleware-logger': 3.972.9
+      '@aws-sdk/middleware-recursion-detection': 3.972.10
+      '@aws-sdk/middleware-user-agent': 3.972.29
+      '@aws-sdk/region-config-resolver': 3.972.11
+      '@aws-sdk/types': 3.973.7
+      '@aws-sdk/util-endpoints': 3.996.6
+      '@aws-sdk/util-user-agent-browser': 3.972.9
+      '@aws-sdk/util-user-agent-node': 3.973.15
+      '@smithy/config-resolver': 4.4.14
+      '@smithy/core': 3.23.14
+      '@smithy/fetch-http-handler': 5.3.16
+      '@smithy/hash-node': 4.2.13
+      '@smithy/invalid-dependency': 4.2.13
+      '@smithy/middleware-content-length': 4.2.13
+      '@smithy/middleware-endpoint': 4.4.29
+      '@smithy/middleware-retry': 4.5.0
+      '@smithy/middleware-serde': 4.2.17
+      '@smithy/middleware-stack': 4.2.13
+      '@smithy/node-config-provider': 4.3.13
+      '@smithy/node-http-handler': 4.5.2
+      '@smithy/protocol-http': 5.3.13
+      '@smithy/smithy-client': 4.12.9
+      '@smithy/types': 4.14.0
+      '@smithy/url-parser': 4.2.13
+      '@smithy/util-base64': 4.3.2
+      '@smithy/util-body-length-browser': 4.2.2
+      '@smithy/util-body-length-node': 4.2.3
+      '@smithy/util-defaults-mode-browser': 4.3.45
+      '@smithy/util-defaults-mode-node': 4.2.49
+      '@smithy/util-endpoints': 3.3.4
+      '@smithy/util-middleware': 4.2.13
+      '@smithy/util-retry': 4.3.0
+      '@smithy/util-utf8': 4.2.2
+      tslib: 2.8.1
+    transitivePeerDependencies:
+      - aws-crt
+
+  '@aws-sdk/region-config-resolver@3.972.11':
+    dependencies:
+      '@aws-sdk/types': 3.973.7
+      '@smithy/config-resolver': 4.4.14
+      '@smithy/node-config-provider': 4.3.13
+      '@smithy/types': 4.14.0
+      tslib: 2.8.1
+
+  '@aws-sdk/token-providers@3.1026.0':
+    dependencies:
+      '@aws-sdk/core': 3.973.27
+      '@aws-sdk/nested-clients': 3.996.19
+      '@aws-sdk/types': 3.973.7
+      '@smithy/property-provider': 4.2.13
+      '@smithy/shared-ini-file-loader': 4.4.8
+      '@smithy/types': 4.14.0
+      tslib: 2.8.1
+    transitivePeerDependencies:
+      - aws-crt
+
+  '@aws-sdk/token-providers@3.1027.0':
+    dependencies:
+      '@aws-sdk/core': 3.973.27
+      '@aws-sdk/nested-clients': 3.996.19
+      '@aws-sdk/types': 3.973.7
+      '@smithy/property-provider': 4.2.13
+      '@smithy/shared-ini-file-loader': 4.4.8
+      '@smithy/types': 4.14.0
+      tslib: 2.8.1
+    transitivePeerDependencies:
+      - aws-crt
+
+  '@aws-sdk/types@3.973.7':
+    dependencies:
+      '@smithy/types': 4.14.0
+      tslib: 2.8.1
+
+  '@aws-sdk/util-endpoints@3.996.6':
+    dependencies:
+      '@aws-sdk/types': 3.973.7
+      '@smithy/types': 4.14.0
+      '@smithy/url-parser': 4.2.13
+      '@smithy/util-endpoints': 3.3.4
+      tslib: 2.8.1
+
+  '@aws-sdk/util-format-url@3.972.9':
+    dependencies:
+      '@aws-sdk/types': 3.973.7
+      '@smithy/querystring-builder': 4.2.13
+      '@smithy/types': 4.14.0
+      tslib: 2.8.1
+
+  '@aws-sdk/util-locate-window@3.965.5':
+    dependencies:
+      tslib: 2.8.1
+
+  '@aws-sdk/util-user-agent-browser@3.972.9':
+    dependencies:
+      '@aws-sdk/types': 3.973.7
+      '@smithy/types': 4.14.0
+      bowser: 2.14.1
+      tslib: 2.8.1
+
+  '@aws-sdk/util-user-agent-node@3.973.15':
+    dependencies:
+      '@aws-sdk/middleware-user-agent': 3.972.29
+      '@aws-sdk/types': 3.973.7
+      '@smithy/node-config-provider': 4.3.13
+      '@smithy/types': 4.14.0
+      '@smithy/util-config-provider': 4.2.2
+      tslib: 2.8.1
+
+  '@aws-sdk/xml-builder@3.972.17':
+    dependencies:
+      '@smithy/types': 4.14.0
+      fast-xml-parser: 5.5.8
+      tslib: 2.8.1
+
+  '@aws/lambda-invoke-store@0.2.4': {}
+
+  '@babel/runtime@7.29.2': {}
+
+  '@borewit/text-codec@0.2.2': {}
+
+  '@google/genai@1.49.0':
+    dependencies:
+      google-auth-library: 10.6.2
+      p-retry: 4.6.2
+      protobufjs: 7.5.4
+      ws: 8.20.0
+    transitivePeerDependencies:
+      - bufferutil
+      - supports-color
+      - utf-8-validate
+
+  '@mariozechner/clipboard-darwin-arm64@0.3.2':
+    optional: true
+
+  '@mariozechner/clipboard-darwin-universal@0.3.2':
+    optional: true
+
+  '@mariozechner/clipboard-darwin-x64@0.3.2':
+    optional: true
+
+  '@mariozechner/clipboard-linux-arm64-gnu@0.3.2':
+    optional: true
+
+  '@mariozechner/clipboard-linux-arm64-musl@0.3.2':
+    optional: true
+
+  '@mariozechner/clipboard-linux-riscv64-gnu@0.3.2':
+    optional: true
+
+  '@mariozechner/clipboard-linux-x64-gnu@0.3.2':
+    optional: true
+
+  '@mariozechner/clipboard-linux-x64-musl@0.3.2':
+    optional: true
+
+  '@mariozechner/clipboard-win32-arm64-msvc@0.3.2':
+    optional: true
+
+  '@mariozechner/clipboard-win32-x64-msvc@0.3.2':
+    optional: true
+
+  '@mariozechner/clipboard@0.3.2':
+    optionalDependencies:
+      '@mariozechner/clipboard-darwin-arm64': 0.3.2
+      '@mariozechner/clipboard-darwin-universal': 0.3.2
+      '@mariozechner/clipboard-darwin-x64': 0.3.2
+      '@mariozechner/clipboard-linux-arm64-gnu': 0.3.2
+      '@mariozechner/clipboard-linux-arm64-musl': 0.3.2
+      '@mariozechner/clipboard-linux-riscv64-gnu': 0.3.2
+      '@mariozechner/clipboard-linux-x64-gnu': 0.3.2
+      '@mariozechner/clipboard-linux-x64-musl': 0.3.2
+      '@mariozechner/clipboard-win32-arm64-msvc': 0.3.2
+      '@mariozechner/clipboard-win32-x64-msvc': 0.3.2
+    optional: true
+
+  '@mariozechner/jiti@2.6.5':
+    dependencies:
+      std-env: 3.10.0
+      yoctocolors: 2.1.2
+
+  '@mariozechner/pi-agent-core@0.65.2(ws@8.20.0)(zod@4.3.6)':
+    dependencies:
+      '@mariozechner/pi-ai': 0.65.2(ws@8.20.0)(zod@4.3.6)
+    transitivePeerDependencies:
+      - '@modelcontextprotocol/sdk'
+      - aws-crt
+      - bufferutil
+      - supports-color
+      - utf-8-validate
+      - ws
+      - zod
+
+  '@mariozechner/pi-ai@0.65.2(ws@8.20.0)(zod@4.3.6)':
+    dependencies:
+      '@anthropic-ai/sdk': 0.73.0(zod@4.3.6)
+      '@aws-sdk/client-bedrock-runtime': 3.1027.0
+      '@google/genai': 1.49.0
+      '@mistralai/mistralai': 1.14.1
+      '@sinclair/typebox': 0.34.49
+      ajv: 8.18.0
+      ajv-formats: 3.0.1(ajv@8.18.0)
+      chalk: 5.6.2
+      openai: 6.26.0(ws@8.20.0)(zod@4.3.6)
+      partial-json: 0.1.7
+      proxy-agent: 6.5.0
+      undici: 7.24.7
+      zod-to-json-schema: 3.25.2(zod@4.3.6)
+    transitivePeerDependencies:
+      - '@modelcontextprotocol/sdk'
+      - aws-crt
+      - bufferutil
+      - supports-color
+      - utf-8-validate
+      - ws
+      - zod
+
+  '@mariozechner/pi-coding-agent@0.65.2(ws@8.20.0)(zod@4.3.6)':
+    dependencies:
+      '@mariozechner/jiti': 2.6.5
+      '@mariozechner/pi-agent-core': 0.65.2(ws@8.20.0)(zod@4.3.6)
+      '@mariozechner/pi-ai': 0.65.2(ws@8.20.0)(zod@4.3.6)
+      '@mariozechner/pi-tui': 0.65.2
+      '@silvia-odwyer/photon-node': 0.3.4
+      ajv: 8.18.0
+      chalk: 5.6.2
+      cli-highlight: 2.1.11
+      diff: 8.0.4
+      extract-zip: 2.0.1
+      file-type: 21.3.4
+      glob: 13.0.6
+      hosted-git-info: 9.0.2
+      ignore: 7.0.5
+      marked: 15.0.12
+      minimatch: 10.2.5
+      proper-lockfile: 4.1.2
+      strip-ansi: 7.2.0
+      undici: 7.24.7
+      yaml: 2.8.3
+    optionalDependencies:
+      '@mariozechner/clipboard': 0.3.2
+    transitivePeerDependencies:
+      - '@modelcontextprotocol/sdk'
+      - aws-crt
+      - bufferutil
+      - supports-color
+      - utf-8-validate
+      - ws
+      - zod
+
+  '@mariozechner/pi-tui@0.65.2':
+    dependencies:
+      '@types/mime-types': 2.1.4
+      chalk: 5.6.2
+      get-east-asian-width: 1.5.0
+      marked: 15.0.12
+      mime-types: 3.0.2
+    optionalDependencies:
+      koffi: 2.15.6
+
+  '@mistralai/mistralai@1.14.1':
+    dependencies:
+      ws: 8.20.0
+      zod: 4.3.6
+      zod-to-json-schema: 3.25.2(zod@4.3.6)
+    transitivePeerDependencies:
+      - bufferutil
+      - utf-8-validate
 
   '@mixmark-io/domino@2.2.0': {}
 
+  '@protobufjs/aspromise@1.1.2': {}
+
+  '@protobufjs/base64@1.1.2': {}
+
+  '@protobufjs/codegen@2.0.4': {}
+
+  '@protobufjs/eventemitter@1.1.0': {}
+
+  '@protobufjs/fetch@1.1.0':
+    dependencies:
+      '@protobufjs/aspromise': 1.1.2
+      '@protobufjs/inquire': 1.1.0
+
+  '@protobufjs/float@1.0.2': {}
+
+  '@protobufjs/inquire@1.1.0': {}
+
+  '@protobufjs/path@1.1.2': {}
+
+  '@protobufjs/pool@1.1.0': {}
+
+  '@protobufjs/utf8@1.1.0': {}
+
+  '@silvia-odwyer/photon-node@0.3.4': {}
+
+  '@sinclair/typebox@0.34.49': {}
+
+  '@smithy/config-resolver@4.4.14':
+    dependencies:
+      '@smithy/node-config-provider': 4.3.13
+      '@smithy/types': 4.14.0
+      '@smithy/util-config-provider': 4.2.2
+      '@smithy/util-endpoints': 3.3.4
+      '@smithy/util-middleware': 4.2.13
+      tslib: 2.8.1
+
+  '@smithy/core@3.23.14':
+    dependencies:
+      '@smithy/protocol-http': 5.3.13
+      '@smithy/types': 4.14.0
+      '@smithy/url-parser': 4.2.13
+      '@smithy/util-base64': 4.3.2
+      '@smithy/util-body-length-browser': 4.2.2
+      '@smithy/util-middleware': 4.2.13
+      '@smithy/util-stream': 4.5.22
+      '@smithy/util-utf8': 4.2.2
+      '@smithy/uuid': 1.1.2
+      tslib: 2.8.1
+
+  '@smithy/credential-provider-imds@4.2.13':
+    dependencies:
+      '@smithy/node-config-provider': 4.3.13
+      '@smithy/property-provider': 4.2.13
+      '@smithy/types': 4.14.0
+      '@smithy/url-parser': 4.2.13
+      tslib: 2.8.1
+
+  '@smithy/eventstream-codec@4.2.13':
+    dependencies:
+      '@aws-crypto/crc32': 5.2.0
+      '@smithy/types': 4.14.0
+      '@smithy/util-hex-encoding': 4.2.2
+      tslib: 2.8.1
+
+  '@smithy/eventstream-serde-browser@4.2.13':
+    dependencies:
+      '@smithy/eventstream-serde-universal': 4.2.13
+      '@smithy/types': 4.14.0
+      tslib: 2.8.1
+
+  '@smithy/eventstream-serde-config-resolver@4.3.13':
+    dependencies:
+      '@smithy/types': 4.14.0
+      tslib: 2.8.1
+
+  '@smithy/eventstream-serde-node@4.2.13':
+    dependencies:
+      '@smithy/eventstream-serde-universal': 4.2.13
+      '@smithy/types': 4.14.0
+      tslib: 2.8.1
+
+  '@smithy/eventstream-serde-universal@4.2.13':
+    dependencies:
+      '@smithy/eventstream-codec': 4.2.13
+      '@smithy/types': 4.14.0
+      tslib: 2.8.1
+
+  '@smithy/fetch-http-handler@5.3.16':
+    dependencies:
+      '@smithy/protocol-http': 5.3.13
+      '@smithy/querystring-builder': 4.2.13
+      '@smithy/types': 4.14.0
+      '@smithy/util-base64': 4.3.2
+      tslib: 2.8.1
+
+  '@smithy/hash-node@4.2.13':
+    dependencies:
+      '@smithy/types': 4.14.0
+      '@smithy/util-buffer-from': 4.2.2
+      '@smithy/util-utf8': 4.2.2
+      tslib: 2.8.1
+
+  '@smithy/invalid-dependency@4.2.13':
+    dependencies:
+      '@smithy/types': 4.14.0
+      tslib: 2.8.1
+
+  '@smithy/is-array-buffer@2.2.0':
+    dependencies:
+      tslib: 2.8.1
+
+  '@smithy/is-array-buffer@4.2.2':
+    dependencies:
+      tslib: 2.8.1
+
+  '@smithy/middleware-content-length@4.2.13':
+    dependencies:
+      '@smithy/protocol-http': 5.3.13
+      '@smithy/types': 4.14.0
+      tslib: 2.8.1
+
+  '@smithy/middleware-endpoint@4.4.29':
+    dependencies:
+      '@smithy/core': 3.23.14
+      '@smithy/middleware-serde': 4.2.17
+      '@smithy/node-config-provider': 4.3.13
+      '@smithy/shared-ini-file-loader': 4.4.8
+      '@smithy/types': 4.14.0
+      '@smithy/url-parser': 4.2.13
+      '@smithy/util-middleware': 4.2.13
+      tslib: 2.8.1
+
+  '@smithy/middleware-retry@4.5.0':
+    dependencies:
+      '@smithy/core': 3.23.14
+      '@smithy/node-config-provider': 4.3.13
+      '@smithy/protocol-http': 5.3.13
+      '@smithy/service-error-classification': 4.2.13
+      '@smithy/smithy-client': 4.12.9
+      '@smithy/types': 4.14.0
+      '@smithy/util-middleware': 4.2.13
+      '@smithy/util-retry': 4.3.0
+      '@smithy/uuid': 1.1.2
+      tslib: 2.8.1
+
+  '@smithy/middleware-serde@4.2.17':
+    dependencies:
+      '@smithy/core': 3.23.14
+      '@smithy/protocol-http': 5.3.13
+      '@smithy/types': 4.14.0
+      tslib: 2.8.1
+
+  '@smithy/middleware-stack@4.2.13':
+    dependencies:
+      '@smithy/types': 4.14.0
+      tslib: 2.8.1
+
+  '@smithy/node-config-provider@4.3.13':
+    dependencies:
+      '@smithy/property-provider': 4.2.13
+      '@smithy/shared-ini-file-loader': 4.4.8
+      '@smithy/types': 4.14.0
+      tslib: 2.8.1
+
+  '@smithy/node-http-handler@4.5.2':
+    dependencies:
+      '@smithy/protocol-http': 5.3.13
+      '@smithy/querystring-builder': 4.2.13
+      '@smithy/types': 4.14.0
+      tslib: 2.8.1
+
+  '@smithy/property-provider@4.2.13':
+    dependencies:
+      '@smithy/types': 4.14.0
+      tslib: 2.8.1
+
+  '@smithy/protocol-http@5.3.13':
+    dependencies:
+      '@smithy/types': 4.14.0
+      tslib: 2.8.1
+
+  '@smithy/querystring-builder@4.2.13':
+    dependencies:
+      '@smithy/types': 4.14.0
+      '@smithy/util-uri-escape': 4.2.2
+      tslib: 2.8.1
+
+  '@smithy/querystring-parser@4.2.13':
+    dependencies:
+      '@smithy/types': 4.14.0
+      tslib: 2.8.1
+
+  '@smithy/service-error-classification@4.2.13':
+    dependencies:
+      '@smithy/types': 4.14.0
+
+  '@smithy/shared-ini-file-loader@4.4.8':
+    dependencies:
+      '@smithy/types': 4.14.0
+      tslib: 2.8.1
+
+  '@smithy/signature-v4@5.3.13':
+    dependencies:
+      '@smithy/is-array-buffer': 4.2.2
+      '@smithy/protocol-http': 5.3.13
+      '@smithy/types': 4.14.0
+      '@smithy/util-hex-encoding': 4.2.2
+      '@smithy/util-middleware': 4.2.13
+      '@smithy/util-uri-escape': 4.2.2
+      '@smithy/util-utf8': 4.2.2
+      tslib: 2.8.1
+
+  '@smithy/smithy-client@4.12.9':
+    dependencies:
+      '@smithy/core': 3.23.14
+      '@smithy/middleware-endpoint': 4.4.29
+      '@smithy/middleware-stack': 4.2.13
+      '@smithy/protocol-http': 5.3.13
+      '@smithy/types': 4.14.0
+      '@smithy/util-stream': 4.5.22
+      tslib: 2.8.1
+
+  '@smithy/types@4.14.0':
+    dependencies:
+      tslib: 2.8.1
+
+  '@smithy/url-parser@4.2.13':
+    dependencies:
+      '@smithy/querystring-parser': 4.2.13
+      '@smithy/types': 4.14.0
+      tslib: 2.8.1
+
+  '@smithy/util-base64@4.3.2':
+    dependencies:
+      '@smithy/util-buffer-from': 4.2.2
+      '@smithy/util-utf8': 4.2.2
+      tslib: 2.8.1
+
+  '@smithy/util-body-length-browser@4.2.2':
+    dependencies:
+      tslib: 2.8.1
+
+  '@smithy/util-body-length-node@4.2.3':
+    dependencies:
+      tslib: 2.8.1
+
+  '@smithy/util-buffer-from@2.2.0':
+    dependencies:
+      '@smithy/is-array-buffer': 2.2.0
+      tslib: 2.8.1
+
+  '@smithy/util-buffer-from@4.2.2':
+    dependencies:
+      '@smithy/is-array-buffer': 4.2.2
+      tslib: 2.8.1
+
+  '@smithy/util-config-provider@4.2.2':
+    dependencies:
+      tslib: 2.8.1
+
+  '@smithy/util-defaults-mode-browser@4.3.45':
+    dependencies:
+      '@smithy/property-provider': 4.2.13
+      '@smithy/smithy-client': 4.12.9
+      '@smithy/types': 4.14.0
+      tslib: 2.8.1
+
+  '@smithy/util-defaults-mode-node@4.2.49':
+    dependencies:
+      '@smithy/config-resolver': 4.4.14
+      '@smithy/credential-provider-imds': 4.2.13
+      '@smithy/node-config-provider': 4.3.13
+      '@smithy/property-provider': 4.2.13
+      '@smithy/smithy-client': 4.12.9
+      '@smithy/types': 4.14.0
+      tslib: 2.8.1
+
+  '@smithy/util-endpoints@3.3.4':
+    dependencies:
+      '@smithy/node-config-provider': 4.3.13
+      '@smithy/types': 4.14.0
+      tslib: 2.8.1
+
+  '@smithy/util-hex-encoding@4.2.2':
+    dependencies:
+      tslib: 2.8.1
+
+  '@smithy/util-middleware@4.2.13':
+    dependencies:
+      '@smithy/types': 4.14.0
+      tslib: 2.8.1
+
+  '@smithy/util-retry@4.3.0':
+    dependencies:
+      '@smithy/service-error-classification': 4.2.13
+      '@smithy/types': 4.14.0
+      tslib: 2.8.1
+
+  '@smithy/util-stream@4.5.22':
+    dependencies:
+      '@smithy/fetch-http-handler': 5.3.16
+      '@smithy/node-http-handler': 4.5.2
+      '@smithy/types': 4.14.0
+      '@smithy/util-base64': 4.3.2
+      '@smithy/util-buffer-from': 4.2.2
+      '@smithy/util-hex-encoding': 4.2.2
+      '@smithy/util-utf8': 4.2.2
+      tslib: 2.8.1
+
+  '@smithy/util-uri-escape@4.2.2':
+    dependencies:
+      tslib: 2.8.1
+
+  '@smithy/util-utf8@2.3.0':
+    dependencies:
+      '@smithy/util-buffer-from': 2.2.0
+      tslib: 2.8.1
+
+  '@smithy/util-utf8@4.2.2':
+    dependencies:
+      '@smithy/util-buffer-from': 4.2.2
+      tslib: 2.8.1
+
+  '@smithy/uuid@1.1.2':
+    dependencies:
+      tslib: 2.8.1
+
+  '@tokenizer/inflate@0.4.1':
+    dependencies:
+      debug: 4.4.3
+      token-types: 6.1.2
+    transitivePeerDependencies:
+      - supports-color
+
+  '@tokenizer/token@0.3.0': {}
+
+  '@tootallnate/quickjs-emscripten@0.23.0': {}
+
+  '@types/mime-types@2.1.4': {}
+
+  '@types/node@25.5.2':
+    dependencies:
+      undici-types: 7.18.2
+
+  '@types/retry@0.12.0': {}
+
   '@types/turndown@5.0.6': {}
+
+  '@types/yauzl@2.10.3':
+    dependencies:
+      '@types/node': 25.5.2
+    optional: true
+
+  agent-base@7.1.4: {}
+
+  ajv-formats@3.0.1(ajv@8.18.0):
+    optionalDependencies:
+      ajv: 8.18.0
+
+  ajv@8.18.0:
+    dependencies:
+      fast-deep-equal: 3.1.3
+      fast-uri: 3.1.0
+      json-schema-traverse: 1.0.0
+      require-from-string: 2.0.2
+
+  ansi-regex@5.0.1: {}
+
+  ansi-regex@6.2.2: {}
+
+  ansi-styles@4.3.0:
+    dependencies:
+      color-convert: 2.0.1
+
+  any-promise@1.3.0: {}
+
+  ast-types@0.13.4:
+    dependencies:
+      tslib: 2.8.1
+
+  balanced-match@4.0.4: {}
+
+  base64-js@1.5.1: {}
+
+  basic-ftp@5.2.1: {}
+
+  bignumber.js@9.3.1: {}
+
+  bowser@2.14.1: {}
+
+  brace-expansion@5.0.5:
+    dependencies:
+      balanced-match: 4.0.4
+
+  buffer-crc32@0.2.13: {}
+
+  buffer-equal-constant-time@1.0.1: {}
+
+  chalk@4.1.2:
+    dependencies:
+      ansi-styles: 4.3.0
+      supports-color: 7.2.0
+
+  chalk@5.6.2: {}
+
+  cli-highlight@2.1.11:
+    dependencies:
+      chalk: 4.1.2
+      highlight.js: 10.7.3
+      mz: 2.7.0
+      parse5: 5.1.1
+      parse5-htmlparser2-tree-adapter: 6.0.1
+      yargs: 16.2.0
+
+  cliui@7.0.4:
+    dependencies:
+      string-width: 4.2.3
+      strip-ansi: 6.0.1
+      wrap-ansi: 7.0.0
+
+  color-convert@2.0.1:
+    dependencies:
+      color-name: 1.1.4
+
+  color-name@1.1.4: {}
+
+  data-uri-to-buffer@4.0.1: {}
+
+  data-uri-to-buffer@6.0.2: {}
+
+  debug@4.4.3:
+    dependencies:
+      ms: 2.1.3
+
+  degenerator@5.0.1:
+    dependencies:
+      ast-types: 0.13.4
+      escodegen: 2.1.0
+      esprima: 4.0.1
+
+  diff@8.0.4: {}
+
+  ecdsa-sig-formatter@1.0.11:
+    dependencies:
+      safe-buffer: 5.2.1
+
+  emoji-regex@8.0.0: {}
+
+  end-of-stream@1.4.5:
+    dependencies:
+      once: 1.4.0
+
+  escalade@3.2.0: {}
+
+  escodegen@2.1.0:
+    dependencies:
+      esprima: 4.0.1
+      estraverse: 5.3.0
+      esutils: 2.0.3
+    optionalDependencies:
+      source-map: 0.6.1
+
+  esprima@4.0.1: {}
+
+  estraverse@5.3.0: {}
+
+  esutils@2.0.3: {}
+
+  extend@3.0.2: {}
+
+  extract-zip@2.0.1:
+    dependencies:
+      debug: 4.4.3
+      get-stream: 5.2.0
+      yauzl: 2.10.0
+    optionalDependencies:
+      '@types/yauzl': 2.10.3
+    transitivePeerDependencies:
+      - supports-color
+
+  fast-deep-equal@3.1.3: {}
+
+  fast-uri@3.1.0: {}
+
+  fast-xml-builder@1.1.4:
+    dependencies:
+      path-expression-matcher: 1.4.0
+
+  fast-xml-parser@5.5.8:
+    dependencies:
+      fast-xml-builder: 1.1.4
+      path-expression-matcher: 1.4.0
+      strnum: 2.2.3
+
+  fd-slicer@1.1.0:
+    dependencies:
+      pend: 1.2.0
+
+  fetch-blob@3.2.0:
+    dependencies:
+      node-domexception: 1.0.0
+      web-streams-polyfill: 3.3.3
+
+  file-type@21.3.4:
+    dependencies:
+      '@tokenizer/inflate': 0.4.1
+      strtok3: 10.3.5
+      token-types: 6.1.2
+      uint8array-extras: 1.5.0
+    transitivePeerDependencies:
+      - supports-color
+
+  formdata-polyfill@4.0.10:
+    dependencies:
+      fetch-blob: 3.2.0
 
   fsevents@2.3.2:
     optional: true
+
+  gaxios@7.1.4:
+    dependencies:
+      extend: 3.0.2
+      https-proxy-agent: 7.0.6
+      node-fetch: 3.3.2
+    transitivePeerDependencies:
+      - supports-color
+
+  gcp-metadata@8.1.2:
+    dependencies:
+      gaxios: 7.1.4
+      google-logging-utils: 1.1.3
+      json-bigint: 1.0.0
+    transitivePeerDependencies:
+      - supports-color
+
+  get-caller-file@2.0.5: {}
+
+  get-east-asian-width@1.5.0: {}
+
+  get-stream@5.2.0:
+    dependencies:
+      pump: 3.0.4
+
+  get-uri@6.0.5:
+    dependencies:
+      basic-ftp: 5.2.1
+      data-uri-to-buffer: 6.0.2
+      debug: 4.4.3
+    transitivePeerDependencies:
+      - supports-color
+
+  glob@13.0.6:
+    dependencies:
+      minimatch: 10.2.5
+      minipass: 7.1.3
+      path-scurry: 2.0.2
+
+  google-auth-library@10.6.2:
+    dependencies:
+      base64-js: 1.5.1
+      ecdsa-sig-formatter: 1.0.11
+      gaxios: 7.1.4
+      gcp-metadata: 8.1.2
+      google-logging-utils: 1.1.3
+      jws: 4.0.1
+    transitivePeerDependencies:
+      - supports-color
+
+  google-logging-utils@1.1.3: {}
+
+  graceful-fs@4.2.11: {}
+
+  has-flag@4.0.0: {}
+
+  highlight.js@10.7.3: {}
+
+  hosted-git-info@9.0.2:
+    dependencies:
+      lru-cache: 11.3.3
+
+  http-proxy-agent@7.0.2:
+    dependencies:
+      agent-base: 7.1.4
+      debug: 4.4.3
+    transitivePeerDependencies:
+      - supports-color
+
+  https-proxy-agent@7.0.6:
+    dependencies:
+      agent-base: 7.1.4
+      debug: 4.4.3
+    transitivePeerDependencies:
+      - supports-color
+
+  ieee754@1.2.1: {}
+
+  ignore@7.0.5: {}
+
+  ip-address@10.1.0: {}
+
+  is-fullwidth-code-point@3.0.0: {}
+
+  json-bigint@1.0.0:
+    dependencies:
+      bignumber.js: 9.3.1
+
+  json-schema-to-ts@3.1.1:
+    dependencies:
+      '@babel/runtime': 7.29.2
+      ts-algebra: 2.0.0
+
+  json-schema-traverse@1.0.0: {}
+
+  jwa@2.0.1:
+    dependencies:
+      buffer-equal-constant-time: 1.0.1
+      ecdsa-sig-formatter: 1.0.11
+      safe-buffer: 5.2.1
+
+  jws@4.0.1:
+    dependencies:
+      jwa: 2.0.1
+      safe-buffer: 5.2.1
+
+  koffi@2.15.6:
+    optional: true
+
+  long@5.3.2: {}
+
+  lru-cache@11.3.3: {}
+
+  lru-cache@7.18.3: {}
+
+  marked@15.0.12: {}
+
+  mime-db@1.54.0: {}
+
+  mime-types@3.0.2:
+    dependencies:
+      mime-db: 1.54.0
+
+  minimatch@10.2.5:
+    dependencies:
+      brace-expansion: 5.0.5
+
+  minipass@7.1.3: {}
+
+  ms@2.1.3: {}
+
+  mz@2.7.0:
+    dependencies:
+      any-promise: 1.3.0
+      object-assign: 4.1.1
+      thenify-all: 1.6.0
+
+  netmask@2.1.1: {}
+
+  node-domexception@1.0.0: {}
+
+  node-fetch@3.3.2:
+    dependencies:
+      data-uri-to-buffer: 4.0.1
+      fetch-blob: 3.2.0
+      formdata-polyfill: 4.0.10
+
+  object-assign@4.1.1: {}
+
+  once@1.4.0:
+    dependencies:
+      wrappy: 1.0.2
+
+  openai@6.26.0(ws@8.20.0)(zod@4.3.6):
+    optionalDependencies:
+      ws: 8.20.0
+      zod: 4.3.6
+
+  p-retry@4.6.2:
+    dependencies:
+      '@types/retry': 0.12.0
+      retry: 0.13.1
+
+  pac-proxy-agent@7.2.0:
+    dependencies:
+      '@tootallnate/quickjs-emscripten': 0.23.0
+      agent-base: 7.1.4
+      debug: 4.4.3
+      get-uri: 6.0.5
+      http-proxy-agent: 7.0.2
+      https-proxy-agent: 7.0.6
+      pac-resolver: 7.0.1
+      socks-proxy-agent: 8.0.5
+    transitivePeerDependencies:
+      - supports-color
+
+  pac-resolver@7.0.1:
+    dependencies:
+      degenerator: 5.0.1
+      netmask: 2.1.1
+
+  parse5-htmlparser2-tree-adapter@6.0.1:
+    dependencies:
+      parse5: 6.0.1
+
+  parse5@5.1.1: {}
+
+  parse5@6.0.1: {}
+
+  partial-json@0.1.7: {}
+
+  path-expression-matcher@1.4.0: {}
+
+  path-scurry@2.0.2:
+    dependencies:
+      lru-cache: 11.3.3
+      minipass: 7.1.3
+
+  pend@1.2.0: {}
 
   playwright-core@1.59.1: {}
 
@@ -66,6 +2367,168 @@ snapshots:
     optionalDependencies:
       fsevents: 2.3.2
 
+  proper-lockfile@4.1.2:
+    dependencies:
+      graceful-fs: 4.2.11
+      retry: 0.12.0
+      signal-exit: 3.0.7
+
+  protobufjs@7.5.4:
+    dependencies:
+      '@protobufjs/aspromise': 1.1.2
+      '@protobufjs/base64': 1.1.2
+      '@protobufjs/codegen': 2.0.4
+      '@protobufjs/eventemitter': 1.1.0
+      '@protobufjs/fetch': 1.1.0
+      '@protobufjs/float': 1.0.2
+      '@protobufjs/inquire': 1.1.0
+      '@protobufjs/path': 1.1.2
+      '@protobufjs/pool': 1.1.0
+      '@protobufjs/utf8': 1.1.0
+      '@types/node': 25.5.2
+      long: 5.3.2
+
+  proxy-agent@6.5.0:
+    dependencies:
+      agent-base: 7.1.4
+      debug: 4.4.3
+      http-proxy-agent: 7.0.2
+      https-proxy-agent: 7.0.6
+      lru-cache: 7.18.3
+      pac-proxy-agent: 7.2.0
+      proxy-from-env: 1.1.0
+      socks-proxy-agent: 8.0.5
+    transitivePeerDependencies:
+      - supports-color
+
+  proxy-from-env@1.1.0: {}
+
+  pump@3.0.4:
+    dependencies:
+      end-of-stream: 1.4.5
+      once: 1.4.0
+
+  require-directory@2.1.1: {}
+
+  require-from-string@2.0.2: {}
+
+  retry@0.12.0: {}
+
+  retry@0.13.1: {}
+
+  safe-buffer@5.2.1: {}
+
+  signal-exit@3.0.7: {}
+
+  smart-buffer@4.2.0: {}
+
+  socks-proxy-agent@8.0.5:
+    dependencies:
+      agent-base: 7.1.4
+      debug: 4.4.3
+      socks: 2.8.7
+    transitivePeerDependencies:
+      - supports-color
+
+  socks@2.8.7:
+    dependencies:
+      ip-address: 10.1.0
+      smart-buffer: 4.2.0
+
+  source-map@0.6.1:
+    optional: true
+
+  std-env@3.10.0: {}
+
+  string-width@4.2.3:
+    dependencies:
+      emoji-regex: 8.0.0
+      is-fullwidth-code-point: 3.0.0
+      strip-ansi: 6.0.1
+
+  strip-ansi@6.0.1:
+    dependencies:
+      ansi-regex: 5.0.1
+
+  strip-ansi@7.2.0:
+    dependencies:
+      ansi-regex: 6.2.2
+
+  strnum@2.2.3: {}
+
+  strtok3@10.3.5:
+    dependencies:
+      '@tokenizer/token': 0.3.0
+
+  supports-color@7.2.0:
+    dependencies:
+      has-flag: 4.0.0
+
+  thenify-all@1.6.0:
+    dependencies:
+      thenify: 3.3.1
+
+  thenify@3.3.1:
+    dependencies:
+      any-promise: 1.3.0
+
+  token-types@6.1.2:
+    dependencies:
+      '@borewit/text-codec': 0.2.2
+      '@tokenizer/token': 0.3.0
+      ieee754: 1.2.1
+
+  ts-algebra@2.0.0: {}
+
+  tslib@2.8.1: {}
+
   turndown@7.2.4:
     dependencies:
       '@mixmark-io/domino': 2.2.0
+
+  uint8array-extras@1.5.0: {}
+
+  undici-types@7.18.2: {}
+
+  undici@7.24.7: {}
+
+  web-streams-polyfill@3.3.3: {}
+
+  wrap-ansi@7.0.0:
+    dependencies:
+      ansi-styles: 4.3.0
+      string-width: 4.2.3
+      strip-ansi: 6.0.1
+
+  wrappy@1.0.2: {}
+
+  ws@8.20.0: {}
+
+  y18n@5.0.8: {}
+
+  yaml@2.8.3: {}
+
+  yargs-parser@20.2.9: {}
+
+  yargs@16.2.0:
+    dependencies:
+      cliui: 7.0.4
+      escalade: 3.2.0
+      get-caller-file: 2.0.5
+      require-directory: 2.1.1
+      string-width: 4.2.3
+      y18n: 5.0.8
+      yargs-parser: 20.2.9
+
+  yauzl@2.10.0:
+    dependencies:
+      buffer-crc32: 0.2.13
+      fd-slicer: 1.1.0
+
+  yoctocolors@2.1.2: {}
+
+  zod-to-json-schema@3.25.2(zod@4.3.6):
+    dependencies:
+      zod: 4.3.6
+
+  zod@4.3.6: {}

--- a/extensions/web-fetch/scripts/postinstall.js
+++ b/extensions/web-fetch/scripts/postinstall.js
@@ -1,0 +1,26 @@
+#!/usr/bin/env node
+
+import { exec as execCb } from "child_process";
+import { dirname, resolve } from "path";
+import { fileURLToPath } from "url";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const cwd = resolve(__dirname, "..");
+
+const skip =
+	process.env.PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD === "1" ||
+	process.env.PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD === "true";
+
+if (skip) {
+	process.stderr.write("[kimchi] postinstall: skipping Playwright browser download (PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD is set)\n");
+	process.exit(0);
+}
+
+const child = execCb("npx playwright install chromium", { cwd }, (error, stdout, stderr) => {
+	if (stdout) process.stdout.write(stdout);
+	if (stderr) process.stderr.write(stderr);
+	if (error) {
+		process.stderr.write(`[kimchi] postinstall: Playwright browser install failed — web_fetch will fall back to native HTTP\n`);
+		process.exit(0); // non-fatal: don't break install
+	}
+});

--- a/extensions/web-fetch/url-validator.test.ts
+++ b/extensions/web-fetch/url-validator.test.ts
@@ -1,0 +1,231 @@
+import { describe, expect, it } from "vitest";
+import { validateURL } from "./url-validator.js";
+
+describe("validateURL", () => {
+	describe("valid URLs", () => {
+		it("accepts http URL", () => {
+			const result = validateURL("http://example.com");
+			expect(result.valid).toBe(true);
+			if (result.valid) {
+				expect(result.url.href).toBe("http://example.com/");
+			}
+		});
+
+		it("accepts https URL", () => {
+			const result = validateURL("https://example.com/path?q=1#frag");
+			expect(result.valid).toBe(true);
+			if (result.valid) {
+				expect(result.url.href).toBe("https://example.com/path?q=1#frag");
+			}
+		});
+
+		it("accepts URL with port", () => {
+			const result = validateURL("https://example.com:8080/page");
+			expect(result.valid).toBe(true);
+		});
+
+		it("accepts public IP address", () => {
+			const result = validateURL("http://8.8.8.8");
+			expect(result.valid).toBe(true);
+		});
+
+		it("accepts 172.x address outside private range", () => {
+			const result = validateURL("http://172.15.0.1");
+			expect(result.valid).toBe(true);
+		});
+
+		it("accepts 172.32.x address outside private range", () => {
+			const result = validateURL("http://172.32.0.1");
+			expect(result.valid).toBe(true);
+		});
+	});
+
+	describe("invalid URLs", () => {
+		it("rejects malformed URL", () => {
+			const result = validateURL("not-a-url");
+			expect(result.valid).toBe(false);
+			if (!result.valid) {
+				expect(result.error).toContain("Invalid URL");
+			}
+		});
+
+		it("rejects empty string", () => {
+			const result = validateURL("");
+			expect(result.valid).toBe(false);
+		});
+
+		it("rejects URL without scheme", () => {
+			const result = validateURL("example.com");
+			expect(result.valid).toBe(false);
+		});
+	});
+
+	describe("blocked schemes", () => {
+		it("rejects ftp scheme", () => {
+			const result = validateURL("ftp://example.com/file");
+			expect(result.valid).toBe(false);
+			if (!result.valid) {
+				expect(result.error).toContain("Unsupported scheme");
+				expect(result.error).toContain("ftp");
+			}
+		});
+
+		it("rejects file scheme", () => {
+			const result = validateURL("file:///etc/passwd");
+			expect(result.valid).toBe(false);
+			if (!result.valid) {
+				expect(result.error).toContain("Unsupported scheme");
+			}
+		});
+
+		it("rejects javascript scheme", () => {
+			// biome-ignore lint/suspicious/noGlobalIsNan: testing URL scheme validation
+			const result = validateURL("javascript:alert(1)");
+			expect(result.valid).toBe(false);
+		});
+
+		it("rejects data scheme", () => {
+			const result = validateURL("data:text/html,<h1>Hi</h1>");
+			expect(result.valid).toBe(false);
+		});
+	});
+
+	describe("SSRF protection — private IPv4 ranges", () => {
+		it("blocks 10.0.0.0/8", () => {
+			const result = validateURL("http://10.0.0.1");
+			expect(result.valid).toBe(false);
+			if (!result.valid) {
+				expect(result.error).toContain("SSRF");
+				expect(result.error).toContain("10.0.0.0/8");
+			}
+		});
+
+		it("blocks 10.255.255.255", () => {
+			const result = validateURL("http://10.255.255.255");
+			expect(result.valid).toBe(false);
+		});
+
+		it("blocks 127.0.0.0/8 (loopback)", () => {
+			const result = validateURL("http://127.0.0.1");
+			expect(result.valid).toBe(false);
+			if (!result.valid) {
+				expect(result.error).toContain("loopback");
+			}
+		});
+
+		it("blocks 127.0.0.2", () => {
+			const result = validateURL("http://127.0.0.2");
+			expect(result.valid).toBe(false);
+		});
+
+		it("blocks 169.254.0.0/16 (link-local)", () => {
+			const result = validateURL("http://169.254.1.1");
+			expect(result.valid).toBe(false);
+			if (!result.valid) {
+				expect(result.error).toContain("link-local");
+			}
+		});
+
+		it("blocks 192.168.0.0/16", () => {
+			const result = validateURL("http://192.168.1.1");
+			expect(result.valid).toBe(false);
+			if (!result.valid) {
+				expect(result.error).toContain("192.168");
+			}
+		});
+
+		it("blocks 172.16.0.0/12 (172.16.x.x)", () => {
+			const result = validateURL("http://172.16.0.1");
+			expect(result.valid).toBe(false);
+			if (!result.valid) {
+				expect(result.error).toContain("172.16.0.0/12");
+			}
+		});
+
+		it("blocks 172.31.255.255 (top of 172.16/12 range)", () => {
+			const result = validateURL("http://172.31.255.255");
+			expect(result.valid).toBe(false);
+		});
+
+		it("blocks 172.20.0.1", () => {
+			const result = validateURL("http://172.20.0.1");
+			expect(result.valid).toBe(false);
+		});
+	});
+
+	describe("SSRF protection — localhost", () => {
+		it("blocks localhost", () => {
+			const result = validateURL("http://localhost");
+			expect(result.valid).toBe(false);
+			if (!result.valid) {
+				expect(result.error).toContain("localhost");
+			}
+		});
+
+		it("blocks localhost with port", () => {
+			const result = validateURL("http://localhost:3000");
+			expect(result.valid).toBe(false);
+		});
+
+		it("blocks localhost.localdomain", () => {
+			const result = validateURL("http://localhost.localdomain");
+			expect(result.valid).toBe(false);
+		});
+	});
+
+	describe("SSRF protection — cloud metadata endpoints", () => {
+		it("blocks AWS/GCP metadata endpoint 169.254.169.254", () => {
+			const result = validateURL("http://169.254.169.254/latest/meta-data/");
+			expect(result.valid).toBe(false);
+			if (!result.valid) {
+				expect(result.error).toContain("SSRF");
+			}
+		});
+
+		it("blocks GCP metadata.google.internal", () => {
+			const result = validateURL("http://metadata.google.internal/computeMetadata/v1/");
+			expect(result.valid).toBe(false);
+			if (!result.valid) {
+				expect(result.error).toContain("metadata");
+			}
+		});
+	});
+
+	describe("SSRF protection — IPv6", () => {
+		it("blocks ::1 (IPv6 loopback)", () => {
+			const result = validateURL("http://[::1]/");
+			expect(result.valid).toBe(false);
+			if (!result.valid) {
+				expect(result.error).toContain("IPv6");
+			}
+		});
+
+		it("blocks fc00:: (unique-local)", () => {
+			const result = validateURL("http://[fc00::1]/");
+			expect(result.valid).toBe(false);
+		});
+
+		it("blocks fd00:: (unique-local)", () => {
+			const result = validateURL("http://[fd12:3456::1]/");
+			expect(result.valid).toBe(false);
+		});
+
+		it("blocks IPv4-mapped IPv6 loopback ::ffff:127.0.0.1", () => {
+			const result = validateURL("http://[::ffff:127.0.0.1]/");
+			expect(result.valid).toBe(false);
+			if (!result.valid) {
+				expect(result.error).toContain("SSRF");
+			}
+		});
+
+		it("blocks IPv4-mapped IPv6 private ::ffff:10.0.0.1", () => {
+			const result = validateURL("http://[::ffff:10.0.0.1]/");
+			expect(result.valid).toBe(false);
+		});
+
+		it("allows IPv4-mapped IPv6 public address", () => {
+			const result = validateURL("http://[::ffff:8.8.8.8]/");
+			expect(result.valid).toBe(true);
+		});
+	});
+});

--- a/extensions/web-fetch/url-validator.ts
+++ b/extensions/web-fetch/url-validator.ts
@@ -1,0 +1,153 @@
+/**
+ * URL validation and SSRF protection for the web_fetch tool.
+ *
+ * Validates URL format (http/https only) and blocks requests to private
+ * IP ranges, localhost, and cloud metadata endpoints.
+ */
+
+/** Private IPv4 ranges that must be blocked. */
+const PRIVATE_IPV4_RANGES = [
+	{ prefix: "10.", label: "private (10.0.0.0/8)" },
+	{ prefix: "127.", label: "loopback (127.0.0.0/8)" },
+	{ prefix: "169.254.", label: "link-local (169.254.0.0/16)" },
+	{ prefix: "192.168.", label: "private (192.168.0.0/16)" },
+] as const;
+
+/** Check if an IPv4 address falls in the 172.16.0.0/12 range (172.16.x – 172.31.x). */
+function isPrivate172(host: string): boolean {
+	if (!host.startsWith("172.")) return false;
+	const parts = host.split(".");
+	if (parts.length !== 4) return false;
+	const second = Number.parseInt(parts[1], 10);
+	return second >= 16 && second <= 31;
+}
+
+/** Private IPv6 addresses / prefixes that must be blocked. */
+const BLOCKED_IPV6 = ["::1", "0:0:0:0:0:0:0:1"] as const;
+
+/** Check if a hostname is a blocked IPv6 address (loopback or unique-local fc00::/7). */
+function isBlockedIPv6(host: string): boolean {
+	// Strip surrounding brackets that URL parsing may leave
+	const bare = host.startsWith("[") && host.endsWith("]") ? host.slice(1, -1) : host;
+	const lower = bare.toLowerCase();
+	if ((BLOCKED_IPV6 as readonly string[]).includes(lower)) return true;
+	// fc00::/7 covers fc00:: – fdff::
+	if (lower.startsWith("fc") || lower.startsWith("fd")) return true;
+	return false;
+}
+
+/** Cloud metadata endpoints. */
+const METADATA_HOSTS = ["169.254.169.254", "metadata.google.internal"] as const;
+
+/** Localhost aliases. */
+const LOCALHOST_ALIASES = ["localhost", "localhost.localdomain"] as const;
+
+export interface ValidationResult {
+	valid: true;
+	url: URL;
+}
+
+export interface ValidationError {
+	valid: false;
+	error: string;
+}
+
+export type ValidateURLResult = ValidationResult | ValidationError;
+
+/**
+ * Validate a URL for use with web_fetch.
+ *
+ * Checks:
+ *  1. URL parses correctly
+ *  2. Scheme is http or https
+ *  3. Hostname is not a private IP, localhost, or cloud metadata endpoint
+ */
+export function validateURL(raw: string): ValidateURLResult {
+	// 1. Parse
+	let url: URL;
+	try {
+		url = new URL(raw);
+	} catch {
+		return { valid: false, error: `Invalid URL: "${raw}" is not a valid URL` };
+	}
+
+	// 2. Scheme
+	if (url.protocol !== "http:" && url.protocol !== "https:") {
+		return {
+			valid: false,
+			error: `Unsupported scheme: "${url.protocol.replace(":", "")}". Only http and https are allowed`,
+		};
+	}
+
+	const hostname = url.hostname;
+
+	// 3a. Localhost aliases
+	if ((LOCALHOST_ALIASES as readonly string[]).includes(hostname.toLowerCase())) {
+		return { valid: false, error: `Blocked URL: requests to localhost are not allowed (SSRF protection)` };
+	}
+
+	// 3b. Cloud metadata endpoints
+	if ((METADATA_HOSTS as readonly string[]).includes(hostname.toLowerCase())) {
+		return {
+			valid: false,
+			error: `Blocked URL: requests to cloud metadata endpoint "${hostname}" are not allowed (SSRF protection)`,
+		};
+	}
+
+	// 3c. Private IPv4 ranges
+	for (const range of PRIVATE_IPV4_RANGES) {
+		if (hostname.startsWith(range.prefix)) {
+			return {
+				valid: false,
+				error: `Blocked URL: "${hostname}" is a ${range.label} address (SSRF protection)`,
+			};
+		}
+	}
+	if (isPrivate172(hostname)) {
+		return {
+			valid: false,
+			error: `Blocked URL: "${hostname}" is a private (172.16.0.0/12) address (SSRF protection)`,
+		};
+	}
+
+	// 3d. Blocked IPv6 addresses
+	if (isBlockedIPv6(hostname)) {
+		return {
+			valid: false,
+			error: `Blocked URL: "${hostname}" is a blocked IPv6 address (SSRF protection)`,
+		};
+	}
+
+	// 3e. IPv4-mapped IPv6 (::ffff:127.0.0.1 or ::ffff:7f00:1 hex form)
+	const bare = hostname.startsWith("[") && hostname.endsWith("]") ? hostname.slice(1, -1) : hostname;
+	const lower = bare.toLowerCase();
+
+	// Decimal form: ::ffff:127.0.0.1
+	const v4MappedDecimal = lower.match(/^::ffff:(\d+\.\d+\.\d+\.\d+)$/);
+	if (v4MappedDecimal) {
+		const innerResult = validateURL(`http://${v4MappedDecimal[1]}/`);
+		if (!innerResult.valid) {
+			return {
+				valid: false,
+				error: `Blocked URL: "${hostname}" maps to a blocked IPv4 address (SSRF protection)`,
+			};
+		}
+	}
+
+	// Hex form: ::ffff:7f00:1 (Node's URL parser normalizes to this)
+	const v4MappedHex = lower.match(/^::ffff:([0-9a-f]{1,4}):([0-9a-f]{1,4})$/);
+	if (v4MappedHex) {
+		const hi = Number.parseInt(v4MappedHex[1], 16);
+		const lo = Number.parseInt(v4MappedHex[2], 16);
+		const ip = `${(hi >> 8) & 0xff}.${hi & 0xff}.${(lo >> 8) & 0xff}.${lo & 0xff}`;
+		const innerResult = validateURL(`http://${ip}/`);
+		if (!innerResult.valid) {
+			return {
+				valid: false,
+				error: `Blocked URL: "${hostname}" maps to a blocked IPv4 address (SSRF protection)`,
+			};
+		}
+	}
+
+	return { valid: true, url };
+}

--- a/package.json
+++ b/package.json
@@ -16,7 +16,8 @@
     "check": "biome check src/ && tsc --noEmit",
     "test": "vitest run --dir src",
     "test:smoke": "vitest run --config tests/smoke/vitest.config.ts",
-    "verify": "pnpm run check && pnpm run build:binary && pnpm run test && pnpm run test:smoke"
+    "test:extensions": "cd extensions/web-fetch && pnpm test",
+    "verify": "pnpm run check && pnpm run build:binary && pnpm run test && pnpm run test:extensions && pnpm run test:smoke"
   },
   "piConfig": {
     "name": "kimchi",

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "copy:assets": "cp package.json dist/ && cp -r src/modes/interactive/theme dist/theme && cp -r node_modules/@mariozechner/pi-coding-agent/dist/core/export-html dist/export-html",
     "build": "tsc && node scripts/copy-themes.js",
     "build:binary": "pnpm run clean && pnpm run build && bun build dist/cli.js --compile --outfile dist/kimchi-code && pnpm run copy:assets",
-    "dev": "tsc --watch",
+    "dev": "tsx src/cli.ts",
     "lint": "biome check src/",
     "lint:fix": "biome check --write src/",
     "check": "biome check src/ && tsc --noEmit",
@@ -32,6 +32,7 @@
   "devDependencies": {
     "@biomejs/biome": "^1.9.4",
     "@types/node": "^22.15.2",
+    "tsx": "^4.21.0",
     "typescript": "^5.7.3",
     "vitest": "^3.1.1"
   },

--- a/package.json
+++ b/package.json
@@ -9,12 +9,14 @@
   },
   "scripts": {
     "build": "tsc && node scripts/copy-themes.js",
-    "build:binary": "pnpm run build && bun build dist/cli.js --compile --outfile dist/kimchi-code && cp package.json dist/ && cp -r src/modes/interactive/theme dist/theme && cp -r node_modules/@mariozechner/pi-coding-agent/dist/core/export-html dist/export-html",
+    "build:binary": "rm -rf dist && pnpm run build && bun build dist/cli.js --compile --outfile dist/kimchi-code && cp package.json dist/ && cp -r src/modes/interactive/theme dist/theme && cp -r node_modules/@mariozechner/pi-coding-agent/dist/core/export-html dist/export-html",
     "dev": "tsc --watch",
     "lint": "biome check src/",
     "lint:fix": "biome check --write src/",
     "check": "biome check src/ && tsc --noEmit",
-    "test": "vitest run --passWithNoTests"
+    "test": "vitest run --dir src",
+    "test:smoke": "vitest run --config tests/smoke/vitest.config.ts",
+    "verify": "pnpm run check && pnpm run build:binary && pnpm run test && pnpm run test:smoke"
   },
   "piConfig": {
     "name": "kimchi",

--- a/package.json
+++ b/package.json
@@ -8,8 +8,10 @@
     "kimchi-code": "dist/cli.js"
   },
   "scripts": {
+    "clean": "rm -rf dist",
+    "copy:assets": "cp package.json dist/ && cp -r src/modes/interactive/theme dist/theme && cp -r node_modules/@mariozechner/pi-coding-agent/dist/core/export-html dist/export-html",
     "build": "tsc && node scripts/copy-themes.js",
-    "build:binary": "rm -rf dist && pnpm run build && bun build dist/cli.js --compile --outfile dist/kimchi-code && cp package.json dist/ && cp -r src/modes/interactive/theme dist/theme && cp -r node_modules/@mariozechner/pi-coding-agent/dist/core/export-html dist/export-html",
+    "build:binary": "pnpm run clean && pnpm run build && bun build dist/cli.js --compile --outfile dist/kimchi-code && pnpm run copy:assets",
     "dev": "tsc --watch",
     "lint": "biome check src/",
     "lint:fix": "biome check --write src/",

--- a/plans/004-web-fetch-quality-slice1.md
+++ b/plans/004-web-fetch-quality-slice1.md
@@ -1,0 +1,55 @@
+# Plan: Slice 1 — Fix cache content corruption and unsafe error cast
+
+## Context
+
+The web-fetch extension has a bug at `execute-handler.ts:103` where `output.replace("Cache: miss", "Cache: hit")` operates on the full output including page body. If a fetched page contains the literal string "Cache: miss", the cached version gets corrupted. Separately, line 59 does `err as FetchError` without an `instanceof` check, which will fail silently on non-FetchError exceptions. This slice fixes both issues.
+
+---
+
+## Changes
+
+### 1. Fix cache corruption — build output with correct cache status directly
+
+**File: `extensions/web-fetch/execute-handler.ts`**
+
+- Extract a helper function `buildOutput(metadataLines, content, truncationNotice)` that joins metadata lines and assembles the final string: `metadata + "\n\n" + content + truncationNotice`.
+- After the metadata `lines` array is built (lines 83-94), produce two outputs:
+  - `output` — uses `lines` as-is (contains `Cache: miss`) for the immediate return
+  - `cachedOutput` — uses a copy of `lines` with `Cache: miss` replaced by `Cache: hit` at the array level (swap the specific array element, not a string replace on the body)
+- Pass `cachedOutput` to `cacheSet()` at line 103 instead of doing `.replace()` on the full string.
+- Remove the `.replace("Cache: miss", "Cache: hit")` call entirely.
+
+### 2. Fix unsafe error cast
+
+**File: `extensions/web-fetch/execute-handler.ts`**
+
+- Change the import of `FetchError` from `type` import to a value import (currently `import { type FetchError, fetchPage }` — change to `import { FetchError, fetchPage }`).
+- Replace line 59 (`const fetchErr = err as FetchError`) with proper type narrowing:
+  ```typescript
+  const message = err instanceof FetchError ? err.message
+    : err instanceof Error ? err.message
+    : String(err);
+  ```
+- Use `message` directly in the error return on line 61.
+
+### 3. Extract `EMPTY_DETAILS` constant
+
+**File: `extensions/web-fetch/execute-handler.ts`**
+
+- Add `const EMPTY_DETAILS = {} as Record<string, never>;` near the top (after the constants).
+- Replace all 4 instances of `details: {} as Record<string, never>` (lines 41, 50, 62, 107) with `details: EMPTY_DETAILS`.
+
+### 4. Add tests
+
+**File: `extensions/web-fetch/execute-handler.test.ts`**
+
+- **Test: page body containing "Cache: miss" is not corrupted in cache.** Mock `fetchPage` to return a body containing the literal string `"Cache: miss"`. Assert that `cacheSet` is called with output that still contains `"Cache: miss"` in the body section (i.e., the body was not modified), and that the metadata section says `"Cache: hit"`.
+
+- **Test: non-FetchError thrown by fetchPage produces readable error message.** Mock `fetchPage` to reject with a plain `Error("connection refused")`. Assert the result text contains `"Error: connection refused"`. Add a second case where `fetchPage` rejects with a string `"something broke"` — assert the result text contains `"Error: something broke"`.
+
+---
+
+## Verification
+
+1. `cd extensions/web-fetch && npx vitest run` — all tests pass (existing + new)
+2. Inspect that no `.replace("Cache: miss", "Cache: hit")` call remains in execute-handler.ts

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -21,12 +21,15 @@ importers:
       '@types/node':
         specifier: ^22.15.2
         version: 22.19.17
+      tsx:
+        specifier: ^4.21.0
+        version: 4.21.0
       typescript:
         specifier: ^5.7.3
         version: 5.9.3
       vitest:
         specifier: ^3.1.1
-        version: 3.2.4(@types/node@22.19.17)(yaml@2.8.3)
+        version: 3.2.4(@types/node@22.19.17)(tsx@4.21.0)(yaml@2.8.3)
 
 packages:
 
@@ -1146,6 +1149,9 @@ packages:
     resolution: {integrity: sha512-nBF+F1rAZVCu/p7rjzgA+Yb4lfYXrpl7a6VmJrU8wF9I1CKvP/QwPNZHnOlwbTkY6dvtFIzFMSyQXbLoTQPRpA==}
     engines: {node: '>=8'}
 
+  get-tsconfig@4.13.7:
+    resolution: {integrity: sha512-7tN6rFgBlMgpBML5j8typ92BKFi2sFQvIdpAqLA2beia5avZDrMs0FLZiM5etShWq5irVyGcGMEA1jcDaK7A/Q==}
+
   get-uri@6.0.5:
     resolution: {integrity: sha512-b1O07XYq8eRuVzBNgJLstU6FYc1tS6wnMtF1I1D9lE8LxZSOGZ7LhxN54yPP6mGw5f2CkXY2BQUL9Fx41qvcIg==}
     engines: {node: '>= 14'}
@@ -1380,6 +1386,9 @@ packages:
     resolution: {integrity: sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==}
     engines: {node: '>=0.10.0'}
 
+  resolve-pkg-maps@1.0.0:
+    resolution: {integrity: sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==}
+
   retry@0.12.0:
     resolution: {integrity: sha512-9LkiTwjUh6rT555DtE9rTX+BKByPfrMzEAtnlEtdEwr3Nkffwiihqe2bWADg+OQRjt9gl6ICdmB/ZFDCGAtSow==}
     engines: {node: '>= 4'}
@@ -1492,6 +1501,11 @@ packages:
 
   tslib@2.8.1:
     resolution: {integrity: sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==}
+
+  tsx@4.21.0:
+    resolution: {integrity: sha512-5C1sg4USs1lfG0GFb2RLXsdpXqBSEhAaA/0kPL01wxzpMqLILNxIxIOKiILz+cdg/pLnOUxFYOR5yhHU666wbw==}
+    engines: {node: '>=18.0.0'}
+    hasBin: true
 
   typescript@5.9.3:
     resolution: {integrity: sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==}
@@ -2752,13 +2766,13 @@ snapshots:
       chai: 5.3.3
       tinyrainbow: 2.0.0
 
-  '@vitest/mocker@3.2.4(vite@7.3.2(@types/node@22.19.17)(yaml@2.8.3))':
+  '@vitest/mocker@3.2.4(vite@7.3.2(@types/node@22.19.17)(tsx@4.21.0)(yaml@2.8.3))':
     dependencies:
       '@vitest/spy': 3.2.4
       estree-walker: 3.0.3
       magic-string: 0.30.21
     optionalDependencies:
-      vite: 7.3.2(@types/node@22.19.17)(yaml@2.8.3)
+      vite: 7.3.2(@types/node@22.19.17)(tsx@4.21.0)(yaml@2.8.3)
 
   '@vitest/pretty-format@3.2.4':
     dependencies:
@@ -3033,6 +3047,10 @@ snapshots:
     dependencies:
       pump: 3.0.4
 
+  get-tsconfig@4.13.7:
+    dependencies:
+      resolve-pkg-maps: 1.0.0
+
   get-uri@6.0.5:
     dependencies:
       basic-ftp: 5.2.0
@@ -3277,6 +3295,8 @@ snapshots:
 
   require-from-string@2.0.2: {}
 
+  resolve-pkg-maps@1.0.0: {}
+
   retry@0.12.0: {}
 
   retry@0.13.1: {}
@@ -3403,6 +3423,13 @@ snapshots:
 
   tslib@2.8.1: {}
 
+  tsx@4.21.0:
+    dependencies:
+      esbuild: 0.27.7
+      get-tsconfig: 4.13.7
+    optionalDependencies:
+      fsevents: 2.3.3
+
   typescript@5.9.3: {}
 
   uint8array-extras@1.5.0: {}
@@ -3413,13 +3440,13 @@ snapshots:
 
   undici@8.0.2: {}
 
-  vite-node@3.2.4(@types/node@22.19.17)(yaml@2.8.3):
+  vite-node@3.2.4(@types/node@22.19.17)(tsx@4.21.0)(yaml@2.8.3):
     dependencies:
       cac: 6.7.14
       debug: 4.4.3
       es-module-lexer: 1.7.0
       pathe: 2.0.3
-      vite: 7.3.2(@types/node@22.19.17)(yaml@2.8.3)
+      vite: 7.3.2(@types/node@22.19.17)(tsx@4.21.0)(yaml@2.8.3)
     transitivePeerDependencies:
       - '@types/node'
       - jiti
@@ -3434,7 +3461,7 @@ snapshots:
       - tsx
       - yaml
 
-  vite@7.3.2(@types/node@22.19.17)(yaml@2.8.3):
+  vite@7.3.2(@types/node@22.19.17)(tsx@4.21.0)(yaml@2.8.3):
     dependencies:
       esbuild: 0.27.7
       fdir: 6.5.0(picomatch@4.0.4)
@@ -3445,13 +3472,14 @@ snapshots:
     optionalDependencies:
       '@types/node': 22.19.17
       fsevents: 2.3.3
+      tsx: 4.21.0
       yaml: 2.8.3
 
-  vitest@3.2.4(@types/node@22.19.17)(yaml@2.8.3):
+  vitest@3.2.4(@types/node@22.19.17)(tsx@4.21.0)(yaml@2.8.3):
     dependencies:
       '@types/chai': 5.2.3
       '@vitest/expect': 3.2.4
-      '@vitest/mocker': 3.2.4(vite@7.3.2(@types/node@22.19.17)(yaml@2.8.3))
+      '@vitest/mocker': 3.2.4(vite@7.3.2(@types/node@22.19.17)(tsx@4.21.0)(yaml@2.8.3))
       '@vitest/pretty-format': 3.2.4
       '@vitest/runner': 3.2.4
       '@vitest/snapshot': 3.2.4
@@ -3469,8 +3497,8 @@ snapshots:
       tinyglobby: 0.2.15
       tinypool: 1.1.1
       tinyrainbow: 2.0.0
-      vite: 7.3.2(@types/node@22.19.17)(yaml@2.8.3)
-      vite-node: 3.2.4(@types/node@22.19.17)(yaml@2.8.3)
+      vite: 7.3.2(@types/node@22.19.17)(tsx@4.21.0)(yaml@2.8.3)
+      vite-node: 3.2.4(@types/node@22.19.17)(tsx@4.21.0)(yaml@2.8.3)
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@types/node': 22.19.17

--- a/src/config.test.ts
+++ b/src/config.test.ts
@@ -49,6 +49,6 @@ describe("loadConfig", () => {
 				env: {},
 				configPath,
 			}),
-		).toThrow("No Cast AI API key found")
+		).toThrow("No Kimchi API key found")
 	})
 })

--- a/src/config.ts
+++ b/src/config.ts
@@ -61,7 +61,7 @@ export function loadConfig(options?: { configPath?: string; env?: Record<string,
 	}
 
 	throw new Error(
-		"No Cast AI API key found. Set the KIMCHI_API_KEY environment variable or log in with the kimchi CLI (`kimchi auth login`).",
+		"No Kimchi API key found. Set the KIMCHI_API_KEY environment variable or log in with the kimchi CLI (`kimchi auth login`).",
 	)
 }
 

--- a/tests/smoke/binary.test.ts
+++ b/tests/smoke/binary.test.ts
@@ -1,39 +1,6 @@
-import { spawnSync, type SpawnSyncReturns } from "node:child_process"
-import { accessSync, constants, mkdtempSync, rmSync } from "node:fs"
-import { tmpdir } from "node:os"
-import { join, resolve } from "node:path"
-import { afterAll, beforeAll, describe, expect, it } from "vitest"
-
-const BINARY_PATH = resolve("dist/kimchi-code")
-
-let tempHome: string
-let tempAgentDir: string
-
-beforeAll(() => {
-	tempHome = mkdtempSync(join(tmpdir(), "kimchi-smoke-home-"))
-	tempAgentDir = mkdtempSync(join(tmpdir(), "kimchi-smoke-agent-"))
-})
-
-afterAll(() => {
-	rmSync(tempHome, { recursive: true, force: true })
-	rmSync(tempAgentDir, { recursive: true, force: true })
-})
-
-function runBinary(
-	args: string[] = [],
-	extraEnv: Record<string, string> = {},
-): SpawnSyncReturns<string> {
-	return spawnSync(BINARY_PATH, args, {
-		encoding: "utf-8",
-		timeout: 30_000,
-		env: {
-			PATH: process.env.PATH,
-			HOME: tempHome,
-			KIMCHI_CODING_AGENT_DIR: tempAgentDir,
-			...extraEnv,
-		},
-	})
-}
+import { accessSync, constants } from "node:fs"
+import { describe, expect, it } from "vitest"
+import { BINARY_PATH, runBinary } from "./harness.js"
 
 describe("binary smoke tests", () => {
 	it("binary exists and is executable", () => {
@@ -74,5 +41,3 @@ describe("binary smoke tests", () => {
 		},
 	)
 })
-
-export { runBinary, BINARY_PATH }

--- a/tests/smoke/binary.test.ts
+++ b/tests/smoke/binary.test.ts
@@ -1,0 +1,78 @@
+import { spawnSync, type SpawnSyncReturns } from "node:child_process"
+import { accessSync, constants, mkdtempSync, rmSync } from "node:fs"
+import { tmpdir } from "node:os"
+import { join, resolve } from "node:path"
+import { afterAll, beforeAll, describe, expect, it } from "vitest"
+
+const BINARY_PATH = resolve("dist/kimchi-code")
+
+let tempHome: string
+let tempAgentDir: string
+
+beforeAll(() => {
+	tempHome = mkdtempSync(join(tmpdir(), "kimchi-smoke-home-"))
+	tempAgentDir = mkdtempSync(join(tmpdir(), "kimchi-smoke-agent-"))
+})
+
+afterAll(() => {
+	rmSync(tempHome, { recursive: true, force: true })
+	rmSync(tempAgentDir, { recursive: true, force: true })
+})
+
+function runBinary(
+	args: string[] = [],
+	extraEnv: Record<string, string> = {},
+): SpawnSyncReturns<string> {
+	return spawnSync(BINARY_PATH, args, {
+		encoding: "utf-8",
+		timeout: 30_000,
+		env: {
+			PATH: process.env.PATH,
+			HOME: tempHome,
+			KIMCHI_CODING_AGENT_DIR: tempAgentDir,
+			...extraEnv,
+		},
+	})
+}
+
+describe("binary smoke tests", () => {
+	it("binary exists and is executable", () => {
+		accessSync(BINARY_PATH, constants.X_OK)
+	})
+
+	it("errors with meaningful message when KIMCHI_API_KEY is missing", () => {
+		const result = runBinary([])
+		expect(result.status).toBe(1)
+		expect(result.stderr).toContain("No Kimchi API key found")
+	})
+
+	it("--version exits cleanly", () => {
+		const result = runBinary(["--version"], {
+			KIMCHI_API_KEY: "smoke-test-dummy",
+		})
+		expect(result.status).toBe(0)
+		expect(result.stdout.trim()).toMatch(/^\d+\.\d+\.\d+/)
+	})
+
+	it("--help exits cleanly", () => {
+		const result = runBinary(["--help"], {
+			KIMCHI_API_KEY: "smoke-test-dummy",
+		})
+		expect(result.status).toBe(0)
+		expect(result.stdout).toContain("Usage")
+	})
+
+	it.skipIf(!process.env.KIMCHI_API_KEY)(
+		"sends a request to a model via -p flag",
+		() => {
+			const result = runBinary(
+				["-p", "respond with only the word hello"],
+				{ KIMCHI_API_KEY: process.env.KIMCHI_API_KEY! },
+			)
+			expect(result.status).toBe(0)
+			expect(result.stdout.trim()).not.toBe("")
+		},
+	)
+})
+
+export { runBinary, BINARY_PATH }

--- a/tests/smoke/harness.ts
+++ b/tests/smoke/harness.ts
@@ -1,0 +1,58 @@
+/**
+ * Shared test harness utilities for smoke tests.
+ *
+ * Provides isolated temp directories and a helper to spawn the compiled
+ * kimchi-code binary with a sandboxed HOME. The binary computes its agent
+ * config dir as HOME/.config/kimchi/harness, so we expose that derived
+ * path for tests that need to place settings files there.
+ */
+
+import { spawnSync, type SpawnSyncReturns } from "node:child_process"
+import { mkdirSync, mkdtempSync, rmSync } from "node:fs"
+import { tmpdir } from "node:os"
+import { join, resolve } from "node:path"
+import { afterAll, beforeAll } from "vitest"
+
+export const BINARY_PATH = resolve("dist/kimchi-code")
+
+let tempHome: string
+
+beforeAll(() => {
+	tempHome = mkdtempSync(join(tmpdir(), "kimchi-smoke-home-"))
+})
+
+afterAll(() => {
+	rmSync(tempHome, { recursive: true, force: true })
+})
+
+/**
+ * Returns the agent config dir that the binary will derive from tempHome.
+ * Matches the logic in src/cli.ts: resolve(homedir(), ".config", "kimchi", "harness").
+ */
+export function getAgentDir(): string {
+	return join(tempHome, ".config", "kimchi", "harness")
+}
+
+/**
+ * Ensure the agent config dir exists and return its path.
+ */
+export function ensureAgentDir(): string {
+	const dir = getAgentDir()
+	mkdirSync(dir, { recursive: true })
+	return dir
+}
+
+export function runBinary(
+	args: string[] = [],
+	extraEnv: Record<string, string> = {},
+): SpawnSyncReturns<string> {
+	return spawnSync(BINARY_PATH, args, {
+		encoding: "utf-8",
+		timeout: 30_000,
+		env: {
+			PATH: process.env.PATH,
+			HOME: tempHome,
+			...extraEnv,
+		},
+	})
+}

--- a/tests/smoke/vitest.config.ts
+++ b/tests/smoke/vitest.config.ts
@@ -1,0 +1,8 @@
+import { defineConfig } from "vitest/config"
+
+export default defineConfig({
+	test: {
+		include: ["tests/smoke/**/*.test.ts"],
+		testTimeout: 30_000,
+	},
+})

--- a/tests/smoke/web-fetch.test.ts
+++ b/tests/smoke/web-fetch.test.ts
@@ -1,0 +1,55 @@
+/**
+ * Smoke test — verify the web_fetch tool works end-to-end through the
+ * kimchi-code harness.
+ *
+ * Requires KIMCHI_API_KEY to be set (skipped otherwise).
+ * Writes settings.json into the temp agent dir so the harness discovers
+ * the web-fetch extension through its normal settings-based loading path.
+ */
+
+import { writeFileSync } from "node:fs"
+import { join, resolve } from "node:path"
+import { beforeAll, describe, expect, it } from "vitest"
+import { ensureAgentDir, runBinary } from "./harness.js"
+
+beforeAll(() => {
+	const agentDir = ensureAgentDir()
+	const extensionAbsPath = resolve("extensions/web-fetch")
+	writeFileSync(
+		join(agentDir, "settings.json"),
+		JSON.stringify({ extensions: [extensionAbsPath] }),
+	)
+})
+
+describe("web_fetch smoke tests", () => {
+	it.skipIf(!process.env.KIMCHI_API_KEY)(
+		"web_fetch tool is registered and available",
+		() => {
+			const result = runBinary(
+				["-p", "List all your available tools, one per line. Just the tool names, nothing else."],
+				{ KIMCHI_API_KEY: process.env.KIMCHI_API_KEY! },
+			)
+
+			expect(result.status).toBe(0)
+			expect(result.stdout.toLowerCase()).toContain("web_fetch")
+		},
+	)
+
+	it.skipIf(!process.env.KIMCHI_API_KEY)(
+		"fetches a web page via the web_fetch tool",
+		() => {
+			const result = runBinary(
+				[
+					"-p",
+					"Use the web_fetch tool to fetch https://example.com in markdown format. After fetching, repeat the first heading you see in the page content verbatim.",
+				],
+				{ KIMCHI_API_KEY: process.env.KIMCHI_API_KEY! },
+			)
+
+			expect(result.status).toBe(0)
+			const output = result.stdout.trim()
+			expect(output).not.toBe("")
+			expect(output.toLowerCase()).toContain("example domain")
+		},
+	)
+})


### PR DESCRIPTION
## Summary

Adds a `web_fetch` tool to kimchi-code as an in-repo extension (`extensions/web-fetch/`). The tool fetches web pages — including JavaScript-rendered SPAs — and converts HTML to clean markdown for the coding agent to consume.

### What it does

- Fetches any URL using **Playwright** (headless Chromium) as the primary fetcher, with automatic **fallback to native `fetch()`** when Playwright/Chromium is not installed
- Converts HTML to **markdown** (default), plain text, or raw HTML via Turndown
- **Browser pool** — single Chromium instance with lazy init, tab reuse (~100ms vs 1-2s cold start), idle timeout (60s), and crash recovery
- **Session-scoped cache** with 15-min TTL and LRU eviction (100 entries) — enables drill-down workflows without re-fetching
- **SSRF protection** — blocks private IPs (10.x, 172.16-31.x, 192.168.x, 127.x, 169.254.x, ::1, fc00::/7), localhost, and cloud metadata endpoints
- Response size limit (5MB), output truncation, configurable timeout (default 30s, max 120s)
- Strips script/style/meta tags before conversion
- Follows redirects automatically, reports final URL in metadata

### Tool parameters

| Parameter | Type | Default | Description |
|-----------|------|---------|-------------|
| `url` | string (required) | — | URL to fetch (`http://` or `https://`) |
| `format` | `markdown` \| `text` \| `html` | `markdown` | Output format |
| `timeout` | number | 30 | Timeout in seconds (max 120) |