### PR TITLE
fix: Release pipeline fails after archive layout changed

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -66,7 +66,7 @@ jobs:
         run: pnpm run build:binary
 
       - name: Package binary
-        run: tar -czf kimchi-code_${{ matrix.os }}_${{ matrix.arch }}.tar.gz -C dist kimchi-code package.json theme
+        run: tar -czf kimchi-code_${{ matrix.os }}_${{ matrix.arch }}.tar.gz -C dist bin share
 
       - name: Upload artifact
         uses: actions/upload-artifact@v4


### PR DESCRIPTION
The auxiliary-files refactor moved build output from dist/{kimchi-code,package.json,theme} to dist/bin/kimchi-code and dist/share/kimchi/{package.json,theme}, but release.yml's tar command still referenced the old paths, failing every tag push at the "Package binary" step.