### PR TITLE
LLM-1396: drop --mode json from terminal bench, fix token usage parsing

### DIFF
--- a/benchmark/terminal-bench-2/src/kimchi_agent/agent.py
+++ b/benchmark/terminal-bench-2/src/kimchi_agent/agent.py
@@ -10,7 +10,7 @@ from harbor.agents.installed.base import (
 from pydantic import ValidationError
 
 from kimchi_agent.config import KimchiAgentConfig
-from kimchi_agent.messages import MessageEndEvent
+from kimchi_agent.messages import SessionEntry
 from kimchi_agent.release import BINARY_RELPATH, SHARE_RELPATH, GitHubClient
 
 if TYPE_CHECKING:
@@ -45,7 +45,6 @@ class KimchiCode(BaseInstalledAgent):
     no provider-specific keys are needed.
     """
 
-    _OUTPUT_FILENAME = "kimchi.txt"
 
     CLI_FLAGS: ClassVar[list[CliFlag]] = [
         CliFlag(
@@ -170,10 +169,9 @@ class KimchiCode(BaseInstalledAgent):
                 f"mkdir -p {CONTAINER_SESSIONS_DIR} && "
                 f"printf '%s' {shlex.quote(instruction)} | "
                 f"{shlex.quote(BINARY_PATH)} "
-                f"--print --mode json --session {CONTAINER_MAIN_SESSION} "
+                f"--print --session {CONTAINER_MAIN_SESSION} "
                 f"--model {shlex.quote(self.model_name)} "
                 f"{cli_flags}"
-                f"2>&1 | stdbuf -oL tee {CONTAINER_LOGS_DIR}/{self._OUTPUT_FILENAME}"
             ),
             env={"KIMCHI_API_KEY": self._config.api_key, "PI_PACKAGE_DIR": PI_PACKAGE_DIR},
         )
@@ -215,8 +213,8 @@ class KimchiCode(BaseInstalledAgent):
         return ",".join(merged)
 
     def populate_context_post_run(self, context: AgentContext) -> None:
-        output_file = self.logs_dir / self._OUTPUT_FILENAME
-        if not output_file.exists():
+        session_file = self.logs_dir / "sessions" / "main.jsonl"
+        if not session_file.exists():
             return
 
         total_input_tokens = 0
@@ -224,17 +222,17 @@ class KimchiCode(BaseInstalledAgent):
         total_cache_read_tokens = 0
         total_cost = 0.0
 
-        for line in output_file.read_text().splitlines():
+        for line in session_file.read_text().splitlines():
             line = line.strip()
             if not line:
                 continue
             try:
-                event = MessageEndEvent.model_validate_json(line)
+                entry = SessionEntry.model_validate_json(line)
             except ValidationError:
                 continue
-            if event.type != "message_end" or event.message.role != "assistant":
+            if entry.type != "message" or entry.message.role != "assistant":
                 continue
-            usage = event.message.usage
+            usage = entry.message.usage
             total_input_tokens += usage.input
             total_output_tokens += usage.output
             total_cache_read_tokens += usage.cache_read

--- a/benchmark/terminal-bench-2/src/kimchi_agent/agent.py
+++ b/benchmark/terminal-bench-2/src/kimchi_agent/agent.py
@@ -45,7 +45,6 @@ class KimchiCode(BaseInstalledAgent):
     no provider-specific keys are needed.
     """
 
-
     CLI_FLAGS: ClassVar[list[CliFlag]] = [
         CliFlag(
             "thinking",
@@ -55,7 +54,12 @@ class KimchiCode(BaseInstalledAgent):
         ),
         CliFlag("tools", cli="--tools", type="str"),
         CliFlag("yolo", cli="--yolo", type="bool"),
-        CliFlag("dangerously-skip-permissions", cli="--dangerously-skip-permissions", type="bool"),
+        CliFlag(
+            "dangerously-skip-permissions",
+            cli="--dangerously-skip-permissions",
+            type="bool",
+            default=True,
+        ),
     ]
 
     def __init__(self, *args, **kwargs):

--- a/benchmark/terminal-bench-2/src/kimchi_agent/agent.py
+++ b/benchmark/terminal-bench-2/src/kimchi_agent/agent.py
@@ -213,8 +213,8 @@ class KimchiCode(BaseInstalledAgent):
         return ",".join(merged)
 
     def populate_context_post_run(self, context: AgentContext) -> None:
-        session_file = self.logs_dir / "sessions" / "main.jsonl"
-        if not session_file.exists():
+        sessions_dir = self.logs_dir / "sessions"
+        if not sessions_dir.is_dir():
             return
 
         total_input_tokens = 0
@@ -222,21 +222,25 @@ class KimchiCode(BaseInstalledAgent):
         total_cache_read_tokens = 0
         total_cost = 0.0
 
-        for line in session_file.read_text().splitlines():
-            line = line.strip()
-            if not line:
-                continue
-            try:
-                entry = SessionEntry.model_validate_json(line)
-            except ValidationError:
-                continue
-            if entry.type != "message" or entry.message.role != "assistant":
-                continue
-            usage = entry.message.usage
-            total_input_tokens += usage.input
-            total_output_tokens += usage.output
-            total_cache_read_tokens += usage.cache_read
-            total_cost += usage.cost.total
+        # Aggregate main.jsonl + subagent <timestamp>_<uuid>.jsonl siblings (see
+        # src/extensions/subagent.ts:prepareChildSessionFile). Subagent runs are
+        # separate sessions, so their usage isn't reflected in main.jsonl.
+        for session_file in sorted(sessions_dir.glob("*.jsonl")):
+            for line in session_file.read_text().splitlines():
+                line = line.strip()
+                if not line:
+                    continue
+                try:
+                    entry = SessionEntry.model_validate_json(line)
+                except ValidationError:
+                    continue
+                if entry.type != "message" or entry.message.role != "assistant":
+                    continue
+                usage = entry.message.usage
+                total_input_tokens += usage.input
+                total_output_tokens += usage.output
+                total_cache_read_tokens += usage.cache_read
+                total_cost += usage.cost.total
 
         context.n_input_tokens = total_input_tokens + total_cache_read_tokens
         context.n_output_tokens = total_output_tokens

--- a/benchmark/terminal-bench-2/src/kimchi_agent/agent.py
+++ b/benchmark/terminal-bench-2/src/kimchi_agent/agent.py
@@ -220,6 +220,7 @@ class KimchiCode(BaseInstalledAgent):
         total_input_tokens = 0
         total_output_tokens = 0
         total_cache_read_tokens = 0
+        total_cache_write_tokens = 0
         total_cost = 0.0
 
         # Aggregate main.jsonl + subagent <timestamp>_<uuid>.jsonl siblings (see
@@ -240,9 +241,13 @@ class KimchiCode(BaseInstalledAgent):
                 total_input_tokens += usage.input
                 total_output_tokens += usage.output
                 total_cache_read_tokens += usage.cache_read
+                total_cache_write_tokens += usage.cache_write
                 total_cost += usage.cost.total
 
-        context.n_input_tokens = total_input_tokens + total_cache_read_tokens
+        # pi-ai treats input, cacheRead, cacheWrite as disjoint summing to totalTokens
+        # (see node_modules/.../pi-ai/dist/providers/anthropic.js). Sum all three for
+        # the wire-level prompt total.
+        context.n_input_tokens = total_input_tokens + total_cache_read_tokens + total_cache_write_tokens
         context.n_output_tokens = total_output_tokens
         context.n_cache_tokens = total_cache_read_tokens
         context.cost_usd = total_cost if total_cost > 0 else None

--- a/benchmark/terminal-bench-2/src/kimchi_agent/messages.py
+++ b/benchmark/terminal-bench-2/src/kimchi_agent/messages.py
@@ -22,6 +22,6 @@ class Message(BaseMessage):
     usage: Usage = Field(default_factory=Usage)
 
 
-class MessageEndEvent(BaseMessage):
+class SessionEntry(BaseMessage):
     type: str
     message: Message = Field(default_factory=Message)


### PR DESCRIPTION
The `--mode json` flag caused pi-mono's agent loop to emit every streaming token as a `message_update` event and every tool output chunk as a `tool_execution_update` event with the full accumulated result. Drop `--mode json` and the tee capture. Read token usage from the session file instead, which is compact and already contains usage data on every assistant message.

---
### Kimchi Summary
### What changed
Updates the benchmark agent to parse native JSONL session files instead of tee'd text output, aggregates token usage across main and subagent sessions, and fixes cache write token accounting. Also changes the default for `--dangerously-skip-permissions` to `True` in benchmark contexts.

### Why
Resolves log processing failures caused by the kimchi binary switching to structured JSONL session logs (fixes "jsonl-logs-bloat" issue LLM-1396). Previously, the agent relied on intercepting stdout via `tee` to a text file, which became unreliable with the JSONL format and excluded subagent session data written to separate files.

### Key changes
- `benchmark/terminal-bench-2/src/kimchi_agent/messages.py`: Renames `MessageEndEvent` to `SessionEntry` to reflect generic JSONL session row structure.
- `benchmark/terminal-bench-2/src/kimchi_agent/agent.py`:
  - Removes `_OUTPUT_FILENAME` constant and `tee` pipe from container command, switching log source from `kimchi.txt` to `sessions/*.jsonl`.
  - Updates `populate_context_post_run()` to iterate over all `*.jsonl` files in the sessions directory, aggregating usage from both `main.jsonl` and subagent timestamped sessions.
  - Adds `total_cache_write_tokens` accumulation and includes it in `context.n_input_tokens` calculation for accurate wire-level prompt totals.
  - Changes `dangerously-skip-permissions` CLI flag default to `True`.

### Impact
- **Breaking**: Benchmark agents now require kimchi binaries that write to `logs/sessions/*.jsonl` rather than the legacy tee-based `kimchi.txt` format.
- **Behavioral**: Token counts will increase to include cache write tokens, and subagent usage is now reflected in totals.
- **Permissions**: Benchmark runs now skip permission prompts by default.