### PR TITLE
LLM-1454: Make keyboard shortcuts non-blocking during permission prompts

### DIFF
--- a/src/extensions/orchestration/prompt-enrichment.ts
+++ b/src/extensions/orchestration/prompt-enrichment.ts
@@ -26,6 +26,7 @@ import { homedir, platform, userInfo } from "node:os"
 import { isAbsolute, join, normalize, resolve } from "node:path"
 import type { AssistantMessage, ImageContent, TextContent } from "@mariozechner/pi-ai"
 import { type ExtensionAPI, type Skill, loadSkills } from "@mariozechner/pi-coding-agent"
+import { isKeyRelease, matchesKey } from "@mariozechner/pi-tui"
 import { ANSI, fg } from "../../ansi.js"
 import { getAvailableModels } from "../../startup-context.js"
 import { getGitBranch } from "../../utils.js"
@@ -135,12 +136,23 @@ export default function (skillPaths: string[]) {
 				)
 			}
 
-			pi.registerShortcut("alt+tab", {
-				description: "Toggle multi-model orchestration on/off",
-				handler: (ctx) => {
-					multiModelEnabled = !multiModelEnabled
-					ctx.ui.setStatus("multi-model", undefined)
-				},
+			// Global terminal input listener so alt+tab works even when a
+			// dialog (e.g. permission prompt) has focus instead of the editor.
+			let unsubAltTab: (() => void) | null = null
+			pi.on("session_start", async (_event, ctx) => {
+				if (unsubAltTab) unsubAltTab()
+				if (ctx.hasUI) {
+					unsubAltTab = ctx.ui.onTerminalInput((data) => {
+						if (matchesKey(data, "alt+tab")) {
+							if (!isKeyRelease(data)) {
+								multiModelEnabled = !multiModelEnabled
+								ctx.ui.setStatus("multi-model", undefined)
+							}
+							return { consume: true }
+						}
+						return undefined
+					})
+				}
 			})
 
 			// Detect the inverse of the context-event nudge below: the orchestrator reasons

--- a/src/extensions/permissions/index.ts
+++ b/src/extensions/permissions/index.ts
@@ -87,8 +87,9 @@ export default function permissionsExtension(pi: ExtensionAPI): void {
 	let cliMode: PermissionMode | undefined
 	let originalActiveTools: string[] | null = null
 	let planModeApplied = false
-	/** Shared mutable ref so handleConfirm (outside the closure) can set/clear the abort controller. */
-	const promptAbortRef: { current: AbortController | null } = { current: null }
+	let yoloWarningShown = false
+	/** Tracks all active permission prompt abort controllers for concurrent tool calls. */
+	const activeAbortControllers = new Set<AbortController>()
 	let unsubscribeTerminalInput: (() => void) | null = null
 
 	function rebuildConfigRules(): void {
@@ -177,12 +178,16 @@ export default function permissionsExtension(pi: ExtensionAPI): void {
 		if (next === "plan") applyPlanModeTools()
 		propagateModeToEnv()
 		updateStatus(ctx)
-		// Dismiss any active permission prompt so the tool_call handler can re-evaluate under the new mode.
-		if (promptAbortRef.current) {
-			promptAbortRef.current.abort()
-			promptAbortRef.current = null
+		// Dismiss all active permission prompts so tool_call handlers re-evaluate under the new mode.
+		for (const ctrl of activeAbortControllers) ctrl.abort()
+		activeAbortControllers.clear()
+		// Show danger warning when switching to yolo mode (only once per session)
+		if (next === "yolo" && ctx.hasUI && !yoloWarningShown) {
+			yoloWarningShown = true
+			const dangerMsg =
+				"DANGER: Running in YOLO mode. All permission checks are disabled. The agent will execute commands without confirmation. This can modify or delete files. Intended for use in disposable or sandboxed environments only. Not recommended for production use."
+			ctx.ui.notify(ctx.ui.theme.fg("error", dangerMsg), "warning")
 		}
-		maybeShowYoloWarning(ctx, next)
 	}
 
 	function doLoadConfig(ctx: ExtensionContext): { errors: string[] } {
@@ -324,18 +329,19 @@ export default function permissionsExtension(pi: ExtensionAPI): void {
 					ctx,
 					subtitle: `Classifier: ${verdict.reason}`,
 					session,
-					abortRef: promptAbortRef,
+					activeAborts: activeAbortControllers,
 				})
 				if (result === "aborted") continue // mode changed, re-evaluate
 				return result
 			}
 
-			const result = await handleConfirm(event, { ctx, session, abortRef: promptAbortRef })
+			const result = await handleConfirm(event, { ctx, session, activeAborts: activeAbortControllers })
 			if (result === "aborted") continue // mode changed, re-evaluate
 			return result
 		}
 
 		// Exhausted re-evaluation attempts — fail closed.
+		console.warn("permissions: mode changed too many times during prompt, failing closed")
 		return { block: true, reason: "Permission mode changed too many times during prompt" }
 	})
 
@@ -364,7 +370,7 @@ interface ConfirmOptions {
 	ctx: ExtensionContext
 	session: SessionMemory
 	subtitle?: string
-	abortRef: { current: AbortController | null }
+	activeAborts: Set<AbortController>
 }
 
 async function handleConfirm(
@@ -372,7 +378,7 @@ async function handleConfirm(
 	opts: ConfirmOptions,
 ): Promise<{ block: true; reason: string } | "aborted" | undefined> {
 	const abort = new AbortController()
-	opts.abortRef.current = abort
+	opts.activeAborts.add(abort)
 	try {
 		const outcome = await promptForApproval({
 			toolName: event.toolName,
@@ -393,7 +399,7 @@ async function handleConfirm(
 		}
 		return { block: true, reason: "Declined by user" }
 	} finally {
-		opts.abortRef.current = null
+		opts.activeAborts.delete(abort)
 	}
 }
 

--- a/src/extensions/permissions/index.ts
+++ b/src/extensions/permissions/index.ts
@@ -181,6 +181,7 @@ export default function permissionsExtension(pi: ExtensionAPI): void {
 		// Dismiss all active permission prompts so tool_call handlers re-evaluate under the new mode.
 		for (const ctrl of activeAbortControllers) ctrl.abort()
 		activeAbortControllers.clear()
+		maybeShowYoloWarning(ctx, next)
 		// Show danger warning when switching to yolo mode (only once per session)
 		if (next === "yolo" && ctx.hasUI && !yoloWarningShown) {
 			yoloWarningShown = true
@@ -267,7 +268,7 @@ export default function permissionsExtension(pi: ExtensionAPI): void {
 		// Re-evaluation loop: when a permission prompt is dismissed because the user
 		// changed mode via shift+tab, we re-evaluate the tool call under the new mode.
 		// Cap iterations at MODES.length to prevent infinite loops.
-		for (let attempt = 0; attempt <= MODES.length; attempt++) {
+		for (let attempt = 0; attempt < MODES.length; attempt++) {
 			const mode = currentMode()
 
 			// YOLO mode: bypass ALL permission checks including rules, denylist, and classifier

--- a/src/extensions/permissions/index.ts
+++ b/src/extensions/permissions/index.ts
@@ -1,4 +1,5 @@
 import type { ExtensionAPI, ExtensionContext, ToolCallEvent } from "@mariozechner/pi-coding-agent"
+import { isKeyRelease, matchesKey } from "@mariozechner/pi-tui"
 import { RST_FG, resolvedSemanticFg } from "../../ansi.js"
 import { classifyToolCall } from "./classifier.js"
 import { registerCommands } from "./commands.js"
@@ -75,11 +76,6 @@ export default function permissionsExtension(pi: ExtensionAPI): void {
 		type: "string",
 	})
 
-	pi.registerShortcut("shift+tab", {
-		description: "Cycle permission mode (default → plan → yolo)",
-		handler: (ctx) => cycleMode(ctx),
-	})
-
 	const session = new SessionMemory()
 	const builtinRules: Rule[] = parseRules(BUILTIN_DENY, "deny", "builtin")
 	// Snapshot env before propagateModeToEnv overwrites it; otherwise
@@ -91,6 +87,9 @@ export default function permissionsExtension(pi: ExtensionAPI): void {
 	let cliMode: PermissionMode | undefined
 	let originalActiveTools: string[] | null = null
 	let planModeApplied = false
+	/** Shared mutable ref so handleConfirm (outside the closure) can set/clear the abort controller. */
+	const promptAbortRef: { current: AbortController | null } = { current: null }
+	let unsubscribeTerminalInput: (() => void) | null = null
 
 	function rebuildConfigRules(): void {
 		configRules = [
@@ -178,6 +177,11 @@ export default function permissionsExtension(pi: ExtensionAPI): void {
 		if (next === "plan") applyPlanModeTools()
 		propagateModeToEnv()
 		updateStatus(ctx)
+		// Dismiss any active permission prompt so the tool_call handler can re-evaluate under the new mode.
+		if (promptAbortRef.current) {
+			promptAbortRef.current.abort()
+			promptAbortRef.current = null
+		}
 		maybeShowYoloWarning(ctx, next)
 	}
 
@@ -213,6 +217,23 @@ export default function permissionsExtension(pi: ExtensionAPI): void {
 			else console.error(`permissions: ${err}`)
 		}
 
+		// Register a global terminal input listener so that the shift+tab shortcut
+		// works even when a permission prompt (ExtensionSelectorComponent) has focus.
+		if (unsubscribeTerminalInput) unsubscribeTerminalInput()
+		if (ctx.hasUI) {
+			unsubscribeTerminalInput = ctx.ui.onTerminalInput((data) => {
+				if (matchesKey(data, "shift+tab")) {
+					// Kitty keyboard protocol sends both press and release events;
+					// ignore the release to avoid cycling the mode twice per keystroke.
+					if (!isKeyRelease(data)) {
+						cycleMode(ctx)
+					}
+					return { consume: true }
+				}
+				return undefined
+			})
+		}
+
 		// CLI-flag rules live in session memory so /permissions list shows them.
 		session.addMany(parseRules(loaded.allowBySource.cli, "allow", "cli"))
 		session.addMany(parseRules(loaded.denyBySource.cli, "deny", "cli"))
@@ -235,69 +256,87 @@ export default function permissionsExtension(pi: ExtensionAPI): void {
 	})
 
 	pi.on("tool_call", async (event, ctx) => {
-		const mode = currentMode()
 		const toolName = event.toolName.toLowerCase()
 		const input = event.input as Record<string, unknown>
 
-		// YOLO mode: bypass ALL permission checks including rules, denylist, and classifier
-		if (mode === "yolo") {
-			return undefined
-		}
+		// Re-evaluation loop: when a permission prompt is dismissed because the user
+		// changed mode via shift+tab, we re-evaluate the tool call under the new mode.
+		// Cap iterations at MODES.length to prevent infinite loops.
+		for (let attempt = 0; attempt <= MODES.length; attempt++) {
+			const mode = currentMode()
 
-		if (mode === "plan") {
-			if (toolName === "bash") {
-				const command = typeof input.command === "string" ? input.command : ""
-				if (!isReadOnlyBashCommand(command)) {
+			// YOLO mode: bypass ALL permission checks including rules, denylist, and classifier
+			if (mode === "yolo") {
+				return undefined
+			}
+
+			if (mode === "plan") {
+				if (toolName === "bash") {
+					const command = typeof input.command === "string" ? input.command : ""
+					if (!isReadOnlyBashCommand(command)) {
+						return {
+							block: true,
+							reason: `Plan mode: bash command "${command}" is not in the read-only allowlist. Use /permissions mode default (or auto) to run writes.`,
+						}
+					}
+					return undefined
+				}
+				if (!isReadOnlyTool(toolName) && !PLAN_MODE_TOOLS.includes(toolName)) {
 					return {
 						block: true,
-						reason: `Plan mode: bash command "${command}" is not in the read-only allowlist. Use /permissions mode default (or auto) to run writes.`,
+						reason: `Plan mode: tool ${toolName} is not available. Use /permissions mode default to enable writes.`,
 					}
 				}
 				return undefined
 			}
-			if (!isReadOnlyTool(toolName) && !PLAN_MODE_TOOLS.includes(toolName)) {
-				return {
-					block: true,
-					reason: `Plan mode: tool ${toolName} is not available. Use /permissions mode default to enable writes.`,
+
+			const match = evaluateRules(allRules(), toolName, input)
+			if (match.decision === "deny") {
+				return { block: true, reason: `Denied by rule ${formatRule(match.rule)}` }
+			}
+			if (match.decision === "allow") return undefined
+
+			if (BUILTIN_ALLOW_TOOL_NAMES.includes(toolName)) return undefined
+
+			// Auto mode + headless default mode (subagents) both go through the
+			// classifier; prompts without a UI fail closed.
+			if (mode === "auto" || !ctx.hasUI) {
+				if (isReadOnlyTool(toolName)) return undefined
+				if (toolName === "bash") {
+					const command = typeof input.command === "string" ? input.command : ""
+					if (isReadOnlyBashCommand(command)) return undefined
 				}
+
+				const verdict = await classifyToolCall(
+					ctx,
+					{ toolName, input, cwd: ctx.cwd },
+					{ timeoutMs: loaded.config.classifierTimeoutMs },
+				)
+
+				if (verdict.verdict === "safe") return undefined
+				if (verdict.verdict === "blocked") {
+					return { block: true, reason: `Classifier blocked: ${verdict.reason}` }
+				}
+				if (!ctx.hasUI) {
+					return { block: true, reason: `Classifier: ${verdict.reason} (no UI to confirm)` }
+				}
+				const result = await handleConfirm(event, {
+					ctx,
+					subtitle: `Classifier: ${verdict.reason}`,
+					session,
+					abortRef: promptAbortRef,
+				})
+				if (result === "aborted") continue // mode changed, re-evaluate
+				return result
 			}
-			return undefined
+
+			const result = await handleConfirm(event, { ctx, session, abortRef: promptAbortRef })
+			if (result === "aborted") continue // mode changed, re-evaluate
+			return result
 		}
 
-		const match = evaluateRules(allRules(), toolName, input)
-		if (match.decision === "deny") {
-			return { block: true, reason: `Denied by rule ${formatRule(match.rule)}` }
-		}
-		if (match.decision === "allow") return undefined
-
-		if (BUILTIN_ALLOW_TOOL_NAMES.includes(toolName)) return undefined
-
-		// Auto mode + headless default mode (subagents) both go through the
-		// classifier; prompts without a UI fail closed.
-		if (mode === "auto" || !ctx.hasUI) {
-			if (isReadOnlyTool(toolName)) return undefined
-			if (toolName === "bash") {
-				const command = typeof input.command === "string" ? input.command : ""
-				if (isReadOnlyBashCommand(command)) return undefined
-			}
-
-			const verdict = await classifyToolCall(
-				ctx,
-				{ toolName, input, cwd: ctx.cwd },
-				{ timeoutMs: loaded.config.classifierTimeoutMs },
-			)
-
-			if (verdict.verdict === "safe") return undefined
-			if (verdict.verdict === "blocked") {
-				return { block: true, reason: `Classifier blocked: ${verdict.reason}` }
-			}
-			if (!ctx.hasUI) {
-				return { block: true, reason: `Classifier: ${verdict.reason} (no UI to confirm)` }
-			}
-			return handleConfirm(event, { ctx, subtitle: `Classifier: ${verdict.reason}`, session })
-		}
-
-		return handleConfirm(event, { ctx, session })
+		// Exhausted re-evaluation attempts — fail closed.
+		return { block: true, reason: "Permission mode changed too many times during prompt" }
 	})
 
 	registerCommands(pi, {
@@ -325,28 +364,37 @@ interface ConfirmOptions {
 	ctx: ExtensionContext
 	session: SessionMemory
 	subtitle?: string
+	abortRef: { current: AbortController | null }
 }
 
 async function handleConfirm(
 	event: ToolCallEvent,
 	opts: ConfirmOptions,
-): Promise<{ block: true; reason: string } | undefined> {
-	const outcome = await promptForApproval({
-		toolName: event.toolName,
-		input: event.input as Record<string, unknown>,
-		ctx: opts.ctx,
-		subtitle: opts.subtitle,
-	})
+): Promise<{ block: true; reason: string } | "aborted" | undefined> {
+	const abort = new AbortController()
+	opts.abortRef.current = abort
+	try {
+		const outcome = await promptForApproval({
+			toolName: event.toolName,
+			input: event.input as Record<string, unknown>,
+			ctx: opts.ctx,
+			subtitle: opts.subtitle,
+			signal: abort.signal,
+		})
 
-	if (outcome.kind === "allow-once") return undefined
-	if (outcome.kind === "allow-remember") {
-		opts.session.add(outcome.rule)
-		return undefined
+		if (outcome.kind === "aborted") return "aborted"
+		if (outcome.kind === "allow-once") return undefined
+		if (outcome.kind === "allow-remember") {
+			opts.session.add(outcome.rule)
+			return undefined
+		}
+		if (outcome.kind === "deny-with-feedback") {
+			return { block: true, reason: outcome.feedback }
+		}
+		return { block: true, reason: "Declined by user" }
+	} finally {
+		opts.abortRef.current = null
 	}
-	if (outcome.kind === "deny-with-feedback") {
-		return { block: true, reason: outcome.feedback }
-	}
-	return { block: true, reason: "Declined by user" }
 }
 
 function splitFlag(raw: boolean | string | undefined): string[] {

--- a/src/extensions/permissions/prompts.ts
+++ b/src/extensions/permissions/prompts.ts
@@ -7,6 +7,7 @@ export type ApprovalOutcome =
 	| { kind: "allow-remember"; rule: Rule }
 	| { kind: "deny-with-feedback"; feedback: string }
 	| { kind: "deny" }
+	| { kind: "aborted" }
 
 interface PromptOptions {
 	toolName: string
@@ -14,6 +15,8 @@ interface PromptOptions {
 	ctx: ExtensionContext
 	/** Extra context line shown above the choices (e.g. classifier reason). */
 	subtitle?: string
+	/** Signal to programmatically dismiss the prompt (e.g. when permission mode changes). */
+	signal?: AbortSignal
 }
 
 export async function promptForApproval(opts: PromptOptions): Promise<ApprovalOutcome> {
@@ -30,7 +33,11 @@ export async function promptForApproval(opts: PromptOptions): Promise<ApprovalOu
 	const yesRemember = `Yes — don't ask again for ${scope.label} this session`
 	const noWithFeedback = "No — tell the assistant what to do differently"
 
-	const choice = await ctx.ui.select(lines.join("\n"), [yesOnce, yesRemember, noWithFeedback])
+	const choice = await ctx.ui.select(lines.join("\n"), [yesOnce, yesRemember, noWithFeedback], {
+		signal: opts.signal,
+	})
+
+	if (choice === undefined && opts.signal?.aborted) return { kind: "aborted" }
 
 	if (choice === yesOnce) return { kind: "allow-once" }
 

--- a/src/extensions/ui.ts
+++ b/src/extensions/ui.ts
@@ -190,7 +190,9 @@ export default function uiExtension(pi: ExtensionAPI) {
 							let idx = available.findIndex((m) => modelsAreEqual(m, current))
 							if (idx === -1) idx = 0
 							const next = available[(idx + 1) % available.length]
-							pi.setModel(next).catch(() => {})
+							pi.setModel(next).catch((err) => {
+								ctx.ui.notify(`Failed to cycle model: ${err instanceof Error ? err.message : String(err)}`, "warning")
+							})
 						}
 					}
 					return { consume: true }

--- a/src/extensions/ui.ts
+++ b/src/extensions/ui.ts
@@ -1,6 +1,8 @@
 import { spawn } from "node:child_process"
+import type { Api, Model } from "@mariozechner/pi-ai"
 import type { ExtensionAPI, ExtensionContext } from "@mariozechner/pi-coding-agent"
 import { isEditToolResult, isWriteToolResult } from "@mariozechner/pi-coding-agent"
+import { isKeyRelease, matchesKey } from "@mariozechner/pi-tui"
 import type { TUI } from "@mariozechner/pi-tui"
 import { PromptEditor } from "../components/editor.js"
 import { ScriptFooter, StatsFooter, buildScriptPayload, readStatusLineCommand } from "../components/footer.js"
@@ -8,6 +10,10 @@ import { LogoHeader } from "../components/logo.js"
 import { SplashHeader } from "../components/splash-header.js"
 import { collapseAll, expandNext, resetState } from "../expand-state.js"
 import { isBareExitAlias } from "./exit-utils.js"
+
+function modelsAreEqual(a: Model<Api>, b: Model<Api>): boolean {
+	return a.provider === b.provider && a.id === b.id
+}
 
 const HORIZONTAL_PADDING = 2
 
@@ -90,6 +96,7 @@ function runScript(scriptPath: string, payload: object, tui: TUI, footer: Script
 
 export default function uiExtension(pi: ExtensionAPI) {
 	let tuiPatched = false
+	let unsubModelCycleInput: (() => void) | null = null
 	let scriptFooter: ScriptFooter | null = null
 	let scriptTui: TUI | null = null
 	let scriptCmd: string | null = null
@@ -169,6 +176,28 @@ export default function uiExtension(pi: ExtensionAPI) {
 			currentEditor = editor
 			return editor
 		})
+
+		// Register a global terminal input listener so ctrl+p (model cycle forward)
+		// works even when a permission prompt or other dialog has focus.
+		if (unsubModelCycleInput) unsubModelCycleInput()
+		if (ctx.hasUI) {
+			unsubModelCycleInput = ctx.ui.onTerminalInput((data) => {
+				if (matchesKey(data, "ctrl+p")) {
+					if (!isKeyRelease(data)) {
+						const available = ctx.modelRegistry.getAvailable()
+						const current = ctx.model
+						if (available.length > 1 && current) {
+							let idx = available.findIndex((m) => modelsAreEqual(m, current))
+							if (idx === -1) idx = 0
+							const next = available[(idx + 1) % available.length]
+							pi.setModel(next).catch(() => {})
+						}
+					}
+					return { consume: true }
+				}
+				return undefined
+			})
+		}
 	})
 
 	pi.on("input", (event, ctx) => {


### PR DESCRIPTION
## Problem

Users cannot interact with the harness at all while a permission prompt is displayed. The `ExtensionSelectorComponent` captures all keyboard focus, blocking extension shortcuts (shift+tab, alt+tab) and app keybindings (ctrl+p).

## Root Cause

Shortcuts were wired through `CustomEditor.onExtensionShortcut`, which only fires when the editor has focus. When `showExtensionSelector()` replaces the editor with the selector component, the shortcut handler becomes unreachable. The selector drops all unrecognized keys.

## Solution

Register global `onTerminalInput` listeners that intercept shortcut keys **before** they reach the focused component. The TUI input pipeline processes these listeners before dispatching to the focused component, so they work regardless of which component has focus.

### Shortcuts now working during permission prompts

| Shortcut | Action | Location |
|---|---|---|
| **shift+tab** | Cycle permission mode | `permissions/index.ts` |
| **alt+tab** | Toggle multi-model orchestration | `orchestration/prompt-enrichment.ts` |
| **ctrl+p** | Cycle to next model | `ui.ts` |

### Key implementation details

- **Abort + re-evaluate**: When shift+tab changes the permission mode during an active prompt, the prompt is dismissed via `AbortController` and the `tool_call` handler re-evaluates the tool call under the new mode (e.g., switching to yolo auto-approves)
- **Key release filtering**: All listeners filter out key release events (`isKeyRelease`) to avoid double-firing under the Kitty keyboard protocol
- **Replaced `registerShortcut`**: All `pi.registerShortcut()` calls replaced with `onTerminalInput` listeners to avoid double-handling (the editor shortcut mechanism + the global listener would both fire)

### Files changed

- `src/extensions/permissions/prompts.ts` — Added `aborted` outcome and `AbortSignal` support
- `src/extensions/permissions/index.ts` — Global input listener for shift+tab, abort controller, re-evaluation loop
- `src/extensions/orchestration/prompt-enrichment.ts` — Global input listener for alt+tab
- `src/extensions/ui.ts` — Global input listener for ctrl+p (model cycling)

## Testing

- All 648 tests pass
- Type checking clean
- Lint clean

---
### Kimchi Summary
### What changed
Converts keyboard shortcuts (`alt+tab`, `shift+tab`, `ctrl+p`) from local editor shortcuts to global terminal input listeners so they work when permission prompts or other dialogs have focus. Adds graceful handling for permission mode changes while prompts are active, and displays a one-time danger warning when entering YOLO mode.

### Why
Previously, shortcuts like `shift+tab` (cycle permission mode) and `alt+tab` (toggle multi-model orchestration) were unavailable when a permission dialog was open because focus was on the dialog component rather than the editor. Additionally, changing permission modes while a tool call was awaiting user confirmation would leave the prompt hanging; now mode changes immediately abort active prompts and re-evaluate the tool call under the new mode.

### Key changes
- **`src/extensions/orchestration/prompt-enrichment.ts`**: Replaces `pi.registerShortcut("alt+tab", …)` with a `session_start` handler that calls `ctx.ui.onTerminalInput` to toggle `multiModelEnabled` globally.
- **`src/extensions/permissions/index.ts`**: 
  - Replaces `pi.registerShortcut("shift+tab", …)` with a global terminal input listener that invokes `cycleMode`.
  - Tracks active permission prompts via an `activeAbortControllers` set; `cycleMode` now aborts all active prompts so concurrent `tool_call` handlers re-evaluate under the new mode.
  - Wraps `tool_call` handling in a re-evaluation loop (max 3 attempts) to handle mode switches during confirmation.
  - Adds `yoloWarningShown` flag to display a one-time danger notification when switching to YOLO mode.
- **`src/extensions/permissions/prompts.ts`**: Adds `signal` option to `promptForApproval` and returns `{ kind: "aborted" }` when the prompt is dismissed via `AbortSignal`.
- **`src/extensions/ui.ts`**: Adds global terminal input listener for `ctrl+p` to cycle through available models via `ctx.modelRegistry`, ensuring it works when dialogs are open.

### Impact
- **Breaking**: Shortcuts now consume input events globally; custom components that previously intercepted these keys may need adjustment.
- **Behavior**: Changing permission mode during an active prompt immediately cancels the prompt and re-runs the permission check; if the mode cycles too many times (>=3), the tool call fails closed with a block.