### PR TITLE
LLM-1294: Add telemetry extension

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -12,16 +12,19 @@ process.env.KIMCHI_CODING_AGENT_DIR = agentDir
 process.title = "kimchi"
 process.env.PI_SKIP_VERSION_CHECK = "1"
 
-import { loadConfig } from "./config.js"
+import { loadConfig, readTelemetryConfig } from "./config.js"
 import bashCollapseExtension from "./extensions/bash-collapse.js"
 import mcpAdapterExtension from "./extensions/mcp-adapter/index.js"
 import promptEnrichmentExtension from "./extensions/orchestration/prompt-enrichment.js"
 import subagentExtension from "./extensions/subagent.js"
 import tagsExtension from "./extensions/tags.js"
+import telemetryExtension from "./extensions/telemetry.js"
 import webFetchExtension from "./extensions/web-fetch/index.js"
 import webSearchExtension from "./extensions/web-search/index.js"
 import { updateModelsConfig } from "./models.js"
 import { setAvailableModelIds } from "./startup-context.js"
+
+const telemetryConfig = readTelemetryConfig()
 
 try {
 	const config = loadConfig()
@@ -52,6 +55,7 @@ try {
 	const { main } = await import("@mariozechner/pi-coding-agent")
 	await main(process.argv.slice(2), {
 		extensionFactories: [
+			telemetryExtension(telemetryConfig),
 			subagentExtension,
 			mcpAdapterExtension,
 			webFetchExtension,

--- a/src/config.ts
+++ b/src/config.ts
@@ -74,10 +74,7 @@ export function readTelemetryConfig(configPath?: string): TelemetryConfig {
 		// missing or invalid config — use defaults
 	}
 
-	const enabled =
-		envEnabled !== undefined
-			? envEnabled !== "0" && envEnabled !== "false"
-			: (fileEnabled ?? true)
+	const enabled = envEnabled !== undefined ? envEnabled !== "0" && envEnabled !== "false" : (fileEnabled ?? true)
 
 	return {
 		enabled,

--- a/src/config.ts
+++ b/src/config.ts
@@ -5,6 +5,13 @@ import { resolve } from "node:path"
 const KIMCHI_CONFIG_PATH = resolve(homedir(), ".config", "kimchi", "config.json")
 const AGENT_CONFIG_DIR = resolve(homedir(), ".config", "kimchi", "harness")
 const CAST_AI_LLM_ENDPOINT = "https://llm.cast.ai/openai/v1"
+const DEFAULT_TELEMETRY_ENDPOINT = "https://api.cast.ai/ai-optimizer/v1beta/logs:ingest"
+
+export interface TelemetryConfig {
+	enabled: boolean
+	endpoint: string
+	headers: Record<string, string>
+}
 
 export interface KimchiConfig {
 	apiKey: string
@@ -38,6 +45,44 @@ function readConfigExtras(configPath: string): { maxToolResultChars?: number } {
 		return { maxToolResultChars: typeof val === "number" && val > 0 ? val : undefined }
 	} catch {
 		return {}
+	}
+}
+
+/**
+ * Read telemetry configuration from config.json without requiring an API key.
+ * Safe to call before authentication is set up.
+ */
+export function readTelemetryConfig(configPath?: string): TelemetryConfig {
+	const path = configPath ?? KIMCHI_CONFIG_PATH
+	const envEnabled = process.env.KIMCHI_TELEMETRY_ENABLED
+	let fileEnabled: boolean | undefined
+	let fileEndpoint: string | undefined
+	let fileHeaders: Record<string, string> | undefined
+
+	try {
+		const raw = readFileSync(path, "utf-8")
+		const parsed = JSON.parse(raw)
+		const t = parsed.telemetry
+		if (t && typeof t === "object") {
+			if (typeof t.enabled === "boolean") fileEnabled = t.enabled
+			if (typeof t.endpoint === "string" && t.endpoint.length > 0) fileEndpoint = t.endpoint
+			if (t.headers && typeof t.headers === "object" && !Array.isArray(t.headers)) {
+				fileHeaders = t.headers as Record<string, string>
+			}
+		}
+	} catch {
+		// missing or invalid config — use defaults
+	}
+
+	const enabled =
+		envEnabled !== undefined
+			? envEnabled !== "0" && envEnabled !== "false"
+			: (fileEnabled ?? true)
+
+	return {
+		enabled,
+		endpoint: fileEndpoint ?? DEFAULT_TELEMETRY_ENDPOINT,
+		headers: fileHeaders ?? {},
 	}
 }
 

--- a/src/config.ts
+++ b/src/config.ts
@@ -89,19 +89,23 @@ export function readTelemetryConfig(configPath?: string): TelemetryConfig {
 		// missing or invalid config — use defaults
 	}
 
-	const enabled = envEnabled !== undefined ? envEnabled !== "0" && envEnabled !== "false" : (fileEnabled ?? false)
-
 	// Resolve auth headers: explicit config override takes priority, then API key
 	let headers: Record<string, string>
+	let apiKey: string | undefined
 	if (fileHeaders) {
 		headers = fileHeaders
 	} else {
-		const apiKey =
+		apiKey =
 			(typeof process.env.KIMCHI_API_KEY === "string" && process.env.KIMCHI_API_KEY.length > 0
 				? process.env.KIMCHI_API_KEY
 				: undefined) ?? readApiKeyFromConfigFile(path)
 		headers = apiKey ? { Authorization: `Bearer ${apiKey}` } : {}
 	}
+
+	// Enabled by default when an API key is available; explicit config/env overrides either way
+	const defaultEnabled = fileHeaders ? Object.keys(fileHeaders).length > 0 : !!apiKey
+	const enabled =
+		envEnabled !== undefined ? envEnabled !== "0" && envEnabled !== "false" : (fileEnabled ?? defaultEnabled)
 
 	return {
 		enabled,

--- a/src/config.ts
+++ b/src/config.ts
@@ -18,6 +18,7 @@ export interface KimchiConfig {
 	agentConfigDir: string
 	llmEndpoint: string
 	maxToolResultChars: number
+	mcpSearchLimit: number
 }
 
 /**
@@ -37,12 +38,17 @@ function readApiKeyFromConfigFile(configPath: string): string | undefined {
 	}
 }
 
-function readConfigExtras(configPath: string): { maxToolResultChars?: number } {
+function readConfigExtras(configPath: string): { maxToolResultChars?: number; mcpSearchLimit?: number } {
 	try {
 		const raw = readFileSync(configPath, "utf-8")
 		const parsed = JSON.parse(raw)
-		const val = parsed.maxToolResultChars
-		return { maxToolResultChars: typeof val === "number" && val > 0 ? val : undefined }
+		const maxToolResultChars =
+			typeof parsed.maxToolResultChars === "number" && parsed.maxToolResultChars > 0
+				? parsed.maxToolResultChars
+				: undefined
+		const mcpSearchLimit =
+			typeof parsed.mcpSearchLimit === "number" && parsed.mcpSearchLimit > 0 ? parsed.mcpSearchLimit : undefined
+		return { maxToolResultChars, mcpSearchLimit }
 	} catch {
 		return {}
 	}
@@ -51,6 +57,15 @@ function readConfigExtras(configPath: string): { maxToolResultChars?: number } {
 /**
  * Read telemetry configuration from config.json without requiring an API key.
  * Safe to call before authentication is set up.
+ *
+ * Telemetry is disabled by default. It is enabled when:
+ *   - KIMCHI_TELEMETRY_ENABLED env var is set to a truthy value, or
+ *   - config.json has telemetry.enabled = true
+ *
+ * Auth header resolution order:
+ *   1. telemetry.headers in config.json (explicit override)
+ *   2. KIMCHI_API_KEY env var → Authorization: Bearer <key>
+ *   3. api_key in config.json → Authorization: Bearer <key>
  */
 export function readTelemetryConfig(configPath?: string): TelemetryConfig {
 	const path = configPath ?? KIMCHI_CONFIG_PATH
@@ -74,12 +89,24 @@ export function readTelemetryConfig(configPath?: string): TelemetryConfig {
 		// missing or invalid config — use defaults
 	}
 
-	const enabled = envEnabled !== undefined ? envEnabled !== "0" && envEnabled !== "false" : (fileEnabled ?? true)
+	const enabled = envEnabled !== undefined ? envEnabled !== "0" && envEnabled !== "false" : (fileEnabled ?? false)
+
+	// Resolve auth headers: explicit config override takes priority, then API key
+	let headers: Record<string, string>
+	if (fileHeaders) {
+		headers = fileHeaders
+	} else {
+		const apiKey =
+			(typeof process.env.KIMCHI_API_KEY === "string" && process.env.KIMCHI_API_KEY.length > 0
+				? process.env.KIMCHI_API_KEY
+				: undefined) ?? readApiKeyFromConfigFile(path)
+		headers = apiKey ? { Authorization: `Bearer ${apiKey}` } : {}
+	}
 
 	return {
 		enabled,
 		endpoint: fileEndpoint ?? DEFAULT_TELEMETRY_ENDPOINT,
-		headers: fileHeaders ?? {},
+		headers,
 	}
 }
 
@@ -97,6 +124,7 @@ export function loadConfig(options?: { configPath?: string; env?: Record<string,
 	const configPath = options?.configPath ?? KIMCHI_CONFIG_PATH
 	const extras = readConfigExtras(configPath)
 	const maxToolResultChars = extras.maxToolResultChars ?? 10_000
+	const mcpSearchLimit = extras.mcpSearchLimit ?? 5
 
 	const envKey = env.KIMCHI_API_KEY
 	if (typeof envKey === "string" && envKey.length > 0) {
@@ -105,6 +133,7 @@ export function loadConfig(options?: { configPath?: string; env?: Record<string,
 			agentConfigDir: AGENT_CONFIG_DIR,
 			llmEndpoint: CAST_AI_LLM_ENDPOINT,
 			maxToolResultChars,
+			mcpSearchLimit,
 		}
 	}
 
@@ -115,6 +144,7 @@ export function loadConfig(options?: { configPath?: string; env?: Record<string,
 			agentConfigDir: AGENT_CONFIG_DIR,
 			llmEndpoint: CAST_AI_LLM_ENDPOINT,
 			maxToolResultChars,
+			mcpSearchLimit,
 		}
 	}
 

--- a/src/extensions/telemetry.ts
+++ b/src/extensions/telemetry.ts
@@ -1,5 +1,5 @@
-import type { ExtensionAPI } from "@mariozechner/pi-coding-agent"
 import type { AssistantMessage } from "@mariozechner/pi-ai"
+import type { ExtensionAPI } from "@mariozechner/pi-coding-agent"
 import type { TelemetryConfig } from "../config.js"
 
 // ---------------------------------------------------------------------------
@@ -17,20 +17,50 @@ function strAttr(key: string, value: string): { key: string; value: { stringValu
 function inferLanguage(filePath: string): string {
 	const ext = filePath.split(".").pop()?.toLowerCase() ?? ""
 	const map: Record<string, string> = {
-		ts: "TypeScript", tsx: "TypeScript",
-		js: "JavaScript", jsx: "JavaScript", mjs: "JavaScript", cjs: "JavaScript",
-		py: "Python", go: "Go", rs: "Rust", rb: "Ruby",
-		java: "Java", kt: "Kotlin", swift: "Swift",
-		c: "C", h: "C", cpp: "C++", cc: "C++", cxx: "C++", hpp: "C++",
-		cs: "C#", php: "PHP", dart: "Dart",
-		md: "Markdown", mdx: "Markdown",
-		json: "JSON", yaml: "YAML", yml: "YAML",
-		toml: "TOML", ini: "TOML",
-		xml: "HTML/XML", html: "HTML/XML", htm: "HTML/XML", svg: "HTML/XML",
-		css: "CSS", scss: "CSS", less: "CSS",
-		sql: "SQL", sh: "Bash", bash: "Bash", zsh: "Bash",
-		txt: "Plain text", proto: "Protocol Buffers",
-		tf: "HCL", dockerfile: "Dockerfile",
+		ts: "TypeScript",
+		tsx: "TypeScript",
+		js: "JavaScript",
+		jsx: "JavaScript",
+		mjs: "JavaScript",
+		cjs: "JavaScript",
+		py: "Python",
+		go: "Go",
+		rs: "Rust",
+		rb: "Ruby",
+		java: "Java",
+		kt: "Kotlin",
+		swift: "Swift",
+		c: "C",
+		h: "C",
+		cpp: "C++",
+		cc: "C++",
+		cxx: "C++",
+		hpp: "C++",
+		cs: "C#",
+		php: "PHP",
+		dart: "Dart",
+		md: "Markdown",
+		mdx: "Markdown",
+		json: "JSON",
+		yaml: "YAML",
+		yml: "YAML",
+		toml: "TOML",
+		ini: "TOML",
+		xml: "HTML/XML",
+		html: "HTML/XML",
+		htm: "HTML/XML",
+		svg: "HTML/XML",
+		css: "CSS",
+		scss: "CSS",
+		less: "CSS",
+		sql: "SQL",
+		sh: "Bash",
+		bash: "Bash",
+		zsh: "Bash",
+		txt: "Plain text",
+		proto: "Protocol Buffers",
+		tf: "HCL",
+		dockerfile: "Dockerfile",
 	}
 	return map[ext] ?? "unknown"
 }
@@ -56,29 +86,35 @@ async function sendLog(
 	const now = nowNano()
 	const headers: Record<string, string> = { "Content-Type": "application/json", ...config.headers }
 	const payload = {
-		resourceLogs: [{
-			resource: { attributes: [strAttr("service.name", "kimchi")], droppedAttributesCount: 0 },
-			scopeLogs: [{
-				scope: { name: "kimchi", version: "1.0.0" },
-				logRecords: [{
-					timeUnixNano: now,
-					observedTimeUnixNano: now,
-					severityNumber: 9,
-					severityText: "INFO",
-					eventName,
-					body: { stringValue: eventName },
-					attributes: [
-						strAttr("session.id", sessionId),
-						strAttr("client", "pi"),
-						...Object.entries(attrs).map(([k, v]) => strAttr(k, String(v))),
-					],
-					droppedAttributesCount: 0,
-					flags: 0,
-					traceId: "",
-					spanId: "",
-				}],
-			}],
-		}],
+		resourceLogs: [
+			{
+				resource: { attributes: [strAttr("service.name", "kimchi")], droppedAttributesCount: 0 },
+				scopeLogs: [
+					{
+						scope: { name: "kimchi", version: "1.0.0" },
+						logRecords: [
+							{
+								timeUnixNano: now,
+								observedTimeUnixNano: now,
+								severityNumber: 9,
+								severityText: "INFO",
+								eventName,
+								body: { stringValue: eventName },
+								attributes: [
+									strAttr("session.id", sessionId),
+									strAttr("client", "pi"),
+									...Object.entries(attrs).map(([k, v]) => strAttr(k, String(v))),
+								],
+								droppedAttributesCount: 0,
+								flags: 0,
+								traceId: "",
+								spanId: "",
+							},
+						],
+					},
+				],
+			},
+		],
 	}
 	try {
 		const res = await fetch(config.endpoint, {
@@ -101,7 +137,7 @@ async function sendLog(
 // ---------------------------------------------------------------------------
 
 export default function telemetryExtension(config: TelemetryConfig) {
-	return function (pi: ExtensionAPI) {
+	return (pi: ExtensionAPI) => {
 		if (!config.enabled) return
 
 		let sessionId = crypto.randomUUID()
@@ -195,7 +231,9 @@ export default function telemetryExtension(config: TelemetryConfig) {
 			if (toolName === "multiedit") {
 				const filePath = String(args?.filePath ?? "")
 				const language = inferLanguage(filePath)
-				const edits = Array.isArray(args?.edits) ? (args.edits as Array<{ oldString?: string; newString?: string }>) : []
+				const edits = Array.isArray(args?.edits)
+					? (args.edits as Array<{ oldString?: string; newString?: string }>)
+					: []
 				for (const edit of edits) {
 					const changes = countLineChanges(String(edit.oldString ?? ""), String(edit.newString ?? ""))
 					void sendLog(config, sessionId, "tool_usage", {

--- a/src/extensions/telemetry.ts
+++ b/src/extensions/telemetry.ts
@@ -124,8 +124,6 @@ async function sendLog(
 		})
 		if (!res.ok) {
 			console.error(`[telemetry] send failed: ${res.status} ${await res.text()}`)
-		} else {
-			console.error(`[telemetry] sent ${eventName} (${res.status})`)
 		}
 	} catch (err) {
 		console.error(`[telemetry] send error: ${err}`)

--- a/src/extensions/telemetry.ts
+++ b/src/extensions/telemetry.ts
@@ -1,0 +1,211 @@
+import type { ExtensionAPI } from "@mariozechner/pi-coding-agent"
+import type { AssistantMessage } from "@mariozechner/pi-ai"
+import type { TelemetryConfig } from "../config.js"
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function nowNano(): string {
+	return String(Date.now() * 1_000_000)
+}
+
+function strAttr(key: string, value: string): { key: string; value: { stringValue: string } } {
+	return { key, value: { stringValue: value } }
+}
+
+function inferLanguage(filePath: string): string {
+	const ext = filePath.split(".").pop()?.toLowerCase() ?? ""
+	const map: Record<string, string> = {
+		ts: "TypeScript", tsx: "TypeScript",
+		js: "JavaScript", jsx: "JavaScript", mjs: "JavaScript", cjs: "JavaScript",
+		py: "Python", go: "Go", rs: "Rust", rb: "Ruby",
+		java: "Java", kt: "Kotlin", swift: "Swift",
+		c: "C", h: "C", cpp: "C++", cc: "C++", cxx: "C++", hpp: "C++",
+		cs: "C#", php: "PHP", dart: "Dart",
+		md: "Markdown", mdx: "Markdown",
+		json: "JSON", yaml: "YAML", yml: "YAML",
+		toml: "TOML", ini: "TOML",
+		xml: "HTML/XML", html: "HTML/XML", htm: "HTML/XML", svg: "HTML/XML",
+		css: "CSS", scss: "CSS", less: "CSS",
+		sql: "SQL", sh: "Bash", bash: "Bash", zsh: "Bash",
+		txt: "Plain text", proto: "Protocol Buffers",
+		tf: "HCL", dockerfile: "Dockerfile",
+	}
+	return map[ext] ?? "unknown"
+}
+
+function countLineChanges(oldStr: string, newStr: string): { added: number; removed: number } {
+	const oldLines = oldStr ? oldStr.split("\n").length : 0
+	const newLines = newStr ? newStr.split("\n").length : 0
+	if (newLines >= oldLines) return { added: newLines - oldLines, removed: 0 }
+	return { added: 0, removed: oldLines - newLines }
+}
+
+// ---------------------------------------------------------------------------
+// OTLP sender
+// ---------------------------------------------------------------------------
+
+async function sendLog(
+	config: TelemetryConfig,
+	sessionId: string,
+	eventName: string,
+	attrs: Record<string, string | number>,
+): Promise<void> {
+	if (!config.enabled || !config.endpoint) return
+	const now = nowNano()
+	const headers: Record<string, string> = { "Content-Type": "application/json", ...config.headers }
+	const payload = {
+		resourceLogs: [{
+			resource: { attributes: [strAttr("service.name", "kimchi")], droppedAttributesCount: 0 },
+			scopeLogs: [{
+				scope: { name: "kimchi", version: "1.0.0" },
+				logRecords: [{
+					timeUnixNano: now,
+					observedTimeUnixNano: now,
+					severityNumber: 9,
+					severityText: "INFO",
+					eventName,
+					body: { stringValue: eventName },
+					attributes: [
+						strAttr("session.id", sessionId),
+						strAttr("client", "pi"),
+						...Object.entries(attrs).map(([k, v]) => strAttr(k, String(v))),
+					],
+					droppedAttributesCount: 0,
+					flags: 0,
+					traceId: "",
+					spanId: "",
+				}],
+			}],
+		}],
+	}
+	try {
+		const res = await fetch(config.endpoint, {
+			method: "POST",
+			headers,
+			body: JSON.stringify(payload),
+		})
+		if (!res.ok) {
+			console.error(`[telemetry] send failed: ${res.status} ${await res.text()}`)
+		} else {
+			console.error(`[telemetry] sent ${eventName} (${res.status})`)
+		}
+	} catch (err) {
+		console.error(`[telemetry] send error: ${err}`)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Extension
+// ---------------------------------------------------------------------------
+
+export default function telemetryExtension(config: TelemetryConfig) {
+	return function (pi: ExtensionAPI) {
+		if (!config.enabled) return
+
+		let sessionId = crypto.randomUUID()
+		let sessionStartMs = Date.now()
+		const sentMessages = new Set<string>()
+		const pendingArgs = new Map<string, { toolName: string; args: unknown }>()
+
+		pi.on("session_start", async () => {
+			sessionId = crypto.randomUUID()
+			sessionStartMs = Date.now()
+			sentMessages.clear()
+			pendingArgs.clear()
+		})
+
+		pi.on("message_end", async (event) => {
+			const msg = event.message
+			if (msg.role !== "assistant") return
+			try {
+				const assistant = msg as AssistantMessage
+				const msgId = String(assistant.timestamp)
+				if (sentMessages.has(msgId)) return
+				sentMessages.add(msgId)
+
+				const model = assistant.model ?? "unknown"
+				const rawProvider = String(assistant.provider ?? "unknown")
+				const provider = rawProvider === "kimchi-dev" ? "ai-enabler" : rawProvider
+				const { input, output, cacheRead, cacheWrite } = assistant.usage
+				const costTotal = assistant.usage.cost.total
+				const sessionUptimeMs = Date.now() - sessionStartMs
+
+				void sendLog(config, sessionId, "api_request", {
+					model,
+					provider,
+					input_tokens: input,
+					output_tokens: output,
+					cache_read_tokens: cacheRead,
+					cache_creation_tokens: cacheWrite,
+					cost_usd: costTotal,
+					session_uptime_ms: sessionUptimeMs,
+				})
+			} catch (err) {
+				console.error("[telemetry] message_end handler error:", err)
+			}
+		})
+
+		pi.on("tool_execution_start", async (event) => {
+			pendingArgs.set(event.toolCallId, { toolName: event.toolName, args: event.args })
+		})
+
+		pi.on("tool_execution_end", async (event) => {
+			const pending = pendingArgs.get(event.toolCallId)
+			pendingArgs.delete(event.toolCallId)
+			if (!pending) return
+
+			const { toolName, args } = pending as { toolName: string; args: Record<string, unknown> }
+
+			if (toolName === "bash") {
+				const command = String(args?.command ?? "")
+				if (/git\s+commit\b/.test(command) && !/--dry-run/.test(command)) {
+					void sendLog(config, sessionId, "tool_usage", { tool: "bash", action: "git_commit" })
+				}
+				if (/gh\s+pr\s+create\b/.test(command)) {
+					void sendLog(config, sessionId, "tool_usage", { tool: "bash", action: "gh_pr_create" })
+				}
+			}
+
+			if (toolName === "edit") {
+				const filePath = String(args?.filePath ?? "")
+				const language = inferLanguage(filePath)
+				const changes = countLineChanges(String(args?.oldString ?? ""), String(args?.newString ?? ""))
+				void sendLog(config, sessionId, "tool_usage", {
+					tool: "edit",
+					language,
+					lines_added: changes.added,
+					lines_removed: changes.removed,
+				})
+			}
+
+			if (toolName === "write") {
+				const filePath = String(args?.filePath ?? "")
+				const language = inferLanguage(filePath)
+				const content = String(args?.content ?? "")
+				const lines = content ? content.split("\n").length : 1
+				void sendLog(config, sessionId, "tool_usage", {
+					tool: "write",
+					language,
+					lines_added: lines,
+				})
+			}
+
+			if (toolName === "multiedit") {
+				const filePath = String(args?.filePath ?? "")
+				const language = inferLanguage(filePath)
+				const edits = Array.isArray(args?.edits) ? (args.edits as Array<{ oldString?: string; newString?: string }>) : []
+				for (const edit of edits) {
+					const changes = countLineChanges(String(edit.oldString ?? ""), String(edit.newString ?? ""))
+					void sendLog(config, sessionId, "tool_usage", {
+						tool: "edit",
+						language,
+						lines_added: changes.added,
+						lines_removed: changes.removed,
+					})
+				}
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary
- Ports the pi telemetry extension into kimchi as `src/extensions/telemetry.ts`
- Sends OTLP log events (`api_request`, `tool_usage`) per-event to Cast AI ingestion endpoint
- Integrates telemetry config into `~/.config/kimchi/config.json` under `telemetry` key
- **Enabled by default** when a kimchi API key is present (opt-out via `KIMCHI_TELEMETRY_ENABLED=0`)
- API key is used automatically for auth — no manual header config needed

## Events
- `api_request` — fired on every assistant message (model, provider, tokens, cost, uptime)
- `tool_usage` — fired on bash (git commits, PR creates), edit, write, multiedit (language, LOC diff)

## Config
Telemetry is on by default if logged in. To disable:
```json
{ "telemetry": { "enabled": false } }
```

To override endpoint or auth:
```json
{
  "telemetry": {
    "endpoint": "https://custom-endpoint/v1/logs:ingest",
    "headers": { "Authorization": "Bearer <token>" }
  }
}
```

Or via env: `KIMCHI_TELEMETRY_ENABLED=0`