### PR TITLE
LLM-1402: add --yolo and --dangerously-skip-permissions flags

### DIFF
--- a/src/extensions/permissions/commands.ts
+++ b/src/extensions/permissions/commands.ts
@@ -123,13 +123,23 @@ async function openModePicker(ctx: ExtensionContext, deps: CommandDeps): Promise
 
 	const OPT_DEFAULT = `${marker("default")}  default — ask before each tool call`
 	const OPT_PLAN = `${marker("plan")}  plan — read-only exploration`
-	const OPT_AUTO = `${marker("auto")}  yolo — run freely, classifier guards the rest`
+	const OPT_AUTO = `${marker("auto")}  auto — run freely, classifier guards the rest`
+	const OPT_YOLO = `${marker("yolo")}  yolo — run freely, no classifier (DANGER)`
 	const CANCEL = "Cancel"
 
-	const choice = await ctx.ui.select("Select permission mode", [OPT_DEFAULT, OPT_PLAN, OPT_AUTO, CANCEL])
+	const choice = await ctx.ui.select("Select permission mode", [OPT_DEFAULT, OPT_PLAN, OPT_AUTO, OPT_YOLO, CANCEL])
 	if (!choice || choice === CANCEL) return
 
-	const picked: PermissionMode = choice === OPT_DEFAULT ? "default" : choice === OPT_PLAN ? "plan" : "auto"
+	const picked: PermissionMode =
+		choice === OPT_DEFAULT
+			? "default"
+			: choice === OPT_PLAN
+				? "plan"
+				: choice === OPT_AUTO
+					? "auto"
+					: choice === OPT_YOLO
+						? "yolo"
+						: "default"
 	handleMode(ctx, deps, picked)
 }
 
@@ -141,7 +151,7 @@ async function promptForRule(ctx: ExtensionContext, deps: CommandDeps, behavior:
 }
 
 const HELP_TEXT = `/permissions — show current mode and rules
-/permissions mode <default|plan|auto> — switch mode
+/permissions mode <default|plan|auto|yolo> — switch mode
 /permissions allow <rule> — add a session allow rule
 /permissions deny <rule> — add a session deny rule
 /permissions save user|project — persist session rules to config

--- a/src/extensions/permissions/index.ts
+++ b/src/extensions/permissions/index.ts
@@ -10,6 +10,13 @@ import { SessionMemory } from "./session-memory.js"
 import { isReadOnlyBashCommand, isReadOnlyTool } from "./taxonomy.js"
 import { BUILTIN_DENY, DEFAULT_CONFIG, type PermissionMode, type Rule } from "./types.js"
 
+/**
+ * DANGER: Bypass flag that disables ALL permission checks.
+ * WARNING: This skips denylist, rules, classifier, and prompts.
+ * For throwaway/sandboxed environments ONLY.
+ */
+const DANGEROUS_BYPASS_FLAG = "dangerously-skip-permissions"
+
 // Safe default so any event that fires before session_start (and therefore
 // before doLoadConfig) doesn't crash reading `loaded.config.*`.
 const EMPTY_LOADED_CONFIG: LoadedConfig = {
@@ -28,7 +35,8 @@ const BUILTIN_ALLOW_TOOL_NAMES = ["subagent", "set_phase"]
 const MODES: Array<{ mode: PermissionMode; label: string; color: "success" | "warning" | "error" }> = [
 	{ mode: "default", label: "default", color: "success" },
 	{ mode: "plan", label: "plan", color: "warning" },
-	{ mode: "auto", label: "yolo", color: "error" },
+	{ mode: "auto", label: "auto", color: "warning" },
+	{ mode: "yolo", label: "yolo", color: "error" },
 ]
 
 export default function permissionsExtension(pi: ExtensionAPI): void {
@@ -37,8 +45,19 @@ export default function permissionsExtension(pi: ExtensionAPI): void {
 		type: "boolean",
 		default: false,
 	})
+	pi.registerFlag("yolo", {
+		description: "Alias for --auto. Start in autonomous mode (YOLO with classifier).",
+		type: "boolean",
+		default: false,
+	})
 	pi.registerFlag("auto", {
 		description: "Start in autonomous mode (YOLO with classifier).",
+		type: "boolean",
+		default: false,
+	})
+	pi.registerFlag(DANGEROUS_BYPASS_FLAG, {
+		description:
+			"DANGER: Skip ALL permission checks including denylist (sudo, .env writes), rules, classifier, and prompts. Intended for throwaway/sandbox environments only.",
 		type: "boolean",
 		default: false,
 	})
@@ -71,6 +90,7 @@ export default function permissionsExtension(pi: ExtensionAPI): void {
 	let cliMode: PermissionMode | undefined
 	let originalActiveTools: string[] | null = null
 	let planModeApplied = false
+	let yoloWarningShown = false
 
 	function rebuildConfigRules(): void {
 		configRules = [
@@ -83,6 +103,11 @@ export default function permissionsExtension(pi: ExtensionAPI): void {
 		]
 	}
 
+	/** Propagate permission mode to spawned subagents. */
+	function propagateModeToEnv(): void {
+		process.env.KIMCHI_PERMISSIONS = currentMode()
+	}
+
 	function currentMode(): PermissionMode {
 		return resolveMode({
 			runtime: runtimeMode,
@@ -90,11 +115,6 @@ export default function permissionsExtension(pi: ExtensionAPI): void {
 			env: envBaseline,
 			config: loaded.config.defaultMode,
 		}).mode
-	}
-
-	// Spawned subagents inherit the mode via process.env.
-	function propagateModeToEnv(): void {
-		process.env.KIMCHI_PERMISSIONS = currentMode()
 	}
 
 	function allRules(): Rule[] {
@@ -153,6 +173,13 @@ export default function permissionsExtension(pi: ExtensionAPI): void {
 		if (next === "plan") applyPlanModeTools()
 		propagateModeToEnv()
 		updateStatus(ctx)
+		// Show danger warning when switching to yolo mode (only once per session)
+		if (next === "yolo" && ctx.hasUI && !yoloWarningShown) {
+			yoloWarningShown = true
+			const dangerMsg =
+				"DANGER: Running in YOLO mode. All permission checks are disabled. The agent will execute commands without confirmation. This can modify or delete files. Intended for use in disposable or sandboxed environments only. Not recommended for production use."
+			ctx.ui.notify(ctx.ui.theme.fg("error", dangerMsg), "warning")
+		}
 	}
 
 	function doLoadConfig(ctx: ExtensionContext): { errors: string[] } {
@@ -181,10 +208,20 @@ export default function permissionsExtension(pi: ExtensionAPI): void {
 
 		if (pi.getFlag("plan")) cliMode = "plan"
 		else if (pi.getFlag("auto")) cliMode = "auto"
+		// YOLO mode: --yolo and --dangerously-skip-permissions both set yolo mode (no classifier, auto-approve all)
+		else if (pi.getFlag("yolo") || pi.getFlag("dangerously-skip-permissions")) cliMode = "yolo"
 
 		if (currentMode() === "plan") applyPlanModeTools()
 		propagateModeToEnv()
 		updateStatus(ctx)
+
+		// Show danger warning when starting in yolo mode (only once per session)
+		if (currentMode() === "yolo" && ctx.hasUI && !yoloWarningShown) {
+			yoloWarningShown = true
+			const dangerMsg =
+				"DANGER: Running in YOLO mode. All permission checks are disabled. The agent will execute commands without confirmation. This can modify or delete files. Intended for use in disposable or sandboxed environments only. Not recommended for production use."
+			ctx.ui.notify(ctx.ui.theme.fg("error", dangerMsg), "warning")
+		}
 	})
 
 	pi.on("before_agent_start", async (event): Promise<{ systemPrompt?: string }> => {
@@ -196,6 +233,11 @@ export default function permissionsExtension(pi: ExtensionAPI): void {
 		const mode = currentMode()
 		const toolName = event.toolName.toLowerCase()
 		const input = event.input as Record<string, unknown>
+
+		// YOLO mode: bypass ALL permission checks including rules, denylist, and classifier
+		if (mode === "yolo") {
+			return undefined
+		}
 
 		if (mode === "plan") {
 			if (toolName === "bash") {

--- a/src/extensions/permissions/mode.test.ts
+++ b/src/extensions/permissions/mode.test.ts
@@ -6,6 +6,13 @@ describe("parseModeString", () => {
 		expect(parseModeString("default")).toBe("default")
 		expect(parseModeString("plan")).toBe("plan")
 		expect(parseModeString("auto")).toBe("auto")
+		expect(parseModeString("yolo")).toBe("yolo")
+	})
+
+	it("yolo mode is recognized", () => {
+		expect(parseModeString("yolo")).toBe("yolo")
+		expect(parseModeString("YOLO")).toBe("yolo")
+		expect(parseModeString("Yolo")).toBe("yolo")
 	})
 
 	it("is case-insensitive", () => {
@@ -14,7 +21,7 @@ describe("parseModeString", () => {
 	})
 
 	it("returns undefined for unknown/empty", () => {
-		expect(parseModeString("yolo")).toBeUndefined()
+		expect(parseModeString("unknown")).toBeUndefined()
 		expect(parseModeString(undefined)).toBeUndefined()
 		expect(parseModeString("")).toBeUndefined()
 	})

--- a/src/extensions/permissions/mode.ts
+++ b/src/extensions/permissions/mode.ts
@@ -19,7 +19,7 @@ export interface ModeResolutionInput {
 export function parseModeString(s: string | undefined): PermissionMode | undefined {
 	if (!s) return undefined
 	const lower = s.toLowerCase()
-	if (lower === "default" || lower === "plan" || lower === "auto") return lower
+	if (lower === "default" || lower === "plan" || lower === "auto" || lower === "yolo") return lower
 	return undefined
 }
 

--- a/src/extensions/permissions/types.ts
+++ b/src/extensions/permissions/types.ts
@@ -1,4 +1,4 @@
-export type PermissionMode = "default" | "plan" | "auto"
+export type PermissionMode = "default" | "plan" | "auto" | "yolo"
 
 export type RuleBehavior = "allow" | "deny"
 


### PR DESCRIPTION
<img width="1011" height="638" alt="Screenshot 2026-04-27 at 16 19 18" src="https://github.com/user-attachments/assets/dda9a3f1-cb37-452c-be52-381c517e80d2" />


Add new YOLO permission mode that bypasses all permission checks:

- `--yolo` flag sets mode to "yolo"
- `--dangerously-skip-permissions` alias for `--yolo`
- YOLO mode skips classifier, rules, and denylist
- Subagents inherit permission mode via `KIMCHI_PERMISSIONS` env var
- Added "yolo" to /permissions mode command selector
- Updated mode tests to include new yolo mode
- Left the `auto` mode as it was
- We can now also do `kimchi-code --plan/--auto/--default/--yolo` to start harness in a specific mode