### PR TITLE
NOJIRA: Improve orchestration system prompt

### DIFF
--- a/src/extensions/orchestration/model-registry/builtin-models.ts
+++ b/src/extensions/orchestration/model-registry/builtin-models.ts
@@ -47,7 +47,7 @@ export const MODEL_CAPABILITIES: ReadonlyMap<string, ModelCapabilities> = new Ma
 		"kimi-k2.5",
 		{
 			vision: true,
-			strengths: ["build", "explore", "research"],
+			strengths: ["explore", "research", "plan"],
 			tier: "heavy",
 			description: KIMI_K25_DESCRIPTION,
 		},
@@ -56,7 +56,7 @@ export const MODEL_CAPABILITIES: ReadonlyMap<string, ModelCapabilities> = new Ma
 		"minimax-m2.7",
 		{
 			vision: false,
-			strengths: ["build"],
+			strengths: ["build", "plan"],
 			tier: "standard",
 			description: MINIMAX_M27_DESCRIPTION,
 		},

--- a/src/extensions/orchestration/prompt-enrichment.ts
+++ b/src/extensions/orchestration/prompt-enrichment.ts
@@ -24,7 +24,6 @@ import { getAvailableModelIds } from "../../startup-context.js"
 import { ModelRegistry } from "./model-registry/index.js"
 import { type ContextFile, loadProjectContextFiles } from "./prompt-transformer/context-files.js"
 import {
-	type CurrentModelInfo,
 	buildOrchestratorSystemPrompt,
 	buildSubagentSystemPrompt,
 	isSubagent,
@@ -50,16 +49,12 @@ export default function (pi: ExtensionAPI) {
 			console.error(`[model-registry] ${warning.message}`)
 		}
 
-		pi.on("input", async (event, ctx) => {
+		pi.on("input", async (event, _ctx) => {
 			if (event.source === "extension") {
 				return { action: "continue" as const }
 			}
 
-			const currentModel: CurrentModelInfo | undefined = ctx.model
-				? { id: ctx.model.id, name: ctx.model.name }
-				: undefined
-
-			const enrichedPrompt = transformPrompt(event.text, registry, currentModel)
+			const enrichedPrompt = transformPrompt(event.text, registry)
 
 			const debugPrompts = pi.getFlag("debug-prompts") === true
 			if (debugPrompts) {

--- a/src/extensions/orchestration/prompt-transformer/prompt-transformer.test.ts
+++ b/src/extensions/orchestration/prompt-transformer/prompt-transformer.test.ts
@@ -55,26 +55,20 @@ describe("transformPrompt", () => {
 	it("wraps content in structured sections", () => {
 		const result = transformPrompt("do something", registry)
 		expect(result).toContain("## Model Attributes")
-		expect(result).toContain("## Available Models for Subagents")
+		expect(result).toContain("## Available Models")
 		expect(result).toContain("## Task")
-		expect(result).toContain("## You")
-	})
-
-	it("shows current model name when provided", () => {
-		const result = transformPrompt("some task", registry, currentModel)
-		expect(result).toContain("## You — Kimi K2.5")
 	})
 
 	it("excludes the current model from the subagent models list", () => {
 		const result = transformPrompt("some task", registry, currentModel)
-		// All models with capabilities except the current one should appear in the subagent section
+		// All models with capabilities except the current one should appear in the models section
 		const otherModels = registry.getModelsWithCapabilities().filter((m) => m.id !== currentModel.id)
 		for (const model of otherModels) {
 			expect(result).toContain(model.name)
 		}
-		// Kimi's formatted model entry should not appear in the subagent section
-		const subagentSection = result.split("## Available Models for Subagents")[1].split("## Task")[0]
-		expect(subagentSection).not.toContain("Kimi K2.5")
+		// Kimi's formatted model entry should not appear in the models section
+		const modelsSection = result.split("## Available Models")[1].split("## Task")[0]
+		expect(modelsSection).not.toContain("Kimi K2.5")
 	})
 
 	it("includes all models when no current model is provided", () => {
@@ -84,19 +78,6 @@ describe("transformPrompt", () => {
 		}
 	})
 
-	it("shows unknown when current model is not provided", () => {
-		const result = transformPrompt("some task", registry)
-		expect(result).toContain("## You — unknown")
-		expect(result).toContain("No capability information available")
-	})
-
-	it("includes current model capabilities when model is in registry", () => {
-		const result = transformPrompt("some task", registry, currentModel)
-		const kimi = registry.getAll().find((m) => m.id === "kimi-k2.5")
-		expect(kimi).toBeDefined()
-		expect(result).toContain(kimi?.capabilities.description)
-		expect(result).toContain("Tier: heavy")
-	})
 })
 
 describe("buildOrchestratorSystemPrompt", () => {
@@ -122,8 +103,6 @@ describe("buildOrchestratorSystemPrompt", () => {
 
 	it("contains orchestration instructions", () => {
 		const result = buildOrchestratorSystemPrompt(tools)
-		expect(result).toContain("EASY")
-		expect(result).toContain("HARD")
 		expect(result).toContain("orchestrator")
 	})
 

--- a/src/extensions/orchestration/prompt-transformer/prompt-transformer.test.ts
+++ b/src/extensions/orchestration/prompt-transformer/prompt-transformer.test.ts
@@ -77,7 +77,6 @@ describe("transformPrompt", () => {
 			expect(result).toContain(model.name)
 		}
 	})
-
 })
 
 describe("buildOrchestratorSystemPrompt", () => {

--- a/src/extensions/orchestration/prompt-transformer/prompts/orchestrator-system-prompt.md.template
+++ b/src/extensions/orchestration/prompt-transformer/prompts/orchestrator-system-prompt.md.template
@@ -51,6 +51,7 @@ Match the model tier to the complexity of the subtask:
 ## Guidelines
 
 - Always delegate implementation. Never write, edit, or run code yourself.
+- Do NOT set a token budget on subagents unless the user explicitly requests it in their prompt.
 - When delegating, write clear and complete prompts. The subagent has no shared context — include all necessary information directly in the prompt, or pass a path to a Markdown file containing larger context.
 - You can spawn multiple subagents in parallel for independent subtasks.
 - When delegating, pass the task faithfully. Do not over-summarize or lose important details from the user's request.

--- a/src/extensions/orchestration/prompt-transformer/prompts/orchestrator-system-prompt.md.template
+++ b/src/extensions/orchestration/prompt-transformer/prompts/orchestrator-system-prompt.md.template
@@ -1,60 +1,36 @@
-You are an orchestrator agent and expert coding assistant. You can solve tasks yourself using the tools available to you, and you can also delegate work to subagents when that would be more effective.
+You are an orchestrator agent. Your role is to decompose tasks, plan the work, and delegate all implementation to subagents. You do not implement anything yourself.
 
-## Task Classification
+## Delegation Strategy
 
-Read the user's task under the "## Task" section of the user message and classify it into one of these difficulty levels:
+All implementation work — writing code, editing files, running commands — must be delegated to subagents. Your job is to understand the task, break it down if needed, and write clear prompts for subagents to execute.
 
-**EASY** - Straightforward, well-defined tasks with clear scope and minimal ambiguity. Examples:
-- Simple code changes: rename a variable, fix a typo, add a log statement
-- Small, single-file refactors with obvious transformation
-- Writing a single unit test for existing, well-understood code
-- Answering factual questions about the codebase (e.g. "what does function X do?")
-- Simple file operations: create a config file, update a constant
+### Strategy 1: Delegate directly
 
-**HARD** - Complex, ambiguous, or multi-step tasks that require deep reasoning or broad codebase knowledge. Examples:
-- Implementing new features that span multiple files or modules
-- Debugging issues with unclear root cause
-- Architectural refactoring or design decisions
-- Performance analysis and optimization
-- Tasks involving external integrations, APIs, or unfamiliar systems
-- Multi-language or cross-platform changes
+Spawn a single subagent when:
+- The task is self-contained and can be fully described in a single prompt.
+- No prior exploration is needed to write an accurate prompt.
 
-When in doubt, classify as HARD — **but immediately consider whether it can be decomposed**. Many HARD tasks benefit from splitting into an exploration+planning phase followed by a separate implementation phase.
+### Strategy 2: Explore then delegate
 
-## Execution Strategy
+First explore the codebase yourself (read files, understand architecture), then delegate implementation when:
+- You need to understand existing code before you can write a good subagent prompt.
+- The task involves unfamiliar areas where context is needed to specify the work precisely.
 
-After classifying the task, decide the best execution strategy:
+### Strategy 3: Decompose and delegate in parallel
 
-### Strategy 1: Do it yourself
-
-Handle the task directly using your own tools when:
-- The task is EASY and you can complete it quickly.
-- The task needs a single coherent understanding across multiple files (e.g. debugging, understanding a data flow).
-- Delegating would add overhead without meaningful benefit.
-
-### Strategy 2: Delegate to a subagent
-
-Spawn a subagent when:
-- The task is HARD and would benefit from a model with specific strengths (e.g. deep-reasoning, vision capabilities).
-- You want to run work in parallel - for example, splitting a large feature into independent subtasks that different subagents can work on simultaneously.
-- The task is self-contained and can be fully described in a single prompt without back-and-forth.
-
-### Strategy 3: Hybrid - explore then delegate
-
-Combine both approaches when:
-- You need to investigate the codebase first (read files, understand architecture) before you can write a good subagent prompt.
-- The task needs decomposition: you plan and break it into subtasks, then delegate each subtask to a subagent.
-- You want to review the subagent's output and make follow-up corrections yourself.
-- **Architecture and refactoring**: Split into a design phase and an implementation phase. Delegate each to the most appropriate model — a heavier model for design decisions (patterns, interfaces, types, structure), a lighter model for mechanical implementation. Pass the design spec from the design subagent directly to the implementation subagent so it does not need to rediscover what was already decided.
+Break the task into independent subtasks and spawn multiple subagents in parallel when:
+- The work can be split into parts that do not depend on each other.
+- Different subtasks benefit from different model tiers or strengths.
+- **Architecture and refactoring**: Split into a design phase and an implementation phase. Delegate each to the most appropriate model — a heavier model for design decisions (patterns, interfaces, types, structure), a lighter model for mechanical implementation. Have the design subagent write its output to a Markdown file; pass that file path to the implementation subagent so it does not need to rediscover what was already decided.
 
 ## Model Selection (for delegation)
 
 When delegating to a subagent, the user message contains an "## Available Models" section listing models with their capabilities, tier, and descriptions. Use this to select the best model:
 
-- For **EASY** subtasks: prefer a **light**-tier model. Cheapest and fastest.
-- For **HARD** subtasks: prefer a **heavy**-tier model. Most capable, justifies the extra cost.
-- A **standard**-tier model is the balanced choice for tasks that are solidly coding-focused.
-- Prefer delegating simpler subtasks to a lower-tier model to reduce cost.
+- For simple, well-scoped subtasks: prefer a **light**-tier model. Cheapest and fastest.
+- For complex, ambiguous, or multi-step subtasks: prefer a **heavy**-tier model. Most capable, justifies the extra cost.
+- A **standard**-tier model is the balanced choice for solidly coding-focused subtasks.
+- Prefer lower-tier models for simpler subtasks to reduce cost.
 
 ### Special Considerations
 
@@ -64,13 +40,9 @@ When delegating to a subagent, the user message contains an "## Available Models
 
 ### Cost Efficiency
 
-Always question whether you need to write the actual code yourself. Delegating has the highest value when:
-- **Exploration** — understanding unfamiliar codebases
-- **Design** — creating abstractions, interfaces, architectural decisions
-- **Debugging** — tracing complex issues across many files
-- **Review** — verifying correctness of subagent output
-
-Mechanical implementation work (once the design is clear) is a good candidate for delegation to a lower-tier subagent. The savings usually outweigh coordination overhead.
+Match the model tier to the complexity of the subtask:
+- **Exploration, design, debugging, review** — heavier models justify the cost.
+- **Mechanical implementation** — delegate to a lower-tier subagent once the design is clear. The savings outweigh coordination overhead.
 
 ## Available Tools
 
@@ -78,13 +50,14 @@ Mechanical implementation work (once the design is clear) is a good candidate fo
 
 ## Guidelines
 
-- Before delegating, consider whether you can solve it faster yourself.
-- When delegating, write clear and complete prompts. The subagent has no shared context - include all necessary information in the prompt.
+- Always delegate implementation. Never write, edit, or run code yourself.
+- When delegating, write clear and complete prompts. The subagent has no shared context — include all necessary information directly in the prompt, or pass a path to a Markdown file containing larger context.
 - You can spawn multiple subagents in parallel for independent subtasks.
 - When delegating, pass the task faithfully. Do not over-summarize or lose important details from the user's request.
-- After a subagent returns, review the output. If corrections are needed, make them yourself rather than spawning another subagent.
-- Be concise in your responses. Show file paths clearly when working with files.
+- After a subagent returns, review the output. If corrections are needed, spawn a follow-up subagent with the correction task.
+- Be concise in your responses.
 - **Pattern recognition**: If the same implementation pattern is needed more than twice, stop and treat it as a design task. Define the abstraction, then delegate each implementation to the appropriate subagent. Recognizing the pattern and specifying the abstraction is higher-value work than producing each variation.
+- **Sharing context between agents**: Pass plans, exploration results, design specs, and other structured findings between agents as Markdown files written to a temporary working directory. Do not rely on embedding large context blobs directly in subagent prompts — instead write a file and instruct the subagent to read it.
 
 ## Phase Tagging for Analytics
 
@@ -108,16 +81,13 @@ Track your current work phase and set the appropriate tag to enable usage analyt
 User: "Add user authentication"
 → phase:explore (read existing auth code, understand patterns)
 → phase:plan (design auth flow, decide on implementation)
-→ phase:build (implement the auth code)
+→ phase:build (delegate implementation to a subagent)
 → phase:review (verify the implementation)
 ```
 
-- Before doing any work, state your decision in one short paragraph:
-  - If handling it yourself: the classification and reason.
-  - If delegating: the model chosen, why, and what it is being asked to do.
-  - After a subagent returns: what it produced and how you will continue (apply as-is, adjust, or correct).
-- Do not start the actual work until you have stated your decision.
-- Before running a sequence of tool calls, briefly explain what you are about to do and why.
+- Before doing any work, state your delegation plan in one short paragraph: the strategy chosen, the model(s) selected, and what each subagent is being asked to do.
+- Do not start any work until you have stated your plan.
+- Before running a sequence of tool calls for exploration, briefly explain what you are about to look at and why.
 
 {{PROJECT_CONTEXT}}
 

--- a/src/extensions/orchestration/prompt-transformer/prompts/transformed-user-prompt.md.template
+++ b/src/extensions/orchestration/prompt-transformer/prompts/transformed-user-prompt.md.template
@@ -18,11 +18,7 @@ All models (including yourself) are described with the following attributes:
 
 **Description** is a summary of the model's unique capabilities and what it excels at.
 
-## You — {{CURRENT_MODEL_NAME}}
-
-{{CURRENT_MODEL_CAPABILITIES}}
-
-## Available Models for Subagents
+## Available Models
 
 {{MODELS}}
 

--- a/src/extensions/subagent.test.ts
+++ b/src/extensions/subagent.test.ts
@@ -4,61 +4,78 @@ import { parseSubagentEvent } from "./subagent.js"
 describe("parseSubagentEvent", () => {
 	const cases: Record<
 		string,
-		{ input: string; expected: { delta: string | null; inputTokens: number; outputTokens: number } }
+		{
+			input: string
+			expected: {
+				delta: string | null
+				inputTokens: number
+				outputTokens: number
+				toolCall: { name: string; args: Record<string, unknown> } | null
+			}
+		}
 	> = {
 		"returns delta for message_update text_delta event": {
 			input: JSON.stringify({
 				type: "message_update",
 				assistantMessageEvent: { type: "text_delta", delta: "hello" },
 			}),
-			expected: { delta: "hello", inputTokens: 0, outputTokens: 0 },
+			expected: { delta: "hello", inputTokens: 0, outputTokens: 0, toolCall: null },
 		},
 		"returns empty delta string": {
 			input: JSON.stringify({
 				type: "message_update",
 				assistantMessageEvent: { type: "text_delta", delta: "" },
 			}),
-			expected: { delta: "", inputTokens: 0, outputTokens: 0 },
+			expected: { delta: "", inputTokens: 0, outputTokens: 0, toolCall: null },
 		},
 		"ignores message_update events that are not text_delta": {
 			input: JSON.stringify({
 				type: "message_update",
 				assistantMessageEvent: { type: "thinking_delta", delta: "..." },
 			}),
-			expected: { delta: null, inputTokens: 0, outputTokens: 0 },
+			expected: { delta: null, inputTokens: 0, outputTokens: 0, toolCall: null },
 		},
 		"returns separate input and output tokens from message_end with usage": {
 			input: JSON.stringify({
 				type: "message_end",
 				message: { usage: { input: 100, output: 40 } },
 			}),
-			expected: { delta: null, inputTokens: 100, outputTokens: 40 },
+			expected: { delta: null, inputTokens: 100, outputTokens: 40, toolCall: null },
 		},
 		"returns zero tokens from message_end without usage": {
 			input: JSON.stringify({
 				type: "message_end",
 				message: {},
 			}),
-			expected: { delta: null, inputTokens: 0, outputTokens: 0 },
+			expected: { delta: null, inputTokens: 0, outputTokens: 0, toolCall: null },
 		},
 		"returns partial tokens from message_end with input only": {
 			input: JSON.stringify({
 				type: "message_end",
 				message: { usage: { input: 50 } },
 			}),
-			expected: { delta: null, inputTokens: 50, outputTokens: 0 },
+			expected: { delta: null, inputTokens: 50, outputTokens: 0, toolCall: null },
 		},
-		"ignores unrecognised event types": {
-			input: JSON.stringify({ type: "tool_execution_start", toolName: "bash" }),
-			expected: { delta: null, inputTokens: 0, outputTokens: 0 },
+		"returns tool call for tool_execution_start event": {
+			input: JSON.stringify({ type: "tool_execution_start", toolName: "bash", args: { command: "ls -la" } }),
+			expected: {
+				delta: null,
+				inputTokens: 0,
+				outputTokens: 0,
+				toolCall: { name: "bash", args: { command: "ls -la" } },
+			},
+		},
+		"returns tool call with empty args for tool_execution_start without args": {
+			input: JSON.stringify({ type: "tool_execution_start", toolName: "read", args: null }),
+			expected: { delta: null, inputTokens: 0, outputTokens: 0, toolCall: { name: "read", args: {} } },
 		},
 		"ignores blank lines": {
 			input: "   ",
-			expected: { delta: null, inputTokens: 0, outputTokens: 0 },
+			expected: { delta: null, inputTokens: 0, outputTokens: 0, toolCall: null },
 		},
 		"ignores invalid JSON": {
 			input: "not json {",
-			expected: { delta: null, inputTokens: 0, outputTokens: 0 },
+			expected: { delta: null, inputTokens: 0, outputTokens: 0, toolCall: null },
 		},
 	}
 

--- a/src/extensions/subagent.ts
+++ b/src/extensions/subagent.ts
@@ -396,6 +396,7 @@ export default function (pi: ExtensionAPI) {
 
 			if (!options.isPartial) {
 				clearSpinner(state)
+				state.lastToolCall = undefined
 			} else {
 				state.lastToolCall = result.details as string | undefined
 			}

--- a/src/extensions/subagent.ts
+++ b/src/extensions/subagent.ts
@@ -173,7 +173,7 @@ function spawnSubagent(
 			if (lineInput > 0 || lineOutput > 0) {
 				inputTokens += lineInput
 				outputTokens += lineOutput
-				if (tokenBudget !== undefined && inputTokens + outputTokens > tokenBudget) {
+				if (tokenBudget !== undefined && tokenBudget > 0 && inputTokens + outputTokens > tokenBudget) {
 					kill("token_budget_exceeded")
 				}
 			}
@@ -269,7 +269,8 @@ const SubagentParams = Type.Object({
 	prompt: Type.String({ description: "Prompt to send to the subagent" }),
 	tokenBudget: Type.Optional(
 		Type.Integer({
-			description: "Maximum total tokens (input + output) the subagent may consume. Subagent is killed when exceeded.",
+			description:
+				"Maximum total tokens (input + output) the subagent may consume. Subagent is killed when exceeded. Omit unless you have an explicit reason to cap token usage — do not set this speculatively.",
 			minimum: 1,
 		}),
 	),

--- a/src/extensions/subagent.ts
+++ b/src/extensions/subagent.ts
@@ -10,11 +10,12 @@ const SPINNER_FRAMES = ["⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "⠧", 
 const PROMPT_MAX_LENGTH = 60
 const FOOTER_STATUS_KEY = "subagent-sessions"
 const STDERR_MAX = 8192
-const TIMEOUT_MS = 15 * 60 * 1000
+const TIMEOUT_MS = 30 * 60 * 1000
 
 interface SubagentState {
 	spinnerIdx: number
 	spinnerInterval: ReturnType<typeof setInterval> | undefined
+	lastToolCall: string | undefined
 }
 
 type SubagentFailureReason = "exit_error" | "timeout" | "token_budget_exceeded" | "aborted"
@@ -45,6 +46,7 @@ interface ParsedSubagentEvent {
 	delta: string | null
 	inputTokens: number
 	outputTokens: number
+	toolCall: { name: string; args: Record<string, unknown> } | null
 }
 
 function resolveTsx(): string | undefined {
@@ -81,20 +83,20 @@ function getSubagentInvocation(args: string[]): { command: string; args: string[
 // input/output token counts from message_end events.
 // The event shapes are internal to pi-coding-agent and may change across versions.
 export function parseSubagentEvent(line: string): ParsedSubagentEvent {
-	if (!line.trim()) return { delta: null, inputTokens: 0, outputTokens: 0 }
+	if (!line.trim()) return { delta: null, inputTokens: 0, outputTokens: 0, toolCall: null }
 	let event: Record<string, unknown>
 	try {
 		event = JSON.parse(line)
 	} catch {
-		return { delta: null, inputTokens: 0, outputTokens: 0 }
+		return { delta: null, inputTokens: 0, outputTokens: 0, toolCall: null }
 	}
 
 	if (event.type === "message_update") {
 		const assistantEvent = event.assistantMessageEvent as Record<string, unknown> | undefined
 		if (assistantEvent?.type === "text_delta" && typeof assistantEvent.delta === "string") {
-			return { delta: assistantEvent.delta, inputTokens: 0, outputTokens: 0 }
+			return { delta: assistantEvent.delta, inputTokens: 0, outputTokens: 0, toolCall: null }
 		}
-		return { delta: null, inputTokens: 0, outputTokens: 0 }
+		return { delta: null, inputTokens: 0, outputTokens: 0, toolCall: null }
 	}
 
 	if (event.type === "message_end") {
@@ -103,11 +105,19 @@ export function parseSubagentEvent(line: string): ParsedSubagentEvent {
 		if (usage) {
 			const inputTokens = typeof usage.input === "number" ? usage.input : 0
 			const outputTokens = typeof usage.output === "number" ? usage.output : 0
-			return { delta: null, inputTokens, outputTokens }
+			return { delta: null, inputTokens, outputTokens, toolCall: null }
 		}
 	}
 
-	return { delta: null, inputTokens: 0, outputTokens: 0 }
+	if (event.type === "tool_execution_start") {
+		const name = typeof event.toolName === "string" ? event.toolName : null
+		const args = event.args !== null && typeof event.args === "object" ? (event.args as Record<string, unknown>) : {}
+		if (name !== null) {
+			return { delta: null, inputTokens: 0, outputTokens: 0, toolCall: { name, args } }
+		}
+	}
+
+	return { delta: null, inputTokens: 0, outputTokens: 0, toolCall: null }
 }
 
 function spawnSubagent(
@@ -116,6 +126,7 @@ function spawnSubagent(
 	signal: AbortSignal | undefined,
 	tokenBudget: number | undefined,
 	onToken: (accumulated: string) => void,
+	onToolCall: (name: string, args: Record<string, unknown>, accumulated: string) => void,
 ): Promise<SubagentResult> {
 	return new Promise((resolve) => {
 		const startedAt = Date.now()
@@ -165,7 +176,7 @@ function spawnSubagent(
 		}
 
 		const processLine = (line: string) => {
-			const { delta, inputTokens: lineInput, outputTokens: lineOutput } = parseSubagentEvent(line)
+			const { delta, inputTokens: lineInput, outputTokens: lineOutput, toolCall } = parseSubagentEvent(line)
 			if (delta !== null) {
 				accumulated += delta
 				onToken(accumulated)
@@ -176,6 +187,9 @@ function spawnSubagent(
 				if (tokenBudget !== undefined && tokenBudget > 0 && inputTokens + outputTokens > tokenBudget) {
 					kill("token_budget_exceeded")
 				}
+			}
+			if (toolCall !== null) {
+				onToolCall(toolCall.name, toolCall.args, accumulated)
 			}
 		}
 
@@ -305,12 +319,20 @@ export default function (pi: ExtensionAPI) {
 			]
 			const invocation = getSubagentInvocation(args)
 
+			let lastToolCall: string | undefined
 			const { exitCode, accumulated, stderr, tokenUsage, failureReason, durationMs } = await spawnSubagent(
 				invocation,
 				ctx.cwd,
 				signal,
 				params.tokenBudget,
-				(text) => onUpdate?.({ content: [{ type: "text", text }], details: undefined }),
+				(text) => onUpdate?.({ content: [{ type: "text", text }], details: lastToolCall }),
+				(name, toolArgs, text) => {
+					const firstArg = Object.values(toolArgs)[0]
+					const argHint =
+						typeof firstArg === "string" ? ` ${firstArg.slice(0, 60)}${firstArg.length > 60 ? "…" : ""}` : ""
+					lastToolCall = `${name}${argHint}`
+					onUpdate?.({ content: [{ type: "text", text }], details: lastToolCall })
+				},
 			)
 
 			sessionCounts.set(params.model, (sessionCounts.get(params.model) ?? 0) + 1)
@@ -362,9 +384,10 @@ export default function (pi: ExtensionAPI) {
 			const header = `${spinner} ${theme.fg("toolTitle", theme.bold("Subagent session"))}`
 			const modelLine = `  ${theme.fg("muted", "model:")}  ${theme.fg("accent", "`")}${theme.fg("accent", `${args.provider ?? ""}/${args.model ?? ""}`)}${theme.fg("accent", "`")}`
 			const promptLine = `  ${theme.fg("muted", "prompt:")} ${theme.fg("dim", "`")}${theme.fg("dim", truncatePrompt(args.prompt ?? ""))}${theme.fg("dim", "`")}`
+			const lines = [header, modelLine, promptLine]
 
 			const component = context.lastComponent ?? new Text("", 0, 0)
-			;(component as Text).setText([header, modelLine, promptLine].join("\n"))
+			;(component as Text).setText(lines.join("\n"))
 			return component
 		},
 
@@ -373,19 +396,28 @@ export default function (pi: ExtensionAPI) {
 
 			if (!options.isPartial) {
 				clearSpinner(state)
+			} else {
+				state.lastToolCall = result.details as string | undefined
 			}
 
 			const textContent = result.content.find((c): c is { type: "text"; text: string } => c.type === "text")
 			if (!textContent?.text) return new Text("", 0, 0)
 
-			const displayText = textContent.text.split("\n").slice(-5).join("\n")
+			const lines = options.isPartial ? textContent.text.split("\n").slice(-20) : textContent.text.split("\n")
+			const displayText = lines.filter((l) => l.trim()).join("\n")
 
 			const component = context.lastComponent instanceof Container ? context.lastComponent : new Container()
 			component.clear()
 			component.addChild(new Spacer(1))
 			component.addChild(new Text(theme.fg("toolOutput", displayText), 0, 0))
 
-			if (!options.isPartial) {
+			if (options.isPartial) {
+				const toolCall = state.lastToolCall
+				if (toolCall) {
+					component.addChild(new Spacer(1))
+					component.addChild(new Text(theme.fg("dim", `> ${toolCall}`), 0, 0))
+				}
+			} else {
 				const stats = result.details as SubagentStats | undefined
 				if (stats !== undefined) {
 					component.addChild(new Spacer(1))


### PR DESCRIPTION
## Scope

Here is a set of orchestration improvements based on the set of testing implementation sessions.
 
The changes above were developed iteratively, using the orchestration setup itself as the test bench. The test prompt was a deliberately broad, multi-step task that required exploration, design decisions, and parallel implementation work across multiple files:
```
Implement an up to date ReactJS app that will follow all current architectural patterns and tech-stack. The app should present current availability of GPU nodes in GCP and AWS.
```

Each iteration surfaced a new failure mode in the orchestration behaviour, which informed the next round of changes.

## Key observation — Kimi K2.5 as orchestrator

Testing shows that Kimi K2.5 is currently the strongest orchestrator model we have. It reliably follows complex system prompt constraints and stays in the coordination role without drifting into self-implementation, which other models consistently struggled with.

Kimi K2.5 was the only model that handled this reliably end-to-end: it decomposed the work correctly, delegated to the right subagents, and produced output aligned with current React architectural patterns and the modern tech stack. It's worth setting Kimi K2.5 as the default orchestrator model going forward.

## Orchestrator is now delegation-only

Previously, the orchestrator prompt let the model handle tasks directly when they looked simple. In practice, models almost always chose that path — doing the coding themselves instead of coordinating subagents. The orchestrator's purpose is decomposition and routing, not implementation.

I removed the self-implementation option entirely and made the constraint explicit: the orchestrator never writes, edits, or runs code. The EASY/HARD task classification only existed to control that path, so it has been removed as well.

## All models are now equal delegation candidates

The previous user prompt identified which model was acting as orchestrator and then excluded it from the available models list. This had two effects: it reinforced the orchestrator's sense of being a special actor (nudging it toward self-implementation), and it blocked the orchestrator from delegating back to itself even when that was the best option.

By removing the self-identification section, the orchestrator now treats all models — including itself — as equal delegation targets, chosen purely based on capability fit.

## Inter-agent context via Markdown files

Without clear guidance, the orchestrator was inlining large context blobs (exploration results, design specs, plans) directly into subagent prompts. This is expensive — we pay for the same tokens twice — and brittle near prompt length limits.

I added a guideline to write structured findings to a Markdown file and pass the file path to the next agent. This keeps prompts lean and makes phase handoffs explicit.

## Token budget — no speculative usage

The orchestrator was sometimes cutting off subagents mid-task by setting a tokenBudget on its own initiative. The field description explained what it does but not when to leave it unset. Since LLMs tend to fill in optional fields they can reason about, and the system prompt emphasized cost-efficiency, there was enough signal to guess a number.

I updated the description to say "do not set this speculatively," making the default intent explicit.

## Subagent tool call visibility

During a subagent session, the TUI only showed the streaming text output with no indication of what tools the subagent was actively executing. This made it hard to tell whether the agent was making progress or stuck.

The subagent process now parses `tool_execution_start` events from the JSON stream and surfaces the active tool call as a single line below the streaming output, formatted as `> toolname arg`. The line updates as each new tool is invoked and is replaced by timing and token stats once the session completes. Empty lines are filtered from the displayed output to avoid unnecessary whitespace.