### PR TITLE
NOJIRA: Fix stuck subagent sessions via stdout inactivity timeout

### DIFF
--- a/src/extensions/orchestration/prompt-enrichment.ts
+++ b/src/extensions/orchestration/prompt-enrichment.ts
@@ -111,10 +111,10 @@ export default function (skillPaths: string[]) {
 				return { action: "handled" as const }
 			})
 
-			// Detect when the model made tool calls, received tool results, and is about to be
-			// called again. Some models (e.g. kimi-k2.5, minimax-m2.7) silently return an empty
-			// response in this situation instead of producing a text answer. Injecting a nudge
-			// before the follow-up call reliably prevents the empty turn.
+			// Detect when the model returned only tool calls with no text, received tool results,
+			// and is about to be called again. Some models (e.g. kimi-k2.5) silently return an
+			// empty response in this situation instead of producing a text answer. Injecting a
+			// nudge before the follow-up call reliably prevents the empty turn.
 			pi.on("context", async (event) => {
 				const messages = event.messages
 
@@ -122,7 +122,8 @@ export default function (skillPaths: string[]) {
 				if (!lastAssistant) return
 
 				const hasToolCalls = lastAssistant.content.some((c) => c.type === "toolCall")
-				if (!hasToolCalls) return
+				const hasText = lastAssistant.content.some((c) => c.type === "text")
+				if (!hasToolCalls || hasText) return
 
 				const lastAssistantIndex = messages.lastIndexOf(lastAssistant)
 				const hasToolResultsAfter = messages.slice(lastAssistantIndex + 1).some((m) => m.role === "toolResult")

--- a/src/extensions/orchestration/prompt-enrichment.ts
+++ b/src/extensions/orchestration/prompt-enrichment.ts
@@ -111,10 +111,10 @@ export default function (skillPaths: string[]) {
 				return { action: "handled" as const }
 			})
 
-			// Detect when the model returned only tool calls with no text, received tool results,
-			// and is about to be called again. Some models (e.g. kimi-k2.5) silently return an
-			// empty response in this situation instead of producing a text answer. Injecting a
-			// nudge before the follow-up call reliably prevents the empty turn.
+			// Detect when the model made tool calls, received tool results, and is about to be
+			// called again. Some models (e.g. kimi-k2.5, minimax-m2.7) silently return an empty
+			// response in this situation instead of producing a text answer. Injecting a nudge
+			// before the follow-up call reliably prevents the empty turn.
 			pi.on("context", async (event) => {
 				const messages = event.messages
 
@@ -122,8 +122,7 @@ export default function (skillPaths: string[]) {
 				if (!lastAssistant) return
 
 				const hasToolCalls = lastAssistant.content.some((c) => c.type === "toolCall")
-				const hasText = lastAssistant.content.some((c) => c.type === "text")
-				if (!hasToolCalls || hasText) return
+				if (!hasToolCalls) return
 
 				const lastAssistantIndex = messages.lastIndexOf(lastAssistant)
 				const hasToolResultsAfter = messages.slice(lastAssistantIndex + 1).some((m) => m.role === "toolResult")

--- a/src/extensions/subagent.ts
+++ b/src/extensions/subagent.ts
@@ -14,6 +14,7 @@ const PROMPT_MAX_LENGTH = 60
 const FOOTER_STATUS_KEY = "subagent-sessions"
 const STDERR_MAX = 8192
 const TIMEOUT_MS = 30 * 60 * 1000
+const INACTIVITY_TIMEOUT_MS = 60 * 1000
 const CHECKPOINT_END_TYPE = "subagent-end"
 const RECOVERY_MESSAGE_TYPE = "subagent-recovery"
 const INTERRUPTED_MESSAGE_TYPE = "subagent-interrupted"
@@ -29,7 +30,7 @@ interface SubagentState extends SpinnerState {
 	lastToolCall: string | undefined
 }
 
-type SubagentFailureReason = "exit_error" | "timeout" | "token_budget_exceeded" | "aborted"
+type SubagentFailureReason = "exit_error" | "timeout" | "token_budget_exceeded" | "aborted" | "output_stalled"
 
 interface SubagentTokenUsage {
 	input: number
@@ -294,8 +295,15 @@ function spawnSubagent(
 		let failureReason: SubagentFailureReason | undefined
 		let closed = false
 
+		let inactivityHandle = setTimeout(() => kill("output_stalled"), INACTIVITY_TIMEOUT_MS)
+		const resetInactivity = () => {
+			clearTimeout(inactivityHandle)
+			inactivityHandle = setTimeout(() => kill("output_stalled"), INACTIVITY_TIMEOUT_MS)
+		}
+
 		const finish = (exitCode: number) => {
 			clearTimeout(timeoutHandle)
+			clearTimeout(inactivityHandle)
 			combinedSignal.removeEventListener("abort", onAbort)
 			resolve({
 				exitCode,
@@ -350,6 +358,7 @@ function spawnSubagent(
 		}
 
 		proc.stdout.on("data", (data: Buffer) => {
+			resetInactivity()
 			buffer += data.toString()
 			const lines = buffer.split("\n")
 			buffer = lines.pop() ?? ""

--- a/src/extensions/subagent.ts
+++ b/src/extensions/subagent.ts
@@ -445,10 +445,12 @@ const SubagentParams = Type.Object({
 		}),
 	),
 	tokenBudget: Type.Optional(
-		Type.Integer({
+		Type.Union([
+			Type.Integer({ minimum: 1 }),
+			Type.String({ pattern: "^[1-9][0-9]*$" }),
+		], {
 			description:
 				"Maximum total tokens (input + output) the subagent may consume. Subagent is killed when exceeded. Omit unless you have an explicit reason to cap token usage — do not set this speculatively.",
-			minimum: 1,
 		}),
 	),
 })
@@ -541,11 +543,13 @@ export default function (pi: ExtensionAPI) {
 			const invocation = getSubagentInvocation(args)
 
 			let lastToolCall: string | undefined
+			const tokenBudget =
+				params.tokenBudget !== undefined ? Number(params.tokenBudget) : undefined
 			const { exitCode, accumulated, stderr, tokenUsage, failureReason, durationMs } = await spawnSubagent(
 				invocation,
 				ctx.cwd,
 				signal,
-				params.tokenBudget,
+				tokenBudget,
 				(text) => {
 					lastToolCall = undefined
 					onUpdate?.({ content: [{ type: "text", text }], details: undefined })

--- a/src/extensions/subagent.ts
+++ b/src/extensions/subagent.ts
@@ -297,6 +297,7 @@ function spawnSubagent(
 
 		let inactivityHandle = setTimeout(() => kill("output_stalled"), INACTIVITY_TIMEOUT_MS)
 		const resetInactivity = () => {
+			if (closed) return
 			clearTimeout(inactivityHandle)
 			inactivityHandle = setTimeout(() => kill("output_stalled"), INACTIVITY_TIMEOUT_MS)
 		}
@@ -366,6 +367,7 @@ function spawnSubagent(
 		})
 
 		proc.stderr.on("data", (data: Buffer) => {
+			resetInactivity()
 			stderr += data.toString()
 			if (stderr.length > STDERR_MAX) {
 				stderr = stderr.slice(0, STDERR_MAX)

--- a/src/extensions/subagent.ts
+++ b/src/extensions/subagent.ts
@@ -445,10 +445,7 @@ const SubagentParams = Type.Object({
 		}),
 	),
 	tokenBudget: Type.Optional(
-		Type.Union([
-			Type.Integer({ minimum: 1 }),
-			Type.String({ pattern: "^[1-9][0-9]*$" }),
-		], {
+		Type.Union([Type.Integer({ minimum: 1 }), Type.String({ pattern: "^[1-9][0-9]*$" })], {
 			description:
 				"Maximum total tokens (input + output) the subagent may consume. Subagent is killed when exceeded. Omit unless you have an explicit reason to cap token usage — do not set this speculatively.",
 		}),
@@ -543,8 +540,7 @@ export default function (pi: ExtensionAPI) {
 			const invocation = getSubagentInvocation(args)
 
 			let lastToolCall: string | undefined
-			const tokenBudget =
-				params.tokenBudget !== undefined ? Number(params.tokenBudget) : undefined
+			const tokenBudget = params.tokenBudget !== undefined ? Number(params.tokenBudget) : undefined
 			const { exitCode, accumulated, stderr, tokenUsage, failureReason, durationMs } = await spawnSubagent(
 				invocation,
 				ctx.cwd,


### PR DESCRIPTION
## Summary

- **Subagent stdout inactivity timeout (1 minute)**: when a subagent's LLM API stream stalls, the process produces no stdout but stays alive until the 30-minute hard timeout. A 1-minute inactivity timer (reset on any stdout byte) kills the subagent early with reason `output_stalled`, returning whatever output was already accumulated.

## Test plan

- [x] Run `research-minimax` session: a stalled subagent should be killed within ~1 minute of going silent rather than waiting 30 minutes
- [x] Verify accumulated output is preserved and returned when killed due to `output_stalled`

---
### Kimchi Summary
### What changed
Adds a 60-second inactivity timeout to subagent sessions to automatically kill processes that stop producing output. Also updates the `tokenBudget` parameter schema to accept numeric strings in addition to integers.

### Why
Prevents subagent sessions from hanging indefinitely when a process becomes unresponsive or stuck without exiting. The `tokenBudget` schema change allows the parameter to be passed as a string (e.g., from JSON configuration) while maintaining validation constraints.

### Key changes
- **`src/extensions/subagent.ts`**: Added `INACTIVITY_TIMEOUT_MS` constant (60 seconds) and `"output_stalled"` variant to `SubagentFailureReason` type
- **`src/extensions/subagent.ts`**: Implemented inactivity tracking in `spawnSubagent` with a reset timer triggered on `stdout` and `stderr` data events; kills the process with `"output_stalled"` reason if no output occurs within the timeout window
- **`src/extensions/subagent.ts`**: Updated `tokenBudget` JSON schema from `Type.Integer` to `Type.Union` of `Integer` or `String` matching regex `^[1-9][0-9]*$`
- **`src/extensions/subagent.ts`**: Added `Number(params.tokenBudget)` conversion to normalize string inputs before passing to the subagent invocation

### Impact
- Subagents that stall without producing stdout or stderr for 60 seconds will be terminated with `failureReason: "output_stalled"` instead of hanging indefinitely  
- The `tokenBudget` parameter now accepts string representations of positive integers (e.g., `"1000"`) in addition to numeric values