### PR TITLE
NOJIRA: Read API key from config file only when calling `web_search` tool

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -2,7 +2,7 @@ import { mkdirSync, readFileSync, renameSync, writeFileSync } from "node:fs"
 import { homedir } from "node:os"
 import { dirname, join, resolve } from "node:path"
 
-const KIMCHI_CONFIG_PATH = resolve(homedir(), ".config", "kimchi", "config.json")
+export const KIMCHI_CONFIG_PATH = resolve(homedir(), ".config", "kimchi", "config.json")
 const AGENT_CONFIG_DIR = resolve(homedir(), ".config", "kimchi", "harness")
 const CAST_AI_LLM_ENDPOINT = "https://llm.cast.ai/openai/v1"
 const DEFAULT_TELEMETRY_ENDPOINT = "https://api.cast.ai/ai-optimizer/v1beta/logs:ingest"
@@ -50,7 +50,7 @@ export interface KimchiConfig {
  * Read the Cast AI API key from the kimchi CLI config file.
  * Returns undefined if the file doesn't exist or the field is missing.
  */
-function readApiKeyFromConfigFile(configPath: string): string | undefined {
+export function readApiKeyFromConfigFile(configPath: string): string | undefined {
 	try {
 		const raw = readFileSync(configPath, "utf-8")
 		const parsed = JSON.parse(raw)

--- a/src/config.ts
+++ b/src/config.ts
@@ -2,7 +2,7 @@ import { mkdirSync, readFileSync, renameSync, writeFileSync } from "node:fs"
 import { homedir } from "node:os"
 import { dirname, join, resolve } from "node:path"
 
-export const KIMCHI_CONFIG_PATH = resolve(homedir(), ".config", "kimchi", "config.json")
+const KIMCHI_CONFIG_PATH = resolve(homedir(), ".config", "kimchi", "config.json")
 const AGENT_CONFIG_DIR = resolve(homedir(), ".config", "kimchi", "harness")
 const CAST_AI_LLM_ENDPOINT = "https://llm.cast.ai/openai/v1"
 const DEFAULT_TELEMETRY_ENDPOINT = "https://api.cast.ai/ai-optimizer/v1beta/logs:ingest"
@@ -50,7 +50,7 @@ export interface KimchiConfig {
  * Read the Cast AI API key from the kimchi CLI config file.
  * Returns undefined if the file doesn't exist or the field is missing.
  */
-export function readApiKeyFromConfigFile(configPath: string): string | undefined {
+export function readApiKeyFromConfigFile(configPath: string = KIMCHI_CONFIG_PATH): string | undefined {
 	try {
 		const raw = readFileSync(configPath, "utf-8")
 		const parsed = JSON.parse(raw)

--- a/src/extensions/web-search/execute-handler.test.ts
+++ b/src/extensions/web-search/execute-handler.test.ts
@@ -1,5 +1,8 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
+import * as config from "../../config.js"
 import { DEFAULT_LIMIT, SEARCH_ENDPOINT, type SearchResponse, executeWebSearch } from "./execute-handler.js"
+
+vi.mock("../../config.js", () => ({ readApiKeyFromConfigFile: vi.fn(), KIMCHI_CONFIG_PATH: "/mock/config.json" }))
 
 function mockFetch(status: number, body: unknown, headers: Record<string, string> = {}): void {
 	vi.stubGlobal(
@@ -22,20 +25,32 @@ function makeSources(count: number) {
 }
 
 beforeEach(() => {
-	vi.stubEnv("KIMCHI_API_KEY", "test-key-123")
+	vi.mocked(config.readApiKeyFromConfigFile).mockReturnValue("test-key-123")
 })
 
 afterEach(() => {
 	vi.unstubAllGlobals()
-	vi.unstubAllEnvs()
+	vi.restoreAllMocks()
 })
 
 describe("executeWebSearch", () => {
 	describe("API key validation", () => {
-		it("throws when KIMCHI_API_KEY is not set", async () => {
-			vi.stubEnv("KIMCHI_API_KEY", "")
+		it("throws a human-readable error when no API key is set in config", async () => {
+			vi.mocked(config.readApiKeyFromConfigFile).mockReturnValue(undefined)
 
-			await expect(executeWebSearch({ query: "test" })).rejects.toThrow("KIMCHI_API_KEY is not set")
+			await expect(executeWebSearch({ query: "test" })).rejects.toThrow(
+				"Web search requires an API key. Run 'kimchi' and log in, or visit https://app.kimchi.dev to create a key.",
+			)
+		})
+
+		it("uses API key from config file", async () => {
+			vi.mocked(config.readApiKeyFromConfigFile).mockReturnValue("key-from-config-file")
+			mockFetch(200, { sources: [] })
+
+			await executeWebSearch({ query: "test" })
+
+			const headers = vi.mocked(fetch).mock.calls[0][1]?.headers as Record<string, string>
+			expect(headers.Authorization).toBe("Bearer key-from-config-file")
 		})
 	})
 

--- a/src/extensions/web-search/execute-handler.test.ts
+++ b/src/extensions/web-search/execute-handler.test.ts
@@ -2,7 +2,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
 import * as config from "../../config.js"
 import { DEFAULT_LIMIT, SEARCH_ENDPOINT, type SearchResponse, executeWebSearch } from "./execute-handler.js"
 
-vi.mock("../../config.js", () => ({ readApiKeyFromConfigFile: vi.fn(), KIMCHI_CONFIG_PATH: "/mock/config.json" }))
+vi.mock("../../config.js", () => ({ readApiKeyFromConfigFile: vi.fn() }))
 
 function mockFetch(status: number, body: unknown, headers: Record<string, string> = {}): void {
 	vi.stubGlobal(

--- a/src/extensions/web-search/execute-handler.ts
+++ b/src/extensions/web-search/execute-handler.ts
@@ -6,7 +6,7 @@
  */
 
 import { truncateHead, truncateLine } from "@mariozechner/pi-coding-agent"
-import { KIMCHI_CONFIG_PATH, readApiKeyFromConfigFile } from "../../config.js"
+import { readApiKeyFromConfigFile } from "../../config.js"
 
 export const SEARCH_ENDPOINT = "https://llm.kimchi.dev/v1/search"
 export const SEARCH_TIMEOUT_MS = 25_000
@@ -100,7 +100,7 @@ async function fetchSearchResponse(body: object, apiKey: string, signal: AbortSi
 }
 
 export async function executeWebSearch(params: WebSearchParams, signal?: AbortSignal): Promise<WebSearchResult> {
-	const apiKey = readApiKeyFromConfigFile(KIMCHI_CONFIG_PATH)
+	const apiKey = readApiKeyFromConfigFile()
 	if (!apiKey) {
 		throw new Error(
 			"Web search requires an API key. Run 'kimchi' and log in, or visit https://app.kimchi.dev to create a key.",

--- a/src/extensions/web-search/execute-handler.ts
+++ b/src/extensions/web-search/execute-handler.ts
@@ -6,6 +6,7 @@
  */
 
 import { truncateHead, truncateLine } from "@mariozechner/pi-coding-agent"
+import { KIMCHI_CONFIG_PATH, readApiKeyFromConfigFile } from "../../config.js"
 
 export const SEARCH_ENDPOINT = "https://llm.kimchi.dev/v1/search"
 export const SEARCH_TIMEOUT_MS = 25_000
@@ -99,9 +100,11 @@ async function fetchSearchResponse(body: object, apiKey: string, signal: AbortSi
 }
 
 export async function executeWebSearch(params: WebSearchParams, signal?: AbortSignal): Promise<WebSearchResult> {
-	const apiKey = process.env.KIMCHI_API_KEY
+	const apiKey = readApiKeyFromConfigFile(KIMCHI_CONFIG_PATH)
 	if (!apiKey) {
-		throw new Error("KIMCHI_API_KEY is not set")
+		throw new Error(
+			"Web search requires an API key. Run 'kimchi' and log in, or visit https://app.kimchi.dev to create a key.",
+		)
 	}
 
 	const maxContentChars = params.max_content_chars ?? DEFAULT_MAX_CONTENT_CHARS


### PR DESCRIPTION
## Summary

- Web search was reading the API key exclusively from the `KIMCHI_API_KEY` env var, causing it to fail in sessions where the key is stored in the config file
- Now reads from `~/.config/kimchi/config.json` (the same source used by the rest of the app)
- Replaced the unhelpful `KIMCHI_API_KEY is not set` error with a message that tells users how to fix it

## Test plan

- [x] `vitest run src/extensions/web-search/execute-handler.test.ts` passes
- [x] `vitest run src/config.test.ts` passes
- [x] Manual: remove `KIMCHI_API_KEY` from env, confirm web search works when key is in config file
- [x] Manual: remove key from both env and config, confirm the human-readable error appears

---
### Kimchi Summary
### What changed
Web search authentication now reads the API key from the kimchi CLI configuration file instead of the `KIMCHI_API_KEY` environment variable. Also added a local benchmark configuration file for development testing.

### Why
Eliminates the need for users to manually export environment variables when they have already authenticated via the `kimchi` CLI, unifying authentication under the standard CLI config file (`~/.config/kimchi/config.json`).

### Key changes
- **`src/config.ts`**: Exported `readApiKeyFromConfigFile` and made the `configPath` parameter optional (defaults to `KIMCHI_CONFIG_PATH`).
- **`src/extensions/web-search/execute-handler.ts`**: Replaced `process.env.KIMCHI_API_KEY` lookup with `readApiKeyFromConfigFile()`. Updated the error message to direct users to run `kimchi` and log in, or visit https://app.kimchi.dev to create a key.
- **`src/extensions/web-search/execute-handler.test.ts`**: Refactored tests to mock `readApiKeyFromConfigFile` instead of stubbing `process.env`.
- **`benchmark/manual/benchmark.local.json`**: Added development-only benchmark configuration.

### Impact
**Breaking change**: Web search now requires the API key to be present in the kimchi CLI config file. Users previously relying solely on the `KIMCHI_API_KEY` environment variable must run `kimchi` to authenticate or manually add the key to the config file.