### PR TITLE
LLM-1399: Don't interrupt streaming by aggresive nudge

### DIFF
--- a/src/extensions/orchestration/prompt-enrichment.ts
+++ b/src/extensions/orchestration/prompt-enrichment.ts
@@ -136,7 +136,7 @@ export default function (skillPaths: string[]) {
 				if (event.message.role !== "assistant") return
 				const { shouldNudge } = continuationNudge.evaluateTurn(event.message)
 				if (!shouldNudge) return
-				pi.sendUserMessage(CONTINUATION_NUDGE_TEXT)
+				pi.sendUserMessage(CONTINUATION_NUDGE_TEXT, { deliverAs: "steer" })
 			})
 
 			pi.on("input", async (event, ctx) => {


### PR DESCRIPTION


---
### Kimchi Summary
### What changed
Sends continuation nudges as steering messages (`deliverAs: "steer"`) instead of standard user messages to prevent conflicts when the agent is already processing.

### Why
Fixes the "agent is already processing" error that occurred when continuation nudges were injected as regular user messages while the agent was active.

### Key changes
- `src/extensions/orchestration/prompt-enrichment.ts`: Updated `pi.sendUserMessage()` call to include `{ deliverAs: "steer" }` option when sending `CONTINUATION_NUDGE_TEXT`.

### Impact
Eliminates race conditions where continuation nudges interfere with ongoing agent processing cycles.