### PR TITLE
NOJIRA: Suppress model response to continuation nudge from display

### DIFF
--- a/src/extensions/orchestration/continuation-nudge.test.ts
+++ b/src/extensions/orchestration/continuation-nudge.test.ts
@@ -1,6 +1,12 @@
 import type { AssistantMessage, UserMessage } from "@mariozechner/pi-ai"
 import { describe, expect, it } from "vitest"
-import { ContinuationNudge, EmptyTurnNudge, type OrchestratorMessages, stripStaleNudges } from "./continuation-nudge.js"
+import {
+	ContinuationNudge,
+	DONE_SIGNAL,
+	EmptyTurnNudge,
+	type OrchestratorMessages,
+	stripStaleNudges,
+} from "./continuation-nudge.js"
 
 function makeAssistant(content: AssistantMessage["content"]): AssistantMessage {
 	return {
@@ -145,6 +151,47 @@ describe("ContinuationNudge.evaluateTurn", () => {
 		guard.resetForNewUserInput()
 		const thinkingOnly = makeAssistant([{ type: "thinking", thinking: "Let me reason..." }])
 		expect(guard.evaluateTurn(thinkingOnly)).toBe(false)
+	})
+})
+
+describe("ContinuationNudge.isDoneSignalReceived", () => {
+	it("returns false when no response has been accumulated", () => {
+		const guard = new ContinuationNudge()
+		expect(guard.isDoneSignalReceived()).toBe(false)
+	})
+
+	it("returns true when accumulated text equals the done signal", () => {
+		const guard = new ContinuationNudge()
+		guard.accumulateResponse(DONE_SIGNAL)
+		expect(guard.isDoneSignalReceived()).toBe(true)
+	})
+
+	it("returns true when accumulated text equals done signal with surrounding whitespace", () => {
+		const guard = new ContinuationNudge()
+		guard.accumulateResponse("  ")
+		guard.accumulateResponse(DONE_SIGNAL)
+		guard.accumulateResponse("\n")
+		expect(guard.isDoneSignalReceived()).toBe(true)
+	})
+
+	it("returns false when accumulated text is not the done signal", () => {
+		const guard = new ContinuationNudge()
+		guard.accumulateResponse("I am done.")
+		expect(guard.isDoneSignalReceived()).toBe(false)
+	})
+
+	it("clears accumulated response on reset", () => {
+		const guard = new ContinuationNudge()
+		guard.accumulateResponse(DONE_SIGNAL)
+		guard.resetForNewUserInput()
+		expect(guard.isDoneSignalReceived()).toBe(false)
+	})
+
+	it("clears accumulated response when a tool call is recorded", () => {
+		const guard = new ContinuationNudge()
+		guard.accumulateResponse(DONE_SIGNAL)
+		guard.recordToolCall()
+		expect(guard.isDoneSignalReceived()).toBe(false)
 	})
 })
 

--- a/src/extensions/orchestration/continuation-nudge.test.ts
+++ b/src/extensions/orchestration/continuation-nudge.test.ts
@@ -114,6 +114,32 @@ describe("ContinuationNudge.evaluateTurn", () => {
 		expect(guard.evaluateTurn(textOnlyMessage)).toBe(true)
 	})
 
+	it("sets nudge response pending after nudging", () => {
+		const guard = new ContinuationNudge()
+		guard.resetForNewUserInput()
+		expect(guard.isNudgeResponsePending()).toBe(false)
+		guard.evaluateTurn(textOnlyMessage)
+		expect(guard.isNudgeResponsePending()).toBe(true)
+	})
+
+	it("clears nudge response pending when a tool call is recorded", () => {
+		const guard = new ContinuationNudge()
+		guard.resetForNewUserInput()
+		guard.evaluateTurn(textOnlyMessage)
+		expect(guard.isNudgeResponsePending()).toBe(true)
+		guard.recordToolCall()
+		expect(guard.isNudgeResponsePending()).toBe(false)
+	})
+
+	it("clears nudge response pending on reset", () => {
+		const guard = new ContinuationNudge()
+		guard.resetForNewUserInput()
+		guard.evaluateTurn(textOnlyMessage)
+		expect(guard.isNudgeResponsePending()).toBe(true)
+		guard.resetForNewUserInput()
+		expect(guard.isNudgeResponsePending()).toBe(false)
+	})
+
 	it("ignores thinking-only turns (no text, no tool call)", () => {
 		const guard = new ContinuationNudge()
 		guard.resetForNewUserInput()

--- a/src/extensions/orchestration/continuation-nudge.ts
+++ b/src/extensions/orchestration/continuation-nudge.ts
@@ -35,7 +35,7 @@ import type { ContextEvent } from "@mariozechner/pi-coding-agent"
 export type OrchestratorMessages = ContextEvent["messages"]
 
 export const CONTINUATION_NUDGE_TEXT =
-	"You ended your turn without calling a tool. If the task is complete, reply with a brief summary. Otherwise, call the appropriate tool now — for any delegated pipeline step, that means invoking the `subagent` tool immediately."
+	"You ended your turn without calling a tool. Did this task actually require a tool call? If not, end your turn now with NO output. If yes, call the appropriate tool immediately."
 
 export const EMPTY_TURN_NUDGE_TEXT =
 	"If you have finished, please summarize the result for the user. Otherwise, continue with the next tool call."
@@ -50,14 +50,21 @@ export const EMPTY_TURN_NUDGE_TEXT =
 export class ContinuationNudge {
 	private toolsCalledSinceLastUserInput = false
 	private nudgedSinceLastUserInput = false
+	private nudgeResponsePending = false
 
 	resetForNewUserInput(): void {
 		this.toolsCalledSinceLastUserInput = false
 		this.nudgedSinceLastUserInput = false
+		this.nudgeResponsePending = false
 	}
 
 	recordToolCall(): void {
 		this.toolsCalledSinceLastUserInput = true
+		this.nudgeResponsePending = false
+	}
+
+	isNudgeResponsePending(): boolean {
+		return this.nudgeResponsePending
 	}
 
 	evaluateTurn(message: AssistantMessage): boolean {
@@ -67,6 +74,7 @@ export class ContinuationNudge {
 		const hasText = message.content.some((c) => c.type === "text" && c.text.trim().length > 0)
 		if (hasToolCalls || !hasText) return false
 		this.nudgedSinceLastUserInput = true
+		this.nudgeResponsePending = true
 		return true
 	}
 }

--- a/src/extensions/orchestration/continuation-nudge.ts
+++ b/src/extensions/orchestration/continuation-nudge.ts
@@ -35,7 +35,7 @@ import type { ContextEvent } from "@mariozechner/pi-coding-agent"
 export type OrchestratorMessages = ContextEvent["messages"]
 
 export const CONTINUATION_NUDGE_TEXT =
-	"You ended your turn without calling a tool. Did this task actually require a tool call? If not, end your turn now with NO output. If yes, call the appropriate tool immediately."
+	"You ended your turn without calling a tool. If this task is complete, respond with <done>. If a tool call is still needed, call it now."
 
 export const EMPTY_TURN_NUDGE_TEXT =
 	"If you have finished, please summarize the result for the user. Otherwise, continue with the next tool call."

--- a/src/extensions/orchestration/continuation-nudge.ts
+++ b/src/extensions/orchestration/continuation-nudge.ts
@@ -34,8 +34,9 @@ import type { ContextEvent } from "@mariozechner/pi-coding-agent"
  */
 export type OrchestratorMessages = ContextEvent["messages"]
 
-export const CONTINUATION_NUDGE_TEXT =
-	"You ended your turn without calling a tool. If this task is complete, respond with <done>. If a tool call is still needed, call it now."
+export const DONE_SIGNAL = "<done>"
+
+export const CONTINUATION_NUDGE_TEXT = `You ended your turn without calling a tool. If this task is complete, respond with ${DONE_SIGNAL}. If a tool call is still needed, call it now.`
 
 export const EMPTY_TURN_NUDGE_TEXT =
 	"If you have finished, please summarize the result for the user. Otherwise, continue with the next tool call."
@@ -51,20 +52,31 @@ export class ContinuationNudge {
 	private toolsCalledSinceLastUserInput = false
 	private nudgedSinceLastUserInput = false
 	private nudgeResponsePending = false
+	private accumulatedResponseText = ""
 
 	resetForNewUserInput(): void {
 		this.toolsCalledSinceLastUserInput = false
 		this.nudgedSinceLastUserInput = false
 		this.nudgeResponsePending = false
+		this.accumulatedResponseText = ""
 	}
 
 	recordToolCall(): void {
 		this.toolsCalledSinceLastUserInput = true
 		this.nudgeResponsePending = false
+		this.accumulatedResponseText = ""
 	}
 
 	isNudgeResponsePending(): boolean {
 		return this.nudgeResponsePending
+	}
+
+	accumulateResponse(text: string): void {
+		this.accumulatedResponseText += text
+	}
+
+	isDoneSignalReceived(): boolean {
+		return this.accumulatedResponseText.trim() === DONE_SIGNAL
 	}
 
 	evaluateTurn(message: AssistantMessage): boolean {

--- a/src/extensions/orchestration/prompt-enrichment.ts
+++ b/src/extensions/orchestration/prompt-enrichment.ts
@@ -173,12 +173,19 @@ export default function (skillPaths: string[]) {
 				const message = event.message as AssistantMessage
 				const content = message.content[ame.contentIndex]
 				if (content?.type === "text") {
+					continuationNudge.accumulateResponse(content.text)
 					content.text = ""
 				}
 			})
 
 			pi.on("turn_end", async (event) => {
 				if (event.message.role !== "assistant") return
+
+				if (continuationNudge.isNudgeResponsePending()) {
+					if (continuationNudge.isDoneSignalReceived()) {
+						return
+					}
+				}
 
 				if (emptyTurnNudge.evaluateTurn(event.message)) {
 					pi.sendMessage(

--- a/src/extensions/orchestration/prompt-enrichment.ts
+++ b/src/extensions/orchestration/prompt-enrichment.ts
@@ -24,7 +24,7 @@ import { execSync } from "node:child_process"
 import { existsSync } from "node:fs"
 import { homedir, platform, userInfo } from "node:os"
 import { isAbsolute, join, normalize, resolve } from "node:path"
-import type { ImageContent, TextContent } from "@mariozechner/pi-ai"
+import type { AssistantMessage, ImageContent, TextContent } from "@mariozechner/pi-ai"
 import { type ExtensionAPI, type Skill, loadSkills } from "@mariozechner/pi-coding-agent"
 import { ANSI, fg } from "../../ansi.js"
 import { getAvailableModels } from "../../startup-context.js"
@@ -164,6 +164,17 @@ export default function (skillPaths: string[]) {
 
 			pi.on("tool_execution_start", async () => {
 				continuationNudge.recordToolCall()
+			})
+
+			pi.on("message_update", (event) => {
+				if (!continuationNudge.isNudgeResponsePending()) return
+				const ame = event.assistantMessageEvent
+				if (ame.type !== "text_delta") return
+				const message = event.message as AssistantMessage
+				const content = message.content[ame.contentIndex]
+				if (content?.type === "text") {
+					content.text = ""
+				}
 			})
 
 			pi.on("turn_end", async (event) => {


### PR DESCRIPTION
## What

When a user sends a conversational message (e.g. a greeting), the orchestrator replies correctly but then a continuation nudge fires because no tool was called. The model's response to that nudge — whether an empty response wrapped by the API proxy or a brief meta-comment like \"No tool call needed\" — was always displayed, producing a duplicate visible reply.

## Fix

- Added `nudgeResponsePending` flag to `ContinuationNudge`, set when a nudge fires
- A new `message_update` handler in `prompt-enrichment.ts` zeroes out streamed text while the flag is active, so the nudge response never renders
- The flag clears on the next tool call (ensuring post-tool summaries still display normally) or on the next user input
- Updated nudge wording to ask the model to self-assess whether a tool call was needed, rather than unconditionally demanding one

---
### Kimchi Summary
### What changed
Implements detection and suppression of continuation nudge responses when the assistant signals task completion. When the AI responds to a continuation nudge with only the `<done>` signal, the response is hidden from the user display while allowing the orchestrator to recognize that no further tool calls are needed.

### Why
Prevents visual noise in the UI by filtering out perfunctory "task complete" acknowledgments that the AI generates in response to continuation prompts, while maintaining the ability to detect when a task is genuinely finished.

### Key changes
- **`src/extensions/orchestration/continuation-nudge.ts`**: Added `DONE_SIGNAL` constant (`"<done>"`), `nudgeResponsePending` state tracking, `accumulateResponse()` method, and `isDoneSignalReceived()` check to detect completion signals.
- **`src/extensions/orchestration/prompt-enrichment.ts`**: Added `"message_update"` handler to suppress text display for pending nudge responses and accumulate response content; modified `"turn_end"` handler to skip empty-turn nudging when the done signal is detected.
- **`src/extensions/orchestration/continuation-nudge.test.ts`**: Added test coverage for nudge response pending state, done signal detection, and reset behaviors.

### Impact
- **Behavioral change**: Assistant messages containing only the `<done>` signal in response to continuation nudges will no longer appear in the conversation history displayed to users.
- **Prompt update**: The `CONTINUATION_NUDGE_TEXT` guidance now instructs the model to respond with `<done>` when tasks are complete rather than providing a summary.