### PR TITLE
LLM-1249: Upgrade mcp({search}) to BM25 ranking

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -13,12 +13,27 @@ export interface TelemetryConfig {
 	headers: Record<string, string>
 }
 
+export interface SearchStrategyConfig {
+	strategy: "bm25" | "regex"
+	bm25K1: number
+	bm25B: number
+	fieldWeights: { name: number; description: number; schemaKey: number }
+}
+
+export const SEARCH_STRATEGY_DEFAULTS: SearchStrategyConfig = {
+	strategy: "bm25",
+	bm25K1: 1.2,
+	bm25B: 0.75,
+	fieldWeights: { name: 6, description: 2, schemaKey: 1 },
+}
+
 export interface KimchiConfig {
 	apiKey: string
 	agentConfigDir: string
 	llmEndpoint: string
 	maxToolResultChars: number
 	mcpSearchLimit: number
+	mcpSearch: SearchStrategyConfig
 }
 
 /**
@@ -38,7 +53,11 @@ function readApiKeyFromConfigFile(configPath: string): string | undefined {
 	}
 }
 
-function readConfigExtras(configPath: string): { maxToolResultChars?: number; mcpSearchLimit?: number } {
+function readConfigExtras(configPath: string): {
+	maxToolResultChars?: number
+	mcpSearchLimit?: number
+	mcpSearch?: Partial<SearchStrategyConfig>
+} {
 	try {
 		const raw = readFileSync(configPath, "utf-8")
 		const parsed = JSON.parse(raw)
@@ -48,7 +67,34 @@ function readConfigExtras(configPath: string): { maxToolResultChars?: number; mc
 				: undefined
 		const mcpSearchLimit =
 			typeof parsed.mcpSearchLimit === "number" && parsed.mcpSearchLimit > 0 ? parsed.mcpSearchLimit : undefined
-		return { maxToolResultChars, mcpSearchLimit }
+		let mcpSearch: Partial<SearchStrategyConfig> | undefined
+		const s = parsed.mcpSearch
+		if (s && typeof s === "object") {
+			mcpSearch = {
+				...(s.strategy === "bm25" || s.strategy === "regex" ? { strategy: s.strategy } : {}),
+				...(typeof s.bm25K1 === "number" ? { bm25K1: s.bm25K1 } : {}),
+				...(typeof s.bm25B === "number" ? { bm25B: s.bm25B } : {}),
+				...(s.fieldWeights && typeof s.fieldWeights === "object"
+					? {
+							fieldWeights: {
+								name:
+									typeof s.fieldWeights.name === "number"
+										? s.fieldWeights.name
+										: SEARCH_STRATEGY_DEFAULTS.fieldWeights.name,
+								description:
+									typeof s.fieldWeights.description === "number"
+										? s.fieldWeights.description
+										: SEARCH_STRATEGY_DEFAULTS.fieldWeights.description,
+								schemaKey:
+									typeof s.fieldWeights.schemaKey === "number"
+										? s.fieldWeights.schemaKey
+										: SEARCH_STRATEGY_DEFAULTS.fieldWeights.schemaKey,
+							},
+						}
+					: {}),
+			}
+		}
+		return { maxToolResultChars, mcpSearchLimit, mcpSearch }
 	} catch {
 		return {}
 	}
@@ -129,6 +175,7 @@ export function loadConfig(options?: { configPath?: string; env?: Record<string,
 	const extras = readConfigExtras(configPath)
 	const maxToolResultChars = extras.maxToolResultChars ?? 10_000
 	const mcpSearchLimit = extras.mcpSearchLimit ?? 5
+	const mcpSearch: SearchStrategyConfig = { ...SEARCH_STRATEGY_DEFAULTS, ...extras.mcpSearch }
 
 	const envKey = env.KIMCHI_API_KEY
 	if (typeof envKey === "string" && envKey.length > 0) {
@@ -138,6 +185,7 @@ export function loadConfig(options?: { configPath?: string; env?: Record<string,
 			llmEndpoint: CAST_AI_LLM_ENDPOINT,
 			maxToolResultChars,
 			mcpSearchLimit,
+			mcpSearch,
 		}
 	}
 
@@ -149,6 +197,7 @@ export function loadConfig(options?: { configPath?: string; env?: Record<string,
 			llmEndpoint: CAST_AI_LLM_ENDPOINT,
 			maxToolResultChars,
 			mcpSearchLimit,
+			mcpSearch,
 		}
 	}
 

--- a/src/extensions/mcp-adapter/bm25.ts
+++ b/src/extensions/mcp-adapter/bm25.ts
@@ -1,0 +1,187 @@
+import type { ToolMetadata } from "./types.js"
+
+// ---- Types -----------------------------------------------------------------
+
+export interface ToolEntry {
+	name: string
+	server: string
+	description: string
+	schemaKeys: string[]
+	requiredKeys: string[]
+}
+
+export interface SearchResult {
+	entry: ToolEntry
+	score: number
+}
+
+export interface SearchStrategy {
+	search(query: string, limit: number): SearchResult[]
+}
+
+export interface BM25Config {
+	strategy: "bm25" | "regex"
+	k1: number
+	b: number
+	fieldWeights: { name: number; description: number; schemaKey: number }
+}
+
+export const BM25_DEFAULTS: BM25Config = {
+	strategy: "bm25",
+	k1: 1.2,
+	b: 0.75,
+	fieldWeights: { name: 6, description: 2, schemaKey: 1 },
+}
+
+// ---- Tokenizer -------------------------------------------------------------
+
+function tokenize(text: string): string[] {
+	return text
+		.replace(/([a-z0-9])([A-Z])/g, "$1 $2")
+		.replace(/[^a-zA-Z0-9]+/g, " ")
+		.toLowerCase()
+		.trim()
+		.split(/\s+/)
+		.filter((t) => t.length > 0)
+}
+
+// ---- BM25 ------------------------------------------------------------------
+
+interface BM25Doc {
+	entry: ToolEntry
+	termFreq: Map<string, number>
+	length: number
+}
+
+interface BM25Index {
+	docs: BM25Doc[]
+	docFreq: Map<string, number>
+	avgLength: number
+}
+
+function addWeightedTokens(tf: Map<string, number>, text: string, weight: number): void {
+	for (const token of tokenize(text)) {
+		tf.set(token, (tf.get(token) ?? 0) + weight)
+	}
+}
+
+function buildDoc(entry: ToolEntry, weights: BM25Config["fieldWeights"]): BM25Doc {
+	const tf = new Map<string, number>()
+	addWeightedTokens(tf, entry.name, weights.name)
+	addWeightedTokens(tf, entry.description, weights.description)
+	for (const key of entry.schemaKeys) {
+		addWeightedTokens(tf, key, weights.schemaKey)
+	}
+	const length = Array.from(tf.values()).reduce((s, v) => s + v, 0)
+	return { entry, termFreq: tf, length }
+}
+
+function buildBM25Index(entries: ToolEntry[], weights: BM25Config["fieldWeights"]): BM25Index {
+	const docs = entries.map((e) => buildDoc(e, weights))
+	const avgLength = docs.length > 0 ? docs.reduce((s, d) => s + d.length, 0) / docs.length : 1
+	const docFreq = new Map<string, number>()
+	for (const doc of docs) {
+		for (const term of doc.termFreq.keys()) {
+			docFreq.set(term, (docFreq.get(term) ?? 0) + 1)
+		}
+	}
+	return { docs, docFreq, avgLength }
+}
+
+function scoreBM25(index: BM25Index, query: string, k1: number, b: number): SearchResult[] {
+	const queryTokens = tokenize(query)
+	if (queryTokens.length === 0 || index.docs.length === 0) return []
+
+	const N = index.docs.length
+	return index.docs
+		.map((doc) => {
+			let score = 0
+			for (const token of queryTokens) {
+				const tf = doc.termFreq.get(token) ?? 0
+				if (tf === 0) continue
+				const df = index.docFreq.get(token) ?? 0
+				const idf = Math.log(1 + (N - df + 0.5) / (df + 0.5))
+				const norm = k1 * (1 - b + b * (doc.length / index.avgLength))
+				score += (idf * (tf * (k1 + 1))) / (tf + norm)
+			}
+			return { entry: doc.entry, score }
+		})
+		.filter((r) => r.score > 0)
+		.sort((x, y) => y.score - x.score || x.entry.name.localeCompare(y.entry.name))
+}
+
+class BM25Strategy implements SearchStrategy {
+	constructor(
+		private readonly index: BM25Index,
+		private readonly k1: number,
+		private readonly b: number,
+	) {}
+
+	search(query: string, limit: number): SearchResult[] {
+		return scoreBM25(this.index, query, this.k1, this.b).slice(0, limit)
+	}
+}
+
+// ---- Regex Strategy --------------------------------------------------------
+
+class RegexStrategy implements SearchStrategy {
+	constructor(private readonly entries: ToolEntry[]) {}
+
+	search(query: string, limit: number): SearchResult[] {
+		if (!query) return []
+		let re: RegExp
+		try {
+			re = new RegExp(query, "i")
+		} catch {
+			return []
+		}
+		return this.entries
+			.map((entry) => ({ entry, score: this.score(entry, re) }))
+			.filter((r) => r.score > 0)
+			.sort((x, y) => y.score - x.score || x.entry.name.localeCompare(y.entry.name))
+			.slice(0, limit)
+	}
+
+	private score(entry: ToolEntry, re: RegExp): number {
+		let s = 0
+		if (re.test(entry.name)) s += 2
+		if (re.test(entry.description)) s += 1
+		for (const key of entry.schemaKeys) if (re.test(key)) s += 0.5
+		return s
+	}
+}
+
+// ---- Factory ---------------------------------------------------------------
+
+export function buildStrategy(entries: ToolEntry[], cfg: BM25Config): SearchStrategy {
+	if (cfg.strategy === "regex") return new RegexStrategy(entries)
+	return new BM25Strategy(buildBM25Index(entries, cfg.fieldWeights), cfg.k1, cfg.b)
+}
+
+// ---- Tool Entry Builder ----------------------------------------------------
+
+function extractSchemaKeys(inputSchema: unknown): string[] {
+	const schema = inputSchema as { properties?: Record<string, unknown> } | null
+	return schema?.properties ? Object.keys(schema.properties) : []
+}
+
+function extractRequiredKeys(inputSchema: unknown): string[] {
+	const schema = inputSchema as { required?: string[] } | null
+	return Array.isArray(schema?.required) ? schema.required : []
+}
+
+export function buildToolEntries(toolMetadata: Map<string, ToolMetadata[]>): ToolEntry[] {
+	const entries: ToolEntry[] = []
+	for (const [server, tools] of toolMetadata) {
+		for (const tool of tools) {
+			entries.push({
+				name: tool.name,
+				server,
+				description: tool.description ?? "",
+				schemaKeys: extractSchemaKeys(tool.inputSchema),
+				requiredKeys: extractRequiredKeys(tool.inputSchema),
+			})
+		}
+	}
+	return entries
+}

--- a/src/extensions/mcp-adapter/index.ts
+++ b/src/extensions/mcp-adapter/index.ts
@@ -4,6 +4,7 @@ import { Type } from "@sinclair/typebox"
 import { Text } from "@mariozechner/pi-tui"
 import { authenticateServer, openMcpPanel, reconnectServers, showStatus, showTools } from "./commands.js"
 import { loadConfig } from "../../config.js"
+import { BM25_DEFAULTS, buildStrategy, buildToolEntries } from "./bm25.js"
 import { loadMcpConfig } from "./config.js"
 import {
 	buildProxyDescription,
@@ -144,6 +145,19 @@ export default function mcpAdapter(pi: ExtensionAPI) {
 				state = nextState
 				updateStatusBar(nextState)
 				initPromise = null
+
+				// Build search strategy from live tool metadata
+				try {
+					const kimchiConfig = loadConfig()
+					const { strategy, bm25K1, bm25B, fieldWeights } = kimchiConfig.mcpSearch
+					const entries = buildToolEntries(nextState.toolMetadata)
+					state.searchStrategy = buildStrategy(entries, { strategy, k1: bm25K1, b: bm25B, fieldWeights })
+					console.error(`[mcp-adapter] search strategy=${strategy}, indexed ${entries.length} tools`)
+				} catch {
+					// loadConfig throws if no API key; fall back to default strategy
+					const entries = buildToolEntries(nextState.toolMetadata)
+					state.searchStrategy = buildStrategy(entries, BM25_DEFAULTS)
+				}
 			})
 			.catch((err) => {
 				if (generation !== lifecycleGeneration) {
@@ -256,6 +270,7 @@ export default function mcpAdapter(pi: ExtensionAPI) {
 				includeSchemas: Type.Optional(
 					Type.Boolean({ description: "Include parameter schemas in search results (default: true)" }),
 				),
+				limit: Type.Optional(Type.Number({ description: "Max number of search results to return (default: 5)" })),
 				server: Type.Optional(
 					Type.String({ description: "Filter to specific server (also disambiguates tool calls)" }),
 				),
@@ -273,6 +288,7 @@ export default function mcpAdapter(pi: ExtensionAPI) {
 					search?: string
 					regex?: boolean
 					includeSchemas?: boolean
+					limit?: number
 					server?: string
 					action?: string
 				},
@@ -334,14 +350,21 @@ export default function mcpAdapter(pi: ExtensionAPI) {
 					return executeDescribe(state, params.describe)
 				}
 				if (params.search) {
-					return executeSearch(state, params.search, params.regex, params.server, params.includeSchemas, getPiTools)
+					let mcpSearchLimit = 5
+				try {
+					const kimchiConfig = loadConfig()
+					mcpSearchLimit = kimchiConfig.mcpSearchLimit
+				} catch {
+					// no API key configured; default is fine
+				}
+				return executeSearch(state, params.search, params.regex, params.server, params.includeSchemas, getPiTools, params.limit ?? mcpSearchLimit, state.searchStrategy)
 				}
 				if (params.server) {
 					return executeList(state, params.server)
 				}
 				return executeStatus(state)
 			},
-			renderCall(args: { tool?: string; args?: string; connect?: string; describe?: string; search?: string; server?: string; action?: string }, theme: Theme, context: { lastComponent: unknown }) {
+			renderCall(args: { tool?: string; args?: string; connect?: string; describe?: string; search?: string; limit?: number; server?: string; action?: string }, theme: Theme, context: { lastComponent: unknown }) {
 				const text = (context.lastComponent as Text | undefined) ?? new Text("", 0, 0)
 				text.setText(formatMcpCall(args, theme))
 				return text
@@ -378,7 +401,7 @@ function formatMcpResult(result: unknown, options: ToolRenderResultOptions, them
 }
 
 function formatMcpCall(
-	params: { tool?: string; args?: string; connect?: string; describe?: string; search?: string; server?: string; action?: string },
+	params: { tool?: string; args?: string; connect?: string; describe?: string; search?: string; limit?: number; server?: string; action?: string },
 	theme: Theme,
 ): string {
 	if (params.tool) {
@@ -401,7 +424,10 @@ function formatMcpCall(
 		return `${theme.bold("mcp")} ${toolDisplay}${argsDisplay}`
 	}
 	if (params.describe) return `${theme.bold("mcp")} ${theme.fg("muted", "describe:")} ${theme.fg("accent", params.describe)}`
-	if (params.search) return `${theme.bold("mcp")} ${theme.fg("muted", "search:")} ${theme.fg("toolOutput", params.search)}`
+	if (params.search) {
+		const limitSuffix = params.limit !== undefined ? theme.fg("muted", ` (limit:${params.limit})`) : ""
+		return `${theme.bold("mcp")} ${theme.fg("muted", "search:")} ${theme.fg("toolOutput", params.search)}${limitSuffix}`
+	}
 	if (params.connect) return `${theme.bold("mcp")} ${theme.fg("muted", "connect:")} ${theme.fg("accent", params.connect)}`
 	if (params.server) return `${theme.bold("mcp")} ${theme.fg("muted", "list:")} ${theme.fg("accent", params.server)}`
 	if (params.action === "ui-messages") return `${theme.bold("mcp")} ${theme.fg("muted", "ui-messages")}`

--- a/src/extensions/mcp-adapter/proxy-modes.ts
+++ b/src/extensions/mcp-adapter/proxy-modes.ts
@@ -4,6 +4,7 @@ import { tmpdir, userInfo } from "node:os"
 import { dirname, join } from "node:path"
 import type { AgentToolResult, ExtensionContext, ToolInfo } from "@mariozechner/pi-coding-agent"
 import { truncateTail } from "@mariozechner/pi-coding-agent"
+import type { SearchStrategy } from "./bm25.js"
 import {
 	getFailureAgeSeconds,
 	lazyConnect,
@@ -306,59 +307,84 @@ export function executeSearch(
 	server?: string,
 	includeSchemas?: boolean,
 	getPiTools?: () => ToolInfo[],
+	limit = 5,
+	strategy?: SearchStrategy,
 ): ProxyToolResult {
 	const showSchemas = includeSchemas !== false
 
-	const matches: Array<{ server: string; tool: ToolMetadata }> = []
-
-	let pattern: RegExp
-	try {
-		if (regex) {
-			pattern = new RegExp(query, "i")
-		} else {
-			const terms = query
-				.trim()
-				.split(/\s+/)
-				.filter((t) => t.length > 0)
-			if (terms.length === 0) {
-				return {
-					content: [{ type: "text" as const, text: "Search query cannot be empty" }],
-					details: { mode: "search", error: "empty_query" },
-				}
-			}
-			const escaped = terms.map((t) => t.replace(/[.*+?^${}()|[\]\\]/g, "\\$&"))
-			pattern = new RegExp(escaped.join("|"), "i")
-		}
-	} catch {
+	// Validate query upfront for both paths
+	const trimmed = query.trim()
+	if (trimmed.length === 0) {
 		return {
-			content: [{ type: "text" as const, text: `Invalid regex: ${query}` }],
-			details: { mode: "search", error: "invalid_pattern", query },
+			content: [{ type: "text" as const, text: "Search query cannot be empty" }],
+			details: { mode: "search", error: "empty_query" },
 		}
 	}
 
+	// Pi tool search always uses regex (they're not in the MCP index)
 	const piMatches: Array<{ name: string; description: string }> = []
 	if (!server && getPiTools) {
-		const piTools = getPiTools()
-		for (const tool of piTools) {
-			if (tool.name === "mcp") continue
-
-			if (pattern.test(tool.name) || pattern.test(tool.description ?? "")) {
-				piMatches.push({
-					name: tool.name,
-					description: tool.description ?? "",
-				})
+		let piPattern: RegExp
+		try {
+			if (regex) {
+				piPattern = new RegExp(trimmed, "i")
+			} else {
+				const escaped = trimmed
+					.split(/\s+/)
+					.filter((t) => t.length > 0)
+					.map((t) => t.replace(/[.*+?^${}()|[\]\\]/g, "\\$&"))
+				piPattern = new RegExp(escaped.join("|"), "i")
 			}
+			for (const tool of getPiTools()) {
+				if (tool.name === "mcp") continue
+				if (piPattern.test(tool.name) || piPattern.test(tool.description ?? "")) {
+					piMatches.push({ name: tool.name, description: tool.description ?? "" })
+				}
+			}
+		} catch {
+			// invalid regex — skip pi tools
 		}
 	}
 
-	for (const [serverName, metadata] of state.toolMetadata.entries()) {
-		if (server && serverName !== server) continue
-		for (const tool of metadata) {
-			if (pattern.test(tool.name) || pattern.test(tool.description)) {
-				matches.push({
-					server: serverName,
-					tool,
-				})
+	// MCP tool search: use strategy (BM25/regex) unless regex flag forces legacy path
+	const matches: Array<{ server: string; tool: ToolMetadata }> = []
+
+	if (!regex && strategy) {
+		// Strategy-based search across all MCP tools, then filter by server if needed
+		const results = strategy.search(trimmed, server ? Number.MAX_SAFE_INTEGER : limit)
+		for (const result of results) {
+			if (server && result.entry.server !== server) continue
+			const serverMeta = state.toolMetadata.get(result.entry.server)
+			const toolMeta = serverMeta?.find((t) => t.name === result.entry.name)
+			if (toolMeta) {
+				matches.push({ server: result.entry.server, tool: toolMeta })
+			}
+		}
+	} else {
+		// Legacy regex path (when regex=true or no strategy available)
+		let pattern: RegExp
+		try {
+			if (regex) {
+				pattern = new RegExp(trimmed, "i")
+			} else {
+				const escaped = trimmed
+					.split(/\s+/)
+					.filter((t) => t.length > 0)
+					.map((t) => t.replace(/[.*+?^${}()|[\]\\]/g, "\\$&"))
+				pattern = new RegExp(escaped.join("|"), "i")
+			}
+		} catch {
+			return {
+				content: [{ type: "text" as const, text: `Invalid regex: ${query}` }],
+				details: { mode: "search", error: "invalid_pattern", query },
+			}
+		}
+		for (const [serverName, metadata] of state.toolMetadata.entries()) {
+			if (server && serverName !== server) continue
+			for (const tool of metadata) {
+				if (pattern.test(tool.name) || pattern.test(tool.description)) {
+					matches.push({ server: serverName, tool })
+				}
 			}
 		}
 	}
@@ -373,9 +399,19 @@ export function executeSearch(
 		}
 	}
 
-	let text = `Found ${totalCount} tool${totalCount === 1 ? "" : "s"} matching "${query}":\n\n`
+	// Apply limit: fill from piMatches first, then MCP matches
+	const piLimit = Math.min(piMatches.length, limit)
+	const mcpLimit = Math.min(matches.length, limit - piLimit)
+	const limitedPiMatches = piMatches.slice(0, piLimit)
+	const limitedMatches = matches.slice(0, mcpLimit)
+	const shownCount = limitedPiMatches.length + limitedMatches.length
+	const truncated = totalCount > shownCount
 
-	for (const match of piMatches) {
+	let text = truncated
+		? `Found ${totalCount} tool${totalCount === 1 ? "" : "s"} matching "${query}" (showing ${shownCount}, refine your query for more):\n\n`
+		: `Found ${totalCount} tool${totalCount === 1 ? "" : "s"} matching "${query}":\n\n`
+
+	for (const match of limitedPiMatches) {
 		if (showSchemas) {
 			text += `[pi tool] ${match.name}\n`
 			text += `  ${match.description || "(no description)"}\n`
@@ -390,7 +426,7 @@ export function executeSearch(
 		}
 	}
 
-	for (const match of matches) {
+	for (const match of limitedMatches) {
 		if (showSchemas) {
 			text += `${match.tool.name}\n`
 			text += `  ${match.tool.description || "(no description)"}\n`
@@ -414,10 +450,11 @@ export function executeSearch(
 		details: {
 			mode: "search",
 			matches: [
-				...piMatches.map((m) => ({ server: "pi", tool: m.name })),
-				...matches.map((m) => ({ server: m.server, tool: m.tool.name })),
+				...limitedPiMatches.map((m) => ({ server: "pi", tool: m.name })),
+				...limitedMatches.map((m) => ({ server: m.server, tool: m.tool.name })),
 			],
 			count: totalCount,
+			shown: shownCount,
 			query,
 		},
 	}

--- a/src/extensions/mcp-adapter/state.ts
+++ b/src/extensions/mcp-adapter/state.ts
@@ -1,4 +1,5 @@
 import type { ExtensionContext } from "@mariozechner/pi-coding-agent"
+import type { SearchStrategy } from "./bm25.js"
 import type { ConsentManager } from "./consent-manager.js"
 import type { McpLifecycleManager } from "./lifecycle.js"
 import type { McpServerManager } from "./server-manager.js"
@@ -38,4 +39,5 @@ export interface McpExtensionState {
 	openBrowser: (url: string) => Promise<void>
 	ui?: ExtensionContext["ui"]
 	sendMessage?: SendMessageFn
+	searchStrategy?: SearchStrategy
 }


### PR DESCRIPTION
## Summary

- Adds pluggable `SearchStrategy` interface (`bm25.ts`) with `BM25Strategy` and `RegexStrategy` implementations
- BM25 index built from live `state.toolMetadata` after MCP init, stored on `McpExtensionState`
- `executeSearch` accepts optional `strategy` param; uses BM25 when present, falls back to legacy regex when `regex=true` or no strategy
- `SearchStrategyConfig` added to `config.ts` — configurable via `~/.config/kimchi/config.json` under `mcpSearch` key (k1, b, fieldWeights, strategy)

## Test plan

- [ ] `pnpm typecheck` passes
- [ ] Start kimchi, run `mcp({ search: "prometheus" })` — ranked results, most relevant first
- [ ] Run `mcp({ search: "prometheus", regex: true })` — uses old regex path