### PR TITLE
LLM-1306: Integrating model capabilities with auto-model discovery

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -32,6 +32,7 @@ import promptEnrichmentExtension from "./extensions/orchestration/prompt-enrichm
 import subagentExtension from "./extensions/subagent.js"
 import webFetchExtension from "./extensions/web-fetch/index.js"
 import { updateModelsConfig } from "./models.js"
+import { setAvailableModelIds } from "./startup-context.js"
 
 try {
 	const config = loadConfig()
@@ -46,6 +47,10 @@ try {
 	if (modelsResult.source === "default") {
 		console.error(`Warning: using default models (${modelsResult.error})`)
 	}
+
+	// Share the discovered model IDs with extensions before main() runs.
+	// prompt-enrichment reads this to build ModelRegistry with live model IDs.
+	setAvailableModelIds(modelsResult.models)
 
 	// Suppress Node.js warnings (same as pi-mono's own cli.js)
 	process.emitWarning = () => {}

--- a/src/extensions/orchestration/model-registry/builtin-models.ts
+++ b/src/extensions/orchestration/model-registry/builtin-models.ts
@@ -1,4 +1,4 @@
-import type { OrchestrationModelDescriptor } from "./types.js"
+import type { ModelCapabilities } from "./types.js"
 
 /**
  * Model descriptions are written as natural-language decision briefs, not
@@ -10,7 +10,16 @@ import type { OrchestrationModelDescriptor } from "./types.js"
  * statements the orchestrator can act on directly: "strongest pure coding
  * model in the pool", "reliably formats tool calls correctly",
  * "near-perfect retrieval accuracy" etc.
+ *
+ * This map is a local capability knowledge-base keyed by model ID. It acts
+ * as an enrichment layer on top of the dynamic model list fetched from the
+ * API at startup. Models present in the API but absent here get a generic
+ * descriptor and a startup warning. Models present here but absent from the
+ * API are excluded from subagent routing (they cannot be called). The
+ * intention is to iterate on these descriptions locally and promote them to
+ * the API once the shape is stable.
  */
+
 const KIMI_K25_DESCRIPTION = `\
 The only model in the pool with vision support — use it when the task involves images, \
 screenshots, or visual input. Most capable and most expensive. \
@@ -27,38 +36,38 @@ can ingest entire large codebases in a single pass. \
 Weakest at coding; not reliable for complex multi-file changes. \
 Best for codebase exploration, research, and simple well-defined tasks.`
 
-export const BUILTIN_MODELS: readonly OrchestrationModelDescriptor[] = [
-	{
-		id: "kimi-k2.5",
-		provider: "kimchi-dev",
-		name: "Kimi K2.5",
-		capabilities: {
+/**
+ * Capability knowledge-base keyed by model ID. Used to enrich the dynamic
+ * model list from the API with orchestration metadata (tier, strengths,
+ * vision, description). Models not present here get a generic descriptor
+ * and a startup warning.
+ */
+export const MODEL_CAPABILITIES: ReadonlyMap<string, ModelCapabilities> = new Map([
+	[
+		"kimi-k2.5",
+		{
 			vision: true,
 			strengths: ["build", "explore"],
 			tier: "heavy",
 			description: KIMI_K25_DESCRIPTION,
 		},
-	},
-	{
-		id: "minimax-m2.7",
-		provider: "kimchi-dev",
-		name: "Minimax M2.7",
-		capabilities: {
+	],
+	[
+		"minimax-m2.7",
+		{
 			vision: false,
 			strengths: ["build"],
 			tier: "standard",
 			description: MINIMAX_M27_DESCRIPTION,
 		},
-	},
-	{
-		id: "nemotron-3-super-fp4",
-		provider: "kimchi-dev",
-		name: "Nemotron 3 Super",
-		capabilities: {
+	],
+	[
+		"nemotron-3-super-fp4",
+		{
 			vision: false,
 			strengths: ["build", "explore", "research"],
 			tier: "light",
 			description: NEMOTRON_3_SUPER_DESCRIPTION,
 		},
-	},
-] as const
+	],
+])

--- a/src/extensions/orchestration/model-registry/index.ts
+++ b/src/extensions/orchestration/model-registry/index.ts
@@ -1,3 +1,4 @@
 export { ModelRegistry } from "./model-registry.js"
-export { BUILTIN_MODELS } from "./builtin-models.js"
+export { MODEL_CAPABILITIES } from "./builtin-models.js"
+export type { ModelRegistryWarning } from "./model-registry.js"
 export type { ModelStrength, ModelTier, ModelCapabilities, OrchestrationModelDescriptor } from "./types.js"

--- a/src/extensions/orchestration/model-registry/model-registry.test.ts
+++ b/src/extensions/orchestration/model-registry/model-registry.test.ts
@@ -1,28 +1,87 @@
 import { describe, expect, it } from "vitest"
-import { BUILTIN_MODELS } from "./builtin-models.js"
+import { MODEL_CAPABILITIES } from "./builtin-models.js"
 import { ModelRegistry } from "./model-registry.js"
 
-describe("ModelRegistry", () => {
-	it("returns all built-in models", () => {
-		const registry = new ModelRegistry()
-		expect(registry.getAll()).toHaveLength(BUILTIN_MODELS.length)
+const KNOWN_IDS = [...MODEL_CAPABILITIES.keys()]
+
+describe("ModelRegistry — known models only", () => {
+	it("returns all known models when all are available in the API", () => {
+		const registry = new ModelRegistry(KNOWN_IDS)
+		expect(registry.getAll()).toHaveLength(KNOWN_IDS.length)
+		expect(registry.getSubagentModels()).toHaveLength(KNOWN_IDS.length)
+		expect(registry.warnings).toHaveLength(0)
 	})
 
-	it("contains expected model data", () => {
-		const registry = new ModelRegistry()
-		const kimi = registry.getAll().find((m) => m.id === "kimi-k2.5")
-		expect(kimi).toBeDefined()
-		expect(kimi?.name).toBe("Kimi K2.5")
-		expect(kimi?.provider).toBe("kimchi-dev")
-		expect(kimi?.capabilities.strengths).toContain("build")
-		expect(kimi?.capabilities.description).toBeTruthy()
+	it("getAll() preserves the API order", () => {
+		const ids = [...KNOWN_IDS].reverse()
+		const registry = new ModelRegistry(ids)
+		expect(registry.getAll().map((m) => m.id)).toEqual(ids)
 	})
 
-	it("every model has a non-placeholder description", () => {
-		const registry = new ModelRegistry()
+	it("every known model has a non-placeholder description", () => {
+		const registry = new ModelRegistry(KNOWN_IDS)
 		for (const model of registry.getAll()) {
 			expect(model.capabilities.description).not.toBe("TODO")
 			expect(model.capabilities.description.length).toBeGreaterThan(50)
 		}
+	})
+})
+
+describe("ModelRegistry — unknown model in API", () => {
+	it("includes the unknown model in getAll() with a generic descriptor", () => {
+		const registry = new ModelRegistry([...KNOWN_IDS, "brand-new-model"])
+		const unknown = registry.getAll().find((m) => m.id === "brand-new-model")
+		expect(unknown).toBeDefined()
+		expect(unknown?.capabilities.description).toContain("No capability information")
+	})
+
+	it("excludes the unknown model from getSubagentModels()", () => {
+		const registry = new ModelRegistry([...KNOWN_IDS, "brand-new-model"])
+		const subagent = registry.getSubagentModels().find((m) => m.id === "brand-new-model")
+		expect(subagent).toBeUndefined()
+	})
+
+	it("emits an unknown_model warning", () => {
+		const registry = new ModelRegistry([...KNOWN_IDS, "brand-new-model"])
+		const warning = registry.warnings.find((w) => w.modelId === "brand-new-model")
+		expect(warning).toBeDefined()
+		expect(warning?.kind).toBe("unknown_model")
+	})
+})
+
+describe("ModelRegistry — orphaned capability entry", () => {
+	it("excludes the orphaned model from both getAll() and getSubagentModels()", () => {
+		// Provide only the first known ID, leaving the rest orphaned
+		const presentId = KNOWN_IDS[0]
+		const registry = new ModelRegistry([presentId])
+		expect(registry.getAll().map((m) => m.id)).toEqual([presentId])
+		expect(registry.getSubagentModels().map((m) => m.id)).toEqual([presentId])
+	})
+
+	it("emits an orphaned_capability warning for each missing model", () => {
+		const presentId = KNOWN_IDS[0]
+		const orphanedIds = KNOWN_IDS.slice(1)
+		const registry = new ModelRegistry([presentId])
+		const orphanWarnings = registry.warnings.filter((w) => w.kind === "orphaned_capability")
+		expect(orphanWarnings.map((w) => w.modelId)).toEqual(expect.arrayContaining(orphanedIds))
+	})
+})
+
+describe("ModelRegistry — subagent pool intersection", () => {
+	it("subagent pool is intersection of API models and capability map", () => {
+		const registry = new ModelRegistry([...KNOWN_IDS, "unknown-extra"])
+		// All known IDs should be in the subagent pool
+		for (const id of KNOWN_IDS) {
+			expect(registry.getSubagentModels().map((m) => m.id)).toContain(id)
+		}
+		// Unknown model must not be in the subagent pool
+		expect(registry.getSubagentModels().map((m) => m.id)).not.toContain("unknown-extra")
+	})
+
+	it("empty API list produces empty registries and orphan warnings for all known models", () => {
+		const registry = new ModelRegistry([])
+		expect(registry.getAll()).toHaveLength(0)
+		expect(registry.getSubagentModels()).toHaveLength(0)
+		expect(registry.warnings.filter((w) => w.kind === "orphaned_capability")).toHaveLength(KNOWN_IDS.length)
 	})
 })

--- a/src/extensions/orchestration/model-registry/model-registry.test.ts
+++ b/src/extensions/orchestration/model-registry/model-registry.test.ts
@@ -8,9 +8,10 @@ describe("ModelRegistry — known models only", () => {
 	it("returns all known models when all are available in the API", () => {
 		const registry = new ModelRegistry(KNOWN_IDS)
 		expect(registry.getAll()).toHaveLength(KNOWN_IDS.length)
-		expect(registry.getSubagentModels()).toHaveLength(KNOWN_IDS.length)
+		expect(registry.getModelsWithCapabilities()).toHaveLength(KNOWN_IDS.length)
 		expect(registry.warnings).toHaveLength(0)
 	})
+
 
 	it("getAll() preserves the API order", () => {
 		const ids = [...KNOWN_IDS].reverse()
@@ -20,7 +21,7 @@ describe("ModelRegistry — known models only", () => {
 
 	it("every known model has a non-placeholder description", () => {
 		const registry = new ModelRegistry(KNOWN_IDS)
-		for (const model of registry.getAll()) {
+		for (const model of registry.getModelsWithCapabilities()) {
 			expect(model.capabilities.description).not.toBe("TODO")
 			expect(model.capabilities.description.length).toBeGreaterThan(50)
 		}
@@ -35,10 +36,9 @@ describe("ModelRegistry — unknown model in API", () => {
 		expect(unknown?.capabilities.description).toContain("No capability information")
 	})
 
-	it("excludes the unknown model from getSubagentModels()", () => {
+	it("excludes the unknown model from getModelsWithCapabilities()", () => {
 		const registry = new ModelRegistry([...KNOWN_IDS, "brand-new-model"])
-		const subagent = registry.getSubagentModels().find((m) => m.id === "brand-new-model")
-		expect(subagent).toBeUndefined()
+		expect(registry.getModelsWithCapabilities().map((m) => m.id)).not.toContain("brand-new-model")
 	})
 
 	it("emits an unknown_model warning", () => {
@@ -50,12 +50,11 @@ describe("ModelRegistry — unknown model in API", () => {
 })
 
 describe("ModelRegistry — orphaned capability entry", () => {
-	it("excludes the orphaned model from both getAll() and getSubagentModels()", () => {
-		// Provide only the first known ID, leaving the rest orphaned
+	it("excludes the orphaned model from both getAll() and getModelsWithCapabilities()", () => {
 		const presentId = KNOWN_IDS[0]
 		const registry = new ModelRegistry([presentId])
 		expect(registry.getAll().map((m) => m.id)).toEqual([presentId])
-		expect(registry.getSubagentModels().map((m) => m.id)).toEqual([presentId])
+		expect(registry.getModelsWithCapabilities().map((m) => m.id)).toEqual([presentId])
 	})
 
 	it("emits an orphaned_capability warning for each missing model", () => {
@@ -67,21 +66,17 @@ describe("ModelRegistry — orphaned capability entry", () => {
 	})
 })
 
-describe("ModelRegistry — subagent pool intersection", () => {
-	it("subagent pool is intersection of API models and capability map", () => {
+describe("ModelRegistry — getModelsWithCapabilities()", () => {
+	it("is the intersection of API models and capability map", () => {
 		const registry = new ModelRegistry([...KNOWN_IDS, "unknown-extra"])
-		// All known IDs should be in the subagent pool
-		for (const id of KNOWN_IDS) {
-			expect(registry.getSubagentModels().map((m) => m.id)).toContain(id)
-		}
-		// Unknown model must not be in the subagent pool
-		expect(registry.getSubagentModels().map((m) => m.id)).not.toContain("unknown-extra")
+		expect(registry.getModelsWithCapabilities().map((m) => m.id)).toEqual(expect.arrayContaining(KNOWN_IDS))
+		expect(registry.getModelsWithCapabilities().map((m) => m.id)).not.toContain("unknown-extra")
 	})
 
-	it("empty API list produces empty registries and orphan warnings for all known models", () => {
+	it("returns empty when API list is empty", () => {
 		const registry = new ModelRegistry([])
-		expect(registry.getAll()).toHaveLength(0)
-		expect(registry.getSubagentModels()).toHaveLength(0)
-		expect(registry.warnings.filter((w) => w.kind === "orphaned_capability")).toHaveLength(KNOWN_IDS.length)
+		expect(registry.getModelsWithCapabilities()).toHaveLength(0)
 	})
 })
+
+

--- a/src/extensions/orchestration/model-registry/model-registry.test.ts
+++ b/src/extensions/orchestration/model-registry/model-registry.test.ts
@@ -12,7 +12,6 @@ describe("ModelRegistry — known models only", () => {
 		expect(registry.warnings).toHaveLength(0)
 	})
 
-
 	it("getAll() preserves the API order", () => {
 		const ids = [...KNOWN_IDS].reverse()
 		const registry = new ModelRegistry(ids)
@@ -78,5 +77,3 @@ describe("ModelRegistry — getModelsWithCapabilities()", () => {
 		expect(registry.getModelsWithCapabilities()).toHaveLength(0)
 	})
 })
-
-

--- a/src/extensions/orchestration/model-registry/model-registry.test.ts
+++ b/src/extensions/orchestration/model-registry/model-registry.test.ts
@@ -35,6 +35,13 @@ describe("ModelRegistry — unknown model in API", () => {
 		expect(unknown?.capabilities.description).toContain("No capability information")
 	})
 
+	it("emits a user-friendly discovery notice for the unknown model", () => {
+		const registry = new ModelRegistry([...KNOWN_IDS, "brand-new-model"])
+		const warning = registry.warnings.find((w) => w.modelId === "brand-new-model")
+		expect(warning?.message).toContain("New model available")
+		expect(warning?.message).toContain("brand-new-model")
+	})
+
 	it("excludes the unknown model from getModelsWithCapabilities()", () => {
 		const registry = new ModelRegistry([...KNOWN_IDS, "brand-new-model"])
 		expect(registry.getModelsWithCapabilities().map((m) => m.id)).not.toContain("brand-new-model")
@@ -56,12 +63,10 @@ describe("ModelRegistry — orphaned capability entry", () => {
 		expect(registry.getModelsWithCapabilities().map((m) => m.id)).toEqual([presentId])
 	})
 
-	it("emits an orphaned_capability warning for each missing model", () => {
+	it("does not emit any warning for capability entries absent from the API", () => {
 		const presentId = KNOWN_IDS[0]
-		const orphanedIds = KNOWN_IDS.slice(1)
 		const registry = new ModelRegistry([presentId])
-		const orphanWarnings = registry.warnings.filter((w) => w.kind === "orphaned_capability")
-		expect(orphanWarnings.map((w) => w.modelId)).toEqual(expect.arrayContaining(orphanedIds))
+		expect(registry.warnings).toHaveLength(0)
 	})
 })
 

--- a/src/extensions/orchestration/model-registry/model-registry.ts
+++ b/src/extensions/orchestration/model-registry/model-registry.ts
@@ -66,9 +66,7 @@ export class ModelRegistry {
 				warnings.push({
 					kind: "unknown_model",
 					modelId: id,
-					message: `Model "${id}" is available via the API but has no capability entry. ` +
-						`It can be used as the orchestrator model but will not be offered as a subagent. ` +
-						`Add an entry to MODEL_CAPABILITIES in builtin-models.ts to enable subagent routing.`,
+					message: `Model "${id}" is available via the API but has no capability entry. It can be used as the orchestrator model but will not be offered as a subagent. Add an entry to MODEL_CAPABILITIES in builtin-models.ts to enable subagent routing.`,
 				})
 				return {
 					id,
@@ -86,8 +84,7 @@ export class ModelRegistry {
 				warnings.push({
 					kind: "orphaned_capability",
 					modelId: capabilityId,
-					message: `Model "${capabilityId}" has a capability entry but was not returned by the API. ` +
-						`It may have been renamed or removed. Update MODEL_CAPABILITIES in builtin-models.ts.`,
+					message: `Model "${capabilityId}" has a capability entry but was not returned by the API. It may have been renamed or removed. Update MODEL_CAPABILITIES in builtin-models.ts.`,
 				})
 			}
 		}
@@ -111,5 +108,4 @@ export class ModelRegistry {
 	getModelsWithCapabilities(): readonly OrchestrationModelDescriptor[] {
 		return this.modelsWithCapabilities
 	}
-
 }

--- a/src/extensions/orchestration/model-registry/model-registry.ts
+++ b/src/extensions/orchestration/model-registry/model-registry.ts
@@ -2,19 +2,115 @@
  * Separate from Pi's ModelRegistry which handles provider config, API keys,
  * and Model objects for inference. This registry holds orchestration metadata
  * (capabilities, strengths) so the Orchestrator LLM can make routing decisions.
+ *
+ * The registry is built from two sources:
+ *   1. availableModelIds — the live model list fetched from the API at startup.
+ *      This is the source of truth for which models actually exist and can be called.
+ *   2. MODEL_CAPABILITIES — a local knowledge-base of curated orchestration metadata
+ *      (tier, strengths, vision, description) keyed by model ID.
+ *
+ * Merging rules:
+ *   - A model in the API with a capability entry → full OrchestrationModelDescriptor.
+ *   - A model in the API without a capability entry → generic descriptor + startup warning.
+ *   - A model in the capability map but absent from the API → orphaned, excluded from
+ *     the subagent pool (it cannot be called) + startup warning.
+ *
+ * Subagent pool = intersection of availableModelIds ∩ MODEL_CAPABILITIES keys.
+ * Orchestrator self-lookup = all models from the API (including unknown ones).
  */
 
-import { BUILTIN_MODELS } from "./builtin-models.js"
-import type { OrchestrationModelDescriptor } from "./types.js"
+import { MODEL_CAPABILITIES } from "./builtin-models.js"
+import type { ModelCapabilities, OrchestrationModelDescriptor } from "./types.js"
+
+const PROVIDER = "kimchi-dev"
+
+const GENERIC_CAPABILITIES: ModelCapabilities = {
+	vision: false,
+	strengths: ["build"],
+	tier: "standard",
+	description: "No capability information available for this model.",
+}
+
+function modelIdToName(id: string): string {
+	return id
+		.split(/[-_]/)
+		.map((part) => part.charAt(0).toUpperCase() + part.slice(1))
+		.join(" ")
+}
+
+export interface ModelRegistryWarning {
+	kind: "unknown_model" | "orphaned_capability"
+	modelId: string
+	message: string
+}
 
 export class ModelRegistry {
-	private readonly models: OrchestrationModelDescriptor[]
+	/** All models from the API, enriched where possible. Used for orchestrator self-lookup. */
+	private readonly allModels: OrchestrationModelDescriptor[]
 
-	constructor() {
-		this.models = [...BUILTIN_MODELS]
+	/** Intersection of API models and capability map. Used for subagent routing. */
+	private readonly subagentModels: OrchestrationModelDescriptor[]
+
+	/** Drift warnings emitted during construction. */
+	readonly warnings: readonly ModelRegistryWarning[]
+
+	constructor(availableModelIds: readonly string[]) {
+		const warnings: ModelRegistryWarning[] = []
+		const apiIdSet = new Set(availableModelIds)
+
+		// Build full descriptor list from the API model IDs
+		this.allModels = availableModelIds.map((id) => {
+			const capabilities = MODEL_CAPABILITIES.get(id)
+			if (capabilities === undefined) {
+				warnings.push({
+					kind: "unknown_model",
+					modelId: id,
+					message: `Model "${id}" is available via the API but has no capability entry. ` +
+						`It can be used as the orchestrator model but will not be offered as a subagent. ` +
+						`Add an entry to MODEL_CAPABILITIES in builtin-models.ts to enable subagent routing.`,
+				})
+				return {
+					id,
+					provider: PROVIDER,
+					name: modelIdToName(id),
+					capabilities: GENERIC_CAPABILITIES,
+				}
+			}
+			return { id, provider: PROVIDER, name: modelIdToName(id), capabilities }
+		})
+
+		// Warn about orphaned capability entries (in map but not in API)
+		for (const capabilityId of MODEL_CAPABILITIES.keys()) {
+			if (!apiIdSet.has(capabilityId)) {
+				warnings.push({
+					kind: "orphaned_capability",
+					modelId: capabilityId,
+					message: `Model "${capabilityId}" has a capability entry but was not returned by the API. ` +
+						`It may have been renamed or removed. Update MODEL_CAPABILITIES in builtin-models.ts.`,
+				})
+			}
+		}
+
+		// Subagent pool: only models present in both the API and the capability map
+		this.subagentModels = this.allModels.filter((m) => MODEL_CAPABILITIES.has(m.id))
+
+		this.warnings = warnings
 	}
 
+	/**
+	 * All models available from the API, with capability enrichment where known.
+	 * Used to look up the current orchestrator model's own capabilities.
+	 */
 	getAll(): readonly OrchestrationModelDescriptor[] {
-		return this.models
+		return this.allModels
+	}
+
+	/**
+	 * Models eligible for subagent delegation: the intersection of API-available
+	 * models and those with known capability entries. Unknown models are excluded
+	 * because generic descriptors provide no useful routing signal.
+	 */
+	getSubagentModels(): readonly OrchestrationModelDescriptor[] {
+		return this.subagentModels
 	}
 }

--- a/src/extensions/orchestration/model-registry/model-registry.ts
+++ b/src/extensions/orchestration/model-registry/model-registry.ts
@@ -11,9 +11,9 @@
  *
  * Merging rules:
  *   - A model in the API with a capability entry → full OrchestrationModelDescriptor.
- *   - A model in the API without a capability entry → generic descriptor + startup warning.
- *   - A model in the capability map but absent from the API → orphaned, excluded from
- *     routing (it cannot be called) + startup warning.
+ *   - A model in the API without a capability entry → generic descriptor + startup notice.
+ *   - A model in the capability map but absent from the API → silently excluded from
+ *     routing (it cannot be called).
  *
  * Models with capabilities = intersection of availableModelIds ∩ MODEL_CAPABILITIES keys.
  * Subagent pool           = models with capabilities, excluding the current orchestrator.
@@ -40,7 +40,7 @@ function modelIdToName(id: string): string {
 }
 
 export interface ModelRegistryWarning {
-	kind: "unknown_model" | "orphaned_capability"
+	kind: "unknown_model"
 	modelId: string
 	message: string
 }
@@ -57,7 +57,6 @@ export class ModelRegistry {
 
 	constructor(availableModelIds: readonly string[]) {
 		const warnings: ModelRegistryWarning[] = []
-		const apiIdSet = new Set(availableModelIds)
 
 		// Build full descriptor list from the API model IDs
 		this.allModels = availableModelIds.map((id) => {
@@ -66,7 +65,7 @@ export class ModelRegistry {
 				warnings.push({
 					kind: "unknown_model",
 					modelId: id,
-					message: `Model "${id}" is available via the API but has no capability entry. It can be used as the orchestrator model but will not be offered as a subagent. Add an entry to MODEL_CAPABILITIES in builtin-models.ts to enable subagent routing.`,
+					message: `New model available: "${id}". Update the harness to unlock its full capabilities (add an entry to MODEL_CAPABILITIES in builtin-models.ts), or add it to your orchestrator config. Until then it will not be offered as a subagent.`,
 				})
 				return {
 					id,
@@ -77,17 +76,6 @@ export class ModelRegistry {
 			}
 			return { id, provider: PROVIDER, name: modelIdToName(id), capabilities }
 		})
-
-		// Warn about orphaned capability entries (in map but not in API)
-		for (const capabilityId of MODEL_CAPABILITIES.keys()) {
-			if (!apiIdSet.has(capabilityId)) {
-				warnings.push({
-					kind: "orphaned_capability",
-					modelId: capabilityId,
-					message: `Model "${capabilityId}" has a capability entry but was not returned by the API. It may have been renamed or removed. Update MODEL_CAPABILITIES in builtin-models.ts.`,
-				})
-			}
-		}
 
 		this.modelsWithCapabilities = this.allModels.filter((m) => MODEL_CAPABILITIES.has(m.id))
 		this.warnings = warnings

--- a/src/extensions/orchestration/model-registry/model-registry.ts
+++ b/src/extensions/orchestration/model-registry/model-registry.ts
@@ -13,9 +13,10 @@
  *   - A model in the API with a capability entry → full OrchestrationModelDescriptor.
  *   - A model in the API without a capability entry → generic descriptor + startup warning.
  *   - A model in the capability map but absent from the API → orphaned, excluded from
- *     the subagent pool (it cannot be called) + startup warning.
+ *     routing (it cannot be called) + startup warning.
  *
- * Subagent pool = intersection of availableModelIds ∩ MODEL_CAPABILITIES keys.
+ * Models with capabilities = intersection of availableModelIds ∩ MODEL_CAPABILITIES keys.
+ * Subagent pool           = models with capabilities, excluding the current orchestrator.
  * Orchestrator self-lookup = all models from the API (including unknown ones).
  */
 
@@ -48,8 +49,8 @@ export class ModelRegistry {
 	/** All models from the API, enriched where possible. Used for orchestrator self-lookup. */
 	private readonly allModels: OrchestrationModelDescriptor[]
 
-	/** Intersection of API models and capability map. Used for subagent routing. */
-	private readonly subagentModels: OrchestrationModelDescriptor[]
+	/** Models that have a real entry in MODEL_CAPABILITIES (API ∩ capability map). */
+	private readonly modelsWithCapabilities: OrchestrationModelDescriptor[]
 
 	/** Drift warnings emitted during construction. */
 	readonly warnings: readonly ModelRegistryWarning[]
@@ -91,26 +92,24 @@ export class ModelRegistry {
 			}
 		}
 
-		// Subagent pool: only models present in both the API and the capability map
-		this.subagentModels = this.allModels.filter((m) => MODEL_CAPABILITIES.has(m.id))
-
+		this.modelsWithCapabilities = this.allModels.filter((m) => MODEL_CAPABILITIES.has(m.id))
 		this.warnings = warnings
 	}
 
 	/**
 	 * All models available from the API, with capability enrichment where known.
-	 * Used to look up the current orchestrator model's own capabilities.
 	 */
 	getAll(): readonly OrchestrationModelDescriptor[] {
 		return this.allModels
 	}
 
 	/**
-	 * Models eligible for subagent delegation: the intersection of API-available
-	 * models and those with known capability entries. Unknown models are excluded
-	 * because generic descriptors provide no useful routing signal.
+	 * Models that have a real entry in MODEL_CAPABILITIES - the intersection of
+	 * the API model list and the local capability knowledge-base. Unknown models
+	 * (those with generic descriptors) are excluded.
 	 */
-	getSubagentModels(): readonly OrchestrationModelDescriptor[] {
-		return this.subagentModels
+	getModelsWithCapabilities(): readonly OrchestrationModelDescriptor[] {
+		return this.modelsWithCapabilities
 	}
+
 }

--- a/src/extensions/orchestration/prompt-enrichment.ts
+++ b/src/extensions/orchestration/prompt-enrichment.ts
@@ -44,11 +44,10 @@ export default function (pi: ExtensionAPI) {
 	if (!subagentMode) {
 		const registry = new ModelRegistry(getAvailableModelIds())
 
-		// Emit startup warnings for drift between the API model list and the
-		// capability knowledge-base. These surface in the terminal so the user
-		// knows when to add a capability entry or clean up a stale one.
+		// Notify the developer when a newly available API model has no capability entry yet.
+		// These surface in the terminal as actionable discovery notices.
 		for (const warning of registry.warnings) {
-			console.error(`Warning [model-registry]: ${warning.message}`)
+			console.error(`[model-registry] ${warning.message}`)
 		}
 
 		pi.on("input", async (event, ctx) => {

--- a/src/extensions/orchestration/prompt-enrichment.ts
+++ b/src/extensions/orchestration/prompt-enrichment.ts
@@ -20,6 +20,7 @@
 
 import type { ImageContent, TextContent } from "@mariozechner/pi-ai"
 import { type ExtensionAPI, type Skill, loadSkills } from "@mariozechner/pi-coding-agent"
+import { getAvailableModelIds } from "../../startup-context.js"
 import { ModelRegistry } from "./model-registry/index.js"
 import { type ContextFile, loadProjectContextFiles } from "./prompt-transformer/context-files.js"
 import {
@@ -41,7 +42,14 @@ export default function (pi: ExtensionAPI) {
 
 	// For sub agents we don't want to transform the prompt sent from parent with model capabilities
 	if (!subagentMode) {
-		const registry = new ModelRegistry()
+		const registry = new ModelRegistry(getAvailableModelIds())
+
+		// Emit startup warnings for drift between the API model list and the
+		// capability knowledge-base. These surface in the terminal so the user
+		// knows when to add a capability entry or clean up a stale one.
+		for (const warning of registry.warnings) {
+			console.error(`Warning [model-registry]: ${warning.message}`)
+		}
 
 		pi.on("input", async (event, ctx) => {
 			if (event.source === "extension") {

--- a/src/extensions/orchestration/prompt-transformer/prompt-transformer.test.ts
+++ b/src/extensions/orchestration/prompt-transformer/prompt-transformer.test.ts
@@ -1,7 +1,9 @@
 import type { Skill } from "@mariozechner/pi-coding-agent"
 import { describe, expect, it } from "vitest"
-import { ModelRegistry } from "../model-registry/index.js"
+import { MODEL_CAPABILITIES, ModelRegistry } from "../model-registry/index.js"
 import { buildOrchestratorSystemPrompt, buildSubagentSystemPrompt, transformPrompt } from "./prompt-transformer.js"
+
+const ALL_KNOWN_IDS = [...MODEL_CAPABILITIES.keys()]
 
 function createSkill(overrides: Partial<Skill> & { name: string; description: string }): Skill {
 	return {
@@ -14,7 +16,7 @@ function createSkill(overrides: Partial<Skill> & { name: string; description: st
 }
 
 describe("transformPrompt", () => {
-	const registry = new ModelRegistry()
+	const registry = new ModelRegistry(ALL_KNOWN_IDS)
 	const currentModel = { id: "kimi-k2.5", name: "Kimi K2.5" }
 
 	it("includes the original user prompt", () => {

--- a/src/extensions/orchestration/prompt-transformer/prompt-transformer.test.ts
+++ b/src/extensions/orchestration/prompt-transformer/prompt-transformer.test.ts
@@ -67,8 +67,8 @@ describe("transformPrompt", () => {
 
 	it("excludes the current model from the subagent models list", () => {
 		const result = transformPrompt("some task", registry, currentModel)
-		// All models except the current one should appear in the subagent section
-		const otherModels = registry.getAll().filter((m) => m.id !== currentModel.id)
+		// All models with capabilities except the current one should appear in the subagent section
+		const otherModels = registry.getModelsWithCapabilities().filter((m) => m.id !== currentModel.id)
 		for (const model of otherModels) {
 			expect(result).toContain(model.name)
 		}

--- a/src/extensions/orchestration/prompt-transformer/prompt-transformer.ts
+++ b/src/extensions/orchestration/prompt-transformer/prompt-transformer.ts
@@ -47,14 +47,14 @@ export interface CurrentModelInfo {
 export function transformPrompt(userPrompt: string, registry: ModelRegistry, currentModel?: CurrentModelInfo): string {
 	const allModels = registry.getAll()
 
-	// Exclude the current orchestrator model from the subagent model list —
-	// the orchestrator doesn't need to see itself as a delegation target.
-	const subagentModels = currentModel ? allModels.filter((m) => m.id !== currentModel.id) : allModels
+	// Subagent pool: only models with known capability entries, excluding the
+	// current orchestrator model (it doesn't need to delegate to itself).
+	const eligibleSubagents = registry.getSubagentModels()
+	const subagentModels = currentModel ? eligibleSubagents.filter((m) => m.id !== currentModel.id) : eligibleSubagents
 	const modelsSection = formatModelsSection(subagentModels)
 
 	const currentModelName = currentModel?.name ?? "unknown"
 
-	// Look up the current model's capabilities from our registry
 	const currentDescriptor = currentModel ? allModels.find((m) => m.id === currentModel.id) : undefined
 	const currentModelCapabilities = currentDescriptor
 		? formatCurrentModelCapabilities(currentDescriptor)

--- a/src/extensions/orchestration/prompt-transformer/prompt-transformer.ts
+++ b/src/extensions/orchestration/prompt-transformer/prompt-transformer.ts
@@ -45,17 +45,16 @@ export interface CurrentModelInfo {
 }
 
 export function transformPrompt(userPrompt: string, registry: ModelRegistry, currentModel?: CurrentModelInfo): string {
-	const allModels = registry.getAll()
-
-	// Subagent pool: only models with known capability entries, excluding the
-	// current orchestrator model (it doesn't need to delegate to itself).
-	const eligibleSubagents = registry.getSubagentModels()
-	const subagentModels = currentModel ? eligibleSubagents.filter((m) => m.id !== currentModel.id) : eligibleSubagents
+	const subagentModels = registry.getModelsWithCapabilities().filter((m) => m.id !== currentModel?.id)
 	const modelsSection = formatModelsSection(subagentModels)
 
 	const currentModelName = currentModel?.name ?? "unknown"
 
-	const currentDescriptor = currentModel ? allModels.find((m) => m.id === currentModel.id) : undefined
+	// Only show capabilities when the current model has a real capability entry.
+	// Unknown models get only the fallback text because generic defaults would be misleading.
+	const currentDescriptor = currentModel
+		? registry.getModelsWithCapabilities().find((m) => m.id === currentModel.id)
+		: undefined
 	const currentModelCapabilities = currentDescriptor
 		? formatCurrentModelCapabilities(currentDescriptor)
 		: "No capability information available for this model."

--- a/src/startup-context.ts
+++ b/src/startup-context.ts
@@ -1,0 +1,21 @@
+/**
+ * Startup context shared between cli.ts and extensions.
+ *
+ * cli.ts runs before pi-mono's main() and before any extension factory is
+ * invoked. It writes discovered model IDs here after fetching from the API,
+ * so extensions can read a fully populated context when they initialise.
+ *
+ * Module-level state is safe here because Node/Bun evaluates each module
+ * exactly once per process. By the time any extension factory runs, cli.ts
+ * has already set these values.
+ */
+
+let _availableModelIds: readonly string[] = []
+
+export function setAvailableModelIds(ids: readonly string[]): void {
+	_availableModelIds = ids
+}
+
+export function getAvailableModelIds(): readonly string[] {
+	return _availableModelIds
+}


### PR DESCRIPTION
# Connect dynamic model discovery to orchestration routing

## Problem

The codebase had two parallel, disconnected model systems:

- **`src/models.ts`** — fetches the live model list from the Cast AI API at startup and writes `models.json` so Pi can *call* models.
- **`model-registry/builtin-models.ts`** — a hardcoded array of `OrchestrationModelDescriptor` objects that the orchestrator used to *route* work to subagents.

These two systems had no connection. When the API returned a new model it became callable for inference but completely invisible to the orchestrator - it wouldn't appear in the "Available Models" section of enriched prompts and couldn't be selected for subagent delegation. Conversely, if a model was renamed or removed server-side, the orchestrator kept advertising it as available with no warning.

## Approach: local capability map + runtime merge

Three approaches were considered:

| Option | Summary | Verdict |
|---|---|---|
| **A** - API returns capabilities | Extend the Cast AI API to return tier/strengths/vision/description alongside model IDs. Single source of truth. | Rejected: requires backend changes and locks in the capability schema before it has been validated. |
| **B** - Client-side merge | Keep the API as-is (`string[]`), maintain a local capability knowledge-base, and merge them at startup. | **Chosen.** |

### Why Option B

Option B was chosen specifically for the **flexibility it preserves**. The natural-language model descriptions are not static facts like `maxContextLength` - they are opinionated editorial briefs that need to be tuned based on observed orchestrator routing quality. Locking them in the API too early would add a deployment cycle to what is fundamentally a **prompt-engineering feedback loop**.

The intent is to **iterate on these descriptions locally**, observe how they affect routing decisions, and promote the stable shape to the API once the contract is understood. This also means Option B directly defines what Option A would look like - the capability map format settled here becomes the API response schema when we are ready to externalize.

## Model selection rules

Two distinct roles exist in the orchestration system, with different rules for each.

### Orchestrator (main session model, selected via `/model`)

The user can select **any model returned by the API** as the orchestrator, regardless of whether it has a capability entry. A model without a capability entry is still fully functional — it can use tools, read files, write code, and spawn subagents. The only degradation is self-awareness: the `## You` section of its enriched prompt will show `"No capability information available for this model."` instead of its tier, strengths, and description. The orchestrator can still reason and act; it just doesn't have a curated brief about its own strengths.

This is intentional. Restricting model selection to only capability-known models would break the user's ability to experiment with newly discovered models before a capability entry has been written for them.

### Subagents (spawned by the orchestrator)

Only models present in **both** the API response and `MODEL_CAPABILITIES` are offered to the orchestrator as delegation targets. The reason is signal quality: the orchestrator's routing decisions are only as good as the information it receives. A generic descriptor (`tier: standard, strengths: build`) tells the orchestrator almost nothing useful — it cannot meaningfully choose between two models described identically. Showing unknown models in the subagent pool would produce random or arbitrary routing rather than informed routing.

The subagent pool is therefore the **intersection** of what exists (API) and what is understood (capability map).

| | Orchestrator | Subagent |
|---|---|---|
| **Eligible models** | Any API model | API models with a capability entry only |
| **Missing capability entry** | Warning shown, model still usable | Model excluded from the pool |
| **Capability display** | Full details if known, fallback text if not | Always full details (guaranteed by pool membership) |
