### PR TITLE
NOJIRA: Add ability to ignore deprecated models

### DIFF
--- a/src/ansi.ts
+++ b/src/ansi.ts
@@ -1,0 +1,9 @@
+export function fg(code: string, text: string): string {
+	if (!code) return text
+	return `\x1b[${code}m${text}\x1b[0m`
+}
+
+export const ANSI = {
+	accent: "38;2;138;190;183",
+	dim: "38;2;102;102;102",
+}

--- a/src/extensions/mcp-adapter/mcp-panel.ts
+++ b/src/extensions/mcp-adapter/mcp-panel.ts
@@ -1,4 +1,5 @@
 import { matchesKey, truncateToWidth, visibleWidth } from "@mariozechner/pi-tui"
+import { fg } from "../../ansi.js"
 import type { CachedTool, MetadataCache, ServerCacheEntry } from "./metadata-cache.js"
 import { resourceNameToToolName } from "./resource-tools.js"
 import { isToolExcluded } from "./types.js"
@@ -30,10 +31,6 @@ const DEFAULT_THEME: PanelTheme = {
 	cancel: "31",
 }
 
-function fg(code: string, text: string): string {
-	if (!code) return text
-	return `\x1b[${code}m${text}\x1b[0m`
-}
 
 const RAINBOW_COLORS = [
 	"38;2;178;129;214",

--- a/src/extensions/orchestration/model-registry/builtin-models.ts
+++ b/src/extensions/orchestration/model-registry/builtin-models.ts
@@ -41,8 +41,14 @@ Best for codebase exploration, research, and simple well-defined tasks.`
  * model list from the API with orchestration metadata (tier, strengths,
  * vision, description). Models not present here get a generic descriptor
  * and a startup warning.
+ *
+ * Set the value to "ignored" to suppress the startup warning for a model
+ * without adding routing support for it.
  */
-export const MODEL_CAPABILITIES: ReadonlyMap<string, ModelCapabilities> = new Map([
+export const MODEL_CAPABILITIES: ReadonlyMap<string, ModelCapabilities | "ignored"> = new Map<
+	string,
+	ModelCapabilities | "ignored"
+>([
 	[
 		"kimi-k2.5",
 		{
@@ -70,4 +76,6 @@ export const MODEL_CAPABILITIES: ReadonlyMap<string, ModelCapabilities> = new Ma
 			description: NEMOTRON_3_SUPER_DESCRIPTION,
 		},
 	],
+	["glm-5-fp8", "ignored"],
+	["minimax-m2.5", "ignored"],
 ])

--- a/src/extensions/orchestration/model-registry/model-registry.test.ts
+++ b/src/extensions/orchestration/model-registry/model-registry.test.ts
@@ -3,19 +3,20 @@ import { MODEL_CAPABILITIES } from "./builtin-models.js"
 import { ModelRegistry } from "./model-registry.js"
 
 const KNOWN_IDS = [...MODEL_CAPABILITIES.keys()]
+const ACTIVE_IDS = KNOWN_IDS.filter((id) => MODEL_CAPABILITIES.get(id) !== "ignored")
 
 describe("ModelRegistry — known models only", () => {
-	it("returns all known models when all are available in the API", () => {
+	it("returns all active (non-ignored) models when all are available in the API", () => {
 		const registry = new ModelRegistry(KNOWN_IDS)
-		expect(registry.getAll()).toHaveLength(KNOWN_IDS.length)
-		expect(registry.getModelsWithCapabilities()).toHaveLength(KNOWN_IDS.length)
+		expect(registry.getAll()).toHaveLength(ACTIVE_IDS.length)
+		expect(registry.getModelsWithCapabilities()).toHaveLength(ACTIVE_IDS.length)
 		expect(registry.warnings).toHaveLength(0)
 	})
 
-	it("getAll() preserves the API order", () => {
+	it("getAll() preserves the API order, excluding ignored models", () => {
 		const ids = [...KNOWN_IDS].reverse()
 		const registry = new ModelRegistry(ids)
-		expect(registry.getAll().map((m) => m.id)).toEqual(ids)
+		expect(registry.getAll().map((m) => m.id)).toEqual([...ACTIVE_IDS].reverse())
 	})
 
 	it("every known model has a non-placeholder description", () => {
@@ -35,11 +36,11 @@ describe("ModelRegistry — unknown model in API", () => {
 		expect(unknown?.capabilities.description).toContain("No capability information")
 	})
 
-	it("emits a user-friendly discovery notice for the unknown model", () => {
+	it("emits a warning for the unknown model", () => {
 		const registry = new ModelRegistry([...KNOWN_IDS, "brand-new-model"])
 		const warning = registry.warnings.find((w) => w.modelId === "brand-new-model")
-		expect(warning?.message).toContain("New model available")
-		expect(warning?.message).toContain("brand-new-model")
+		expect(warning).toBeDefined()
+		expect(warning?.modelId).toBe("brand-new-model")
 	})
 
 	it("excludes the unknown model from getModelsWithCapabilities()", () => {
@@ -57,23 +58,38 @@ describe("ModelRegistry — unknown model in API", () => {
 
 describe("ModelRegistry — orphaned capability entry", () => {
 	it("excludes the orphaned model from both getAll() and getModelsWithCapabilities()", () => {
-		const presentId = KNOWN_IDS[0]
+		const presentId = ACTIVE_IDS[0]
 		const registry = new ModelRegistry([presentId])
 		expect(registry.getAll().map((m) => m.id)).toEqual([presentId])
 		expect(registry.getModelsWithCapabilities().map((m) => m.id)).toEqual([presentId])
 	})
 
 	it("does not emit any warning for capability entries absent from the API", () => {
-		const presentId = KNOWN_IDS[0]
+		const presentId = ACTIVE_IDS[0]
 		const registry = new ModelRegistry([presentId])
 		expect(registry.warnings).toHaveLength(0)
 	})
 })
 
+describe("ModelRegistry — ignored models", () => {
+	it("excludes ignored models from getAll() and getModelsWithCapabilities()", () => {
+		const ignoredIds = KNOWN_IDS.filter((id) => MODEL_CAPABILITIES.get(id) === "ignored")
+		const registry = new ModelRegistry(ignoredIds)
+		expect(registry.getAll()).toHaveLength(0)
+		expect(registry.getModelsWithCapabilities()).toHaveLength(0)
+	})
+
+	it("does not emit warnings for ignored models", () => {
+		const ignoredIds = KNOWN_IDS.filter((id) => MODEL_CAPABILITIES.get(id) === "ignored")
+		const registry = new ModelRegistry(ignoredIds)
+		expect(registry.warnings).toHaveLength(0)
+	})
+})
+
 describe("ModelRegistry — getModelsWithCapabilities()", () => {
-	it("is the intersection of API models and capability map", () => {
+	it("is the intersection of API models and capability map, excluding ignored", () => {
 		const registry = new ModelRegistry([...KNOWN_IDS, "unknown-extra"])
-		expect(registry.getModelsWithCapabilities().map((m) => m.id)).toEqual(expect.arrayContaining(KNOWN_IDS))
+		expect(registry.getModelsWithCapabilities().map((m) => m.id)).toEqual(expect.arrayContaining(ACTIVE_IDS))
 		expect(registry.getModelsWithCapabilities().map((m) => m.id)).not.toContain("unknown-extra")
 	})
 

--- a/src/extensions/orchestration/model-registry/model-registry.ts
+++ b/src/extensions/orchestration/model-registry/model-registry.ts
@@ -42,7 +42,6 @@ function modelIdToName(id: string): string {
 export interface ModelRegistryWarning {
 	kind: "unknown_model"
 	modelId: string
-	message: string
 }
 
 export class ModelRegistry {
@@ -59,25 +58,25 @@ export class ModelRegistry {
 		const warnings: ModelRegistryWarning[] = []
 
 		// Build full descriptor list from the API model IDs
-		this.allModels = availableModelIds.map((id) => {
-			const capabilities = MODEL_CAPABILITIES.get(id)
-			if (capabilities === undefined) {
-				warnings.push({
-					kind: "unknown_model",
-					modelId: id,
-					message: `New model available: "${id}". Update the harness to unlock its full capabilities (add an entry to MODEL_CAPABILITIES in builtin-models.ts), or add it to your orchestrator config. Until then it will not be offered as a subagent.`,
-				})
-				return {
-					id,
-					provider: PROVIDER,
-					name: modelIdToName(id),
-					capabilities: GENERIC_CAPABILITIES,
-				}
+		const allModels: OrchestrationModelDescriptor[] = []
+		for (const id of availableModelIds) {
+			const entry = MODEL_CAPABILITIES.get(id)
+			if (entry === "ignored") {
+				continue
 			}
-			return { id, provider: PROVIDER, name: modelIdToName(id), capabilities }
-		})
+			if (entry === undefined) {
+				warnings.push({ kind: "unknown_model", modelId: id })
+				allModels.push({ id, provider: PROVIDER, name: modelIdToName(id), capabilities: GENERIC_CAPABILITIES })
+			} else {
+				allModels.push({ id, provider: PROVIDER, name: modelIdToName(id), capabilities: entry })
+			}
+		}
+		this.allModels = allModels
 
-		this.modelsWithCapabilities = this.allModels.filter((m) => MODEL_CAPABILITIES.has(m.id))
+		this.modelsWithCapabilities = this.allModels.filter((m) => {
+			const entry = MODEL_CAPABILITIES.get(m.id)
+			return entry !== undefined && entry !== "ignored"
+		})
 		this.warnings = warnings
 	}
 

--- a/src/extensions/orchestration/prompt-enrichment.ts
+++ b/src/extensions/orchestration/prompt-enrichment.ts
@@ -20,6 +20,7 @@
 
 import type { ImageContent, TextContent } from "@mariozechner/pi-ai"
 import { type ExtensionAPI, type Skill, loadSkills } from "@mariozechner/pi-coding-agent"
+import { ANSI, fg } from "../../ansi.js"
 import { getAvailableModelIds } from "../../startup-context.js"
 import { ModelRegistry } from "./model-registry/index.js"
 import { type ContextFile, loadProjectContextFiles } from "./prompt-transformer/context-files.js"
@@ -44,10 +45,11 @@ export default function (pi: ExtensionAPI) {
 	if (!subagentMode) {
 		const registry = new ModelRegistry(getAvailableModelIds())
 
-		// Notify the developer when a newly available API model has no capability entry yet.
-		// These surface in the terminal as actionable discovery notices.
+		// Announce newly available API models that have no capability entry yet.
 		for (const warning of registry.warnings) {
-			console.error(`[model-registry] ${warning.message}`)
+			console.log(
+				`${fg(ANSI.accent, ` New model available: "kimchi-dev/${warning.modelId}"`)}\n${fg(ANSI.dim, " Update the app or add the new model to model capabilities config to unlock orchestration support.")}`,
+			)
 		}
 
 		pi.on("input", async (event, ctx) => {


### PR DESCRIPTION
Adds the ability to mark models as `"ignored"` in `MODEL_CAPABILITIES` to suppress startup warnings for known-unneeded models without adding routing support. Extracts shared ANSI color helpers into `src/ansi.ts` for reuse.