### PR TITLE
NOJIRA: Reduce empty turn nudge frequency

### DIFF
--- a/src/extensions/orchestration/continuation-nudge.test.ts
+++ b/src/extensions/orchestration/continuation-nudge.test.ts
@@ -1,13 +1,6 @@
-import type { AssistantMessage, ToolResultMessage, UserMessage } from "@mariozechner/pi-ai"
+import type { AssistantMessage, UserMessage } from "@mariozechner/pi-ai"
 import { describe, expect, it } from "vitest"
-import {
-	ContinuationNudge,
-	EMPTY_TURN_NUDGE_TEXT,
-	EmptyTurnNudge,
-	type OrchestratorMessages,
-	buildEmptyTurnNudgedMessages,
-	stripStaleNudges,
-} from "./continuation-nudge.js"
+import { ContinuationNudge, type OrchestratorMessages, stripStaleNudges } from "./continuation-nudge.js"
 
 function makeAssistant(content: AssistantMessage["content"]): AssistantMessage {
 	return {
@@ -133,17 +126,6 @@ function makeUser(text: string): UserMessage {
 	return { role: "user", content: [{ type: "text", text }], timestamp: Date.now() }
 }
 
-function makeToolResult(toolCallId: string, text: string): ToolResultMessage {
-	return {
-		role: "toolResult",
-		toolCallId,
-		toolName: "subagent",
-		content: [{ type: "text", text }],
-		isError: false,
-		timestamp: Date.now(),
-	}
-}
-
 function makeNudge(): OrchestratorMessages[number] {
 	return {
 		role: "custom" as const,
@@ -152,10 +134,6 @@ function makeNudge(): OrchestratorMessages[number] {
 		display: false,
 		timestamp: Date.now(),
 	}
-}
-
-function lastMessage(messages: OrchestratorMessages): OrchestratorMessages[number] {
-	return messages[messages.length - 1]
 }
 
 describe("stripStaleNudges", () => {
@@ -198,109 +176,5 @@ describe("stripStaleNudges", () => {
 		const messages: OrchestratorMessages = [makeUser("q"), other, textOnlyMessage]
 		const result = stripStaleNudges(messages)
 		expect(result).toContainEqual(other)
-	})
-})
-
-describe("buildEmptyTurnNudgedMessages", () => {
-	it("returns undefined when there is no assistant message yet", () => {
-		expect(buildEmptyTurnNudgedMessages([makeUser("start")])).toBeUndefined()
-	})
-
-	it("returns undefined when the last assistant message has text", () => {
-		const messages: OrchestratorMessages = [makeUser("q"), textOnlyMessage]
-		expect(buildEmptyTurnNudgedMessages(messages)).toBeUndefined()
-	})
-
-	it("returns undefined when the last assistant message has both text and a tool call", () => {
-		const messages: OrchestratorMessages = [makeUser("q"), textAndToolCallMessage, makeToolResult("call_2", "ok")]
-		expect(buildEmptyTurnNudgedMessages(messages)).toBeUndefined()
-	})
-
-	it("returns undefined when tool calls are present but no tool results have arrived yet", () => {
-		const messages: OrchestratorMessages = [makeUser("q"), toolCallMessage]
-		expect(buildEmptyTurnNudgedMessages(messages)).toBeUndefined()
-	})
-
-	it("appends a custom-role nudge when tool-call-only assistant is followed by tool results", () => {
-		const messages: OrchestratorMessages = [makeUser("q"), toolCallMessage, makeToolResult("call_1", "done")]
-		const nudged = buildEmptyTurnNudgedMessages(messages)
-		expect(nudged).toBeDefined()
-		expect(nudged?.length).toBe(messages.length + 1)
-		const appended = lastMessage(nudged as OrchestratorMessages)
-		expect(appended.role).toBe("custom")
-	})
-
-	it("does not mutate the caller's messages array", () => {
-		const messages: OrchestratorMessages = [makeUser("q"), toolCallMessage, makeToolResult("call_1", "done")]
-		const originalLength = messages.length
-		buildEmptyTurnNudgedMessages(messages)
-		expect(messages.length).toBe(originalLength)
-	})
-
-	it("uses the most recent assistant message (ignores older ones)", () => {
-		const messages: OrchestratorMessages = [
-			makeUser("q1"),
-			textOnlyMessage,
-			makeUser("q2"),
-			toolCallMessage,
-			makeToolResult("call_1", "done"),
-		]
-		expect(buildEmptyTurnNudgedMessages(messages)).toBeDefined()
-	})
-})
-
-describe("EmptyTurnNudge", () => {
-	const emptyMessage = makeAssistant([])
-	const whitespaceOnlyMessage = makeAssistant([{ type: "text", text: "   \n  " }])
-
-	it("arms after an empty assistant turn", () => {
-		const guard = new EmptyTurnNudge()
-		guard.evaluateTurn(emptyMessage)
-		expect(guard.shouldNudge()).toBe(true)
-	})
-
-	it("does not arm after a turn with text", () => {
-		const guard = new EmptyTurnNudge()
-		guard.evaluateTurn(textOnlyMessage)
-		expect(guard.shouldNudge()).toBe(false)
-	})
-
-	it("does not arm after a turn with tool calls", () => {
-		const guard = new EmptyTurnNudge()
-		guard.evaluateTurn(toolCallMessage)
-		expect(guard.shouldNudge()).toBe(false)
-	})
-
-	it("does not arm after a turn with both text and tool calls", () => {
-		const guard = new EmptyTurnNudge()
-		guard.evaluateTurn(textAndToolCallMessage)
-		expect(guard.shouldNudge()).toBe(false)
-	})
-
-	it("treats whitespace-only text as empty", () => {
-		const guard = new EmptyTurnNudge()
-		guard.evaluateTurn(whitespaceOnlyMessage)
-		expect(guard.shouldNudge()).toBe(true)
-	})
-
-	it("disarms after shouldNudge returns true", () => {
-		const guard = new EmptyTurnNudge()
-		guard.evaluateTurn(emptyMessage)
-		expect(guard.shouldNudge()).toBe(true)
-		expect(guard.shouldNudge()).toBe(false)
-	})
-
-	it("disarms after a non-empty turn follows an empty one", () => {
-		const guard = new EmptyTurnNudge()
-		guard.evaluateTurn(emptyMessage)
-		guard.evaluateTurn(textOnlyMessage)
-		expect(guard.shouldNudge()).toBe(false)
-	})
-
-	it("resets on new user input", () => {
-		const guard = new EmptyTurnNudge()
-		guard.evaluateTurn(emptyMessage)
-		guard.resetForNewUserInput()
-		expect(guard.shouldNudge()).toBe(false)
 	})
 })

--- a/src/extensions/orchestration/continuation-nudge.test.ts
+++ b/src/extensions/orchestration/continuation-nudge.test.ts
@@ -1,6 +1,6 @@
 import type { AssistantMessage, UserMessage } from "@mariozechner/pi-ai"
 import { describe, expect, it } from "vitest"
-import { ContinuationNudge, type OrchestratorMessages, stripStaleNudges } from "./continuation-nudge.js"
+import { ContinuationNudge, EmptyTurnNudge, type OrchestratorMessages, stripStaleNudges } from "./continuation-nudge.js"
 
 function makeAssistant(content: AssistantMessage["content"]): AssistantMessage {
 	return {
@@ -176,5 +176,71 @@ describe("stripStaleNudges", () => {
 		const messages: OrchestratorMessages = [makeUser("q"), other, textOnlyMessage]
 		const result = stripStaleNudges(messages)
 		expect(result).toContainEqual(other)
+	})
+})
+
+describe("EmptyTurnNudge", () => {
+	const emptyMessage = makeAssistant([])
+	const whitespaceOnlyMessage = makeAssistant([{ type: "text", text: "   \n  " }])
+
+	it("nudges when an empty turn follows a tool-call-only turn", () => {
+		const guard = new EmptyTurnNudge()
+		guard.evaluateTurn(toolCallMessage)
+		expect(guard.evaluateTurn(emptyMessage)).toBe(true)
+	})
+
+	it("does not nudge on an empty turn without a preceding tool-call-only turn", () => {
+		const guard = new EmptyTurnNudge()
+		expect(guard.evaluateTurn(emptyMessage)).toBe(false)
+	})
+
+	it("does not nudge on an empty turn after a text-only turn", () => {
+		const guard = new EmptyTurnNudge()
+		guard.evaluateTurn(textOnlyMessage)
+		expect(guard.evaluateTurn(emptyMessage)).toBe(false)
+	})
+
+	it("does not nudge on an empty turn after a text-and-tool-call turn", () => {
+		const guard = new EmptyTurnNudge()
+		guard.evaluateTurn(textAndToolCallMessage)
+		expect(guard.evaluateTurn(emptyMessage)).toBe(false)
+	})
+
+	it("treats whitespace-only text as empty", () => {
+		const guard = new EmptyTurnNudge()
+		guard.evaluateTurn(toolCallMessage)
+		expect(guard.evaluateTurn(whitespaceOnlyMessage)).toBe(true)
+	})
+
+	it("does not nudge on a tool-call turn itself", () => {
+		const guard = new EmptyTurnNudge()
+		expect(guard.evaluateTurn(toolCallMessage)).toBe(false)
+	})
+
+	it("does not nudge on a text-only turn", () => {
+		const guard = new EmptyTurnNudge()
+		expect(guard.evaluateTurn(textOnlyMessage)).toBe(false)
+	})
+
+	it("resets tracking after firing", () => {
+		const guard = new EmptyTurnNudge()
+		guard.evaluateTurn(toolCallMessage)
+		expect(guard.evaluateTurn(emptyMessage)).toBe(true)
+		expect(guard.evaluateTurn(emptyMessage)).toBe(false)
+	})
+
+	it("resets on new user input", () => {
+		const guard = new EmptyTurnNudge()
+		guard.evaluateTurn(toolCallMessage)
+		guard.resetForNewUserInput()
+		expect(guard.evaluateTurn(emptyMessage)).toBe(false)
+	})
+
+	it("re-arms after a new tool-call-only turn", () => {
+		const guard = new EmptyTurnNudge()
+		guard.evaluateTurn(toolCallMessage)
+		expect(guard.evaluateTurn(emptyMessage)).toBe(true)
+		guard.evaluateTurn(toolCallMessage)
+		expect(guard.evaluateTurn(emptyMessage)).toBe(true)
 	})
 })

--- a/src/extensions/orchestration/continuation-nudge.test.ts
+++ b/src/extensions/orchestration/continuation-nudge.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, it } from "vitest"
 import {
 	ContinuationNudge,
 	EMPTY_TURN_NUDGE_TEXT,
+	EmptyTurnNudge,
 	type OrchestratorMessages,
 	buildEmptyTurnNudgedMessages,
 	stripStaleNudges,
@@ -56,75 +57,75 @@ describe("ContinuationNudge.evaluateTurn", () => {
 	it("nudges a text-only first turn after user input", () => {
 		const guard = new ContinuationNudge()
 		guard.resetForNewUserInput()
-		expect(guard.evaluateTurn(textOnlyMessage).shouldNudge).toBe(true)
+		expect(guard.evaluateTurn(textOnlyMessage)).toBe(true)
 	})
 
 	it("does not nudge when the turn contains a tool call", () => {
 		const guard = new ContinuationNudge()
 		guard.resetForNewUserInput()
-		expect(guard.evaluateTurn(toolCallMessage).shouldNudge).toBe(false)
+		expect(guard.evaluateTurn(toolCallMessage)).toBe(false)
 	})
 
 	it("does not nudge when the turn has both text and a tool call", () => {
 		const guard = new ContinuationNudge()
 		guard.resetForNewUserInput()
-		expect(guard.evaluateTurn(textAndToolCallMessage).shouldNudge).toBe(false)
+		expect(guard.evaluateTurn(textAndToolCallMessage)).toBe(false)
 	})
 
 	it("does not nudge when the turn has no text at all", () => {
 		const guard = new ContinuationNudge()
 		guard.resetForNewUserInput()
-		expect(guard.evaluateTurn(makeAssistant([])).shouldNudge).toBe(false)
+		expect(guard.evaluateTurn(makeAssistant([]))).toBe(false)
 	})
 
 	it("treats empty-string text as no text", () => {
 		const guard = new ContinuationNudge()
 		guard.resetForNewUserInput()
-		expect(guard.evaluateTurn(emptyTextMessage).shouldNudge).toBe(false)
+		expect(guard.evaluateTurn(emptyTextMessage)).toBe(false)
 	})
 
 	it("treats whitespace-only text as no text", () => {
 		const guard = new ContinuationNudge()
 		guard.resetForNewUserInput()
-		expect(guard.evaluateTurn(whitespaceTextMessage).shouldNudge).toBe(false)
+		expect(guard.evaluateTurn(whitespaceTextMessage)).toBe(false)
 	})
 
 	it("nudges at most once per user-input cycle", () => {
 		const guard = new ContinuationNudge()
 		guard.resetForNewUserInput()
-		expect(guard.evaluateTurn(textOnlyMessage).shouldNudge).toBe(true)
-		expect(guard.evaluateTurn(textOnlyMessage).shouldNudge).toBe(false)
+		expect(guard.evaluateTurn(textOnlyMessage)).toBe(true)
+		expect(guard.evaluateTurn(textOnlyMessage)).toBe(false)
 	})
 
 	it("does not nudge when any tool has already been called this cycle", () => {
 		const guard = new ContinuationNudge()
 		guard.resetForNewUserInput()
 		guard.recordToolCall()
-		expect(guard.evaluateTurn(textOnlyMessage).shouldNudge).toBe(false)
+		expect(guard.evaluateTurn(textOnlyMessage)).toBe(false)
 	})
 
 	it("re-arms after a new user input", () => {
 		const guard = new ContinuationNudge()
 		guard.resetForNewUserInput()
-		expect(guard.evaluateTurn(textOnlyMessage).shouldNudge).toBe(true)
+		expect(guard.evaluateTurn(textOnlyMessage)).toBe(true)
 		guard.resetForNewUserInput()
-		expect(guard.evaluateTurn(textOnlyMessage).shouldNudge).toBe(true)
+		expect(guard.evaluateTurn(textOnlyMessage)).toBe(true)
 	})
 
 	it("re-arms tool-call tracking on reset", () => {
 		const guard = new ContinuationNudge()
 		guard.resetForNewUserInput()
 		guard.recordToolCall()
-		expect(guard.evaluateTurn(textOnlyMessage).shouldNudge).toBe(false)
+		expect(guard.evaluateTurn(textOnlyMessage)).toBe(false)
 		guard.resetForNewUserInput()
-		expect(guard.evaluateTurn(textOnlyMessage).shouldNudge).toBe(true)
+		expect(guard.evaluateTurn(textOnlyMessage)).toBe(true)
 	})
 
 	it("ignores thinking-only turns (no text, no tool call)", () => {
 		const guard = new ContinuationNudge()
 		guard.resetForNewUserInput()
 		const thinkingOnly = makeAssistant([{ type: "thinking", thinking: "Let me reason..." }])
-		expect(guard.evaluateTurn(thinkingOnly).shouldNudge).toBe(false)
+		expect(guard.evaluateTurn(thinkingOnly)).toBe(false)
 	})
 })
 
@@ -245,5 +246,61 @@ describe("buildEmptyTurnNudgedMessages", () => {
 			makeToolResult("call_1", "done"),
 		]
 		expect(buildEmptyTurnNudgedMessages(messages)).toBeDefined()
+	})
+})
+
+describe("EmptyTurnNudge", () => {
+	const emptyMessage = makeAssistant([])
+	const whitespaceOnlyMessage = makeAssistant([{ type: "text", text: "   \n  " }])
+
+	it("arms after an empty assistant turn", () => {
+		const guard = new EmptyTurnNudge()
+		guard.evaluateTurn(emptyMessage)
+		expect(guard.shouldNudge()).toBe(true)
+	})
+
+	it("does not arm after a turn with text", () => {
+		const guard = new EmptyTurnNudge()
+		guard.evaluateTurn(textOnlyMessage)
+		expect(guard.shouldNudge()).toBe(false)
+	})
+
+	it("does not arm after a turn with tool calls", () => {
+		const guard = new EmptyTurnNudge()
+		guard.evaluateTurn(toolCallMessage)
+		expect(guard.shouldNudge()).toBe(false)
+	})
+
+	it("does not arm after a turn with both text and tool calls", () => {
+		const guard = new EmptyTurnNudge()
+		guard.evaluateTurn(textAndToolCallMessage)
+		expect(guard.shouldNudge()).toBe(false)
+	})
+
+	it("treats whitespace-only text as empty", () => {
+		const guard = new EmptyTurnNudge()
+		guard.evaluateTurn(whitespaceOnlyMessage)
+		expect(guard.shouldNudge()).toBe(true)
+	})
+
+	it("disarms after shouldNudge returns true", () => {
+		const guard = new EmptyTurnNudge()
+		guard.evaluateTurn(emptyMessage)
+		expect(guard.shouldNudge()).toBe(true)
+		expect(guard.shouldNudge()).toBe(false)
+	})
+
+	it("disarms after a non-empty turn follows an empty one", () => {
+		const guard = new EmptyTurnNudge()
+		guard.evaluateTurn(emptyMessage)
+		guard.evaluateTurn(textOnlyMessage)
+		expect(guard.shouldNudge()).toBe(false)
+	})
+
+	it("resets on new user input", () => {
+		const guard = new EmptyTurnNudge()
+		guard.evaluateTurn(emptyMessage)
+		guard.resetForNewUserInput()
+		expect(guard.shouldNudge()).toBe(false)
 	})
 })

--- a/src/extensions/orchestration/continuation-nudge.ts
+++ b/src/extensions/orchestration/continuation-nudge.ts
@@ -2,18 +2,16 @@
  * Two complementary nudges for Kimi K2.x tool-calling quirks that each
  * leave the agent loop in a stuck-looking state. Both target the same failure
  * class (model said one thing, didn't follow through in the next tool-use
- * step) but fire at different points in the turn lifecycle:
+ * step) and are delivered as `followUp` messages from the `turn_end` handler
+ * so the agent loop restarts:
  *
- *   1. Continuation nudge — post-turn. The orchestrator reasons in prose,
- *      announces it will delegate, and ends its turn without emitting the
- *      `subagent` tool call. Delivered as a `followUp` via `pi.sendMessage`
- *      so the agent loop restarts. Mirrors AISI Inspect's `on_continue`.
+ *   1. Continuation nudge — the orchestrator reasons in prose, announces it
+ *      will delegate, and ends its turn without emitting the `subagent` tool
+ *      call. Mirrors AISI Inspect's `on_continue`.
  *
- *   2. Empty-turn nudge — reactive. Some Kimi deployments return an empty
- *      response (no text, no tool calls) after receiving tool results. When
- *      detected on `turn_end`, the nudge is armed and injected into the next
- *      LLM context via the `context` event so it doesn't pollute the session
- *      history.
+ *   2. Empty-turn nudge — some Kimi deployments return an empty response
+ *      (no text, no tool calls) after receiving tool results. Detected
+ *      inline in the `turn_end` handler.
  *
  * Both are delivered as custom messages with `display: false` so they
  * never appear in the conversation. Stale nudges (those the model has
@@ -24,7 +22,6 @@
  * inside the `if (!subagentMode)` guard.
  */
 
-import type { AssistantMessage } from "@mariozechner/pi-ai"
 import type { ContextEvent } from "@mariozechner/pi-coding-agent"
 
 /**
@@ -72,42 +69,6 @@ export class ContinuationNudge {
 	}
 }
 
-/**
- * Reactive state machine for the "empty follow-up" nudge.
- *
- * Some model deployments (notably Kimi K2.x) return an empty response — no text, no tool calls — after receiving tool results from a tool-call-only turn. The agent loop stalls because there is nothing to execute or display. This class detects that failure and arms a one-shot nudge that is injected into the next LLM context to prompt the model to continue.
- *
- * The nudge is reactive: it only fires after an empty response has actually occurred, not preemptively on every tool-result → LLM-call transition. Models that never produce empty responses never see the nudge at all.
- */
-export class EmptyTurnNudge {
-	private armed = false
-
-	evaluateTurn(message: AssistantMessage): void {
-		const hasText = message.content.some((c) => c.type === "text" && c.text.trim().length > 0)
-		const hasToolCalls = message.content.some((c) => c.type === "toolCall")
-		this.armed = !hasText && !hasToolCalls
-	}
-
-	shouldNudge(): boolean {
-		if (!this.armed) return false
-		this.armed = false
-		return true
-	}
-
-	resetForNewUserInput(): void {
-		this.armed = false
-	}
-}
-
-/**
- * Pre-LLM-call nudge for the "tool-call-only assistant, tool results pending"
- * pattern. Returns a new messages array with a custom-role nudge appended if
- * the pattern matches, otherwise `undefined` (signal for the caller to leave
- * the context untouched).
- *
- * Injected via the `context` event so it is transient — visible only to the
- * targeted LLM call, not persisted in the session history.
- */
 export const NUDGE_CUSTOM_TYPE = "nudge"
 
 function isNudgeMessage(m: OrchestratorMessages[number]): boolean {
@@ -124,28 +85,4 @@ export function stripStaleNudges(messages: OrchestratorMessages): OrchestratorMe
 	if (lastAssistantIdx === -1) return messages
 	const stripped = messages.filter((m, i) => i > lastAssistantIdx || !isNudgeMessage(m))
 	return stripped.length === messages.length ? messages : stripped
-}
-
-export function buildEmptyTurnNudgedMessages(messages: OrchestratorMessages): OrchestratorMessages | undefined {
-	const lastAssistant = [...messages].reverse().find((m): m is AssistantMessage => m.role === "assistant")
-	if (!lastAssistant) return undefined
-
-	const hasToolCalls = lastAssistant.content.some((c) => c.type === "toolCall")
-	const hasText = lastAssistant.content.some((c) => c.type === "text")
-	if (!hasToolCalls || hasText) return undefined
-
-	const lastAssistantIndex = messages.lastIndexOf(lastAssistant)
-	const hasToolResultsAfter = messages.slice(lastAssistantIndex + 1).some((m) => m.role === "toolResult")
-	if (!hasToolResultsAfter) return undefined
-
-	return [
-		...messages,
-		{
-			role: "custom" as const,
-			customType: NUDGE_CUSTOM_TYPE,
-			content: [{ type: "text" as const, text: EMPTY_TURN_NUDGE_TEXT }],
-			display: false,
-			timestamp: Date.now(),
-		},
-	]
 }

--- a/src/extensions/orchestration/continuation-nudge.ts
+++ b/src/extensions/orchestration/continuation-nudge.ts
@@ -9,10 +9,10 @@
  *      `subagent` tool call. Delivered as a `followUp` via `pi.sendMessage`
  *      so the agent loop restarts. Mirrors AISI Inspect's `on_continue`.
  *
- *   2. Empty-turn nudge — pre-LLM-call. The model returned a tool-call-only
- *      response (no text) and tool results are ready. Some Kimi deployments
- *      return an empty response on the next call. Injected transiently into
- *      the context via the `context` event so it doesn't pollute the session
+ *   2. Empty-turn nudge — reactive. Some Kimi deployments return an empty
+ *      response (no text, no tool calls) after receiving tool results. When
+ *      detected on `turn_end`, the nudge is armed and injected into the next
+ *      LLM context via the `context` event so it doesn't pollute the session
  *      history.
  *
  * Both are delivered as custom messages with `display: false` so they
@@ -41,10 +41,6 @@ export const CONTINUATION_NUDGE_TEXT =
 export const EMPTY_TURN_NUDGE_TEXT =
 	"If you have finished, please summarize the result for the user. Otherwise, continue with the next tool call."
 
-export interface NudgeDecision {
-	shouldNudge: boolean
-}
-
 /**
  * Post-turn state machine for the "text-only drift" nudge.
  *
@@ -65,14 +61,41 @@ export class ContinuationNudge {
 		this.toolsCalledSinceLastUserInput = true
 	}
 
-	evaluateTurn(message: AssistantMessage): NudgeDecision {
-		if (this.nudgedSinceLastUserInput) return { shouldNudge: false }
-		if (this.toolsCalledSinceLastUserInput) return { shouldNudge: false }
+	evaluateTurn(message: AssistantMessage): boolean {
+		if (this.nudgedSinceLastUserInput) return false
+		if (this.toolsCalledSinceLastUserInput) return false
 		const hasToolCalls = message.content.some((c) => c.type === "toolCall")
 		const hasText = message.content.some((c) => c.type === "text" && c.text.trim().length > 0)
-		if (hasToolCalls || !hasText) return { shouldNudge: false }
+		if (hasToolCalls || !hasText) return false
 		this.nudgedSinceLastUserInput = true
-		return { shouldNudge: true }
+		return true
+	}
+}
+
+/**
+ * Reactive state machine for the "empty follow-up" nudge.
+ *
+ * Some model deployments (notably Kimi K2.x) return an empty response — no text, no tool calls — after receiving tool results from a tool-call-only turn. The agent loop stalls because there is nothing to execute or display. This class detects that failure and arms a one-shot nudge that is injected into the next LLM context to prompt the model to continue.
+ *
+ * The nudge is reactive: it only fires after an empty response has actually occurred, not preemptively on every tool-result → LLM-call transition. Models that never produce empty responses never see the nudge at all.
+ */
+export class EmptyTurnNudge {
+	private armed = false
+
+	evaluateTurn(message: AssistantMessage): void {
+		const hasText = message.content.some((c) => c.type === "text" && c.text.trim().length > 0)
+		const hasToolCalls = message.content.some((c) => c.type === "toolCall")
+		this.armed = !hasText && !hasToolCalls
+	}
+
+	shouldNudge(): boolean {
+		if (!this.armed) return false
+		this.armed = false
+		return true
+	}
+
+	resetForNewUserInput(): void {
+		this.armed = false
 	}
 }
 

--- a/src/extensions/orchestration/continuation-nudge.ts
+++ b/src/extensions/orchestration/continuation-nudge.ts
@@ -10,8 +10,9 @@
  *      call. Mirrors AISI Inspect's `on_continue`.
  *
  *   2. Empty-turn nudge — some Kimi deployments return an empty response
- *      (no text, no tool calls) after receiving tool results. Detected
- *      inline in the `turn_end` handler.
+ *      (no text, no tool calls) after receiving tool results from a
+ *      tool-call-only turn. `EmptyTurnNudge` tracks whether the previous
+ *      turn was tool-call-only so the `turn_end` handler can decide.
  *
  * Both are delivered as custom messages with `display: false` so they
  * never appear in the conversation. Stale nudges (those the model has
@@ -22,6 +23,7 @@
  * inside the `if (!subagentMode)` guard.
  */
 
+import type { AssistantMessage } from "@mariozechner/pi-ai"
 import type { ContextEvent } from "@mariozechner/pi-coding-agent"
 
 /**
@@ -66,6 +68,32 @@ export class ContinuationNudge {
 		if (hasToolCalls || !hasText) return false
 		this.nudgedSinceLastUserInput = true
 		return true
+	}
+}
+
+/**
+ * Tracks whether the previous assistant turn was tool-call-only so the `turn_end` handler can send a followUp nudge only when the empty response follows a tool-result → LLM-call sequence. Models that never produce empty responses never see the nudge.
+ *
+ * Some model deployments (notably Kimi K2.x) return an empty response — no text, no tool calls — after receiving tool results from a tool-call-only turn. The agent loop stalls because there is nothing to execute or display.
+ */
+export class EmptyTurnNudge {
+	private previousTurnWasToolCallOnly = false
+
+	evaluateTurn(message: AssistantMessage): boolean {
+		const hasText = message.content.some((c) => c.type === "text" && c.text.trim().length > 0)
+		const hasToolCalls = message.content.some((c) => c.type === "toolCall")
+
+		if (!hasText && !hasToolCalls && this.previousTurnWasToolCallOnly) {
+			this.previousTurnWasToolCallOnly = false
+			return true
+		}
+
+		this.previousTurnWasToolCallOnly = hasToolCalls && !hasText
+		return false
+	}
+
+	resetForNewUserInput(): void {
+		this.previousTurnWasToolCallOnly = false
 	}
 }
 

--- a/src/extensions/orchestration/prompt-enrichment.ts
+++ b/src/extensions/orchestration/prompt-enrichment.ts
@@ -32,9 +32,8 @@ import { getGitBranch } from "../../utils.js"
 import {
 	CONTINUATION_NUDGE_TEXT,
 	ContinuationNudge,
-	EmptyTurnNudge,
+	EMPTY_TURN_NUDGE_TEXT,
 	NUDGE_CUSTOM_TYPE,
-	buildEmptyTurnNudgedMessages,
 	stripStaleNudges,
 } from "./continuation-nudge.js"
 import { ModelRegistry } from "./model-registry/index.js"
@@ -154,12 +153,10 @@ export default function (skillPaths: string[]) {
 			// that one returns `{action: "handled"}` in interactive mode, which short-
 			// circuits the input-handler chain.
 			const continuationNudge = new ContinuationNudge()
-			const emptyTurnNudge = new EmptyTurnNudge()
 
 			pi.on("input", async (event) => {
 				if (event.source === "extension") return
 				continuationNudge.resetForNewUserInput()
-				emptyTurnNudge.resetForNewUserInput()
 			})
 
 			pi.on("tool_execution_start", async () => {
@@ -168,7 +165,18 @@ export default function (skillPaths: string[]) {
 
 			pi.on("turn_end", async (event) => {
 				if (event.message.role !== "assistant") return
-				emptyTurnNudge.evaluateTurn(event.message)
+
+				const hasText = event.message.content.some((c) => c.type === "text" && c.text.trim().length > 0)
+				const hasToolCalls = event.message.content.some((c) => c.type === "toolCall")
+
+				if (!hasText && !hasToolCalls) {
+					pi.sendMessage(
+						{ customType: NUDGE_CUSTOM_TYPE, content: EMPTY_TURN_NUDGE_TEXT, display: false },
+						{ deliverAs: "followUp" },
+					)
+					return
+				}
+
 				if (!continuationNudge.evaluateTurn(event.message)) return
 				pi.sendMessage(
 					{ customType: NUDGE_CUSTOM_TYPE, content: CONTINUATION_NUDGE_TEXT, display: false },
@@ -217,19 +225,8 @@ export default function (skillPaths: string[]) {
 				return { action: "handled" as const }
 			})
 
-			// Pre-LLM-call complement of the turn_end nudge above. Reactive: only injects
-			// the nudge after the model actually produced an empty response (no text, no
-			// tool calls) on the previous turn, rather than preemptively on every
-			// tool-result → LLM-call transition. Models that never produce empty responses
-			// never see the nudge.
 			pi.on("context", async (event) => {
 				const cleaned = stripStaleNudges(event.messages)
-				if (!emptyTurnNudge.shouldNudge()) {
-					if (cleaned !== event.messages) return { messages: cleaned }
-					return
-				}
-				const nudged = buildEmptyTurnNudgedMessages(cleaned)
-				if (nudged) return { messages: nudged }
 				if (cleaned !== event.messages) return { messages: cleaned }
 			})
 		}

--- a/src/extensions/orchestration/prompt-enrichment.ts
+++ b/src/extensions/orchestration/prompt-enrichment.ts
@@ -32,6 +32,7 @@ import { getGitBranch } from "../../utils.js"
 import {
 	CONTINUATION_NUDGE_TEXT,
 	ContinuationNudge,
+	EmptyTurnNudge,
 	NUDGE_CUSTOM_TYPE,
 	buildEmptyTurnNudgedMessages,
 	stripStaleNudges,
@@ -153,10 +154,12 @@ export default function (skillPaths: string[]) {
 			// that one returns `{action: "handled"}` in interactive mode, which short-
 			// circuits the input-handler chain.
 			const continuationNudge = new ContinuationNudge()
+			const emptyTurnNudge = new EmptyTurnNudge()
 
 			pi.on("input", async (event) => {
 				if (event.source === "extension") return
 				continuationNudge.resetForNewUserInput()
+				emptyTurnNudge.resetForNewUserInput()
 			})
 
 			pi.on("tool_execution_start", async () => {
@@ -165,8 +168,8 @@ export default function (skillPaths: string[]) {
 
 			pi.on("turn_end", async (event) => {
 				if (event.message.role !== "assistant") return
-				const { shouldNudge } = continuationNudge.evaluateTurn(event.message)
-				if (!shouldNudge) return
+				emptyTurnNudge.evaluateTurn(event.message)
+				if (!continuationNudge.evaluateTurn(event.message)) return
 				pi.sendMessage(
 					{ customType: NUDGE_CUSTOM_TYPE, content: CONTINUATION_NUDGE_TEXT, display: false },
 					{ deliverAs: "followUp" },
@@ -214,13 +217,17 @@ export default function (skillPaths: string[]) {
 				return { action: "handled" as const }
 			})
 
-			// Pre-LLM-call complement of the turn_end nudge above: the model returned only
-			// tool calls with no text, tool results are queued, and it is about to be
-			// called again. Some Kimi deployments return an empty response on this specific
-			// follow-up; a custom-role nudge injected transiently into the context prevents it
-			// without polluting the session history.
+			// Pre-LLM-call complement of the turn_end nudge above. Reactive: only injects
+			// the nudge after the model actually produced an empty response (no text, no
+			// tool calls) on the previous turn, rather than preemptively on every
+			// tool-result → LLM-call transition. Models that never produce empty responses
+			// never see the nudge.
 			pi.on("context", async (event) => {
 				const cleaned = stripStaleNudges(event.messages)
+				if (!emptyTurnNudge.shouldNudge()) {
+					if (cleaned !== event.messages) return { messages: cleaned }
+					return
+				}
 				const nudged = buildEmptyTurnNudgedMessages(cleaned)
 				if (nudged) return { messages: nudged }
 				if (cleaned !== event.messages) return { messages: cleaned }

--- a/src/extensions/orchestration/prompt-enrichment.ts
+++ b/src/extensions/orchestration/prompt-enrichment.ts
@@ -33,6 +33,7 @@ import {
 	CONTINUATION_NUDGE_TEXT,
 	ContinuationNudge,
 	EMPTY_TURN_NUDGE_TEXT,
+	EmptyTurnNudge,
 	NUDGE_CUSTOM_TYPE,
 	stripStaleNudges,
 } from "./continuation-nudge.js"
@@ -153,10 +154,12 @@ export default function (skillPaths: string[]) {
 			// that one returns `{action: "handled"}` in interactive mode, which short-
 			// circuits the input-handler chain.
 			const continuationNudge = new ContinuationNudge()
+			const emptyTurnNudge = new EmptyTurnNudge()
 
 			pi.on("input", async (event) => {
 				if (event.source === "extension") return
 				continuationNudge.resetForNewUserInput()
+				emptyTurnNudge.resetForNewUserInput()
 			})
 
 			pi.on("tool_execution_start", async () => {
@@ -166,10 +169,7 @@ export default function (skillPaths: string[]) {
 			pi.on("turn_end", async (event) => {
 				if (event.message.role !== "assistant") return
 
-				const hasText = event.message.content.some((c) => c.type === "text" && c.text.trim().length > 0)
-				const hasToolCalls = event.message.content.some((c) => c.type === "toolCall")
-
-				if (!hasText && !hasToolCalls) {
+				if (emptyTurnNudge.evaluateTurn(event.message)) {
 					pi.sendMessage(
 						{ customType: NUDGE_CUSTOM_TYPE, content: EMPTY_TURN_NUDGE_TEXT, display: false },
 						{ deliverAs: "followUp" },


### PR DESCRIPTION
# Summary

Replaces a proactive nudge (injected into the LLM context before every call) with a reactive one (sent as a followUp only when the stall actually happens).

The old implementation fired the empty-turn nudge on every LLM call where the previous assistant message was tool-call-only with tool results ready. That's the normal, happy-path flow for any tool-using model. So models that never stall were still getting nudged constantly, just invisibly (injected into the context window, consuming tokens and potentially skewing behavior).

The fix makes it reactive: only nudge after the model actually produces an empty response following a tool-call-only turn. Models that don't exhibit the quirk never see the nudge at all.

Nudges are now in session.jsonl that is desired for billing transparency.

---
### Kimchi Summary
### What changed
Consolidates the empty-turn nudge mechanism into the `turn_end` handler using a new stateful `EmptyTurnNudge` class, replacing the previous pre-LLM-call injection logic. Simplifies `ContinuationNudge.evaluateTurn` to return a plain boolean.

### Why
Some Kimi K2.x deployments return empty responses (no text, no tool calls) after receiving tool results from a tool-call-only turn, stalling the agent loop. The previous approach inspected message history and injected nudges into the context, firing too frequently. Tracking turn-to-turn state allows the nudge to fire only when an empty turn specifically follows a tool-call-only turn.

### Key changes
- `continuation-nudge.ts`:
  - Changed `ContinuationNudge.evaluateTurn` return type from `NudgeDecision` object to plain `boolean`
  - Added `EmptyTurnNudge` class to track whether the previous assistant turn was tool-call-only across the agent loop
  - Removed `buildEmptyTurnNudgedMessages` function and the `NudgeDecision` interface
- `prompt-enrichment.ts`:
  - Instantiated `EmptyTurnNudge` alongside `ContinuationNudge` with matching lifecycle resets on user input
  - Moved empty-turn nudge logic from the `context` event (pre-LLM-call injection) to the `turn_end` event, sending it via `pi.sendMessage` with `deliverAs: "followUp"`
  - Simplified the `context` event handler to only strip stale nudges without injecting new ones

### Impact
- **Frequency reduction**: Empty-turn nudges now fire only when an empty assistant turn immediately follows a tool-call-only turn, eliminating unnecessary nudges for models that don't exhibit this quirk.
- **Behavioral change**: Both nudges are now delivered consistently as `followUp` messages rather than one being injected into the context window.