### PR TITLE
NOJIRA: Display resume command with session ID on exit

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -23,9 +23,7 @@ let sessionId: string | undefined
 
 process.on("exit", (code) => {
 	if (code === 0) {
-		const resumeCmd = sessionId
-			? `kimchi-code --session ${sessionId}`
-			: "kimchi-code --continue"
+		const resumeCmd = sessionId ? `kimchi-code --session ${sessionId}` : "kimchi-code --continue"
 		console.log(`\nTo resume: ${resumeCmd}`)
 	}
 })

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -2,6 +2,7 @@
 // All static imports here (extensions, pi-mono) are safe because the env is already configured.
 
 import { resolve } from "node:path"
+import type { ExtensionAPI, ExtensionContext } from "@mariozechner/pi-coding-agent"
 import { loadConfig, readTelemetryConfig } from "./config.js"
 import bashCollapseExtension from "./extensions/bash-collapse.js"
 import loopGuardExtension from "./extensions/loop-guard.js"
@@ -17,6 +18,23 @@ import { updateModelsConfig } from "./models.js"
 import { setAvailableModelIds } from "./startup-context.js"
 
 const telemetryConfig = readTelemetryConfig()
+
+let sessionId: string | undefined
+
+process.on("exit", (code) => {
+	if (code === 0) {
+		const resumeCmd = sessionId
+			? `kimchi-code --session ${sessionId}`
+			: "kimchi-code --continue"
+		console.log(`\nTo resume: ${resumeCmd}`)
+	}
+})
+
+function sessionIdCaptureExtension(pi: ExtensionAPI) {
+	pi.on("session_start", (_event, ctx: ExtensionContext) => {
+		sessionId = ctx.sessionManager.getSessionId()
+	})
+}
 
 try {
 	const config = loadConfig()
@@ -51,6 +69,7 @@ try {
 	const { main } = await import("@mariozechner/pi-coding-agent")
 	await main(process.argv.slice(2), {
 		extensionFactories: [
+			sessionIdCaptureExtension,
 			bashCollapseExtension,
 			loopGuardExtension,
 			mcpAdapterExtension,

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -30,7 +30,11 @@ process.on("exit", (code) => {
 
 function sessionIdCaptureExtension(pi: ExtensionAPI) {
 	pi.on("session_start", (_event, ctx: ExtensionContext) => {
-		sessionId = ctx.sessionManager.getSessionId()
+		try {
+			sessionId = ctx.sessionManager.getSessionId()
+		} catch {
+			// ignore — exit handler falls back to --continue
+		}
 	})
 }
 


### PR DESCRIPTION
## Summary

- Captures the session ID via a new `sessionIdCaptureExtension` that listens to `session_start`
- On clean exit (code 0), prints `kimchi-code --session <id>` so the user can resume directly
- Falls back to `kimchi-code --continue` if the session never started (e.g. config error)

<img width="2002" height="1286" alt="2026-04-22 12 46 54" src="https://github.com/user-attachments/assets/e8a245a5-fc40-4004-a5c7-84f709b04802" />

---
### Kimchi Summary
### What changed
Adds a resume hint on successful CLI exit. When the process exits with code `0`, it now prints a command to resume the session using either the captured session ID or a generic `--continue` flag.

### Why
Improves UX by reminding users how to continue their work after the agent session ends.

### Key changes
- `src/cli.ts`: Imports `ExtensionAPI` and `ExtensionContext` from `@mariozechner/pi-coding-agent`
- `src/cli.ts`: Adds `sessionIdCaptureExtension` to capture `sessionId` via `ctx.sessionManager.getSessionId()` on the `session_start` event
- `src/cli.ts`: Adds a `process.on("exit")` handler that prints a resume command when exiting with code `0`, falling back to `kimchi-code --continue` if no session ID was captured
- `src/cli.ts`: Registers `sessionIdCaptureExtension` in the `extensionFactories` array passed to `main`