### PR TITLE
NOJIRA: Improve orchestrator model communication and prompt structure

### DIFF
--- a/src/extensions/orchestration/model-registry/builtin-models.ts
+++ b/src/extensions/orchestration/model-registry/builtin-models.ts
@@ -12,43 +12,20 @@ import type { OrchestrationModelDescriptor } from "./types.js"
  * "near-perfect retrieval accuracy" etc.
  */
 const KIMI_K25_DESCRIPTION = `\
-1T-parameter MoE model (32B active), 256K context. \
-The only vision model in the pool - can reason over images, generate code \
-from UI designs and screenshots, and process visual inputs. \
-Strong at resolving real-world GitHub issues across multiple languages. \
-Excels at deep mathematical and scientific reasoning, including graduate-level \
-science questions and frontier-difficulty problems that most models cannot solve. \
-Leading agentic capabilities - can autonomously browse the web, chain tool calls, \
-and decompose complex tasks into parallel sub-tasks via its agent-swarm architecture. \
-Most capable and most expensive model in the pool. Best choice for complex \
-multi-step tasks, anything involving visual inputs, or problems that require \
-deep reasoning and autonomous multi-tool workflows.`
+The only model in the pool with vision support — use it when the task involves images, \
+screenshots, or visual input. Most capable and most expensive. \
+Best for complex multi-step tasks, deep reasoning, or anything requiring autonomous multi-tool workflows.`
 
 const MINIMAX_M27_DESCRIPTION = `\
-230B-parameter MoE model (only ~10B active), 192K context, Lightning Attention. \
-The strongest pure coding model in the pool - has the highest accuracy at resolving \
-real-world GitHub issues, including complex multi-file bugs and hard edge cases. \
-Strong across 10+ programming languages in 200K+ real-world environments. \
-Plans architecture before coding with a natural spec-writing tendency. \
-Excellent at autonomous tool calling and multi-step function chains - reliably \
-formats tool calls correctly and handles extended multi-turn tool conversations. \
-Solid mathematical and scientific reasoning, though slightly behind the heavy-tier model. \
-Very fast inference thanks to only 4% parameter activation. \
-Best choice for coding tasks of any complexity where quality and speed both matter, \
-especially when the task is purely text-based with no visual inputs.`
+The strongest coding model in the pool. \
+Best accuracy on multi-file bugs, complex refactors, and extended tool call chains. \
+Best default choice for any well-scoped coding task.`
 
 const NEMOTRON_3_SUPER_DESCRIPTION = `\
-120B-parameter LatentMoE hybrid model (12B active), up to 1M token context, NVFP4 quantized. \
-The weakest coding model in the pool - adequate for simple, well-scoped code changes \
-but not reliable for complex multi-file bug fixes or feature implementations. \
-Surprisingly strong reasoning for its size - handles advanced math and graduate-level \
-science questions well. Decent at following instructions in agentic workflows, \
-though struggles with autonomous web search and information retrieval tasks. \
-Standout capability is its 1M token context window with near-perfect retrieval \
-accuracy - can ingest entire large codebases, trace cross-file dependencies, \
-and answer questions about massive documents in a single pass. \
-Cheapest and fastest model in the pool. Best choice for codebase exploration, \
-research, reading large files, and simple straightforward tasks.`
+Cheapest and fastest. 1M token context window with near-perfect retrieval — \
+can ingest entire large codebases in a single pass. \
+Weakest at coding; not reliable for complex multi-file changes. \
+Best for codebase exploration, research, and simple well-defined tasks.`
 
 export const BUILTIN_MODELS: readonly OrchestrationModelDescriptor[] = [
 	{

--- a/src/extensions/orchestration/prompt-transformer/prompts/orchestrator-system-prompt.md.template
+++ b/src/extensions/orchestration/prompt-transformer/prompts/orchestrator-system-prompt.md.template
@@ -73,3 +73,10 @@ When delegating to a subagent, the user message contains an "## Available Models
 - When delegating, pass the task faithfully. Do not over-summarize or lose important details from the user's request.
 - After a subagent returns, review the output. If corrections are needed, make them yourself rather than spawning another subagent.
 - Be concise in your responses. Show file paths clearly when working with files.
+
+- Before doing any work, state your decision in one short paragraph:
+  - If handling it yourself: the classification and reason.
+  - If delegating: the model chosen, why, and what it is being asked to do.
+  - After a subagent returns: what it produced and how you will continue (apply as-is, adjust, or correct).
+- Do not start the actual work until you have stated your decision.
+- Before running a sequence of tool calls, briefly explain what you are about to do and why.

--- a/src/extensions/orchestration/prompt-transformer/prompts/orchestrator-system-prompt.md.template
+++ b/src/extensions/orchestration/prompt-transformer/prompts/orchestrator-system-prompt.md.template
@@ -36,9 +36,10 @@ Handle the task directly using your own tools when:
 ### Strategy 2: Delegate to a subagent
 
 Spawn a subagent when:
-- The task is HARD and would benefit from a model with specific strengths (e.g. better coding benchmarks, vision capabilities).
+- The task is HARD and would benefit from a model with specific strengths (e.g. deep-reasoning, vision capabilities).
 - You want to run work in parallel - for example, splitting a large feature into independent subtasks that different subagents can work on simultaneously.
 - The task is self-contained and can be fully described in a single prompt without back-and-forth.
+- If you are a heavy-tier model, prefer delegating simpler subtasks to a lower-tier model to reduce cost.
 
 ### Strategy 3: Hybrid - explore then delegate
 
@@ -54,7 +55,6 @@ When delegating to a subagent, the user message contains an "## Available Models
 - For **EASY** subtasks: prefer a **light**-tier model. Cheapest and fastest.
 - For **HARD** subtasks: prefer a **heavy**-tier model. Most capable, justifies the extra cost.
 - A **standard**-tier model is the balanced choice for tasks that are solidly coding-focused.
-- If you are a heavy-tier model, prefer delegating simpler subtasks to a lower-tier model to reduce cost.
 
 ### Special Considerations
 

--- a/src/extensions/orchestration/prompt-transformer/prompts/orchestrator-system-prompt.md.template
+++ b/src/extensions/orchestration/prompt-transformer/prompts/orchestrator-system-prompt.md.template
@@ -54,6 +54,7 @@ When delegating to a subagent, the user message contains an "## Available Models
 - For **EASY** subtasks: prefer a **light**-tier model. Cheapest and fastest.
 - For **HARD** subtasks: prefer a **heavy**-tier model. Most capable, justifies the extra cost.
 - A **standard**-tier model is the balanced choice for tasks that are solidly coding-focused.
+- If you are a heavy-tier model, prefer delegating simpler subtasks to a lower-tier model to reduce cost.
 
 ### Special Considerations
 


### PR DESCRIPTION
## Summary

- Condensed model descriptions in `builtin-models.ts` from raw spec sheets into concise decision-oriented briefs, removing architecture details (parameter counts, context sizes, benchmark names) in favour of actionable guidance the orchestrator can act on directly.
- Improved orchestrator system prompt guidelines: fixed a contradiction between "be verbose" and "be concise", deduplicated the decision-stating instruction, fixed sub-bullet formatting, and added a directive to briefly narrate sequences of tool calls before executing them.

## Why

The previous model descriptions bloated the user prompt with technical specifications that require interpretation. Pre-digesting them into short decision briefs reduces token usage and makes model selection more reliable. The prompt structure fixes remove conflicting instructions that could cause inconsistent orchestrator behaviour.

## Test plan

- [x] Verify orchestrator selects models correctly for easy/hard/vision tasks
- [x] Verify orchestrator narrates tool call sequences before executing them
- [x] Verify orchestrator states its decision before starting work