### PR TITLE
NOJIRA: Terminal Bench 2 fixes

### DIFF
--- a/benchmark/terminal-bench-2/README.md
+++ b/benchmark/terminal-bench-2/README.md
@@ -81,17 +81,23 @@ MODEL=kimchi-dev/kimi-k2.5 ./scripts/run-local.sh -i terminal-bench/fix-git
 
 ### Tagging runs for tracking
 
-kimchi-code attaches tags from `KIMCHI_TAGS` to every outgoing LLM request payload and telemetry event, which lets you slice usage/tokens/cost server-side by run, experiment, or branch. Forward the variable into the task container with `--ae`:
+kimchi-code attaches tags from `KIMCHI_TAGS` to every outgoing LLM request payload and telemetry event, which lets you slice usage/tokens/cost server-side by run, experiment, or branch.
+
+The agent auto-injects `run:<timestamp>`, `task:<task_id>`, and `trial:<task_id>__<suffix>` derived from the trial directory layout (`jobs/<timestamp>/<task>__<trial>/`). You don't need to set these yourself — they're correct across globs (`-i 'terminal-bench/build-*'`), full-dataset runs, and parallel attempts (`-k N`, `-n N`).
+
+To add custom tags, forward `KIMCHI_TAGS` with `--ae`:
 
 ```bash
 ./scripts/run-local.sh \
   -i terminal-bench/fix-git \
-  --ae "KIMCHI_TAGS=bench:terminal-bench-2,task:fix-git,run:baseline"
+  --ae "KIMCHI_TAGS=bench:terminal-bench-2,experiment:baseline"
 ```
+
+User-supplied values win on key collision: passing `--ae KIMCHI_TAGS=task:custom` overrides the auto-injected `task:<task_id>`.
 
 Tag format is `key:value`, comma-separated; keys and values are alphanumeric plus `.`, `_`, `-`, max 64 chars each side. Invalid tags are dropped silently. Per-trial token/cost totals also land in `jobs/<timestamp>/<task>__<trial_id>/result.json` regardless of tags, so for local-only aggregation you can just group result files by the `KIMCHI_TAGS` value you ran them with.
 
-`--ae` is required: the agent passes an explicit env dict to the container and only `KIMCHI_API_KEY` is forwarded from the host by default. Harbor merges `--ae` values on top of that dict (`harbor/agents/installed/base.py` `_exec`), so `--ae KIMCHI_TAGS=...` reaches kimchi-code without any code changes.
+`--ae` is the only mechanism for forwarding extra env: the agent passes an explicit env dict to the container and only `KIMCHI_API_KEY` is forwarded from the host by default. Harbor merges `--ae` values on top of that dict (`harbor/agents/installed/base.py` `_exec`).
 
 ## Environment variables
 

--- a/benchmark/terminal-bench-2/README.md
+++ b/benchmark/terminal-bench-2/README.md
@@ -104,7 +104,7 @@ Tag format is `key:value`, comma-separated; keys and values are alphanumeric plu
 
 ## Results
 
-`benchmark/terminal-bench-2/jobs/<timestamp>/<task>__<trial_id>/` — each trial directory contains `trial.log`, `result.json` (with `reward`), and `config.json`. The raw kimchi JSONL stream is in `agent/kimchi.txt`.
+`benchmark/terminal-bench-2/jobs/<timestamp>/<task>__<trial_id>/` — each trial directory contains `trial.log`, `result.json` (with `reward`), and `config.json`. The raw kimchi JSONL stream is in `agent/kimchi.txt`. Resumable session files (parent + each subagent, linked via `parentSession`) are in `agent/sessions/*.jsonl`; replay any of them with `kimchi-code --session <path>`.
 
 ## Troubleshooting
 

--- a/benchmark/terminal-bench-2/src/kimchi_agent/agent.py
+++ b/benchmark/terminal-bench-2/src/kimchi_agent/agent.py
@@ -153,6 +153,12 @@ class KimchiCode(BaseInstalledAgent):
         if cli_flags:
             cli_flags += " "
 
+        # Harbor's _exec merges _extra_env *over* env=, so the merged value must live
+        # in _extra_env to win. Idempotent: a second run() sees the merged string as
+        # "user tags", finds all auto keys collide, and produces the same output.
+        user_tags = self._extra_env.get("KIMCHI_TAGS", "")
+        self._extra_env["KIMCHI_TAGS"] = self._merge_kimchi_tags(user_tags)
+
         await self.exec_as_agent(
             environment,
             command=(
@@ -166,6 +172,42 @@ class KimchiCode(BaseInstalledAgent):
             ),
             env={"KIMCHI_API_KEY": self._config.api_key, "PI_PACKAGE_DIR": PI_PACKAGE_DIR},
         )
+
+    def _auto_tags(self) -> dict[str, str]:
+        # logs_dir is expected to be jobs/<run>/<task>__<trial>/agent. Derive
+        # run / task / trial from that ancestry so they're injected automatically
+        # and survive glob / full-dataset runs where the user can't statically
+        # know the task name.
+        trial_dir = self.logs_dir.parent
+        run_dir = trial_dir.parent
+        if self.logs_dir.name != "agent" or run_dir.parent.name != "jobs":
+            self.logger.debug(
+                "Skipping auto KIMCHI_TAGS; logs_dir does not match jobs/<run>/<task>__<trial>/agent",
+                extra={"logs_dir": str(self.logs_dir)},
+            )
+            return {}
+        trial_id = trial_dir.name
+        return {
+            "run": run_dir.name,
+            "task": trial_id.split("__", 1)[0],
+            "trial": trial_id,
+        }
+
+    def _merge_kimchi_tags(self, user_raw: str) -> str:
+        # User-supplied values via --ae KIMCHI_TAGS=... win on key collision.
+        user_raw = user_raw.strip()
+        user_keys: set[str] = set()
+        for tag in user_raw.split(","):
+            if ":" not in tag:
+                continue
+            key = tag.split(":", 1)[0].strip()
+            if key:
+                user_keys.add(key)
+
+        merged = [f"{k}:{v}" for k, v in self._auto_tags().items() if k not in user_keys]
+        if user_raw:
+            merged.append(user_raw)
+        return ",".join(merged)
 
     def populate_context_post_run(self, context: AgentContext) -> None:
         output_file = self.logs_dir / self._OUTPUT_FILENAME

--- a/benchmark/terminal-bench-2/src/kimchi_agent/agent.py
+++ b/benchmark/terminal-bench-2/src/kimchi_agent/agent.py
@@ -159,16 +159,19 @@ class KimchiCode(BaseInstalledAgent):
         user_tags = self._extra_env.get("KIMCHI_TAGS", "")
         self._extra_env["KIMCHI_TAGS"] = self._merge_kimchi_tags(user_tags)
 
+        # Pipe the prompt via stdin instead of as a positional arg: pi-coding-agent's
+        # parseArgs treats any token starting with `-` as a flag (no `--` end-of-options
+        # marker), which deterministically crashes on instructions like "- You are given...".
         await self.exec_as_agent(
             environment,
             command=(
                 f"mkdir -p {CONTAINER_SESSIONS_DIR} && "
+                f"printf '%s' {shlex.quote(instruction)} | "
                 f"{shlex.quote(BINARY_PATH)} "
                 f"--print --mode json --session {CONTAINER_MAIN_SESSION} "
                 f"--model {shlex.quote(self.model_name)} "
                 f"{cli_flags}"
-                f"{shlex.quote(instruction)} "
-                f"2>&1 </dev/null | stdbuf -oL tee {CONTAINER_LOGS_DIR}/{self._OUTPUT_FILENAME}"
+                f"2>&1 | stdbuf -oL tee {CONTAINER_LOGS_DIR}/{self._OUTPUT_FILENAME}"
             ),
             env={"KIMCHI_API_KEY": self._config.api_key, "PI_PACKAGE_DIR": PI_PACKAGE_DIR},
         )

--- a/benchmark/terminal-bench-2/src/kimchi_agent/agent.py
+++ b/benchmark/terminal-bench-2/src/kimchi_agent/agent.py
@@ -27,6 +27,11 @@ BINARY_PATH = f"{INSTALL_DIR}/{BINARY_RELPATH.as_posix()}"
 PI_PACKAGE_DIR = f"{INSTALL_DIR}/{SHARE_RELPATH.as_posix()}"
 UPLOAD_STAGE_DIR = "/tmp/kimchi-stage"
 
+# In-container paths. /logs/agent is bind-mounted to self.logs_dir on the host.
+CONTAINER_LOGS_DIR = "/logs/agent"
+CONTAINER_SESSIONS_DIR = f"{CONTAINER_LOGS_DIR}/sessions"
+CONTAINER_MAIN_SESSION = f"{CONTAINER_SESSIONS_DIR}/main.jsonl"
+
 
 class KimchiCode(BaseInstalledAgent):
     """Harbor agent that runs the kimchi-code binary inside the task container.
@@ -151,12 +156,13 @@ class KimchiCode(BaseInstalledAgent):
         await self.exec_as_agent(
             environment,
             command=(
+                f"mkdir -p {CONTAINER_SESSIONS_DIR} && "
                 f"{shlex.quote(BINARY_PATH)} "
-                f"--print --mode json --no-session "
+                f"--print --mode json --session {CONTAINER_MAIN_SESSION} "
                 f"--model {shlex.quote(self.model_name)} "
                 f"{cli_flags}"
                 f"{shlex.quote(instruction)} "
-                f"2>&1 </dev/null | stdbuf -oL tee /logs/agent/{self._OUTPUT_FILENAME}"
+                f"2>&1 </dev/null | stdbuf -oL tee {CONTAINER_LOGS_DIR}/{self._OUTPUT_FILENAME}"
             ),
             env={"KIMCHI_API_KEY": self._config.api_key, "PI_PACKAGE_DIR": PI_PACKAGE_DIR},
         )


### PR DESCRIPTION
## Summary
- Save subagent sessions alongside the main session for post-run troubleshooting.
- Auto-tag trials with run/task/trial IDs so logs are filterable.
- Pipe agent prompts via stdin to avoid pi-coding-agent's argv parser crashing on prompts starting with `-`.

---
### Kimchi Summary
### What changed
Adds automatic injection of telemetry tags (`run`, `task`, `trial`) derived from the benchmark directory structure, persists agent sessions for replay, and fixes parsing errors when instructions start with hyphens.

### Why
Eliminates manual tag configuration for standard benchmark runs while ensuring consistent metadata for cost/usage tracking. Session persistence enables debugging and replay of subagent executions.

### Key changes
- `agent.py`: Adds `_auto_tags()` and `_merge_kimchi_tags()` to derive `KIMCHI_TAGS` from `jobs/<timestamp>/<task>__<trial>/` directory layout and merge with user-supplied tags (user values win on collision)
- `agent.py`: Changes `kimchi-code` invocation to use `--session` instead of `--no-session`, writing session files to `agent/sessions/*.jsonl` for replay support
- `agent.py`: Pipes instruction via stdin using `printf` to avoid `pi-coding-agent` argument parsing errors when instructions start with `-`
- `README.md`: Documents auto-tagging behavior, tag precedence rules, and session file locations

### Impact
- User-supplied `KIMCHI_TAGS` values now override auto-generated tags for the same key (e.g., `task:custom` overrides auto-detected task)
- Expects logs directory structure to match `jobs/<run>/<task>__<trial>/agent` for auto-tagging; falls back gracefully if structure differs
- Session files accumulate in trial directories; ensure adequate disk space for long benchmark runs