### PR TITLE
LLM-1355: Inject environment metadata into system prompts

### DIFF
--- a/src/extensions/orchestration/prompt-enrichment.ts
+++ b/src/extensions/orchestration/prompt-enrichment.ts
@@ -20,7 +20,9 @@
  * returns "continue" so the message passes through unchanged.
  */
 
-import { homedir, type, userInfo } from "node:os"
+import { execSync } from "node:child_process"
+import { existsSync, readFileSync } from "node:fs"
+import { homedir, platform, userInfo } from "node:os"
 import { isAbsolute, join, normalize, resolve } from "node:path"
 import type { AssistantMessage, ImageContent, TextContent } from "@mariozechner/pi-ai"
 import { type ExtensionAPI, type Skill, loadSkills } from "@mariozechner/pi-coding-agent"
@@ -59,6 +61,26 @@ function safeUsername(): string {
 		return userInfo().username
 	} catch {
 		return process.env.USER ?? process.env.USERNAME ?? "unknown"
+	}
+}
+
+function readGitBranch(cwd: string): string | undefined {
+	try {
+		const head = readFileSync(join(cwd, ".git", "HEAD"), "utf8").trim()
+		return head.startsWith("ref: refs/heads/") ? head.slice("ref: refs/heads/".length) : undefined
+	} catch {
+		return undefined
+	}
+}
+
+function readGitRemote(cwd: string): string | undefined {
+	try {
+		return (
+			execSync("git remote get-url origin", { cwd, encoding: "utf8", stdio: ["ignore", "pipe", "ignore"] }).trim() ||
+			undefined
+		)
+	} catch {
+		return undefined
 	}
 }
 
@@ -167,12 +189,19 @@ export default function (skillPaths: string[]) {
 				skillPaths: expandSkillPaths(skillPaths, ctx.cwd),
 			}).skills
 
+			const platformNames: Record<string, string> = { darwin: "macOS", win32: "Windows" }
+			const now = new Date()
+			const isGitRepo = existsSync(join(ctx.cwd, ".git", "HEAD"))
 			const env: EnvironmentInfo = {
-				os: type() === "Darwin" ? "macOS" : type(),
+				os: platformNames[platform()] ?? platform(),
 				username: safeUsername(),
 				homeDir: homedir(),
 				cwd: ctx.cwd,
-				currentTime: new Date().toISOString(),
+				currentTime: now.toISOString(),
+				localDate: now.toLocaleDateString("en-CA"),
+				isGitRepo,
+				gitBranch: isGitRepo ? readGitBranch(ctx.cwd) : undefined,
+				gitRemote: isGitRepo ? readGitRemote(ctx.cwd) : undefined,
 			}
 
 			if (subagentMode) {

--- a/src/extensions/orchestration/prompt-enrichment.ts
+++ b/src/extensions/orchestration/prompt-enrichment.ts
@@ -21,7 +21,7 @@
  */
 
 import { execSync } from "node:child_process"
-import { existsSync, readFileSync } from "node:fs"
+import { existsSync } from "node:fs"
 import { homedir, platform, userInfo } from "node:os"
 import { isAbsolute, join, normalize, resolve } from "node:path"
 import type { AssistantMessage, ImageContent, TextContent } from "@mariozechner/pi-ai"
@@ -66,8 +66,10 @@ function safeUsername(): string {
 
 function readGitBranch(cwd: string): string | undefined {
 	try {
-		const head = readFileSync(join(cwd, ".git", "HEAD"), "utf8").trim()
-		return head.startsWith("ref: refs/heads/") ? head.slice("ref: refs/heads/".length) : undefined
+		return (
+			execSync("git symbolic-ref --short HEAD", { cwd, encoding: "utf8", stdio: ["ignore", "pipe", "ignore"] }).trim() ||
+			undefined
+		)
 	} catch {
 		return undefined
 	}
@@ -178,8 +180,14 @@ export default function (skillPaths: string[]) {
 			})
 		}
 
+		const platformNames: Record<string, string> = { darwin: "macOS", win32: "Windows" }
+		const cachedOs = platformNames[platform()] ?? platform()
+		const cachedUsername = safeUsername()
+		const cachedHomeDir = homedir()
+
 		let cachedContextFiles: ContextFile[] | undefined
 		let cachedSkills: Skill[] | undefined
+		let cachedGitRemote: string | undefined | null = null
 
 		pi.on("before_agent_start", async (_event, ctx) => {
 			const tools = pi.getAllTools()
@@ -189,19 +197,21 @@ export default function (skillPaths: string[]) {
 				skillPaths: expandSkillPaths(skillPaths, ctx.cwd),
 			}).skills
 
-			const platformNames: Record<string, string> = { darwin: "macOS", win32: "Windows" }
 			const now = new Date()
 			const isGitRepo = existsSync(join(ctx.cwd, ".git", "HEAD"))
+			if (isGitRepo && cachedGitRemote === null) {
+				cachedGitRemote = readGitRemote(ctx.cwd)
+			}
 			const env: EnvironmentInfo = {
-				os: platformNames[platform()] ?? platform(),
-				username: safeUsername(),
-				homeDir: homedir(),
+				os: cachedOs,
+				username: cachedUsername,
+				homeDir: cachedHomeDir,
 				cwd: ctx.cwd,
 				currentTime: now.toISOString(),
 				localDate: now.toLocaleDateString("en-CA"),
 				isGitRepo,
 				gitBranch: isGitRepo ? readGitBranch(ctx.cwd) : undefined,
-				gitRemote: isGitRepo ? readGitRemote(ctx.cwd) : undefined,
+				gitRemote: isGitRepo ? cachedGitRemote ?? undefined : undefined,
 			}
 
 			if (subagentMode) {

--- a/src/extensions/orchestration/prompt-enrichment.ts
+++ b/src/extensions/orchestration/prompt-enrichment.ts
@@ -20,7 +20,7 @@
  * returns "continue" so the message passes through unchanged.
  */
 
-import { homedir } from "node:os"
+import { homedir, type, userInfo } from "node:os"
 import { isAbsolute, join, normalize, resolve } from "node:path"
 import type { AssistantMessage, ImageContent, TextContent } from "@mariozechner/pi-ai"
 import { type ExtensionAPI, type Skill, loadSkills } from "@mariozechner/pi-coding-agent"
@@ -29,6 +29,7 @@ import { getAvailableModelIds } from "../../startup-context.js"
 import { ModelRegistry } from "./model-registry/index.js"
 import { type ContextFile, loadProjectContextFiles } from "./prompt-transformer/context-files.js"
 import {
+	type EnvironmentInfo,
 	buildOrchestratorSystemPrompt,
 	buildSubagentSystemPrompt,
 	isSubagent,
@@ -158,17 +159,25 @@ export default function (skillPaths: string[]) {
 				skillPaths: expandSkillPaths(skillPaths, ctx.cwd),
 			}).skills
 
+			const env: EnvironmentInfo = {
+				os: type() === "Darwin" ? "macOS" : type(),
+				username: userInfo().username,
+				homeDir: homedir(),
+				cwd: ctx.cwd,
+				currentTime: new Date().toISOString(),
+			}
+
 			if (subagentMode) {
 				// Filter the subagent tool out of the active tool set to prevent
 				// the subagent from spawning further subagents.
 				const activeTools = pi.getActiveTools().filter((name) => name !== "subagent")
 				pi.setActiveTools(activeTools)
 
-				const systemPrompt = buildSubagentSystemPrompt(tools, cachedContextFiles, cachedSkills)
+				const systemPrompt = buildSubagentSystemPrompt(tools, env, cachedContextFiles, cachedSkills)
 				return { systemPrompt }
 			}
 
-			const systemPrompt = buildOrchestratorSystemPrompt(tools, cachedContextFiles, cachedSkills)
+			const systemPrompt = buildOrchestratorSystemPrompt(tools, env, cachedContextFiles, cachedSkills)
 			return { systemPrompt }
 		})
 	}

--- a/src/extensions/orchestration/prompt-enrichment.ts
+++ b/src/extensions/orchestration/prompt-enrichment.ts
@@ -67,8 +67,11 @@ function safeUsername(): string {
 function readGitBranch(cwd: string): string | undefined {
 	try {
 		return (
-			execSync("git symbolic-ref --short HEAD", { cwd, encoding: "utf8", stdio: ["ignore", "pipe", "ignore"] }).trim() ||
-			undefined
+			execSync("git symbolic-ref --short HEAD", {
+				cwd,
+				encoding: "utf8",
+				stdio: ["ignore", "pipe", "ignore"],
+			}).trim() || undefined
 		)
 	} catch {
 		return undefined
@@ -211,7 +214,7 @@ export default function (skillPaths: string[]) {
 				localDate: now.toLocaleDateString("en-CA"),
 				isGitRepo,
 				gitBranch: isGitRepo ? readGitBranch(ctx.cwd) : undefined,
-				gitRemote: isGitRepo ? cachedGitRemote ?? undefined : undefined,
+				gitRemote: isGitRepo ? (cachedGitRemote ?? undefined) : undefined,
 			}
 
 			if (subagentMode) {

--- a/src/extensions/orchestration/prompt-enrichment.ts
+++ b/src/extensions/orchestration/prompt-enrichment.ts
@@ -54,6 +54,14 @@ function expandSkillPaths(configuredPaths: string[], cwd: string): string[] {
 	return expanded
 }
 
+function safeUsername(): string {
+	try {
+		return userInfo().username
+	} catch {
+		return process.env.USER ?? process.env.USERNAME ?? "unknown"
+	}
+}
+
 export default function (skillPaths: string[]) {
 	return (pi: ExtensionAPI) => {
 		const subagentMode = isSubagent()
@@ -161,7 +169,7 @@ export default function (skillPaths: string[]) {
 
 			const env: EnvironmentInfo = {
 				os: type() === "Darwin" ? "macOS" : type(),
-				username: userInfo().username,
+				username: safeUsername(),
 				homeDir: homedir(),
 				cwd: ctx.cwd,
 				currentTime: new Date().toISOString(),

--- a/src/extensions/orchestration/prompt-transformer/prompt-transformer.test.ts
+++ b/src/extensions/orchestration/prompt-transformer/prompt-transformer.test.ts
@@ -14,6 +14,8 @@ const testEnv: EnvironmentInfo = {
 	homeDir: "/home/testuser",
 	cwd: "/home/testuser/projects/myapp",
 	currentTime: "2026-01-01T00:00:00.000Z",
+	localDate: "2026-01-01",
+	isGitRepo: false,
 }
 
 const ALL_KNOWN_IDS = [...MODEL_CAPABILITIES.keys()]
@@ -190,9 +192,29 @@ describe("buildOrchestratorSystemPrompt", () => {
 		expect(result).toContain("# Environment")
 		expect(result).toContain(`OS: ${testEnv.os}`)
 		expect(result).toContain(`Username: ${testEnv.username}`)
-		expect(result).toContain(`Home directory: ${testEnv.homeDir}`)
-		expect(result).toContain(`Working directory: ${testEnv.cwd}`)
-		expect(result).toContain(`Current time: ${testEnv.currentTime}`)
+		expect(result).toContain(`Home directory: "${testEnv.homeDir}"`)
+		expect(result).toContain(`Working directory: "${testEnv.cwd}"`)
+		expect(result).toContain(`Current time: ${testEnv.currentTime} (local date: ${testEnv.localDate})`)
+		expect(result).toContain("Git repository: no")
+	})
+
+	it("injects git branch and remote when present", () => {
+		const gitEnv: EnvironmentInfo = {
+			...testEnv,
+			isGitRepo: true,
+			gitBranch: "main",
+			gitRemote: "git@github.com:org/repo.git",
+		}
+		const result = buildOrchestratorSystemPrompt(tools, gitEnv)
+		expect(result).toContain("Git repository: yes")
+		expect(result).toContain("Git branch: main")
+		expect(result).toContain("Git remote: git@github.com:org/repo.git")
+	})
+
+	it("omits git branch and remote lines when not a git repo", () => {
+		const result = buildOrchestratorSystemPrompt(tools, testEnv)
+		expect(result).not.toContain("Git branch:")
+		expect(result).not.toContain("Git remote:")
 	})
 
 	it("replaces the {{ENVIRONMENT}} placeholder", () => {
@@ -292,9 +314,23 @@ describe("buildSubagentSystemPrompt", () => {
 		expect(result).toContain("# Environment")
 		expect(result).toContain(`OS: ${testEnv.os}`)
 		expect(result).toContain(`Username: ${testEnv.username}`)
-		expect(result).toContain(`Home directory: ${testEnv.homeDir}`)
-		expect(result).toContain(`Working directory: ${testEnv.cwd}`)
-		expect(result).toContain(`Current time: ${testEnv.currentTime}`)
+		expect(result).toContain(`Home directory: "${testEnv.homeDir}"`)
+		expect(result).toContain(`Working directory: "${testEnv.cwd}"`)
+		expect(result).toContain(`Current time: ${testEnv.currentTime} (local date: ${testEnv.localDate})`)
+		expect(result).toContain("Git repository: no")
+	})
+
+	it("injects git branch and remote when present", () => {
+		const gitEnv: EnvironmentInfo = {
+			...testEnv,
+			isGitRepo: true,
+			gitBranch: "feature/my-branch",
+			gitRemote: "https://github.com/org/repo.git",
+		}
+		const result = buildSubagentSystemPrompt(tools, gitEnv)
+		expect(result).toContain("Git repository: yes")
+		expect(result).toContain("Git branch: feature/my-branch")
+		expect(result).toContain("Git remote: https://github.com/org/repo.git")
 	})
 
 	it("replaces the {{ENVIRONMENT}} placeholder", () => {

--- a/src/extensions/orchestration/prompt-transformer/prompt-transformer.test.ts
+++ b/src/extensions/orchestration/prompt-transformer/prompt-transformer.test.ts
@@ -1,7 +1,20 @@
 import type { Skill } from "@mariozechner/pi-coding-agent"
 import { describe, expect, it } from "vitest"
 import { MODEL_CAPABILITIES, ModelRegistry } from "../model-registry/index.js"
-import { buildOrchestratorSystemPrompt, buildSubagentSystemPrompt, transformPrompt } from "./prompt-transformer.js"
+import {
+	type EnvironmentInfo,
+	buildOrchestratorSystemPrompt,
+	buildSubagentSystemPrompt,
+	transformPrompt,
+} from "./prompt-transformer.js"
+
+const testEnv: EnvironmentInfo = {
+	os: "Linux",
+	username: "testuser",
+	homeDir: "/home/testuser",
+	cwd: "/home/testuser/projects/myapp",
+	currentTime: "2026-01-01T00:00:00.000Z",
+}
 
 const ALL_KNOWN_IDS = [...MODEL_CAPABILITIES.keys()]
 
@@ -87,7 +100,7 @@ describe("buildOrchestratorSystemPrompt", () => {
 	]
 
 	it("includes all tool names and descriptions", () => {
-		const result = buildOrchestratorSystemPrompt(tools)
+		const result = buildOrchestratorSystemPrompt(tools, testEnv)
 		for (const tool of tools) {
 			expect(result).toContain(tool.name)
 			expect(result).toContain(tool.description)
@@ -95,30 +108,30 @@ describe("buildOrchestratorSystemPrompt", () => {
 	})
 
 	it("formats tools as a list", () => {
-		const result = buildOrchestratorSystemPrompt(tools)
+		const result = buildOrchestratorSystemPrompt(tools, testEnv)
 		expect(result).toContain("- read: Read file contents")
 		expect(result).toContain("- subagent: Spawn an isolated subagent process")
 	})
 
 	it("contains self-classification instructions", () => {
-		const result = buildOrchestratorSystemPrompt(tools)
+		const result = buildOrchestratorSystemPrompt(tools, testEnv)
 		expect(result).toContain("subagent")
 		expect(result).toContain("delegate")
 	})
 
 	it("replaces the {{TOOLS}} placeholder", () => {
-		const result = buildOrchestratorSystemPrompt(tools)
+		const result = buildOrchestratorSystemPrompt(tools, testEnv)
 		expect(result).not.toContain("{{TOOLS}}")
 	})
 
 	it("handles empty tools list", () => {
-		const result = buildOrchestratorSystemPrompt([])
+		const result = buildOrchestratorSystemPrompt([], testEnv)
 		expect(result).toContain("(No tools available)")
 		expect(result).not.toContain("{{TOOLS}}")
 	})
 
 	it("replaces the {{PROJECT_CONTEXT}} placeholder when no context files", () => {
-		const result = buildOrchestratorSystemPrompt(tools)
+		const result = buildOrchestratorSystemPrompt(tools, testEnv)
 		expect(result).not.toContain("{{PROJECT_CONTEXT}}")
 	})
 
@@ -127,7 +140,7 @@ describe("buildOrchestratorSystemPrompt", () => {
 			{ path: "/repo/AGENTS.md", content: "Always run tests before committing." },
 			{ path: "/repo/sub/CLAUDE.md", content: "Use pnpm, not npm." },
 		]
-		const result = buildOrchestratorSystemPrompt(tools, contextFiles)
+		const result = buildOrchestratorSystemPrompt(tools, testEnv, contextFiles)
 		expect(result).toContain("# Project Guidelines")
 		expect(result).toContain("Always run tests before committing.")
 		expect(result).toContain("Use pnpm, not npm.")
@@ -138,14 +151,14 @@ describe("buildOrchestratorSystemPrompt", () => {
 
 	it("places project guidelines after the guidelines section", () => {
 		const contextFiles = [{ path: "/repo/AGENTS.md", content: "custom rule" }]
-		const result = buildOrchestratorSystemPrompt(tools, contextFiles)
+		const result = buildOrchestratorSystemPrompt(tools, testEnv, contextFiles)
 		const guidelinesPos = result.indexOf("## Guidelines")
 		const contextPos = result.indexOf("# Project Guidelines")
 		expect(guidelinesPos).toBeLessThan(contextPos)
 	})
 
 	it("replaces the {{SKILLS}} placeholder when no skills", () => {
-		const result = buildOrchestratorSystemPrompt(tools)
+		const result = buildOrchestratorSystemPrompt(tools, testEnv)
 		expect(result).not.toContain("{{SKILLS}}")
 	})
 
@@ -154,7 +167,7 @@ describe("buildOrchestratorSystemPrompt", () => {
 			createSkill({ name: "deploy", description: "Deploy the app to production" }),
 			createSkill({ name: "review", description: "Review a pull request" }),
 		]
-		const result = buildOrchestratorSystemPrompt(tools, undefined, skills)
+		const result = buildOrchestratorSystemPrompt(tools, testEnv, undefined, skills)
 		expect(result).toContain("available_skills")
 		expect(result).toContain("deploy")
 		expect(result).toContain("Deploy the app to production")
@@ -167,9 +180,32 @@ describe("buildOrchestratorSystemPrompt", () => {
 			createSkill({ name: "safe-skill", description: "Visible skill" }),
 			createSkill({ name: "hidden-skill", description: "Hidden skill", disableModelInvocation: true }),
 		]
-		const result = buildOrchestratorSystemPrompt(tools, undefined, skills)
+		const result = buildOrchestratorSystemPrompt(tools, testEnv, undefined, skills)
 		expect(result).toContain("safe-skill")
 		expect(result).not.toContain("hidden-skill")
+	})
+
+	it("injects environment info into the prompt", () => {
+		const result = buildOrchestratorSystemPrompt(tools, testEnv)
+		expect(result).toContain("# Environment")
+		expect(result).toContain(`OS: ${testEnv.os}`)
+		expect(result).toContain(`Username: ${testEnv.username}`)
+		expect(result).toContain(`Home directory: ${testEnv.homeDir}`)
+		expect(result).toContain(`Working directory: ${testEnv.cwd}`)
+		expect(result).toContain(`Current time: ${testEnv.currentTime}`)
+	})
+
+	it("replaces the {{ENVIRONMENT}} placeholder", () => {
+		const result = buildOrchestratorSystemPrompt(tools, testEnv)
+		expect(result).not.toContain("{{ENVIRONMENT}}")
+	})
+
+	it("places environment section before project guidelines", () => {
+		const contextFiles = [{ path: "/repo/AGENTS.md", content: "custom rule" }]
+		const result = buildOrchestratorSystemPrompt(tools, testEnv, contextFiles)
+		const envPos = result.indexOf("# Environment")
+		const contextPos = result.indexOf("# Project Guidelines")
+		expect(envPos).toBeLessThan(contextPos)
 	})
 })
 
@@ -183,12 +219,12 @@ describe("buildSubagentSystemPrompt", () => {
 	]
 
 	it("excludes the subagent tool", () => {
-		const result = buildSubagentSystemPrompt(tools)
+		const result = buildSubagentSystemPrompt(tools, testEnv)
 		expect(result).not.toContain("subagent")
 	})
 
 	it("includes all other tools", () => {
-		const result = buildSubagentSystemPrompt(tools)
+		const result = buildSubagentSystemPrompt(tools, testEnv)
 		expect(result).toContain("- read: Read file contents")
 		expect(result).toContain("- bash: Execute bash commands")
 		expect(result).toContain("- edit: Edit files")
@@ -196,35 +232,35 @@ describe("buildSubagentSystemPrompt", () => {
 	})
 
 	it("replaces the {{TOOLS}} placeholder", () => {
-		const result = buildSubagentSystemPrompt(tools)
+		const result = buildSubagentSystemPrompt(tools, testEnv)
 		expect(result).not.toContain("{{TOOLS}}")
 	})
 
 	it("contains coding assistant instructions", () => {
-		const result = buildSubagentSystemPrompt(tools)
+		const result = buildSubagentSystemPrompt(tools, testEnv)
 		expect(result).toContain("expert coding assistant")
 	})
 
 	it("does not contain orchestration instructions", () => {
-		const result = buildSubagentSystemPrompt(tools)
+		const result = buildSubagentSystemPrompt(tools, testEnv)
 		expect(result).not.toContain("orchestrator")
 		expect(result).not.toContain("EASY")
 		expect(result).not.toContain("HARD")
 	})
 
 	it("handles tools list with only the subagent tool", () => {
-		const result = buildSubagentSystemPrompt([{ name: "subagent", description: "Spawn" }])
+		const result = buildSubagentSystemPrompt([{ name: "subagent", description: "Spawn" }], testEnv)
 		expect(result).toContain("(No tools available)")
 	})
 
 	it("replaces the {{PROJECT_CONTEXT}} placeholder when no context files", () => {
-		const result = buildSubagentSystemPrompt(tools)
+		const result = buildSubagentSystemPrompt(tools, testEnv)
 		expect(result).not.toContain("{{PROJECT_CONTEXT}}")
 	})
 
 	it("injects project guidelines files into the prompt", () => {
 		const contextFiles = [{ path: "/project/AGENTS.md", content: "Use TypeScript strict mode." }]
-		const result = buildSubagentSystemPrompt(tools, contextFiles)
+		const result = buildSubagentSystemPrompt(tools, testEnv, contextFiles)
 		expect(result).toContain("# Project Guidelines")
 		expect(result).toContain("Use TypeScript strict mode.")
 		expect(result).not.toContain("/project/AGENTS.md")
@@ -232,22 +268,37 @@ describe("buildSubagentSystemPrompt", () => {
 
 	it("places project guidelines after the guidelines section", () => {
 		const contextFiles = [{ path: "/repo/AGENTS.md", content: "rule" }]
-		const result = buildSubagentSystemPrompt(tools, contextFiles)
+		const result = buildSubagentSystemPrompt(tools, testEnv, contextFiles)
 		const guidelinesPos = result.indexOf("## Guidelines")
 		const contextPos = result.indexOf("# Project Guidelines")
 		expect(guidelinesPos).toBeLessThan(contextPos)
 	})
 
 	it("replaces the {{SKILLS}} placeholder when no skills", () => {
-		const result = buildSubagentSystemPrompt(tools)
+		const result = buildSubagentSystemPrompt(tools, testEnv)
 		expect(result).not.toContain("{{SKILLS}}")
 	})
 
 	it("injects skills into the prompt", () => {
 		const skills = [createSkill({ name: "deploy", description: "Deploy the app" })]
-		const result = buildSubagentSystemPrompt(tools, undefined, skills)
+		const result = buildSubagentSystemPrompt(tools, testEnv, undefined, skills)
 		expect(result).toContain("available_skills")
 		expect(result).toContain("deploy")
 		expect(result).toContain("Deploy the app")
+	})
+
+	it("injects environment info into the prompt", () => {
+		const result = buildSubagentSystemPrompt(tools, testEnv)
+		expect(result).toContain("# Environment")
+		expect(result).toContain(`OS: ${testEnv.os}`)
+		expect(result).toContain(`Username: ${testEnv.username}`)
+		expect(result).toContain(`Home directory: ${testEnv.homeDir}`)
+		expect(result).toContain(`Working directory: ${testEnv.cwd}`)
+		expect(result).toContain(`Current time: ${testEnv.currentTime}`)
+	})
+
+	it("replaces the {{ENVIRONMENT}} placeholder", () => {
+		const result = buildSubagentSystemPrompt(tools, testEnv)
+		expect(result).not.toContain("{{ENVIRONMENT}}")
 	})
 })

--- a/src/extensions/orchestration/prompt-transformer/prompt-transformer.ts
+++ b/src/extensions/orchestration/prompt-transformer/prompt-transformer.ts
@@ -6,6 +6,14 @@ import systemPromptTemplate from "./prompts/orchestrator-system-prompt.js"
 import subagentSystemPromptTemplate from "./prompts/subagent-system-prompt.js"
 import userPromptTemplate from "./prompts/transformed-user-prompt.js"
 
+export interface EnvironmentInfo {
+	os: string
+	username: string
+	homeDir: string
+	cwd: string
+	currentTime: string
+}
+
 const SUBAGENT_TOOL_NAME = "subagent"
 
 function formatModel(model: OrchestrationModelDescriptor): string {
@@ -68,29 +76,35 @@ export function transformPrompt(userPrompt: string, registry: ModelRegistry, cur
 
 export function buildOrchestratorSystemPrompt(
 	tools: readonly ToolInfo[],
+	env: EnvironmentInfo,
 	contextFiles?: readonly ContextFile[],
 	skills?: readonly Skill[],
 ): string {
 	const toolsSection = formatToolsSection(tools)
+	const environmentSection = formatEnvironmentSection(env)
 	const projectContext = formatProjectContext(contextFiles)
 	const skillsSection = formatSkills(skills)
 	return systemPromptTemplate
 		.replace("{{TOOLS}}", () => toolsSection)
+		.replace("{{ENVIRONMENT}}", () => environmentSection)
 		.replace("{{PROJECT_CONTEXT}}", () => projectContext)
 		.replace("{{SKILLS}}", () => skillsSection)
 }
 
 export function buildSubagentSystemPrompt(
 	tools: readonly ToolInfo[],
+	env: EnvironmentInfo,
 	contextFiles?: readonly ContextFile[],
 	skills?: readonly Skill[],
 ): string {
 	const filtered = tools.filter((t) => t.name !== SUBAGENT_TOOL_NAME)
 	const toolsSection = formatToolsSection(filtered)
+	const environmentSection = formatEnvironmentSection(env)
 	const projectContext = formatProjectContext(contextFiles)
 	const skillsSection = formatSkills(skills)
 	return subagentSystemPromptTemplate
 		.replace("{{TOOLS}}", () => toolsSection)
+		.replace("{{ENVIRONMENT}}", () => environmentSection)
 		.replace("{{PROJECT_CONTEXT}}", () => projectContext)
 		.replace("{{SKILLS}}", () => skillsSection)
 }
@@ -98,6 +112,18 @@ export function buildSubagentSystemPrompt(
 function formatToolsSection(tools: readonly ToolInfo[]): string {
 	if (tools.length === 0) return "(No tools available)"
 	return tools.map((t) => `- ${t.name}: ${t.description}`).join("\n")
+}
+
+function formatEnvironmentSection(env: EnvironmentInfo): string {
+	return [
+		"# Environment",
+		"",
+		`- OS: ${env.os}`,
+		`- Username: ${env.username}`,
+		`- Home directory: ${env.homeDir}`,
+		`- Working directory: ${env.cwd}`,
+		`- Current time: ${env.currentTime}`,
+	].join("\n")
 }
 
 function formatProjectContext(contextFiles?: readonly ContextFile[]): string {

--- a/src/extensions/orchestration/prompt-transformer/prompt-transformer.ts
+++ b/src/extensions/orchestration/prompt-transformer/prompt-transformer.ts
@@ -12,6 +12,10 @@ export interface EnvironmentInfo {
 	homeDir: string
 	cwd: string
 	currentTime: string
+	localDate: string
+	isGitRepo: boolean
+	gitBranch?: string
+	gitRemote?: string
 }
 
 const SUBAGENT_TOOL_NAME = "subagent"
@@ -115,15 +119,19 @@ function formatToolsSection(tools: readonly ToolInfo[]): string {
 }
 
 function formatEnvironmentSection(env: EnvironmentInfo): string {
-	return [
+	const lines = [
 		"# Environment",
 		"",
 		`- OS: ${env.os}`,
 		`- Username: ${env.username}`,
-		`- Home directory: ${env.homeDir}`,
-		`- Working directory: ${env.cwd}`,
-		`- Current time: ${env.currentTime}`,
-	].join("\n")
+		`- Home directory: "${env.homeDir}"`,
+		`- Working directory: "${env.cwd}"`,
+		`- Current time: ${env.currentTime} (local date: ${env.localDate})`,
+		`- Git repository: ${env.isGitRepo ? "yes" : "no"}`,
+	]
+	if (env.gitBranch !== undefined) lines.push(`- Git branch: ${env.gitBranch}`)
+	if (env.gitRemote !== undefined) lines.push(`- Git remote: ${env.gitRemote}`)
+	return lines.join("\n")
 }
 
 function formatProjectContext(contextFiles?: readonly ContextFile[]): string {

--- a/src/extensions/orchestration/prompt-transformer/prompts/orchestrator-system-prompt.ts
+++ b/src/extensions/orchestration/prompt-transformer/prompts/orchestrator-system-prompt.ts
@@ -1,5 +1,7 @@
 export default `You are an expert coding assistant. Your available tools are listed under **Available Tools** below — use only those, never guess or invent tool names. You can also spawn subagents when delegation is more appropriate than doing the work yourself.
 
+{{ENVIRONMENT}}
+
 ## How to approach every task
 
 Before acting, reason through the following steps:

--- a/src/extensions/orchestration/prompt-transformer/prompts/subagent-system-prompt.ts
+++ b/src/extensions/orchestration/prompt-transformer/prompts/subagent-system-prompt.ts
@@ -1,5 +1,7 @@
 export default `You are an expert coding assistant. You operate inside a coding agent harness. Use only the tools listed under **Available Tools** below — never guess or invent tool names.
 
+{{ENVIRONMENT}}
+
 ## Available Tools
 
 {{TOOLS}}

--- a/src/modes/acp/server.ts
+++ b/src/modes/acp/server.ts
@@ -8,6 +8,7 @@ import {
 	type AuthenticateRequest,
 	type AuthenticateResponse,
 	type CancelNotification,
+	type ContentBlock,
 	type InitializeRequest,
 	type InitializeResponse,
 	type NewSessionRequest,
@@ -139,7 +140,7 @@ export class KimchiAcpAgent implements Agent {
 			}
 		}
 		const text = params.prompt
-			.map((b) => (b.type === "text" ? b.text : ""))
+			.map((b: ContentBlock) => (b.type === "text" ? b.text : ""))
 			.join("")
 			.trim()
 		if (!text) {
@@ -322,7 +323,7 @@ export class KimchiAcpAgent implements Agent {
 		// AgentSession event emitter, and awaiting inside it would back-pressure
 		// every subsequent event through the event loop, which pi-mono's
 		// _processAgentEvent does not expect.
-		this.conn.sessionUpdate(params).catch((err) => {
+		this.conn.sessionUpdate(params).catch((err: unknown) => {
 			process.stderr.write(`acp sessionUpdate failed: ${String(err)}\n`)
 		})
 	}
@@ -472,7 +473,7 @@ export async function runAcpMode(options: RunAcpOptions): Promise<void> {
 	const stream = ndJsonStream(writable, readable)
 
 	let agentInstance: KimchiAcpAgent | undefined
-	const conn = new AgentSideConnection((c) => {
+	const conn = new AgentSideConnection((c: AgentSideConnection) => {
 		agentInstance = new KimchiAcpAgent(c, options)
 		return agentInstance
 	}, stream)


### PR DESCRIPTION
Fixes hallucination of home directory paths by injecting factual environment metadata into both orchestrator and subagent system prompts.

## Changes

- Add `EnvironmentInfo` interface to `prompt-transformer.ts` with OS, username, home directory, working directory, and current time fields
- Inject `{{ENVIRONMENT}}` section into both system prompt templates, positioned early (right after intro) so the model has path context before any reasoning
- Map `os.type() === "Darwin"` to `"macOS"` for readable display
- Update `prompt-enrichment.ts` to collect and pass env at `before_agent_start`
- Add tests covering env injection and placeholder replacement for both prompts
- Fix implicit `any` type errors in `server.ts` and collapsed import in `cli.ts` (picked up from master merge conflicts on this branch)

## Demo
<img width="1796" height="1046" alt="2026-04-23 10 45 31" src="https://github.com/user-attachments/assets/6b9ea597-cb34-4785-98d2-03dd30b23aff" />

---
### Kimchi Summary
### What changed
Injects runtime environment details—including operating system, username, current working directory, and Git repository state (branch and remote)—into the orchestrator and subagent system prompts.

### Why
Providing the AI with explicit context about the execution environment enables more accurate path handling, shell command construction, and repository-aware assistance without requiring the model to infer these details from the conversation history.

### Key changes
- **`prompt-enrichment.ts`**: Adds `safeUsername()`, `readGitBranch()`, and `readGitRemote()` helpers to safely collect environment metadata; assembles `EnvironmentInfo` payload (OS, paths, timestamps, Git status) on agent startup and caches static values.
- **`prompt-transformer.ts`**: Introduces `EnvironmentInfo` interface and `formatEnvironmentSection()` to render the environment block; updates `buildOrchestratorSystemPrompt()` and `buildSubagentSystemPrompt()` to accept `env` parameter and replace the new `{{ENVIRONMENT}}` placeholder.
- **Prompt templates**: Adds `{{ENVIRONMENT}}` placeholder to `orchestrator-system-prompt.ts` and `subagent-system-prompt.ts` immediately after the role preamble.
- **`prompt-transformer.test.ts`**: Adds `testEnv` fixture and test coverage verifying environment section injection, Git metadata presence/absence logic, and placeholder replacement.
- **`modes/acp/server.ts`**: Adds explicit type annotations (`ContentBlock`, `unknown`, `AgentSideConnection`) to callback parameters to avoid implicit `any` types.