### PR TITLE
LLM-1348: CC migration wizard

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
 		"configDir": ".config/kimchi/harness"
 	},
 	"dependencies": {
+		"@clack/prompts": "^1.2.0",
 		"@mariozechner/pi-coding-agent": "^0.67.68",
 		"@mariozechner/pi-tui": "^0.67.68",
 		"@modelcontextprotocol/ext-apps": "^1.2.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,6 +8,9 @@ importers:
 
   .:
     dependencies:
+      '@clack/prompts':
+        specifier: ^1.2.0
+        version: 1.2.0
       '@mariozechner/pi-coding-agent':
         specifier: ^0.67.68
         version: 0.67.68(@modelcontextprotocol/sdk@1.29.0(zod@4.3.6))(ws@8.20.0)(zod@4.3.6)
@@ -270,6 +273,12 @@ packages:
 
   '@borewit/text-codec@0.2.2':
     resolution: {integrity: sha512-DDaRehssg1aNrH4+2hnj1B7vnUGEjU6OIlyRdkMd0aUdIUvKXrJfXsy8LVtXAy7DRvYVluWbMspsRhz2lcW0mQ==}
+
+  '@clack/core@1.2.0':
+    resolution: {integrity: sha512-qfxof/3T3t9DPU/Rj3OmcFyZInceqj/NVtO9rwIuJqCUgh32gwPjpFQQp/ben07qKlhpwq7GzfWpST4qdJ5Drg==}
+
+  '@clack/prompts@1.2.0':
+    resolution: {integrity: sha512-4jmztR9fMqPMjz6H/UZXj0zEmE43ha1euENwkckKKel4XpSfokExPo5AiVStdHSAlHekz4d0CA/r45Ok1E4D3w==}
 
   '@esbuild/aix-ppc64@0.27.7':
     resolution: {integrity: sha512-EKX3Qwmhz1eMdEJokhALr0YiD0lhQNwDqkPYyPhiSwKrh7/4KRjQc04sZ8db+5DVVnZ1LmbNDI1uAMPEUBnQPg==}
@@ -1271,8 +1280,17 @@ packages:
   fast-deep-equal@3.1.3:
     resolution: {integrity: sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==}
 
+  fast-string-truncated-width@1.2.1:
+    resolution: {integrity: sha512-Q9acT/+Uu3GwGj+5w/zsGuQjh9O1TyywhIwAxHudtWrgF09nHOPrvTLhQevPbttcxjr/SNN7mJmfOw/B1bXgow==}
+
+  fast-string-width@1.1.0:
+    resolution: {integrity: sha512-O3fwIVIH5gKB38QNbdg+3760ZmGz0SZMgvwJbA1b2TGXceKE6A2cOlfogh1iw8lr049zPyd7YADHy+B7U4W9bQ==}
+
   fast-uri@3.1.0:
     resolution: {integrity: sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==}
+
+  fast-wrap-ansi@0.1.6:
+    resolution: {integrity: sha512-HlUwET7a5gqjURj70D5jl7aC3Zmy4weA1SHUfM0JFI0Ptq987NH2TwbBFLoERhfwk+E+eaq4EK3jXoT+R3yp3w==}
 
   fast-xml-builder@1.1.4:
     resolution: {integrity: sha512-f2jhpN4Eccy0/Uz9csxh3Nu6q4ErKxf0XIsasomfOihuSUa3/xw6w8dnOtCDgEItQFJG8KyXPzQXzcODDrrbOg==}
@@ -1797,6 +1815,9 @@ packages:
 
   signal-exit@3.0.7:
     resolution: {integrity: sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==}
+
+  sisteransi@1.0.5:
+    resolution: {integrity: sha512-bLGGlR1QxBcynn2d5YmDX4MGjlZvy2MRBDRNHLJ8VI6l6+9FUiyTFNJ0IveOSP0bcXgVDPRcfGqA0pjaqUpfVg==}
 
   smart-buffer@4.2.0:
     resolution: {integrity: sha512-94hK0Hh8rPqQl2xXc3HsaBoOXKV20MToPkcXvwbISWLEs+64sBq5kFgn2kJDHb1Pry9yrP0dxrCI9RRci7RXKg==}
@@ -2506,6 +2527,18 @@ snapshots:
     optional: true
 
   '@borewit/text-codec@0.2.2': {}
+
+  '@clack/core@1.2.0':
+    dependencies:
+      fast-wrap-ansi: 0.1.6
+      sisteransi: 1.0.5
+
+  '@clack/prompts@1.2.0':
+    dependencies:
+      '@clack/core': 1.2.0
+      fast-string-width: 1.1.0
+      fast-wrap-ansi: 0.1.6
+      sisteransi: 1.0.5
 
   '@esbuild/aix-ppc64@0.27.7':
     optional: true
@@ -3563,7 +3596,17 @@ snapshots:
 
   fast-deep-equal@3.1.3: {}
 
+  fast-string-truncated-width@1.2.1: {}
+
+  fast-string-width@1.1.0:
+    dependencies:
+      fast-string-truncated-width: 1.2.1
+
   fast-uri@3.1.0: {}
+
+  fast-wrap-ansi@0.1.6:
+    dependencies:
+      fast-string-width: 1.1.0
 
   fast-xml-builder@1.1.4:
     dependencies:
@@ -4136,6 +4179,8 @@ snapshots:
   siginfo@2.0.0: {}
 
   signal-exit@3.0.7: {}
+
+  sisteransi@1.0.5: {}
 
   smart-buffer@4.2.0: {}
 

--- a/src/cc-discovery.ts
+++ b/src/cc-discovery.ts
@@ -52,16 +52,18 @@ export function discoverCcConfig(): CcDiscovery {
 				}
 			}
 		}
-	} catch {
-		// file missing or unreadable
+	} catch (err) {
+		if ((err as NodeJS.ErrnoException).code !== "ENOENT") {
+			console.warn(`Failed to read Claude Code config: ${err instanceof Error ? err.message : String(err)}`)
+		}
 	}
 
 	let skillCount = 0
 	if (existsSync(CC_SKILLS_DIR)) {
 		try {
 			skillCount = readdirSync(CC_SKILLS_DIR, { withFileTypes: true }).filter((e) => e.isDirectory()).length
-		} catch {
-			// unreadable
+		} catch (err) {
+			console.warn(`Failed to read Claude Code skills directory: ${err instanceof Error ? err.message : String(err)}`)
 		}
 	}
 

--- a/src/cc-discovery.ts
+++ b/src/cc-discovery.ts
@@ -1,0 +1,69 @@
+import { existsSync, readFileSync, readdirSync } from "node:fs"
+import { homedir } from "node:os"
+import { join } from "node:path"
+import type { ServerEntry } from "./extensions/mcp-adapter/types.js"
+
+const CC_CONFIG_PATH = join(homedir(), ".claude.json")
+const CC_SKILLS_DIR = join(homedir(), ".claude", "skills")
+
+export interface CcDiscovery {
+	mcpServers: Record<string, ServerEntry>
+	skillCount: number
+}
+
+interface CcMcpServerRaw {
+	type?: string
+	command?: string
+	args?: string[]
+	env?: Record<string, string>
+	cwd?: string
+	url?: string
+	header?: Record<string, string>
+	headers?: Record<string, string>
+	[key: string]: unknown
+}
+
+function transformServer(raw: CcMcpServerRaw): ServerEntry {
+	const entry: ServerEntry = {}
+	if (raw.command !== undefined) entry.command = raw.command
+	if (raw.args !== undefined) entry.args = raw.args
+	if (raw.env !== undefined) entry.env = raw.env
+	if (raw.cwd !== undefined) entry.cwd = raw.cwd
+	if (raw.url !== undefined) entry.url = raw.url
+	const headers = raw.headers ?? raw.header
+	if (headers !== undefined) entry.headers = headers
+	return entry
+}
+
+export function discoverCcConfig(): CcDiscovery {
+	const mcpServers: Record<string, ServerEntry> = {}
+
+	try {
+		const raw = JSON.parse(readFileSync(CC_CONFIG_PATH, "utf-8"))
+		const projects = raw?.projects
+		if (projects && typeof projects === "object") {
+			for (const project of Object.values(projects)) {
+				const servers = (project as Record<string, unknown>)?.mcpServers
+				if (!servers || typeof servers !== "object") continue
+				for (const [name, def] of Object.entries(servers as Record<string, CcMcpServerRaw>)) {
+					if (!mcpServers[name]) {
+						mcpServers[name] = transformServer(def)
+					}
+				}
+			}
+		}
+	} catch {
+		// file missing or unreadable
+	}
+
+	let skillCount = 0
+	if (existsSync(CC_SKILLS_DIR)) {
+		try {
+			skillCount = readdirSync(CC_SKILLS_DIR, { withFileTypes: true }).filter((e) => e.isDirectory()).length
+		} catch {
+			// unreadable
+		}
+	}
+
+	return { mcpServers, skillCount }
+}

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -3,7 +3,7 @@
 
 import { resolve } from "node:path"
 import type { ExtensionAPI, ExtensionContext } from "@mariozechner/pi-coding-agent"
-import { loadConfig, readTelemetryConfig, writeSkillPaths } from "./config.js"
+import { loadConfig, readTelemetryConfig, writeMigrationState, writeSkillPaths } from "./config.js"
 import bashCollapseExtension from "./extensions/bash-collapse.js"
 import loopGuardExtension from "./extensions/loop-guard.js"
 import mcpAdapterExtension from "./extensions/mcp-adapter/index.js"
@@ -15,7 +15,7 @@ import telemetryExtension from "./extensions/telemetry.js"
 import webFetchExtension from "./extensions/web-fetch/index.js"
 import webSearchExtension from "./extensions/web-search/index.js"
 import { updateModelsConfig } from "./models.js"
-import { runSkillsWizard } from "./skills-wizard.js"
+import { runSetupWizard } from "./setup-wizard.js"
 import { setAvailableModelIds } from "./startup-context.js"
 
 const telemetryConfig = readTelemetryConfig()
@@ -42,10 +42,19 @@ function sessionIdCaptureExtension(pi: ExtensionAPI) {
 try {
 	const config = loadConfig()
 
-	let skillPaths = config.skillPaths
-	if (skillPaths === undefined) {
-		skillPaths = await runSkillsWizard()
-		writeSkillPaths(skillPaths)
+	const needsSkillsSetup = config.skillPaths === undefined
+	const needsMigrationCheck = config.migrationState === undefined
+	let skillPaths = config.skillPaths ?? []
+
+	if (needsSkillsSetup || needsMigrationCheck) {
+		const result = await runSetupWizard({ needsSkillsSetup, needsMigrationCheck })
+		if (needsSkillsSetup) {
+			skillPaths = result.skillPaths
+			writeSkillPaths(skillPaths)
+		}
+		if (result.migrationState !== undefined) {
+			writeMigrationState(result.migrationState)
+		}
 	}
 
 	// Expose the API key as an env var so pi-mono's models.json can resolve it

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -3,7 +3,7 @@
 
 import { resolve } from "node:path"
 import type { ExtensionAPI, ExtensionContext } from "@mariozechner/pi-coding-agent"
-import { loadConfig, readTelemetryConfig } from "./config.js"
+import { loadConfig, readTelemetryConfig, writeSkillPaths } from "./config.js"
 import bashCollapseExtension from "./extensions/bash-collapse.js"
 import loopGuardExtension from "./extensions/loop-guard.js"
 import mcpAdapterExtension from "./extensions/mcp-adapter/index.js"
@@ -15,6 +15,7 @@ import telemetryExtension from "./extensions/telemetry.js"
 import webFetchExtension from "./extensions/web-fetch/index.js"
 import webSearchExtension from "./extensions/web-search/index.js"
 import { updateModelsConfig } from "./models.js"
+import { runSkillsWizard } from "./skills-wizard.js"
 import { setAvailableModelIds } from "./startup-context.js"
 
 const telemetryConfig = readTelemetryConfig()
@@ -40,6 +41,12 @@ function sessionIdCaptureExtension(pi: ExtensionAPI) {
 
 try {
 	const config = loadConfig()
+
+	let skillPaths = config.skillPaths
+	if (skillPaths === undefined) {
+		skillPaths = await runSkillsWizard()
+		writeSkillPaths(skillPaths)
+	}
 
 	// Expose the API key as an env var so pi-mono's models.json can resolve it
 	// via the "KIMCHI_API_KEY" apiKey field in the Cast AI provider config.
@@ -75,7 +82,7 @@ try {
 			bashCollapseExtension,
 			loopGuardExtension,
 			mcpAdapterExtension,
-			promptEnrichmentExtension,
+			promptEnrichmentExtension(skillPaths),
 			promptSummaryExtension,
 			subagentExtension,
 			tagsExtension,

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -3,7 +3,7 @@
 
 import { resolve } from "node:path"
 import type { ExtensionAPI, ExtensionContext } from "@mariozechner/pi-coding-agent"
-import { loadConfig, readTelemetryConfig, writeMigrationState, writeSkillPaths } from "./config.js"
+import { DEFAULT_SKILL_PATHS, loadConfig, readTelemetryConfig, writeMigrationState, writeSkillPaths } from "./config.js"
 import bashCollapseExtension from "./extensions/bash-collapse.js"
 import loopGuardExtension from "./extensions/loop-guard.js"
 import mcpAdapterExtension from "./extensions/mcp-adapter/index.js"
@@ -47,13 +47,21 @@ try {
 	let skillPaths = config.skillPaths ?? []
 
 	if (needsSkillsSetup || needsMigrationCheck) {
-		const result = await runSetupWizard({ needsSkillsSetup, needsMigrationCheck })
-		if (needsSkillsSetup) {
-			skillPaths = result.skillPaths
-			writeSkillPaths(skillPaths)
-		}
-		if (result.migrationState !== undefined) {
-			writeMigrationState(result.migrationState)
+		if (!process.stdin.isTTY) {
+			if (needsSkillsSetup) {
+				skillPaths = DEFAULT_SKILL_PATHS
+				writeSkillPaths(skillPaths)
+			}
+			writeMigrationState("done")
+		} else {
+			const result = await runSetupWizard({ needsSkillsSetup, needsMigrationCheck })
+			if (needsSkillsSetup) {
+				skillPaths = result.skillPaths
+				writeSkillPaths(skillPaths)
+			}
+			if (result.migrationState !== undefined) {
+				writeMigrationState(result.migrationState)
+			}
 		}
 	}
 

--- a/src/config.ts
+++ b/src/config.ts
@@ -33,6 +33,8 @@ export const SEARCH_STRATEGY_DEFAULTS: SearchStrategyConfig = {
 	fieldWeights: { name: 6, description: 2, schemaKey: 1 },
 }
 
+export type MigrationState = "done" | "skip-forever"
+
 export interface KimchiConfig {
 	apiKey: string
 	agentConfigDir: string
@@ -41,6 +43,7 @@ export interface KimchiConfig {
 	mcpSearchLimit: number
 	mcpSearch: SearchStrategyConfig
 	skillPaths?: string[]
+	migrationState?: MigrationState
 }
 
 /**
@@ -65,6 +68,7 @@ function readConfigExtras(configPath: string): {
 	mcpSearchLimit?: number
 	mcpSearch?: Partial<SearchStrategyConfig>
 	skillPaths?: string[]
+	migrationState?: MigrationState
 } {
 	try {
 		const raw = readFileSync(configPath, "utf-8")
@@ -106,7 +110,11 @@ function readConfigExtras(configPath: string): {
 			Array.isArray(parsed.skillPaths) && parsed.skillPaths.every((p: unknown) => typeof p === "string")
 				? (parsed.skillPaths as string[])
 				: undefined
-		return { maxToolResultChars, mcpSearchLimit, mcpSearch, skillPaths }
+		const migrationState =
+			parsed.migrationState === "done" || parsed.migrationState === "skip-forever"
+				? (parsed.migrationState as MigrationState)
+				: undefined
+		return { maxToolResultChars, mcpSearchLimit, mcpSearch, skillPaths, migrationState }
 	} catch {
 		return {}
 	}
@@ -190,6 +198,7 @@ export function loadConfig(options?: { configPath?: string; env?: Record<string,
 	const mcpSearch: SearchStrategyConfig = { ...SEARCH_STRATEGY_DEFAULTS, ...extras.mcpSearch }
 
 	const skillPaths = extras.skillPaths
+	const migrationState = extras.migrationState
 
 	const envKey = env.KIMCHI_API_KEY
 	if (typeof envKey === "string" && envKey.length > 0) {
@@ -201,6 +210,7 @@ export function loadConfig(options?: { configPath?: string; env?: Record<string,
 			mcpSearchLimit,
 			mcpSearch,
 			skillPaths,
+			migrationState,
 		}
 	}
 
@@ -214,6 +224,7 @@ export function loadConfig(options?: { configPath?: string; env?: Record<string,
 			mcpSearchLimit,
 			mcpSearch,
 			skillPaths,
+			migrationState,
 		}
 	}
 
@@ -224,6 +235,18 @@ export function loadConfig(options?: { configPath?: string; env?: Record<string,
 
 export function getAgentConfigDir(): string {
 	return AGENT_CONFIG_DIR
+}
+
+export function writeMigrationState(state: MigrationState, configPath?: string): void {
+	const resolvedPath = configPath ?? KIMCHI_CONFIG_PATH
+	let raw: Record<string, unknown> = {}
+	try {
+		raw = JSON.parse(readFileSync(resolvedPath, "utf-8")) as Record<string, unknown>
+	} catch {
+		// file missing or invalid — start fresh
+	}
+	raw.migrationState = state
+	writeFileSync(resolvedPath, `${JSON.stringify(raw, null, 2)}\n`, "utf-8")
 }
 
 export function writeSkillPaths(paths: string[], configPath?: string): void {

--- a/src/config.ts
+++ b/src/config.ts
@@ -8,8 +8,8 @@ const CAST_AI_LLM_ENDPOINT = "https://llm.cast.ai/openai/v1"
 const DEFAULT_TELEMETRY_ENDPOINT = "https://api.cast.ai/ai-optimizer/v1beta/logs:ingest"
 
 export const DEFAULT_SKILL_PATHS = [
-	join(".pi", "agent", "skills"),
 	join(".config", "kimchi", "harness", "skills"),
+	join(".pi", "agent", "skills"),
 	join(".claude", "skills"),
 ]
 

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,11 +1,17 @@
-import { readFileSync } from "node:fs"
+import { readFileSync, writeFileSync } from "node:fs"
 import { homedir } from "node:os"
-import { resolve } from "node:path"
+import { join, resolve } from "node:path"
 
 const KIMCHI_CONFIG_PATH = resolve(homedir(), ".config", "kimchi", "config.json")
 const AGENT_CONFIG_DIR = resolve(homedir(), ".config", "kimchi", "harness")
 const CAST_AI_LLM_ENDPOINT = "https://llm.cast.ai/openai/v1"
 const DEFAULT_TELEMETRY_ENDPOINT = "https://api.cast.ai/ai-optimizer/v1beta/logs:ingest"
+
+export const DEFAULT_SKILL_PATHS = [
+	join(homedir(), ".pi", "agent", "skills"),
+	join(homedir(), ".config", "kimchi", "harness", "skills"),
+	join(homedir(), ".claude", "skills"),
+]
 
 export interface TelemetryConfig {
 	enabled: boolean
@@ -34,6 +40,7 @@ export interface KimchiConfig {
 	maxToolResultChars: number
 	mcpSearchLimit: number
 	mcpSearch: SearchStrategyConfig
+	skillPaths?: string[]
 }
 
 /**
@@ -57,6 +64,7 @@ function readConfigExtras(configPath: string): {
 	maxToolResultChars?: number
 	mcpSearchLimit?: number
 	mcpSearch?: Partial<SearchStrategyConfig>
+	skillPaths?: string[]
 } {
 	try {
 		const raw = readFileSync(configPath, "utf-8")
@@ -94,7 +102,11 @@ function readConfigExtras(configPath: string): {
 					: {}),
 			}
 		}
-		return { maxToolResultChars, mcpSearchLimit, mcpSearch }
+		const skillPaths =
+			Array.isArray(parsed.skillPaths) && parsed.skillPaths.every((p: unknown) => typeof p === "string")
+				? (parsed.skillPaths as string[])
+				: undefined
+		return { maxToolResultChars, mcpSearchLimit, mcpSearch, skillPaths }
 	} catch {
 		return {}
 	}
@@ -177,6 +189,8 @@ export function loadConfig(options?: { configPath?: string; env?: Record<string,
 	const mcpSearchLimit = extras.mcpSearchLimit ?? 5
 	const mcpSearch: SearchStrategyConfig = { ...SEARCH_STRATEGY_DEFAULTS, ...extras.mcpSearch }
 
+	const skillPaths = extras.skillPaths
+
 	const envKey = env.KIMCHI_API_KEY
 	if (typeof envKey === "string" && envKey.length > 0) {
 		return {
@@ -186,6 +200,7 @@ export function loadConfig(options?: { configPath?: string; env?: Record<string,
 			maxToolResultChars,
 			mcpSearchLimit,
 			mcpSearch,
+			skillPaths,
 		}
 	}
 
@@ -198,6 +213,7 @@ export function loadConfig(options?: { configPath?: string; env?: Record<string,
 			maxToolResultChars,
 			mcpSearchLimit,
 			mcpSearch,
+			skillPaths,
 		}
 	}
 
@@ -208,4 +224,16 @@ export function loadConfig(options?: { configPath?: string; env?: Record<string,
 
 export function getAgentConfigDir(): string {
 	return AGENT_CONFIG_DIR
+}
+
+export function writeSkillPaths(paths: string[], configPath?: string): void {
+	const resolvedPath = configPath ?? KIMCHI_CONFIG_PATH
+	let raw: Record<string, unknown> = {}
+	try {
+		raw = JSON.parse(readFileSync(resolvedPath, "utf-8")) as Record<string, unknown>
+	} catch {
+		// file missing or invalid — start fresh
+	}
+	raw.skillPaths = paths
+	writeFileSync(resolvedPath, `${JSON.stringify(raw, null, 2)}\n`, "utf-8")
 }

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,6 +1,6 @@
-import { readFileSync, writeFileSync } from "node:fs"
+import { mkdirSync, readFileSync, renameSync, writeFileSync } from "node:fs"
 import { homedir } from "node:os"
-import { join, resolve } from "node:path"
+import { dirname, join, resolve } from "node:path"
 
 const KIMCHI_CONFIG_PATH = resolve(homedir(), ".config", "kimchi", "config.json")
 const AGENT_CONFIG_DIR = resolve(homedir(), ".config", "kimchi", "harness")
@@ -237,26 +237,24 @@ export function getAgentConfigDir(): string {
 	return AGENT_CONFIG_DIR
 }
 
-export function writeMigrationState(state: MigrationState, configPath?: string): void {
-	const resolvedPath = configPath ?? KIMCHI_CONFIG_PATH
+function writeConfigField(key: string, value: unknown, configPath: string): void {
 	let raw: Record<string, unknown> = {}
 	try {
-		raw = JSON.parse(readFileSync(resolvedPath, "utf-8")) as Record<string, unknown>
+		raw = JSON.parse(readFileSync(configPath, "utf-8")) as Record<string, unknown>
 	} catch {
 		// file missing or invalid — start fresh
 	}
-	raw.migrationState = state
-	writeFileSync(resolvedPath, `${JSON.stringify(raw, null, 2)}\n`, "utf-8")
+	raw[key] = value
+	mkdirSync(dirname(configPath), { recursive: true })
+	const tmp = `${configPath}.${process.pid}.tmp`
+	writeFileSync(tmp, `${JSON.stringify(raw, null, 2)}\n`, "utf-8")
+	renameSync(tmp, configPath)
+}
+
+export function writeMigrationState(state: MigrationState, configPath?: string): void {
+	writeConfigField("migrationState", state, configPath ?? KIMCHI_CONFIG_PATH)
 }
 
 export function writeSkillPaths(paths: string[], configPath?: string): void {
-	const resolvedPath = configPath ?? KIMCHI_CONFIG_PATH
-	let raw: Record<string, unknown> = {}
-	try {
-		raw = JSON.parse(readFileSync(resolvedPath, "utf-8")) as Record<string, unknown>
-	} catch {
-		// file missing or invalid — start fresh
-	}
-	raw.skillPaths = paths
-	writeFileSync(resolvedPath, `${JSON.stringify(raw, null, 2)}\n`, "utf-8")
+	writeConfigField("skillPaths", paths, configPath ?? KIMCHI_CONFIG_PATH)
 }

--- a/src/config.ts
+++ b/src/config.ts
@@ -8,9 +8,9 @@ const CAST_AI_LLM_ENDPOINT = "https://llm.cast.ai/openai/v1"
 const DEFAULT_TELEMETRY_ENDPOINT = "https://api.cast.ai/ai-optimizer/v1beta/logs:ingest"
 
 export const DEFAULT_SKILL_PATHS = [
-	join(homedir(), ".pi", "agent", "skills"),
-	join(homedir(), ".config", "kimchi", "harness", "skills"),
-	join(homedir(), ".claude", "skills"),
+	join(".pi", "agent", "skills"),
+	join(".config", "kimchi", "harness", "skills"),
+	join(".claude", "skills"),
 ]
 
 export interface TelemetryConfig {

--- a/src/extensions/orchestration/prompt-enrichment.ts
+++ b/src/extensions/orchestration/prompt-enrichment.ts
@@ -22,6 +22,8 @@
 
 import type { ImageContent, TextContent } from "@mariozechner/pi-ai"
 import { type ExtensionAPI, type Skill, loadSkills } from "@mariozechner/pi-coding-agent"
+import { homedir } from "os"
+import { join } from "path"
 import { ANSI, fg } from "../../ansi.js"
 import { getAvailableModelIds } from "../../startup-context.js"
 import { ModelRegistry } from "./model-registry/index.js"
@@ -97,7 +99,17 @@ export default function (pi: ExtensionAPI) {
 	pi.on("before_agent_start", async (_event, ctx) => {
 		const tools = pi.getAllTools()
 		cachedContextFiles ??= loadProjectContextFiles(ctx.cwd)
-		cachedSkills ??= loadSkills({ cwd: ctx.cwd }).skills
+		cachedSkills ??= loadSkills({
+			cwd: ctx.cwd,
+			skillPaths: [
+				join(homedir(), ".pi", "agent", "skills"),
+				join(ctx.cwd, ".pi", "agent", "skills"),
+				join(homedir(), ".config", "kimchi", "harness", "skills"),
+				join(ctx.cwd, ".config", "kimchi", "harness", "skills"),
+				join(homedir(), ".claude", "skills"),
+				join(ctx.cwd, ".claude", "skills"),
+			],
+		}).skills
 
 		if (subagentMode) {
 			// Filter the subagent tool out of the active tool set to prevent

--- a/src/extensions/orchestration/prompt-enrichment.ts
+++ b/src/extensions/orchestration/prompt-enrichment.ts
@@ -21,7 +21,7 @@
  */
 
 import { homedir } from "node:os"
-import { isAbsolute, join } from "node:path"
+import { isAbsolute, join, normalize, resolve } from "node:path"
 import type { ImageContent, TextContent } from "@mariozechner/pi-ai"
 import { type ExtensionAPI, type Skill, loadSkills } from "@mariozechner/pi-coding-agent"
 import { ANSI, fg } from "../../ansi.js"
@@ -39,11 +39,15 @@ function expandSkillPaths(configuredPaths: string[], cwd: string): string[] {
 	const home = homedir()
 	const expanded: string[] = []
 	for (const p of configuredPaths) {
-		if (isAbsolute(p) || p.startsWith("~/")) {
-			expanded.push(p.startsWith("~/") ? join(home, p.slice(2)) : p)
+		if (isAbsolute(p)) {
+			expanded.push(normalize(p))
+		} else if (p.startsWith("~/")) {
+			expanded.push(resolve(home, p.slice(2)))
 		} else {
-			expanded.push(join(home, p))
-			expanded.push(join(cwd, p))
+			const fromHome = resolve(home, p)
+			const fromCwd = resolve(cwd, p)
+			if (fromHome.startsWith(`${home}/`) || fromHome === home) expanded.push(fromHome)
+			if (fromCwd.startsWith(`${cwd}/`) || fromCwd === cwd) expanded.push(fromCwd)
 		}
 	}
 	return expanded

--- a/src/extensions/orchestration/prompt-enrichment.ts
+++ b/src/extensions/orchestration/prompt-enrichment.ts
@@ -21,7 +21,7 @@
  */
 
 import { homedir } from "node:os"
-import { join } from "node:path"
+import { isAbsolute, join, relative } from "node:path"
 import type { ImageContent, TextContent } from "@mariozechner/pi-ai"
 import { type ExtensionAPI, type Skill, loadSkills } from "@mariozechner/pi-coding-agent"
 import { ANSI, fg } from "../../ansi.js"
@@ -35,93 +35,101 @@ import {
 	transformPrompt,
 } from "./prompt-transformer/prompt-transformer.js"
 
-export default function (pi: ExtensionAPI) {
-	const subagentMode = isSubagent()
+function expandSkillPaths(configuredPaths: string[], cwd: string): string[] {
+	const home = homedir()
+	const expanded: string[] = []
+	for (const p of configuredPaths) {
+		const resolved = p.startsWith("~/") ? join(home, p.slice(2)) : p
+		expanded.push(resolved)
+		if (isAbsolute(resolved) && resolved.startsWith(`${home}/`)) {
+			expanded.push(join(cwd, relative(home, resolved)))
+		}
+	}
+	return expanded
+}
 
-	pi.registerFlag("debug-prompts", {
-		type: "boolean",
-		description: "Print enriched prompts in the UI (default: hidden)",
-		default: false,
-	})
+export default function (skillPaths: string[]) {
+	return (pi: ExtensionAPI) => {
+		const subagentMode = isSubagent()
 
-	// For sub agents we don't want to transform the prompt sent from parent with model capabilities
-	if (!subagentMode) {
-		const registry = new ModelRegistry(getAvailableModelIds())
+		pi.registerFlag("debug-prompts", {
+			type: "boolean",
+			description: "Print enriched prompts in the UI (default: hidden)",
+			default: false,
+		})
 
-		// Announce newly available API models that have no capability entry yet.
-		for (const warning of registry.warnings) {
-			console.log(
-				`${fg(ANSI.accent, ` New model available: "kimchi-dev/${warning.modelId}"`)}\n${fg(ANSI.dim, " Update the app or add the new model to model capabilities config to unlock orchestration support.")}`,
-			)
+		// For sub agents we don't want to transform the prompt sent from parent with model capabilities
+		if (!subagentMode) {
+			const registry = new ModelRegistry(getAvailableModelIds())
+
+			// Announce newly available API models that have no capability entry yet.
+			for (const warning of registry.warnings) {
+				console.log(
+					`${fg(ANSI.accent, ` New model available: "kimchi-dev/${warning.modelId}"`)}\n${fg(ANSI.dim, " Update the app or add the new model to model capabilities config to unlock orchestration support.")}`,
+				)
+			}
+
+			pi.on("input", async (event, ctx) => {
+				if (event.source === "extension") {
+					return { action: "continue" as const }
+				}
+
+				// Steering and follow-up messages arrive while the agent is streaming
+				// (ctx.isIdle() === false, i.e. session.isStreaming === true).
+				// Skip enrichment and let them pass through unchanged
+				if (!ctx.isIdle()) {
+					return { action: "continue" as const }
+				}
+
+				const currentModel = ctx.model ? { id: ctx.model.id, name: ctx.model.id } : undefined
+				const enrichedPrompt = transformPrompt(event.text, registry, currentModel)
+
+				// Non-interactive (--print/--mode rpc) and debug-prompts mode: replace the user
+				// text inline. The "handled" + sendUserMessage path below relies on the TUI event
+				// loop staying alive long enough for the queued message to drain — in --print mode
+				// the loop returns as soon as session.prompt resolves and disposeRuntime cancels
+				// the in-flight LLM call, so nothing is ever sent. Transforming inline lets the
+				// caller's await session.prompt(enrichedPrompt) do the work synchronously.
+				const debugPrompts = pi.getFlag("debug-prompts") === true
+				if (debugPrompts || !ctx.hasUI) {
+					return { action: "transform" as const, text: enrichedPrompt, images: event.images }
+				}
+
+				pi.sendMessage(
+					{ customType: "enriched-prompt", content: [{ type: "text", text: enrichedPrompt }], display: false },
+					{ deliverAs: "nextTurn" },
+				)
+				const userContent: (TextContent | ImageContent)[] = [{ type: "text", text: event.text }]
+				if (event.images) userContent.push(...event.images)
+				pi.sendUserMessage(userContent)
+
+				return { action: "handled" as const }
+			})
 		}
 
-		pi.on("input", async (event, ctx) => {
-			if (event.source === "extension") {
-				return { action: "continue" as const }
+		let cachedContextFiles: ContextFile[] | undefined
+		let cachedSkills: Skill[] | undefined
+
+		pi.on("before_agent_start", async (_event, ctx) => {
+			const tools = pi.getAllTools()
+			cachedContextFiles ??= loadProjectContextFiles(ctx.cwd)
+			cachedSkills ??= loadSkills({
+				cwd: ctx.cwd,
+				skillPaths: expandSkillPaths(skillPaths, ctx.cwd),
+			}).skills
+
+			if (subagentMode) {
+				// Filter the subagent tool out of the active tool set to prevent
+				// the subagent from spawning further subagents.
+				const activeTools = pi.getActiveTools().filter((name) => name !== "subagent")
+				pi.setActiveTools(activeTools)
+
+				const systemPrompt = buildSubagentSystemPrompt(tools, cachedContextFiles, cachedSkills)
+				return { systemPrompt }
 			}
 
-			// Steering and follow-up messages arrive while the agent is streaming
-			// (ctx.isIdle() === false, i.e. session.isStreaming === true).
-			// Skip enrichment and let them pass through unchanged
-			if (!ctx.isIdle()) {
-				return { action: "continue" as const }
-			}
-
-			const currentModel = ctx.model ? { id: ctx.model.id, name: ctx.model.id } : undefined
-			const enrichedPrompt = transformPrompt(event.text, registry, currentModel)
-
-			// Non-interactive (--print/--mode rpc) and debug-prompts mode: replace the user
-			// text inline. The "handled" + sendUserMessage path below relies on the TUI event
-			// loop staying alive long enough for the queued message to drain — in --print mode
-			// the loop returns as soon as session.prompt resolves and disposeRuntime cancels
-			// the in-flight LLM call, so nothing is ever sent. Transforming inline lets the
-			// caller's await session.prompt(enrichedPrompt) do the work synchronously.
-			const debugPrompts = pi.getFlag("debug-prompts") === true
-			if (debugPrompts || !ctx.hasUI) {
-				return { action: "transform" as const, text: enrichedPrompt, images: event.images }
-			}
-
-			pi.sendMessage(
-				{ customType: "enriched-prompt", content: [{ type: "text", text: enrichedPrompt }], display: false },
-				{ deliverAs: "nextTurn" },
-			)
-			const userContent: (TextContent | ImageContent)[] = [{ type: "text", text: event.text }]
-			if (event.images) userContent.push(...event.images)
-			pi.sendUserMessage(userContent)
-
-			return { action: "handled" as const }
+			const systemPrompt = buildOrchestratorSystemPrompt(tools, cachedContextFiles, cachedSkills)
+			return { systemPrompt }
 		})
 	}
-
-	let cachedContextFiles: ContextFile[] | undefined
-	let cachedSkills: Skill[] | undefined
-
-	pi.on("before_agent_start", async (_event, ctx) => {
-		const tools = pi.getAllTools()
-		cachedContextFiles ??= loadProjectContextFiles(ctx.cwd)
-		cachedSkills ??= loadSkills({
-			cwd: ctx.cwd,
-			skillPaths: [
-				join(homedir(), ".pi", "agent", "skills"),
-				join(ctx.cwd, ".pi", "agent", "skills"),
-				join(homedir(), ".config", "kimchi", "harness", "skills"),
-				join(ctx.cwd, ".config", "kimchi", "harness", "skills"),
-				join(homedir(), ".claude", "skills"),
-				join(ctx.cwd, ".claude", "skills"),
-			],
-		}).skills
-
-		if (subagentMode) {
-			// Filter the subagent tool out of the active tool set to prevent
-			// the subagent from spawning further subagents.
-			const activeTools = pi.getActiveTools().filter((name) => name !== "subagent")
-			pi.setActiveTools(activeTools)
-
-			const systemPrompt = buildSubagentSystemPrompt(tools, cachedContextFiles, cachedSkills)
-			return { systemPrompt }
-		}
-
-		const systemPrompt = buildOrchestratorSystemPrompt(tools, cachedContextFiles, cachedSkills)
-		return { systemPrompt }
-	})
 }

--- a/src/extensions/orchestration/prompt-enrichment.ts
+++ b/src/extensions/orchestration/prompt-enrichment.ts
@@ -20,10 +20,10 @@
  * returns "continue" so the message passes through unchanged.
  */
 
+import { homedir } from "node:os"
+import { join } from "node:path"
 import type { ImageContent, TextContent } from "@mariozechner/pi-ai"
 import { type ExtensionAPI, type Skill, loadSkills } from "@mariozechner/pi-coding-agent"
-import { homedir } from "os"
-import { join } from "path"
 import { ANSI, fg } from "../../ansi.js"
 import { getAvailableModelIds } from "../../startup-context.js"
 import { ModelRegistry } from "./model-registry/index.js"

--- a/src/extensions/orchestration/prompt-enrichment.ts
+++ b/src/extensions/orchestration/prompt-enrichment.ts
@@ -21,7 +21,7 @@
  */
 
 import { homedir } from "node:os"
-import { isAbsolute, join, relative } from "node:path"
+import { isAbsolute, join } from "node:path"
 import type { ImageContent, TextContent } from "@mariozechner/pi-ai"
 import { type ExtensionAPI, type Skill, loadSkills } from "@mariozechner/pi-coding-agent"
 import { ANSI, fg } from "../../ansi.js"
@@ -39,10 +39,11 @@ function expandSkillPaths(configuredPaths: string[], cwd: string): string[] {
 	const home = homedir()
 	const expanded: string[] = []
 	for (const p of configuredPaths) {
-		const resolved = p.startsWith("~/") ? join(home, p.slice(2)) : p
-		expanded.push(resolved)
-		if (isAbsolute(resolved) && resolved.startsWith(`${home}/`)) {
-			expanded.push(join(cwd, relative(home, resolved)))
+		if (isAbsolute(p) || p.startsWith("~/")) {
+			expanded.push(p.startsWith("~/") ? join(home, p.slice(2)) : p)
+		} else {
+			expanded.push(join(home, p))
+			expanded.push(join(cwd, p))
 		}
 	}
 	return expanded

--- a/src/setup-wizard.ts
+++ b/src/setup-wizard.ts
@@ -1,4 +1,4 @@
-import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs"
+import { existsSync, mkdirSync, readFileSync, renameSync, writeFileSync } from "node:fs"
 import { homedir } from "node:os"
 import { dirname, join } from "node:path"
 import * as clack from "@clack/prompts"
@@ -43,7 +43,8 @@ async function runMigrationPhase(
 		return "skip-once"
 	}
 
-	return action as MigrationAction
+	const validActions: MigrationAction[] = ["migrate", "skip-once", "skip-forever"]
+	return validActions.includes(action as MigrationAction) ? (action as MigrationAction) : "skip-once"
 }
 
 function writeMcpServers(servers: Record<string, ServerEntry>): void {
@@ -63,7 +64,9 @@ function writeMcpServers(servers: Record<string, ServerEntry>): void {
 	const merged: Record<string, ServerEntry> = { ...servers, ...existingServers }
 
 	existing.mcpServers = merged
-	writeFileSync(mcpPath, `${JSON.stringify(existing, null, 2)}\n`, "utf-8")
+	const tmp = `${mcpPath}.${process.pid}.tmp`
+	writeFileSync(tmp, `${JSON.stringify(existing, null, 2)}\n`, "utf-8")
+	renameSync(tmp, mcpPath)
 }
 
 async function runSkillsPhase(): Promise<string[]> {
@@ -73,11 +76,11 @@ async function runSkillsPhase(): Promise<string[]> {
 		required: false,
 	})
 
-	if (clack.isCancel(selected)) {
+	if (clack.isCancel(selected) || !Array.isArray(selected)) {
 		return DEFAULT_SKILL_PATHS
 	}
 
-	const paths = selected as string[]
+	const paths = selected
 
 	const customInput = await clack.text({
 		message: "Add a custom path (leave empty to skip):",

--- a/src/setup-wizard.ts
+++ b/src/setup-wizard.ts
@@ -1,0 +1,131 @@
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs"
+import { homedir } from "node:os"
+import { dirname, join } from "node:path"
+import * as clack from "@clack/prompts"
+import { discoverCcConfig } from "./cc-discovery.js"
+import { DEFAULT_SKILL_PATHS, getAgentConfigDir } from "./config.js"
+import type { ServerEntry } from "./extensions/mcp-adapter/types.js"
+
+export type MigrationState = "done" | "skip-forever"
+
+export interface SetupResult {
+	skillPaths: string[]
+	migrationState?: MigrationState
+}
+
+type MigrationAction = "migrate" | "skip-once" | "skip-forever"
+
+async function runMigrationPhase(
+	mcpServers: Record<string, ServerEntry>,
+	skillCount: number,
+): Promise<MigrationAction> {
+	const serverNames = Object.keys(mcpServers)
+	const lines: string[] = []
+	if (serverNames.length > 0) {
+		lines.push(`MCP servers: ${serverNames.join(", ")}`)
+	}
+	if (skillCount > 0) {
+		lines.push(`Skills: ${skillCount} skill(s) in ~/.claude/skills/`)
+	}
+
+	clack.note(lines.join("\n"), "Claude Code configuration found")
+
+	const action = await clack.select<MigrationAction>({
+		message: "Migrate Claude Code MCP servers to Kimchi?",
+		options: [
+			{ value: "migrate", label: "Migrate now" },
+			{ value: "skip-once", label: "Skip this time" },
+			{ value: "skip-forever", label: "Never ask again" },
+		],
+	})
+
+	if (clack.isCancel(action)) {
+		return "skip-once"
+	}
+
+	return action as MigrationAction
+}
+
+function writeMcpServers(servers: Record<string, ServerEntry>): void {
+	const mcpPath = join(getAgentConfigDir(), "mcp.json")
+	mkdirSync(dirname(mcpPath), { recursive: true })
+
+	let existing: Record<string, unknown> = {}
+	if (existsSync(mcpPath)) {
+		try {
+			existing = JSON.parse(readFileSync(mcpPath, "utf-8")) as Record<string, unknown>
+		} catch {
+			// corrupt — start fresh
+		}
+	}
+
+	const existingServers = (existing.mcpServers ?? {}) as Record<string, ServerEntry>
+	const merged: Record<string, ServerEntry> = { ...servers, ...existingServers }
+
+	existing.mcpServers = merged
+	writeFileSync(mcpPath, `${JSON.stringify(existing, null, 2)}\n`, "utf-8")
+}
+
+async function runSkillsPhase(): Promise<string[]> {
+	const selected = await clack.multiselect<string>({
+		message: "Select skill paths to enable:",
+		options: DEFAULT_SKILL_PATHS.map((p) => ({ value: p, label: p, initialChecked: true })),
+		required: false,
+	})
+
+	if (clack.isCancel(selected)) {
+		return DEFAULT_SKILL_PATHS
+	}
+
+	const paths = selected as string[]
+
+	const customInput = await clack.text({
+		message: "Add a custom path (leave empty to skip):",
+		placeholder: "e.g. .my-skills or /absolute/path/to/skills",
+	})
+
+	if (!clack.isCancel(customInput) && typeof customInput === "string" && customInput.trim().length > 0) {
+		paths.push(customInput.trim())
+	}
+
+	return paths
+}
+
+export async function runSetupWizard(options: {
+	needsSkillsSetup: boolean
+	needsMigrationCheck: boolean
+}): Promise<SetupResult> {
+	clack.intro("Kimchi first-time setup")
+
+	let migrationState: MigrationState | undefined
+	const discovery = options.needsMigrationCheck ? discoverCcConfig() : { mcpServers: {}, skillCount: 0 }
+	const hasCcConfig =
+		options.needsMigrationCheck && (Object.keys(discovery.mcpServers).length > 0 || discovery.skillCount > 0)
+
+	if (hasCcConfig) {
+		const action = await runMigrationPhase(discovery.mcpServers, discovery.skillCount)
+		if (action === "migrate") {
+			writeMcpServers(discovery.mcpServers)
+			migrationState = "done"
+			clack.log.success(`Migrated ${Object.keys(discovery.mcpServers).length} MCP server(s) to Kimchi.`)
+		} else if (action === "skip-forever") {
+			migrationState = "skip-forever"
+		}
+		// skip-once: leave migrationState undefined so wizard runs again next time
+	} else if (options.needsMigrationCheck) {
+		migrationState = "done"
+	}
+
+	let skillPaths = DEFAULT_SKILL_PATHS
+	if (options.needsSkillsSetup) {
+		clack.note(
+			"Kimchi will look for skill files in the selected directories.\n" +
+				"Each relative path is scanned under both ~ and the current project.",
+			"Skills",
+		)
+		skillPaths = await runSkillsPhase()
+	}
+
+	clack.outro("Setup complete.")
+	return { skillPaths, migrationState }
+}

--- a/src/skills-wizard.ts
+++ b/src/skills-wizard.ts
@@ -1,0 +1,28 @@
+import { createInterface } from "node:readline/promises"
+import { DEFAULT_SKILL_PATHS } from "./config.js"
+
+export async function runSkillsWizard(): Promise<string[]> {
+	const rl = createInterface({ input: process.stdin, output: process.stdout })
+
+	console.log("\nSkills configuration")
+	console.log("--------------------")
+	console.log("Kimchi loads skill files from configured directories.")
+	console.log("Each path is also scanned relative to the current project directory.\n")
+	console.log("Default paths:")
+	for (const p of DEFAULT_SKILL_PATHS) {
+		console.log(`  ${p}`)
+	}
+	console.log()
+
+	const answer = await rl.question("Press Enter to accept defaults, or enter custom paths (comma-separated):\n> ")
+	rl.close()
+
+	if (answer.trim() === "") {
+		return DEFAULT_SKILL_PATHS
+	}
+
+	return answer
+		.split(",")
+		.map((p) => p.trim())
+		.filter((p) => p.length > 0)
+}

--- a/src/skills-wizard.ts
+++ b/src/skills-wizard.ts
@@ -1,28 +1,36 @@
-import { createInterface } from "node:readline/promises"
+import * as clack from "@clack/prompts"
 import { DEFAULT_SKILL_PATHS } from "./config.js"
 
 export async function runSkillsWizard(): Promise<string[]> {
-	const rl = createInterface({ input: process.stdin, output: process.stdout })
+	clack.intro("Skills configuration")
+	clack.note(
+		"Kimchi will look for skill files in the selected directories.\n" +
+			"Each relative path is scanned under both ~ and the current project.",
+		"First-time setup",
+	)
 
-	console.log("\nSkills configuration")
-	console.log("--------------------")
-	console.log("Kimchi loads skill files from configured directories.")
-	console.log("Each path is also scanned relative to the current project directory.\n")
-	console.log("Default paths:")
-	for (const p of DEFAULT_SKILL_PATHS) {
-		console.log(`  ${p}`)
-	}
-	console.log()
+	const selected = await clack.multiselect<string>({
+		message: "Select skill paths to enable:",
+		options: DEFAULT_SKILL_PATHS.map((p) => ({ value: p, label: p, initialChecked: true })),
+		required: false,
+	})
 
-	const answer = await rl.question("Press Enter to accept defaults, or enter custom paths (comma-separated):\n> ")
-	rl.close()
-
-	if (answer.trim() === "") {
+	if (clack.isCancel(selected)) {
+		clack.cancel("Setup cancelled. Using default paths.")
 		return DEFAULT_SKILL_PATHS
 	}
 
-	return answer
-		.split(",")
-		.map((p) => p.trim())
-		.filter((p) => p.length > 0)
+	const paths = selected as string[]
+
+	const customInput = await clack.text({
+		message: "Add a custom path (leave empty to skip):",
+		placeholder: "e.g. .my-skills or /absolute/path/to/skills",
+	})
+
+	if (!clack.isCancel(customInput) && typeof customInput === "string" && customInput.trim().length > 0) {
+		paths.push(customInput.trim())
+	}
+
+	clack.outro(`Saved ${paths.length} skill path(s).`)
+	return paths
 }


### PR DESCRIPTION
## What this PR does

Addresses two gaps in the CC→Kimchi migration story for users coming from Claude Code:

### 1. Skill path discovery

Previously, `prompt-enrichment` loaded skills only from `pi-coding-agent`'s own config directory (`~/.pi/agent/` in dev, `~/.config/kimchi/harness/` in binary). Skills stored in `~/.claude/skills/` — the standard location for CC users — were silently ignored.

**Changes:**
- `promptEnrichmentExtension` is now a factory that accepts an explicit `skillPaths: string[]`
- `expandSkillPaths()` expands relative suffixes to both `~/suffix` and `<cwd>/suffix`, so paths like `.claude/skills` work regardless of where you run from
- Default paths cover all three common locations: `.pi/agent/skills`, `.config/kimchi/harness/skills`, `.claude/skills`

### 2. First-run setup wizard

On first launch (when `skillPaths` or `migrationState` are absent from `~/.config/kimchi/config.json`), an interactive CLI wizard runs using `@clack/prompts`.

**Skills phase** — multiselect from the three default paths, with an option to add a custom path. Selection is saved as `skillPaths` in `config.json` and never asked again.

**CC migration phase** — discovers existing Claude Code configuration from `~/.claude.json`:
- Collects all MCP servers defined across CC projects (deduplicated by name)
- Counts skills in `~/.claude/skills/`

The user is offered three choices:
- **Migrate now** — MCP server definitions are written to `~/.config/kimchi/harness/mcp.json` (merging with any existing entries; kimchi config takes precedence). `migrationState: "done"` is saved.
- **Skip this time** — no flag is written; the migration question appears again on next launch.
- **Never ask again** — `migrationState: "skip-forever"` is saved; migration phase is skipped on all future launches.

If no CC config is found at all, the 
migration phase is skipped silently and `migrationState: "done"` is recorded.

### 3. Demo

<img width="1996" height="1572" alt="2026-04-22 16 19 35" src="https://github.com/user-attachments/assets/427aa413-a7da-4067-89cf-933b423de1f5" />

---
### Kimchi Summary
### What changed
Adds an interactive first-time setup wizard that detects existing Claude Code configurations and guides users through migrating MCP servers and configuring skill search paths.

### Why
Provides a seamless migration path for users transitioning from Claude Code to Kimchi by automatically detecting `~/.claude.json` settings and offering to import MCP server configurations, while also establishing configurable skill discovery paths.

### Key changes
- Added `@clack/prompts` dependency for interactive CLI UI
- Added `src/cc-discovery.ts` to parse Claude Code config (`~/.claude.json`) and count skills in `~/.claude/skills`
- Added `src/setup-wizard.ts` implementing the interactive wizard with:
  - Migration phase for importing MCP servers to `mcp.json`
  - Skills phase for selecting search paths from `DEFAULT_SKILL_PATHS`
- Modified `src/cli.ts` to trigger wizard when `skillPaths` or `migrationState` is unset; falls back to defaults in non-TTY environments
- Extended `src/config.ts` with `skillPaths`/`migrationState` config fields and `writeSkillPaths()`/`writeMigrationState()` persistence helpers
- Updated `src/extensions/orchestration/prompt-enrichment.ts` to accept `skillPaths` parameter and expand paths relative to home/project directories via `expandSkillPaths()`

### Impact
- **First launch**: Interactive users see the wizard once; non-interactive sessions use `DEFAULT_SKILL_PATHS` and skip migration
- **Migration persistence**: Users can select "Never ask again" to set `migrationState: "skip-forever"` 
- **Skill loading**: Skills are now loaded from configured paths instead of hardcoded locations