### PR TITLE
LLM-1393: Add --multi-model mode toggle

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ kimchi-code --multi-model=false
 
 You can also toggle the mode at any time during a session with the **option/alt+tab** keyboard shortcut. The current state is shown in the footer (`multi-model: on` / `multi-model: off`).
 
-When multi-model is off the agent uses a simpler system prompt and automatic task classification/delegation is disabled. The subagent tool is still available if you explicitly ask the agent to delegate a task.
+When multi-model is off the agent uses a single-model system prompt: environment, tools, research rules, guidelines, and phase tagging are all active, but task classification and delegation logic are disabled. The subagent tool is still available if you explicitly ask the agent to delegate a task.
 
 ### HTTP proxy
 

--- a/README.md
+++ b/README.md
@@ -37,6 +37,20 @@ The supported model list is fetched at startup from the kimchi metadata service.
 
 Use `/model` in the interactive CLI to switch between available models.
 
+### Multi-model orchestration
+
+By default, kimchi-code runs in multi-model mode: the main agent classifies each task, executes what it can directly, and delegates the rest to specialised subagents picked from the available model roster.
+
+To disable orchestration and run as a single, direct coding assistant:
+
+```bash
+kimchi-code --multi-model=false
+```
+
+You can also toggle the mode at any time during a session with the **option/alt+tab** keyboard shortcut. The current state is shown in the footer (`multi-model: on` / `multi-model: off`).
+
+When multi-model is off the agent uses a simpler system prompt and automatic task classification/delegation is disabled. The subagent tool is still available if you explicitly ask the agent to delegate a task.
+
 ### HTTP proxy
 
 kimchi-code respects `HTTP_PROXY` / `HTTPS_PROXY` environment variables for network requests.

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ To disable orchestration and run as a single, direct coding assistant:
 kimchi-code --multi-model=false
 ```
 
-You can also toggle the mode at any time during a session with the **option/alt+tab** keyboard shortcut. The current state is shown in the footer (`multi-model: on` / `multi-model: off`).
+You can also toggle the mode at any time during a session with the **option/alt+shift+tab** keyboard shortcut. The current state is shown in the footer (`multi-model: on` / `multi-model: off`).
 
 When multi-model is off the agent uses a single-model system prompt: environment, tools, research rules, guidelines, and phase tagging are all active, but task classification and delegation logic are disabled. The subagent tool is still available if you explicitly ask the agent to delegate a task.
 

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ To disable orchestration and run as a single, direct coding assistant:
 kimchi-code --multi-model=false
 ```
 
-You can also toggle the mode at any time during a session with the **option/alt+shift+tab** keyboard shortcut. The current state is shown in the footer (`multi-model: on` / `multi-model: off`).
+You can also toggle the mode at any time during a session with the **option/alt+tab** keyboard shortcut. The current state is shown in the footer (`multi-model: on` / `multi-model: off`).
 
 When multi-model is off the agent uses a single-model system prompt: environment, tools, research rules, guidelines, and phase tagging are all active, but task classification and delegation logic are disabled. The subagent tool is still available if you explicitly ask the agent to delegate a task.
 

--- a/src/components/footer.ts
+++ b/src/components/footer.ts
@@ -3,6 +3,7 @@ import type { Component } from "@mariozechner/pi-tui"
 import { truncateToWidth, visibleWidth } from "@mariozechner/pi-tui"
 import { RST_FG, TEAL_FG } from "../ansi.js"
 import { formatCount } from "../extensions/format.js"
+import { getMultiModelEnabled } from "../extensions/orchestration/prompt-enrichment.js"
 import { getActiveSubagentCount } from "../extensions/subagent.js"
 import { getActiveTags, getCurrentPhase, parseTag } from "../extensions/tags.js"
 
@@ -93,6 +94,12 @@ export class StatsFooter implements Component {
 		return seg(mode)
 	}
 
+	private multiModelSegment(): FooterSegment {
+		const enabled = getMultiModelEnabled()
+		const label = enabled ? teal("on") : this.dim("off")
+		return seg(`${this.dim("multi-model:")} ${label} ${this.dim("→ option/alt+tab")}`)
+	}
+
 	private subagentSegment(): FooterSegment | null {
 		const count = getActiveSubagentCount()
 		if (count === 0) return null
@@ -106,6 +113,7 @@ export class StatsFooter implements Component {
 
 		const segments = [
 			this.permissionsSegment(),
+			this.multiModelSegment(),
 			this.modelSegment(),
 			this.subagentSegment(),
 			this.contextSegment(),

--- a/src/components/footer.ts
+++ b/src/components/footer.ts
@@ -97,7 +97,7 @@ export class StatsFooter implements Component {
 	private multiModelSegment(): FooterSegment {
 		const enabled = getMultiModelEnabled()
 		const label = enabled ? teal("on") : this.dim("off")
-		return seg(`${this.dim("multi-model:")} ${label} ${this.dim("→ option/alt+tab")}`)
+		return seg(`${this.dim("multi-model:")} ${label} ${this.dim("→ option/alt+shift+tab")}`)
 	}
 
 	private subagentSegment(): FooterSegment | null {

--- a/src/components/footer.ts
+++ b/src/components/footer.ts
@@ -97,7 +97,8 @@ export class StatsFooter implements Component {
 	private multiModelSegment(): FooterSegment {
 		const enabled = getMultiModelEnabled()
 		const label = enabled ? teal("on") : this.dim("off")
-		return seg(`${this.dim("multi-model:")} ${label} ${this.dim("→ option/alt+shift+tab")}`)
+		const shortcut = process.platform === "darwin" ? "option+tab" : "alt+tab"
+		return seg(`${this.dim("multi-model:")} ${label} ${this.dim(`→ ${shortcut}`)}`)
 	}
 
 	private subagentSegment(): FooterSegment | null {

--- a/src/extensions/orchestration/prompt-enrichment.ts
+++ b/src/extensions/orchestration/prompt-enrichment.ts
@@ -77,6 +77,28 @@ function readGitRemote(cwd: string): string | undefined {
 	}
 }
 
+function readMultiModelArgv(): boolean {
+	const args = process.argv
+	for (let i = 0; i < args.length; i++) {
+		const arg = args[i]
+		if (arg === "--multi-model=false") return false
+		if (arg === "--multi-model=true") return true
+		if (arg === "--multi-model") {
+			const next = args[i + 1]
+			if (next === "false") return false
+			if (next === "true") return true
+			return true
+		}
+	}
+	return true
+}
+
+let multiModelEnabled = readMultiModelArgv()
+
+export function getMultiModelEnabled(): boolean {
+	return multiModelEnabled
+}
+
 export default function (skillPaths: string[]) {
 	return (pi: ExtensionAPI) => {
 		const subagentMode = isSubagent()
@@ -85,6 +107,12 @@ export default function (skillPaths: string[]) {
 			type: "boolean",
 			description: "Print enriched prompts in the UI (default: hidden)",
 			default: false,
+		})
+
+		pi.registerFlag("multi-model", {
+			type: "boolean",
+			description: "Enable multi-model orchestration (default: enabled). Toggle with alt+tab.",
+			default: true,
 		})
 
 		// For sub agents we don't want to transform the prompt sent from parent with model capabilities
@@ -97,6 +125,14 @@ export default function (skillPaths: string[]) {
 					`${fg(ANSI.accent, ` New model available: "kimchi-dev/${warning.modelId}"`)}\n${fg(ANSI.dim, " Update the app or add the new model to model capabilities config to unlock orchestration support.")}`,
 				)
 			}
+
+			pi.registerShortcut("alt+tab", {
+				description: "Toggle multi-model orchestration on/off",
+				handler: (ctx) => {
+					multiModelEnabled = !multiModelEnabled
+					ctx.ui.setStatus("multi-model", undefined)
+				},
+			})
 
 			// Detect the inverse of the context-event nudge below: the orchestrator reasons
 			// in prose, announces it will delegate, and ends its turn without emitting the
@@ -135,6 +171,10 @@ export default function (skillPaths: string[]) {
 				// (ctx.isIdle() === false, i.e. session.isStreaming === true).
 				// Skip enrichment and let them pass through unchanged
 				if (!ctx.isIdle()) {
+					return { action: "continue" as const }
+				}
+
+				if (!multiModelEnabled) {
 					return { action: "continue" as const }
 				}
 
@@ -208,11 +248,12 @@ export default function (skillPaths: string[]) {
 				gitRemote: isGitRepo ? (cachedGitRemote ?? undefined) : undefined,
 			}
 
-			if (subagentMode) {
-				// Filter the subagent tool out of the active tool set to prevent
-				// the subagent from spawning further subagents.
-				const activeTools = pi.getActiveTools().filter((name) => name !== "subagent")
-				pi.setActiveTools(activeTools)
+			if (subagentMode || !multiModelEnabled) {
+				if (subagentMode) {
+					// Filter the subagent tool out to prevent infinite delegation chains.
+					const activeTools = pi.getActiveTools().filter((name) => name !== "subagent")
+					pi.setActiveTools(activeTools)
+				}
 
 				const systemPrompt = buildSubagentSystemPrompt(tools, env, cachedContextFiles, cachedSkills)
 				return { systemPrompt }

--- a/src/extensions/orchestration/prompt-enrichment.ts
+++ b/src/extensions/orchestration/prompt-enrichment.ts
@@ -113,7 +113,7 @@ export default function (skillPaths: string[]) {
 
 		pi.registerFlag("multi-model", {
 			type: "boolean",
-			description: "Enable multi-model orchestration (default: enabled). Toggle with alt+shift+tab.",
+			description: "Enable multi-model orchestration (default: enabled). Toggle with alt+tab.",
 			default: true,
 		})
 
@@ -128,7 +128,7 @@ export default function (skillPaths: string[]) {
 				)
 			}
 
-			pi.registerShortcut("alt+shift+tab", {
+			pi.registerShortcut("alt+tab", {
 				description: "Toggle multi-model orchestration on/off",
 				handler: (ctx) => {
 					multiModelEnabled = !multiModelEnabled

--- a/src/extensions/orchestration/prompt-enrichment.ts
+++ b/src/extensions/orchestration/prompt-enrichment.ts
@@ -78,6 +78,7 @@ function readGitRemote(cwd: string): string | undefined {
 	}
 }
 
+// Workaround: pi-mono's applyExtensionFlagValues ignores the actual value for boolean flags (always sets true). Read argv directly until upstream is fixed.
 function readMultiModelArgv(): boolean {
 	const args = process.argv
 	for (let i = 0; i < args.length; i++) {

--- a/src/extensions/orchestration/prompt-enrichment.ts
+++ b/src/extensions/orchestration/prompt-enrichment.ts
@@ -113,7 +113,7 @@ export default function (skillPaths: string[]) {
 
 		pi.registerFlag("multi-model", {
 			type: "boolean",
-			description: "Enable multi-model orchestration (default: enabled). Toggle with alt+tab.",
+			description: "Enable multi-model orchestration (default: enabled). Toggle with alt+shift+tab.",
 			default: true,
 		})
 
@@ -128,7 +128,7 @@ export default function (skillPaths: string[]) {
 				)
 			}
 
-			pi.registerShortcut("alt+tab", {
+			pi.registerShortcut("alt+shift+tab", {
 				description: "Toggle multi-model orchestration on/off",
 				handler: (ctx) => {
 					multiModelEnabled = !multiModelEnabled

--- a/src/extensions/orchestration/prompt-enrichment.ts
+++ b/src/extensions/orchestration/prompt-enrichment.ts
@@ -35,6 +35,7 @@ import { type ContextFile, loadProjectContextFiles } from "./prompt-transformer/
 import {
 	type EnvironmentInfo,
 	buildOrchestratorSystemPrompt,
+	buildSingleModelSystemPrompt,
 	buildSubagentSystemPrompt,
 	isSubagent,
 	transformPrompt,
@@ -248,14 +249,16 @@ export default function (skillPaths: string[]) {
 				gitRemote: isGitRepo ? (cachedGitRemote ?? undefined) : undefined,
 			}
 
-			if (subagentMode || !multiModelEnabled) {
-				if (subagentMode) {
-					// Filter the subagent tool out to prevent infinite delegation chains.
-					const activeTools = pi.getActiveTools().filter((name) => name !== "subagent")
-					pi.setActiveTools(activeTools)
-				}
-
+			if (subagentMode) {
+				// Filter the subagent tool out to prevent infinite delegation chains.
+				const activeTools = pi.getActiveTools().filter((name) => name !== "subagent")
+				pi.setActiveTools(activeTools)
 				const systemPrompt = buildSubagentSystemPrompt(tools, env, cachedContextFiles, cachedSkills)
+				return { systemPrompt }
+			}
+
+			if (!multiModelEnabled) {
+				const systemPrompt = buildSingleModelSystemPrompt(tools, env, cachedContextFiles, cachedSkills)
 				return { systemPrompt }
 			}
 

--- a/src/extensions/orchestration/prompt-transformer/prompt-transformer.ts
+++ b/src/extensions/orchestration/prompt-transformer/prompt-transformer.ts
@@ -3,6 +3,7 @@ import type { ModelRegistry } from "../model-registry/index.js"
 import type { OrchestrationModelDescriptor } from "../model-registry/types.js"
 import type { ContextFile } from "./context-files.js"
 import systemPromptTemplate from "./prompts/orchestrator-system-prompt.js"
+import singleModelSystemPromptTemplate from "./prompts/single-model-system-prompt.js"
 import subagentSystemPromptTemplate from "./prompts/subagent-system-prompt.js"
 import userPromptTemplate from "./prompts/transformed-user-prompt.js"
 
@@ -89,6 +90,23 @@ export function buildOrchestratorSystemPrompt(
 	const projectContext = formatProjectContext(contextFiles)
 	const skillsSection = formatSkills(skills)
 	return systemPromptTemplate
+		.replace("{{TOOLS}}", () => toolsSection)
+		.replace("{{ENVIRONMENT}}", () => environmentSection)
+		.replace("{{PROJECT_CONTEXT}}", () => projectContext)
+		.replace("{{SKILLS}}", () => skillsSection)
+}
+
+export function buildSingleModelSystemPrompt(
+	tools: readonly ToolInfo[],
+	env: EnvironmentInfo,
+	contextFiles?: readonly ContextFile[],
+	skills?: readonly Skill[],
+): string {
+	const toolsSection = formatToolsSection(tools)
+	const environmentSection = formatEnvironmentSection(env)
+	const projectContext = formatProjectContext(contextFiles)
+	const skillsSection = formatSkills(skills)
+	return singleModelSystemPromptTemplate
 		.replace("{{TOOLS}}", () => toolsSection)
 		.replace("{{ENVIRONMENT}}", () => environmentSection)
 		.replace("{{PROJECT_CONTEXT}}", () => projectContext)

--- a/src/extensions/orchestration/prompt-transformer/prompts/orchestrator-system-prompt.ts
+++ b/src/extensions/orchestration/prompt-transformer/prompts/orchestrator-system-prompt.ts
@@ -1,4 +1,7 @@
-export default `You are an expert coding assistant. Your available tools are listed under **Available Tools** below — use only those, never guess or invent tool names. You can also spawn subagents when delegation is more appropriate than doing the work yourself.
+import { CORE_GUIDELINES, FOOTER, PHASE_TAGGING, RESEARCH_RULES, TOOLS_SECTION } from "./shared.js"
+
+export default [
+	`You are an expert coding assistant. Your available tools are listed under **Available Tools** below — use only those, never guess or invent tool names. You can also spawn subagents when delegation is more appropriate than doing the work yourself.
 
 {{ENVIRONMENT}}
 
@@ -67,37 +70,13 @@ Include a \`tokenBudget\` for every subagent call:
 - Complex multi-layer architecture or large codebase exploration: 500,000 tokens
 - Research or design tasks producing a design document: 200,000 tokens
 
-If a subagent hits its budget, spawn a follow-up with the remaining work rather than raising the budget.
+If a subagent hits its budget, spawn a follow-up with the remaining work rather than raising the budget.`,
+	TOOLS_SECTION,
+	RESEARCH_RULES,
+	`## Guidelines
 
-## Available Tools
-
-{{TOOLS}}
-
-## Research Rules
-
-- Use \`web_search\` only during the \`research\` step — not during \`explore\`, \`plan\`, or \`build\`.
-- **Avoid web_fetch.** It returns raw website content that can flood your context window. Prefer \`web_search\` for most research. Use \`web_fetch\` only when the information is frequently updated and unlikely to be indexed (e.g. changelogs, latest release notes), or when the user's message contains an explicit URL. When you do use it, request markdown or text format and delegate to a subagent to keep the output out of the main context.
-- **Run at most one web_search per task.** Do NOT run a second search to verify or refine.
-
-## Guidelines
-
-- Be concise in your responses.
-- Show file paths clearly when working with files.
-- Read files before modifying them.
-- Prefer editing existing files over creating new ones.
-- Do NOT introduce security vulnerabilities.
-- Do NOT add features, refactoring, or improvements beyond what was asked.
-- If you encounter an error, diagnose the root cause before retrying.
-- **Pattern recognition**: If the same implementation pattern is needed more than twice, define the abstraction first, then implement.
-- **Sharing context between agents**: Pass plans and structured findings as Markdown files in a temporary working directory, not as inline blobs in prompts.
-
-## Phase Tagging for Analytics
-
-You must call \`set_phase\` before every block of work. Never take an action without the correct phase being set first. Use one of \`explore\`, \`research\`,\`plan\`, \`build\`, or \`review\` strictly matching current pipeline step.
-
-The session starts in \`explore\` phase by default. Call \`set_phase\` immediately when your work type changes. Only one phase is active at a time — the most recent call wins.
-
-{{PROJECT_CONTEXT}}
-
-{{SKILLS}}
-`
+${CORE_GUIDELINES}
+- **Sharing context between agents**: Pass plans and structured findings as Markdown files in a temporary working directory, not as inline blobs in prompts.`,
+	PHASE_TAGGING,
+	FOOTER,
+].join("\n\n")

--- a/src/extensions/orchestration/prompt-transformer/prompts/shared.ts
+++ b/src/extensions/orchestration/prompt-transformer/prompts/shared.ts
@@ -1,0 +1,28 @@
+export const TOOLS_SECTION = `## Available Tools
+
+{{TOOLS}}`
+
+export const RESEARCH_RULES = `## Research Rules
+
+- Use \`web_search\` only during the \`research\` step — not during \`explore\`, \`plan\`, or \`build\`.
+- **Avoid web_fetch.** It returns raw website content that can flood your context window. Prefer \`web_search\` for most research. Use \`web_fetch\` only when the information is frequently updated and unlikely to be indexed (e.g. changelogs, latest release notes), or when the user's message contains an explicit URL. When you do use it, request markdown or text format and delegate to a subagent to keep the output out of the main context.
+- **Run at most one web_search per task.** Do NOT run a second search to verify or refine.`
+
+export const CORE_GUIDELINES = `- Be concise in your responses.
+- Show file paths clearly when working with files.
+- Read files before modifying them.
+- Prefer editing existing files over creating new ones.
+- Do NOT introduce security vulnerabilities.
+- Do NOT add features, refactoring, or improvements beyond what was asked.
+- If you encounter an error, diagnose the root cause before retrying.
+- **Pattern recognition**: If the same implementation pattern is needed more than twice, define the abstraction first, then implement.`
+
+export const PHASE_TAGGING = `## Phase Tagging for Analytics
+
+You must call \`set_phase\` before every block of work. Never take an action without the correct phase being set first. Use one of \`explore\`, \`research\`, \`plan\`, \`build\`, or \`review\` strictly matching current work type.
+
+The session starts in \`explore\` phase by default. Call \`set_phase\` immediately when your work type changes. Only one phase is active at a time — the most recent call wins.`
+
+export const FOOTER = `{{PROJECT_CONTEXT}}
+
+{{SKILLS}}`

--- a/src/extensions/orchestration/prompt-transformer/prompts/single-model-system-prompt.ts
+++ b/src/extensions/orchestration/prompt-transformer/prompts/single-model-system-prompt.ts
@@ -1,0 +1,14 @@
+import { CORE_GUIDELINES, FOOTER, PHASE_TAGGING, RESEARCH_RULES, TOOLS_SECTION } from "./shared.js"
+
+export default [
+	`You are an expert coding assistant. Your available tools are listed under **Available Tools** below — use only those, never guess or invent tool names.
+
+{{ENVIRONMENT}}`,
+	TOOLS_SECTION,
+	RESEARCH_RULES,
+	`## Guidelines
+
+${CORE_GUIDELINES}`,
+	PHASE_TAGGING,
+	FOOTER,
+].join("\n\n")

--- a/src/extensions/orchestration/prompt-transformer/prompts/subagent-system-prompt.ts
+++ b/src/extensions/orchestration/prompt-transformer/prompts/subagent-system-prompt.ts
@@ -1,23 +1,13 @@
-export default `You are an expert coding assistant. You operate inside a coding agent harness. Use only the tools listed under **Available Tools** below — never guess or invent tool names.
+import { CORE_GUIDELINES, FOOTER, TOOLS_SECTION } from "./shared.js"
 
-{{ENVIRONMENT}}
+export default [
+	`You are an expert coding assistant. You operate inside a coding agent harness. Use only the tools listed under **Available Tools** below — never guess or invent tool names.
 
-## Available Tools
+{{ENVIRONMENT}}`,
+	TOOLS_SECTION,
+	`## Guidelines
 
-{{TOOLS}}
-
-## Guidelines
-
-- Be concise in your responses.
-- Show file paths clearly when working with files.
-- Read files before modifying them to understand existing code.
-- Prefer editing existing files over creating new ones.
-- Use the appropriate tool for each operation: read for files, bash for shell commands, edit for modifications, write for new files.
-- Do NOT introduce security vulnerabilities. Prioritize safe, correct code.
-- Do NOT add features, refactoring, or improvements beyond what was asked.
-- If you encounter an error, diagnose the root cause before retrying.
-
-{{PROJECT_CONTEXT}}
-
-{{SKILLS}}
-`
+${CORE_GUIDELINES}
+- Use the appropriate tool for each operation: read for files, bash for shell commands, edit for modifications, write for new files.`,
+	FOOTER,
+].join("\n\n")


### PR DESCRIPTION
## What this adds

A way to run `kimchi-code` without multi-model orchestration — useful when you want a single focused assistant instead of automatic task delegation across models.

## How it works for users

**Disable at startup:**
```bash
kimchi-code --multi-model=false
```

**Toggle mid-session:** press **option/alt+tab** at any time. No restart needed.

**See the current state** in the footer:
```
multi-model: on → option/alt+tab
multi-model: off → option/alt+tab
```

## Behaviour differences

| | Multi-model on (default) | Multi-model off |
|---|---|---|
| Task handling | Classifies task, executes matching steps directly, delegates the rest to specialised subagents | Single agent handles everything end-to-end |
| System prompt | Orchestrator prompt with delegation and model-selection logic | Full-featured prompt (environment, tools, research rules, phase tagging) — orchestration sections removed |
| Subagent tool | Used automatically | Still available — model can delegate if you explicitly ask it to |
| Prompt enrichment | User prompt wrapped with model capabilities and available subagent roster | Passed through as-is |

## Default

Multi-model remains **enabled** by default. This is purely an opt-out.

---
### Kimchi Summary
### What changed
Adds a runtime toggle to disable multi-model orchestration, allowing `kimchi-code` to run as a single direct coding assistant without automatic task classification or subagent delegation.

### Why
Provides a simplified interaction mode for users who prefer direct assistance from a single model rather than the default orchestrated multi-agent workflow.

### Key changes
- Add `--multi-model` CLI flag (defaults to `true`) to control orchestration mode at startup
- Register `alt+tab` (`option+tab` on macOS) keyboard shortcut to toggle mode during a session
- Add `multiModelSegment()` to `StatsFooter` displaying current state (`multi-model: on/off`) and toggle shortcut
- Introduce `buildSingleModelSystemPrompt()` in `prompt-transformer.ts` and new `single-model-system-prompt.ts` template for non-orchestrated mode
- Extract shared prompt sections (`CORE_GUIDELINES`, `RESEARCH_RULES`, `PHASE_TAGGING`, etc.) into new `shared.ts` to reduce duplication across orchestrator, single-model, and subagent prompts
- Skip orchestration prompt transformation when `multiModelEnabled` is `false` in `prompt-enrichment.ts`

### Impact
- **Behavior**: When disabled, the agent skips delegation logic but retains the `subagent` tool for explicit use; system prompt excludes orchestrator-specific instructions
- **UI**: Footer displays current multi-model state and keyboard shortcut hint
- **Performance**: Single-model mode eliminates classification overhead for lower latency on simple tasks