### PR TITLE
NOJIRA: Add manual smoke-testing benchmark

### DIFF
--- a/benchmark/manual/.gitignore
+++ b/benchmark/manual/.gitignore
@@ -1,0 +1,1 @@
+sessions/

--- a/benchmark/manual/README.md
+++ b/benchmark/manual/README.md
@@ -1,0 +1,129 @@
+# Kimchi-dev Smoke-Testing Benchmark
+
+A manual benchmark for testing AI coding orchestrators against three fixed tasks. Sessions are numbered sequentially; each session runs the same prompts and produces JSONL logs that can be analyzed and compared across sessions.
+
+## Setup
+
+Edit `benchmark.json` to match your environment:
+
+```json
+{
+  "binary": "/path/to/your/kimchi-code",
+  "models": ["kimi-k2.5", "minimax-m2.7"]
+}
+```
+
+- `binary` — path to the kimchi-code binary (`~` is expanded)
+- `models` — list of model IDs to benchmark; scripts are generated for every model × task combination
+
+## Workflow
+
+### 1. Create a session
+
+```bash
+./new-session.sh
+```
+
+Creates `session-01` (or the next number), subdirectories under `runs/`, and one run script per task × model combination.
+
+### 2. Run the scripts
+
+Open all runs in parallel panes (requires iTerm2):
+
+```bash
+./sessions/session-01/run-all.sh
+```
+
+Or run individual scripts:
+
+```bash
+./sessions/session-01/run-simple-kimi-k2.5.sh
+./sessions/session-01/run-complex-kimi-k2.5.sh
+./sessions/session-01/run-complex-single-kimi-k2.5.sh
+./sessions/session-01/run-research-kimi-k2.5.sh
+./sessions/session-01/run-simple-minimax-m2.7.sh
+...
+```
+
+Each script writes a timestamped `.jsonl` file into its `runs/<task>-<model>/` directory.
+
+### 3. Analyze results
+
+Analyze the most recent session:
+
+```bash
+python3 analyze-session.py
+```
+
+Analyze a specific session by name or number:
+
+```bash
+python3 analyze-session.py session-03
+python3 analyze-session.py 3
+```
+
+Output shows per-run token consumption, subagent count, duration, and quality checks. Saves `analysis.json` in the session directory.
+
+### 4. Compare sessions
+
+Compare the last two sessions:
+
+```bash
+python3 compare-sessions.py
+```
+
+Compare specific sessions:
+
+```bash
+python3 compare-sessions.py session-02 session-03
+python3 compare-sessions.py 2 3
+```
+
+Shows a table with token delta (%), subagent counts, and durations side by side.
+
+## Benchmark tasks
+
+See `tasks.md` for full prompts, baseline implementations, and expected behavior.
+
+| Task | Prompt summary | Expected |
+|------|---------------|----------|
+| simple | Go HTTP rate limiter middleware (token bucket, per-IP) | 1 subagent, <5 min, <300k tokens |
+| complex | Go REST API task management (layered architecture) | 2–6 subagents, <10 min, <700k tokens |
+| complex-single | Same as complex, single-model mode | 1–5 subagents, <10 min, <500k tokens |
+| research | Top 3 Go HTTP router libraries with stars and examples | 0 subagents, <2 min, <30k tokens |
+
+## Session directory structure
+
+```
+sessions/session-01/
+├── run-simple-kimi-k2.5.sh          # one script per task × model
+├── run-complex-kimi-k2.5.sh
+├── run-complex-single-kimi-k2.5.sh
+├── run-research-kimi-k2.5.sh
+├── run-simple-minimax-m2.7.sh
+├── ...
+├── run-all.sh
+├── analysis.json          # created by analyze-session.py
+└── runs/
+    ├── simple-kimi-k2.5/
+    │   └── session-YYYYMMDD-HHMMSS.jsonl
+    ├── complex-kimi-k2.5/
+    ├── complex-single-kimi-k2.5/
+    ├── research-kimi-k2.5/
+    ├── simple-minimax-m2.7/
+    └── ...
+```
+
+## Analysis reference
+
+`analyze-session.py` reads the most recent `.jsonl` in each run directory. Quality check results:
+
+- `[+]` PASS — within expected range
+- `[!]` WARN — outside expected range but not a hard failure
+- `[x]` FAIL — exceeded token budget, wrong subagent count for task type, or exceeded time budget
+
+`compare-sessions.py` calls `analyze-session.py` automatically if `analysis.json` is missing for either session.
+
+## Historical findings
+
+See `SUMMARY.md` for a token trajectory table across the first 10 sessions and the five changes that had the largest measurable impact on token consumption and output quality.

--- a/benchmark/manual/analyze-session.py
+++ b/benchmark/manual/analyze-session.py
@@ -5,6 +5,7 @@ import json
 import subprocess
 import sys
 from collections import Counter
+from datetime import datetime
 from pathlib import Path
 
 IMPROVEMENT_DIR = Path(__file__).parent
@@ -119,13 +120,12 @@ def analyze_jsonl(path):
             "sub_tokens": subs.get("input", 0) + subs.get("output", 0),
             "subagent_count": subagent_count,
             "orch_tool_calls": orch_tool_calls,
-            "terminated": False,
+            "terminated": terminated,
         }
 
     if not start_ts or not end_ts or (orch_input + orch_output) == 0:
         return None
 
-    from datetime import datetime
     t1 = datetime.fromisoformat(start_ts.replace("Z", "+00:00"))
     t2 = datetime.fromisoformat(end_ts.replace("Z", "+00:00"))
     duration_s = (t2 - t1).total_seconds()

--- a/benchmark/manual/analyze-session.py
+++ b/benchmark/manual/analyze-session.py
@@ -1,0 +1,278 @@
+#!/usr/bin/env python3
+"""Analyze all runs in a benchmark session."""
+
+import json
+import subprocess
+import sys
+from collections import Counter
+from pathlib import Path
+
+IMPROVEMENT_DIR = Path(__file__).parent
+SESSIONS_DIR = IMPROVEMENT_DIR / "sessions"
+
+TASK_CRITERIA = {
+    "simple": {
+        "min_subagents": 1,
+        "max_subagents": 2,
+        "max_tokens": 300_000,
+        "max_duration_s": 300,
+    },
+    "complex": {
+        "min_subagents": 2,
+        "max_subagents": 6,
+        "max_tokens": 700_000,
+        "max_duration_s": 600,
+    },
+    "complex-single": {
+        "min_subagents": 1,
+        "max_subagents": 5,
+        "max_tokens": 500_000,
+        "max_duration_s": 600,
+    },
+    "research": {
+        "min_subagents": 0,
+        "max_subagents": 0,
+        "max_tokens": 30_000,
+        "max_duration_s": 120,
+    },
+}
+
+
+def format_tokens(n):
+    if n >= 1_000_000:
+        return f"{n / 1_000_000:.1f}m"
+    if n >= 1_000:
+        return f"{n / 1_000:.1f}k"
+    return str(n)
+
+
+def parse_elapsed_to_seconds(elapsed_str):
+    elapsed_str = elapsed_str.strip()
+    if "m" in elapsed_str and "s" in elapsed_str:
+        parts = elapsed_str.split("m")
+        mins = int(parts[0].strip())
+        secs = float(parts[1].replace("s", "").strip())
+        return mins * 60 + secs
+    if "s" in elapsed_str:
+        return float(elapsed_str.replace("s", "").strip())
+    return 0.0
+
+
+def analyze_jsonl(path):
+    summary_details = None
+    subagent_count = 0
+    orch_tool_calls = []
+    terminated = False
+    start_ts = end_ts = None
+    orch_input = orch_output = 0
+    sub_input = sub_output = 0
+
+    with open(path) as f:
+        for raw in f:
+            raw = raw.strip()
+            if not raw:
+                continue
+            try:
+                event = json.loads(raw)
+            except json.JSONDecodeError:
+                continue
+
+            ts = event.get("timestamp")
+            if ts:
+                if start_ts is None:
+                    start_ts = ts
+                end_ts = ts
+
+            if event.get("customType") == "prompt-summary":
+                summary_details = event.get("details", {})
+
+            if event.get("customType") == "agent_terminated":
+                terminated = True
+
+            if event.get("type") == "message":
+                msg = event.get("message", {})
+                role = msg.get("role", "")
+                if role == "toolResult" and msg.get("toolName") == "subagent":
+                    subagent_count += 1
+                    tu = (msg.get("details") or {}).get("tokenUsage") or {}
+                    sub_input += tu.get("input", 0)
+                    sub_output += tu.get("output", 0)
+                if role == "assistant":
+                    usage = msg.get("usage") or {}
+                    orch_input += usage.get("input", 0)
+                    orch_output += usage.get("output", 0)
+                    for item in msg.get("content", []):
+                        if item.get("type") == "toolCall" and item.get("name") != "subagent":
+                            orch_tool_calls.append(item.get("name"))
+
+    if summary_details:
+        total = summary_details.get("total") or {}
+        orch = summary_details.get("orchestrator") or {}
+        subs = summary_details.get("subagents") or {}
+        elapsed = summary_details.get("elapsed", "")
+        duration_s = parse_elapsed_to_seconds(elapsed)
+        return {
+            "elapsed": elapsed,
+            "duration_s": duration_s,
+            "total_tokens": total.get("input", 0) + total.get("output", 0),
+            "orch_tokens": orch.get("input", 0) + orch.get("output", 0),
+            "sub_tokens": subs.get("input", 0) + subs.get("output", 0),
+            "subagent_count": subagent_count,
+            "orch_tool_calls": orch_tool_calls,
+            "terminated": False,
+        }
+
+    if not start_ts or not end_ts or (orch_input + orch_output) == 0:
+        return None
+
+    from datetime import datetime
+    t1 = datetime.fromisoformat(start_ts.replace("Z", "+00:00"))
+    t2 = datetime.fromisoformat(end_ts.replace("Z", "+00:00"))
+    duration_s = (t2 - t1).total_seconds()
+    m, s = int(duration_s // 60), int(duration_s % 60)
+    elapsed = f"{m}m {s}s" if m else f"{s}s"
+
+    return {
+        "elapsed": elapsed,
+        "duration_s": duration_s,
+        "total_tokens": orch_input + orch_output + sub_input + sub_output,
+        "orch_tokens": orch_input + orch_output,
+        "sub_tokens": sub_input + sub_output,
+        "subagent_count": subagent_count,
+        "orch_tool_calls": orch_tool_calls,
+        "terminated": terminated,
+    }
+
+
+def task_from_run_name(run_name):
+    for task in sorted(TASK_CRITERIA.keys(), key=len, reverse=True):
+        if run_name.startswith(task):
+            return task
+    return None
+
+
+def quality_checks(metrics, task):
+    criteria = TASK_CRITERIA.get(task)
+    if not criteria:
+        return []
+
+    checks = []
+    sub = metrics["subagent_count"]
+    min_s, max_s = criteria["min_subagents"], criteria["max_subagents"]
+
+    if min_s == max_s == 0:
+        if sub == 0:
+            checks.append(("PASS", "no subagents spawned (expected: 0)"))
+        else:
+            checks.append(("FAIL", f"spawned {sub} subagent(s) (expected: 0)"))
+    elif sub < min_s:
+        checks.append(("WARN", f"subagents: {sub} (expected: {min_s}–{max_s})"))
+    elif sub > max_s:
+        checks.append(("WARN", f"subagents: {sub} (expected: {min_s}–{max_s})"))
+    else:
+        checks.append(("PASS", f"subagents: {sub} (expected: {min_s}–{max_s})"))
+
+    total = metrics["total_tokens"]
+    budget = criteria["max_tokens"]
+    label = f"tokens: {format_tokens(total)} (budget: {format_tokens(budget)})"
+    checks.append(("PASS" if total <= budget else "FAIL", label))
+
+    dur = metrics["duration_s"]
+    max_dur = criteria["max_duration_s"]
+    dur_str = f"{int(dur // 60)}m {int(dur % 60)}s" if dur >= 60 else f"{dur:.1f}s"
+    max_str = f"{max_dur // 60}m" if max_dur >= 60 else f"{max_dur}s"
+    checks.append(("PASS" if dur <= max_dur else "FAIL", f"duration: {dur_str} (budget: {max_str})"))
+
+    return checks
+
+
+def find_latest_jsonl(run_dir):
+    jsonls = sorted(Path(run_dir).glob("*.jsonl"), key=lambda p: p.stat().st_mtime)
+    return jsonls[-1] if jsonls else None
+
+
+def analyze_session(session_dir):
+    runs_dir = session_dir / "runs"
+    if not runs_dir.exists():
+        return None
+
+    results = {}
+    for run_dir in sorted(d for d in runs_dir.iterdir() if d.is_dir()):
+        jsonl = find_latest_jsonl(run_dir)
+        if not jsonl:
+            continue
+        metrics = analyze_jsonl(jsonl)
+        if metrics:
+            results[run_dir.name] = metrics
+
+    return results or None
+
+
+def print_report(session_name, results):
+    print(f"\nSession: {session_name}")
+    print("=" * 70)
+
+    for run_name, metrics in sorted(results.items()):
+        task = task_from_run_name(run_name)
+        checks = quality_checks(metrics, task) if task else []
+
+        if all(c[0] == "PASS" for c in checks):
+            overall = "PASS"
+        elif any(c[0] == "FAIL" for c in checks):
+            overall = "FAIL"
+        else:
+            overall = "WARN"
+
+        terminated_tag = "  (terminated)" if metrics.get("terminated") else ""
+        print(f"\n{run_name}  [{overall}]{terminated_tag}")
+        print(f"  Duration:  {metrics['elapsed']}")
+        print(f"  Tokens:    {format_tokens(metrics['total_tokens'])} total"
+              f"  (orch: {format_tokens(metrics['orch_tokens'])}, sub: {format_tokens(metrics['sub_tokens'])})")
+        print(f"  Subagents: {metrics['subagent_count']}")
+
+        if metrics["orch_tool_calls"]:
+            counts = Counter(metrics["orch_tool_calls"])
+            tools_str = ", ".join(f"{k}×{v}" for k, v in sorted(counts.items()))
+            print(f"  Orch tools: {tools_str}")
+
+        for status, msg in checks:
+            symbol = "+" if status == "PASS" else ("!" if status == "WARN" else "x")
+            print(f"  [{symbol}] {msg}")
+
+    print()
+
+
+def resolve_session(arg):
+    if arg.isdigit():
+        return SESSIONS_DIR / f"session-{int(arg):02d}"
+    return SESSIONS_DIR / arg
+
+
+if __name__ == "__main__":
+    if len(sys.argv) >= 2:
+        session_dir = resolve_session(sys.argv[1])
+    else:
+        sessions = sorted(
+            (d for d in SESSIONS_DIR.iterdir() if d.is_dir() and d.name.startswith("session-")),
+            key=lambda d: d.name,
+        ) if SESSIONS_DIR.exists() else []
+        if not sessions:
+            print("No sessions found. Run ./new-session.sh to create one.", file=sys.stderr)
+            sys.exit(1)
+        session_dir = sessions[-1]
+
+    if not session_dir.exists():
+        print(f"Session directory not found: {session_dir}", file=sys.stderr)
+        sys.exit(1)
+
+    results = analyze_session(session_dir)
+    if not results:
+        print(f"No completed runs found in {session_dir}/runs/", file=sys.stderr)
+        sys.exit(1)
+
+    print_report(session_dir.name, results)
+
+    analysis_file = session_dir / "analysis.json"
+    with open(analysis_file, "w") as f:
+        json.dump(results, f, indent=2)
+    print(f"Saved: {analysis_file}")

--- a/benchmark/manual/benchmark.json
+++ b/benchmark/manual/benchmark.json
@@ -1,0 +1,7 @@
+{
+  "binary": "~/_dev/kimchi-dev/dist/bin/kimchi-code",
+  "models": [
+    "kimi-k2.5",
+    "minimax-m2.7"
+  ]
+}

--- a/benchmark/manual/benchmark.json
+++ b/benchmark/manual/benchmark.json
@@ -1,1 +1,7 @@
-ewogICJiaW5hcnkiOiAia2ltY2hpLWNvZGUiLAogICJtb2RlbHMiOiBbCiAgICAia2ltaS1rMi41IiwKICAgICJtaW5pbWF4LW0yLjciCiAgXQp9Cg==
+{
+  "binary": "kimchi-code",
+  "models": [
+    "kimi-k2.5",
+    "minimax-m2.7"
+  ]
+}

--- a/benchmark/manual/benchmark.json
+++ b/benchmark/manual/benchmark.json
@@ -1,7 +1,1 @@
-{
-  "binary": "~/_dev/kimchi-dev/dist/bin/kimchi-code",
-  "models": [
-    "kimi-k2.5",
-    "minimax-m2.7"
-  ]
-}
+ewogICJiaW5hcnkiOiAia2ltY2hpLWNvZGUiLAogICJtb2RlbHMiOiBbCiAgICAia2ltaS1rMi41IiwKICAgICJtaW5pbWF4LW0yLjciCiAgXQp9Cg==

--- a/benchmark/manual/compare-sessions.py
+++ b/benchmark/manual/compare-sessions.py
@@ -1,0 +1,118 @@
+#!/usr/bin/env python3
+"""Compare token usage and quality metrics between two benchmark sessions."""
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+IMPROVEMENT_DIR = Path(__file__).parent
+SESSIONS_DIR = IMPROVEMENT_DIR / "sessions"
+
+
+def format_tokens(n):
+    if n >= 1_000_000:
+        return f"{n / 1_000_000:.1f}m"
+    if n >= 1_000:
+        return f"{n / 1_000:.1f}k"
+    return str(n)
+
+
+def delta_str(a, b):
+    if a == 0:
+        return "N/A"
+    pct = (b - a) / a * 100
+    sign = "+" if pct >= 0 else ""
+    return f"{sign}{pct:.1f}%"
+
+
+def ensure_analysis(session_dir):
+    analysis_file = session_dir / "analysis.json"
+    if not analysis_file.exists():
+        print(f"Running analysis for {session_dir.name}...")
+        subprocess.run(
+            [sys.executable, str(IMPROVEMENT_DIR / "analyze-session.py"), str(session_dir)],
+            check=True,
+        )
+    if not analysis_file.exists():
+        return None
+    with open(analysis_file) as f:
+        return json.load(f)
+
+
+def resolve_session(arg):
+    if arg.isdigit():
+        return SESSIONS_DIR / f"session-{int(arg):02d}"
+    return SESSIONS_DIR / arg
+
+
+def compare(session_a_dir, session_b_dir):
+    a = ensure_analysis(session_a_dir)
+    b = ensure_analysis(session_b_dir)
+
+    if not a or not b:
+        print("Could not load metrics for one or both sessions.", file=sys.stderr)
+        sys.exit(1)
+
+    all_runs = sorted(set(a.keys()) | set(b.keys()))
+
+    print(f"\nComparing {session_a_dir.name} vs {session_b_dir.name}")
+    print("=" * 84)
+    header = (
+        f"{'Run':<22}  {'Tokens A':>10}  {'Tokens B':>10}  {'Delta':>8}"
+        f"  {'Sub A':>5}  {'Sub B':>5}  {'Dur A':>8}  {'Dur B':>8}"
+    )
+    print(header)
+    print("-" * 84)
+
+    for run in all_runs:
+        if run not in a:
+            print(f"{run:<22}  (only in {session_b_dir.name})")
+            continue
+        if run not in b:
+            print(f"{run:<22}  (only in {session_a_dir.name})")
+            continue
+
+        ta = a[run]["total_tokens"]
+        tb = b[run]["total_tokens"]
+        sa = a[run]["subagent_count"]
+        sb = b[run]["subagent_count"]
+        da = a[run]["elapsed"]
+        db = b[run]["elapsed"]
+
+        print(
+            f"{run:<22}  {format_tokens(ta):>10}  {format_tokens(tb):>10}  {delta_str(ta, tb):>8}"
+            f"  {sa:>5}  {sb:>5}  {da:>8}  {db:>8}"
+        )
+
+    print()
+
+
+if __name__ == "__main__":
+    all_sessions = sorted(
+        (d for d in SESSIONS_DIR.iterdir() if d.is_dir() and d.name.startswith("session-")),
+        key=lambda d: d.name,
+    ) if SESSIONS_DIR.exists() else []
+
+    if len(sys.argv) >= 3:
+        session_a = resolve_session(sys.argv[1])
+        session_b = resolve_session(sys.argv[2])
+    elif len(sys.argv) == 2:
+        session_b = resolve_session(sys.argv[1])
+        idx = next((i for i, s in enumerate(all_sessions) if s.name == session_b.name), None)
+        if idx is None or idx == 0:
+            print("Cannot find a previous session to compare against.", file=sys.stderr)
+            sys.exit(1)
+        session_a = all_sessions[idx - 1]
+    else:
+        if len(all_sessions) < 2:
+            print("Need at least 2 sessions to compare.", file=sys.stderr)
+            sys.exit(1)
+        session_a, session_b = all_sessions[-2], all_sessions[-1]
+
+    for s in (session_a, session_b):
+        if not s.exists():
+            print(f"Session directory not found: {s}", file=sys.stderr)
+            sys.exit(1)
+
+    compare(session_a, session_b)

--- a/benchmark/manual/new-session.sh
+++ b/benchmark/manual/new-session.sh
@@ -1,0 +1,153 @@
+#!/bin/zsh
+set -e
+
+IMPROVEMENT_DIR="${0:A:h}"
+BENCHMARK_JSON="$IMPROVEMENT_DIR/benchmark.json"
+
+if [[ ! -f "$BENCHMARK_JSON" ]]; then
+  echo "benchmark.json not found at $BENCHMARK_JSON"
+  echo "Create it with: {\"binary\": \"path/to/binary\", \"models\": [\"model-id\", ...]}"
+  exit 1
+fi
+
+BINARY=$(python3 -c "import json,os; cfg=json.load(open('$BENCHMARK_JSON')); print(os.path.expanduser(cfg.get('binary','~/_dev/kimchi-dev/dist/bin/kimchi-code')))")
+
+if [[ ! -f "$BINARY" ]]; then
+  echo "Binary not found: $BINARY"
+  echo "Update 'binary' in benchmark.json or build the binary first."
+  exit 1
+fi
+
+SESSIONS_DIR="$IMPROVEMENT_DIR/sessions"
+mkdir -p "$SESSIONS_DIR"
+
+# Determine next session number
+LAST=$(ls -d "$SESSIONS_DIR"/session-* 2>/dev/null | grep -oE '[0-9]+$' | sort -n | tail -1)
+N=$(( ${LAST:-0} + 1 ))
+SESSION="session-$(printf '%02d' $N)"
+SESSION_DIR="$SESSIONS_DIR/$SESSION"
+
+echo "Creating $SESSION..."
+
+# Generate all scripts via Python
+python3 - "$SESSION_DIR" "$N" "$BENCHMARK_JSON" "$HOME" "$BINARY" <<'PYEOF'
+import json, os, sys, stat
+
+session_dir, n, benchmark_json, home, binary = sys.argv[1], int(sys.argv[2]), sys.argv[3], sys.argv[4], sys.argv[5]
+
+cfg = json.load(open(benchmark_json))
+models = cfg.get("models", [])
+if not models:
+    sys.exit("No models configured. Set 'models' array in benchmark.json.")
+
+simple_prompt = (
+    "Implement a Go HTTP middleware that rate-limits requests per client IP using a token bucket algorithm. "
+    "Requirements: Each IP gets 10 requests per second. Respond with HTTP 429 when limit is exceeded. "
+    "Thread-safe implementation. Include tests with map-based test cases. "
+    "Put the code in directory: $DIR/rate-limiter/. Include a README.md explaining usage."
+)
+
+complex_prompt = (
+    "Implement a Go REST API for a task management system. "
+    "This is a multi-layer project — start with a plan before writing any code. "
+    "Requirements: Use standard library only (no frameworks, no external dependencies). "
+    "Layered architecture: handler -> service -> repository. In-memory repository. "
+    "Endpoints: POST /tasks (create, fields: title+description), GET /tasks (list all), "
+    "GET /tasks/{id} (get by id), PATCH /tasks/{id} (update status: todo/in-progress/done), DELETE /tasks/{id} (delete). "
+    "Proper HTTP status codes and JSON responses. "
+    "Unit tests for the service layer using map-based test cases. "
+    "Put all code in directory: $DIR/task-api/"
+)
+
+research_prompt = (
+    "What are the most popular third-party HTTP router libraries for Go? "
+    "List the top 3 with: GitHub stars (approximate), key differentiators, "
+    "and a one-line example of defining a route with a path parameter."
+)
+
+tasks = [
+    ("simple",         simple_prompt,  []),
+    ("complex",        complex_prompt, []),
+    ("complex-single", complex_prompt, ["--multi-model=false"]),
+    ("research",       research_prompt,[]),
+]
+
+all_scripts = []
+for model in models:
+    print(f"model: kimchi-dev/{model}")
+    for task, task_prompt, extra_flags in tasks:
+        run_dir = f"{task}-{model}"
+        os.makedirs(os.path.join(session_dir, "runs", run_dir), exist_ok=True)
+        slug = f"s{n}-{task}-{model}"
+        script_path = os.path.join(session_dir, f"run-{task}-{model}.sh")
+        flags = "\n".join(f"  {flag} \\" for flag in extra_flags)
+        flags_block = (flags + "\n") if flags else ""
+        content = f"""#!/bin/zsh
+TS=$(date +%Y%m%d-%H%M%S)
+SESSION_FILE="{session_dir}/runs/{run_dir}/session-${{TS}}.jsonl"
+DIR=$(mktemp -d /private/tmp/kimchi-{slug}-XXXXXX)
+echo "Working directory: $DIR"
+echo "Session file: $SESSION_FILE"
+cd "$DIR"
+{binary} \\
+  --yolo \\
+  --model kimchi-dev/{model} \\
+{flags_block}  --session "$SESSION_FILE" \\
+  "{task_prompt}"
+"""
+        with open(script_path, "w") as f:
+            f.write(content)
+        os.chmod(script_path, os.stat(script_path).st_mode | stat.S_IXUSR | stat.S_IXGRP | stat.S_IXOTH)
+        all_scripts.append(script_path)
+
+# run-all.sh — iTerm2 grid (cols=tasks, rows=models) with background fallback
+run_all = os.path.join(session_dir, "run-all.sh")
+cols = len(tasks)
+rows = len(models)
+
+# Build AppleScript: create top row with vertical splits, then add rows with horizontal splits
+as_lines = ["      set g0_0 to current session"]
+for c in range(1, cols):
+    as_lines.append(f"      set g{c}_0 to (split vertically with default profile of g{c-1}_0)")
+for r in range(1, rows):
+    for c in range(cols):
+        as_lines.append(f"      set g{c}_{r} to (split horizontally with default profile of g{c}_{r-1})")
+for r in range(rows):
+    for c in range(cols):
+        i = r * cols + c
+        if i < len(all_scripts):
+            as_lines.append(f'      tell g{c}_{r} to write text "{all_scripts[i]}"')
+as_body = "\n".join(as_lines)
+
+# Background fallback: run each script with output to a per-script log file
+bg_lines = []
+for script in all_scripts:
+    name = os.path.basename(script).replace(".sh", "")
+    log = os.path.join(session_dir, f"{name}.log")
+    bg_lines.append(f'  "{script}" >"{log}" 2>&1 &')
+bg_body = "\n".join(bg_lines)
+
+with open(run_all, "w") as f:
+    f.write(f"""#!/bin/zsh
+if osascript -e 'id of application "iTerm2"' &>/dev/null 2>&1; then
+  osascript <<APPLESCRIPT
+tell application "iTerm2"
+  tell current window
+    tell current tab
+{as_body}
+    end tell
+  end tell
+end tell
+APPLESCRIPT
+else
+  echo "iTerm2 not available — running {len(all_scripts)} scripts in background (logs in {session_dir}/)..."
+{bg_body}
+  wait
+  echo "All done."
+fi
+""")
+os.chmod(run_all, os.stat(run_all).st_mode | stat.S_IXUSR | stat.S_IXGRP | stat.S_IXOTH)
+
+print(f"\nDone. {len(all_scripts)} scripts created in {session_dir}/")
+print(f"Next: {session_dir}/run-all.sh")
+PYEOF

--- a/benchmark/manual/session-summary.py
+++ b/benchmark/manual/session-summary.py
@@ -1,0 +1,95 @@
+#!/usr/bin/env python3
+"""Extract token usage summary from a kimchi session log."""
+
+import json
+import sys
+from datetime import datetime
+from pathlib import Path
+
+
+def format_duration(ms: int) -> str:
+    s = ms / 1000
+    if s < 60:
+        return f"{s:.1f}s"
+    m = int(s // 60)
+    rem = round(s % 60)
+    return f"{m}m {rem}s"
+
+
+def summarize(path: str):
+    orch_input = orch_output = 0
+    subagents = []
+    start_ts = end_ts = None
+
+    with open(path) as f:
+        for line in f:
+            line = line.strip()
+            if not line:
+                continue
+            try:
+                e = json.loads(line)
+            except json.JSONDecodeError:
+                continue
+
+            ts = e.get("timestamp")
+            if ts:
+                if start_ts is None:
+                    start_ts = ts
+                end_ts = ts
+
+            if e.get("type") != "message":
+                continue
+
+            msg = e.get("message", {})
+            role = msg.get("role", "")
+
+            if role == "assistant":
+                usage = msg.get("usage", {})
+                orch_input += usage.get("input", 0)
+                orch_output += usage.get("output", 0)
+
+            if role == "toolResult" and msg.get("toolName") == "subagent":
+                details = msg.get("details") or {}
+                tu = details.get("tokenUsage", {})
+                subagents.append({
+                    "model": None,
+                    "input": tu.get("input", 0),
+                    "output": tu.get("output", 0),
+                    "durationMs": details.get("durationMs", 0),
+                })
+
+    sub_input = sum(s["input"] for s in subagents)
+    sub_output = sum(s["output"] for s in subagents)
+    total_input = orch_input + sub_input
+    total_output = orch_output + sub_output
+
+    duration_ms = 0
+    if start_ts and end_ts:
+        t1 = datetime.fromisoformat(start_ts.replace("Z", "+00:00"))
+        t2 = datetime.fromisoformat(end_ts.replace("Z", "+00:00"))
+        duration_ms = int((t2 - t1).total_seconds() * 1000)
+
+    print(f"\nSession summary  ({format_duration(duration_ms)})")
+    print(f"  {'orchestrator':<16} ↑{orch_input:>10,}   ↓{orch_output:>8,}   total {orch_input+orch_output:>10,}")
+    if subagents:
+        print(f"  {'subagents':<16} ↑{sub_input:>10,}   ↓{sub_output:>8,}   total {sub_input+sub_output:>10,}")
+        for i, s in enumerate(subagents, 1):
+            dur = format_duration(s["durationMs"])
+            print(f"    [{i}] ↑{s['input']:>10,}   ↓{s['output']:>8,}   {dur}")
+    print(f"  {'total':<16} ↑{total_input:>10,}   ↓{total_output:>8,}   total {total_input+total_output:>10,}")
+
+
+if __name__ == "__main__":
+    if len(sys.argv) < 2:
+        # Find the most recent session log
+        sessions_dir = Path.home() / ".config/kimchi/harness/sessions"
+        logs = sorted(sessions_dir.rglob("*.jsonl"), key=lambda p: p.stat().st_mtime)
+        if not logs:
+            print("No session logs found")
+            sys.exit(1)
+        path = str(logs[-1])
+        print(f"Using: {path}")
+    else:
+        path = sys.argv[1]
+
+    summarize(path)

--- a/benchmark/manual/tasks.md
+++ b/benchmark/manual/tasks.md
@@ -1,0 +1,62 @@
+# Task Definitions
+
+Used across all sessions as consistent benchmarks.
+
+---
+
+## Task 1 — Simple coding: Go HTTP Rate Limiter Middleware
+
+**Prompt:**
+```
+Implement a Go HTTP middleware that rate-limits requests per client IP using a token bucket algorithm.
+Requirements:
+- Each IP gets 10 requests per second
+- Respond with HTTP 429 when limit is exceeded
+- Thread-safe implementation
+- Put the code in directory: rate-limiter/
+- Include a README.md explaining usage
+```
+
+**Expected:** single subagent, light/standard model, <5 min, tests included, no external deps.
+
+**Baseline (Claude):** token bucket via sync.Map + per-bucket mutex, cleanup goroutine, net.SplitHostPort for IP, map-based tests, no comments.
+
+---
+
+## Task 2 — Complex coding: Go REST API Task Management
+
+**Prompt:**
+```
+Implement a Go REST API for a task management system.
+Requirements:
+- Use standard library only (no frameworks, no external dependencies)
+- Layered architecture: handler -> service -> repository
+- In-memory repository
+- Endpoints: POST /tasks (create, fields: title+description), GET /tasks (list all), GET /tasks/{id} (get by id), PATCH /tasks/{id} (update status: todo/in-progress/done), DELETE /tasks/{id} (delete)
+- Proper HTTP status codes and JSON responses
+- Unit tests for the service layer using map-based test cases
+- Put all code in directory: task-api/
+```
+
+**Expected:** plan phase (heavy model) + implementation phase (standard model), <10 min, clean layer separation, map-based tests, stdlib only.
+
+**Baseline (Claude):** model.go, repository interface + in-memory impl, service with interface, handler with manual routing, atomic counter for IDs, map-based service tests, no external deps, no comments.
+
+---
+
+## Task 3 — Research query: Most popular Go HTTP router libraries
+
+**Prompt:**
+```
+What are the most popular third-party HTTP router libraries for Go?
+List the top 3 with: GitHub stars (approximate), key differentiators, and a one-line example of defining a route with a path parameter.
+```
+
+**Expected:** orchestrator answers directly without spawning subagents (it has web-search available), fast (<1 min), concise response, no code written.
+
+**Baseline (Claude):**
+1. **gorilla/mux** (~21k stars) — feature-rich, regex routes, middleware. `r.HandleFunc("/users/{id}", handler)`
+2. **go-chi/chi** (~18k stars) — lightweight, idiomatic, composable middleware. `r.Get("/users/{id}", handler)`
+3. **julienschmidt/httprouter** (~16k stars) — minimal, fastest, explicit method routing. `router.GET("/users/:id", handler)`
+
+---


### PR DESCRIPTION
## Summary

Adds a manual benchmark under `benchmark/manual/` that can be used for quick smoke-testing to verify the current implementation works end-to-end across a few representative scenarios.

- Three fixed tasks cover the main use cases: a simple single-agent coding task, a complex multi-agent coding task (both orchestrated and single-model modes), and a research/web-search query
- Each session is stored in a numbered directory (`sessions/session-NN/`) with one JSONL log per task × model run, making it easy to revisit, diff, or feed into an LLM for deeper investigation
- `analyze-session.py` parses token usage, subagent counts, and duration; flags runs that exceed expected budgets
- `compare-sessions.py` produces a side-by-side table so regressions between two sessions are immediately visible
- `new-session.sh` generates per-task run scripts for every configured model, including an iTerm2 `run-all.sh` to open all runs in parallel panes

## Test plan

- [x] Run `./new-session.sh` and confirm session directory and run scripts are created
- [x] Execute one or more run scripts and confirm JSONL output is produced
- [x] Run `python3 analyze-session.py` and confirm per-run metrics and quality checks are printed
- [x] Run `python3 compare-sessions.py` across two sessions and confirm the comparison table is correct

---
### Kimchi Summary
### What changed
Adds a manual benchmarking framework (`benchmark/manual/`) for smoke-testing the kimchi-dev AI coding orchestrator against three fixed tasks (Go HTTP rate limiter, REST API, and research query). The framework generates sequentially numbered sessions, creates run scripts for configured models, and provides analysis tools to track token usage, subagent counts, and execution duration across runs.

### Why
Enables systematic measurement of performance and quality regressions when iterating on the orchestrator logic or evaluating new models. Captures detailed metrics (orchestrator vs subagent token consumption, task duration, spawned subagent counts) with pass/warn/fail criteria for each benchmark task to ensure changes deliver measurable improvements.

### Key changes
- **`new-session.sh`** — Creates numbered sessions (e.g., `session-01`) with subdirectories and executable run scripts for every model × task combination defined in `benchmark.json`; includes `run-all.sh` with iTerm2 grid support
- **`benchmark.json`** — Configuration for the binary path and list of model IDs to benchmark (e.g., `kimi-k2.5`, `minimax-m2.7`)
- **`analyze-session.py`** — Parses JSONL session logs to calculate total tokens, orchestrator vs subagent breakdown, duration, and subagent counts; applies quality checks against task-specific budgets (e.g., `simple` task: <300k tokens, 1 subagent, <5 min)
- **`compare-sessions.py`** — Compares two sessions side-by-side showing token deltas (%), subagent count differences, and duration changes; auto-runs analysis if needed
- **`session-summary.py`** — Standalone CLI tool for quick token usage summaries from any kimchi session log file
- **`tasks.md`** — Specifications for the three benchmark tasks: `simple` (rate limiter middleware), `complex` (layered REST API), and `research` (Go HTTP router libraries), including expected subagent counts and token budgets
- **`README.md`** — Complete workflow documentation: setup, creating sessions, running benchmarks in parallel, analyzing results, and comparing sessions

### Impact
- **Additive only**: New `benchmark/manual/` directory with no modifications to existing application code
- **Git ignore**: `sessions/` directory is excluded from version control to avoid committing generated scripts and JSONL logs
- **Dependencies**: Requires Python 3 for analysis scripts; iTerm2 is optional for the grid layout feature (automatically falls back to background process execution)