### PR TITLE
LLM-1307: Support for project files

### DIFF
--- a/src/extensions/orchestration/prompt-enrichment.ts
+++ b/src/extensions/orchestration/prompt-enrichment.ts
@@ -21,7 +21,7 @@
 import type { ImageContent, TextContent } from "@mariozechner/pi-ai"
 import { type ExtensionAPI, type Skill, loadSkills } from "@mariozechner/pi-coding-agent"
 import { ModelRegistry } from "./model-registry/index.js"
-import { loadProjectContextFiles } from "./prompt-transformer/context-files.js"
+import { type ContextFile, loadProjectContextFiles } from "./prompt-transformer/context-files.js"
 import {
 	type CurrentModelInfo,
 	buildOrchestratorSystemPrompt,
@@ -71,10 +71,13 @@ export default function (pi: ExtensionAPI) {
 		})
 	}
 
+	let cachedContextFiles: ContextFile[] | undefined
+	let cachedSkills: Skill[] | undefined
+
 	pi.on("before_agent_start", async (_event, ctx) => {
 		const tools = pi.getAllTools()
-		const contextFiles = loadProjectContextFiles(ctx.cwd)
-		const { skills } = loadSkills({ cwd: ctx.cwd })
+		cachedContextFiles ??= loadProjectContextFiles(ctx.cwd)
+		cachedSkills ??= loadSkills({ cwd: ctx.cwd }).skills
 
 		if (subagentMode) {
 			// Filter the subagent tool out of the active tool set to prevent
@@ -82,11 +85,11 @@ export default function (pi: ExtensionAPI) {
 			const activeTools = pi.getActiveTools().filter((name) => name !== "subagent")
 			pi.setActiveTools(activeTools)
 
-			const systemPrompt = buildSubagentSystemPrompt(tools, contextFiles, skills)
+			const systemPrompt = buildSubagentSystemPrompt(tools, cachedContextFiles, cachedSkills)
 			return { systemPrompt }
 		}
 
-		const systemPrompt = buildOrchestratorSystemPrompt(tools, contextFiles, skills)
+		const systemPrompt = buildOrchestratorSystemPrompt(tools, cachedContextFiles, cachedSkills)
 		return { systemPrompt }
 	})
 }

--- a/src/extensions/orchestration/prompt-enrichment.ts
+++ b/src/extensions/orchestration/prompt-enrichment.ts
@@ -20,6 +20,7 @@
 
 import type { ImageContent, TextContent } from "@mariozechner/pi-ai"
 import type { ExtensionAPI } from "@mariozechner/pi-coding-agent"
+import { loadProjectContextFiles } from "./prompt-transformer/context-files.js"
 import { ModelRegistry } from "./model-registry/index.js"
 import {
 	type CurrentModelInfo,
@@ -70,8 +71,9 @@ export default function (pi: ExtensionAPI) {
 		})
 	}
 
-	pi.on("before_agent_start", async () => {
+	pi.on("before_agent_start", async (_event, ctx) => {
 		const tools = pi.getAllTools()
+		const contextFiles = loadProjectContextFiles(ctx.cwd)
 
 		if (subagentMode) {
 			// Filter the subagent tool out of the active tool set to prevent
@@ -79,11 +81,11 @@ export default function (pi: ExtensionAPI) {
 			const activeTools = pi.getActiveTools().filter((name) => name !== "subagent")
 			pi.setActiveTools(activeTools)
 
-			const systemPrompt = buildSubagentSystemPrompt(tools)
+			const systemPrompt = buildSubagentSystemPrompt(tools, contextFiles)
 			return { systemPrompt }
 		}
 
-		const systemPrompt = buildOrchestratorSystemPrompt(tools)
+		const systemPrompt = buildOrchestratorSystemPrompt(tools, contextFiles)
 		return { systemPrompt }
 	})
 }

--- a/src/extensions/orchestration/prompt-enrichment.ts
+++ b/src/extensions/orchestration/prompt-enrichment.ts
@@ -20,8 +20,8 @@
 
 import type { ImageContent, TextContent } from "@mariozechner/pi-ai"
 import type { ExtensionAPI } from "@mariozechner/pi-coding-agent"
-import { loadProjectContextFiles } from "./prompt-transformer/context-files.js"
 import { ModelRegistry } from "./model-registry/index.js"
+import { loadProjectContextFiles } from "./prompt-transformer/context-files.js"
 import {
 	type CurrentModelInfo,
 	buildOrchestratorSystemPrompt,

--- a/src/extensions/orchestration/prompt-enrichment.ts
+++ b/src/extensions/orchestration/prompt-enrichment.ts
@@ -19,7 +19,7 @@
  */
 
 import type { ImageContent, TextContent } from "@mariozechner/pi-ai"
-import type { ExtensionAPI } from "@mariozechner/pi-coding-agent"
+import { type ExtensionAPI, type Skill, loadSkills } from "@mariozechner/pi-coding-agent"
 import { ModelRegistry } from "./model-registry/index.js"
 import { loadProjectContextFiles } from "./prompt-transformer/context-files.js"
 import {
@@ -74,6 +74,7 @@ export default function (pi: ExtensionAPI) {
 	pi.on("before_agent_start", async (_event, ctx) => {
 		const tools = pi.getAllTools()
 		const contextFiles = loadProjectContextFiles(ctx.cwd)
+		const { skills } = loadSkills({ cwd: ctx.cwd })
 
 		if (subagentMode) {
 			// Filter the subagent tool out of the active tool set to prevent
@@ -81,11 +82,11 @@ export default function (pi: ExtensionAPI) {
 			const activeTools = pi.getActiveTools().filter((name) => name !== "subagent")
 			pi.setActiveTools(activeTools)
 
-			const systemPrompt = buildSubagentSystemPrompt(tools, contextFiles)
+			const systemPrompt = buildSubagentSystemPrompt(tools, contextFiles, skills)
 			return { systemPrompt }
 		}
 
-		const systemPrompt = buildOrchestratorSystemPrompt(tools, contextFiles)
+		const systemPrompt = buildOrchestratorSystemPrompt(tools, contextFiles, skills)
 		return { systemPrompt }
 	})
 }

--- a/src/extensions/orchestration/prompt-transformer/context-files.test.ts
+++ b/src/extensions/orchestration/prompt-transformer/context-files.test.ts
@@ -1,0 +1,71 @@
+import { mkdirSync, rmSync, writeFileSync } from "node:fs"
+import { join } from "node:path"
+import { afterEach, beforeEach, describe, expect, it } from "vitest"
+import { loadProjectContextFiles } from "./context-files.js"
+
+describe("loadProjectContextFiles", () => {
+	const tmpBase = join(import.meta.dirname, "__test_tmp_context__")
+	const nested = join(tmpBase, "a", "b", "c")
+
+	beforeEach(() => {
+		mkdirSync(nested, { recursive: true })
+	})
+
+	afterEach(() => {
+		rmSync(tmpBase, { recursive: true, force: true })
+	})
+
+	it("returns empty array when no context files exist", () => {
+		const result = loadProjectContextFiles(nested)
+		// May pick up AGENTS.md from ancestor dirs in the real repo,
+		// but none from within our temp tree
+		const inTmp = result.filter((f) => f.path.startsWith(tmpBase))
+		expect(inTmp).toEqual([])
+	})
+
+	it("discovers AGENTS.md in cwd", () => {
+		writeFileSync(join(nested, "AGENTS.md"), "# Project rules")
+		const result = loadProjectContextFiles(nested)
+		const inTmp = result.filter((f) => f.path.startsWith(tmpBase))
+		expect(inTmp).toHaveLength(1)
+		expect(inTmp[0].path).toBe(join(nested, "AGENTS.md"))
+		expect(inTmp[0].content).toBe("# Project rules")
+	})
+
+	it("discovers CLAUDE.md when AGENTS.md is absent", () => {
+		writeFileSync(join(nested, "CLAUDE.md"), "# Claude rules")
+		const result = loadProjectContextFiles(nested)
+		const inTmp = result.filter((f) => f.path.startsWith(tmpBase))
+		expect(inTmp).toHaveLength(1)
+		expect(inTmp[0].path).toBe(join(nested, "CLAUDE.md"))
+	})
+
+	it("prefers AGENTS.md over CLAUDE.md in the same directory", () => {
+		writeFileSync(join(nested, "AGENTS.md"), "agents wins")
+		writeFileSync(join(nested, "CLAUDE.md"), "claude loses")
+		const result = loadProjectContextFiles(nested)
+		const inTmp = result.filter((f) => f.path.startsWith(tmpBase))
+		expect(inTmp).toHaveLength(1)
+		expect(inTmp[0].path).toBe(join(nested, "AGENTS.md"))
+	})
+
+	it("collects files from multiple ancestor directories in root-to-cwd order", () => {
+		const parentDir = join(tmpBase, "a")
+		writeFileSync(join(parentDir, "AGENTS.md"), "parent rules")
+		writeFileSync(join(nested, "CLAUDE.md"), "child rules")
+		const result = loadProjectContextFiles(nested)
+		const inTmp = result.filter((f) => f.path.startsWith(tmpBase))
+		expect(inTmp).toHaveLength(2)
+		// Ancestor first, child last
+		expect(inTmp[0].path).toBe(join(parentDir, "AGENTS.md"))
+		expect(inTmp[1].path).toBe(join(nested, "CLAUDE.md"))
+	})
+
+	it("does not return duplicate paths", () => {
+		writeFileSync(join(tmpBase, "AGENTS.md"), "root level")
+		const result = loadProjectContextFiles(tmpBase)
+		const inTmp = result.filter((f) => f.path.startsWith(tmpBase))
+		const paths = inTmp.map((f) => f.path)
+		expect(new Set(paths).size).toBe(paths.length)
+	})
+})

--- a/src/extensions/orchestration/prompt-transformer/context-files.ts
+++ b/src/extensions/orchestration/prompt-transformer/context-files.ts
@@ -12,7 +12,7 @@
  */
 
 import { existsSync, readFileSync } from "node:fs"
-import { resolve, join } from "node:path"
+import { join, resolve } from "node:path"
 
 export interface ContextFile {
 	path: string

--- a/src/extensions/orchestration/prompt-transformer/context-files.ts
+++ b/src/extensions/orchestration/prompt-transformer/context-files.ts
@@ -41,16 +41,14 @@ function loadContextFileFromDir(dir: string): ContextFile | null {
  */
 export function loadProjectContextFiles(cwd: string): ContextFile[] {
 	const files: ContextFile[] = []
-	const seen = new Set<string>()
 
 	let dir = resolve(cwd)
 	const root = resolve("/")
 
 	while (true) {
 		const found = loadContextFileFromDir(dir)
-		if (found && !seen.has(found.path)) {
+		if (found) {
 			files.unshift(found)
-			seen.add(found.path)
 		}
 
 		if (dir === root) break

--- a/src/extensions/orchestration/prompt-transformer/context-files.ts
+++ b/src/extensions/orchestration/prompt-transformer/context-files.ts
@@ -1,0 +1,63 @@
+/**
+ * Discover project context files (AGENTS.md, CLAUDE.md) by walking up
+ * the directory tree from cwd to root.
+ *
+ * This replicates the discovery logic from Pi's internal
+ * `loadProjectContextFiles()` (resource-loader.ts) which is not exported
+ * as a standalone function. We need it to inject user-provided project
+ * guidelines into our custom system prompts.
+ *
+ * Per directory, the first match wins: AGENTS.md is checked before CLAUDE.md.
+ * Files are returned in root → cwd order (ancestors first).
+ */
+
+import { existsSync, readFileSync } from "node:fs"
+import { resolve, join } from "node:path"
+
+export interface ContextFile {
+	path: string
+	content: string
+}
+
+const CONTEXT_FILE_NAMES = ["AGENTS.md", "CLAUDE.md"]
+
+function loadContextFileFromDir(dir: string): ContextFile | null {
+	for (const filename of CONTEXT_FILE_NAMES) {
+		const filePath = join(dir, filename)
+		if (existsSync(filePath)) {
+			try {
+				return { path: filePath, content: readFileSync(filePath, "utf-8") }
+			} catch {
+				// Unreadable file — skip silently
+			}
+		}
+	}
+	return null
+}
+
+/**
+ * Walk from `cwd` up to the filesystem root, collecting one context file
+ * per directory. Returns them in ancestor-first order (root → cwd).
+ */
+export function loadProjectContextFiles(cwd: string): ContextFile[] {
+	const files: ContextFile[] = []
+	const seen = new Set<string>()
+
+	let dir = resolve(cwd)
+	const root = resolve("/")
+
+	while (true) {
+		const found = loadContextFileFromDir(dir)
+		if (found && !seen.has(found.path)) {
+			files.unshift(found)
+			seen.add(found.path)
+		}
+
+		if (dir === root) break
+		const parent = resolve(dir, "..")
+		if (parent === dir) break
+		dir = parent
+	}
+
+	return files
+}

--- a/src/extensions/orchestration/prompt-transformer/prompt-transformer.test.ts
+++ b/src/extensions/orchestration/prompt-transformer/prompt-transformer.test.ts
@@ -124,6 +124,33 @@ describe("buildOrchestratorSystemPrompt", () => {
 		expect(result).toContain("(No tools available)")
 		expect(result).not.toContain("{{TOOLS}}")
 	})
+
+	it("replaces the {{PROJECT_CONTEXT}} placeholder when no context files", () => {
+		const result = buildOrchestratorSystemPrompt(tools)
+		expect(result).not.toContain("{{PROJECT_CONTEXT}}")
+	})
+
+	it("injects project context files into the prompt", () => {
+		const contextFiles = [
+			{ path: "/repo/AGENTS.md", content: "Always run tests before committing." },
+			{ path: "/repo/sub/CLAUDE.md", content: "Use pnpm, not npm." },
+		]
+		const result = buildOrchestratorSystemPrompt(tools, contextFiles)
+		expect(result).toContain("# Project Context")
+		expect(result).toContain("Always run tests before committing.")
+		expect(result).toContain("Use pnpm, not npm.")
+		expect(result).not.toContain("/repo/AGENTS.md")
+		expect(result).not.toContain("/repo/sub/CLAUDE.md")
+		expect(result).not.toContain("{{PROJECT_CONTEXT}}")
+	})
+
+	it("places project context after the guidelines section", () => {
+		const contextFiles = [{ path: "/repo/AGENTS.md", content: "custom rule" }]
+		const result = buildOrchestratorSystemPrompt(tools, contextFiles)
+		const guidelinesPos = result.indexOf("## Guidelines")
+		const contextPos = result.indexOf("# Project Context")
+		expect(guidelinesPos).toBeLessThan(contextPos)
+	})
 })
 
 describe("buildSubagentSystemPrompt", () => {
@@ -168,5 +195,26 @@ describe("buildSubagentSystemPrompt", () => {
 	it("handles tools list with only the subagent tool", () => {
 		const result = buildSubagentSystemPrompt([{ name: "subagent", description: "Spawn" }])
 		expect(result).toContain("(No tools available)")
+	})
+
+	it("replaces the {{PROJECT_CONTEXT}} placeholder when no context files", () => {
+		const result = buildSubagentSystemPrompt(tools)
+		expect(result).not.toContain("{{PROJECT_CONTEXT}}")
+	})
+
+	it("injects project context files into the prompt", () => {
+		const contextFiles = [{ path: "/project/AGENTS.md", content: "Use TypeScript strict mode." }]
+		const result = buildSubagentSystemPrompt(tools, contextFiles)
+		expect(result).toContain("# Project Context")
+		expect(result).toContain("Use TypeScript strict mode.")
+		expect(result).not.toContain("/project/AGENTS.md")
+	})
+
+	it("places project context after the guidelines section", () => {
+		const contextFiles = [{ path: "/repo/AGENTS.md", content: "rule" }]
+		const result = buildSubagentSystemPrompt(tools, contextFiles)
+		const guidelinesPos = result.indexOf("## Guidelines")
+		const contextPos = result.indexOf("# Project Context")
+		expect(guidelinesPos).toBeLessThan(contextPos)
 	})
 })

--- a/src/extensions/orchestration/prompt-transformer/prompt-transformer.test.ts
+++ b/src/extensions/orchestration/prompt-transformer/prompt-transformer.test.ts
@@ -136,7 +136,7 @@ describe("buildOrchestratorSystemPrompt", () => {
 			{ path: "/repo/sub/CLAUDE.md", content: "Use pnpm, not npm." },
 		]
 		const result = buildOrchestratorSystemPrompt(tools, contextFiles)
-		expect(result).toContain("# Project Context")
+		expect(result).toContain("# Project Guidelines")
 		expect(result).toContain("Always run tests before committing.")
 		expect(result).toContain("Use pnpm, not npm.")
 		expect(result).not.toContain("/repo/AGENTS.md")
@@ -144,11 +144,11 @@ describe("buildOrchestratorSystemPrompt", () => {
 		expect(result).not.toContain("{{PROJECT_CONTEXT}}")
 	})
 
-	it("places project context after the guidelines section", () => {
+	it("places project guidelines after the guidelines section", () => {
 		const contextFiles = [{ path: "/repo/AGENTS.md", content: "custom rule" }]
 		const result = buildOrchestratorSystemPrompt(tools, contextFiles)
 		const guidelinesPos = result.indexOf("## Guidelines")
-		const contextPos = result.indexOf("# Project Context")
+		const contextPos = result.indexOf("# Project Guidelines")
 		expect(guidelinesPos).toBeLessThan(contextPos)
 	})
 })
@@ -202,19 +202,19 @@ describe("buildSubagentSystemPrompt", () => {
 		expect(result).not.toContain("{{PROJECT_CONTEXT}}")
 	})
 
-	it("injects project context files into the prompt", () => {
+	it("injects project guidelines files into the prompt", () => {
 		const contextFiles = [{ path: "/project/AGENTS.md", content: "Use TypeScript strict mode." }]
 		const result = buildSubagentSystemPrompt(tools, contextFiles)
-		expect(result).toContain("# Project Context")
+		expect(result).toContain("# Project Guidelines")
 		expect(result).toContain("Use TypeScript strict mode.")
 		expect(result).not.toContain("/project/AGENTS.md")
 	})
 
-	it("places project context after the guidelines section", () => {
+	it("places project guidelines after the guidelines section", () => {
 		const contextFiles = [{ path: "/repo/AGENTS.md", content: "rule" }]
 		const result = buildSubagentSystemPrompt(tools, contextFiles)
 		const guidelinesPos = result.indexOf("## Guidelines")
-		const contextPos = result.indexOf("# Project Context")
+		const contextPos = result.indexOf("# Project Guidelines")
 		expect(guidelinesPos).toBeLessThan(contextPos)
 	})
 })

--- a/src/extensions/orchestration/prompt-transformer/prompt-transformer.test.ts
+++ b/src/extensions/orchestration/prompt-transformer/prompt-transformer.test.ts
@@ -1,6 +1,17 @@
+import type { Skill } from "@mariozechner/pi-coding-agent"
 import { describe, expect, it } from "vitest"
 import { ModelRegistry } from "../model-registry/index.js"
 import { buildOrchestratorSystemPrompt, buildSubagentSystemPrompt, transformPrompt } from "./prompt-transformer.js"
+
+function createSkill(overrides: Partial<Skill> & { name: string; description: string }): Skill {
+	return {
+		filePath: `/skills/${overrides.name}/SKILL.md`,
+		baseDir: `/skills/${overrides.name}`,
+		sourceInfo: { path: `/skills/${overrides.name}/SKILL.md`, source: "local", scope: "project", origin: "top-level" },
+		disableModelInvocation: false,
+		...overrides,
+	}
+}
 
 describe("transformPrompt", () => {
 	const registry = new ModelRegistry()
@@ -151,6 +162,34 @@ describe("buildOrchestratorSystemPrompt", () => {
 		const contextPos = result.indexOf("# Project Guidelines")
 		expect(guidelinesPos).toBeLessThan(contextPos)
 	})
+
+	it("replaces the {{SKILLS}} placeholder when no skills", () => {
+		const result = buildOrchestratorSystemPrompt(tools)
+		expect(result).not.toContain("{{SKILLS}}")
+	})
+
+	it("injects skills into the prompt", () => {
+		const skills = [
+			createSkill({ name: "deploy", description: "Deploy the app to production" }),
+			createSkill({ name: "review", description: "Review a pull request" }),
+		]
+		const result = buildOrchestratorSystemPrompt(tools, undefined, skills)
+		expect(result).toContain("available_skills")
+		expect(result).toContain("deploy")
+		expect(result).toContain("Deploy the app to production")
+		expect(result).toContain("review")
+		expect(result).toContain("Review a pull request")
+	})
+
+	it("excludes skills with disableModelInvocation", () => {
+		const skills = [
+			createSkill({ name: "safe-skill", description: "Visible skill" }),
+			createSkill({ name: "hidden-skill", description: "Hidden skill", disableModelInvocation: true }),
+		]
+		const result = buildOrchestratorSystemPrompt(tools, undefined, skills)
+		expect(result).toContain("safe-skill")
+		expect(result).not.toContain("hidden-skill")
+	})
 })
 
 describe("buildSubagentSystemPrompt", () => {
@@ -216,5 +255,18 @@ describe("buildSubagentSystemPrompt", () => {
 		const guidelinesPos = result.indexOf("## Guidelines")
 		const contextPos = result.indexOf("# Project Guidelines")
 		expect(guidelinesPos).toBeLessThan(contextPos)
+	})
+
+	it("replaces the {{SKILLS}} placeholder when no skills", () => {
+		const result = buildSubagentSystemPrompt(tools)
+		expect(result).not.toContain("{{SKILLS}}")
+	})
+
+	it("injects skills into the prompt", () => {
+		const skills = [createSkill({ name: "deploy", description: "Deploy the app" })]
+		const result = buildSubagentSystemPrompt(tools, undefined, skills)
+		expect(result).toContain("available_skills")
+		expect(result).toContain("deploy")
+		expect(result).toContain("Deploy the app")
 	})
 })

--- a/src/extensions/orchestration/prompt-transformer/prompt-transformer.ts
+++ b/src/extensions/orchestration/prompt-transformer/prompt-transformer.ts
@@ -1,6 +1,6 @@
-import type { ContextFile } from "./context-files.js"
 import type { ModelRegistry } from "../model-registry/index.js"
 import type { OrchestrationModelDescriptor } from "../model-registry/types.js"
+import type { ContextFile } from "./context-files.js"
 import systemPromptTemplate from "./prompts/orchestrator-system-prompt.md.template" with { type: "text" }
 import subagentSystemPromptTemplate from "./prompts/subagent-system-prompt.md.template" with { type: "text" }
 import userPromptTemplate from "./prompts/transformed-user-prompt.md.template" with { type: "text" }
@@ -66,7 +66,10 @@ export function transformPrompt(userPrompt: string, registry: ModelRegistry, cur
 		.replace("{{USER_PROMPT}}", () => userPrompt)
 }
 
-export function buildOrchestratorSystemPrompt(tools: readonly ToolInfo[], contextFiles?: readonly ContextFile[]): string {
+export function buildOrchestratorSystemPrompt(
+	tools: readonly ToolInfo[],
+	contextFiles?: readonly ContextFile[],
+): string {
 	const toolsSection = formatToolsSection(tools)
 	const projectContext = formatProjectContext(contextFiles)
 	return systemPromptTemplate

--- a/src/extensions/orchestration/prompt-transformer/prompt-transformer.ts
+++ b/src/extensions/orchestration/prompt-transformer/prompt-transformer.ts
@@ -1,3 +1,4 @@
+import type { ContextFile } from "./context-files.js"
 import type { ModelRegistry } from "../model-registry/index.js"
 import type { OrchestrationModelDescriptor } from "../model-registry/types.js"
 import systemPromptTemplate from "./prompts/orchestrator-system-prompt.md.template" with { type: "text" }
@@ -65,20 +66,32 @@ export function transformPrompt(userPrompt: string, registry: ModelRegistry, cur
 		.replace("{{USER_PROMPT}}", () => userPrompt)
 }
 
-export function buildOrchestratorSystemPrompt(tools: readonly ToolInfo[]): string {
+export function buildOrchestratorSystemPrompt(tools: readonly ToolInfo[], contextFiles?: readonly ContextFile[]): string {
 	const toolsSection = formatToolsSection(tools)
-	return systemPromptTemplate.replace("{{TOOLS}}", () => toolsSection)
+	const projectContext = formatProjectContext(contextFiles)
+	return systemPromptTemplate
+		.replace("{{TOOLS}}", () => toolsSection)
+		.replace("{{PROJECT_CONTEXT}}", () => projectContext)
 }
 
-export function buildSubagentSystemPrompt(tools: readonly ToolInfo[]): string {
+export function buildSubagentSystemPrompt(tools: readonly ToolInfo[], contextFiles?: readonly ContextFile[]): string {
 	const filtered = tools.filter((t) => t.name !== SUBAGENT_TOOL_NAME)
 	const toolsSection = formatToolsSection(filtered)
-	return subagentSystemPromptTemplate.replace("{{TOOLS}}", () => toolsSection)
+	const projectContext = formatProjectContext(contextFiles)
+	return subagentSystemPromptTemplate
+		.replace("{{TOOLS}}", () => toolsSection)
+		.replace("{{PROJECT_CONTEXT}}", () => projectContext)
 }
 
 function formatToolsSection(tools: readonly ToolInfo[]): string {
 	if (tools.length === 0) return "(No tools available)"
 	return tools.map((t) => `- ${t.name}: ${t.description}`).join("\n")
+}
+
+function formatProjectContext(contextFiles?: readonly ContextFile[]): string {
+	if (!contextFiles || contextFiles.length === 0) return ""
+	const combined = contextFiles.map((f) => f.content).join("\n\n")
+	return `# Project Context\n\n${combined}`
 }
 
 export function isSubagent(): boolean {

--- a/src/extensions/orchestration/prompt-transformer/prompt-transformer.ts
+++ b/src/extensions/orchestration/prompt-transformer/prompt-transformer.ts
@@ -91,7 +91,7 @@ function formatToolsSection(tools: readonly ToolInfo[]): string {
 function formatProjectContext(contextFiles?: readonly ContextFile[]): string {
 	if (!contextFiles || contextFiles.length === 0) return ""
 	const combined = contextFiles.map((f) => f.content).join("\n\n")
-	return `# Project Context\n\n${combined}`
+	return `# Project Guidelines\n\n${combined}`
 }
 
 export function isSubagent(): boolean {

--- a/src/extensions/orchestration/prompt-transformer/prompt-transformer.ts
+++ b/src/extensions/orchestration/prompt-transformer/prompt-transformer.ts
@@ -1,3 +1,4 @@
+import { type Skill, formatSkillsForPrompt } from "@mariozechner/pi-coding-agent"
 import type { ModelRegistry } from "../model-registry/index.js"
 import type { OrchestrationModelDescriptor } from "../model-registry/types.js"
 import type { ContextFile } from "./context-files.js"
@@ -69,21 +70,30 @@ export function transformPrompt(userPrompt: string, registry: ModelRegistry, cur
 export function buildOrchestratorSystemPrompt(
 	tools: readonly ToolInfo[],
 	contextFiles?: readonly ContextFile[],
+	skills?: readonly Skill[],
 ): string {
 	const toolsSection = formatToolsSection(tools)
 	const projectContext = formatProjectContext(contextFiles)
+	const skillsSection = formatSkills(skills)
 	return systemPromptTemplate
 		.replace("{{TOOLS}}", () => toolsSection)
 		.replace("{{PROJECT_CONTEXT}}", () => projectContext)
+		.replace("{{SKILLS}}", () => skillsSection)
 }
 
-export function buildSubagentSystemPrompt(tools: readonly ToolInfo[], contextFiles?: readonly ContextFile[]): string {
+export function buildSubagentSystemPrompt(
+	tools: readonly ToolInfo[],
+	contextFiles?: readonly ContextFile[],
+	skills?: readonly Skill[],
+): string {
 	const filtered = tools.filter((t) => t.name !== SUBAGENT_TOOL_NAME)
 	const toolsSection = formatToolsSection(filtered)
 	const projectContext = formatProjectContext(contextFiles)
+	const skillsSection = formatSkills(skills)
 	return subagentSystemPromptTemplate
 		.replace("{{TOOLS}}", () => toolsSection)
 		.replace("{{PROJECT_CONTEXT}}", () => projectContext)
+		.replace("{{SKILLS}}", () => skillsSection)
 }
 
 function formatToolsSection(tools: readonly ToolInfo[]): string {
@@ -95,6 +105,11 @@ function formatProjectContext(contextFiles?: readonly ContextFile[]): string {
 	if (!contextFiles || contextFiles.length === 0) return ""
 	const combined = contextFiles.map((f) => f.content).join("\n\n")
 	return `# Project Guidelines\n\n${combined}`
+}
+
+function formatSkills(skills?: readonly Skill[]): string {
+	if (!skills || skills.length === 0) return ""
+	return formatSkillsForPrompt(skills as Skill[])
 }
 
 export function isSubagent(): boolean {

--- a/src/extensions/orchestration/prompt-transformer/prompt-transformer.ts
+++ b/src/extensions/orchestration/prompt-transformer/prompt-transformer.ts
@@ -109,6 +109,7 @@ function formatProjectContext(contextFiles?: readonly ContextFile[]): string {
 
 function formatSkills(skills?: readonly Skill[]): string {
 	if (!skills || skills.length === 0) return ""
+	// Cast required until upstream accepts readonly Skill[]
 	return formatSkillsForPrompt(skills as Skill[])
 }
 

--- a/src/extensions/orchestration/prompt-transformer/prompts/orchestrator-system-prompt.md.template
+++ b/src/extensions/orchestration/prompt-transformer/prompts/orchestrator-system-prompt.md.template
@@ -81,3 +81,5 @@ When delegating to a subagent, the user message contains an "## Available Models
   - After a subagent returns: what it produced and how you will continue (apply as-is, adjust, or correct).
 - Do not start the actual work until you have stated your decision.
 - Before running a sequence of tool calls, briefly explain what you are about to do and why.
+
+{{PROJECT_CONTEXT}}

--- a/src/extensions/orchestration/prompt-transformer/prompts/orchestrator-system-prompt.md.template
+++ b/src/extensions/orchestration/prompt-transformer/prompts/orchestrator-system-prompt.md.template
@@ -83,3 +83,5 @@ When delegating to a subagent, the user message contains an "## Available Models
 - Before running a sequence of tool calls, briefly explain what you are about to do and why.
 
 {{PROJECT_CONTEXT}}
+
+{{SKILLS}}

--- a/src/extensions/orchestration/prompt-transformer/prompts/subagent-system-prompt.md.template
+++ b/src/extensions/orchestration/prompt-transformer/prompts/subagent-system-prompt.md.template
@@ -16,3 +16,5 @@ You operate inside a coding agent harness with access to the tools listed below.
 - Do not introduce security vulnerabilities. Prioritize safe, correct code.
 - Do not add features, refactoring, or improvements beyond what was asked.
 - If you encounter an error, diagnose the root cause before retrying.
+
+{{PROJECT_CONTEXT}}

--- a/src/extensions/orchestration/prompt-transformer/prompts/subagent-system-prompt.md.template
+++ b/src/extensions/orchestration/prompt-transformer/prompts/subagent-system-prompt.md.template
@@ -18,3 +18,5 @@ You operate inside a coding agent harness with access to the tools listed below.
 - If you encounter an error, diagnose the root cause before retrying.
 
 {{PROJECT_CONTEXT}}
+
+{{SKILLS}}


### PR DESCRIPTION
# Add project context file discovery (AGENTS.md / CLAUDE.md) and skills to orchestration prompts

## Summary

- Introduce `loadProjectContextFiles()` to discover `AGENTS.md` / `CLAUDE.md` files by walking up the directory tree from cwd
- Inject discovered project guidelines into both orchestrator and subagent system prompts via a new `# Project Guidelines` section
- Load and inject skills into both prompts using Pi's standalone `loadSkills()` and `formatSkillsForPrompt()` utilities
- System-level guidelines (`## Guidelines`) are kept separate from user-provided project context and skills, giving the LLM clear distinction between our orchestration rules and project-specific instructions

## Why we replicate the context file discovery logic instead of using Pi's ResourceLoader

Pi's `DefaultResourceLoader` is the central service that discovers context files, skills, extensions, themes, prompt templates, and system prompt overrides. While it is publicly exported from `@mariozechner/pi-coding-agent`, **instantiating it from an extension is not viable** for the following reasons:

1. **It's heavyweight.** `reload()` triggers full package resolution, loads all extensions (executing their factory functions), walks skill/prompt/theme directories, and resolves system prompts. Creating a second instance duplicates all of this work that Pi already performed at boot time.

2. **It's a singleton by design.** The framework assumes one `ResourceLoader` owns resource discovery. It's constructed once in `main()` → passed into `createAgentSessionRuntime()` → passed into `AgentSession` — and the extension API surface (`ExtensionAPI`, `ExtensionContext`) does not expose it.

## Why skills work differently from context files

Pi exports `loadSkills()` and `formatSkillsForPrompt()` as standalone functions from `@mariozechner/pi-coding-agent` — they are pure utilities usable independently of the `ResourceLoader`. We import and use them directly:

```typescript
import { loadSkills, formatSkillsForPrompt } from "@mariozechner/pi-coding-agent"

const { skills } = loadSkills({ cwd: ctx.cwd })
```

The equivalent function for context files — `loadProjectContextFiles()` — is **not exported**. It's a private function inside `resource-loader.ts`, not marked with `export`, and not re-exported from the package's `index.ts`. Since the function is ~35 lines of straightforward filesystem walking (check each ancestor directory for `AGENTS.md` then `CLAUDE.md`), we replicate it in our codebase.

## Follow-up: upstream PR to pi-mono

We will open a PR to the pi-mono repository to export `loadProjectContextFiles()` as a standalone utility function, consistent with how `loadSkills()` is already exported. Once that lands, we can drop our local copy and import it directly from `@mariozechner/pi-coding-agent`.
