### PR TITLE
feat: inject User-Agent via undici dispatcher interceptor

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -24,6 +24,7 @@ import webSearchExtension from "./extensions/web-search/index.js"
 import { updateModelsConfig } from "./models.js"
 import { runSetupWizard } from "./setup-wizard.js"
 import { setAvailableModelIds } from "./startup-context.js"
+import { getVersion } from "./utils.js"
 
 const telemetryConfig = readTelemetryConfig()
 
@@ -139,9 +140,17 @@ try {
 	// Suppress Node.js warnings (same as pi-mono's own cli.js)
 	process.emitWarning = () => {}
 
-	// Set up HTTP proxy support
+	// Set up HTTP proxy support with User-Agent injection
 	const { EnvHttpProxyAgent, setGlobalDispatcher } = await import("undici")
-	setGlobalDispatcher(new EnvHttpProxyAgent())
+	const userAgent = `kimchi/${getVersion()}`
+	const agent = new EnvHttpProxyAgent()
+	setGlobalDispatcher(
+		agent.compose((dispatch) => (opts, handler) => {
+			const headers = new Headers(opts.headers as HeadersInit)
+			headers.set("user-agent", userAgent)
+			return dispatch({ ...opts, headers: Object.fromEntries(headers) }, handler)
+		}),
+	)
 
 	const extensionFactories = [
 		sessionIdCaptureExtension,

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -146,7 +146,7 @@ try {
 	const agent = new EnvHttpProxyAgent()
 	setGlobalDispatcher(
 		agent.compose((dispatch) => (opts, handler) => {
-			const headers = new Headers(opts.headers as HeadersInit)
+			const headers = new Headers((opts.headers ?? undefined) as HeadersInit)
 			headers.set("user-agent", userAgent)
 			return dispatch({ ...opts, headers: Object.fromEntries(headers) }, handler)
 		}),

--- a/src/extensions/web-fetch/page-fetcher.ts
+++ b/src/extensions/web-fetch/page-fetcher.ts
@@ -250,7 +250,6 @@ async function fetchWithNative(url: string, options?: FetchOptions): Promise<Fet
 			signal: controller.signal,
 			redirect: "follow",
 			headers: {
-				"User-Agent": "kimchi-web-fetch/0.1",
 				Accept: "text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8",
 			},
 		})

--- a/src/models.ts
+++ b/src/models.ts
@@ -45,7 +45,6 @@ function buildModelsConfig(models: string[]) {
 				apiKey: "KIMCHI_API_KEY",
 				api: "openai-completions",
 				authHeader: true,
-				headers: { "User-Agent": "kimchi/0.0.1" },
 				models: models.map((id) => ({
 					id,
 					name: modelIdToName(id),


### PR DESCRIPTION
## Summary

- Remove hardcoded `User-Agent` strings from model provider config (`src/models.ts`) and web-fetch call site (`page-fetcher.ts`)
- Inject `User-Agent: kimchi/<version>` transparently on every outgoing HTTP request via an undici `compose()` interceptor in `src/cli.ts`
- Version sourced from `getVersion()` which reads `package.json` at runtime — already patched to the git tag by `scripts/set-version.js` during release builds

## Test Plan

- [ ] All 436 tests pass
- [ ] `pnpm run build` compiles clean
- [ ] At runtime, all outgoing requests (LLM API, model listing, web-fetch) carry `User-Agent: kimchi/<version>`

---
### Kimchi Summary
### What changed
Centralizes User-Agent header injection for all outbound HTTP requests by configuring the global `undici` dispatcher, replacing hardcoded version strings with a dynamic `kimchi/<version>` identifier.

### Why
Eliminates scattered hardcoded User-Agent values that required manual updates and risked becoming stale. Ensures consistent client identification across API calls and web fetch operations.

### Key changes
- `src/cli.ts`: Imports `getVersion` and composes `EnvHttpProxyAgent` with a dispatcher that injects `kimchi/${getVersion()}` User-Agent header on every request
- `src/extensions/web-fetch/page-fetcher.ts`: Removes hardcoded `"User-Agent": "kimchi-web-fetch/0.1"` header from `fetchWithNative`
- `src/models.ts`: Removes hardcoded `"User-Agent": "kimchi/0.0.1"` header from the OpenAI completions configuration

### Impact
- All outbound HTTP requests now automatically include the correct application version in the User-Agent string
- Removes inconsistent legacy identifiers (`kimchi-web-fetch/0.1`, `kimchi/0.0.1`) in favor of a unified `kimchi/<semver>` format
- No breaking changes; downstream services receive improved, consistent client identification