### PR TITLE
LLM-1353: Add continuation nudge if the tool wasn't called

### DIFF
--- a/src/extensions/orchestration/continuation-nudge.test.ts
+++ b/src/extensions/orchestration/continuation-nudge.test.ts
@@ -1,0 +1,123 @@
+import type { AssistantMessage } from "@mariozechner/pi-ai"
+import { describe, expect, it } from "vitest"
+import { ContinuationNudge } from "./continuation-nudge.js"
+
+function makeAssistant(content: AssistantMessage["content"]): AssistantMessage {
+	return {
+		role: "assistant",
+		content,
+		api: "anthropic-messages",
+		provider: "anthropic",
+		model: "kimi-k2.5",
+		usage: {
+			input: 0,
+			output: 0,
+			cacheRead: 0,
+			cacheWrite: 0,
+			totalTokens: 0,
+			cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+		},
+		stopReason: "stop",
+		timestamp: Date.now(),
+	}
+}
+
+const textOnlyMessage = makeAssistant([{ type: "text", text: "I will delegate this to Nemotron." }])
+
+const toolCallMessage = makeAssistant([
+	{
+		type: "toolCall",
+		id: "call_1",
+		name: "subagent",
+		arguments: { provider: "kimchi-dev", model: "nemotron-3-super-fp4", prompt: "build it" },
+	},
+])
+
+const textAndToolCallMessage = makeAssistant([
+	{ type: "text", text: "Delegating now." },
+	{
+		type: "toolCall",
+		id: "call_2",
+		name: "subagent",
+		arguments: { provider: "kimchi-dev", model: "nemotron-3-super-fp4", prompt: "build it" },
+	},
+])
+
+const emptyTextMessage = makeAssistant([{ type: "text", text: "" }])
+const whitespaceTextMessage = makeAssistant([{ type: "text", text: "   \n  " }])
+
+describe("ContinuationNudge.evaluateTurn", () => {
+	it("nudges a text-only first turn after user input", () => {
+		const guard = new ContinuationNudge()
+		guard.resetForNewUserInput()
+		expect(guard.evaluateTurn(textOnlyMessage).shouldNudge).toBe(true)
+	})
+
+	it("does not nudge when the turn contains a tool call", () => {
+		const guard = new ContinuationNudge()
+		guard.resetForNewUserInput()
+		expect(guard.evaluateTurn(toolCallMessage).shouldNudge).toBe(false)
+	})
+
+	it("does not nudge when the turn has both text and a tool call", () => {
+		const guard = new ContinuationNudge()
+		guard.resetForNewUserInput()
+		expect(guard.evaluateTurn(textAndToolCallMessage).shouldNudge).toBe(false)
+	})
+
+	it("does not nudge when the turn has no text at all", () => {
+		const guard = new ContinuationNudge()
+		guard.resetForNewUserInput()
+		expect(guard.evaluateTurn(makeAssistant([])).shouldNudge).toBe(false)
+	})
+
+	it("treats empty-string text as no text", () => {
+		const guard = new ContinuationNudge()
+		guard.resetForNewUserInput()
+		expect(guard.evaluateTurn(emptyTextMessage).shouldNudge).toBe(false)
+	})
+
+	it("treats whitespace-only text as no text", () => {
+		const guard = new ContinuationNudge()
+		guard.resetForNewUserInput()
+		expect(guard.evaluateTurn(whitespaceTextMessage).shouldNudge).toBe(false)
+	})
+
+	it("nudges at most once per user-input cycle", () => {
+		const guard = new ContinuationNudge()
+		guard.resetForNewUserInput()
+		expect(guard.evaluateTurn(textOnlyMessage).shouldNudge).toBe(true)
+		expect(guard.evaluateTurn(textOnlyMessage).shouldNudge).toBe(false)
+	})
+
+	it("does not nudge when any tool has already been called this cycle", () => {
+		const guard = new ContinuationNudge()
+		guard.resetForNewUserInput()
+		guard.recordToolCall()
+		expect(guard.evaluateTurn(textOnlyMessage).shouldNudge).toBe(false)
+	})
+
+	it("re-arms after a new user input", () => {
+		const guard = new ContinuationNudge()
+		guard.resetForNewUserInput()
+		expect(guard.evaluateTurn(textOnlyMessage).shouldNudge).toBe(true)
+		guard.resetForNewUserInput()
+		expect(guard.evaluateTurn(textOnlyMessage).shouldNudge).toBe(true)
+	})
+
+	it("re-arms tool-call tracking on reset", () => {
+		const guard = new ContinuationNudge()
+		guard.resetForNewUserInput()
+		guard.recordToolCall()
+		expect(guard.evaluateTurn(textOnlyMessage).shouldNudge).toBe(false)
+		guard.resetForNewUserInput()
+		expect(guard.evaluateTurn(textOnlyMessage).shouldNudge).toBe(true)
+	})
+
+	it("ignores thinking-only turns (no text, no tool call)", () => {
+		const guard = new ContinuationNudge()
+		guard.resetForNewUserInput()
+		const thinkingOnly = makeAssistant([{ type: "thinking", thinking: "Let me reason..." }])
+		expect(guard.evaluateTurn(thinkingOnly).shouldNudge).toBe(false)
+	})
+})

--- a/src/extensions/orchestration/continuation-nudge.test.ts
+++ b/src/extensions/orchestration/continuation-nudge.test.ts
@@ -1,7 +1,11 @@
-import type { AgentMessage } from "@mariozechner/pi-agent-core"
 import type { AssistantMessage, ToolResultMessage, UserMessage } from "@mariozechner/pi-ai"
 import { describe, expect, it } from "vitest"
-import { ContinuationNudge, EMPTY_TURN_NUDGE_TEXT, buildEmptyTurnNudgedMessages } from "./continuation-nudge.js"
+import {
+	ContinuationNudge,
+	EMPTY_TURN_NUDGE_TEXT,
+	type OrchestratorMessages,
+	buildEmptyTurnNudgedMessages,
+} from "./continuation-nudge.js"
 
 function makeAssistant(content: AssistantMessage["content"]): AssistantMessage {
 	return {
@@ -138,7 +142,7 @@ function makeToolResult(toolCallId: string, text: string): ToolResultMessage {
 	}
 }
 
-function lastMessage(messages: AgentMessage[]): AgentMessage {
+function lastMessage(messages: OrchestratorMessages): OrchestratorMessages[number] {
 	return messages[messages.length - 1]
 }
 
@@ -148,32 +152,32 @@ describe("buildEmptyTurnNudgedMessages", () => {
 	})
 
 	it("returns undefined when the last assistant message has text", () => {
-		const messages: AgentMessage[] = [makeUser("q"), textOnlyMessage]
+		const messages: OrchestratorMessages = [makeUser("q"), textOnlyMessage]
 		expect(buildEmptyTurnNudgedMessages(messages)).toBeUndefined()
 	})
 
 	it("returns undefined when the last assistant message has both text and a tool call", () => {
-		const messages: AgentMessage[] = [makeUser("q"), textAndToolCallMessage, makeToolResult("call_2", "ok")]
+		const messages: OrchestratorMessages = [makeUser("q"), textAndToolCallMessage, makeToolResult("call_2", "ok")]
 		expect(buildEmptyTurnNudgedMessages(messages)).toBeUndefined()
 	})
 
 	it("returns undefined when tool calls are present but no tool results have arrived yet", () => {
-		const messages: AgentMessage[] = [makeUser("q"), toolCallMessage]
+		const messages: OrchestratorMessages = [makeUser("q"), toolCallMessage]
 		expect(buildEmptyTurnNudgedMessages(messages)).toBeUndefined()
 	})
 
 	it("appends a user-role nudge when tool-call-only assistant is followed by tool results", () => {
-		const messages: AgentMessage[] = [makeUser("q"), toolCallMessage, makeToolResult("call_1", "done")]
+		const messages: OrchestratorMessages = [makeUser("q"), toolCallMessage, makeToolResult("call_1", "done")]
 		const nudged = buildEmptyTurnNudgedMessages(messages)
 		expect(nudged).toBeDefined()
 		expect(nudged?.length).toBe(messages.length + 1)
-		const appended = lastMessage(nudged as AgentMessage[])
+		const appended = lastMessage(nudged as OrchestratorMessages)
 		expect(appended.role).toBe("user")
 		expect((appended as UserMessage).content).toEqual([{ type: "text", text: EMPTY_TURN_NUDGE_TEXT }])
 	})
 
 	it("does not mutate the caller's messages array", () => {
-		const messages: AgentMessage[] = [makeUser("q"), toolCallMessage, makeToolResult("call_1", "done")]
+		const messages: OrchestratorMessages = [makeUser("q"), toolCallMessage, makeToolResult("call_1", "done")]
 		const originalLength = messages.length
 		buildEmptyTurnNudgedMessages(messages)
 		expect(messages.length).toBe(originalLength)
@@ -181,7 +185,7 @@ describe("buildEmptyTurnNudgedMessages", () => {
 
 	it("uses the most recent assistant message (ignores older ones)", () => {
 		// An earlier text-only assistant turn should not disqualify a later tool-call-only drift.
-		const messages: AgentMessage[] = [
+		const messages: OrchestratorMessages = [
 			makeUser("q1"),
 			textOnlyMessage,
 			makeUser("q2"),

--- a/src/extensions/orchestration/continuation-nudge.test.ts
+++ b/src/extensions/orchestration/continuation-nudge.test.ts
@@ -1,6 +1,7 @@
-import type { AssistantMessage } from "@mariozechner/pi-ai"
+import type { AgentMessage } from "@mariozechner/pi-agent-core"
+import type { AssistantMessage, ToolResultMessage, UserMessage } from "@mariozechner/pi-ai"
 import { describe, expect, it } from "vitest"
-import { ContinuationNudge } from "./continuation-nudge.js"
+import { ContinuationNudge, EMPTY_TURN_NUDGE_TEXT, buildEmptyTurnNudgedMessages } from "./continuation-nudge.js"
 
 function makeAssistant(content: AssistantMessage["content"]): AssistantMessage {
 	return {
@@ -119,5 +120,74 @@ describe("ContinuationNudge.evaluateTurn", () => {
 		guard.resetForNewUserInput()
 		const thinkingOnly = makeAssistant([{ type: "thinking", thinking: "Let me reason..." }])
 		expect(guard.evaluateTurn(thinkingOnly).shouldNudge).toBe(false)
+	})
+})
+
+function makeUser(text: string): UserMessage {
+	return { role: "user", content: [{ type: "text", text }], timestamp: Date.now() }
+}
+
+function makeToolResult(toolCallId: string, text: string): ToolResultMessage {
+	return {
+		role: "toolResult",
+		toolCallId,
+		toolName: "subagent",
+		content: [{ type: "text", text }],
+		isError: false,
+		timestamp: Date.now(),
+	}
+}
+
+function lastMessage(messages: AgentMessage[]): AgentMessage {
+	return messages[messages.length - 1]
+}
+
+describe("buildEmptyTurnNudgedMessages", () => {
+	it("returns undefined when there is no assistant message yet", () => {
+		expect(buildEmptyTurnNudgedMessages([makeUser("start")])).toBeUndefined()
+	})
+
+	it("returns undefined when the last assistant message has text", () => {
+		const messages: AgentMessage[] = [makeUser("q"), textOnlyMessage]
+		expect(buildEmptyTurnNudgedMessages(messages)).toBeUndefined()
+	})
+
+	it("returns undefined when the last assistant message has both text and a tool call", () => {
+		const messages: AgentMessage[] = [makeUser("q"), textAndToolCallMessage, makeToolResult("call_2", "ok")]
+		expect(buildEmptyTurnNudgedMessages(messages)).toBeUndefined()
+	})
+
+	it("returns undefined when tool calls are present but no tool results have arrived yet", () => {
+		const messages: AgentMessage[] = [makeUser("q"), toolCallMessage]
+		expect(buildEmptyTurnNudgedMessages(messages)).toBeUndefined()
+	})
+
+	it("appends a user-role nudge when tool-call-only assistant is followed by tool results", () => {
+		const messages: AgentMessage[] = [makeUser("q"), toolCallMessage, makeToolResult("call_1", "done")]
+		const nudged = buildEmptyTurnNudgedMessages(messages)
+		expect(nudged).toBeDefined()
+		expect(nudged?.length).toBe(messages.length + 1)
+		const appended = lastMessage(nudged as AgentMessage[])
+		expect(appended.role).toBe("user")
+		expect((appended as UserMessage).content).toEqual([{ type: "text", text: EMPTY_TURN_NUDGE_TEXT }])
+	})
+
+	it("does not mutate the caller's messages array", () => {
+		const messages: AgentMessage[] = [makeUser("q"), toolCallMessage, makeToolResult("call_1", "done")]
+		const originalLength = messages.length
+		buildEmptyTurnNudgedMessages(messages)
+		expect(messages.length).toBe(originalLength)
+	})
+
+	it("uses the most recent assistant message (ignores older ones)", () => {
+		// An earlier text-only assistant turn should not disqualify a later tool-call-only drift.
+		const messages: AgentMessage[] = [
+			makeUser("q1"),
+			textOnlyMessage,
+			makeUser("q2"),
+			toolCallMessage,
+			makeToolResult("call_1", "done"),
+		]
+		expect(buildEmptyTurnNudgedMessages(messages)).toBeDefined()
 	})
 })

--- a/src/extensions/orchestration/continuation-nudge.ts
+++ b/src/extensions/orchestration/continuation-nudge.ts
@@ -1,0 +1,45 @@
+import type { AssistantMessage } from "@mariozechner/pi-ai"
+
+export const CONTINUATION_NUDGE_TEXT =
+	"You ended your turn without calling a tool. If the task is complete, reply with a brief summary. Otherwise, call the appropriate tool now — for any delegated pipeline step, that means invoking the `subagent` tool immediately."
+
+export interface NudgeDecision {
+	shouldNudge: boolean
+}
+
+/**
+ * State machine for the orchestrator "text-only drift" nudge.
+ *
+ * Detects the failure mode where the orchestrator reasons through the
+ * self-assessment in prose, announces it will delegate, and then ends its
+ * turn without emitting the `subagent` tool call. Documented for kimi-k2.5
+ * and other models with unreliable native tool-calling; mirrors the
+ * `on_continue` pattern used by AISI Inspect's ReAct agent.
+ *
+ * Fires at most once per user-input cycle, and only when no tool has been
+ * called during that cycle — so legitimate end-of-task summaries after a
+ * completed tool sequence are not nudged.
+ */
+export class ContinuationNudge {
+	private toolsCalledSinceLastUserInput = false
+	private nudgedSinceLastUserInput = false
+
+	resetForNewUserInput(): void {
+		this.toolsCalledSinceLastUserInput = false
+		this.nudgedSinceLastUserInput = false
+	}
+
+	recordToolCall(): void {
+		this.toolsCalledSinceLastUserInput = true
+	}
+
+	evaluateTurn(message: AssistantMessage): NudgeDecision {
+		if (this.nudgedSinceLastUserInput) return { shouldNudge: false }
+		if (this.toolsCalledSinceLastUserInput) return { shouldNudge: false }
+		const hasToolCalls = message.content.some((c) => c.type === "toolCall")
+		const hasText = message.content.some((c) => c.type === "text" && c.text.trim().length > 0)
+		if (hasToolCalls || !hasText) return { shouldNudge: false }
+		this.nudgedSinceLastUserInput = true
+		return { shouldNudge: true }
+	}
+}

--- a/src/extensions/orchestration/continuation-nudge.ts
+++ b/src/extensions/orchestration/continuation-nudge.ts
@@ -1,20 +1,40 @@
+/**
+ * Two complementary workarounds for Kimi K2.x tool-calling quirks that each
+ * leave the agent loop in a stuck-looking state. Both targets the same failure
+ * class (model said one thing, didn't follow through in the next tool-use
+ * step) but on opposite sides of the loop lifecycle:
+ *
+ *   1. `ContinuationNudge` — post-turn. The orchestrator reasons through the
+ *      self-assessment in prose, announces it will delegate, and ends its
+ *      turn without emitting the `subagent` tool call. Without a nudge the
+ *      agent loop exits and the user has to re-prompt ("is it completed?").
+ *      Mirrors AISI Inspect's `on_continue` parameter.
+ *
+ *   2. `buildEmptyTurnNudgedMessages` — pre-LLM-call. The model returned a
+ *      tool-call-only response (no text), tool results are queued, and it
+ *      is about to be called again. Some Kimi deployments return an empty
+ *      response on this specific follow-up. Injecting a user-role nudge
+ *      into the context reliably prevents the empty turn.
+ *
+ * Both are orchestrator-only concerns — they are wired in
+ * `prompt-enrichment.ts` inside the `if (!subagentMode)` guard.
+ */
+
+import type { AgentMessage } from "@mariozechner/pi-agent-core"
 import type { AssistantMessage } from "@mariozechner/pi-ai"
 
 export const CONTINUATION_NUDGE_TEXT =
 	"You ended your turn without calling a tool. If the task is complete, reply with a brief summary. Otherwise, call the appropriate tool now — for any delegated pipeline step, that means invoking the `subagent` tool immediately."
+
+export const EMPTY_TURN_NUDGE_TEXT =
+	"If you have finished, please summarize the result for the user. Otherwise, continue with the next tool call."
 
 export interface NudgeDecision {
 	shouldNudge: boolean
 }
 
 /**
- * State machine for the orchestrator "text-only drift" nudge.
- *
- * Detects the failure mode where the orchestrator reasons through the
- * self-assessment in prose, announces it will delegate, and then ends its
- * turn without emitting the `subagent` tool call. Documented for kimi-k2.5
- * and other models with unreliable native tool-calling; mirrors the
- * `on_continue` pattern used by AISI Inspect's ReAct agent.
+ * Post-turn state machine for the "text-only drift" nudge.
  *
  * Fires at most once per user-input cycle, and only when no tool has been
  * called during that cycle — so legitimate end-of-task summaries after a
@@ -42,4 +62,35 @@ export class ContinuationNudge {
 		this.nudgedSinceLastUserInput = true
 		return { shouldNudge: true }
 	}
+}
+
+/**
+ * Pre-LLM-call nudge for the "tool-call-only assistant, tool results pending"
+ * pattern. Returns a new messages array with a user-role nudge appended if
+ * the pattern matches, otherwise `undefined` (signal for the caller to leave
+ * the context untouched).
+ *
+ * Stateless by design — every decision is computable from the messages array
+ * alone, which also makes it trivial to unit test.
+ */
+export function buildEmptyTurnNudgedMessages(messages: AgentMessage[]): AgentMessage[] | undefined {
+	const lastAssistant = [...messages].reverse().find((m): m is AssistantMessage => m.role === "assistant")
+	if (!lastAssistant) return undefined
+
+	const hasToolCalls = lastAssistant.content.some((c) => c.type === "toolCall")
+	const hasText = lastAssistant.content.some((c) => c.type === "text")
+	if (!hasToolCalls || hasText) return undefined
+
+	const lastAssistantIndex = messages.lastIndexOf(lastAssistant)
+	const hasToolResultsAfter = messages.slice(lastAssistantIndex + 1).some((m) => m.role === "toolResult")
+	if (!hasToolResultsAfter) return undefined
+
+	return [
+		...messages,
+		{
+			role: "user" as const,
+			content: [{ type: "text" as const, text: EMPTY_TURN_NUDGE_TEXT }],
+			timestamp: Date.now(),
+		},
+	]
 }

--- a/src/extensions/orchestration/continuation-nudge.ts
+++ b/src/extensions/orchestration/continuation-nudge.ts
@@ -20,8 +20,16 @@
  * `prompt-enrichment.ts` inside the `if (!subagentMode)` guard.
  */
 
-import type { AgentMessage } from "@mariozechner/pi-agent-core"
 import type { AssistantMessage } from "@mariozechner/pi-ai"
+import type { ContextEvent } from "@mariozechner/pi-coding-agent"
+
+/**
+ * Message-array shape passed through `context` events. Derived from
+ * `ContextEvent` because `AgentMessage` lives in `@mariozechner/pi-agent-core`,
+ * which is only a transitive dep — importing it directly works under npm's
+ * flat install but breaks under pnpm's strict resolution (and thus CI).
+ */
+export type OrchestratorMessages = ContextEvent["messages"]
 
 export const CONTINUATION_NUDGE_TEXT =
 	"You ended your turn without calling a tool. If the task is complete, reply with a brief summary. Otherwise, call the appropriate tool now — for any delegated pipeline step, that means invoking the `subagent` tool immediately."
@@ -73,7 +81,7 @@ export class ContinuationNudge {
  * Stateless by design — every decision is computable from the messages array
  * alone, which also makes it trivial to unit test.
  */
-export function buildEmptyTurnNudgedMessages(messages: AgentMessage[]): AgentMessage[] | undefined {
+export function buildEmptyTurnNudgedMessages(messages: OrchestratorMessages): OrchestratorMessages | undefined {
 	const lastAssistant = [...messages].reverse().find((m): m is AssistantMessage => m.role === "assistant")
 	if (!lastAssistant) return undefined
 

--- a/src/extensions/orchestration/prompt-enrichment.ts
+++ b/src/extensions/orchestration/prompt-enrichment.ts
@@ -22,11 +22,11 @@
 
 import { homedir } from "node:os"
 import { isAbsolute, join, normalize, resolve } from "node:path"
-import type { AssistantMessage, ImageContent, TextContent } from "@mariozechner/pi-ai"
+import type { ImageContent, TextContent } from "@mariozechner/pi-ai"
 import { type ExtensionAPI, type Skill, loadSkills } from "@mariozechner/pi-coding-agent"
 import { ANSI, fg } from "../../ansi.js"
 import { getAvailableModelIds } from "../../startup-context.js"
-import { CONTINUATION_NUDGE_TEXT, ContinuationNudge } from "./continuation-nudge.js"
+import { CONTINUATION_NUDGE_TEXT, ContinuationNudge, buildEmptyTurnNudgedMessages } from "./continuation-nudge.js"
 import { ModelRegistry } from "./model-registry/index.js"
 import { type ContextFile, loadProjectContextFiles } from "./prompt-transformer/context-files.js"
 import {
@@ -140,39 +140,14 @@ export default function (skillPaths: string[]) {
 				return { action: "handled" as const }
 			})
 
-			// Detect when the model returned only tool calls with no text, received tool results,
-			// and is about to be called again. Some models (e.g. kimi-k2.5) silently return an
-			// empty response in this situation instead of producing a text answer. Injecting a
-			// nudge before the follow-up call reliably prevents the empty turn.
+			// Pre-LLM-call complement of the turn_end nudge above: the model returned only
+			// tool calls with no text, tool results are queued, and it is about to be
+			// called again. Some Kimi deployments return an empty response on this specific
+			// follow-up; a user-role nudge injected into the context reliably prevents it.
 			pi.on("context", async (event) => {
-				const messages = event.messages
-
-				const lastAssistant = [...messages].reverse().find((m): m is AssistantMessage => m.role === "assistant")
-				if (!lastAssistant) return
-
-				const hasToolCalls = lastAssistant.content.some((c) => c.type === "toolCall")
-				const hasText = lastAssistant.content.some((c) => c.type === "text")
-				if (!hasToolCalls || hasText) return
-
-				const lastAssistantIndex = messages.lastIndexOf(lastAssistant)
-				const hasToolResultsAfter = messages.slice(lastAssistantIndex + 1).some((m) => m.role === "toolResult")
-				if (!hasToolResultsAfter) return
-
-				return {
-					messages: [
-						...messages,
-						{
-							role: "user" as const,
-							content: [
-								{
-									type: "text" as const,
-									text: "If you have finished, please summarize the result for the user. Otherwise, continue with the next tool call.",
-								},
-							],
-							timestamp: Date.now(),
-						},
-					],
-				}
+				const nudged = buildEmptyTurnNudgedMessages(event.messages)
+				if (!nudged) return
+				return { messages: nudged }
 			})
 		}
 

--- a/src/extensions/orchestration/prompt-enrichment.ts
+++ b/src/extensions/orchestration/prompt-enrichment.ts
@@ -26,6 +26,7 @@ import type { AssistantMessage, ImageContent, TextContent } from "@mariozechner/
 import { type ExtensionAPI, type Skill, loadSkills } from "@mariozechner/pi-coding-agent"
 import { ANSI, fg } from "../../ansi.js"
 import { getAvailableModelIds } from "../../startup-context.js"
+import { CONTINUATION_NUDGE_TEXT, ContinuationNudge } from "./continuation-nudge.js"
 import { ModelRegistry } from "./model-registry/index.js"
 import { type ContextFile, loadProjectContextFiles } from "./prompt-transformer/context-files.js"
 import {
@@ -73,6 +74,34 @@ export default function (skillPaths: string[]) {
 					`${fg(ANSI.accent, ` New model available: "kimchi-dev/${warning.modelId}"`)}\n${fg(ANSI.dim, " Update the app or add the new model to model capabilities config to unlock orchestration support.")}`,
 				)
 			}
+
+			// Detect the inverse of the context-event nudge below: the orchestrator reasons
+			// in prose, announces it will delegate, and ends its turn without emitting the
+			// `subagent` tool call. The agent loop would otherwise exit and wait for another
+			// user prompt. Nudge once per user-input cycle, and only when no tool has fired
+			// that cycle — so genuine end-of-task summaries are left alone. Mirrors AISI
+			// Inspect's `on_continue`.
+			//
+			// The reset handler is registered BEFORE the enrichment handler below because
+			// that one returns `{action: "handled"}` in interactive mode, which short-
+			// circuits the input-handler chain.
+			const continuationNudge = new ContinuationNudge()
+
+			pi.on("input", async (event) => {
+				if (event.source === "extension") return
+				continuationNudge.resetForNewUserInput()
+			})
+
+			pi.on("tool_execution_start", async () => {
+				continuationNudge.recordToolCall()
+			})
+
+			pi.on("turn_end", async (event) => {
+				if (event.message.role !== "assistant") return
+				const { shouldNudge } = continuationNudge.evaluateTurn(event.message)
+				if (!shouldNudge) return
+				pi.sendUserMessage(CONTINUATION_NUDGE_TEXT)
+			})
 
 			pi.on("input", async (event, ctx) => {
 				if (event.source === "extension") {


### PR DESCRIPTION


---
### Kimchi Summary
### What changed
Add dual nudge mechanisms to prevent Kimi K2.x agent loop stalls: a post-turn guard detects when the model ends with text-only promises to delegate without calling tools, and a pre-call guard injects context when tool-call-only turns risk empty follow-up responses.

### Why
Kimi K2.x exhibits two stuck states: (1) the orchestrator announces delegation in prose but omits the `subagent` tool call, exiting the loop prematurely, and (2) after tool-call-only turns with pending results, the model returns empty responses. These workarounds mirror AISI Inspect's `on_continue` to maintain flow without user re-prompting.

### Key changes
- **`src/extensions/orchestration/continuation-nudge.ts`**: Add `ContinuationNudge` class for post-turn drift detection and `buildEmptyTurnNudgedMessages` for pre-LLM-call context injection; export `CONTINUATION_NUDGE_TEXT` and `EMPTY_TURN_NUDGE_TEXT` constants and `OrchestratorMessages` type.
- **`src/extensions/orchestration/continuation-nudge.test.ts`**: Add unit tests covering text-only detection, tool call tracking, whitespace handling, cycle resets, and message array immutability.
- **`src/extensions/orchestration/prompt-enrichment.ts`**: Integrate `ContinuationNudge` via `input`, `tool_execution_start`, and `turn_end` event handlers; refactor `context` event handler to use `buildEmptyTurnNudgedMessages`.

### Impact
- **Behavior**: Automatic recovery from Kimi K2.x stuck states without user intervention.
- **Safety**: Nudges fire at most once per user-input cycle and only when specific drift patterns are detected.
- **Testing**: Full unit test coverage for state machine logic.