### PR TITLE
NOJIRA: Hide enriched prompt from harness UI by default

### DIFF
--- a/src/extensions/orchestration/prompt-enrichment.ts
+++ b/src/extensions/orchestration/prompt-enrichment.ts
@@ -18,6 +18,7 @@
  * and never trigger the "input" event.
  */
 
+import type { ImageContent, TextContent } from "@mariozechner/pi-ai"
 import type { ExtensionAPI } from "@mariozechner/pi-coding-agent"
 import { ModelRegistry } from "./model-registry/index.js"
 import {
@@ -61,7 +62,9 @@ export default function (pi: ExtensionAPI) {
 				{ customType: "enriched-prompt", content: [{ type: "text", text: enrichedPrompt }], display: false },
 				{ deliverAs: "nextTurn" },
 			)
-			pi.sendUserMessage(event.text)
+			const userContent: (TextContent | ImageContent)[] = [{ type: "text", text: event.text }]
+			if (event.images) userContent.push(...event.images)
+			pi.sendUserMessage(userContent)
 
 			return { action: "handled" as const }
 		})

--- a/src/extensions/orchestration/prompt-enrichment.ts
+++ b/src/extensions/orchestration/prompt-enrichment.ts
@@ -31,6 +31,12 @@ import {
 export default function (pi: ExtensionAPI) {
 	const subagentMode = isSubagent()
 
+	pi.registerFlag("debug-prompts", {
+		type: "boolean",
+		description: "Print enriched prompts in the UI (default: hidden)",
+		default: false,
+	})
+
 	// For sub agents we don't want to transform the prompt sent from parent with model capabilities
 	if (!subagentMode) {
 		const registry = new ModelRegistry()
@@ -45,7 +51,19 @@ export default function (pi: ExtensionAPI) {
 				: undefined
 
 			const enrichedPrompt = transformPrompt(event.text, registry, currentModel)
-			return { action: "transform" as const, text: enrichedPrompt, images: event.images }
+
+			const debugPrompts = pi.getFlag("debug-prompts") === true
+			if (debugPrompts) {
+				return { action: "transform" as const, text: enrichedPrompt, images: event.images }
+			}
+
+			pi.sendMessage(
+				{ customType: "enriched-prompt", content: [{ type: "text", text: enrichedPrompt }], display: false },
+				{ deliverAs: "nextTurn" },
+			)
+			pi.sendUserMessage(event.text)
+
+			return { action: "handled" as const }
 		})
 	}
 


### PR DESCRIPTION
The transformed user prompt (model capabilities block) was always rendered in the TUI, exposing internal orchestration details to the user. The enriched prompt is now injected as a hidden context message so the LLM still receives it, while the original user text is what appears in the chat. The previous behaviour can be restored with the new `--debug-prompts` flag.