### PR TITLE
LLM-1298: Auto-discover available Kimchi models

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6,7 +6,7 @@ settings:
 
 patchedDependencies:
   '@mariozechner/pi-coding-agent':
-    hash: 8d1e6f2a2b885a4f848c2487023a978247d0cecad90cd7c6673601fbd93b8803
+    hash: b966969e9ec0a9ab77fbeeae4e179380093a6acfb96e8249aa74cf4798e719d6
     path: patches/@mariozechner__pi-coding-agent.patch
 
 importers:
@@ -15,7 +15,7 @@ importers:
     dependencies:
       '@mariozechner/pi-coding-agent':
         specifier: ^0.65.2
-        version: 0.65.2(patch_hash=8d1e6f2a2b885a4f848c2487023a978247d0cecad90cd7c6673601fbd93b8803)(ws@8.20.0)(zod@4.3.6)
+        version: 0.65.2(patch_hash=b966969e9ec0a9ab77fbeeae4e179380093a6acfb96e8249aa74cf4798e719d6)(ws@8.20.0)(zod@4.3.6)
       '@mariozechner/pi-tui':
         specifier: ^0.65.2
         version: 0.65.2
@@ -2323,7 +2323,7 @@ snapshots:
       - ws
       - zod
 
-  '@mariozechner/pi-coding-agent@0.65.2(patch_hash=8d1e6f2a2b885a4f848c2487023a978247d0cecad90cd7c6673601fbd93b8803)(ws@8.20.0)(zod@4.3.6)':
+  '@mariozechner/pi-coding-agent@0.65.2(patch_hash=b966969e9ec0a9ab77fbeeae4e179380093a6acfb96e8249aa74cf4798e719d6)(ws@8.20.0)(zod@4.3.6)':
     dependencies:
       '@mariozechner/jiti': 2.6.5
       '@mariozechner/pi-agent-core': 0.65.2(ws@8.20.0)(zod@4.3.6)

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6,7 +6,7 @@ settings:
 
 patchedDependencies:
   '@mariozechner/pi-coding-agent':
-    hash: b966969e9ec0a9ab77fbeeae4e179380093a6acfb96e8249aa74cf4798e719d6
+    hash: 8d1e6f2a2b885a4f848c2487023a978247d0cecad90cd7c6673601fbd93b8803
     path: patches/@mariozechner__pi-coding-agent.patch
 
 importers:
@@ -15,7 +15,7 @@ importers:
     dependencies:
       '@mariozechner/pi-coding-agent':
         specifier: ^0.65.2
-        version: 0.65.2(patch_hash=b966969e9ec0a9ab77fbeeae4e179380093a6acfb96e8249aa74cf4798e719d6)(ws@8.20.0)(zod@4.3.6)
+        version: 0.65.2(patch_hash=8d1e6f2a2b885a4f848c2487023a978247d0cecad90cd7c6673601fbd93b8803)(ws@8.20.0)(zod@4.3.6)
       '@mariozechner/pi-tui':
         specifier: ^0.65.2
         version: 0.65.2
@@ -2323,7 +2323,7 @@ snapshots:
       - ws
       - zod
 
-  '@mariozechner/pi-coding-agent@0.65.2(patch_hash=b966969e9ec0a9ab77fbeeae4e179380093a6acfb96e8249aa74cf4798e719d6)(ws@8.20.0)(zod@4.3.6)':
+  '@mariozechner/pi-coding-agent@0.65.2(patch_hash=8d1e6f2a2b885a4f848c2487023a978247d0cecad90cd7c6673601fbd93b8803)(ws@8.20.0)(zod@4.3.6)':
     dependencies:
       '@mariozechner/jiti': 2.6.5
       '@mariozechner/pi-agent-core': 0.65.2(ws@8.20.0)(zod@4.3.6)

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -51,10 +51,7 @@ try {
 	// Delegate to pi-mono's CLI main function, injecting the kimchi extension
 	const { main } = await import("@mariozechner/pi-coding-agent")
 	await main(process.argv.slice(2), {
-		extensionFactories: [
-			subagentExtension,
-			webFetchExtension,
-		],
+		extensionFactories: [subagentExtension, webFetchExtension],
 	})
 } catch (err) {
 	console.error(err instanceof Error ? err.message : String(err))

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -39,7 +39,10 @@ try {
 
 	// Ensure models.json exists with Cast AI provider configuration
 	const modelsJsonPath = resolve(agentDir, "models.json")
-	await updateModelsConfig(modelsJsonPath, config.apiKey)
+	const modelsResult = await updateModelsConfig(modelsJsonPath, config.apiKey)
+	if (modelsResult.source === "default") {
+		console.error(`Warning: using default models (${modelsResult.error})`)
+	}
 
 	// Suppress Node.js warnings (same as pi-mono's own cli.js)
 	process.emitWarning = () => {}

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -28,7 +28,7 @@ process.env.PI_SKIP_VERSION_CHECK = "1"
 import { loadConfig } from "./config.js"
 import subagentExtension from "./extensions/subagent.js"
 import webFetchExtension from "./extensions/web-fetch/index.js"
-import { ensureModelsConfig } from "./models.js"
+import { updateModelsConfig } from "./models.js"
 
 try {
 	const config = loadConfig()
@@ -39,7 +39,7 @@ try {
 
 	// Ensure models.json exists with Cast AI provider configuration
 	const modelsJsonPath = resolve(agentDir, "models.json")
-	ensureModelsConfig(modelsJsonPath)
+	await updateModelsConfig(modelsJsonPath, config.apiKey)
 
 	// Suppress Node.js warnings (same as pi-mono's own cli.js)
 	process.emitWarning = () => {}
@@ -50,7 +50,12 @@ try {
 
 	// Delegate to pi-mono's CLI main function, injecting the kimchi extension
 	const { main } = await import("@mariozechner/pi-coding-agent")
-	await main(process.argv.slice(2), { extensionFactories: [subagentExtension, webFetchExtension] })
+	await main(process.argv.slice(2), {
+		extensionFactories: [
+			subagentExtension,
+			webFetchExtension,
+		],
+	})
 } catch (err) {
 	console.error(err instanceof Error ? err.message : String(err))
 	process.exit(1)

--- a/src/models.test.ts
+++ b/src/models.test.ts
@@ -1,0 +1,226 @@
+import { existsSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
+import { hasKimchiProvider, updateModelsConfig } from "./models.js"
+
+describe("updateModelsConfig", () => {
+	let tempDir: string
+	let modelsJsonPath: string
+
+	beforeEach(() => {
+		tempDir = mkdtempSync(join(tmpdir(), "kimchi-models-test-"))
+		modelsJsonPath = join(tempDir, "models.json")
+		vi.stubGlobal("fetch", vi.fn())
+	})
+
+	afterEach(() => {
+		rmSync(tempDir, { recursive: true, force: true })
+		vi.restoreAllMocks()
+	})
+
+	it("overwrites existing file with fetched models", async () => {
+		const existing = { providers: { custom: {} } }
+		writeFileSync(modelsJsonPath, JSON.stringify(existing))
+
+		vi.mocked(fetch).mockResolvedValueOnce({
+			ok: true,
+			json: async () => ({ models: ["new-model"] }),
+		} as Response)
+
+		await updateModelsConfig(modelsJsonPath, "test-key")
+
+		const content = JSON.parse(readFileSync(modelsJsonPath, "utf-8"))
+		expect(content.providers["kimchi-dev"].models.map((m: { id: string }) => m.id)).toEqual([
+			"new-model",
+		])
+	})
+
+	it("writes discovered models when fetch succeeds", async () => {
+		vi.mocked(fetch).mockResolvedValueOnce({
+			ok: true,
+			json: async () => ({
+				models: ["my-model-1", "my-model-2"],
+			}),
+		} as Response)
+
+		const result = await updateModelsConfig(modelsJsonPath, "test-key")
+
+		expect(result).toEqual({ source: "discovered", models: ["my-model-1", "my-model-2"] })
+		expect(existsSync(modelsJsonPath)).toBe(true)
+		const config = JSON.parse(readFileSync(modelsJsonPath, "utf-8"))
+		expect(config.providers["kimchi-dev"].models).toEqual([
+			{
+				id: "my-model-1",
+				name: "My Model 1",
+				reasoning: false,
+				input: ["text"],
+				contextWindow: 131072,
+				maxTokens: 16384,
+				cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+			},
+			{
+				id: "my-model-2",
+				name: "My Model 2",
+				reasoning: false,
+				input: ["text"],
+				contextWindow: 131072,
+				maxTokens: 16384,
+				cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+			},
+		])
+	})
+
+	it("uses correct auth header when fetching models", async () => {
+		vi.mocked(fetch).mockResolvedValueOnce({
+			ok: true,
+			json: async () => ({ models: ["m1"] }),
+		} as Response)
+
+		await updateModelsConfig(modelsJsonPath, "my-api-key")
+
+		expect(fetch).toHaveBeenCalledWith(
+			"https://api.cast.ai/v1/llm/openai/models?providerName=AI%20Enabler",
+			{ headers: { Authorization: "Bearer my-api-key" } },
+		)
+	})
+
+	it("falls back to default models when fetch fails with network error", async () => {
+		vi.mocked(fetch).mockRejectedValueOnce(new Error("network error"))
+
+		const result = await updateModelsConfig(modelsJsonPath, "test-key")
+
+		expect(result).toEqual({
+			source: "default",
+			models: ["kimi-k2.5", "glm-5-fp8", "minimax-m2.5"],
+			error: "network error",
+		})
+		expect(existsSync(modelsJsonPath)).toBe(true)
+		const config = JSON.parse(readFileSync(modelsJsonPath, "utf-8"))
+		expect(config.providers["kimchi-dev"].models.map((m: { id: string }) => m.id)).toEqual([
+			"kimi-k2.5",
+			"glm-5-fp8",
+			"minimax-m2.5",
+		])
+	})
+
+	it("falls back to default models when fetch returns non-ok status", async () => {
+		vi.mocked(fetch).mockResolvedValueOnce({
+			ok: false,
+			status: 401,
+			statusText: "Unauthorized",
+		} as Response)
+
+		const result = await updateModelsConfig(modelsJsonPath, "bad-key")
+
+		expect(result).toEqual({
+			source: "default",
+			models: ["kimi-k2.5", "glm-5-fp8", "minimax-m2.5"],
+			error: "Failed to fetch models: 401 Unauthorized",
+		})
+		expect(existsSync(modelsJsonPath)).toBe(true)
+		const config = JSON.parse(readFileSync(modelsJsonPath, "utf-8"))
+		expect(config.providers["kimchi-dev"].models.map((m: { id: string }) => m.id)).toEqual([
+			"kimi-k2.5",
+			"glm-5-fp8",
+			"minimax-m2.5",
+		])
+	})
+
+	it("falls back to default models when fetch returns empty list", async () => {
+		vi.mocked(fetch).mockResolvedValueOnce({
+			ok: true,
+			json: async () => ({ models: [] }),
+		} as Response)
+
+		const result = await updateModelsConfig(modelsJsonPath, "test-key")
+
+		expect(result).toEqual({
+			source: "default",
+			models: ["kimi-k2.5", "glm-5-fp8", "minimax-m2.5"],
+			error: "API returned empty model list",
+		})
+		const config = JSON.parse(readFileSync(modelsJsonPath, "utf-8"))
+		expect(config.providers["kimchi-dev"].models.map((m: { id: string }) => m.id)).toEqual([
+			"kimi-k2.5",
+			"glm-5-fp8",
+			"minimax-m2.5",
+		])
+	})
+
+	it("sorts models alphabetically", async () => {
+		vi.mocked(fetch).mockResolvedValueOnce({
+			ok: true,
+			json: async () => ({ models: ["zebra-model", "alpha-model", "mango-model"] }),
+		} as Response)
+
+		const result = await updateModelsConfig(modelsJsonPath, "test-key")
+
+		expect(result).toEqual({
+			source: "discovered",
+			models: ["alpha-model", "mango-model", "zebra-model"],
+		})
+	})
+
+	it("excludes models matching smoll* pattern", async () => {
+		vi.mocked(fetch).mockResolvedValueOnce({
+			ok: true,
+			json: async () => ({ models: ["good-model", "smollm2-360m", "smollm2-135m"] }),
+		} as Response)
+
+		const result = await updateModelsConfig(modelsJsonPath, "test-key")
+
+		expect(result).toEqual({ source: "discovered", models: ["good-model"] })
+	})
+
+	it("excludes models matching qwen* pattern", async () => {
+		vi.mocked(fetch).mockResolvedValueOnce({
+			ok: true,
+			json: async () => ({ models: ["good-model", "qwen3-coder-next-fp8"] }),
+		} as Response)
+
+		const result = await updateModelsConfig(modelsJsonPath, "test-key")
+
+		expect(result).toEqual({ source: "discovered", models: ["good-model"] })
+	})
+
+	it("creates nested directories if they do not exist", async () => {
+		vi.mocked(fetch).mockResolvedValueOnce({
+			ok: true,
+			json: async () => ({ models: ["m1"] }),
+		} as Response)
+
+		const nestedPath = join(tempDir, "a", "b", "models.json")
+		await updateModelsConfig(nestedPath, "test-key")
+
+		expect(existsSync(nestedPath)).toBe(true)
+	})
+})
+
+describe("hasKimchiProvider", () => {
+	let tempDir: string
+
+	beforeEach(() => {
+		tempDir = mkdtempSync(join(tmpdir(), "kimchi-models-test-"))
+	})
+
+	afterEach(() => {
+		rmSync(tempDir, { recursive: true, force: true })
+	})
+
+	it("returns false when file does not exist", () => {
+		expect(hasKimchiProvider(join(tempDir, "missing.json"))).toBe(false)
+	})
+
+	it("returns false when file has no kimchi-dev provider", () => {
+		const p = join(tempDir, "models.json")
+		writeFileSync(p, JSON.stringify({ providers: { other: {} } }))
+		expect(hasKimchiProvider(p)).toBe(false)
+	})
+
+	it("returns true when file contains kimchi-dev provider", () => {
+		const p = join(tempDir, "models.json")
+		writeFileSync(p, JSON.stringify({ providers: { "kimchi-dev": { models: [] } } }))
+		expect(hasKimchiProvider(p)).toBe(true)
+	})
+})

--- a/src/models.test.ts
+++ b/src/models.test.ts
@@ -31,9 +31,7 @@ describe("updateModelsConfig", () => {
 		await updateModelsConfig(modelsJsonPath, "test-key")
 
 		const content = JSON.parse(readFileSync(modelsJsonPath, "utf-8"))
-		expect(content.providers["kimchi-dev"].models.map((m: { id: string }) => m.id)).toEqual([
-			"new-model",
-		])
+		expect(content.providers["kimchi-dev"].models.map((m: { id: string }) => m.id)).toEqual(["new-model"])
 	})
 
 	it("writes discovered models when fetch succeeds", async () => {
@@ -79,10 +77,9 @@ describe("updateModelsConfig", () => {
 
 		await updateModelsConfig(modelsJsonPath, "my-api-key")
 
-		expect(fetch).toHaveBeenCalledWith(
-			"https://api.cast.ai/v1/llm/openai/models?providerName=AI%20Enabler",
-			{ headers: { Authorization: "Bearer my-api-key" } },
-		)
+		expect(fetch).toHaveBeenCalledWith("https://api.cast.ai/v1/llm/openai/models?providerName=AI%20Enabler", {
+			headers: { Authorization: "Bearer my-api-key" },
+		})
 	})
 
 	it("falls back to default models when fetch fails with network error", async () => {

--- a/src/models.test.ts
+++ b/src/models.test.ts
@@ -69,7 +69,7 @@ describe("updateModelsConfig", () => {
 		])
 	})
 
-	it("uses correct auth header when fetching models", async () => {
+	it("uses correct auth header and timeout when fetching models", async () => {
 		vi.mocked(fetch).mockResolvedValueOnce({
 			ok: true,
 			json: async () => ({ models: ["m1"] }),
@@ -77,9 +77,13 @@ describe("updateModelsConfig", () => {
 
 		await updateModelsConfig(modelsJsonPath, "my-api-key")
 
-		expect(fetch).toHaveBeenCalledWith("https://api.cast.ai/v1/llm/openai/models?providerName=AI%20Enabler", {
-			headers: { Authorization: "Bearer my-api-key" },
-		})
+		expect(fetch).toHaveBeenCalledWith(
+			"https://api.cast.ai/v1/llm/openai/models?providerName=AI%20Enabler",
+			expect.objectContaining({
+				headers: { Authorization: "Bearer my-api-key" },
+				signal: expect.any(AbortSignal),
+			}),
+		)
 	})
 
 	it("falls back to default models when fetch fails with network error", async () => {
@@ -143,6 +147,46 @@ describe("updateModelsConfig", () => {
 			"glm-5-fp8",
 			"minimax-m2.5",
 		])
+	})
+
+	it("falls back to default models when all fetched models are filtered out", async () => {
+		vi.mocked(fetch).mockResolvedValueOnce({
+			ok: true,
+			json: async () => ({ models: ["smollm2-360m", "qwen3-coder-next-fp8"] }),
+		} as Response)
+
+		const result = await updateModelsConfig(modelsJsonPath, "test-key")
+
+		expect(result).toEqual({
+			source: "default",
+			models: ["kimi-k2.5", "glm-5-fp8", "minimax-m2.5"],
+			error: "API returned no usable models after filtering",
+		})
+	})
+
+	it("falls back to default models when response has unexpected shape", async () => {
+		vi.mocked(fetch).mockResolvedValueOnce({
+			ok: true,
+			json: async () => ({ data: "unexpected" }),
+		} as Response)
+
+		const result = await updateModelsConfig(modelsJsonPath, "test-key")
+
+		expect(result).toEqual({
+			source: "default",
+			models: ["kimi-k2.5", "glm-5-fp8", "minimax-m2.5"],
+			error: "Unexpected response shape from models API",
+		})
+	})
+
+	it("falls back to default models on fetch timeout", async () => {
+		const abortError = new DOMException("The operation was aborted.", "AbortError")
+		vi.mocked(fetch).mockRejectedValueOnce(abortError)
+
+		const result = await updateModelsConfig(modelsJsonPath, "test-key")
+
+		expect(result.source).toBe("default")
+		expect(result.models).toEqual(["kimi-k2.5", "glm-5-fp8", "minimax-m2.5"])
 	})
 
 	it("sorts models alphabetically", async () => {

--- a/src/models.ts
+++ b/src/models.ts
@@ -7,9 +7,7 @@ const CAST_AI_LLM_BASE_URL = "https://llm.cast.ai/openai/v1"
 const EXCLUDED_MODEL_PATTERNS = [/^smoll/i, /^qwen/i]
 
 function filterAndSortModels(models: string[]): string[] {
-	return models
-		.filter((id) => !EXCLUDED_MODEL_PATTERNS.some((re) => re.test(id)))
-		.sort((a, b) => a.localeCompare(b))
+	return models.filter((id) => !EXCLUDED_MODEL_PATTERNS.some((re) => re.test(id))).sort((a, b) => a.localeCompare(b))
 }
 
 interface CastAIModelsResponse {
@@ -112,10 +110,7 @@ export type ModelsConfigResult =
  * fails. Always overwrites any existing file so the model list stays current
  * on every startup.
  */
-export async function updateModelsConfig(
-	modelsJsonPath: string,
-	apiKey: string,
-): Promise<ModelsConfigResult> {
+export async function updateModelsConfig(modelsJsonPath: string, apiKey: string): Promise<ModelsConfigResult> {
 	const dir = dirname(modelsJsonPath)
 	mkdirSync(dir, { recursive: true })
 

--- a/src/models.ts
+++ b/src/models.ts
@@ -2,7 +2,8 @@ import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs"
 import { dirname } from "node:path"
 
 const CAST_AI_MODELS_API = "https://api.cast.ai/v1/llm/openai/models?providerName=AI%20Enabler"
-const CAST_AI_LLM_BASE_URL = "https://llm.cast.ai/openai/v1"
+const CAST_AI_LLM_BASE_URL = "https://llm.kimchi.dev/openai/v1"
+const FETCH_TIMEOUT_MS = 5000
 
 const EXCLUDED_MODEL_PATTERNS = [/^smoll/i, /^qwen/i]
 
@@ -24,12 +25,16 @@ function modelIdToName(id: string): string {
 async function fetchAvailableModels(apiKey: string): Promise<string[]> {
 	const response = await fetch(CAST_AI_MODELS_API, {
 		headers: { Authorization: `Bearer ${apiKey}` },
+		signal: AbortSignal.timeout(FETCH_TIMEOUT_MS),
 	})
 	if (!response.ok) {
 		throw new Error(`Failed to fetch models: ${response.status} ${response.statusText}`)
 	}
-	const body = (await response.json()) as CastAIModelsResponse
-	return body.models
+	const body = await response.json()
+	if (!body || typeof body !== "object" || !Array.isArray(body.models)) {
+		throw new Error("Unexpected response shape from models API")
+	}
+	return (body as CastAIModelsResponse).models
 }
 
 function buildModelsConfig(models: string[]) {
@@ -63,7 +68,7 @@ function buildModelsConfig(models: string[]) {
 const DEFAULT_MODELS_CONFIG = {
 	providers: {
 		"kimchi-dev": {
-			baseUrl: "https://llm.cast.ai/openai/v1",
+			baseUrl: CAST_AI_LLM_BASE_URL,
 			apiKey: "KIMCHI_API_KEY",
 			api: "openai-completions",
 			authHeader: true,
@@ -125,7 +130,7 @@ export async function updateModelsConfig(modelsJsonPath: string, apiKey: string)
 		return {
 			source: "default",
 			models: DEFAULT_MODELS_CONFIG.providers["kimchi-dev"].models.map((m) => m.id),
-			error: "API returned empty model list",
+			error: fetched.length === 0 ? "API returned empty model list" : "API returned no usable models after filtering",
 		}
 	} catch (err) {
 		writeFileSync(modelsJsonPath, JSON.stringify(DEFAULT_MODELS_CONFIG, null, "\t"), "utf-8")

--- a/src/models.ts
+++ b/src/models.ts
@@ -1,6 +1,61 @@
 import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs"
 import { dirname } from "node:path"
 
+const CAST_AI_MODELS_API = "https://api.cast.ai/v1/llm/openai/models?providerName=AI%20Enabler"
+const CAST_AI_LLM_BASE_URL = "https://llm.cast.ai/openai/v1"
+
+const EXCLUDED_MODEL_PATTERNS = [/^smoll/i, /^qwen/i]
+
+function filterAndSortModels(models: string[]): string[] {
+	return models
+		.filter((id) => !EXCLUDED_MODEL_PATTERNS.some((re) => re.test(id)))
+		.sort((a, b) => a.localeCompare(b))
+}
+
+interface CastAIModelsResponse {
+	models: string[]
+}
+
+function modelIdToName(id: string): string {
+	return id
+		.split(/[-_]/)
+		.map((part) => part.charAt(0).toUpperCase() + part.slice(1))
+		.join(" ")
+}
+
+async function fetchAvailableModels(apiKey: string): Promise<string[]> {
+	const response = await fetch(CAST_AI_MODELS_API, {
+		headers: { Authorization: `Bearer ${apiKey}` },
+	})
+	if (!response.ok) {
+		throw new Error(`Failed to fetch models: ${response.status} ${response.statusText}`)
+	}
+	const body = (await response.json()) as CastAIModelsResponse
+	return body.models
+}
+
+function buildModelsConfig(models: string[]) {
+	return {
+		providers: {
+			"kimchi-dev": {
+				baseUrl: CAST_AI_LLM_BASE_URL,
+				apiKey: "KIMCHI_API_KEY",
+				api: "openai-completions",
+				authHeader: true,
+				models: models.map((id) => ({
+					id,
+					name: modelIdToName(id),
+					reasoning: false,
+					input: ["text"],
+					contextWindow: 131072,
+					maxTokens: 16384,
+					cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+				})),
+			},
+		},
+	}
+}
+
 /**
  * The default models.json configuration for the Cast AI provider.
  * Models are registered with the "kimchi-dev" provider name. The apiKey field
@@ -47,19 +102,44 @@ const DEFAULT_MODELS_CONFIG = {
 	},
 }
 
-/**
- * Ensure models.json exists in the agent config directory.
- * If the file doesn't exist, writes the default Cast AI provider configuration.
- * If the file already exists, leaves it untouched (user may have customized it).
- */
-export function ensureModelsConfig(modelsJsonPath: string): void {
-	if (existsSync(modelsJsonPath)) {
-		return
-	}
+export type ModelsConfigResult =
+	| { source: "discovered"; models: string[] }
+	| { source: "default"; models: string[]; error?: string }
 
+/**
+ * Fetch available models from the Cast AI API and write the configuration to
+ * modelsJsonPath. Falls back to the static default configuration if the fetch
+ * fails. Always overwrites any existing file so the model list stays current
+ * on every startup.
+ */
+export async function updateModelsConfig(
+	modelsJsonPath: string,
+	apiKey: string,
+): Promise<ModelsConfigResult> {
 	const dir = dirname(modelsJsonPath)
 	mkdirSync(dir, { recursive: true })
-	writeFileSync(modelsJsonPath, JSON.stringify(DEFAULT_MODELS_CONFIG, null, "\t"), "utf-8")
+
+	try {
+		const fetched = await fetchAvailableModels(apiKey)
+		const models = filterAndSortModels(fetched)
+		if (models.length > 0) {
+			writeFileSync(modelsJsonPath, JSON.stringify(buildModelsConfig(models), null, "\t"), "utf-8")
+			return { source: "discovered", models }
+		}
+		writeFileSync(modelsJsonPath, JSON.stringify(DEFAULT_MODELS_CONFIG, null, "\t"), "utf-8")
+		return {
+			source: "default",
+			models: DEFAULT_MODELS_CONFIG.providers["kimchi-dev"].models.map((m) => m.id),
+			error: "API returned empty model list",
+		}
+	} catch (err) {
+		writeFileSync(modelsJsonPath, JSON.stringify(DEFAULT_MODELS_CONFIG, null, "\t"), "utf-8")
+		return {
+			source: "default",
+			models: DEFAULT_MODELS_CONFIG.providers["kimchi-dev"].models.map((m) => m.id),
+			error: err instanceof Error ? err.message : String(err),
+		}
+	}
 }
 
 /**


### PR DESCRIPTION
### Summary

- Replace the static `ensureModelsConfig` (write-once, never update) with `updateModelsConfig`, which fetches the live model list from the Cast AI API on every startup and overwrites `models.json` to keep it current.
- Filter out deprecated model families (`smoll*`, `qwen*`) and sort remaining models alphabetically before writing.
- Fall back to a hardcoded default config (`kimi-k2.5`, `glm-5-fp8`, `minimax-m2.5`) when the API is unreachable or returns an empty list, so the CLI always starts successfully.
- Add `hasKimchiProvider` utility to detect whether an existing `models.json` already contains the `kimchi-dev` provider block.