### PR TITLE
LLM-1351: feat(lsp): add LSP extension with diagnostics, hover, definition, references, rename

### DIFF
--- a/extensions/lsp.ts
+++ b/extensions/lsp.ts
@@ -78,15 +78,15 @@ export default function (pi: ExtensionAPI) {
 				}),
 			),
 		}),
-		async execute(_toolCallId, params, _signal, _onUpdate, ctx) {
-			const filePath = path.isAbsolute(params.file_path) ? params.file_path : path.join(ctx.cwd, params.file_path)
-			const servers = activeServers.length > 0 ? activeServers : detectServers(ctx.cwd)
+		async execute(_toolCallId, params, _signal, _onUpdate, _ctx) {
+			const filePath = path.isAbsolute(params.file_path) ? params.file_path : path.join(cwd, params.file_path)
+			const servers = activeServers.length > 0 ? activeServers : detectServers(cwd)
 			const server = serverForFile(filePath, servers)
 			if (!server) {
 				return { content: [{ type: "text", text: "No LSP server available for this file type." }], details: null }
 			}
 
-			const client = await getOrCreateClient(server, ctx.cwd)
+			const client = await getOrCreateClient(server, cwd)
 			await refreshFile(client, filePath)
 
 			const waitMs = Math.min(params.wait_ms ?? 2000, 10000)
@@ -116,15 +116,15 @@ export default function (pi: ExtensionAPI) {
 			line: Type.Number({ description: "0-based line number" }),
 			character: Type.Number({ description: "0-based character offset" }),
 		}),
-		async execute(_toolCallId, params, _signal, _onUpdate, ctx) {
-			const filePath = path.isAbsolute(params.file_path) ? params.file_path : path.join(ctx.cwd, params.file_path)
-			const servers = activeServers.length > 0 ? activeServers : detectServers(ctx.cwd)
+		async execute(_toolCallId, params, _signal, _onUpdate, _ctx) {
+			const filePath = path.isAbsolute(params.file_path) ? params.file_path : path.join(cwd, params.file_path)
+			const servers = activeServers.length > 0 ? activeServers : detectServers(cwd)
 			const server = serverForFile(filePath, servers)
 			if (!server) {
 				return { content: [{ type: "text", text: "No LSP server available for this file type." }], details: null }
 			}
 
-			const client = await getOrCreateClient(server, ctx.cwd)
+			const client = await getOrCreateClient(server, cwd)
 			await ensureFileOpen(client, filePath)
 
 			const result = (await sendRequest(client, "textDocument/hover", {
@@ -159,15 +159,15 @@ export default function (pi: ExtensionAPI) {
 				}),
 			),
 		}),
-		async execute(_toolCallId, params, _signal, _onUpdate, ctx) {
-			const filePath = path.isAbsolute(params.file_path) ? params.file_path : path.join(ctx.cwd, params.file_path)
-			const servers = activeServers.length > 0 ? activeServers : detectServers(ctx.cwd)
+		async execute(_toolCallId, params, _signal, _onUpdate, _ctx) {
+			const filePath = path.isAbsolute(params.file_path) ? params.file_path : path.join(cwd, params.file_path)
+			const servers = activeServers.length > 0 ? activeServers : detectServers(cwd)
 			const server = serverForFile(filePath, servers)
 			if (!server) {
 				return { content: [{ type: "text", text: "No LSP server available for this file type." }], details: null }
 			}
 
-			const client = await getOrCreateClient(server, ctx.cwd)
+			const client = await getOrCreateClient(server, cwd)
 			await ensureFileOpen(client, filePath)
 
 			const lspMethod = `textDocument/${params.method ?? "definition"}`
@@ -182,7 +182,7 @@ export default function (pi: ExtensionAPI) {
 
 			const locations = normalizeLocations(result)
 			const lines = locations.map((loc) => {
-				const file = path.relative(ctx.cwd, uriToFile(loc.uri))
+				const file = path.relative(cwd, uriToFile(loc.uri))
 				return `${file}:${loc.range.start.line + 1}:${loc.range.start.character + 1}`
 			})
 			return { content: [{ type: "text", text: lines.join("\n") }], details: null }
@@ -205,15 +205,15 @@ export default function (pi: ExtensionAPI) {
 				Type.Boolean({ description: "Include the declaration itself in results (default: true)", default: true }),
 			),
 		}),
-		async execute(_toolCallId, params, _signal, _onUpdate, ctx) {
-			const filePath = path.isAbsolute(params.file_path) ? params.file_path : path.join(ctx.cwd, params.file_path)
-			const servers = activeServers.length > 0 ? activeServers : detectServers(ctx.cwd)
+		async execute(_toolCallId, params, _signal, _onUpdate, _ctx) {
+			const filePath = path.isAbsolute(params.file_path) ? params.file_path : path.join(cwd, params.file_path)
+			const servers = activeServers.length > 0 ? activeServers : detectServers(cwd)
 			const server = serverForFile(filePath, servers)
 			if (!server) {
 				return { content: [{ type: "text", text: "No LSP server available for this file type." }], details: null }
 			}
 
-			const client = await getOrCreateClient(server, ctx.cwd)
+			const client = await getOrCreateClient(server, cwd)
 			await ensureFileOpen(client, filePath)
 
 			const result = (await sendRequest(client, "textDocument/references", {
@@ -227,7 +227,7 @@ export default function (pi: ExtensionAPI) {
 			}
 
 			const lines = result.map((loc) => {
-				const file = path.relative(ctx.cwd, uriToFile(loc.uri))
+				const file = path.relative(cwd, uriToFile(loc.uri))
 				return `${file}:${loc.range.start.line + 1}:${loc.range.start.character + 1}`
 			})
 			return { content: [{ type: "text", text: `${result.length} reference(s):\n${lines.join("\n")}` }], details: null }
@@ -248,15 +248,15 @@ export default function (pi: ExtensionAPI) {
 			character: Type.Number({ description: "0-based character offset of the symbol" }),
 			new_name: Type.String({ description: "New name for the symbol" }),
 		}),
-		async execute(_toolCallId, params, _signal, _onUpdate, ctx) {
-			const filePath = path.isAbsolute(params.file_path) ? params.file_path : path.join(ctx.cwd, params.file_path)
-			const servers = activeServers.length > 0 ? activeServers : detectServers(ctx.cwd)
+		async execute(_toolCallId, params, _signal, _onUpdate, _ctx) {
+			const filePath = path.isAbsolute(params.file_path) ? params.file_path : path.join(cwd, params.file_path)
+			const servers = activeServers.length > 0 ? activeServers : detectServers(cwd)
 			const server = serverForFile(filePath, servers)
 			if (!server) {
 				return { content: [{ type: "text", text: "No LSP server available for this file type." }], details: null }
 			}
 
-			const client = await getOrCreateClient(server, ctx.cwd)
+			const client = await getOrCreateClient(server, cwd)
 			await ensureFileOpen(client, filePath)
 
 			// Check if rename is valid at this position
@@ -283,7 +283,7 @@ export default function (pi: ExtensionAPI) {
 				return { content: [{ type: "text", text: "Rename returned no changes." }], details: null }
 			}
 
-			const applied = await applyWorkspaceEdit(edit, ctx.cwd)
+			const applied = await applyWorkspaceEdit(edit, cwd)
 
 			// Refresh all modified files in the client that performed the rename
 			const affectedUris = [

--- a/extensions/lsp.ts
+++ b/extensions/lsp.ts
@@ -16,6 +16,11 @@ import { detectServers, serverForFile } from "./lsp/servers.js"
 import type { Hover, Location, LocationLink, TextDocumentEdit, WorkspaceEdit } from "./lsp/types.js"
 import { fileToUri, formatDiagnostic, uriToFile } from "./lsp/utils.js"
 
+export function clientCwd(filePath: string, sessionCwd: string): string {
+	if (filePath.startsWith(sessionCwd + path.sep) || filePath === sessionCwd) return sessionCwd
+	return path.dirname(filePath)
+}
+
 export default function (pi: ExtensionAPI) {
 	let cwd = ""
 	let activeServers: ReturnType<typeof detectServers> = []

--- a/extensions/lsp.ts
+++ b/extensions/lsp.ts
@@ -91,7 +91,7 @@ export default function (pi: ExtensionAPI) {
 				return { content: [{ type: "text", text: "No LSP server available for this file type." }], details: null }
 			}
 
-			const client = await getOrCreateClient(server, cwd)
+			const client = await getOrCreateClient(server, clientCwd(filePath, cwd))
 			await refreshFile(client, filePath)
 
 			const waitMs = Math.min(params.wait_ms ?? 2000, 10000)
@@ -129,7 +129,7 @@ export default function (pi: ExtensionAPI) {
 				return { content: [{ type: "text", text: "No LSP server available for this file type." }], details: null }
 			}
 
-			const client = await getOrCreateClient(server, cwd)
+			const client = await getOrCreateClient(server, clientCwd(filePath, cwd))
 			await ensureFileOpen(client, filePath)
 
 			const result = (await sendRequest(client, "textDocument/hover", {
@@ -172,7 +172,7 @@ export default function (pi: ExtensionAPI) {
 				return { content: [{ type: "text", text: "No LSP server available for this file type." }], details: null }
 			}
 
-			const client = await getOrCreateClient(server, cwd)
+			const client = await getOrCreateClient(server, clientCwd(filePath, cwd))
 			await ensureFileOpen(client, filePath)
 
 			const lspMethod = `textDocument/${params.method ?? "definition"}`
@@ -218,7 +218,7 @@ export default function (pi: ExtensionAPI) {
 				return { content: [{ type: "text", text: "No LSP server available for this file type." }], details: null }
 			}
 
-			const client = await getOrCreateClient(server, cwd)
+			const client = await getOrCreateClient(server, clientCwd(filePath, cwd))
 			await ensureFileOpen(client, filePath)
 
 			const result = (await sendRequest(client, "textDocument/references", {
@@ -261,7 +261,7 @@ export default function (pi: ExtensionAPI) {
 				return { content: [{ type: "text", text: "No LSP server available for this file type." }], details: null }
 			}
 
-			const client = await getOrCreateClient(server, cwd)
+			const client = await getOrCreateClient(server, clientCwd(filePath, cwd))
 			await ensureFileOpen(client, filePath)
 
 			// Check if rename is valid at this position

--- a/extensions/lsp.ts
+++ b/extensions/lsp.ts
@@ -1,0 +1,339 @@
+// extensions/lsp.ts
+/**
+ * LSP Extension
+ *
+ * Gives the agent type-aware code intelligence via LSP.
+ * Supports TypeScript (typescript-language-server) and Go (gopls).
+ *
+ * Usage: kimchi -e extensions/lsp.ts
+ */
+import path from "node:path"
+import type { ExtensionAPI } from "@mariozechner/pi-coding-agent"
+import { Type } from "@sinclair/typebox"
+import {
+	ensureFileOpen,
+	getAllClients,
+	getOrCreateClient,
+	refreshFile,
+	sendRequest,
+	shutdownAll,
+} from "./lsp/client.js"
+import { applyWorkspaceEdit } from "./lsp/edits.js"
+import { detectServers, serverForFile } from "./lsp/servers.js"
+import type { Hover, Location, LocationLink, TextDocumentEdit, WorkspaceEdit } from "./lsp/types.js"
+import { fileToUri, formatDiagnostic, uriToFile } from "./lsp/utils.js"
+
+export default function (pi: ExtensionAPI) {
+	let cwd = ""
+
+	// ── Session start: detect servers, hook file sync, shutdown on exit ─────────
+
+	pi.on("session_start", async (_event, ctx) => {
+		cwd = ctx.cwd
+		const servers = detectServers(cwd)
+		if (servers.length === 0) return
+
+		// Eagerly start servers so they're warm when first tool is called
+		for (const server of servers) {
+			getOrCreateClient(server, cwd).catch(() => {})
+		}
+	})
+
+	pi.on("session_shutdown", async () => {
+		shutdownAll()
+	})
+
+	// ── File sync: refresh LSP after agent edits files ───────────────────────────
+
+	pi.on("tool_result", async (event) => {
+		if (!("toolName" in event)) return
+		if (event.toolName !== "edit" && event.toolName !== "write") return
+		if (event.isError) return
+
+		// Extract the file path from the tool input
+		const input = event.input as Record<string, unknown>
+		const filePath = (input.file_path ?? input.path) as string | undefined
+		if (!filePath) return
+
+		const resolved = path.isAbsolute(filePath) ? filePath : path.join(cwd, filePath)
+		const servers = detectServers(cwd)
+		const server = serverForFile(resolved, servers)
+		if (!server) return
+
+		try {
+			const client = await getOrCreateClient(server, cwd)
+			await refreshFile(client, resolved)
+		} catch {
+			// Non-fatal: LSP sync failure doesn't break the agent
+		}
+	})
+
+	// ── Tool: lsp_diagnostics ─────────────────────────────────────────────────
+
+	pi.registerTool({
+		name: "lsp_diagnostics",
+		label: "LSP: Get Diagnostics",
+		description:
+			"Get type errors, warnings, and linter diagnostics for a file from the language server. Call after editing a file to check for errors. Returns empty list if no issues found.",
+		promptSnippet: "Get LSP diagnostics (type errors, warnings) for a file",
+		parameters: Type.Object({
+			file_path: Type.String({ description: "Absolute or cwd-relative path to the file to check" }),
+			wait_ms: Type.Optional(
+				Type.Number({
+					description: "Milliseconds to wait for diagnostics after refreshing (default 2000, max 10000)",
+					default: 2000,
+				}),
+			),
+		}),
+		async execute(_toolCallId, params, _signal, _onUpdate, ctx) {
+			const filePath = path.isAbsolute(params.file_path) ? params.file_path : path.join(ctx.cwd, params.file_path)
+			const servers = detectServers(ctx.cwd)
+			const server = serverForFile(filePath, servers)
+			if (!server) {
+				return { content: [{ type: "text", text: "No LSP server available for this file type." }], details: null }
+			}
+
+			const client = await getOrCreateClient(server, ctx.cwd)
+			await refreshFile(client, filePath)
+
+			const waitMs = Math.min(params.wait_ms ?? 2000, 10000)
+			await new Promise((resolve) => setTimeout(resolve, waitMs))
+
+			const uri = fileToUri(filePath)
+			const entry = client.diagnostics.get(uri)
+			if (!entry || entry.diagnostics.length === 0) {
+				return { content: [{ type: "text", text: "No diagnostics found — file looks clean." }], details: null }
+			}
+
+			const lines = entry.diagnostics.map((d) => formatDiagnostic(d))
+			return { content: [{ type: "text", text: lines.join("\n") }], details: null }
+		},
+	})
+
+	// ── Tool: lsp_hover ───────────────────────────────────────────────────────
+
+	pi.registerTool({
+		name: "lsp_hover",
+		label: "LSP: Hover Info",
+		description:
+			"Get type information and documentation for a symbol at a specific position. Useful for understanding types before making changes.",
+		promptSnippet: "Get LSP hover info (type, docs) at a file position",
+		parameters: Type.Object({
+			file_path: Type.String({ description: "Absolute or cwd-relative path to the file" }),
+			line: Type.Number({ description: "0-based line number" }),
+			character: Type.Number({ description: "0-based character offset" }),
+		}),
+		async execute(_toolCallId, params, _signal, _onUpdate, ctx) {
+			const filePath = path.isAbsolute(params.file_path) ? params.file_path : path.join(ctx.cwd, params.file_path)
+			const servers = detectServers(ctx.cwd)
+			const server = serverForFile(filePath, servers)
+			if (!server) {
+				return { content: [{ type: "text", text: "No LSP server available for this file type." }], details: null }
+			}
+
+			const client = await getOrCreateClient(server, ctx.cwd)
+			await ensureFileOpen(client, filePath)
+
+			const result = (await sendRequest(client, "textDocument/hover", {
+				textDocument: { uri: fileToUri(filePath) },
+				position: { line: params.line, character: params.character },
+			})) as Hover | null
+
+			if (!result) {
+				return { content: [{ type: "text", text: "No hover information available at this position." }], details: null }
+			}
+
+			const text = extractHoverText(result)
+			return { content: [{ type: "text", text }], details: null }
+		},
+	})
+
+	// ── Tool: lsp_definition ─────────────────────────────────────────────────
+
+	pi.registerTool({
+		name: "lsp_definition",
+		label: "LSP: Go to Definition",
+		description:
+			"Find the definition of a symbol at a position. Returns file path and line number. Pass method='typeDefinition' or method='implementation' for variants.",
+		promptSnippet: "Navigate to definition/type-definition/implementation of a symbol",
+		parameters: Type.Object({
+			file_path: Type.String({ description: "Absolute or cwd-relative path to the file" }),
+			line: Type.Number({ description: "0-based line number" }),
+			character: Type.Number({ description: "0-based character offset" }),
+			method: Type.Optional(
+				Type.Union([Type.Literal("definition"), Type.Literal("typeDefinition"), Type.Literal("implementation")], {
+					default: "definition",
+				}),
+			),
+		}),
+		async execute(_toolCallId, params, _signal, _onUpdate, ctx) {
+			const filePath = path.isAbsolute(params.file_path) ? params.file_path : path.join(ctx.cwd, params.file_path)
+			const servers = detectServers(ctx.cwd)
+			const server = serverForFile(filePath, servers)
+			if (!server) {
+				return { content: [{ type: "text", text: "No LSP server available for this file type." }], details: null }
+			}
+
+			const client = await getOrCreateClient(server, ctx.cwd)
+			await ensureFileOpen(client, filePath)
+
+			const lspMethod = `textDocument/${params.method ?? "definition"}`
+			const result = (await sendRequest(client, lspMethod, {
+				textDocument: { uri: fileToUri(filePath) },
+				position: { line: params.line, character: params.character },
+			})) as Location | Location[] | LocationLink[] | null
+
+			if (!result) {
+				return { content: [{ type: "text", text: "No definition found." }], details: null }
+			}
+
+			const locations = normalizeLocations(result)
+			const lines = locations.map((loc) => {
+				const file = path.relative(ctx.cwd, uriToFile(loc.uri))
+				return `${file}:${loc.range.start.line + 1}:${loc.range.start.character + 1}`
+			})
+			return { content: [{ type: "text", text: lines.join("\n") }], details: null }
+		},
+	})
+
+	// ── Tool: lsp_references ─────────────────────────────────────────────────
+
+	pi.registerTool({
+		name: "lsp_references",
+		label: "LSP: Find References",
+		description:
+			"Find all references to a symbol across the codebase. Essential before renaming or deleting a symbol to understand the full impact.",
+		promptSnippet: "Find all references to a symbol for refactoring impact analysis",
+		parameters: Type.Object({
+			file_path: Type.String({ description: "Absolute or cwd-relative path to the file" }),
+			line: Type.Number({ description: "0-based line number" }),
+			character: Type.Number({ description: "0-based character offset" }),
+			include_declaration: Type.Optional(
+				Type.Boolean({ description: "Include the declaration itself in results (default: true)", default: true }),
+			),
+		}),
+		async execute(_toolCallId, params, _signal, _onUpdate, ctx) {
+			const filePath = path.isAbsolute(params.file_path) ? params.file_path : path.join(ctx.cwd, params.file_path)
+			const servers = detectServers(ctx.cwd)
+			const server = serverForFile(filePath, servers)
+			if (!server) {
+				return { content: [{ type: "text", text: "No LSP server available for this file type." }], details: null }
+			}
+
+			const client = await getOrCreateClient(server, ctx.cwd)
+			await ensureFileOpen(client, filePath)
+
+			const result = (await sendRequest(client, "textDocument/references", {
+				textDocument: { uri: fileToUri(filePath) },
+				position: { line: params.line, character: params.character },
+				context: { includeDeclaration: params.include_declaration ?? true },
+			})) as Location[] | null
+
+			if (!result || result.length === 0) {
+				return { content: [{ type: "text", text: "No references found." }], details: null }
+			}
+
+			const lines = result.map((loc) => {
+				const file = path.relative(ctx.cwd, uriToFile(loc.uri))
+				return `${file}:${loc.range.start.line + 1}:${loc.range.start.character + 1}`
+			})
+			return { content: [{ type: "text", text: `${result.length} reference(s):\n${lines.join("\n")}` }], details: null }
+		},
+	})
+
+	// ── Tool: lsp_rename ─────────────────────────────────────────────────────
+
+	pi.registerTool({
+		name: "lsp_rename",
+		label: "LSP: Rename Symbol",
+		description:
+			"Atomically rename a symbol across all files. The language server computes all affected locations and the extension applies the edits. Returns a summary of changed files.",
+		promptSnippet: "Rename a symbol across all files using the language server",
+		parameters: Type.Object({
+			file_path: Type.String({ description: "Absolute or cwd-relative path to the file containing the symbol" }),
+			line: Type.Number({ description: "0-based line number of the symbol" }),
+			character: Type.Number({ description: "0-based character offset of the symbol" }),
+			new_name: Type.String({ description: "New name for the symbol" }),
+		}),
+		async execute(_toolCallId, params, _signal, _onUpdate, ctx) {
+			const filePath = path.isAbsolute(params.file_path) ? params.file_path : path.join(ctx.cwd, params.file_path)
+			const servers = detectServers(ctx.cwd)
+			const server = serverForFile(filePath, servers)
+			if (!server) {
+				return { content: [{ type: "text", text: "No LSP server available for this file type." }], details: null }
+			}
+
+			const client = await getOrCreateClient(server, ctx.cwd)
+			await ensureFileOpen(client, filePath)
+
+			// Check if rename is valid at this position
+			const prepareResult = await sendRequest(client, "textDocument/prepareRename", {
+				textDocument: { uri: fileToUri(filePath) },
+				position: { line: params.line, character: params.character },
+			}).catch(() => null)
+
+			if (prepareResult === null) {
+				return {
+					content: [{ type: "text", text: "Cannot rename: symbol at this position is not renameable." }],
+					details: null,
+				}
+			}
+
+			// Request the rename workspace edit
+			const edit = (await sendRequest(client, "textDocument/rename", {
+				textDocument: { uri: fileToUri(filePath) },
+				position: { line: params.line, character: params.character },
+				newName: params.new_name,
+			})) as WorkspaceEdit | null
+
+			if (!edit) {
+				return { content: [{ type: "text", text: "Rename returned no changes." }], details: null }
+			}
+
+			const applied = await applyWorkspaceEdit(edit, ctx.cwd)
+
+			// Refresh all modified files in LSP clients
+			for (const client of getAllClients()) {
+				const affectedUris = [
+					...Object.keys(edit.changes ?? {}),
+					...(edit.documentChanges ?? [])
+						.filter((c): c is TextDocumentEdit => "textDocument" in c)
+						.map((c) => c.textDocument.uri),
+				]
+				for (const uri of affectedUris) {
+					const file = uriToFile(uri)
+					refreshFile(client, file).catch(() => {})
+				}
+			}
+
+			return { content: [{ type: "text", text: applied.join("\n") }], details: null }
+		},
+	})
+}
+
+// =============================================================================
+// Helpers
+// =============================================================================
+
+function extractHoverText(hover: Hover): string {
+	const c = hover.contents
+	if (typeof c === "string") return c
+	if (Array.isArray(c)) {
+		return c
+			.map((item) => (typeof item === "string" ? item : item.value))
+			.filter(Boolean)
+			.join("\n\n")
+	}
+	if ("value" in c) return c.value
+	return String(c)
+}
+
+function normalizeLocations(result: Location | Location[] | LocationLink[]): Location[] {
+	if (!Array.isArray(result)) return [result as Location]
+	return (result as Array<Location | LocationLink>).map((item) => {
+		if ("targetUri" in item) {
+			return { uri: item.targetUri, range: item.targetSelectionRange }
+		}
+		return item as Location
+	})
+}

--- a/extensions/lsp.ts
+++ b/extensions/lsp.ts
@@ -7,12 +7,13 @@
  *
  * Usage: kimchi -e extensions/lsp.ts
  */
+import fs from "node:fs"
 import path from "node:path"
 import type { ExtensionAPI } from "@mariozechner/pi-coding-agent"
 import { Type } from "@sinclair/typebox"
 import { ensureFileOpen, getOrCreateClient, refreshFile, sendRequest, shutdownAll } from "./lsp/client.js"
 import { applyWorkspaceEdit } from "./lsp/edits.js"
-import { detectServers, serverForFile } from "./lsp/servers.js"
+import { detectServers, findRoot, serverForFile } from "./lsp/servers.js"
 import type { Hover, Location, LocationLink, TextDocumentEdit, WorkspaceEdit } from "./lsp/types.js"
 import { fileToUri, formatDiagnostic, uriToFile } from "./lsp/utils.js"
 
@@ -32,8 +33,12 @@ export default function (pi: ExtensionAPI) {
 		activeServers = detectServers(cwd)
 		if (activeServers.length === 0) return
 
-		// Eagerly start servers so they're warm when first tool is called
+		// Eagerly start servers that have a project marker directly in sessionCwd
+		const goMarkers = ["go.mod"]
+		const tsMarkers = ["tsconfig.json", "package.json"]
 		for (const server of activeServers) {
+			const markers = server.name === "gopls" ? goMarkers : tsMarkers
+			if (!markers.some((m) => fs.existsSync(path.join(cwd, m)))) continue
 			getOrCreateClient(server, cwd).catch(() => {})
 		}
 	})
@@ -91,7 +96,7 @@ export default function (pi: ExtensionAPI) {
 				return { content: [{ type: "text", text: "No LSP server available for this file type." }], details: null }
 			}
 
-			const client = await getOrCreateClient(server, clientCwd(filePath, cwd))
+			const client = await getOrCreateClient(server, findRoot(filePath, server.name, cwd))
 			await refreshFile(client, filePath)
 
 			const waitMs = Math.min(params.wait_ms ?? 2000, 10000)
@@ -129,7 +134,7 @@ export default function (pi: ExtensionAPI) {
 				return { content: [{ type: "text", text: "No LSP server available for this file type." }], details: null }
 			}
 
-			const client = await getOrCreateClient(server, clientCwd(filePath, cwd))
+			const client = await getOrCreateClient(server, findRoot(filePath, server.name, cwd))
 			await ensureFileOpen(client, filePath)
 
 			const result = (await sendRequest(client, "textDocument/hover", {
@@ -172,7 +177,7 @@ export default function (pi: ExtensionAPI) {
 				return { content: [{ type: "text", text: "No LSP server available for this file type." }], details: null }
 			}
 
-			const client = await getOrCreateClient(server, clientCwd(filePath, cwd))
+			const client = await getOrCreateClient(server, findRoot(filePath, server.name, cwd))
 			await ensureFileOpen(client, filePath)
 
 			const lspMethod = `textDocument/${params.method ?? "definition"}`
@@ -218,7 +223,7 @@ export default function (pi: ExtensionAPI) {
 				return { content: [{ type: "text", text: "No LSP server available for this file type." }], details: null }
 			}
 
-			const client = await getOrCreateClient(server, clientCwd(filePath, cwd))
+			const client = await getOrCreateClient(server, findRoot(filePath, server.name, cwd))
 			await ensureFileOpen(client, filePath)
 
 			const result = (await sendRequest(client, "textDocument/references", {
@@ -261,7 +266,7 @@ export default function (pi: ExtensionAPI) {
 				return { content: [{ type: "text", text: "No LSP server available for this file type." }], details: null }
 			}
 
-			const client = await getOrCreateClient(server, clientCwd(filePath, cwd))
+			const client = await getOrCreateClient(server, findRoot(filePath, server.name, cwd))
 			await ensureFileOpen(client, filePath)
 
 			// Check if rename is valid at this position

--- a/extensions/lsp.ts
+++ b/extensions/lsp.ts
@@ -10,14 +10,7 @@
 import path from "node:path"
 import type { ExtensionAPI } from "@mariozechner/pi-coding-agent"
 import { Type } from "@sinclair/typebox"
-import {
-	ensureFileOpen,
-	getAllClients,
-	getOrCreateClient,
-	refreshFile,
-	sendRequest,
-	shutdownAll,
-} from "./lsp/client.js"
+import { ensureFileOpen, getOrCreateClient, refreshFile, sendRequest, shutdownAll } from "./lsp/client.js"
 import { applyWorkspaceEdit } from "./lsp/edits.js"
 import { detectServers, serverForFile } from "./lsp/servers.js"
 import type { Hover, Location, LocationLink, TextDocumentEdit, WorkspaceEdit } from "./lsp/types.js"
@@ -25,16 +18,17 @@ import { fileToUri, formatDiagnostic, uriToFile } from "./lsp/utils.js"
 
 export default function (pi: ExtensionAPI) {
 	let cwd = ""
+	let activeServers: ReturnType<typeof detectServers> = []
 
 	// ── Session start: detect servers, hook file sync, shutdown on exit ─────────
 
 	pi.on("session_start", async (_event, ctx) => {
 		cwd = ctx.cwd
-		const servers = detectServers(cwd)
-		if (servers.length === 0) return
+		activeServers = detectServers(cwd)
+		if (activeServers.length === 0) return
 
 		// Eagerly start servers so they're warm when first tool is called
-		for (const server of servers) {
+		for (const server of activeServers) {
 			getOrCreateClient(server, cwd).catch(() => {})
 		}
 	})
@@ -56,8 +50,7 @@ export default function (pi: ExtensionAPI) {
 		if (!filePath) return
 
 		const resolved = path.isAbsolute(filePath) ? filePath : path.join(cwd, filePath)
-		const servers = detectServers(cwd)
-		const server = serverForFile(resolved, servers)
+		const server = serverForFile(resolved, activeServers)
 		if (!server) return
 
 		try {
@@ -87,8 +80,7 @@ export default function (pi: ExtensionAPI) {
 		}),
 		async execute(_toolCallId, params, _signal, _onUpdate, ctx) {
 			const filePath = path.isAbsolute(params.file_path) ? params.file_path : path.join(ctx.cwd, params.file_path)
-			const servers = detectServers(ctx.cwd)
-			const server = serverForFile(filePath, servers)
+			const server = serverForFile(filePath, activeServers)
 			if (!server) {
 				return { content: [{ type: "text", text: "No LSP server available for this file type." }], details: null }
 			}
@@ -125,8 +117,7 @@ export default function (pi: ExtensionAPI) {
 		}),
 		async execute(_toolCallId, params, _signal, _onUpdate, ctx) {
 			const filePath = path.isAbsolute(params.file_path) ? params.file_path : path.join(ctx.cwd, params.file_path)
-			const servers = detectServers(ctx.cwd)
-			const server = serverForFile(filePath, servers)
+			const server = serverForFile(filePath, activeServers)
 			if (!server) {
 				return { content: [{ type: "text", text: "No LSP server available for this file type." }], details: null }
 			}
@@ -168,8 +159,7 @@ export default function (pi: ExtensionAPI) {
 		}),
 		async execute(_toolCallId, params, _signal, _onUpdate, ctx) {
 			const filePath = path.isAbsolute(params.file_path) ? params.file_path : path.join(ctx.cwd, params.file_path)
-			const servers = detectServers(ctx.cwd)
-			const server = serverForFile(filePath, servers)
+			const server = serverForFile(filePath, activeServers)
 			if (!server) {
 				return { content: [{ type: "text", text: "No LSP server available for this file type." }], details: null }
 			}
@@ -214,8 +204,7 @@ export default function (pi: ExtensionAPI) {
 		}),
 		async execute(_toolCallId, params, _signal, _onUpdate, ctx) {
 			const filePath = path.isAbsolute(params.file_path) ? params.file_path : path.join(ctx.cwd, params.file_path)
-			const servers = detectServers(ctx.cwd)
-			const server = serverForFile(filePath, servers)
+			const server = serverForFile(filePath, activeServers)
 			if (!server) {
 				return { content: [{ type: "text", text: "No LSP server available for this file type." }], details: null }
 			}
@@ -257,8 +246,7 @@ export default function (pi: ExtensionAPI) {
 		}),
 		async execute(_toolCallId, params, _signal, _onUpdate, ctx) {
 			const filePath = path.isAbsolute(params.file_path) ? params.file_path : path.join(ctx.cwd, params.file_path)
-			const servers = detectServers(ctx.cwd)
-			const server = serverForFile(filePath, servers)
+			const server = serverForFile(filePath, activeServers)
 			if (!server) {
 				return { content: [{ type: "text", text: "No LSP server available for this file type." }], details: null }
 			}
@@ -292,18 +280,15 @@ export default function (pi: ExtensionAPI) {
 
 			const applied = await applyWorkspaceEdit(edit, ctx.cwd)
 
-			// Refresh all modified files in LSP clients
-			for (const client of getAllClients()) {
-				const affectedUris = [
-					...Object.keys(edit.changes ?? {}),
-					...(edit.documentChanges ?? [])
-						.filter((c): c is TextDocumentEdit => "textDocument" in c)
-						.map((c) => c.textDocument.uri),
-				]
-				for (const uri of affectedUris) {
-					const file = uriToFile(uri)
-					refreshFile(client, file).catch(() => {})
-				}
+			// Refresh all modified files in the client that performed the rename
+			const affectedUris = [
+				...Object.keys(edit.changes ?? {}),
+				...(edit.documentChanges ?? [])
+					.filter((c): c is TextDocumentEdit => "textDocument" in c)
+					.map((c) => c.textDocument.uri),
+			]
+			for (const uri of affectedUris) {
+				refreshFile(client, uriToFile(uri)).catch(() => {})
 			}
 
 			return { content: [{ type: "text", text: applied.join("\n") }], details: null }

--- a/extensions/lsp.ts
+++ b/extensions/lsp.ts
@@ -80,7 +80,8 @@ export default function (pi: ExtensionAPI) {
 		}),
 		async execute(_toolCallId, params, _signal, _onUpdate, ctx) {
 			const filePath = path.isAbsolute(params.file_path) ? params.file_path : path.join(ctx.cwd, params.file_path)
-			const server = serverForFile(filePath, activeServers)
+			const servers = activeServers.length > 0 ? activeServers : detectServers(ctx.cwd)
+			const server = serverForFile(filePath, servers)
 			if (!server) {
 				return { content: [{ type: "text", text: "No LSP server available for this file type." }], details: null }
 			}
@@ -117,7 +118,8 @@ export default function (pi: ExtensionAPI) {
 		}),
 		async execute(_toolCallId, params, _signal, _onUpdate, ctx) {
 			const filePath = path.isAbsolute(params.file_path) ? params.file_path : path.join(ctx.cwd, params.file_path)
-			const server = serverForFile(filePath, activeServers)
+			const servers = activeServers.length > 0 ? activeServers : detectServers(ctx.cwd)
+			const server = serverForFile(filePath, servers)
 			if (!server) {
 				return { content: [{ type: "text", text: "No LSP server available for this file type." }], details: null }
 			}
@@ -159,7 +161,8 @@ export default function (pi: ExtensionAPI) {
 		}),
 		async execute(_toolCallId, params, _signal, _onUpdate, ctx) {
 			const filePath = path.isAbsolute(params.file_path) ? params.file_path : path.join(ctx.cwd, params.file_path)
-			const server = serverForFile(filePath, activeServers)
+			const servers = activeServers.length > 0 ? activeServers : detectServers(ctx.cwd)
+			const server = serverForFile(filePath, servers)
 			if (!server) {
 				return { content: [{ type: "text", text: "No LSP server available for this file type." }], details: null }
 			}
@@ -204,7 +207,8 @@ export default function (pi: ExtensionAPI) {
 		}),
 		async execute(_toolCallId, params, _signal, _onUpdate, ctx) {
 			const filePath = path.isAbsolute(params.file_path) ? params.file_path : path.join(ctx.cwd, params.file_path)
-			const server = serverForFile(filePath, activeServers)
+			const servers = activeServers.length > 0 ? activeServers : detectServers(ctx.cwd)
+			const server = serverForFile(filePath, servers)
 			if (!server) {
 				return { content: [{ type: "text", text: "No LSP server available for this file type." }], details: null }
 			}
@@ -246,7 +250,8 @@ export default function (pi: ExtensionAPI) {
 		}),
 		async execute(_toolCallId, params, _signal, _onUpdate, ctx) {
 			const filePath = path.isAbsolute(params.file_path) ? params.file_path : path.join(ctx.cwd, params.file_path)
-			const server = serverForFile(filePath, activeServers)
+			const servers = activeServers.length > 0 ? activeServers : detectServers(ctx.cwd)
+			const server = serverForFile(filePath, servers)
 			if (!server) {
 				return { content: [{ type: "text", text: "No LSP server available for this file type." }], details: null }
 			}

--- a/extensions/lsp/client.ts
+++ b/extensions/lsp/client.ts
@@ -332,6 +332,9 @@ export async function refreshFile(client: LspClient, filePath: string): Promise<
 
 		if (!info) {
 			await ensureFileOpen(client, filePath)
+			// Send didSave after didOpen so servers like gopls publish diagnostics
+			const uri = fileToUri(filePath)
+			await sendNotification(client, "textDocument/didSave", { textDocument: { uri } })
 			return
 		}
 

--- a/extensions/lsp/client.ts
+++ b/extensions/lsp/client.ts
@@ -1,5 +1,4 @@
 // extensions/lsp/client.ts
-import fs from "node:fs"
 import type {
 	BunProcess,
 	LspClient,
@@ -10,11 +9,6 @@ import type {
 	ServerConfig,
 } from "./types.js"
 import { detectLanguageId, fileToUri } from "./utils.js"
-
-const LSP_LOG = "/tmp/lsp-debug.log"
-function appendLspLog(msg: string): void {
-	fs.appendFileSync(LSP_LOG, `${new Date().toISOString()} ${msg}`)
-}
 
 // =============================================================================
 // Client State
@@ -65,7 +59,7 @@ function parseMessage(buf: Buffer): { message: LspJsonRpcResponse | LspJsonRpcNo
 	const lenMatch = headerText.match(/Content-Length: (\d+)/i)
 	if (!lenMatch) return null
 
-	const contentLen = parseInt(lenMatch[1], 10)
+	const contentLen = Number.parseInt(lenMatch[1], 10)
 	const start = headerEnd + 4
 	const end = start + contentLen
 	if (buf.length < end) return null
@@ -82,7 +76,6 @@ async function writeMessage(
 ): Promise<void> {
 	const content = JSON.stringify(msg)
 	const header = `Content-Length: ${Buffer.byteLength(content, "utf-8")}\r\n\r\n`
-	appendLspLog(`→ ${header.trim()} ${content}\n`)
 	proc.stdin.write(header + content)
 	if (proc.stdin.flush) await proc.stdin.flush()
 }
@@ -100,14 +93,12 @@ async function startMessageReader(client: LspClient): Promise<void> {
 		while (true) {
 			const { done, value } = await reader.read()
 			if (done) break
-			appendLspLog(`← ${value.length} bytes from ${client.name}\n`)
 
 			client.messageBuffer = Buffer.concat([client.messageBuffer, value])
 			let parsed = parseMessage(client.messageBuffer)
 			while (parsed) {
 				const { message, remaining } = parsed
 				client.messageBuffer = remaining
-				appendLspLog(`← parsed: ${JSON.stringify(message).slice(0, 300)}\n`)
 
 				if ("id" in message && message.id !== undefined) {
 					const pending = client.pendingRequests.get(message.id as number)
@@ -126,7 +117,6 @@ async function startMessageReader(client: LspClient): Promise<void> {
 						writeMessage(client.proc, response).catch(() => {})
 					}
 				} else if ("method" in message) {
-					appendLspLog(`notification: ${message.method}\n`)
 					if (message.method === "textDocument/publishDiagnostics" && message.params) {
 						const params = message.params as PublishDiagnosticsParams
 						client.diagnostics.set(params.uri, {
@@ -169,30 +159,29 @@ const DEFAULT_TIMEOUT_MS = 30_000
 export async function getOrCreateClient(config: ServerConfig, cwd: string): Promise<LspClient> {
 	const key = `${config.command}:${cwd}`
 
-	// TODO: re-enable caching once LSP integration is stable
-	// const existing = clients.get(key)
-	// if (existing) {
-	// 	existing.lastActivity = Date.now()
-	// 	return existing
-	// }
+	const existing = clients.get(key)
+	if (existing) {
+		existing.lastActivity = Date.now()
+		return existing
+	}
 
-	// const existingLock = clientLocks.get(key)
-	// if (existingLock) return existingLock
+	const existingLock = clientLocks.get(key)
+	if (existingLock) return existingLock
 
 	const clientPromise = (async () => {
 		// Bun global available at runtime but not typed — use globalThis cast
+		// biome-ignore lint/suspicious/noExplicitAny: Bun not typed without @types/bun
 		const Bun = (globalThis as any).Bun
-		appendLspLog(`spawning ${config.command} in ${cwd}\n`)
+		// biome-ignore lint/suspicious/noExplicitAny: Bun not typed without @types/bun
 		const proc = Bun.spawn([config.command, ...(config.args ?? [])], {
 			cwd,
 			stdin: "pipe",
 			stdout: "pipe",
 			stderr: "pipe",
 		}) as BunProcess
-		appendLspLog(`spawned pid=${(proc as any).pid ?? "?"}\n`)
 
 		let resolveProjectLoaded!: () => void
-		const projectLoaded = new Promise<void>(resolve => {
+		const projectLoaded = new Promise<void>((resolve) => {
 			resolveProjectLoaded = resolve
 		})
 		const timeout = setTimeout(resolveProjectLoaded, PROJECT_LOAD_TIMEOUT_MS)
@@ -220,11 +209,12 @@ export async function getOrCreateClient(config: ServerConfig, cwd: string): Prom
 		}
 		clients.set(key, client)
 
+		// biome-ignore lint/suspicious/noExplicitAny: Bun not typed without @types/bun
 		;(proc as any).exited.then(() => {
-			appendLspLog(`exited code=${( proc as any).exitCode} key=${key}\n`)
 			clients.delete(key)
 			clientLocks.delete(key)
 			client.resolveProjectLoaded()
+			// biome-ignore lint/suspicious/noExplicitAny: Bun not typed without @types/bun
 			const err = new Error(`LSP server exited (code ${(proc as any).exitCode})`)
 			for (const pending of client.pendingRequests.values()) pending.reject(err)
 			client.pendingRequests.clear()
@@ -236,11 +226,12 @@ export async function getOrCreateClient(config: ServerConfig, cwd: string): Prom
 			const reader = client.proc.stderr.getReader()
 			try {
 				while (true) {
-					const { done, value } = await reader.read()
+					const { done } = await reader.read()
 					if (done) break
-					appendLspLog(`stderr(${config.command}): ${Buffer.from(value).toString()}`)
 				}
-			} finally { reader.releaseLock() }
+			} finally {
+				reader.releaseLock()
+			}
 		})()
 
 		try {
@@ -254,7 +245,6 @@ export async function getOrCreateClient(config: ServerConfig, cwd: string): Prom
 			})
 			await sendNotification(client, "initialized", {})
 			await client.projectLoaded
-			appendLspLog(`projectLoaded for ${key}\n`)
 			return client
 		} catch (err) {
 			clients.delete(key)
@@ -298,12 +288,18 @@ export async function sendRequest(client: LspClient, method: string, params: unk
 		}, DEFAULT_TIMEOUT_MS)
 
 		client.pendingRequests.set(id, {
-			resolve: v => { clearTimeout(timer); resolve(v) },
-			reject: e => { clearTimeout(timer); reject(e) },
+			resolve: (v) => {
+				clearTimeout(timer)
+				resolve(v)
+			},
+			reject: (e) => {
+				clearTimeout(timer)
+				reject(e)
+			},
 			method,
 		})
 
-		writeMessage(client.proc, request).catch(err => {
+		writeMessage(client.proc, request).catch((err) => {
 			clearTimeout(timer)
 			client.pendingRequests.delete(id)
 			reject(err)
@@ -327,12 +323,16 @@ export async function ensureFileOpen(client: LspClient, filePath: string): Promi
 
 	const lockKey = `${client.name}:${uri}`
 	const existingLock = fileOperationLocks.get(lockKey)
-	if (existingLock) { await existingLock; return }
+	if (existingLock) {
+		await existingLock
+		return
+	}
 
 	const openPromise = (async () => {
 		if (client.openFiles.has(uri)) return
 		let content: string
 		try {
+			// biome-ignore lint/suspicious/noExplicitAny: Bun not typed without @types/bun
 			const Bun = (globalThis as any).Bun
 			content = await Bun.file(filePath).text()
 		} catch {
@@ -347,7 +347,11 @@ export async function ensureFileOpen(client: LspClient, filePath: string): Promi
 	})()
 
 	fileOperationLocks.set(lockKey, openPromise)
-	try { await openPromise } finally { fileOperationLocks.delete(lockKey) }
+	try {
+		await openPromise
+	} finally {
+		fileOperationLocks.delete(lockKey)
+	}
 }
 
 export async function refreshFile(client: LspClient, filePath: string): Promise<void> {
@@ -371,6 +375,7 @@ export async function refreshFile(client: LspClient, filePath: string): Promise<
 
 		let content: string
 		try {
+			// biome-ignore lint/suspicious/noExplicitAny: Bun not typed without @types/bun
 			const Bun = (globalThis as any).Bun
 			content = await Bun.file(filePath).text()
 		} catch {
@@ -390,7 +395,11 @@ export async function refreshFile(client: LspClient, filePath: string): Promise<
 	})()
 
 	fileOperationLocks.set(lockKey, refreshPromise)
-	try { await refreshPromise } finally { fileOperationLocks.delete(lockKey) }
+	try {
+		await refreshPromise
+	} finally {
+		fileOperationLocks.delete(lockKey)
+	}
 }
 
 export function getAllClients(): LspClient[] {

--- a/extensions/lsp/client.ts
+++ b/extensions/lsp/client.ts
@@ -113,6 +113,7 @@ async function startMessageReader(client: LspClient): Promise<void> {
 					// Silently ignore server-initiated requests (workspace/configuration, workspace/applyEdit)
 					// We advertise applyEdit: false and configuration: false in capabilities.
 				} else if ("method" in message) {
+					process.stderr.write(`[LSP] notification: ${message.method}\n`)
 					if (message.method === "textDocument/publishDiagnostics" && message.params) {
 						const params = message.params as PublishDiagnosticsParams
 						client.diagnostics.set(params.uri, {
@@ -213,6 +214,11 @@ export async function getOrCreateClient(config: ServerConfig, cwd: string): Prom
 		})
 
 		startMessageReader(client)
+		// Drain stderr to prevent pipe buffer filling and blocking gopls stdout
+		;(async () => {
+			const reader = client.proc.stderr.getReader()
+			try { while (!(await reader.read()).done) {} } finally { reader.releaseLock() }
+		})()
 
 		try {
 			await sendRequest(client, "initialize", {

--- a/extensions/lsp/client.ts
+++ b/extensions/lsp/client.ts
@@ -248,6 +248,8 @@ export async function getOrCreateClient(config: ServerConfig, cwd: string): Prom
 				workspaceFolders: [{ uri: fileToUri(cwd), name: cwd.split("/").pop() ?? "workspace" }],
 			})
 			await sendNotification(client, "initialized", {})
+			await client.projectLoaded
+			appendLspLog(`projectLoaded for ${key}\n`)
 			return client
 		} catch (err) {
 			clients.delete(key)

--- a/extensions/lsp/client.ts
+++ b/extensions/lsp/client.ts
@@ -76,6 +76,7 @@ async function writeMessage(
 ): Promise<void> {
 	const content = JSON.stringify(msg)
 	const header = `Content-Length: ${Buffer.byteLength(content, "utf-8")}\r\n\r\n`
+	process.stderr.write(`[LSP →] ${header.trim()} ${content.slice(0, 80)}\n`)
 	proc.stdin.write(header + content)
 	if (proc.stdin.flush) await proc.stdin.flush()
 }
@@ -93,6 +94,7 @@ async function startMessageReader(client: LspClient): Promise<void> {
 		while (true) {
 			const { done, value } = await reader.read()
 			if (done) break
+			process.stderr.write(`[LSP ←] ${value.length} bytes from ${client.name}\n`)
 
 			client.messageBuffer = Buffer.concat([client.messageBuffer, value])
 			let parsed = parseMessage(client.messageBuffer)

--- a/extensions/lsp/client.ts
+++ b/extensions/lsp/client.ts
@@ -168,12 +168,14 @@ export async function getOrCreateClient(config: ServerConfig, cwd: string): Prom
 	const clientPromise = (async () => {
 		// Bun global available at runtime but not typed — use globalThis cast
 		const Bun = (globalThis as any).Bun
+		process.stderr.write(`[LSP] spawning ${config.command} in ${cwd}\n`)
 		const proc = Bun.spawn([config.command, ...(config.args ?? [])], {
 			cwd,
 			stdin: "pipe",
 			stdout: "pipe",
 			stderr: "pipe",
 		}) as BunProcess
+		process.stderr.write(`[LSP] spawned pid=${proc.pid ?? "?"}\n`)
 
 		let resolveProjectLoaded!: () => void
 		const projectLoaded = new Promise<void>(resolve => {

--- a/extensions/lsp/client.ts
+++ b/extensions/lsp/client.ts
@@ -164,14 +164,15 @@ const DEFAULT_TIMEOUT_MS = 30_000
 export async function getOrCreateClient(config: ServerConfig, cwd: string): Promise<LspClient> {
 	const key = `${config.command}:${cwd}`
 
-	const existing = clients.get(key)
-	if (existing) {
-		existing.lastActivity = Date.now()
-		return existing
-	}
+	// TODO: re-enable caching once LSP integration is stable
+	// const existing = clients.get(key)
+	// if (existing) {
+	// 	existing.lastActivity = Date.now()
+	// 	return existing
+	// }
 
-	const existingLock = clientLocks.get(key)
-	if (existingLock) return existingLock
+	// const existingLock = clientLocks.get(key)
+	// if (existingLock) return existingLock
 
 	const clientPromise = (async () => {
 		// Bun global available at runtime but not typed — use globalThis cast

--- a/extensions/lsp/client.ts
+++ b/extensions/lsp/client.ts
@@ -1,4 +1,5 @@
 // extensions/lsp/client.ts
+import fs from "node:fs"
 import type {
 	BunProcess,
 	LspClient,
@@ -9,6 +10,11 @@ import type {
 	ServerConfig,
 } from "./types.js"
 import { detectLanguageId, fileToUri } from "./utils.js"
+
+const LSP_LOG = "/tmp/lsp-debug.log"
+function appendLspLog(msg: string): void {
+	fs.appendFileSync(LSP_LOG, `${new Date().toISOString()} ${msg}`)
+}
 
 // =============================================================================
 // Client State
@@ -76,7 +82,7 @@ async function writeMessage(
 ): Promise<void> {
 	const content = JSON.stringify(msg)
 	const header = `Content-Length: ${Buffer.byteLength(content, "utf-8")}\r\n\r\n`
-	process.stderr.write(`[LSP →] ${header.trim()} ${content.slice(0, 80)}\n`)
+	appendLspLog(`→ ${header.trim()} ${content}\n`)
 	proc.stdin.write(header + content)
 	if (proc.stdin.flush) await proc.stdin.flush()
 }
@@ -94,7 +100,7 @@ async function startMessageReader(client: LspClient): Promise<void> {
 		while (true) {
 			const { done, value } = await reader.read()
 			if (done) break
-			process.stderr.write(`[LSP ←] ${value.length} bytes from ${client.name}\n`)
+			appendLspLog(`← ${value.length} bytes from ${client.name}\n`)
 
 			client.messageBuffer = Buffer.concat([client.messageBuffer, value])
 			let parsed = parseMessage(client.messageBuffer)
@@ -115,7 +121,7 @@ async function startMessageReader(client: LspClient): Promise<void> {
 					// Silently ignore server-initiated requests (workspace/configuration, workspace/applyEdit)
 					// We advertise applyEdit: false and configuration: false in capabilities.
 				} else if ("method" in message) {
-					process.stderr.write(`[LSP] notification: ${message.method}\n`)
+					appendLspLog(`notification: ${message.method}\n`)
 					if (message.method === "textDocument/publishDiagnostics" && message.params) {
 						const params = message.params as PublishDiagnosticsParams
 						client.diagnostics.set(params.uri, {
@@ -170,14 +176,14 @@ export async function getOrCreateClient(config: ServerConfig, cwd: string): Prom
 	const clientPromise = (async () => {
 		// Bun global available at runtime but not typed — use globalThis cast
 		const Bun = (globalThis as any).Bun
-		process.stderr.write(`[LSP] spawning ${config.command} in ${cwd}\n`)
+		appendLspLog(`spawning ${config.command} in ${cwd}\n`)
 		const proc = Bun.spawn([config.command, ...(config.args ?? [])], {
 			cwd,
 			stdin: "pipe",
 			stdout: "pipe",
 			stderr: "pipe",
 		}) as BunProcess
-		process.stderr.write(`[LSP] spawned pid=${(proc as any).pid ?? "?"}\n`)
+		appendLspLog(`spawned pid=${(proc as any).pid ?? "?"}\n`)
 
 		let resolveProjectLoaded!: () => void
 		const projectLoaded = new Promise<void>(resolve => {
@@ -225,7 +231,7 @@ export async function getOrCreateClient(config: ServerConfig, cwd: string): Prom
 				while (true) {
 					const { done, value } = await reader.read()
 					if (done) break
-					process.stderr.write(`[LSP stderr ${config.command}] ${Buffer.from(value).toString()}\n`)
+					appendLspLog(`stderr(${config.command}): ${Buffer.from(value).toString()}`)
 				}
 			} finally { reader.releaseLock() }
 		})()

--- a/extensions/lsp/client.ts
+++ b/extensions/lsp/client.ts
@@ -215,6 +215,7 @@ export async function getOrCreateClient(config: ServerConfig, cwd: string): Prom
 		clients.set(key, client)
 
 		;(proc as any).exited.then(() => {
+			appendLspLog(`exited code=${( proc as any).exitCode} key=${key}\n`)
 			clients.delete(key)
 			clientLocks.delete(key)
 			client.resolveProjectLoaded()

--- a/extensions/lsp/client.ts
+++ b/extensions/lsp/client.ts
@@ -217,7 +217,13 @@ export async function getOrCreateClient(config: ServerConfig, cwd: string): Prom
 		// Drain stderr to prevent pipe buffer filling and blocking gopls stdout
 		;(async () => {
 			const reader = client.proc.stderr.getReader()
-			try { while (!(await reader.read()).done) {} } finally { reader.releaseLock() }
+			try {
+				while (true) {
+					const { done, value } = await reader.read()
+					if (done) break
+					process.stderr.write(`[LSP stderr ${config.command}] ${Buffer.from(value).toString()}\n`)
+				}
+			} finally { reader.releaseLock() }
 		})()
 
 		try {

--- a/extensions/lsp/client.ts
+++ b/extensions/lsp/client.ts
@@ -78,7 +78,7 @@ function parseMessage(buf: Buffer): { message: LspJsonRpcResponse | LspJsonRpcNo
 
 async function writeMessage(
 	proc: BunProcess,
-	msg: LspJsonRpcRequest | LspJsonRpcNotification,
+	msg: LspJsonRpcRequest | LspJsonRpcNotification | LspJsonRpcResponse,
 ): Promise<void> {
 	const content = JSON.stringify(msg)
 	const header = `Content-Length: ${Buffer.byteLength(content, "utf-8")}\r\n\r\n`
@@ -107,6 +107,7 @@ async function startMessageReader(client: LspClient): Promise<void> {
 			while (parsed) {
 				const { message, remaining } = parsed
 				client.messageBuffer = remaining
+				appendLspLog(`← parsed: ${JSON.stringify(message).slice(0, 300)}\n`)
 
 				if ("id" in message && message.id !== undefined) {
 					const pending = client.pendingRequests.get(message.id as number)
@@ -118,8 +119,12 @@ async function startMessageReader(client: LspClient): Promise<void> {
 							pending.resolve(message.result)
 						}
 					}
-					// Silently ignore server-initiated requests (workspace/configuration, workspace/applyEdit)
-					// We advertise applyEdit: false and configuration: false in capabilities.
+					// Reply null to server-initiated requests so servers don't block waiting for a response.
+					// (e.g. window/workDoneProgress/create, workspace/configuration)
+					if ("method" in message) {
+						const response: LspJsonRpcResponse = { jsonrpc: "2.0", id: message.id as number, result: null }
+						writeMessage(client.proc, response).catch(() => {})
+					}
 				} else if ("method" in message) {
 					appendLspLog(`notification: ${message.method}\n`)
 					if (message.method === "textDocument/publishDiagnostics" && message.params) {

--- a/extensions/lsp/client.ts
+++ b/extensions/lsp/client.ts
@@ -1,0 +1,364 @@
+// extensions/lsp/client.ts
+import type {
+	BunProcess,
+	LspClient,
+	LspJsonRpcNotification,
+	LspJsonRpcRequest,
+	LspJsonRpcResponse,
+	PublishDiagnosticsParams,
+	ServerConfig,
+} from "./types.js"
+import { detectLanguageId, fileToUri } from "./utils.js"
+
+// =============================================================================
+// Client State
+// =============================================================================
+
+const clients = new Map<string, LspClient>()
+const clientLocks = new Map<string, Promise<LspClient>>()
+const fileOperationLocks = new Map<string, Promise<void>>()
+
+// =============================================================================
+// Client Capabilities
+// =============================================================================
+
+const CLIENT_CAPABILITIES = {
+	textDocument: {
+		synchronization: { didSave: true, dynamicRegistration: false },
+		hover: { contentFormat: ["markdown", "plaintext"], dynamicRegistration: false },
+		definition: { dynamicRegistration: false, linkSupport: true },
+		typeDefinition: { dynamicRegistration: false, linkSupport: true },
+		implementation: { dynamicRegistration: false, linkSupport: true },
+		references: { dynamicRegistration: false },
+		rename: { dynamicRegistration: false, prepareSupport: true },
+		publishDiagnostics: { relatedInformation: true, versionSupport: true },
+	},
+	window: { workDoneProgress: true },
+	workspace: {
+		applyEdit: false,
+		configuration: false,
+	},
+}
+
+// =============================================================================
+// Message Protocol
+// =============================================================================
+
+function findHeaderEnd(buf: Buffer): number {
+	for (let i = 0; i < buf.length - 3; i++) {
+		if (buf[i] === 13 && buf[i + 1] === 10 && buf[i + 2] === 13 && buf[i + 3] === 10) return i
+	}
+	return -1
+}
+
+function parseMessage(buf: Buffer): { message: LspJsonRpcResponse | LspJsonRpcNotification; remaining: Buffer } | null {
+	const headerEnd = findHeaderEnd(buf)
+	if (headerEnd === -1) return null
+
+	const headerText = buf.slice(0, headerEnd).toString()
+	const lenMatch = headerText.match(/Content-Length: (\d+)/i)
+	if (!lenMatch) return null
+
+	const contentLen = parseInt(lenMatch[1], 10)
+	const start = headerEnd + 4
+	const end = start + contentLen
+	if (buf.length < end) return null
+
+	return {
+		message: JSON.parse(buf.slice(start, end).toString()),
+		remaining: buf.subarray(end),
+	}
+}
+
+async function writeMessage(
+	proc: BunProcess,
+	msg: LspJsonRpcRequest | LspJsonRpcNotification,
+): Promise<void> {
+	const content = JSON.stringify(msg)
+	const header = `Content-Length: ${Buffer.byteLength(content, "utf-8")}\r\n\r\n`
+	proc.stdin.write(header + content)
+	if (proc.stdin.flush) await proc.stdin.flush()
+}
+
+// =============================================================================
+// Message Reader
+// =============================================================================
+
+async function startMessageReader(client: LspClient): Promise<void> {
+	if (client.isReading) return
+	client.isReading = true
+
+	const reader = client.proc.stdout.getReader()
+	try {
+		while (true) {
+			const { done, value } = await reader.read()
+			if (done) break
+
+			client.messageBuffer = Buffer.concat([client.messageBuffer, value])
+			let parsed = parseMessage(client.messageBuffer)
+			while (parsed) {
+				const { message, remaining } = parsed
+				client.messageBuffer = remaining
+
+				if ("id" in message && message.id !== undefined) {
+					const pending = client.pendingRequests.get(message.id as number)
+					if (pending) {
+						client.pendingRequests.delete(message.id as number)
+						if ("error" in message && message.error) {
+							pending.reject(new Error(`LSP error: ${message.error.message}`))
+						} else {
+							pending.resolve(message.result)
+						}
+					}
+					// Silently ignore server-initiated requests (workspace/configuration, workspace/applyEdit)
+					// We advertise applyEdit: false and configuration: false in capabilities.
+				} else if ("method" in message) {
+					if (message.method === "textDocument/publishDiagnostics" && message.params) {
+						const params = message.params as PublishDiagnosticsParams
+						client.diagnostics.set(params.uri, {
+							diagnostics: params.diagnostics,
+							version: params.version ?? null,
+						})
+						client.diagnosticsVersion++
+					} else if (message.method === "$/progress" && message.params) {
+						const params = message.params as { token: string | number; value?: { kind?: string } }
+						if (params.value?.kind === "begin") {
+							client.activeProgressTokens.add(params.token)
+						} else if (params.value?.kind === "end") {
+							client.activeProgressTokens.delete(params.token)
+							if (client.activeProgressTokens.size === 0) client.resolveProjectLoaded()
+						}
+					}
+				}
+
+				parsed = parseMessage(client.messageBuffer)
+			}
+		}
+	} catch (err) {
+		for (const pending of client.pendingRequests.values()) {
+			pending.reject(new Error(`LSP connection closed: ${err}`))
+		}
+		client.pendingRequests.clear()
+	} finally {
+		reader.releaseLock()
+		client.isReading = false
+	}
+}
+
+// =============================================================================
+// Client Lifecycle
+// =============================================================================
+
+const PROJECT_LOAD_TIMEOUT_MS = 15_000
+const DEFAULT_TIMEOUT_MS = 30_000
+
+export async function getOrCreateClient(config: ServerConfig, cwd: string): Promise<LspClient> {
+	const key = `${config.command}:${cwd}`
+
+	const existing = clients.get(key)
+	if (existing) {
+		existing.lastActivity = Date.now()
+		return existing
+	}
+
+	const existingLock = clientLocks.get(key)
+	if (existingLock) return existingLock
+
+	const clientPromise = (async () => {
+		// Bun global available at runtime but not typed — use globalThis cast
+		const Bun = (globalThis as any).Bun
+		const proc = Bun.spawn([config.command, ...(config.args ?? [])], {
+			cwd,
+			stdin: "pipe",
+			stdout: "pipe",
+			stderr: "pipe",
+		}) as BunProcess
+
+		let resolveProjectLoaded!: () => void
+		const projectLoaded = new Promise<void>(resolve => {
+			resolveProjectLoaded = resolve
+		})
+		const timeout = setTimeout(resolveProjectLoaded, PROJECT_LOAD_TIMEOUT_MS)
+		const originalResolve = resolveProjectLoaded
+		resolveProjectLoaded = () => {
+			clearTimeout(timeout)
+			originalResolve()
+		}
+
+		const client: LspClient = {
+			name: key,
+			cwd,
+			proc,
+			requestId: 0,
+			diagnostics: new Map(),
+			diagnosticsVersion: 0,
+			openFiles: new Map(),
+			pendingRequests: new Map(),
+			messageBuffer: Buffer.alloc(0),
+			isReading: false,
+			lastActivity: Date.now(),
+			activeProgressTokens: new Set(),
+			projectLoaded,
+			resolveProjectLoaded,
+		}
+		clients.set(key, client)
+
+		;(proc as any).exited.then(() => {
+			clients.delete(key)
+			clientLocks.delete(key)
+			client.resolveProjectLoaded()
+			const err = new Error(`LSP server exited (code ${(proc as any).exitCode})`)
+			for (const pending of client.pendingRequests.values()) pending.reject(err)
+			client.pendingRequests.clear()
+		})
+
+		startMessageReader(client)
+
+		try {
+			await sendRequest(client, "initialize", {
+				processId: process.pid,
+				rootUri: fileToUri(cwd),
+				rootPath: cwd,
+				capabilities: CLIENT_CAPABILITIES,
+				initializationOptions: config.initOptions ?? {},
+				workspaceFolders: [{ uri: fileToUri(cwd), name: cwd.split("/").pop() ?? "workspace" }],
+			})
+			await sendNotification(client, "initialized", {})
+			return client
+		} catch (err) {
+			clients.delete(key)
+			clientLocks.delete(key)
+			proc.kill()
+			throw err
+		} finally {
+			clientLocks.delete(key)
+		}
+	})()
+
+	clientLocks.set(key, clientPromise)
+	return clientPromise
+}
+
+export function shutdownAll(): void {
+	const all = Array.from(clients.values())
+	clients.clear()
+	const err = new Error("LSP shutdown")
+	for (const client of all) {
+		for (const pending of client.pendingRequests.values()) pending.reject(err)
+		client.pendingRequests.clear()
+		sendRequest(client, "shutdown", null).catch(() => {})
+		client.proc.kill()
+	}
+}
+
+// =============================================================================
+// Protocol
+// =============================================================================
+
+export async function sendRequest(client: LspClient, method: string, params: unknown): Promise<unknown> {
+	const id = ++client.requestId
+	const request: LspJsonRpcRequest = { jsonrpc: "2.0", id, method, params }
+	client.lastActivity = Date.now()
+
+	return new Promise((resolve, reject) => {
+		const timer = setTimeout(() => {
+			client.pendingRequests.delete(id)
+			reject(new Error(`LSP ${method} timed out after ${DEFAULT_TIMEOUT_MS}ms`))
+		}, DEFAULT_TIMEOUT_MS)
+
+		client.pendingRequests.set(id, {
+			resolve: v => { clearTimeout(timer); resolve(v) },
+			reject: e => { clearTimeout(timer); reject(e) },
+			method,
+		})
+
+		writeMessage(client.proc, request).catch(err => {
+			clearTimeout(timer)
+			client.pendingRequests.delete(id)
+			reject(err)
+		})
+	})
+}
+
+export async function sendNotification(client: LspClient, method: string, params: unknown): Promise<void> {
+	const notification: LspJsonRpcNotification = { jsonrpc: "2.0", method, params }
+	client.lastActivity = Date.now()
+	await writeMessage(client.proc, notification)
+}
+
+// =============================================================================
+// File Sync
+// =============================================================================
+
+export async function ensureFileOpen(client: LspClient, filePath: string): Promise<void> {
+	const uri = fileToUri(filePath)
+	if (client.openFiles.has(uri)) return
+
+	const lockKey = `${client.name}:${uri}`
+	const existingLock = fileOperationLocks.get(lockKey)
+	if (existingLock) { await existingLock; return }
+
+	const openPromise = (async () => {
+		if (client.openFiles.has(uri)) return
+		let content: string
+		try {
+			const Bun = (globalThis as any).Bun
+			content = await Bun.file(filePath).text()
+		} catch {
+			return // file doesn't exist
+		}
+		const languageId = detectLanguageId(filePath)
+		await sendNotification(client, "textDocument/didOpen", {
+			textDocument: { uri, languageId, version: 1, text: content },
+		})
+		client.openFiles.set(uri, { version: 1, languageId })
+		client.lastActivity = Date.now()
+	})()
+
+	fileOperationLocks.set(lockKey, openPromise)
+	try { await openPromise } finally { fileOperationLocks.delete(lockKey) }
+}
+
+export async function refreshFile(client: LspClient, filePath: string): Promise<void> {
+	const uri = fileToUri(filePath)
+	const lockKey = `${client.name}:${uri}`
+
+	const existingLock = fileOperationLocks.get(lockKey)
+	if (existingLock) await existingLock
+
+	const refreshPromise = (async () => {
+		client.diagnostics.delete(uri)
+		const info = client.openFiles.get(uri)
+
+		if (!info) {
+			await ensureFileOpen(client, filePath)
+			return
+		}
+
+		let content: string
+		try {
+			const Bun = (globalThis as any).Bun
+			content = await Bun.file(filePath).text()
+		} catch {
+			return
+		}
+
+		const version = ++info.version
+		await sendNotification(client, "textDocument/didChange", {
+			textDocument: { uri, version },
+			contentChanges: [{ text: content }],
+		})
+		await sendNotification(client, "textDocument/didSave", {
+			textDocument: { uri },
+			text: content,
+		})
+		client.lastActivity = Date.now()
+	})()
+
+	fileOperationLocks.set(lockKey, refreshPromise)
+	try { await refreshPromise } finally { fileOperationLocks.delete(lockKey) }
+}
+
+export function getAllClients(): LspClient[] {
+	return Array.from(clients.values())
+}

--- a/extensions/lsp/client.ts
+++ b/extensions/lsp/client.ts
@@ -175,7 +175,7 @@ export async function getOrCreateClient(config: ServerConfig, cwd: string): Prom
 			stdout: "pipe",
 			stderr: "pipe",
 		}) as BunProcess
-		process.stderr.write(`[LSP] spawned pid=${proc.pid ?? "?"}\n`)
+		process.stderr.write(`[LSP] spawned pid=${(proc as any).pid ?? "?"}\n`)
 
 		let resolveProjectLoaded!: () => void
 		const projectLoaded = new Promise<void>(resolve => {

--- a/extensions/lsp/edits.ts
+++ b/extensions/lsp/edits.ts
@@ -1,0 +1,78 @@
+// extensions/lsp/edits.ts
+import * as fs from "node:fs/promises"
+import path from "node:path"
+import type { TextEdit, WorkspaceEdit } from "./types.js"
+import { uriToFile } from "./utils.js"
+
+export function applyTextEditsToString(content: string, edits: TextEdit[]): string {
+	if (edits.length === 0) return content
+	const lines = content.split("\n")
+
+	const sorted = [...edits].sort((a, b) => {
+		if (a.range.start.line !== b.range.start.line) return b.range.start.line - a.range.start.line
+		return b.range.start.character - a.range.start.character
+	})
+
+	for (const edit of sorted) {
+		const { start, end } = edit.range
+		if (start.line === end.line) {
+			const line = lines[start.line] ?? ""
+			lines[start.line] = line.slice(0, start.character) + edit.newText + line.slice(end.character)
+		} else {
+			const startLine = lines[start.line] ?? ""
+			const endLine = lines[end.line] ?? ""
+			const merged = startLine.slice(0, start.character) + edit.newText + endLine.slice(end.character)
+			lines.splice(start.line, end.line - start.line + 1, ...merged.split("\n"))
+		}
+	}
+
+	return lines.join("\n")
+}
+
+async function applyTextEditsToFile(filePath: string, edits: TextEdit[]): Promise<void> {
+	const content = await fs.readFile(filePath, "utf-8")
+	const result = applyTextEditsToString(content, edits)
+	await fs.writeFile(filePath, result, "utf-8")
+}
+
+/** Apply a workspace edit. Used for rename results only. Returns list of applied change descriptions. */
+export async function applyWorkspaceEdit(edit: WorkspaceEdit, cwd: string): Promise<string[]> {
+	const applied: string[] = []
+
+	if (edit.changes) {
+		for (const [uri, textEdits] of Object.entries(edit.changes)) {
+			const filePath = uriToFile(uri)
+			await applyTextEditsToFile(filePath, textEdits)
+			applied.push(`Applied ${textEdits.length} edit(s) to ${path.relative(cwd, filePath)}`)
+		}
+	}
+
+	if (edit.documentChanges) {
+		for (const change of edit.documentChanges) {
+			if ("textDocument" in change && "edits" in change) {
+				const filePath = uriToFile(change.textDocument.uri)
+				const textEdits = change.edits.filter((e): e is TextEdit => "range" in e && "newText" in e)
+				await applyTextEditsToFile(filePath, textEdits)
+				applied.push(`Applied ${textEdits.length} edit(s) to ${path.relative(cwd, filePath)}`)
+			} else if ("kind" in change) {
+				if (change.kind === "create") {
+					const filePath = uriToFile(change.uri)
+					await fs.writeFile(filePath, "", "utf-8")
+					applied.push(`Created ${path.relative(cwd, filePath)}`)
+				} else if (change.kind === "rename") {
+					const oldPath = uriToFile(change.oldUri)
+					const newPath = uriToFile(change.newUri)
+					await fs.mkdir(path.dirname(newPath), { recursive: true })
+					await fs.rename(oldPath, newPath)
+					applied.push(`Renamed ${path.relative(cwd, oldPath)} → ${path.relative(cwd, newPath)}`)
+				} else if (change.kind === "delete") {
+					const filePath = uriToFile(change.uri)
+					await fs.rm(filePath, { recursive: true })
+					applied.push(`Deleted ${path.relative(cwd, filePath)}`)
+				}
+			}
+		}
+	}
+
+	return applied
+}

--- a/extensions/lsp/servers.ts
+++ b/extensions/lsp/servers.ts
@@ -1,4 +1,5 @@
 // extensions/lsp/servers.ts
+import fs from "node:fs"
 import path from "node:path"
 import type { ServerConfig } from "./types.js"
 
@@ -36,4 +37,29 @@ export function detectServers(_cwd: string): ServerConfig[] {
 export function serverForFile(filePath: string, servers: ServerConfig[]): ServerConfig | null {
 	const ext = path.extname(filePath).slice(1).toLowerCase()
 	return servers.find((s) => s.extensions.includes(ext)) ?? null
+}
+
+const ROOT_MARKERS: Record<string, string[]> = {
+	gopls: ["go.mod"],
+	"typescript-language-server": ["tsconfig.json", "package.json"],
+}
+
+/**
+ * Walk up from filePath to find the nearest project root for the given server.
+ * Clamps to sessionCwd — never escapes above it.
+ * Falls back to path.dirname(filePath) if no marker found.
+ */
+export function findRoot(filePath: string, serverName: string, sessionCwd: string): string {
+	const markers = ROOT_MARKERS[serverName] ?? []
+	let dir = path.dirname(filePath)
+	const boundary = sessionCwd
+
+	while (true) {
+		if (markers.some((m) => fs.existsSync(path.join(dir, m)))) return dir
+		if (dir === boundary || dir === path.dirname(dir)) break
+		dir = path.dirname(dir)
+	}
+
+	// If no marker found within sessionCwd, use file's own directory
+	return path.dirname(filePath)
 }

--- a/extensions/lsp/servers.ts
+++ b/extensions/lsp/servers.ts
@@ -1,0 +1,69 @@
+// extensions/lsp/servers.ts
+import * as fs from "node:fs"
+import path from "node:path"
+import type { ServerConfig } from "./types.js"
+
+const SERVERS: ServerConfig[] = [
+	{
+		name: "typescript-language-server",
+		command: "typescript-language-server",
+		args: ["--stdio"],
+		extensions: ["ts", "tsx", "mts", "cts", "js", "jsx", "mjs", "cjs"],
+	},
+	{
+		name: "gopls",
+		command: "gopls",
+		args: [],
+		extensions: ["go"],
+	},
+]
+
+function exists(cmd: string): boolean {
+	try {
+		const result = (globalThis as any).Bun.spawnSync(["which", cmd], { stdout: "pipe", stderr: "pipe" })
+		return result.exitCode === 0
+	} catch {
+		return false
+	}
+}
+
+function cwdHasExtension(cwd: string, exts: string[]): boolean {
+	try {
+		const entries = fs.readdirSync(cwd, { recursive: true, withFileTypes: true })
+		return (entries as fs.Dirent[]).some(
+			e => e.isFile() && exts.some(ext => e.name.endsWith(`.${ext}`)),
+		)
+	} catch {
+		return false
+	}
+}
+
+/** Detect which LSP servers apply to the given cwd based on file extensions present. */
+export function detectServers(cwd: string): ServerConfig[] {
+	const applicable: ServerConfig[] = []
+
+	for (const server of SERVERS) {
+		let apply = false
+
+		if (server.name === "typescript-language-server") {
+			apply =
+				fs.existsSync(path.join(cwd, "tsconfig.json")) ||
+				fs.existsSync(path.join(cwd, "package.json")) ||
+				cwdHasExtension(cwd, server.extensions)
+		} else if (server.name === "gopls") {
+			apply = fs.existsSync(path.join(cwd, "go.mod")) || cwdHasExtension(cwd, server.extensions)
+		}
+
+		if (apply && exists(server.command)) {
+			applicable.push(server)
+		}
+	}
+
+	return applicable
+}
+
+/** Get the server config for a specific file path, or null if no server applies. */
+export function serverForFile(filePath: string, servers: ServerConfig[]): ServerConfig | null {
+	const ext = path.extname(filePath).slice(1).toLowerCase()
+	return servers.find(s => s.extensions.includes(ext)) ?? null
+}

--- a/extensions/lsp/servers.ts
+++ b/extensions/lsp/servers.ts
@@ -1,5 +1,4 @@
 // extensions/lsp/servers.ts
-import * as fs from "node:fs"
 import path from "node:path"
 import type { ServerConfig } from "./types.js"
 
@@ -20,6 +19,7 @@ const SERVERS: ServerConfig[] = [
 
 function exists(cmd: string): boolean {
 	try {
+		// biome-ignore lint/suspicious/noExplicitAny: Bun not typed without @types/bun
 		const result = (globalThis as any).Bun.spawnSync(["which", cmd], { stdout: "pipe", stderr: "pipe" })
 		return result.exitCode === 0
 	} catch {
@@ -27,43 +27,13 @@ function exists(cmd: string): boolean {
 	}
 }
 
-function cwdHasExtension(cwd: string, exts: string[]): boolean {
-	try {
-		const entries = fs.readdirSync(cwd, { recursive: true, withFileTypes: true })
-		return (entries as fs.Dirent[]).some(
-			e => e.isFile() && exts.some(ext => e.name.endsWith(`.${ext}`)),
-		)
-	} catch {
-		return false
-	}
-}
-
-/** Detect which LSP servers apply to the given cwd based on file extensions present. */
-export function detectServers(cwd: string): ServerConfig[] {
-	const applicable: ServerConfig[] = []
-
-	for (const server of SERVERS) {
-		let apply = false
-
-		if (server.name === "typescript-language-server") {
-			apply =
-				fs.existsSync(path.join(cwd, "tsconfig.json")) ||
-				fs.existsSync(path.join(cwd, "package.json")) ||
-				cwdHasExtension(cwd, server.extensions)
-		} else if (server.name === "gopls") {
-			apply = fs.existsSync(path.join(cwd, "go.mod")) || cwdHasExtension(cwd, server.extensions)
-		}
-
-		if (apply && exists(server.command)) {
-			applicable.push(server)
-		}
-	}
-
-	return applicable
+/** Returns all LSP servers whose binary is available on PATH. */
+export function detectServers(_cwd: string): ServerConfig[] {
+	return SERVERS.filter((s) => exists(s.command))
 }
 
 /** Get the server config for a specific file path, or null if no server applies. */
 export function serverForFile(filePath: string, servers: ServerConfig[]): ServerConfig | null {
 	const ext = path.extname(filePath).slice(1).toLowerCase()
-	return servers.find(s => s.extensions.includes(ext)) ?? null
+	return servers.find((s) => s.extensions.includes(ext)) ?? null
 }

--- a/extensions/lsp/types.ts
+++ b/extensions/lsp/types.ts
@@ -1,0 +1,152 @@
+// extensions/lsp/types.ts
+
+export interface Position {
+	line: number
+	character: number
+}
+
+export interface Range {
+	start: Position
+	end: Position
+}
+
+export interface Location {
+	uri: string
+	range: Range
+}
+
+export interface LocationLink {
+	originSelectionRange?: Range
+	targetUri: string
+	targetRange: Range
+	targetSelectionRange: Range
+}
+
+export interface TextEdit {
+	range: Range
+	newText: string
+}
+
+export interface TextDocumentEdit {
+	textDocument: { uri: string; version?: number | null }
+	edits: TextEdit[]
+}
+
+export interface CreateFile {
+	kind: "create"
+	uri: string
+}
+
+export interface RenameFile {
+	kind: "rename"
+	oldUri: string
+	newUri: string
+}
+
+export interface DeleteFile {
+	kind: "delete"
+	uri: string
+}
+
+export interface WorkspaceEdit {
+	changes?: Record<string, TextEdit[]>
+	documentChanges?: (TextDocumentEdit | CreateFile | RenameFile | DeleteFile)[]
+}
+
+export type DiagnosticSeverity = 1 | 2 | 3 | 4
+
+export interface Diagnostic {
+	range: Range
+	severity?: DiagnosticSeverity
+	code?: string | number
+	source?: string
+	message: string
+}
+
+export interface PublishDiagnosticsParams {
+	uri: string
+	version?: number
+	diagnostics: Diagnostic[]
+}
+
+export interface Hover {
+	contents:
+		| string
+		| { language?: string; value: string }
+		| { kind: "markdown" | "plaintext"; value: string }
+		| Array<string | { language?: string; value: string }>
+	range?: Range
+}
+
+export interface DocumentSymbol {
+	name: string
+	kind: number
+	range: Range
+	selectionRange: Range
+	children?: DocumentSymbol[]
+}
+
+export interface LspJsonRpcRequest {
+	jsonrpc: "2.0"
+	id: number
+	method: string
+	params: unknown
+}
+
+export interface LspJsonRpcResponse {
+	jsonrpc: "2.0"
+	id: number
+	result?: unknown
+	error?: { code: number; message: string; data?: unknown }
+}
+
+export interface LspJsonRpcNotification {
+	jsonrpc: "2.0"
+	method: string
+	params?: unknown
+}
+
+export interface OpenFileInfo {
+	version: number
+	languageId: string
+}
+
+export interface PendingRequest {
+	resolve: (value: unknown) => void
+	reject: (reason: Error) => void
+	method: string
+}
+
+export interface BunProcess {
+	stdin: { write(data: Uint8Array | string): void; flush?(): Promise<void>; end(): void }
+	stdout: ReadableStream<Uint8Array>
+	stderr: ReadableStream<Uint8Array>
+	kill(): void
+	exited: Promise<void>
+	exitCode: number | null
+}
+
+export interface LspClient {
+	name: string
+	cwd: string
+	proc: BunProcess
+	requestId: number
+	diagnostics: Map<string, { diagnostics: Diagnostic[]; version: number | null }>
+	diagnosticsVersion: number
+	openFiles: Map<string, OpenFileInfo>
+	pendingRequests: Map<number, PendingRequest>
+	messageBuffer: Buffer
+	isReading: boolean
+	lastActivity: number
+	activeProgressTokens: Set<string | number>
+	projectLoaded: Promise<void>
+	resolveProjectLoaded: () => void
+}
+
+export interface ServerConfig {
+	name: string
+	command: string
+	args?: string[]
+	extensions: string[]
+	initOptions?: Record<string, unknown>
+}

--- a/extensions/lsp/utils.ts
+++ b/extensions/lsp/utils.ts
@@ -1,0 +1,80 @@
+// extensions/lsp/utils.ts
+import path from "node:path"
+import type { Diagnostic } from "./types.js"
+
+// =============================================================================
+// URI Handling
+// =============================================================================
+
+export function fileToUri(filePath: string): string {
+	const resolved = path.resolve(filePath)
+	if (process.platform === "win32") {
+		return `file:///${resolved.replace(/\\/g, "/")}`
+	}
+	return `file://${resolved}`
+}
+
+export function uriToFile(uri: string): string {
+	if (!uri.startsWith("file://")) return uri
+	let filePath = decodeURIComponent(uri.slice(7))
+	if (process.platform === "win32" && filePath.startsWith("/") && /^[A-Za-z]:/.test(filePath.slice(1))) {
+		filePath = filePath.slice(1)
+	}
+	return filePath
+}
+
+// =============================================================================
+// Language Detection
+// =============================================================================
+
+const EXT_TO_LANG: Record<string, string> = {
+	ts: "typescript",
+	tsx: "typescriptreact",
+	mts: "typescript",
+	cts: "typescript",
+	js: "javascript",
+	jsx: "javascriptreact",
+	mjs: "javascript",
+	cjs: "javascript",
+	go: "go",
+	rs: "rust",
+	py: "python",
+	rb: "ruby",
+	java: "java",
+	c: "c",
+	cpp: "cpp",
+	h: "c",
+	hpp: "cpp",
+	cs: "csharp",
+	json: "json",
+	yaml: "yaml",
+	yml: "yaml",
+	toml: "toml",
+	md: "markdown",
+	sh: "shellscript",
+	bash: "shellscript",
+}
+
+export function detectLanguageId(filePath: string): string {
+	const ext = path.extname(filePath).slice(1).toLowerCase()
+	return EXT_TO_LANG[ext] ?? "plaintext"
+}
+
+// =============================================================================
+// Diagnostic Formatting
+// =============================================================================
+
+const SEVERITY_NAMES: Record<number, string> = {
+	1: "error",
+	2: "warning",
+	3: "info",
+	4: "hint",
+}
+
+export function formatDiagnostic(d: Diagnostic): string {
+	const line = d.range.start.line + 1
+	const col = d.range.start.character + 1
+	const sev = SEVERITY_NAMES[d.severity ?? 1] ?? "error"
+	const code = d.code !== undefined ? ` [${d.code}]` : ""
+	return `${line}:${col} ${sev}${code}: ${d.message}`
+}

--- a/src/extensions/lsp/edits.test.ts
+++ b/src/extensions/lsp/edits.test.ts
@@ -1,0 +1,69 @@
+// src/extensions/lsp/edits.test.ts
+import { describe, expect, it } from "vitest"
+import { applyTextEditsToString } from "../../../extensions/lsp/edits.js"
+
+describe("applyTextEditsToString", () => {
+	it("applies a single-line replacement", () => {
+		const content = "const foo = 1\nconst bar = 2\n"
+		const result = applyTextEditsToString(content, [
+			{
+				range: { start: { line: 0, character: 6 }, end: { line: 0, character: 9 } },
+				newText: "baz",
+			},
+		])
+		expect(result).toBe("const baz = 1\nconst bar = 2\n")
+	})
+
+	it("applies multiple edits in bottom-to-top order", () => {
+		const content = "aaa\nbbb\nccc\n"
+		const result = applyTextEditsToString(content, [
+			{
+				range: { start: { line: 0, character: 0 }, end: { line: 0, character: 3 } },
+				newText: "AAA",
+			},
+			{
+				range: { start: { line: 2, character: 0 }, end: { line: 2, character: 3 } },
+				newText: "CCC",
+			},
+		])
+		expect(result).toBe("AAA\nbbb\nCCC\n")
+	})
+
+	it("applies a multi-line replacement", () => {
+		const content = "function foo() {\n  return 1\n}\n"
+		const result = applyTextEditsToString(content, [
+			{
+				range: { start: { line: 0, character: 9 }, end: { line: 2, character: 1 } },
+				newText: "bar() {\n  return 2\n}",
+			},
+		])
+		expect(result).toBe("function bar() {\n  return 2\n}\n")
+	})
+
+	it("handles insertion (empty range)", () => {
+		const content = "hello world\n"
+		const result = applyTextEditsToString(content, [
+			{
+				range: { start: { line: 0, character: 5 }, end: { line: 0, character: 5 } },
+				newText: " beautiful",
+			},
+		])
+		expect(result).toBe("hello beautiful world\n")
+	})
+
+	it("handles deletion (empty newText)", () => {
+		const content = "hello world\n"
+		const result = applyTextEditsToString(content, [
+			{
+				range: { start: { line: 0, character: 5 }, end: { line: 0, character: 11 } },
+				newText: "",
+			},
+		])
+		expect(result).toBe("hello\n")
+	})
+
+	it("returns content unchanged for empty edits array", () => {
+		const content = "unchanged\n"
+		expect(applyTextEditsToString(content, [])).toBe("unchanged\n")
+	})
+})

--- a/src/extensions/lsp/lsp-entry.test.ts
+++ b/src/extensions/lsp/lsp-entry.test.ts
@@ -1,0 +1,25 @@
+import path from "node:path"
+import { describe, expect, it } from "vitest"
+import { clientCwd } from "../../../extensions/lsp.js"
+
+describe("clientCwd", () => {
+	it("returns sessionCwd for file inside it", () => {
+		expect(clientCwd("/repo/src/foo.ts", "/repo")).toBe("/repo")
+	})
+
+	it("returns sessionCwd for file at sessionCwd root", () => {
+		expect(clientCwd("/repo/foo.ts", "/repo")).toBe("/repo")
+	})
+
+	it("returns file directory for file outside sessionCwd", () => {
+		expect(clientCwd("/tmp/test.ts", "/repo")).toBe("/tmp")
+	})
+
+	it("does not match sessionCwd as prefix of unrelated path", () => {
+		expect(clientCwd("/repo-other/foo.ts", "/repo")).toBe("/repo-other")
+	})
+
+	it("returns file directory for deeply nested outside file", () => {
+		expect(clientCwd("/tmp/gotest/main.go", "/repo")).toBe("/tmp/gotest")
+	})
+})

--- a/src/extensions/lsp/lsp-entry.test.ts
+++ b/src/extensions/lsp/lsp-entry.test.ts
@@ -1,4 +1,3 @@
-import path from "node:path"
 import { describe, expect, it } from "vitest"
 import { clientCwd } from "../../../extensions/lsp.js"
 

--- a/src/extensions/lsp/utils.test.ts
+++ b/src/extensions/lsp/utils.test.ts
@@ -1,0 +1,81 @@
+// src/extensions/lsp/utils.test.ts
+import { describe, expect, it } from "vitest"
+import { detectLanguageId, fileToUri, formatDiagnostic, uriToFile } from "../../../extensions/lsp/utils.js"
+
+describe("fileToUri", () => {
+	it("converts absolute unix path to file URI", () => {
+		expect(fileToUri("/home/user/foo.ts")).toBe("file:///home/user/foo.ts")
+	})
+
+	it("resolves relative paths", () => {
+		const result = fileToUri("foo.ts")
+		expect(result).toMatch(/^file:\/\/\//)
+		expect(result).toMatch(/foo\.ts$/)
+	})
+})
+
+describe("uriToFile", () => {
+	it("converts file URI back to path", () => {
+		expect(uriToFile("file:///home/user/foo.ts")).toBe("/home/user/foo.ts")
+	})
+
+	it("passes through non-file URIs", () => {
+		expect(uriToFile("untitled:foo")).toBe("untitled:foo")
+	})
+
+	it("round-trips with fileToUri", () => {
+		const path = "/tmp/test/bar.go"
+		expect(uriToFile(fileToUri(path))).toBe(path)
+	})
+})
+
+describe("detectLanguageId", () => {
+	it("detects TypeScript", () => {
+		expect(detectLanguageId("foo.ts")).toBe("typescript")
+	})
+
+	it("detects TypeScript JSX", () => {
+		expect(detectLanguageId("foo.tsx")).toBe("typescriptreact")
+	})
+
+	it("detects Go", () => {
+		expect(detectLanguageId("foo.go")).toBe("go")
+	})
+
+	it("detects JavaScript", () => {
+		expect(detectLanguageId("foo.js")).toBe("javascript")
+	})
+
+	it("falls back to plaintext for unknown", () => {
+		expect(detectLanguageId("foo.xyz")).toBe("plaintext")
+	})
+})
+
+describe("formatDiagnostic", () => {
+	it("formats an error diagnostic", () => {
+		const result = formatDiagnostic({
+			range: { start: { line: 4, character: 2 }, end: { line: 4, character: 10 } },
+			severity: 1,
+			message: "Cannot find name 'foo'",
+		})
+		expect(result).toBe("5:3 error: Cannot find name 'foo'")
+	})
+
+	it("formats a warning diagnostic with code", () => {
+		const result = formatDiagnostic({
+			range: { start: { line: 0, character: 0 }, end: { line: 0, character: 1 } },
+			severity: 2,
+			code: "TS2345",
+			message: "Type mismatch",
+		})
+		expect(result).toBe("1:1 warning [TS2345]: Type mismatch")
+	})
+
+	it("defaults to error severity when missing", () => {
+		const result = formatDiagnostic({
+			range: { start: { line: 0, character: 0 }, end: { line: 0, character: 1 } },
+			message: "something wrong",
+		})
+		expect(result).toContain("error")
+	})
+})


### PR DESCRIPTION
## Summary

- Adds `extensions/lsp.ts` — loadable via `kimchi -e extensions/lsp.ts`
- Supports TypeScript (`typescript-language-server`) and Go (`gopls`) via PATH detection
- Registers 5 tools: `lsp_diagnostics`, `lsp_hover`, `lsp_definition`, `lsp_references`, `lsp_rename`
- Handles ad-hoc files outside sessionCwd by walking up to the nearest project root (`go.mod` / `tsconfig.json`)
- Responds to server-initiated requests (e.g. `window/workDoneProgress/create`) so gopls doesn't block after `initialized`
- Awaits `$/progress` end tokens (with 15s fallback) before returning the client, ensuring gopls is ready
- Client caching by project root — one gopls/tsserver per workspace

## Key fix

gopls sends `window/workDoneProgress/create` (a JSON-RPC request with both `id` and `method`) immediately after `initialized`, then blocks on our response before sending `$/progress` notifications or processing any further messages. We were silently ignoring it, causing all LSP operations to hang. Fixed by replying `null` to any server-initiated request.

## Test plan

- [ ] Unit tests: `pnpm test` — 350 passing
- [ ] TypeScript diagnostics: `lsp_diagnostics` on a `.ts` file with a type error
- [ ] Go diagnostics: `lsp_diagnostics` on `tmp-go-test/main.go` (has `cannot use "not a number" as int`)
- [ ] Hover: `lsp_hover` on a symbol
- [ ] Definition: `lsp_definition` on a symbol
- [ ] References: `lsp_references` on a symbol
- [ ] Rename: `lsp_rename` on a symbol