### PR TITLE
NOJIRA: Make "exit" prompt and /exit command quit the harness

### DIFF
--- a/src/extensions/exit-utils.ts
+++ b/src/extensions/exit-utils.ts
@@ -1,0 +1,22 @@
+/**
+ * Check if input is the bare "exit" alias (without leading slash).
+ * When true, the input handler will immediately exit the process.
+ */
+export function isBareExitAlias(text: string): boolean {
+	const trimmed = text.trim()
+	return trimmed === "exit"
+}
+
+/**
+ * Quit the application immediately.
+ * Centralized exit point for consistent behavior across all exit paths.
+ *
+ * Note: Immediate exit is safe here because:
+ * 1. This is only called when the user explicitly types "exit" at the input prompt
+ * 2. The agent is idle (no in-flight LLM calls or streaming responses)
+ * 3. Synchronous cleanup via process.on("exit") handlers still runs
+ * 4. Matches user expectation of immediate termination (like shell exit)
+ */
+export function quitApplication(): never {
+	process.exit(0)
+}

--- a/src/extensions/ui.test.ts
+++ b/src/extensions/ui.test.ts
@@ -1,0 +1,78 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
+
+// Extract the function for testing
+function shouldTransformToQuit(text: string): boolean {
+	const trimmed = text.trim()
+	return trimmed === "exit"
+}
+
+describe("shouldTransformToQuit", () => {
+	it("returns true for exact 'exit' input", () => {
+		expect(shouldTransformToQuit("exit")).toBe(true)
+	})
+
+	it("returns true for 'exit' with leading/trailing whitespace", () => {
+		expect(shouldTransformToQuit("  exit  ")).toBe(true)
+		expect(shouldTransformToQuit("\texit\n")).toBe(true)
+		expect(shouldTransformToQuit("  exit")).toBe(true)
+		expect(shouldTransformToQuit("exit  ")).toBe(true)
+	})
+
+	it("returns false for '/exit' command", () => {
+		expect(shouldTransformToQuit("/exit")).toBe(false)
+	})
+
+	it("returns false for 'EXIT' (case sensitive)", () => {
+		expect(shouldTransformToQuit("EXIT")).toBe(false)
+		expect(shouldTransformToQuit("Exit")).toBe(false)
+	})
+
+	it("returns false for empty input", () => {
+		expect(shouldTransformToQuit("")).toBe(false)
+		expect(shouldTransformToQuit("   ")).toBe(false)
+	})
+
+	it("returns false for other text", () => {
+		expect(shouldTransformToQuit("hello")).toBe(false)
+		expect(shouldTransformToQuit("exit now")).toBe(false)
+		expect(shouldTransformToQuit("please exit")).toBe(false)
+		expect(shouldTransformToQuit("quit")).toBe(false)
+	})
+})
+
+describe("exit command behavior", () => {
+	let exitSpy: ReturnType<typeof vi.spyOn>
+
+	beforeEach(() => {
+		exitSpy = vi.spyOn(process, "exit").mockImplementation(() => undefined as never)
+	})
+
+	afterEach(() => {
+		exitSpy.mockRestore()
+	})
+
+	it("calls process.exit(0) when 'exit' is typed", () => {
+		// Simulate what the input handler does
+		if (shouldTransformToQuit("exit")) {
+			process.exit(0)
+		}
+
+		expect(exitSpy).toHaveBeenCalledWith(0)
+	})
+
+	it("does not call process.exit for non-exit input", () => {
+		if (shouldTransformToQuit("hello")) {
+			process.exit(0)
+		}
+
+		expect(exitSpy).not.toHaveBeenCalled()
+	})
+
+	it("does not call process.exit for '/exit' command", () => {
+		if (shouldTransformToQuit("/exit")) {
+			process.exit(0)
+		}
+
+		expect(exitSpy).not.toHaveBeenCalled()
+	})
+})

--- a/src/extensions/ui.test.ts
+++ b/src/extensions/ui.test.ts
@@ -1,9 +1,13 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
 
-// Extract the function for testing
+// Extract the functions for testing
 function isBareExitAlias(text: string): boolean {
 	const trimmed = text.trim()
 	return trimmed === "exit"
+}
+
+function quitApplication(): never {
+	process.exit(0)
 }
 
 describe("isBareExitAlias", () => {
@@ -54,7 +58,7 @@ describe("exit command behavior", () => {
 	it("calls process.exit(0) when 'exit' is typed", () => {
 		// Simulate what the input handler does
 		if (isBareExitAlias("exit")) {
-			process.exit(0)
+			quitApplication()
 		}
 
 		expect(exitSpy).toHaveBeenCalledWith(0)
@@ -62,7 +66,7 @@ describe("exit command behavior", () => {
 
 	it("does not call process.exit for non-exit input", () => {
 		if (isBareExitAlias("hello")) {
-			process.exit(0)
+			quitApplication()
 		}
 
 		expect(exitSpy).not.toHaveBeenCalled()
@@ -70,9 +74,16 @@ describe("exit command behavior", () => {
 
 	it("does not call process.exit for '/exit' command", () => {
 		if (isBareExitAlias("/exit")) {
-			process.exit(0)
+			quitApplication()
 		}
 
 		expect(exitSpy).not.toHaveBeenCalled()
+	})
+
+	it("calls process.exit(0) via quitApplication for /exit command", async () => {
+		// Simulate what the command handler does
+		quitApplication()
+
+		expect(exitSpy).toHaveBeenCalledWith(0)
 	})
 })

--- a/src/extensions/ui.test.ts
+++ b/src/extensions/ui.test.ts
@@ -1,14 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
-
-// Extract the functions for testing
-function isBareExitAlias(text: string): boolean {
-	const trimmed = text.trim()
-	return trimmed === "exit"
-}
-
-function quitApplication(): never {
-	process.exit(0)
-}
+import { isBareExitAlias, quitApplication } from "./exit-utils.js"
 
 describe("isBareExitAlias", () => {
 	it("returns true for exact 'exit' input", () => {

--- a/src/extensions/ui.test.ts
+++ b/src/extensions/ui.test.ts
@@ -36,7 +36,8 @@ describe("isBareExitAlias", () => {
 })
 
 describe("exit command behavior", () => {
-	let exitSpy: ReturnType<typeof vi.spyOn>
+	// biome-ignore lint/suspicious/noExplicitAny: vi.spyOn types differ between vitest versions
+	let exitSpy: any
 
 	beforeEach(() => {
 		exitSpy = vi.spyOn(process, "exit").mockImplementation(() => undefined as never)

--- a/src/extensions/ui.test.ts
+++ b/src/extensions/ui.test.ts
@@ -1,42 +1,42 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
 
 // Extract the function for testing
-function shouldTransformToQuit(text: string): boolean {
+function isBareExitAlias(text: string): boolean {
 	const trimmed = text.trim()
 	return trimmed === "exit"
 }
 
-describe("shouldTransformToQuit", () => {
+describe("isBareExitAlias", () => {
 	it("returns true for exact 'exit' input", () => {
-		expect(shouldTransformToQuit("exit")).toBe(true)
+		expect(isBareExitAlias("exit")).toBe(true)
 	})
 
 	it("returns true for 'exit' with leading/trailing whitespace", () => {
-		expect(shouldTransformToQuit("  exit  ")).toBe(true)
-		expect(shouldTransformToQuit("\texit\n")).toBe(true)
-		expect(shouldTransformToQuit("  exit")).toBe(true)
-		expect(shouldTransformToQuit("exit  ")).toBe(true)
+		expect(isBareExitAlias("  exit  ")).toBe(true)
+		expect(isBareExitAlias("\texit\n")).toBe(true)
+		expect(isBareExitAlias("  exit")).toBe(true)
+		expect(isBareExitAlias("exit  ")).toBe(true)
 	})
 
 	it("returns false for '/exit' command", () => {
-		expect(shouldTransformToQuit("/exit")).toBe(false)
+		expect(isBareExitAlias("/exit")).toBe(false)
 	})
 
 	it("returns false for 'EXIT' (case sensitive)", () => {
-		expect(shouldTransformToQuit("EXIT")).toBe(false)
-		expect(shouldTransformToQuit("Exit")).toBe(false)
+		expect(isBareExitAlias("EXIT")).toBe(false)
+		expect(isBareExitAlias("Exit")).toBe(false)
 	})
 
 	it("returns false for empty input", () => {
-		expect(shouldTransformToQuit("")).toBe(false)
-		expect(shouldTransformToQuit("   ")).toBe(false)
+		expect(isBareExitAlias("")).toBe(false)
+		expect(isBareExitAlias("   ")).toBe(false)
 	})
 
 	it("returns false for other text", () => {
-		expect(shouldTransformToQuit("hello")).toBe(false)
-		expect(shouldTransformToQuit("exit now")).toBe(false)
-		expect(shouldTransformToQuit("please exit")).toBe(false)
-		expect(shouldTransformToQuit("quit")).toBe(false)
+		expect(isBareExitAlias("hello")).toBe(false)
+		expect(isBareExitAlias("exit now")).toBe(false)
+		expect(isBareExitAlias("please exit")).toBe(false)
+		expect(isBareExitAlias("quit")).toBe(false)
 	})
 })
 
@@ -53,7 +53,7 @@ describe("exit command behavior", () => {
 
 	it("calls process.exit(0) when 'exit' is typed", () => {
 		// Simulate what the input handler does
-		if (shouldTransformToQuit("exit")) {
+		if (isBareExitAlias("exit")) {
 			process.exit(0)
 		}
 
@@ -61,7 +61,7 @@ describe("exit command behavior", () => {
 	})
 
 	it("does not call process.exit for non-exit input", () => {
-		if (shouldTransformToQuit("hello")) {
+		if (isBareExitAlias("hello")) {
 			process.exit(0)
 		}
 
@@ -69,7 +69,7 @@ describe("exit command behavior", () => {
 	})
 
 	it("does not call process.exit for '/exit' command", () => {
-		if (shouldTransformToQuit("/exit")) {
+		if (isBareExitAlias("/exit")) {
 			process.exit(0)
 		}
 

--- a/src/extensions/ui.ts
+++ b/src/extensions/ui.ts
@@ -6,6 +6,15 @@ import { LogoHeader } from "../components/logo.js"
 import { SplashHeader } from "../components/splash-header.js"
 import { collapseAll, expandNext, resetState } from "../expand-state.js"
 
+/**
+ * Check if input is the exit alias and should be transformed to /quit
+ */
+function shouldTransformToQuit(text: string): boolean {
+	const trimmed = text.trim()
+	// Transform plain "exit" (without leading slash) to /exit
+	return trimmed === "exit"
+}
+
 const HORIZONTAL_PADDING = 2
 
 // Strip OSC 133 shell-integration marks emitted by pi-mono around each message.
@@ -54,10 +63,23 @@ export default function uiExtension(pi: ExtensionAPI) {
 		})
 	})
 
-	pi.on("input", (_event, ctx) => {
+	pi.on("input", (event, ctx) => {
+		// Handle exit aliases: immediately quit when user types "exit"
+		if (shouldTransformToQuit(event.text)) {
+			process.exit(0)
+		}
+
 		if (!splashActive) return
 		splashActive = false
 		ctx.ui.setHeader((_tui, theme) => new LogoHeader(theme))
 		currentEditor?.setSplashMode(false)
+	})
+
+	// Register /exit as an alias for /quit
+	pi.registerCommand("exit", {
+		description: "Exit the application (alias for /quit)",
+		handler: async () => {
+			process.exit(0)
+		},
 	})
 }

--- a/src/extensions/ui.ts
+++ b/src/extensions/ui.ts
@@ -7,11 +7,11 @@ import { SplashHeader } from "../components/splash-header.js"
 import { collapseAll, expandNext, resetState } from "../expand-state.js"
 
 /**
- * Check if input is the exit alias and should be transformed to /quit
+ * Check if input is the bare "exit" alias (without leading slash).
+ * When true, the input handler will immediately exit the process.
  */
-function shouldTransformToQuit(text: string): boolean {
+function isBareExitAlias(text: string): boolean {
 	const trimmed = text.trim()
-	// Transform plain "exit" (without leading slash) to /exit
 	return trimmed === "exit"
 }
 
@@ -64,8 +64,8 @@ export default function uiExtension(pi: ExtensionAPI) {
 	})
 
 	pi.on("input", (event, ctx) => {
-		// Handle exit aliases: immediately quit when user types "exit"
-		if (shouldTransformToQuit(event.text)) {
+		// Handle bare "exit" alias: immediately quit without sending to model
+		if (isBareExitAlias(event.text)) {
 			process.exit(0)
 		}
 

--- a/src/extensions/ui.ts
+++ b/src/extensions/ui.ts
@@ -18,6 +18,12 @@ function isBareExitAlias(text: string): boolean {
 /**
  * Quit the application immediately.
  * Centralized exit point for consistent behavior across all exit paths.
+ *
+ * Note: Immediate exit is safe here because:
+ * 1. This is only called when the user explicitly types "exit" at the input prompt
+ * 2. The agent is idle (no in-flight LLM calls or streaming responses)
+ * 3. Synchronous cleanup via process.on("exit") handlers still runs
+ * 4. Matches user expectation of immediate termination (like shell exit)
  */
 function quitApplication(): never {
 	process.exit(0)

--- a/src/extensions/ui.ts
+++ b/src/extensions/ui.ts
@@ -15,6 +15,14 @@ function isBareExitAlias(text: string): boolean {
 	return trimmed === "exit"
 }
 
+/**
+ * Quit the application immediately.
+ * Centralized exit point for consistent behavior across all exit paths.
+ */
+function quitApplication(): never {
+	process.exit(0)
+}
+
 const HORIZONTAL_PADDING = 2
 
 // Strip OSC 133 shell-integration marks emitted by pi-mono around each message.
@@ -66,7 +74,7 @@ export default function uiExtension(pi: ExtensionAPI) {
 	pi.on("input", (event, ctx) => {
 		// Handle bare "exit" alias: immediately quit without sending to model
 		if (isBareExitAlias(event.text)) {
-			process.exit(0)
+			quitApplication()
 		}
 
 		if (!splashActive) return
@@ -79,7 +87,7 @@ export default function uiExtension(pi: ExtensionAPI) {
 	pi.registerCommand("exit", {
 		description: "Exit the application (alias for /quit)",
 		handler: async () => {
-			process.exit(0)
+			quitApplication()
 		},
 	})
 }

--- a/src/extensions/ui.ts
+++ b/src/extensions/ui.ts
@@ -5,29 +5,7 @@ import { StatsFooter } from "../components/footer.js"
 import { LogoHeader } from "../components/logo.js"
 import { SplashHeader } from "../components/splash-header.js"
 import { collapseAll, expandNext, resetState } from "../expand-state.js"
-
-/**
- * Check if input is the bare "exit" alias (without leading slash).
- * When true, the input handler will immediately exit the process.
- */
-function isBareExitAlias(text: string): boolean {
-	const trimmed = text.trim()
-	return trimmed === "exit"
-}
-
-/**
- * Quit the application immediately.
- * Centralized exit point for consistent behavior across all exit paths.
- *
- * Note: Immediate exit is safe here because:
- * 1. This is only called when the user explicitly types "exit" at the input prompt
- * 2. The agent is idle (no in-flight LLM calls or streaming responses)
- * 3. Synchronous cleanup via process.on("exit") handlers still runs
- * 4. Matches user expectation of immediate termination (like shell exit)
- */
-function quitApplication(): never {
-	process.exit(0)
-}
+import { isBareExitAlias, quitApplication } from "./exit-utils.js"
 
 const HORIZONTAL_PADDING = 2
 


### PR DESCRIPTION


---
### Kimchi Summary
### What changed
Adds support for exiting the application via bare `exit` input or `/exit` command. Typing `exit` at the input prompt (without a leading slash) now terminates the process immediately without sending the text to the LLM, matching shell-like behavior.

### Key changes
- Added `src/extensions/exit-utils.ts` with `isBareExitAlias()` to detect bare "exit" input (whitespace-trimmed, no leading slash) and `quitApplication()` to call `process.exit(0)`
- Modified `src/extensions/ui.ts` input handler to check for bare `exit` alias via `isBareExitAlias()` and quit immediately before sending to the model
- Registered `/exit` command in `src/extensions/ui.ts` as an alias for `/quit` using the same `quitApplication()` handler
- Added `src/extensions/ui.test.ts` with unit tests for exit detection logic (whitespace handling, case sensitivity, `/exit` exclusion) and exit behavior

### Impact
Immediate exit is safe because it only triggers when the agent is idle (no in-flight LLM calls). Synchronous cleanup via `process.on("exit")` handlers still executes. No breaking changes or migration steps required.