### PR TITLE
Add GitHub bug report template and troubleshooting guide

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,66 @@
+name: Bug Report
+description: Report an issue with the kimchi coding harness
+labels: ["bug"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        See [Troubleshooting Guide](../../docs/troubleshooting.md) for useful debugging commands.
+
+        **Tip:** Before submitting, check that your report doesn't include any sensitive information (API keys, credentials, proprietary code).
+
+  - type: textarea
+    id: description
+    attributes:
+      label: What happened?
+      description: Describe what you observed and what you expected instead.
+      placeholder: |
+        **Actual:** The agent failed to edit the file and returned an empty response.
+        **Expected:** The agent should have replaced "foo" with "bar" in config.ts.
+    validations:
+      required: true
+
+  - type: textarea
+    id: reproduction
+    attributes:
+      label: Reproduction command
+      description: |
+        A one-liner that reproduces the issue. Pin the model with `--provider` and `--model` for consistency.
+      placeholder: |
+        kimchi-code -p "your prompt here" --provider kimchi-dev --model kimi-k2.5
+      render: shell
+    validations:
+      required: true
+
+  - type: input
+    id: version
+    attributes:
+      label: Harness version
+      description: Output of `kimchi-code --version`
+      placeholder: "0.5.0"
+    validations:
+      required: true
+
+  - type: textarea
+    id: session-file
+    attributes:
+      label: Session file
+      description: |
+        If the bug occurred during an interactive session, paste the session file path. You can also export it to HTML for easier sharing: `kimchi-code --export <path-to-session.jsonl>`
+      placeholder: ~/.config/kimchi/harness/sessions/--path--/session.jsonl
+    validations:
+      required: false
+
+  - type: textarea
+    id: json-event-stream
+    attributes:
+      label: JSON event stream
+      description: |
+        Optional. Re-run your reproduction command with `--mode json --no-session` to capture a machine-readable event trace:
+        ```
+        kimchi-code --mode json -p "your prompt" --no-session --provider kimchi-dev --model kimi-k2.5 > events.jsonl
+        ```
+        Paste the contents or attach the file.
+      render: json
+    validations:
+      required: false

--- a/docs/sandboxing.md
+++ b/docs/sandboxing.md
@@ -1,0 +1,35 @@
+# Sandboxing
+
+Requires [Docker Desktop](https://www.docker.com/products/docker-desktop/) on macOS. Only your working directory and its subdirectories are shared with the host — everything else (`/tmp`, home directory, system paths) lives inside the sandbox. The network is proxied — HTTP/HTTPS goes through a policy-controlled proxy, non-HTTP protocols (raw TCP, UDP) are blocked entirely. The first run pulls the sandbox image and takes a while — subsequent runs start in seconds.
+
+## Commands
+
+### Run — create and enter a sandbox in one step
+
+```sh
+docker sandbox run shell .
+```
+
+### Create — named, persistent sandbox for ongoing work
+
+```sh
+docker sandbox create --name kimchi-debug shell .
+```
+
+### Exec — run a command inside an existing sandbox
+
+```sh
+docker sandbox exec kimchi-debug kimchi-code -p "your prompt"
+```
+
+### List — view all active sandboxes
+
+```sh
+docker sandbox ls
+```
+
+### Remove — permanently remove a sandbox and its internal data
+
+```sh
+docker sandbox rm kimchi-debug
+```

--- a/docs/sandboxing.md
+++ b/docs/sandboxing.md
@@ -1,8 +1,31 @@
 # Sandboxing
 
-Requires [Docker Desktop](https://www.docker.com/products/docker-desktop/) on macOS. Only your working directory and its subdirectories are shared with the host — everything else (`/tmp`, home directory, system paths) lives inside the sandbox. The network is proxied — HTTP/HTTPS goes through a policy-controlled proxy, non-HTTP protocols (raw TCP, UDP) are blocked entirely. The first run pulls the sandbox image and takes a while — subsequent runs start in seconds.
+Requires [Docker Desktop](https://www.docker.com/products/docker-desktop/) on macOS. The sandbox runs Linux — the standard macOS binary will not work inside it.
+
+Build a Linux binary first from the kimchi-dev project root:
+
+```sh
+pnpm run build:binary-linux-arm64   # Apple Silicon (M1/M2/M3/M4)
+pnpm run build:binary-linux-x64     # Intel Mac or x86-64 Linux host
+```
+
+Then start the sandbox from the kimchi-dev directory so `dist/kimchi-code` is available inside it.
+
+Only your working directory and its subdirectories are shared with the host — everything else (`/tmp`, home directory, system paths) lives inside the sandbox. The network is proxied — HTTP/HTTPS goes through a policy-controlled proxy, non-HTTP protocols (raw TCP, UDP) are blocked entirely. The first run pulls the sandbox image and takes a while — subsequent runs start in seconds.
 
 ## Commands
+
+### Quick start
+
+Both steps run in the same terminal:
+
+```sh
+# 1. Create a named sandbox (shell = agent type, . = workspace to mount)
+docker sandbox create --name kimchi-sandbox shell .
+
+# 2. Launch kimchi-code with the API key (-w sets the working directory to the mounted workspace)
+docker sandbox exec -it -e KIMCHI_API_KEY -w "$(pwd)" kimchi-sandbox ./dist/kimchi-code --provider kimchi-dev --model kimi-k2.5
+```
 
 ### Run — create and enter a sandbox in one step
 
@@ -10,16 +33,24 @@ Requires [Docker Desktop](https://www.docker.com/products/docker-desktop/) on ma
 docker sandbox run shell .
 ```
 
+This opens an interactive shell inside the sandbox, but **environment variables from the host are not forwarded** — `KIMCHI_API_KEY` and other secrets will not be available. To pass env vars, use `exec -e` on a running sandbox instead (see below).
+
 ### Create — named, persistent sandbox for ongoing work
 
 ```sh
-docker sandbox create --name kimchi-debug shell .
+docker sandbox create --name kimchi-sandbox shell .
 ```
 
 ### Exec — run a command inside an existing sandbox
 
+Only `exec` supports forwarding host environment variables with `-e`:
+
 ```sh
-docker sandbox exec kimchi-debug kimchi-code -p "your prompt"
+# Forward KIMCHI_API_KEY from the host and run kimchi-code
+docker sandbox exec -it -e KIMCHI_API_KEY -w "$(pwd)" kimchi-sandbox ./dist/kimchi-code -p "your prompt"
+
+# Interactive shell with the API key available
+docker sandbox exec -it -e KIMCHI_API_KEY -w "$(pwd)" kimchi-sandbox bash
 ```
 
 ### List — view all active sandboxes
@@ -31,5 +62,5 @@ docker sandbox ls
 ### Remove — permanently remove a sandbox and its internal data
 
 ```sh
-docker sandbox rm kimchi-debug
+docker sandbox rm kimchi-sandbox
 ```

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -2,128 +2,51 @@
 
 ## Reproducing issues
 
-The fastest way to reproduce a bug is a non-interactive one-liner. Pin the model so the same provider/model combination is used every time:
-
 ```sh
-kimchi-code -p "your prompt here" --provider kimchi-dev --model kimi-k2.5
-```
-
-Add `--no-session` to run without loading or saving session state — this ensures a clean slate:
-
-```sh
+# One-liner repro — pin provider/model, skip session state for a clean slate
 kimchi-code -p "your prompt" --no-session --provider kimchi-dev --model kimi-k2.5
 ```
 
-## Capturing diagnostic output
-
-### JSON event stream
-
-Run with `--mode json` to get a machine-readable stream of every event (tool calls, model responses, errors):
+## Diagnostic output
 
 ```sh
+# Machine-readable event stream (tool calls, responses, errors)
 kimchi-code --mode json -p "your prompt" --no-session --provider kimchi-dev --model kimi-k2.5 > events.jsonl
-```
 
-Each line in `events.jsonl` is a JSON object. This is the most detailed trace available.
-
-### Enriched prompts
-
-Use `--debug-prompts` to see the full prompt after orchestration enrichment (model capabilities, available models injected):
-
-```sh
+# Full enriched prompt after orchestration
 kimchi-code -p "your prompt" --debug-prompts --provider kimchi-dev --model kimi-k2.5
-```
 
-### Verbose startup
-
-Use `--verbose` to see model scope and startup diagnostics:
-
-```sh
+# Startup diagnostics and model scope
 kimchi-code --verbose -p "your prompt" --provider kimchi-dev --model kimi-k2.5
 ```
 
 ## Isolating the problem
 
-### Disable extensions
-
-If you suspect an extension is causing the issue, disable all of them:
-
 ```sh
+# Disable extensions / skills / prompt templates
 kimchi-code -p "your prompt" --no-extensions --provider kimchi-dev --model kimi-k2.5
-```
+kimchi-code -p "your prompt" --no-skills --provider kimchi-dev --model kimi-k2.5
 
-Similarly, `--no-skills` and `--no-prompt-templates` disable those resource types.
-
-### Restrict tools
-
-Limit which tools the agent can use to narrow down a misbehaving tool:
-
-```sh
-# Only allow read and bash
+# Restrict tools (available: read, bash, edit, write, grep, find, ls)
 kimchi-code -p "your prompt" --tools read,bash --provider kimchi-dev --model kimi-k2.5
-
-# Disable all tools
 kimchi-code -p "your prompt" --no-tools --provider kimchi-dev --model kimi-k2.5
 ```
 
-Available tools: `read`, `bash`, `edit`, `write`, `grep`, `find`, `ls`
+## Sessions
 
-## Inspecting sessions
-
-### Session file location
-
-Session files are stored as JSONL at:
-
-```
-~/.config/kimchi/harness/sessions/<encoded-cwd>/<session-id>.jsonl
-```
-
-### Exporting a session to HTML
-
-Convert a session file to a shareable HTML page:
+Session files live at `~/.config/kimchi/harness/sessions/<encoded-cwd>/<session-id>.jsonl`.
 
 ```sh
-kimchi-code --export ~/.config/kimchi/harness/sessions/--path--/session.jsonl
-# or specify an output path
-kimchi-code --export session.jsonl output.html
+kimchi-code --continue                  # resume most recent session
+kimchi-code --session <path-or-prefix>  # resume a specific session
+kimchi-code --resume                    # browse past sessions interactively
+kimchi-code --export session.jsonl output.html  # export session to HTML
 ```
 
-### Resuming a session
-
-Continue the most recent session in the current directory:
+## Quick reference
 
 ```sh
-kimchi-code --continue
-```
-
-Resume a specific session by path or ID prefix:
-
-```sh
-kimchi-code --session <path-or-id-prefix>
-```
-
-Browse and select from past sessions interactively:
-
-```sh
-kimchi-code --resume
-```
-
-## Checking available models
-
-List all models the harness can see:
-
-```sh
-kimchi-code --list-models
-```
-
-Search for a specific model:
-
-```sh
-kimchi-code --list-models kimi
-```
-
-## Version
-
-```sh
+kimchi-code --list-models        # list all available models
+kimchi-code --list-models kimi   # search for a model
 kimchi-code --version
 ```

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -1,0 +1,129 @@
+# Troubleshooting
+
+## Reproducing issues
+
+The fastest way to reproduce a bug is a non-interactive one-liner. Pin the model so the same provider/model combination is used every time:
+
+```sh
+kimchi-code -p "your prompt here" --provider kimchi-dev --model kimi-k2.5
+```
+
+Add `--no-session` to run without loading or saving session state — this ensures a clean slate:
+
+```sh
+kimchi-code -p "your prompt" --no-session --provider kimchi-dev --model kimi-k2.5
+```
+
+## Capturing diagnostic output
+
+### JSON event stream
+
+Run with `--mode json` to get a machine-readable stream of every event (tool calls, model responses, errors):
+
+```sh
+kimchi-code --mode json -p "your prompt" --no-session --provider kimchi-dev --model kimi-k2.5 > events.jsonl
+```
+
+Each line in `events.jsonl` is a JSON object. This is the most detailed trace available.
+
+### Enriched prompts
+
+Use `--debug-prompts` to see the full prompt after orchestration enrichment (model capabilities, available models injected):
+
+```sh
+kimchi-code -p "your prompt" --debug-prompts --provider kimchi-dev --model kimi-k2.5
+```
+
+### Verbose startup
+
+Use `--verbose` to see model scope and startup diagnostics:
+
+```sh
+kimchi-code --verbose -p "your prompt" --provider kimchi-dev --model kimi-k2.5
+```
+
+## Isolating the problem
+
+### Disable extensions
+
+If you suspect an extension is causing the issue, disable all of them:
+
+```sh
+kimchi-code -p "your prompt" --no-extensions --provider kimchi-dev --model kimi-k2.5
+```
+
+Similarly, `--no-skills` and `--no-prompt-templates` disable those resource types.
+
+### Restrict tools
+
+Limit which tools the agent can use to narrow down a misbehaving tool:
+
+```sh
+# Only allow read and bash
+kimchi-code -p "your prompt" --tools read,bash --provider kimchi-dev --model kimi-k2.5
+
+# Disable all tools
+kimchi-code -p "your prompt" --no-tools --provider kimchi-dev --model kimi-k2.5
+```
+
+Available tools: `read`, `bash`, `edit`, `write`, `grep`, `find`, `ls`
+
+## Inspecting sessions
+
+### Session file location
+
+Session files are stored as JSONL at:
+
+```
+~/.config/kimchi/harness/sessions/<encoded-cwd>/<session-id>.jsonl
+```
+
+### Exporting a session to HTML
+
+Convert a session file to a shareable HTML page:
+
+```sh
+kimchi-code --export ~/.config/kimchi/harness/sessions/--path--/session.jsonl
+# or specify an output path
+kimchi-code --export session.jsonl output.html
+```
+
+### Resuming a session
+
+Continue the most recent session in the current directory:
+
+```sh
+kimchi-code --continue
+```
+
+Resume a specific session by path or ID prefix:
+
+```sh
+kimchi-code --session <path-or-id-prefix>
+```
+
+Browse and select from past sessions interactively:
+
+```sh
+kimchi-code --resume
+```
+
+## Checking available models
+
+List all models the harness can see:
+
+```sh
+kimchi-code --list-models
+```
+
+Search for a specific model:
+
+```sh
+kimchi-code --list-models kimi
+```
+
+## Version
+
+```sh
+kimchi-code --version
+```

--- a/package.json
+++ b/package.json
@@ -11,6 +11,8 @@
 		"clean": "rm -rf dist",
 		"build": "tsc --noEmit && node scripts/copy-resources.js --dev",
 		"build:binary": "node scripts/build-binary.js",
+		"build:binary-linux-arm64": "node scripts/build-binary.js --target linux-arm64",
+		"build:binary-linux-x64": "node scripts/build-binary.js --target linux-x64",
 		"dev": "bun run src/cli.ts",
 		"lint": "biome check src/ scripts/",
 		"lint:fix": "biome check --write src/ scripts/",

--- a/scripts/build-binary.js
+++ b/scripts/build-binary.js
@@ -1,8 +1,25 @@
 // Build the CLI into a standalone Bun binary under dist/.
 // Steps: clean → typecheck → compile → fix macOS codesign → copy binary resources.
+//
+// Usage:
+//   node scripts/build-binary.js                        # build for the host platform
+//   node scripts/build-binary.js --target linux-arm64   # cross-compile for Linux ARM64 (Apple Silicon Docker)
+//   node scripts/build-binary.js --target linux-x64     # cross-compile for Linux x86-64
 
 import { execSync } from "node:child_process"
 import { platform } from "node:os"
+
+const TARGET_MAP = {
+	"linux-arm64": "bun-linux-arm64",
+	"linux-x64": "bun-linux-x64-modern",
+}
+
+const targetArg =
+	process.argv.find((a) => a.startsWith("--target="))?.split("=")[1] ??
+	(process.argv.includes("--target") ? process.argv[process.argv.indexOf("--target") + 1] : undefined)
+
+const crossTarget = targetArg ? (TARGET_MAP[targetArg] ?? targetArg) : undefined
+const isCrossCompile = !!crossTarget
 
 function run(label, cmd) {
 	console.log(`\n→ ${label}`)
@@ -18,12 +35,16 @@ run("typecheck", "pnpm run typecheck")
 
 // Externalize packages that cannot be bundled into a Bun compiled binary (native addons, browser automation harnesses).
 // If a new dependency causes a build failure, check whether it also needs --external here.
-run("compile", "bun build src/cli.ts --compile --outfile dist/kimchi-code --external chromium-bidi --external electron")
+const targetFlag = crossTarget ? ` --target=${crossTarget}` : ""
+run(
+	"compile",
+	`bun build src/cli.ts --compile${targetFlag} --outfile dist/kimchi-code --external chromium-bidi --external electron`,
+)
 
 // Bun --compile produces binaries with an invalid code signature on macOS.
 // The kernel kills badly-signed arm64 binaries immediately (SIGKILL, exit 137).
 // Strip the corrupt signature and re-sign ad-hoc. See: https://github.com/oven-sh/bun/issues/7208
-if (platform() === "darwin") {
+if (!isCrossCompile && platform() === "darwin") {
 	run("codesign (strip)", "codesign --remove-signature dist/kimchi-code")
 	run("codesign (ad-hoc)", "codesign -s - dist/kimchi-code")
 }


### PR DESCRIPTION
Add a lean issue template that captures the minimum for reproducible bug reports (description, reproduction command, version) with optional advanced fields (session file, JSON event stream). Include a troubleshooting guide covering CLI flags useful for debugging, isolating problems, and inspecting sessions.