### PR TITLE
LLM-1402: add --yolo and --dangerously-skip-permissions flags to benchmar…

### DIFF
--- a/benchmark/terminal-bench-2/src/kimchi_agent/agent.py
+++ b/benchmark/terminal-bench-2/src/kimchi_agent/agent.py
@@ -55,6 +55,8 @@ class KimchiCode(BaseInstalledAgent):
             choices=["off", "minimal", "low", "medium", "high", "xhigh"],
         ),
         CliFlag("tools", cli="--tools", type="str"),
+        CliFlag("yolo", cli="--yolo", type="bool"),
+        CliFlag("dangerously-skip-permissions", cli="--dangerously-skip-permissions", type="bool"),
     ]
 
     def __init__(self, *args, **kwargs):


### PR DESCRIPTION
…k agent

---
### Kimchi Summary
### What changed
Adds `--yolo` and `--dangerously-skip-permissions` boolean CLI flags to the `KimchiCode` agent configuration in the terminal benchmark suite.

### Key changes
- `benchmark/terminal-bench-2/src/kimchi_agent/agent.py`: Appended `CliFlag("yolo")` and `CliFlag("dangerously-skip-permissions")` entries to the agent flags list.

### Impact
These flags enable permissive execution modes that bypass standard safety checks, with `--dangerously-skip-permissions` explicitly indicating potential security risks when enabled. Use only in isolated benchmark environments.