### PR TITLE
LLM-1462: Infer bearer auth and include top-level MCP servers

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,8 +22,7 @@
 		"test": "vitest run --dir src",
 		"test:smoke": "vitest run --config tests/smoke/vitest.config.ts",
 		"prepare": "husky",
-		"verify": "pnpm run check && pnpm run build:binary && pnpm run test && pnpm run test:smoke",
-		"prepare": "husky"
+		"verify": "pnpm run check && pnpm run build:binary && pnpm run test && pnpm run test:smoke"
 	},
 	"piConfig": {
 		"name": "kimchi",
@@ -73,6 +72,9 @@
 			"koffi",
 			"node-pty",
 			"protobufjs"
-		]
+		],
+		"patchedDependencies": {
+			"@mariozechner/pi-coding-agent": "patches/@mariozechner__pi-coding-agent.patch"
+		}
 	}
 }

--- a/patches/@mariozechner__pi-coding-agent.patch
+++ b/patches/@mariozechner__pi-coding-agent.patch
@@ -1,0 +1,24 @@
+diff --git a/dist/cli/args.js b/dist/cli/args.js
+index 60fb3b9c763006fd2a4d761aa93e4746d66dfa2f..79c30e0671ef38280fda9224f270e7af1e91da8d 100644
+--- a/dist/cli/args.js
++++ b/dist/cli/args.js
+@@ -288,6 +288,7 @@ ${chalk.bold("Examples:")}
+   ${APP_NAME} --export session.jsonl output.html
+ 
+ ${chalk.bold("Environment Variables:")}
++  KIMCHI_API_KEY                   - Kimchi API key (auto-login when not already configured)
+   ANTHROPIC_API_KEY                - Anthropic Claude API key
+   ANTHROPIC_OAUTH_TOKEN            - Anthropic OAuth token (alternative to API key)
+   OPENAI_API_KEY                   - OpenAI GPT API key
+diff --git a/dist/core/model-resolver.js b/dist/core/model-resolver.js
+index b8b1369b7b186b572b7fe8524eedbb6c22e1bb37..fba65f033fe305ed65aa413a8882f1231b6e3052 100644
+--- a/dist/core/model-resolver.js
++++ b/dist/core/model-resolver.js
+@@ -31,6 +31,7 @@ export const defaultModelPerProvider = {
+     opencode: "claude-opus-4-6",
+     "opencode-go": "kimi-k2.5",
+     "kimi-coding": "kimi-for-coding",
++    "kimchi-dev": "kimi-k2.5",
+ };
+ /**
+  * Helper to check if a model ID looks like an alias (no date suffix)

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4,6 +4,11 @@ settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
+patchedDependencies:
+  '@mariozechner/pi-coding-agent':
+    hash: abb877a867e699ad24e2f72cb410d78bab73ece3c24663625133b61c0fbc513f
+    path: patches/@mariozechner__pi-coding-agent.patch
+
 importers:
 
   .:
@@ -16,7 +21,7 @@ importers:
         version: 1.2.0
       '@mariozechner/pi-coding-agent':
         specifier: ^0.67.68
-        version: 0.67.68(@modelcontextprotocol/sdk@1.29.0(zod@4.3.6))(ws@8.20.0)(zod@4.3.6)
+        version: 0.67.68(patch_hash=abb877a867e699ad24e2f72cb410d78bab73ece3c24663625133b61c0fbc513f)(@modelcontextprotocol/sdk@1.29.0(zod@4.3.6))(ws@8.20.0)(zod@4.3.6)
       '@mariozechner/pi-tui':
         specifier: ^0.67.68
         version: 0.67.68
@@ -2798,7 +2803,7 @@ snapshots:
       - ws
       - zod
 
-  '@mariozechner/pi-coding-agent@0.67.68(@modelcontextprotocol/sdk@1.29.0(zod@4.3.6))(ws@8.20.0)(zod@4.3.6)':
+  '@mariozechner/pi-coding-agent@0.67.68(patch_hash=abb877a867e699ad24e2f72cb410d78bab73ece3c24663625133b61c0fbc513f)(@modelcontextprotocol/sdk@1.29.0(zod@4.3.6))(ws@8.20.0)(zod@4.3.6)':
     dependencies:
       '@mariozechner/jiti': 2.6.5
       '@mariozechner/pi-agent-core': 0.67.68(@modelcontextprotocol/sdk@1.29.0(zod@4.3.6))(ws@8.20.0)(zod@4.3.6)

--- a/src/cc-discovery.test.ts
+++ b/src/cc-discovery.test.ts
@@ -1,0 +1,116 @@
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
+import { afterEach, beforeEach, describe, expect, it } from "vitest"
+import { discoverCcConfig } from "./cc-discovery.js"
+
+describe("discoverCcConfig", () => {
+	let tempDir: string
+	let configPath: string
+
+	beforeEach(() => {
+		tempDir = mkdtempSync(join(tmpdir(), "kimchi-cc-test-"))
+		configPath = join(tempDir, ".claude.json")
+	})
+
+	afterEach(() => {
+		rmSync(tempDir, { recursive: true, force: true })
+	})
+
+	function write(data: unknown) {
+		writeFileSync(configPath, JSON.stringify(data))
+	}
+
+	const cases: Record<string, { config: unknown; assert: (result: ReturnType<typeof discoverCcConfig>) => void }> = {
+		"server only at top-level is discovered": {
+			config: {
+				mcpServers: { github: { url: "https://api.github.com/mcp" } },
+			},
+			assert(result) {
+				expect(result.mcpServers.github).toMatchObject({ url: "https://api.github.com/mcp" })
+			},
+		},
+		"project-level entry wins over same-name top-level entry": {
+			config: {
+				projects: {
+					"/my/project": { mcpServers: { tool: { command: "project-tool" } } },
+				},
+				mcpServers: { tool: { command: "top-level-tool" } },
+			},
+			assert(result) {
+				expect(result.mcpServers.tool).toMatchObject({ command: "project-tool" })
+			},
+		},
+		"URL server with Authorization: Bearer sets auth bearer": {
+			config: {
+				mcpServers: {
+					svc: { url: "https://example.com/mcp", headers: { Authorization: "Bearer secret123" } },
+				},
+			},
+			assert(result) {
+				expect(result.mcpServers.svc).toMatchObject({ auth: "bearer" })
+			},
+		},
+		"URL server with authorization: bearer (lowercase) sets auth bearer": {
+			config: {
+				mcpServers: {
+					svc: { url: "https://example.com/mcp", headers: { authorization: "bearer secret123" } },
+				},
+			},
+			assert(result) {
+				expect(result.mcpServers.svc).toMatchObject({ auth: "bearer" })
+			},
+		},
+		"URL server with Authorization: Basic does not set auth": {
+			config: {
+				mcpServers: {
+					svc: { url: "https://example.com/mcp", headers: { Authorization: "Basic dXNlcjpwYXNz" } },
+				},
+			},
+			assert(result) {
+				expect(result.mcpServers.svc?.auth).toBeUndefined()
+			},
+		},
+		"URL server with no headers does not set auth": {
+			config: {
+				mcpServers: { svc: { url: "https://example.com/mcp" } },
+			},
+			assert(result) {
+				expect(result.mcpServers.svc?.auth).toBeUndefined()
+			},
+		},
+		"stdio server with Authorization header does not set auth": {
+			config: {
+				mcpServers: {
+					svc: { command: "my-tool", headers: { Authorization: "Bearer secret123" } },
+				},
+			},
+			assert(result) {
+				expect(result.mcpServers.svc?.auth).toBeUndefined()
+			},
+		},
+		"malformed entries (null, array, string) are skipped without crashing": {
+			config: {
+				mcpServers: {
+					bad1: null,
+					bad2: ["array"],
+					bad3: "string",
+					good: { command: "ok-tool" },
+				},
+			},
+			assert(result) {
+				expect(result.mcpServers.bad1).toBeUndefined()
+				expect(result.mcpServers.bad2).toBeUndefined()
+				expect(result.mcpServers.bad3).toBeUndefined()
+				expect(result.mcpServers.good).toMatchObject({ command: "ok-tool" })
+			},
+		},
+	}
+
+	for (const [name, tc] of Object.entries(cases)) {
+		it(name, () => {
+			write(tc.config)
+			tc.assert(discoverCcConfig(configPath))
+		})
+	}
+})

--- a/src/cc-discovery.ts
+++ b/src/cc-discovery.ts
@@ -49,32 +49,28 @@ function hasBearerAuthorizationHeader(headers: Record<string, string>): boolean 
 	)
 }
 
-export function discoverCcConfig(): CcDiscovery {
+function ingestServers(into: Record<string, ServerEntry>, source: unknown): void {
+	if (!source || typeof source !== "object" || Array.isArray(source)) return
+	for (const [name, def] of Object.entries(source as Record<string, unknown>)) {
+		if (into[name]) continue
+		if (def === null || typeof def !== "object" || Array.isArray(def)) continue
+		into[name] = transformServer(def as CcMcpServerRaw)
+	}
+}
+
+export function discoverCcConfig(configPath = CC_CONFIG_PATH): CcDiscovery {
 	const mcpServers: Record<string, ServerEntry> = {}
 
 	try {
-		const raw = JSON.parse(readFileSync(CC_CONFIG_PATH, "utf-8"))
+		const raw = JSON.parse(readFileSync(configPath, "utf-8"))
 		const projects = raw?.projects
 		if (projects && typeof projects === "object") {
 			for (const project of Object.values(projects)) {
-				const servers = (project as Record<string, unknown>)?.mcpServers
-				if (!servers || typeof servers !== "object") continue
-				for (const [name, def] of Object.entries(servers as Record<string, unknown>)) {
-					if (!mcpServers[name] && def !== null && typeof def === "object" && !Array.isArray(def)) {
-						mcpServers[name] = transformServer(def as CcMcpServerRaw)
-					}
-				}
+				ingestServers(mcpServers, (project as Record<string, unknown>)?.mcpServers)
 			}
 		}
 
-		const topLevel = raw?.mcpServers
-		if (topLevel && typeof topLevel === "object") {
-			for (const [name, def] of Object.entries(topLevel as Record<string, unknown>)) {
-				if (!mcpServers[name] && def !== null && typeof def === "object" && !Array.isArray(def)) {
-					mcpServers[name] = transformServer(def as CcMcpServerRaw)
-				}
-			}
-		}
+		ingestServers(mcpServers, raw?.mcpServers)
 	} catch (err) {
 		if ((err as NodeJS.ErrnoException).code !== "ENOENT") {
 			console.warn(`Failed to read Claude Code config: ${err instanceof Error ? err.message : String(err)}`)

--- a/src/cc-discovery.ts
+++ b/src/cc-discovery.ts
@@ -32,7 +32,14 @@ function transformServer(raw: CcMcpServerRaw): ServerEntry {
 	if (raw.url !== undefined) entry.url = raw.url
 	const headers = raw.headers ?? raw.header
 	if (headers !== undefined) entry.headers = headers
+	if (raw.url !== undefined && headers !== undefined && hasAuthorizationHeader(headers)) {
+		entry.auth = "bearer"
+	}
 	return entry
+}
+
+function hasAuthorizationHeader(headers: Record<string, string>): boolean {
+	return Object.keys(headers).some((k) => k.toLowerCase() === "authorization")
 }
 
 export function discoverCcConfig(): CcDiscovery {
@@ -49,6 +56,15 @@ export function discoverCcConfig(): CcDiscovery {
 					if (!mcpServers[name]) {
 						mcpServers[name] = transformServer(def)
 					}
+				}
+			}
+		}
+
+		const topLevel = raw?.mcpServers
+		if (topLevel && typeof topLevel === "object") {
+			for (const [name, def] of Object.entries(topLevel as Record<string, CcMcpServerRaw>)) {
+				if (!mcpServers[name]) {
+					mcpServers[name] = transformServer(def)
 				}
 			}
 		}

--- a/src/cc-discovery.ts
+++ b/src/cc-discovery.ts
@@ -32,14 +32,21 @@ function transformServer(raw: CcMcpServerRaw): ServerEntry {
 	if (raw.url !== undefined) entry.url = raw.url
 	const headers = raw.headers ?? raw.header
 	if (headers !== undefined) entry.headers = headers
-	if (raw.url !== undefined && headers !== undefined && hasAuthorizationHeader(headers)) {
+	if (
+		raw.url !== undefined &&
+		headers !== null &&
+		typeof headers === "object" &&
+		hasBearerAuthorizationHeader(headers)
+	) {
 		entry.auth = "bearer"
 	}
 	return entry
 }
 
-function hasAuthorizationHeader(headers: Record<string, string>): boolean {
-	return Object.keys(headers).some((k) => k.toLowerCase() === "authorization")
+function hasBearerAuthorizationHeader(headers: Record<string, string>): boolean {
+	return Object.entries(headers).some(
+		([k, v]) => k.toLowerCase() === "authorization" && typeof v === "string" && v.toLowerCase().startsWith("bearer "),
+	)
 }
 
 export function discoverCcConfig(): CcDiscovery {
@@ -52,9 +59,9 @@ export function discoverCcConfig(): CcDiscovery {
 			for (const project of Object.values(projects)) {
 				const servers = (project as Record<string, unknown>)?.mcpServers
 				if (!servers || typeof servers !== "object") continue
-				for (const [name, def] of Object.entries(servers as Record<string, CcMcpServerRaw>)) {
-					if (!mcpServers[name]) {
-						mcpServers[name] = transformServer(def)
+				for (const [name, def] of Object.entries(servers as Record<string, unknown>)) {
+					if (!mcpServers[name] && def !== null && typeof def === "object" && !Array.isArray(def)) {
+						mcpServers[name] = transformServer(def as CcMcpServerRaw)
 					}
 				}
 			}
@@ -62,9 +69,9 @@ export function discoverCcConfig(): CcDiscovery {
 
 		const topLevel = raw?.mcpServers
 		if (topLevel && typeof topLevel === "object") {
-			for (const [name, def] of Object.entries(topLevel as Record<string, CcMcpServerRaw>)) {
-				if (!mcpServers[name]) {
-					mcpServers[name] = transformServer(def)
+			for (const [name, def] of Object.entries(topLevel as Record<string, unknown>)) {
+				if (!mcpServers[name] && def !== null && typeof def === "object" && !Array.isArray(def)) {
+					mcpServers[name] = transformServer(def as CcMcpServerRaw)
 				}
 			}
 		}


### PR DESCRIPTION
## Problem

Two bugs in Claude Code config migration (`src/cc-discovery.ts`).

**Bug 1: top-level MCP servers ignored**

`~/.claude.json` stores MCP servers in two places:
- per-project: `projects["<path>"].mcpServers`
- global: top-level `mcpServers`

The migration only scanned the per-project entries. Any server configured at the top level (outside a specific project) was silently skipped.

**Bug 2: OAuth triggered for servers with static bearer tokens**

When a URL-based server was migrated, `auth` was left unset. Kimchi defaults to OAuth auto-detection for any URL-based server with no explicit `auth` field (`supportsOAuth` returns `true` when `definition.auth === undefined`).

On first connect, if the remote MCP server responds with `WWW-Authenticate`, the MCP SDK's `McpOAuthProvider` attempts dynamic client registration against the advertised auth server. Servers that only accept static tokens (e.g. `https://api.githubcopilot.com/mcp`) do not support dynamic client registration, causing:

```
Error: Failed to authenticate "github": Incompatible auth server: does not support dynamic client registration
```

The server only works after manually adding `"auth": "bearer"` to `mcp.json` and restarting.

## Root Cause

`transformServer()` copied `headers` from the Claude Code config but never inferred the appropriate `auth` mode. A server that already has a static `Authorization` header in Claude Code was clearly using bearer auth — there is no reason to attempt OAuth during migration.

## Fix

1. After scanning `projects[*].mcpServers`, also scan the top-level `mcpServers` key (project-level entries take precedence).

2. In `transformServer()`, if the server has a `url` and its `headers` include an `Authorization` key (case-insensitive), set `auth: "bearer"` automatically. This disables OAuth auto-detection and uses the static token directly, matching the intent of the original Claude Code configuration.

---
### Kimchi Summary
### What changed
Adds automatic discovery of MCP servers from Claude Code configuration (`.claude.json`), including support for Bearer token authentication detection. Also patches the upstream coding agent to recognize Kimchi-specific environment variables and model aliases.

### Key changes
- **`src/cc-discovery.ts`**: 
  - Adds Bearer authorization detection for URL-based MCP servers via `hasBearerAuthorizationHeader()`
  - Now ingests both project-level and top-level `mcpServers` entries (project-level takes precedence)
  - Adds `auth: "bearer"` property when `Authorization: Bearer` headers are detected
  - Refactors ingestion logic into `ingestServers()` helper and makes `configPath` parameter injectable for testing

- **`src/cc-discovery.test.ts`**: 
  - New comprehensive test suite covering project/top-level precedence, Bearer auth detection (case-insensitive), and malformed entry handling

- **`patches/@mariozechner__pi-coding-agent.patch`**:
  - Documents `KIMCHI_API_KEY` environment variable for auto-login
  - Maps `kimchi-dev` provider alias to `kimi-k2.5` model

- **`package.json`**: 
  - Configures `patchedDependencies` for `@mariozechner/pi-coding-agent`
  - Removes duplicate `"prepare": "husky"` script entry