### PR TITLE
LLM-1457: hide yolo warning when value changes

### DIFF
--- a/src/components/footer.ts
+++ b/src/components/footer.ts
@@ -199,6 +199,12 @@ export class StatsFooter implements Component {
 		return seg(teal(`${count} subagent${count === 1 ? "" : "s"}`))
 	}
 
+	private permissionsWarning(width: number): string | null {
+		const text = this._footerData.getExtensionStatuses().get("permissions-warning")
+		if (!text) return null
+		return truncateToWidth(this.theme.fg("warning", text), width)
+	}
+
 	render(width: number): string[] {
 		const tags = getActiveTags()
 			.map(parseTag)
@@ -230,6 +236,7 @@ export class StatsFooter implements Component {
 			line = truncateToWidth(left, width)
 		}
 
-		return [line]
+		const warning = this.permissionsWarning(width)
+		return warning ? [warning, line] : [line]
 	}
 }

--- a/src/extensions/permissions/index.ts
+++ b/src/extensions/permissions/index.ts
@@ -90,7 +90,6 @@ export default function permissionsExtension(pi: ExtensionAPI): void {
 	let cliMode: PermissionMode | undefined
 	let originalActiveTools: string[] | null = null
 	let planModeApplied = false
-	let yoloWarningShown = false
 
 	function rebuildConfigRules(): void {
 		configRules = [
@@ -173,13 +172,7 @@ export default function permissionsExtension(pi: ExtensionAPI): void {
 		if (next === "plan") applyPlanModeTools()
 		propagateModeToEnv()
 		updateStatus(ctx)
-		// Show danger warning when switching to yolo mode (only once per session)
-		if (next === "yolo" && ctx.hasUI && !yoloWarningShown) {
-			yoloWarningShown = true
-			const dangerMsg =
-				"DANGER: Running in YOLO mode. All permission checks are disabled. The agent will execute commands without confirmation. This can modify or delete files. Intended for use in disposable or sandboxed environments only. Not recommended for production use."
-			ctx.ui.notify(ctx.ui.theme.fg("error", dangerMsg), "warning")
-		}
+		maybeShowYoloWarning(ctx, next)
 	}
 
 	function doLoadConfig(ctx: ExtensionContext): { errors: string[] } {
@@ -192,6 +185,18 @@ export default function permissionsExtension(pi: ExtensionAPI): void {
 		loaded = lc
 		rebuildConfigRules()
 		return { errors }
+	}
+
+	function maybeShowYoloWarning(ctx: ExtensionContext, mode: PermissionMode) {
+		if (!ctx.hasUI) return
+		if (mode === "yolo") {
+			ctx.ui.setStatus(
+				"permissions-warning",
+				"WARNING: all permission checks disabled. YOLO mode is recommended for sandbox/disposable environments only.",
+			)
+		} else {
+			ctx.ui.setStatus("permissions-warning", undefined)
+		}
 	}
 
 	pi.on("session_start", async (_event, ctx) => {
@@ -215,13 +220,7 @@ export default function permissionsExtension(pi: ExtensionAPI): void {
 		propagateModeToEnv()
 		updateStatus(ctx)
 
-		// Show danger warning when starting in yolo mode (only once per session)
-		if (currentMode() === "yolo" && ctx.hasUI && !yoloWarningShown) {
-			yoloWarningShown = true
-			const dangerMsg =
-				"DANGER: Running in YOLO mode. All permission checks are disabled. The agent will execute commands without confirmation. This can modify or delete files. Intended for use in disposable or sandboxed environments only. Not recommended for production use."
-			ctx.ui.notify(ctx.ui.theme.fg("error", dangerMsg), "warning")
-		}
+		maybeShowYoloWarning(ctx, currentMode())
 	})
 
 	pi.on("before_agent_start", async (event): Promise<{ systemPrompt?: string }> => {


### PR DESCRIPTION


---
### Kimchi Summary
### What changed
Moves the YOLO mode permission warning from a one-time notification to a persistent footer status. The warning now appears in the stats footer whenever the agent is running in `yolo` mode and is cleared when switching to other modes.

### Key changes
- **`StatsFooter.render()`**: Renders a permissions warning line above the status bar when a `"permissions-warning"` status is set.
- **`StatsFooter.permissionsWarning()`**: Added helper to fetch and format the warning text from extension statuses.
- **`permissionsExtension`**: 
  - Replaced `yoloWarningShown` session flag with `maybeShowYoloWarning()` utility.
  - Uses `ctx.ui.setStatus("permissions-warning", ...)` to toggle the footer warning based on current permission mode.
  - Simplified warning text to emphasize sandbox/disposable environment usage.

### Impact
The YOLO mode warning is now continuously visible in the footer instead of appearing once as a transient notification. Users switching between modes will see the warning appear or disappear immediately.