### PR TITLE
fix(smoke): stabilize smoke tests after -p mode fix

### DIFF
--- a/tests/smoke/binary.test.ts
+++ b/tests/smoke/binary.test.ts
@@ -37,8 +37,6 @@ describe("binary smoke tests", () => {
 			extraEnv: { KIMCHI_API_KEY: "smoke-test-dummy" },
 			throwOnError: false,
 		})
-		// The orchestration extension intercepts the prompt (action: "handled"), so the binary exits cleanly without reaching the LLM API.
-		expect(result.status).toBe(0)
 		// The orchestration extension fires "input" and "before_agent_start" events, triggering template loading. If templates are missing from the compiled binary, the extension runner reports ENOENT via "Extension error" on stderr.
 		expect(result.stderr).not.toContain("Extension error")
 	})

--- a/tests/smoke/harness.ts
+++ b/tests/smoke/harness.ts
@@ -52,7 +52,7 @@ export function ensureAgentDir(): string {
 	return dir
 }
 
-const DEFAULT_TIMEOUT_MS = 14_000
+const DEFAULT_TIMEOUT_MS = 30_000
 
 interface RunBinaryOptions {
 	args?: string[]


### PR DESCRIPTION
- Increase default timeout from 14s to 30s for tests that require a real LLM round-trip.
- Stop asserting exit status in the prompt-template embedding test, since a dummy KIMCHI_API_KEY now reaches the API and exits non-zero. The test still verifies its real invariant (no "Extension error" on stderr).