### PR TITLE
NOJIRA: Fix smoke tests - replace undici dispatcher with globalThis.fetch wrapper

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -147,17 +147,15 @@ try {
 	// Suppress Node.js warnings (same as pi-mono's own cli.js)
 	process.emitWarning = () => {}
 
-	// Set up HTTP proxy support with User-Agent injection
-	const { EnvHttpProxyAgent, setGlobalDispatcher } = await import("undici")
 	const userAgent = `kimchi/${getVersion()}`
-	const agent = new EnvHttpProxyAgent()
-	setGlobalDispatcher(
-		agent.compose((dispatch) => (opts, handler) => {
-			const headers = new Headers((opts.headers ?? undefined) as HeadersInit)
+	const originalFetch = globalThis.fetch.bind(globalThis)
+	globalThis.fetch = (input: RequestInfo | URL, init?: RequestInit): Promise<Response> => {
+		const headers = new Headers(init?.headers)
+		if (!headers.has("user-agent")) {
 			headers.set("user-agent", userAgent)
-			return dispatch({ ...opts, headers: Object.fromEntries(headers) }, handler)
-		}),
-	)
+		}
+		return originalFetch(input, { ...init, headers })
+	}
 
 	const extensionFactories = [
 		sessionIdCaptureExtension,

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -147,14 +147,19 @@ try {
 	// Suppress Node.js warnings (same as pi-mono's own cli.js)
 	process.emitWarning = () => {}
 
-	const userAgent = `kimchi/${getVersion()}`
-	const originalFetch = globalThis.fetch.bind(globalThis)
-	globalThis.fetch = (input: RequestInfo | URL, init?: RequestInit): Promise<Response> => {
-		const headers = new Headers(init?.headers)
-		if (!headers.has("user-agent")) {
-			headers.set("user-agent", userAgent)
+	const fetchPatchedSymbol = Symbol.for("kimchi.fetchPatched")
+	if (!(globalThis.fetch as typeof globalThis.fetch & { [key: symbol]: boolean })[fetchPatchedSymbol]) {
+		const userAgent = `kimchi/${getVersion()}`
+		const originalFetch = globalThis.fetch.bind(globalThis)
+		const patchedFetch = (input: RequestInfo | URL, init?: RequestInit): Promise<Response> => {
+			const headers = new Headers(init?.headers)
+			if (!headers.has("user-agent")) {
+				headers.set("user-agent", userAgent)
+			}
+			return originalFetch(input, { ...init, headers })
 		}
-		return originalFetch(input, { ...init, headers })
+		;(patchedFetch as typeof patchedFetch & { [key: symbol]: boolean })[fetchPatchedSymbol] = true
+		globalThis.fetch = patchedFetch
 	}
 
 	const extensionFactories = [


### PR DESCRIPTION
## Summary
- `EnvHttpProxyAgent.compose()` is `undefined` in a compiled Bun binary — Bun's bundler breaks the undici prototype chain, causing a crash on every invocation including `--version`, `--help`, and `--export`
- `undici`'s `setGlobalDispatcher` has no effect on Bun's built-in `fetch` anyway, so the previous approach never provided proxy support in the binary
- Replace with a `globalThis.fetch` wrapper that injects the `user-agent` header; Bun handles `HTTP_PROXY`/`HTTPS_PROXY` natively

## Test plan
- [x] Smoke tests pass: `--version`, `--help`, `--export` exit cleanly
- [x] `interactive-paste` tests pass (were timing out because the binary crashed on spawn)
- [x] User-agent header (`kimchi/<version>`) is present in outgoing HTTP requests

---
### Kimchi Summary
### What changed
Replaces the `undici`-based HTTP dispatcher setup with a direct monkey-patch of `globalThis.fetch` to inject the `user-agent` header, preventing duplicate initialization with a symbol-based guard.

### Why
Fixes crashes in binary/compiled distributions caused by `undici`'s `compose` API and `EnvHttpProxyAgent` incompatibility with bundled module structures.

### Key changes
- `src/cli.ts`: Removed `undici` imports (`EnvHttpProxyAgent`, `setGlobalDispatcher`) and dispatcher composition logic
- `src/cli.ts`: Added `fetchPatchedSymbol` guard to prevent double-patching when the CLI entry point is re-evaluated
- `src/cli.ts`: Implemented User-Agent injection via `globalThis.fetch` wrapper using standard `Headers` API instead of dispatcher middleware

### Impact
- Resolves binary build crashes related to `undici` internal module resolution
- Maintains existing User-Agent injection behavior (`kimchi/{version}`)
- No breaking changes or migration steps required