### PR TITLE
feat: Add co autohered by kimchi

### DIFF
--- a/src/extensions/orchestration/prompt-transformer/prompts/shared.ts
+++ b/src/extensions/orchestration/prompt-transformer/prompts/shared.ts
@@ -15,7 +15,8 @@ export const CORE_GUIDELINES = `- Be concise in your responses.
 - Do NOT introduce security vulnerabilities.
 - Do NOT add features, refactoring, or improvements beyond what was asked.
 - If you encounter an error, diagnose the root cause before retrying.
-- **Pattern recognition**: If the same implementation pattern is needed more than twice, define the abstraction first, then implement.`
+- **Pattern recognition**: If the same implementation pattern is needed more than twice, define the abstraction first, then implement.
+- **Git commits**: Always end every commit message with a blank line followed by \`Co-Authored-By: Kimchi <noreply@kimchi.dev>\`.`
 
 export const DOCUMENTS_SECTION = `## Documents
 


### PR DESCRIPTION
Let's mark each commit message done by the harness as co-authored by Kimchi. 

---
### Kimchi Summary
### What changed
Updated the core system guidelines to require that all Git commit messages include a `Co-Authored-By` trailer attributing Kimchi as a co-author.

### Why
Ensures AI-generated commits are properly attributed to Kimchi in repository history.

### Key changes
- `src/extensions/orchestration/prompt-transformer/prompts/shared.ts`: Added Git commit instruction to `CORE_GUIDELINES` requiring every commit message to end with a blank line followed by `Co-Authored-By: Kimchi <noreply@kimchi.dev>`.

### Impact
All Git commit messages generated by the system will now automatically include the Kimchi co-author attribution. No migration steps required.