### PR TITLE
LLM-1335: Add loop guard to prevent infinite tool call loops

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -14,6 +14,7 @@ process.env.PI_SKIP_VERSION_CHECK = "1"
 
 import { loadConfig, readTelemetryConfig } from "./config.js"
 import bashCollapseExtension from "./extensions/bash-collapse.js"
+import loopGuardExtension from "./extensions/loop-guard.js"
 import mcpAdapterExtension from "./extensions/mcp-adapter/index.js"
 import promptEnrichmentExtension from "./extensions/orchestration/prompt-enrichment.js"
 import promptSummaryExtension from "./extensions/prompt-summary.js"
@@ -57,6 +58,7 @@ try {
 	await main(process.argv.slice(2), {
 		extensionFactories: [
 			bashCollapseExtension,
+			loopGuardExtension,
 			mcpAdapterExtension,
 			promptEnrichmentExtension,
 			promptSummaryExtension,

--- a/src/extensions/loop-guard.test.ts
+++ b/src/extensions/loop-guard.test.ts
@@ -1,0 +1,233 @@
+import { describe, expect, it } from "vitest"
+import { CALL_HISTORY_WINDOW, LoopGuard, MAX_CONSECUTIVE_FAILURES, MAX_REPEATED_CALLS } from "./loop-guard.js"
+
+describe("LoopGuard.reset", () => {
+	it("clears consecutive failure count", () => {
+		const guard = new LoopGuard()
+		for (let i = 0; i < MAX_CONSECUTIVE_FAILURES - 1; i++) {
+			guard.recordResult(true)
+		}
+		guard.reset()
+		const result = guard.checkAndRecord("bash", { command: "ls" })
+		expect(result).toEqual({ block: false })
+	})
+
+	it("clears call history", () => {
+		const guard = new LoopGuard()
+		for (let i = 0; i < MAX_REPEATED_CALLS; i++) {
+			guard.checkAndRecord("bash", { command: "ls" })
+		}
+		guard.reset()
+		const result = guard.checkAndRecord("bash", { command: "ls" })
+		expect(result).toEqual({ block: false })
+	})
+
+	it("clears triggered flag", () => {
+		const guard = new LoopGuard()
+		for (let i = 0; i < MAX_CONSECUTIVE_FAILURES; i++) {
+			guard.recordResult(true)
+		}
+		guard.checkAndRecord("bash", { command: "ls" })
+		expect(guard.isTriggered()).toBe(true)
+		guard.reset()
+		expect(guard.isTriggered()).toBe(false)
+	})
+})
+
+describe("LoopGuard.isTriggered", () => {
+	it("returns false initially", () => {
+		const guard = new LoopGuard()
+		expect(guard.isTriggered()).toBe(false)
+	})
+
+	it("returns true after consecutive failure block", () => {
+		const guard = new LoopGuard()
+		for (let i = 0; i < MAX_CONSECUTIVE_FAILURES; i++) {
+			guard.recordResult(true)
+		}
+		guard.checkAndRecord("bash", { command: "ls" })
+		expect(guard.isTriggered()).toBe(true)
+	})
+
+	it("returns true after repeated call block", () => {
+		const guard = new LoopGuard()
+		for (let i = 0; i < MAX_REPEATED_CALLS; i++) {
+			guard.checkAndRecord("bash", { command: "ls" })
+		}
+		guard.checkAndRecord("bash", { command: "ls" })
+		expect(guard.isTriggered()).toBe(true)
+	})
+
+	it("returns false for allowed calls even near thresholds", () => {
+		const guard = new LoopGuard()
+		for (let i = 0; i < MAX_CONSECUTIVE_FAILURES - 1; i++) {
+			guard.recordResult(true)
+		}
+		guard.checkAndRecord("bash", { command: "ls" })
+		expect(guard.isTriggered()).toBe(false)
+	})
+})
+
+describe("LoopGuard.recordResult", () => {
+	it("increments consecutive failures on error", () => {
+		const guard = new LoopGuard()
+		for (let i = 0; i < MAX_CONSECUTIVE_FAILURES - 1; i++) {
+			guard.recordResult(true)
+		}
+		const result = guard.checkAndRecord("bash", { command: "ls" })
+		expect(result).toEqual({ block: false })
+
+		guard.recordResult(true)
+		const blocked = guard.checkAndRecord("bash", { command: "other" })
+		expect(blocked.block).toBe(true)
+	})
+
+	it("resets consecutive failures on success", () => {
+		const guard = new LoopGuard()
+		for (let i = 0; i < MAX_CONSECUTIVE_FAILURES - 1; i++) {
+			guard.recordResult(true)
+		}
+		guard.recordResult(false)
+		for (let i = 0; i < MAX_CONSECUTIVE_FAILURES - 1; i++) {
+			guard.recordResult(true)
+		}
+		const result = guard.checkAndRecord("bash", { command: "ls" })
+		expect(result).toEqual({ block: false })
+	})
+})
+
+describe("LoopGuard.checkAndRecord - consecutive failure blocking", () => {
+	const cases: Array<{ failures: number; expectBlock: boolean }> = [
+		{ failures: MAX_CONSECUTIVE_FAILURES - 1, expectBlock: false },
+		{ failures: MAX_CONSECUTIVE_FAILURES, expectBlock: true },
+		{ failures: MAX_CONSECUTIVE_FAILURES + 1, expectBlock: true },
+	]
+
+	for (const { failures, expectBlock } of cases) {
+		it(`blocks=${expectBlock} after ${failures} consecutive failures`, () => {
+			const guard = new LoopGuard()
+			for (let i = 0; i < failures; i++) {
+				guard.recordResult(true)
+			}
+			const result = guard.checkAndRecord("bash", { command: "ls" })
+			expect(result.block).toBe(expectBlock)
+		})
+	}
+
+	it("includes failure count in block reason", () => {
+		const guard = new LoopGuard()
+		for (let i = 0; i < MAX_CONSECUTIVE_FAILURES; i++) {
+			guard.recordResult(true)
+		}
+		const result = guard.checkAndRecord("bash", { command: "ls" })
+		expect(result.reason).toContain(String(MAX_CONSECUTIVE_FAILURES))
+	})
+
+	it("does not add to call history when blocking on consecutive failures", () => {
+		const guard = new LoopGuard()
+		for (let i = 0; i < MAX_CONSECUTIVE_FAILURES; i++) {
+			guard.recordResult(true)
+		}
+		guard.checkAndRecord("bash", { command: "ls" })
+		guard.reset()
+		const result = guard.checkAndRecord("bash", { command: "ls" })
+		expect(result).toEqual({ block: false })
+	})
+})
+
+describe("LoopGuard.checkAndRecord - repeated call blocking", () => {
+	const cases: Array<{ calls: number; expectBlock: boolean }> = [
+		{ calls: MAX_REPEATED_CALLS - 1, expectBlock: false },
+		{ calls: MAX_REPEATED_CALLS, expectBlock: true },
+		{ calls: MAX_REPEATED_CALLS + 1, expectBlock: true },
+	]
+
+	for (const { calls, expectBlock } of cases) {
+		it(`blocks=${expectBlock} after ${calls} identical previous calls`, () => {
+			const guard = new LoopGuard()
+			for (let i = 0; i < calls; i++) {
+				guard.checkAndRecord("bash", { command: "ls" })
+			}
+			const result = guard.checkAndRecord("bash", { command: "ls" })
+			expect(result.block).toBe(expectBlock)
+		})
+	}
+
+	it("includes tool name and repeat count in block reason", () => {
+		const guard = new LoopGuard()
+		for (let i = 0; i < MAX_REPEATED_CALLS; i++) {
+			guard.checkAndRecord("bash", { command: "ls" })
+		}
+		const result = guard.checkAndRecord("bash", { command: "ls" })
+		expect(result.reason).toContain("bash")
+		expect(result.reason).toContain(String(MAX_REPEATED_CALLS + 1))
+	})
+
+	it("does not block different tool names", () => {
+		const guard = new LoopGuard()
+		for (let i = 0; i < MAX_REPEATED_CALLS; i++) {
+			guard.checkAndRecord("bash", { command: "ls" })
+		}
+		const result = guard.checkAndRecord("read", { file_path: "/tmp/foo" })
+		expect(result).toEqual({ block: false })
+	})
+
+	it("does not block same tool with different arguments", () => {
+		const guard = new LoopGuard()
+		for (let i = 0; i < MAX_REPEATED_CALLS; i++) {
+			guard.checkAndRecord("bash", { command: "ls" })
+		}
+		const result = guard.checkAndRecord("bash", { command: "pwd" })
+		expect(result).toEqual({ block: false })
+	})
+
+	it("treats argument objects with same keys in different order as identical", () => {
+		const guard = new LoopGuard()
+		for (let i = 0; i < MAX_REPEATED_CALLS; i++) {
+			guard.checkAndRecord("bash", { b: 2, a: 1 })
+		}
+		const result = guard.checkAndRecord("bash", { a: 1, b: 2 })
+		expect(result.block).toBe(true)
+	})
+
+	it("does not add to history when blocking on repeated call", () => {
+		const guard = new LoopGuard()
+		for (let i = 0; i < MAX_REPEATED_CALLS; i++) {
+			guard.checkAndRecord("bash", { command: "ls" })
+		}
+		guard.checkAndRecord("bash", { command: "ls" })
+		guard.checkAndRecord("bash", { command: "ls" })
+
+		guard.reset()
+		for (let i = 0; i < MAX_REPEATED_CALLS - 1; i++) {
+			guard.checkAndRecord("bash", { command: "ls" })
+		}
+		const result = guard.checkAndRecord("bash", { command: "ls" })
+		expect(result).toEqual({ block: false })
+	})
+})
+
+describe("LoopGuard.checkAndRecord - call history window", () => {
+	it("evicts oldest entries beyond window size", () => {
+		const guard = new LoopGuard()
+		for (let i = 0; i < MAX_REPEATED_CALLS; i++) {
+			guard.checkAndRecord("bash", { command: "ls" })
+		}
+		for (let i = 0; i < CALL_HISTORY_WINDOW; i++) {
+			guard.checkAndRecord("read", { file_path: `/file${i}` })
+		}
+		const result = guard.checkAndRecord("bash", { command: "ls" })
+		expect(result).toEqual({ block: false })
+	})
+})
+
+describe("LoopGuard.checkAndRecord - empty params", () => {
+	it("handles empty argument objects", () => {
+		const guard = new LoopGuard()
+		for (let i = 0; i < MAX_REPEATED_CALLS; i++) {
+			guard.checkAndRecord("mcp", {})
+		}
+		const result = guard.checkAndRecord("mcp", {})
+		expect(result.block).toBe(true)
+	})
+})

--- a/src/extensions/loop-guard.test.ts
+++ b/src/extensions/loop-guard.test.ts
@@ -190,6 +190,15 @@ describe("LoopGuard.checkAndRecord - repeated call blocking", () => {
 		expect(result.block).toBe(true)
 	})
 
+	it("treats undefined values as equivalent to missing keys", () => {
+		const guard = new LoopGuard()
+		for (let i = 0; i < MAX_REPEATED_CALLS; i++) {
+			guard.checkAndRecord("bash", { command: "ls" })
+		}
+		const result = guard.checkAndRecord("bash", { command: "ls", timeout: undefined })
+		expect(result.block).toBe(true)
+	})
+
 	it("does not add to history when blocking on repeated call", () => {
 		const guard = new LoopGuard()
 		for (let i = 0; i < MAX_REPEATED_CALLS; i++) {

--- a/src/extensions/loop-guard.ts
+++ b/src/extensions/loop-guard.ts
@@ -69,6 +69,7 @@ function stableStringify(value: unknown): string {
 	const obj = value as Record<string, unknown>
 	const entries = Object.keys(obj)
 		.sort()
+		.filter((k) => obj[k] !== undefined)
 		.map((k) => `${JSON.stringify(k)}:${stableStringify(obj[k])}`)
 	return `{${entries.join(",")}}`
 }

--- a/src/extensions/loop-guard.ts
+++ b/src/extensions/loop-guard.ts
@@ -1,0 +1,107 @@
+import type { ExtensionAPI } from "@mariozechner/pi-coding-agent"
+
+export const MAX_CONSECUTIVE_FAILURES = 5
+export const MAX_REPEATED_CALLS = 3
+export const CALL_HISTORY_WINDOW = 15
+
+export class LoopGuard {
+	private consecutiveFailures = 0
+	private callHistory: string[] = []
+	private triggered = false
+
+	reset(): void {
+		this.consecutiveFailures = 0
+		this.callHistory = []
+		this.triggered = false
+	}
+
+	isTriggered(): boolean {
+		return this.triggered
+	}
+
+	recordResult(isError: boolean): void {
+		if (isError) {
+			this.consecutiveFailures++
+		} else {
+			this.consecutiveFailures = 0
+		}
+	}
+
+	checkAndRecord(toolName: string, input: Record<string, unknown>): { block: boolean; reason?: string } {
+		if (this.consecutiveFailures >= MAX_CONSECUTIVE_FAILURES) {
+			this.triggered = true
+			return {
+				block: true,
+				reason: `Loop guard: ${this.consecutiveFailures} consecutive tool failures. Stop retrying and summarize what went wrong.`,
+			}
+		}
+
+		const fingerprint = toolFingerprint(toolName, input)
+		const repeatCount = this.callHistory.filter((f) => f === fingerprint).length
+		if (repeatCount >= MAX_REPEATED_CALLS) {
+			this.triggered = true
+			return {
+				block: true,
+				reason: `Loop guard: "${toolName}" called with identical arguments ${repeatCount + 1} times. Stop repeating and try a different approach.`,
+			}
+		}
+
+		this.callHistory.push(fingerprint)
+		if (this.callHistory.length > CALL_HISTORY_WINDOW) {
+			this.callHistory.shift()
+		}
+
+		return { block: false }
+	}
+}
+
+function toolFingerprint(toolName: string, input: Record<string, unknown>): string {
+	return `${toolName}:${stableStringify(input)}`
+}
+
+function stableStringify(value: unknown): string {
+	if (value === null || typeof value !== "object") {
+		return JSON.stringify(value)
+	}
+	if (Array.isArray(value)) {
+		return `[${value.map(stableStringify).join(",")}]`
+	}
+	const obj = value as Record<string, unknown>
+	const entries = Object.keys(obj)
+		.sort()
+		.map((k) => `${JSON.stringify(k)}:${stableStringify(obj[k])}`)
+	return `{${entries.join(",")}}`
+}
+
+const STOP_MESSAGE =
+	"Loop guard activated. Do not make any more tool calls. Respond only with plain text summarizing what was attempted and why it failed."
+
+export default function loopGuardExtension(pi: ExtensionAPI) {
+	const guard = new LoopGuard()
+
+	pi.on("input", () => {
+		guard.reset()
+	})
+
+	pi.on("tool_execution_end", (event) => {
+		guard.recordResult(event.isError)
+	})
+
+	pi.on("tool_call", (event) => {
+		const check = guard.checkAndRecord(event.toolName, event.input as Record<string, unknown>)
+		if (check.block) {
+			return { block: true, reason: check.reason }
+		}
+	})
+
+	pi.on("before_agent_start", () => {
+		if (!guard.isTriggered()) return
+		return {
+			message: {
+				customType: "loop-guard-stop",
+				content: [{ type: "text" as const, text: STOP_MESSAGE }],
+				display: true,
+			},
+		}
+	})
+}

--- a/src/extensions/mcp-adapter/proxy-modes.ts
+++ b/src/extensions/mcp-adapter/proxy-modes.ts
@@ -678,12 +678,7 @@ export async function executeCall(
 						if (connectedAfterAuth) {
 							toolMeta = findToolByName(state.toolMetadata.get(serverName), toolName)
 							if (!toolMeta) {
-								return {
-									content: [
-										{ type: "text" as const, text: `Tool "${toolName}" not found on "${serverName}" after reconnect.` },
-									],
-									details: { mode: "call", error: "tool_not_found_after_reconnect", requestedTool: toolName },
-								}
+								throw new Error(`Tool "${toolName}" not found on "${serverName}" after reconnect.`)
 							}
 						}
 					}
@@ -761,10 +756,7 @@ export async function executeCall(
 		} else {
 			msg += ` Use mcp({ search: "..." }) to search.`
 		}
-		return {
-			content: [{ type: "text" as const, text: msg }],
-			details: { mode: "call", error: "tool_not_found", requestedTool: toolName, hintServer },
-		}
+		throw new Error(msg)
 	}
 
 	let connection = state.manager.getConnection(serverName)
@@ -812,6 +804,7 @@ export async function executeCall(
 			}
 		}
 
+		let toolNotFoundAfterReconnect: string | undefined
 		try {
 			if (state.ui) {
 				state.ui.setStatus("mcp", `MCP: connecting to ${serverName}...`)
@@ -852,12 +845,7 @@ export async function executeCall(
 					available.length > 0
 						? `Available tools on "${serverName}": ${available.join(", ")}`
 						: `Server "${serverName}" has no tools.`
-				return {
-					content: [
-						{ type: "text" as const, text: `Tool "${toolName}" not found on "${serverName}" after reconnect. ${hint}` },
-					],
-					details: { mode: "call", error: "tool_not_found_after_reconnect", requestedTool: toolName },
-				}
+				toolNotFoundAfterReconnect = `Tool "${toolName}" not found on "${serverName}" after reconnect. ${hint}`
 			}
 		} catch (error) {
 			state.failureTracker.set(serverName, Date.now())
@@ -868,6 +856,13 @@ export async function executeCall(
 				details: { mode: "call", error: "connect_failed", message },
 			}
 		}
+		if (toolNotFoundAfterReconnect) {
+			throw new Error(toolNotFoundAfterReconnect)
+		}
+	}
+
+	if (!toolMeta) {
+		throw new Error(`Tool "${toolName}" not found.`)
 	}
 
 	let uiSession: UiSessionRuntime | null = null


### PR DESCRIPTION
## Summary

- Add `LoopGuard` extension that blocks tool calls on 5 consecutive failures or 3 identical repeated calls within a 15-call history window
- Inject a stop message via `before_agent_start` when the guard is triggered, so the model stops making tool calls for the remainder of that turn
- Fix `tool_not_found` in the MCP proxy to throw instead of returning a non-error result — the framework only sets `isError: true` when `execute` throws, so silent returns were never counted as failures by the guard
- Register `loopGuardExtension` in `cli.ts`

## Test plan

- [x] All 351 unit tests pass (`pnpm test`)
- [x] Typecheck passes (`pnpm typecheck`)
- [x] Manual: prompt the model to call a nonexistent MCP tool repeatedly — guard should trigger after 5 failures and model should stop
- [x] Manual: prompt the model to repeat the same tool call with identical args — guard should trigger after 3 repeats