### PR TITLE
LLM-1374: resolve models from API

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,14 +33,9 @@ kimchi-code stores its own configuration (settings, sessions, models) under:
 
 ### Models
 
-The following models are available through kimchi-dev:
+The supported model list is fetched at startup from the kimchi metadata service.
 
-- `kimi-k2.5` — Kimi K2.5
-- `glm-5-fp8` — GLM 5 FP8
-- `minimax-m2.7` — Minimax M2.7
-- `nemotron-3-super-fp4` - Nemotron-3 Super FP4
-
-A default `models.json` is created automatically on first run at `~/.config/kimchi/harness/models.json`. You can edit this file to customize model settings.
+Use `/model` in the interactive CLI to switch between available models.
 
 ### HTTP proxy
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -25,7 +25,7 @@ import webFetchExtension from "./extensions/web-fetch/index.js"
 import webSearchExtension from "./extensions/web-search/index.js"
 import { updateModelsConfig } from "./models.js"
 import { runSetupWizard } from "./setup-wizard.js"
-import { setAvailableModelIds } from "./startup-context.js"
+import { setAvailableModels } from "./startup-context.js"
 import { getVersion } from "./utils.js"
 
 const telemetryConfig = readTelemetryConfig()
@@ -105,10 +105,7 @@ try {
 		throw new Error("KIMCHI_CODING_AGENT_DIR is not set; cli.ts must be entered via entry.ts")
 	}
 	const modelsJsonPath = resolve(agentDir, "models.json")
-	const modelsResult = await updateModelsConfig(modelsJsonPath, config.apiKey)
-	if (modelsResult.source === "default") {
-		console.error(`Warning: using default models (${modelsResult.error})`)
-	}
+	const { models } = await updateModelsConfig(modelsJsonPath, config.apiKey)
 
 	// Must run before main() so the keybindings file is loaded with the
 	// override in place.
@@ -116,7 +113,7 @@ try {
 
 	// Share the discovered model IDs with extensions before main() runs.
 	// prompt-enrichment reads this to build ModelRegistry with live model IDs.
-	setAvailableModelIds(modelsResult.models)
+	setAvailableModels(models)
 
 	// Write default settings on first run only — respect user's choices afterward
 	const settingsPath = resolve(agentDir, "settings.json")

--- a/src/extensions/orchestration/model-registry/builtin-models.ts
+++ b/src/extensions/orchestration/model-registry/builtin-models.ts
@@ -36,6 +36,11 @@ can ingest entire large codebases in a single pass. \
 Weakest at coding; not reliable for complex multi-file changes. \
 Best for codebase exploration, research, and simple well-defined tasks.`
 
+const CLAUDE_OPUS_47_DESCRIPTION = `\
+Anthropic's flagship Claude model. Strongest general reasoning, planning, and vision support. \
+Best for complex multi-step tasks requiring deep research and exploration across large codebases.`
+
+// TODO: these capabilities could be returned by our models metadata API.
 /**
  * Capability knowledge-base keyed by model ID. Used to enrich the dynamic
  * model list from the API with orchestration metadata (tier, strengths,
@@ -76,6 +81,18 @@ export const MODEL_CAPABILITIES: ReadonlyMap<string, ModelCapabilities | "ignore
 			description: NEMOTRON_3_SUPER_DESCRIPTION,
 		},
 	],
+	[
+		"claude-opus-4-7",
+		{
+			vision: true,
+			strengths: ["explore", "research", "plan", "review"],
+			tier: "heavy",
+			description: CLAUDE_OPUS_47_DESCRIPTION,
+		},
+	],
 	["glm-5-fp8", "ignored"],
 	["minimax-m2.5", "ignored"],
+	["claude-opus-4-6", "ignored"],
+	["claude-sonnet-4-6", "ignored"],
+	["claude-sonnet-4-5", "ignored"],
 ])

--- a/src/extensions/orchestration/model-registry/model-registry.test.ts
+++ b/src/extensions/orchestration/model-registry/model-registry.test.ts
@@ -1,55 +1,86 @@
 import { describe, expect, it } from "vitest"
+import type { ModelMetadata } from "../../../models.js"
 import { MODEL_CAPABILITIES } from "./builtin-models.js"
 import { ModelRegistry } from "./model-registry.js"
 
 const KNOWN_IDS = [...MODEL_CAPABILITIES.keys()]
 const ACTIVE_IDS = KNOWN_IDS.filter((id) => MODEL_CAPABILITIES.get(id) !== "ignored")
 
+function metadata(slug: string, overrides: Partial<ModelMetadata> = {}): ModelMetadata {
+	return {
+		slug,
+		display_name: "",
+		description: "",
+		provider: "ai-enabler",
+		tool_call: true,
+		reasoning: false,
+		input_modalities: ["text"],
+		is_serverless: true,
+		limits: { context_window: 131072, max_output_tokens: 16384 },
+		...overrides,
+	}
+}
+
+const KNOWN_METADATA = KNOWN_IDS.map((id) => metadata(id))
+const ACTIVE_METADATA = ACTIVE_IDS.map((id) => metadata(id))
+
 describe("ModelRegistry — known models only", () => {
 	it("returns all active (non-ignored) models when all are available in the API", () => {
-		const registry = new ModelRegistry(KNOWN_IDS)
-		expect(registry.getAll()).toHaveLength(ACTIVE_IDS.length)
-		expect(registry.getModelsWithCapabilities()).toHaveLength(ACTIVE_IDS.length)
+		const registry = new ModelRegistry(KNOWN_METADATA)
+		expect(registry.getAll()).toHaveLength(ACTIVE_METADATA.length)
+		expect(registry.getModelsWithCapabilities()).toHaveLength(ACTIVE_METADATA.length)
 		expect(registry.warnings).toHaveLength(0)
 	})
 
 	it("getAll() preserves the API order, excluding ignored models", () => {
-		const ids = [...KNOWN_IDS].reverse()
-		const registry = new ModelRegistry(ids)
+		const reversed = [...KNOWN_METADATA].reverse()
+		const registry = new ModelRegistry(reversed)
 		expect(registry.getAll().map((m) => m.id)).toEqual([...ACTIVE_IDS].reverse())
 	})
 
 	it("every known model has a non-placeholder description", () => {
-		const registry = new ModelRegistry(KNOWN_IDS)
+		const registry = new ModelRegistry(KNOWN_METADATA)
 		for (const model of registry.getModelsWithCapabilities()) {
 			expect(model.capabilities.description).not.toBe("TODO")
 			expect(model.capabilities.description.length).toBeGreaterThan(50)
 		}
 	})
+
+	it("uses display_name from metadata when non-empty", () => {
+		const id = ACTIVE_IDS[0]
+		const registry = new ModelRegistry([metadata(id, { display_name: "Custom Label" })])
+		expect(registry.getAll()[0].name).toBe("Custom Label")
+	})
+
+	it("falls back to derived name when display_name is empty", () => {
+		const id = ACTIVE_IDS[0]
+		const registry = new ModelRegistry([metadata(id, { display_name: "" })])
+		expect(registry.getAll()[0].name.length).toBeGreaterThan(0)
+	})
 })
 
 describe("ModelRegistry — unknown model in API", () => {
 	it("includes the unknown model in getAll() with a generic descriptor", () => {
-		const registry = new ModelRegistry([...KNOWN_IDS, "brand-new-model"])
+		const registry = new ModelRegistry([...KNOWN_METADATA, metadata("brand-new-model")])
 		const unknown = registry.getAll().find((m) => m.id === "brand-new-model")
 		expect(unknown).toBeDefined()
 		expect(unknown?.capabilities.description).toContain("No capability information")
 	})
 
 	it("emits a warning for the unknown model", () => {
-		const registry = new ModelRegistry([...KNOWN_IDS, "brand-new-model"])
+		const registry = new ModelRegistry([...KNOWN_METADATA, metadata("brand-new-model")])
 		const warning = registry.warnings.find((w) => w.modelId === "brand-new-model")
 		expect(warning).toBeDefined()
 		expect(warning?.modelId).toBe("brand-new-model")
 	})
 
 	it("excludes the unknown model from getModelsWithCapabilities()", () => {
-		const registry = new ModelRegistry([...KNOWN_IDS, "brand-new-model"])
+		const registry = new ModelRegistry([...KNOWN_METADATA, metadata("brand-new-model")])
 		expect(registry.getModelsWithCapabilities().map((m) => m.id)).not.toContain("brand-new-model")
 	})
 
 	it("emits an unknown_model warning", () => {
-		const registry = new ModelRegistry([...KNOWN_IDS, "brand-new-model"])
+		const registry = new ModelRegistry([...KNOWN_METADATA, metadata("brand-new-model")])
 		const warning = registry.warnings.find((w) => w.modelId === "brand-new-model")
 		expect(warning).toBeDefined()
 		expect(warning?.kind).toBe("unknown_model")
@@ -59,14 +90,14 @@ describe("ModelRegistry — unknown model in API", () => {
 describe("ModelRegistry — orphaned capability entry", () => {
 	it("excludes the orphaned model from both getAll() and getModelsWithCapabilities()", () => {
 		const presentId = ACTIVE_IDS[0]
-		const registry = new ModelRegistry([presentId])
+		const registry = new ModelRegistry([metadata(presentId)])
 		expect(registry.getAll().map((m) => m.id)).toEqual([presentId])
 		expect(registry.getModelsWithCapabilities().map((m) => m.id)).toEqual([presentId])
 	})
 
 	it("does not emit any warning for capability entries absent from the API", () => {
 		const presentId = ACTIVE_IDS[0]
-		const registry = new ModelRegistry([presentId])
+		const registry = new ModelRegistry([metadata(presentId)])
 		expect(registry.warnings).toHaveLength(0)
 	})
 })
@@ -74,21 +105,21 @@ describe("ModelRegistry — orphaned capability entry", () => {
 describe("ModelRegistry — ignored models", () => {
 	it("excludes ignored models from getAll() and getModelsWithCapabilities()", () => {
 		const ignoredIds = KNOWN_IDS.filter((id) => MODEL_CAPABILITIES.get(id) === "ignored")
-		const registry = new ModelRegistry(ignoredIds)
+		const registry = new ModelRegistry(ignoredIds.map((id) => metadata(id)))
 		expect(registry.getAll()).toHaveLength(0)
 		expect(registry.getModelsWithCapabilities()).toHaveLength(0)
 	})
 
 	it("does not emit warnings for ignored models", () => {
 		const ignoredIds = KNOWN_IDS.filter((id) => MODEL_CAPABILITIES.get(id) === "ignored")
-		const registry = new ModelRegistry(ignoredIds)
+		const registry = new ModelRegistry(ignoredIds.map((id) => metadata(id)))
 		expect(registry.warnings).toHaveLength(0)
 	})
 })
 
 describe("ModelRegistry — getModelsWithCapabilities()", () => {
 	it("is the intersection of API models and capability map, excluding ignored", () => {
-		const registry = new ModelRegistry([...KNOWN_IDS, "unknown-extra"])
+		const registry = new ModelRegistry([...KNOWN_METADATA, metadata("unknown-extra")])
 		expect(registry.getModelsWithCapabilities().map((m) => m.id)).toEqual(expect.arrayContaining(ACTIVE_IDS))
 		expect(registry.getModelsWithCapabilities().map((m) => m.id)).not.toContain("unknown-extra")
 	})

--- a/src/extensions/orchestration/model-registry/model-registry.test.ts
+++ b/src/extensions/orchestration/model-registry/model-registry.test.ts
@@ -10,9 +10,7 @@ function metadata(slug: string, overrides: Partial<ModelMetadata> = {}): ModelMe
 	return {
 		slug,
 		display_name: "",
-		description: "",
 		provider: "ai-enabler",
-		tool_call: true,
 		reasoning: false,
 		input_modalities: ["text"],
 		is_serverless: true,

--- a/src/extensions/orchestration/model-registry/model-registry.ts
+++ b/src/extensions/orchestration/model-registry/model-registry.ts
@@ -4,22 +4,23 @@
  * (capabilities, strengths) so the Orchestrator LLM can make routing decisions.
  *
  * The registry is built from two sources:
- *   1. availableModelIds — the live model list fetched from the API at startup.
- *      This is the source of truth for which models actually exist and can be called.
- *   2. MODEL_CAPABILITIES — a local knowledge-base of curated orchestration metadata
- *      (tier, strengths, vision, description) keyed by model ID.
+ *   1. availableModels — the live metadata list fetched from the API at
+ *      startup. This is the source of truth for which models actually exist
+ *      and can be called.
+ *   2. MODEL_CAPABILITIES — a local knowledge-base of curated orchestration
+ *      metadata (tier, strengths, vision, description) keyed by model slug.
  *
  * Merging rules:
- *   - A model in the API with a capability entry → full OrchestrationModelDescriptor.
- *   - A model in the API without a capability entry → generic descriptor + startup notice.
- *   - A model in the capability map but absent from the API → silently excluded from
- *     routing (it cannot be called).
- *
- * Models with capabilities = intersection of availableModelIds ∩ MODEL_CAPABILITIES keys.
- * Subagent pool           = models with capabilities, excluding the current orchestrator.
- * Orchestrator self-lookup = all models from the API (including unknown ones).
+ *   - A model in the API with a capability entry → full descriptor.
+ *   - A model in the API without a capability entry → generic descriptor +
+ *     startup notice.
+ *   - A model marked "ignored" in MODEL_CAPABILITIES → excluded silently
+ *     (does not route, does not warn).
+ *   - A model in the capability map but absent from the API → silently
+ *     excluded from routing (it cannot be called).
  */
 
+import type { ModelMetadata } from "../../../models.js"
 import { MODEL_CAPABILITIES } from "./builtin-models.js"
 import type { ModelCapabilities, OrchestrationModelDescriptor } from "./types.js"
 
@@ -39,59 +40,57 @@ function modelIdToName(id: string): string {
 		.join(" ")
 }
 
+function deriveName(m: ModelMetadata): string {
+	return m.display_name.trim().length > 0 ? m.display_name : modelIdToName(m.slug)
+}
+
 export interface ModelRegistryWarning {
 	kind: "unknown_model"
 	modelId: string
 }
 
 export class ModelRegistry {
-	/** All models from the API, enriched where possible. Used for orchestrator self-lookup. */
 	private readonly allModels: OrchestrationModelDescriptor[]
-
-	/** Models that have a real entry in MODEL_CAPABILITIES (API ∩ capability map). */
 	private readonly modelsWithCapabilities: OrchestrationModelDescriptor[]
-
-	/** Drift warnings emitted during construction. */
 	readonly warnings: readonly ModelRegistryWarning[]
 
-	constructor(availableModelIds: readonly string[]) {
+	constructor(availableModels: readonly ModelMetadata[]) {
 		const warnings: ModelRegistryWarning[] = []
-
-		// Build full descriptor list from the API model IDs
 		const allModels: OrchestrationModelDescriptor[] = []
-		for (const id of availableModelIds) {
-			const entry = MODEL_CAPABILITIES.get(id)
-			if (entry === "ignored") {
-				continue
-			}
+
+		for (const m of availableModels) {
+			const entry = MODEL_CAPABILITIES.get(m.slug)
+			if (entry === "ignored") continue
 			if (entry === undefined) {
-				warnings.push({ kind: "unknown_model", modelId: id })
-				allModels.push({ id, provider: PROVIDER, name: modelIdToName(id), capabilities: GENERIC_CAPABILITIES })
+				warnings.push({ kind: "unknown_model", modelId: m.slug })
+				allModels.push({
+					id: m.slug,
+					provider: PROVIDER,
+					name: deriveName(m),
+					capabilities: GENERIC_CAPABILITIES,
+				})
 			} else {
-				allModels.push({ id, provider: PROVIDER, name: modelIdToName(id), capabilities: entry })
+				allModels.push({
+					id: m.slug,
+					provider: PROVIDER,
+					name: deriveName(m),
+					capabilities: entry,
+				})
 			}
 		}
-		this.allModels = allModels
 
-		this.modelsWithCapabilities = this.allModels.filter((m) => {
-			const entry = MODEL_CAPABILITIES.get(m.id)
+		this.allModels = allModels
+		this.modelsWithCapabilities = this.allModels.filter((descriptor) => {
+			const entry = MODEL_CAPABILITIES.get(descriptor.id)
 			return entry !== undefined && entry !== "ignored"
 		})
 		this.warnings = warnings
 	}
 
-	/**
-	 * All models available from the API, with capability enrichment where known.
-	 */
 	getAll(): readonly OrchestrationModelDescriptor[] {
 		return this.allModels
 	}
 
-	/**
-	 * Models that have a real entry in MODEL_CAPABILITIES - the intersection of
-	 * the API model list and the local capability knowledge-base. Unknown models
-	 * (those with generic descriptors) are excluded.
-	 */
 	getModelsWithCapabilities(): readonly OrchestrationModelDescriptor[] {
 		return this.modelsWithCapabilities
 	}

--- a/src/extensions/orchestration/prompt-enrichment.ts
+++ b/src/extensions/orchestration/prompt-enrichment.ts
@@ -27,7 +27,7 @@ import { isAbsolute, join, normalize, resolve } from "node:path"
 import type { ImageContent, TextContent } from "@mariozechner/pi-ai"
 import { type ExtensionAPI, type Skill, loadSkills } from "@mariozechner/pi-coding-agent"
 import { ANSI, fg } from "../../ansi.js"
-import { getAvailableModelIds } from "../../startup-context.js"
+import { getAvailableModels } from "../../startup-context.js"
 import { getGitBranch } from "../../utils.js"
 import { CONTINUATION_NUDGE_TEXT, ContinuationNudge, buildEmptyTurnNudgedMessages } from "./continuation-nudge.js"
 import { ModelRegistry } from "./model-registry/index.js"
@@ -89,7 +89,7 @@ export default function (skillPaths: string[]) {
 
 		// For sub agents we don't want to transform the prompt sent from parent with model capabilities
 		if (!subagentMode) {
-			const registry = new ModelRegistry(getAvailableModelIds())
+			const registry = new ModelRegistry(getAvailableModels())
 
 			// Announce newly available API models that have no capability entry yet.
 			for (const warning of registry.warnings) {

--- a/src/extensions/orchestration/prompt-transformer/prompt-transformer.test.ts
+++ b/src/extensions/orchestration/prompt-transformer/prompt-transformer.test.ts
@@ -1,5 +1,6 @@
 import type { Skill } from "@mariozechner/pi-coding-agent"
 import { describe, expect, it } from "vitest"
+import type { ModelMetadata } from "../../../models.js"
 import { MODEL_CAPABILITIES, ModelRegistry } from "../model-registry/index.js"
 import {
 	type EnvironmentInfo,
@@ -20,6 +21,22 @@ const testEnv: EnvironmentInfo = {
 
 const ALL_KNOWN_IDS = [...MODEL_CAPABILITIES.keys()]
 
+function fakeMetadata(slug: string): ModelMetadata {
+	return {
+		slug,
+		display_name: "",
+		description: "",
+		provider: "ai-enabler",
+		tool_call: true,
+		reasoning: false,
+		input_modalities: ["text"],
+		is_serverless: true,
+		limits: { context_window: 131072, max_output_tokens: 16384 },
+	}
+}
+
+const ALL_KNOWN_METADATA = ALL_KNOWN_IDS.map(fakeMetadata)
+
 function createSkill(overrides: Partial<Skill> & { name: string; description: string }): Skill {
 	return {
 		filePath: `/skills/${overrides.name}/SKILL.md`,
@@ -31,7 +48,7 @@ function createSkill(overrides: Partial<Skill> & { name: string; description: st
 }
 
 describe("transformPrompt", () => {
-	const registry = new ModelRegistry(ALL_KNOWN_IDS)
+	const registry = new ModelRegistry(ALL_KNOWN_METADATA)
 	const currentModel = { id: "kimi-k2.5", name: "Kimi K2.5" }
 
 	it("includes the original user prompt", () => {

--- a/src/extensions/orchestration/prompt-transformer/prompt-transformer.test.ts
+++ b/src/extensions/orchestration/prompt-transformer/prompt-transformer.test.ts
@@ -25,9 +25,7 @@ function fakeMetadata(slug: string): ModelMetadata {
 	return {
 		slug,
 		display_name: "",
-		description: "",
 		provider: "ai-enabler",
-		tool_call: true,
 		reasoning: false,
 		input_modalities: ["text"],
 		is_serverless: true,

--- a/src/models.test.ts
+++ b/src/models.test.ts
@@ -2,7 +2,59 @@ import { existsSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "no
 import { tmpdir } from "node:os"
 import { join } from "node:path"
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
-import { hasKimchiProvider, updateModelsConfig } from "./models.js"
+import { updateModelsConfig } from "./models.js"
+
+const KIMI: unknown = {
+	slug: "kimi-k2.5",
+	display_name: "Kimi K2.5",
+	description: "Primary model",
+	provider: "ai-enabler",
+	tool_call: true,
+	reasoning: true,
+	input_modalities: ["text", "image"],
+	is_serverless: true,
+	is_routable: false,
+	limits: { context_window: 262144, max_output_tokens: 262144 },
+}
+
+const GLM: unknown = {
+	slug: "glm-5-fp8",
+	display_name: "GLM-5 FP8",
+	description: "Coding subagent",
+	provider: "ai-enabler",
+	tool_call: true,
+	reasoning: true,
+	input_modalities: ["text"],
+	is_serverless: true,
+	is_routable: false,
+	limits: { context_window: 202752, max_output_tokens: 202752 },
+}
+
+const OPUS_47: unknown = {
+	slug: "claude-opus-4-7",
+	display_name: "",
+	description: "",
+	provider: "anthropic",
+	tool_call: true,
+	reasoning: true,
+	input_modalities: ["text", "image"],
+	is_serverless: false,
+	is_routable: false,
+	limits: { context_window: 1_000_000, max_output_tokens: 128_000 },
+}
+
+const OPUS_46: unknown = {
+	slug: "claude-opus-4-6",
+	display_name: "",
+	description: "",
+	provider: "anthropic",
+	tool_call: true,
+	reasoning: true,
+	input_modalities: ["text", "image"],
+	is_serverless: false,
+	is_routable: false,
+	limits: { context_window: 1_000_000, max_output_tokens: 128_000 },
+}
 
 describe("updateModelsConfig", () => {
 	let tempDir: string
@@ -19,66 +71,76 @@ describe("updateModelsConfig", () => {
 		vi.restoreAllMocks()
 	})
 
-	it("overwrites existing file with fetched models", async () => {
-		const existing = { providers: { custom: {} } }
-		writeFileSync(modelsJsonPath, JSON.stringify(existing))
-
+	it("maps each metadata field into the pi-mono model config", async () => {
 		vi.mocked(fetch).mockResolvedValueOnce({
 			ok: true,
-			json: async () => ({ models: ["new-model"] }),
+			json: async () => ({ models: [KIMI] }),
 		} as Response)
 
 		await updateModelsConfig(modelsJsonPath, "test-key")
 
-		const content = JSON.parse(readFileSync(modelsJsonPath, "utf-8"))
-		expect(content.providers["kimchi-dev"].models.map((m: { id: string }) => m.id)).toEqual(["new-model"])
-	})
-
-	it("writes discovered models when fetch succeeds", async () => {
-		vi.mocked(fetch).mockResolvedValueOnce({
-			ok: true,
-			json: async () => ({
-				models: ["my-model-1", "my-model-2"],
-			}),
-		} as Response)
-
-		const result = await updateModelsConfig(modelsJsonPath, "test-key")
-
-		expect(result).toEqual({ source: "discovered", models: ["my-model-1", "my-model-2"] })
-		expect(existsSync(modelsJsonPath)).toBe(true)
 		const config = JSON.parse(readFileSync(modelsJsonPath, "utf-8"))
 		expect(config.providers["kimchi-dev"].models).toEqual([
 			{
-				id: "my-model-1",
-				name: "My Model 1",
-				reasoning: false,
-				input: ["text"],
-				contextWindow: 131072,
-				maxTokens: 16384,
-				cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
-			},
-			{
-				id: "my-model-2",
-				name: "My Model 2",
-				reasoning: false,
-				input: ["text"],
-				contextWindow: 131072,
-				maxTokens: 16384,
+				id: "kimi-k2.5",
+				name: "Kimi K2.5",
+				reasoning: true,
+				input: ["text", "image"],
+				contextWindow: 262144,
+				maxTokens: 262144,
 				cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
 			},
 		])
 	})
 
-	it("uses correct auth header and timeout when fetching models", async () => {
+	it("falls back to derived name when display_name is empty", async () => {
 		vi.mocked(fetch).mockResolvedValueOnce({
 			ok: true,
-			json: async () => ({ models: ["m1"] }),
+			json: async () => ({ models: [OPUS_47] }),
+		} as Response)
+
+		await updateModelsConfig(modelsJsonPath, "test-key")
+
+		const config = JSON.parse(readFileSync(modelsJsonPath, "utf-8"))
+		expect(config.providers["kimchi-dev"].models[0].name).toBe("Claude Opus 4 7")
+	})
+
+	it("passes input_modalities through directly", async () => {
+		vi.mocked(fetch).mockResolvedValueOnce({
+			ok: true,
+			json: async () => ({ models: [GLM] }),
+		} as Response)
+
+		await updateModelsConfig(modelsJsonPath, "test-key")
+
+		const config = JSON.parse(readFileSync(modelsJsonPath, "utf-8"))
+		expect(config.providers["kimchi-dev"].models[0].input).toEqual(["text"])
+	})
+
+	it("puts AI-Enabler models first and preserves API order for others, all under kimchi-dev", async () => {
+		vi.mocked(fetch).mockResolvedValueOnce({
+			ok: true,
+			json: async () => ({ models: [OPUS_46, GLM, OPUS_47, KIMI] }),
+		} as Response)
+
+		await updateModelsConfig(modelsJsonPath, "test-key")
+
+		const config = JSON.parse(readFileSync(modelsJsonPath, "utf-8"))
+		expect(Object.keys(config.providers)).toEqual(["kimchi-dev"])
+		const ids = config.providers["kimchi-dev"].models.map((m: { id: string }) => m.id)
+		expect(ids).toEqual(["glm-5-fp8", "kimi-k2.5", "claude-opus-4-6", "claude-opus-4-7"])
+	})
+
+	it("uses correct URL, Authorization header, and timeout", async () => {
+		vi.mocked(fetch).mockResolvedValueOnce({
+			ok: true,
+			json: async () => ({ models: [KIMI] }),
 		} as Response)
 
 		await updateModelsConfig(modelsJsonPath, "my-api-key")
 
 		expect(fetch).toHaveBeenCalledWith(
-			"https://api.cast.ai/v1/llm/openai/models?providerName=AI%20Enabler",
+			"https://llm.kimchi.dev/v1/models/metadata?include_in_cli=true",
 			expect.objectContaining({
 				headers: { Authorization: "Bearer my-api-key" },
 				signal: expect.any(AbortSignal),
@@ -86,182 +148,73 @@ describe("updateModelsConfig", () => {
 		)
 	})
 
-	it("falls back to default models when fetch fails with network error", async () => {
-		vi.mocked(fetch).mockRejectedValueOnce(new Error("network error"))
+	it("returns discovered metadata when fetch succeeds", async () => {
+		vi.mocked(fetch).mockResolvedValueOnce({
+			ok: true,
+			json: async () => ({ models: [KIMI, GLM] }),
+		} as Response)
 
 		const result = await updateModelsConfig(modelsJsonPath, "test-key")
 
-		expect(result).toEqual({
-			source: "default",
-			models: ["kimi-k2.5", "glm-5-fp8", "minimax-m2.7"],
-			error: "network error",
-		})
-		expect(existsSync(modelsJsonPath)).toBe(true)
-		const config = JSON.parse(readFileSync(modelsJsonPath, "utf-8"))
-		expect(config.providers["kimchi-dev"].models.map((m: { id: string }) => m.id)).toEqual([
-			"kimi-k2.5",
-			"glm-5-fp8",
-			"minimax-m2.7",
-		])
+		expect(result.models.map((m) => m.slug)).toEqual(["kimi-k2.5", "glm-5-fp8"])
 	})
 
-	it("falls back to default models when fetch returns non-ok status", async () => {
+	it("overwrites an existing models.json with fetched metadata", async () => {
+		writeFileSync(modelsJsonPath, JSON.stringify({ providers: { custom: {} } }))
+		vi.mocked(fetch).mockResolvedValueOnce({
+			ok: true,
+			json: async () => ({ models: [KIMI] }),
+		} as Response)
+
+		await updateModelsConfig(modelsJsonPath, "test-key")
+
+		const config = JSON.parse(readFileSync(modelsJsonPath, "utf-8"))
+		expect(config.providers["kimchi-dev"].models.map((m: { id: string }) => m.id)).toEqual(["kimi-k2.5"])
+	})
+
+	it("throws on network error", async () => {
+		vi.mocked(fetch).mockRejectedValueOnce(new Error("network error"))
+		await expect(updateModelsConfig(modelsJsonPath, "test-key")).rejects.toThrow("network error")
+	})
+
+	it("throws on non-ok response", async () => {
 		vi.mocked(fetch).mockResolvedValueOnce({
 			ok: false,
 			status: 401,
 			statusText: "Unauthorized",
 		} as Response)
-
-		const result = await updateModelsConfig(modelsJsonPath, "bad-key")
-
-		expect(result).toEqual({
-			source: "default",
-			models: ["kimi-k2.5", "glm-5-fp8", "minimax-m2.7"],
-			error: "Failed to fetch models: 401 Unauthorized",
-		})
-		expect(existsSync(modelsJsonPath)).toBe(true)
-		const config = JSON.parse(readFileSync(modelsJsonPath, "utf-8"))
-		expect(config.providers["kimchi-dev"].models.map((m: { id: string }) => m.id)).toEqual([
-			"kimi-k2.5",
-			"glm-5-fp8",
-			"minimax-m2.7",
-		])
+		await expect(updateModelsConfig(modelsJsonPath, "bad-key")).rejects.toThrow(
+			"Failed to fetch models: 401 Unauthorized",
+		)
 	})
 
-	it("falls back to default models when fetch returns empty list", async () => {
-		vi.mocked(fetch).mockResolvedValueOnce({
-			ok: true,
-			json: async () => ({ models: [] }),
-		} as Response)
-
-		const result = await updateModelsConfig(modelsJsonPath, "test-key")
-
-		expect(result).toEqual({
-			source: "default",
-			models: ["kimi-k2.5", "glm-5-fp8", "minimax-m2.7"],
-			error: "API returned empty model list",
-		})
-		const config = JSON.parse(readFileSync(modelsJsonPath, "utf-8"))
-		expect(config.providers["kimchi-dev"].models.map((m: { id: string }) => m.id)).toEqual([
-			"kimi-k2.5",
-			"glm-5-fp8",
-			"minimax-m2.7",
-		])
-	})
-
-	it("falls back to default models when all fetched models are filtered out", async () => {
-		vi.mocked(fetch).mockResolvedValueOnce({
-			ok: true,
-			json: async () => ({ models: ["smollm2-360m", "qwen3-coder-next-fp8"] }),
-		} as Response)
-
-		const result = await updateModelsConfig(modelsJsonPath, "test-key")
-
-		expect(result).toEqual({
-			source: "default",
-			models: ["kimi-k2.5", "glm-5-fp8", "minimax-m2.7"],
-			error: "API returned no usable models after filtering",
-		})
-	})
-
-	it("falls back to default models when response has unexpected shape", async () => {
+	it("throws on unexpected response shape", async () => {
 		vi.mocked(fetch).mockResolvedValueOnce({
 			ok: true,
 			json: async () => ({ data: "unexpected" }),
 		} as Response)
-
-		const result = await updateModelsConfig(modelsJsonPath, "test-key")
-
-		expect(result).toEqual({
-			source: "default",
-			models: ["kimi-k2.5", "glm-5-fp8", "minimax-m2.7"],
-			error: "Unexpected response shape from models API",
-		})
+		await expect(updateModelsConfig(modelsJsonPath, "test-key")).rejects.toThrow(
+			"Unexpected response shape from models API",
+		)
 	})
 
-	it("falls back to default models on fetch timeout", async () => {
-		const abortError = new DOMException("The operation was aborted.", "AbortError")
-		vi.mocked(fetch).mockRejectedValueOnce(abortError)
-
-		const result = await updateModelsConfig(modelsJsonPath, "test-key")
-
-		expect(result.source).toBe("default")
-		expect(result.models).toEqual(["kimi-k2.5", "glm-5-fp8", "minimax-m2.7"])
-	})
-
-	it("sorts models alphabetically", async () => {
+	it("throws when API returns empty list", async () => {
 		vi.mocked(fetch).mockResolvedValueOnce({
 			ok: true,
-			json: async () => ({ models: ["zebra-model", "alpha-model", "mango-model"] }),
+			json: async () => ({ models: [] }),
 		} as Response)
-
-		const result = await updateModelsConfig(modelsJsonPath, "test-key")
-
-		expect(result).toEqual({
-			source: "discovered",
-			models: ["alpha-model", "mango-model", "zebra-model"],
-		})
-	})
-
-	it("excludes models matching smoll* pattern", async () => {
-		vi.mocked(fetch).mockResolvedValueOnce({
-			ok: true,
-			json: async () => ({ models: ["good-model", "smollm2-360m", "smollm2-135m"] }),
-		} as Response)
-
-		const result = await updateModelsConfig(modelsJsonPath, "test-key")
-
-		expect(result).toEqual({ source: "discovered", models: ["good-model"] })
-	})
-
-	it("excludes models matching qwen* pattern", async () => {
-		vi.mocked(fetch).mockResolvedValueOnce({
-			ok: true,
-			json: async () => ({ models: ["good-model", "qwen3-coder-next-fp8"] }),
-		} as Response)
-
-		const result = await updateModelsConfig(modelsJsonPath, "test-key")
-
-		expect(result).toEqual({ source: "discovered", models: ["good-model"] })
+		await expect(updateModelsConfig(modelsJsonPath, "test-key")).rejects.toThrow("API returned empty model list")
 	})
 
 	it("creates nested directories if they do not exist", async () => {
 		vi.mocked(fetch).mockResolvedValueOnce({
 			ok: true,
-			json: async () => ({ models: ["m1"] }),
+			json: async () => ({ models: [KIMI] }),
 		} as Response)
 
 		const nestedPath = join(tempDir, "a", "b", "models.json")
 		await updateModelsConfig(nestedPath, "test-key")
 
 		expect(existsSync(nestedPath)).toBe(true)
-	})
-})
-
-describe("hasKimchiProvider", () => {
-	let tempDir: string
-
-	beforeEach(() => {
-		tempDir = mkdtempSync(join(tmpdir(), "kimchi-models-test-"))
-	})
-
-	afterEach(() => {
-		rmSync(tempDir, { recursive: true, force: true })
-	})
-
-	it("returns false when file does not exist", () => {
-		expect(hasKimchiProvider(join(tempDir, "missing.json"))).toBe(false)
-	})
-
-	it("returns false when file has no kimchi-dev provider", () => {
-		const p = join(tempDir, "models.json")
-		writeFileSync(p, JSON.stringify({ providers: { other: {} } }))
-		expect(hasKimchiProvider(p)).toBe(false)
-	})
-
-	it("returns true when file contains kimchi-dev provider", () => {
-		const p = join(tempDir, "models.json")
-		writeFileSync(p, JSON.stringify({ providers: { "kimchi-dev": { models: [] } } }))
-		expect(hasKimchiProvider(p)).toBe(true)
 	})
 })

--- a/src/models.test.ts
+++ b/src/models.test.ts
@@ -7,52 +7,40 @@ import { updateModelsConfig } from "./models.js"
 const KIMI: unknown = {
 	slug: "kimi-k2.5",
 	display_name: "Kimi K2.5",
-	description: "Primary model",
 	provider: "ai-enabler",
-	tool_call: true,
 	reasoning: true,
 	input_modalities: ["text", "image"],
 	is_serverless: true,
-	is_routable: false,
 	limits: { context_window: 262144, max_output_tokens: 262144 },
 }
 
 const GLM: unknown = {
 	slug: "glm-5-fp8",
 	display_name: "GLM-5 FP8",
-	description: "Coding subagent",
 	provider: "ai-enabler",
-	tool_call: true,
 	reasoning: true,
 	input_modalities: ["text"],
 	is_serverless: true,
-	is_routable: false,
 	limits: { context_window: 202752, max_output_tokens: 202752 },
 }
 
 const OPUS_47: unknown = {
 	slug: "claude-opus-4-7",
 	display_name: "",
-	description: "",
 	provider: "anthropic",
-	tool_call: true,
 	reasoning: true,
 	input_modalities: ["text", "image"],
 	is_serverless: false,
-	is_routable: false,
 	limits: { context_window: 1_000_000, max_output_tokens: 128_000 },
 }
 
 const OPUS_46: unknown = {
 	slug: "claude-opus-4-6",
 	display_name: "",
-	description: "",
 	provider: "anthropic",
-	tool_call: true,
 	reasoning: true,
 	input_modalities: ["text", "image"],
 	is_serverless: false,
-	is_routable: false,
 	limits: { context_window: 1_000_000, max_output_tokens: 128_000 },
 }
 
@@ -93,18 +81,6 @@ describe("updateModelsConfig", () => {
 		])
 	})
 
-	it("falls back to derived name when display_name is empty", async () => {
-		vi.mocked(fetch).mockResolvedValueOnce({
-			ok: true,
-			json: async () => ({ models: [OPUS_47] }),
-		} as Response)
-
-		await updateModelsConfig(modelsJsonPath, "test-key")
-
-		const config = JSON.parse(readFileSync(modelsJsonPath, "utf-8"))
-		expect(config.providers["kimchi-dev"].models[0].name).toBe("Claude Opus 4 7")
-	})
-
 	it("passes input_modalities through directly", async () => {
 		vi.mocked(fetch).mockResolvedValueOnce({
 			ok: true,
@@ -115,6 +91,30 @@ describe("updateModelsConfig", () => {
 
 		const config = JSON.parse(readFileSync(modelsJsonPath, "utf-8"))
 		expect(config.providers["kimchi-dev"].models[0].input).toEqual(["text"])
+	})
+
+	it("disables supportsReasoningEffort for anthropic models", async () => {
+		vi.mocked(fetch).mockResolvedValueOnce({
+			ok: true,
+			json: async () => ({ models: [OPUS_47] }),
+		} as Response)
+
+		await updateModelsConfig(modelsJsonPath, "test-key")
+
+		const config = JSON.parse(readFileSync(modelsJsonPath, "utf-8"))
+		expect(config.providers["kimchi-dev"].models[0].compat).toEqual({ supportsReasoningEffort: false })
+	})
+
+	it("omits compat for non-anthropic models", async () => {
+		vi.mocked(fetch).mockResolvedValueOnce({
+			ok: true,
+			json: async () => ({ models: [KIMI] }),
+		} as Response)
+
+		await updateModelsConfig(modelsJsonPath, "test-key")
+
+		const config = JSON.parse(readFileSync(modelsJsonPath, "utf-8"))
+		expect(config.providers["kimchi-dev"].models[0]).not.toHaveProperty("compat")
 	})
 
 	it("puts AI-Enabler models first and preserves API order for others, all under kimchi-dev", async () => {
@@ -172,12 +172,12 @@ describe("updateModelsConfig", () => {
 		expect(config.providers["kimchi-dev"].models.map((m: { id: string }) => m.id)).toEqual(["kimi-k2.5"])
 	})
 
-	it("throws on network error", async () => {
+	it("throws on fetch failure when no cached config exists", async () => {
 		vi.mocked(fetch).mockRejectedValueOnce(new Error("network error"))
 		await expect(updateModelsConfig(modelsJsonPath, "test-key")).rejects.toThrow("network error")
 	})
 
-	it("throws on non-ok response", async () => {
+	it("throws on non-ok response when no cached config exists", async () => {
 		vi.mocked(fetch).mockResolvedValueOnce({
 			ok: false,
 			status: 401,
@@ -188,7 +188,7 @@ describe("updateModelsConfig", () => {
 		)
 	})
 
-	it("throws on unexpected response shape", async () => {
+	it("throws on unexpected response shape when no cached config exists", async () => {
 		vi.mocked(fetch).mockResolvedValueOnce({
 			ok: true,
 			json: async () => ({ data: "unexpected" }),
@@ -198,12 +198,55 @@ describe("updateModelsConfig", () => {
 		)
 	})
 
-	it("throws when API returns empty list", async () => {
+	it("throws when API returns empty list and no cached config exists", async () => {
 		vi.mocked(fetch).mockResolvedValueOnce({
 			ok: true,
 			json: async () => ({ models: [] }),
 		} as Response)
 		await expect(updateModelsConfig(modelsJsonPath, "test-key")).rejects.toThrow("API returned empty model list")
+	})
+
+	it("falls back to cached metadata when fetch fails", async () => {
+		// Seed a successful fetch so the cache is populated.
+		vi.mocked(fetch).mockResolvedValueOnce({
+			ok: true,
+			json: async () => ({ models: [KIMI, OPUS_47] }),
+		} as Response)
+		await updateModelsConfig(modelsJsonPath, "test-key")
+		vi.mocked(fetch).mockRejectedValueOnce(new Error("network down"))
+
+		const result = await updateModelsConfig(modelsJsonPath, "test-key")
+
+		expect(result.models.map((m) => m.slug)).toEqual(["kimi-k2.5", "claude-opus-4-7"])
+	})
+
+	it("falls back to cached metadata when API returns empty list", async () => {
+		vi.mocked(fetch).mockResolvedValueOnce({
+			ok: true,
+			json: async () => ({ models: [KIMI] }),
+		} as Response)
+		await updateModelsConfig(modelsJsonPath, "test-key")
+		vi.mocked(fetch).mockResolvedValueOnce({
+			ok: true,
+			json: async () => ({ models: [] }),
+		} as Response)
+
+		const result = await updateModelsConfig(modelsJsonPath, "test-key")
+
+		expect(result.models.map((m) => m.slug)).toEqual(["kimi-k2.5"])
+	})
+
+	it("does not overwrite cached models.json when fetch fails", async () => {
+		vi.mocked(fetch).mockResolvedValueOnce({
+			ok: true,
+			json: async () => ({ models: [KIMI] }),
+		} as Response)
+		await updateModelsConfig(modelsJsonPath, "test-key")
+		const original = readFileSync(modelsJsonPath, "utf-8")
+		vi.mocked(fetch).mockRejectedValueOnce(new Error("network down"))
+		await updateModelsConfig(modelsJsonPath, "test-key")
+
+		expect(readFileSync(modelsJsonPath, "utf-8")).toBe(original)
 	})
 
 	it("creates nested directories if they do not exist", async () => {

--- a/src/models.ts
+++ b/src/models.ts
@@ -85,7 +85,7 @@ function buildModelsConfig(models: ModelMetadata[]) {
 				api: "openai-completions",
 				authHeader: true,
 				headers: { "User-Agent": `kimchi/${getVersion()}` },
-			    models: models.map(metadataToModel),
+				models: models.map(metadataToModel),
 			},
 		},
 	}

--- a/src/models.ts
+++ b/src/models.ts
@@ -1,162 +1,114 @@
-import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs"
+import { mkdirSync, writeFileSync } from "node:fs"
 import { dirname } from "node:path"
 import { getVersion } from "./utils.js"
 
-const CAST_AI_MODELS_API = "https://api.cast.ai/v1/llm/openai/models?providerName=AI%20Enabler"
-const CAST_AI_LLM_BASE_URL = "https://llm.kimchi.dev/openai/v1"
+const KIMCHI_API = "https://llm.kimchi.dev"
+const MODELS_METADATA_API = `${KIMCHI_API}/v1/models/metadata?include_in_cli=true`
+const CHAT_COMPLETIONS_API = `${KIMCHI_API}/openai/v1`
 const FETCH_TIMEOUT_MS = 5000
 
-const EXCLUDED_MODEL_PATTERNS = [/^smoll/i, /^qwen/i]
-
-function filterAndSortModels(models: string[]): string[] {
-	return models.filter((id) => !EXCLUDED_MODEL_PATTERNS.some((re) => re.test(id))).sort((a, b) => a.localeCompare(b))
+export interface ModelMetadata {
+	slug: string
+	display_name: string
+	description: string
+	provider: string
+	tool_call: boolean
+	reasoning: boolean
+	input_modalities: ("text" | "image")[]
+	is_serverless: boolean
+	limits: {
+		context_window: number
+		max_output_tokens: number
+	}
 }
 
-interface CastAIModelsResponse {
-	models: string[]
+interface ModelsMetadataResponse {
+	models: ModelMetadata[]
 }
 
-function modelIdToName(id: string): string {
-	return id
-		.split(/[-_]/)
-		.map((part) => part.charAt(0).toUpperCase() + part.slice(1))
-		.join(" ")
+function sortModels(models: ModelMetadata[]): ModelMetadata[] {
+	const serverless = models.filter((m) => m.is_serverless)
+	const rest = models.filter((m) => !m.is_serverless)
+	return [...serverless, ...rest]
 }
 
-async function fetchAvailableModels(apiKey: string): Promise<string[]> {
-	const response = await fetch(CAST_AI_MODELS_API, {
+async function fetchAvailableModels(apiKey: string): Promise<ModelMetadata[]> {
+	const response = await fetch(MODELS_METADATA_API, {
 		headers: { Authorization: `Bearer ${apiKey}` },
 		signal: AbortSignal.timeout(FETCH_TIMEOUT_MS),
 	})
 	if (!response.ok) {
 		throw new Error(`Failed to fetch models: ${response.status} ${response.statusText}`)
 	}
-	const body = await response.json()
-	if (!body || typeof body !== "object" || !Array.isArray(body.models)) {
+	const body = (await response.json()) as ModelsMetadataResponse
+	if (!Array.isArray(body?.models)) {
 		throw new Error("Unexpected response shape from models API")
 	}
-	return (body as CastAIModelsResponse).models
+	return body.models
 }
 
-function buildModelsConfig(models: string[]) {
+interface PiModelConfig {
+	id: string
+	name: string
+	reasoning: boolean
+	input: ("text" | "image")[]
+	contextWindow: number
+	maxTokens: number
+	cost: { input: number; output: number; cacheRead: number; cacheWrite: number }
+	compat?: { supportsReasoningEffort?: boolean }
+}
+
+function metadataToModel(m: ModelMetadata): PiModelConfig {
+	// TODO: our LiteLLM gateway does not support `thinking.type.enabled` for Antrhopic >Opus 4.6 models
+	// Therefore, we disable it for now. Revisit, once we upgrade our LiteLLM version.
+	const compat = m.provider === "anthropic" ? { supportsReasoningEffort: false } : undefined
+	return {
+		id: m.slug,
+		name: m.display_name.trim().length > 0 ? m.display_name : m.slug,
+		reasoning: m.reasoning,
+		input: m.input_modalities,
+		contextWindow: m.limits.context_window,
+		maxTokens: m.limits.max_output_tokens,
+		// TODO: add costs support
+		cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+		...(compat && { compat }),
+	}
+}
+
+function buildModelsConfig(models: ModelMetadata[]) {
 	return {
 		providers: {
 			"kimchi-dev": {
-				baseUrl: CAST_AI_LLM_BASE_URL,
+				baseUrl: CHAT_COMPLETIONS_API,
 				apiKey: "KIMCHI_API_KEY",
 				api: "openai-completions",
 				authHeader: true,
 				headers: { "User-Agent": `kimchi/${getVersion()}` },
-				models: models.map((id) => ({
-					id,
-					name: modelIdToName(id),
-					reasoning: false,
-					input: ["text"],
-					contextWindow: 131072,
-					maxTokens: 16384,
-					cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
-				})),
+			    models: models.map(metadataToModel),
 			},
 		},
 	}
 }
 
-/**
- * The default models.json configuration for the Cast AI provider.
- * Models are registered with the "kimchi-dev" provider name. The apiKey field
- * references the KIMCHI_API_KEY environment variable, which is set by the
- * CLI entry point from the resolved kimchi config before pi-mono imports.
- */
-const DEFAULT_MODELS_CONFIG = {
-	providers: {
-		"kimchi-dev": {
-			baseUrl: CAST_AI_LLM_BASE_URL,
-			apiKey: "KIMCHI_API_KEY",
-			api: "openai-completions",
-			authHeader: true,
-			headers: { "User-Agent": `kimchi/${getVersion()}` },
-			models: [
-				{
-					id: "kimi-k2.5",
-					name: "Kimi K2.5",
-					reasoning: false,
-					input: ["text"],
-					contextWindow: 131072,
-					maxTokens: 16384,
-					cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
-				},
-				{
-					id: "glm-5-fp8",
-					name: "GLM 5 FP8",
-					reasoning: false,
-					input: ["text"],
-					contextWindow: 131072,
-					maxTokens: 16384,
-					cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
-				},
-				{
-					id: "minimax-m2.7",
-					name: "Minimax M2.7",
-					reasoning: true,
-					input: ["text"],
-					contextWindow: 196608,
-					maxTokens: 32768,
-					cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
-				},
-			],
-		},
-	},
+export interface ModelsConfigResult {
+	models: ModelMetadata[]
 }
 
-export type ModelsConfigResult =
-	| { source: "discovered"; models: string[] }
-	| { source: "default"; models: string[]; error?: string }
-
 /**
- * Fetch available models from the Cast AI API and write the configuration to
- * modelsJsonPath. Falls back to the static default configuration if the fetch
- * fails. Always overwrites any existing file so the model list stays current
- * on every startup.
+ * Fetch available models from the kimchi metadata API and write the
+ * configuration to modelsJsonPath. Always overwrites any existing file so
+ * the model list stays current on every startup. Throws on fetch failure
+ * or empty response.
  */
 export async function updateModelsConfig(modelsJsonPath: string, apiKey: string): Promise<ModelsConfigResult> {
 	const dir = dirname(modelsJsonPath)
 	mkdirSync(dir, { recursive: true })
 
-	try {
-		const fetched = await fetchAvailableModels(apiKey)
-		const models = filterAndSortModels(fetched)
-		if (models.length > 0) {
-			writeFileSync(modelsJsonPath, JSON.stringify(buildModelsConfig(models), null, "\t"), "utf-8")
-			return { source: "discovered", models }
-		}
-		writeFileSync(modelsJsonPath, JSON.stringify(DEFAULT_MODELS_CONFIG, null, "\t"), "utf-8")
-		return {
-			source: "default",
-			models: DEFAULT_MODELS_CONFIG.providers["kimchi-dev"].models.map((m) => m.id),
-			error: fetched.length === 0 ? "API returned empty model list" : "API returned no usable models after filtering",
-		}
-	} catch (err) {
-		writeFileSync(modelsJsonPath, JSON.stringify(DEFAULT_MODELS_CONFIG, null, "\t"), "utf-8")
-		return {
-			source: "default",
-			models: DEFAULT_MODELS_CONFIG.providers["kimchi-dev"].models.map((m) => m.id),
-			error: err instanceof Error ? err.message : String(err),
-		}
+	const fetched = await fetchAvailableModels(apiKey)
+	if (fetched.length === 0) {
+		throw new Error("API returned empty model list")
 	}
-}
-
-/**
- * Check whether the models.json at the given path already contains a "kimchi-dev" provider.
- */
-export function hasKimchiProvider(modelsJsonPath: string): boolean {
-	if (!existsSync(modelsJsonPath)) {
-		return false
-	}
-	try {
-		const raw = readFileSync(modelsJsonPath, "utf-8")
-		const config = JSON.parse(raw)
-		return config?.providers?.["kimchi-dev"] !== undefined
-	} catch {
-		return false
-	}
+	const models = sortModels(fetched)
+	writeFileSync(modelsJsonPath, JSON.stringify(buildModelsConfig(models), null, "\t"), "utf-8")
+	return { models }
 }

--- a/src/models.ts
+++ b/src/models.ts
@@ -1,4 +1,4 @@
-import { mkdirSync, writeFileSync } from "node:fs"
+import { mkdirSync, readFileSync, writeFileSync } from "node:fs"
 import { dirname } from "node:path"
 import { getVersion } from "./utils.js"
 
@@ -10,9 +10,7 @@ const FETCH_TIMEOUT_MS = 5000
 export interface ModelMetadata {
 	slug: string
 	display_name: string
-	description: string
 	provider: string
-	tool_call: boolean
 	reasoning: boolean
 	input_modalities: ("text" | "image")[]
 	is_serverless: boolean
@@ -43,6 +41,9 @@ async function fetchAvailableModels(apiKey: string): Promise<ModelMetadata[]> {
 	const body = (await response.json()) as ModelsMetadataResponse
 	if (!Array.isArray(body?.models)) {
 		throw new Error("Unexpected response shape from models API")
+	}
+	if (body.models.length === 0) {
+		throw new Error("API returned empty model list")
 	}
 	return body.models
 }
@@ -94,20 +95,55 @@ export interface ModelsConfigResult {
 	models: ModelMetadata[]
 }
 
+function modelToMetadata(m: PiModelConfig): ModelMetadata {
+	return {
+		slug: m.id,
+		display_name: m.name,
+		// `compat` is only set for anthropic models in metadataToModel, so its
+		// presence is a reliable indicator of the provider after a round-trip.
+		provider: m.compat ? "anthropic" : "",
+		reasoning: m.reasoning,
+		input_modalities: m.input,
+		// is_serverless is not persisted; sortModels will treat all cached models
+		// as serverless on fallback, which is acceptable for a degraded path.
+		is_serverless: true,
+		limits: { context_window: m.contextWindow, max_output_tokens: m.maxTokens },
+	}
+}
+
+function readCachedMetadata(modelsJsonPath: string): ModelMetadata[] | undefined {
+	try {
+		const raw = readFileSync(modelsJsonPath, "utf-8")
+		const parsed = JSON.parse(raw)
+		const models = parsed?.providers?.["kimchi-dev"]?.models
+		if (!Array.isArray(models) || models.length === 0) return undefined
+		return (models as PiModelConfig[]).map(modelToMetadata)
+	} catch {
+		return undefined
+	}
+}
+
 /**
  * Fetch available models from the kimchi metadata API and write the
- * configuration to modelsJsonPath. Always overwrites any existing file so
- * the model list stays current on every startup. Throws on fetch failure
- * or empty response.
+ * configuration to modelsJsonPath. If the fetch fails (or returns an empty
+ * list) and the previous models.json is still on disk, returns the cached
+ * models with a warning. Throws only when there is no cache to fall back on.
  */
 export async function updateModelsConfig(modelsJsonPath: string, apiKey: string): Promise<ModelsConfigResult> {
 	const dir = dirname(modelsJsonPath)
 	mkdirSync(dir, { recursive: true })
 
-	const fetched = await fetchAvailableModels(apiKey)
-	if (fetched.length === 0) {
-		throw new Error("API returned empty model list")
+	let fetched: ModelMetadata[]
+	try {
+		fetched = await fetchAvailableModels(apiKey)
+	} catch (err) {
+		const cached = readCachedMetadata(modelsJsonPath)
+		if (!cached) throw err
+		const message = err instanceof Error ? err.message : String(err)
+		console.warn(`Failed to refresh models from API, using cached list: ${message}`)
+		return { models: cached }
 	}
+
 	const models = sortModels(fetched)
 	writeFileSync(modelsJsonPath, JSON.stringify(buildModelsConfig(models), null, "\t"), "utf-8")
 	return { models }

--- a/src/startup-context.ts
+++ b/src/startup-context.ts
@@ -2,20 +2,22 @@
  * Startup context shared between cli.ts and extensions.
  *
  * cli.ts runs before pi-mono's main() and before any extension factory is
- * invoked. It writes discovered model IDs here after fetching from the API,
- * so extensions can read a fully populated context when they initialise.
+ * invoked. It writes discovered model metadata here after fetching from the
+ * API, so extensions can read a fully populated context when they initialise.
  *
  * Module-level state is safe here because Node/Bun evaluates each module
  * exactly once per process. By the time any extension factory runs, cli.ts
  * has already set these values.
  */
 
-let _availableModelIds: readonly string[] = []
+import type { ModelMetadata } from "./models.js"
 
-export function setAvailableModelIds(ids: readonly string[]): void {
-	_availableModelIds = ids
+let _availableModels: readonly ModelMetadata[] = []
+
+export function setAvailableModels(models: readonly ModelMetadata[]): void {
+	_availableModels = models
 }
 
-export function getAvailableModelIds(): readonly string[] {
-	return _availableModelIds
+export function getAvailableModels(): readonly ModelMetadata[] {
+	return _availableModels
 }


### PR DESCRIPTION


---
### Kimchi Summary
### What changed
Replaces the static hardcoded model list with dynamic resolution from the kimchi metadata API at startup. The CLI now fetches full model metadata—including capabilities, context windows, and provider information—and caches it locally. Adds support for Anthropic Claude Opus 4.7 alongside existing AI Enabler models.

### Why
Eliminates the need to release new CLI versions to update supported models. Enables automatic discovery of new models and their capabilities as they become available in the API, while gracefully handling network failures via local caching.

### Key changes
- `src/models.ts`: Switches to fetching `ModelMetadata` from `llm.kimchi.dev/v1/models/metadata?include_in_cli=true` instead of just model IDs. Removes static default fallback; now caches fetched metadata to disk and falls back to the cached list on API failures. Adds provider-specific compatibility flags (e.g., disabling `supportsReasoningEffort` for Anthropic models).
- `src/startup-context.ts`: Renames functions to `setAvailableModels`/`getAvailableModels`, now operating on `ModelMetadata[]` instead of `string[]`.
- `src/extensions/orchestration/model-registry/model-registry.ts`: Accepts `ModelMetadata[]` in constructor, preferring `display_name` from metadata over derived slug-to-name conversion.
- `src/extensions/orchestration/model-registry/builtin-models.ts`: Adds capability entry for `claude-opus-4-7` (heavy tier, vision support) and marks older Claude variants as ignored.
- `src/cli.ts`: Updates to use new metadata-based API; removes warning logic for default models.
- `README.md`: Updates documentation to reflect that models are now fetched dynamically at startup.

### Impact
- **Behavior change**: On API failure, the CLI now retains the last successfully fetched model list instead of reverting to a hardcoded default set.
- **New capabilities**: Claude Opus 4.7 is available for complex multi-step tasks requiring deep reasoning and vision support.
- **Breaking changes**: None for end users; existing `models.json` files remain compatible and will be updated automatically.