### PR TITLE
feat: add kimchi alias for kimchi-code

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,5 +1,0 @@
-## [Unreleased]
-
-### Added
-- Added 'kimchi' as an alias for 'kimchi-code' command
-- Both commands are now fully interchangeable for all flags

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,0 +1,5 @@
+## [Unreleased]
+
+### Added
+- Added 'kimchi' as an alias for 'kimchi-code' command
+- Both commands are now fully interchangeable for all flags

--- a/package.json
+++ b/package.json
@@ -1,78 +1,78 @@
 {
-	"name": "@kimchi-dev/cli",
-	"version": "0.1.0",
-	"description": "kimchi-code — a coding agent CLI powered by Cast AI",
-	"type": "module",
-	"license": "MIT",
-	"bin": {
-		"kimchi-code": "src/entry.ts"
-	},
-	"scripts": {
-		"clean": "rm -rf dist",
-		"build": "tsc --noEmit && node scripts/copy-resources.js --dev",
-		"build:binary": "node scripts/build-binary.js",
-		"install:local": "node scripts/install-local.js",
-		"build:binary-linux-arm64": "node scripts/build-binary.js --target linux-arm64",
-		"build:binary-linux-x64": "node scripts/build-binary.js --target linux-x64",
-		"dev": "bun run --preload ./src/set-package-dir.ts src/entry.ts",
-		"lint": "biome check src/ scripts/",
-		"lint:fix": "biome check --write src/ scripts/",
-		"typecheck": "tsc --noEmit",
-		"check": "pnpm run lint && pnpm run typecheck",
-		"test": "vitest run --dir src",
-		"test:smoke": "vitest run --config tests/smoke/vitest.config.ts",
-		"prepare": "husky",
-		"verify": "pnpm run check && pnpm run build:binary && pnpm run test && pnpm run test:smoke",
-		"prepare": "husky"
-	},
-	"piConfig": {
-		"name": "kimchi",
-		"configDir": ".config/kimchi/harness"
-	},
-	"dependencies": {
-		"@agentclientprotocol/sdk": "^0.19.0",
-		"@clack/prompts": "^1.2.0",
-		"@mariozechner/pi-coding-agent": "^0.67.68",
-		"@mariozechner/pi-tui": "^0.67.68",
-		"@modelcontextprotocol/ext-apps": "^1.2.2",
-		"@modelcontextprotocol/sdk": "^1.25.1",
-		"micromatch": "^4.0.8",
-		"open": "^10.2.0",
-		"shell-quote": "^1.8.3",
-		"undici": "^8.0.2",
-		"uuid": "^14.0.0",
-		"zod": "^4.0.0"
-	},
-	"peerDependencies": {
-		"@sinclair/typebox": "*"
-	},
-	"devDependencies": {
-		"@biomejs/biome": "^1.9.4",
-		"@mariozechner/pi-ai": "^0.67.68",
-		"@mixmark-io/domino": "^2.2.0",
-		"@types/micromatch": "^4.0.10",
-		"@types/node": "^22.15.2",
-		"@types/shell-quote": "^1.7.5",
-		"@types/turndown": "^5.0.5",
-		"husky": "^9.1.7",
-		"node-pty": "^1.1.0",
-		"playwright": "^1.52.0",
-		"tsx": "^4.21.0",
-		"turndown": "^7.2.0",
-		"typescript": "^5.7.3",
-		"vitest": "^3.1.1"
-	},
-	"engines": {
-		"node": ">=22.0.0"
-	},
-	"packageManager": "pnpm@10.8.1",
-	"pnpm": {
-		"onlyBuiltDependencies": [
-			"@biomejs/biome",
-			"esbuild",
-			"koffi",
-			"node-pty",
-			"protobufjs"
-		]
-	}
+  "name": "@kimchi-dev/cli",
+  "version": "0.1.0",
+  "description": "kimchi-code \u2014 a coding agent CLI powered by Cast AI",
+  "type": "module",
+  "license": "MIT",
+  "bin": {
+    "kimchi-code": "src/entry.ts",
+    "kimchi": "src/entry.ts"
+  },
+  "scripts": {
+    "clean": "rm -rf dist",
+    "build": "tsc --noEmit && node scripts/copy-resources.js --dev",
+    "build:binary": "node scripts/build-binary.js",
+    "install:local": "node scripts/install-local.js",
+    "build:binary-linux-arm64": "node scripts/build-binary.js --target linux-arm64",
+    "build:binary-linux-x64": "node scripts/build-binary.js --target linux-x64",
+    "dev": "bun run --preload ./src/set-package-dir.ts src/entry.ts",
+    "lint": "biome check src/ scripts/",
+    "lint:fix": "biome check --write src/ scripts/",
+    "typecheck": "tsc --noEmit",
+    "check": "pnpm run lint && pnpm run typecheck",
+    "test": "vitest run --dir src",
+    "test:smoke": "vitest run --config tests/smoke/vitest.config.ts",
+    "prepare": "husky",
+    "verify": "pnpm run check && pnpm run build:binary && pnpm run test && pnpm run test:smoke"
+  },
+  "piConfig": {
+    "name": "kimchi",
+    "configDir": ".config/kimchi/harness"
+  },
+  "dependencies": {
+    "@agentclientprotocol/sdk": "^0.19.0",
+    "@clack/prompts": "^1.2.0",
+    "@mariozechner/pi-coding-agent": "^0.67.68",
+    "@mariozechner/pi-tui": "^0.67.68",
+    "@modelcontextprotocol/ext-apps": "^1.2.2",
+    "@modelcontextprotocol/sdk": "^1.25.1",
+    "micromatch": "^4.0.8",
+    "open": "^10.2.0",
+    "shell-quote": "^1.8.3",
+    "undici": "^8.0.2",
+    "uuid": "^14.0.0",
+    "zod": "^4.0.0"
+  },
+  "peerDependencies": {
+    "@sinclair/typebox": "*"
+  },
+  "devDependencies": {
+    "@biomejs/biome": "^1.9.4",
+    "@mariozechner/pi-ai": "^0.67.68",
+    "@mixmark-io/domino": "^2.2.0",
+    "@types/micromatch": "^4.0.10",
+    "@types/node": "^22.15.2",
+    "@types/shell-quote": "^1.7.5",
+    "@types/turndown": "^5.0.5",
+    "husky": "^9.1.7",
+    "node-pty": "^1.1.0",
+    "playwright": "^1.52.0",
+    "tsx": "^4.21.0",
+    "turndown": "^7.2.0",
+    "typescript": "^5.7.3",
+    "vitest": "^3.1.1"
+  },
+  "engines": {
+    "node": ">=22.0.0"
+  },
+  "packageManager": "pnpm@10.8.1",
+  "pnpm": {
+    "onlyBuiltDependencies": [
+      "@biomejs/biome",
+      "esbuild",
+      "koffi",
+      "node-pty",
+      "protobufjs"
+    ]
+  }
 }

--- a/package.json
+++ b/package.json
@@ -1,78 +1,78 @@
 {
-  "name": "@kimchi-dev/cli",
-  "version": "0.1.0",
-  "description": "kimchi-code \u2014 a coding agent CLI powered by Cast AI",
-  "type": "module",
-  "license": "MIT",
-  "bin": {
-    "kimchi-code": "src/entry.ts",
-    "kimchi": "src/entry.ts"
-  },
-  "scripts": {
-    "clean": "rm -rf dist",
-    "build": "tsc --noEmit && node scripts/copy-resources.js --dev",
-    "build:binary": "node scripts/build-binary.js",
-    "install:local": "node scripts/install-local.js",
-    "build:binary-linux-arm64": "node scripts/build-binary.js --target linux-arm64",
-    "build:binary-linux-x64": "node scripts/build-binary.js --target linux-x64",
-    "dev": "bun run --preload ./src/set-package-dir.ts src/entry.ts",
-    "lint": "biome check src/ scripts/",
-    "lint:fix": "biome check --write src/ scripts/",
-    "typecheck": "tsc --noEmit",
-    "check": "pnpm run lint && pnpm run typecheck",
-    "test": "vitest run --dir src",
-    "test:smoke": "vitest run --config tests/smoke/vitest.config.ts",
-    "prepare": "husky",
-    "verify": "pnpm run check && pnpm run build:binary && pnpm run test && pnpm run test:smoke"
-  },
-  "piConfig": {
-    "name": "kimchi",
-    "configDir": ".config/kimchi/harness"
-  },
-  "dependencies": {
-    "@agentclientprotocol/sdk": "^0.19.0",
-    "@clack/prompts": "^1.2.0",
-    "@mariozechner/pi-coding-agent": "^0.67.68",
-    "@mariozechner/pi-tui": "^0.67.68",
-    "@modelcontextprotocol/ext-apps": "^1.2.2",
-    "@modelcontextprotocol/sdk": "^1.25.1",
-    "micromatch": "^4.0.8",
-    "open": "^10.2.0",
-    "shell-quote": "^1.8.3",
-    "undici": "^8.0.2",
-    "uuid": "^14.0.0",
-    "zod": "^4.0.0"
-  },
-  "peerDependencies": {
-    "@sinclair/typebox": "*"
-  },
-  "devDependencies": {
-    "@biomejs/biome": "^1.9.4",
-    "@mariozechner/pi-ai": "^0.67.68",
-    "@mixmark-io/domino": "^2.2.0",
-    "@types/micromatch": "^4.0.10",
-    "@types/node": "^22.15.2",
-    "@types/shell-quote": "^1.7.5",
-    "@types/turndown": "^5.0.5",
-    "husky": "^9.1.7",
-    "node-pty": "^1.1.0",
-    "playwright": "^1.52.0",
-    "tsx": "^4.21.0",
-    "turndown": "^7.2.0",
-    "typescript": "^5.7.3",
-    "vitest": "^3.1.1"
-  },
-  "engines": {
-    "node": ">=22.0.0"
-  },
-  "packageManager": "pnpm@10.8.1",
-  "pnpm": {
-    "onlyBuiltDependencies": [
-      "@biomejs/biome",
-      "esbuild",
-      "koffi",
-      "node-pty",
-      "protobufjs"
-    ]
-  }
+	"name": "@kimchi-dev/cli",
+	"version": "0.1.0",
+	"description": "kimchi-code — a coding agent CLI powered by Cast AI",
+	"type": "module",
+	"license": "MIT",
+	"bin": {
+		"kimchi-code": "src/entry.ts",
+		"kimchi": "src/entry.ts"
+	},
+	"scripts": {
+		"clean": "rm -rf dist",
+		"build": "tsc --noEmit && node scripts/copy-resources.js --dev",
+		"build:binary": "node scripts/build-binary.js",
+		"install:local": "node scripts/install-local.js",
+		"build:binary-linux-arm64": "node scripts/build-binary.js --target linux-arm64",
+		"build:binary-linux-x64": "node scripts/build-binary.js --target linux-x64",
+		"dev": "bun run --preload ./src/set-package-dir.ts src/entry.ts",
+		"lint": "biome check src/ scripts/",
+		"lint:fix": "biome check --write src/ scripts/",
+		"typecheck": "tsc --noEmit",
+		"check": "pnpm run lint && pnpm run typecheck",
+		"test": "vitest run --dir src",
+		"test:smoke": "vitest run --config tests/smoke/vitest.config.ts",
+		"prepare": "husky",
+		"verify": "pnpm run check && pnpm run build:binary && pnpm run test && pnpm run test:smoke"
+	},
+	"piConfig": {
+		"name": "kimchi",
+		"configDir": ".config/kimchi/harness"
+	},
+	"dependencies": {
+		"@agentclientprotocol/sdk": "^0.19.0",
+		"@clack/prompts": "^1.2.0",
+		"@mariozechner/pi-coding-agent": "^0.67.68",
+		"@mariozechner/pi-tui": "^0.67.68",
+		"@modelcontextprotocol/ext-apps": "^1.2.2",
+		"@modelcontextprotocol/sdk": "^1.25.1",
+		"micromatch": "^4.0.8",
+		"open": "^10.2.0",
+		"shell-quote": "^1.8.3",
+		"undici": "^8.0.2",
+		"uuid": "^14.0.0",
+		"zod": "^4.0.0"
+	},
+	"peerDependencies": {
+		"@sinclair/typebox": "*"
+	},
+	"devDependencies": {
+		"@biomejs/biome": "^1.9.4",
+		"@mariozechner/pi-ai": "^0.67.68",
+		"@mixmark-io/domino": "^2.2.0",
+		"@types/micromatch": "^4.0.10",
+		"@types/node": "^22.15.2",
+		"@types/shell-quote": "^1.7.5",
+		"@types/turndown": "^5.0.5",
+		"husky": "^9.1.7",
+		"node-pty": "^1.1.0",
+		"playwright": "^1.52.0",
+		"tsx": "^4.21.0",
+		"turndown": "^7.2.0",
+		"typescript": "^5.7.3",
+		"vitest": "^3.1.1"
+	},
+	"engines": {
+		"node": ">=22.0.0"
+	},
+	"packageManager": "pnpm@10.8.1",
+	"pnpm": {
+		"onlyBuiltDependencies": [
+			"@biomejs/biome",
+			"esbuild",
+			"koffi",
+			"node-pty",
+			"protobufjs"
+		]
+	}
 }

--- a/scripts/build-binary.js
+++ b/scripts/build-binary.js
@@ -7,7 +7,9 @@
 //   node scripts/build-binary.js --target linux-x64     # cross-compile for Linux x86-64
 
 import { execSync } from "node:child_process"
+import { existsSync, symlinkSync, unlinkSync } from "node:fs"
 import { platform } from "node:os"
+import { join } from "node:path"
 
 const TARGET_MAP = {
 	"linux-arm64": "bun-linux-arm64",
@@ -50,3 +52,10 @@ if (!isCrossCompile && platform() === "darwin") {
 }
 
 run("copy resources", "node scripts/copy-resources.js")
+// Create symlink for kimchi
+const kimchiPath = join("dist", "bin", "kimchi")
+if (existsSync(kimchiPath)) {
+	unlinkSync(kimchiPath)
+}
+// Create symlink with relative target (same directory)
+symlinkSync("kimchi-code", kimchiPath)

--- a/scripts/build-binary.js
+++ b/scripts/build-binary.js
@@ -52,10 +52,9 @@ if (!isCrossCompile && platform() === "darwin") {
 }
 
 run("copy resources", "node scripts/copy-resources.js")
-// Create symlink for kimchi
+
 const kimchiPath = join("dist", "bin", "kimchi")
 if (existsSync(kimchiPath)) {
 	unlinkSync(kimchiPath)
 }
-// Create symlink with relative target (same directory)
 symlinkSync("kimchi-code", kimchiPath)

--- a/scripts/install-local.js
+++ b/scripts/install-local.js
@@ -27,12 +27,11 @@ const shareDest = join(prefix, "share", "kimchi")
 
 mkdirSync(binDest, { recursive: true })
 cpSync(distBin, join(binDest, "kimchi-code"))
-// Create symlink for kimchi
+
 const kimchiPath = join(binDest, "kimchi")
 if (existsSync(kimchiPath)) {
 	unlinkSync(kimchiPath)
 }
-// Create symlink with relative target (same directory)
 symlinkSync("kimchi-code", kimchiPath)
 
 cpSync(distShare, shareDest, { recursive: true })

--- a/scripts/install-local.js
+++ b/scripts/install-local.js
@@ -3,7 +3,7 @@
 //
 // Usage: node scripts/install-local.js
 
-import { cpSync, existsSync, mkdirSync } from "node:fs"
+import { cpSync, existsSync, mkdirSync, symlinkSync, unlinkSync } from "node:fs"
 import { homedir } from "node:os"
 import { dirname, join } from "node:path"
 import { fileURLToPath } from "node:url"
@@ -27,8 +27,16 @@ const shareDest = join(prefix, "share", "kimchi")
 
 mkdirSync(binDest, { recursive: true })
 cpSync(distBin, join(binDest, "kimchi-code"))
+// Create symlink for kimchi
+const kimchiPath = join(binDest, "kimchi")
+if (existsSync(kimchiPath)) {
+	unlinkSync(kimchiPath)
+}
+// Create symlink with relative target (same directory)
+symlinkSync("kimchi-code", kimchiPath)
 
 cpSync(distShare, shareDest, { recursive: true })
 
 console.log(`Installed binary  → ${join(binDest, "kimchi-code")}`)
+console.log(`Installed symlink → ${join(binDest, "kimchi")}`)
 console.log(`Installed share   → ${shareDest}`)


### PR DESCRIPTION
This PR adds a 'kimchi' alias for the 'kimchi-code' command, making them fully interchangeable.

## Changes

1. package.json: Added 'kimchi' binary pointing to src/entry.ts
2. scripts/build-binary.js: Create symlink dist/bin/kimchi -> dist/bin/kimchi-code during build (using relative target for portability)
3. scripts/install-local.js: Create symlink ~/.local/bin/kimchi -> ~/.local/bin/kimchi-code during local installation (using relative target)
4. Fixed: Added missing symlinkSync import in install-local.js
5. Cleanup: Removed duplicate 'prepare': 'husky' key from package.json

## Verification

Both commands now work identically for all flags:
- kimchi --yolo works same as kimchi-code --yolo
- kimchi --help works same as kimchi-code --help
- kimchi --version works same as kimchi-code --version
- All other flags and options work identically

This allows users to use either kimchi or kimchi-code interchangeably for launching the Kimchi coding harness.

Note: Addresses PR review feedback regarding symlink target consistency and missing imports.

---
### Kimchi Summary
### What changed
Registers `kimchi` as a shorter alias for the `kimchi-code` CLI command. After installation, users can invoke the tool using either `kimchi` or `kimchi-code`.

### Why
Provides a more convenient, memorable command name while maintaining backward compatibility with the existing `kimchi-code` entry point.

### Key changes
- **`package.json`**: Adds `"kimchi": "src/entry.ts"` to the `bin` field and removes duplicate `prepare` script entry.
- **`scripts/build-binary.js`**: Creates a symbolic link `dist/bin/kimchi → kimchi-code` after the cross-compilation step.
- **`scripts/install-local.js`**: Creates a symbolic link in the local bin directory (`bin/kimchi → kimchi-code`) during local installation.

### Impact
- Fully backward compatible; existing `kimchi-code` invocations continue to work.
- Users installing from npm or local builds will have both commands available in their `PATH`.