### PR TITLE
NOJIRA: Fix models not loaded in dev mode

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
 		"build:binary": "node scripts/build-binary.js",
 		"build:binary-linux-arm64": "node scripts/build-binary.js --target linux-arm64",
 		"build:binary-linux-x64": "node scripts/build-binary.js --target linux-x64",
-		"dev": "bun run src/cli.ts",
+		"dev": "bun run --preload ./src/set-package-dir.ts src/cli.ts",
 		"lint": "biome check src/ scripts/",
 		"lint:fix": "biome check --write src/ scripts/",
 		"typecheck": "tsc --noEmit",

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,20 +1,7 @@
 #!/usr/bin/env node
 
 import { homedir } from "node:os"
-import { dirname, resolve } from "node:path"
-import { fileURLToPath } from "node:url"
-
-import { isBunBinary } from "./env.js"
-
-// Set PI_PACKAGE_DIR before any pi-mono imports so piConfig is discovered
-// from this project's package.json (which sets name: "kimchi").
-// In a bun-compiled binary, import.meta.url points to a virtual filesystem
-// ($bunfs), so we skip the override and let pi-mono's built-in detection use
-// dirname(process.execPath) instead — package.json is shipped next to the binary.
-if (!isBunBinary) {
-	const __dirname = dirname(fileURLToPath(import.meta.url))
-	process.env.PI_PACKAGE_DIR = resolve(__dirname, "..")
-}
+import { resolve } from "node:path"
 
 // Set agent config directory before any pi-mono imports.
 // pi-mono computes the env var name as APP_NAME.toUpperCase() + "_CODING_AGENT_DIR",

--- a/src/set-package-dir.ts
+++ b/src/set-package-dir.ts
@@ -1,0 +1,5 @@
+import { dirname, resolve } from "node:path"
+import { fileURLToPath } from "node:url"
+
+const __dirname = dirname(fileURLToPath(import.meta.url))
+process.env.PI_PACKAGE_DIR = resolve(__dirname, "..")


### PR DESCRIPTION
In ESM, static imports are resolved and executed before the importing module's body runs. Setting `PI_PACKAGE_DIR` inside `cli.ts` was always too late — `pi-coding-agent`'s `config.js` had already evaluated, walked up to its own `package.json`, and set `APP_NAME` to `"pi"`, causing the agent dir to resolve to `~/.pi/agent/` instead of `~/.config/kimchi/harness/`. Moving the assignment into a Bun preload script (`set-package-dir.ts`) ensures it runs before any module is evaluated, fixing model loading in dev mode without affecting the compiled binary.