### PR TITLE
LLM-1339: Use followUp delivery for continuation nudge.

### DIFF
--- a/src/extensions/orchestration/prompt-enrichment.ts
+++ b/src/extensions/orchestration/prompt-enrichment.ts
@@ -123,7 +123,7 @@ export default function (skillPaths: string[]) {
 				if (event.message.role !== "assistant") return
 				const { shouldNudge } = continuationNudge.evaluateTurn(event.message)
 				if (!shouldNudge) return
-				pi.sendUserMessage(CONTINUATION_NUDGE_TEXT, { deliverAs: "steer" })
+				pi.sendUserMessage(CONTINUATION_NUDGE_TEXT, { deliverAs: "followUp" })
 			})
 
 			pi.on("input", async (event, ctx) => {


### PR DESCRIPTION
The nudge fires on text-only turns when the agent loop is about to exit. followUp is the queue checked at that exit boundary. steer is designed to redirect the agent mid-execution between tool calls, which doesn't apply here.

---
### Kimchi Summary
### What changed
Switches the delivery mode for automatic continuation prompts from `"steer"` to `"followUp"` in the orchestration layer.

### Why
Addresses issue LLM-1399. The `"followUp"` delivery type is the appropriate mechanism for continuation nudges, ensuring the LLM receives them as follow-up messages rather than steering inputs.

### Key changes
- `src/extensions/orchestration/prompt-enrichment.ts`: Changed the `deliverAs` option in `pi.sendUserMessage()` from `"steer"` to `"followUp"` when triggering continuation nudges after assistant messages.

### Impact
This changes how continuation prompts are classified and handled by the message pipeline. Ensure downstream consumers and telemetry correctly interpret messages with `deliverAs: "followUp"`.