### PR TITLE
Hitl metrics

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,24 @@ Thumbs.db
 
 # Test coverage
 coverage/
+
+# ── GSD baseline (auto-generated) ──
+.gsd
+.gsd-id
+.mcp.json
+.bg-shell/
+*~
+*.code-workspace
+.env.*
+!.env.example
+.next/
+build/
+__pycache__/
+*.pyc
+.venv/
+venv/
+target/
+vendor/
+*.log
+.cache/
+tmp/

--- a/.gitignore
+++ b/.gitignore
@@ -25,6 +25,9 @@ Thumbs.db
 # Test coverage
 coverage/
 
+# Kimchi local config
+.kimchi/
+
 # ── GSD baseline (auto-generated) ──
 .gsd
 .gsd-id

--- a/extensions/hitl-metrics/commands/metrics.test.ts
+++ b/extensions/hitl-metrics/commands/metrics.test.ts
@@ -1,0 +1,412 @@
+/**
+ * Metrics Command Integration Tests
+ *
+ * Tests the /metrics command handler with both populated and empty DB scenarios.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest"
+import { handleMetricsCommand } from "./metrics.ts"
+import { HitlDatabase, projectHash, getSessionStats, getRecentSessions } from "../storage/index.ts"
+import type { HitlStats, HitlSession } from "../types.ts"
+import type { ExtensionCommandContext, Theme } from "@mariozechner/pi-coding-agent"
+import { homedir } from "node:os"
+import { resolve } from "node:path"
+import { mkdtempSync, rmSync } from "node:fs"
+
+// --- Mock Theme ---
+const mockTheme: Theme = {
+	fg: (color: string, text: string) => `[${color}:${text}]`,
+	bg: (color: string, text: string) => text,
+	bold: (text: string) => `<b>${text}</b>`,
+	dim: (text: string) => text,
+	italic: (text: string) => text,
+	underline: (text: string) => text,
+	strikethrough: (text: string) => text,
+}
+
+// --- Mock ExtensionCommandContext ---
+function createMockCtx(overrides: Partial<ExtensionCommandContext> = {}): ExtensionCommandContext {
+	return {
+		cwd: "/tmp/test",
+		hasUI: true,
+		ui: {
+			notify: vi.fn(),
+			theme: mockTheme,
+		},
+		...overrides,
+	}
+}
+
+// --- Setup Helpers ---
+function seedDatabase(db: HitlDatabase, hash: string): void {
+	db.open()
+	db.initSchema()
+
+	// Insert test sessions
+	const now = Date.now()
+	const sessionId1 = "test-session-1"
+	const sessionId2 = "test-session-2"
+
+	db.run(
+		"INSERT INTO hitl_sessions (id, project_hash, started_at, ended_at, status) VALUES (?, ?, ?, ?, ?)",
+		[sessionId1, hash, now - 3600000, now - 3000000, "closed"],
+	)
+	db.run(
+		"INSERT INTO hitl_sessions (id, project_hash, started_at, ended_at, status) VALUES (?, ?, ?, ?, ?)",
+		[sessionId2, hash, now - 1800000, now - 900000, "closed"],
+	)
+
+	// Insert test events
+	db.run(
+		"INSERT INTO hitl_events (session_id, tool_name, question_count, duration_ms, selected_options, created_at) VALUES (?, ?, ?, ?, ?, ?)",
+		[sessionId1, "ask_user_questions", 2, 1200, JSON.stringify(["option1"]), now - 3500000],
+	)
+	db.run(
+		"INSERT INTO hitl_events (session_id, tool_name, question_count, duration_ms, selected_options, created_at) VALUES (?, ?, ?, ?, ?, ?)",
+		[sessionId1, "ask_user_questions", 1, 800, JSON.stringify(["option2"]), now - 3400000],
+	)
+	db.run(
+		"INSERT INTO hitl_events (session_id, tool_name, question_count, duration_ms, selected_options, created_at) VALUES (?, ?, ?, ?, ?, ?)",
+		[sessionId2, "ask_user_questions", 3, 2000, JSON.stringify(["option3", "option4"]), now - 800000],
+	)
+}
+
+// --- Tests ---
+describe("handleMetricsCommand", () => {
+	let tempDir: string
+	let mockCtx: ReturnType<typeof createMockCtx>
+
+	beforeEach(() => {
+		tempDir = mkdtempSync("/tmp/hitl-test-")
+		mockCtx = createMockCtx({ cwd: tempDir })
+	})
+
+	afterEach(() => {
+		try {
+			rmSync(tempDir, { recursive: true, force: true })
+		} catch {
+			// Ignore
+		}
+	})
+
+	it("should show empty state when no DB exists", async () => {
+		await handleMetricsCommand("", mockCtx)
+
+		expect(mockCtx.ui.notify).toHaveBeenCalledWith("No HITL data recorded yet", "info")
+	})
+
+	it("should show error when cwd is missing", async () => {
+		const ctxNoCwd = createMockCtx({ cwd: undefined })
+		await handleMetricsCommand("", ctxNoCwd)
+
+		expect(ctxNoCwd.ui.notify).toHaveBeenCalledWith("No project directory available", "error")
+	})
+
+	it("should handle no-UI case gracefully", async () => {
+		const consoleSpy = vi.spyOn(console, "log").mockImplementation(() => {})
+		
+		// Use a unique temp directory path to avoid picking up existing data
+		const uniqueTempDir = mkdtempSync("/tmp/hitl-noui-test-")
+		const ctxNoUI = createMockCtx({ hasUI: false, cwd: uniqueTempDir })
+
+		await handleMetricsCommand("", ctxNoUI)
+
+		expect(consoleSpy).toHaveBeenCalledWith("HITL Metrics:")
+		// Output contains the no-data message since DB doesn't exist
+		const output = consoleSpy.mock.calls[1][0] as string
+		expect(output).toContain("No HITL data recorded yet")
+
+		consoleSpy.mockRestore()
+		
+		// Cleanup
+		try {
+			rmSync(uniqueTempDir, { recursive: true, force: true })
+		} catch {
+			// Ignore
+		}
+	})
+
+	it("should display metrics via notify when DB has data", async () => {
+		const projectHashStr = projectHash(tempDir)
+		const storageDir = resolve(homedir(), ".hitl-metrics")
+		const expectedDbPath = resolve(storageDir, `${projectHashStr}.db`)
+
+		// Create DB at expected location
+		const db = new HitlDatabase(expectedDbPath)
+		seedDatabase(db, projectHashStr)
+		db.close()
+
+		await handleMetricsCommand("", mockCtx)
+
+		// Should notify with formatted output containing expected elements
+		const notifyCall = mockCtx.ui.notify as unknown as ReturnType<typeof vi.fn>
+		expect(notifyCall).toHaveBeenCalled()
+		const notifiedMessage = notifyCall.mock.calls[0][0] as string
+		expect(notifiedMessage).toContain("HITL Metrics")
+		expect(notifiedMessage).toContain("Total sessions")
+		expect(notifiedMessage).toContain("2")
+
+		// Cleanup
+		try {
+			rmSync(expectedDbPath, { force: true })
+		} catch {
+			// Ignore
+		}
+	})
+
+	it("should handle DB errors gracefully", async () => {
+		// Mock console.warn to suppress warning
+		const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {})
+		
+		// Point to a directory where DB exists but is corrupted
+		const projectHashStr = projectHash(tempDir)
+		const storageDir = resolve(homedir(), ".hitl-metrics")
+		const expectedDbPath = resolve(storageDir, `${projectHashStr}.db`)
+
+		// Create empty/corrupted DB file
+		const db = new HitlDatabase(expectedDbPath)
+		db.open()
+		db.close()
+		// Database exists but has no schema — querying should fail gracefully
+
+		await handleMetricsCommand("", mockCtx)
+
+		// Should fall back to empty state
+		expect(mockCtx.ui.notify).toHaveBeenCalledWith("No HITL data recorded yet", "info")
+
+		warnSpy.mockRestore()
+
+		// Cleanup
+		try {
+			rmSync(expectedDbPath, { force: true })
+		} catch {
+			// Ignore
+		}
+	})
+})
+
+describe("storage integration", () => {
+	let tempDir: string
+
+	beforeEach(() => {
+		tempDir = mkdtempSync("/tmp/hitl-test-")
+	})
+
+	afterEach(() => {
+		try {
+			rmSync(tempDir, { recursive: true, force: true })
+		} catch {
+			// Ignore
+		}
+	})
+
+	it("getSessionStats and getRecentSessions return correct data", async () => {
+		const hash = projectHash(tempDir)
+		const dbPath = resolve(tempDir, "test.db")
+
+		// Create and seed DB
+		const db = new HitlDatabase(dbPath)
+		seedDatabase(db, hash)
+		db.close()
+
+		// Reopen to query
+		const db2 = new HitlDatabase(dbPath)
+		db2.open()
+
+		const stats: HitlStats = getSessionStats(db2, hash)
+		const sessions: HitlSession[] = getRecentSessions(db2, hash, 10)
+
+		expect(stats.total_sessions).toBe(2)
+		expect(stats.interaction_count).toBe(3)
+		expect(stats.total_hitl_time_ms).toBe(4000) // 1200 + 800 + 2000
+		expect(stats.avg_wait_ms).toBeGreaterThan(0)
+		expect(sessions.length).toBe(2)
+		expect(sessions[0].status).toBe("closed")
+
+		db2.close()
+	})
+
+	it("returns zero stats for empty database", () => {
+		const hash = projectHash(tempDir)
+		const dbPath = resolve(tempDir, "empty.db")
+
+		// Create empty DB with schema
+		const db = new HitlDatabase(dbPath)
+		db.open()
+		db.initSchema()
+
+		const stats: HitlStats = getSessionStats(db, hash)
+		const sessions: HitlSession[] = getRecentSessions(db, hash, 10)
+
+		expect(stats.total_sessions).toBe(0)
+		expect(stats.interaction_count).toBe(0)
+		
+expect(stats.total_hitl_time_ms).toBe(0)
+		expect(stats.avg_wait_ms).toBe(0)
+		expect(sessions.length).toBe(0)
+
+		db.close()
+	})
+})
+
+describe("timeline integration", () => {
+	let tempDir: string
+
+	beforeEach(() => {
+		tempDir = mkdtempSync("/tmp/hitl-test-")
+	})
+
+	afterEach(() => {
+		try {
+			rmSync(tempDir, { recursive: true, force: true })
+		} catch {
+			// Ignore
+		}
+	})
+
+	it("getMetricsOutput includes timeline for closed session with events", async () => {
+		const { getMetricsOutput } = await import("./metrics.ts")
+		const projectHashStr = projectHash(tempDir)
+		const storageDir = resolve(homedir(), ".hitl-metrics")
+		const expectedDbPath = resolve(storageDir, `${projectHashStr}.db`)
+
+		// Create DB at expected location
+		const db = new HitlDatabase(expectedDbPath)
+		db.open()
+		db.initSchema()
+
+		const now = Date.now()
+		const sessionId = "test-session-timeline"
+
+		// Insert a closed session
+		db.run(
+			"INSERT INTO hitl_sessions (id, project_hash, started_at, ended_at, status) VALUES (?, ?, ?, ?, ?)",
+			[sessionId, projectHashStr, now - 3600000, now - 60000, "closed"],
+		)
+
+		// Insert events for the session
+		db.run(
+			"INSERT INTO hitl_events (session_id, tool_name, question_count, duration_ms, selected_options, created_at) VALUES (?, ?, ?, ?, ?, ?)",
+			[sessionId, "ask_user_questions", 2, 120000, JSON.stringify(["option1"]), now - 3500000],
+		)
+		db.run(
+			"INSERT INTO hitl_events (session_id, tool_name, question_count, duration_ms, selected_options, created_at) VALUES (?, ?, ?, ?, ?, ?)",
+			[sessionId, "ask_user_questions", 1, 60000, JSON.stringify(["option2"]), now - 3300000],
+		)
+
+		db.close()
+
+		const mockTheme = {
+			fg: (c: string, t: string) => t,
+			bg: (c: string, t: string) => t,
+			bold: (t: string) => t,
+			dim: (t: string) => t,
+			italic: (t: string) => t,
+			underline: (t: string) => t,
+			strikethrough: (t: string) => t,
+		}
+
+		const output = await getMetricsOutput(tempDir, mockTheme as Theme)
+
+		expect(output).toContain("Session Timeline")
+		expect(output).toContain("solo")
+		expect(output).toContain("HITL")
+
+		// Cleanup
+		try {
+			rmSync(expectedDbPath, { force: true })
+		} catch {
+			// Ignore
+		}
+	})
+
+	it("getMetricsOutput omits timeline when no closed sessions exist", async () => {
+		const { getMetricsOutput } = await import("./metrics.ts")
+		const projectHashStr = projectHash(tempDir)
+		const storageDir = resolve(homedir(), ".hitl-metrics")
+		const expectedDbPath = resolve(storageDir, `${projectHashStr}.db`)
+
+		// Create DB at expected location
+		const db = new HitlDatabase(expectedDbPath)
+		db.open()
+		db.initSchema()
+
+		const now = Date.now()
+		const sessionId = "test-session-active"
+
+		// Insert only an active session (no closed sessions)
+		db.run(
+			"INSERT INTO hitl_sessions (id, project_hash, started_at, ended_at, status) VALUES (?, ?, ?, ?, ?)",
+			[sessionId, projectHashStr, now - 3600000, null, "active"],
+		)
+
+		db.close()
+
+		const mockTheme = {
+			fg: (c: string, t: string) => t,
+			bg: (c: string, t: string) => t,
+			bold: (t: string) => t,
+			dim: (t: string) => t,
+			italic: (t: string) => t,
+			underline: (t: string) => t,
+			strikethrough: (t: string) => t,
+		}
+
+		const output = await getMetricsOutput(tempDir, mockTheme as Theme)
+
+		// Should have metrics but no timeline section
+		expect(output).toContain("Total sessions")
+		expect(output).not.toContain("Session Timeline")
+
+		// Cleanup
+		try {
+			rmSync(expectedDbPath, { force: true })
+		} catch {
+			// Ignore
+		}
+	})
+
+	it("metrics command shows timeline when DB has closed session data", async () => {
+		const projectHashStr = projectHash(tempDir)
+		const storageDir = resolve(homedir(), ".hitl-metrics")
+		const expectedDbPath = resolve(storageDir, `${projectHashStr}.db`)
+
+		// Create DB at expected location
+		const db = new HitlDatabase(expectedDbPath)
+		db.open()
+		db.initSchema()
+
+		const now = Date.now()
+		const sessionId = "test-session-closed"
+
+		// Insert a closed session with events
+		db.run(
+			"INSERT INTO hitl_sessions (id, project_hash, started_at, ended_at, status) VALUES (?, ?, ?, ?, ?)",
+			[sessionId, projectHashStr, now - 3600000, now - 60000, "closed"],
+		)
+		db.run(
+			"INSERT INTO hitl_events (session_id, tool_name, question_count, duration_ms, selected_options, created_at) VALUES (?, ?, ?, ?, ?, ?)",
+			[sessionId, "ask_user_questions", 2, 120000, JSON.stringify(["option1"]), now - 3500000],
+		)
+
+		db.close()
+
+		const mockCtx = createMockCtx({ cwd: tempDir })
+		await handleMetricsCommand("", mockCtx)
+
+		// Should notify with output containing timeline
+		const notifyCall = mockCtx.ui.notify as unknown as ReturnType<typeof vi.fn>
+		expect(notifyCall).toHaveBeenCalled()
+		const notifiedMessage = notifyCall.mock.calls[0][0] as string
+		expect(notifiedMessage).toContain("Session Timeline")
+		expect(notifiedMessage).toContain("solo")
+		expect(notifiedMessage).toContain("HITL")
+
+		// Cleanup
+		try {
+			rmSync(expectedDbPath, { force: true })
+		} catch {
+			// Ignore
+		}
+	})
+})

--- a/extensions/hitl-metrics/commands/metrics.test.ts
+++ b/extensions/hitl-metrics/commands/metrics.test.ts
@@ -5,24 +5,35 @@
  */
 
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest"
-import { handleMetricsCommand } from "./metrics.ts"
-import { HitlDatabase, projectHash, getSessionStats, getRecentSessions } from "../storage/index.ts"
-import type { HitlStats, HitlSession } from "../types.ts"
+import { handleMetricsCommand } from "./metrics.js"
+import { HitlDatabase, projectHash, getSessionStats, getRecentSessions } from "../storage/index.js"
+import type { HitlStats, HitlSession } from "../types.js"
 import type { ExtensionCommandContext, Theme } from "@mariozechner/pi-coding-agent"
 import { homedir } from "node:os"
 import { resolve } from "node:path"
 import { mkdtempSync, rmSync } from "node:fs"
 
 // --- Mock Theme ---
-const mockTheme: Theme = {
-	fg: (color: string, text: string) => `[${color}:${text}]`,
-	bg: (color: string, text: string) => text,
-	bold: (text: string) => `<b>${text}</b>`,
-	dim: (text: string) => text,
-	italic: (text: string) => text,
-	underline: (text: string) => text,
-	strikethrough: (text: string) => text,
+function createMockTheme(): Theme {
+	const noOp = (text: string) => text
+	return {
+		name: "mock",
+		fg: (_c, text) => `[color:${text}]`,
+		bg: (_c, text) => text,
+		bold: (text) => `<b>${text}</b>`,
+		italic: noOp,
+		underline: noOp,
+		inverse: noOp,
+		strikethrough: noOp,
+		getFgAnsi: () => "",
+		getBgAnsi: () => "",
+		getColorMode: () => "truecolor",
+		getThinkingBorderColor: () => noOp,
+		getBashModeBorderColor: () => noOp,
+	} as unknown as Theme
 }
+
+const mockTheme: Theme = createMockTheme()
 
 // --- Mock ExtensionCommandContext ---
 function createMockCtx(overrides: Partial<ExtensionCommandContext> = {}): ExtensionCommandContext {
@@ -265,7 +276,7 @@ describe("timeline integration", () => {
 	})
 
 	it("getMetricsOutput includes timeline for closed session with events", async () => {
-		const { getMetricsOutput } = await import("./metrics.ts")
+		const { getMetricsOutput } = await import("./metrics.js")
 		const projectHashStr = projectHash(tempDir)
 		const storageDir = resolve(homedir(), ".hitl-metrics")
 		const expectedDbPath = resolve(storageDir, `${projectHashStr}.db`)
@@ -297,9 +308,9 @@ describe("timeline integration", () => {
 		db.close()
 
 		const mockTheme = {
-			fg: (c: string, t: string) => t,
-			bg: (c: string, t: string) => t,
-			bold: (t: string) => t,
+			fg: (_c: string, t: string) => t,
+			bg: (_c: string, t: string) => t,
+			bold: (t: string) => t, inverse: (t: string) => t,
 			dim: (t: string) => t,
 			italic: (t: string) => t,
 			underline: (t: string) => t,
@@ -321,7 +332,7 @@ describe("timeline integration", () => {
 	})
 
 	it("getMetricsOutput omits timeline when no closed sessions exist", async () => {
-		const { getMetricsOutput } = await import("./metrics.ts")
+		const { getMetricsOutput } = await import("./metrics.js")
 		const projectHashStr = projectHash(tempDir)
 		const storageDir = resolve(homedir(), ".hitl-metrics")
 		const expectedDbPath = resolve(storageDir, `${projectHashStr}.db`)
@@ -343,9 +354,9 @@ describe("timeline integration", () => {
 		db.close()
 
 		const mockTheme = {
-			fg: (c: string, t: string) => t,
-			bg: (c: string, t: string) => t,
-			bold: (t: string) => t,
+			fg: (_c: string, t: string) => t,
+			bg: (_c: string, t: string) => t,
+			bold: (t: string) => t, inverse: (t: string) => t,
 			dim: (t: string) => t,
 			italic: (t: string) => t,
 			underline: (t: string) => t,

--- a/extensions/hitl-metrics/commands/metrics.test.ts
+++ b/extensions/hitl-metrics/commands/metrics.test.ts
@@ -10,8 +10,8 @@ import { HitlDatabase, projectHash, getSessionStats, getRecentSessions } from ".
 import type { HitlStats, HitlSession } from "../types.js"
 import type { ExtensionCommandContext, Theme } from "@mariozechner/pi-coding-agent"
 import { homedir } from "node:os"
-import { resolve } from "node:path"
-import { mkdtempSync, rmSync } from "node:fs"
+import { resolve, join } from "node:path"
+import { mkdtempSync, rmSync, mkdirSync } from "node:fs"
 import { createMockTheme } from "../test-helpers/mock-theme.js"
 
 const mockTheme: Theme = createMockTheme()
@@ -84,6 +84,17 @@ function seedDatabase(db: HitlDatabase, hash: string): void {
 		"INSERT INTO hitl_events (session_id, tool_name, question_count, duration_ms, selected_options, created_at) VALUES (?, ?, ?, ?, ?, ?)",
 		[sessionId2, "ask_user_questions", 3, 2000, JSON.stringify(["option3", "option4"]), now - 800000],
 	)
+
+	// Set session time metrics so getSessionStats reads them correctly
+	// (stats now sums session.hitl_time_ms, not hitl_events.duration_ms)
+	db.run(
+		"UPDATE hitl_sessions SET agent_time_ms = 10000, hitl_time_ms = 2000, idle_time_ms = 500 WHERE id = ?",
+		[sessionId1],
+	)
+	db.run(
+		"UPDATE hitl_sessions SET agent_time_ms = 5000, hitl_time_ms = 2000, idle_time_ms = 300 WHERE id = ?",
+		[sessionId2],
+	)
 }
 
 // --- Tests ---
@@ -143,8 +154,9 @@ describe("handleMetricsCommand", () => {
 
 	it("should display metrics via notify when DB has data", async () => {
 		const projectHashStr = projectHash(tempDir)
-		const storageDir = resolve(homedir(), ".hitl-metrics")
-		const expectedDbPath = resolve(storageDir, `${projectHashStr}.db`)
+		const storageDir = join(homedir(), ".kimchi", "metrics", projectHashStr)
+		const expectedDbPath = join(storageDir, "hitl.db")
+		mkdirSync(storageDir, { recursive: true })
 
 		// Create DB at expected location
 		const db = new HitlDatabase(expectedDbPath)
@@ -228,8 +240,8 @@ describe("storage integration", () => {
 		const db2 = new HitlDatabase(dbPath)
 		db2.open()
 
-		const stats: HitlStats = getSessionStats(db2, hash)
-		const sessions: HitlSession[] = getRecentSessions(db2, hash, 10)
+		const stats: HitlStats = getSessionStats(db2)
+		const sessions: HitlSession[] = getRecentSessions(db2, 10)
 
 		expect(stats.total_sessions).toBe(2)
 		expect(stats.interaction_count).toBe(3)
@@ -250,8 +262,8 @@ describe("storage integration", () => {
 		db.open()
 		db.initSchema()
 
-		const stats: HitlStats = getSessionStats(db, hash)
-		const sessions: HitlSession[] = getRecentSessions(db, hash, 10)
+		const stats: HitlStats = getSessionStats(db)
+		const sessions: HitlSession[] = getRecentSessions(db, 10)
 
 		expect(stats.total_sessions).toBe(0)
 		expect(stats.interaction_count).toBe(0)
@@ -282,8 +294,9 @@ describe("timeline integration", () => {
 	it("getMetricsOutput includes timeline for closed session with events", async () => {
 		const { getMetricsOutput } = await import("./metrics.js")
 		const projectHashStr = projectHash(tempDir)
-		const storageDir = resolve(homedir(), ".hitl-metrics")
-		const expectedDbPath = resolve(storageDir, `${projectHashStr}.db`)
+		const storageDir = join(homedir(), ".kimchi", "metrics", projectHashStr)
+		const expectedDbPath = join(storageDir, "hitl.db")
+		mkdirSync(storageDir, { recursive: true })
 
 		// Create DB at expected location
 		const db = new HitlDatabase(expectedDbPath)
@@ -293,19 +306,22 @@ describe("timeline integration", () => {
 		const now = Date.now()
 		const sessionId = "test-session-timeline"
 
-		// Insert a closed session
+		// Insert a closed session with time data for timeline rendering
 		db.run(
-			"INSERT INTO hitl_sessions (id, project_hash, started_at, ended_at, status) VALUES (?, ?, ?, ?, ?)",
-			[sessionId, projectHashStr, now - 3600000, now - 60000, "closed"],
+			`INSERT INTO hitl_sessions (id, project_hash, started_at, ended_at, status, end_cause, agent_time_ms, hitl_time_ms, idle_time_ms)
+			 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+			[sessionId, projectHashStr, now - 3600000, now - 60000, "closed", "complete", 120000, 120000, 60000],
 		)
 
 		// Insert events for the session
 		db.run(
-			"INSERT INTO hitl_events (session_id, tool_name, question_count, duration_ms, selected_options, created_at) VALUES (?, ?, ?, ?, ?, ?)",
+			`INSERT INTO hitl_events (session_id, tool_name, question_count, duration_ms, selected_options, created_at)
+			 VALUES (?, ?, ?, ?, ?, ?)`,
 			[sessionId, "ask_user_questions", 2, 120000, JSON.stringify(["option1"]), now - 3500000],
 		)
 		db.run(
-			"INSERT INTO hitl_events (session_id, tool_name, question_count, duration_ms, selected_options, created_at) VALUES (?, ?, ?, ?, ?, ?)",
+			`INSERT INTO hitl_events (session_id, tool_name, question_count, duration_ms, selected_options, created_at)
+			 VALUES (?, ?, ?, ?, ?, ?)`,
 			[sessionId, "ask_user_questions", 1, 60000, JSON.stringify(["option2"]), now - 3300000],
 		)
 
@@ -313,11 +329,12 @@ describe("timeline integration", () => {
 
 		const mockTheme = createMockTheme()
 
-		const output = await getMetricsOutput(tempDir, mockTheme as Theme)
+		const output = await getMetricsOutput(tempDir, mockTheme as Theme, { dbPath: expectedDbPath })
 
 		expect(output).toContain("Session Timeline")
-		expect(output).toContain("solo")
+		expect(output).toContain("agent")
 		expect(output).toContain("HITL")
+		expect(output).toContain("idle")
 
 		// Cleanup
 		try {
@@ -330,8 +347,9 @@ describe("timeline integration", () => {
 	it("getMetricsOutput omits timeline when no closed sessions exist", async () => {
 		const { getMetricsOutput } = await import("./metrics.js")
 		const projectHashStr = projectHash(tempDir)
-		const storageDir = resolve(homedir(), ".hitl-metrics")
-		const expectedDbPath = resolve(storageDir, `${projectHashStr}.db`)
+		const storageDir = join(homedir(), ".kimchi", "metrics", projectHashStr)
+		const expectedDbPath = join(storageDir, "hitl.db")
+		mkdirSync(storageDir, { recursive: true })
 
 		// Create DB at expected location
 		const db = new HitlDatabase(expectedDbPath)
@@ -343,15 +361,16 @@ describe("timeline integration", () => {
 
 		// Insert only an active session (no closed sessions)
 		db.run(
-			"INSERT INTO hitl_sessions (id, project_hash, started_at, ended_at, status) VALUES (?, ?, ?, ?, ?)",
-			[sessionId, projectHashStr, now - 3600000, null, "active"],
+			`INSERT INTO hitl_sessions (id, project_hash, started_at, ended_at, status, end_cause, agent_time_ms, hitl_time_ms, idle_time_ms)
+			 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+			[sessionId, projectHashStr, now - 3600000, null, "active", null, 0, 0, 0],
 		)
 
 		db.close()
 
 		const mockTheme = createMockTheme()
 
-		const output = await getMetricsOutput(tempDir, mockTheme as Theme)
+		const output = await getMetricsOutput(tempDir, mockTheme as Theme, { dbPath: expectedDbPath })
 
 		// Should have metrics but no timeline section
 		expect(output).toContain("Total sessions")
@@ -367,8 +386,9 @@ describe("timeline integration", () => {
 
 	it("metrics command shows timeline when DB has closed session data", async () => {
 		const projectHashStr = projectHash(tempDir)
-		const storageDir = resolve(homedir(), ".hitl-metrics")
-		const expectedDbPath = resolve(storageDir, `${projectHashStr}.db`)
+		const storageDir = join(homedir(), ".kimchi", "metrics", projectHashStr)
+		const expectedDbPath = join(storageDir, "hitl.db")
+		mkdirSync(storageDir, { recursive: true })
 
 		// Create DB at expected location
 		const db = new HitlDatabase(expectedDbPath)
@@ -378,13 +398,15 @@ describe("timeline integration", () => {
 		const now = Date.now()
 		const sessionId = "test-session-closed"
 
-		// Insert a closed session with events
+		// Insert a closed session with time data
 		db.run(
-			"INSERT INTO hitl_sessions (id, project_hash, started_at, ended_at, status) VALUES (?, ?, ?, ?, ?)",
-			[sessionId, projectHashStr, now - 3600000, now - 60000, "closed"],
+			`INSERT INTO hitl_sessions (id, project_hash, started_at, ended_at, status, end_cause, agent_time_ms, hitl_time_ms, idle_time_ms)
+			 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+			[sessionId, projectHashStr, now - 3600000, now - 60000, "closed", "complete", 120000, 120000, 60000],
 		)
 		db.run(
-			"INSERT INTO hitl_events (session_id, tool_name, question_count, duration_ms, selected_options, created_at) VALUES (?, ?, ?, ?, ?, ?)",
+			`INSERT INTO hitl_events (session_id, tool_name, question_count, duration_ms, selected_options, created_at)
+			 VALUES (?, ?, ?, ?, ?, ?)`,
 			[sessionId, "ask_user_questions", 2, 120000, JSON.stringify(["option1"]), now - 3500000],
 		)
 
@@ -398,8 +420,9 @@ describe("timeline integration", () => {
 		expect(notifyCall).toHaveBeenCalled()
 		const notifiedMessage = notifyCall.mock.calls[0][0] as string
 		expect(notifiedMessage).toContain("Session Timeline")
-		expect(notifiedMessage).toContain("solo")
+		expect(notifiedMessage).toContain("agent")
 		expect(notifiedMessage).toContain("HITL")
+		expect(notifiedMessage).toContain("idle")
 
 		// Cleanup
 		try {

--- a/extensions/hitl-metrics/commands/metrics.test.ts
+++ b/extensions/hitl-metrics/commands/metrics.test.ts
@@ -12,40 +12,44 @@ import type { ExtensionCommandContext, Theme } from "@mariozechner/pi-coding-age
 import { homedir } from "node:os"
 import { resolve } from "node:path"
 import { mkdtempSync, rmSync } from "node:fs"
-
-// --- Mock Theme ---
-function createMockTheme(): Theme {
-	const noOp = (text: string) => text
-	return {
-		name: "mock",
-		fg: (_c, text) => `[color:${text}]`,
-		bg: (_c, text) => text,
-		bold: (text) => `<b>${text}</b>`,
-		italic: noOp,
-		underline: noOp,
-		inverse: noOp,
-		strikethrough: noOp,
-		getFgAnsi: () => "",
-		getBgAnsi: () => "",
-		getColorMode: () => "truecolor",
-		getThinkingBorderColor: () => noOp,
-		getBashModeBorderColor: () => noOp,
-	} as unknown as Theme
-}
+import { createMockTheme } from "../test-helpers/mock-theme.js"
 
 const mockTheme: Theme = createMockTheme()
 
 // --- Mock ExtensionCommandContext ---
 function createMockCtx(overrides: Partial<ExtensionCommandContext> = {}): ExtensionCommandContext {
+	const noOp = () => undefined
 	return {
 		cwd: "/tmp/test",
 		hasUI: true,
 		ui: {
 			notify: vi.fn(),
 			theme: mockTheme,
-		},
+			select: vi.fn(),
+			confirm: vi.fn(),
+			input: vi.fn(),
+			onTerminalInput: () => () => {},
+			setStatus: vi.fn(),
+			setWorkingMessage: vi.fn(),
+			setHiddenThinkingLabel: vi.fn(),
+			setWidget: vi.fn(),
+			setFooter: vi.fn(),
+			setHeader: vi.fn(),
+			setTitle: vi.fn(),
+			custom: vi.fn(),
+			autocomplete: vi.fn(),
+			editor: vi.fn(),
+			setEditor: vi.fn(),
+			setEditorComponent: vi.fn(),
+			focusEditor: vi.fn(),
+			setInputKeybindings: vi.fn(),
+			setSessionInputKeybindings: vi.fn(),
+			setExpandHandler: vi.fn(),
+			keybindings: {} as any,
+			tui: {} as any,
+		} as unknown as ExtensionCommandContext["ui"],
 		...overrides,
-	}
+	} as unknown as ExtensionCommandContext
 }
 
 // --- Setup Helpers ---
@@ -307,15 +311,7 @@ describe("timeline integration", () => {
 
 		db.close()
 
-		const mockTheme = {
-			fg: (_c: string, t: string) => t,
-			bg: (_c: string, t: string) => t,
-			bold: (t: string) => t, inverse: (t: string) => t,
-			dim: (t: string) => t,
-			italic: (t: string) => t,
-			underline: (t: string) => t,
-			strikethrough: (t: string) => t,
-		}
+		const mockTheme = createMockTheme()
 
 		const output = await getMetricsOutput(tempDir, mockTheme as Theme)
 
@@ -353,15 +349,7 @@ describe("timeline integration", () => {
 
 		db.close()
 
-		const mockTheme = {
-			fg: (_c: string, t: string) => t,
-			bg: (_c: string, t: string) => t,
-			bold: (t: string) => t, inverse: (t: string) => t,
-			dim: (t: string) => t,
-			italic: (t: string) => t,
-			underline: (t: string) => t,
-			strikethrough: (t: string) => t,
-		}
+		const mockTheme = createMockTheme()
 
 		const output = await getMetricsOutput(tempDir, mockTheme as Theme)
 

--- a/extensions/hitl-metrics/commands/metrics.ts
+++ b/extensions/hitl-metrics/commands/metrics.ts
@@ -5,16 +5,41 @@
  * accumulated data from the SQLite database.
  */
 
-import type { ExtensionCommandContext, Theme } from "@mariozechner/pi-coding-agent"
-import { formatMetrics, formatTimelineSection } from "../formatters.ts"
-import { HitlDatabase, projectHash, getSessionStats, getRecentSessions, getSessionEvents } from "../storage/index.ts"
-import { buildTimeline } from "../timeline.ts"
-import type { HitlStats, HitlSession } from "../types.ts"
+import type { ExtensionCommandContext } from "@mariozechner/pi-coding-agent"
+import type { Theme } from "@mariozechner/pi-coding-agent"
+import { formatMetrics, formatTimelineSection } from "../formatters.js"
+import { HitlDatabase, projectHash, getSessionStats, getRecentSessions, getSessionEvents } from "../storage/index.js"
+import { buildTimeline } from "../timeline.js"
+import type { HitlStats, HitlSession } from "../types.js"
 import { homedir } from "node:os"
 import { resolve } from "node:path"
 
 /** Storage directory path (shared with SessionManager) */
 const STORAGE_DIR = resolve(homedir(), ".hitl-metrics")
+
+/**
+ * Create a fallback theme when no UI is available.
+ * This satisfies the Theme type interface without actual color support.
+ */
+function createFallbackTheme(): Theme {
+	const noOp = (text: string) => text
+	// Simple theme that just returns text unchanged
+	return {
+		name: "fallback",
+		fg: (_c: string, text: string) => text,
+		bg: (_c: string, text: string) => text,
+		bold: noOp,
+		italic: noOp,
+		underline: noOp,
+		inverse: noOp,
+		strikethrough: noOp,
+		getFgAnsi: () => "",
+		getBgAnsi: () => "",
+		getColorMode: () => "truecolor",
+		getThinkingBorderColor: () => noOp,
+		getBashModeBorderColor: () => noOp,
+	} as unknown as Theme
+}
 
 /**
  * Get metrics output for a project directory.
@@ -84,18 +109,12 @@ export async function handleMetricsCommand(_args: string, ctx: ExtensionCommandC
 			return
 		}
 
+		let theme: Theme
 		if (!ctx.hasUI) {
-			// No UI available — log to console instead (or we could print without formatting)
+			// No UI available — use fallback theme
+			theme = createFallbackTheme()
+			const output = await getMetricsOutput(cwd, theme)
 			console.log("HITL Metrics:")
-			const output = await getMetricsOutput(cwd, {
-				fg: (_c, t) => t,
-				bg: (_c, t) => t,
-				bold: (t) => t.toUpperCase(),
-				dim: (t) => t,
-				italic: (t) => t,
-				underline: (t) => t,
-				strikethrough: (t) => t,
-			})
 			console.log(output)
 			return
 		}

--- a/extensions/hitl-metrics/commands/metrics.ts
+++ b/extensions/hitl-metrics/commands/metrics.ts
@@ -1,29 +1,30 @@
 /**
  * /metrics Command Handler
  *
- * Displays HITL metrics for the current project by querying
- * accumulated data from the SQLite database.
+ * Displays HITL metrics for the current project with three-category
+ * time breakdown: agent, HITL, and idle time.
  */
 
 import type { ExtensionCommandContext } from "@mariozechner/pi-coding-agent"
 import type { Theme } from "@mariozechner/pi-coding-agent"
 import { formatMetrics, formatTimelineSection } from "../formatters.js"
-import { HitlDatabase, projectHash, getSessionStats, getRecentSessions, getSessionEvents } from "../storage/index.js"
+import {
+	HitlDatabase,
+	projectHash,
+	getSessionStats,
+	getRecentSessions,
+	getSessionEvents,
+	getSessionActivityEvents,
+} from "../storage/index.js"
 import { buildTimeline } from "../timeline.js"
 import type { HitlStats, HitlSession } from "../types.js"
 import { homedir } from "node:os"
-import { resolve } from "node:path"
+import { join, resolve } from "node:path"
 
-/** Storage directory path (shared with SessionManager) */
-const STORAGE_DIR = resolve(homedir(), ".hitl-metrics")
+const STORAGE_DIR = join(homedir(), ".kimchi", "metrics")
 
-/**
- * Create a fallback theme when no UI is available.
- * This satisfies the Theme type interface without actual color support.
- */
 function createFallbackTheme(): Theme {
 	const noOp = (text: string) => text
-	// Simple theme that just returns text unchanged
 	return {
 		name: "fallback",
 		fg: (_c: string, text: string) => text,
@@ -41,20 +42,14 @@ function createFallbackTheme(): Theme {
 	} as unknown as Theme
 }
 
-/**
- * Get metrics output for a project directory.
- * Opens a temporary DB connection, queries stats, formats output, closes DB.
- * Pure and testable — the command handler is just glue.
- *
- * @param cwd - Project directory path
- * @param theme - Theme for color/formatting
- * @returns Formatted metrics string (or empty state message)
- */
-export async function getMetricsOutput(cwd: string, theme: Theme): Promise<string> {
+export async function getMetricsOutput(
+	cwd: string,
+	theme: Theme,
+	options: { dbPath?: string } = {},
+): Promise<string> {
 	const hash = projectHash(cwd)
-	const dbPath = resolve(STORAGE_DIR, `${hash}.db`)
+	const dbPath = options.dbPath ?? resolve(STORAGE_DIR, hash, "hitl.db")
 
-	// Check if DB file exists before trying to open
 	const { existsSync } = await import("node:fs")
 	if (!existsSync(dbPath)) {
 		return "No HITL data recorded yet"
@@ -64,23 +59,21 @@ export async function getMetricsOutput(cwd: string, theme: Theme): Promise<strin
 	db.open()
 
 	try {
-		// Read-only: no need to initSchema (tables must already exist)
-		const stats: HitlStats = getSessionStats(db, hash)
-		const sessions: HitlSession[] = getRecentSessions(db, hash, 10)
+		const stats: HitlStats = getSessionStats(db)
+		const sessions: HitlSession[] = getRecentSessions(db, 10)
 
-		// Empty check — stats might be zero even if DB exists
 		if (stats.total_sessions === 0) {
 			return "No HITL data recorded yet"
 		}
 
-		// Find most recent closed session for timeline
-		const mostRecentClosedSession = sessions.find(s => s.status === "closed" && s.ended_at !== null)
-		
-		// Build timeline section if we have a closed session
+		// Find most recent closed session for timeline with activity data
+		const mostRecentClosedSession = sessions.find((s) => s.status === "closed" && s.ended_at !== null)
+
 		let timelineSection = ""
-		if (mostRecentClosedSession !== undefined) {
+		if (mostRecentClosedSession) {
 			const events = getSessionEvents(db, mostRecentClosedSession.id)
-			const segments = buildTimeline(mostRecentClosedSession, events)
+			const activities = getSessionActivityEvents(db, mostRecentClosedSession.id)
+			const segments = buildTimeline(mostRecentClosedSession, events, activities)
 			timelineSection = formatTimelineSection(segments, theme, 60)
 		}
 
@@ -94,13 +87,6 @@ export async function getMetricsOutput(cwd: string, theme: Theme): Promise<strin
 	}
 }
 
-/**
- * Handle the /metrics command.
- * Queries HITL metrics for the current project and displays them via UI.
- *
- * @param _args - Command arguments (unused)
- * @param ctx - Extension command context
- */
 export async function handleMetricsCommand(_args: string, ctx: ExtensionCommandContext): Promise<void> {
 	try {
 		const cwd = ctx.cwd
@@ -109,11 +95,8 @@ export async function handleMetricsCommand(_args: string, ctx: ExtensionCommandC
 			return
 		}
 
-		let theme: Theme
 		if (!ctx.hasUI) {
-			// No UI available — use fallback theme
-			theme = createFallbackTheme()
-			const output = await getMetricsOutput(cwd, theme)
+			const output = await getMetricsOutput(cwd, createFallbackTheme())
 			console.log("HITL Metrics:")
 			console.log(output)
 			return
@@ -122,7 +105,6 @@ export async function handleMetricsCommand(_args: string, ctx: ExtensionCommandC
 		const output = await getMetricsOutput(cwd, ctx.ui.theme)
 		ctx.ui.notify(output, "info")
 	} catch (error) {
-		// Non-fatal error handling — show graceful message
 		const message = error instanceof Error ? error.message : String(error)
 		console.warn(`[HITL] Error in metrics command: ${message}`)
 		ctx.ui.notify("No HITL data recorded yet", "info")

--- a/extensions/hitl-metrics/commands/metrics.ts
+++ b/extensions/hitl-metrics/commands/metrics.ts
@@ -1,0 +1,111 @@
+/**
+ * /metrics Command Handler
+ *
+ * Displays HITL metrics for the current project by querying
+ * accumulated data from the SQLite database.
+ */
+
+import type { ExtensionCommandContext, Theme } from "@mariozechner/pi-coding-agent"
+import { formatMetrics, formatTimelineSection } from "../formatters.ts"
+import { HitlDatabase, projectHash, getSessionStats, getRecentSessions, getSessionEvents } from "../storage/index.ts"
+import { buildTimeline } from "../timeline.ts"
+import type { HitlStats, HitlSession } from "../types.ts"
+import { homedir } from "node:os"
+import { resolve } from "node:path"
+
+/** Storage directory path (shared with SessionManager) */
+const STORAGE_DIR = resolve(homedir(), ".hitl-metrics")
+
+/**
+ * Get metrics output for a project directory.
+ * Opens a temporary DB connection, queries stats, formats output, closes DB.
+ * Pure and testable — the command handler is just glue.
+ *
+ * @param cwd - Project directory path
+ * @param theme - Theme for color/formatting
+ * @returns Formatted metrics string (or empty state message)
+ */
+export async function getMetricsOutput(cwd: string, theme: Theme): Promise<string> {
+	const hash = projectHash(cwd)
+	const dbPath = resolve(STORAGE_DIR, `${hash}.db`)
+
+	// Check if DB file exists before trying to open
+	const { existsSync } = await import("node:fs")
+	if (!existsSync(dbPath)) {
+		return "No HITL data recorded yet"
+	}
+
+	const db = new HitlDatabase(dbPath)
+	db.open()
+
+	try {
+		// Read-only: no need to initSchema (tables must already exist)
+		const stats: HitlStats = getSessionStats(db, hash)
+		const sessions: HitlSession[] = getRecentSessions(db, hash, 10)
+
+		// Empty check — stats might be zero even if DB exists
+		if (stats.total_sessions === 0) {
+			return "No HITL data recorded yet"
+		}
+
+		// Find most recent closed session for timeline
+		const mostRecentClosedSession = sessions.find(s => s.status === "closed" && s.ended_at !== null)
+		
+		// Build timeline section if we have a closed session
+		let timelineSection = ""
+		if (mostRecentClosedSession !== undefined) {
+			const events = getSessionEvents(db, mostRecentClosedSession.id)
+			const segments = buildTimeline(mostRecentClosedSession, events)
+			timelineSection = formatTimelineSection(segments, theme, 60)
+		}
+
+		return formatMetrics(stats, sessions, theme, timelineSection)
+	} catch (error) {
+		const message = error instanceof Error ? error.message : String(error)
+		console.warn(`[HITL] Error querying metrics: ${message}`)
+		return "No HITL data recorded yet"
+	} finally {
+		db.close()
+	}
+}
+
+/**
+ * Handle the /metrics command.
+ * Queries HITL metrics for the current project and displays them via UI.
+ *
+ * @param _args - Command arguments (unused)
+ * @param ctx - Extension command context
+ */
+export async function handleMetricsCommand(_args: string, ctx: ExtensionCommandContext): Promise<void> {
+	try {
+		const cwd = ctx.cwd
+		if (!cwd) {
+			ctx.ui.notify("No project directory available", "error")
+			return
+		}
+
+		if (!ctx.hasUI) {
+			// No UI available — log to console instead (or we could print without formatting)
+			console.log("HITL Metrics:")
+			const output = await getMetricsOutput(cwd, {
+				fg: (_c, t) => t,
+				bg: (_c, t) => t,
+				bold: (t) => t.toUpperCase(),
+				dim: (t) => t,
+				italic: (t) => t,
+				underline: (t) => t,
+				strikethrough: (t) => t,
+			})
+			console.log(output)
+			return
+		}
+
+		const output = await getMetricsOutput(cwd, ctx.ui.theme)
+		ctx.ui.notify(output, "info")
+	} catch (error) {
+		// Non-fatal error handling — show graceful message
+		const message = error instanceof Error ? error.message : String(error)
+		console.warn(`[HITL] Error in metrics command: ${message}`)
+		ctx.ui.notify("No HITL data recorded yet", "info")
+	}
+}

--- a/extensions/hitl-metrics/e2e-acp.ts
+++ b/extensions/hitl-metrics/e2e-acp.ts
@@ -1,0 +1,366 @@
+#!/usr/bin/env bun
+/**
+ * ACP E2E test for HITL metrics.
+ *
+ * Uses two approaches to verify the full flow:
+ *   A) Pre-recorded JSONL fixture — deterministic, no LLM needed
+ *   B) Real kimchi binary — exercises the actual LLM + extension stack
+ *
+ * Usage:
+ *   bun run extensions/hitl-metrics/e2e-acp.ts
+ */
+
+import { spawn } from "node:child_process"
+import { createRequire } from "node:module"
+import { join } from "node:path"
+import { homedir } from "node:os"
+import { mkdirSync, readFileSync, existsSync } from "node:fs"
+import { HitlDatabase } from "./storage/db.js"
+import { getSessionStats } from "./storage/session.js"
+import { getMetricsOutput } from "./commands/metrics.js"
+import { createMockTheme } from "./test-helpers/mock-theme.js"
+
+// ─── Config ───────────────────────────────────────────────────────────────────
+
+const CWD = process.cwd()
+const PROJECT_HASH = "65d14f0abb50c294" // real project hash of CWD
+const STORAGE_DIR = join(homedir(), ".kimchi", "metrics", PROJECT_HASH)
+const SESSION_FILE = `/tmp/kimchi-acp-session-${Date.now()}.jsonl`
+const METRICS_DB = join(STORAGE_DIR, "hitl.db")
+
+mkdirSync(STORAGE_DIR, { recursive: true })
+
+// ─── Types ────────────────────────────────────────────────────────────────────
+
+interface JsonlEvent {
+  type: string
+  [key: string]: unknown
+}
+
+interface ToolStart { toolName: string; toolCallId: string; args: Record<string, unknown> }
+interface ToolEnd { toolName: string; toolCallId: string; isError: boolean; result: unknown }
+
+function parseEvents(raw: string): JsonlEvent[] {
+  return raw.split("\n").map((l) => l.trim()).filter(Boolean).map((l) => {
+    try { return JSON.parse(l) }
+    catch { return null }
+  }).filter(Boolean) as JsonlEvent[]
+}
+
+function extractToolEvents(events: JsonlEvent[]): { starts: ToolStart[]; ends: ToolEnd[] } {
+  const starts: ToolStart[] = []
+  const ends: ToolEnd[] = []
+  for (const e of events) {
+    if (e.type === "tool_execution_start") {
+      starts.push({
+        toolName: e.toolName as string,
+        toolCallId: e.toolCallId as string,
+        args: (e.args as Record<string, unknown>) ?? {},
+      })
+    }
+    if (e.type === "tool_execution_end") {
+      ends.push({
+        toolName: e.toolName as string,
+        toolCallId: e.toolCallId as string,
+        isError: (e.isError as boolean) ?? false,
+        result: e.result,
+      })
+    }
+  }
+  return { starts, ends }
+}
+
+// ─── Run kimchi binary ────────────────────────────────────────────────────────
+
+interface RunResult { stdout: string; stderr: string; exitCode: number; events: JsonlEvent[] }
+
+async function runKimchi(args: string[], prompt: string): Promise<RunResult> {
+  return new Promise((resolve) => {
+    const proc = spawn(args[0], args.slice(1), {
+      cwd: CWD,
+      env: { ...process.env },
+      timeout: 120_000,
+    })
+    const out: Buffer[] = []
+    const err: Buffer[] = []
+    proc.stdout.on("data", (d) => out.push(d as Buffer))
+    proc.stderr.on("data", (d) => err.push(d as Buffer))
+    proc.on("close", (code) => {
+      const stdout = Buffer.concat(out).toString()
+      const stderr = Buffer.concat(err).toString()
+      resolve({ stdout, stderr, exitCode: code ?? 1, events: parseEvents(stdout) })
+    })
+    proc.on("error", (err_) => resolve({ stdout: "", stderr: err_.message, exitCode: 1, events: [] }))
+    proc.stdin.write(prompt + "\n")
+    proc.stdin.end()
+  })
+}
+
+// ─── Build expected events from JSONL ────────────────────────────────────────
+
+interface ExpectedToolEvent {
+  tool: string
+  questionCount: number
+  durationMs: number
+  answerSelected: string[]
+}
+
+function buildExpected(starts: ToolStart[], ends: ToolEnd[]): ExpectedToolEvent[] {
+  const endById = new Map(ends.map((e) => [e.toolCallId, e]))
+  const result: ExpectedToolEvent[] = []
+  for (const s of starts) {
+    const end = endById.get(s.toolCallId)
+    if (s.toolName === "ask_user_questions") {
+      const questions = (s.args.questions as any[]) ?? []
+      const questionCount = questions.length
+      let selected: string[] = []
+      const text = (end?.result as any)?.content?.[0]?.text
+      if (text) {
+        try {
+          const parsed = JSON.parse(text)
+          for (const [, ans] of Object.entries(parsed.answers ?? {})) {
+            selected.push(...((ans as { answers: string[] }).answers ?? []))
+          }
+        }
+        catch { /* not JSON */ }
+      }
+      const durationMs = end ? ((end as any).durationMs ?? 3000) : 3000
+      result.push({ tool: "ask_user_questions", questionCount, durationMs, answerSelected: selected })
+    }
+    else if (s.toolName === "bash") {
+      const durationMs = end ? ((end as any).durationMs ?? 5000) : 5000
+      result.push({ tool: "bash", questionCount: 0, durationMs, answerSelected: [] })
+    }
+  }
+  return result
+}
+
+// ─── Verify metrics DB ────────────────────────────────────────────────────────
+
+function verifyDb(dbPath: string, expected: ExpectedToolEvent[]) {
+  const hitlEvents = expected.filter((e) => e.tool === "ask_user_questions")
+  const bashEvents = expected.filter((e) => e.tool === "bash")
+
+  if (!existsSync(dbPath)) {
+    console.log("  ⚠️  No DB found at:", dbPath)
+    return { passed: 0, failed: 4 + expected.length }
+  }
+
+  const db = new HitlDatabase(dbPath)
+  db.open()
+  const stats = getSessionStats(db)
+  const sessions = db.query<{ id: string; hitl_time_ms: number; agent_time_ms: number; idle_time_ms: number; status: string }>(
+    "SELECT * FROM hitl_sessions",
+  )
+  const dbEvents = db.query<{ id: number; tool_name: string; question_count: number; duration_ms: number }>(
+    "SELECT * FROM hitl_events",
+  )
+  db.close()
+
+  let passed = 0
+  let failed = 0
+
+  const check = (label: string, actual: unknown, expected: unknown) => {
+    const ok = actual == expected || (typeof expected === "boolean" && !!actual === expected)
+    if (ok) { console.log(`  ✓ ${label}: ${actual}`); passed++ }
+    else { console.log(`  ✗ ${label}: expected ${expected}, got ${actual}`); failed++ }
+  }
+
+  console.log("\n  DB Stats:")
+  check("sessions in DB", sessions.length, 1)
+  check("HITL events in DB", dbEvents.length, hitlEvents.length)
+  check("interaction_count", stats.interaction_count, hitlEvents.length)
+  check("hitl_time_ms > 0", stats.total_hitl_time_ms > 0, true)
+
+  if (hitlEvents.length > 0) {
+    const totalHitlMs = hitlEvents.reduce((s, e) => s + e.durationMs, 0)
+    const dbHitlMs = dbEvents.reduce((s, e) => s + e.duration_ms, 0)
+    check("HITL time matches (approx)", Math.abs(dbHitlMs - totalHitlMs) < 2000, true)
+    check("question count", dbEvents[0]?.question_count, hitlEvents[0]?.questionCount)
+  }
+
+  console.log("\n  Session rows:")
+  for (const s of sessions) {
+    const total = s.hitl_time_ms + s.agent_time_ms + s.idle_time_ms
+    console.log(
+      `    ${s.status.padEnd(8)} HITL:${(s.hitl_time_ms / 1000).toFixed(1)}s  ` +
+      `Agent:${(s.agent_time_ms / 1000).toFixed(1)}s  ` +
+      `Idle:${(s.idle_time_ms / 1000).toFixed(1)}s  ` +
+      `total:${(total / 1000).toFixed(1)}s`,
+    )
+  }
+
+  console.log("\n  HITL events:")
+  for (const e of dbEvents) {
+    console.log(`    ${e.tool_name.padEnd(25)} ${e.question_count}Q  ${(e.duration_ms / 1000).toFixed(1)}s`)
+  }
+
+  return { passed, failed }
+}
+
+// ─── /metrics output ──────────────────────────────────────────────────────────
+
+function showMetrics(dbPath: string) {
+  console.log("═".repeat(60))
+  console.log("📊 /metrics output:")
+  console.log("═".repeat(60) + "\n")
+  try {
+    const output = getMetricsOutput(CWD, createMockTheme(), { dbPath })
+    console.log(output)
+  }
+  catch (err) {
+    console.log("  (metrics command error)")
+    console.error(err)
+  }
+}
+
+// ─── TUI output ────────────────────────────────────────────────────────────────
+
+function showTuiOutput(stderr: string) {
+  // Filter out noise — print meaningful TUI output
+  const lines = stderr.split("\n").filter((l) =>
+    l.trim() &&
+    !l.includes("Duplicate key") &&
+    !l.includes("prepare") &&
+    !l.includes("warn:"),
+  )
+  if (lines.length) {
+    console.log("─── TUI Output ───")
+    lines.forEach((l) => console.log(l))
+    console.log("─── End TUI ───\n")
+  }
+}
+
+// ─── Main ─────────────────────────────────────────────────────────────────────
+
+async function main() {
+  console.log("=== ACP E2E: HITL Metrics ===\n")
+  console.log("Project:", CWD)
+  console.log("DB:", METRICS_DB)
+  console.log("")
+
+  // ── Approach A: Run real kimchi with extension via bun run ──────────────────
+  console.log("─── Approach A: bun run + extension (DB recording) ───\n")
+
+  // Get API key from config
+  const configPath = join(homedir(), ".config", "kimchi", "config.json")
+  const apiKey = (() => {
+    try {
+      return JSON.parse(readFileSync(configPath, "utf8")).api_key ?? ""
+    }
+    catch { return "" }
+  })()
+
+  if (!apiKey) {
+    console.error("❌ No api_key in ~/.config/kimchi/config.json")
+    process.exit(1)
+  }
+
+  // Resolve PI_PACKAGE_DIR via require.resolve so it's absolute
+  const piPkgDir = require.resolve("@mariozechner/pi-coding-agent/package.json").replace(/[/\\]package\.json$/, "")
+  const agentDir = join(homedir(), ".config", "kimchi", "harness")
+
+  // Build env. Set PI_PACKAGE_DIR explicitly so entry.ts uses the local auxiliary files dir
+  // (instead of resolving from the global /opt/homebrew/bin/gsd install).
+  const auxDir = join(CWD, "node_modules", "@mariozechner", "pi-coding-agent")
+  const runEnv: Record<string, string> = {
+    ...process.env,
+    KIMCHI_API_KEY: apiKey,
+    PI_SKIP_VERSION_CHECK: "1",
+    KIMCHI_CODING_AGENT_DIR: agentDir,
+    PI_PACKAGE_DIR: auxDir,
+  }
+
+  const PROMPT = `You are a metrics test assistant. Execute this EXACT sequence:
+
+1. Run: bash sleep 3
+2. Then use ask_user_questions with:
+   id: "choice"
+   header: "Next?"
+   question: "What next?"
+   options: [
+     { label: "Continue", description: "Keep going" },
+     { label: "Stop", description: "Done" }
+   ]
+3. Run: bash sleep 2
+4. Say "Done."`
+
+  console.log("Running kimchi with extension + real LLM...")
+  const result = await runKimchi(
+    [
+      "bun", "run", "src/entry.ts",
+      "--print", "--mode", "json", "--no-session",
+      "-e", "extensions/hitl-metrics/index.ts",
+      "--model", "kimi-k2.5",
+    ],
+    PROMPT,
+    runEnv,
+  )
+
+  console.log(`Exit code: ${result.exitCode}`)
+  showTuiOutput(result.stderr)
+  console.log(`JSONL events captured: ${result.events.length}`)
+
+  // Parse events
+  const { starts, ends } = extractToolEvents(result.events)
+  const expected = buildExpected(starts, ends)
+
+  console.log("\nTool events from JSONL:")
+  for (const s of starts) {
+    const end = ends.find((e) => e.toolCallId === s.toolCallId)
+    const ok = end && !end.isError
+    console.log(
+      `  ${ok ? "✅" : end ? "❌" : "⏳"}  ${s.toolName.padEnd(25)}  ${JSON.stringify(s.args).slice(0, 60)}...`,
+    )
+  }
+
+  console.log("\nExpected metrics (from JSONL):")
+  for (const e of expected) {
+    const q = e.questionCount > 0 ? ` (${e.questionCount}Q)` : ""
+    const ans = e.answerSelected.length ? ` → ${e.answerSelected.join(", ")}` : ""
+    console.log(
+      `  ${e.tool.padEnd(25)}  ${(e.durationMs / 1000).toFixed(1)}s${q}${ans}`,
+    )
+  }
+
+  // ── Verify DB ──────────────────────────────────────────────────────────────
+  console.log("\n" + "═".repeat(60))
+  console.log("📊 DB Verification:")
+  console.log("═".repeat(60))
+  const dbResult = verifyDb(METRICS_DB, expected)
+
+  // ── /metrics output ────────────────────────────────────────────────────────
+  showMetrics(METRICS_DB)
+
+  // ── Approach B: Run kimchi binary for comparison (no extension) ────────────
+  console.log("─── Approach B: kimchi binary (no extension) ───\n")
+  console.log("Running kimchi binary for comparison...")
+  const binaryResult = await runKimchi(
+    ["/opt/homebrew/bin/gsd", "--print", "--mode", "json", "--no-session", "--model", "kimi-k2.5"],
+    "bash echo hello",
+    { KIMCHI_API_KEY: apiKey } as Record<string, string>,
+  )
+  console.log(`Exit code: ${binaryResult.exitCode}`)
+  console.log(`JSONL events captured: ${binaryResult.events.length}`)
+
+  const { starts: bStarts, ends: bEnds } = extractToolEvents(binaryResult.events)
+  console.log("\nTool calls (binary):")
+  for (const s of bStarts) {
+    const end = bEnds.find((e) => e.toolCallId === s.toolCallId)
+    console.log(`  ${end && !end.isError ? "✅" : "❌"}  ${s.toolName}`)
+  }
+
+  // ── Summary ────────────────────────────────────────────────────────────────
+  console.log("\n" + "═".repeat(60))
+  console.log("✅ Result:")
+  console.log("═".repeat(60))
+  console.log(`  JSONL events (bun run):  ${result.events.length}`)
+  console.log(`  JSONL events (binary):   ${binaryResult.events.length}`)
+  console.log(`  DB /metrics assertions:  ${dbResult.passed} passed, ${dbResult.failed} failed`)
+  console.log(`  Tool events captured:    ${starts.length} (${starts.filter((s) => s.toolName === "bash").length} bash, ${starts.filter((s) => s.toolName === "ask_user_questions").length} ask_user_questions)`)
+}
+
+main().catch((err) => {
+  console.error("\n❌ Fatal:", err)
+  process.exit(1)
+})

--- a/extensions/hitl-metrics/e2e-acp.ts
+++ b/extensions/hitl-metrics/e2e-acp.ts
@@ -293,8 +293,7 @@ async function main() {
       "-e", "extensions/hitl-metrics/index.ts",
       "--model", "kimi-k2.5",
     ],
-    PROMPT,
-    runEnv,
+    PROMPT
   )
 
   console.log(`Exit code: ${result.exitCode}`)
@@ -338,7 +337,6 @@ async function main() {
   const binaryResult = await runKimchi(
     ["/opt/homebrew/bin/gsd", "--print", "--mode", "json", "--no-session", "--model", "kimi-k2.5"],
     "bash echo hello",
-    { KIMCHI_API_KEY: apiKey } as Record<string, string>,
   )
   console.log(`Exit code: ${binaryResult.exitCode}`)
   console.log(`JSONL events captured: ${binaryResult.events.length}`)

--- a/extensions/hitl-metrics/e2e-rpc.py
+++ b/extensions/hitl-metrics/e2e-rpc.py
@@ -1,0 +1,312 @@
+#!/usr/bin/env python3
+"""
+RPC-mode E2E test for HITL metrics.
+
+Verifies the full HITL extension lifecycle:
+1. Binary runs in RPC mode with the hitl-metrics extension loaded
+2. tool_execution_start/end events fire for tool calls
+3. Session is recorded in the metrics DB with the real kimchi session ID
+4. agent_time_ms accumulates correctly
+
+Usage:
+    python3 e2e-rpc.py [--model MODEL]
+"""
+
+import asyncio
+import json
+import os
+import sqlite3
+import sys
+import time
+import uuid
+from pathlib import Path
+
+
+# ─── Config ───────────────────────────────────────────────────────────────────
+
+CWD = Path(__file__).parent.parent.parent.resolve()
+DIST_BIN = CWD / "dist" / "bin" / "kimchi-code"
+SHARE_DIR = CWD / "dist" / "share" / "kimchi"
+HARNESS_DIR = Path.home() / ".config" / "kimchi" / "harness"
+SESSION_FILE = f"/tmp/hitl-rpc-{time.time():.0f}.jsonl"
+
+MODEL = "kimchi-dev/kimi-k2.5"
+
+# Prompt that triggers tool use (permissions will cancel — error expected)
+TOOL_PROMPT = (
+    "List the files in extensions/hitl-metrics/ using the ls tool. "
+    "Run: ls extensions/hitl-metrics/"
+)
+
+
+def api_key() -> str:
+    return json.loads(Path.home().joinpath(".config/kimchi/config.json").read_text())["api_key"]
+
+
+def metrics_db() -> str:
+    import hashlib
+    h = hashlib.sha256(str(CWD).encode()).hexdigest()[:16]
+    return str(Path.home() / ".kimchi/metrics" / h / "hitl.db")
+
+
+# ─── RPC helpers ──────────────────────────────────────────────────────────────
+
+def rid() -> str:
+    return str(uuid.uuid4())
+
+
+async def read_line(r: asyncio.StreamReader, timeout: float = 30.0) -> str | None:
+    try:
+        line = await asyncio.wait_for(r.readline(), timeout=timeout)
+        return line.decode().strip() if line else None
+    except asyncio.TimeoutError:
+        return None
+
+
+def parse(line: str) -> dict | None:
+    try:
+        return json.loads(line)
+    except (json.JSONDecodeError, TypeError):
+        return None
+
+
+# ─── Core: concurrent reader + writer ────────────────────────────────────────
+
+async def run_session(prompt: str, timeout: float = 120.0) -> dict:
+    """Run a session with a concurrent reader so the binary can produce output
+    while we feed it the prompt. This avoids pipe buffer deadlock."""
+    cmd = [
+        str(DIST_BIN), "--mode", "rpc", "--session", SESSION_FILE,
+        "--model", MODEL, "-e", str(CWD / "extensions/hitl-metrics/index.ts"),
+    ]
+    env = {**os.environ,
+           "PI_PACKAGE_DIR": str(SHARE_DIR),
+           "KIMCHI_CODING_AGENT_DIR": str(HARNESS_DIR),
+           "KIMCHI_API_KEY": api_key(),
+           "PI_SKIP_VERSION_CHECK": "1"}
+
+    proc = await asyncio.create_subprocess_exec(
+        cmd[0], *cmd[1:],
+        stdin=asyncio.subprocess.PIPE, stdout=asyncio.subprocess.PIPE,
+        stderr=asyncio.subprocess.PIPE, env=env, cwd=str(CWD),
+    )
+    stdin_w: asyncio.StreamWriter = proc.stdin
+    stdout_r: asyncio.StreamReader = proc.stdout
+
+    async def send(cmd: dict) -> None:
+        stdin_w.write(json.dumps(cmd).encode() + b"\n")
+        await stdin_w.drain()
+
+    all_events: list[dict] = []
+    session_id: str | None = None
+    tool_starts: list[dict] = []
+    tool_ends: list[dict] = []
+    event_queue: asyncio.Queue[dict | None] = asyncio.Queue()
+
+    # Background reader — puts parsed events into a queue
+    async def reader():
+        while True:
+            line = await read_line(stdout_r, timeout=20.0)
+            if not line:
+                await event_queue.put(None)  # EOF sentinel
+                break
+            ev = parse(line)
+            await event_queue.put(ev)
+
+    reader_task = asyncio.create_task(reader())
+
+    # Give the binary a moment to initialize
+    await asyncio.sleep(0.3)
+
+    # Query session ID via get_state (session event not available in RPC mode)
+    state_req_id = rid()
+    await send({"type": "get_state", "id": state_req_id})
+    deadline_get_state = time.time() + 30
+    while time.time() < deadline_get_state:
+        ev = await asyncio.wait_for(event_queue.get(), timeout=20.0)
+        if ev is None:
+            break
+        all_events.append(ev)
+        if ev.get("type") == "response" and ev.get("id") == state_req_id:
+            if ev.get("success"):
+                session_id = ev.get("data", {}).get("sessionId")
+            break
+
+    # Send prompt
+    req_id = rid()
+    print(f"  Sending prompt...")
+    await send({"type": "prompt", "id": req_id, "message": prompt})
+
+    # Main event loop — consumes from queue
+    deadline = time.time() + timeout
+    prompt_success = False
+    ui_responses: list[dict] = []
+
+    while time.time() < deadline:
+        remaining = deadline - time.time()
+        try:
+            ev = await asyncio.wait_for(event_queue.get(), timeout=min(remaining, 15.0))
+        except asyncio.TimeoutError:
+            break
+        if ev is None:  # EOF
+            break
+
+        all_events.append(ev)
+        t = ev.get("type", "?")
+
+        if t == "response" and ev.get("id") == req_id:
+            prompt_success = ev.get("success", False)
+            print(f"  Prompt accepted: {prompt_success}")
+
+        elif t == "session" and not session_id:
+            session_id = ev.get("id")
+            print(f"  Session: {session_id}")
+
+        elif t == "tool_execution_start":
+            tool_starts.append(ev)
+            print(f"  [TOOL] start: {ev.get('toolName', '?')}  {ev.get('toolCallId', '')[:12]}")
+
+        elif t == "tool_execution_end":
+            tool_ends.append(ev)
+            err = ev.get("isError", False)
+            print(f"  [TOOL] end:   {ev.get('toolName', '?')}  error={err}")
+
+        elif t == "extension_ui_request":
+            ui_responses.append(ev)
+            req_id_ui = ev.get("id")
+            method = ev.get("method", "")
+            if method == "select":
+                opts = ev.get("options", [])
+                if isinstance(opts, list) and opts:
+                    first = opts[0]
+                    val = (first.get("label") if isinstance(first, dict) else str(first)) or "cancelled"
+                else:
+                    val = "cancelled"
+                title = ev.get("title", "")[:50]
+                print(f"  [UI] select: {title!r} → {val}")
+                await send({"type": "extension_ui_response", "id": req_id_ui, "value": val})
+            elif method in ("setStatus", "setTitle", "notify", "set_editor_text"):
+                pass
+            else:
+                print(f"  [UI] {method}: cancelling")
+                await send({"type": "extension_ui_response", "id": req_id_ui, "cancelled": True})
+
+        elif t == "agent_end":
+            print(f"  [AGENT END]")
+            break
+
+        elif t == "error":
+            print(f"  [ERROR] {ev.get('error', '')[:80]}")
+
+    # Shutdown
+    reader_task.cancel()
+    try:
+        await asyncio.wait_for(send({"type": "abort", "id": rid()}), timeout=3.0)
+    except Exception:
+        pass
+    proc.terminate()
+    try:
+        await asyncio.wait_for(proc.wait(), timeout=5.0)
+    except asyncio.TimeoutError:
+        proc.kill()
+        await proc.wait()
+
+    stderr = (await proc.stderr.read()).decode()
+    return {
+        "events": all_events, "session_id": session_id,
+        "exit_code": proc.returncode, "stderr": stderr[:300],
+        "prompt_success": prompt_success,
+        "tool_starts": tool_starts, "tool_ends": tool_ends,
+        "ui_responses": ui_responses,
+    }
+
+
+# ─── Verification ─────────────────────────────────────────────────────────────
+
+def verify(result: dict) -> dict[str, tuple[bool, str]]:
+    evs = result["events"]
+    types = [e.get("type") for e in evs]
+    sid = result["session_id"]
+    db = metrics_db()
+    checks: dict[str, tuple[bool, str]] = {}
+
+    checks["Process ran"] = (result["exit_code"] != 127, f"code={result['exit_code']}")
+    checks["Session ID from events"] = (bool(sid), sid[:20] if sid else "NONE")
+    checks["Prompt accepted"] = (result["prompt_success"], str(result["prompt_success"]))
+    checks["tool_execution_start fired"] = ("tool_execution_start" in types,
+                                            f"count={len(result['tool_starts'])}")
+    checks["tool_execution_end fired"] = ("tool_execution_end" in types,
+                                          f"count={len(result['tool_ends'])}")
+    checks["Matching start/end counts"] = (
+        len(result["tool_starts"]) == len(result["tool_ends"]),
+        f"s={len(result['tool_starts'])} e={len(result['tool_ends'])}"
+    )
+
+    # DB verification
+    if Path(db).exists():
+        conn = sqlite3.connect(db)
+        curs = conn.cursor()
+        curs.execute(
+            "SELECT hitl_time_ms, agent_time_ms, status FROM hitl_sessions WHERE id=?",
+            (sid,) if sid else ("",),
+        )
+        row = curs.fetchone()
+        checks["Session recorded in DB"] = (row is not None, sid[:20] if sid else "no-sid")
+        if row:
+            hitl_ms, agent_ms, status = row
+            checks["Status is valid"] = (status in ("active", "closed"), f"status={status}")
+            checks["Time metrics recorded"] = (hitl_ms >= 0 and agent_ms >= 0,
+                                               f"HITL={hitl_ms}ms Agent={agent_ms}ms")
+            checks["Agent time > 0"] = (agent_ms > 0, f"Agent={agent_ms}ms")
+            curs.execute(
+                "SELECT tool_name, duration_ms FROM hitl_events WHERE session_id=?",
+                (sid,) if sid else ("",),
+            )
+            ev_rows = curs.fetchall()
+            checks["Non-HITL events in DB"] = (len(ev_rows) > 0, f"count={len(ev_rows)}")
+        conn.close()
+    else:
+        checks["Metrics DB exists"] = (False, "not found")
+
+    return checks
+
+
+# ─── Main ─────────────────────────────────────────────────────────────────────
+
+async def run_test() -> dict:
+    print("=" * 60)
+    print("RPC E2E: HITL Metrics")
+    print("=" * 60)
+    print(f"Binary: {DIST_BIN}  Model: {MODEL}  DB: {metrics_db()}\n")
+
+    result = await run_session(TOOL_PROMPT, timeout=120.0)
+    print(f"\n  {len(result['events'])} events, session={result['session_id']}")
+
+    checks = verify(result)
+    print(f"\n  Verification:")
+    for label, (passed, detail) in checks.items():
+        print(f"  {'✓' if passed else '✗'} {label}: {detail}")
+
+    all_passed = all(v[0] for v in checks.values())
+    print(f"\n{'=' * 60}")
+    print(f"  {'ALL PASS' if all_passed else 'FAILURES DETECTED'}")
+    print(f"{'=' * 60}")
+    return {"result": result, "checks": checks, "all_passed": all_passed}
+
+
+async def main() -> None:
+    try:
+        r = await asyncio.wait_for(run_test(), timeout=300)
+        sys.exit(0 if r["all_passed"] else 1)
+    except asyncio.TimeoutError:
+        print("TIMEOUT")
+        sys.exit(1)
+    except Exception as e:
+        print(f"FATAL: {e}")
+        import traceback
+        traceback.print_exc()
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/extensions/hitl-metrics/e2e.test.ts
+++ b/extensions/hitl-metrics/e2e.test.ts
@@ -1,0 +1,215 @@
+/**
+ * HITL Metrics End-to-End Tests
+ *
+ * Exercises the full extension event path: session_start → recordEvent
+ * → DB write → getMetricsOutput → verify non-zero data.
+ *
+ * Key insight: SessionManager stores data at ~/.kimchi/metrics/<hash>/hitl.db
+ * (where hash = projectHash(tempDir)), NOT inside tempDir itself.
+ * getMetricsOutput must use the same path.
+ */
+
+import { describe, it, expect } from "vitest"
+import { mkdtempSync, rmSync } from "node:fs"
+import { tmpdir, homedir } from "node:os"
+import { join } from "node:path"
+import { getMetricsOutput } from "./commands/metrics.js"
+import { createMockTheme } from "./test-helpers/mock-theme.js"
+import { SessionManager } from "./session-manager.js"
+import { projectHash } from "./storage/index.js"
+
+const STORAGE_DIR = join(homedir(), ".kimchi", "metrics")
+
+function createTempDir(): string {
+	return mkdtempSync(join(tmpdir(), "hitl-e2e-"))
+}
+
+function storageDbPath(tempDir: string): string {
+	return join(STORAGE_DIR, projectHash(tempDir), "hitl.db")
+}
+
+function sleep(ms: number): Promise<void> {
+	return new Promise((resolve) => setTimeout(resolve, ms))
+}
+
+function cleanup(dir: string): void {
+	try { rmSync(dir, { recursive: true, force: true }) } catch {}
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("HITL Metrics E2E — DB write/read cycle", () => {
+	it("recordEvent writes to DB and getMetricsOutput reads non-zero values", async () => {
+		const tempDir = createTempDir()
+		const dbPath = storageDbPath(tempDir)
+
+		// Write: create session + record 3 HITL events
+		const manager = new SessionManager()
+		manager.init(tempDir)
+		const session = manager.getSession()
+		expect(session).not.toBeNull()
+		expect(session!.status).toBe("active")
+
+		await sleep(10)
+		manager.recordEvent("ask_user_questions", 2, 500, ["A", "B"])
+		await sleep(10)
+		manager.recordEvent("ask_user_questions", 1, 300, ["C"])
+		await sleep(10)
+		manager.recordEvent("ask_user_questions", 3, 800, ["X", "Y", "Z"])
+		manager.close()
+
+		// Read: use same dbPath that SessionManager used
+		const output = await getMetricsOutput(tempDir, createMockTheme(), { dbPath })
+		expect(output).toContain("HITL Metrics")
+		expect(output).toMatch(/Total sessions:\s+1/)
+		expect(output).toMatch(/Interactions:\s+([1-9]\d*)/)
+		expect(output).toMatch(/Total HITL time:\s+(?!0s\b)\d/)
+		expect(output).toMatch(/Complete:\s+1/)
+
+		cleanup(tempDir)
+	})
+
+	it("multiple manager invocations accumulate sessions and interactions", async () => {
+		const tempDir = createTempDir()
+		const dbPath = storageDbPath(tempDir)
+
+		// Session 1: 2 events
+		{
+			const m = new SessionManager()
+			m.init(tempDir)
+			await sleep(10)
+			m.recordEvent("ask_user_questions", 1, 200, ["A"])
+			await sleep(10)
+			m.recordEvent("ask_user_questions", 1, 150, ["B"])
+			m.close()
+		}
+
+		// Session 2: 1 event
+		{
+			await sleep(10)
+			const m = new SessionManager()
+			m.init(tempDir)
+			await sleep(10)
+			m.recordEvent("ask_user_questions", 1, 150, ["C"])
+			m.close()
+		}
+
+		// Session 3: 3 events
+		{
+			await sleep(10)
+			const m = new SessionManager()
+			m.init(tempDir)
+			await sleep(10)
+			m.recordEvent("ask_user_questions", 1, 100, ["D"])
+			await sleep(10)
+			m.recordEvent("ask_user_questions", 1, 100, ["E"])
+			await sleep(10)
+			m.recordEvent("ask_user_questions", 1, 100, ["F"])
+			m.close()
+		}
+
+		const output = await getMetricsOutput(tempDir, createMockTheme(), { dbPath })
+		expect(output).toMatch(/Total sessions:\s+3/)
+		expect(output).toMatch(/Interactions:\s+6/) // 2 + 1 + 3
+		expect(output).toMatch(/Complete:\s+3/)
+		expect(output).toMatch(/Interrupted:\s+0/)
+
+		cleanup(tempDir)
+	})
+
+	it("data persists across manager restart cycles", async () => {
+		const tempDir = createTempDir()
+		const dbPath = storageDbPath(tempDir)
+
+		// Session 1: 1 event
+		{
+			const m = new SessionManager()
+			m.init(tempDir)
+			await sleep(10)
+			m.recordEvent("ask_user_questions", 1, 200, ["Yes"])
+			m.close()
+		}
+
+		// Verify session 1
+		const output1 = await getMetricsOutput(tempDir, createMockTheme(), { dbPath })
+		expect(output1).toMatch(/Total sessions:\s+1/)
+		expect(output1).toMatch(/Interactions:\s+1/)
+
+		// Session 2: 2 events (must be BEFORE close)
+		{
+			await sleep(10)
+			const m = new SessionManager()
+			m.init(tempDir)
+			await sleep(10)
+			m.recordEvent("ask_user_questions", 1, 300, ["A"])
+			await sleep(10)
+			m.recordEvent("ask_user_questions", 1, 300, ["B"])
+			m.close()
+		}
+
+		// Verify accumulated: 1 + 2 = 3 interactions
+		const output2 = await getMetricsOutput(tempDir, createMockTheme(), { dbPath })
+		expect(output2).toMatch(/Total sessions:\s+2/)
+		expect(output2).toMatch(/Interactions:\s+3/)
+
+		cleanup(tempDir)
+	})
+
+	it("realistic session with agent + HITL phases renders timeline", async () => {
+		const tempDir = createTempDir()
+		const dbPath = storageDbPath(tempDir)
+
+		const manager = new SessionManager()
+		manager.init(tempDir)
+
+		// Agent work
+		manager.recordStartTime("call-1")
+		await sleep(100)
+		manager.recordStartTime("call-2")
+		await sleep(100)
+
+		// HITL interaction 1
+		manager.recordStartTime("call-hitl-1")
+		await sleep(100)
+		manager.recordEvent("ask_user_questions", 2, 1500, ["Option A", "Option B"])
+		await sleep(100)
+
+		// More agent work
+		manager.recordStartTime("call-3")
+		await sleep(100)
+
+		// HITL interaction 2
+		manager.recordStartTime("call-hitl-2")
+		await sleep(100)
+		manager.recordEvent("ask_user_questions", 1, 600, ["Yes"])
+
+		manager.close()
+
+		const output = await getMetricsOutput(tempDir, createMockTheme(), { dbPath })
+		expect(output).toMatch(/Interactions:\s+2/)
+		expect(output).toContain("Session Timeline")
+		expect(output).toContain("agent")
+		expect(output).toContain("HITL")
+
+		cleanup(tempDir)
+	})
+
+	it("empty DB produces valid output without crashing", async () => {
+		const tempDir = createTempDir()
+		const dbPath = storageDbPath(tempDir)
+
+		// Create manager but don't close — session stays active
+		const manager = new SessionManager()
+		manager.init(tempDir)
+
+		const output = await getMetricsOutput(tempDir, createMockTheme(), { dbPath })
+		expect(output).toContain("HITL Metrics")
+		// 1 active session, 0 interactions
+		expect(output).toMatch(/Total sessions:\s+1/)
+		expect(output).toMatch(/Interactions:\s+0/)
+
+		cleanup(tempDir)
+	})
+})

--- a/extensions/hitl-metrics/formatters.test.ts
+++ b/extensions/hitl-metrics/formatters.test.ts
@@ -1,0 +1,307 @@
+/**
+ * HITL Metrics Formatters Unit Tests
+ */
+
+import { describe, it, expect } from "vitest"
+import { formatDuration, formatMetrics, formatSessionRow, formatTimelineSection } from "./formatters.ts"
+import type { HitlStats, HitlSession, Theme, TimelineSegment } from "./types.ts"
+
+/**
+ * Minimal mock theme that returns plain strings (no ANSI codes)
+ * — suitable for deterministic unit tests
+ */
+function createMockTheme(): Theme {
+	return {
+		fg: (_color: string, text: string) => text,
+		bg: (_color: string, text: string) => text,
+		bold: (text: string) => text,
+		dim: (text: string) => text,
+		italic: (text: string) => text,
+		underline: (text: string) => text,
+		strikethrough: (text: string) => text,
+	}
+}
+
+describe("formatDuration", () => {
+	it("formats 0ms as 0s", () => {
+		expect(formatDuration(0)).toBe("0s")
+	})
+
+	it("formats 5000ms as 5s", () => {
+		expect(formatDuration(5000)).toBe("5s")
+	})
+
+	it("formats 65000ms as 1m 5s", () => {
+		expect(formatDuration(65000)).toBe("1m 5s")
+	})
+
+	it("formats 3661000ms as 1h 1m 1s", () => {
+		expect(formatDuration(3661000)).toBe("1h 1m 1s")
+	})
+
+	it("formats 7200000ms as 2h 0m 0s", () => {
+		expect(formatDuration(7200000)).toBe("2h 0m 0s")
+	})
+
+	it("handles negative input by clamping to 0", () => {
+		expect(formatDuration(-100)).toBe("0s")
+	})
+
+	it("rounds seconds correctly", () => {
+		expect(formatDuration(1499)).toBe("1s") // rounds to 1s
+		expect(formatDuration(1500)).toBe("2s") // rounds to 2s
+	})
+
+	it("handles minutes without hours", () => {
+		expect(formatDuration(90000)).toBe("1m 30s")
+		expect(formatDuration(3599000)).toBe("59m 59s")
+	})
+
+	it("handles hours with minutes and seconds", () => {
+		expect(formatDuration(7322000)).toBe("2h 2m 2s")
+	})
+})
+
+describe("formatMetrics", () => {
+	const mockTheme = createMockTheme()
+
+	it("renders header and empty state for zero stats", () => {
+		const stats: HitlStats = {
+			total_sessions: 0,
+			total_hitl_time_ms: 0,
+			interaction_count: 0,
+			avg_wait_ms: 0,
+		}
+		const output = formatMetrics(stats, [], mockTheme)
+
+		expect(output).toContain("HITL Metrics")
+		expect(output).toContain("No HITL data recorded yet")
+		expect(output).not.toContain("Statistics")
+	})
+
+	it("renders all four stat fields with labels", () => {
+		const stats: HitlStats = {
+			total_sessions: 42,
+			total_hitl_time_ms: 3661000,
+			interaction_count: 150,
+			avg_wait_ms: 24000,
+		}
+		const output = formatMetrics(stats, [], mockTheme)
+
+		expect(output).toContain("Total sessions:")
+		expect(output).toContain("42")
+		expect(output).toContain("Total HITL time:")
+		expect(output).toContain("1h 1m 1s")
+		expect(output).toContain("Interactions:")
+		expect(output).toContain("150")
+		expect(output).toContain("Avg wait time:")
+		expect(output).toContain("24s")
+	})
+
+	it("renders statistics header before stats", () => {
+		const stats: HitlStats = {
+			total_sessions: 1,
+			total_hitl_time_ms: 0,
+			interaction_count: 1,
+			avg_wait_ms: 0,
+		}
+		const output = formatMetrics(stats, [], mockTheme)
+
+		expect(output).toContain("Statistics")
+		expect(output.indexOf("Statistics")).toBeLessThan(output.indexOf("Total sessions:"))
+	})
+
+	it("shows recent sessions section with timestamps", () => {
+		const stats: HitlStats = {
+			total_sessions: 2,
+			total_hitl_time_ms: 0,
+			interaction_count: 2,
+			avg_wait_ms: 0,
+		}
+		const sessions: HitlSession[] = [
+			{
+				id: "sess-1",
+				project_hash: "abc123",
+				started_at: 1714233600000, // 2024-04-27 12:00
+				ended_at: 1714237200000, // 2024-04-27 13:00
+				status: "closed",
+			},
+		]
+		const output = formatMetrics(stats, sessions, mockTheme)
+
+		expect(output).toContain("Recent Sessions")
+		expect(output).toContain("2024-04-27")
+		expect(output).toMatch(/CLOSED|closed/i)
+	})
+
+	it("shows message when no recent sessions", () => {
+		const stats: HitlStats = {
+			total_sessions: 1,
+			total_hitl_time_ms: 0,
+			interaction_count: 1,
+			avg_wait_ms: 0,
+		}
+		const output = formatMetrics(stats, [], mockTheme)
+
+		expect(output).toContain("Recent Sessions")
+		expect(output).toContain("No recent sessions")
+	})
+
+	it("limits recent sessions to 10 with ellipsis", () => {
+		const stats: HitlStats = {
+			total_sessions: 15,
+			total_hitl_time_ms: 0,
+			interaction_count: 15,
+			avg_wait_ms: 0,
+		}
+		const sessions: HitlSession[] = Array.from({ length: 15 }, (_, i) => ({
+			id: `sess-${i}`,
+			project_hash: "abc123",
+			started_at: 1714233600000 + i * 1000,
+			ended_at: null,
+			status: "active" as const,
+		}))
+
+		const output = formatMetrics(stats, sessions, mockTheme)
+
+		// Should have "... and 5 more" or similar ellipsis
+		expect(output).toMatch(/\.{3,}|and \d+ more/)
+	})
+
+	it("handles sessions as first argument in slice form", () => {
+		// Verify the function signature matches expected form
+		const stats: HitlStats = { total_sessions: 1, total_hitl_time_ms: 0, interaction_count: 1, avg_wait_ms: 0 }
+		const output = formatMetrics(stats, [], mockTheme)
+		expect(output).toBeTruthy()
+	})
+})
+
+describe("formatSessionRow", () => {
+	const mockTheme = createMockTheme()
+
+	it("formats active session with timestamp and status", () => {
+		const session: HitlSession = {
+			id: "sess-1",
+			project_hash: "abc123",
+			started_at: 1714233600000,
+			ended_at: null,
+			status: "active",
+		}
+		const output = formatSessionRow(session, mockTheme)
+
+		expect(output).toContain("2024-04-27")
+		expect(output).toContain("ACTIVE")
+		expect(output).toContain("(active)")
+	})
+
+	it("formats closed session with duration", () => {
+		const session: HitlSession = {
+			id: "sess-2",
+			project_hash: "def456",
+			started_at: 1714233600000,
+			ended_at: 1714237200000, // 1 hour later
+			status: "closed",
+		}
+		const output = formatSessionRow(session, mockTheme)
+
+		expect(output).toContain("CLOSED")
+		expect(output).toContain("(1h 0m 0s)")
+	})
+
+	it("formats orphaned session with duration", () => {
+		const session: HitlSession = {
+			id: "sess-3",
+			project_hash: "ghi789",
+			started_at: 1714233600000,
+			ended_at: 1714237260000,
+			status: "orphaned",
+		}
+		const output = formatSessionRow(session, mockTheme)
+
+		expect(output).toContain("ORPHANED")
+		expect(output).toMatch(/\(\d+h \d+m \d+s\)/)
+	})
+})
+
+import { formatTimelineSection } from "./formatters.ts"
+import type { TimelineSegment } from "./types.ts"
+
+describe("formatTimelineSection", () => {
+	const mockTheme = createMockTheme()
+
+	it("returns empty string for empty segments", () => {
+		const output = formatTimelineSection([], mockTheme)
+		expect(output).toBe("")
+	})
+
+	it("returns formatted section with header and chart for segments", () => {
+		const segments: TimelineSegment[] = [
+			{ type: "solo", startMs: 0, endMs: 5000, durationMs: 5000 },
+			{ type: "hitl", startMs: 5000, endMs: 8000, durationMs: 3000 },
+		]
+		const output = formatTimelineSection(segments, mockTheme)
+
+		expect(output).toContain("Session Timeline")
+		expect(output).toContain("solo")
+		expect(output).toContain("HITL")
+	})
+
+	it("respects custom width parameter", () => {
+		const segments: TimelineSegment[] = [
+			{ type: "solo", startMs: 0, endMs: 1000, durationMs: 1000 },
+		]
+		const output = formatTimelineSection(segments, mockTheme, 30)
+
+		expect(output).toContain("Session Timeline")
+		// The bar should be present with visual characters
+		expect(output).toContain("█")
+	})
+})
+
+describe("formatMetrics with timeline", () => {
+	const mockTheme = createMockTheme()
+
+	it("includes timeline section when provided", () => {
+		const stats: HitlStats = {
+			total_sessions: 1,
+			total_hitl_time_ms: 1000,
+			interaction_count: 1,
+			avg_wait_ms: 1000,
+		}
+		const sessions: HitlSession[] = []
+		const timeline = "Session Timeline\n\n  [timeline chart]"
+
+		const output = formatMetrics(stats, sessions, mockTheme, timeline)
+
+		expect(output).toContain("Session Timeline")
+		expect(output).toContain("[timeline chart]")
+	})
+
+	it("omits timeline section when empty string", () => {
+		const stats: HitlStats = {
+			total_sessions: 1,
+			total_hitl_time_ms: 1000,
+			interaction_count: 1,
+			avg_wait_ms: 1000,
+		}
+		const sessions: HitlSession[] = []
+
+		const output = formatMetrics(stats, sessions, mockTheme, "")
+
+		expect(output).not.toContain("Session Timeline")
+	})
+
+	it("omits timeline section when undefined", () => {
+		const stats: HitlStats = {
+			total_sessions: 1,
+			total_hitl_time_ms: 1000,
+			interaction_count: 1,
+			avg_wait_ms: 1000,
+		}
+		const sessions: HitlSession[] = []
+
+		const output = formatMetrics(stats, sessions, mockTheme)
+
+		expect(output).not.toContain("Session Timeline")
+	})
+})

--- a/extensions/hitl-metrics/formatters.test.ts
+++ b/extensions/hitl-metrics/formatters.test.ts
@@ -5,30 +5,7 @@
 import { describe, it, expect } from "vitest"
 import { formatDuration, formatMetrics, formatSessionRow, formatTimelineSection } from "./formatters.js"
 import type { HitlStats, HitlSession, TimelineSegment } from "./types.js"
-import type { Theme } from "@mariozechner/pi-coding-agent"
-
-/**
- * Minimal mock theme that returns plain strings (no ANSI codes)
- * — suitable for deterministic unit tests
- */
-function createMockTheme(): Theme {
-	const noOp = (text: string) => text
-	return {
-		name: "mock",
-		fg: (_c, text) => text,
-		bg: (_c, text) => text,
-		bold: noOp,
-		italic: noOp,
-		underline: noOp,
-		inverse: noOp,
-		strikethrough: noOp,
-		getFgAnsi: () => "",
-		getBgAnsi: () => "",
-		getColorMode: () => "truecolor",
-		getThinkingBorderColor: () => noOp,
-		getBashModeBorderColor: () => noOp,
-	} as unknown as Theme
-}
+import { createMockTheme } from "./test-helpers/mock-theme.js"
 
 describe("formatDuration", () => {
 	it("formats 0ms as 0s", () => {

--- a/extensions/hitl-metrics/formatters.test.ts
+++ b/extensions/hitl-metrics/formatters.test.ts
@@ -24,26 +24,8 @@ describe("formatDuration", () => {
 		expect(formatDuration(3661000)).toBe("1h 1m 1s")
 	})
 
-	it("formats 7200000ms as 2h 0m 0s", () => {
-		expect(formatDuration(7200000)).toBe("2h 0m 0s")
-	})
-
 	it("handles negative input by clamping to 0", () => {
 		expect(formatDuration(-100)).toBe("0s")
-	})
-
-	it("rounds seconds correctly", () => {
-		expect(formatDuration(1499)).toBe("1s") // rounds to 1s
-		expect(formatDuration(1500)).toBe("2s") // rounds to 2s
-	})
-
-	it("handles minutes without hours", () => {
-		expect(formatDuration(90000)).toBe("1m 30s")
-		expect(formatDuration(3599000)).toBe("59m 59s")
-	})
-
-	it("handles hours with minutes and seconds", () => {
-		expect(formatDuration(7322000)).toBe("2h 2m 2s")
 	})
 })
 
@@ -56,155 +38,110 @@ describe("formatMetrics", () => {
 			total_hitl_time_ms: 0,
 			interaction_count: 0,
 			avg_wait_ms: 0,
+			permission_count: 0,
+			total_permission_time_ms: 0,
 		}
 		const output = formatMetrics(stats, [], mockTheme)
-
 		expect(output).toContain("HITL Metrics")
 		expect(output).toContain("No HITL data recorded yet")
-		expect(output).not.toContain("Statistics")
 	})
 
-	it("renders all four stat fields with labels", () => {
+	it("renders stat fields with labels", () => {
 		const stats: HitlStats = {
 			total_sessions: 42,
 			total_hitl_time_ms: 3661000,
 			interaction_count: 150,
 			avg_wait_ms: 24000,
+			permission_count: 10,
+			total_permission_time_ms: 50000,
 		}
 		const output = formatMetrics(stats, [], mockTheme)
-
-		expect(output).toContain("Total sessions:")
 		expect(output).toContain("42")
-		expect(output).toContain("Total HITL time:")
-		expect(output).toContain("1h 1m 1s")
-		expect(output).toContain("Interactions:")
 		expect(output).toContain("150")
-		expect(output).toContain("Avg wait time:")
-		expect(output).toContain("24s")
 	})
 
-	it("renders statistics header before stats", () => {
+	it("renders permission stats when present", () => {
 		const stats: HitlStats = {
 			total_sessions: 1,
-			total_hitl_time_ms: 0,
-			interaction_count: 1,
-			avg_wait_ms: 0,
+			total_hitl_time_ms: 60000,
+			interaction_count: 5,
+			avg_wait_ms: 12000,
+			permission_count: 10,
+			total_permission_time_ms: 50000,
 		}
 		const output = formatMetrics(stats, [], mockTheme)
-
-		expect(output).toContain("Statistics")
-		expect(output.indexOf("Statistics")).toBeLessThan(output.indexOf("Total sessions:"))
+		expect(output).toContain("Permission Events")
+		expect(output).toContain("Permission prompts: 10")
+		expect(output).toContain("Permission time:")
 	})
 
-	it("shows recent sessions section with timestamps", () => {
-		const stats: HitlStats = {
-			total_sessions: 2,
-			total_hitl_time_ms: 0,
-			interaction_count: 2,
-			avg_wait_ms: 0,
-		}
-		const sessions: HitlSession[] = [
-			{
-				id: "sess-1",
-				project_hash: "abc123",
-				started_at: 1714233600000, // 2024-04-27 12:00
-				ended_at: 1714237200000, // 2024-04-27 13:00
-				status: "closed",
-			},
-		]
-		const output = formatMetrics(stats, sessions, mockTheme)
-
-		expect(output).toContain("Recent Sessions")
-		expect(output).toContain("2024-04-27")
-		expect(output).toMatch(/CLOSED|closed/i)
-	})
-
-	it("shows message when no recent sessions", () => {
+	it("does not render permission section when count is zero", () => {
 		const stats: HitlStats = {
 			total_sessions: 1,
-			total_hitl_time_ms: 0,
-			interaction_count: 1,
-			avg_wait_ms: 0,
+			total_hitl_time_ms: 60000,
+			interaction_count: 5,
+			avg_wait_ms: 12000,
+			permission_count: 0,
+			total_permission_time_ms: 0,
 		}
 		const output = formatMetrics(stats, [], mockTheme)
-
-		expect(output).toContain("Recent Sessions")
-		expect(output).toContain("No recent sessions")
-	})
-
-	it("limits recent sessions to 10 with ellipsis", () => {
-		const stats: HitlStats = {
-			total_sessions: 15,
-			total_hitl_time_ms: 0,
-			interaction_count: 15,
-			avg_wait_ms: 0,
-		}
-		const sessions: HitlSession[] = Array.from({ length: 15 }, (_, i) => ({
-			id: `sess-${i}`,
-			project_hash: "abc123",
-			started_at: 1714233600000 + i * 1000,
-			ended_at: null,
-			status: "active" as const,
-		}))
-
-		const output = formatMetrics(stats, sessions, mockTheme)
-
-		// Should have "... and 5 more" or similar ellipsis
-		expect(output).toMatch(/\.{3,}|and \d+ more/)
-	})
-
-	it("handles sessions as first argument in slice form", () => {
-		// Verify the function signature matches expected form
-		const stats: HitlStats = { total_sessions: 1, total_hitl_time_ms: 0, interaction_count: 1, avg_wait_ms: 0 }
-		const output = formatMetrics(stats, [], mockTheme)
-		expect(output).toBeTruthy()
+		expect(output).not.toContain("Permission Events")
 	})
 })
 
 describe("formatSessionRow", () => {
 	const mockTheme = createMockTheme()
 
-	it("formats active session with timestamp and status", () => {
-		const session: HitlSession = {
+	function createSession(overrides: Partial<HitlSession> = {}): HitlSession {
+		return {
 			id: "sess-1",
 			project_hash: "abc123",
 			started_at: 1714233600000,
 			ended_at: null,
 			status: "active",
+			end_cause: null,
+			agent_time_ms: 0,
+			hitl_time_ms: 0,
+			idle_time_ms: 0,
+			...overrides,
 		}
-		const output = formatSessionRow(session, mockTheme)
+	}
 
-		expect(output).toContain("2024-04-27")
+	it("formats active session", () => {
+		const session = createSession()
+		const output = formatSessionRow(session, mockTheme)
 		expect(output).toContain("ACTIVE")
-		expect(output).toContain("(active)")
 	})
 
-	it("formats closed session with duration", () => {
-		const session: HitlSession = {
-			id: "sess-2",
-			project_hash: "def456",
-			started_at: 1714233600000,
-			ended_at: 1714237200000, // 1 hour later
+	it("formats closed session", () => {
+		const session = createSession({
 			status: "closed",
-		}
+			ended_at: 1714237200000,
+			end_cause: "complete",
+		})
 		const output = formatSessionRow(session, mockTheme)
-
 		expect(output).toContain("CLOSED")
-		expect(output).toContain("(1h 0m 0s)")
+		expect(output).toContain("✓")
 	})
 
-	it("formats orphaned session with duration", () => {
-		const session: HitlSession = {
-			id: "sess-3",
-			project_hash: "ghi789",
-			started_at: 1714233600000,
-			ended_at: 1714237260000,
-			status: "orphaned",
-		}
+	it("formats interrupted session", () => {
+		const session = createSession({
+			status: "closed",
+			ended_at: 1714237200000,
+			end_cause: "signal",
+		})
 		const output = formatSessionRow(session, mockTheme)
+		expect(output).toContain("✗")
+	})
 
+	it("formats orphaned session", () => {
+		const session = createSession({
+			status: "orphaned",
+			ended_at: 1714237200000,
+			end_cause: "orphaned",
+		})
+		const output = formatSessionRow(session, mockTheme)
 		expect(output).toContain("ORPHANED")
-		expect(output).toMatch(/\(\d+h \d+m \d+s\)/)
 	})
 })
 
@@ -216,74 +153,16 @@ describe("formatTimelineSection", () => {
 		expect(output).toBe("")
 	})
 
-	it("returns formatted section with header and chart for segments", () => {
+	it("returns formatted section with three categories", () => {
 		const segments: TimelineSegment[] = [
-			{ type: "solo", startMs: 0, endMs: 5000, durationMs: 5000 },
+			{ type: "agent", startMs: 0, endMs: 5000, durationMs: 5000 },
 			{ type: "hitl", startMs: 5000, endMs: 8000, durationMs: 3000 },
+			{ type: "idle", startMs: 8000, endMs: 10000, durationMs: 2000 },
 		]
 		const output = formatTimelineSection(segments, mockTheme)
-
 		expect(output).toContain("Session Timeline")
-		expect(output).toContain("solo")
+		expect(output).toContain("agent")
 		expect(output).toContain("HITL")
-	})
-
-	it("respects custom width parameter", () => {
-		const segments: TimelineSegment[] = [
-			{ type: "solo", startMs: 0, endMs: 1000, durationMs: 1000 },
-		]
-		const output = formatTimelineSection(segments, mockTheme, 30)
-
-		expect(output).toContain("Session Timeline")
-		// The bar should be present with visual characters
-		expect(output).toContain("█")
-	})
-})
-
-describe("formatMetrics with timeline", () => {
-	const mockTheme = createMockTheme()
-
-	it("includes timeline section when provided", () => {
-		const stats: HitlStats = {
-			total_sessions: 1,
-			total_hitl_time_ms: 1000,
-			interaction_count: 1,
-			avg_wait_ms: 1000,
-		}
-		const sessions: HitlSession[] = []
-		const timeline = "Session Timeline\n\n  [timeline chart]"
-
-		const output = formatMetrics(stats, sessions, mockTheme, timeline)
-
-		expect(output).toContain("Session Timeline")
-		expect(output).toContain("[timeline chart]")
-	})
-
-	it("omits timeline section when empty string", () => {
-		const stats: HitlStats = {
-			total_sessions: 1,
-			total_hitl_time_ms: 1000,
-			interaction_count: 1,
-			avg_wait_ms: 1000,
-		}
-		const sessions: HitlSession[] = []
-
-		const output = formatMetrics(stats, sessions, mockTheme, "")
-
-		expect(output).not.toContain("Session Timeline")
-	})
-
-	it("omits timeline section when undefined", () => {
-		const stats: HitlStats = {
-			total_sessions: 1,
-			total_hitl_time_ms: 1000,
-			interaction_count: 1,
-			avg_wait_ms: 1000,
-		}
-		const sessions: HitlSession[] = []
-
-		const output = formatMetrics(stats, sessions, mockTheme)
-
-		expect(output).not.toContain("Session Timeline")
+		expect(output).toContain("idle")
 	})
 })

--- a/extensions/hitl-metrics/formatters.test.ts
+++ b/extensions/hitl-metrics/formatters.test.ts
@@ -3,23 +3,31 @@
  */
 
 import { describe, it, expect } from "vitest"
-import { formatDuration, formatMetrics, formatSessionRow, formatTimelineSection } from "./formatters.ts"
-import type { HitlStats, HitlSession, Theme, TimelineSegment } from "./types.ts"
+import { formatDuration, formatMetrics, formatSessionRow, formatTimelineSection } from "./formatters.js"
+import type { HitlStats, HitlSession, TimelineSegment } from "./types.js"
+import type { Theme } from "@mariozechner/pi-coding-agent"
 
 /**
  * Minimal mock theme that returns plain strings (no ANSI codes)
  * — suitable for deterministic unit tests
  */
 function createMockTheme(): Theme {
+	const noOp = (text: string) => text
 	return {
-		fg: (_color: string, text: string) => text,
-		bg: (_color: string, text: string) => text,
-		bold: (text: string) => text,
-		dim: (text: string) => text,
-		italic: (text: string) => text,
-		underline: (text: string) => text,
-		strikethrough: (text: string) => text,
-	}
+		name: "mock",
+		fg: (_c, text) => text,
+		bg: (_c, text) => text,
+		bold: noOp,
+		italic: noOp,
+		underline: noOp,
+		inverse: noOp,
+		strikethrough: noOp,
+		getFgAnsi: () => "",
+		getBgAnsi: () => "",
+		getColorMode: () => "truecolor",
+		getThinkingBorderColor: () => noOp,
+		getBashModeBorderColor: () => noOp,
+	} as unknown as Theme
 }
 
 describe("formatDuration", () => {
@@ -222,9 +230,6 @@ describe("formatSessionRow", () => {
 		expect(output).toMatch(/\(\d+h \d+m \d+s\)/)
 	})
 })
-
-import { formatTimelineSection } from "./formatters.ts"
-import type { TimelineSegment } from "./types.ts"
 
 describe("formatTimelineSection", () => {
 	const mockTheme = createMockTheme()

--- a/extensions/hitl-metrics/formatters.ts
+++ b/extensions/hitl-metrics/formatters.ts
@@ -5,21 +5,11 @@
  * No side effects — completely testable.
  */
 
-import type { HitlStats, HitlSession, TimelineSegment } from "./types.ts"
-import { renderTimeline } from "./timeline.ts"
+import type { HitlStats, HitlSession, TimelineSegment } from "./types.js"
+import { renderTimeline } from "./timeline.js"
 
-/**
- * Theme interface for color/formatting — matches @mariozechner/pi-coding-agent Theme
- */
-export interface Theme {
-	fg: (color: string, text: string) => string
-	bg: (color: string, text: string) => string
-	bold: (text: string) => string
-	dim: (text: string) => string
-	italic: (text: string) => string
-	underline: (text: string) => string
-	strikethrough: (text: string) => string
-}
+// Use the Theme type from @mariozechner/pi-coding-agent
+import type { Theme } from "@mariozechner/pi-coding-agent"
 
 /**
  * Convert milliseconds to human-readable "Xh Ym Zs" format.
@@ -88,11 +78,11 @@ export function formatSessionRow(session: HitlSession, theme: Theme): string {
 	// Status color coding (use text labels since we don't have specific colors)
 	let statusDisplay: string
 	if (session.status === "active") {
-		statusDisplay = theme.fg("yellow", status)
+		statusDisplay = theme.fg("warning", status)
 	} else if (session.status === "closed") {
-		statusDisplay = theme.fg("green", status)
+		statusDisplay = theme.fg("success", status)
 	} else {
-		statusDisplay = theme.fg("red", status)
+		statusDisplay = theme.fg("error", status)
 	}
 
 	return `  ${timestamp}  ${statusDisplay}${duration}`

--- a/extensions/hitl-metrics/formatters.ts
+++ b/extensions/hitl-metrics/formatters.ts
@@ -1,0 +1,181 @@
+/**
+ * HITL Metrics Formatters
+ *
+ * Pure formatting utilities for displaying HITL metrics in the TUI.
+ * No side effects — completely testable.
+ */
+
+import type { HitlStats, HitlSession, TimelineSegment } from "./types.ts"
+import { renderTimeline } from "./timeline.ts"
+
+/**
+ * Theme interface for color/formatting — matches @mariozechner/pi-coding-agent Theme
+ */
+export interface Theme {
+	fg: (color: string, text: string) => string
+	bg: (color: string, text: string) => string
+	bold: (text: string) => string
+	dim: (text: string) => string
+	italic: (text: string) => string
+	underline: (text: string) => string
+	strikethrough: (text: string) => string
+}
+
+/**
+ * Convert milliseconds to human-readable "Xh Ym Zs" format.
+ * - Omits zero-value leading segments (e.g., no "0h" if < 1 hour)
+ * - Always shows at least "0s" for zero input
+ * - Rounds seconds to whole numbers
+ */
+export function formatDuration(ms: number): string {
+	if (ms < 0) ms = 0
+	if (ms === 0) return "0s"
+
+	const totalSeconds = Math.round(ms / 1000)
+	const hours = Math.floor(totalSeconds / 3600)
+	const minutes = Math.floor((totalSeconds % 3600) / 60)
+	const seconds = totalSeconds % 60
+
+	const parts: string[] = []
+
+	if (hours > 0) {
+		parts.push(`${hours}h`)
+	}
+
+	if (minutes > 0 || hours > 0) {
+		parts.push(`${minutes}m`)
+	}
+
+	// Always show seconds (unless we have hours/minutes, then show even if 0)
+	if (hours === 0 && minutes === 0) {
+		parts.push(`${seconds}s`)
+	} else {
+		parts.push(`${seconds}s`)
+	}
+
+	return parts.join(" ")
+}
+
+/**
+ * Format a timestamp (Unix epoch ms) to ISO date string (YYYY-MM-DD HH:MM)
+ */
+function formatTimestamp(ms: number): string {
+	const date = new Date(ms)
+	const year = date.getFullYear()
+	const month = String(date.getMonth() + 1).padStart(2, "0")
+	const day = String(date.getDate()).padStart(2, "0")
+	const hour = String(date.getHours()).padStart(2, "0")
+	const minute = String(date.getMinutes()).padStart(2, "0")
+
+	return `${year}-${month}-${day} ${hour}:${minute}`
+}
+
+/**
+ * Format a single session row for the recent sessions list
+ */
+export function formatSessionRow(session: HitlSession, theme: Theme): string {
+	const timestamp = formatTimestamp(session.started_at)
+	const status = session.status.toUpperCase()
+
+	let duration = ""
+	if (session.ended_at !== null) {
+		const durationMs = session.ended_at - session.started_at
+		duration = ` (${formatDuration(durationMs)})`
+	} else {
+		duration = " (active)"
+	}
+
+	// Status color coding (use text labels since we don't have specific colors)
+	let statusDisplay: string
+	if (session.status === "active") {
+		statusDisplay = theme.fg("yellow", status)
+	} else if (session.status === "closed") {
+		statusDisplay = theme.fg("green", status)
+	} else {
+		statusDisplay = theme.fg("red", status)
+	}
+
+	return `  ${timestamp}  ${statusDisplay}${duration}`
+}
+
+/**
+ * Format a timeline section with a section header.
+ * Returns an empty string if there are no timeline segments.
+ *
+ * @param segments - Array of timeline segments (from most recent session)
+ * @param theme - Theme for color/formatting
+ * @param width - Chart width in characters (default: 60)
+ * @returns Formatted timeline section string, or empty string if no segments
+ */
+export function formatTimelineSection(
+	segments: TimelineSegment[],
+	theme: Theme,
+	width: number = 60,
+): string {
+	if (segments.length === 0) {
+		return ""
+	}
+
+	const lines: string[] = []
+	lines.push(theme.bold("Session Timeline"))
+	lines.push("")
+	lines.push("  " + renderTimeline(segments, theme, width))
+	lines.push("")
+
+	return lines.join("\n")
+}
+
+/**
+ * Build the complete /metrics output as themed text lines
+ */
+export function formatMetrics(
+	stats: HitlStats,
+	recentSessions: HitlSession[],
+	theme: Theme,
+	timelineSection?: string,
+): string {
+	const lines: string[] = []
+
+	// Header
+	lines.push("")
+	lines.push(theme.bold("HITL Metrics"))
+	lines.push("")
+
+	// Empty state check
+	if (stats.total_sessions === 0) {
+		lines.push("  No HITL data recorded yet")
+		lines.push("")
+		return lines.join("\n")
+	}
+
+	// Stats section
+	lines.push(theme.bold("Statistics"))
+	lines.push(`  Total sessions:     ${stats.total_sessions}`)
+	lines.push(`  Total HITL time:    ${formatDuration(stats.total_hitl_time_ms)}`)
+	lines.push(`  Interactions:       ${stats.interaction_count}`)
+	lines.push(`  Avg wait time:      ${formatDuration(stats.avg_wait_ms)}`)
+	lines.push("")
+
+	// Recent sessions section
+	lines.push(theme.bold("Recent Sessions"))
+	if (recentSessions.length === 0) {
+		lines.push("  No recent sessions")
+	} else {
+		// Show up to 10 sessions
+		const sessionsToShow = recentSessions.slice(0, 10)
+		for (const session of sessionsToShow) {
+			lines.push(formatSessionRow(session, theme))
+		}
+		if (recentSessions.length > 10) {
+			lines.push(`  ... and ${recentSessions.length - 10} more`)
+		}
+	}
+	lines.push("")
+
+	// Append timeline section if provided
+	if (timelineSection !== undefined && timelineSection !== "") {
+		lines.push(timelineSection)
+	}
+
+	return lines.join("\n")
+}

--- a/extensions/hitl-metrics/formatters.ts
+++ b/extensions/hitl-metrics/formatters.ts
@@ -2,158 +2,136 @@
  * HITL Metrics Formatters
  *
  * Pure formatting utilities for displaying HITL metrics in the TUI.
- * No side effects — completely testable.
+ * Updated to support three-category time tracking and end causes.
  */
 
 import type { HitlStats, HitlSession, TimelineSegment } from "./types.js"
 import { renderTimeline } from "./timeline.js"
-
-// Use the Theme type from @mariozechner/pi-coding-agent
 import type { Theme } from "@mariozechner/pi-coding-agent"
 
-/**
- * Convert milliseconds to human-readable "Xh Ym Zs" format.
- * - Omits zero-value leading segments (e.g., no "0h" if < 1 hour)
- * - Always shows at least "0s" for zero input
- * - Rounds seconds to whole numbers
- */
 export function formatDuration(ms: number): string {
 	if (ms < 0) ms = 0
 	if (ms === 0) return "0s"
-
 	const totalSeconds = Math.round(ms / 1000)
 	const hours = Math.floor(totalSeconds / 3600)
 	const minutes = Math.floor((totalSeconds % 3600) / 60)
 	const seconds = totalSeconds % 60
-
 	const parts: string[] = []
-
-	if (hours > 0) {
-		parts.push(`${hours}h`)
-	}
-
-	if (minutes > 0 || hours > 0) {
-		parts.push(`${minutes}m`)
-	}
-
-	// Always show seconds (unless we have hours/minutes, then show even if 0)
-	if (hours === 0 && minutes === 0) {
-		parts.push(`${seconds}s`)
-	} else {
-		parts.push(`${seconds}s`)
-	}
-
+	if (hours > 0) parts.push(`${hours}h`)
+	if (minutes > 0 || hours > 0) parts.push(`${minutes}m`)
+	parts.push(`${seconds}s`)
 	return parts.join(" ")
 }
 
-/**
- * Format a timestamp (Unix epoch ms) to ISO date string (YYYY-MM-DD HH:MM)
- */
 function formatTimestamp(ms: number): string {
-	const date = new Date(ms)
-	const year = date.getFullYear()
-	const month = String(date.getMonth() + 1).padStart(2, "0")
-	const day = String(date.getDate()).padStart(2, "0")
-	const hour = String(date.getHours()).padStart(2, "0")
-	const minute = String(date.getMinutes()).padStart(2, "0")
-
-	return `${year}-${month}-${day} ${hour}:${minute}`
+	const d = new Date(ms)
+	return `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, "0")}-${String(d.getDate()).padStart(2, "0")} ${String(d.getHours()).padStart(2, "0")}:${String(d.getMinutes()).padStart(2, "0")}`
 }
 
-/**
- * Format a single session row for the recent sessions list
- */
+function formatEndCause(cause: string | null | undefined): string {
+	if (!cause) return ""
+	const icons: Record<string, string> = {
+		complete: "✓",
+		disconnect: "⚠",
+		signal: "✗",
+		orphaned: "?",
+	}
+	return icons[cause] || "?"
+}
+
+function getCauseColor(cause: string | null | undefined): "success" | "error" | "warning" | "muted" {
+	if (cause === "complete") return "success"
+	if (cause === "disconnect" || cause === "signal" || cause === "orphaned") return "error"
+	return "muted"
+}
+
 export function formatSessionRow(session: HitlSession, theme: Theme): string {
 	const timestamp = formatTimestamp(session.started_at)
-	const status = session.status.toUpperCase()
+	const duration = session.ended_at ? formatDuration(session.ended_at - session.started_at) : "active"
+	const causeIcon = session.end_cause ? formatEndCause(session.end_cause) : ""
+	const causeColor = getCauseColor(session.end_cause)
 
-	let duration = ""
-	if (session.ended_at !== null) {
-		const durationMs = session.ended_at - session.started_at
-		duration = ` (${formatDuration(durationMs)})`
-	} else {
-		duration = " (active)"
-	}
-
-	// Status color coding (use text labels since we don't have specific colors)
 	let statusDisplay: string
-	if (session.status === "active") {
-		statusDisplay = theme.fg("warning", status)
-	} else if (session.status === "closed") {
-		statusDisplay = theme.fg("success", status)
-	} else {
-		statusDisplay = theme.fg("error", status)
-	}
+	if (session.status === "active") statusDisplay = theme.fg("warning", "ACTIVE")
+	else if (session.status === "closed") statusDisplay = theme.fg("success", "CLOSED")
+	else statusDisplay = theme.fg("error", "ORPHANED")
 
-	return `  ${timestamp}  ${statusDisplay}${duration}`
+	const causeDisplay = causeIcon ? ` ${theme.fg(causeColor, causeIcon)}` : ""
+
+	return `  ${timestamp}  ${statusDisplay}${causeDisplay}  (${duration})`
 }
 
-/**
- * Format a timeline section with a section header.
- * Returns an empty string if there are no timeline segments.
- *
- * @param segments - Array of timeline segments (from most recent session)
- * @param theme - Theme for color/formatting
- * @param width - Chart width in characters (default: 60)
- * @returns Formatted timeline section string, or empty string if no segments
- */
-export function formatTimelineSection(
-	segments: TimelineSegment[],
-	theme: Theme,
-	width: number = 60,
-): string {
-	if (segments.length === 0) {
-		return ""
-	}
-
-	const lines: string[] = []
-	lines.push(theme.bold("Session Timeline"))
-	lines.push("")
-	lines.push("  " + renderTimeline(segments, theme, width))
-	lines.push("")
-
-	return lines.join("\n")
+export function formatTimelineSection(segments: TimelineSegment[], theme: Theme, width = 60): string {
+	if (segments.length === 0) return ""
+	return [theme.bold("Session Timeline"), "", "  " + renderTimeline(segments, theme, width), ""].join("\n")
 }
 
-/**
- * Build the complete /metrics output as themed text lines
- */
 export function formatMetrics(
 	stats: HitlStats,
 	recentSessions: HitlSession[],
 	theme: Theme,
 	timelineSection?: string,
 ): string {
-	const lines: string[] = []
+	const lines: string[] = ["", theme.bold("HITL Metrics"), ""]
 
-	// Header
-	lines.push("")
-	lines.push(theme.bold("HITL Metrics"))
-	lines.push("")
-
-	// Empty state check
 	if (stats.total_sessions === 0) {
-		lines.push("  No HITL data recorded yet")
-		lines.push("")
+		lines.push("  No HITL data recorded yet", "")
 		return lines.join("\n")
 	}
 
-	// Stats section
+	// Calculate totals from sessions
+	let totalAgentMs = 0
+	let totalHitlMs = 0
+	let totalIdleMs = 0
+
+	for (const session of recentSessions) {
+		totalAgentMs += session.agent_time_ms || 0
+		totalHitlMs += session.hitl_time_ms || 0
+		totalIdleMs += session.idle_time_ms || 0
+	}
+
+	// Add session-level aggregation for backward compatibility
+	lines.push(theme.bold("Time Breakdown"))
+	lines.push(`  Agent time: ${formatDuration(totalAgentMs)}`)
+	lines.push(`  HITL time:  ${formatDuration(totalHitlMs)}`)
+	lines.push(`  Idle time:  ${formatDuration(totalIdleMs)}`)
+	lines.push("")
+
 	lines.push(theme.bold("Statistics"))
 	lines.push(`  Total sessions:     ${stats.total_sessions}`)
 	lines.push(`  Total HITL time:    ${formatDuration(stats.total_hitl_time_ms)}`)
 	lines.push(`  Interactions:       ${stats.interaction_count}`)
 	lines.push(`  Avg wait time:      ${formatDuration(stats.avg_wait_ms)}`)
 	lines.push("")
+	
+	// Permission stats
+	if (stats.permission_count > 0) {
+		lines.push(theme.bold("Permission Events"))
+		lines.push(`  Permission prompts: ${stats.permission_count}`)
+		lines.push(`  Permission time:    ${formatDuration(stats.total_permission_time_ms)}`)
+		lines.push("")
+	}
 
-	// Recent sessions section
+	// Count end causes
+	const endCauses = { complete: 0, disconnect: 0, signal: 0, orphaned: 0 }
+	for (const s of recentSessions) {
+		if (s.end_cause) endCauses[s.end_cause]++
+	}
+	const completed = endCauses.complete
+	const interrupted = endCauses.disconnect + endCauses.signal + endCauses.orphaned
+
+	if (completed > 0 || interrupted > 0) {
+		lines.push(theme.bold("Session Outcomes"))
+		lines.push(`  Complete: ${completed}`)
+		lines.push(`  Interrupted: ${interrupted}`)
+		lines.push("")
+	}
+
 	lines.push(theme.bold("Recent Sessions"))
 	if (recentSessions.length === 0) {
 		lines.push("  No recent sessions")
 	} else {
-		// Show up to 10 sessions
-		const sessionsToShow = recentSessions.slice(0, 10)
-		for (const session of sessionsToShow) {
+		for (const session of recentSessions.slice(0, 10)) {
 			lines.push(formatSessionRow(session, theme))
 		}
 		if (recentSessions.length > 10) {
@@ -162,8 +140,7 @@ export function formatMetrics(
 	}
 	lines.push("")
 
-	// Append timeline section if provided
-	if (timelineSection !== undefined && timelineSection !== "") {
+	if (timelineSection) {
 		lines.push(timelineSection)
 	}
 

--- a/extensions/hitl-metrics/hooks.test.ts
+++ b/extensions/hitl-metrics/hooks.test.ts
@@ -1,0 +1,1050 @@
+/**
+ * HITL Metrics Extension Hook Tests
+ *
+ * Comprehensive end-to-end tests covering the complete extension lifecycle.
+ * Uses a mock pi harness to fire events exactly as the real agent would,
+ * then queries the DB and metrics output to verify correctness.
+ *
+ * Key: HITL_DB_PATH env var redirects the SessionManager singleton's DB to
+ * the test's temp directory so reads and writes meet in the same place.
+ */
+
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest"
+import { mkdtempSync, rmSync, existsSync, mkdirSync } from "node:fs"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
+import { randomUUID } from "node:crypto"
+import hitlMetricsExtension from "./index.js"
+import { getMetricsOutput } from "./commands/metrics.js"
+import { createMockTheme } from "./test-helpers/mock-theme.js"
+import { HitlDatabase } from "./storage/db.js"
+import { projectHash } from "./storage/hash.js"
+import type { ExtensionAPI, ExtensionContext } from "@mariozechner/pi-coding-agent"
+import type { HitlSession, HitlEvent } from "./types.js"
+
+// ============================================================================
+// Mock pi harness
+// ============================================================================
+
+function createMockPi(): ExtensionAPI & {
+	_trigger: (eventName: string, event?: Record<string, unknown>, ctx?: ExtensionContext) => Promise<void>
+	_handlers: Map<string, ((event: unknown, ctx?: ExtensionContext) => Promise<void>)[]>
+	_commands: Map<string, { description: string; handler: (args: string, ctx: ExtensionContext) => Promise<void> }>
+} {
+	const handlers = new Map<string, ((event: unknown, ctx?: ExtensionContext) => Promise<void>)[]>()
+	const commands = new Map<string, { description: string; handler: (args: string, ctx: ExtensionContext) => Promise<void> }>()
+
+	return {
+		_handlers: handlers,
+		_commands: commands,
+		on: (event, handler) => {
+			if (!handlers.has(event)) handlers.set(event, [])
+			handlers.get(event)!.push(handler as never)
+		},
+		registerCommand: (name, config) => commands.set(name, config),
+		_trigger: async (event, data, ctx) => {
+			const h = handlers.get(event) || []
+			for (const fn of h) await fn(data, ctx)
+		},
+	} as never
+}
+
+function createMockCtx(cwd: string): ExtensionContext {
+	return {
+		cwd,
+		hasUI: true,
+		ui: {
+			notify: vi.fn(),
+			theme: createMockTheme() as never,
+			select: vi.fn(),
+			confirm: vi.fn(),
+			input: vi.fn(),
+		},
+	} as never
+}
+
+// ============================================================================
+// Test helpers
+// ============================================================================
+
+function createTempDir(): string {
+	return mkdtempSync(join(tmpdir(), "hitl-hooks-"))
+}
+
+/**
+ * Redirect the SessionManager singleton's DB to a test-specific path.
+ * The extension reads HITL_DB_PATH from env and passes it to SessionManager.init().
+ */
+function redirectDbTo(tempDir: string): void {
+	const hash = projectHash(tempDir)
+	const dbDir = join(tempDir, hash)
+	if (!existsSync(dbDir)) mkdirSync(dbDir, { recursive: true })
+	process.env.HITL_DB_PATH = join(dbDir, "hitl.db")
+}
+
+function restoreDbPath(): void {
+	delete process.env.HITL_DB_PATH
+}
+
+function readSessions(db: HitlDatabase): HitlSession[] {
+	return db.query<HitlSession>(
+		`SELECT id, project_hash, started_at, ended_at, status, end_cause,
+		        agent_time_ms, hitl_time_ms, idle_time_ms
+		 FROM hitl_sessions ORDER BY started_at ASC`,
+	)
+}
+
+function readEvents(db: HitlDatabase): HitlEvent[] {
+	return db.query<HitlEvent>(
+		`SELECT id, session_id, tool_name, question_count, duration_ms, selected_options, created_at
+		 FROM hitl_events ORDER BY created_at ASC`,
+	)
+}
+
+function readActivities(db: HitlDatabase, sessionId?: string): Array<Record<string, unknown>> {
+	const where = sessionId ? "WHERE session_id = ?" : ""
+	const args = sessionId ? [sessionId] : []
+	return db.query(
+		`SELECT id, session_id, activity_type, duration_ms, timestamp
+		 FROM activity_events ${where} ORDER BY id ASC`,
+		args,
+	)
+}
+
+function delay(ms: number): Promise<void> {
+	return new Promise((r) => setTimeout(r, ms))
+}
+
+// Helper to fire a HITL interaction
+// Always waits at least MIN_WAIT before firing result to avoid cache threshold
+// 50ms minimum + extra buffer ensures we exceed CACHE_THRESHOLD_MS = 50
+const MIN_WAIT_MS = 60
+function fireHitl(
+	mockPi: ReturnType<typeof createMockPi>,
+	index: number,
+	questions: number,
+	selectedOptions: string[],
+	durationMs: number,
+): Promise<void> {
+	const callId = `call-hitl-${index}`
+	const waitMs = Math.max(durationMs / 2, MIN_WAIT_MS)
+	return mockPi
+		._trigger("tool_execution_start", { toolName: "ask_user_questions", toolCallId: callId })
+		.then(() => delay(waitMs))
+		.then(() =>
+			mockPi._trigger("tool_result", {
+				toolName: "ask_user_questions",
+				toolCallId: callId,
+				isError: false,
+				input: { questions: Array.from({ length: questions }, (_, i) => ({ id: i })) },
+				result: { selectedOptions },
+			}),
+		)
+}
+
+// Helper to fire a non-HITL tool
+function fireTool(
+	mockPi: ReturnType<typeof createMockPi>,
+	name: string,
+	callId: string,
+	durationMs: number,
+): Promise<void> {
+	return mockPi
+		._trigger("tool_execution_start", { toolName: name, toolCallId: callId })
+		.then(() => delay(durationMs / 2))
+		.then(() =>
+			mockPi._trigger("tool_result", {
+				toolName: name,
+				toolCallId: callId,
+				isError: false,
+				input: {},
+				result: { output: `ok` },
+			}),
+		)
+}
+
+// ============================================================================
+// Hook Registration Tests
+// ============================================================================
+
+describe("HITL Extension — hook registration", () => {
+	it("registers all required hooks and command", () => {
+		const mockPi = createMockPi()
+		hitlMetricsExtension(mockPi)
+		expect(mockPi._handlers.has("session_start")).toBe(true)
+		expect(mockPi._handlers.has("input")).toBe(true)
+		expect(mockPi._handlers.has("tool_execution_start")).toBe(true)
+		expect(mockPi._handlers.has("tool_result")).toBe(true)
+		expect(mockPi._handlers.has("session_shutdown")).toBe(true)
+		expect(mockPi._commands.has("metrics")).toBe(true)
+	})
+
+	it("each hook registers exactly one handler", () => {
+		const mockPi = createMockPi()
+		hitlMetricsExtension(mockPi)
+		expect(mockPi._handlers.get("session_start")?.length).toBe(1)
+		expect(mockPi._handlers.get("tool_result")?.length).toBe(1)
+		expect(mockPi._handlers.get("tool_execution_start")?.length).toBe(1)
+		expect(mockPi._handlers.get("input")?.length).toBe(1)
+		expect(mockPi._handlers.get("session_shutdown")?.length).toBe(1)
+	})
+
+	it("/metrics command has correct description", () => {
+		const mockPi = createMockPi()
+		hitlMetricsExtension(mockPi)
+		expect(mockPi._commands.get("metrics")?.description).toBe("Show HITL interaction metrics")
+	})
+})
+
+// ============================================================================
+// session_start Tests
+// ============================================================================
+
+describe("HITL Extension — session_start hook", () => {
+	let consoleWarnSpy: ReturnType<typeof vi.spyOn>
+	let tempDir: string
+	let mockCtx: ExtensionContext
+
+	beforeEach(() => {
+		consoleWarnSpy = vi.spyOn(console, "warn").mockImplementation(() => {})
+		tempDir = createTempDir()
+		redirectDbTo(tempDir)
+		mockCtx = createMockCtx(tempDir)
+	})
+
+	afterEach(() => {
+		consoleWarnSpy.mockRestore()
+		restoreDbPath()
+		rmSync(tempDir, { recursive: true, force: true })
+	})
+
+	it("creates database file and session on session_start", async () => {
+		const mockPi = createMockPi()
+		hitlMetricsExtension(mockPi)
+		await mockPi._trigger("session_start", {}, mockCtx)
+
+		const dbPath = process.env.HITL_DB_PATH!
+		expect(existsSync(dbPath)).toBe(true)
+
+		const db = new HitlDatabase(dbPath)
+		db.open()
+		const sessions = readSessions(db)
+		expect(sessions).toHaveLength(1)
+		expect(sessions[0].status).toBe("active")
+		expect(sessions[0].project_hash).toBe(projectHash(tempDir))
+		expect(sessions[0].ended_at).toBeNull()
+		expect(sessions[0].end_cause).toBeNull()
+		db.close()
+	})
+
+	it("initializes session with zeroed time metrics", async () => {
+		const mockPi = createMockPi()
+		hitlMetricsExtension(mockPi)
+		await mockPi._trigger("session_start", {}, mockCtx)
+
+		const db = new HitlDatabase(process.env.HITL_DB_PATH!)
+		db.open()
+		const sessions = readSessions(db)
+		expect(sessions[0].agent_time_ms).toBe(0)
+		expect(sessions[0].hitl_time_ms).toBe(0)
+		expect(sessions[0].idle_time_ms).toBe(0)
+		db.close()
+	})
+
+	it("is non-fatal when cwd is empty", async () => {
+		const mockPi = createMockPi()
+		hitlMetricsExtension(mockPi)
+		await mockPi._trigger("session_start", {}, { cwd: "", hasUI: false } as ExtensionContext)
+		expect(consoleWarnSpy).toHaveBeenCalledWith(expect.stringContaining("cwd"))
+	})
+
+	it("closes orphaned sessions on startup", async () => {
+		// Pre-create a stale active session (>2h old, beyond the orphan threshold)
+		const dbPath = process.env.HITL_DB_PATH!
+		const db = new HitlDatabase(dbPath)
+		db.open()
+		db.initSchema()
+		// Insert session 3 hours ago — definitely beyond the 2h orphan threshold
+		const oldTime = Date.now() - 3 * 60 * 60 * 1000
+		db.run(
+			`INSERT INTO hitl_sessions (id, project_hash, started_at, status, agent_time_ms, hitl_time_ms, idle_time_ms)
+			 VALUES (?, ?, ?, ?, ?, ?, ?)`,
+			["old-session", projectHash(tempDir), oldTime, "active", 0, 0, 0],
+		)
+		db.close()
+
+		const mockPi = createMockPi()
+		hitlMetricsExtension(mockPi)
+		await mockPi._trigger("session_start", {}, mockCtx)
+
+		const db2 = new HitlDatabase(dbPath)
+		db2.open()
+		const sessions = readSessions(db2)
+		const old = sessions.find((s) => s.id === "old-session")
+		expect(old?.status).toBe("orphaned")
+		expect(old?.end_cause).toBe("orphaned")
+		const active = sessions.filter((s) => s.status === "active")
+		expect(active).toHaveLength(1)
+		db2.close()
+	})
+})
+
+// ============================================================================
+// tool_execution_start Tests
+// ============================================================================
+
+describe("HITL Extension — tool_execution_start hook", () => {
+	let consoleWarnSpy: ReturnType<typeof vi.spyOn>
+	let tempDir: string
+	let mockCtx: ExtensionContext
+
+	beforeEach(() => {
+		consoleWarnSpy = vi.spyOn(console, "warn").mockImplementation(() => {})
+		tempDir = createTempDir()
+		redirectDbTo(tempDir)
+		mockCtx = createMockCtx(tempDir)
+	})
+
+	afterEach(() => {
+		consoleWarnSpy.mockRestore()
+		restoreDbPath()
+		rmSync(tempDir, { recursive: true, force: true })
+	})
+
+	it("records activity events for tool starts", async () => {
+		const mockPi = createMockPi()
+		hitlMetricsExtension(mockPi)
+		await mockPi._trigger("session_start", {}, mockCtx)
+		await mockPi._trigger("tool_execution_start", { toolName: "read_file", toolCallId: "call-1" })
+		await mockPi._trigger("tool_execution_start", { toolName: "bash", toolCallId: "call-2" })
+		await mockPi._trigger("session_shutdown", {})
+
+		const db = new HitlDatabase(process.env.HITL_DB_PATH!)
+		db.open()
+		const activities = readActivities(db)
+		expect(activities.length).toBe(2)
+		expect(activities.every((a) => (a.activity_type as string) === "tool_start")).toBe(true)
+		db.close()
+	})
+
+	it("ignores events without toolCallId", async () => {
+		const mockPi = createMockPi()
+		hitlMetricsExtension(mockPi)
+		await mockPi._trigger("session_start", {}, mockCtx)
+		// Should not throw
+		await mockPi._trigger("tool_execution_start", { toolName: "bash" })
+		expect(consoleWarnSpy).not.toHaveBeenCalled()
+	})
+
+	it("records separate events for each tool start", async () => {
+		const mockPi = createMockPi()
+		hitlMetricsExtension(mockPi)
+		await mockPi._trigger("session_start", {}, mockCtx)
+		await mockPi._trigger("tool_execution_start", { toolName: "bash", toolCallId: "call-a" })
+		await mockPi._trigger("tool_execution_start", { toolName: "write_file", toolCallId: "call-b" })
+		await mockPi._trigger("tool_execution_start", { toolName: "bash", toolCallId: "call-c" })
+		await mockPi._trigger("session_shutdown", {})
+
+		const db = new HitlDatabase(process.env.HITL_DB_PATH!)
+		db.open()
+		const activities = readActivities(db)
+		expect(activities.length).toBe(3)
+		db.close()
+	})
+})
+
+// ============================================================================
+// tool_result Tests — HITL Events
+// ============================================================================
+
+describe("HITL Extension — tool_result hook (ask_user_questions)", () => {
+	let consoleWarnSpy: ReturnType<typeof vi.spyOn>
+	let tempDir: string
+	let mockCtx: ExtensionContext
+
+	beforeEach(() => {
+		consoleWarnSpy = vi.spyOn(console, "warn").mockImplementation(() => {})
+		tempDir = createTempDir()
+		redirectDbTo(tempDir)
+		mockCtx = createMockCtx(tempDir)
+	})
+
+	afterEach(() => {
+		consoleWarnSpy.mockRestore()
+		restoreDbPath()
+		rmSync(tempDir, { recursive: true, force: true })
+	})
+
+	it("writes HITL event with correct fields", async () => {
+		const mockPi = createMockPi()
+		hitlMetricsExtension(mockPi)
+		await mockPi._trigger("session_start", {}, mockCtx)
+		// 150ms ensures total duration passes 50ms cache threshold with margin
+		await fireHitl(mockPi, 1, 2, ["opt-a"], 150)
+		await mockPi._trigger("session_shutdown", {})
+
+		const db = new HitlDatabase(process.env.HITL_DB_PATH!)
+		db.open()
+		const events = readEvents(db)
+		expect(events).toHaveLength(1)
+		expect(events[0].tool_name).toBe("ask_user_questions")
+		expect(events[0].question_count).toBe(2)
+		expect(events[0].selected_options).toBe(JSON.stringify(["opt-a"]))
+		// Duration reflects elapsed time between start and result (≥50ms cache threshold)
+		expect(events[0].duration_ms).toBeGreaterThanOrEqual(50)
+		// hitl_time_ms persisted to DB on session_shutdown
+		const sessions = readSessions(db)
+		expect(sessions[0].hitl_time_ms).toBeGreaterThan(0)
+		db.close()
+	})
+
+	it("extracts question count from input.questions array length", async () => {
+		const mockPi = createMockPi()
+		hitlMetricsExtension(mockPi)
+		await mockPi._trigger("session_start", {}, mockCtx)
+		await fireHitl(mockPi, 1, 4, ["x"], 50)
+		await mockPi._trigger("session_shutdown", {})
+
+		const db = new HitlDatabase(process.env.HITL_DB_PATH!)
+		db.open()
+		const events = readEvents(db)
+		expect(events[0].question_count).toBe(4)
+		db.close()
+	})
+
+	it("extracts selectedOptions array from result", async () => {
+		const mockPi = createMockPi()
+		hitlMetricsExtension(mockPi)
+		await mockPi._trigger("session_start", {}, mockCtx)
+		await fireHitl(mockPi, 1, 3, ["A", "B", "C"], 50)
+		await mockPi._trigger("session_shutdown", {})
+
+		const db = new HitlDatabase(process.env.HITL_DB_PATH!)
+		db.open()
+		const events = readEvents(db)
+		expect(JSON.parse(events[0].selected_options)).toEqual(["A", "B", "C"])
+		db.close()
+	})
+
+	it("drops error results", async () => {
+		const mockPi = createMockPi()
+		hitlMetricsExtension(mockPi)
+		await mockPi._trigger("session_start", {}, mockCtx)
+		await mockPi._trigger("tool_execution_start", { toolName: "ask_user_questions", toolCallId: "call-err" })
+		await mockPi._trigger("tool_result", {
+			toolName: "ask_user_questions",
+			toolCallId: "call-err",
+			isError: true,
+			input: { questions: [{ id: 1 }] },
+			result: {},
+		})
+		await mockPi._trigger("session_shutdown", {})
+
+		const db = new HitlDatabase(process.env.HITL_DB_PATH!)
+		db.open()
+		expect(readEvents(db)).toHaveLength(0)
+		db.close()
+	})
+
+	it("skips result without tool_execution_start (no duration)", async () => {
+		const mockPi = createMockPi()
+		hitlMetricsExtension(mockPi)
+		await mockPi._trigger("session_start", {}, mockCtx)
+		await mockPi._trigger("tool_result", {
+			toolName: "ask_user_questions",
+			toolCallId: "call-no-start",
+			isError: false,
+			input: { questions: [{ id: 1 }] },
+			result: { selectedOptions: ["x"] },
+		})
+		await mockPi._trigger("session_shutdown", {})
+
+		const db = new HitlDatabase(process.env.HITL_DB_PATH!)
+		db.open()
+		expect(readEvents(db)).toHaveLength(0) // no start time, no duration
+		db.close()
+	})
+
+	it("skips fast results below cache threshold", async () => {
+		const mockPi = createMockPi()
+		hitlMetricsExtension(mockPi)
+		await mockPi._trigger("session_start", {}, mockCtx)
+		await mockPi._trigger("tool_execution_start", { toolName: "ask_user_questions", toolCallId: "call-fast" })
+		// Fire immediately — no delay
+		await mockPi._trigger("tool_result", {
+			toolName: "ask_user_questions",
+			toolCallId: "call-fast",
+			isError: false,
+			input: { questions: [{ id: 1 }] },
+			result: { selectedOptions: ["y"] },
+		})
+		await mockPi._trigger("session_shutdown", {})
+
+		const db = new HitlDatabase(process.env.HITL_DB_PATH!)
+		db.open()
+		expect(readEvents(db)).toHaveLength(0) // below 50ms cache threshold
+		db.close()
+	})
+
+	it("accumulates hitl_time_ms for multiple HITL events", async () => {
+		const mockPi = createMockPi()
+		hitlMetricsExtension(mockPi)
+		await mockPi._trigger("session_start", {}, mockCtx)
+		await fireHitl(mockPi, 1, 1, ["A"], 80)
+		await fireHitl(mockPi, 2, 1, ["B"], 120)
+		await mockPi._trigger("session_shutdown", {})
+
+		const db = new HitlDatabase(process.env.HITL_DB_PATH!)
+		db.open()
+		const events = readEvents(db)
+		const sessions = readSessions(db)
+		expect(events).toHaveLength(2)
+		expect(sessions[0].hitl_time_ms).toBeGreaterThan(0)
+		db.close()
+	})
+})
+
+// ============================================================================
+// tool_result Tests — Non-HITL Tools
+// ============================================================================
+
+describe("HITL Extension — tool_result hook (non-HITL tools)", () => {
+	let consoleWarnSpy: ReturnType<typeof vi.spyOn>
+	let tempDir: string
+	let mockCtx: ExtensionContext
+
+	beforeEach(() => {
+		consoleWarnSpy = vi.spyOn(console, "warn").mockImplementation(() => {})
+		tempDir = createTempDir()
+		redirectDbTo(tempDir)
+		mockCtx = createMockCtx(tempDir)
+	})
+
+	afterEach(() => {
+		consoleWarnSpy.mockRestore()
+		restoreDbPath()
+		rmSync(tempDir, { recursive: true, force: true })
+	})
+
+	const nonHitlTools = ["bash", "read_file", "write_file", "lsp", "search_the_web", "browser_navigate"]
+
+	for (const toolName of nonHitlTools) {
+		it(`${toolName} does NOT create hitl_events rows`, async () => {
+			const mockPi = createMockPi()
+			hitlMetricsExtension(mockPi)
+			await mockPi._trigger("session_start", {}, mockCtx)
+			await fireTool(mockPi, toolName, `call-${toolName}`, 100)
+
+			const db = new HitlDatabase(process.env.HITL_DB_PATH!)
+			db.open()
+			expect(readEvents(db)).toHaveLength(0)
+			db.close()
+		})
+	}
+
+	it("accumulates agent_time_ms for non-HITL tools", async () => {
+		const mockPi = createMockPi()
+		hitlMetricsExtension(mockPi)
+		await mockPi._trigger("session_start", {}, mockCtx)
+		await fireTool(mockPi, "bash", "call-agent", 200)
+		await mockPi._trigger("session_shutdown", {})
+
+		const db = new HitlDatabase(process.env.HITL_DB_PATH!)
+		db.open()
+		const sessions = readSessions(db)
+		// fireTool delay is durationMs/2, so minimum is ~durationMs/2
+		expect(sessions[0].agent_time_ms).toBeGreaterThanOrEqual(90)
+		db.close()
+	})
+
+	it("tool_execution_start is required for duration tracking", async () => {
+		const mockPi = createMockPi()
+		hitlMetricsExtension(mockPi)
+		await mockPi._trigger("session_start", {}, mockCtx)
+		await mockPi._trigger("tool_result", {
+			toolName: "bash",
+			toolCallId: "call-no-start",
+			isError: false,
+		})
+		await mockPi._trigger("session_shutdown", {})
+
+		const db = new HitlDatabase(process.env.HITL_DB_PATH!)
+		db.open()
+		// No start time → no duration → no agent time accumulated
+		const sessions = readSessions(db)
+		expect(sessions[0].agent_time_ms).toBe(0)
+		db.close()
+	})
+})
+
+// ============================================================================
+// input Handler Tests
+// ============================================================================
+
+describe("HITL Extension — input hook", () => {
+	let consoleWarnSpy: ReturnType<typeof vi.spyOn>
+	let tempDir: string
+	let mockCtx: ExtensionContext
+
+	beforeEach(() => {
+		consoleWarnSpy = vi.spyOn(console, "warn").mockImplementation(() => {})
+		tempDir = createTempDir()
+		redirectDbTo(tempDir)
+		mockCtx = createMockCtx(tempDir)
+	})
+
+	afterEach(() => {
+		consoleWarnSpy.mockRestore()
+		restoreDbPath()
+		rmSync(tempDir, { recursive: true, force: true })
+	})
+
+	it("skips extension-generated messages", async () => {
+		const mockPi = createMockPi()
+		hitlMetricsExtension(mockPi)
+		await mockPi._trigger("session_start", {}, mockCtx)
+		await mockPi._trigger("input", { source: "extension" })
+		// No throw, no warning
+		expect(consoleWarnSpy).not.toHaveBeenCalled()
+	})
+
+	it("records user_input activity event", async () => {
+		const mockPi = createMockPi()
+		hitlMetricsExtension(mockPi)
+		await mockPi._trigger("session_start", {}, mockCtx)
+		await mockPi._trigger("input", { source: "user" })
+
+		const db = new HitlDatabase(process.env.HITL_DB_PATH!)
+		db.open()
+		const activities = readActivities(db)
+		const userInputs = activities.filter((a) => (a.activity_type as string) === "user_input")
+		expect(userInputs).toHaveLength(1)
+		db.close()
+	})
+
+	it("is non-fatal when no session is active", async () => {
+		const mockPi = createMockPi()
+		hitlMetricsExtension(mockPi)
+		// No session_start — session is null
+		await mockPi._trigger("input", { source: "user" })
+		expect(consoleWarnSpy).not.toHaveBeenCalled()
+	})
+})
+
+// ============================================================================
+// session_shutdown Tests
+// ============================================================================
+
+describe("HITL Extension — session_shutdown hook", () => {
+	let consoleWarnSpy: ReturnType<typeof vi.spyOn>
+	let tempDir: string
+	let mockCtx: ExtensionContext
+
+	beforeEach(() => {
+		consoleWarnSpy = vi.spyOn(console, "warn").mockImplementation(() => {})
+		tempDir = createTempDir()
+		redirectDbTo(tempDir)
+		mockCtx = createMockCtx(tempDir)
+	})
+
+	afterEach(() => {
+		consoleWarnSpy.mockRestore()
+		restoreDbPath()
+		rmSync(tempDir, { recursive: true, force: true })
+	})
+
+	it("closes session with end_cause=signal by default", async () => {
+		const mockPi = createMockPi()
+		hitlMetricsExtension(mockPi)
+		await mockPi._trigger("session_start", {}, mockCtx)
+		await mockPi._trigger("session_shutdown", {})
+
+		const db = new HitlDatabase(process.env.HITL_DB_PATH!)
+		db.open()
+		const sessions = readSessions(db)
+		expect(sessions[0].status).toBe("closed")
+		expect(sessions[0].end_cause).toBe("signal")
+		expect(sessions[0].ended_at).not.toBeNull()
+		db.close()
+	})
+
+	it("sets end_cause=disconnect when cause=disconnect", async () => {
+		const mockPi = createMockPi()
+		hitlMetricsExtension(mockPi)
+		await mockPi._trigger("session_start", {}, mockCtx)
+		await mockPi._trigger("session_shutdown", { cause: "disconnect" })
+
+		const db = new HitlDatabase(process.env.HITL_DB_PATH!)
+		db.open()
+		const sessions = readSessions(db)
+		expect(sessions[0].status).toBe("closed")
+		expect(sessions[0].end_cause).toBe("complete") // disconnect → complete
+		db.close()
+	})
+
+	it("persists accumulated time metrics", async () => {
+		const mockPi = createMockPi()
+		hitlMetricsExtension(mockPi)
+		await mockPi._trigger("session_start", {}, mockCtx)
+		await fireTool(mockPi, "bash", "call-agent", 200)
+		await mockPi._trigger("session_shutdown", {})
+
+		const db = new HitlDatabase(process.env.HITL_DB_PATH!)
+		db.open()
+		const sessions = readSessions(db)
+		expect(sessions[0].agent_time_ms).toBeGreaterThan(0)
+		db.close()
+	})
+
+	it("is non-fatal when called before session_start", async () => {
+		const mockPi = createMockPi()
+		hitlMetricsExtension(mockPi)
+		// No session_start — session is null
+		await mockPi._trigger("session_shutdown", { cause: "disconnect" })
+		expect(consoleWarnSpy).not.toHaveBeenCalled()
+	})
+
+	it("session_shutdown sets end_cause on the closed session", async () => {
+		// Test that closeSession marks exactly one active session as closed
+		// with the correct end_cause — independent of which session is "most recent"
+		const now = Date.now()
+		const db = new HitlDatabase(process.env.HITL_DB_PATH!)
+		db.open()
+		db.run(
+			`INSERT INTO hitl_sessions (id, project_hash, started_at, status, agent_time_ms, hitl_time_ms, idle_time_ms)
+			 VALUES (?, ?, ?, ?, ?, ?, ?)`,
+			["test-session", projectHash(tempDir), now - 30_000, "active", 0, 0, 0],
+		)
+		db.close()
+
+		const mockPi = createMockPi()
+		hitlMetricsExtension(mockPi)
+		await mockPi._trigger("session_start", {}, mockCtx)
+		await mockPi._trigger("session_shutdown", { cause: "disconnect" })
+
+		// Verify a session was closed with the correct end_cause
+		const db2 = new HitlDatabase(process.env.HITL_DB_PATH!)
+		db2.open()
+		const closed = db2.query<{ id: string; end_cause: string }>(
+			`SELECT id, end_cause FROM hitl_sessions WHERE status = 'closed'`,
+		)
+		expect(closed.length).toBeGreaterThanOrEqual(1)
+		expect(closed[0].end_cause).toBe("complete") // disconnect → complete
+		db2.close()
+	})
+
+	it("command handler returns formatted metrics via ui.notify", async () => {
+		const mockPi = createMockPi()
+		hitlMetricsExtension(mockPi)
+		await mockPi._trigger("session_start", {}, mockCtx)
+		await mockPi._trigger("session_shutdown", {})
+
+		// getMetricsOutput returns full formatted output (what the handler passes to ui.notify)
+		const output = await getMetricsOutput(tempDir, createMockTheme(), {
+			dbPath: process.env.HITL_DB_PATH,
+		})
+		expect(output).toContain("HITL Metrics")
+		expect(output).toMatch(/Total sessions:\s+1/)
+		expect(output).toContain("Recent Sessions")
+	})
+
+	it("shows interaction count for HITL events", async () => {
+		const mockPi = createMockPi()
+		hitlMetricsExtension(mockPi)
+		await mockPi._trigger("session_start", {}, mockCtx)
+		await fireHitl(mockPi, 1, 1, ["yes"], 100)
+		await mockPi._trigger("session_shutdown", {})
+
+		const output = await getMetricsOutput(tempDir, createMockTheme(), {
+			dbPath: process.env.HITL_DB_PATH,
+		})
+		expect(output).toMatch(/Interactions:\s+1/)
+	})
+
+	it("shows 0 interactions when no HITL events occurred", async () => {
+		const mockPi = createMockPi()
+		hitlMetricsExtension(mockPi)
+		await mockPi._trigger("session_start", {}, mockCtx)
+		await mockPi._trigger("session_shutdown", {})
+
+		const output = await getMetricsOutput(tempDir, createMockTheme(), {
+			dbPath: process.env.HITL_DB_PATH,
+		})
+		expect(output).toMatch(/Interactions:\s+0/)
+	})
+
+	it("shows agent time from non-HITL tools", async () => {
+		const mockPi = createMockPi()
+		hitlMetricsExtension(mockPi)
+		await mockPi._trigger("session_start", {}, mockCtx)
+		await fireTool(mockPi, "bash", "call-bash", 5000)
+		await mockPi._trigger("session_shutdown", {})
+
+		const output = await getMetricsOutput(tempDir, createMockTheme(), {
+			dbPath: process.env.HITL_DB_PATH,
+		})
+		expect(output).toMatch(/Agent time:\s+\d+s/)
+	})
+
+	it("shows HITL time from user interactions", async () => {
+		const mockPi = createMockPi()
+		hitlMetricsExtension(mockPi)
+		await mockPi._trigger("session_start", {}, mockCtx)
+		await fireHitl(mockPi, 1, 2, ["a", "b"], 3000)
+		await mockPi._trigger("session_shutdown", {})
+
+		const output = await getMetricsOutput(tempDir, createMockTheme(), {
+			dbPath: process.env.HITL_DB_PATH,
+		})
+		// Should show HITL time (may be expressed in minutes or seconds)
+		expect(output).toContain("HITL")
+		expect(output).toMatch(/Interactions:\s+1/)
+	})
+
+	it("shows session outcome breakdown", async () => {
+		const mockPi = createMockPi()
+		hitlMetricsExtension(mockPi)
+		await mockPi._trigger("session_start", {}, mockCtx)
+		await mockPi._trigger("session_shutdown", { cause: "signal" })
+
+		const output = await getMetricsOutput(tempDir, createMockTheme(), {
+			dbPath: process.env.HITL_DB_PATH,
+		})
+		expect(output).toMatch(/Interrupted:\s+1/)
+		expect(output).toMatch(/Complete:\s+0/)
+	})
+
+	it("shows 'Complete' when end_cause=complete", async () => {
+		// Note: end_cause=complete is set by the agent when a session ends naturally,
+		// not by our extension directly. We verify the display handles it.
+		// Insert a complete session directly
+		const db = new HitlDatabase(process.env.HITL_DB_PATH!)
+		db.open()
+		db.initSchema()
+		db.run(
+			`INSERT INTO hitl_sessions (id, project_hash, started_at, ended_at, status, end_cause,
+			        agent_time_ms, hitl_time_ms, idle_time_ms)
+			 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+			["complete-session", projectHash(tempDir), Date.now() - 60000, Date.now(), "closed", "complete", 300000, 60000, 30000],
+		)
+		db.close()
+
+		const output = await getMetricsOutput(tempDir, createMockTheme(), {
+			dbPath: process.env.HITL_DB_PATH,
+		})
+		expect(output).toMatch(/Complete:\s+1/)
+	})
+
+	it("renders timeline with agent, HITL, and idle segments", async () => {
+		const mockPi = createMockPi()
+		hitlMetricsExtension(mockPi)
+		await mockPi._trigger("session_start", {}, mockCtx)
+		await fireTool(mockPi, "bash", "call-t1", 5000)
+		await fireHitl(mockPi, 1, 2, ["A"], 3000)
+		await mockPi._trigger("input", { source: "user" }) // end idle
+		await mockPi._trigger("session_shutdown", {})
+
+		const output = await getMetricsOutput(tempDir, createMockTheme(), {
+			dbPath: process.env.HITL_DB_PATH,
+		})
+		expect(output).toContain("Session Timeline")
+		// Timeline block chars ([█▓░]) are rendered but may not match in all environments
+		expect(output).toContain("agent")
+		expect(output).toContain("HITL")
+		expect(output).toContain("idle")
+	})
+
+	it("warns and shows error when cwd is missing", async () => {
+		const mockPi = createMockPi()
+		hitlMetricsExtension(mockPi)
+
+		const noCwdCtx = { cwd: "", hasUI: true, ui: mockCtx.ui } as ExtensionContext
+		const handler = mockPi._commands.get("metrics")?.handler
+		await handler!("", noCwdCtx)
+
+		const notifyCall = (noCwdCtx.ui.notify as unknown as ReturnType<typeof vi.fn>)
+		expect(notifyCall).toHaveBeenCalledWith(expect.stringContaining("No project directory"), "error")
+	})
+
+	it("command handler returns formatted metrics via ui.notify", async () => {
+		const mockPi = createMockPi()
+		hitlMetricsExtension(mockPi)
+		await mockPi._trigger("session_start", {}, mockCtx)
+		await mockPi._trigger("session_shutdown", {})
+
+		// getMetricsOutput returns full formatted output (what the handler passes to ui.notify)
+		const output = await getMetricsOutput(tempDir, createMockTheme(), {
+			dbPath: process.env.HITL_DB_PATH,
+		})
+		expect(output).toContain("HITL Metrics")
+		expect(output).toMatch(/Total sessions:\s+1/)
+		expect(output).toContain("Recent Sessions")
+	})
+})
+
+// ============================================================================
+// Full Lifecycle Integration Tests
+// ============================================================================
+
+describe("HITL Extension — full lifecycle integration", () => {
+	let consoleWarnSpy: ReturnType<typeof vi.spyOn>
+	let tempDir: string
+	let mockCtx: ExtensionContext
+
+	beforeEach(() => {
+		consoleWarnSpy = vi.spyOn(console, "warn").mockImplementation(() => {})
+		tempDir = createTempDir()
+		redirectDbTo(tempDir)
+		mockCtx = createMockCtx(tempDir)
+	})
+
+	afterEach(() => {
+		consoleWarnSpy.mockRestore()
+		restoreDbPath()
+		rmSync(tempDir, { recursive: true, force: true })
+	})
+
+	it("realistic session: multiple tools, HITL interactions, correct metrics", async () => {
+		const mockPi = createMockPi()
+		hitlMetricsExtension(mockPi)
+		await mockPi._trigger("session_start", {}, mockCtx)
+
+		// Agent work (shorter durations to stay within 5s test timeout)
+		await fireTool(mockPi, "bash", "call-1", 1500)
+		await fireTool(mockPi, "read_file", "call-2", 1000)
+		// HITL interaction (3 questions, 1s)
+		await fireHitl(mockPi, 1, 3, ["A", "B", "C"], 1000)
+		// More agent work
+		await fireTool(mockPi, "write_file", "call-3", 800)
+
+		await mockPi._trigger("session_shutdown", { cause: "signal" })
+
+		// Verify DB state
+		const db = new HitlDatabase(process.env.HITL_DB_PATH!)
+		db.open()
+		const sessions = readSessions(db)
+		const events = readEvents(db)
+
+		expect(sessions).toHaveLength(1)
+		expect(sessions[0].status).toBe("closed")
+		expect(sessions[0].end_cause).toBe("signal")
+		expect(sessions[0].agent_time_ms).toBeGreaterThan(0)
+		expect(sessions[0].hitl_time_ms).toBeGreaterThan(0)
+
+		expect(events).toHaveLength(1)
+		expect(events[0].tool_name).toBe("ask_user_questions")
+		expect(events[0].question_count).toBe(3)
+		expect(JSON.parse(events[0].selected_options)).toEqual(["A", "B", "C"])
+		db.close()
+
+		// Verify /metrics output
+		const output = await getMetricsOutput(tempDir, createMockTheme(), {
+			dbPath: process.env.HITL_DB_PATH,
+		})
+		expect(output).toMatch(/Interactions:\s+1/)
+		expect(output).toMatch(/Total sessions:\s+1/)
+		expect(output).toMatch(/Interrupted:\s+1/)
+		expect(output).toContain("Session Timeline")
+	})
+
+	it("multi-session: correct counts across three sessions", async () => {
+		// Session 1: 2 HITL events
+		{
+			const mockPi = createMockPi()
+			hitlMetricsExtension(mockPi)
+			await mockPi._trigger("session_start", {}, mockCtx)
+			await fireHitl(mockPi, 1, 2, ["A", "B"], 500)
+			await fireHitl(mockPi, 2, 1, ["C"], 500)
+			await mockPi._trigger("session_shutdown", { cause: "signal" })
+		}
+
+		// Session 2: 1 HITL event, disconnect
+		{
+			const mockPi = createMockPi()
+			hitlMetricsExtension(mockPi)
+			await mockPi._trigger("session_start", {}, mockCtx)
+			await fireHitl(mockPi, 1, 3, ["X"], 500)
+			await mockPi._trigger("session_shutdown", { cause: "disconnect" })
+		}
+
+		// Session 3: no HITL
+		{
+			const mockPi = createMockPi()
+			hitlMetricsExtension(mockPi)
+			await mockPi._trigger("session_start", {}, mockCtx)
+			await fireTool(mockPi, "bash", "call-b", 500)
+			await mockPi._trigger("session_shutdown", { cause: "signal" })
+		}
+
+		const output = await getMetricsOutput(tempDir, createMockTheme(), {
+			dbPath: process.env.HITL_DB_PATH,
+		})
+		expect(output).toMatch(/Total sessions:\s+3/)
+		expect(output).toMatch(/Interactions:\s+3/) // 2 + 1 + 0
+		expect(output).toMatch(/Complete:\s+1/) // 1 disconnect (S2) → complete; S1 is also disconnect → complete; S3 is signal
+		expect(output).toMatch(/Interrupted:\s+2/) // S1 is orphaned (5min timeout), S3 is signal
+	})
+
+	it("cache detection: fast HITL result is not recorded", async () => {
+		const mockPi = createMockPi()
+		hitlMetricsExtension(mockPi)
+		await mockPi._trigger("session_start", {}, mockCtx)
+		await mockPi._trigger("tool_execution_start", { toolName: "ask_user_questions", toolCallId: "call-cache" })
+		// Immediate result — no delay (cached)
+		await mockPi._trigger("tool_result", {
+			toolName: "ask_user_questions",
+			toolCallId: "call-cache",
+			isError: false,
+			input: { questions: [{ id: 1 }] },
+			result: { selectedOptions: ["cached"] },
+		})
+		await mockPi._trigger("session_shutdown", {})
+
+		const db = new HitlDatabase(process.env.HITL_DB_PATH!)
+		db.open()
+		expect(readEvents(db)).toHaveLength(0) // cached result skipped
+		expect(readSessions(db)[0].hitl_time_ms).toBe(0) // no HITL time accumulated
+		db.close()
+	})
+
+	it("idle time tracking: user input starts idle, next tool ends it", async () => {
+		const mockPi = createMockPi()
+		hitlMetricsExtension(mockPi)
+		await mockPi._trigger("session_start", {}, mockCtx)
+		// User provides input → starts idle period
+		await mockPi._trigger("input", { source: "user" })
+		await delay(200) // idle gap
+		// Tool starts → ends idle, records duration
+		await mockPi._trigger("tool_execution_start", { toolName: "bash", toolCallId: "call-end-idle" })
+		await mockPi._trigger("tool_result", {
+			toolName: "bash",
+			toolCallId: "call-end-idle",
+			isError: false,
+		})
+		await mockPi._trigger("session_shutdown", {})
+
+		const db = new HitlDatabase(process.env.HITL_DB_PATH!)
+		db.open()
+		const sessions = readSessions(db)
+		expect(sessions[0].idle_time_ms).toBeGreaterThanOrEqual(150)
+		db.close()
+	})
+
+	it("session timeline: most recent closed session is rendered", async () => {
+		const mockPi = createMockPi()
+		hitlMetricsExtension(mockPi)
+
+		// Create two closed sessions with shorter tool durations
+		for (let i = 0; i < 2; i++) {
+			await mockPi._trigger("session_start", {}, mockCtx)
+			await fireTool(mockPi, "bash", `call-${i}`, 500) // 500ms each
+			await mockPi._trigger("session_shutdown", { cause: "signal" })
+		}
+
+		const output = await getMetricsOutput(tempDir, createMockTheme(), {
+			dbPath: process.env.HITL_DB_PATH,
+		})
+		// Timeline should render (both sessions closed, latest one shown)
+		expect(output).toContain("Session Timeline")
+	})
+})

--- a/extensions/hitl-metrics/hooks.test.ts
+++ b/extensions/hitl-metrics/hooks.test.ts
@@ -37,12 +37,12 @@ function createMockPi(): ExtensionAPI & {
 	return {
 		_handlers: handlers,
 		_commands: commands,
-		on: (event, handler) => {
+		on: (event: string, handler: (event: unknown, ctx?: ExtensionContext) => Promise<void>) => {
 			if (!handlers.has(event)) handlers.set(event, [])
-			handlers.get(event)!.push(handler as never)
+			handlers.get(event)!.push(handler)
 		},
-		registerCommand: (name, config) => commands.set(name, config),
-		_trigger: async (event, data, ctx) => {
+		registerCommand: (name: string, config: { description: string; handler: (args: string, ctx: ExtensionContext) => Promise<void> }) => commands.set(name, config),
+		_trigger: async (event: string, data?: unknown, ctx?: ExtensionContext) => {
 			const h = handlers.get(event) || []
 			for (const fn of h) await fn(data, ctx)
 		},

--- a/extensions/hitl-metrics/index.test.ts
+++ b/extensions/hitl-metrics/index.test.ts
@@ -3,7 +3,7 @@
  */
 
 import { describe, it, expect, beforeEach, afterEach, vi } from "vitest"
-import hitlMetricsExtension from "./index.ts"
+import hitlMetricsExtension from "./index.js"
 import type { ExtensionAPI, ExtensionContext } from "@mariozechner/pi-coding-agent"
 
 function createMockPi(): ExtensionAPI & {
@@ -102,7 +102,7 @@ describe("HITL Metrics Extension", () => {
 			await mockPi.trigger("session_start", {}, { cwd: "/tmp/test" } as ExtensionContext)
 			await mockPi.trigger("tool_execution_start", { toolName: "read_file", toolCallId: "call-1" })
 			await new Promise(r => setTimeout(r, 100))
-			await mockPi.trigger("tool_result", { toolName: "read_file", toolCallId: "call-1", isError: false, input: { path: "test.ts" }, result: { content: "" } }, {} as ExtensionContext)
+			await mockPi.trigger("tool_result", { toolName: "read_file", toolCallId: "call-1", isError: false, input: { path: "test.js" }, result: { content: "" } }, {} as ExtensionContext)
 			expect(consoleWarnSpy).not.toHaveBeenCalledWith(expect.stringContaining("read_file"))
 		})
 

--- a/extensions/hitl-metrics/index.test.ts
+++ b/extensions/hitl-metrics/index.test.ts
@@ -1,0 +1,135 @@
+/**
+ * HITL Metrics Extension Integration Tests
+ */
+
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest"
+import hitlMetricsExtension from "./index.ts"
+import type { ExtensionAPI, ExtensionContext } from "@mariozechner/pi-coding-agent"
+
+function createMockPi(): ExtensionAPI & {
+	handlers: Map<string, ((event: unknown, ctx?: ExtensionContext) => Promise<void>)[]>
+	commands: Map<string, { description: string; handler: (args: string, ctx: ExtensionContext) => Promise<void> }>
+	trigger: (eventName: string, event: unknown, ctx?: ExtensionContext) => Promise<void>
+} {
+	const handlers = new Map<string, ((event: unknown, ctx?: ExtensionContext) => Promise<void>)[]>()
+	const commands = new Map<string, { description: string; handler: (args: string, ctx: ExtensionContext) => Promise<void> }>()
+	return {
+		handlers,
+		commands,
+		on: (eventName: string, handler: (event: unknown, ctx?: ExtensionContext) => Promise<void>) => {
+			if (!handlers.has(eventName)) handlers.set(eventName, [])
+			handlers.get(eventName)!.push(handler)
+		},
+		registerCommand: (name: string, config: { description: string; handler: (args: string, ctx: ExtensionContext) => Promise<void> }) => {
+			commands.set(name, config)
+		},
+		trigger: async (eventName: string, event: unknown, ctx?: ExtensionContext) => {
+			const eventHandlers = handlers.get(eventName) || []
+			for (const handler of eventHandlers) await handler(event, ctx)
+		},
+	} as ExtensionAPI & {
+		handlers: Map<string, ((event: unknown, ctx?: ExtensionContext) => Promise<void>)[]>
+		commands: Map<string, { description: string; handler: (args: string, ctx: ExtensionContext) => Promise<void> }>
+		trigger: (eventName: string, event: unknown, ctx?: ExtensionContext) => Promise<void>
+	}
+}
+
+describe("HITL Metrics Extension", () => {
+	let mockPi: ReturnType<typeof createMockPi>
+	let consoleWarnSpy: ReturnType<typeof vi.spyOn>
+
+	beforeEach(() => {
+		mockPi = createMockPi()
+		consoleWarnSpy = vi.spyOn(console, "warn").mockImplementation(() => {})
+	})
+
+	afterEach(() => {
+		consoleWarnSpy.mockRestore()
+	})
+
+	describe("hook registration", () => {
+		it("registers all four lifecycle hooks", () => {
+			hitlMetricsExtension(mockPi)
+			expect(mockPi.handlers.has("session_start")).toBe(true)
+			expect(mockPi.handlers.has("tool_execution_start")).toBe(true)
+			expect(mockPi.handlers.has("tool_result")).toBe(true)
+			expect(mockPi.handlers.has("session_shutdown")).toBe(true)
+		})
+
+		it("registers exactly one handler per hook", () => {
+			hitlMetricsExtension(mockPi)
+			expect(mockPi.handlers.get("session_start")?.length).toBe(1)
+			expect(mockPi.handlers.get("tool_execution_start")?.length).toBe(1)
+			expect(mockPi.handlers.get("tool_result")?.length).toBe(1)
+			expect(mockPi.handlers.get("session_shutdown")?.length).toBe(1)
+		})
+	})
+
+	describe("session lifecycle flow", () => {
+		it("completes start -> execution_start -> result flow", async () => {
+			hitlMetricsExtension(mockPi)
+			await mockPi.trigger("session_start", {}, { cwd: "/tmp/test" } as ExtensionContext)
+			await mockPi.trigger("tool_execution_start", { toolName: "ask_user_questions", toolCallId: "call-1" })
+			await new Promise(r => setTimeout(r, 100))
+			await mockPi.trigger("tool_result", { toolName: "ask_user_questions", toolCallId: "call-1", isError: false, input: { questions: [{ id: 1 }] }, result: { selectedOptions: ["A"] } }, {} as ExtensionContext)
+			const warnings = consoleWarnSpy.mock.calls.filter(c => typeof c[0] === "string" && (c[0].includes("Failed") || c[0].includes("error")))
+			expect(warnings.length).toBe(0)
+		})
+
+		it("session_shutdown closes session", async () => {
+			hitlMetricsExtension(mockPi)
+			await mockPi.trigger("session_start", {}, { cwd: "/tmp/test" } as ExtensionContext)
+			await mockPi.trigger("session_shutdown", { cause: "signal" }, {} as ExtensionContext)
+			expect(consoleWarnSpy).not.toHaveBeenCalledWith(expect.stringContaining("Error in session_shutdown"))
+		})
+
+		it("accumulates multiple events in one session", async () => {
+			hitlMetricsExtension(mockPi)
+			await mockPi.trigger("session_start", {}, { cwd: "/tmp/test" } as ExtensionContext)
+			for (let i = 0; i < 2; i++) {
+				await mockPi.trigger("tool_execution_start", { toolName: "ask_user_questions", toolCallId: `call-${i}` })
+				await new Promise(r => setTimeout(r, 60))
+				await mockPi.trigger("tool_result", { toolName: "ask_user_questions", toolCallId: `call-${i}`, isError: false, input: { questions: [{ id: i }] }, result: { selectedOptions: ["A"] } }, {} as ExtensionContext)
+			}
+			const warnings = consoleWarnSpy.mock.calls.filter(c => typeof c[0] === "string" && c[0].includes("Failed to record"))
+			expect(warnings.length).toBe(0)
+		})
+	})
+
+	describe("filtering and edge cases", () => {
+		it("ignores non-ask_user_questions events", async () => {
+			hitlMetricsExtension(mockPi)
+			await mockPi.trigger("session_start", {}, { cwd: "/tmp/test" } as ExtensionContext)
+			await mockPi.trigger("tool_execution_start", { toolName: "read_file", toolCallId: "call-1" })
+			await new Promise(r => setTimeout(r, 100))
+			await mockPi.trigger("tool_result", { toolName: "read_file", toolCallId: "call-1", isError: false, input: { path: "test.ts" }, result: { content: "" } }, {} as ExtensionContext)
+			expect(consoleWarnSpy).not.toHaveBeenCalledWith(expect.stringContaining("read_file"))
+		})
+
+		it("skips error results", async () => {
+			hitlMetricsExtension(mockPi)
+			await mockPi.trigger("session_start", {}, { cwd: "/tmp/test" } as ExtensionContext)
+			await mockPi.trigger("tool_execution_start", { toolName: "ask_user_questions", toolCallId: "call-1" })
+			await new Promise(r => setTimeout(r, 100))
+			await mockPi.trigger("tool_result", { toolName: "ask_user_questions", toolCallId: "call-1", isError: true, input: {}, result: {} }, {} as ExtensionContext)
+			expect(consoleWarnSpy).not.toHaveBeenCalledWith(expect.stringContaining("error"))
+		})
+
+		it("skips cached results (fast <50ms)", async () => {
+			hitlMetricsExtension(mockPi)
+			await mockPi.trigger("session_start", {}, { cwd: "/tmp/test" } as ExtensionContext)
+			await mockPi.trigger("tool_execution_start", { toolName: "ask_user_questions", toolCallId: "call-1" })
+			// Immediate response (<50ms) should be skipped
+			await mockPi.trigger("tool_result", { toolName: "ask_user_questions", toolCallId: "call-1", isError: false, input: { questions: [{}] }, result: { selectedOptions: ["A"] } }, {} as ExtensionContext)
+			expect(consoleWarnSpy).not.toHaveBeenCalledWith(expect.stringContaining("error"))
+		})
+
+		it("handles missing start time gracefully", async () => {
+			hitlMetricsExtension(mockPi)
+			await mockPi.trigger("session_start", {}, { cwd: "/tmp/test" } as ExtensionContext)
+			// No tool_execution_start - simulates cached result
+			await mockPi.trigger("tool_result", { toolName: "ask_user_questions", toolCallId: "call-1", isError: false, input: {}, result: { selectedOptions: ["A"] } }, {} as ExtensionContext)
+			expect(consoleWarnSpy).not.toHaveBeenCalledWith(expect.stringContaining("error"))
+		})
+	})
+})

--- a/extensions/hitl-metrics/index.ts
+++ b/extensions/hitl-metrics/index.ts
@@ -11,8 +11,8 @@
  * - session_shutdown: Clean up and close session
  */
 
-import { SessionManager } from "./session-manager.ts"
-import { handleMetricsCommand } from "./commands/metrics.ts"
+import { SessionManager } from "./session-manager.js"
+import { handleMetricsCommand } from "./commands/metrics.js"
 import type { ExtensionAPI, ExtensionContext } from "@mariozechner/pi-coding-agent"
 
 /**

--- a/extensions/hitl-metrics/index.ts
+++ b/extensions/hitl-metrics/index.ts
@@ -49,9 +49,14 @@ export default function hitlMetricsExtension(pi: ExtensionAPI): void {
 				console.warn("[HITL] No cwd provided in session_start, skipping initialization")
 				return
 			}
-			// HITL_DB_PATH overrides the DB path entirely (useful for testing).
-			// When set, the dirname is created if missing and the file is "hitl.db" inside it.
+			// Use the actual kimchi session ID so DB rows match session files.
+			// ctx.sessionId is undefined at session_start, so we read from sessionManager.
+			// ctx.sessionManager.sessionId is available immediately after session creation.
+			const sessionId: string | undefined = (ctx as unknown as { sessionId?: string }).sessionId ?? (ctx as unknown as { sessionManager?: { sessionId: string } }).sessionManager?.sessionId
 			const initOptions = process.env.HITL_DB_PATH ? { dbPath: process.env.HITL_DB_PATH } : {}
+			if (sessionId) {
+				Object.assign(initOptions, { sessionId })
+			}
 			manager.init(cwd, initOptions)
 		} catch (error) {
 			const message = error instanceof Error ? error.message : String(error)

--- a/extensions/hitl-metrics/index.ts
+++ b/extensions/hitl-metrics/index.ts
@@ -1,0 +1,157 @@
+/**
+ * HITL Metrics Extension
+ *
+ * Extension entrypoint that registers tools to capture Human-in-the-Loop
+ * interaction events from ask_user_questions tool calls.
+ *
+ * Hooks:
+ * - session_start: Initialize database and session
+ * - tool_execution_start: Track start times for duration calculation
+ * - tool_result: Filter ask_user_questions calls and write events
+ * - session_shutdown: Clean up and close session
+ */
+
+import { SessionManager } from "./session-manager.ts"
+import { handleMetricsCommand } from "./commands/metrics.ts"
+import type { ExtensionAPI, ExtensionContext } from "@mariozechner/pi-coding-agent"
+
+/**
+ * Cache detection threshold in milliseconds.
+ * Results faster than this are likely served from cache.
+ */
+const CACHE_THRESHOLD_MS = 50
+
+/**
+ * Default function exported for pi extension loading.
+ *
+ * @param pi - ExtensionAPI from pi-coding-agent
+ */
+export default function hitlMetricsExtension(pi: ExtensionAPI): void {
+	const manager = new SessionManager()
+
+	// Register /metrics slash command
+	pi.registerCommand("metrics", {
+		description: "Show HITL interaction metrics",
+		handler: async (args, ctx) => {
+			handleMetricsCommand(args, ctx)
+		},
+	})
+
+	// -------------------------------------------------------------------------
+	// Session Start: Initialize DB, schema, and session
+	// -------------------------------------------------------------------------
+	pi.on("session_start", async (_event, ctx: ExtensionContext) => {
+		try {
+			const cwd = ctx.cwd
+			if (!cwd) {
+				console.warn("[HITL] No cwd provided in session_start, skipping initialization")
+				return
+			}
+			manager.init(cwd)
+		} catch (error) {
+			const message = error instanceof Error ? error.message : String(error)
+			console.warn(`[HITL] Error in session_start handler: ${message}`)
+		}
+	})
+
+	// -------------------------------------------------------------------------
+	// Tool Execution Start: Track start times for duration calculation
+	// -------------------------------------------------------------------------
+	pi.on("tool_execution_start", async (event) => {
+		try {
+			// Only track ask_user_questions executions
+			if (event.toolName !== "ask_user_questions") return
+
+			// Store start time keyed by toolCallId
+			if (event.toolCallId) {
+				manager.recordStartTime(event.toolCallId)
+			}
+		} catch (error) {
+			const message = error instanceof Error ? error.message : String(error)
+			console.warn(`[HITL] Error in tool_execution_start handler: ${message}`)
+		}
+	})
+
+	// -------------------------------------------------------------------------
+	// Tool Result: Filter ask_user_questions and write events to DB
+	// -------------------------------------------------------------------------
+	pi.on("tool_result", async (event) => {
+		try {
+			// Skip non-ask_user_questions tools
+			if (event.toolName !== "ask_user_questions") return
+
+			// Skip error results
+			if (event.isError) return
+
+			// Get toolCallId for duration lookup
+			const toolCallId = (event as { toolCallId?: string }).toolCallId
+			if (!toolCallId) {
+				console.warn("[HITL] ask_user_questions result missing toolCallId")
+				return
+			}
+
+			// Consume start time and compute duration
+			const startTime = manager.consumeStartTime(toolCallId)
+			let durationMs: number
+
+			if (startTime !== undefined) {
+				durationMs = Date.now() - startTime
+			} else {
+				// No matching start time — indicates cached result or restart
+				// Silently skip (don't record cached events)
+				return
+			}
+
+			// Skip cached results (duration below threshold indicates cache hit)
+			if (durationMs < CACHE_THRESHOLD_MS) {
+				return
+			}
+
+			// Extract question count from input (if available)
+			let questionCount = 0
+			const input = (event as { input?: { questions?: unknown[] } }).input
+			if (input?.questions && Array.isArray(input.questions)) {
+				questionCount = input.questions.length
+			}
+
+			// Extract selected options from result
+			const selectedOptions: string[] = []
+			const result = (event as { result?: { selectedOptions?: string[] } }).result
+			if (result?.selectedOptions && Array.isArray(result.selectedOptions)) {
+				for (const option of result.selectedOptions) {
+					if (typeof option === "string") {
+						selectedOptions.push(option)
+					}
+				}
+			}
+
+			// Record the event
+			const recorded = manager.recordEvent(
+				"ask_user_questions",
+				questionCount,
+				durationMs,
+				selectedOptions,
+			)
+
+			if (!recorded) {
+				console.warn("[HITL] Failed to record event (database error)")
+			}
+		} catch (error) {
+			const message = error instanceof Error ? error.message : String(error)
+			console.warn(`[HITL] Error in tool_result handler: ${message}`)
+		}
+	})
+
+	// -------------------------------------------------------------------------
+	// Session Shutdown: Clean up and close session
+	// -------------------------------------------------------------------------
+	pi.on("session_shutdown", async (event) => {
+		try {
+			const cause = (event as { cause?: "signal" | "disconnect" }).cause ?? "signal"
+			manager.close()
+		} catch (error) {
+			const message = error instanceof Error ? error.message : String(error)
+			console.warn(`[HITL] Error in session_shutdown handler: ${message}`)
+		}
+	})
+}

--- a/extensions/hitl-metrics/index.ts
+++ b/extensions/hitl-metrics/index.ts
@@ -2,23 +2,25 @@
  * HITL Metrics Extension
  *
  * Extension entrypoint that registers tools to capture Human-in-the-Loop
- * interaction events from ask_user_questions tool calls.
+ * interaction events and tracks three categories of time:
+ * - Agent time: tool execution (excluding HITL)
+ * - HITL time: HITL tool duration (${HITL_TOOL_NAME})
+ * - Idle time: gaps between activities
  *
  * Hooks:
  * - session_start: Initialize database and session
- * - tool_execution_start: Track start times for duration calculation
- * - tool_result: Filter ask_user_questions calls and write events
- * - session_shutdown: Clean up and close session
+ * - input: Track user input, mark end of idle
+ * - tool_execution_start: Track all tool starts
+ * - tool_result: Filter all tools, categorize time, write events
+ * - session_shutdown: Clean up and close session with end cause
  */
 
-import { SessionManager } from "./session-manager.js"
+import { SessionManager, HITL_TOOL_NAME } from "./session-manager.js"
+import type { EndCause } from "./storage/index.js"
 import { handleMetricsCommand } from "./commands/metrics.js"
 import type { ExtensionAPI, ExtensionContext } from "@mariozechner/pi-coding-agent"
 
-/**
- * Cache detection threshold in milliseconds.
- * Results faster than this are likely served from cache.
- */
+/** Cache detection threshold in milliseconds */
 const CACHE_THRESHOLD_MS = 50
 
 /**
@@ -47,7 +49,10 @@ export default function hitlMetricsExtension(pi: ExtensionAPI): void {
 				console.warn("[HITL] No cwd provided in session_start, skipping initialization")
 				return
 			}
-			manager.init(cwd)
+			// HITL_DB_PATH overrides the DB path entirely (useful for testing).
+			// When set, the dirname is created if missing and the file is "hitl.db" inside it.
+			const initOptions = process.env.HITL_DB_PATH ? { dbPath: process.env.HITL_DB_PATH } : {}
+			manager.init(cwd, initOptions)
 		} catch (error) {
 			const message = error instanceof Error ? error.message : String(error)
 			console.warn(`[HITL] Error in session_start handler: ${message}`)
@@ -55,17 +60,26 @@ export default function hitlMetricsExtension(pi: ExtensionAPI): void {
 	})
 
 	// -------------------------------------------------------------------------
-	// Tool Execution Start: Track start times for duration calculation
+	// Input: Track user input (marks end of idle time)
+	// -------------------------------------------------------------------------
+	pi.on("input", async (event) => {
+		try {
+			// Skip extension-generated messages
+			if (event.source === "extension") return
+			manager.recordUserInput()
+		} catch (error) {
+			const message = error instanceof Error ? error.message : String(error)
+			console.warn(`[HITL] Error in input handler: ${message}`)
+		}
+	})
+
+	// -------------------------------------------------------------------------
+	// Tool Execution Start: Track start times for all tools
 	// -------------------------------------------------------------------------
 	pi.on("tool_execution_start", async (event) => {
 		try {
-			// Only track ask_user_questions executions
-			if (event.toolName !== "ask_user_questions") return
-
-			// Store start time keyed by toolCallId
-			if (event.toolCallId) {
-				manager.recordStartTime(event.toolCallId)
-			}
+			if (!event.toolCallId) return
+			manager.recordToolStart(event.toolCallId, event.toolName)
 		} catch (error) {
 			const message = error instanceof Error ? error.message : String(error)
 			console.warn(`[HITL] Error in tool_execution_start handler: ${message}`)
@@ -73,68 +87,36 @@ export default function hitlMetricsExtension(pi: ExtensionAPI): void {
 	})
 
 	// -------------------------------------------------------------------------
-	// Tool Result: Filter ask_user_questions and write events to DB
+	// Tool Result: Categorize and record all tool results
 	// -------------------------------------------------------------------------
 	pi.on("tool_result", async (event) => {
 		try {
-			// Skip non-ask_user_questions tools
-			if (event.toolName !== "ask_user_questions") return
-
-			// Skip error results
-			if (event.isError) return
-
-			// Get toolCallId for duration lookup
 			const toolCallId = (event as { toolCallId?: string }).toolCallId
-			if (!toolCallId) {
-				console.warn("[HITL] ask_user_questions result missing toolCallId")
-				return
-			}
+			if (!toolCallId) return
 
-			// Consume start time and compute duration
+			// Compute duration
 			const startTime = manager.consumeStartTime(toolCallId)
-			let durationMs: number
+			if (!startTime) return // Cached or orphaned result
 
-			if (startTime !== undefined) {
-				durationMs = Date.now() - startTime
+			const durationMs = Date.now() - startTime
+			if (durationMs < CACHE_THRESHOLD_MS) return // Likely cached
+
+			// Handle HITL tools specially
+			if (event.toolName === HITL_TOOL_NAME && !event.isError) {
+				// Extract question count from input
+				const input = (event as { input?: { questions?: unknown[] } }).input
+				const questionCount = input?.questions && Array.isArray(input.questions) 
+					? input.questions.length 
+					: 0
+
+				// Extract selected options from result
+				const result = (event as { result?: { selectedOptions?: string[] } }).result
+				const selectedOptions: string[] = result?.selectedOptions?.filter((o): o is string => typeof o === "string") || []
+
+				manager.recordEvent(event.toolName, questionCount, durationMs, selectedOptions)
 			} else {
-				// No matching start time — indicates cached result or restart
-				// Silently skip (don't record cached events)
-				return
-			}
-
-			// Skip cached results (duration below threshold indicates cache hit)
-			if (durationMs < CACHE_THRESHOLD_MS) {
-				return
-			}
-
-			// Extract question count from input (if available)
-			let questionCount = 0
-			const input = (event as { input?: { questions?: unknown[] } }).input
-			if (input?.questions && Array.isArray(input.questions)) {
-				questionCount = input.questions.length
-			}
-
-			// Extract selected options from result
-			const selectedOptions: string[] = []
-			const result = (event as { result?: { selectedOptions?: string[] } }).result
-			if (result?.selectedOptions && Array.isArray(result.selectedOptions)) {
-				for (const option of result.selectedOptions) {
-					if (typeof option === "string") {
-						selectedOptions.push(option)
-					}
-				}
-			}
-
-			// Record the event
-			const recorded = manager.recordEvent(
-				"ask_user_questions",
-				questionCount,
-				durationMs,
-				selectedOptions,
-			)
-
-			if (!recorded) {
-				console.warn("[HITL] Failed to record event (database error)")
+				// Record as regular tool execution (contributing to agent time)
+				manager.recordToolEnd(toolCallId, event.toolName, durationMs)
 			}
 		} catch (error) {
 			const message = error instanceof Error ? error.message : String(error)
@@ -143,12 +125,14 @@ export default function hitlMetricsExtension(pi: ExtensionAPI): void {
 	})
 
 	// -------------------------------------------------------------------------
-	// Session Shutdown: Clean up and close session
+	// Session Shutdown: Clean up and close session with end cause
 	// -------------------------------------------------------------------------
 	pi.on("session_shutdown", async (event) => {
 		try {
-			const cause = (event as { cause?: "signal" | "disconnect" }).cause ?? "signal"
-			manager.close()
+			const rawCause = (event as { cause?: string }).cause
+			// "disconnect" = normal exit (connection closed), "signal" = killed
+			const endCause: EndCause = rawCause === "disconnect" ? "complete" : (rawCause as EndCause) ?? "signal"
+			manager.close(endCause)
 		} catch (error) {
 			const message = error instanceof Error ? error.message : String(error)
 			console.warn(`[HITL] Error in session_shutdown handler: ${message}`)

--- a/extensions/hitl-metrics/index.ts
+++ b/extensions/hitl-metrics/index.ts
@@ -35,6 +35,7 @@ export default function hitlMetricsExtension(pi: ExtensionAPI): void {
 	pi.registerCommand("metrics", {
 		description: "Show HITL interaction metrics",
 		handler: async (args, ctx) => {
+			manager.persist()
 			handleMetricsCommand(args, ctx)
 		},
 	})
@@ -92,6 +93,19 @@ export default function hitlMetricsExtension(pi: ExtensionAPI): void {
 	})
 
 	// -------------------------------------------------------------------------
+	// Tool Execution End: RPC-mode fallback for tool time tracking
+	// -------------------------------------------------------------------------
+	pi.on("tool_execution_end", async (event) => {
+		try {
+			if (!event.toolCallId) return
+			manager.recordToolEndFromEvent(event.toolCallId, event.toolName)
+		} catch (error) {
+			const message = error instanceof Error ? error.message : String(error)
+			console.warn(`[HITL] Error in tool_execution_end handler: ${message}`)
+		}
+	})
+
+	// -------------------------------------------------------------------------
 	// Tool Result: Categorize and record all tool results
 	// -------------------------------------------------------------------------
 	pi.on("tool_result", async (event) => {
@@ -126,6 +140,18 @@ export default function hitlMetricsExtension(pi: ExtensionAPI): void {
 		} catch (error) {
 			const message = error instanceof Error ? error.message : String(error)
 			console.warn(`[HITL] Error in tool_result handler: ${message}`)
+		}
+	})
+
+	// -------------------------------------------------------------------------
+	// Agent End: Flush metrics if session_shutdown never fires (RPC mode)
+	// -------------------------------------------------------------------------
+	pi.on("agent_end", async () => {
+		try {
+			manager.persist()
+		} catch (error) {
+			const message = error instanceof Error ? error.message : String(error)
+			console.warn(`[HITL] Error in agent_end handler: ${message}`)
 		}
 	})
 

--- a/extensions/hitl-metrics/session-manager.test.ts
+++ b/extensions/hitl-metrics/session-manager.test.ts
@@ -3,7 +3,7 @@
  */
 
 import { describe, it, expect, beforeEach, afterEach, vi } from "vitest"
-import { SessionManager } from "./session-manager.ts"
+import { SessionManager } from "./session-manager.js"
 
 describe("SessionManager", () => {
 	describe("with :memory: database via init()", () => {

--- a/extensions/hitl-metrics/session-manager.test.ts
+++ b/extensions/hitl-metrics/session-manager.test.ts
@@ -131,6 +131,20 @@ describe("SessionManager", () => {
 			expect(time1).toBeGreaterThan(0)
 			expect(time2).toBeGreaterThan(0)
 		})
+
+		it("getLiveIdleMs() returns accumulated idle including open period", () => {
+			// Simulate: user input opens idle, then we check live idle before tool_start closes it
+			manager.recordUserInput() // opens idle_start
+			// Don't call recordToolStart — idle is still open
+			const liveIdle = manager.getLiveIdleMs()
+			expect(liveIdle).toBeGreaterThan(0) // open idle is counted
+		})
+
+		it("getLiveIdleMs() returns only accumulated idle when no open period", () => {
+			// No idle started — should be 0
+			const liveIdle = manager.getLiveIdleMs()
+			expect(liveIdle).toBe(0)
+		})
 	})
 
 	describe("session persistence", () => {

--- a/extensions/hitl-metrics/session-manager.test.ts
+++ b/extensions/hitl-metrics/session-manager.test.ts
@@ -1,0 +1,176 @@
+/**
+ * SessionManager Unit Tests
+ */
+
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest"
+import { SessionManager } from "./session-manager.ts"
+
+describe("SessionManager", () => {
+	describe("with :memory: database via init()", () => {
+		let manager: SessionManager
+		let consoleWarnSpy: ReturnType<typeof vi.spyOn>
+
+		beforeEach(() => {
+			manager = new SessionManager()
+			consoleWarnSpy = vi.spyOn(console, "warn").mockImplementation(() => {})
+		})
+
+		afterEach(() => {
+			manager.close()
+			consoleWarnSpy.mockRestore()
+		})
+
+		it("init() opens DB, inits schema, creates session", () => {
+			manager.init("/tmp/test-project")
+
+			const session = manager.getSession()
+			expect(session).not.toBeNull()
+			expect(session?.status).toBe("active")
+			expect(session?.project_hash).toBeTruthy()
+			expect(session?.started_at).toBeGreaterThan(0)
+		})
+
+		it("getSession() returns current active session", () => {
+			manager.init("/tmp/test-project")
+
+			const session = manager.getSession()
+			expect(session).not.toBeNull()
+			expect(session?.status).toBe("active")
+		})
+
+		it("recordEvent() returns false when no active session", () => {
+			// Don't call init() - no session exists
+			const result = manager.recordEvent("ask_user_questions", 1, 1000, ["Option"])
+			expect(result).toBe(false)
+		})
+
+		it("recordEvent() returns false after session is closed", () => {
+			manager.init("/tmp/test-project")
+			manager.close()
+
+			const result = manager.recordEvent("ask_user_questions", 1, 1000, ["Option"])
+			expect(result).toBe(false)
+		})
+
+		it("close() closes the session and database", () => {
+			manager.init("/tmp/test-project")
+			const sessionBefore = manager.getSession()
+			expect(sessionBefore).not.toBeNull()
+
+			manager.close()
+
+			const sessionAfter = manager.getSession()
+			expect(sessionAfter).toBeNull()
+		})
+
+		it("close() is idempotent (safe to call twice)", () => {
+			manager.init("/tmp/test-project")
+			manager.close()
+			manager.close() // Should not throw
+
+			expect(manager.getSession()).toBeNull()
+		})
+
+		it("init() is non-fatal with empty path (doesn't throw)", () => {
+			// Empty path produces a valid hash - test just verifies no exception thrown
+			expect(() => manager.init("")).not.toThrow()
+			// Empty string hashes to a valid project_hash, so a session is created
+			// This is acceptable behavior - the hash function handles empty strings
+		})
+	})
+
+	describe("event recording with duration tracking", () => {
+		let manager: SessionManager
+
+		beforeEach(() => {
+			manager = new SessionManager()
+			manager.init("/tmp/test-project")
+		})
+
+		afterEach(() => {
+			manager.close()
+		})
+
+		it("recordStartTime() stores start time for tool call", () => {
+			const toolCallId = "call-123"
+			manager.recordStartTime(toolCallId)
+
+			const startTime = manager.consumeStartTime(toolCallId)
+			expect(startTime).toBeGreaterThan(0)
+		})
+
+		it("recordStartTime() handles empty toolCallId gracefully", () => {
+			// Should not throw
+			manager.recordStartTime("")
+			expect(manager.consumeStartTime("")).toBeUndefined()
+		})
+
+		it("consumeStartTime() returns and removes start time", () => {
+			const toolCallId = "call-456"
+			manager.recordStartTime(toolCallId)
+
+			const first = manager.consumeStartTime(toolCallId)
+			const second = manager.consumeStartTime(toolCallId)
+
+			expect(first).toBeGreaterThan(0)
+			expect(second).toBeUndefined()
+		})
+
+		it("consumeStartTime() returns undefined for unknown toolCallId", () => {
+			const startTime = manager.consumeStartTime("non-existent")
+			expect(startTime).toBeUndefined()
+		})
+
+		it("multiple start times can be tracked independently", () => {
+			manager.recordStartTime("call-1")
+			manager.recordStartTime("call-2")
+
+			const time1 = manager.consumeStartTime("call-1")
+			const time2 = manager.consumeStartTime("call-2")
+
+			expect(time1).toBeGreaterThan(0)
+			expect(time2).toBeGreaterThan(0)
+		})
+	})
+
+	describe("session persistence", () => {
+		let manager: SessionManager
+		let consoleWarnSpy: ReturnType<typeof vi.spyOn>
+
+		beforeEach(() => {
+			consoleWarnSpy = vi.spyOn(console, "warn").mockImplementation(() => {})
+		})
+
+		afterEach(() => {
+			manager?.close()
+			consoleWarnSpy.mockRestore()
+		})
+
+		it("recordEvent() writes event to hitl_events table with correct fields", () => {
+			manager = new SessionManager()
+			manager.init("/tmp/test-project")
+
+			const result = manager.recordEvent("ask_user_questions", 3, 5000, [
+				"Option A",
+				"Option B",
+			])
+
+			expect(result).toBe(true)
+		})
+
+		it("same project path produces same project_hash across instances", () => {
+			const manager1 = new SessionManager()
+			manager1.init("/tmp/same-project")
+			const hash1 = manager1.getSession()?.project_hash
+
+			const manager2 = new SessionManager()
+			manager2.init("/tmp/same-project")
+			const hash2 = manager2.getSession()?.project_hash
+
+			expect(hash1).toBe(hash2)
+
+			manager1.close()
+			manager2.close()
+		})
+	})
+})

--- a/extensions/hitl-metrics/session-manager.ts
+++ b/extensions/hitl-metrics/session-manager.ts
@@ -68,7 +68,7 @@ export class SessionManager {
 		this.isInitialized = false
 	}
 
-	init(cwd: string, options: { dbPath?: string } = {}): void {
+	init(cwd: string, options: { dbPath?: string; sessionId?: string } = {}): void {
 		// Always reset on init — enables clean re-initialization between sessions
 		// and allows test harnesses to redirect the DB path per-session
 		this.reset()
@@ -100,7 +100,7 @@ export class SessionManager {
 			}
 
 			closeOrphanSessions(this.db)
-			this.session = getOrCreateSession(this.db, this.projectHashValue)
+			this.session = getOrCreateSession(this.db, this.projectHashValue, { sessionId: options.sessionId })
 			if (!this.session) {
 				console.warn("[HITL] Failed to create session, events will be silently dropped")
 				return

--- a/extensions/hitl-metrics/session-manager.ts
+++ b/extensions/hitl-metrics/session-manager.ts
@@ -8,8 +8,8 @@
 import * as path from "node:path"
 import * as os from "node:os"
 import * as fs from "node:fs"
-import { HitlDatabase, projectHash, getOrCreateSession, closeSession, closeOrphanSessions } from "./storage/index.ts"
-import type { HitlSession } from "./types.ts"
+import { HitlDatabase, projectHash, getOrCreateSession, closeSession, closeOrphanSessions } from "./storage/index.js"
+import type { HitlSession } from "./types.js"
 
 /**
  * Manages HITL sessions and event recording.

--- a/extensions/hitl-metrics/session-manager.ts
+++ b/extensions/hitl-metrics/session-manager.ts
@@ -127,12 +127,33 @@ export class SessionManager {
 	recordToolStart(toolCallId: string, toolName: string): void {
 		if (!toolCallId) return
 		this.pendingStartTimes.set(toolCallId, Date.now())
-
+		// Ensure session exists before recording (handles RPC mode where session_start may not fire)
+		this.ensureSession()
 		if (this.db && this.session) {
 			recordActivityEvent(this.db, this.session.id, "tool_start", toolName)
 		}
 		if (this.isIdle) this.endIdlePeriod()
 		this.lastActivityTimestamp = Date.now()
+	}
+
+	/**
+	 * Lazily initialize the session if it hasn't been created yet.
+	 * This handles modes (e.g. RPC) where session_start may not fire before tool events.
+	 */
+	private ensureSession(): void {
+		if (this.session !== null || this.db === null) return
+		try {
+			this.session = getOrCreateSession(this.db, this.projectHashValue, {})
+			if (this.session) {
+				this.lastActivityTimestamp = Date.now()
+				this.agentTimeAccumulator = this.session.agent_time_ms
+				this.hitlTimeAccumulator = this.session.hitl_time_ms
+				this.idleTimeAccumulator = this.session.idle_time_ms
+			}
+		} catch (error) {
+			const message = error instanceof Error ? error.message : String(error)
+			console.warn(`[HITL] Lazy session init failed: ${message}`)
+		}
 	}
 
 	/** Record end of any tool execution and accumulate agent time */
@@ -143,6 +164,31 @@ export class SessionManager {
 			recordActivityEvent(this.db, this.session.id, "tool_end", toolName, durationMs)
 		}
 
+		// Accumulate agent time (exclude HITL tools tracked separately)
+		if (toolName !== HITL_TOOL_NAME) {
+			this.agentTimeAccumulator += durationMs
+		}
+		this.lastActivityTimestamp = Date.now()
+		this.maybeStartIdleTimer()
+	}
+
+	/**
+	 * Record tool end from tool_execution_end event.
+	 * In print mode, tool_result fires first and deletes startTime from pendingStartTimes,
+	 * so we skip when already consumed (no double-counting). In RPC mode, tool_result
+	 * may not fire, so we compute duration here using the stored start time.
+	 */
+	recordToolEndFromEvent(toolCallId: string, toolName: string): void {
+		const startTime = this.pendingStartTimes.get(toolCallId)
+		// Only record if not already consumed by tool_result (which deletes on consume)
+		if (startTime === undefined) return
+		this.pendingStartTimes.delete(toolCallId)
+		const durationMs = Date.now() - startTime
+		// Ensure session exists before recording (covers session_start not firing before tool_execution_end)
+		this.ensureSession()
+		if (this.db && this.session) {
+			recordActivityEvent(this.db, this.session.id, "tool_end", toolName, durationMs)
+		}
 		// Accumulate agent time (exclude HITL tools tracked separately)
 		if (toolName !== HITL_TOOL_NAME) {
 			this.agentTimeAccumulator += durationMs
@@ -266,6 +312,19 @@ export class SessionManager {
 		this.db = null
 		this.session = null
 		this.pendingStartTimes.clear()
+	}
+
+	/** Returns total idle time including any currently open idle period (not yet flushed to DB) */
+	getLiveIdleMs(): number {
+		const liveExtra = this.isIdle && this.currentIdleStart > 0 ? Date.now() - this.currentIdleStart : 0
+		return this.idleTimeAccumulator + liveExtra
+	}
+
+	/** Persist accumulated time metrics to database (public for external triggers) */
+	persist(): void {
+		if (!this.db || !this.session) return
+		const liveIdleMs = this.getLiveIdleMs()
+		updateSessionTimes(this.db, this.session.id, this.agentTimeAccumulator, this.hitlTimeAccumulator, liveIdleMs)
 	}
 
 	/** Persist accumulated time metrics to database */

--- a/extensions/hitl-metrics/session-manager.ts
+++ b/extensions/hitl-metrics/session-manager.ts
@@ -8,60 +8,109 @@
 import * as path from "node:path"
 import * as os from "node:os"
 import * as fs from "node:fs"
-import { HitlDatabase, projectHash, getOrCreateSession, closeSession, closeOrphanSessions } from "./storage/index.js"
-import type { HitlSession } from "./types.js"
+import {
+	HitlDatabase,
+	projectHash,
+	getOrCreateSession,
+	closeSession,
+	closeOrphanSessions,
+	recordActivityEvent,
+	recordPermissionEvent,
+	updateSessionTimes,
+	EndCause,
+} from "./storage/index.js"
+import type { HitlSession, HitlPermissionEvent } from "./types.js"
+
+/** HITL tool name — confirmed from pi framework: extensions/ask-user-questions.ts registers "ask_user_questions" */
+export const HITL_TOOL_NAME = "ask_user_questions"
+
+/** Threshold for idle detection; gaps longer than this mark idle periods */
+const IDLE_THRESHOLD_MS = 3000
 
 /**
  * Manages HITL sessions and event recording.
  * Tracks duration via tool execution start times and writes events to database.
+ * Now supports three-category time tracking: agent, HITL, and idle time.
  */
 export class SessionManager {
 	private db: HitlDatabase | null = null
 	private session: HitlSession | null = null
 	private projectHashValue: string = ""
 	private pendingStartTimes: Map<string, number> = new Map()
+	private isInitialized: boolean = false
+
+	// Activity tracking state
+	private lastActivityTimestamp: number = 0
+	private agentTimeAccumulator: number = 0
+	private hitlTimeAccumulator: number = 0
+	private idleTimeAccumulator: number = 0
+	private currentIdleStart: number = 0
+	private isIdle: boolean = false
 
 	/**
-	 * Initialize the session manager for the given project directory.
-	 * Opens database, initializes schema, closes orphans, creates/resumes session.
-	 *
-	 * @param cwd - Project working directory
+	 * Reset all state — used by tests and when cwd changes between sessions.
+	 * Safe to call even when not initialized.
 	 */
-	init(cwd: string): void {
+	reset(): void {
+		if (this.db) {
+			this.db.close()
+			this.db = null
+		}
+		this.session = null
+		this.projectHashValue = ""
+		this.pendingStartTimes.clear()
+		this.lastActivityTimestamp = 0
+		this.agentTimeAccumulator = 0
+		this.hitlTimeAccumulator = 0
+		this.idleTimeAccumulator = 0
+		this.currentIdleStart = 0
+		this.isIdle = false
+		this.isInitialized = false
+	}
+
+	init(cwd: string, options: { dbPath?: string } = {}): void {
+		// Always reset on init — enables clean re-initialization between sessions
+		// and allows test harnesses to redirect the DB path per-session
+		this.reset()
 		try {
-			// Generate project hash from cwd
 			this.projectHashValue = projectHash(cwd)
+			let dbPath: string
+			let dbDir: string
 
-			// Build DB path at ~/.hitl-metrics/<hash>.db
-			const dbDir = path.join(os.homedir(), ".hitl-metrics")
-			const dbPath = path.join(dbDir, `${this.projectHashValue}.db`)
+			if (options.dbPath) {
+				// Test override: write to explicit path
+				dbPath = options.dbPath
+				dbDir = path.dirname(dbPath)
+				if (!fs.existsSync(dbDir)) fs.mkdirSync(dbDir, { recursive: true })
+			} else {
+				// Production: write to ~/.kimchi/metrics/<hash>/hitl.db
+				dbDir = path.join(os.homedir(), ".kimchi", "metrics", this.projectHashValue)
+				dbPath = path.join(dbDir, "hitl.db")
+				fs.mkdirSync(dbDir, { recursive: true })
+			}
 
-			// Ensure directory exists
-			fs.mkdirSync(dbDir, { recursive: true })
-
-			// Initialize database
 			this.db = new HitlDatabase(dbPath)
-			const opened = this.db.open()
-			if (!opened) {
+			if (!this.db.open()) {
 				console.warn("[HITL] Failed to open database, events will be silently dropped")
 				return
 			}
-
-			// Initialize schema
-			const schemaOk = this.db.initSchema()
-			if (!schemaOk) {
+			if (!this.db.initSchema()) {
 				console.warn("[HITL] Failed to initialize schema, events will be silently dropped")
 				return
 			}
 
-			// Close any orphaned sessions from previous crashes
 			closeOrphanSessions(this.db)
-
-			// Get or create session
 			this.session = getOrCreateSession(this.db, this.projectHashValue)
 			if (!this.session) {
 				console.warn("[HITL] Failed to create session, events will be silently dropped")
+				return
 			}
+
+			// Initialize activity tracking from session
+			this.lastActivityTimestamp = Date.now()
+			this.agentTimeAccumulator = this.session.agent_time_ms
+			this.hitlTimeAccumulator = this.session.hitl_time_ms
+			this.idleTimeAccumulator = this.session.idle_time_ms
 		} catch (error) {
 			const message = error instanceof Error ? error.message : String(error)
 			console.warn(`[HITL] Initialization error: ${message}`)
@@ -70,84 +119,133 @@ export class SessionManager {
 		}
 	}
 
-	/**
-	 * Get the current active session, or null if not initialized.
-	 *
-	 * @returns HitlSession or null
-	 */
 	getSession(): HitlSession | null {
 		return this.session
 	}
 
-	/**
-	 * Record the start time for a tool execution to enable duration tracking.
-	 * Called on tool_execution_start hook.
-	 *
-	 * @param toolCallId - Unique identifier for the tool call
-	 */
-	recordStartTime(toolCallId: string): void {
+	/** Record start of any tool execution */
+	recordToolStart(toolCallId: string, toolName: string): void {
 		if (!toolCallId) return
 		this.pendingStartTimes.set(toolCallId, Date.now())
-	}
 
-	/**
-	 * Get and remove the start time for a tool call.
-	 * Used internally to compute duration.
-	 *
-	 * @param toolCallId - Unique identifier for the tool call
-	 * @returns Start timestamp or undefined if not found
-	 */
-	consumeStartTime(toolCallId: string): number | undefined {
-		const startTime = this.pendingStartTimes.get(toolCallId)
-		if (startTime !== undefined) {
-			this.pendingStartTimes.delete(toolCallId)
+		if (this.db && this.session) {
+			recordActivityEvent(this.db, this.session.id, "tool_start", toolName)
 		}
-		return startTime
+		if (this.isIdle) this.endIdlePeriod()
+		this.lastActivityTimestamp = Date.now()
 	}
 
-	/**
-	 * Record a HITL event to the database.
-	 * Non-fatal: returns false on errors without throwing.
-	 *
-	 * @param toolName - Name of the tool that triggered the interaction
-	 * @param questionCount - Number of questions asked
-	 * @param durationMs - Duration in milliseconds
-	 * @param selectedOptions - Array of user-selected option labels
-	 * @returns true if recorded successfully, false otherwise
-	 */
+	/** Record end of any tool execution and accumulate agent time */
+	recordToolEnd(toolCallId: string, toolName: string, durationMs: number): void {
+		this.pendingStartTimes.delete(toolCallId)
+
+		if (this.db && this.session) {
+			recordActivityEvent(this.db, this.session.id, "tool_end", toolName, durationMs)
+		}
+
+		// Accumulate agent time (exclude HITL tools tracked separately)
+		if (toolName !== HITL_TOOL_NAME) {
+			this.agentTimeAccumulator += durationMs
+		}
+		this.lastActivityTimestamp = Date.now()
+		this.maybeStartIdleTimer()
+	}
+
+	/** Record user input (mark end of idle, reset timers) */
+	recordUserInput(): void {
+		if (this.isIdle) this.endIdlePeriod()
+		if (this.db && this.session) {
+			recordActivityEvent(this.db, this.session.id, "user_input")
+		}
+		this.lastActivityTimestamp = Date.now()
+		// Start idle tracking — next tool start will end it
+		this.startIdlePeriod()
+	}
+
+	/** Check if we should start idle tracking */
+	private maybeStartIdleTimer(): void {
+		// Called after tool execution; if no immediate next action, idle starts
+		// In practice, idle is detected lazily when next activity arrives
+	}
+
+	private startIdlePeriod(): void {
+		if (this.isIdle || !this.session) return
+		this.isIdle = true
+		this.currentIdleStart = Date.now()
+		recordActivityEvent(this.db!, this.session.id, "idle_start")
+	}
+
+	private endIdlePeriod(): void {
+		if (!this.isIdle || !this.session || this.currentIdleStart === 0) return
+		const duration = Date.now() - this.currentIdleStart
+		this.idleTimeAccumulator += duration
+		this.isIdle = false
+		recordActivityEvent(this.db!, this.session.id, "idle_end", undefined, duration)
+	}
+
+	/** Legacy method - kept for backward compatibility */
+	recordStartTime(toolCallId: string): void {
+		this.recordToolStart(toolCallId, "unknown")
+	}
+
+	/** Legacy method - kept for backward compatibility */
+	consumeStartTime(toolCallId: string): number | undefined {
+		const start = this.pendingStartTimes.get(toolCallId)
+		if (start !== undefined) this.pendingStartTimes.delete(toolCallId)
+		return start
+	}
+
+	/** Record permission/approval event */
+	recordPermissionEvent(
+		toolName: string,
+		action: string,
+		outcome: HitlPermissionEvent["outcome"],
+		durationMs: number,
+		reason?: string,
+	): boolean {
+		if (!this.db || !this.session) return false
+		if (this.isIdle) this.endIdlePeriod()
+
+		try {
+			return recordPermissionEvent(
+				this.db,
+				this.session.id,
+				toolName,
+				action,
+				outcome,
+				durationMs,
+				reason,
+			)
+		} catch (error) {
+			const message = error instanceof Error ? error.message : String(error)
+			console.warn(`[HITL] Permission event recording error: ${message}`)
+			return false
+		}
+	}
+
+	/** Record HITL event (ask_user_questions) */
 	recordEvent(
 		toolName: string,
 		questionCount: number,
 		durationMs: number,
 		selectedOptions: string[],
 	): boolean {
-		if (!this.db || !this.session) {
-			// Silently drop events when DB/session unavailable (graceful degradation)
-			return false
-		}
+		if (!this.db || !this.session) return false
+		if (this.isIdle) this.endIdlePeriod()
 
 		try {
 			const createdAt = Date.now()
-			const selectedOptionsJson = JSON.stringify(selectedOptions)
-
-			const sql = `INSERT INTO hitl_events
-				(session_id, tool_name, question_count, duration_ms, selected_options, created_at)
-				VALUES (?, ?, ?, ?, ?, ?)`
-
-			const success = this.db.run(sql, [
-				this.session.id,
-				toolName,
-				questionCount,
-				durationMs,
-				selectedOptionsJson,
-				createdAt,
-			])
-
+			const success = this.db.run(
+				`INSERT INTO hitl_events (session_id, tool_name, question_count, duration_ms, selected_options, created_at)
+				 VALUES (?, ?, ?, ?, ?, ?)`,
+				[this.session.id, toolName, questionCount, durationMs, JSON.stringify(selectedOptions), createdAt],
+			)
 			if (!success) {
 				console.warn("[HITL] Failed to write event to database")
 				return false
 			}
-
+			this.hitlTimeAccumulator += durationMs
+			this.lastActivityTimestamp = Date.now()
 			return true
 		} catch (error) {
 			const message = error instanceof Error ? error.message : String(error)
@@ -156,32 +254,24 @@ export class SessionManager {
 		}
 	}
 
-	/**
-	 * Close the session manager and release resources.
-	 * Closes the active session and database connection.
-	 */
-	close(): void {
-		try {
-			if (this.session && this.db) {
-				closeSession(this.db, this.session.id)
-			}
-		} catch (error) {
-			const message = error instanceof Error ? error.message : String(error)
-			console.warn(`[HITL] Error closing session: ${message}`)
-		}
+	/** Close session with optional end cause */
+	close(endCause: EndCause = "complete"): void {
+		if (this.isIdle) this.endIdlePeriod()
+		this.persistTimeMetrics()
 
-		try {
-			if (this.db) {
-				this.db.close()
-			}
-		} catch (error) {
-			const message = error instanceof Error ? error.message : String(error)
-			console.warn(`[HITL] Error closing database: ${message}`)
+		if (this.session && this.db) {
+			closeSession(this.db, this.session.id, endCause)
 		}
-
+		if (this.db) this.db.close()
 		this.db = null
 		this.session = null
 		this.pendingStartTimes.clear()
+	}
+
+	/** Persist accumulated time metrics to database */
+	private persistTimeMetrics(): void {
+		if (!this.db || !this.session) return
+		updateSessionTimes(this.db, this.session.id, this.agentTimeAccumulator, this.hitlTimeAccumulator, this.idleTimeAccumulator)
 	}
 }
 

--- a/extensions/hitl-metrics/session-manager.ts
+++ b/extensions/hitl-metrics/session-manager.ts
@@ -1,0 +1,188 @@
+/**
+ * HITL Session Manager
+ *
+ * Encapsulates database initialization, session lifecycle, and event recording.
+ * All methods are non-fatal (catch errors, log warnings, return safe defaults).
+ */
+
+import * as path from "node:path"
+import * as os from "node:os"
+import * as fs from "node:fs"
+import { HitlDatabase, projectHash, getOrCreateSession, closeSession, closeOrphanSessions } from "./storage/index.ts"
+import type { HitlSession } from "./types.ts"
+
+/**
+ * Manages HITL sessions and event recording.
+ * Tracks duration via tool execution start times and writes events to database.
+ */
+export class SessionManager {
+	private db: HitlDatabase | null = null
+	private session: HitlSession | null = null
+	private projectHashValue: string = ""
+	private pendingStartTimes: Map<string, number> = new Map()
+
+	/**
+	 * Initialize the session manager for the given project directory.
+	 * Opens database, initializes schema, closes orphans, creates/resumes session.
+	 *
+	 * @param cwd - Project working directory
+	 */
+	init(cwd: string): void {
+		try {
+			// Generate project hash from cwd
+			this.projectHashValue = projectHash(cwd)
+
+			// Build DB path at ~/.hitl-metrics/<hash>.db
+			const dbDir = path.join(os.homedir(), ".hitl-metrics")
+			const dbPath = path.join(dbDir, `${this.projectHashValue}.db`)
+
+			// Ensure directory exists
+			fs.mkdirSync(dbDir, { recursive: true })
+
+			// Initialize database
+			this.db = new HitlDatabase(dbPath)
+			const opened = this.db.open()
+			if (!opened) {
+				console.warn("[HITL] Failed to open database, events will be silently dropped")
+				return
+			}
+
+			// Initialize schema
+			const schemaOk = this.db.initSchema()
+			if (!schemaOk) {
+				console.warn("[HITL] Failed to initialize schema, events will be silently dropped")
+				return
+			}
+
+			// Close any orphaned sessions from previous crashes
+			closeOrphanSessions(this.db)
+
+			// Get or create session
+			this.session = getOrCreateSession(this.db, this.projectHashValue)
+			if (!this.session) {
+				console.warn("[HITL] Failed to create session, events will be silently dropped")
+			}
+		} catch (error) {
+			const message = error instanceof Error ? error.message : String(error)
+			console.warn(`[HITL] Initialization error: ${message}`)
+			this.db = null
+			this.session = null
+		}
+	}
+
+	/**
+	 * Get the current active session, or null if not initialized.
+	 *
+	 * @returns HitlSession or null
+	 */
+	getSession(): HitlSession | null {
+		return this.session
+	}
+
+	/**
+	 * Record the start time for a tool execution to enable duration tracking.
+	 * Called on tool_execution_start hook.
+	 *
+	 * @param toolCallId - Unique identifier for the tool call
+	 */
+	recordStartTime(toolCallId: string): void {
+		if (!toolCallId) return
+		this.pendingStartTimes.set(toolCallId, Date.now())
+	}
+
+	/**
+	 * Get and remove the start time for a tool call.
+	 * Used internally to compute duration.
+	 *
+	 * @param toolCallId - Unique identifier for the tool call
+	 * @returns Start timestamp or undefined if not found
+	 */
+	consumeStartTime(toolCallId: string): number | undefined {
+		const startTime = this.pendingStartTimes.get(toolCallId)
+		if (startTime !== undefined) {
+			this.pendingStartTimes.delete(toolCallId)
+		}
+		return startTime
+	}
+
+	/**
+	 * Record a HITL event to the database.
+	 * Non-fatal: returns false on errors without throwing.
+	 *
+	 * @param toolName - Name of the tool that triggered the interaction
+	 * @param questionCount - Number of questions asked
+	 * @param durationMs - Duration in milliseconds
+	 * @param selectedOptions - Array of user-selected option labels
+	 * @returns true if recorded successfully, false otherwise
+	 */
+	recordEvent(
+		toolName: string,
+		questionCount: number,
+		durationMs: number,
+		selectedOptions: string[],
+	): boolean {
+		if (!this.db || !this.session) {
+			// Silently drop events when DB/session unavailable (graceful degradation)
+			return false
+		}
+
+		try {
+			const createdAt = Date.now()
+			const selectedOptionsJson = JSON.stringify(selectedOptions)
+
+			const sql = `INSERT INTO hitl_events
+				(session_id, tool_name, question_count, duration_ms, selected_options, created_at)
+				VALUES (?, ?, ?, ?, ?, ?)`
+
+			const success = this.db.run(sql, [
+				this.session.id,
+				toolName,
+				questionCount,
+				durationMs,
+				selectedOptionsJson,
+				createdAt,
+			])
+
+			if (!success) {
+				console.warn("[HITL] Failed to write event to database")
+				return false
+			}
+
+			return true
+		} catch (error) {
+			const message = error instanceof Error ? error.message : String(error)
+			console.warn(`[HITL] Event recording error: ${message}`)
+			return false
+		}
+	}
+
+	/**
+	 * Close the session manager and release resources.
+	 * Closes the active session and database connection.
+	 */
+	close(): void {
+		try {
+			if (this.session && this.db) {
+				closeSession(this.db, this.session.id)
+			}
+		} catch (error) {
+			const message = error instanceof Error ? error.message : String(error)
+			console.warn(`[HITL] Error closing session: ${message}`)
+		}
+
+		try {
+			if (this.db) {
+				this.db.close()
+			}
+		} catch (error) {
+			const message = error instanceof Error ? error.message : String(error)
+			console.warn(`[HITL] Error closing database: ${message}`)
+		}
+
+		this.db = null
+		this.session = null
+		this.pendingStartTimes.clear()
+	}
+}
+
+export default SessionManager

--- a/extensions/hitl-metrics/smoke.test.ts
+++ b/extensions/hitl-metrics/smoke.test.ts
@@ -9,22 +9,31 @@ import { describe, it, expect, beforeEach, afterEach, vi } from "vitest"
 import { mkdtempSync, rmSync, existsSync } from "node:fs"
 import { tmpdir } from "node:os"
 import { join } from "node:path"
-import { SessionManager } from "./session-manager.ts"
-import { getMetricsOutput } from "./commands/metrics.ts"
+import { SessionManager } from "./session-manager.js"
+import { getMetricsOutput } from "./commands/metrics.js"
+
+import type { Theme } from "@mariozechner/pi-coding-agent"
 
 /**
  * Create a mock theme for testing (no-op formatting)
  */
-function createMockTheme() {
+function createMockTheme(): Theme {
+	const noOp = (text: string) => text
 	return {
-		fg: (_c: string, text: string) => text,
-		bg: (_c: string, text: string) => text,
-		bold: (text: string) => text,
-		dim: (text: string) => text,
-		italic: (text: string) => text,
-		underline: (text: string) => text,
-		strikethrough: (text: string) => text,
-	}
+		name: "mock",
+		fg: (_c, text) => text,
+		bg: (_c, text) => text,
+		bold: noOp,
+		italic: noOp,
+		underline: noOp,
+		inverse: noOp,
+		strikethrough: noOp,
+		getFgAnsi: () => "",
+		getBgAnsi: () => "",
+		getColorMode: () => "truecolor",
+		getThinkingBorderColor: () => noOp,
+		getBashModeBorderColor: () => noOp,
+	} as unknown as Theme
 }
 
 /**

--- a/extensions/hitl-metrics/smoke.test.ts
+++ b/extensions/hitl-metrics/smoke.test.ts
@@ -1,0 +1,290 @@
+/**
+ * HITL Metrics Integration Smoke Tests
+ *
+ * End-to-end tests that exercise the full HITL metrics lifecycle through
+ * real code paths with file-based SQLite databases in temp directories.
+ */
+
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest"
+import { mkdtempSync, rmSync, existsSync } from "node:fs"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
+import { SessionManager } from "./session-manager.ts"
+import { getMetricsOutput } from "./commands/metrics.ts"
+
+/**
+ * Create a mock theme for testing (no-op formatting)
+ */
+function createMockTheme() {
+	return {
+		fg: (_c: string, text: string) => text,
+		bg: (_c: string, text: string) => text,
+		bold: (text: string) => text,
+		dim: (text: string) => text,
+		italic: (text: string) => text,
+		underline: (text: string) => text,
+		strikethrough: (text: string) => text,
+	}
+}
+
+/**
+ * Helper to create a unique temp directory for each test
+ */
+function createTempDir(): string {
+	return mkdtempSync(join(tmpdir(), "hitl-smoke-test-"))
+}
+
+/**
+ * Helper to cleanup temp directory
+ */
+function cleanupTempDir(dir: string): void {
+	if (existsSync(dir)) {
+		rmSync(dir, { recursive: true, force: true })
+	}
+}
+
+describe("HITL Metrics Smoke Tests", () => {
+	let consoleWarnSpy: ReturnType<typeof vi.spyOn>
+	let tempDirs: string[] = []
+
+	beforeEach(() => {
+		consoleWarnSpy = vi.spyOn(console, "warn").mockImplementation(() => {})
+		tempDirs = []
+	})
+
+	afterEach(() => {
+		consoleWarnSpy.mockRestore()
+		// Cleanup all temp directories
+		for (const dir of tempDirs) {
+			cleanupTempDir(dir)
+		}
+	})
+
+	describe("single session lifecycle", () => {
+		it("records events and metrics reflect them correctly", async () => {
+			const tempDir = createTempDir()
+			tempDirs.push(tempDir)
+
+			// Create and initialize session manager
+			const manager = new SessionManager()
+			manager.init(tempDir)
+
+			const session = manager.getSession()
+			expect(session).not.toBeNull()
+			expect(session?.status).toBe("active")
+
+			// Record events with realistic durations
+			// Simulate tool execution timing
+			manager.recordStartTime("call-1")
+			await new Promise(resolve => setTimeout(resolve, 50))
+			const startTime1 = manager.consumeStartTime("call-1")
+			expect(startTime1).toBeDefined()
+			const duration1 = Date.now() - startTime1!
+
+			const result1 = manager.recordEvent("ask_user_questions", 2, duration1, [
+				"Option A",
+				"Option B",
+			])
+			expect(result1).toBe(true)
+
+			// Record second event
+			manager.recordStartTime("call-2")
+			await new Promise(resolve => setTimeout(resolve, 30))
+			const startTime2 = manager.consumeStartTime("call-2")
+			expect(startTime2).toBeDefined()
+			const duration2 = Date.now() - startTime2!
+
+			const result2 = manager.recordEvent("secure_env_collect", 1, duration2, [
+				"OPENAI_API_KEY",
+			])
+			expect(result2).toBe(true)
+
+			// Record third event
+			const result3 = manager.recordEvent("search_and_read", 0, 150, [])
+			expect(result3).toBe(true)
+
+			// Close the manager (closes session)
+			manager.close()
+
+			// Now call getMetricsOutput with a fresh connection to the same DB
+			const theme = createMockTheme()
+			const output = await getMetricsOutput(tempDir, theme)
+
+			// Verify output contains expected stats
+			expect(output).toContain("HITL Metrics")
+			expect(output).toContain("Total sessions:     1")
+			expect(output).toContain("Interactions:       3")
+			expect(output).toContain("Total HITL time:")
+
+			// Verify session appears in recent sessions
+			expect(output).toContain("Recent Sessions")
+			expect(output).toContain("CLOSED")
+		})
+
+		it("timeline renders for closed sessions with events", async () => {
+			const tempDir = createTempDir()
+			tempDirs.push(tempDir)
+
+			const manager = new SessionManager()
+			manager.init(tempDir)
+
+			// Record events to create timeline data
+			manager.recordStartTime("call-1")
+			await new Promise(resolve => setTimeout(resolve, 20))
+			const startTime = manager.consumeStartTime("call-1")!
+			manager.recordEvent("ask_user_questions", 1, Date.now() - startTime, [
+				"Yes",
+			])
+
+			// Record another event after a small delay
+			await new Promise(resolve => setTimeout(resolve, 20))
+			manager.recordEvent("search_and_read", 0, 100, [])
+
+			manager.close()
+
+			const theme = createMockTheme()
+			const output = await getMetricsOutput(tempDir, theme)
+
+			// Verify timeline appears
+			expect(output).toContain("Session Timeline")
+
+			// Verify legend characters appear (solo and HITL indicators)
+			expect(output).toContain("solo")
+			expect(output).toContain("HITL")
+		})
+	})
+
+	describe("multi-session accumulation", () => {
+		it("multiple sessions accumulate correctly", async () => {
+			const tempDir = createTempDir()
+			tempDirs.push(tempDir)
+
+			// Session 1: Create manager, record events, close
+			const manager1 = new SessionManager()
+			manager1.init(tempDir)
+
+			manager1.recordStartTime("s1-call-1")
+			await new Promise(resolve => setTimeout(resolve, 30))
+			const s1Start1 = manager1.consumeStartTime("s1-call-1")!
+			manager1.recordEvent("ask_user_questions", 2, Date.now() - s1Start1, ["A", "B"])
+
+			manager1.recordStartTime("s1-call-2")
+			await new Promise(resolve => setTimeout(resolve, 20))
+			const s1Start2 = manager1.consumeStartTime("s1-call-2")!
+			manager1.recordEvent("secure_env_collect", 1, Date.now() - s1Start2, ["KEY"])
+
+			manager1.close()
+
+			// Session 2: Create a NEW manager on same directory
+			const manager2 = new SessionManager()
+			manager2.init(tempDir)
+
+			// This should be a new session (not resumed, since previous was closed)
+			const session2 = manager2.getSession()
+			expect(session2).not.toBeNull()
+
+			// Record events in second session
+			manager2.recordStartTime("s2-call-1")
+			await new Promise(resolve => setTimeout(resolve, 25))
+			const s2Start1 = manager2.consumeStartTime("s2-call-1")!
+			manager2.recordEvent("search_and_read", 0, Date.now() - s2Start1, [])
+
+			manager2.recordStartTime("s2-call-2")
+			await new Promise(resolve => setTimeout(resolve, 15))
+			const s2Start2 = manager2.consumeStartTime("s2-call-2")!
+			manager2.recordEvent("ask_user_questions", 1, Date.now() - s2Start2, ["Continue"])
+
+			manager2.close()
+
+			// Verify metrics show accumulated data
+			const theme = createMockTheme()
+			const output = await getMetricsOutput(tempDir, theme)
+
+			// Should show 2 total sessions
+			expect(output).toContain("Total sessions:     2")
+
+			// Should show 4 interactions (2 from session 1 + 2 from session 2)
+			expect(output).toContain("Interactions:       4")
+
+			// Should show accumulated HITL time (all events)
+			expect(output).toContain("Total HITL time:")
+
+			// Both sessions should be in recent sessions
+			expect(output).toContain("Recent Sessions")
+
+			// Count occurrences of CLOSED status
+			const closedMatches = output.match(/CLOSED/g)
+			expect(closedMatches?.length).toBeGreaterThanOrEqual(2)
+		})
+
+		it("data persists across restart", async () => {
+			const tempDir = createTempDir()
+			tempDirs.push(tempDir)
+
+			// First "run" - simulate work with first manager
+			const manager1 = new SessionManager()
+			manager1.init(tempDir)
+
+			manager1.recordEvent("ask_user_questions", 1, 500, ["Yes"])
+			manager1.recordEvent("search_and_read", 0, 200, [])
+
+			manager1.close()
+
+			//
+			// Simulate "restart" by opening getMetricsOutput with fresh DB connection
+			const theme = createMockTheme()
+			const output = await getMetricsOutput(tempDir, theme)
+
+			// Verify data from first session persisted and is visible
+			expect(output).toContain("Total sessions:     1")
+			expect(output).toContain("Interactions:       2")
+			expect(output).toContain("Total HITL time:")
+
+			// Also prove we can add more data (restart and continue)
+			const manager2 = new SessionManager()
+			manager2.init(tempDir)
+			manager2.recordEvent("another_tool", 1, 300, ["Option"])
+			manager2.close()
+
+			const output2 = await getMetricsOutput(tempDir, theme)
+			expect(output2).toContain("Interactions:       3")
+		})
+	})
+
+	describe("error handling", () => {
+		it("non-fatal degradation when DB cannot be opened", () => {
+			const manager = new SessionManager()
+
+			// Initialize with a valid path (session is created in memory)
+			const tempDir = createTempDir()
+			tempDirs.push(tempDir)
+			manager.init(tempDir)
+
+			// Close the manager to release DB connection
+			manager.close()
+
+			// recordEvent should return false when db/session unavailable
+			// (tested by not re-initializing after close)
+			const result = manager.recordEvent("ask_user_questions", 1, 1000, ["Yes"])
+			expect(result).toBe(false)
+
+			// close should not throw even when called multiple times
+			expect(() => manager.close()).not.toThrow()
+		})
+
+		it("non-fatal degradation on manager without init", () => {
+			const manager = new SessionManager()
+
+			// Using manager without calling init() should not throw
+			expect(() => manager.getSession()).not.toThrow()
+			expect(manager.getSession()).toBeNull()
+
+			// recordEvent should return false when not initialized
+			const result = manager.recordEvent("ask_user_questions", 1, 1000, ["Yes"])
+			expect(result).toBe(false)
+
+			// close should not throw even when never initialized
+			expect(() => manager.close()).not.toThrow()
+		})
+	})
+})

--- a/extensions/hitl-metrics/smoke.test.ts
+++ b/extensions/hitl-metrics/smoke.test.ts
@@ -134,9 +134,10 @@ describe("HITL Metrics Smoke Tests", () => {
 			// Verify timeline appears
 			expect(output).toContain("Session Timeline")
 
-			// Verify legend characters appear (solo and HITL indicators)
-			expect(output).toContain("solo")
+			// Verify legend characters appear (agent, HITL, idle indicators)
+			expect(output).toContain("agent")
 			expect(output).toContain("HITL")
+			expect(output).toContain("idle")
 		})
 	})
 

--- a/extensions/hitl-metrics/smoke.test.ts
+++ b/extensions/hitl-metrics/smoke.test.ts
@@ -11,30 +11,7 @@ import { tmpdir } from "node:os"
 import { join } from "node:path"
 import { SessionManager } from "./session-manager.js"
 import { getMetricsOutput } from "./commands/metrics.js"
-
-import type { Theme } from "@mariozechner/pi-coding-agent"
-
-/**
- * Create a mock theme for testing (no-op formatting)
- */
-function createMockTheme(): Theme {
-	const noOp = (text: string) => text
-	return {
-		name: "mock",
-		fg: (_c, text) => text,
-		bg: (_c, text) => text,
-		bold: noOp,
-		italic: noOp,
-		underline: noOp,
-		inverse: noOp,
-		strikethrough: noOp,
-		getFgAnsi: () => "",
-		getBgAnsi: () => "",
-		getColorMode: () => "truecolor",
-		getThinkingBorderColor: () => noOp,
-		getBashModeBorderColor: () => noOp,
-	} as unknown as Theme
-}
+import { createMockTheme } from "./test-helpers/mock-theme.js"
 
 /**
  * Helper to create a unique temp directory for each test

--- a/extensions/hitl-metrics/storage/db.test.ts
+++ b/extensions/hitl-metrics/storage/db.test.ts
@@ -1,0 +1,179 @@
+/**
+ * HitlDatabase Unit Tests
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from "vitest"
+import { HitlDatabase } from "./db.ts"
+import { SESSIONS_TABLE_SQL, EVENTS_TABLE_SQL, PROJECT_HASH_INDEX_SQL, SESSION_ID_INDEX_SQL } from "./schema.ts"
+
+describe("HitlDatabase", () => {
+	describe("with :memory: database", () => {
+		let db: HitlDatabase
+
+		beforeEach(() => {
+			db = new HitlDatabase(":memory:")
+		})
+
+		afterEach(() => {
+			db.close()
+		})
+
+		it("opens successfully", () => {
+			const opened = db.open()
+			expect(opened).toBe(true)
+			expect(db.isOpen).toBe(true)
+		})
+
+		it("returns false on double open (lazy init)", () => {
+			db.open()
+			const secondOpen = db.open()
+			// Second open creates new Database instance (replaces previous)
+			// This is acceptable behavior - we just verify it doesn't crash
+			expect(db.isOpen).toBe(true)
+		})
+
+		it("initializes schema successfully", () => {
+			db.open()
+			const schemaOk = db.initSchema()
+			expect(schemaOk).toBe(true)
+		})
+
+		it("closes successfully", () => {
+			db.open()
+			db.close()
+			expect(db.isOpen).toBe(false)
+		})
+
+		it("can insert and query data after init", () => {
+			db.open()
+			db.initSchema()
+
+			// Insert a session
+			const insertOk = db.run(
+				"INSERT INTO hitl_sessions (id, project_hash, started_at, status) VALUES (?, ?, ?, ?)",
+				["test-session-1", "abc123def4567890", 1234567890, "active"],
+			)
+			expect(insertOk).toBe(true)
+
+			// Query it back
+			const results = db.query<{ id: string; project_hash: string; status: string }>(
+				"SELECT id, project_hash, status FROM hitl_sessions WHERE id = ?",
+				["test-session-1"],
+			)
+			expect(results).toHaveLength(1)
+			expect(results[0].id).toBe("test-session-1")
+			expect(results[0].project_hash).toBe("abc123def4567890")
+			expect(results[0].status).toBe("active")
+		})
+
+		it("returns empty array on failed query (non-fatal)", () => {
+			db.open()
+			// Query before schema init - should fail gracefully
+			const results = db.query("SELECT * FROM hitl_sessions")
+			expect(results).toEqual([])
+		})
+
+		it("returns false on failed run (non-fatal)", () => {
+			db.open()
+			// Try to insert without schema - should fail gracefully
+			const insertOk = db.run("INSERT INTO hitl_sessions (id) VALUES (?)", ["test"])
+			expect(insertOk).toBe(false)
+		})
+
+		it("handles multiple sessions in same project", () => {
+			db.open()
+			db.initSchema()
+
+			db.run(
+				"INSERT INTO hitl_sessions (id, project_hash, started_at, status) VALUES (?, ?, ?, ?)",
+				["session-1", "proj-hash-1", 1000, "active"],
+			)
+			db.run(
+				"INSERT INTO hitl_sessions (id, project_hash, started_at, status) VALUES (?, ?, ?, ?)",
+				["session-2", "proj-hash-1", 2000, "closed"],
+			)
+
+			const results = db.query<{ id: string }>(
+				"SELECT id FROM hitl_sessions WHERE project_hash = ? ORDER BY started_at",
+				["proj-hash-1"],
+			)
+			expect(results).toHaveLength(2)
+			expect(results[0].id).toBe("session-1")
+			expect(results[1].id).toBe("session-2")
+		})
+
+		it("supports foreign key constraints (events link to sessions)", () => {
+			db.open()
+			db.initSchema()
+
+			// Insert session
+			db.run(
+				"INSERT INTO hitl_sessions (id, project_hash, started_at, status) VALUES (?, ?, ?, ?)",
+				["session-parent", "proj-hash", 1000, "active"],
+			)
+
+			// Insert event referencing session
+			db.run(
+				"INSERT INTO hitl_events (session_id, tool_name, question_count, duration_ms, selected_options, created_at) VALUES (?, ?, ?, ?, ?, ?)",
+				["session-parent", "ask_user", 3, 5000, '["option1", "option2"]', 2000],
+			)
+
+			const events = db.query<{ tool_name: string; question_count: number }>(
+				"SELECT tool_name, question_count FROM hitl_events WHERE session_id = ?",
+				["session-parent"],
+			)
+			expect(events).toHaveLength(1)
+			expect(events[0].tool_name).toBe("ask_user")
+			expect(events[0].question_count).toBe(3)
+		})
+	})
+
+	describe("schema constants", () => {
+		it("SESSIONS_TABLE_SQL contains expected columns", () => {
+			expect(SESSIONS_TABLE_SQL).toContain("hitl_sessions")
+			expect(SESSIONS_TABLE_SQL).toContain("id TEXT PRIMARY KEY")
+			expect(SESSIONS_TABLE_SQL).toContain("project_hash TEXT")
+			expect(SESSIONS_TABLE_SQL).toContain("started_at INTEGER")
+			expect(SESSIONS_TABLE_SQL).toContain("ended_at INTEGER")
+			expect(SESSIONS_TABLE_SQL).toContain("status TEXT")
+		})
+
+		it("EVENTS_TABLE_SQL contains expected columns", () => {
+			expect(EVENTS_TABLE_SQL).toContain("hitl_events")
+			expect(EVENTS_TABLE_SQL).toContain("id INTEGER PRIMARY KEY AUTOINCREMENT")
+			expect(EVENTS_TABLE_SQL).toContain("session_id TEXT")
+			expect(EVENTS_TABLE_SQL).toContain("tool_name TEXT")
+			expect(EVENTS_TABLE_SQL).toContain("question_count INTEGER")
+			expect(EVENTS_TABLE_SQL).toContain("duration_ms INTEGER")
+			expect(EVENTS_TABLE_SQL).toContain("selected_options TEXT")
+			expect(EVENTS_TABLE_SQL).toContain("created_at INTEGER")
+			expect(EVENTS_TABLE_SQL).toContain("FOREIGN KEY")
+		})
+
+		it("indexes are defined", () => {
+			expect(PROJECT_HASH_INDEX_SQL).toContain("idx_sessions_project_hash")
+			expect(SESSION_ID_INDEX_SQL).toContain("idx_events_session_id")
+		})
+	})
+
+	describe("error handling", () => {
+		it("returns false for operations before open()", () => {
+			const db = new HitlDatabase(":memory:")
+			// Don't call open()
+			expect(db.initSchema()).toBe(false)
+			expect(db.run("SELECT 1")).toBe(false)
+			expect(db.query("SELECT 1")).toEqual([])
+			db.close() // safe no-op
+		})
+
+		it("returns empty/false for operations after close()", () => {
+			const db = new HitlDatabase(":memory:")
+			db.open()
+			db.initSchema()
+			db.close()
+			expect(db.isOpen).toBe(false)
+			expect(db.query("SELECT 1")).toEqual([])
+			expect(db.run("SELECT 1")).toBe(false)
+		})
+	})
+})

--- a/extensions/hitl-metrics/storage/db.test.ts
+++ b/extensions/hitl-metrics/storage/db.test.ts
@@ -3,8 +3,8 @@
  */
 
 import { describe, it, expect, beforeEach, afterEach } from "vitest"
-import { HitlDatabase } from "./db.ts"
-import { SESSIONS_TABLE_SQL, EVENTS_TABLE_SQL, PROJECT_HASH_INDEX_SQL, SESSION_ID_INDEX_SQL } from "./schema.ts"
+import { HitlDatabase } from "./db.js"
+import { SESSIONS_TABLE_SQL, EVENTS_TABLE_SQL, PROJECT_HASH_INDEX_SQL, SESSION_ID_INDEX_SQL } from "./schema.js"
 
 describe("HitlDatabase", () => {
 	describe("with :memory: database", () => {

--- a/extensions/hitl-metrics/storage/db.ts
+++ b/extensions/hitl-metrics/storage/db.ts
@@ -5,15 +5,18 @@
  * WAL mode, and schema initialization.
  */
 
-import { Database } from "bun:sqlite"
-import { SESSIONS_TABLE_SQL, EVENTS_TABLE_SQL, PROJECT_HASH_INDEX_SQL, SESSION_ID_INDEX_SQL } from "./schema.ts"
+import { SESSIONS_TABLE_SQL, EVENTS_TABLE_SQL, PROJECT_HASH_INDEX_SQL, SESSION_ID_INDEX_SQL } from "./schema.js"
+
+// bun:sqlite is a built-in Bun module - we use a relaxed type for runtime
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+type BunDatabase = any
 
 /**
  * Non-fatal database wrapper for HITL metrics.
  * All operations catch errors, log warnings, and return safe defaults.
  */
 export class HitlDatabase {
-	private db: Database | null = null
+	private db: BunDatabase | null = null
 	private dbPath: string
 	private isClosed = false
 
@@ -30,7 +33,9 @@ export class HitlDatabase {
 	 */
 	open(): boolean {
 		try {
-			this.db = new Database(this.dbPath)
+			// eslint-disable-next-line @typescript-eslint/no-var-requires
+			const sqlite = require("bun:sqlite")
+			this.db = new sqlite.Database(this.dbPath)
 			this.db.exec("PRAGMA journal_mode=WAL")
 			this.db.exec("PRAGMA busy_timeout=3000")
 			return true
@@ -152,7 +157,7 @@ export class HitlDatabase {
 	 * Get the underlying Database instance for advanced operations.
 	 * Returns null if closed or not open.
 	 */
-	get raw(): Database | null {
+	get raw(): BunDatabase | null {
 		return this.isClosed ? null : this.db
 	}
 }

--- a/extensions/hitl-metrics/storage/db.ts
+++ b/extensions/hitl-metrics/storage/db.ts
@@ -5,18 +5,26 @@
  * WAL mode, and schema initialization.
  */
 
+// Bun's built-in SQLite module - only available at runtime under Bun
+// We use dynamic require to avoid TypeScript errors during Node.js builds
+// eslint-disable-next-line @typescript-eslint/no-var-requires
+const { Database } = require("bun:sqlite")
 import { SESSIONS_TABLE_SQL, EVENTS_TABLE_SQL, PROJECT_HASH_INDEX_SQL, SESSION_ID_INDEX_SQL } from "./schema.js"
 
-// bun:sqlite is a built-in Bun module - we use a relaxed type for runtime
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-type BunDatabase = any
+// Minimal type for Database at build time
+type DatabaseInstance = {
+	exec(sql: string): void
+	run(sql: string, params?: (string | number | null)[]): void
+	query(sql: string): { all(...params: (string | number | null)[]): unknown[] }
+	close(): void
+}
 
 /**
  * Non-fatal database wrapper for HITL metrics.
  * All operations catch errors, log warnings, and return safe defaults.
  */
 export class HitlDatabase {
-	private db: BunDatabase | null = null
+	private db: DatabaseInstance | null = null
 	private dbPath: string
 	private isClosed = false
 
@@ -33,9 +41,7 @@ export class HitlDatabase {
 	 */
 	open(): boolean {
 		try {
-			// eslint-disable-next-line @typescript-eslint/no-var-requires
-			const sqlite = require("bun:sqlite")
-			this.db = new sqlite.Database(this.dbPath)
+			this.db = new Database(this.dbPath) as DatabaseInstance
 			this.db.exec("PRAGMA journal_mode=WAL")
 			this.db.exec("PRAGMA busy_timeout=3000")
 			return true
@@ -82,7 +88,7 @@ export class HitlDatabase {
 	 * @param params - Bound parameters
 	 * @returns true if executed successfully, false otherwise
 	 */
-	run(sql: string, params: unknown[] = []): boolean {
+	run(sql: string, params: (string | number | null)[] = []): boolean {
 		if (!this.db) {
 			console.warn("[HitlDatabase] Cannot run: database not open")
 			return false
@@ -109,7 +115,7 @@ export class HitlDatabase {
 	 * @param params - Bound parameters
 	 * @returns Array of results (empty on error)
 	 */
-	query<T extends Record<string, unknown>>(sql: string, params: unknown[] = []): T[] {
+	query<T extends Record<string, unknown>>(sql: string, params: (string | number | null)[] = []): T[] {
 		if (!this.db) {
 			console.warn("[HitlDatabase] Cannot query: database not open")
 			return []
@@ -157,7 +163,7 @@ export class HitlDatabase {
 	 * Get the underlying Database instance for advanced operations.
 	 * Returns null if closed or not open.
 	 */
-	get raw(): BunDatabase | null {
+	get raw(): DatabaseInstance | null {
 		return this.isClosed ? null : this.db
 	}
 }

--- a/extensions/hitl-metrics/storage/db.ts
+++ b/extensions/hitl-metrics/storage/db.ts
@@ -1,0 +1,158 @@
+/**
+ * HITL Database Wrapper
+ *
+ * Thin wrapper around bun:sqlite with non-fatal error handling,
+ * WAL mode, and schema initialization.
+ */
+
+import { Database } from "bun:sqlite"
+import { SESSIONS_TABLE_SQL, EVENTS_TABLE_SQL, PROJECT_HASH_INDEX_SQL, SESSION_ID_INDEX_SQL } from "./schema.ts"
+
+/**
+ * Non-fatal database wrapper for HITL metrics.
+ * All operations catch errors, log warnings, and return safe defaults.
+ */
+export class HitlDatabase {
+	private db: Database | null = null
+	private dbPath: string
+	private isClosed = false
+
+	/**
+	 * @param dbPath - Path to SQLite file, or ":memory:" for tests
+	 */
+	constructor(dbPath: string) {
+		this.dbPath = dbPath
+	}
+
+	/**
+	 * Open the database connection with WAL mode enabled.
+	 * @returns true if successfully opened, false otherwise
+	 */
+	open(): boolean {
+		try {
+			this.db = new Database(this.dbPath)
+			this.db.exec("PRAGMA journal_mode=WAL")
+			this.db.exec("PRAGMA busy_timeout=3000")
+			return true
+		} catch (error) {
+			const message = error instanceof Error ? error.message : String(error)
+			console.warn(`[HitlDatabase] Failed to open database at ${this.dbPath}: ${message}`)
+			this.db = null
+			return false
+		}
+	}
+
+	/**
+	 * Initialize schema (tables and indexes).
+	 * Safe to call multiple times (uses IF NOT EXISTS).
+	 * @returns true if successful, false otherwise
+	 */
+	initSchema(): boolean {
+		if (!this.db) {
+			console.warn("[HitlDatabase] Cannot init schema: database not open")
+			return false
+		}
+		if (this.isClosed) {
+			console.warn("[HitlDatabase] Cannot init schema: database is closed")
+			return false
+		}
+		try {
+			this.db.exec(SESSIONS_TABLE_SQL)
+			this.db.exec(EVENTS_TABLE_SQL)
+			this.db.exec(PROJECT_HASH_INDEX_SQL)
+			this.db.exec(SESSION_ID_INDEX_SQL)
+			return true
+		} catch (error) {
+			const message = error instanceof Error ? error.message : String(error)
+			console.warn(`[HitlDatabase] Schema initialization failed: ${message}`)
+			return false
+		}
+	}
+
+	/**
+	 * Execute a SQL statement with optional parameters.
+	 * Non-fatal: logs on error, returns boolean success.
+	 *
+	 * @param sql - SQL statement
+	 * @param params - Bound parameters
+	 * @returns true if executed successfully, false otherwise
+	 */
+	run(sql: string, params: unknown[] = []): boolean {
+		if (!this.db) {
+			console.warn("[HitlDatabase] Cannot run: database not open")
+			return false
+		}
+		if (this.isClosed) {
+			console.warn("[HitlDatabase] Cannot run: database is closed")
+			return false
+		}
+		try {
+			this.db.run(sql, params)
+			return true
+		} catch (error) {
+			const message = error instanceof Error ? error.message : String(error)
+			console.warn(`[HitlDatabase] Query failed: ${message} | SQL: ${sql.slice(0, 100)}`)
+			return false
+		}
+	}
+
+	/**
+	 * Execute a query and return typed results.
+	 * Non-fatal: logs on error, returns empty array on failure.
+	 *
+	 * @param sql - SELECT statement
+	 * @param params - Bound parameters
+	 * @returns Array of results (empty on error)
+	 */
+	query<T extends Record<string, unknown>>(sql: string, params: unknown[] = []): T[] {
+		if (!this.db) {
+			console.warn("[HitlDatabase] Cannot query: database not open")
+			return []
+		}
+		if (this.isClosed) {
+			console.warn("[HitlDatabase] Cannot query: database is closed")
+			return []
+		}
+		try {
+			const stmt = this.db.query(sql)
+			return stmt.all(...params) as T[]
+		} catch (error) {
+			const message = error instanceof Error ? error.message : String(error)
+			console.warn(`[HitlDatabase] Query failed: ${message} | SQL: ${sql.slice(0, 100)}`)
+			return []
+		}
+	}
+
+	/**
+	 * Close the database connection.
+	 * Safe to call multiple times.
+	 */
+	close(): void {
+		if (this.isClosed || !this.db) {
+			return
+		}
+		try {
+			this.db.close()
+			this.isClosed = true
+			this.db = null
+		} catch (error) {
+			const message = error instanceof Error ? error.message : String(error)
+			console.warn(`[HitlDatabase] Error closing database: ${message}`)
+		}
+	}
+
+	/**
+	 * Check if database is open and ready for operations.
+	 */
+	get isOpen(): boolean {
+		return this.db !== null && !this.isClosed
+	}
+
+	/**
+	 * Get the underlying Database instance for advanced operations.
+	 * Returns null if closed or not open.
+	 */
+	get raw(): Database | null {
+		return this.isClosed ? null : this.db
+	}
+}

--- a/extensions/hitl-metrics/storage/db.ts
+++ b/extensions/hitl-metrics/storage/db.ts
@@ -9,7 +9,17 @@
 // We use dynamic require to avoid TypeScript errors during Node.js builds
 // eslint-disable-next-line @typescript-eslint/no-var-requires
 const { Database } = require("bun:sqlite")
-import { SESSIONS_TABLE_SQL, EVENTS_TABLE_SQL, PROJECT_HASH_INDEX_SQL, SESSION_ID_INDEX_SQL } from "./schema.js"
+import {
+	SESSIONS_TABLE_SQL,
+	EVENTS_TABLE_SQL,
+	ACTIVITY_EVENTS_TABLE_SQL,
+	PERMISSION_EVENTS_TABLE_SQL,
+	PROJECT_HASH_INDEX_SQL,
+	SESSION_ID_INDEX_SQL,
+	ACTIVITY_SESSION_ID_INDEX_SQL,
+	ACTIVITY_TIMESTAMP_INDEX_SQL,
+	PERMISSION_SESSION_ID_INDEX_SQL,
+} from "./schema.js"
 
 // Minimal type for Database at build time
 type DatabaseInstance = {
@@ -56,6 +66,8 @@ export class HitlDatabase {
 	/**
 	 * Initialize schema (tables and indexes).
 	 * Safe to call multiple times (uses IF NOT EXISTS).
+	 * Detects and migrates old-schema databases created before the
+	 * status/end_cause redesign.
 	 * @returns true if successful, false otherwise
 	 */
 	initSchema(): boolean {
@@ -68,15 +80,81 @@ export class HitlDatabase {
 			return false
 		}
 		try {
+			// Attempt CREATE TABLE IF NOT EXISTS first — works for new databases
 			this.db.exec(SESSIONS_TABLE_SQL)
 			this.db.exec(EVENTS_TABLE_SQL)
+			this.db.exec(ACTIVITY_EVENTS_TABLE_SQL)
+			this.db.exec(PERMISSION_EVENTS_TABLE_SQL)
 			this.db.exec(PROJECT_HASH_INDEX_SQL)
 			this.db.exec(SESSION_ID_INDEX_SQL)
+			this.db.exec(ACTIVITY_SESSION_ID_INDEX_SQL)
+			this.db.exec(ACTIVITY_TIMESTAMP_INDEX_SQL)
+			this.db.exec(PERMISSION_SESSION_ID_INDEX_SQL)
+
+			// Migration: detect old-schema tables that exist but lack the new columns.
+			// The old schema had "complete INTEGER" and "metadata_json TEXT" columns.
+			// The new schema uses "status TEXT" and "end_cause TEXT" instead.
+			this.migrateOldSchema()
+
 			return true
 		} catch (error) {
 			const message = error instanceof Error ? error.message : String(error)
 			console.warn(`[HitlDatabase] Schema initialization failed: ${message}`)
 			return false
+		}
+	}
+
+	/**
+	 * Migrate databases created with the old hitl_sessions schema.
+	 * The old table had: id, project_hash, started_at, ended_at, complete, metadata_json
+	 * The new table has: id, project_hash, started_at, ended_at, status, end_cause, agent_time_ms, hitl_time_ms, idle_time_ms
+	 *
+	 * Migration strategy:
+	 * - Add missing columns (status, end_cause, agent_time_ms, hitl_time_ms, idle_time_ms)
+	 * - Populate status from old 'complete' flag (1=closed, 0=active), NULL ended_at → active
+	 * - Leave orphaned rows to be cleaned up by closeOrphanSessions()
+	 */
+	private migrateOldSchema(): void {
+		if (!this.db) return
+		try {
+			// Check if this is the old schema by probing for the 'complete' column
+			const pragmaRows = this.db.query("PRAGMA table_info(hitl_sessions)").all() as Array<{ name: string }>
+			const columnNames = new Set(pragmaRows.map((r) => r.name))
+
+			if (!columnNames.has("complete")) return // Already new schema
+
+			console.warn("[HitlDatabase] Detected old-schema database, migrating...")
+
+			// Add new columns that are missing
+			const alterOps: Array<[string, string]> = [
+				["status", "TEXT NOT NULL DEFAULT 'active' CHECK (status IN ('active', 'closed', 'orphaned'))"],
+				["end_cause", "TEXT CHECK (end_cause IN ('complete', 'disconnect', 'signal', 'orphaned'))"],
+				["agent_time_ms", "INTEGER NOT NULL DEFAULT 0"],
+				["hitl_time_ms", "INTEGER NOT NULL DEFAULT 0"],
+				["idle_time_ms", "INTEGER NOT NULL DEFAULT 0"],
+			]
+
+			for (const [colName, colDef] of alterOps) {
+				if (!columnNames.has(colName)) {
+					this.db.exec(`ALTER TABLE hitl_sessions ADD COLUMN ${colName} ${colDef}`)
+				}
+			}
+
+			// Migrate data: closed sessions where complete=1
+			this.db.exec(`
+				UPDATE hitl_sessions
+				SET status = 'closed', end_cause = 'complete'
+				WHERE complete = 1 AND status IS NULL
+			`)
+
+			// Sessions with NULL ended_at and complete=0 stay 'active'
+			// Sessions with NULL ended_at and complete=1 get status from above
+
+			console.warn("[HitlDatabase] Migration complete.")
+		} catch (error) {
+			// Non-fatal: log and continue
+			const message = error instanceof Error ? error.message : String(error)
+			console.warn(`[HitlDatabase] Migration failed (non-fatal): ${message}`)
 		}
 	}
 
@@ -126,7 +204,9 @@ export class HitlDatabase {
 		}
 		try {
 			const stmt = this.db.query(sql)
-			return stmt.all(...params) as T[]
+			// Use Function.prototype.apply to spread array params as individual arguments.
+			// stmt.all(...[a, b]) fails in Bun — .apply(stmt, [a, b]) works correctly.
+			return (stmt.all as (...args: unknown[]) => unknown[]).apply(stmt, params) as T[]
 		} catch (error) {
 			const message = error instanceof Error ? error.message : String(error)
 			console.warn(`[HitlDatabase] Query failed: ${message} | SQL: ${sql.slice(0, 100)}`)

--- a/extensions/hitl-metrics/storage/hash.test.ts
+++ b/extensions/hitl-metrics/storage/hash.test.ts
@@ -3,7 +3,7 @@
  */
 
 import { describe, it, expect } from "vitest"
-import { projectHash } from "./hash.ts"
+import { projectHash } from "./hash.js"
 
 describe("projectHash", () => {
 	it("returns 16 hex characters for a valid path", () => {

--- a/extensions/hitl-metrics/storage/hash.test.ts
+++ b/extensions/hitl-metrics/storage/hash.test.ts
@@ -1,0 +1,46 @@
+/**
+ * Project Hash Unit Tests
+ */
+
+import { describe, it, expect } from "vitest"
+import { projectHash } from "./hash.ts"
+
+describe("projectHash", () => {
+	it("returns 16 hex characters for a valid path", () => {
+		const hash = projectHash("/Users/dev/myproject")
+		expect(hash).toHaveLength(16)
+		expect(hash).toMatch(/^[0-9a-f]+$/)
+	})
+
+	it("is deterministic - same input produces same output", () => {
+		const path = "/Users/dev/myproject"
+		const hash1 = projectHash(path)
+		const hash2 = projectHash(path)
+		expect(hash1).toBe(hash2)
+	})
+
+	it("produces different hashes for different paths", () => {
+		const hash1 = projectHash("/Users/dev/project1")
+		const hash2 = projectHash("/Users/dev/project2")
+		expect(hash1).not.toBe(hash2)
+	})
+
+	it("handles empty string", () => {
+		const hash = projectHash("")
+		expect(hash).toHaveLength(16)
+		expect(hash).toMatch(/^[0-9a-f]+$/)
+	})
+
+	it("handles paths with special characters", () => {
+		const hash = projectHash("/Users/dev/my-project_v2.0/test")
+		expect(hash).toHaveLength(16)
+		expect(hash).toMatch(/^[0-9a-f]+$/)
+	})
+
+	it("handles very long paths", () => {
+		const longPath = "/Users/dev/" + "a".repeat(500)
+		const hash = projectHash(longPath)
+		expect(hash).toHaveLength(16)
+		expect(hash).toMatch(/^[0-9a-f]+$/)
+	})
+})

--- a/extensions/hitl-metrics/storage/hash.ts
+++ b/extensions/hitl-metrics/storage/hash.ts
@@ -1,0 +1,18 @@
+/**
+ * Project Hash Utility
+ *
+ * Generates deterministic hashes for project path identification.
+ */
+
+import { createHash } from "node:crypto"
+
+/**
+ * Generate a project hash from a realpath string.
+ * Uses SHA-256 truncated to first 16 hex characters.
+ *
+ * @param realpath - Absolute project path
+ * @returns 16-character hex hash string
+ */
+export function projectHash(realpath: string): string {
+	return createHash("sha256").update(realpath).digest("hex").slice(0, 16)
+}

--- a/extensions/hitl-metrics/storage/index.ts
+++ b/extensions/hitl-metrics/storage/index.ts
@@ -4,9 +4,9 @@
  * Boundary contract for S02 consumption.
  */
 
-export { HitlDatabase } from "./db.ts"
-export { SESSIONS_TABLE_SQL, EVENTS_TABLE_SQL, PROJECT_HASH_INDEX_SQL, SESSION_ID_INDEX_SQL } from "./schema.ts"
-export { projectHash } from "./hash.ts"
+export { HitlDatabase } from "./db.js"
+export { SESSIONS_TABLE_SQL, EVENTS_TABLE_SQL, PROJECT_HASH_INDEX_SQL, SESSION_ID_INDEX_SQL } from "./schema.js"
+export { projectHash } from "./hash.js"
 export {
 	getOrCreateSession,
 	closeSession,
@@ -14,4 +14,4 @@ export {
 	getRecentSessions,
 	getSessionStats,
 	getSessionEvents,
-} from "./session.ts"
+} from "./session.js"

--- a/extensions/hitl-metrics/storage/index.ts
+++ b/extensions/hitl-metrics/storage/index.ts
@@ -1,0 +1,17 @@
+/**
+ * HITL Metrics Storage Barrel Export
+ *
+ * Boundary contract for S02 consumption.
+ */
+
+export { HitlDatabase } from "./db.ts"
+export { SESSIONS_TABLE_SQL, EVENTS_TABLE_SQL, PROJECT_HASH_INDEX_SQL, SESSION_ID_INDEX_SQL } from "./schema.ts"
+export { projectHash } from "./hash.ts"
+export {
+	getOrCreateSession,
+	closeSession,
+	closeOrphanSessions,
+	getRecentSessions,
+	getSessionStats,
+	getSessionEvents,
+} from "./session.ts"

--- a/extensions/hitl-metrics/storage/index.ts
+++ b/extensions/hitl-metrics/storage/index.ts
@@ -5,13 +5,29 @@
  */
 
 export { HitlDatabase } from "./db.js"
-export { SESSIONS_TABLE_SQL, EVENTS_TABLE_SQL, PROJECT_HASH_INDEX_SQL, SESSION_ID_INDEX_SQL } from "./schema.js"
-export { projectHash } from "./hash.js"
 export {
-	getOrCreateSession,
+	SESSIONS_TABLE_SQL,
+	EVENTS_TABLE_SQL,
+	ACTIVITY_EVENTS_TABLE_SQL,
+	PERMISSION_EVENTS_TABLE_SQL,
+	PROJECT_HASH_INDEX_SQL,
+	SESSION_ID_INDEX_SQL,
+	ACTIVITY_SESSION_ID_INDEX_SQL,
+	ACTIVITY_TIMESTAMP_INDEX_SQL,
+	PERMISSION_SESSION_ID_INDEX_SQL,
+} from "./schema.js"
+export { projectHash } from "./hash.js"
+export type { EndCause } from "./session.js"
+export {
 	closeSession,
 	closeOrphanSessions,
+	getOrCreateSession,
 	getRecentSessions,
-	getSessionStats,
+	getSessionActivityEvents,
 	getSessionEvents,
+	getSessionPermissionEvents,
+	getSessionStats,
+	recordActivityEvent,
+	recordPermissionEvent,
+	updateSessionTimes,
 } from "./session.js"

--- a/extensions/hitl-metrics/storage/schema.ts
+++ b/extensions/hitl-metrics/storage/schema.ts
@@ -1,0 +1,40 @@
+/**
+ * Database Schema SQL
+ *
+ * CREATE TABLE statements for HITL metrics storage.
+ */
+
+/** SQL to create the hitl_sessions table */
+export const SESSIONS_TABLE_SQL = `
+CREATE TABLE IF NOT EXISTS hitl_sessions (
+    id TEXT PRIMARY KEY,
+    project_hash TEXT NOT NULL,
+    started_at INTEGER NOT NULL,
+    ended_at INTEGER,
+    status TEXT NOT NULL CHECK (status IN ('active', 'closed', 'orphaned'))
+)
+`
+
+/** SQL to create the hitl_events table */
+export const EVENTS_TABLE_SQL = `
+CREATE TABLE IF NOT EXISTS hitl_events (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    session_id TEXT NOT NULL,
+    tool_name TEXT NOT NULL,
+    question_count INTEGER NOT NULL DEFAULT 0,
+    duration_ms INTEGER NOT NULL DEFAULT 0,
+    selected_options TEXT NOT NULL DEFAULT '[]',
+    created_at INTEGER NOT NULL,
+    FOREIGN KEY (session_id) REFERENCES hitl_sessions(id) ON DELETE CASCADE
+)
+`
+
+/** Index for efficient project-scoped queries */
+export const PROJECT_HASH_INDEX_SQL = `
+CREATE INDEX IF NOT EXISTS idx_sessions_project_hash ON hitl_sessions(project_hash)
+`
+
+/** Index for efficient session-scoped event queries */
+export const SESSION_ID_INDEX_SQL = `
+CREATE INDEX IF NOT EXISTS idx_events_session_id ON hitl_events(session_id)
+`

--- a/extensions/hitl-metrics/storage/schema.ts
+++ b/extensions/hitl-metrics/storage/schema.ts
@@ -11,7 +11,11 @@ CREATE TABLE IF NOT EXISTS hitl_sessions (
     project_hash TEXT NOT NULL,
     started_at INTEGER NOT NULL,
     ended_at INTEGER,
-    status TEXT NOT NULL CHECK (status IN ('active', 'closed', 'orphaned'))
+    status TEXT NOT NULL CHECK (status IN ('active', 'closed', 'orphaned')),
+    end_cause TEXT CHECK (end_cause IN ('complete', 'disconnect', 'signal', 'orphaned')),
+    agent_time_ms INTEGER NOT NULL DEFAULT 0,
+    hitl_time_ms INTEGER NOT NULL DEFAULT 0,
+    idle_time_ms INTEGER NOT NULL DEFAULT 0
 )
 `
 
@@ -29,6 +33,34 @@ CREATE TABLE IF NOT EXISTS hitl_events (
 )
 `
 
+/** SQL to create the activity_events table for detailed timeline tracking */
+export const ACTIVITY_EVENTS_TABLE_SQL = `
+CREATE TABLE IF NOT EXISTS activity_events (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    session_id TEXT NOT NULL,
+    activity_type TEXT NOT NULL CHECK (activity_type IN ('tool_start', 'tool_end', 'user_input', 'idle_start', 'idle_end')),
+    tool_name TEXT,
+    duration_ms INTEGER,
+    timestamp INTEGER NOT NULL,
+    FOREIGN KEY (session_id) REFERENCES hitl_sessions(id) ON DELETE CASCADE
+)
+`
+
+/** SQL to create the permission_events table for tracking permission approvals/denials */
+export const PERMISSION_EVENTS_TABLE_SQL = `
+CREATE TABLE IF NOT EXISTS hitl_permission_events (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    session_id TEXT NOT NULL,
+    tool_name TEXT NOT NULL,
+    action TEXT NOT NULL,
+    outcome TEXT NOT NULL CHECK (outcome IN ('allow', 'allow_once', 'allow_remember', 'deny', 'deny_feedback', 'blocked')),
+    reason TEXT,
+    duration_ms INTEGER NOT NULL DEFAULT 0,
+    created_at INTEGER NOT NULL,
+    FOREIGN KEY (session_id) REFERENCES hitl_sessions(id) ON DELETE CASCADE
+)
+`
+
 /** Index for efficient project-scoped queries */
 export const PROJECT_HASH_INDEX_SQL = `
 CREATE INDEX IF NOT EXISTS idx_sessions_project_hash ON hitl_sessions(project_hash)
@@ -37,4 +69,19 @@ CREATE INDEX IF NOT EXISTS idx_sessions_project_hash ON hitl_sessions(project_ha
 /** Index for efficient session-scoped event queries */
 export const SESSION_ID_INDEX_SQL = `
 CREATE INDEX IF NOT EXISTS idx_events_session_id ON hitl_events(session_id)
+`
+
+/** Index for efficient activity event queries */
+export const ACTIVITY_SESSION_ID_INDEX_SQL = `
+CREATE INDEX IF NOT EXISTS idx_activity_session_id ON activity_events(session_id)
+`
+
+/** Index for efficient activity timestamp queries */
+export const ACTIVITY_TIMESTAMP_INDEX_SQL = `
+CREATE INDEX IF NOT EXISTS idx_activity_timestamp ON activity_events(session_id, timestamp)
+`
+
+/** Index for efficient permission event queries by session */
+export const PERMISSION_SESSION_ID_INDEX_SQL = `
+CREATE INDEX IF NOT EXISTS idx_permission_session_id ON hitl_permission_events(session_id)
 `

--- a/extensions/hitl-metrics/storage/session.test.ts
+++ b/extensions/hitl-metrics/storage/session.test.ts
@@ -10,6 +10,8 @@ import {
 	closeOrphanSessions,
 	getRecentSessions,
 	getSessionStats,
+	recordPermissionEvent,
+	getSessionPermissionEvents,
 } from "./session.js"
 
 describe("Session Management", () => {
@@ -37,7 +39,7 @@ describe("Session Management", () => {
 			expect(typeof session?.id).toBe("string")
 		})
 
-		it("returns existing active session within 5-minute window", () => {
+		it("returns existing active session within 2.hour window", () => {
 			const first = getOrCreateSession(db, "project-abc-123")
 			const second = getOrCreateSession(db, "project-abc-123")
 
@@ -56,8 +58,9 @@ describe("Session Management", () => {
 			expect(second?.id).not.toBe(first?.id)
 		})
 
-		it("creates new session when old session exceeded 5-min timeout", () => {
-			const oldTime = Date.now() - 6 * 60 * 1000
+		it("creates new session when old session exceeded 2.h timeout", async () => {
+			// Insert active session 3 hours ago — beyond the 2h resume window
+			const oldTime = Date.now() - 3 * 60 * 60 * 1000
 			db.run(
 				"INSERT INTO hitl_sessions (id, project_hash, started_at, status) VALUES (?, ?, ?, ?)",
 				["old-session-id", "project-abc-123", oldTime, "active"],
@@ -192,11 +195,11 @@ describe("Session Management", () => {
 			consoleSpy.mockRestore()
 		})
 
-		it("uses default threshold of 5 minutes", () => {
-			const sixMinsAgo = Date.now() - 6 * 60 * 1000
+		it("uses default threshold of 2 hours", () => {
+			const threeHoursAgo = Date.now() - 3 * 60 * 60 * 1000
 			db.run(
 				"INSERT INTO hitl_sessions (id, project_hash, started_at, status) VALUES (?, ?, ?, ?)",
-				["orphan-default", "project-x", sixMinsAgo, "active"],
+				["orphan-default", "project-x", threeHoursAgo, "active"],
 			)
 
 			const count = closeOrphanSessions(db)
@@ -225,7 +228,7 @@ describe("Session Management", () => {
 				["session-newest", "project-x", 3000, "closed"],
 			)
 
-			const sessions = getRecentSessions(db, "project-x")
+			const sessions = getRecentSessions(db)
 
 			expect(sessions).toHaveLength(3
 )
@@ -235,7 +238,7 @@ describe("Session Management", () => {
 		})
 
 		it("returns empty array when no sessions exist", () => {
-			const sessions = getRecentSessions(db, "nonexistent-project")
+			const sessions = getRecentSessions(db)
 			expect(sessions).toEqual([])
 		})
 
@@ -253,7 +256,7 @@ describe("Session Management", () => {
 				["session-3", "project-x", 3000, "closed"],
 			)
 
-			const sessions = getRecentSessions(db, "project-x", 2)
+			const sessions = getRecentSessions(db, 2)
 			expect(sessions).toHaveLength(2)
 			expect(sessions[0].id).toBe("session-3")
 			expect(sessions[1].id).toBe("session-2")
@@ -267,11 +270,11 @@ describe("Session Management", () => {
 				)
 			}
 
-			const sessions = getRecentSessions(db, "project-x")
+			const sessions = getRecentSessions(db)
 			expect(sessions.length).toBeLessThanOrEqual(10)
 		})
 
-		it("filters by project hash", () => {
+		it("returns all sessions from the DB (no hash filter needed — DB is project-scoped)", () => {
 			db.run(
 				"INSERT INTO hitl_sessions (id, project_hash, started_at, status) VALUES (?, ?, ?, ?)",
 				["session-a", "project-a", 1000, "active"],
@@ -281,21 +284,23 @@ describe("Session Management", () => {
 				["session-b", "project-b", 2000, "active"],
 			)
 
-			const sessionsA = getRecentSessions(db, "project-a")
-			expect(sessionsA).toHaveLength(1)
-			expect(sessionsA[0].project_hash).toBe("project-a")
+			const sessions = getRecentSessions(db)
+			// Both sessions returned — DB is already scoped to one project
+			expect(sessions).toHaveLength(2)
+			expect(sessions[0].id).toBe("session-b") // newest first
+			expect(sessions[1].id).toBe("session-a")
 		})
 
 		it("returns empty array on database closure", () => {
 			db.close()
-			const sessions = getRecentSessions(db, "project-x")
+			const sessions = getRecentSessions(db)
 			expect(sessions).toEqual([])
 		})
 	})
 
 	describe("getSessionStats", () => {
 		it("returns zeros for empty project", () => {
-			const stats = getSessionStats(db, "empty-project")
+			const stats = getSessionStats(db)
 
 			expect(stats.total_sessions).toBe(0)
 			expect(stats.total_hitl_time_ms).toBe(0)
@@ -304,14 +309,14 @@ describe("Session Management", () => {
 		})
 
 		it("returns correct aggregates", () => {
-			// Create session
+			// Create sessions with hitl_time_ms set (stats now reads from sessions, not events)
 			db.run(
-				"INSERT INTO hitl_sessions (id, project_hash, started_at, status) VALUES (?, ?, ?, ?)",
-				["session-1", "project-x", 1000, "active"],
+				"INSERT INTO hitl_sessions (id, project_hash, started_at, status, hitl_time_ms) VALUES (?, ?, ?, ?, ?)",
+				["session-1", "project-x", 1000, "active", 3000],
 			)
 			db.run(
-				"INSERT INTO hitl_sessions (id, project_hash, started_at, status) VALUES (?, ?, ?, ?)",
-				["session-2", "project-x", 2000, "closed"],
+				"INSERT INTO hitl_sessions (id, project_hash, started_at, status, hitl_time_ms) VALUES (?, ?, ?, ?, ?)",
+				["session-2", "project-x", 2000, "closed", 3000],
 			)
 
 			// Create events
@@ -328,7 +333,7 @@ describe("Session Management", () => {
 				["session-2", "tool-c", 3, 3000, "[]", 5000],
 			)
 
-			const stats = getSessionStats(db, "project-x")
+			const stats = getSessionStats(db)
 
 			expect(stats.total_sessions).toBe(2)
 			expect(stats.interaction_count).toBe(3)
@@ -346,7 +351,7 @@ describe("Session Management", () => {
 				["session-1", "tool-a", 1, 5000, "[]", 2000],
 			)
 
-			const stats = getSessionStats(db, "project-x")
+			const stats = getSessionStats(db)
 
 			expect(stats.avg_wait_ms).toBe(5000)
 		})
@@ -357,7 +362,7 @@ describe("Session Management", () => {
 				["session-1", "project-x", 1000, "active"],
 			)
 
-			const stats = getSessionStats(db, "project-x")
+			const stats = getSessionStats(db)
 
 			expect(stats.total_sessions).toBe(1)
 			expect(stats.interaction_count).toBe(0)
@@ -365,7 +370,7 @@ describe("Session Management", () => {
 			expect(stats.avg_wait_ms).toBe(0)
 		})
 
-		it("filters by project hash", () => {
+		it("counts all sessions in DB (no hash filter needed — DB is project-scoped)", () => {
 			db.run(
 				"INSERT INTO hitl_sessions (id, project_hash, started_at, status) VALUES (?, ?, ?, ?)",
 				["session-a", "project-a", 1000, "active"],
@@ -375,18 +380,152 @@ describe("Session Management", () => {
 				["session-b", "project-b", 2000, "active"],
 			)
 
-			const statsA = getSessionStats(db, "project-a")
-			expect(statsA.total_sessions).toBe(1)
+			const stats = getSessionStats(db)
+			expect(stats.total_sessions).toBe(2) // Both sessions counted — DB is already project-scoped
 		})
 
 		it("returns zeros on database closure", () => {
 			db.close()
-			const stats = getSessionStats(db, "project-x")
+			const stats = getSessionStats(db)
 
 			expect(stats.total_sessions).toBe(0)
 			expect(stats.total_hitl_time_ms).toBe(0)
 			expect(stats.interaction_count).toBe(0)
 			expect(stats.avg_wait_ms).toBe(0)
+		})
+	})
+
+	describe("recordPermissionEvent", () => {
+		it("records a permission event", () => {
+			db.run(
+				"INSERT INTO hitl_sessions (id, project_hash, started_at, status) VALUES (?, ?, ?, ?)",
+				["session-perm", "project-x", 1000, "active"],
+			)
+
+			const result = recordPermissionEvent(
+				db,
+				"session-perm",
+				"bash",
+				"rm -rf /tmp/*",
+				"allow",
+				500,
+			)
+
+			expect(result).toBe(true)
+
+			const events = getSessionPermissionEvents(db, "session-perm")
+			expect(events).toHaveLength(1)
+			expect(events[0].tool_name).toBe("bash")
+			expect(events[0].action).toBe("rm -rf /tmp/*")
+			expect(events[0].outcome).toBe("allow")
+			expect(events[0].duration_ms).toBe(500)
+		})
+
+		it("records different outcomes", () => {
+			db.run(
+				"INSERT INTO hitl_sessions (id, project_hash, started_at, status) VALUES (?, ?, ?, ?)",
+				["session-outcomes", "project-x", 1000, "active"],
+			)
+
+			recordPermissionEvent(db, "session-outcomes", "bash", "cmd1", "allow", 100)
+			recordPermissionEvent(db, "session-outcomes", "bash", "cmd2", "allow_once", 200)
+			recordPermissionEvent(db, "session-outcomes", "bash", "cmd3", "deny", 300)
+			recordPermissionEvent(db, "session-outcomes", "bash", "cmd4", "blocked", 400, "Denied by rule")
+
+			const events = getSessionPermissionEvents(db, "session-outcomes")
+			expect(events).toHaveLength(4)
+			expect(events[0].outcome).toBe("allow")
+			expect(events[1].outcome).toBe("allow_once")
+			expect(events[2].outcome).toBe("deny")
+			expect(events[3].outcome).toBe("blocked")
+			expect(events[3].reason).toBe("Denied by rule")
+		})
+
+		it("is non-fatal when database is closed", () => {
+			db.close()
+			const result = recordPermissionEvent(
+				db,
+				"session-perm",
+				"bash",
+				"cmd",
+				"deny",
+				100,
+			)
+			expect(result).toBe(false)
+		})
+
+		it("is non-fatal when session does not exist", () => {
+			const result = recordPermissionEvent(
+				db,
+				"nonexistent-session",
+				"bash",
+				"cmd",
+				"allow",
+				100,
+			)
+			expect(result).toBe(false)
+		})
+	})
+
+	describe("getSessionPermissionEvents", () => {
+		it("returns empty array when no permission events exist", () => {
+			db.run(
+				"INSERT INTO hitl_sessions (id, project_hash, started_at, status) VALUES (?, ?, ?, ?)",
+				["session-empty", "project-x", 1000, "active"],
+			)
+
+			const events = getSessionPermissionEvents(db, "session-empty")
+			expect(events).toEqual([])
+		})
+
+		it("returns events in chronological order", () => {
+			db.run(
+				"INSERT INTO hitl_sessions (id, project_hash, started_at, status) VALUES (?, ?, ?, ?)",
+				["session-chron", "project-x", 1000, "active"],
+			)
+
+			recordPermissionEvent(db, "session-chron", "write", "file1", "allow", 100)
+			recordPermissionEvent(db, "session-chron", "write", "file2", "allow", 200)
+
+			const events = getSessionPermissionEvents(db, "session-chron")
+			expect(events).toHaveLength(2)
+			expect(events[0].action).toBe("file1")
+			expect(events[1].action).toBe("file2")
+		})
+
+		it("returns empty array on database closure", () => {
+			db.close()
+			const events = getSessionPermissionEvents(db, "any-session")
+			expect(events).toEqual([])
+		})
+	})
+
+	describe("getSessionStats with permission events", () => {
+		it("aggregates permission event stats", () => {
+			db.run(
+				"INSERT INTO hitl_sessions (id, project_hash, started_at, status) VALUES (?, ?, ?, ?)",
+				["session-perm-stats", "project-perm", 1000, "active"],
+			)
+
+			recordPermissionEvent(db, "session-perm-stats", "bash", "cmd1", "allow", 1000)
+			recordPermissionEvent(db, "session-perm-stats", "bash", "cmd2", "deny", 500)
+
+			const stats = getSessionStats(db)
+
+			expect(stats.permission_count).toBe(2)
+			expect(stats.total_permission_time_ms).toBe(1500)
+		})
+
+		it("returns zero permission stats when no permission events", () => {
+			db.run(
+				"INSERT INTO hitl_sessions (id, project_hash, started_at, status) VALUES (?, ?, ?, ?)",
+				["session-no-perm", "project-no-perm", 1000, "active"],
+			)
+
+			const stats = getSessionStats(db)
+
+			expect(stats.permission_count).toBe(0)
+			expect(stats.total_permission_time_ms).toBe(0)
 		})
 	})
 })

--- a/extensions/hitl-metrics/storage/session.test.ts
+++ b/extensions/hitl-metrics/storage/session.test.ts
@@ -1,0 +1,392 @@
+/**
+ * HITL Session Management Unit Tests
+ */
+
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest"
+import { HitlDatabase } from "./db.ts"
+import {
+	getOrCreateSession,
+	closeSession,
+	closeOrphanSessions,
+	getRecentSessions,
+	getSessionStats,
+} from "./session.ts"
+
+describe("Session Management", () => {
+	let db: HitlDatabase
+
+	beforeEach(() => {
+		db = new HitlDatabase(":memory:")
+		db.open()
+		db.initSchema()
+	})
+
+	afterEach(() => {
+		db.close()
+	})
+
+	describe("getOrCreateSession", () => {
+		it("creates a new session when none exists", () => {
+			const session = getOrCreateSession(db, "project-abc-123")
+
+			expect(session).not.toBeNull()
+			expect(session?.project_hash).toBe("project-abc-123")
+			expect(session?.status).toBe("active")
+			expect(session?.ended_at).toBeNull()
+			expect(session?.started_at).toBeGreaterThan(0)
+			expect(typeof session?.id).toBe("string")
+		})
+
+		it("returns existing active session within 5-minute window", () => {
+			const first = getOrCreateSession(db, "project-abc-123")
+			const second = getOrCreateSession(db, "project-abc-123")
+
+			expect(first).not.toBeNull()
+			expect(second).not.toBeNull()
+			expect(second?.id).toBe(first?.id)
+		})
+
+		it("creates new session when old session was closed", () => {
+			const first = getOrCreateSession(db, "project-abc-123")
+			closeSession(db, first!.id)
+
+			const second = getOrCreateSession(db, "project-abc-123")
+
+			expect(second).not.toBeNull()
+			expect(second?.id).not.toBe(first?.id)
+		})
+
+		it("creates new session when old session exceeded 5-min timeout", () => {
+			const oldTime = Date.now() - 6 * 60 * 1000
+			db.run(
+				"INSERT INTO hitl_sessions (id, project_hash, started_at, status) VALUES (?, ?, ?, ?)",
+				["old-session-id", "project-abc-123", oldTime, "active"],
+			)
+
+			const session = getOrCreateSession(db, "project-abc-123")
+
+			expect(session).not.toBeNull()
+			expect(session?.id).not.toBe("old-session-id")
+			expect(session?.status).toBe("active")
+		})
+
+		it("isolates sessions by project hash", () => {
+			const sessionA = getOrCreateSession(db, "project-a")
+			const sessionB = getOrCreateSession(db, "project-b")
+
+			expect(sessionA?.id).not.toBe(sessionB?.id)
+			expect(sessionA?.project_hash).toBe("project-a")
+			expect(sessionB?.project_hash).toBe("project-b")
+		})
+
+		it("returns null on database closure", () => {
+			db.close()
+			const session = getOrCreateSession(db, "project-abc-123")
+			expect(session).toBeNull()
+		})
+	})
+
+	describe("closeSession", () => {
+		it("marks session as closed with ended_at", () => {
+			const session = getOrCreateSession(db, "project-x")
+			const closed = closeSession(db, session!.id)
+
+			expect(closed).toBe(true)
+
+			const queryResult = db.query<{ status: string; ended_at: number }>(
+				"SELECT status, ended_at FROM hitl_sessions WHERE id = ?",
+				[session!.id],
+			)
+			expect(queryResult[0].status).toBe("closed")
+			expect(queryResult[0].ended_at).toBeGreaterThan(0)
+		})
+
+		it("returns false for non-existent session", () => {
+			const result = closeSession(db, "non-existent-id")
+			expect(result).toBe(false)
+		})
+
+		it("is non-fatal (returns false) after database closure", () => {
+			const session = getOrCreateSession(db, "project-x")
+			db.close()
+			const closed = closeSession(db, session!.id)
+			expect(closed).toBe(false)
+		})
+	})
+
+	describe("closeOrphanSessions", () => {
+		it("closes sessions older than threshold", () => {
+			const oldTime = Date.now() - 10 * 60 * 1000
+			db.run(
+				"INSERT INTO hitl_sessions (id, project_hash, started_at, status) VALUES (?, ?, ?, ?)",
+				["orphan-1", "project-abc-123", oldTime, "active"],
+			)
+
+			const count = closeOrphanSessions(db, 5 * 60 * 1000)
+
+			expect(count).toBe(1)
+
+			const status = db.query<{ status: string }>(
+				"SELECT status FROM hitl_sessions WHERE id = ?",
+				["orphan-1"],
+			)
+			expect(status[0].status).toBe("orphaned")
+		})
+
+		it("does not close sessions within threshold", () => {
+			const recentTime = Date.now() - 2 * 60 * 1000
+			db.run(
+				"INSERT INTO hitl_sessions (id, project_hash, started_at, status) VALUES (?, ?, ?, ?)",
+				["active-session", "project-abc-123", recentTime, "active"],
+			)
+
+			const count = closeOrphanSessions(db, 5 * 60 * 1000)
+
+			expect(count).toBe(0)
+
+			const status = db.query<{ status: string }>(
+				"SELECT status FROM hitl_sessions WHERE id = ?",
+				["active-session"],
+			)
+			expect(status[0].status).toBe("active")
+		})
+
+		it("only targets active sessions", () => {
+			const oldTime = Date.now() - 10 * 60 * 1000
+			db.run(
+				"INSERT INTO hitl_sessions (id, project_hash, started_at, status, ended_at) VALUES (?, ?, ?, ?, ?)",
+				["already-closed", "project-abc-123", oldTime, "closed", oldTime + 1000],
+			)
+
+			const count = closeOrphanSessions(db, 5 * 60 * 1000)
+			expect(count).toBe(0)
+		})
+
+		it("closes multiple orphan sessions at once", () => {
+			const oldTime = Date.now() - 60 * 60 * 1000
+			db.run(
+				"INSERT INTO hitl_sessions (id, project_hash, started_at, status) VALUES (?, ?, ?, ?)",
+				["orphan-a", "project-a", oldTime, "active"],
+			)
+			db.run(
+				"INSERT INTO hitl_sessions (id, project_hash, started_at, status) VALUES (?, ?, ?, ?)",
+				["orphan-b", "project-b", oldTime, "active"],
+			)
+
+			const count = closeOrphanSessions(db, 5 * 60 * 1000)
+
+			expect(count).toBe(2)
+		})
+
+		it("logs warning when orphans are found", () => {
+			const consoleSpy = vi.spyOn(console, "warn").mockImplementation(() => {})
+			const oldTime = Date.now() - 10 * 60 * 1000
+			db.run(
+				"INSERT INTO hitl_sessions (id, project_hash, started_at, status) VALUES (?, ?, ?, ?)",
+				["orphan", "project-x", oldTime, "active"],
+			)
+
+			closeOrphanSessions(db, 5 * 60 * 1000)
+
+			expect(consoleSpy).toHaveBeenCalledWith("[HITL] Closed 1 orphan session(s)")
+			consoleSpy.mockRestore()
+		})
+
+		it("uses default threshold of 5 minutes", () => {
+			const sixMinsAgo = Date.now() - 6 * 60 * 1000
+			db.run(
+				"INSERT INTO hitl_sessions (id, project_hash, started_at, status) VALUES (?, ?, ?, ?)",
+				["orphan-default", "project-x", sixMinsAgo, "active"],
+			)
+
+			const count = closeOrphanSessions(db)
+			expect(count).toBe(1)
+		})
+
+		it("is non-fatal (returns 0) after database closure", () => {
+			db.close()
+			const count = closeOrphanSessions(db)
+			expect(count).toBe(0)
+		})
+	})
+
+	describe("getRecentSessions", () => {
+		it("returns sessions in descending order", () => {
+			db.run(
+				"INSERT INTO hitl_sessions (id, project_hash, started_at, status) VALUES (?, ?, ?, ?)",
+				["session-oldest", "project-x", 1000, "closed"],
+			)
+			db.run(
+				"INSERT INTO hitl_sessions (id, project_hash, started_at, status) VALUES (?, ?, ?, ?)",
+				["session-middle", "project-x", 2000, "active"],
+			)
+			db.run(
+				"INSERT INTO hitl_sessions (id, project_hash, started_at, status) VALUES (?, ?, ?, ?)",
+				["session-newest", "project-x", 3000, "closed"],
+			)
+
+			const sessions = getRecentSessions(db, "project-x")
+
+			expect(sessions).toHaveLength(3
+)
+			expect(sessions[0].id).toBe("session-newest")
+			expect(sessions[1].id).toBe("session-middle")
+			expect(sessions[2].id).toBe("session-oldest")
+		})
+
+		it("returns empty array when no sessions exist", () => {
+			const sessions = getRecentSessions(db, "nonexistent-project")
+			expect(sessions).toEqual([])
+		})
+
+		it("respects limit parameter", () => {
+			db.run(
+				"INSERT INTO hitl_sessions (id, project_hash, started_at, status) VALUES (?, ?, ?, ?)",
+				["session-1", "project-x", 1000, "closed"],
+			)
+			db.run(
+				"INSERT INTO hitl_sessions (id, project_hash, started_at, status) VALUES (?, ?, ?, ?)",
+				["session-2", "project-x", 2000, "active"],
+			)
+			db.run(
+				"INSERT INTO hitl_sessions (id, project_hash, started_at, status) VALUES (?, ?, ?, ?)",
+				["session-3", "project-x", 3000, "closed"],
+			)
+
+			const sessions = getRecentSessions(db, "project-x", 2)
+			expect(sessions).toHaveLength(2)
+			expect(sessions[0].id).toBe("session-3")
+			expect(sessions[1].id).toBe("session-2")
+		})
+
+		it("uses default limit of 10", () => {
+			for (let i = 0; i < 15; i++) {
+				db.run(
+					"INSERT INTO hitl_sessions (id, project_hash, started_at, status) VALUES (?, ?, ?, ?)",
+					[`session-${i}`, "project-x", 1000 + i, "active"],
+				)
+			}
+
+			const sessions = getRecentSessions(db, "project-x")
+			expect(sessions.length).toBeLessThanOrEqual(10)
+		})
+
+		it("filters by project hash", () => {
+			db.run(
+				"INSERT INTO hitl_sessions (id, project_hash, started_at, status) VALUES (?, ?, ?, ?)",
+				["session-a", "project-a", 1000, "active"],
+			)
+			db.run(
+				"INSERT INTO hitl_sessions (id, project_hash, started_at, status) VALUES (?, ?, ?, ?)",
+				["session-b", "project-b", 2000, "active"],
+			)
+
+			const sessionsA = getRecentSessions(db, "project-a")
+			expect(sessionsA).toHaveLength(1)
+			expect(sessionsA[0].project_hash).toBe("project-a")
+		})
+
+		it("returns empty array on database closure", () => {
+			db.close()
+			const sessions = getRecentSessions(db, "project-x")
+			expect(sessions).toEqual([])
+		})
+	})
+
+	describe("getSessionStats", () => {
+		it("returns zeros for empty project", () => {
+			const stats = getSessionStats(db, "empty-project")
+
+			expect(stats.total_sessions).toBe(0)
+			expect(stats.total_hitl_time_ms).toBe(0)
+			expect(stats.interaction_count).toBe(0)
+			expect(stats.avg_wait_ms).toBe(0)
+		})
+
+		it("returns correct aggregates", () => {
+			// Create session
+			db.run(
+				"INSERT INTO hitl_sessions (id, project_hash, started_at, status) VALUES (?, ?, ?, ?)",
+				["session-1", "project-x", 1000, "active"],
+			)
+			db.run(
+				"INSERT INTO hitl_sessions (id, project_hash, started_at, status) VALUES (?, ?, ?, ?)",
+				["session-2", "project-x", 2000, "closed"],
+			)
+
+			// Create events
+			db.run(
+				"INSERT INTO hitl_events (session_id, tool_name, question_count, duration_ms, selected_options, created_at) VALUES (?, ?, ?, ?, ?, ?)",
+				["session-1", "tool-a", 2, 1000, "[]", 3000],
+			)
+			db.run(
+				"INSERT INTO hitl_events (session_id, tool_name, question_count, duration_ms, selected_options, created_at) VALUES (?, ?, ?, ?, ?, ?)",
+				["session-1", "tool-b", 1, 2000, "[]", 4000],
+			)
+			db.run(
+				"INSERT INTO hitl_events (session_id, tool_name, question_count, duration_ms, selected_options, created_at) VALUES (?, ?, ?, ?, ?, ?)",
+				["session-2", "tool-c", 3, 3000, "[]", 5000],
+			)
+
+			const stats = getSessionStats(db, "project-x")
+
+			expect(stats.total_sessions).toBe(2)
+			expect(stats.interaction_count).toBe(3)
+			expect(stats.total_hitl_time_ms).toBe(6000)
+			expect(stats.avg_wait_ms).toBe(2000)
+		})
+
+		it("calculates average correctly for single event", () => {
+			db.run(
+				"INSERT INTO hitl_sessions (id, project_hash, started_at, status) VALUES (?, ?, ?, ?)",
+				["session-1", "project-x", 1000, "active"],
+			)
+			db.run(
+				"INSERT INTO hitl_events (session_id, tool_name, question_count, duration_ms, selected_options, created_at) VALUES (?, ?, ?, ?, ?, ?)",
+				["session-1", "tool-a", 1, 5000, "[]", 2000],
+			)
+
+			const stats = getSessionStats(db, "project-x")
+
+			expect(stats.avg_wait_ms).toBe(5000)
+		})
+
+		it("handles sessions with no events", () => {
+			db.run(
+				"INSERT INTO hitl_sessions (id, project_hash, started_at, status) VALUES (?, ?, ?, ?)",
+				["session-1", "project-x", 1000, "active"],
+			)
+
+			const stats = getSessionStats(db, "project-x")
+
+			expect(stats.total_sessions).toBe(1)
+			expect(stats.interaction_count).toBe(0)
+			expect(stats.total_hitl_time_ms).toBe(0)
+			expect(stats.avg_wait_ms).toBe(0)
+		})
+
+		it("filters by project hash", () => {
+			db.run(
+				"INSERT INTO hitl_sessions (id, project_hash, started_at, status) VALUES (?, ?, ?, ?)",
+				["session-a", "project-a", 1000, "active"],
+			)
+			db.run(
+				"INSERT INTO hitl_sessions (id, project_hash, started_at, status) VALUES (?, ?, ?, ?)",
+				["session-b", "project-b", 2000, "active"],
+			)
+
+			const statsA = getSessionStats(db, "project-a")
+			expect(statsA.total_sessions).toBe(1)
+		})
+
+		it("returns zeros on database closure", () => {
+			db.close()
+			const stats = getSessionStats(db, "project-x")
+
+			expect(stats.total_sessions).toBe(0)
+			expect(stats.total_hitl_time_ms).toBe(0)
+			expect(stats.interaction_count).toBe(0)
+			expect(stats.avg_wait_ms).toBe(0)
+		})
+	})
+})

--- a/extensions/hitl-metrics/storage/session.test.ts
+++ b/extensions/hitl-metrics/storage/session.test.ts
@@ -3,14 +3,14 @@
  */
 
 import { describe, it, expect, beforeEach, afterEach, vi } from "vitest"
-import { HitlDatabase } from "./db.ts"
+import { HitlDatabase } from "./db.js"
 import {
 	getOrCreateSession,
 	closeSession,
 	closeOrphanSessions,
 	getRecentSessions,
 	getSessionStats,
-} from "./session.ts"
+} from "./session.js"
 
 describe("Session Management", () => {
 	let db: HitlDatabase

--- a/extensions/hitl-metrics/storage/session.ts
+++ b/extensions/hitl-metrics/storage/session.ts
@@ -7,28 +7,27 @@
 
 import { randomUUID } from "node:crypto"
 import type { HitlDatabase } from "./db.js"
-import type { HitlSession, HitlStats, HitlEvent } from "../types.js"
+import type { HitlSession, HitlStats, HitlEvent, ActivityEvent, HitlPermissionEvent } from "../types.js"
 
-const FIVE_MINUTES_MS = 5 * 60 * 1000
+const FIVE_MINUTES_MS = 2 * 60 * 60 * 1000 // 2 hours — resume if kimchi restarted within 2h
+
+/** Valid session end causes */
+export type EndCause = "complete" | "disconnect" | "signal" | "orphaned"
 
 /**
  * Get an existing active session or create a new one.
  * Resumes if an active session exists and started within the last 5 minutes.
  * Non-fatal: returns null on database errors.
- *
- * @param db - HitlDatabase instance
- * @param projectHash - Project identifier hash
- * @returns HitlSession or null on error
  */
 export function getOrCreateSession(
 	db: HitlDatabase,
 	projectHash: string,
 ): HitlSession | null {
 	try {
-		// Check for existing active session
 		const cutoffTime = Date.now() - FIVE_MINUTES_MS
 		const existing = db.query<HitlSession>(
-			`SELECT id, project_hash, started_at, ended_at, status
+			`SELECT id, project_hash, started_at, ended_at, status, end_cause,
+			        agent_time_ms, hitl_time_ms, idle_time_ms
 			 FROM hitl_sessions
 			 WHERE project_hash = ?
 			   AND status = 'active'
@@ -37,23 +36,16 @@ export function getOrCreateSession(
 			 LIMIT 1`,
 			[projectHash, cutoffTime],
 		)
+		if (existing.length > 0) return existing[0]
 
-		if (existing.length > 0) {
-			return existing[0]
-		}
-
-		// Create new session
 		const sessionId = randomUUID()
 		const startedAt = Date.now()
 		const inserted = db.run(
-			`INSERT INTO hitl_sessions (id, project_hash, started_at, status)
-			 VALUES (?, ?, ?, ?)`,
+			`INSERT INTO hitl_sessions (id, project_hash, started_at, status, agent_time_ms, hitl_time_ms, idle_time_ms)
+			 VALUES (?, ?, ?, ?, 0, 0, 0)`,
 			[sessionId, projectHash, startedAt, "active"],
 		)
-
-		if (!inserted) {
-			return null
-		}
+		if (!inserted) return null
 
 		return {
 			id: sessionId,
@@ -61,6 +53,10 @@ export function getOrCreateSession(
 			started_at: startedAt,
 			ended_at: null,
 			status: "active",
+			end_cause: null,
+			agent_time_ms: 0,
+			hitl_time_ms: 0,
+			idle_time_ms: 0,
 		}
 	} catch (error) {
 		const message = error instanceof Error ? error.message : String(error)
@@ -70,21 +66,17 @@ export function getOrCreateSession(
 }
 
 /**
- * Close a session by marking it as closed with an end time.
- * Non-fatal: returns false on database errors.
- *
- * @param db - HitlDatabase instance
- * @param sessionId - Session UUID to close
- * @returns true if successful, false otherwise
+ * Close a session by marking it as closed with an end time and cause.
  */
-export function closeSession(db: HitlDatabase, sessionId: string): boolean {
+export function closeSession(
+	db: HitlDatabase,
+	sessionId: string,
+	endCause: EndCause = "complete",
+): boolean {
 	try {
 		const result = db.query<{ changes: number }>(
-			`UPDATE hitl_sessions
-			 SET status = 'closed', ended_at = ?
-			 WHERE id = ?
-			 RETURNING 1 as changes`,
-			[Date.now(), sessionId],
+			`UPDATE hitl_sessions SET status = 'closed', ended_at = ?, end_cause = ? WHERE id = ? RETURNING 1 as changes`,
+			[Date.now(), endCause, sessionId],
 		)
 		return result.length > 0
 	} catch (error) {
@@ -95,15 +87,30 @@ export function closeSession(db: HitlDatabase, sessionId: string): boolean {
 }
 
 /**
- * Find and close orphaned sessions (active sessions older than threshold).
- * Orphaned sessions are those that have been active longer than expected,
- * likely due to a crash or unclean shutdown.
- * Logs a warning with the count of closed orphans.
- * Non-fatal: returns 0 on database errors.
- *
- * @param db - HitlDatabase instance
- * @param thresholdMs - Age threshold in milliseconds (default: 5 minutes)
- * @returns Number of sessions marked as orphaned
+ * Update session time metrics.
+ */
+export function updateSessionTimes(
+	db: HitlDatabase,
+	sessionId: string,
+	agentTimeMs: number,
+	hitlTimeMs: number,
+	idleTimeMs: number,
+): boolean {
+	try {
+		const result = db.query<{ changes: number }>(
+			`UPDATE hitl_sessions SET agent_time_ms = ?, hitl_time_ms = ?, idle_time_ms = ? WHERE id = ? RETURNING 1 as changes`,
+			[agentTimeMs, hitlTimeMs, idleTimeMs, sessionId],
+		)
+		return result.length > 0
+	} catch (error) {
+		const message = error instanceof Error ? error.message : String(error)
+		console.warn(`[updateSessionTimes] Error: ${message}`)
+		return false
+	}
+}
+
+/**
+ * Find and close orphaned sessions.
  */
 export function closeOrphanSessions(
 	db: HitlDatabase,
@@ -112,18 +119,12 @@ export function closeOrphanSessions(
 	try {
 		const cutoffTime = Date.now() - thresholdMs
 		const result = db.query<{ count: number }>(
-			`UPDATE hitl_sessions
-			 SET status = 'orphaned', ended_at = ?
-			 WHERE status = 'active'
-			   AND started_at < ?
-			 RETURNING 1 as count`,
+			`UPDATE hitl_sessions SET status = 'orphaned', ended_at = ?, end_cause = 'orphaned'
+			 WHERE status = 'active' AND started_at < ? RETURNING 1 as count`,
 			[Date.now(), cutoffTime],
 		)
-
 		const count = result.length
-		if (count > 0) {
-			console.warn(`[HITL] Closed ${count} orphan session(s)`)
-		}
+		if (count > 0) console.warn(`[HITL] Closed ${count} orphan session(s)`)
 		return count
 	} catch (error) {
 		const message = error instanceof Error ? error.message : String(error)
@@ -133,27 +134,103 @@ export function closeOrphanSessions(
 }
 
 /**
- * Get recent sessions for a project, ordered by start time descending.
- * Non-fatal: returns empty array on database errors.
- *
- * @param db - HitlDatabase instance
- * @param projectHash - Project identifier hash
- * @param limit - Maximum number of sessions to return (default: 10)
- * @returns Array of HitlSession objects
+ * Record a permission event.
  */
-export function getRecentSessions(
+export function recordPermissionEvent(
 	db: HitlDatabase,
-	projectHash: string,
-	limit: number = 10,
-): HitlSession[] {
+	sessionId: string,
+	toolName: string,
+	action: string,
+	outcome: HitlPermissionEvent["outcome"],
+	durationMs: number,
+	reason?: string,
+): boolean {
 	try {
+		// Verify session exists before inserting permission event
+		const sessions = db.query<{ id: string }>(
+			"SELECT id FROM hitl_sessions WHERE id = ?",
+			[sessionId],
+		)
+		if (sessions.length === 0) {
+			console.warn(`[recordPermissionEvent] Session ${sessionId} not found`)
+			return false
+		}
+		return db.run(
+			`INSERT INTO hitl_permission_events (session_id, tool_name, action, outcome, reason, duration_ms, created_at)
+			 VALUES (?, ?, ?, ?, ?, ?, ?)`,
+			[sessionId, toolName, action, outcome, reason ?? null, durationMs, Date.now()],
+		)
+	} catch (error) {
+		const message = error instanceof Error ? error.message : String(error)
+		console.warn(`[recordPermissionEvent] Error: ${message}`)
+		return false
+	}
+}
+
+/**
+ * Get permission events for a specific session.
+ */
+export function getSessionPermissionEvents(db: HitlDatabase, sessionId: string): HitlPermissionEvent[] {
+	try {
+		return db.query<HitlPermissionEvent>(
+			`SELECT id, session_id, tool_name, action, outcome, reason, duration_ms, created_at
+			 FROM hitl_permission_events WHERE session_id = ? ORDER BY created_at ASC`,
+			[sessionId],
+		)
+	} catch (error) {
+		const message = error instanceof Error ? error.message : String(error)
+		console.warn(`[getSessionPermissionEvents] Error: ${message}`)
+		return []
+	}
+}
+export function recordActivityEvent(
+	db: HitlDatabase,
+	sessionId: string,
+	activityType: ActivityEvent["activity_type"],
+	toolName?: string,
+	durationMs?: number,
+): boolean {
+	try {
+		return db.run(
+			`INSERT INTO activity_events (session_id, activity_type, tool_name, duration_ms, timestamp)
+			 VALUES (?, ?, ?, ?, ?)`,
+			[sessionId, activityType, toolName ?? null, durationMs ?? null, Date.now()],
+		)
+	} catch (error) {
+		const message = error instanceof Error ? error.message : String(error)
+		console.warn(`[recordActivityEvent] Error: ${message}`)
+		return false
+	}
+}
+
+/**
+ * Get activity events for a specific session.
+ */
+export function getSessionActivityEvents(db: HitlDatabase, sessionId: string): ActivityEvent[] {
+	try {
+		return db.query<ActivityEvent>(
+			`SELECT id, session_id, activity_type, tool_name, duration_ms, timestamp
+			 FROM activity_events WHERE session_id = ? ORDER BY timestamp ASC`,
+			[sessionId],
+		)
+	} catch (error) {
+		const message = error instanceof Error ? error.message : String(error)
+		console.warn(`[getSessionActivityEvents] Error: ${message}`)
+		return []
+	}
+}
+
+/**
+ * Get recent sessions for a project.
+ * DB is already scoped to a single project, so no hash filter needed.
+ */
+export function getRecentSessions(db: HitlDatabase, limit: number = 10): HitlSession[] {
+	try {
+		const limitVal = Math.min(limit, 100)
 		return db.query<HitlSession>(
-			`SELECT id, project_hash, started_at, ended_at, status
-			 FROM hitl_sessions
-			 WHERE project_hash = ?
-			 ORDER BY started_at DESC
-			 LIMIT ?`,
-			[projectHash, Math.min(limit, 100)], // Cap at 100 to prevent abuse
+			`SELECT id, project_hash, started_at, ended_at, status, end_cause,
+			        agent_time_ms, hitl_time_ms, idle_time_ms
+			 FROM hitl_sessions ORDER BY started_at DESC LIMIT ${limitVal}`,
 		)
 	} catch (error) {
 		const message = error instanceof Error ? error.message : String(error)
@@ -163,23 +240,13 @@ export function getRecentSessions(
 }
 
 /**
- * Get events for a specific session, ordered by creation time ascending.
- * Non-fatal: returns empty array on database errors.
- *
- * @param db - HitlDatabase instance
- * @param sessionId - Session UUID to query events for
- * @returns Array of HitlEvent objects ordered by created_at ASC
+ * Get events for a specific session.
  */
-export function getSessionEvents(
-	db: HitlDatabase,
-	sessionId: string,
-): HitlEvent[] {
+export function getSessionEvents(db: HitlDatabase, sessionId: string): HitlEvent[] {
 	try {
 		return db.query<HitlEvent>(
 			`SELECT id, session_id, tool_name, question_count, duration_ms, selected_options, created_at
-			 FROM hitl_events
-			 WHERE session_id = ?
-			 ORDER BY created_at ASC`,
+			 FROM hitl_events WHERE session_id = ? ORDER BY created_at ASC`,
 			[sessionId],
 		)
 	} catch (error) {
@@ -190,52 +257,47 @@ export function getSessionEvents(
 }
 
 /**
- * Get aggregated statistics for a project's HITL sessions.
- * Calculates total sessions, total HITL time, interaction count, and average wait time.
- * Non-fatal: returns zero-valued stats on database errors or empty results.
- *
- * @param db - HitlDatabase instance
- * @param projectHash - Project identifier hash
- * @returns HitlStats aggregate
+ * Get aggregated statistics.
  */
-export function getSessionStats(
-	db: HitlDatabase,
-	projectHash: string,
-): HitlStats {
+export function getSessionStats(db: HitlDatabase): HitlStats {
 	try {
-		// Aggregate sessions and events for this project
+		// Use scalar subqueries to avoid JOIN multiplying session rows.
+		// A naive LEFT JOIN produces a cartesian product of sessions × events × permissions,
+		// causing SUM(session_time_ms) to be inflated by event count.
 		const result = db.query<{
 			total_sessions: number
 			total_hitl_time_ms: number
 			interaction_count: number
 			avg_wait_ms: number | null
+			permission_count: number
+			total_permission_time_ms: number
 		}>(
 			`SELECT
-				COUNT(DISTINCT s.id) as total_sessions,
-				COALESCE(SUM(e.duration_ms), 0) as total_hitl_time_ms,
-				COUNT(e.id) as interaction_count,
-				AVG(e.duration_ms) as avg_wait_ms
-			 FROM hitl_sessions s
-			 LEFT JOIN hitl_events e ON e.session_id = s.id
-			 WHERE s.project_hash = ?`,
-			[projectHash],
+			        (SELECT COUNT(*) FROM hitl_sessions) as total_sessions,
+			        (SELECT COALESCE(SUM(hitl_time_ms), 0) FROM hitl_sessions) as total_hitl_time_ms,
+			        (SELECT COUNT(*) FROM hitl_events) as interaction_count,
+			        (SELECT AVG(duration_ms) FROM hitl_events) as avg_wait_ms,
+			        (SELECT COUNT(*) FROM hitl_permission_events) as permission_count,
+			        (SELECT COALESCE(SUM(duration_ms), 0) FROM hitl_permission_events) as total_permission_time_ms`,
 		)
-
 		if (result.length === 0) {
 			return {
 				total_sessions: 0,
 				total_hitl_time_ms: 0,
 				interaction_count: 0,
 				avg_wait_ms: 0,
+				permission_count: 0,
+				total_permission_time_ms: 0,
 			}
 		}
-
 		const row = result[0]
 		return {
 			total_sessions: row.total_sessions ?? 0,
 			total_hitl_time_ms: row.total_hitl_time_ms ?? 0,
 			interaction_count: row.interaction_count ?? 0,
 			avg_wait_ms: Math.round(row.avg_wait_ms ?? 0),
+			permission_count: row.permission_count ?? 0,
+			total_permission_time_ms: row.total_permission_time_ms ?? 0,
 		}
 	} catch (error) {
 		const message = error instanceof Error ? error.message : String(error)
@@ -245,6 +307,8 @@ export function getSessionStats(
 			total_hitl_time_ms: 0,
 			interaction_count: 0,
 			avg_wait_ms: 0,
+			permission_count: 0,
+			total_permission_time_ms: 0,
 		}
 	}
 }

--- a/extensions/hitl-metrics/storage/session.ts
+++ b/extensions/hitl-metrics/storage/session.ts
@@ -22,23 +22,28 @@ export type EndCause = "complete" | "disconnect" | "signal" | "orphaned"
 export function getOrCreateSession(
 	db: HitlDatabase,
 	projectHash: string,
+	options: { sessionId?: string } = {},
 ): HitlSession | null {
 	try {
-		const cutoffTime = Date.now() - FIVE_MINUTES_MS
-		const existing = db.query<HitlSession>(
-			`SELECT id, project_hash, started_at, ended_at, status, end_cause,
-			        agent_time_ms, hitl_time_ms, idle_time_ms
-			 FROM hitl_sessions
-			 WHERE project_hash = ?
-			   AND status = 'active'
-			   AND started_at >= ?
-			 ORDER BY started_at DESC
-			 LIMIT 1`,
-			[projectHash, cutoffTime],
-		)
-		if (existing.length > 0) return existing[0]
+		// Use provided session ID if given; otherwise try to resume existing active session
+		const sessionId = options.sessionId ?? randomUUID()
+		const useExisting = !options.sessionId
 
-		const sessionId = randomUUID()
+		if (useExisting) {
+			const cutoffTime = Date.now() - FIVE_MINUTES_MS
+			const existing = db.query<HitlSession>(
+				`SELECT id, project_hash, started_at, ended_at, status, end_cause,
+				        agent_time_ms, hitl_time_ms, idle_time_ms
+				 FROM hitl_sessions
+				 WHERE project_hash = ?
+				   AND status = 'active'
+				   AND started_at >= ?
+				 ORDER BY started_at DESC
+				 LIMIT 1`,
+				[projectHash, cutoffTime],
+			)
+			if (existing.length > 0) return existing[0]
+		}
 		const startedAt = Date.now()
 		const inserted = db.run(
 			`INSERT INTO hitl_sessions (id, project_hash, started_at, status, agent_time_ms, hitl_time_ms, idle_time_ms)

--- a/extensions/hitl-metrics/storage/session.ts
+++ b/extensions/hitl-metrics/storage/session.ts
@@ -1,0 +1,250 @@
+/**
+ * HITL Session Management
+ *
+ * Session lifecycle functions: create/resume sessions, close orphans,
+ * and query session statistics.
+ */
+
+import { randomUUID } from "node:crypto"
+import type { HitlDatabase } from "./db.ts"
+import type { HitlSession, HitlStats, HitlEvent } from "../types.ts"
+
+const FIVE_MINUTES_MS = 5 * 60 * 1000
+
+/**
+ * Get an existing active session or create a new one.
+ * Resumes if an active session exists and started within the last 5 minutes.
+ * Non-fatal: returns null on database errors.
+ *
+ * @param db - HitlDatabase instance
+ * @param projectHash - Project identifier hash
+ * @returns HitlSession or null on error
+ */
+export function getOrCreateSession(
+	db: HitlDatabase,
+	projectHash: string,
+): HitlSession | null {
+	try {
+		// Check for existing active session
+		const cutoffTime = Date.now() - FIVE_MINUTES_MS
+		const existing = db.query<HitlSession>(
+			`SELECT id, project_hash, started_at, ended_at, status
+			 FROM hitl_sessions
+			 WHERE project_hash = ?
+			   AND status = 'active'
+			   AND started_at >= ?
+			 ORDER BY started_at DESC
+			 LIMIT 1`,
+			[projectHash, cutoffTime],
+		)
+
+		if (existing.length > 0) {
+			return existing[0]
+		}
+
+		// Create new session
+		const sessionId = randomUUID()
+		const startedAt = Date.now()
+		const inserted = db.run(
+			`INSERT INTO hitl_sessions (id, project_hash, started_at, status)
+			 VALUES (?, ?, ?, ?)`,
+			[sessionId, projectHash, startedAt, "active"],
+		)
+
+		if (!inserted) {
+			return null
+		}
+
+		return {
+			id: sessionId,
+			project_hash: projectHash,
+			started_at: startedAt,
+			ended_at: null,
+			status: "active",
+		}
+	} catch (error) {
+		const message = error instanceof Error ? error.message : String(error)
+		console.warn(`[getOrCreateSession] Error: ${message}`)
+		return null
+	}
+}
+
+/**
+ * Close a session by marking it as closed with an end time.
+ * Non-fatal: returns false on database errors.
+ *
+ * @param db - HitlDatabase instance
+ * @param sessionId - Session UUID to close
+ * @returns true if successful, false otherwise
+ */
+export function closeSession(db: HitlDatabase, sessionId: string): boolean {
+	try {
+		const result = db.query<{ changes: number }>(
+			`UPDATE hitl_sessions
+			 SET status = 'closed', ended_at = ?
+			 WHERE id = ?
+			 RETURNING 1 as changes`,
+			[Date.now(), sessionId],
+		)
+		return result.length > 0
+	} catch (error) {
+		const message = error instanceof Error ? error.message : String(error)
+		console.warn(`[closeSession] Error: ${message}`)
+		return false
+	}
+}
+
+/**
+ * Find and close orphaned sessions (active sessions older than threshold).
+ * Orphaned sessions are those that have been active longer than expected,
+ * likely due to a crash or unclean shutdown.
+ * Logs a warning with the count of closed orphans.
+ * Non-fatal: returns 0 on database errors.
+ *
+ * @param db - HitlDatabase instance
+ * @param thresholdMs - Age threshold in milliseconds (default: 5 minutes)
+ * @returns Number of sessions marked as orphaned
+ */
+export function closeOrphanSessions(
+	db: HitlDatabase,
+	thresholdMs: number = FIVE_MINUTES_MS,
+): number {
+	try {
+		const cutoffTime = Date.now() - thresholdMs
+		const result = db.query<{ count: number }>(
+			`UPDATE hitl_sessions
+			 SET status = 'orphaned', ended_at = ?
+			 WHERE status = 'active'
+			   AND started_at < ?
+			 RETURNING 1 as count`,
+			[Date.now(), cutoffTime],
+		)
+
+		const count = result.length
+		if (count > 0) {
+			console.warn(`[HITL] Closed ${count} orphan session(s)`)
+		}
+		return count
+	} catch (error) {
+		const message = error instanceof Error ? error.message : String(error)
+		console.warn(`[closeOrphanSessions] Error: ${message}`)
+		return 0
+	}
+}
+
+/**
+ * Get recent sessions for a project, ordered by start time descending.
+ * Non-fatal: returns empty array on database errors.
+ *
+ * @param db - HitlDatabase instance
+ * @param projectHash - Project identifier hash
+ * @param limit - Maximum number of sessions to return (default: 10)
+ * @returns Array of HitlSession objects
+ */
+export function getRecentSessions(
+	db: HitlDatabase,
+	projectHash: string,
+	limit: number = 10,
+): HitlSession[] {
+	try {
+		return db.query<HitlSession>(
+			`SELECT id, project_hash, started_at, ended_at, status
+			 FROM hitl_sessions
+			 WHERE project_hash = ?
+			 ORDER BY started_at DESC
+			 LIMIT ?`,
+			[projectHash, Math.min(limit, 100)], // Cap at 100 to prevent abuse
+		)
+	} catch (error) {
+		const message = error instanceof Error ? error.message : String(error)
+		console.warn(`[getRecentSessions] Error: ${message}`)
+		return []
+	}
+}
+
+/**
+ * Get events for a specific session, ordered by creation time ascending.
+ * Non-fatal: returns empty array on database errors.
+ *
+ * @param db - HitlDatabase instance
+ * @param sessionId - Session UUID to query events for
+ * @returns Array of HitlEvent objects ordered by created_at ASC
+ */
+export function getSessionEvents(
+	db: HitlDatabase,
+	sessionId: string,
+): HitlEvent[] {
+	try {
+		return db.query<HitlEvent>(
+			`SELECT id, session_id, tool_name, question_count, duration_ms, selected_options, created_at
+			 FROM hitl_events
+			 WHERE session_id = ?
+			 ORDER BY created_at ASC`,
+			[sessionId],
+		)
+	} catch (error) {
+		const message = error instanceof Error ? error.message : String(error)
+		console.warn(`[getSessionEvents] Error: ${message}`)
+		return []
+	}
+}
+
+/**
+ * Get aggregated statistics for a project's HITL sessions.
+ * Calculates total sessions, total HITL time, interaction count, and average wait time.
+ * Non-fatal: returns zero-valued stats on database errors or empty results.
+ *
+ * @param db - HitlDatabase instance
+ * @param projectHash - Project identifier hash
+ * @returns HitlStats aggregate
+ */
+export function getSessionStats(
+	db: HitlDatabase,
+	projectHash: string,
+): HitlStats {
+	try {
+		// Aggregate sessions and events for this project
+		const result = db.query<{
+			total_sessions: number
+			total_hitl_time_ms: number
+			interaction_count: number
+			avg_wait_ms: number | null
+		}>(
+			`SELECT
+				COUNT(DISTINCT s.id) as total_sessions,
+				COALESCE(SUM(e.duration_ms), 0) as total_hitl_time_ms,
+				COUNT(e.id) as interaction_count,
+				AVG(e.duration_ms) as avg_wait_ms
+			 FROM hitl_sessions s
+			 LEFT JOIN hitl_events e ON e.session_id = s.id
+			 WHERE s.project_hash = ?`,
+			[projectHash],
+		)
+
+		if (result.length === 0) {
+			return {
+				total_sessions: 0,
+				total_hitl_time_ms: 0,
+				interaction_count: 0,
+				avg_wait_ms: 0,
+			}
+		}
+
+		const row = result[0]
+		return {
+			total_sessions: row.total_sessions ?? 0,
+			total_hitl_time_ms: row.total_hitl_time_ms ?? 0,
+			interaction_count: row.interaction_count ?? 0,
+			avg_wait_ms: Math.round(row.avg_wait_ms ?? 0),
+		}
+	} catch (error) {
+		const message = error instanceof Error ? error.message : String(error)
+		console.warn(`[getSessionStats] Error: ${message}`)
+		return {
+			total_sessions: 0,
+			total_hitl_time_ms: 0,
+			interaction_count: 0,
+			avg_wait_ms: 0,
+		}
+	}
+}

--- a/extensions/hitl-metrics/storage/session.ts
+++ b/extensions/hitl-metrics/storage/session.ts
@@ -6,8 +6,8 @@
  */
 
 import { randomUUID } from "node:crypto"
-import type { HitlDatabase } from "./db.ts"
-import type { HitlSession, HitlStats, HitlEvent } from "../types.ts"
+import type { HitlDatabase } from "./db.js"
+import type { HitlSession, HitlStats, HitlEvent } from "../types.js"
 
 const FIVE_MINUTES_MS = 5 * 60 * 1000
 

--- a/extensions/hitl-metrics/test-helpers/mock-theme.ts
+++ b/extensions/hitl-metrics/test-helpers/mock-theme.ts
@@ -1,27 +1,14 @@
-/**
- * Test helper for creating mock Theme instances
- *
- * Provides a mock Theme that satisfies the interface for deterministic tests.
- */
-
-import type { Theme, ThemeColor } from "@mariozechner/pi-coding-agent"
-
-type NoOp = (text: string) => string
-
-const noOp: NoOp = (text) => text
-
-// ThemeBg type is not exported from main package, but we know the valid values
-type ThemeBg = "selectedBg" | "userMessageBg" | "customMessageBg" | "toolPendingBg" | "toolSuccessBg" | "toolErrorBg"
+import type { Theme } from "@mariozechner/pi-coding-agent"
 
 /**
- * Create a minimal mock Theme for testing.
- * Returns plain strings without ANSI codes for deterministic tests.
+ * Creates a mock theme for testing purposes.
  */
 export function createMockTheme(): Theme {
+	const noOp = (text: string) => text
 	return {
 		name: "mock",
-		fg: (_color: ThemeColor, text: string) => text,
-		bg: (_color: ThemeBg, text: string) => text,
+		fg: (_c: "success" | "error" | "warning" | "muted" | "accent" | "dim" | "toolTitle" | string, text: string) => text,
+		bg: (_c: string, text: string) => text,
 		bold: noOp,
 		italic: noOp,
 		underline: noOp,

--- a/extensions/hitl-metrics/test-helpers/mock-theme.ts
+++ b/extensions/hitl-metrics/test-helpers/mock-theme.ts
@@ -1,0 +1,36 @@
+/**
+ * Test helper for creating mock Theme instances
+ *
+ * Provides a mock Theme that satisfies the interface for deterministic tests.
+ */
+
+import type { Theme, ThemeColor } from "@mariozechner/pi-coding-agent"
+
+type NoOp = (text: string) => string
+
+const noOp: NoOp = (text) => text
+
+// ThemeBg type is not exported from main package, but we know the valid values
+type ThemeBg = "selectedBg" | "userMessageBg" | "customMessageBg" | "toolPendingBg" | "toolSuccessBg" | "toolErrorBg"
+
+/**
+ * Create a minimal mock Theme for testing.
+ * Returns plain strings without ANSI codes for deterministic tests.
+ */
+export function createMockTheme(): Theme {
+	return {
+		name: "mock",
+		fg: (_color: ThemeColor, text: string) => text,
+		bg: (_color: ThemeBg, text: string) => text,
+		bold: noOp,
+		italic: noOp,
+		underline: noOp,
+		inverse: noOp,
+		strikethrough: noOp,
+		getFgAnsi: () => "",
+		getBgAnsi: () => "",
+		getColorMode: () => "truecolor",
+		getThinkingBorderColor: () => noOp,
+		getBashModeBorderColor: () => noOp,
+	} as unknown as Theme
+}

--- a/extensions/hitl-metrics/test-hitl-simulation.ts
+++ b/extensions/hitl-metrics/test-hitl-simulation.ts
@@ -1,0 +1,204 @@
+/**
+ * HITL Metrics Simulation Test
+ *
+ * Programmatically exercises the full HITL interaction lifecycle:
+ *   1. Start kimchi session (session_start)
+ *   2. Agent calls ask_user_questions (tool_execution_start)
+ *   3. User responds (tool_result with response data)
+ *   4. Session ends (session_shutdown)
+ *   5. Query /metrics — verify HITL time and interaction count
+ *
+ * No kimchi instance needed — calls through SessionManager directly.
+ *
+ * Usage:
+ *   bun run extensions/hitl-metrics/test-hitl-simulation.ts
+ */
+
+import { mkdtempSync, rmSync } from "node:fs"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
+import { homedir } from "node:os"
+import { SessionManager } from "./session-manager.js"
+import { projectHash } from "./storage/index.js"
+import { HitlDatabase } from "./storage/db.js"
+import { getSessionStats } from "./storage/session.js"
+import { getMetricsOutput } from "./commands/metrics.js"
+import { createMockTheme } from "./test-helpers/mock-theme.js"
+
+const STORAGE_DIR = join(homedir(), ".kimchi", "metrics")
+
+function storageDbPath(cwd: string): string {
+	return join(STORAGE_DIR, projectHash(cwd), "hitl.db")
+}
+
+function sleep(ms: number): Promise<void> {
+	return new Promise((resolve) => setTimeout(resolve, ms))
+}
+
+async function simulateHitlInteraction(
+	manager: SessionManager,
+	questionCount: number,
+	userResponseTimeMs: number,
+	questions: string[],
+): Promise<void> {
+	const toolCallId = `call-hitl-${Date.now()}`
+
+	// Step 1: Agent calls ask_user_questions (tool_execution_start)
+	const startTime = Date.now()
+	// Record tool start for activity tracking
+	manager.recordStartTime(toolCallId)
+
+	// Step 2: User takes time to think and respond
+	// During this time the session is "blocked" — HITL time accumulates
+	await sleep(userResponseTimeMs)
+
+	// Step 3: User responds (tool_result)
+	// Format matches what pi's ask_user_questions actually returns
+	const answers: Record<string, { answers: string[] }> = {}
+	for (let i = 0; i < questionCount; i++) {
+		answers[`q${i + 1}`] = { answers: [questions[i] ?? "Option A"] }
+	}
+	const resultJson = JSON.stringify({ answers })
+
+	const actualDuration = Date.now() - startTime
+	manager.recordEvent("ask_user_questions", questionCount, actualDuration, questions)
+}
+
+async function main() {
+	const tempDir = mkdtempSync(join(tmpdir(), "hitl-sim-"))
+	const dbPath = storageDbPath(tempDir)
+
+	console.log("=== HITL Metrics Simulation ===\n")
+	console.log("Temp dir:", tempDir)
+	console.log("DB path:", dbPath)
+
+	// ── Session 1: Quick confirmation (2 seconds) ──────────────────────────────
+	{
+		console.log("\n[Session 1] Quick confirmation — 2s response time")
+		const manager = new SessionManager()
+		manager.init(tempDir)
+
+		await simulateHitlInteraction(manager, 1, 2000, ["Yes"])
+
+		manager.close()
+		const stats = manager.getSession() // null after close, but data is in DB
+		console.log("  ✓ Session closed")
+	}
+
+	// ── Session 2: Multi-option choice (5 seconds) ─────────────────────────────
+	{
+		console.log("\n[Session 2] Multi-option — 5s response time")
+		await sleep(100) // Small gap between sessions
+
+		const manager = new SessionManager()
+		manager.init(tempDir)
+
+		await simulateHitlInteraction(
+			manager,
+			2,
+			5000,
+			["Approach A: TDD-first", "Approach B: Test later"],
+		)
+
+		manager.close()
+		console.log("  ✓ Session closed")
+	}
+
+	// ── Session 3: Architecture decision (30 seconds) ──────────────────────────
+	{
+		console.log("\n[Session 3] Architecture decision — 30s response time")
+		await sleep(100)
+
+		const manager = new SessionManager()
+		manager.init(tempDir)
+
+		await simulateHitlInteraction(
+			manager,
+			3,
+			30000,
+			["PostgreSQL — relational, mature", "SQLite — embedded, simple", "DynamoDB — managed, scalable"],
+		)
+
+		manager.close()
+		console.log("  ✓ Session closed")
+	}
+
+	// ── Verify: Query DB directly ──────────────────────────────────────────────
+	console.log("\n=== Database Contents ===\n")
+	const db = new HitlDatabase(dbPath)
+	db.open()
+
+	const stats = getSessionStats(db)
+	const events = db.query<{ id: number; tool_name: string; question_count: number; duration_ms: number; created_at: number }>(
+		"SELECT id, tool_name, question_count, duration_ms, created_at FROM hitl_events ORDER BY created_at ASC",
+	)
+	const sessions = db.query<{ id: string; started_at: number; ended_at: number; status: string; hitl_time_ms: number; agent_time_ms: number; idle_time_ms: number }>(
+		"SELECT id, started_at, ended_at, status, hitl_time_ms, agent_time_ms, idle_time_ms FROM hitl_sessions",
+	)
+
+	db.close()
+
+	console.log("Sessions:")
+	for (const s of sessions) {
+		const dur = s.ended_at ? ` (${((s.ended_at - s.started_at) / 1000).toFixed(0)}s)` : " (active)"
+		console.log(
+			`  ${s.status.padEnd(8)} hitl:${(s.hitl_time_ms / 1000).toFixed(1)}s  agent:${(s.agent_time_ms / 1000).toFixed(1)}s  idle:${(s.idle_time_ms / 1000).toFixed(1)}s${dur}`,
+		)
+	}
+
+	console.log(`\nHITL Events: ${events.length}`)
+	for (const e of events) {
+		console.log(`  ${e.question_count}Q  ${(e.duration_ms / 1000).toFixed(1)}s  selected:${e.duration_ms > 10000 ? "long" : "quick"}`)
+	}
+
+	console.log(`\nStats:`)
+	console.log(`  Total sessions:    ${stats.total_sessions}`)
+	console.log(`  Interactions:      ${stats.interaction_count}`)
+	console.log(`  Total HITL time:   ${(stats.total_hitl_time_ms / 1000).toFixed(1)}s`)
+	console.log(`  Avg wait time:     ${(stats.avg_wait_ms / 1000).toFixed(1)}s`)
+
+	// ── Verify: getMetricsOutput ───────────────────────────────────────────────
+	console.log("\n=== /metrics Output ===\n")
+	const output = await getMetricsOutput(tempDir, createMockTheme(), { dbPath })
+	console.log(output)
+
+	// ── Assertions ─────────────────────────────────────────────────────────────
+	console.log("\n=== Assertions ===\n")
+
+	let passed = 0
+	let failed = 0
+
+	function check(label: string, actual: unknown, expected: unknown) {
+		const ok = actual === expected
+		if (ok) {
+			console.log(`  ✓ ${label}: ${actual}`)
+			passed++
+		} else {
+			console.log(`  ✗ ${label}: expected ${expected}, got ${actual}`)
+			failed++
+		}
+	}
+
+	check("Sessions", stats.total_sessions, 3)
+	check("Interactions", stats.interaction_count, 3)
+	check("HITL time > 35s", stats.total_hitl_time_ms > 35000, true) // 2s + 5s + 30s
+	check("Non-zero avg wait", stats.avg_wait_ms > 0, true)
+	check("3 HITL events in DB", events.length, 3)
+	check("Event 1: 1 question", events[0].question_count, 1)
+	check("Event 2: 2 questions", events[1].question_count, 2)
+	check("Event 3: 3 questions", events[2].question_count, 3)
+	check("metrics output contains HITL time", output.includes("HITL time"), true)
+	check("metrics output shows 3 interactions", output.includes("Interactions:"), true)
+	check("timeline renders", output.includes("Session Timeline"), true)
+
+	console.log(`\n${passed} passed, ${failed} failed`)
+
+	// ── Cleanup ────────────────────────────────────────────────────────────────
+	rmSync(tempDir, { recursive: true, force: true })
+	process.exit(failed > 0 ? 1 : 0)
+}
+
+main().catch((err) => {
+	console.error("Fatal:", err)
+	process.exit(1)
+})

--- a/extensions/hitl-metrics/timeline.test.ts
+++ b/extensions/hitl-metrics/timeline.test.ts
@@ -1,0 +1,280 @@
+/**
+ * Timeline Tests
+ *
+ * Comprehensive tests for timeline segment computation and ASCII chart rendering.
+ */
+
+import { describe, it, expect } from "bun:test"
+import { buildTimeline, renderTimeline } from "./timeline.ts"
+import type { HitlSession, HitlEvent, TimelineSegment } from "./types.ts"
+import type { Theme } from "./formatters.ts"
+
+// Mock theme for testing (no ANSI colors)
+const mockTheme: Theme = {
+	fg: (_color: string, text: string) => text,
+	bg: (_color: string, text: string) => text,
+	bold: (text: string) => text,
+	dim: (text: string) => text,
+	italic: (text: string) => text,
+	underline: (text: string) => text,
+	strikethrough: (text: string) => text,
+}
+
+// Helper to create a session
+function createSession(overrides: Partial<HitlSession> = {}): HitlSession {
+	return {
+		id: "test-session-id",
+		project_hash: "abc123",
+		started_at: 1000,
+		ended_at: 5000,
+		status: "closed",
+		...overrides,
+	}
+}
+
+// Helper to create an event
+function createEvent(overrides: Partial<HitlEvent> = {}): HitlEvent {
+	return {
+		id: 1,
+		session_id: "test-session-id",
+		tool_name: "test_tool",
+		question_count: 1,
+		duration_ms: 500,
+		selected_options: "[]",
+		created_at: 2000,
+		...overrides,
+	}
+}
+
+describe("buildTimeline", () => {
+	it("returns single solo segment when no events", () => {
+		const session = createSession({ started_at: 1000, ended_at: 5000 })
+		const segments = buildTimeline(session, [])
+
+		expect(segments).toHaveLength(1)
+		expect(segments[0]).toEqual({
+			type: "solo",
+			startMs: 1000,
+			endMs: 5000,
+			durationMs: 4000,
+		})
+	})
+
+	it("builds correct segments for single event", () => {
+		const session = createSession({ started_at: 1000, ended_at: 5000 })
+		const event = createEvent({ created_at: 2000, duration_ms: 1000 })
+		const segments = buildTimeline(session, [event])
+
+		expect(segments).toHaveLength(3)
+		expect(segments[0]).toEqual({
+			type: "solo",
+			startMs: 1000,
+			endMs: 2000,
+			durationMs: 1000,
+		})
+		expect(segments[1]).toEqual({
+			type: "hitl",
+			startMs: 2000,
+			endMs: 3000,
+			durationMs: 1000,
+		})
+		expect(segments[2]).toEqual({
+			type: "solo",
+			startMs: 3000,
+			endMs: 5000,
+			durationMs: 2000,
+		})
+	})
+
+	it("builds correct segments for multiple events", () => {
+		const session = createSession({ started_at: 0, ended_at: 10000 })
+		const events: HitlEvent[] = [
+			createEvent({ id: 1, created_at: 2000, duration_ms: 1000 }),
+			createEvent({ id: 2, created_at: 5000, duration_ms: 500 }),
+			createEvent({ id: 3, created_at: 8000, duration_ms: 1000 }),
+		]
+		const segments = buildTimeline(session, events)
+
+		expect(segments).toHaveLength(7)
+
+		expect(segments[0].type).toBe("solo")
+		expect(segments[1].type).toBe("hitl")
+		expect(segments[2].type).toBe("solo")
+		expect(segments[3].type).toBe("hitl")
+		expect(segments[4].type).toBe("solo")
+		expect(segments[5].type).toBe("hitl")
+		expect(segments[6].type).toBe("solo")
+
+		expect(segments[0].startMs).toBe(0)
+		expect(segments[6].endMs).toBe(10000)
+	})
+
+	it("uses Date.now() as end for active session (null ended_at)", () => {
+		const beforeNow = Date.now() - 100
+		const session = createSession({ started_at: beforeNow, ended_at: null })
+		const segments = buildTimeline(session, [])
+
+		expect(segments).toHaveLength(1)
+		expect(segments[0].startMs).toBe(beforeNow)
+		expect(segments[0].endMs).toBeGreaterThan(beforeNow + 50)
+		expect(segments[0].endMs).toBeLessThanOrEqual(Date.now())
+	})
+
+	it("handles back-to-back events (no solo gap between)", () => {
+		const session = createSession({ started_at: 0, ended_at: 5000 })
+		const events: HitlEvent[] = [
+			createEvent({ id: 1, created_at: 1000, duration_ms: 1000 }),
+			createEvent({ id: 2, created_at: 2000, duration_ms: 1000 }),
+		]
+		const segments = buildTimeline(session, events)
+
+		expect(segments).toHaveLength(4)
+		expect(segments[0].type).toBe("solo")
+		expect(segments[0].endMs).toBe(1000)
+		expect(segments[1].type).toBe("hitl")
+		expect(segments[1].endMs).toBe(2000)
+		expect(segments[2].type).toBe("hitl")
+		expect(segments[2].endMs).toBe(3000)
+		expect(segments[3].type).toBe("solo")
+	})
+
+	it("handles event at exact session start", () => {
+		const session = createSession({ started_at: 1000, ended_at: 5000 })
+		const event = createEvent({ created_at: 1000, duration_ms: 1000 })
+		const segments = buildTimeline(session, [event])
+
+		expect(segments).toHaveLength(2)
+		expect(segments[0].type).toBe("hitl")
+		expect(segments[0].startMs).toBe(1000)
+		expect(segments[1].type).toBe("solo")
+	})
+
+	it("handles event at exact session end", () => {
+		const session = createSession({ started_at: 1000, ended_at: 3000 })
+		const event = createEvent({ created_at: 2000, duration_ms: 1000 })
+		const segments = buildTimeline(session, [event])
+
+		expect(segments).toHaveLength(2)
+		expect(segments[0].type).toBe("solo")
+		expect(segments[1].type).toBe("hitl")
+		expect(segments[1].endMs).toBe(3000)
+	})
+
+	it("handles zero-duration event", () => {
+		const session = createSession({ started_at: 1000, ended_at: 5000 })
+		const event = createEvent({ created_at: 2000, duration_ms: 0 })
+		const segments = buildTimeline(session, [event])
+
+		expect(segments).toHaveLength(3)
+		expect(segments[1].durationMs).toBe(0)
+	})
+})
+
+describe("renderTimeline", () => {
+	it("returns placeholder for empty segments", () => {
+		const result = renderTimeline([], mockTheme)
+		expect(result).toBe("  No timeline data")
+	})
+
+	it("renders single solo segment", () => {
+		const segments: TimelineSegment[] = [
+			{ type: "solo", startMs: 0, endMs: 60000, durationMs: 60000 },
+		]
+		const result = renderTimeline(segments, mockTheme, 10)
+
+		const lines = result.split("\n")
+		expect(lines[0]).toBe("██████████") // All solo chars
+		expect(lines[1]).toContain("solo")
+	})
+
+	it("renders single hitl segment", () => {
+		const segments: TimelineSegment[] = [
+			{ type: "hitl", startMs: 0, endMs: 60000, durationMs: 60000 },
+		]
+		const result = renderTimeline(segments, mockTheme, 10)
+
+		const lines = result.split("\n")
+		expect(lines[0]).toBe("▓▓▓▓▓▓▓▓▓▓") // All hitl chars
+		expect(lines[1]).toContain("HITL")
+	})
+
+	it("renders mixed segments with correct proportions", () => {
+		const segments: TimelineSegment[] = [
+			{ type: "solo", startMs: 0, endMs: 4000, durationMs: 4000 },
+			{ type: "hitl", startMs: 4000, endMs: 5000, durationMs: 1000 },
+			{ type: "solo", startMs: 5000, endMs: 10000, durationMs: 5000 },
+		]
+		const result = renderTimeline(segments, mockTheme, 10)
+
+		const lines = result.split("\n")
+		const bar = lines[0]
+		expect(bar.length).toBe(10)
+
+		const soloCount = (bar.match(/█/g) || []).length
+		const hitlCount = (bar.match(/▓/g) || []).length
+		expect(soloCount).toBeGreaterThanOrEqual(8)
+		expect(hitlCount).toBeGreaterThanOrEqual(1)
+	})
+
+	it("shows both solo and HITL in legend", () => {
+		const segments: TimelineSegment[] = [
+			{ type: "solo", startMs: 0, endMs: 60000, durationMs: 60000 },
+			{ type: "hitl", startMs: 60000, endMs: 120000, durationMs: 60000 },
+		]
+		const result = renderTimeline(segments, mockTheme, 20)
+
+		const lines = result.split("\n")
+		expect(lines[1]).toContain("█")
+		expect(lines[1]).toContain("solo")
+		expect(lines[1]).toContain("▓")
+		expect(lines[1]).toContain("HITL")
+	})
+
+	it("handles very short segments in narrow width", () => {
+		const segments: TimelineSegment[] = [
+			{ type: "solo", startMs: 0, endMs: 100000, durationMs: 100000 },
+			{ type: "hitl", startMs: 100000, endMs: 100050, durationMs: 50 },
+		]
+		// With limited width, dominant segment fills the bar
+		const result = renderTimeline(segments, mockTheme, 20)
+
+		const lines = result.split("\n")
+		const bar = lines[0]
+		expect(bar.length).toBe(20)
+		// Legend still shows both segment types
+		expect(lines[1]).toContain("solo")
+		expect(lines[1]).toContain("HITL")
+	})
+
+	it("handles zero duration total", () => {
+		const segments: TimelineSegment[] = [
+			{ type: "solo", startMs: 1000, endMs: 1000, durationMs: 0 },
+		]
+		const result = renderTimeline(segments, mockTheme)
+
+		expect(result).toContain("─")
+	})
+
+	it("skips zero-duration segments in rendering", () => {
+		const segments: TimelineSegment[] = [
+			{ type: "solo", startMs: 0, endMs: 5000, durationMs: 5000 },
+			{ type: "hitl", startMs: 5000, endMs: 5000, durationMs: 0 },
+			{ type: "solo", startMs: 5000, endMs: 10000, durationMs: 5000 },
+		]
+		const result = renderTimeline(segments, mockTheme, 10)
+
+		const lines = result.split("\n")
+		const bar = lines[0]
+		expect(bar).not.toContain("▓")
+	})
+
+	it("uses default width of 60", () => {
+		const segments: TimelineSegment[] = [
+			{ type: "solo", startMs: 0, endMs: 1000, durationMs: 1000 },
+		]
+		const result = renderTimeline(segments, mockTheme)
+
+		const lines = result.split("\n")
+		expect(lines[0].length).toBe(60)
+	})
+})

--- a/extensions/hitl-metrics/timeline.test.ts
+++ b/extensions/hitl-metrics/timeline.test.ts
@@ -7,27 +7,7 @@
 import { describe, it, expect } from "vitest"
 import { buildTimeline, renderTimeline } from "./timeline.js"
 import type { HitlSession, HitlEvent, TimelineSegment } from "./types.js"
-import type { Theme } from "@mariozechner/pi-coding-agent"
-
-// Mock theme for testing (no ANSI colors) — implements Theme interface
-function createMockTheme(): Theme {
-	const noOp = (text: string) => text
-	return {
-		name: "mock",
-		fg: (_c, text) => text,
-		bg: (_c, text) => text,
-		bold: noOp,
-		italic: noOp,
-		underline: noOp,
-		inverse: noOp,
-		strikethrough: noOp,
-		getFgAnsi: () => "",
-		getBgAnsi: () => "",
-		getColorMode: () => "truecolor",
-		getThinkingBorderColor: () => noOp,
-		getBashModeBorderColor: () => noOp,
-	} as unknown as Theme
-}
+import { createMockTheme } from "./test-helpers/mock-theme.js"
 
 const mockTheme = createMockTheme()
 

--- a/extensions/hitl-metrics/timeline.test.ts
+++ b/extensions/hitl-metrics/timeline.test.ts
@@ -115,6 +115,44 @@ describe("buildTimeline", () => {
 		expect(agentSegments.length).toBe(1)
 		expect(agentSegments[0].durationMs).toBe(4000)
 	})
+
+	it("active session: no trailing idle after last tool_end", () => {
+		const session = createSession({ started_at: 1000, ended_at: null, status: "active", agent_time_ms: 0, hitl_time_ms: 0, idle_time_ms: 0 })
+		const activities: ActivityEvent[] = [
+			createActivity({ activity_type: "tool_start", timestamp: 1000 }),
+			createActivity({ activity_type: "tool_end", timestamp: 2000, duration_ms: 1000 }),
+		]
+		const segments = buildTimeline(session, [], activities)
+		// Total duration should reflect only the known activity, not extend to Date.now()
+		const totalMs = segments.reduce((sum, s) => sum + s.durationMs, 0)
+		expect(totalMs).toBeLessThanOrEqual(1000)
+		const idleSegments = segments.filter((s) => s.type === "idle")
+		expect(idleSegments.length).toBe(0)
+	})
+
+	it("active session: trailing idle shown when last activity is idle_start (agent waiting)", () => {
+		const before = Date.now()
+		const session = createSession({ started_at: before - 5000, ended_at: null, status: "active", agent_time_ms: 0, hitl_time_ms: 0, idle_time_ms: 0 })
+		const activities: ActivityEvent[] = [
+			createActivity({ activity_type: "user_input", timestamp: before - 5000 }),
+			createActivity({ activity_type: "idle_start", timestamp: before - 5000 }),
+		]
+		const segments = buildTimeline(session, [], activities)
+		const idleSegments = segments.filter((s) => s.type === "idle")
+		expect(idleSegments.length).toBe(1)
+		expect(idleSegments[0].durationMs).toBeGreaterThan(0)
+	})
+
+	it("closed session: always fills trailing gap as idle", () => {
+		const session = createSession({ started_at: 1000, ended_at: 5000, status: "closed", agent_time_ms: 0, hitl_time_ms: 0, idle_time_ms: 0 })
+		const activities: ActivityEvent[] = [
+			createActivity({ activity_type: "tool_start", timestamp: 1000 }),
+			createActivity({ activity_type: "tool_end", timestamp: 2000, duration_ms: 1000 }),
+		]
+		const segments = buildTimeline(session, [], activities)
+		const end = segments.reduce((max, s) => Math.max(max, s.endMs), 0)
+		expect(end).toBe(5000)
+	})
 })
 
 describe("renderTimeline", () => {

--- a/extensions/hitl-metrics/timeline.test.ts
+++ b/extensions/hitl-metrics/timeline.test.ts
@@ -2,16 +2,16 @@
  * Timeline Tests
  *
  * Comprehensive tests for timeline segment computation and ASCII chart rendering.
+ * Updated for three-category timeline: agent, hitl, idle.
  */
 
 import { describe, it, expect } from "vitest"
 import { buildTimeline, renderTimeline } from "./timeline.js"
-import type { HitlSession, HitlEvent, TimelineSegment } from "./types.js"
+import type { HitlSession, HitlEvent, TimelineSegment, ActivityEvent } from "./types.js"
 import { createMockTheme } from "./test-helpers/mock-theme.js"
 
 const mockTheme = createMockTheme()
 
-// Helper to create a session
 function createSession(overrides: Partial<HitlSession> = {}): HitlSession {
 	return {
 		id: "test-session-id",
@@ -19,11 +19,14 @@ function createSession(overrides: Partial<HitlSession> = {}): HitlSession {
 		started_at: 1000,
 		ended_at: 5000,
 		status: "closed",
+		end_cause: "complete",
+		agent_time_ms: 3000,
+		hitl_time_ms: 1000,
+		idle_time_ms: 1000,
 		...overrides,
 	}
 }
 
-// Helper to create an event
 function createEvent(overrides: Partial<HitlEvent> = {}): HitlEvent {
 	return {
 		id: 1,
@@ -37,127 +40,80 @@ function createEvent(overrides: Partial<HitlEvent> = {}): HitlEvent {
 	}
 }
 
+function createActivity(overrides: Partial<ActivityEvent> = {}): ActivityEvent {
+	return {
+		id: 1,
+		session_id: "test-session-id",
+		activity_type: "tool_start",
+		tool_name: "test_tool",
+		duration_ms: null,
+		timestamp: 2000,
+		...overrides,
+	}
+}
+
 describe("buildTimeline", () => {
-	it("returns single solo segment when no events", () => {
-		const session = createSession({ started_at: 1000, ended_at: 5000 })
+	it("builds from session totals when no events or activities", () => {
+		const session = createSession({ agent_time_ms: 3000, hitl_time_ms: 1000, idle_time_ms: 1000 })
 		const segments = buildTimeline(session, [])
 
-		expect(segments).toHaveLength(1)
-		expect(segments[0]).toEqual({
-			type: "solo",
-			startMs: 1000,
-			endMs: 5000,
-			durationMs: 4000,
-		})
+		// Should have segments based on session totals (agent + hitl + idle = 5000)
+		expect(segments.length).toBeGreaterThan(0)
+		const totalDuration = segments.reduce((sum, s) => sum + s.durationMs, 0)
+		expect(totalDuration).toBe(5000)
 	})
 
-	it("builds correct segments for single event", () => {
+	it("builds from HITL events when no activities", () => {
 		const session = createSession({ started_at: 1000, ended_at: 5000 })
 		const event = createEvent({ created_at: 2000, duration_ms: 1000 })
 		const segments = buildTimeline(session, [event])
 
-		expect(segments).toHaveLength(3)
-		expect(segments[0]).toEqual({
-			type: "solo",
-			startMs: 1000,
-			endMs: 2000,
-			durationMs: 1000,
-		})
-		expect(segments[1]).toEqual({
-			type: "hitl",
-			startMs: 2000,
-			endMs: 3000,
-			durationMs: 1000,
-		})
-		expect(segments[2]).toEqual({
-			type: "solo",
-			startMs: 3000,
-			endMs: 5000,
-			durationMs: 2000,
-		})
+		expect(segments.length).toBeGreaterThanOrEqual(2)
+		// First segment should be agent time before HITL
+		expect(segments[0].type).toBe("agent")
+		expect(segments[0].endMs).toBe(2000)
+
+		// HITL segment
+		const hitlSegment = segments.find((s) => s.type === "hitl")
+		expect(hitlSegment).toBeDefined()
+		expect(hitlSegment!.startMs).toBe(2000)
+		expect(hitlSegment!.durationMs).toBe(1000)
 	})
 
-	it("builds correct segments for multiple events", () => {
+	it("builds from activity events when available", () => {
+		const session = createSession({ started_at: 1000, ended_at: 5000 })
+		const activities: ActivityEvent[] = [
+			createActivity({ activity_type: "tool_start", timestamp: 1000 }),
+			createActivity({ activity_type: "tool_end", timestamp: 2000, duration_ms: 1000 }),
+			createActivity({ activity_type: "idle_start", timestamp: 2000 }),
+			createActivity({ activity_type: "idle_end", timestamp: 3500, duration_ms: 1500 }),
+			createActivity({ activity_type: "tool_start", timestamp: 3500 }),
+			createActivity({ activity_type: "tool_end", timestamp: 5000, duration_ms: 1500 }),
+		]
+
+		const segments = buildTimeline(session, [], activities)
+		expect(segments.length).toBeGreaterThan(0)
+
+		// Should have agent, idle, and potentially agent segments
+		const types = segments.map((s) => s.type)
+		expect(types).toContain("agent")
+		expect(types).toContain("idle")
+	})
+
+	it("merges consecutive segments of same type", () => {
 		const session = createSession({ started_at: 0, ended_at: 10000 })
-		const events: HitlEvent[] = [
-			createEvent({ id: 1, created_at: 2000, duration_ms: 1000 }),
-			createEvent({ id: 2, created_at: 5000, duration_ms: 500 }),
-			createEvent({ id: 3, created_at: 8000, duration_ms: 1000 }),
+		const activities: ActivityEvent[] = [
+			createActivity({ activity_type: "tool_start", timestamp: 0 }),
+			createActivity({ activity_type: "tool_end", timestamp: 2000, duration_ms: 2000 }),
+			createActivity({ activity_type: "tool_start", timestamp: 2000 }), // immediate next
+			createActivity({ activity_type: "tool_end", timestamp: 4000, duration_ms: 2000 }),
 		]
-		const segments = buildTimeline(session, events)
 
-		expect(segments).toHaveLength(7)
-
-		expect(segments[0].type).toBe("solo")
-		expect(segments[1].type).toBe("hitl")
-		expect(segments[2].type).toBe("solo")
-		expect(segments[3].type).toBe("hitl")
-		expect(segments[4].type).toBe("solo")
-		expect(segments[5].type).toBe("hitl")
-		expect(segments[6].type).toBe("solo")
-
-		expect(segments[0].startMs).toBe(0)
-		expect(segments[6].endMs).toBe(10000)
-	})
-
-	it("uses Date.now() as end for active session (null ended_at)", () => {
-		const beforeNow = Date.now() - 100
-		const session = createSession({ started_at: beforeNow, ended_at: null })
-		const segments = buildTimeline(session, [])
-
-		expect(segments).toHaveLength(1)
-		expect(segments[0].startMs).toBe(beforeNow)
-		expect(segments[0].endMs).toBeGreaterThan(beforeNow + 50)
-		expect(segments[0].endMs).toBeLessThanOrEqual(Date.now())
-	})
-
-	it("handles back-to-back events (no solo gap between)", () => {
-		const session = createSession({ started_at: 0, ended_at: 5000 })
-		const events: HitlEvent[] = [
-			createEvent({ id: 1, created_at: 1000, duration_ms: 1000 }),
-			createEvent({ id: 2, created_at: 2000, duration_ms: 1000 }),
-		]
-		const segments = buildTimeline(session, events)
-
-		expect(segments).toHaveLength(4)
-		expect(segments[0].type).toBe("solo")
-		expect(segments[0].endMs).toBe(1000)
-		expect(segments[1].type).toBe("hitl")
-		expect(segments[1].endMs).toBe(2000)
-		expect(segments[2].type).toBe("hitl")
-		expect(segments[2].endMs).toBe(3000)
-		expect(segments[3].type).toBe("solo")
-	})
-
-	it("handles event at exact session start", () => {
-		const session = createSession({ started_at: 1000, ended_at: 5000 })
-		const event = createEvent({ created_at: 1000, duration_ms: 1000 })
-		const segments = buildTimeline(session, [event])
-
-		expect(segments).toHaveLength(2)
-		expect(segments[0].type).toBe("hitl")
-		expect(segments[0].startMs).toBe(1000)
-		expect(segments[1].type).toBe("solo")
-	})
-
-	it("handles event at exact session end", () => {
-		const session = createSession({ started_at: 1000, ended_at: 3000 })
-		const event = createEvent({ created_at: 2000, duration_ms: 1000 })
-		const segments = buildTimeline(session, [event])
-
-		expect(segments).toHaveLength(2)
-		expect(segments[0].type).toBe("solo")
-		expect(segments[1].type).toBe("hitl")
-		expect(segments[1].endMs).toBe(3000)
-	})
-
-	it("handles zero-duration event", () => {
-		const session = createSession({ started_at: 1000, ended_at: 5000 })
-		const event = createEvent({ created_at: 2000, duration_ms: 0 })
-		const segments = buildTimeline(session, [event])
-
-		expect(segments).toHaveLength(3)
-		expect(segments[1].durationMs).toBe(0)
+		const segments = buildTimeline(session, [], activities)
+		// Should merge the two agent segments
+		const agentSegments = segments.filter((s) => s.type === "agent")
+		expect(agentSegments.length).toBe(1)
+		expect(agentSegments[0].durationMs).toBe(4000)
 	})
 })
 
@@ -167,105 +123,38 @@ describe("renderTimeline", () => {
 		expect(result).toBe("  No timeline data")
 	})
 
-	it("renders single solo segment", () => {
+	it("renders three-category timeline", () => {
 		const segments: TimelineSegment[] = [
-			{ type: "solo", startMs: 0, endMs: 60000, durationMs: 60000 },
+			{ type: "agent", startMs: 0, endMs: 4000, durationMs: 4000 },
+			{ type: "hitl", startMs: 4000, endMs: 7000, durationMs: 3000 },
+			{ type: "idle", startMs: 7000, endMs: 10000, durationMs: 3000 },
 		]
-		const result = renderTimeline(segments, mockTheme, 10)
+		const result = renderTimeline(segments, mockTheme, 30)
 
 		const lines = result.split("\n")
-		expect(lines[0]).toBe("██████████") // All solo chars
-		expect(lines[1]).toContain("solo")
-	})
-
-	it("renders single hitl segment", () => {
-		const segments: TimelineSegment[] = [
-			{ type: "hitl", startMs: 0, endMs: 60000, durationMs: 60000 },
-		]
-		const result = renderTimeline(segments, mockTheme, 10)
-
-		const lines = result.split("\n")
-		expect(lines[0]).toBe("▓▓▓▓▓▓▓▓▓▓") // All hitl chars
+		expect(lines.length).toBe(2) // bar line + legend
+		expect(lines[1]).toContain("agent")
 		expect(lines[1]).toContain("HITL")
+		expect(lines[1]).toContain("idle")
 	})
 
-	it("renders mixed segments with correct proportions", () => {
+	it("uses correct characters for each category", () => {
 		const segments: TimelineSegment[] = [
-			{ type: "solo", startMs: 0, endMs: 4000, durationMs: 4000 },
-			{ type: "hitl", startMs: 4000, endMs: 5000, durationMs: 1000 },
-			{ type: "solo", startMs: 5000, endMs: 10000, durationMs: 5000 },
+			{ type: "agent", startMs: 0, endMs: 1000, durationMs: 1000 },
+			{ type: "hitl", startMs: 1000, endMs: 2000, durationMs: 1000 },
+			{ type: "idle", startMs: 2000, endMs: 3000, durationMs: 1000 },
 		]
-		const result = renderTimeline(segments, mockTheme, 10)
+		const result = renderTimeline(segments, mockTheme, 30)
 
-		const lines = result.split("\n")
-		const bar = lines[0]
-		expect(bar.length).toBe(10)
-
-		const soloCount = (bar.match(/█/g) || []).length
-		const hitlCount = (bar.match(/▓/g) || []).length
-		expect(soloCount).toBeGreaterThanOrEqual(8)
-		expect(hitlCount).toBeGreaterThanOrEqual(1)
-	})
-
-	it("shows both solo and HITL in legend", () => {
-		const segments: TimelineSegment[] = [
-			{ type: "solo", startMs: 0, endMs: 60000, durationMs: 60000 },
-			{ type: "hitl", startMs: 60000, endMs: 120000, durationMs: 60000 },
-		]
-		const result = renderTimeline(segments, mockTheme, 20)
-
-		const lines = result.split("\n")
-		expect(lines[1]).toContain("█")
-		expect(lines[1]).toContain("solo")
-		expect(lines[1]).toContain("▓")
-		expect(lines[1]).toContain("HITL")
-	})
-
-	it("handles very short segments in narrow width", () => {
-		const segments: TimelineSegment[] = [
-			{ type: "solo", startMs: 0, endMs: 100000, durationMs: 100000 },
-			{ type: "hitl", startMs: 100000, endMs: 100050, durationMs: 50 },
-		]
-		// With limited width, dominant segment fills the bar
-		const result = renderTimeline(segments, mockTheme, 20)
-
-		const lines = result.split("\n")
-		const bar = lines[0]
-		expect(bar.length).toBe(20)
-		// Legend still shows both segment types
-		expect(lines[1]).toContain("solo")
-		expect(lines[1]).toContain("HITL")
+		const bar = result.split("\n")[0]
+		expect(bar).toContain("█") // agent
+		expect(bar).toContain("▓") // hitl
+		expect(bar).toContain("░") // idle
 	})
 
 	it("handles zero duration total", () => {
-		const segments: TimelineSegment[] = [
-			{ type: "solo", startMs: 1000, endMs: 1000, durationMs: 0 },
-		]
+		const segments: TimelineSegment[] = [{ type: "agent", startMs: 1000, endMs: 1000, durationMs: 0 }]
 		const result = renderTimeline(segments, mockTheme)
-
 		expect(result).toContain("─")
-	})
-
-	it("skips zero-duration segments in rendering", () => {
-		const segments: TimelineSegment[] = [
-			{ type: "solo", startMs: 0, endMs: 5000, durationMs: 5000 },
-			{ type: "hitl", startMs: 5000, endMs: 5000, durationMs: 0 },
-			{ type: "solo", startMs: 5000, endMs: 10000, durationMs: 5000 },
-		]
-		const result = renderTimeline(segments, mockTheme, 10)
-
-		const lines = result.split("\n")
-		const bar = lines[0]
-		expect(bar).not.toContain("▓")
-	})
-
-	it("uses default width of 60", () => {
-		const segments: TimelineSegment[] = [
-			{ type: "solo", startMs: 0, endMs: 1000, durationMs: 1000 },
-		]
-		const result = renderTimeline(segments, mockTheme)
-
-		const lines = result.split("\n")
-		expect(lines[0].length).toBe(60)
 	})
 })

--- a/extensions/hitl-metrics/timeline.test.ts
+++ b/extensions/hitl-metrics/timeline.test.ts
@@ -4,21 +4,32 @@
  * Comprehensive tests for timeline segment computation and ASCII chart rendering.
  */
 
-import { describe, it, expect } from "bun:test"
-import { buildTimeline, renderTimeline } from "./timeline.ts"
-import type { HitlSession, HitlEvent, TimelineSegment } from "./types.ts"
-import type { Theme } from "./formatters.ts"
+import { describe, it, expect } from "vitest"
+import { buildTimeline, renderTimeline } from "./timeline.js"
+import type { HitlSession, HitlEvent, TimelineSegment } from "./types.js"
+import type { Theme } from "@mariozechner/pi-coding-agent"
 
-// Mock theme for testing (no ANSI colors)
-const mockTheme: Theme = {
-	fg: (_color: string, text: string) => text,
-	bg: (_color: string, text: string) => text,
-	bold: (text: string) => text,
-	dim: (text: string) => text,
-	italic: (text: string) => text,
-	underline: (text: string) => text,
-	strikethrough: (text: string) => text,
+// Mock theme for testing (no ANSI colors) — implements Theme interface
+function createMockTheme(): Theme {
+	const noOp = (text: string) => text
+	return {
+		name: "mock",
+		fg: (_c, text) => text,
+		bg: (_c, text) => text,
+		bold: noOp,
+		italic: noOp,
+		underline: noOp,
+		inverse: noOp,
+		strikethrough: noOp,
+		getFgAnsi: () => "",
+		getBgAnsi: () => "",
+		getColorMode: () => "truecolor",
+		getThinkingBorderColor: () => noOp,
+		getBashModeBorderColor: () => noOp,
+	} as unknown as Theme
 }
+
+const mockTheme = createMockTheme()
 
 // Helper to create a session
 function createSession(overrides: Partial<HitlSession> = {}): HitlSession {

--- a/extensions/hitl-metrics/timeline.ts
+++ b/extensions/hitl-metrics/timeline.ts
@@ -1,0 +1,185 @@
+/**
+ * Timeline Chart Renderer
+ *
+ * Pure functions for building session timelines and rendering ASCII charts.
+ * No side effects — completely testable.
+ */
+
+import type { HitlSession, HitlEvent, TimelineSegment } from "./types.ts"
+import type { Theme } from "./formatters.ts"
+import { formatDuration } from "./formatters.ts"
+
+/** Default chart width in characters */
+const DEFAULT_WIDTH = 60
+
+/** Character for solo time segments (agent-only) */
+const SOLO_CHAR = "█"
+
+/** Character for HITL time segments (human-in-the-loop) */
+const HITL_CHAR = "▓"
+
+/**
+ * Build timeline segments from session and events.
+ *
+ * Timeline structure:
+ * 1. Solo from session start → first event created_at
+ * 2. HITL from first event created_at → created_at + duration_ms
+ * 3. Solo from end of HITL → next event created_at
+ * 4. ... repeat for all events ...
+ * 5. Solo from end of last HITL → session end (or now if active)
+ *
+ * @param session - The HITL session with start/end times
+ * @param events - Array of HITL events ordered by created_at
+ * @returns Array of timeline segments
+ */
+export function buildTimeline(
+	session: HitlSession,
+	events: HitlEvent[],
+): TimelineSegment[] {
+	const segments: TimelineSegment[] = []
+	const sessionStart = session.started_at
+	const sessionEnd = session.ended_at ?? Date.now()
+
+	// No events → single solo segment spanning the session
+	if (events.length === 0) {
+		return [
+			{
+				type: "solo",
+				startMs: sessionStart,
+				endMs: sessionEnd,
+				durationMs: sessionEnd - sessionStart,
+			},
+		]
+	}
+
+	let currentTime = sessionStart
+
+	for (const event of events) {
+		const eventStart = event.created_at
+		const eventEnd = event.created_at + event.duration_ms
+
+		// Solo segment before this event (if there's a gap)
+		if (eventStart > currentTime) {
+			segments.push({
+				type: "solo",
+				startMs: currentTime,
+				endMs: eventStart,
+				durationMs: eventStart - currentTime,
+			})
+		}
+
+		// HITL segment for this event
+		segments.push({
+			type: "hitl",
+			startMs: eventStart,
+			endMs: eventEnd,
+			durationMs: event.duration_ms,
+		})
+
+		currentTime = eventEnd
+	}
+
+	// Final solo segment after last event (if session continues)
+	if (currentTime < sessionEnd) {
+		segments.push({
+			type: "solo",
+			startMs: currentTime,
+			endMs: sessionEnd,
+			durationMs: sessionEnd - currentTime,
+		})
+	}
+
+	return segments
+}
+
+/**
+ * Render timeline segments as an ASCII bar chart.
+ *
+ * @param segments - Array of timeline segments
+ * @param theme - Theme for color formatting
+ * @param width - Chart width in characters (default: 60)
+ * @returns Multi-line string with bar and legend
+ */
+export function renderTimeline(
+	segments: TimelineSegment[],
+	theme: Theme,
+	width: number = DEFAULT_WIDTH,
+): string {
+	if (segments.length === 0) {
+		return "  No timeline data"
+	}
+
+	// Calculate totals
+	let totalSoloMs = 0
+	let totalHitlMs = 0
+	let totalDurationMs = 0
+
+	for (const segment of segments) {
+		totalDurationMs += segment.durationMs
+		if (segment.type === "solo") {
+			totalSoloMs += segment.durationMs
+		} else {
+			totalHitlMs += segment.durationMs
+		}
+	}
+
+	// Handle zero duration edge case
+	if (totalDurationMs === 0) {
+		return "  ─".repeat(Math.floor(width / 2))
+	}
+
+	// Build the bar
+	const barChars: string[] = []
+	let soloChars = 0
+	let hitlChars = 0
+
+	for (const segment of segments) {
+		// Skip zero-duration segments
+		if (segment.durationMs <= 0) continue
+
+		// Calculate proportional width (minimum 1 char for any non-zero segment)
+		const proportion = segment.durationMs / totalDurationMs
+		let charCount = Math.max(1, Math.round(proportion * width))
+
+		// Don't exceed remaining width
+		const remainingWidth = width - barChars.length
+		if (charCount > remainingWidth) {
+			charCount = remainingWidth
+		}
+		if (charCount <= 0) break
+
+		const char = segment.type === "solo" ? SOLO_CHAR : HITL_CHAR
+		for (let i = 0; i < charCount; i++) {
+			barChars.push(char)
+		}
+
+		if (segment.type === "solo") {
+			soloChars += charCount
+		} else {
+			hitlChars += charCount
+		}
+	}
+
+	// Pad or trim to exact width
+	while (barChars.length < width) {
+		barChars.push(SOLO_CHAR)
+	}
+	const barLine = barChars.slice(0, width).join("")
+
+	// Color the bar
+	let coloredBar = ""
+	for (const char of barLine) {
+		if (char === SOLO_CHAR) {
+			coloredBar += theme.fg("cyan", char)
+		} else {
+			coloredBar += theme.fg("yellow", char)
+		}
+	}
+
+	// Build legend
+	const soloLegend = theme.fg("cyan", SOLO_CHAR) + " solo " + formatDuration(totalSoloMs)
+	const hitlLegend = theme.fg("yellow", HITL_CHAR) + " HITL " + formatDuration(totalHitlMs)
+	const legendLine = `  ${soloLegend}    ${hitlLegend}`
+
+	return `${coloredBar}\n${legendLine}`
+}

--- a/extensions/hitl-metrics/timeline.ts
+++ b/extensions/hitl-metrics/timeline.ts
@@ -18,12 +18,12 @@ const IDLE_CHAR = "░"
 export function buildTimeline(session: HitlSession, events: HitlEvent[], activities?: ActivityEvent[]): TimelineSegment[] {
 	const sessionEnd = session.ended_at ?? Date.now()
 	if (activities && activities.length > 0) {
-		return buildTimelineFromActivities(session.started_at, sessionEnd, activities)
+		return buildTimelineFromActivities(session.started_at, session.ended_at ?? null, activities)
 	}
 	return buildTimelineFromEvents(session, events, sessionEnd)
 }
 
-function buildTimelineFromActivities(sessionStart: number, sessionEnd: number, activities: ActivityEvent[]): TimelineSegment[] {
+function buildTimelineFromActivities(sessionStart: number, sessionEndedAt: number | null, activities: ActivityEvent[]): TimelineSegment[] {
 	const segments: TimelineSegment[] = []
 	sortActivities(activities)
 
@@ -45,8 +45,21 @@ function buildTimelineFromActivities(sessionStart: number, sessionEnd: number, a
 		pushSegment(segments, currentSegment, currentTime)
 	}
 
-	if (currentTime < sessionEnd) {
-		segments.push({ type: "idle", startMs: currentTime, endMs: sessionEnd, durationMs: sessionEnd - currentTime })
+	if (sessionEndedAt !== null) {
+		// Closed session: fill the remaining gap to session end
+		if (currentTime < sessionEndedAt) {
+			segments.push({ type: "idle", startMs: currentTime, endMs: sessionEndedAt, durationMs: sessionEndedAt - currentTime })
+		}
+	} else {
+		// Active session: only append trailing idle if we're actively waiting (last activity was idle_start)
+		const lastActivity = activities[activities.length - 1]
+		if (lastActivity?.activity_type === "idle_start") {
+			const now = Date.now()
+			if (currentTime < now) {
+				segments.push({ type: "idle", startMs: currentTime, endMs: now, durationMs: now - currentTime })
+			}
+		}
+		// Otherwise: agent finished last turn — no trailing segment shown
 	}
 
 	return mergeConsecutiveSegments(segments)

--- a/extensions/hitl-metrics/timeline.ts
+++ b/extensions/hitl-metrics/timeline.ts
@@ -5,9 +5,9 @@
  * No side effects — completely testable.
  */
 
-import type { HitlSession, HitlEvent, TimelineSegment } from "./types.ts"
-import type { Theme } from "./formatters.ts"
-import { formatDuration } from "./formatters.ts"
+import type { HitlSession, HitlEvent, TimelineSegment } from "./types.js"
+import type { Theme } from "@mariozechner/pi-coding-agent"
+import { formatDuration } from "./formatters.js"
 
 /** Default chart width in characters */
 const DEFAULT_WIDTH = 60
@@ -166,19 +166,19 @@ export function renderTimeline(
 	}
 	const barLine = barChars.slice(0, width).join("")
 
-	// Color the bar
+	// Color the bar - use theme colors that exist in ThemeColor type
 	let coloredBar = ""
 	for (const char of barLine) {
 		if (char === SOLO_CHAR) {
-			coloredBar += theme.fg("cyan", char)
+			coloredBar += theme.fg("success", char)
 		} else {
-			coloredBar += theme.fg("yellow", char)
+			coloredBar += theme.fg("warning", char)
 		}
 	}
 
-	// Build legend
-	const soloLegend = theme.fg("cyan", SOLO_CHAR) + " solo " + formatDuration(totalSoloMs)
-	const hitlLegend = theme.fg("yellow", HITL_CHAR) + " HITL " + formatDuration(totalHitlMs)
+	// Build legend - use theme colors that exist
+	const soloLegend = theme.fg("success", SOLO_CHAR) + " solo " + formatDuration(totalSoloMs)
+	const hitlLegend = theme.fg("warning", HITL_CHAR) + " HITL " + formatDuration(totalHitlMs)
 	const legendLine = `  ${soloLegend}    ${hitlLegend}`
 
 	return `${coloredBar}\n${legendLine}`

--- a/extensions/hitl-metrics/timeline.ts
+++ b/extensions/hitl-metrics/timeline.ts
@@ -2,184 +2,193 @@
  * Timeline Chart Renderer
  *
  * Pure functions for building session timelines and rendering ASCII charts.
- * No side effects — completely testable.
+ * Supports three time categories: agent, hitl, idle.
  */
 
-import type { HitlSession, HitlEvent, TimelineSegment } from "./types.js"
+import type { HitlSession, HitlEvent, ActivityEvent, TimelineSegment } from "./types.js"
 import type { Theme } from "@mariozechner/pi-coding-agent"
 import { formatDuration } from "./formatters.js"
 
-/** Default chart width in characters */
 const DEFAULT_WIDTH = 60
 
-/** Character for solo time segments (agent-only) */
-const SOLO_CHAR = "█"
-
-/** Character for HITL time segments (human-in-the-loop) */
+const AGENT_CHAR = "█"
 const HITL_CHAR = "▓"
+const IDLE_CHAR = "░"
 
-/**
- * Build timeline segments from session and events.
- *
- * Timeline structure:
- * 1. Solo from session start → first event created_at
- * 2. HITL from first event created_at → created_at + duration_ms
- * 3. Solo from end of HITL → next event created_at
- * 4. ... repeat for all events ...
- * 5. Solo from end of last HITL → session end (or now if active)
- *
- * @param session - The HITL session with start/end times
- * @param events - Array of HITL events ordered by created_at
- * @returns Array of timeline segments
- */
-export function buildTimeline(
-	session: HitlSession,
-	events: HitlEvent[],
-): TimelineSegment[] {
-	const segments: TimelineSegment[] = []
-	const sessionStart = session.started_at
+export function buildTimeline(session: HitlSession, events: HitlEvent[], activities?: ActivityEvent[]): TimelineSegment[] {
 	const sessionEnd = session.ended_at ?? Date.now()
-
-	// No events → single solo segment spanning the session
-	if (events.length === 0) {
-		return [
-			{
-				type: "solo",
-				startMs: sessionStart,
-				endMs: sessionEnd,
-				durationMs: sessionEnd - sessionStart,
-			},
-		]
+	if (activities && activities.length > 0) {
+		return buildTimelineFromActivities(session.started_at, sessionEnd, activities)
 	}
+	return buildTimelineFromEvents(session, events, sessionEnd)
+}
+
+function buildTimelineFromActivities(sessionStart: number, sessionEnd: number, activities: ActivityEvent[]): TimelineSegment[] {
+	const segments: TimelineSegment[] = []
+	sortActivities(activities)
 
 	let currentTime = sessionStart
+	let currentSegment: TimelineSegment | null = null
+
+	for (const activity of activities) {
+		const type = activityTypeToSegmentType(activity.activity_type)
+		if (!currentSegment || currentSegment.type !== type) {
+			if (currentSegment) {
+				pushSegment(segments, currentSegment, currentTime)
+			}
+			currentSegment = createSegment(type, currentTime)
+		}
+		currentTime = activity.timestamp
+	}
+
+	if (currentSegment) {
+		pushSegment(segments, currentSegment, currentTime)
+	}
+
+	if (currentTime < sessionEnd) {
+		segments.push({ type: "idle", startMs: currentTime, endMs: sessionEnd, durationMs: sessionEnd - currentTime })
+	}
+
+	return mergeConsecutiveSegments(segments)
+}
+
+function sortActivities(activities: ActivityEvent[]): void {
+	activities.sort((a, b) => a.timestamp - b.timestamp)
+}
+
+function createSegment(type: TimelineSegment["type"], startMs: number): TimelineSegment {
+	return { type, startMs, endMs: startMs, durationMs: 0 }
+}
+
+function pushSegment(segments: TimelineSegment[], segment: TimelineSegment, endTime: number): void {
+	if (endTime > segment.startMs) {
+		segment.endMs = endTime
+		segment.durationMs = endTime - segment.startMs
+		segments.push(segment)
+	}
+}
+
+function activityTypeToSegmentType(activityType: ActivityEvent["activity_type"]): TimelineSegment["type"] {
+	if (activityType === "tool_start" || activityType === "tool_end") return "agent"
+	if (activityType === "user_input") return "hitl"
+	return "idle"
+}
+
+function buildTimelineFromEvents(session: HitlSession, events: HitlEvent[], sessionEnd: number): TimelineSegment[] {
+	if (events.length === 0) {
+		return buildFromSessionTotals(session, sessionEnd)
+	}
+
+	const segments: TimelineSegment[] = []
+	let currentTime = session.started_at
 
 	for (const event of events) {
 		const eventStart = event.created_at
-		const eventEnd = event.created_at + event.duration_ms
-
-		// Solo segment before this event (if there's a gap)
 		if (eventStart > currentTime) {
-			segments.push({
-				type: "solo",
-				startMs: currentTime,
-				endMs: eventStart,
-				durationMs: eventStart - currentTime,
-			})
+			segments.push({ type: "agent", startMs: currentTime, endMs: eventStart, durationMs: eventStart - currentTime })
 		}
-
-		// HITL segment for this event
-		segments.push({
-			type: "hitl",
-			startMs: eventStart,
-			endMs: eventEnd,
-			durationMs: event.duration_ms,
-		})
-
+		const eventEnd = eventStart + event.duration_ms
+		segments.push({ type: "hitl", startMs: eventStart, endMs: eventEnd, durationMs: event.duration_ms })
 		currentTime = eventEnd
 	}
 
-	// Final solo segment after last event (if session continues)
 	if (currentTime < sessionEnd) {
-		segments.push({
-			type: "solo",
-			startMs: currentTime,
-			endMs: sessionEnd,
-			durationMs: sessionEnd - currentTime,
-		})
+		const remaining = sessionEnd - currentTime
+		segments.push({ type: session.idle_time_ms >= remaining ? "idle" : "agent", startMs: currentTime, endMs: sessionEnd, durationMs: remaining })
+	}
+
+	return mergeConsecutiveSegments(segments)
+}
+
+function buildFromSessionTotals(session: HitlSession, sessionEnd: number): TimelineSegment[] {
+	const segments: TimelineSegment[] = []
+	let currentTime = session.started_at
+
+	if (session.agent_time_ms > 0) {
+		segments.push({ type: "agent", startMs: currentTime, endMs: currentTime + session.agent_time_ms, durationMs: session.agent_time_ms })
+		currentTime += session.agent_time_ms
+	}
+	if (session.hitl_time_ms > 0) {
+		segments.push({ type: "hitl", startMs: currentTime, endMs: currentTime + session.hitl_time_ms, durationMs: session.hitl_time_ms })
+		currentTime += session.hitl_time_ms
+	}
+	if (session.idle_time_ms > 0) {
+		const idleStart = sessionEnd - session.idle_time_ms
+		segments.push({ type: "idle", startMs: idleStart, endMs: sessionEnd, durationMs: session.idle_time_ms })
 	}
 
 	return segments
 }
 
-/**
- * Render timeline segments as an ASCII bar chart.
- *
- * @param segments - Array of timeline segments
- * @param theme - Theme for color formatting
- * @param width - Chart width in characters (default: 60)
- * @returns Multi-line string with bar and legend
- */
-export function renderTimeline(
-	segments: TimelineSegment[],
-	theme: Theme,
-	width: number = DEFAULT_WIDTH,
-): string {
-	if (segments.length === 0) {
-		return "  No timeline data"
-	}
-
-	// Calculate totals
-	let totalSoloMs = 0
-	let totalHitlMs = 0
-	let totalDurationMs = 0
-
+function mergeConsecutiveSegments(segments: TimelineSegment[]): TimelineSegment[] {
+	const merged: TimelineSegment[] = []
 	for (const segment of segments) {
-		totalDurationMs += segment.durationMs
-		if (segment.type === "solo") {
-			totalSoloMs += segment.durationMs
+		if (segment.durationMs <= 0) continue
+		const last = merged[merged.length - 1]
+		if (last && last.type === segment.type) {
+			last.endMs = segment.endMs
+			last.durationMs += segment.durationMs
 		} else {
-			totalHitlMs += segment.durationMs
+			merged.push({ ...segment })
 		}
 	}
+	return merged
+}
 
-	// Handle zero duration edge case
-	if (totalDurationMs === 0) {
+export function renderTimeline(segments: TimelineSegment[], theme: Theme, width: number = DEFAULT_WIDTH): string {
+	if (segments.length === 0) return "  No timeline data"
+
+	const { totalAgentMs, totalHitlMs, totalIdleMs } = calculateTotals(segments)
+
+	const totalDurationMs = segments.reduce((max, s) => Math.max(max, s.endMs), 0) - segments[0].startMs
+	if (totalDurationMs <= 0 || segments.every((s) => s.durationMs <= 0)) {
 		return "  ─".repeat(Math.floor(width / 2))
 	}
 
-	// Build the bar
+	const barLine = buildBar(segments, totalDurationMs, width)
+	const coloredBar = applyColors(barLine, theme)
+	const legend = buildLegend(totalAgentMs, totalHitlMs, totalIdleMs, theme)
+
+	return `${coloredBar}\n${legend}`
+}
+
+function calculateTotals(segments: TimelineSegment[]) {
+	let totalAgentMs = 0, totalHitlMs = 0, totalIdleMs = 0, totalDurationMs = 0
+	for (const s of segments) {
+		totalDurationMs += s.durationMs
+		if (s.type === "agent") totalAgentMs += s.durationMs
+		else if (s.type === "hitl") totalHitlMs += s.durationMs
+		else totalIdleMs += s.durationMs
+	}
+	return { totalAgentMs, totalHitlMs, totalIdleMs, totalDurationMs }
+}
+
+function buildBar(segments: TimelineSegment[], totalDurationMs: number, width: number): string {
 	const barChars: string[] = []
-	let soloChars = 0
-	let hitlChars = 0
-
 	for (const segment of segments) {
-		// Skip zero-duration segments
 		if (segment.durationMs <= 0) continue
-
-		// Calculate proportional width (minimum 1 char for any non-zero segment)
-		const proportion = segment.durationMs / totalDurationMs
-		let charCount = Math.max(1, Math.round(proportion * width))
-
-		// Don't exceed remaining width
-		const remainingWidth = width - barChars.length
-		if (charCount > remainingWidth) {
-			charCount = remainingWidth
-		}
-		if (charCount <= 0) break
-
-		const char = segment.type === "solo" ? SOLO_CHAR : HITL_CHAR
-		for (let i = 0; i < charCount; i++) {
-			barChars.push(char)
-		}
-
-		if (segment.type === "solo") {
-			soloChars += charCount
-		} else {
-			hitlChars += charCount
-		}
+		const count = Math.min(Math.max(1, Math.round((segment.durationMs / totalDurationMs) * width)), width - barChars.length)
+		if (count <= 0) break
+		const char = segment.type === "agent" ? AGENT_CHAR : segment.type === "hitl" ? HITL_CHAR : IDLE_CHAR
+		barChars.push(...Array(count).fill(char))
 	}
+	while (barChars.length < width) barChars.push(IDLE_CHAR)
+	return barChars.slice(0, width).join("")
+}
 
-	// Pad or trim to exact width
-	while (barChars.length < width) {
-		barChars.push(SOLO_CHAR)
-	}
-	const barLine = barChars.slice(0, width).join("")
-
-	// Color the bar - use theme colors that exist in ThemeColor type
-	let coloredBar = ""
+function applyColors(barLine: string, theme: Theme): string {
+	let colored = ""
 	for (const char of barLine) {
-		if (char === SOLO_CHAR) {
-			coloredBar += theme.fg("success", char)
-		} else {
-			coloredBar += theme.fg("warning", char)
-		}
+		if (char === AGENT_CHAR) colored += theme.fg("success", char)
+		else if (char === HITL_CHAR) colored += theme.fg("warning", char)
+		else colored += theme.fg("muted", char)
 	}
+	return colored
+}
 
-	// Build legend - use theme colors that exist
-	const soloLegend = theme.fg("success", SOLO_CHAR) + " solo " + formatDuration(totalSoloMs)
-	const hitlLegend = theme.fg("warning", HITL_CHAR) + " HITL " + formatDuration(totalHitlMs)
-	const legendLine = `  ${soloLegend}    ${hitlLegend}`
-
-	return `${coloredBar}\n${legendLine}`
+function buildLegend(agentMs: number, hitlMs: number, idleMs: number, theme: Theme): string {
+	const agent = theme.fg("success", AGENT_CHAR) + " agent " + formatDuration(agentMs)
+	const hitl = theme.fg("warning", HITL_CHAR) + " HITL " + formatDuration(hitlMs)
+	const idle = theme.fg("muted", IDLE_CHAR) + " idle " + formatDuration(idleMs)
+	return `  ${agent}  ${hitl}  ${idle}`
 }

--- a/extensions/hitl-metrics/tsconfig.json
+++ b/extensions/hitl-metrics/tsconfig.json
@@ -9,6 +9,6 @@
 		"declaration": true,
 		"outDir": "./dist"
 	},
-	"include": ["**/*.ts"],
+	"include": ["**/*.ts", "types/**/*.d.ts"],
 	"exclude": ["**/*.test.ts", "dist"]
 }

--- a/extensions/hitl-metrics/tsconfig.json
+++ b/extensions/hitl-metrics/tsconfig.json
@@ -1,0 +1,14 @@
+{
+	"compilerOptions": {
+		"target": "ES2023",
+		"module": "NodeNext",
+		"moduleResolution": "NodeNext",
+		"esModuleInterop": true,
+		"strict": true,
+		"skipLibCheck": true,
+		"declaration": true,
+		"outDir": "./dist"
+	},
+	"include": ["**/*.ts"],
+	"exclude": ["**/*.test.ts", "dist"]
+}

--- a/extensions/hitl-metrics/types.ts
+++ b/extensions/hitl-metrics/types.ts
@@ -1,0 +1,69 @@
+/**
+ * HITL (Human-in-the-Loop) Metrics Type Definitions
+ *
+ * Type contracts for tracking interactive user sessions and events.
+ */
+
+/**
+ * Represents a HITL session - a period of interactive user engagement
+ */
+export interface HitlSession {
+	/** UUID primary key */
+	id: string
+	/** Project hash (SHA-256 truncated to 16 hex chars) for multi-project isolation */
+	project_hash: string
+	/** Session start time (Unix epoch milliseconds) */
+	started_at: number
+	/** Session end time (null if active) */
+	ended_at: number | null
+	/** Current session status */
+	status: "active" | "closed" | "orphaned"
+}
+
+/**
+ * Represents a single HITL interaction event
+ */
+export interface HitlEvent {
+	/** Auto-incrementing primary key */
+	id: number
+	/** Foreign key to hitl_sessions.id */
+	session_id: string
+	/** Name of the tool that triggered the interaction */
+	tool_name: string
+	/** Number of questions asked in this event */
+	question_count: number
+	/** Duration in milliseconds from question to completion */
+	duration_ms: number
+	/** JSON array of selected options */
+	selected_options: string
+	/** Event creation time (Unix epoch milliseconds) */
+	created_at: number
+}
+
+/**
+ * Aggregated HITL statistics for a project
+ */
+export interface HitlStats {
+	/** Total number of HITL sessions */
+	total_sessions: number
+	/** Total time spent in HITL interactions (ms) */
+	total_hitl_time_ms: number
+	/** Total number of interaction events */
+	interaction_count: number
+	/** Average wait time per interaction (ms) */
+	avg_wait_ms: number
+}
+
+/**
+ * Timeline segment representing either solo or HITL time period
+ */
+export interface TimelineSegment {
+	/** Type of segment: 'solo' for agent-only, 'hitl' for human-in-the-loop */
+	type: "solo" | "hitl"
+	/** Start time in milliseconds (Unix epoch) */
+	startMs: number
+	/** End time in milliseconds (Unix epoch) */
+	endMs: number
+	/** Duration in milliseconds */
+	durationMs: number
+}

--- a/extensions/hitl-metrics/types.ts
+++ b/extensions/hitl-metrics/types.ts
@@ -18,6 +18,8 @@ export interface HitlSession {
 	ended_at: number | null
 	/** Current session status */
 	status: "active" | "closed" | "orphaned"
+	/** Allow string indexing for SQLite query results */
+	[key: string]: unknown
 }
 
 /**
@@ -38,6 +40,8 @@ export interface HitlEvent {
 	selected_options: string
 	/** Event creation time (Unix epoch milliseconds) */
 	created_at: number
+	/** Allow string indexing for SQLite query results */
+	[key: string]: unknown
 }
 
 /**

--- a/extensions/hitl-metrics/types.ts
+++ b/extensions/hitl-metrics/types.ts
@@ -18,6 +18,14 @@ export interface HitlSession {
 	ended_at: number | null
 	/** Current session status */
 	status: "active" | "closed" | "orphaned"
+	/** Reason for session end (null if active) */
+	end_cause: "complete" | "disconnect" | "signal" | "orphaned" | null | undefined
+	/** Total time agent spent executing tools (milliseconds) */
+	agent_time_ms: number
+	/** Total time spent in HITL interactions (milliseconds) */
+	hitl_time_ms: number
+	/** Total idle time waiting for user input (milliseconds) */
+	idle_time_ms: number
 	/** Allow string indexing for SQLite query results */
 	[key: string]: unknown
 }
@@ -45,6 +53,26 @@ export interface HitlEvent {
 }
 
 /**
+ * Represents an activity tracking event for detailed timeline reconstruction
+ */
+export interface ActivityEvent {
+	/** Auto-incrementing primary key */
+	id: number
+	/** Foreign key to hitl_sessions.id */
+	session_id: string
+	/** Type of activity recorded */
+	activity_type: "tool_start" | "tool_end" | "user_input" | "idle_start" | "idle_end"
+	/** Tool name for tool events */
+	tool_name: string | null
+	/** Duration in milliseconds (for completed activities) */
+	duration_ms: number | null
+	/** Event timestamp (Unix epoch milliseconds) */
+	timestamp: number
+	/** Allow string indexing for SQLite query results */
+	[key: string]: unknown
+}
+
+/**
  * Aggregated HITL statistics for a project
  */
 export interface HitlStats {
@@ -56,14 +84,42 @@ export interface HitlStats {
 	interaction_count: number
 	/** Average wait time per interaction (ms) */
 	avg_wait_ms: number
+	/** Total number of permission/approval interactions */
+	permission_count: number
+	/** Total time spent waiting for permission responses (ms) */
+	total_permission_time_ms: number
 }
 
 /**
- * Timeline segment representing either solo or HITL time period
+ * Represents a permission/approval event
+ */
+export interface HitlPermissionEvent {
+	/** Auto-incrementing primary key */
+	id: number
+	/** Foreign key to hitl_sessions.id */
+	session_id: string
+	/** Name of the tool that requires permission */
+	tool_name: string
+	/** Action/command being requested */
+	action: string
+	/** Outcome of the permission request */
+	outcome: "allow" | "allow_once" | "allow_remember" | "deny" | "deny_feedback" | "blocked"
+	/** Reason for block/denial (if applicable) */
+	reason: string | null
+	/** Duration in milliseconds from prompt to response */
+	duration_ms: number
+	/** Event creation time (Unix epoch milliseconds) */
+	created_at: number
+	/** Allow string indexing for SQLite query results */
+	[key: string]: unknown
+}
+
+/**
+ * Timeline segment representing time spent in different states
  */
 export interface TimelineSegment {
-	/** Type of segment: 'solo' for agent-only, 'hitl' for human-in-the-loop */
-	type: "solo" | "hitl"
+	/** Type of segment: 'agent', 'hitl', or 'idle' */
+	type: "agent" | "hitl" | "idle"
 	/** Start time in milliseconds (Unix epoch) */
 	startMs: number
 	/** End time in milliseconds (Unix epoch) */

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,6945 @@
+{
+	"name": "@kimchi-dev/cli",
+	"version": "0.1.0",
+	"lockfileVersion": 3,
+	"requires": true,
+	"packages": {
+		"": {
+			"name": "@kimchi-dev/cli",
+			"version": "0.1.0",
+			"license": "MIT",
+			"dependencies": {
+				"@agentclientprotocol/sdk": "^0.19.0",
+				"@clack/prompts": "^1.2.0",
+				"@mariozechner/pi-coding-agent": "^0.67.68",
+				"@mariozechner/pi-tui": "^0.67.68",
+				"@modelcontextprotocol/ext-apps": "^1.2.2",
+				"@modelcontextprotocol/sdk": "^1.25.1",
+				"micromatch": "^4.0.8",
+				"open": "^10.2.0",
+				"shell-quote": "^1.8.3",
+				"undici": "^8.0.2",
+				"uuid": "^14.0.0",
+				"zod": "^4.0.0"
+			},
+			"bin": {
+				"kimchi-code": "src/entry.ts"
+			},
+			"devDependencies": {
+				"@biomejs/biome": "^1.9.4",
+				"@mariozechner/pi-ai": "^0.67.68",
+				"@mixmark-io/domino": "^2.2.0",
+				"@types/micromatch": "^4.0.10",
+				"@types/node": "^22.15.2",
+				"@types/shell-quote": "^1.7.5",
+				"@types/turndown": "^5.0.5",
+				"node-pty": "^1.1.0",
+				"playwright": "^1.52.0",
+				"tsx": "^4.21.0",
+				"turndown": "^7.2.0",
+				"typescript": "^5.7.3",
+				"vitest": "^3.1.1"
+			},
+			"engines": {
+				"node": ">=22.0.0"
+			},
+			"peerDependencies": {
+				"@sinclair/typebox": "*"
+			}
+		},
+		"node_modules/@agentclientprotocol/sdk": {
+			"version": "0.19.2",
+			"resolved": "https://registry.npmjs.org/@agentclientprotocol/sdk/-/sdk-0.19.2.tgz",
+			"integrity": "sha512-G1Qi50Kc2GZxYjvH6t6yG8KFZMVe5vWTzZH4c7ylb0yiqMfNQSBDHPy0FMxYLPsorMqlM+eyV4yRp4oeUjl/Lw==",
+			"license": "Apache-2.0",
+			"peerDependencies": {
+				"zod": "^3.25.0 || ^4.0.0"
+			}
+		},
+		"node_modules/@anthropic-ai/sdk": {
+			"version": "0.90.0",
+			"resolved": "https://registry.npmjs.org/@anthropic-ai/sdk/-/sdk-0.90.0.tgz",
+			"integrity": "sha512-MzZtPabJF1b0FTDl6Z6H5ljphPwACLGP13lu8MTiB8jXaW/YXlpOp+Po2cVou3MPM5+f5toyLnul9whKCy7fBg==",
+			"license": "MIT",
+			"dependencies": {
+				"json-schema-to-ts": "^3.1.1"
+			},
+			"bin": {
+				"anthropic-ai-sdk": "bin/cli"
+			},
+			"peerDependencies": {
+				"zod": "^3.25.0 || ^4.0.0"
+			},
+			"peerDependenciesMeta": {
+				"zod": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/@aws-crypto/crc32": {
+			"version": "5.2.0",
+			"resolved": "https://registry.npmjs.org/@aws-crypto/crc32/-/crc32-5.2.0.tgz",
+			"integrity": "sha512-nLbCWqQNgUiwwtFsen1AdzAtvuLRsQS8rYgMuxCrdKf9kOssamGLuPwyTY9wyYblNr9+1XM8v6zoDTPPSIeANg==",
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@aws-crypto/util": "^5.2.0",
+				"@aws-sdk/types": "^3.222.0",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=16.0.0"
+			}
+		},
+		"node_modules/@aws-crypto/sha256-browser": {
+			"version": "5.2.0",
+			"resolved": "https://registry.npmjs.org/@aws-crypto/sha256-browser/-/sha256-browser-5.2.0.tgz",
+			"integrity": "sha512-AXfN/lGotSQwu6HNcEsIASo7kWXZ5HYWvfOmSNKDsEqC4OashTp8alTmaz+F7TC2L083SFv5RdB+qU3Vs1kZqw==",
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@aws-crypto/sha256-js": "^5.2.0",
+				"@aws-crypto/supports-web-crypto": "^5.2.0",
+				"@aws-crypto/util": "^5.2.0",
+				"@aws-sdk/types": "^3.222.0",
+				"@aws-sdk/util-locate-window": "^3.0.0",
+				"@smithy/util-utf8": "^2.0.0",
+				"tslib": "^2.6.2"
+			}
+		},
+		"node_modules/@aws-crypto/sha256-browser/node_modules/@smithy/is-array-buffer": {
+			"version": "2.2.0",
+			"resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-2.2.0.tgz",
+			"integrity": "sha512-GGP3O9QFD24uGeAXYUjwSTXARoqpZykHadOmA8G5vfJPK0/DC67qa//0qvqrJzL1xc8WQWX7/yc7fwudjPHPhA==",
+			"license": "Apache-2.0",
+			"dependencies": {
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=14.0.0"
+			}
+		},
+		"node_modules/@aws-crypto/sha256-browser/node_modules/@smithy/util-buffer-from": {
+			"version": "2.2.0",
+			"resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-2.2.0.tgz",
+			"integrity": "sha512-IJdWBbTcMQ6DA0gdNhh/BwrLkDR+ADW5Kr1aZmd4k3DIF6ezMV4R2NIAmT08wQJ3yUK82thHWmC/TnK/wpMMIA==",
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@smithy/is-array-buffer": "^2.2.0",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=14.0.0"
+			}
+		},
+		"node_modules/@aws-crypto/sha256-browser/node_modules/@smithy/util-utf8": {
+			"version": "2.3.0",
+			"resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-2.3.0.tgz",
+			"integrity": "sha512-R8Rdn8Hy72KKcebgLiv8jQcQkXoLMOGGv5uI1/k0l+snqkOzQ1R0ChUBCxWMlBsFMekWjq0wRudIweFs7sKT5A==",
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@smithy/util-buffer-from": "^2.2.0",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=14.0.0"
+			}
+		},
+		"node_modules/@aws-crypto/sha256-js": {
+			"version": "5.2.0",
+			"resolved": "https://registry.npmjs.org/@aws-crypto/sha256-js/-/sha256-js-5.2.0.tgz",
+			"integrity": "sha512-FFQQyu7edu4ufvIZ+OadFpHHOt+eSTBaYaki44c+akjg7qZg9oOQeLlk77F6tSYqjDAFClrHJk9tMf0HdVyOvA==",
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@aws-crypto/util": "^5.2.0",
+				"@aws-sdk/types": "^3.222.0",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=16.0.0"
+			}
+		},
+		"node_modules/@aws-crypto/supports-web-crypto": {
+			"version": "5.2.0",
+			"resolved": "https://registry.npmjs.org/@aws-crypto/supports-web-crypto/-/supports-web-crypto-5.2.0.tgz",
+			"integrity": "sha512-iAvUotm021kM33eCdNfwIN//F77/IADDSs58i+MDaOqFrVjZo9bAal0NK7HurRuWLLpF1iLX7gbWrjHjeo+YFg==",
+			"license": "Apache-2.0",
+			"dependencies": {
+				"tslib": "^2.6.2"
+			}
+		},
+		"node_modules/@aws-crypto/util": {
+			"version": "5.2.0",
+			"resolved": "https://registry.npmjs.org/@aws-crypto/util/-/util-5.2.0.tgz",
+			"integrity": "sha512-4RkU9EsI6ZpBve5fseQlGNUWKMa1RLPQ1dnjnQoe07ldfIzcsGb5hC5W0Dm7u423KWzawlrpbjXBrXCEv9zazQ==",
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@aws-sdk/types": "^3.222.0",
+				"@smithy/util-utf8": "^2.0.0",
+				"tslib": "^2.6.2"
+			}
+		},
+		"node_modules/@aws-crypto/util/node_modules/@smithy/is-array-buffer": {
+			"version": "2.2.0",
+			"resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-2.2.0.tgz",
+			"integrity": "sha512-GGP3O9QFD24uGeAXYUjwSTXARoqpZykHadOmA8G5vfJPK0/DC67qa//0qvqrJzL1xc8WQWX7/yc7fwudjPHPhA==",
+			"license": "Apache-2.0",
+			"dependencies": {
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=14.0.0"
+			}
+		},
+		"node_modules/@aws-crypto/util/node_modules/@smithy/util-buffer-from": {
+			"version": "2.2.0",
+			"resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-2.2.0.tgz",
+			"integrity": "sha512-IJdWBbTcMQ6DA0gdNhh/BwrLkDR+ADW5Kr1aZmd4k3DIF6ezMV4R2NIAmT08wQJ3yUK82thHWmC/TnK/wpMMIA==",
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@smithy/is-array-buffer": "^2.2.0",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=14.0.0"
+			}
+		},
+		"node_modules/@aws-crypto/util/node_modules/@smithy/util-utf8": {
+			"version": "2.3.0",
+			"resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-2.3.0.tgz",
+			"integrity": "sha512-R8Rdn8Hy72KKcebgLiv8jQcQkXoLMOGGv5uI1/k0l+snqkOzQ1R0ChUBCxWMlBsFMekWjq0wRudIweFs7sKT5A==",
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@smithy/util-buffer-from": "^2.2.0",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=14.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/client-bedrock-runtime": {
+			"version": "3.1038.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/client-bedrock-runtime/-/client-bedrock-runtime-3.1038.0.tgz",
+			"integrity": "sha512-oGiqs9v9WzPOdv7PDdm9iPibHgrbDvCDyNg43wFZn2PiiEUisFM+xUP2CRMsj41SmwZPhohmZkXiUu1+MghbAQ==",
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@aws-crypto/sha256-browser": "5.2.0",
+				"@aws-crypto/sha256-js": "5.2.0",
+				"@aws-sdk/core": "^3.974.6",
+				"@aws-sdk/credential-provider-node": "^3.972.37",
+				"@aws-sdk/eventstream-handler-node": "^3.972.14",
+				"@aws-sdk/middleware-eventstream": "^3.972.10",
+				"@aws-sdk/middleware-host-header": "^3.972.10",
+				"@aws-sdk/middleware-logger": "^3.972.10",
+				"@aws-sdk/middleware-recursion-detection": "^3.972.11",
+				"@aws-sdk/middleware-user-agent": "^3.972.36",
+				"@aws-sdk/middleware-websocket": "^3.972.16",
+				"@aws-sdk/region-config-resolver": "^3.972.13",
+				"@aws-sdk/token-providers": "3.1038.0",
+				"@aws-sdk/types": "^3.973.8",
+				"@aws-sdk/util-endpoints": "^3.996.8",
+				"@aws-sdk/util-user-agent-browser": "^3.972.10",
+				"@aws-sdk/util-user-agent-node": "^3.973.22",
+				"@smithy/config-resolver": "^4.4.17",
+				"@smithy/core": "^3.23.17",
+				"@smithy/eventstream-serde-browser": "^4.2.14",
+				"@smithy/eventstream-serde-config-resolver": "^4.3.14",
+				"@smithy/eventstream-serde-node": "^4.2.14",
+				"@smithy/fetch-http-handler": "^5.3.17",
+				"@smithy/hash-node": "^4.2.14",
+				"@smithy/invalid-dependency": "^4.2.14",
+				"@smithy/middleware-content-length": "^4.2.14",
+				"@smithy/middleware-endpoint": "^4.4.32",
+				"@smithy/middleware-retry": "^4.5.6",
+				"@smithy/middleware-serde": "^4.2.20",
+				"@smithy/middleware-stack": "^4.2.14",
+				"@smithy/node-config-provider": "^4.3.14",
+				"@smithy/node-http-handler": "^4.6.1",
+				"@smithy/protocol-http": "^5.3.14",
+				"@smithy/smithy-client": "^4.12.13",
+				"@smithy/types": "^4.14.1",
+				"@smithy/url-parser": "^4.2.14",
+				"@smithy/util-base64": "^4.3.2",
+				"@smithy/util-body-length-browser": "^4.2.2",
+				"@smithy/util-body-length-node": "^4.2.3",
+				"@smithy/util-defaults-mode-browser": "^4.3.49",
+				"@smithy/util-defaults-mode-node": "^4.2.54",
+				"@smithy/util-endpoints": "^3.4.2",
+				"@smithy/util-middleware": "^4.2.14",
+				"@smithy/util-retry": "^4.3.5",
+				"@smithy/util-stream": "^4.5.25",
+				"@smithy/util-utf8": "^4.2.2",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=20.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/core": {
+			"version": "3.974.6",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.974.6.tgz",
+			"integrity": "sha512-8Vu7zGxu+39ChR/s5J7nXBw3a2kMHAi0OfKT8ohgTVjX0qYed/8mIfdBb638oBmKrWCwwKjYAM5J/4gMJ8nAJA==",
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@aws-sdk/types": "^3.973.8",
+				"@aws-sdk/xml-builder": "^3.972.20",
+				"@smithy/core": "^3.23.17",
+				"@smithy/node-config-provider": "^4.3.14",
+				"@smithy/property-provider": "^4.2.14",
+				"@smithy/protocol-http": "^5.3.14",
+				"@smithy/signature-v4": "^5.3.14",
+				"@smithy/smithy-client": "^4.12.13",
+				"@smithy/types": "^4.14.1",
+				"@smithy/util-base64": "^4.3.2",
+				"@smithy/util-middleware": "^4.2.14",
+				"@smithy/util-retry": "^4.3.5",
+				"@smithy/util-utf8": "^4.2.2",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=20.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/credential-provider-env": {
+			"version": "3.972.32",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.972.32.tgz",
+			"integrity": "sha512-7vA4GHg8NSmQxquJHSBcSM3RgB4ZaaRi6u4+zGFKOmOH6aqlgr2Sda46clkZDYzlirgfY96w15Zj0jh6PT48ng==",
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@aws-sdk/core": "^3.974.6",
+				"@aws-sdk/types": "^3.973.8",
+				"@smithy/property-provider": "^4.2.14",
+				"@smithy/types": "^4.14.1",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=20.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/credential-provider-http": {
+			"version": "3.972.34",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.972.34.tgz",
+			"integrity": "sha512-vBrhWujFCLp1u8ptJRWYlipMutzPptb8pDQ00rKVH9q67T7rGd3VTWIj63aKrlLuY6qSsw1Rt5F/D/7wnNgryA==",
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@aws-sdk/core": "^3.974.6",
+				"@aws-sdk/types": "^3.973.8",
+				"@smithy/fetch-http-handler": "^5.3.17",
+				"@smithy/node-http-handler": "^4.6.1",
+				"@smithy/property-provider": "^4.2.14",
+				"@smithy/protocol-http": "^5.3.14",
+				"@smithy/smithy-client": "^4.12.13",
+				"@smithy/types": "^4.14.1",
+				"@smithy/util-stream": "^4.5.25",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=20.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/credential-provider-ini": {
+			"version": "3.972.36",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.972.36.tgz",
+			"integrity": "sha512-FBHyCmV8EB0gUvh1d+CZm87zt2PrdC7OyWexLRoH3I5zWSOUGa+9t58Y5jbxRfwUp3AWpHAFvKY6YzgR845sVA==",
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@aws-sdk/core": "^3.974.6",
+				"@aws-sdk/credential-provider-env": "^3.972.32",
+				"@aws-sdk/credential-provider-http": "^3.972.34",
+				"@aws-sdk/credential-provider-login": "^3.972.36",
+				"@aws-sdk/credential-provider-process": "^3.972.32",
+				"@aws-sdk/credential-provider-sso": "^3.972.36",
+				"@aws-sdk/credential-provider-web-identity": "^3.972.36",
+				"@aws-sdk/nested-clients": "^3.997.4",
+				"@aws-sdk/types": "^3.973.8",
+				"@smithy/credential-provider-imds": "^4.2.14",
+				"@smithy/property-provider": "^4.2.14",
+				"@smithy/shared-ini-file-loader": "^4.4.9",
+				"@smithy/types": "^4.14.1",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=20.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/credential-provider-login": {
+			"version": "3.972.36",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-login/-/credential-provider-login-3.972.36.tgz",
+			"integrity": "sha512-IFap01lJKxQc0C/OHmZwZQr/cKq0DhrcmKedRrdnnl42D+P0SImnnnWQjv07uIPqpEdtqmkPXb9TiPYTU+prxQ==",
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@aws-sdk/core": "^3.974.6",
+				"@aws-sdk/nested-clients": "^3.997.4",
+				"@aws-sdk/types": "^3.973.8",
+				"@smithy/property-provider": "^4.2.14",
+				"@smithy/protocol-http": "^5.3.14",
+				"@smithy/shared-ini-file-loader": "^4.4.9",
+				"@smithy/types": "^4.14.1",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=20.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/credential-provider-node": {
+			"version": "3.972.37",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.972.37.tgz",
+			"integrity": "sha512-/WFixFAAiw8WpmjZcI0l4t3DerXLmVinOIfuotmRZnu2qmsFPoqqmstASz0z8bi1pGdFXzeLzf6bwucM3mZcUQ==",
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@aws-sdk/credential-provider-env": "^3.972.32",
+				"@aws-sdk/credential-provider-http": "^3.972.34",
+				"@aws-sdk/credential-provider-ini": "^3.972.36",
+				"@aws-sdk/credential-provider-process": "^3.972.32",
+				"@aws-sdk/credential-provider-sso": "^3.972.36",
+				"@aws-sdk/credential-provider-web-identity": "^3.972.36",
+				"@aws-sdk/types": "^3.973.8",
+				"@smithy/credential-provider-imds": "^4.2.14",
+				"@smithy/property-provider": "^4.2.14",
+				"@smithy/shared-ini-file-loader": "^4.4.9",
+				"@smithy/types": "^4.14.1",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=20.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/credential-provider-process": {
+			"version": "3.972.32",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.972.32.tgz",
+			"integrity": "sha512-uZp4tlGbpczV8QxmtIwOpSkcyGtBRR8/T4BAumRKfAt1nwCig3FSCZvrKl6ARDIDVRYn5p2oRcAsfFR01EgMGA==",
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@aws-sdk/core": "^3.974.6",
+				"@aws-sdk/types": "^3.973.8",
+				"@smithy/property-provider": "^4.2.14",
+				"@smithy/shared-ini-file-loader": "^4.4.9",
+				"@smithy/types": "^4.14.1",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=20.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/credential-provider-sso": {
+			"version": "3.972.36",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.972.36.tgz",
+			"integrity": "sha512-DsLr0UHMyKzRJKe2bjlwU8q1cfoXg8TIJKV/xwvnalAemiZLOZunFzj/whGnFDZIBVLdnbLiwv5SvRf1+CSwkg==",
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@aws-sdk/core": "^3.974.6",
+				"@aws-sdk/nested-clients": "^3.997.4",
+				"@aws-sdk/token-providers": "3.1038.0",
+				"@aws-sdk/types": "^3.973.8",
+				"@smithy/property-provider": "^4.2.14",
+				"@smithy/shared-ini-file-loader": "^4.4.9",
+				"@smithy/types": "^4.14.1",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=20.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/credential-provider-web-identity": {
+			"version": "3.972.36",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.972.36.tgz",
+			"integrity": "sha512-uzrURO7frJhHQVVNR5zBJcCYeMYflmXcWBK1+MiBym2Dfjh6nXATrMixrmGZi+97Q7ETZ+y/4lUwAy0Nfnznjw==",
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@aws-sdk/core": "^3.974.6",
+				"@aws-sdk/nested-clients": "^3.997.4",
+				"@aws-sdk/types": "^3.973.8",
+				"@smithy/property-provider": "^4.2.14",
+				"@smithy/shared-ini-file-loader": "^4.4.9",
+				"@smithy/types": "^4.14.1",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=20.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/eventstream-handler-node": {
+			"version": "3.972.14",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/eventstream-handler-node/-/eventstream-handler-node-3.972.14.tgz",
+			"integrity": "sha512-m4X56gxG76/CKfxNVbOFuYwnAZcHgS6HOH8lgp15HoGHIAVTcZfZrXvcYzJFOMLEJgVn+JHBu6EiNV+xSNXXFg==",
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@aws-sdk/types": "^3.973.8",
+				"@smithy/eventstream-codec": "^4.2.14",
+				"@smithy/types": "^4.14.1",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=20.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/middleware-eventstream": {
+			"version": "3.972.10",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/middleware-eventstream/-/middleware-eventstream-3.972.10.tgz",
+			"integrity": "sha512-QUqLs7Af1II9X4fCRAu+EGHG3KHyOp4RkuLhRKoA3NuFlh6TL8i+zXBl8w2LUxqm44B/Kom45hgSlwA1SpTsXQ==",
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@aws-sdk/types": "^3.973.8",
+				"@smithy/protocol-http": "^5.3.14",
+				"@smithy/types": "^4.14.1",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=20.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/middleware-host-header": {
+			"version": "3.972.10",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.972.10.tgz",
+			"integrity": "sha512-IJSsIMeVQ8MMCPbuh1AbltkFhLBLXn7aejzfX5YKT/VLDHn++Dcz8886tXckE+wQssyPUhaXrJhdakO2VilRhg==",
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@aws-sdk/types": "^3.973.8",
+				"@smithy/protocol-http": "^5.3.14",
+				"@smithy/types": "^4.14.1",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=20.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/middleware-logger": {
+			"version": "3.972.10",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.972.10.tgz",
+			"integrity": "sha512-OOuGvvz1Dm20SjZo5oEBePFqxt5nf8AwkNDSyUHvD9/bfNASmstcYxFAHUowy4n6Io7mWUZ04JURZwSBvyQanQ==",
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@aws-sdk/types": "^3.973.8",
+				"@smithy/types": "^4.14.1",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=20.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/middleware-recursion-detection": {
+			"version": "3.972.11",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.972.11.tgz",
+			"integrity": "sha512-+zz6f79Kj9V5qFK2P+D8Ehjnw4AhphAlCAsPjUqEcInA9umtSSKMrHbSagEeOIsDNuvVrH98bjRHcyQukTrhaQ==",
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@aws-sdk/types": "^3.973.8",
+				"@aws/lambda-invoke-store": "^0.2.2",
+				"@smithy/protocol-http": "^5.3.14",
+				"@smithy/types": "^4.14.1",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=20.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/middleware-sdk-s3": {
+			"version": "3.972.35",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-s3/-/middleware-sdk-s3-3.972.35.tgz",
+			"integrity": "sha512-lLppaNTAz+wNgLdi4FtHzrlwrGF0ODTnBWHBaFg85SKs0eJ+M+tP5ifrA8f/0lNd+Ak3MC1NGC6RavV3ny4HTg==",
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@aws-sdk/core": "^3.974.6",
+				"@aws-sdk/types": "^3.973.8",
+				"@aws-sdk/util-arn-parser": "^3.972.3",
+				"@smithy/core": "^3.23.17",
+				"@smithy/node-config-provider": "^4.3.14",
+				"@smithy/protocol-http": "^5.3.14",
+				"@smithy/signature-v4": "^5.3.14",
+				"@smithy/smithy-client": "^4.12.13",
+				"@smithy/types": "^4.14.1",
+				"@smithy/util-config-provider": "^4.2.2",
+				"@smithy/util-middleware": "^4.2.14",
+				"@smithy/util-stream": "^4.5.25",
+				"@smithy/util-utf8": "^4.2.2",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=20.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/middleware-user-agent": {
+			"version": "3.972.36",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.972.36.tgz",
+			"integrity": "sha512-O2beToxguBvrZFFZ+fFgPbbae8MvyIBjQ6lImee4APHEXXNAD5ZJ2ayLF1mb7rsKw86TM81y5czg82bZncjSjg==",
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@aws-sdk/core": "^3.974.6",
+				"@aws-sdk/types": "^3.973.8",
+				"@aws-sdk/util-endpoints": "^3.996.8",
+				"@smithy/core": "^3.23.17",
+				"@smithy/protocol-http": "^5.3.14",
+				"@smithy/types": "^4.14.1",
+				"@smithy/util-retry": "^4.3.5",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=20.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/middleware-websocket": {
+			"version": "3.972.16",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/middleware-websocket/-/middleware-websocket-3.972.16.tgz",
+			"integrity": "sha512-86+S9oCyRVGzoMRpQhxkArp7kD2K75GPmaNevd9B6EyNhWoNvnCZZ3WbgN4j7ZT+jvtvBCGZvI2XHsWZJ+BRIg==",
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@aws-sdk/types": "^3.973.8",
+				"@aws-sdk/util-format-url": "^3.972.10",
+				"@smithy/eventstream-codec": "^4.2.14",
+				"@smithy/eventstream-serde-browser": "^4.2.14",
+				"@smithy/fetch-http-handler": "^5.3.17",
+				"@smithy/protocol-http": "^5.3.14",
+				"@smithy/signature-v4": "^5.3.14",
+				"@smithy/types": "^4.14.1",
+				"@smithy/util-base64": "^4.3.2",
+				"@smithy/util-hex-encoding": "^4.2.2",
+				"@smithy/util-utf8": "^4.2.2",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">= 14.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/nested-clients": {
+			"version": "3.997.4",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/nested-clients/-/nested-clients-3.997.4.tgz",
+			"integrity": "sha512-4Sf+WY1lMJzXlw5MiyCMe/UzdILCwvuaHThbqMXS6dfh9gZy3No360I42RXquOI/ULUOhWy2HCyU0Fp20fQGPQ==",
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@aws-crypto/sha256-browser": "5.2.0",
+				"@aws-crypto/sha256-js": "5.2.0",
+				"@aws-sdk/core": "^3.974.6",
+				"@aws-sdk/middleware-host-header": "^3.972.10",
+				"@aws-sdk/middleware-logger": "^3.972.10",
+				"@aws-sdk/middleware-recursion-detection": "^3.972.11",
+				"@aws-sdk/middleware-user-agent": "^3.972.36",
+				"@aws-sdk/region-config-resolver": "^3.972.13",
+				"@aws-sdk/signature-v4-multi-region": "^3.996.23",
+				"@aws-sdk/types": "^3.973.8",
+				"@aws-sdk/util-endpoints": "^3.996.8",
+				"@aws-sdk/util-user-agent-browser": "^3.972.10",
+				"@aws-sdk/util-user-agent-node": "^3.973.22",
+				"@smithy/config-resolver": "^4.4.17",
+				"@smithy/core": "^3.23.17",
+				"@smithy/fetch-http-handler": "^5.3.17",
+				"@smithy/hash-node": "^4.2.14",
+				"@smithy/invalid-dependency": "^4.2.14",
+				"@smithy/middleware-content-length": "^4.2.14",
+				"@smithy/middleware-endpoint": "^4.4.32",
+				"@smithy/middleware-retry": "^4.5.6",
+				"@smithy/middleware-serde": "^4.2.20",
+				"@smithy/middleware-stack": "^4.2.14",
+				"@smithy/node-config-provider": "^4.3.14",
+				"@smithy/node-http-handler": "^4.6.1",
+				"@smithy/protocol-http": "^5.3.14",
+				"@smithy/smithy-client": "^4.12.13",
+				"@smithy/types": "^4.14.1",
+				"@smithy/url-parser": "^4.2.14",
+				"@smithy/util-base64": "^4.3.2",
+				"@smithy/util-body-length-browser": "^4.2.2",
+				"@smithy/util-body-length-node": "^4.2.3",
+				"@smithy/util-defaults-mode-browser": "^4.3.49",
+				"@smithy/util-defaults-mode-node": "^4.2.54",
+				"@smithy/util-endpoints": "^3.4.2",
+				"@smithy/util-middleware": "^4.2.14",
+				"@smithy/util-retry": "^4.3.5",
+				"@smithy/util-utf8": "^4.2.2",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=20.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/region-config-resolver": {
+			"version": "3.972.13",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/region-config-resolver/-/region-config-resolver-3.972.13.tgz",
+			"integrity": "sha512-CvJ2ZIjK/jVD/lbOpowBVElJyC1YxLTIJ13yM0AEo0t2v7swOzGjSA6lJGH+DwZXQhcjUjoYwc8bVYCX5MDr1A==",
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@aws-sdk/types": "^3.973.8",
+				"@smithy/config-resolver": "^4.4.17",
+				"@smithy/node-config-provider": "^4.3.14",
+				"@smithy/types": "^4.14.1",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=20.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/signature-v4-multi-region": {
+			"version": "3.996.23",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4-multi-region/-/signature-v4-multi-region-3.996.23.tgz",
+			"integrity": "sha512-wBbys3Y53Ikly556vyADurKpYQHXS7Jjaskbz+Ga9PZCz7PB/9f3VdKbDlz7dqIzn+xwz7L/a6TR4iXcOi8IRw==",
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@aws-sdk/middleware-sdk-s3": "^3.972.35",
+				"@aws-sdk/types": "^3.973.8",
+				"@smithy/protocol-http": "^5.3.14",
+				"@smithy/signature-v4": "^5.3.14",
+				"@smithy/types": "^4.14.1",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=20.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/token-providers": {
+			"version": "3.1038.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.1038.0.tgz",
+			"integrity": "sha512-Qniru+9oGGb/HNK/gGZWbV3jsD0k71ngE7qMQ/x6gYNYLd2EOwHCS6E2E6jfkaqO4i0d+nNKmfRy8bNcshKdGQ==",
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@aws-sdk/core": "^3.974.6",
+				"@aws-sdk/nested-clients": "^3.997.4",
+				"@aws-sdk/types": "^3.973.8",
+				"@smithy/property-provider": "^4.2.14",
+				"@smithy/shared-ini-file-loader": "^4.4.9",
+				"@smithy/types": "^4.14.1",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=20.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/types": {
+			"version": "3.973.8",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.973.8.tgz",
+			"integrity": "sha512-gjlAdtHMbtR9X5iIhVUvbVcy55KnznpC6bkDUWW9z915bi0ckdUr5cjf16Kp6xq0bP5HBD2xzgbL9F9Quv5vUw==",
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@smithy/types": "^4.14.1",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=20.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/util-arn-parser": {
+			"version": "3.972.3",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/util-arn-parser/-/util-arn-parser-3.972.3.tgz",
+			"integrity": "sha512-HzSD8PMFrvgi2Kserxuff5VitNq2sgf3w9qxmskKDiDTThWfVteJxuCS9JXiPIPtmCrp+7N9asfIaVhBFORllA==",
+			"license": "Apache-2.0",
+			"dependencies": {
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=20.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/util-endpoints": {
+			"version": "3.996.8",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.996.8.tgz",
+			"integrity": "sha512-oOZHcRDihk5iEe5V25NVWg45b3qEA8OpHWVdU/XQh8Zj4heVPAJqWvMphQnU7LkufmUo10EpvFPZuQMiFLJK3g==",
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@aws-sdk/types": "^3.973.8",
+				"@smithy/types": "^4.14.1",
+				"@smithy/url-parser": "^4.2.14",
+				"@smithy/util-endpoints": "^3.4.2",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=20.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/util-format-url": {
+			"version": "3.972.10",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/util-format-url/-/util-format-url-3.972.10.tgz",
+			"integrity": "sha512-DEKiHNJVtNxdyTeQspzY+15Po/kHm6sF0Cs4HV9Q2+lplB63+DrvdeiSoOSdWEWAoO2RcY1veoXVDz2tWxWCgQ==",
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@aws-sdk/types": "^3.973.8",
+				"@smithy/querystring-builder": "^4.2.14",
+				"@smithy/types": "^4.14.1",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=20.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/util-locate-window": {
+			"version": "3.965.5",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/util-locate-window/-/util-locate-window-3.965.5.tgz",
+			"integrity": "sha512-WhlJNNINQB+9qtLtZJcpQdgZw3SCDCpXdUJP7cToGwHbCWCnRckGlc6Bx/OhWwIYFNAn+FIydY8SZ0QmVu3xTQ==",
+			"license": "Apache-2.0",
+			"dependencies": {
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=20.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/util-user-agent-browser": {
+			"version": "3.972.10",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.972.10.tgz",
+			"integrity": "sha512-FAzqXvfEssGdSIz8ejatan0bOdx1qefBWKF/gWmVBXIP1HkS7v/wjjaqrAGGKvyihrXTXW00/2/1nTJtxpXz7g==",
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@aws-sdk/types": "^3.973.8",
+				"@smithy/types": "^4.14.1",
+				"bowser": "^2.11.0",
+				"tslib": "^2.6.2"
+			}
+		},
+		"node_modules/@aws-sdk/util-user-agent-node": {
+			"version": "3.973.22",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.973.22.tgz",
+			"integrity": "sha512-YTYqTmOUrwbm1h99Ee4y/mVYpFRl0oSO/amtP5cc1BZZWdaAVWs9zj3TkyRHWvR9aI/ZS8m3mS6awXtYUlWyaw==",
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@aws-sdk/middleware-user-agent": "^3.972.36",
+				"@aws-sdk/types": "^3.973.8",
+				"@smithy/node-config-provider": "^4.3.14",
+				"@smithy/types": "^4.14.1",
+				"@smithy/util-config-provider": "^4.2.2",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=20.0.0"
+			},
+			"peerDependencies": {
+				"aws-crt": ">=1.0.0"
+			},
+			"peerDependenciesMeta": {
+				"aws-crt": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/@aws-sdk/xml-builder": {
+			"version": "3.972.21",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/xml-builder/-/xml-builder-3.972.21.tgz",
+			"integrity": "sha512-qxNiHUtlrsjTeSlrPWiFkWps7uD6YB4eKzg7eLAFH8jbiHTlt0ePNlo2Xu+WlftP38JIcMaIX4jTUjOlE2ySWw==",
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@nodable/entities": "2.1.0",
+				"@smithy/types": "^4.14.1",
+				"fast-xml-parser": "5.7.2",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=20.0.0"
+			}
+		},
+		"node_modules/@aws/lambda-invoke-store": {
+			"version": "0.2.4",
+			"resolved": "https://registry.npmjs.org/@aws/lambda-invoke-store/-/lambda-invoke-store-0.2.4.tgz",
+			"integrity": "sha512-iY8yvjE0y651BixKNPgmv1WrQc+GZ142sb0z4gYnChDDY2YqI4P/jsSopBWrKfAt7LOJAkOXt7rC/hms+WclQQ==",
+			"license": "Apache-2.0",
+			"engines": {
+				"node": ">=18.0.0"
+			}
+		},
+		"node_modules/@babel/runtime": {
+			"version": "7.29.2",
+			"resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.29.2.tgz",
+			"integrity": "sha512-JiDShH45zKHWyGe4ZNVRrCjBz8Nh9TMmZG1kh4QTK8hCBTWBi8Da+i7s1fJw7/lYpM4ccepSNfqzZ/QvABBi5g==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=6.9.0"
+			}
+		},
+		"node_modules/@biomejs/biome": {
+			"version": "1.9.4",
+			"resolved": "https://registry.npmjs.org/@biomejs/biome/-/biome-1.9.4.tgz",
+			"integrity": "sha512-1rkd7G70+o9KkTn5KLmDYXihGoTaIGO9PIIN2ZB7UJxFrWw04CZHPYiMRjYsaDvVV7hP1dYNRLxSANLaBFGpog==",
+			"dev": true,
+			"hasInstallScript": true,
+			"license": "MIT OR Apache-2.0",
+			"bin": {
+				"biome": "bin/biome"
+			},
+			"engines": {
+				"node": ">=14.21.3"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/biome"
+			},
+			"optionalDependencies": {
+				"@biomejs/cli-darwin-arm64": "1.9.4",
+				"@biomejs/cli-darwin-x64": "1.9.4",
+				"@biomejs/cli-linux-arm64": "1.9.4",
+				"@biomejs/cli-linux-arm64-musl": "1.9.4",
+				"@biomejs/cli-linux-x64": "1.9.4",
+				"@biomejs/cli-linux-x64-musl": "1.9.4",
+				"@biomejs/cli-win32-arm64": "1.9.4",
+				"@biomejs/cli-win32-x64": "1.9.4"
+			}
+		},
+		"node_modules/@biomejs/cli-darwin-arm64": {
+			"version": "1.9.4",
+			"resolved": "https://registry.npmjs.org/@biomejs/cli-darwin-arm64/-/cli-darwin-arm64-1.9.4.tgz",
+			"integrity": "sha512-bFBsPWrNvkdKrNCYeAp+xo2HecOGPAy9WyNyB/jKnnedgzl4W4Hb9ZMzYNbf8dMCGmUdSavlYHiR01QaYR58cw==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MIT OR Apache-2.0",
+			"optional": true,
+			"os": [
+				"darwin"
+			],
+			"engines": {
+				"node": ">=14.21.3"
+			}
+		},
+		"node_modules/@biomejs/cli-darwin-x64": {
+			"version": "1.9.4",
+			"resolved": "https://registry.npmjs.org/@biomejs/cli-darwin-x64/-/cli-darwin-x64-1.9.4.tgz",
+			"integrity": "sha512-ngYBh/+bEedqkSevPVhLP4QfVPCpb+4BBe2p7Xs32dBgs7rh9nY2AIYUL6BgLw1JVXV8GlpKmb/hNiuIxfPfZg==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "MIT OR Apache-2.0",
+			"optional": true,
+			"os": [
+				"darwin"
+			],
+			"engines": {
+				"node": ">=14.21.3"
+			}
+		},
+		"node_modules/@biomejs/cli-linux-arm64": {
+			"version": "1.9.4",
+			"resolved": "https://registry.npmjs.org/@biomejs/cli-linux-arm64/-/cli-linux-arm64-1.9.4.tgz",
+			"integrity": "sha512-fJIW0+LYujdjUgJJuwesP4EjIBl/N/TcOX3IvIHJQNsAqvV2CHIogsmA94BPG6jZATS4Hi+xv4SkBBQSt1N4/g==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"libc": [
+				"glibc"
+			],
+			"license": "MIT OR Apache-2.0",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">=14.21.3"
+			}
+		},
+		"node_modules/@biomejs/cli-linux-arm64-musl": {
+			"version": "1.9.4",
+			"resolved": "https://registry.npmjs.org/@biomejs/cli-linux-arm64-musl/-/cli-linux-arm64-musl-1.9.4.tgz",
+			"integrity": "sha512-v665Ct9WCRjGa8+kTr0CzApU0+XXtRgwmzIf1SeKSGAv+2scAlW6JR5PMFo6FzqqZ64Po79cKODKf3/AAmECqA==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"libc": [
+				"musl"
+			],
+			"license": "MIT OR Apache-2.0",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">=14.21.3"
+			}
+		},
+		"node_modules/@biomejs/cli-linux-x64": {
+			"version": "1.9.4",
+			"resolved": "https://registry.npmjs.org/@biomejs/cli-linux-x64/-/cli-linux-x64-1.9.4.tgz",
+			"integrity": "sha512-lRCJv/Vi3Vlwmbd6K+oQ0KhLHMAysN8lXoCI7XeHlxaajk06u7G+UsFSO01NAs5iYuWKmVZjmiOzJ0OJmGsMwg==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"libc": [
+				"glibc"
+			],
+			"license": "MIT OR Apache-2.0",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">=14.21.3"
+			}
+		},
+		"node_modules/@biomejs/cli-linux-x64-musl": {
+			"version": "1.9.4",
+			"resolved": "https://registry.npmjs.org/@biomejs/cli-linux-x64-musl/-/cli-linux-x64-musl-1.9.4.tgz",
+			"integrity": "sha512-gEhi/jSBhZ2m6wjV530Yy8+fNqG8PAinM3oV7CyO+6c3CEh16Eizm21uHVsyVBEB6RIM8JHIl6AGYCv6Q6Q9Tg==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"libc": [
+				"musl"
+			],
+			"license": "MIT OR Apache-2.0",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">=14.21.3"
+			}
+		},
+		"node_modules/@biomejs/cli-win32-arm64": {
+			"version": "1.9.4",
+			"resolved": "https://registry.npmjs.org/@biomejs/cli-win32-arm64/-/cli-win32-arm64-1.9.4.tgz",
+			"integrity": "sha512-tlbhLk+WXZmgwoIKwHIHEBZUwxml7bRJgk0X2sPyNR3S93cdRq6XulAZRQJ17FYGGzWne0fgrXBKpl7l4M87Hg==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MIT OR Apache-2.0",
+			"optional": true,
+			"os": [
+				"win32"
+			],
+			"engines": {
+				"node": ">=14.21.3"
+			}
+		},
+		"node_modules/@biomejs/cli-win32-x64": {
+			"version": "1.9.4",
+			"resolved": "https://registry.npmjs.org/@biomejs/cli-win32-x64/-/cli-win32-x64-1.9.4.tgz",
+			"integrity": "sha512-8Y5wMhVIPaWe6jw2H+KlEm4wP/f7EW3810ZLmDlrEEy5KvBsb9ECEfu/kMWD484ijfQ8+nIi0giMgu9g1UAuuA==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "MIT OR Apache-2.0",
+			"optional": true,
+			"os": [
+				"win32"
+			],
+			"engines": {
+				"node": ">=14.21.3"
+			}
+		},
+		"node_modules/@borewit/text-codec": {
+			"version": "0.2.2",
+			"resolved": "https://registry.npmjs.org/@borewit/text-codec/-/text-codec-0.2.2.tgz",
+			"integrity": "sha512-DDaRehssg1aNrH4+2hnj1B7vnUGEjU6OIlyRdkMd0aUdIUvKXrJfXsy8LVtXAy7DRvYVluWbMspsRhz2lcW0mQ==",
+			"license": "MIT",
+			"funding": {
+				"type": "github",
+				"url": "https://github.com/sponsors/Borewit"
+			}
+		},
+		"node_modules/@clack/core": {
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/@clack/core/-/core-1.2.0.tgz",
+			"integrity": "sha512-qfxof/3T3t9DPU/Rj3OmcFyZInceqj/NVtO9rwIuJqCUgh32gwPjpFQQp/ben07qKlhpwq7GzfWpST4qdJ5Drg==",
+			"license": "MIT",
+			"dependencies": {
+				"fast-wrap-ansi": "^0.1.3",
+				"sisteransi": "^1.0.5"
+			}
+		},
+		"node_modules/@clack/prompts": {
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/@clack/prompts/-/prompts-1.2.0.tgz",
+			"integrity": "sha512-4jmztR9fMqPMjz6H/UZXj0zEmE43ha1euENwkckKKel4XpSfokExPo5AiVStdHSAlHekz4d0CA/r45Ok1E4D3w==",
+			"license": "MIT",
+			"dependencies": {
+				"@clack/core": "1.2.0",
+				"fast-string-width": "^1.1.0",
+				"fast-wrap-ansi": "^0.1.3",
+				"sisteransi": "^1.0.5"
+			}
+		},
+		"node_modules/@esbuild/aix-ppc64": {
+			"version": "0.27.7",
+			"resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.27.7.tgz",
+			"integrity": "sha512-EKX3Qwmhz1eMdEJokhALr0YiD0lhQNwDqkPYyPhiSwKrh7/4KRjQc04sZ8db+5DVVnZ1LmbNDI1uAMPEUBnQPg==",
+			"cpu": [
+				"ppc64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"aix"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/android-arm": {
+			"version": "0.27.7",
+			"resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.27.7.tgz",
+			"integrity": "sha512-jbPXvB4Yj2yBV7HUfE2KHe4GJX51QplCN1pGbYjvsyCZbQmies29EoJbkEc+vYuU5o45AfQn37vZlyXy4YJ8RQ==",
+			"cpu": [
+				"arm"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"android"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/android-arm64": {
+			"version": "0.27.7",
+			"resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.27.7.tgz",
+			"integrity": "sha512-62dPZHpIXzvChfvfLJow3q5dDtiNMkwiRzPylSCfriLvZeq0a1bWChrGx/BbUbPwOrsWKMn8idSllklzBy+dgQ==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"android"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/android-x64": {
+			"version": "0.27.7",
+			"resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.27.7.tgz",
+			"integrity": "sha512-x5VpMODneVDb70PYV2VQOmIUUiBtY3D3mPBG8NxVk5CogneYhkR7MmM3yR/uMdITLrC1ml/NV1rj4bMJuy9MCg==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"android"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/darwin-arm64": {
+			"version": "0.27.7",
+			"resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.27.7.tgz",
+			"integrity": "sha512-5lckdqeuBPlKUwvoCXIgI2D9/ABmPq3Rdp7IfL70393YgaASt7tbju3Ac+ePVi3KDH6N2RqePfHnXkaDtY9fkw==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"darwin"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/darwin-x64": {
+			"version": "0.27.7",
+			"resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.27.7.tgz",
+			"integrity": "sha512-rYnXrKcXuT7Z+WL5K980jVFdvVKhCHhUwid+dDYQpH+qu+TefcomiMAJpIiC2EM3Rjtq0sO3StMV/+3w3MyyqQ==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"darwin"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/freebsd-arm64": {
+			"version": "0.27.7",
+			"resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.27.7.tgz",
+			"integrity": "sha512-B48PqeCsEgOtzME2GbNM2roU29AMTuOIN91dsMO30t+Ydis3z/3Ngoj5hhnsOSSwNzS+6JppqWsuhTp6E82l2w==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"freebsd"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/freebsd-x64": {
+			"version": "0.27.7",
+			"resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.27.7.tgz",
+			"integrity": "sha512-jOBDK5XEjA4m5IJK3bpAQF9/Lelu/Z9ZcdhTRLf4cajlB+8VEhFFRjWgfy3M1O4rO2GQ/b2dLwCUGpiF/eATNQ==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"freebsd"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/linux-arm": {
+			"version": "0.27.7",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.27.7.tgz",
+			"integrity": "sha512-RkT/YXYBTSULo3+af8Ib0ykH8u2MBh57o7q/DAs3lTJlyVQkgQvlrPTnjIzzRPQyavxtPtfg0EopvDyIt0j1rA==",
+			"cpu": [
+				"arm"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/linux-arm64": {
+			"version": "0.27.7",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.27.7.tgz",
+			"integrity": "sha512-RZPHBoxXuNnPQO9rvjh5jdkRmVizktkT7TCDkDmQ0W2SwHInKCAV95GRuvdSvA7w4VMwfCjUiPwDi0ZO6Nfe9A==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/linux-ia32": {
+			"version": "0.27.7",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.27.7.tgz",
+			"integrity": "sha512-GA48aKNkyQDbd3KtkplYWT102C5sn/EZTY4XROkxONgruHPU72l+gW+FfF8tf2cFjeHaRbWpOYa/uRBz/Xq1Pg==",
+			"cpu": [
+				"ia32"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/linux-loong64": {
+			"version": "0.27.7",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.27.7.tgz",
+			"integrity": "sha512-a4POruNM2oWsD4WKvBSEKGIiWQF8fZOAsycHOt6JBpZ+JN2n2JH9WAv56SOyu9X5IqAjqSIPTaJkqN8F7XOQ5Q==",
+			"cpu": [
+				"loong64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/linux-mips64el": {
+			"version": "0.27.7",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.27.7.tgz",
+			"integrity": "sha512-KabT5I6StirGfIz0FMgl1I+R1H73Gp0ofL9A3nG3i/cYFJzKHhouBV5VWK1CSgKvVaG4q1RNpCTR2LuTVB3fIw==",
+			"cpu": [
+				"mips64el"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/linux-ppc64": {
+			"version": "0.27.7",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.27.7.tgz",
+			"integrity": "sha512-gRsL4x6wsGHGRqhtI+ifpN/vpOFTQtnbsupUF5R5YTAg+y/lKelYR1hXbnBdzDjGbMYjVJLJTd2OFmMewAgwlQ==",
+			"cpu": [
+				"ppc64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/linux-riscv64": {
+			"version": "0.27.7",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.27.7.tgz",
+			"integrity": "sha512-hL25LbxO1QOngGzu2U5xeXtxXcW+/GvMN3ejANqXkxZ/opySAZMrc+9LY/WyjAan41unrR3YrmtTsUpwT66InQ==",
+			"cpu": [
+				"riscv64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/linux-s390x": {
+			"version": "0.27.7",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.27.7.tgz",
+			"integrity": "sha512-2k8go8Ycu1Kb46vEelhu1vqEP+UeRVj2zY1pSuPdgvbd5ykAw82Lrro28vXUrRmzEsUV0NzCf54yARIK8r0fdw==",
+			"cpu": [
+				"s390x"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/linux-x64": {
+			"version": "0.27.7",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.27.7.tgz",
+			"integrity": "sha512-hzznmADPt+OmsYzw1EE33ccA+HPdIqiCRq7cQeL1Jlq2gb1+OyWBkMCrYGBJ+sxVzve2ZJEVeePbLM2iEIZSxA==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/netbsd-arm64": {
+			"version": "0.27.7",
+			"resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.27.7.tgz",
+			"integrity": "sha512-b6pqtrQdigZBwZxAn1UpazEisvwaIDvdbMbmrly7cDTMFnw/+3lVxxCTGOrkPVnsYIosJJXAsILG9XcQS+Yu6w==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"netbsd"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/netbsd-x64": {
+			"version": "0.27.7",
+			"resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.27.7.tgz",
+			"integrity": "sha512-OfatkLojr6U+WN5EDYuoQhtM+1xco+/6FSzJJnuWiUw5eVcicbyK3dq5EeV/QHT1uy6GoDhGbFpprUiHUYggrw==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"netbsd"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/openbsd-arm64": {
+			"version": "0.27.7",
+			"resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.27.7.tgz",
+			"integrity": "sha512-AFuojMQTxAz75Fo8idVcqoQWEHIXFRbOc1TrVcFSgCZtQfSdc1RXgB3tjOn/krRHENUB4j00bfGjyl2mJrU37A==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"openbsd"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/openbsd-x64": {
+			"version": "0.27.7",
+			"resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.27.7.tgz",
+			"integrity": "sha512-+A1NJmfM8WNDv5CLVQYJ5PshuRm/4cI6WMZRg1by1GwPIQPCTs1GLEUHwiiQGT5zDdyLiRM/l1G0Pv54gvtKIg==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"openbsd"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/openharmony-arm64": {
+			"version": "0.27.7",
+			"resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.27.7.tgz",
+			"integrity": "sha512-+KrvYb/C8zA9CU/g0sR6w2RBw7IGc5J2BPnc3dYc5VJxHCSF1yNMxTV5LQ7GuKteQXZtspjFbiuW5/dOj7H4Yw==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"openharmony"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/sunos-x64": {
+			"version": "0.27.7",
+			"resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.27.7.tgz",
+			"integrity": "sha512-ikktIhFBzQNt/QDyOL580ti9+5mL/YZeUPKU2ivGtGjdTYoqz6jObj6nOMfhASpS4GU4Q/Clh1QtxWAvcYKamA==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"sunos"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/win32-arm64": {
+			"version": "0.27.7",
+			"resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.27.7.tgz",
+			"integrity": "sha512-7yRhbHvPqSpRUV7Q20VuDwbjW5kIMwTHpptuUzV+AA46kiPze5Z7qgt6CLCK3pWFrHeNfDd1VKgyP4O+ng17CA==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"win32"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/win32-ia32": {
+			"version": "0.27.7",
+			"resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.27.7.tgz",
+			"integrity": "sha512-SmwKXe6VHIyZYbBLJrhOoCJRB/Z1tckzmgTLfFYOfpMAx63BJEaL9ExI8x7v0oAO3Zh6D/Oi1gVxEYr5oUCFhw==",
+			"cpu": [
+				"ia32"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"win32"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/win32-x64": {
+			"version": "0.27.7",
+			"resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.27.7.tgz",
+			"integrity": "sha512-56hiAJPhwQ1R4i+21FVF7V8kSD5zZTdHcVuRFMW0hn753vVfQN8xlx4uOPT4xoGH0Z/oVATuR82AiqSTDIpaHg==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"win32"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@google/genai": {
+			"version": "1.50.1",
+			"resolved": "https://registry.npmjs.org/@google/genai/-/genai-1.50.1.tgz",
+			"integrity": "sha512-YbkX7H9+1Pt8wOt7DDREy8XSoiL6fRDzZQRyaVBarFf8MR3zHGqVdvM4cLbDXqPhxqvegZShgfxb8kw9C7YhAQ==",
+			"license": "Apache-2.0",
+			"dependencies": {
+				"google-auth-library": "^10.3.0",
+				"p-retry": "^4.6.2",
+				"protobufjs": "^7.5.4",
+				"ws": "^8.18.0"
+			},
+			"engines": {
+				"node": ">=20.0.0"
+			},
+			"peerDependencies": {
+				"@modelcontextprotocol/sdk": "^1.25.2"
+			},
+			"peerDependenciesMeta": {
+				"@modelcontextprotocol/sdk": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/@hono/node-server": {
+			"version": "1.19.14",
+			"resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.14.tgz",
+			"integrity": "sha512-GwtvgtXxnWsucXvbQXkRgqksiH2Qed37H9xHZocE5sA3N8O8O8/8FA3uclQXxXVzc9XBZuEOMK7+r02FmSpHtw==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=18.14.1"
+			},
+			"peerDependencies": {
+				"hono": "^4"
+			}
+		},
+		"node_modules/@jridgewell/sourcemap-codec": {
+			"version": "1.5.5",
+			"resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+			"integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/@mariozechner/clipboard": {
+			"version": "0.3.3",
+			"resolved": "https://registry.npmjs.org/@mariozechner/clipboard/-/clipboard-0.3.3.tgz",
+			"integrity": "sha512-e7jASirzfm+ROiOGFh843+cFZTy3DfzP+jldCvh8RnEk0C3QihDTn7dd7Yh7KAJydwIJ18FJSZ2swHvCJhk18g==",
+			"license": "MIT",
+			"optional": true,
+			"engines": {
+				"node": ">= 10"
+			},
+			"optionalDependencies": {
+				"@mariozechner/clipboard-darwin-arm64": "0.3.3",
+				"@mariozechner/clipboard-darwin-universal": "0.3.3",
+				"@mariozechner/clipboard-darwin-x64": "0.3.3",
+				"@mariozechner/clipboard-linux-arm64-gnu": "0.3.3",
+				"@mariozechner/clipboard-linux-arm64-musl": "0.3.3",
+				"@mariozechner/clipboard-linux-riscv64-gnu": "0.3.3",
+				"@mariozechner/clipboard-linux-x64-gnu": "0.3.3",
+				"@mariozechner/clipboard-linux-x64-musl": "0.3.3",
+				"@mariozechner/clipboard-win32-arm64-msvc": "0.3.3",
+				"@mariozechner/clipboard-win32-x64-msvc": "0.3.3"
+			}
+		},
+		"node_modules/@mariozechner/clipboard-darwin-arm64": {
+			"version": "0.3.3",
+			"resolved": "https://registry.npmjs.org/@mariozechner/clipboard-darwin-arm64/-/clipboard-darwin-arm64-0.3.3.tgz",
+			"integrity": "sha512-+zhuZGXqVrdkbIRdnwiZNbTJ7V3elq/A+C5d5laJoyhJgWs41eO5NUMkBkj6f23F2L4PRXEhdn5/ktlPx+bG3Q==",
+			"cpu": [
+				"arm64"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"darwin"
+			],
+			"engines": {
+				"node": ">= 10"
+			}
+		},
+		"node_modules/@mariozechner/clipboard-darwin-universal": {
+			"version": "0.3.3",
+			"resolved": "https://registry.npmjs.org/@mariozechner/clipboard-darwin-universal/-/clipboard-darwin-universal-0.3.3.tgz",
+			"integrity": "sha512-x9aRfTyndVqpEQ44LNNCK/EXZd9y8rWkLQgNhmWpby9PXrjPhNxfjUc2Db4mt4nJjU/4zzO8F5v/XyzlUGSdhQ==",
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"darwin"
+			],
+			"engines": {
+				"node": ">= 10"
+			}
+		},
+		"node_modules/@mariozechner/clipboard-darwin-x64": {
+			"version": "0.3.3",
+			"resolved": "https://registry.npmjs.org/@mariozechner/clipboard-darwin-x64/-/clipboard-darwin-x64-0.3.3.tgz",
+			"integrity": "sha512-6ut/NawB0KiYPCwrirgNp6Br62LntL978q7G6d/Rs2pmPvQb53bP96eUMYl+Y3a7Qk13bGZ4w9rVPFxRE9m9ag==",
+			"cpu": [
+				"x64"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"darwin"
+			],
+			"engines": {
+				"node": ">= 10"
+			}
+		},
+		"node_modules/@mariozechner/clipboard-linux-arm64-gnu": {
+			"version": "0.3.3",
+			"resolved": "https://registry.npmjs.org/@mariozechner/clipboard-linux-arm64-gnu/-/clipboard-linux-arm64-gnu-0.3.3.tgz",
+			"integrity": "sha512-gf3dH4kBddU1AOyHVB53mjLUFfJAKlTmxTMw51jdeg7eE7IjfEBXVvM4bifMtBxbWkT0eA0FUZ1C0KQ6Z5l6pw==",
+			"cpu": [
+				"arm64"
+			],
+			"libc": [
+				"glibc"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">= 10"
+			}
+		},
+		"node_modules/@mariozechner/clipboard-linux-arm64-musl": {
+			"version": "0.3.3",
+			"resolved": "https://registry.npmjs.org/@mariozechner/clipboard-linux-arm64-musl/-/clipboard-linux-arm64-musl-0.3.3.tgz",
+			"integrity": "sha512-o1paj2+zmAQ/LaPS85XJCxhNowNQpxYM2cGY6pWvB5Kqmz6hZjl6CzDg5tbf1hZkn/Em6jpOaE2UtMxKdELBDA==",
+			"cpu": [
+				"arm64"
+			],
+			"libc": [
+				"musl"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">= 10"
+			}
+		},
+		"node_modules/@mariozechner/clipboard-linux-riscv64-gnu": {
+			"version": "0.3.3",
+			"resolved": "https://registry.npmjs.org/@mariozechner/clipboard-linux-riscv64-gnu/-/clipboard-linux-riscv64-gnu-0.3.3.tgz",
+			"integrity": "sha512-dkEhE4ekePJwMbBq9HP1//CFMNmDzA/iV9AXqBfvL5CWmmDIRXqh4A3YZt3tWO/HdMerX+xNCEiR7WiOsIG+UA==",
+			"cpu": [
+				"riscv64"
+			],
+			"libc": [
+				"glibc"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">= 10"
+			}
+		},
+		"node_modules/@mariozechner/clipboard-linux-x64-gnu": {
+			"version": "0.3.3",
+			"resolved": "https://registry.npmjs.org/@mariozechner/clipboard-linux-x64-gnu/-/clipboard-linux-x64-gnu-0.3.3.tgz",
+			"integrity": "sha512-lT2yANtTLlEtFBIH3uGoRa/CQas/eBoLNi3qr9axQFoRgF4RGPSJ66yHOSnMECBneTIb1Iqv3UxokTfX27CdoQ==",
+			"cpu": [
+				"x64"
+			],
+			"libc": [
+				"glibc"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">= 10"
+			}
+		},
+		"node_modules/@mariozechner/clipboard-linux-x64-musl": {
+			"version": "0.3.3",
+			"resolved": "https://registry.npmjs.org/@mariozechner/clipboard-linux-x64-musl/-/clipboard-linux-x64-musl-0.3.3.tgz",
+			"integrity": "sha512-saq/MCB0QHK/7ZZLjAZ0QkbY944dyjOsur8gneGCfMitt+GOiE1CU4OUipHC4b6x8UDY9bRLsR4aBaxu22OFPA==",
+			"cpu": [
+				"x64"
+			],
+			"libc": [
+				"musl"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">= 10"
+			}
+		},
+		"node_modules/@mariozechner/clipboard-win32-arm64-msvc": {
+			"version": "0.3.3",
+			"resolved": "https://registry.npmjs.org/@mariozechner/clipboard-win32-arm64-msvc/-/clipboard-win32-arm64-msvc-0.3.3.tgz",
+			"integrity": "sha512-cGuvSj0/2X2w983yEcKw+i+r1EBej6ZZIN+fXG3eY2G/HaIQpbXpLvMxKyZ9LKtbZx+Z6q/gELEoSBMLML6BaQ==",
+			"cpu": [
+				"arm64"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"win32"
+			],
+			"engines": {
+				"node": ">= 10"
+			}
+		},
+		"node_modules/@mariozechner/clipboard-win32-x64-msvc": {
+			"version": "0.3.3",
+			"resolved": "https://registry.npmjs.org/@mariozechner/clipboard-win32-x64-msvc/-/clipboard-win32-x64-msvc-0.3.3.tgz",
+			"integrity": "sha512-5hvaEq/bgYovTIGx43O/S7loIHYV3ue90WcV1dz0wdMXroVKZKeU/yfwM0PALQA1OcrEHiGXGySFReXr72lGtA==",
+			"cpu": [
+				"x64"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"win32"
+			],
+			"engines": {
+				"node": ">= 10"
+			}
+		},
+		"node_modules/@mariozechner/jiti": {
+			"version": "2.6.5",
+			"resolved": "https://registry.npmjs.org/@mariozechner/jiti/-/jiti-2.6.5.tgz",
+			"integrity": "sha512-faGUlTcXka5l7rv0lP3K3vGW/ejRuOS24RR2aSFWREUQqzjgdsuWNo/IiPqL3kWRGt6Ahl2+qcDAwtdeWeuGUw==",
+			"license": "MIT",
+			"dependencies": {
+				"std-env": "^3.10.0",
+				"yoctocolors": "^2.1.2"
+			},
+			"bin": {
+				"jiti": "lib/jiti-cli.mjs"
+			}
+		},
+		"node_modules/@mariozechner/pi-agent-core": {
+			"version": "0.67.68",
+			"resolved": "https://registry.npmjs.org/@mariozechner/pi-agent-core/-/pi-agent-core-0.67.68.tgz",
+			"integrity": "sha512-anwFuzeUL7Qjbyih4DWY7w1zrOTrBxaz1L6+duLUuuzpHOun0EiP4KWIGTXPT5oJA7ZaeRNTyXJ7PlWfGQG33g==",
+			"license": "MIT",
+			"dependencies": {
+				"@mariozechner/pi-ai": "^0.67.68"
+			},
+			"engines": {
+				"node": ">=20.0.0"
+			}
+		},
+		"node_modules/@mariozechner/pi-ai": {
+			"version": "0.67.68",
+			"resolved": "https://registry.npmjs.org/@mariozechner/pi-ai/-/pi-ai-0.67.68.tgz",
+			"integrity": "sha512-DWWQmcb3IV3mbGXmzYBScfKA6kA52n/stY029eiBikrIxVT7DGLG6n7KSvTA2R4qBSgi1iFL3nGHtwxmtIn6Lg==",
+			"license": "MIT",
+			"dependencies": {
+				"@anthropic-ai/sdk": "^0.90.0",
+				"@aws-sdk/client-bedrock-runtime": "^3.1030.0",
+				"@google/genai": "^1.40.0",
+				"@mistralai/mistralai": "^2.2.0",
+				"@sinclair/typebox": "^0.34.41",
+				"ajv": "^8.17.1",
+				"ajv-formats": "^3.0.1",
+				"chalk": "^5.6.2",
+				"openai": "6.26.0",
+				"partial-json": "^0.1.7",
+				"proxy-agent": "^6.5.0",
+				"undici": "^7.19.1",
+				"zod-to-json-schema": "^3.24.6"
+			},
+			"bin": {
+				"pi-ai": "dist/cli.js"
+			},
+			"engines": {
+				"node": ">=20.0.0"
+			}
+		},
+		"node_modules/@mariozechner/pi-ai/node_modules/undici": {
+			"version": "7.25.0",
+			"resolved": "https://registry.npmjs.org/undici/-/undici-7.25.0.tgz",
+			"integrity": "sha512-xXnp4kTyor2Zq+J1FfPI6Eq3ew5h6Vl0F/8d9XU5zZQf1tX9s2Su1/3PiMmUANFULpmksxkClamIZcaUqryHsQ==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=20.18.1"
+			}
+		},
+		"node_modules/@mariozechner/pi-coding-agent": {
+			"version": "0.67.68",
+			"resolved": "https://registry.npmjs.org/@mariozechner/pi-coding-agent/-/pi-coding-agent-0.67.68.tgz",
+			"integrity": "sha512-Bai2yUBpgjftqGvg3GNV9pxcMAatqJwQYsqM+7j39+tm+IpoW7hbMBnzXZQvykAwXIrTXpZFF5yp5ajeDI5Atg==",
+			"license": "MIT",
+			"dependencies": {
+				"@mariozechner/jiti": "^2.6.2",
+				"@mariozechner/pi-agent-core": "^0.67.68",
+				"@mariozechner/pi-ai": "^0.67.68",
+				"@mariozechner/pi-tui": "^0.67.68",
+				"@silvia-odwyer/photon-node": "^0.3.4",
+				"ajv": "^8.17.1",
+				"chalk": "^5.5.0",
+				"cli-highlight": "^2.1.11",
+				"diff": "^8.0.2",
+				"extract-zip": "^2.0.1",
+				"file-type": "^21.1.1",
+				"glob": "^13.0.1",
+				"hosted-git-info": "^9.0.2",
+				"ignore": "^7.0.5",
+				"marked": "^15.0.12",
+				"minimatch": "^10.2.3",
+				"proper-lockfile": "^4.1.2",
+				"strip-ansi": "^7.1.0",
+				"undici": "^7.19.1",
+				"uuid": "^11.1.0",
+				"yaml": "^2.8.2"
+			},
+			"bin": {
+				"pi": "dist/cli.js"
+			},
+			"engines": {
+				"node": ">=20.6.0"
+			},
+			"optionalDependencies": {
+				"@mariozechner/clipboard": "^0.3.2"
+			}
+		},
+		"node_modules/@mariozechner/pi-coding-agent/node_modules/undici": {
+			"version": "7.25.0",
+			"resolved": "https://registry.npmjs.org/undici/-/undici-7.25.0.tgz",
+			"integrity": "sha512-xXnp4kTyor2Zq+J1FfPI6Eq3ew5h6Vl0F/8d9XU5zZQf1tX9s2Su1/3PiMmUANFULpmksxkClamIZcaUqryHsQ==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=20.18.1"
+			}
+		},
+		"node_modules/@mariozechner/pi-coding-agent/node_modules/uuid": {
+			"version": "11.1.0",
+			"resolved": "https://registry.npmjs.org/uuid/-/uuid-11.1.0.tgz",
+			"integrity": "sha512-0/A9rDy9P7cJ+8w1c9WD9V//9Wj15Ce2MPz8Ri6032usz+NfePxx5AcN3bN+r6ZL6jEo066/yNYB3tn4pQEx+A==",
+			"funding": [
+				"https://github.com/sponsors/broofa",
+				"https://github.com/sponsors/ctavan"
+			],
+			"license": "MIT",
+			"bin": {
+				"uuid": "dist/esm/bin/uuid"
+			}
+		},
+		"node_modules/@mariozechner/pi-tui": {
+			"version": "0.67.68",
+			"resolved": "https://registry.npmjs.org/@mariozechner/pi-tui/-/pi-tui-0.67.68.tgz",
+			"integrity": "sha512-RhcMaGz88lNOm5+9yx+YCIfXZALLbMxB2cwsoHzyOzs+OZAItw8tz6xJZPAnX0RHY+ENQEGMMDY9TF6pxxnkbA==",
+			"license": "MIT",
+			"dependencies": {
+				"@types/mime-types": "^2.1.4",
+				"chalk": "^5.5.0",
+				"get-east-asian-width": "^1.3.0",
+				"marked": "^15.0.12",
+				"mime-types": "^3.0.1"
+			},
+			"engines": {
+				"node": ">=20.0.0"
+			},
+			"optionalDependencies": {
+				"koffi": "^2.9.0"
+			}
+		},
+		"node_modules/@mistralai/mistralai": {
+			"version": "2.2.1",
+			"resolved": "https://registry.npmjs.org/@mistralai/mistralai/-/mistralai-2.2.1.tgz",
+			"integrity": "sha512-uKU8CZmL2RzYKmplsU01hii4p3pe4HqJefpWNRWXm1Tcm0Sm4xXfwSLIy4k7ZCPlbETCGcp69E7hZs+WOJ5itQ==",
+			"license": "Apache-2.0",
+			"dependencies": {
+				"ws": "^8.18.0",
+				"zod": "^3.25.0 || ^4.0.0",
+				"zod-to-json-schema": "^3.25.0"
+			}
+		},
+		"node_modules/@mixmark-io/domino": {
+			"version": "2.2.0",
+			"resolved": "https://registry.npmjs.org/@mixmark-io/domino/-/domino-2.2.0.tgz",
+			"integrity": "sha512-Y28PR25bHXUg88kCV7nivXrP2Nj2RueZ3/l/jdx6J9f8J4nsEGcgX0Qe6lt7Pa+J79+kPiJU3LguR6O/6zrLOw==",
+			"dev": true,
+			"license": "BSD-2-Clause"
+		},
+		"node_modules/@modelcontextprotocol/ext-apps": {
+			"version": "1.7.1",
+			"resolved": "https://registry.npmjs.org/@modelcontextprotocol/ext-apps/-/ext-apps-1.7.1.tgz",
+			"integrity": "sha512-J3WdG1A4JSSKnSWKyU+895dBVYBV2Utgtf7fUsUK45mlkETm53a/1DR6Pm3hUGKqLLQthZLmpxOg8VPzJi/lyg==",
+			"license": "MIT",
+			"workspaces": [
+				"examples/*"
+			],
+			"dependencies": {
+				"@standard-schema/spec": "^1.1.0"
+			},
+			"engines": {
+				"node": ">=20"
+			},
+			"peerDependencies": {
+				"@modelcontextprotocol/sdk": "^1.29.0",
+				"react": "^17.0.0 || ^18.0.0 || ^19.0.0",
+				"react-dom": "^17.0.0 || ^18.0.0 || ^19.0.0",
+				"zod": "^3.25.0 || ^4.0.0"
+			},
+			"peerDependenciesMeta": {
+				"react": {
+					"optional": true
+				},
+				"react-dom": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/@modelcontextprotocol/sdk": {
+			"version": "1.29.0",
+			"resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.29.0.tgz",
+			"integrity": "sha512-zo37mZA9hJWpULgkRpowewez1y6ML5GsXJPY8FI0tBBCd77HEvza4jDqRKOXgHNn867PVGCyTdzqpz0izu5ZjQ==",
+			"license": "MIT",
+			"dependencies": {
+				"@hono/node-server": "^1.19.9",
+				"ajv": "^8.17.1",
+				"ajv-formats": "^3.0.1",
+				"content-type": "^1.0.5",
+				"cors": "^2.8.5",
+				"cross-spawn": "^7.0.5",
+				"eventsource": "^3.0.2",
+				"eventsource-parser": "^3.0.0",
+				"express": "^5.2.1",
+				"express-rate-limit": "^8.2.1",
+				"hono": "^4.11.4",
+				"jose": "^6.1.3",
+				"json-schema-typed": "^8.0.2",
+				"pkce-challenge": "^5.0.0",
+				"raw-body": "^3.0.0",
+				"zod": "^3.25 || ^4.0",
+				"zod-to-json-schema": "^3.25.1"
+			},
+			"engines": {
+				"node": ">=18"
+			},
+			"peerDependencies": {
+				"@cfworker/json-schema": "^4.1.1",
+				"zod": "^3.25 || ^4.0"
+			},
+			"peerDependenciesMeta": {
+				"@cfworker/json-schema": {
+					"optional": true
+				},
+				"zod": {
+					"optional": false
+				}
+			}
+		},
+		"node_modules/@nodable/entities": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/@nodable/entities/-/entities-2.1.0.tgz",
+			"integrity": "sha512-nyT7T3nbMyBI/lvr6L5TyWbFJAI9FTgVRakNoBqCD+PmID8DzFrrNdLLtHMwMszOtqZa8PAOV24ZqDnQrhQINA==",
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/nodable"
+				}
+			],
+			"license": "MIT"
+		},
+		"node_modules/@protobufjs/aspromise": {
+			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/@protobufjs/aspromise/-/aspromise-1.1.2.tgz",
+			"integrity": "sha512-j+gKExEuLmKwvz3OgROXtrJ2UG2x8Ch2YZUxahh+s1F2HZ+wAceUNLkvy6zKCPVRkU++ZWQrdxsUeQXmcg4uoQ==",
+			"license": "BSD-3-Clause"
+		},
+		"node_modules/@protobufjs/base64": {
+			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/@protobufjs/base64/-/base64-1.1.2.tgz",
+			"integrity": "sha512-AZkcAA5vnN/v4PDqKyMR5lx7hZttPDgClv83E//FMNhR2TMcLUhfRUBHCmSl0oi9zMgDDqRUJkSxO3wm85+XLg==",
+			"license": "BSD-3-Clause"
+		},
+		"node_modules/@protobufjs/codegen": {
+			"version": "2.0.5",
+			"resolved": "https://registry.npmjs.org/@protobufjs/codegen/-/codegen-2.0.5.tgz",
+			"integrity": "sha512-zgXFLzW3Ap33e6d0Wlj4MGIm6Ce8O89n/apUaGNB/jx+hw+ruWEp7EwGUshdLKVRCxZW12fp9r40E1mQrf/34g==",
+			"license": "BSD-3-Clause"
+		},
+		"node_modules/@protobufjs/eventemitter": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/@protobufjs/eventemitter/-/eventemitter-1.1.0.tgz",
+			"integrity": "sha512-j9ednRT81vYJ9OfVuXG6ERSTdEL1xVsNgqpkxMsbIabzSo3goCjDIveeGv5d03om39ML71RdmrGNjG5SReBP/Q==",
+			"license": "BSD-3-Clause"
+		},
+		"node_modules/@protobufjs/fetch": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/@protobufjs/fetch/-/fetch-1.1.0.tgz",
+			"integrity": "sha512-lljVXpqXebpsijW71PZaCYeIcE5on1w5DlQy5WH6GLbFryLUrBD4932W/E2BSpfRJWseIL4v/KPgBFxDOIdKpQ==",
+			"license": "BSD-3-Clause",
+			"dependencies": {
+				"@protobufjs/aspromise": "^1.1.1",
+				"@protobufjs/inquire": "^1.1.0"
+			}
+		},
+		"node_modules/@protobufjs/float": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/@protobufjs/float/-/float-1.0.2.tgz",
+			"integrity": "sha512-Ddb+kVXlXst9d+R9PfTIxh1EdNkgoRe5tOX6t01f1lYWOvJnSPDBlG241QLzcyPdoNTsblLUdujGSE4RzrTZGQ==",
+			"license": "BSD-3-Clause"
+		},
+		"node_modules/@protobufjs/inquire": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/@protobufjs/inquire/-/inquire-1.1.1.tgz",
+			"integrity": "sha512-mnzgDV26ueAvk7rsbt9L7bE0SuAoqyuys/sMMrmVcN5x9VsxpcG3rqAUSgDyLp0UZlmNfIbQ4fHfCtreVBk8Ew==",
+			"license": "BSD-3-Clause"
+		},
+		"node_modules/@protobufjs/path": {
+			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/@protobufjs/path/-/path-1.1.2.tgz",
+			"integrity": "sha512-6JOcJ5Tm08dOHAbdR3GrvP+yUUfkjG5ePsHYczMFLq3ZmMkAD98cDgcT2iA1lJ9NVwFd4tH/iSSoe44YWkltEA==",
+			"license": "BSD-3-Clause"
+		},
+		"node_modules/@protobufjs/pool": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/@protobufjs/pool/-/pool-1.1.0.tgz",
+			"integrity": "sha512-0kELaGSIDBKvcgS4zkjz1PeddatrjYcmMWOlAuAPwAeccUrPHdUqo/J6LiymHHEiJT5NrF1UVwxY14f+fy4WQw==",
+			"license": "BSD-3-Clause"
+		},
+		"node_modules/@protobufjs/utf8": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/@protobufjs/utf8/-/utf8-1.1.1.tgz",
+			"integrity": "sha512-oOAWABowe8EAbMyWKM0tYDKi8Yaox52D+HWZhAIJqQXbqe0xI/GV7FhLWqlEKreMkfDjshR5FKgi3mnle0h6Eg==",
+			"license": "BSD-3-Clause"
+		},
+		"node_modules/@rollup/rollup-android-arm-eabi": {
+			"version": "4.60.2",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.60.2.tgz",
+			"integrity": "sha512-dnlp69efPPg6Uaw2dVqzWRfAWRnYVb1XJ8CyyhIbZeaq4CA5/mLeZ1IEt9QqQxmbdvagjLIm2ZL8BxXv5lH4Yw==",
+			"cpu": [
+				"arm"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"android"
+			]
+		},
+		"node_modules/@rollup/rollup-android-arm64": {
+			"version": "4.60.2",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.60.2.tgz",
+			"integrity": "sha512-OqZTwDRDchGRHHm/hwLOL7uVPB9aUvI0am/eQuWMNyFHf5PSEQmyEeYYheA0EPPKUO/l0uigCp+iaTjoLjVoHg==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"android"
+			]
+		},
+		"node_modules/@rollup/rollup-darwin-arm64": {
+			"version": "4.60.2",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.60.2.tgz",
+			"integrity": "sha512-UwRE7CGpvSVEQS8gUMBe1uADWjNnVgP3Iusyda1nSRwNDCsRjnGc7w6El6WLQsXmZTbLZx9cecegumcitNfpmA==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"darwin"
+			]
+		},
+		"node_modules/@rollup/rollup-darwin-x64": {
+			"version": "4.60.2",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.60.2.tgz",
+			"integrity": "sha512-gjEtURKLCC5VXm1I+2i1u9OhxFsKAQJKTVB8WvDAHF+oZlq0GTVFOlTlO1q3AlCTE/DF32c16ESvfgqR7343/g==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"darwin"
+			]
+		},
+		"node_modules/@rollup/rollup-freebsd-arm64": {
+			"version": "4.60.2",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.60.2.tgz",
+			"integrity": "sha512-Bcl6CYDeAgE70cqZaMojOi/eK63h5Me97ZqAQoh77VPjMysA/4ORQBRGo3rRy45x4MzVlU9uZxs8Uwy7ZaKnBw==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"freebsd"
+			]
+		},
+		"node_modules/@rollup/rollup-freebsd-x64": {
+			"version": "4.60.2",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.60.2.tgz",
+			"integrity": "sha512-LU+TPda3mAE2QB0/Hp5VyeKJivpC6+tlOXd1VMoXV/YFMvk/MNk5iXeBfB4MQGRWyOYVJ01625vjkr0Az98OJQ==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"freebsd"
+			]
+		},
+		"node_modules/@rollup/rollup-linux-arm-gnueabihf": {
+			"version": "4.60.2",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.60.2.tgz",
+			"integrity": "sha512-2QxQrM+KQ7DAW4o22j+XZ6RKdxjLD7BOWTP0Bv0tmjdyhXSsr2Ul1oJDQqh9Zf5qOwTuTc7Ek83mOFaKnodPjg==",
+			"cpu": [
+				"arm"
+			],
+			"dev": true,
+			"libc": [
+				"glibc"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			]
+		},
+		"node_modules/@rollup/rollup-linux-arm-musleabihf": {
+			"version": "4.60.2",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.60.2.tgz",
+			"integrity": "sha512-TbziEu2DVsTEOPif2mKWkMeDMLoYjx95oESa9fkQQK7r/Orta0gnkcDpzwufEcAO2BLBsD7mZkXGFqEdMRRwfw==",
+			"cpu": [
+				"arm"
+			],
+			"dev": true,
+			"libc": [
+				"musl"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			]
+		},
+		"node_modules/@rollup/rollup-linux-arm64-gnu": {
+			"version": "4.60.2",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.60.2.tgz",
+			"integrity": "sha512-bO/rVDiDUuM2YfuCUwZ1t1cP+/yqjqz+Xf2VtkdppefuOFS2OSeAfgafaHNkFn0t02hEyXngZkxtGqXcXwO8Rg==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"libc": [
+				"glibc"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			]
+		},
+		"node_modules/@rollup/rollup-linux-arm64-musl": {
+			"version": "4.60.2",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.60.2.tgz",
+			"integrity": "sha512-hr26p7e93Rl0Za+JwW7EAnwAvKkehh12BU1Llm9Ykiibg4uIr2rbpxG9WCf56GuvidlTG9KiiQT/TXT1yAWxTA==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"libc": [
+				"musl"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			]
+		},
+		"node_modules/@rollup/rollup-linux-loong64-gnu": {
+			"version": "4.60.2",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.60.2.tgz",
+			"integrity": "sha512-pOjB/uSIyDt+ow3k/RcLvUAOGpysT2phDn7TTUB3n75SlIgZzM6NKAqlErPhoFU+npgY3/n+2HYIQVbF70P9/A==",
+			"cpu": [
+				"loong64"
+			],
+			"dev": true,
+			"libc": [
+				"glibc"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			]
+		},
+		"node_modules/@rollup/rollup-linux-loong64-musl": {
+			"version": "4.60.2",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.60.2.tgz",
+			"integrity": "sha512-2/w+q8jszv9Ww1c+6uJT3OwqhdmGP2/4T17cu8WuwyUuuaCDDJ2ojdyYwZzCxx0GcsZBhzi3HmH+J5pZNXnd+Q==",
+			"cpu": [
+				"loong64"
+			],
+			"dev": true,
+			"libc": [
+				"musl"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			]
+		},
+		"node_modules/@rollup/rollup-linux-ppc64-gnu": {
+			"version": "4.60.2",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.60.2.tgz",
+			"integrity": "sha512-11+aL5vKheYgczxtPVVRhdptAM2H7fcDR5Gw4/bTcteuZBlH4oP9f5s9zYO9aGZvoGeBpqXI/9TZZihZ609wKw==",
+			"cpu": [
+				"ppc64"
+			],
+			"dev": true,
+			"libc": [
+				"glibc"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			]
+		},
+		"node_modules/@rollup/rollup-linux-ppc64-musl": {
+			"version": "4.60.2",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.60.2.tgz",
+			"integrity": "sha512-i16fokAGK46IVZuV8LIIwMdtqhin9hfYkCh8pf8iC3QU3LpwL+1FSFGej+O7l3E/AoknL6Dclh2oTdnRMpTzFQ==",
+			"cpu": [
+				"ppc64"
+			],
+			"dev": true,
+			"libc": [
+				"musl"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			]
+		},
+		"node_modules/@rollup/rollup-linux-riscv64-gnu": {
+			"version": "4.60.2",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.60.2.tgz",
+			"integrity": "sha512-49FkKS6RGQoriDSK/6E2GkAsAuU5kETFCh7pG4yD/ylj9rKhTmO3elsnmBvRD4PgJPds5W2PkhC82aVwmUcJ7A==",
+			"cpu": [
+				"riscv64"
+			],
+			"dev": true,
+			"libc": [
+				"glibc"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			]
+		},
+		"node_modules/@rollup/rollup-linux-riscv64-musl": {
+			"version": "4.60.2",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.60.2.tgz",
+			"integrity": "sha512-mjYNkHPfGpUR00DuM1ZZIgs64Hpf4bWcz9Z41+4Q+pgDx73UwWdAYyf6EG/lRFldmdHHzgrYyge5akFUW0D3mQ==",
+			"cpu": [
+				"riscv64"
+			],
+			"dev": true,
+			"libc": [
+				"musl"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			]
+		},
+		"node_modules/@rollup/rollup-linux-s390x-gnu": {
+			"version": "4.60.2",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.60.2.tgz",
+			"integrity": "sha512-ALyvJz965BQk8E9Al/JDKKDLH2kfKFLTGMlgkAbbYtZuJt9LU8DW3ZoDMCtQpXAltZxwBHevXz5u+gf0yA0YoA==",
+			"cpu": [
+				"s390x"
+			],
+			"dev": true,
+			"libc": [
+				"glibc"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			]
+		},
+		"node_modules/@rollup/rollup-linux-x64-gnu": {
+			"version": "4.60.2",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.60.2.tgz",
+			"integrity": "sha512-UQjrkIdWrKI626Du8lCQ6MJp/6V1LAo2bOK9OTu4mSn8GGXIkPXk/Vsp4bLHCd9Z9Iz2OTEaokUE90VweJgIYQ==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"libc": [
+				"glibc"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			]
+		},
+		"node_modules/@rollup/rollup-linux-x64-musl": {
+			"version": "4.60.2",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.60.2.tgz",
+			"integrity": "sha512-bTsRGj6VlSdn/XD4CGyzMnzaBs9bsRxy79eTqTCBsA8TMIEky7qg48aPkvJvFe1HyzQ5oMZdg7AnVlWQSKLTnw==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"libc": [
+				"musl"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			]
+		},
+		"node_modules/@rollup/rollup-openbsd-x64": {
+			"version": "4.60.2",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.60.2.tgz",
+			"integrity": "sha512-6d4Z3534xitaA1FcMWP7mQPq5zGwBmGbhphh2DwaA1aNIXUu3KTOfwrWpbwI4/Gr0uANo7NTtaykFyO2hPuFLg==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"openbsd"
+			]
+		},
+		"node_modules/@rollup/rollup-openharmony-arm64": {
+			"version": "4.60.2",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.60.2.tgz",
+			"integrity": "sha512-NetAg5iO2uN7eB8zE5qrZ3CSil+7IJt4WDFLcC75Ymywq1VZVD6qJ6EvNLjZ3rEm6gB7XW5JdT60c6MN35Z85Q==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"openharmony"
+			]
+		},
+		"node_modules/@rollup/rollup-win32-arm64-msvc": {
+			"version": "4.60.2",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.60.2.tgz",
+			"integrity": "sha512-NCYhOotpgWZ5kdxCZsv6Iudx0wX8980Q/oW4pNFNihpBKsDbEA1zpkfxJGC0yugsUuyDZ7gL37dbzwhR0VI7pQ==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"win32"
+			]
+		},
+		"node_modules/@rollup/rollup-win32-ia32-msvc": {
+			"version": "4.60.2",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.60.2.tgz",
+			"integrity": "sha512-RXsaOqXxfoUBQoOgvmmijVxJnW2IGB0eoMO7F8FAjaj0UTywUO/luSqimWBJn04WNgUkeNhh7fs7pESXajWmkg==",
+			"cpu": [
+				"ia32"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"win32"
+			]
+		},
+		"node_modules/@rollup/rollup-win32-x64-gnu": {
+			"version": "4.60.2",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.60.2.tgz",
+			"integrity": "sha512-qdAzEULD+/hzObedtmV6iBpdL5TIbKVztGiK7O3/KYSf+HIzU257+MX1EXJcyIiDbMAqmbwaufcYPvyRryeZtA==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"win32"
+			]
+		},
+		"node_modules/@rollup/rollup-win32-x64-msvc": {
+			"version": "4.60.2",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.60.2.tgz",
+			"integrity": "sha512-Nd/SgG27WoA9e+/TdK74KnHz852TLa94ovOYySo/yMPuTmpckK/jIF2jSwS3g7ELSKXK13/cVdmg1Z/DaCWKxA==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"win32"
+			]
+		},
+		"node_modules/@silvia-odwyer/photon-node": {
+			"version": "0.3.4",
+			"resolved": "https://registry.npmjs.org/@silvia-odwyer/photon-node/-/photon-node-0.3.4.tgz",
+			"integrity": "sha512-bnly4BKB3KDTFxrUIcgCLbaeVVS8lrAkri1pEzskpmxu9MdfGQTy8b8EgcD83ywD3RPMsIulY8xJH5Awa+t9fA==",
+			"license": "Apache-2.0"
+		},
+		"node_modules/@sinclair/typebox": {
+			"version": "0.34.49",
+			"resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.34.49.tgz",
+			"integrity": "sha512-brySQQs7Jtn0joV8Xh9ZV/hZb9Ozb0pmazDIASBkYKCjXrXU3mpcFahmK/z4YDhGkQvP9mWJbVyahdtU5wQA+A==",
+			"license": "MIT"
+		},
+		"node_modules/@smithy/config-resolver": {
+			"version": "4.4.17",
+			"resolved": "https://registry.npmjs.org/@smithy/config-resolver/-/config-resolver-4.4.17.tgz",
+			"integrity": "sha512-TzDZcAnhTyAHbXVxWZo7/tEcrIeFq20IBk8So3OLOetWpR8EwY/yEqBMBFaJMeyEiREDq4NfEl+qO3OAUD+vbQ==",
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@smithy/node-config-provider": "^4.3.14",
+				"@smithy/types": "^4.14.1",
+				"@smithy/util-config-provider": "^4.2.2",
+				"@smithy/util-endpoints": "^3.4.2",
+				"@smithy/util-middleware": "^4.2.14",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=18.0.0"
+			}
+		},
+		"node_modules/@smithy/core": {
+			"version": "3.23.17",
+			"resolved": "https://registry.npmjs.org/@smithy/core/-/core-3.23.17.tgz",
+			"integrity": "sha512-x7BlLbUFL8NWCGjMF9C+1N5cVCxcPa7g6Tv9B4A2luWx3be3oU8hQ96wIwxe/s7OhIzvoJH73HAUSg5JXVlEtQ==",
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@smithy/protocol-http": "^5.3.14",
+				"@smithy/types": "^4.14.1",
+				"@smithy/url-parser": "^4.2.14",
+				"@smithy/util-base64": "^4.3.2",
+				"@smithy/util-body-length-browser": "^4.2.2",
+				"@smithy/util-middleware": "^4.2.14",
+				"@smithy/util-stream": "^4.5.25",
+				"@smithy/util-utf8": "^4.2.2",
+				"@smithy/uuid": "^1.1.2",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=18.0.0"
+			}
+		},
+		"node_modules/@smithy/credential-provider-imds": {
+			"version": "4.2.14",
+			"resolved": "https://registry.npmjs.org/@smithy/credential-provider-imds/-/credential-provider-imds-4.2.14.tgz",
+			"integrity": "sha512-Au28zBN48ZAoXdooGUHemuVBrkE+Ie6RPmGNIAJsFqj33Vhb6xAgRifUydZ2aY+M+KaMAETAlKk5NC5h1G7wpg==",
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@smithy/node-config-provider": "^4.3.14",
+				"@smithy/property-provider": "^4.2.14",
+				"@smithy/types": "^4.14.1",
+				"@smithy/url-parser": "^4.2.14",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=18.0.0"
+			}
+		},
+		"node_modules/@smithy/eventstream-codec": {
+			"version": "4.2.14",
+			"resolved": "https://registry.npmjs.org/@smithy/eventstream-codec/-/eventstream-codec-4.2.14.tgz",
+			"integrity": "sha512-erZq0nOIpzfeZdCyzZjdJb4nVSKLUmSkaQUVkRGQTXs30gyUGeKnrYEg+Xe1W5gE3aReS7IgsvANwVPxSzY6Pw==",
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@aws-crypto/crc32": "5.2.0",
+				"@smithy/types": "^4.14.1",
+				"@smithy/util-hex-encoding": "^4.2.2",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=18.0.0"
+			}
+		},
+		"node_modules/@smithy/eventstream-serde-browser": {
+			"version": "4.2.14",
+			"resolved": "https://registry.npmjs.org/@smithy/eventstream-serde-browser/-/eventstream-serde-browser-4.2.14.tgz",
+			"integrity": "sha512-8IelTCtTctWRbb+0Dcy+C0aICh1qa0qWXqgjcXDmMuCvPJRnv26hiDZoAau2ILOniki65mCPKqOQs/BaWvO4CQ==",
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@smithy/eventstream-serde-universal": "^4.2.14",
+				"@smithy/types": "^4.14.1",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=18.0.0"
+			}
+		},
+		"node_modules/@smithy/eventstream-serde-config-resolver": {
+			"version": "4.3.14",
+			"resolved": "https://registry.npmjs.org/@smithy/eventstream-serde-config-resolver/-/eventstream-serde-config-resolver-4.3.14.tgz",
+			"integrity": "sha512-sqHiHpYRYo3FJlaIxD1J8PhbcmJAm7IuM16mVnwSkCToD7g00IBZzKuiLNMGmftULmEUX6/UAz8/NN5uMP8bVA==",
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@smithy/types": "^4.14.1",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=18.0.0"
+			}
+		},
+		"node_modules/@smithy/eventstream-serde-node": {
+			"version": "4.2.14",
+			"resolved": "https://registry.npmjs.org/@smithy/eventstream-serde-node/-/eventstream-serde-node-4.2.14.tgz",
+			"integrity": "sha512-Ht/8BuGlKfFTy0H3+8eEu0vdpwGztCnaLLXtpXNdQqiR7Hj4vFScU3T436vRAjATglOIPjJXronY+1WxxNLSiw==",
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@smithy/eventstream-serde-universal": "^4.2.14",
+				"@smithy/types": "^4.14.1",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=18.0.0"
+			}
+		},
+		"node_modules/@smithy/eventstream-serde-universal": {
+			"version": "4.2.14",
+			"resolved": "https://registry.npmjs.org/@smithy/eventstream-serde-universal/-/eventstream-serde-universal-4.2.14.tgz",
+			"integrity": "sha512-lWyt4T2XQZUZgK3tQ3Wn0w3XBvZsK/vjTuJl6bXbnGZBHH0ZUSONTYiK9TgjTTzU54xQr3DRFwpjmhp0oLm3gg==",
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@smithy/eventstream-codec": "^4.2.14",
+				"@smithy/types": "^4.14.1",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=18.0.0"
+			}
+		},
+		"node_modules/@smithy/fetch-http-handler": {
+			"version": "5.3.17",
+			"resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-5.3.17.tgz",
+			"integrity": "sha512-bXOvQzaSm6MnmLaWA1elgfQcAtN4UP3vXqV97bHuoOrHQOJiLT3ds6o9eo5bqd0TJfRFpzdGnDQdW3FACiAVdw==",
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@smithy/protocol-http": "^5.3.14",
+				"@smithy/querystring-builder": "^4.2.14",
+				"@smithy/types": "^4.14.1",
+				"@smithy/util-base64": "^4.3.2",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=18.0.0"
+			}
+		},
+		"node_modules/@smithy/hash-node": {
+			"version": "4.2.14",
+			"resolved": "https://registry.npmjs.org/@smithy/hash-node/-/hash-node-4.2.14.tgz",
+			"integrity": "sha512-8ZBDY2DD4wr+GGjTpPtiglEsqr0lUP+KHqgZcWczFf6qeZ/YRjMIOoQWVQlmwu7EtxKTd8YXD8lblmYcpBIA1g==",
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@smithy/types": "^4.14.1",
+				"@smithy/util-buffer-from": "^4.2.2",
+				"@smithy/util-utf8": "^4.2.2",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=18.0.0"
+			}
+		},
+		"node_modules/@smithy/invalid-dependency": {
+			"version": "4.2.14",
+			"resolved": "https://registry.npmjs.org/@smithy/invalid-dependency/-/invalid-dependency-4.2.14.tgz",
+			"integrity": "sha512-c21qJiTSb25xvvOp+H2TNZzPCngrvl5vIPqPB8zQ/DmJF4QWXO19x1dWfMJZ6wZuuWUPPm0gV8C0cU3+ifcWuw==",
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@smithy/types": "^4.14.1",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=18.0.0"
+			}
+		},
+		"node_modules/@smithy/is-array-buffer": {
+			"version": "4.2.2",
+			"resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-4.2.2.tgz",
+			"integrity": "sha512-n6rQ4N8Jj4YTQO3YFrlgZuwKodf4zUFs7EJIWH86pSCWBaAtAGBFfCM7Wx6D2bBJ2xqFNxGBSrUWswT3M0VJow==",
+			"license": "Apache-2.0",
+			"dependencies": {
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=18.0.0"
+			}
+		},
+		"node_modules/@smithy/middleware-content-length": {
+			"version": "4.2.14",
+			"resolved": "https://registry.npmjs.org/@smithy/middleware-content-length/-/middleware-content-length-4.2.14.tgz",
+			"integrity": "sha512-xhHq7fX4/3lv5NHxLUk3OeEvl0xZ+Ek3qIbWaCL4f9JwgDZEclPBElljaZCAItdGPQl/kSM4LPMOpy1MYgprpw==",
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@smithy/protocol-http": "^5.3.14",
+				"@smithy/types": "^4.14.1",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=18.0.0"
+			}
+		},
+		"node_modules/@smithy/middleware-endpoint": {
+			"version": "4.4.32",
+			"resolved": "https://registry.npmjs.org/@smithy/middleware-endpoint/-/middleware-endpoint-4.4.32.tgz",
+			"integrity": "sha512-ZZkgyjnJppiZbIm6Qbx92pbXYi1uzenIvGhBSCDlc7NwuAkiqSgS75j1czAD25ZLs2FjMjYy1q7gyRVWG6JA0Q==",
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@smithy/core": "^3.23.17",
+				"@smithy/middleware-serde": "^4.2.20",
+				"@smithy/node-config-provider": "^4.3.14",
+				"@smithy/shared-ini-file-loader": "^4.4.9",
+				"@smithy/types": "^4.14.1",
+				"@smithy/url-parser": "^4.2.14",
+				"@smithy/util-middleware": "^4.2.14",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=18.0.0"
+			}
+		},
+		"node_modules/@smithy/middleware-retry": {
+			"version": "4.5.6",
+			"resolved": "https://registry.npmjs.org/@smithy/middleware-retry/-/middleware-retry-4.5.6.tgz",
+			"integrity": "sha512-5zhmo2AkstmM/RMKYP0NHfmuYWBR+/umlmSuALgajLxf0X0rLE6d17MfzTxpzkILWVhwvCJkCyPH0AfMlbaucQ==",
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@smithy/core": "^3.23.17",
+				"@smithy/node-config-provider": "^4.3.14",
+				"@smithy/protocol-http": "^5.3.14",
+				"@smithy/service-error-classification": "^4.3.1",
+				"@smithy/smithy-client": "^4.12.13",
+				"@smithy/types": "^4.14.1",
+				"@smithy/util-middleware": "^4.2.14",
+				"@smithy/util-retry": "^4.3.5",
+				"@smithy/uuid": "^1.1.2",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=18.0.0"
+			}
+		},
+		"node_modules/@smithy/middleware-serde": {
+			"version": "4.2.20",
+			"resolved": "https://registry.npmjs.org/@smithy/middleware-serde/-/middleware-serde-4.2.20.tgz",
+			"integrity": "sha512-Lx9JMO9vArPtiChE3wbEZ5akMIDQpWQtlu90lhACQmNOXcGXRbaDywMHDzuDZ2OkZzP+9wQfZi3YJT9F67zTQQ==",
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@smithy/core": "^3.23.17",
+				"@smithy/protocol-http": "^5.3.14",
+				"@smithy/types": "^4.14.1",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=18.0.0"
+			}
+		},
+		"node_modules/@smithy/middleware-stack": {
+			"version": "4.2.14",
+			"resolved": "https://registry.npmjs.org/@smithy/middleware-stack/-/middleware-stack-4.2.14.tgz",
+			"integrity": "sha512-2dvkUKLuFdKsCRmOE4Mn63co0Djtsm+JMh0bYZQupN1pJwMeE8FmQmRLLzzEMN0dnNi7CDCYYH8F0EVwWiPBeA==",
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@smithy/types": "^4.14.1",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=18.0.0"
+			}
+		},
+		"node_modules/@smithy/node-config-provider": {
+			"version": "4.3.14",
+			"resolved": "https://registry.npmjs.org/@smithy/node-config-provider/-/node-config-provider-4.3.14.tgz",
+			"integrity": "sha512-S+gFjyo/weSVL0P1b9Ts8C/CwIfNCgUPikk3sl6QVsfE/uUuO+QsF+NsE/JkpvWqqyz1wg7HFdiaZuj5CoBMRg==",
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@smithy/property-provider": "^4.2.14",
+				"@smithy/shared-ini-file-loader": "^4.4.9",
+				"@smithy/types": "^4.14.1",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=18.0.0"
+			}
+		},
+		"node_modules/@smithy/node-http-handler": {
+			"version": "4.6.1",
+			"resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-4.6.1.tgz",
+			"integrity": "sha512-iB+orM4x3xrr57X3YaXazfKnntl0LHlZB1kcXSGzMV1Tt0+YwEjGlbjk/44qEGtBzXAz6yFDzkYTKSV6Pj2HUg==",
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@smithy/protocol-http": "^5.3.14",
+				"@smithy/querystring-builder": "^4.2.14",
+				"@smithy/types": "^4.14.1",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=18.0.0"
+			}
+		},
+		"node_modules/@smithy/property-provider": {
+			"version": "4.2.14",
+			"resolved": "https://registry.npmjs.org/@smithy/property-provider/-/property-provider-4.2.14.tgz",
+			"integrity": "sha512-WuM31CgfsnQ/10i7NYr0PyxqknD72Y5uMfUMVSniPjbEPceiTErb4eIqJQ+pdxNEAUEWrewrGjIRjVbVHsxZiQ==",
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@smithy/types": "^4.14.1",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=18.0.0"
+			}
+		},
+		"node_modules/@smithy/protocol-http": {
+			"version": "5.3.14",
+			"resolved": "https://registry.npmjs.org/@smithy/protocol-http/-/protocol-http-5.3.14.tgz",
+			"integrity": "sha512-dN5F8kHx8RNU0r+pCwNmFZyz6ChjMkzShy/zup6MtkRmmix4vZzJdW+di7x//b1LiynIev88FM18ie+wwPcQtQ==",
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@smithy/types": "^4.14.1",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=18.0.0"
+			}
+		},
+		"node_modules/@smithy/querystring-builder": {
+			"version": "4.2.14",
+			"resolved": "https://registry.npmjs.org/@smithy/querystring-builder/-/querystring-builder-4.2.14.tgz",
+			"integrity": "sha512-XYA5Z0IqTeF+5XDdh4BBmSA0HvbgVZIyv4cmOoUheDNR57K1HgBp9ukUMx3Cr3XpDHHpLBnexPE3LAtDsZkj2A==",
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@smithy/types": "^4.14.1",
+				"@smithy/util-uri-escape": "^4.2.2",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=18.0.0"
+			}
+		},
+		"node_modules/@smithy/querystring-parser": {
+			"version": "4.2.14",
+			"resolved": "https://registry.npmjs.org/@smithy/querystring-parser/-/querystring-parser-4.2.14.tgz",
+			"integrity": "sha512-hr+YyqBD23GVvRxGGrcc/oOeNlK3PzT5Fu4dzrDXxzS1LpFiuL2PQQqKPs87M79aW7ziMs+nvB3qdw77SqE7Lw==",
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@smithy/types": "^4.14.1",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=18.0.0"
+			}
+		},
+		"node_modules/@smithy/service-error-classification": {
+			"version": "4.3.1",
+			"resolved": "https://registry.npmjs.org/@smithy/service-error-classification/-/service-error-classification-4.3.1.tgz",
+			"integrity": "sha512-aUQuDGh760ts/8MU+APjIZhlLPKhIIfqyzZaJikLEIMrdxFvxuLYD0WxWzaYWpmLbQlXDe9p7EWM3HsBe0K6Gw==",
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@smithy/types": "^4.14.1"
+			},
+			"engines": {
+				"node": ">=18.0.0"
+			}
+		},
+		"node_modules/@smithy/shared-ini-file-loader": {
+			"version": "4.4.9",
+			"resolved": "https://registry.npmjs.org/@smithy/shared-ini-file-loader/-/shared-ini-file-loader-4.4.9.tgz",
+			"integrity": "sha512-495/V2I15SHgedSJoDPD23JuSfKAp726ZI1V0wtjB07Wh7q/0tri/0e0DLefZCHgxZonrGKt/OCTpAtP1wE1kQ==",
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@smithy/types": "^4.14.1",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=18.0.0"
+			}
+		},
+		"node_modules/@smithy/signature-v4": {
+			"version": "5.3.14",
+			"resolved": "https://registry.npmjs.org/@smithy/signature-v4/-/signature-v4-5.3.14.tgz",
+			"integrity": "sha512-1D9Y/nmlVjCeSivCbhZ7hgEpmHyY1h0GvpSZt3l0xcD9JjmjVC1CHOozS6+Gh+/ldMH8JuJ6cujObQqfayAVFA==",
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@smithy/is-array-buffer": "^4.2.2",
+				"@smithy/protocol-http": "^5.3.14",
+				"@smithy/types": "^4.14.1",
+				"@smithy/util-hex-encoding": "^4.2.2",
+				"@smithy/util-middleware": "^4.2.14",
+				"@smithy/util-uri-escape": "^4.2.2",
+				"@smithy/util-utf8": "^4.2.2",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=18.0.0"
+			}
+		},
+		"node_modules/@smithy/smithy-client": {
+			"version": "4.12.13",
+			"resolved": "https://registry.npmjs.org/@smithy/smithy-client/-/smithy-client-4.12.13.tgz",
+			"integrity": "sha512-y/Pcj1V9+qG98gyu1gvftHB7rDpdh+7kIBIggs55yGm3JdtBV8GT8IFF3a1qxZ79QnaJHX9GXzvBG6tAd+czJA==",
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@smithy/core": "^3.23.17",
+				"@smithy/middleware-endpoint": "^4.4.32",
+				"@smithy/middleware-stack": "^4.2.14",
+				"@smithy/protocol-http": "^5.3.14",
+				"@smithy/types": "^4.14.1",
+				"@smithy/util-stream": "^4.5.25",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=18.0.0"
+			}
+		},
+		"node_modules/@smithy/types": {
+			"version": "4.14.1",
+			"resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.14.1.tgz",
+			"integrity": "sha512-59b5HtSVrVR/eYNei3BUj3DCPKD/G7EtDDe7OEJE7i7FtQFugYo6MxbotS8mVJkLNVf8gYaAlEBwwtJ9HzhWSg==",
+			"license": "Apache-2.0",
+			"dependencies": {
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=18.0.0"
+			}
+		},
+		"node_modules/@smithy/url-parser": {
+			"version": "4.2.14",
+			"resolved": "https://registry.npmjs.org/@smithy/url-parser/-/url-parser-4.2.14.tgz",
+			"integrity": "sha512-p06BiBigJ8bTA3MgnOfCtDUWnAMY0YfedO/GRpmc7p+wg3KW8vbXy1xwSu5ASy0wV7rRYtlfZOIKH4XqfhjSQQ==",
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@smithy/querystring-parser": "^4.2.14",
+				"@smithy/types": "^4.14.1",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=18.0.0"
+			}
+		},
+		"node_modules/@smithy/util-base64": {
+			"version": "4.3.2",
+			"resolved": "https://registry.npmjs.org/@smithy/util-base64/-/util-base64-4.3.2.tgz",
+			"integrity": "sha512-XRH6b0H/5A3SgblmMa5ErXQ2XKhfbQB+Fm/oyLZ2O2kCUrwgg55bU0RekmzAhuwOjA9qdN5VU2BprOvGGUkOOQ==",
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@smithy/util-buffer-from": "^4.2.2",
+				"@smithy/util-utf8": "^4.2.2",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=18.0.0"
+			}
+		},
+		"node_modules/@smithy/util-body-length-browser": {
+			"version": "4.2.2",
+			"resolved": "https://registry.npmjs.org/@smithy/util-body-length-browser/-/util-body-length-browser-4.2.2.tgz",
+			"integrity": "sha512-JKCrLNOup3OOgmzeaKQwi4ZCTWlYR5H4Gm1r2uTMVBXoemo1UEghk5vtMi1xSu2ymgKVGW631e2fp9/R610ZjQ==",
+			"license": "Apache-2.0",
+			"dependencies": {
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=18.0.0"
+			}
+		},
+		"node_modules/@smithy/util-body-length-node": {
+			"version": "4.2.3",
+			"resolved": "https://registry.npmjs.org/@smithy/util-body-length-node/-/util-body-length-node-4.2.3.tgz",
+			"integrity": "sha512-ZkJGvqBzMHVHE7r/hcuCxlTY8pQr1kMtdsVPs7ex4mMU+EAbcXppfo5NmyxMYi2XU49eqaz56j2gsk4dHHPG/g==",
+			"license": "Apache-2.0",
+			"dependencies": {
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=18.0.0"
+			}
+		},
+		"node_modules/@smithy/util-buffer-from": {
+			"version": "4.2.2",
+			"resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-4.2.2.tgz",
+			"integrity": "sha512-FDXD7cvUoFWwN6vtQfEta540Y/YBe5JneK3SoZg9bThSoOAC/eGeYEua6RkBgKjGa/sz6Y+DuBZj3+YEY21y4Q==",
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@smithy/is-array-buffer": "^4.2.2",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=18.0.0"
+			}
+		},
+		"node_modules/@smithy/util-config-provider": {
+			"version": "4.2.2",
+			"resolved": "https://registry.npmjs.org/@smithy/util-config-provider/-/util-config-provider-4.2.2.tgz",
+			"integrity": "sha512-dWU03V3XUprJwaUIFVv4iOnS1FC9HnMHDfUrlNDSh4315v0cWyaIErP8KiqGVbf5z+JupoVpNM7ZB3jFiTejvQ==",
+			"license": "Apache-2.0",
+			"dependencies": {
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=18.0.0"
+			}
+		},
+		"node_modules/@smithy/util-defaults-mode-browser": {
+			"version": "4.3.49",
+			"resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-browser/-/util-defaults-mode-browser-4.3.49.tgz",
+			"integrity": "sha512-a5bNrdiONYB/qE2BuKegvUMd/+ZDwdg4vsNuuSzYE8qs2EYAdK9CynL+Rzn29PbPiUqoz/cbpRbcLzD5lEevHw==",
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@smithy/property-provider": "^4.2.14",
+				"@smithy/smithy-client": "^4.12.13",
+				"@smithy/types": "^4.14.1",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=18.0.0"
+			}
+		},
+		"node_modules/@smithy/util-defaults-mode-node": {
+			"version": "4.2.54",
+			"resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-node/-/util-defaults-mode-node-4.2.54.tgz",
+			"integrity": "sha512-g1cvrJvOnzeJgEdf7AE4luI7gp6L8weE0y9a9wQUSGtjb8QRHDbCJYuE4Sy0SD9N8RrnNPFsPltAz/OSoBR9Zw==",
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@smithy/config-resolver": "^4.4.17",
+				"@smithy/credential-provider-imds": "^4.2.14",
+				"@smithy/node-config-provider": "^4.3.14",
+				"@smithy/property-provider": "^4.2.14",
+				"@smithy/smithy-client": "^4.12.13",
+				"@smithy/types": "^4.14.1",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=18.0.0"
+			}
+		},
+		"node_modules/@smithy/util-endpoints": {
+			"version": "3.4.2",
+			"resolved": "https://registry.npmjs.org/@smithy/util-endpoints/-/util-endpoints-3.4.2.tgz",
+			"integrity": "sha512-a55Tr+3OKld4TTtnT+RhKOQHyPxm3j/xL4OR83WBUhLJaKDS9dnJ7arRMOp3t31dcLhApwG9bgvrRXBHlLdIkg==",
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@smithy/node-config-provider": "^4.3.14",
+				"@smithy/types": "^4.14.1",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=18.0.0"
+			}
+		},
+		"node_modules/@smithy/util-hex-encoding": {
+			"version": "4.2.2",
+			"resolved": "https://registry.npmjs.org/@smithy/util-hex-encoding/-/util-hex-encoding-4.2.2.tgz",
+			"integrity": "sha512-Qcz3W5vuHK4sLQdyT93k/rfrUwdJ8/HZ+nMUOyGdpeGA1Wxt65zYwi3oEl9kOM+RswvYq90fzkNDahPS8K0OIg==",
+			"license": "Apache-2.0",
+			"dependencies": {
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=18.0.0"
+			}
+		},
+		"node_modules/@smithy/util-middleware": {
+			"version": "4.2.14",
+			"resolved": "https://registry.npmjs.org/@smithy/util-middleware/-/util-middleware-4.2.14.tgz",
+			"integrity": "sha512-1Su2vj9RYNDEv/V+2E+jXkkwGsgR7dc4sfHn9Z7ruzQHJIEni9zzw5CauvRXlFJfmgcqYP8fWa0dkh2Q2YaQyw==",
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@smithy/types": "^4.14.1",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=18.0.0"
+			}
+		},
+		"node_modules/@smithy/util-retry": {
+			"version": "4.3.5",
+			"resolved": "https://registry.npmjs.org/@smithy/util-retry/-/util-retry-4.3.5.tgz",
+			"integrity": "sha512-h1IJsbgMDA+jaTjrco/JsyfWOgHRJBv8myB1y4AEI2fjIzD6ktZ7pFAyTw+gwN9GKIAygvC6db0mq0j8N2rFOg==",
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@smithy/service-error-classification": "^4.3.1",
+				"@smithy/types": "^4.14.1",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=18.0.0"
+			}
+		},
+		"node_modules/@smithy/util-stream": {
+			"version": "4.5.25",
+			"resolved": "https://registry.npmjs.org/@smithy/util-stream/-/util-stream-4.5.25.tgz",
+			"integrity": "sha512-/PFpG4k8Ze8Ei+mMKj3oiPICYekthuzePZMgZbCqMiXIHHf4n2aZ4Ps0aSRShycFTGuj/J6XldmC0x0DwednIA==",
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@smithy/fetch-http-handler": "^5.3.17",
+				"@smithy/node-http-handler": "^4.6.1",
+				"@smithy/types": "^4.14.1",
+				"@smithy/util-base64": "^4.3.2",
+				"@smithy/util-buffer-from": "^4.2.2",
+				"@smithy/util-hex-encoding": "^4.2.2",
+				"@smithy/util-utf8": "^4.2.2",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=18.0.0"
+			}
+		},
+		"node_modules/@smithy/util-uri-escape": {
+			"version": "4.2.2",
+			"resolved": "https://registry.npmjs.org/@smithy/util-uri-escape/-/util-uri-escape-4.2.2.tgz",
+			"integrity": "sha512-2kAStBlvq+lTXHyAZYfJRb/DfS3rsinLiwb+69SstC9Vb0s9vNWkRwpnj918Pfi85mzi42sOqdV72OLxWAISnw==",
+			"license": "Apache-2.0",
+			"dependencies": {
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=18.0.0"
+			}
+		},
+		"node_modules/@smithy/util-utf8": {
+			"version": "4.2.2",
+			"resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-4.2.2.tgz",
+			"integrity": "sha512-75MeYpjdWRe8M5E3AW0O4Cx3UadweS+cwdXjwYGBW5h/gxxnbeZ877sLPX/ZJA9GVTlL/qG0dXP29JWFCD1Ayw==",
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@smithy/util-buffer-from": "^4.2.2",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=18.0.0"
+			}
+		},
+		"node_modules/@smithy/uuid": {
+			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/@smithy/uuid/-/uuid-1.1.2.tgz",
+			"integrity": "sha512-O/IEdcCUKkubz60tFbGA7ceITTAJsty+lBjNoorP4Z6XRqaFb/OjQjZODophEcuq68nKm6/0r+6/lLQ+XVpk8g==",
+			"license": "Apache-2.0",
+			"dependencies": {
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=18.0.0"
+			}
+		},
+		"node_modules/@standard-schema/spec": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
+			"integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
+			"license": "MIT"
+		},
+		"node_modules/@tokenizer/inflate": {
+			"version": "0.4.1",
+			"resolved": "https://registry.npmjs.org/@tokenizer/inflate/-/inflate-0.4.1.tgz",
+			"integrity": "sha512-2mAv+8pkG6GIZiF1kNg1jAjh27IDxEPKwdGul3snfztFerfPGI1LjDezZp3i7BElXompqEtPmoPx6c2wgtWsOA==",
+			"license": "MIT",
+			"dependencies": {
+				"debug": "^4.4.3",
+				"token-types": "^6.1.1"
+			},
+			"engines": {
+				"node": ">=18"
+			},
+			"funding": {
+				"type": "github",
+				"url": "https://github.com/sponsors/Borewit"
+			}
+		},
+		"node_modules/@tokenizer/token": {
+			"version": "0.3.0",
+			"resolved": "https://registry.npmjs.org/@tokenizer/token/-/token-0.3.0.tgz",
+			"integrity": "sha512-OvjF+z51L3ov0OyAU0duzsYuvO01PH7x4t6DJx+guahgTnBHkhJdG7soQeTSFLWN3efnHyibZ4Z8l2EuWwJN3A==",
+			"license": "MIT"
+		},
+		"node_modules/@tootallnate/quickjs-emscripten": {
+			"version": "0.23.0",
+			"resolved": "https://registry.npmjs.org/@tootallnate/quickjs-emscripten/-/quickjs-emscripten-0.23.0.tgz",
+			"integrity": "sha512-C5Mc6rdnsaJDjO3UpGW/CQTHtCKaYlScZTly4JIu97Jxo/odCiH0ITnDXSJPTOrEKk/ycSZ0AOgTmkDtkOsvIA==",
+			"license": "MIT"
+		},
+		"node_modules/@types/braces": {
+			"version": "3.0.5",
+			"resolved": "https://registry.npmjs.org/@types/braces/-/braces-3.0.5.tgz",
+			"integrity": "sha512-SQFof9H+LXeWNz8wDe7oN5zu7ket0qwMu5vZubW4GCJ8Kkeh6nBWUz87+KTz/G3Kqsrp0j/W253XJb3KMEeg3w==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/@types/chai": {
+			"version": "5.2.3",
+			"resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
+			"integrity": "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@types/deep-eql": "*",
+				"assertion-error": "^2.0.1"
+			}
+		},
+		"node_modules/@types/deep-eql": {
+			"version": "4.0.2",
+			"resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
+			"integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/@types/estree": {
+			"version": "1.0.8",
+			"resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
+			"integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/@types/micromatch": {
+			"version": "4.0.10",
+			"resolved": "https://registry.npmjs.org/@types/micromatch/-/micromatch-4.0.10.tgz",
+			"integrity": "sha512-5jOhFDElqr4DKTrTEbnW8DZ4Hz5LRUEmyrGpCMrD/NphYv3nUnaF08xmSLx1rGGnyEs/kFnhiw6dCgcDqMr5PQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@types/braces": "*"
+			}
+		},
+		"node_modules/@types/mime-types": {
+			"version": "2.1.4",
+			"resolved": "https://registry.npmjs.org/@types/mime-types/-/mime-types-2.1.4.tgz",
+			"integrity": "sha512-lfU4b34HOri+kAY5UheuFMWPDOI+OPceBSHZKp69gEyTL/mmJ4cnU6Y/rlme3UL3GyOn6Y42hyIEw0/q8sWx5w==",
+			"license": "MIT"
+		},
+		"node_modules/@types/node": {
+			"version": "22.19.17",
+			"resolved": "https://registry.npmjs.org/@types/node/-/node-22.19.17.tgz",
+			"integrity": "sha512-wGdMcf+vPYM6jikpS/qhg6WiqSV/OhG+jeeHT/KlVqxYfD40iYJf9/AE1uQxVWFvU7MipKRkRv8NSHiCGgPr8Q==",
+			"license": "MIT",
+			"dependencies": {
+				"undici-types": "~6.21.0"
+			}
+		},
+		"node_modules/@types/retry": {
+			"version": "0.12.0",
+			"resolved": "https://registry.npmjs.org/@types/retry/-/retry-0.12.0.tgz",
+			"integrity": "sha512-wWKOClTTiizcZhXnPY4wikVAwmdYHp8q6DmC+EJUzAMsycb7HB32Kh9RN4+0gExjmPmZSAQjgURXIGATPegAvA==",
+			"license": "MIT"
+		},
+		"node_modules/@types/shell-quote": {
+			"version": "1.7.5",
+			"resolved": "https://registry.npmjs.org/@types/shell-quote/-/shell-quote-1.7.5.tgz",
+			"integrity": "sha512-+UE8GAGRPbJVQDdxi16dgadcBfQ+KG2vgZhV1+3A1XmHbmwcdwhCUwIdy+d3pAGrbvgRoVSjeI9vOWyq376Yzw==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/@types/turndown": {
+			"version": "5.0.6",
+			"resolved": "https://registry.npmjs.org/@types/turndown/-/turndown-5.0.6.tgz",
+			"integrity": "sha512-ru00MoyeeouE5BX4gRL+6m/BsDfbRayOskWqUvh7CLGW+UXxHQItqALa38kKnOiZPqJrtzJUgAC2+F0rL1S4Pg==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/@types/yauzl": {
+			"version": "2.10.3",
+			"resolved": "https://registry.npmjs.org/@types/yauzl/-/yauzl-2.10.3.tgz",
+			"integrity": "sha512-oJoftv0LSuaDZE3Le4DbKX+KS9G36NzOeSap90UIK0yMA/NhKJhqlSGtNDORNRaIbQfzjXDrQa0ytJ6mNRGz/Q==",
+			"license": "MIT",
+			"optional": true,
+			"dependencies": {
+				"@types/node": "*"
+			}
+		},
+		"node_modules/@vitest/expect": {
+			"version": "3.2.4",
+			"resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-3.2.4.tgz",
+			"integrity": "sha512-Io0yyORnB6sikFlt8QW5K7slY4OjqNX9jmJQ02QDda8lyM6B5oNgVWoSoKPac8/kgnCUzuHQKrSLtu/uOqqrig==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@types/chai": "^5.2.2",
+				"@vitest/spy": "3.2.4",
+				"@vitest/utils": "3.2.4",
+				"chai": "^5.2.0",
+				"tinyrainbow": "^2.0.0"
+			},
+			"funding": {
+				"url": "https://opencollective.com/vitest"
+			}
+		},
+		"node_modules/@vitest/mocker": {
+			"version": "3.2.4",
+			"resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-3.2.4.tgz",
+			"integrity": "sha512-46ryTE9RZO/rfDd7pEqFl7etuyzekzEhUbTW3BvmeO/BcCMEgq59BKhek3dXDWgAj4oMK6OZi+vRr1wPW6qjEQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@vitest/spy": "3.2.4",
+				"estree-walker": "^3.0.3",
+				"magic-string": "^0.30.17"
+			},
+			"funding": {
+				"url": "https://opencollective.com/vitest"
+			},
+			"peerDependencies": {
+				"msw": "^2.4.9",
+				"vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0"
+			},
+			"peerDependenciesMeta": {
+				"msw": {
+					"optional": true
+				},
+				"vite": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/@vitest/pretty-format": {
+			"version": "3.2.4",
+			"resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-3.2.4.tgz",
+			"integrity": "sha512-IVNZik8IVRJRTr9fxlitMKeJeXFFFN0JaB9PHPGQ8NKQbGpfjlTx9zO4RefN8gp7eqjNy8nyK3NZmBzOPeIxtA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"tinyrainbow": "^2.0.0"
+			},
+			"funding": {
+				"url": "https://opencollective.com/vitest"
+			}
+		},
+		"node_modules/@vitest/runner": {
+			"version": "3.2.4",
+			"resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-3.2.4.tgz",
+			"integrity": "sha512-oukfKT9Mk41LreEW09vt45f8wx7DordoWUZMYdY/cyAk7w5TWkTRCNZYF7sX7n2wB7jyGAl74OxgwhPgKaqDMQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@vitest/utils": "3.2.4",
+				"pathe": "^2.0.3",
+				"strip-literal": "^3.0.0"
+			},
+			"funding": {
+				"url": "https://opencollective.com/vitest"
+			}
+		},
+		"node_modules/@vitest/snapshot": {
+			"version": "3.2.4",
+			"resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-3.2.4.tgz",
+			"integrity": "sha512-dEYtS7qQP2CjU27QBC5oUOxLE/v5eLkGqPE0ZKEIDGMs4vKWe7IjgLOeauHsR0D5YuuycGRO5oSRXnwnmA78fQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@vitest/pretty-format": "3.2.4",
+				"magic-string": "^0.30.17",
+				"pathe": "^2.0.3"
+			},
+			"funding": {
+				"url": "https://opencollective.com/vitest"
+			}
+		},
+		"node_modules/@vitest/spy": {
+			"version": "3.2.4",
+			"resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-3.2.4.tgz",
+			"integrity": "sha512-vAfasCOe6AIK70iP5UD11Ac4siNUNJ9i/9PZ3NKx07sG6sUxeag1LWdNrMWeKKYBLlzuK+Gn65Yd5nyL6ds+nw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"tinyspy": "^4.0.3"
+			},
+			"funding": {
+				"url": "https://opencollective.com/vitest"
+			}
+		},
+		"node_modules/@vitest/utils": {
+			"version": "3.2.4",
+			"resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-3.2.4.tgz",
+			"integrity": "sha512-fB2V0JFrQSMsCo9HiSq3Ezpdv4iYaXRG1Sx8edX3MwxfyNn83mKiGzOcH+Fkxt4MHxr3y42fQi1oeAInqgX2QA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@vitest/pretty-format": "3.2.4",
+				"loupe": "^3.1.4",
+				"tinyrainbow": "^2.0.0"
+			},
+			"funding": {
+				"url": "https://opencollective.com/vitest"
+			}
+		},
+		"node_modules/accepts": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/accepts/-/accepts-2.0.0.tgz",
+			"integrity": "sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng==",
+			"license": "MIT",
+			"dependencies": {
+				"mime-types": "^3.0.0",
+				"negotiator": "^1.0.0"
+			},
+			"engines": {
+				"node": ">= 0.6"
+			}
+		},
+		"node_modules/agent-base": {
+			"version": "7.1.4",
+			"resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
+			"integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
+			"license": "MIT",
+			"engines": {
+				"node": ">= 14"
+			}
+		},
+		"node_modules/ajv": {
+			"version": "8.20.0",
+			"resolved": "https://registry.npmjs.org/ajv/-/ajv-8.20.0.tgz",
+			"integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
+			"license": "MIT",
+			"dependencies": {
+				"fast-deep-equal": "^3.1.3",
+				"fast-uri": "^3.0.1",
+				"json-schema-traverse": "^1.0.0",
+				"require-from-string": "^2.0.2"
+			},
+			"funding": {
+				"type": "github",
+				"url": "https://github.com/sponsors/epoberezkin"
+			}
+		},
+		"node_modules/ajv-formats": {
+			"version": "3.0.1",
+			"resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-3.0.1.tgz",
+			"integrity": "sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==",
+			"license": "MIT",
+			"dependencies": {
+				"ajv": "^8.0.0"
+			},
+			"peerDependencies": {
+				"ajv": "^8.0.0"
+			},
+			"peerDependenciesMeta": {
+				"ajv": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/ansi-regex": {
+			"version": "6.2.2",
+			"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz",
+			"integrity": "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=12"
+			},
+			"funding": {
+				"url": "https://github.com/chalk/ansi-regex?sponsor=1"
+			}
+		},
+		"node_modules/ansi-styles": {
+			"version": "4.3.0",
+			"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+			"integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+			"license": "MIT",
+			"dependencies": {
+				"color-convert": "^2.0.1"
+			},
+			"engines": {
+				"node": ">=8"
+			},
+			"funding": {
+				"url": "https://github.com/chalk/ansi-styles?sponsor=1"
+			}
+		},
+		"node_modules/any-promise": {
+			"version": "1.3.0",
+			"resolved": "https://registry.npmjs.org/any-promise/-/any-promise-1.3.0.tgz",
+			"integrity": "sha512-7UvmKalWRt1wgjL1RrGxoSJW/0QZFIegpeGvZG9kjp8vrRu55XTHbwnqq2GpXm9uLbcuhxm3IqX9OB4MZR1b2A==",
+			"license": "MIT"
+		},
+		"node_modules/assertion-error": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+			"integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/ast-types": {
+			"version": "0.13.4",
+			"resolved": "https://registry.npmjs.org/ast-types/-/ast-types-0.13.4.tgz",
+			"integrity": "sha512-x1FCFnFifvYDDzTaLII71vG5uvDwgtmDTEVWAxrgeiR8VjMONcCXJx7E+USjDtHlwFmt9MysbqgF9b9Vjr6w+w==",
+			"license": "MIT",
+			"dependencies": {
+				"tslib": "^2.0.1"
+			},
+			"engines": {
+				"node": ">=4"
+			}
+		},
+		"node_modules/balanced-match": {
+			"version": "4.0.4",
+			"resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+			"integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
+			"license": "MIT",
+			"engines": {
+				"node": "18 || 20 || >=22"
+			}
+		},
+		"node_modules/base64-js": {
+			"version": "1.5.1",
+			"resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+			"integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/feross"
+				},
+				{
+					"type": "patreon",
+					"url": "https://www.patreon.com/feross"
+				},
+				{
+					"type": "consulting",
+					"url": "https://feross.org/support"
+				}
+			],
+			"license": "MIT"
+		},
+		"node_modules/basic-ftp": {
+			"version": "5.3.1",
+			"resolved": "https://registry.npmjs.org/basic-ftp/-/basic-ftp-5.3.1.tgz",
+			"integrity": "sha512-bopVNp6ugyA150DDuZfPFdt1KZ5a94ZDiwX4hMgZDzF+GttD80lEy8kj98kbyhLXnPvhtIo93mdnLIjpCAeeOw==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=10.0.0"
+			}
+		},
+		"node_modules/bignumber.js": {
+			"version": "9.3.1",
+			"resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-9.3.1.tgz",
+			"integrity": "sha512-Ko0uX15oIUS7wJ3Rb30Fs6SkVbLmPBAKdlm7q9+ak9bbIeFf0MwuBsQV6z7+X768/cHsfg+WlysDWJcmthjsjQ==",
+			"license": "MIT",
+			"engines": {
+				"node": "*"
+			}
+		},
+		"node_modules/body-parser": {
+			"version": "2.2.2",
+			"resolved": "https://registry.npmjs.org/body-parser/-/body-parser-2.2.2.tgz",
+			"integrity": "sha512-oP5VkATKlNwcgvxi0vM0p/D3n2C3EReYVX+DNYs5TjZFn/oQt2j+4sVJtSMr18pdRr8wjTcBl6LoV+FUwzPmNA==",
+			"license": "MIT",
+			"dependencies": {
+				"bytes": "^3.1.2",
+				"content-type": "^1.0.5",
+				"debug": "^4.4.3",
+				"http-errors": "^2.0.0",
+				"iconv-lite": "^0.7.0",
+				"on-finished": "^2.4.1",
+				"qs": "^6.14.1",
+				"raw-body": "^3.0.1",
+				"type-is": "^2.0.1"
+			},
+			"engines": {
+				"node": ">=18"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/express"
+			}
+		},
+		"node_modules/bowser": {
+			"version": "2.14.1",
+			"resolved": "https://registry.npmjs.org/bowser/-/bowser-2.14.1.tgz",
+			"integrity": "sha512-tzPjzCxygAKWFOJP011oxFHs57HzIhOEracIgAePE4pqB3LikALKnSzUyU4MGs9/iCEUuHlAJTjTc5M+u7YEGg==",
+			"license": "MIT"
+		},
+		"node_modules/brace-expansion": {
+			"version": "5.0.5",
+			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
+			"integrity": "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==",
+			"license": "MIT",
+			"dependencies": {
+				"balanced-match": "^4.0.2"
+			},
+			"engines": {
+				"node": "18 || 20 || >=22"
+			}
+		},
+		"node_modules/braces": {
+			"version": "3.0.3",
+			"resolved": "https://registry.npmjs.org/braces/-/braces-3.0.3.tgz",
+			"integrity": "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==",
+			"license": "MIT",
+			"dependencies": {
+				"fill-range": "^7.1.1"
+			},
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/buffer-crc32": {
+			"version": "0.2.13",
+			"resolved": "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-0.2.13.tgz",
+			"integrity": "sha512-VO9Ht/+p3SN7SKWqcrgEzjGbRSJYTx+Q1pTQC0wrWqHx0vpJraQ6GtHx8tvcg1rlK1byhU5gccxgOgj7B0TDkQ==",
+			"license": "MIT",
+			"engines": {
+				"node": "*"
+			}
+		},
+		"node_modules/buffer-equal-constant-time": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz",
+			"integrity": "sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA==",
+			"license": "BSD-3-Clause"
+		},
+		"node_modules/bundle-name": {
+			"version": "4.1.0",
+			"resolved": "https://registry.npmjs.org/bundle-name/-/bundle-name-4.1.0.tgz",
+			"integrity": "sha512-tjwM5exMg6BGRI+kNmTntNsvdZS1X8BFYS6tnJ2hdH0kVxM6/eVZ2xy+FqStSWvYmtfFMDLIxurorHwDKfDz5Q==",
+			"license": "MIT",
+			"dependencies": {
+				"run-applescript": "^7.0.0"
+			},
+			"engines": {
+				"node": ">=18"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/bytes": {
+			"version": "3.1.2",
+			"resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.2.tgz",
+			"integrity": "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==",
+			"license": "MIT",
+			"engines": {
+				"node": ">= 0.8"
+			}
+		},
+		"node_modules/cac": {
+			"version": "6.7.14",
+			"resolved": "https://registry.npmjs.org/cac/-/cac-6.7.14.tgz",
+			"integrity": "sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/call-bind-apply-helpers": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+			"integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+			"license": "MIT",
+			"dependencies": {
+				"es-errors": "^1.3.0",
+				"function-bind": "^1.1.2"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			}
+		},
+		"node_modules/call-bound": {
+			"version": "1.0.4",
+			"resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.4.tgz",
+			"integrity": "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==",
+			"license": "MIT",
+			"dependencies": {
+				"call-bind-apply-helpers": "^1.0.2",
+				"get-intrinsic": "^1.3.0"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/chai": {
+			"version": "5.3.3",
+			"resolved": "https://registry.npmjs.org/chai/-/chai-5.3.3.tgz",
+			"integrity": "sha512-4zNhdJD/iOjSH0A05ea+Ke6MU5mmpQcbQsSOkgdaUMJ9zTlDTD/GYlwohmIE2u0gaxHYiVHEn1Fw9mZ/ktJWgw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"assertion-error": "^2.0.1",
+				"check-error": "^2.1.1",
+				"deep-eql": "^5.0.1",
+				"loupe": "^3.1.0",
+				"pathval": "^2.0.0"
+			},
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/chalk": {
+			"version": "5.6.2",
+			"resolved": "https://registry.npmjs.org/chalk/-/chalk-5.6.2.tgz",
+			"integrity": "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA==",
+			"license": "MIT",
+			"engines": {
+				"node": "^12.17.0 || ^14.13 || >=16.0.0"
+			},
+			"funding": {
+				"url": "https://github.com/chalk/chalk?sponsor=1"
+			}
+		},
+		"node_modules/check-error": {
+			"version": "2.1.3",
+			"resolved": "https://registry.npmjs.org/check-error/-/check-error-2.1.3.tgz",
+			"integrity": "sha512-PAJdDJusoxnwm1VwW07VWwUN1sl7smmC3OKggvndJFadxxDRyFJBX/ggnu/KE4kQAB7a3Dp8f/YXC1FlUprWmA==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">= 16"
+			}
+		},
+		"node_modules/cli-highlight": {
+			"version": "2.1.11",
+			"resolved": "https://registry.npmjs.org/cli-highlight/-/cli-highlight-2.1.11.tgz",
+			"integrity": "sha512-9KDcoEVwyUXrjcJNvHD0NFc/hiwe/WPVYIleQh2O1N2Zro5gWJZ/K+3DGn8w8P/F6FxOgzyC5bxDyHIgCSPhGg==",
+			"license": "ISC",
+			"dependencies": {
+				"chalk": "^4.0.0",
+				"highlight.js": "^10.7.1",
+				"mz": "^2.4.0",
+				"parse5": "^5.1.1",
+				"parse5-htmlparser2-tree-adapter": "^6.0.0",
+				"yargs": "^16.0.0"
+			},
+			"bin": {
+				"highlight": "bin/highlight"
+			},
+			"engines": {
+				"node": ">=8.0.0",
+				"npm": ">=5.0.0"
+			}
+		},
+		"node_modules/cli-highlight/node_modules/chalk": {
+			"version": "4.1.2",
+			"resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+			"integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+			"license": "MIT",
+			"dependencies": {
+				"ansi-styles": "^4.1.0",
+				"supports-color": "^7.1.0"
+			},
+			"engines": {
+				"node": ">=10"
+			},
+			"funding": {
+				"url": "https://github.com/chalk/chalk?sponsor=1"
+			}
+		},
+		"node_modules/cliui": {
+			"version": "7.0.4",
+			"resolved": "https://registry.npmjs.org/cliui/-/cliui-7.0.4.tgz",
+			"integrity": "sha512-OcRE68cOsVMXp1Yvonl/fzkQOyjLSu/8bhPDfQt0e0/Eb283TKP20Fs2MqoPsr9SwA595rRCA+QMzYc9nBP+JQ==",
+			"license": "ISC",
+			"dependencies": {
+				"string-width": "^4.2.0",
+				"strip-ansi": "^6.0.0",
+				"wrap-ansi": "^7.0.0"
+			}
+		},
+		"node_modules/cliui/node_modules/ansi-regex": {
+			"version": "5.0.1",
+			"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+			"integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/cliui/node_modules/strip-ansi": {
+			"version": "6.0.1",
+			"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+			"integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+			"license": "MIT",
+			"dependencies": {
+				"ansi-regex": "^5.0.1"
+			},
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/color-convert": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+			"integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+			"license": "MIT",
+			"dependencies": {
+				"color-name": "~1.1.4"
+			},
+			"engines": {
+				"node": ">=7.0.0"
+			}
+		},
+		"node_modules/color-name": {
+			"version": "1.1.4",
+			"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+			"integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+			"license": "MIT"
+		},
+		"node_modules/content-disposition": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-1.1.0.tgz",
+			"integrity": "sha512-5jRCH9Z/+DRP7rkvY83B+yGIGX96OYdJmzngqnw2SBSxqCFPd0w2km3s5iawpGX8krnwSGmF0FW5Nhr0Hfai3g==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=18"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/express"
+			}
+		},
+		"node_modules/content-type": {
+			"version": "1.0.5",
+			"resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.5.tgz",
+			"integrity": "sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==",
+			"license": "MIT",
+			"engines": {
+				"node": ">= 0.6"
+			}
+		},
+		"node_modules/cookie": {
+			"version": "0.7.2",
+			"resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.2.tgz",
+			"integrity": "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==",
+			"license": "MIT",
+			"engines": {
+				"node": ">= 0.6"
+			}
+		},
+		"node_modules/cookie-signature": {
+			"version": "1.2.2",
+			"resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.2.2.tgz",
+			"integrity": "sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=6.6.0"
+			}
+		},
+		"node_modules/cors": {
+			"version": "2.8.6",
+			"resolved": "https://registry.npmjs.org/cors/-/cors-2.8.6.tgz",
+			"integrity": "sha512-tJtZBBHA6vjIAaF6EnIaq6laBBP9aq/Y3ouVJjEfoHbRBcHBAHYcMh/w8LDrk2PvIMMq8gmopa5D4V8RmbrxGw==",
+			"license": "MIT",
+			"dependencies": {
+				"object-assign": "^4",
+				"vary": "^1"
+			},
+			"engines": {
+				"node": ">= 0.10"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/express"
+			}
+		},
+		"node_modules/cross-spawn": {
+			"version": "7.0.6",
+			"resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+			"integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
+			"license": "MIT",
+			"dependencies": {
+				"path-key": "^3.1.0",
+				"shebang-command": "^2.0.0",
+				"which": "^2.0.1"
+			},
+			"engines": {
+				"node": ">= 8"
+			}
+		},
+		"node_modules/data-uri-to-buffer": {
+			"version": "4.0.1",
+			"resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-4.0.1.tgz",
+			"integrity": "sha512-0R9ikRb668HB7QDxT1vkpuUBtqc53YyAwMwGeUFKRojY/NWKvdZ+9UYtRfGmhqNbRkTSVpMbmyhXipFFv2cb/A==",
+			"license": "MIT",
+			"engines": {
+				"node": ">= 12"
+			}
+		},
+		"node_modules/debug": {
+			"version": "4.4.3",
+			"resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+			"integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+			"license": "MIT",
+			"dependencies": {
+				"ms": "^2.1.3"
+			},
+			"engines": {
+				"node": ">=6.0"
+			},
+			"peerDependenciesMeta": {
+				"supports-color": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/deep-eql": {
+			"version": "5.0.2",
+			"resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-5.0.2.tgz",
+			"integrity": "sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=6"
+			}
+		},
+		"node_modules/default-browser": {
+			"version": "5.5.0",
+			"resolved": "https://registry.npmjs.org/default-browser/-/default-browser-5.5.0.tgz",
+			"integrity": "sha512-H9LMLr5zwIbSxrmvikGuI/5KGhZ8E2zH3stkMgM5LpOWDutGM2JZaj460Udnf1a+946zc7YBgrqEWwbk7zHvGw==",
+			"license": "MIT",
+			"dependencies": {
+				"bundle-name": "^4.1.0",
+				"default-browser-id": "^5.0.0"
+			},
+			"engines": {
+				"node": ">=18"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/default-browser-id": {
+			"version": "5.0.1",
+			"resolved": "https://registry.npmjs.org/default-browser-id/-/default-browser-id-5.0.1.tgz",
+			"integrity": "sha512-x1VCxdX4t+8wVfd1so/9w+vQ4vx7lKd2Qp5tDRutErwmR85OgmfX7RlLRMWafRMY7hbEiXIbudNrjOAPa/hL8Q==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=18"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/define-lazy-prop": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/define-lazy-prop/-/define-lazy-prop-3.0.0.tgz",
+			"integrity": "sha512-N+MeXYoqr3pOgn8xfyRPREN7gHakLYjhsHhWGT3fWAiL4IkAt0iDw14QiiEm2bE30c5XX5q0FtAA3CK5f9/BUg==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=12"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/degenerator": {
+			"version": "5.0.1",
+			"resolved": "https://registry.npmjs.org/degenerator/-/degenerator-5.0.1.tgz",
+			"integrity": "sha512-TllpMR/t0M5sqCXfj85i4XaAzxmS5tVA16dqvdkMwGmzI+dXLXnw3J+3Vdv7VKw+ThlTMboK6i9rnZ6Nntj5CQ==",
+			"license": "MIT",
+			"dependencies": {
+				"ast-types": "^0.13.4",
+				"escodegen": "^2.1.0",
+				"esprima": "^4.0.1"
+			},
+			"engines": {
+				"node": ">= 14"
+			}
+		},
+		"node_modules/depd": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
+			"integrity": "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==",
+			"license": "MIT",
+			"engines": {
+				"node": ">= 0.8"
+			}
+		},
+		"node_modules/diff": {
+			"version": "8.0.4",
+			"resolved": "https://registry.npmjs.org/diff/-/diff-8.0.4.tgz",
+			"integrity": "sha512-DPi0FmjiSU5EvQV0++GFDOJ9ASQUVFh5kD+OzOnYdi7n3Wpm9hWWGfB/O2blfHcMVTL5WkQXSnRiK9makhrcnw==",
+			"license": "BSD-3-Clause",
+			"engines": {
+				"node": ">=0.3.1"
+			}
+		},
+		"node_modules/dunder-proto": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
+			"integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+			"license": "MIT",
+			"dependencies": {
+				"call-bind-apply-helpers": "^1.0.1",
+				"es-errors": "^1.3.0",
+				"gopd": "^1.2.0"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			}
+		},
+		"node_modules/ecdsa-sig-formatter": {
+			"version": "1.0.11",
+			"resolved": "https://registry.npmjs.org/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.11.tgz",
+			"integrity": "sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==",
+			"license": "Apache-2.0",
+			"dependencies": {
+				"safe-buffer": "^5.0.1"
+			}
+		},
+		"node_modules/ee-first": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
+			"integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==",
+			"license": "MIT"
+		},
+		"node_modules/emoji-regex": {
+			"version": "8.0.0",
+			"resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+			"integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+			"license": "MIT"
+		},
+		"node_modules/encodeurl": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-2.0.0.tgz",
+			"integrity": "sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==",
+			"license": "MIT",
+			"engines": {
+				"node": ">= 0.8"
+			}
+		},
+		"node_modules/end-of-stream": {
+			"version": "1.4.5",
+			"resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.5.tgz",
+			"integrity": "sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==",
+			"license": "MIT",
+			"dependencies": {
+				"once": "^1.4.0"
+			}
+		},
+		"node_modules/es-define-property": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+			"integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
+			"license": "MIT",
+			"engines": {
+				"node": ">= 0.4"
+			}
+		},
+		"node_modules/es-errors": {
+			"version": "1.3.0",
+			"resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+			"integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+			"license": "MIT",
+			"engines": {
+				"node": ">= 0.4"
+			}
+		},
+		"node_modules/es-module-lexer": {
+			"version": "1.7.0",
+			"resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-1.7.0.tgz",
+			"integrity": "sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/es-object-atoms": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
+			"integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
+			"license": "MIT",
+			"dependencies": {
+				"es-errors": "^1.3.0"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			}
+		},
+		"node_modules/esbuild": {
+			"version": "0.27.7",
+			"resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.27.7.tgz",
+			"integrity": "sha512-IxpibTjyVnmrIQo5aqNpCgoACA/dTKLTlhMHihVHhdkxKyPO1uBBthumT0rdHmcsk9uMonIWS0m4FljWzILh3w==",
+			"dev": true,
+			"hasInstallScript": true,
+			"license": "MIT",
+			"bin": {
+				"esbuild": "bin/esbuild"
+			},
+			"engines": {
+				"node": ">=18"
+			},
+			"optionalDependencies": {
+				"@esbuild/aix-ppc64": "0.27.7",
+				"@esbuild/android-arm": "0.27.7",
+				"@esbuild/android-arm64": "0.27.7",
+				"@esbuild/android-x64": "0.27.7",
+				"@esbuild/darwin-arm64": "0.27.7",
+				"@esbuild/darwin-x64": "0.27.7",
+				"@esbuild/freebsd-arm64": "0.27.7",
+				"@esbuild/freebsd-x64": "0.27.7",
+				"@esbuild/linux-arm": "0.27.7",
+				"@esbuild/linux-arm64": "0.27.7",
+				"@esbuild/linux-ia32": "0.27.7",
+				"@esbuild/linux-loong64": "0.27.7",
+				"@esbuild/linux-mips64el": "0.27.7",
+				"@esbuild/linux-ppc64": "0.27.7",
+				"@esbuild/linux-riscv64": "0.27.7",
+				"@esbuild/linux-s390x": "0.27.7",
+				"@esbuild/linux-x64": "0.27.7",
+				"@esbuild/netbsd-arm64": "0.27.7",
+				"@esbuild/netbsd-x64": "0.27.7",
+				"@esbuild/openbsd-arm64": "0.27.7",
+				"@esbuild/openbsd-x64": "0.27.7",
+				"@esbuild/openharmony-arm64": "0.27.7",
+				"@esbuild/sunos-x64": "0.27.7",
+				"@esbuild/win32-arm64": "0.27.7",
+				"@esbuild/win32-ia32": "0.27.7",
+				"@esbuild/win32-x64": "0.27.7"
+			}
+		},
+		"node_modules/escalade": {
+			"version": "3.2.0",
+			"resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
+			"integrity": "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=6"
+			}
+		},
+		"node_modules/escape-html": {
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
+			"integrity": "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==",
+			"license": "MIT"
+		},
+		"node_modules/escodegen": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/escodegen/-/escodegen-2.1.0.tgz",
+			"integrity": "sha512-2NlIDTwUWJN0mRPQOdtQBzbUHvdGY2P1VXSyU83Q3xKxM7WHX2Ql8dKq782Q9TgQUNOLEzEYu9bzLNj1q88I5w==",
+			"license": "BSD-2-Clause",
+			"dependencies": {
+				"esprima": "^4.0.1",
+				"estraverse": "^5.2.0",
+				"esutils": "^2.0.2"
+			},
+			"bin": {
+				"escodegen": "bin/escodegen.js",
+				"esgenerate": "bin/esgenerate.js"
+			},
+			"engines": {
+				"node": ">=6.0"
+			},
+			"optionalDependencies": {
+				"source-map": "~0.6.1"
+			}
+		},
+		"node_modules/esprima": {
+			"version": "4.0.1",
+			"resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
+			"integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
+			"license": "BSD-2-Clause",
+			"bin": {
+				"esparse": "bin/esparse.js",
+				"esvalidate": "bin/esvalidate.js"
+			},
+			"engines": {
+				"node": ">=4"
+			}
+		},
+		"node_modules/estraverse": {
+			"version": "5.3.0",
+			"resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
+			"integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
+			"license": "BSD-2-Clause",
+			"engines": {
+				"node": ">=4.0"
+			}
+		},
+		"node_modules/estree-walker": {
+			"version": "3.0.3",
+			"resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+			"integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@types/estree": "^1.0.0"
+			}
+		},
+		"node_modules/esutils": {
+			"version": "2.0.3",
+			"resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
+			"integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==",
+			"license": "BSD-2-Clause",
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/etag": {
+			"version": "1.8.1",
+			"resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
+			"integrity": "sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==",
+			"license": "MIT",
+			"engines": {
+				"node": ">= 0.6"
+			}
+		},
+		"node_modules/eventsource": {
+			"version": "3.0.7",
+			"resolved": "https://registry.npmjs.org/eventsource/-/eventsource-3.0.7.tgz",
+			"integrity": "sha512-CRT1WTyuQoD771GW56XEZFQ/ZoSfWid1alKGDYMmkt2yl8UXrVR4pspqWNEcqKvVIzg6PAltWjxcSSPrboA4iA==",
+			"license": "MIT",
+			"dependencies": {
+				"eventsource-parser": "^3.0.1"
+			},
+			"engines": {
+				"node": ">=18.0.0"
+			}
+		},
+		"node_modules/eventsource-parser": {
+			"version": "3.0.8",
+			"resolved": "https://registry.npmjs.org/eventsource-parser/-/eventsource-parser-3.0.8.tgz",
+			"integrity": "sha512-70QWGkr4snxr0OXLRWsFLeRBIRPuQOvt4s8QYjmUlmlkyTZkRqS7EDVRZtzU3TiyDbXSzaOeF0XUKy8PchzukQ==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=18.0.0"
+			}
+		},
+		"node_modules/expect-type": {
+			"version": "1.3.0",
+			"resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.3.0.tgz",
+			"integrity": "sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"engines": {
+				"node": ">=12.0.0"
+			}
+		},
+		"node_modules/express": {
+			"version": "5.2.1",
+			"resolved": "https://registry.npmjs.org/express/-/express-5.2.1.tgz",
+			"integrity": "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==",
+			"license": "MIT",
+			"dependencies": {
+				"accepts": "^2.0.0",
+				"body-parser": "^2.2.1",
+				"content-disposition": "^1.0.0",
+				"content-type": "^1.0.5",
+				"cookie": "^0.7.1",
+				"cookie-signature": "^1.2.1",
+				"debug": "^4.4.0",
+				"depd": "^2.0.0",
+				"encodeurl": "^2.0.0",
+				"escape-html": "^1.0.3",
+				"etag": "^1.8.1",
+				"finalhandler": "^2.1.0",
+				"fresh": "^2.0.0",
+				"http-errors": "^2.0.0",
+				"merge-descriptors": "^2.0.0",
+				"mime-types": "^3.0.0",
+				"on-finished": "^2.4.1",
+				"once": "^1.4.0",
+				"parseurl": "^1.3.3",
+				"proxy-addr": "^2.0.7",
+				"qs": "^6.14.0",
+				"range-parser": "^1.2.1",
+				"router": "^2.2.0",
+				"send": "^1.1.0",
+				"serve-static": "^2.2.0",
+				"statuses": "^2.0.1",
+				"type-is": "^2.0.1",
+				"vary": "^1.1.2"
+			},
+			"engines": {
+				"node": ">= 18"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/express"
+			}
+		},
+		"node_modules/express-rate-limit": {
+			"version": "8.4.1",
+			"resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.4.1.tgz",
+			"integrity": "sha512-NGVYwQSAyEQgzxX1iCM978PP9AdO/hW93gMcF6ZwQCm+rFvLsBH6w4xcXWTcliS8La5EPRN3p9wzItqBwJrfNw==",
+			"license": "MIT",
+			"dependencies": {
+				"ip-address": "10.1.0"
+			},
+			"engines": {
+				"node": ">= 16"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/express-rate-limit"
+			},
+			"peerDependencies": {
+				"express": ">= 4.11"
+			}
+		},
+		"node_modules/extend": {
+			"version": "3.0.2",
+			"resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
+			"integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==",
+			"license": "MIT"
+		},
+		"node_modules/extract-zip": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/extract-zip/-/extract-zip-2.0.1.tgz",
+			"integrity": "sha512-GDhU9ntwuKyGXdZBUgTIe+vXnWj0fppUEtMDL0+idd5Sta8TGpHssn/eusA9mrPr9qNDym6SxAYZjNvCn/9RBg==",
+			"license": "BSD-2-Clause",
+			"dependencies": {
+				"debug": "^4.1.1",
+				"get-stream": "^5.1.0",
+				"yauzl": "^2.10.0"
+			},
+			"bin": {
+				"extract-zip": "cli.js"
+			},
+			"engines": {
+				"node": ">= 10.17.0"
+			},
+			"optionalDependencies": {
+				"@types/yauzl": "^2.9.1"
+			}
+		},
+		"node_modules/fast-deep-equal": {
+			"version": "3.1.3",
+			"resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+			"integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+			"license": "MIT"
+		},
+		"node_modules/fast-string-truncated-width": {
+			"version": "1.2.1",
+			"resolved": "https://registry.npmjs.org/fast-string-truncated-width/-/fast-string-truncated-width-1.2.1.tgz",
+			"integrity": "sha512-Q9acT/+Uu3GwGj+5w/zsGuQjh9O1TyywhIwAxHudtWrgF09nHOPrvTLhQevPbttcxjr/SNN7mJmfOw/B1bXgow==",
+			"license": "MIT"
+		},
+		"node_modules/fast-string-width": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/fast-string-width/-/fast-string-width-1.1.0.tgz",
+			"integrity": "sha512-O3fwIVIH5gKB38QNbdg+3760ZmGz0SZMgvwJbA1b2TGXceKE6A2cOlfogh1iw8lr049zPyd7YADHy+B7U4W9bQ==",
+			"license": "MIT",
+			"dependencies": {
+				"fast-string-truncated-width": "^1.2.0"
+			}
+		},
+		"node_modules/fast-uri": {
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.0.tgz",
+			"integrity": "sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==",
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/fastify"
+				},
+				{
+					"type": "opencollective",
+					"url": "https://opencollective.com/fastify"
+				}
+			],
+			"license": "BSD-3-Clause"
+		},
+		"node_modules/fast-wrap-ansi": {
+			"version": "0.1.6",
+			"resolved": "https://registry.npmjs.org/fast-wrap-ansi/-/fast-wrap-ansi-0.1.6.tgz",
+			"integrity": "sha512-HlUwET7a5gqjURj70D5jl7aC3Zmy4weA1SHUfM0JFI0Ptq987NH2TwbBFLoERhfwk+E+eaq4EK3jXoT+R3yp3w==",
+			"license": "MIT",
+			"dependencies": {
+				"fast-string-width": "^1.1.0"
+			}
+		},
+		"node_modules/fast-xml-builder": {
+			"version": "1.1.5",
+			"resolved": "https://registry.npmjs.org/fast-xml-builder/-/fast-xml-builder-1.1.5.tgz",
+			"integrity": "sha512-4TJn/8FKLeslLAH3dnohXqE3QSoxkhvaMzepOIZytwJXZO69Bfz0HBdDHzOTOon6G59Zrk6VQ2bEiv1t61rfkA==",
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/NaturalIntelligence"
+				}
+			],
+			"license": "MIT",
+			"dependencies": {
+				"path-expression-matcher": "^1.1.3"
+			}
+		},
+		"node_modules/fast-xml-parser": {
+			"version": "5.7.2",
+			"resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.7.2.tgz",
+			"integrity": "sha512-P7oW7tLbYnhOLQk/Gv7cZgzgMPP/XN03K02/Jy6Y/NHzyIAIpxuZIM/YqAkfiXFPxA2CTm7NtCijK9EDu09u2w==",
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/NaturalIntelligence"
+				}
+			],
+			"license": "MIT",
+			"dependencies": {
+				"@nodable/entities": "^2.1.0",
+				"fast-xml-builder": "^1.1.5",
+				"path-expression-matcher": "^1.5.0",
+				"strnum": "^2.2.3"
+			},
+			"bin": {
+				"fxparser": "src/cli/cli.js"
+			}
+		},
+		"node_modules/fd-slicer": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/fd-slicer/-/fd-slicer-1.1.0.tgz",
+			"integrity": "sha512-cE1qsB/VwyQozZ+q1dGxR8LBYNZeofhEdUNGSMbQD3Gw2lAzX9Zb3uIU6Ebc/Fmyjo9AWWfnn0AUCHqtevs/8g==",
+			"license": "MIT",
+			"dependencies": {
+				"pend": "~1.2.0"
+			}
+		},
+		"node_modules/fetch-blob": {
+			"version": "3.2.0",
+			"resolved": "https://registry.npmjs.org/fetch-blob/-/fetch-blob-3.2.0.tgz",
+			"integrity": "sha512-7yAQpD2UMJzLi1Dqv7qFYnPbaPx7ZfFK6PiIxQ4PfkGPyNyl2Ugx+a/umUonmKqjhM4DnfbMvdX6otXq83soQQ==",
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/jimmywarting"
+				},
+				{
+					"type": "paypal",
+					"url": "https://paypal.me/jimmywarting"
+				}
+			],
+			"license": "MIT",
+			"dependencies": {
+				"node-domexception": "^1.0.0",
+				"web-streams-polyfill": "^3.0.3"
+			},
+			"engines": {
+				"node": "^12.20 || >= 14.13"
+			}
+		},
+		"node_modules/file-type": {
+			"version": "21.3.4",
+			"resolved": "https://registry.npmjs.org/file-type/-/file-type-21.3.4.tgz",
+			"integrity": "sha512-Ievi/yy8DS3ygGvT47PjSfdFoX+2isQueoYP1cntFW1JLYAuS4GD7NUPGg4zv2iZfV52uDyk5w5Z0TdpRS6Q1g==",
+			"license": "MIT",
+			"dependencies": {
+				"@tokenizer/inflate": "^0.4.1",
+				"strtok3": "^10.3.4",
+				"token-types": "^6.1.1",
+				"uint8array-extras": "^1.4.0"
+			},
+			"engines": {
+				"node": ">=20"
+			},
+			"funding": {
+				"url": "https://github.com/sindresorhus/file-type?sponsor=1"
+			}
+		},
+		"node_modules/fill-range": {
+			"version": "7.1.1",
+			"resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
+			"integrity": "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==",
+			"license": "MIT",
+			"dependencies": {
+				"to-regex-range": "^5.0.1"
+			},
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/finalhandler": {
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-2.1.1.tgz",
+			"integrity": "sha512-S8KoZgRZN+a5rNwqTxlZZePjT/4cnm0ROV70LedRHZ0p8u9fRID0hJUZQpkKLzro8LfmC8sx23bY6tVNxv8pQA==",
+			"license": "MIT",
+			"dependencies": {
+				"debug": "^4.4.0",
+				"encodeurl": "^2.0.0",
+				"escape-html": "^1.0.3",
+				"on-finished": "^2.4.1",
+				"parseurl": "^1.3.3",
+				"statuses": "^2.0.1"
+			},
+			"engines": {
+				"node": ">= 18.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/express"
+			}
+		},
+		"node_modules/formdata-polyfill": {
+			"version": "4.0.10",
+			"resolved": "https://registry.npmjs.org/formdata-polyfill/-/formdata-polyfill-4.0.10.tgz",
+			"integrity": "sha512-buewHzMvYL29jdeQTVILecSaZKnt/RJWjoZCF5OW60Z67/GmSLBkOFM7qh1PI3zFNtJbaZL5eQu1vLfazOwj4g==",
+			"license": "MIT",
+			"dependencies": {
+				"fetch-blob": "^3.1.2"
+			},
+			"engines": {
+				"node": ">=12.20.0"
+			}
+		},
+		"node_modules/forwarded": {
+			"version": "0.2.0",
+			"resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.2.0.tgz",
+			"integrity": "sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==",
+			"license": "MIT",
+			"engines": {
+				"node": ">= 0.6"
+			}
+		},
+		"node_modules/fresh": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/fresh/-/fresh-2.0.0.tgz",
+			"integrity": "sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A==",
+			"license": "MIT",
+			"engines": {
+				"node": ">= 0.8"
+			}
+		},
+		"node_modules/fsevents": {
+			"version": "2.3.2",
+			"resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+			"integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+			"dev": true,
+			"hasInstallScript": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"darwin"
+			],
+			"engines": {
+				"node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+			}
+		},
+		"node_modules/function-bind": {
+			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+			"integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+			"license": "MIT",
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/gaxios": {
+			"version": "7.1.4",
+			"resolved": "https://registry.npmjs.org/gaxios/-/gaxios-7.1.4.tgz",
+			"integrity": "sha512-bTIgTsM2bWn3XklZISBTQX7ZSddGW+IO3bMdGaemHZ3tbqExMENHLx6kKZ/KlejgrMtj8q7wBItt51yegqalrA==",
+			"license": "Apache-2.0",
+			"dependencies": {
+				"extend": "^3.0.2",
+				"https-proxy-agent": "^7.0.1",
+				"node-fetch": "^3.3.2"
+			},
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/gcp-metadata": {
+			"version": "8.1.2",
+			"resolved": "https://registry.npmjs.org/gcp-metadata/-/gcp-metadata-8.1.2.tgz",
+			"integrity": "sha512-zV/5HKTfCeKWnxG0Dmrw51hEWFGfcF2xiXqcA3+J90WDuP0SvoiSO5ORvcBsifmx/FoIjgQN3oNOGaQ5PhLFkg==",
+			"license": "Apache-2.0",
+			"dependencies": {
+				"gaxios": "^7.0.0",
+				"google-logging-utils": "^1.0.0",
+				"json-bigint": "^1.0.0"
+			},
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/get-caller-file": {
+			"version": "2.0.5",
+			"resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
+			"integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
+			"license": "ISC",
+			"engines": {
+				"node": "6.* || 8.* || >= 10.*"
+			}
+		},
+		"node_modules/get-east-asian-width": {
+			"version": "1.5.0",
+			"resolved": "https://registry.npmjs.org/get-east-asian-width/-/get-east-asian-width-1.5.0.tgz",
+			"integrity": "sha512-CQ+bEO+Tva/qlmw24dCejulK5pMzVnUOFOijVogd3KQs07HnRIgp8TGipvCCRT06xeYEbpbgwaCxglFyiuIcmA==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=18"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/get-intrinsic": {
+			"version": "1.3.0",
+			"resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+			"integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
+			"license": "MIT",
+			"dependencies": {
+				"call-bind-apply-helpers": "^1.0.2",
+				"es-define-property": "^1.0.1",
+				"es-errors": "^1.3.0",
+				"es-object-atoms": "^1.1.1",
+				"function-bind": "^1.1.2",
+				"get-proto": "^1.0.1",
+				"gopd": "^1.2.0",
+				"has-symbols": "^1.1.0",
+				"hasown": "^2.0.2",
+				"math-intrinsics": "^1.1.0"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/get-proto": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
+			"integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+			"license": "MIT",
+			"dependencies": {
+				"dunder-proto": "^1.0.1",
+				"es-object-atoms": "^1.0.0"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			}
+		},
+		"node_modules/get-stream": {
+			"version": "5.2.0",
+			"resolved": "https://registry.npmjs.org/get-stream/-/get-stream-5.2.0.tgz",
+			"integrity": "sha512-nBF+F1rAZVCu/p7rjzgA+Yb4lfYXrpl7a6VmJrU8wF9I1CKvP/QwPNZHnOlwbTkY6dvtFIzFMSyQXbLoTQPRpA==",
+			"license": "MIT",
+			"dependencies": {
+				"pump": "^3.0.0"
+			},
+			"engines": {
+				"node": ">=8"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/get-tsconfig": {
+			"version": "4.14.0",
+			"resolved": "https://registry.npmjs.org/get-tsconfig/-/get-tsconfig-4.14.0.tgz",
+			"integrity": "sha512-yTb+8DXzDREzgvYmh6s9vHsSVCHeC0G3PI5bEXNBHtmshPnO+S5O7qgLEOn0I5QvMy6kpZN8K1NKGyilLb93wA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"resolve-pkg-maps": "^1.0.0"
+			},
+			"funding": {
+				"url": "https://github.com/privatenumber/get-tsconfig?sponsor=1"
+			}
+		},
+		"node_modules/get-uri": {
+			"version": "6.0.5",
+			"resolved": "https://registry.npmjs.org/get-uri/-/get-uri-6.0.5.tgz",
+			"integrity": "sha512-b1O07XYq8eRuVzBNgJLstU6FYc1tS6wnMtF1I1D9lE8LxZSOGZ7LhxN54yPP6mGw5f2CkXY2BQUL9Fx41qvcIg==",
+			"license": "MIT",
+			"dependencies": {
+				"basic-ftp": "^5.0.2",
+				"data-uri-to-buffer": "^6.0.2",
+				"debug": "^4.3.4"
+			},
+			"engines": {
+				"node": ">= 14"
+			}
+		},
+		"node_modules/get-uri/node_modules/data-uri-to-buffer": {
+			"version": "6.0.2",
+			"resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-6.0.2.tgz",
+			"integrity": "sha512-7hvf7/GW8e86rW0ptuwS3OcBGDjIi6SZva7hCyWC0yYry2cOPmLIjXAUHI6DK2HsnwJd9ifmt57i8eV2n4YNpw==",
+			"license": "MIT",
+			"engines": {
+				"node": ">= 14"
+			}
+		},
+		"node_modules/glob": {
+			"version": "13.0.6",
+			"resolved": "https://registry.npmjs.org/glob/-/glob-13.0.6.tgz",
+			"integrity": "sha512-Wjlyrolmm8uDpm/ogGyXZXb1Z+Ca2B8NbJwqBVg0axK9GbBeoS7yGV6vjXnYdGm6X53iehEuxxbyiKp8QmN4Vw==",
+			"license": "BlueOak-1.0.0",
+			"dependencies": {
+				"minimatch": "^10.2.2",
+				"minipass": "^7.1.3",
+				"path-scurry": "^2.0.2"
+			},
+			"engines": {
+				"node": "18 || 20 || >=22"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/isaacs"
+			}
+		},
+		"node_modules/google-auth-library": {
+			"version": "10.6.2",
+			"resolved": "https://registry.npmjs.org/google-auth-library/-/google-auth-library-10.6.2.tgz",
+			"integrity": "sha512-e27Z6EThmVNNvtYASwQxose/G57rkRuaRbQyxM2bvYLLX/GqWZ5chWq2EBoUchJbCc57eC9ArzO5wMsEmWftCw==",
+			"license": "Apache-2.0",
+			"dependencies": {
+				"base64-js": "^1.3.0",
+				"ecdsa-sig-formatter": "^1.0.11",
+				"gaxios": "^7.1.4",
+				"gcp-metadata": "8.1.2",
+				"google-logging-utils": "1.1.3",
+				"jws": "^4.0.0"
+			},
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/google-logging-utils": {
+			"version": "1.1.3",
+			"resolved": "https://registry.npmjs.org/google-logging-utils/-/google-logging-utils-1.1.3.tgz",
+			"integrity": "sha512-eAmLkjDjAFCVXg7A1unxHsLf961m6y17QFqXqAXGj/gVkKFrEICfStRfwUlGNfeCEjNRa32JEWOUTlYXPyyKvA==",
+			"license": "Apache-2.0",
+			"engines": {
+				"node": ">=14"
+			}
+		},
+		"node_modules/gopd": {
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
+			"integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+			"license": "MIT",
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/graceful-fs": {
+			"version": "4.2.11",
+			"resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
+			"integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
+			"license": "ISC"
+		},
+		"node_modules/has-flag": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+			"integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/has-symbols": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
+			"integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
+			"license": "MIT",
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/hasown": {
+			"version": "2.0.3",
+			"resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.3.tgz",
+			"integrity": "sha512-ej4AhfhfL2Q2zpMmLo7U1Uv9+PyhIZpgQLGT1F9miIGmiCJIoCgSmczFdrc97mWT4kVY72KA+WnnhJ5pghSvSg==",
+			"license": "MIT",
+			"dependencies": {
+				"function-bind": "^1.1.2"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			}
+		},
+		"node_modules/highlight.js": {
+			"version": "10.7.3",
+			"resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-10.7.3.tgz",
+			"integrity": "sha512-tzcUFauisWKNHaRkN4Wjl/ZA07gENAjFl3J/c480dprkGTg5EQstgaNFqBfUqCq54kZRIEcreTsAgF/m2quD7A==",
+			"license": "BSD-3-Clause",
+			"engines": {
+				"node": "*"
+			}
+		},
+		"node_modules/hono": {
+			"version": "4.12.15",
+			"resolved": "https://registry.npmjs.org/hono/-/hono-4.12.15.tgz",
+			"integrity": "sha512-qM0jDhFEaCBb4TxoW7f53Qrpv9RBiayUHo0S52JudprkhvpjIrGoU1mnnr29Fvd1U335ZFPZQY1wlkqgfGXyLg==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=16.9.0"
+			}
+		},
+		"node_modules/hosted-git-info": {
+			"version": "9.0.2",
+			"resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-9.0.2.tgz",
+			"integrity": "sha512-M422h7o/BR3rmCQ8UHi7cyyMqKltdP9Uo+J2fXK+RSAY+wTcKOIRyhTuKv4qn+DJf3g+PL890AzId5KZpX+CBg==",
+			"license": "ISC",
+			"dependencies": {
+				"lru-cache": "^11.1.0"
+			},
+			"engines": {
+				"node": "^20.17.0 || >=22.9.0"
+			}
+		},
+		"node_modules/http-errors": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.1.tgz",
+			"integrity": "sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==",
+			"license": "MIT",
+			"dependencies": {
+				"depd": "~2.0.0",
+				"inherits": "~2.0.4",
+				"setprototypeof": "~1.2.0",
+				"statuses": "~2.0.2",
+				"toidentifier": "~1.0.1"
+			},
+			"engines": {
+				"node": ">= 0.8"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/express"
+			}
+		},
+		"node_modules/http-proxy-agent": {
+			"version": "7.0.2",
+			"resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-7.0.2.tgz",
+			"integrity": "sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==",
+			"license": "MIT",
+			"dependencies": {
+				"agent-base": "^7.1.0",
+				"debug": "^4.3.4"
+			},
+			"engines": {
+				"node": ">= 14"
+			}
+		},
+		"node_modules/https-proxy-agent": {
+			"version": "7.0.6",
+			"resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
+			"integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
+			"license": "MIT",
+			"dependencies": {
+				"agent-base": "^7.1.2",
+				"debug": "4"
+			},
+			"engines": {
+				"node": ">= 14"
+			}
+		},
+		"node_modules/iconv-lite": {
+			"version": "0.7.2",
+			"resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.2.tgz",
+			"integrity": "sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw==",
+			"license": "MIT",
+			"dependencies": {
+				"safer-buffer": ">= 2.1.2 < 3.0.0"
+			},
+			"engines": {
+				"node": ">=0.10.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/express"
+			}
+		},
+		"node_modules/ieee754": {
+			"version": "1.2.1",
+			"resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
+			"integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/feross"
+				},
+				{
+					"type": "patreon",
+					"url": "https://www.patreon.com/feross"
+				},
+				{
+					"type": "consulting",
+					"url": "https://feross.org/support"
+				}
+			],
+			"license": "BSD-3-Clause"
+		},
+		"node_modules/ignore": {
+			"version": "7.0.5",
+			"resolved": "https://registry.npmjs.org/ignore/-/ignore-7.0.5.tgz",
+			"integrity": "sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg==",
+			"license": "MIT",
+			"engines": {
+				"node": ">= 4"
+			}
+		},
+		"node_modules/inherits": {
+			"version": "2.0.4",
+			"resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+			"integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+			"license": "ISC"
+		},
+		"node_modules/ip-address": {
+			"version": "10.1.0",
+			"resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.1.0.tgz",
+			"integrity": "sha512-XXADHxXmvT9+CRxhXg56LJovE+bmWnEWB78LB83VZTprKTmaC5QfruXocxzTZ2Kl0DNwKuBdlIhjL8LeY8Sf8Q==",
+			"license": "MIT",
+			"engines": {
+				"node": ">= 12"
+			}
+		},
+		"node_modules/ipaddr.js": {
+			"version": "1.9.1",
+			"resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
+			"integrity": "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==",
+			"license": "MIT",
+			"engines": {
+				"node": ">= 0.10"
+			}
+		},
+		"node_modules/is-docker": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/is-docker/-/is-docker-3.0.0.tgz",
+			"integrity": "sha512-eljcgEDlEns/7AXFosB5K/2nCM4P7FQPkGc/DWLy5rmFEWvZayGrik1d9/QIY5nJ4f9YsVvBkA6kJpHn9rISdQ==",
+			"license": "MIT",
+			"bin": {
+				"is-docker": "cli.js"
+			},
+			"engines": {
+				"node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/is-fullwidth-code-point": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+			"integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/is-inside-container": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/is-inside-container/-/is-inside-container-1.0.0.tgz",
+			"integrity": "sha512-KIYLCCJghfHZxqjYBE7rEy0OBuTd5xCHS7tHVgvCLkx7StIoaxwNW3hCALgEUjFfeRk+MG/Qxmp/vtETEF3tRA==",
+			"license": "MIT",
+			"dependencies": {
+				"is-docker": "^3.0.0"
+			},
+			"bin": {
+				"is-inside-container": "cli.js"
+			},
+			"engines": {
+				"node": ">=14.16"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/is-number": {
+			"version": "7.0.0",
+			"resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
+			"integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=0.12.0"
+			}
+		},
+		"node_modules/is-promise": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/is-promise/-/is-promise-4.0.0.tgz",
+			"integrity": "sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==",
+			"license": "MIT"
+		},
+		"node_modules/is-wsl": {
+			"version": "3.1.1",
+			"resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-3.1.1.tgz",
+			"integrity": "sha512-e6rvdUCiQCAuumZslxRJWR/Doq4VpPR82kqclvcS0efgt430SlGIk05vdCN58+VrzgtIcfNODjozVielycD4Sw==",
+			"license": "MIT",
+			"dependencies": {
+				"is-inside-container": "^1.0.0"
+			},
+			"engines": {
+				"node": ">=16"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/isexe": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+			"integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+			"license": "ISC"
+		},
+		"node_modules/jose": {
+			"version": "6.2.3",
+			"resolved": "https://registry.npmjs.org/jose/-/jose-6.2.3.tgz",
+			"integrity": "sha512-YYVDInQKFJfR/xa3ojUTl8c2KoTwiL1R5Wg9YCydwH0x0B9grbzlg5HC7mMjCtUJjbQ/YnGEZIhI5tCgfTb4Hw==",
+			"license": "MIT",
+			"funding": {
+				"url": "https://github.com/sponsors/panva"
+			}
+		},
+		"node_modules/js-tokens": {
+			"version": "9.0.1",
+			"resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-9.0.1.tgz",
+			"integrity": "sha512-mxa9E9ITFOt0ban3j6L5MpjwegGz6lBQmM1IJkWeBZGcMxto50+eWdjC/52xDbS2vy0k7vIMK0Fe2wfL9OQSpQ==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/json-bigint": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/json-bigint/-/json-bigint-1.0.0.tgz",
+			"integrity": "sha512-SiPv/8VpZuWbvLSMtTDU8hEfrZWg/mH/nV/b4o0CYbSxu1UIQPLdwKOCIyLQX+VIPO5vrLX3i8qtqFyhdPSUSQ==",
+			"license": "MIT",
+			"dependencies": {
+				"bignumber.js": "^9.0.0"
+			}
+		},
+		"node_modules/json-schema-to-ts": {
+			"version": "3.1.1",
+			"resolved": "https://registry.npmjs.org/json-schema-to-ts/-/json-schema-to-ts-3.1.1.tgz",
+			"integrity": "sha512-+DWg8jCJG2TEnpy7kOm/7/AxaYoaRbjVB4LFZLySZlWn8exGs3A4OLJR966cVvU26N7X9TWxl+Jsw7dzAqKT6g==",
+			"license": "MIT",
+			"dependencies": {
+				"@babel/runtime": "^7.18.3",
+				"ts-algebra": "^2.0.0"
+			},
+			"engines": {
+				"node": ">=16"
+			}
+		},
+		"node_modules/json-schema-traverse": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+			"integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+			"license": "MIT"
+		},
+		"node_modules/json-schema-typed": {
+			"version": "8.0.2",
+			"resolved": "https://registry.npmjs.org/json-schema-typed/-/json-schema-typed-8.0.2.tgz",
+			"integrity": "sha512-fQhoXdcvc3V28x7C7BMs4P5+kNlgUURe2jmUT1T//oBRMDrqy1QPelJimwZGo7Hg9VPV3EQV5Bnq4hbFy2vetA==",
+			"license": "BSD-2-Clause"
+		},
+		"node_modules/jwa": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/jwa/-/jwa-2.0.1.tgz",
+			"integrity": "sha512-hRF04fqJIP8Abbkq5NKGN0Bbr3JxlQ+qhZufXVr0DvujKy93ZCbXZMHDL4EOtodSbCWxOqR8MS1tXA5hwqCXDg==",
+			"license": "MIT",
+			"dependencies": {
+				"buffer-equal-constant-time": "^1.0.1",
+				"ecdsa-sig-formatter": "1.0.11",
+				"safe-buffer": "^5.0.1"
+			}
+		},
+		"node_modules/jws": {
+			"version": "4.0.1",
+			"resolved": "https://registry.npmjs.org/jws/-/jws-4.0.1.tgz",
+			"integrity": "sha512-EKI/M/yqPncGUUh44xz0PxSidXFr/+r0pA70+gIYhjv+et7yxM+s29Y+VGDkovRofQem0fs7Uvf4+YmAdyRduA==",
+			"license": "MIT",
+			"dependencies": {
+				"jwa": "^2.0.1",
+				"safe-buffer": "^5.0.1"
+			}
+		},
+		"node_modules/koffi": {
+			"version": "2.16.1",
+			"resolved": "https://registry.npmjs.org/koffi/-/koffi-2.16.1.tgz",
+			"integrity": "sha512-0Ie6CfD026dNfWSosDw9dPxPzO9Rlyo0N8m5r05S8YjytIpuilzMFDMY4IDy/8xQsTwpuVinhncD+S8n3bcYZQ==",
+			"hasInstallScript": true,
+			"license": "MIT",
+			"optional": true,
+			"funding": {
+				"url": "https://liberapay.com/Koromix"
+			}
+		},
+		"node_modules/long": {
+			"version": "5.3.2",
+			"resolved": "https://registry.npmjs.org/long/-/long-5.3.2.tgz",
+			"integrity": "sha512-mNAgZ1GmyNhD7AuqnTG3/VQ26o760+ZYBPKjPvugO8+nLbYfX6TVpJPseBvopbdY+qpZ/lKUnmEc1LeZYS3QAA==",
+			"license": "Apache-2.0"
+		},
+		"node_modules/loupe": {
+			"version": "3.2.1",
+			"resolved": "https://registry.npmjs.org/loupe/-/loupe-3.2.1.tgz",
+			"integrity": "sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/lru-cache": {
+			"version": "11.3.5",
+			"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.3.5.tgz",
+			"integrity": "sha512-NxVFwLAnrd9i7KUBxC4DrUhmgjzOs+1Qm50D3oF1/oL+r1NpZ4gA7xvG0/zJ8evR7zIKn4vLf7qTNduWFtCrRw==",
+			"license": "BlueOak-1.0.0",
+			"engines": {
+				"node": "20 || >=22"
+			}
+		},
+		"node_modules/magic-string": {
+			"version": "0.30.21",
+			"resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+			"integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@jridgewell/sourcemap-codec": "^1.5.5"
+			}
+		},
+		"node_modules/marked": {
+			"version": "15.0.12",
+			"resolved": "https://registry.npmjs.org/marked/-/marked-15.0.12.tgz",
+			"integrity": "sha512-8dD6FusOQSrpv9Z1rdNMdlSgQOIP880DHqnohobOmYLElGEqAL/JvxvuxZO16r4HtjTlfPRDC1hbvxC9dPN2nA==",
+			"license": "MIT",
+			"bin": {
+				"marked": "bin/marked.js"
+			},
+			"engines": {
+				"node": ">= 18"
+			}
+		},
+		"node_modules/math-intrinsics": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+			"integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+			"license": "MIT",
+			"engines": {
+				"node": ">= 0.4"
+			}
+		},
+		"node_modules/media-typer": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/media-typer/-/media-typer-1.1.0.tgz",
+			"integrity": "sha512-aisnrDP4GNe06UcKFnV5bfMNPBUw4jsLGaWwWfnH3v02GnBuXX2MCVn5RbrWo0j3pczUilYblq7fQ7Nw2t5XKw==",
+			"license": "MIT",
+			"engines": {
+				"node": ">= 0.8"
+			}
+		},
+		"node_modules/merge-descriptors": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-2.0.0.tgz",
+			"integrity": "sha512-Snk314V5ayFLhp3fkUREub6WtjBfPdCPY1Ln8/8munuLuiYhsABgBVWsozAG+MWMbVEvcdcpbi9R7ww22l9Q3g==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=18"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/micromatch": {
+			"version": "4.0.8",
+			"resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.8.tgz",
+			"integrity": "sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==",
+			"license": "MIT",
+			"dependencies": {
+				"braces": "^3.0.3",
+				"picomatch": "^2.3.1"
+			},
+			"engines": {
+				"node": ">=8.6"
+			}
+		},
+		"node_modules/mime-db": {
+			"version": "1.54.0",
+			"resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
+			"integrity": "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==",
+			"license": "MIT",
+			"engines": {
+				"node": ">= 0.6"
+			}
+		},
+		"node_modules/mime-types": {
+			"version": "3.0.2",
+			"resolved": "https://registry.npmjs.org/mime-types/-/mime-types-3.0.2.tgz",
+			"integrity": "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==",
+			"license": "MIT",
+			"dependencies": {
+				"mime-db": "^1.54.0"
+			},
+			"engines": {
+				"node": ">=18"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/express"
+			}
+		},
+		"node_modules/minimatch": {
+			"version": "10.2.5",
+			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz",
+			"integrity": "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==",
+			"license": "BlueOak-1.0.0",
+			"dependencies": {
+				"brace-expansion": "^5.0.5"
+			},
+			"engines": {
+				"node": "18 || 20 || >=22"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/isaacs"
+			}
+		},
+		"node_modules/minipass": {
+			"version": "7.1.3",
+			"resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.3.tgz",
+			"integrity": "sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==",
+			"license": "BlueOak-1.0.0",
+			"engines": {
+				"node": ">=16 || 14 >=14.17"
+			}
+		},
+		"node_modules/ms": {
+			"version": "2.1.3",
+			"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+			"integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+			"license": "MIT"
+		},
+		"node_modules/mz": {
+			"version": "2.7.0",
+			"resolved": "https://registry.npmjs.org/mz/-/mz-2.7.0.tgz",
+			"integrity": "sha512-z81GNO7nnYMEhrGh9LeymoE4+Yr0Wn5McHIZMK5cfQCl+NDX08sCZgUc9/6MHni9IWuFLm1Z3HTCXu2z9fN62Q==",
+			"license": "MIT",
+			"dependencies": {
+				"any-promise": "^1.0.0",
+				"object-assign": "^4.0.1",
+				"thenify-all": "^1.0.0"
+			}
+		},
+		"node_modules/nanoid": {
+			"version": "3.3.11",
+			"resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
+			"integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
+			"dev": true,
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/ai"
+				}
+			],
+			"license": "MIT",
+			"bin": {
+				"nanoid": "bin/nanoid.cjs"
+			},
+			"engines": {
+				"node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+			}
+		},
+		"node_modules/negotiator": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/negotiator/-/negotiator-1.0.0.tgz",
+			"integrity": "sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==",
+			"license": "MIT",
+			"engines": {
+				"node": ">= 0.6"
+			}
+		},
+		"node_modules/netmask": {
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/netmask/-/netmask-2.1.1.tgz",
+			"integrity": "sha512-eonl3sLUha+S1GzTPxychyhnUzKyeQkZ7jLjKrBagJgPla13F+uQ71HgpFefyHgqrjEbCPkDArxYsjY8/+gLKA==",
+			"license": "MIT",
+			"engines": {
+				"node": ">= 0.4.0"
+			}
+		},
+		"node_modules/node-addon-api": {
+			"version": "7.1.1",
+			"resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-7.1.1.tgz",
+			"integrity": "sha512-5m3bsyrjFWE1xf7nz7YXdN4udnVtXK6/Yfgn5qnahL6bCkf2yKt4k3nuTKAtT4r3IG8JNR2ncsIMdZuAzJjHQQ==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/node-domexception": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/node-domexception/-/node-domexception-1.0.0.tgz",
+			"integrity": "sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ==",
+			"deprecated": "Use your platform's native DOMException instead",
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/jimmywarting"
+				},
+				{
+					"type": "github",
+					"url": "https://paypal.me/jimmywarting"
+				}
+			],
+			"license": "MIT",
+			"engines": {
+				"node": ">=10.5.0"
+			}
+		},
+		"node_modules/node-fetch": {
+			"version": "3.3.2",
+			"resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-3.3.2.tgz",
+			"integrity": "sha512-dRB78srN/l6gqWulah9SrxeYnxeddIG30+GOqK/9OlLVyLg3HPnr6SqOWTWOXKRwC2eGYCkZ59NNuSgvSrpgOA==",
+			"license": "MIT",
+			"dependencies": {
+				"data-uri-to-buffer": "^4.0.0",
+				"fetch-blob": "^3.1.4",
+				"formdata-polyfill": "^4.0.10"
+			},
+			"engines": {
+				"node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/node-fetch"
+			}
+		},
+		"node_modules/node-pty": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/node-pty/-/node-pty-1.1.0.tgz",
+			"integrity": "sha512-20JqtutY6JPXTUnL0ij1uad7Qe1baT46lyolh2sSENDd4sTzKZ4nmAFkeAARDKwmlLjPx6XKRlwRUxwjOy+lUg==",
+			"dev": true,
+			"hasInstallScript": true,
+			"license": "MIT",
+			"dependencies": {
+				"node-addon-api": "^7.1.0"
+			}
+		},
+		"node_modules/object-assign": {
+			"version": "4.1.1",
+			"resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+			"integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/object-inspect": {
+			"version": "1.13.4",
+			"resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.4.tgz",
+			"integrity": "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==",
+			"license": "MIT",
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/on-finished": {
+			"version": "2.4.1",
+			"resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.4.1.tgz",
+			"integrity": "sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==",
+			"license": "MIT",
+			"dependencies": {
+				"ee-first": "1.1.1"
+			},
+			"engines": {
+				"node": ">= 0.8"
+			}
+		},
+		"node_modules/once": {
+			"version": "1.4.0",
+			"resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+			"integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+			"license": "ISC",
+			"dependencies": {
+				"wrappy": "1"
+			}
+		},
+		"node_modules/open": {
+			"version": "10.2.0",
+			"resolved": "https://registry.npmjs.org/open/-/open-10.2.0.tgz",
+			"integrity": "sha512-YgBpdJHPyQ2UE5x+hlSXcnejzAvD0b22U2OuAP+8OnlJT+PjWPxtgmGqKKc+RgTM63U9gN0YzrYc71R2WT/hTA==",
+			"license": "MIT",
+			"dependencies": {
+				"default-browser": "^5.2.1",
+				"define-lazy-prop": "^3.0.0",
+				"is-inside-container": "^1.0.0",
+				"wsl-utils": "^0.1.0"
+			},
+			"engines": {
+				"node": ">=18"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/openai": {
+			"version": "6.26.0",
+			"resolved": "https://registry.npmjs.org/openai/-/openai-6.26.0.tgz",
+			"integrity": "sha512-zd23dbWTjiJ6sSAX6s0HrCZi41JwTA1bQVs0wLQPZ2/5o2gxOJA5wh7yOAUgwYybfhDXyhwlpeQf7Mlgx8EOCA==",
+			"license": "Apache-2.0",
+			"bin": {
+				"openai": "bin/cli"
+			},
+			"peerDependencies": {
+				"ws": "^8.18.0",
+				"zod": "^3.25 || ^4.0"
+			},
+			"peerDependenciesMeta": {
+				"ws": {
+					"optional": true
+				},
+				"zod": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/p-retry": {
+			"version": "4.6.2",
+			"resolved": "https://registry.npmjs.org/p-retry/-/p-retry-4.6.2.tgz",
+			"integrity": "sha512-312Id396EbJdvRONlngUx0NydfrIQ5lsYu0znKVUzVvArzEIt08V1qhtyESbGVd1FGX7UKtiFp5uwKZdM8wIuQ==",
+			"license": "MIT",
+			"dependencies": {
+				"@types/retry": "0.12.0",
+				"retry": "^0.13.1"
+			},
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/pac-proxy-agent": {
+			"version": "7.2.0",
+			"resolved": "https://registry.npmjs.org/pac-proxy-agent/-/pac-proxy-agent-7.2.0.tgz",
+			"integrity": "sha512-TEB8ESquiLMc0lV8vcd5Ql/JAKAoyzHFXaStwjkzpOpC5Yv+pIzLfHvjTSdf3vpa2bMiUQrg9i6276yn8666aA==",
+			"license": "MIT",
+			"dependencies": {
+				"@tootallnate/quickjs-emscripten": "^0.23.0",
+				"agent-base": "^7.1.2",
+				"debug": "^4.3.4",
+				"get-uri": "^6.0.1",
+				"http-proxy-agent": "^7.0.0",
+				"https-proxy-agent": "^7.0.6",
+				"pac-resolver": "^7.0.1",
+				"socks-proxy-agent": "^8.0.5"
+			},
+			"engines": {
+				"node": ">= 14"
+			}
+		},
+		"node_modules/pac-resolver": {
+			"version": "7.0.1",
+			"resolved": "https://registry.npmjs.org/pac-resolver/-/pac-resolver-7.0.1.tgz",
+			"integrity": "sha512-5NPgf87AT2STgwa2ntRMr45jTKrYBGkVU36yT0ig/n/GMAa3oPqhZfIQ2kMEimReg0+t9kZViDVZ83qfVUlckg==",
+			"license": "MIT",
+			"dependencies": {
+				"degenerator": "^5.0.0",
+				"netmask": "^2.0.2"
+			},
+			"engines": {
+				"node": ">= 14"
+			}
+		},
+		"node_modules/parse5": {
+			"version": "5.1.1",
+			"resolved": "https://registry.npmjs.org/parse5/-/parse5-5.1.1.tgz",
+			"integrity": "sha512-ugq4DFI0Ptb+WWjAdOK16+u/nHfiIrcE+sh8kZMaM0WllQKLI9rOUq6c2b7cwPkXdzfQESqvoqK6ug7U/Yyzug==",
+			"license": "MIT"
+		},
+		"node_modules/parse5-htmlparser2-tree-adapter": {
+			"version": "6.0.1",
+			"resolved": "https://registry.npmjs.org/parse5-htmlparser2-tree-adapter/-/parse5-htmlparser2-tree-adapter-6.0.1.tgz",
+			"integrity": "sha512-qPuWvbLgvDGilKc5BoicRovlT4MtYT6JfJyBOMDsKoiT+GiuP5qyrPCnR9HcPECIJJmZh5jRndyNThnhhb/vlA==",
+			"license": "MIT",
+			"dependencies": {
+				"parse5": "^6.0.1"
+			}
+		},
+		"node_modules/parse5-htmlparser2-tree-adapter/node_modules/parse5": {
+			"version": "6.0.1",
+			"resolved": "https://registry.npmjs.org/parse5/-/parse5-6.0.1.tgz",
+			"integrity": "sha512-Ofn/CTFzRGTTxwpNEs9PP93gXShHcTq255nzRYSKe8AkVpZY7e1fpmTfOyoIvjP5HG7Z2ZM7VS9PPhQGW2pOpw==",
+			"license": "MIT"
+		},
+		"node_modules/parseurl": {
+			"version": "1.3.3",
+			"resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
+			"integrity": "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==",
+			"license": "MIT",
+			"engines": {
+				"node": ">= 0.8"
+			}
+		},
+		"node_modules/partial-json": {
+			"version": "0.1.7",
+			"resolved": "https://registry.npmjs.org/partial-json/-/partial-json-0.1.7.tgz",
+			"integrity": "sha512-Njv/59hHaokb/hRUjce3Hdv12wd60MtM9Z5Olmn+nehe0QDAsRtRbJPvJ0Z91TusF0SuZRIvnM+S4l6EIP8leA==",
+			"license": "MIT"
+		},
+		"node_modules/path-expression-matcher": {
+			"version": "1.5.0",
+			"resolved": "https://registry.npmjs.org/path-expression-matcher/-/path-expression-matcher-1.5.0.tgz",
+			"integrity": "sha512-cbrerZV+6rvdQrrD+iGMcZFEiiSrbv9Tfdkvnusy6y0x0GKBXREFg/Y65GhIfm0tnLntThhzCnfKwp1WRjeCyQ==",
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/NaturalIntelligence"
+				}
+			],
+			"license": "MIT",
+			"engines": {
+				"node": ">=14.0.0"
+			}
+		},
+		"node_modules/path-key": {
+			"version": "3.1.1",
+			"resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+			"integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/path-scurry": {
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-2.0.2.tgz",
+			"integrity": "sha512-3O/iVVsJAPsOnpwWIeD+d6z/7PmqApyQePUtCndjatj/9I5LylHvt5qluFaBT3I5h3r1ejfR056c+FCv+NnNXg==",
+			"license": "BlueOak-1.0.0",
+			"dependencies": {
+				"lru-cache": "^11.0.0",
+				"minipass": "^7.1.2"
+			},
+			"engines": {
+				"node": "18 || 20 || >=22"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/isaacs"
+			}
+		},
+		"node_modules/path-to-regexp": {
+			"version": "8.4.2",
+			"resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.4.2.tgz",
+			"integrity": "sha512-qRcuIdP69NPm4qbACK+aDogI5CBDMi1jKe0ry5rSQJz8JVLsC7jV8XpiJjGRLLol3N+R5ihGYcrPLTno6pAdBA==",
+			"license": "MIT",
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/express"
+			}
+		},
+		"node_modules/pathe": {
+			"version": "2.0.3",
+			"resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+			"integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/pathval": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/pathval/-/pathval-2.0.1.tgz",
+			"integrity": "sha512-//nshmD55c46FuFw26xV/xFAaB5HF9Xdap7HJBBnrKdAd6/GxDBaNA1870O79+9ueg61cZLSVc+OaFlfmObYVQ==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">= 14.16"
+			}
+		},
+		"node_modules/pend": {
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/pend/-/pend-1.2.0.tgz",
+			"integrity": "sha512-F3asv42UuXchdzt+xXqfW1OGlVBe+mxa2mqI0pg5yAHZPvFmY3Y6drSf/GQ1A86WgWEN9Kzh/WrgKa6iGcHXLg==",
+			"license": "MIT"
+		},
+		"node_modules/picocolors": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+			"integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+			"dev": true,
+			"license": "ISC"
+		},
+		"node_modules/picomatch": {
+			"version": "2.3.2",
+			"resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
+			"integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=8.6"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/jonschlinkert"
+			}
+		},
+		"node_modules/pkce-challenge": {
+			"version": "5.0.1",
+			"resolved": "https://registry.npmjs.org/pkce-challenge/-/pkce-challenge-5.0.1.tgz",
+			"integrity": "sha512-wQ0b/W4Fr01qtpHlqSqspcj3EhBvimsdh0KlHhH8HRZnMsEa0ea2fTULOXOS9ccQr3om+GcGRk4e+isrZWV8qQ==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=16.20.0"
+			}
+		},
+		"node_modules/playwright": {
+			"version": "1.59.1",
+			"resolved": "https://registry.npmjs.org/playwright/-/playwright-1.59.1.tgz",
+			"integrity": "sha512-C8oWjPR3F81yljW9o5OxcWzfh6avkVwDD2VYdwIGqTkl+OGFISgypqzfu7dOe4QNLL2aqcWBmI3PMtLIK233lw==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"playwright-core": "1.59.1"
+			},
+			"bin": {
+				"playwright": "cli.js"
+			},
+			"engines": {
+				"node": ">=18"
+			},
+			"optionalDependencies": {
+				"fsevents": "2.3.2"
+			}
+		},
+		"node_modules/playwright-core": {
+			"version": "1.59.1",
+			"resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.59.1.tgz",
+			"integrity": "sha512-HBV/RJg81z5BiiZ9yPzIiClYV/QMsDCKUyogwH9p3MCP6IYjUFu/MActgYAvK0oWyV9NlwM3GLBjADyWgydVyg==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"bin": {
+				"playwright-core": "cli.js"
+			},
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/postcss": {
+			"version": "8.5.12",
+			"resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.12.tgz",
+			"integrity": "sha512-W62t/Se6rA0Az3DfCL0AqJwXuKwBeYg6nOaIgzP+xZ7N5BFCI7DYi1qs6ygUYT6rvfi6t9k65UMLJC+PHZpDAA==",
+			"dev": true,
+			"funding": [
+				{
+					"type": "opencollective",
+					"url": "https://opencollective.com/postcss/"
+				},
+				{
+					"type": "tidelift",
+					"url": "https://tidelift.com/funding/github/npm/postcss"
+				},
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/ai"
+				}
+			],
+			"license": "MIT",
+			"dependencies": {
+				"nanoid": "^3.3.11",
+				"picocolors": "^1.1.1",
+				"source-map-js": "^1.2.1"
+			},
+			"engines": {
+				"node": "^10 || ^12 || >=14"
+			}
+		},
+		"node_modules/proper-lockfile": {
+			"version": "4.1.2",
+			"resolved": "https://registry.npmjs.org/proper-lockfile/-/proper-lockfile-4.1.2.tgz",
+			"integrity": "sha512-TjNPblN4BwAWMXU8s9AEz4JmQxnD1NNL7bNOY/AKUzyamc379FWASUhc/K1pL2noVb+XmZKLL68cjzLsiOAMaA==",
+			"license": "MIT",
+			"dependencies": {
+				"graceful-fs": "^4.2.4",
+				"retry": "^0.12.0",
+				"signal-exit": "^3.0.2"
+			}
+		},
+		"node_modules/proper-lockfile/node_modules/retry": {
+			"version": "0.12.0",
+			"resolved": "https://registry.npmjs.org/retry/-/retry-0.12.0.tgz",
+			"integrity": "sha512-9LkiTwjUh6rT555DtE9rTX+BKByPfrMzEAtnlEtdEwr3Nkffwiihqe2bWADg+OQRjt9gl6ICdmB/ZFDCGAtSow==",
+			"license": "MIT",
+			"engines": {
+				"node": ">= 4"
+			}
+		},
+		"node_modules/protobufjs": {
+			"version": "7.5.6",
+			"resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.5.6.tgz",
+			"integrity": "sha512-M71sTMB146U3u0di3yup8iM+zv8yPRNQVr1KK4tyBitl3qFvEGucq/rGDRShD2rsJhtN02RJaJ7j5X5hmy8SJg==",
+			"hasInstallScript": true,
+			"license": "BSD-3-Clause",
+			"dependencies": {
+				"@protobufjs/aspromise": "^1.1.2",
+				"@protobufjs/base64": "^1.1.2",
+				"@protobufjs/codegen": "^2.0.5",
+				"@protobufjs/eventemitter": "^1.1.0",
+				"@protobufjs/fetch": "^1.1.0",
+				"@protobufjs/float": "^1.0.2",
+				"@protobufjs/inquire": "^1.1.1",
+				"@protobufjs/path": "^1.1.2",
+				"@protobufjs/pool": "^1.1.0",
+				"@protobufjs/utf8": "^1.1.1",
+				"@types/node": ">=13.7.0",
+				"long": "^5.0.0"
+			},
+			"engines": {
+				"node": ">=12.0.0"
+			}
+		},
+		"node_modules/proxy-addr": {
+			"version": "2.0.7",
+			"resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.7.tgz",
+			"integrity": "sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==",
+			"license": "MIT",
+			"dependencies": {
+				"forwarded": "0.2.0",
+				"ipaddr.js": "1.9.1"
+			},
+			"engines": {
+				"node": ">= 0.10"
+			}
+		},
+		"node_modules/proxy-agent": {
+			"version": "6.5.0",
+			"resolved": "https://registry.npmjs.org/proxy-agent/-/proxy-agent-6.5.0.tgz",
+			"integrity": "sha512-TmatMXdr2KlRiA2CyDu8GqR8EjahTG3aY3nXjdzFyoZbmB8hrBsTyMezhULIXKnC0jpfjlmiZ3+EaCzoInSu/A==",
+			"license": "MIT",
+			"dependencies": {
+				"agent-base": "^7.1.2",
+				"debug": "^4.3.4",
+				"http-proxy-agent": "^7.0.1",
+				"https-proxy-agent": "^7.0.6",
+				"lru-cache": "^7.14.1",
+				"pac-proxy-agent": "^7.1.0",
+				"proxy-from-env": "^1.1.0",
+				"socks-proxy-agent": "^8.0.5"
+			},
+			"engines": {
+				"node": ">= 14"
+			}
+		},
+		"node_modules/proxy-agent/node_modules/lru-cache": {
+			"version": "7.18.3",
+			"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-7.18.3.tgz",
+			"integrity": "sha512-jumlc0BIUrS3qJGgIkWZsyfAM7NCWiBcCDhnd+3NNM5KbBmLTgHVfWBcg6W+rLUsIpzpERPsvwUP7CckAQSOoA==",
+			"license": "ISC",
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/proxy-from-env": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
+			"integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==",
+			"license": "MIT"
+		},
+		"node_modules/pump": {
+			"version": "3.0.4",
+			"resolved": "https://registry.npmjs.org/pump/-/pump-3.0.4.tgz",
+			"integrity": "sha512-VS7sjc6KR7e1ukRFhQSY5LM2uBWAUPiOPa/A3mkKmiMwSmRFUITt0xuj+/lesgnCv+dPIEYlkzrcyXgquIHMcA==",
+			"license": "MIT",
+			"dependencies": {
+				"end-of-stream": "^1.1.0",
+				"once": "^1.3.1"
+			}
+		},
+		"node_modules/qs": {
+			"version": "6.15.1",
+			"resolved": "https://registry.npmjs.org/qs/-/qs-6.15.1.tgz",
+			"integrity": "sha512-6YHEFRL9mfgcAvql/XhwTvf5jKcOiiupt2FiJxHkiX1z4j7WL8J/jRHYLluORvc1XxB5rV20KoeK00gVJamspg==",
+			"license": "BSD-3-Clause",
+			"dependencies": {
+				"side-channel": "^1.1.0"
+			},
+			"engines": {
+				"node": ">=0.6"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/range-parser": {
+			"version": "1.2.1",
+			"resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.1.tgz",
+			"integrity": "sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==",
+			"license": "MIT",
+			"engines": {
+				"node": ">= 0.6"
+			}
+		},
+		"node_modules/raw-body": {
+			"version": "3.0.2",
+			"resolved": "https://registry.npmjs.org/raw-body/-/raw-body-3.0.2.tgz",
+			"integrity": "sha512-K5zQjDllxWkf7Z5xJdV0/B0WTNqx6vxG70zJE4N0kBs4LovmEYWJzQGxC9bS9RAKu3bgM40lrd5zoLJ12MQ5BA==",
+			"license": "MIT",
+			"dependencies": {
+				"bytes": "~3.1.2",
+				"http-errors": "~2.0.1",
+				"iconv-lite": "~0.7.0",
+				"unpipe": "~1.0.0"
+			},
+			"engines": {
+				"node": ">= 0.10"
+			}
+		},
+		"node_modules/require-directory": {
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
+			"integrity": "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/require-from-string": {
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+			"integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/resolve-pkg-maps": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/resolve-pkg-maps/-/resolve-pkg-maps-1.0.0.tgz",
+			"integrity": "sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==",
+			"dev": true,
+			"license": "MIT",
+			"funding": {
+				"url": "https://github.com/privatenumber/resolve-pkg-maps?sponsor=1"
+			}
+		},
+		"node_modules/retry": {
+			"version": "0.13.1",
+			"resolved": "https://registry.npmjs.org/retry/-/retry-0.13.1.tgz",
+			"integrity": "sha512-XQBQ3I8W1Cge0Seh+6gjj03LbmRFWuoszgK9ooCpwYIrhhoO80pfq4cUkU5DkknwfOfFteRwlZ56PYOGYyFWdg==",
+			"license": "MIT",
+			"engines": {
+				"node": ">= 4"
+			}
+		},
+		"node_modules/rollup": {
+			"version": "4.60.2",
+			"resolved": "https://registry.npmjs.org/rollup/-/rollup-4.60.2.tgz",
+			"integrity": "sha512-J9qZyW++QK/09NyN/zeO0dG/1GdGfyp9lV8ajHnRVLfo/uFsbji5mHnDgn/qYdUHyCkM2N+8VyspgZclfAh0eQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@types/estree": "1.0.8"
+			},
+			"bin": {
+				"rollup": "dist/bin/rollup"
+			},
+			"engines": {
+				"node": ">=18.0.0",
+				"npm": ">=8.0.0"
+			},
+			"optionalDependencies": {
+				"@rollup/rollup-android-arm-eabi": "4.60.2",
+				"@rollup/rollup-android-arm64": "4.60.2",
+				"@rollup/rollup-darwin-arm64": "4.60.2",
+				"@rollup/rollup-darwin-x64": "4.60.2",
+				"@rollup/rollup-freebsd-arm64": "4.60.2",
+				"@rollup/rollup-freebsd-x64": "4.60.2",
+				"@rollup/rollup-linux-arm-gnueabihf": "4.60.2",
+				"@rollup/rollup-linux-arm-musleabihf": "4.60.2",
+				"@rollup/rollup-linux-arm64-gnu": "4.60.2",
+				"@rollup/rollup-linux-arm64-musl": "4.60.2",
+				"@rollup/rollup-linux-loong64-gnu": "4.60.2",
+				"@rollup/rollup-linux-loong64-musl": "4.60.2",
+				"@rollup/rollup-linux-ppc64-gnu": "4.60.2",
+				"@rollup/rollup-linux-ppc64-musl": "4.60.2",
+				"@rollup/rollup-linux-riscv64-gnu": "4.60.2",
+				"@rollup/rollup-linux-riscv64-musl": "4.60.2",
+				"@rollup/rollup-linux-s390x-gnu": "4.60.2",
+				"@rollup/rollup-linux-x64-gnu": "4.60.2",
+				"@rollup/rollup-linux-x64-musl": "4.60.2",
+				"@rollup/rollup-openbsd-x64": "4.60.2",
+				"@rollup/rollup-openharmony-arm64": "4.60.2",
+				"@rollup/rollup-win32-arm64-msvc": "4.60.2",
+				"@rollup/rollup-win32-ia32-msvc": "4.60.2",
+				"@rollup/rollup-win32-x64-gnu": "4.60.2",
+				"@rollup/rollup-win32-x64-msvc": "4.60.2",
+				"fsevents": "~2.3.2"
+			}
+		},
+		"node_modules/router": {
+			"version": "2.2.0",
+			"resolved": "https://registry.npmjs.org/router/-/router-2.2.0.tgz",
+			"integrity": "sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ==",
+			"license": "MIT",
+			"dependencies": {
+				"debug": "^4.4.0",
+				"depd": "^2.0.0",
+				"is-promise": "^4.0.0",
+				"parseurl": "^1.3.3",
+				"path-to-regexp": "^8.0.0"
+			},
+			"engines": {
+				"node": ">= 18"
+			}
+		},
+		"node_modules/run-applescript": {
+			"version": "7.1.0",
+			"resolved": "https://registry.npmjs.org/run-applescript/-/run-applescript-7.1.0.tgz",
+			"integrity": "sha512-DPe5pVFaAsinSaV6QjQ6gdiedWDcRCbUuiQfQa2wmWV7+xC9bGulGI8+TdRmoFkAPaBXk8CrAbnlY2ISniJ47Q==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=18"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/safe-buffer": {
+			"version": "5.2.1",
+			"resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+			"integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/feross"
+				},
+				{
+					"type": "patreon",
+					"url": "https://www.patreon.com/feross"
+				},
+				{
+					"type": "consulting",
+					"url": "https://feross.org/support"
+				}
+			],
+			"license": "MIT"
+		},
+		"node_modules/safer-buffer": {
+			"version": "2.1.2",
+			"resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+			"integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+			"license": "MIT"
+		},
+		"node_modules/send": {
+			"version": "1.2.1",
+			"resolved": "https://registry.npmjs.org/send/-/send-1.2.1.tgz",
+			"integrity": "sha512-1gnZf7DFcoIcajTjTwjwuDjzuz4PPcY2StKPlsGAQ1+YH20IRVrBaXSWmdjowTJ6u8Rc01PoYOGHXfP1mYcZNQ==",
+			"license": "MIT",
+			"dependencies": {
+				"debug": "^4.4.3",
+				"encodeurl": "^2.0.0",
+				"escape-html": "^1.0.3",
+				"etag": "^1.8.1",
+				"fresh": "^2.0.0",
+				"http-errors": "^2.0.1",
+				"mime-types": "^3.0.2",
+				"ms": "^2.1.3",
+				"on-finished": "^2.4.1",
+				"range-parser": "^1.2.1",
+				"statuses": "^2.0.2"
+			},
+			"engines": {
+				"node": ">= 18"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/express"
+			}
+		},
+		"node_modules/serve-static": {
+			"version": "2.2.1",
+			"resolved": "https://registry.npmjs.org/serve-static/-/serve-static-2.2.1.tgz",
+			"integrity": "sha512-xRXBn0pPqQTVQiC8wyQrKs2MOlX24zQ0POGaj0kultvoOCstBQM5yvOhAVSUwOMjQtTvsPWoNCHfPGwaaQJhTw==",
+			"license": "MIT",
+			"dependencies": {
+				"encodeurl": "^2.0.0",
+				"escape-html": "^1.0.3",
+				"parseurl": "^1.3.3",
+				"send": "^1.2.0"
+			},
+			"engines": {
+				"node": ">= 18"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/express"
+			}
+		},
+		"node_modules/setprototypeof": {
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
+			"integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==",
+			"license": "ISC"
+		},
+		"node_modules/shebang-command": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+			"integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+			"license": "MIT",
+			"dependencies": {
+				"shebang-regex": "^3.0.0"
+			},
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/shebang-regex": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+			"integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/shell-quote": {
+			"version": "1.8.3",
+			"resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.8.3.tgz",
+			"integrity": "sha512-ObmnIF4hXNg1BqhnHmgbDETF8dLPCggZWBjkQfhZpbszZnYur5DUljTcCHii5LC3J5E0yeO/1LIMyH+UvHQgyw==",
+			"license": "MIT",
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/side-channel": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.0.tgz",
+			"integrity": "sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==",
+			"license": "MIT",
+			"dependencies": {
+				"es-errors": "^1.3.0",
+				"object-inspect": "^1.13.3",
+				"side-channel-list": "^1.0.0",
+				"side-channel-map": "^1.0.1",
+				"side-channel-weakmap": "^1.0.2"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/side-channel-list": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.1.tgz",
+			"integrity": "sha512-mjn/0bi/oUURjc5Xl7IaWi/OJJJumuoJFQJfDDyO46+hBWsfaVM65TBHq2eoZBhzl9EchxOijpkbRC8SVBQU0w==",
+			"license": "MIT",
+			"dependencies": {
+				"es-errors": "^1.3.0",
+				"object-inspect": "^1.13.4"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/side-channel-map": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/side-channel-map/-/side-channel-map-1.0.1.tgz",
+			"integrity": "sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==",
+			"license": "MIT",
+			"dependencies": {
+				"call-bound": "^1.0.2",
+				"es-errors": "^1.3.0",
+				"get-intrinsic": "^1.2.5",
+				"object-inspect": "^1.13.3"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/side-channel-weakmap": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/side-channel-weakmap/-/side-channel-weakmap-1.0.2.tgz",
+			"integrity": "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==",
+			"license": "MIT",
+			"dependencies": {
+				"call-bound": "^1.0.2",
+				"es-errors": "^1.3.0",
+				"get-intrinsic": "^1.2.5",
+				"object-inspect": "^1.13.3",
+				"side-channel-map": "^1.0.1"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/siginfo": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+			"integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+			"dev": true,
+			"license": "ISC"
+		},
+		"node_modules/signal-exit": {
+			"version": "3.0.7",
+			"resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
+			"integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
+			"license": "ISC"
+		},
+		"node_modules/sisteransi": {
+			"version": "1.0.5",
+			"resolved": "https://registry.npmjs.org/sisteransi/-/sisteransi-1.0.5.tgz",
+			"integrity": "sha512-bLGGlR1QxBcynn2d5YmDX4MGjlZvy2MRBDRNHLJ8VI6l6+9FUiyTFNJ0IveOSP0bcXgVDPRcfGqA0pjaqUpfVg==",
+			"license": "MIT"
+		},
+		"node_modules/smart-buffer": {
+			"version": "4.2.0",
+			"resolved": "https://registry.npmjs.org/smart-buffer/-/smart-buffer-4.2.0.tgz",
+			"integrity": "sha512-94hK0Hh8rPqQl2xXc3HsaBoOXKV20MToPkcXvwbISWLEs+64sBq5kFgn2kJDHb1Pry9yrP0dxrCI9RRci7RXKg==",
+			"license": "MIT",
+			"engines": {
+				"node": ">= 6.0.0",
+				"npm": ">= 3.0.0"
+			}
+		},
+		"node_modules/socks": {
+			"version": "2.8.8",
+			"resolved": "https://registry.npmjs.org/socks/-/socks-2.8.8.tgz",
+			"integrity": "sha512-NlGELfPrgX2f1TAAcz0WawlLn+0r3FyhhCRpFFK2CemXenPYvzMWWZINv3eDNo9ucdwme7oCHRY0Jnbs4aIkog==",
+			"license": "MIT",
+			"dependencies": {
+				"ip-address": "^10.1.1",
+				"smart-buffer": "^4.2.0"
+			},
+			"engines": {
+				"node": ">= 10.0.0",
+				"npm": ">= 3.0.0"
+			}
+		},
+		"node_modules/socks-proxy-agent": {
+			"version": "8.0.5",
+			"resolved": "https://registry.npmjs.org/socks-proxy-agent/-/socks-proxy-agent-8.0.5.tgz",
+			"integrity": "sha512-HehCEsotFqbPW9sJ8WVYB6UbmIMv7kUUORIF2Nncq4VQvBfNBLibW9YZR5dlYCSUhwcD628pRllm7n+E+YTzJw==",
+			"license": "MIT",
+			"dependencies": {
+				"agent-base": "^7.1.2",
+				"debug": "^4.3.4",
+				"socks": "^2.8.3"
+			},
+			"engines": {
+				"node": ">= 14"
+			}
+		},
+		"node_modules/socks/node_modules/ip-address": {
+			"version": "10.1.1",
+			"resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.1.1.tgz",
+			"integrity": "sha512-1FMu8/N15Ck1BL551Jf42NYIoin2unWjLQ2Fze/DXryJRl5twqtwNHlO39qERGbIOcKYWHdgRryhOC+NG4eaLw==",
+			"license": "MIT",
+			"engines": {
+				"node": ">= 12"
+			}
+		},
+		"node_modules/source-map": {
+			"version": "0.6.1",
+			"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+			"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+			"license": "BSD-3-Clause",
+			"optional": true,
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/source-map-js": {
+			"version": "1.2.1",
+			"resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+			"integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+			"dev": true,
+			"license": "BSD-3-Clause",
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/stackback": {
+			"version": "0.0.2",
+			"resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+			"integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/statuses": {
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.2.tgz",
+			"integrity": "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==",
+			"license": "MIT",
+			"engines": {
+				"node": ">= 0.8"
+			}
+		},
+		"node_modules/std-env": {
+			"version": "3.10.0",
+			"resolved": "https://registry.npmjs.org/std-env/-/std-env-3.10.0.tgz",
+			"integrity": "sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==",
+			"license": "MIT"
+		},
+		"node_modules/string-width": {
+			"version": "4.2.3",
+			"resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+			"integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+			"license": "MIT",
+			"dependencies": {
+				"emoji-regex": "^8.0.0",
+				"is-fullwidth-code-point": "^3.0.0",
+				"strip-ansi": "^6.0.1"
+			},
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/string-width/node_modules/ansi-regex": {
+			"version": "5.0.1",
+			"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+			"integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/string-width/node_modules/strip-ansi": {
+			"version": "6.0.1",
+			"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+			"integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+			"license": "MIT",
+			"dependencies": {
+				"ansi-regex": "^5.0.1"
+			},
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/strip-ansi": {
+			"version": "7.2.0",
+			"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.2.0.tgz",
+			"integrity": "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==",
+			"license": "MIT",
+			"dependencies": {
+				"ansi-regex": "^6.2.2"
+			},
+			"engines": {
+				"node": ">=12"
+			},
+			"funding": {
+				"url": "https://github.com/chalk/strip-ansi?sponsor=1"
+			}
+		},
+		"node_modules/strip-literal": {
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/strip-literal/-/strip-literal-3.1.0.tgz",
+			"integrity": "sha512-8r3mkIM/2+PpjHoOtiAW8Rg3jJLHaV7xPwG+YRGrv6FP0wwk/toTpATxWYOW0BKdWwl82VT2tFYi5DlROa0Mxg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"js-tokens": "^9.0.1"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/antfu"
+			}
+		},
+		"node_modules/strnum": {
+			"version": "2.2.3",
+			"resolved": "https://registry.npmjs.org/strnum/-/strnum-2.2.3.tgz",
+			"integrity": "sha512-oKx6RUCuHfT3oyVjtnrmn19H1SiCqgJSg+54XqURKp5aCMbrXrhLjRN9TjuwMjiYstZ0MzDrHqkGZ5dFTKd+zg==",
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/NaturalIntelligence"
+				}
+			],
+			"license": "MIT"
+		},
+		"node_modules/strtok3": {
+			"version": "10.3.5",
+			"resolved": "https://registry.npmjs.org/strtok3/-/strtok3-10.3.5.tgz",
+			"integrity": "sha512-ki4hZQfh5rX0QDLLkOCj+h+CVNkqmp/CMf8v8kZpkNVK6jGQooMytqzLZYUVYIZcFZ6yDB70EfD8POcFXiF5oA==",
+			"license": "MIT",
+			"dependencies": {
+				"@tokenizer/token": "^0.3.0"
+			},
+			"engines": {
+				"node": ">=18"
+			},
+			"funding": {
+				"type": "github",
+				"url": "https://github.com/sponsors/Borewit"
+			}
+		},
+		"node_modules/supports-color": {
+			"version": "7.2.0",
+			"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+			"integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+			"license": "MIT",
+			"dependencies": {
+				"has-flag": "^4.0.0"
+			},
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/thenify": {
+			"version": "3.3.1",
+			"resolved": "https://registry.npmjs.org/thenify/-/thenify-3.3.1.tgz",
+			"integrity": "sha512-RVZSIV5IG10Hk3enotrhvz0T9em6cyHBLkH/YAZuKqd8hRkKhSfCGIcP2KUY0EPxndzANBmNllzWPwak+bheSw==",
+			"license": "MIT",
+			"dependencies": {
+				"any-promise": "^1.0.0"
+			}
+		},
+		"node_modules/thenify-all": {
+			"version": "1.6.0",
+			"resolved": "https://registry.npmjs.org/thenify-all/-/thenify-all-1.6.0.tgz",
+			"integrity": "sha512-RNxQH/qI8/t3thXJDwcstUO4zeqo64+Uy/+sNVRBx4Xn2OX+OZ9oP+iJnNFqplFra2ZUVeKCSa2oVWi3T4uVmA==",
+			"license": "MIT",
+			"dependencies": {
+				"thenify": ">= 3.1.0 < 4"
+			},
+			"engines": {
+				"node": ">=0.8"
+			}
+		},
+		"node_modules/tinybench": {
+			"version": "2.9.0",
+			"resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+			"integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/tinyexec": {
+			"version": "0.3.2",
+			"resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-0.3.2.tgz",
+			"integrity": "sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/tinyglobby": {
+			"version": "0.2.16",
+			"resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.16.tgz",
+			"integrity": "sha512-pn99VhoACYR8nFHhxqix+uvsbXineAasWm5ojXoN8xEwK5Kd3/TrhNn1wByuD52UxWRLy8pu+kRMniEi6Eq9Zg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"fdir": "^6.5.0",
+				"picomatch": "^4.0.4"
+			},
+			"engines": {
+				"node": ">=12.0.0"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/SuperchupuDev"
+			}
+		},
+		"node_modules/tinyglobby/node_modules/fdir": {
+			"version": "6.5.0",
+			"resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+			"integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=12.0.0"
+			},
+			"peerDependencies": {
+				"picomatch": "^3 || ^4"
+			},
+			"peerDependenciesMeta": {
+				"picomatch": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/tinyglobby/node_modules/picomatch": {
+			"version": "4.0.4",
+			"resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+			"integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=12"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/jonschlinkert"
+			}
+		},
+		"node_modules/tinypool": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/tinypool/-/tinypool-1.1.1.tgz",
+			"integrity": "sha512-Zba82s87IFq9A9XmjiX5uZA/ARWDrB03OHlq+Vw1fSdt0I+4/Kutwy8BP4Y/y/aORMo61FQ0vIb5j44vSo5Pkg==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": "^18.0.0 || >=20.0.0"
+			}
+		},
+		"node_modules/tinyrainbow": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-2.0.0.tgz",
+			"integrity": "sha512-op4nsTR47R6p0vMUUoYl/a+ljLFVtlfaXkLQmqfLR1qHma1h/ysYk4hEXZ880bf2CYgTskvTa/e196Vd5dDQXw==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=14.0.0"
+			}
+		},
+		"node_modules/tinyspy": {
+			"version": "4.0.4",
+			"resolved": "https://registry.npmjs.org/tinyspy/-/tinyspy-4.0.4.tgz",
+			"integrity": "sha512-azl+t0z7pw/z958Gy9svOTuzqIk6xq+NSheJzn5MMWtWTFywIacg2wUlzKFGtt3cthx0r2SxMK0yzJOR0IES7Q==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=14.0.0"
+			}
+		},
+		"node_modules/to-regex-range": {
+			"version": "5.0.1",
+			"resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
+			"integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
+			"license": "MIT",
+			"dependencies": {
+				"is-number": "^7.0.0"
+			},
+			"engines": {
+				"node": ">=8.0"
+			}
+		},
+		"node_modules/toidentifier": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.1.tgz",
+			"integrity": "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=0.6"
+			}
+		},
+		"node_modules/token-types": {
+			"version": "6.1.2",
+			"resolved": "https://registry.npmjs.org/token-types/-/token-types-6.1.2.tgz",
+			"integrity": "sha512-dRXchy+C0IgK8WPC6xvCHFRIWYUbqqdEIKPaKo/AcTUNzwLTK6AH7RjdLWsEZcAN/TBdtfUw3PYEgPr5VPr6ww==",
+			"license": "MIT",
+			"dependencies": {
+				"@borewit/text-codec": "^0.2.1",
+				"@tokenizer/token": "^0.3.0",
+				"ieee754": "^1.2.1"
+			},
+			"engines": {
+				"node": ">=14.16"
+			},
+			"funding": {
+				"type": "github",
+				"url": "https://github.com/sponsors/Borewit"
+			}
+		},
+		"node_modules/ts-algebra": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/ts-algebra/-/ts-algebra-2.0.0.tgz",
+			"integrity": "sha512-FPAhNPFMrkwz76P7cdjdmiShwMynZYN6SgOujD1urY4oNm80Ou9oMdmbR45LotcKOXoy7wSmHkRFE6Mxbrhefw==",
+			"license": "MIT"
+		},
+		"node_modules/tslib": {
+			"version": "2.8.1",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+			"integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+			"license": "0BSD"
+		},
+		"node_modules/tsx": {
+			"version": "4.21.0",
+			"resolved": "https://registry.npmjs.org/tsx/-/tsx-4.21.0.tgz",
+			"integrity": "sha512-5C1sg4USs1lfG0GFb2RLXsdpXqBSEhAaA/0kPL01wxzpMqLILNxIxIOKiILz+cdg/pLnOUxFYOR5yhHU666wbw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"esbuild": "~0.27.0",
+				"get-tsconfig": "^4.7.5"
+			},
+			"bin": {
+				"tsx": "dist/cli.mjs"
+			},
+			"engines": {
+				"node": ">=18.0.0"
+			},
+			"optionalDependencies": {
+				"fsevents": "~2.3.3"
+			}
+		},
+		"node_modules/tsx/node_modules/fsevents": {
+			"version": "2.3.3",
+			"resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+			"integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+			"dev": true,
+			"hasInstallScript": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"darwin"
+			],
+			"engines": {
+				"node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+			}
+		},
+		"node_modules/turndown": {
+			"version": "7.2.4",
+			"resolved": "https://registry.npmjs.org/turndown/-/turndown-7.2.4.tgz",
+			"integrity": "sha512-I8yFsfRzmzK0WV1pNNOA4A7y4RDfFxPRxb3t+e3ui14qSGOxGtiSP6GjeX+Y6CHb7HYaFj7ECUD7VE5kQMZWGQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@mixmark-io/domino": "^2.2.0"
+			},
+			"engines": {
+				"node": ">=18",
+				"npm": ">=9"
+			}
+		},
+		"node_modules/type-is": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/type-is/-/type-is-2.0.1.tgz",
+			"integrity": "sha512-OZs6gsjF4vMp32qrCbiVSkrFmXtG/AZhY3t0iAMrMBiAZyV9oALtXO8hsrHbMXF9x6L3grlFuwW2oAz7cav+Gw==",
+			"license": "MIT",
+			"dependencies": {
+				"content-type": "^1.0.5",
+				"media-typer": "^1.1.0",
+				"mime-types": "^3.0.0"
+			},
+			"engines": {
+				"node": ">= 0.6"
+			}
+		},
+		"node_modules/typescript": {
+			"version": "5.9.3",
+			"resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+			"integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"bin": {
+				"tsc": "bin/tsc",
+				"tsserver": "bin/tsserver"
+			},
+			"engines": {
+				"node": ">=14.17"
+			}
+		},
+		"node_modules/uint8array-extras": {
+			"version": "1.5.0",
+			"resolved": "https://registry.npmjs.org/uint8array-extras/-/uint8array-extras-1.5.0.tgz",
+			"integrity": "sha512-rvKSBiC5zqCCiDZ9kAOszZcDvdAHwwIKJG33Ykj43OKcWsnmcBRL09YTU4nOeHZ8Y2a7l1MgTd08SBe9A8Qj6A==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=18"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/undici": {
+			"version": "8.1.0",
+			"resolved": "https://registry.npmjs.org/undici/-/undici-8.1.0.tgz",
+			"integrity": "sha512-E9MkTS4xXLnRPYqxH2e6Hr2/49e7WFDKczKcCaFH4VaZs2iNvHMqeIkyUAD9vM8kujy9TjVrRlQ5KkdEJxB2pw==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=22.19.0"
+			}
+		},
+		"node_modules/undici-types": {
+			"version": "6.21.0",
+			"resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+			"integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+			"license": "MIT"
+		},
+		"node_modules/unpipe": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
+			"integrity": "sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==",
+			"license": "MIT",
+			"engines": {
+				"node": ">= 0.8"
+			}
+		},
+		"node_modules/uuid": {
+			"version": "14.0.0",
+			"resolved": "https://registry.npmjs.org/uuid/-/uuid-14.0.0.tgz",
+			"integrity": "sha512-Qo+uWgilfSmAhXCMav1uYFynlQO7fMFiMVZsQqZRMIXp0O7rR7qjkj+cPvBHLgBqi960QCoo/PH2/6ZtVqKvrg==",
+			"funding": [
+				"https://github.com/sponsors/broofa",
+				"https://github.com/sponsors/ctavan"
+			],
+			"license": "MIT",
+			"bin": {
+				"uuid": "dist-node/bin/uuid"
+			}
+		},
+		"node_modules/vary": {
+			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
+			"integrity": "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==",
+			"license": "MIT",
+			"engines": {
+				"node": ">= 0.8"
+			}
+		},
+		"node_modules/vite": {
+			"version": "7.3.2",
+			"resolved": "https://registry.npmjs.org/vite/-/vite-7.3.2.tgz",
+			"integrity": "sha512-Bby3NOsna2jsjfLVOHKes8sGwgl4TT0E6vvpYgnAYDIF/tie7MRaFthmKuHx1NSXjiTueXH3do80FMQgvEktRg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"esbuild": "^0.27.0",
+				"fdir": "^6.5.0",
+				"picomatch": "^4.0.3",
+				"postcss": "^8.5.6",
+				"rollup": "^4.43.0",
+				"tinyglobby": "^0.2.15"
+			},
+			"bin": {
+				"vite": "bin/vite.js"
+			},
+			"engines": {
+				"node": "^20.19.0 || >=22.12.0"
+			},
+			"funding": {
+				"url": "https://github.com/vitejs/vite?sponsor=1"
+			},
+			"optionalDependencies": {
+				"fsevents": "~2.3.3"
+			},
+			"peerDependencies": {
+				"@types/node": "^20.19.0 || >=22.12.0",
+				"jiti": ">=1.21.0",
+				"less": "^4.0.0",
+				"lightningcss": "^1.21.0",
+				"sass": "^1.70.0",
+				"sass-embedded": "^1.70.0",
+				"stylus": ">=0.54.8",
+				"sugarss": "^5.0.0",
+				"terser": "^5.16.0",
+				"tsx": "^4.8.1",
+				"yaml": "^2.4.2"
+			},
+			"peerDependenciesMeta": {
+				"@types/node": {
+					"optional": true
+				},
+				"jiti": {
+					"optional": true
+				},
+				"less": {
+					"optional": true
+				},
+				"lightningcss": {
+					"optional": true
+				},
+				"sass": {
+					"optional": true
+				},
+				"sass-embedded": {
+					"optional": true
+				},
+				"stylus": {
+					"optional": true
+				},
+				"sugarss": {
+					"optional": true
+				},
+				"terser": {
+					"optional": true
+				},
+				"tsx": {
+					"optional": true
+				},
+				"yaml": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/vite-node": {
+			"version": "3.2.4",
+			"resolved": "https://registry.npmjs.org/vite-node/-/vite-node-3.2.4.tgz",
+			"integrity": "sha512-EbKSKh+bh1E1IFxeO0pg1n4dvoOTt0UDiXMd/qn++r98+jPO1xtJilvXldeuQ8giIB5IkpjCgMleHMNEsGH6pg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"cac": "^6.7.14",
+				"debug": "^4.4.1",
+				"es-module-lexer": "^1.7.0",
+				"pathe": "^2.0.3",
+				"vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0"
+			},
+			"bin": {
+				"vite-node": "vite-node.mjs"
+			},
+			"engines": {
+				"node": "^18.0.0 || ^20.0.0 || >=22.0.0"
+			},
+			"funding": {
+				"url": "https://opencollective.com/vitest"
+			}
+		},
+		"node_modules/vite/node_modules/fdir": {
+			"version": "6.5.0",
+			"resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+			"integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=12.0.0"
+			},
+			"peerDependencies": {
+				"picomatch": "^3 || ^4"
+			},
+			"peerDependenciesMeta": {
+				"picomatch": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/vite/node_modules/fsevents": {
+			"version": "2.3.3",
+			"resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+			"integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+			"dev": true,
+			"hasInstallScript": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"darwin"
+			],
+			"engines": {
+				"node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+			}
+		},
+		"node_modules/vite/node_modules/picomatch": {
+			"version": "4.0.4",
+			"resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+			"integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=12"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/jonschlinkert"
+			}
+		},
+		"node_modules/vitest": {
+			"version": "3.2.4",
+			"resolved": "https://registry.npmjs.org/vitest/-/vitest-3.2.4.tgz",
+			"integrity": "sha512-LUCP5ev3GURDysTWiP47wRRUpLKMOfPh+yKTx3kVIEiu5KOMeqzpnYNsKyOoVrULivR8tLcks4+lga33Whn90A==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@types/chai": "^5.2.2",
+				"@vitest/expect": "3.2.4",
+				"@vitest/mocker": "3.2.4",
+				"@vitest/pretty-format": "^3.2.4",
+				"@vitest/runner": "3.2.4",
+				"@vitest/snapshot": "3.2.4",
+				"@vitest/spy": "3.2.4",
+				"@vitest/utils": "3.2.4",
+				"chai": "^5.2.0",
+				"debug": "^4.4.1",
+				"expect-type": "^1.2.1",
+				"magic-string": "^0.30.17",
+				"pathe": "^2.0.3",
+				"picomatch": "^4.0.2",
+				"std-env": "^3.9.0",
+				"tinybench": "^2.9.0",
+				"tinyexec": "^0.3.2",
+				"tinyglobby": "^0.2.14",
+				"tinypool": "^1.1.1",
+				"tinyrainbow": "^2.0.0",
+				"vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0",
+				"vite-node": "3.2.4",
+				"why-is-node-running": "^2.3.0"
+			},
+			"bin": {
+				"vitest": "vitest.mjs"
+			},
+			"engines": {
+				"node": "^18.0.0 || ^20.0.0 || >=22.0.0"
+			},
+			"funding": {
+				"url": "https://opencollective.com/vitest"
+			},
+			"peerDependencies": {
+				"@edge-runtime/vm": "*",
+				"@types/debug": "^4.1.12",
+				"@types/node": "^18.0.0 || ^20.0.0 || >=22.0.0",
+				"@vitest/browser": "3.2.4",
+				"@vitest/ui": "3.2.4",
+				"happy-dom": "*",
+				"jsdom": "*"
+			},
+			"peerDependenciesMeta": {
+				"@edge-runtime/vm": {
+					"optional": true
+				},
+				"@types/debug": {
+					"optional": true
+				},
+				"@types/node": {
+					"optional": true
+				},
+				"@vitest/browser": {
+					"optional": true
+				},
+				"@vitest/ui": {
+					"optional": true
+				},
+				"happy-dom": {
+					"optional": true
+				},
+				"jsdom": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/vitest/node_modules/picomatch": {
+			"version": "4.0.4",
+			"resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+			"integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=12"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/jonschlinkert"
+			}
+		},
+		"node_modules/web-streams-polyfill": {
+			"version": "3.3.3",
+			"resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-3.3.3.tgz",
+			"integrity": "sha512-d2JWLCivmZYTSIoge9MsgFCZrt571BikcWGYkjC1khllbTeDlGqZ2D8vD8E/lJa8WGWbb7Plm8/XJYV7IJHZZw==",
+			"license": "MIT",
+			"engines": {
+				"node": ">= 8"
+			}
+		},
+		"node_modules/which": {
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+			"integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+			"license": "ISC",
+			"dependencies": {
+				"isexe": "^2.0.0"
+			},
+			"bin": {
+				"node-which": "bin/node-which"
+			},
+			"engines": {
+				"node": ">= 8"
+			}
+		},
+		"node_modules/why-is-node-running": {
+			"version": "2.3.0",
+			"resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+			"integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"siginfo": "^2.0.0",
+				"stackback": "0.0.2"
+			},
+			"bin": {
+				"why-is-node-running": "cli.js"
+			},
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/wrap-ansi": {
+			"version": "7.0.0",
+			"resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+			"integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+			"license": "MIT",
+			"dependencies": {
+				"ansi-styles": "^4.0.0",
+				"string-width": "^4.1.0",
+				"strip-ansi": "^6.0.0"
+			},
+			"engines": {
+				"node": ">=10"
+			},
+			"funding": {
+				"url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+			}
+		},
+		"node_modules/wrap-ansi/node_modules/ansi-regex": {
+			"version": "5.0.1",
+			"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+			"integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/wrap-ansi/node_modules/strip-ansi": {
+			"version": "6.0.1",
+			"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+			"integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+			"license": "MIT",
+			"dependencies": {
+				"ansi-regex": "^5.0.1"
+			},
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/wrappy": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+			"integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
+			"license": "ISC"
+		},
+		"node_modules/ws": {
+			"version": "8.20.0",
+			"resolved": "https://registry.npmjs.org/ws/-/ws-8.20.0.tgz",
+			"integrity": "sha512-sAt8BhgNbzCtgGbt2OxmpuryO63ZoDk/sqaB/znQm94T4fCEsy/yV+7CdC1kJhOU9lboAEU7R3kquuycDoibVA==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=10.0.0"
+			},
+			"peerDependencies": {
+				"bufferutil": "^4.0.1",
+				"utf-8-validate": ">=5.0.2"
+			},
+			"peerDependenciesMeta": {
+				"bufferutil": {
+					"optional": true
+				},
+				"utf-8-validate": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/wsl-utils": {
+			"version": "0.1.0",
+			"resolved": "https://registry.npmjs.org/wsl-utils/-/wsl-utils-0.1.0.tgz",
+			"integrity": "sha512-h3Fbisa2nKGPxCpm89Hk33lBLsnaGBvctQopaBSOW/uIs6FTe1ATyAnKFJrzVs9vpGdsTe73WF3V4lIsk4Gacw==",
+			"license": "MIT",
+			"dependencies": {
+				"is-wsl": "^3.1.0"
+			},
+			"engines": {
+				"node": ">=18"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/y18n": {
+			"version": "5.0.8",
+			"resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
+			"integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==",
+			"license": "ISC",
+			"engines": {
+				"node": ">=10"
+			}
+		},
+		"node_modules/yaml": {
+			"version": "2.8.3",
+			"resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.3.tgz",
+			"integrity": "sha512-AvbaCLOO2Otw/lW5bmh9d/WEdcDFdQp2Z2ZUH3pX9U2ihyUY0nvLv7J6TrWowklRGPYbB/IuIMfYgxaCPg5Bpg==",
+			"license": "ISC",
+			"bin": {
+				"yaml": "bin.mjs"
+			},
+			"engines": {
+				"node": ">= 14.6"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/eemeli"
+			}
+		},
+		"node_modules/yargs": {
+			"version": "16.2.0",
+			"resolved": "https://registry.npmjs.org/yargs/-/yargs-16.2.0.tgz",
+			"integrity": "sha512-D1mvvtDG0L5ft/jGWkLpG1+m0eQxOfaBvTNELraWj22wSVUMWxZUvYgJYcKh6jGGIkJFhH4IZPQhR4TKpc8mBw==",
+			"license": "MIT",
+			"dependencies": {
+				"cliui": "^7.0.2",
+				"escalade": "^3.1.1",
+				"get-caller-file": "^2.0.5",
+				"require-directory": "^2.1.1",
+				"string-width": "^4.2.0",
+				"y18n": "^5.0.5",
+				"yargs-parser": "^20.2.2"
+			},
+			"engines": {
+				"node": ">=10"
+			}
+		},
+		"node_modules/yargs-parser": {
+			"version": "20.2.9",
+			"resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-20.2.9.tgz",
+			"integrity": "sha512-y11nGElTIV+CT3Zv9t7VKl+Q3hTQoT9a1Qzezhhl6Rp21gJ/IVTW7Z3y9EWXhuUBC2Shnf+DX0antecpAwSP8w==",
+			"license": "ISC",
+			"engines": {
+				"node": ">=10"
+			}
+		},
+		"node_modules/yauzl": {
+			"version": "2.10.0",
+			"resolved": "https://registry.npmjs.org/yauzl/-/yauzl-2.10.0.tgz",
+			"integrity": "sha512-p4a9I6X6nu6IhoGmBqAcbJy1mlC4j27vEPZX9F4L4/vZT3Lyq1VkFHw/V/PUcB9Buo+DG3iHkT0x3Qya58zc3g==",
+			"license": "MIT",
+			"dependencies": {
+				"buffer-crc32": "~0.2.3",
+				"fd-slicer": "~1.1.0"
+			}
+		},
+		"node_modules/yoctocolors": {
+			"version": "2.1.2",
+			"resolved": "https://registry.npmjs.org/yoctocolors/-/yoctocolors-2.1.2.tgz",
+			"integrity": "sha512-CzhO+pFNo8ajLM2d2IW/R93ipy99LWjtwblvC1RsoSUMZgyLbYFr221TnSNT7GjGdYui6P459mw9JH/g/zW2ug==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=18"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/zod": {
+			"version": "4.3.6",
+			"resolved": "https://registry.npmjs.org/zod/-/zod-4.3.6.tgz",
+			"integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
+			"license": "MIT",
+			"funding": {
+				"url": "https://github.com/sponsors/colinhacks"
+			}
+		},
+		"node_modules/zod-to-json-schema": {
+			"version": "3.25.2",
+			"resolved": "https://registry.npmjs.org/zod-to-json-schema/-/zod-to-json-schema-3.25.2.tgz",
+			"integrity": "sha512-O/PgfnpT1xKSDeQYSCfRI5Gy3hPf91mKVDuYLUHZJMiDFptvP41MSnWofm8dnCm0256ZNfZIM7DSzuSMAFnjHA==",
+			"license": "ISC",
+			"peerDependencies": {
+				"zod": "^3.25.28 || ^4"
+			}
+		}
+	}
+}

--- a/src/types/bun-sqlite.d.ts
+++ b/src/types/bun-sqlite.d.ts
@@ -1,0 +1,16 @@
+// Type declarations for bun:sqlite - local to hitl-metrics extension
+// This file provides types for the Bun SQLite module without conflicting with Node types
+
+declare module "bun:sqlite" {
+	export class Database {
+		constructor(path: string)
+		exec(sql: string): void
+		run(sql: string, params?: (string | number | null | boolean | Uint8Array)[]): void
+		query(sql: string): Statement
+		close(): void
+	}
+
+	export interface Statement {
+		all(...params: (string | number | null | boolean | Uint8Array)[]): unknown[]
+	}
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -13,5 +13,5 @@
 		"resolveJsonModule": true
 	},
 	"include": ["src", "extensions", "scripts"],
-	"exclude": ["node_modules", "dist", "**/*.test.ts"]
+	"exclude": ["node_modules", "dist"]
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -13,5 +13,5 @@
 		"resolveJsonModule": true
 	},
 	"include": ["src", "extensions", "scripts"],
-	"exclude": ["node_modules", "dist"]
+	"exclude": ["node_modules", "dist", "**/*.test.ts"]
 }


### PR DESCRIPTION


---
### Kimchi Summary
### What changed
Introduces a new HITL (Human-in-the-Loop) metrics extension that instruments agent sessions to track time spent in agent execution, human interaction, and idle states. Adds the `/metrics` command to display aggregated statistics, recent sessions, and an ASCII timeline of the most recent closed session.

### Why
Provides observability into HITL interaction patterns and session efficiency by persisting telemetry data locally for analysis.

### Key changes
- `extensions/hitl-metrics/commands/metrics.ts`: Implements `/metrics` command with three-category time tracking (agent, HITL, idle) and timeline visualization via `getMetricsOutput()`.
- `extensions/hitl-metrics/formatters.ts`: Adds formatting utilities for duration (`formatDuration`), metrics tables (`formatMetrics`), session rows (`formatSessionRow`), and ASCII timeline blocks (`formatTimelineSection`).
- `extensions/hitl-metrics/index.ts`: Registers extension hooks (`session_start`, `tool_execution_start`, `tool_result`, `session_shutdown`, `input`) to capture lifecycle events.
- `extensions/hitl-metrics/session-manager.ts`: Manages session state and SQLite persistence at `~/.kimchi/metrics/<hash>/hitl.db`.
- `extensions/hitl-metrics/storage/`: Database abstraction (`HitlDatabase`, `projectHash`) with tables `hitl_sessions`, `hitl_events`, and `activity_events`.
- `.gitignore`: Excludes `.kimchi/` local config and GSD baseline artifacts.
- Test coverage: Adds unit tests (`metrics.test.ts`, `formatters.test.ts`, `hooks.test.ts`), integration tests (`e2e.test.ts`), and E2E harnesses (`e2e-acp.ts`, `e2e-rpc.py`) verifying DB write/read cycles and metrics accuracy.

### Impact
- Creates local SQLite database `~/.kimchi/metrics/<project_hash>/hitl.db` on first run; auto-initializes schema.
- Non-breaking: gracefully handles missing project directories (logs warning) and headless mode (prints to console).
- Records durations for `ask_user_questions` tool calls, extracting question counts and selected options; skips "cached" results ≤50ms to avoid noise.
- Categorizes session time into `agent_time_ms`, `hitl_time_ms`, and `idle_time_ms` buckets based on tool start/result and user input events.