### PR TITLE
feat: inject User-Agent header with kimchi version

### DIFF
--- a/src/models.ts
+++ b/src/models.ts
@@ -1,5 +1,6 @@
 import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs"
 import { dirname } from "node:path"
+import { getVersion } from "./utils.js"
 
 const CAST_AI_MODELS_API = "https://api.cast.ai/v1/llm/openai/models?providerName=AI%20Enabler"
 const CAST_AI_LLM_BASE_URL = "https://llm.kimchi.dev/openai/v1"
@@ -45,6 +46,7 @@ function buildModelsConfig(models: string[]) {
 				apiKey: "KIMCHI_API_KEY",
 				api: "openai-completions",
 				authHeader: true,
+				headers: { "User-Agent": `kimchi/${getVersion()}` },
 				models: models.map((id) => ({
 					id,
 					name: modelIdToName(id),
@@ -72,6 +74,7 @@ const DEFAULT_MODELS_CONFIG = {
 			apiKey: "KIMCHI_API_KEY",
 			api: "openai-completions",
 			authHeader: true,
+			headers: { "User-Agent": `kimchi/${getVersion()}` },
 			models: [
 				{
 					id: "kimi-k2.5",


### PR DESCRIPTION
Adds "User-Agent: kimchi/${version}" header to all LLM API requests by including it in the provider configuration.

---
### Kimchi Summary
### What changed
Injects a `User-Agent` header containing the CLI version into the OpenAI-compatible API configuration used for model requests.

### Why
Allows the API to identify client versions for analytics, troubleshooting, and targeted communications about deprecations or updates.

### Key changes
- `src/models.ts`:
  - Imports `getVersion` from `./utils.js`
  - Adds `headers: { "User-Agent": \`kimchi/${getVersion()}\` }` to the configuration object in `buildModelsConfig()`
  - Adds the same `headers` configuration to `DEFAULT_MODELS_CONFIG`

### Impact
Low risk. This is an additive change that provides version metadata in HTTP request headers without affecting existing functionality.