### PR TITLE
LLM-1336 Make steering messages flow to the LLM

### DIFF
--- a/src/extensions/orchestration/prompt-enrichment.ts
+++ b/src/extensions/orchestration/prompt-enrichment.ts
@@ -14,8 +14,8 @@
  * - "before_agent_start": replaces Pi's system prompt with the subagent
  *   system prompt. Filters out the subagent tool to prevent infinite loops.
  *
- * Steering messages are naturally excluded — they go through Agent.steer()
- * and never trigger the "input" event.
+ * Steering messages are excluded — when the agent is streaming, the handler
+ * returns "continue" so the message passes through unchanged.
  */
 
 import type { ImageContent, TextContent } from "@mariozechner/pi-ai"
@@ -53,6 +53,13 @@ export default function (pi: ExtensionAPI) {
 
 		pi.on("input", async (event, _ctx) => {
 			if (event.source === "extension") {
+				return { action: "continue" as const }
+			}
+
+			// Steering and follow-up messages arrive while the agent is streaming
+			// (ctx.isIdle() === false, i.e. session.isStreaming === true).
+			// Skip enrichment and let them pass through unchanged
+			if (!_ctx.isIdle()) {
 				return { action: "continue" as const }
 			}
 


### PR DESCRIPTION
## Problem

Sending a steering or follow-up message while the agent was streaming crashed with:

```
Extension "<runtime>" error: Agent is already processing.
Specify streamingBehavior ('steer' or 'followUp') to queue the message.
```

## Root Cause

The `input` event handler in `prompt-enrichment.ts` was intercepting all non-extension messages — including steering messages sent mid-stream — and re-injecting them via `pi.sendUserMessage()` without the required `deliverAs` option, causing `prompt()` to throw.

## Fix

Added an early-return guard in the `input` handler: when the agent is not idle (i.e. streaming), skip enrichment and return `{ action: "continue" }` so the message passes through unchanged.
