### PR TITLE
LLM-1403: Standardize working document location

### DIFF
--- a/src/extensions/orchestration/prompt-enrichment.ts
+++ b/src/extensions/orchestration/prompt-enrichment.ts
@@ -254,7 +254,7 @@ export default function (skillPaths: string[]) {
 				username: cachedUsername,
 				homeDir: cachedHomeDir,
 				cwd: ctx.cwd,
-				workspaceDir: join(ctx.cwd, ".kimchi", "docs"),
+				documentsDir: join(ctx.cwd, ".kimchi", "docs"),
 				currentTime: now.toISOString(),
 				localDate: now.toLocaleDateString("en-CA"),
 				isGitRepo,

--- a/src/extensions/orchestration/prompt-enrichment.ts
+++ b/src/extensions/orchestration/prompt-enrichment.ts
@@ -254,6 +254,7 @@ export default function (skillPaths: string[]) {
 				username: cachedUsername,
 				homeDir: cachedHomeDir,
 				cwd: ctx.cwd,
+				workspaceDir: join(ctx.cwd, ".kimchi", "docs"),
 				currentTime: now.toISOString(),
 				localDate: now.toLocaleDateString("en-CA"),
 				isGitRepo,

--- a/src/extensions/orchestration/prompt-transformer/prompt-transformer.test.ts
+++ b/src/extensions/orchestration/prompt-transformer/prompt-transformer.test.ts
@@ -14,6 +14,7 @@ const testEnv: EnvironmentInfo = {
 	username: "testuser",
 	homeDir: "/home/testuser",
 	cwd: "/home/testuser/projects/myapp",
+	workspaceDir: "/home/testuser/projects/myapp/.kimchi/docs",
 	currentTime: "2026-01-01T00:00:00.000Z",
 	localDate: "2026-01-01",
 	isGitRepo: false,

--- a/src/extensions/orchestration/prompt-transformer/prompt-transformer.test.ts
+++ b/src/extensions/orchestration/prompt-transformer/prompt-transformer.test.ts
@@ -14,7 +14,7 @@ const testEnv: EnvironmentInfo = {
 	username: "testuser",
 	homeDir: "/home/testuser",
 	cwd: "/home/testuser/projects/myapp",
-	workspaceDir: "/home/testuser/projects/myapp/.kimchi/docs",
+	documentsDir: "/home/testuser/projects/myapp/.kimchi/docs",
 	currentTime: "2026-01-01T00:00:00.000Z",
 	localDate: "2026-01-01",
 	isGitRepo: false,

--- a/src/extensions/orchestration/prompt-transformer/prompt-transformer.ts
+++ b/src/extensions/orchestration/prompt-transformer/prompt-transformer.ts
@@ -12,6 +12,7 @@ export interface EnvironmentInfo {
 	username: string
 	homeDir: string
 	cwd: string
+	workspaceDir: string
 	currentTime: string
 	localDate: string
 	isGitRepo: boolean
@@ -144,6 +145,7 @@ function formatEnvironmentSection(env: EnvironmentInfo): string {
 		`- Username: ${env.username}`,
 		`- Home directory: "${env.homeDir}"`,
 		`- Working directory: "${env.cwd}"`,
+		`- Workspace directory: "${env.workspaceDir}"`,
 		`- Current time: ${env.currentTime} (local date: ${env.localDate})`,
 		`- Git repository: ${env.isGitRepo ? "yes" : "no"}`,
 	]

--- a/src/extensions/orchestration/prompt-transformer/prompt-transformer.ts
+++ b/src/extensions/orchestration/prompt-transformer/prompt-transformer.ts
@@ -12,7 +12,7 @@ export interface EnvironmentInfo {
 	username: string
 	homeDir: string
 	cwd: string
-	workspaceDir: string
+	documentsDir: string
 	currentTime: string
 	localDate: string
 	isGitRepo: boolean
@@ -145,7 +145,7 @@ function formatEnvironmentSection(env: EnvironmentInfo): string {
 		`- Username: ${env.username}`,
 		`- Home directory: "${env.homeDir}"`,
 		`- Working directory: "${env.cwd}"`,
-		`- Workspace directory: "${env.workspaceDir}"`,
+		`- Documents directory: "${env.documentsDir}"`,
 		`- Current time: ${env.currentTime} (local date: ${env.localDate})`,
 		`- Git repository: ${env.isGitRepo ? "yes" : "no"}`,
 	]

--- a/src/extensions/orchestration/prompt-transformer/prompts/orchestrator-system-prompt.ts
+++ b/src/extensions/orchestration/prompt-transformer/prompts/orchestrator-system-prompt.ts
@@ -1,4 +1,4 @@
-import { CORE_GUIDELINES, FOOTER, PHASE_TAGGING, RESEARCH_RULES, TOOLS_SECTION, WORKSPACE_SECTION } from "./shared.js"
+import { CORE_GUIDELINES, FOOTER, PHASE_TAGGING, RESEARCH_RULES, TOOLS_SECTION, DOCUMENTS_SECTION } from "./shared.js"
 
 export default [
 	`You are an expert coding assistant. Your available tools are listed under **Available Tools** below — use only those, never guess or invent tool names. You can also spawn subagents when delegation is more appropriate than doing the work yourself.
@@ -34,7 +34,7 @@ Look at **Your Capabilities** in the user message. Your strengths are the author
 
 - If a step matches your strengths, do it yourself.
 - If a step does not match your strengths, delegate it to a model whose strengths fit — regardless of whether you think you could attempt it.
-- If your tier is \`heavy\`, delegate each step you don't own to a separate subagent. Write a plan first (spec file with interfaces and file paths) to the Workspace directory, then delegate only \`build\` to a cheaper model — passing the spec file path. Never delegate an unplanned task in a single subagent call.
+- If your tier is \`heavy\`, delegate each step you don't own to a separate subagent. Write a plan first (spec file with interfaces and file paths) to the Documents directory, then delegate only \`build\` to a cheaper model — passing the spec file path. Never delegate an unplanned task in a single subagent call.
 - If your tier is \`standard\` or \`light\` and the task requires \`explore\`, \`research\`, or \`plan\` steps: you must delegate those steps. Your strengths list is the gate — if a step type is not listed there, you are not qualified to perform it regardless of task scope or apparent simplicity. Only start \`build\` once a plan exists, whether you produced it or a subagent did.
 
 The goal is to use the model best suited to each step, not the one already running.
@@ -46,7 +46,7 @@ Run the steps in order. For steps you own, use your tools directly. For steps yo
 ## Subagent delegation rules
 
 - Write subagent prompts that are fully self-contained. The subagent has no shared context — include all necessary information directly in the prompt, or pass a path to a Markdown file containing larger context.
-- When delegating \`plan\` before \`build\`, have the planning subagent write a Markdown spec file (full method signatures, file paths, interfaces) to the Workspace directory. Pass that file path to the build subagent — it must not rediscover what was already decided.
+- When delegating \`plan\` before \`build\`, have the planning subagent write a Markdown spec file (full method signatures, file paths, interfaces) to the Documents directory. Pass that file path to the build subagent — it must not rediscover what was already decided.
 - Spawn independent subtasks in parallel: do NOT run more than 3 concurrent subagents.
 - After a subagent returns, review the output. If corrections are needed, spawn a follow-up with the correction task.
 - Do NOT spawn a subagent for work you can do in a single tool call.
@@ -72,12 +72,12 @@ Include a \`tokenBudget\` for every subagent call:
 
 If a subagent hits its budget, spawn a follow-up with the remaining work rather than raising the budget.`,
 	TOOLS_SECTION,
-	WORKSPACE_SECTION,
+	DOCUMENTS_SECTION,
 	RESEARCH_RULES,
 	`## Guidelines
 
 ${CORE_GUIDELINES}
-- **Sharing context between agents**: Pass plans and structured findings as Markdown files in the Workspace directory, not as inline blobs in prompts.`,
+- **Sharing context between agents**: Pass plans and structured findings as Markdown files in the Documents directory, not as inline blobs in prompts.`,
 	PHASE_TAGGING,
 	FOOTER,
 ].join("\n\n")

--- a/src/extensions/orchestration/prompt-transformer/prompts/orchestrator-system-prompt.ts
+++ b/src/extensions/orchestration/prompt-transformer/prompts/orchestrator-system-prompt.ts
@@ -1,4 +1,4 @@
-import { CORE_GUIDELINES, FOOTER, PHASE_TAGGING, RESEARCH_RULES, TOOLS_SECTION } from "./shared.js"
+import { CORE_GUIDELINES, FOOTER, PHASE_TAGGING, RESEARCH_RULES, TOOLS_SECTION, WORKSPACE_SECTION } from "./shared.js"
 
 export default [
 	`You are an expert coding assistant. Your available tools are listed under **Available Tools** below — use only those, never guess or invent tool names. You can also spawn subagents when delegation is more appropriate than doing the work yourself.
@@ -34,7 +34,7 @@ Look at **Your Capabilities** in the user message. Your strengths are the author
 
 - If a step matches your strengths, do it yourself.
 - If a step does not match your strengths, delegate it to a model whose strengths fit — regardless of whether you think you could attempt it.
-- If your tier is \`heavy\`, delegate each step you don't own to a separate subagent. Write a plan first (spec file with interfaces and file paths), then delegate only \`build\` to a cheaper model — passing the spec file path. Never delegate an unplanned task in a single subagent call.
+- If your tier is \`heavy\`, delegate each step you don't own to a separate subagent. Write a plan first (spec file with interfaces and file paths) to the Workspace directory, then delegate only \`build\` to a cheaper model — passing the spec file path. Never delegate an unplanned task in a single subagent call.
 - If your tier is \`standard\` or \`light\` and the task requires \`explore\`, \`research\`, or \`plan\` steps: you must delegate those steps. Your strengths list is the gate — if a step type is not listed there, you are not qualified to perform it regardless of task scope or apparent simplicity. Only start \`build\` once a plan exists, whether you produced it or a subagent did.
 
 The goal is to use the model best suited to each step, not the one already running.
@@ -46,7 +46,7 @@ Run the steps in order. For steps you own, use your tools directly. For steps yo
 ## Subagent delegation rules
 
 - Write subagent prompts that are fully self-contained. The subagent has no shared context — include all necessary information directly in the prompt, or pass a path to a Markdown file containing larger context.
-- When delegating \`plan\` before \`build\`, have the planning subagent write a Markdown spec file (full method signatures, file paths, interfaces). Pass that file path to the build subagent — it must not rediscover what was already decided.
+- When delegating \`plan\` before \`build\`, have the planning subagent write a Markdown spec file (full method signatures, file paths, interfaces) to the Workspace directory. Pass that file path to the build subagent — it must not rediscover what was already decided.
 - Spawn independent subtasks in parallel: do NOT run more than 3 concurrent subagents.
 - After a subagent returns, review the output. If corrections are needed, spawn a follow-up with the correction task.
 - Do NOT spawn a subagent for work you can do in a single tool call.
@@ -72,11 +72,12 @@ Include a \`tokenBudget\` for every subagent call:
 
 If a subagent hits its budget, spawn a follow-up with the remaining work rather than raising the budget.`,
 	TOOLS_SECTION,
+	WORKSPACE_SECTION,
 	RESEARCH_RULES,
 	`## Guidelines
 
 ${CORE_GUIDELINES}
-- **Sharing context between agents**: Pass plans and structured findings as Markdown files in a temporary working directory, not as inline blobs in prompts.`,
+- **Sharing context between agents**: Pass plans and structured findings as Markdown files in the Workspace directory, not as inline blobs in prompts.`,
 	PHASE_TAGGING,
 	FOOTER,
 ].join("\n\n")

--- a/src/extensions/orchestration/prompt-transformer/prompts/orchestrator-system-prompt.ts
+++ b/src/extensions/orchestration/prompt-transformer/prompts/orchestrator-system-prompt.ts
@@ -1,4 +1,4 @@
-import { CORE_GUIDELINES, FOOTER, PHASE_TAGGING, RESEARCH_RULES, TOOLS_SECTION, DOCUMENTS_SECTION } from "./shared.js"
+import { CORE_GUIDELINES, DOCUMENTS_SECTION, FOOTER, PHASE_TAGGING, RESEARCH_RULES, TOOLS_SECTION } from "./shared.js"
 
 export default [
 	`You are an expert coding assistant. Your available tools are listed under **Available Tools** below — use only those, never guess or invent tool names. You can also spawn subagents when delegation is more appropriate than doing the work yourself.

--- a/src/extensions/orchestration/prompt-transformer/prompts/shared.ts
+++ b/src/extensions/orchestration/prompt-transformer/prompts/shared.ts
@@ -17,6 +17,10 @@ export const CORE_GUIDELINES = `- Be concise in your responses.
 - If you encounter an error, diagnose the root cause before retrying.
 - **Pattern recognition**: If the same implementation pattern is needed more than twice, define the abstraction first, then implement.`
 
+export const WORKSPACE_SECTION = `## Workspace
+
+The Workspace directory is shown in the Environment section. Use it for **all** intermediate and output files: plans, specs, research notes, findings, or any file passed between agents. Never write working documents to the project directory or a temporary directory.`
+
 export const PHASE_TAGGING = `## Phase Tagging for Analytics
 
 You must call \`set_phase\` before every block of work. Never take an action without the correct phase being set first. Use one of \`explore\`, \`research\`, \`plan\`, \`build\`, or \`review\` strictly matching current work type.

--- a/src/extensions/orchestration/prompt-transformer/prompts/shared.ts
+++ b/src/extensions/orchestration/prompt-transformer/prompts/shared.ts
@@ -17,9 +17,9 @@ export const CORE_GUIDELINES = `- Be concise in your responses.
 - If you encounter an error, diagnose the root cause before retrying.
 - **Pattern recognition**: If the same implementation pattern is needed more than twice, define the abstraction first, then implement.`
 
-export const WORKSPACE_SECTION = `## Workspace
+export const DOCUMENTS_SECTION = `## Documents
 
-The Workspace directory is shown in the Environment section. Use it for **all** intermediate and output files: plans, specs, research notes, findings, or any file passed between agents. Never write working documents to the project directory or a temporary directory.`
+The Documents directory is shown in the Environment section. Use it for **all** intermediate and output files: plans, specs, research notes, findings, or any file passed between agents. Never write working documents to the project directory or a temporary directory.`
 
 export const PHASE_TAGGING = `## Phase Tagging for Analytics
 

--- a/src/extensions/orchestration/prompt-transformer/prompts/single-model-system-prompt.ts
+++ b/src/extensions/orchestration/prompt-transformer/prompts/single-model-system-prompt.ts
@@ -1,4 +1,4 @@
-import { CORE_GUIDELINES, FOOTER, PHASE_TAGGING, RESEARCH_RULES, TOOLS_SECTION, DOCUMENTS_SECTION } from "./shared.js"
+import { CORE_GUIDELINES, DOCUMENTS_SECTION, FOOTER, PHASE_TAGGING, RESEARCH_RULES, TOOLS_SECTION } from "./shared.js"
 
 export default [
 	`You are an expert coding assistant. Your available tools are listed under **Available Tools** below — use only those, never guess or invent tool names.

--- a/src/extensions/orchestration/prompt-transformer/prompts/single-model-system-prompt.ts
+++ b/src/extensions/orchestration/prompt-transformer/prompts/single-model-system-prompt.ts
@@ -1,11 +1,11 @@
-import { CORE_GUIDELINES, FOOTER, PHASE_TAGGING, RESEARCH_RULES, TOOLS_SECTION, WORKSPACE_SECTION } from "./shared.js"
+import { CORE_GUIDELINES, FOOTER, PHASE_TAGGING, RESEARCH_RULES, TOOLS_SECTION, DOCUMENTS_SECTION } from "./shared.js"
 
 export default [
 	`You are an expert coding assistant. Your available tools are listed under **Available Tools** below — use only those, never guess or invent tool names.
 
 {{ENVIRONMENT}}`,
 	TOOLS_SECTION,
-	WORKSPACE_SECTION,
+	DOCUMENTS_SECTION,
 	RESEARCH_RULES,
 	`## Guidelines
 

--- a/src/extensions/orchestration/prompt-transformer/prompts/single-model-system-prompt.ts
+++ b/src/extensions/orchestration/prompt-transformer/prompts/single-model-system-prompt.ts
@@ -1,10 +1,11 @@
-import { CORE_GUIDELINES, FOOTER, PHASE_TAGGING, RESEARCH_RULES, TOOLS_SECTION } from "./shared.js"
+import { CORE_GUIDELINES, FOOTER, PHASE_TAGGING, RESEARCH_RULES, TOOLS_SECTION, WORKSPACE_SECTION } from "./shared.js"
 
 export default [
 	`You are an expert coding assistant. Your available tools are listed under **Available Tools** below — use only those, never guess or invent tool names.
 
 {{ENVIRONMENT}}`,
 	TOOLS_SECTION,
+	WORKSPACE_SECTION,
 	RESEARCH_RULES,
 	`## Guidelines
 

--- a/src/extensions/orchestration/prompt-transformer/prompts/subagent-system-prompt.ts
+++ b/src/extensions/orchestration/prompt-transformer/prompts/subagent-system-prompt.ts
@@ -1,11 +1,11 @@
-import { CORE_GUIDELINES, FOOTER, TOOLS_SECTION, WORKSPACE_SECTION } from "./shared.js"
+import { CORE_GUIDELINES, FOOTER, TOOLS_SECTION, DOCUMENTS_SECTION } from "./shared.js"
 
 export default [
 	`You are an expert coding assistant. You operate inside a coding agent harness. Use only the tools listed under **Available Tools** below — never guess or invent tool names.
 
 {{ENVIRONMENT}}`,
 	TOOLS_SECTION,
-	WORKSPACE_SECTION,
+	DOCUMENTS_SECTION,
 	`## Guidelines
 
 ${CORE_GUIDELINES}

--- a/src/extensions/orchestration/prompt-transformer/prompts/subagent-system-prompt.ts
+++ b/src/extensions/orchestration/prompt-transformer/prompts/subagent-system-prompt.ts
@@ -1,4 +1,4 @@
-import { CORE_GUIDELINES, FOOTER, TOOLS_SECTION, DOCUMENTS_SECTION } from "./shared.js"
+import { CORE_GUIDELINES, DOCUMENTS_SECTION, FOOTER, TOOLS_SECTION } from "./shared.js"
 
 export default [
 	`You are an expert coding assistant. You operate inside a coding agent harness. Use only the tools listed under **Available Tools** below — never guess or invent tool names.

--- a/src/extensions/orchestration/prompt-transformer/prompts/subagent-system-prompt.ts
+++ b/src/extensions/orchestration/prompt-transformer/prompts/subagent-system-prompt.ts
@@ -1,10 +1,11 @@
-import { CORE_GUIDELINES, FOOTER, TOOLS_SECTION } from "./shared.js"
+import { CORE_GUIDELINES, FOOTER, TOOLS_SECTION, WORKSPACE_SECTION } from "./shared.js"
 
 export default [
 	`You are an expert coding assistant. You operate inside a coding agent harness. Use only the tools listed under **Available Tools** below — never guess or invent tool names.
 
 {{ENVIRONMENT}}`,
 	TOOLS_SECTION,
+	WORKSPACE_SECTION,
 	`## Guidelines
 
 ${CORE_GUIDELINES}


### PR DESCRIPTION
## Problem

Agents had no consistent place to write working documents — plans, specs, research notes, and findings ended up wherever each model decided: the project directory, a temp directory, or an arbitrary subdirectory. This made it impossible to reliably find, pass, or reuse documents across agent sessions or between parent and subagent.

## What changed

All agents now have a single, predictable location for working documents: `.kimchi/docs/` inside the working directory. This path is surfaced directly in every agent's environment context so no model needs to guess or infer it.

Every system prompt — orchestrator, single-model, and subagent — now includes a dedicated **Workspace** section that names this directory as the required destination for all intermediate and output files, and explicitly prohibits writing to project or temp directories.

Because the workspace is tied to the working directory rather than a session, the same documents are accessible across multiple sessions working on the same task.

---
### Kimchi Summary
### What changed
Introduces a dedicated Documents directory (`<cwd>/.kimchi/docs`) for agent-generated artifacts and exposes it in the environment context. All system prompts now instruct agents to write intermediate files—such as plans, specs, and research notes—to this directory rather than the project root or temporary locations.

### Why
Standardizes where agents persist working documents to ensure reliable context sharing between orchestrators and subagents. Previously, agents were instructed to use "temporary working directories" or the project root, which could lead to files being written in inconsistent or ephemeral locations.

### Key changes
- **`prompt-enrichment.ts`**: Adds `documentsDir` field (resolved to `.kimchi/docs`) to the environment context object.
- **`prompt-transformer.ts`**: Extends `EnvironmentInfo` interface with `documentsDir` and includes it in the formatted Environment section of prompts.
- **`shared.ts`**: Adds new `DOCUMENTS_SECTION` constant defining the Documents directory purpose and usage rules.
- **`orchestrator-system-prompt.ts`**, **`single-model-system-prompt.ts`**, **`subagent-system-prompt.ts`**: Import and inject `DOCUMENTS_SECTION` into system prompts; update delegation rules to specify writing spec files to the Documents directory.
- **`prompt-transformer.test.ts`**: Updates test fixture to include the new `documentsDir` value.

### Impact
Agents must now write **all** intermediate and output files (plans, specs, findings) to the Documents directory path provided in the Environment section. This affects subagent delegation flows: planning agents must write Markdown specs to this directory for build agents to consume. Project directories will no longer accumulate temporary agent artifacts.