### PR TITLE
LLM-1249: Bundle pi-mcp-adapter extension into compiled binary

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -21,6 +21,6 @@
 		}
 	},
 	"files": {
-		"ignore": ["dist/", "node_modules/"]
+		"ignore": ["dist/", "node_modules/", "src/extensions/mcp-adapter/"]
 	}
 }

--- a/docs/superpowers/specs/2026-04-15-mcp-tool-result-offload-design.md
+++ b/docs/superpowers/specs/2026-04-15-mcp-tool-result-offload-design.md
@@ -1,0 +1,100 @@
+# MCP Tool Result Offload Design
+
+## Context
+
+MCP tool calls (especially Loki log queries) return large payloads that go directly into LLM context, causing token spikes. A Loki query returning 51KB of JSON caused a 1k → 31k token spike in one session. The existing `truncateTail` (50KB/2000 lines) failed because the response was a single JSON blob treated as one line.
+
+The fix mirrors Claude Code's pattern: when a tool result exceeds a threshold, save the full result to a file and return a message to the model with the path and instructions for reading it.
+
+---
+
+## Design
+
+### Configuration
+
+Add `maxToolResultChars?: number` to `src/config.ts` `Config` type. Read from `~/.config/kimchi/config.json`. Default: `10_000` characters (~2,500 tokens at 4 chars/token).
+
+```json
+{
+  "maxToolResultChars": 10000
+}
+```
+
+### `applyOffload` function (`proxy-modes.ts`)
+
+Replaces `applyTruncation`. Signature:
+
+```typescript
+function applyOffload(
+  content: ContentBlock[],
+  toolName: string,
+  maxChars: number,
+  ctx: ExtensionContext,
+): ContentBlock[]
+```
+
+**Logic:**
+1. Filter `type === "text"` blocks, concatenate into single string
+2. If total chars ≤ `maxChars` → return content as-is (no change)
+3. If over limit:
+   - Detect format: try `JSON.parse` on trimmed content → `.json`, else `.txt`
+   - Derive output dir:
+     - `sessionFile = ctx.sessionManager.getSessionFile()`
+     - If set: `dirname(sessionFile)/tool-results/`
+     - Else: `os.tmpdir()/kimchi-tool-results/`
+   - `mkdirSync(dir, { recursive: true })`
+   - Write full content to `<dir>/<uuid>.<ext>`
+   - On I/O failure: log warning, fall back to `truncateTail`
+   - Return message to model (see below)
+
+**Model message format:**
+```
+result (<N> characters) exceeds limit. Full output saved to <path>.
+Format: <JSON | Plain text>
+- To search: use bash with grep on the file directly
+- To read in chunks: bash -c "python3 -c \"print(open('<path>').read()[A:B])\""
+- For analysis requiring full content: use a subagent with the file path
+```
+
+### Parameter threading
+
+- `src/config.ts`: add `maxToolResultChars` to `Config`, default `10_000`
+- `src/extensions/mcp-adapter/index.ts`: pass `ctx` and `config.maxToolResultChars` to `executeCall`
+- `src/extensions/mcp-adapter/proxy-modes.ts`: `executeCall` receives `ctx: ExtensionContext` and `maxToolResultChars: number`; calls `applyOffload` instead of `applyTruncation`
+
+### What is NOT changed
+
+- `executeSearch`, `executeList`, `executeDescribe` — not affected
+- Direct tool executors — not affected
+- `renderResult` 10-line UI collapse — separate concern, unchanged
+- bash/read tools — not affected (can revisit later)
+
+---
+
+## Edge Cases
+
+| Scenario | Handling |
+|---|---|
+| `getSessionFile()` returns null | Fall back to `os.tmpdir()/kimchi-tool-results/` |
+| `mkdirSync` or file write fails | Log warning, fall back to `truncateTail` |
+| Content is not valid JSON | Use `.txt` extension |
+| Content has mixed blocks (images etc.) | Only text blocks concatenated; non-text blocks dropped from file |
+
+---
+
+## Files Changed
+
+- `src/config.ts`
+- `src/extensions/mcp-adapter/index.ts`
+- `src/extensions/mcp-adapter/proxy-modes.ts`
+
+---
+
+## Verification
+
+1. Run `pnpm typecheck` — must pass
+2. Build binary: `pnpm build:binary`
+3. Start session, run a Loki query that returns large output
+4. Confirm context stays under ~3k tokens (not 31k)
+5. Confirm a file appears under `<session-dir>/tool-results/`
+6. Confirm model uses bash/grep to read it rather than having it in context

--- a/docs/superpowers/specs/2026-04-15-mcp-tool-result-offload-design.md
+++ b/docs/superpowers/specs/2026-04-15-mcp-tool-result-offload-design.md
@@ -37,15 +37,17 @@ function applyOffload(
 1. Filter `type === "text"` blocks, concatenate into single string
 2. If total chars ≤ `maxChars` → return content as-is (no change)
 3. If over limit:
-   - Detect format: try `JSON.parse` on trimmed content → `.json`, else `.txt`
+   - Detect format: lightweight heuristic `/^\s*[\{\[]/.test(content)` → `.json`, else `.txt` (avoids blocking the event loop on large strings; concatenated multi-block content is never valid JSON anyway)
    - Derive output dir:
      - `sessionFile = ctx.sessionManager.getSessionFile()`
      - If set: `dirname(sessionFile)/tool-results/`
      - Else: `os.tmpdir()/kimchi-tool-results/`
    - `mkdirSync(dir, { recursive: true })`
    - Write full content to `<dir>/<uuid>.<ext>`
-   - On I/O failure: log warning, fall back to `truncateTail`
-   - Return message to model (see below)
+   - On I/O failure: log warning, hard-slice: `text.slice(0, maxChars) + "\n\n... [Truncated due to I/O error]"` (do NOT fall back to `truncateTail` — it fails on single-line blobs, the same class of input that triggered offload)
+   - Return: all original non-text blocks (images etc.) preserved + new offload message text block
+
+**Note:** The message references `bash` for file inspection. Kimchi always registers bash as a core tool, so this is guaranteed to be available.
 
 **Model message format:**
 ```
@@ -75,10 +77,10 @@ Format: <JSON | Plain text>
 
 | Scenario | Handling |
 |---|---|
-| `getSessionFile()` returns null | Fall back to `os.tmpdir()/kimchi-tool-results/` |
+| `getSessionFile()` returns null | Fall back to `os.tmpdir()/kimchi-tool-results/` (files unmanaged; rely on OS temp cleanup; proper cleanup deferred to future PR) |
 | `mkdirSync` or file write fails | Log warning, fall back to `truncateTail` |
 | Content is not valid JSON | Use `.txt` extension |
-| Content has mixed blocks (images etc.) | Only text blocks concatenated; non-text blocks dropped from file |
+| Content has mixed blocks (images etc.) | Only text blocks written to file; non-text blocks (images) preserved in the returned `ContentBlock[]` alongside the offload message |
 
 ---
 

--- a/docs/superpowers/specs/2026-04-15-mcp-tool-result-offload-design.md
+++ b/docs/superpowers/specs/2026-04-15-mcp-tool-result-offload-design.md
@@ -61,15 +61,18 @@ Format: <JSON | Plain text>
 ### Parameter threading
 
 - `src/config.ts`: add `maxToolResultChars` to `Config`, default `10_000`
-- `src/extensions/mcp-adapter/index.ts`: pass `ctx` and `config.maxToolResultChars` to `executeCall`
+- `src/extensions/mcp-adapter/index.ts`: import `loadConfig` from `../../config.js` to access `maxToolResultChars`; pass `ctx` and the value to `executeCall`
 - `src/extensions/mcp-adapter/proxy-modes.ts`: `executeCall` receives `ctx: ExtensionContext` and `maxToolResultChars: number`; calls `applyOffload` instead of `applyTruncation`
 
 ### What is NOT changed
 
 - `executeSearch`, `executeList`, `executeDescribe` — not affected
-- Direct tool executors — not affected
 - `renderResult` 10-line UI collapse — separate concern, unchanged
 - bash/read tools — not affected (can revisit later)
+
+### Known gap: direct tool executors
+
+`direct-tools.ts` (`createDirectToolExecutor`) also executes MCP tool calls and has the same context bloat risk. It is out of scope for this PR but should be addressed in a follow-up. The `applyOffload` function should be extracted to a shared utility so both `proxy-modes.ts` and `direct-tools.ts` can use it.
 
 ---
 
@@ -77,8 +80,8 @@ Format: <JSON | Plain text>
 
 | Scenario | Handling |
 |---|---|
-| `getSessionFile()` returns null | Fall back to `os.tmpdir()/kimchi-tool-results/` (files unmanaged; rely on OS temp cleanup; proper cleanup deferred to future PR) |
-| `mkdirSync` or file write fails | Log warning, fall back to `truncateTail` |
+| `getSessionFile()` returns null | Fall back to `os.tmpdir()/kimchi-tool-results-${os.userInfo().uid}/` (per-user isolation avoids permission conflicts on multi-user systems; files unmanaged, rely on OS temp cleanup; proper cleanup deferred to future PR) |
+| `mkdirSync` or file write fails | Log warning, hard-slice: `text.slice(0, maxChars) + "\n\n... [Truncated due to I/O error]"` |
 | Content is not valid JSON | Use `.txt` extension |
 | Content has mixed blocks (images etc.) | Only text blocks written to file; non-text blocks (images) preserved in the returned `ContentBlock[]` alongside the offload message |
 

--- a/package.json
+++ b/package.json
@@ -27,7 +27,11 @@
 	"dependencies": {
 		"@mariozechner/pi-coding-agent": "^0.65.2",
 		"@mariozechner/pi-tui": "^0.65.2",
-		"undici": "^8.0.2"
+		"@modelcontextprotocol/ext-apps": "^1.2.2",
+		"@modelcontextprotocol/sdk": "^1.25.1",
+		"open": "^10.2.0",
+		"undici": "^8.0.2",
+		"zod": "^4.0.0"
 	},
 	"peerDependencies": {
 		"@sinclair/typebox": "*"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -15,23 +15,35 @@ importers:
     dependencies:
       '@mariozechner/pi-coding-agent':
         specifier: ^0.65.2
-        version: 0.65.2(patch_hash=b966969e9ec0a9ab77fbeeae4e179380093a6acfb96e8249aa74cf4798e719d6)(ws@8.20.0)(zod@4.3.6)
+        version: 0.65.2(patch_hash=b966969e9ec0a9ab77fbeeae4e179380093a6acfb96e8249aa74cf4798e719d6)(@modelcontextprotocol/sdk@1.29.0(zod@4.3.6))(ws@8.20.0)(zod@4.3.6)
       '@mariozechner/pi-tui':
         specifier: ^0.65.2
         version: 0.65.2
+      '@modelcontextprotocol/ext-apps':
+        specifier: ^1.2.2
+        version: 1.5.0(@modelcontextprotocol/sdk@1.29.0(zod@4.3.6))(zod@4.3.6)
+      '@modelcontextprotocol/sdk':
+        specifier: ^1.25.1
+        version: 1.29.0(zod@4.3.6)
       '@sinclair/typebox':
         specifier: '*'
         version: 0.34.49
+      open:
+        specifier: ^10.2.0
+        version: 10.2.0
       undici:
         specifier: ^8.0.2
         version: 8.0.2
+      zod:
+        specifier: ^4.0.0
+        version: 4.3.6
     devDependencies:
       '@biomejs/biome':
         specifier: ^1.9.4
         version: 1.9.4
       '@mariozechner/pi-ai':
         specifier: ^0.65.2
-        version: 0.65.2(ws@8.20.0)(zod@4.3.6)
+        version: 0.65.2(@modelcontextprotocol/sdk@1.29.0(zod@4.3.6))(ws@8.20.0)(zod@4.3.6)
       '@mixmark-io/domino':
         specifier: ^2.2.0
         version: 2.2.0
@@ -430,6 +442,12 @@ packages:
       '@modelcontextprotocol/sdk':
         optional: true
 
+  '@hono/node-server@1.19.14':
+    resolution: {integrity: sha512-GwtvgtXxnWsucXvbQXkRgqksiH2Qed37H9xHZocE5sA3N8O8O8/8FA3uclQXxXVzc9XBZuEOMK7+r02FmSpHtw==}
+    engines: {node: '>=18.14.1'}
+    peerDependencies:
+      hono: ^4
+
   '@jridgewell/sourcemap-codec@1.5.5':
     resolution: {integrity: sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==}
 
@@ -523,6 +541,30 @@ packages:
 
   '@mixmark-io/domino@2.2.0':
     resolution: {integrity: sha512-Y28PR25bHXUg88kCV7nivXrP2Nj2RueZ3/l/jdx6J9f8J4nsEGcgX0Qe6lt7Pa+J79+kPiJU3LguR6O/6zrLOw==}
+
+  '@modelcontextprotocol/ext-apps@1.5.0':
+    resolution: {integrity: sha512-q4fut89TOoP2LEPHSGfZErIf1K1xOTTzV+41h/bB2BqKw2gKb0uLKbHusOy1UtbY0puS16zBho/vFp3f5XMVbQ==}
+    engines: {node: '>=20'}
+    peerDependencies:
+      '@modelcontextprotocol/sdk': ^1.29.0
+      react: ^17.0.0 || ^18.0.0 || ^19.0.0
+      react-dom: ^17.0.0 || ^18.0.0 || ^19.0.0
+      zod: ^3.25.0 || ^4.0.0
+    peerDependenciesMeta:
+      react:
+        optional: true
+      react-dom:
+        optional: true
+
+  '@modelcontextprotocol/sdk@1.29.0':
+    resolution: {integrity: sha512-zo37mZA9hJWpULgkRpowewez1y6ML5GsXJPY8FI0tBBCd77HEvza4jDqRKOXgHNn867PVGCyTdzqpz0izu5ZjQ==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@cfworker/json-schema': ^4.1.1
+      zod: ^3.25 || ^4.0
+    peerDependenciesMeta:
+      '@cfworker/json-schema':
+        optional: true
 
   '@protobufjs/aspromise@1.1.2':
     resolution: {integrity: sha512-j+gKExEuLmKwvz3OgROXtrJ2UG2x8Ch2YZUxahh+s1F2HZ+wAceUNLkvy6zKCPVRkU++ZWQrdxsUeQXmcg4uoQ==}
@@ -936,6 +978,10 @@ packages:
   '@vitest/utils@3.2.4':
     resolution: {integrity: sha512-fB2V0JFrQSMsCo9HiSq3Ezpdv4iYaXRG1Sx8edX3MwxfyNn83mKiGzOcH+Fkxt4MHxr3y42fQi1oeAInqgX2QA==}
 
+  accepts@2.0.0:
+    resolution: {integrity: sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng==}
+    engines: {node: '>= 0.6'}
+
   agent-base@7.1.4:
     resolution: {integrity: sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==}
     engines: {node: '>= 14'}
@@ -989,6 +1035,10 @@ packages:
   bignumber.js@9.3.1:
     resolution: {integrity: sha512-Ko0uX15oIUS7wJ3Rb30Fs6SkVbLmPBAKdlm7q9+ak9bbIeFf0MwuBsQV6z7+X768/cHsfg+WlysDWJcmthjsjQ==}
 
+  body-parser@2.2.2:
+    resolution: {integrity: sha512-oP5VkATKlNwcgvxi0vM0p/D3n2C3EReYVX+DNYs5TjZFn/oQt2j+4sVJtSMr18pdRr8wjTcBl6LoV+FUwzPmNA==}
+    engines: {node: '>=18'}
+
   bowser@2.14.1:
     resolution: {integrity: sha512-tzPjzCxygAKWFOJP011oxFHs57HzIhOEracIgAePE4pqB3LikALKnSzUyU4MGs9/iCEUuHlAJTjTc5M+u7YEGg==}
 
@@ -1002,9 +1052,25 @@ packages:
   buffer-equal-constant-time@1.0.1:
     resolution: {integrity: sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA==}
 
+  bundle-name@4.1.0:
+    resolution: {integrity: sha512-tjwM5exMg6BGRI+kNmTntNsvdZS1X8BFYS6tnJ2hdH0kVxM6/eVZ2xy+FqStSWvYmtfFMDLIxurorHwDKfDz5Q==}
+    engines: {node: '>=18'}
+
+  bytes@3.1.2:
+    resolution: {integrity: sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==}
+    engines: {node: '>= 0.8'}
+
   cac@6.7.14:
     resolution: {integrity: sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==}
     engines: {node: '>=8'}
+
+  call-bind-apply-helpers@1.0.2:
+    resolution: {integrity: sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==}
+    engines: {node: '>= 0.4'}
+
+  call-bound@1.0.4:
+    resolution: {integrity: sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==}
+    engines: {node: '>= 0.4'}
 
   chai@5.3.3:
     resolution: {integrity: sha512-4zNhdJD/iOjSH0A05ea+Ke6MU5mmpQcbQsSOkgdaUMJ9zTlDTD/GYlwohmIE2u0gaxHYiVHEn1Fw9mZ/ktJWgw==}
@@ -1037,6 +1103,30 @@ packages:
   color-name@1.1.4:
     resolution: {integrity: sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==}
 
+  content-disposition@1.1.0:
+    resolution: {integrity: sha512-5jRCH9Z/+DRP7rkvY83B+yGIGX96OYdJmzngqnw2SBSxqCFPd0w2km3s5iawpGX8krnwSGmF0FW5Nhr0Hfai3g==}
+    engines: {node: '>=18'}
+
+  content-type@1.0.5:
+    resolution: {integrity: sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==}
+    engines: {node: '>= 0.6'}
+
+  cookie-signature@1.2.2:
+    resolution: {integrity: sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg==}
+    engines: {node: '>=6.6.0'}
+
+  cookie@0.7.2:
+    resolution: {integrity: sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==}
+    engines: {node: '>= 0.6'}
+
+  cors@2.8.6:
+    resolution: {integrity: sha512-tJtZBBHA6vjIAaF6EnIaq6laBBP9aq/Y3ouVJjEfoHbRBcHBAHYcMh/w8LDrk2PvIMMq8gmopa5D4V8RmbrxGw==}
+    engines: {node: '>= 0.10'}
+
+  cross-spawn@7.0.6:
+    resolution: {integrity: sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==}
+    engines: {node: '>= 8'}
+
   data-uri-to-buffer@4.0.1:
     resolution: {integrity: sha512-0R9ikRb668HB7QDxT1vkpuUBtqc53YyAwMwGeUFKRojY/NWKvdZ+9UYtRfGmhqNbRkTSVpMbmyhXipFFv2cb/A==}
     engines: {node: '>= 12'}
@@ -1058,25 +1148,64 @@ packages:
     resolution: {integrity: sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==}
     engines: {node: '>=6'}
 
+  default-browser-id@5.0.1:
+    resolution: {integrity: sha512-x1VCxdX4t+8wVfd1so/9w+vQ4vx7lKd2Qp5tDRutErwmR85OgmfX7RlLRMWafRMY7hbEiXIbudNrjOAPa/hL8Q==}
+    engines: {node: '>=18'}
+
+  default-browser@5.5.0:
+    resolution: {integrity: sha512-H9LMLr5zwIbSxrmvikGuI/5KGhZ8E2zH3stkMgM5LpOWDutGM2JZaj460Udnf1a+946zc7YBgrqEWwbk7zHvGw==}
+    engines: {node: '>=18'}
+
+  define-lazy-prop@3.0.0:
+    resolution: {integrity: sha512-N+MeXYoqr3pOgn8xfyRPREN7gHakLYjhsHhWGT3fWAiL4IkAt0iDw14QiiEm2bE30c5XX5q0FtAA3CK5f9/BUg==}
+    engines: {node: '>=12'}
+
   degenerator@5.0.1:
     resolution: {integrity: sha512-TllpMR/t0M5sqCXfj85i4XaAzxmS5tVA16dqvdkMwGmzI+dXLXnw3J+3Vdv7VKw+ThlTMboK6i9rnZ6Nntj5CQ==}
     engines: {node: '>= 14'}
+
+  depd@2.0.0:
+    resolution: {integrity: sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==}
+    engines: {node: '>= 0.8'}
 
   diff@8.0.4:
     resolution: {integrity: sha512-DPi0FmjiSU5EvQV0++GFDOJ9ASQUVFh5kD+OzOnYdi7n3Wpm9hWWGfB/O2blfHcMVTL5WkQXSnRiK9makhrcnw==}
     engines: {node: '>=0.3.1'}
 
+  dunder-proto@1.0.1:
+    resolution: {integrity: sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==}
+    engines: {node: '>= 0.4'}
+
   ecdsa-sig-formatter@1.0.11:
     resolution: {integrity: sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==}
+
+  ee-first@1.1.1:
+    resolution: {integrity: sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==}
 
   emoji-regex@8.0.0:
     resolution: {integrity: sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==}
 
+  encodeurl@2.0.0:
+    resolution: {integrity: sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==}
+    engines: {node: '>= 0.8'}
+
   end-of-stream@1.4.5:
     resolution: {integrity: sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==}
 
+  es-define-property@1.0.1:
+    resolution: {integrity: sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==}
+    engines: {node: '>= 0.4'}
+
+  es-errors@1.3.0:
+    resolution: {integrity: sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==}
+    engines: {node: '>= 0.4'}
+
   es-module-lexer@1.7.0:
     resolution: {integrity: sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==}
+
+  es-object-atoms@1.1.1:
+    resolution: {integrity: sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==}
+    engines: {node: '>= 0.4'}
 
   esbuild@0.27.7:
     resolution: {integrity: sha512-IxpibTjyVnmrIQo5aqNpCgoACA/dTKLTlhMHihVHhdkxKyPO1uBBthumT0rdHmcsk9uMonIWS0m4FljWzILh3w==}
@@ -1086,6 +1215,9 @@ packages:
   escalade@3.2.0:
     resolution: {integrity: sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==}
     engines: {node: '>=6'}
+
+  escape-html@1.0.3:
+    resolution: {integrity: sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==}
 
   escodegen@2.1.0:
     resolution: {integrity: sha512-2NlIDTwUWJN0mRPQOdtQBzbUHvdGY2P1VXSyU83Q3xKxM7WHX2Ql8dKq782Q9TgQUNOLEzEYu9bzLNj1q88I5w==}
@@ -1108,9 +1240,31 @@ packages:
     resolution: {integrity: sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==}
     engines: {node: '>=0.10.0'}
 
+  etag@1.8.1:
+    resolution: {integrity: sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==}
+    engines: {node: '>= 0.6'}
+
+  eventsource-parser@3.0.6:
+    resolution: {integrity: sha512-Vo1ab+QXPzZ4tCa8SwIHJFaSzy4R6SHf7BY79rFBDf0idraZWAkYrDjDj8uWaSm3S2TK+hJ7/t1CEmZ7jXw+pg==}
+    engines: {node: '>=18.0.0'}
+
+  eventsource@3.0.7:
+    resolution: {integrity: sha512-CRT1WTyuQoD771GW56XEZFQ/ZoSfWid1alKGDYMmkt2yl8UXrVR4pspqWNEcqKvVIzg6PAltWjxcSSPrboA4iA==}
+    engines: {node: '>=18.0.0'}
+
   expect-type@1.3.0:
     resolution: {integrity: sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==}
     engines: {node: '>=12.0.0'}
+
+  express-rate-limit@8.3.2:
+    resolution: {integrity: sha512-77VmFeJkO0/rvimEDuUC5H30oqUC4EyOhyGccfqoLebB0oiEYfM7nwPrsDsBL1gsTpwfzX8SFy2MT3TDyRq+bg==}
+    engines: {node: '>= 16'}
+    peerDependencies:
+      express: '>= 4.11'
+
+  express@5.2.1:
+    resolution: {integrity: sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==}
+    engines: {node: '>= 18'}
 
   extend@3.0.2:
     resolution: {integrity: sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==}
@@ -1153,9 +1307,21 @@ packages:
     resolution: {integrity: sha512-Ievi/yy8DS3ygGvT47PjSfdFoX+2isQueoYP1cntFW1JLYAuS4GD7NUPGg4zv2iZfV52uDyk5w5Z0TdpRS6Q1g==}
     engines: {node: '>=20'}
 
+  finalhandler@2.1.1:
+    resolution: {integrity: sha512-S8KoZgRZN+a5rNwqTxlZZePjT/4cnm0ROV70LedRHZ0p8u9fRID0hJUZQpkKLzro8LfmC8sx23bY6tVNxv8pQA==}
+    engines: {node: '>= 18.0.0'}
+
   formdata-polyfill@4.0.10:
     resolution: {integrity: sha512-buewHzMvYL29jdeQTVILecSaZKnt/RJWjoZCF5OW60Z67/GmSLBkOFM7qh1PI3zFNtJbaZL5eQu1vLfazOwj4g==}
     engines: {node: '>=12.20.0'}
+
+  forwarded@0.2.0:
+    resolution: {integrity: sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==}
+    engines: {node: '>= 0.6'}
+
+  fresh@2.0.0:
+    resolution: {integrity: sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A==}
+    engines: {node: '>= 0.8'}
 
   fsevents@2.3.2:
     resolution: {integrity: sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==}
@@ -1166,6 +1332,9 @@ packages:
     resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
     engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
     os: [darwin]
+
+  function-bind@1.1.2:
+    resolution: {integrity: sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==}
 
   gaxios@7.1.4:
     resolution: {integrity: sha512-bTIgTsM2bWn3XklZISBTQX7ZSddGW+IO3bMdGaemHZ3tbqExMENHLx6kKZ/KlejgrMtj8q7wBItt51yegqalrA==}
@@ -1182,6 +1351,14 @@ packages:
   get-east-asian-width@1.5.0:
     resolution: {integrity: sha512-CQ+bEO+Tva/qlmw24dCejulK5pMzVnUOFOijVogd3KQs07HnRIgp8TGipvCCRT06xeYEbpbgwaCxglFyiuIcmA==}
     engines: {node: '>=18'}
+
+  get-intrinsic@1.3.0:
+    resolution: {integrity: sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==}
+    engines: {node: '>= 0.4'}
+
+  get-proto@1.0.1:
+    resolution: {integrity: sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==}
+    engines: {node: '>= 0.4'}
 
   get-stream@5.2.0:
     resolution: {integrity: sha512-nBF+F1rAZVCu/p7rjzgA+Yb4lfYXrpl7a6VmJrU8wF9I1CKvP/QwPNZHnOlwbTkY6dvtFIzFMSyQXbLoTQPRpA==}
@@ -1206,6 +1383,10 @@ packages:
     resolution: {integrity: sha512-eAmLkjDjAFCVXg7A1unxHsLf961m6y17QFqXqAXGj/gVkKFrEICfStRfwUlGNfeCEjNRa32JEWOUTlYXPyyKvA==}
     engines: {node: '>=14'}
 
+  gopd@1.2.0:
+    resolution: {integrity: sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==}
+    engines: {node: '>= 0.4'}
+
   graceful-fs@4.2.11:
     resolution: {integrity: sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==}
 
@@ -1213,12 +1394,28 @@ packages:
     resolution: {integrity: sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==}
     engines: {node: '>=8'}
 
+  has-symbols@1.1.0:
+    resolution: {integrity: sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==}
+    engines: {node: '>= 0.4'}
+
+  hasown@2.0.2:
+    resolution: {integrity: sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==}
+    engines: {node: '>= 0.4'}
+
   highlight.js@10.7.3:
     resolution: {integrity: sha512-tzcUFauisWKNHaRkN4Wjl/ZA07gENAjFl3J/c480dprkGTg5EQstgaNFqBfUqCq54kZRIEcreTsAgF/m2quD7A==}
+
+  hono@4.12.12:
+    resolution: {integrity: sha512-p1JfQMKaceuCbpJKAPKVqyqviZdS0eUxH9v82oWo1kb9xjQ5wA6iP3FNVAPDFlz5/p7d45lO+BpSk1tuSZMF4Q==}
+    engines: {node: '>=16.9.0'}
 
   hosted-git-info@9.0.2:
     resolution: {integrity: sha512-M422h7o/BR3rmCQ8UHi7cyyMqKltdP9Uo+J2fXK+RSAY+wTcKOIRyhTuKv4qn+DJf3g+PL890AzId5KZpX+CBg==}
     engines: {node: ^20.17.0 || >=22.9.0}
+
+  http-errors@2.0.1:
+    resolution: {integrity: sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==}
+    engines: {node: '>= 0.8'}
 
   http-proxy-agent@7.0.2:
     resolution: {integrity: sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==}
@@ -1228,6 +1425,10 @@ packages:
     resolution: {integrity: sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==}
     engines: {node: '>= 14'}
 
+  iconv-lite@0.7.2:
+    resolution: {integrity: sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw==}
+    engines: {node: '>=0.10.0'}
+
   ieee754@1.2.1:
     resolution: {integrity: sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==}
 
@@ -1235,13 +1436,43 @@ packages:
     resolution: {integrity: sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg==}
     engines: {node: '>= 4'}
 
+  inherits@2.0.4:
+    resolution: {integrity: sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==}
+
   ip-address@10.1.0:
     resolution: {integrity: sha512-XXADHxXmvT9+CRxhXg56LJovE+bmWnEWB78LB83VZTprKTmaC5QfruXocxzTZ2Kl0DNwKuBdlIhjL8LeY8Sf8Q==}
     engines: {node: '>= 12'}
 
+  ipaddr.js@1.9.1:
+    resolution: {integrity: sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==}
+    engines: {node: '>= 0.10'}
+
+  is-docker@3.0.0:
+    resolution: {integrity: sha512-eljcgEDlEns/7AXFosB5K/2nCM4P7FQPkGc/DWLy5rmFEWvZayGrik1d9/QIY5nJ4f9YsVvBkA6kJpHn9rISdQ==}
+    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
+    hasBin: true
+
   is-fullwidth-code-point@3.0.0:
     resolution: {integrity: sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==}
     engines: {node: '>=8'}
+
+  is-inside-container@1.0.0:
+    resolution: {integrity: sha512-KIYLCCJghfHZxqjYBE7rEy0OBuTd5xCHS7tHVgvCLkx7StIoaxwNW3hCALgEUjFfeRk+MG/Qxmp/vtETEF3tRA==}
+    engines: {node: '>=14.16'}
+    hasBin: true
+
+  is-promise@4.0.0:
+    resolution: {integrity: sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==}
+
+  is-wsl@3.1.1:
+    resolution: {integrity: sha512-e6rvdUCiQCAuumZslxRJWR/Doq4VpPR82kqclvcS0efgt430SlGIk05vdCN58+VrzgtIcfNODjozVielycD4Sw==}
+    engines: {node: '>=16'}
+
+  isexe@2.0.0:
+    resolution: {integrity: sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==}
+
+  jose@6.2.2:
+    resolution: {integrity: sha512-d7kPDd34KO/YnzaDOlikGpOurfF0ByC2sEV4cANCtdqLlTfBlw2p14O/5d/zv40gJPbIQxfES3nSx1/oYNyuZQ==}
 
   js-tokens@9.0.1:
     resolution: {integrity: sha512-mxa9E9ITFOt0ban3j6L5MpjwegGz6lBQmM1IJkWeBZGcMxto50+eWdjC/52xDbS2vy0k7vIMK0Fe2wfL9OQSpQ==}
@@ -1255,6 +1486,9 @@ packages:
 
   json-schema-traverse@1.0.0:
     resolution: {integrity: sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==}
+
+  json-schema-typed@8.0.2:
+    resolution: {integrity: sha512-fQhoXdcvc3V28x7C7BMs4P5+kNlgUURe2jmUT1T//oBRMDrqy1QPelJimwZGo7Hg9VPV3EQV5Bnq4hbFy2vetA==}
 
   jwa@2.0.1:
     resolution: {integrity: sha512-hRF04fqJIP8Abbkq5NKGN0Bbr3JxlQ+qhZufXVr0DvujKy93ZCbXZMHDL4EOtodSbCWxOqR8MS1tXA5hwqCXDg==}
@@ -1287,6 +1521,18 @@ packages:
     engines: {node: '>= 18'}
     hasBin: true
 
+  math-intrinsics@1.1.0:
+    resolution: {integrity: sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==}
+    engines: {node: '>= 0.4'}
+
+  media-typer@1.1.0:
+    resolution: {integrity: sha512-aisnrDP4GNe06UcKFnV5bfMNPBUw4jsLGaWwWfnH3v02GnBuXX2MCVn5RbrWo0j3pczUilYblq7fQ7Nw2t5XKw==}
+    engines: {node: '>= 0.8'}
+
+  merge-descriptors@2.0.0:
+    resolution: {integrity: sha512-Snk314V5ayFLhp3fkUREub6WtjBfPdCPY1Ln8/8munuLuiYhsABgBVWsozAG+MWMbVEvcdcpbi9R7ww22l9Q3g==}
+    engines: {node: '>=18'}
+
   mime-db@1.54.0:
     resolution: {integrity: sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==}
     engines: {node: '>= 0.6'}
@@ -1314,6 +1560,10 @@ packages:
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
     hasBin: true
 
+  negotiator@1.0.0:
+    resolution: {integrity: sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==}
+    engines: {node: '>= 0.6'}
+
   netmask@2.1.0:
     resolution: {integrity: sha512-z9sZrk6wyf8/NDKKqe+Tyl58XtgkYrV4kgt1O8xrzYvpl1LvPacPo0imMLHfpStk3kgCIq1ksJ2bmJn9hue2lQ==}
     engines: {node: '>= 0.4.0'}
@@ -1331,8 +1581,20 @@ packages:
     resolution: {integrity: sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==}
     engines: {node: '>=0.10.0'}
 
+  object-inspect@1.13.4:
+    resolution: {integrity: sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==}
+    engines: {node: '>= 0.4'}
+
+  on-finished@2.4.1:
+    resolution: {integrity: sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==}
+    engines: {node: '>= 0.8'}
+
   once@1.4.0:
     resolution: {integrity: sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==}
+
+  open@10.2.0:
+    resolution: {integrity: sha512-YgBpdJHPyQ2UE5x+hlSXcnejzAvD0b22U2OuAP+8OnlJT+PjWPxtgmGqKKc+RgTM63U9gN0YzrYc71R2WT/hTA==}
+    engines: {node: '>=18'}
 
   openai@6.26.0:
     resolution: {integrity: sha512-zd23dbWTjiJ6sSAX6s0HrCZi41JwTA1bQVs0wLQPZ2/5o2gxOJA5wh7yOAUgwYybfhDXyhwlpeQf7Mlgx8EOCA==}
@@ -1367,6 +1629,10 @@ packages:
   parse5@6.0.1:
     resolution: {integrity: sha512-Ofn/CTFzRGTTxwpNEs9PP93gXShHcTq255nzRYSKe8AkVpZY7e1fpmTfOyoIvjP5HG7Z2ZM7VS9PPhQGW2pOpw==}
 
+  parseurl@1.3.3:
+    resolution: {integrity: sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==}
+    engines: {node: '>= 0.8'}
+
   partial-json@0.1.7:
     resolution: {integrity: sha512-Njv/59hHaokb/hRUjce3Hdv12wd60MtM9Z5Olmn+nehe0QDAsRtRbJPvJ0Z91TusF0SuZRIvnM+S4l6EIP8leA==}
 
@@ -1374,9 +1640,16 @@ packages:
     resolution: {integrity: sha512-s4DQMxIdhj3jLFWd9LxHOplj4p9yQ4ffMGowFf3cpEgrrJjEhN0V5nxw4Ye1EViAGDoL4/1AeO6qHpqYPOzE4Q==}
     engines: {node: '>=14.0.0'}
 
+  path-key@3.1.1:
+    resolution: {integrity: sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==}
+    engines: {node: '>=8'}
+
   path-scurry@2.0.2:
     resolution: {integrity: sha512-3O/iVVsJAPsOnpwWIeD+d6z/7PmqApyQePUtCndjatj/9I5LylHvt5qluFaBT3I5h3r1ejfR056c+FCv+NnNXg==}
     engines: {node: 18 || 20 || >=22}
+
+  path-to-regexp@8.4.2:
+    resolution: {integrity: sha512-qRcuIdP69NPm4qbACK+aDogI5CBDMi1jKe0ry5rSQJz8JVLsC7jV8XpiJjGRLLol3N+R5ihGYcrPLTno6pAdBA==}
 
   pathe@2.0.3:
     resolution: {integrity: sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==}
@@ -1394,6 +1667,10 @@ packages:
   picomatch@4.0.4:
     resolution: {integrity: sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==}
     engines: {node: '>=12'}
+
+  pkce-challenge@5.0.1:
+    resolution: {integrity: sha512-wQ0b/W4Fr01qtpHlqSqspcj3EhBvimsdh0KlHhH8HRZnMsEa0ea2fTULOXOS9ccQr3om+GcGRk4e+isrZWV8qQ==}
+    engines: {node: '>=16.20.0'}
 
   playwright-core@1.59.1:
     resolution: {integrity: sha512-HBV/RJg81z5BiiZ9yPzIiClYV/QMsDCKUyogwH9p3MCP6IYjUFu/MActgYAvK0oWyV9NlwM3GLBjADyWgydVyg==}
@@ -1416,6 +1693,10 @@ packages:
     resolution: {integrity: sha512-CvexbZtbov6jW2eXAvLukXjXUW1TzFaivC46BpWc/3BpcCysb5Vffu+B3XHMm8lVEuy2Mm4XGex8hBSg1yapPg==}
     engines: {node: '>=12.0.0'}
 
+  proxy-addr@2.0.7:
+    resolution: {integrity: sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==}
+    engines: {node: '>= 0.10'}
+
   proxy-agent@6.5.0:
     resolution: {integrity: sha512-TmatMXdr2KlRiA2CyDu8GqR8EjahTG3aY3nXjdzFyoZbmB8hrBsTyMezhULIXKnC0jpfjlmiZ3+EaCzoInSu/A==}
     engines: {node: '>= 14'}
@@ -1425,6 +1706,18 @@ packages:
 
   pump@3.0.4:
     resolution: {integrity: sha512-VS7sjc6KR7e1ukRFhQSY5LM2uBWAUPiOPa/A3mkKmiMwSmRFUITt0xuj+/lesgnCv+dPIEYlkzrcyXgquIHMcA==}
+
+  qs@6.15.1:
+    resolution: {integrity: sha512-6YHEFRL9mfgcAvql/XhwTvf5jKcOiiupt2FiJxHkiX1z4j7WL8J/jRHYLluORvc1XxB5rV20KoeK00gVJamspg==}
+    engines: {node: '>=0.6'}
+
+  range-parser@1.2.1:
+    resolution: {integrity: sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==}
+    engines: {node: '>= 0.6'}
+
+  raw-body@3.0.2:
+    resolution: {integrity: sha512-K5zQjDllxWkf7Z5xJdV0/B0WTNqx6vxG70zJE4N0kBs4LovmEYWJzQGxC9bS9RAKu3bgM40lrd5zoLJ12MQ5BA==}
+    engines: {node: '>= 0.10'}
 
   require-directory@2.1.1:
     resolution: {integrity: sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==}
@@ -1450,8 +1743,54 @@ packages:
     engines: {node: '>=18.0.0', npm: '>=8.0.0'}
     hasBin: true
 
+  router@2.2.0:
+    resolution: {integrity: sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ==}
+    engines: {node: '>= 18'}
+
+  run-applescript@7.1.0:
+    resolution: {integrity: sha512-DPe5pVFaAsinSaV6QjQ6gdiedWDcRCbUuiQfQa2wmWV7+xC9bGulGI8+TdRmoFkAPaBXk8CrAbnlY2ISniJ47Q==}
+    engines: {node: '>=18'}
+
   safe-buffer@5.2.1:
     resolution: {integrity: sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==}
+
+  safer-buffer@2.1.2:
+    resolution: {integrity: sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==}
+
+  send@1.2.1:
+    resolution: {integrity: sha512-1gnZf7DFcoIcajTjTwjwuDjzuz4PPcY2StKPlsGAQ1+YH20IRVrBaXSWmdjowTJ6u8Rc01PoYOGHXfP1mYcZNQ==}
+    engines: {node: '>= 18'}
+
+  serve-static@2.2.1:
+    resolution: {integrity: sha512-xRXBn0pPqQTVQiC8wyQrKs2MOlX24zQ0POGaj0kultvoOCstBQM5yvOhAVSUwOMjQtTvsPWoNCHfPGwaaQJhTw==}
+    engines: {node: '>= 18'}
+
+  setprototypeof@1.2.0:
+    resolution: {integrity: sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==}
+
+  shebang-command@2.0.0:
+    resolution: {integrity: sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==}
+    engines: {node: '>=8'}
+
+  shebang-regex@3.0.0:
+    resolution: {integrity: sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==}
+    engines: {node: '>=8'}
+
+  side-channel-list@1.0.1:
+    resolution: {integrity: sha512-mjn/0bi/oUURjc5Xl7IaWi/OJJJumuoJFQJfDDyO46+hBWsfaVM65TBHq2eoZBhzl9EchxOijpkbRC8SVBQU0w==}
+    engines: {node: '>= 0.4'}
+
+  side-channel-map@1.0.1:
+    resolution: {integrity: sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==}
+    engines: {node: '>= 0.4'}
+
+  side-channel-weakmap@1.0.2:
+    resolution: {integrity: sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==}
+    engines: {node: '>= 0.4'}
+
+  side-channel@1.1.0:
+    resolution: {integrity: sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==}
+    engines: {node: '>= 0.4'}
 
   siginfo@2.0.0:
     resolution: {integrity: sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==}
@@ -1481,6 +1820,10 @@ packages:
 
   stackback@0.0.2:
     resolution: {integrity: sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==}
+
+  statuses@2.0.2:
+    resolution: {integrity: sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==}
+    engines: {node: '>= 0.8'}
 
   std-env@3.10.0:
     resolution: {integrity: sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==}
@@ -1540,6 +1883,10 @@ packages:
     resolution: {integrity: sha512-azl+t0z7pw/z958Gy9svOTuzqIk6xq+NSheJzn5MMWtWTFywIacg2wUlzKFGtt3cthx0r2SxMK0yzJOR0IES7Q==}
     engines: {node: '>=14.0.0'}
 
+  toidentifier@1.0.1:
+    resolution: {integrity: sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==}
+    engines: {node: '>=0.6'}
+
   token-types@6.1.2:
     resolution: {integrity: sha512-dRXchy+C0IgK8WPC6xvCHFRIWYUbqqdEIKPaKo/AcTUNzwLTK6AH7RjdLWsEZcAN/TBdtfUw3PYEgPr5VPr6ww==}
     engines: {node: '>=14.16'}
@@ -1558,6 +1905,10 @@ packages:
   turndown@7.2.4:
     resolution: {integrity: sha512-I8yFsfRzmzK0WV1pNNOA4A7y4RDfFxPRxb3t+e3ui14qSGOxGtiSP6GjeX+Y6CHb7HYaFj7ECUD7VE5kQMZWGQ==}
     engines: {node: '>=18', npm: '>=9'}
+
+  type-is@2.0.1:
+    resolution: {integrity: sha512-OZs6gsjF4vMp32qrCbiVSkrFmXtG/AZhY3t0iAMrMBiAZyV9oALtXO8hsrHbMXF9x6L3grlFuwW2oAz7cav+Gw==}
+    engines: {node: '>= 0.6'}
 
   typescript@5.9.3:
     resolution: {integrity: sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==}
@@ -1578,6 +1929,14 @@ packages:
   undici@8.0.2:
     resolution: {integrity: sha512-B9MeU5wuFhkFAuNeA19K2GDFcQXZxq33fL0nRy2Aq30wdufZbyyvxW3/ChaeipXVfy/wUweZyzovQGk39+9k2w==}
     engines: {node: '>=22.19.0'}
+
+  unpipe@1.0.0:
+    resolution: {integrity: sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==}
+    engines: {node: '>= 0.8'}
+
+  vary@1.1.2:
+    resolution: {integrity: sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==}
+    engines: {node: '>= 0.8'}
 
   vite-node@3.2.4:
     resolution: {integrity: sha512-EbKSKh+bh1E1IFxeO0pg1n4dvoOTt0UDiXMd/qn++r98+jPO1xtJilvXldeuQ8giIB5IkpjCgMleHMNEsGH6pg==}
@@ -1656,6 +2015,11 @@ packages:
     resolution: {integrity: sha512-d2JWLCivmZYTSIoge9MsgFCZrt571BikcWGYkjC1khllbTeDlGqZ2D8vD8E/lJa8WGWbb7Plm8/XJYV7IJHZZw==}
     engines: {node: '>= 8'}
 
+  which@2.0.2:
+    resolution: {integrity: sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==}
+    engines: {node: '>= 8'}
+    hasBin: true
+
   why-is-node-running@2.3.0:
     resolution: {integrity: sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==}
     engines: {node: '>=8'}
@@ -1679,6 +2043,10 @@ packages:
         optional: true
       utf-8-validate:
         optional: true
+
+  wsl-utils@0.1.0:
+    resolution: {integrity: sha512-h3Fbisa2nKGPxCpm89Hk33lBLsnaGBvctQopaBSOW/uIs6FTe1ATyAnKFJrzVs9vpGdsTe73WF3V4lIsk4Gacw==}
+    engines: {node: '>=18'}
 
   y18n@5.0.8:
     resolution: {integrity: sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==}
@@ -2225,16 +2593,22 @@ snapshots:
   '@esbuild/win32-x64@0.27.7':
     optional: true
 
-  '@google/genai@1.48.0':
+  '@google/genai@1.48.0(@modelcontextprotocol/sdk@1.29.0(zod@4.3.6))':
     dependencies:
       google-auth-library: 10.6.2
       p-retry: 4.6.2
       protobufjs: 7.5.4
       ws: 8.20.0
+    optionalDependencies:
+      '@modelcontextprotocol/sdk': 1.29.0(zod@4.3.6)
     transitivePeerDependencies:
       - bufferutil
       - supports-color
       - utf-8-validate
+
+  '@hono/node-server@1.19.14(hono@4.12.12)':
+    dependencies:
+      hono: 4.12.12
 
   '@jridgewell/sourcemap-codec@1.5.5': {}
 
@@ -2287,9 +2661,9 @@ snapshots:
       std-env: 3.10.0
       yoctocolors: 2.1.2
 
-  '@mariozechner/pi-agent-core@0.65.2(ws@8.20.0)(zod@4.3.6)':
+  '@mariozechner/pi-agent-core@0.65.2(@modelcontextprotocol/sdk@1.29.0(zod@4.3.6))(ws@8.20.0)(zod@4.3.6)':
     dependencies:
-      '@mariozechner/pi-ai': 0.65.2(ws@8.20.0)(zod@4.3.6)
+      '@mariozechner/pi-ai': 0.65.2(@modelcontextprotocol/sdk@1.29.0(zod@4.3.6))(ws@8.20.0)(zod@4.3.6)
     transitivePeerDependencies:
       - '@modelcontextprotocol/sdk'
       - aws-crt
@@ -2299,11 +2673,11 @@ snapshots:
       - ws
       - zod
 
-  '@mariozechner/pi-ai@0.65.2(ws@8.20.0)(zod@4.3.6)':
+  '@mariozechner/pi-ai@0.65.2(@modelcontextprotocol/sdk@1.29.0(zod@4.3.6))(ws@8.20.0)(zod@4.3.6)':
     dependencies:
       '@anthropic-ai/sdk': 0.73.0(zod@4.3.6)
       '@aws-sdk/client-bedrock-runtime': 3.1025.0
-      '@google/genai': 1.48.0
+      '@google/genai': 1.48.0(@modelcontextprotocol/sdk@1.29.0(zod@4.3.6))
       '@mistralai/mistralai': 1.14.1
       '@sinclair/typebox': 0.34.49
       ajv: 8.18.0
@@ -2323,11 +2697,11 @@ snapshots:
       - ws
       - zod
 
-  '@mariozechner/pi-coding-agent@0.65.2(patch_hash=b966969e9ec0a9ab77fbeeae4e179380093a6acfb96e8249aa74cf4798e719d6)(ws@8.20.0)(zod@4.3.6)':
+  '@mariozechner/pi-coding-agent@0.65.2(patch_hash=b966969e9ec0a9ab77fbeeae4e179380093a6acfb96e8249aa74cf4798e719d6)(@modelcontextprotocol/sdk@1.29.0(zod@4.3.6))(ws@8.20.0)(zod@4.3.6)':
     dependencies:
       '@mariozechner/jiti': 2.6.5
-      '@mariozechner/pi-agent-core': 0.65.2(ws@8.20.0)(zod@4.3.6)
-      '@mariozechner/pi-ai': 0.65.2(ws@8.20.0)(zod@4.3.6)
+      '@mariozechner/pi-agent-core': 0.65.2(@modelcontextprotocol/sdk@1.29.0(zod@4.3.6))(ws@8.20.0)(zod@4.3.6)
+      '@mariozechner/pi-ai': 0.65.2(@modelcontextprotocol/sdk@1.29.0(zod@4.3.6))(ws@8.20.0)(zod@4.3.6)
       '@mariozechner/pi-tui': 0.65.2
       '@silvia-odwyer/photon-node': 0.3.4
       ajv: 8.18.0
@@ -2376,6 +2750,33 @@ snapshots:
       - utf-8-validate
 
   '@mixmark-io/domino@2.2.0': {}
+
+  '@modelcontextprotocol/ext-apps@1.5.0(@modelcontextprotocol/sdk@1.29.0(zod@4.3.6))(zod@4.3.6)':
+    dependencies:
+      '@modelcontextprotocol/sdk': 1.29.0(zod@4.3.6)
+      zod: 4.3.6
+
+  '@modelcontextprotocol/sdk@1.29.0(zod@4.3.6)':
+    dependencies:
+      '@hono/node-server': 1.19.14(hono@4.12.12)
+      ajv: 8.18.0
+      ajv-formats: 3.0.1(ajv@8.18.0)
+      content-type: 1.0.5
+      cors: 2.8.6
+      cross-spawn: 7.0.6
+      eventsource: 3.0.7
+      eventsource-parser: 3.0.6
+      express: 5.2.1
+      express-rate-limit: 8.3.2(express@5.2.1)
+      hono: 4.12.12
+      jose: 6.2.2
+      json-schema-typed: 8.0.2
+      pkce-challenge: 5.0.1
+      raw-body: 3.0.2
+      zod: 4.3.6
+      zod-to-json-schema: 3.25.2(zod@4.3.6)
+    transitivePeerDependencies:
+      - supports-color
 
   '@protobufjs/aspromise@1.1.2': {}
 
@@ -2856,6 +3257,11 @@ snapshots:
       loupe: 3.2.1
       tinyrainbow: 2.0.0
 
+  accepts@2.0.0:
+    dependencies:
+      mime-types: 3.0.2
+      negotiator: 1.0.0
+
   agent-base@7.1.4: {}
 
   ajv-formats@3.0.1(ajv@8.18.0):
@@ -2893,6 +3299,20 @@ snapshots:
 
   bignumber.js@9.3.1: {}
 
+  body-parser@2.2.2:
+    dependencies:
+      bytes: 3.1.2
+      content-type: 1.0.5
+      debug: 4.4.3
+      http-errors: 2.0.1
+      iconv-lite: 0.7.2
+      on-finished: 2.4.1
+      qs: 6.15.1
+      raw-body: 3.0.2
+      type-is: 2.0.1
+    transitivePeerDependencies:
+      - supports-color
+
   bowser@2.14.1: {}
 
   brace-expansion@5.0.5:
@@ -2903,7 +3323,23 @@ snapshots:
 
   buffer-equal-constant-time@1.0.1: {}
 
+  bundle-name@4.1.0:
+    dependencies:
+      run-applescript: 7.1.0
+
+  bytes@3.1.2: {}
+
   cac@6.7.14: {}
+
+  call-bind-apply-helpers@1.0.2:
+    dependencies:
+      es-errors: 1.3.0
+      function-bind: 1.1.2
+
+  call-bound@1.0.4:
+    dependencies:
+      call-bind-apply-helpers: 1.0.2
+      get-intrinsic: 1.3.0
 
   chai@5.3.3:
     dependencies:
@@ -2943,6 +3379,25 @@ snapshots:
 
   color-name@1.1.4: {}
 
+  content-disposition@1.1.0: {}
+
+  content-type@1.0.5: {}
+
+  cookie-signature@1.2.2: {}
+
+  cookie@0.7.2: {}
+
+  cors@2.8.6:
+    dependencies:
+      object-assign: 4.1.1
+      vary: 1.1.2
+
+  cross-spawn@7.0.6:
+    dependencies:
+      path-key: 3.1.1
+      shebang-command: 2.0.0
+      which: 2.0.2
+
   data-uri-to-buffer@4.0.1: {}
 
   data-uri-to-buffer@6.0.2: {}
@@ -2953,25 +3408,54 @@ snapshots:
 
   deep-eql@5.0.2: {}
 
+  default-browser-id@5.0.1: {}
+
+  default-browser@5.5.0:
+    dependencies:
+      bundle-name: 4.1.0
+      default-browser-id: 5.0.1
+
+  define-lazy-prop@3.0.0: {}
+
   degenerator@5.0.1:
     dependencies:
       ast-types: 0.13.4
       escodegen: 2.1.0
       esprima: 4.0.1
 
+  depd@2.0.0: {}
+
   diff@8.0.4: {}
+
+  dunder-proto@1.0.1:
+    dependencies:
+      call-bind-apply-helpers: 1.0.2
+      es-errors: 1.3.0
+      gopd: 1.2.0
 
   ecdsa-sig-formatter@1.0.11:
     dependencies:
       safe-buffer: 5.2.1
 
+  ee-first@1.1.1: {}
+
   emoji-regex@8.0.0: {}
+
+  encodeurl@2.0.0: {}
 
   end-of-stream@1.4.5:
     dependencies:
       once: 1.4.0
 
+  es-define-property@1.0.1: {}
+
+  es-errors@1.3.0: {}
+
   es-module-lexer@1.7.0: {}
+
+  es-object-atoms@1.1.1:
+    dependencies:
+      es-errors: 1.3.0
 
   esbuild@0.27.7:
     optionalDependencies:
@@ -3004,6 +3488,8 @@ snapshots:
 
   escalade@3.2.0: {}
 
+  escape-html@1.0.3: {}
+
   escodegen@2.1.0:
     dependencies:
       esprima: 4.0.1
@@ -3022,7 +3508,53 @@ snapshots:
 
   esutils@2.0.3: {}
 
+  etag@1.8.1: {}
+
+  eventsource-parser@3.0.6: {}
+
+  eventsource@3.0.7:
+    dependencies:
+      eventsource-parser: 3.0.6
+
   expect-type@1.3.0: {}
+
+  express-rate-limit@8.3.2(express@5.2.1):
+    dependencies:
+      express: 5.2.1
+      ip-address: 10.1.0
+
+  express@5.2.1:
+    dependencies:
+      accepts: 2.0.0
+      body-parser: 2.2.2
+      content-disposition: 1.1.0
+      content-type: 1.0.5
+      cookie: 0.7.2
+      cookie-signature: 1.2.2
+      debug: 4.4.3
+      depd: 2.0.0
+      encodeurl: 2.0.0
+      escape-html: 1.0.3
+      etag: 1.8.1
+      finalhandler: 2.1.1
+      fresh: 2.0.0
+      http-errors: 2.0.1
+      merge-descriptors: 2.0.0
+      mime-types: 3.0.2
+      on-finished: 2.4.1
+      once: 1.4.0
+      parseurl: 1.3.3
+      proxy-addr: 2.0.7
+      qs: 6.15.1
+      range-parser: 1.2.1
+      router: 2.2.0
+      send: 1.2.1
+      serve-static: 2.2.1
+      statuses: 2.0.2
+      type-is: 2.0.1
+      vary: 1.1.2
+    transitivePeerDependencies:
+      - supports-color
 
   extend@3.0.2: {}
 
@@ -3072,15 +3604,32 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  finalhandler@2.1.1:
+    dependencies:
+      debug: 4.4.3
+      encodeurl: 2.0.0
+      escape-html: 1.0.3
+      on-finished: 2.4.1
+      parseurl: 1.3.3
+      statuses: 2.0.2
+    transitivePeerDependencies:
+      - supports-color
+
   formdata-polyfill@4.0.10:
     dependencies:
       fetch-blob: 3.2.0
+
+  forwarded@0.2.0: {}
+
+  fresh@2.0.0: {}
 
   fsevents@2.3.2:
     optional: true
 
   fsevents@2.3.3:
     optional: true
+
+  function-bind@1.1.2: {}
 
   gaxios@7.1.4:
     dependencies:
@@ -3101,6 +3650,24 @@ snapshots:
   get-caller-file@2.0.5: {}
 
   get-east-asian-width@1.5.0: {}
+
+  get-intrinsic@1.3.0:
+    dependencies:
+      call-bind-apply-helpers: 1.0.2
+      es-define-property: 1.0.1
+      es-errors: 1.3.0
+      es-object-atoms: 1.1.1
+      function-bind: 1.1.2
+      get-proto: 1.0.1
+      gopd: 1.2.0
+      has-symbols: 1.1.0
+      hasown: 2.0.2
+      math-intrinsics: 1.1.0
+
+  get-proto@1.0.1:
+    dependencies:
+      dunder-proto: 1.0.1
+      es-object-atoms: 1.1.1
 
   get-stream@5.2.0:
     dependencies:
@@ -3137,15 +3704,33 @@ snapshots:
 
   google-logging-utils@1.1.3: {}
 
+  gopd@1.2.0: {}
+
   graceful-fs@4.2.11: {}
 
   has-flag@4.0.0: {}
 
+  has-symbols@1.1.0: {}
+
+  hasown@2.0.2:
+    dependencies:
+      function-bind: 1.1.2
+
   highlight.js@10.7.3: {}
+
+  hono@4.12.12: {}
 
   hosted-git-info@9.0.2:
     dependencies:
       lru-cache: 11.3.2
+
+  http-errors@2.0.1:
+    dependencies:
+      depd: 2.0.0
+      inherits: 2.0.4
+      setprototypeof: 1.2.0
+      statuses: 2.0.2
+      toidentifier: 1.0.1
 
   http-proxy-agent@7.0.2:
     dependencies:
@@ -3161,13 +3746,37 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  iconv-lite@0.7.2:
+    dependencies:
+      safer-buffer: 2.1.2
+
   ieee754@1.2.1: {}
 
   ignore@7.0.5: {}
 
+  inherits@2.0.4: {}
+
   ip-address@10.1.0: {}
 
+  ipaddr.js@1.9.1: {}
+
+  is-docker@3.0.0: {}
+
   is-fullwidth-code-point@3.0.0: {}
+
+  is-inside-container@1.0.0:
+    dependencies:
+      is-docker: 3.0.0
+
+  is-promise@4.0.0: {}
+
+  is-wsl@3.1.1:
+    dependencies:
+      is-inside-container: 1.0.0
+
+  isexe@2.0.0: {}
+
+  jose@6.2.2: {}
 
   js-tokens@9.0.1: {}
 
@@ -3181,6 +3790,8 @@ snapshots:
       ts-algebra: 2.0.0
 
   json-schema-traverse@1.0.0: {}
+
+  json-schema-typed@8.0.2: {}
 
   jwa@2.0.1:
     dependencies:
@@ -3210,6 +3821,12 @@ snapshots:
 
   marked@15.0.12: {}
 
+  math-intrinsics@1.1.0: {}
+
+  media-typer@1.1.0: {}
+
+  merge-descriptors@2.0.0: {}
+
   mime-db@1.54.0: {}
 
   mime-types@3.0.2:
@@ -3232,6 +3849,8 @@ snapshots:
 
   nanoid@3.3.11: {}
 
+  negotiator@1.0.0: {}
+
   netmask@2.1.0: {}
 
   node-domexception@1.0.0: {}
@@ -3244,9 +3863,22 @@ snapshots:
 
   object-assign@4.1.1: {}
 
+  object-inspect@1.13.4: {}
+
+  on-finished@2.4.1:
+    dependencies:
+      ee-first: 1.1.1
+
   once@1.4.0:
     dependencies:
       wrappy: 1.0.2
+
+  open@10.2.0:
+    dependencies:
+      default-browser: 5.5.0
+      define-lazy-prop: 3.0.0
+      is-inside-container: 1.0.0
+      wsl-utils: 0.1.0
 
   openai@6.26.0(ws@8.20.0)(zod@4.3.6):
     optionalDependencies:
@@ -3284,14 +3916,20 @@ snapshots:
 
   parse5@6.0.1: {}
 
+  parseurl@1.3.3: {}
+
   partial-json@0.1.7: {}
 
   path-expression-matcher@1.4.0: {}
+
+  path-key@3.1.1: {}
 
   path-scurry@2.0.2:
     dependencies:
       lru-cache: 11.3.2
       minipass: 7.1.3
+
+  path-to-regexp@8.4.2: {}
 
   pathe@2.0.3: {}
 
@@ -3302,6 +3940,8 @@ snapshots:
   picocolors@1.1.1: {}
 
   picomatch@4.0.4: {}
+
+  pkce-challenge@5.0.1: {}
 
   playwright-core@1.59.1: {}
 
@@ -3338,6 +3978,11 @@ snapshots:
       '@types/node': 22.19.17
       long: 5.3.2
 
+  proxy-addr@2.0.7:
+    dependencies:
+      forwarded: 0.2.0
+      ipaddr.js: 1.9.1
+
   proxy-agent@6.5.0:
     dependencies:
       agent-base: 7.1.4
@@ -3357,6 +4002,19 @@ snapshots:
     dependencies:
       end-of-stream: 1.4.5
       once: 1.4.0
+
+  qs@6.15.1:
+    dependencies:
+      side-channel: 1.1.0
+
+  range-parser@1.2.1: {}
+
+  raw-body@3.0.2:
+    dependencies:
+      bytes: 3.1.2
+      http-errors: 2.0.1
+      iconv-lite: 0.7.2
+      unpipe: 1.0.0
 
   require-directory@2.1.1: {}
 
@@ -3399,7 +4057,82 @@ snapshots:
       '@rollup/rollup-win32-x64-msvc': 4.60.1
       fsevents: 2.3.3
 
+  router@2.2.0:
+    dependencies:
+      debug: 4.4.3
+      depd: 2.0.0
+      is-promise: 4.0.0
+      parseurl: 1.3.3
+      path-to-regexp: 8.4.2
+    transitivePeerDependencies:
+      - supports-color
+
+  run-applescript@7.1.0: {}
+
   safe-buffer@5.2.1: {}
+
+  safer-buffer@2.1.2: {}
+
+  send@1.2.1:
+    dependencies:
+      debug: 4.4.3
+      encodeurl: 2.0.0
+      escape-html: 1.0.3
+      etag: 1.8.1
+      fresh: 2.0.0
+      http-errors: 2.0.1
+      mime-types: 3.0.2
+      ms: 2.1.3
+      on-finished: 2.4.1
+      range-parser: 1.2.1
+      statuses: 2.0.2
+    transitivePeerDependencies:
+      - supports-color
+
+  serve-static@2.2.1:
+    dependencies:
+      encodeurl: 2.0.0
+      escape-html: 1.0.3
+      parseurl: 1.3.3
+      send: 1.2.1
+    transitivePeerDependencies:
+      - supports-color
+
+  setprototypeof@1.2.0: {}
+
+  shebang-command@2.0.0:
+    dependencies:
+      shebang-regex: 3.0.0
+
+  shebang-regex@3.0.0: {}
+
+  side-channel-list@1.0.1:
+    dependencies:
+      es-errors: 1.3.0
+      object-inspect: 1.13.4
+
+  side-channel-map@1.0.1:
+    dependencies:
+      call-bound: 1.0.4
+      es-errors: 1.3.0
+      get-intrinsic: 1.3.0
+      object-inspect: 1.13.4
+
+  side-channel-weakmap@1.0.2:
+    dependencies:
+      call-bound: 1.0.4
+      es-errors: 1.3.0
+      get-intrinsic: 1.3.0
+      object-inspect: 1.13.4
+      side-channel-map: 1.0.1
+
+  side-channel@1.1.0:
+    dependencies:
+      es-errors: 1.3.0
+      object-inspect: 1.13.4
+      side-channel-list: 1.0.1
+      side-channel-map: 1.0.1
+      side-channel-weakmap: 1.0.2
 
   siginfo@2.0.0: {}
 
@@ -3426,6 +4159,8 @@ snapshots:
     optional: true
 
   stackback@0.0.2: {}
+
+  statuses@2.0.2: {}
 
   std-env@3.10.0: {}
 
@@ -3480,6 +4215,8 @@ snapshots:
 
   tinyspy@4.0.4: {}
 
+  toidentifier@1.0.1: {}
+
   token-types@6.1.2:
     dependencies:
       '@borewit/text-codec': 0.2.2
@@ -3501,6 +4238,12 @@ snapshots:
     dependencies:
       '@mixmark-io/domino': 2.2.0
 
+  type-is@2.0.1:
+    dependencies:
+      content-type: 1.0.5
+      media-typer: 1.1.0
+      mime-types: 3.0.2
+
   typescript@5.9.3: {}
 
   uint8array-extras@1.5.0: {}
@@ -3510,6 +4253,10 @@ snapshots:
   undici@7.24.7: {}
 
   undici@8.0.2: {}
+
+  unpipe@1.0.0: {}
+
+  vary@1.1.2: {}
 
   vite-node@3.2.4(@types/node@22.19.17)(tsx@4.21.0)(yaml@2.8.3):
     dependencies:
@@ -3589,6 +4336,10 @@ snapshots:
 
   web-streams-polyfill@3.3.3: {}
 
+  which@2.0.2:
+    dependencies:
+      isexe: 2.0.0
+
   why-is-node-running@2.3.0:
     dependencies:
       siginfo: 2.0.0
@@ -3603,6 +4354,10 @@ snapshots:
   wrappy@1.0.2: {}
 
   ws@8.20.0: {}
+
+  wsl-utils@0.1.0:
+    dependencies:
+      is-wsl: 3.1.1
 
   y18n@5.0.8: {}
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -27,6 +27,7 @@ process.env.PI_SKIP_VERSION_CHECK = "1"
 
 import { loadConfig } from "./config.js"
 import bashCollapseExtension from "./extensions/bash-collapse.js"
+import mcpAdapterExtension from "./extensions/mcp-adapter/index.js"
 import promptEnrichmentExtension from "./extensions/orchestration/prompt-enrichment.js"
 import subagentExtension from "./extensions/subagent.js"
 import webFetchExtension from "./extensions/web-fetch/index.js"
@@ -56,7 +57,13 @@ try {
 	// Delegate to pi-mono's CLI main function, injecting the kimchi extension
 	const { main } = await import("@mariozechner/pi-coding-agent")
 	await main(process.argv.slice(2), {
-		extensionFactories: [subagentExtension, webFetchExtension, promptEnrichmentExtension, bashCollapseExtension],
+		extensionFactories: [
+			subagentExtension,
+			mcpAdapterExtension,
+			webFetchExtension,
+			promptEnrichmentExtension,
+			bashCollapseExtension,
+		],
 	})
 } catch (err) {
 	console.error(err instanceof Error ? err.message : String(err))

--- a/src/config.ts
+++ b/src/config.ts
@@ -10,6 +10,7 @@ export interface KimchiConfig {
 	apiKey: string
 	agentConfigDir: string
 	llmEndpoint: string
+	maxToolResultChars: number
 }
 
 /**
@@ -29,6 +30,17 @@ function readApiKeyFromConfigFile(configPath: string): string | undefined {
 	}
 }
 
+function readConfigExtras(configPath: string): { maxToolResultChars?: number } {
+	try {
+		const raw = readFileSync(configPath, "utf-8")
+		const parsed = JSON.parse(raw)
+		const val = parsed.maxToolResultChars
+		return { maxToolResultChars: typeof val === "number" && val > 0 ? val : undefined }
+	} catch {
+		return {}
+	}
+}
+
 /**
  * Load the kimchi-code configuration.
  *
@@ -41,6 +53,8 @@ function readApiKeyFromConfigFile(configPath: string): string | undefined {
 export function loadConfig(options?: { configPath?: string; env?: Record<string, string | undefined> }): KimchiConfig {
 	const env = options?.env ?? process.env
 	const configPath = options?.configPath ?? KIMCHI_CONFIG_PATH
+	const extras = readConfigExtras(configPath)
+	const maxToolResultChars = extras.maxToolResultChars ?? 10_000
 
 	const envKey = env.KIMCHI_API_KEY
 	if (typeof envKey === "string" && envKey.length > 0) {
@@ -48,6 +62,7 @@ export function loadConfig(options?: { configPath?: string; env?: Record<string,
 			apiKey: envKey,
 			agentConfigDir: AGENT_CONFIG_DIR,
 			llmEndpoint: CAST_AI_LLM_ENDPOINT,
+			maxToolResultChars,
 		}
 	}
 
@@ -57,6 +72,7 @@ export function loadConfig(options?: { configPath?: string; env?: Record<string,
 			apiKey: fileKey,
 			agentConfigDir: AGENT_CONFIG_DIR,
 			llmEndpoint: CAST_AI_LLM_ENDPOINT,
+			maxToolResultChars,
 		}
 	}
 

--- a/src/extensions/mcp-adapter/CHANGELOG.md
+++ b/src/extensions/mcp-adapter/CHANGELOG.md
@@ -1,0 +1,264 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [2.4.0] - 2026-04-13
+
+### Added
+- `settings.disableProxyTool` to hide the `mcp` proxy tool once configured direct tools are fully available from cache. Thanks @tanavamsikrishna for PR #41.
+- Per-server `excludeTools` to hide specific MCP tools/resources by original or prefixed name across direct tools, proxy discovery, and the `/mcp` panel. Thanks @ahmadaccino for issue #36.
+- `settings.autoAuth` to optionally trigger OAuth automatically from proxy/direct tool usage, then rerun the original blocked connect/tool operation once after authentication succeeds. Thanks @unimonkiez for issue #34.
+
+### Fixed
+- Regenerated `package-lock.json` so the root lockfile metadata matches `package.json` again, including the declared `open`, `@types/bun`, `@types/open`, and `tsx` entries.
+- Kept the `mcp` proxy tool available as a first-session fallback when configured direct tools are still missing cache metadata, avoiding no-tool startup gaps.
+
+## [2.3.5] - 2026-04-13
+
+### Fixed
+- Session lifecycle now always tears down OAuth callback state on restart and shutdown, preventing callback-server leaks across session transitions.
+- OAuth callback server now calls `unref()` after successful bind so it no longer keeps sub-agent processes alive by itself.
+- Strict OAuth port mode now rebinds to the configured callback port when safe, while refusing to switch ports when authorizations are still pending.
+- Added focused lifecycle/callback-server regression coverage for teardown, `unref()`, strict rebinding, and pending-auth guardrails.
+- Thanks @blai for the investigation and PR #43 that surfaced the sub-agent hang/root lifecycle issues.
+
+## [2.3.4] - 2026-04-12
+
+### Fixed
+- OAuth callback handling now allows dynamic-registration flows to fall back to a free local port when the preferred callback port is busy, while keeping pre-registered clients on their exact configured redirect port.
+- Documented the new callback-port behavior and added focused auth-flow regression coverage.
+
+## [2.3.3] - 2026-04-12
+
+### Fixed
+- Remove the blank footer status line when no MCP servers are configured by clearing the MCP status entry instead of setting it to an empty string. Thanks @HazAT for PR #27.
+
+## [2.3.2] - 2026-04-11
+
+### Added
+- Optional `oauth.grantType: "client_credentials"` for non-interactive machine-to-machine OAuth on HTTP MCP servers.
+
+### Fixed
+- `/mcp-auth <server>` now handles `client_credentials` without browser/callback flow.
+- MCP panel status no longer marks `client_credentials` servers as auth-blocked solely because no stored user tokens exist yet.
+- OAuth auth flow now closes temporary transports consistently on success, refresh, and auth removal paths.
+- Init paths now preserve debug-level context for previously silent direct-tool bootstrap and lazy-connect failures.
+
+## [2.3.1] - 2026-04-11
+
+### Fixed
+- Removed `/mcp-auth-callback`. OAuth auth now hard-cuts to `/mcp-auth <server>` only.
+
+## [2.3.0] - 2026-04-11
+
+### Added
+- OAuth callback server initialization on session start and a deprecated `/mcp-auth-callback` command that now points users to `/mcp-auth <server>`.
+
+### Fixed
+- OAuth `needs-auth` handling across `/mcp` status/panel, `mcp({ connect })`, `mcp({ tool })`, reconnect flow, lazy/direct tool execution, and startup bootstrap.
+- OAuth callback cleanup now cancels by stored OAuth state and closes pending transports on failure/cancel paths.
+- Callback server now fails fast when the OAuth callback port is occupied by another process.
+- Package manifest test now ignores root `*.test.ts` files.
+
+## [2.2.2] - 2026-04-03
+
+### Fixed
+- Session lifecycle teardown now handles repeated `session_start` transitions safely and prevents stale async init results from replacing newer state.
+- Shutdown now still runs `gracefulShutdown()` even if metadata cache flushing throws, avoiding leaked MCP processes.
+- Proxy/direct tool init error paths now preserve and surface underlying error messages instead of returning generic failures.
+- Invalid `mcp` tool `args` now fail by throwing with parse/type context instead of returning non-failing tool payloads.
+- Added focused lifecycle regressions tests for stale init cleanup and init-error visibility.
+
+## [2.2.1] - 2026-03-23
+
+### Fixed
+- Added `promptSnippet` to MCP proxy tool and direct MCP tools so they appear in the system prompt's Available tools section (required since pi 0.59.0)
+
+## [2.2.0] - 2026-03-16
+
+### Added
+- **MCP UI Integration** - Support for the [MCP UI](https://github.com/MCP-UI-Org/mcp-ui) standard. Tools with `_meta.ui.resourceUri` open interactive UIs:
+  - Bidirectional AppBridge communication (tool calls, messages, context updates)
+  - Works with both stdio and HTTP MCP servers
+  - User consent management for tool calls from UI (configurable: never/once-per-server/always)
+  - Keyboard shortcuts: Cmd/Ctrl+Enter to complete, Escape to cancel
+  - UI prompts/intents trigger agent turns via `pi.sendMessage({ triggerTurn: true })`
+  - `mcp({ action: "ui-messages" })` retrieves accumulated messages from UI sessions
+
+- **Session reuse** - When the agent calls the same tool while its UI is already open, results push to the existing window instead of replacing it. Per-call stream IDs with independent sequences. Error results scoped to the individual call.
+
+- **Glimpse integration** - MCP UI opens in a native macOS WKWebView window instead of a browser tab when [Glimpse](https://github.com/hazat/glimpse) is installed (`pi install npm:glimpseui`). Falls back to browser on non-macOS or when unavailable. Override with `MCP_UI_VIEWER=browser` or `MCP_UI_VIEWER=glimpse`.
+
+- **Logger module** (`logger.ts`) - Centralized logging with levels (debug/info/warn/error), contextual child loggers, and `MCP_UI_DEBUG=1` env var.
+
+- **Error types** (`errors.ts`) - Structured errors with recovery hints: `ResourceFetchError`, `ResourceParseError`, `BridgeConnectionError`, `ConsentError`, `SessionError`, `ServerError`, and `wrapError()` helper.
+
+- **Test suite** - 178 tests covering consent manager, UI resource handler, host HTML template, logger, and error types.
+
+- **Interactive visualizer example** (`examples/interactive-visualizer`) - Minimal MCP server demonstrating charts (bar/line/pie/doughnut via Chart.js), bidirectional messaging, and streaming.
+
+### Fixed
+- Host-iframe timing: bridge now connects before loading iframe, fixing `ui/initialize` timeout on first load
+- All internal `log.info` calls demoted to `log.debug` to eliminate stdout noise during normal use
+
+### Technical Notes
+- Uses local minified AppBridge bundle (408KB) to avoid CDN Zod bundling issues
+- Serves app HTML from `/ui-app` endpoint instead of blob URLs to avoid iframe issues
+- SSE for real-time tool result streaming to browser
+
+## [2.1.2] - 2026-02-03
+
+### Changed
+- Added demo video and `pi.video` field to package.json for pi package browser.
+
+## [2.1.0] - 2026-02-02
+
+### Added
+- **Direct tool registration** - Promote specific MCP tools to first-class Pi tools via `directTools` config (per-server or global). Direct tools appear in the agent's tool list alongside builtins, so the LLM uses them without needing to search through the proxy first. Registers from cached metadata at startup — no server connections needed.
+- **`/mcp` interactive panel** - New TUI overlay replacing the text-based status dump. Shows server connection status, tool lists with direct/proxy toggles, token cost estimates, inline reconnect, and auth notices. Changes written to config on save.
+- **Auto-enriched proxy description** - The `mcp` proxy tool description now includes server names and tool counts from the metadata cache, so the LLM knows what's available without a search call (~30 extra tokens).
+- **`MCP_DIRECT_TOOLS` env var** - Subagent processes receive their direct tool configuration via environment variable, keeping subagents lean by default.
+- **First-run bootstrap** - Servers with `directTools` configured but no cache entry are connected during `session_start` to populate the cache. Direct tools become available after restart.
+- Config provenance tracking for correct write-back to user/project/import sources
+- Builtin name collision guard (skips direct tools that would shadow `read`, `write`, etc.)
+- Cross-server name deduplication for `prefix: "none"` and `prefix: "short"` modes
+
+## [2.0.1] - 2026-02-01
+
+### Fixed
+- Adapt execute signature to pi v0.51.0: add signal, onUpdate, ctx parameters
+
+## [2.0.0] - 2026-01-29
+
+### Changed
+- **BREAKING: Lazy startup by default** - All servers now default to `lifecycle: "lazy"` and only connect when a tool call needs them. Previously all servers connected eagerly on session start. Set `lifecycle: "keep-alive"` or `lifecycle: "eager"` to restore the old behavior per-server.
+- **Idle timeout** - Connected servers are automatically disconnected after 10 minutes of inactivity (configurable via `settings.idleTimeout` or per-server `idleTimeout`). Cached metadata keeps search/list working after disconnect. Set `idleTimeout: 0` to disable.
+- `/mcp reconnect` accepts an optional server name to connect or reconnect a single server
+
+### Added
+- **Metadata cache** - Tool and resource metadata persisted to `~/.pi/agent/mcp-cache.json`. Enables search/list/describe without live connections. Per-server config hashing with 7-day staleness. Multi-session safe via read-merge-write with per-process tmp files.
+- **npx binary resolution** - Resolves npx package binaries to direct paths, eliminating the ~143 MB npm parent process per server. Persistent cache at `~/.pi/agent/mcp-npx-cache.json` with 24h TTL.
+- **`mcp({ connect: "server-name" })` mode** - Explicitly trigger connection and metadata refresh for a named server
+- **Failure backoff** - Servers that fail to connect are skipped for 60 seconds to avoid repeated connection storms
+- **In-flight tracking** - Active tool calls prevent idle timeout from shutting down a server mid-request
+- **Prefix-match fallback** - Tool calls with unrecognized names try to match a server prefix and lazy-connect the matching server
+- Lifecycle options: `lazy` (default), `eager` (connect at startup, no auto-reconnect), `keep-alive` (unchanged)
+- Per-server `idleTimeout` override and global `settings.idleTimeout`
+- First-run bootstrap: connects all servers on first session to populate the cache
+
+### Fixed
+- Connection close race condition: concurrent close + connect no longer orphans server processes
+- **Fuzzy tool name matching** - Hyphens and underscores are treated as equivalent during tool lookup. MCP tools like `resolve-library-id` are now found when called as `resolve_library_id`, which LLMs naturally guess since the prefix separator is `_`.
+- **Better "tool not found" errors** - When a server is identified (via prefix match or override) but the tool isn't found, the error now lists that server's available tools so the LLM can self-correct immediately instead of needing a separate list call
+
+## [1.6.0] - 2026-01-29
+
+### Added
+- **Unified pi tool search** - `mcp({ search: "..." })` now searches both MCP tools and Pi tools (from installed extensions)
+- Pi tools appear first in results with `[pi tool]` prefix
+- Details object includes `server: "pi"` for pi tools
+- Banner image for README
+
+## [1.5.1] - 2026-01-26
+
+### Changed
+- Added `pi-package` keyword for npm discoverability (pi v0.50.0 package system)
+
+## [1.5.0] - 2026-01-22
+
+### Changed
+- **BREAKING: `args` parameter is now a JSON string** - The `args` parameter which previously accepted an object now accepts a JSON string. This change was required for compatibility with Claude's Vertex AI API (`google-antigravity` provider) which rejects `patternProperties` in JSON schemas (generated by `Type.Record()`).
+
+### Added
+- **Type validation for args** - Parsed args are now validated to ensure they're a JSON object (not null, array, or primitive). Clear error messages for invalid input.
+- **`isError: true` on error responses** - JSON parse errors and type validation errors now properly set `isError: true` to indicate failure to the LLM.
+
+### Migration
+```typescript
+// Before (1.4.x)
+mcp({ tool: "my_tool", args: { key: "value" } })
+
+// After (1.5.0)
+mcp({ tool: "my_tool", args: '{"key": "value"}' })
+```
+
+## [1.4.1] - 2026-01-19
+
+### Changed
+
+- Status bar shows server count instead of tool count ("MCP: 5 servers")
+
+## [1.4.0] - 2026-01-19
+
+### Changed
+
+- **Non-blocking startup** - Pi starts immediately, MCP servers connect in background. First MCP call waits only if init isn't done yet.
+
+### Fixed
+
+- Tool metadata now includes `inputSchema` after `/mcp reconnect` (was missing, breaking describe and error hints)
+
+## [1.3.0] - 2026-01-19
+
+### Changed
+
+- **Parallel server connections** - All MCP servers now connect in parallel on startup instead of sequentially, significantly faster with many servers
+
+## [1.2.2] - 2026-01-19
+
+### Fixed
+
+- Installer now downloads from `main` branch (renamed from `master`)
+
+## [1.2.1] - 2026-01-19
+
+### Added
+
+- **npx installer** - Run `npx pi-mcp-adapter` to install (downloads files, installs deps, configures settings.json)
+
+## [1.1.0] - 2026-01-19
+
+### Changed
+
+- **Search includes schemas by default** - Search results now include parameter schemas, reducing tool calls needed (search + call instead of search + describe + call)
+- **Space-separated search terms match as OR** - `"navigate screenshot"` finds tools matching either word (like most search engines)
+- **Suppress server stderr by default** - MCP server logs no longer clutter terminal on startup
+- Use `includeSchemas: false` for compact output without schemas
+- Use `debug: true` per-server to show stderr when troubleshooting
+
+## [1.0.0] - 2026-01-19
+
+### Added
+
+- **Single unified `mcp` tool** with token-efficient architecture (~200 tokens vs ~15,000 for individual tools)
+- **Five operation modes:**
+  - `mcp({})` - Show server status
+  - `mcp({ server: "name" })` - List tools from a server
+  - `mcp({ search: "query" })` - Search tools by name/description
+  - `mcp({ describe: "tool_name" })` - Show tool details and parameter schema
+  - `mcp({ tool: "name", args: {...} })` - Call a tool
+- **Stdio transport** for local MCP servers (command + args)
+- **HTTP transport** with automatic fallback (StreamableHTTP → SSE)
+- **Config imports** from Cursor, Claude Code, Claude Desktop, VS Code, Windsurf, Codex
+- **Resource tools** - MCP resources exposed as callable tools
+- **OAuth support** - Token file-based authentication
+- **Bearer token auth** - Static or environment variable tokens
+- **Keep-alive connections** with automatic health checks and reconnection
+- **Schema on-demand** - Parameter schemas shown in `describe` mode and error responses
+- **Commands:**
+  - `/mcp` or `/mcp status` - Show server status
+  - `/mcp tools` - List all tools
+  - `/mcp reconnect` - Force reconnect all servers
+  - `/mcp-auth <server>` - Show OAuth setup instructions
+
+### Architecture
+
+- Tools stored in metadata map, not registered individually with Pi
+- MCP server validates arguments (no client-side schema conversion)
+- Reconnect callback updates metadata after auto-reconnect
+- Human-readable schema formatting for LLM consumption

--- a/src/extensions/mcp-adapter/LICENSE
+++ b/src/extensions/mcp-adapter/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Nico Bailon
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/src/extensions/mcp-adapter/README.md
+++ b/src/extensions/mcp-adapter/README.md
@@ -1,0 +1,316 @@
+<p>
+  <img src="banner.png" alt="pi-mcp-adapter" width="1100">
+</p>
+
+# Pi MCP Adapter
+
+Use MCP servers with [Pi](https://github.com/badlogic/pi-mono/) without burning your context window.
+
+https://github.com/user-attachments/assets/4b7c66ff-e27e-4639-b195-22c3db406a5a
+
+## Why This Exists
+
+Mario wrote about [why you might not need MCP](https://mariozechner.at/posts/2025-11-02-what-if-you-dont-need-mcp/). The problem: tool definitions are verbose. A single MCP server can burn 10k+ tokens, and you're paying that cost whether you use those tools or not. Connect a few servers and you've burned half your context window before the conversation starts.
+
+His take: skip MCP entirely, write simple CLI tools instead.
+
+But the MCP ecosystem has useful stuff - databases, browsers, APIs. This adapter gives you access without the bloat. One proxy tool (~200 tokens) instead of hundreds. The agent discovers what it needs on-demand. Servers only start when you actually use them.
+
+## Install
+
+```bash
+pi install npm:pi-mcp-adapter
+```
+
+Restart Pi after installation.
+
+## Quick Start
+
+Create `~/.pi/agent/mcp.json`:
+
+```json
+{
+  "mcpServers": {
+    "chrome-devtools": {
+      "command": "npx",
+      "args": ["-y", "chrome-devtools-mcp@latest"]
+    }
+  }
+}
+```
+
+Servers are **lazy by default** — they won't connect until you actually call one of their tools. The adapter caches tool metadata so search and describe work without live connections.
+
+```
+mcp({ search: "screenshot" })
+```
+```
+chrome_devtools_take_screenshot
+  Take a screenshot of the page or element.
+
+  Parameters:
+    format (enum: "png", "jpeg", "webp") [default: "png"]
+    fullPage (boolean) - Full page instead of viewport
+```
+```
+mcp({ tool: "chrome_devtools_take_screenshot", args: '{"format": "png"}' })
+```
+
+Note: `args` is a JSON string, not an object.
+
+Two calls instead of 26 tools cluttering the context.
+
+## Config
+
+### Server Options
+
+```json
+{
+  "mcpServers": {
+    "my-server": {
+      "command": "npx",
+      "args": ["-y", "some-mcp-server"],
+      "lifecycle": "lazy",
+      "idleTimeout": 10
+    }
+  }
+}
+```
+
+| Field | Description |
+|-------|-------------|
+| `command` | Executable for stdio transport |
+| `args` | Command arguments |
+| `env` | Environment variables (`${VAR}` interpolation) |
+| `cwd` | Working directory |
+| `url` | HTTP endpoint (StreamableHTTP with SSE fallback) |
+| `auth` | `"bearer"` or `"oauth"` |
+| `oauth.grantType` | `"authorization_code"` (default) or `"client_credentials"` for non-interactive machine auth |
+| `bearerToken` / `bearerTokenEnv` | Token or env var name |
+| `lifecycle` | `"lazy"` (default), `"eager"`, or `"keep-alive"` |
+| `idleTimeout` | Minutes before idle disconnect (overrides global) |
+| `exposeResources` | Expose MCP resources as tools (default: true) |
+| `directTools` | `true`, `string[]`, or `false` — register tools individually instead of through proxy |
+| `excludeTools` | `string[]` of tool names to hide (matches original names like `get_screenshot` and prefixed names like `figma_get_screenshot`) |
+| `debug` | Show server stderr (default: false) |
+
+### Lifecycle Modes
+
+- **`lazy`** (default) — Don't connect at startup. Connect on first tool call. Disconnect after idle timeout. Cached metadata keeps search/list working without connections.
+- **`eager`** — Connect at startup but don't auto-reconnect if the connection drops. No idle timeout by default (set `idleTimeout` explicitly to enable).
+- **`keep-alive`** — Connect at startup. Auto-reconnect via health checks. No idle timeout. Use for servers you always need available.
+
+### Settings
+
+```json
+{
+  "settings": {
+    "toolPrefix": "server",
+    "idleTimeout": 10
+  },
+  "mcpServers": { }
+}
+```
+
+| Setting | Description |
+|---------|-------------|
+| `toolPrefix` | `"server"` (default), `"short"` (strips `-mcp` suffix), or `"none"` |
+| `idleTimeout` | Global idle timeout in minutes (default: 10, 0 to disable) |
+| `directTools` | Global default for all servers (default: false). Per-server overrides this. |
+| `disableProxyTool` | Hide the `mcp` proxy tool once configured direct tools are fully available from cache. |
+| `autoAuth` | Auto-run OAuth on `connect`/tool calls when a server needs auth, then retry once (default: false). |
+
+Per-server `idleTimeout` overrides the global setting.
+
+### Direct Tools
+
+By default, all MCP tools are accessed through the single `mcp` proxy tool. This keeps context small but means the LLM has to discover tools via search. If you want specific tools to show up directly in the agent's tool list — alongside `read`, `bash`, `edit`, etc. — add `directTools` to your config.
+
+Per-server:
+
+```json
+{
+  "mcpServers": {
+    "chrome-devtools": {
+      "command": "npx",
+      "args": ["-y", "chrome-devtools-mcp@latest"],
+      "directTools": true
+    },
+    "github": {
+      "command": "npx",
+      "args": ["-y", "@modelcontextprotocol/server-github"],
+      "directTools": ["search_repositories", "get_file_contents"]
+    },
+    "huge-server": {
+      "command": "npx",
+      "args": ["-y", "mega-mcp@latest"]
+    }
+  }
+}
+```
+
+| Value | Behavior |
+|-------|----------|
+| `true` | Register all tools from this server as individual Pi tools |
+| `["tool_a", "tool_b"]` | Register only these tools (use original MCP names) |
+| Omitted or `false` | Proxy only (default) |
+
+To set a global default for all servers:
+
+```json
+{
+  "settings": {
+    "directTools": true
+  },
+  "mcpServers": {
+    "huge-server": {
+      "directTools": false
+    }
+  }
+}
+```
+
+Per-server `directTools` overrides the global setting. The example above registers direct tools for every server except `huge-server`.
+
+To exclude specific tools while still using `directTools: true`, add `excludeTools` on the server:
+
+```json
+{
+  "mcpServers": {
+    "figma": {
+      "url": "http://localhost:3845/mcp",
+      "directTools": true,
+      "excludeTools": ["get_figjam", "figma_get_code_connect_map"]
+    }
+  }
+}
+```
+
+`excludeTools` filters direct tools, proxy search/list/describe, and the `/mcp` panel view.
+
+Each direct tool costs ~150-300 tokens in the system prompt (name + description + schema). Good for targeted sets of 5-20 tools. For servers with 75+ tools, stick with the proxy or pick specific tools with a `string[]`.
+
+Direct tools register from the metadata cache (`~/.pi/agent/mcp-cache.json`), so no server connections are needed at startup. On the first session after adding `directTools` to a new server, the cache won't exist yet — tools fall back to proxy-only and the cache populates in the background. Restart Pi and they'll be available. To force it: `/mcp reconnect <server>` then restart.
+
+**Interactive configuration:** Run `/mcp` to open an interactive panel showing all servers with connection status, tools, and direct/proxy toggles. You can reconnect servers, initiate OAuth, and toggle tools between direct and proxy — all from one overlay. Changes are written to your config file; restart Pi to apply.
+
+**Subagent integration:** If you use the subagent extension, agents can request direct MCP tools in their frontmatter with `mcp:server-name` syntax. See the subagent README for details.
+
+### MCP UI Integration
+
+MCP servers can ship interactive UIs via the [MCP UI](https://github.com/MCP-UI-Org/mcp-ui) standard. When you call a tool that has a UI resource, the adapter opens it in a native macOS window via [Glimpse](https://github.com/hazat/glimpse) if available, otherwise falls back to the browser.
+
+**How it works:**
+
+1. Agent calls a tool like `launch_dashboard`
+2. The tool's metadata includes `_meta.ui.resourceUri` pointing to a UI resource
+3. pi-mcp-adapter fetches the UI HTML and opens it in an iframe
+4. The UI can call MCP tools and send messages back to the agent
+
+**Native rendering:** On macOS, if [Glimpse](https://github.com/hazat/glimpse) is installed (`pi install npm:glimpseui`), UIs open in a native WKWebView window instead of a browser tab. Set `MCP_UI_VIEWER=browser` to force the browser, or `MCP_UI_VIEWER=glimpse` to require native rendering.
+
+**Bidirectional communication:** The UI talks back. When it sends a prompt or intent, the message is stored and `triggerTurn()` wakes the agent. The agent retrieves messages via `mcp({ action: "ui-messages" })` and responds, enabling conversational UIs where the app and agent collaborate in real-time.
+
+**Session reuse:** When the agent calls the same tool again while its UI is already open, the adapter pushes the new result to the existing window instead of replacing it. This enables live updates — the agent can refine a chart, add data, or respond to user input without losing the current view. Different tools still replace the session as before.
+
+**Message types from UI:**
+
+| Type | Purpose |
+|------|---------|
+| `prompt` | User message that triggers an agent response |
+| `intent` | Structured action with name + params |
+| `notify` | Fire-and-forget notification |
+| `message` | Generic message payload |
+| (custom) | Any other type forwarded as intent |
+
+**Retrieving UI messages:**
+
+```
+mcp({ action: "ui-messages" })
+```
+
+Returns accumulated messages from UI sessions. Each message includes `type`, `sessionId`, `serverName`, `toolName`, and `timestamp`. Prompt messages include `prompt`, intent messages include `intent` and `params`.
+
+**Browser controls:**
+
+- **Cmd/Ctrl+Enter** — Complete and close
+- **Escape** — Cancel and close
+- **Done/Cancel buttons** — Same as keyboard shortcuts
+
+**Technical notes:**
+
+- Tool consent gates whether UIs can call MCP tools (never/once-per-server/always)
+- Works with both stdio and HTTP MCP servers
+- Uses a local 408KB AppBridge bundle (MCP SDK + Zod) for browser↔server communication
+
+### Local Example: Interactive Visualizer
+
+A minimal MCP UI example at `examples/interactive-visualizer` demonstrating charts, bidirectional messaging, and streaming. From that directory:
+
+```bash
+npm install
+npm run build
+npm run install-local
+```
+
+Restart pi, then ask the agent to show a chart — it calls `show_chart` and opens the UI in Glimpse (macOS) or the browser. Use `npm run uninstall-local` to remove the MCP entry.
+
+### Import Existing Configs
+
+Already have MCP set up elsewhere? Import it:
+
+```json
+{
+  "imports": ["cursor", "claude-code", "claude-desktop"],
+  "mcpServers": { }
+}
+```
+
+Supported: `cursor`, `claude-code`, `claude-desktop`, `vscode`, `windsurf`, `codex`
+
+### Project Config
+
+Add `.pi/mcp.json` in a project root for project-specific servers. Project config overrides global and imported servers.
+
+## Usage
+
+| Mode | Example |
+|------|---------|
+| Status | `mcp({ })` |
+| List server | `mcp({ server: "name" })` |
+| Search | `mcp({ search: "screenshot navigate" })` |
+| Describe | `mcp({ describe: "tool_name" })` |
+| Call | `mcp({ tool: "...", args: '{"key": "value"}' })` |
+| Connect | `mcp({ connect: "server-name" })` |
+| UI messages | `mcp({ action: "ui-messages" })` |
+
+Search includes both MCP tools and Pi tools (from extensions). Pi tools appear first with `[pi tool]` prefix. Space-separated words are OR'd.
+
+Tool names are fuzzy-matched on hyphens and underscores — `context7_resolve_library_id` finds `context7_resolve-library-id`.
+
+## Commands
+
+| Command | What it does |
+|---------|--------------|
+| `/mcp` | Interactive panel (server status, tool toggles, reconnect) |
+| `/mcp tools` | List all tools |
+| `/mcp reconnect` | Reconnect all servers |
+| `/mcp reconnect <server>` | Connect or reconnect a single server |
+| `/mcp-auth <server>` | OAuth setup |
+
+If `settings.autoAuth` is `true`, `mcp({ connect: ... })`, `mcp({ tool: ... })`, and direct tool calls will automatically run OAuth when needed and retry once. In non-interactive sessions, browser-based OAuth still requires running `/mcp-auth <server>` manually.
+
+## How It Works
+
+- One `mcp` tool in context (~200 tokens) instead of hundreds
+- Servers are lazy by default — they connect on first tool call, not at startup
+- Tool metadata is cached to disk so search/list/describe work without live connections
+- Idle servers disconnect after 10 minutes (configurable), reconnect automatically on next use
+- npx-based servers resolve to direct binary paths, skipping the ~143 MB npm parent process
+- MCP server validates arguments, not the adapter
+- Keep-alive servers get health checks and auto-reconnect
+- Specific tools can be promoted from the proxy to first-class Pi tools via `directTools` config, so the LLM sees them directly instead of having to search
+
+## Limitations
+
+- Cross-session server sharing not yet implemented (each Pi session runs its own server processes)

--- a/src/extensions/mcp-adapter/app-bridge.bundle.js
+++ b/src/extensions/mcp-adapter/app-bridge.bundle.js
@@ -1,0 +1,10430 @@
+var Mu = Object.defineProperty
+var $e = (t, r) => {
+	for (var n in r) Mu(t, n, { get: r[n], enumerable: !0 })
+}
+var s = {}
+$e(s, {
+	$brand: () => pn,
+	$input: () => Si,
+	$output: () => ki,
+	NEVER: () => mn,
+	TimePrecision: () => ji,
+	ZodAny: () => Mc,
+	ZodArray: () => Hc,
+	ZodBase64: () => Ea,
+	ZodBase64URL: () => Aa,
+	ZodBigInt: () => Dt,
+	ZodBigIntFormat: () => Ma,
+	ZodBoolean: () => Zt,
+	ZodCIDRv4: () => Da,
+	ZodCIDRv6: () => Ra,
+	ZodCUID: () => ja,
+	ZodCUID2: () => Pa,
+	ZodCatch: () => au,
+	ZodCustom: () => Hr,
+	ZodCustomStringFormat: () => Ec,
+	ZodDate: () => qr,
+	ZodDefault: () => eu,
+	ZodDiscriminatedUnion: () => Jc,
+	ZodE164: () => Ca,
+	ZodEmail: () => ka,
+	ZodEmoji: () => wa,
+	ZodEnum: () => Ot,
+	ZodError: () => wm,
+	ZodFile: () => Xc,
+	ZodGUID: () => Ar,
+	ZodIPv4: () => Ua,
+	ZodIPv6: () => Za,
+	ZodISODate: () => Dr,
+	ZodISODateTime: () => Zr,
+	ZodISODuration: () => Er,
+	ZodISOTime: () => Rr,
+	ZodIntersection: () => Bc,
+	ZodIssueCode: () => Sp,
+	ZodJWT: () => La,
+	ZodKSUID: () => Na,
+	ZodLazy: () => pu,
+	ZodLiteral: () => Qc,
+	ZodMap: () => Gc,
+	ZodNaN: () => cu,
+	ZodNanoID: () => Ia,
+	ZodNever: () => Vc,
+	ZodNonOptional: () => Ba,
+	ZodNull: () => Lc,
+	ZodNullable: () => Yc,
+	ZodNumber: () => Ut,
+	ZodNumberFormat: () => He,
+	ZodObject: () => Vr,
+	ZodOptional: () => Ja,
+	ZodPipe: () => Wa,
+	ZodPrefault: () => ru,
+	ZodPromise: () => fu,
+	ZodReadonly: () => uu,
+	ZodRealError: () => Fe,
+	ZodRecord: () => Va,
+	ZodSet: () => Kc,
+	ZodString: () => Nt,
+	ZodStringFormat: () => C,
+	ZodSuccess: () => iu,
+	ZodSymbol: () => Ac,
+	ZodTemplateLiteral: () => mu,
+	ZodTransform: () => Fa,
+	ZodTuple: () => Wc,
+	ZodType: () => P,
+	ZodULID: () => Ta,
+	ZodURL: () => Sa,
+	ZodUUID: () => fe,
+	ZodUndefined: () => Cc,
+	ZodUnion: () => qa,
+	ZodUnknown: () => qc,
+	ZodVoid: () => Fc,
+	ZodXID: () => Oa,
+	_ZodString: () => za,
+	_default: () => tu,
+	any: () => ap,
+	array: () => T,
+	base64: () => Jm,
+	base64url: () => Bm,
+	bigint: () => tp,
+	boolean: () => H,
+	catch: () => su,
+	check: () => gu,
+	cidrv4: () => Fm,
+	cidrv6: () => Hm,
+	clone: () => te,
+	coerce: () => Ka,
+	config: () => F,
+	core: () => de,
+	cuid: () => Em,
+	cuid2: () => Am,
+	custom: () => Ga,
+	date: () => cp,
+	discriminatedUnion: () => Fr,
+	e164: () => Wm,
+	email: () => jm,
+	emoji: () => Dm,
+	endsWith: () => zt,
+	enum: () => X,
+	file: () => hp,
+	flattenError: () => it,
+	float32: () => Qm,
+	float64: () => Xm,
+	formatError: () => at,
+	function: () => pa,
+	getErrorMap: () => Ip,
+	globalRegistry: () => ce,
+	gt: () => me,
+	gte: () => ee,
+	guid: () => Pm,
+	includes: () => $t,
+	instanceof: () => xp,
+	int: () => xa,
+	int32: () => Ym,
+	int64: () => rp,
+	intersection: () => Et,
+	ipv4: () => qm,
+	ipv6: () => Vm,
+	iso: () => Ve,
+	json: () => kp,
+	jwt: () => Gm,
+	keyof: () => up,
+	ksuid: () => Mm,
+	lazy: () => du,
+	length: () => qe,
+	literal: () => w,
+	locales: () => gt,
+	looseObject: () => Q,
+	lowercase: () => _t,
+	lt: () => le,
+	lte: () => oe,
+	map: () => dp,
+	maxLength: () => Me,
+	maxSize: () => Le,
+	mime: () => kt,
+	minLength: () => ve,
+	minSize: () => Pe,
+	multipleOf: () => je,
+	nan: () => _p,
+	nanoid: () => Rm,
+	nativeEnum: () => gp,
+	negative: () => ra,
+	never: () => Mr,
+	nonnegative: () => oa,
+	nonoptional: () => ou,
+	nonpositive: () => na,
+	normalize: () => St,
+	null: () => Rt,
+	nullable: () => Cr,
+	nullish: () => vp,
+	number: () => Z,
+	object: () => z,
+	optional: () => q,
+	overwrite: () => pe,
+	parse: () => ba,
+	parseAsync: () => _a,
+	partialRecord: () => pp,
+	pipe: () => Lr,
+	positive: () => ta,
+	prefault: () => nu,
+	preprocess: () => Jr,
+	prettifyError: () => Sn,
+	promise: () => $p,
+	property: () => ia,
+	readonly: () => lu,
+	record: () => L,
+	refine: () => hu,
+	regex: () => bt,
+	regexes: () => Se,
+	registry: () => mr,
+	safeParse: () => ya,
+	safeParseAsync: () => $a,
+	set: () => fp,
+	setErrorMap: () => wp,
+	size: () => vt,
+	startsWith: () => xt,
+	strictObject: () => lp,
+	string: () => l,
+	stringFormat: () => Km,
+	stringbool: () => zp,
+	success: () => bp,
+	superRefine: () => vu,
+	symbol: () => op,
+	templateLiteral: () => yp,
+	toJSONSchema: () => da,
+	toLowerCase: () => It,
+	toUpperCase: () => jt,
+	transform: () => Ha,
+	treeifyError: () => kn,
+	trim: () => wt,
+	tuple: () => mp,
+	uint32: () => ep,
+	uint64: () => np,
+	ulid: () => Cm,
+	undefined: () => ip,
+	union: () => R,
+	unknown: () => M,
+	uppercase: () => yt,
+	url: () => Zm,
+	uuid: () => Tm,
+	uuidv4: () => Om,
+	uuidv6: () => Nm,
+	uuidv7: () => Um,
+	void: () => sp,
+	xid: () => Lm,
+})
+var de = {}
+$e(de, {
+	$ZodAny: () => Xo,
+	$ZodArray: () => pt,
+	$ZodAsyncError: () => se,
+	$ZodBase64: () => qo,
+	$ZodBase64URL: () => Vo,
+	$ZodBigInt: () => cr,
+	$ZodBigIntFormat: () => Wo,
+	$ZodBoolean: () => mt,
+	$ZodCIDRv4: () => Co,
+	$ZodCIDRv6: () => Lo,
+	$ZodCUID: () => jo,
+	$ZodCUID2: () => Po,
+	$ZodCatch: () => vi,
+	$ZodCheck: () => V,
+	$ZodCheckBigIntFormat: () => no,
+	$ZodCheckEndsWith: () => ho,
+	$ZodCheckGreaterThan: () => or,
+	$ZodCheckIncludes: () => fo,
+	$ZodCheckLengthEquals: () => uo,
+	$ZodCheckLessThan: () => nr,
+	$ZodCheckLowerCase: () => mo,
+	$ZodCheckMaxLength: () => so,
+	$ZodCheckMaxSize: () => oo,
+	$ZodCheckMimeType: () => bo,
+	$ZodCheckMinLength: () => co,
+	$ZodCheckMinSize: () => io,
+	$ZodCheckMultipleOf: () => to,
+	$ZodCheckNumberFormat: () => ro,
+	$ZodCheckOverwrite: () => _o,
+	$ZodCheckProperty: () => vo,
+	$ZodCheckRegex: () => lo,
+	$ZodCheckSizeEquals: () => ao,
+	$ZodCheckStartsWith: () => go,
+	$ZodCheckStringFormat: () => Re,
+	$ZodCheckUpperCase: () => po,
+	$ZodCustom: () => zi,
+	$ZodCustomStringFormat: () => Jo,
+	$ZodDate: () => ti,
+	$ZodDefault: () => di,
+	$ZodDiscriminatedUnion: () => ni,
+	$ZodE164: () => Fo,
+	$ZodEmail: () => ko,
+	$ZodEmoji: () => wo,
+	$ZodEnum: () => ci,
+	$ZodError: () => ot,
+	$ZodFile: () => li,
+	$ZodFunction: () => Ur,
+	$ZodGUID: () => xo,
+	$ZodIPv4: () => Eo,
+	$ZodIPv6: () => Ao,
+	$ZodISODate: () => Zo,
+	$ZodISODateTime: () => Uo,
+	$ZodISODuration: () => Ro,
+	$ZodISOTime: () => Do,
+	$ZodIntersection: () => oi,
+	$ZodJWT: () => Ho,
+	$ZodKSUID: () => No,
+	$ZodLazy: () => xi,
+	$ZodLiteral: () => ui,
+	$ZodMap: () => ai,
+	$ZodNaN: () => bi,
+	$ZodNanoID: () => Io,
+	$ZodNever: () => Yo,
+	$ZodNonOptional: () => gi,
+	$ZodNull: () => Qo,
+	$ZodNullable: () => pi,
+	$ZodNumber: () => sr,
+	$ZodNumberFormat: () => Bo,
+	$ZodObject: () => ri,
+	$ZodOptional: () => mi,
+	$ZodPipe: () => ft,
+	$ZodPrefault: () => fi,
+	$ZodPromise: () => $i,
+	$ZodReadonly: () => _i,
+	$ZodRealError: () => Ze,
+	$ZodRecord: () => ii,
+	$ZodRegistry: () => Ae,
+	$ZodSet: () => si,
+	$ZodString: () => we,
+	$ZodStringFormat: () => A,
+	$ZodSuccess: () => hi,
+	$ZodSymbol: () => Go,
+	$ZodTemplateLiteral: () => yi,
+	$ZodTransform: () => dt,
+	$ZodTuple: () => Ie,
+	$ZodType: () => j,
+	$ZodULID: () => To,
+	$ZodURL: () => So,
+	$ZodUUID: () => zo,
+	$ZodUndefined: () => Ko,
+	$ZodUnion: () => ur,
+	$ZodUnknown: () => Ee,
+	$ZodVoid: () => ei,
+	$ZodXID: () => Oo,
+	$brand: () => pn,
+	$constructor: () => u,
+	$input: () => Si,
+	$output: () => ki,
+	Doc: () => lt,
+	JSONSchema: () => Zc,
+	JSONSchemaGenerator: () => Tt,
+	NEVER: () => mn,
+	TimePrecision: () => ji,
+	_any: () => Gi,
+	_array: () => Pt,
+	_base64: () => Pr,
+	_base64url: () => Tr,
+	_bigint: () => qi,
+	_boolean: () => Li,
+	_catch: () => _m,
+	_cidrv4: () => Ir,
+	_cidrv6: () => jr,
+	_coercedBigint: () => Vi,
+	_coercedBoolean: () => Mi,
+	_coercedDate: () => Yi,
+	_coercedNumber: () => Zi,
+	_coercedString: () => Ii,
+	_cuid: () => yr,
+	_cuid2: () => $r,
+	_custom: () => ca,
+	_date: () => Xi,
+	_default: () => hm,
+	_discriminatedUnion: () => im,
+	_e164: () => Or,
+	_email: () => pr,
+	_emoji: () => br,
+	_endsWith: () => zt,
+	_enum: () => lm,
+	_file: () => sa,
+	_float32: () => Ri,
+	_float64: () => Ei,
+	_gt: () => me,
+	_gte: () => ee,
+	_guid: () => ht,
+	_includes: () => $t,
+	_int: () => Di,
+	_int32: () => Ai,
+	_int64: () => Fi,
+	_intersection: () => am,
+	_ipv4: () => Sr,
+	_ipv6: () => wr,
+	_isoDate: () => Ti,
+	_isoDateTime: () => Pi,
+	_isoDuration: () => Ni,
+	_isoTime: () => Oi,
+	_jwt: () => Nr,
+	_ksuid: () => kr,
+	_lazy: () => zm,
+	_length: () => qe,
+	_literal: () => pm,
+	_lowercase: () => _t,
+	_lt: () => le,
+	_lte: () => oe,
+	_map: () => cm,
+	_max: () => oe,
+	_maxLength: () => Me,
+	_maxSize: () => Le,
+	_mime: () => kt,
+	_min: () => ee,
+	_minLength: () => ve,
+	_minSize: () => Pe,
+	_multipleOf: () => je,
+	_nan: () => ea,
+	_nanoid: () => _r,
+	_nativeEnum: () => mm,
+	_negative: () => ra,
+	_never: () => Ki,
+	_nonnegative: () => oa,
+	_nonoptional: () => vm,
+	_nonpositive: () => na,
+	_normalize: () => St,
+	_null: () => Wi,
+	_nullable: () => gm,
+	_number: () => Ui,
+	_optional: () => fm,
+	_overwrite: () => pe,
+	_parse: () => Xt,
+	_parseAsync: () => Yt,
+	_pipe: () => ym,
+	_positive: () => ta,
+	_promise: () => km,
+	_property: () => ia,
+	_readonly: () => $m,
+	_record: () => sm,
+	_refine: () => ua,
+	_regex: () => bt,
+	_safeParse: () => er,
+	_safeParseAsync: () => tr,
+	_set: () => um,
+	_size: () => vt,
+	_startsWith: () => xt,
+	_string: () => wi,
+	_stringFormat: () => ma,
+	_stringbool: () => la,
+	_success: () => bm,
+	_symbol: () => Ji,
+	_templateLiteral: () => xm,
+	_toLowerCase: () => It,
+	_toUpperCase: () => jt,
+	_transform: () => dm,
+	_trim: () => wt,
+	_tuple: () => aa,
+	_uint32: () => Ci,
+	_uint64: () => Hi,
+	_ulid: () => xr,
+	_undefined: () => Bi,
+	_union: () => om,
+	_unknown: () => Ce,
+	_uppercase: () => yt,
+	_url: () => vr,
+	_uuid: () => dr,
+	_uuidv4: () => fr,
+	_uuidv6: () => gr,
+	_uuidv7: () => hr,
+	_void: () => Qi,
+	_xid: () => zr,
+	clone: () => te,
+	config: () => F,
+	flattenError: () => it,
+	formatError: () => at,
+	function: () => pa,
+	globalConfig: () => Ke,
+	globalRegistry: () => ce,
+	isValidBase64: () => Mo,
+	isValidBase64URL: () => Hs,
+	isValidJWT: () => Js,
+	locales: () => gt,
+	parse: () => st,
+	parseAsync: () => ct,
+	prettifyError: () => Sn,
+	regexes: () => Se,
+	registry: () => mr,
+	safeParse: () => De,
+	safeParseAsync: () => ut,
+	toDotPath: () => Is,
+	toJSONSchema: () => da,
+	treeifyError: () => kn,
+	util: () => y,
+	version: () => yo,
+})
+var mn = Object.freeze({ status: "aborted" })
+function u(t, r, n) {
+	function i(c, p) {
+		var h
+		Object.defineProperty(c, "_zod", { value: c._zod ?? {}, enumerable: !1 }),
+			(h = c._zod).traits ?? (h.traits = new Set()),
+			c._zod.traits.add(t),
+			r(c, p)
+		for (const g in a.prototype) g in c || Object.defineProperty(c, g, { value: a.prototype[g].bind(c) })
+		;(c._zod.constr = a), (c._zod.def = p)
+	}
+	const e = n?.Parent ?? Object
+	class o extends e {}
+	Object.defineProperty(o, "name", { value: t })
+	function a(c) {
+		var p
+		const h = n?.Parent ? new o() : this
+		i(h, c), (p = h._zod).deferred ?? (p.deferred = [])
+		for (const g of h._zod.deferred) g()
+		return h
+	}
+	return (
+		Object.defineProperty(a, "init", { value: i }),
+		Object.defineProperty(a, Symbol.hasInstance, {
+			value: (c) => (n?.Parent && c instanceof n.Parent ? !0 : c?._zod?.traits?.has(t)),
+		}),
+		Object.defineProperty(a, "name", { value: t }),
+		a
+	)
+}
+var pn = Symbol("zod_brand"),
+	se = class extends Error {
+		constructor() {
+			super("Encountered Promise during synchronous parse. Use .parseAsync() instead.")
+		}
+	},
+	Ke = {}
+function F(t) {
+	return t && Object.assign(Ke, t), Ke
+}
+var y = {}
+$e(y, {
+	BIGINT_FORMAT_RANGES: () => xn,
+	Class: () => fn,
+	NUMBER_FORMAT_RANGES: () => $n,
+	aborted: () => ze,
+	allowsEval: () => bn,
+	assert: () => Ju,
+	assertEqual: () => qu,
+	assertIs: () => Fu,
+	assertNever: () => Hu,
+	assertNotEqual: () => Vu,
+	assignProp: () => vn,
+	cached: () => Ye,
+	captureStackTrace: () => Qt,
+	cleanEnum: () => il,
+	cleanRegex: () => et,
+	clone: () => te,
+	createTransparentProxy: () => Xu,
+	defineLazy: () => U,
+	esc: () => xe,
+	escapeRegex: () => ue,
+	extend: () => tl,
+	finalizeIssue: () => re,
+	floatSafeRemainder: () => hn,
+	getElementAtPath: () => Bu,
+	getEnumValues: () => Xe,
+	getLengthableOrigin: () => nt,
+	getParsedType: () => Qu,
+	getSizableOrigin: () => rt,
+	isObject: () => Ne,
+	isPlainObject: () => Ue,
+	issue: () => zn,
+	joinValues: () => f,
+	jsonStringifyReplacer: () => gn,
+	merge: () => rl,
+	normalizeParams: () => v,
+	nullish: () => he,
+	numKeys: () => Ku,
+	omit: () => el,
+	optionalKeys: () => yn,
+	partial: () => nl,
+	pick: () => Yu,
+	prefixIssues: () => Y,
+	primitiveTypes: () => _n,
+	promiseAllObject: () => Wu,
+	propertyKeyTypes: () => tt,
+	randomString: () => Gu,
+	required: () => ol,
+	stringifyPrimitive: () => _,
+	unwrapMessage: () => Qe,
+})
+function qu(t) {
+	return t
+}
+function Vu(t) {
+	return t
+}
+function Fu(t) {}
+function Hu(t) {
+	throw new Error()
+}
+function Ju(t) {}
+function Xe(t) {
+	const r = Object.values(t).filter((i) => typeof i == "number")
+	return Object.entries(t)
+		.filter(([i, e]) => r.indexOf(+i) === -1)
+		.map(([i, e]) => e)
+}
+function f(t, r = "|") {
+	return t.map((n) => _(n)).join(r)
+}
+function gn(t, r) {
+	return typeof r == "bigint" ? r.toString() : r
+}
+function Ye(t) {
+	return {
+		get value() {
+			{
+				const n = t()
+				return Object.defineProperty(this, "value", { value: n }), n
+			}
+			throw new Error("cached value already set")
+		},
+	}
+}
+function he(t) {
+	return t == null
+}
+function et(t) {
+	const r = t.startsWith("^") ? 1 : 0,
+		n = t.endsWith("$") ? t.length - 1 : t.length
+	return t.slice(r, n)
+}
+function hn(t, r) {
+	const n = (t.toString().split(".")[1] || "").length,
+		i = (r.toString().split(".")[1] || "").length,
+		e = n > i ? n : i,
+		o = Number.parseInt(t.toFixed(e).replace(".", "")),
+		a = Number.parseInt(r.toFixed(e).replace(".", ""))
+	return (o % a) / 10 ** e
+}
+function U(t, r, n) {
+	Object.defineProperty(t, r, {
+		get() {
+			{
+				const e = n()
+				return (t[r] = e), e
+			}
+			throw new Error("cached value already set")
+		},
+		set(e) {
+			Object.defineProperty(t, r, { value: e })
+		},
+		configurable: !0,
+	})
+}
+function vn(t, r, n) {
+	Object.defineProperty(t, r, { value: n, writable: !0, enumerable: !0, configurable: !0 })
+}
+function Bu(t, r) {
+	return r ? r.reduce((n, i) => n?.[i], t) : t
+}
+function Wu(t) {
+	const r = Object.keys(t),
+		n = r.map((i) => t[i])
+	return Promise.all(n).then((i) => {
+		const e = {}
+		for (let o = 0; o < r.length; o++) e[r[o]] = i[o]
+		return e
+	})
+}
+function Gu(t = 10) {
+	let r = "abcdefghijklmnopqrstuvwxyz",
+		n = ""
+	for (let i = 0; i < t; i++) n += r[Math.floor(Math.random() * r.length)]
+	return n
+}
+function xe(t) {
+	return JSON.stringify(t)
+}
+var Qt = Error.captureStackTrace ? Error.captureStackTrace : (...t) => {}
+function Ne(t) {
+	return typeof t == "object" && t !== null && !Array.isArray(t)
+}
+var bn = Ye(() => {
+	if (typeof navigator < "u" && navigator?.userAgent?.includes("Cloudflare")) return !1
+	try {
+		const t = Function
+		return new t(""), !0
+	} catch {
+		return !1
+	}
+})
+function Ue(t) {
+	if (Ne(t) === !1) return !1
+	const r = t.constructor
+	if (r === void 0) return !0
+	const n = r.prototype
+	return !(Ne(n) === !1 || Object.prototype.hasOwnProperty.call(n, "isPrototypeOf") === !1)
+}
+function Ku(t) {
+	let r = 0
+	for (const n in t) Object.prototype.hasOwnProperty.call(t, n) && r++
+	return r
+}
+var Qu = (t) => {
+		const r = typeof t
+		switch (r) {
+			case "undefined":
+				return "undefined"
+			case "string":
+				return "string"
+			case "number":
+				return Number.isNaN(t) ? "nan" : "number"
+			case "boolean":
+				return "boolean"
+			case "function":
+				return "function"
+			case "bigint":
+				return "bigint"
+			case "symbol":
+				return "symbol"
+			case "object":
+				return Array.isArray(t)
+					? "array"
+					: t === null
+						? "null"
+						: t.then && typeof t.then == "function" && t.catch && typeof t.catch == "function"
+							? "promise"
+							: typeof Map < "u" && t instanceof Map
+								? "map"
+								: typeof Set < "u" && t instanceof Set
+									? "set"
+									: typeof Date < "u" && t instanceof Date
+										? "date"
+										: typeof File < "u" && t instanceof File
+											? "file"
+											: "object"
+			default:
+				throw new Error(`Unknown data type: ${r}`)
+		}
+	},
+	tt = new Set(["string", "number", "symbol"]),
+	_n = new Set(["string", "number", "bigint", "boolean", "symbol", "undefined"])
+function ue(t) {
+	return t.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")
+}
+function te(t, r, n) {
+	const i = new t._zod.constr(r ?? t._zod.def)
+	return (!r || n?.parent) && (i._zod.parent = t), i
+}
+function v(t) {
+	const r = t
+	if (!r) return {}
+	if (typeof r == "string") return { error: () => r }
+	if (r?.message !== void 0) {
+		if (r?.error !== void 0) throw new Error("Cannot specify both `message` and `error` params")
+		r.error = r.message
+	}
+	return delete r.message, typeof r.error == "string" ? { ...r, error: () => r.error } : r
+}
+function Xu(t) {
+	let r
+	return new Proxy(
+		{},
+		{
+			get(n, i, e) {
+				return r ?? (r = t()), Reflect.get(r, i, e)
+			},
+			set(n, i, e, o) {
+				return r ?? (r = t()), Reflect.set(r, i, e, o)
+			},
+			has(n, i) {
+				return r ?? (r = t()), Reflect.has(r, i)
+			},
+			deleteProperty(n, i) {
+				return r ?? (r = t()), Reflect.deleteProperty(r, i)
+			},
+			ownKeys(n) {
+				return r ?? (r = t()), Reflect.ownKeys(r)
+			},
+			getOwnPropertyDescriptor(n, i) {
+				return r ?? (r = t()), Reflect.getOwnPropertyDescriptor(r, i)
+			},
+			defineProperty(n, i, e) {
+				return r ?? (r = t()), Reflect.defineProperty(r, i, e)
+			},
+		},
+	)
+}
+function _(t) {
+	return typeof t == "bigint" ? t.toString() + "n" : typeof t == "string" ? `"${t}"` : `${t}`
+}
+function yn(t) {
+	return Object.keys(t).filter((r) => t[r]._zod.optin === "optional" && t[r]._zod.optout === "optional")
+}
+var $n = {
+		safeint: [Number.MIN_SAFE_INTEGER, Number.MAX_SAFE_INTEGER],
+		int32: [-2147483648, 2147483647],
+		uint32: [0, 4294967295],
+		float32: [-34028234663852886e22, 34028234663852886e22],
+		float64: [-Number.MAX_VALUE, Number.MAX_VALUE],
+	},
+	xn = {
+		int64: [BigInt("-9223372036854775808"), BigInt("9223372036854775807")],
+		uint64: [BigInt(0), BigInt("18446744073709551615")],
+	}
+function Yu(t, r) {
+	const n = {},
+		i = t._zod.def
+	for (const e in r) {
+		if (!(e in i.shape)) throw new Error(`Unrecognized key: "${e}"`)
+		r[e] && (n[e] = i.shape[e])
+	}
+	return te(t, { ...t._zod.def, shape: n, checks: [] })
+}
+function el(t, r) {
+	const n = { ...t._zod.def.shape },
+		i = t._zod.def
+	for (const e in r) {
+		if (!(e in i.shape)) throw new Error(`Unrecognized key: "${e}"`)
+		r[e] && delete n[e]
+	}
+	return te(t, { ...t._zod.def, shape: n, checks: [] })
+}
+function tl(t, r) {
+	if (!Ue(r)) throw new Error("Invalid input to extend: expected a plain object")
+	const n = {
+		...t._zod.def,
+		get shape() {
+			const i = { ...t._zod.def.shape, ...r }
+			return vn(this, "shape", i), i
+		},
+		checks: [],
+	}
+	return te(t, n)
+}
+function rl(t, r) {
+	return te(t, {
+		...t._zod.def,
+		get shape() {
+			const n = { ...t._zod.def.shape, ...r._zod.def.shape }
+			return vn(this, "shape", n), n
+		},
+		catchall: r._zod.def.catchall,
+		checks: [],
+	})
+}
+function nl(t, r, n) {
+	const i = r._zod.def.shape,
+		e = { ...i }
+	if (n)
+		for (const o in n) {
+			if (!(o in i)) throw new Error(`Unrecognized key: "${o}"`)
+			n[o] && (e[o] = t ? new t({ type: "optional", innerType: i[o] }) : i[o])
+		}
+	else for (const o in i) e[o] = t ? new t({ type: "optional", innerType: i[o] }) : i[o]
+	return te(r, { ...r._zod.def, shape: e, checks: [] })
+}
+function ol(t, r, n) {
+	const i = r._zod.def.shape,
+		e = { ...i }
+	if (n)
+		for (const o in n) {
+			if (!(o in e)) throw new Error(`Unrecognized key: "${o}"`)
+			n[o] && (e[o] = new t({ type: "nonoptional", innerType: i[o] }))
+		}
+	else for (const o in i) e[o] = new t({ type: "nonoptional", innerType: i[o] })
+	return te(r, { ...r._zod.def, shape: e, checks: [] })
+}
+function ze(t, r = 0) {
+	for (let n = r; n < t.issues.length; n++) if (t.issues[n]?.continue !== !0) return !0
+	return !1
+}
+function Y(t, r) {
+	return r.map((n) => {
+		var i
+		return (i = n).path ?? (i.path = []), n.path.unshift(t), n
+	})
+}
+function Qe(t) {
+	return typeof t == "string" ? t : t?.message
+}
+function re(t, r, n) {
+	const i = { ...t, path: t.path ?? [] }
+	if (!t.message) {
+		const e =
+			Qe(t.inst?._zod.def?.error?.(t)) ??
+			Qe(r?.error?.(t)) ??
+			Qe(n.customError?.(t)) ??
+			Qe(n.localeError?.(t)) ??
+			"Invalid input"
+		i.message = e
+	}
+	return delete i.inst, delete i.continue, r?.reportInput || delete i.input, i
+}
+function rt(t) {
+	return t instanceof Set ? "set" : t instanceof Map ? "map" : t instanceof File ? "file" : "unknown"
+}
+function nt(t) {
+	return Array.isArray(t) ? "array" : typeof t == "string" ? "string" : "unknown"
+}
+function zn(...t) {
+	const [r, n, i] = t
+	return typeof r == "string" ? { message: r, code: "custom", input: n, inst: i } : { ...r }
+}
+function il(t) {
+	return Object.entries(t)
+		.filter(([r, n]) => Number.isNaN(Number.parseInt(r, 10)))
+		.map((r) => r[1])
+}
+var fn = class {
+	constructor(...r) {}
+}
+var ws = (t, r) => {
+		;(t.name = "$ZodError"),
+			Object.defineProperty(t, "_zod", { value: t._zod, enumerable: !1 }),
+			Object.defineProperty(t, "issues", { value: r, enumerable: !1 }),
+			Object.defineProperty(t, "message", {
+				get() {
+					return JSON.stringify(r, gn, 2)
+				},
+				enumerable: !0,
+			}),
+			Object.defineProperty(t, "toString", { value: () => t.message, enumerable: !1 })
+	},
+	ot = u("$ZodError", ws),
+	Ze = u("$ZodError", ws, { Parent: Error })
+function it(t, r = (n) => n.message) {
+	const n = {},
+		i = []
+	for (const e of t.issues)
+		e.path.length > 0 ? ((n[e.path[0]] = n[e.path[0]] || []), n[e.path[0]].push(r(e))) : i.push(r(e))
+	return { formErrors: i, fieldErrors: n }
+}
+function at(t, r) {
+	const n = r || ((o) => o.message),
+		i = { _errors: [] },
+		e = (o) => {
+			for (const a of o.issues)
+				if (a.code === "invalid_union" && a.errors.length) a.errors.map((c) => e({ issues: c }))
+				else if (a.code === "invalid_key") e({ issues: a.issues })
+				else if (a.code === "invalid_element") e({ issues: a.issues })
+				else if (a.path.length === 0) i._errors.push(n(a))
+				else {
+					let c = i,
+						p = 0
+					while (p < a.path.length) {
+						const h = a.path[p]
+						p === a.path.length - 1
+							? ((c[h] = c[h] || { _errors: [] }), c[h]._errors.push(n(a)))
+							: (c[h] = c[h] || { _errors: [] }),
+							(c = c[h]),
+							p++
+					}
+				}
+		}
+	return e(t), i
+}
+function kn(t, r) {
+	const n = r || ((o) => o.message),
+		i = { errors: [] },
+		e = (o, a = []) => {
+			var c, p
+			for (const h of o.issues)
+				if (h.code === "invalid_union" && h.errors.length) h.errors.map((g) => e({ issues: g }, h.path))
+				else if (h.code === "invalid_key") e({ issues: h.issues }, h.path)
+				else if (h.code === "invalid_element") e({ issues: h.issues }, h.path)
+				else {
+					const g = [...a, ...h.path]
+					if (g.length === 0) {
+						i.errors.push(n(h))
+						continue
+					}
+					let m = i,
+						$ = 0
+					while ($ < g.length) {
+						const b = g[$],
+							d = $ === g.length - 1
+						typeof b == "string"
+							? (m.properties ?? (m.properties = {}),
+								(c = m.properties)[b] ?? (c[b] = { errors: [] }),
+								(m = m.properties[b]))
+							: (m.items ?? (m.items = []), (p = m.items)[b] ?? (p[b] = { errors: [] }), (m = m.items[b])),
+							d && m.errors.push(n(h)),
+							$++
+					}
+				}
+		}
+	return e(t), i
+}
+function Is(t) {
+	const r = []
+	for (const n of t)
+		typeof n == "number"
+			? r.push(`[${n}]`)
+			: typeof n == "symbol"
+				? r.push(`[${JSON.stringify(String(n))}]`)
+				: /[^\w$]/.test(n)
+					? r.push(`[${JSON.stringify(n)}]`)
+					: (r.length && r.push("."), r.push(n))
+	return r.join("")
+}
+function Sn(t) {
+	const r = [],
+		n = [...t.issues].sort((i, e) => i.path.length - e.path.length)
+	for (const i of n) r.push(`\u2716 ${i.message}`), i.path?.length && r.push(`  \u2192 at ${Is(i.path)}`)
+	return r.join(`
+`)
+}
+var Xt = (t) => (r, n, i, e) => {
+		const o = i ? Object.assign(i, { async: !1 }) : { async: !1 },
+			a = r._zod.run({ value: n, issues: [] }, o)
+		if (a instanceof Promise) throw new se()
+		if (a.issues.length) {
+			const c = new (e?.Err ?? t)(a.issues.map((p) => re(p, o, F())))
+			throw (Qt(c, e?.callee), c)
+		}
+		return a.value
+	},
+	st = Xt(Ze),
+	Yt = (t) => async (r, n, i, e) => {
+		let o = i ? Object.assign(i, { async: !0 }) : { async: !0 },
+			a = r._zod.run({ value: n, issues: [] }, o)
+		if ((a instanceof Promise && (a = await a), a.issues.length)) {
+			const c = new (e?.Err ?? t)(a.issues.map((p) => re(p, o, F())))
+			throw (Qt(c, e?.callee), c)
+		}
+		return a.value
+	},
+	ct = Yt(Ze),
+	er = (t) => (r, n, i) => {
+		const e = i ? { ...i, async: !1 } : { async: !1 },
+			o = r._zod.run({ value: n, issues: [] }, e)
+		if (o instanceof Promise) throw new se()
+		return o.issues.length
+			? { success: !1, error: new (t ?? ot)(o.issues.map((a) => re(a, e, F()))) }
+			: { success: !0, data: o.value }
+	},
+	De = er(Ze),
+	tr = (t) => async (r, n, i) => {
+		let e = i ? Object.assign(i, { async: !0 }) : { async: !0 },
+			o = r._zod.run({ value: n, issues: [] }, e)
+		return (
+			o instanceof Promise && (o = await o),
+			o.issues.length
+				? { success: !1, error: new t(o.issues.map((a) => re(a, e, F()))) }
+				: { success: !0, data: o.value }
+		)
+	},
+	ut = tr(Ze)
+var Se = {}
+$e(Se, {
+	_emoji: () => js,
+	base64: () => Ln,
+	base64url: () => rr,
+	bigint: () => Bn,
+	boolean: () => Kn,
+	browserEmail: () => fl,
+	cidrv4: () => An,
+	cidrv6: () => Cn,
+	cuid: () => wn,
+	cuid2: () => In,
+	date: () => Vn,
+	datetime: () => Hn,
+	domain: () => gl,
+	duration: () => Nn,
+	e164: () => qn,
+	email: () => Zn,
+	emoji: () => Dn,
+	extendedDuration: () => sl,
+	guid: () => Un,
+	hostname: () => Mn,
+	html5Email: () => ml,
+	integer: () => Wn,
+	ipv4: () => Rn,
+	ipv6: () => En,
+	ksuid: () => Tn,
+	lowercase: () => Yn,
+	nanoid: () => On,
+	null: () => Qn,
+	number: () => Gn,
+	rfc5322Email: () => pl,
+	string: () => Jn,
+	time: () => Fn,
+	ulid: () => jn,
+	undefined: () => Xn,
+	unicodeEmail: () => dl,
+	uppercase: () => eo,
+	uuid: () => ke,
+	uuid4: () => cl,
+	uuid6: () => ul,
+	uuid7: () => ll,
+	xid: () => Pn,
+})
+var wn = /^[cC][^\s-]{8,}$/,
+	In = /^[0-9a-z]+$/,
+	jn = /^[0-9A-HJKMNP-TV-Za-hjkmnp-tv-z]{26}$/,
+	Pn = /^[0-9a-vA-V]{20}$/,
+	Tn = /^[A-Za-z0-9]{27}$/,
+	On = /^[a-zA-Z0-9_-]{21}$/,
+	Nn = /^P(?:(\d+W)|(?!.*W)(?=\d|T\d)(\d+Y)?(\d+M)?(\d+D)?(T(?=\d)(\d+H)?(\d+M)?(\d+([.,]\d+)?S)?)?)$/,
+	sl =
+		/^[-+]?P(?!$)(?:(?:[-+]?\d+Y)|(?:[-+]?\d+[.,]\d+Y$))?(?:(?:[-+]?\d+M)|(?:[-+]?\d+[.,]\d+M$))?(?:(?:[-+]?\d+W)|(?:[-+]?\d+[.,]\d+W$))?(?:(?:[-+]?\d+D)|(?:[-+]?\d+[.,]\d+D$))?(?:T(?=[\d+-])(?:(?:[-+]?\d+H)|(?:[-+]?\d+[.,]\d+H$))?(?:(?:[-+]?\d+M)|(?:[-+]?\d+[.,]\d+M$))?(?:[-+]?\d+(?:[.,]\d+)?S)?)??$/,
+	Un = /^([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12})$/,
+	ke = (t) =>
+		t
+			? new RegExp(`^([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-${t}[0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12})$`)
+			: /^([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-8][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}|00000000-0000-0000-0000-000000000000)$/,
+	cl = ke(4),
+	ul = ke(6),
+	ll = ke(7),
+	Zn = /^(?!\.)(?!.*\.\.)([A-Za-z0-9_'+\-\.]*)[A-Za-z0-9_+-]@([A-Za-z0-9][A-Za-z0-9\-]*\.)+[A-Za-z]{2,}$/,
+	ml =
+		/^[a-zA-Z0-9.!#$%&'*+/=?^_`{|}~-]+@[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?(?:\.[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?)*$/,
+	pl =
+		/^(([^<>()\[\]\\.,;:\s@"]+(\.[^<>()\[\]\\.,;:\s@"]+)*)|(".+"))@((\[[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}])|(([a-zA-Z\-0-9]+\.)+[a-zA-Z]{2,}))$/,
+	dl = /^[^\s@"]{1,64}@[^\s@]{1,255}$/u,
+	fl =
+		/^[a-zA-Z0-9.!#$%&'*+/=?^_`{|}~-]+@[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?(?:\.[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?)*$/,
+	js = "^(\\p{Extended_Pictographic}|\\p{Emoji_Component})+$"
+function Dn() {
+	return new RegExp(js, "u")
+}
+var Rn =
+		/^(?:(?:25[0-5]|2[0-4][0-9]|1[0-9][0-9]|[1-9][0-9]|[0-9])\.){3}(?:25[0-5]|2[0-4][0-9]|1[0-9][0-9]|[1-9][0-9]|[0-9])$/,
+	En = /^(([0-9a-fA-F]{1,4}:){7}[0-9a-fA-F]{1,4}|::|([0-9a-fA-F]{1,4})?::([0-9a-fA-F]{1,4}:?){0,6})$/,
+	An =
+		/^((25[0-5]|2[0-4][0-9]|1[0-9][0-9]|[1-9][0-9]|[0-9])\.){3}(25[0-5]|2[0-4][0-9]|1[0-9][0-9]|[1-9][0-9]|[0-9])\/([0-9]|[1-2][0-9]|3[0-2])$/,
+	Cn =
+		/^(([0-9a-fA-F]{1,4}:){7}[0-9a-fA-F]{1,4}|::|([0-9a-fA-F]{1,4})?::([0-9a-fA-F]{1,4}:?){0,6})\/(12[0-8]|1[01][0-9]|[1-9]?[0-9])$/,
+	Ln = /^$|^(?:[0-9a-zA-Z+/]{4})*(?:(?:[0-9a-zA-Z+/]{2}==)|(?:[0-9a-zA-Z+/]{3}=))?$/,
+	rr = /^[A-Za-z0-9_-]*$/,
+	Mn = /^([a-zA-Z0-9-]+\.)*[a-zA-Z0-9-]+$/,
+	gl = /^([a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?\.)+[a-zA-Z]{2,}$/,
+	qn = /^\+(?:[0-9]){6,14}[0-9]$/,
+	Ps =
+		"(?:(?:\\d\\d[2468][048]|\\d\\d[13579][26]|\\d\\d0[48]|[02468][048]00|[13579][26]00)-02-29|\\d{4}-(?:(?:0[13578]|1[02])-(?:0[1-9]|[12]\\d|3[01])|(?:0[469]|11)-(?:0[1-9]|[12]\\d|30)|(?:02)-(?:0[1-9]|1\\d|2[0-8])))",
+	Vn = new RegExp(`^${Ps}$`)
+function Ts(t) {
+	const r = "(?:[01]\\d|2[0-3]):[0-5]\\d"
+	return typeof t.precision == "number"
+		? t.precision === -1
+			? `${r}`
+			: t.precision === 0
+				? `${r}:[0-5]\\d`
+				: `${r}:[0-5]\\d\\.\\d{${t.precision}}`
+		: `${r}(?::[0-5]\\d(?:\\.\\d+)?)?`
+}
+function Fn(t) {
+	return new RegExp(`^${Ts(t)}$`)
+}
+function Hn(t) {
+	const r = Ts({ precision: t.precision }),
+		n = ["Z"]
+	t.local && n.push(""), t.offset && n.push("([+-]\\d{2}:\\d{2})")
+	const i = `${r}(?:${n.join("|")})`
+	return new RegExp(`^${Ps}T(?:${i})$`)
+}
+var Jn = (t) => {
+		const r = t ? `[\\s\\S]{${t?.minimum ?? 0},${t?.maximum ?? ""}}` : "[\\s\\S]*"
+		return new RegExp(`^${r}$`)
+	},
+	Bn = /^\d+n?$/,
+	Wn = /^\d+$/,
+	Gn = /^-?\d+(?:\.\d+)?/i,
+	Kn = /true|false/i,
+	Qn = /null/i
+var Xn = /undefined/i
+var Yn = /^[^A-Z]*$/,
+	eo = /^[^a-z]*$/
+var V = u("$ZodCheck", (t, r) => {
+		var n
+		t._zod ?? (t._zod = {}), (t._zod.def = r), (n = t._zod).onattach ?? (n.onattach = [])
+	}),
+	Ns = { number: "number", bigint: "bigint", object: "date" },
+	nr = u("$ZodCheckLessThan", (t, r) => {
+		V.init(t, r)
+		const n = Ns[typeof r.value]
+		t._zod.onattach.push((i) => {
+			const e = i._zod.bag,
+				o = (r.inclusive ? e.maximum : e.exclusiveMaximum) ?? Number.POSITIVE_INFINITY
+			r.value < o && (r.inclusive ? (e.maximum = r.value) : (e.exclusiveMaximum = r.value))
+		}),
+			(t._zod.check = (i) => {
+				;(r.inclusive ? i.value <= r.value : i.value < r.value) ||
+					i.issues.push({
+						origin: n,
+						code: "too_big",
+						maximum: r.value,
+						input: i.value,
+						inclusive: r.inclusive,
+						inst: t,
+						continue: !r.abort,
+					})
+			})
+	}),
+	or = u("$ZodCheckGreaterThan", (t, r) => {
+		V.init(t, r)
+		const n = Ns[typeof r.value]
+		t._zod.onattach.push((i) => {
+			const e = i._zod.bag,
+				o = (r.inclusive ? e.minimum : e.exclusiveMinimum) ?? Number.NEGATIVE_INFINITY
+			r.value > o && (r.inclusive ? (e.minimum = r.value) : (e.exclusiveMinimum = r.value))
+		}),
+			(t._zod.check = (i) => {
+				;(r.inclusive ? i.value >= r.value : i.value > r.value) ||
+					i.issues.push({
+						origin: n,
+						code: "too_small",
+						minimum: r.value,
+						input: i.value,
+						inclusive: r.inclusive,
+						inst: t,
+						continue: !r.abort,
+					})
+			})
+	}),
+	to = u("$ZodCheckMultipleOf", (t, r) => {
+		V.init(t, r),
+			t._zod.onattach.push((n) => {
+				var i
+				;(i = n._zod.bag).multipleOf ?? (i.multipleOf = r.value)
+			}),
+			(t._zod.check = (n) => {
+				if (typeof n.value != typeof r.value) throw new Error("Cannot mix number and bigint in multiple_of check.")
+				;(typeof n.value == "bigint" ? n.value % r.value === BigInt(0) : hn(n.value, r.value) === 0) ||
+					n.issues.push({
+						origin: typeof n.value,
+						code: "not_multiple_of",
+						divisor: r.value,
+						input: n.value,
+						inst: t,
+						continue: !r.abort,
+					})
+			})
+	}),
+	ro = u("$ZodCheckNumberFormat", (t, r) => {
+		V.init(t, r), (r.format = r.format || "float64")
+		const n = r.format?.includes("int"),
+			i = n ? "int" : "number",
+			[e, o] = $n[r.format]
+		t._zod.onattach.push((a) => {
+			const c = a._zod.bag
+			;(c.format = r.format), (c.minimum = e), (c.maximum = o), n && (c.pattern = Wn)
+		}),
+			(t._zod.check = (a) => {
+				const c = a.value
+				if (n) {
+					if (!Number.isInteger(c)) {
+						a.issues.push({ expected: i, format: r.format, code: "invalid_type", input: c, inst: t })
+						return
+					}
+					if (!Number.isSafeInteger(c)) {
+						c > 0
+							? a.issues.push({
+									input: c,
+									code: "too_big",
+									maximum: Number.MAX_SAFE_INTEGER,
+									note: "Integers must be within the safe integer range.",
+									inst: t,
+									origin: i,
+									continue: !r.abort,
+								})
+							: a.issues.push({
+									input: c,
+									code: "too_small",
+									minimum: Number.MIN_SAFE_INTEGER,
+									note: "Integers must be within the safe integer range.",
+									inst: t,
+									origin: i,
+									continue: !r.abort,
+								})
+						return
+					}
+				}
+				c < e &&
+					a.issues.push({
+						origin: "number",
+						input: c,
+						code: "too_small",
+						minimum: e,
+						inclusive: !0,
+						inst: t,
+						continue: !r.abort,
+					}),
+					c > o && a.issues.push({ origin: "number", input: c, code: "too_big", maximum: o, inst: t })
+			})
+	}),
+	no = u("$ZodCheckBigIntFormat", (t, r) => {
+		V.init(t, r)
+		const [n, i] = xn[r.format]
+		t._zod.onattach.push((e) => {
+			const o = e._zod.bag
+			;(o.format = r.format), (o.minimum = n), (o.maximum = i)
+		}),
+			(t._zod.check = (e) => {
+				const o = e.value
+				o < n &&
+					e.issues.push({
+						origin: "bigint",
+						input: o,
+						code: "too_small",
+						minimum: n,
+						inclusive: !0,
+						inst: t,
+						continue: !r.abort,
+					}),
+					o > i && e.issues.push({ origin: "bigint", input: o, code: "too_big", maximum: i, inst: t })
+			})
+	}),
+	oo = u("$ZodCheckMaxSize", (t, r) => {
+		var n
+		V.init(t, r),
+			(n = t._zod.def).when ??
+				(n.when = (i) => {
+					const e = i.value
+					return !he(e) && e.size !== void 0
+				}),
+			t._zod.onattach.push((i) => {
+				const e = i._zod.bag.maximum ?? Number.POSITIVE_INFINITY
+				r.maximum < e && (i._zod.bag.maximum = r.maximum)
+			}),
+			(t._zod.check = (i) => {
+				const e = i.value
+				e.size <= r.maximum ||
+					i.issues.push({ origin: rt(e), code: "too_big", maximum: r.maximum, input: e, inst: t, continue: !r.abort })
+			})
+	}),
+	io = u("$ZodCheckMinSize", (t, r) => {
+		var n
+		V.init(t, r),
+			(n = t._zod.def).when ??
+				(n.when = (i) => {
+					const e = i.value
+					return !he(e) && e.size !== void 0
+				}),
+			t._zod.onattach.push((i) => {
+				const e = i._zod.bag.minimum ?? Number.NEGATIVE_INFINITY
+				r.minimum > e && (i._zod.bag.minimum = r.minimum)
+			}),
+			(t._zod.check = (i) => {
+				const e = i.value
+				e.size >= r.minimum ||
+					i.issues.push({ origin: rt(e), code: "too_small", minimum: r.minimum, input: e, inst: t, continue: !r.abort })
+			})
+	}),
+	ao = u("$ZodCheckSizeEquals", (t, r) => {
+		var n
+		V.init(t, r),
+			(n = t._zod.def).when ??
+				(n.when = (i) => {
+					const e = i.value
+					return !he(e) && e.size !== void 0
+				}),
+			t._zod.onattach.push((i) => {
+				const e = i._zod.bag
+				;(e.minimum = r.size), (e.maximum = r.size), (e.size = r.size)
+			}),
+			(t._zod.check = (i) => {
+				const e = i.value,
+					o = e.size
+				if (o === r.size) return
+				const a = o > r.size
+				i.issues.push({
+					origin: rt(e),
+					...(a ? { code: "too_big", maximum: r.size } : { code: "too_small", minimum: r.size }),
+					inclusive: !0,
+					exact: !0,
+					input: i.value,
+					inst: t,
+					continue: !r.abort,
+				})
+			})
+	}),
+	so = u("$ZodCheckMaxLength", (t, r) => {
+		var n
+		V.init(t, r),
+			(n = t._zod.def).when ??
+				(n.when = (i) => {
+					const e = i.value
+					return !he(e) && e.length !== void 0
+				}),
+			t._zod.onattach.push((i) => {
+				const e = i._zod.bag.maximum ?? Number.POSITIVE_INFINITY
+				r.maximum < e && (i._zod.bag.maximum = r.maximum)
+			}),
+			(t._zod.check = (i) => {
+				const e = i.value
+				if (e.length <= r.maximum) return
+				const a = nt(e)
+				i.issues.push({
+					origin: a,
+					code: "too_big",
+					maximum: r.maximum,
+					inclusive: !0,
+					input: e,
+					inst: t,
+					continue: !r.abort,
+				})
+			})
+	}),
+	co = u("$ZodCheckMinLength", (t, r) => {
+		var n
+		V.init(t, r),
+			(n = t._zod.def).when ??
+				(n.when = (i) => {
+					const e = i.value
+					return !he(e) && e.length !== void 0
+				}),
+			t._zod.onattach.push((i) => {
+				const e = i._zod.bag.minimum ?? Number.NEGATIVE_INFINITY
+				r.minimum > e && (i._zod.bag.minimum = r.minimum)
+			}),
+			(t._zod.check = (i) => {
+				const e = i.value
+				if (e.length >= r.minimum) return
+				const a = nt(e)
+				i.issues.push({
+					origin: a,
+					code: "too_small",
+					minimum: r.minimum,
+					inclusive: !0,
+					input: e,
+					inst: t,
+					continue: !r.abort,
+				})
+			})
+	}),
+	uo = u("$ZodCheckLengthEquals", (t, r) => {
+		var n
+		V.init(t, r),
+			(n = t._zod.def).when ??
+				(n.when = (i) => {
+					const e = i.value
+					return !he(e) && e.length !== void 0
+				}),
+			t._zod.onattach.push((i) => {
+				const e = i._zod.bag
+				;(e.minimum = r.length), (e.maximum = r.length), (e.length = r.length)
+			}),
+			(t._zod.check = (i) => {
+				const e = i.value,
+					o = e.length
+				if (o === r.length) return
+				const a = nt(e),
+					c = o > r.length
+				i.issues.push({
+					origin: a,
+					...(c ? { code: "too_big", maximum: r.length } : { code: "too_small", minimum: r.length }),
+					inclusive: !0,
+					exact: !0,
+					input: i.value,
+					inst: t,
+					continue: !r.abort,
+				})
+			})
+	}),
+	Re = u("$ZodCheckStringFormat", (t, r) => {
+		var n, i
+		V.init(t, r),
+			t._zod.onattach.push((e) => {
+				const o = e._zod.bag
+				;(o.format = r.format), r.pattern && (o.patterns ?? (o.patterns = new Set()), o.patterns.add(r.pattern))
+			}),
+			r.pattern
+				? ((n = t._zod).check ??
+					(n.check = (e) => {
+						;(r.pattern.lastIndex = 0),
+							!r.pattern.test(e.value) &&
+								e.issues.push({
+									origin: "string",
+									code: "invalid_format",
+									format: r.format,
+									input: e.value,
+									...(r.pattern ? { pattern: r.pattern.toString() } : {}),
+									inst: t,
+									continue: !r.abort,
+								})
+					}))
+				: ((i = t._zod).check ?? (i.check = () => {}))
+	}),
+	lo = u("$ZodCheckRegex", (t, r) => {
+		Re.init(t, r),
+			(t._zod.check = (n) => {
+				;(r.pattern.lastIndex = 0),
+					!r.pattern.test(n.value) &&
+						n.issues.push({
+							origin: "string",
+							code: "invalid_format",
+							format: "regex",
+							input: n.value,
+							pattern: r.pattern.toString(),
+							inst: t,
+							continue: !r.abort,
+						})
+			})
+	}),
+	mo = u("$ZodCheckLowerCase", (t, r) => {
+		r.pattern ?? (r.pattern = Yn), Re.init(t, r)
+	}),
+	po = u("$ZodCheckUpperCase", (t, r) => {
+		r.pattern ?? (r.pattern = eo), Re.init(t, r)
+	}),
+	fo = u("$ZodCheckIncludes", (t, r) => {
+		V.init(t, r)
+		const n = ue(r.includes),
+			i = new RegExp(typeof r.position == "number" ? `^.{${r.position}}${n}` : n)
+		;(r.pattern = i),
+			t._zod.onattach.push((e) => {
+				const o = e._zod.bag
+				o.patterns ?? (o.patterns = new Set()), o.patterns.add(i)
+			}),
+			(t._zod.check = (e) => {
+				e.value.includes(r.includes, r.position) ||
+					e.issues.push({
+						origin: "string",
+						code: "invalid_format",
+						format: "includes",
+						includes: r.includes,
+						input: e.value,
+						inst: t,
+						continue: !r.abort,
+					})
+			})
+	}),
+	go = u("$ZodCheckStartsWith", (t, r) => {
+		V.init(t, r)
+		const n = new RegExp(`^${ue(r.prefix)}.*`)
+		r.pattern ?? (r.pattern = n),
+			t._zod.onattach.push((i) => {
+				const e = i._zod.bag
+				e.patterns ?? (e.patterns = new Set()), e.patterns.add(n)
+			}),
+			(t._zod.check = (i) => {
+				i.value.startsWith(r.prefix) ||
+					i.issues.push({
+						origin: "string",
+						code: "invalid_format",
+						format: "starts_with",
+						prefix: r.prefix,
+						input: i.value,
+						inst: t,
+						continue: !r.abort,
+					})
+			})
+	}),
+	ho = u("$ZodCheckEndsWith", (t, r) => {
+		V.init(t, r)
+		const n = new RegExp(`.*${ue(r.suffix)}$`)
+		r.pattern ?? (r.pattern = n),
+			t._zod.onattach.push((i) => {
+				const e = i._zod.bag
+				e.patterns ?? (e.patterns = new Set()), e.patterns.add(n)
+			}),
+			(t._zod.check = (i) => {
+				i.value.endsWith(r.suffix) ||
+					i.issues.push({
+						origin: "string",
+						code: "invalid_format",
+						format: "ends_with",
+						suffix: r.suffix,
+						input: i.value,
+						inst: t,
+						continue: !r.abort,
+					})
+			})
+	})
+function Os(t, r, n) {
+	t.issues.length && r.issues.push(...Y(n, t.issues))
+}
+var vo = u("$ZodCheckProperty", (t, r) => {
+		V.init(t, r),
+			(t._zod.check = (n) => {
+				const i = r.schema._zod.run({ value: n.value[r.property], issues: [] }, {})
+				if (i instanceof Promise) return i.then((e) => Os(e, n, r.property))
+				Os(i, n, r.property)
+			})
+	}),
+	bo = u("$ZodCheckMimeType", (t, r) => {
+		V.init(t, r)
+		const n = new Set(r.mime)
+		t._zod.onattach.push((i) => {
+			i._zod.bag.mime = r.mime
+		}),
+			(t._zod.check = (i) => {
+				n.has(i.value.type) || i.issues.push({ code: "invalid_value", values: r.mime, input: i.value.type, inst: t })
+			})
+	}),
+	_o = u("$ZodCheckOverwrite", (t, r) => {
+		V.init(t, r),
+			(t._zod.check = (n) => {
+				n.value = r.tx(n.value)
+			})
+	})
+var lt = class {
+	constructor(r = []) {
+		;(this.content = []), (this.indent = 0), this && (this.args = r)
+	}
+	indented(r) {
+		;(this.indent += 1), r(this), (this.indent -= 1)
+	}
+	write(r) {
+		if (typeof r == "function") {
+			r(this, { execution: "sync" }), r(this, { execution: "async" })
+			return
+		}
+		const i = r
+				.split(`
+`)
+				.filter((a) => a),
+			e = Math.min(...i.map((a) => a.length - a.trimStart().length)),
+			o = i.map((a) => a.slice(e)).map((a) => " ".repeat(this.indent * 2) + a)
+		for (const a of o) this.content.push(a)
+	}
+	compile() {
+		const r = Function,
+			n = this?.args,
+			e = [...(this?.content ?? [""]).map((o) => `  ${o}`)]
+		return new r(
+			...n,
+			e.join(`
+`),
+		)
+	}
+}
+var yo = { major: 4, minor: 0, patch: 0 }
+var j = u("$ZodType", (t, r) => {
+		var n
+		t ?? (t = {}), (t._zod.def = r), (t._zod.bag = t._zod.bag || {}), (t._zod.version = yo)
+		const i = [...(t._zod.def.checks ?? [])]
+		t._zod.traits.has("$ZodCheck") && i.unshift(t)
+		for (const e of i) for (const o of e._zod.onattach) o(t)
+		if (i.length === 0)
+			(n = t._zod).deferred ?? (n.deferred = []),
+				t._zod.deferred?.push(() => {
+					t._zod.run = t._zod.parse
+				})
+		else {
+			const e = (o, a, c) => {
+				let p = ze(o),
+					h
+				for (const g of a) {
+					if (g._zod.def.when) {
+						if (!g._zod.def.when(o)) continue
+					} else if (p) continue
+					const m = o.issues.length,
+						$ = g._zod.check(o)
+					if ($ instanceof Promise && c?.async === !1) throw new se()
+					if (h || $ instanceof Promise)
+						h = (h ?? Promise.resolve()).then(async () => {
+							await $, o.issues.length !== m && (p || (p = ze(o, m)))
+						})
+					else {
+						if (o.issues.length === m) continue
+						p || (p = ze(o, m))
+					}
+				}
+				return h ? h.then(() => o) : o
+			}
+			t._zod.run = (o, a) => {
+				const c = t._zod.parse(o, a)
+				if (c instanceof Promise) {
+					if (a.async === !1) throw new se()
+					return c.then((p) => e(p, i, a))
+				}
+				return e(c, i, a)
+			}
+		}
+		t["~standard"] = {
+			validate: (e) => {
+				try {
+					const o = De(t, e)
+					return o.success ? { value: o.data } : { issues: o.error?.issues }
+				} catch {
+					return ut(t, e).then((a) => (a.success ? { value: a.data } : { issues: a.error?.issues }))
+				}
+			},
+			vendor: "zod",
+			version: 1,
+		}
+	}),
+	we = u("$ZodString", (t, r) => {
+		j.init(t, r),
+			(t._zod.pattern = [...(t?._zod.bag?.patterns ?? [])].pop() ?? Jn(t._zod.bag)),
+			(t._zod.parse = (n, i) => {
+				if (r.coerce)
+					try {
+						n.value = String(n.value)
+					} catch {}
+				return (
+					typeof n.value == "string" ||
+						n.issues.push({ expected: "string", code: "invalid_type", input: n.value, inst: t }),
+					n
+				)
+			})
+	}),
+	A = u("$ZodStringFormat", (t, r) => {
+		Re.init(t, r), we.init(t, r)
+	}),
+	xo = u("$ZodGUID", (t, r) => {
+		r.pattern ?? (r.pattern = Un), A.init(t, r)
+	}),
+	zo = u("$ZodUUID", (t, r) => {
+		if (r.version) {
+			const i = { v1: 1, v2: 2, v3: 3, v4: 4, v5: 5, v6: 6, v7: 7, v8: 8 }[r.version]
+			if (i === void 0) throw new Error(`Invalid UUID version: "${r.version}"`)
+			r.pattern ?? (r.pattern = ke(i))
+		} else r.pattern ?? (r.pattern = ke())
+		A.init(t, r)
+	}),
+	ko = u("$ZodEmail", (t, r) => {
+		r.pattern ?? (r.pattern = Zn), A.init(t, r)
+	}),
+	So = u("$ZodURL", (t, r) => {
+		A.init(t, r),
+			(t._zod.check = (n) => {
+				try {
+					const i = n.value,
+						e = new URL(i),
+						o = e.href
+					r.hostname &&
+						((r.hostname.lastIndex = 0),
+						r.hostname.test(e.hostname) ||
+							n.issues.push({
+								code: "invalid_format",
+								format: "url",
+								note: "Invalid hostname",
+								pattern: Mn.source,
+								input: n.value,
+								inst: t,
+								continue: !r.abort,
+							})),
+						r.protocol &&
+							((r.protocol.lastIndex = 0),
+							r.protocol.test(e.protocol.endsWith(":") ? e.protocol.slice(0, -1) : e.protocol) ||
+								n.issues.push({
+									code: "invalid_format",
+									format: "url",
+									note: "Invalid protocol",
+									pattern: r.protocol.source,
+									input: n.value,
+									inst: t,
+									continue: !r.abort,
+								})),
+						!i.endsWith("/") && o.endsWith("/") ? (n.value = o.slice(0, -1)) : (n.value = o)
+					return
+				} catch {
+					n.issues.push({ code: "invalid_format", format: "url", input: n.value, inst: t, continue: !r.abort })
+				}
+			})
+	}),
+	wo = u("$ZodEmoji", (t, r) => {
+		r.pattern ?? (r.pattern = Dn()), A.init(t, r)
+	}),
+	Io = u("$ZodNanoID", (t, r) => {
+		r.pattern ?? (r.pattern = On), A.init(t, r)
+	}),
+	jo = u("$ZodCUID", (t, r) => {
+		r.pattern ?? (r.pattern = wn), A.init(t, r)
+	}),
+	Po = u("$ZodCUID2", (t, r) => {
+		r.pattern ?? (r.pattern = In), A.init(t, r)
+	}),
+	To = u("$ZodULID", (t, r) => {
+		r.pattern ?? (r.pattern = jn), A.init(t, r)
+	}),
+	Oo = u("$ZodXID", (t, r) => {
+		r.pattern ?? (r.pattern = Pn), A.init(t, r)
+	}),
+	No = u("$ZodKSUID", (t, r) => {
+		r.pattern ?? (r.pattern = Tn), A.init(t, r)
+	}),
+	Uo = u("$ZodISODateTime", (t, r) => {
+		r.pattern ?? (r.pattern = Hn(r)), A.init(t, r)
+	}),
+	Zo = u("$ZodISODate", (t, r) => {
+		r.pattern ?? (r.pattern = Vn), A.init(t, r)
+	}),
+	Do = u("$ZodISOTime", (t, r) => {
+		r.pattern ?? (r.pattern = Fn(r)), A.init(t, r)
+	}),
+	Ro = u("$ZodISODuration", (t, r) => {
+		r.pattern ?? (r.pattern = Nn), A.init(t, r)
+	}),
+	Eo = u("$ZodIPv4", (t, r) => {
+		r.pattern ?? (r.pattern = Rn),
+			A.init(t, r),
+			t._zod.onattach.push((n) => {
+				const i = n._zod.bag
+				i.format = "ipv4"
+			})
+	}),
+	Ao = u("$ZodIPv6", (t, r) => {
+		r.pattern ?? (r.pattern = En),
+			A.init(t, r),
+			t._zod.onattach.push((n) => {
+				const i = n._zod.bag
+				i.format = "ipv6"
+			}),
+			(t._zod.check = (n) => {
+				try {
+					new URL(`http://[${n.value}]`)
+				} catch {
+					n.issues.push({ code: "invalid_format", format: "ipv6", input: n.value, inst: t, continue: !r.abort })
+				}
+			})
+	}),
+	Co = u("$ZodCIDRv4", (t, r) => {
+		r.pattern ?? (r.pattern = An), A.init(t, r)
+	}),
+	Lo = u("$ZodCIDRv6", (t, r) => {
+		r.pattern ?? (r.pattern = Cn),
+			A.init(t, r),
+			(t._zod.check = (n) => {
+				const [i, e] = n.value.split("/")
+				try {
+					if (!e) throw new Error()
+					const o = Number(e)
+					if (`${o}` !== e) throw new Error()
+					if (o < 0 || o > 128) throw new Error()
+					new URL(`http://[${i}]`)
+				} catch {
+					n.issues.push({ code: "invalid_format", format: "cidrv6", input: n.value, inst: t, continue: !r.abort })
+				}
+			})
+	})
+function Mo(t) {
+	if (t === "") return !0
+	if (t.length % 4 !== 0) return !1
+	try {
+		return atob(t), !0
+	} catch {
+		return !1
+	}
+}
+var qo = u("$ZodBase64", (t, r) => {
+	r.pattern ?? (r.pattern = Ln),
+		A.init(t, r),
+		t._zod.onattach.push((n) => {
+			n._zod.bag.contentEncoding = "base64"
+		}),
+		(t._zod.check = (n) => {
+			Mo(n.value) ||
+				n.issues.push({ code: "invalid_format", format: "base64", input: n.value, inst: t, continue: !r.abort })
+		})
+})
+function Hs(t) {
+	if (!rr.test(t)) return !1
+	const r = t.replace(/[-_]/g, (i) => (i === "-" ? "+" : "/")),
+		n = r.padEnd(Math.ceil(r.length / 4) * 4, "=")
+	return Mo(n)
+}
+var Vo = u("$ZodBase64URL", (t, r) => {
+		r.pattern ?? (r.pattern = rr),
+			A.init(t, r),
+			t._zod.onattach.push((n) => {
+				n._zod.bag.contentEncoding = "base64url"
+			}),
+			(t._zod.check = (n) => {
+				Hs(n.value) ||
+					n.issues.push({ code: "invalid_format", format: "base64url", input: n.value, inst: t, continue: !r.abort })
+			})
+	}),
+	Fo = u("$ZodE164", (t, r) => {
+		r.pattern ?? (r.pattern = qn), A.init(t, r)
+	})
+function Js(t, r = null) {
+	try {
+		const n = t.split(".")
+		if (n.length !== 3) return !1
+		const [i] = n
+		if (!i) return !1
+		const e = JSON.parse(atob(i))
+		return !(("typ" in e && e?.typ !== "JWT") || !e.alg || (r && (!("alg" in e) || e.alg !== r)))
+	} catch {
+		return !1
+	}
+}
+var Ho = u("$ZodJWT", (t, r) => {
+		A.init(t, r),
+			(t._zod.check = (n) => {
+				Js(n.value, r.alg) ||
+					n.issues.push({ code: "invalid_format", format: "jwt", input: n.value, inst: t, continue: !r.abort })
+			})
+	}),
+	Jo = u("$ZodCustomStringFormat", (t, r) => {
+		A.init(t, r),
+			(t._zod.check = (n) => {
+				r.fn(n.value) ||
+					n.issues.push({ code: "invalid_format", format: r.format, input: n.value, inst: t, continue: !r.abort })
+			})
+	}),
+	sr = u("$ZodNumber", (t, r) => {
+		j.init(t, r),
+			(t._zod.pattern = t._zod.bag.pattern ?? Gn),
+			(t._zod.parse = (n, i) => {
+				if (r.coerce)
+					try {
+						n.value = Number(n.value)
+					} catch {}
+				const e = n.value
+				if (typeof e == "number" && !Number.isNaN(e) && Number.isFinite(e)) return n
+				const o = typeof e == "number" ? (Number.isNaN(e) ? "NaN" : Number.isFinite(e) ? void 0 : "Infinity") : void 0
+				return (
+					n.issues.push({ expected: "number", code: "invalid_type", input: e, inst: t, ...(o ? { received: o } : {}) }),
+					n
+				)
+			})
+	}),
+	Bo = u("$ZodNumber", (t, r) => {
+		ro.init(t, r), sr.init(t, r)
+	}),
+	mt = u("$ZodBoolean", (t, r) => {
+		j.init(t, r),
+			(t._zod.pattern = Kn),
+			(t._zod.parse = (n, i) => {
+				if (r.coerce)
+					try {
+						n.value = !!n.value
+					} catch {}
+				const e = n.value
+				return (
+					typeof e == "boolean" || n.issues.push({ expected: "boolean", code: "invalid_type", input: e, inst: t }), n
+				)
+			})
+	}),
+	cr = u("$ZodBigInt", (t, r) => {
+		j.init(t, r),
+			(t._zod.pattern = Bn),
+			(t._zod.parse = (n, i) => {
+				if (r.coerce)
+					try {
+						n.value = BigInt(n.value)
+					} catch {}
+				return (
+					typeof n.value == "bigint" ||
+						n.issues.push({ expected: "bigint", code: "invalid_type", input: n.value, inst: t }),
+					n
+				)
+			})
+	}),
+	Wo = u("$ZodBigInt", (t, r) => {
+		no.init(t, r), cr.init(t, r)
+	}),
+	Go = u("$ZodSymbol", (t, r) => {
+		j.init(t, r),
+			(t._zod.parse = (n, i) => {
+				const e = n.value
+				return typeof e == "symbol" || n.issues.push({ expected: "symbol", code: "invalid_type", input: e, inst: t }), n
+			})
+	}),
+	Ko = u("$ZodUndefined", (t, r) => {
+		j.init(t, r),
+			(t._zod.pattern = Xn),
+			(t._zod.values = new Set([void 0])),
+			(t._zod.optin = "optional"),
+			(t._zod.optout = "optional"),
+			(t._zod.parse = (n, i) => {
+				const e = n.value
+				return typeof e > "u" || n.issues.push({ expected: "undefined", code: "invalid_type", input: e, inst: t }), n
+			})
+	}),
+	Qo = u("$ZodNull", (t, r) => {
+		j.init(t, r),
+			(t._zod.pattern = Qn),
+			(t._zod.values = new Set([null])),
+			(t._zod.parse = (n, i) => {
+				const e = n.value
+				return e === null || n.issues.push({ expected: "null", code: "invalid_type", input: e, inst: t }), n
+			})
+	}),
+	Xo = u("$ZodAny", (t, r) => {
+		j.init(t, r), (t._zod.parse = (n) => n)
+	}),
+	Ee = u("$ZodUnknown", (t, r) => {
+		j.init(t, r), (t._zod.parse = (n) => n)
+	}),
+	Yo = u("$ZodNever", (t, r) => {
+		j.init(t, r),
+			(t._zod.parse = (n, i) => (
+				n.issues.push({ expected: "never", code: "invalid_type", input: n.value, inst: t }), n
+			))
+	}),
+	ei = u("$ZodVoid", (t, r) => {
+		j.init(t, r),
+			(t._zod.parse = (n, i) => {
+				const e = n.value
+				return typeof e > "u" || n.issues.push({ expected: "void", code: "invalid_type", input: e, inst: t }), n
+			})
+	}),
+	ti = u("$ZodDate", (t, r) => {
+		j.init(t, r),
+			(t._zod.parse = (n, i) => {
+				if (r.coerce)
+					try {
+						n.value = new Date(n.value)
+					} catch {}
+				const e = n.value,
+					o = e instanceof Date
+				return (
+					(o && !Number.isNaN(e.getTime())) ||
+						n.issues.push({
+							expected: "date",
+							code: "invalid_type",
+							input: e,
+							...(o ? { received: "Invalid Date" } : {}),
+							inst: t,
+						}),
+					n
+				)
+			})
+	})
+function Zs(t, r, n) {
+	t.issues.length && r.issues.push(...Y(n, t.issues)), (r.value[n] = t.value)
+}
+var pt = u("$ZodArray", (t, r) => {
+	j.init(t, r),
+		(t._zod.parse = (n, i) => {
+			const e = n.value
+			if (!Array.isArray(e)) return n.issues.push({ expected: "array", code: "invalid_type", input: e, inst: t }), n
+			n.value = Array(e.length)
+			const o = []
+			for (let a = 0; a < e.length; a++) {
+				const c = e[a],
+					p = r.element._zod.run({ value: c, issues: [] }, i)
+				p instanceof Promise ? o.push(p.then((h) => Zs(h, n, a))) : Zs(p, n, a)
+			}
+			return o.length ? Promise.all(o).then(() => n) : n
+		})
+})
+function ir(t, r, n) {
+	t.issues.length && r.issues.push(...Y(n, t.issues)), (r.value[n] = t.value)
+}
+function Ds(t, r, n, i) {
+	t.issues.length
+		? i[n] === void 0
+			? n in i
+				? (r.value[n] = void 0)
+				: (r.value[n] = t.value)
+			: r.issues.push(...Y(n, t.issues))
+		: t.value === void 0
+			? n in i && (r.value[n] = void 0)
+			: (r.value[n] = t.value)
+}
+var ri = u("$ZodObject", (t, r) => {
+	j.init(t, r)
+	const n = Ye(() => {
+		const m = Object.keys(r.shape)
+		for (const b of m)
+			if (!(r.shape[b] instanceof j)) throw new Error(`Invalid element at key "${b}": expected a Zod schema`)
+		const $ = yn(r.shape)
+		return { shape: r.shape, keys: m, keySet: new Set(m), numKeys: m.length, optionalKeys: new Set($) }
+	})
+	U(t._zod, "propValues", () => {
+		const m = r.shape,
+			$ = {}
+		for (const b in m) {
+			const d = m[b]._zod
+			if (d.values) {
+				$[b] ?? ($[b] = new Set())
+				for (const x of d.values) $[b].add(x)
+			}
+		}
+		return $
+	})
+	let i = (m) => {
+			const $ = new lt(["shape", "payload", "ctx"]),
+				b = n.value,
+				d = (S) => {
+					const I = xe(S)
+					return `shape[${I}]._zod.run({ value: input[${I}], issues: [] }, ctx)`
+				}
+			$.write("const input = payload.value;")
+			let x = Object.create(null),
+				k = 0
+			for (const S of b.keys) x[S] = `key_${k++}`
+			$.write("const newResult = {}")
+			for (const S of b.keys)
+				if (b.optionalKeys.has(S)) {
+					const I = x[S]
+					$.write(`const ${I} = ${d(S)};`)
+					const O = xe(S)
+					$.write(`
+        if (${I}.issues.length) {
+          if (input[${O}] === undefined) {
+            if (${O} in input) {
+              newResult[${O}] = undefined;
+            }
+          } else {
+            payload.issues = payload.issues.concat(
+              ${I}.issues.map((iss) => ({
+                ...iss,
+                path: iss.path ? [${O}, ...iss.path] : [${O}],
+              }))
+            );
+          }
+        } else if (${I}.value === undefined) {
+          if (${O} in input) newResult[${O}] = undefined;
+        } else {
+          newResult[${O}] = ${I}.value;
+        }
+        `)
+				} else {
+					const I = x[S]
+					$.write(`const ${I} = ${d(S)};`),
+						$.write(`
+          if (${I}.issues.length) payload.issues = payload.issues.concat(${I}.issues.map(iss => ({
+            ...iss,
+            path: iss.path ? [${xe(S)}, ...iss.path] : [${xe(S)}]
+          })));`),
+						$.write(`newResult[${xe(S)}] = ${I}.value`)
+				}
+			$.write("payload.value = newResult;"), $.write("return payload;")
+			const D = $.compile()
+			return (S, I) => D(m, S, I)
+		},
+		e,
+		o = Ne,
+		a = !Ke.jitless,
+		p = a && bn.value,
+		h = r.catchall,
+		g
+	t._zod.parse = (m, $) => {
+		g ?? (g = n.value)
+		const b = m.value
+		if (!o(b)) return m.issues.push({ expected: "object", code: "invalid_type", input: b, inst: t }), m
+		const d = []
+		if (a && p && $?.async === !1 && $.jitless !== !0) e || (e = i(r.shape)), (m = e(m, $))
+		else {
+			m.value = {}
+			const I = g.shape
+			for (const O of g.keys) {
+				const ye = I[O],
+					Kt = ye._zod.run({ value: b[O], issues: [] }, $),
+					ks = ye._zod.optin === "optional" && ye._zod.optout === "optional"
+				Kt instanceof Promise
+					? d.push(Kt.then((Ss) => (ks ? Ds(Ss, m, O, b) : ir(Ss, m, O))))
+					: ks
+						? Ds(Kt, m, O, b)
+						: ir(Kt, m, O)
+			}
+		}
+		if (!h) return d.length ? Promise.all(d).then(() => m) : m
+		const x = [],
+			k = g.keySet,
+			D = h._zod,
+			S = D.def.type
+		for (const I of Object.keys(b)) {
+			if (k.has(I)) continue
+			if (S === "never") {
+				x.push(I)
+				continue
+			}
+			const O = D.run({ value: b[I], issues: [] }, $)
+			O instanceof Promise ? d.push(O.then((ye) => ir(ye, m, I))) : ir(O, m, I)
+		}
+		return (
+			x.length && m.issues.push({ code: "unrecognized_keys", keys: x, input: b, inst: t }),
+			d.length ? Promise.all(d).then(() => m) : m
+		)
+	}
+})
+function Rs(t, r, n, i) {
+	for (const e of t) if (e.issues.length === 0) return (r.value = e.value), r
+	return (
+		r.issues.push({
+			code: "invalid_union",
+			input: r.value,
+			inst: n,
+			errors: t.map((e) => e.issues.map((o) => re(o, i, F()))),
+		}),
+		r
+	)
+}
+var ur = u("$ZodUnion", (t, r) => {
+		j.init(t, r),
+			U(t._zod, "optin", () => (r.options.some((n) => n._zod.optin === "optional") ? "optional" : void 0)),
+			U(t._zod, "optout", () => (r.options.some((n) => n._zod.optout === "optional") ? "optional" : void 0)),
+			U(t._zod, "values", () => {
+				if (r.options.every((n) => n._zod.values)) return new Set(r.options.flatMap((n) => Array.from(n._zod.values)))
+			}),
+			U(t._zod, "pattern", () => {
+				if (r.options.every((n) => n._zod.pattern)) {
+					const n = r.options.map((i) => i._zod.pattern)
+					return new RegExp(`^(${n.map((i) => et(i.source)).join("|")})$`)
+				}
+			}),
+			(t._zod.parse = (n, i) => {
+				let e = !1,
+					o = []
+				for (const a of r.options) {
+					const c = a._zod.run({ value: n.value, issues: [] }, i)
+					if (c instanceof Promise) o.push(c), (e = !0)
+					else {
+						if (c.issues.length === 0) return c
+						o.push(c)
+					}
+				}
+				return e ? Promise.all(o).then((a) => Rs(a, n, t, i)) : Rs(o, n, t, i)
+			})
+	}),
+	ni = u("$ZodDiscriminatedUnion", (t, r) => {
+		ur.init(t, r)
+		const n = t._zod.parse
+		U(t._zod, "propValues", () => {
+			const e = {}
+			for (const o of r.options) {
+				const a = o._zod.propValues
+				if (!a || Object.keys(a).length === 0)
+					throw new Error(`Invalid discriminated union option at index "${r.options.indexOf(o)}"`)
+				for (const [c, p] of Object.entries(a)) {
+					e[c] || (e[c] = new Set())
+					for (const h of p) e[c].add(h)
+				}
+			}
+			return e
+		})
+		const i = Ye(() => {
+			const e = r.options,
+				o = new Map()
+			for (const a of e) {
+				const c = a._zod.propValues[r.discriminator]
+				if (!c || c.size === 0) throw new Error(`Invalid discriminated union option at index "${r.options.indexOf(a)}"`)
+				for (const p of c) {
+					if (o.has(p)) throw new Error(`Duplicate discriminator value "${String(p)}"`)
+					o.set(p, a)
+				}
+			}
+			return o
+		})
+		t._zod.parse = (e, o) => {
+			const a = e.value
+			if (!Ne(a)) return e.issues.push({ code: "invalid_type", expected: "object", input: a, inst: t }), e
+			const c = i.value.get(a?.[r.discriminator])
+			return c
+				? c._zod.run(e, o)
+				: r.unionFallback
+					? n(e, o)
+					: (e.issues.push({
+							code: "invalid_union",
+							errors: [],
+							note: "No matching discriminator",
+							input: a,
+							path: [r.discriminator],
+							inst: t,
+						}),
+						e)
+		}
+	}),
+	oi = u("$ZodIntersection", (t, r) => {
+		j.init(t, r),
+			(t._zod.parse = (n, i) => {
+				const e = n.value,
+					o = r.left._zod.run({ value: e, issues: [] }, i),
+					a = r.right._zod.run({ value: e, issues: [] }, i)
+				return o instanceof Promise || a instanceof Promise
+					? Promise.all([o, a]).then(([p, h]) => Es(n, p, h))
+					: Es(n, o, a)
+			})
+	})
+function $o(t, r) {
+	if (t === r) return { valid: !0, data: t }
+	if (t instanceof Date && r instanceof Date && +t == +r) return { valid: !0, data: t }
+	if (Ue(t) && Ue(r)) {
+		const n = Object.keys(r),
+			i = Object.keys(t).filter((o) => n.indexOf(o) !== -1),
+			e = { ...t, ...r }
+		for (const o of i) {
+			const a = $o(t[o], r[o])
+			if (!a.valid) return { valid: !1, mergeErrorPath: [o, ...a.mergeErrorPath] }
+			e[o] = a.data
+		}
+		return { valid: !0, data: e }
+	}
+	if (Array.isArray(t) && Array.isArray(r)) {
+		if (t.length !== r.length) return { valid: !1, mergeErrorPath: [] }
+		const n = []
+		for (let i = 0; i < t.length; i++) {
+			const e = t[i],
+				o = r[i],
+				a = $o(e, o)
+			if (!a.valid) return { valid: !1, mergeErrorPath: [i, ...a.mergeErrorPath] }
+			n.push(a.data)
+		}
+		return { valid: !0, data: n }
+	}
+	return { valid: !1, mergeErrorPath: [] }
+}
+function Es(t, r, n) {
+	if ((r.issues.length && t.issues.push(...r.issues), n.issues.length && t.issues.push(...n.issues), ze(t))) return t
+	const i = $o(r.value, n.value)
+	if (!i.valid) throw new Error(`Unmergable intersection. Error path: ${JSON.stringify(i.mergeErrorPath)}`)
+	return (t.value = i.data), t
+}
+var Ie = u("$ZodTuple", (t, r) => {
+	j.init(t, r)
+	const n = r.items,
+		i = n.length - [...n].reverse().findIndex((e) => e._zod.optin !== "optional")
+	t._zod.parse = (e, o) => {
+		const a = e.value
+		if (!Array.isArray(a)) return e.issues.push({ input: a, inst: t, expected: "tuple", code: "invalid_type" }), e
+		e.value = []
+		const c = []
+		if (!r.rest) {
+			const h = a.length > n.length,
+				g = a.length < i - 1
+			if (h || g)
+				return (
+					e.issues.push({
+						input: a,
+						inst: t,
+						origin: "array",
+						...(h ? { code: "too_big", maximum: n.length } : { code: "too_small", minimum: n.length }),
+					}),
+					e
+				)
+		}
+		let p = -1
+		for (const h of n) {
+			if ((p++, p >= a.length && p >= i)) continue
+			const g = h._zod.run({ value: a[p], issues: [] }, o)
+			g instanceof Promise ? c.push(g.then((m) => ar(m, e, p))) : ar(g, e, p)
+		}
+		if (r.rest) {
+			const h = a.slice(n.length)
+			for (const g of h) {
+				p++
+				const m = r.rest._zod.run({ value: g, issues: [] }, o)
+				m instanceof Promise ? c.push(m.then(($) => ar($, e, p))) : ar(m, e, p)
+			}
+		}
+		return c.length ? Promise.all(c).then(() => e) : e
+	}
+})
+function ar(t, r, n) {
+	t.issues.length && r.issues.push(...Y(n, t.issues)), (r.value[n] = t.value)
+}
+var ii = u("$ZodRecord", (t, r) => {
+		j.init(t, r),
+			(t._zod.parse = (n, i) => {
+				const e = n.value
+				if (!Ue(e)) return n.issues.push({ expected: "record", code: "invalid_type", input: e, inst: t }), n
+				const o = []
+				if (r.keyType._zod.values) {
+					const a = r.keyType._zod.values
+					n.value = {}
+					for (const p of a)
+						if (typeof p == "string" || typeof p == "number" || typeof p == "symbol") {
+							const h = r.valueType._zod.run({ value: e[p], issues: [] }, i)
+							h instanceof Promise
+								? o.push(
+										h.then((g) => {
+											g.issues.length && n.issues.push(...Y(p, g.issues)), (n.value[p] = g.value)
+										}),
+									)
+								: (h.issues.length && n.issues.push(...Y(p, h.issues)), (n.value[p] = h.value))
+						}
+					let c
+					for (const p in e) a.has(p) || ((c = c ?? []), c.push(p))
+					c && c.length > 0 && n.issues.push({ code: "unrecognized_keys", input: e, inst: t, keys: c })
+				} else {
+					n.value = {}
+					for (const a of Reflect.ownKeys(e)) {
+						if (a === "__proto__") continue
+						const c = r.keyType._zod.run({ value: a, issues: [] }, i)
+						if (c instanceof Promise) throw new Error("Async schemas not supported in object keys currently")
+						if (c.issues.length) {
+							n.issues.push({
+								origin: "record",
+								code: "invalid_key",
+								issues: c.issues.map((h) => re(h, i, F())),
+								input: a,
+								path: [a],
+								inst: t,
+							}),
+								(n.value[c.value] = c.value)
+							continue
+						}
+						const p = r.valueType._zod.run({ value: e[a], issues: [] }, i)
+						p instanceof Promise
+							? o.push(
+									p.then((h) => {
+										h.issues.length && n.issues.push(...Y(a, h.issues)), (n.value[c.value] = h.value)
+									}),
+								)
+							: (p.issues.length && n.issues.push(...Y(a, p.issues)), (n.value[c.value] = p.value))
+					}
+				}
+				return o.length ? Promise.all(o).then(() => n) : n
+			})
+	}),
+	ai = u("$ZodMap", (t, r) => {
+		j.init(t, r),
+			(t._zod.parse = (n, i) => {
+				const e = n.value
+				if (!(e instanceof Map)) return n.issues.push({ expected: "map", code: "invalid_type", input: e, inst: t }), n
+				const o = []
+				n.value = new Map()
+				for (const [a, c] of e) {
+					const p = r.keyType._zod.run({ value: a, issues: [] }, i),
+						h = r.valueType._zod.run({ value: c, issues: [] }, i)
+					p instanceof Promise || h instanceof Promise
+						? o.push(
+								Promise.all([p, h]).then(([g, m]) => {
+									As(g, m, n, a, e, t, i)
+								}),
+							)
+						: As(p, h, n, a, e, t, i)
+				}
+				return o.length ? Promise.all(o).then(() => n) : n
+			})
+	})
+function As(t, r, n, i, e, o, a) {
+	t.issues.length &&
+		(tt.has(typeof i)
+			? n.issues.push(...Y(i, t.issues))
+			: n.issues.push({
+					origin: "map",
+					code: "invalid_key",
+					input: e,
+					inst: o,
+					issues: t.issues.map((c) => re(c, a, F())),
+				})),
+		r.issues.length &&
+			(tt.has(typeof i)
+				? n.issues.push(...Y(i, r.issues))
+				: n.issues.push({
+						origin: "map",
+						code: "invalid_element",
+						input: e,
+						inst: o,
+						key: i,
+						issues: r.issues.map((c) => re(c, a, F())),
+					})),
+		n.value.set(t.value, r.value)
+}
+var si = u("$ZodSet", (t, r) => {
+	j.init(t, r),
+		(t._zod.parse = (n, i) => {
+			const e = n.value
+			if (!(e instanceof Set)) return n.issues.push({ input: e, inst: t, expected: "set", code: "invalid_type" }), n
+			const o = []
+			n.value = new Set()
+			for (const a of e) {
+				const c = r.valueType._zod.run({ value: a, issues: [] }, i)
+				c instanceof Promise ? o.push(c.then((p) => Cs(p, n))) : Cs(c, n)
+			}
+			return o.length ? Promise.all(o).then(() => n) : n
+		})
+})
+function Cs(t, r) {
+	t.issues.length && r.issues.push(...t.issues), r.value.add(t.value)
+}
+var ci = u("$ZodEnum", (t, r) => {
+		j.init(t, r)
+		const n = Xe(r.entries)
+		;(t._zod.values = new Set(n)),
+			(t._zod.pattern = new RegExp(
+				`^(${n
+					.filter((i) => tt.has(typeof i))
+					.map((i) => (typeof i == "string" ? ue(i) : i.toString()))
+					.join("|")})$`,
+			)),
+			(t._zod.parse = (i, e) => {
+				const o = i.value
+				return t._zod.values.has(o) || i.issues.push({ code: "invalid_value", values: n, input: o, inst: t }), i
+			})
+	}),
+	ui = u("$ZodLiteral", (t, r) => {
+		j.init(t, r),
+			(t._zod.values = new Set(r.values)),
+			(t._zod.pattern = new RegExp(
+				`^(${r.values.map((n) => (typeof n == "string" ? ue(n) : n ? n.toString() : String(n))).join("|")})$`,
+			)),
+			(t._zod.parse = (n, i) => {
+				const e = n.value
+				return t._zod.values.has(e) || n.issues.push({ code: "invalid_value", values: r.values, input: e, inst: t }), n
+			})
+	}),
+	li = u("$ZodFile", (t, r) => {
+		j.init(t, r),
+			(t._zod.parse = (n, i) => {
+				const e = n.value
+				return e instanceof File || n.issues.push({ expected: "file", code: "invalid_type", input: e, inst: t }), n
+			})
+	}),
+	dt = u("$ZodTransform", (t, r) => {
+		j.init(t, r),
+			(t._zod.parse = (n, i) => {
+				const e = r.transform(n.value, n)
+				if (i.async) return (e instanceof Promise ? e : Promise.resolve(e)).then((a) => ((n.value = a), n))
+				if (e instanceof Promise) throw new se()
+				return (n.value = e), n
+			})
+	}),
+	mi = u("$ZodOptional", (t, r) => {
+		j.init(t, r),
+			(t._zod.optin = "optional"),
+			(t._zod.optout = "optional"),
+			U(t._zod, "values", () => (r.innerType._zod.values ? new Set([...r.innerType._zod.values, void 0]) : void 0)),
+			U(t._zod, "pattern", () => {
+				const n = r.innerType._zod.pattern
+				return n ? new RegExp(`^(${et(n.source)})?$`) : void 0
+			}),
+			(t._zod.parse = (n, i) =>
+				r.innerType._zod.optin === "optional"
+					? r.innerType._zod.run(n, i)
+					: n.value === void 0
+						? n
+						: r.innerType._zod.run(n, i))
+	}),
+	pi = u("$ZodNullable", (t, r) => {
+		j.init(t, r),
+			U(t._zod, "optin", () => r.innerType._zod.optin),
+			U(t._zod, "optout", () => r.innerType._zod.optout),
+			U(t._zod, "pattern", () => {
+				const n = r.innerType._zod.pattern
+				return n ? new RegExp(`^(${et(n.source)}|null)$`) : void 0
+			}),
+			U(t._zod, "values", () => (r.innerType._zod.values ? new Set([...r.innerType._zod.values, null]) : void 0)),
+			(t._zod.parse = (n, i) => (n.value === null ? n : r.innerType._zod.run(n, i)))
+	}),
+	di = u("$ZodDefault", (t, r) => {
+		j.init(t, r),
+			(t._zod.optin = "optional"),
+			U(t._zod, "values", () => r.innerType._zod.values),
+			(t._zod.parse = (n, i) => {
+				if (n.value === void 0) return (n.value = r.defaultValue), n
+				const e = r.innerType._zod.run(n, i)
+				return e instanceof Promise ? e.then((o) => Ls(o, r)) : Ls(e, r)
+			})
+	})
+function Ls(t, r) {
+	return t.value === void 0 && (t.value = r.defaultValue), t
+}
+var fi = u("$ZodPrefault", (t, r) => {
+		j.init(t, r),
+			(t._zod.optin = "optional"),
+			U(t._zod, "values", () => r.innerType._zod.values),
+			(t._zod.parse = (n, i) => (n.value === void 0 && (n.value = r.defaultValue), r.innerType._zod.run(n, i)))
+	}),
+	gi = u("$ZodNonOptional", (t, r) => {
+		j.init(t, r),
+			U(t._zod, "values", () => {
+				const n = r.innerType._zod.values
+				return n ? new Set([...n].filter((i) => i !== void 0)) : void 0
+			}),
+			(t._zod.parse = (n, i) => {
+				const e = r.innerType._zod.run(n, i)
+				return e instanceof Promise ? e.then((o) => Ms(o, t)) : Ms(e, t)
+			})
+	})
+function Ms(t, r) {
+	return (
+		!t.issues.length &&
+			t.value === void 0 &&
+			t.issues.push({ code: "invalid_type", expected: "nonoptional", input: t.value, inst: r }),
+		t
+	)
+}
+var hi = u("$ZodSuccess", (t, r) => {
+		j.init(t, r),
+			(t._zod.parse = (n, i) => {
+				const e = r.innerType._zod.run(n, i)
+				return e instanceof Promise
+					? e.then((o) => ((n.value = o.issues.length === 0), n))
+					: ((n.value = e.issues.length === 0), n)
+			})
+	}),
+	vi = u("$ZodCatch", (t, r) => {
+		j.init(t, r),
+			(t._zod.optin = "optional"),
+			U(t._zod, "optout", () => r.innerType._zod.optout),
+			U(t._zod, "values", () => r.innerType._zod.values),
+			(t._zod.parse = (n, i) => {
+				const e = r.innerType._zod.run(n, i)
+				return e instanceof Promise
+					? e.then(
+							(o) => (
+								(n.value = o.value),
+								o.issues.length &&
+									((n.value = r.catchValue({
+										...n,
+										error: { issues: o.issues.map((a) => re(a, i, F())) },
+										input: n.value,
+									})),
+									(n.issues = [])),
+								n
+							),
+						)
+					: ((n.value = e.value),
+						e.issues.length &&
+							((n.value = r.catchValue({
+								...n,
+								error: { issues: e.issues.map((o) => re(o, i, F())) },
+								input: n.value,
+							})),
+							(n.issues = [])),
+						n)
+			})
+	}),
+	bi = u("$ZodNaN", (t, r) => {
+		j.init(t, r),
+			(t._zod.parse = (n, i) => (
+				(typeof n.value != "number" || !Number.isNaN(n.value)) &&
+					n.issues.push({ input: n.value, inst: t, expected: "nan", code: "invalid_type" }),
+				n
+			))
+	}),
+	ft = u("$ZodPipe", (t, r) => {
+		j.init(t, r),
+			U(t._zod, "values", () => r.in._zod.values),
+			U(t._zod, "optin", () => r.in._zod.optin),
+			U(t._zod, "optout", () => r.out._zod.optout),
+			(t._zod.parse = (n, i) => {
+				const e = r.in._zod.run(n, i)
+				return e instanceof Promise ? e.then((o) => qs(o, r, i)) : qs(e, r, i)
+			})
+	})
+function qs(t, r, n) {
+	return ze(t) ? t : r.out._zod.run({ value: t.value, issues: t.issues }, n)
+}
+var _i = u("$ZodReadonly", (t, r) => {
+	j.init(t, r),
+		U(t._zod, "propValues", () => r.innerType._zod.propValues),
+		U(t._zod, "values", () => r.innerType._zod.values),
+		U(t._zod, "optin", () => r.innerType._zod.optin),
+		U(t._zod, "optout", () => r.innerType._zod.optout),
+		(t._zod.parse = (n, i) => {
+			const e = r.innerType._zod.run(n, i)
+			return e instanceof Promise ? e.then(Vs) : Vs(e)
+		})
+})
+function Vs(t) {
+	return (t.value = Object.freeze(t.value)), t
+}
+var yi = u("$ZodTemplateLiteral", (t, r) => {
+		j.init(t, r)
+		const n = []
+		for (const i of r.parts)
+			if (i instanceof j) {
+				if (!i._zod.pattern)
+					throw new Error(`Invalid template literal part, no pattern found: ${[...i._zod.traits].shift()}`)
+				const e = i._zod.pattern instanceof RegExp ? i._zod.pattern.source : i._zod.pattern
+				if (!e) throw new Error(`Invalid template literal part: ${i._zod.traits}`)
+				const o = e.startsWith("^") ? 1 : 0,
+					a = e.endsWith("$") ? e.length - 1 : e.length
+				n.push(e.slice(o, a))
+			} else if (i === null || _n.has(typeof i)) n.push(ue(`${i}`))
+			else throw new Error(`Invalid template literal part: ${i}`)
+		;(t._zod.pattern = new RegExp(`^${n.join("")}$`)),
+			(t._zod.parse = (i, e) =>
+				typeof i.value != "string"
+					? (i.issues.push({ input: i.value, inst: t, expected: "template_literal", code: "invalid_type" }), i)
+					: ((t._zod.pattern.lastIndex = 0),
+						t._zod.pattern.test(i.value) ||
+							i.issues.push({
+								input: i.value,
+								inst: t,
+								code: "invalid_format",
+								format: "template_literal",
+								pattern: t._zod.pattern.source,
+							}),
+						i))
+	}),
+	$i = u("$ZodPromise", (t, r) => {
+		j.init(t, r),
+			(t._zod.parse = (n, i) => Promise.resolve(n.value).then((e) => r.innerType._zod.run({ value: e, issues: [] }, i)))
+	}),
+	xi = u("$ZodLazy", (t, r) => {
+		j.init(t, r),
+			U(t._zod, "innerType", () => r.getter()),
+			U(t._zod, "pattern", () => t._zod.innerType._zod.pattern),
+			U(t._zod, "propValues", () => t._zod.innerType._zod.propValues),
+			U(t._zod, "optin", () => t._zod.innerType._zod.optin),
+			U(t._zod, "optout", () => t._zod.innerType._zod.optout),
+			(t._zod.parse = (n, i) => t._zod.innerType._zod.run(n, i))
+	}),
+	zi = u("$ZodCustom", (t, r) => {
+		V.init(t, r),
+			j.init(t, r),
+			(t._zod.parse = (n, i) => n),
+			(t._zod.check = (n) => {
+				const i = n.value,
+					e = r.fn(i)
+				if (e instanceof Promise) return e.then((o) => Fs(o, n, i, t))
+				Fs(e, n, i, t)
+			})
+	})
+function Fs(t, r, n, i) {
+	if (!t) {
+		const e = { code: "custom", input: n, inst: i, path: [...(i._zod.def.path ?? [])], continue: !i._zod.def.abort }
+		i._zod.def.params && (e.params = i._zod.def.params), r.issues.push(zn(e))
+	}
+}
+var gt = {}
+$e(gt, {
+	ar: () => Ws,
+	az: () => Gs,
+	be: () => Qs,
+	ca: () => Xs,
+	cs: () => Ys,
+	de: () => ec,
+	en: () => lr,
+	eo: () => tc,
+	es: () => rc,
+	fa: () => nc,
+	fi: () => oc,
+	fr: () => ic,
+	frCA: () => ac,
+	he: () => sc,
+	hu: () => cc,
+	id: () => uc,
+	it: () => lc,
+	ja: () => mc,
+	kh: () => pc,
+	ko: () => dc,
+	mk: () => fc,
+	ms: () => gc,
+	nl: () => hc,
+	no: () => vc,
+	ota: () => bc,
+	pl: () => yc,
+	ps: () => _c,
+	pt: () => $c,
+	ru: () => zc,
+	sl: () => kc,
+	sv: () => Sc,
+	ta: () => wc,
+	th: () => Ic,
+	tr: () => jc,
+	ua: () => Pc,
+	ur: () => Tc,
+	vi: () => Oc,
+	zhCN: () => Nc,
+	zhTW: () => Uc,
+})
+var hl = () => {
+	const t = {
+		string: { unit: "\u062D\u0631\u0641", verb: "\u0623\u0646 \u064A\u062D\u0648\u064A" },
+		file: { unit: "\u0628\u0627\u064A\u062A", verb: "\u0623\u0646 \u064A\u062D\u0648\u064A" },
+		array: { unit: "\u0639\u0646\u0635\u0631", verb: "\u0623\u0646 \u064A\u062D\u0648\u064A" },
+		set: { unit: "\u0639\u0646\u0635\u0631", verb: "\u0623\u0646 \u064A\u062D\u0648\u064A" },
+	}
+	function r(e) {
+		return t[e] ?? null
+	}
+	const n = (e) => {
+			const o = typeof e
+			switch (o) {
+				case "number":
+					return Number.isNaN(e) ? "NaN" : "number"
+				case "object": {
+					if (Array.isArray(e)) return "array"
+					if (e === null) return "null"
+					if (Object.getPrototypeOf(e) !== Object.prototype && e.constructor) return e.constructor.name
+				}
+			}
+			return o
+		},
+		i = {
+			regex: "\u0645\u062F\u062E\u0644",
+			email: "\u0628\u0631\u064A\u062F \u0625\u0644\u0643\u062A\u0631\u0648\u0646\u064A",
+			url: "\u0631\u0627\u0628\u0637",
+			emoji: "\u0625\u064A\u0645\u0648\u062C\u064A",
+			uuid: "UUID",
+			uuidv4: "UUIDv4",
+			uuidv6: "UUIDv6",
+			nanoid: "nanoid",
+			guid: "GUID",
+			cuid: "cuid",
+			cuid2: "cuid2",
+			ulid: "ULID",
+			xid: "XID",
+			ksuid: "KSUID",
+			datetime: "\u062A\u0627\u0631\u064A\u062E \u0648\u0648\u0642\u062A \u0628\u0645\u0639\u064A\u0627\u0631 ISO",
+			date: "\u062A\u0627\u0631\u064A\u062E \u0628\u0645\u0639\u064A\u0627\u0631 ISO",
+			time: "\u0648\u0642\u062A \u0628\u0645\u0639\u064A\u0627\u0631 ISO",
+			duration: "\u0645\u062F\u0629 \u0628\u0645\u0639\u064A\u0627\u0631 ISO",
+			ipv4: "\u0639\u0646\u0648\u0627\u0646 IPv4",
+			ipv6: "\u0639\u0646\u0648\u0627\u0646 IPv6",
+			cidrv4: "\u0645\u062F\u0649 \u0639\u0646\u0627\u0648\u064A\u0646 \u0628\u0635\u064A\u063A\u0629 IPv4",
+			cidrv6: "\u0645\u062F\u0649 \u0639\u0646\u0627\u0648\u064A\u0646 \u0628\u0635\u064A\u063A\u0629 IPv6",
+			base64: "\u0646\u064E\u0635 \u0628\u062A\u0631\u0645\u064A\u0632 base64-encoded",
+			base64url: "\u0646\u064E\u0635 \u0628\u062A\u0631\u0645\u064A\u0632 base64url-encoded",
+			json_string: "\u0646\u064E\u0635 \u0639\u0644\u0649 \u0647\u064A\u0626\u0629 JSON",
+			e164: "\u0631\u0642\u0645 \u0647\u0627\u062A\u0641 \u0628\u0645\u0639\u064A\u0627\u0631 E.164",
+			jwt: "JWT",
+			template_literal: "\u0645\u062F\u062E\u0644",
+		}
+	return (e) => {
+		switch (e.code) {
+			case "invalid_type":
+				return `\u0645\u062F\u062E\u0644\u0627\u062A \u063A\u064A\u0631 \u0645\u0642\u0628\u0648\u0644\u0629: \u064A\u0641\u062A\u0631\u0636 \u0625\u062F\u062E\u0627\u0644 ${e.expected}\u060C \u0648\u0644\u0643\u0646 \u062A\u0645 \u0625\u062F\u062E\u0627\u0644 ${n(e.input)}`
+			case "invalid_value":
+				return e.values.length === 1
+					? `\u0645\u062F\u062E\u0644\u0627\u062A \u063A\u064A\u0631 \u0645\u0642\u0628\u0648\u0644\u0629: \u064A\u0641\u062A\u0631\u0636 \u0625\u062F\u062E\u0627\u0644 ${_(e.values[0])}`
+					: `\u0627\u062E\u062A\u064A\u0627\u0631 \u063A\u064A\u0631 \u0645\u0642\u0628\u0648\u0644: \u064A\u062A\u0648\u0642\u0639 \u0627\u0646\u062A\u0642\u0627\u0621 \u0623\u062D\u062F \u0647\u0630\u0647 \u0627\u0644\u062E\u064A\u0627\u0631\u0627\u062A: ${f(e.values, "|")}`
+			case "too_big": {
+				const o = e.inclusive ? "<=" : "<",
+					a = r(e.origin)
+				return a
+					? ` \u0623\u0643\u0628\u0631 \u0645\u0646 \u0627\u0644\u0644\u0627\u0632\u0645: \u064A\u0641\u062A\u0631\u0636 \u0623\u0646 \u062A\u0643\u0648\u0646 ${e.origin ?? "\u0627\u0644\u0642\u064A\u0645\u0629"} ${o} ${e.maximum.toString()} ${a.unit ?? "\u0639\u0646\u0635\u0631"}`
+					: `\u0623\u0643\u0628\u0631 \u0645\u0646 \u0627\u0644\u0644\u0627\u0632\u0645: \u064A\u0641\u062A\u0631\u0636 \u0623\u0646 \u062A\u0643\u0648\u0646 ${e.origin ?? "\u0627\u0644\u0642\u064A\u0645\u0629"} ${o} ${e.maximum.toString()}`
+			}
+			case "too_small": {
+				const o = e.inclusive ? ">=" : ">",
+					a = r(e.origin)
+				return a
+					? `\u0623\u0635\u063A\u0631 \u0645\u0646 \u0627\u0644\u0644\u0627\u0632\u0645: \u064A\u0641\u062A\u0631\u0636 \u0644\u0640 ${e.origin} \u0623\u0646 \u064A\u0643\u0648\u0646 ${o} ${e.minimum.toString()} ${a.unit}`
+					: `\u0623\u0635\u063A\u0631 \u0645\u0646 \u0627\u0644\u0644\u0627\u0632\u0645: \u064A\u0641\u062A\u0631\u0636 \u0644\u0640 ${e.origin} \u0623\u0646 \u064A\u0643\u0648\u0646 ${o} ${e.minimum.toString()}`
+			}
+			case "invalid_format": {
+				const o = e
+				return o.format === "starts_with"
+					? `\u0646\u064E\u0635 \u063A\u064A\u0631 \u0645\u0642\u0628\u0648\u0644: \u064A\u062C\u0628 \u0623\u0646 \u064A\u0628\u062F\u0623 \u0628\u0640 "${e.prefix}"`
+					: o.format === "ends_with"
+						? `\u0646\u064E\u0635 \u063A\u064A\u0631 \u0645\u0642\u0628\u0648\u0644: \u064A\u062C\u0628 \u0623\u0646 \u064A\u0646\u062A\u0647\u064A \u0628\u0640 "${o.suffix}"`
+						: o.format === "includes"
+							? `\u0646\u064E\u0635 \u063A\u064A\u0631 \u0645\u0642\u0628\u0648\u0644: \u064A\u062C\u0628 \u0623\u0646 \u064A\u062A\u0636\u0645\u0651\u064E\u0646 "${o.includes}"`
+							: o.format === "regex"
+								? `\u0646\u064E\u0635 \u063A\u064A\u0631 \u0645\u0642\u0628\u0648\u0644: \u064A\u062C\u0628 \u0623\u0646 \u064A\u0637\u0627\u0628\u0642 \u0627\u0644\u0646\u0645\u0637 ${o.pattern}`
+								: `${i[o.format] ?? e.format} \u063A\u064A\u0631 \u0645\u0642\u0628\u0648\u0644`
+			}
+			case "not_multiple_of":
+				return `\u0631\u0642\u0645 \u063A\u064A\u0631 \u0645\u0642\u0628\u0648\u0644: \u064A\u062C\u0628 \u0623\u0646 \u064A\u0643\u0648\u0646 \u0645\u0646 \u0645\u0636\u0627\u0639\u0641\u0627\u062A ${e.divisor}`
+			case "unrecognized_keys":
+				return `\u0645\u0639\u0631\u0641${e.keys.length > 1 ? "\u0627\u062A" : ""} \u063A\u0631\u064A\u0628${e.keys.length > 1 ? "\u0629" : ""}: ${f(e.keys, "\u060C ")}`
+			case "invalid_key":
+				return `\u0645\u0639\u0631\u0641 \u063A\u064A\u0631 \u0645\u0642\u0628\u0648\u0644 \u0641\u064A ${e.origin}`
+			case "invalid_union":
+				return "\u0645\u062F\u062E\u0644 \u063A\u064A\u0631 \u0645\u0642\u0628\u0648\u0644"
+			case "invalid_element":
+				return `\u0645\u062F\u062E\u0644 \u063A\u064A\u0631 \u0645\u0642\u0628\u0648\u0644 \u0641\u064A ${e.origin}`
+			default:
+				return "\u0645\u062F\u062E\u0644 \u063A\u064A\u0631 \u0645\u0642\u0628\u0648\u0644"
+		}
+	}
+}
+function Ws() {
+	return { localeError: hl() }
+}
+var vl = () => {
+	const t = {
+		string: { unit: "simvol", verb: "olmal\u0131d\u0131r" },
+		file: { unit: "bayt", verb: "olmal\u0131d\u0131r" },
+		array: { unit: "element", verb: "olmal\u0131d\u0131r" },
+		set: { unit: "element", verb: "olmal\u0131d\u0131r" },
+	}
+	function r(e) {
+		return t[e] ?? null
+	}
+	const n = (e) => {
+			const o = typeof e
+			switch (o) {
+				case "number":
+					return Number.isNaN(e) ? "NaN" : "number"
+				case "object": {
+					if (Array.isArray(e)) return "array"
+					if (e === null) return "null"
+					if (Object.getPrototypeOf(e) !== Object.prototype && e.constructor) return e.constructor.name
+				}
+			}
+			return o
+		},
+		i = {
+			regex: "input",
+			email: "email address",
+			url: "URL",
+			emoji: "emoji",
+			uuid: "UUID",
+			uuidv4: "UUIDv4",
+			uuidv6: "UUIDv6",
+			nanoid: "nanoid",
+			guid: "GUID",
+			cuid: "cuid",
+			cuid2: "cuid2",
+			ulid: "ULID",
+			xid: "XID",
+			ksuid: "KSUID",
+			datetime: "ISO datetime",
+			date: "ISO date",
+			time: "ISO time",
+			duration: "ISO duration",
+			ipv4: "IPv4 address",
+			ipv6: "IPv6 address",
+			cidrv4: "IPv4 range",
+			cidrv6: "IPv6 range",
+			base64: "base64-encoded string",
+			base64url: "base64url-encoded string",
+			json_string: "JSON string",
+			e164: "E.164 number",
+			jwt: "JWT",
+			template_literal: "input",
+		}
+	return (e) => {
+		switch (e.code) {
+			case "invalid_type":
+				return `Yanl\u0131\u015F d\u0259y\u0259r: g\xF6zl\u0259nil\u0259n ${e.expected}, daxil olan ${n(e.input)}`
+			case "invalid_value":
+				return e.values.length === 1
+					? `Yanl\u0131\u015F d\u0259y\u0259r: g\xF6zl\u0259nil\u0259n ${_(e.values[0])}`
+					: `Yanl\u0131\u015F se\xE7im: a\u015Fa\u011F\u0131dak\u0131lardan biri olmal\u0131d\u0131r: ${f(e.values, "|")}`
+			case "too_big": {
+				const o = e.inclusive ? "<=" : "<",
+					a = r(e.origin)
+				return a
+					? `\xC7ox b\xF6y\xFCk: g\xF6zl\u0259nil\u0259n ${e.origin ?? "d\u0259y\u0259r"} ${o}${e.maximum.toString()} ${a.unit ?? "element"}`
+					: `\xC7ox b\xF6y\xFCk: g\xF6zl\u0259nil\u0259n ${e.origin ?? "d\u0259y\u0259r"} ${o}${e.maximum.toString()}`
+			}
+			case "too_small": {
+				const o = e.inclusive ? ">=" : ">",
+					a = r(e.origin)
+				return a
+					? `\xC7ox ki\xE7ik: g\xF6zl\u0259nil\u0259n ${e.origin} ${o}${e.minimum.toString()} ${a.unit}`
+					: `\xC7ox ki\xE7ik: g\xF6zl\u0259nil\u0259n ${e.origin} ${o}${e.minimum.toString()}`
+			}
+			case "invalid_format": {
+				const o = e
+				return o.format === "starts_with"
+					? `Yanl\u0131\u015F m\u0259tn: "${o.prefix}" il\u0259 ba\u015Flamal\u0131d\u0131r`
+					: o.format === "ends_with"
+						? `Yanl\u0131\u015F m\u0259tn: "${o.suffix}" il\u0259 bitm\u0259lidir`
+						: o.format === "includes"
+							? `Yanl\u0131\u015F m\u0259tn: "${o.includes}" daxil olmal\u0131d\u0131r`
+							: o.format === "regex"
+								? `Yanl\u0131\u015F m\u0259tn: ${o.pattern} \u015Fablonuna uy\u011Fun olmal\u0131d\u0131r`
+								: `Yanl\u0131\u015F ${i[o.format] ?? e.format}`
+			}
+			case "not_multiple_of":
+				return `Yanl\u0131\u015F \u0259d\u0259d: ${e.divisor} il\u0259 b\xF6l\xFCn\u0259 bil\u0259n olmal\u0131d\u0131r`
+			case "unrecognized_keys":
+				return `Tan\u0131nmayan a\xE7ar${e.keys.length > 1 ? "lar" : ""}: ${f(e.keys, ", ")}`
+			case "invalid_key":
+				return `${e.origin} daxilind\u0259 yanl\u0131\u015F a\xE7ar`
+			case "invalid_union":
+				return "Yanl\u0131\u015F d\u0259y\u0259r"
+			case "invalid_element":
+				return `${e.origin} daxilind\u0259 yanl\u0131\u015F d\u0259y\u0259r`
+			default:
+				return "Yanl\u0131\u015F d\u0259y\u0259r"
+		}
+	}
+}
+function Gs() {
+	return { localeError: vl() }
+}
+function Ks(t, r, n, i) {
+	const e = Math.abs(t),
+		o = e % 10,
+		a = e % 100
+	return a >= 11 && a <= 19 ? i : o === 1 ? r : o >= 2 && o <= 4 ? n : i
+}
+var bl = () => {
+	const t = {
+		string: {
+			unit: {
+				one: "\u0441\u0456\u043C\u0432\u0430\u043B",
+				few: "\u0441\u0456\u043C\u0432\u0430\u043B\u044B",
+				many: "\u0441\u0456\u043C\u0432\u0430\u043B\u0430\u045E",
+			},
+			verb: "\u043C\u0435\u0446\u044C",
+		},
+		array: {
+			unit: {
+				one: "\u044D\u043B\u0435\u043C\u0435\u043D\u0442",
+				few: "\u044D\u043B\u0435\u043C\u0435\u043D\u0442\u044B",
+				many: "\u044D\u043B\u0435\u043C\u0435\u043D\u0442\u0430\u045E",
+			},
+			verb: "\u043C\u0435\u0446\u044C",
+		},
+		set: {
+			unit: {
+				one: "\u044D\u043B\u0435\u043C\u0435\u043D\u0442",
+				few: "\u044D\u043B\u0435\u043C\u0435\u043D\u0442\u044B",
+				many: "\u044D\u043B\u0435\u043C\u0435\u043D\u0442\u0430\u045E",
+			},
+			verb: "\u043C\u0435\u0446\u044C",
+		},
+		file: {
+			unit: {
+				one: "\u0431\u0430\u0439\u0442",
+				few: "\u0431\u0430\u0439\u0442\u044B",
+				many: "\u0431\u0430\u0439\u0442\u0430\u045E",
+			},
+			verb: "\u043C\u0435\u0446\u044C",
+		},
+	}
+	function r(e) {
+		return t[e] ?? null
+	}
+	const n = (e) => {
+			const o = typeof e
+			switch (o) {
+				case "number":
+					return Number.isNaN(e) ? "NaN" : "\u043B\u0456\u043A"
+				case "object": {
+					if (Array.isArray(e)) return "\u043C\u0430\u0441\u0456\u045E"
+					if (e === null) return "null"
+					if (Object.getPrototypeOf(e) !== Object.prototype && e.constructor) return e.constructor.name
+				}
+			}
+			return o
+		},
+		i = {
+			regex: "\u0443\u0432\u043E\u0434",
+			email: "email \u0430\u0434\u0440\u0430\u0441",
+			url: "URL",
+			emoji: "\u044D\u043C\u043E\u0434\u0437\u0456",
+			uuid: "UUID",
+			uuidv4: "UUIDv4",
+			uuidv6: "UUIDv6",
+			nanoid: "nanoid",
+			guid: "GUID",
+			cuid: "cuid",
+			cuid2: "cuid2",
+			ulid: "ULID",
+			xid: "XID",
+			ksuid: "KSUID",
+			datetime: "ISO \u0434\u0430\u0442\u0430 \u0456 \u0447\u0430\u0441",
+			date: "ISO \u0434\u0430\u0442\u0430",
+			time: "ISO \u0447\u0430\u0441",
+			duration: "ISO \u043F\u0440\u0430\u0446\u044F\u0433\u043B\u0430\u0441\u0446\u044C",
+			ipv4: "IPv4 \u0430\u0434\u0440\u0430\u0441",
+			ipv6: "IPv6 \u0430\u0434\u0440\u0430\u0441",
+			cidrv4: "IPv4 \u0434\u044B\u044F\u043F\u0430\u0437\u043E\u043D",
+			cidrv6: "IPv6 \u0434\u044B\u044F\u043F\u0430\u0437\u043E\u043D",
+			base64: "\u0440\u0430\u0434\u043E\u043A \u0443 \u0444\u0430\u0440\u043C\u0430\u0446\u0435 base64",
+			base64url: "\u0440\u0430\u0434\u043E\u043A \u0443 \u0444\u0430\u0440\u043C\u0430\u0446\u0435 base64url",
+			json_string: "JSON \u0440\u0430\u0434\u043E\u043A",
+			e164: "\u043D\u0443\u043C\u0430\u0440 E.164",
+			jwt: "JWT",
+			template_literal: "\u0443\u0432\u043E\u0434",
+		}
+	return (e) => {
+		switch (e.code) {
+			case "invalid_type":
+				return `\u041D\u044F\u043F\u0440\u0430\u0432\u0456\u043B\u044C\u043D\u044B \u045E\u0432\u043E\u0434: \u0447\u0430\u043A\u0430\u045E\u0441\u044F ${e.expected}, \u0430\u0442\u0440\u044B\u043C\u0430\u043D\u0430 ${n(e.input)}`
+			case "invalid_value":
+				return e.values.length === 1
+					? `\u041D\u044F\u043F\u0440\u0430\u0432\u0456\u043B\u044C\u043D\u044B \u045E\u0432\u043E\u0434: \u0447\u0430\u043A\u0430\u043B\u0430\u0441\u044F ${_(e.values[0])}`
+					: `\u041D\u044F\u043F\u0440\u0430\u0432\u0456\u043B\u044C\u043D\u044B \u0432\u0430\u0440\u044B\u044F\u043D\u0442: \u0447\u0430\u043A\u0430\u045E\u0441\u044F \u0430\u0434\u0437\u0456\u043D \u0437 ${f(e.values, "|")}`
+			case "too_big": {
+				const o = e.inclusive ? "<=" : "<",
+					a = r(e.origin)
+				if (a) {
+					const c = Number(e.maximum),
+						p = Ks(c, a.unit.one, a.unit.few, a.unit.many)
+					return `\u0417\u0430\u043D\u0430\u0434\u0442\u0430 \u0432\u044F\u043B\u0456\u043A\u0456: \u0447\u0430\u043A\u0430\u043B\u0430\u0441\u044F, \u0448\u0442\u043E ${e.origin ?? "\u0437\u043D\u0430\u0447\u044D\u043D\u043D\u0435"} \u043F\u0430\u0432\u0456\u043D\u043D\u0430 ${a.verb} ${o}${e.maximum.toString()} ${p}`
+				}
+				return `\u0417\u0430\u043D\u0430\u0434\u0442\u0430 \u0432\u044F\u043B\u0456\u043A\u0456: \u0447\u0430\u043A\u0430\u043B\u0430\u0441\u044F, \u0448\u0442\u043E ${e.origin ?? "\u0437\u043D\u0430\u0447\u044D\u043D\u043D\u0435"} \u043F\u0430\u0432\u0456\u043D\u043D\u0430 \u0431\u044B\u0446\u044C ${o}${e.maximum.toString()}`
+			}
+			case "too_small": {
+				const o = e.inclusive ? ">=" : ">",
+					a = r(e.origin)
+				if (a) {
+					const c = Number(e.minimum),
+						p = Ks(c, a.unit.one, a.unit.few, a.unit.many)
+					return `\u0417\u0430\u043D\u0430\u0434\u0442\u0430 \u043C\u0430\u043B\u044B: \u0447\u0430\u043A\u0430\u043B\u0430\u0441\u044F, \u0448\u0442\u043E ${e.origin} \u043F\u0430\u0432\u0456\u043D\u043D\u0430 ${a.verb} ${o}${e.minimum.toString()} ${p}`
+				}
+				return `\u0417\u0430\u043D\u0430\u0434\u0442\u0430 \u043C\u0430\u043B\u044B: \u0447\u0430\u043A\u0430\u043B\u0430\u0441\u044F, \u0448\u0442\u043E ${e.origin} \u043F\u0430\u0432\u0456\u043D\u043D\u0430 \u0431\u044B\u0446\u044C ${o}${e.minimum.toString()}`
+			}
+			case "invalid_format": {
+				const o = e
+				return o.format === "starts_with"
+					? `\u041D\u044F\u043F\u0440\u0430\u0432\u0456\u043B\u044C\u043D\u044B \u0440\u0430\u0434\u043E\u043A: \u043F\u0430\u0432\u0456\u043D\u0435\u043D \u043F\u0430\u0447\u044B\u043D\u0430\u0446\u0446\u0430 \u0437 "${o.prefix}"`
+					: o.format === "ends_with"
+						? `\u041D\u044F\u043F\u0440\u0430\u0432\u0456\u043B\u044C\u043D\u044B \u0440\u0430\u0434\u043E\u043A: \u043F\u0430\u0432\u0456\u043D\u0435\u043D \u0437\u0430\u043A\u0430\u043D\u0447\u0432\u0430\u0446\u0446\u0430 \u043D\u0430 "${o.suffix}"`
+						: o.format === "includes"
+							? `\u041D\u044F\u043F\u0440\u0430\u0432\u0456\u043B\u044C\u043D\u044B \u0440\u0430\u0434\u043E\u043A: \u043F\u0430\u0432\u0456\u043D\u0435\u043D \u0437\u043C\u044F\u0448\u0447\u0430\u0446\u044C "${o.includes}"`
+							: o.format === "regex"
+								? `\u041D\u044F\u043F\u0440\u0430\u0432\u0456\u043B\u044C\u043D\u044B \u0440\u0430\u0434\u043E\u043A: \u043F\u0430\u0432\u0456\u043D\u0435\u043D \u0430\u0434\u043F\u0430\u0432\u044F\u0434\u0430\u0446\u044C \u0448\u0430\u0431\u043B\u043E\u043D\u0443 ${o.pattern}`
+								: `\u041D\u044F\u043F\u0440\u0430\u0432\u0456\u043B\u044C\u043D\u044B ${i[o.format] ?? e.format}`
+			}
+			case "not_multiple_of":
+				return `\u041D\u044F\u043F\u0440\u0430\u0432\u0456\u043B\u044C\u043D\u044B \u043B\u0456\u043A: \u043F\u0430\u0432\u0456\u043D\u0435\u043D \u0431\u044B\u0446\u044C \u043A\u0440\u0430\u0442\u043D\u044B\u043C ${e.divisor}`
+			case "unrecognized_keys":
+				return `\u041D\u0435\u0440\u0430\u0441\u043F\u0430\u0437\u043D\u0430\u043D\u044B ${e.keys.length > 1 ? "\u043A\u043B\u044E\u0447\u044B" : "\u043A\u043B\u044E\u0447"}: ${f(e.keys, ", ")}`
+			case "invalid_key":
+				return `\u041D\u044F\u043F\u0440\u0430\u0432\u0456\u043B\u044C\u043D\u044B \u043A\u043B\u044E\u0447 \u0443 ${e.origin}`
+			case "invalid_union":
+				return "\u041D\u044F\u043F\u0440\u0430\u0432\u0456\u043B\u044C\u043D\u044B \u045E\u0432\u043E\u0434"
+			case "invalid_element":
+				return `\u041D\u044F\u043F\u0440\u0430\u0432\u0456\u043B\u044C\u043D\u0430\u0435 \u0437\u043D\u0430\u0447\u044D\u043D\u043D\u0435 \u045E ${e.origin}`
+			default:
+				return "\u041D\u044F\u043F\u0440\u0430\u0432\u0456\u043B\u044C\u043D\u044B \u045E\u0432\u043E\u0434"
+		}
+	}
+}
+function Qs() {
+	return { localeError: bl() }
+}
+var _l = () => {
+	const t = {
+		string: { unit: "car\xE0cters", verb: "contenir" },
+		file: { unit: "bytes", verb: "contenir" },
+		array: { unit: "elements", verb: "contenir" },
+		set: { unit: "elements", verb: "contenir" },
+	}
+	function r(e) {
+		return t[e] ?? null
+	}
+	const n = (e) => {
+			const o = typeof e
+			switch (o) {
+				case "number":
+					return Number.isNaN(e) ? "NaN" : "number"
+				case "object": {
+					if (Array.isArray(e)) return "array"
+					if (e === null) return "null"
+					if (Object.getPrototypeOf(e) !== Object.prototype && e.constructor) return e.constructor.name
+				}
+			}
+			return o
+		},
+		i = {
+			regex: "entrada",
+			email: "adre\xE7a electr\xF2nica",
+			url: "URL",
+			emoji: "emoji",
+			uuid: "UUID",
+			uuidv4: "UUIDv4",
+			uuidv6: "UUIDv6",
+			nanoid: "nanoid",
+			guid: "GUID",
+			cuid: "cuid",
+			cuid2: "cuid2",
+			ulid: "ULID",
+			xid: "XID",
+			ksuid: "KSUID",
+			datetime: "data i hora ISO",
+			date: "data ISO",
+			time: "hora ISO",
+			duration: "durada ISO",
+			ipv4: "adre\xE7a IPv4",
+			ipv6: "adre\xE7a IPv6",
+			cidrv4: "rang IPv4",
+			cidrv6: "rang IPv6",
+			base64: "cadena codificada en base64",
+			base64url: "cadena codificada en base64url",
+			json_string: "cadena JSON",
+			e164: "n\xFAmero E.164",
+			jwt: "JWT",
+			template_literal: "entrada",
+		}
+	return (e) => {
+		switch (e.code) {
+			case "invalid_type":
+				return `Tipus inv\xE0lid: s'esperava ${e.expected}, s'ha rebut ${n(e.input)}`
+			case "invalid_value":
+				return e.values.length === 1
+					? `Valor inv\xE0lid: s'esperava ${_(e.values[0])}`
+					: `Opci\xF3 inv\xE0lida: s'esperava una de ${f(e.values, " o ")}`
+			case "too_big": {
+				const o = e.inclusive ? "com a m\xE0xim" : "menys de",
+					a = r(e.origin)
+				return a
+					? `Massa gran: s'esperava que ${e.origin ?? "el valor"} contingu\xE9s ${o} ${e.maximum.toString()} ${a.unit ?? "elements"}`
+					: `Massa gran: s'esperava que ${e.origin ?? "el valor"} fos ${o} ${e.maximum.toString()}`
+			}
+			case "too_small": {
+				const o = e.inclusive ? "com a m\xEDnim" : "m\xE9s de",
+					a = r(e.origin)
+				return a
+					? `Massa petit: s'esperava que ${e.origin} contingu\xE9s ${o} ${e.minimum.toString()} ${a.unit}`
+					: `Massa petit: s'esperava que ${e.origin} fos ${o} ${e.minimum.toString()}`
+			}
+			case "invalid_format": {
+				const o = e
+				return o.format === "starts_with"
+					? `Format inv\xE0lid: ha de comen\xE7ar amb "${o.prefix}"`
+					: o.format === "ends_with"
+						? `Format inv\xE0lid: ha d'acabar amb "${o.suffix}"`
+						: o.format === "includes"
+							? `Format inv\xE0lid: ha d'incloure "${o.includes}"`
+							: o.format === "regex"
+								? `Format inv\xE0lid: ha de coincidir amb el patr\xF3 ${o.pattern}`
+								: `Format inv\xE0lid per a ${i[o.format] ?? e.format}`
+			}
+			case "not_multiple_of":
+				return `N\xFAmero inv\xE0lid: ha de ser m\xFAltiple de ${e.divisor}`
+			case "unrecognized_keys":
+				return `Clau${e.keys.length > 1 ? "s" : ""} no reconeguda${e.keys.length > 1 ? "s" : ""}: ${f(e.keys, ", ")}`
+			case "invalid_key":
+				return `Clau inv\xE0lida a ${e.origin}`
+			case "invalid_union":
+				return "Entrada inv\xE0lida"
+			case "invalid_element":
+				return `Element inv\xE0lid a ${e.origin}`
+			default:
+				return "Entrada inv\xE0lida"
+		}
+	}
+}
+function Xs() {
+	return { localeError: _l() }
+}
+var yl = () => {
+	const t = {
+		string: { unit: "znak\u016F", verb: "m\xEDt" },
+		file: { unit: "bajt\u016F", verb: "m\xEDt" },
+		array: { unit: "prvk\u016F", verb: "m\xEDt" },
+		set: { unit: "prvk\u016F", verb: "m\xEDt" },
+	}
+	function r(e) {
+		return t[e] ?? null
+	}
+	const n = (e) => {
+			const o = typeof e
+			switch (o) {
+				case "number":
+					return Number.isNaN(e) ? "NaN" : "\u010D\xEDslo"
+				case "string":
+					return "\u0159et\u011Bzec"
+				case "boolean":
+					return "boolean"
+				case "bigint":
+					return "bigint"
+				case "function":
+					return "funkce"
+				case "symbol":
+					return "symbol"
+				case "undefined":
+					return "undefined"
+				case "object": {
+					if (Array.isArray(e)) return "pole"
+					if (e === null) return "null"
+					if (Object.getPrototypeOf(e) !== Object.prototype && e.constructor) return e.constructor.name
+				}
+			}
+			return o
+		},
+		i = {
+			regex: "regul\xE1rn\xED v\xFDraz",
+			email: "e-mailov\xE1 adresa",
+			url: "URL",
+			emoji: "emoji",
+			uuid: "UUID",
+			uuidv4: "UUIDv4",
+			uuidv6: "UUIDv6",
+			nanoid: "nanoid",
+			guid: "GUID",
+			cuid: "cuid",
+			cuid2: "cuid2",
+			ulid: "ULID",
+			xid: "XID",
+			ksuid: "KSUID",
+			datetime: "datum a \u010Das ve form\xE1tu ISO",
+			date: "datum ve form\xE1tu ISO",
+			time: "\u010Das ve form\xE1tu ISO",
+			duration: "doba trv\xE1n\xED ISO",
+			ipv4: "IPv4 adresa",
+			ipv6: "IPv6 adresa",
+			cidrv4: "rozsah IPv4",
+			cidrv6: "rozsah IPv6",
+			base64: "\u0159et\u011Bzec zak\xF3dovan\xFD ve form\xE1tu base64",
+			base64url: "\u0159et\u011Bzec zak\xF3dovan\xFD ve form\xE1tu base64url",
+			json_string: "\u0159et\u011Bzec ve form\xE1tu JSON",
+			e164: "\u010D\xEDslo E.164",
+			jwt: "JWT",
+			template_literal: "vstup",
+		}
+	return (e) => {
+		switch (e.code) {
+			case "invalid_type":
+				return `Neplatn\xFD vstup: o\u010Dek\xE1v\xE1no ${e.expected}, obdr\u017Eeno ${n(e.input)}`
+			case "invalid_value":
+				return e.values.length === 1
+					? `Neplatn\xFD vstup: o\u010Dek\xE1v\xE1no ${_(e.values[0])}`
+					: `Neplatn\xE1 mo\u017Enost: o\u010Dek\xE1v\xE1na jedna z hodnot ${f(e.values, "|")}`
+			case "too_big": {
+				const o = e.inclusive ? "<=" : "<",
+					a = r(e.origin)
+				return a
+					? `Hodnota je p\u0159\xEDli\u0161 velk\xE1: ${e.origin ?? "hodnota"} mus\xED m\xEDt ${o}${e.maximum.toString()} ${a.unit ?? "prvk\u016F"}`
+					: `Hodnota je p\u0159\xEDli\u0161 velk\xE1: ${e.origin ?? "hodnota"} mus\xED b\xFDt ${o}${e.maximum.toString()}`
+			}
+			case "too_small": {
+				const o = e.inclusive ? ">=" : ">",
+					a = r(e.origin)
+				return a
+					? `Hodnota je p\u0159\xEDli\u0161 mal\xE1: ${e.origin ?? "hodnota"} mus\xED m\xEDt ${o}${e.minimum.toString()} ${a.unit ?? "prvk\u016F"}`
+					: `Hodnota je p\u0159\xEDli\u0161 mal\xE1: ${e.origin ?? "hodnota"} mus\xED b\xFDt ${o}${e.minimum.toString()}`
+			}
+			case "invalid_format": {
+				const o = e
+				return o.format === "starts_with"
+					? `Neplatn\xFD \u0159et\u011Bzec: mus\xED za\u010D\xEDnat na "${o.prefix}"`
+					: o.format === "ends_with"
+						? `Neplatn\xFD \u0159et\u011Bzec: mus\xED kon\u010Dit na "${o.suffix}"`
+						: o.format === "includes"
+							? `Neplatn\xFD \u0159et\u011Bzec: mus\xED obsahovat "${o.includes}"`
+							: o.format === "regex"
+								? `Neplatn\xFD \u0159et\u011Bzec: mus\xED odpov\xEDdat vzoru ${o.pattern}`
+								: `Neplatn\xFD form\xE1t ${i[o.format] ?? e.format}`
+			}
+			case "not_multiple_of":
+				return `Neplatn\xE9 \u010D\xEDslo: mus\xED b\xFDt n\xE1sobkem ${e.divisor}`
+			case "unrecognized_keys":
+				return `Nezn\xE1m\xE9 kl\xED\u010De: ${f(e.keys, ", ")}`
+			case "invalid_key":
+				return `Neplatn\xFD kl\xED\u010D v ${e.origin}`
+			case "invalid_union":
+				return "Neplatn\xFD vstup"
+			case "invalid_element":
+				return `Neplatn\xE1 hodnota v ${e.origin}`
+			default:
+				return "Neplatn\xFD vstup"
+		}
+	}
+}
+function Ys() {
+	return { localeError: yl() }
+}
+var $l = () => {
+	const t = {
+		string: { unit: "Zeichen", verb: "zu haben" },
+		file: { unit: "Bytes", verb: "zu haben" },
+		array: { unit: "Elemente", verb: "zu haben" },
+		set: { unit: "Elemente", verb: "zu haben" },
+	}
+	function r(e) {
+		return t[e] ?? null
+	}
+	const n = (e) => {
+			const o = typeof e
+			switch (o) {
+				case "number":
+					return Number.isNaN(e) ? "NaN" : "Zahl"
+				case "object": {
+					if (Array.isArray(e)) return "Array"
+					if (e === null) return "null"
+					if (Object.getPrototypeOf(e) !== Object.prototype && e.constructor) return e.constructor.name
+				}
+			}
+			return o
+		},
+		i = {
+			regex: "Eingabe",
+			email: "E-Mail-Adresse",
+			url: "URL",
+			emoji: "Emoji",
+			uuid: "UUID",
+			uuidv4: "UUIDv4",
+			uuidv6: "UUIDv6",
+			nanoid: "nanoid",
+			guid: "GUID",
+			cuid: "cuid",
+			cuid2: "cuid2",
+			ulid: "ULID",
+			xid: "XID",
+			ksuid: "KSUID",
+			datetime: "ISO-Datum und -Uhrzeit",
+			date: "ISO-Datum",
+			time: "ISO-Uhrzeit",
+			duration: "ISO-Dauer",
+			ipv4: "IPv4-Adresse",
+			ipv6: "IPv6-Adresse",
+			cidrv4: "IPv4-Bereich",
+			cidrv6: "IPv6-Bereich",
+			base64: "Base64-codierter String",
+			base64url: "Base64-URL-codierter String",
+			json_string: "JSON-String",
+			e164: "E.164-Nummer",
+			jwt: "JWT",
+			template_literal: "Eingabe",
+		}
+	return (e) => {
+		switch (e.code) {
+			case "invalid_type":
+				return `Ung\xFCltige Eingabe: erwartet ${e.expected}, erhalten ${n(e.input)}`
+			case "invalid_value":
+				return e.values.length === 1
+					? `Ung\xFCltige Eingabe: erwartet ${_(e.values[0])}`
+					: `Ung\xFCltige Option: erwartet eine von ${f(e.values, "|")}`
+			case "too_big": {
+				const o = e.inclusive ? "<=" : "<",
+					a = r(e.origin)
+				return a
+					? `Zu gro\xDF: erwartet, dass ${e.origin ?? "Wert"} ${o}${e.maximum.toString()} ${a.unit ?? "Elemente"} hat`
+					: `Zu gro\xDF: erwartet, dass ${e.origin ?? "Wert"} ${o}${e.maximum.toString()} ist`
+			}
+			case "too_small": {
+				const o = e.inclusive ? ">=" : ">",
+					a = r(e.origin)
+				return a
+					? `Zu klein: erwartet, dass ${e.origin} ${o}${e.minimum.toString()} ${a.unit} hat`
+					: `Zu klein: erwartet, dass ${e.origin} ${o}${e.minimum.toString()} ist`
+			}
+			case "invalid_format": {
+				const o = e
+				return o.format === "starts_with"
+					? `Ung\xFCltiger String: muss mit "${o.prefix}" beginnen`
+					: o.format === "ends_with"
+						? `Ung\xFCltiger String: muss mit "${o.suffix}" enden`
+						: o.format === "includes"
+							? `Ung\xFCltiger String: muss "${o.includes}" enthalten`
+							: o.format === "regex"
+								? `Ung\xFCltiger String: muss dem Muster ${o.pattern} entsprechen`
+								: `Ung\xFCltig: ${i[o.format] ?? e.format}`
+			}
+			case "not_multiple_of":
+				return `Ung\xFCltige Zahl: muss ein Vielfaches von ${e.divisor} sein`
+			case "unrecognized_keys":
+				return `${e.keys.length > 1 ? "Unbekannte Schl\xFCssel" : "Unbekannter Schl\xFCssel"}: ${f(e.keys, ", ")}`
+			case "invalid_key":
+				return `Ung\xFCltiger Schl\xFCssel in ${e.origin}`
+			case "invalid_union":
+				return "Ung\xFCltige Eingabe"
+			case "invalid_element":
+				return `Ung\xFCltiger Wert in ${e.origin}`
+			default:
+				return "Ung\xFCltige Eingabe"
+		}
+	}
+}
+function ec() {
+	return { localeError: $l() }
+}
+var xl = (t) => {
+		const r = typeof t
+		switch (r) {
+			case "number":
+				return Number.isNaN(t) ? "NaN" : "number"
+			case "object": {
+				if (Array.isArray(t)) return "array"
+				if (t === null) return "null"
+				if (Object.getPrototypeOf(t) !== Object.prototype && t.constructor) return t.constructor.name
+			}
+		}
+		return r
+	},
+	zl = () => {
+		const t = {
+			string: { unit: "characters", verb: "to have" },
+			file: { unit: "bytes", verb: "to have" },
+			array: { unit: "items", verb: "to have" },
+			set: { unit: "items", verb: "to have" },
+		}
+		function r(i) {
+			return t[i] ?? null
+		}
+		const n = {
+			regex: "input",
+			email: "email address",
+			url: "URL",
+			emoji: "emoji",
+			uuid: "UUID",
+			uuidv4: "UUIDv4",
+			uuidv6: "UUIDv6",
+			nanoid: "nanoid",
+			guid: "GUID",
+			cuid: "cuid",
+			cuid2: "cuid2",
+			ulid: "ULID",
+			xid: "XID",
+			ksuid: "KSUID",
+			datetime: "ISO datetime",
+			date: "ISO date",
+			time: "ISO time",
+			duration: "ISO duration",
+			ipv4: "IPv4 address",
+			ipv6: "IPv6 address",
+			cidrv4: "IPv4 range",
+			cidrv6: "IPv6 range",
+			base64: "base64-encoded string",
+			base64url: "base64url-encoded string",
+			json_string: "JSON string",
+			e164: "E.164 number",
+			jwt: "JWT",
+			template_literal: "input",
+		}
+		return (i) => {
+			switch (i.code) {
+				case "invalid_type":
+					return `Invalid input: expected ${i.expected}, received ${xl(i.input)}`
+				case "invalid_value":
+					return i.values.length === 1
+						? `Invalid input: expected ${_(i.values[0])}`
+						: `Invalid option: expected one of ${f(i.values, "|")}`
+				case "too_big": {
+					const e = i.inclusive ? "<=" : "<",
+						o = r(i.origin)
+					return o
+						? `Too big: expected ${i.origin ?? "value"} to have ${e}${i.maximum.toString()} ${o.unit ?? "elements"}`
+						: `Too big: expected ${i.origin ?? "value"} to be ${e}${i.maximum.toString()}`
+				}
+				case "too_small": {
+					const e = i.inclusive ? ">=" : ">",
+						o = r(i.origin)
+					return o
+						? `Too small: expected ${i.origin} to have ${e}${i.minimum.toString()} ${o.unit}`
+						: `Too small: expected ${i.origin} to be ${e}${i.minimum.toString()}`
+				}
+				case "invalid_format": {
+					const e = i
+					return e.format === "starts_with"
+						? `Invalid string: must start with "${e.prefix}"`
+						: e.format === "ends_with"
+							? `Invalid string: must end with "${e.suffix}"`
+							: e.format === "includes"
+								? `Invalid string: must include "${e.includes}"`
+								: e.format === "regex"
+									? `Invalid string: must match pattern ${e.pattern}`
+									: `Invalid ${n[e.format] ?? i.format}`
+				}
+				case "not_multiple_of":
+					return `Invalid number: must be a multiple of ${i.divisor}`
+				case "unrecognized_keys":
+					return `Unrecognized key${i.keys.length > 1 ? "s" : ""}: ${f(i.keys, ", ")}`
+				case "invalid_key":
+					return `Invalid key in ${i.origin}`
+				case "invalid_union":
+					return "Invalid input"
+				case "invalid_element":
+					return `Invalid value in ${i.origin}`
+				default:
+					return "Invalid input"
+			}
+		}
+	}
+function lr() {
+	return { localeError: zl() }
+}
+var kl = (t) => {
+		const r = typeof t
+		switch (r) {
+			case "number":
+				return Number.isNaN(t) ? "NaN" : "nombro"
+			case "object": {
+				if (Array.isArray(t)) return "tabelo"
+				if (t === null) return "senvalora"
+				if (Object.getPrototypeOf(t) !== Object.prototype && t.constructor) return t.constructor.name
+			}
+		}
+		return r
+	},
+	Sl = () => {
+		const t = {
+			string: { unit: "karaktrojn", verb: "havi" },
+			file: { unit: "bajtojn", verb: "havi" },
+			array: { unit: "elementojn", verb: "havi" },
+			set: { unit: "elementojn", verb: "havi" },
+		}
+		function r(i) {
+			return t[i] ?? null
+		}
+		const n = {
+			regex: "enigo",
+			email: "retadreso",
+			url: "URL",
+			emoji: "emo\u011Dio",
+			uuid: "UUID",
+			uuidv4: "UUIDv4",
+			uuidv6: "UUIDv6",
+			nanoid: "nanoid",
+			guid: "GUID",
+			cuid: "cuid",
+			cuid2: "cuid2",
+			ulid: "ULID",
+			xid: "XID",
+			ksuid: "KSUID",
+			datetime: "ISO-datotempo",
+			date: "ISO-dato",
+			time: "ISO-tempo",
+			duration: "ISO-da\u016Dro",
+			ipv4: "IPv4-adreso",
+			ipv6: "IPv6-adreso",
+			cidrv4: "IPv4-rango",
+			cidrv6: "IPv6-rango",
+			base64: "64-ume kodita karaktraro",
+			base64url: "URL-64-ume kodita karaktraro",
+			json_string: "JSON-karaktraro",
+			e164: "E.164-nombro",
+			jwt: "JWT",
+			template_literal: "enigo",
+		}
+		return (i) => {
+			switch (i.code) {
+				case "invalid_type":
+					return `Nevalida enigo: atendi\u011Dis ${i.expected}, ricevi\u011Dis ${kl(i.input)}`
+				case "invalid_value":
+					return i.values.length === 1
+						? `Nevalida enigo: atendi\u011Dis ${_(i.values[0])}`
+						: `Nevalida opcio: atendi\u011Dis unu el ${f(i.values, "|")}`
+				case "too_big": {
+					const e = i.inclusive ? "<=" : "<",
+						o = r(i.origin)
+					return o
+						? `Tro granda: atendi\u011Dis ke ${i.origin ?? "valoro"} havu ${e}${i.maximum.toString()} ${o.unit ?? "elementojn"}`
+						: `Tro granda: atendi\u011Dis ke ${i.origin ?? "valoro"} havu ${e}${i.maximum.toString()}`
+				}
+				case "too_small": {
+					const e = i.inclusive ? ">=" : ">",
+						o = r(i.origin)
+					return o
+						? `Tro malgranda: atendi\u011Dis ke ${i.origin} havu ${e}${i.minimum.toString()} ${o.unit}`
+						: `Tro malgranda: atendi\u011Dis ke ${i.origin} estu ${e}${i.minimum.toString()}`
+				}
+				case "invalid_format": {
+					const e = i
+					return e.format === "starts_with"
+						? `Nevalida karaktraro: devas komenci\u011Di per "${e.prefix}"`
+						: e.format === "ends_with"
+							? `Nevalida karaktraro: devas fini\u011Di per "${e.suffix}"`
+							: e.format === "includes"
+								? `Nevalida karaktraro: devas inkluzivi "${e.includes}"`
+								: e.format === "regex"
+									? `Nevalida karaktraro: devas kongrui kun la modelo ${e.pattern}`
+									: `Nevalida ${n[e.format] ?? i.format}`
+				}
+				case "not_multiple_of":
+					return `Nevalida nombro: devas esti oblo de ${i.divisor}`
+				case "unrecognized_keys":
+					return `Nekonata${i.keys.length > 1 ? "j" : ""} \u015Dlosilo${i.keys.length > 1 ? "j" : ""}: ${f(i.keys, ", ")}`
+				case "invalid_key":
+					return `Nevalida \u015Dlosilo en ${i.origin}`
+				case "invalid_union":
+					return "Nevalida enigo"
+				case "invalid_element":
+					return `Nevalida valoro en ${i.origin}`
+				default:
+					return "Nevalida enigo"
+			}
+		}
+	}
+function tc() {
+	return { localeError: Sl() }
+}
+var wl = () => {
+	const t = {
+		string: { unit: "caracteres", verb: "tener" },
+		file: { unit: "bytes", verb: "tener" },
+		array: { unit: "elementos", verb: "tener" },
+		set: { unit: "elementos", verb: "tener" },
+	}
+	function r(e) {
+		return t[e] ?? null
+	}
+	const n = (e) => {
+			const o = typeof e
+			switch (o) {
+				case "number":
+					return Number.isNaN(e) ? "NaN" : "n\xFAmero"
+				case "object": {
+					if (Array.isArray(e)) return "arreglo"
+					if (e === null) return "nulo"
+					if (Object.getPrototypeOf(e) !== Object.prototype) return e.constructor.name
+				}
+			}
+			return o
+		},
+		i = {
+			regex: "entrada",
+			email: "direcci\xF3n de correo electr\xF3nico",
+			url: "URL",
+			emoji: "emoji",
+			uuid: "UUID",
+			uuidv4: "UUIDv4",
+			uuidv6: "UUIDv6",
+			nanoid: "nanoid",
+			guid: "GUID",
+			cuid: "cuid",
+			cuid2: "cuid2",
+			ulid: "ULID",
+			xid: "XID",
+			ksuid: "KSUID",
+			datetime: "fecha y hora ISO",
+			date: "fecha ISO",
+			time: "hora ISO",
+			duration: "duraci\xF3n ISO",
+			ipv4: "direcci\xF3n IPv4",
+			ipv6: "direcci\xF3n IPv6",
+			cidrv4: "rango IPv4",
+			cidrv6: "rango IPv6",
+			base64: "cadena codificada en base64",
+			base64url: "URL codificada en base64",
+			json_string: "cadena JSON",
+			e164: "n\xFAmero E.164",
+			jwt: "JWT",
+			template_literal: "entrada",
+		}
+	return (e) => {
+		switch (e.code) {
+			case "invalid_type":
+				return `Entrada inv\xE1lida: se esperaba ${e.expected}, recibido ${n(e.input)}`
+			case "invalid_value":
+				return e.values.length === 1
+					? `Entrada inv\xE1lida: se esperaba ${_(e.values[0])}`
+					: `Opci\xF3n inv\xE1lida: se esperaba una de ${f(e.values, "|")}`
+			case "too_big": {
+				const o = e.inclusive ? "<=" : "<",
+					a = r(e.origin)
+				return a
+					? `Demasiado grande: se esperaba que ${e.origin ?? "valor"} tuviera ${o}${e.maximum.toString()} ${a.unit ?? "elementos"}`
+					: `Demasiado grande: se esperaba que ${e.origin ?? "valor"} fuera ${o}${e.maximum.toString()}`
+			}
+			case "too_small": {
+				const o = e.inclusive ? ">=" : ">",
+					a = r(e.origin)
+				return a
+					? `Demasiado peque\xF1o: se esperaba que ${e.origin} tuviera ${o}${e.minimum.toString()} ${a.unit}`
+					: `Demasiado peque\xF1o: se esperaba que ${e.origin} fuera ${o}${e.minimum.toString()}`
+			}
+			case "invalid_format": {
+				const o = e
+				return o.format === "starts_with"
+					? `Cadena inv\xE1lida: debe comenzar con "${o.prefix}"`
+					: o.format === "ends_with"
+						? `Cadena inv\xE1lida: debe terminar en "${o.suffix}"`
+						: o.format === "includes"
+							? `Cadena inv\xE1lida: debe incluir "${o.includes}"`
+							: o.format === "regex"
+								? `Cadena inv\xE1lida: debe coincidir con el patr\xF3n ${o.pattern}`
+								: `Inv\xE1lido ${i[o.format] ?? e.format}`
+			}
+			case "not_multiple_of":
+				return `N\xFAmero inv\xE1lido: debe ser m\xFAltiplo de ${e.divisor}`
+			case "unrecognized_keys":
+				return `Llave${e.keys.length > 1 ? "s" : ""} desconocida${e.keys.length > 1 ? "s" : ""}: ${f(e.keys, ", ")}`
+			case "invalid_key":
+				return `Llave inv\xE1lida en ${e.origin}`
+			case "invalid_union":
+				return "Entrada inv\xE1lida"
+			case "invalid_element":
+				return `Valor inv\xE1lido en ${e.origin}`
+			default:
+				return "Entrada inv\xE1lida"
+		}
+	}
+}
+function rc() {
+	return { localeError: wl() }
+}
+var Il = () => {
+	const t = {
+		string: {
+			unit: "\u06A9\u0627\u0631\u0627\u06A9\u062A\u0631",
+			verb: "\u062F\u0627\u0634\u062A\u0647 \u0628\u0627\u0634\u062F",
+		},
+		file: { unit: "\u0628\u0627\u06CC\u062A", verb: "\u062F\u0627\u0634\u062A\u0647 \u0628\u0627\u0634\u062F" },
+		array: { unit: "\u0622\u06CC\u062A\u0645", verb: "\u062F\u0627\u0634\u062A\u0647 \u0628\u0627\u0634\u062F" },
+		set: { unit: "\u0622\u06CC\u062A\u0645", verb: "\u062F\u0627\u0634\u062A\u0647 \u0628\u0627\u0634\u062F" },
+	}
+	function r(e) {
+		return t[e] ?? null
+	}
+	const n = (e) => {
+			const o = typeof e
+			switch (o) {
+				case "number":
+					return Number.isNaN(e) ? "NaN" : "\u0639\u062F\u062F"
+				case "object": {
+					if (Array.isArray(e)) return "\u0622\u0631\u0627\u06CC\u0647"
+					if (e === null) return "null"
+					if (Object.getPrototypeOf(e) !== Object.prototype && e.constructor) return e.constructor.name
+				}
+			}
+			return o
+		},
+		i = {
+			regex: "\u0648\u0631\u0648\u062F\u06CC",
+			email: "\u0622\u062F\u0631\u0633 \u0627\u06CC\u0645\u06CC\u0644",
+			url: "URL",
+			emoji: "\u0627\u06CC\u0645\u0648\u062C\u06CC",
+			uuid: "UUID",
+			uuidv4: "UUIDv4",
+			uuidv6: "UUIDv6",
+			nanoid: "nanoid",
+			guid: "GUID",
+			cuid: "cuid",
+			cuid2: "cuid2",
+			ulid: "ULID",
+			xid: "XID",
+			ksuid: "KSUID",
+			datetime: "\u062A\u0627\u0631\u06CC\u062E \u0648 \u0632\u0645\u0627\u0646 \u0627\u06CC\u0632\u0648",
+			date: "\u062A\u0627\u0631\u06CC\u062E \u0627\u06CC\u0632\u0648",
+			time: "\u0632\u0645\u0627\u0646 \u0627\u06CC\u0632\u0648",
+			duration: "\u0645\u062F\u062A \u0632\u0645\u0627\u0646 \u0627\u06CC\u0632\u0648",
+			ipv4: "IPv4 \u0622\u062F\u0631\u0633",
+			ipv6: "IPv6 \u0622\u062F\u0631\u0633",
+			cidrv4: "IPv4 \u062F\u0627\u0645\u0646\u0647",
+			cidrv6: "IPv6 \u062F\u0627\u0645\u0646\u0647",
+			base64: "base64-encoded \u0631\u0634\u062A\u0647",
+			base64url: "base64url-encoded \u0631\u0634\u062A\u0647",
+			json_string: "JSON \u0631\u0634\u062A\u0647",
+			e164: "E.164 \u0639\u062F\u062F",
+			jwt: "JWT",
+			template_literal: "\u0648\u0631\u0648\u062F\u06CC",
+		}
+	return (e) => {
+		switch (e.code) {
+			case "invalid_type":
+				return `\u0648\u0631\u0648\u062F\u06CC \u0646\u0627\u0645\u0639\u062A\u0628\u0631: \u0645\u06CC\u200C\u0628\u0627\u06CC\u0633\u062A ${e.expected} \u0645\u06CC\u200C\u0628\u0648\u062F\u060C ${n(e.input)} \u062F\u0631\u06CC\u0627\u0641\u062A \u0634\u062F`
+			case "invalid_value":
+				return e.values.length === 1
+					? `\u0648\u0631\u0648\u062F\u06CC \u0646\u0627\u0645\u0639\u062A\u0628\u0631: \u0645\u06CC\u200C\u0628\u0627\u06CC\u0633\u062A ${_(e.values[0])} \u0645\u06CC\u200C\u0628\u0648\u062F`
+					: `\u06AF\u0632\u06CC\u0646\u0647 \u0646\u0627\u0645\u0639\u062A\u0628\u0631: \u0645\u06CC\u200C\u0628\u0627\u06CC\u0633\u062A \u06CC\u06A9\u06CC \u0627\u0632 ${f(e.values, "|")} \u0645\u06CC\u200C\u0628\u0648\u062F`
+			case "too_big": {
+				const o = e.inclusive ? "<=" : "<",
+					a = r(e.origin)
+				return a
+					? `\u062E\u06CC\u0644\u06CC \u0628\u0632\u0631\u06AF: ${e.origin ?? "\u0645\u0642\u062F\u0627\u0631"} \u0628\u0627\u06CC\u062F ${o}${e.maximum.toString()} ${a.unit ?? "\u0639\u0646\u0635\u0631"} \u0628\u0627\u0634\u062F`
+					: `\u062E\u06CC\u0644\u06CC \u0628\u0632\u0631\u06AF: ${e.origin ?? "\u0645\u0642\u062F\u0627\u0631"} \u0628\u0627\u06CC\u062F ${o}${e.maximum.toString()} \u0628\u0627\u0634\u062F`
+			}
+			case "too_small": {
+				const o = e.inclusive ? ">=" : ">",
+					a = r(e.origin)
+				return a
+					? `\u062E\u06CC\u0644\u06CC \u06A9\u0648\u0686\u06A9: ${e.origin} \u0628\u0627\u06CC\u062F ${o}${e.minimum.toString()} ${a.unit} \u0628\u0627\u0634\u062F`
+					: `\u062E\u06CC\u0644\u06CC \u06A9\u0648\u0686\u06A9: ${e.origin} \u0628\u0627\u06CC\u062F ${o}${e.minimum.toString()} \u0628\u0627\u0634\u062F`
+			}
+			case "invalid_format": {
+				const o = e
+				return o.format === "starts_with"
+					? `\u0631\u0634\u062A\u0647 \u0646\u0627\u0645\u0639\u062A\u0628\u0631: \u0628\u0627\u06CC\u062F \u0628\u0627 "${o.prefix}" \u0634\u0631\u0648\u0639 \u0634\u0648\u062F`
+					: o.format === "ends_with"
+						? `\u0631\u0634\u062A\u0647 \u0646\u0627\u0645\u0639\u062A\u0628\u0631: \u0628\u0627\u06CC\u062F \u0628\u0627 "${o.suffix}" \u062A\u0645\u0627\u0645 \u0634\u0648\u062F`
+						: o.format === "includes"
+							? `\u0631\u0634\u062A\u0647 \u0646\u0627\u0645\u0639\u062A\u0628\u0631: \u0628\u0627\u06CC\u062F \u0634\u0627\u0645\u0644 "${o.includes}" \u0628\u0627\u0634\u062F`
+							: o.format === "regex"
+								? `\u0631\u0634\u062A\u0647 \u0646\u0627\u0645\u0639\u062A\u0628\u0631: \u0628\u0627\u06CC\u062F \u0628\u0627 \u0627\u0644\u06AF\u0648\u06CC ${o.pattern} \u0645\u0637\u0627\u0628\u0642\u062A \u062F\u0627\u0634\u062A\u0647 \u0628\u0627\u0634\u062F`
+								: `${i[o.format] ?? e.format} \u0646\u0627\u0645\u0639\u062A\u0628\u0631`
+			}
+			case "not_multiple_of":
+				return `\u0639\u062F\u062F \u0646\u0627\u0645\u0639\u062A\u0628\u0631: \u0628\u0627\u06CC\u062F \u0645\u0636\u0631\u0628 ${e.divisor} \u0628\u0627\u0634\u062F`
+			case "unrecognized_keys":
+				return `\u06A9\u0644\u06CC\u062F${e.keys.length > 1 ? "\u0647\u0627\u06CC" : ""} \u0646\u0627\u0634\u0646\u0627\u0633: ${f(e.keys, ", ")}`
+			case "invalid_key":
+				return `\u06A9\u0644\u06CC\u062F \u0646\u0627\u0634\u0646\u0627\u0633 \u062F\u0631 ${e.origin}`
+			case "invalid_union":
+				return "\u0648\u0631\u0648\u062F\u06CC \u0646\u0627\u0645\u0639\u062A\u0628\u0631"
+			case "invalid_element":
+				return `\u0645\u0642\u062F\u0627\u0631 \u0646\u0627\u0645\u0639\u062A\u0628\u0631 \u062F\u0631 ${e.origin}`
+			default:
+				return "\u0648\u0631\u0648\u062F\u06CC \u0646\u0627\u0645\u0639\u062A\u0628\u0631"
+		}
+	}
+}
+function nc() {
+	return { localeError: Il() }
+}
+var jl = () => {
+	const t = {
+		string: { unit: "merkki\xE4", subject: "merkkijonon" },
+		file: { unit: "tavua", subject: "tiedoston" },
+		array: { unit: "alkiota", subject: "listan" },
+		set: { unit: "alkiota", subject: "joukon" },
+		number: { unit: "", subject: "luvun" },
+		bigint: { unit: "", subject: "suuren kokonaisluvun" },
+		int: { unit: "", subject: "kokonaisluvun" },
+		date: { unit: "", subject: "p\xE4iv\xE4m\xE4\xE4r\xE4n" },
+	}
+	function r(e) {
+		return t[e] ?? null
+	}
+	const n = (e) => {
+			const o = typeof e
+			switch (o) {
+				case "number":
+					return Number.isNaN(e) ? "NaN" : "number"
+				case "object": {
+					if (Array.isArray(e)) return "array"
+					if (e === null) return "null"
+					if (Object.getPrototypeOf(e) !== Object.prototype && e.constructor) return e.constructor.name
+				}
+			}
+			return o
+		},
+		i = {
+			regex: "s\xE4\xE4nn\xF6llinen lauseke",
+			email: "s\xE4hk\xF6postiosoite",
+			url: "URL-osoite",
+			emoji: "emoji",
+			uuid: "UUID",
+			uuidv4: "UUIDv4",
+			uuidv6: "UUIDv6",
+			nanoid: "nanoid",
+			guid: "GUID",
+			cuid: "cuid",
+			cuid2: "cuid2",
+			ulid: "ULID",
+			xid: "XID",
+			ksuid: "KSUID",
+			datetime: "ISO-aikaleima",
+			date: "ISO-p\xE4iv\xE4m\xE4\xE4r\xE4",
+			time: "ISO-aika",
+			duration: "ISO-kesto",
+			ipv4: "IPv4-osoite",
+			ipv6: "IPv6-osoite",
+			cidrv4: "IPv4-alue",
+			cidrv6: "IPv6-alue",
+			base64: "base64-koodattu merkkijono",
+			base64url: "base64url-koodattu merkkijono",
+			json_string: "JSON-merkkijono",
+			e164: "E.164-luku",
+			jwt: "JWT",
+			template_literal: "templaattimerkkijono",
+		}
+	return (e) => {
+		switch (e.code) {
+			case "invalid_type":
+				return `Virheellinen tyyppi: odotettiin ${e.expected}, oli ${n(e.input)}`
+			case "invalid_value":
+				return e.values.length === 1
+					? `Virheellinen sy\xF6te: t\xE4ytyy olla ${_(e.values[0])}`
+					: `Virheellinen valinta: t\xE4ytyy olla yksi seuraavista: ${f(e.values, "|")}`
+			case "too_big": {
+				const o = e.inclusive ? "<=" : "<",
+					a = r(e.origin)
+				return a
+					? `Liian suuri: ${a.subject} t\xE4ytyy olla ${o}${e.maximum.toString()} ${a.unit}`.trim()
+					: `Liian suuri: arvon t\xE4ytyy olla ${o}${e.maximum.toString()}`
+			}
+			case "too_small": {
+				const o = e.inclusive ? ">=" : ">",
+					a = r(e.origin)
+				return a
+					? `Liian pieni: ${a.subject} t\xE4ytyy olla ${o}${e.minimum.toString()} ${a.unit}`.trim()
+					: `Liian pieni: arvon t\xE4ytyy olla ${o}${e.minimum.toString()}`
+			}
+			case "invalid_format": {
+				const o = e
+				return o.format === "starts_with"
+					? `Virheellinen sy\xF6te: t\xE4ytyy alkaa "${o.prefix}"`
+					: o.format === "ends_with"
+						? `Virheellinen sy\xF6te: t\xE4ytyy loppua "${o.suffix}"`
+						: o.format === "includes"
+							? `Virheellinen sy\xF6te: t\xE4ytyy sis\xE4lt\xE4\xE4 "${o.includes}"`
+							: o.format === "regex"
+								? `Virheellinen sy\xF6te: t\xE4ytyy vastata s\xE4\xE4nn\xF6llist\xE4 lauseketta ${o.pattern}`
+								: `Virheellinen ${i[o.format] ?? e.format}`
+			}
+			case "not_multiple_of":
+				return `Virheellinen luku: t\xE4ytyy olla luvun ${e.divisor} monikerta`
+			case "unrecognized_keys":
+				return `${e.keys.length > 1 ? "Tuntemattomat avaimet" : "Tuntematon avain"}: ${f(e.keys, ", ")}`
+			case "invalid_key":
+				return "Virheellinen avain tietueessa"
+			case "invalid_union":
+				return "Virheellinen unioni"
+			case "invalid_element":
+				return "Virheellinen arvo joukossa"
+			default:
+				return "Virheellinen sy\xF6te"
+		}
+	}
+}
+function oc() {
+	return { localeError: jl() }
+}
+var Pl = () => {
+	const t = {
+		string: { unit: "caract\xE8res", verb: "avoir" },
+		file: { unit: "octets", verb: "avoir" },
+		array: { unit: "\xE9l\xE9ments", verb: "avoir" },
+		set: { unit: "\xE9l\xE9ments", verb: "avoir" },
+	}
+	function r(e) {
+		return t[e] ?? null
+	}
+	const n = (e) => {
+			const o = typeof e
+			switch (o) {
+				case "number":
+					return Number.isNaN(e) ? "NaN" : "nombre"
+				case "object": {
+					if (Array.isArray(e)) return "tableau"
+					if (e === null) return "null"
+					if (Object.getPrototypeOf(e) !== Object.prototype && e.constructor) return e.constructor.name
+				}
+			}
+			return o
+		},
+		i = {
+			regex: "entr\xE9e",
+			email: "adresse e-mail",
+			url: "URL",
+			emoji: "emoji",
+			uuid: "UUID",
+			uuidv4: "UUIDv4",
+			uuidv6: "UUIDv6",
+			nanoid: "nanoid",
+			guid: "GUID",
+			cuid: "cuid",
+			cuid2: "cuid2",
+			ulid: "ULID",
+			xid: "XID",
+			ksuid: "KSUID",
+			datetime: "date et heure ISO",
+			date: "date ISO",
+			time: "heure ISO",
+			duration: "dur\xE9e ISO",
+			ipv4: "adresse IPv4",
+			ipv6: "adresse IPv6",
+			cidrv4: "plage IPv4",
+			cidrv6: "plage IPv6",
+			base64: "cha\xEEne encod\xE9e en base64",
+			base64url: "cha\xEEne encod\xE9e en base64url",
+			json_string: "cha\xEEne JSON",
+			e164: "num\xE9ro E.164",
+			jwt: "JWT",
+			template_literal: "entr\xE9e",
+		}
+	return (e) => {
+		switch (e.code) {
+			case "invalid_type":
+				return `Entr\xE9e invalide : ${e.expected} attendu, ${n(e.input)} re\xE7u`
+			case "invalid_value":
+				return e.values.length === 1
+					? `Entr\xE9e invalide : ${_(e.values[0])} attendu`
+					: `Option invalide : une valeur parmi ${f(e.values, "|")} attendue`
+			case "too_big": {
+				const o = e.inclusive ? "<=" : "<",
+					a = r(e.origin)
+				return a
+					? `Trop grand : ${e.origin ?? "valeur"} doit ${a.verb} ${o}${e.maximum.toString()} ${a.unit ?? "\xE9l\xE9ment(s)"}`
+					: `Trop grand : ${e.origin ?? "valeur"} doit \xEAtre ${o}${e.maximum.toString()}`
+			}
+			case "too_small": {
+				const o = e.inclusive ? ">=" : ">",
+					a = r(e.origin)
+				return a
+					? `Trop petit : ${e.origin} doit ${a.verb} ${o}${e.minimum.toString()} ${a.unit}`
+					: `Trop petit : ${e.origin} doit \xEAtre ${o}${e.minimum.toString()}`
+			}
+			case "invalid_format": {
+				const o = e
+				return o.format === "starts_with"
+					? `Cha\xEEne invalide : doit commencer par "${o.prefix}"`
+					: o.format === "ends_with"
+						? `Cha\xEEne invalide : doit se terminer par "${o.suffix}"`
+						: o.format === "includes"
+							? `Cha\xEEne invalide : doit inclure "${o.includes}"`
+							: o.format === "regex"
+								? `Cha\xEEne invalide : doit correspondre au mod\xE8le ${o.pattern}`
+								: `${i[o.format] ?? e.format} invalide`
+			}
+			case "not_multiple_of":
+				return `Nombre invalide : doit \xEAtre un multiple de ${e.divisor}`
+			case "unrecognized_keys":
+				return `Cl\xE9${e.keys.length > 1 ? "s" : ""} non reconnue${e.keys.length > 1 ? "s" : ""} : ${f(e.keys, ", ")}`
+			case "invalid_key":
+				return `Cl\xE9 invalide dans ${e.origin}`
+			case "invalid_union":
+				return "Entr\xE9e invalide"
+			case "invalid_element":
+				return `Valeur invalide dans ${e.origin}`
+			default:
+				return "Entr\xE9e invalide"
+		}
+	}
+}
+function ic() {
+	return { localeError: Pl() }
+}
+var Tl = () => {
+	const t = {
+		string: { unit: "caract\xE8res", verb: "avoir" },
+		file: { unit: "octets", verb: "avoir" },
+		array: { unit: "\xE9l\xE9ments", verb: "avoir" },
+		set: { unit: "\xE9l\xE9ments", verb: "avoir" },
+	}
+	function r(e) {
+		return t[e] ?? null
+	}
+	const n = (e) => {
+			const o = typeof e
+			switch (o) {
+				case "number":
+					return Number.isNaN(e) ? "NaN" : "number"
+				case "object": {
+					if (Array.isArray(e)) return "array"
+					if (e === null) return "null"
+					if (Object.getPrototypeOf(e) !== Object.prototype && e.constructor) return e.constructor.name
+				}
+			}
+			return o
+		},
+		i = {
+			regex: "entr\xE9e",
+			email: "adresse courriel",
+			url: "URL",
+			emoji: "emoji",
+			uuid: "UUID",
+			uuidv4: "UUIDv4",
+			uuidv6: "UUIDv6",
+			nanoid: "nanoid",
+			guid: "GUID",
+			cuid: "cuid",
+			cuid2: "cuid2",
+			ulid: "ULID",
+			xid: "XID",
+			ksuid: "KSUID",
+			datetime: "date-heure ISO",
+			date: "date ISO",
+			time: "heure ISO",
+			duration: "dur\xE9e ISO",
+			ipv4: "adresse IPv4",
+			ipv6: "adresse IPv6",
+			cidrv4: "plage IPv4",
+			cidrv6: "plage IPv6",
+			base64: "cha\xEEne encod\xE9e en base64",
+			base64url: "cha\xEEne encod\xE9e en base64url",
+			json_string: "cha\xEEne JSON",
+			e164: "num\xE9ro E.164",
+			jwt: "JWT",
+			template_literal: "entr\xE9e",
+		}
+	return (e) => {
+		switch (e.code) {
+			case "invalid_type":
+				return `Entr\xE9e invalide : attendu ${e.expected}, re\xE7u ${n(e.input)}`
+			case "invalid_value":
+				return e.values.length === 1
+					? `Entr\xE9e invalide : attendu ${_(e.values[0])}`
+					: `Option invalide : attendu l'une des valeurs suivantes ${f(e.values, "|")}`
+			case "too_big": {
+				const o = e.inclusive ? "\u2264" : "<",
+					a = r(e.origin)
+				return a
+					? `Trop grand : attendu que ${e.origin ?? "la valeur"} ait ${o}${e.maximum.toString()} ${a.unit}`
+					: `Trop grand : attendu que ${e.origin ?? "la valeur"} soit ${o}${e.maximum.toString()}`
+			}
+			case "too_small": {
+				const o = e.inclusive ? "\u2265" : ">",
+					a = r(e.origin)
+				return a
+					? `Trop petit : attendu que ${e.origin} ait ${o}${e.minimum.toString()} ${a.unit}`
+					: `Trop petit : attendu que ${e.origin} soit ${o}${e.minimum.toString()}`
+			}
+			case "invalid_format": {
+				const o = e
+				return o.format === "starts_with"
+					? `Cha\xEEne invalide : doit commencer par "${o.prefix}"`
+					: o.format === "ends_with"
+						? `Cha\xEEne invalide : doit se terminer par "${o.suffix}"`
+						: o.format === "includes"
+							? `Cha\xEEne invalide : doit inclure "${o.includes}"`
+							: o.format === "regex"
+								? `Cha\xEEne invalide : doit correspondre au motif ${o.pattern}`
+								: `${i[o.format] ?? e.format} invalide`
+			}
+			case "not_multiple_of":
+				return `Nombre invalide : doit \xEAtre un multiple de ${e.divisor}`
+			case "unrecognized_keys":
+				return `Cl\xE9${e.keys.length > 1 ? "s" : ""} non reconnue${e.keys.length > 1 ? "s" : ""} : ${f(e.keys, ", ")}`
+			case "invalid_key":
+				return `Cl\xE9 invalide dans ${e.origin}`
+			case "invalid_union":
+				return "Entr\xE9e invalide"
+			case "invalid_element":
+				return `Valeur invalide dans ${e.origin}`
+			default:
+				return "Entr\xE9e invalide"
+		}
+	}
+}
+function ac() {
+	return { localeError: Tl() }
+}
+var Ol = () => {
+	const t = {
+		string: { unit: "\u05D0\u05D5\u05EA\u05D9\u05D5\u05EA", verb: "\u05DC\u05DB\u05DC\u05D5\u05DC" },
+		file: { unit: "\u05D1\u05D9\u05D9\u05D8\u05D9\u05DD", verb: "\u05DC\u05DB\u05DC\u05D5\u05DC" },
+		array: { unit: "\u05E4\u05E8\u05D9\u05D8\u05D9\u05DD", verb: "\u05DC\u05DB\u05DC\u05D5\u05DC" },
+		set: { unit: "\u05E4\u05E8\u05D9\u05D8\u05D9\u05DD", verb: "\u05DC\u05DB\u05DC\u05D5\u05DC" },
+	}
+	function r(e) {
+		return t[e] ?? null
+	}
+	const n = (e) => {
+			const o = typeof e
+			switch (o) {
+				case "number":
+					return Number.isNaN(e) ? "NaN" : "number"
+				case "object": {
+					if (Array.isArray(e)) return "array"
+					if (e === null) return "null"
+					if (Object.getPrototypeOf(e) !== Object.prototype && e.constructor) return e.constructor.name
+				}
+			}
+			return o
+		},
+		i = {
+			regex: "\u05E7\u05DC\u05D8",
+			email: "\u05DB\u05EA\u05D5\u05D1\u05EA \u05D0\u05D9\u05DE\u05D9\u05D9\u05DC",
+			url: "\u05DB\u05EA\u05D5\u05D1\u05EA \u05E8\u05E9\u05EA",
+			emoji: "\u05D0\u05D9\u05DE\u05D5\u05D2'\u05D9",
+			uuid: "UUID",
+			uuidv4: "UUIDv4",
+			uuidv6: "UUIDv6",
+			nanoid: "nanoid",
+			guid: "GUID",
+			cuid: "cuid",
+			cuid2: "cuid2",
+			ulid: "ULID",
+			xid: "XID",
+			ksuid: "KSUID",
+			datetime: "\u05EA\u05D0\u05E8\u05D9\u05DA \u05D5\u05D6\u05DE\u05DF ISO",
+			date: "\u05EA\u05D0\u05E8\u05D9\u05DA ISO",
+			time: "\u05D6\u05DE\u05DF ISO",
+			duration: "\u05DE\u05E9\u05DA \u05D6\u05DE\u05DF ISO",
+			ipv4: "\u05DB\u05EA\u05D5\u05D1\u05EA IPv4",
+			ipv6: "\u05DB\u05EA\u05D5\u05D1\u05EA IPv6",
+			cidrv4: "\u05D8\u05D5\u05D5\u05D7 IPv4",
+			cidrv6: "\u05D8\u05D5\u05D5\u05D7 IPv6",
+			base64: "\u05DE\u05D7\u05E8\u05D5\u05D6\u05EA \u05D1\u05D1\u05E1\u05D9\u05E1 64",
+			base64url:
+				"\u05DE\u05D7\u05E8\u05D5\u05D6\u05EA \u05D1\u05D1\u05E1\u05D9\u05E1 64 \u05DC\u05DB\u05EA\u05D5\u05D1\u05D5\u05EA \u05E8\u05E9\u05EA",
+			json_string: "\u05DE\u05D7\u05E8\u05D5\u05D6\u05EA JSON",
+			e164: "\u05DE\u05E1\u05E4\u05E8 E.164",
+			jwt: "JWT",
+			template_literal: "\u05E7\u05DC\u05D8",
+		}
+	return (e) => {
+		switch (e.code) {
+			case "invalid_type":
+				return `\u05E7\u05DC\u05D8 \u05DC\u05D0 \u05EA\u05E7\u05D9\u05DF: \u05E6\u05E8\u05D9\u05DA ${e.expected}, \u05D4\u05EA\u05E7\u05D1\u05DC ${n(e.input)}`
+			case "invalid_value":
+				return e.values.length === 1
+					? `\u05E7\u05DC\u05D8 \u05DC\u05D0 \u05EA\u05E7\u05D9\u05DF: \u05E6\u05E8\u05D9\u05DA ${_(e.values[0])}`
+					: `\u05E7\u05DC\u05D8 \u05DC\u05D0 \u05EA\u05E7\u05D9\u05DF: \u05E6\u05E8\u05D9\u05DA \u05D0\u05D7\u05EA \u05DE\u05D4\u05D0\u05E4\u05E9\u05E8\u05D5\u05D9\u05D5\u05EA  ${f(e.values, "|")}`
+			case "too_big": {
+				const o = e.inclusive ? "<=" : "<",
+					a = r(e.origin)
+				return a
+					? `\u05D2\u05D3\u05D5\u05DC \u05DE\u05D3\u05D9: ${e.origin ?? "value"} \u05E6\u05E8\u05D9\u05DA \u05DC\u05D4\u05D9\u05D5\u05EA ${o}${e.maximum.toString()} ${a.unit ?? "elements"}`
+					: `\u05D2\u05D3\u05D5\u05DC \u05DE\u05D3\u05D9: ${e.origin ?? "value"} \u05E6\u05E8\u05D9\u05DA \u05DC\u05D4\u05D9\u05D5\u05EA ${o}${e.maximum.toString()}`
+			}
+			case "too_small": {
+				const o = e.inclusive ? ">=" : ">",
+					a = r(e.origin)
+				return a
+					? `\u05E7\u05D8\u05DF \u05DE\u05D3\u05D9: ${e.origin} \u05E6\u05E8\u05D9\u05DA \u05DC\u05D4\u05D9\u05D5\u05EA ${o}${e.minimum.toString()} ${a.unit}`
+					: `\u05E7\u05D8\u05DF \u05DE\u05D3\u05D9: ${e.origin} \u05E6\u05E8\u05D9\u05DA \u05DC\u05D4\u05D9\u05D5\u05EA ${o}${e.minimum.toString()}`
+			}
+			case "invalid_format": {
+				const o = e
+				return o.format === "starts_with"
+					? `\u05DE\u05D7\u05E8\u05D5\u05D6\u05EA \u05DC\u05D0 \u05EA\u05E7\u05D9\u05E0\u05D4: \u05D7\u05D9\u05D9\u05D1\u05EA \u05DC\u05D4\u05EA\u05D7\u05D9\u05DC \u05D1"${o.prefix}"`
+					: o.format === "ends_with"
+						? `\u05DE\u05D7\u05E8\u05D5\u05D6\u05EA \u05DC\u05D0 \u05EA\u05E7\u05D9\u05E0\u05D4: \u05D7\u05D9\u05D9\u05D1\u05EA \u05DC\u05D4\u05E1\u05EA\u05D9\u05D9\u05DD \u05D1 "${o.suffix}"`
+						: o.format === "includes"
+							? `\u05DE\u05D7\u05E8\u05D5\u05D6\u05EA \u05DC\u05D0 \u05EA\u05E7\u05D9\u05E0\u05D4: \u05D7\u05D9\u05D9\u05D1\u05EA \u05DC\u05DB\u05DC\u05D5\u05DC "${o.includes}"`
+							: o.format === "regex"
+								? `\u05DE\u05D7\u05E8\u05D5\u05D6\u05EA \u05DC\u05D0 \u05EA\u05E7\u05D9\u05E0\u05D4: \u05D7\u05D9\u05D9\u05D1\u05EA \u05DC\u05D4\u05EA\u05D0\u05D9\u05DD \u05DC\u05EA\u05D1\u05E0\u05D9\u05EA ${o.pattern}`
+								: `${i[o.format] ?? e.format} \u05DC\u05D0 \u05EA\u05E7\u05D9\u05DF`
+			}
+			case "not_multiple_of":
+				return `\u05DE\u05E1\u05E4\u05E8 \u05DC\u05D0 \u05EA\u05E7\u05D9\u05DF: \u05D7\u05D9\u05D9\u05D1 \u05DC\u05D4\u05D9\u05D5\u05EA \u05DE\u05DB\u05E4\u05DC\u05D4 \u05E9\u05DC ${e.divisor}`
+			case "unrecognized_keys":
+				return `\u05DE\u05E4\u05EA\u05D7${e.keys.length > 1 ? "\u05D5\u05EA" : ""} \u05DC\u05D0 \u05DE\u05D6\u05D5\u05D4${e.keys.length > 1 ? "\u05D9\u05DD" : "\u05D4"}: ${f(e.keys, ", ")}`
+			case "invalid_key":
+				return `\u05DE\u05E4\u05EA\u05D7 \u05DC\u05D0 \u05EA\u05E7\u05D9\u05DF \u05D1${e.origin}`
+			case "invalid_union":
+				return "\u05E7\u05DC\u05D8 \u05DC\u05D0 \u05EA\u05E7\u05D9\u05DF"
+			case "invalid_element":
+				return `\u05E2\u05E8\u05DA \u05DC\u05D0 \u05EA\u05E7\u05D9\u05DF \u05D1${e.origin}`
+			default:
+				return "\u05E7\u05DC\u05D8 \u05DC\u05D0 \u05EA\u05E7\u05D9\u05DF"
+		}
+	}
+}
+function sc() {
+	return { localeError: Ol() }
+}
+var Nl = () => {
+	const t = {
+		string: { unit: "karakter", verb: "legyen" },
+		file: { unit: "byte", verb: "legyen" },
+		array: { unit: "elem", verb: "legyen" },
+		set: { unit: "elem", verb: "legyen" },
+	}
+	function r(e) {
+		return t[e] ?? null
+	}
+	const n = (e) => {
+			const o = typeof e
+			switch (o) {
+				case "number":
+					return Number.isNaN(e) ? "NaN" : "sz\xE1m"
+				case "object": {
+					if (Array.isArray(e)) return "t\xF6mb"
+					if (e === null) return "null"
+					if (Object.getPrototypeOf(e) !== Object.prototype && e.constructor) return e.constructor.name
+				}
+			}
+			return o
+		},
+		i = {
+			regex: "bemenet",
+			email: "email c\xEDm",
+			url: "URL",
+			emoji: "emoji",
+			uuid: "UUID",
+			uuidv4: "UUIDv4",
+			uuidv6: "UUIDv6",
+			nanoid: "nanoid",
+			guid: "GUID",
+			cuid: "cuid",
+			cuid2: "cuid2",
+			ulid: "ULID",
+			xid: "XID",
+			ksuid: "KSUID",
+			datetime: "ISO id\u0151b\xE9lyeg",
+			date: "ISO d\xE1tum",
+			time: "ISO id\u0151",
+			duration: "ISO id\u0151intervallum",
+			ipv4: "IPv4 c\xEDm",
+			ipv6: "IPv6 c\xEDm",
+			cidrv4: "IPv4 tartom\xE1ny",
+			cidrv6: "IPv6 tartom\xE1ny",
+			base64: "base64-k\xF3dolt string",
+			base64url: "base64url-k\xF3dolt string",
+			json_string: "JSON string",
+			e164: "E.164 sz\xE1m",
+			jwt: "JWT",
+			template_literal: "bemenet",
+		}
+	return (e) => {
+		switch (e.code) {
+			case "invalid_type":
+				return `\xC9rv\xE9nytelen bemenet: a v\xE1rt \xE9rt\xE9k ${e.expected}, a kapott \xE9rt\xE9k ${n(e.input)}`
+			case "invalid_value":
+				return e.values.length === 1
+					? `\xC9rv\xE9nytelen bemenet: a v\xE1rt \xE9rt\xE9k ${_(e.values[0])}`
+					: `\xC9rv\xE9nytelen opci\xF3: valamelyik \xE9rt\xE9k v\xE1rt ${f(e.values, "|")}`
+			case "too_big": {
+				const o = e.inclusive ? "<=" : "<",
+					a = r(e.origin)
+				return a
+					? `T\xFAl nagy: ${e.origin ?? "\xE9rt\xE9k"} m\xE9rete t\xFAl nagy ${o}${e.maximum.toString()} ${a.unit ?? "elem"}`
+					: `T\xFAl nagy: a bemeneti \xE9rt\xE9k ${e.origin ?? "\xE9rt\xE9k"} t\xFAl nagy: ${o}${e.maximum.toString()}`
+			}
+			case "too_small": {
+				const o = e.inclusive ? ">=" : ">",
+					a = r(e.origin)
+				return a
+					? `T\xFAl kicsi: a bemeneti \xE9rt\xE9k ${e.origin} m\xE9rete t\xFAl kicsi ${o}${e.minimum.toString()} ${a.unit}`
+					: `T\xFAl kicsi: a bemeneti \xE9rt\xE9k ${e.origin} t\xFAl kicsi ${o}${e.minimum.toString()}`
+			}
+			case "invalid_format": {
+				const o = e
+				return o.format === "starts_with"
+					? `\xC9rv\xE9nytelen string: "${o.prefix}" \xE9rt\xE9kkel kell kezd\u0151dnie`
+					: o.format === "ends_with"
+						? `\xC9rv\xE9nytelen string: "${o.suffix}" \xE9rt\xE9kkel kell v\xE9gz\u0151dnie`
+						: o.format === "includes"
+							? `\xC9rv\xE9nytelen string: "${o.includes}" \xE9rt\xE9ket kell tartalmaznia`
+							: o.format === "regex"
+								? `\xC9rv\xE9nytelen string: ${o.pattern} mint\xE1nak kell megfelelnie`
+								: `\xC9rv\xE9nytelen ${i[o.format] ?? e.format}`
+			}
+			case "not_multiple_of":
+				return `\xC9rv\xE9nytelen sz\xE1m: ${e.divisor} t\xF6bbsz\xF6r\xF6s\xE9nek kell lennie`
+			case "unrecognized_keys":
+				return `Ismeretlen kulcs${e.keys.length > 1 ? "s" : ""}: ${f(e.keys, ", ")}`
+			case "invalid_key":
+				return `\xC9rv\xE9nytelen kulcs ${e.origin}`
+			case "invalid_union":
+				return "\xC9rv\xE9nytelen bemenet"
+			case "invalid_element":
+				return `\xC9rv\xE9nytelen \xE9rt\xE9k: ${e.origin}`
+			default:
+				return "\xC9rv\xE9nytelen bemenet"
+		}
+	}
+}
+function cc() {
+	return { localeError: Nl() }
+}
+var Ul = () => {
+	const t = {
+		string: { unit: "karakter", verb: "memiliki" },
+		file: { unit: "byte", verb: "memiliki" },
+		array: { unit: "item", verb: "memiliki" },
+		set: { unit: "item", verb: "memiliki" },
+	}
+	function r(e) {
+		return t[e] ?? null
+	}
+	const n = (e) => {
+			const o = typeof e
+			switch (o) {
+				case "number":
+					return Number.isNaN(e) ? "NaN" : "number"
+				case "object": {
+					if (Array.isArray(e)) return "array"
+					if (e === null) return "null"
+					if (Object.getPrototypeOf(e) !== Object.prototype && e.constructor) return e.constructor.name
+				}
+			}
+			return o
+		},
+		i = {
+			regex: "input",
+			email: "alamat email",
+			url: "URL",
+			emoji: "emoji",
+			uuid: "UUID",
+			uuidv4: "UUIDv4",
+			uuidv6: "UUIDv6",
+			nanoid: "nanoid",
+			guid: "GUID",
+			cuid: "cuid",
+			cuid2: "cuid2",
+			ulid: "ULID",
+			xid: "XID",
+			ksuid: "KSUID",
+			datetime: "tanggal dan waktu format ISO",
+			date: "tanggal format ISO",
+			time: "jam format ISO",
+			duration: "durasi format ISO",
+			ipv4: "alamat IPv4",
+			ipv6: "alamat IPv6",
+			cidrv4: "rentang alamat IPv4",
+			cidrv6: "rentang alamat IPv6",
+			base64: "string dengan enkode base64",
+			base64url: "string dengan enkode base64url",
+			json_string: "string JSON",
+			e164: "angka E.164",
+			jwt: "JWT",
+			template_literal: "input",
+		}
+	return (e) => {
+		switch (e.code) {
+			case "invalid_type":
+				return `Input tidak valid: diharapkan ${e.expected}, diterima ${n(e.input)}`
+			case "invalid_value":
+				return e.values.length === 1
+					? `Input tidak valid: diharapkan ${_(e.values[0])}`
+					: `Pilihan tidak valid: diharapkan salah satu dari ${f(e.values, "|")}`
+			case "too_big": {
+				const o = e.inclusive ? "<=" : "<",
+					a = r(e.origin)
+				return a
+					? `Terlalu besar: diharapkan ${e.origin ?? "value"} memiliki ${o}${e.maximum.toString()} ${a.unit ?? "elemen"}`
+					: `Terlalu besar: diharapkan ${e.origin ?? "value"} menjadi ${o}${e.maximum.toString()}`
+			}
+			case "too_small": {
+				const o = e.inclusive ? ">=" : ">",
+					a = r(e.origin)
+				return a
+					? `Terlalu kecil: diharapkan ${e.origin} memiliki ${o}${e.minimum.toString()} ${a.unit}`
+					: `Terlalu kecil: diharapkan ${e.origin} menjadi ${o}${e.minimum.toString()}`
+			}
+			case "invalid_format": {
+				const o = e
+				return o.format === "starts_with"
+					? `String tidak valid: harus dimulai dengan "${o.prefix}"`
+					: o.format === "ends_with"
+						? `String tidak valid: harus berakhir dengan "${o.suffix}"`
+						: o.format === "includes"
+							? `String tidak valid: harus menyertakan "${o.includes}"`
+							: o.format === "regex"
+								? `String tidak valid: harus sesuai pola ${o.pattern}`
+								: `${i[o.format] ?? e.format} tidak valid`
+			}
+			case "not_multiple_of":
+				return `Angka tidak valid: harus kelipatan dari ${e.divisor}`
+			case "unrecognized_keys":
+				return `Kunci tidak dikenali ${e.keys.length > 1 ? "s" : ""}: ${f(e.keys, ", ")}`
+			case "invalid_key":
+				return `Kunci tidak valid di ${e.origin}`
+			case "invalid_union":
+				return "Input tidak valid"
+			case "invalid_element":
+				return `Nilai tidak valid di ${e.origin}`
+			default:
+				return "Input tidak valid"
+		}
+	}
+}
+function uc() {
+	return { localeError: Ul() }
+}
+var Zl = () => {
+	const t = {
+		string: { unit: "caratteri", verb: "avere" },
+		file: { unit: "byte", verb: "avere" },
+		array: { unit: "elementi", verb: "avere" },
+		set: { unit: "elementi", verb: "avere" },
+	}
+	function r(e) {
+		return t[e] ?? null
+	}
+	const n = (e) => {
+			const o = typeof e
+			switch (o) {
+				case "number":
+					return Number.isNaN(e) ? "NaN" : "numero"
+				case "object": {
+					if (Array.isArray(e)) return "vettore"
+					if (e === null) return "null"
+					if (Object.getPrototypeOf(e) !== Object.prototype && e.constructor) return e.constructor.name
+				}
+			}
+			return o
+		},
+		i = {
+			regex: "input",
+			email: "indirizzo email",
+			url: "URL",
+			emoji: "emoji",
+			uuid: "UUID",
+			uuidv4: "UUIDv4",
+			uuidv6: "UUIDv6",
+			nanoid: "nanoid",
+			guid: "GUID",
+			cuid: "cuid",
+			cuid2: "cuid2",
+			ulid: "ULID",
+			xid: "XID",
+			ksuid: "KSUID",
+			datetime: "data e ora ISO",
+			date: "data ISO",
+			time: "ora ISO",
+			duration: "durata ISO",
+			ipv4: "indirizzo IPv4",
+			ipv6: "indirizzo IPv6",
+			cidrv4: "intervallo IPv4",
+			cidrv6: "intervallo IPv6",
+			base64: "stringa codificata in base64",
+			base64url: "URL codificata in base64",
+			json_string: "stringa JSON",
+			e164: "numero E.164",
+			jwt: "JWT",
+			template_literal: "input",
+		}
+	return (e) => {
+		switch (e.code) {
+			case "invalid_type":
+				return `Input non valido: atteso ${e.expected}, ricevuto ${n(e.input)}`
+			case "invalid_value":
+				return e.values.length === 1
+					? `Input non valido: atteso ${_(e.values[0])}`
+					: `Opzione non valida: atteso uno tra ${f(e.values, "|")}`
+			case "too_big": {
+				const o = e.inclusive ? "<=" : "<",
+					a = r(e.origin)
+				return a
+					? `Troppo grande: ${e.origin ?? "valore"} deve avere ${o}${e.maximum.toString()} ${a.unit ?? "elementi"}`
+					: `Troppo grande: ${e.origin ?? "valore"} deve essere ${o}${e.maximum.toString()}`
+			}
+			case "too_small": {
+				const o = e.inclusive ? ">=" : ">",
+					a = r(e.origin)
+				return a
+					? `Troppo piccolo: ${e.origin} deve avere ${o}${e.minimum.toString()} ${a.unit}`
+					: `Troppo piccolo: ${e.origin} deve essere ${o}${e.minimum.toString()}`
+			}
+			case "invalid_format": {
+				const o = e
+				return o.format === "starts_with"
+					? `Stringa non valida: deve iniziare con "${o.prefix}"`
+					: o.format === "ends_with"
+						? `Stringa non valida: deve terminare con "${o.suffix}"`
+						: o.format === "includes"
+							? `Stringa non valida: deve includere "${o.includes}"`
+							: o.format === "regex"
+								? `Stringa non valida: deve corrispondere al pattern ${o.pattern}`
+								: `Invalid ${i[o.format] ?? e.format}`
+			}
+			case "not_multiple_of":
+				return `Numero non valido: deve essere un multiplo di ${e.divisor}`
+			case "unrecognized_keys":
+				return `Chiav${e.keys.length > 1 ? "i" : "e"} non riconosciut${e.keys.length > 1 ? "e" : "a"}: ${f(e.keys, ", ")}`
+			case "invalid_key":
+				return `Chiave non valida in ${e.origin}`
+			case "invalid_union":
+				return "Input non valido"
+			case "invalid_element":
+				return `Valore non valido in ${e.origin}`
+			default:
+				return "Input non valido"
+		}
+	}
+}
+function lc() {
+	return { localeError: Zl() }
+}
+var Dl = () => {
+	const t = {
+		string: { unit: "\u6587\u5B57", verb: "\u3067\u3042\u308B" },
+		file: { unit: "\u30D0\u30A4\u30C8", verb: "\u3067\u3042\u308B" },
+		array: { unit: "\u8981\u7D20", verb: "\u3067\u3042\u308B" },
+		set: { unit: "\u8981\u7D20", verb: "\u3067\u3042\u308B" },
+	}
+	function r(e) {
+		return t[e] ?? null
+	}
+	const n = (e) => {
+			const o = typeof e
+			switch (o) {
+				case "number":
+					return Number.isNaN(e) ? "NaN" : "\u6570\u5024"
+				case "object": {
+					if (Array.isArray(e)) return "\u914D\u5217"
+					if (e === null) return "null"
+					if (Object.getPrototypeOf(e) !== Object.prototype && e.constructor) return e.constructor.name
+				}
+			}
+			return o
+		},
+		i = {
+			regex: "\u5165\u529B\u5024",
+			email: "\u30E1\u30FC\u30EB\u30A2\u30C9\u30EC\u30B9",
+			url: "URL",
+			emoji: "\u7D75\u6587\u5B57",
+			uuid: "UUID",
+			uuidv4: "UUIDv4",
+			uuidv6: "UUIDv6",
+			nanoid: "nanoid",
+			guid: "GUID",
+			cuid: "cuid",
+			cuid2: "cuid2",
+			ulid: "ULID",
+			xid: "XID",
+			ksuid: "KSUID",
+			datetime: "ISO\u65E5\u6642",
+			date: "ISO\u65E5\u4ED8",
+			time: "ISO\u6642\u523B",
+			duration: "ISO\u671F\u9593",
+			ipv4: "IPv4\u30A2\u30C9\u30EC\u30B9",
+			ipv6: "IPv6\u30A2\u30C9\u30EC\u30B9",
+			cidrv4: "IPv4\u7BC4\u56F2",
+			cidrv6: "IPv6\u7BC4\u56F2",
+			base64: "base64\u30A8\u30F3\u30B3\u30FC\u30C9\u6587\u5B57\u5217",
+			base64url: "base64url\u30A8\u30F3\u30B3\u30FC\u30C9\u6587\u5B57\u5217",
+			json_string: "JSON\u6587\u5B57\u5217",
+			e164: "E.164\u756A\u53F7",
+			jwt: "JWT",
+			template_literal: "\u5165\u529B\u5024",
+		}
+	return (e) => {
+		switch (e.code) {
+			case "invalid_type":
+				return `\u7121\u52B9\u306A\u5165\u529B: ${e.expected}\u304C\u671F\u5F85\u3055\u308C\u307E\u3057\u305F\u304C\u3001${n(e.input)}\u304C\u5165\u529B\u3055\u308C\u307E\u3057\u305F`
+			case "invalid_value":
+				return e.values.length === 1
+					? `\u7121\u52B9\u306A\u5165\u529B: ${_(e.values[0])}\u304C\u671F\u5F85\u3055\u308C\u307E\u3057\u305F`
+					: `\u7121\u52B9\u306A\u9078\u629E: ${f(e.values, "\u3001")}\u306E\u3044\u305A\u308C\u304B\u3067\u3042\u308B\u5FC5\u8981\u304C\u3042\u308A\u307E\u3059`
+			case "too_big": {
+				const o = e.inclusive ? "\u4EE5\u4E0B\u3067\u3042\u308B" : "\u3088\u308A\u5C0F\u3055\u3044",
+					a = r(e.origin)
+				return a
+					? `\u5927\u304D\u3059\u304E\u308B\u5024: ${e.origin ?? "\u5024"}\u306F${e.maximum.toString()}${a.unit ?? "\u8981\u7D20"}${o}\u5FC5\u8981\u304C\u3042\u308A\u307E\u3059`
+					: `\u5927\u304D\u3059\u304E\u308B\u5024: ${e.origin ?? "\u5024"}\u306F${e.maximum.toString()}${o}\u5FC5\u8981\u304C\u3042\u308A\u307E\u3059`
+			}
+			case "too_small": {
+				const o = e.inclusive ? "\u4EE5\u4E0A\u3067\u3042\u308B" : "\u3088\u308A\u5927\u304D\u3044",
+					a = r(e.origin)
+				return a
+					? `\u5C0F\u3055\u3059\u304E\u308B\u5024: ${e.origin}\u306F${e.minimum.toString()}${a.unit}${o}\u5FC5\u8981\u304C\u3042\u308A\u307E\u3059`
+					: `\u5C0F\u3055\u3059\u304E\u308B\u5024: ${e.origin}\u306F${e.minimum.toString()}${o}\u5FC5\u8981\u304C\u3042\u308A\u307E\u3059`
+			}
+			case "invalid_format": {
+				const o = e
+				return o.format === "starts_with"
+					? `\u7121\u52B9\u306A\u6587\u5B57\u5217: "${o.prefix}"\u3067\u59CB\u307E\u308B\u5FC5\u8981\u304C\u3042\u308A\u307E\u3059`
+					: o.format === "ends_with"
+						? `\u7121\u52B9\u306A\u6587\u5B57\u5217: "${o.suffix}"\u3067\u7D42\u308F\u308B\u5FC5\u8981\u304C\u3042\u308A\u307E\u3059`
+						: o.format === "includes"
+							? `\u7121\u52B9\u306A\u6587\u5B57\u5217: "${o.includes}"\u3092\u542B\u3080\u5FC5\u8981\u304C\u3042\u308A\u307E\u3059`
+							: o.format === "regex"
+								? `\u7121\u52B9\u306A\u6587\u5B57\u5217: \u30D1\u30BF\u30FC\u30F3${o.pattern}\u306B\u4E00\u81F4\u3059\u308B\u5FC5\u8981\u304C\u3042\u308A\u307E\u3059`
+								: `\u7121\u52B9\u306A${i[o.format] ?? e.format}`
+			}
+			case "not_multiple_of":
+				return `\u7121\u52B9\u306A\u6570\u5024: ${e.divisor}\u306E\u500D\u6570\u3067\u3042\u308B\u5FC5\u8981\u304C\u3042\u308A\u307E\u3059`
+			case "unrecognized_keys":
+				return `\u8A8D\u8B58\u3055\u308C\u3066\u3044\u306A\u3044\u30AD\u30FC${e.keys.length > 1 ? "\u7FA4" : ""}: ${f(e.keys, "\u3001")}`
+			case "invalid_key":
+				return `${e.origin}\u5185\u306E\u7121\u52B9\u306A\u30AD\u30FC`
+			case "invalid_union":
+				return "\u7121\u52B9\u306A\u5165\u529B"
+			case "invalid_element":
+				return `${e.origin}\u5185\u306E\u7121\u52B9\u306A\u5024`
+			default:
+				return "\u7121\u52B9\u306A\u5165\u529B"
+		}
+	}
+}
+function mc() {
+	return { localeError: Dl() }
+}
+var Rl = () => {
+	const t = {
+		string: { unit: "\u178F\u17BD\u17A2\u1780\u17D2\u179F\u179A", verb: "\u1782\u17BD\u179A\u1798\u17B6\u1793" },
+		file: { unit: "\u1794\u17C3", verb: "\u1782\u17BD\u179A\u1798\u17B6\u1793" },
+		array: { unit: "\u1792\u17B6\u178F\u17BB", verb: "\u1782\u17BD\u179A\u1798\u17B6\u1793" },
+		set: { unit: "\u1792\u17B6\u178F\u17BB", verb: "\u1782\u17BD\u179A\u1798\u17B6\u1793" },
+	}
+	function r(e) {
+		return t[e] ?? null
+	}
+	const n = (e) => {
+			const o = typeof e
+			switch (o) {
+				case "number":
+					return Number.isNaN(e)
+						? "\u1798\u17B7\u1793\u1798\u17C2\u1793\u1787\u17B6\u179B\u17C1\u1781 (NaN)"
+						: "\u179B\u17C1\u1781"
+				case "object": {
+					if (Array.isArray(e)) return "\u17A2\u17B6\u179A\u17C1 (Array)"
+					if (e === null) return "\u1782\u17D2\u1798\u17B6\u1793\u178F\u1798\u17D2\u179B\u17C3 (null)"
+					if (Object.getPrototypeOf(e) !== Object.prototype && e.constructor) return e.constructor.name
+				}
+			}
+			return o
+		},
+		i = {
+			regex: "\u1791\u17B7\u1793\u17D2\u1793\u1793\u17D0\u1799\u1794\u1789\u17D2\u1785\u17BC\u179B",
+			email: "\u17A2\u17B6\u179F\u1799\u178A\u17D2\u178B\u17B6\u1793\u17A2\u17CA\u17B8\u1798\u17C2\u179B",
+			url: "URL",
+			emoji: "\u179F\u1789\u17D2\u1789\u17B6\u17A2\u17B6\u179A\u1798\u17D2\u1798\u178E\u17CD",
+			uuid: "UUID",
+			uuidv4: "UUIDv4",
+			uuidv6: "UUIDv6",
+			nanoid: "nanoid",
+			guid: "GUID",
+			cuid: "cuid",
+			cuid2: "cuid2",
+			ulid: "ULID",
+			xid: "XID",
+			ksuid: "KSUID",
+			datetime:
+				"\u1780\u17B6\u179B\u1794\u179A\u17B7\u1785\u17D2\u1786\u17C1\u1791 \u1793\u17B7\u1784\u1798\u17C9\u17C4\u1784 ISO",
+			date: "\u1780\u17B6\u179B\u1794\u179A\u17B7\u1785\u17D2\u1786\u17C1\u1791 ISO",
+			time: "\u1798\u17C9\u17C4\u1784 ISO",
+			duration: "\u179A\u1799\u17C8\u1796\u17C1\u179B ISO",
+			ipv4: "\u17A2\u17B6\u179F\u1799\u178A\u17D2\u178B\u17B6\u1793 IPv4",
+			ipv6: "\u17A2\u17B6\u179F\u1799\u178A\u17D2\u178B\u17B6\u1793 IPv6",
+			cidrv4: "\u178A\u17C2\u1793\u17A2\u17B6\u179F\u1799\u178A\u17D2\u178B\u17B6\u1793 IPv4",
+			cidrv6: "\u178A\u17C2\u1793\u17A2\u17B6\u179F\u1799\u178A\u17D2\u178B\u17B6\u1793 IPv6",
+			base64: "\u1781\u17D2\u179F\u17C2\u17A2\u1780\u17D2\u179F\u179A\u17A2\u17CA\u17B7\u1780\u17BC\u178A base64",
+			base64url: "\u1781\u17D2\u179F\u17C2\u17A2\u1780\u17D2\u179F\u179A\u17A2\u17CA\u17B7\u1780\u17BC\u178A base64url",
+			json_string: "\u1781\u17D2\u179F\u17C2\u17A2\u1780\u17D2\u179F\u179A JSON",
+			e164: "\u179B\u17C1\u1781 E.164",
+			jwt: "JWT",
+			template_literal: "\u1791\u17B7\u1793\u17D2\u1793\u1793\u17D0\u1799\u1794\u1789\u17D2\u1785\u17BC\u179B",
+		}
+	return (e) => {
+		switch (e.code) {
+			case "invalid_type":
+				return `\u1791\u17B7\u1793\u17D2\u1793\u1793\u17D0\u1799\u1794\u1789\u17D2\u1785\u17BC\u179B\u1798\u17B7\u1793\u178F\u17D2\u179A\u17B9\u1798\u178F\u17D2\u179A\u17BC\u179C\u17D6 \u178F\u17D2\u179A\u17BC\u179C\u1780\u17B6\u179A ${e.expected} \u1794\u17C9\u17BB\u1793\u17D2\u178F\u17C2\u1791\u1791\u17BD\u179B\u1794\u17B6\u1793 ${n(e.input)}`
+			case "invalid_value":
+				return e.values.length === 1
+					? `\u1791\u17B7\u1793\u17D2\u1793\u1793\u17D0\u1799\u1794\u1789\u17D2\u1785\u17BC\u179B\u1798\u17B7\u1793\u178F\u17D2\u179A\u17B9\u1798\u178F\u17D2\u179A\u17BC\u179C\u17D6 \u178F\u17D2\u179A\u17BC\u179C\u1780\u17B6\u179A ${_(e.values[0])}`
+					: `\u1787\u1798\u17D2\u179A\u17BE\u179F\u1798\u17B7\u1793\u178F\u17D2\u179A\u17B9\u1798\u178F\u17D2\u179A\u17BC\u179C\u17D6 \u178F\u17D2\u179A\u17BC\u179C\u1787\u17B6\u1798\u17BD\u1799\u1780\u17D2\u1793\u17BB\u1784\u1785\u17C6\u178E\u17C4\u1798 ${f(e.values, "|")}`
+			case "too_big": {
+				const o = e.inclusive ? "<=" : "<",
+					a = r(e.origin)
+				return a
+					? `\u1792\u17C6\u1796\u17C1\u1780\u17D6 \u178F\u17D2\u179A\u17BC\u179C\u1780\u17B6\u179A ${e.origin ?? "\u178F\u1798\u17D2\u179B\u17C3"} ${o} ${e.maximum.toString()} ${a.unit ?? "\u1792\u17B6\u178F\u17BB"}`
+					: `\u1792\u17C6\u1796\u17C1\u1780\u17D6 \u178F\u17D2\u179A\u17BC\u179C\u1780\u17B6\u179A ${e.origin ?? "\u178F\u1798\u17D2\u179B\u17C3"} ${o} ${e.maximum.toString()}`
+			}
+			case "too_small": {
+				const o = e.inclusive ? ">=" : ">",
+					a = r(e.origin)
+				return a
+					? `\u178F\u17BC\u1785\u1796\u17C1\u1780\u17D6 \u178F\u17D2\u179A\u17BC\u179C\u1780\u17B6\u179A ${e.origin} ${o} ${e.minimum.toString()} ${a.unit}`
+					: `\u178F\u17BC\u1785\u1796\u17C1\u1780\u17D6 \u178F\u17D2\u179A\u17BC\u179C\u1780\u17B6\u179A ${e.origin} ${o} ${e.minimum.toString()}`
+			}
+			case "invalid_format": {
+				const o = e
+				return o.format === "starts_with"
+					? `\u1781\u17D2\u179F\u17C2\u17A2\u1780\u17D2\u179F\u179A\u1798\u17B7\u1793\u178F\u17D2\u179A\u17B9\u1798\u178F\u17D2\u179A\u17BC\u179C\u17D6 \u178F\u17D2\u179A\u17BC\u179C\u1785\u17B6\u1794\u17CB\u1795\u17D2\u178F\u17BE\u1798\u178A\u17C4\u1799 "${o.prefix}"`
+					: o.format === "ends_with"
+						? `\u1781\u17D2\u179F\u17C2\u17A2\u1780\u17D2\u179F\u179A\u1798\u17B7\u1793\u178F\u17D2\u179A\u17B9\u1798\u178F\u17D2\u179A\u17BC\u179C\u17D6 \u178F\u17D2\u179A\u17BC\u179C\u1794\u1789\u17D2\u1785\u1794\u17CB\u178A\u17C4\u1799 "${o.suffix}"`
+						: o.format === "includes"
+							? `\u1781\u17D2\u179F\u17C2\u17A2\u1780\u17D2\u179F\u179A\u1798\u17B7\u1793\u178F\u17D2\u179A\u17B9\u1798\u178F\u17D2\u179A\u17BC\u179C\u17D6 \u178F\u17D2\u179A\u17BC\u179C\u1798\u17B6\u1793 "${o.includes}"`
+							: o.format === "regex"
+								? `\u1781\u17D2\u179F\u17C2\u17A2\u1780\u17D2\u179F\u179A\u1798\u17B7\u1793\u178F\u17D2\u179A\u17B9\u1798\u178F\u17D2\u179A\u17BC\u179C\u17D6 \u178F\u17D2\u179A\u17BC\u179C\u178F\u17C2\u1795\u17D2\u1782\u17BC\u1795\u17D2\u1782\u1784\u1793\u17B9\u1784\u1791\u1798\u17D2\u179A\u1784\u17CB\u178A\u17C2\u179B\u1794\u17B6\u1793\u1780\u17C6\u178E\u178F\u17CB ${o.pattern}`
+								: `\u1798\u17B7\u1793\u178F\u17D2\u179A\u17B9\u1798\u178F\u17D2\u179A\u17BC\u179C\u17D6 ${i[o.format] ?? e.format}`
+			}
+			case "not_multiple_of":
+				return `\u179B\u17C1\u1781\u1798\u17B7\u1793\u178F\u17D2\u179A\u17B9\u1798\u178F\u17D2\u179A\u17BC\u179C\u17D6 \u178F\u17D2\u179A\u17BC\u179C\u178F\u17C2\u1787\u17B6\u1796\u17A0\u17BB\u1782\u17BB\u178E\u1793\u17C3 ${e.divisor}`
+			case "unrecognized_keys":
+				return `\u179A\u1780\u1783\u17BE\u1789\u179F\u17C4\u1798\u17B7\u1793\u179F\u17D2\u1782\u17B6\u179B\u17CB\u17D6 ${f(e.keys, ", ")}`
+			case "invalid_key":
+				return `\u179F\u17C4\u1798\u17B7\u1793\u178F\u17D2\u179A\u17B9\u1798\u178F\u17D2\u179A\u17BC\u179C\u1793\u17C5\u1780\u17D2\u1793\u17BB\u1784 ${e.origin}`
+			case "invalid_union":
+				return "\u1791\u17B7\u1793\u17D2\u1793\u1793\u17D0\u1799\u1798\u17B7\u1793\u178F\u17D2\u179A\u17B9\u1798\u178F\u17D2\u179A\u17BC\u179C"
+			case "invalid_element":
+				return `\u1791\u17B7\u1793\u17D2\u1793\u1793\u17D0\u1799\u1798\u17B7\u1793\u178F\u17D2\u179A\u17B9\u1798\u178F\u17D2\u179A\u17BC\u179C\u1793\u17C5\u1780\u17D2\u1793\u17BB\u1784 ${e.origin}`
+			default:
+				return "\u1791\u17B7\u1793\u17D2\u1793\u1793\u17D0\u1799\u1798\u17B7\u1793\u178F\u17D2\u179A\u17B9\u1798\u178F\u17D2\u179A\u17BC\u179C"
+		}
+	}
+}
+function pc() {
+	return { localeError: Rl() }
+}
+var El = () => {
+	const t = {
+		string: { unit: "\uBB38\uC790", verb: "to have" },
+		file: { unit: "\uBC14\uC774\uD2B8", verb: "to have" },
+		array: { unit: "\uAC1C", verb: "to have" },
+		set: { unit: "\uAC1C", verb: "to have" },
+	}
+	function r(e) {
+		return t[e] ?? null
+	}
+	const n = (e) => {
+			const o = typeof e
+			switch (o) {
+				case "number":
+					return Number.isNaN(e) ? "NaN" : "number"
+				case "object": {
+					if (Array.isArray(e)) return "array"
+					if (e === null) return "null"
+					if (Object.getPrototypeOf(e) !== Object.prototype && e.constructor) return e.constructor.name
+				}
+			}
+			return o
+		},
+		i = {
+			regex: "\uC785\uB825",
+			email: "\uC774\uBA54\uC77C \uC8FC\uC18C",
+			url: "URL",
+			emoji: "\uC774\uBAA8\uC9C0",
+			uuid: "UUID",
+			uuidv4: "UUIDv4",
+			uuidv6: "UUIDv6",
+			nanoid: "nanoid",
+			guid: "GUID",
+			cuid: "cuid",
+			cuid2: "cuid2",
+			ulid: "ULID",
+			xid: "XID",
+			ksuid: "KSUID",
+			datetime: "ISO \uB0A0\uC9DC\uC2DC\uAC04",
+			date: "ISO \uB0A0\uC9DC",
+			time: "ISO \uC2DC\uAC04",
+			duration: "ISO \uAE30\uAC04",
+			ipv4: "IPv4 \uC8FC\uC18C",
+			ipv6: "IPv6 \uC8FC\uC18C",
+			cidrv4: "IPv4 \uBC94\uC704",
+			cidrv6: "IPv6 \uBC94\uC704",
+			base64: "base64 \uC778\uCF54\uB529 \uBB38\uC790\uC5F4",
+			base64url: "base64url \uC778\uCF54\uB529 \uBB38\uC790\uC5F4",
+			json_string: "JSON \uBB38\uC790\uC5F4",
+			e164: "E.164 \uBC88\uD638",
+			jwt: "JWT",
+			template_literal: "\uC785\uB825",
+		}
+	return (e) => {
+		switch (e.code) {
+			case "invalid_type":
+				return `\uC798\uBABB\uB41C \uC785\uB825: \uC608\uC0C1 \uD0C0\uC785\uC740 ${e.expected}, \uBC1B\uC740 \uD0C0\uC785\uC740 ${n(e.input)}\uC785\uB2C8\uB2E4`
+			case "invalid_value":
+				return e.values.length === 1
+					? `\uC798\uBABB\uB41C \uC785\uB825: \uAC12\uC740 ${_(e.values[0])} \uC774\uC5B4\uC57C \uD569\uB2C8\uB2E4`
+					: `\uC798\uBABB\uB41C \uC635\uC158: ${f(e.values, "\uB610\uB294 ")} \uC911 \uD558\uB098\uC5EC\uC57C \uD569\uB2C8\uB2E4`
+			case "too_big": {
+				const o = e.inclusive ? "\uC774\uD558" : "\uBBF8\uB9CC",
+					a = o === "\uBBF8\uB9CC" ? "\uC774\uC5B4\uC57C \uD569\uB2C8\uB2E4" : "\uC5EC\uC57C \uD569\uB2C8\uB2E4",
+					c = r(e.origin),
+					p = c?.unit ?? "\uC694\uC18C"
+				return c
+					? `${e.origin ?? "\uAC12"}\uC774 \uB108\uBB34 \uD07D\uB2C8\uB2E4: ${e.maximum.toString()}${p} ${o}${a}`
+					: `${e.origin ?? "\uAC12"}\uC774 \uB108\uBB34 \uD07D\uB2C8\uB2E4: ${e.maximum.toString()} ${o}${a}`
+			}
+			case "too_small": {
+				const o = e.inclusive ? "\uC774\uC0C1" : "\uCD08\uACFC",
+					a = o === "\uC774\uC0C1" ? "\uC774\uC5B4\uC57C \uD569\uB2C8\uB2E4" : "\uC5EC\uC57C \uD569\uB2C8\uB2E4",
+					c = r(e.origin),
+					p = c?.unit ?? "\uC694\uC18C"
+				return c
+					? `${e.origin ?? "\uAC12"}\uC774 \uB108\uBB34 \uC791\uC2B5\uB2C8\uB2E4: ${e.minimum.toString()}${p} ${o}${a}`
+					: `${e.origin ?? "\uAC12"}\uC774 \uB108\uBB34 \uC791\uC2B5\uB2C8\uB2E4: ${e.minimum.toString()} ${o}${a}`
+			}
+			case "invalid_format": {
+				const o = e
+				return o.format === "starts_with"
+					? `\uC798\uBABB\uB41C \uBB38\uC790\uC5F4: "${o.prefix}"(\uC73C)\uB85C \uC2DC\uC791\uD574\uC57C \uD569\uB2C8\uB2E4`
+					: o.format === "ends_with"
+						? `\uC798\uBABB\uB41C \uBB38\uC790\uC5F4: "${o.suffix}"(\uC73C)\uB85C \uB05D\uB098\uC57C \uD569\uB2C8\uB2E4`
+						: o.format === "includes"
+							? `\uC798\uBABB\uB41C \uBB38\uC790\uC5F4: "${o.includes}"\uC744(\uB97C) \uD3EC\uD568\uD574\uC57C \uD569\uB2C8\uB2E4`
+							: o.format === "regex"
+								? `\uC798\uBABB\uB41C \uBB38\uC790\uC5F4: \uC815\uADDC\uC2DD ${o.pattern} \uD328\uD134\uACFC \uC77C\uCE58\uD574\uC57C \uD569\uB2C8\uB2E4`
+								: `\uC798\uBABB\uB41C ${i[o.format] ?? e.format}`
+			}
+			case "not_multiple_of":
+				return `\uC798\uBABB\uB41C \uC22B\uC790: ${e.divisor}\uC758 \uBC30\uC218\uC5EC\uC57C \uD569\uB2C8\uB2E4`
+			case "unrecognized_keys":
+				return `\uC778\uC2DD\uD560 \uC218 \uC5C6\uB294 \uD0A4: ${f(e.keys, ", ")}`
+			case "invalid_key":
+				return `\uC798\uBABB\uB41C \uD0A4: ${e.origin}`
+			case "invalid_union":
+				return "\uC798\uBABB\uB41C \uC785\uB825"
+			case "invalid_element":
+				return `\uC798\uBABB\uB41C \uAC12: ${e.origin}`
+			default:
+				return "\uC798\uBABB\uB41C \uC785\uB825"
+		}
+	}
+}
+function dc() {
+	return { localeError: El() }
+}
+var Al = () => {
+	const t = {
+		string: { unit: "\u0437\u043D\u0430\u0446\u0438", verb: "\u0434\u0430 \u0438\u043C\u0430\u0430\u0442" },
+		file: { unit: "\u0431\u0430\u0458\u0442\u0438", verb: "\u0434\u0430 \u0438\u043C\u0430\u0430\u0442" },
+		array: { unit: "\u0441\u0442\u0430\u0432\u043A\u0438", verb: "\u0434\u0430 \u0438\u043C\u0430\u0430\u0442" },
+		set: { unit: "\u0441\u0442\u0430\u0432\u043A\u0438", verb: "\u0434\u0430 \u0438\u043C\u0430\u0430\u0442" },
+	}
+	function r(e) {
+		return t[e] ?? null
+	}
+	const n = (e) => {
+			const o = typeof e
+			switch (o) {
+				case "number":
+					return Number.isNaN(e) ? "NaN" : "\u0431\u0440\u043E\u0458"
+				case "object": {
+					if (Array.isArray(e)) return "\u043D\u0438\u0437\u0430"
+					if (e === null) return "null"
+					if (Object.getPrototypeOf(e) !== Object.prototype && e.constructor) return e.constructor.name
+				}
+			}
+			return o
+		},
+		i = {
+			regex: "\u0432\u043D\u0435\u0441",
+			email: "\u0430\u0434\u0440\u0435\u0441\u0430 \u043D\u0430 \u0435-\u043F\u043E\u0448\u0442\u0430",
+			url: "URL",
+			emoji: "\u0435\u043C\u043E\u045F\u0438",
+			uuid: "UUID",
+			uuidv4: "UUIDv4",
+			uuidv6: "UUIDv6",
+			nanoid: "nanoid",
+			guid: "GUID",
+			cuid: "cuid",
+			cuid2: "cuid2",
+			ulid: "ULID",
+			xid: "XID",
+			ksuid: "KSUID",
+			datetime: "ISO \u0434\u0430\u0442\u0443\u043C \u0438 \u0432\u0440\u0435\u043C\u0435",
+			date: "ISO \u0434\u0430\u0442\u0443\u043C",
+			time: "ISO \u0432\u0440\u0435\u043C\u0435",
+			duration: "ISO \u0432\u0440\u0435\u043C\u0435\u0442\u0440\u0430\u0435\u045A\u0435",
+			ipv4: "IPv4 \u0430\u0434\u0440\u0435\u0441\u0430",
+			ipv6: "IPv6 \u0430\u0434\u0440\u0435\u0441\u0430",
+			cidrv4: "IPv4 \u043E\u043F\u0441\u0435\u0433",
+			cidrv6: "IPv6 \u043E\u043F\u0441\u0435\u0433",
+			base64: "base64-\u0435\u043D\u043A\u043E\u0434\u0438\u0440\u0430\u043D\u0430 \u043D\u0438\u0437\u0430",
+			base64url: "base64url-\u0435\u043D\u043A\u043E\u0434\u0438\u0440\u0430\u043D\u0430 \u043D\u0438\u0437\u0430",
+			json_string: "JSON \u043D\u0438\u0437\u0430",
+			e164: "E.164 \u0431\u0440\u043E\u0458",
+			jwt: "JWT",
+			template_literal: "\u0432\u043D\u0435\u0441",
+		}
+	return (e) => {
+		switch (e.code) {
+			case "invalid_type":
+				return `\u0413\u0440\u0435\u0448\u0435\u043D \u0432\u043D\u0435\u0441: \u0441\u0435 \u043E\u0447\u0435\u043A\u0443\u0432\u0430 ${e.expected}, \u043F\u0440\u0438\u043C\u0435\u043D\u043E ${n(e.input)}`
+			case "invalid_value":
+				return e.values.length === 1
+					? `Invalid input: expected ${_(e.values[0])}`
+					: `\u0413\u0440\u0435\u0448\u0430\u043D\u0430 \u043E\u043F\u0446\u0438\u0458\u0430: \u0441\u0435 \u043E\u0447\u0435\u043A\u0443\u0432\u0430 \u0435\u0434\u043D\u0430 ${f(e.values, "|")}`
+			case "too_big": {
+				const o = e.inclusive ? "<=" : "<",
+					a = r(e.origin)
+				return a
+					? `\u041F\u0440\u0435\u043C\u043D\u043E\u0433\u0443 \u0433\u043E\u043B\u0435\u043C: \u0441\u0435 \u043E\u0447\u0435\u043A\u0443\u0432\u0430 ${e.origin ?? "\u0432\u0440\u0435\u0434\u043D\u043E\u0441\u0442\u0430"} \u0434\u0430 \u0438\u043C\u0430 ${o}${e.maximum.toString()} ${a.unit ?? "\u0435\u043B\u0435\u043C\u0435\u043D\u0442\u0438"}`
+					: `\u041F\u0440\u0435\u043C\u043D\u043E\u0433\u0443 \u0433\u043E\u043B\u0435\u043C: \u0441\u0435 \u043E\u0447\u0435\u043A\u0443\u0432\u0430 ${e.origin ?? "\u0432\u0440\u0435\u0434\u043D\u043E\u0441\u0442\u0430"} \u0434\u0430 \u0431\u0438\u0434\u0435 ${o}${e.maximum.toString()}`
+			}
+			case "too_small": {
+				const o = e.inclusive ? ">=" : ">",
+					a = r(e.origin)
+				return a
+					? `\u041F\u0440\u0435\u043C\u043D\u043E\u0433\u0443 \u043C\u0430\u043B: \u0441\u0435 \u043E\u0447\u0435\u043A\u0443\u0432\u0430 ${e.origin} \u0434\u0430 \u0438\u043C\u0430 ${o}${e.minimum.toString()} ${a.unit}`
+					: `\u041F\u0440\u0435\u043C\u043D\u043E\u0433\u0443 \u043C\u0430\u043B: \u0441\u0435 \u043E\u0447\u0435\u043A\u0443\u0432\u0430 ${e.origin} \u0434\u0430 \u0431\u0438\u0434\u0435 ${o}${e.minimum.toString()}`
+			}
+			case "invalid_format": {
+				const o = e
+				return o.format === "starts_with"
+					? `\u041D\u0435\u0432\u0430\u0436\u0435\u0447\u043A\u0430 \u043D\u0438\u0437\u0430: \u043C\u043E\u0440\u0430 \u0434\u0430 \u0437\u0430\u043F\u043E\u0447\u043D\u0443\u0432\u0430 \u0441\u043E "${o.prefix}"`
+					: o.format === "ends_with"
+						? `\u041D\u0435\u0432\u0430\u0436\u0435\u0447\u043A\u0430 \u043D\u0438\u0437\u0430: \u043C\u043E\u0440\u0430 \u0434\u0430 \u0437\u0430\u0432\u0440\u0448\u0443\u0432\u0430 \u0441\u043E "${o.suffix}"`
+						: o.format === "includes"
+							? `\u041D\u0435\u0432\u0430\u0436\u0435\u0447\u043A\u0430 \u043D\u0438\u0437\u0430: \u043C\u043E\u0440\u0430 \u0434\u0430 \u0432\u043A\u043B\u0443\u0447\u0443\u0432\u0430 "${o.includes}"`
+							: o.format === "regex"
+								? `\u041D\u0435\u0432\u0430\u0436\u0435\u0447\u043A\u0430 \u043D\u0438\u0437\u0430: \u043C\u043E\u0440\u0430 \u0434\u0430 \u043E\u0434\u0433\u043E\u0430\u0440\u0430 \u043D\u0430 \u043F\u0430\u0442\u0435\u0440\u043D\u043E\u0442 ${o.pattern}`
+								: `Invalid ${i[o.format] ?? e.format}`
+			}
+			case "not_multiple_of":
+				return `\u0413\u0440\u0435\u0448\u0435\u043D \u0431\u0440\u043E\u0458: \u043C\u043E\u0440\u0430 \u0434\u0430 \u0431\u0438\u0434\u0435 \u0434\u0435\u043B\u0438\u0432 \u0441\u043E ${e.divisor}`
+			case "unrecognized_keys":
+				return `${e.keys.length > 1 ? "\u041D\u0435\u043F\u0440\u0435\u043F\u043E\u0437\u043D\u0430\u0435\u043D\u0438 \u043A\u043B\u0443\u0447\u0435\u0432\u0438" : "\u041D\u0435\u043F\u0440\u0435\u043F\u043E\u0437\u043D\u0430\u0435\u043D \u043A\u043B\u0443\u0447"}: ${f(e.keys, ", ")}`
+			case "invalid_key":
+				return `\u0413\u0440\u0435\u0448\u0435\u043D \u043A\u043B\u0443\u0447 \u0432\u043E ${e.origin}`
+			case "invalid_union":
+				return "\u0413\u0440\u0435\u0448\u0435\u043D \u0432\u043D\u0435\u0441"
+			case "invalid_element":
+				return `\u0413\u0440\u0435\u0448\u043D\u0430 \u0432\u0440\u0435\u0434\u043D\u043E\u0441\u0442 \u0432\u043E ${e.origin}`
+			default:
+				return "\u0413\u0440\u0435\u0448\u0435\u043D \u0432\u043D\u0435\u0441"
+		}
+	}
+}
+function fc() {
+	return { localeError: Al() }
+}
+var Cl = () => {
+	const t = {
+		string: { unit: "aksara", verb: "mempunyai" },
+		file: { unit: "bait", verb: "mempunyai" },
+		array: { unit: "elemen", verb: "mempunyai" },
+		set: { unit: "elemen", verb: "mempunyai" },
+	}
+	function r(e) {
+		return t[e] ?? null
+	}
+	const n = (e) => {
+			const o = typeof e
+			switch (o) {
+				case "number":
+					return Number.isNaN(e) ? "NaN" : "nombor"
+				case "object": {
+					if (Array.isArray(e)) return "array"
+					if (e === null) return "null"
+					if (Object.getPrototypeOf(e) !== Object.prototype && e.constructor) return e.constructor.name
+				}
+			}
+			return o
+		},
+		i = {
+			regex: "input",
+			email: "alamat e-mel",
+			url: "URL",
+			emoji: "emoji",
+			uuid: "UUID",
+			uuidv4: "UUIDv4",
+			uuidv6: "UUIDv6",
+			nanoid: "nanoid",
+			guid: "GUID",
+			cuid: "cuid",
+			cuid2: "cuid2",
+			ulid: "ULID",
+			xid: "XID",
+			ksuid: "KSUID",
+			datetime: "tarikh masa ISO",
+			date: "tarikh ISO",
+			time: "masa ISO",
+			duration: "tempoh ISO",
+			ipv4: "alamat IPv4",
+			ipv6: "alamat IPv6",
+			cidrv4: "julat IPv4",
+			cidrv6: "julat IPv6",
+			base64: "string dikodkan base64",
+			base64url: "string dikodkan base64url",
+			json_string: "string JSON",
+			e164: "nombor E.164",
+			jwt: "JWT",
+			template_literal: "input",
+		}
+	return (e) => {
+		switch (e.code) {
+			case "invalid_type":
+				return `Input tidak sah: dijangka ${e.expected}, diterima ${n(e.input)}`
+			case "invalid_value":
+				return e.values.length === 1
+					? `Input tidak sah: dijangka ${_(e.values[0])}`
+					: `Pilihan tidak sah: dijangka salah satu daripada ${f(e.values, "|")}`
+			case "too_big": {
+				const o = e.inclusive ? "<=" : "<",
+					a = r(e.origin)
+				return a
+					? `Terlalu besar: dijangka ${e.origin ?? "nilai"} ${a.verb} ${o}${e.maximum.toString()} ${a.unit ?? "elemen"}`
+					: `Terlalu besar: dijangka ${e.origin ?? "nilai"} adalah ${o}${e.maximum.toString()}`
+			}
+			case "too_small": {
+				const o = e.inclusive ? ">=" : ">",
+					a = r(e.origin)
+				return a
+					? `Terlalu kecil: dijangka ${e.origin} ${a.verb} ${o}${e.minimum.toString()} ${a.unit}`
+					: `Terlalu kecil: dijangka ${e.origin} adalah ${o}${e.minimum.toString()}`
+			}
+			case "invalid_format": {
+				const o = e
+				return o.format === "starts_with"
+					? `String tidak sah: mesti bermula dengan "${o.prefix}"`
+					: o.format === "ends_with"
+						? `String tidak sah: mesti berakhir dengan "${o.suffix}"`
+						: o.format === "includes"
+							? `String tidak sah: mesti mengandungi "${o.includes}"`
+							: o.format === "regex"
+								? `String tidak sah: mesti sepadan dengan corak ${o.pattern}`
+								: `${i[o.format] ?? e.format} tidak sah`
+			}
+			case "not_multiple_of":
+				return `Nombor tidak sah: perlu gandaan ${e.divisor}`
+			case "unrecognized_keys":
+				return `Kunci tidak dikenali: ${f(e.keys, ", ")}`
+			case "invalid_key":
+				return `Kunci tidak sah dalam ${e.origin}`
+			case "invalid_union":
+				return "Input tidak sah"
+			case "invalid_element":
+				return `Nilai tidak sah dalam ${e.origin}`
+			default:
+				return "Input tidak sah"
+		}
+	}
+}
+function gc() {
+	return { localeError: Cl() }
+}
+var Ll = () => {
+	const t = {
+		string: { unit: "tekens" },
+		file: { unit: "bytes" },
+		array: { unit: "elementen" },
+		set: { unit: "elementen" },
+	}
+	function r(e) {
+		return t[e] ?? null
+	}
+	const n = (e) => {
+			const o = typeof e
+			switch (o) {
+				case "number":
+					return Number.isNaN(e) ? "NaN" : "getal"
+				case "object": {
+					if (Array.isArray(e)) return "array"
+					if (e === null) return "null"
+					if (Object.getPrototypeOf(e) !== Object.prototype && e.constructor) return e.constructor.name
+				}
+			}
+			return o
+		},
+		i = {
+			regex: "invoer",
+			email: "emailadres",
+			url: "URL",
+			emoji: "emoji",
+			uuid: "UUID",
+			uuidv4: "UUIDv4",
+			uuidv6: "UUIDv6",
+			nanoid: "nanoid",
+			guid: "GUID",
+			cuid: "cuid",
+			cuid2: "cuid2",
+			ulid: "ULID",
+			xid: "XID",
+			ksuid: "KSUID",
+			datetime: "ISO datum en tijd",
+			date: "ISO datum",
+			time: "ISO tijd",
+			duration: "ISO duur",
+			ipv4: "IPv4-adres",
+			ipv6: "IPv6-adres",
+			cidrv4: "IPv4-bereik",
+			cidrv6: "IPv6-bereik",
+			base64: "base64-gecodeerde tekst",
+			base64url: "base64 URL-gecodeerde tekst",
+			json_string: "JSON string",
+			e164: "E.164-nummer",
+			jwt: "JWT",
+			template_literal: "invoer",
+		}
+	return (e) => {
+		switch (e.code) {
+			case "invalid_type":
+				return `Ongeldige invoer: verwacht ${e.expected}, ontving ${n(e.input)}`
+			case "invalid_value":
+				return e.values.length === 1
+					? `Ongeldige invoer: verwacht ${_(e.values[0])}`
+					: `Ongeldige optie: verwacht \xE9\xE9n van ${f(e.values, "|")}`
+			case "too_big": {
+				const o = e.inclusive ? "<=" : "<",
+					a = r(e.origin)
+				return a
+					? `Te lang: verwacht dat ${e.origin ?? "waarde"} ${o}${e.maximum.toString()} ${a.unit ?? "elementen"} bevat`
+					: `Te lang: verwacht dat ${e.origin ?? "waarde"} ${o}${e.maximum.toString()} is`
+			}
+			case "too_small": {
+				const o = e.inclusive ? ">=" : ">",
+					a = r(e.origin)
+				return a
+					? `Te kort: verwacht dat ${e.origin} ${o}${e.minimum.toString()} ${a.unit} bevat`
+					: `Te kort: verwacht dat ${e.origin} ${o}${e.minimum.toString()} is`
+			}
+			case "invalid_format": {
+				const o = e
+				return o.format === "starts_with"
+					? `Ongeldige tekst: moet met "${o.prefix}" beginnen`
+					: o.format === "ends_with"
+						? `Ongeldige tekst: moet op "${o.suffix}" eindigen`
+						: o.format === "includes"
+							? `Ongeldige tekst: moet "${o.includes}" bevatten`
+							: o.format === "regex"
+								? `Ongeldige tekst: moet overeenkomen met patroon ${o.pattern}`
+								: `Ongeldig: ${i[o.format] ?? e.format}`
+			}
+			case "not_multiple_of":
+				return `Ongeldig getal: moet een veelvoud van ${e.divisor} zijn`
+			case "unrecognized_keys":
+				return `Onbekende key${e.keys.length > 1 ? "s" : ""}: ${f(e.keys, ", ")}`
+			case "invalid_key":
+				return `Ongeldige key in ${e.origin}`
+			case "invalid_union":
+				return "Ongeldige invoer"
+			case "invalid_element":
+				return `Ongeldige waarde in ${e.origin}`
+			default:
+				return "Ongeldige invoer"
+		}
+	}
+}
+function hc() {
+	return { localeError: Ll() }
+}
+var Ml = () => {
+	const t = {
+		string: { unit: "tegn", verb: "\xE5 ha" },
+		file: { unit: "bytes", verb: "\xE5 ha" },
+		array: { unit: "elementer", verb: "\xE5 inneholde" },
+		set: { unit: "elementer", verb: "\xE5 inneholde" },
+	}
+	function r(e) {
+		return t[e] ?? null
+	}
+	const n = (e) => {
+			const o = typeof e
+			switch (o) {
+				case "number":
+					return Number.isNaN(e) ? "NaN" : "tall"
+				case "object": {
+					if (Array.isArray(e)) return "liste"
+					if (e === null) return "null"
+					if (Object.getPrototypeOf(e) !== Object.prototype && e.constructor) return e.constructor.name
+				}
+			}
+			return o
+		},
+		i = {
+			regex: "input",
+			email: "e-postadresse",
+			url: "URL",
+			emoji: "emoji",
+			uuid: "UUID",
+			uuidv4: "UUIDv4",
+			uuidv6: "UUIDv6",
+			nanoid: "nanoid",
+			guid: "GUID",
+			cuid: "cuid",
+			cuid2: "cuid2",
+			ulid: "ULID",
+			xid: "XID",
+			ksuid: "KSUID",
+			datetime: "ISO dato- og klokkeslett",
+			date: "ISO-dato",
+			time: "ISO-klokkeslett",
+			duration: "ISO-varighet",
+			ipv4: "IPv4-omr\xE5de",
+			ipv6: "IPv6-omr\xE5de",
+			cidrv4: "IPv4-spekter",
+			cidrv6: "IPv6-spekter",
+			base64: "base64-enkodet streng",
+			base64url: "base64url-enkodet streng",
+			json_string: "JSON-streng",
+			e164: "E.164-nummer",
+			jwt: "JWT",
+			template_literal: "input",
+		}
+	return (e) => {
+		switch (e.code) {
+			case "invalid_type":
+				return `Ugyldig input: forventet ${e.expected}, fikk ${n(e.input)}`
+			case "invalid_value":
+				return e.values.length === 1
+					? `Ugyldig verdi: forventet ${_(e.values[0])}`
+					: `Ugyldig valg: forventet en av ${f(e.values, "|")}`
+			case "too_big": {
+				const o = e.inclusive ? "<=" : "<",
+					a = r(e.origin)
+				return a
+					? `For stor(t): forventet ${e.origin ?? "value"} til \xE5 ha ${o}${e.maximum.toString()} ${a.unit ?? "elementer"}`
+					: `For stor(t): forventet ${e.origin ?? "value"} til \xE5 ha ${o}${e.maximum.toString()}`
+			}
+			case "too_small": {
+				const o = e.inclusive ? ">=" : ">",
+					a = r(e.origin)
+				return a
+					? `For lite(n): forventet ${e.origin} til \xE5 ha ${o}${e.minimum.toString()} ${a.unit}`
+					: `For lite(n): forventet ${e.origin} til \xE5 ha ${o}${e.minimum.toString()}`
+			}
+			case "invalid_format": {
+				const o = e
+				return o.format === "starts_with"
+					? `Ugyldig streng: m\xE5 starte med "${o.prefix}"`
+					: o.format === "ends_with"
+						? `Ugyldig streng: m\xE5 ende med "${o.suffix}"`
+						: o.format === "includes"
+							? `Ugyldig streng: m\xE5 inneholde "${o.includes}"`
+							: o.format === "regex"
+								? `Ugyldig streng: m\xE5 matche m\xF8nsteret ${o.pattern}`
+								: `Ugyldig ${i[o.format] ?? e.format}`
+			}
+			case "not_multiple_of":
+				return `Ugyldig tall: m\xE5 v\xE6re et multiplum av ${e.divisor}`
+			case "unrecognized_keys":
+				return `${e.keys.length > 1 ? "Ukjente n\xF8kler" : "Ukjent n\xF8kkel"}: ${f(e.keys, ", ")}`
+			case "invalid_key":
+				return `Ugyldig n\xF8kkel i ${e.origin}`
+			case "invalid_union":
+				return "Ugyldig input"
+			case "invalid_element":
+				return `Ugyldig verdi i ${e.origin}`
+			default:
+				return "Ugyldig input"
+		}
+	}
+}
+function vc() {
+	return { localeError: Ml() }
+}
+var ql = () => {
+	const t = {
+		string: { unit: "harf", verb: "olmal\u0131d\u0131r" },
+		file: { unit: "bayt", verb: "olmal\u0131d\u0131r" },
+		array: { unit: "unsur", verb: "olmal\u0131d\u0131r" },
+		set: { unit: "unsur", verb: "olmal\u0131d\u0131r" },
+	}
+	function r(e) {
+		return t[e] ?? null
+	}
+	const n = (e) => {
+			const o = typeof e
+			switch (o) {
+				case "number":
+					return Number.isNaN(e) ? "NaN" : "numara"
+				case "object": {
+					if (Array.isArray(e)) return "saf"
+					if (e === null) return "gayb"
+					if (Object.getPrototypeOf(e) !== Object.prototype && e.constructor) return e.constructor.name
+				}
+			}
+			return o
+		},
+		i = {
+			regex: "giren",
+			email: "epostag\xE2h",
+			url: "URL",
+			emoji: "emoji",
+			uuid: "UUID",
+			uuidv4: "UUIDv4",
+			uuidv6: "UUIDv6",
+			nanoid: "nanoid",
+			guid: "GUID",
+			cuid: "cuid",
+			cuid2: "cuid2",
+			ulid: "ULID",
+			xid: "XID",
+			ksuid: "KSUID",
+			datetime: "ISO heng\xE2m\u0131",
+			date: "ISO tarihi",
+			time: "ISO zaman\u0131",
+			duration: "ISO m\xFCddeti",
+			ipv4: "IPv4 ni\u015F\xE2n\u0131",
+			ipv6: "IPv6 ni\u015F\xE2n\u0131",
+			cidrv4: "IPv4 menzili",
+			cidrv6: "IPv6 menzili",
+			base64: "base64-\u015Fifreli metin",
+			base64url: "base64url-\u015Fifreli metin",
+			json_string: "JSON metin",
+			e164: "E.164 say\u0131s\u0131",
+			jwt: "JWT",
+			template_literal: "giren",
+		}
+	return (e) => {
+		switch (e.code) {
+			case "invalid_type":
+				return `F\xE2sit giren: umulan ${e.expected}, al\u0131nan ${n(e.input)}`
+			case "invalid_value":
+				return e.values.length === 1
+					? `F\xE2sit giren: umulan ${_(e.values[0])}`
+					: `F\xE2sit tercih: m\xFBteberler ${f(e.values, "|")}`
+			case "too_big": {
+				const o = e.inclusive ? "<=" : "<",
+					a = r(e.origin)
+				return a
+					? `Fazla b\xFCy\xFCk: ${e.origin ?? "value"}, ${o}${e.maximum.toString()} ${a.unit ?? "elements"} sahip olmal\u0131yd\u0131.`
+					: `Fazla b\xFCy\xFCk: ${e.origin ?? "value"}, ${o}${e.maximum.toString()} olmal\u0131yd\u0131.`
+			}
+			case "too_small": {
+				const o = e.inclusive ? ">=" : ">",
+					a = r(e.origin)
+				return a
+					? `Fazla k\xFC\xE7\xFCk: ${e.origin}, ${o}${e.minimum.toString()} ${a.unit} sahip olmal\u0131yd\u0131.`
+					: `Fazla k\xFC\xE7\xFCk: ${e.origin}, ${o}${e.minimum.toString()} olmal\u0131yd\u0131.`
+			}
+			case "invalid_format": {
+				const o = e
+				return o.format === "starts_with"
+					? `F\xE2sit metin: "${o.prefix}" ile ba\u015Flamal\u0131.`
+					: o.format === "ends_with"
+						? `F\xE2sit metin: "${o.suffix}" ile bitmeli.`
+						: o.format === "includes"
+							? `F\xE2sit metin: "${o.includes}" ihtiv\xE2 etmeli.`
+							: o.format === "regex"
+								? `F\xE2sit metin: ${o.pattern} nak\u015F\u0131na uymal\u0131.`
+								: `F\xE2sit ${i[o.format] ?? e.format}`
+			}
+			case "not_multiple_of":
+				return `F\xE2sit say\u0131: ${e.divisor} kat\u0131 olmal\u0131yd\u0131.`
+			case "unrecognized_keys":
+				return `Tan\u0131nmayan anahtar ${e.keys.length > 1 ? "s" : ""}: ${f(e.keys, ", ")}`
+			case "invalid_key":
+				return `${e.origin} i\xE7in tan\u0131nmayan anahtar var.`
+			case "invalid_union":
+				return "Giren tan\u0131namad\u0131."
+			case "invalid_element":
+				return `${e.origin} i\xE7in tan\u0131nmayan k\u0131ymet var.`
+			default:
+				return "K\u0131ymet tan\u0131namad\u0131."
+		}
+	}
+}
+function bc() {
+	return { localeError: ql() }
+}
+var Vl = () => {
+	const t = {
+		string: { unit: "\u062A\u0648\u06A9\u064A", verb: "\u0648\u0644\u0631\u064A" },
+		file: { unit: "\u0628\u0627\u06CC\u067C\u0633", verb: "\u0648\u0644\u0631\u064A" },
+		array: { unit: "\u062A\u0648\u06A9\u064A", verb: "\u0648\u0644\u0631\u064A" },
+		set: { unit: "\u062A\u0648\u06A9\u064A", verb: "\u0648\u0644\u0631\u064A" },
+	}
+	function r(e) {
+		return t[e] ?? null
+	}
+	const n = (e) => {
+			const o = typeof e
+			switch (o) {
+				case "number":
+					return Number.isNaN(e) ? "NaN" : "\u0639\u062F\u062F"
+				case "object": {
+					if (Array.isArray(e)) return "\u0627\u0631\u06D0"
+					if (e === null) return "null"
+					if (Object.getPrototypeOf(e) !== Object.prototype && e.constructor) return e.constructor.name
+				}
+			}
+			return o
+		},
+		i = {
+			regex: "\u0648\u0631\u0648\u062F\u064A",
+			email: "\u0628\u0631\u06CC\u069A\u0646\u0627\u0644\u06CC\u06A9",
+			url: "\u06CC\u0648 \u0622\u0631 \u0627\u0644",
+			emoji: "\u0627\u06CC\u0645\u0648\u062C\u064A",
+			uuid: "UUID",
+			uuidv4: "UUIDv4",
+			uuidv6: "UUIDv6",
+			nanoid: "nanoid",
+			guid: "GUID",
+			cuid: "cuid",
+			cuid2: "cuid2",
+			ulid: "ULID",
+			xid: "XID",
+			ksuid: "KSUID",
+			datetime: "\u0646\u06CC\u067C\u0647 \u0627\u0648 \u0648\u062E\u062A",
+			date: "\u0646\u06D0\u067C\u0647",
+			time: "\u0648\u062E\u062A",
+			duration: "\u0645\u0648\u062F\u0647",
+			ipv4: "\u062F IPv4 \u067E\u062A\u0647",
+			ipv6: "\u062F IPv6 \u067E\u062A\u0647",
+			cidrv4: "\u062F IPv4 \u0633\u0627\u062D\u0647",
+			cidrv6: "\u062F IPv6 \u0633\u0627\u062D\u0647",
+			base64: "base64-encoded \u0645\u062A\u0646",
+			base64url: "base64url-encoded \u0645\u062A\u0646",
+			json_string: "JSON \u0645\u062A\u0646",
+			e164: "\u062F E.164 \u0634\u0645\u06D0\u0631\u0647",
+			jwt: "JWT",
+			template_literal: "\u0648\u0631\u0648\u062F\u064A",
+		}
+	return (e) => {
+		switch (e.code) {
+			case "invalid_type":
+				return `\u0646\u0627\u0633\u0645 \u0648\u0631\u0648\u062F\u064A: \u0628\u0627\u06CC\u062F ${e.expected} \u0648\u0627\u06CC, \u0645\u06AB\u0631 ${n(e.input)} \u062A\u0631\u0644\u0627\u0633\u0647 \u0634\u0648`
+			case "invalid_value":
+				return e.values.length === 1
+					? `\u0646\u0627\u0633\u0645 \u0648\u0631\u0648\u062F\u064A: \u0628\u0627\u06CC\u062F ${_(e.values[0])} \u0648\u0627\u06CC`
+					: `\u0646\u0627\u0633\u0645 \u0627\u0646\u062A\u062E\u0627\u0628: \u0628\u0627\u06CC\u062F \u06CC\u0648 \u0644\u0647 ${f(e.values, "|")} \u0685\u062E\u0647 \u0648\u0627\u06CC`
+			case "too_big": {
+				const o = e.inclusive ? "<=" : "<",
+					a = r(e.origin)
+				return a
+					? `\u0689\u06CC\u0631 \u0644\u0648\u06CC: ${e.origin ?? "\u0627\u0631\u0632\u069A\u062A"} \u0628\u0627\u06CC\u062F ${o}${e.maximum.toString()} ${a.unit ?? "\u0639\u0646\u0635\u0631\u0648\u0646\u0647"} \u0648\u0644\u0631\u064A`
+					: `\u0689\u06CC\u0631 \u0644\u0648\u06CC: ${e.origin ?? "\u0627\u0631\u0632\u069A\u062A"} \u0628\u0627\u06CC\u062F ${o}${e.maximum.toString()} \u0648\u064A`
+			}
+			case "too_small": {
+				const o = e.inclusive ? ">=" : ">",
+					a = r(e.origin)
+				return a
+					? `\u0689\u06CC\u0631 \u06A9\u0648\u0686\u0646\u06CC: ${e.origin} \u0628\u0627\u06CC\u062F ${o}${e.minimum.toString()} ${a.unit} \u0648\u0644\u0631\u064A`
+					: `\u0689\u06CC\u0631 \u06A9\u0648\u0686\u0646\u06CC: ${e.origin} \u0628\u0627\u06CC\u062F ${o}${e.minimum.toString()} \u0648\u064A`
+			}
+			case "invalid_format": {
+				const o = e
+				return o.format === "starts_with"
+					? `\u0646\u0627\u0633\u0645 \u0645\u062A\u0646: \u0628\u0627\u06CC\u062F \u062F "${o.prefix}" \u0633\u0631\u0647 \u067E\u06CC\u0644 \u0634\u064A`
+					: o.format === "ends_with"
+						? `\u0646\u0627\u0633\u0645 \u0645\u062A\u0646: \u0628\u0627\u06CC\u062F \u062F "${o.suffix}" \u0633\u0631\u0647 \u067E\u0627\u06CC \u062A\u0647 \u0648\u0631\u0633\u064A\u0696\u064A`
+						: o.format === "includes"
+							? `\u0646\u0627\u0633\u0645 \u0645\u062A\u0646: \u0628\u0627\u06CC\u062F "${o.includes}" \u0648\u0644\u0631\u064A`
+							: o.format === "regex"
+								? `\u0646\u0627\u0633\u0645 \u0645\u062A\u0646: \u0628\u0627\u06CC\u062F \u062F ${o.pattern} \u0633\u0631\u0647 \u0645\u0637\u0627\u0628\u0642\u062A \u0648\u0644\u0631\u064A`
+								: `${i[o.format] ?? e.format} \u0646\u0627\u0633\u0645 \u062F\u06CC`
+			}
+			case "not_multiple_of":
+				return `\u0646\u0627\u0633\u0645 \u0639\u062F\u062F: \u0628\u0627\u06CC\u062F \u062F ${e.divisor} \u0645\u0636\u0631\u0628 \u0648\u064A`
+			case "unrecognized_keys":
+				return `\u0646\u0627\u0633\u0645 ${e.keys.length > 1 ? "\u06A9\u0644\u06CC\u0689\u0648\u0646\u0647" : "\u06A9\u0644\u06CC\u0689"}: ${f(e.keys, ", ")}`
+			case "invalid_key":
+				return `\u0646\u0627\u0633\u0645 \u06A9\u0644\u06CC\u0689 \u067E\u0647 ${e.origin} \u06A9\u06D0`
+			case "invalid_union":
+				return "\u0646\u0627\u0633\u0645\u0647 \u0648\u0631\u0648\u062F\u064A"
+			case "invalid_element":
+				return `\u0646\u0627\u0633\u0645 \u0639\u0646\u0635\u0631 \u067E\u0647 ${e.origin} \u06A9\u06D0`
+			default:
+				return "\u0646\u0627\u0633\u0645\u0647 \u0648\u0631\u0648\u062F\u064A"
+		}
+	}
+}
+function _c() {
+	return { localeError: Vl() }
+}
+var Fl = () => {
+	const t = {
+		string: { unit: "znak\xF3w", verb: "mie\u0107" },
+		file: { unit: "bajt\xF3w", verb: "mie\u0107" },
+		array: { unit: "element\xF3w", verb: "mie\u0107" },
+		set: { unit: "element\xF3w", verb: "mie\u0107" },
+	}
+	function r(e) {
+		return t[e] ?? null
+	}
+	const n = (e) => {
+			const o = typeof e
+			switch (o) {
+				case "number":
+					return Number.isNaN(e) ? "NaN" : "liczba"
+				case "object": {
+					if (Array.isArray(e)) return "tablica"
+					if (e === null) return "null"
+					if (Object.getPrototypeOf(e) !== Object.prototype && e.constructor) return e.constructor.name
+				}
+			}
+			return o
+		},
+		i = {
+			regex: "wyra\u017Cenie",
+			email: "adres email",
+			url: "URL",
+			emoji: "emoji",
+			uuid: "UUID",
+			uuidv4: "UUIDv4",
+			uuidv6: "UUIDv6",
+			nanoid: "nanoid",
+			guid: "GUID",
+			cuid: "cuid",
+			cuid2: "cuid2",
+			ulid: "ULID",
+			xid: "XID",
+			ksuid: "KSUID",
+			datetime: "data i godzina w formacie ISO",
+			date: "data w formacie ISO",
+			time: "godzina w formacie ISO",
+			duration: "czas trwania ISO",
+			ipv4: "adres IPv4",
+			ipv6: "adres IPv6",
+			cidrv4: "zakres IPv4",
+			cidrv6: "zakres IPv6",
+			base64: "ci\u0105g znak\xF3w zakodowany w formacie base64",
+			base64url: "ci\u0105g znak\xF3w zakodowany w formacie base64url",
+			json_string: "ci\u0105g znak\xF3w w formacie JSON",
+			e164: "liczba E.164",
+			jwt: "JWT",
+			template_literal: "wej\u015Bcie",
+		}
+	return (e) => {
+		switch (e.code) {
+			case "invalid_type":
+				return `Nieprawid\u0142owe dane wej\u015Bciowe: oczekiwano ${e.expected}, otrzymano ${n(e.input)}`
+			case "invalid_value":
+				return e.values.length === 1
+					? `Nieprawid\u0142owe dane wej\u015Bciowe: oczekiwano ${_(e.values[0])}`
+					: `Nieprawid\u0142owa opcja: oczekiwano jednej z warto\u015Bci ${f(e.values, "|")}`
+			case "too_big": {
+				const o = e.inclusive ? "<=" : "<",
+					a = r(e.origin)
+				return a
+					? `Za du\u017Ca warto\u015B\u0107: oczekiwano, \u017Ce ${e.origin ?? "warto\u015B\u0107"} b\u0119dzie mie\u0107 ${o}${e.maximum.toString()} ${a.unit ?? "element\xF3w"}`
+					: `Zbyt du\u017C(y/a/e): oczekiwano, \u017Ce ${e.origin ?? "warto\u015B\u0107"} b\u0119dzie wynosi\u0107 ${o}${e.maximum.toString()}`
+			}
+			case "too_small": {
+				const o = e.inclusive ? ">=" : ">",
+					a = r(e.origin)
+				return a
+					? `Za ma\u0142a warto\u015B\u0107: oczekiwano, \u017Ce ${e.origin ?? "warto\u015B\u0107"} b\u0119dzie mie\u0107 ${o}${e.minimum.toString()} ${a.unit ?? "element\xF3w"}`
+					: `Zbyt ma\u0142(y/a/e): oczekiwano, \u017Ce ${e.origin ?? "warto\u015B\u0107"} b\u0119dzie wynosi\u0107 ${o}${e.minimum.toString()}`
+			}
+			case "invalid_format": {
+				const o = e
+				return o.format === "starts_with"
+					? `Nieprawid\u0142owy ci\u0105g znak\xF3w: musi zaczyna\u0107 si\u0119 od "${o.prefix}"`
+					: o.format === "ends_with"
+						? `Nieprawid\u0142owy ci\u0105g znak\xF3w: musi ko\u0144czy\u0107 si\u0119 na "${o.suffix}"`
+						: o.format === "includes"
+							? `Nieprawid\u0142owy ci\u0105g znak\xF3w: musi zawiera\u0107 "${o.includes}"`
+							: o.format === "regex"
+								? `Nieprawid\u0142owy ci\u0105g znak\xF3w: musi odpowiada\u0107 wzorcowi ${o.pattern}`
+								: `Nieprawid\u0142ow(y/a/e) ${i[o.format] ?? e.format}`
+			}
+			case "not_multiple_of":
+				return `Nieprawid\u0142owa liczba: musi by\u0107 wielokrotno\u015Bci\u0105 ${e.divisor}`
+			case "unrecognized_keys":
+				return `Nierozpoznane klucze${e.keys.length > 1 ? "s" : ""}: ${f(e.keys, ", ")}`
+			case "invalid_key":
+				return `Nieprawid\u0142owy klucz w ${e.origin}`
+			case "invalid_union":
+				return "Nieprawid\u0142owe dane wej\u015Bciowe"
+			case "invalid_element":
+				return `Nieprawid\u0142owa warto\u015B\u0107 w ${e.origin}`
+			default:
+				return "Nieprawid\u0142owe dane wej\u015Bciowe"
+		}
+	}
+}
+function yc() {
+	return { localeError: Fl() }
+}
+var Hl = () => {
+	const t = {
+		string: { unit: "caracteres", verb: "ter" },
+		file: { unit: "bytes", verb: "ter" },
+		array: { unit: "itens", verb: "ter" },
+		set: { unit: "itens", verb: "ter" },
+	}
+	function r(e) {
+		return t[e] ?? null
+	}
+	const n = (e) => {
+			const o = typeof e
+			switch (o) {
+				case "number":
+					return Number.isNaN(e) ? "NaN" : "n\xFAmero"
+				case "object": {
+					if (Array.isArray(e)) return "array"
+					if (e === null) return "nulo"
+					if (Object.getPrototypeOf(e) !== Object.prototype && e.constructor) return e.constructor.name
+				}
+			}
+			return o
+		},
+		i = {
+			regex: "padr\xE3o",
+			email: "endere\xE7o de e-mail",
+			url: "URL",
+			emoji: "emoji",
+			uuid: "UUID",
+			uuidv4: "UUIDv4",
+			uuidv6: "UUIDv6",
+			nanoid: "nanoid",
+			guid: "GUID",
+			cuid: "cuid",
+			cuid2: "cuid2",
+			ulid: "ULID",
+			xid: "XID",
+			ksuid: "KSUID",
+			datetime: "data e hora ISO",
+			date: "data ISO",
+			time: "hora ISO",
+			duration: "dura\xE7\xE3o ISO",
+			ipv4: "endere\xE7o IPv4",
+			ipv6: "endere\xE7o IPv6",
+			cidrv4: "faixa de IPv4",
+			cidrv6: "faixa de IPv6",
+			base64: "texto codificado em base64",
+			base64url: "URL codificada em base64",
+			json_string: "texto JSON",
+			e164: "n\xFAmero E.164",
+			jwt: "JWT",
+			template_literal: "entrada",
+		}
+	return (e) => {
+		switch (e.code) {
+			case "invalid_type":
+				return `Tipo inv\xE1lido: esperado ${e.expected}, recebido ${n(e.input)}`
+			case "invalid_value":
+				return e.values.length === 1
+					? `Entrada inv\xE1lida: esperado ${_(e.values[0])}`
+					: `Op\xE7\xE3o inv\xE1lida: esperada uma das ${f(e.values, "|")}`
+			case "too_big": {
+				const o = e.inclusive ? "<=" : "<",
+					a = r(e.origin)
+				return a
+					? `Muito grande: esperado que ${e.origin ?? "valor"} tivesse ${o}${e.maximum.toString()} ${a.unit ?? "elementos"}`
+					: `Muito grande: esperado que ${e.origin ?? "valor"} fosse ${o}${e.maximum.toString()}`
+			}
+			case "too_small": {
+				const o = e.inclusive ? ">=" : ">",
+					a = r(e.origin)
+				return a
+					? `Muito pequeno: esperado que ${e.origin} tivesse ${o}${e.minimum.toString()} ${a.unit}`
+					: `Muito pequeno: esperado que ${e.origin} fosse ${o}${e.minimum.toString()}`
+			}
+			case "invalid_format": {
+				const o = e
+				return o.format === "starts_with"
+					? `Texto inv\xE1lido: deve come\xE7ar com "${o.prefix}"`
+					: o.format === "ends_with"
+						? `Texto inv\xE1lido: deve terminar com "${o.suffix}"`
+						: o.format === "includes"
+							? `Texto inv\xE1lido: deve incluir "${o.includes}"`
+							: o.format === "regex"
+								? `Texto inv\xE1lido: deve corresponder ao padr\xE3o ${o.pattern}`
+								: `${i[o.format] ?? e.format} inv\xE1lido`
+			}
+			case "not_multiple_of":
+				return `N\xFAmero inv\xE1lido: deve ser m\xFAltiplo de ${e.divisor}`
+			case "unrecognized_keys":
+				return `Chave${e.keys.length > 1 ? "s" : ""} desconhecida${e.keys.length > 1 ? "s" : ""}: ${f(e.keys, ", ")}`
+			case "invalid_key":
+				return `Chave inv\xE1lida em ${e.origin}`
+			case "invalid_union":
+				return "Entrada inv\xE1lida"
+			case "invalid_element":
+				return `Valor inv\xE1lido em ${e.origin}`
+			default:
+				return "Campo inv\xE1lido"
+		}
+	}
+}
+function $c() {
+	return { localeError: Hl() }
+}
+function xc(t, r, n, i) {
+	const e = Math.abs(t),
+		o = e % 10,
+		a = e % 100
+	return a >= 11 && a <= 19 ? i : o === 1 ? r : o >= 2 && o <= 4 ? n : i
+}
+var Jl = () => {
+	const t = {
+		string: {
+			unit: {
+				one: "\u0441\u0438\u043C\u0432\u043E\u043B",
+				few: "\u0441\u0438\u043C\u0432\u043E\u043B\u0430",
+				many: "\u0441\u0438\u043C\u0432\u043E\u043B\u043E\u0432",
+			},
+			verb: "\u0438\u043C\u0435\u0442\u044C",
+		},
+		file: {
+			unit: {
+				one: "\u0431\u0430\u0439\u0442",
+				few: "\u0431\u0430\u0439\u0442\u0430",
+				many: "\u0431\u0430\u0439\u0442",
+			},
+			verb: "\u0438\u043C\u0435\u0442\u044C",
+		},
+		array: {
+			unit: {
+				one: "\u044D\u043B\u0435\u043C\u0435\u043D\u0442",
+				few: "\u044D\u043B\u0435\u043C\u0435\u043D\u0442\u0430",
+				many: "\u044D\u043B\u0435\u043C\u0435\u043D\u0442\u043E\u0432",
+			},
+			verb: "\u0438\u043C\u0435\u0442\u044C",
+		},
+		set: {
+			unit: {
+				one: "\u044D\u043B\u0435\u043C\u0435\u043D\u0442",
+				few: "\u044D\u043B\u0435\u043C\u0435\u043D\u0442\u0430",
+				many: "\u044D\u043B\u0435\u043C\u0435\u043D\u0442\u043E\u0432",
+			},
+			verb: "\u0438\u043C\u0435\u0442\u044C",
+		},
+	}
+	function r(e) {
+		return t[e] ?? null
+	}
+	const n = (e) => {
+			const o = typeof e
+			switch (o) {
+				case "number":
+					return Number.isNaN(e) ? "NaN" : "\u0447\u0438\u0441\u043B\u043E"
+				case "object": {
+					if (Array.isArray(e)) return "\u043C\u0430\u0441\u0441\u0438\u0432"
+					if (e === null) return "null"
+					if (Object.getPrototypeOf(e) !== Object.prototype && e.constructor) return e.constructor.name
+				}
+			}
+			return o
+		},
+		i = {
+			regex: "\u0432\u0432\u043E\u0434",
+			email: "email \u0430\u0434\u0440\u0435\u0441",
+			url: "URL",
+			emoji: "\u044D\u043C\u043E\u0434\u0437\u0438",
+			uuid: "UUID",
+			uuidv4: "UUIDv4",
+			uuidv6: "UUIDv6",
+			nanoid: "nanoid",
+			guid: "GUID",
+			cuid: "cuid",
+			cuid2: "cuid2",
+			ulid: "ULID",
+			xid: "XID",
+			ksuid: "KSUID",
+			datetime: "ISO \u0434\u0430\u0442\u0430 \u0438 \u0432\u0440\u0435\u043C\u044F",
+			date: "ISO \u0434\u0430\u0442\u0430",
+			time: "ISO \u0432\u0440\u0435\u043C\u044F",
+			duration: "ISO \u0434\u043B\u0438\u0442\u0435\u043B\u044C\u043D\u043E\u0441\u0442\u044C",
+			ipv4: "IPv4 \u0430\u0434\u0440\u0435\u0441",
+			ipv6: "IPv6 \u0430\u0434\u0440\u0435\u0441",
+			cidrv4: "IPv4 \u0434\u0438\u0430\u043F\u0430\u0437\u043E\u043D",
+			cidrv6: "IPv6 \u0434\u0438\u0430\u043F\u0430\u0437\u043E\u043D",
+			base64: "\u0441\u0442\u0440\u043E\u043A\u0430 \u0432 \u0444\u043E\u0440\u043C\u0430\u0442\u0435 base64",
+			base64url: "\u0441\u0442\u0440\u043E\u043A\u0430 \u0432 \u0444\u043E\u0440\u043C\u0430\u0442\u0435 base64url",
+			json_string: "JSON \u0441\u0442\u0440\u043E\u043A\u0430",
+			e164: "\u043D\u043E\u043C\u0435\u0440 E.164",
+			jwt: "JWT",
+			template_literal: "\u0432\u0432\u043E\u0434",
+		}
+	return (e) => {
+		switch (e.code) {
+			case "invalid_type":
+				return `\u041D\u0435\u0432\u0435\u0440\u043D\u044B\u0439 \u0432\u0432\u043E\u0434: \u043E\u0436\u0438\u0434\u0430\u043B\u043E\u0441\u044C ${e.expected}, \u043F\u043E\u043B\u0443\u0447\u0435\u043D\u043E ${n(e.input)}`
+			case "invalid_value":
+				return e.values.length === 1
+					? `\u041D\u0435\u0432\u0435\u0440\u043D\u044B\u0439 \u0432\u0432\u043E\u0434: \u043E\u0436\u0438\u0434\u0430\u043B\u043E\u0441\u044C ${_(e.values[0])}`
+					: `\u041D\u0435\u0432\u0435\u0440\u043D\u044B\u0439 \u0432\u0430\u0440\u0438\u0430\u043D\u0442: \u043E\u0436\u0438\u0434\u0430\u043B\u043E\u0441\u044C \u043E\u0434\u043D\u043E \u0438\u0437 ${f(e.values, "|")}`
+			case "too_big": {
+				const o = e.inclusive ? "<=" : "<",
+					a = r(e.origin)
+				if (a) {
+					const c = Number(e.maximum),
+						p = xc(c, a.unit.one, a.unit.few, a.unit.many)
+					return `\u0421\u043B\u0438\u0448\u043A\u043E\u043C \u0431\u043E\u043B\u044C\u0448\u043E\u0435 \u0437\u043D\u0430\u0447\u0435\u043D\u0438\u0435: \u043E\u0436\u0438\u0434\u0430\u043B\u043E\u0441\u044C, \u0447\u0442\u043E ${e.origin ?? "\u0437\u043D\u0430\u0447\u0435\u043D\u0438\u0435"} \u0431\u0443\u0434\u0435\u0442 \u0438\u043C\u0435\u0442\u044C ${o}${e.maximum.toString()} ${p}`
+				}
+				return `\u0421\u043B\u0438\u0448\u043A\u043E\u043C \u0431\u043E\u043B\u044C\u0448\u043E\u0435 \u0437\u043D\u0430\u0447\u0435\u043D\u0438\u0435: \u043E\u0436\u0438\u0434\u0430\u043B\u043E\u0441\u044C, \u0447\u0442\u043E ${e.origin ?? "\u0437\u043D\u0430\u0447\u0435\u043D\u0438\u0435"} \u0431\u0443\u0434\u0435\u0442 ${o}${e.maximum.toString()}`
+			}
+			case "too_small": {
+				const o = e.inclusive ? ">=" : ">",
+					a = r(e.origin)
+				if (a) {
+					const c = Number(e.minimum),
+						p = xc(c, a.unit.one, a.unit.few, a.unit.many)
+					return `\u0421\u043B\u0438\u0448\u043A\u043E\u043C \u043C\u0430\u043B\u0435\u043D\u044C\u043A\u043E\u0435 \u0437\u043D\u0430\u0447\u0435\u043D\u0438\u0435: \u043E\u0436\u0438\u0434\u0430\u043B\u043E\u0441\u044C, \u0447\u0442\u043E ${e.origin} \u0431\u0443\u0434\u0435\u0442 \u0438\u043C\u0435\u0442\u044C ${o}${e.minimum.toString()} ${p}`
+				}
+				return `\u0421\u043B\u0438\u0448\u043A\u043E\u043C \u043C\u0430\u043B\u0435\u043D\u044C\u043A\u043E\u0435 \u0437\u043D\u0430\u0447\u0435\u043D\u0438\u0435: \u043E\u0436\u0438\u0434\u0430\u043B\u043E\u0441\u044C, \u0447\u0442\u043E ${e.origin} \u0431\u0443\u0434\u0435\u0442 ${o}${e.minimum.toString()}`
+			}
+			case "invalid_format": {
+				const o = e
+				return o.format === "starts_with"
+					? `\u041D\u0435\u0432\u0435\u0440\u043D\u0430\u044F \u0441\u0442\u0440\u043E\u043A\u0430: \u0434\u043E\u043B\u0436\u043D\u0430 \u043D\u0430\u0447\u0438\u043D\u0430\u0442\u044C\u0441\u044F \u0441 "${o.prefix}"`
+					: o.format === "ends_with"
+						? `\u041D\u0435\u0432\u0435\u0440\u043D\u0430\u044F \u0441\u0442\u0440\u043E\u043A\u0430: \u0434\u043E\u043B\u0436\u043D\u0430 \u0437\u0430\u043A\u0430\u043D\u0447\u0438\u0432\u0430\u0442\u044C\u0441\u044F \u043D\u0430 "${o.suffix}"`
+						: o.format === "includes"
+							? `\u041D\u0435\u0432\u0435\u0440\u043D\u0430\u044F \u0441\u0442\u0440\u043E\u043A\u0430: \u0434\u043E\u043B\u0436\u043D\u0430 \u0441\u043E\u0434\u0435\u0440\u0436\u0430\u0442\u044C "${o.includes}"`
+							: o.format === "regex"
+								? `\u041D\u0435\u0432\u0435\u0440\u043D\u0430\u044F \u0441\u0442\u0440\u043E\u043A\u0430: \u0434\u043E\u043B\u0436\u043D\u0430 \u0441\u043E\u043E\u0442\u0432\u0435\u0442\u0441\u0442\u0432\u043E\u0432\u0430\u0442\u044C \u0448\u0430\u0431\u043B\u043E\u043D\u0443 ${o.pattern}`
+								: `\u041D\u0435\u0432\u0435\u0440\u043D\u044B\u0439 ${i[o.format] ?? e.format}`
+			}
+			case "not_multiple_of":
+				return `\u041D\u0435\u0432\u0435\u0440\u043D\u043E\u0435 \u0447\u0438\u0441\u043B\u043E: \u0434\u043E\u043B\u0436\u043D\u043E \u0431\u044B\u0442\u044C \u043A\u0440\u0430\u0442\u043D\u044B\u043C ${e.divisor}`
+			case "unrecognized_keys":
+				return `\u041D\u0435\u0440\u0430\u0441\u043F\u043E\u0437\u043D\u0430\u043D\u043D${e.keys.length > 1 ? "\u044B\u0435" : "\u044B\u0439"} \u043A\u043B\u044E\u0447${e.keys.length > 1 ? "\u0438" : ""}: ${f(e.keys, ", ")}`
+			case "invalid_key":
+				return `\u041D\u0435\u0432\u0435\u0440\u043D\u044B\u0439 \u043A\u043B\u044E\u0447 \u0432 ${e.origin}`
+			case "invalid_union":
+				return "\u041D\u0435\u0432\u0435\u0440\u043D\u044B\u0435 \u0432\u0445\u043E\u0434\u043D\u044B\u0435 \u0434\u0430\u043D\u043D\u044B\u0435"
+			case "invalid_element":
+				return `\u041D\u0435\u0432\u0435\u0440\u043D\u043E\u0435 \u0437\u043D\u0430\u0447\u0435\u043D\u0438\u0435 \u0432 ${e.origin}`
+			default:
+				return "\u041D\u0435\u0432\u0435\u0440\u043D\u044B\u0435 \u0432\u0445\u043E\u0434\u043D\u044B\u0435 \u0434\u0430\u043D\u043D\u044B\u0435"
+		}
+	}
+}
+function zc() {
+	return { localeError: Jl() }
+}
+var Bl = () => {
+	const t = {
+		string: { unit: "znakov", verb: "imeti" },
+		file: { unit: "bajtov", verb: "imeti" },
+		array: { unit: "elementov", verb: "imeti" },
+		set: { unit: "elementov", verb: "imeti" },
+	}
+	function r(e) {
+		return t[e] ?? null
+	}
+	const n = (e) => {
+			const o = typeof e
+			switch (o) {
+				case "number":
+					return Number.isNaN(e) ? "NaN" : "\u0161tevilo"
+				case "object": {
+					if (Array.isArray(e)) return "tabela"
+					if (e === null) return "null"
+					if (Object.getPrototypeOf(e) !== Object.prototype && e.constructor) return e.constructor.name
+				}
+			}
+			return o
+		},
+		i = {
+			regex: "vnos",
+			email: "e-po\u0161tni naslov",
+			url: "URL",
+			emoji: "emoji",
+			uuid: "UUID",
+			uuidv4: "UUIDv4",
+			uuidv6: "UUIDv6",
+			nanoid: "nanoid",
+			guid: "GUID",
+			cuid: "cuid",
+			cuid2: "cuid2",
+			ulid: "ULID",
+			xid: "XID",
+			ksuid: "KSUID",
+			datetime: "ISO datum in \u010Das",
+			date: "ISO datum",
+			time: "ISO \u010Das",
+			duration: "ISO trajanje",
+			ipv4: "IPv4 naslov",
+			ipv6: "IPv6 naslov",
+			cidrv4: "obseg IPv4",
+			cidrv6: "obseg IPv6",
+			base64: "base64 kodiran niz",
+			base64url: "base64url kodiran niz",
+			json_string: "JSON niz",
+			e164: "E.164 \u0161tevilka",
+			jwt: "JWT",
+			template_literal: "vnos",
+		}
+	return (e) => {
+		switch (e.code) {
+			case "invalid_type":
+				return `Neveljaven vnos: pri\u010Dakovano ${e.expected}, prejeto ${n(e.input)}`
+			case "invalid_value":
+				return e.values.length === 1
+					? `Neveljaven vnos: pri\u010Dakovano ${_(e.values[0])}`
+					: `Neveljavna mo\u017Enost: pri\u010Dakovano eno izmed ${f(e.values, "|")}`
+			case "too_big": {
+				const o = e.inclusive ? "<=" : "<",
+					a = r(e.origin)
+				return a
+					? `Preveliko: pri\u010Dakovano, da bo ${e.origin ?? "vrednost"} imelo ${o}${e.maximum.toString()} ${a.unit ?? "elementov"}`
+					: `Preveliko: pri\u010Dakovano, da bo ${e.origin ?? "vrednost"} ${o}${e.maximum.toString()}`
+			}
+			case "too_small": {
+				const o = e.inclusive ? ">=" : ">",
+					a = r(e.origin)
+				return a
+					? `Premajhno: pri\u010Dakovano, da bo ${e.origin} imelo ${o}${e.minimum.toString()} ${a.unit}`
+					: `Premajhno: pri\u010Dakovano, da bo ${e.origin} ${o}${e.minimum.toString()}`
+			}
+			case "invalid_format": {
+				const o = e
+				return o.format === "starts_with"
+					? `Neveljaven niz: mora se za\u010Deti z "${o.prefix}"`
+					: o.format === "ends_with"
+						? `Neveljaven niz: mora se kon\u010Dati z "${o.suffix}"`
+						: o.format === "includes"
+							? `Neveljaven niz: mora vsebovati "${o.includes}"`
+							: o.format === "regex"
+								? `Neveljaven niz: mora ustrezati vzorcu ${o.pattern}`
+								: `Neveljaven ${i[o.format] ?? e.format}`
+			}
+			case "not_multiple_of":
+				return `Neveljavno \u0161tevilo: mora biti ve\u010Dkratnik ${e.divisor}`
+			case "unrecognized_keys":
+				return `Neprepoznan${e.keys.length > 1 ? "i klju\u010Di" : " klju\u010D"}: ${f(e.keys, ", ")}`
+			case "invalid_key":
+				return `Neveljaven klju\u010D v ${e.origin}`
+			case "invalid_union":
+				return "Neveljaven vnos"
+			case "invalid_element":
+				return `Neveljavna vrednost v ${e.origin}`
+			default:
+				return "Neveljaven vnos"
+		}
+	}
+}
+function kc() {
+	return { localeError: Bl() }
+}
+var Wl = () => {
+	const t = {
+		string: { unit: "tecken", verb: "att ha" },
+		file: { unit: "bytes", verb: "att ha" },
+		array: { unit: "objekt", verb: "att inneh\xE5lla" },
+		set: { unit: "objekt", verb: "att inneh\xE5lla" },
+	}
+	function r(e) {
+		return t[e] ?? null
+	}
+	const n = (e) => {
+			const o = typeof e
+			switch (o) {
+				case "number":
+					return Number.isNaN(e) ? "NaN" : "antal"
+				case "object": {
+					if (Array.isArray(e)) return "lista"
+					if (e === null) return "null"
+					if (Object.getPrototypeOf(e) !== Object.prototype && e.constructor) return e.constructor.name
+				}
+			}
+			return o
+		},
+		i = {
+			regex: "regulj\xE4rt uttryck",
+			email: "e-postadress",
+			url: "URL",
+			emoji: "emoji",
+			uuid: "UUID",
+			uuidv4: "UUIDv4",
+			uuidv6: "UUIDv6",
+			nanoid: "nanoid",
+			guid: "GUID",
+			cuid: "cuid",
+			cuid2: "cuid2",
+			ulid: "ULID",
+			xid: "XID",
+			ksuid: "KSUID",
+			datetime: "ISO-datum och tid",
+			date: "ISO-datum",
+			time: "ISO-tid",
+			duration: "ISO-varaktighet",
+			ipv4: "IPv4-intervall",
+			ipv6: "IPv6-intervall",
+			cidrv4: "IPv4-spektrum",
+			cidrv6: "IPv6-spektrum",
+			base64: "base64-kodad str\xE4ng",
+			base64url: "base64url-kodad str\xE4ng",
+			json_string: "JSON-str\xE4ng",
+			e164: "E.164-nummer",
+			jwt: "JWT",
+			template_literal: "mall-literal",
+		}
+	return (e) => {
+		switch (e.code) {
+			case "invalid_type":
+				return `Ogiltig inmatning: f\xF6rv\xE4ntat ${e.expected}, fick ${n(e.input)}`
+			case "invalid_value":
+				return e.values.length === 1
+					? `Ogiltig inmatning: f\xF6rv\xE4ntat ${_(e.values[0])}`
+					: `Ogiltigt val: f\xF6rv\xE4ntade en av ${f(e.values, "|")}`
+			case "too_big": {
+				const o = e.inclusive ? "<=" : "<",
+					a = r(e.origin)
+				return a
+					? `F\xF6r stor(t): f\xF6rv\xE4ntade ${e.origin ?? "v\xE4rdet"} att ha ${o}${e.maximum.toString()} ${a.unit ?? "element"}`
+					: `F\xF6r stor(t): f\xF6rv\xE4ntat ${e.origin ?? "v\xE4rdet"} att ha ${o}${e.maximum.toString()}`
+			}
+			case "too_small": {
+				const o = e.inclusive ? ">=" : ">",
+					a = r(e.origin)
+				return a
+					? `F\xF6r lite(t): f\xF6rv\xE4ntade ${e.origin ?? "v\xE4rdet"} att ha ${o}${e.minimum.toString()} ${a.unit}`
+					: `F\xF6r lite(t): f\xF6rv\xE4ntade ${e.origin ?? "v\xE4rdet"} att ha ${o}${e.minimum.toString()}`
+			}
+			case "invalid_format": {
+				const o = e
+				return o.format === "starts_with"
+					? `Ogiltig str\xE4ng: m\xE5ste b\xF6rja med "${o.prefix}"`
+					: o.format === "ends_with"
+						? `Ogiltig str\xE4ng: m\xE5ste sluta med "${o.suffix}"`
+						: o.format === "includes"
+							? `Ogiltig str\xE4ng: m\xE5ste inneh\xE5lla "${o.includes}"`
+							: o.format === "regex"
+								? `Ogiltig str\xE4ng: m\xE5ste matcha m\xF6nstret "${o.pattern}"`
+								: `Ogiltig(t) ${i[o.format] ?? e.format}`
+			}
+			case "not_multiple_of":
+				return `Ogiltigt tal: m\xE5ste vara en multipel av ${e.divisor}`
+			case "unrecognized_keys":
+				return `${e.keys.length > 1 ? "Ok\xE4nda nycklar" : "Ok\xE4nd nyckel"}: ${f(e.keys, ", ")}`
+			case "invalid_key":
+				return `Ogiltig nyckel i ${e.origin ?? "v\xE4rdet"}`
+			case "invalid_union":
+				return "Ogiltig input"
+			case "invalid_element":
+				return `Ogiltigt v\xE4rde i ${e.origin ?? "v\xE4rdet"}`
+			default:
+				return "Ogiltig input"
+		}
+	}
+}
+function Sc() {
+	return { localeError: Wl() }
+}
+var Gl = () => {
+	const t = {
+		string: {
+			unit: "\u0B8E\u0BB4\u0BC1\u0BA4\u0BCD\u0BA4\u0BC1\u0B95\u0BCD\u0B95\u0BB3\u0BCD",
+			verb: "\u0B95\u0BCA\u0BA3\u0BCD\u0B9F\u0BBF\u0BB0\u0BC1\u0B95\u0BCD\u0B95 \u0BB5\u0BC7\u0BA3\u0BCD\u0B9F\u0BC1\u0BAE\u0BCD",
+		},
+		file: {
+			unit: "\u0BAA\u0BC8\u0B9F\u0BCD\u0B9F\u0BC1\u0B95\u0BB3\u0BCD",
+			verb: "\u0B95\u0BCA\u0BA3\u0BCD\u0B9F\u0BBF\u0BB0\u0BC1\u0B95\u0BCD\u0B95 \u0BB5\u0BC7\u0BA3\u0BCD\u0B9F\u0BC1\u0BAE\u0BCD",
+		},
+		array: {
+			unit: "\u0B89\u0BB1\u0BC1\u0BAA\u0BCD\u0BAA\u0BC1\u0B95\u0BB3\u0BCD",
+			verb: "\u0B95\u0BCA\u0BA3\u0BCD\u0B9F\u0BBF\u0BB0\u0BC1\u0B95\u0BCD\u0B95 \u0BB5\u0BC7\u0BA3\u0BCD\u0B9F\u0BC1\u0BAE\u0BCD",
+		},
+		set: {
+			unit: "\u0B89\u0BB1\u0BC1\u0BAA\u0BCD\u0BAA\u0BC1\u0B95\u0BB3\u0BCD",
+			verb: "\u0B95\u0BCA\u0BA3\u0BCD\u0B9F\u0BBF\u0BB0\u0BC1\u0B95\u0BCD\u0B95 \u0BB5\u0BC7\u0BA3\u0BCD\u0B9F\u0BC1\u0BAE\u0BCD",
+		},
+	}
+	function r(e) {
+		return t[e] ?? null
+	}
+	const n = (e) => {
+			const o = typeof e
+			switch (o) {
+				case "number":
+					return Number.isNaN(e)
+						? "\u0B8E\u0BA3\u0BCD \u0B85\u0BB2\u0BCD\u0BB2\u0BBE\u0BA4\u0BA4\u0BC1"
+						: "\u0B8E\u0BA3\u0BCD"
+				case "object": {
+					if (Array.isArray(e)) return "\u0B85\u0BA3\u0BBF"
+					if (e === null) return "\u0BB5\u0BC6\u0BB1\u0BC1\u0BAE\u0BC8"
+					if (Object.getPrototypeOf(e) !== Object.prototype && e.constructor) return e.constructor.name
+				}
+			}
+			return o
+		},
+		i = {
+			regex: "\u0B89\u0BB3\u0BCD\u0BB3\u0BC0\u0B9F\u0BC1",
+			email: "\u0BAE\u0BBF\u0BA9\u0BCD\u0BA9\u0B9E\u0BCD\u0B9A\u0BB2\u0BCD \u0BAE\u0BC1\u0B95\u0BB5\u0BB0\u0BBF",
+			url: "URL",
+			emoji: "emoji",
+			uuid: "UUID",
+			uuidv4: "UUIDv4",
+			uuidv6: "UUIDv6",
+			nanoid: "nanoid",
+			guid: "GUID",
+			cuid: "cuid",
+			cuid2: "cuid2",
+			ulid: "ULID",
+			xid: "XID",
+			ksuid: "KSUID",
+			datetime: "ISO \u0BA4\u0BC7\u0BA4\u0BBF \u0BA8\u0BC7\u0BB0\u0BAE\u0BCD",
+			date: "ISO \u0BA4\u0BC7\u0BA4\u0BBF",
+			time: "ISO \u0BA8\u0BC7\u0BB0\u0BAE\u0BCD",
+			duration: "ISO \u0B95\u0BBE\u0BB2 \u0B85\u0BB3\u0BB5\u0BC1",
+			ipv4: "IPv4 \u0BAE\u0BC1\u0B95\u0BB5\u0BB0\u0BBF",
+			ipv6: "IPv6 \u0BAE\u0BC1\u0B95\u0BB5\u0BB0\u0BBF",
+			cidrv4: "IPv4 \u0BB5\u0BB0\u0BAE\u0BCD\u0BAA\u0BC1",
+			cidrv6: "IPv6 \u0BB5\u0BB0\u0BAE\u0BCD\u0BAA\u0BC1",
+			base64: "base64-encoded \u0B9A\u0BB0\u0BAE\u0BCD",
+			base64url: "base64url-encoded \u0B9A\u0BB0\u0BAE\u0BCD",
+			json_string: "JSON \u0B9A\u0BB0\u0BAE\u0BCD",
+			e164: "E.164 \u0B8E\u0BA3\u0BCD",
+			jwt: "JWT",
+			template_literal: "input",
+		}
+	return (e) => {
+		switch (e.code) {
+			case "invalid_type":
+				return `\u0BA4\u0BB5\u0BB1\u0BBE\u0BA9 \u0B89\u0BB3\u0BCD\u0BB3\u0BC0\u0B9F\u0BC1: \u0B8E\u0BA4\u0BBF\u0BB0\u0BCD\u0BAA\u0BBE\u0BB0\u0BCD\u0B95\u0BCD\u0B95\u0BAA\u0BCD\u0BAA\u0B9F\u0BCD\u0B9F\u0BA4\u0BC1 ${e.expected}, \u0BAA\u0BC6\u0BB1\u0BAA\u0BCD\u0BAA\u0B9F\u0BCD\u0B9F\u0BA4\u0BC1 ${n(e.input)}`
+			case "invalid_value":
+				return e.values.length === 1
+					? `\u0BA4\u0BB5\u0BB1\u0BBE\u0BA9 \u0B89\u0BB3\u0BCD\u0BB3\u0BC0\u0B9F\u0BC1: \u0B8E\u0BA4\u0BBF\u0BB0\u0BCD\u0BAA\u0BBE\u0BB0\u0BCD\u0B95\u0BCD\u0B95\u0BAA\u0BCD\u0BAA\u0B9F\u0BCD\u0B9F\u0BA4\u0BC1 ${_(e.values[0])}`
+					: `\u0BA4\u0BB5\u0BB1\u0BBE\u0BA9 \u0BB5\u0BBF\u0BB0\u0BC1\u0BAA\u0BCD\u0BAA\u0BAE\u0BCD: \u0B8E\u0BA4\u0BBF\u0BB0\u0BCD\u0BAA\u0BBE\u0BB0\u0BCD\u0B95\u0BCD\u0B95\u0BAA\u0BCD\u0BAA\u0B9F\u0BCD\u0B9F\u0BA4\u0BC1 ${f(e.values, "|")} \u0B87\u0BB2\u0BCD \u0B92\u0BA9\u0BCD\u0BB1\u0BC1`
+			case "too_big": {
+				const o = e.inclusive ? "<=" : "<",
+					a = r(e.origin)
+				return a
+					? `\u0BAE\u0BBF\u0B95 \u0BAA\u0BC6\u0BB0\u0BBF\u0BAF\u0BA4\u0BC1: \u0B8E\u0BA4\u0BBF\u0BB0\u0BCD\u0BAA\u0BBE\u0BB0\u0BCD\u0B95\u0BCD\u0B95\u0BAA\u0BCD\u0BAA\u0B9F\u0BCD\u0B9F\u0BA4\u0BC1 ${e.origin ?? "\u0BAE\u0BA4\u0BBF\u0BAA\u0BCD\u0BAA\u0BC1"} ${o}${e.maximum.toString()} ${a.unit ?? "\u0B89\u0BB1\u0BC1\u0BAA\u0BCD\u0BAA\u0BC1\u0B95\u0BB3\u0BCD"} \u0B86\u0B95 \u0B87\u0BB0\u0BC1\u0B95\u0BCD\u0B95 \u0BB5\u0BC7\u0BA3\u0BCD\u0B9F\u0BC1\u0BAE\u0BCD`
+					: `\u0BAE\u0BBF\u0B95 \u0BAA\u0BC6\u0BB0\u0BBF\u0BAF\u0BA4\u0BC1: \u0B8E\u0BA4\u0BBF\u0BB0\u0BCD\u0BAA\u0BBE\u0BB0\u0BCD\u0B95\u0BCD\u0B95\u0BAA\u0BCD\u0BAA\u0B9F\u0BCD\u0B9F\u0BA4\u0BC1 ${e.origin ?? "\u0BAE\u0BA4\u0BBF\u0BAA\u0BCD\u0BAA\u0BC1"} ${o}${e.maximum.toString()} \u0B86\u0B95 \u0B87\u0BB0\u0BC1\u0B95\u0BCD\u0B95 \u0BB5\u0BC7\u0BA3\u0BCD\u0B9F\u0BC1\u0BAE\u0BCD`
+			}
+			case "too_small": {
+				const o = e.inclusive ? ">=" : ">",
+					a = r(e.origin)
+				return a
+					? `\u0BAE\u0BBF\u0B95\u0B9A\u0BCD \u0B9A\u0BBF\u0BB1\u0BBF\u0BAF\u0BA4\u0BC1: \u0B8E\u0BA4\u0BBF\u0BB0\u0BCD\u0BAA\u0BBE\u0BB0\u0BCD\u0B95\u0BCD\u0B95\u0BAA\u0BCD\u0BAA\u0B9F\u0BCD\u0B9F\u0BA4\u0BC1 ${e.origin} ${o}${e.minimum.toString()} ${a.unit} \u0B86\u0B95 \u0B87\u0BB0\u0BC1\u0B95\u0BCD\u0B95 \u0BB5\u0BC7\u0BA3\u0BCD\u0B9F\u0BC1\u0BAE\u0BCD`
+					: `\u0BAE\u0BBF\u0B95\u0B9A\u0BCD \u0B9A\u0BBF\u0BB1\u0BBF\u0BAF\u0BA4\u0BC1: \u0B8E\u0BA4\u0BBF\u0BB0\u0BCD\u0BAA\u0BBE\u0BB0\u0BCD\u0B95\u0BCD\u0B95\u0BAA\u0BCD\u0BAA\u0B9F\u0BCD\u0B9F\u0BA4\u0BC1 ${e.origin} ${o}${e.minimum.toString()} \u0B86\u0B95 \u0B87\u0BB0\u0BC1\u0B95\u0BCD\u0B95 \u0BB5\u0BC7\u0BA3\u0BCD\u0B9F\u0BC1\u0BAE\u0BCD`
+			}
+			case "invalid_format": {
+				const o = e
+				return o.format === "starts_with"
+					? `\u0BA4\u0BB5\u0BB1\u0BBE\u0BA9 \u0B9A\u0BB0\u0BAE\u0BCD: "${o.prefix}" \u0B87\u0BB2\u0BCD \u0BA4\u0BCA\u0B9F\u0B99\u0BCD\u0B95 \u0BB5\u0BC7\u0BA3\u0BCD\u0B9F\u0BC1\u0BAE\u0BCD`
+					: o.format === "ends_with"
+						? `\u0BA4\u0BB5\u0BB1\u0BBE\u0BA9 \u0B9A\u0BB0\u0BAE\u0BCD: "${o.suffix}" \u0B87\u0BB2\u0BCD \u0BAE\u0BC1\u0B9F\u0BBF\u0BB5\u0B9F\u0BC8\u0BAF \u0BB5\u0BC7\u0BA3\u0BCD\u0B9F\u0BC1\u0BAE\u0BCD`
+						: o.format === "includes"
+							? `\u0BA4\u0BB5\u0BB1\u0BBE\u0BA9 \u0B9A\u0BB0\u0BAE\u0BCD: "${o.includes}" \u0B90 \u0B89\u0BB3\u0BCD\u0BB3\u0B9F\u0B95\u0BCD\u0B95 \u0BB5\u0BC7\u0BA3\u0BCD\u0B9F\u0BC1\u0BAE\u0BCD`
+							: o.format === "regex"
+								? `\u0BA4\u0BB5\u0BB1\u0BBE\u0BA9 \u0B9A\u0BB0\u0BAE\u0BCD: ${o.pattern} \u0BAE\u0BC1\u0BB1\u0BC8\u0BAA\u0BBE\u0B9F\u0BCD\u0B9F\u0BC1\u0B9F\u0BA9\u0BCD \u0BAA\u0BCA\u0BB0\u0BC1\u0BA8\u0BCD\u0BA4 \u0BB5\u0BC7\u0BA3\u0BCD\u0B9F\u0BC1\u0BAE\u0BCD`
+								: `\u0BA4\u0BB5\u0BB1\u0BBE\u0BA9 ${i[o.format] ?? e.format}`
+			}
+			case "not_multiple_of":
+				return `\u0BA4\u0BB5\u0BB1\u0BBE\u0BA9 \u0B8E\u0BA3\u0BCD: ${e.divisor} \u0B87\u0BA9\u0BCD \u0BAA\u0BB2\u0BAE\u0BBE\u0B95 \u0B87\u0BB0\u0BC1\u0B95\u0BCD\u0B95 \u0BB5\u0BC7\u0BA3\u0BCD\u0B9F\u0BC1\u0BAE\u0BCD`
+			case "unrecognized_keys":
+				return `\u0B85\u0B9F\u0BC8\u0BAF\u0BBE\u0BB3\u0BAE\u0BCD \u0BA4\u0BC6\u0BB0\u0BBF\u0BAF\u0BBE\u0BA4 \u0BB5\u0BBF\u0B9A\u0BC8${e.keys.length > 1 ? "\u0B95\u0BB3\u0BCD" : ""}: ${f(e.keys, ", ")}`
+			case "invalid_key":
+				return `${e.origin} \u0B87\u0BB2\u0BCD \u0BA4\u0BB5\u0BB1\u0BBE\u0BA9 \u0BB5\u0BBF\u0B9A\u0BC8`
+			case "invalid_union":
+				return "\u0BA4\u0BB5\u0BB1\u0BBE\u0BA9 \u0B89\u0BB3\u0BCD\u0BB3\u0BC0\u0B9F\u0BC1"
+			case "invalid_element":
+				return `${e.origin} \u0B87\u0BB2\u0BCD \u0BA4\u0BB5\u0BB1\u0BBE\u0BA9 \u0BAE\u0BA4\u0BBF\u0BAA\u0BCD\u0BAA\u0BC1`
+			default:
+				return "\u0BA4\u0BB5\u0BB1\u0BBE\u0BA9 \u0B89\u0BB3\u0BCD\u0BB3\u0BC0\u0B9F\u0BC1"
+		}
+	}
+}
+function wc() {
+	return { localeError: Gl() }
+}
+var Kl = () => {
+	const t = {
+		string: { unit: "\u0E15\u0E31\u0E27\u0E2D\u0E31\u0E01\u0E29\u0E23", verb: "\u0E04\u0E27\u0E23\u0E21\u0E35" },
+		file: { unit: "\u0E44\u0E1A\u0E15\u0E4C", verb: "\u0E04\u0E27\u0E23\u0E21\u0E35" },
+		array: { unit: "\u0E23\u0E32\u0E22\u0E01\u0E32\u0E23", verb: "\u0E04\u0E27\u0E23\u0E21\u0E35" },
+		set: { unit: "\u0E23\u0E32\u0E22\u0E01\u0E32\u0E23", verb: "\u0E04\u0E27\u0E23\u0E21\u0E35" },
+	}
+	function r(e) {
+		return t[e] ?? null
+	}
+	const n = (e) => {
+			const o = typeof e
+			switch (o) {
+				case "number":
+					return Number.isNaN(e)
+						? "\u0E44\u0E21\u0E48\u0E43\u0E0A\u0E48\u0E15\u0E31\u0E27\u0E40\u0E25\u0E02 (NaN)"
+						: "\u0E15\u0E31\u0E27\u0E40\u0E25\u0E02"
+				case "object": {
+					if (Array.isArray(e)) return "\u0E2D\u0E32\u0E23\u0E4C\u0E40\u0E23\u0E22\u0E4C (Array)"
+					if (e === null) return "\u0E44\u0E21\u0E48\u0E21\u0E35\u0E04\u0E48\u0E32 (null)"
+					if (Object.getPrototypeOf(e) !== Object.prototype && e.constructor) return e.constructor.name
+				}
+			}
+			return o
+		},
+		i = {
+			regex: "\u0E02\u0E49\u0E2D\u0E21\u0E39\u0E25\u0E17\u0E35\u0E48\u0E1B\u0E49\u0E2D\u0E19",
+			email: "\u0E17\u0E35\u0E48\u0E2D\u0E22\u0E39\u0E48\u0E2D\u0E35\u0E40\u0E21\u0E25",
+			url: "URL",
+			emoji: "\u0E2D\u0E34\u0E42\u0E21\u0E08\u0E34",
+			uuid: "UUID",
+			uuidv4: "UUIDv4",
+			uuidv6: "UUIDv6",
+			nanoid: "nanoid",
+			guid: "GUID",
+			cuid: "cuid",
+			cuid2: "cuid2",
+			ulid: "ULID",
+			xid: "XID",
+			ksuid: "KSUID",
+			datetime: "\u0E27\u0E31\u0E19\u0E17\u0E35\u0E48\u0E40\u0E27\u0E25\u0E32\u0E41\u0E1A\u0E1A ISO",
+			date: "\u0E27\u0E31\u0E19\u0E17\u0E35\u0E48\u0E41\u0E1A\u0E1A ISO",
+			time: "\u0E40\u0E27\u0E25\u0E32\u0E41\u0E1A\u0E1A ISO",
+			duration: "\u0E0A\u0E48\u0E27\u0E07\u0E40\u0E27\u0E25\u0E32\u0E41\u0E1A\u0E1A ISO",
+			ipv4: "\u0E17\u0E35\u0E48\u0E2D\u0E22\u0E39\u0E48 IPv4",
+			ipv6: "\u0E17\u0E35\u0E48\u0E2D\u0E22\u0E39\u0E48 IPv6",
+			cidrv4: "\u0E0A\u0E48\u0E27\u0E07 IP \u0E41\u0E1A\u0E1A IPv4",
+			cidrv6: "\u0E0A\u0E48\u0E27\u0E07 IP \u0E41\u0E1A\u0E1A IPv6",
+			base64: "\u0E02\u0E49\u0E2D\u0E04\u0E27\u0E32\u0E21\u0E41\u0E1A\u0E1A Base64",
+			base64url:
+				"\u0E02\u0E49\u0E2D\u0E04\u0E27\u0E32\u0E21\u0E41\u0E1A\u0E1A Base64 \u0E2A\u0E33\u0E2B\u0E23\u0E31\u0E1A URL",
+			json_string: "\u0E02\u0E49\u0E2D\u0E04\u0E27\u0E32\u0E21\u0E41\u0E1A\u0E1A JSON",
+			e164: "\u0E40\u0E1A\u0E2D\u0E23\u0E4C\u0E42\u0E17\u0E23\u0E28\u0E31\u0E1E\u0E17\u0E4C\u0E23\u0E30\u0E2B\u0E27\u0E48\u0E32\u0E07\u0E1B\u0E23\u0E30\u0E40\u0E17\u0E28 (E.164)",
+			jwt: "\u0E42\u0E17\u0E40\u0E04\u0E19 JWT",
+			template_literal: "\u0E02\u0E49\u0E2D\u0E21\u0E39\u0E25\u0E17\u0E35\u0E48\u0E1B\u0E49\u0E2D\u0E19",
+		}
+	return (e) => {
+		switch (e.code) {
+			case "invalid_type":
+				return `\u0E1B\u0E23\u0E30\u0E40\u0E20\u0E17\u0E02\u0E49\u0E2D\u0E21\u0E39\u0E25\u0E44\u0E21\u0E48\u0E16\u0E39\u0E01\u0E15\u0E49\u0E2D\u0E07: \u0E04\u0E27\u0E23\u0E40\u0E1B\u0E47\u0E19 ${e.expected} \u0E41\u0E15\u0E48\u0E44\u0E14\u0E49\u0E23\u0E31\u0E1A ${n(e.input)}`
+			case "invalid_value":
+				return e.values.length === 1
+					? `\u0E04\u0E48\u0E32\u0E44\u0E21\u0E48\u0E16\u0E39\u0E01\u0E15\u0E49\u0E2D\u0E07: \u0E04\u0E27\u0E23\u0E40\u0E1B\u0E47\u0E19 ${_(e.values[0])}`
+					: `\u0E15\u0E31\u0E27\u0E40\u0E25\u0E37\u0E2D\u0E01\u0E44\u0E21\u0E48\u0E16\u0E39\u0E01\u0E15\u0E49\u0E2D\u0E07: \u0E04\u0E27\u0E23\u0E40\u0E1B\u0E47\u0E19\u0E2B\u0E19\u0E36\u0E48\u0E07\u0E43\u0E19 ${f(e.values, "|")}`
+			case "too_big": {
+				const o = e.inclusive
+						? "\u0E44\u0E21\u0E48\u0E40\u0E01\u0E34\u0E19"
+						: "\u0E19\u0E49\u0E2D\u0E22\u0E01\u0E27\u0E48\u0E32",
+					a = r(e.origin)
+				return a
+					? `\u0E40\u0E01\u0E34\u0E19\u0E01\u0E33\u0E2B\u0E19\u0E14: ${e.origin ?? "\u0E04\u0E48\u0E32"} \u0E04\u0E27\u0E23\u0E21\u0E35${o} ${e.maximum.toString()} ${a.unit ?? "\u0E23\u0E32\u0E22\u0E01\u0E32\u0E23"}`
+					: `\u0E40\u0E01\u0E34\u0E19\u0E01\u0E33\u0E2B\u0E19\u0E14: ${e.origin ?? "\u0E04\u0E48\u0E32"} \u0E04\u0E27\u0E23\u0E21\u0E35${o} ${e.maximum.toString()}`
+			}
+			case "too_small": {
+				const o = e.inclusive
+						? "\u0E2D\u0E22\u0E48\u0E32\u0E07\u0E19\u0E49\u0E2D\u0E22"
+						: "\u0E21\u0E32\u0E01\u0E01\u0E27\u0E48\u0E32",
+					a = r(e.origin)
+				return a
+					? `\u0E19\u0E49\u0E2D\u0E22\u0E01\u0E27\u0E48\u0E32\u0E01\u0E33\u0E2B\u0E19\u0E14: ${e.origin} \u0E04\u0E27\u0E23\u0E21\u0E35${o} ${e.minimum.toString()} ${a.unit}`
+					: `\u0E19\u0E49\u0E2D\u0E22\u0E01\u0E27\u0E48\u0E32\u0E01\u0E33\u0E2B\u0E19\u0E14: ${e.origin} \u0E04\u0E27\u0E23\u0E21\u0E35${o} ${e.minimum.toString()}`
+			}
+			case "invalid_format": {
+				const o = e
+				return o.format === "starts_with"
+					? `\u0E23\u0E39\u0E1B\u0E41\u0E1A\u0E1A\u0E44\u0E21\u0E48\u0E16\u0E39\u0E01\u0E15\u0E49\u0E2D\u0E07: \u0E02\u0E49\u0E2D\u0E04\u0E27\u0E32\u0E21\u0E15\u0E49\u0E2D\u0E07\u0E02\u0E36\u0E49\u0E19\u0E15\u0E49\u0E19\u0E14\u0E49\u0E27\u0E22 "${o.prefix}"`
+					: o.format === "ends_with"
+						? `\u0E23\u0E39\u0E1B\u0E41\u0E1A\u0E1A\u0E44\u0E21\u0E48\u0E16\u0E39\u0E01\u0E15\u0E49\u0E2D\u0E07: \u0E02\u0E49\u0E2D\u0E04\u0E27\u0E32\u0E21\u0E15\u0E49\u0E2D\u0E07\u0E25\u0E07\u0E17\u0E49\u0E32\u0E22\u0E14\u0E49\u0E27\u0E22 "${o.suffix}"`
+						: o.format === "includes"
+							? `\u0E23\u0E39\u0E1B\u0E41\u0E1A\u0E1A\u0E44\u0E21\u0E48\u0E16\u0E39\u0E01\u0E15\u0E49\u0E2D\u0E07: \u0E02\u0E49\u0E2D\u0E04\u0E27\u0E32\u0E21\u0E15\u0E49\u0E2D\u0E07\u0E21\u0E35 "${o.includes}" \u0E2D\u0E22\u0E39\u0E48\u0E43\u0E19\u0E02\u0E49\u0E2D\u0E04\u0E27\u0E32\u0E21`
+							: o.format === "regex"
+								? `\u0E23\u0E39\u0E1B\u0E41\u0E1A\u0E1A\u0E44\u0E21\u0E48\u0E16\u0E39\u0E01\u0E15\u0E49\u0E2D\u0E07: \u0E15\u0E49\u0E2D\u0E07\u0E15\u0E23\u0E07\u0E01\u0E31\u0E1A\u0E23\u0E39\u0E1B\u0E41\u0E1A\u0E1A\u0E17\u0E35\u0E48\u0E01\u0E33\u0E2B\u0E19\u0E14 ${o.pattern}`
+								: `\u0E23\u0E39\u0E1B\u0E41\u0E1A\u0E1A\u0E44\u0E21\u0E48\u0E16\u0E39\u0E01\u0E15\u0E49\u0E2D\u0E07: ${i[o.format] ?? e.format}`
+			}
+			case "not_multiple_of":
+				return `\u0E15\u0E31\u0E27\u0E40\u0E25\u0E02\u0E44\u0E21\u0E48\u0E16\u0E39\u0E01\u0E15\u0E49\u0E2D\u0E07: \u0E15\u0E49\u0E2D\u0E07\u0E40\u0E1B\u0E47\u0E19\u0E08\u0E33\u0E19\u0E27\u0E19\u0E17\u0E35\u0E48\u0E2B\u0E32\u0E23\u0E14\u0E49\u0E27\u0E22 ${e.divisor} \u0E44\u0E14\u0E49\u0E25\u0E07\u0E15\u0E31\u0E27`
+			case "unrecognized_keys":
+				return `\u0E1E\u0E1A\u0E04\u0E35\u0E22\u0E4C\u0E17\u0E35\u0E48\u0E44\u0E21\u0E48\u0E23\u0E39\u0E49\u0E08\u0E31\u0E01: ${f(e.keys, ", ")}`
+			case "invalid_key":
+				return `\u0E04\u0E35\u0E22\u0E4C\u0E44\u0E21\u0E48\u0E16\u0E39\u0E01\u0E15\u0E49\u0E2D\u0E07\u0E43\u0E19 ${e.origin}`
+			case "invalid_union":
+				return "\u0E02\u0E49\u0E2D\u0E21\u0E39\u0E25\u0E44\u0E21\u0E48\u0E16\u0E39\u0E01\u0E15\u0E49\u0E2D\u0E07: \u0E44\u0E21\u0E48\u0E15\u0E23\u0E07\u0E01\u0E31\u0E1A\u0E23\u0E39\u0E1B\u0E41\u0E1A\u0E1A\u0E22\u0E39\u0E40\u0E19\u0E35\u0E22\u0E19\u0E17\u0E35\u0E48\u0E01\u0E33\u0E2B\u0E19\u0E14\u0E44\u0E27\u0E49"
+			case "invalid_element":
+				return `\u0E02\u0E49\u0E2D\u0E21\u0E39\u0E25\u0E44\u0E21\u0E48\u0E16\u0E39\u0E01\u0E15\u0E49\u0E2D\u0E07\u0E43\u0E19 ${e.origin}`
+			default:
+				return "\u0E02\u0E49\u0E2D\u0E21\u0E39\u0E25\u0E44\u0E21\u0E48\u0E16\u0E39\u0E01\u0E15\u0E49\u0E2D\u0E07"
+		}
+	}
+}
+function Ic() {
+	return { localeError: Kl() }
+}
+var Ql = (t) => {
+		const r = typeof t
+		switch (r) {
+			case "number":
+				return Number.isNaN(t) ? "NaN" : "number"
+			case "object": {
+				if (Array.isArray(t)) return "array"
+				if (t === null) return "null"
+				if (Object.getPrototypeOf(t) !== Object.prototype && t.constructor) return t.constructor.name
+			}
+		}
+		return r
+	},
+	Xl = () => {
+		const t = {
+			string: { unit: "karakter", verb: "olmal\u0131" },
+			file: { unit: "bayt", verb: "olmal\u0131" },
+			array: { unit: "\xF6\u011Fe", verb: "olmal\u0131" },
+			set: { unit: "\xF6\u011Fe", verb: "olmal\u0131" },
+		}
+		function r(i) {
+			return t[i] ?? null
+		}
+		const n = {
+			regex: "girdi",
+			email: "e-posta adresi",
+			url: "URL",
+			emoji: "emoji",
+			uuid: "UUID",
+			uuidv4: "UUIDv4",
+			uuidv6: "UUIDv6",
+			nanoid: "nanoid",
+			guid: "GUID",
+			cuid: "cuid",
+			cuid2: "cuid2",
+			ulid: "ULID",
+			xid: "XID",
+			ksuid: "KSUID",
+			datetime: "ISO tarih ve saat",
+			date: "ISO tarih",
+			time: "ISO saat",
+			duration: "ISO s\xFCre",
+			ipv4: "IPv4 adresi",
+			ipv6: "IPv6 adresi",
+			cidrv4: "IPv4 aral\u0131\u011F\u0131",
+			cidrv6: "IPv6 aral\u0131\u011F\u0131",
+			base64: "base64 ile \u015Fifrelenmi\u015F metin",
+			base64url: "base64url ile \u015Fifrelenmi\u015F metin",
+			json_string: "JSON dizesi",
+			e164: "E.164 say\u0131s\u0131",
+			jwt: "JWT",
+			template_literal: "\u015Eablon dizesi",
+		}
+		return (i) => {
+			switch (i.code) {
+				case "invalid_type":
+					return `Ge\xE7ersiz de\u011Fer: beklenen ${i.expected}, al\u0131nan ${Ql(i.input)}`
+				case "invalid_value":
+					return i.values.length === 1
+						? `Ge\xE7ersiz de\u011Fer: beklenen ${_(i.values[0])}`
+						: `Ge\xE7ersiz se\xE7enek: a\u015Fa\u011F\u0131dakilerden biri olmal\u0131: ${f(i.values, "|")}`
+				case "too_big": {
+					const e = i.inclusive ? "<=" : "<",
+						o = r(i.origin)
+					return o
+						? `\xC7ok b\xFCy\xFCk: beklenen ${i.origin ?? "de\u011Fer"} ${e}${i.maximum.toString()} ${o.unit ?? "\xF6\u011Fe"}`
+						: `\xC7ok b\xFCy\xFCk: beklenen ${i.origin ?? "de\u011Fer"} ${e}${i.maximum.toString()}`
+				}
+				case "too_small": {
+					const e = i.inclusive ? ">=" : ">",
+						o = r(i.origin)
+					return o
+						? `\xC7ok k\xFC\xE7\xFCk: beklenen ${i.origin} ${e}${i.minimum.toString()} ${o.unit}`
+						: `\xC7ok k\xFC\xE7\xFCk: beklenen ${i.origin} ${e}${i.minimum.toString()}`
+				}
+				case "invalid_format": {
+					const e = i
+					return e.format === "starts_with"
+						? `Ge\xE7ersiz metin: "${e.prefix}" ile ba\u015Flamal\u0131`
+						: e.format === "ends_with"
+							? `Ge\xE7ersiz metin: "${e.suffix}" ile bitmeli`
+							: e.format === "includes"
+								? `Ge\xE7ersiz metin: "${e.includes}" i\xE7ermeli`
+								: e.format === "regex"
+									? `Ge\xE7ersiz metin: ${e.pattern} desenine uymal\u0131`
+									: `Ge\xE7ersiz ${n[e.format] ?? i.format}`
+				}
+				case "not_multiple_of":
+					return `Ge\xE7ersiz say\u0131: ${i.divisor} ile tam b\xF6l\xFCnebilmeli`
+				case "unrecognized_keys":
+					return `Tan\u0131nmayan anahtar${i.keys.length > 1 ? "lar" : ""}: ${f(i.keys, ", ")}`
+				case "invalid_key":
+					return `${i.origin} i\xE7inde ge\xE7ersiz anahtar`
+				case "invalid_union":
+					return "Ge\xE7ersiz de\u011Fer"
+				case "invalid_element":
+					return `${i.origin} i\xE7inde ge\xE7ersiz de\u011Fer`
+				default:
+					return "Ge\xE7ersiz de\u011Fer"
+			}
+		}
+	}
+function jc() {
+	return { localeError: Xl() }
+}
+var Yl = () => {
+	const t = {
+		string: { unit: "\u0441\u0438\u043C\u0432\u043E\u043B\u0456\u0432", verb: "\u043C\u0430\u0442\u0438\u043C\u0435" },
+		file: { unit: "\u0431\u0430\u0439\u0442\u0456\u0432", verb: "\u043C\u0430\u0442\u0438\u043C\u0435" },
+		array: {
+			unit: "\u0435\u043B\u0435\u043C\u0435\u043D\u0442\u0456\u0432",
+			verb: "\u043C\u0430\u0442\u0438\u043C\u0435",
+		},
+		set: {
+			unit: "\u0435\u043B\u0435\u043C\u0435\u043D\u0442\u0456\u0432",
+			verb: "\u043C\u0430\u0442\u0438\u043C\u0435",
+		},
+	}
+	function r(e) {
+		return t[e] ?? null
+	}
+	const n = (e) => {
+			const o = typeof e
+			switch (o) {
+				case "number":
+					return Number.isNaN(e) ? "NaN" : "\u0447\u0438\u0441\u043B\u043E"
+				case "object": {
+					if (Array.isArray(e)) return "\u043C\u0430\u0441\u0438\u0432"
+					if (e === null) return "null"
+					if (Object.getPrototypeOf(e) !== Object.prototype && e.constructor) return e.constructor.name
+				}
+			}
+			return o
+		},
+		i = {
+			regex: "\u0432\u0445\u0456\u0434\u043D\u0456 \u0434\u0430\u043D\u0456",
+			email:
+				"\u0430\u0434\u0440\u0435\u0441\u0430 \u0435\u043B\u0435\u043A\u0442\u0440\u043E\u043D\u043D\u043E\u0457 \u043F\u043E\u0448\u0442\u0438",
+			url: "URL",
+			emoji: "\u0435\u043C\u043E\u0434\u0437\u0456",
+			uuid: "UUID",
+			uuidv4: "UUIDv4",
+			uuidv6: "UUIDv6",
+			nanoid: "nanoid",
+			guid: "GUID",
+			cuid: "cuid",
+			cuid2: "cuid2",
+			ulid: "ULID",
+			xid: "XID",
+			ksuid: "KSUID",
+			datetime: "\u0434\u0430\u0442\u0430 \u0442\u0430 \u0447\u0430\u0441 ISO",
+			date: "\u0434\u0430\u0442\u0430 ISO",
+			time: "\u0447\u0430\u0441 ISO",
+			duration: "\u0442\u0440\u0438\u0432\u0430\u043B\u0456\u0441\u0442\u044C ISO",
+			ipv4: "\u0430\u0434\u0440\u0435\u0441\u0430 IPv4",
+			ipv6: "\u0430\u0434\u0440\u0435\u0441\u0430 IPv6",
+			cidrv4: "\u0434\u0456\u0430\u043F\u0430\u0437\u043E\u043D IPv4",
+			cidrv6: "\u0434\u0456\u0430\u043F\u0430\u0437\u043E\u043D IPv6",
+			base64: "\u0440\u044F\u0434\u043E\u043A \u0443 \u043A\u043E\u0434\u0443\u0432\u0430\u043D\u043D\u0456 base64",
+			base64url:
+				"\u0440\u044F\u0434\u043E\u043A \u0443 \u043A\u043E\u0434\u0443\u0432\u0430\u043D\u043D\u0456 base64url",
+			json_string: "\u0440\u044F\u0434\u043E\u043A JSON",
+			e164: "\u043D\u043E\u043C\u0435\u0440 E.164",
+			jwt: "JWT",
+			template_literal: "\u0432\u0445\u0456\u0434\u043D\u0456 \u0434\u0430\u043D\u0456",
+		}
+	return (e) => {
+		switch (e.code) {
+			case "invalid_type":
+				return `\u041D\u0435\u043F\u0440\u0430\u0432\u0438\u043B\u044C\u043D\u0456 \u0432\u0445\u0456\u0434\u043D\u0456 \u0434\u0430\u043D\u0456: \u043E\u0447\u0456\u043A\u0443\u0454\u0442\u044C\u0441\u044F ${e.expected}, \u043E\u0442\u0440\u0438\u043C\u0430\u043D\u043E ${n(e.input)}`
+			case "invalid_value":
+				return e.values.length === 1
+					? `\u041D\u0435\u043F\u0440\u0430\u0432\u0438\u043B\u044C\u043D\u0456 \u0432\u0445\u0456\u0434\u043D\u0456 \u0434\u0430\u043D\u0456: \u043E\u0447\u0456\u043A\u0443\u0454\u0442\u044C\u0441\u044F ${_(e.values[0])}`
+					: `\u041D\u0435\u043F\u0440\u0430\u0432\u0438\u043B\u044C\u043D\u0430 \u043E\u043F\u0446\u0456\u044F: \u043E\u0447\u0456\u043A\u0443\u0454\u0442\u044C\u0441\u044F \u043E\u0434\u043D\u0435 \u0437 ${f(e.values, "|")}`
+			case "too_big": {
+				const o = e.inclusive ? "<=" : "<",
+					a = r(e.origin)
+				return a
+					? `\u0417\u0430\u043D\u0430\u0434\u0442\u043E \u0432\u0435\u043B\u0438\u043A\u0435: \u043E\u0447\u0456\u043A\u0443\u0454\u0442\u044C\u0441\u044F, \u0449\u043E ${e.origin ?? "\u0437\u043D\u0430\u0447\u0435\u043D\u043D\u044F"} ${a.verb} ${o}${e.maximum.toString()} ${a.unit ?? "\u0435\u043B\u0435\u043C\u0435\u043D\u0442\u0456\u0432"}`
+					: `\u0417\u0430\u043D\u0430\u0434\u0442\u043E \u0432\u0435\u043B\u0438\u043A\u0435: \u043E\u0447\u0456\u043A\u0443\u0454\u0442\u044C\u0441\u044F, \u0449\u043E ${e.origin ?? "\u0437\u043D\u0430\u0447\u0435\u043D\u043D\u044F"} \u0431\u0443\u0434\u0435 ${o}${e.maximum.toString()}`
+			}
+			case "too_small": {
+				const o = e.inclusive ? ">=" : ">",
+					a = r(e.origin)
+				return a
+					? `\u0417\u0430\u043D\u0430\u0434\u0442\u043E \u043C\u0430\u043B\u0435: \u043E\u0447\u0456\u043A\u0443\u0454\u0442\u044C\u0441\u044F, \u0449\u043E ${e.origin} ${a.verb} ${o}${e.minimum.toString()} ${a.unit}`
+					: `\u0417\u0430\u043D\u0430\u0434\u0442\u043E \u043C\u0430\u043B\u0435: \u043E\u0447\u0456\u043A\u0443\u0454\u0442\u044C\u0441\u044F, \u0449\u043E ${e.origin} \u0431\u0443\u0434\u0435 ${o}${e.minimum.toString()}`
+			}
+			case "invalid_format": {
+				const o = e
+				return o.format === "starts_with"
+					? `\u041D\u0435\u043F\u0440\u0430\u0432\u0438\u043B\u044C\u043D\u0438\u0439 \u0440\u044F\u0434\u043E\u043A: \u043F\u043E\u0432\u0438\u043D\u0435\u043D \u043F\u043E\u0447\u0438\u043D\u0430\u0442\u0438\u0441\u044F \u0437 "${o.prefix}"`
+					: o.format === "ends_with"
+						? `\u041D\u0435\u043F\u0440\u0430\u0432\u0438\u043B\u044C\u043D\u0438\u0439 \u0440\u044F\u0434\u043E\u043A: \u043F\u043E\u0432\u0438\u043D\u0435\u043D \u0437\u0430\u043A\u0456\u043D\u0447\u0443\u0432\u0430\u0442\u0438\u0441\u044F \u043D\u0430 "${o.suffix}"`
+						: o.format === "includes"
+							? `\u041D\u0435\u043F\u0440\u0430\u0432\u0438\u043B\u044C\u043D\u0438\u0439 \u0440\u044F\u0434\u043E\u043A: \u043F\u043E\u0432\u0438\u043D\u0435\u043D \u043C\u0456\u0441\u0442\u0438\u0442\u0438 "${o.includes}"`
+							: o.format === "regex"
+								? `\u041D\u0435\u043F\u0440\u0430\u0432\u0438\u043B\u044C\u043D\u0438\u0439 \u0440\u044F\u0434\u043E\u043A: \u043F\u043E\u0432\u0438\u043D\u0435\u043D \u0432\u0456\u0434\u043F\u043E\u0432\u0456\u0434\u0430\u0442\u0438 \u0448\u0430\u0431\u043B\u043E\u043D\u0443 ${o.pattern}`
+								: `\u041D\u0435\u043F\u0440\u0430\u0432\u0438\u043B\u044C\u043D\u0438\u0439 ${i[o.format] ?? e.format}`
+			}
+			case "not_multiple_of":
+				return `\u041D\u0435\u043F\u0440\u0430\u0432\u0438\u043B\u044C\u043D\u0435 \u0447\u0438\u0441\u043B\u043E: \u043F\u043E\u0432\u0438\u043D\u043D\u043E \u0431\u0443\u0442\u0438 \u043A\u0440\u0430\u0442\u043D\u0438\u043C ${e.divisor}`
+			case "unrecognized_keys":
+				return `\u041D\u0435\u0440\u043E\u0437\u043F\u0456\u0437\u043D\u0430\u043D\u0438\u0439 \u043A\u043B\u044E\u0447${e.keys.length > 1 ? "\u0456" : ""}: ${f(e.keys, ", ")}`
+			case "invalid_key":
+				return `\u041D\u0435\u043F\u0440\u0430\u0432\u0438\u043B\u044C\u043D\u0438\u0439 \u043A\u043B\u044E\u0447 \u0443 ${e.origin}`
+			case "invalid_union":
+				return "\u041D\u0435\u043F\u0440\u0430\u0432\u0438\u043B\u044C\u043D\u0456 \u0432\u0445\u0456\u0434\u043D\u0456 \u0434\u0430\u043D\u0456"
+			case "invalid_element":
+				return `\u041D\u0435\u043F\u0440\u0430\u0432\u0438\u043B\u044C\u043D\u0435 \u0437\u043D\u0430\u0447\u0435\u043D\u043D\u044F \u0443 ${e.origin}`
+			default:
+				return "\u041D\u0435\u043F\u0440\u0430\u0432\u0438\u043B\u044C\u043D\u0456 \u0432\u0445\u0456\u0434\u043D\u0456 \u0434\u0430\u043D\u0456"
+		}
+	}
+}
+function Pc() {
+	return { localeError: Yl() }
+}
+var em = () => {
+	const t = {
+		string: { unit: "\u062D\u0631\u0648\u0641", verb: "\u06C1\u0648\u0646\u0627" },
+		file: { unit: "\u0628\u0627\u0626\u0679\u0633", verb: "\u06C1\u0648\u0646\u0627" },
+		array: { unit: "\u0622\u0626\u0679\u0645\u0632", verb: "\u06C1\u0648\u0646\u0627" },
+		set: { unit: "\u0622\u0626\u0679\u0645\u0632", verb: "\u06C1\u0648\u0646\u0627" },
+	}
+	function r(e) {
+		return t[e] ?? null
+	}
+	const n = (e) => {
+			const o = typeof e
+			switch (o) {
+				case "number":
+					return Number.isNaN(e) ? "NaN" : "\u0646\u0645\u0628\u0631"
+				case "object": {
+					if (Array.isArray(e)) return "\u0622\u0631\u06D2"
+					if (e === null) return "\u0646\u0644"
+					if (Object.getPrototypeOf(e) !== Object.prototype && e.constructor) return e.constructor.name
+				}
+			}
+			return o
+		},
+		i = {
+			regex: "\u0627\u0646 \u067E\u0679",
+			email: "\u0627\u06CC \u0645\u06CC\u0644 \u0627\u06CC\u0688\u0631\u06CC\u0633",
+			url: "\u06CC\u0648 \u0622\u0631 \u0627\u06CC\u0644",
+			emoji: "\u0627\u06CC\u0645\u0648\u062C\u06CC",
+			uuid: "\u06CC\u0648 \u06CC\u0648 \u0622\u0626\u06CC \u0688\u06CC",
+			uuidv4: "\u06CC\u0648 \u06CC\u0648 \u0622\u0626\u06CC \u0688\u06CC \u0648\u06CC 4",
+			uuidv6: "\u06CC\u0648 \u06CC\u0648 \u0622\u0626\u06CC \u0688\u06CC \u0648\u06CC 6",
+			nanoid: "\u0646\u06CC\u0646\u0648 \u0622\u0626\u06CC \u0688\u06CC",
+			guid: "\u062C\u06CC \u06CC\u0648 \u0622\u0626\u06CC \u0688\u06CC",
+			cuid: "\u0633\u06CC \u06CC\u0648 \u0622\u0626\u06CC \u0688\u06CC",
+			cuid2: "\u0633\u06CC \u06CC\u0648 \u0622\u0626\u06CC \u0688\u06CC 2",
+			ulid: "\u06CC\u0648 \u0627\u06CC\u0644 \u0622\u0626\u06CC \u0688\u06CC",
+			xid: "\u0627\u06CC\u06A9\u0633 \u0622\u0626\u06CC \u0688\u06CC",
+			ksuid: "\u06A9\u06D2 \u0627\u06CC\u0633 \u06CC\u0648 \u0622\u0626\u06CC \u0688\u06CC",
+			datetime: "\u0622\u0626\u06CC \u0627\u06CC\u0633 \u0627\u0648 \u0688\u06CC\u0679 \u0679\u0627\u0626\u0645",
+			date: "\u0622\u0626\u06CC \u0627\u06CC\u0633 \u0627\u0648 \u062A\u0627\u0631\u06CC\u062E",
+			time: "\u0622\u0626\u06CC \u0627\u06CC\u0633 \u0627\u0648 \u0648\u0642\u062A",
+			duration: "\u0622\u0626\u06CC \u0627\u06CC\u0633 \u0627\u0648 \u0645\u062F\u062A",
+			ipv4: "\u0622\u0626\u06CC \u067E\u06CC \u0648\u06CC 4 \u0627\u06CC\u0688\u0631\u06CC\u0633",
+			ipv6: "\u0622\u0626\u06CC \u067E\u06CC \u0648\u06CC 6 \u0627\u06CC\u0688\u0631\u06CC\u0633",
+			cidrv4: "\u0622\u0626\u06CC \u067E\u06CC \u0648\u06CC 4 \u0631\u06CC\u0646\u062C",
+			cidrv6: "\u0622\u0626\u06CC \u067E\u06CC \u0648\u06CC 6 \u0631\u06CC\u0646\u062C",
+			base64: "\u0628\u06CC\u0633 64 \u0627\u0646 \u06A9\u0648\u0688\u0688 \u0633\u0679\u0631\u0646\u06AF",
+			base64url:
+				"\u0628\u06CC\u0633 64 \u06CC\u0648 \u0622\u0631 \u0627\u06CC\u0644 \u0627\u0646 \u06A9\u0648\u0688\u0688 \u0633\u0679\u0631\u0646\u06AF",
+			json_string: "\u062C\u06D2 \u0627\u06CC\u0633 \u0627\u0648 \u0627\u06CC\u0646 \u0633\u0679\u0631\u0646\u06AF",
+			e164: "\u0627\u06CC 164 \u0646\u0645\u0628\u0631",
+			jwt: "\u062C\u06D2 \u0688\u0628\u0644\u06CC\u0648 \u0679\u06CC",
+			template_literal: "\u0627\u0646 \u067E\u0679",
+		}
+	return (e) => {
+		switch (e.code) {
+			case "invalid_type":
+				return `\u063A\u0644\u0637 \u0627\u0646 \u067E\u0679: ${e.expected} \u0645\u062A\u0648\u0642\u0639 \u062A\u06BE\u0627\u060C ${n(e.input)} \u0645\u0648\u0635\u0648\u0644 \u06C1\u0648\u0627`
+			case "invalid_value":
+				return e.values.length === 1
+					? `\u063A\u0644\u0637 \u0627\u0646 \u067E\u0679: ${_(e.values[0])} \u0645\u062A\u0648\u0642\u0639 \u062A\u06BE\u0627`
+					: `\u063A\u0644\u0637 \u0622\u067E\u0634\u0646: ${f(e.values, "|")} \u0645\u06CC\u06BA \u0633\u06D2 \u0627\u06CC\u06A9 \u0645\u062A\u0648\u0642\u0639 \u062A\u06BE\u0627`
+			case "too_big": {
+				const o = e.inclusive ? "<=" : "<",
+					a = r(e.origin)
+				return a
+					? `\u0628\u06C1\u062A \u0628\u0691\u0627: ${e.origin ?? "\u0648\u06CC\u0644\u06CC\u0648"} \u06A9\u06D2 ${o}${e.maximum.toString()} ${a.unit ?? "\u0639\u0646\u0627\u0635\u0631"} \u06C1\u0648\u0646\u06D2 \u0645\u062A\u0648\u0642\u0639 \u062A\u06BE\u06D2`
+					: `\u0628\u06C1\u062A \u0628\u0691\u0627: ${e.origin ?? "\u0648\u06CC\u0644\u06CC\u0648"} \u06A9\u0627 ${o}${e.maximum.toString()} \u06C1\u0648\u0646\u0627 \u0645\u062A\u0648\u0642\u0639 \u062A\u06BE\u0627`
+			}
+			case "too_small": {
+				const o = e.inclusive ? ">=" : ">",
+					a = r(e.origin)
+				return a
+					? `\u0628\u06C1\u062A \u0686\u06BE\u0648\u0679\u0627: ${e.origin} \u06A9\u06D2 ${o}${e.minimum.toString()} ${a.unit} \u06C1\u0648\u0646\u06D2 \u0645\u062A\u0648\u0642\u0639 \u062A\u06BE\u06D2`
+					: `\u0628\u06C1\u062A \u0686\u06BE\u0648\u0679\u0627: ${e.origin} \u06A9\u0627 ${o}${e.minimum.toString()} \u06C1\u0648\u0646\u0627 \u0645\u062A\u0648\u0642\u0639 \u062A\u06BE\u0627`
+			}
+			case "invalid_format": {
+				const o = e
+				return o.format === "starts_with"
+					? `\u063A\u0644\u0637 \u0633\u0679\u0631\u0646\u06AF: "${o.prefix}" \u0633\u06D2 \u0634\u0631\u0648\u0639 \u06C1\u0648\u0646\u0627 \u0686\u0627\u06C1\u06CC\u06D2`
+					: o.format === "ends_with"
+						? `\u063A\u0644\u0637 \u0633\u0679\u0631\u0646\u06AF: "${o.suffix}" \u067E\u0631 \u062E\u062A\u0645 \u06C1\u0648\u0646\u0627 \u0686\u0627\u06C1\u06CC\u06D2`
+						: o.format === "includes"
+							? `\u063A\u0644\u0637 \u0633\u0679\u0631\u0646\u06AF: "${o.includes}" \u0634\u0627\u0645\u0644 \u06C1\u0648\u0646\u0627 \u0686\u0627\u06C1\u06CC\u06D2`
+							: o.format === "regex"
+								? `\u063A\u0644\u0637 \u0633\u0679\u0631\u0646\u06AF: \u067E\u06CC\u0679\u0631\u0646 ${o.pattern} \u0633\u06D2 \u0645\u06CC\u0686 \u06C1\u0648\u0646\u0627 \u0686\u0627\u06C1\u06CC\u06D2`
+								: `\u063A\u0644\u0637 ${i[o.format] ?? e.format}`
+			}
+			case "not_multiple_of":
+				return `\u063A\u0644\u0637 \u0646\u0645\u0628\u0631: ${e.divisor} \u06A9\u0627 \u0645\u0636\u0627\u0639\u0641 \u06C1\u0648\u0646\u0627 \u0686\u0627\u06C1\u06CC\u06D2`
+			case "unrecognized_keys":
+				return `\u063A\u06CC\u0631 \u062A\u0633\u0644\u06CC\u0645 \u0634\u062F\u06C1 \u06A9\u06CC${e.keys.length > 1 ? "\u0632" : ""}: ${f(e.keys, "\u060C ")}`
+			case "invalid_key":
+				return `${e.origin} \u0645\u06CC\u06BA \u063A\u0644\u0637 \u06A9\u06CC`
+			case "invalid_union":
+				return "\u063A\u0644\u0637 \u0627\u0646 \u067E\u0679"
+			case "invalid_element":
+				return `${e.origin} \u0645\u06CC\u06BA \u063A\u0644\u0637 \u0648\u06CC\u0644\u06CC\u0648`
+			default:
+				return "\u063A\u0644\u0637 \u0627\u0646 \u067E\u0679"
+		}
+	}
+}
+function Tc() {
+	return { localeError: em() }
+}
+var tm = () => {
+	const t = {
+		string: { unit: "k\xFD t\u1EF1", verb: "c\xF3" },
+		file: { unit: "byte", verb: "c\xF3" },
+		array: { unit: "ph\u1EA7n t\u1EED", verb: "c\xF3" },
+		set: { unit: "ph\u1EA7n t\u1EED", verb: "c\xF3" },
+	}
+	function r(e) {
+		return t[e] ?? null
+	}
+	const n = (e) => {
+			const o = typeof e
+			switch (o) {
+				case "number":
+					return Number.isNaN(e) ? "NaN" : "s\u1ED1"
+				case "object": {
+					if (Array.isArray(e)) return "m\u1EA3ng"
+					if (e === null) return "null"
+					if (Object.getPrototypeOf(e) !== Object.prototype && e.constructor) return e.constructor.name
+				}
+			}
+			return o
+		},
+		i = {
+			regex: "\u0111\u1EA7u v\xE0o",
+			email: "\u0111\u1ECBa ch\u1EC9 email",
+			url: "URL",
+			emoji: "emoji",
+			uuid: "UUID",
+			uuidv4: "UUIDv4",
+			uuidv6: "UUIDv6",
+			nanoid: "nanoid",
+			guid: "GUID",
+			cuid: "cuid",
+			cuid2: "cuid2",
+			ulid: "ULID",
+			xid: "XID",
+			ksuid: "KSUID",
+			datetime: "ng\xE0y gi\u1EDD ISO",
+			date: "ng\xE0y ISO",
+			time: "gi\u1EDD ISO",
+			duration: "kho\u1EA3ng th\u1EDDi gian ISO",
+			ipv4: "\u0111\u1ECBa ch\u1EC9 IPv4",
+			ipv6: "\u0111\u1ECBa ch\u1EC9 IPv6",
+			cidrv4: "d\u1EA3i IPv4",
+			cidrv6: "d\u1EA3i IPv6",
+			base64: "chu\u1ED7i m\xE3 h\xF3a base64",
+			base64url: "chu\u1ED7i m\xE3 h\xF3a base64url",
+			json_string: "chu\u1ED7i JSON",
+			e164: "s\u1ED1 E.164",
+			jwt: "JWT",
+			template_literal: "\u0111\u1EA7u v\xE0o",
+		}
+	return (e) => {
+		switch (e.code) {
+			case "invalid_type":
+				return `\u0110\u1EA7u v\xE0o kh\xF4ng h\u1EE3p l\u1EC7: mong \u0111\u1EE3i ${e.expected}, nh\u1EADn \u0111\u01B0\u1EE3c ${n(e.input)}`
+			case "invalid_value":
+				return e.values.length === 1
+					? `\u0110\u1EA7u v\xE0o kh\xF4ng h\u1EE3p l\u1EC7: mong \u0111\u1EE3i ${_(e.values[0])}`
+					: `T\xF9y ch\u1ECDn kh\xF4ng h\u1EE3p l\u1EC7: mong \u0111\u1EE3i m\u1ED9t trong c\xE1c gi\xE1 tr\u1ECB ${f(e.values, "|")}`
+			case "too_big": {
+				const o = e.inclusive ? "<=" : "<",
+					a = r(e.origin)
+				return a
+					? `Qu\xE1 l\u1EDBn: mong \u0111\u1EE3i ${e.origin ?? "gi\xE1 tr\u1ECB"} ${a.verb} ${o}${e.maximum.toString()} ${a.unit ?? "ph\u1EA7n t\u1EED"}`
+					: `Qu\xE1 l\u1EDBn: mong \u0111\u1EE3i ${e.origin ?? "gi\xE1 tr\u1ECB"} ${o}${e.maximum.toString()}`
+			}
+			case "too_small": {
+				const o = e.inclusive ? ">=" : ">",
+					a = r(e.origin)
+				return a
+					? `Qu\xE1 nh\u1ECF: mong \u0111\u1EE3i ${e.origin} ${a.verb} ${o}${e.minimum.toString()} ${a.unit}`
+					: `Qu\xE1 nh\u1ECF: mong \u0111\u1EE3i ${e.origin} ${o}${e.minimum.toString()}`
+			}
+			case "invalid_format": {
+				const o = e
+				return o.format === "starts_with"
+					? `Chu\u1ED7i kh\xF4ng h\u1EE3p l\u1EC7: ph\u1EA3i b\u1EAFt \u0111\u1EA7u b\u1EB1ng "${o.prefix}"`
+					: o.format === "ends_with"
+						? `Chu\u1ED7i kh\xF4ng h\u1EE3p l\u1EC7: ph\u1EA3i k\u1EBFt th\xFAc b\u1EB1ng "${o.suffix}"`
+						: o.format === "includes"
+							? `Chu\u1ED7i kh\xF4ng h\u1EE3p l\u1EC7: ph\u1EA3i bao g\u1ED3m "${o.includes}"`
+							: o.format === "regex"
+								? `Chu\u1ED7i kh\xF4ng h\u1EE3p l\u1EC7: ph\u1EA3i kh\u1EDBp v\u1EDBi m\u1EABu ${o.pattern}`
+								: `${i[o.format] ?? e.format} kh\xF4ng h\u1EE3p l\u1EC7`
+			}
+			case "not_multiple_of":
+				return `S\u1ED1 kh\xF4ng h\u1EE3p l\u1EC7: ph\u1EA3i l\xE0 b\u1ED9i s\u1ED1 c\u1EE7a ${e.divisor}`
+			case "unrecognized_keys":
+				return `Kh\xF3a kh\xF4ng \u0111\u01B0\u1EE3c nh\u1EADn d\u1EA1ng: ${f(e.keys, ", ")}`
+			case "invalid_key":
+				return `Kh\xF3a kh\xF4ng h\u1EE3p l\u1EC7 trong ${e.origin}`
+			case "invalid_union":
+				return "\u0110\u1EA7u v\xE0o kh\xF4ng h\u1EE3p l\u1EC7"
+			case "invalid_element":
+				return `Gi\xE1 tr\u1ECB kh\xF4ng h\u1EE3p l\u1EC7 trong ${e.origin}`
+			default:
+				return "\u0110\u1EA7u v\xE0o kh\xF4ng h\u1EE3p l\u1EC7"
+		}
+	}
+}
+function Oc() {
+	return { localeError: tm() }
+}
+var rm = () => {
+	const t = {
+		string: { unit: "\u5B57\u7B26", verb: "\u5305\u542B" },
+		file: { unit: "\u5B57\u8282", verb: "\u5305\u542B" },
+		array: { unit: "\u9879", verb: "\u5305\u542B" },
+		set: { unit: "\u9879", verb: "\u5305\u542B" },
+	}
+	function r(e) {
+		return t[e] ?? null
+	}
+	const n = (e) => {
+			const o = typeof e
+			switch (o) {
+				case "number":
+					return Number.isNaN(e) ? "\u975E\u6570\u5B57(NaN)" : "\u6570\u5B57"
+				case "object": {
+					if (Array.isArray(e)) return "\u6570\u7EC4"
+					if (e === null) return "\u7A7A\u503C(null)"
+					if (Object.getPrototypeOf(e) !== Object.prototype && e.constructor) return e.constructor.name
+				}
+			}
+			return o
+		},
+		i = {
+			regex: "\u8F93\u5165",
+			email: "\u7535\u5B50\u90AE\u4EF6",
+			url: "URL",
+			emoji: "\u8868\u60C5\u7B26\u53F7",
+			uuid: "UUID",
+			uuidv4: "UUIDv4",
+			uuidv6: "UUIDv6",
+			nanoid: "nanoid",
+			guid: "GUID",
+			cuid: "cuid",
+			cuid2: "cuid2",
+			ulid: "ULID",
+			xid: "XID",
+			ksuid: "KSUID",
+			datetime: "ISO\u65E5\u671F\u65F6\u95F4",
+			date: "ISO\u65E5\u671F",
+			time: "ISO\u65F6\u95F4",
+			duration: "ISO\u65F6\u957F",
+			ipv4: "IPv4\u5730\u5740",
+			ipv6: "IPv6\u5730\u5740",
+			cidrv4: "IPv4\u7F51\u6BB5",
+			cidrv6: "IPv6\u7F51\u6BB5",
+			base64: "base64\u7F16\u7801\u5B57\u7B26\u4E32",
+			base64url: "base64url\u7F16\u7801\u5B57\u7B26\u4E32",
+			json_string: "JSON\u5B57\u7B26\u4E32",
+			e164: "E.164\u53F7\u7801",
+			jwt: "JWT",
+			template_literal: "\u8F93\u5165",
+		}
+	return (e) => {
+		switch (e.code) {
+			case "invalid_type":
+				return `\u65E0\u6548\u8F93\u5165\uFF1A\u671F\u671B ${e.expected}\uFF0C\u5B9E\u9645\u63A5\u6536 ${n(e.input)}`
+			case "invalid_value":
+				return e.values.length === 1
+					? `\u65E0\u6548\u8F93\u5165\uFF1A\u671F\u671B ${_(e.values[0])}`
+					: `\u65E0\u6548\u9009\u9879\uFF1A\u671F\u671B\u4EE5\u4E0B\u4E4B\u4E00 ${f(e.values, "|")}`
+			case "too_big": {
+				const o = e.inclusive ? "<=" : "<",
+					a = r(e.origin)
+				return a
+					? `\u6570\u503C\u8FC7\u5927\uFF1A\u671F\u671B ${e.origin ?? "\u503C"} ${o}${e.maximum.toString()} ${a.unit ?? "\u4E2A\u5143\u7D20"}`
+					: `\u6570\u503C\u8FC7\u5927\uFF1A\u671F\u671B ${e.origin ?? "\u503C"} ${o}${e.maximum.toString()}`
+			}
+			case "too_small": {
+				const o = e.inclusive ? ">=" : ">",
+					a = r(e.origin)
+				return a
+					? `\u6570\u503C\u8FC7\u5C0F\uFF1A\u671F\u671B ${e.origin} ${o}${e.minimum.toString()} ${a.unit}`
+					: `\u6570\u503C\u8FC7\u5C0F\uFF1A\u671F\u671B ${e.origin} ${o}${e.minimum.toString()}`
+			}
+			case "invalid_format": {
+				const o = e
+				return o.format === "starts_with"
+					? `\u65E0\u6548\u5B57\u7B26\u4E32\uFF1A\u5FC5\u987B\u4EE5 "${o.prefix}" \u5F00\u5934`
+					: o.format === "ends_with"
+						? `\u65E0\u6548\u5B57\u7B26\u4E32\uFF1A\u5FC5\u987B\u4EE5 "${o.suffix}" \u7ED3\u5C3E`
+						: o.format === "includes"
+							? `\u65E0\u6548\u5B57\u7B26\u4E32\uFF1A\u5FC5\u987B\u5305\u542B "${o.includes}"`
+							: o.format === "regex"
+								? `\u65E0\u6548\u5B57\u7B26\u4E32\uFF1A\u5FC5\u987B\u6EE1\u8DB3\u6B63\u5219\u8868\u8FBE\u5F0F ${o.pattern}`
+								: `\u65E0\u6548${i[o.format] ?? e.format}`
+			}
+			case "not_multiple_of":
+				return `\u65E0\u6548\u6570\u5B57\uFF1A\u5FC5\u987B\u662F ${e.divisor} \u7684\u500D\u6570`
+			case "unrecognized_keys":
+				return `\u51FA\u73B0\u672A\u77E5\u7684\u952E(key): ${f(e.keys, ", ")}`
+			case "invalid_key":
+				return `${e.origin} \u4E2D\u7684\u952E(key)\u65E0\u6548`
+			case "invalid_union":
+				return "\u65E0\u6548\u8F93\u5165"
+			case "invalid_element":
+				return `${e.origin} \u4E2D\u5305\u542B\u65E0\u6548\u503C(value)`
+			default:
+				return "\u65E0\u6548\u8F93\u5165"
+		}
+	}
+}
+function Nc() {
+	return { localeError: rm() }
+}
+var nm = () => {
+	const t = {
+		string: { unit: "\u5B57\u5143", verb: "\u64C1\u6709" },
+		file: { unit: "\u4F4D\u5143\u7D44", verb: "\u64C1\u6709" },
+		array: { unit: "\u9805\u76EE", verb: "\u64C1\u6709" },
+		set: { unit: "\u9805\u76EE", verb: "\u64C1\u6709" },
+	}
+	function r(e) {
+		return t[e] ?? null
+	}
+	const n = (e) => {
+			const o = typeof e
+			switch (o) {
+				case "number":
+					return Number.isNaN(e) ? "NaN" : "number"
+				case "object": {
+					if (Array.isArray(e)) return "array"
+					if (e === null) return "null"
+					if (Object.getPrototypeOf(e) !== Object.prototype && e.constructor) return e.constructor.name
+				}
+			}
+			return o
+		},
+		i = {
+			regex: "\u8F38\u5165",
+			email: "\u90F5\u4EF6\u5730\u5740",
+			url: "URL",
+			emoji: "emoji",
+			uuid: "UUID",
+			uuidv4: "UUIDv4",
+			uuidv6: "UUIDv6",
+			nanoid: "nanoid",
+			guid: "GUID",
+			cuid: "cuid",
+			cuid2: "cuid2",
+			ulid: "ULID",
+			xid: "XID",
+			ksuid: "KSUID",
+			datetime: "ISO \u65E5\u671F\u6642\u9593",
+			date: "ISO \u65E5\u671F",
+			time: "ISO \u6642\u9593",
+			duration: "ISO \u671F\u9593",
+			ipv4: "IPv4 \u4F4D\u5740",
+			ipv6: "IPv6 \u4F4D\u5740",
+			cidrv4: "IPv4 \u7BC4\u570D",
+			cidrv6: "IPv6 \u7BC4\u570D",
+			base64: "base64 \u7DE8\u78BC\u5B57\u4E32",
+			base64url: "base64url \u7DE8\u78BC\u5B57\u4E32",
+			json_string: "JSON \u5B57\u4E32",
+			e164: "E.164 \u6578\u503C",
+			jwt: "JWT",
+			template_literal: "\u8F38\u5165",
+		}
+	return (e) => {
+		switch (e.code) {
+			case "invalid_type":
+				return `\u7121\u6548\u7684\u8F38\u5165\u503C\uFF1A\u9810\u671F\u70BA ${e.expected}\uFF0C\u4F46\u6536\u5230 ${n(e.input)}`
+			case "invalid_value":
+				return e.values.length === 1
+					? `\u7121\u6548\u7684\u8F38\u5165\u503C\uFF1A\u9810\u671F\u70BA ${_(e.values[0])}`
+					: `\u7121\u6548\u7684\u9078\u9805\uFF1A\u9810\u671F\u70BA\u4EE5\u4E0B\u5176\u4E2D\u4E4B\u4E00 ${f(e.values, "|")}`
+			case "too_big": {
+				const o = e.inclusive ? "<=" : "<",
+					a = r(e.origin)
+				return a
+					? `\u6578\u503C\u904E\u5927\uFF1A\u9810\u671F ${e.origin ?? "\u503C"} \u61C9\u70BA ${o}${e.maximum.toString()} ${a.unit ?? "\u500B\u5143\u7D20"}`
+					: `\u6578\u503C\u904E\u5927\uFF1A\u9810\u671F ${e.origin ?? "\u503C"} \u61C9\u70BA ${o}${e.maximum.toString()}`
+			}
+			case "too_small": {
+				const o = e.inclusive ? ">=" : ">",
+					a = r(e.origin)
+				return a
+					? `\u6578\u503C\u904E\u5C0F\uFF1A\u9810\u671F ${e.origin} \u61C9\u70BA ${o}${e.minimum.toString()} ${a.unit}`
+					: `\u6578\u503C\u904E\u5C0F\uFF1A\u9810\u671F ${e.origin} \u61C9\u70BA ${o}${e.minimum.toString()}`
+			}
+			case "invalid_format": {
+				const o = e
+				return o.format === "starts_with"
+					? `\u7121\u6548\u7684\u5B57\u4E32\uFF1A\u5FC5\u9808\u4EE5 "${o.prefix}" \u958B\u982D`
+					: o.format === "ends_with"
+						? `\u7121\u6548\u7684\u5B57\u4E32\uFF1A\u5FC5\u9808\u4EE5 "${o.suffix}" \u7D50\u5C3E`
+						: o.format === "includes"
+							? `\u7121\u6548\u7684\u5B57\u4E32\uFF1A\u5FC5\u9808\u5305\u542B "${o.includes}"`
+							: o.format === "regex"
+								? `\u7121\u6548\u7684\u5B57\u4E32\uFF1A\u5FC5\u9808\u7B26\u5408\u683C\u5F0F ${o.pattern}`
+								: `\u7121\u6548\u7684 ${i[o.format] ?? e.format}`
+			}
+			case "not_multiple_of":
+				return `\u7121\u6548\u7684\u6578\u5B57\uFF1A\u5FC5\u9808\u70BA ${e.divisor} \u7684\u500D\u6578`
+			case "unrecognized_keys":
+				return `\u7121\u6CD5\u8B58\u5225\u7684\u9375\u503C${e.keys.length > 1 ? "\u5011" : ""}\uFF1A${f(e.keys, "\u3001")}`
+			case "invalid_key":
+				return `${e.origin} \u4E2D\u6709\u7121\u6548\u7684\u9375\u503C`
+			case "invalid_union":
+				return "\u7121\u6548\u7684\u8F38\u5165\u503C"
+			case "invalid_element":
+				return `${e.origin} \u4E2D\u6709\u7121\u6548\u7684\u503C`
+			default:
+				return "\u7121\u6548\u7684\u8F38\u5165\u503C"
+		}
+	}
+}
+function Uc() {
+	return { localeError: nm() }
+}
+var ki = Symbol("ZodOutput"),
+	Si = Symbol("ZodInput"),
+	Ae = class {
+		constructor() {
+			;(this._map = new Map()), (this._idmap = new Map())
+		}
+		add(r, ...n) {
+			const i = n[0]
+			if ((this._map.set(r, i), i && typeof i == "object" && "id" in i)) {
+				if (this._idmap.has(i.id)) throw new Error(`ID ${i.id} already exists in the registry`)
+				this._idmap.set(i.id, r)
+			}
+			return this
+		}
+		clear() {
+			return (this._map = new Map()), (this._idmap = new Map()), this
+		}
+		remove(r) {
+			const n = this._map.get(r)
+			return n && typeof n == "object" && "id" in n && this._idmap.delete(n.id), this._map.delete(r), this
+		}
+		get(r) {
+			const n = r._zod.parent
+			if (n) {
+				const i = { ...(this.get(n) ?? {}) }
+				return delete i.id, { ...i, ...this._map.get(r) }
+			}
+			return this._map.get(r)
+		}
+		has(r) {
+			return this._map.has(r)
+		}
+	}
+function mr() {
+	return new Ae()
+}
+var ce = mr()
+function wi(t, r) {
+	return new t({ type: "string", ...v(r) })
+}
+function Ii(t, r) {
+	return new t({ type: "string", coerce: !0, ...v(r) })
+}
+function pr(t, r) {
+	return new t({ type: "string", format: "email", check: "string_format", abort: !1, ...v(r) })
+}
+function ht(t, r) {
+	return new t({ type: "string", format: "guid", check: "string_format", abort: !1, ...v(r) })
+}
+function dr(t, r) {
+	return new t({ type: "string", format: "uuid", check: "string_format", abort: !1, ...v(r) })
+}
+function fr(t, r) {
+	return new t({ type: "string", format: "uuid", check: "string_format", abort: !1, version: "v4", ...v(r) })
+}
+function gr(t, r) {
+	return new t({ type: "string", format: "uuid", check: "string_format", abort: !1, version: "v6", ...v(r) })
+}
+function hr(t, r) {
+	return new t({ type: "string", format: "uuid", check: "string_format", abort: !1, version: "v7", ...v(r) })
+}
+function vr(t, r) {
+	return new t({ type: "string", format: "url", check: "string_format", abort: !1, ...v(r) })
+}
+function br(t, r) {
+	return new t({ type: "string", format: "emoji", check: "string_format", abort: !1, ...v(r) })
+}
+function _r(t, r) {
+	return new t({ type: "string", format: "nanoid", check: "string_format", abort: !1, ...v(r) })
+}
+function yr(t, r) {
+	return new t({ type: "string", format: "cuid", check: "string_format", abort: !1, ...v(r) })
+}
+function $r(t, r) {
+	return new t({ type: "string", format: "cuid2", check: "string_format", abort: !1, ...v(r) })
+}
+function xr(t, r) {
+	return new t({ type: "string", format: "ulid", check: "string_format", abort: !1, ...v(r) })
+}
+function zr(t, r) {
+	return new t({ type: "string", format: "xid", check: "string_format", abort: !1, ...v(r) })
+}
+function kr(t, r) {
+	return new t({ type: "string", format: "ksuid", check: "string_format", abort: !1, ...v(r) })
+}
+function Sr(t, r) {
+	return new t({ type: "string", format: "ipv4", check: "string_format", abort: !1, ...v(r) })
+}
+function wr(t, r) {
+	return new t({ type: "string", format: "ipv6", check: "string_format", abort: !1, ...v(r) })
+}
+function Ir(t, r) {
+	return new t({ type: "string", format: "cidrv4", check: "string_format", abort: !1, ...v(r) })
+}
+function jr(t, r) {
+	return new t({ type: "string", format: "cidrv6", check: "string_format", abort: !1, ...v(r) })
+}
+function Pr(t, r) {
+	return new t({ type: "string", format: "base64", check: "string_format", abort: !1, ...v(r) })
+}
+function Tr(t, r) {
+	return new t({ type: "string", format: "base64url", check: "string_format", abort: !1, ...v(r) })
+}
+function Or(t, r) {
+	return new t({ type: "string", format: "e164", check: "string_format", abort: !1, ...v(r) })
+}
+function Nr(t, r) {
+	return new t({ type: "string", format: "jwt", check: "string_format", abort: !1, ...v(r) })
+}
+var ji = { Any: null, Minute: -1, Second: 0, Millisecond: 3, Microsecond: 6 }
+function Pi(t, r) {
+	return new t({
+		type: "string",
+		format: "datetime",
+		check: "string_format",
+		offset: !1,
+		local: !1,
+		precision: null,
+		...v(r),
+	})
+}
+function Ti(t, r) {
+	return new t({ type: "string", format: "date", check: "string_format", ...v(r) })
+}
+function Oi(t, r) {
+	return new t({ type: "string", format: "time", check: "string_format", precision: null, ...v(r) })
+}
+function Ni(t, r) {
+	return new t({ type: "string", format: "duration", check: "string_format", ...v(r) })
+}
+function Ui(t, r) {
+	return new t({ type: "number", checks: [], ...v(r) })
+}
+function Zi(t, r) {
+	return new t({ type: "number", coerce: !0, checks: [], ...v(r) })
+}
+function Di(t, r) {
+	return new t({ type: "number", check: "number_format", abort: !1, format: "safeint", ...v(r) })
+}
+function Ri(t, r) {
+	return new t({ type: "number", check: "number_format", abort: !1, format: "float32", ...v(r) })
+}
+function Ei(t, r) {
+	return new t({ type: "number", check: "number_format", abort: !1, format: "float64", ...v(r) })
+}
+function Ai(t, r) {
+	return new t({ type: "number", check: "number_format", abort: !1, format: "int32", ...v(r) })
+}
+function Ci(t, r) {
+	return new t({ type: "number", check: "number_format", abort: !1, format: "uint32", ...v(r) })
+}
+function Li(t, r) {
+	return new t({ type: "boolean", ...v(r) })
+}
+function Mi(t, r) {
+	return new t({ type: "boolean", coerce: !0, ...v(r) })
+}
+function qi(t, r) {
+	return new t({ type: "bigint", ...v(r) })
+}
+function Vi(t, r) {
+	return new t({ type: "bigint", coerce: !0, ...v(r) })
+}
+function Fi(t, r) {
+	return new t({ type: "bigint", check: "bigint_format", abort: !1, format: "int64", ...v(r) })
+}
+function Hi(t, r) {
+	return new t({ type: "bigint", check: "bigint_format", abort: !1, format: "uint64", ...v(r) })
+}
+function Ji(t, r) {
+	return new t({ type: "symbol", ...v(r) })
+}
+function Bi(t, r) {
+	return new t({ type: "undefined", ...v(r) })
+}
+function Wi(t, r) {
+	return new t({ type: "null", ...v(r) })
+}
+function Gi(t) {
+	return new t({ type: "any" })
+}
+function Ce(t) {
+	return new t({ type: "unknown" })
+}
+function Ki(t, r) {
+	return new t({ type: "never", ...v(r) })
+}
+function Qi(t, r) {
+	return new t({ type: "void", ...v(r) })
+}
+function Xi(t, r) {
+	return new t({ type: "date", ...v(r) })
+}
+function Yi(t, r) {
+	return new t({ type: "date", coerce: !0, ...v(r) })
+}
+function ea(t, r) {
+	return new t({ type: "nan", ...v(r) })
+}
+function le(t, r) {
+	return new nr({ check: "less_than", ...v(r), value: t, inclusive: !1 })
+}
+function oe(t, r) {
+	return new nr({ check: "less_than", ...v(r), value: t, inclusive: !0 })
+}
+function me(t, r) {
+	return new or({ check: "greater_than", ...v(r), value: t, inclusive: !1 })
+}
+function ee(t, r) {
+	return new or({ check: "greater_than", ...v(r), value: t, inclusive: !0 })
+}
+function ta(t) {
+	return me(0, t)
+}
+function ra(t) {
+	return le(0, t)
+}
+function na(t) {
+	return oe(0, t)
+}
+function oa(t) {
+	return ee(0, t)
+}
+function je(t, r) {
+	return new to({ check: "multiple_of", ...v(r), value: t })
+}
+function Le(t, r) {
+	return new oo({ check: "max_size", ...v(r), maximum: t })
+}
+function Pe(t, r) {
+	return new io({ check: "min_size", ...v(r), minimum: t })
+}
+function vt(t, r) {
+	return new ao({ check: "size_equals", ...v(r), size: t })
+}
+function Me(t, r) {
+	return new so({ check: "max_length", ...v(r), maximum: t })
+}
+function ve(t, r) {
+	return new co({ check: "min_length", ...v(r), minimum: t })
+}
+function qe(t, r) {
+	return new uo({ check: "length_equals", ...v(r), length: t })
+}
+function bt(t, r) {
+	return new lo({ check: "string_format", format: "regex", ...v(r), pattern: t })
+}
+function _t(t) {
+	return new mo({ check: "string_format", format: "lowercase", ...v(t) })
+}
+function yt(t) {
+	return new po({ check: "string_format", format: "uppercase", ...v(t) })
+}
+function $t(t, r) {
+	return new fo({ check: "string_format", format: "includes", ...v(r), includes: t })
+}
+function xt(t, r) {
+	return new go({ check: "string_format", format: "starts_with", ...v(r), prefix: t })
+}
+function zt(t, r) {
+	return new ho({ check: "string_format", format: "ends_with", ...v(r), suffix: t })
+}
+function ia(t, r, n) {
+	return new vo({ check: "property", property: t, schema: r, ...v(n) })
+}
+function kt(t, r) {
+	return new bo({ check: "mime_type", mime: t, ...v(r) })
+}
+function pe(t) {
+	return new _o({ check: "overwrite", tx: t })
+}
+function St(t) {
+	return pe((r) => r.normalize(t))
+}
+function wt() {
+	return pe((t) => t.trim())
+}
+function It() {
+	return pe((t) => t.toLowerCase())
+}
+function jt() {
+	return pe((t) => t.toUpperCase())
+}
+function Pt(t, r, n) {
+	return new t({ type: "array", element: r, ...v(n) })
+}
+function om(t, r, n) {
+	return new t({ type: "union", options: r, ...v(n) })
+}
+function im(t, r, n, i) {
+	return new t({ type: "union", options: n, discriminator: r, ...v(i) })
+}
+function am(t, r, n) {
+	return new t({ type: "intersection", left: r, right: n })
+}
+function aa(t, r, n, i) {
+	const e = n instanceof j,
+		o = e ? i : n,
+		a = e ? n : null
+	return new t({ type: "tuple", items: r, rest: a, ...v(o) })
+}
+function sm(t, r, n, i) {
+	return new t({ type: "record", keyType: r, valueType: n, ...v(i) })
+}
+function cm(t, r, n, i) {
+	return new t({ type: "map", keyType: r, valueType: n, ...v(i) })
+}
+function um(t, r, n) {
+	return new t({ type: "set", valueType: r, ...v(n) })
+}
+function lm(t, r, n) {
+	const i = Array.isArray(r) ? Object.fromEntries(r.map((e) => [e, e])) : r
+	return new t({ type: "enum", entries: i, ...v(n) })
+}
+function mm(t, r, n) {
+	return new t({ type: "enum", entries: r, ...v(n) })
+}
+function pm(t, r, n) {
+	return new t({ type: "literal", values: Array.isArray(r) ? r : [r], ...v(n) })
+}
+function sa(t, r) {
+	return new t({ type: "file", ...v(r) })
+}
+function dm(t, r) {
+	return new t({ type: "transform", transform: r })
+}
+function fm(t, r) {
+	return new t({ type: "optional", innerType: r })
+}
+function gm(t, r) {
+	return new t({ type: "nullable", innerType: r })
+}
+function hm(t, r, n) {
+	return new t({
+		type: "default",
+		innerType: r,
+		get defaultValue() {
+			return typeof n == "function" ? n() : n
+		},
+	})
+}
+function vm(t, r, n) {
+	return new t({ type: "nonoptional", innerType: r, ...v(n) })
+}
+function bm(t, r) {
+	return new t({ type: "success", innerType: r })
+}
+function _m(t, r, n) {
+	return new t({ type: "catch", innerType: r, catchValue: typeof n == "function" ? n : () => n })
+}
+function ym(t, r, n) {
+	return new t({ type: "pipe", in: r, out: n })
+}
+function $m(t, r) {
+	return new t({ type: "readonly", innerType: r })
+}
+function xm(t, r, n) {
+	return new t({ type: "template_literal", parts: r, ...v(n) })
+}
+function zm(t, r) {
+	return new t({ type: "lazy", getter: r })
+}
+function km(t, r) {
+	return new t({ type: "promise", innerType: r })
+}
+function ca(t, r, n) {
+	const i = v(n)
+	return i.abort ?? (i.abort = !0), new t({ type: "custom", check: "custom", fn: r, ...i })
+}
+function ua(t, r, n) {
+	return new t({ type: "custom", check: "custom", fn: r, ...v(n) })
+}
+function la(t, r) {
+	let n = v(r),
+		i = n.truthy ?? ["true", "1", "yes", "on", "y", "enabled"],
+		e = n.falsy ?? ["false", "0", "no", "off", "n", "disabled"]
+	n.case !== "sensitive" &&
+		((i = i.map((d) => (typeof d == "string" ? d.toLowerCase() : d))),
+		(e = e.map((d) => (typeof d == "string" ? d.toLowerCase() : d))))
+	const o = new Set(i),
+		a = new Set(e),
+		c = t.Pipe ?? ft,
+		p = t.Boolean ?? mt,
+		h = t.String ?? we,
+		g = t.Transform ?? dt,
+		m = new g({
+			type: "transform",
+			transform: (d, x) => {
+				let k = d
+				return (
+					n.case !== "sensitive" && (k = k.toLowerCase()),
+					o.has(k)
+						? !0
+						: a.has(k)
+							? !1
+							: (x.issues.push({
+									code: "invalid_value",
+									expected: "stringbool",
+									values: [...o, ...a],
+									input: x.value,
+									inst: m,
+								}),
+								{})
+				)
+			},
+			error: n.error,
+		}),
+		$ = new c({ type: "pipe", in: new h({ type: "string", error: n.error }), out: m, error: n.error })
+	return new c({ type: "pipe", in: $, out: new p({ type: "boolean", error: n.error }), error: n.error })
+}
+function ma(t, r, n, i = {}) {
+	const e = v(i),
+		o = {
+			...v(i),
+			check: "string_format",
+			type: "string",
+			format: r,
+			fn: typeof n == "function" ? n : (c) => n.test(c),
+			...e,
+		}
+	return n instanceof RegExp && (o.pattern = n), new t(o)
+}
+var Ur = class {
+	constructor(r) {
+		;(this._def = r), (this.def = r)
+	}
+	implement(r) {
+		if (typeof r != "function") throw new Error("implement() must be called with a function")
+		const n = (...i) => {
+			const e = this._def.input ? st(this._def.input, i, void 0, { callee: n }) : i
+			if (!Array.isArray(e)) throw new Error("Invalid arguments schema: not an array or tuple schema.")
+			const o = r(...e)
+			return this._def.output ? st(this._def.output, o, void 0, { callee: n }) : o
+		}
+		return n
+	}
+	implementAsync(r) {
+		if (typeof r != "function") throw new Error("implement() must be called with a function")
+		const n = async (...i) => {
+			const e = this._def.input ? await ct(this._def.input, i, void 0, { callee: n }) : i
+			if (!Array.isArray(e)) throw new Error("Invalid arguments schema: not an array or tuple schema.")
+			const o = await r(...e)
+			return this._def.output ? ct(this._def.output, o, void 0, { callee: n }) : o
+		}
+		return n
+	}
+	input(...r) {
+		const n = this.constructor
+		return Array.isArray(r[0])
+			? new n({ type: "function", input: new Ie({ type: "tuple", items: r[0], rest: r[1] }), output: this._def.output })
+			: new n({ type: "function", input: r[0], output: this._def.output })
+	}
+	output(r) {
+		const n = this.constructor
+		return new n({ type: "function", input: this._def.input, output: r })
+	}
+}
+function pa(t) {
+	return new Ur({
+		type: "function",
+		input: Array.isArray(t?.input) ? aa(Ie, t?.input) : (t?.input ?? Pt(pt, Ce(Ee))),
+		output: t?.output ?? Ce(Ee),
+	})
+}
+var Tt = class {
+	constructor(r) {
+		;(this.counter = 0),
+			(this.metadataRegistry = r?.metadata ?? ce),
+			(this.target = r?.target ?? "draft-2020-12"),
+			(this.unrepresentable = r?.unrepresentable ?? "throw"),
+			(this.override = r?.override ?? (() => {})),
+			(this.io = r?.io ?? "output"),
+			(this.seen = new Map())
+	}
+	process(r, n = { path: [], schemaPath: [] }) {
+		var i
+		const e = r._zod.def,
+			o = { guid: "uuid", url: "uri", datetime: "date-time", json_string: "json-string", regex: "" },
+			a = this.seen.get(r)
+		if (a) return a.count++, n.schemaPath.includes(r) && (a.cycle = n.path), a.schema
+		const c = { schema: {}, count: 1, cycle: void 0, path: n.path }
+		this.seen.set(r, c)
+		const p = r._zod.toJSONSchema?.()
+		if (p) c.schema = p
+		else {
+			const m = { ...n, schemaPath: [...n.schemaPath, r], path: n.path },
+				$ = r._zod.parent
+			if ($) (c.ref = $), this.process($, m), (this.seen.get($).isParent = !0)
+			else {
+				const b = c.schema
+				switch (e.type) {
+					case "string": {
+						const d = b
+						d.type = "string"
+						const { minimum: x, maximum: k, format: D, patterns: S, contentEncoding: I } = r._zod.bag
+						if (
+							(typeof x == "number" && (d.minLength = x),
+							typeof k == "number" && (d.maxLength = k),
+							D && ((d.format = o[D] ?? D), d.format === "" && delete d.format),
+							I && (d.contentEncoding = I),
+							S && S.size > 0)
+						) {
+							const O = [...S]
+							O.length === 1
+								? (d.pattern = O[0].source)
+								: O.length > 1 &&
+									(c.schema.allOf = [
+										...O.map((ye) => ({
+											...(this.target === "draft-7" ? { type: "string" } : {}),
+											pattern: ye.source,
+										})),
+									])
+						}
+						break
+					}
+					case "number": {
+						const d = b,
+							{
+								minimum: x,
+								maximum: k,
+								format: D,
+								multipleOf: S,
+								exclusiveMaximum: I,
+								exclusiveMinimum: O,
+							} = r._zod.bag
+						typeof D == "string" && D.includes("int") ? (d.type = "integer") : (d.type = "number"),
+							typeof O == "number" && (d.exclusiveMinimum = O),
+							typeof x == "number" &&
+								((d.minimum = x), typeof O == "number" && (O >= x ? delete d.minimum : delete d.exclusiveMinimum)),
+							typeof I == "number" && (d.exclusiveMaximum = I),
+							typeof k == "number" &&
+								((d.maximum = k), typeof I == "number" && (I <= k ? delete d.maximum : delete d.exclusiveMaximum)),
+							typeof S == "number" && (d.multipleOf = S)
+						break
+					}
+					case "boolean": {
+						const d = b
+						d.type = "boolean"
+						break
+					}
+					case "bigint": {
+						if (this.unrepresentable === "throw") throw new Error("BigInt cannot be represented in JSON Schema")
+						break
+					}
+					case "symbol": {
+						if (this.unrepresentable === "throw") throw new Error("Symbols cannot be represented in JSON Schema")
+						break
+					}
+					case "null": {
+						b.type = "null"
+						break
+					}
+					case "any":
+						break
+					case "unknown":
+						break
+					case "undefined": {
+						if (this.unrepresentable === "throw") throw new Error("Undefined cannot be represented in JSON Schema")
+						break
+					}
+					case "void": {
+						if (this.unrepresentable === "throw") throw new Error("Void cannot be represented in JSON Schema")
+						break
+					}
+					case "never": {
+						b.not = {}
+						break
+					}
+					case "date": {
+						if (this.unrepresentable === "throw") throw new Error("Date cannot be represented in JSON Schema")
+						break
+					}
+					case "array": {
+						const d = b,
+							{ minimum: x, maximum: k } = r._zod.bag
+						typeof x == "number" && (d.minItems = x),
+							typeof k == "number" && (d.maxItems = k),
+							(d.type = "array"),
+							(d.items = this.process(e.element, { ...m, path: [...m.path, "items"] }))
+						break
+					}
+					case "object": {
+						const d = b
+						;(d.type = "object"), (d.properties = {})
+						const x = e.shape
+						for (const S in x) d.properties[S] = this.process(x[S], { ...m, path: [...m.path, "properties", S] })
+						const k = new Set(Object.keys(x)),
+							D = new Set(
+								[...k].filter((S) => {
+									const I = e.shape[S]._zod
+									return this.io === "input" ? I.optin === void 0 : I.optout === void 0
+								}),
+							)
+						D.size > 0 && (d.required = Array.from(D)),
+							e.catchall?._zod.def.type === "never"
+								? (d.additionalProperties = !1)
+								: e.catchall
+									? e.catchall &&
+										(d.additionalProperties = this.process(e.catchall, {
+											...m,
+											path: [...m.path, "additionalProperties"],
+										}))
+									: this.io === "output" && (d.additionalProperties = !1)
+						break
+					}
+					case "union": {
+						const d = b
+						d.anyOf = e.options.map((x, k) => this.process(x, { ...m, path: [...m.path, "anyOf", k] }))
+						break
+					}
+					case "intersection": {
+						const d = b,
+							x = this.process(e.left, { ...m, path: [...m.path, "allOf", 0] }),
+							k = this.process(e.right, { ...m, path: [...m.path, "allOf", 1] }),
+							D = (I) => "allOf" in I && Object.keys(I).length === 1,
+							S = [...(D(x) ? x.allOf : [x]), ...(D(k) ? k.allOf : [k])]
+						d.allOf = S
+						break
+					}
+					case "tuple": {
+						const d = b
+						d.type = "array"
+						const x = e.items.map((S, I) => this.process(S, { ...m, path: [...m.path, "prefixItems", I] }))
+						if ((this.target === "draft-2020-12" ? (d.prefixItems = x) : (d.items = x), e.rest)) {
+							const S = this.process(e.rest, { ...m, path: [...m.path, "items"] })
+							this.target === "draft-2020-12" ? (d.items = S) : (d.additionalItems = S)
+						}
+						e.rest && (d.items = this.process(e.rest, { ...m, path: [...m.path, "items"] }))
+						const { minimum: k, maximum: D } = r._zod.bag
+						typeof k == "number" && (d.minItems = k), typeof D == "number" && (d.maxItems = D)
+						break
+					}
+					case "record": {
+						const d = b
+						;(d.type = "object"),
+							(d.propertyNames = this.process(e.keyType, { ...m, path: [...m.path, "propertyNames"] })),
+							(d.additionalProperties = this.process(e.valueType, { ...m, path: [...m.path, "additionalProperties"] }))
+						break
+					}
+					case "map": {
+						if (this.unrepresentable === "throw") throw new Error("Map cannot be represented in JSON Schema")
+						break
+					}
+					case "set": {
+						if (this.unrepresentable === "throw") throw new Error("Set cannot be represented in JSON Schema")
+						break
+					}
+					case "enum": {
+						const d = b,
+							x = Xe(e.entries)
+						x.every((k) => typeof k == "number") && (d.type = "number"),
+							x.every((k) => typeof k == "string") && (d.type = "string"),
+							(d.enum = x)
+						break
+					}
+					case "literal": {
+						const d = b,
+							x = []
+						for (const k of e.values)
+							if (k === void 0) {
+								if (this.unrepresentable === "throw")
+									throw new Error("Literal `undefined` cannot be represented in JSON Schema")
+							} else if (typeof k == "bigint") {
+								if (this.unrepresentable === "throw")
+									throw new Error("BigInt literals cannot be represented in JSON Schema")
+								x.push(Number(k))
+							} else x.push(k)
+						if (x.length !== 0)
+							if (x.length === 1) {
+								const k = x[0]
+								;(d.type = k === null ? "null" : typeof k), (d.const = k)
+							} else
+								x.every((k) => typeof k == "number") && (d.type = "number"),
+									x.every((k) => typeof k == "string") && (d.type = "string"),
+									x.every((k) => typeof k == "boolean") && (d.type = "string"),
+									x.every((k) => k === null) && (d.type = "null"),
+									(d.enum = x)
+						break
+					}
+					case "file": {
+						const d = b,
+							x = { type: "string", format: "binary", contentEncoding: "binary" },
+							{ minimum: k, maximum: D, mime: S } = r._zod.bag
+						k !== void 0 && (x.minLength = k),
+							D !== void 0 && (x.maxLength = D),
+							S
+								? S.length === 1
+									? ((x.contentMediaType = S[0]), Object.assign(d, x))
+									: (d.anyOf = S.map((I) => ({ ...x, contentMediaType: I })))
+								: Object.assign(d, x)
+						break
+					}
+					case "transform": {
+						if (this.unrepresentable === "throw") throw new Error("Transforms cannot be represented in JSON Schema")
+						break
+					}
+					case "nullable": {
+						const d = this.process(e.innerType, m)
+						b.anyOf = [d, { type: "null" }]
+						break
+					}
+					case "nonoptional": {
+						this.process(e.innerType, m), (c.ref = e.innerType)
+						break
+					}
+					case "success": {
+						const d = b
+						d.type = "boolean"
+						break
+					}
+					case "default": {
+						this.process(e.innerType, m),
+							(c.ref = e.innerType),
+							(b.default = JSON.parse(JSON.stringify(e.defaultValue)))
+						break
+					}
+					case "prefault": {
+						this.process(e.innerType, m),
+							(c.ref = e.innerType),
+							this.io === "input" && (b._prefault = JSON.parse(JSON.stringify(e.defaultValue)))
+						break
+					}
+					case "catch": {
+						this.process(e.innerType, m), (c.ref = e.innerType)
+						let d
+						try {
+							d = e.catchValue(void 0)
+						} catch {
+							throw new Error("Dynamic catch values are not supported in JSON Schema")
+						}
+						b.default = d
+						break
+					}
+					case "nan": {
+						if (this.unrepresentable === "throw") throw new Error("NaN cannot be represented in JSON Schema")
+						break
+					}
+					case "template_literal": {
+						const d = b,
+							x = r._zod.pattern
+						if (!x) throw new Error("Pattern not found in template literal")
+						;(d.type = "string"), (d.pattern = x.source)
+						break
+					}
+					case "pipe": {
+						const d = this.io === "input" ? (e.in._zod.def.type === "transform" ? e.out : e.in) : e.out
+						this.process(d, m), (c.ref = d)
+						break
+					}
+					case "readonly": {
+						this.process(e.innerType, m), (c.ref = e.innerType), (b.readOnly = !0)
+						break
+					}
+					case "promise": {
+						this.process(e.innerType, m), (c.ref = e.innerType)
+						break
+					}
+					case "optional": {
+						this.process(e.innerType, m), (c.ref = e.innerType)
+						break
+					}
+					case "lazy": {
+						const d = r._zod.innerType
+						this.process(d, m), (c.ref = d)
+						break
+					}
+					case "custom": {
+						if (this.unrepresentable === "throw") throw new Error("Custom types cannot be represented in JSON Schema")
+						break
+					}
+					default:
+				}
+			}
+		}
+		const h = this.metadataRegistry.get(r)
+		return (
+			h && Object.assign(c.schema, h),
+			this.io === "input" && J(r) && (delete c.schema.examples, delete c.schema.default),
+			this.io === "input" && c.schema._prefault && ((i = c.schema).default ?? (i.default = c.schema._prefault)),
+			delete c.schema._prefault,
+			this.seen.get(r).schema
+		)
+	}
+	emit(r, n) {
+		const i = { cycles: n?.cycles ?? "ref", reused: n?.reused ?? "inline", external: n?.external ?? void 0 },
+			e = this.seen.get(r)
+		if (!e) throw new Error("Unprocessed schema. This is a bug in Zod.")
+		const o = (g) => {
+				const m = this.target === "draft-2020-12" ? "$defs" : "definitions"
+				if (i.external) {
+					const x = i.external.registry.get(g[0])?.id,
+						k = i.external.uri ?? ((S) => S)
+					if (x) return { ref: k(x) }
+					const D = g[1].defId ?? g[1].schema.id ?? `schema${this.counter++}`
+					return (g[1].defId = D), { defId: D, ref: `${k("__shared")}#/${m}/${D}` }
+				}
+				if (g[1] === e) return { ref: "#" }
+				const b = `#/${m}/`,
+					d = g[1].schema.id ?? `__schema${this.counter++}`
+				return { defId: d, ref: b + d }
+			},
+			a = (g) => {
+				if (g[1].schema.$ref) return
+				const m = g[1],
+					{ ref: $, defId: b } = o(g)
+				;(m.def = { ...m.schema }), b && (m.defId = b)
+				const d = m.schema
+				for (const x in d) delete d[x]
+				d.$ref = $
+			}
+		if (i.cycles === "throw")
+			for (const g of this.seen.entries()) {
+				const m = g[1]
+				if (m.cycle)
+					throw new Error(`Cycle detected: #/${m.cycle?.join("/")}/<root>
+
+Set the \`cycles\` parameter to \`"ref"\` to resolve cyclical schemas with defs.`)
+			}
+		for (const g of this.seen.entries()) {
+			const m = g[1]
+			if (r === g[0]) {
+				a(g)
+				continue
+			}
+			if (i.external) {
+				const b = i.external.registry.get(g[0])?.id
+				if (r !== g[0] && b) {
+					a(g)
+					continue
+				}
+			}
+			if (this.metadataRegistry.get(g[0])?.id) {
+				a(g)
+				continue
+			}
+			if (m.cycle) {
+				a(g)
+				continue
+			}
+			if (m.count > 1 && i.reused === "ref") {
+				a(g)
+				continue
+			}
+		}
+		const c = (g, m) => {
+			const $ = this.seen.get(g),
+				b = $.def ?? $.schema,
+				d = { ...b }
+			if ($.ref === null) return
+			const x = $.ref
+			if ((($.ref = null), x)) {
+				c(x, m)
+				const k = this.seen.get(x).schema
+				k.$ref && m.target === "draft-7"
+					? ((b.allOf = b.allOf ?? []), b.allOf.push(k))
+					: (Object.assign(b, k), Object.assign(b, d))
+			}
+			$.isParent || this.override({ zodSchema: g, jsonSchema: b, path: $.path ?? [] })
+		}
+		for (const g of [...this.seen.entries()].reverse()) c(g[0], { target: this.target })
+		const p = {}
+		if (
+			(this.target === "draft-2020-12"
+				? (p.$schema = "https://json-schema.org/draft/2020-12/schema")
+				: this.target === "draft-7"
+					? (p.$schema = "http://json-schema.org/draft-07/schema#")
+					: console.warn(`Invalid target: ${this.target}`),
+			i.external?.uri)
+		) {
+			const g = i.external.registry.get(r)?.id
+			if (!g) throw new Error("Schema is missing an `id` property")
+			p.$id = i.external.uri(g)
+		}
+		Object.assign(p, e.def)
+		const h = i.external?.defs ?? {}
+		for (const g of this.seen.entries()) {
+			const m = g[1]
+			m.def && m.defId && (h[m.defId] = m.def)
+		}
+		i.external || (Object.keys(h).length > 0 && (this.target === "draft-2020-12" ? (p.$defs = h) : (p.definitions = h)))
+		try {
+			return JSON.parse(JSON.stringify(p))
+		} catch {
+			throw new Error("Error converting schema to JSON.")
+		}
+	}
+}
+function da(t, r) {
+	if (t instanceof Ae) {
+		const i = new Tt(r),
+			e = {}
+		for (const c of t._idmap.entries()) {
+			const [p, h] = c
+			i.process(h)
+		}
+		const o = {},
+			a = { registry: t, uri: r?.uri, defs: e }
+		for (const c of t._idmap.entries()) {
+			const [p, h] = c
+			o[p] = i.emit(h, { ...r, external: a })
+		}
+		if (Object.keys(e).length > 0) {
+			const c = i.target === "draft-2020-12" ? "$defs" : "definitions"
+			o.__shared = { [c]: e }
+		}
+		return { schemas: o }
+	}
+	const n = new Tt(r)
+	return n.process(t), n.emit(t, r)
+}
+function J(t, r) {
+	const n = r ?? { seen: new Set() }
+	if (n.seen.has(t)) return !1
+	n.seen.add(t)
+	const e = t._zod.def
+	switch (e.type) {
+		case "string":
+		case "number":
+		case "bigint":
+		case "boolean":
+		case "date":
+		case "symbol":
+		case "undefined":
+		case "null":
+		case "any":
+		case "unknown":
+		case "never":
+		case "void":
+		case "literal":
+		case "enum":
+		case "nan":
+		case "file":
+		case "template_literal":
+			return !1
+		case "array":
+			return J(e.element, n)
+		case "object": {
+			for (const o in e.shape) if (J(e.shape[o], n)) return !0
+			return !1
+		}
+		case "union": {
+			for (const o of e.options) if (J(o, n)) return !0
+			return !1
+		}
+		case "intersection":
+			return J(e.left, n) || J(e.right, n)
+		case "tuple": {
+			for (const o of e.items) if (J(o, n)) return !0
+			return !!(e.rest && J(e.rest, n))
+		}
+		case "record":
+			return J(e.keyType, n) || J(e.valueType, n)
+		case "map":
+			return J(e.keyType, n) || J(e.valueType, n)
+		case "set":
+			return J(e.valueType, n)
+		case "promise":
+		case "optional":
+		case "nonoptional":
+		case "nullable":
+		case "readonly":
+			return J(e.innerType, n)
+		case "lazy":
+			return J(e.getter(), n)
+		case "default":
+			return J(e.innerType, n)
+		case "prefault":
+			return J(e.innerType, n)
+		case "custom":
+			return !1
+		case "transform":
+			return !0
+		case "pipe":
+			return J(e.in, n) || J(e.out, n)
+		case "success":
+			return !1
+		case "catch":
+			return !1
+		default:
+	}
+	throw new Error(`Unknown schema type: ${e.type}`)
+}
+var Zc = {}
+var Ve = {}
+$e(Ve, {
+	ZodISODate: () => Dr,
+	ZodISODateTime: () => Zr,
+	ZodISODuration: () => Er,
+	ZodISOTime: () => Rr,
+	date: () => ga,
+	datetime: () => fa,
+	duration: () => va,
+	time: () => ha,
+})
+var Zr = u("ZodISODateTime", (t, r) => {
+	Uo.init(t, r), C.init(t, r)
+})
+function fa(t) {
+	return Pi(Zr, t)
+}
+var Dr = u("ZodISODate", (t, r) => {
+	Zo.init(t, r), C.init(t, r)
+})
+function ga(t) {
+	return Ti(Dr, t)
+}
+var Rr = u("ZodISOTime", (t, r) => {
+	Do.init(t, r), C.init(t, r)
+})
+function ha(t) {
+	return Oi(Rr, t)
+}
+var Er = u("ZodISODuration", (t, r) => {
+	Ro.init(t, r), C.init(t, r)
+})
+function va(t) {
+	return Ni(Er, t)
+}
+var Rc = (t, r) => {
+		ot.init(t, r),
+			(t.name = "ZodError"),
+			Object.defineProperties(t, {
+				format: { value: (n) => at(t, n) },
+				flatten: { value: (n) => it(t, n) },
+				addIssue: { value: (n) => t.issues.push(n) },
+				addIssues: { value: (n) => t.issues.push(...n) },
+				isEmpty: {
+					get() {
+						return t.issues.length === 0
+					},
+				},
+			})
+	},
+	wm = u("ZodError", Rc),
+	Fe = u("ZodError", Rc, { Parent: Error })
+var ba = Xt(Fe),
+	_a = Yt(Fe),
+	ya = er(Fe),
+	$a = tr(Fe)
+var P = u(
+		"ZodType",
+		(t, r) => (
+			j.init(t, r),
+			(t.def = r),
+			Object.defineProperty(t, "_def", { value: r }),
+			(t.check = (...n) =>
+				t.clone({
+					...r,
+					checks: [
+						...(r.checks ?? []),
+						...n.map((i) =>
+							typeof i == "function" ? { _zod: { check: i, def: { check: "custom" }, onattach: [] } } : i,
+						),
+					],
+				})),
+			(t.clone = (n, i) => te(t, n, i)),
+			(t.brand = () => t),
+			(t.register = (n, i) => (n.add(t, i), t)),
+			(t.parse = (n, i) => ba(t, n, i, { callee: t.parse })),
+			(t.safeParse = (n, i) => ya(t, n, i)),
+			(t.parseAsync = async (n, i) => _a(t, n, i, { callee: t.parseAsync })),
+			(t.safeParseAsync = async (n, i) => $a(t, n, i)),
+			(t.spa = t.safeParseAsync),
+			(t.refine = (n, i) => t.check(hu(n, i))),
+			(t.superRefine = (n) => t.check(vu(n))),
+			(t.overwrite = (n) => t.check(pe(n))),
+			(t.optional = () => q(t)),
+			(t.nullable = () => Cr(t)),
+			(t.nullish = () => q(Cr(t))),
+			(t.nonoptional = (n) => ou(t, n)),
+			(t.array = () => T(t)),
+			(t.or = (n) => R([t, n])),
+			(t.and = (n) => Et(t, n)),
+			(t.transform = (n) => Lr(t, Ha(n))),
+			(t.default = (n) => tu(t, n)),
+			(t.prefault = (n) => nu(t, n)),
+			(t.catch = (n) => su(t, n)),
+			(t.pipe = (n) => Lr(t, n)),
+			(t.readonly = () => lu(t)),
+			(t.describe = (n) => {
+				const i = t.clone()
+				return ce.add(i, { description: n }), i
+			}),
+			Object.defineProperty(t, "description", {
+				get() {
+					return ce.get(t)?.description
+				},
+				configurable: !0,
+			}),
+			(t.meta = (...n) => {
+				if (n.length === 0) return ce.get(t)
+				const i = t.clone()
+				return ce.add(i, n[0]), i
+			}),
+			(t.isOptional = () => t.safeParse(void 0).success),
+			(t.isNullable = () => t.safeParse(null).success),
+			t
+		),
+	),
+	za = u("_ZodString", (t, r) => {
+		we.init(t, r), P.init(t, r)
+		const n = t._zod.bag
+		;(t.format = n.format ?? null),
+			(t.minLength = n.minimum ?? null),
+			(t.maxLength = n.maximum ?? null),
+			(t.regex = (...i) => t.check(bt(...i))),
+			(t.includes = (...i) => t.check($t(...i))),
+			(t.startsWith = (...i) => t.check(xt(...i))),
+			(t.endsWith = (...i) => t.check(zt(...i))),
+			(t.min = (...i) => t.check(ve(...i))),
+			(t.max = (...i) => t.check(Me(...i))),
+			(t.length = (...i) => t.check(qe(...i))),
+			(t.nonempty = (...i) => t.check(ve(1, ...i))),
+			(t.lowercase = (i) => t.check(_t(i))),
+			(t.uppercase = (i) => t.check(yt(i))),
+			(t.trim = () => t.check(wt())),
+			(t.normalize = (...i) => t.check(St(...i))),
+			(t.toLowerCase = () => t.check(It())),
+			(t.toUpperCase = () => t.check(jt()))
+	}),
+	Nt = u("ZodString", (t, r) => {
+		we.init(t, r),
+			za.init(t, r),
+			(t.email = (n) => t.check(pr(ka, n))),
+			(t.url = (n) => t.check(vr(Sa, n))),
+			(t.jwt = (n) => t.check(Nr(La, n))),
+			(t.emoji = (n) => t.check(br(wa, n))),
+			(t.guid = (n) => t.check(ht(Ar, n))),
+			(t.uuid = (n) => t.check(dr(fe, n))),
+			(t.uuidv4 = (n) => t.check(fr(fe, n))),
+			(t.uuidv6 = (n) => t.check(gr(fe, n))),
+			(t.uuidv7 = (n) => t.check(hr(fe, n))),
+			(t.nanoid = (n) => t.check(_r(Ia, n))),
+			(t.guid = (n) => t.check(ht(Ar, n))),
+			(t.cuid = (n) => t.check(yr(ja, n))),
+			(t.cuid2 = (n) => t.check($r(Pa, n))),
+			(t.ulid = (n) => t.check(xr(Ta, n))),
+			(t.base64 = (n) => t.check(Pr(Ea, n))),
+			(t.base64url = (n) => t.check(Tr(Aa, n))),
+			(t.xid = (n) => t.check(zr(Oa, n))),
+			(t.ksuid = (n) => t.check(kr(Na, n))),
+			(t.ipv4 = (n) => t.check(Sr(Ua, n))),
+			(t.ipv6 = (n) => t.check(wr(Za, n))),
+			(t.cidrv4 = (n) => t.check(Ir(Da, n))),
+			(t.cidrv6 = (n) => t.check(jr(Ra, n))),
+			(t.e164 = (n) => t.check(Or(Ca, n))),
+			(t.datetime = (n) => t.check(fa(n))),
+			(t.date = (n) => t.check(ga(n))),
+			(t.time = (n) => t.check(ha(n))),
+			(t.duration = (n) => t.check(va(n)))
+	})
+function l(t) {
+	return wi(Nt, t)
+}
+var C = u("ZodStringFormat", (t, r) => {
+		A.init(t, r), za.init(t, r)
+	}),
+	ka = u("ZodEmail", (t, r) => {
+		ko.init(t, r), C.init(t, r)
+	})
+function jm(t) {
+	return pr(ka, t)
+}
+var Ar = u("ZodGUID", (t, r) => {
+	xo.init(t, r), C.init(t, r)
+})
+function Pm(t) {
+	return ht(Ar, t)
+}
+var fe = u("ZodUUID", (t, r) => {
+	zo.init(t, r), C.init(t, r)
+})
+function Tm(t) {
+	return dr(fe, t)
+}
+function Om(t) {
+	return fr(fe, t)
+}
+function Nm(t) {
+	return gr(fe, t)
+}
+function Um(t) {
+	return hr(fe, t)
+}
+var Sa = u("ZodURL", (t, r) => {
+	So.init(t, r), C.init(t, r)
+})
+function Zm(t) {
+	return vr(Sa, t)
+}
+var wa = u("ZodEmoji", (t, r) => {
+	wo.init(t, r), C.init(t, r)
+})
+function Dm(t) {
+	return br(wa, t)
+}
+var Ia = u("ZodNanoID", (t, r) => {
+	Io.init(t, r), C.init(t, r)
+})
+function Rm(t) {
+	return _r(Ia, t)
+}
+var ja = u("ZodCUID", (t, r) => {
+	jo.init(t, r), C.init(t, r)
+})
+function Em(t) {
+	return yr(ja, t)
+}
+var Pa = u("ZodCUID2", (t, r) => {
+	Po.init(t, r), C.init(t, r)
+})
+function Am(t) {
+	return $r(Pa, t)
+}
+var Ta = u("ZodULID", (t, r) => {
+	To.init(t, r), C.init(t, r)
+})
+function Cm(t) {
+	return xr(Ta, t)
+}
+var Oa = u("ZodXID", (t, r) => {
+	Oo.init(t, r), C.init(t, r)
+})
+function Lm(t) {
+	return zr(Oa, t)
+}
+var Na = u("ZodKSUID", (t, r) => {
+	No.init(t, r), C.init(t, r)
+})
+function Mm(t) {
+	return kr(Na, t)
+}
+var Ua = u("ZodIPv4", (t, r) => {
+	Eo.init(t, r), C.init(t, r)
+})
+function qm(t) {
+	return Sr(Ua, t)
+}
+var Za = u("ZodIPv6", (t, r) => {
+	Ao.init(t, r), C.init(t, r)
+})
+function Vm(t) {
+	return wr(Za, t)
+}
+var Da = u("ZodCIDRv4", (t, r) => {
+	Co.init(t, r), C.init(t, r)
+})
+function Fm(t) {
+	return Ir(Da, t)
+}
+var Ra = u("ZodCIDRv6", (t, r) => {
+	Lo.init(t, r), C.init(t, r)
+})
+function Hm(t) {
+	return jr(Ra, t)
+}
+var Ea = u("ZodBase64", (t, r) => {
+	qo.init(t, r), C.init(t, r)
+})
+function Jm(t) {
+	return Pr(Ea, t)
+}
+var Aa = u("ZodBase64URL", (t, r) => {
+	Vo.init(t, r), C.init(t, r)
+})
+function Bm(t) {
+	return Tr(Aa, t)
+}
+var Ca = u("ZodE164", (t, r) => {
+	Fo.init(t, r), C.init(t, r)
+})
+function Wm(t) {
+	return Or(Ca, t)
+}
+var La = u("ZodJWT", (t, r) => {
+	Ho.init(t, r), C.init(t, r)
+})
+function Gm(t) {
+	return Nr(La, t)
+}
+var Ec = u("ZodCustomStringFormat", (t, r) => {
+	Jo.init(t, r), C.init(t, r)
+})
+function Km(t, r, n = {}) {
+	return ma(Ec, t, r, n)
+}
+var Ut = u("ZodNumber", (t, r) => {
+	sr.init(t, r),
+		P.init(t, r),
+		(t.gt = (i, e) => t.check(me(i, e))),
+		(t.gte = (i, e) => t.check(ee(i, e))),
+		(t.min = (i, e) => t.check(ee(i, e))),
+		(t.lt = (i, e) => t.check(le(i, e))),
+		(t.lte = (i, e) => t.check(oe(i, e))),
+		(t.max = (i, e) => t.check(oe(i, e))),
+		(t.int = (i) => t.check(xa(i))),
+		(t.safe = (i) => t.check(xa(i))),
+		(t.positive = (i) => t.check(me(0, i))),
+		(t.nonnegative = (i) => t.check(ee(0, i))),
+		(t.negative = (i) => t.check(le(0, i))),
+		(t.nonpositive = (i) => t.check(oe(0, i))),
+		(t.multipleOf = (i, e) => t.check(je(i, e))),
+		(t.step = (i, e) => t.check(je(i, e))),
+		(t.finite = () => t)
+	const n = t._zod.bag
+	;(t.minValue =
+		Math.max(n.minimum ?? Number.NEGATIVE_INFINITY, n.exclusiveMinimum ?? Number.NEGATIVE_INFINITY) ?? null),
+		(t.maxValue =
+			Math.min(n.maximum ?? Number.POSITIVE_INFINITY, n.exclusiveMaximum ?? Number.POSITIVE_INFINITY) ?? null),
+		(t.isInt = (n.format ?? "").includes("int") || Number.isSafeInteger(n.multipleOf ?? 0.5)),
+		(t.isFinite = !0),
+		(t.format = n.format ?? null)
+})
+function Z(t) {
+	return Ui(Ut, t)
+}
+var He = u("ZodNumberFormat", (t, r) => {
+	Bo.init(t, r), Ut.init(t, r)
+})
+function xa(t) {
+	return Di(He, t)
+}
+function Qm(t) {
+	return Ri(He, t)
+}
+function Xm(t) {
+	return Ei(He, t)
+}
+function Ym(t) {
+	return Ai(He, t)
+}
+function ep(t) {
+	return Ci(He, t)
+}
+var Zt = u("ZodBoolean", (t, r) => {
+	mt.init(t, r), P.init(t, r)
+})
+function H(t) {
+	return Li(Zt, t)
+}
+var Dt = u("ZodBigInt", (t, r) => {
+	cr.init(t, r),
+		P.init(t, r),
+		(t.gte = (i, e) => t.check(ee(i, e))),
+		(t.min = (i, e) => t.check(ee(i, e))),
+		(t.gt = (i, e) => t.check(me(i, e))),
+		(t.gte = (i, e) => t.check(ee(i, e))),
+		(t.min = (i, e) => t.check(ee(i, e))),
+		(t.lt = (i, e) => t.check(le(i, e))),
+		(t.lte = (i, e) => t.check(oe(i, e))),
+		(t.max = (i, e) => t.check(oe(i, e))),
+		(t.positive = (i) => t.check(me(BigInt(0), i))),
+		(t.negative = (i) => t.check(le(BigInt(0), i))),
+		(t.nonpositive = (i) => t.check(oe(BigInt(0), i))),
+		(t.nonnegative = (i) => t.check(ee(BigInt(0), i))),
+		(t.multipleOf = (i, e) => t.check(je(i, e)))
+	const n = t._zod.bag
+	;(t.minValue = n.minimum ?? null), (t.maxValue = n.maximum ?? null), (t.format = n.format ?? null)
+})
+function tp(t) {
+	return qi(Dt, t)
+}
+var Ma = u("ZodBigIntFormat", (t, r) => {
+	Wo.init(t, r), Dt.init(t, r)
+})
+function rp(t) {
+	return Fi(Ma, t)
+}
+function np(t) {
+	return Hi(Ma, t)
+}
+var Ac = u("ZodSymbol", (t, r) => {
+	Go.init(t, r), P.init(t, r)
+})
+function op(t) {
+	return Ji(Ac, t)
+}
+var Cc = u("ZodUndefined", (t, r) => {
+	Ko.init(t, r), P.init(t, r)
+})
+function ip(t) {
+	return Bi(Cc, t)
+}
+var Lc = u("ZodNull", (t, r) => {
+	Qo.init(t, r), P.init(t, r)
+})
+function Rt(t) {
+	return Wi(Lc, t)
+}
+var Mc = u("ZodAny", (t, r) => {
+	Xo.init(t, r), P.init(t, r)
+})
+function ap() {
+	return Gi(Mc)
+}
+var qc = u("ZodUnknown", (t, r) => {
+	Ee.init(t, r), P.init(t, r)
+})
+function M() {
+	return Ce(qc)
+}
+var Vc = u("ZodNever", (t, r) => {
+	Yo.init(t, r), P.init(t, r)
+})
+function Mr(t) {
+	return Ki(Vc, t)
+}
+var Fc = u("ZodVoid", (t, r) => {
+	ei.init(t, r), P.init(t, r)
+})
+function sp(t) {
+	return Qi(Fc, t)
+}
+var qr = u("ZodDate", (t, r) => {
+	ti.init(t, r), P.init(t, r), (t.min = (i, e) => t.check(ee(i, e))), (t.max = (i, e) => t.check(oe(i, e)))
+	const n = t._zod.bag
+	;(t.minDate = n.minimum ? new Date(n.minimum) : null), (t.maxDate = n.maximum ? new Date(n.maximum) : null)
+})
+function cp(t) {
+	return Xi(qr, t)
+}
+var Hc = u("ZodArray", (t, r) => {
+	pt.init(t, r),
+		P.init(t, r),
+		(t.element = r.element),
+		(t.min = (n, i) => t.check(ve(n, i))),
+		(t.nonempty = (n) => t.check(ve(1, n))),
+		(t.max = (n, i) => t.check(Me(n, i))),
+		(t.length = (n, i) => t.check(qe(n, i))),
+		(t.unwrap = () => t.element)
+})
+function T(t, r) {
+	return Pt(Hc, t, r)
+}
+function up(t) {
+	const r = t._zod.def.shape
+	return w(Object.keys(r))
+}
+var Vr = u("ZodObject", (t, r) => {
+	ri.init(t, r),
+		P.init(t, r),
+		y.defineLazy(t, "shape", () => r.shape),
+		(t.keyof = () => X(Object.keys(t._zod.def.shape))),
+		(t.catchall = (n) => t.clone({ ...t._zod.def, catchall: n })),
+		(t.passthrough = () => t.clone({ ...t._zod.def, catchall: M() })),
+		(t.loose = () => t.clone({ ...t._zod.def, catchall: M() })),
+		(t.strict = () => t.clone({ ...t._zod.def, catchall: Mr() })),
+		(t.strip = () => t.clone({ ...t._zod.def, catchall: void 0 })),
+		(t.extend = (n) => y.extend(t, n)),
+		(t.merge = (n) => y.merge(t, n)),
+		(t.pick = (n) => y.pick(t, n)),
+		(t.omit = (n) => y.omit(t, n)),
+		(t.partial = (...n) => y.partial(Ja, t, n[0])),
+		(t.required = (...n) => y.required(Ba, t, n[0]))
+})
+function z(t, r) {
+	const n = {
+		type: "object",
+		get shape() {
+			return y.assignProp(this, "shape", { ...t }), this.shape
+		},
+		...y.normalizeParams(r),
+	}
+	return new Vr(n)
+}
+function lp(t, r) {
+	return new Vr({
+		type: "object",
+		get shape() {
+			return y.assignProp(this, "shape", { ...t }), this.shape
+		},
+		catchall: Mr(),
+		...y.normalizeParams(r),
+	})
+}
+function Q(t, r) {
+	return new Vr({
+		type: "object",
+		get shape() {
+			return y.assignProp(this, "shape", { ...t }), this.shape
+		},
+		catchall: M(),
+		...y.normalizeParams(r),
+	})
+}
+var qa = u("ZodUnion", (t, r) => {
+	ur.init(t, r), P.init(t, r), (t.options = r.options)
+})
+function R(t, r) {
+	return new qa({ type: "union", options: t, ...y.normalizeParams(r) })
+}
+var Jc = u("ZodDiscriminatedUnion", (t, r) => {
+	qa.init(t, r), ni.init(t, r)
+})
+function Fr(t, r, n) {
+	return new Jc({ type: "union", options: r, discriminator: t, ...y.normalizeParams(n) })
+}
+var Bc = u("ZodIntersection", (t, r) => {
+	oi.init(t, r), P.init(t, r)
+})
+function Et(t, r) {
+	return new Bc({ type: "intersection", left: t, right: r })
+}
+var Wc = u("ZodTuple", (t, r) => {
+	Ie.init(t, r), P.init(t, r), (t.rest = (n) => t.clone({ ...t._zod.def, rest: n }))
+})
+function mp(t, r, n) {
+	const i = r instanceof j,
+		e = i ? n : r,
+		o = i ? r : null
+	return new Wc({ type: "tuple", items: t, rest: o, ...y.normalizeParams(e) })
+}
+var Va = u("ZodRecord", (t, r) => {
+	ii.init(t, r), P.init(t, r), (t.keyType = r.keyType), (t.valueType = r.valueType)
+})
+function L(t, r, n) {
+	return new Va({ type: "record", keyType: t, valueType: r, ...y.normalizeParams(n) })
+}
+function pp(t, r, n) {
+	return new Va({ type: "record", keyType: R([t, Mr()]), valueType: r, ...y.normalizeParams(n) })
+}
+var Gc = u("ZodMap", (t, r) => {
+	ai.init(t, r), P.init(t, r), (t.keyType = r.keyType), (t.valueType = r.valueType)
+})
+function dp(t, r, n) {
+	return new Gc({ type: "map", keyType: t, valueType: r, ...y.normalizeParams(n) })
+}
+var Kc = u("ZodSet", (t, r) => {
+	si.init(t, r),
+		P.init(t, r),
+		(t.min = (...n) => t.check(Pe(...n))),
+		(t.nonempty = (n) => t.check(Pe(1, n))),
+		(t.max = (...n) => t.check(Le(...n))),
+		(t.size = (...n) => t.check(vt(...n)))
+})
+function fp(t, r) {
+	return new Kc({ type: "set", valueType: t, ...y.normalizeParams(r) })
+}
+var Ot = u("ZodEnum", (t, r) => {
+	ci.init(t, r), P.init(t, r), (t.enum = r.entries), (t.options = Object.values(r.entries))
+	const n = new Set(Object.keys(r.entries))
+	;(t.extract = (i, e) => {
+		const o = {}
+		for (const a of i)
+			if (n.has(a)) o[a] = r.entries[a]
+			else throw new Error(`Key ${a} not found in enum`)
+		return new Ot({ ...r, checks: [], ...y.normalizeParams(e), entries: o })
+	}),
+		(t.exclude = (i, e) => {
+			const o = { ...r.entries }
+			for (const a of i)
+				if (n.has(a)) delete o[a]
+				else throw new Error(`Key ${a} not found in enum`)
+			return new Ot({ ...r, checks: [], ...y.normalizeParams(e), entries: o })
+		})
+})
+function X(t, r) {
+	const n = Array.isArray(t) ? Object.fromEntries(t.map((i) => [i, i])) : t
+	return new Ot({ type: "enum", entries: n, ...y.normalizeParams(r) })
+}
+function gp(t, r) {
+	return new Ot({ type: "enum", entries: t, ...y.normalizeParams(r) })
+}
+var Qc = u("ZodLiteral", (t, r) => {
+	ui.init(t, r),
+		P.init(t, r),
+		(t.values = new Set(r.values)),
+		Object.defineProperty(t, "value", {
+			get() {
+				if (r.values.length > 1)
+					throw new Error("This schema contains multiple valid literal values. Use `.values` instead.")
+				return r.values[0]
+			},
+		})
+})
+function w(t, r) {
+	return new Qc({ type: "literal", values: Array.isArray(t) ? t : [t], ...y.normalizeParams(r) })
+}
+var Xc = u("ZodFile", (t, r) => {
+	li.init(t, r),
+		P.init(t, r),
+		(t.min = (n, i) => t.check(Pe(n, i))),
+		(t.max = (n, i) => t.check(Le(n, i))),
+		(t.mime = (n, i) => t.check(kt(Array.isArray(n) ? n : [n], i)))
+})
+function hp(t) {
+	return sa(Xc, t)
+}
+var Fa = u("ZodTransform", (t, r) => {
+	dt.init(t, r),
+		P.init(t, r),
+		(t._zod.parse = (n, i) => {
+			n.addIssue = (o) => {
+				if (typeof o == "string") n.issues.push(y.issue(o, n.value, r))
+				else {
+					const a = o
+					a.fatal && (a.continue = !1),
+						a.code ?? (a.code = "custom"),
+						a.input ?? (a.input = n.value),
+						a.inst ?? (a.inst = t),
+						a.continue ?? (a.continue = !0),
+						n.issues.push(y.issue(a))
+				}
+			}
+			const e = r.transform(n.value, n)
+			return e instanceof Promise ? e.then((o) => ((n.value = o), n)) : ((n.value = e), n)
+		})
+})
+function Ha(t) {
+	return new Fa({ type: "transform", transform: t })
+}
+var Ja = u("ZodOptional", (t, r) => {
+	mi.init(t, r), P.init(t, r), (t.unwrap = () => t._zod.def.innerType)
+})
+function q(t) {
+	return new Ja({ type: "optional", innerType: t })
+}
+var Yc = u("ZodNullable", (t, r) => {
+	pi.init(t, r), P.init(t, r), (t.unwrap = () => t._zod.def.innerType)
+})
+function Cr(t) {
+	return new Yc({ type: "nullable", innerType: t })
+}
+function vp(t) {
+	return q(Cr(t))
+}
+var eu = u("ZodDefault", (t, r) => {
+	di.init(t, r), P.init(t, r), (t.unwrap = () => t._zod.def.innerType), (t.removeDefault = t.unwrap)
+})
+function tu(t, r) {
+	return new eu({
+		type: "default",
+		innerType: t,
+		get defaultValue() {
+			return typeof r == "function" ? r() : r
+		},
+	})
+}
+var ru = u("ZodPrefault", (t, r) => {
+	fi.init(t, r), P.init(t, r), (t.unwrap = () => t._zod.def.innerType)
+})
+function nu(t, r) {
+	return new ru({
+		type: "prefault",
+		innerType: t,
+		get defaultValue() {
+			return typeof r == "function" ? r() : r
+		},
+	})
+}
+var Ba = u("ZodNonOptional", (t, r) => {
+	gi.init(t, r), P.init(t, r), (t.unwrap = () => t._zod.def.innerType)
+})
+function ou(t, r) {
+	return new Ba({ type: "nonoptional", innerType: t, ...y.normalizeParams(r) })
+}
+var iu = u("ZodSuccess", (t, r) => {
+	hi.init(t, r), P.init(t, r), (t.unwrap = () => t._zod.def.innerType)
+})
+function bp(t) {
+	return new iu({ type: "success", innerType: t })
+}
+var au = u("ZodCatch", (t, r) => {
+	vi.init(t, r), P.init(t, r), (t.unwrap = () => t._zod.def.innerType), (t.removeCatch = t.unwrap)
+})
+function su(t, r) {
+	return new au({ type: "catch", innerType: t, catchValue: typeof r == "function" ? r : () => r })
+}
+var cu = u("ZodNaN", (t, r) => {
+	bi.init(t, r), P.init(t, r)
+})
+function _p(t) {
+	return ea(cu, t)
+}
+var Wa = u("ZodPipe", (t, r) => {
+	ft.init(t, r), P.init(t, r), (t.in = r.in), (t.out = r.out)
+})
+function Lr(t, r) {
+	return new Wa({ type: "pipe", in: t, out: r })
+}
+var uu = u("ZodReadonly", (t, r) => {
+	_i.init(t, r), P.init(t, r)
+})
+function lu(t) {
+	return new uu({ type: "readonly", innerType: t })
+}
+var mu = u("ZodTemplateLiteral", (t, r) => {
+	yi.init(t, r), P.init(t, r)
+})
+function yp(t, r) {
+	return new mu({ type: "template_literal", parts: t, ...y.normalizeParams(r) })
+}
+var pu = u("ZodLazy", (t, r) => {
+	xi.init(t, r), P.init(t, r), (t.unwrap = () => t._zod.def.getter())
+})
+function du(t) {
+	return new pu({ type: "lazy", getter: t })
+}
+var fu = u("ZodPromise", (t, r) => {
+	$i.init(t, r), P.init(t, r), (t.unwrap = () => t._zod.def.innerType)
+})
+function $p(t) {
+	return new fu({ type: "promise", innerType: t })
+}
+var Hr = u("ZodCustom", (t, r) => {
+	zi.init(t, r), P.init(t, r)
+})
+function gu(t) {
+	const r = new V({ check: "custom" })
+	return (r._zod.check = t), r
+}
+function Ga(t, r) {
+	return ca(Hr, t ?? (() => !0), r)
+}
+function hu(t, r = {}) {
+	return ua(Hr, t, r)
+}
+function vu(t) {
+	const r = gu(
+		(n) => (
+			(n.addIssue = (i) => {
+				if (typeof i == "string") n.issues.push(y.issue(i, n.value, r._zod.def))
+				else {
+					const e = i
+					e.fatal && (e.continue = !1),
+						e.code ?? (e.code = "custom"),
+						e.input ?? (e.input = n.value),
+						e.inst ?? (e.inst = r),
+						e.continue ?? (e.continue = !r._zod.def.abort),
+						n.issues.push(y.issue(e))
+				}
+			}),
+			t(n.value, n)
+		),
+	)
+	return r
+}
+function xp(t, r = { error: `Input not instance of ${t.name}` }) {
+	const n = new Hr({ type: "custom", check: "custom", fn: (i) => i instanceof t, abort: !0, ...y.normalizeParams(r) })
+	return (n._zod.bag.Class = t), n
+}
+var zp = (...t) => la({ Pipe: Wa, Boolean: Zt, String: Nt, Transform: Fa }, ...t)
+function kp(t) {
+	const r = du(() => R([l(t), Z(), H(), Rt(), T(r), L(l(), r)]))
+	return r
+}
+function Jr(t, r) {
+	return Lr(Ha(t), r)
+}
+var Sp = {
+	invalid_type: "invalid_type",
+	too_big: "too_big",
+	too_small: "too_small",
+	invalid_format: "invalid_format",
+	not_multiple_of: "not_multiple_of",
+	unrecognized_keys: "unrecognized_keys",
+	invalid_union: "invalid_union",
+	invalid_key: "invalid_key",
+	invalid_element: "invalid_element",
+	invalid_value: "invalid_value",
+	custom: "custom",
+}
+function wp(t) {
+	F({ customError: t })
+}
+function Ip() {
+	return F().customError
+}
+var Ka = {}
+$e(Ka, { bigint: () => Op, boolean: () => Tp, date: () => Np, number: () => Pp, string: () => jp })
+function jp(t) {
+	return Ii(Nt, t)
+}
+function Pp(t) {
+	return Zi(Ut, t)
+}
+function Tp(t) {
+	return Mi(Zt, t)
+}
+function Op(t) {
+	return Vi(Dt, t)
+}
+function Np(t) {
+	return Yi(qr, t)
+}
+F(lr())
+var be = "io.modelcontextprotocol/related-task",
+	Wr = "2.0",
+	B = Ga((t) => t !== null && (typeof t == "object" || typeof t == "function")),
+	bu = R([l(), Z().int()]),
+	_u = l(),
+	Gh = Q({ ttl: R([Z(), Rt()]).optional(), pollInterval: Z().optional() }),
+	Up = z({ ttl: Z().optional() }),
+	Zp = z({ taskId: l() }),
+	Xa = Q({ progressToken: bu.optional(), [be]: Zp.optional() }),
+	ne = z({ _meta: Xa.optional() }),
+	At = ne.extend({ task: Up.optional() }),
+	yu = (t) => At.safeParse(t).success,
+	W = z({ method: l(), params: ne.loose().optional() }),
+	ie = z({ _meta: Xa.optional() }),
+	ae = z({ method: l(), params: ie.loose().optional() }),
+	G = Q({ _meta: Xa.optional() }),
+	Be = R([l(), Z().int()]),
+	$u = z({ jsonrpc: w(Wr), id: Be, ...W.shape }).strict(),
+	Ya = (t) => $u.safeParse(t).success,
+	xu = z({ jsonrpc: w(Wr), ...ae.shape }).strict(),
+	zu = (t) => xu.safeParse(t).success,
+	es = z({ jsonrpc: w(Wr), id: Be, result: G }).strict(),
+	Ct = (t) => es.safeParse(t).success
+var E
+;((t) => {
+	;(t[(t.ConnectionClosed = -32e3)] = "ConnectionClosed"),
+		(t[(t.RequestTimeout = -32001)] = "RequestTimeout"),
+		(t[(t.ParseError = -32700)] = "ParseError"),
+		(t[(t.InvalidRequest = -32600)] = "InvalidRequest"),
+		(t[(t.MethodNotFound = -32601)] = "MethodNotFound"),
+		(t[(t.InvalidParams = -32602)] = "InvalidParams"),
+		(t[(t.InternalError = -32603)] = "InternalError"),
+		(t[(t.UrlElicitationRequired = -32042)] = "UrlElicitationRequired")
+})(E || (E = {}))
+var ts = z({
+	jsonrpc: w(Wr),
+	id: Be.optional(),
+	error: z({ code: Z().int(), message: l(), data: M().optional() }),
+}).strict()
+var ku = (t) => ts.safeParse(t).success
+var Su = R([$u, xu, es, ts]),
+	Kh = R([es, ts]),
+	rs = G.strict(),
+	Dp = ie.extend({ requestId: Be.optional(), reason: l().optional() }),
+	Gr = ae.extend({ method: w("notifications/cancelled"), params: Dp }),
+	Rp = z({ src: l(), mimeType: l().optional(), sizes: T(l()).optional(), theme: X(["light", "dark"]).optional() }),
+	Lt = z({ icons: T(Rp).optional() }),
+	Je = z({ name: l(), title: l().optional() }),
+	Mt = Je.extend({ ...Je.shape, ...Lt.shape, version: l(), websiteUrl: l().optional(), description: l().optional() }),
+	Ep = Et(z({ applyDefaults: H().optional() }), L(l(), M())),
+	Ap = Jr(
+		(t) => (t && typeof t == "object" && !Array.isArray(t) && Object.keys(t).length === 0 ? { form: {} } : t),
+		Et(z({ form: Ep.optional(), url: B.optional() }), L(l(), M()).optional()),
+	),
+	Cp = Q({
+		list: B.optional(),
+		cancel: B.optional(),
+		requests: Q({
+			sampling: Q({ createMessage: B.optional() }).optional(),
+			elicitation: Q({ create: B.optional() }).optional(),
+		}).optional(),
+	}),
+	Lp = Q({
+		list: B.optional(),
+		cancel: B.optional(),
+		requests: Q({ tools: Q({ call: B.optional() }).optional() }).optional(),
+	}),
+	Mp = z({
+		experimental: L(l(), B).optional(),
+		sampling: z({ context: B.optional(), tools: B.optional() }).optional(),
+		elicitation: Ap.optional(),
+		roots: z({ listChanged: H().optional() }).optional(),
+		tasks: Cp.optional(),
+	}),
+	qp = ne.extend({ protocolVersion: l(), capabilities: Mp, clientInfo: Mt }),
+	Vp = W.extend({ method: w("initialize"), params: qp })
+var Fp = z({
+		experimental: L(l(), B).optional(),
+		logging: B.optional(),
+		completions: B.optional(),
+		prompts: z({ listChanged: H().optional() }).optional(),
+		resources: z({ subscribe: H().optional(), listChanged: H().optional() }).optional(),
+		tools: z({ listChanged: H().optional() }).optional(),
+		tasks: Lp.optional(),
+	}),
+	Hp = G.extend({ protocolVersion: l(), capabilities: Fp, serverInfo: Mt, instructions: l().optional() }),
+	Jp = ae.extend({ method: w("notifications/initialized"), params: ie.optional() })
+var Te = W.extend({ method: w("ping"), params: ne.optional() }),
+	Bp = z({ progress: Z(), total: q(Z()), message: q(l()) }),
+	Wp = z({ ...ie.shape, ...Bp.shape, progressToken: bu }),
+	Kr = ae.extend({ method: w("notifications/progress"), params: Wp }),
+	Gp = ne.extend({ cursor: _u.optional() }),
+	qt = W.extend({ params: Gp.optional() }),
+	Vt = G.extend({ nextCursor: _u.optional() }),
+	Kp = X(["working", "input_required", "completed", "failed", "cancelled"]),
+	Ft = z({
+		taskId: l(),
+		status: Kp,
+		ttl: R([Z(), Rt()]),
+		createdAt: l(),
+		lastUpdatedAt: l(),
+		pollInterval: q(Z()),
+		statusMessage: q(l()),
+	}),
+	Qr = G.extend({ task: Ft }),
+	Qp = ie.merge(Ft),
+	Ht = ae.extend({ method: w("notifications/tasks/status"), params: Qp }),
+	Xr = W.extend({ method: w("tasks/get"), params: ne.extend({ taskId: l() }) }),
+	Yr = G.merge(Ft),
+	en = W.extend({ method: w("tasks/result"), params: ne.extend({ taskId: l() }) }),
+	Qh = G.loose(),
+	tn = qt.extend({ method: w("tasks/list") }),
+	rn = Vt.extend({ tasks: T(Ft) }),
+	nn = W.extend({ method: w("tasks/cancel"), params: ne.extend({ taskId: l() }) }),
+	wu = G.merge(Ft),
+	Iu = z({ uri: l(), mimeType: q(l()), _meta: L(l(), M()).optional() }),
+	ju = Iu.extend({ text: l() }),
+	ns = l().refine(
+		(t) => {
+			try {
+				return atob(t), !0
+			} catch {
+				return !1
+			}
+		},
+		{ message: "Invalid Base64 string" },
+	),
+	Pu = Iu.extend({ blob: ns }),
+	Jt = X(["user", "assistant"]),
+	We = z({
+		audience: T(Jt).optional(),
+		priority: Z().min(0).max(1).optional(),
+		lastModified: Ve.datetime({ offset: !0 }).optional(),
+	}),
+	Tu = z({
+		...Je.shape,
+		...Lt.shape,
+		uri: l(),
+		description: q(l()),
+		mimeType: q(l()),
+		annotations: We.optional(),
+		_meta: q(Q({})),
+	}),
+	Xp = z({
+		...Je.shape,
+		...Lt.shape,
+		uriTemplate: l(),
+		description: q(l()),
+		mimeType: q(l()),
+		annotations: We.optional(),
+		_meta: q(Q({})),
+	}),
+	os = qt.extend({ method: w("resources/list") }),
+	on = Vt.extend({ resources: T(Tu) }),
+	is = qt.extend({ method: w("resources/templates/list") }),
+	as = Vt.extend({ resourceTemplates: T(Xp) }),
+	ss = ne.extend({ uri: l() }),
+	Yp = ss,
+	cs = W.extend({ method: w("resources/read"), params: Yp }),
+	an = G.extend({ contents: T(R([ju, Pu])) }),
+	us = ae.extend({ method: w("notifications/resources/list_changed"), params: ie.optional() }),
+	ed = ss,
+	td = W.extend({ method: w("resources/subscribe"), params: ed }),
+	rd = ss,
+	nd = W.extend({ method: w("resources/unsubscribe"), params: rd }),
+	od = ie.extend({ uri: l() }),
+	id = ae.extend({ method: w("notifications/resources/updated"), params: od }),
+	ad = z({ name: l(), description: q(l()), required: q(H()) }),
+	sd = z({ ...Je.shape, ...Lt.shape, description: q(l()), arguments: q(T(ad)), _meta: q(Q({})) }),
+	ls = qt.extend({ method: w("prompts/list") }),
+	ms = Vt.extend({ prompts: T(sd) }),
+	cd = ne.extend({ name: l(), arguments: L(l(), l()).optional() }),
+	ud = W.extend({ method: w("prompts/get"), params: cd }),
+	ps = z({ type: w("text"), text: l(), annotations: We.optional(), _meta: L(l(), M()).optional() }),
+	ds = z({ type: w("image"), data: ns, mimeType: l(), annotations: We.optional(), _meta: L(l(), M()).optional() }),
+	fs = z({ type: w("audio"), data: ns, mimeType: l(), annotations: We.optional(), _meta: L(l(), M()).optional() }),
+	ld = z({ type: w("tool_use"), name: l(), id: l(), input: L(l(), M()), _meta: L(l(), M()).optional() }),
+	gs = z({ type: w("resource"), resource: R([ju, Pu]), annotations: We.optional(), _meta: L(l(), M()).optional() }),
+	hs = Tu.extend({ type: w("resource_link") }),
+	Ge = R([ps, ds, fs, hs, gs]),
+	md = z({ role: Jt, content: Ge }),
+	pd = G.extend({ description: l().optional(), messages: T(md) }),
+	vs = ae.extend({ method: w("notifications/prompts/list_changed"), params: ie.optional() }),
+	dd = z({
+		title: l().optional(),
+		readOnlyHint: H().optional(),
+		destructiveHint: H().optional(),
+		idempotentHint: H().optional(),
+		openWorldHint: H().optional(),
+	}),
+	fd = z({ taskSupport: X(["required", "optional", "forbidden"]).optional() }),
+	sn = z({
+		...Je.shape,
+		...Lt.shape,
+		description: l().optional(),
+		inputSchema: z({ type: w("object"), properties: L(l(), B).optional(), required: T(l()).optional() }).catchall(M()),
+		outputSchema: z({ type: w("object"), properties: L(l(), B).optional(), required: T(l()).optional() })
+			.catchall(M())
+			.optional(),
+		annotations: dd.optional(),
+		execution: fd.optional(),
+		_meta: L(l(), M()).optional(),
+	}),
+	Ou = qt.extend({ method: w("tools/list") }),
+	gd = Vt.extend({ tools: T(sn) }),
+	Oe = G.extend({ content: T(Ge).default([]), structuredContent: L(l(), M()).optional(), isError: H().optional() }),
+	Xh = Oe.or(G.extend({ toolResult: M() })),
+	hd = At.extend({ name: l(), arguments: L(l(), M()).optional() }),
+	cn = W.extend({ method: w("tools/call"), params: hd }),
+	bs = ae.extend({ method: w("notifications/tools/list_changed"), params: ie.optional() }),
+	Yh = z({ autoRefresh: H().default(!0), debounceMs: Z().int().nonnegative().default(300) }),
+	Nu = X(["debug", "info", "notice", "warning", "error", "critical", "alert", "emergency"]),
+	vd = ne.extend({ level: Nu }),
+	bd = W.extend({ method: w("logging/setLevel"), params: vd }),
+	_d = ie.extend({ level: Nu, logger: l().optional(), data: M() }),
+	_s = ae.extend({ method: w("notifications/message"), params: _d }),
+	yd = z({ name: l().optional() }),
+	$d = z({
+		hints: T(yd).optional(),
+		costPriority: Z().min(0).max(1).optional(),
+		speedPriority: Z().min(0).max(1).optional(),
+		intelligencePriority: Z().min(0).max(1).optional(),
+	}),
+	xd = z({ mode: X(["auto", "required", "none"]).optional() }),
+	zd = z({
+		type: w("tool_result"),
+		toolUseId: l().describe("The unique identifier for the corresponding tool call."),
+		content: T(Ge).default([]),
+		structuredContent: z({}).loose().optional(),
+		isError: H().optional(),
+		_meta: L(l(), M()).optional(),
+	}),
+	kd = Fr("type", [ps, ds, fs]),
+	Br = Fr("type", [ps, ds, fs, ld, zd]),
+	Sd = z({ role: Jt, content: R([Br, T(Br)]), _meta: L(l(), M()).optional() }),
+	wd = At.extend({
+		messages: T(Sd),
+		modelPreferences: $d.optional(),
+		systemPrompt: l().optional(),
+		includeContext: X(["none", "thisServer", "allServers"]).optional(),
+		temperature: Z().optional(),
+		maxTokens: Z().int(),
+		stopSequences: T(l()).optional(),
+		metadata: B.optional(),
+		tools: T(sn).optional(),
+		toolChoice: xd.optional(),
+	}),
+	Id = W.extend({ method: w("sampling/createMessage"), params: wd }),
+	jd = G.extend({
+		model: l(),
+		stopReason: q(X(["endTurn", "stopSequence", "maxTokens"]).or(l())),
+		role: Jt,
+		content: kd,
+	}),
+	Pd = G.extend({
+		model: l(),
+		stopReason: q(X(["endTurn", "stopSequence", "maxTokens", "toolUse"]).or(l())),
+		role: Jt,
+		content: R([Br, T(Br)]),
+	}),
+	Td = z({ type: w("boolean"), title: l().optional(), description: l().optional(), default: H().optional() }),
+	Od = z({
+		type: w("string"),
+		title: l().optional(),
+		description: l().optional(),
+		minLength: Z().optional(),
+		maxLength: Z().optional(),
+		format: X(["email", "uri", "date", "date-time"]).optional(),
+		default: l().optional(),
+	}),
+	Nd = z({
+		type: X(["number", "integer"]),
+		title: l().optional(),
+		description: l().optional(),
+		minimum: Z().optional(),
+		maximum: Z().optional(),
+		default: Z().optional(),
+	}),
+	Ud = z({
+		type: w("string"),
+		title: l().optional(),
+		description: l().optional(),
+		enum: T(l()),
+		default: l().optional(),
+	}),
+	Zd = z({
+		type: w("string"),
+		title: l().optional(),
+		description: l().optional(),
+		oneOf: T(z({ const: l(), title: l() })),
+		default: l().optional(),
+	}),
+	Dd = z({
+		type: w("string"),
+		title: l().optional(),
+		description: l().optional(),
+		enum: T(l()),
+		enumNames: T(l()).optional(),
+		default: l().optional(),
+	}),
+	Rd = R([Ud, Zd]),
+	Ed = z({
+		type: w("array"),
+		title: l().optional(),
+		description: l().optional(),
+		minItems: Z().optional(),
+		maxItems: Z().optional(),
+		items: z({ type: w("string"), enum: T(l()) }),
+		default: T(l()).optional(),
+	}),
+	Ad = z({
+		type: w("array"),
+		title: l().optional(),
+		description: l().optional(),
+		minItems: Z().optional(),
+		maxItems: Z().optional(),
+		items: z({ anyOf: T(z({ const: l(), title: l() })) }),
+		default: T(l()).optional(),
+	}),
+	Cd = R([Ed, Ad]),
+	Ld = R([Dd, Rd, Cd]),
+	Md = R([Ld, Td, Od, Nd]),
+	qd = At.extend({
+		mode: w("form").optional(),
+		message: l(),
+		requestedSchema: z({ type: w("object"), properties: L(l(), Md), required: T(l()).optional() }),
+	}),
+	Vd = At.extend({ mode: w("url"), message: l(), elicitationId: l(), url: l().url() }),
+	Fd = R([qd, Vd]),
+	Hd = W.extend({ method: w("elicitation/create"), params: Fd }),
+	Jd = ie.extend({ elicitationId: l() }),
+	Bd = ae.extend({ method: w("notifications/elicitation/complete"), params: Jd }),
+	Wd = G.extend({
+		action: X(["accept", "decline", "cancel"]),
+		content: Jr((t) => (t === null ? void 0 : t), L(l(), R([l(), Z(), H(), T(l())])).optional()),
+	}),
+	Gd = z({ type: w("ref/resource"), uri: l() })
+var Kd = z({ type: w("ref/prompt"), name: l() }),
+	Qd = ne.extend({
+		ref: R([Kd, Gd]),
+		argument: z({ name: l(), value: l() }),
+		context: z({ arguments: L(l(), l()).optional() }).optional(),
+	}),
+	Xd = W.extend({ method: w("completion/complete"), params: Qd })
+var Yd = G.extend({ completion: Q({ values: T(l()).max(100), total: q(Z().int()), hasMore: q(H()) }) }),
+	ef = z({ uri: l().startsWith("file://"), name: l().optional(), _meta: L(l(), M()).optional() }),
+	tf = W.extend({ method: w("roots/list"), params: ne.optional() }),
+	rf = G.extend({ roots: T(ef) }),
+	nf = ae.extend({ method: w("notifications/roots/list_changed"), params: ie.optional() }),
+	ev = R([Te, Vp, Xd, bd, ud, ls, os, is, cs, td, nd, cn, Ou, Xr, en, tn, nn]),
+	tv = R([Gr, Kr, Jp, nf, Ht]),
+	rv = R([rs, jd, Pd, Wd, rf, Yr, rn, Qr]),
+	nv = R([Te, Id, Hd, tf, Xr, en, tn, nn]),
+	ov = R([Gr, Kr, _s, id, us, bs, vs, Ht, Bd]),
+	iv = R([rs, Hp, Yd, pd, ms, on, as, an, Oe, gd, Yr, rn, Qr]),
+	N = class t extends Error {
+		constructor(r, n, i) {
+			super(`MCP error ${r}: ${n}`), (this.code = r), (this.data = i), (this.name = "McpError")
+		}
+		static fromError(r, n, i) {
+			if (r === E.UrlElicitationRequired && i) {
+				const e = i
+				if (e.elicitations) return new Qa(e.elicitations, n)
+			}
+			return new t(r, n, i)
+		}
+	},
+	Qa = class extends N {
+		constructor(r, n = `URL elicitation${r.length > 1 ? "s" : ""} required`) {
+			super(E.UrlElicitationRequired, n, { elicitations: r })
+		}
+		get elicitations() {
+			return this.data?.elicitations ?? []
+		}
+	}
+function un(t) {
+	return !!t._zod
+}
+function ln(t, r) {
+	return un(t) ? De(t, r) : t.safeParse(r)
+}
+function Uu(t) {
+	if (!t) return
+	let r
+	if ((un(t) ? (r = t._zod?.def?.shape) : (r = t.shape), !!r)) {
+		if (typeof r == "function")
+			try {
+				return r()
+			} catch {
+				return
+			}
+		return r
+	}
+}
+function Zu(t) {
+	if (un(t)) {
+		const o = t._zod?.def
+		if (o) {
+			if (o.value !== void 0) return o.value
+			if (Array.isArray(o.values) && o.values.length > 0) return o.values[0]
+		}
+	}
+	const n = t._def
+	if (n) {
+		if (n.value !== void 0) return n.value
+		if (Array.isArray(n.values) && n.values.length > 0) return n.values[0]
+	}
+	const i = t.value
+	if (i !== void 0) return i
+}
+function _e(t) {
+	return t === "completed" || t === "failed" || t === "cancelled"
+}
+var Vv = new Set("ABCDEFGHIJKLMNOPQRSTUVXYZabcdefghijklmnopqrstuvxyz0123456789")
+function ys(t) {
+	const n = Uu(t)?.method
+	if (!n) throw new Error("Schema is missing a method literal")
+	const i = Zu(n)
+	if (typeof i != "string") throw new Error("Schema method literal must be a string")
+	return i
+}
+function $s(t, r) {
+	const n = ln(t, r)
+	if (!n.success) throw n.error
+	return n.data
+}
+var lf = 6e4,
+	Wt = class {
+		constructor(r) {
+			;(this._options = r),
+				(this._requestMessageId = 0),
+				(this._requestHandlers = new Map()),
+				(this._requestHandlerAbortControllers = new Map()),
+				(this._notificationHandlers = new Map()),
+				(this._responseHandlers = new Map()),
+				(this._progressHandlers = new Map()),
+				(this._timeoutInfo = new Map()),
+				(this._pendingDebouncedNotifications = new Set()),
+				(this._taskProgressTokens = new Map()),
+				(this._requestResolvers = new Map()),
+				this.setNotificationHandler(Gr, (n) => {
+					this._oncancel(n)
+				}),
+				this.setNotificationHandler(Kr, (n) => {
+					this._onprogress(n)
+				}),
+				this.setRequestHandler(Te, (n) => ({})),
+				(this._taskStore = r?.taskStore),
+				(this._taskMessageQueue = r?.taskMessageQueue),
+				this._taskStore &&
+					(this.setRequestHandler(Xr, async (n, i) => {
+						const e = await this._taskStore.getTask(n.params.taskId, i.sessionId)
+						if (!e) throw new N(E.InvalidParams, "Failed to retrieve task: Task not found")
+						return { ...e }
+					}),
+					this.setRequestHandler(en, async (n, i) => {
+						const e = async () => {
+							const o = n.params.taskId
+							if (this._taskMessageQueue) {
+								let c
+								while ((c = await this._taskMessageQueue.dequeue(o, i.sessionId))) {
+									if (c.type === "response" || c.type === "error") {
+										const p = c.message,
+											h = p.id,
+											g = this._requestResolvers.get(h)
+										if (g)
+											if ((this._requestResolvers.delete(h), c.type === "response")) g(p)
+											else {
+												const m = p,
+													$ = new N(m.error.code, m.error.message, m.error.data)
+												g($)
+											}
+										else {
+											const m = c.type === "response" ? "Response" : "Error"
+											this._onerror(new Error(`${m} handler missing for request ${h}`))
+										}
+										continue
+									}
+									await this._transport?.send(c.message, { relatedRequestId: i.requestId })
+								}
+							}
+							const a = await this._taskStore.getTask(o, i.sessionId)
+							if (!a) throw new N(E.InvalidParams, `Task not found: ${o}`)
+							if (!_e(a.status)) return await this._waitForTaskUpdate(o, i.signal), await e()
+							if (_e(a.status)) {
+								const c = await this._taskStore.getTaskResult(o, i.sessionId)
+								return this._clearTaskQueue(o), { ...c, _meta: { ...c._meta, [be]: { taskId: o } } }
+							}
+							return await e()
+						}
+						return await e()
+					}),
+					this.setRequestHandler(tn, async (n, i) => {
+						try {
+							const { tasks: e, nextCursor: o } = await this._taskStore.listTasks(n.params?.cursor, i.sessionId)
+							return { tasks: e, nextCursor: o, _meta: {} }
+						} catch (e) {
+							throw new N(E.InvalidParams, `Failed to list tasks: ${e instanceof Error ? e.message : String(e)}`)
+						}
+					}),
+					this.setRequestHandler(nn, async (n, i) => {
+						try {
+							const e = await this._taskStore.getTask(n.params.taskId, i.sessionId)
+							if (!e) throw new N(E.InvalidParams, `Task not found: ${n.params.taskId}`)
+							if (_e(e.status)) throw new N(E.InvalidParams, `Cannot cancel task in terminal status: ${e.status}`)
+							await this._taskStore.updateTaskStatus(
+								n.params.taskId,
+								"cancelled",
+								"Client cancelled task execution.",
+								i.sessionId,
+							),
+								this._clearTaskQueue(n.params.taskId)
+							const o = await this._taskStore.getTask(n.params.taskId, i.sessionId)
+							if (!o) throw new N(E.InvalidParams, `Task not found after cancellation: ${n.params.taskId}`)
+							return { _meta: {}, ...o }
+						} catch (e) {
+							throw e instanceof N
+								? e
+								: new N(E.InvalidRequest, `Failed to cancel task: ${e instanceof Error ? e.message : String(e)}`)
+						}
+					}))
+		}
+		async _oncancel(r) {
+			if (!r.params.requestId) return
+			this._requestHandlerAbortControllers.get(r.params.requestId)?.abort(r.params.reason)
+		}
+		_setupTimeout(r, n, i, e, o = !1) {
+			this._timeoutInfo.set(r, {
+				timeoutId: setTimeout(e, n),
+				startTime: Date.now(),
+				timeout: n,
+				maxTotalTimeout: i,
+				resetTimeoutOnProgress: o,
+				onTimeout: e,
+			})
+		}
+		_resetTimeout(r) {
+			const n = this._timeoutInfo.get(r)
+			if (!n) return !1
+			const i = Date.now() - n.startTime
+			if (n.maxTotalTimeout && i >= n.maxTotalTimeout)
+				throw (
+					(this._timeoutInfo.delete(r),
+					N.fromError(E.RequestTimeout, "Maximum total timeout exceeded", {
+						maxTotalTimeout: n.maxTotalTimeout,
+						totalElapsed: i,
+					}))
+				)
+			return clearTimeout(n.timeoutId), (n.timeoutId = setTimeout(n.onTimeout, n.timeout)), !0
+		}
+		_cleanupTimeout(r) {
+			const n = this._timeoutInfo.get(r)
+			n && (clearTimeout(n.timeoutId), this._timeoutInfo.delete(r))
+		}
+		async connect(r) {
+			this._transport = r
+			const n = this.transport?.onclose
+			this._transport.onclose = () => {
+				n?.(), this._onclose()
+			}
+			const i = this.transport?.onerror
+			this._transport.onerror = (o) => {
+				i?.(o), this._onerror(o)
+			}
+			const e = this._transport?.onmessage
+			;(this._transport.onmessage = (o, a) => {
+				e?.(o, a),
+					Ct(o) || ku(o)
+						? this._onresponse(o)
+						: Ya(o)
+							? this._onrequest(o, a)
+							: zu(o)
+								? this._onnotification(o)
+								: this._onerror(new Error(`Unknown message type: ${JSON.stringify(o)}`))
+			}),
+				await this._transport.start()
+		}
+		_onclose() {
+			const r = this._responseHandlers
+			;(this._responseHandlers = new Map()),
+				this._progressHandlers.clear(),
+				this._taskProgressTokens.clear(),
+				this._pendingDebouncedNotifications.clear()
+			const n = N.fromError(E.ConnectionClosed, "Connection closed")
+			;(this._transport = void 0), this.onclose?.()
+			for (const i of r.values()) i(n)
+		}
+		_onerror(r) {
+			this.onerror?.(r)
+		}
+		_onnotification(r) {
+			const n = this._notificationHandlers.get(r.method) ?? this.fallbackNotificationHandler
+			n !== void 0 &&
+				Promise.resolve()
+					.then(() => n(r))
+					.catch((i) => this._onerror(new Error(`Uncaught error in notification handler: ${i}`)))
+		}
+		_onrequest(r, n) {
+			const i = this._requestHandlers.get(r.method) ?? this.fallbackRequestHandler,
+				e = this._transport,
+				o = r.params?._meta?.[be]?.taskId
+			if (i === void 0) {
+				const g = { jsonrpc: "2.0", id: r.id, error: { code: E.MethodNotFound, message: "Method not found" } }
+				o && this._taskMessageQueue
+					? this._enqueueTaskMessage(o, { type: "error", message: g, timestamp: Date.now() }, e?.sessionId).catch((m) =>
+							this._onerror(new Error(`Failed to enqueue error response: ${m}`)),
+						)
+					: e?.send(g).catch((m) => this._onerror(new Error(`Failed to send an error response: ${m}`)))
+				return
+			}
+			const a = new AbortController()
+			this._requestHandlerAbortControllers.set(r.id, a)
+			const c = yu(r.params) ? r.params.task : void 0,
+				p = this._taskStore ? this.requestTaskStore(r, e?.sessionId) : void 0,
+				h = {
+					signal: a.signal,
+					sessionId: e?.sessionId,
+					_meta: r.params?._meta,
+					sendNotification: async (g) => {
+						const m = { relatedRequestId: r.id }
+						o && (m.relatedTask = { taskId: o }), await this.notification(g, m)
+					},
+					sendRequest: async (g, m, $) => {
+						const b = { ...$, relatedRequestId: r.id }
+						o && !b.relatedTask && (b.relatedTask = { taskId: o })
+						const d = b.relatedTask?.taskId ?? o
+						return d && p && (await p.updateTaskStatus(d, "input_required")), await this.request(g, m, b)
+					},
+					authInfo: n?.authInfo,
+					requestId: r.id,
+					requestInfo: n?.requestInfo,
+					taskId: o,
+					taskStore: p,
+					taskRequestedTtl: c?.ttl,
+					closeSSEStream: n?.closeSSEStream,
+					closeStandaloneSSEStream: n?.closeStandaloneSSEStream,
+				}
+			Promise.resolve()
+				.then(() => {
+					c && this.assertTaskHandlerCapability(r.method)
+				})
+				.then(() => i(r, h))
+				.then(
+					async (g) => {
+						if (a.signal.aborted) return
+						const m = { result: g, jsonrpc: "2.0", id: r.id }
+						o && this._taskMessageQueue
+							? await this._enqueueTaskMessage(o, { type: "response", message: m, timestamp: Date.now() }, e?.sessionId)
+							: await e?.send(m)
+					},
+					async (g) => {
+						if (a.signal.aborted) return
+						const m = {
+							jsonrpc: "2.0",
+							id: r.id,
+							error: {
+								code: Number.isSafeInteger(g.code) ? g.code : E.InternalError,
+								message: g.message ?? "Internal error",
+								...(g.data !== void 0 && { data: g.data }),
+							},
+						}
+						o && this._taskMessageQueue
+							? await this._enqueueTaskMessage(o, { type: "error", message: m, timestamp: Date.now() }, e?.sessionId)
+							: await e?.send(m)
+					},
+				)
+				.catch((g) => this._onerror(new Error(`Failed to send response: ${g}`)))
+				.finally(() => {
+					this._requestHandlerAbortControllers.delete(r.id)
+				})
+		}
+		_onprogress(r) {
+			const { progressToken: n, ...i } = r.params,
+				e = Number(n),
+				o = this._progressHandlers.get(e)
+			if (!o) {
+				this._onerror(new Error(`Received a progress notification for an unknown token: ${JSON.stringify(r)}`))
+				return
+			}
+			const a = this._responseHandlers.get(e),
+				c = this._timeoutInfo.get(e)
+			if (c && a && c.resetTimeoutOnProgress)
+				try {
+					this._resetTimeout(e)
+				} catch (p) {
+					this._responseHandlers.delete(e), this._progressHandlers.delete(e), this._cleanupTimeout(e), a(p)
+					return
+				}
+			o(i)
+		}
+		_onresponse(r) {
+			const n = Number(r.id),
+				i = this._requestResolvers.get(n)
+			if (i) {
+				if ((this._requestResolvers.delete(n), Ct(r))) i(r)
+				else {
+					const a = new N(r.error.code, r.error.message, r.error.data)
+					i(a)
+				}
+				return
+			}
+			const e = this._responseHandlers.get(n)
+			if (e === void 0) {
+				this._onerror(new Error(`Received a response for an unknown message ID: ${JSON.stringify(r)}`))
+				return
+			}
+			this._responseHandlers.delete(n), this._cleanupTimeout(n)
+			let o = !1
+			if (Ct(r) && r.result && typeof r.result == "object") {
+				const a = r.result
+				if (a.task && typeof a.task == "object") {
+					const c = a.task
+					typeof c.taskId == "string" && ((o = !0), this._taskProgressTokens.set(c.taskId, n))
+				}
+			}
+			if ((o || this._progressHandlers.delete(n), Ct(r))) e(r)
+			else {
+				const a = N.fromError(r.error.code, r.error.message, r.error.data)
+				e(a)
+			}
+		}
+		get transport() {
+			return this._transport
+		}
+		async close() {
+			await this._transport?.close()
+		}
+		async *requestStream(r, n, i) {
+			const { task: e } = i ?? {}
+			if (!e) {
+				try {
+					yield { type: "result", result: await this.request(r, n, i) }
+				} catch (a) {
+					yield { type: "error", error: a instanceof N ? a : new N(E.InternalError, String(a)) }
+				}
+				return
+			}
+			let o
+			try {
+				const a = await this.request(r, Qr, i)
+				if (a.task) (o = a.task.taskId), yield { type: "taskCreated", task: a.task }
+				else throw new N(E.InternalError, "Task creation did not return a task")
+				for (;;) {
+					const c = await this.getTask({ taskId: o }, i)
+					if ((yield { type: "taskStatus", task: c }, _e(c.status))) {
+						c.status === "completed"
+							? yield { type: "result", result: await this.getTaskResult({ taskId: o }, n, i) }
+							: c.status === "failed"
+								? yield { type: "error", error: new N(E.InternalError, `Task ${o} failed`) }
+								: c.status === "cancelled" &&
+									(yield { type: "error", error: new N(E.InternalError, `Task ${o} was cancelled`) })
+						return
+					}
+					if (c.status === "input_required") {
+						yield { type: "result", result: await this.getTaskResult({ taskId: o }, n, i) }
+						return
+					}
+					const p = c.pollInterval ?? this._options?.defaultTaskPollInterval ?? 1e3
+					await new Promise((h) => setTimeout(h, p)), i?.signal?.throwIfAborted()
+				}
+			} catch (a) {
+				yield { type: "error", error: a instanceof N ? a : new N(E.InternalError, String(a)) }
+			}
+		}
+		request(r, n, i) {
+			const { relatedRequestId: e, resumptionToken: o, onresumptiontoken: a, task: c, relatedTask: p } = i ?? {}
+			return new Promise((h, g) => {
+				const m = (S) => {
+					g(S)
+				}
+				if (!this._transport) {
+					m(new Error("Not connected"))
+					return
+				}
+				if (this._options?.enforceStrictCapabilities === !0)
+					try {
+						this.assertCapabilityForMethod(r.method), c && this.assertTaskCapability(r.method)
+					} catch (S) {
+						m(S)
+						return
+					}
+				i?.signal?.throwIfAborted()
+				const $ = this._requestMessageId++,
+					b = { ...r, jsonrpc: "2.0", id: $ }
+				i?.onprogress &&
+					(this._progressHandlers.set($, i.onprogress),
+					(b.params = { ...r.params, _meta: { ...(r.params?._meta || {}), progressToken: $ } })),
+					c && (b.params = { ...b.params, task: c }),
+					p && (b.params = { ...b.params, _meta: { ...(b.params?._meta || {}), [be]: p } })
+				const d = (S) => {
+					this._responseHandlers.delete($),
+						this._progressHandlers.delete($),
+						this._cleanupTimeout($),
+						this._transport
+							?.send(
+								{ jsonrpc: "2.0", method: "notifications/cancelled", params: { requestId: $, reason: String(S) } },
+								{ relatedRequestId: e, resumptionToken: o, onresumptiontoken: a },
+							)
+							.catch((O) => this._onerror(new Error(`Failed to send cancellation: ${O}`)))
+					const I = S instanceof N ? S : new N(E.RequestTimeout, String(S))
+					g(I)
+				}
+				this._responseHandlers.set($, (S) => {
+					if (!i?.signal?.aborted) {
+						if (S instanceof Error) return g(S)
+						try {
+							const I = ln(n, S.result)
+							I.success ? h(I.data) : g(I.error)
+						} catch (I) {
+							g(I)
+						}
+					}
+				}),
+					i?.signal?.addEventListener("abort", () => {
+						d(i?.signal?.reason)
+					})
+				const x = i?.timeout ?? lf,
+					k = () => d(N.fromError(E.RequestTimeout, "Request timed out", { timeout: x }))
+				this._setupTimeout($, x, i?.maxTotalTimeout, k, i?.resetTimeoutOnProgress ?? !1)
+				const D = p?.taskId
+				if (D) {
+					const S = (I) => {
+						const O = this._responseHandlers.get($)
+						O ? O(I) : this._onerror(new Error(`Response handler missing for side-channeled request ${$}`))
+					}
+					this._requestResolvers.set($, S),
+						this._enqueueTaskMessage(D, { type: "request", message: b, timestamp: Date.now() }).catch((I) => {
+							this._cleanupTimeout($), g(I)
+						})
+				} else
+					this._transport.send(b, { relatedRequestId: e, resumptionToken: o, onresumptiontoken: a }).catch((S) => {
+						this._cleanupTimeout($), g(S)
+					})
+			})
+		}
+		async getTask(r, n) {
+			return this.request({ method: "tasks/get", params: r }, Yr, n)
+		}
+		async getTaskResult(r, n, i) {
+			return this.request({ method: "tasks/result", params: r }, n, i)
+		}
+		async listTasks(r, n) {
+			return this.request({ method: "tasks/list", params: r }, rn, n)
+		}
+		async cancelTask(r, n) {
+			return this.request({ method: "tasks/cancel", params: r }, wu, n)
+		}
+		async notification(r, n) {
+			if (!this._transport) throw new Error("Not connected")
+			this.assertNotificationCapability(r.method)
+			const i = n?.relatedTask?.taskId
+			if (i) {
+				const c = {
+					...r,
+					jsonrpc: "2.0",
+					params: { ...r.params, _meta: { ...(r.params?._meta || {}), [be]: n.relatedTask } },
+				}
+				await this._enqueueTaskMessage(i, { type: "notification", message: c, timestamp: Date.now() })
+				return
+			}
+			if (
+				(this._options?.debouncedNotificationMethods ?? []).includes(r.method) &&
+				!r.params &&
+				!n?.relatedRequestId &&
+				!n?.relatedTask
+			) {
+				if (this._pendingDebouncedNotifications.has(r.method)) return
+				this._pendingDebouncedNotifications.add(r.method),
+					Promise.resolve().then(() => {
+						if ((this._pendingDebouncedNotifications.delete(r.method), !this._transport)) return
+						let c = { ...r, jsonrpc: "2.0" }
+						n?.relatedTask &&
+							(c = { ...c, params: { ...c.params, _meta: { ...(c.params?._meta || {}), [be]: n.relatedTask } } }),
+							this._transport?.send(c, n).catch((p) => this._onerror(p))
+					})
+				return
+			}
+			let a = { ...r, jsonrpc: "2.0" }
+			n?.relatedTask &&
+				(a = { ...a, params: { ...a.params, _meta: { ...(a.params?._meta || {}), [be]: n.relatedTask } } }),
+				await this._transport.send(a, n)
+		}
+		setRequestHandler(r, n) {
+			const i = ys(r)
+			this.assertRequestHandlerCapability(i),
+				this._requestHandlers.set(i, (e, o) => {
+					const a = $s(r, e)
+					return Promise.resolve(n(a, o))
+				})
+		}
+		removeRequestHandler(r) {
+			this._requestHandlers.delete(r)
+		}
+		assertCanSetRequestHandler(r) {
+			if (this._requestHandlers.has(r))
+				throw new Error(`A request handler for ${r} already exists, which would be overridden`)
+		}
+		setNotificationHandler(r, n) {
+			const i = ys(r)
+			this._notificationHandlers.set(i, (e) => {
+				const o = $s(r, e)
+				return Promise.resolve(n(o))
+			})
+		}
+		removeNotificationHandler(r) {
+			this._notificationHandlers.delete(r)
+		}
+		_cleanupTaskProgressHandler(r) {
+			const n = this._taskProgressTokens.get(r)
+			n !== void 0 && (this._progressHandlers.delete(n), this._taskProgressTokens.delete(r))
+		}
+		async _enqueueTaskMessage(r, n, i) {
+			if (!this._taskStore || !this._taskMessageQueue)
+				throw new Error("Cannot enqueue task message: taskStore and taskMessageQueue are not configured")
+			const e = this._options?.maxTaskQueueSize
+			await this._taskMessageQueue.enqueue(r, n, i, e)
+		}
+		async _clearTaskQueue(r, n) {
+			if (this._taskMessageQueue) {
+				const i = await this._taskMessageQueue.dequeueAll(r, n)
+				for (const e of i)
+					if (e.type === "request" && Ya(e.message)) {
+						const o = e.message.id,
+							a = this._requestResolvers.get(o)
+						a
+							? (a(new N(E.InternalError, "Task cancelled or completed")), this._requestResolvers.delete(o))
+							: this._onerror(new Error(`Resolver missing for request ${o} during task ${r} cleanup`))
+					}
+			}
+		}
+		async _waitForTaskUpdate(r, n) {
+			let i = this._options?.defaultTaskPollInterval ?? 1e3
+			try {
+				const e = await this._taskStore?.getTask(r)
+				e?.pollInterval && (i = e.pollInterval)
+			} catch {}
+			return new Promise((e, o) => {
+				if (n.aborted) {
+					o(new N(E.InvalidRequest, "Request cancelled"))
+					return
+				}
+				const a = setTimeout(e, i)
+				n.addEventListener(
+					"abort",
+					() => {
+						clearTimeout(a), o(new N(E.InvalidRequest, "Request cancelled"))
+					},
+					{ once: !0 },
+				)
+			})
+		}
+		requestTaskStore(r, n) {
+			const i = this._taskStore
+			if (!i) throw new Error("No task store configured")
+			return {
+				createTask: async (e) => {
+					if (!r) throw new Error("No request provided")
+					return await i.createTask(e, r.id, { method: r.method, params: r.params }, n)
+				},
+				getTask: async (e) => {
+					const o = await i.getTask(e, n)
+					if (!o) throw new N(E.InvalidParams, "Failed to retrieve task: Task not found")
+					return o
+				},
+				storeTaskResult: async (e, o, a) => {
+					await i.storeTaskResult(e, o, a, n)
+					const c = await i.getTask(e, n)
+					if (c) {
+						const p = Ht.parse({ method: "notifications/tasks/status", params: c })
+						await this.notification(p), _e(c.status) && this._cleanupTaskProgressHandler(e)
+					}
+				},
+				getTaskResult: (e) => i.getTaskResult(e, n),
+				updateTaskStatus: async (e, o, a) => {
+					const c = await i.getTask(e, n)
+					if (!c) throw new N(E.InvalidParams, `Task "${e}" not found - it may have been cleaned up`)
+					if (_e(c.status))
+						throw new N(
+							E.InvalidParams,
+							`Cannot update task "${e}" from terminal status "${c.status}" to "${o}". Terminal states (completed, failed, cancelled) cannot transition to other states.`,
+						)
+					await i.updateTaskStatus(e, o, a, n)
+					const p = await i.getTask(e, n)
+					if (p) {
+						const h = Ht.parse({ method: "notifications/tasks/status", params: p })
+						await this.notification(h), _e(p.status) && this._cleanupTaskProgressHandler(e)
+					}
+				},
+				listTasks: (e) => i.listTasks(e, n),
+			}
+		}
+	}
+var Cu = "2026-01-26",
+	Fy = "ui/open-link",
+	Hy = "ui/download-file",
+	Jy = "ui/message",
+	By = "ui/notifications/sandbox-proxy-ready",
+	Wy = "ui/notifications/sandbox-resource-ready",
+	Gy = "ui/notifications/size-changed",
+	Ky = "ui/notifications/tool-input",
+	mf = "ui/notifications/tool-input-partial",
+	Qy = "ui/notifications/tool-result",
+	Xy = "ui/notifications/tool-cancelled",
+	Yy = "ui/notifications/host-context-changed",
+	e$ = "ui/resource-teardown",
+	t$ = "ui/initialize",
+	r$ = "ui/notifications/initialized",
+	n$ = "ui/request-display-mode",
+	pf = s.union([s.literal("light"), s.literal("dark")]).describe("Color theme preference for the host environment."),
+	Gt = s
+		.union([s.literal("inline"), s.literal("fullscreen"), s.literal("pip")])
+		.describe("Display mode for UI presentation."),
+	df = s
+		.union([
+			s.literal("--color-background-primary"),
+			s.literal("--color-background-secondary"),
+			s.literal("--color-background-tertiary"),
+			s.literal("--color-background-inverse"),
+			s.literal("--color-background-ghost"),
+			s.literal("--color-background-info"),
+			s.literal("--color-background-danger"),
+			s.literal("--color-background-success"),
+			s.literal("--color-background-warning"),
+			s.literal("--color-background-disabled"),
+			s.literal("--color-text-primary"),
+			s.literal("--color-text-secondary"),
+			s.literal("--color-text-tertiary"),
+			s.literal("--color-text-inverse"),
+			s.literal("--color-text-ghost"),
+			s.literal("--color-text-info"),
+			s.literal("--color-text-danger"),
+			s.literal("--color-text-success"),
+			s.literal("--color-text-warning"),
+			s.literal("--color-text-disabled"),
+			s.literal("--color-border-primary"),
+			s.literal("--color-border-secondary"),
+			s.literal("--color-border-tertiary"),
+			s.literal("--color-border-inverse"),
+			s.literal("--color-border-ghost"),
+			s.literal("--color-border-info"),
+			s.literal("--color-border-danger"),
+			s.literal("--color-border-success"),
+			s.literal("--color-border-warning"),
+			s.literal("--color-border-disabled"),
+			s.literal("--color-ring-primary"),
+			s.literal("--color-ring-secondary"),
+			s.literal("--color-ring-inverse"),
+			s.literal("--color-ring-info"),
+			s.literal("--color-ring-danger"),
+			s.literal("--color-ring-success"),
+			s.literal("--color-ring-warning"),
+			s.literal("--font-sans"),
+			s.literal("--font-mono"),
+			s.literal("--font-weight-normal"),
+			s.literal("--font-weight-medium"),
+			s.literal("--font-weight-semibold"),
+			s.literal("--font-weight-bold"),
+			s.literal("--font-text-xs-size"),
+			s.literal("--font-text-sm-size"),
+			s.literal("--font-text-md-size"),
+			s.literal("--font-text-lg-size"),
+			s.literal("--font-heading-xs-size"),
+			s.literal("--font-heading-sm-size"),
+			s.literal("--font-heading-md-size"),
+			s.literal("--font-heading-lg-size"),
+			s.literal("--font-heading-xl-size"),
+			s.literal("--font-heading-2xl-size"),
+			s.literal("--font-heading-3xl-size"),
+			s.literal("--font-text-xs-line-height"),
+			s.literal("--font-text-sm-line-height"),
+			s.literal("--font-text-md-line-height"),
+			s.literal("--font-text-lg-line-height"),
+			s.literal("--font-heading-xs-line-height"),
+			s.literal("--font-heading-sm-line-height"),
+			s.literal("--font-heading-md-line-height"),
+			s.literal("--font-heading-lg-line-height"),
+			s.literal("--font-heading-xl-line-height"),
+			s.literal("--font-heading-2xl-line-height"),
+			s.literal("--font-heading-3xl-line-height"),
+			s.literal("--border-radius-xs"),
+			s.literal("--border-radius-sm"),
+			s.literal("--border-radius-md"),
+			s.literal("--border-radius-lg"),
+			s.literal("--border-radius-xl"),
+			s.literal("--border-radius-full"),
+			s.literal("--border-width-regular"),
+			s.literal("--shadow-hairline"),
+			s.literal("--shadow-sm"),
+			s.literal("--shadow-md"),
+			s.literal("--shadow-lg"),
+		])
+		.describe("CSS variable keys available to MCP apps for theming."),
+	ff = s
+		.record(
+			df.describe(`Style variables for theming MCP apps.
+
+Individual style keys are optional - hosts may provide any subset of these values.
+Values are strings containing CSS values (colors, sizes, font stacks, etc.).
+
+Note: This type uses \`Record<K, string | undefined>\` rather than \`Partial<Record<K, string>>\`
+for compatibility with Zod schema generation. Both are functionally equivalent for validation.`),
+			s.union([s.string(), s.undefined()]).describe(`Style variables for theming MCP apps.
+
+Individual style keys are optional - hosts may provide any subset of these values.
+Values are strings containing CSS values (colors, sizes, font stacks, etc.).
+
+Note: This type uses \`Record<K, string | undefined>\` rather than \`Partial<Record<K, string>>\`
+for compatibility with Zod schema generation. Both are functionally equivalent for validation.`),
+		)
+		.describe(`Style variables for theming MCP apps.
+
+Individual style keys are optional - hosts may provide any subset of these values.
+Values are strings containing CSS values (colors, sizes, font stacks, etc.).
+
+Note: This type uses \`Record<K, string | undefined>\` rather than \`Partial<Record<K, string>>\`
+for compatibility with Zod schema generation. Both are functionally equivalent for validation.`),
+	gf = s.object({
+		method: s.literal("ui/open-link"),
+		params: s.object({ url: s.string().describe("URL to open in the host's browser") }),
+	}),
+	a$ = s
+		.object({
+			isError: s
+				.boolean()
+				.optional()
+				.describe("True if the host failed to open the URL (e.g., due to security policy)."),
+		})
+		.passthrough(),
+	s$ = s
+		.object({
+			isError: s.boolean().optional().describe("True if the download failed (e.g., user cancelled or host denied)."),
+		})
+		.passthrough(),
+	c$ = s
+		.object({ isError: s.boolean().optional().describe("True if the host rejected or failed to deliver the message.") })
+		.passthrough(),
+	hf = s.object({ method: s.literal("ui/notifications/sandbox-proxy-ready"), params: s.object({}) }),
+	xs = s.object({
+		connectDomains: s
+			.array(s.string())
+			.optional()
+			.describe(`Origins for network requests (fetch/XHR/WebSocket).
+
+- Maps to CSP \`connect-src\` directive
+- Empty or omitted \u2192 no network connections (secure default)`),
+		resourceDomains: s
+			.array(s.string())
+			.optional()
+			.describe(
+				"Origins for static resources (images, scripts, stylesheets, fonts, media).\n\n- Maps to CSP `img-src`, `script-src`, `style-src`, `font-src`, `media-src` directives\n- Wildcard subdomains supported: `https://*.example.com`\n- Empty or omitted \u2192 no network resources (secure default)",
+			),
+		frameDomains: s
+			.array(s.string())
+			.optional()
+			.describe(
+				"Origins for nested iframes.\n\n- Maps to CSP `frame-src` directive\n- Empty or omitted \u2192 no nested iframes allowed (`frame-src 'none'`)",
+			),
+		baseUriDomains: s
+			.array(s.string())
+			.optional()
+			.describe(
+				"Allowed base URIs for the document.\n\n- Maps to CSP `base-uri` directive\n- Empty or omitted \u2192 only same origin allowed (`base-uri 'self'`)",
+			),
+	}),
+	zs = s.object({
+		camera: s.object({}).optional().describe("Request camera access.\n\nMaps to Permission Policy `camera` feature."),
+		microphone: s
+			.object({})
+			.optional()
+			.describe("Request microphone access.\n\nMaps to Permission Policy `microphone` feature."),
+		geolocation: s
+			.object({})
+			.optional()
+			.describe("Request geolocation access.\n\nMaps to Permission Policy `geolocation` feature."),
+		clipboardWrite: s
+			.object({})
+			.optional()
+			.describe("Request clipboard write access.\n\nMaps to Permission Policy `clipboard-write` feature."),
+	}),
+	vf = s.object({
+		method: s.literal("ui/notifications/size-changed"),
+		params: s.object({
+			width: s.number().optional().describe("New width in pixels."),
+			height: s.number().optional().describe("New height in pixels."),
+		}),
+	}),
+	u$ = s.object({
+		method: s.literal("ui/notifications/tool-input"),
+		params: s.object({
+			arguments: s
+				.record(s.string(), s.unknown().describe("Complete tool call arguments as key-value pairs."))
+				.optional()
+				.describe("Complete tool call arguments as key-value pairs."),
+		}),
+	}),
+	l$ = s.object({
+		method: s.literal("ui/notifications/tool-input-partial"),
+		params: s.object({
+			arguments: s
+				.record(s.string(), s.unknown().describe("Partial tool call arguments (incomplete, may change)."))
+				.optional()
+				.describe("Partial tool call arguments (incomplete, may change)."),
+		}),
+	}),
+	m$ = s.object({
+		method: s.literal("ui/notifications/tool-cancelled"),
+		params: s.object({
+			reason: s.string().optional().describe('Optional reason for the cancellation (e.g., "user action", "timeout").'),
+		}),
+	}),
+	bf = s.object({ fonts: s.string().optional() }),
+	_f = s.object({
+		variables: ff.optional().describe("CSS variables for theming the app."),
+		css: bf.optional().describe("CSS blocks that apps can inject."),
+	}),
+	p$ = s.object({ method: s.literal("ui/resource-teardown"), params: s.object({}) }),
+	yf = s.record(s.string(), s.unknown()),
+	Du = s.object({
+		text: s.object({}).optional().describe("Host supports text content blocks."),
+		image: s.object({}).optional().describe("Host supports image content blocks."),
+		audio: s.object({}).optional().describe("Host supports audio content blocks."),
+		resource: s.object({}).optional().describe("Host supports resource content blocks."),
+		resourceLink: s.object({}).optional().describe("Host supports resource link content blocks."),
+		structuredContent: s.object({}).optional().describe("Host supports structured content."),
+	}),
+	$f = s.object({
+		experimental: s.object({}).optional().describe("Experimental features (structure TBD)."),
+		openLinks: s.object({}).optional().describe("Host supports opening external URLs."),
+		downloadFile: s.object({}).optional().describe("Host supports file downloads via ui/download-file."),
+		serverTools: s
+			.object({ listChanged: s.boolean().optional().describe("Host supports tools/list_changed notifications.") })
+			.optional()
+			.describe("Host can proxy tool calls to the MCP server."),
+		serverResources: s
+			.object({ listChanged: s.boolean().optional().describe("Host supports resources/list_changed notifications.") })
+			.optional()
+			.describe("Host can proxy resource reads to the MCP server."),
+		logging: s.object({}).optional().describe("Host accepts log messages."),
+		sandbox: s
+			.object({
+				permissions: zs.optional().describe("Permissions granted by the host (camera, microphone, geolocation)."),
+				csp: xs.optional().describe("CSP domains approved by the host."),
+			})
+			.optional()
+			.describe("Sandbox configuration applied by the host."),
+		updateModelContext: Du.optional().describe(
+			"Host accepts context updates (ui/update-model-context) to be included in the model's context for future turns.",
+		),
+		message: Du.optional().describe("Host supports receiving content messages (ui/message) from the view."),
+	}),
+	xf = s.object({
+		experimental: s.object({}).optional().describe("Experimental features (structure TBD)."),
+		tools: s
+			.object({ listChanged: s.boolean().optional().describe("App supports tools/list_changed notifications.") })
+			.optional()
+			.describe("App exposes MCP-style tools that the host can call."),
+		availableDisplayModes: s.array(Gt).optional().describe("Display modes the app supports."),
+	}),
+	zf = s.object({ method: s.literal("ui/notifications/initialized"), params: s.object({}).optional() }),
+	d$ = s.object({
+		csp: xs.optional().describe("Content Security Policy configuration for UI resources."),
+		permissions: zs.optional().describe("Sandbox permissions requested by the UI resource."),
+		domain: s
+			.string()
+			.optional()
+			.describe(`Dedicated origin for view sandbox.
+
+Useful when views need stable, dedicated origins for OAuth callbacks, CORS policies, or API key allowlists.
+
+**Host-dependent:** The format and validation rules for this field are determined by each host. Servers MUST consult host-specific documentation for the expected domain format. Common patterns include:
+- Hash-based subdomains (e.g., \`{hash}.claudemcpcontent.com\`)
+- URL-derived subdomains (e.g., \`www-example-com.oaiusercontent.com\`)
+
+If omitted, host uses default sandbox origin (typically per-conversation).`),
+		prefersBorder: s
+			.boolean()
+			.optional()
+			.describe(`Visual boundary preference - true if view prefers a visible border.
+
+Boolean requesting whether a visible border and background is provided by the host. Specifying an explicit value for this is recommended because hosts' defaults may vary.
+
+- \`true\`: request visible border + background
+- \`false\`: request no visible border + background
+- omitted: host decides border`),
+	}),
+	Ru = s.object({
+		method: s.literal("ui/request-display-mode"),
+		params: s.object({ mode: Gt.describe("The display mode being requested.") }),
+	}),
+	f$ = s
+		.object({
+			mode: Gt.describe("The display mode that was actually set. May differ from requested if not supported."),
+		})
+		.passthrough(),
+	kf = s.union([s.literal("model"), s.literal("app")]).describe("Tool visibility scope - who can access the tool."),
+	g$ = s.object({
+		resourceUri: s.string().optional(),
+		visibility: s
+			.array(kf)
+			.optional()
+			.describe(`Who can access this tool. Default: ["model", "app"]
+- "model": Tool visible to and callable by the agent
+- "app": Tool callable by the app from this server only`),
+	}),
+	h$ = s.object({
+		mimeTypes: s
+			.array(s.string())
+			.optional()
+			.describe(
+				'Array of supported MIME types for UI resources.\nMust include `"text/html;profile=mcp-app"` for MCP Apps support.',
+			),
+	}),
+	Sf = s.object({
+		method: s.literal("ui/download-file"),
+		params: s.object({
+			contents: s
+				.array(s.union([gs, hs]))
+				.describe(
+					"Resource contents to download \u2014 embedded (inline data) or linked (host fetches). Uses standard MCP resource types.",
+				),
+		}),
+	}),
+	wf = s.object({
+		method: s.literal("ui/message"),
+		params: s.object({
+			role: s.literal("user").describe('Message role, currently only "user" is supported.'),
+			content: s.array(Ge).describe("Message content blocks (text, image, etc.)."),
+		}),
+	}),
+	v$ = s.object({
+		method: s.literal("ui/notifications/sandbox-resource-ready"),
+		params: s.object({
+			html: s.string().describe("HTML content to load into the inner iframe."),
+			sandbox: s.string().optional().describe("Optional override for the inner iframe's sandbox attribute."),
+			csp: xs.optional().describe("CSP configuration from resource metadata."),
+			permissions: zs.optional().describe("Sandbox permissions from resource metadata."),
+		}),
+	}),
+	b$ = s.object({
+		method: s.literal("ui/notifications/tool-result"),
+		params: Oe.describe("Standard MCP tool execution result."),
+	}),
+	Lu = s
+		.object({
+			toolInfo: s
+				.object({
+					id: Be.optional().describe("JSON-RPC id of the tools/call request."),
+					tool: sn.describe("Tool definition including name, inputSchema, etc."),
+				})
+				.optional()
+				.describe("Metadata of the tool call that instantiated this App."),
+			theme: pf.optional().describe("Current color theme preference."),
+			styles: _f.optional().describe("Style configuration for theming the app."),
+			displayMode: Gt.optional().describe("How the UI is currently displayed."),
+			availableDisplayModes: s.array(Gt).optional().describe("Display modes the host supports."),
+			containerDimensions: s
+				.union([
+					s.object({ height: s.number().describe("Fixed container height in pixels.") }),
+					s.object({
+						maxHeight: s.union([s.number(), s.undefined()]).optional().describe("Maximum container height in pixels."),
+					}),
+				])
+				.and(
+					s.union([
+						s.object({ width: s.number().describe("Fixed container width in pixels.") }),
+						s.object({
+							maxWidth: s.union([s.number(), s.undefined()]).optional().describe("Maximum container width in pixels."),
+						}),
+					]),
+				)
+				.optional()
+				.describe(`Container dimensions. Represents the dimensions of the iframe or other
+container holding the app. Specify either width or maxWidth, and either height or maxHeight.`),
+			locale: s.string().optional().describe("User's language and region preference in BCP 47 format."),
+			timeZone: s.string().optional().describe("User's timezone in IANA format."),
+			userAgent: s.string().optional().describe("Host application identifier."),
+			platform: s
+				.union([s.literal("web"), s.literal("desktop"), s.literal("mobile")])
+				.optional()
+				.describe("Platform type for responsive design decisions."),
+			deviceCapabilities: s
+				.object({
+					touch: s.boolean().optional().describe("Whether the device supports touch input."),
+					hover: s.boolean().optional().describe("Whether the device supports hover interactions."),
+				})
+				.optional()
+				.describe("Device input capabilities."),
+			safeAreaInsets: s
+				.object({
+					top: s.number().describe("Top safe area inset in pixels."),
+					right: s.number().describe("Right safe area inset in pixels."),
+					bottom: s.number().describe("Bottom safe area inset in pixels."),
+					left: s.number().describe("Left safe area inset in pixels."),
+				})
+				.optional()
+				.describe("Mobile safe area boundaries in pixels."),
+		})
+		.passthrough(),
+	_$ = s.object({
+		method: s.literal("ui/notifications/host-context-changed"),
+		params: Lu.describe("Partial context update containing only changed fields."),
+	}),
+	If = s.object({
+		method: s.literal("ui/update-model-context"),
+		params: s.object({
+			content: s.array(Ge).optional().describe("Context content blocks (text, image, etc.)."),
+			structuredContent: s
+				.record(s.string(), s.unknown().describe("Structured content for machine-readable context data."))
+				.optional()
+				.describe("Structured content for machine-readable context data."),
+		}),
+	}),
+	jf = s.object({
+		method: s.literal("ui/initialize"),
+		params: s.object({
+			appInfo: Mt.describe("App identification (name and version)."),
+			appCapabilities: xf.describe("Features and capabilities this app provides."),
+			protocolVersion: s.string().describe("Protocol version this app supports."),
+		}),
+	}),
+	y$ = s
+		.object({
+			protocolVersion: s.string().describe('Negotiated protocol version string (e.g., "2025-11-21").'),
+			hostInfo: Mt.describe("Host application identification and version."),
+			hostCapabilities: $f.describe("Features and capabilities provided by the host."),
+			hostContext: Lu.describe("Rich context about the host environment."),
+		})
+		.passthrough(),
+	Eu = class {
+		eventTarget
+		eventSource
+		messageListener
+		constructor(r = window.parent, n) {
+			;(this.eventTarget = r),
+				(this.eventSource = n),
+				(this.messageListener = (i) => {
+					if (n && i.source !== this.eventSource) {
+						console.debug("Ignoring message from unknown source", i)
+						return
+					}
+					const e = Su.safeParse(i.data)
+					e.success
+						? (console.debug("Parsed message", e.data), this.onmessage?.(e.data))
+						: i.data?.jsonrpc !== "2.0"
+							? console.debug("Ignoring non-JSON-RPC message", e.error.message, i)
+							: (console.error("Failed to parse message", e.error.message, i),
+								this.onerror?.(Error("Invalid JSON-RPC message received: " + e.error.message)))
+				})
+		}
+		async start() {
+			window.addEventListener("message", this.messageListener)
+		}
+		async send(r, n) {
+			r.method !== mf && console.debug("Sending message", r), this.eventTarget.postMessage(r, "*")
+		}
+		async close() {
+			window.removeEventListener("message", this.messageListener), this.onclose?.()
+		}
+		onclose
+		onerror
+		onmessage
+		sessionId
+		setProtocolVersion
+	},
+	Pf = "ui/resourceUri",
+	k$ = "text/html;profile=mcp-app"
+function S$(t) {
+	let r = t._meta?.ui?.resourceUri
+	if ((r === void 0 && (r = t._meta?.[Pf]), typeof r == "string" && r.startsWith("ui://"))) return r
+	if (r !== void 0) throw Error(`Invalid UI resource URI: ${JSON.stringify(r)}`)
+}
+function w$(t) {
+	const r = t._meta?.ui?.visibility
+	return r ? r.length === 1 && r[0] === "model" : !1
+}
+function I$(t) {
+	const r = t._meta?.ui?.visibility
+	return r ? r.length === 1 && r[0] === "app" : !1
+}
+function j$(t) {
+	if (!t) return ""
+	const r = []
+	return (
+		t.camera && r.push("camera"),
+		t.microphone && r.push("microphone"),
+		t.geolocation && r.push("geolocation"),
+		t.clipboardWrite && r.push("clipboard-write"),
+		r.join("; ")
+	)
+}
+var Tf = [Cu],
+	Au = class extends Wt {
+		_client
+		_hostInfo
+		_capabilities
+		_appCapabilities
+		_hostContext = {}
+		_appInfo
+		constructor(r, n, i, e) {
+			super(e),
+				(this._client = r),
+				(this._hostInfo = n),
+				(this._capabilities = i),
+				(this._hostContext = e?.hostContext || {}),
+				this.setRequestHandler(jf, (o) => this._oninitialize(o)),
+				this.setRequestHandler(Te, (o, a) => (this.onping?.(o.params, a), {})),
+				this.setRequestHandler(Ru, (o) => ({ mode: this._hostContext.displayMode ?? "inline" }))
+		}
+		getAppCapabilities() {
+			return this._appCapabilities
+		}
+		getAppVersion() {
+			return this._appInfo
+		}
+		onping
+		set onsizechange(r) {
+			this.setNotificationHandler(vf, (n) => r(n.params))
+		}
+		set onsandboxready(r) {
+			this.setNotificationHandler(hf, (n) => r(n.params))
+		}
+		set oninitialized(r) {
+			this.setNotificationHandler(zf, (n) => r(n.params))
+		}
+		set onmessage(r) {
+			this.setRequestHandler(wf, async (n, i) => r(n.params, i))
+		}
+		set onopenlink(r) {
+			this.setRequestHandler(gf, async (n, i) => r(n.params, i))
+		}
+		set ondownloadfile(r) {
+			this.setRequestHandler(Sf, async (n, i) => r(n.params, i))
+		}
+		set onrequestdisplaymode(r) {
+			this.setRequestHandler(Ru, async (n, i) => r(n.params, i))
+		}
+		set onloggingmessage(r) {
+			this.setNotificationHandler(_s, async (n) => {
+				r(n.params)
+			})
+		}
+		set onupdatemodelcontext(r) {
+			this.setRequestHandler(If, async (n, i) => r(n.params, i))
+		}
+		set oncalltool(r) {
+			this.setRequestHandler(cn, async (n, i) => r(n.params, i))
+		}
+		sendToolListChanged(r = {}) {
+			return this.notification({ method: "notifications/tools/list_changed", params: r })
+		}
+		set onlistresources(r) {
+			this.setRequestHandler(os, async (n, i) => r(n.params, i))
+		}
+		set onlistresourcetemplates(r) {
+			this.setRequestHandler(is, async (n, i) => r(n.params, i))
+		}
+		set onreadresource(r) {
+			this.setRequestHandler(cs, async (n, i) => r(n.params, i))
+		}
+		sendResourceListChanged(r = {}) {
+			return this.notification({ method: "notifications/resources/list_changed", params: r })
+		}
+		set onlistprompts(r) {
+			this.setRequestHandler(ls, async (n, i) => r(n.params, i))
+		}
+		sendPromptListChanged(r = {}) {
+			return this.notification({ method: "notifications/prompts/list_changed", params: r })
+		}
+		assertCapabilityForMethod(r) {}
+		assertRequestHandlerCapability(r) {}
+		assertNotificationCapability(r) {}
+		assertTaskCapability(r) {
+			throw Error("Tasks are not supported in MCP Apps")
+		}
+		assertTaskHandlerCapability(r) {
+			throw Error("Task handlers are not supported in MCP Apps")
+		}
+		getCapabilities() {
+			return this._capabilities
+		}
+		async _oninitialize(r) {
+			const n = r.params.protocolVersion
+			return (
+				(this._appCapabilities = r.params.appCapabilities),
+				(this._appInfo = r.params.appInfo),
+				{
+					protocolVersion: Tf.includes(n) ? n : Cu,
+					hostCapabilities: this.getCapabilities(),
+					hostInfo: this._hostInfo,
+					hostContext: this._hostContext,
+				}
+			)
+		}
+		setHostContext(r) {
+			let n = {},
+				i = !1
+			for (const e of Object.keys(r)) {
+				const o = this._hostContext[e],
+					a = r[e]
+				Of(o, a) || ((n[e] = a), (i = !0))
+			}
+			i && ((this._hostContext = r), this.sendHostContextChange(n))
+		}
+		sendHostContextChange(r) {
+			return this.notification({ method: "ui/notifications/host-context-changed", params: r })
+		}
+		sendToolInput(r) {
+			return this.notification({ method: "ui/notifications/tool-input", params: r })
+		}
+		sendToolInputPartial(r) {
+			return this.notification({ method: "ui/notifications/tool-input-partial", params: r })
+		}
+		sendToolResult(r) {
+			return this.notification({ method: "ui/notifications/tool-result", params: r })
+		}
+		sendToolCancelled(r) {
+			return this.notification({ method: "ui/notifications/tool-cancelled", params: r })
+		}
+		sendSandboxResourceReady(r) {
+			return this.notification({ method: "ui/notifications/sandbox-resource-ready", params: r })
+		}
+		teardownResource(r, n) {
+			return this.request({ method: "ui/resource-teardown", params: r }, yf, n)
+		}
+		sendResourceTeardown = this.teardownResource
+		async connect(r) {
+			if (this.transport) throw Error("AppBridge is already connected. Call close() before connecting again.")
+			if (this._client) {
+				const n = this._client.getServerCapabilities()
+				if (!n) throw Error("Client server capabilities not available")
+				n.tools &&
+					((this.oncalltool = async (i, e) =>
+						this._client.request({ method: "tools/call", params: i }, Oe, { signal: e.signal })),
+					n.tools.listChanged && this._client.setNotificationHandler(bs, (i) => this.sendToolListChanged(i.params))),
+					n.resources &&
+						((this.onlistresources = async (i, e) =>
+							this._client.request({ method: "resources/list", params: i }, on, { signal: e.signal })),
+						(this.onlistresourcetemplates = async (i, e) =>
+							this._client.request({ method: "resources/templates/list", params: i }, as, { signal: e.signal })),
+						(this.onreadresource = async (i, e) =>
+							this._client.request({ method: "resources/read", params: i }, an, { signal: e.signal })),
+						n.resources.listChanged &&
+							this._client.setNotificationHandler(us, (i) => this.sendResourceListChanged(i.params))),
+					n.prompts &&
+						((this.onlistprompts = async (i, e) =>
+							this._client.request({ method: "prompts/list", params: i }, ms, { signal: e.signal })),
+						n.prompts.listChanged &&
+							this._client.setNotificationHandler(vs, (i) => this.sendPromptListChanged(i.params)))
+			}
+			return super.connect(r)
+		}
+	}
+function Of(t, r) {
+	return JSON.stringify(t) === JSON.stringify(r)
+}
+export {
+	Au as AppBridge,
+	Hy as DOWNLOAD_FILE_METHOD,
+	Yy as HOST_CONTEXT_CHANGED_METHOD,
+	r$ as INITIALIZED_METHOD,
+	t$ as INITIALIZE_METHOD,
+	Cu as LATEST_PROTOCOL_VERSION,
+	Jy as MESSAGE_METHOD,
+	xf as McpUiAppCapabilitiesSchema,
+	Gt as McpUiDisplayModeSchema,
+	Sf as McpUiDownloadFileRequestSchema,
+	s$ as McpUiDownloadFileResultSchema,
+	$f as McpUiHostCapabilitiesSchema,
+	_$ as McpUiHostContextChangedNotificationSchema,
+	Lu as McpUiHostContextSchema,
+	bf as McpUiHostCssSchema,
+	_f as McpUiHostStylesSchema,
+	jf as McpUiInitializeRequestSchema,
+	y$ as McpUiInitializeResultSchema,
+	zf as McpUiInitializedNotificationSchema,
+	wf as McpUiMessageRequestSchema,
+	c$ as McpUiMessageResultSchema,
+	gf as McpUiOpenLinkRequestSchema,
+	a$ as McpUiOpenLinkResultSchema,
+	Ru as McpUiRequestDisplayModeRequestSchema,
+	f$ as McpUiRequestDisplayModeResultSchema,
+	xs as McpUiResourceCspSchema,
+	d$ as McpUiResourceMetaSchema,
+	zs as McpUiResourcePermissionsSchema,
+	p$ as McpUiResourceTeardownRequestSchema,
+	yf as McpUiResourceTeardownResultSchema,
+	hf as McpUiSandboxProxyReadyNotificationSchema,
+	v$ as McpUiSandboxResourceReadyNotificationSchema,
+	vf as McpUiSizeChangedNotificationSchema,
+	Du as McpUiSupportedContentBlockModalitiesSchema,
+	pf as McpUiThemeSchema,
+	m$ as McpUiToolCancelledNotificationSchema,
+	u$ as McpUiToolInputNotificationSchema,
+	l$ as McpUiToolInputPartialNotificationSchema,
+	g$ as McpUiToolMetaSchema,
+	b$ as McpUiToolResultNotificationSchema,
+	kf as McpUiToolVisibilitySchema,
+	If as McpUiUpdateModelContextRequestSchema,
+	Fy as OPEN_LINK_METHOD,
+	Eu as PostMessageTransport,
+	n$ as REQUEST_DISPLAY_MODE_METHOD,
+	k$ as RESOURCE_MIME_TYPE,
+	e$ as RESOURCE_TEARDOWN_METHOD,
+	Pf as RESOURCE_URI_META_KEY,
+	By as SANDBOX_PROXY_READY_METHOD,
+	Wy as SANDBOX_RESOURCE_READY_METHOD,
+	Gy as SIZE_CHANGED_METHOD,
+	Tf as SUPPORTED_PROTOCOL_VERSIONS,
+	Xy as TOOL_CANCELLED_METHOD,
+	Ky as TOOL_INPUT_METHOD,
+	mf as TOOL_INPUT_PARTIAL_METHOD,
+	Qy as TOOL_RESULT_METHOD,
+	j$ as buildAllowAttribute,
+	S$ as getToolUiResourceUri,
+	I$ as isToolVisibilityAppOnly,
+	w$ as isToolVisibilityModelOnly,
+}

--- a/src/extensions/mcp-adapter/commands.ts
+++ b/src/extensions/mcp-adapter/commands.ts
@@ -1,0 +1,228 @@
+import type { ExtensionAPI, ExtensionContext } from "@mariozechner/pi-coding-agent"
+import { getServerProvenance, writeDirectToolsConfig } from "./config.js"
+import { getFailureAgeSeconds, lazyConnect, updateMetadataCache, updateStatusBar } from "./init.js"
+import { authenticate, supportsOAuth } from "./mcp-auth-flow.js"
+import { hasStoredTokens } from "./mcp-auth.js"
+import { loadMetadataCache } from "./metadata-cache.js"
+import type { McpExtensionState } from "./state.js"
+import { buildToolMetadata } from "./tool-metadata.js"
+import type { McpConfig, McpPanelCallbacks, McpPanelResult, ServerEntry } from "./types.js"
+
+export async function showStatus(state: McpExtensionState, ctx: ExtensionContext): Promise<void> {
+	if (!ctx.hasUI) return
+
+	const lines: string[] = ["MCP Server Status:", ""]
+
+	for (const name of Object.keys(state.config.mcpServers)) {
+		const connection = state.manager.getConnection(name)
+		const metadata = state.toolMetadata.get(name)
+		const toolCount = metadata?.length ?? 0
+		const failedAgo = getFailureAgeSeconds(state, name)
+		let status = "not connected"
+		let statusIcon = "○"
+		let failed = false
+
+		if (connection?.status === "connected") {
+			status = "connected"
+			statusIcon = "✓"
+		} else if (connection?.status === "needs-auth") {
+			status = "needs auth"
+			statusIcon = "⚠"
+		} else if (failedAgo !== null) {
+			status = `failed ${failedAgo}s ago`
+			statusIcon = "✗"
+			failed = true
+		} else if (metadata !== undefined) {
+			status = "cached"
+		}
+
+		const toolSuffix = failed ? "" : ` (${toolCount} tools${status === "cached" ? ", cached" : ""})`
+		lines.push(`${statusIcon} ${name}: ${status}${toolSuffix}`)
+	}
+
+	if (Object.keys(state.config.mcpServers).length === 0) {
+		lines.push("No MCP servers configured")
+	}
+
+	ctx.ui.notify(lines.join("\n"), "info")
+}
+
+export async function showTools(state: McpExtensionState, ctx: ExtensionContext): Promise<void> {
+	if (!ctx.hasUI) return
+
+	const allTools = [...state.toolMetadata.values()].flat().map((m) => m.name)
+
+	if (allTools.length === 0) {
+		ctx.ui.notify("No MCP tools available", "info")
+		return
+	}
+
+	const lines = ["MCP Tools:", "", ...allTools.map((t) => `  ${t}`), "", `Total: ${allTools.length} tools`]
+
+	ctx.ui.notify(lines.join("\n"), "info")
+}
+
+export async function reconnectServers(
+	state: McpExtensionState,
+	ctx: ExtensionContext,
+	targetServer?: string,
+): Promise<void> {
+	if (targetServer && !state.config.mcpServers[targetServer]) {
+		if (ctx.hasUI) {
+			ctx.ui.notify(`Server "${targetServer}" not found in config`, "error")
+		}
+		return
+	}
+
+	const entries = targetServer
+		? [[targetServer, state.config.mcpServers[targetServer]] as [string, ServerEntry]]
+		: Object.entries(state.config.mcpServers)
+
+	for (const [name, definition] of entries) {
+		try {
+			await state.manager.close(name)
+
+			const connection = await state.manager.connect(name, definition)
+			if (connection.status === "needs-auth") {
+				if (ctx.hasUI) {
+					ctx.ui.notify(`MCP: ${name} requires OAuth. Run /mcp-auth ${name} first.`, "warning")
+				}
+				continue
+			}
+			const prefix = state.config.settings?.toolPrefix ?? "server"
+
+			const { metadata, failedTools } = buildToolMetadata(
+				connection.tools,
+				connection.resources,
+				definition,
+				name,
+				prefix,
+			)
+			state.toolMetadata.set(name, metadata)
+			updateMetadataCache(state, name)
+			state.failureTracker.delete(name)
+
+			if (ctx.hasUI) {
+				ctx.ui.notify(
+					`MCP: Reconnected to ${name} (${connection.tools.length} tools, ${connection.resources.length} resources)`,
+					"info",
+				)
+				if (failedTools.length > 0) {
+					ctx.ui.notify(`MCP: ${name} - ${failedTools.length} tools skipped`, "warning")
+				}
+			}
+		} catch (error) {
+			const message = error instanceof Error ? error.message : String(error)
+			state.failureTracker.set(name, Date.now())
+			if (ctx.hasUI) {
+				ctx.ui.notify(`MCP: Failed to reconnect to ${name}: ${message}`, "error")
+			}
+		}
+	}
+
+	updateStatusBar(state)
+}
+
+export async function authenticateServer(serverName: string, config: McpConfig, ctx: ExtensionContext): Promise<void> {
+	if (!ctx.hasUI) return
+
+	const definition = config.mcpServers[serverName]
+	if (!definition) {
+		ctx.ui.notify(`Server "${serverName}" not found in config`, "error")
+		return
+	}
+
+	if (!supportsOAuth(definition)) {
+		ctx.ui.notify(
+			`Server "${serverName}" does not use OAuth authentication.\n` +
+				`Set "auth": "oauth" or omit auth for auto-detection.`,
+			"error",
+		)
+		return
+	}
+
+	if (!definition.url) {
+		ctx.ui.notify(`Server "${serverName}" has no URL configured (OAuth requires HTTP transport)`, "error")
+		return
+	}
+
+	// Full automatic OAuth flow using SDK
+	try {
+		ctx.ui.setStatus("mcp-auth", `Authenticating ${serverName}...`)
+
+		// Runs the configured OAuth flow (interactive browser or non-interactive client_credentials)
+		const status = await authenticate(serverName, definition.url, definition)
+
+		if (status === "authenticated") {
+			ctx.ui.notify(
+				`OAuth authentication successful for "${serverName}"!\n` +
+					`Run /mcp reconnect ${serverName} to connect with the new token.`,
+				"info",
+			)
+		} else {
+			ctx.ui.notify(`OAuth authentication failed for "${serverName}".`, "error")
+		}
+	} catch (error) {
+		const message = error instanceof Error ? error.message : String(error)
+		ctx.ui.notify(`Failed to authenticate "${serverName}": ${message}`, "error")
+	} finally {
+		ctx.ui.setStatus("mcp-auth", undefined)
+	}
+}
+
+export async function openMcpPanel(
+	state: McpExtensionState,
+	pi: ExtensionAPI,
+	ctx: ExtensionContext,
+	configOverridePath?: string,
+): Promise<void> {
+	const config = state.config
+	const cache = loadMetadataCache()
+	const provenanceMap = getServerProvenance((pi.getFlag("mcp-config") as string | undefined) ?? configOverridePath)
+
+	const callbacks: McpPanelCallbacks = {
+		reconnect: async (serverName: string) => {
+			return lazyConnect(state, serverName)
+		},
+		getConnectionStatus: (serverName: string) => {
+			const definition = config.mcpServers[serverName]
+			const connection = state.manager.getConnection(serverName)
+			if (connection?.status === "needs-auth") {
+				return "needs-auth"
+			}
+			if (
+				definition?.auth === "oauth" &&
+				definition.oauth !== false &&
+				definition.oauth?.grantType !== "client_credentials" &&
+				!hasStoredTokens(serverName)
+			) {
+				return "needs-auth"
+			}
+			if (connection?.status === "connected") return "connected"
+			if (getFailureAgeSeconds(state, serverName) !== null) return "failed"
+			return "idle"
+		},
+		refreshCacheAfterReconnect: (serverName: string) => {
+			const freshCache = loadMetadataCache()
+			return freshCache?.servers?.[serverName] ?? null
+		},
+	}
+
+	const { createMcpPanel } = await import("./mcp-panel.js")
+
+	return new Promise<void>((resolve) => {
+		ctx.ui.custom(
+			(tui, _theme, _keybindings, done) => {
+				return createMcpPanel(config, cache, provenanceMap, callbacks, tui, (result: McpPanelResult) => {
+					if (!result.cancelled && result.changes.size > 0) {
+						writeDirectToolsConfig(result.changes, provenanceMap, config)
+						ctx.ui.notify("Direct tools updated. Restart pi to apply.", "info")
+					}
+					done(undefined)
+					resolve()
+				})
+			},
+			{ overlay: true, overlayOptions: { anchor: "center", width: 82 } },
+		)
+	})
+}

--- a/src/extensions/mcp-adapter/config.ts
+++ b/src/extensions/mcp-adapter/config.ts
@@ -5,7 +5,10 @@ import { dirname, join, resolve } from "node:path"
 import type { ImportKind, McpConfig, McpSettings, ServerEntry, ServerProvenance } from "./types.js"
 import { getAgentDir } from "./utils.js"
 
-const DEFAULT_CONFIG_PATH = join(getAgentDir(), "mcp.json")
+let _defaultConfigPath: string | undefined
+function getDefaultConfigPath(): string {
+	return (_defaultConfigPath ??= join(getAgentDir(), "mcp.json"))
+}
 const PROJECT_CONFIG_NAME = ".kimchi/mcp.json"
 
 // Import source paths for other tools
@@ -19,7 +22,7 @@ const IMPORT_PATHS: Record<ImportKind, string> = {
 }
 
 export function loadMcpConfig(overridePath?: string): McpConfig {
-	const configPath = overridePath ? resolve(overridePath) : DEFAULT_CONFIG_PATH
+	const configPath = overridePath ? resolve(overridePath) : getDefaultConfigPath()
 
 	// Load base config
 	let config: McpConfig = { mcpServers: {} }
@@ -129,7 +132,7 @@ function extractServers(config: unknown, kind: ImportKind): Record<string, Serve
 
 export function getServerProvenance(overridePath?: string): Map<string, ServerProvenance> {
 	const provenance = new Map<string, ServerProvenance>()
-	const userPath = overridePath ? resolve(overridePath) : DEFAULT_CONFIG_PATH
+	const userPath = overridePath ? resolve(overridePath) : getDefaultConfigPath()
 
 	let userConfig: McpConfig = { mcpServers: {} }
 	if (existsSync(userPath)) {

--- a/src/extensions/mcp-adapter/config.ts
+++ b/src/extensions/mcp-adapter/config.ts
@@ -1,0 +1,222 @@
+// config.ts - Config loading with import support
+import { existsSync, mkdirSync, readFileSync, renameSync, writeFileSync } from "node:fs"
+import { homedir } from "node:os"
+import { dirname, join, resolve } from "node:path"
+import type { ImportKind, McpConfig, McpSettings, ServerEntry, ServerProvenance } from "./types.js"
+
+const DEFAULT_CONFIG_PATH = join(homedir(), ".pi", "agent", "mcp.json")
+const PROJECT_CONFIG_NAME = ".pi/mcp.json"
+
+// Import source paths for other tools
+const IMPORT_PATHS: Record<ImportKind, string> = {
+	cursor: join(homedir(), ".cursor", "mcp.json"),
+	"claude-code": join(homedir(), ".claude", "claude_desktop_config.json"),
+	"claude-desktop": join(homedir(), "Library", "Application Support", "Claude", "claude_desktop_config.json"),
+	codex: join(homedir(), ".codex", "config.json"),
+	windsurf: join(homedir(), ".windsurf", "mcp.json"),
+	vscode: ".vscode/mcp.json", // Relative to project
+}
+
+export function loadMcpConfig(overridePath?: string): McpConfig {
+	const configPath = overridePath ? resolve(overridePath) : DEFAULT_CONFIG_PATH
+
+	// Load base config
+	let config: McpConfig = { mcpServers: {} }
+
+	if (existsSync(configPath)) {
+		try {
+			const raw = JSON.parse(readFileSync(configPath, "utf-8"))
+			config = validateConfig(raw)
+		} catch (error) {
+			console.warn(`Failed to load MCP config from ${configPath}:`, error)
+		}
+	}
+
+	// Process imports from other tools
+	if (config.imports?.length) {
+		for (const importKind of config.imports) {
+			const importPath = IMPORT_PATHS[importKind]
+			if (!importPath) continue
+
+			const fullPath = importPath.startsWith(".") ? resolve(process.cwd(), importPath) : importPath
+
+			if (!existsSync(fullPath)) continue
+
+			try {
+				const imported = JSON.parse(readFileSync(fullPath, "utf-8"))
+				const servers = extractServers(imported, importKind)
+
+				// Merge - local config takes precedence over imports
+				for (const [name, def] of Object.entries(servers)) {
+					if (!config.mcpServers[name]) {
+						config.mcpServers[name] = def
+					}
+				}
+			} catch (error) {
+				console.warn(`Failed to import MCP config from ${importKind}:`, error)
+			}
+		}
+	}
+
+	// Check for project-local config (skip if it's the same as the main config)
+	const projectPath = resolve(process.cwd(), PROJECT_CONFIG_NAME)
+	if (existsSync(projectPath) && projectPath !== configPath) {
+		try {
+			const projectConfig = JSON.parse(readFileSync(projectPath, "utf-8"))
+			const validated = validateConfig(projectConfig)
+
+			// Project config overrides everything
+			config.mcpServers = { ...config.mcpServers, ...validated.mcpServers }
+			if (validated.settings) {
+				config.settings = { ...config.settings, ...validated.settings }
+			}
+		} catch (error) {
+			console.warn(`Failed to load project MCP config:`, error)
+		}
+	}
+
+	return config
+}
+
+function validateConfig(raw: unknown): McpConfig {
+	if (!raw || typeof raw !== "object") {
+		return { mcpServers: {} }
+	}
+
+	const obj = raw as Record<string, unknown>
+	const servers = obj.mcpServers ?? obj["mcp-servers"] ?? {}
+
+	// Must be a plain object, not an array or null
+	if (typeof servers !== "object" || servers === null || Array.isArray(servers)) {
+		return { mcpServers: {} }
+	}
+
+	return {
+		mcpServers: servers as Record<string, ServerEntry>,
+		imports: Array.isArray(obj.imports) ? (obj.imports as ImportKind[]) : undefined,
+		settings: obj.settings as McpSettings | undefined,
+	}
+}
+
+function extractServers(config: unknown, kind: ImportKind): Record<string, ServerEntry> {
+	if (!config || typeof config !== "object") return {}
+
+	const obj = config as Record<string, unknown>
+
+	let servers: unknown
+	switch (kind) {
+		case "claude-desktop":
+		case "claude-code":
+		case "codex":
+			servers = obj.mcpServers
+			break
+		case "cursor":
+		case "windsurf":
+		case "vscode":
+			servers = obj.mcpServers ?? obj["mcp-servers"]
+			break
+		default:
+			return {}
+	}
+
+	if (!servers || typeof servers !== "object" || Array.isArray(servers)) {
+		return {}
+	}
+
+	return servers as Record<string, ServerEntry>
+}
+
+export function getServerProvenance(overridePath?: string): Map<string, ServerProvenance> {
+	const provenance = new Map<string, ServerProvenance>()
+	const userPath = overridePath ? resolve(overridePath) : DEFAULT_CONFIG_PATH
+
+	let userConfig: McpConfig = { mcpServers: {} }
+	if (existsSync(userPath)) {
+		try {
+			userConfig = validateConfig(JSON.parse(readFileSync(userPath, "utf-8")))
+		} catch {}
+	}
+	for (const name of Object.keys(userConfig.mcpServers)) {
+		provenance.set(name, { path: userPath, kind: "user" })
+	}
+
+	if (userConfig.imports?.length) {
+		for (const importKind of userConfig.imports) {
+			const importPath = IMPORT_PATHS[importKind]
+			if (!importPath) continue
+			const fullPath = importPath.startsWith(".") ? resolve(process.cwd(), importPath) : importPath
+			if (!existsSync(fullPath)) continue
+			try {
+				const imported = JSON.parse(readFileSync(fullPath, "utf-8"))
+				const servers = extractServers(imported, importKind)
+				for (const name of Object.keys(servers)) {
+					if (!provenance.has(name)) {
+						provenance.set(name, { path: userPath, kind: "import", importKind })
+					}
+				}
+			} catch {}
+		}
+	}
+
+	const projectPath = resolve(process.cwd(), PROJECT_CONFIG_NAME)
+	if (existsSync(projectPath) && projectPath !== userPath) {
+		try {
+			const projectConfig = validateConfig(JSON.parse(readFileSync(projectPath, "utf-8")))
+			for (const name of Object.keys(projectConfig.mcpServers)) {
+				provenance.set(name, { path: projectPath, kind: "project" })
+			}
+		} catch {}
+	}
+
+	return provenance
+}
+
+export function writeDirectToolsConfig(
+	changes: Map<string, true | string[] | false>,
+	provenance: Map<string, ServerProvenance>,
+	fullConfig: McpConfig,
+): void {
+	const byPath = new Map<string, { name: string; value: true | string[] | false; prov: ServerProvenance }[]>()
+
+	for (const [serverName, value] of changes) {
+		const prov = provenance.get(serverName)
+		if (!prov) continue
+
+		const targetPath = prov.path
+
+		if (!byPath.has(targetPath)) byPath.set(targetPath, [])
+		byPath.get(targetPath)!.push({ name: serverName, value, prov })
+	}
+
+	for (const [filePath, entries] of byPath) {
+		let raw: Record<string, unknown> = {}
+		if (existsSync(filePath)) {
+			try {
+				raw = JSON.parse(readFileSync(filePath, "utf-8"))
+			} catch {}
+		}
+		if (!raw || typeof raw !== "object") raw = {}
+
+		const servers = (raw.mcpServers ?? raw["mcp-servers"] ?? {}) as Record<string, ServerEntry>
+		if (typeof servers !== "object" || Array.isArray(servers)) continue
+
+		for (const { name, value, prov } of entries) {
+			if (prov.kind === "import") {
+				const fullDef = fullConfig.mcpServers[name]
+				if (fullDef) {
+					servers[name] = { ...fullDef, directTools: value }
+				}
+			} else if (servers[name]) {
+				servers[name] = { ...servers[name], directTools: value }
+			}
+		}
+
+		const key = raw["mcp-servers"] && !raw.mcpServers ? "mcp-servers" : "mcpServers"
+		raw[key] = servers
+
+		mkdirSync(dirname(filePath), { recursive: true })
+		const tmpPath = `${filePath}.${process.pid}.tmp`
+		writeFileSync(tmpPath, JSON.stringify(raw, null, 2) + "\n", "utf-8")
+		renameSync(tmpPath, filePath)
+	}
+}

--- a/src/extensions/mcp-adapter/config.ts
+++ b/src/extensions/mcp-adapter/config.ts
@@ -3,9 +3,10 @@ import { existsSync, mkdirSync, readFileSync, renameSync, writeFileSync } from "
 import { homedir } from "node:os"
 import { dirname, join, resolve } from "node:path"
 import type { ImportKind, McpConfig, McpSettings, ServerEntry, ServerProvenance } from "./types.js"
+import { getAgentDir } from "./utils.js"
 
-const DEFAULT_CONFIG_PATH = join(homedir(), ".pi", "agent", "mcp.json")
-const PROJECT_CONFIG_NAME = ".pi/mcp.json"
+const DEFAULT_CONFIG_PATH = join(getAgentDir(), "mcp.json")
+const PROJECT_CONFIG_NAME = ".kimchi/mcp.json"
 
 // Import source paths for other tools
 const IMPORT_PATHS: Record<ImportKind, string> = {

--- a/src/extensions/mcp-adapter/consent-manager.ts
+++ b/src/extensions/mcp-adapter/consent-manager.ts
@@ -1,0 +1,64 @@
+import { ConsentError } from "./errors.js"
+import { logger } from "./logger.js"
+
+export type ToolConsentMode = "never" | "once-per-server" | "always"
+
+export class ConsentManager {
+	private approvedServers = new Set<string>()
+	private deniedServers = new Set<string>()
+	private log = logger.child({ component: "ConsentManager" })
+
+	constructor(private mode: ToolConsentMode = "once-per-server") {
+		this.log.debug("Initialized", { mode })
+	}
+
+	requiresPrompt(serverName: string): boolean {
+		if (this.mode === "never") return false
+		if (this.deniedServers.has(serverName)) return true
+		if (this.mode === "always") return true
+		return !this.approvedServers.has(serverName)
+	}
+
+	shouldCacheConsent(): boolean {
+		return this.mode !== "always"
+	}
+
+	registerDecision(serverName: string, approved: boolean): void {
+		this.deniedServers.delete(serverName)
+		this.approvedServers.delete(serverName)
+
+		if (approved) {
+			this.approvedServers.add(serverName)
+			this.log.debug("Consent granted", { server: serverName })
+			return
+		}
+
+		this.deniedServers.add(serverName)
+		this.log.debug("Consent denied", { server: serverName })
+	}
+
+	ensureApproved(serverName: string): void {
+		if (this.mode === "never") return
+		if (this.deniedServers.has(serverName)) {
+			throw new ConsentError(serverName, { denied: true })
+		}
+		if (!this.approvedServers.has(serverName)) {
+			throw new ConsentError(serverName, { requiresApproval: true })
+		}
+		if (this.mode === "always") {
+			this.approvedServers.delete(serverName)
+		}
+	}
+
+	clear(serverName?: string): void {
+		if (serverName) {
+			this.approvedServers.delete(serverName)
+			this.deniedServers.delete(serverName)
+			this.log.debug("Cleared consent for server", { server: serverName })
+			return
+		}
+		this.approvedServers.clear()
+		this.deniedServers.clear()
+		this.log.debug("Cleared all consent records")
+	}
+}

--- a/src/extensions/mcp-adapter/direct-tools.ts
+++ b/src/extensions/mcp-adapter/direct-tools.ts
@@ -1,0 +1,407 @@
+import type { ToolDefinition } from "@mariozechner/pi-coding-agent"
+import { getFailureAgeSeconds, lazyConnect } from "./init.js"
+import { authenticate, supportsOAuth } from "./mcp-auth-flow.js"
+import type { MetadataCache } from "./metadata-cache.js"
+import { isServerCacheValid } from "./metadata-cache.js"
+import { resourceNameToToolName } from "./resource-tools.js"
+import type { McpExtensionState } from "./state.js"
+import { formatSchema } from "./tool-metadata.js"
+import { transformMcpContent } from "./tool-registrar.js"
+import type { DirectToolSpec, McpConfig, McpContent } from "./types.js"
+import { formatToolName, isToolExcluded } from "./types.js"
+import { type UiSessionRuntime, maybeStartUiSession } from "./ui-session.js"
+
+const BUILTIN_NAMES = new Set(["read", "bash", "edit", "write", "grep", "find", "ls", "mcp"])
+
+type DirectAutoAuthResult = { status: "skipped" } | { status: "success" } | { status: "failed"; message: string }
+
+async function attemptDirectAutoAuth(state: McpExtensionState, serverName: string): Promise<DirectAutoAuthResult> {
+	if (state.config.settings?.autoAuth !== true) {
+		return { status: "skipped" }
+	}
+
+	const definition = state.config.mcpServers[serverName]
+	if (!definition || !supportsOAuth(definition) || !definition.url) {
+		return { status: "skipped" }
+	}
+
+	const grantType =
+		(definition.oauth && typeof definition.oauth === "object" && definition.oauth.grantType) || "authorization_code"
+	if (!state.ui && grantType !== "client_credentials") {
+		return {
+			status: "failed",
+			message: `MCP server "${serverName}" requires OAuth authentication. Run /mcp-auth ${serverName} in an interactive session.`,
+		}
+	}
+
+	try {
+		await authenticate(serverName, definition.url, definition)
+		return { status: "success" }
+	} catch (error) {
+		const message = error instanceof Error ? error.message : String(error)
+		return {
+			status: "failed",
+			message: `OAuth authentication failed for "${serverName}": ${message}. Run /mcp-auth ${serverName} first.`,
+		}
+	}
+}
+
+export function resolveDirectTools(
+	config: McpConfig,
+	cache: MetadataCache | null,
+	prefix: "server" | "none" | "short",
+	envOverride?: string[],
+): DirectToolSpec[] {
+	const specs: DirectToolSpec[] = []
+	if (!cache) return specs
+
+	const seenNames = new Set<string>()
+
+	const envServers = new Set<string>()
+	const envTools = new Map<string, Set<string>>()
+	if (envOverride) {
+		for (let item of envOverride) {
+			item = item.replace(/\/+$/, "")
+			if (item.includes("/")) {
+				const [server, tool] = item.split("/", 2)
+				if (server && tool) {
+					if (!envTools.has(server)) envTools.set(server, new Set())
+					envTools.get(server)!.add(tool)
+				} else if (server) {
+					envServers.add(server)
+				}
+			} else if (item) {
+				envServers.add(item)
+			}
+		}
+	}
+
+	const globalDirect = config.settings?.directTools
+
+	for (const [serverName, definition] of Object.entries(config.mcpServers)) {
+		const serverCache = cache.servers[serverName]
+		if (!serverCache || !isServerCacheValid(serverCache, definition)) continue
+
+		let toolFilter: true | string[] | false = false
+
+		if (envOverride) {
+			if (envServers.has(serverName)) {
+				toolFilter = true
+			} else if (envTools.has(serverName)) {
+				toolFilter = [...envTools.get(serverName)!]
+			}
+		} else {
+			if (definition.directTools !== undefined) {
+				toolFilter = definition.directTools
+			} else if (globalDirect) {
+				toolFilter = globalDirect
+			}
+		}
+
+		if (!toolFilter) continue
+
+		for (const tool of serverCache.tools ?? []) {
+			if (toolFilter !== true && !toolFilter.includes(tool.name)) continue
+			if (isToolExcluded(tool.name, serverName, prefix, definition.excludeTools)) continue
+			const prefixedName = formatToolName(tool.name, serverName, prefix)
+			if (BUILTIN_NAMES.has(prefixedName)) {
+				console.warn(`MCP: skipping direct tool "${prefixedName}" (collides with builtin)`)
+				continue
+			}
+			if (seenNames.has(prefixedName)) {
+				console.warn(`MCP: skipping duplicate direct tool "${prefixedName}" from "${serverName}"`)
+				continue
+			}
+			seenNames.add(prefixedName)
+			specs.push({
+				serverName,
+				originalName: tool.name,
+				prefixedName,
+				description: tool.description ?? "",
+				inputSchema: tool.inputSchema,
+				uiResourceUri: tool.uiResourceUri,
+				uiStreamMode: tool.uiStreamMode,
+			})
+		}
+
+		if (definition.exposeResources !== false) {
+			for (const resource of serverCache.resources ?? []) {
+				const baseName = `get_${resourceNameToToolName(resource.name)}`
+				if (toolFilter !== true && !toolFilter.includes(baseName)) continue
+				if (isToolExcluded(baseName, serverName, prefix, definition.excludeTools)) continue
+				const prefixedName = formatToolName(baseName, serverName, prefix)
+				if (BUILTIN_NAMES.has(prefixedName)) {
+					console.warn(`MCP: skipping direct resource tool "${prefixedName}" (collides with builtin)`)
+					continue
+				}
+				if (seenNames.has(prefixedName)) {
+					console.warn(`MCP: skipping duplicate direct resource tool "${prefixedName}" from "${serverName}"`)
+					continue
+				}
+				seenNames.add(prefixedName)
+				specs.push({
+					serverName,
+					originalName: baseName,
+					prefixedName,
+					description: resource.description ?? `Read resource: ${resource.uri}`,
+					resourceUri: resource.uri,
+				})
+			}
+		}
+	}
+
+	return specs
+}
+
+export function getMissingConfiguredDirectToolServers(config: McpConfig, cache: MetadataCache | null): string[] {
+	const missing: string[] = []
+	const globalDirect = config.settings?.directTools
+
+	for (const [serverName, definition] of Object.entries(config.mcpServers)) {
+		const hasDirectTools = definition.directTools !== undefined ? !!definition.directTools : !!globalDirect
+
+		if (!hasDirectTools) continue
+
+		const serverCache = cache?.servers?.[serverName]
+		if (!serverCache || !isServerCacheValid(serverCache, definition)) {
+			missing.push(serverName)
+		}
+	}
+
+	return missing
+}
+
+export function buildProxyDescription(
+	config: McpConfig,
+	cache: MetadataCache | null,
+	directSpecs: DirectToolSpec[],
+): string {
+	const prefix = config.settings?.toolPrefix ?? "server"
+	let desc = `MCP gateway - connect to MCP servers and call their tools.\n`
+
+	const directByServer = new Map<string, number>()
+	for (const spec of directSpecs) {
+		directByServer.set(spec.serverName, (directByServer.get(spec.serverName) ?? 0) + 1)
+	}
+	if (directByServer.size > 0) {
+		const parts = [...directByServer.entries()].map(([server, count]) => `${server} (${count})`)
+		desc += `\nDirect tools available (call as normal tools): ${parts.join(", ")}\n`
+	}
+
+	const serverSummaries: string[] = []
+	for (const serverName of Object.keys(config.mcpServers)) {
+		const entry = cache?.servers?.[serverName]
+		const definition = config.mcpServers[serverName]
+		const toolCount = (entry?.tools ?? []).filter(
+			(tool) => !isToolExcluded(tool.name, serverName, prefix, definition.excludeTools),
+		).length
+		const resourceCount =
+			definition?.exposeResources !== false
+				? (entry?.resources ?? []).filter((resource) => {
+						const baseName = `get_${resourceNameToToolName(resource.name)}`
+						return !isToolExcluded(baseName, serverName, prefix, definition.excludeTools)
+					}).length
+				: 0
+		const totalItems = toolCount + resourceCount
+		if (totalItems === 0) continue
+		const directCount = directByServer.get(serverName) ?? 0
+		const proxyCount = totalItems - directCount
+		if (proxyCount > 0) {
+			serverSummaries.push(`${serverName} (${proxyCount} tools)`)
+		}
+	}
+
+	if (serverSummaries.length > 0) {
+		desc += `\nServers: ${serverSummaries.join(", ")}\n`
+	}
+
+	desc += `\nUsage:\n`
+	desc += `  mcp({ })                              → Show server status\n`
+	desc += `  mcp({ server: "name" })               → List tools from server\n`
+	desc += `  mcp({ search: "query" })              → Search for tools (MCP + pi, space-separated words OR'd)\n`
+	desc += `  mcp({ describe: "tool_name" })        → Show tool details and parameters\n`
+	desc += `  mcp({ connect: "server-name" })       → Connect to a server and refresh metadata\n`
+	desc += `  mcp({ tool: "name", args: '{"key": "value"}' })    → Call a tool (args is JSON string)\n`
+	desc += `  mcp({ action: "ui-messages" })        → Retrieve accumulated messages from completed UI sessions\n`
+	desc += `\nMode: tool (call) > connect > describe > search > server (list) > action > nothing (status)`
+
+	return desc
+}
+
+type DirectToolExecute = ToolDefinition["execute"]
+
+export function createDirectToolExecutor(
+	getState: () => McpExtensionState | null,
+	getInitPromise: () => Promise<McpExtensionState> | null,
+	spec: DirectToolSpec,
+): DirectToolExecute {
+	return async function execute(_toolCallId, params) {
+		let state = getState()
+		const initPromise = getInitPromise()
+
+		if (!state && initPromise) {
+			try {
+				state = await initPromise
+			} catch (error) {
+				const message = error instanceof Error ? error.message : String(error)
+				return {
+					content: [{ type: "text" as const, text: `MCP initialization failed: ${message}` }],
+					details: { error: "init_failed", message },
+				}
+			}
+		}
+		if (!state) {
+			return {
+				content: [{ type: "text" as const, text: "MCP not initialized" }],
+				details: { error: "not_initialized" },
+			}
+		}
+
+		let connected = await lazyConnect(state, spec.serverName)
+		let autoAuthAttempted = false
+
+		if (!connected && state.manager.getConnection(spec.serverName)?.status === "needs-auth") {
+			autoAuthAttempted = true
+			const autoAuth = await attemptDirectAutoAuth(state, spec.serverName)
+			if (autoAuth.status === "failed") {
+				return {
+					content: [{ type: "text" as const, text: autoAuth.message }],
+					details: { error: "auth_required", server: spec.serverName, message: autoAuth.message },
+				}
+			}
+			if (autoAuth.status === "success") {
+				await state.manager.close(spec.serverName)
+				state.failureTracker.delete(spec.serverName)
+				connected = await lazyConnect(state, spec.serverName)
+			}
+		}
+
+		if (!connected) {
+			const authConnection = state.manager.getConnection(spec.serverName)
+			if (authConnection?.status === "needs-auth") {
+				const message = `MCP server "${spec.serverName}" requires OAuth authentication. Run /mcp-auth ${spec.serverName} first.`
+				return {
+					content: [{ type: "text" as const, text: message }],
+					details: { error: "auth_required", server: spec.serverName, message, autoAuthAttempted },
+				}
+			}
+			const failedAgo = getFailureAgeSeconds(state, spec.serverName)
+			return {
+				content: [
+					{
+						type: "text" as const,
+						text: `MCP server "${spec.serverName}" not available${failedAgo !== null ? ` (failed ${failedAgo}s ago)` : ""}`,
+					},
+				],
+				details: { error: "server_unavailable", server: spec.serverName },
+			}
+		}
+
+		const connection = state.manager.getConnection(spec.serverName)
+		if (!connection || connection.status !== "connected") {
+			return {
+				content: [{ type: "text" as const, text: `MCP server "${spec.serverName}" not connected` }],
+				details: { error: "not_connected", server: spec.serverName },
+			}
+		}
+
+		let uiSession: UiSessionRuntime | null = null
+
+		try {
+			state.manager.touch(spec.serverName)
+			state.manager.incrementInFlight(spec.serverName)
+
+			if (spec.resourceUri) {
+				const result = await connection.client.readResource({ uri: spec.resourceUri })
+				const content = (result.contents ?? []).map((c) => ({
+					type: "text" as const,
+					text:
+						"text" in c
+							? c.text
+							: "blob" in c
+								? `[Binary data: ${(c as { mimeType?: string }).mimeType ?? "unknown"}]`
+								: JSON.stringify(c),
+				}))
+				return {
+					content: content.length > 0 ? content : [{ type: "text" as const, text: "(empty resource)" }],
+					details: { server: spec.serverName, resourceUri: spec.resourceUri },
+				}
+			}
+
+			const hasUi = !!spec.uiResourceUri
+			uiSession = hasUi
+				? await maybeStartUiSession(state, {
+						serverName: spec.serverName,
+						toolName: spec.originalName,
+						toolArgs: (params ?? {}) as Record<string, unknown>,
+						uiResourceUri: spec.uiResourceUri!,
+						streamMode: spec.uiStreamMode,
+					})
+				: null
+
+			const resultPromise = connection.client.callTool({
+				name: spec.originalName,
+				arguments: (params ?? {}) as Record<string, unknown>,
+				_meta: uiSession?.requestMeta,
+			})
+
+			const result = await resultPromise
+			uiSession?.sendToolResult(result as unknown as import("@modelcontextprotocol/sdk/types.js").CallToolResult)
+
+			const mcpContent = (result.content ?? []) as McpContent[]
+			const content = transformMcpContent(mcpContent)
+
+			if (result.isError) {
+				let errorText =
+					content
+						.filter((c) => c.type === "text")
+						.map((c) => (c as { text: string }).text)
+						.join("\n") || "Tool execution failed"
+				if (spec.inputSchema) {
+					errorText += `\n\nExpected parameters:\n${formatSchema(spec.inputSchema)}`
+				}
+				return {
+					content: [{ type: "text" as const, text: `Error: ${errorText}` }],
+					details: { error: "tool_error", server: spec.serverName },
+				}
+			}
+
+			const resultText =
+				content
+					.filter((c) => c.type === "text")
+					.map((c) => (c as { text: string }).text)
+					.join("\n") || "(empty result)"
+			if (hasUi) {
+				const uiMessage = uiSession?.reused
+					? "Updated the open UI."
+					: "📺 Interactive UI is now open in your browser. I'll respond to your prompts and intents as you interact with it."
+				return {
+					content: [{ type: "text" as const, text: `${resultText}\n\n${uiMessage}` }],
+					details: { server: spec.serverName, tool: spec.originalName, uiOpen: true },
+				}
+			}
+
+			return {
+				content: content.length > 0 ? content : [{ type: "text" as const, text: "(empty result)" }],
+				details: { server: spec.serverName, tool: spec.originalName },
+			}
+		} catch (error) {
+			const message = error instanceof Error ? error.message : String(error)
+			uiSession?.sendToolCancelled(message)
+			let errorText = `Failed to call tool: ${message}`
+			if (spec.inputSchema) {
+				errorText += `\n\nExpected parameters:\n${formatSchema(spec.inputSchema)}`
+			}
+			return {
+				content: [{ type: "text" as const, text: errorText }],
+				details: { error: "call_failed", server: spec.serverName },
+			}
+		} finally {
+			if (uiSession?.reused) {
+				uiSession.close()
+			}
+			state.manager.decrementInFlight(spec.serverName)
+			state.manager.touch(spec.serverName)
+		}
+	}
+}

--- a/src/extensions/mcp-adapter/errors.ts
+++ b/src/extensions/mcp-adapter/errors.ts
@@ -1,0 +1,198 @@
+/**
+ * Custom error types for MCP UI operations.
+ * Provides structured errors with context and recovery hints.
+ */
+
+export interface McpUiErrorContext {
+	server?: string
+	tool?: string
+	uri?: string
+	session?: string
+	[key: string]: unknown
+}
+
+/**
+ * Base error class for MCP UI errors.
+ */
+export class McpUiError extends Error {
+	readonly code: string
+	readonly context: McpUiErrorContext
+	readonly recoveryHint?: string
+	readonly cause?: Error
+
+	constructor(
+		message: string,
+		options: {
+			code: string
+			context?: McpUiErrorContext
+			recoveryHint?: string
+			cause?: Error
+		},
+	) {
+		super(message)
+		this.name = "McpUiError"
+		this.code = options.code
+		this.context = options.context ?? {}
+		this.recoveryHint = options.recoveryHint
+		this.cause = options.cause
+
+		// Maintain proper stack trace
+		if (Error.captureStackTrace) {
+			Error.captureStackTrace(this, this.constructor)
+		}
+	}
+
+	toJSON(): Record<string, unknown> {
+		return {
+			name: this.name,
+			code: this.code,
+			message: this.message,
+			context: this.context,
+			recoveryHint: this.recoveryHint,
+			stack: this.stack,
+		}
+	}
+}
+
+/**
+ * Error fetching a UI resource from the MCP server.
+ */
+export class ResourceFetchError extends McpUiError {
+	constructor(uri: string, reason: string, options?: { server?: string; cause?: Error }) {
+		super(`Failed to fetch UI resource "${uri}": ${reason}`, {
+			code: "RESOURCE_FETCH_ERROR",
+			context: { uri, server: options?.server },
+			recoveryHint: "Check that the MCP server is connected and the resource URI is valid.",
+			cause: options?.cause,
+		})
+		this.name = "ResourceFetchError"
+	}
+}
+
+/**
+ * Error parsing or validating UI resource content.
+ */
+export class ResourceParseError extends McpUiError {
+	constructor(uri: string, reason: string, options?: { server?: string; mimeType?: string }) {
+		super(`Invalid UI resource "${uri}": ${reason}`, {
+			code: "RESOURCE_PARSE_ERROR",
+			context: { uri, server: options?.server, mimeType: options?.mimeType },
+			recoveryHint: "Ensure the resource returns valid HTML with the correct MIME type.",
+		})
+		this.name = "ResourceParseError"
+	}
+}
+
+/**
+ * Error connecting to the AppBridge.
+ */
+export class BridgeConnectionError extends McpUiError {
+	constructor(reason: string, options?: { session?: string; cause?: Error }) {
+		super(`AppBridge connection failed: ${reason}`, {
+			code: "BRIDGE_CONNECTION_ERROR",
+			context: { session: options?.session },
+			recoveryHint: "Check browser console for detailed errors. The iframe may have failed to load.",
+			cause: options?.cause,
+		})
+		this.name = "BridgeConnectionError"
+	}
+}
+
+/**
+ * Error related to user consent for tool calls.
+ */
+export class ConsentError extends McpUiError {
+	readonly denied: boolean
+
+	constructor(server: string, options: { denied?: boolean; requiresApproval?: boolean }) {
+		const message = options.denied
+			? `Tool calls for "${server}" were denied for this session`
+			: `Tool call approval required for "${server}"`
+
+		super(message, {
+			code: options.denied ? "CONSENT_DENIED" : "CONSENT_REQUIRED",
+			context: { server },
+			recoveryHint: options.denied
+				? "The user denied tool access. Start a new session to try again."
+				: "Prompt the user for consent before calling tools.",
+		})
+		this.name = "ConsentError"
+		this.denied = options.denied ?? false
+	}
+}
+
+/**
+ * Error with UI server session management.
+ */
+export class SessionError extends McpUiError {
+	constructor(reason: string, options?: { session?: string; cause?: Error }) {
+		super(`Session error: ${reason}`, {
+			code: "SESSION_ERROR",
+			context: { session: options?.session },
+			recoveryHint: "The session may have expired or been closed. Try opening the UI again.",
+			cause: options?.cause,
+		})
+		this.name = "SessionError"
+	}
+}
+
+/**
+ * Error starting or operating the UI server.
+ */
+export class ServerError extends McpUiError {
+	constructor(reason: string, options?: { port?: number; cause?: Error }) {
+		super(`UI server error: ${reason}`, {
+			code: "SERVER_ERROR",
+			context: { port: options?.port },
+			recoveryHint: "Check if the port is available. Another process may be using it.",
+			cause: options?.cause,
+		})
+		this.name = "ServerError"
+	}
+}
+
+/**
+ * Error communicating with the MCP server.
+ */
+export class McpServerError extends McpUiError {
+	constructor(server: string, reason: string, options?: { tool?: string; cause?: Error }) {
+		super(`MCP server "${server}" error: ${reason}`, {
+			code: "MCP_SERVER_ERROR",
+			context: { server, tool: options?.tool },
+			recoveryHint: "Check that the MCP server is running and responsive.",
+			cause: options?.cause,
+		})
+		this.name = "McpServerError"
+	}
+}
+
+/**
+ * Wrap an unknown error into an McpUiError.
+ */
+export function wrapError(error: unknown, context?: McpUiErrorContext): McpUiError {
+	if (error instanceof McpUiError) {
+		// Merge contexts
+		return new McpUiError(error.message, {
+			code: error.code,
+			context: { ...error.context, ...context },
+			recoveryHint: error.recoveryHint,
+			cause: error.cause,
+		})
+	}
+
+	const cause = error instanceof Error ? error : undefined
+	const message = error instanceof Error ? error.message : String(error)
+
+	return new McpUiError(message, {
+		code: "UNKNOWN_ERROR",
+		context,
+		cause,
+	})
+}
+
+/**
+ * Check if an error is a specific MCP UI error type.
+ */
+export function isErrorCode(error: unknown, code: string): boolean {
+	return error instanceof McpUiError && error.code === code
+}

--- a/src/extensions/mcp-adapter/glimpse-ui.ts
+++ b/src/extensions/mcp-adapter/glimpse-ui.ts
@@ -1,0 +1,78 @@
+import { execFileSync } from "node:child_process"
+import { existsSync } from "node:fs"
+import { createRequire } from "node:module"
+import { platform } from "node:os"
+import { dirname, join } from "node:path"
+
+let glimpseAvailable: boolean | null = null
+let resolvedBinaryPath: string | null = null
+
+export function isGlimpseAvailable(): boolean {
+	if (glimpseAvailable !== null) return glimpseAvailable
+
+	if (platform() !== "darwin") {
+		glimpseAvailable = false
+		return false
+	}
+
+	resolvedBinaryPath = getGlimpseBinaryPath()
+	glimpseAvailable = resolvedBinaryPath !== null
+	return glimpseAvailable
+}
+
+function getGlimpseBinaryPath(): string | null {
+	if (process.env.GLIMPSE_BINARY && existsSync(process.env.GLIMPSE_BINARY)) {
+		return process.env.GLIMPSE_BINARY
+	}
+
+	// Local node_modules
+	try {
+		const require = createRequire(import.meta.url)
+		const glimpseuiPath = require.resolve("glimpseui")
+		const binaryPath = join(dirname(glimpseuiPath), "glimpse")
+		if (existsSync(binaryPath)) return binaryPath
+	} catch {}
+
+	// Global npm install
+	try {
+		const globalRoot = execFileSync("npm", ["root", "-g"], { encoding: "utf-8" }).trim()
+		const binaryPath = join(globalRoot, "glimpseui", "src", "glimpse")
+		if (existsSync(binaryPath)) return binaryPath
+	} catch {}
+
+	return null
+}
+
+export async function openGlimpseWindow(
+	html: string,
+	options: {
+		title: string
+		width?: number
+		height?: number
+		onClosed: () => void
+	},
+) {
+	const modulePath = resolvedBinaryPath ? join(dirname(resolvedBinaryPath), "glimpse.mjs") : "glimpseui"
+	const glimpse = await import(modulePath)
+
+	let active = true
+	const win = glimpse.open(html, {
+		width: options.width ?? 900,
+		height: options.height ?? 700,
+		title: options.title,
+	})
+
+	win.on("closed", () => {
+		if (!active) return
+		active = false
+		options.onClosed()
+	})
+
+	return {
+		close: () => {
+			if (!active) return
+			active = false
+			win.close()
+		},
+	}
+}

--- a/src/extensions/mcp-adapter/host-html-template.ts
+++ b/src/extensions/mcp-adapter/host-html-template.ts
@@ -1,0 +1,423 @@
+import type { UiHostContext, UiResourceContent, UiResourceCsp } from "./types.js"
+
+// Use locally bundled AppBridge to avoid CDN Zod bundling issues
+const DEFAULT_APP_BRIDGE_MODULE_URL = "/app-bridge.bundle.js"
+
+export interface HostHtmlTemplateInput {
+	sessionToken: string
+	serverName: string
+	toolName: string
+	toolArgs: Record<string, unknown>
+	resource: UiResourceContent
+	allowAttribute: string
+	requireToolConsent: boolean
+	cacheToolConsent: boolean
+	hostContext?: UiHostContext
+	appBridgeModuleUrl?: string
+}
+
+export function buildHostHtmlTemplate(input: HostHtmlTemplateInput): string {
+	const cspContent = buildCspMetaContent(input.resource.meta.csp)
+	const resourceHtml = applyCspMeta(input.resource.html, cspContent)
+	const hostContext = input.hostContext ?? {}
+
+	const sessionToken = safeInlineJSON(input.sessionToken)
+	const toolArgs = safeInlineJSON(input.toolArgs)
+	const uiHtml = safeInlineJSON(resourceHtml)
+	const serverName = safeInlineJSON(input.serverName)
+	const toolName = safeInlineJSON(input.toolName)
+	const hostContextJson = safeInlineJSON(hostContext)
+	const allowAttribute = safeInlineJSON(input.allowAttribute)
+	const requireToolConsent = safeInlineJSON(input.requireToolConsent)
+	const cacheToolConsent = safeInlineJSON(input.cacheToolConsent)
+	const moduleUrl = safeInlineJSON(input.appBridgeModuleUrl ?? DEFAULT_APP_BRIDGE_MODULE_URL)
+
+	return `<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>MCP UI - ${escapeHtml(input.serverName)} / ${escapeHtml(input.toolName)}</title>
+  <style>
+    :root {
+      color-scheme: light dark;
+      --bg: #0f1115;
+      --surface: #181c22;
+      --text: #ecf0f5;
+      --muted: #a9b2bf;
+      --accent: #43c0ff;
+      --border: rgba(255, 255, 255, 0.12);
+      --good: #34d399;
+      --warn: #fbbf24;
+      --bad: #f87171;
+    }
+    @media (prefers-color-scheme: light) {
+      :root {
+        --bg: #f6f7fb;
+        --surface: #ffffff;
+        --text: #1d2939;
+        --muted: #667085;
+        --accent: #0ea5e9;
+        --border: rgba(15, 23, 42, 0.14);
+        --good: #059669;
+        --warn: #b45309;
+        --bad: #b91c1c;
+      }
+    }
+    * { box-sizing: border-box; }
+    html, body { margin: 0; padding: 0; height: 100%; font-family: ui-sans-serif, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif; background: var(--bg); color: var(--text); }
+    body { display: flex; flex-direction: column; min-height: 100vh; }
+    header { background: var(--surface); border-bottom: 1px solid var(--border); padding: 10px 14px; display: flex; align-items: center; justify-content: space-between; gap: 10px; }
+    .title { display: flex; gap: 8px; align-items: baseline; min-width: 0; }
+    .server { font-size: 12px; color: var(--muted); text-transform: uppercase; letter-spacing: 0.08em; white-space: nowrap; }
+    .tool { font-size: 14px; font-weight: 600; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+    .badge { border: 1px solid var(--border); border-radius: 999px; padding: 2px 8px; font-size: 11px; color: var(--muted); white-space: nowrap; }
+    .controls { display: flex; gap: 8px; align-items: center; }
+    .status { font-size: 12px; color: var(--muted); white-space: nowrap; }
+    button { border: 1px solid var(--border); background: transparent; color: var(--text); border-radius: 8px; padding: 6px 10px; cursor: pointer; font-size: 12px; }
+    button.primary { border-color: color-mix(in srgb, var(--good) 40%, var(--border) 60%); color: var(--good); }
+    button.danger { border-color: color-mix(in srgb, var(--bad) 40%, var(--border) 60%); color: var(--bad); }
+    button:hover { background: color-mix(in srgb, var(--surface) 75%, var(--accent) 25%); }
+    main { flex: 1; min-height: 0; padding: 10px; display: flex; }
+    iframe { width: 100%; height: 100%; border: 1px solid var(--border); border-radius: 10px; background: white; }
+    .overlay { position: fixed; inset: 0; background: color-mix(in srgb, var(--bg) 90%, black 10%); display: none; align-items: center; justify-content: center; z-index: 2; }
+    .overlay.visible { display: flex; }
+    .panel { width: min(680px, calc(100vw - 40px)); background: var(--surface); border: 1px solid var(--border); border-radius: 12px; padding: 18px; }
+    .panel h2 { margin: 0 0 8px; font-size: 16px; }
+    .panel p { margin: 0; color: var(--muted); line-height: 1.4; font-size: 14px; white-space: pre-wrap; }
+  </style>
+</head>
+<body>
+  <header>
+    <div class="title">
+      <span class="server">MCP · <span id="server-name"></span></span>
+      <span class="tool" id="tool-name"></span>
+      <span class="badge">Sandboxed</span>
+    </div>
+    <div class="controls">
+      <span class="status" id="status">Loading UI...</span>
+      <button class="primary" id="done-btn" title="Cmd/Ctrl+Enter">Done</button>
+      <button class="danger" id="cancel-btn" title="Escape">Cancel</button>
+    </div>
+  </header>
+  <main>
+    <iframe id="mcp-app" referrerpolicy="no-referrer"></iframe>
+  </main>
+  <div class="overlay" id="error-overlay">
+    <div class="panel">
+      <h2>UI Error</h2>
+      <p id="error-message"></p>
+    </div>
+  </div>
+  <script type="module">
+    import { AppBridge, PostMessageTransport } from ${moduleUrl};
+
+    const SESSION_TOKEN = ${sessionToken};
+    const SERVER_NAME = ${serverName};
+    const TOOL_NAME = ${toolName};
+    const TOOL_ARGS = ${toolArgs};
+    const HOST_CONTEXT = ${hostContextJson};
+    const ALLOW_ATTRIBUTE = ${allowAttribute};
+    const REQUIRE_TOOL_CONSENT = ${requireToolConsent};
+    const CACHE_TOOL_CONSENT = ${cacheToolConsent};
+    const STREAM_CONTEXT_KEY = "pi-mcp-adapter/stream";
+    const STREAM_PATCH_METHOD = "notifications/pi-mcp-adapter/ui-result-patch";
+
+    const iframe = document.getElementById("mcp-app");
+    const statusNode = document.getElementById("status");
+    const doneBtn = document.getElementById("done-btn");
+    const cancelBtn = document.getElementById("cancel-btn");
+    const errorOverlay = document.getElementById("error-overlay");
+    const errorMessage = document.getElementById("error-message");
+
+    document.getElementById("server-name").textContent = SERVER_NAME;
+    document.getElementById("tool-name").textContent = TOOL_NAME;
+
+    const setStatus = (text, isError = false) => {
+      statusNode.textContent = text;
+      statusNode.style.color = isError ? "var(--bad)" : "var(--muted)";
+    };
+
+    const showError = (message) => {
+      errorMessage.textContent = message;
+      errorOverlay.classList.add("visible");
+      setStatus("Error", true);
+    };
+
+    const post = async (endpoint, params) => {
+      const response = await fetch(endpoint, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ token: SESSION_TOKEN, params }),
+      });
+
+      const body = await response.json().catch(() => ({ ok: false, error: "Invalid JSON response" }));
+      if (!response.ok || !body.ok) {
+        const message = body.error || ("HTTP " + response.status);
+        throw new Error(message);
+      }
+      return body.result ?? {};
+    };
+
+    let consentGranted = !REQUIRE_TOOL_CONSENT;
+    const initialStreamContext = HOST_CONTEXT?.[STREAM_CONTEXT_KEY];
+    const streamMode = initialStreamContext?.mode === "stream-first" ? "stream-first" : "eager";
+
+    const bridge = new AppBridge(
+      null,
+      { name: "pi", version: "1.0.0" },
+      { serverTools: {}, openLinks: {}, logging: {}, updateModelContext: {}, message: {} },
+      { hostContext: HOST_CONTEXT }
+    );
+
+    bridge.oncalltool = async (params) => {
+      if (!consentGranted) {
+        const accepted = window.confirm("Allow this UI to call server tools for this session?");
+        if (!accepted) {
+          await post("/proxy/ui/consent", { approved: false }).catch(() => {});
+          return {
+            isError: true,
+            content: [{ type: "text", text: "Tool call denied by user." }],
+          };
+        }
+        await post("/proxy/ui/consent", { approved: true });
+        if (CACHE_TOOL_CONSENT) {
+          consentGranted = true;
+        }
+      }
+      const result = await post("/proxy/tools/call", params);
+      // Notify agent about the tool call
+      await post("/proxy/ui/message", {
+        type: "intent",
+        intent: "call_tool",
+        params: { tool: params.name, arguments: params.arguments, isError: result.isError }
+      }).catch(() => {});
+      return result;
+    };
+
+    bridge.onmessage = async (params) => post("/proxy/ui/message", params);
+    bridge.onupdatemodelcontext = async (params) => post("/proxy/ui/context", params);
+    
+    // Also listen for raw postMessage events with custom types (notify, prompt, intent, etc.)
+    // These bypass the AppBridge protocol but are used by some MCP UI implementations
+    window.addEventListener("message", async (event) => {
+      const data = event.data;
+      if (!data || typeof data !== "object") return;
+      
+      // Skip AppBridge protocol messages (handled by bridge)
+      if (data.jsonrpc || (typeof data.method === "string" && (data.method.startsWith("app/") || data.method.startsWith("host/")))) return;
+      
+      // Handle raw UI action messages
+      const msgType = data.type;
+      if (typeof msgType !== "string") return;
+      
+      if (msgType === "notify" || msgType === "prompt" || msgType === "intent" || msgType === "message") {
+        // Standard MCP-UI types - preserve their semantics
+        // Support both { type, payload: {...} } and { type, field: value } formats
+        const { type: _, payload, ...directFields } = data;
+        await post("/proxy/ui/message", { type: msgType, ...directFields, ...(payload || {}) }).catch(() => {});
+      } else if (!msgType.startsWith("ui-lifecycle-") && !msgType.startsWith("ui-message-")) {
+        // Any other custom type - forward as intent with type as intent name
+        // (Skip internal lifecycle/ack messages)
+        const payload = data.payload || {};
+        await post("/proxy/ui/message", {
+          type: "intent",
+          intent: msgType,
+          params: payload,
+        }).catch(() => {});
+      }
+    });
+    bridge.ondownloadfile = async (params) => post("/proxy/ui/download-file", params);
+    bridge.onrequestdisplaymode = async (params) => post("/proxy/ui/request-display-mode", params);
+    bridge.onopenlink = async (params) => {
+      const result = await post("/proxy/ui/open-link", params);
+      if (!result.isError) {
+        window.open(params.url, "_blank", "noopener,noreferrer");
+        // Notify agent about the link open
+        await post("/proxy/ui/message", {
+          type: "intent",
+          intent: "open_link",
+          params: { url: params.url }
+        }).catch(() => {});
+      }
+      return result;
+    };
+
+    bridge.oninitialized = () => {
+      if (streamMode !== "stream-first") {
+        bridge.sendToolInput({ arguments: TOOL_ARGS });
+      }
+      setStatus(streamMode === "stream-first" ? "Streaming…" : "Connected");
+    };
+
+    bridge.onsizechange = ({ width, height }) => {
+      if (typeof width === "number" && width > 0) {
+        iframe.style.minWidth = Math.min(width, window.innerWidth - 24) + "px";
+      }
+      if (typeof height === "number" && height > 0) {
+        iframe.style.height = Math.max(height, 320) + "px";
+      }
+    };
+
+    if (ALLOW_ATTRIBUTE) {
+      iframe.setAttribute("allow", ALLOW_ATTRIBUTE);
+    }
+
+    // Connect bridge BEFORE loading iframe to ensure we're listening when the app sends ui/initialize
+    try {
+      const transport = new PostMessageTransport(iframe.contentWindow, null);
+      await bridge.connect(transport);
+    } catch (error) {
+      console.error("[host] Bridge connection failed:", error);
+      showError("Failed to initialize AppBridge: " + String(error));
+    }
+
+    const iframeLoaded = new Promise((resolve) => {
+      iframe.onload = resolve;
+    });
+    iframe.src = "/ui-app?session=" + encodeURIComponent(SESSION_TOKEN);
+    await iframeLoaded;
+
+    const eventSource = new EventSource("/events?session=" + encodeURIComponent(SESSION_TOKEN));
+    eventSource.addEventListener("tool-input", (event) => {
+      try {
+        bridge.sendToolInput(JSON.parse(event.data));
+      } catch (error) {
+        showError("Failed to forward tool input: " + String(error));
+      }
+    });
+    eventSource.addEventListener("tool-result", (event) => {
+      try {
+        bridge.sendToolResult(JSON.parse(event.data));
+      } catch (error) {
+        showError("Failed to forward tool result: " + String(error));
+      }
+    });
+    eventSource.addEventListener("tool-cancelled", (event) => {
+      try {
+        bridge.sendToolCancelled(JSON.parse(event.data));
+      } catch (error) {
+        showError("Failed to forward cancellation: " + String(error));
+      }
+    });
+    eventSource.addEventListener("result-patch", async (event) => {
+      try {
+        await bridge.notification({
+          method: STREAM_PATCH_METHOD,
+          params: JSON.parse(event.data),
+        });
+      } catch (error) {
+        showError("Failed to forward stream patch: " + String(error));
+      }
+    });
+    eventSource.addEventListener("host-context", (event) => {
+      try {
+        bridge.setHostContext(JSON.parse(event.data));
+      } catch {}
+    });
+    eventSource.addEventListener("session-complete", async () => {
+      await bridge.teardownResource({}).catch(() => {});
+      eventSource.close();
+      window.close();
+    });
+    eventSource.onerror = () => {
+      setStatus("Connection lost", true);
+    };
+
+    const heartbeat = setInterval(() => {
+      post("/proxy/ui/heartbeat", {}).catch(() => {});
+    }, 10000);
+
+    const complete = async (reason) => {
+      try {
+        await post("/proxy/ui/complete", { reason });
+      } catch {}
+      try {
+        await bridge.teardownResource({});
+      } catch {}
+      clearInterval(heartbeat);
+      eventSource.close();
+      window.close();
+    };
+
+    doneBtn.addEventListener("click", () => complete("done"));
+    cancelBtn.addEventListener("click", () => complete("cancel"));
+    window.addEventListener("keydown", (event) => {
+      if (event.key === "Escape") {
+        event.preventDefault();
+        complete("cancel");
+      } else if ((event.metaKey || event.ctrlKey) && event.key === "Enter") {
+        event.preventDefault();
+        complete("done");
+      }
+    });
+  </script>
+</body>
+</html>`
+}
+
+export function buildCspMetaContent(csp: UiResourceCsp | undefined): string | undefined {
+	if (!csp) return undefined
+
+	const directives: string[] = []
+	directives.push("default-src 'none'")
+
+	const scriptSrc = toDirective("script-src", csp.scriptDomains)
+	const styleSrc = toDirective("style-src", csp.styleDomains)
+	const fontSrc = toDirective("font-src", csp.fontDomains)
+	const imgSrc = toDirective("img-src", csp.imgDomains)
+	const mediaSrc = toDirective("media-src", csp.mediaDomains)
+	const connectSrc = toDirective("connect-src", csp.connectDomains)
+	const frameSrc = toDirective("frame-src", csp.frameDomains)
+	const workerSrc = toDirective("worker-src", csp.workerDomains)
+	const baseUri = toDirective("base-uri", csp.baseUriDomains)
+
+	if (scriptSrc) directives.push(scriptSrc)
+	if (styleSrc) directives.push(styleSrc)
+	if (fontSrc) directives.push(fontSrc)
+	if (imgSrc) directives.push(imgSrc)
+	if (mediaSrc) directives.push(mediaSrc)
+	if (connectSrc) directives.push(connectSrc)
+	if (frameSrc) directives.push(frameSrc)
+	if (workerSrc) directives.push(workerSrc)
+	if (baseUri) directives.push(baseUri)
+
+	return directives.join("; ")
+}
+
+function toDirective(name: string, domains: string[] | undefined): string | null {
+	if (!domains || domains.length === 0) return null
+	return `${name} ${domains.join(" ")}`
+}
+
+export function applyCspMeta(html: string, cspContent: string | undefined): string {
+	if (!cspContent) return html
+	if (/http-equiv=["']Content-Security-Policy["']/i.test(html)) return html
+	const metaTag = `<meta http-equiv="Content-Security-Policy" content="${escapeHtmlAttribute(cspContent)}">`
+	if (/<head[^>]*>/i.test(html)) {
+		return html.replace(/<head[^>]*>/i, (match) => `${match}\n${metaTag}`)
+	}
+	return `${metaTag}\n${html}`
+}
+
+function safeInlineJSON(value: unknown): string {
+	return JSON.stringify(value)
+		.replace(/</g, "\\u003c")
+		.replace(/>/g, "\\u003e")
+		.replace(/&/g, "\\u0026")
+		.replace(/\u2028/g, "\\u2028")
+		.replace(/\u2029/g, "\\u2029")
+}
+
+function escapeHtml(value: string): string {
+	return value
+		.replace(/&/g, "&amp;")
+		.replace(/</g, "&lt;")
+		.replace(/>/g, "&gt;")
+		.replace(/"/g, "&quot;")
+		.replace(/'/g, "&#39;")
+}
+
+function escapeHtmlAttribute(value: string): string {
+	return value.replace(/&/g, "&amp;").replace(/"/g, "&quot;").replace(/</g, "&lt;").replace(/>/g, "&gt;")
+}

--- a/src/extensions/mcp-adapter/index.ts
+++ b/src/extensions/mcp-adapter/index.ts
@@ -3,6 +3,7 @@ import { Theme, keyHint } from "@mariozechner/pi-coding-agent"
 import { Type } from "@sinclair/typebox"
 import { Text } from "@mariozechner/pi-tui"
 import { authenticateServer, openMcpPanel, reconnectServers, showStatus, showTools } from "./commands.js"
+import { loadConfig } from "../../config.js"
 import { loadMcpConfig } from "./config.js"
 import {
 	buildProxyDescription,
@@ -277,7 +278,7 @@ export default function mcpAdapter(pi: ExtensionAPI) {
 				},
 				_signal,
 				_onUpdate,
-				_ctx,
+				ctx,
 			) {
 				let parsedArgs: Record<string, unknown> | undefined
 				if (params.args) {
@@ -316,8 +317,15 @@ export default function mcpAdapter(pi: ExtensionAPI) {
 				if (params.action === "ui-messages") {
 					return executeUiMessages(state)
 				}
+				let maxToolResultChars = 10_000
+				try {
+					const kimchiConfig = loadConfig()
+					maxToolResultChars = kimchiConfig.maxToolResultChars
+				} catch {
+					// loadConfig throws when API key is missing; default is fine here
+				}
 				if (params.tool) {
-					return executeCall(state, params.tool, parsedArgs, params.server)
+					return executeCall(state, params.tool, parsedArgs, params.server, ctx, maxToolResultChars)
 				}
 				if (params.connect) {
 					return executeConnect(state, params.connect)

--- a/src/extensions/mcp-adapter/index.ts
+++ b/src/extensions/mcp-adapter/index.ts
@@ -1,5 +1,7 @@
-import type { ExtensionAPI, ToolInfo } from "@mariozechner/pi-coding-agent"
+import type { ExtensionAPI, ToolInfo, ToolRenderResultOptions } from "@mariozechner/pi-coding-agent"
+import { Theme, keyHint } from "@mariozechner/pi-coding-agent"
 import { Type } from "@sinclair/typebox"
+import { Text } from "@mariozechner/pi-tui"
 import { authenticateServer, openMcpPanel, reconnectServers, showStatus, showTools } from "./commands.js"
 import { loadMcpConfig } from "./config.js"
 import {
@@ -331,6 +333,69 @@ export default function mcpAdapter(pi: ExtensionAPI) {
 				}
 				return executeStatus(state)
 			},
+			renderCall(args: { tool?: string; args?: string; connect?: string; describe?: string; search?: string; server?: string; action?: string }, theme: Theme, context: { lastComponent: unknown }) {
+				const text = (context.lastComponent as Text | undefined) ?? new Text("", 0, 0)
+				text.setText(formatMcpCall(args, theme))
+				return text
+			},
+			renderResult(result: unknown, options: ToolRenderResultOptions, theme: Theme, context: { lastComponent?: unknown }) {
+				const text = (context.lastComponent as Text | undefined) ?? new Text("", 0, 0)
+				text.setText(formatMcpResult(result, options, theme))
+				return text
+			},
 		})
 	}
+}
+
+const COLLAPSED_LINES = 10
+
+function formatMcpResult(result: unknown, options: ToolRenderResultOptions, theme: Theme): string {
+	const content = (result as { content?: Array<{ type: string; text?: string }> })?.content ?? []
+	const textParts = content
+		.filter((c): c is { type: "text"; text: string } => c.type === "text" && typeof c.text === "string")
+		.map((c) => c.text)
+	const combined = textParts.join("\n")
+	if (!combined) return ""
+
+	const lines = combined.split("\n")
+	const maxLines = options.expanded ? lines.length : COLLAPSED_LINES
+	const displayLines = lines.slice(0, maxLines)
+	const remaining = lines.length - maxLines
+
+	let text = `\n${displayLines.map((line) => theme.fg("toolOutput", line)).join("\n")}`
+	if (remaining > 0) {
+		text += `${theme.fg("muted", `\n... (${remaining} more lines,`)} ${keyHint("app.tools.expand", "to expand")})`
+	}
+	return text
+}
+
+function formatMcpCall(
+	params: { tool?: string; args?: string; connect?: string; describe?: string; search?: string; server?: string; action?: string },
+	theme: Theme,
+): string {
+	if (params.tool) {
+		// Parse server prefix from tool name: "grafana_prod_master_query_loki" -> server="grafana_prod_master", tool="query_loki"
+		// We display as-is since the full prefixed name is what the model uses
+		const toolDisplay = theme.fg("accent", params.tool)
+		let argsDisplay = ""
+		if (params.args) {
+			try {
+				const parsed = JSON.parse(params.args) as Record<string, unknown>
+				const parts = Object.entries(parsed).map(([k, v]) => {
+					const val = typeof v === "string" ? v.slice(0, 60) + (v.length > 60 ? "…" : "") : String(v).slice(0, 60)
+					return `${theme.fg("muted", k + ":")} ${theme.fg("toolOutput", val)}`
+				})
+				if (parts.length > 0) argsDisplay = `(${parts.join(", ")})`
+			} catch {
+				argsDisplay = `(${theme.fg("toolOutput", params.args.slice(0, 80))})`
+			}
+		}
+		return `${theme.bold("mcp")} ${toolDisplay}${argsDisplay}`
+	}
+	if (params.describe) return `${theme.bold("mcp")} ${theme.fg("muted", "describe:")} ${theme.fg("accent", params.describe)}`
+	if (params.search) return `${theme.bold("mcp")} ${theme.fg("muted", "search:")} ${theme.fg("toolOutput", params.search)}`
+	if (params.connect) return `${theme.bold("mcp")} ${theme.fg("muted", "connect:")} ${theme.fg("accent", params.connect)}`
+	if (params.server) return `${theme.bold("mcp")} ${theme.fg("muted", "list:")} ${theme.fg("accent", params.server)}`
+	if (params.action === "ui-messages") return `${theme.bold("mcp")} ${theme.fg("muted", "ui-messages")}`
+	return theme.bold("mcp")
 }

--- a/src/extensions/mcp-adapter/index.ts
+++ b/src/extensions/mcp-adapter/index.ts
@@ -1,0 +1,336 @@
+import type { ExtensionAPI, ToolInfo } from "@mariozechner/pi-coding-agent"
+import { Type } from "@sinclair/typebox"
+import { authenticateServer, openMcpPanel, reconnectServers, showStatus, showTools } from "./commands.js"
+import { loadMcpConfig } from "./config.js"
+import {
+	buildProxyDescription,
+	createDirectToolExecutor,
+	getMissingConfiguredDirectToolServers,
+	resolveDirectTools,
+} from "./direct-tools.js"
+import { flushMetadataCache, initializeMcp, updateStatusBar } from "./init.js"
+import { initializeOAuth, shutdownOAuth } from "./mcp-auth-flow.js"
+import { loadMetadataCache } from "./metadata-cache.js"
+import {
+	executeCall,
+	executeConnect,
+	executeDescribe,
+	executeList,
+	executeSearch,
+	executeStatus,
+	executeUiMessages,
+} from "./proxy-modes.js"
+import type { McpExtensionState } from "./state.js"
+import { getConfigPathFromArgv, truncateAtWord } from "./utils.js"
+
+export default function mcpAdapter(pi: ExtensionAPI) {
+	let state: McpExtensionState | null = null
+	let initPromise: Promise<McpExtensionState> | null = null
+	let lifecycleGeneration = 0
+
+	async function shutdownState(currentState: McpExtensionState | null, reason: string): Promise<void> {
+		if (!currentState) return
+
+		if (currentState.uiServer) {
+			currentState.uiServer.close(reason)
+			currentState.uiServer = null
+		}
+
+		let flushError: unknown
+		try {
+			flushMetadataCache(currentState)
+		} catch (error) {
+			flushError = error
+		}
+
+		try {
+			await currentState.lifecycle.gracefulShutdown()
+		} catch (error) {
+			if (flushError) {
+				console.error("MCP: graceful shutdown failed after metadata flush error", error)
+			} else {
+				throw error
+			}
+		}
+
+		if (flushError) {
+			throw flushError
+		}
+	}
+
+	const earlyConfigPath = getConfigPathFromArgv()
+	const earlyConfig = loadMcpConfig(earlyConfigPath)
+	const earlyCache = loadMetadataCache()
+	const prefix = earlyConfig.settings?.toolPrefix ?? "server"
+
+	const envRaw = process.env.MCP_DIRECT_TOOLS
+	const directSpecs =
+		envRaw === "__none__"
+			? []
+			: resolveDirectTools(
+					earlyConfig,
+					earlyCache,
+					prefix,
+					envRaw
+						?.split(",")
+						.map((s) => s.trim())
+						.filter(Boolean),
+				)
+	const missingConfiguredDirectToolServers = getMissingConfiguredDirectToolServers(earlyConfig, earlyCache)
+	const shouldRegisterProxyTool =
+		earlyConfig.settings?.disableProxyTool !== true ||
+		directSpecs.length === 0 ||
+		missingConfiguredDirectToolServers.length > 0
+
+	for (const spec of directSpecs) {
+		pi.registerTool({
+			name: spec.prefixedName,
+			label: `MCP: ${spec.originalName}`,
+			description: spec.description || "(no description)",
+			promptSnippet: truncateAtWord(spec.description, 100) || `MCP tool from ${spec.serverName}`,
+			parameters: Type.Unsafe<Record<string, unknown>>(spec.inputSchema || { type: "object", properties: {} }),
+			execute: createDirectToolExecutor(
+				() => state,
+				() => initPromise,
+				spec,
+			),
+		})
+	}
+
+	const getPiTools = (): ToolInfo[] => pi.getAllTools()
+
+	pi.registerFlag("mcp-config", {
+		description: "Path to MCP config file",
+		type: "string",
+	})
+
+	pi.on("session_start", async (_event, ctx) => {
+		const generation = ++lifecycleGeneration
+		const previousState = state
+		state = null
+		initPromise = null
+
+		try {
+			await Promise.all([shutdownState(previousState, "session_restart"), shutdownOAuth()])
+		} catch (error) {
+			console.error("MCP: failed to shut down previous session state", error)
+		}
+
+		if (generation !== lifecycleGeneration) {
+			return
+		}
+
+		await initializeOAuth().catch((err) => {
+			console.error("MCP OAuth initialization failed:", err)
+		})
+
+		const promise = initializeMcp(pi, ctx)
+		initPromise = promise
+
+		promise
+			.then(async (nextState) => {
+				if (generation !== lifecycleGeneration || initPromise !== promise) {
+					try {
+						await shutdownState(nextState, "stale_session_start")
+					} catch (error) {
+						console.error("MCP: failed to clean stale session state", error)
+					}
+					return
+				}
+
+				state = nextState
+				updateStatusBar(nextState)
+				initPromise = null
+			})
+			.catch((err) => {
+				if (generation !== lifecycleGeneration) {
+					return
+				}
+				if (initPromise !== promise && initPromise !== null) {
+					return
+				}
+				console.error("MCP initialization failed:", err)
+				initPromise = null
+			})
+	})
+
+	pi.on("session_shutdown", async () => {
+		++lifecycleGeneration
+		const currentState = state
+		state = null
+		initPromise = null
+
+		try {
+			await Promise.all([shutdownState(currentState, "session_shutdown"), shutdownOAuth()])
+		} catch (error) {
+			console.error("MCP: session shutdown cleanup failed", error)
+		}
+	})
+
+	pi.registerCommand("mcp", {
+		description: "Show MCP server status",
+		handler: async (args, ctx) => {
+			if (!state && initPromise) {
+				try {
+					state = await initPromise
+				} catch (error) {
+					const message = error instanceof Error ? error.message : String(error)
+					if (ctx.hasUI) ctx.ui.notify(`MCP initialization failed: ${message}`, "error")
+					return
+				}
+			}
+			if (!state) {
+				if (ctx.hasUI) ctx.ui.notify("MCP not initialized", "error")
+				return
+			}
+
+			const parts = args?.trim()?.split(/\s+/) ?? []
+			const subcommand = parts[0] ?? ""
+			const targetServer = parts[1]
+
+			switch (subcommand) {
+				case "reconnect":
+					await reconnectServers(state, ctx, targetServer)
+					break
+				case "tools":
+					await showTools(state, ctx)
+					break
+				case "status":
+				case "":
+				default:
+					if (ctx.hasUI) {
+						await openMcpPanel(state, pi, ctx, earlyConfigPath)
+					} else {
+						await showStatus(state, ctx)
+					}
+					break
+			}
+		},
+	})
+
+	pi.registerCommand("mcp-auth", {
+		description: "Authenticate with an MCP server (OAuth)",
+		handler: async (args, ctx) => {
+			const serverName = args?.trim()
+			if (!serverName) {
+				if (ctx.hasUI) ctx.ui.notify("Usage: /mcp-auth <server-name>", "error")
+				return
+			}
+
+			if (!state && initPromise) {
+				try {
+					state = await initPromise
+				} catch (error) {
+					const message = error instanceof Error ? error.message : String(error)
+					if (ctx.hasUI) ctx.ui.notify(`MCP initialization failed: ${message}`, "error")
+					return
+				}
+			}
+			if (!state) {
+				if (ctx.hasUI) ctx.ui.notify("MCP not initialized", "error")
+				return
+			}
+
+			await authenticateServer(serverName, state.config, ctx)
+		},
+	})
+
+	if (shouldRegisterProxyTool) {
+		pi.registerTool({
+			name: "mcp",
+			label: "MCP",
+			description: buildProxyDescription(earlyConfig, earlyCache, directSpecs),
+			promptSnippet: "MCP gateway - connect to MCP servers and call their tools",
+			parameters: Type.Object({
+				tool: Type.Optional(Type.String({ description: "Tool name to call (e.g., 'xcodebuild_list_sims')" })),
+				args: Type.Optional(Type.String({ description: 'Arguments as JSON string (e.g., \'{"key": "value"}\')' })),
+				connect: Type.Optional(
+					Type.String({ description: "Server name to connect (lazy connect + metadata refresh)" }),
+				),
+				describe: Type.Optional(Type.String({ description: "Tool name to describe (shows parameters)" })),
+				search: Type.Optional(Type.String({ description: "Search tools by name/description" })),
+				regex: Type.Optional(Type.Boolean({ description: "Treat search as regex (default: substring match)" })),
+				includeSchemas: Type.Optional(
+					Type.Boolean({ description: "Include parameter schemas in search results (default: true)" }),
+				),
+				server: Type.Optional(
+					Type.String({ description: "Filter to specific server (also disambiguates tool calls)" }),
+				),
+				action: Type.Optional(
+					Type.String({ description: "Action: 'ui-messages' to retrieve prompts/intents from UI sessions" }),
+				),
+			}),
+			async execute(
+				_toolCallId,
+				params: {
+					tool?: string
+					args?: string
+					connect?: string
+					describe?: string
+					search?: string
+					regex?: boolean
+					includeSchemas?: boolean
+					server?: string
+					action?: string
+				},
+				_signal,
+				_onUpdate,
+				_ctx,
+			) {
+				let parsedArgs: Record<string, unknown> | undefined
+				if (params.args) {
+					try {
+						parsedArgs = JSON.parse(params.args)
+						if (typeof parsedArgs !== "object" || parsedArgs === null || Array.isArray(parsedArgs)) {
+							const gotType = Array.isArray(parsedArgs) ? "array" : parsedArgs === null ? "null" : typeof parsedArgs
+							throw new Error(`Invalid args: expected a JSON object, got ${gotType}`)
+						}
+					} catch (error) {
+						if (error instanceof SyntaxError) {
+							throw new Error(`Invalid args JSON: ${error.message}`, { cause: error })
+						}
+						throw error
+					}
+				}
+
+				if (!state && initPromise) {
+					try {
+						state = await initPromise
+					} catch (error) {
+						const message = error instanceof Error ? error.message : String(error)
+						return {
+							content: [{ type: "text" as const, text: `MCP initialization failed: ${message}` }],
+							details: { error: "init_failed", message },
+						}
+					}
+				}
+				if (!state) {
+					return {
+						content: [{ type: "text" as const, text: "MCP not initialized" }],
+						details: { error: "not_initialized" },
+					}
+				}
+
+				if (params.action === "ui-messages") {
+					return executeUiMessages(state)
+				}
+				if (params.tool) {
+					return executeCall(state, params.tool, parsedArgs, params.server)
+				}
+				if (params.connect) {
+					return executeConnect(state, params.connect)
+				}
+				if (params.describe) {
+					return executeDescribe(state, params.describe)
+				}
+				if (params.search) {
+					return executeSearch(state, params.search, params.regex, params.server, params.includeSchemas, getPiTools)
+				}
+				if (params.server) {
+					return executeList(state, params.server)
+				}
+				return executeStatus(state)
+			},
+		})
+	}
+}

--- a/src/extensions/mcp-adapter/init.ts
+++ b/src/extensions/mcp-adapter/init.ts
@@ -1,0 +1,323 @@
+import { existsSync } from "node:fs"
+import type { ExtensionAPI, ExtensionContext } from "@mariozechner/pi-coding-agent"
+import { loadMcpConfig } from "./config.js"
+import { ConsentManager } from "./consent-manager.js"
+import { getMissingConfiguredDirectToolServers } from "./direct-tools.js"
+import { McpLifecycleManager } from "./lifecycle.js"
+import { logger } from "./logger.js"
+import {
+	type ServerCacheEntry,
+	computeServerHash,
+	getMetadataCachePath,
+	isServerCacheValid,
+	loadMetadataCache,
+	reconstructToolMetadata,
+	saveMetadataCache,
+	serializeResources,
+	serializeTools,
+} from "./metadata-cache.js"
+import { McpServerManager } from "./server-manager.js"
+import type { McpExtensionState } from "./state.js"
+import { buildToolMetadata, totalToolCount } from "./tool-metadata.js"
+import type { ToolMetadata } from "./types.js"
+import { UiResourceHandler } from "./ui-resource-handler.js"
+import { openUrl, parallelLimit } from "./utils.js"
+
+const FAILURE_BACKOFF_MS = 60 * 1000
+
+export async function initializeMcp(pi: ExtensionAPI, ctx: ExtensionContext): Promise<McpExtensionState> {
+	const configPath = pi.getFlag("mcp-config") as string | undefined
+	const config = loadMcpConfig(configPath)
+
+	const manager = new McpServerManager()
+	const lifecycle = new McpLifecycleManager(manager)
+	const toolMetadata = new Map<string, ToolMetadata[]>()
+	const failureTracker = new Map<string, number>()
+	const uiResourceHandler = new UiResourceHandler(manager)
+	const consentManager = new ConsentManager("once-per-server")
+	const ui = ctx.hasUI ? ctx.ui : undefined
+	const state: McpExtensionState = {
+		manager,
+		lifecycle,
+		toolMetadata,
+		config,
+		failureTracker,
+		uiResourceHandler,
+		consentManager,
+		uiServer: null,
+		completedUiSessions: [],
+		openBrowser: (url: string) => openUrl(pi, url, process.env.BROWSER),
+		ui,
+		sendMessage: (message, options) => pi.sendMessage(message, options),
+	}
+
+	const serverEntries = Object.entries(config.mcpServers)
+	if (serverEntries.length === 0) {
+		return state
+	}
+
+	const idleSetting = typeof config.settings?.idleTimeout === "number" ? config.settings.idleTimeout : 10
+	lifecycle.setGlobalIdleTimeout(idleSetting)
+
+	const cachePath = getMetadataCachePath()
+	const cacheFileExists = existsSync(cachePath)
+	let cache = loadMetadataCache()
+	let bootstrapAll = false
+
+	if (!cacheFileExists) {
+		bootstrapAll = true
+		saveMetadataCache({ version: 1, servers: {} })
+	} else if (!cache) {
+		cache = { version: 1, servers: {} }
+		saveMetadataCache(cache)
+	}
+
+	const prefix = config.settings?.toolPrefix ?? "server"
+
+	for (const [name, definition] of serverEntries) {
+		const lifecycleMode = definition.lifecycle ?? "lazy"
+		const idleOverride = definition.idleTimeout ?? (lifecycleMode === "eager" ? 0 : undefined)
+		lifecycle.registerServer(name, definition, idleOverride !== undefined ? { idleTimeout: idleOverride } : undefined)
+		if (lifecycleMode === "keep-alive") {
+			lifecycle.markKeepAlive(name, definition)
+		}
+
+		if (cache?.servers?.[name] && isServerCacheValid(cache.servers[name], definition)) {
+			const metadata = reconstructToolMetadata(name, cache.servers[name], prefix, definition)
+			toolMetadata.set(name, metadata)
+		}
+	}
+
+	const startupServers = bootstrapAll
+		? serverEntries
+		: serverEntries.filter(([, definition]) => {
+				const mode = definition.lifecycle ?? "lazy"
+				return mode === "keep-alive" || mode === "eager"
+			})
+
+	if (ctx.hasUI && startupServers.length > 0) {
+		ctx.ui.setStatus("mcp", `MCP: connecting to ${startupServers.length} servers...`)
+	}
+
+	const results = await parallelLimit(startupServers, 10, async ([name, definition]) => {
+		try {
+			const connection = await manager.connect(name, definition)
+			if (connection.status === "needs-auth") {
+				return { name, definition, connection: null, error: `OAuth authentication required. Run /mcp-auth ${name}.` }
+			}
+			return { name, definition, connection, error: null }
+		} catch (error) {
+			const message = error instanceof Error ? error.message : String(error)
+			return { name, definition, connection: null, error: message }
+		}
+	})
+
+	for (const { name, definition, connection, error } of results) {
+		if (error || !connection) {
+			if (ctx.hasUI) {
+				ctx.ui.notify(`MCP: Failed to connect to ${name}: ${error}`, "error")
+			}
+			console.error(`MCP: Failed to connect to ${name}: ${error}`)
+			continue
+		}
+
+		const { metadata, failedTools } = buildToolMetadata(
+			connection.tools,
+			connection.resources,
+			definition,
+			name,
+			prefix,
+		)
+		toolMetadata.set(name, metadata)
+		updateMetadataCache(state, name)
+
+		if (failedTools.length > 0 && ctx.hasUI) {
+			ctx.ui.notify(`MCP: ${name} - ${failedTools.length} tools skipped`, "warning")
+		}
+	}
+
+	const connectedCount = results.filter((r) => r.connection).length
+	const failedCount = results.filter((r) => r.error).length
+	if (ctx.hasUI && connectedCount > 0) {
+		const totalTools = totalToolCount(state)
+		const msg =
+			failedCount > 0
+				? `MCP: ${connectedCount}/${startupServers.length} servers connected (${totalTools} tools)`
+				: `MCP: ${connectedCount} servers connected (${totalTools} tools)`
+		ctx.ui.notify(msg, "info")
+	}
+
+	const envDirect = process.env.MCP_DIRECT_TOOLS
+	if (envDirect !== "__none__") {
+		const currentCache = loadMetadataCache()
+		const missingCacheServers = getMissingConfiguredDirectToolServers(config, currentCache)
+
+		if (missingCacheServers.length > 0) {
+			const bootstrapResults = await parallelLimit(
+				missingCacheServers.filter((name) => !results.some((r) => r.name === name && r.connection)),
+				10,
+				async (name) => {
+					const definition = config.mcpServers[name]
+					try {
+						const connection = await manager.connect(name, definition)
+						if (connection.status === "needs-auth") {
+							return { name, ok: false }
+						}
+						const { metadata } = buildToolMetadata(connection.tools, connection.resources, definition, name, prefix)
+						toolMetadata.set(name, metadata)
+						updateMetadataCache(state, name)
+						return { name, ok: true }
+					} catch (error) {
+						const message = error instanceof Error ? error.message : String(error)
+						logger.debug(`MCP: direct-tools bootstrap failed for ${name}: ${message}`)
+						return { name, ok: false }
+					}
+				},
+			)
+			const bootstrapped = bootstrapResults.filter((r) => r.ok).map((r) => r.name)
+			if (bootstrapped.length > 0 && ctx.hasUI) {
+				ctx.ui.notify(`MCP: direct tools for ${bootstrapped.join(", ")} will be available after restart`, "info")
+			}
+		}
+	}
+
+	lifecycle.setReconnectCallback((serverName) => {
+		updateServerMetadata(state, serverName)
+		updateMetadataCache(state, serverName)
+		state.failureTracker.delete(serverName)
+		updateStatusBar(state)
+	})
+
+	lifecycle.setIdleShutdownCallback((serverName) => {
+		const idleMinutes = getEffectiveIdleTimeoutMinutes(state, serverName)
+		logger.debug(`${serverName} shut down (idle ${idleMinutes}m)`)
+		updateStatusBar(state)
+	})
+
+	lifecycle.startHealthChecks()
+
+	return state
+}
+
+export function updateServerMetadata(state: McpExtensionState, serverName: string): void {
+	const connection = state.manager.getConnection(serverName)
+	if (!connection || connection.status !== "connected") return
+
+	const definition = state.config.mcpServers[serverName]
+	if (!definition) return
+
+	const prefix = state.config.settings?.toolPrefix ?? "server"
+
+	const { metadata } = buildToolMetadata(connection.tools, connection.resources, definition, serverName, prefix)
+	state.toolMetadata.set(serverName, metadata)
+}
+
+export function updateMetadataCache(state: McpExtensionState, serverName: string): void {
+	const connection = state.manager.getConnection(serverName)
+	if (!connection || connection.status !== "connected") return
+
+	const definition = state.config.mcpServers[serverName]
+	if (!definition) return
+
+	const configHash = computeServerHash(definition)
+	const existing = loadMetadataCache()
+	const existingEntry = existing?.servers?.[serverName]
+
+	const tools = serializeTools(connection.tools)
+	let resources = definition.exposeResources === false ? [] : serializeResources(connection.resources)
+
+	if (
+		definition.exposeResources !== false &&
+		resources.length === 0 &&
+		existingEntry?.resources?.length &&
+		existingEntry.configHash === configHash
+	) {
+		resources = existingEntry.resources
+	}
+
+	const entry: ServerCacheEntry = {
+		configHash,
+		tools,
+		resources,
+		cachedAt: Date.now(),
+	}
+
+	saveMetadataCache({ version: 1, servers: { [serverName]: entry } })
+}
+
+export function flushMetadataCache(state: McpExtensionState): void {
+	for (const [name, connection] of state.manager.getAllConnections()) {
+		if (connection.status === "connected") {
+			updateMetadataCache(state, name)
+		}
+	}
+}
+
+export function updateStatusBar(state: McpExtensionState): void {
+	const ui = state.ui
+	if (!ui) return
+	const total = Object.keys(state.config.mcpServers).length
+	if (total === 0) {
+		ui.setStatus("mcp", undefined)
+		return
+	}
+	const connectedCount = state.manager.getAllConnections().size
+	ui.setStatus("mcp", ui.theme.fg("accent", `MCP: ${connectedCount}/${total} servers`))
+}
+
+export function getFailureAgeSeconds(state: McpExtensionState, serverName: string): number | null {
+	const failedAt = state.failureTracker.get(serverName)
+	if (!failedAt) return null
+	const ageMs = Date.now() - failedAt
+	if (ageMs > FAILURE_BACKOFF_MS) return null
+	return Math.round(ageMs / 1000)
+}
+
+export async function lazyConnect(state: McpExtensionState, serverName: string): Promise<boolean> {
+	const connection = state.manager.getConnection(serverName)
+	if (connection?.status === "needs-auth") {
+		return false
+	}
+	if (connection?.status === "connected") {
+		updateServerMetadata(state, serverName)
+		return true
+	}
+
+	const failedAgo = getFailureAgeSeconds(state, serverName)
+	if (failedAgo !== null) return false
+
+	const definition = state.config.mcpServers[serverName]
+	if (!definition) return false
+
+	try {
+		if (state.ui) {
+			state.ui.setStatus("mcp", `MCP: connecting to ${serverName}...`)
+		}
+		const newConnection = await state.manager.connect(serverName, definition)
+		if (newConnection.status === "needs-auth") {
+			return false
+		}
+		state.failureTracker.delete(serverName)
+		updateServerMetadata(state, serverName)
+		updateMetadataCache(state, serverName)
+		updateStatusBar(state)
+		return true
+	} catch (error) {
+		state.failureTracker.set(serverName, Date.now())
+		const message = error instanceof Error ? error.message : String(error)
+		logger.debug(`MCP: lazy connect failed for ${serverName}: ${message}`)
+		updateStatusBar(state)
+		return false
+	}
+}
+
+function getEffectiveIdleTimeoutMinutes(state: McpExtensionState, serverName: string): number {
+	const definition = state.config.mcpServers[serverName]
+	if (!definition) {
+		return typeof state.config.settings?.idleTimeout === "number" ? state.config.settings.idleTimeout : 10
+	}
+	if (typeof definition.idleTimeout === "number") return definition.idleTimeout
+	const mode = definition.lifecycle ?? "lazy"
+	if (mode === "eager") return 0
+	return typeof state.config.settings?.idleTimeout === "number" ? state.config.settings.idleTimeout : 10
+}

--- a/src/extensions/mcp-adapter/lifecycle.ts
+++ b/src/extensions/mcp-adapter/lifecycle.ts
@@ -1,0 +1,93 @@
+import { logger } from "./logger.js"
+import type { McpServerManager } from "./server-manager.js"
+import type { ServerDefinition } from "./types.js"
+
+export type ReconnectCallback = (serverName: string) => void
+
+export class McpLifecycleManager {
+	private manager: McpServerManager
+	private keepAliveServers = new Map<string, ServerDefinition>()
+	private allServers = new Map<string, ServerDefinition>()
+	private serverSettings = new Map<string, { idleTimeout?: number }>()
+	private globalIdleTimeout: number = 10 * 60 * 1000
+	private healthCheckInterval?: NodeJS.Timeout
+	private onReconnect?: ReconnectCallback
+	private onIdleShutdown?: (serverName: string) => void
+
+	constructor(manager: McpServerManager) {
+		this.manager = manager
+	}
+
+	/**
+	 * Set callback to be invoked after a successful auto-reconnect.
+	 * Use this to update tool metadata when a server reconnects.
+	 */
+	setReconnectCallback(callback: ReconnectCallback): void {
+		this.onReconnect = callback
+	}
+
+	markKeepAlive(name: string, definition: ServerDefinition): void {
+		this.keepAliveServers.set(name, definition)
+	}
+
+	registerServer(name: string, definition: ServerDefinition, settings?: { idleTimeout?: number }): void {
+		this.allServers.set(name, definition)
+		if (settings?.idleTimeout !== undefined) {
+			this.serverSettings.set(name, settings)
+		}
+	}
+
+	setGlobalIdleTimeout(minutes: number): void {
+		this.globalIdleTimeout = minutes * 60 * 1000
+	}
+
+	setIdleShutdownCallback(callback: (serverName: string) => void): void {
+		this.onIdleShutdown = callback
+	}
+
+	startHealthChecks(intervalMs = 30000): void {
+		this.healthCheckInterval = setInterval(() => {
+			this.checkConnections()
+		}, intervalMs)
+		this.healthCheckInterval.unref()
+	}
+
+	private async checkConnections(): Promise<void> {
+		for (const [name, definition] of this.keepAliveServers) {
+			const connection = this.manager.getConnection(name)
+
+			if (!connection || connection.status !== "connected") {
+				try {
+					await this.manager.connect(name, definition)
+					logger.debug(`Reconnected to ${name}`)
+					// Notify extension to update metadata
+					this.onReconnect?.(name)
+				} catch (error) {
+					console.error(`MCP: Failed to reconnect to ${name}:`, error)
+				}
+			}
+		}
+
+		for (const [name] of this.allServers) {
+			if (this.keepAliveServers.has(name)) continue
+			const timeout = this.getIdleTimeout(name)
+			if (timeout > 0 && this.manager.isIdle(name, timeout)) {
+				await this.manager.close(name)
+				this.onIdleShutdown?.(name)
+			}
+		}
+	}
+
+	private getIdleTimeout(name: string): number {
+		const perServer = this.serverSettings.get(name)?.idleTimeout
+		if (perServer !== undefined) return perServer * 60 * 1000
+		return this.globalIdleTimeout
+	}
+
+	async gracefulShutdown(): Promise<void> {
+		if (this.healthCheckInterval) {
+			clearInterval(this.healthCheckInterval)
+		}
+		await this.manager.closeAll()
+	}
+}

--- a/src/extensions/mcp-adapter/logger.ts
+++ b/src/extensions/mcp-adapter/logger.ts
@@ -1,0 +1,169 @@
+/**
+ * Centralized logging for MCP UI operations.
+ * Provides structured, contextual logs with levels.
+ */
+
+export type LogLevel = "debug" | "info" | "warn" | "error"
+
+export interface LogContext {
+	server?: string
+	session?: string
+	tool?: string
+	uri?: string
+	[key: string]: unknown
+}
+
+export interface LogEntry {
+	level: LogLevel
+	message: string
+	context?: LogContext
+	error?: Error
+	timestamp: Date
+}
+
+type LogHandler = (entry: LogEntry) => void
+
+const LEVEL_PRIORITY: Record<LogLevel, number> = {
+	debug: 0,
+	info: 1,
+	warn: 2,
+	error: 3,
+}
+
+const LEVEL_PREFIX: Record<LogLevel, string> = {
+	debug: "[MCP-UI:DEBUG]",
+	info: "[MCP-UI]",
+	warn: "[MCP-UI:WARN]",
+	error: "[MCP-UI:ERROR]",
+}
+
+class Logger {
+	private minLevel: LogLevel = "info"
+	private handlers: LogHandler[] = []
+	private defaultContext: LogContext = {}
+
+	setLevel(level: LogLevel): void {
+		this.minLevel = level
+	}
+
+	setDefaultContext(context: LogContext): void {
+		this.defaultContext = context
+	}
+
+	addHandler(handler: LogHandler): void {
+		this.handlers.push(handler)
+	}
+
+	clearHandlers(): void {
+		this.handlers = []
+	}
+
+	private shouldLog(level: LogLevel): boolean {
+		return LEVEL_PRIORITY[level] >= LEVEL_PRIORITY[this.minLevel]
+	}
+
+	private emit(level: LogLevel, message: string, context?: LogContext, error?: Error): void {
+		if (!this.shouldLog(level)) return
+
+		const entry: LogEntry = {
+			level,
+			message,
+			context: { ...this.defaultContext, ...context },
+			error,
+			timestamp: new Date(),
+		}
+
+		// Default console output
+		const prefix = LEVEL_PREFIX[level]
+		const contextStr = formatContext(entry.context)
+		const fullMessage = contextStr ? `${prefix} ${message} ${contextStr}` : `${prefix} ${message}`
+
+		if (level === "error") {
+			console.error(fullMessage, error ?? "")
+		} else if (level === "warn") {
+			console.warn(fullMessage)
+		} else if (level === "debug") {
+			console.debug(fullMessage)
+		} else {
+			console.log(fullMessage)
+		}
+
+		// Custom handlers
+		for (const handler of this.handlers) {
+			try {
+				handler(entry)
+			} catch {
+				// Ignore handler errors
+			}
+		}
+	}
+
+	debug(message: string, context?: LogContext): void {
+		this.emit("debug", message, context)
+	}
+
+	info(message: string, context?: LogContext): void {
+		this.emit("info", message, context)
+	}
+
+	warn(message: string, context?: LogContext): void {
+		this.emit("warn", message, context)
+	}
+
+	error(message: string, error?: Error, context?: LogContext): void {
+		this.emit("error", message, context, error)
+	}
+
+	/**
+	 * Create a child logger with additional default context.
+	 */
+	child(context: LogContext): ChildLogger {
+		return new ChildLogger(this, context)
+	}
+}
+
+class ChildLogger {
+	constructor(
+		private parent: Logger,
+		private context: LogContext,
+	) {}
+
+	debug(message: string, context?: LogContext): void {
+		this.parent.debug(message, { ...this.context, ...context })
+	}
+
+	info(message: string, context?: LogContext): void {
+		this.parent.info(message, { ...this.context, ...context })
+	}
+
+	warn(message: string, context?: LogContext): void {
+		this.parent.warn(message, { ...this.context, ...context })
+	}
+
+	error(message: string, error?: Error, context?: LogContext): void {
+		this.parent.error(message, error, { ...this.context, ...context })
+	}
+
+	child(context: LogContext): ChildLogger {
+		return new ChildLogger(this.parent, { ...this.context, ...context })
+	}
+}
+
+function formatContext(context?: LogContext): string {
+	if (!context || Object.keys(context).length === 0) return ""
+	const parts: string[] = []
+	for (const [key, value] of Object.entries(context)) {
+		if (value !== undefined && value !== null) {
+			parts.push(`${key}=${typeof value === "string" ? value : JSON.stringify(value)}`)
+		}
+	}
+	return parts.length > 0 ? `(${parts.join(", ")})` : ""
+}
+
+// Singleton instance
+export const logger = new Logger()
+
+// Enable debug mode via environment variable
+if (process.env.MCP_UI_DEBUG === "1" || process.env.MCP_UI_DEBUG === "true") {
+	logger.setLevel("debug")
+}

--- a/src/extensions/mcp-adapter/mcp-auth-flow.ts
+++ b/src/extensions/mcp-adapter/mcp-auth-flow.ts
@@ -1,0 +1,394 @@
+/**
+ * MCP Auth Flow
+ *
+ * High-level OAuth flow management using the MCP SDK's built-in auth functions.
+ * Follows the OpenCode pattern: let the SDK handle discovery internally via transport.
+ */
+
+import { UnauthorizedError } from "@modelcontextprotocol/sdk/client/auth.js"
+import { Client } from "@modelcontextprotocol/sdk/client/index.js"
+import { StreamableHTTPClientTransport } from "@modelcontextprotocol/sdk/client/streamableHttp.js"
+import open from "open"
+import {
+	type StoredTokens,
+	clearAllCredentials,
+	clearOAuthState,
+	getAuthForUrl,
+	getOAuthState,
+	hasStoredTokens,
+	isTokenExpired,
+	updateOAuthState,
+} from "./mcp-auth.js"
+import {
+	cancelPendingCallback,
+	ensureCallbackServer,
+	stopCallbackServer,
+	waitForCallback,
+} from "./mcp-callback-server.js"
+import { type McpOAuthConfig, McpOAuthProvider } from "./mcp-oauth-provider.js"
+import type { ServerEntry } from "./types.js"
+
+/** Auth status for a server */
+export type AuthStatus = "authenticated" | "expired" | "not_authenticated"
+
+// Track pending transports for auth completion
+const pendingTransports = new Map<string, StreamableHTTPClientTransport>()
+
+// Deduplicate concurrent authenticate() calls per server.
+const pendingAuthentications = new Map<string, Promise<AuthStatus>>()
+
+/**
+ * Generate a cryptographically secure random state parameter.
+ */
+function generateState(): string {
+	return Array.from(crypto.getRandomValues(new Uint8Array(32)))
+		.map((b) => b.toString(16).padStart(2, "0"))
+		.join("")
+}
+
+/**
+ * Extract OAuth configuration from a ServerEntry.
+ */
+function extractOAuthConfig(definition: ServerEntry): McpOAuthConfig {
+	// If oauth is explicitly false, return empty config
+	if (definition.oauth === false) {
+		return {}
+	}
+	return {
+		grantType: definition.oauth?.grantType,
+		clientId: definition.oauth?.clientId,
+		clientSecret: definition.oauth?.clientSecret,
+		scope: definition.oauth?.scope,
+	}
+}
+
+/**
+ * Start OAuth authentication flow for a server.
+ * Returns the authorization URL that should be opened in a browser.
+ *
+ * This follows the OpenCode pattern:
+ * 1. Create transport with auth provider
+ * 2. Try to connect - SDK handles discovery internally
+ * 3. If UnauthorizedError, capture the auth URL from onRedirect
+ */
+export async function startAuth(
+	serverName: string,
+	serverUrl: string,
+	definition?: ServerEntry,
+): Promise<{ authorizationUrl: string; transport: StreamableHTTPClientTransport }> {
+	const config = definition ? extractOAuthConfig(definition) : {}
+
+	if (config.grantType === "client_credentials") {
+		const authProvider = new McpOAuthProvider(serverName, serverUrl, config, {
+			onRedirect: async () => {
+				throw new Error("Browser redirect is not used for client_credentials flow")
+			},
+		})
+		const transport = new StreamableHTTPClientTransport(new URL(serverUrl), {
+			authProvider,
+		})
+		const client = new Client({
+			name: "pi-mcp",
+			version: "3.0.0",
+		})
+
+		try {
+			await client.connect(transport)
+			return { authorizationUrl: "", transport }
+		} finally {
+			await client.close().catch(() => {})
+			await transport.close().catch(() => {})
+		}
+	}
+
+	// Start the callback server.
+	// Pre-registered OAuth clients require an exact redirect URI, so enforce strict port binding.
+	await ensureCallbackServer({ strictPort: Boolean(config.clientId) })
+
+	// Generate and store OAuth state BEFORE creating the provider
+	// The SDK will call provider.state() to read this value
+	const oauthState = generateState()
+	await updateOAuthState(serverName, oauthState)
+
+	// Create the auth provider
+	let capturedUrl: URL | undefined
+	const authProvider = new McpOAuthProvider(serverName, serverUrl, config, {
+		onRedirect: async (url) => {
+			capturedUrl = url
+		},
+	})
+
+	// Create transport with auth provider
+	// The SDK handles OAuth discovery internally when connecting
+	const transport = new StreamableHTTPClientTransport(new URL(serverUrl), {
+		authProvider,
+	})
+	const client = new Client({
+		name: "pi-mcp",
+		version: "3.0.0",
+	})
+
+	// Try to connect - this triggers the OAuth flow
+	try {
+		await client.connect(transport)
+		// If we get here, we're already authenticated
+		await client.close().catch(() => {})
+		await transport.close().catch(() => {})
+		return { authorizationUrl: "", transport }
+	} catch (error) {
+		if (error instanceof UnauthorizedError && capturedUrl) {
+			await client.close().catch(() => {})
+			// Store transport for later finishAuth
+			pendingTransports.set(serverName, transport)
+			return { authorizationUrl: capturedUrl.toString(), transport }
+		}
+		await client.close().catch(() => {})
+		await transport.close().catch(() => {})
+		throw error
+	}
+}
+
+/**
+ * Complete OAuth authentication with the authorization code.
+ */
+export async function completeAuth(serverName: string, authorizationCode: string): Promise<AuthStatus> {
+	const transport = pendingTransports.get(serverName)
+	if (!transport) {
+		throw new Error(`No pending OAuth flow for server: ${serverName}`)
+	}
+
+	try {
+		// Complete the auth using the transport's finishAuth method
+		await transport.finishAuth(authorizationCode)
+		return "authenticated"
+	} finally {
+		pendingTransports.delete(serverName)
+		await transport.close().catch(() => {})
+	}
+}
+
+/**
+ * Perform the complete OAuth authentication flow for a server.
+ *
+ * @param serverName - The name of the MCP server
+ * @param serverUrl - The URL of the MCP server
+ * @param definition - The server definition (optional)
+ * @returns The final auth status
+ */
+export async function authenticate(
+	serverName: string,
+	serverUrl: string,
+	definition?: ServerEntry,
+): Promise<AuthStatus> {
+	const inFlight = pendingAuthentications.get(serverName)
+	if (inFlight) {
+		return inFlight
+	}
+
+	const operation = (async (): Promise<AuthStatus> => {
+		// Start auth flow
+		const { authorizationUrl } = await startAuth(serverName, serverUrl, definition)
+
+		// If no auth URL needed, already authenticated
+		if (!authorizationUrl) {
+			return "authenticated"
+		}
+
+		// Get the state that was already generated and stored in startAuth()
+		const oauthState = await getOAuthState(serverName)
+		if (!oauthState) {
+			throw new Error("OAuth state not found - this should not happen")
+		}
+
+		// Register the callback BEFORE opening the browser
+		const callbackPromise = waitForCallback(oauthState)
+
+		// Open browser
+		console.log(`MCP Auth: Opening browser for ${serverName}`)
+		try {
+			await open(authorizationUrl)
+		} catch (error) {
+			console.warn(`MCP Auth: Failed to open browser for ${serverName}`, { error })
+			throw new Error(`Could not open browser. Please open this URL manually: ${authorizationUrl}`, { cause: error })
+		}
+
+		try {
+			// Wait for callback
+			const code = await callbackPromise
+
+			// Validate state
+			const storedState = await getOAuthState(serverName)
+			if (storedState !== oauthState) {
+				await clearOAuthState(serverName)
+				throw new Error("OAuth state mismatch - potential CSRF attack")
+			}
+			await clearOAuthState(serverName)
+
+			// Complete the auth
+			return await completeAuth(serverName, code)
+		} catch (error) {
+			cancelPendingCallback(oauthState)
+			const pendingTransport = pendingTransports.get(serverName)
+			if (pendingTransport) {
+				pendingTransports.delete(serverName)
+				await pendingTransport.close().catch(() => {})
+			}
+			throw error
+		}
+	})()
+
+	pendingAuthentications.set(serverName, operation)
+
+	try {
+		return await operation
+	} finally {
+		if (pendingAuthentications.get(serverName) === operation) {
+			pendingAuthentications.delete(serverName)
+		}
+	}
+}
+
+/**
+ * Get a valid access token for a server, refreshing if necessary.
+ *
+ * @param serverName - The name of the MCP server
+ * @param serverUrl - The URL of the MCP server
+ * @returns The valid tokens or null if not authenticated
+ */
+export async function getValidToken(serverName: string, serverUrl: string): Promise<StoredTokens | null> {
+	// Check if we have valid tokens
+	const entry = await getAuthForUrl(serverName, serverUrl)
+	if (!entry?.tokens) {
+		return null
+	}
+
+	// Check expiration
+	const expired = await isTokenExpired(serverName)
+	if (expired === false) {
+		return entry.tokens
+	}
+
+	if (expired === true && entry.tokens.refreshToken) {
+		// Token is expired, try to refresh
+		console.log(`MCP Auth: Token expired for ${serverName}, attempting refresh`)
+
+		try {
+			// Create auth provider for token refresh
+			const authProvider = new McpOAuthProvider(
+				serverName,
+				serverUrl,
+				{},
+				{
+					onRedirect: async () => {},
+				},
+			)
+
+			const clientInfo = await authProvider.clientInformation()
+			if (!clientInfo) {
+				console.log(`MCP Auth: No client info for refresh for ${serverName}`)
+				return null
+			}
+
+			// Try to get tokens to find the token endpoint
+			const existingTokens = await authProvider.tokens()
+			if (!existingTokens) {
+				return null
+			}
+
+			// Create transport to trigger refresh
+			const transport = new StreamableHTTPClientTransport(new URL(serverUrl), {
+				authProvider,
+			})
+
+			// Try to connect - SDK will attempt token refresh internally
+			const client = new Client({ name: "pi-mcp", version: "3.0.0" })
+			try {
+				await client.connect(transport)
+				// Get refreshed tokens
+				const refreshed = await getAuthForUrl(serverName, serverUrl)
+				return refreshed?.tokens ?? null
+			} catch (error) {
+				console.error(`MCP Auth: Token refresh failed for ${serverName}`, { error })
+				return null
+			} finally {
+				await client.close().catch(() => {})
+				await transport.close().catch(() => {})
+			}
+		} catch (error) {
+			console.error(`MCP Auth: Token refresh failed for ${serverName}`, { error })
+			return null
+		}
+	}
+
+	// No expiration info or no refresh token, assume valid
+	return entry.tokens
+}
+
+/**
+ * Check the authentication status for a server.
+ *
+ * @param serverName - The name of the MCP server
+ * @returns The current auth status
+ */
+export async function getAuthStatus(serverName: string): Promise<AuthStatus> {
+	const hasTokens = await hasStoredTokens(serverName)
+	if (!hasTokens) return "not_authenticated"
+
+	const expired = await isTokenExpired(serverName)
+	return expired ? "expired" : "authenticated"
+}
+
+/**
+ * Remove all OAuth credentials for a server.
+ *
+ * @param serverName - The name of the MCP server
+ */
+export async function removeAuth(serverName: string): Promise<void> {
+	const oauthState = await getOAuthState(serverName)
+	if (oauthState) {
+		cancelPendingCallback(oauthState)
+	}
+	const pendingTransport = pendingTransports.get(serverName)
+	if (pendingTransport) {
+		pendingTransports.delete(serverName)
+		await pendingTransport.close().catch(() => {})
+	}
+	clearAllCredentials(serverName)
+	await clearOAuthState(serverName)
+	console.log(`MCP Auth: Removed credentials for ${serverName}`)
+}
+
+/**
+ * Check if OAuth is supported for a server configuration.
+ * OAuth is supported for HTTP servers unless explicitly disabled.
+ *
+ * @param definition - The server definition
+ * @returns True if OAuth is supported
+ */
+export function supportsOAuth(definition: ServerEntry): boolean {
+	// OAuth requires a URL
+	if (!definition.url) return false
+
+	// Explicitly disabled via auth: false or oauth: false
+	if (definition.auth === false) return false
+	if (definition.oauth === false) return false
+
+	// OAuth is enabled if auth is 'oauth' or not specified (auto-detect)
+	return definition.auth === "oauth" || definition.auth === undefined
+}
+
+/**
+ * Initialize the OAuth system on startup.
+ * Starts the callback server if there are any OAuth servers configured.
+ */
+export async function initializeOAuth(): Promise<void> {
+	await ensureCallbackServer()
+}
+
+/**
+ * Shutdown the OAuth system.
+ * Stops the callback server and cancels pending auths.
+ */
+export async function shutdownOAuth(): Promise<void> {
+	await stopCallbackServer()
+}

--- a/src/extensions/mcp-adapter/mcp-auth.ts
+++ b/src/extensions/mcp-adapter/mcp-auth.ts
@@ -9,8 +9,8 @@
  */
 
 import { existsSync, mkdirSync, readFileSync, rmSync, writeFileSync } from "fs"
-import { homedir } from "os"
 import { join } from "path"
+import { getAgentDir } from "./utils.js"
 
 /** OAuth token storage format */
 export interface StoredTokens {
@@ -39,7 +39,7 @@ export interface AuthEntry {
 
 // Base directory for auth storage - can be overridden via env var for testing
 function getAuthBaseDir(): string {
-	return process.env.MCP_OAUTH_DIR ? process.env.MCP_OAUTH_DIR : join(homedir(), ".pi", "agent", "mcp-oauth")
+	return process.env.MCP_OAUTH_DIR ?? join(getAgentDir(), "mcp-oauth")
 }
 
 /**

--- a/src/extensions/mcp-adapter/mcp-auth.ts
+++ b/src/extensions/mcp-adapter/mcp-auth.ts
@@ -1,0 +1,267 @@
+/**
+ * MCP Auth Storage Module
+ *
+ * Handles secure storage of OAuth credentials, tokens, client information,
+ * and PKCE state for MCP servers. Maintains backward compatibility with
+ * per-server directory structure.
+ *
+ * Token storage location: ~/.pi/agent/mcp-oauth/<server>/tokens.json
+ */
+
+import { existsSync, mkdirSync, readFileSync, rmSync, writeFileSync } from "fs"
+import { homedir } from "os"
+import { join } from "path"
+
+/** OAuth token storage format */
+export interface StoredTokens {
+	accessToken: string
+	refreshToken?: string
+	expiresAt?: number // Unix timestamp in seconds
+	scope?: string
+}
+
+/** OAuth client information from dynamic or static registration */
+export interface StoredClientInfo {
+	clientId: string
+	clientSecret?: string
+	clientIdIssuedAt?: number
+	clientSecretExpiresAt?: number
+}
+
+/** Complete auth entry for a server */
+export interface AuthEntry {
+	tokens?: StoredTokens
+	clientInfo?: StoredClientInfo
+	codeVerifier?: string
+	oauthState?: string
+	serverUrl?: string // Track the URL these credentials are for
+}
+
+// Base directory for auth storage - can be overridden via env var for testing
+function getAuthBaseDir(): string {
+	return process.env.MCP_OAUTH_DIR ? process.env.MCP_OAUTH_DIR : join(homedir(), ".pi", "agent", "mcp-oauth")
+}
+
+/**
+ * Get the server-specific directory path.
+ */
+function getServerDir(serverName: string): string {
+	return join(getAuthBaseDir(), serverName)
+}
+
+/**
+ * Get the tokens file path for a server.
+ */
+function getTokensFilePath(serverName: string): string {
+	return join(getServerDir(serverName), "tokens.json")
+}
+
+/**
+ * Ensure the server directory exists with secure permissions.
+ */
+function ensureServerDir(serverName: string): void {
+	const dir = getServerDir(serverName)
+	if (!existsSync(dir)) {
+		mkdirSync(dir, { recursive: true, mode: 0o700 })
+	}
+}
+
+/**
+ * Read the auth entry for a server from disk.
+ * Returns undefined if file doesn't exist.
+ */
+function readAuthEntry(serverName: string): AuthEntry | undefined {
+	try {
+		const filePath = getTokensFilePath(serverName)
+		if (!existsSync(filePath)) {
+			return undefined
+		}
+		const data = readFileSync(filePath, "utf-8")
+		return JSON.parse(data) as AuthEntry
+	} catch (error) {
+		console.error(`Failed to read auth entry for ${serverName}:`, error)
+		return undefined
+	}
+}
+
+/**
+ * Write the auth entry for a server to disk with secure permissions.
+ */
+function writeAuthEntry(serverName: string, entry: AuthEntry): void {
+	ensureServerDir(serverName)
+	const filePath = getTokensFilePath(serverName)
+	writeFileSync(filePath, JSON.stringify(entry, null, 2), { mode: 0o600 })
+}
+
+/**
+ * Get auth entry for a server.
+ */
+export function getAuthEntry(serverName: string): AuthEntry | undefined {
+	return readAuthEntry(serverName)
+}
+
+/**
+ * Get auth entry and validate it's for the correct URL.
+ * Returns undefined if URL has changed (credentials are invalid).
+ */
+export function getAuthForUrl(serverName: string, serverUrl: string): AuthEntry | undefined {
+	const entry = getAuthEntry(serverName)
+	if (!entry) return undefined
+
+	// If no serverUrl is stored, this is from an old version - consider it invalid
+	if (!entry.serverUrl) return undefined
+
+	// If URL has changed, credentials are invalid
+	if (entry.serverUrl !== serverUrl) return undefined
+
+	return entry
+}
+
+/**
+ * Save auth entry for a server.
+ */
+export function saveAuthEntry(serverName: string, entry: AuthEntry, serverUrl?: string): void {
+	// Always update serverUrl if provided
+	if (serverUrl) {
+		entry.serverUrl = serverUrl
+	}
+	writeAuthEntry(serverName, entry)
+}
+
+/**
+ * Remove auth entry for a server.
+ * Also removes the server directory if empty.
+ */
+export function removeAuthEntry(serverName: string): void {
+	try {
+		const filePath = getTokensFilePath(serverName)
+		if (existsSync(filePath)) {
+			writeFileSync(filePath, "{}", { mode: 0o600 })
+		}
+		// Try to remove the directory
+		const dir = getServerDir(serverName)
+		if (existsSync(dir)) {
+			try {
+				rmSync(dir, { recursive: true })
+			} catch {
+				// Directory may not be empty, ignore
+			}
+		}
+	} catch (error) {
+		console.error(`Failed to remove auth entry for ${serverName}:`, error)
+	}
+}
+
+/**
+ * Update tokens for a server.
+ */
+export function updateTokens(serverName: string, tokens: StoredTokens, serverUrl?: string): void {
+	const entry = getAuthEntry(serverName) ?? {}
+	entry.tokens = tokens
+	saveAuthEntry(serverName, entry, serverUrl)
+}
+
+/**
+ * Update client info for a server.
+ */
+export function updateClientInfo(serverName: string, clientInfo: StoredClientInfo, serverUrl?: string): void {
+	const entry = getAuthEntry(serverName) ?? {}
+	entry.clientInfo = clientInfo
+	saveAuthEntry(serverName, entry, serverUrl)
+}
+
+/**
+ * Update code verifier for a server.
+ */
+export function updateCodeVerifier(serverName: string, codeVerifier: string): void {
+	const entry = getAuthEntry(serverName) ?? {}
+	entry.codeVerifier = codeVerifier
+	saveAuthEntry(serverName, entry)
+}
+
+/**
+ * Clear code verifier for a server.
+ */
+export function clearCodeVerifier(serverName: string): void {
+	const entry = getAuthEntry(serverName)
+	if (entry) {
+		delete entry.codeVerifier
+		saveAuthEntry(serverName, entry)
+	}
+}
+
+/**
+ * Update OAuth state for a server.
+ */
+export function updateOAuthState(serverName: string, state: string): void {
+	const entry = getAuthEntry(serverName) ?? {}
+	entry.oauthState = state
+	saveAuthEntry(serverName, entry)
+}
+
+/**
+ * Get OAuth state for a server.
+ */
+export function getOAuthState(serverName: string): string | undefined {
+	const entry = getAuthEntry(serverName)
+	return entry?.oauthState
+}
+
+/**
+ * Clear OAuth state for a server.
+ */
+export function clearOAuthState(serverName: string): void {
+	const entry = getAuthEntry(serverName)
+	if (entry) {
+		delete entry.oauthState
+		saveAuthEntry(serverName, entry)
+	}
+}
+
+/**
+ * Check if stored tokens are expired.
+ * Returns null if no tokens exist, false if no expiry or not expired, true if expired.
+ */
+export function isTokenExpired(serverName: string): boolean | null {
+	const entry = getAuthEntry(serverName)
+	if (!entry?.tokens) return null
+	if (!entry.tokens.expiresAt) return false
+	return entry.tokens.expiresAt < Date.now() / 1000
+}
+
+/**
+ * Check if a server has stored tokens.
+ */
+export function hasStoredTokens(serverName: string): boolean {
+	const entry = getAuthEntry(serverName)
+	return !!entry?.tokens
+}
+
+/**
+ * Clear all credentials for a server.
+ */
+export function clearAllCredentials(serverName: string): void {
+	removeAuthEntry(serverName)
+}
+
+/**
+ * Clear only client info for a server.
+ */
+export function clearClientInfo(serverName: string): void {
+	const entry = getAuthEntry(serverName)
+	if (entry) {
+		delete entry.clientInfo
+		saveAuthEntry(serverName, entry)
+	}
+}
+
+/**
+ * Clear only tokens for a server.
+ */
+export function clearTokens(serverName: string): void {
+	const entry = getAuthEntry(serverName)
+	if (entry) {
+		delete entry.tokens
+		saveAuthEntry(serverName, entry)
+	}
+}

--- a/src/extensions/mcp-adapter/mcp-callback-server.ts
+++ b/src/extensions/mcp-adapter/mcp-callback-server.ts
@@ -1,0 +1,284 @@
+/**
+ * MCP OAuth Callback Server
+ *
+ * HTTP server that handles OAuth callbacks from the authorization server.
+ * Uses Node.js http module for compatibility.
+ */
+
+import { type IncomingMessage, type Server, type ServerResponse, createServer } from "http"
+import {
+	OAUTH_CALLBACK_PATH,
+	getConfiguredOAuthCallbackPort,
+	getOAuthCallbackPort,
+	setOAuthCallbackPort,
+} from "./mcp-oauth-provider.js"
+
+// HTML templates for callback responses
+const HTML_SUCCESS = `<!DOCTYPE html>
+<html>
+<head>
+  <title>Pi - Authorization Successful</title>
+  <style>
+    body { font-family: system-ui, -apple-system, sans-serif; display: flex; justify-content: center; align-items: center; height: 100vh; margin: 0; background: #1a1a2e; color: #eee; }
+    .container { text-align: center; padding: 2rem; }
+    h1 { color: #4ade80; margin-bottom: 1rem; }
+    p { color: #aaa; }
+  </style>
+</head>
+<body>
+  <div class="container">
+    <h1>Authorization Successful</h1>
+    <p>You can close this window and return to Pi.</p>
+  </div>
+  <script>setTimeout(() => window.close(), 2000);</script>
+</body>
+</html>`
+
+const HTML_ERROR = (error: string) => `<!DOCTYPE html>
+<html>
+<head>
+  <title>Pi - Authorization Failed</title>
+  <style>
+    body { font-family: system-ui, -apple-system, sans-serif; display: flex; justify-content: center; align-items: center; height: 100vh; margin: 0; background: #1a1a2e; color: #eee; }
+    .container { text-align: center; padding: 2rem; }
+    h1 { color: #f87171; margin-bottom: 1rem; }
+    p { color: #aaa; }
+    .error { color: #fca5a5; font-family: monospace; margin-top: 1rem; padding: 1rem; background: rgba(248,113,113,0.1); border-radius: 0.5rem; }
+  </style>
+</head>
+<body>
+  <div class="container">
+    <h1>Authorization Failed</h1>
+    <p>An error occurred during authorization.</p>
+    <div class="error">${error}</div>
+  </div>
+</body>
+</html>`
+
+/** Pending authorization request */
+interface PendingAuth {
+	resolve: (code: string) => void
+	reject: (error: Error) => void
+	timeout: ReturnType<typeof setTimeout>
+}
+
+/** Server singleton state */
+let server: Server | undefined
+const pendingAuths = new Map<string, PendingAuth>()
+
+/** Timeout for callback completion (5 minutes) */
+const CALLBACK_TIMEOUT_MS = 5 * 60 * 1000
+
+const MAX_PORT_SCAN_ATTEMPTS = 25
+
+interface EnsureCallbackServerOptions {
+	strictPort?: boolean
+}
+
+/**
+ * Handle incoming HTTP requests to the callback server.
+ */
+function handleRequest(req: IncomingMessage, res: ServerResponse): void {
+	const url = new URL(req.url || "/", `http://${req.headers.host}`)
+
+	// Only handle the callback path
+	if (url.pathname !== OAUTH_CALLBACK_PATH) {
+		res.writeHead(404, { "Content-Type": "text/plain" })
+		res.end("Not found")
+		return
+	}
+
+	const code = url.searchParams.get("code")
+	const state = url.searchParams.get("state")
+	const error = url.searchParams.get("error")
+	const errorDescription = url.searchParams.get("error_description")
+
+	// Enforce state parameter presence for CSRF protection
+	if (!state) {
+		const errorMsg = "Missing required state parameter - potential CSRF attack"
+		res.writeHead(400, { "Content-Type": "text/html" })
+		res.end(HTML_ERROR(errorMsg))
+		return
+	}
+
+	// Handle OAuth errors
+	if (error) {
+		const errorMsg = errorDescription || error
+		// Send HTTP response first before rejecting promise
+		res.writeHead(200, { "Content-Type": "text/html" })
+		res.end(HTML_ERROR(errorMsg))
+		// Reject promise after response is sent (defer to allow test to attach handler)
+		if (pendingAuths.has(state)) {
+			const pending = pendingAuths.get(state)!
+			clearTimeout(pending.timeout)
+			pendingAuths.delete(state)
+			setTimeout(() => pending.reject(new Error(errorMsg)), 0)
+		}
+		return
+	}
+
+	// Require authorization code
+	if (!code) {
+		res.writeHead(400, { "Content-Type": "text/html" })
+		res.end(HTML_ERROR("No authorization code provided"))
+		return
+	}
+
+	// Validate state parameter
+	if (!pendingAuths.has(state)) {
+		const errorMsg = "Invalid or expired state parameter - potential CSRF attack"
+		res.writeHead(400, { "Content-Type": "text/html" })
+		res.end(HTML_ERROR(errorMsg))
+		return
+	}
+
+	const pending = pendingAuths.get(state)!
+
+	// Clear timeout and resolve the pending promise
+	clearTimeout(pending.timeout)
+	pendingAuths.delete(state)
+	pending.resolve(code)
+
+	res.writeHead(200, { "Content-Type": "text/html" })
+	res.end(HTML_SUCCESS)
+}
+
+/**
+ * Ensure the callback server is running.
+ * If strictPort is true, requires binding on the configured callback port.
+ * If strictPort is false, scans forward for an available local port.
+ */
+export async function ensureCallbackServer(options: EnsureCallbackServerOptions = {}): Promise<void> {
+	const configuredPort = getConfiguredOAuthCallbackPort()
+	const strictPort = options.strictPort === true
+
+	if (server) {
+		if (!strictPort || getOAuthCallbackPort() === configuredPort) return
+
+		if (pendingAuths.size > 0) {
+			throw new Error(
+				`OAuth callback server is running on port ${getOAuthCallbackPort()}, but strict callback port ${configuredPort} is required and cannot be switched while authorizations are pending`,
+			)
+		}
+
+		await stopCallbackServer()
+	}
+
+	const preferredPort = configuredPort
+	const maxAttempts = strictPort ? 1 : MAX_PORT_SCAN_ATTEMPTS
+	let lastError: Error | undefined
+
+	for (let offset = 0; offset < maxAttempts; offset++) {
+		const candidatePort = preferredPort + offset
+		const candidateServer = createServer(handleRequest)
+
+		try {
+			await new Promise<void>((resolve, reject) => {
+				candidateServer.once("error", (err) => {
+					reject(err)
+				})
+
+				candidateServer.listen(candidatePort, "127.0.0.1", () => {
+					resolve()
+				})
+			})
+
+			server = candidateServer
+			server.unref()
+			setOAuthCallbackPort(candidatePort)
+			return
+		} catch (error) {
+			const nodeError = error as NodeJS.ErrnoException
+			await new Promise<void>((resolve) => {
+				candidateServer.close(() => resolve())
+			})
+
+			if (nodeError.code !== "EADDRINUSE") {
+				throw error
+			}
+
+			lastError = error instanceof Error ? error : new Error(String(error))
+		}
+	}
+
+	if (strictPort) {
+		throw new Error(
+			`OAuth callback port ${preferredPort} is already in use. Pre-registered OAuth clients require an exact redirect URI; set MCP_OAUTH_CALLBACK_PORT to your registered port or free port ${preferredPort}`,
+			{ cause: lastError },
+		)
+	}
+
+	throw new Error(
+		`OAuth callback port ${preferredPort} is already in use and no free port was found in range ${preferredPort}-${preferredPort + MAX_PORT_SCAN_ATTEMPTS - 1}`,
+		{ cause: lastError },
+	)
+}
+
+/**
+ * Wait for a callback with the given OAuth state.
+ * Returns a promise that resolves with the authorization code.
+ */
+export function waitForCallback(oauthState: string): Promise<string> {
+	return new Promise((resolve, reject) => {
+		const timeout = setTimeout(() => {
+			if (pendingAuths.has(oauthState)) {
+				pendingAuths.delete(oauthState)
+				reject(new Error("OAuth callback timeout - authorization took too long"))
+			}
+		}, CALLBACK_TIMEOUT_MS)
+
+		pendingAuths.set(oauthState, { resolve, reject, timeout })
+	})
+}
+
+/**
+ * Cancel a pending authorization by state.
+ */
+export function cancelPendingCallback(oauthState: string): void {
+	const pending = pendingAuths.get(oauthState)
+	if (pending) {
+		clearTimeout(pending.timeout)
+		pendingAuths.delete(oauthState)
+		pending.reject(new Error("Authorization cancelled"))
+	}
+}
+
+/**
+ * Stop the callback server and reject all pending authorizations.
+ */
+export async function stopCallbackServer(): Promise<void> {
+	if (server) {
+		await new Promise<void>((resolve) => {
+			server!.close(() => {
+				resolve()
+			})
+		})
+		server = undefined
+	}
+
+	setOAuthCallbackPort(getConfiguredOAuthCallbackPort())
+
+	// Reject all pending auths (defer to allow any pending operations to complete)
+	const pendingList = Array.from(pendingAuths.entries())
+	pendingAuths.clear()
+	setTimeout(() => {
+		for (const [, pending] of pendingList) {
+			clearTimeout(pending.timeout)
+			pending.reject(new Error("OAuth callback server stopped"))
+		}
+	}, 0)
+}
+
+/**
+ * Check if the callback server is running.
+ */
+export function isCallbackServerRunning(): boolean {
+	return server !== undefined
+}
+
+/**
+ * Get the number of pending authorizations.
+ */
+export function getPendingAuthCount(): number {
+	return pendingAuths.size
+}

--- a/src/extensions/mcp-adapter/mcp-oauth-provider.ts
+++ b/src/extensions/mcp-adapter/mcp-oauth-provider.ts
@@ -1,0 +1,288 @@
+/**
+ * MCP OAuth Provider
+ *
+ * Implementation of the MCP SDK's OAuthClientProvider interface.
+ * Handles OAuth client registration, token storage, and authorization redirection.
+ */
+
+import type { OAuthClientProvider } from "@modelcontextprotocol/sdk/client/auth.js"
+import type {
+	OAuthClientInformation,
+	OAuthClientInformationFull,
+	OAuthClientMetadata,
+	OAuthTokens,
+} from "@modelcontextprotocol/sdk/shared/auth.js"
+import {
+	type StoredClientInfo,
+	type StoredTokens,
+	clearAllCredentials,
+	clearClientInfo,
+	clearTokens,
+	getAuthEntry,
+	getAuthForUrl,
+	updateClientInfo,
+	updateCodeVerifier,
+	updateOAuthState,
+	updateTokens,
+} from "./mcp-auth.js"
+
+// Callback server configuration
+const DEFAULT_OAUTH_CALLBACK_PORT = 19876
+const OAUTH_CALLBACK_PATH = "/mcp/oauth/callback"
+
+let configuredOAuthCallbackPort = DEFAULT_OAUTH_CALLBACK_PORT
+
+if (process.env.MCP_OAUTH_CALLBACK_PORT) {
+	const parsedPort = Number.parseInt(process.env.MCP_OAUTH_CALLBACK_PORT, 10)
+	if (Number.isInteger(parsedPort) && parsedPort > 0 && parsedPort <= 65535) {
+		configuredOAuthCallbackPort = parsedPort
+	}
+}
+
+let oauthCallbackPort = configuredOAuthCallbackPort
+
+export function getConfiguredOAuthCallbackPort(): number {
+	return configuredOAuthCallbackPort
+}
+
+export function getOAuthCallbackPort(): number {
+	return oauthCallbackPort
+}
+
+export function setOAuthCallbackPort(port: number): void {
+	oauthCallbackPort = port
+}
+
+/** Configuration options for OAuth */
+export interface McpOAuthConfig {
+	grantType?: "authorization_code" | "client_credentials"
+	clientId?: string
+	clientSecret?: string
+	scope?: string
+}
+
+/** Callbacks for OAuth flow interactions */
+export interface McpOAuthCallbacks {
+	onRedirect: (url: URL) => void | Promise<void>
+}
+
+/**
+ * OAuth provider implementation for MCP servers.
+ * Implements the OAuthClientProvider interface from the MCP SDK.
+ */
+export class McpOAuthProvider implements OAuthClientProvider {
+	constructor(
+		private serverName: string,
+		private serverUrl: string,
+		private config: McpOAuthConfig,
+		private callbacks: McpOAuthCallbacks,
+	) {}
+
+	private get usesClientCredentials(): boolean {
+		return this.config.grantType === "client_credentials"
+	}
+
+	/**
+	 * The redirect URL for OAuth callbacks.
+	 * This must match the redirect_uri in client metadata.
+	 */
+	get redirectUrl(): string | undefined {
+		if (this.usesClientCredentials) return undefined
+		return `http://127.0.0.1:${getOAuthCallbackPort()}${OAUTH_CALLBACK_PATH}`
+	}
+
+	/**
+	 * Client metadata for dynamic registration.
+	 * Describes this client to the OAuth authorization server.
+	 */
+	get clientMetadata(): OAuthClientMetadata {
+		if (this.usesClientCredentials) {
+			return {
+				client_name: "Pi Coding Agent",
+				redirect_uris: [],
+				grant_types: ["client_credentials"],
+				token_endpoint_auth_method: this.config.clientSecret ? "client_secret_post" : "none",
+			}
+		}
+
+		const redirectUrl = this.redirectUrl
+		if (!redirectUrl) {
+			throw new Error("redirectUrl is required for authorization_code flow")
+		}
+
+		return {
+			redirect_uris: [redirectUrl],
+			client_name: "Pi Coding Agent",
+			client_uri: "https://github.com/nicobailon/pi-mcp-adapter",
+			grant_types: ["authorization_code", "refresh_token"],
+			response_types: ["code"],
+			token_endpoint_auth_method: this.config.clientSecret ? "client_secret_post" : "none",
+		}
+	}
+
+	/**
+	 * Get client information (for pre-registered or dynamically registered clients).
+	 * Returns undefined if no client info exists or if the server URL has changed.
+	 */
+	async clientInformation(): Promise<OAuthClientInformation | undefined> {
+		// Check config first (pre-registered client)
+		if (this.config.clientId) {
+			return {
+				client_id: this.config.clientId,
+				client_secret: this.config.clientSecret,
+			}
+		}
+
+		// Check stored client info (from dynamic registration)
+		// Use getAuthForUrl to validate credentials are for the current server URL
+		const entry = await getAuthForUrl(this.serverName, this.serverUrl)
+		if (entry?.clientInfo) {
+			// Check if client secret has expired
+			if (entry.clientInfo.clientSecretExpiresAt && entry.clientInfo.clientSecretExpiresAt < Date.now() / 1000) {
+				return undefined
+			}
+			return {
+				client_id: entry.clientInfo.clientId,
+				client_secret: entry.clientInfo.clientSecret,
+			}
+		}
+
+		// No client info or URL changed - will trigger dynamic registration
+		return undefined
+	}
+
+	/**
+	 * Save client information from dynamic registration.
+	 */
+	async saveClientInformation(info: OAuthClientInformationFull): Promise<void> {
+		const clientInfo: StoredClientInfo = {
+			clientId: info.client_id,
+			clientSecret: info.client_secret,
+			clientIdIssuedAt: info.client_id_issued_at,
+			clientSecretExpiresAt: info.client_secret_expires_at,
+		}
+		updateClientInfo(this.serverName, clientInfo, this.serverUrl)
+	}
+
+	/**
+	 * Get stored OAuth tokens.
+	 * Returns undefined if no tokens exist or if the server URL has changed.
+	 */
+	async tokens(): Promise<OAuthTokens | undefined> {
+		// Use getAuthForUrl to validate tokens are for the current server URL
+		const entry = await getAuthForUrl(this.serverName, this.serverUrl)
+		if (!entry?.tokens) return undefined
+
+		return {
+			access_token: entry.tokens.accessToken,
+			token_type: "Bearer",
+			refresh_token: entry.tokens.refreshToken,
+			expires_in: entry.tokens.expiresAt
+				? Math.max(0, Math.floor(entry.tokens.expiresAt - Date.now() / 1000))
+				: undefined,
+			scope: entry.tokens.scope,
+		}
+	}
+
+	/**
+	 * Save OAuth tokens.
+	 */
+	async saveTokens(tokens: OAuthTokens): Promise<void> {
+		const storedTokens: StoredTokens = {
+			accessToken: tokens.access_token,
+			refreshToken: tokens.refresh_token,
+			expiresAt: tokens.expires_in ? Date.now() / 1000 + tokens.expires_in : undefined,
+			scope: tokens.scope,
+		}
+		updateTokens(this.serverName, storedTokens, this.serverUrl)
+	}
+
+	/**
+	 * Redirect the user to the authorization URL.
+	 * This opens the browser for the user to authenticate.
+	 */
+	async redirectToAuthorization(authorizationUrl: URL): Promise<void> {
+		if (this.usesClientCredentials) {
+			throw new Error("redirectToAuthorization is not used for client_credentials flow")
+		}
+		// URL is passed to callback, not logged (may contain sensitive params)
+		await this.callbacks.onRedirect(authorizationUrl)
+	}
+
+	/**
+	 * Save the PKCE code verifier.
+	 */
+	async saveCodeVerifier(codeVerifier: string): Promise<void> {
+		updateCodeVerifier(this.serverName, codeVerifier)
+	}
+
+	/**
+	 * Get the stored PKCE code verifier.
+	 * @throws Error if no code verifier is stored
+	 */
+	async codeVerifier(): Promise<string> {
+		if (this.usesClientCredentials) {
+			throw new Error("codeVerifier is not used for client_credentials flow")
+		}
+		const entry = await getAuthEntry(this.serverName)
+		if (!entry?.codeVerifier) {
+			throw new Error(`No code verifier saved for MCP server: ${this.serverName}`)
+		}
+		return entry.codeVerifier
+	}
+
+	/**
+	 * Save the OAuth state parameter for CSRF protection.
+	 */
+	async saveState(state: string): Promise<void> {
+		updateOAuthState(this.serverName, state)
+	}
+
+	/**
+	 * Get the stored OAuth state parameter.
+	 * @throws Error if no state is stored
+	 */
+	async state(): Promise<string> {
+		if (this.usesClientCredentials) {
+			throw new Error("state is not used for client_credentials flow")
+		}
+		const entry = await getAuthEntry(this.serverName)
+		if (!entry?.oauthState) {
+			throw new Error(`No OAuth state saved for MCP server: ${this.serverName}`)
+		}
+		return entry.oauthState
+	}
+
+	/**
+	 * Invalidate credentials when authentication fails.
+	 * Clears tokens, client info, or all credentials based on the type.
+	 */
+	async invalidateCredentials(type: "all" | "client" | "tokens"): Promise<void> {
+		switch (type) {
+			case "all":
+				clearAllCredentials(this.serverName)
+				break
+			case "client":
+				clearClientInfo(this.serverName)
+				break
+			case "tokens":
+				clearTokens(this.serverName)
+				break
+		}
+	}
+
+	prepareTokenRequest(scope?: string): URLSearchParams | undefined {
+		if (!this.usesClientCredentials) {
+			return undefined
+		}
+
+		const params = new URLSearchParams({ grant_type: "client_credentials" })
+		const requestedScope = scope ?? this.config.scope
+		if (requestedScope) {
+			params.set("scope", requestedScope)
+		}
+		return params
+	}
+}
+
+export { DEFAULT_OAUTH_CALLBACK_PORT, OAUTH_CALLBACK_PATH }

--- a/src/extensions/mcp-adapter/mcp-panel.ts
+++ b/src/extensions/mcp-adapter/mcp-panel.ts
@@ -1,0 +1,751 @@
+import { matchesKey, truncateToWidth, visibleWidth } from "@mariozechner/pi-tui"
+import type { CachedTool, MetadataCache, ServerCacheEntry } from "./metadata-cache.js"
+import { resourceNameToToolName } from "./resource-tools.js"
+import { isToolExcluded } from "./types.js"
+import type { McpConfig, McpPanelCallbacks, McpPanelResult, ServerProvenance } from "./types.js"
+
+interface PanelTheme {
+	border: string
+	title: string
+	selected: string
+	direct: string
+	needsAuth: string
+	placeholder: string
+	description: string
+	hint: string
+	confirm: string
+	cancel: string
+}
+
+const DEFAULT_THEME: PanelTheme = {
+	border: "2",
+	title: "2",
+	selected: "36",
+	direct: "32",
+	needsAuth: "33",
+	placeholder: "2;3",
+	description: "2",
+	hint: "2",
+	confirm: "32",
+	cancel: "31",
+}
+
+function fg(code: string, text: string): string {
+	if (!code) return text
+	return `\x1b[${code}m${text}\x1b[0m`
+}
+
+const RAINBOW_COLORS = [
+	"38;2;178;129;214",
+	"38;2;215;135;175",
+	"38;2;254;188;56",
+	"38;2;228;192;15",
+	"38;2;137;210;129",
+	"38;2;0;175;175",
+	"38;2;23;143;185",
+]
+
+function rainbowProgress(filled: number, total: number): string {
+	const dots: string[] = []
+	for (let i = 0; i < total; i++) {
+		const color = RAINBOW_COLORS[i % RAINBOW_COLORS.length]
+		dots.push(fg(color, i < filled ? "●" : "○"))
+	}
+	return dots.join(" ")
+}
+
+function fuzzyScore(query: string, text: string): number {
+	const lq = query.toLowerCase()
+	const lt = text.toLowerCase()
+	if (lt.includes(lq)) return 100 + (lq.length / lt.length) * 50
+	let score = 0
+	let qi = 0
+	let consecutive = 0
+	for (let i = 0; i < lt.length && qi < lq.length; i++) {
+		if (lt[i] === lq[qi]) {
+			score += 10 + consecutive
+			consecutive += 5
+			qi++
+		} else {
+			consecutive = 0
+		}
+	}
+	return qi === lq.length ? score : 0
+}
+
+function estimateTokens(tool: CachedTool): number {
+	const schemaLen = JSON.stringify(tool.inputSchema ?? {}).length
+	const descLen = tool.description?.length ?? 0
+	return Math.ceil((tool.name.length + descLen + schemaLen) / 4) + 10
+}
+
+type ConnectionStatus = "connected" | "idle" | "failed" | "needs-auth" | "connecting"
+
+interface ToolState {
+	name: string
+	description: string
+	isDirect: boolean
+	wasDirect: boolean
+	estimatedTokens: number
+}
+
+interface ServerState {
+	name: string
+	expanded: boolean
+	source: "user" | "project" | "import"
+	importKind?: string
+	excludeTools?: string[]
+	exposeResources: boolean
+	connectionStatus: ConnectionStatus
+	tools: ToolState[]
+	hasCachedData: boolean
+}
+
+interface VisibleItem {
+	type: "server" | "tool"
+	serverIndex: number
+	toolIndex?: number
+}
+
+class McpPanel {
+	private prefix: "server" | "none" | "short"
+	private servers: ServerState[] = []
+	private cursorIndex = 0
+	private nameQuery = ""
+	private descSearchActive = false
+	private descQuery = ""
+	private dirty = false
+	private confirmingDiscard = false
+	private discardSelected = 1
+	private importNotice: string | null = null
+	private authNotice: string | null = null
+	private inactivityTimeout: ReturnType<typeof setTimeout> | null = null
+	private visibleItems: VisibleItem[] = []
+	private tui: { requestRender(): void }
+	private t = DEFAULT_THEME
+
+	private static readonly MAX_VISIBLE = 12
+	private static readonly INACTIVITY_MS = 60_000
+
+	constructor(
+		config: McpConfig,
+		cache: MetadataCache | null,
+		provenance: Map<string, ServerProvenance>,
+		private callbacks: McpPanelCallbacks,
+		tui: { requestRender(): void },
+		private done: (result: McpPanelResult) => void,
+	) {
+		this.tui = tui
+		this.prefix = config.settings?.toolPrefix ?? "server"
+
+		for (const [serverName, definition] of Object.entries(config.mcpServers)) {
+			const prov = provenance.get(serverName)
+			const serverCache = cache?.servers?.[serverName]
+
+			const globalDirect = config.settings?.directTools
+			let toolFilter: true | string[] | false = false
+			if (definition.directTools !== undefined) {
+				toolFilter = definition.directTools
+			} else if (globalDirect) {
+				toolFilter = globalDirect
+			}
+
+			const tools: ToolState[] = []
+			if (serverCache) {
+				for (const tool of serverCache.tools ?? []) {
+					if (isToolExcluded(tool.name, serverName, this.prefix, definition.excludeTools)) {
+						continue
+					}
+
+					const isDirect = toolFilter === true || (Array.isArray(toolFilter) && toolFilter.includes(tool.name))
+					tools.push({
+						name: tool.name,
+						description: tool.description ?? "",
+						isDirect,
+						wasDirect: isDirect,
+						estimatedTokens: estimateTokens(tool),
+					})
+				}
+				if (definition.exposeResources !== false) {
+					for (const resource of serverCache.resources ?? []) {
+						const baseName = `get_${resourceNameToToolName(resource.name)}`
+						if (isToolExcluded(baseName, serverName, this.prefix, definition.excludeTools)) {
+							continue
+						}
+
+						const isDirect = toolFilter === true || (Array.isArray(toolFilter) && toolFilter.includes(baseName))
+						const ct: CachedTool = { name: baseName, description: resource.description }
+						tools.push({
+							name: baseName,
+							description: resource.description ?? `Read resource: ${resource.uri}`,
+							isDirect,
+							wasDirect: isDirect,
+							estimatedTokens: estimateTokens(ct),
+						})
+					}
+				}
+			}
+
+			const status = callbacks.getConnectionStatus(serverName)
+
+			this.servers.push({
+				name: serverName,
+				expanded: false,
+				source: prov?.kind ?? "user",
+				importKind: prov?.importKind,
+				excludeTools: definition.excludeTools,
+				exposeResources: definition.exposeResources !== false,
+				connectionStatus: status,
+				tools,
+				hasCachedData: !!serverCache,
+			})
+		}
+
+		this.rebuildVisibleItems()
+		this.resetInactivityTimeout()
+	}
+
+	private resetInactivityTimeout(): void {
+		if (this.inactivityTimeout) clearTimeout(this.inactivityTimeout)
+		this.inactivityTimeout = setTimeout(() => {
+			this.cleanup()
+			this.done({ cancelled: true, changes: new Map() })
+		}, McpPanel.INACTIVITY_MS)
+	}
+
+	private cleanup(): void {
+		if (this.inactivityTimeout) {
+			clearTimeout(this.inactivityTimeout)
+			this.inactivityTimeout = null
+		}
+	}
+
+	private rebuildVisibleItems(): void {
+		const query = this.descSearchActive ? this.descQuery : this.nameQuery
+		const mode = this.descSearchActive ? "desc" : "name"
+
+		this.visibleItems = []
+		for (let si = 0; si < this.servers.length; si++) {
+			const server = this.servers[si]
+			this.visibleItems.push({ type: "server", serverIndex: si })
+			if (server.expanded || query) {
+				for (let ti = 0; ti < server.tools.length; ti++) {
+					const tool = server.tools[ti]
+					if (query) {
+						const score =
+							mode === "name"
+								? Math.max(fuzzyScore(query, tool.name), fuzzyScore(query, server.name) * 0.6)
+								: fuzzyScore(query, tool.description)
+						if (score === 0) continue
+					}
+					this.visibleItems.push({ type: "tool", serverIndex: si, toolIndex: ti })
+				}
+			}
+		}
+
+		if (query) {
+			this.visibleItems = this.visibleItems.filter((item) => {
+				if (item.type === "server") {
+					return this.visibleItems.some((other) => other.type === "tool" && other.serverIndex === item.serverIndex)
+				}
+				return true
+			})
+		}
+	}
+
+	private updateDirty(): void {
+		this.dirty = this.servers.some((s) => s.tools.some((t) => t.isDirect !== t.wasDirect))
+	}
+
+	private buildResult(): McpPanelResult {
+		const changes = new Map<string, true | string[] | false>()
+		for (const server of this.servers) {
+			const changed = server.tools.some((t) => t.isDirect !== t.wasDirect)
+			if (!changed) continue
+			const directTools = server.tools.filter((t) => t.isDirect)
+			if (directTools.length === server.tools.length && server.tools.length > 0) {
+				changes.set(server.name, true)
+			} else if (directTools.length === 0) {
+				changes.set(server.name, false)
+			} else {
+				changes.set(
+					server.name,
+					directTools.map((t) => t.name),
+				)
+			}
+		}
+		return { changes, cancelled: false }
+	}
+
+	handleInput(data: string): void {
+		this.resetInactivityTimeout()
+		this.importNotice = null
+		this.authNotice = null
+
+		if (this.confirmingDiscard) {
+			this.handleDiscardInput(data)
+			return
+		}
+
+		// Global shortcuts — always work, even during desc search
+		if (matchesKey(data, "ctrl+c")) {
+			this.cleanup()
+			this.done({ cancelled: true, changes: new Map() })
+			return
+		}
+
+		if (matchesKey(data, "ctrl+s")) {
+			this.cleanup()
+			this.done(this.buildResult())
+			return
+		}
+
+		// Modal description search mode
+		if (this.descSearchActive) {
+			if (matchesKey(data, "escape") || matchesKey(data, "return")) {
+				this.descSearchActive = false
+				this.descQuery = ""
+				this.rebuildVisibleItems()
+				this.cursorIndex = Math.min(this.cursorIndex, Math.max(0, this.visibleItems.length - 1))
+				return
+			}
+			if (matchesKey(data, "backspace")) {
+				if (this.descQuery.length > 0) {
+					this.descQuery = this.descQuery.slice(0, -1)
+					this.rebuildVisibleItems()
+					this.cursorIndex = Math.min(this.cursorIndex, Math.max(0, this.visibleItems.length - 1))
+				}
+				return
+			}
+			if (matchesKey(data, "up")) {
+				this.moveCursor(-1)
+				return
+			}
+			if (matchesKey(data, "down")) {
+				this.moveCursor(1)
+				return
+			}
+			if (matchesKey(data, "space")) {
+				// Toggle even while in desc search
+				const item = this.visibleItems[this.cursorIndex]
+				if (item) this.toggleItem(item)
+				return
+			}
+			if (data.length === 1 && data.charCodeAt(0) >= 32) {
+				this.descQuery += data
+				this.rebuildVisibleItems()
+				this.cursorIndex = Math.min(this.cursorIndex, Math.max(0, this.visibleItems.length - 1))
+				return
+			}
+			return
+		}
+
+		if (matchesKey(data, "escape")) {
+			if (this.nameQuery) {
+				this.nameQuery = ""
+				this.rebuildVisibleItems()
+				this.cursorIndex = Math.min(this.cursorIndex, Math.max(0, this.visibleItems.length - 1))
+				return
+			}
+			if (this.dirty) {
+				this.confirmingDiscard = true
+				this.discardSelected = 1
+				return
+			}
+			this.cleanup()
+			this.done({ cancelled: true, changes: new Map() })
+			return
+		}
+
+		if (matchesKey(data, "up")) {
+			this.moveCursor(-1)
+			return
+		}
+		if (matchesKey(data, "down")) {
+			this.moveCursor(1)
+			return
+		}
+
+		if (matchesKey(data, "space")) {
+			const item = this.visibleItems[this.cursorIndex]
+			if (item) this.toggleItem(item)
+			return
+		}
+
+		if (matchesKey(data, "return")) {
+			const item = this.visibleItems[this.cursorIndex]
+			if (!item) return
+			const server = this.servers[item.serverIndex]
+			if (item.type === "server") {
+				if (server.connectionStatus === "needs-auth") {
+					this.authNotice = `OAuth required — run /mcp-auth ${server.name} after closing this panel`
+					return
+				}
+				server.expanded = !server.expanded
+				this.rebuildVisibleItems()
+				this.cursorIndex = Math.min(this.cursorIndex, Math.max(0, this.visibleItems.length - 1))
+			} else if (item.toolIndex !== undefined) {
+				const tool = server.tools[item.toolIndex]
+				tool.isDirect = !tool.isDirect
+				if (tool.isDirect && server.source === "import") {
+					this.importNotice = `Imported from ${server.importKind ?? "external"} — will copy to user config on save`
+				}
+				this.updateDirty()
+			}
+			return
+		}
+
+		if (matchesKey(data, "ctrl+r")) {
+			const item = this.visibleItems[this.cursorIndex]
+			if (!item) return
+			const server = this.servers[item.serverIndex]
+			if (server.connectionStatus === "connecting") return
+			server.connectionStatus = "connecting"
+			this.callbacks
+				.reconnect(server.name)
+				.then(() => {
+					server.connectionStatus = this.callbacks.getConnectionStatus(server.name)
+					if (server.connectionStatus === "connected") {
+						const entry = this.callbacks.refreshCacheAfterReconnect(server.name)
+						if (entry) {
+							this.rebuildServerTools(server, entry)
+						}
+						server.hasCachedData = true
+					}
+					this.tui.requestRender()
+				})
+				.catch((error) => {
+					server.connectionStatus = "failed"
+					const message = error instanceof Error ? error.message : String(error)
+					this.authNotice = `Reconnect failed for ${server.name}: ${message}`
+					this.tui.requestRender()
+				})
+			return
+		}
+
+		if (data === "?") {
+			this.descSearchActive = true
+			this.descQuery = ""
+			this.rebuildVisibleItems()
+			this.cursorIndex = Math.min(this.cursorIndex, Math.max(0, this.visibleItems.length - 1))
+			return
+		}
+
+		// Backspace removes from name query
+		if (matchesKey(data, "backspace")) {
+			if (this.nameQuery.length > 0) {
+				this.nameQuery = this.nameQuery.slice(0, -1)
+				this.rebuildVisibleItems()
+				this.cursorIndex = Math.min(this.cursorIndex, Math.max(0, this.visibleItems.length - 1))
+			}
+			return
+		}
+
+		// All other printable chars → always-on name search
+		if (data.length === 1 && data.charCodeAt(0) >= 32) {
+			this.nameQuery += data
+			this.rebuildVisibleItems()
+			this.cursorIndex = Math.min(this.cursorIndex, Math.max(0, this.visibleItems.length - 1))
+			return
+		}
+	}
+
+	private toggleItem(item: VisibleItem): void {
+		const server = this.servers[item.serverIndex]
+		if (item.type === "server") {
+			const newState = !server.tools.every((t) => t.isDirect)
+			if (server.source === "import" && newState) {
+				this.importNotice = `Imported from ${server.importKind ?? "external"} — will copy to user config on save`
+			}
+			for (const t of server.tools) t.isDirect = newState
+		} else if (item.toolIndex !== undefined) {
+			const tool = server.tools[item.toolIndex]
+			tool.isDirect = !tool.isDirect
+			if (tool.isDirect && server.source === "import") {
+				this.importNotice = `Imported from ${server.importKind ?? "external"} — will copy to user config on save`
+			}
+		}
+		this.updateDirty()
+	}
+
+	private handleDiscardInput(data: string): void {
+		if (matchesKey(data, "ctrl+c")) {
+			this.cleanup()
+			this.done({ cancelled: true, changes: new Map() })
+			return
+		}
+		if (matchesKey(data, "escape") || data === "n" || data === "N") {
+			this.confirmingDiscard = false
+			return
+		}
+		if (matchesKey(data, "return")) {
+			if (this.discardSelected === 0) {
+				this.cleanup()
+				this.done({ cancelled: true, changes: new Map() })
+			} else {
+				this.confirmingDiscard = false
+			}
+			return
+		}
+		if (data === "y" || data === "Y") {
+			this.cleanup()
+			this.done({ cancelled: true, changes: new Map() })
+			return
+		}
+		if (matchesKey(data, "left") || matchesKey(data, "right") || matchesKey(data, "tab")) {
+			this.discardSelected = this.discardSelected === 0 ? 1 : 0
+		}
+	}
+
+	private moveCursor(delta: number): void {
+		if (this.visibleItems.length === 0) return
+		this.cursorIndex = Math.max(0, Math.min(this.visibleItems.length - 1, this.cursorIndex + delta))
+	}
+
+	private rebuildServerTools(server: ServerState, entry: ServerCacheEntry): void {
+		const existingState = new Map<string, boolean>()
+		for (const t of server.tools) existingState.set(t.name, t.isDirect)
+
+		const newTools: ToolState[] = []
+		for (const tool of entry.tools ?? []) {
+			if (isToolExcluded(tool.name, server.name, this.prefix, server.excludeTools)) {
+				continue
+			}
+
+			const prev = existingState.get(tool.name)
+			const isDirect = prev !== undefined ? prev : false
+			newTools.push({
+				name: tool.name,
+				description: tool.description ?? "",
+				isDirect,
+				wasDirect: prev !== undefined ? (server.tools.find((t) => t.name === tool.name)?.wasDirect ?? false) : false,
+				estimatedTokens: estimateTokens(tool),
+			})
+		}
+
+		if (server.exposeResources) {
+			for (const resource of entry.resources ?? []) {
+				const baseName = `get_${resourceNameToToolName(resource.name)}`
+				if (isToolExcluded(baseName, server.name, this.prefix, server.excludeTools)) {
+					continue
+				}
+
+				const prev = existingState.get(baseName)
+				const isDirect = prev !== undefined ? prev : false
+				const ct: CachedTool = { name: baseName, description: resource.description }
+				newTools.push({
+					name: baseName,
+					description: resource.description ?? `Read resource: ${resource.uri}`,
+					isDirect,
+					wasDirect: prev !== undefined ? (server.tools.find((t) => t.name === baseName)?.wasDirect ?? false) : false,
+					estimatedTokens: estimateTokens(ct),
+				})
+			}
+		}
+
+		server.tools = newTools
+		this.rebuildVisibleItems()
+		this.updateDirty()
+	}
+
+	render(width: number): string[] {
+		const innerW = width - 2
+		const lines: string[] = []
+		const t = this.t
+		const bold = (s: string) => `\x1b[1m${s}\x1b[22m`
+		const italic = (s: string) => `\x1b[3m${s}\x1b[23m`
+		const inverse = (s: string) => `\x1b[7m${s}\x1b[27m`
+
+		const row = (content: string) =>
+			fg(t.border, "│") + truncateToWidth(" " + content, innerW, "…", true) + fg(t.border, "│")
+		const emptyRow = () => fg(t.border, "│") + " ".repeat(innerW) + fg(t.border, "│")
+		const divider = () => fg(t.border, "├" + "─".repeat(innerW) + "┤")
+
+		const titleText = " MCP Servers "
+		const borderLen = innerW - visibleWidth(titleText)
+		const leftB = Math.floor(borderLen / 2)
+		const rightB = borderLen - leftB
+		lines.push(fg(t.border, "╭" + "─".repeat(leftB)) + fg(t.title, titleText) + fg(t.border, "─".repeat(rightB) + "╮"))
+
+		lines.push(emptyRow())
+
+		const cursor = fg(t.selected, "│")
+		const searchIcon = fg(t.border, "◎")
+		if (this.descSearchActive) {
+			lines.push(row(`${searchIcon}  ${fg(t.needsAuth, "desc:")} ${this.descQuery}${cursor}`))
+		} else if (this.nameQuery) {
+			lines.push(row(`${searchIcon}  ${this.nameQuery}${cursor}`))
+		} else {
+			lines.push(row(`${searchIcon}  ${fg(t.placeholder, italic("search..."))}`))
+		}
+
+		lines.push(emptyRow())
+		lines.push(divider())
+
+		if (this.servers.length === 0) {
+			lines.push(emptyRow())
+			lines.push(row(fg(t.hint, italic("No MCP servers configured."))))
+			lines.push(emptyRow())
+		} else {
+			const maxVis = McpPanel.MAX_VISIBLE
+			const total = this.visibleItems.length
+			const startIdx = Math.max(0, Math.min(this.cursorIndex - Math.floor(maxVis / 2), total - maxVis))
+			const endIdx = Math.min(startIdx + maxVis, total)
+
+			lines.push(emptyRow())
+
+			for (let i = startIdx; i < endIdx; i++) {
+				const item = this.visibleItems[i]
+				const isCursor = i === this.cursorIndex
+				const server = this.servers[item.serverIndex]
+
+				if (item.type === "server") {
+					lines.push(row(this.renderServerRow(server, isCursor)))
+				} else if (item.toolIndex !== undefined) {
+					lines.push(row(this.renderToolRow(server.tools[item.toolIndex], isCursor, innerW)))
+				}
+			}
+
+			lines.push(emptyRow())
+
+			if (total > maxVis) {
+				const prog = Math.round(((this.cursorIndex + 1) / total) * 10)
+				lines.push(row(`${rainbowProgress(prog, 10)}  ${fg(t.hint, `${this.cursorIndex + 1}/${total}`)}`))
+				lines.push(emptyRow())
+			}
+
+			if (this.importNotice) {
+				lines.push(row(fg(t.needsAuth, italic(this.importNotice))))
+				lines.push(emptyRow())
+			}
+			if (this.authNotice) {
+				lines.push(row(fg(t.needsAuth, italic(this.authNotice))))
+				lines.push(emptyRow())
+			}
+		}
+
+		lines.push(divider())
+		lines.push(emptyRow())
+
+		if (this.confirmingDiscard) {
+			const discardBtn =
+				this.discardSelected === 0 ? inverse(bold(fg(t.cancel, "  Discard  "))) : fg(t.hint, "  Discard  ")
+			const keepBtn = this.discardSelected === 1 ? inverse(bold(fg(t.confirm, "  Keep  "))) : fg(t.hint, "  Keep  ")
+			lines.push(row(`Discard unsaved changes?  ${discardBtn}   ${keepBtn}`))
+		} else {
+			const directCount = this.servers.reduce((sum, s) => sum + s.tools.filter((t) => t.isDirect).length, 0)
+			const totalTokens = this.servers.reduce(
+				(sum, s) => sum + s.tools.filter((t) => t.isDirect).reduce((ts, t) => ts + t.estimatedTokens, 0),
+				0,
+			)
+			const stats =
+				directCount > 0 ? `${directCount} direct  ~${totalTokens.toLocaleString()} tokens` : "no direct tools"
+			lines.push(row(fg(t.description, stats + (this.dirty ? fg(t.needsAuth, "  (unsaved)") : ""))))
+		}
+
+		lines.push(emptyRow())
+		const hints = [
+			italic("↑↓") + " navigate",
+			italic("space") + " toggle",
+			italic("⏎") + " expand",
+			italic("ctrl+r") + " reconnect",
+			italic("?") + " desc search",
+			italic("ctrl+s") + " save",
+			italic("esc") + " clear/close",
+			italic("ctrl+c") + " quit",
+		]
+		const gap = "  "
+		const gapW = 2
+		const maxW = innerW - 2
+		let curLine = ""
+		let curW = 0
+		for (const hint of hints) {
+			const hw = visibleWidth(hint)
+			const needed = curW === 0 ? hw : gapW + hw
+			if (curW > 0 && curW + needed > maxW) {
+				lines.push(row(fg(t.hint, curLine)))
+				curLine = hint
+				curW = hw
+			} else {
+				curLine += (curW > 0 ? gap : "") + hint
+				curW += needed
+			}
+		}
+		if (curLine) lines.push(row(fg(t.hint, curLine)))
+
+		lines.push(fg(t.border, "╰" + "─".repeat(innerW) + "╯"))
+
+		return lines
+	}
+
+	private renderServerRow(server: ServerState, isCursor: boolean): string {
+		const t = this.t
+		const bold = (s: string) => `\x1b[1m${s}\x1b[22m`
+
+		const expandIcon = server.expanded ? "▾" : "▸"
+		const prefix = isCursor ? fg(t.selected, expandIcon) : fg(t.border, server.expanded ? expandIcon : "·")
+
+		const nameStr = isCursor ? bold(fg(t.selected, server.name)) : server.name
+		const importLabel = server.source === "import" ? fg(t.description, ` (${server.importKind ?? "import"})`) : ""
+
+		if (!server.hasCachedData) {
+			return `${prefix}   ${nameStr}${importLabel}  ${fg(t.description, "(not cached)")}`
+		}
+
+		const directCount = server.tools.filter((t) => t.isDirect).length
+		const totalCount = server.tools.length
+		let toggleIcon = fg(t.description, "○")
+		if (directCount === totalCount && totalCount > 0) {
+			toggleIcon = fg(t.direct, "●")
+		} else if (directCount > 0) {
+			toggleIcon = fg(t.needsAuth, "◐")
+		}
+
+		let toolInfo = ""
+		if (totalCount > 0) {
+			toolInfo = `${directCount}/${totalCount}`
+			if (directCount > 0) {
+				const tokens = server.tools.filter((t) => t.isDirect).reduce((s, t) => s + t.estimatedTokens, 0)
+				toolInfo += `  ~${tokens.toLocaleString()}`
+			}
+			toolInfo = fg(t.description, toolInfo)
+		}
+
+		return `${prefix} ${toggleIcon} ${nameStr}${importLabel}  ${toolInfo}`
+	}
+
+	private renderToolRow(tool: ToolState, isCursor: boolean, innerW: number): string {
+		const t = this.t
+		const bold = (s: string) => `\x1b[1m${s}\x1b[22m`
+
+		const toggleIcon = tool.isDirect ? fg(t.direct, "●") : fg(t.description, "○")
+		const cursor = isCursor ? fg(t.selected, "▸") : " "
+		const nameStr = isCursor ? bold(fg(t.selected, tool.name)) : tool.name
+
+		const prefixLen = 7 + visibleWidth(tool.name)
+		const maxDescLen = Math.max(0, innerW - prefixLen - 8)
+		const descStr =
+			maxDescLen > 5 && tool.description
+				? fg(t.description, "— " + truncateToWidth(tool.description, maxDescLen, "…"))
+				: ""
+
+		return `  ${cursor} ${toggleIcon} ${nameStr} ${descStr}`
+	}
+
+	invalidate(): void {}
+
+	dispose(): void {
+		this.cleanup()
+	}
+}
+
+export function createMcpPanel(
+	config: McpConfig,
+	cache: MetadataCache | null,
+	provenance: Map<string, ServerProvenance>,
+	callbacks: McpPanelCallbacks,
+	tui: { requestRender(): void },
+	done: (result: McpPanelResult) => void,
+): McpPanel & { dispose(): void } {
+	return new McpPanel(config, cache, provenance, callbacks, tui, done)
+}

--- a/src/extensions/mcp-adapter/metadata-cache.ts
+++ b/src/extensions/mcp-adapter/metadata-cache.ts
@@ -10,7 +10,10 @@ import { extractToolUiStreamMode, getAgentDir } from "./utils.js"
 
 const CACHE_VERSION = 1
 const CACHE_MAX_AGE_MS = 7 * 24 * 60 * 60 * 1000
-const CACHE_PATH = join(getAgentDir(), "mcp-cache.json")
+let _cachePath: string | undefined
+function getCachePath(): string {
+	return (_cachePath ??= join(getAgentDir(), "mcp-cache.json"))
+}
 
 export interface CachedTool {
 	name: string
@@ -39,13 +42,13 @@ export interface MetadataCache {
 }
 
 export function getMetadataCachePath(): string {
-	return CACHE_PATH
+	return getCachePath()
 }
 
 export function loadMetadataCache(): MetadataCache | null {
-	if (!existsSync(CACHE_PATH)) return null
+	if (!existsSync(getCachePath())) return null
 	try {
-		const raw = JSON.parse(readFileSync(CACHE_PATH, "utf-8"))
+		const raw = JSON.parse(readFileSync(getCachePath(), "utf-8"))
 		if (!raw || typeof raw !== "object") return null
 		if (raw.version !== CACHE_VERSION) return null
 		if (!raw.servers || typeof raw.servers !== "object") return null
@@ -56,13 +59,13 @@ export function loadMetadataCache(): MetadataCache | null {
 }
 
 export function saveMetadataCache(cache: MetadataCache): void {
-	const dir = dirname(CACHE_PATH)
+	const dir = dirname(getCachePath())
 	mkdirSync(dir, { recursive: true })
 
 	const merged: MetadataCache = { version: CACHE_VERSION, servers: {} }
 	try {
-		if (existsSync(CACHE_PATH)) {
-			const existing = JSON.parse(readFileSync(CACHE_PATH, "utf-8")) as MetadataCache
+		if (existsSync(getCachePath())) {
+			const existing = JSON.parse(readFileSync(getCachePath(), "utf-8")) as MetadataCache
 			if (existing && existing.version === CACHE_VERSION && existing.servers) {
 				merged.servers = { ...existing.servers }
 			}
@@ -74,9 +77,9 @@ export function saveMetadataCache(cache: MetadataCache): void {
 	merged.version = CACHE_VERSION
 	merged.servers = { ...merged.servers, ...cache.servers }
 
-	const tmpPath = `${CACHE_PATH}.${process.pid}.tmp`
+	const tmpPath = `${getCachePath()}.${process.pid}.tmp`
 	writeFileSync(tmpPath, JSON.stringify(merged, null, 2), "utf-8")
-	renameSync(tmpPath, CACHE_PATH)
+	renameSync(tmpPath, getCachePath())
 }
 
 export function computeServerHash(definition: ServerEntry): string {

--- a/src/extensions/mcp-adapter/metadata-cache.ts
+++ b/src/extensions/mcp-adapter/metadata-cache.ts
@@ -1,17 +1,16 @@
 import { createHash } from "node:crypto"
 // metadata-cache.ts - Persistent MCP metadata cache
 import { existsSync, mkdirSync, readFileSync, renameSync, writeFileSync } from "node:fs"
-import { homedir } from "node:os"
 import { dirname, join } from "node:path"
 import { getToolUiResourceUri } from "@modelcontextprotocol/ext-apps/app-bridge"
 import { resourceNameToToolName } from "./resource-tools.js"
 import type { McpResource, McpTool, ServerEntry, ToolMetadata } from "./types.js"
 import { formatToolName, isToolExcluded } from "./types.js"
-import { extractToolUiStreamMode } from "./utils.js"
+import { extractToolUiStreamMode, getAgentDir } from "./utils.js"
 
 const CACHE_VERSION = 1
 const CACHE_MAX_AGE_MS = 7 * 24 * 60 * 60 * 1000
-const CACHE_PATH = join(homedir(), ".pi", "agent", "mcp-cache.json")
+const CACHE_PATH = join(getAgentDir(), "mcp-cache.json")
 
 export interface CachedTool {
 	name: string

--- a/src/extensions/mcp-adapter/metadata-cache.ts
+++ b/src/extensions/mcp-adapter/metadata-cache.ts
@@ -1,0 +1,200 @@
+import { createHash } from "node:crypto"
+// metadata-cache.ts - Persistent MCP metadata cache
+import { existsSync, mkdirSync, readFileSync, renameSync, writeFileSync } from "node:fs"
+import { homedir } from "node:os"
+import { dirname, join } from "node:path"
+import { getToolUiResourceUri } from "@modelcontextprotocol/ext-apps/app-bridge"
+import { resourceNameToToolName } from "./resource-tools.js"
+import type { McpResource, McpTool, ServerEntry, ToolMetadata } from "./types.js"
+import { formatToolName, isToolExcluded } from "./types.js"
+import { extractToolUiStreamMode } from "./utils.js"
+
+const CACHE_VERSION = 1
+const CACHE_MAX_AGE_MS = 7 * 24 * 60 * 60 * 1000
+const CACHE_PATH = join(homedir(), ".pi", "agent", "mcp-cache.json")
+
+export interface CachedTool {
+	name: string
+	description?: string
+	inputSchema?: unknown
+	uiResourceUri?: string
+	uiStreamMode?: "eager" | "stream-first"
+}
+
+export interface CachedResource {
+	uri: string
+	name: string
+	description?: string
+}
+
+export interface ServerCacheEntry {
+	configHash: string
+	tools: CachedTool[]
+	resources: CachedResource[]
+	cachedAt: number
+}
+
+export interface MetadataCache {
+	version: number
+	servers: Record<string, ServerCacheEntry>
+}
+
+export function getMetadataCachePath(): string {
+	return CACHE_PATH
+}
+
+export function loadMetadataCache(): MetadataCache | null {
+	if (!existsSync(CACHE_PATH)) return null
+	try {
+		const raw = JSON.parse(readFileSync(CACHE_PATH, "utf-8"))
+		if (!raw || typeof raw !== "object") return null
+		if (raw.version !== CACHE_VERSION) return null
+		if (!raw.servers || typeof raw.servers !== "object") return null
+		return raw as MetadataCache
+	} catch {
+		return null
+	}
+}
+
+export function saveMetadataCache(cache: MetadataCache): void {
+	const dir = dirname(CACHE_PATH)
+	mkdirSync(dir, { recursive: true })
+
+	const merged: MetadataCache = { version: CACHE_VERSION, servers: {} }
+	try {
+		if (existsSync(CACHE_PATH)) {
+			const existing = JSON.parse(readFileSync(CACHE_PATH, "utf-8")) as MetadataCache
+			if (existing && existing.version === CACHE_VERSION && existing.servers) {
+				merged.servers = { ...existing.servers }
+			}
+		}
+	} catch {
+		// Ignore parse errors and proceed with empty cache
+	}
+
+	merged.version = CACHE_VERSION
+	merged.servers = { ...merged.servers, ...cache.servers }
+
+	const tmpPath = `${CACHE_PATH}.${process.pid}.tmp`
+	writeFileSync(tmpPath, JSON.stringify(merged, null, 2), "utf-8")
+	renameSync(tmpPath, CACHE_PATH)
+}
+
+export function computeServerHash(definition: ServerEntry): string {
+	// Hash only fields that affect server identity and tool/resource output.
+	// Exclude lifecycle, idleTimeout, debug — those are runtime behavior settings
+	// that don't change which tools a server exposes.
+	const identity: Record<string, unknown> = {
+		command: definition.command,
+		args: definition.args,
+		env: definition.env,
+		cwd: definition.cwd,
+		url: definition.url,
+		headers: definition.headers,
+		auth: definition.auth,
+		bearerToken: definition.bearerToken,
+		bearerTokenEnv: definition.bearerTokenEnv,
+		exposeResources: definition.exposeResources,
+		excludeTools: definition.excludeTools,
+	}
+	const normalized = stableStringify(identity)
+	return createHash("sha256").update(normalized).digest("hex")
+}
+
+export function isServerCacheValid(
+	entry: ServerCacheEntry,
+	definition: ServerEntry,
+	maxAgeMs: number = CACHE_MAX_AGE_MS,
+): boolean {
+	if (!entry || entry.configHash !== computeServerHash(definition)) return false
+	if (!entry.cachedAt || typeof entry.cachedAt !== "number") return false
+	if (maxAgeMs > 0 && Date.now() - entry.cachedAt > maxAgeMs) return false
+	return true
+}
+
+export function reconstructToolMetadata(
+	serverName: string,
+	entry: ServerCacheEntry,
+	prefix: "server" | "none" | "short",
+	definition: Pick<ServerEntry, "exposeResources" | "excludeTools">,
+): ToolMetadata[] {
+	const metadata: ToolMetadata[] = []
+
+	for (const tool of entry.tools ?? []) {
+		if (!tool?.name) continue
+		if (isToolExcluded(tool.name, serverName, prefix, definition.excludeTools)) {
+			continue
+		}
+
+		metadata.push({
+			name: formatToolName(tool.name, serverName, prefix),
+			originalName: tool.name,
+			description: tool.description ?? "",
+			inputSchema: tool.inputSchema,
+			uiResourceUri: tool.uiResourceUri,
+			uiStreamMode: tool.uiStreamMode,
+		})
+	}
+
+	if (definition.exposeResources !== false) {
+		for (const resource of entry.resources ?? []) {
+			if (!resource?.name || !resource?.uri) continue
+			const baseName = `get_${resourceNameToToolName(resource.name)}`
+			if (isToolExcluded(baseName, serverName, prefix, definition.excludeTools)) {
+				continue
+			}
+
+			metadata.push({
+				name: formatToolName(baseName, serverName, prefix),
+				originalName: baseName,
+				description: resource.description ?? `Read resource: ${resource.uri}`,
+				resourceUri: resource.uri,
+			})
+		}
+	}
+
+	return metadata
+}
+
+export function serializeTools(tools: McpTool[]): CachedTool[] {
+	return tools
+		.filter((t) => t?.name)
+		.map((t) => ({
+			name: t.name,
+			description: t.description,
+			inputSchema: t.inputSchema,
+			uiResourceUri: tryGetToolUiResourceUri(t),
+			uiStreamMode: extractToolUiStreamMode(t._meta),
+		}))
+}
+
+export function serializeResources(resources: McpResource[]): CachedResource[] {
+	return resources
+		.filter((r) => r?.name && r?.uri)
+		.map((r) => ({
+			uri: r.uri,
+			name: r.name,
+			description: r.description,
+		}))
+}
+
+function stableStringify(value: unknown): string {
+	if (value === null || value === undefined || typeof value !== "object") {
+		const serialized = JSON.stringify(value)
+		return serialized === undefined ? "undefined" : serialized
+	}
+	if (Array.isArray(value)) {
+		return `[${value.map((v) => stableStringify(v)).join(",")}]`
+	}
+	const obj = value as Record<string, unknown>
+	const keys = Object.keys(obj).sort()
+	return `{${keys.map((k) => `${JSON.stringify(k)}:${stableStringify(obj[k])}`).join(",")}}`
+}
+
+function tryGetToolUiResourceUri(tool: McpTool): string | undefined {
+	try {
+		return getToolUiResourceUri({ _meta: tool._meta })
+	} catch {
+		return undefined
+	}
+}

--- a/src/extensions/mcp-adapter/npx-resolver.ts
+++ b/src/extensions/mcp-adapter/npx-resolver.ts
@@ -18,7 +18,10 @@ import { getAgentDir } from "./utils.js"
 
 const CACHE_VERSION = 1
 const CACHE_TTL_MS = 24 * 60 * 60 * 1000
-const CACHE_PATH = join(getAgentDir(), "mcp-npx-cache.json")
+let _cachePath: string | undefined
+function getCachePath(): string {
+	return (_cachePath ??= join(getAgentDir(), "mcp-npx-cache.json"))
+}
 
 interface NpxCacheEntry {
 	resolvedBin: string
@@ -375,9 +378,9 @@ function getNpmCacheDir(): string | null {
 }
 
 function loadCache(): NpxCache | null {
-	if (!existsSync(CACHE_PATH)) return null
+	if (!existsSync(getCachePath())) return null
 	try {
-		const raw = JSON.parse(readFileSync(CACHE_PATH, "utf-8"))
+		const raw = JSON.parse(readFileSync(getCachePath(), "utf-8"))
 		if (!raw || typeof raw !== "object") return null
 		if (raw.version !== CACHE_VERSION) return null
 		if (!raw.entries || typeof raw.entries !== "object") return null
@@ -388,13 +391,13 @@ function loadCache(): NpxCache | null {
 }
 
 function saveCacheEntry(key: string, entry: NpxCacheEntry): void {
-	const dir = dirname(CACHE_PATH)
+	const dir = dirname(getCachePath())
 	mkdirSync(dir, { recursive: true })
 
 	const merged: NpxCache = { version: CACHE_VERSION, entries: {} }
 	try {
-		if (existsSync(CACHE_PATH)) {
-			const existing = JSON.parse(readFileSync(CACHE_PATH, "utf-8")) as NpxCache
+		if (existsSync(getCachePath())) {
+			const existing = JSON.parse(readFileSync(getCachePath(), "utf-8")) as NpxCache
 			if (existing && existing.version === CACHE_VERSION && existing.entries) {
 				merged.entries = { ...existing.entries }
 			}
@@ -404,9 +407,9 @@ function saveCacheEntry(key: string, entry: NpxCacheEntry): void {
 	}
 
 	merged.entries[key] = entry
-	const tmpPath = `${CACHE_PATH}.${process.pid}.tmp`
+	const tmpPath = `${getCachePath()}.${process.pid}.tmp`
 	writeFileSync(tmpPath, JSON.stringify(merged, null, 2), "utf-8")
-	renameSync(tmpPath, CACHE_PATH)
+	renameSync(tmpPath, getCachePath())
 }
 
 function safeRealpath(path: string): string {

--- a/src/extensions/mcp-adapter/npx-resolver.ts
+++ b/src/extensions/mcp-adapter/npx-resolver.ts
@@ -1,0 +1,426 @@
+import { spawn, spawnSync } from "node:child_process"
+// npx-resolver.ts - Resolve npx/npm exec binaries to avoid npm parent processes
+import {
+	closeSync,
+	existsSync,
+	mkdirSync,
+	openSync,
+	readFileSync,
+	readSync,
+	readdirSync,
+	realpathSync,
+	renameSync,
+	statSync,
+	writeFileSync,
+} from "node:fs"
+import { homedir } from "node:os"
+import { dirname, extname, join, resolve, sep } from "node:path"
+
+const CACHE_VERSION = 1
+const CACHE_TTL_MS = 24 * 60 * 60 * 1000
+const CACHE_PATH = join(homedir(), ".pi", "agent", "mcp-npx-cache.json")
+
+interface NpxCacheEntry {
+	resolvedBin: string
+	resolvedAt: number
+	packageVersion?: string
+	isJs: boolean
+}
+
+interface NpxCache {
+	version: number
+	entries: Record<string, NpxCacheEntry>
+}
+
+export interface NpxResolution {
+	binPath: string
+	extraArgs: string[]
+	isJs: boolean
+}
+
+interface ParsedInvocation {
+	packageSpec: string
+	binName?: string
+	extraArgs: string[]
+}
+
+export async function resolveNpxBinary(command: string, args: string[]): Promise<NpxResolution | null> {
+	const parsed = command === "npx" ? parseNpxArgs(args) : command === "npm" ? parseNpmExecArgs(args) : null
+
+	if (!parsed) return null
+
+	const cacheKey = JSON.stringify([command, ...args])
+	const cache = loadCache()
+	const cached = cache?.entries?.[cacheKey]
+
+	if (cached && Date.now() - cached.resolvedAt < CACHE_TTL_MS && existsSync(cached.resolvedBin)) {
+		return { binPath: cached.resolvedBin, extraArgs: parsed.extraArgs, isJs: cached.isJs }
+	}
+
+	const resolved = resolveFromNpmCache(parsed.packageSpec, parsed.binName)
+	if (resolved) {
+		saveCacheEntry(cacheKey, resolved)
+		return { binPath: resolved.resolvedBin, extraArgs: parsed.extraArgs, isJs: resolved.isJs }
+	}
+
+	// Slow path: force npx cache population
+	await forceNpxCache(parsed.packageSpec)
+	const resolvedAfterInstall = resolveFromNpmCache(parsed.packageSpec, parsed.binName)
+	if (resolvedAfterInstall) {
+		saveCacheEntry(cacheKey, resolvedAfterInstall)
+		return { binPath: resolvedAfterInstall.resolvedBin, extraArgs: parsed.extraArgs, isJs: resolvedAfterInstall.isJs }
+	}
+
+	return null
+}
+
+function parseNpxArgs(args: string[]): ParsedInvocation | null {
+	const separatorIndex = args.indexOf("--")
+	const before = separatorIndex >= 0 ? args.slice(0, separatorIndex) : args
+	const after = separatorIndex >= 0 ? args.slice(separatorIndex + 1) : []
+
+	const positionals: string[] = []
+	let packageSpec: string | undefined
+	let sawPackageFlag = false
+	let foundFirstPositional = false
+
+	for (let i = 0; i < before.length; i++) {
+		const arg = before[i]
+		if (foundFirstPositional) {
+			positionals.push(arg)
+			continue
+		}
+		if (arg === "-y" || arg === "--yes") continue
+		if (arg === "-p" || arg === "--package") {
+			const value = before[i + 1]
+			if (!value || value.startsWith("-")) return null
+			if (!packageSpec) packageSpec = value
+			sawPackageFlag = true
+			i++
+			continue
+		}
+		if (arg.startsWith("--package=")) {
+			const value = arg.slice("--package=".length)
+			if (!value) return null
+			if (!packageSpec) packageSpec = value
+			sawPackageFlag = true
+			continue
+		}
+		if (arg.startsWith("-")) {
+			return null
+		}
+		positionals.push(arg)
+		foundFirstPositional = true
+	}
+
+	if (sawPackageFlag) {
+		const binName = positionals[0]
+		if (!packageSpec || !binName) return null
+		const extraArgs = positionals.slice(1).concat(after)
+		return { packageSpec, binName, extraArgs }
+	}
+
+	const packagePositional = positionals[0]
+	if (!packagePositional) return null
+	const extraArgs = positionals.slice(1).concat(after)
+	return { packageSpec: packagePositional, extraArgs }
+}
+
+function parseNpmExecArgs(args: string[]): ParsedInvocation | null {
+	if (args[0] !== "exec") return null
+	const execArgs = args.slice(1)
+	const separatorIndex = execArgs.indexOf("--")
+	if (separatorIndex < 0) return null
+
+	const before = execArgs.slice(0, separatorIndex)
+	const after = execArgs.slice(separatorIndex + 1)
+
+	let packageSpec: string | undefined
+	for (let i = 0; i < before.length; i++) {
+		const arg = before[i]
+		if (arg === "-y" || arg === "--yes") continue
+		if (arg === "--package") {
+			const value = before[i + 1]
+			if (!value || value.startsWith("-")) return null
+			if (!packageSpec) packageSpec = value
+			i++
+			continue
+		}
+		if (arg.startsWith("--package=")) {
+			const value = arg.slice("--package=".length)
+			if (!value) return null
+			if (!packageSpec) packageSpec = value
+			continue
+		}
+		if (arg.startsWith("-")) {
+			return null
+		}
+	}
+
+	const binName = after[0]
+	if (!packageSpec || !binName) return null
+	const extraArgs = after.slice(1)
+	return { packageSpec, binName, extraArgs }
+}
+
+function resolveFromNpmCache(packageSpec: string, binName?: string): NpxCacheEntry | null {
+	const cacheDir = getNpmCacheDir()
+	if (!cacheDir) return null
+
+	const packageName = extractPackageName(packageSpec)
+	if (!packageName) return null
+
+	const packageDir = findCachedPackageDir(cacheDir, packageName)
+	if (!packageDir) return null
+
+	const packageJsonPath = join(packageDir, "package.json")
+	if (!existsSync(packageJsonPath)) return null
+
+	let pkg: { bin?: string | Record<string, string>; version?: string } | null = null
+	try {
+		pkg = JSON.parse(readFileSync(packageJsonPath, "utf-8")) as {
+			bin?: string | Record<string, string>
+			version?: string
+		}
+	} catch {
+		return null
+	}
+
+	const binField = pkg?.bin
+	if (!binField) return null
+
+	const candidates = buildBinCandidates(packageName, binName)
+	let chosenBinName: string | undefined
+	let binRel: string | undefined
+
+	if (typeof binField === "string") {
+		chosenBinName = defaultBinName(packageName)
+		binRel = binField
+	} else {
+		for (const candidate of candidates) {
+			if (binField[candidate]) {
+				chosenBinName = candidate
+				binRel = binField[candidate]
+				break
+			}
+		}
+		if (!binRel) {
+			const firstEntry = Object.entries(binField)[0]
+			if (firstEntry) {
+				chosenBinName = firstEntry[0]
+				binRel = firstEntry[1]
+			}
+		}
+	}
+
+	if (!binRel) return null
+
+	const nodeModulesDir = findNodeModulesDir(packageDir)
+	const binLink = chosenBinName ? join(nodeModulesDir, ".bin", chosenBinName) : null
+	let resolvedBin = binLink && existsSync(binLink) ? safeRealpath(binLink) : ""
+	if (!resolvedBin) {
+		resolvedBin = resolve(packageDir, binRel)
+		if (!existsSync(resolvedBin)) return null
+	}
+
+	const isJs = detectJsBinary(resolvedBin)
+	return {
+		resolvedBin,
+		resolvedAt: Date.now(),
+		packageVersion: pkg?.version,
+		isJs,
+	}
+}
+
+const FORCE_CACHE_TIMEOUT_MS = 30_000
+
+async function forceNpxCache(packageSpec: string): Promise<void> {
+	try {
+		await new Promise<void>((resolve, reject) => {
+			const proc = spawn("npm", ["exec", "--yes", "--package", packageSpec, "--", "node", "-e", "1"], {
+				stdio: "ignore",
+			})
+			const timer = setTimeout(() => {
+				proc.kill()
+				reject(new Error("timeout"))
+			}, FORCE_CACHE_TIMEOUT_MS)
+			timer.unref()
+			proc.on("close", () => {
+				clearTimeout(timer)
+				resolve()
+			})
+			proc.on("error", (err) => {
+				clearTimeout(timer)
+				reject(err)
+			})
+		})
+	} catch {
+		// Ignore failures, resolution will fall back to original command
+	}
+}
+
+function buildBinCandidates(packageName: string, explicitBin?: string): string[] {
+	const candidates: string[] = []
+	if (explicitBin) candidates.push(explicitBin)
+
+	if (packageName.startsWith("@")) {
+		const namePart = packageName.split("/")[1] ?? ""
+		const scopePart = packageName.split("/")[0]?.replace("@", "") ?? ""
+		if (namePart) candidates.push(namePart)
+		if (scopePart && namePart) candidates.push(`${scopePart}-${namePart}`)
+	} else {
+		candidates.push(packageName)
+	}
+
+	return [...new Set(candidates.filter(Boolean))]
+}
+
+function extractPackageName(spec: string): string | null {
+	const trimmed = spec.trim()
+	if (!trimmed) return null
+	if (trimmed.startsWith("@")) {
+		const slashIndex = trimmed.indexOf("/")
+		if (slashIndex < 0) return null
+		const atIndex = trimmed.lastIndexOf("@")
+		if (atIndex > slashIndex) {
+			return trimmed.slice(0, atIndex)
+		}
+		return trimmed
+	}
+	const atIndex = trimmed.indexOf("@")
+	return atIndex >= 0 ? trimmed.slice(0, atIndex) : trimmed
+}
+
+function defaultBinName(packageName: string): string {
+	if (packageName.startsWith("@")) {
+		const parts = packageName.split("/")
+		return parts[1] ?? packageName.replace("@", "").replace("/", "-")
+	}
+	return packageName
+}
+
+function findCachedPackageDir(cacheDir: string, packageName: string): string | null {
+	const npxDir = join(cacheDir, "_npx")
+	if (!existsSync(npxDir)) return null
+
+	const packagePathParts = packageName.startsWith("@") ? packageName.split("/") : [packageName]
+
+	const candidates = readdirSync(npxDir, { withFileTypes: true })
+		.filter((entry) => entry.isDirectory())
+		.map((entry) => {
+			const full = join(npxDir, entry.name)
+			const mtime = safeStatMtime(full)
+			return { name: entry.name, mtime }
+		})
+		.sort((a, b) => b.mtime - a.mtime)
+
+	for (const entry of candidates) {
+		const pkgDir = join(npxDir, entry.name, "node_modules", ...packagePathParts)
+		if (existsSync(join(pkgDir, "package.json"))) {
+			return pkgDir
+		}
+	}
+
+	return null
+}
+
+function findNodeModulesDir(packageDir: string): string {
+	const parts = packageDir.split(sep)
+	const idx = parts.lastIndexOf("node_modules")
+	if (idx >= 0) {
+		return parts.slice(0, idx + 1).join(sep)
+	}
+	return join(packageDir, "..")
+}
+
+function detectJsBinary(binPath: string): boolean {
+	const ext = extname(binPath).toLowerCase()
+	if (ext === ".js" || ext === ".mjs" || ext === ".cjs") return true
+	try {
+		const fd = openSync(binPath, "r")
+		try {
+			const buf = Buffer.alloc(256)
+			readSync(fd, buf, 0, 256, 0)
+			const firstLine = buf.toString("utf-8").split("\n")[0] ?? ""
+			return firstLine.startsWith("#!") && firstLine.includes("node")
+		} finally {
+			closeSync(fd)
+		}
+	} catch {
+		return false
+	}
+}
+
+let npmCacheDirCached: string | null | undefined
+
+function getNpmCacheDir(): string | null {
+	if (npmCacheDirCached !== undefined) return npmCacheDirCached
+	if (process.env.NPM_CONFIG_CACHE) {
+		npmCacheDirCached = process.env.NPM_CONFIG_CACHE
+		return npmCacheDirCached
+	}
+	try {
+		const result = spawnSync("npm", ["config", "get", "cache"], { encoding: "utf-8" })
+		if (result.status === 0) {
+			const path = String(result.stdout).trim()
+			npmCacheDirCached = path || null
+			return npmCacheDirCached
+		}
+	} catch {
+		npmCacheDirCached = null
+		return null
+	}
+	npmCacheDirCached = null
+	return null
+}
+
+function loadCache(): NpxCache | null {
+	if (!existsSync(CACHE_PATH)) return null
+	try {
+		const raw = JSON.parse(readFileSync(CACHE_PATH, "utf-8"))
+		if (!raw || typeof raw !== "object") return null
+		if (raw.version !== CACHE_VERSION) return null
+		if (!raw.entries || typeof raw.entries !== "object") return null
+		return raw as NpxCache
+	} catch {
+		return null
+	}
+}
+
+function saveCacheEntry(key: string, entry: NpxCacheEntry): void {
+	const dir = dirname(CACHE_PATH)
+	mkdirSync(dir, { recursive: true })
+
+	const merged: NpxCache = { version: CACHE_VERSION, entries: {} }
+	try {
+		if (existsSync(CACHE_PATH)) {
+			const existing = JSON.parse(readFileSync(CACHE_PATH, "utf-8")) as NpxCache
+			if (existing && existing.version === CACHE_VERSION && existing.entries) {
+				merged.entries = { ...existing.entries }
+			}
+		}
+	} catch {
+		// Ignore parse errors
+	}
+
+	merged.entries[key] = entry
+	const tmpPath = `${CACHE_PATH}.${process.pid}.tmp`
+	writeFileSync(tmpPath, JSON.stringify(merged, null, 2), "utf-8")
+	renameSync(tmpPath, CACHE_PATH)
+}
+
+function safeRealpath(path: string): string {
+	try {
+		return realpathSync(path)
+	} catch {
+		return ""
+	}
+}
+
+function safeStatMtime(path: string): number {
+	try {
+		return statSync(path).mtimeMs
+	} catch {
+		return 0
+	}
+}

--- a/src/extensions/mcp-adapter/npx-resolver.ts
+++ b/src/extensions/mcp-adapter/npx-resolver.ts
@@ -13,12 +13,12 @@ import {
 	statSync,
 	writeFileSync,
 } from "node:fs"
-import { homedir } from "node:os"
 import { dirname, extname, join, resolve, sep } from "node:path"
+import { getAgentDir } from "./utils.js"
 
 const CACHE_VERSION = 1
 const CACHE_TTL_MS = 24 * 60 * 60 * 1000
-const CACHE_PATH = join(homedir(), ".pi", "agent", "mcp-npx-cache.json")
+const CACHE_PATH = join(getAgentDir(), "mcp-npx-cache.json")
 
 interface NpxCacheEntry {
 	resolvedBin: string

--- a/src/extensions/mcp-adapter/oauth-handler.ts
+++ b/src/extensions/mcp-adapter/oauth-handler.ts
@@ -1,0 +1,57 @@
+// oauth-handler.ts - OAuth token management for MCP servers
+import { existsSync, readFileSync } from "node:fs"
+import { homedir } from "node:os"
+import { join } from "node:path"
+import type { OAuthTokens } from "@modelcontextprotocol/sdk/shared/auth.js"
+
+// Token storage path for a server
+function getTokensPath(serverName: string): string {
+	return join(homedir(), ".pi", "agent", "mcp-oauth", serverName, "tokens.json")
+}
+
+/**
+ * Get stored OAuth tokens for a server (if any).
+ * Returns undefined if no tokens or tokens are expired.
+ *
+ * Token file location: ~/.pi/agent/mcp-oauth/<server>/tokens.json
+ *
+ * Expected format:
+ * {
+ *   "access_token": "...",
+ *   "token_type": "bearer",
+ *   "refresh_token": "...",  // optional
+ *   "expires_in": 3600,      // optional, seconds
+ *   "expiresAt": 1234567890  // optional, absolute timestamp ms
+ * }
+ */
+export function getStoredTokens(serverName: string): OAuthTokens | undefined {
+	const tokensPath = getTokensPath(serverName)
+
+	if (!existsSync(tokensPath)) return undefined
+
+	try {
+		const stored = JSON.parse(readFileSync(tokensPath, "utf-8"))
+
+		// Validate required field
+		if (!stored.access_token || typeof stored.access_token !== "string") {
+			return undefined
+		}
+
+		// Check expiration if expiresAt is set
+		if (stored.expiresAt && typeof stored.expiresAt === "number") {
+			if (Date.now() > stored.expiresAt) {
+				// Token expired
+				return undefined
+			}
+		}
+
+		return {
+			access_token: stored.access_token,
+			token_type: stored.token_type ?? "bearer",
+			refresh_token: stored.refresh_token,
+			expires_in: stored.expires_in,
+		}
+	} catch {
+		return undefined
+	}
+}

--- a/src/extensions/mcp-adapter/oauth-handler.ts
+++ b/src/extensions/mcp-adapter/oauth-handler.ts
@@ -1,12 +1,12 @@
 // oauth-handler.ts - OAuth token management for MCP servers
 import { existsSync, readFileSync } from "node:fs"
-import { homedir } from "node:os"
 import { join } from "node:path"
 import type { OAuthTokens } from "@modelcontextprotocol/sdk/shared/auth.js"
+import { getAgentDir } from "./utils.js"
 
 // Token storage path for a server
 function getTokensPath(serverName: string): string {
-	return join(homedir(), ".pi", "agent", "mcp-oauth", serverName, "tokens.json")
+	return join(getAgentDir(), "mcp-oauth", serverName, "tokens.json")
 }
 
 /**

--- a/src/extensions/mcp-adapter/proxy-modes.ts
+++ b/src/extensions/mcp-adapter/proxy-modes.ts
@@ -1,4 +1,5 @@
 import type { AgentToolResult, ToolInfo } from "@mariozechner/pi-coding-agent"
+import { truncateTail } from "@mariozechner/pi-coding-agent"
 import {
 	getFailureAgeSeconds,
 	lazyConnect,
@@ -16,6 +17,23 @@ import { type UiSessionRuntime, maybeStartUiSession } from "./ui-session.js"
 import { truncateAtWord } from "./utils.js"
 
 type ProxyToolResult = AgentToolResult<Record<string, unknown>>
+
+import type { ImageContent, TextContent } from "@mariozechner/pi-ai"
+
+type ContentBlock = TextContent | ImageContent
+
+function applyTruncation(content: ContentBlock[]): ContentBlock[] {
+	const textItems = content.filter((c): c is TextContent => c.type === "text")
+	if (textItems.length === 0) return content
+
+	const combined = textItems.map((c) => c.text).join("\n")
+	const result = truncateTail(combined)
+	if (!result.truncated) return content
+
+	const notice = `\n[Truncated: showing last ${result.outputLines} of ${result.totalLines} lines (${result.totalBytes.toLocaleString()} bytes total). Use mcp({ describe: "tool_name" }) to check parameters if needed.]`
+	const nonText = content.filter((c): c is ImageContent => c.type !== "text")
+	return [{ type: "text" as const, text: result.content + notice }, ...nonText]
+}
 
 type AutoAuthResult = { status: "skipped" } | { status: "success" } | { status: "failed"; message: string }
 
@@ -809,8 +827,9 @@ export async function executeCall(
 			}
 		}
 
+		const truncated = applyTruncation((content.length > 0 ? content : [{ type: "text" as const, text: "(empty result)" }]) as ContentBlock[])
 		return {
-			content: content.length > 0 ? content : [{ type: "text" as const, text: "(empty result)" }],
+			content: truncated,
 			details: { mode: "call", mcpResult: result, server: serverName, tool: toolMeta.originalName },
 		}
 	} catch (error) {

--- a/src/extensions/mcp-adapter/proxy-modes.ts
+++ b/src/extensions/mcp-adapter/proxy-modes.ts
@@ -1,0 +1,836 @@
+import type { AgentToolResult, ToolInfo } from "@mariozechner/pi-coding-agent"
+import {
+	getFailureAgeSeconds,
+	lazyConnect,
+	updateMetadataCache,
+	updateServerMetadata,
+	updateStatusBar,
+} from "./init.js"
+import { authenticate, supportsOAuth } from "./mcp-auth-flow.js"
+import type { McpExtensionState } from "./state.js"
+import { buildToolMetadata, findToolByName, formatSchema, getToolNames } from "./tool-metadata.js"
+import { transformMcpContent } from "./tool-registrar.js"
+import type { McpContent, ToolMetadata } from "./types.js"
+import { getServerPrefix, parseUiPromptHandoff } from "./types.js"
+import { type UiSessionRuntime, maybeStartUiSession } from "./ui-session.js"
+import { truncateAtWord } from "./utils.js"
+
+type ProxyToolResult = AgentToolResult<Record<string, unknown>>
+
+type AutoAuthResult = { status: "skipped" } | { status: "success" } | { status: "failed"; message: string }
+
+function getAuthRequiredMessage(serverName: string): string {
+	return `Server "${serverName}" requires OAuth authentication. Run /mcp-auth ${serverName} first.`
+}
+
+async function attemptAutoAuth(state: McpExtensionState, serverName: string): Promise<AutoAuthResult> {
+	if (state.config.settings?.autoAuth !== true) {
+		return { status: "skipped" }
+	}
+
+	const definition = state.config.mcpServers[serverName]
+	if (!definition || !supportsOAuth(definition) || !definition.url) {
+		return { status: "skipped" }
+	}
+
+	const grantType =
+		(definition.oauth && typeof definition.oauth === "object" && definition.oauth.grantType) || "authorization_code"
+	if (!state.ui && grantType !== "client_credentials") {
+		return {
+			status: "failed",
+			message: `Server "${serverName}" requires OAuth authentication. Run /mcp-auth ${serverName} in an interactive session.`,
+		}
+	}
+
+	try {
+		await authenticate(serverName, definition.url, definition)
+		return { status: "success" }
+	} catch (error) {
+		const message = error instanceof Error ? error.message : String(error)
+		return {
+			status: "failed",
+			message: `OAuth authentication failed for "${serverName}": ${message}. Run /mcp-auth ${serverName} first.`,
+		}
+	}
+}
+
+export function executeUiMessages(state: McpExtensionState): ProxyToolResult {
+	const sessions = state.completedUiSessions
+
+	if (sessions.length === 0) {
+		return {
+			content: [{ type: "text" as const, text: "No UI session messages available." }],
+			details: { sessions: 0 },
+		}
+	}
+
+	const output: string[] = []
+	output.push(`UI Session Messages (${sessions.length} session${sessions.length > 1 ? "s" : ""}):\n`)
+
+	const allPrompts: string[] = []
+	const allIntents = sessions.flatMap((session) => session.messages.intents)
+	const parsedHandoffs: Array<{ intent: string; params: Record<string, unknown>; raw: string }> = []
+
+	for (const session of sessions) {
+		const timestamp = session.completedAt.toLocaleTimeString()
+		output.push(`\n## ${session.serverName} / ${session.toolName} (${timestamp}, ${session.reason})`)
+
+		const plainPrompts: string[] = []
+		for (const prompt of session.messages.prompts) {
+			allPrompts.push(prompt)
+			const handoff = parseUiPromptHandoff(prompt)
+			if (handoff) {
+				parsedHandoffs.push(handoff)
+			} else {
+				plainPrompts.push(prompt)
+			}
+		}
+
+		if (plainPrompts.length > 0) {
+			output.push("\n### Prompts:")
+			for (const prompt of plainPrompts) {
+				output.push(`- ${prompt}`)
+			}
+		}
+
+		const intentsForSession = [
+			...session.messages.intents,
+			...session.messages.prompts
+				.map((prompt) => parseUiPromptHandoff(prompt))
+				.filter((handoff): handoff is NonNullable<typeof handoff> => !!handoff)
+				.map((handoff) => ({ intent: handoff.intent, params: handoff.params })),
+		]
+
+		if (intentsForSession.length > 0) {
+			output.push("\n### Intents:")
+			for (const intent of intentsForSession) {
+				const params = intent.params ? ` (${JSON.stringify(intent.params)})` : ""
+				output.push(`- ${intent.intent}${params}`)
+			}
+		}
+
+		if (session.messages.notifications.length > 0) {
+			output.push("\n### Notifications:")
+			for (const notification of session.messages.notifications) {
+				output.push(`- ${notification}`)
+			}
+		}
+	}
+
+	const count = sessions.length
+	state.completedUiSessions = []
+
+	return {
+		content: [{ type: "text" as const, text: output.join("\n") }],
+		details: {
+			sessions: count,
+			prompts: allPrompts,
+			intents: [...allIntents, ...parsedHandoffs.map(({ intent, params }) => ({ intent, params }))],
+			handoffs: parsedHandoffs,
+			cleared: true,
+		},
+	}
+}
+
+export function executeStatus(state: McpExtensionState): ProxyToolResult {
+	const servers: Array<{ name: string; status: string; toolCount: number; failedAgo: number | null }> = []
+
+	for (const name of Object.keys(state.config.mcpServers)) {
+		const connection = state.manager.getConnection(name)
+		const metadata = state.toolMetadata.get(name)
+		const toolCount = metadata?.length ?? 0
+		const failedAgo = getFailureAgeSeconds(state, name)
+		let status = "not connected"
+		if (connection?.status === "connected") {
+			status = "connected"
+		} else if (connection?.status === "needs-auth") {
+			status = "needs-auth"
+		} else if (failedAgo !== null) {
+			status = "failed"
+		} else if (metadata !== undefined) {
+			status = "cached"
+		}
+
+		servers.push({ name, status, toolCount, failedAgo })
+	}
+
+	const totalTools = servers.reduce((sum, s) => sum + s.toolCount, 0)
+	const connectedCount = servers.filter((s) => s.status === "connected").length
+
+	let text = `MCP: ${connectedCount}/${servers.length} servers, ${totalTools} tools\n\n`
+	for (const server of servers) {
+		if (server.status === "connected") {
+			text += `✓ ${server.name} (${server.toolCount} tools)\n`
+			continue
+		}
+		if (server.status === "needs-auth") {
+			text += `⚠ ${server.name} (needs auth)\n`
+			continue
+		}
+		if (server.status === "cached") {
+			text += `○ ${server.name} (${server.toolCount} tools, cached)\n`
+			continue
+		}
+		if (server.status === "failed") {
+			text += `✗ ${server.name} (failed ${server.failedAgo ?? 0}s ago)\n`
+			continue
+		}
+		text += `○ ${server.name} (not connected)\n`
+	}
+
+	if (servers.length > 0) {
+		text += `\nmcp({ server: "name" }) to list tools, mcp({ search: "..." }) to search`
+	}
+
+	return {
+		content: [{ type: "text" as const, text: text.trim() }],
+		details: { mode: "status", servers, totalTools, connectedCount },
+	}
+}
+
+export function executeDescribe(state: McpExtensionState, toolName: string): ProxyToolResult {
+	let serverName: string | undefined
+	let toolMeta: ToolMetadata | undefined
+
+	for (const [server, metadata] of state.toolMetadata.entries()) {
+		const found = findToolByName(metadata, toolName)
+		if (found) {
+			serverName = server
+			toolMeta = found
+			break
+		}
+	}
+
+	if (!serverName || !toolMeta) {
+		return {
+			content: [{ type: "text" as const, text: `Tool "${toolName}" not found. Use mcp({ search: "..." }) to search.` }],
+			details: { mode: "describe", error: "tool_not_found", requestedTool: toolName },
+		}
+	}
+
+	let text = `${toolMeta.name}\n`
+	text += `Server: ${serverName}\n`
+	if (toolMeta.resourceUri) {
+		text += `Type: Resource (reads from ${toolMeta.resourceUri})\n`
+	}
+	text += `\n${toolMeta.description || "(no description)"}\n`
+
+	if (toolMeta.inputSchema && !toolMeta.resourceUri) {
+		text += `\nParameters:\n${formatSchema(toolMeta.inputSchema)}`
+	} else if (toolMeta.resourceUri) {
+		text += `\nNo parameters required (resource tool).`
+	} else {
+		text += `\nNo parameters defined.`
+	}
+
+	return {
+		content: [{ type: "text" as const, text: text.trim() }],
+		details: { mode: "describe", tool: toolMeta, server: serverName },
+	}
+}
+
+export function executeSearch(
+	state: McpExtensionState,
+	query: string,
+	regex?: boolean,
+	server?: string,
+	includeSchemas?: boolean,
+	getPiTools?: () => ToolInfo[],
+): ProxyToolResult {
+	const showSchemas = includeSchemas !== false
+
+	const matches: Array<{ server: string; tool: ToolMetadata }> = []
+
+	let pattern: RegExp
+	try {
+		if (regex) {
+			pattern = new RegExp(query, "i")
+		} else {
+			const terms = query
+				.trim()
+				.split(/\s+/)
+				.filter((t) => t.length > 0)
+			if (terms.length === 0) {
+				return {
+					content: [{ type: "text" as const, text: "Search query cannot be empty" }],
+					details: { mode: "search", error: "empty_query" },
+				}
+			}
+			const escaped = terms.map((t) => t.replace(/[.*+?^${}()|[\]\\]/g, "\\$&"))
+			pattern = new RegExp(escaped.join("|"), "i")
+		}
+	} catch {
+		return {
+			content: [{ type: "text" as const, text: `Invalid regex: ${query}` }],
+			details: { mode: "search", error: "invalid_pattern", query },
+		}
+	}
+
+	const piMatches: Array<{ name: string; description: string }> = []
+	if (!server && getPiTools) {
+		const piTools = getPiTools()
+		for (const tool of piTools) {
+			if (tool.name === "mcp") continue
+
+			if (pattern.test(tool.name) || pattern.test(tool.description ?? "")) {
+				piMatches.push({
+					name: tool.name,
+					description: tool.description ?? "",
+				})
+			}
+		}
+	}
+
+	for (const [serverName, metadata] of state.toolMetadata.entries()) {
+		if (server && serverName !== server) continue
+		for (const tool of metadata) {
+			if (pattern.test(tool.name) || pattern.test(tool.description)) {
+				matches.push({
+					server: serverName,
+					tool,
+				})
+			}
+		}
+	}
+
+	const totalCount = piMatches.length + matches.length
+
+	if (totalCount === 0) {
+		const msg = server ? `No tools matching "${query}" in "${server}"` : `No tools matching "${query}"`
+		return {
+			content: [{ type: "text" as const, text: msg }],
+			details: { mode: "search", matches: [], count: 0, query },
+		}
+	}
+
+	let text = `Found ${totalCount} tool${totalCount === 1 ? "" : "s"} matching "${query}":\n\n`
+
+	for (const match of piMatches) {
+		if (showSchemas) {
+			text += `[pi tool] ${match.name}\n`
+			text += `  ${match.description || "(no description)"}\n`
+			text += `  No parameters (call directly).\n`
+			text += "\n"
+		} else {
+			text += `[pi tool] ${match.name}`
+			if (match.description) {
+				text += ` - ${truncateAtWord(match.description, 50)}`
+			}
+			text += "\n"
+		}
+	}
+
+	for (const match of matches) {
+		if (showSchemas) {
+			text += `${match.tool.name}\n`
+			text += `  ${match.tool.description || "(no description)"}\n`
+			if (match.tool.inputSchema && !match.tool.resourceUri) {
+				text += `\n  Parameters:\n${formatSchema(match.tool.inputSchema, "    ")}\n`
+			} else if (match.tool.resourceUri) {
+				text += `  No parameters (resource tool).\n`
+			}
+			text += "\n"
+		} else {
+			text += `- ${match.tool.name}`
+			if (match.tool.description) {
+				text += ` - ${truncateAtWord(match.tool.description, 50)}`
+			}
+			text += "\n"
+		}
+	}
+
+	return {
+		content: [{ type: "text" as const, text: text.trim() }],
+		details: {
+			mode: "search",
+			matches: [
+				...piMatches.map((m) => ({ server: "pi", tool: m.name })),
+				...matches.map((m) => ({ server: m.server, tool: m.tool.name })),
+			],
+			count: totalCount,
+			query,
+		},
+	}
+}
+
+export function executeList(state: McpExtensionState, server: string): ProxyToolResult {
+	if (!state.config.mcpServers[server]) {
+		return {
+			content: [{ type: "text" as const, text: `Server "${server}" not found. Use mcp({}) to see available servers.` }],
+			details: { mode: "list", server, tools: [], count: 0, error: "not_found" },
+		}
+	}
+
+	const metadata = state.toolMetadata.get(server)
+	const toolNames = metadata?.map((m) => m.name) ?? []
+	const connection = state.manager.getConnection(server)
+
+	if (toolNames.length === 0) {
+		if (connection?.status === "connected") {
+			return {
+				content: [{ type: "text" as const, text: `Server "${server}" has no tools.` }],
+				details: { mode: "list", server, tools: [], count: 0 },
+			}
+		}
+		if (metadata !== undefined) {
+			return {
+				content: [{ type: "text" as const, text: `Server "${server}" has no cached tools (not connected).` }],
+				details: { mode: "list", server, tools: [], count: 0, cached: true },
+			}
+		}
+		return {
+			content: [
+				{
+					type: "text" as const,
+					text: `Server "${server}" is configured but not connected. Use mcp({ connect: "${server}" }) or /mcp reconnect ${server} to retry.`,
+				},
+			],
+			details: { mode: "list", server, tools: [], count: 0, error: "not_connected" },
+		}
+	}
+
+	const cachedNote = connection?.status === "connected" ? "" : " (not connected, cached)"
+	let text = `${server} (${toolNames.length} tools${cachedNote}):\n\n`
+
+	const descMap = new Map<string, string>()
+	if (metadata) {
+		for (const m of metadata) {
+			descMap.set(m.name, m.description)
+		}
+	}
+
+	for (const tool of toolNames) {
+		const desc = descMap.get(tool) ?? ""
+		const truncated = truncateAtWord(desc, 50)
+		text += `- ${tool}`
+		if (truncated) text += ` - ${truncated}`
+		text += "\n"
+	}
+
+	return {
+		content: [{ type: "text" as const, text: text.trim() }],
+		details: { mode: "list", server, tools: toolNames, count: toolNames.length },
+	}
+}
+
+export async function executeConnect(state: McpExtensionState, serverName: string): Promise<ProxyToolResult> {
+	const definition = state.config.mcpServers[serverName]
+	if (!definition) {
+		return {
+			content: [
+				{ type: "text" as const, text: `Server "${serverName}" not found. Use mcp({}) to see available servers.` },
+			],
+			details: { mode: "connect", error: "not_found", server: serverName },
+		}
+	}
+
+	try {
+		if (state.ui) {
+			state.ui.setStatus("mcp", `MCP: connecting to ${serverName}...`)
+		}
+		let connection = await state.manager.connect(serverName, definition)
+		if (connection.status === "needs-auth") {
+			const autoAuth = await attemptAutoAuth(state, serverName)
+			if (autoAuth.status === "failed") {
+				return {
+					content: [{ type: "text" as const, text: autoAuth.message }],
+					details: { mode: "connect", error: "auth_required", server: serverName, message: autoAuth.message },
+				}
+			}
+			if (autoAuth.status === "success") {
+				await state.manager.close(serverName)
+				connection = await state.manager.connect(serverName, definition)
+			}
+			if (connection.status === "needs-auth") {
+				const message = getAuthRequiredMessage(serverName)
+				return {
+					content: [{ type: "text" as const, text: message }],
+					details: { mode: "connect", error: "auth_required", server: serverName, message },
+				}
+			}
+		}
+		const prefix = state.config.settings?.toolPrefix ?? "server"
+		const { metadata } = buildToolMetadata(connection.tools, connection.resources, definition, serverName, prefix)
+		state.toolMetadata.set(serverName, metadata)
+		updateMetadataCache(state, serverName)
+		state.failureTracker.delete(serverName)
+		updateStatusBar(state)
+		return executeList(state, serverName)
+	} catch (error) {
+		state.failureTracker.set(serverName, Date.now())
+		updateStatusBar(state)
+		const message = error instanceof Error ? error.message : String(error)
+		return {
+			content: [{ type: "text" as const, text: `Failed to connect to "${serverName}": ${message}` }],
+			details: { mode: "connect", error: "connect_failed", server: serverName, message },
+		}
+	}
+}
+
+export async function executeCall(
+	state: McpExtensionState,
+	toolName: string,
+	args?: Record<string, unknown>,
+	serverOverride?: string,
+): Promise<ProxyToolResult> {
+	let serverName: string | undefined = serverOverride
+	let toolMeta: ToolMetadata | undefined
+	let autoAuthAttempted = false
+	const prefixMode = state.config.settings?.toolPrefix ?? "server"
+
+	if (serverName && !state.config.mcpServers[serverName]) {
+		return {
+			content: [
+				{ type: "text" as const, text: `Server "${serverName}" not found. Use mcp({}) to see available servers.` },
+			],
+			details: { mode: "call", error: "server_not_found", server: serverName },
+		}
+	}
+
+	if (serverName) {
+		toolMeta = findToolByName(state.toolMetadata.get(serverName), toolName)
+	} else {
+		for (const [server, metadata] of state.toolMetadata.entries()) {
+			const found = findToolByName(metadata, toolName)
+			if (found) {
+				serverName = server
+				toolMeta = found
+				break
+			}
+		}
+	}
+
+	if (serverName && !toolMeta) {
+		const connected = await lazyConnect(state, serverName)
+		if (connected) {
+			toolMeta = findToolByName(state.toolMetadata.get(serverName), toolName)
+		} else {
+			const needsAuthConnection = state.manager.getConnection(serverName)
+			if (needsAuthConnection?.status === "needs-auth") {
+				if (!autoAuthAttempted) {
+					autoAuthAttempted = true
+					const autoAuth = await attemptAutoAuth(state, serverName)
+					if (autoAuth.status === "failed") {
+						return {
+							content: [{ type: "text" as const, text: autoAuth.message }],
+							details: { mode: "call", error: "auth_required", server: serverName, message: autoAuth.message },
+						}
+					}
+					if (autoAuth.status === "success") {
+						await state.manager.close(serverName)
+						state.failureTracker.delete(serverName)
+						const connectedAfterAuth = await lazyConnect(state, serverName)
+						if (connectedAfterAuth) {
+							toolMeta = findToolByName(state.toolMetadata.get(serverName), toolName)
+							if (!toolMeta) {
+								return {
+									content: [
+										{ type: "text" as const, text: `Tool "${toolName}" not found on "${serverName}" after reconnect.` },
+									],
+									details: { mode: "call", error: "tool_not_found_after_reconnect", requestedTool: toolName },
+								}
+							}
+						}
+					}
+				}
+
+				if (!toolMeta && state.manager.getConnection(serverName)?.status === "needs-auth") {
+					const message = getAuthRequiredMessage(serverName)
+					return {
+						content: [{ type: "text" as const, text: message }],
+						details: { mode: "call", error: "auth_required", server: serverName, message },
+					}
+				}
+			}
+
+			if (!toolMeta) {
+				const failedAgo = getFailureAgeSeconds(state, serverName)
+				if (failedAgo !== null) {
+					return {
+						content: [
+							{ type: "text" as const, text: `Server "${serverName}" not available (last failed ${failedAgo}s ago)` },
+						],
+						details: { mode: "call", error: "server_backoff", server: serverName },
+					}
+				}
+			}
+		}
+	}
+
+	let prefixMatchedServer: string | undefined
+
+	if (!serverName && !toolMeta && prefixMode !== "none") {
+		const candidates = Object.keys(state.config.mcpServers)
+			.map((name) => ({ name, prefix: getServerPrefix(name, prefixMode) }))
+			.filter((c) => c.prefix && toolName.startsWith(c.prefix + "_"))
+			.sort((a, b) => b.prefix.length - a.prefix.length)
+
+		for (const { name: configuredServer } of candidates) {
+			const existingConnection = state.manager.getConnection(configuredServer)
+			const failedAgo = getFailureAgeSeconds(state, configuredServer)
+			if (failedAgo !== null && existingConnection?.status !== "needs-auth") continue
+
+			let connected = await lazyConnect(state, configuredServer)
+			if (!connected && state.manager.getConnection(configuredServer)?.status === "needs-auth" && !autoAuthAttempted) {
+				autoAuthAttempted = true
+				const autoAuth = await attemptAutoAuth(state, configuredServer)
+				if (autoAuth.status === "failed") {
+					return {
+						content: [{ type: "text" as const, text: autoAuth.message }],
+						details: { mode: "call", error: "auth_required", server: configuredServer, message: autoAuth.message },
+					}
+				}
+				if (autoAuth.status === "success") {
+					await state.manager.close(configuredServer)
+					state.failureTracker.delete(configuredServer)
+					connected = await lazyConnect(state, configuredServer)
+				}
+			}
+
+			if (!connected) continue
+			if (!prefixMatchedServer) prefixMatchedServer = configuredServer
+			toolMeta = findToolByName(state.toolMetadata.get(configuredServer), toolName)
+			if (toolMeta) {
+				serverName = configuredServer
+				break
+			}
+		}
+	}
+
+	if (!serverName || !toolMeta) {
+		const hintServer = serverName ?? prefixMatchedServer
+		const available = hintServer ? getToolNames(state, hintServer) : []
+		let msg = `Tool "${toolName}" not found.`
+		if (available.length > 0) {
+			msg += ` Server "${hintServer}" has: ${available.join(", ")}`
+		} else {
+			msg += ` Use mcp({ search: "..." }) to search.`
+		}
+		return {
+			content: [{ type: "text" as const, text: msg }],
+			details: { mode: "call", error: "tool_not_found", requestedTool: toolName, hintServer },
+		}
+	}
+
+	let connection = state.manager.getConnection(serverName)
+	if (connection?.status === "needs-auth") {
+		if (!autoAuthAttempted) {
+			autoAuthAttempted = true
+			const autoAuth = await attemptAutoAuth(state, serverName)
+			if (autoAuth.status === "failed") {
+				return {
+					content: [{ type: "text" as const, text: autoAuth.message }],
+					details: { mode: "call", error: "auth_required", server: serverName, message: autoAuth.message },
+				}
+			}
+			if (autoAuth.status === "success") {
+				await state.manager.close(serverName)
+				state.failureTracker.delete(serverName)
+				connection = state.manager.getConnection(serverName)
+			}
+		}
+
+		if (connection?.status === "needs-auth") {
+			const message = getAuthRequiredMessage(serverName)
+			return {
+				content: [{ type: "text" as const, text: message }],
+				details: { mode: "call", error: "auth_required", server: serverName, message },
+			}
+		}
+	}
+	if (!connection || connection.status !== "connected") {
+		const failedAgo = getFailureAgeSeconds(state, serverName)
+		if (failedAgo !== null) {
+			return {
+				content: [
+					{ type: "text" as const, text: `Server "${serverName}" not available (last failed ${failedAgo}s ago)` },
+				],
+				details: { mode: "call", error: "server_backoff", server: serverName },
+			}
+		}
+
+		const definition = state.config.mcpServers[serverName]
+		if (!definition) {
+			return {
+				content: [{ type: "text" as const, text: `Server "${serverName}" not connected` }],
+				details: { mode: "call", error: "server_not_connected", server: serverName },
+			}
+		}
+
+		try {
+			if (state.ui) {
+				state.ui.setStatus("mcp", `MCP: connecting to ${serverName}...`)
+			}
+			connection = await state.manager.connect(serverName, definition)
+			if (connection.status === "needs-auth") {
+				if (!autoAuthAttempted) {
+					autoAuthAttempted = true
+					const autoAuth = await attemptAutoAuth(state, serverName)
+					if (autoAuth.status === "failed") {
+						return {
+							content: [{ type: "text" as const, text: autoAuth.message }],
+							details: { mode: "call", error: "auth_required", server: serverName, message: autoAuth.message },
+						}
+					}
+					if (autoAuth.status === "success") {
+						await state.manager.close(serverName)
+						connection = await state.manager.connect(serverName, definition)
+					}
+				}
+
+				if (connection.status === "needs-auth") {
+					const message = getAuthRequiredMessage(serverName)
+					return {
+						content: [{ type: "text" as const, text: message }],
+						details: { mode: "call", error: "auth_required", server: serverName, message },
+					}
+				}
+			}
+			state.failureTracker.delete(serverName)
+			updateServerMetadata(state, serverName)
+			updateMetadataCache(state, serverName)
+			updateStatusBar(state)
+			toolMeta = findToolByName(state.toolMetadata.get(serverName), toolName)
+			if (!toolMeta) {
+				const available = getToolNames(state, serverName)
+				const hint =
+					available.length > 0
+						? `Available tools on "${serverName}": ${available.join(", ")}`
+						: `Server "${serverName}" has no tools.`
+				return {
+					content: [
+						{ type: "text" as const, text: `Tool "${toolName}" not found on "${serverName}" after reconnect. ${hint}` },
+					],
+					details: { mode: "call", error: "tool_not_found_after_reconnect", requestedTool: toolName },
+				}
+			}
+		} catch (error) {
+			state.failureTracker.set(serverName, Date.now())
+			updateStatusBar(state)
+			const message = error instanceof Error ? error.message : String(error)
+			return {
+				content: [{ type: "text" as const, text: `Failed to connect to "${serverName}": ${message}` }],
+				details: { mode: "call", error: "connect_failed", message },
+			}
+		}
+	}
+
+	let uiSession: UiSessionRuntime | null = null
+
+	try {
+		state.manager.touch(serverName)
+		state.manager.incrementInFlight(serverName)
+
+		if (toolMeta.resourceUri) {
+			const result = await connection.client.readResource({ uri: toolMeta.resourceUri })
+			const content = (result.contents ?? []).map((c) => ({
+				type: "text" as const,
+				text:
+					"text" in c
+						? c.text
+						: "blob" in c
+							? `[Binary data: ${(c as { mimeType?: string }).mimeType ?? "unknown"}]`
+							: JSON.stringify(c),
+			}))
+			return {
+				content: content.length > 0 ? content : [{ type: "text" as const, text: "(empty resource)" }],
+				details: { mode: "call", resourceUri: toolMeta.resourceUri, server: serverName },
+			}
+		}
+
+		uiSession = toolMeta.uiResourceUri
+			? await maybeStartUiSession(state, {
+					serverName,
+					toolName: toolMeta.originalName,
+					toolArgs: args ?? {},
+					uiResourceUri: toolMeta.uiResourceUri,
+					streamMode: toolMeta.uiStreamMode,
+				})
+			: null
+
+		const resultPromise = connection.client.callTool({
+			name: toolMeta.originalName,
+			arguments: args ?? {},
+			_meta: uiSession?.requestMeta,
+		})
+
+		if (toolMeta.uiResourceUri) {
+			const result = await resultPromise
+			uiSession?.sendToolResult(result as unknown as import("@modelcontextprotocol/sdk/types.js").CallToolResult)
+			const mcpContent = (result.content ?? []) as McpContent[]
+			const content = transformMcpContent(mcpContent)
+
+			const mcpText = content
+				.filter((c) => c.type === "text")
+				.map((c) => (c as { text: string }).text)
+				.join("\n")
+
+			if (result.isError) {
+				let errorWithSchema = `Error: ${mcpText || "Tool execution failed"}`
+				if (toolMeta.inputSchema) {
+					errorWithSchema += `\n\nExpected parameters:\n${formatSchema(toolMeta.inputSchema)}`
+				}
+				return {
+					content: [{ type: "text" as const, text: errorWithSchema }],
+					details: { mode: "call", error: "tool_error", mcpResult: result },
+				}
+			}
+
+			const resultText = mcpText || "(empty result)"
+			const uiMessage = uiSession?.reused
+				? "Updated the open UI."
+				: "📺 Interactive UI is now open in your browser. I'll respond to your prompts and intents as you interact with it."
+			return {
+				content: [{ type: "text" as const, text: `${resultText}\n\n${uiMessage}` }],
+				details: { mode: "call", mcpResult: result, server: serverName, tool: toolMeta.originalName, uiOpen: true },
+			}
+		}
+
+		const result = await resultPromise
+
+		const mcpContent = (result.content ?? []) as McpContent[]
+		const content = transformMcpContent(mcpContent)
+
+		if (result.isError) {
+			const errorText =
+				content
+					.filter((c) => c.type === "text")
+					.map((c) => (c as { text: string }).text)
+					.join("\n") || "Tool execution failed"
+
+			let errorWithSchema = `Error: ${errorText}`
+			if (toolMeta.inputSchema) {
+				errorWithSchema += `\n\nExpected parameters:\n${formatSchema(toolMeta.inputSchema)}`
+			}
+
+			return {
+				content: [{ type: "text" as const, text: errorWithSchema }],
+				details: { mode: "call", error: "tool_error", mcpResult: result },
+			}
+		}
+
+		return {
+			content: content.length > 0 ? content : [{ type: "text" as const, text: "(empty result)" }],
+			details: { mode: "call", mcpResult: result, server: serverName, tool: toolMeta.originalName },
+		}
+	} catch (error) {
+		const message = error instanceof Error ? error.message : String(error)
+		uiSession?.sendToolCancelled(message)
+
+		let errorWithSchema = `Failed to call tool: ${message}`
+		if (toolMeta.inputSchema) {
+			errorWithSchema += `\n\nExpected parameters:\n${formatSchema(toolMeta.inputSchema)}`
+		}
+
+		return {
+			content: [{ type: "text" as const, text: errorWithSchema }],
+			details: { mode: "call", error: "call_failed", message },
+		}
+	} finally {
+		if (uiSession?.reused) {
+			uiSession.close()
+		}
+		state.manager.decrementInFlight(serverName)
+		state.manager.touch(serverName)
+	}
+}

--- a/src/extensions/mcp-adapter/proxy-modes.ts
+++ b/src/extensions/mcp-adapter/proxy-modes.ts
@@ -1,4 +1,8 @@
-import type { AgentToolResult, ToolInfo } from "@mariozechner/pi-coding-agent"
+import { randomUUID } from "node:crypto"
+import { mkdirSync, writeFileSync } from "node:fs"
+import { tmpdir, userInfo } from "node:os"
+import { dirname, join } from "node:path"
+import type { AgentToolResult, ExtensionContext, ToolInfo } from "@mariozechner/pi-coding-agent"
 import { truncateTail } from "@mariozechner/pi-coding-agent"
 import {
 	getFailureAgeSeconds,
@@ -33,6 +37,54 @@ function applyTruncation(content: ContentBlock[]): ContentBlock[] {
 	const notice = `\n[Truncated: showing last ${result.outputLines} of ${result.totalLines} lines (${result.totalBytes.toLocaleString()} bytes total). Use mcp({ describe: "tool_name" }) to check parameters if needed.]`
 	const nonText = content.filter((c): c is ImageContent => c.type !== "text")
 	return [{ type: "text" as const, text: result.content + notice }, ...nonText]
+}
+
+function applyOffload(
+	content: ContentBlock[],
+	toolName: string,
+	maxChars: number,
+	ctx: ExtensionContext,
+): ContentBlock[] {
+	const textItems = content.filter((c): c is TextContent => c.type === "text")
+	if (textItems.length === 0) return content
+
+	const combined = textItems.map((c) => c.text).join("\n")
+	if (combined.length <= maxChars) return content
+
+	const nonText = content.filter((c) => c.type !== "text")
+
+	// Lightweight format detection — avoids JSON.parse on large strings
+	const ext = /^\s*[\{\[]/.test(combined) ? "json" : "txt"
+
+	// Derive output directory from session file
+	let dir: string
+	const sessionFile = ctx.sessionManager.getSessionFile()
+	if (sessionFile) {
+		dir = join(dirname(sessionFile), "tool-results")
+	} else {
+		dir = join(tmpdir(), `kimchi-tool-results-${userInfo().uid}`)
+	}
+
+	let path: string
+	try {
+		mkdirSync(dir, { recursive: true })
+		path = join(dir, `${randomUUID()}.${ext}`)
+		writeFileSync(path, combined, "utf-8")
+	} catch (err) {
+		console.warn(`[mcp-adapter] applyOffload: failed to write tool result to disk:`, err)
+		// Hard-slice fallback — do NOT use truncateTail; it fails on single-line blobs
+		const sliced = combined.slice(0, maxChars) + "\n\n... [Truncated due to I/O error]"
+		return [...nonText, { type: "text" as const, text: sliced }]
+	}
+
+	const format = ext === "json" ? "JSON" : "Plain text"
+	const message = `result (${combined.length.toLocaleString()} characters) exceeds limit. Full output saved to ${path}.
+Format: ${format}
+- To search: use bash with grep on the file directly
+- To read in chunks: bash -c "python3 -c \\"print(open('${path}').read()[A:B])\\""
+- For analysis requiring full content: use a subagent with the file path`
+
+	return [...nonText, { type: "text" as const, text: message }]
 }
 
 type AutoAuthResult = { status: "skipped" } | { status: "success" } | { status: "failed"; message: string }
@@ -490,6 +542,8 @@ export async function executeCall(
 	toolName: string,
 	args?: Record<string, unknown>,
 	serverOverride?: string,
+	ctx?: ExtensionContext,
+	maxToolResultChars?: number,
 ): Promise<ProxyToolResult> {
 	let serverName: string | undefined = serverOverride
 	let toolMeta: ToolMetadata | undefined
@@ -827,7 +881,10 @@ export async function executeCall(
 			}
 		}
 
-		const truncated = applyTruncation((content.length > 0 ? content : [{ type: "text" as const, text: "(empty result)" }]) as ContentBlock[])
+		const finalContent = (content.length > 0 ? content : [{ type: "text" as const, text: "(empty result)" }]) as ContentBlock[]
+		const truncated = ctx
+			? applyOffload(finalContent, toolName, maxToolResultChars ?? 10_000, ctx)
+			: applyTruncation(finalContent)
 		return {
 			content: truncated,
 			details: { mode: "call", mcpResult: result, server: serverName, tool: toolMeta.originalName },

--- a/src/extensions/mcp-adapter/resource-tools.ts
+++ b/src/extensions/mcp-adapter/resource-tools.ts
@@ -1,0 +1,17 @@
+// resource-tools.ts - MCP resource name utilities
+
+export function resourceNameToToolName(name: string): string {
+	let result = name
+		.replace(/[^a-zA-Z0-9]/g, "_")
+		.replace(/_+/g, "_")
+		.replace(/^_+/, "") // Remove leading underscores
+		.replace(/_+$/, "") // Remove trailing underscores
+		.toLowerCase()
+
+	// Ensure we have a valid name
+	if (!result || /^\d/.test(result)) {
+		result = "resource" + (result ? "_" + result : "")
+	}
+
+	return result
+}

--- a/src/extensions/mcp-adapter/server-manager.ts
+++ b/src/extensions/mcp-adapter/server-manager.ts
@@ -1,0 +1,355 @@
+import { UnauthorizedError } from "@modelcontextprotocol/sdk/client/auth.js"
+import { Client } from "@modelcontextprotocol/sdk/client/index.js"
+import { SSEClientTransport } from "@modelcontextprotocol/sdk/client/sse.js"
+import { StdioClientTransport } from "@modelcontextprotocol/sdk/client/stdio.js"
+import { StreamableHTTPClientTransport } from "@modelcontextprotocol/sdk/client/streamableHttp.js"
+import type { ReadResourceResult } from "@modelcontextprotocol/sdk/types.js"
+import { logger } from "./logger.js"
+import { supportsOAuth } from "./mcp-auth-flow.js"
+import { McpOAuthProvider } from "./mcp-oauth-provider.js"
+import { resolveNpxBinary } from "./npx-resolver.js"
+import type { McpResource, McpTool, ServerDefinition, ServerStreamResultPatchNotification, Transport } from "./types.js"
+import { serverStreamResultPatchNotificationSchema } from "./types.js"
+
+interface ServerConnection {
+	client: Client
+	transport: Transport
+	definition: ServerDefinition
+	tools: McpTool[]
+	resources: McpResource[]
+	lastUsedAt: number
+	inFlight: number
+	status: "connected" | "closed" | "needs-auth"
+}
+
+type UiStreamListener = (serverName: string, notification: ServerStreamResultPatchNotification["params"]) => void
+
+export class McpServerManager {
+	private connections = new Map<string, ServerConnection>()
+	private connectPromises = new Map<string, Promise<ServerConnection>>()
+	private uiStreamListeners = new Map<string, UiStreamListener>()
+
+	async connect(name: string, definition: ServerDefinition): Promise<ServerConnection> {
+		// Dedupe concurrent connection attempts
+		if (this.connectPromises.has(name)) {
+			return this.connectPromises.get(name)!
+		}
+
+		// Reuse existing connection if healthy
+		const existing = this.connections.get(name)
+		if (existing?.status === "connected") {
+			existing.lastUsedAt = Date.now()
+			return existing
+		}
+
+		const promise = this.createConnection(name, definition)
+		this.connectPromises.set(name, promise)
+
+		try {
+			const connection = await promise
+			this.connections.set(name, connection)
+			return connection
+		} finally {
+			this.connectPromises.delete(name)
+		}
+	}
+
+	private async createConnection(name: string, definition: ServerDefinition): Promise<ServerConnection> {
+		const client = new Client({ name: `pi-mcp-${name}`, version: "1.0.0" })
+
+		let transport: Transport
+
+		if (definition.command) {
+			let command = definition.command
+			let args = definition.args ?? []
+
+			if (command === "npx" || command === "npm") {
+				const resolved = await resolveNpxBinary(command, args)
+				if (resolved) {
+					command = resolved.isJs ? "node" : resolved.binPath
+					args = resolved.isJs ? [resolved.binPath, ...resolved.extraArgs] : resolved.extraArgs
+					logger.debug(`${name} resolved to ${resolved.binPath} (skipping npm parent)`)
+				}
+			}
+
+			transport = new StdioClientTransport({
+				command,
+				args,
+				env: resolveEnv(definition.env),
+				cwd: definition.cwd,
+				stderr: definition.debug ? "inherit" : "ignore",
+			})
+		} else if (definition.url) {
+			// HTTP transport with fallback
+			transport = await this.createHttpTransport(definition, name)
+		} else {
+			throw new Error(`Server ${name} has no command or url`)
+		}
+
+		try {
+			await client.connect(transport)
+			this.attachAdapterNotificationHandlers(name, client)
+
+			// Discover tools and resources
+			const [tools, resources] = await Promise.all([this.fetchAllTools(client), this.fetchAllResources(client)])
+
+			return {
+				client,
+				transport,
+				definition,
+				tools,
+				resources,
+				lastUsedAt: Date.now(),
+				inFlight: 0,
+				status: "connected",
+			}
+		} catch (error) {
+			// Check for UnauthorizedError - server requires OAuth
+			if (error instanceof UnauthorizedError && supportsOAuth(definition)) {
+				// Clean up both client and transport before reporting needs-auth.
+				await client.close().catch(() => {})
+				await transport.close().catch(() => {})
+
+				return {
+					client,
+					transport,
+					definition,
+					tools: [],
+					resources: [],
+					lastUsedAt: Date.now(),
+					inFlight: 0,
+					status: "needs-auth",
+				}
+			}
+
+			// Clean up both client and transport on any error
+			await client.close().catch(() => {})
+			await transport.close().catch(() => {})
+			throw error
+		}
+	}
+
+	private async createHttpTransport(definition: ServerDefinition, serverName: string): Promise<Transport> {
+		const url = new URL(definition.url!)
+
+		// Build headers first (including any bearer token)
+		const headers = resolveHeaders(definition.headers) ?? {}
+
+		// For bearer auth, add the token to headers BEFORE creating requestInit
+		if (definition.auth === "bearer") {
+			const token =
+				definition.bearerToken ?? (definition.bearerTokenEnv ? process.env[definition.bearerTokenEnv] : undefined)
+			if (token) {
+				headers["Authorization"] = `Bearer ${token}`
+			}
+		}
+
+		// Create request init with headers (Authorization now included for bearer auth)
+		const requestInit = Object.keys(headers).length > 0 ? { headers } : undefined
+
+		// For OAuth servers, create an auth provider
+		let authProvider: McpOAuthProvider | undefined
+		if (supportsOAuth(definition)) {
+			// Extract OAuth config (handles both object and false cases)
+			const oauthConfig =
+				definition.oauth === false
+					? {}
+					: {
+							grantType: definition.oauth?.grantType,
+							clientId: definition.oauth?.clientId,
+							clientSecret: definition.oauth?.clientSecret,
+							scope: definition.oauth?.scope,
+						}
+			authProvider = new McpOAuthProvider(serverName, definition.url!, oauthConfig, {
+				onRedirect: async (_authUrl) => {
+					// URL is captured by startAuth, no need to log
+				},
+			})
+		}
+
+		// Try StreamableHTTP first (modern MCP servers)
+		const streamableTransport = new StreamableHTTPClientTransport(url, {
+			requestInit,
+			authProvider,
+		})
+
+		try {
+			// Create a test client to verify the transport works
+			const testClient = new Client({ name: "pi-mcp-probe", version: "2.1.2" })
+			await testClient.connect(streamableTransport)
+			await testClient.close().catch(() => {})
+			// Close probe transport before creating fresh one
+			await streamableTransport.close().catch(() => {})
+
+			// StreamableHTTP works - create fresh transport for actual use
+			return new StreamableHTTPClientTransport(url, { requestInit, authProvider })
+		} catch (error) {
+			// StreamableHTTP failed, close and try SSE fallback
+			await streamableTransport.close().catch(() => {})
+
+			// If this was an UnauthorizedError, don't try SSE - the server needs auth
+			if (error instanceof UnauthorizedError) {
+				throw error
+			}
+
+			// SSE is the legacy transport
+			return new SSEClientTransport(url, { requestInit, authProvider })
+		}
+	}
+
+	private async fetchAllTools(client: Client): Promise<McpTool[]> {
+		const allTools: McpTool[] = []
+		let cursor: string | undefined
+
+		do {
+			const result = await client.listTools(cursor ? { cursor } : undefined)
+			allTools.push(...(result.tools ?? []))
+			cursor = result.nextCursor
+		} while (cursor)
+
+		return allTools
+	}
+
+	private async fetchAllResources(client: Client): Promise<McpResource[]> {
+		try {
+			const allResources: McpResource[] = []
+			let cursor: string | undefined
+
+			do {
+				const result = await client.listResources(cursor ? { cursor } : undefined)
+				allResources.push(...(result.resources ?? []))
+				cursor = result.nextCursor
+			} while (cursor)
+
+			return allResources
+		} catch {
+			// Server may not support resources
+			return []
+		}
+	}
+
+	private attachAdapterNotificationHandlers(serverName: string, client: Client): void {
+		client.setNotificationHandler(serverStreamResultPatchNotificationSchema, (notification) => {
+			const listener = this.uiStreamListeners.get(notification.params.streamToken)
+			if (!listener) return
+			listener(serverName, notification.params)
+		})
+	}
+
+	registerUiStreamListener(streamToken: string, listener: UiStreamListener): void {
+		this.uiStreamListeners.set(streamToken, listener)
+	}
+
+	removeUiStreamListener(streamToken: string): void {
+		this.uiStreamListeners.delete(streamToken)
+	}
+
+	async readResource(name: string, uri: string): Promise<ReadResourceResult> {
+		const connection = this.connections.get(name)
+		if (!connection || connection.status !== "connected") {
+			throw new Error(`Server "${name}" is not connected`)
+		}
+
+		try {
+			this.touch(name)
+			this.incrementInFlight(name)
+			return await connection.client.readResource({ uri })
+		} finally {
+			this.decrementInFlight(name)
+			this.touch(name)
+		}
+	}
+
+	async close(name: string): Promise<void> {
+		const connection = this.connections.get(name)
+		if (!connection) return
+
+		// Delete from map BEFORE async cleanup to prevent a race where a
+		// concurrent connect() creates a new connection that our deferred
+		// delete() would then remove, orphaning the new server process.
+		connection.status = "closed"
+		this.connections.delete(name)
+		await connection.client.close().catch(() => {})
+		await connection.transport.close().catch(() => {})
+	}
+
+	async closeAll(): Promise<void> {
+		const names = [...this.connections.keys()]
+		await Promise.all(names.map((name) => this.close(name)))
+	}
+
+	getConnection(name: string): ServerConnection | undefined {
+		return this.connections.get(name)
+	}
+
+	getAllConnections(): Map<string, ServerConnection> {
+		return new Map(this.connections)
+	}
+
+	touch(name: string): void {
+		const connection = this.connections.get(name)
+		if (connection) {
+			connection.lastUsedAt = Date.now()
+		}
+	}
+
+	incrementInFlight(name: string): void {
+		const connection = this.connections.get(name)
+		if (connection) {
+			connection.inFlight = (connection.inFlight ?? 0) + 1
+		}
+	}
+
+	decrementInFlight(name: string): void {
+		const connection = this.connections.get(name)
+		if (connection && connection.inFlight) {
+			connection.inFlight--
+		}
+	}
+
+	isIdle(name: string, timeoutMs: number): boolean {
+		const connection = this.connections.get(name)
+		if (!connection || connection.status !== "connected") return false
+		if (connection.inFlight > 0) return false
+		return Date.now() - connection.lastUsedAt > timeoutMs
+	}
+}
+
+/**
+ * Resolve environment variables with interpolation.
+ */
+function resolveEnv(env?: Record<string, string>): Record<string, string> {
+	// Copy process.env, filtering out undefined values
+	const resolved: Record<string, string> = {}
+	for (const [key, value] of Object.entries(process.env)) {
+		if (value !== undefined) {
+			resolved[key] = value
+		}
+	}
+
+	if (!env) return resolved
+
+	for (const [key, value] of Object.entries(env)) {
+		// Support ${VAR} and $env:VAR interpolation
+		resolved[key] = value
+			.replace(/\$\{(\w+)\}/g, (_, name) => process.env[name] ?? "")
+			.replace(/\$env:(\w+)/g, (_, name) => process.env[name] ?? "")
+	}
+
+	return resolved
+}
+
+/**
+ * Resolve headers with environment variable interpolation.
+ */
+function resolveHeaders(headers?: Record<string, string>): Record<string, string> | undefined {
+	if (!headers) return undefined
+
+	const resolved: Record<string, string> = {}
+	for (const [key, value] of Object.entries(headers)) {
+		resolved[key] = value
+			.replace(/\$\{(\w+)\}/g, (_, name) => process.env[name] ?? "")
+			.replace(/\$env:(\w+)/g, (_, name) => process.env[name] ?? "")
+	}
+	return resolved
+}

--- a/src/extensions/mcp-adapter/state.ts
+++ b/src/extensions/mcp-adapter/state.ts
@@ -1,0 +1,41 @@
+import type { ExtensionContext } from "@mariozechner/pi-coding-agent"
+import type { ConsentManager } from "./consent-manager.js"
+import type { McpLifecycleManager } from "./lifecycle.js"
+import type { McpServerManager } from "./server-manager.js"
+import type { McpConfig, ToolMetadata, UiSessionMessages, UiStreamSummary } from "./types.js"
+import type { UiResourceHandler } from "./ui-resource-handler.js"
+import type { UiServerHandle } from "./ui-server.js"
+
+export interface CompletedUiSession {
+	serverName: string
+	toolName: string
+	completedAt: Date
+	reason: string
+	messages: UiSessionMessages
+	stream?: UiStreamSummary
+}
+
+export type SendMessageFn = (
+	message: {
+		customType: string
+		content: Array<{ type: "text"; text: string } | { type: "image"; data: string; mimeType: string }>
+		display: boolean
+		details?: unknown
+	},
+	options?: { triggerTurn?: boolean },
+) => void
+
+export interface McpExtensionState {
+	manager: McpServerManager
+	lifecycle: McpLifecycleManager
+	toolMetadata: Map<string, ToolMetadata[]>
+	config: McpConfig
+	failureTracker: Map<string, number>
+	uiResourceHandler: UiResourceHandler
+	consentManager: ConsentManager
+	uiServer: UiServerHandle | null
+	completedUiSessions: CompletedUiSession[]
+	openBrowser: (url: string) => Promise<void>
+	ui?: ExtensionContext["ui"]
+	sendMessage?: SendMessageFn
+}

--- a/src/extensions/mcp-adapter/tool-metadata.ts
+++ b/src/extensions/mcp-adapter/tool-metadata.ts
@@ -1,0 +1,152 @@
+import { getToolUiResourceUri } from "@modelcontextprotocol/ext-apps/app-bridge"
+import { resourceNameToToolName } from "./resource-tools.js"
+import type { McpExtensionState } from "./state.js"
+import type { McpResource, McpTool, ServerEntry, ToolMetadata } from "./types.js"
+import { formatToolName, isToolExcluded } from "./types.js"
+import { extractToolUiStreamMode } from "./utils.js"
+
+export function buildToolMetadata(
+	tools: McpTool[],
+	resources: McpResource[],
+	definition: ServerEntry,
+	serverName: string,
+	prefix: "server" | "none" | "short",
+): { metadata: ToolMetadata[]; failedTools: string[] } {
+	const metadata: ToolMetadata[] = []
+	const failedTools: string[] = []
+
+	for (const tool of tools) {
+		if (!tool?.name) {
+			failedTools.push("(unnamed)")
+			continue
+		}
+		if (isToolExcluded(tool.name, serverName, prefix, definition.excludeTools)) {
+			continue
+		}
+
+		let uiResourceUri: string | undefined
+		try {
+			uiResourceUri = getToolUiResourceUri({ _meta: tool._meta })
+		} catch {
+			failedTools.push(tool.name)
+		}
+		metadata.push({
+			name: formatToolName(tool.name, serverName, prefix),
+			originalName: tool.name,
+			description: tool.description ?? "",
+			inputSchema: tool.inputSchema,
+			uiResourceUri,
+			uiStreamMode: extractToolUiStreamMode(tool._meta),
+		})
+	}
+
+	if (definition.exposeResources !== false) {
+		for (const resource of resources) {
+			const baseName = `get_${resourceNameToToolName(resource.name)}`
+			if (isToolExcluded(baseName, serverName, prefix, definition.excludeTools)) {
+				continue
+			}
+
+			metadata.push({
+				name: formatToolName(baseName, serverName, prefix),
+				originalName: baseName,
+				description: resource.description ?? `Read resource: ${resource.uri}`,
+				resourceUri: resource.uri,
+			})
+		}
+	}
+
+	return { metadata, failedTools }
+}
+
+export function getToolNames(state: McpExtensionState, serverName: string): string[] {
+	return state.toolMetadata.get(serverName)?.map((m) => m.name) ?? []
+}
+
+export function totalToolCount(state: McpExtensionState): number {
+	let count = 0
+	for (const metadata of state.toolMetadata.values()) {
+		count += metadata.length
+	}
+	return count
+}
+
+export function findToolByName(metadata: ToolMetadata[] | undefined, toolName: string): ToolMetadata | undefined {
+	if (!metadata) return undefined
+	const exact = metadata.find((m) => m.name === toolName)
+	if (exact) return exact
+	const normalized = toolName.replace(/-/g, "_")
+	return metadata.find((m) => m.name.replace(/-/g, "_") === normalized)
+}
+
+export function formatSchema(schema: unknown, indent = "  "): string {
+	if (!schema || typeof schema !== "object") {
+		return `${indent}(no schema)`
+	}
+
+	const s = schema as Record<string, unknown>
+
+	if (s.type === "object" && s.properties && typeof s.properties === "object") {
+		const props = s.properties as Record<string, unknown>
+		const required = Array.isArray(s.required) ? (s.required as string[]) : []
+
+		if (Object.keys(props).length === 0) {
+			return `${indent}(no parameters)`
+		}
+
+		const lines: string[] = []
+		for (const [name, propSchema] of Object.entries(props)) {
+			const isRequired = required.includes(name)
+			const propLine = formatProperty(name, propSchema, isRequired, indent)
+			lines.push(propLine)
+		}
+		return lines.join("\n")
+	}
+
+	if (s.type) {
+		return `${indent}(${s.type})`
+	}
+
+	return `${indent}(complex schema)`
+}
+
+function formatProperty(name: string, schema: unknown, required: boolean, indent: string): string {
+	if (!schema || typeof schema !== "object") {
+		return `${indent}${name}${required ? " *required*" : ""}`
+	}
+
+	const s = schema as Record<string, unknown>
+	const parts: string[] = []
+
+	let typeStr = ""
+	if (s.type) {
+		if (Array.isArray(s.type)) {
+			typeStr = s.type.join(" | ")
+		} else {
+			typeStr = String(s.type)
+		}
+	} else if (s.enum) {
+		typeStr = "enum"
+	} else if (s.anyOf || s.oneOf) {
+		typeStr = "union"
+	}
+
+	if (Array.isArray(s.enum)) {
+		const enumVals = s.enum.map((v) => JSON.stringify(v)).join(", ")
+		typeStr = `enum: ${enumVals}`
+	}
+
+	parts.push(`${indent}${name}`)
+	if (typeStr) parts.push(`(${typeStr})`)
+	if (required) parts.push("*required*")
+
+	if (s.description && typeof s.description === "string") {
+		parts.push(`- ${s.description}`)
+	}
+
+	if (s.default !== undefined) {
+		parts.push(`[default: ${JSON.stringify(s.default)}]`)
+	}
+
+	return parts.join(" ")
+}

--- a/src/extensions/mcp-adapter/tool-registrar.ts
+++ b/src/extensions/mcp-adapter/tool-registrar.ts
@@ -1,0 +1,46 @@
+// tool-registrar.ts - MCP content transformation
+// NOTE: Tools are NOT registered with Pi - only the unified `mcp` proxy tool is registered.
+// This keeps the LLM context small (1 tool instead of 100s).
+
+import type { ContentBlock, McpContent } from "./types.js"
+
+/**
+ * Transform MCP content types to Pi content blocks.
+ */
+export function transformMcpContent(content: McpContent[]): ContentBlock[] {
+	return content.map((c) => {
+		if (c.type === "text") {
+			return { type: "text" as const, text: c.text ?? "" }
+		}
+		if (c.type === "image") {
+			return {
+				type: "image" as const,
+				data: c.data ?? "",
+				mimeType: c.mimeType ?? "image/png",
+			}
+		}
+		if (c.type === "resource") {
+			const resourceUri = c.resource?.uri ?? "(no URI)"
+			const resourceContent = c.resource?.text ?? (c.resource ? JSON.stringify(c.resource) : "(no content)")
+			return {
+				type: "text" as const,
+				text: `[Resource: ${resourceUri}]\n${resourceContent}`,
+			}
+		}
+		if (c.type === "resource_link") {
+			const linkName = c.name ?? c.uri ?? "unknown"
+			const linkUri = c.uri ?? "(no URI)"
+			return {
+				type: "text" as const,
+				text: `[Resource Link: ${linkName}]\nURI: ${linkUri}`,
+			}
+		}
+		if (c.type === "audio") {
+			return {
+				type: "text" as const,
+				text: `[Audio content: ${c.mimeType ?? "audio/*"}]`,
+			}
+		}
+		return { type: "text" as const, text: JSON.stringify(c) }
+	})
+}

--- a/src/extensions/mcp-adapter/types.ts
+++ b/src/extensions/mcp-adapter/types.ts
@@ -1,0 +1,412 @@
+import type { ImageContent, TextContent } from "@mariozechner/pi-ai"
+import type { SSEClientTransport } from "@modelcontextprotocol/sdk/client/sse.js"
+// types.ts - Core type definitions
+import type { StdioClientTransport } from "@modelcontextprotocol/sdk/client/stdio.js"
+import type { StreamableHTTPClientTransport } from "@modelcontextprotocol/sdk/client/streamableHttp.js"
+import type { UiStreamMode } from "./ui-stream-types.js"
+
+// Transport type (stdio + HTTP)
+export type Transport = StdioClientTransport | SSEClientTransport | StreamableHTTPClientTransport
+
+// Import sources for config
+export type ImportKind = "cursor" | "claude-code" | "claude-desktop" | "codex" | "windsurf" | "vscode"
+
+// Tool definition from MCP server
+export interface McpTool {
+	name: string
+	title?: string
+	description?: string
+	inputSchema?: unknown // JSON Schema
+	_meta?: Record<string, unknown>
+}
+
+// Resource definition from MCP server
+export interface McpResource {
+	uri: string
+	name: string
+	description?: string
+	mimeType?: string
+	_meta?: Record<string, unknown>
+}
+
+export interface UiResourceMeta {
+	csp?: UiResourceCsp
+	permissions?: UiResourcePermissions
+	domain?: string
+	prefersBorder?: boolean
+}
+
+export interface UiResourceContent {
+	uri: string
+	html: string
+	mimeType?: string
+	meta: UiResourceMeta
+}
+
+export interface UiProxyRequestBody<TParams> {
+	token: string
+	params: TParams
+}
+
+export interface UiProxyResult<T = Record<string, unknown>> {
+	ok: boolean
+	result?: T
+	error?: string
+}
+
+export interface UiResourceCsp {
+	connectDomains?: string[]
+	scriptDomains?: string[]
+	styleDomains?: string[]
+	fontDomains?: string[]
+	imgDomains?: string[]
+	mediaDomains?: string[]
+	frameDomains?: string[]
+	workerDomains?: string[]
+	baseUriDomains?: string[]
+}
+
+export interface UiResourcePermissions {
+	camera?: {}
+	microphone?: {}
+	geolocation?: {}
+	clipboardWrite?: {}
+}
+
+export interface UiToolInfo {
+	id?: string | number
+	tool: {
+		name: string
+		description?: string
+		inputSchema?: unknown
+	}
+}
+
+export interface UiHostContext {
+	toolInfo?: UiToolInfo
+	theme?: "light" | "dark"
+	styles?: Record<string, unknown>
+	displayMode?: UiDisplayMode
+	availableDisplayModes?: UiDisplayMode[]
+	containerDimensions?: {
+		width?: number
+		maxWidth?: number
+		height?: number
+		maxHeight?: number
+	}
+	[key: string]: unknown
+}
+
+export type UiDisplayMode = "inline" | "fullscreen" | "pip"
+
+// Re-export stream types from the shared lightweight module.
+// This allows the example package to import stream schemas without pulling the full types.ts dependency graph.
+export {
+	UI_STREAM_HOST_CONTEXT_KEY,
+	UI_STREAM_REQUEST_META_KEY,
+	UI_STREAM_RESULT_PATCH_METHOD,
+	SERVER_STREAM_RESULT_PATCH_METHOD,
+	UI_STREAM_STRUCTURED_CONTENT_KEY,
+	uiStreamModeSchema,
+	visualizationStreamPhaseSchema,
+	visualizationStreamFrameTypeSchema,
+	visualizationStreamStatusSchema,
+	uiStreamHostContextSchema,
+	visualizationStreamEnvelopeSchema,
+	uiStreamCallToolResultSchema,
+	uiStreamResultPatchNotificationSchema,
+	serverStreamResultPatchNotificationSchema,
+	getUiStreamHostContext,
+	getVisualizationStreamEnvelope,
+	type UiStreamMode,
+	type VisualizationStreamPhase,
+	type VisualizationStreamFrameType,
+	type VisualizationStreamStatus,
+	type UiStreamHostContext,
+	type VisualizationStreamEnvelope,
+	type UiStreamCallToolResult,
+	type UiStreamResultPatchNotification,
+	type ServerStreamResultPatchNotification,
+	type UiStreamSummary,
+} from "./ui-stream-types.js"
+
+export interface UiMessageParams {
+	role?: string
+	content?: unknown[]
+	type?: "prompt" | "notify" | "intent" | "message"
+	message?: string
+	prompt?: string
+	intent?: string
+	params?: Record<string, unknown>
+	[key: string]: unknown
+}
+
+/**
+ * Extract prompt text from either legacy MCP UI message shapes or native AppBridge user messages.
+ */
+export function extractUiPromptText(params: UiMessageParams): string | undefined {
+	if (params.type === "prompt" || params.prompt) {
+		const prompt = params.prompt ?? String(params.message ?? "")
+		return prompt || undefined
+	}
+
+	if (params.role === "user" && Array.isArray(params.content)) {
+		const text = params.content
+			.map((block) =>
+				block && typeof block === "object" && "text" in block ? String((block as { text?: unknown }).text ?? "") : "",
+			)
+			.filter(Boolean)
+			.join("\n\n")
+		return text || undefined
+	}
+
+	return undefined
+}
+
+/**
+ * Structured UI handoff recovered from a canonical prompt envelope.
+ */
+export interface UiPromptHandoff {
+	intent: string
+	params: Record<string, unknown>
+	raw: string
+}
+
+/**
+ * Parse a canonical named UI handoff encoded as `intent\n{json}`.
+ */
+export function parseUiPromptHandoff(prompt: string): UiPromptHandoff | undefined {
+	const newlineIndex = prompt.indexOf("\n")
+	if (newlineIndex <= 0) {
+		return undefined
+	}
+
+	const intent = prompt.slice(0, newlineIndex).trim()
+	const payloadText = prompt.slice(newlineIndex + 1).trim()
+	if (!intent || !payloadText) {
+		return undefined
+	}
+
+	if (!/^[A-Za-z][A-Za-z0-9_-]*$/.test(intent)) {
+		return undefined
+	}
+
+	try {
+		const parsed = JSON.parse(payloadText)
+		if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
+			return undefined
+		}
+		return {
+			intent,
+			params: parsed as Record<string, unknown>,
+			raw: prompt,
+		}
+	} catch {
+		return undefined
+	}
+}
+
+/**
+ * Accumulated messages from a UI session.
+ * Collected during the session and available when it ends.
+ */
+export interface UiSessionMessages {
+	prompts: string[]
+	notifications: string[]
+	intents: Array<{ intent: string; params?: Record<string, unknown> }>
+}
+
+export interface UiModelContextParams {
+	content?: unknown[]
+	structuredContent?: Record<string, unknown>
+	[key: string]: unknown
+}
+
+export interface UiOpenLinkResult {
+	isError?: boolean
+	[key: string]: unknown
+}
+
+export interface UiDisplayModeRequest {
+	mode?: UiDisplayMode
+}
+
+export interface UiDisplayModeResult {
+	mode: UiDisplayMode
+	[key: string]: unknown
+}
+
+// Content types from MCP
+export interface McpContent {
+	type: "text" | "image" | "audio" | "resource" | "resource_link"
+	text?: string
+	data?: string
+	mimeType?: string
+	resource?: {
+		uri: string
+		text?: string
+		blob?: string
+	}
+	uri?: string
+	name?: string
+	description?: string
+}
+
+// Pi content block type
+export type ContentBlock = TextContent | ImageContent
+
+// OAuth configuration (SDK handles auto-discovery and dynamic registration)
+export interface OAuthConfig {
+	/** OAuth grant type (defaults to authorization_code) */
+	grantType?: "authorization_code" | "client_credentials"
+	/** Pre-registered client ID (optional, dynamic registration used if not provided) */
+	clientId?: string
+	/** Client secret for confidential clients */
+	clientSecret?: string
+	/** Requested OAuth scopes */
+	scope?: string
+}
+
+// Server configuration
+export interface ServerEntry {
+	command?: string
+	args?: string[]
+	env?: Record<string, string>
+	cwd?: string
+	// HTTP fields
+	url?: string
+	headers?: Record<string, string>
+	/**
+	 * Authentication type:
+	 * - 'oauth' - Use OAuth 2.1 (auto-discovers endpoints, supports dynamic client registration)
+	 * - 'bearer' - Use static Bearer token
+	 * - false - Disable authentication
+	 * If not specified and url is present, OAuth will be auto-detected
+	 */
+	auth?: "oauth" | "bearer" | false
+	bearerToken?: string
+	bearerTokenEnv?: string
+	/**
+	 * OAuth configuration (optional).
+	 * If not provided, the SDK will attempt dynamic client registration.
+	 * Set to false to explicitly disable OAuth for this server.
+	 */
+	oauth?: OAuthConfig | false
+	lifecycle?: "keep-alive" | "lazy" | "eager"
+	idleTimeout?: number // minutes, overrides global setting
+	// Resource handling
+	exposeResources?: boolean
+	// Direct tool registration
+	directTools?: boolean | string[]
+	// Exclude specific MCP tools/resources by original or prefixed name
+	excludeTools?: string[]
+	// Debug
+	debug?: boolean // Show server stderr (default: false)
+}
+
+// Settings
+export interface McpSettings {
+	toolPrefix?: "server" | "none" | "short"
+	idleTimeout?: number // minutes, default 10, 0 to disable
+	directTools?: boolean
+	disableProxyTool?: boolean
+	autoAuth?: boolean
+}
+
+// Root config
+export interface McpConfig {
+	mcpServers: Record<string, ServerEntry>
+	imports?: ImportKind[]
+	settings?: McpSettings
+}
+
+// Alias for clarity
+export type ServerDefinition = ServerEntry
+
+export interface ToolMetadata {
+	name: string // Prefixed tool name (e.g., "xcodebuild_list_sims")
+	originalName: string // Original MCP tool name (e.g., "list_sims")
+	description: string
+	resourceUri?: string // For resource tools: the URI to read
+	uiResourceUri?: string // For app-enabled tools: the UI resource URI
+	inputSchema?: unknown // JSON Schema for parameters (stored for describe/errors)
+	uiStreamMode?: UiStreamMode
+}
+
+export interface DirectToolSpec {
+	serverName: string
+	originalName: string
+	prefixedName: string
+	description: string
+	inputSchema?: unknown
+	resourceUri?: string
+	uiResourceUri?: string
+	uiStreamMode?: UiStreamMode
+}
+
+export interface ServerProvenance {
+	path: string
+	kind: "user" | "project" | "import"
+	importKind?: string
+}
+
+export interface McpPanelCallbacks {
+	reconnect: (serverName: string) => Promise<boolean>
+	getConnectionStatus: (serverName: string) => "connected" | "idle" | "failed" | "needs-auth"
+	refreshCacheAfterReconnect: (serverName: string) => import("./metadata-cache.js").ServerCacheEntry | null
+}
+
+export interface McpPanelResult {
+	changes: Map<string, true | string[] | false>
+	cancelled: boolean
+}
+
+/**
+ * Get server prefix based on tool prefix mode.
+ */
+export function getServerPrefix(serverName: string, mode: "server" | "none" | "short"): string {
+	if (mode === "none") return ""
+	if (mode === "short") {
+		let short = serverName.replace(/-?mcp$/i, "").replace(/-/g, "_")
+		if (!short) short = "mcp"
+		return short
+	}
+	return serverName.replace(/-/g, "_")
+}
+
+/**
+ * Format a tool name with server prefix.
+ */
+export function formatToolName(toolName: string, serverName: string, prefix: "server" | "none" | "short"): string {
+	const p = getServerPrefix(serverName, prefix)
+	return p ? `${p}_${toolName}` : toolName
+}
+
+function normalizeToolName(value: string): string {
+	return value.replace(/-/g, "_")
+}
+
+export function isToolExcluded(
+	toolName: string,
+	serverName: string,
+	prefix: "server" | "none" | "short",
+	excludeTools?: unknown,
+): boolean {
+	if (!Array.isArray(excludeTools) || excludeTools.length === 0) return false
+
+	const candidates = new Set<string>([
+		normalizeToolName(toolName),
+		normalizeToolName(formatToolName(toolName, serverName, prefix)),
+		normalizeToolName(formatToolName(toolName, serverName, "server")),
+		normalizeToolName(formatToolName(toolName, serverName, "short")),
+	])
+
+	for (const excluded of excludeTools) {
+		if (typeof excluded !== "string") continue
+		if (candidates.has(normalizeToolName(excluded))) {
+			return true
+		}
+	}
+
+	return false
+}

--- a/src/extensions/mcp-adapter/ui-resource-handler.ts
+++ b/src/extensions/mcp-adapter/ui-resource-handler.ts
@@ -1,0 +1,143 @@
+import { RESOURCE_MIME_TYPE } from "@modelcontextprotocol/ext-apps/app-bridge"
+import type { ReadResourceResult } from "@modelcontextprotocol/sdk/types.js"
+import { ResourceFetchError, ResourceParseError } from "./errors.js"
+import { logger } from "./logger.js"
+import type { McpServerManager } from "./server-manager.js"
+import type { UiResourceContent, UiResourceMeta } from "./types.js"
+
+interface ResourceContentRecord {
+	uri?: string
+	mimeType?: string
+	text?: string
+	blob?: string
+	_meta?: Record<string, unknown>
+}
+
+export class UiResourceHandler {
+	private log = logger.child({ component: "UiResourceHandler" })
+
+	constructor(private manager: McpServerManager) {}
+
+	async readUiResource(serverName: string, uri: string): Promise<UiResourceContent> {
+		const log = this.log.child({ server: serverName, uri })
+
+		if (!uri.startsWith("ui://")) {
+			throw new ResourceParseError(uri, "URI must start with ui://", { server: serverName })
+		}
+
+		log.debug("Fetching UI resource")
+
+		let result: ReadResourceResult
+		try {
+			result = await this.manager.readResource(serverName, uri)
+		} catch (error) {
+			const message = error instanceof Error ? error.message : String(error)
+			log.error("Failed to read resource", error instanceof Error ? error : undefined)
+			throw new ResourceFetchError(uri, message, {
+				server: serverName,
+				cause: error instanceof Error ? error : undefined,
+			})
+		}
+
+		const content = selectContent(result, uri)
+		const mimeType = content.mimeType
+
+		if (mimeType && !isHtmlMimeType(mimeType)) {
+			log.warn("Unsupported MIME type", { mimeType })
+			throw new ResourceParseError(
+				uri,
+				`unsupported MIME type "${mimeType}" (expected text/html or ${RESOURCE_MIME_TYPE})`,
+				{ server: serverName, mimeType },
+			)
+		}
+
+		const html = toHtml(content)
+		if (!html.trim()) {
+			log.warn("Resource content is empty")
+			throw new ResourceParseError(uri, "content is empty", { server: serverName })
+		}
+
+		const contentMeta = extractUiMeta(content._meta)
+		const listMeta = extractUiMeta(this.getListResourceMeta(serverName, uri))
+
+		log.debug("Resource loaded successfully", {
+			contentLength: html.length,
+			hasCsp: !!contentMeta.csp || !!listMeta.csp,
+		})
+
+		return {
+			uri: content.uri ?? uri,
+			html,
+			mimeType: mimeType ?? RESOURCE_MIME_TYPE,
+			meta: {
+				csp: contentMeta.csp ?? listMeta.csp,
+				permissions: contentMeta.permissions ?? listMeta.permissions,
+				domain: contentMeta.domain ?? listMeta.domain,
+				prefersBorder: contentMeta.prefersBorder ?? listMeta.prefersBorder,
+			},
+		}
+	}
+
+	private getListResourceMeta(serverName: string, uri: string): Record<string, unknown> | undefined {
+		const connection = this.manager.getConnection(serverName)
+		if (!connection?.resources?.length) return undefined
+		const resource = connection.resources.find((entry) => entry.uri === uri)
+		if (!resource || !resource._meta || typeof resource._meta !== "object") return undefined
+		return resource._meta
+	}
+}
+
+function selectContent(result: ReadResourceResult, preferredUri: string): ResourceContentRecord {
+	const contents = (result.contents ?? []) as ResourceContentRecord[]
+	if (contents.length === 0) {
+		throw new Error(`No contents returned for UI resource: ${preferredUri}`)
+	}
+
+	const byUri = contents.find((content) => content.uri === preferredUri)
+	if (byUri) return byUri
+
+	const byHtmlMime = contents.find((content) => content.mimeType && isHtmlMimeType(content.mimeType))
+	if (byHtmlMime) return byHtmlMime
+
+	return contents[0]
+}
+
+function isHtmlMimeType(mimeType: string): boolean {
+	const normalized = mimeType.toLowerCase()
+	return normalized.startsWith("text/html") || normalized === RESOURCE_MIME_TYPE.toLowerCase()
+}
+
+function toHtml(content: ResourceContentRecord): string {
+	if (typeof content.text === "string") {
+		return content.text
+	}
+
+	if (typeof content.blob === "string") {
+		return Buffer.from(content.blob, "base64").toString("utf-8")
+	}
+
+	throw new Error(`UI resource ${content.uri ?? "(unknown)"} did not include text or blob content`)
+}
+
+function extractUiMeta(meta: Record<string, unknown> | undefined): UiResourceMeta {
+	if (!meta || typeof meta !== "object") return {}
+	const ui = meta.ui as Record<string, unknown> | undefined
+	if (!ui || typeof ui !== "object") return {}
+
+	const out: UiResourceMeta = {}
+
+	if (ui.csp && typeof ui.csp === "object") {
+		out.csp = ui.csp as UiResourceMeta["csp"]
+	}
+	if (ui.permissions && typeof ui.permissions === "object") {
+		out.permissions = ui.permissions as UiResourceMeta["permissions"]
+	}
+	if (typeof ui.domain === "string") {
+		out.domain = ui.domain
+	}
+	if (typeof ui.prefersBorder === "boolean") {
+		out.prefersBorder = ui.prefersBorder
+	}
+
+	return out
+}

--- a/src/extensions/mcp-adapter/ui-server.ts
+++ b/src/extensions/mcp-adapter/ui-server.ts
@@ -1,0 +1,619 @@
+import { randomUUID } from "node:crypto"
+import fs from "node:fs/promises"
+import http, { type IncomingMessage, type ServerResponse } from "node:http"
+import path from "node:path"
+import { buildAllowAttribute } from "@modelcontextprotocol/ext-apps/app-bridge"
+import type { CallToolRequest, CallToolResult } from "@modelcontextprotocol/sdk/types.js"
+import type { ConsentManager } from "./consent-manager.js"
+import { ServerError, wrapError } from "./errors.js"
+import { applyCspMeta, buildCspMetaContent, buildHostHtmlTemplate } from "./host-html-template.js"
+import { logger } from "./logger.js"
+import type { McpServerManager } from "./server-manager.js"
+import {
+	type UiDisplayMode,
+	type UiDisplayModeRequest,
+	type UiDisplayModeResult,
+	type UiHostContext,
+	type UiMessageParams,
+	type UiModelContextParams,
+	type UiOpenLinkResult,
+	type UiProxyRequestBody,
+	type UiProxyResult,
+	type UiResourceContent,
+	type UiSessionMessages,
+	type UiStreamSummary,
+	extractUiPromptText,
+	getVisualizationStreamEnvelope,
+} from "./types.js"
+
+const MAX_BODY_SIZE = 2 * 1024 * 1024
+const ABANDONED_GRACE_MS = 60_000
+const WATCHDOG_INTERVAL_MS = 5_000
+const MAX_EVENT_LOG = 128
+
+export interface UiServerOptions {
+	serverName: string
+	toolName: string
+	toolArgs: Record<string, unknown>
+	resource: UiResourceContent
+	manager: McpServerManager
+	consentManager: ConsentManager
+	hostContext?: UiHostContext
+	initialResultPromise?: Promise<CallToolResult>
+	sessionToken?: string
+	port?: number
+	onMessage?: (params: UiMessageParams) => Promise<void> | void
+	onContextUpdate?: (params: UiModelContextParams) => Promise<void> | void
+	onComplete?: (reason: string) => void
+}
+
+export interface UiServerHandle {
+	url: string
+	port: number
+	sessionToken: string
+	serverName: string
+	toolName: string
+	close: (reason?: string) => void
+	sendToolInput: (args: Record<string, unknown>) => void
+	sendToolResult: (result: CallToolResult) => void
+	sendResultPatch: (result: CallToolResult) => void
+	sendToolCancelled: (reason: string) => void
+	sendHostContext: (context: UiHostContext) => void
+	/** Get accumulated messages from this session */
+	getSessionMessages: () => UiSessionMessages
+	getStreamSummary: () => UiStreamSummary | undefined
+}
+
+export async function startUiServer(options: UiServerOptions): Promise<UiServerHandle> {
+	const sessionToken = options.sessionToken ?? randomUUID()
+	const log = logger.child({
+		component: "UiServer",
+		server: options.serverName,
+		tool: options.toolName,
+		session: sessionToken.slice(0, 8),
+	})
+
+	log.debug("Starting UI server")
+
+	const sseClients = new Set<ServerResponse>()
+	let completed = false
+	let lastHeartbeatAt = Date.now()
+	let watchdog: NodeJS.Timeout | null = null
+	let currentDisplayMode: UiDisplayMode = options.hostContext?.displayMode ?? "inline"
+	let nextEventId = 1
+	const eventLog: Array<{ id: number; name: string; payload: unknown }> = []
+	let streamSummary: UiStreamSummary | undefined
+
+	// Track messages from UI for retrieval
+	const sessionMessages: UiSessionMessages = {
+		prompts: [],
+		notifications: [],
+		intents: [],
+	}
+
+	const hostContext: UiHostContext = {
+		displayMode: currentDisplayMode,
+		availableDisplayModes: ["inline", "fullscreen", "pip"],
+		platform: "desktop",
+		...options.hostContext,
+		// Only include toolInfo if caller provides full tool definition with inputSchema
+		// The App validates toolInfo.tool.inputSchema as required object
+	}
+
+	const initialStreamContext = hostContext["pi-mcp-adapter/stream"]
+	if (initialStreamContext && typeof initialStreamContext === "object") {
+		const streamId = (initialStreamContext as { streamId?: unknown }).streamId
+		const mode = (initialStreamContext as { mode?: unknown }).mode
+		if (typeof streamId === "string" && (mode === "eager" || mode === "stream-first")) {
+			streamSummary = {
+				streamId,
+				mode,
+				frames: 0,
+				phases: [],
+			}
+		}
+	}
+
+	const touchHeartbeat = () => {
+		lastHeartbeatAt = Date.now()
+	}
+
+	const updateStreamSummary = (payload: unknown) => {
+		const envelope = getVisualizationStreamEnvelope(
+			(payload as { structuredContent?: unknown } | null)?.structuredContent,
+		)
+		if (!envelope) return
+		if (!streamSummary) {
+			streamSummary = {
+				streamId: envelope.streamId,
+				mode: "eager",
+				frames: 0,
+				phases: [],
+			}
+		}
+		streamSummary.frames += 1
+		if (!streamSummary.phases.includes(envelope.phase)) {
+			streamSummary.phases.push(envelope.phase)
+		}
+		streamSummary.finalStatus = envelope.status
+		streamSummary.lastMessage = envelope.message
+	}
+
+	const serializeEvent = (eventId: number, name: string, payload: unknown): string => {
+		return `id: ${eventId}\nevent: ${name}\ndata: ${JSON.stringify(payload)}\n\n`
+	}
+
+	const getLatestCheckpointIndex = () => {
+		for (let index = eventLog.length - 1; index >= 0; index -= 1) {
+			const entry = eventLog[index]
+			const envelope = getVisualizationStreamEnvelope(
+				(entry.payload as { structuredContent?: unknown } | null)?.structuredContent,
+			)
+			if (envelope?.frameType === "checkpoint" || envelope?.frameType === "final") {
+				return index
+			}
+		}
+		return -1
+	}
+
+	const pruneEventLog = () => {
+		if (eventLog.length <= MAX_EVENT_LOG) return
+		const latestCheckpointIndex = getLatestCheckpointIndex()
+
+		if (latestCheckpointIndex > 0) {
+			eventLog.splice(0, latestCheckpointIndex)
+		}
+
+		if (eventLog.length > MAX_EVENT_LOG) {
+			eventLog.splice(0, eventLog.length - MAX_EVENT_LOG)
+		}
+	}
+
+	const pushEvent = (name: string, payload: unknown) => {
+		if (completed) return
+		const eventId = nextEventId++
+		eventLog.push({ id: eventId, name, payload })
+		updateStreamSummary(payload)
+		pruneEventLog()
+		const chunk = serializeEvent(eventId, name, payload)
+		for (const client of sseClients) {
+			try {
+				client.write(chunk)
+			} catch {
+				sseClients.delete(client)
+			}
+		}
+	}
+
+	const replayEvents = (res: ServerResponse, lastEventIdHeader?: string | null) => {
+		const parsedLastId = lastEventIdHeader ? Number(lastEventIdHeader) : Number.NaN
+		const eventsToReplay = Number.isFinite(parsedLastId)
+			? eventLog.filter((entry) => entry.id > parsedLastId)
+			: (() => {
+					const latestCheckpointIndex = getLatestCheckpointIndex()
+					return latestCheckpointIndex >= 0 ? eventLog.slice(latestCheckpointIndex) : eventLog
+				})()
+
+		for (const entry of eventsToReplay) {
+			try {
+				res.write(serializeEvent(entry.id, entry.name, entry.payload))
+			} catch {
+				sseClients.delete(res)
+				return
+			}
+		}
+	}
+
+	const closeSse = () => {
+		for (const client of sseClients) {
+			try {
+				client.end()
+			} catch {}
+		}
+		sseClients.clear()
+	}
+
+	const stopWatchdog = () => {
+		if (!watchdog) return
+		clearInterval(watchdog)
+		watchdog = null
+	}
+
+	const markCompleted = (reason: string) => {
+		if (completed) return
+		log.debug("Session completed", { reason })
+		pushEvent("session-complete", { reason })
+		completed = true
+		stopWatchdog()
+		options.onComplete?.(reason)
+	}
+
+	const server = http.createServer(async (req, res) => {
+		try {
+			const method = req.method || "GET"
+			const url = new URL(req.url || "/", `http://${req.headers.host || "127.0.0.1"}`)
+
+			if (method === "GET" && url.pathname === "/") {
+				if (!validateTokenQuery(url, sessionToken, res)) return
+				touchHeartbeat()
+
+				const html = buildHostHtmlTemplate({
+					sessionToken,
+					serverName: options.serverName,
+					toolName: options.toolName,
+					toolArgs: options.toolArgs,
+					resource: options.resource,
+					allowAttribute: buildAllowAttribute(options.resource.meta.permissions),
+					requireToolConsent: options.consentManager.requiresPrompt(options.serverName),
+					cacheToolConsent: options.consentManager.shouldCacheConsent(),
+					hostContext,
+				})
+
+				res.writeHead(200, {
+					"Content-Type": "text/html; charset=utf-8",
+					"Cache-Control": "no-store",
+				})
+				res.end(html)
+				return
+			}
+
+			if (method === "GET" && url.pathname === "/events") {
+				if (!validateTokenQuery(url, sessionToken, res)) return
+				touchHeartbeat()
+				log.debug("SSE client connected", { clientCount: sseClients.size + 1 })
+				res.writeHead(200, {
+					"Content-Type": "text/event-stream",
+					"Cache-Control": "no-cache, no-transform",
+					Connection: "keep-alive",
+					"X-Accel-Buffering": "no",
+				})
+				res.write(": connected\n\n")
+				sseClients.add(res)
+				replayEvents(res, req.headers["last-event-id"] ? String(req.headers["last-event-id"]) : null)
+				req.on("close", () => {
+					sseClients.delete(res)
+				})
+				return
+			}
+
+			if (method === "GET" && url.pathname === "/health") {
+				if (!validateTokenQuery(url, sessionToken, res)) return
+				sendJson(res, 200, { ok: true, result: { healthy: true } })
+				return
+			}
+
+			if (method === "GET" && url.pathname === "/ui-app") {
+				if (!validateTokenQuery(url, sessionToken, res)) return
+				touchHeartbeat()
+				// Serve the MCP app's UI HTML directly (avoids blob URL security issues)
+				// Apply CSP meta tag if specified in resource metadata
+				const cspContent = buildCspMetaContent(options.resource.meta.csp)
+				const appHtml = applyCspMeta(options.resource.html, cspContent)
+				res.writeHead(200, {
+					"Content-Type": "text/html; charset=utf-8",
+					"Cache-Control": "no-store",
+				})
+				res.end(appHtml)
+				return
+			}
+
+			if (method === "GET" && url.pathname === "/app-bridge.bundle.js") {
+				// Serve the pre-bundled AppBridge module
+				const bundlePath = path.join(import.meta.dirname, "app-bridge.bundle.js")
+				try {
+					const content = await fs.readFile(bundlePath, "utf-8")
+					res.writeHead(200, {
+						"Content-Type": "application/javascript",
+						"Cache-Control": "public, max-age=31536000",
+					})
+					res.end(content)
+				} catch {
+					sendJson(res, 500, { ok: false, error: "Bundle not found" })
+				}
+				return
+			}
+
+			if (method !== "POST") {
+				sendJson(res, 404, { ok: false, error: "Not found" })
+				return
+			}
+
+			const body = await parseBody(req, res)
+			if (!body) return
+			if (!validateTokenBody(body, sessionToken, res)) return
+			const params = body.params ?? {}
+			touchHeartbeat()
+
+			if (url.pathname === "/proxy/tools/call") {
+				options.consentManager.ensureApproved(options.serverName)
+				const callParams = params as CallToolRequest["params"]
+				if (!callParams || typeof callParams.name !== "string" || !callParams.name.trim()) {
+					sendJson(res, 400, { ok: false, error: "Invalid tools/call params" })
+					return
+				}
+
+				const connection = options.manager.getConnection(options.serverName)
+				if (!connection || connection.status !== "connected") {
+					sendJson(res, 503, { ok: false, error: `Server "${options.serverName}" is not connected` })
+					return
+				}
+
+				try {
+					options.manager.touch(options.serverName)
+					options.manager.incrementInFlight(options.serverName)
+					const result = await connection.client.callTool({
+						name: callParams.name,
+						arguments:
+							callParams.arguments && typeof callParams.arguments === "object" && !Array.isArray(callParams.arguments)
+								? callParams.arguments
+								: {},
+					})
+					sendJson(res, 200, { ok: true, result })
+				} finally {
+					options.manager.decrementInFlight(options.serverName)
+					options.manager.touch(options.serverName)
+				}
+				return
+			}
+
+			if (url.pathname === "/proxy/ui/consent") {
+				const approved = !!(params as { approved?: boolean }).approved
+				options.consentManager.registerDecision(options.serverName, approved)
+				sendJson(res, 200, { ok: true, result: { approved } })
+				return
+			}
+
+			if (url.pathname === "/proxy/ui/message") {
+				const msgParams = params as UiMessageParams
+				const promptText = extractUiPromptText(msgParams)
+
+				// Track messages by type (order: prompt → intent → notify)
+				// Must match the order in index.ts onMessage handler
+				if (promptText) {
+					sessionMessages.prompts.push(promptText)
+					log.debug("UI prompt received", { prompt: promptText.slice(0, 100) })
+				} else if (msgParams.type === "intent" || msgParams.intent) {
+					const intentName = msgParams.intent ?? ""
+					if (intentName) {
+						sessionMessages.intents.push({
+							intent: intentName,
+							params: msgParams.params,
+						})
+						log.debug("UI intent received", { intent: intentName })
+					}
+				} else if (msgParams.type === "notify" || msgParams.message) {
+					const notifyText = msgParams.message ?? ""
+					if (notifyText) {
+						sessionMessages.notifications.push(notifyText)
+						log.debug("UI notification", { message: notifyText.slice(0, 100) })
+					}
+				}
+
+				await options.onMessage?.(msgParams)
+				sendJson(res, 200, { ok: true, result: {} })
+				return
+			}
+
+			if (url.pathname === "/proxy/ui/context") {
+				const ctxParams = params as UiModelContextParams
+				log.debug("UI context update", { hasContent: !!ctxParams.content })
+				await options.onContextUpdate?.(ctxParams)
+				sendJson(res, 200, { ok: true, result: {} })
+				return
+			}
+
+			if (url.pathname === "/proxy/ui/open-link") {
+				const openParams = params as { url?: string }
+				if (!openParams?.url || typeof openParams.url !== "string") {
+					sendJson(res, 400, { ok: false, error: "Invalid open-link params" })
+					return
+				}
+				let result: UiOpenLinkResult = {}
+				try {
+					new URL(openParams.url)
+				} catch {
+					result = { isError: true }
+				}
+				sendJson(res, 200, { ok: true, result })
+				return
+			}
+
+			if (url.pathname === "/proxy/ui/download-file") {
+				sendJson(res, 200, { ok: true, result: { isError: true } })
+				return
+			}
+
+			if (url.pathname === "/proxy/ui/request-display-mode") {
+				const displayParams = params as UiDisplayModeRequest
+				const requested = displayParams?.mode
+				const available = hostContext.availableDisplayModes ?? ["inline"]
+				if (requested && available.includes(requested)) {
+					currentDisplayMode = requested
+				}
+				hostContext.displayMode = currentDisplayMode
+				pushEvent("host-context", { displayMode: currentDisplayMode })
+				const result: UiDisplayModeResult = { mode: currentDisplayMode }
+				sendJson(res, 200, { ok: true, result })
+				return
+			}
+
+			if (url.pathname === "/proxy/ui/heartbeat") {
+				sendJson(res, 200, { ok: true, result: {} })
+				return
+			}
+
+			if (url.pathname === "/proxy/ui/complete") {
+				const reason =
+					typeof (params as { reason?: string }).reason === "string" ? (params as { reason?: string }).reason! : "done"
+				markCompleted(reason)
+				sendJson(res, 200, { ok: true, result: {} })
+				setTimeout(() => {
+					try {
+						server.close()
+					} catch {}
+					closeSse()
+				}, 20).unref()
+				return
+			}
+
+			sendJson(res, 404, { ok: false, error: "Not found" })
+		} catch (error) {
+			const wrapped = wrapError(error, { server: options.serverName, tool: options.toolName })
+			const status = /approval required|denied/i.test(wrapped.message) ? 403 : 500
+			if (status === 500) {
+				log.error("Request handler error", error instanceof Error ? error : undefined)
+			}
+			sendJson(res, status, { ok: false, error: wrapped.message })
+		}
+	})
+
+	if (options.initialResultPromise) {
+		options.initialResultPromise.then(
+			(result) => pushEvent("tool-result", result),
+			(error) => {
+				const reason = error instanceof Error ? error.message : String(error)
+				pushEvent("tool-cancelled", { reason })
+			},
+		)
+	}
+
+	watchdog = setInterval(() => {
+		if (completed) return
+		if (Date.now() - lastHeartbeatAt <= ABANDONED_GRACE_MS) return
+		markCompleted("stale")
+		try {
+			server.close()
+		} catch {}
+		closeSse()
+	}, WATCHDOG_INTERVAL_MS)
+	watchdog.unref()
+
+	return new Promise((resolve, reject) => {
+		const onError = (error: Error) => {
+			log.error("Failed to start server", error)
+			reject(new ServerError(error.message, { port: options.port, cause: error }))
+		}
+
+		server.once("error", onError)
+		server.listen(options.port ?? 0, "127.0.0.1", () => {
+			server.off("error", onError)
+			const address = server.address()
+			if (!address || typeof address === "string") {
+				const err = new ServerError("invalid address")
+				log.error("Invalid server address", err)
+				reject(err)
+				return
+			}
+
+			log.debug("Server started", { port: address.port })
+
+			const handle: UiServerHandle = {
+				url: `http://localhost:${address.port}/?session=${sessionToken}`,
+				port: address.port,
+				sessionToken,
+				serverName: options.serverName,
+				toolName: options.toolName,
+				close: (reason?: string) => {
+					markCompleted(reason ?? "closed")
+					try {
+						server.close()
+					} catch {}
+					closeSse()
+				},
+				sendToolInput: (args: Record<string, unknown>) => {
+					pushEvent("tool-input", { arguments: args })
+				},
+				sendToolResult: (result: CallToolResult) => {
+					pushEvent("tool-result", result)
+				},
+				sendResultPatch: (result: CallToolResult) => {
+					pushEvent("result-patch", result)
+				},
+				sendToolCancelled: (reason: string) => {
+					pushEvent("tool-cancelled", { reason })
+				},
+				sendHostContext: (context: UiHostContext) => {
+					Object.assign(hostContext, context)
+					pushEvent("host-context", context)
+				},
+				getSessionMessages: () => ({ ...sessionMessages }),
+				getStreamSummary: () => (streamSummary ? { ...streamSummary, phases: [...streamSummary.phases] } : undefined),
+			}
+
+			resolve(handle)
+		})
+	})
+}
+
+async function parseBody(
+	req: IncomingMessage,
+	res: ServerResponse,
+): Promise<UiProxyRequestBody<Record<string, unknown>> | null> {
+	try {
+		const body = await readBody(req)
+		if (!body || typeof body !== "object") {
+			sendJson(res, 400, { ok: false, error: "Invalid request body" })
+			return null
+		}
+		return body as UiProxyRequestBody<Record<string, unknown>>
+	} catch (error) {
+		sendJson(res, 400, { ok: false, error: error instanceof Error ? error.message : "Invalid body" })
+		return null
+	}
+}
+
+function readBody(req: IncomingMessage): Promise<unknown> {
+	return new Promise((resolve, reject) => {
+		let size = 0
+		const chunks: Buffer[] = []
+
+		req.on("data", (chunk: Buffer) => {
+			size += chunk.length
+			if (size > MAX_BODY_SIZE) {
+				req.destroy()
+				reject(new Error("Request body too large"))
+				return
+			}
+			chunks.push(chunk)
+		})
+
+		req.on("end", () => {
+			try {
+				resolve(JSON.parse(Buffer.concat(chunks).toString("utf-8")))
+			} catch (error) {
+				reject(error)
+			}
+		})
+
+		req.on("error", reject)
+	})
+}
+
+function validateTokenQuery(url: URL, expected: string, res: ServerResponse): boolean {
+	const token = url.searchParams.get("session")
+	if (token !== expected) {
+		sendJson(res, 403, { ok: false, error: "Invalid session" })
+		return false
+	}
+	return true
+}
+
+function validateTokenBody(
+	body: UiProxyRequestBody<Record<string, unknown>>,
+	expected: string,
+	res: ServerResponse,
+): boolean {
+	if (body.token !== expected) {
+		sendJson(res, 403, { ok: false, error: "Invalid session" })
+		return false
+	}
+	return true
+}
+
+function sendJson<T>(res: ServerResponse, status: number, payload: UiProxyResult<T>): void {
+	res.writeHead(status, {
+		"Content-Type": "application/json; charset=utf-8",
+		"Cache-Control": "no-store",
+	})
+	res.end(JSON.stringify(payload))
+}

--- a/src/extensions/mcp-adapter/ui-session.ts
+++ b/src/extensions/mcp-adapter/ui-session.ts
@@ -1,0 +1,378 @@
+import { randomUUID } from "node:crypto"
+import type { CallToolResult } from "@modelcontextprotocol/sdk/types.js"
+import { isGlimpseAvailable, openGlimpseWindow } from "./glimpse-ui.js"
+import { logger } from "./logger.js"
+import type { McpExtensionState } from "./state.js"
+import {
+	UI_STREAM_HOST_CONTEXT_KEY,
+	UI_STREAM_REQUEST_META_KEY,
+	UI_STREAM_STRUCTURED_CONTENT_KEY,
+	type UiHostContext,
+	type UiMessageParams,
+	type UiModelContextParams,
+	type UiStreamMode,
+	extractUiPromptText,
+} from "./types.js"
+import { type UiServerHandle, startUiServer } from "./ui-server.js"
+
+let activeGlimpseWindow: { close(): void } | null = null
+
+export interface UiSessionRequest {
+	serverName: string
+	toolName: string
+	toolArgs: Record<string, unknown>
+	uiResourceUri: string
+	streamMode?: UiStreamMode
+}
+
+export interface UiSessionRuntime {
+	serverName: string
+	toolName: string
+	reused: boolean
+	streamId?: string
+	streamToken?: string
+	streamMode?: UiStreamMode
+	requestMeta?: Record<string, unknown>
+	url: string
+	isActive: () => boolean
+	sendToolResult: (result: CallToolResult) => void
+	sendResultPatch: (result: CallToolResult) => void
+	sendToolCancelled: (reason: string) => void
+	close: (reason?: string) => void
+}
+
+const MAX_COMPLETED_SESSIONS = 10
+
+function withStreamEnvelope(result: CallToolResult, streamId: string | undefined, sequence: number): CallToolResult {
+	if (!streamId) {
+		return result
+	}
+
+	const structuredContent =
+		result.structuredContent && typeof result.structuredContent === "object" && !Array.isArray(result.structuredContent)
+			? { ...result.structuredContent }
+			: {}
+
+	const rawEnvelope = structuredContent[UI_STREAM_STRUCTURED_CONTENT_KEY]
+	const envelope =
+		rawEnvelope && typeof rawEnvelope === "object" && !Array.isArray(rawEnvelope)
+			? { ...(rawEnvelope as Record<string, unknown>) }
+			: {
+					frameType: "final",
+					phase: "settled",
+					status: result.isError ? "error" : "ok",
+				}
+
+	structuredContent[UI_STREAM_STRUCTURED_CONTENT_KEY] = {
+		...envelope,
+		streamId,
+		sequence,
+	}
+
+	return {
+		...result,
+		structuredContent,
+	}
+}
+
+async function openInBrowser(state: McpExtensionState, url: string): Promise<void> {
+	try {
+		await state.openBrowser(url)
+	} catch (error) {
+		const message = error instanceof Error ? error.message : String(error)
+		state.ui?.notify(`MCP UI browser open failed: ${message}`, "warning")
+		state.ui?.notify(`Open manually: ${url}`, "info")
+	}
+}
+
+export async function maybeStartUiSession(
+	state: McpExtensionState,
+	request: UiSessionRequest,
+): Promise<UiSessionRuntime | null> {
+	const log = logger.child({
+		component: "UiSession",
+		server: request.serverName,
+		tool: request.toolName,
+	})
+
+	try {
+		if (
+			state.uiServer &&
+			state.uiServer.serverName === request.serverName &&
+			state.uiServer.toolName === request.toolName
+		) {
+			const existingHandle = state.uiServer
+			const streamMode = request.streamMode
+			const streamId = streamMode ? randomUUID() : undefined
+			const streamToken = streamMode ? randomUUID() : undefined
+			let active = true
+			let nextStreamSequence = 0
+
+			const cleanupStreamListener = () => {
+				if (streamToken) {
+					state.manager.removeUiStreamListener(streamToken)
+				}
+			}
+
+			existingHandle.sendToolInput(request.toolArgs)
+
+			if (streamToken) {
+				state.manager.registerUiStreamListener(streamToken, (serverName, notification) => {
+					if (!active || state.uiServer !== existingHandle) return
+					if (serverName !== request.serverName) return
+					nextStreamSequence += 1
+					existingHandle.sendResultPatch(
+						withStreamEnvelope(notification.result as CallToolResult, streamId, nextStreamSequence),
+					)
+				})
+			}
+
+			return {
+				serverName: request.serverName,
+				toolName: request.toolName,
+				reused: true,
+				streamId,
+				streamToken,
+				streamMode,
+				requestMeta: streamToken ? { [UI_STREAM_REQUEST_META_KEY]: streamToken } : undefined,
+				url: existingHandle.url,
+				isActive: () => active && state.uiServer === existingHandle,
+				sendToolResult: (result: CallToolResult) => {
+					if (!active || state.uiServer !== existingHandle) return
+					nextStreamSequence += 1
+					existingHandle.sendToolResult(withStreamEnvelope(result, streamId, nextStreamSequence))
+				},
+				sendResultPatch: (result: CallToolResult) => {
+					if (!active || state.uiServer !== existingHandle) return
+					nextStreamSequence += 1
+					existingHandle.sendResultPatch(withStreamEnvelope(result, streamId, nextStreamSequence))
+				},
+				sendToolCancelled: (reason: string) => {
+					if (!active || state.uiServer !== existingHandle) return
+					nextStreamSequence += 1
+					existingHandle.sendToolResult(
+						withStreamEnvelope(
+							{
+								isError: true,
+								content: [{ type: "text", text: reason }],
+							},
+							streamId,
+							nextStreamSequence,
+						),
+					)
+				},
+				close: () => {
+					active = false
+					cleanupStreamListener()
+				},
+			}
+		}
+
+		const resource = await state.uiResourceHandler.readUiResource(request.serverName, request.uiResourceUri)
+
+		if (state.uiServer) {
+			state.uiServer.close("replaced")
+			state.uiServer = null
+		}
+		if (activeGlimpseWindow) {
+			activeGlimpseWindow.close()
+			activeGlimpseWindow = null
+		}
+
+		const streamMode = request.streamMode
+		const streamId = streamMode ? randomUUID() : undefined
+		const streamToken = streamMode ? randomUUID() : undefined
+		const hostContext: UiHostContext | undefined =
+			streamMode && streamId
+				? {
+						[UI_STREAM_HOST_CONTEXT_KEY]: {
+							mode: streamMode,
+							streamId,
+							intermediateResultPatches: streamMode === "stream-first",
+							partialInput: false,
+						},
+					}
+				: undefined
+
+		let active = true
+		let nextStreamSequence = 0
+		let handle: UiServerHandle | null = null
+
+		const cleanupStreamListener = () => {
+			if (streamToken) {
+				state.manager.removeUiStreamListener(streamToken)
+			}
+		}
+
+		handle = await startUiServer({
+			serverName: request.serverName,
+			toolName: request.toolName,
+			toolArgs: streamMode === "stream-first" ? {} : request.toolArgs,
+			resource,
+			manager: state.manager,
+			consentManager: state.consentManager,
+			hostContext,
+
+			onMessage: (params: UiMessageParams) => {
+				const prompt = extractUiPromptText(params)
+				if (prompt) {
+					if (state.sendMessage) {
+						state.sendMessage(
+							{
+								customType: "mcp-ui-prompt",
+								content: [{ type: "text", text: `User sent prompt from ${request.serverName} UI: "${prompt}"` }],
+								display: true,
+								details: { server: request.serverName, tool: request.toolName, prompt },
+							},
+							{ triggerTurn: true },
+						)
+						log.debug("Triggered agent turn for UI prompt", { prompt: prompt.slice(0, 50) })
+					}
+				} else if (params.type === "intent" || params.intent) {
+					const intent = params.intent ?? ""
+					const intentParams = params.params
+					if (intent && state.sendMessage) {
+						const paramsStr = intentParams ? ` ${JSON.stringify(intentParams)}` : ""
+						state.sendMessage(
+							{
+								customType: "mcp-ui-intent",
+								content: [
+									{ type: "text", text: `User triggered intent from ${request.serverName} UI: ${intent}${paramsStr}` },
+								],
+								display: true,
+								details: { server: request.serverName, tool: request.toolName, intent, params: intentParams },
+							},
+							{ triggerTurn: true },
+						)
+						log.debug("Triggered agent turn for UI intent", { intent })
+					}
+				} else if (params.type === "notify" || params.message) {
+					const text = params.message ?? ""
+					if (text && state.ui) {
+						state.ui.notify(`[${request.serverName}] ${text}`, "info")
+					}
+				}
+			},
+
+			onContextUpdate: (params: UiModelContextParams) => {
+				log.debug("Model context update from UI", {
+					hasContent: !!params.content,
+					hasStructured: !!params.structuredContent,
+				})
+			},
+
+			onComplete: (reason: string) => {
+				active = false
+				cleanupStreamListener()
+
+				if (state.uiServer === handle && handle) {
+					const messages = handle.getSessionMessages()
+					const stream = handle.getStreamSummary()
+					const hasContent =
+						messages.prompts.length > 0 || messages.intents.length > 0 || messages.notifications.length > 0 || !!stream
+
+					if (hasContent) {
+						state.completedUiSessions.push({
+							serverName: handle.serverName,
+							toolName: handle.toolName,
+							completedAt: new Date(),
+							reason,
+							messages,
+							stream,
+						})
+
+						while (state.completedUiSessions.length > MAX_COMPLETED_SESSIONS) {
+							state.completedUiSessions.shift()
+						}
+
+						log.debug("Session completed", {
+							reason,
+							prompts: messages.prompts.length,
+							intents: messages.intents.length,
+							notifications: messages.notifications.length,
+							streamFrames: stream?.frames ?? 0,
+						})
+					}
+
+					state.uiServer = null
+					if (activeGlimpseWindow) {
+						activeGlimpseWindow.close()
+						activeGlimpseWindow = null
+					}
+				}
+			},
+		})
+
+		if (streamToken) {
+			state.manager.registerUiStreamListener(streamToken, (serverName, notification) => {
+				if (!active || state.uiServer !== handle) return
+				if (serverName !== request.serverName) return
+				nextStreamSequence += 1
+				handle.sendResultPatch(withStreamEnvelope(notification.result as CallToolResult, streamId, nextStreamSequence))
+			})
+		}
+
+		state.uiServer = handle
+
+		const glimpseDetected = isGlimpseAvailable()
+		const viewerPref = process.env.MCP_UI_VIEWER?.toLowerCase()
+		const useGlimpse = viewerPref === "glimpse" || (viewerPref !== "browser" && glimpseDetected)
+
+		if (useGlimpse) {
+			try {
+				const glimpseHtml = `<!DOCTYPE html><html><head><meta charset="utf-8"><style>body{margin:0;padding:0;width:100vw;height:100vh;overflow:hidden}iframe{width:100%;height:100%;border:none}</style></head><body><iframe src="${handle.url}"></iframe></body></html>`
+				activeGlimpseWindow = await openGlimpseWindow(glimpseHtml, {
+					title: `MCP · ${request.serverName} · ${request.toolName}`,
+					width: 1000,
+					height: 800,
+					onClosed: () => {
+						if (active) handle.close("glimpse-closed")
+					},
+				})
+			} catch (error) {
+				log.debug("Glimpse unavailable, using browser", {
+					error: error instanceof Error ? error.message : String(error),
+				})
+				await openInBrowser(state, handle.url)
+			}
+		} else {
+			await openInBrowser(state, handle.url)
+		}
+
+		return {
+			serverName: request.serverName,
+			toolName: request.toolName,
+			reused: false,
+			streamId,
+			streamToken,
+			streamMode,
+			requestMeta: streamToken ? { [UI_STREAM_REQUEST_META_KEY]: streamToken } : undefined,
+			url: handle.url,
+			isActive: () => active && state.uiServer === handle,
+			sendToolResult: (result: CallToolResult) => {
+				if (!active || state.uiServer !== handle) return
+				nextStreamSequence += 1
+				handle.sendToolResult(withStreamEnvelope(result, streamId, nextStreamSequence))
+			},
+			sendResultPatch: (result: CallToolResult) => {
+				if (!active || state.uiServer !== handle) return
+				nextStreamSequence += 1
+				handle.sendResultPatch(withStreamEnvelope(result, streamId, nextStreamSequence))
+			},
+			sendToolCancelled: (reason: string) => {
+				if (!active || state.uiServer !== handle) return
+				handle.sendToolCancelled(reason)
+			},
+			close: (reason?: string) => {
+				active = false
+				cleanupStreamListener()
+				handle.close(reason)
+			},
+		}
+	} catch (error) {
+		const message = error instanceof Error ? error.message : String(error)
+		log.error("Failed to start UI session", error instanceof Error ? error : undefined)
+		state.ui?.notify(`MCP UI unavailable for ${request.toolName} (${request.serverName}): ${message}`, "warning")
+		return null
+	}
+}

--- a/src/extensions/mcp-adapter/ui-stream-types.ts
+++ b/src/extensions/mcp-adapter/ui-stream-types.ts
@@ -1,0 +1,93 @@
+import { z } from "zod"
+
+export const UI_STREAM_HOST_CONTEXT_KEY = "pi-mcp-adapter/stream"
+export const UI_STREAM_REQUEST_META_KEY = "pi-mcp-adapter/stream-token"
+export const UI_STREAM_RESULT_PATCH_METHOD = "notifications/pi-mcp-adapter/ui-result-patch"
+export const SERVER_STREAM_RESULT_PATCH_METHOD = "notifications/pi-mcp-adapter/result-patch"
+export const UI_STREAM_STRUCTURED_CONTENT_KEY = "pi-mcp-adapter/stream"
+
+export const uiStreamModeSchema = z.enum(["eager", "stream-first"])
+export type UiStreamMode = z.infer<typeof uiStreamModeSchema>
+
+export const visualizationStreamPhaseSchema = z.enum(["shell", "narrative", "structure", "detail", "settled"])
+export type VisualizationStreamPhase = z.infer<typeof visualizationStreamPhaseSchema>
+
+export const visualizationStreamFrameTypeSchema = z.enum(["patch", "checkpoint", "final"])
+export type VisualizationStreamFrameType = z.infer<typeof visualizationStreamFrameTypeSchema>
+
+export const visualizationStreamStatusSchema = z.enum(["ok", "error"])
+export type VisualizationStreamStatus = z.infer<typeof visualizationStreamStatusSchema>
+
+const looseRecordSchema = z.record(z.string(), z.unknown())
+const looseArraySchema = z.array(z.unknown())
+
+export const uiStreamHostContextSchema = z.object({
+	mode: uiStreamModeSchema,
+	streamId: z.string().min(1),
+	intermediateResultPatches: z.boolean(),
+	partialInput: z.boolean(),
+})
+export type UiStreamHostContext = z.infer<typeof uiStreamHostContextSchema>
+
+export const visualizationStreamEnvelopeSchema = z.object({
+	streamId: z.string().min(1),
+	sequence: z.number().int().nonnegative(),
+	frameType: visualizationStreamFrameTypeSchema,
+	phase: visualizationStreamPhaseSchema,
+	status: visualizationStreamStatusSchema,
+	message: z.string().optional(),
+	spec: looseRecordSchema.optional(),
+	checkpoint: looseRecordSchema.optional(),
+})
+export type VisualizationStreamEnvelope = z.infer<typeof visualizationStreamEnvelopeSchema>
+
+export const uiStreamCallToolResultSchema = z
+	.object({
+		content: looseArraySchema.optional(),
+		structuredContent: looseRecordSchema.optional(),
+		isError: z.boolean().optional(),
+		_meta: looseRecordSchema.optional(),
+	})
+	.passthrough()
+export type UiStreamCallToolResult = z.infer<typeof uiStreamCallToolResultSchema>
+
+export const uiStreamResultPatchNotificationSchema = z.object({
+	method: z.literal(UI_STREAM_RESULT_PATCH_METHOD),
+	params: uiStreamCallToolResultSchema,
+})
+export type UiStreamResultPatchNotification = z.infer<typeof uiStreamResultPatchNotificationSchema>
+
+export const serverStreamResultPatchNotificationSchema = z.object({
+	method: z.literal(SERVER_STREAM_RESULT_PATCH_METHOD),
+	params: z.object({
+		streamToken: z.string().min(1),
+		result: uiStreamCallToolResultSchema,
+	}),
+})
+export type ServerStreamResultPatchNotification = z.infer<typeof serverStreamResultPatchNotificationSchema>
+
+export interface UiStreamSummary {
+	streamId: string
+	mode: UiStreamMode
+	frames: number
+	phases: VisualizationStreamPhase[]
+	finalStatus?: VisualizationStreamStatus
+	lastMessage?: string
+}
+
+export function getUiStreamHostContext(
+	hostContext: Record<string, unknown> | undefined,
+): UiStreamHostContext | undefined {
+	const candidate = hostContext?.[UI_STREAM_HOST_CONTEXT_KEY]
+	const parsed = uiStreamHostContextSchema.safeParse(candidate)
+	return parsed.success ? parsed.data : undefined
+}
+
+export function getVisualizationStreamEnvelope(structuredContent: unknown): VisualizationStreamEnvelope | undefined {
+	if (!structuredContent || typeof structuredContent !== "object" || Array.isArray(structuredContent)) {
+		return undefined
+	}
+	const candidate = (structuredContent as Record<string, unknown>)[UI_STREAM_STRUCTURED_CONTENT_KEY]
+	const parsed = visualizationStreamEnvelopeSchema.safeParse(candidate)
+	return parsed.success ? parsed.data : undefined
+}

--- a/src/extensions/mcp-adapter/utils.ts
+++ b/src/extensions/mcp-adapter/utils.ts
@@ -1,5 +1,6 @@
 import { platform } from "node:os"
 import type { ExtensionAPI } from "@mariozechner/pi-coding-agent"
+export { getAgentDir } from "@mariozechner/pi-coding-agent"
 
 export async function openUrl(pi: ExtensionAPI, url: string, browser?: string): Promise<void> {
 	const os = platform()

--- a/src/extensions/mcp-adapter/utils.ts
+++ b/src/extensions/mcp-adapter/utils.ts
@@ -1,0 +1,75 @@
+import { platform } from "node:os"
+import type { ExtensionAPI } from "@mariozechner/pi-coding-agent"
+
+export async function openUrl(pi: ExtensionAPI, url: string, browser?: string): Promise<void> {
+	const os = platform()
+	let result
+
+	if (os === "darwin") {
+		result = browser ? await pi.exec("open", ["-a", browser, url]) : await pi.exec("open", [url])
+	} else if (os === "win32") {
+		result = browser
+			? await pi.exec("cmd", ["/c", "start", "", browser, url])
+			: await pi.exec("cmd", ["/c", "start", "", url])
+	} else {
+		result = browser ? await pi.exec(browser, [url]) : await pi.exec("xdg-open", [url])
+	}
+
+	if (result.code !== 0) {
+		throw new Error(result.stderr || `Failed to open browser (exit code ${result.code})`)
+	}
+}
+
+export async function parallelLimit<T, R>(items: T[], limit: number, fn: (item: T) => Promise<R>): Promise<R[]> {
+	const results: R[] = []
+	let index = 0
+
+	async function worker() {
+		while (index < items.length) {
+			const i = index++
+			results[i] = await fn(items[i])
+		}
+	}
+
+	const workers = Array(Math.min(limit, items.length))
+		.fill(null)
+		.map(() => worker())
+	await Promise.all(workers)
+	return results
+}
+
+export function getConfigPathFromArgv(): string | undefined {
+	const idx = process.argv.indexOf("--mcp-config")
+	if (idx >= 0 && idx + 1 < process.argv.length) {
+		return process.argv[idx + 1]
+	}
+	return undefined
+}
+
+export function truncateAtWord(text: string, target: number): string {
+	if (!text || text.length <= target) return text
+
+	const truncated = text.slice(0, target)
+	const lastSpace = truncated.lastIndexOf(" ")
+
+	if (lastSpace > target * 0.6) {
+		return truncated.slice(0, lastSpace) + "..."
+	}
+
+	return truncated + "..."
+}
+
+/**
+ * Extract the adapter-owned UI stream mode from tool metadata.
+ */
+export function extractToolUiStreamMode(
+	toolMeta: Record<string, unknown> | undefined,
+): "eager" | "stream-first" | undefined {
+	const uiMeta = toolMeta?.ui
+	if (!uiMeta || typeof uiMeta !== "object") return undefined
+	const streamMode = (uiMeta as Record<string, unknown>)["pi-mcp-adapter.streamMode"]
+	if (streamMode === "eager" || streamMode === "stream-first") {
+		return streamMode
+	}
+	return undefined
+}


### PR DESCRIPTION
## Summary
Vendors [pi-mcp-adapter](https://github.com/nicobailon/pi-mcp-adapter) v2.4.0 source code into `src/extensions/mcp-adapter/` and bundles it into the compiled binary.

## Changes
- Vendor pi-mcp-adapter source into `src/extensions/mcp-adapter/`
- Add MCP SDK dependencies (`@modelcontextprotocol/sdk`, `@modelcontextprotocol/ext-apps`, `open`, `zod`)
- Fix type compatibility issues with our pi-coding-agent version:
  - Change `display` type from string to boolean in `SendMessageFn`
  - Fix OAuth `grantType` type narrowing
  - Add null checks for `handle` in callbacks
  - Cast empty objects to `Record<string, unknown>`
- Exclude `mcp-adapter/` from biome linting (vendored external code)
- Register `mcpAdapterExtension` in cli.ts extensionFactories array

## Additional improvements (on top of vendored source)

### Fix: lazy path evaluation in Bun binary
Path constants in `config.ts`, `metadata-cache.ts`, and `npx-resolver.ts` were evaluated at module load time — before `KIMCHI_CODING_AGENT_DIR` was set in `cli.ts`. In the Bun binary, static imports are hoisted before any code runs, so the adapter was always writing to `~/.pi/agent/` instead of `~/.config/kimchi/harness/`. Fixed by making all three path constants lazy via memoized getter functions.

### Feature: MCP tool result offload
Large MCP tool results (e.g. a Loki query returning 51KB of JSON) caused a 1k → 31k token spike per session. The existing line-based truncation failed because the response was a single JSON blob treated as one line.

Mirrors Claude Code's pattern: when a tool result exceeds `maxToolResultChars` characters, save the full result to `<session-dir>/tool-results/<uuid>.json` and return a short path + instructions message to the model instead.

- Default threshold: 10,000 characters (~2,500 tokens). Configurable via `maxToolResultChars` in `~/.config/kimchi/config.json`.
- JSON detection: lightweight regex heuristic (`/^\s*[\{\[]/`) — avoids blocking the event loop with `JSON.parse` on large strings.
- Session dir: `dirname(ctx.sessionManager.getSessionFile()) + /tool-results/`. Falls back to `os.tmpdir()/kimchi-tool-results-<uid>/` when no session file is set.
- I/O failure fallback: hard-slice at `maxToolResultChars` (not the old line-based truncation, which fails on single-line blobs).
- Result: **8.3k tokens** for the test Loki query vs **59k tokens** in Claude Code (7x reduction).

## What this enables
The MCP adapter provides:
- The `mcp` tool for connecting to MCP servers and calling their tools
- The `/mcp` command for server status and management  
- The `--mcp-config` CLI flag for specifying MCP config file path

## Testing
- ✅ `pnpm run check` - Lint and typecheck pass
- ✅ `pnpm run test` - All 253 tests pass
- ✅ Runtime test - CLI shows `--mcp-config` flag from the MCP adapter extension
- ✅ Binary correctly reads MCP config from `~/.config/kimchi/harness/mcp.json` (lazy path fix verified: 5/5 servers connected)
- ✅ Tool result offload verified: Loki query (`{service_name="ai-optimizer"} | json | logfmt`, 12h, limit 50) stays at ~8.3k tokens

## License
pi-mcp-adapter is MIT licensed. LICENSE file included in vendored source.