### PR TITLE
LLM-1386: /login integration for Kimchi API key management

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -90,7 +90,8 @@ try {
 		let config = loadConfig()
 
 		const envKey = process.env.KIMCHI_API_KEY || undefined
-		process.env.KIMCHI_API_KEY = undefined
+		// biome-ignore lint/performance/noDelete: process.env coerces assignments to strings, so `= undefined` would set it to the literal "undefined"
+		delete process.env.KIMCHI_API_KEY
 		if (envKey && !config.apiKey) {
 			writeApiKey(envKey)
 			config = loadConfig()

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -5,9 +5,17 @@ import { copyFileSync, existsSync, mkdirSync, readFileSync, writeFileSync } from
 import { dirname, resolve } from "node:path"
 import { fileURLToPath } from "node:url"
 import type { ExtensionAPI, ExtensionContext } from "@mariozechner/pi-coding-agent"
-import { DEFAULT_SKILL_PATHS, loadConfig, readTelemetryConfig, writeMigrationState, writeSkillPaths } from "./config.js"
+import {
+	DEFAULT_SKILL_PATHS,
+	loadConfig,
+	readTelemetryConfig,
+	writeApiKey,
+	writeMigrationState,
+	writeSkillPaths,
+} from "./config.js"
 import { isBunBinary } from "./env.js"
 import bashCollapseExtension from "./extensions/bash-collapse.js"
+import loginExtension from "./extensions/login/index.js"
 import loopGuardExtension from "./extensions/loop-guard.js"
 import mcpAdapterExtension from "./extensions/mcp-adapter/index.js"
 import promptEnrichmentExtension from "./extensions/orchestration/prompt-enrichment.js"
@@ -36,6 +44,7 @@ let sessionId: string | undefined
 // logs and not actionable — the IDE owns session continuation. Decide once,
 // at module load, before anything else runs.
 const acpMode = isAcpMode(process.argv.slice(2))
+const helpOrVersion = isHelpOrVersionArgs(process.argv.slice(2))
 
 process.on("exit", (code) => {
 	if (code === 0 && !acpMode) {
@@ -60,6 +69,10 @@ function sessionIdCaptureExtension(pi: ExtensionAPI) {
 // canonical --mode parser lives in pi-mono; this only looks for the one value
 // that forces a different entrypoint. Don't extend this sniff for new flags —
 // thread them through pi-mono's parser instead.
+function isHelpOrVersionArgs(args: string[]): boolean {
+	return args.some((a) => a === "--help" || a === "-h" || a === "--version" || a === "-v")
+}
+
 function isAcpMode(args: string[]): boolean {
 	for (let i = 0; i < args.length; i++) {
 		const a = args[i]
@@ -70,119 +83,130 @@ function isAcpMode(args: string[]): boolean {
 }
 
 try {
-	const config = loadConfig()
-
-	const needsSkillsSetup = config.skillPaths === undefined
-	const needsMigrationCheck = config.migrationState === undefined
-	let skillPaths = config.skillPaths ?? []
-
-	if (needsSkillsSetup || needsMigrationCheck) {
-		if (!process.stdin.isTTY) {
-			if (needsSkillsSetup) {
-				skillPaths = DEFAULT_SKILL_PATHS
-				writeSkillPaths(skillPaths)
-			}
-			writeMigrationState("done")
-		} else {
-			const result = await runSetupWizard({ needsSkillsSetup, needsMigrationCheck })
-			if (needsSkillsSetup) {
-				skillPaths = result.skillPaths
-				writeSkillPaths(skillPaths)
-			}
-			if (result.migrationState !== undefined) {
-				writeMigrationState(result.migrationState)
-			}
-		}
-	}
-
-	// Expose the API key as an env var so pi-mono's models.json can resolve it
-	// via the "KIMCHI_API_KEY" apiKey field in the Cast AI provider config.
-	process.env.KIMCHI_API_KEY = config.apiKey
-
-	// Ensure models.json exists with Cast AI provider configuration
-	const agentDir = process.env.KIMCHI_CODING_AGENT_DIR
-	if (!agentDir) {
-		throw new Error("KIMCHI_CODING_AGENT_DIR is not set; cli.ts must be entered via entry.ts")
-	}
-	const modelsJsonPath = resolve(agentDir, "models.json")
-	const { models } = await updateModelsConfig(modelsJsonPath, config.apiKey)
-
-	// Must run before main() so the keybindings file is loaded with the
-	// override in place.
-	reserveShiftTabForPermissions(agentDir)
-
-	// Share the discovered model IDs with extensions before main() runs.
-	// prompt-enrichment reads this to build ModelRegistry with live model IDs.
-	setAvailableModels(models)
-
-	// Write default settings on first run only — respect user's choices afterward
-	const settingsPath = resolve(agentDir, "settings.json")
-	try {
-		readFileSync(settingsPath, "utf-8")
-	} catch (err) {
-		if ((err as NodeJS.ErrnoException).code === "ENOENT") {
-			writeFileSync(settingsPath, `${JSON.stringify({ quietStartup: true, theme: "kimchi" }, null, 2)}\n`)
-		} else {
-			console.error(`Warning: could not read ${settingsPath}: ${(err as Error).message}`)
-		}
-	}
-
-	// Copy kimchi theme into agent dir so initTheme can find it before extensions load
-	const themesDir = resolve(agentDir, "themes")
-	const kimchiThemeDest = resolve(themesDir, "kimchi.json")
-	if (!existsSync(kimchiThemeDest)) {
-		mkdirSync(themesDir, { recursive: true })
-		const kimchiThemeSrc = isBunBinary
-			? resolve(process.env.PI_PACKAGE_DIR ?? "", "theme", "kimchi.json")
-			: resolve(dirname(fileURLToPath(import.meta.url)), "../themes/kimchi.json")
-		copyFileSync(kimchiThemeSrc, kimchiThemeDest)
-	}
-
-	// Suppress Node.js warnings (same as pi-mono's own cli.js)
-	process.emitWarning = () => {}
-
-	const fetchPatchedSymbol = Symbol.for("kimchi.fetchPatched")
-	if (!(globalThis.fetch as typeof globalThis.fetch & { [key: symbol]: boolean })[fetchPatchedSymbol]) {
-		const userAgent = `kimchi/${getVersion()}`
-		const originalFetch = globalThis.fetch.bind(globalThis)
-		const patchedFetch = (input: RequestInfo | URL, init?: RequestInit): Promise<Response> => {
-			const headers = new Headers(init?.headers)
-			if (!headers.has("user-agent")) {
-				headers.set("user-agent", userAgent)
-			}
-			return originalFetch(input, { ...init, headers })
-		}
-		;(patchedFetch as typeof patchedFetch & { [key: symbol]: boolean })[fetchPatchedSymbol] = true
-		globalThis.fetch = patchedFetch
-	}
-
-	const extensionFactories = [
-		sessionIdCaptureExtension,
-		shutdownMarkerExtension,
-		terminalColorsExtension,
-		bashCollapseExtension,
-		loopGuardExtension,
-		mcpAdapterExtension,
-		permissionsExtension,
-		promptEnrichmentExtension(skillPaths),
-		promptSummaryExtension,
-		uiExtension,
-		subagentExtension,
-		tagsExtension,
-		telemetryExtension(telemetryConfig),
-		toolRendererExtension,
-		webFetchExtension,
-		webSearchExtension,
-	]
-
-	const rawArgs = process.argv.slice(2)
-	if (acpMode) {
-		const { runAcpMode } = await import("./modes/acp/server.js")
-		await runAcpMode({ extensionFactories, agentDir })
-	} else {
-		// Delegate to pi-mono's CLI main function, injecting the kimchi extension
+	if (helpOrVersion) {
 		const { main } = await import("@mariozechner/pi-coding-agent")
-		await main(rawArgs, { extensionFactories })
+		await main(process.argv.slice(2), { extensionFactories: [] })
+	} else {
+		let config = loadConfig()
+
+		const envKey = process.env.KIMCHI_API_KEY || undefined
+		process.env.KIMCHI_API_KEY = undefined
+		if (envKey && !config.apiKey) {
+			writeApiKey(envKey)
+			config = loadConfig()
+		}
+
+		const apiKey = config.apiKey
+
+		const needsSkillsSetup = config.skillPaths === undefined
+		const needsMigrationCheck = config.migrationState === undefined
+		let skillPaths = config.skillPaths ?? []
+
+		if (needsSkillsSetup || needsMigrationCheck) {
+			if (!process.stdin.isTTY) {
+				if (needsSkillsSetup) {
+					skillPaths = DEFAULT_SKILL_PATHS
+					writeSkillPaths(skillPaths)
+				}
+				writeMigrationState("done")
+			} else {
+				const result = await runSetupWizard({ needsSkillsSetup, needsMigrationCheck })
+				if (needsSkillsSetup) {
+					skillPaths = result.skillPaths
+					writeSkillPaths(skillPaths)
+				}
+				if (result.migrationState !== undefined) {
+					writeMigrationState(result.migrationState)
+				}
+			}
+		}
+
+		// Ensure models.json exists with Cast AI provider configuration
+		const agentDir = process.env.KIMCHI_CODING_AGENT_DIR
+		if (!agentDir) {
+			throw new Error("KIMCHI_CODING_AGENT_DIR is not set; cli.ts must be entered via entry.ts")
+		}
+		const modelsJsonPath = resolve(agentDir, "models.json")
+		const { models } = await updateModelsConfig(modelsJsonPath, apiKey)
+
+		// Must run before main() so the keybindings file is loaded with the
+		// override in place.
+		reserveShiftTabForPermissions(agentDir)
+
+		// Share the discovered model metadata with extensions before main() runs.
+		// prompt-enrichment reads this to build ModelRegistry with live model IDs.
+		setAvailableModels(models)
+
+		// Write default settings on first run only — respect user's choices afterward
+		const settingsPath = resolve(agentDir, "settings.json")
+		try {
+			readFileSync(settingsPath, "utf-8")
+		} catch (err) {
+			if ((err as NodeJS.ErrnoException).code === "ENOENT") {
+				writeFileSync(settingsPath, `${JSON.stringify({ quietStartup: true, theme: "kimchi" }, null, 2)}\n`)
+			} else {
+				console.error(`Warning: could not read ${settingsPath}: ${(err as Error).message}`)
+			}
+		}
+
+		// Copy kimchi theme into agent dir so initTheme can find it before extensions load
+		const themesDir = resolve(agentDir, "themes")
+		const kimchiThemeDest = resolve(themesDir, "kimchi.json")
+		if (!existsSync(kimchiThemeDest)) {
+			mkdirSync(themesDir, { recursive: true })
+			const kimchiThemeSrc = isBunBinary
+				? resolve(process.env.PI_PACKAGE_DIR ?? "", "theme", "kimchi.json")
+				: resolve(dirname(fileURLToPath(import.meta.url)), "../themes/kimchi.json")
+			copyFileSync(kimchiThemeSrc, kimchiThemeDest)
+		}
+
+		// Suppress Node.js warnings (same as pi-mono's own cli.js)
+		process.emitWarning = () => {}
+
+		const fetchPatchedSymbol = Symbol.for("kimchi.fetchPatched")
+		if (!(globalThis.fetch as typeof globalThis.fetch & { [key: symbol]: boolean })[fetchPatchedSymbol]) {
+			const userAgent = `kimchi/${getVersion()}`
+			const originalFetch = globalThis.fetch.bind(globalThis)
+			const patchedFetch = (input: RequestInfo | URL, init?: RequestInit): Promise<Response> => {
+				const headers = new Headers(init?.headers)
+				if (!headers.has("user-agent")) {
+					headers.set("user-agent", userAgent)
+				}
+				return originalFetch(input, { ...init, headers })
+			}
+			;(patchedFetch as typeof patchedFetch & { [key: symbol]: boolean })[fetchPatchedSymbol] = true
+			globalThis.fetch = patchedFetch
+		}
+
+		const extensionFactories = [
+			sessionIdCaptureExtension,
+			shutdownMarkerExtension,
+			terminalColorsExtension,
+			bashCollapseExtension,
+			loopGuardExtension,
+			mcpAdapterExtension,
+			permissionsExtension,
+			promptEnrichmentExtension(skillPaths),
+			promptSummaryExtension,
+			uiExtension,
+			subagentExtension,
+			tagsExtension,
+			telemetryExtension(telemetryConfig),
+			toolRendererExtension,
+			webFetchExtension,
+			webSearchExtension,
+			loginExtension,
+		]
+
+		const rawArgs = process.argv.slice(2)
+		if (acpMode) {
+			const { runAcpMode } = await import("./modes/acp/server.js")
+			await runAcpMode({ extensionFactories, agentDir })
+		} else {
+			// Delegate to pi-mono's CLI main function, injecting the kimchi extension
+			const { main } = await import("@mariozechner/pi-coding-agent")
+			await main(rawArgs, { extensionFactories })
+		}
 	}
 } catch (err) {
 	console.error(err instanceof Error ? err.message : String(err))

--- a/src/config.test.ts
+++ b/src/config.test.ts
@@ -2,7 +2,7 @@ import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs"
 import { tmpdir } from "node:os"
 import { join } from "node:path"
 import { afterEach, beforeEach, describe, expect, it } from "vitest"
-import { loadConfig, writeApiKey } from "./config.js"
+import { clearApiKey, loadConfig, writeApiKey } from "./config.js"
 
 describe("loadConfig", () => {
 	let tempDir: string
@@ -17,37 +17,26 @@ describe("loadConfig", () => {
 		rmSync(tempDir, { recursive: true, force: true })
 	})
 
-	it("uses KIMCHI_API_KEY env var when set", () => {
-		const config = loadConfig({
-			env: { KIMCHI_API_KEY: "env-key-123" },
-			configPath,
-		})
-		expect(config.apiKey).toBe("env-key-123")
-	})
-
-	it("reads api_key from config file when env var is not set", () => {
-		writeFileSync(configPath, JSON.stringify({ api_key: "file-key-456" }))
-		const config = loadConfig({
-			env: {},
-			configPath,
-		})
+	it("reads apiKey from config file", () => {
+		writeFileSync(configPath, JSON.stringify({ apiKey: "file-key-456" }))
+		const config = loadConfig({ configPath })
 		expect(config.apiKey).toBe("file-key-456")
 	})
 
-	it("env var takes precedence over config file", () => {
+	it("reads api_key from config file for backward compatibility", () => {
 		writeFileSync(configPath, JSON.stringify({ api_key: "file-key-456" }))
-		const config = loadConfig({
-			env: { KIMCHI_API_KEY: "env-key-123" },
-			configPath,
-		})
-		expect(config.apiKey).toBe("env-key-123")
+		const config = loadConfig({ configPath })
+		expect(config.apiKey).toBe("file-key-456")
+	})
+
+	it("prefers apiKey over api_key when both are set", () => {
+		writeFileSync(configPath, JSON.stringify({ apiKey: "new-key", api_key: "old-key" }))
+		const config = loadConfig({ configPath })
+		expect(config.apiKey).toBe("new-key")
 	})
 
 	it("returns empty apiKey when no key is found", () => {
-		const config = loadConfig({
-			env: {},
-			configPath,
-		})
+		const config = loadConfig({ configPath })
 		expect(config.apiKey).toBe("")
 	})
 })
@@ -65,16 +54,55 @@ describe("writeApiKey", () => {
 		rmSync(tempDir, { recursive: true, force: true })
 	})
 
-	it("writes api_key to config file", () => {
+	it("writes apiKey to config file", () => {
 		writeApiKey("new-key-789", configPath)
 		const raw = JSON.parse(readFileSync(configPath, "utf-8"))
-		expect(raw.api_key).toBe("new-key-789")
+		expect(raw.apiKey).toBe("new-key-789")
 	})
 
-	it("preserves existing fields when writing api_key", () => {
+	it("preserves existing fields when writing apiKey", () => {
 		writeFileSync(configPath, JSON.stringify({ migrationState: "done" }))
 		writeApiKey("new-key-789", configPath)
 		const raw = JSON.parse(readFileSync(configPath, "utf-8"))
-		expect(raw).toEqual({ migrationState: "done", api_key: "new-key-789" })
+		expect(raw).toEqual({ migrationState: "done", apiKey: "new-key-789" })
+	})
+})
+
+describe("clearApiKey", () => {
+	let tempDir: string
+	let configPath: string
+
+	beforeEach(() => {
+		tempDir = mkdtempSync(join(tmpdir(), "kimchi-test-"))
+		configPath = join(tempDir, "config.json")
+	})
+
+	afterEach(() => {
+		rmSync(tempDir, { recursive: true, force: true })
+	})
+
+	it("removes apiKey from config file", () => {
+		writeFileSync(configPath, JSON.stringify({ apiKey: "key-to-clear", migrationState: "done" }))
+		clearApiKey(configPath)
+		const raw = JSON.parse(readFileSync(configPath, "utf-8"))
+		expect(raw).toEqual({ migrationState: "done" })
+	})
+
+	it("removes legacy api_key from config file", () => {
+		writeFileSync(configPath, JSON.stringify({ api_key: "key-to-clear", migrationState: "done" }))
+		clearApiKey(configPath)
+		const raw = JSON.parse(readFileSync(configPath, "utf-8"))
+		expect(raw).toEqual({ migrationState: "done" })
+	})
+
+	it("removes both apiKey and api_key when both are present", () => {
+		writeFileSync(configPath, JSON.stringify({ apiKey: "new-key", api_key: "old-key", migrationState: "done" }))
+		clearApiKey(configPath)
+		const raw = JSON.parse(readFileSync(configPath, "utf-8"))
+		expect(raw).toEqual({ migrationState: "done" })
+	})
+
+	it("is a no-op when config file does not exist", () => {
+		expect(() => clearApiKey(configPath)).not.toThrow()
 	})
 })

--- a/src/config.test.ts
+++ b/src/config.test.ts
@@ -1,8 +1,8 @@
-import { mkdtempSync, rmSync, writeFileSync } from "node:fs"
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs"
 import { tmpdir } from "node:os"
 import { join } from "node:path"
 import { afterEach, beforeEach, describe, expect, it } from "vitest"
-import { loadConfig } from "./config.js"
+import { loadConfig, writeApiKey } from "./config.js"
 
 describe("loadConfig", () => {
 	let tempDir: string
@@ -43,12 +43,38 @@ describe("loadConfig", () => {
 		expect(config.apiKey).toBe("env-key-123")
 	})
 
-	it("throws when no API key is found", () => {
-		expect(() =>
-			loadConfig({
-				env: {},
-				configPath,
-			}),
-		).toThrow("No Kimchi API key found")
+	it("returns empty apiKey when no key is found", () => {
+		const config = loadConfig({
+			env: {},
+			configPath,
+		})
+		expect(config.apiKey).toBe("")
+	})
+})
+
+describe("writeApiKey", () => {
+	let tempDir: string
+	let configPath: string
+
+	beforeEach(() => {
+		tempDir = mkdtempSync(join(tmpdir(), "kimchi-test-"))
+		configPath = join(tempDir, "config.json")
+	})
+
+	afterEach(() => {
+		rmSync(tempDir, { recursive: true, force: true })
+	})
+
+	it("writes api_key to config file", () => {
+		writeApiKey("new-key-789", configPath)
+		const raw = JSON.parse(readFileSync(configPath, "utf-8"))
+		expect(raw.api_key).toBe("new-key-789")
+	})
+
+	it("preserves existing fields when writing api_key", () => {
+		writeFileSync(configPath, JSON.stringify({ migrationState: "done" }))
+		writeApiKey("new-key-789", configPath)
+		const raw = JSON.parse(readFileSync(configPath, "utf-8"))
+		expect(raw).toEqual({ migrationState: "done", api_key: "new-key-789" })
 	})
 })

--- a/src/config.ts
+++ b/src/config.ts
@@ -215,22 +215,16 @@ export function loadConfig(options?: { configPath?: string; env?: Record<string,
 	}
 
 	const fileKey = readApiKeyFromConfigFile(configPath)
-	if (fileKey) {
-		return {
-			apiKey: fileKey,
-			agentConfigDir: AGENT_CONFIG_DIR,
-			llmEndpoint: CAST_AI_LLM_ENDPOINT,
-			maxToolResultChars,
-			mcpSearchLimit,
-			mcpSearch,
-			skillPaths,
-			migrationState,
-		}
+	return {
+		apiKey: fileKey ?? "",
+		agentConfigDir: AGENT_CONFIG_DIR,
+		llmEndpoint: CAST_AI_LLM_ENDPOINT,
+		maxToolResultChars,
+		mcpSearchLimit,
+		mcpSearch,
+		skillPaths,
+		migrationState,
 	}
-
-	throw new Error(
-		"No Kimchi API key found. Set the KIMCHI_API_KEY environment variable or log in with the kimchi CLI (`kimchi auth login`).",
-	)
 }
 
 export function getAgentConfigDir(): string {
@@ -257,4 +251,8 @@ export function writeMigrationState(state: MigrationState, configPath?: string):
 
 export function writeSkillPaths(paths: string[], configPath?: string): void {
 	writeConfigField("skillPaths", paths, configPath ?? KIMCHI_CONFIG_PATH)
+}
+
+export function writeApiKey(key: string, configPath?: string): void {
+	writeConfigField("api_key", key, configPath ?? KIMCHI_CONFIG_PATH)
 }

--- a/src/config.ts
+++ b/src/config.ts
@@ -250,8 +250,10 @@ export function clearApiKey(configPath?: string): void {
 	} catch {
 		return
 	}
-	raw.apiKey = undefined
-	raw.api_key = undefined
+	// biome-ignore lint/performance/noDelete: explicit removal is clearer than relying on JSON.stringify to silently drop undefined values
+	delete raw.apiKey
+	// biome-ignore lint/performance/noDelete: explicit removal is clearer than relying on JSON.stringify to silently drop undefined values
+	delete raw.api_key
 	const tmp = `${path}.${process.pid}.tmp`
 	writeFileSync(tmp, `${JSON.stringify(raw, null, 2)}\n`, "utf-8")
 	renameSync(tmp, path)

--- a/src/config.ts
+++ b/src/config.ts
@@ -54,6 +54,9 @@ function readApiKeyFromConfigFile(configPath: string): string | undefined {
 	try {
 		const raw = readFileSync(configPath, "utf-8")
 		const parsed = JSON.parse(raw)
+		if (typeof parsed.apiKey === "string" && parsed.apiKey.length > 0) {
+			return parsed.apiKey
+		}
 		if (typeof parsed.api_key === "string" && parsed.api_key.length > 0) {
 			return parsed.api_key
 		}
@@ -189,30 +192,12 @@ export function readTelemetryConfig(configPath?: string): TelemetryConfig {
  *
  * Throws if no API key is found in either location.
  */
-export function loadConfig(options?: { configPath?: string; env?: Record<string, string | undefined> }): KimchiConfig {
-	const env = options?.env ?? process.env
+export function loadConfig(options?: { configPath?: string }): KimchiConfig {
 	const configPath = options?.configPath ?? KIMCHI_CONFIG_PATH
 	const extras = readConfigExtras(configPath)
 	const maxToolResultChars = extras.maxToolResultChars ?? 10_000
 	const mcpSearchLimit = extras.mcpSearchLimit ?? 5
 	const mcpSearch: SearchStrategyConfig = { ...SEARCH_STRATEGY_DEFAULTS, ...extras.mcpSearch }
-
-	const skillPaths = extras.skillPaths
-	const migrationState = extras.migrationState
-
-	const envKey = env.KIMCHI_API_KEY
-	if (typeof envKey === "string" && envKey.length > 0) {
-		return {
-			apiKey: envKey,
-			agentConfigDir: AGENT_CONFIG_DIR,
-			llmEndpoint: CAST_AI_LLM_ENDPOINT,
-			maxToolResultChars,
-			mcpSearchLimit,
-			mcpSearch,
-			skillPaths,
-			migrationState,
-		}
-	}
 
 	const fileKey = readApiKeyFromConfigFile(configPath)
 	return {
@@ -222,8 +207,8 @@ export function loadConfig(options?: { configPath?: string; env?: Record<string,
 		maxToolResultChars,
 		mcpSearchLimit,
 		mcpSearch,
-		skillPaths,
-		migrationState,
+		skillPaths: extras.skillPaths,
+		migrationState: extras.migrationState,
 	}
 }
 
@@ -254,5 +239,20 @@ export function writeSkillPaths(paths: string[], configPath?: string): void {
 }
 
 export function writeApiKey(key: string, configPath?: string): void {
-	writeConfigField("api_key", key, configPath ?? KIMCHI_CONFIG_PATH)
+	writeConfigField("apiKey", key, configPath ?? KIMCHI_CONFIG_PATH)
+}
+
+export function clearApiKey(configPath?: string): void {
+	const path = configPath ?? KIMCHI_CONFIG_PATH
+	let raw: Record<string, unknown> = {}
+	try {
+		raw = JSON.parse(readFileSync(path, "utf-8")) as Record<string, unknown>
+	} catch {
+		return
+	}
+	delete raw["apiKey"]
+	delete raw["api_key"]
+	const tmp = `${path}.${process.pid}.tmp`
+	writeFileSync(tmp, `${JSON.stringify(raw, null, 2)}\n`, "utf-8")
+	renameSync(tmp, path)
 }

--- a/src/config.ts
+++ b/src/config.ts
@@ -250,8 +250,8 @@ export function clearApiKey(configPath?: string): void {
 	} catch {
 		return
 	}
-	delete raw["apiKey"]
-	delete raw["api_key"]
+	raw.apiKey = undefined
+	raw.api_key = undefined
 	const tmp = `${path}.${process.pid}.tmp`
 	writeFileSync(tmp, `${JSON.stringify(raw, null, 2)}\n`, "utf-8")
 	renameSync(tmp, path)

--- a/src/extensions/login/index.ts
+++ b/src/extensions/login/index.ts
@@ -1,0 +1,28 @@
+import { resolve } from "node:path"
+import type { ExtensionAPI } from "@mariozechner/pi-coding-agent"
+import { writeApiKey } from "../../config.js"
+import { updateModelsConfig } from "../../models.js"
+
+export default function loginExtension(pi: ExtensionAPI): void {
+	const agentDir = process.env.KIMCHI_CODING_AGENT_DIR
+	if (!agentDir) return
+	const modelsJsonPath = resolve(agentDir, "models.json")
+
+	pi.registerProvider("kimchi-dev", {
+		oauth: {
+			name: "Kimchi",
+			login: async (callbacks) => {
+				const key = await callbacks.onPrompt({
+					message: "Enter your Kimchi API key:",
+					placeholder: "castai_...",
+				})
+				writeApiKey(key)
+				process.env.KIMCHI_API_KEY = key
+				await updateModelsConfig(modelsJsonPath, key)
+				return { access: key, refresh: "", expires: Number.MAX_SAFE_INTEGER }
+			},
+			refreshToken: (credentials) => Promise.resolve(credentials),
+			getApiKey: (credentials) => credentials.access,
+		},
+	})
+}

--- a/src/extensions/login/index.ts
+++ b/src/extensions/login/index.ts
@@ -1,23 +1,45 @@
 import { resolve } from "node:path"
 import type { ExtensionAPI } from "@mariozechner/pi-coding-agent"
-import { writeApiKey } from "../../config.js"
-import { updateModelsConfig } from "../../models.js"
+import { clearApiKey, loadConfig, writeApiKey } from "../../config.js"
+import { updateModelsConfig, validateApiKey } from "../../models.js"
 
 export default function loginExtension(pi: ExtensionAPI): void {
 	const agentDir = process.env.KIMCHI_CODING_AGENT_DIR
 	if (!agentDir) return
 	const modelsJsonPath = resolve(agentDir, "models.json")
 
+	pi.on("session_start", (_event, ctx) => {
+		const authStorage = ctx.modelRegistry.authStorage
+
+		const configKey = loadConfig().apiKey
+		if (configKey) {
+			authStorage.set("kimchi-dev", { type: "oauth", access: configKey, refresh: "", expires: Number.MAX_SAFE_INTEGER })
+		}
+
+		const originalLogout = authStorage.logout.bind(authStorage)
+		authStorage.logout = (provider: string) => {
+			originalLogout(provider)
+			if (provider === "kimchi-dev") {
+				clearApiKey()
+			}
+		}
+	})
+
 	pi.registerProvider("kimchi-dev", {
 		oauth: {
 			name: "Kimchi",
 			login: async (callbacks) => {
 				const key = await callbacks.onPrompt({
-					message: "Enter your Kimchi API key:",
-					placeholder: "castai_...",
+					message:
+						"You need an API key to use Kimchi's open-source models.\nTo create one:\n\n  1. Open https://app.kimchi.dev\n  2. Go to API Keys → Create API Key\n  3. Paste the key below\n\nYou'll be prompted to log in if you don't have an account.\n\nAPI Key:",
+					placeholder: "Enter your Kimchi API key",
 				})
+				try {
+					await validateApiKey(key)
+				} catch {
+					throw new Error("Invalid API key. Please check your key and try again.")
+				}
 				writeApiKey(key)
-				process.env.KIMCHI_API_KEY = key
 				await updateModelsConfig(modelsJsonPath, key)
 				return { access: key, refresh: "", expires: Number.MAX_SAFE_INTEGER }
 			},

--- a/src/models.test.ts
+++ b/src/models.test.ts
@@ -260,4 +260,21 @@ describe("updateModelsConfig", () => {
 
 		expect(existsSync(nestedPath)).toBe(true)
 	})
+
+	it("writes default models silently when apiKey is empty", async () => {
+		const result = await updateModelsConfig(modelsJsonPath, "")
+
+		expect(result).toEqual({
+			source: "default",
+			models: ["kimi-k2.5", "glm-5-fp8", "minimax-m2.7"],
+		})
+		expect(fetch).not.toHaveBeenCalled()
+		expect(existsSync(modelsJsonPath)).toBe(true)
+		const config = JSON.parse(readFileSync(modelsJsonPath, "utf-8"))
+		expect(config.providers["kimchi-dev"].models.map((m: { id: string }) => m.id)).toEqual([
+			"kimi-k2.5",
+			"glm-5-fp8",
+			"minimax-m2.7",
+		])
+	})
 })

--- a/src/models.test.ts
+++ b/src/models.test.ts
@@ -261,20 +261,11 @@ describe("updateModelsConfig", () => {
 		expect(existsSync(nestedPath)).toBe(true)
 	})
 
-	it("writes default models silently when apiKey is empty", async () => {
+	it("returns empty models without fetching when apiKey is empty", async () => {
 		const result = await updateModelsConfig(modelsJsonPath, "")
 
-		expect(result).toEqual({
-			source: "default",
-			models: ["kimi-k2.5", "glm-5-fp8", "minimax-m2.7"],
-		})
+		expect(result).toEqual({ models: [] })
 		expect(fetch).not.toHaveBeenCalled()
-		expect(existsSync(modelsJsonPath)).toBe(true)
-		const config = JSON.parse(readFileSync(modelsJsonPath, "utf-8"))
-		expect(config.providers["kimchi-dev"].models.map((m: { id: string }) => m.id)).toEqual([
-			"kimi-k2.5",
-			"glm-5-fp8",
-			"minimax-m2.7",
-		])
+		expect(existsSync(modelsJsonPath)).toBe(false)
 	})
 })

--- a/src/models.ts
+++ b/src/models.ts
@@ -123,15 +123,25 @@ function readCachedMetadata(modelsJsonPath: string): ModelMetadata[] | undefined
 	}
 }
 
+export async function validateApiKey(apiKey: string): Promise<void> {
+	await fetchAvailableModels(apiKey)
+}
+
 /**
  * Fetch available models from the kimchi metadata API and write the
- * configuration to modelsJsonPath. If the fetch fails (or returns an empty
- * list) and the previous models.json is still on disk, returns the cached
- * models with a warning. Throws only when there is no cache to fall back on.
+ * configuration to modelsJsonPath. If no API key is configured, returns
+ * cached models (if available) or an empty list without making a network call.
+ * If the fetch fails and the previous models.json is still on disk, returns
+ * the cached models with a warning. Throws only when a key is present but
+ * there is no cache to fall back on.
  */
 export async function updateModelsConfig(modelsJsonPath: string, apiKey: string): Promise<ModelsConfigResult> {
 	const dir = dirname(modelsJsonPath)
 	mkdirSync(dir, { recursive: true })
+
+	if (!apiKey) {
+		return { models: readCachedMetadata(modelsJsonPath) ?? [] }
+	}
 
 	let fetched: ModelMetadata[]
 	try {

--- a/tests/smoke/binary.test.ts
+++ b/tests/smoke/binary.test.ts
@@ -9,12 +9,6 @@ describe("binary smoke tests", () => {
 		accessSync(BINARY_PATH, constants.X_OK)
 	})
 
-	it("errors with meaningful message when KIMCHI_API_KEY is missing", () => {
-		const result = runBinary({ throwOnError: false })
-		expect(result.status).toBe(1)
-		expect(result.stderr).toContain("No Kimchi API key found")
-	})
-
 	it("--version exits cleanly", () => {
 		const result = runBinary({
 			args: ["--version"],


### PR DESCRIPTION
## Summary

Integrates Kimchi API key management with the built-in `/login` and `/logout` commands.

**Login via `/login`**
- Select the Kimchi provider, paste your API key when prompted
- The key is validated against the models endpoint before being saved — invalid keys are rejected with an error
- On success the key is written to `~/.config/kimchi/config.json` and the model list refreshes immediately
- The provider shows `✓ logged in` in the `/login` list once authenticated

**Logout via `/logout`**
- Clears the key from both the auth store and the config file
- No credentials survive the session after logout

**Auto-login via `KIMCHI_API_KEY` env var**
- If `KIMCHI_API_KEY` is set and no key is already configured, it is written to config on startup (one-time bootstrap)
- The env var is cleared from the process immediately after — config is the single source of truth from that point on
- If a key is already configured, the env var is ignored

**Starting without a key**
- The harness starts normally, using a default model list
- The user is guided to `/login` to authenticate

**Config file**
- API key is stored as `apiKey` in `~/.config/kimchi/config.json`
- The legacy `api_key` spelling is accepted on read for backward compatibility

## Test plan

- [x] `pnpm run check` passes
- [x] `pnpm run test` passes (601 tests)
- [x] `pnpm run test:smoke` passes
- [x] `/login` → Kimchi → paste valid key → shows `✓ logged in`, models available
- [x] `/login` → Kimchi → paste invalid key → error shown, nothing saved
- [x] `/logout` → Kimchi → key cleared, `✓ logged in` gone, API calls rejected
- [x] Start with `KIMCHI_API_KEY` set and no config key → key auto-saved, no prompt
- [x] Start with `KIMCHI_API_KEY` set and existing config key → env var ignored
- [x] `/logout` after `KIMCHI_API_KEY` auto-login → stays logged out on next start
- [x] Start with no key at all → harness opens normally, default models available

## Demos
### /login command
<img width="1822" height="1046" alt="2026-04-27 14 03 54" src="https://github.com/user-attachments/assets/fba25f56-d2ab-4fd8-a3bb-a97a92db1a68" />

### invalid API key
<img width="1822" height="1046" alt="2026-04-27 14 09 12" src="https://github.com/user-attachments/assets/09edef66-ede8-4032-aff8-dd770195d323" />

### auto-login with ENV variable
<img width="1822" height="1046" alt="2026-04-27 14 07 55" src="https://github.com/user-attachments/assets/7a108880-8596-41d4-addb-f15b3be411d7" />

---
### Kimchi Summary
### What changed
Adds interactive login/logout support for Kimchi API keys and removes the hard requirement for credentials when running `--help` or `--version`. The CLI now supports bootstrapping from a `KIMCHI_API_KEY` environment variable (persisted to config) or via an interactive prompt, and gracefully handles missing keys by deferring authentication to the login flow.

### Why
Previously, the CLI threw an error at startup if no API key was configured, preventing users from viewing help text or logging in interactively. This change enables a smoother onboarding experience where users can authenticate via the built-in `kimchi auth login` command rather than manually managing environment variables.

### Key changes
- **`src/extensions/login/index.ts`** (new): Implements OAuth provider `kimchi-dev` with interactive API key prompt, validation against the Kimchi API, and persistence to config. Handles logout by clearing the stored key.
- **`src/cli.ts`**: Adds `loginExtension` to extension factories; detects `--help`, `-h`, `--version`, and `-v` flags to bypass skill setup and auth initialization; consumes `KIMCHI_API_KEY` from environment on first run, writes it to config via `writeApiKey()`, then scrubs it from `process.env`.
- **`src/config.ts`**: Removes `KIMCHI_API_KEY` env var checking from `loadConfig()`; changes missing key behavior to return empty string instead of throwing; adds `writeApiKey()` and `clearApiKey()` helpers; adds support for camelCase `apiKey` field alongside legacy `api_key`.
- **`src/models.ts`**: Adds `validateApiKey()` helper; updates `updateModelsConfig()` to skip network calls and return empty models when API key is missing or empty.
- **`src/config.test.ts`**: Removes env var precedence tests; adds coverage for `writeApiKey` and `clearApiKey`; updates assertions to expect empty strings instead of thrown errors.
- **`tests/smoke/binary.test.ts`**: Removes test asserting error on missing API key.

### Impact
- **Breaking**: `loadConfig()` no longer reads `KIMCHI_API_KEY` from environment or throws on missing keys. Callers must handle empty `apiKey` values or set the key via `writeApiKey()`.
- **Behavioral**: CLI commands `--help` and `--version` no longer require authentication. Running without a key will trigger the interactive login flow when the user attempts an operation requiring API access.
- **Migration**: Users previously relying on `KIMCHI_API_KEY` env var for persistent sessions should run `kimchi auth login` once to persist the key, or continue setting the env var which will be auto-persisted on next run.