### PR TITLE
LLM-1266: Fix release build: upgrade macOS runners to macos-15

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -36,11 +36,11 @@ jobs:
           - target: bun-darwin-x64
             os: darwin
             arch: amd64
-            runner: macos-13
+            runner: macos-15
           - target: bun-darwin-arm64
             os: darwin
             arch: arm64
-            runner: macos-14
+            runner: macos-15
           - target: bun-linux-x64
             os: linux
             arch: amd64


### PR DESCRIPTION
macos-13 was deprecated by GitHub Actions, causing the darwin-x64 build to fail. Upgrade both macOS runners to macos-15 (current GA). Cross-compilation via Bun --target handles architecture differences.