### PR TITLE
LLM-1382: hide self assessment from model output

### DIFF
--- a/src/extensions/orchestration/prompt-transformer/prompts/transformed-user-prompt.ts
+++ b/src/extensions/orchestration/prompt-transformer/prompts/transformed-user-prompt.ts
@@ -6,7 +6,7 @@ You are **{{CURRENT_MODEL_NAME}}**.
 
 ## Required: Self-Assessment Before Acting
 
-Before taking any action, you must reason through the following checklist explicitly in your response:
+Before taking any action, silently reason through the following checklist and act on its conclusion. Keep this reasoning internal — do not write the checklist, your answers, or any narration of it into your response. Proceed directly to the action (tool call, or a brief clarifying question if input is missing).
 
 1. Is this task simple (single-file, no design decisions, unambiguous) or complex (multiple files, layered architecture, any structural decision, or modifying code you haven't read)?
 2. Which pipeline steps does it need? (explore / research / plan / build / review — only those required)
@@ -14,7 +14,7 @@ Before taking any action, you must reason through the following checklist explic
    - Yes → you will do it yourself.
    - No → you must delegate it to a model whose strengths include it.
 
-Do NOT skip this checklist. Do NOT begin implementation until you have completed it.
+Do NOT skip this reasoning, and do NOT print it. Begin implementation only after completing it silently.
 
 ## Model Attributes
 


### PR DESCRIPTION


---
### Kimchi Summary
### What changed
Modified the system prompt to require models to perform self-assessment reasoning silently without emitting the checklist or internal deliberation into the final response.

### Why
Removes verbose meta-commentary from model outputs while preserving the safety and delegation logic of the self-assessment step.

### Key changes
- `transformed-user-prompt.ts`: Updated instructions to require internal-only reasoning for the pre-action checklist, explicitly prohibiting the model from writing the checklist, answers, or narration into responses.

### Impact
Model responses will be more concise and action-oriented, proceeding directly to tool calls or clarifying questions without explicit self-assessment preamble.