### PR TITLE
LLM-1291: Add sub-agent timeout and budget limits

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6,7 +6,7 @@ settings:
 
 patchedDependencies:
   '@mariozechner/pi-coding-agent':
-    hash: 8d1e6f2a2b885a4f848c2487023a978247d0cecad90cd7c6673601fbd93b8803
+    hash: b966969e9ec0a9ab77fbeeae4e179380093a6acfb96e8249aa74cf4798e719d6
     path: patches/@mariozechner__pi-coding-agent.patch
 
 importers:
@@ -15,7 +15,7 @@ importers:
     dependencies:
       '@mariozechner/pi-coding-agent':
         specifier: ^0.65.2
-        version: 0.65.2(patch_hash=8d1e6f2a2b885a4f848c2487023a978247d0cecad90cd7c6673601fbd93b8803)(ws@8.20.0)(zod@4.3.6)
+        version: 0.65.2(patch_hash=b966969e9ec0a9ab77fbeeae4e179380093a6acfb96e8249aa74cf4798e719d6)(ws@8.20.0)(zod@4.3.6)
       '@mariozechner/pi-tui':
         specifier: ^0.65.2
         version: 0.65.2
@@ -2323,7 +2323,7 @@ snapshots:
       - ws
       - zod
 
-  '@mariozechner/pi-coding-agent@0.65.2(patch_hash=8d1e6f2a2b885a4f848c2487023a978247d0cecad90cd7c6673601fbd93b8803)(ws@8.20.0)(zod@4.3.6)':
+  '@mariozechner/pi-coding-agent@0.65.2(patch_hash=b966969e9ec0a9ab77fbeeae4e179380093a6acfb96e8249aa74cf4798e719d6)(ws@8.20.0)(zod@4.3.6)':
     dependencies:
       '@mariozechner/jiti': 2.6.5
       '@mariozechner/pi-agent-core': 0.65.2(ws@8.20.0)(zod@4.3.6)

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6,7 +6,7 @@ settings:
 
 patchedDependencies:
   '@mariozechner/pi-coding-agent':
-    hash: b966969e9ec0a9ab77fbeeae4e179380093a6acfb96e8249aa74cf4798e719d6
+    hash: 8d1e6f2a2b885a4f848c2487023a978247d0cecad90cd7c6673601fbd93b8803
     path: patches/@mariozechner__pi-coding-agent.patch
 
 importers:
@@ -15,7 +15,7 @@ importers:
     dependencies:
       '@mariozechner/pi-coding-agent':
         specifier: ^0.65.2
-        version: 0.65.2(patch_hash=b966969e9ec0a9ab77fbeeae4e179380093a6acfb96e8249aa74cf4798e719d6)(ws@8.20.0)(zod@4.3.6)
+        version: 0.65.2(patch_hash=8d1e6f2a2b885a4f848c2487023a978247d0cecad90cd7c6673601fbd93b8803)(ws@8.20.0)(zod@4.3.6)
       '@mariozechner/pi-tui':
         specifier: ^0.65.2
         version: 0.65.2
@@ -2323,7 +2323,7 @@ snapshots:
       - ws
       - zod
 
-  '@mariozechner/pi-coding-agent@0.65.2(patch_hash=b966969e9ec0a9ab77fbeeae4e179380093a6acfb96e8249aa74cf4798e719d6)(ws@8.20.0)(zod@4.3.6)':
+  '@mariozechner/pi-coding-agent@0.65.2(patch_hash=8d1e6f2a2b885a4f848c2487023a978247d0cecad90cd7c6673601fbd93b8803)(ws@8.20.0)(zod@4.3.6)':
     dependencies:
       '@mariozechner/jiti': 2.6.5
       '@mariozechner/pi-agent-core': 0.65.2(ws@8.20.0)(zod@4.3.6)

--- a/src/extensions/subagent.test.ts
+++ b/src/extensions/subagent.test.ts
@@ -2,60 +2,63 @@ import { describe, expect, it } from "vitest"
 import { parseSubagentEvent } from "./subagent.js"
 
 describe("parseSubagentEvent", () => {
-	const cases: Record<string, { input: string; expected: { delta: string | null; tokensUsed: number } }> = {
+	const cases: Record<
+		string,
+		{ input: string; expected: { delta: string | null; inputTokens: number; outputTokens: number } }
+	> = {
 		"returns delta for message_update text_delta event": {
 			input: JSON.stringify({
 				type: "message_update",
 				assistantMessageEvent: { type: "text_delta", delta: "hello" },
 			}),
-			expected: { delta: "hello", tokensUsed: 0 },
+			expected: { delta: "hello", inputTokens: 0, outputTokens: 0 },
 		},
 		"returns empty delta string": {
 			input: JSON.stringify({
 				type: "message_update",
 				assistantMessageEvent: { type: "text_delta", delta: "" },
 			}),
-			expected: { delta: "", tokensUsed: 0 },
+			expected: { delta: "", inputTokens: 0, outputTokens: 0 },
 		},
 		"ignores message_update events that are not text_delta": {
 			input: JSON.stringify({
 				type: "message_update",
 				assistantMessageEvent: { type: "thinking_delta", delta: "..." },
 			}),
-			expected: { delta: null, tokensUsed: 0 },
+			expected: { delta: null, inputTokens: 0, outputTokens: 0 },
 		},
-		"returns tokensUsed from message_end with usage": {
+		"returns separate input and output tokens from message_end with usage": {
 			input: JSON.stringify({
 				type: "message_end",
 				message: { usage: { input: 100, output: 40 } },
 			}),
-			expected: { delta: null, tokensUsed: 140 },
+			expected: { delta: null, inputTokens: 100, outputTokens: 40 },
 		},
 		"returns zero tokens from message_end without usage": {
 			input: JSON.stringify({
 				type: "message_end",
 				message: {},
 			}),
-			expected: { delta: null, tokensUsed: 0 },
+			expected: { delta: null, inputTokens: 0, outputTokens: 0 },
 		},
-		"returns zero tokens from message_end with partial usage": {
+		"returns partial tokens from message_end with input only": {
 			input: JSON.stringify({
 				type: "message_end",
 				message: { usage: { input: 50 } },
 			}),
-			expected: { delta: null, tokensUsed: 50 },
+			expected: { delta: null, inputTokens: 50, outputTokens: 0 },
 		},
 		"ignores unrecognised event types": {
 			input: JSON.stringify({ type: "tool_execution_start", toolName: "bash" }),
-			expected: { delta: null, tokensUsed: 0 },
+			expected: { delta: null, inputTokens: 0, outputTokens: 0 },
 		},
 		"ignores blank lines": {
 			input: "   ",
-			expected: { delta: null, tokensUsed: 0 },
+			expected: { delta: null, inputTokens: 0, outputTokens: 0 },
 		},
 		"ignores invalid JSON": {
 			input: "not json {",
-			expected: { delta: null, tokensUsed: 0 },
+			expected: { delta: null, inputTokens: 0, outputTokens: 0 },
 		},
 	}
 

--- a/src/extensions/subagent.test.ts
+++ b/src/extensions/subagent.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, it } from "vitest"
+import { parseSubagentEvent } from "./subagent.js"
+
+describe("parseSubagentEvent", () => {
+	const cases: Record<string, { input: string; expected: { delta: string | null; tokensUsed: number } }> = {
+		"returns delta for message_update text_delta event": {
+			input: JSON.stringify({
+				type: "message_update",
+				assistantMessageEvent: { type: "text_delta", delta: "hello" },
+			}),
+			expected: { delta: "hello", tokensUsed: 0 },
+		},
+		"returns empty delta string": {
+			input: JSON.stringify({
+				type: "message_update",
+				assistantMessageEvent: { type: "text_delta", delta: "" },
+			}),
+			expected: { delta: "", tokensUsed: 0 },
+		},
+		"ignores message_update events that are not text_delta": {
+			input: JSON.stringify({
+				type: "message_update",
+				assistantMessageEvent: { type: "thinking_delta", delta: "..." },
+			}),
+			expected: { delta: null, tokensUsed: 0 },
+		},
+		"returns tokensUsed from message_end with usage": {
+			input: JSON.stringify({
+				type: "message_end",
+				message: { usage: { input: 100, output: 40 } },
+			}),
+			expected: { delta: null, tokensUsed: 140 },
+		},
+		"returns zero tokens from message_end without usage": {
+			input: JSON.stringify({
+				type: "message_end",
+				message: {},
+			}),
+			expected: { delta: null, tokensUsed: 0 },
+		},
+		"returns zero tokens from message_end with partial usage": {
+			input: JSON.stringify({
+				type: "message_end",
+				message: { usage: { input: 50 } },
+			}),
+			expected: { delta: null, tokensUsed: 50 },
+		},
+		"ignores unrecognised event types": {
+			input: JSON.stringify({ type: "tool_execution_start", toolName: "bash" }),
+			expected: { delta: null, tokensUsed: 0 },
+		},
+		"ignores blank lines": {
+			input: "   ",
+			expected: { delta: null, tokensUsed: 0 },
+		},
+		"ignores invalid JSON": {
+			input: "not json {",
+			expected: { delta: null, tokensUsed: 0 },
+		},
+	}
+
+	for (const [name, { input, expected }] of Object.entries(cases)) {
+		it(name, () => {
+			expect(parseSubagentEvent(input)).toEqual(expected)
+		})
+	}
+})

--- a/src/extensions/subagent.ts
+++ b/src/extensions/subagent.ts
@@ -11,14 +11,14 @@ const PROMPT_MAX_LENGTH = 60
 const FOOTER_STATUS_KEY = "subagent-sessions"
 const STDERR_MAX = 8192
 const TIMEOUT_MS = 15 * 60 * 1000
-const DEFAULT_TOKEN_BUDGET = 10_000_000
 
 interface SubagentState {
 	spinnerIdx: number
 	spinnerInterval: ReturnType<typeof setInterval> | undefined
 }
 
-type SubagentFailureReason = "exit_error" | "timeout" | "token_budget_exceeded"
+// Fix 1: add "aborted" to distinguish user cancellation from process crash.
+type SubagentFailureReason = "exit_error" | "timeout" | "token_budget_exceeded" | "aborted"
 
 interface SubagentTokenUsage {
 	input: number
@@ -43,8 +43,10 @@ interface SubagentError {
 }
 
 interface ParsedSubagentEvent {
+	// Fix 3: delta is string | null — never a number.
 	delta: string | null
-	tokensUsed: number
+	inputTokens: number
+	outputTokens: number
 }
 
 function resolveTsx(): string | undefined {
@@ -77,37 +79,39 @@ function getSubagentInvocation(args: string[]): { command: string; args: string[
 }
 
 // Parses a single JSON line from the subagent's --mode json stdout stream.
-// Returns text delta from message_update/text_delta events, and total tokens
-// (input + output) from message_end events.
+// Returns text delta from message_update/text_delta events, and separate
+// input/output token counts from message_end events.
 // The event shapes are internal to pi-coding-agent and may change across versions.
 export function parseSubagentEvent(line: string): ParsedSubagentEvent {
-	if (!line.trim()) return { delta: null, tokensUsed: 0 }
+	if (!line.trim()) return { delta: null, inputTokens: 0, outputTokens: 0 }
 	let event: Record<string, unknown>
 	try {
 		event = JSON.parse(line)
 	} catch {
-		return { delta: null, tokensUsed: 0 }
+		return { delta: null, inputTokens: 0, outputTokens: 0 }
 	}
 
 	if (event.type === "message_update") {
 		const assistantEvent = event.assistantMessageEvent as Record<string, unknown> | undefined
 		if (assistantEvent?.type === "text_delta" && typeof assistantEvent.delta === "string") {
-			return { delta: assistantEvent.delta, tokensUsed: 0 }
+			return { delta: assistantEvent.delta, inputTokens: 0, outputTokens: 0 }
 		}
-		return { delta: null, tokensUsed: 0 }
+		return { delta: null, inputTokens: 0, outputTokens: 0 }
 	}
 
+	// Fix 4: track input and output tokens separately from message_end — the provider
+	// reports them as distinct fields, no approximation needed.
 	if (event.type === "message_end") {
 		const message = event.message as Record<string, unknown> | undefined
 		const usage = message?.usage as Record<string, unknown> | undefined
 		if (usage) {
-			const input = typeof usage.input === "number" ? usage.input : 0
-			const output = typeof usage.output === "number" ? usage.output : 0
-			return { delta: null, tokensUsed: input + output }
+			const inputTokens = typeof usage.input === "number" ? usage.input : 0
+			const outputTokens = typeof usage.output === "number" ? usage.output : 0
+			return { delta: null, inputTokens, outputTokens }
 		}
 	}
 
-	return { delta: null, tokensUsed: 0 }
+	return { delta: null, inputTokens: 0, outputTokens: 0 }
 }
 
 function spawnSubagent(
@@ -136,13 +140,16 @@ function spawnSubagent(
 		let buffer = ""
 		let accumulated = ""
 		let stderr = ""
-		let totalTokensUsed = 0
 		let inputTokens = 0
 		let outputTokens = 0
 		let failureReason: SubagentFailureReason | undefined
+		// Fix 7: track actual process exit, not whether .kill() was called.
+		let closed = false
 
+		// Fix 8: single exit path — cleans up timeout and abort listener.
 		const finish = (exitCode: number) => {
 			clearTimeout(timeoutHandle)
+			combinedSignal.removeEventListener("abort", onAbort)
 			resolve({
 				exitCode,
 				accumulated,
@@ -158,25 +165,22 @@ function spawnSubagent(
 				failureReason = reason
 			}
 			proc.kill("SIGTERM")
+			// Fix 7: use `closed` to detect whether the process has actually exited.
 			setTimeout(() => {
-				if (!proc.killed) proc.kill("SIGKILL")
+				if (!closed) proc.kill("SIGKILL")
 			}, 5000)
 		}
 
 		const processLine = (line: string) => {
-			const { delta, tokensUsed } = parseSubagentEvent(line)
+			const { delta, inputTokens: lineInput, outputTokens: lineOutput } = parseSubagentEvent(line)
 			if (delta !== null) {
 				accumulated += delta
 				onToken(accumulated)
 			}
-			if (tokensUsed > 0) {
-				totalTokensUsed += tokensUsed
-				// Approximate split: pi-agent-core reports input+output combined in message_end.
-				// We track the running total and attribute the increment proportionally on each
-				// message_end. For budget enforcement the total is what matters.
-				inputTokens = Math.round(totalTokensUsed * 0.6)
-				outputTokens = totalTokensUsed - inputTokens
-				if (tokenBudget !== undefined && totalTokensUsed > tokenBudget) {
+			if (lineInput > 0 || lineOutput > 0) {
+				inputTokens += lineInput
+				outputTokens += lineOutput
+				if (tokenBudget !== undefined && inputTokens + outputTokens > tokenBudget) {
 					kill("token_budget_exceeded")
 				}
 			}
@@ -197,27 +201,25 @@ function spawnSubagent(
 		})
 
 		proc.on("close", (code) => {
+			closed = true
 			if (buffer.trim()) processLine(buffer)
 			finish(code ?? 0)
 		})
 
+		// Fix 8: route proc error through finish for unified cleanup.
 		proc.on("error", (err) => {
-			clearTimeout(timeoutHandle)
-			resolve({
-				exitCode: 1,
-				accumulated,
-				stderr: stderr || err.message,
-				tokenUsage: { input: inputTokens, output: outputTokens },
-				failureReason: failureReason ?? "exit_error",
-				durationMs: Date.now() - startedAt,
-			})
+			closed = true
+			if (failureReason === undefined) failureReason = "exit_error"
+			stderr = stderr || err.message
+			finish(1)
 		})
 
+		// Fix 1 & 5: distinguish user-initiated abort from timeout.
 		const onAbort = () => {
-			if (timeoutController.signal.aborted && failureReason === undefined) {
+			if (timeoutController.signal.aborted) {
 				kill("timeout")
 			} else if (failureReason === undefined) {
-				kill("exit_error")
+				kill("aborted")
 			}
 		}
 
@@ -225,7 +227,6 @@ function spawnSubagent(
 			onAbort()
 		} else {
 			combinedSignal.addEventListener("abort", onAbort, { once: true })
-			proc.on("close", () => combinedSignal.removeEventListener("abort", onAbort))
 		}
 	})
 }
@@ -275,6 +276,7 @@ const SubagentParams = Type.Object({
 	}),
 	model: Type.String({ description: "Model ID to use for the subagent (e.g. glm-5-fp8, kimi-k2.5)" }),
 	prompt: Type.String({ description: "Prompt to send to the subagent" }),
+	// Fix 6: tokenBudget is truly optional — no silent default applied.
 	tokenBudget: Type.Optional(
 		Type.Integer({
 			description: "Maximum total tokens (input + output) the subagent may consume. Subagent is killed when exceeded.",
@@ -312,11 +314,12 @@ export default function (pi: ExtensionAPI) {
 			]
 			const invocation = getSubagentInvocation(args)
 
+			// Fix 6: pass tokenBudget only when explicitly provided.
 			const { exitCode, accumulated, stderr, tokenUsage, failureReason, durationMs } = await spawnSubagent(
 				invocation,
 				ctx.cwd,
 				signal,
-				params.tokenBudget ?? DEFAULT_TOKEN_BUDGET,
+				params.tokenBudget,
 				(text) => onUpdate?.({ content: [{ type: "text", text }], details: undefined }),
 			)
 

--- a/src/extensions/subagent.ts
+++ b/src/extensions/subagent.ts
@@ -10,16 +10,40 @@ const SPINNER_FRAMES = ["⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "⠧", 
 const PROMPT_MAX_LENGTH = 60
 const FOOTER_STATUS_KEY = "subagent-sessions"
 const STDERR_MAX = 8192
+const TIMEOUT_MS = 15 * 60 * 1000
 
 interface SubagentState {
 	spinnerIdx: number
 	spinnerInterval: ReturnType<typeof setInterval> | undefined
 }
 
+type SubagentFailureReason = "exit_error" | "timeout" | "token_budget_exceeded"
+
+interface SubagentTokenUsage {
+	input: number
+	output: number
+}
+
 interface SubagentResult {
 	exitCode: number
 	accumulated: string
 	stderr: string
+	tokenUsage: SubagentTokenUsage
+	failureReason: SubagentFailureReason | undefined
+	durationMs: number
+}
+
+interface SubagentError {
+	reason: SubagentFailureReason
+	model: string
+	tokenUsage: SubagentTokenUsage
+	durationMs: number
+	detail: string
+}
+
+interface ParsedSubagentEvent {
+	delta: string | null
+	tokensUsed: number
 }
 
 function resolveTsx(): string | undefined {
@@ -51,34 +75,56 @@ function getSubagentInvocation(args: string[]): { command: string; args: string[
 	return { command: process.execPath, args: [process.argv[1], ...args] }
 }
 
-// Parses a single JSON line from the subagent's --mode json stdout stream and
-// returns the text delta if present, or null otherwise.
-// The event shape (message_update / assistantMessageEvent / text_delta) is
-// internal to pi-coding-agent and may change across versions.
-export function parseSubagentEvent(line: string): string | null {
-	if (!line.trim()) return null
+// Parses a single JSON line from the subagent's --mode json stdout stream.
+// Returns text delta from message_update/text_delta events, and total tokens
+// (input + output) from message_end events.
+// The event shapes are internal to pi-coding-agent and may change across versions.
+export function parseSubagentEvent(line: string): ParsedSubagentEvent {
+	if (!line.trim()) return { delta: null, tokensUsed: 0 }
 	let event: Record<string, unknown>
 	try {
 		event = JSON.parse(line)
 	} catch {
-		return null
+		return { delta: null, tokensUsed: 0 }
 	}
+
 	if (event.type === "message_update") {
 		const assistantEvent = event.assistantMessageEvent as Record<string, unknown> | undefined
 		if (assistantEvent?.type === "text_delta" && typeof assistantEvent.delta === "string") {
-			return assistantEvent.delta
+			return { delta: assistantEvent.delta, tokensUsed: 0 }
+		}
+		return { delta: null, tokensUsed: 0 }
+	}
+
+	if (event.type === "message_end") {
+		const message = event.message as Record<string, unknown> | undefined
+		const usage = message?.usage as Record<string, unknown> | undefined
+		if (usage) {
+			const input = typeof usage.input === "number" ? usage.input : 0
+			const output = typeof usage.output === "number" ? usage.output : 0
+			return { delta: null, tokensUsed: input + output }
 		}
 	}
-	return null
+
+	return { delta: null, tokensUsed: 0 }
 }
 
 function spawnSubagent(
 	invocation: { command: string; args: string[] },
 	cwd: string,
 	signal: AbortSignal | undefined,
+	tokenBudget: number | undefined,
 	onToken: (accumulated: string) => void,
 ): Promise<SubagentResult> {
 	return new Promise((resolve) => {
+		const startedAt = Date.now()
+
+		const timeoutController = new AbortController()
+		const timeoutHandle = setTimeout(() => timeoutController.abort(), TIMEOUT_MS)
+
+		const combinedSignal =
+			signal !== undefined ? AbortSignal.any([signal, timeoutController.signal]) : timeoutController.signal
+
 		const proc = spawn(invocation.command, invocation.args, {
 			cwd,
 			shell: false,
@@ -89,12 +135,49 @@ function spawnSubagent(
 		let buffer = ""
 		let accumulated = ""
 		let stderr = ""
+		let totalTokensUsed = 0
+		let inputTokens = 0
+		let outputTokens = 0
+		let failureReason: SubagentFailureReason | undefined
+
+		const finish = (exitCode: number) => {
+			clearTimeout(timeoutHandle)
+			resolve({
+				exitCode,
+				accumulated,
+				stderr,
+				tokenUsage: { input: inputTokens, output: outputTokens },
+				failureReason,
+				durationMs: Date.now() - startedAt,
+			})
+		}
+
+		const kill = (reason: SubagentFailureReason) => {
+			if (failureReason === undefined) {
+				failureReason = reason
+			}
+			proc.kill("SIGTERM")
+			setTimeout(() => {
+				if (!proc.killed) proc.kill("SIGKILL")
+			}, 5000)
+		}
 
 		const processLine = (line: string) => {
-			const delta = parseSubagentEvent(line)
+			const { delta, tokensUsed } = parseSubagentEvent(line)
 			if (delta !== null) {
 				accumulated += delta
 				onToken(accumulated)
+			}
+			if (tokensUsed > 0) {
+				totalTokensUsed += tokensUsed
+				// Approximate split: pi-agent-core reports input+output combined in message_end.
+				// We track the running total and attribute the increment proportionally on each
+				// message_end. For budget enforcement the total is what matters.
+				inputTokens = Math.round(totalTokensUsed * 0.6)
+				outputTokens = totalTokensUsed - inputTokens
+				if (tokenBudget !== undefined && totalTokensUsed > tokenBudget) {
+					kill("token_budget_exceeded")
+				}
 			}
 		}
 
@@ -114,23 +197,34 @@ function spawnSubagent(
 
 		proc.on("close", (code) => {
 			if (buffer.trim()) processLine(buffer)
-			resolve({ exitCode: code ?? 0, accumulated, stderr })
+			finish(code ?? 0)
 		})
 
-		proc.on("error", (err) => resolve({ exitCode: 1, accumulated, stderr: stderr || err.message }))
+		proc.on("error", (err) => {
+			clearTimeout(timeoutHandle)
+			resolve({
+				exitCode: 1,
+				accumulated,
+				stderr: stderr || err.message,
+				tokenUsage: { input: inputTokens, output: outputTokens },
+				failureReason: failureReason ?? "exit_error",
+				durationMs: Date.now() - startedAt,
+			})
+		})
 
-		if (signal) {
-			const kill = () => {
-				proc.kill("SIGTERM")
-				setTimeout(() => {
-					if (!proc.killed) proc.kill("SIGKILL")
-				}, 5000)
+		const onAbort = () => {
+			if (timeoutController.signal.aborted && failureReason === undefined) {
+				kill("timeout")
+			} else if (failureReason === undefined) {
+				kill("exit_error")
 			}
-			if (signal.aborted) kill()
-			else {
-				signal.addEventListener("abort", kill, { once: true })
-				proc.on("close", () => signal.removeEventListener("abort", kill))
-			}
+		}
+
+		if (combinedSignal.aborted) {
+			onAbort()
+		} else {
+			combinedSignal.addEventListener("abort", onAbort, { once: true })
+			proc.on("close", () => combinedSignal.removeEventListener("abort", onAbort))
 		}
 	})
 }
@@ -152,17 +246,23 @@ function clearSpinner(state: SubagentState) {
 	}
 }
 
+function buildErrorResponse(error: SubagentError): string {
+	return JSON.stringify(error)
+}
+
 const SubagentParams = Type.Object({
 	provider: Type.String({
 		description:
 			'Provider name for the subagent model (e.g. "kimchi-dev"). Must match the provider registered in models.json.',
 	}),
-	model: Type.String({
-		description: "Model ID to use for the subagent (e.g. glm-5-fp8, kimi-k2.5)",
-	}),
-	prompt: Type.String({
-		description: "Prompt to send to the subagent",
-	}),
+	model: Type.String({ description: "Model ID to use for the subagent (e.g. glm-5-fp8, kimi-k2.5)" }),
+	prompt: Type.String({ description: "Prompt to send to the subagent" }),
+	tokenBudget: Type.Optional(
+		Type.Integer({
+			description: "Maximum total tokens (input + output) the subagent may consume. Subagent is killed when exceeded.",
+			minimum: 1,
+		}),
+	),
 })
 
 export default function (pi: ExtensionAPI) {
@@ -180,7 +280,7 @@ export default function (pi: ExtensionAPI) {
 		description:
 			"Spawn an isolated subagent process with the given provider, model, and prompt. " +
 			'Both provider and model are required — provider must match the model\'s registered provider name (e.g. "kimchi-dev"). ' +
-			"The subagent runs in a separate pi process with no shared context and returns its final response.",
+			`The subagent runs in a separate pi process with no shared context and returns its final response. Hard timeout: ${TIMEOUT_MS / 60000} minutes.`,
 		parameters: SubagentParams,
 
 		async execute(_toolCallId, params, signal, onUpdate, ctx) {
@@ -197,8 +297,12 @@ export default function (pi: ExtensionAPI) {
 			]
 			const invocation = getSubagentInvocation(args)
 
-			const { exitCode, accumulated, stderr } = await spawnSubagent(invocation, ctx.cwd, signal, (text) =>
-				onUpdate?.({ content: [{ type: "text", text }], details: undefined }),
+			const { exitCode, accumulated, stderr, tokenUsage, failureReason, durationMs } = await spawnSubagent(
+				invocation,
+				ctx.cwd,
+				signal,
+				params.tokenBudget,
+				(text) => onUpdate?.({ content: [{ type: "text", text }], details: undefined }),
 			)
 
 			sessionCounts.set(params.model, (sessionCounts.get(params.model) ?? 0) + 1)
@@ -206,10 +310,16 @@ export default function (pi: ExtensionAPI) {
 				ctx.ui.setStatus(FOOTER_STATUS_KEY, formatFooterStatus(sessionCounts, ctx.ui.theme))
 			}
 
-			if (exitCode !== 0) {
-				const errorMsg = stderr.trim() || accumulated || "(no output)"
+			if (failureReason !== undefined || exitCode !== 0) {
+				const error: SubagentError = {
+					reason: failureReason ?? "exit_error",
+					model: params.model,
+					tokenUsage,
+					durationMs,
+					detail: stderr.trim() || accumulated || "(no output)",
+				}
 				return {
-					content: [{ type: "text", text: `Subagent failed (exit ${exitCode}): ${errorMsg}` }],
+					content: [{ type: "text", text: buildErrorResponse(error) }],
 					details: undefined,
 					isError: true,
 				}

--- a/src/extensions/subagent.ts
+++ b/src/extensions/subagent.ts
@@ -11,6 +11,7 @@ const PROMPT_MAX_LENGTH = 60
 const FOOTER_STATUS_KEY = "subagent-sessions"
 const STDERR_MAX = 8192
 const TIMEOUT_MS = 15 * 60 * 1000
+const DEFAULT_TOKEN_BUDGET = 10_000_000
 
 interface SubagentState {
 	spinnerIdx: number
@@ -246,6 +247,23 @@ function clearSpinner(state: SubagentState) {
 	}
 }
 
+interface SubagentStats {
+	durationMs: number
+	tokenUsage: SubagentTokenUsage
+}
+
+function formatDuration(ms: number): string {
+	if (ms < 1000) return `${ms}ms`
+	return `${(ms / 1000).toFixed(1)}s`
+}
+
+function formatStats(stats: SubagentStats, theme: Theme): string {
+	const duration = theme.fg("dim", formatDuration(stats.durationMs))
+	const input = theme.fg("dim", `↑${stats.tokenUsage.input.toLocaleString()}`)
+	const output = theme.fg("dim", `↓${stats.tokenUsage.output.toLocaleString()}`)
+	return `- ${duration}  ${input}  ${output}`
+}
+
 function buildErrorResponse(error: SubagentError): string {
 	return JSON.stringify(error)
 }
@@ -277,10 +295,7 @@ export default function (pi: ExtensionAPI) {
 	pi.registerTool({
 		name: "subagent",
 		label: "Subagent",
-		description:
-			"Spawn an isolated subagent process with the given provider, model, and prompt. " +
-			'Both provider and model are required — provider must match the model\'s registered provider name (e.g. "kimchi-dev"). ' +
-			`The subagent runs in a separate pi process with no shared context and returns its final response. Hard timeout: ${TIMEOUT_MS / 60000} minutes.`,
+		description: `Spawn an isolated subagent process with the given provider, model, and prompt. Both provider and model are required — provider must match the model's registered provider name (e.g. "kimchi-dev"). The subagent runs in a separate pi process with no shared context and returns its final response. Hard timeout: ${TIMEOUT_MS / 60000} minutes.`,
 		parameters: SubagentParams,
 
 		async execute(_toolCallId, params, signal, onUpdate, ctx) {
@@ -301,7 +316,7 @@ export default function (pi: ExtensionAPI) {
 				invocation,
 				ctx.cwd,
 				signal,
-				params.tokenBudget,
+				params.tokenBudget ?? DEFAULT_TOKEN_BUDGET,
 				(text) => onUpdate?.({ content: [{ type: "text", text }], details: undefined }),
 			)
 
@@ -309,6 +324,8 @@ export default function (pi: ExtensionAPI) {
 			if (ctx.hasUI) {
 				ctx.ui.setStatus(FOOTER_STATUS_KEY, formatFooterStatus(sessionCounts, ctx.ui.theme))
 			}
+
+			const stats: SubagentStats = { durationMs, tokenUsage }
 
 			if (failureReason !== undefined || exitCode !== 0) {
 				const error: SubagentError = {
@@ -320,14 +337,14 @@ export default function (pi: ExtensionAPI) {
 				}
 				return {
 					content: [{ type: "text", text: buildErrorResponse(error) }],
-					details: undefined,
+					details: stats,
 					isError: true,
 				}
 			}
 
 			return {
 				content: [{ type: "text", text: accumulated || "(no output)" }],
-				details: undefined,
+				details: stats,
 			}
 		},
 
@@ -374,6 +391,15 @@ export default function (pi: ExtensionAPI) {
 			component.clear()
 			component.addChild(new Spacer(1))
 			component.addChild(new Text(theme.fg("toolOutput", displayText), 0, 0))
+
+			if (!options.isPartial) {
+				const stats = result.details as SubagentStats | undefined
+				if (stats !== undefined) {
+					component.addChild(new Spacer(1))
+					component.addChild(new Text(formatStats(stats, theme), 0, 0))
+				}
+			}
+
 			return component
 		},
 	})

--- a/src/extensions/subagent.ts
+++ b/src/extensions/subagent.ts
@@ -17,7 +17,6 @@ interface SubagentState {
 	spinnerInterval: ReturnType<typeof setInterval> | undefined
 }
 
-// Fix 1: add "aborted" to distinguish user cancellation from process crash.
 type SubagentFailureReason = "exit_error" | "timeout" | "token_budget_exceeded" | "aborted"
 
 interface SubagentTokenUsage {
@@ -43,7 +42,6 @@ interface SubagentError {
 }
 
 interface ParsedSubagentEvent {
-	// Fix 3: delta is string | null — never a number.
 	delta: string | null
 	inputTokens: number
 	outputTokens: number
@@ -99,8 +97,6 @@ export function parseSubagentEvent(line: string): ParsedSubagentEvent {
 		return { delta: null, inputTokens: 0, outputTokens: 0 }
 	}
 
-	// Fix 4: track input and output tokens separately from message_end — the provider
-	// reports them as distinct fields, no approximation needed.
 	if (event.type === "message_end") {
 		const message = event.message as Record<string, unknown> | undefined
 		const usage = message?.usage as Record<string, unknown> | undefined
@@ -143,10 +139,8 @@ function spawnSubagent(
 		let inputTokens = 0
 		let outputTokens = 0
 		let failureReason: SubagentFailureReason | undefined
-		// Fix 7: track actual process exit, not whether .kill() was called.
 		let closed = false
 
-		// Fix 8: single exit path — cleans up timeout and abort listener.
 		const finish = (exitCode: number) => {
 			clearTimeout(timeoutHandle)
 			combinedSignal.removeEventListener("abort", onAbort)
@@ -165,7 +159,6 @@ function spawnSubagent(
 				failureReason = reason
 			}
 			proc.kill("SIGTERM")
-			// Fix 7: use `closed` to detect whether the process has actually exited.
 			setTimeout(() => {
 				if (!closed) proc.kill("SIGKILL")
 			}, 5000)
@@ -206,7 +199,6 @@ function spawnSubagent(
 			finish(code ?? 0)
 		})
 
-		// Fix 8: route proc error through finish for unified cleanup.
 		proc.on("error", (err) => {
 			closed = true
 			if (failureReason === undefined) failureReason = "exit_error"
@@ -214,7 +206,6 @@ function spawnSubagent(
 			finish(1)
 		})
 
-		// Fix 1 & 5: distinguish user-initiated abort from timeout.
 		const onAbort = () => {
 			if (timeoutController.signal.aborted) {
 				kill("timeout")
@@ -276,7 +267,6 @@ const SubagentParams = Type.Object({
 	}),
 	model: Type.String({ description: "Model ID to use for the subagent (e.g. glm-5-fp8, kimi-k2.5)" }),
 	prompt: Type.String({ description: "Prompt to send to the subagent" }),
-	// Fix 6: tokenBudget is truly optional — no silent default applied.
 	tokenBudget: Type.Optional(
 		Type.Integer({
 			description: "Maximum total tokens (input + output) the subagent may consume. Subagent is killed when exceeded.",
@@ -314,7 +304,6 @@ export default function (pi: ExtensionAPI) {
 			]
 			const invocation = getSubagentInvocation(args)
 
-			// Fix 6: pass tokenBudget only when explicitly provided.
 			const { exitCode, accumulated, stderr, tokenUsage, failureReason, durationMs } = await spawnSubagent(
 				invocation,
 				ctx.cwd,


### PR DESCRIPTION
Adds reliability and resource-control features to the subagent extension.

**Hard timeout**
Subagents are killed (SIGTERM → SIGKILL after 5 s) if they run longer than 15 minutes, preventing runaway processes from blocking indefinitely.

**Token budget**
An optional `tokenBudget` parameter caps total tokens (input + output). The subagent is killed when the budget is exceeded. A default budget of 10 M tokens is applied when no explicit value is provided.

**Token tracking**
Token usage (input + output) is extracted from `message_end` events in the streaming JSON output. Duration and token counts are shown in the tool UI after each subagent run.

**Structured error responses**
On failure the tool returns a JSON `SubagentError` object containing:
- `reason`: `exit_error` | `timeout` | `token_budget_exceeded`
- `model`, `tokenUsage`, `durationMs`, `detail`

Previously the tool returned a plain string on failure.

**Tests**
New `subagent.test.ts` covers `parseSubagentEvent` for all event types, including empty delta, partial usage, unrecognised event types, blank lines, and invalid JSON.

---

**Out of scope (deferred)**
- Hard iteration limit on inner-loop cycles (loop prevention)
- Crash detection with configurable retry policy

---

Timeout:
<img width="896" height="570" alt="image" src="https://github.com/user-attachments/assets/9fe823a7-6906-4e07-9f18-cab4d89a7225" />

Tokens budget:
<img width="899" height="357" alt="image" src="https://github.com/user-attachments/assets/b9736e0a-fcbf-47a4-8822-dfc96ad5b71d" />