### PR TITLE
LLM-1358: fix multi-line paste for terminals without bracketed-paste support

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
 		"@mixmark-io/domino": "^2.2.0",
 		"@types/node": "^22.15.2",
 		"@types/turndown": "^5.0.5",
+		"node-pty": "^1.1.0",
 		"playwright": "^1.52.0",
 		"tsx": "^4.21.0",
 		"turndown": "^7.2.0",
@@ -55,6 +56,12 @@
 	},
 	"packageManager": "pnpm@10.8.1",
 	"pnpm": {
-		"onlyBuiltDependencies": ["@biomejs/biome", "esbuild", "koffi", "protobufjs"]
+		"onlyBuiltDependencies": [
+			"@biomejs/biome",
+			"esbuild",
+			"koffi",
+			"node-pty",
+			"protobufjs"
+		]
 	}
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -48,6 +48,9 @@ importers:
       '@types/turndown':
         specifier: ^5.0.5
         version: 5.0.6
+      node-pty:
+        specifier: ^1.1.0
+        version: 1.1.0
       playwright:
         specifier: ^1.52.0
         version: 1.59.1
@@ -1559,6 +1562,9 @@ packages:
     resolution: {integrity: sha512-z9sZrk6wyf8/NDKKqe+Tyl58XtgkYrV4kgt1O8xrzYvpl1LvPacPo0imMLHfpStk3kgCIq1ksJ2bmJn9hue2lQ==}
     engines: {node: '>= 0.4.0'}
 
+  node-addon-api@7.1.1:
+    resolution: {integrity: sha512-5m3bsyrjFWE1xf7nz7YXdN4udnVtXK6/Yfgn5qnahL6bCkf2yKt4k3nuTKAtT4r3IG8JNR2ncsIMdZuAzJjHQQ==}
+
   node-domexception@1.0.0:
     resolution: {integrity: sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ==}
     engines: {node: '>=10.5.0'}
@@ -1567,6 +1573,9 @@ packages:
   node-fetch@3.3.2:
     resolution: {integrity: sha512-dRB78srN/l6gqWulah9SrxeYnxeddIG30+GOqK/9OlLVyLg3HPnr6SqOWTWOXKRwC2eGYCkZ59NNuSgvSrpgOA==}
     engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
+
+  node-pty@1.1.0:
+    resolution: {integrity: sha512-20JqtutY6JPXTUnL0ij1uad7Qe1baT46lyolh2sSENDd4sTzKZ4nmAFkeAARDKwmlLjPx6XKRlwRUxwjOy+lUg==}
 
   object-assign@4.1.1:
     resolution: {integrity: sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==}
@@ -3837,6 +3846,8 @@ snapshots:
 
   netmask@2.1.0: {}
 
+  node-addon-api@7.1.1: {}
+
   node-domexception@1.0.0: {}
 
   node-fetch@3.3.2:
@@ -3844,6 +3855,10 @@ snapshots:
       data-uri-to-buffer: 4.0.1
       fetch-blob: 3.2.0
       formdata-polyfill: 4.0.10
+
+  node-pty@1.1.0:
+    dependencies:
+      node-addon-api: 7.1.1
 
   object-assign@4.1.1: {}
 

--- a/src/entry.ts
+++ b/src/entry.ts
@@ -10,6 +10,7 @@ import { homedir } from "node:os"
 import { resolve } from "node:path"
 import { resolveAuxiliaryFilesDir } from "./auxiliary-files/resolver.js"
 import { validateAuxiliaryFiles } from "./auxiliary-files/validator.js"
+import { installPasteInterceptor } from "./paste-interceptor.js"
 
 const preSet = !!process.env.PI_PACKAGE_DIR
 const auxiliaryDir = resolveAuxiliaryFilesDir(process.env, homedir(), process.execPath)
@@ -28,5 +29,8 @@ process.env.KIMCHI_CODING_AGENT_DIR = agentDir
 
 process.title = "kimchi"
 process.env.PI_SKIP_VERSION_CHECK = "1"
+
+// Install before the dynamic cli.js import - the interceptor must wrap process.stdin.emit before any pi-* listener attaches. See src/paste-interceptor.ts for the rationale (LLM-1358).
+installPasteInterceptor()
 
 await import("./cli.js")

--- a/src/paste-interceptor.test.ts
+++ b/src/paste-interceptor.test.ts
@@ -1,0 +1,89 @@
+import { EventEmitter } from "node:events"
+import { describe, expect, it } from "vitest"
+import { installPasteInterceptor, looksLikeRawPaste, wrapAsBracketedPaste } from "./paste-interceptor.js"
+
+const ESC = String.fromCharCode(0x1b)
+
+describe("looksLikeRawPaste", () => {
+	it("is false for a single character", () => {
+		expect(looksLikeRawPaste("a")).toBe(false)
+		expect(looksLikeRawPaste("\r")).toBe(false)
+	})
+
+	it("is false for two \\r in a short chunk (below length threshold)", () => {
+		// Length 3 — a human could plausibly type this; not enough signal to treat as paste.
+		expect(looksLikeRawPaste("\r\r\r")).toBe(false)
+	})
+
+	it("is false for text with only one \\r", () => {
+		expect(looksLikeRawPaste("hello world\r")).toBe(false)
+	})
+
+	it("is true for a multi-line paste without markers", () => {
+		expect(looksLikeRawPaste("one\rtwo\rthree\rhow many lines?")).toBe(true)
+	})
+
+	it("is true for exactly two \\r separators in a 4+ byte chunk", () => {
+		expect(looksLikeRawPaste("a\rb\r")).toBe(true)
+	})
+
+	it("is false when the chunk contains an ESC byte (conservative guard)", () => {
+		// An ESC here usually means a key sequence is mixed in — don't corrupt it.
+		expect(looksLikeRawPaste(`one\rtwo\r${ESC}[A`)).toBe(false)
+	})
+})
+
+describe("wrapAsBracketedPaste", () => {
+	it("wraps with ESC[200~ … ESC[201~ and normalizes \\r to \\n", () => {
+		const out = wrapAsBracketedPaste("one\rtwo\rthree")
+		expect(out).toBe(`${ESC}[200~one\ntwo\nthree${ESC}[201~`)
+	})
+
+	it("normalizes \\r\\n as well as bare \\r", () => {
+		const out = wrapAsBracketedPaste("a\r\nb\rc")
+		expect(out).toBe(`${ESC}[200~a\nb\nc${ESC}[201~`)
+	})
+})
+
+describe("installPasteInterceptor", () => {
+	function makeFakeStdin(): EventEmitter {
+		// A plain EventEmitter is enough — the interceptor only uses .emit and .on isn't touched.
+		return new EventEmitter()
+	}
+
+	it("wraps raw-paste-burst chunks in bracketed-paste markers before listeners see them", () => {
+		const stdin = makeFakeStdin()
+		installPasteInterceptor(stdin as unknown as NodeJS.ReadStream)
+		const received: string[] = []
+		stdin.on("data", (chunk) => received.push(chunk.toString()))
+
+		stdin.emit("data", "one\rtwo\rthree")
+
+		expect(received).toHaveLength(1)
+		expect(received[0]).toBe(`${ESC}[200~one\ntwo\nthree${ESC}[201~`)
+	})
+
+	it("passes through chunks that don't look like a paste", () => {
+		const stdin = makeFakeStdin()
+		installPasteInterceptor(stdin as unknown as NodeJS.ReadStream)
+		const received: string[] = []
+		stdin.on("data", (chunk) => received.push(chunk.toString()))
+
+		stdin.emit("data", "\r")
+		stdin.emit("data", "hello")
+		stdin.emit("data", `${ESC}[A`) // arrow key — should not be swallowed
+
+		expect(received).toEqual(["\r", "hello", `${ESC}[A`])
+	})
+
+	it("passes non-data events through unchanged", () => {
+		const stdin = makeFakeStdin()
+		installPasteInterceptor(stdin as unknown as NodeJS.ReadStream)
+		let endCalled = 0
+		stdin.on("end", () => endCalled++)
+
+		stdin.emit("end")
+
+		expect(endCalled).toBe(1)
+	})
+})

--- a/src/paste-interceptor.test.ts
+++ b/src/paste-interceptor.test.ts
@@ -86,4 +86,19 @@ describe("installPasteInterceptor", () => {
 
 		expect(endCalled).toBe(1)
 	})
+
+	it("is idempotent — calling install twice does not double-wrap emit", () => {
+		const stdin = makeFakeStdin()
+		installPasteInterceptor(stdin as unknown as NodeJS.ReadStream)
+		const emitAfterFirst = stdin.emit
+		installPasteInterceptor(stdin as unknown as NodeJS.ReadStream)
+		expect(stdin.emit).toBe(emitAfterFirst)
+
+		// Sanity: a paste chunk still produces exactly one wrapped data event, not two.
+		const received: string[] = []
+		stdin.on("data", (chunk) => received.push(chunk.toString()))
+		stdin.emit("data", "one\rtwo\rthree")
+		expect(received).toHaveLength(1)
+		expect(received[0]).toBe(`${ESC}[200~one\ntwo\nthree${ESC}[201~`)
+	})
 })

--- a/src/paste-interceptor.ts
+++ b/src/paste-interceptor.ts
@@ -1,0 +1,42 @@
+// Heuristic fallback for terminals that don't honor bracketed-paste mode (ESC[?2004h).
+// Without bracketed paste, a pasted multi-line block arrives as raw keystrokes — every \r matches the Editor's Enter keybinding and submits the first line as a message. The intent (a single multi-line prompt) is lost.
+// This interceptor watches process.stdin and, when a single chunk looks like a burst paste, re-emits it wrapped in ESC[200~...ESC[201~ so pi-tui's existing bracketed-paste pipeline handles it. If the heuristic doesn't fire, behavior is unchanged.
+
+// Use String.fromCharCode — biome strips literal control bytes from string literals.
+const ESC = String.fromCharCode(0x1b)
+const BRACKETED_START = `${ESC}[200~`
+const BRACKETED_END = `${ESC}[201~`
+
+const MIN_CHUNK_LEN = 4
+const MIN_CR_COUNT = 2
+
+export function looksLikeRawPaste(chunk: string): boolean {
+	if (chunk.length < MIN_CHUNK_LEN) return false
+	let crCount = 0
+	for (let i = 0; i < chunk.length; i++) {
+		if (chunk[i] === "\r") crCount++
+		if (crCount >= MIN_CR_COUNT) break
+	}
+	if (crCount < MIN_CR_COUNT) return false
+	// Conservative guard: if the chunk contains any escape byte, leave it alone. A real paste is plain text; an ESC here likely means the chunk also carries a key sequence we shouldn't corrupt.
+	if (chunk.includes(ESC)) return false
+	return true
+}
+
+export function wrapAsBracketedPaste(chunk: string): string {
+	return BRACKETED_START + chunk.replace(/\r\n?/g, "\n") + BRACKETED_END
+}
+
+export function installPasteInterceptor(stdin: NodeJS.ReadStream = process.stdin): void {
+	const originalEmit = stdin.emit.bind(stdin)
+	stdin.emit = ((event: string | symbol, ...args: unknown[]) => {
+		if (event === "data" && args.length > 0) {
+			const chunk = args[0]
+			const text = typeof chunk === "string" ? chunk : Buffer.isBuffer(chunk) ? chunk.toString("utf8") : null
+			if (text !== null && looksLikeRawPaste(text)) {
+				return originalEmit("data", wrapAsBracketedPaste(text))
+			}
+		}
+		return originalEmit(event as string, ...args)
+	}) as typeof stdin.emit
+}

--- a/src/paste-interceptor.ts
+++ b/src/paste-interceptor.ts
@@ -10,26 +10,28 @@ const BRACKETED_END = `${ESC}[201~`
 const MIN_CHUNK_LEN = 4
 const MIN_CR_COUNT = 2
 
+// Count \r only, not \n. In raw mode Enter is \r, so human pastes arrive as \r-separated; \n in a stdin chunk means programmatic input, not a paste. Adding \n to the count would wrap benign program output in bracketed-paste markers.
 export function looksLikeRawPaste(chunk: string): boolean {
 	if (chunk.length < MIN_CHUNK_LEN) return false
-	let crCount = 0
-	for (let i = 0; i < chunk.length; i++) {
-		if (chunk[i] === "\r") crCount++
-		if (crCount >= MIN_CR_COUNT) break
-	}
-	if (crCount < MIN_CR_COUNT) return false
 	// Conservative guard: if the chunk contains any escape byte, leave it alone. A real paste is plain text; an ESC here likely means the chunk also carries a key sequence we shouldn't corrupt.
 	if (chunk.includes(ESC)) return false
-	return true
+	let crCount = 0
+	for (const ch of chunk) {
+		if (ch === "\r" && ++crCount >= MIN_CR_COUNT) return true
+	}
+	return false
 }
 
 export function wrapAsBracketedPaste(chunk: string): string {
 	return BRACKETED_START + chunk.replace(/\r\n?/g, "\n") + BRACKETED_END
 }
 
+type MarkedEmit = NodeJS.ReadStream["emit"] & { installed?: boolean }
+
 export function installPasteInterceptor(stdin: NodeJS.ReadStream = process.stdin): void {
+	if ((stdin.emit as MarkedEmit).installed) return
 	const originalEmit = stdin.emit.bind(stdin)
-	stdin.emit = ((event: string | symbol, ...args: unknown[]) => {
+	const wrapped: MarkedEmit = (event: string | symbol, ...args: unknown[]) => {
 		if (event === "data" && args.length > 0) {
 			const chunk = args[0]
 			const text = typeof chunk === "string" ? chunk : Buffer.isBuffer(chunk) ? chunk.toString("utf8") : null
@@ -38,5 +40,7 @@ export function installPasteInterceptor(stdin: NodeJS.ReadStream = process.stdin
 			}
 		}
 		return originalEmit(event as string, ...args)
-	}) as typeof stdin.emit
+	}
+	wrapped.installed = true
+	stdin.emit = wrapped
 }

--- a/tests/smoke/harness.ts
+++ b/tests/smoke/harness.ts
@@ -8,10 +8,14 @@
  */
 
 import { type SpawnSyncReturns, spawnSync } from "node:child_process"
-import { mkdirSync, mkdtempSync, rmSync } from "node:fs"
+import { chmodSync, mkdirSync, mkdtempSync, rmSync, statSync } from "node:fs"
+import { createRequire } from "node:module"
 import { tmpdir } from "node:os"
-import { join, resolve } from "node:path"
+import { dirname, join, resolve } from "node:path"
+import { type IPty, spawn as ptySpawn } from "node-pty"
 import { afterAll, beforeAll } from "vitest"
+
+const nodeRequire = createRequire(import.meta.url)
 
 export const BINARY_PATH = resolve("dist/bin/kimchi-code")
 export const PACKAGE_DIR = resolve("dist/share/kimchi")
@@ -89,4 +93,98 @@ export function runBinary(opts: RunBinaryOptions = {}): SpawnSyncReturns<string>
 		}
 	}
 	return result
+}
+
+// pnpm drops the executable bit on node-pty's spawn-helper. Without +x, pty.spawn fails with "posix_spawnp failed" the first time the harness tries to start a PTY-backed process. Fix it once at module load.
+function ensurePtySpawnHelperExecutable(): void {
+	// Derive the prebuilds dir from node-pty's own entry point so we track whatever version is installed rather than hardcoding it.
+	const ptyEntry = nodeRequire.resolve("node-pty") // .../node-pty/lib/index.js
+	const prebuildsDir = join(dirname(dirname(ptyEntry)), "prebuilds")
+	// The harness may run on any of these platforms; chmod whichever ones are present and ignore the rest.
+	for (const platform of ["darwin-arm64", "darwin-x64", "linux-x64", "linux-arm64"]) {
+		const helper = join(prebuildsDir, platform, "spawn-helper")
+		try {
+			const mode = statSync(helper).mode
+			if ((mode & 0o111) === 0) {
+				chmodSync(helper, mode | 0o755)
+			}
+		} catch {
+			// Helper not present for this platform — ignore.
+		}
+	}
+}
+ensurePtySpawnHelperExecutable()
+
+interface RunInteractiveOptions {
+	cols?: number
+	rows?: number
+	extraEnv?: Record<string, string>
+}
+
+export interface InteractiveSession {
+	/** Escape hatch for raw node-pty operations the helpers don't cover. */
+	pty: IPty
+	/** Everything kimchi has printed so far, ANSI escapes intact. */
+	output(): string
+	/** Poll the output; resolve when `predicate(output)` is true, reject on timeout. Use for "wait for prompt", "wait for render". */
+	waitFor(predicate: (out: string) => boolean, timeoutMs?: number): Promise<void>
+	/** Type `data` into kimchi as if from a keyboard. */
+	write(data: string): void
+	/** Like `write`, but wrapped in terminal bracketed-paste markers — simulates a real paste. */
+	bracketedPaste(text: string): void
+	/** Send Ctrl+C twice to clear + exit, then hard-kill as a safety net. Call in `finally`. */
+	kill(): Promise<number>
+}
+
+/** Spawn kimchi under a real PTY so its interactive TUI boots. Prefer `runBinary` for non-interactive checks — use this only when you need to drive the editor/prompt. */
+export function spawnInteractive(opts: RunInteractiveOptions = {}): InteractiveSession {
+	const { cols = 120, rows = 40, extraEnv = {} } = opts
+	const home = getTempHome()
+	const pty = ptySpawn(BINARY_PATH, [], {
+		name: "xterm-256color",
+		cols,
+		rows,
+		cwd: home,
+		env: {
+			PATH: process.env.PATH ?? "",
+			HOME: home,
+			PI_PACKAGE_DIR: PACKAGE_DIR,
+			TERM: "xterm-256color",
+			KIMCHI_API_KEY: "smoke-test-dummy",
+			...extraEnv,
+		},
+	})
+
+	let buf = ""
+	pty.onData((d) => {
+		buf += d
+	})
+
+	return {
+		pty,
+		output: () => buf,
+		write: (data) => pty.write(data),
+		bracketedPaste: (text) => pty.write(`\x1b[200~${text}\x1b[201~`),
+		waitFor: (predicate, timeoutMs = 10_000) =>
+			new Promise<void>((resolvePromise, rejectPromise) => {
+				if (predicate(buf)) return resolvePromise()
+				const start = Date.now()
+				const interval = setInterval(() => {
+					if (predicate(buf)) {
+						clearInterval(interval)
+						resolvePromise()
+					} else if (Date.now() - start > timeoutMs) {
+						clearInterval(interval)
+						rejectPromise(new Error(`waitFor timed out after ${timeoutMs}ms. Captured output:\n${buf.slice(-2000)}`))
+					}
+				}, 50)
+			}),
+		kill: () =>
+			new Promise<number>((resolvePromise) => {
+				pty.onExit(({ exitCode }) => resolvePromise(exitCode))
+				pty.write("\x03") // Ctrl+C to clear the editor
+				pty.write("\x03") // Ctrl+C again to exit
+				setTimeout(() => pty.kill(), 500)
+			}),
+	}
 }

--- a/tests/smoke/harness.ts
+++ b/tests/smoke/harness.ts
@@ -8,7 +8,7 @@
  */
 
 import { type SpawnSyncReturns, spawnSync } from "node:child_process"
-import { chmodSync, mkdirSync, mkdtempSync, rmSync, statSync } from "node:fs"
+import { chmodSync, mkdirSync, mkdtempSync, readdirSync, rmSync, statSync } from "node:fs"
 import { createRequire } from "node:module"
 import { tmpdir } from "node:os"
 import { dirname, join, resolve } from "node:path"
@@ -100,8 +100,13 @@ function ensurePtySpawnHelperExecutable(): void {
 	// Derive the prebuilds dir from node-pty's own entry point so we track whatever version is installed rather than hardcoding it.
 	const ptyEntry = nodeRequire.resolve("node-pty") // .../node-pty/lib/index.js
 	const prebuildsDir = join(dirname(dirname(ptyEntry)), "prebuilds")
-	// The harness may run on any of these platforms; chmod whichever ones are present and ignore the rest.
-	for (const platform of ["darwin-arm64", "darwin-x64", "linux-x64", "linux-arm64"]) {
+	let entries: string[]
+	try {
+		entries = readdirSync(prebuildsDir)
+	} catch {
+		return // node-pty installed without prebuilds (e.g. built from source) — nothing to chmod.
+	}
+	for (const platform of entries) {
 		const helper = join(prebuildsDir, platform, "spawn-helper")
 		try {
 			const mode = statSync(helper).mode
@@ -109,7 +114,7 @@ function ensurePtySpawnHelperExecutable(): void {
 				chmodSync(helper, mode | 0o755)
 			}
 		} catch {
-			// Helper not present for this platform — ignore.
+			// Platform dir exists but has no spawn-helper — ignore.
 		}
 	}
 }

--- a/tests/smoke/interactive-paste.test.ts
+++ b/tests/smoke/interactive-paste.test.ts
@@ -83,36 +83,51 @@ describe("interactive multi-line paste (LLM-1358)", () => {
 		}
 	})
 
-	// Reproduces the failure mode behind LLM-1358. If the colleague's terminal (or an intermediate layer — tmux, ssh wrapper, a remote-dev terminal) doesn't honor pi-tui's bracketed-paste enable sequence `\x1b[?2004h`, the paste arrives as raw keystrokes. The Editor's `tui.input.submit` keybinding matches bare `\r` (Enter), so the first `\r` submits the first line as a chat message and the remaining lines get typed into a now-empty editor, which in turn submits them one by one. The user sees their paste split across messages with nothing resembling a single multi-line prompt — colloquially, "multi-line paste doesn't work."
-	it(
-		"raw paste without bracketed-paste markers submits after the first newline (failure repro)",
-		{ timeout: 60_000 },
-		async () => {
-			const session = spawnInteractive()
-			try {
-				await waitForPrompt(session)
+	// LLM-1358 fix verification. When the terminal (or tmux/SSH layer) doesn't honor pi-tui's bracketed-paste enable sequence, a multi-line paste arrives as raw `\r`-separated keystrokes, which would normally submit each line as its own message. The paste interceptor in src/paste-interceptor.ts detects such bursts and re-emits them wrapped in ESC[200~...ESC[201~ so pi-tui's existing bracketed-paste pipeline handles them correctly. This test confirms the fallback path produces the same result as the bracketed-paste path.
+	it("paste without bracketed-paste markers is recovered by the interceptor", { timeout: 60_000 }, async () => {
+		const session = spawnInteractive()
+		try {
+			await waitForPrompt(session)
 
-				// Terminals send Enter as `\r`, not `\n`. Replace accordingly so this really simulates "bracketed paste is disabled and the paste came in as keystrokes."
-				session.pty.write(PASTED.replace(/\n/g, "\r"))
+			// Terminals send Enter as `\r`, not `\n`. Writing `\r`-separated content simulates "bracketed paste is disabled and the paste arrived as keystrokes."
+			session.pty.write(PASTED.replace(/\n/g, "\r"))
 
-				// Wait for evidence that a submission occurred. The agent will try to process the first submitted line and either render a spinner ("Working...") or an auth error — both are unambiguous signals that the Editor treated the pasted content as "type this then press Enter" rather than a single paste.
-				await session.waitFor((out) => {
-					const plain = stripAnsi(out)
-					return /Working\.\.\./.test(plain) || /Error:/.test(plain)
-				}, 10_000)
+			await session.waitFor((out) => allFourLinesVisible(stripAnsi(out)), 5_000)
 
-				const plain = stripAnsi(session.output())
-
-				// Primary symptom: the 4 lines do NOT all appear as standalone editor rows — they got split across submitted messages instead. Specifically, the intermediate lines ("two" and "three") don't survive anywhere as distinct editor rows.
-				expect(allFourLinesVisible(plain)).toBe(false)
-				expect(plain).not.toMatch(/(^|\n)\s*two\s+\n/)
-				expect(plain).not.toMatch(/(^|\n)\s*three\s+\n/)
-
-				// Evidence that kimchi treated the paste as "submit the first line as a message" — either the agent is processing, or the dummy API key produced an auth error.
-				expect(plain).toMatch(/Working\.\.\.|Error:/)
-			} finally {
-				await session.kill()
+			const plain = stripAnsi(session.output())
+			for (const re of FOUR_LINE_ROW_REGEXES) {
+				expect(plain).toMatch(re)
 			}
-		},
-	)
+			expect(plain).not.toMatch(/onetwothree/)
+			expect(plain).not.toMatch(/threehow many/)
+		} finally {
+			await session.kill()
+		}
+	})
+
+	// False-positive guard for the paste interceptor. Pressing Enter rapidly (or a keyboard macro firing `\r`s) must NOT be misidentified as a paste. Two risks:
+	//   1) looksLikeRawPaste fires on a single `\r` — impossible by design (length < 4 and cr-count < 2), covered by the unit test.
+	//   2) The kernel / PTY layer coalesces multiple `\r` writes into one large chunk — the heuristic would then see ≥2 `\r`s and wrap. This test verifies small gaps between writes are enough to prevent that coalescing.
+	// Signal: if the interceptor misfires, the ten `\r`s get wrapped as a single paste, normalized to ten `\n`s, and the Editor renders a tall block of empty rows inside the prompt border. We assert the stripped output does not contain that tall empty block.
+	it("individually-typed \\r bytes are not treated as a paste", { timeout: 60_000 }, async () => {
+		const session = spawnInteractive()
+		try {
+			await waitForPrompt(session)
+
+			// Write `\r` ten times with small gaps so each lands as its own stdin chunk (not kernel-coalesced into one large burst the heuristic would misread).
+			for (let i = 0; i < 10; i++) {
+				session.pty.write("\r")
+				await new Promise((r) => setTimeout(r, 30))
+			}
+			// Let the TUI fully render whatever state the writes produced.
+			await new Promise((r) => setTimeout(r, 500))
+
+			const plain = stripAnsi(session.output())
+
+			// A misfire would wrap `\r\r\r\r\r\r\r\r\r\r` into a single bracketed paste and push ten `\n`-separated empty rows into the editor buffer — showing up as a long run of blank rows between the editor border dividers. Six or more consecutive empty/whitespace-only lines is well beyond anything the idle TUI renders.
+			expect(plain).not.toMatch(/(\n\s*){6,}\n/)
+		} finally {
+			await session.kill()
+		}
+	})
 })

--- a/tests/smoke/interactive-paste.test.ts
+++ b/tests/smoke/interactive-paste.test.ts
@@ -1,0 +1,118 @@
+import { describe, expect, it } from "vitest"
+import { type InteractiveSession, spawnInteractive } from "./harness.js"
+
+// Built via String.fromCharCode — biome strips literal control bytes from string literals.
+const ESC = String.fromCharCode(0x1b)
+const BEL = String.fromCharCode(0x07)
+
+const OSC_RE = new RegExp(`${ESC}\\][^${BEL}]*${BEL}`, "g") // hyperlinks, title updates: ESC ] ... BEL
+const CSI_RE = new RegExp(`${ESC}\\[[\\d;?>]*[a-zA-Z]`, "g") // colors, cursor motion, clears: ESC [ ... letter
+const KEYPAD_RE = new RegExp(`${ESC}[=>]`, "g") // keypad mode toggles: ESC =, ESC >
+const CHARSET_RE = new RegExp(`${ESC}\\([AB012]`, "g") // G0 charset select: ESC ( B etc.
+
+// Strip ANSI SGR/CSI/OSC escapes and normalize line endings. The TUI uses bare `\r` to move the cursor to column 0 before overwriting a row, so treat any `\r` (alone or as part of `\r\n`) as a logical row break for matching purposes.
+function stripAnsi(s: string): string {
+	return s
+		.replace(OSC_RE, "")
+		.replace(CSI_RE, "")
+		.replace(KEYPAD_RE, "")
+		.replace(CHARSET_RE, "")
+		.replace(/\r\n?/g, "\n")
+}
+
+// Wait for the interactive prompt to be fully mounted. The hint "ctrl+c/ctrl+d clear/exit" only appears once the TUI's Editor is accepting input. First-time spawns on a cold sandbox HOME download fd/rg (~30s), so the timeout is generous.
+async function waitForPrompt(session: InteractiveSession): Promise<void> {
+	await session.waitFor((out) => out.includes("ctrl+c/ctrl+d"), 45_000)
+	// Banner can render before the Editor binds its input handler.
+	await new Promise((r) => setTimeout(r, 500))
+}
+
+const PASTED = "one\ntwo\nthree\nhow many lines of text do I have?"
+
+const FOUR_LINE_ROW_REGEXES = [
+	/(^|\n).*one\s+\n/,
+	/(^|\n)\s*two\s+\n/,
+	/(^|\n)\s*three\s+\n/,
+	/how many lines of text do I have\?/,
+]
+
+function allFourLinesVisible(plain: string): boolean {
+	return FOUR_LINE_ROW_REGEXES.every((re) => re.test(plain))
+}
+
+describe("interactive multi-line paste (LLM-1358)", () => {
+	it("bracketed paste of 4 lines keeps all 4 lines in the editor buffer", { timeout: 60_000 }, async () => {
+		const session = spawnInteractive()
+		try {
+			await waitForPrompt(session)
+			session.bracketedPaste(PASTED)
+			await session.waitFor((out) => allFourLinesVisible(stripAnsi(out)), 5_000)
+
+			const plain = stripAnsi(session.output())
+			for (const re of FOUR_LINE_ROW_REGEXES) {
+				expect(plain).toMatch(re)
+			}
+			// LLM-1358 regression guard: if the paste handler stripped newlines, every pasted line would collide into a single row with no separators.
+			expect(plain).not.toMatch(/onetwothree/)
+			expect(plain).not.toMatch(/threehow many/)
+		} finally {
+			await session.kill()
+		}
+	})
+
+	it("bracketed paste split across multiple writes still preserves all lines", { timeout: 60_000 }, async () => {
+		const session = spawnInteractive()
+		try {
+			await waitForPrompt(session)
+
+			// Split the paste marker + content across two writes with a delay, exercising StdinBuffer's cross-chunk pasteBuffer accumulation (pi-tui stdin-buffer.js:230-273). If that logic regresses, the end marker won't be found and handlePaste won't fire.
+			const firstHalf = `${ESC}[200~one\ntwo\n`
+			const secondHalf = `three\nhow many lines of text do I have?${ESC}[201~`
+			session.pty.write(firstHalf)
+			await new Promise((r) => setTimeout(r, 80))
+			session.pty.write(secondHalf)
+
+			await session.waitFor((out) => allFourLinesVisible(stripAnsi(out)), 5_000)
+
+			const plain = stripAnsi(session.output())
+			for (const re of FOUR_LINE_ROW_REGEXES) {
+				expect(plain).toMatch(re)
+			}
+		} finally {
+			await session.kill()
+		}
+	})
+
+	// Reproduces the failure mode behind LLM-1358. If the colleague's terminal (or an intermediate layer — tmux, ssh wrapper, a remote-dev terminal) doesn't honor pi-tui's bracketed-paste enable sequence `\x1b[?2004h`, the paste arrives as raw keystrokes. The Editor's `tui.input.submit` keybinding matches bare `\r` (Enter), so the first `\r` submits the first line as a chat message and the remaining lines get typed into a now-empty editor, which in turn submits them one by one. The user sees their paste split across messages with nothing resembling a single multi-line prompt — colloquially, "multi-line paste doesn't work."
+	it(
+		"raw paste without bracketed-paste markers submits after the first newline (failure repro)",
+		{ timeout: 60_000 },
+		async () => {
+			const session = spawnInteractive()
+			try {
+				await waitForPrompt(session)
+
+				// Terminals send Enter as `\r`, not `\n`. Replace accordingly so this really simulates "bracketed paste is disabled and the paste came in as keystrokes."
+				session.pty.write(PASTED.replace(/\n/g, "\r"))
+
+				// Wait for evidence that a submission occurred. The agent will try to process the first submitted line and either render a spinner ("Working...") or an auth error — both are unambiguous signals that the Editor treated the pasted content as "type this then press Enter" rather than a single paste.
+				await session.waitFor((out) => {
+					const plain = stripAnsi(out)
+					return /Working\.\.\./.test(plain) || /Error:/.test(plain)
+				}, 10_000)
+
+				const plain = stripAnsi(session.output())
+
+				// Primary symptom: the 4 lines do NOT all appear as standalone editor rows — they got split across submitted messages instead. Specifically, the intermediate lines ("two" and "three") don't survive anywhere as distinct editor rows.
+				expect(allFourLinesVisible(plain)).toBe(false)
+				expect(plain).not.toMatch(/(^|\n)\s*two\s+\n/)
+				expect(plain).not.toMatch(/(^|\n)\s*three\s+\n/)
+
+				// Evidence that kimchi treated the paste as "submit the first line as a message" — either the agent is processing, or the dummy API key produced an auth error.
+				expect(plain).toMatch(/Working\.\.\.|Error:/)
+			} finally {
+				await session.kill()
+			}
+		},
+	)
+})


### PR DESCRIPTION
## Summary

- Interactive TUI paste used to break when the terminal (or an intermediate tmux/SSH layer) didn't honor pi-tui's `ESC[?2004h` enable sequence: a pasted block arrived as raw `\r`-separated keystrokes, and every `\r` matched the Editor's Enter keybinding, so the first line was submitted as its own message and the remainder got split across further turns.
- Added a stdin-level paste interceptor in `src/entry.ts` — when a single stdin chunk looks like a burst paste (length ≥ 4, two or more `\r`s, no ESC bytes), re-emit it wrapped in `ESC[200~ … ESC[201~` so pi-tui's existing bracketed-paste pipeline handles it unchanged. No pi-tui patch, monkey-patch, or dep override.
- First commit adds PTY-based smoke infrastructure (`node-pty` devDep + `spawnInteractive()` helper in `tests/smoke/harness.ts`) so the interactive TUI code path is actually exercised. The existing `spawnSync` harness can't — piped stdio forces non-interactive "print" mode.

## Context for reviewers

I wasn't able to reproduce the bug on my own machine — bracketed paste works end-to-end in the terminals I have. The behavior only surfaces in environments that strip or don't emit the `ESC[200~`/`ESC[201~` markers. The new smoke test #3 uses `pty.write` without the markers to simulate that environment deterministically, and a revert probe (temporarily disabling the interceptor) confirms the test actually exercises the new code path.