### PR TITLE
LLM-1249: Dynamic MCP tool injection after search/describe

### DIFF
--- a/src/extensions/mcp-adapter/direct-tools.ts
+++ b/src/extensions/mcp-adapter/direct-tools.ts
@@ -216,14 +216,12 @@ export function buildProxyDescription(
 	}
 
 	desc += `\nUsage:\n`
-	desc += `  mcp({ })                              → Show server status\n`
-	desc += `  mcp({ server: "name" })               → List tools from server\n`
-	desc += `  mcp({ search: "query" })              → Search for tools (MCP + pi, space-separated words OR'd)\n`
-	desc += `  mcp({ describe: "tool_name" })        → Show tool details and parameters\n`
+	desc += `  mcp({ search: "query" })              → ALWAYS START HERE. Search tools by name/description. Injects matched tool schemas into context so you can call them directly.\n`
+	desc += `  mcp({ describe: "tool_name" })        → Get full schema for a specific tool. Use when you know the tool name but need its parameters.\n`
+	desc += `  mcp({ tool: "name", args: '{"key": "value"}' })    → Call a tool by proxy (args is JSON string). Prefer calling injected tools directly after search/describe.\n`
 	desc += `  mcp({ connect: "server-name" })       → Connect to a server and refresh metadata\n`
-	desc += `  mcp({ tool: "name", args: '{"key": "value"}' })    → Call a tool (args is JSON string)\n`
 	desc += `  mcp({ action: "ui-messages" })        → Retrieve accumulated messages from completed UI sessions\n`
-	desc += `\nMode: tool (call) > connect > describe > search > server (list) > action > nothing (status)`
+	desc += `\nWorkflow: search → schemas injected → call tool directly (do NOT guess parameters without searching first)`
 
 	return desc
 }

--- a/src/extensions/mcp-adapter/index.ts
+++ b/src/extensions/mcp-adapter/index.ts
@@ -107,11 +107,15 @@ export default function mcpAdapter(pi: ExtensionAPI) {
 		registeredToolNames.add(spec.prefixedName)
 	}
 
-	function registerAndActivate(specs: DirectToolSpec[]): void {
-		if (!state) return
+	function registerAndActivate(specs: DirectToolSpec[]): string[] {
+		if (!state) return []
 		const newNames: string[] = []
+		const alreadyActive: string[] = []
 		for (const spec of specs) {
-			if (registeredToolNames.has(spec.prefixedName)) continue
+			if (registeredToolNames.has(spec.prefixedName)) {
+				alreadyActive.push(spec.prefixedName)
+				continue
+			}
 			pi.registerTool({
 				name: spec.prefixedName,
 				label: `MCP: ${spec.originalName}`,
@@ -126,13 +130,16 @@ export default function mcpAdapter(pi: ExtensionAPI) {
 			registeredToolNames.add(spec.prefixedName)
 			newNames.push(spec.prefixedName)
 		}
-		if (newNames.length === 0) return
-		for (const name of newNames) {
-			state.dynamicToolNames.add(name)
+		const allInjected = [...alreadyActive, ...newNames]
+		if (newNames.length > 0) {
+			for (const name of newNames) {
+				state.dynamicToolNames.add(name)
+			}
+			const current = new Set(pi.getActiveTools())
+			for (const name of newNames) current.add(name)
+			pi.setActiveTools([...current])
 		}
-		const current = new Set(pi.getActiveTools())
-		for (const name of newNames) current.add(name)
-		pi.setActiveTools([...current])
+		return allInjected
 	}
 
 	pi.on("input", () => {

--- a/src/extensions/mcp-adapter/index.ts
+++ b/src/extensions/mcp-adapter/index.ts
@@ -21,9 +21,7 @@ import {
 	executeCall,
 	executeConnect,
 	executeDescribe,
-	executeList,
 	executeSearch,
-	executeStatus,
 	executeUiMessages,
 } from "./proxy-modes.js"
 import type { McpExtensionState } from "./state.js"
@@ -201,7 +199,6 @@ export default function mcpAdapter(pi: ExtensionAPI) {
 					const { strategy, bm25K1, bm25B, fieldWeights } = kimchiConfig.mcpSearch
 					const entries = buildToolEntries(nextState.toolMetadata)
 					state.searchStrategy = buildStrategy(entries, { strategy, k1: bm25K1, b: bm25B, fieldWeights })
-					console.error(`[mcp-adapter] search strategy=${strategy}, indexed ${entries.length} tools`)
 				} catch {
 					// loadConfig throws if no API key; fall back to default strategy
 					const entries = buildToolEntries(nextState.toolMetadata)
@@ -321,7 +318,7 @@ export default function mcpAdapter(pi: ExtensionAPI) {
 				),
 				limit: Type.Optional(Type.Number({ description: "Max number of search results to return (default: 5)" })),
 				server: Type.Optional(
-					Type.String({ description: "Filter to specific server (also disambiguates tool calls)" }),
+					Type.String({ description: "Filter search/describe/call to a specific server" }),
 				),
 				action: Type.Optional(
 					Type.String({ description: "Action: 'ui-messages' to retrieve prompts/intents from UI sessions" }),
@@ -412,10 +409,10 @@ export default function mcpAdapter(pi: ExtensionAPI) {
 					registerAndActivate(specs.map((s) => ({ ...s, prefixedName: formatToolName(s.originalName, s.serverName, prefix) })))
 				)
 				}
-				if (params.server) {
-					return executeList(state, params.server)
+				return {
+					content: [{ type: "text" as const, text: `Workflow Error: Missing action parameter.\nTo use MCP tools, you must first discover them and their schemas.\nUse mcp({ search: "..." }) to find tools, or mcp({ describe: "tool_name" }) to get a schema. Matched tools will then be injected for you to call directly.` }],
+					details: { error: "missing_action" },
 				}
-				return executeStatus(state)
 			},
 			renderCall(args: { tool?: string; args?: string; connect?: string; describe?: string; search?: string; limit?: number; server?: string; action?: string }, theme: Theme, context: { lastComponent: unknown }) {
 				const text = (context.lastComponent as Text | undefined) ?? new Text("", 0, 0)
@@ -482,7 +479,7 @@ function formatMcpCall(
 		return `${theme.bold("mcp")} ${theme.fg("muted", "search:")} ${theme.fg("toolOutput", params.search)}${limitSuffix}`
 	}
 	if (params.connect) return `${theme.bold("mcp")} ${theme.fg("muted", "connect:")} ${theme.fg("accent", params.connect)}`
-	if (params.server) return `${theme.bold("mcp")} ${theme.fg("muted", "list:")} ${theme.fg("accent", params.server)}`
+	if (params.server) return `${theme.bold("mcp")} ${theme.fg("muted", "server:")} ${theme.fg("accent", params.server)}`
 	if (params.action === "ui-messages") return `${theme.bold("mcp")} ${theme.fg("muted", "ui-messages")}`
 	return theme.bold("mcp")
 }

--- a/src/extensions/mcp-adapter/index.ts
+++ b/src/extensions/mcp-adapter/index.ts
@@ -1,6 +1,8 @@
 import type { ExtensionAPI, ToolInfo, ToolRenderResultOptions } from "@mariozechner/pi-coding-agent"
 import { Theme, keyHint } from "@mariozechner/pi-coding-agent"
 import { Type } from "@sinclair/typebox"
+import type { DirectToolSpec } from "./types.js"
+import { formatToolName } from "./types.js"
 import { Text } from "@mariozechner/pi-tui"
 import { authenticateServer, openMcpPanel, reconnectServers, showStatus, showTools } from "./commands.js"
 import { loadConfig } from "../../config.js"
@@ -86,6 +88,9 @@ export default function mcpAdapter(pi: ExtensionAPI) {
 		directSpecs.length === 0 ||
 		missingConfiguredDirectToolServers.length > 0
 
+	// Track all registered tool names to avoid double-registration
+	const registeredToolNames = new Set<string>()
+
 	for (const spec of directSpecs) {
 		pi.registerTool({
 			name: spec.prefixedName,
@@ -99,7 +104,44 @@ export default function mcpAdapter(pi: ExtensionAPI) {
 				spec,
 			),
 		})
+		registeredToolNames.add(spec.prefixedName)
 	}
+
+	function registerAndActivate(specs: DirectToolSpec[]): void {
+		if (!state) return
+		const newNames: string[] = []
+		for (const spec of specs) {
+			if (registeredToolNames.has(spec.prefixedName)) continue
+			pi.registerTool({
+				name: spec.prefixedName,
+				label: `MCP: ${spec.originalName}`,
+				description: spec.description || "(no description)",
+				parameters: Type.Unsafe<Record<string, unknown>>(spec.inputSchema || { type: "object", properties: {} }),
+				execute: createDirectToolExecutor(
+					() => state,
+					() => initPromise,
+					spec,
+				),
+			})
+			registeredToolNames.add(spec.prefixedName)
+			newNames.push(spec.prefixedName)
+		}
+		if (newNames.length === 0) return
+		for (const name of newNames) {
+			state.dynamicToolNames.add(name)
+		}
+		const current = new Set(pi.getActiveTools())
+		for (const name of newNames) current.add(name)
+		pi.setActiveTools([...current])
+	}
+
+	pi.on("input", () => {
+		if (!state || state.dynamicToolNames.size === 0) return
+		const dynamic = state.dynamicToolNames
+		const cleaned = pi.getActiveTools().filter((n) => !dynamic.has(n))
+		pi.setActiveTools(cleaned)
+		state.dynamicToolNames.clear()
+	})
 
 	const getPiTools = (): ToolInfo[] => pi.getAllTools()
 
@@ -347,7 +389,9 @@ export default function mcpAdapter(pi: ExtensionAPI) {
 					return executeConnect(state, params.connect)
 				}
 				if (params.describe) {
-					return executeDescribe(state, params.describe)
+					return executeDescribe(state, params.describe, (specs) =>
+						registerAndActivate(specs.map((s) => ({ ...s, prefixedName: formatToolName(s.originalName, s.serverName, prefix) })))
+					)
 				}
 				if (params.search) {
 					let mcpSearchLimit = 5
@@ -357,7 +401,9 @@ export default function mcpAdapter(pi: ExtensionAPI) {
 				} catch {
 					// no API key configured; default is fine
 				}
-				return executeSearch(state, params.search, params.regex, params.server, params.includeSchemas, getPiTools, params.limit ?? mcpSearchLimit, state.searchStrategy)
+				return executeSearch(state, params.search, params.regex, params.server, params.includeSchemas, getPiTools, params.limit ?? mcpSearchLimit, state.searchStrategy, (specs) =>
+					registerAndActivate(specs.map((s) => ({ ...s, prefixedName: formatToolName(s.originalName, s.serverName, prefix) })))
+				)
 				}
 				if (params.server) {
 					return executeList(state, params.server)

--- a/src/extensions/mcp-adapter/init.ts
+++ b/src/extensions/mcp-adapter/init.ts
@@ -49,6 +49,7 @@ export async function initializeMcp(pi: ExtensionAPI, ctx: ExtensionContext): Pr
 		openBrowser: (url: string) => openUrl(pi, url, process.env.BROWSER),
 		ui,
 		sendMessage: (message, options) => pi.sendMessage(message, options),
+		dynamicToolNames: new Set(),
 	}
 
 	const serverEntries = Object.entries(config.mcpServers)

--- a/src/extensions/mcp-adapter/proxy-modes.ts
+++ b/src/extensions/mcp-adapter/proxy-modes.ts
@@ -250,7 +250,7 @@ export function executeStatus(state: McpExtensionState): ProxyToolResult {
 	}
 
 	if (servers.length > 0) {
-		text += `\nmcp({ server: "name" }) to list tools, mcp({ search: "..." }) to search`
+		text += `\nmcp({ search: "..." }) to find tools, mcp({ describe: "tool_name" }) to get schema`
 	}
 
 	return {
@@ -314,7 +314,7 @@ export function executeDescribe(
 	}
 
 	if (injectedNames.length > 0) {
-		text += `\n\nInjected into context — call directly as: ${injectedNames[0]}`
+		text += `\n\nInjected into context. Call it using the exact name shown above (do NOT add any prefix): ${injectedNames[0]}`
 	}
 
 	return {
@@ -487,7 +487,7 @@ export function executeSearch(
 	}
 
 	if (injectedNames.length > 0) {
-		text += `\nInjected into context (call directly by name): ${injectedNames.join(", ")}`
+		text += `\nInjected into context. Call using the exact names shown above (do NOT add any prefix): ${injectedNames.join(", ")}`
 	}
 
 	return {

--- a/src/extensions/mcp-adapter/proxy-modes.ts
+++ b/src/extensions/mcp-adapter/proxy-modes.ts
@@ -262,7 +262,7 @@ export function executeStatus(state: McpExtensionState): ProxyToolResult {
 export function executeDescribe(
 	state: McpExtensionState,
 	toolName: string,
-	onInject?: (specs: DirectToolSpec[]) => void,
+	onInject?: (specs: DirectToolSpec[]) => string[],
 ): ProxyToolResult {
 	let serverName: string | undefined
 	let toolMeta: ToolMetadata | undefined
@@ -283,8 +283,9 @@ export function executeDescribe(
 		}
 	}
 
+	let injectedNames: string[] = []
 	if (onInject && !toolMeta.resourceUri) {
-		onInject([
+		injectedNames = onInject([
 			{
 				serverName,
 				originalName: toolMeta.name,
@@ -312,9 +313,13 @@ export function executeDescribe(
 		text += `\nNo parameters defined.`
 	}
 
+	if (injectedNames.length > 0) {
+		text += `\n\nInjected into context — call directly as: ${injectedNames[0]}`
+	}
+
 	return {
 		content: [{ type: "text" as const, text: text.trim() }],
-		details: { mode: "describe", tool: toolMeta, server: serverName },
+		details: { mode: "describe", tool: toolMeta, server: serverName, injected: injectedNames },
 	}
 }
 
@@ -327,7 +332,7 @@ export function executeSearch(
 	getPiTools?: () => ToolInfo[],
 	limit = 5,
 	strategy?: SearchStrategy,
-	onInject?: (specs: DirectToolSpec[]) => void,
+	onInject?: (specs: DirectToolSpec[]) => string[],
 ): ProxyToolResult {
 	const showSchemas = includeSchemas !== false
 
@@ -427,6 +432,7 @@ export function executeSearch(
 	const truncated = totalCount > shownCount
 
 	// Inject matched MCP tools as native pi tools for the next turn
+	let injectedNames: string[] = []
 	if (onInject && limitedMatches.length > 0) {
 		const specs: DirectToolSpec[] = limitedMatches
 			.filter((m) => !m.tool.resourceUri)
@@ -439,7 +445,7 @@ export function executeSearch(
 				uiResourceUri: m.tool.uiResourceUri,
 				uiStreamMode: m.tool.uiStreamMode,
 			}))
-		if (specs.length > 0) onInject(specs)
+		if (specs.length > 0) injectedNames = onInject(specs)
 	}
 
 	let text = truncated
@@ -480,6 +486,10 @@ export function executeSearch(
 		}
 	}
 
+	if (injectedNames.length > 0) {
+		text += `\nInjected into context (call directly by name): ${injectedNames.join(", ")}`
+	}
+
 	return {
 		content: [{ type: "text" as const, text: text.trim() }],
 		details: {
@@ -491,6 +501,7 @@ export function executeSearch(
 			count: totalCount,
 			shown: shownCount,
 			query,
+			injected: injectedNames,
 		},
 	}
 }

--- a/src/extensions/mcp-adapter/proxy-modes.ts
+++ b/src/extensions/mcp-adapter/proxy-modes.ts
@@ -16,7 +16,7 @@ import { authenticate, supportsOAuth } from "./mcp-auth-flow.js"
 import type { McpExtensionState } from "./state.js"
 import { buildToolMetadata, findToolByName, formatSchema, getToolNames } from "./tool-metadata.js"
 import { transformMcpContent } from "./tool-registrar.js"
-import type { McpContent, ToolMetadata } from "./types.js"
+import type { DirectToolSpec, McpContent, ToolMetadata } from "./types.js"
 import { getServerPrefix, parseUiPromptHandoff } from "./types.js"
 import { type UiSessionRuntime, maybeStartUiSession } from "./ui-session.js"
 import { truncateAtWord } from "./utils.js"
@@ -259,7 +259,11 @@ export function executeStatus(state: McpExtensionState): ProxyToolResult {
 	}
 }
 
-export function executeDescribe(state: McpExtensionState, toolName: string): ProxyToolResult {
+export function executeDescribe(
+	state: McpExtensionState,
+	toolName: string,
+	onInject?: (specs: DirectToolSpec[]) => void,
+): ProxyToolResult {
 	let serverName: string | undefined
 	let toolMeta: ToolMetadata | undefined
 
@@ -277,6 +281,20 @@ export function executeDescribe(state: McpExtensionState, toolName: string): Pro
 			content: [{ type: "text" as const, text: `Tool "${toolName}" not found. Use mcp({ search: "..." }) to search.` }],
 			details: { mode: "describe", error: "tool_not_found", requestedTool: toolName },
 		}
+	}
+
+	if (onInject && !toolMeta.resourceUri) {
+		onInject([
+			{
+				serverName,
+				originalName: toolMeta.name,
+				prefixedName: toolName,
+				description: toolMeta.description ?? "",
+				inputSchema: toolMeta.inputSchema,
+				uiResourceUri: toolMeta.uiResourceUri,
+				uiStreamMode: toolMeta.uiStreamMode,
+			},
+		])
 	}
 
 	let text = `${toolMeta.name}\n`
@@ -309,6 +327,7 @@ export function executeSearch(
 	getPiTools?: () => ToolInfo[],
 	limit = 5,
 	strategy?: SearchStrategy,
+	onInject?: (specs: DirectToolSpec[]) => void,
 ): ProxyToolResult {
 	const showSchemas = includeSchemas !== false
 
@@ -406,6 +425,22 @@ export function executeSearch(
 	const limitedMatches = matches.slice(0, mcpLimit)
 	const shownCount = limitedPiMatches.length + limitedMatches.length
 	const truncated = totalCount > shownCount
+
+	// Inject matched MCP tools as native pi tools for the next turn
+	if (onInject && limitedMatches.length > 0) {
+		const specs: DirectToolSpec[] = limitedMatches
+			.filter((m) => !m.tool.resourceUri)
+			.map((m) => ({
+				serverName: m.server,
+				originalName: m.tool.name,
+				prefixedName: m.tool.name,
+				description: m.tool.description ?? "",
+				inputSchema: m.tool.inputSchema,
+				uiResourceUri: m.tool.uiResourceUri,
+				uiStreamMode: m.tool.uiStreamMode,
+			}))
+		if (specs.length > 0) onInject(specs)
+	}
 
 	let text = truncated
 		? `Found ${totalCount} tool${totalCount === 1 ? "" : "s"} matching "${query}" (showing ${shownCount}, refine your query for more):\n\n`

--- a/src/extensions/mcp-adapter/state.ts
+++ b/src/extensions/mcp-adapter/state.ts
@@ -40,4 +40,6 @@ export interface McpExtensionState {
 	ui?: ExtensionContext["ui"]
 	sendMessage?: SendMessageFn
 	searchStrategy?: SearchStrategy
+	/** Prefixed names of tools registered dynamically via search/describe injection */
+	dynamicToolNames: Set<string>
 }


### PR DESCRIPTION
## Summary

Implements dynamic MCP tool injection so the model can call MCP tools directly with correct schemas instead of guessing parameters.

**BM25 search** (`bm25.ts`): Replaces regex/OR substring matching with ranked BM25 scoring. Pluggable `SearchStrategy` interface; tunable via `mcpSearch` in `config.json`.

**Dynamic tool injection**: After `mcp({search})` or `mcp({describe})`, matched tools are registered as native pi tools with full schemas and activated in the model's context. Model calls them directly on the next turn. Cleaned up on the next user `input` event.

**Search-first enforcement**: Removed the `mcp({server})` list path. Bare `mcp()` now returns a workflow error. Tool description and injection notices updated to make search the explicit entry point and prevent double-prefix mistakes (e.g. `pal_pal_chat`).

## Test plan

- [ ] `pnpm typecheck` passes
- [ ] `mcp({ search: "..." })` returns ranked results and injects tool schemas into context
- [ ] Model calls injected tool directly with correct parameters on next turn
- [ ] `mcp({ describe: "tool_name" })` injects single tool schema
- [ ] `mcp()` with no params returns workflow error
- [ ] New user message clears injected tools from active set