### PR TITLE
NOJIRA: remove alt-screen buffer to restore terminal scrollback

### DIFF
--- a/src/extensions/terminal-colors.ts
+++ b/src/extensions/terminal-colors.ts
@@ -8,24 +8,16 @@ const QUERY_FG = "\x1b]10;?\x07"
 const QUERY_BG = "\x1b]11;?\x07"
 const QUERY_TIMEOUT_MS = 200
 
-const ENTER_ALT_SCREEN = "\x1b[?1049h"
-const EXIT_ALT_SCREEN = "\x1b[?1049l"
-
 export default function terminalColorsExtension(pi: ExtensionAPI) {
 	let savedFg: string | null = null
 	let savedBg: string | null = null
 	let active = false
-	let altScreenActive = false
 	let exitHandlersInstalled = false
 
 	const restore = () => {
 		if (!active) return
 		active = false
 		if (!process.stdout.isTTY) return
-		if (altScreenActive) {
-			altScreenActive = false
-			process.stdout.write(EXIT_ALT_SCREEN)
-		}
 		process.stdout.write(savedFg ? `\x1b]10;${savedFg}\x07` : "\x1b]110\x07")
 		process.stdout.write(savedBg ? `\x1b]11;${savedBg}\x07` : "\x1b]111\x07")
 	}
@@ -43,16 +35,11 @@ export default function terminalColorsExtension(pi: ExtensionAPI) {
 		process.once("SIGHUP", () => signalRestore("SIGHUP"))
 	}
 
-	pi.on("session_start", (event) => {
+	pi.on("session_start", () => {
 		if (!process.stdin.isTTY) return
 
 		active = true
 		installExitHandlers()
-
-		if (event.reason === "startup") {
-			altScreenActive = true
-			process.stdout.write(ENTER_ALT_SCREEN)
-		}
 
 		if (savedFg !== null || savedBg !== null) {
 			process.stdout.write(SET_FG)

--- a/src/extensions/ui.ts
+++ b/src/extensions/ui.ts
@@ -9,12 +9,7 @@ import { collapseAll, expandNext, resetState } from "../expand-state.js"
 const HORIZONTAL_PADDING = 2
 
 // Strip OSC 133 shell-integration marks emitted by pi-mono around each message.
-// In the main terminal screen these marks enable "jump to previous message" in
-// shell-integration-aware terminals (Wezterm, Kitty, Ghostty, iTerm2, etc.).
-// But kimchi runs in the alt screen (see terminal-colors.ts), where scrollback
-// navigation typically doesn't apply — and iTerm2 still renders a visible blue
-// triangle at each mark, which is noisy in the TUI. Net benefit of stripping is
-// positive in kimchi's alt-screen context.
+// iTerm2 renders a visible blue triangle at each mark, which is noisy in the TUI.
 // biome-ignore lint/suspicious/noControlCharactersInRegex: matching ANSI/OSC
 const OSC133_RE = /\x1b\]133;[A-Z]\x07/g
 


### PR DESCRIPTION


---
### Kimchi Summary
### What changed
Removes the alternative screen buffer (alt screen) logic from the terminal colors extension. The application now runs in the main terminal screen instead of switching to the alternate buffer on startup.

### Why
Running in the alt screen was causing scrolling issues and prevented standard terminal scrollback navigation. By remaining in the main screen, users can scroll through output history using native terminal controls.

### Key changes
- `src/extensions/terminal-colors.ts`: Removed `ENTER_ALT_SCREEN` (`\x1b[?1049h`) and `EXIT_ALT_SCREEN` (`\x1b[?1049l`) ANSI escape sequences and the `altScreenActive` state variable.
- `src/extensions/terminal-colors.ts`: Removed the alt screen entry logic from the `session_start` event handler and the corresponding exit logic from the `restore()` cleanup function.
- `src/extensions/ui.ts`: Updated the comment for the `OSC133_RE` regex to remove the outdated justification about operating in the alt screen context.

### Impact
- **Behavioral change**: The TUI now renders in the main terminal buffer, preserving scrollback history after exit instead of clearing to the previous screen state.
- **Scrolling**: Fixes mouse and keyboard scrolling issues associated with the alt screen boundary.
- **Visual change**: Previous terminal output remains visible above the application interface rather than being replaced by a clean alt screen.