### PR TITLE
NOJIRA: Fix smoke test exit code expectation after prompt enrichment change

### DIFF
--- a/tests/smoke/binary.test.ts
+++ b/tests/smoke/binary.test.ts
@@ -35,9 +35,9 @@ describe("binary smoke tests", () => {
 			extraEnv: { KIMCHI_API_KEY: "smoke-test-dummy" },
 			throwOnError: false,
 		})
-		// The binary should fail with exit code 1 due to the dummy API key.
-		expect(result.status).toBe(1)
-		// The orchestration extension fires "input" and "before_agent_start" events before API key validation, triggering template loading. If templates are missing from the compiled binary, the extension runner reports ENOENT via "Extension error" on stderr.
+		// The orchestration extension intercepts the prompt (action: "handled"), so the binary exits cleanly without reaching the LLM API.
+		expect(result.status).toBe(0)
+		// The orchestration extension fires "input" and "before_agent_start" events, triggering template loading. If templates are missing from the compiled binary, the extension runner reports ENOENT via "Extension error" on stderr.
 		expect(result.stderr).not.toContain("Extension error")
 	})
 


### PR DESCRIPTION
## Summary

- Updates smoke test to expect exit code `0` when running with `-p` and a dummy API key

## Context

The orchestration extension now returns `action: "handled"` for the non-debug prompt path (introduced in #21), which prevents the prompt from reaching the LLM. As a result, the binary exits cleanly with `0` instead of `1` when the LLM call would have previously failed due to the dummy API key.

The key assertion — no `Extension error` on stderr — is unchanged and still validates that prompt template loading works correctly in the compiled binary.

## Test plan

- [x] Smoke tests pass: `pnpm run test:smoke`