### PR TITLE
NOJIRA: Inject response nudge when model returns empty turn after tool calls

### DIFF
--- a/src/extensions/orchestration/prompt-enrichment.ts
+++ b/src/extensions/orchestration/prompt-enrichment.ts
@@ -134,7 +134,7 @@ export default function (skillPaths: string[]) {
 						...messages,
 						{
 							role: "user" as const,
-							content: [{ type: "text" as const, text: "Please respond to the user now." }],
+							content: [{ type: "text" as const, text: "If you have finished, please summarize the result for the user. Otherwise, continue with the next tool call." }],
 							timestamp: Date.now(),
 						},
 					],

--- a/src/extensions/orchestration/prompt-enrichment.ts
+++ b/src/extensions/orchestration/prompt-enrichment.ts
@@ -22,7 +22,7 @@
 
 import { homedir } from "node:os"
 import { isAbsolute, join, normalize, resolve } from "node:path"
-import type { ImageContent, TextContent } from "@mariozechner/pi-ai"
+import type { AssistantMessage, ImageContent, TextContent } from "@mariozechner/pi-ai"
 import { type ExtensionAPI, type Skill, loadSkills } from "@mariozechner/pi-coding-agent"
 import { ANSI, fg } from "../../ansi.js"
 import { getAvailableModelIds } from "../../startup-context.js"
@@ -109,6 +109,36 @@ export default function (skillPaths: string[]) {
 				pi.sendUserMessage(userContent)
 
 				return { action: "handled" as const }
+			})
+
+			// Detect when the model returned only tool calls with no text, received tool results,
+			// and is about to be called again. Some models (e.g. kimi-k2.5) silently return an
+			// empty response in this situation instead of producing a text answer. Injecting a
+			// nudge before the follow-up call reliably prevents the empty turn.
+			pi.on("context", async (event) => {
+				const messages = event.messages
+
+				const lastAssistant = [...messages].reverse().find((m): m is AssistantMessage => m.role === "assistant")
+				if (!lastAssistant) return
+
+				const hasToolCalls = lastAssistant.content.some((c) => c.type === "toolCall")
+				const hasText = lastAssistant.content.some((c) => c.type === "text")
+				if (!hasToolCalls || hasText) return
+
+				const lastAssistantIndex = messages.lastIndexOf(lastAssistant)
+				const hasToolResultsAfter = messages.slice(lastAssistantIndex + 1).some((m) => m.role === "toolResult")
+				if (!hasToolResultsAfter) return
+
+				return {
+					messages: [
+						...messages,
+						{
+							role: "user" as const,
+							content: [{ type: "text" as const, text: "Please respond to the user now." }],
+							timestamp: Date.now(),
+						},
+					],
+				}
 			})
 		}
 

--- a/src/extensions/orchestration/prompt-enrichment.ts
+++ b/src/extensions/orchestration/prompt-enrichment.ts
@@ -134,7 +134,12 @@ export default function (skillPaths: string[]) {
 						...messages,
 						{
 							role: "user" as const,
-							content: [{ type: "text" as const, text: "If you have finished, please summarize the result for the user. Otherwise, continue with the next tool call." }],
+							content: [
+								{
+									type: "text" as const,
+									text: "If you have finished, please summarize the result for the user. Otherwise, continue with the next tool call.",
+								},
+							],
 							timestamp: Date.now(),
 						},
 					],


### PR DESCRIPTION
## Problem

Some models (observed with kimi-k2.5) return an empty assistant response — content: [], stopReason: stop, output: 0 — after receiving tool results, instead of producing a text answer. The agent loop treats this as a clean stop and closes the prompt with no response shown to the user.

Root cause: agent-loop.js exits the inner loop when toolCalls.length === 0, and _isRetryableError in agent-session.js only retries on stopReason === error, so silent empty stops pass through unchallenged.

## Fix

In the context event handler (fires before each LLM call), detect the pattern:
- Last assistant message had tool calls but no text
- Tool results are present after it (model is being called again after completing tool calls)

If detected, append a user message "Please respond to the user now." to the context before the call. This nudges the model to produce output instead of returning empty.

The handler is registered only in orchestrator mode (not subagents), and is a no-op for models that already behave correctly.

---
### Kimchi Summary
### What changed
Adds automatic prompt injection to prevent empty model responses after tool execution sequences. When the model returns only tool calls without text and subsequently receives tool results, a follow-up nudge is now inserted to prompt the model to summarize or continue.

### Why
Certain models such as kimi-k2.5 silently return empty responses when they receive tool results after emitting tool calls without accompanying text, causing the conversation to stall on blank turns.

### Key changes
- Imported `AssistantMessage` type from `@mariozechner/pi-ai` in `prompt-enrichment.ts`
- Registered new `context` event handler in the extension setup to intercept message sequences
- Implemented detection logic for assistant messages containing only `toolCall` content (no `text`) followed by `toolResult` messages
- Injects a user message with guidance: "If you have finished, please summarize the result for the user. Otherwise, continue with the next tool call."

### Impact
Prevents conversation stalls specifically affecting kimi-k2.5 and similar models during multi-turn tool interactions. No breaking changes or migration steps required.