### PR TITLE
feat: set User-Agent header to kimchi/0.0.1 on LLM requests

### DIFF
--- a/src/models.ts
+++ b/src/models.ts
@@ -45,6 +45,7 @@ function buildModelsConfig(models: string[]) {
 				apiKey: "KIMCHI_API_KEY",
 				api: "openai-completions",
 				authHeader: true,
+				headers: { "User-Agent": "kimchi/0.0.1" },
 				models: models.map((id) => ({
 					id,
 					name: modelIdToName(id),


### PR DESCRIPTION
## Summary

- Sets `User-Agent: kimchi/0.0.1` on all outgoing LLM requests via the provider `headers` config
- Enables kimchi traffic identification in gateway metrics