### PR TITLE
LLM-1379 Save subagent sessions

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,12 @@ A default `models.json` is created automatically on first run at `~/.config/kimc
 
 kimchi-code respects `HTTP_PROXY` / `HTTPS_PROXY` environment variables for network requests.
 
+### Subagent sessions
+
+Every `subagent` invocation writes its own persistent session file alongside the parent's, in the same session directory. The child's session header back-references its parent, and the parent's tool-result records the child's session id and file path. Nested subagents (sub-subagents) follow the same rule at any depth — all descendants land next to the original top-level parent.
+
+This means subagent runs are fully recoverable from disk: open the parent's `.jsonl`, follow the `sessionFile` on any `subagent` tool-result to the child, and replay it like any other session. In pi's session-selector, children render under their parent as a tree. Deleting the parent's session directory removes its children automatically.
+
 ## Tags
 
 kimchi-code supports tagging LLM requests for usage tracking and cost attribution. Tags are automatically included with every LLM request and displayed in the footer of the interactive UI.

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
 		"open": "^10.2.0",
 		"shell-quote": "^1.8.3",
 		"undici": "^8.0.2",
+		"uuid": "^14.0.0",
 		"zod": "^4.0.0"
 	},
 	"peerDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -41,6 +41,9 @@ importers:
       undici:
         specifier: ^8.0.2
         version: 8.0.2
+      uuid:
+        specifier: ^14.0.0
+        version: 14.0.0
       zod:
         specifier: ^4.0.0
         version: 4.3.6
@@ -2014,6 +2017,10 @@ packages:
 
   uuid@11.1.0:
     resolution: {integrity: sha512-0/A9rDy9P7cJ+8w1c9WD9V//9Wj15Ce2MPz8Ri6032usz+NfePxx5AcN3bN+r6ZL6jEo066/yNYB3tn4pQEx+A==}
+    hasBin: true
+
+  uuid@14.0.0:
+    resolution: {integrity: sha512-Qo+uWgilfSmAhXCMav1uYFynlQO7fMFiMVZsQqZRMIXp0O7rR7qjkj+cPvBHLgBqi960QCoo/PH2/6ZtVqKvrg==}
     hasBin: true
 
   vary@1.1.2:
@@ -4393,6 +4400,8 @@ snapshots:
   unpipe@1.0.0: {}
 
   uuid@11.1.0: {}
+
+  uuid@14.0.0: {}
 
   vary@1.1.2: {}
 

--- a/src/extensions/subagent.test.ts
+++ b/src/extensions/subagent.test.ts
@@ -359,13 +359,10 @@ describe("prepareChildSessionFile", () => {
 		expect(() => prepareChildSessionFile(missingDir, parentFile, "/work/dir")).toThrow()
 	})
 
-	it("uses real uuidv7 by default and produces a distinct session per call", () => {
+	// PRD N4: parallel subagents under one parent must each get a distinct sessionId. Guards against regressions like caching/memoizing the id per parent, which would silently collide under fan-out.
+	it("assigns a distinct sessionId to each call so parallel spawns cannot collide", () => {
 		const parentFile = join(tmp, "parent.jsonl")
-		const a = prepareChildSessionFile(tmp, parentFile, "/work/dir")
-		const b = prepareChildSessionFile(tmp, parentFile, "/work/dir")
-		expect(a?.sessionId).toBeTruthy()
-		expect(b?.sessionId).toBeTruthy()
-		expect(a?.sessionId).not.toBe(b?.sessionId)
-		expect(a?.childSessionFile).not.toBe(b?.childSessionFile)
+		const ids = Array.from({ length: 8 }, () => prepareChildSessionFile(tmp, parentFile, "/work/dir")?.sessionId)
+		expect(new Set(ids).size).toBe(ids.length)
 	})
 })

--- a/src/extensions/subagent.test.ts
+++ b/src/extensions/subagent.test.ts
@@ -1,8 +1,9 @@
-import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs"
+import { mkdirSync, mkdtempSync, readFileSync, rmSync, statSync, writeFileSync } from "node:fs"
 import { tmpdir } from "node:os"
 import { join, resolve } from "node:path"
-import { afterAll, beforeAll, describe, expect, it } from "vitest"
-import { buildSubagentArgs, parseSubagentEvent, validateAttachments } from "./subagent.js"
+import { CURRENT_SESSION_VERSION } from "@mariozechner/pi-coding-agent"
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it } from "vitest"
+import { buildSubagentArgs, parseSubagentEvent, prepareChildSessionFile, validateAttachments } from "./subagent.js"
 
 describe("parseSubagentEvent", () => {
 	const cases: Record<
@@ -255,13 +256,14 @@ describe("buildSubagentArgs", () => {
 		expect(args.some((a) => a.startsWith("@"))).toBe(false)
 	})
 
-	it("places attachments after extensionArgs and before prompt", () => {
-		const args = buildSubagentArgs(base, ["/abs/a.png", "/abs/b.txt"], ["-e", "ext-one"])
+	it("emits --session <path> and places attachments after extensionArgs and before prompt when a childSessionFile is provided", () => {
+		const args = buildSubagentArgs(base, ["/abs/a.png", "/abs/b.txt"], ["-e", "ext-one"], "/abs/sessions/child.jsonl")
 		expect(args).toEqual([
 			"--mode",
 			"json",
 			"-p",
-			"--no-session",
+			"--session",
+			"/abs/sessions/child.jsonl",
 			"--provider",
 			"kimchi-dev",
 			"--model",
@@ -274,10 +276,96 @@ describe("buildSubagentArgs", () => {
 		])
 	})
 
+	it("falls back to --no-session when childSessionFile is omitted (in-memory parent case)", () => {
+		const args = buildSubagentArgs(base, [], [])
+		expect(args).toContain("--no-session")
+		expect(args).not.toContain("--session")
+	})
+
 	it("passes absolute paths straight through with a single @ prefix", () => {
 		const abs = resolve("/tmp/img.png")
 		const args = buildSubagentArgs(base, [abs], [])
 		expect(args).toContain(`@${abs}`)
 		expect(args.some((a) => a.startsWith("@@"))).toBe(false)
+	})
+})
+
+describe("prepareChildSessionFile", () => {
+	let tmp: string
+
+	beforeEach(() => {
+		tmp = mkdtempSync(join(tmpdir(), "subagent-prewrite-"))
+	})
+	afterEach(() => {
+		rmSync(tmp, { recursive: true, force: true })
+	})
+
+	it("returns undefined when the parent session file is undefined (in-memory parent)", () => {
+		expect(prepareChildSessionFile(tmp, undefined, "/some/cwd")).toBeUndefined()
+	})
+
+	it("returns undefined when the parent session dir is empty", () => {
+		expect(prepareChildSessionFile("", "/abs/parent.jsonl", "/some/cwd")).toBeUndefined()
+	})
+
+	it("writes a header-only file with correct fields and schema version", () => {
+		const parentFile = join(tmp, "parent.jsonl")
+		const fixedId = "01928374-5565-7abc-8def-123456789abc"
+		const fixedTs = new Date("2026-04-24T10:20:30.400Z")
+
+		const prepared = prepareChildSessionFile(
+			tmp,
+			parentFile,
+			"/work/dir",
+			undefined,
+			() => fixedId,
+			() => fixedTs,
+		)
+
+		expect(prepared).toBeDefined()
+		expect(prepared?.sessionId).toBe(fixedId)
+		// Filename pattern: <ISO-with-colons-and-dots-replaced>_<uuid>.jsonl in the parent session dir.
+		expect(prepared?.childSessionFile).toBe(join(tmp, `2026-04-24T10-20-30-400Z_${fixedId}.jsonl`))
+
+		const contents = readFileSync(prepared?.childSessionFile ?? "", "utf-8")
+		expect(contents.endsWith("\n")).toBe(true)
+		const lines = contents.trimEnd().split("\n")
+		expect(lines).toHaveLength(1)
+
+		const header = JSON.parse(lines[0]) as Record<string, unknown>
+		expect(header).toEqual({
+			type: "session",
+			version: CURRENT_SESSION_VERSION,
+			id: fixedId,
+			timestamp: fixedTs.toISOString(),
+			cwd: "/work/dir",
+			parentSession: parentFile,
+		})
+	})
+
+	it("writes the header file with 0o600 permissions", () => {
+		const parentFile = join(tmp, "parent.jsonl")
+		const prepared = prepareChildSessionFile(tmp, parentFile, "/work/dir")
+
+		// Ensure the prepared path actually landed in the parent dir.
+		expect(prepared?.childSessionFile.startsWith(tmp)).toBe(true)
+		const mode = statSync(prepared?.childSessionFile ?? "").mode & 0o777
+		expect(mode).toBe(0o600)
+	})
+
+	it("propagates I/O errors (e.g. non-existent parent dir) so callers can surface them", () => {
+		const missingDir = join(tmp, "does-not-exist")
+		const parentFile = join(missingDir, "parent.jsonl")
+		expect(() => prepareChildSessionFile(missingDir, parentFile, "/work/dir")).toThrow()
+	})
+
+	it("uses real uuidv7 by default and produces a distinct session per call", () => {
+		const parentFile = join(tmp, "parent.jsonl")
+		const a = prepareChildSessionFile(tmp, parentFile, "/work/dir")
+		const b = prepareChildSessionFile(tmp, parentFile, "/work/dir")
+		expect(a?.sessionId).toBeTruthy()
+		expect(b?.sessionId).toBeTruthy()
+		expect(a?.sessionId).not.toBe(b?.sessionId)
+		expect(a?.childSessionFile).not.toBe(b?.childSessionFile)
 	})
 })

--- a/src/extensions/subagent.test.ts
+++ b/src/extensions/subagent.test.ts
@@ -317,7 +317,6 @@ describe("prepareChildSessionFile", () => {
 			tmp,
 			parentFile,
 			"/work/dir",
-			undefined,
 			() => fixedId,
 			() => fixedTs,
 		)
@@ -325,9 +324,9 @@ describe("prepareChildSessionFile", () => {
 		expect(prepared).toBeDefined()
 		expect(prepared?.sessionId).toBe(fixedId)
 		// Filename pattern: <ISO-with-colons-and-dots-replaced>_<uuid>.jsonl in the parent session dir.
-		expect(prepared?.childSessionFile).toBe(join(tmp, `2026-04-24T10-20-30-400Z_${fixedId}.jsonl`))
+		expect(prepared?.sessionFile).toBe(join(tmp, `2026-04-24T10-20-30-400Z_${fixedId}.jsonl`))
 
-		const contents = readFileSync(prepared?.childSessionFile ?? "", "utf-8")
+		const contents = readFileSync(prepared?.sessionFile ?? "", "utf-8")
 		expect(contents.endsWith("\n")).toBe(true)
 		const lines = contents.trimEnd().split("\n")
 		expect(lines).toHaveLength(1)
@@ -343,13 +342,13 @@ describe("prepareChildSessionFile", () => {
 		})
 	})
 
+	// Prompt content may contain secrets, so the header file must not be world/group-readable.
 	it("writes the header file with 0o600 permissions", () => {
 		const parentFile = join(tmp, "parent.jsonl")
 		const prepared = prepareChildSessionFile(tmp, parentFile, "/work/dir")
 
-		// Ensure the prepared path actually landed in the parent dir.
-		expect(prepared?.childSessionFile.startsWith(tmp)).toBe(true)
-		const mode = statSync(prepared?.childSessionFile ?? "").mode & 0o777
+		expect(prepared?.sessionFile.startsWith(tmp)).toBe(true)
+		const mode = statSync(prepared?.sessionFile ?? "").mode & 0o777
 		expect(mode).toBe(0o600)
 	})
 
@@ -359,7 +358,7 @@ describe("prepareChildSessionFile", () => {
 		expect(() => prepareChildSessionFile(missingDir, parentFile, "/work/dir")).toThrow()
 	})
 
-	// PRD N4: parallel subagents under one parent must each get a distinct sessionId. Guards against regressions like caching/memoizing the id per parent, which would silently collide under fan-out.
+	// Guards against regressions like caching/memoizing the id per parent, which would silently collide under fan-out.
 	it("assigns a distinct sessionId to each call so parallel spawns cannot collide", () => {
 		const parentFile = join(tmp, "parent.jsonl")
 		const ids = Array.from({ length: 8 }, () => prepareChildSessionFile(tmp, parentFile, "/work/dir")?.sessionId)

--- a/src/extensions/subagent.ts
+++ b/src/extensions/subagent.ts
@@ -1,10 +1,17 @@
 import { spawn } from "node:child_process"
-import { existsSync } from "node:fs"
-import { dirname, isAbsolute, resolve } from "node:path"
+import { existsSync, writeFileSync } from "node:fs"
+import { dirname, isAbsolute, join, resolve } from "node:path"
 import type { AssistantMessage, ToolCall } from "@mariozechner/pi-ai"
-import type { ExtensionAPI, SessionEntry, Theme } from "@mariozechner/pi-coding-agent"
+import {
+	CURRENT_SESSION_VERSION,
+	type ExtensionAPI,
+	type SessionEntry,
+	type SessionHeader,
+	type Theme,
+} from "@mariozechner/pi-coding-agent"
 import { Container, Spacer, Text, truncateToWidth, wrapTextWithAnsi } from "@mariozechner/pi-tui"
 import { Type } from "@sinclair/typebox"
+import { v7 as uuidv7 } from "uuid"
 import { ToolBlockView, getTextContent } from "../components/tool-block.js"
 import { isBunBinary, isRunningUnderBun } from "../env.js"
 import { isToolExpanded, registerToolCall } from "../expand-state.js"
@@ -175,12 +182,14 @@ export function buildSubagentArgs(
 	params: { provider: string; model: string; prompt: string },
 	resolvedAttachments: string[],
 	extensionArgs: string[],
+	childSessionFile?: string,
 ): string[] {
+	const sessionArgs = childSessionFile !== undefined ? ["--session", childSessionFile] : ["--no-session"]
 	return [
 		"--mode",
 		"json",
 		"-p",
-		"--no-session",
+		...sessionArgs,
 		"--provider",
 		params.provider,
 		"--model",
@@ -419,6 +428,8 @@ function formatFooterStatus(counts: Map<string, number>, theme: Theme): string {
 interface SubagentStats {
 	durationMs: number
 	tokenUsage: SubagentTokenUsage
+	sessionId?: string
+	sessionFile?: string
 }
 
 function formatStats(stats: SubagentStats, theme: Theme): string {
@@ -534,7 +545,22 @@ export default function (pi: ExtensionAPI) {
 					isError: true,
 				}
 			}
-			const args = buildSubagentArgs(params, validated.resolved, collectExtensionArgs())
+			const parentSessionDir = ctx.sessionManager.getSessionDir()
+			const parentSessionFile = ctx.sessionManager.getSessionFile()
+			const sessionId = uuidv7()
+			const timestamp = new Date().toISOString()
+			const childSessionFile = join(parentSessionDir, `${timestamp.replace(/[:.]/g, "-")}_${sessionId}.jsonl`)
+			const header: SessionHeader = {
+				type: "session",
+				version: CURRENT_SESSION_VERSION,
+				id: sessionId,
+				timestamp,
+				cwd: ctx.cwd,
+				parentSession: parentSessionFile,
+			}
+			writeFileSync(childSessionFile, `${JSON.stringify(header)}\n`)
+
+			const args = buildSubagentArgs(params, validated.resolved, collectExtensionArgs(), childSessionFile)
 			const invocation = getSubagentInvocation(args)
 
 			let lastToolCall: string | undefined
@@ -569,7 +595,7 @@ export default function (pi: ExtensionAPI) {
 				ctx.ui.setStatus(FOOTER_STATUS_KEY, formatFooterStatus(sessionCounts, ctx.ui.theme))
 			}
 
-			const stats: SubagentStats = { durationMs, tokenUsage }
+			const stats: SubagentStats = { durationMs, tokenUsage, sessionId, sessionFile: childSessionFile }
 
 			if (failureReason !== undefined || exitCode !== 0) {
 				const error: SubagentError = {

--- a/src/extensions/subagent.ts
+++ b/src/extensions/subagent.ts
@@ -547,18 +547,41 @@ export default function (pi: ExtensionAPI) {
 			}
 			const parentSessionDir = ctx.sessionManager.getSessionDir()
 			const parentSessionFile = ctx.sessionManager.getSessionFile()
-			const sessionId = uuidv7()
-			const timestamp = new Date().toISOString()
-			const childSessionFile = join(parentSessionDir, `${timestamp.replace(/[:.]/g, "-")}_${sessionId}.jsonl`)
-			const header: SessionHeader = {
-				type: "session",
-				version: CURRENT_SESSION_VERSION,
-				id: sessionId,
-				timestamp,
-				cwd: ctx.cwd,
-				parentSession: parentSessionFile,
+			// Parent is in-memory (--no-session) or has no resolvable session dir: there's nothing to back-reference, so skip the pre-write and let the child run with --no-session too. No broken links, no orphan files.
+			const canPersistChild = parentSessionFile !== undefined && parentSessionDir.length > 0
+			let sessionId: string | undefined
+			let childSessionFile: string | undefined
+			if (canPersistChild) {
+				sessionId = uuidv7()
+				const timestamp = new Date().toISOString()
+				childSessionFile = join(parentSessionDir, `${timestamp.replace(/[:.]/g, "-")}_${sessionId}.jsonl`)
+				const header: SessionHeader = {
+					type: "session",
+					version: CURRENT_SESSION_VERSION,
+					id: sessionId,
+					timestamp,
+					cwd: ctx.cwd,
+					parentSession: parentSessionFile,
+				}
+				try {
+					writeFileSync(childSessionFile, `${JSON.stringify(header)}\n`, { mode: 0o600 })
+				} catch (err) {
+					const detail = err instanceof Error ? err.message : String(err)
+					const zeroUsage: SubagentTokenUsage = { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 }
+					const error: SubagentError = {
+						reason: "exit_error",
+						model: params.model,
+						tokenUsage: zeroUsage,
+						durationMs: 0,
+						detail: `Failed to pre-write subagent session file at ${childSessionFile}: ${detail}`,
+					}
+					return {
+						content: [{ type: "text", text: JSON.stringify(error) }],
+						details: { durationMs: 0, tokenUsage: zeroUsage },
+						isError: true,
+					}
+				}
 			}
-			writeFileSync(childSessionFile, `${JSON.stringify(header)}\n`)
 
 			const args = buildSubagentArgs(params, validated.resolved, collectExtensionArgs(), childSessionFile)
 			const invocation = getSubagentInvocation(args)

--- a/src/extensions/subagent.ts
+++ b/src/extensions/subagent.ts
@@ -200,6 +200,37 @@ export function buildSubagentArgs(
 	]
 }
 
+export interface PreparedChildSession {
+	sessionId: string
+	childSessionFile: string
+}
+
+/** Pre-writes a header-only .jsonl session file for a subagent child so pi-mono's `--session <path>` opens it and preserves the back-reference to the parent. Returns undefined when the parent has no persistent session to link to (in-memory / --no-session parent, or empty session dir). Throws on I/O errors so callers can surface them as subagent failures. Exposed for testing. */
+export function prepareChildSessionFile(
+	parentSessionDir: string,
+	parentSessionFile: string | undefined,
+	cwd: string,
+	writeFile: (path: string, data: string, mode: number) => void = (p, d, m) => writeFileSync(p, d, { mode: m }),
+	generateId: () => string = uuidv7,
+	now: () => Date = () => new Date(),
+): PreparedChildSession | undefined {
+	// Parent is in-memory (--no-session) or has no resolvable session dir: there's nothing to back-reference, so skip the pre-write and let the child run with --no-session too. No broken links, no orphan files.
+	if (parentSessionFile === undefined || parentSessionDir.length === 0) return undefined
+	const sessionId = generateId()
+	const timestamp = now().toISOString()
+	const childSessionFile = join(parentSessionDir, `${timestamp.replace(/[:.]/g, "-")}_${sessionId}.jsonl`)
+	const header: SessionHeader = {
+		type: "session",
+		version: CURRENT_SESSION_VERSION,
+		id: sessionId,
+		timestamp,
+		cwd,
+		parentSession: parentSessionFile,
+	}
+	writeFile(childSessionFile, `${JSON.stringify(header)}\n`, 0o600)
+	return { sessionId, childSessionFile }
+}
+
 function getSubagentInvocation(args: string[]): { command: string; args: string[] } {
 	// Bun single-file binary: process.execPath IS the self-contained binary and the entry script is baked in, so we spawn with just the CLI args. Do NOT prepend process.argv[1] — it's a virtual /$bunfs/... path that only exists inside this process's embedded filesystem, and the child would either error or misread it as a positional arg.
 	if (isBunBinary) {
@@ -547,39 +578,28 @@ export default function (pi: ExtensionAPI) {
 			}
 			const parentSessionDir = ctx.sessionManager.getSessionDir()
 			const parentSessionFile = ctx.sessionManager.getSessionFile()
-			// Parent is in-memory (--no-session) or has no resolvable session dir: there's nothing to back-reference, so skip the pre-write and let the child run with --no-session too. No broken links, no orphan files.
-			const canPersistChild = parentSessionFile !== undefined && parentSessionDir.length > 0
 			let sessionId: string | undefined
 			let childSessionFile: string | undefined
-			if (canPersistChild) {
-				sessionId = uuidv7()
-				const timestamp = new Date().toISOString()
-				childSessionFile = join(parentSessionDir, `${timestamp.replace(/[:.]/g, "-")}_${sessionId}.jsonl`)
-				const header: SessionHeader = {
-					type: "session",
-					version: CURRENT_SESSION_VERSION,
-					id: sessionId,
-					timestamp,
-					cwd: ctx.cwd,
-					parentSession: parentSessionFile,
+			try {
+				const prepared = prepareChildSessionFile(parentSessionDir, parentSessionFile, ctx.cwd)
+				if (prepared) {
+					sessionId = prepared.sessionId
+					childSessionFile = prepared.childSessionFile
 				}
-				try {
-					writeFileSync(childSessionFile, `${JSON.stringify(header)}\n`, { mode: 0o600 })
-				} catch (err) {
-					const detail = err instanceof Error ? err.message : String(err)
-					const zeroUsage: SubagentTokenUsage = { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 }
-					const error: SubagentError = {
-						reason: "exit_error",
-						model: params.model,
-						tokenUsage: zeroUsage,
-						durationMs: 0,
-						detail: `Failed to pre-write subagent session file at ${childSessionFile}: ${detail}`,
-					}
-					return {
-						content: [{ type: "text", text: JSON.stringify(error) }],
-						details: { durationMs: 0, tokenUsage: zeroUsage },
-						isError: true,
-					}
+			} catch (err) {
+				const detail = err instanceof Error ? err.message : String(err)
+				const zeroUsage: SubagentTokenUsage = { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 }
+				const error: SubagentError = {
+					reason: "exit_error",
+					model: params.model,
+					tokenUsage: zeroUsage,
+					durationMs: 0,
+					detail: `Failed to pre-write subagent session file under ${parentSessionDir}: ${detail}`,
+				}
+				return {
+					content: [{ type: "text", text: JSON.stringify(error) }],
+					details: { durationMs: 0, tokenUsage: zeroUsage },
+					isError: true,
 				}
 			}
 

--- a/src/extensions/subagent.ts
+++ b/src/extensions/subagent.ts
@@ -200,9 +200,9 @@ export function buildSubagentArgs(
 	]
 }
 
-export interface PreparedChildSession {
+export interface ChildSessionHandle {
 	sessionId: string
-	childSessionFile: string
+	sessionFile: string
 }
 
 /** Pre-writes a header-only .jsonl session file for a subagent child so pi-mono's `--session <path>` opens it and preserves the back-reference to the parent. Returns undefined when the parent has no persistent session to link to (in-memory / --no-session parent, or empty session dir). Throws on I/O errors so callers can surface them as subagent failures. Exposed for testing. */
@@ -210,15 +210,14 @@ export function prepareChildSessionFile(
 	parentSessionDir: string,
 	parentSessionFile: string | undefined,
 	cwd: string,
-	writeFile: (path: string, data: string, mode: number) => void = (p, d, m) => writeFileSync(p, d, { mode: m }),
 	generateId: () => string = uuidv7,
 	now: () => Date = () => new Date(),
-): PreparedChildSession | undefined {
+): ChildSessionHandle | undefined {
 	// Parent is in-memory (--no-session) or has no resolvable session dir: there's nothing to back-reference, so skip the pre-write and let the child run with --no-session too. No broken links, no orphan files.
 	if (parentSessionFile === undefined || parentSessionDir.length === 0) return undefined
 	const sessionId = generateId()
 	const timestamp = now().toISOString()
-	const childSessionFile = join(parentSessionDir, `${timestamp.replace(/[:.]/g, "-")}_${sessionId}.jsonl`)
+	const sessionFile = join(parentSessionDir, `${timestamp.replace(/[:.]/g, "-")}_${sessionId}.jsonl`)
 	const header: SessionHeader = {
 		type: "session",
 		version: CURRENT_SESSION_VERSION,
@@ -227,8 +226,8 @@ export function prepareChildSessionFile(
 		cwd,
 		parentSession: parentSessionFile,
 	}
-	writeFile(childSessionFile, `${JSON.stringify(header)}\n`, 0o600)
-	return { sessionId, childSessionFile }
+	writeFileSync(sessionFile, `${JSON.stringify(header)}\n`, { mode: 0o600 })
+	return { sessionId, sessionFile }
 }
 
 function getSubagentInvocation(args: string[]): { command: string; args: string[] } {
@@ -584,7 +583,7 @@ export default function (pi: ExtensionAPI) {
 				const prepared = prepareChildSessionFile(parentSessionDir, parentSessionFile, ctx.cwd)
 				if (prepared) {
 					sessionId = prepared.sessionId
-					childSessionFile = prepared.childSessionFile
+					childSessionFile = prepared.sessionFile
 				}
 			} catch (err) {
 				const detail = err instanceof Error ? err.message : String(err)

--- a/tests/smoke/subagent-session-tracking.test.ts
+++ b/tests/smoke/subagent-session-tracking.test.ts
@@ -1,17 +1,10 @@
-// Smoke test for subagent session tracking (PRD: prd/subagent-session-tracking.md).
-// Exercises the end-to-end path that unit tests can't reach: a real kimchi run
-// spawns a real subagent subprocess, and the parent and child session files
-// must land side-by-side on disk with the correct linkage.
+// End-to-end checks that a real kimchi run spawning a real subagent subprocess leaves parent and child session files side-by-side on disk with bidirectional linkage — the path unit tests can't reach.
 
-import { mkdtempSync, readFileSync, readdirSync, rmSync, statSync } from "node:fs"
+import { mkdtempSync, readFileSync, readdirSync, rmSync } from "node:fs"
 import { tmpdir } from "node:os"
 import { join } from "node:path"
 import { afterEach, beforeEach, describe, expect, it } from "vitest"
 import { runBinary } from "./harness.js"
-
-if (!process.env.KIMCHI_API_KEY) {
-	console.warn("[smoke] KIMCHI_API_KEY not set — subagent-session-tracking smoke test will be skipped.")
-}
 
 interface TokenUsage {
 	input: number
@@ -37,77 +30,26 @@ interface SessionEntry {
 	}
 }
 
-function readJsonl<T = SessionEntry>(path: string): T[] {
+function readJsonl(path: string): SessionEntry[] {
 	return readFileSync(path, "utf-8")
 		.split("\n")
 		.filter((l) => l.trim().length > 0)
-		.map((l) => JSON.parse(l) as T)
+		.map((l) => JSON.parse(l) as SessionEntry)
 }
 
-const ZERO_USAGE: TokenUsage = { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 }
-
-function addUsage(a: TokenUsage, b: TokenUsage): TokenUsage {
-	return {
-		input: a.input + b.input,
-		output: a.output + b.output,
-		cacheRead: a.cacheRead + b.cacheRead,
-		cacheWrite: a.cacheWrite + b.cacheWrite,
-	}
-}
-
-function subtractUsage(a: TokenUsage, b: TokenUsage): TokenUsage {
-	return {
-		input: a.input - b.input,
-		output: a.output - b.output,
-		cacheRead: a.cacheRead - b.cacheRead,
-		cacheWrite: a.cacheWrite - b.cacheWrite,
-	}
-}
-
-// Per-session sum of `message.usage` across every assistant message — this is the child's "per-turn" billing, recomputed from the on-disk session file.
+// Sum `message.usage` across every assistant message in a session file — reconstructs per-turn billing from disk.
 function sumAssistantUsage(entries: SessionEntry[]): TokenUsage {
-	let total: TokenUsage = { ...ZERO_USAGE }
+	const total: TokenUsage = { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 }
 	for (const entry of entries) {
 		if (entry.type !== "message" || entry.message?.role !== "assistant") continue
 		const u = entry.message.usage
 		if (!u) continue
-		total = addUsage(total, {
-			input: u.input ?? 0,
-			output: u.output ?? 0,
-			cacheRead: u.cacheRead ?? 0,
-			cacheWrite: u.cacheWrite ?? 0,
-		})
+		total.input += u.input ?? 0
+		total.output += u.output ?? 0
+		total.cacheRead += u.cacheRead ?? 0
+		total.cacheWrite += u.cacheWrite ?? 0
 	}
 	return total
-}
-
-// Every (parentSession, subagentStats) edge carried in a parent session file's tool-result entries.
-interface BillingEdge {
-	parentFile: string
-	childSessionId: string
-	childSessionFile: string
-	aggregate: TokenUsage
-}
-
-function extractSubagentEdges(parentFile: string, entries: SessionEntry[]): BillingEdge[] {
-	const edges: BillingEdge[] = []
-	for (const entry of entries) {
-		if (entry.type !== "message" || entry.message?.role !== "toolResult") continue
-		const details = entry.message.details as SubagentDetails | undefined
-		if (!details?.sessionId || !details.sessionFile || !details.tokenUsage) continue
-		edges.push({
-			parentFile,
-			childSessionId: details.sessionId,
-			childSessionFile: details.sessionFile,
-			aggregate: {
-				input: details.tokenUsage.input,
-				output: details.tokenUsage.output,
-				cacheRead: details.tokenUsage.cacheRead,
-				cacheWrite: details.tokenUsage.cacheWrite,
-			},
-		})
-	}
-	return edges
 }
 
 describe("subagent session tracking smoke tests", () => {
@@ -140,13 +82,8 @@ describe("subagent session tracking smoke tests", () => {
 				timeoutMs: 55_000,
 			})
 
-			// Expect at least 2 session files: one parent, one child. In-memory aux files (like lock files) can bring more; we just need ≥ 2.
 			const files = readdirSync(sessionDir).filter((f) => f.endsWith(".jsonl"))
-			expect(files.length, "expected parent + child session files in the custom --session-dir").toBeGreaterThanOrEqual(
-				2,
-			)
-
-			const sessionsByHeader = new Map<
+			const sessionsByFile = new Map<
 				string,
 				{ file: string; header: { id?: string; parentSession?: string }; entries: SessionEntry[] }
 			>()
@@ -155,11 +92,11 @@ describe("subagent session tracking smoke tests", () => {
 				const entries = readJsonl(full)
 				const header = entries[0] as unknown as { id?: string; parentSession?: string; type?: string }
 				if (header?.type !== "session") continue
-				sessionsByHeader.set(name, { file: full, header, entries })
+				sessionsByFile.set(name, { file: full, header, entries })
 			}
 
-			const parent = [...sessionsByHeader.values()].find((s) => !s.header.parentSession)
-			const child = [...sessionsByHeader.values()].find((s) => s.header.parentSession !== undefined)
+			const parent = [...sessionsByFile.values()].find((s) => !s.header.parentSession)
+			const child = [...sessionsByFile.values()].find((s) => s.header.parentSession !== undefined)
 			expect(parent, "parent session file (no parentSession header) should exist").toBeDefined()
 			expect(child, "child session file (with parentSession header) should exist").toBeDefined()
 
@@ -180,17 +117,12 @@ describe("subagent session tracking smoke tests", () => {
 			const details = toolResult?.message?.details as SubagentDetails
 			expect(details.sessionId).toBe(child?.header.id)
 			expect(details.sessionFile).toBe(child?.file)
-
-			// Retention: removing the parent session dir removes the child (same dir, by D3/D5).
-			const childPath = child?.file
-			rmSync(sessionDir, { recursive: true, force: true })
-			expect(() => statSync(childPath as string)).toThrow()
 		},
 	)
 
-	// Phase 5: a subagent that itself spawns a further subagent must land its grandchild in the top-level parent's session directory, with a back-reference chain grandchild → child → parent intact. This is load-bearing for pi's session-selector tree rendering at depth > 1 and for the billing walk convention — neither works if descendants scatter across directories.
+	// Nesting: a subagent that itself spawns a subagent must land its grandchild in the top-level parent's dir, with a back-reference chain parent → child → grandchild intact. Load-bearing for pi's session-selector tree UI at depth > 1. The test also pins that each child's on-disk `message.usage` sum matches the aggregate the parent recorded in SubagentStats — i.e. pi-mono's assistant-usage fields don't drift from kimchi-dev's stdout aggregation.
 	it.skipIf(!process.env.KIMCHI_API_KEY)(
-		"nested subagent runs keep all descendants in the top-level parent's directory with an intact back-reference chain",
+		"nested subagent runs keep all descendants in the top-level parent's directory, with intact back-references and reconciled per-turn usage",
 		{ timeout: 120_000, retry: 1 },
 		() => {
 			const prompt = [
@@ -216,13 +148,7 @@ describe("subagent session tracking smoke tests", () => {
 				timeoutMs: 110_000,
 			})
 
-			// Expect ≥ 3 session files: parent, child, grandchild — all as siblings in the top-level parent dir.
 			const files = readdirSync(sessionDir).filter((f) => f.endsWith(".jsonl"))
-			expect(
-				files.length,
-				"expected parent + child + grandchild session files in the top-level --session-dir",
-			).toBeGreaterThanOrEqual(3)
-
 			const sessionsByFile = new Map<
 				string,
 				{ file: string; header: { id?: string; parentSession?: string }; entries: SessionEntry[] }
@@ -249,7 +175,7 @@ describe("subagent session tracking smoke tests", () => {
 			expect(child?.file.startsWith(`${sessionDir}/`)).toBe(true)
 			expect(grandchild?.file.startsWith(`${sessionDir}/`)).toBe(true)
 
-			// Forward linkage: each level's tool-result must point at the next level's session file/id.
+			// Forward linkage: each level's tool-result points at the next level's session file/id, AND the aggregate tokenUsage the parent recorded matches the child's on-disk per-turn usage sum.
 			const parentToolResult = parent?.entries.find(
 				(e) =>
 					e.type === "message" &&
@@ -257,7 +183,11 @@ describe("subagent session tracking smoke tests", () => {
 					(e.message.details as SubagentDetails | undefined)?.sessionFile === child?.file,
 			)
 			expect(parentToolResult, "parent tool-result should reference child.sessionFile").toBeDefined()
-			expect((parentToolResult?.message?.details as SubagentDetails).sessionId).toBe(child?.header.id)
+			const parentDetails = parentToolResult?.message?.details as SubagentDetails
+			expect(parentDetails.sessionId).toBe(child?.header.id)
+			expect(parentDetails.tokenUsage, "child per-turn sum must equal parent's recorded aggregate").toEqual(
+				sumAssistantUsage(child?.entries ?? []),
+			)
 
 			const childToolResult = child?.entries.find(
 				(e) =>
@@ -266,108 +196,11 @@ describe("subagent session tracking smoke tests", () => {
 					(e.message.details as SubagentDetails | undefined)?.sessionFile === grandchild?.file,
 			)
 			expect(childToolResult, "child tool-result should reference grandchild.sessionFile").toBeDefined()
-			expect((childToolResult?.message?.details as SubagentDetails).sessionId).toBe(grandchild?.header.id)
-		},
-	)
-
-	// Phase 6: walk a real nested-subagent session directory and confirm per-turn usage stored in each child's session file reconciles with the aggregate SubagentStats recorded in its parent's tool-result, and that the PRD §10 billing-walk conventions (leaves-only and all-minus-aggregates) agree on the total. This is the success-criterion #3 check — if it diverges, downstream billing tooling cannot trust the on-disk session files.
-	it.skipIf(!process.env.KIMCHI_API_KEY)(
-		"per-turn usage in each child session file matches the aggregate in the parent's tool-result, and both rollup conventions agree on the total",
-		{ timeout: 120_000, retry: 1 },
-		() => {
-			const prompt = [
-				"Use the `subagent` tool exactly once with these arguments:",
-				'- provider: "kimchi-dev"',
-				'- model: "kimi-k2.5"',
-				"- prompt: (multi-line, copy verbatim)",
-				'    """',
-				"    Use the `subagent` tool exactly once with these arguments:",
-				'    - provider: "kimchi-dev"',
-				'    - model: "kimi-k2.5"',
-				'    - prompt: "Reply with only the single word: OK"',
-				"",
-				"    After it returns, echo the subagent's reply verbatim as your final answer and nothing else.",
-				'    """',
-				"",
-				"After it returns, echo the subagent's reply verbatim as your final answer and nothing else.",
-			].join("\n")
-
-			runBinary({
-				args: ["--session-dir", sessionDir, "-p", prompt],
-				extraEnv: { KIMCHI_API_KEY: process.env.KIMCHI_API_KEY as string },
-				timeoutMs: 110_000,
-			})
-
-			const files = readdirSync(sessionDir).filter((f) => f.endsWith(".jsonl"))
-			expect(files.length, "billing walk needs the full nested tree on disk").toBeGreaterThanOrEqual(3)
-
-			interface Loaded {
-				file: string
-				id: string
-				parentSession: string | undefined
-				entries: SessionEntry[]
-				perTurn: TokenUsage
-				edges: BillingEdge[]
-			}
-
-			const sessions: Loaded[] = []
-			for (const name of files) {
-				const full = join(sessionDir, name)
-				const entries = readJsonl(full)
-				const header = entries[0] as unknown as { type?: string; id?: string; parentSession?: string }
-				if (header?.type !== "session" || !header.id) continue
-				sessions.push({
-					file: full,
-					id: header.id,
-					parentSession: header.parentSession,
-					entries,
-					perTurn: sumAssistantUsage(entries),
-					edges: extractSubagentEdges(full, entries),
-				})
-			}
-
-			const byFile = new Map(sessions.map((s) => [s.file, s]))
-			const allEdges = sessions.flatMap((s) => s.edges)
-			expect(
-				allEdges.length,
-				"billing walk expects at least two subagent edges (top → child, child → grandchild)",
-			).toBeGreaterThanOrEqual(2)
-
-			// Primary reconciliation: for every SubagentStats edge, the aggregate stored on the parent equals the sum of `message.usage` across the child's assistant messages. A mismatch here means either the stdout message_end stream missed a turn or the child flushed a message the parent didn't count.
-			for (const edge of allEdges) {
-				const child = byFile.get(edge.childSessionFile)
-				expect(
-					child,
-					`child session file referenced by edge should exist on disk: ${edge.childSessionFile}`,
-				).toBeDefined()
-				if (!child) continue
-				expect(
-					child.perTurn,
-					`child ${edge.childSessionId} per-turn sum must equal its parent's SubagentStats.tokenUsage`,
-				).toEqual(edge.aggregate)
-			}
-
-			// Secondary self-consistency: PRD §10 gives two conventions for summing tokens across a session directory without double-counting. They must yield identical totals over the same tree.
-			const referencedIds = new Set(allEdges.map((e) => e.childSessionId))
-			const leavesTotal = sessions
-				.filter((s) => !referencedIds.has(s.id))
-				.map((s) => s.perTurn)
-				.reduce(addUsage, { ...ZERO_USAGE })
-
-			const allSummed = sessions.map((s) => s.perTurn).reduce(addUsage, { ...ZERO_USAGE })
-			const subtractTotal = allEdges.map((e) => e.aggregate).reduce(subtractUsage, allSummed)
-
-			expect(
-				leavesTotal,
-				"leaves-only and all-minus-aggregates conventions must agree on the billing total over the same session tree",
-			).toEqual(subtractTotal)
-
-			console.log("[phase6] billing walk:", {
-				sessions: sessions.length,
-				edges: allEdges.length,
-				leavesTotal,
-				subtractTotal,
-			})
+			const childDetails = childToolResult?.message?.details as SubagentDetails
+			expect(childDetails.sessionId).toBe(grandchild?.header.id)
+			expect(childDetails.tokenUsage, "grandchild per-turn sum must equal child's recorded aggregate").toEqual(
+				sumAssistantUsage(grandchild?.entries ?? []),
+			)
 		},
 	)
 })

--- a/tests/smoke/subagent-session-tracking.test.ts
+++ b/tests/smoke/subagent-session-tracking.test.ts
@@ -13,16 +13,28 @@ if (!process.env.KIMCHI_API_KEY) {
 	console.warn("[smoke] KIMCHI_API_KEY not set — subagent-session-tracking smoke test will be skipped.")
 }
 
+interface TokenUsage {
+	input: number
+	output: number
+	cacheRead: number
+	cacheWrite: number
+}
+
 interface SubagentDetails {
 	sessionId?: string
 	sessionFile?: string
-	tokenUsage?: unknown
+	tokenUsage?: TokenUsage
 	durationMs?: number
 }
 
 interface SessionEntry {
 	type: string
-	message?: { role?: string; toolCallId?: string; details?: unknown }
+	message?: {
+		role?: string
+		toolCallId?: string
+		details?: unknown
+		usage?: { input?: number; output?: number; cacheRead?: number; cacheWrite?: number }
+	}
 }
 
 function readJsonl<T = SessionEntry>(path: string): T[] {
@@ -30,6 +42,72 @@ function readJsonl<T = SessionEntry>(path: string): T[] {
 		.split("\n")
 		.filter((l) => l.trim().length > 0)
 		.map((l) => JSON.parse(l) as T)
+}
+
+const ZERO_USAGE: TokenUsage = { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 }
+
+function addUsage(a: TokenUsage, b: TokenUsage): TokenUsage {
+	return {
+		input: a.input + b.input,
+		output: a.output + b.output,
+		cacheRead: a.cacheRead + b.cacheRead,
+		cacheWrite: a.cacheWrite + b.cacheWrite,
+	}
+}
+
+function subtractUsage(a: TokenUsage, b: TokenUsage): TokenUsage {
+	return {
+		input: a.input - b.input,
+		output: a.output - b.output,
+		cacheRead: a.cacheRead - b.cacheRead,
+		cacheWrite: a.cacheWrite - b.cacheWrite,
+	}
+}
+
+// Per-session sum of `message.usage` across every assistant message — this is the child's "per-turn" billing, recomputed from the on-disk session file.
+function sumAssistantUsage(entries: SessionEntry[]): TokenUsage {
+	let total: TokenUsage = { ...ZERO_USAGE }
+	for (const entry of entries) {
+		if (entry.type !== "message" || entry.message?.role !== "assistant") continue
+		const u = entry.message.usage
+		if (!u) continue
+		total = addUsage(total, {
+			input: u.input ?? 0,
+			output: u.output ?? 0,
+			cacheRead: u.cacheRead ?? 0,
+			cacheWrite: u.cacheWrite ?? 0,
+		})
+	}
+	return total
+}
+
+// Every (parentSession, subagentStats) edge carried in a parent session file's tool-result entries.
+interface BillingEdge {
+	parentFile: string
+	childSessionId: string
+	childSessionFile: string
+	aggregate: TokenUsage
+}
+
+function extractSubagentEdges(parentFile: string, entries: SessionEntry[]): BillingEdge[] {
+	const edges: BillingEdge[] = []
+	for (const entry of entries) {
+		if (entry.type !== "message" || entry.message?.role !== "toolResult") continue
+		const details = entry.message.details as SubagentDetails | undefined
+		if (!details?.sessionId || !details.sessionFile || !details.tokenUsage) continue
+		edges.push({
+			parentFile,
+			childSessionId: details.sessionId,
+			childSessionFile: details.sessionFile,
+			aggregate: {
+				input: details.tokenUsage.input,
+				output: details.tokenUsage.output,
+				cacheRead: details.tokenUsage.cacheRead,
+				cacheWrite: details.tokenUsage.cacheWrite,
+			},
+		})
+	}
+	return edges
 }
 
 describe("subagent session tracking smoke tests", () => {
@@ -189,6 +267,107 @@ describe("subagent session tracking smoke tests", () => {
 			)
 			expect(childToolResult, "child tool-result should reference grandchild.sessionFile").toBeDefined()
 			expect((childToolResult?.message?.details as SubagentDetails).sessionId).toBe(grandchild?.header.id)
+		},
+	)
+
+	// Phase 6: walk a real nested-subagent session directory and confirm per-turn usage stored in each child's session file reconciles with the aggregate SubagentStats recorded in its parent's tool-result, and that the PRD §10 billing-walk conventions (leaves-only and all-minus-aggregates) agree on the total. This is the success-criterion #3 check — if it diverges, downstream billing tooling cannot trust the on-disk session files.
+	it.skipIf(!process.env.KIMCHI_API_KEY)(
+		"per-turn usage in each child session file matches the aggregate in the parent's tool-result, and both rollup conventions agree on the total",
+		{ timeout: 120_000, retry: 1 },
+		() => {
+			const prompt = [
+				"Use the `subagent` tool exactly once with these arguments:",
+				'- provider: "kimchi-dev"',
+				'- model: "kimi-k2.5"',
+				"- prompt: (multi-line, copy verbatim)",
+				'    """',
+				"    Use the `subagent` tool exactly once with these arguments:",
+				'    - provider: "kimchi-dev"',
+				'    - model: "kimi-k2.5"',
+				'    - prompt: "Reply with only the single word: OK"',
+				"",
+				"    After it returns, echo the subagent's reply verbatim as your final answer and nothing else.",
+				'    """',
+				"",
+				"After it returns, echo the subagent's reply verbatim as your final answer and nothing else.",
+			].join("\n")
+
+			runBinary({
+				args: ["--session-dir", sessionDir, "-p", prompt],
+				extraEnv: { KIMCHI_API_KEY: process.env.KIMCHI_API_KEY as string },
+				timeoutMs: 110_000,
+			})
+
+			const files = readdirSync(sessionDir).filter((f) => f.endsWith(".jsonl"))
+			expect(files.length, "billing walk needs the full nested tree on disk").toBeGreaterThanOrEqual(3)
+
+			interface Loaded {
+				file: string
+				id: string
+				parentSession: string | undefined
+				entries: SessionEntry[]
+				perTurn: TokenUsage
+				edges: BillingEdge[]
+			}
+
+			const sessions: Loaded[] = []
+			for (const name of files) {
+				const full = join(sessionDir, name)
+				const entries = readJsonl(full)
+				const header = entries[0] as unknown as { type?: string; id?: string; parentSession?: string }
+				if (header?.type !== "session" || !header.id) continue
+				sessions.push({
+					file: full,
+					id: header.id,
+					parentSession: header.parentSession,
+					entries,
+					perTurn: sumAssistantUsage(entries),
+					edges: extractSubagentEdges(full, entries),
+				})
+			}
+
+			const byFile = new Map(sessions.map((s) => [s.file, s]))
+			const allEdges = sessions.flatMap((s) => s.edges)
+			expect(
+				allEdges.length,
+				"billing walk expects at least two subagent edges (top → child, child → grandchild)",
+			).toBeGreaterThanOrEqual(2)
+
+			// Primary reconciliation: for every SubagentStats edge, the aggregate stored on the parent equals the sum of `message.usage` across the child's assistant messages. A mismatch here means either the stdout message_end stream missed a turn or the child flushed a message the parent didn't count.
+			for (const edge of allEdges) {
+				const child = byFile.get(edge.childSessionFile)
+				expect(
+					child,
+					`child session file referenced by edge should exist on disk: ${edge.childSessionFile}`,
+				).toBeDefined()
+				if (!child) continue
+				expect(
+					child.perTurn,
+					`child ${edge.childSessionId} per-turn sum must equal its parent's SubagentStats.tokenUsage`,
+				).toEqual(edge.aggregate)
+			}
+
+			// Secondary self-consistency: PRD §10 gives two conventions for summing tokens across a session directory without double-counting. They must yield identical totals over the same tree.
+			const referencedIds = new Set(allEdges.map((e) => e.childSessionId))
+			const leavesTotal = sessions
+				.filter((s) => !referencedIds.has(s.id))
+				.map((s) => s.perTurn)
+				.reduce(addUsage, { ...ZERO_USAGE })
+
+			const allSummed = sessions.map((s) => s.perTurn).reduce(addUsage, { ...ZERO_USAGE })
+			const subtractTotal = allEdges.map((e) => e.aggregate).reduce(subtractUsage, allSummed)
+
+			expect(
+				leavesTotal,
+				"leaves-only and all-minus-aggregates conventions must agree on the billing total over the same session tree",
+			).toEqual(subtractTotal)
+
+			console.log("[phase6] billing walk:", {
+				sessions: sessions.length,
+				edges: allEdges.length,
+				leavesTotal,
+				subtractTotal,
+			})
 		},
 	)
 })

--- a/tests/smoke/subagent-session-tracking.test.ts
+++ b/tests/smoke/subagent-session-tracking.test.ts
@@ -109,4 +109,86 @@ describe("subagent session tracking smoke tests", () => {
 			expect(() => statSync(childPath as string)).toThrow()
 		},
 	)
+
+	// Phase 5: a subagent that itself spawns a further subagent must land its grandchild in the top-level parent's session directory, with a back-reference chain grandchild → child → parent intact. This is load-bearing for pi's session-selector tree rendering at depth > 1 and for the billing walk convention — neither works if descendants scatter across directories.
+	it.skipIf(!process.env.KIMCHI_API_KEY)(
+		"nested subagent runs keep all descendants in the top-level parent's directory with an intact back-reference chain",
+		{ timeout: 120_000, retry: 1 },
+		() => {
+			const prompt = [
+				"Use the `subagent` tool exactly once with these arguments:",
+				'- provider: "kimchi-dev"',
+				'- model: "kimi-k2.5"',
+				"- prompt: (multi-line, copy verbatim)",
+				'    """',
+				"    Use the `subagent` tool exactly once with these arguments:",
+				'    - provider: "kimchi-dev"',
+				'    - model: "kimi-k2.5"',
+				'    - prompt: "Reply with only the single word: OK"',
+				"",
+				"    After it returns, echo the subagent's reply verbatim as your final answer and nothing else.",
+				'    """',
+				"",
+				"After it returns, echo the subagent's reply verbatim as your final answer and nothing else.",
+			].join("\n")
+
+			runBinary({
+				args: ["--session-dir", sessionDir, "-p", prompt],
+				extraEnv: { KIMCHI_API_KEY: process.env.KIMCHI_API_KEY as string },
+				timeoutMs: 110_000,
+			})
+
+			// Expect ≥ 3 session files: parent, child, grandchild — all as siblings in the top-level parent dir.
+			const files = readdirSync(sessionDir).filter((f) => f.endsWith(".jsonl"))
+			expect(
+				files.length,
+				"expected parent + child + grandchild session files in the top-level --session-dir",
+			).toBeGreaterThanOrEqual(3)
+
+			const sessionsByFile = new Map<
+				string,
+				{ file: string; header: { id?: string; parentSession?: string }; entries: SessionEntry[] }
+			>()
+			for (const name of files) {
+				const full = join(sessionDir, name)
+				const entries = readJsonl(full)
+				const header = entries[0] as unknown as { id?: string; parentSession?: string; type?: string }
+				if (header?.type !== "session") continue
+				sessionsByFile.set(full, { file: full, header, entries })
+			}
+
+			const parent = [...sessionsByFile.values()].find((s) => !s.header.parentSession)
+			expect(parent, "top-level parent session (no parentSession header) should exist").toBeDefined()
+
+			// Walk the chain: parent → child → grandchild via `parentSession` headers.
+			const child = [...sessionsByFile.values()].find((s) => s.header.parentSession === parent?.file)
+			expect(child, "child session back-referencing the parent should exist").toBeDefined()
+
+			const grandchild = [...sessionsByFile.values()].find((s) => s.header.parentSession === child?.file)
+			expect(grandchild, "grandchild session back-referencing the child should exist").toBeDefined()
+
+			// All three must share the same directory — required for pi's non-recursive session-selector tree to render the full chain.
+			expect(child?.file.startsWith(`${sessionDir}/`)).toBe(true)
+			expect(grandchild?.file.startsWith(`${sessionDir}/`)).toBe(true)
+
+			// Forward linkage: each level's tool-result must point at the next level's session file/id.
+			const parentToolResult = parent?.entries.find(
+				(e) =>
+					e.type === "message" &&
+					e.message?.role === "toolResult" &&
+					(e.message.details as SubagentDetails | undefined)?.sessionFile === child?.file,
+			)
+			expect(parentToolResult, "parent tool-result should reference child.sessionFile").toBeDefined()
+			expect((parentToolResult?.message?.details as SubagentDetails).sessionId).toBe(child?.header.id)
+
+			const childToolResult = child?.entries.find(
+				(e) =>
+					e.type === "message" &&
+					e.message?.role === "toolResult" &&
+					(e.message.details as SubagentDetails | undefined)?.sessionFile === grandchild?.file,
+			)
+			expect(childToolResult, "child tool-result should reference grandchild.sessionFile").toBeDefined()
+			expect((childToolResult?.message?.details as SubagentDetails).sessionId).toBe(grandchild?.header.id)
+		},
+	)
 })

--- a/tests/smoke/subagent-session-tracking.test.ts
+++ b/tests/smoke/subagent-session-tracking.test.ts
@@ -1,0 +1,112 @@
+// Smoke test for subagent session tracking (PRD: prd/subagent-session-tracking.md).
+// Exercises the end-to-end path that unit tests can't reach: a real kimchi run
+// spawns a real subagent subprocess, and the parent and child session files
+// must land side-by-side on disk with the correct linkage.
+
+import { mkdtempSync, readFileSync, readdirSync, rmSync, statSync } from "node:fs"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
+import { afterEach, beforeEach, describe, expect, it } from "vitest"
+import { runBinary } from "./harness.js"
+
+if (!process.env.KIMCHI_API_KEY) {
+	console.warn("[smoke] KIMCHI_API_KEY not set — subagent-session-tracking smoke test will be skipped.")
+}
+
+interface SubagentDetails {
+	sessionId?: string
+	sessionFile?: string
+	tokenUsage?: unknown
+	durationMs?: number
+}
+
+interface SessionEntry {
+	type: string
+	message?: { role?: string; toolCallId?: string; details?: unknown }
+}
+
+function readJsonl<T = SessionEntry>(path: string): T[] {
+	return readFileSync(path, "utf-8")
+		.split("\n")
+		.filter((l) => l.trim().length > 0)
+		.map((l) => JSON.parse(l) as T)
+}
+
+describe("subagent session tracking smoke tests", () => {
+	let sessionDir: string
+
+	beforeEach(() => {
+		sessionDir = mkdtempSync(join(tmpdir(), "kimchi-subagent-session-"))
+	})
+
+	afterEach(() => {
+		rmSync(sessionDir, { recursive: true, force: true })
+	})
+
+	it.skipIf(!process.env.KIMCHI_API_KEY)(
+		"subagent run leaves a child session file with a header that back-references the parent, and the parent's tool-result records the child's id and path",
+		{ timeout: 60_000, retry: 1 },
+		() => {
+			const prompt = [
+				"Use the `subagent` tool exactly once with these arguments:",
+				'- provider: "kimchi-dev"',
+				'- model: "kimi-k2.5"',
+				'- prompt: "Reply with only the single word: OK"',
+				"",
+				"After it returns, echo the subagent's reply verbatim as your final answer and nothing else.",
+			].join("\n")
+
+			runBinary({
+				args: ["--session-dir", sessionDir, "-p", prompt],
+				extraEnv: { KIMCHI_API_KEY: process.env.KIMCHI_API_KEY as string },
+				timeoutMs: 55_000,
+			})
+
+			// Expect at least 2 session files: one parent, one child. In-memory aux files (like lock files) can bring more; we just need ≥ 2.
+			const files = readdirSync(sessionDir).filter((f) => f.endsWith(".jsonl"))
+			expect(files.length, "expected parent + child session files in the custom --session-dir").toBeGreaterThanOrEqual(
+				2,
+			)
+
+			const sessionsByHeader = new Map<
+				string,
+				{ file: string; header: { id?: string; parentSession?: string }; entries: SessionEntry[] }
+			>()
+			for (const name of files) {
+				const full = join(sessionDir, name)
+				const entries = readJsonl(full)
+				const header = entries[0] as unknown as { id?: string; parentSession?: string; type?: string }
+				if (header?.type !== "session") continue
+				sessionsByHeader.set(name, { file: full, header, entries })
+			}
+
+			const parent = [...sessionsByHeader.values()].find((s) => !s.header.parentSession)
+			const child = [...sessionsByHeader.values()].find((s) => s.header.parentSession !== undefined)
+			expect(parent, "parent session file (no parentSession header) should exist").toBeDefined()
+			expect(child, "child session file (with parentSession header) should exist").toBeDefined()
+
+			// Header linkage: child → parent.
+			expect(child?.header.parentSession).toBe(parent?.file)
+
+			// Parent → child linkage: the parent session log should carry a tool-result entry with SubagentStats.details referencing the child.
+			const toolResult = parent?.entries.find(
+				(e) =>
+					e.type === "message" &&
+					e.message?.role === "toolResult" &&
+					(e.message.details as SubagentDetails | undefined)?.sessionFile !== undefined,
+			)
+			expect(
+				toolResult,
+				"parent session should contain a subagent tool-result with sessionFile populated",
+			).toBeDefined()
+			const details = toolResult?.message?.details as SubagentDetails
+			expect(details.sessionId).toBe(child?.header.id)
+			expect(details.sessionFile).toBe(child?.file)
+
+			// Retention: removing the parent session dir removes the child (same dir, by D3/D5).
+			const childPath = child?.file
+			rmSync(sessionDir, { recursive: true, force: true })
+			expect(() => statSync(childPath as string)).toThrow()
+		},
+	)
+})


### PR DESCRIPTION
## Summary

From the orchestrator process we pre-create the subagent's session file and write a header that links child → parent, then pass that path to the child via `--session`. This gives bidirectional linkage: the child's header back-references the parent (`parentSession`), and the parent's tool-result records the child's session id and file path.

Picked this approach because pi's built-in features — `/resume` and the session-selector tree view — already handle nested session navigation correctly when parent and child live in the same session directory with `parentSession` set. No custom UI needed; we align with pi's existing fork-session convention.

Subagent runs are now recoverable, replayable, and billable from local session logs without re-running anything. Falls back safely when the parent is in-memory (`--no-session`) or the pre-write fails.

<img width="1225" height="1030" alt="Screenshot 2026-04-24 at 17 27 02" src="https://github.com/user-attachments/assets/4d06e330-35a5-4186-8a85-c390b7a32405" />