### PR TITLE
Draft: LLM-1292: Implement /stats command

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,6 @@ Thumbs.db
 
 # Test coverage
 coverage/
+
+# Kimchi docs directory
+.kimchi/

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -25,6 +25,7 @@ import permissionsExtension from "./extensions/permissions/index.js"
 import { reserveShiftTabForPermissions } from "./extensions/permissions/keybindings.js"
 import promptSummaryExtension from "./extensions/prompt-summary.js"
 import shutdownMarkerExtension from "./extensions/shutdown-marker.js"
+import statsExtension from "./extensions/stats/index.js"
 import subagentExtension from "./extensions/subagent.js"
 import tagsExtension from "./extensions/tags.js"
 import telemetryExtension from "./extensions/telemetry.js"
@@ -221,6 +222,7 @@ try {
 			sessionIdCaptureExtension,
 			outputFilterExtension,
 			shutdownMarkerExtension,
+			statsExtension,
 			terminalColorsExtension,
 			kimchiMinimalTintsExtension,
 			bashCollapseExtension,

--- a/src/extensions/stats/api.ts
+++ b/src/extensions/stats/api.ts
@@ -1,0 +1,222 @@
+/**
+ * Cast AI Analytics API Client
+ *
+ * Fetches analytics, productivity metrics, and timeseries data from Cast AI.
+ */
+
+import type {
+	GenerateAnalyticsRequest,
+	GenerateAnalyticsResponse,
+	GenerateProductivityMetricsTimeseriesRequest,
+	GenerateProductivityMetricsTimeseriesResponse,
+	GetProductivityMetricsRequest,
+	GetProductivityMetricsResponse,
+} from "./types.js"
+
+const BASE_URL = "https://api.cast.ai"
+
+// Hardcoded user ID as specified in requirements
+const HARDCODED_USER_ID = "d1c79c82-c230-4b19-9def-dbe49bf63368"
+
+// Hardcoded organization ID - needed for some endpoints
+const FALLBACK_ORG_ID = "516442fe-054a-49e2-ac2d-9dc9b104c3d2"
+
+interface ApiClientConfig {
+	apiKey: string
+	baseUrl?: string
+	userId?: string
+	organizationId?: string
+}
+
+export class CastAiStatsApi {
+	private apiKey: string
+	private baseUrl: string
+	private userId: string
+	private organizationId: string
+
+	constructor(config: ApiClientConfig) {
+		this.apiKey = config.apiKey
+		this.baseUrl = config.baseUrl ?? BASE_URL
+		this.userId = config.userId ?? HARDCODED_USER_ID
+		this.organizationId = config.organizationId ?? FALLBACK_ORG_ID
+	}
+
+	/**
+	 * Make an authenticated API request to Cast AI
+	 */
+	private async request<T>(path: string, options: RequestInit = {}): Promise<T> {
+		const url = `${this.baseUrl}${path}`
+		const headers = new Headers(options.headers)
+		headers.set("Authorization", `Bearer ${this.apiKey}`)
+		headers.set("Content-Type", "application/json")
+		headers.set("Accept", "application/json")
+
+		const response = await fetch(url, {
+			...options,
+			headers,
+		})
+
+		if (!response.ok) {
+			const errorText = await response.text().catch(() => "Unknown error")
+			throw new Error(`Kimchi API error (${response.status}): ${errorText}`)
+		}
+
+		return response.json() as Promise<T>
+	}
+
+	/**
+	 * Generates analytics data for the organization.
+	 * Endpoint: GET /ai-optimizer/v1beta/organizations/{id}:generateAnalyticsReport
+	 *
+	 * Note: This endpoint requires an organization ID. It supports filtering by castai_api_key_owner_id.
+	 */
+	async generateAnalytics(startTime: Date, endTime: Date, organizationId?: string): Promise<GenerateAnalyticsResponse> {
+		const orgId = organizationId ?? this.organizationId
+
+		// Build filter for user - uses CEL expression
+		// Filter format: castai_api_key_owner_id == "user-id"
+		const filter = `castai_api_key_owner_id == "${this.userId}"`
+
+		const params = new URLSearchParams({
+			startTime: startTime.toISOString(),
+			endTime: endTime.toISOString(),
+			filter: filter,
+		})
+
+		return this.request<GenerateAnalyticsResponse>(
+			`/ai-optimizer/v1beta/organizations/${orgId}:generateAnalyticsReport?${params.toString()}`,
+		)
+	}
+
+	/**
+	 * Gets aggregated productivity metrics.
+	 * Endpoint: GET /ai-optimizer/v1beta/productivity-metrics
+	 *
+	 * Note: Supports user_id filtering.
+	 */
+	async getProductivityMetrics(
+		startTime: Date,
+		endTime: Date,
+		options: {
+			metricNames?: string[]
+			sessionId?: string
+			providerName?: string
+		} = {},
+	): Promise<GetProductivityMetricsResponse> {
+		const params = new URLSearchParams({
+			from: startTime.toISOString(),
+			to: endTime.toISOString(),
+		})
+
+		// NOTE: Not filtering by user_id for productivity metrics - shows all org data
+		// Analytics endpoint still filters by user via CEL expression
+
+		// Optional provider filter
+		if (options.providerName) {
+			params.set("provider_name", options.providerName)
+		}
+
+		if (options.metricNames?.length) {
+			for (const name of options.metricNames) {
+				params.append("metric_names", name)
+			}
+		}
+
+		if (options.sessionId) {
+			params.set("session_id", options.sessionId)
+		}
+
+		return this.request<GetProductivityMetricsResponse>(
+			`/ai-optimizer/v1beta/productivity-metrics?${params.toString()}`,
+		)
+	}
+
+	/**
+	 * Generates productivity metrics as time series data points.
+	 * Endpoint: GET /ai-optimizer/v1beta/organizations/{organization_id}/productivity-metrics:generateTimeseries
+	 *
+	 * Note: This endpoint requires an organization ID. Supports user_id filtering.
+	 */
+	async generateProductivityMetricsTimeseries(
+		startTime: Date,
+		endTime: Date,
+		organizationId?: string,
+		options: {
+			metricNames?: string[]
+			sessionId?: string
+			providerName?: string
+		} = {},
+	): Promise<GenerateProductivityMetricsTimeseriesResponse> {
+		const orgId = organizationId ?? this.organizationId
+
+		const params = new URLSearchParams({
+			from: startTime.toISOString(),
+			to: endTime.toISOString(),
+		})
+
+		// Note: Productivity timeseries is org-wide data (no user filter)
+		// No provider_name filter - show all providers (claude-code-otel, opencode-otel)
+
+		if (options.metricNames?.length) {
+			for (const name of options.metricNames) {
+				params.append("metric_names", name)
+			}
+		}
+
+		if (options.sessionId) {
+			params.set("session_id", options.sessionId)
+		}
+
+		return this.request<GenerateProductivityMetricsTimeseriesResponse>(
+			`/ai-optimizer/v1beta/organizations/${orgId}/productivity-metrics:generateTimeseries?${params.toString()}`,
+		)
+	}
+
+	/**
+	 * Get the hardcoded user ID being used
+	 */
+	getUserId(): string {
+		return this.userId
+	}
+
+	/**
+	 * Get the organization ID being used
+	 */
+	getOrganizationId(): string {
+		return this.organizationId
+	}
+
+	/**
+	 * Set a different organization ID
+	 */
+	setOrganizationId(orgId: string): void {
+		this.organizationId = orgId
+	}
+}
+
+/**
+ * Create a stats API client with the given API key
+ */
+export function createStatsClient(config: ApiClientConfig): CastAiStatsApi {
+	return new CastAiStatsApi(config)
+}
+
+/**
+ * Get default time range for stats queries (last 30 days)
+ */
+export function getDefaultTimeRange(): { startTime: Date; endTime: Date } {
+	const endTime = new Date()
+	const startTime = new Date()
+	startTime.setDate(startTime.getDate() - 30)
+	return { startTime, endTime }
+}
+
+/**
+ * Get time range for stats queries (last N days)
+ */
+export function getTimeRange(days: number): { startTime: Date; endTime: Date } {
+	const endTime = new Date()
+	const startTime = new Date()
+	startTime.setDate(startTime.getDate() - days)
+	return { startTime, endTime }
+}

--- a/src/extensions/stats/display.ts
+++ b/src/extensions/stats/display.ts
@@ -1,0 +1,228 @@
+/**
+ * Terminal display formatting for stats data
+ */
+
+import type { Theme } from "@mariozechner/pi-coding-agent"
+import { formatCount } from "../format.js"
+import type { GenerateAnalyticsResponse, GetProductivityMetricsResponse } from "./types.js"
+
+function formatCurrency(amount: string | number): string {
+	const num = typeof amount === "string" ? Number.parseFloat(amount) : amount
+	if (Number.isNaN(num)) return "$0.00"
+	return `$${num.toFixed(2)}`
+}
+
+function formatChangeIndicator(change: number, theme: Theme): string {
+	if (change > 0) {
+		return theme.fg("error", `+${change.toFixed(1)}%`)
+	}
+	if (change < 0) {
+		return theme.fg("success", `${change.toFixed(1)}%`)
+	}
+	return theme.fg("dim", "0%")
+}
+
+function formatDuration(seconds: number): string {
+	const hours = Math.floor(seconds / 3600)
+	const mins = Math.floor((seconds % 3600) / 60)
+	if (hours > 0) {
+		return `${hours}h ${mins}m`
+	}
+	return `${mins}m`
+}
+
+export function formatAnalyticsSummary(data: GenerateAnalyticsResponse, theme: Theme): string[] {
+	const lines: string[] = []
+
+	lines.push("")
+	lines.push(theme.bold(theme.fg("accent", "📊 Analytics (Last 30 Days)")))
+
+	// Token usage section
+	let totalInput = 0
+	let totalOutput = 0
+
+	if (data.inputTokens?.items) {
+		for (const item of data.inputTokens.items) {
+			if (item.models) {
+				for (const model of item.models) {
+					totalInput += model.totalCount || 0
+				}
+			}
+		}
+	}
+
+	if (data.outputTokens?.items) {
+		for (const item of data.outputTokens.items) {
+			if (item.models) {
+				for (const model of item.models) {
+					totalOutput += model.totalCount || 0
+				}
+			}
+		}
+	}
+
+	const total = totalInput + totalOutput
+
+	// Cost section
+	let totalCost = 0
+	if (data.cost?.items) {
+		for (const item of data.cost.items) {
+			if (item.models) {
+				for (const model of item.models) {
+					totalCost += Number.parseFloat(model.totalCost || "0")
+				}
+			}
+		}
+	}
+
+	// API calls section
+	let totalCalls = 0
+	if (data.apiCalls?.items) {
+		for (const item of data.apiCalls.items) {
+			if (item.models) {
+				totalCalls += item.models.length
+			}
+		}
+	}
+
+	// Main stats line with breakdown
+	const mainParts: string[] = []
+	if (total > 0) {
+		const tokenPart = `${theme.fg("accent", formatCount(total))} (${formatCount(totalInput)}⇣ ${formatCount(totalOutput)}⇡)`
+		mainParts.push(`${theme.bold("Tokens:")} ${tokenPart}`)
+	}
+	if (totalCost > 0) mainParts.push(`${theme.bold("Cost:")} ${theme.fg("accent", formatCurrency(totalCost))}`)
+	if (totalCalls > 0) mainParts.push(`${theme.bold("Calls:")} ${theme.fg("accent", formatCount(totalCalls))}`)
+
+	if (mainParts.length > 0) {
+		lines.push(`  ${mainParts.join("  ")}`)
+	}
+
+	// Change indicators line
+	const changeParts: string[] = []
+	if (data.comparison?.inputTokens?.changePercentage !== undefined) {
+		changeParts.push(`in: ${formatChangeIndicator(data.comparison.inputTokens.changePercentage, theme)}`)
+	}
+	if (data.comparison?.outputTokens?.changePercentage !== undefined) {
+		changeParts.push(`out: ${formatChangeIndicator(data.comparison.outputTokens.changePercentage, theme)}`)
+	}
+	if (data.comparison?.cost?.changePercentage !== undefined) {
+		changeParts.push(`cost: ${formatChangeIndicator(data.comparison.cost.changePercentage, theme)}`)
+	}
+	if (data.comparison?.apiCalls?.changePercentage !== undefined) {
+		changeParts.push(`calls: ${formatChangeIndicator(data.comparison.apiCalls.changePercentage, theme)}`)
+	}
+	if (changeParts.length > 0) {
+		lines.push(`  ${theme.bold("Change:")} ${changeParts.join("  ")}`)
+	}
+
+	// Model breakdown
+	const modelCosts = new Map<string, number>()
+	if (data.cost?.items) {
+		for (const item of data.cost.items) {
+			if (item.models) {
+				for (const model of item.models) {
+					const cost = Number.parseFloat(model.totalCost || "0")
+					if (cost > 0) {
+						const existing = modelCosts.get(model.model) || 0
+						modelCosts.set(model.model, existing + cost)
+					}
+				}
+			}
+		}
+	}
+
+	if (modelCosts.size > 0) {
+		const sortedModels = Array.from(modelCosts.entries())
+			.sort((a, b) => b[1] - a[1])
+			.slice(0, 5)
+		const modelParts = sortedModels.map(([model, cost]) => `${model}: ${theme.fg("accent", formatCurrency(cost))}`)
+		lines.push(`  ${theme.bold("Models:")} ${modelParts.join(", ")}`)
+	}
+
+	if (data.mostRecentTime) {
+		const recentDate = new Date(data.mostRecentTime)
+		lines.push(theme.fg("dim", `  Last: ${recentDate.toLocaleDateString()}`))
+	}
+
+	return lines
+}
+
+export function formatProductivitySummary(data: GetProductivityMetricsResponse, theme: Theme): string[] {
+	const lines: string[] = []
+
+	lines.push("")
+	lines.push(theme.bold(theme.fg("accent", "🚀 Productivity (Last 30 Days)")))
+
+	if (!data.items?.length) {
+		lines.push(theme.fg("dim", "  No data"))
+		return lines
+	}
+
+	for (const item of data.items) {
+		// Provider name as header
+		if (item.providerName) {
+			lines.push(`  ${theme.fg("accent", item.providerName)}`)
+		}
+
+		// Row 1: Sessions and duration stats
+		if (item.sessionStats) {
+			const stats = item.sessionStats
+			const sessionParts: string[] = []
+			sessionParts.push(`${theme.bold("Sessions:")} ${stats.totalSessions}`)
+			sessionParts.push(`${formatDuration(stats.totalDurationSeconds)} total`)
+			sessionParts.push(`${formatDuration(stats.durationP50Seconds)} median`)
+			lines.push(`    ${sessionParts.join("  ")}`)
+		}
+
+		// Row 2: Activity metrics
+		if (item.comparison) {
+			const comp = item.comparison
+			const activityParts: string[] = []
+			if (comp.linesOfCode?.value) activityParts.push(`${theme.bold("LoC:")} ${formatCount(comp.linesOfCode.value)}`)
+			if (comp.commits?.value) activityParts.push(`${theme.bold("Commits:")} ${formatCount(comp.commits.value)}`)
+			if (comp.pullRequests?.value) activityParts.push(`${theme.bold("PRs:")} ${formatCount(comp.pullRequests.value)}`)
+			if (comp.toolUsage?.value) activityParts.push(`${theme.bold("Tools:")} ${formatCount(comp.toolUsage.value)}`)
+			if (activityParts.length > 0) {
+				lines.push(`    ${activityParts.join("  ")}`)
+			}
+
+			// Row 3: Usage metrics
+			const usageParts: string[] = []
+			if (comp.tokens?.value) usageParts.push(`${theme.bold("Tokens:")} ${formatCount(comp.tokens.value)}`)
+			if (comp.cost?.value) usageParts.push(`${theme.bold("Cost:")} ${formatCurrency(comp.cost.value)}`)
+			if (usageParts.length > 0) {
+				lines.push(`    ${usageParts.join("  ")}`)
+			}
+		}
+
+		// Row 4: Additional metric summaries
+		if (item.summaries?.length) {
+			const summaryParts = item.summaries.slice(0, 5).map((s) => {
+				const shortName = s.metricName?.replace(/claude_code\./, "").replace(/_/g, " ") ?? ""
+				return `${shortName}: ${formatCount(s.totalValue)}`
+			})
+			if (summaryParts.length > 0) {
+				lines.push(`    ${theme.fg("dim", summaryParts.join("  "))}`)
+			}
+		}
+	}
+
+	return lines
+}
+
+export function formatError(message: string, theme: Theme): string[] {
+	return ["", theme.fg("error", `Error: ${message}`), ""]
+}
+
+export function formatHelp(theme: Theme): string[] {
+	return [
+		"",
+		theme.bold("Stats Command Usage"),
+		"",
+		"  /stats                    Show analytics and productivity metrics (last 30 days)",
+		"  /stats 7                  Show metrics for last 7 days (1-30 days supported)",
+		"  /stats help               Show this help message",
+		"",
+	]
+}

--- a/src/extensions/stats/index.ts
+++ b/src/extensions/stats/index.ts
@@ -1,0 +1,150 @@
+/**
+ * Stats Extension
+ *
+ * Provides /stats command to view Cast AI analytics directly in the TUI.
+ * Fetches data from:
+ * - Analytics API (generateAnalyticsReport)
+ * - Productivity Metrics API (getProductivityMetrics)
+ */
+
+import type { ExtensionAPI, ExtensionCommandContext } from "@mariozechner/pi-coding-agent"
+import { exitSplashMode } from "../ui.js"
+import { CastAiStatsApi, getTimeRange } from "./api.js"
+import { formatError, formatHelp } from "./display.js"
+import { formatAnalyticsVisual, formatProductivityVisual } from "./visual.js"
+
+// API key used for Cast AI API requests
+const DEFAULT_API_KEY = "c7b7ea88b9c92c21d2487634e62884aa5d167fb188be676a30fe99639b3a81b1"
+
+// Hardcoded user ID as specified
+const HARDCODED_USER_ID = "d1c79c82-c230-4b19-9def-dbe49bf63368"
+
+// Organization ID - provided by user
+const ORGANIZATION_ID = "516442fe-054a-49e2-ac2d-9dc9b104c3d2"
+
+interface StatsConfig {
+	apiKey: string
+	userId: string
+	organizationId: string
+}
+
+function getStatsConfig(): StatsConfig {
+	const envKey = process.env.CASTAI_API_KEY
+	const envOrg = process.env.CASTAI_ORG_ID
+
+	return {
+		apiKey: envKey || DEFAULT_API_KEY,
+		userId: HARDCODED_USER_ID,
+		organizationId: envOrg || ORGANIZATION_ID,
+	}
+}
+
+function createApiClient(): CastAiStatsApi {
+	const config = getStatsConfig()
+	return new CastAiStatsApi({
+		apiKey: config.apiKey,
+		userId: config.userId,
+		organizationId: config.organizationId,
+	})
+}
+
+async function handleStatsCommand(args: string, ctx: ExtensionCommandContext): Promise<void> {
+	if (!ctx.hasUI) {
+		return
+	}
+
+	const trimmed = args.trim().toLowerCase()
+
+	// Exit splash mode and switch to chat view (do this early for all commands)
+	exitSplashMode(ctx)
+
+	// Show help if requested
+	if (trimmed === "help" || trimmed === "--help" || trimmed === "-h") {
+		const helpLines = formatHelp(ctx.ui.theme)
+		ctx.ui.notify(helpLines.join("\n"), "info")
+		return
+	}
+
+	// Parse number of days (e.g., "/stats 7" for last 7 days)
+	let days = 30 // default
+	if (trimmed) {
+		const parsedDays = Number.parseInt(trimmed, 10)
+		if (!Number.isNaN(parsedDays) && parsedDays > 0 && parsedDays <= 365) {
+			days = parsedDays
+		}
+	}
+
+	const api = createApiClient()
+	const { startTime, endTime } = getTimeRange(days)
+
+	// Show loading indicator while fetching data
+	ctx.ui.notify(`Fetching stats for last ${days} days...`, "info")
+
+	try {
+		const outputLines: string[] = []
+		const terminalWidth = process.stdout.columns ?? 100
+
+		// Fetch analytics data
+		try {
+			const analytics = await api.generateAnalytics(startTime, endTime)
+			const hasTokenData = analytics.inputTokens?.items?.length || analytics.outputTokens?.items?.length
+			const hasCostData = analytics.cost?.items?.length
+			const hasApiCalls = analytics.apiCalls?.items?.length
+
+			if (!hasTokenData && !hasCostData && !hasApiCalls) {
+				outputLines.push("", ctx.ui.theme.fg("dim", "No analytics data found for the selected period."), "")
+			} else {
+				const analyticsLines = formatAnalyticsVisual(analytics, ctx.ui.theme, terminalWidth, days)
+				outputLines.push(...analyticsLines)
+			}
+		} catch (err) {
+			const msg = err instanceof Error ? err.message : String(err)
+			if (msg.includes("404") || msg.includes("organization")) {
+				outputLines.push(
+					...formatError(
+						"Analytics endpoint requires a valid organization ID. " +
+							"Set CASTAI_ORG_ID environment variable if needed.",
+						ctx.ui.theme,
+					),
+				)
+			} else {
+				outputLines.push(...formatError(`Analytics API: ${msg}`, ctx.ui.theme))
+			}
+		}
+
+		// Fetch productivity metrics
+		try {
+			const productivity = await api.getProductivityMetrics(startTime, endTime)
+			const hasItems = productivity.items?.length && productivity.items.length > 0
+
+			if (!hasItems) {
+				outputLines.push("", ctx.ui.theme.fg("dim", "No productivity data found for the selected period."), "")
+			} else {
+				const productivityLines = formatProductivityVisual(productivity, ctx.ui.theme, terminalWidth, days)
+				outputLines.push(...productivityLines)
+			}
+		} catch (err) {
+			const msg = err instanceof Error ? err.message : String(err)
+			outputLines.push(...formatError(`Productivity API: ${msg}`, ctx.ui.theme))
+		}
+
+		// Display all collected output
+		if (outputLines.length > 0) {
+			ctx.ui.notify(outputLines.join("\n"), "info")
+		} else {
+			ctx.ui.notify("No data available", "info")
+		}
+	} catch (err) {
+		const message = err instanceof Error ? err.message : String(err)
+		ctx.ui.notify(formatError(message, ctx.ui.theme).join("\n"), "error")
+	}
+}
+
+export default function statsExtension(pi: ExtensionAPI) {
+	pi.registerCommand("stats", {
+		description: "View coding analytics and metrics (/stats 7 for last 7 days)",
+		handler: async (args: string, ctx: ExtensionCommandContext) => {
+			await handleStatsCommand(args, ctx)
+		},
+	})
+}

--- a/src/extensions/stats/stats.test.ts
+++ b/src/extensions/stats/stats.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from "vitest"
-import { getTimeRange } from "./api.js"
 import { formatCount } from "../format.js"
-import { getProviderDisplayName, formatCurrency } from "./visual.js"
+import { getTimeRange } from "./api.js"
+import { formatCurrency, getProviderDisplayName } from "./visual.js"
 
 describe("getTimeRange", () => {
 	it("returns correct time range for 30 days", () => {
@@ -55,7 +55,7 @@ describe("formatCurrency", () => {
 
 	it("handles invalid input", () => {
 		expect(formatCurrency("invalid")).toBe("$0.00")
-		expect(formatCurrency(NaN)).toBe("$0.00")
+		expect(formatCurrency(Number.NaN)).toBe("$0.00")
 	})
 })
 

--- a/src/extensions/stats/stats.test.ts
+++ b/src/extensions/stats/stats.test.ts
@@ -1,0 +1,82 @@
+import { describe, expect, it } from "vitest"
+import { getTimeRange } from "./api.js"
+import { formatCount } from "../format.js"
+import { getProviderDisplayName, formatCurrency } from "./visual.js"
+
+describe("getTimeRange", () => {
+	it("returns correct time range for 30 days", () => {
+		const { startTime, endTime } = getTimeRange(30)
+		const diffMs = endTime.getTime() - startTime.getTime()
+		const diffDays = diffMs / (1000 * 60 * 60 * 24)
+		expect(diffDays).toBeCloseTo(30, 0)
+	})
+
+	it("returns correct time range for 7 days", () => {
+		const { startTime, endTime } = getTimeRange(7)
+		const diffMs = endTime.getTime() - startTime.getTime()
+		const diffDays = diffMs / (1000 * 60 * 60 * 24)
+		expect(diffDays).toBeCloseTo(7, 0)
+	})
+
+	it("returns correct time range for 1 day", () => {
+		const { startTime, endTime } = getTimeRange(1)
+		const diffMs = endTime.getTime() - startTime.getTime()
+		const diffDays = diffMs / (1000 * 60 * 60 * 24)
+		expect(diffDays).toBeCloseTo(1, 0)
+	})
+})
+
+describe("formatCount", () => {
+	it("formats thousands with k suffix", () => {
+		expect(formatCount(1500)).toBe("1.5k")
+		expect(formatCount(10000)).toBe("10k")
+	})
+
+	it("formats millions with M suffix", () => {
+		expect(formatCount(1500000)).toBe("1.5M")
+		expect(formatCount(10000000)).toBe("10M")
+	})
+
+	it("returns plain number for small values", () => {
+		expect(formatCount(500)).toBe("500")
+		expect(formatCount(999)).toBe("999")
+	})
+})
+
+describe("formatCurrency", () => {
+	it("formats number with dollar sign and 2 decimals", () => {
+		expect(formatCurrency(1500.5)).toBe("$1500.50")
+		expect(formatCurrency(0)).toBe("$0.00")
+	})
+
+	it("formats string amount", () => {
+		expect(formatCurrency("1234.56")).toBe("$1234.56")
+	})
+
+	it("handles invalid input", () => {
+		expect(formatCurrency("invalid")).toBe("$0.00")
+		expect(formatCurrency(NaN)).toBe("$0.00")
+	})
+})
+
+describe("getProviderDisplayName", () => {
+	it("maps claude-code-otel to Claude Code", () => {
+		expect(getProviderDisplayName("claude-code-otel")).toBe("Claude Code")
+	})
+
+	it("maps opencode-otel to OpenCode", () => {
+		expect(getProviderDisplayName("opencode-otel")).toBe("OpenCode")
+	})
+
+	it("maps pi-otel to Kimchi", () => {
+		expect(getProviderDisplayName("pi-otel")).toBe("Kimchi")
+	})
+
+	it("returns original name for unknown providers", () => {
+		expect(getProviderDisplayName("unknown-provider")).toBe("unknown-provider")
+	})
+
+	it("handles empty string", () => {
+		expect(getProviderDisplayName("")).toBe("")
+	})
+})

--- a/src/extensions/stats/types.ts
+++ b/src/extensions/stats/types.ts
@@ -1,0 +1,249 @@
+/**
+ * TypeScript types matching Cast AI Analytics API responses.
+ * Based on actual API responses (protobuf JSON encoding uses camelCase)
+ */
+
+// ─── Request Types ────────────────────────────────────────────────────────────
+
+export interface GenerateAnalyticsRequest {
+	id: string
+	start_time: string
+	end_time: string
+	castai_api_key?: string
+	filter?: string
+}
+
+export interface GetProductivityMetricsRequest {
+	from: string
+	to: string
+	metric_names?: string[]
+	user_id?: string
+	session_id?: string
+	provider_name?: string
+}
+
+export interface GenerateProductivityMetricsTimeseriesRequest {
+	organization_id: string
+	from: string
+	to: string
+	metric_names?: string[]
+	user_id?: string
+	session_id?: string
+	provider_name?: string
+}
+
+// ─── Analytics API Types ─────────────────────────────────────────────────────
+
+export interface GenerateAnalyticsResponse {
+	comparison?: Comparison
+	cost?: Cost
+	apiCalls?: ApiCalls
+	inputTokens?: Tokens
+	outputTokens?: Tokens
+	errors?: Errors
+	ttft?: Ttft
+	requestDuration?: RequestDuration
+	hostedModels?: HostedModels
+	stepDuration: string
+	mostRecentTime?: string
+}
+
+export interface Comparison {
+	inputTokens?: ComparisonValue
+	outputTokens?: ComparisonValue
+	apiCalls?: ComparisonValue
+	errors?: ComparisonValue
+	cost?: ComparisonValue
+}
+
+export interface ComparisonValue {
+	currentValue: number
+	previousValue: number
+	changePercentage: number
+}
+
+export interface Cost {
+	items: CostItem[]
+}
+
+export interface CostItem {
+	executionTime: string
+	models: ModelCost[]
+}
+
+export interface ModelCost {
+	model: string
+	provider: string
+	castaiApiKey: string
+	providerName: string
+	totalCost: string
+	totalCostPerMillionTokens: string
+	castaiApiKeyMetadata: CastAiApiKeyMetadata
+	inputTokenCost: string
+	outputTokenCost: string
+}
+
+export interface CastAiApiKeyMetadata {
+	id: string
+	name: string
+	ownerType: string
+	ownerId: string
+	ownerEmail: string
+}
+
+export interface ApiCalls {
+	items: ApiCallItem[]
+}
+
+export interface ApiCallItem {
+	executionTime: string
+	models: ModelStatItem[]
+}
+
+export interface Tokens {
+	items: TokenItem[]
+}
+
+// Token items have models array like cost
+export interface TokenItem {
+	executionTime: string
+	models: ModelStatItem[]
+}
+
+// Model stats used in apiCalls and tokens
+export interface ModelStatItem {
+	model: string
+	provider: string
+	castaiApiKey: string
+	providerName: string
+	totalCount: number
+	castaiApiKeyMetadata: CastAiApiKeyMetadata
+}
+
+export interface Errors {
+	items: ErrorItem[]
+}
+
+export interface ErrorItem {
+	executionTime: string
+	value: number
+	errorType?: string
+	model?: string
+}
+
+export interface Ttft {
+	items: TtftItem[]
+}
+
+export interface TtftItem {
+	executionTime: string
+	p50: number
+	p90: number
+	p99: number
+}
+
+export interface RequestDuration {
+	items: RequestDurationItem[]
+}
+
+export interface RequestDurationItem {
+	executionTime: string
+	p50: number
+	p90: number
+	p99: number
+}
+
+export interface HostedModels {
+	items: HostedModelItem[]
+}
+
+export interface HostedModelItem {
+	model: string
+	count: number
+}
+
+// ─── Productivity Metrics API Types ───────────────────────────────────────────
+
+export interface GetProductivityMetricsResponse {
+	from?: string
+	to?: string
+	items: ProviderProductivityMetrics[]
+}
+
+export interface ProviderProductivityMetrics {
+	providerName: string
+	summaries: MetricSummary[]
+	sessionStats: SessionStats
+	comparison: ProductivityComparison
+}
+
+export interface MetricSummary {
+	metricName: string
+	totalValue: number
+	breakdown: DimensionValue[]
+	groupedBreakdown: GroupedDimensionValue[]
+}
+
+export interface DimensionValue {
+	dimension: string
+	value: string
+	count: number
+	valueSum: number
+}
+
+export interface GroupedDimensionValue {
+	dimensions: Record<string, string>
+	valueSum: number
+}
+
+export interface SessionStats {
+	totalSessions: number
+	totalDurationSeconds: number
+	avgSessionDurationSeconds: number
+	medianSessionDurationSeconds: number
+	durationP50Seconds: number
+	durationP75Seconds: number
+	durationP90Seconds: number
+	durationP99Seconds: number
+}
+
+export interface ProductivityComparison {
+	linesOfCode: ProductivityComparisonValue
+	pullRequests: ProductivityComparisonValue
+	commits: ProductivityComparisonValue
+	cost: ProductivityComparisonValue
+	tokens: ProductivityComparisonValue
+	sessionTimeSeconds: ProductivityComparisonValue
+	sessions: ProductivityComparisonValue
+	toolUsage: ProductivityComparisonValue
+	toolDurationMs: ProductivityComparisonValue
+}
+
+export interface ProductivityComparisonValue {
+	value: number
+	previousIntervalValue: number
+	changePercentage: number
+}
+
+// ─── Productivity Metrics Timeseries API Types ───────────────────────────────
+
+export interface GenerateProductivityMetricsTimeseriesResponse {
+	from?: string
+	to?: string
+	providers: ProviderTimeSeries[]
+}
+
+export interface ProviderTimeSeries {
+	providerName: string
+	metrics: MetricTimeSeries[]
+}
+
+export interface MetricTimeSeries {
+	metricName: string
+	dataPoints: TimeSeriesDataPoint[]
+}
+
+export interface TimeSeriesDataPoint {
+	timestamp: string
+	value: number
+}

--- a/src/extensions/stats/visual.ts
+++ b/src/extensions/stats/visual.ts
@@ -1,0 +1,335 @@
+/**
+ * Visual dashboard formatting for stats data
+ */
+
+import type { Theme } from "@mariozechner/pi-coding-agent"
+import { formatCount } from "../format.js"
+import type {
+	DimensionValue,
+	GenerateAnalyticsResponse,
+	GetProductivityMetricsResponse,
+	MetricSummary,
+	ProviderProductivityMetrics,
+} from "./types.js"
+
+export function formatCurrency(amount: string | number): string {
+	const num = typeof amount === "string" ? Number.parseFloat(amount) : amount
+	if (Number.isNaN(num)) return "$0.00"
+	return `$${num.toFixed(2)}`
+}
+
+export function formatDurationCompact(seconds: number): string {
+	const hours = Math.floor(seconds / 3600)
+	const mins = Math.floor((seconds % 3600) / 60)
+	if (hours > 0) {
+		return `${hours}h ${mins}m`
+	}
+	return `${mins}m`
+}
+
+/**
+ * Maps provider name to a friendly display name
+ */
+export function getProviderDisplayName(providerName: string): string {
+	const mapping: Record<string, string> = {
+		"claude-code-otel": "Claude Code",
+		"opencode-otel": "OpenCode",
+		"pi-otel": "Kimchi",
+	}
+	return mapping[providerName] || providerName
+}
+
+export function formatAnalyticsVisual(data: GenerateAnalyticsResponse, theme: Theme, termWidth = 100, days = 30): string[] {
+	const lines: string[] = []
+
+	lines.push("")
+	lines.push(theme.bold(theme.fg("accent", "  Analytics")))
+	lines.push(theme.fg("dim", `  Last ${days} Days`))
+	lines.push("")
+
+	// Collect model stats
+	const modelStats = new Map<
+		string,
+		{ cost: number; inputTokens: number; outputTokens: number; inputCost: number; outputCost: number }
+	>()
+
+	if (data.cost?.items) {
+		for (const item of data.cost.items) {
+			if (item.models) {
+				for (const model of item.models) {
+					const cost = Number.parseFloat(model.totalCost || "0")
+					if (cost > 0) {
+						const existing = modelStats.get(model.model) || {
+							cost: 0,
+							inputTokens: 0,
+							outputTokens: 0,
+							inputCost: 0,
+							outputCost: 0,
+						}
+						existing.cost += cost
+						existing.inputCost += Number.parseFloat(model.inputTokenCost || "0")
+						existing.outputCost += Number.parseFloat(model.outputTokenCost || "0")
+						modelStats.set(model.model, existing)
+					}
+				}
+			}
+		}
+	}
+
+	if (data.inputTokens?.items) {
+		for (const item of data.inputTokens.items) {
+			if (item.models) {
+				for (const model of item.models) {
+					const stats = modelStats.get(model.model) || {
+						cost: 0,
+						inputTokens: 0,
+						outputTokens: 0,
+						inputCost: 0,
+						outputCost: 0,
+					}
+					stats.inputTokens += model.totalCount || 0
+					modelStats.set(model.model, stats)
+				}
+			}
+		}
+	}
+
+	if (data.outputTokens?.items) {
+		for (const item of data.outputTokens.items) {
+			if (item.models) {
+				for (const model of item.models) {
+					const stats = modelStats.get(model.model) || {
+						cost: 0,
+						inputTokens: 0,
+						outputTokens: 0,
+						inputCost: 0,
+						outputCost: 0,
+					}
+					stats.outputTokens += model.totalCount || 0
+					modelStats.set(model.model, stats)
+				}
+			}
+		}
+	}
+
+	if (modelStats.size > 0) {
+		// Fixed column widths for compact display
+		const modelCol = 20
+		const tokensCol = 12
+		const ioCol = 18
+		const costCol = 12
+		const costIoCol = 18
+		const lineWidth = modelCol + tokensCol + ioCol + costCol + costIoCol + 4
+
+		lines.push(
+			`  ${"Model".padEnd(modelCol)} ${"Tokens".padStart(tokensCol)} ${"(I / O)".padStart(ioCol)} ${"Cost".padStart(costCol)} ${"(I / O)".padStart(costIoCol)}`,
+		)
+		lines.push(`  ${theme.fg("dim", "─".repeat(lineWidth))}`)
+
+		let totalInputTokens = 0
+		let totalOutputTokens = 0
+		let totalModelCost = 0
+		let totalInputCost = 0
+		let totalOutputCost = 0
+
+		const sortedModels = Array.from(modelStats.entries()).sort((a, b) => b[1].cost - a[1].cost)
+		for (const [model, stats] of sortedModels.slice(0, 6)) {
+			const label = model.length > 15 ? `${model.slice(0, 12)}...` : model
+			const totalTokens = stats.inputTokens + stats.outputTokens
+			const tokenStr = formatCount(totalTokens).padStart(tokensCol)
+			const ioStr = `${formatCount(stats.inputTokens)} / ${formatCount(stats.outputTokens)}`.padStart(ioCol)
+			const costStr = formatCurrency(stats.cost).padStart(costCol)
+			const costIoStr = `${formatCurrency(stats.inputCost)} / ${formatCurrency(stats.outputCost)}`.padStart(costIoCol)
+			lines.push(`  ${theme.fg("accent", label.padEnd(modelCol))} ${tokenStr} ${ioStr} ${costStr} ${costIoStr}`)
+
+			totalInputTokens += stats.inputTokens
+			totalOutputTokens += stats.outputTokens
+			totalModelCost += stats.cost
+			totalInputCost += stats.inputCost
+			totalOutputCost += stats.outputCost
+		}
+
+		lines.push(`  ${theme.fg("dim", "─".repeat(lineWidth))}`)
+		const totalTokensStr = formatCount(totalInputTokens + totalOutputTokens).padStart(tokensCol)
+		const totalIoStr = `${formatCount(totalInputTokens)} / ${formatCount(totalOutputTokens)}`.padStart(ioCol)
+		const totalCostStr = formatCurrency(totalModelCost).padStart(costCol)
+		const totalCostIoStr = `${formatCurrency(totalInputCost)} / ${formatCurrency(totalOutputCost)}`.padStart(costIoCol)
+		lines.push(`  ${"Total".padEnd(modelCol)} ${totalTokensStr} ${totalIoStr} ${totalCostStr} ${totalCostIoStr}`)
+	}
+
+	return lines
+}
+
+export function formatProductivityVisual(
+	data: GetProductivityMetricsResponse,
+	theme: Theme,
+	termWidth = 100,
+	days = 30,
+): string[] {
+	const lines: string[] = []
+
+	lines.push("")
+	lines.push(theme.bold(theme.fg("accent", "  Coding Agent Metrics")))
+	lines.push(theme.fg("dim", `  Last ${days} Days`))
+
+	if (!data.items?.length) {
+		lines.push(theme.fg("dim", "  No data"))
+		return lines
+	}
+
+	// Fixed column widths (not responsive) for compact display
+	const metricCol = 16
+	const providerCol = 20
+	const lineWidth = metricCol + providerCol * data.items.length + 4
+
+	const providers = data.items.map((item) => {
+		const name = getProviderDisplayName(item.providerName || "unknown")
+		return name.length > providerCol - 3 ? `${name.slice(0, providerCol - 6)}...` : name
+	})
+
+	// Helper to get breakdown value from summaries
+	const getBreakdown = (
+		item: ProviderProductivityMetrics,
+		metricName: string,
+		dimension: string,
+		value: string,
+	): number => {
+		const summary = item.summaries?.find((s) => s.metricName === metricName)
+		if (!summary?.breakdown) return 0
+		const entry = summary.breakdown.find((b) => b.dimension === dimension && b.value === value)
+		return entry?.valueSum ?? 0
+	}
+
+	const rows: { label: string; values: string[]; bold?: boolean }[] = []
+
+	// Session metrics
+	rows.push({
+		label: "Sessions",
+		values: data.items.map((item) => {
+			const val = item.sessionStats?.totalSessions ?? 0
+			return val > 0 ? formatCount(val) : "-"
+		}),
+	})
+	rows.push({
+		label: "Duration",
+		values: data.items.map((item) => {
+			const seconds = item.sessionStats?.totalDurationSeconds ?? 0
+			return seconds > 0 ? formatDurationCompact(seconds) : "-"
+		}),
+	})
+	rows.push({
+		label: "Median",
+		values: data.items.map((item) => {
+			const seconds = item.sessionStats?.durationP50Seconds ?? 0
+			return seconds > 0 ? formatDurationCompact(seconds) : "-"
+		}),
+	})
+
+	// Lines of Code - granular
+	rows.push({
+		label: "LoC Added",
+		values: data.items.map((item) => {
+			const val = getBreakdown(item, "claude_code.lines_of_code.count", "type", "added")
+			return val > 0 ? formatCount(val) : "-"
+		}),
+	})
+	rows.push({
+		label: "LoC Removed",
+		values: data.items.map((item) => {
+			const val = getBreakdown(item, "claude_code.lines_of_code.count", "type", "removed")
+			return val > 0 ? formatCount(val) : "-"
+		}),
+	})
+
+	// Commits & PRs
+	rows.push({
+		label: "Commits",
+		values: data.items.map((item) => {
+			const val = item.comparison?.commits?.value ?? 0
+			return val > 0 ? formatCount(val) : "-"
+		}),
+	})
+	rows.push({
+		label: "PRs",
+		values: data.items.map((item) => {
+			const val = item.comparison?.pullRequests?.value ?? 0
+			return val > 0 ? String(val) : "-"
+		}),
+	})
+
+	// Tool usage
+	rows.push({
+		label: "Tool Calls",
+		values: data.items.map((item) => {
+			const val = item.comparison?.toolUsage?.value ?? 0
+			return val > 0 ? formatCount(val) : "-"
+		}),
+	})
+	rows.push({
+		label: "Edit Tool",
+		values: data.items.map((item) => {
+			const summary = item.summaries?.find((s) => s.metricName === "claude_code.code_edit_tool.decision")
+			return summary ? formatCount(summary.totalValue) : "-"
+		}),
+	})
+
+	// Tokens - granular breakdown
+	rows.push({
+		label: "Tokens In",
+		values: data.items.map((item) => {
+			const val = getBreakdown(item, "claude_code.token.usage", "type", "input")
+			return val > 0 ? formatCount(val) : "-"
+		}),
+	})
+	rows.push({
+		label: "Tokens Out",
+		values: data.items.map((item) => {
+			const val = getBreakdown(item, "claude_code.token.usage", "type", "output")
+			return val > 0 ? formatCount(val) : "-"
+		}),
+	})
+	rows.push({
+		label: "Cache Read",
+		values: data.items.map((item) => {
+			const val = getBreakdown(item, "claude_code.token.usage", "type", "cacheRead")
+			return val > 0 ? formatCount(val) : "-"
+		}),
+	})
+	rows.push({
+		label: "Cache Create",
+		values: data.items.map((item) => {
+			const val = getBreakdown(item, "claude_code.token.usage", "type", "cacheCreation")
+			return val > 0 ? formatCount(val) : "-"
+		}),
+	})
+
+	// Cost
+	rows.push({
+		label: "Cost",
+		values: data.items.map((item) => {
+			const val = item.comparison?.cost?.value ?? 0
+			return val > 0 ? formatCurrency(val) : "-"
+		}),
+	})
+
+	// Render header
+	lines.push("")
+	let header = `  ${"Metric".padEnd(metricCol)}`
+	for (const provider of providers) {
+		header += ` ${theme.fg("accent", provider.padStart(providerCol))}`
+	}
+	lines.push(header)
+	lines.push(`  ${theme.fg("dim", "─".repeat(lineWidth))}`)
+
+	// Render rows
+	for (const row of rows) {
+		let line = `  ${(row.bold ? theme.bold(row.label) : row.label).padEnd(metricCol)}`
+		for (const value of row.values) {
+			const displayValue = row.bold && value !== "-" ? theme.bold(value) : value
+			line += ` ${displayValue.padStart(providerCol)}`
+		}
+		lines.push(line)
+	}
+
+	return lines
+}

--- a/src/extensions/stats/visual.ts
+++ b/src/extensions/stats/visual.ts
@@ -39,7 +39,12 @@ export function getProviderDisplayName(providerName: string): string {
 	return mapping[providerName] || providerName
 }
 
-export function formatAnalyticsVisual(data: GenerateAnalyticsResponse, theme: Theme, termWidth = 100, days = 30): string[] {
+export function formatAnalyticsVisual(
+	data: GenerateAnalyticsResponse,
+	theme: Theme,
+	termWidth = 100,
+	days = 30,
+): string[] {
 	const lines: string[] = []
 
 	lines.push("")

--- a/src/extensions/ui.ts
+++ b/src/extensions/ui.ts
@@ -25,6 +25,21 @@ function patchTuiPadding(tui: TUI) {
 	}
 }
 
+// Track splash state globally so other extensions can reset it
+let splashActive = false
+let currentEditor: PromptEditor | undefined
+
+/**
+ * Reset splash mode and switch to chat view.
+ * Call this from command handlers that need to exit splash mode.
+ */
+export function exitSplashMode(ctx: { ui: { setHeader: (factory: (tui: TUI, theme: import("@mariozechner/pi-coding-agent").Theme) => import("@mariozechner/pi-tui").Component) => void } }): void {
+	if (!splashActive) return
+	splashActive = false
+	ctx.ui.setHeader((_tui, theme) => new LogoHeader(theme))
+	currentEditor?.setSplashMode(false)
+}
+
 function runScript(scriptPath: string, payload: object, tui: TUI, footer: ScriptFooter, onDone: () => void): void {
 	const child = spawn(scriptPath, [], {
 		env: process.env,
@@ -65,8 +80,6 @@ function runScript(scriptPath: string, payload: object, tui: TUI, footer: Script
 }
 
 export default function uiExtension(pi: ExtensionAPI) {
-	let splashActive = false
-	let currentEditor: PromptEditor | undefined
 	let tuiPatched = false
 	let scriptFooter: ScriptFooter | null = null
 	let scriptTui: TUI | null = null

--- a/src/extensions/ui.ts
+++ b/src/extensions/ui.ts
@@ -33,7 +33,16 @@ let currentEditor: PromptEditor | undefined
  * Reset splash mode and switch to chat view.
  * Call this from command handlers that need to exit splash mode.
  */
-export function exitSplashMode(ctx: { ui: { setHeader: (factory: (tui: TUI, theme: import("@mariozechner/pi-coding-agent").Theme) => import("@mariozechner/pi-tui").Component) => void } }): void {
+export function exitSplashMode(ctx: {
+	ui: {
+		setHeader: (
+			factory: (
+				tui: TUI,
+				theme: import("@mariozechner/pi-coding-agent").Theme,
+			) => import("@mariozechner/pi-tui").Component,
+		) => void
+	}
+}): void {
 	if (!splashActive) return
 	splashActive = false
 	ctx.ui.setHeader((_tui, theme) => new LogoHeader(theme))


### PR DESCRIPTION
# TODO

The implementation is almost complete. The only issue is that we must know the organization ID of the user (required in the analytics and productivity metrics timeseries endpoints) and Cast AI user ID (so we can filter the retrieved data by the user). Now, those are hardcoded. Requires changes on kubecast side which I will implement.

## Trying to get more than 30d of stats
<img width="1132" height="670" alt="Screenshot 2026-04-28 at 12 12 08" src="https://github.com/user-attachments/assets/a7699306-213b-4133-bd4b-45d7aa86973c" />

## Fetching data notification
<img width="747" height="265" alt="Screenshot 2026-04-28 at 15 23 07" src="https://github.com/user-attachments/assets/3b14fb92-8bfd-479e-bf6c-ebdbd4c817b4" />

## Response example
<img width="708" height="604" alt="Screenshot 2026-04-28 at 12 12 34" src="https://github.com/user-attachments/assets/b90dc930-6e5c-4737-a6d4-47ee034b6de4" />

---
### Kimchi Summary
### What changed
Adds a new `/stats` command that displays Cast AI analytics and productivity metrics directly in the terminal. Users can view token usage, costs, session statistics, lines of code changes, commits, and PR metrics with configurable time ranges (1–30 days).

### Why
Provides visibility into AI-assisted coding activity and resource consumption without requiring users to switch to a web dashboard.

### Key changes
- `src/extensions/stats/index.ts`: Registers `/stats` command and orchestrates data fetching from Cast AI APIs (`generateAnalytics`, `getProductivityMetrics`)
- `src/extensions/stats/api.ts`: Implements `CastAiStatsApi` client with authenticated fetch logic, time range helpers, and error handling
- `src/extensions/stats/visual.ts`: Formats analytics and productivity data as aligned ASCII tables showing model breakdowns, token counts, and cost breakdowns by provider (Claude Code, OpenCode, Kimchi)
- `src/extensions/stats/display.ts`: Helper functions for formatting currency, durations, change indicators, and help text
- `src/extensions/stats/types.ts`: TypeScript interfaces matching Cast AI Analytics API response schemas
- `src/extensions/stats/stats.test.ts`: Unit tests for `getTimeRange`, `formatCount`, `formatCurrency`, and provider name mapping
- `src/extensions/ui.ts`: Exports `exitSplashMode` function and moves splash state to module level so commands can reset the splash screen
- `src/cli.ts`: Imports and registers `statsExtension` in the extension pipeline
- `.gitignore`: Adds `.kimchi/` directory to ignore list

### Impact
- **New command**: `/stats [days]` displays aggregated metrics (default 30 days, supports 1–30 days)
- **Configuration**: Uses `CASTAI_API_KEY` and `CASTAI_ORG_ID` environment variables (falls back to hardcoded defaults if unset)
- **UI Integration**: Automatically exits splash mode when command is invoked; output uses existing theme system for consistent styling
- **Dependencies**: Adds no external dependencies; uses native `fetch` for API calls

---
### Kimchi Summary
### What changed
Add a `/stats` command that displays Cast AI analytics and productivity metrics directly in the terminal. Users can view token usage, model costs, session statistics, lines of code, commits, and pull requests for customizable time ranges (default 30 days).

### Key changes
- **`src/extensions/stats/`**: New extension implementing the stats dashboard:
  - `api.ts`: `CastAiStatsApi` client with methods `generateAnalytics()`, `getProductivityMetrics()`, and `generateProductivityMetricsTimeseries()` for querying Cast AI endpoints
  - `visual.ts`: Terminal table formatting showing model-level cost breakdowns and cross-provider productivity comparisons (Claude Code, OpenCode, Kimchi)
  - `types.ts`: TypeScript definitions for analytics and productivity API schemas
  - `display.ts`: Helper functions for formatting currency, durations, and usage summaries
  - `index.ts`: Command handler registering `/stats [days]` (supports 1-365 days)
  - `stats.test.ts`: Unit tests for `getTimeRange()`, `formatCount()`, and `formatCurrency()`
- **`src/cli.ts`**: Registered `statsExtension` in the extension loading pipeline
- **`src/extensions/ui.ts`**: Exported `exitSplashMode()` utility to allow command handlers to reset splash screen state before displaying output
- **`.gitignore`**: Added `.kimchi/` directory exclusion for generated documentation

### Impact
- New `/stats` command available in the TUI; use `/stats 7` to view metrics for the last 7 days
- Requires `CASTAI_API_KEY` and `CASTAI_ORG_ID` environment variables (falls back to hardcoded development values if unset)
- Gracefully handles missing data and API errors with formatted error messages instead of stack traces