### PR TITLE
LLM-1434: Use pi shutdown for exit to gracefully restore terminal settings

### DIFF
--- a/src/extensions/exit-utils.ts
+++ b/src/extensions/exit-utils.ts
@@ -1,22 +1,8 @@
 /**
  * Check if input is the bare "exit" alias (without leading slash).
- * When true, the input handler will immediately exit the process.
+ * When true, the input handler will trigger a graceful shutdown.
  */
 export function isBareExitAlias(text: string): boolean {
 	const trimmed = text.trim()
 	return trimmed === "exit"
-}
-
-/**
- * Quit the application immediately.
- * Centralized exit point for consistent behavior across all exit paths.
- *
- * Note: Immediate exit is safe here because:
- * 1. This is only called when the user explicitly types "exit" at the input prompt
- * 2. The agent is idle (no in-flight LLM calls or streaming responses)
- * 3. Synchronous cleanup via process.on("exit") handlers still runs
- * 4. Matches user expectation of immediate termination (like shell exit)
- */
-export function quitApplication(): never {
-	process.exit(0)
 }

--- a/src/extensions/ui.test.ts
+++ b/src/extensions/ui.test.ts
@@ -1,5 +1,5 @@
-import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
-import { isBareExitAlias, quitApplication } from "./exit-utils.js"
+import { describe, expect, it } from "vitest"
+import { isBareExitAlias } from "./exit-utils.js"
 
 describe("isBareExitAlias", () => {
 	it("returns true for exact 'exit' input", () => {
@@ -32,50 +32,5 @@ describe("isBareExitAlias", () => {
 		expect(isBareExitAlias("exit now")).toBe(false)
 		expect(isBareExitAlias("please exit")).toBe(false)
 		expect(isBareExitAlias("quit")).toBe(false)
-	})
-})
-
-describe("exit command behavior", () => {
-	// biome-ignore lint/suspicious/noExplicitAny: vi.spyOn types differ between vitest versions
-	let exitSpy: any
-
-	beforeEach(() => {
-		exitSpy = vi.spyOn(process, "exit").mockImplementation(() => undefined as never)
-	})
-
-	afterEach(() => {
-		exitSpy.mockRestore()
-	})
-
-	it("calls process.exit(0) when 'exit' is typed", () => {
-		// Simulate what the input handler does
-		if (isBareExitAlias("exit")) {
-			quitApplication()
-		}
-
-		expect(exitSpy).toHaveBeenCalledWith(0)
-	})
-
-	it("does not call process.exit for non-exit input", () => {
-		if (isBareExitAlias("hello")) {
-			quitApplication()
-		}
-
-		expect(exitSpy).not.toHaveBeenCalled()
-	})
-
-	it("does not call process.exit for '/exit' command", () => {
-		if (isBareExitAlias("/exit")) {
-			quitApplication()
-		}
-
-		expect(exitSpy).not.toHaveBeenCalled()
-	})
-
-	it("calls process.exit(0) via quitApplication for /exit command", async () => {
-		// Simulate what the command handler does
-		quitApplication()
-
-		expect(exitSpy).toHaveBeenCalledWith(0)
 	})
 })

--- a/src/extensions/ui.ts
+++ b/src/extensions/ui.ts
@@ -7,7 +7,7 @@ import { ScriptFooter, StatsFooter, buildScriptPayload, readStatusLineCommand } 
 import { LogoHeader } from "../components/logo.js"
 import { SplashHeader } from "../components/splash-header.js"
 import { collapseAll, expandNext, resetState } from "../expand-state.js"
-import { isBareExitAlias, quitApplication } from "./exit-utils.js"
+import { isBareExitAlias } from "./exit-utils.js"
 
 const HORIZONTAL_PADDING = 2
 
@@ -151,7 +151,7 @@ export default function uiExtension(pi: ExtensionAPI) {
 
 	pi.on("input", (event, ctx) => {
 		if (isBareExitAlias(event.text)) {
-			quitApplication()
+			ctx.shutdown()
 		}
 
 		if (!splashActive) return
@@ -187,8 +187,8 @@ export default function uiExtension(pi: ExtensionAPI) {
 
 	pi.registerCommand("exit", {
 		description: "Exit the application (alias for /quit)",
-		handler: async () => {
-			quitApplication()
+		handler: async (_args, ctx) => {
+			ctx.shutdown()
 		},
 	})
 }


### PR DESCRIPTION


---
### Kimchi Summary
### What changed
Replaced immediate process termination with graceful shutdown when users exit the application. Typing "exit" or using the `/exit` command now triggers `ctx.shutdown()` instead of calling `process.exit(0)` directly.

### Why
Immediate `process.exit()` terminates the process synchronously, potentially interrupting in-flight operations and bypassing async cleanup handlers. Using the framework's `ctx.shutdown()` ensures proper resource cleanup and graceful termination of active connections.

### Key changes
- **`src/extensions/exit-utils.ts`**: Removed `quitApplication()` function and updated documentation for `isBareExitAlias()` to reflect graceful shutdown behavior.
- **`src/extensions/ui.ts`**: Modified input handler and `/exit` command to invoke `ctx.shutdown()` instead of `quitApplication()`.
- **`src/extensions/ui.test.ts`**: Removed test suite verifying immediate `process.exit(0)` calls.

### Impact
Users may observe a brief delay when exiting as the application completes cleanup operations (flushing logs, closing connections) rather than terminating instantly. This aligns with standard graceful shutdown patterns and prevents data loss from interrupted async tasks.