### PR TITLE
LLM-1339: Make nudge messages invisible in the conversation

### DIFF
--- a/src/extensions/orchestration/continuation-nudge.test.ts
+++ b/src/extensions/orchestration/continuation-nudge.test.ts
@@ -5,6 +5,7 @@ import {
 	EMPTY_TURN_NUDGE_TEXT,
 	type OrchestratorMessages,
 	buildEmptyTurnNudgedMessages,
+	stripStaleNudges,
 } from "./continuation-nudge.js"
 
 function makeAssistant(content: AssistantMessage["content"]): AssistantMessage {
@@ -142,9 +143,62 @@ function makeToolResult(toolCallId: string, text: string): ToolResultMessage {
 	}
 }
 
+function makeNudge(): OrchestratorMessages[number] {
+	return {
+		role: "custom" as const,
+		customType: "nudge",
+		content: [{ type: "text" as const, text: "nudge" }],
+		display: false,
+		timestamp: Date.now(),
+	}
+}
+
 function lastMessage(messages: OrchestratorMessages): OrchestratorMessages[number] {
 	return messages[messages.length - 1]
 }
+
+describe("stripStaleNudges", () => {
+	it("returns the same array when there are no nudge messages", () => {
+		const messages: OrchestratorMessages = [makeUser("q"), textOnlyMessage]
+		expect(stripStaleNudges(messages)).toBe(messages)
+	})
+
+	it("strips a nudge that precedes an assistant response", () => {
+		const nudge = makeNudge()
+		const messages: OrchestratorMessages = [makeUser("q"), nudge, textOnlyMessage]
+		const result = stripStaleNudges(messages)
+		expect(result).not.toBe(messages)
+		expect(result).toHaveLength(2)
+		expect(result).not.toContainEqual(nudge)
+	})
+
+	it("keeps a nudge that comes after the last assistant message", () => {
+		const nudge = makeNudge()
+		const messages: OrchestratorMessages = [makeUser("q"), textOnlyMessage, nudge]
+		const result = stripStaleNudges(messages)
+		expect(result).toBe(messages)
+	})
+
+	it("strips multiple stale nudges", () => {
+		const messages: OrchestratorMessages = [
+			makeUser("q1"),
+			makeNudge(),
+			textOnlyMessage,
+			makeUser("q2"),
+			makeNudge(),
+			toolCallMessage,
+		]
+		const result = stripStaleNudges(messages)
+		expect(result.filter((m) => m.role === "custom")).toHaveLength(0)
+	})
+
+	it("does not strip non-nudge custom messages", () => {
+		const other = { role: "custom" as const, customType: "other", content: "x", display: false, timestamp: Date.now() }
+		const messages: OrchestratorMessages = [makeUser("q"), other, textOnlyMessage]
+		const result = stripStaleNudges(messages)
+		expect(result).toContainEqual(other)
+	})
+})
 
 describe("buildEmptyTurnNudgedMessages", () => {
 	it("returns undefined when there is no assistant message yet", () => {
@@ -166,14 +220,13 @@ describe("buildEmptyTurnNudgedMessages", () => {
 		expect(buildEmptyTurnNudgedMessages(messages)).toBeUndefined()
 	})
 
-	it("appends a user-role nudge when tool-call-only assistant is followed by tool results", () => {
+	it("appends a custom-role nudge when tool-call-only assistant is followed by tool results", () => {
 		const messages: OrchestratorMessages = [makeUser("q"), toolCallMessage, makeToolResult("call_1", "done")]
 		const nudged = buildEmptyTurnNudgedMessages(messages)
 		expect(nudged).toBeDefined()
 		expect(nudged?.length).toBe(messages.length + 1)
 		const appended = lastMessage(nudged as OrchestratorMessages)
-		expect(appended.role).toBe("user")
-		expect((appended as UserMessage).content).toEqual([{ type: "text", text: EMPTY_TURN_NUDGE_TEXT }])
+		expect(appended.role).toBe("custom")
 	})
 
 	it("does not mutate the caller's messages array", () => {
@@ -184,7 +237,6 @@ describe("buildEmptyTurnNudgedMessages", () => {
 	})
 
 	it("uses the most recent assistant message (ignores older ones)", () => {
-		// An earlier text-only assistant turn should not disqualify a later tool-call-only drift.
 		const messages: OrchestratorMessages = [
 			makeUser("q1"),
 			textOnlyMessage,

--- a/src/extensions/orchestration/continuation-nudge.ts
+++ b/src/extensions/orchestration/continuation-nudge.ts
@@ -1,23 +1,27 @@
 /**
- * Two complementary workarounds for Kimi K2.x tool-calling quirks that each
- * leave the agent loop in a stuck-looking state. Both targets the same failure
+ * Two complementary nudges for Kimi K2.x tool-calling quirks that each
+ * leave the agent loop in a stuck-looking state. Both target the same failure
  * class (model said one thing, didn't follow through in the next tool-use
- * step) but on opposite sides of the loop lifecycle:
+ * step) but fire at different points in the turn lifecycle:
  *
- *   1. `ContinuationNudge` — post-turn. The orchestrator reasons through the
- *      self-assessment in prose, announces it will delegate, and ends its
- *      turn without emitting the `subagent` tool call. Without a nudge the
- *      agent loop exits and the user has to re-prompt ("is it completed?").
- *      Mirrors AISI Inspect's `on_continue` parameter.
+ *   1. Continuation nudge — post-turn. The orchestrator reasons in prose,
+ *      announces it will delegate, and ends its turn without emitting the
+ *      `subagent` tool call. Delivered as a `followUp` via `pi.sendMessage`
+ *      so the agent loop restarts. Mirrors AISI Inspect's `on_continue`.
  *
- *   2. `buildEmptyTurnNudgedMessages` — pre-LLM-call. The model returned a
- *      tool-call-only response (no text), tool results are queued, and it
- *      is about to be called again. Some Kimi deployments return an empty
- *      response on this specific follow-up. Injecting a user-role nudge
- *      into the context reliably prevents the empty turn.
+ *   2. Empty-turn nudge — pre-LLM-call. The model returned a tool-call-only
+ *      response (no text) and tool results are ready. Some Kimi deployments
+ *      return an empty response on the next call. Injected transiently into
+ *      the context via the `context` event so it doesn't pollute the session
+ *      history.
  *
- * Both are orchestrator-only concerns — they are wired in
- * `prompt-enrichment.ts` inside the `if (!subagentMode)` guard.
+ * Both are delivered as custom messages with `display: false` so they
+ * never appear in the conversation. Stale nudges (those the model has
+ * already acted on) are stripped from the LLM context by
+ * `stripStaleNudges` before each call.
+ *
+ * Both are orchestrator-only concerns — wired in `prompt-enrichment.ts`
+ * inside the `if (!subagentMode)` guard.
  */
 
 import type { AssistantMessage } from "@mariozechner/pi-ai"
@@ -74,13 +78,31 @@ export class ContinuationNudge {
 
 /**
  * Pre-LLM-call nudge for the "tool-call-only assistant, tool results pending"
- * pattern. Returns a new messages array with a user-role nudge appended if
+ * pattern. Returns a new messages array with a custom-role nudge appended if
  * the pattern matches, otherwise `undefined` (signal for the caller to leave
  * the context untouched).
  *
- * Stateless by design — every decision is computable from the messages array
- * alone, which also makes it trivial to unit test.
+ * Injected via the `context` event so it is transient — visible only to the
+ * targeted LLM call, not persisted in the session history.
  */
+export const NUDGE_CUSTOM_TYPE = "nudge"
+
+function isNudgeMessage(m: OrchestratorMessages[number]): boolean {
+	return m.role === "custom" && "customType" in m && (m as { customType: string }).customType === NUDGE_CUSTOM_TYPE
+}
+
+/**
+ * Strip nudge messages that the model has already acted on (i.e. there is an
+ * assistant response after them). Keeps nudges that are still at the tail of
+ * the array — the model hasn't seen those yet.
+ */
+export function stripStaleNudges(messages: OrchestratorMessages): OrchestratorMessages {
+	const lastAssistantIdx = messages.findLastIndex((m) => m.role === "assistant")
+	if (lastAssistantIdx === -1) return messages
+	const stripped = messages.filter((m, i) => i > lastAssistantIdx || !isNudgeMessage(m))
+	return stripped.length === messages.length ? messages : stripped
+}
+
 export function buildEmptyTurnNudgedMessages(messages: OrchestratorMessages): OrchestratorMessages | undefined {
 	const lastAssistant = [...messages].reverse().find((m): m is AssistantMessage => m.role === "assistant")
 	if (!lastAssistant) return undefined
@@ -96,8 +118,10 @@ export function buildEmptyTurnNudgedMessages(messages: OrchestratorMessages): Or
 	return [
 		...messages,
 		{
-			role: "user" as const,
+			role: "custom" as const,
+			customType: NUDGE_CUSTOM_TYPE,
 			content: [{ type: "text" as const, text: EMPTY_TURN_NUDGE_TEXT }],
+			display: false,
 			timestamp: Date.now(),
 		},
 	]

--- a/src/extensions/orchestration/prompt-enrichment.ts
+++ b/src/extensions/orchestration/prompt-enrichment.ts
@@ -172,7 +172,6 @@ export default function (skillPaths: string[]) {
 				return { action: "handled" as const }
 			})
 
-
 			// Pre-LLM-call complement of the turn_end nudge above: the model returned only
 			// tool calls with no text, tool results are queued, and it is about to be
 			// called again. Some Kimi deployments return an empty response on this specific
@@ -183,7 +182,7 @@ export default function (skillPaths: string[]) {
 				const nudged = buildEmptyTurnNudgedMessages(cleaned)
 				if (nudged) return { messages: nudged }
 				if (cleaned !== event.messages) return { messages: cleaned }
-			})	
+			})
 		}
 
 		const platformNames: Record<string, string> = { darwin: "macOS", win32: "Windows" }

--- a/src/extensions/orchestration/prompt-enrichment.ts
+++ b/src/extensions/orchestration/prompt-enrichment.ts
@@ -29,7 +29,13 @@ import { type ExtensionAPI, type Skill, loadSkills } from "@mariozechner/pi-codi
 import { ANSI, fg } from "../../ansi.js"
 import { getAvailableModels } from "../../startup-context.js"
 import { getGitBranch } from "../../utils.js"
-import { CONTINUATION_NUDGE_TEXT, ContinuationNudge, buildEmptyTurnNudgedMessages } from "./continuation-nudge.js"
+import {
+	CONTINUATION_NUDGE_TEXT,
+	ContinuationNudge,
+	NUDGE_CUSTOM_TYPE,
+	buildEmptyTurnNudgedMessages,
+	stripStaleNudges,
+} from "./continuation-nudge.js"
 import { ModelRegistry } from "./model-registry/index.js"
 import { type ContextFile, loadProjectContextFiles } from "./prompt-transformer/context-files.js"
 import {
@@ -123,7 +129,10 @@ export default function (skillPaths: string[]) {
 				if (event.message.role !== "assistant") return
 				const { shouldNudge } = continuationNudge.evaluateTurn(event.message)
 				if (!shouldNudge) return
-				pi.sendUserMessage(CONTINUATION_NUDGE_TEXT, { deliverAs: "followUp" })
+				pi.sendMessage(
+					{ customType: NUDGE_CUSTOM_TYPE, content: CONTINUATION_NUDGE_TEXT, display: false },
+					{ deliverAs: "followUp" },
+				)
 			})
 
 			pi.on("input", async (event, ctx) => {
@@ -163,15 +172,18 @@ export default function (skillPaths: string[]) {
 				return { action: "handled" as const }
 			})
 
+
 			// Pre-LLM-call complement of the turn_end nudge above: the model returned only
 			// tool calls with no text, tool results are queued, and it is about to be
 			// called again. Some Kimi deployments return an empty response on this specific
-			// follow-up; a user-role nudge injected into the context reliably prevents it.
+			// follow-up; a custom-role nudge injected transiently into the context prevents it
+			// without polluting the session history.
 			pi.on("context", async (event) => {
-				const nudged = buildEmptyTurnNudgedMessages(event.messages)
-				if (!nudged) return
-				return { messages: nudged }
-			})
+				const cleaned = stripStaleNudges(event.messages)
+				const nudged = buildEmptyTurnNudgedMessages(cleaned)
+				if (nudged) return { messages: nudged }
+				if (cleaned !== event.messages) return { messages: cleaned }
+			})	
 		}
 
 		const platformNames: Record<string, string> = { darwin: "macOS", win32: "Windows" }


### PR DESCRIPTION
Both nudges now use custom messages with display: false instead of user messages. Stale nudges that the model already acted on are stripped from the LLM context via stripStaleNudges in the context event handler.

---
### Kimchi Summary
### What changed
Introduces `stripStaleNudges` to filter out nudge messages that have already been acted upon, and converts nudge messages from user-role to custom-role with `display: false` to keep them invisible and transient.

### Why
Prevents nudge messages from accumulating in the LLM context and appearing in the conversation history. Previously, nudges were injected as persistent user messages; now they are cleaned up after the model responds, ensuring only relevant nudges (those at the tail of the array awaiting a response) remain in context.

### Key changes
- `continuation-nudge.ts`:
  - Added `stripStaleNudges` function that removes nudge messages preceding the most recent assistant message.
  - Changed `buildEmptyTurnNudgedMessages` to return custom-role messages with `customType: "nudge"` and `display: false` instead of user-role messages.
  - Added `NUDGE_CUSTOM_TYPE` constant.
- `prompt-enrichment.ts`:
  - Updated `context` event handler to call `stripStaleNudges` before each LLM invocation.
  - Changed continuation nudge delivery from `pi.sendUserMessage` to `pi.sendMessage` with `customType: NUDGE_CUSTOM_TYPE` and `display: false`.
- `continuation-nudge.test.ts`:
  - Added test suite for `stripStaleNudges` covering single/multiple stale nudges and preservation of non-nudge custom messages.
  - Updated existing tests to assert `role: "custom"` instead of `role: "user"`.

### Impact
Nudge messages no longer pollute the session history or user-facing conversation. Stale nudges are automatically stripped from the LLM context, reducing token usage and preventing confusion in multi-turn interactions. No migration steps required—existing sessions will simply stop showing nudges.