### PR TITLE
feat: agent UX improvements

### DIFF
--- a/extensions/lsp.ts
+++ b/extensions/lsp.ts
@@ -9,7 +9,8 @@
  */
 import fs from "node:fs"
 import path from "node:path"
-import type { ExtensionAPI } from "@mariozechner/pi-coding-agent"
+import type { ExtensionAPI, Theme } from "@mariozechner/pi-coding-agent"
+import { Container, Text } from "@mariozechner/pi-tui"
 import { Type } from "@sinclair/typebox"
 import { ensureFileOpen, getOrCreateClient, refreshFile, sendRequest, shutdownAll } from "./lsp/client.js"
 import { applyWorkspaceEdit } from "./lsp/edits.js"
@@ -111,6 +112,7 @@ export default function (pi: ExtensionAPI) {
 			const lines = entry.diagnostics.map((d) => formatDiagnostic(d))
 			return { content: [{ type: "text", text: lines.join("\n") }], details: null }
 		},
+		renderCall: (args, theme, context) => renderLspCall("LSP: Get Diagnostics", args, theme, context),
 	})
 
 	// ── Tool: lsp_hover ───────────────────────────────────────────────────────
@@ -149,6 +151,7 @@ export default function (pi: ExtensionAPI) {
 			const text = extractHoverText(result)
 			return { content: [{ type: "text", text }], details: null }
 		},
+		renderCall: (args, theme, context) => renderLspCall("LSP: Hover Info", args, theme, context),
 	})
 
 	// ── Tool: lsp_definition ─────────────────────────────────────────────────
@@ -197,6 +200,7 @@ export default function (pi: ExtensionAPI) {
 			})
 			return { content: [{ type: "text", text: lines.join("\n") }], details: null }
 		},
+		renderCall: (args, theme, context) => renderLspCall("LSP: Go to Definition", args, theme, context),
 	})
 
 	// ── Tool: lsp_references ─────────────────────────────────────────────────
@@ -242,6 +246,7 @@ export default function (pi: ExtensionAPI) {
 			})
 			return { content: [{ type: "text", text: `${result.length} reference(s):\n${lines.join("\n")}` }], details: null }
 		},
+		renderCall: (args, theme, context) => renderLspCall("LSP: Find References", args, theme, context),
 	})
 
 	// ── Tool: lsp_rename ─────────────────────────────────────────────────────
@@ -308,12 +313,32 @@ export default function (pi: ExtensionAPI) {
 
 			return { content: [{ type: "text", text: applied.join("\n") }], details: null }
 		},
+		renderCall: (args, theme, context) => renderLspCall("LSP: Rename Symbol", args, theme, context),
 	})
 }
 
 // =============================================================================
 // Helpers
 // =============================================================================
+
+function renderLspCall(
+	label: string,
+	args: Record<string, unknown>,
+	theme: Theme,
+	context: { lastComponent: unknown },
+): Container {
+	const filePath = (args.file_path as string | undefined) ?? ""
+	const line = args.line !== undefined ? `:${(args.line as number) + 1}` : ""
+	const char = args.character !== undefined ? `:${(args.character as number) + 1}` : ""
+	const loc = filePath ? `${filePath}${line}${char}` : ""
+	const header = `${theme.fg("muted", "-")} ${theme.fg("toolTitle", theme.bold(label))}`
+	const fileLine = loc ? `  ${theme.fg("muted", "file:")} ${theme.fg("accent", "`")}${theme.fg("accent", loc)}${theme.fg("accent", "`")}` : ""
+	const text = fileLine ? `${header}\n${fileLine}` : header
+	const component = context.lastComponent instanceof Container ? context.lastComponent : new Container()
+	component.clear()
+	component.addChild(new Text(text, 0, 0))
+	return component
+}
 
 function extractHoverText(hover: Hover): string {
 	const c = hover.contents

--- a/extensions/lsp.ts
+++ b/extensions/lsp.ts
@@ -112,7 +112,7 @@ export default function (pi: ExtensionAPI) {
 			const lines = entry.diagnostics.map((d) => formatDiagnostic(d))
 			return { content: [{ type: "text", text: lines.join("\n") }], details: null }
 		},
-		renderCall: (args, theme, context) => renderLspCall("LSP: Get Diagnostics", args, theme, context),
+		renderCall: lspRenderCall("LSP: Get Diagnostics"),
 	})
 
 	// ── Tool: lsp_hover ───────────────────────────────────────────────────────
@@ -151,7 +151,7 @@ export default function (pi: ExtensionAPI) {
 			const text = extractHoverText(result)
 			return { content: [{ type: "text", text }], details: null }
 		},
-		renderCall: (args, theme, context) => renderLspCall("LSP: Hover Info", args, theme, context),
+		renderCall: lspRenderCall("LSP: Hover Info"),
 	})
 
 	// ── Tool: lsp_definition ─────────────────────────────────────────────────
@@ -200,7 +200,7 @@ export default function (pi: ExtensionAPI) {
 			})
 			return { content: [{ type: "text", text: lines.join("\n") }], details: null }
 		},
-		renderCall: (args, theme, context) => renderLspCall("LSP: Go to Definition", args, theme, context),
+		renderCall: lspRenderCall("LSP: Go to Definition"),
 	})
 
 	// ── Tool: lsp_references ─────────────────────────────────────────────────
@@ -246,7 +246,7 @@ export default function (pi: ExtensionAPI) {
 			})
 			return { content: [{ type: "text", text: `${result.length} reference(s):\n${lines.join("\n")}` }], details: null }
 		},
-		renderCall: (args, theme, context) => renderLspCall("LSP: Find References", args, theme, context),
+		renderCall: lspRenderCall("LSP: Find References"),
 	})
 
 	// ── Tool: lsp_rename ─────────────────────────────────────────────────────
@@ -313,7 +313,7 @@ export default function (pi: ExtensionAPI) {
 
 			return { content: [{ type: "text", text: applied.join("\n") }], details: null }
 		},
-		renderCall: (args, theme, context) => renderLspCall("LSP: Rename Symbol", args, theme, context),
+		renderCall: lspRenderCall("LSP: Rename Symbol"),
 	})
 }
 
@@ -321,23 +321,20 @@ export default function (pi: ExtensionAPI) {
 // Helpers
 // =============================================================================
 
-function renderLspCall(
-	label: string,
-	args: Record<string, unknown>,
-	theme: Theme,
-	context: { lastComponent: unknown },
-): Container {
-	const filePath = (args.file_path as string | undefined) ?? ""
-	const line = args.line !== undefined ? `:${(args.line as number) + 1}` : ""
-	const char = args.character !== undefined ? `:${(args.character as number) + 1}` : ""
-	const loc = filePath ? `${filePath}${line}${char}` : ""
-	const header = `${theme.fg("muted", "-")} ${theme.fg("toolTitle", theme.bold(label))}`
-	const fileLine = loc ? `  ${theme.fg("muted", "file:")} ${theme.fg("accent", "`")}${theme.fg("accent", loc)}${theme.fg("accent", "`")}` : ""
-	const text = fileLine ? `${header}\n${fileLine}` : header
-	const component = context.lastComponent instanceof Container ? context.lastComponent : new Container()
-	component.clear()
-	component.addChild(new Text(text, 0, 0))
-	return component
+function lspRenderCall(label: string) {
+	return (args: Record<string, unknown>, theme: Theme, context: { lastComponent: unknown }): Container => {
+		const filePath = (args.file_path as string | undefined) ?? ""
+		const line = args.line !== undefined ? `:${(args.line as number) + 1}` : ""
+		const char = args.character !== undefined ? `:${(args.character as number) + 1}` : ""
+		const loc = filePath ? `${filePath}${line}${char}` : ""
+		const header = `${theme.fg("muted", "-")} ${theme.fg("toolTitle", theme.bold(label))}`
+		const fileLine = loc ? `  ${theme.fg("muted", "file:")} ${theme.fg("accent", "`")}${theme.fg("accent", loc)}${theme.fg("accent", "`")}` : ""
+		const text = fileLine ? `${header}\n${fileLine}` : header
+		const component = context.lastComponent instanceof Container ? context.lastComponent : new Container()
+		component.clear()
+		component.addChild(new Text(text, 0, 0))
+		return component
+	}
 }
 
 function extractHoverText(hover: Hover): string {

--- a/src/auxiliary-files/resolver.test.ts
+++ b/src/auxiliary-files/resolver.test.ts
@@ -1,4 +1,7 @@
-import { describe, expect, it } from "vitest"
+import { mkdirSync, rmSync, writeFileSync } from "node:fs"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
+import { afterEach, beforeEach, describe, expect, it } from "vitest"
 import { resolveAuxiliaryFilesDir } from "./resolver.js"
 
 describe("resolveAuxiliaryFilesDir", () => {
@@ -43,5 +46,40 @@ describe("resolveAuxiliaryFilesDir", () => {
 	it("handles XDG_DATA_HOME with a trailing slash", () => {
 		const env = { XDG_DATA_HOME: "/xdg/data/" }
 		expect(resolveAuxiliaryFilesDir(env, home)).toBe("/xdg/data/kimchi")
+	})
+
+	describe("binary-sibling share directory", () => {
+		let tmpBase: string
+
+		beforeEach(() => {
+			tmpBase = join(tmpdir(), `kimchi-resolver-test-${process.pid}`)
+			// Simulate dist/bin/kimchi-code + dist/share/kimchi/package.json
+			mkdirSync(join(tmpBase, "bin"), { recursive: true })
+			mkdirSync(join(tmpBase, "share", "kimchi"), { recursive: true })
+			writeFileSync(join(tmpBase, "share", "kimchi", "package.json"), "{}")
+		})
+
+		afterEach(() => {
+			rmSync(tmpBase, { recursive: true, force: true })
+		})
+
+		it("returns sibling share dir when package.json exists next to the binary", () => {
+			const execPath = join(tmpBase, "bin", "kimchi-code")
+			const env: Record<string, string | undefined> = {}
+			expect(resolveAuxiliaryFilesDir(env, home, execPath)).toBe(join(tmpBase, "share", "kimchi"))
+		})
+
+		it("PI_PACKAGE_DIR takes precedence over sibling share dir", () => {
+			const execPath = join(tmpBase, "bin", "kimchi-code")
+			const env = { PI_PACKAGE_DIR: "/custom/path" }
+			expect(resolveAuxiliaryFilesDir(env, home, execPath)).toBe("/custom/path")
+		})
+
+		it("falls through to XDG when sibling share dir has no package.json", () => {
+			rmSync(join(tmpBase, "share", "kimchi", "package.json"))
+			const execPath = join(tmpBase, "bin", "kimchi-code")
+			const env = { XDG_DATA_HOME: "/xdg/data" }
+			expect(resolveAuxiliaryFilesDir(env, home, execPath)).toBe("/xdg/data/kimchi")
+		})
 	})
 })

--- a/src/auxiliary-files/resolver.ts
+++ b/src/auxiliary-files/resolver.ts
@@ -1,8 +1,22 @@
+import { existsSync } from "node:fs"
 import { join } from "node:path"
 
-export function resolveAuxiliaryFilesDir(env: Record<string, string | undefined>, homeDir: string): string {
+export function resolveAuxiliaryFilesDir(
+	env: Record<string, string | undefined>,
+	homeDir: string,
+	execPath?: string,
+): string {
 	if (env.PI_PACKAGE_DIR) {
 		return env.PI_PACKAGE_DIR
+	}
+
+	// When running as a compiled binary (dist/bin/kimchi-code), share files
+	// live at ../share/kimchi relative to the binary.
+	if (execPath) {
+		const siblingShare = join(execPath, "..", "..", "share", "kimchi")
+		if (existsSync(join(siblingShare, "package.json"))) {
+			return siblingShare
+		}
 	}
 
 	if (env.XDG_DATA_HOME) {

--- a/src/entry.ts
+++ b/src/entry.ts
@@ -12,7 +12,7 @@ import { resolveAuxiliaryFilesDir } from "./auxiliary-files/resolver.js"
 import { validateAuxiliaryFiles } from "./auxiliary-files/validator.js"
 
 const preSet = !!process.env.PI_PACKAGE_DIR
-const auxiliaryDir = resolveAuxiliaryFilesDir(process.env, homedir())
+const auxiliaryDir = resolveAuxiliaryFilesDir(process.env, homedir(), process.execPath)
 if (!preSet) {
 	try {
 		validateAuxiliaryFiles(auxiliaryDir)

--- a/src/extensions/orchestration/prompt-transformer/prompts/orchestrator-system-prompt.md.template
+++ b/src/extensions/orchestration/prompt-transformer/prompts/orchestrator-system-prompt.md.template
@@ -1,4 +1,4 @@
-You are an expert coding assistant. You have full access to tools to read, write, edit files, and run commands. You can also spawn subagents when delegation is more appropriate than doing the work yourself.
+You are an expert coding assistant. Your available tools are listed under **Available Tools** below — use only those, never guess or invent tool names. You can also spawn subagents when delegation is more appropriate than doing the work yourself.
 
 ## How to approach every task
 

--- a/src/extensions/orchestration/prompt-transformer/prompts/subagent-system-prompt.md.template
+++ b/src/extensions/orchestration/prompt-transformer/prompts/subagent-system-prompt.md.template
@@ -1,6 +1,4 @@
-You are an expert coding assistant. You help users by reading files, executing commands, editing code, and writing new files.
-
-You operate inside a coding agent harness with access to the tools listed below. Use them to accomplish the task the user has given you.
+You are an expert coding assistant. You operate inside a coding agent harness. Use only the tools listed under **Available Tools** below — never guess or invent tool names.
 
 ## Available Tools
 

--- a/src/extensions/subagent.ts
+++ b/src/extensions/subagent.ts
@@ -65,6 +65,22 @@ function resolveTsx(): string | undefined {
 	return undefined
 }
 
+function collectExtensionArgs(): string[] {
+	const result: string[] = []
+	const argv = process.argv
+	for (let i = 0; i < argv.length; i++) {
+		if (argv[i] === "-e" || argv[i] === "--extension") {
+			if (i + 1 < argv.length) {
+				result.push("-e", argv[i + 1])
+				i++
+			}
+		} else if (argv[i].startsWith("--extension=")) {
+			result.push("-e", argv[i].slice("--extension=".length))
+		}
+	}
+	return result
+}
+
 function getSubagentInvocation(args: string[]): { command: string; args: string[] } {
 	if (isBunBinary) {
 		return { command: process.execPath, args }
@@ -324,6 +340,7 @@ export default function (pi: ExtensionAPI) {
 		parameters: SubagentParams,
 
 		async execute(_toolCallId, params, signal, onUpdate, ctx) {
+			const extensionArgs = collectExtensionArgs()
 			const args = [
 				"--mode",
 				"json",
@@ -333,6 +350,7 @@ export default function (pi: ExtensionAPI) {
 				params.provider,
 				"--model",
 				params.model,
+				...extensionArgs,
 				params.prompt,
 			]
 			const invocation = getSubagentInvocation(args)


### PR DESCRIPTION
## Summary

- **LSP tool rendering**: add `renderCall` to all 5 LSP tools showing file path and position (e.g. `src/models.ts:80:5`), matching the style of other tools
- **Subagent extension forwarding**: subagents now inherit `-e` flags from the parent process, so extensions like `lsp.ts` are available in subagents
- **Binary resolver**: auto-detect `dist/share/kimchi/` next to the binary so `pnpm build:binary && ./dist/bin/kimchi-code` works without polluting `~/.local/share/kimchi`
- **Prompt fix**: replace misleading "you have full access to tools to read, write, edit files" opener with explicit instruction to use only listed tools — prevents models from hallucinating `find`/`grep` as tool names

## Test plan

- [ ] `pnpm test` — 393 passing
- [ ] `pnpm typecheck` — clean
- [ ] Build binary and run directly: `pnpm build:binary && ./dist/bin/kimchi-code` — no auxiliary files error
- [ ] Run with LSP extension and spawn subagent — subagent has `lsp_hover` etc. available
- [ ] Call `lsp_hover` — UI shows `LSP: Hover Info` with `file:path:line:char`