### PR TITLE
NOJIRA: Allow local (gitignored) override of benchmark.json

### DIFF
--- a/benchmark/manual/.gitignore
+++ b/benchmark/manual/.gitignore
@@ -1,1 +1,2 @@
 sessions/
+benchmark.local.json

--- a/benchmark/manual/new-session.sh
+++ b/benchmark/manual/new-session.sh
@@ -2,10 +2,14 @@
 set -e
 
 IMPROVEMENT_DIR="${0:A:h}"
-BENCHMARK_JSON="$IMPROVEMENT_DIR/benchmark.json"
 
-if [[ ! -f "$BENCHMARK_JSON" ]]; then
-  echo "benchmark.json not found at $BENCHMARK_JSON"
+# Check for local override first, then fall back to default config
+if [[ -f "$IMPROVEMENT_DIR/benchmark.local.json" ]]; then
+  BENCHMARK_JSON="$IMPROVEMENT_DIR/benchmark.local.json"
+elif [[ -f "$IMPROVEMENT_DIR/benchmark.json" ]]; then
+  BENCHMARK_JSON="$IMPROVEMENT_DIR/benchmark.json"
+else
+  echo "benchmark.json not found at $IMPROVEMENT_DIR/benchmark.json"
   echo "Create it with: {\"binary\": \"path/to/binary\", \"models\": [\"model-id\", ...]}"
   exit 1
 fi


### PR DESCRIPTION
## Summary

Allow local (gitignored) override of `benchmark/manual/benchmark.json`.

## Changes

- **`benchmark/manual/.gitignore`**: Add `benchmark.local.json` to gitignore
- **`benchmark/manual/new-session.sh`**: Check for `benchmark.local.json` first, fall back to `benchmark.json`

## How it works

The `new-session.sh` script now checks for local override in this order:
1. If `benchmark.local.json` exists, it's used
2. Otherwise falls back to `benchmark.json`
3. Error if neither exists

This allows developers to have local-specific configuration (different binary path, different set of models, etc.) without modifying or committing the tracked file.

---
### Kimchi Summary
### What changed
Added support for local benchmark configuration overrides. The `new-session.sh` script now checks for `benchmark.local.json` before falling back to the standard `benchmark.json`, and the local override file is gitignored to prevent accidental commits.

### Why
Allows developers to maintain personal benchmark configurations (e.g., local binary paths or test models) without modifying the shared `benchmark.json` or risking commit of environment-specific settings.

### Key changes
- `benchmark/manual/new-session.sh`: Implements fallback logic to prioritize `benchmark.local.json` over `benchmark.json` when locating the configuration file
- `benchmark/manual/.gitignore`: Added `benchmark.local.json` to exclude local overrides from version control