### PR TITLE
NOJIRA: Fix failing smoke tests

### DIFF
--- a/tests/smoke/harness.ts
+++ b/tests/smoke/harness.ts
@@ -8,7 +8,7 @@
  */
 
 import { type SpawnSyncReturns, spawnSync } from "node:child_process"
-import { chmodSync, mkdirSync, mkdtempSync, readdirSync, rmSync, statSync } from "node:fs"
+import { chmodSync, mkdirSync, mkdtempSync, readdirSync, rmSync, statSync, writeFileSync } from "node:fs"
 import { createRequire } from "node:module"
 import { tmpdir } from "node:os"
 import { dirname, join, resolve } from "node:path"
@@ -24,6 +24,13 @@ let tempHome: string | undefined
 
 beforeAll(() => {
 	tempHome = mkdtempSync(join(tmpdir(), "kimchi-smoke-home-"))
+	const configDir = join(tempHome, ".config", "kimchi")
+	mkdirSync(configDir, { recursive: true })
+	writeFileSync(
+		join(configDir, "config.json"),
+		JSON.stringify({ skillPaths: [], migrationState: "done" }, null, 2),
+		"utf-8",
+	)
 })
 
 afterAll(() => {


### PR DESCRIPTION


---
### Kimchi Summary
### What changed
The smoke test harness now initializes a mock Kimchi configuration file with `migrationState: "done"` before test execution, ensuring tests run against a properly configured environment.

### Why
Smoke tests were failing due to missing configuration or uninitialized migration state when running in isolated temporary home directories.

### Key changes
- **tests/smoke/harness.ts**: 
  - Added `writeFileSync` import from `node:fs`
  - Modified `beforeAll` hook to create `.config/kimchi/` directory structure
  - Writes `config.json` with `skillPaths: []` and `migrationState: "done"` to prevent migration prompts or configuration errors during test runs