### PR TITLE
fix: opus should be visible better than kimi

### DIFF
--- a/src/extensions/orchestration/model-registry/builtin-models.ts
+++ b/src/extensions/orchestration/model-registry/builtin-models.ts
@@ -22,8 +22,8 @@ import type { ModelCapabilities } from "./types.js"
 
 const KIMI_K25_DESCRIPTION = `\
 The only model in the pool with vision support — use it when the task involves images, \
-screenshots, or visual input. Most capable and most expensive. \
-Best for complex multi-step tasks, deep reasoning, or anything requiring autonomous multi-tool workflows.`
+screenshots, or visual input. Best for exploration and research tasks, particularly those \
+requiring image understanding or visual context. Excellent for autonomous multi-tool workflows.`
 
 const MINIMAX_M27_DESCRIPTION = `\
 The strongest coding model in the pool. \
@@ -37,8 +37,10 @@ Weakest at coding; not reliable for complex multi-file changes. \
 Best for codebase exploration, research, and simple well-defined tasks.`
 
 const CLAUDE_OPUS_47_DESCRIPTION = `\
-Anthropic's flagship Claude model. Strongest general reasoning, planning, and vision support. \
-Best for complex multi-step tasks requiring deep research and exploration across large codebases.`
+Anthropic's flagship Claude model. Dominates at architectural planning and complex task \
+decomposition — when a hard problem needs a superior plan, this is the model to delegate to. \
+Also excels at deep reasoning, research, and exploration across large codebases. Best for \
+complex multi-step tasks requiring careful analysis and methodical planning.`
 
 // TODO: these capabilities could be returned by our models metadata API.
 /**


### PR DESCRIPTION


---
### Kimchi Summary
### What changed
Updated the model capability descriptions for Claude Opus 4.7 and Kimi K2.5 to clarify their respective strengths. Claude Opus is now explicitly positioned as the dominant choice for architectural planning and complex task decomposition, while Kimi K2.5 is focused on exploration and vision tasks.

### Why
The previous descriptions did not sufficiently differentiate Opus as the preferred model for hard planning problems requiring superior architectural reasoning, causing it to be overlooked in favor of Kimi.

### Key changes
- **`builtin-models.ts`**: Rewrote `CLAUDE_OPUS_47_DESCRIPTION` to emphasize dominance in "architectural planning" and "complex task decomposition" for hard problems requiring methodical analysis and superior plans.
- **`builtin-models.ts`**: Revised `KIMI_K25_DESCRIPTION` to focus on "exploration and research tasks" with image understanding, removing the claim of being best for general complex multi-step tasks.

### Impact
Affects model selection behavior in the orchestration layer. Tasks requiring complex architectural planning and decomposition will now more likely route to Claude Opus 4.7 rather than Kimi K2.5.