### PR TITLE
NOJIRA: Add a local env startup script for ease of contribution

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,7 +162,21 @@ User: "Add user authentication"
 - [corepack](https://nodejs.org/api/corepack.html) enabled (`corepack enable`)
 - pnpm (installed automatically via corepack)
 
-### Setup
+### Quick Setup (Automated)
+
+Use the dev startup script to automatically set up the environment and start the harness:
+
+```bash
+./scripts/dev-startup.sh
+```
+
+This script will:
+- Check and install node, pnpm, and bun (if missing)
+- Install dependencies with `pnpm install`
+- Copy necessary resources
+- Start the harness with `pnpm run dev`
+
+### Manual Setup
 
 ```bash
 git clone git@github.com:castai/kimchi-dev.git

--- a/scripts/dev-startup.sh
+++ b/scripts/dev-startup.sh
@@ -1,0 +1,78 @@
+#!/bin/bash
+set -e
+
+# Colors for output
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+NC='\033[0m' # No Color
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(dirname "$SCRIPT_DIR")"
+
+cd "$PROJECT_ROOT"
+
+echo -e "${GREEN}🚀 Starting Kimchi dev environment setup...${NC}"
+
+# Check if Homebrew is installed
+if ! command -v brew &> /dev/null; then
+    echo -e "${YELLOW}⚠️  Homebrew not found. Please install Homebrew first:${NC}"
+    echo "   /bin/bash -c \"\$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)\""
+    exit 1
+fi
+
+# Install node and pnpm via brew (skip if already installed)
+echo -e "${GREEN}📦 Checking node and pnpm...${NC}"
+
+if ! command -v node &> /dev/null; then
+    echo -e "${YELLOW}   Installing node...${NC}"
+    brew install node
+else
+    echo -e "${GREEN}   ✓ node already installed ($(node --version))${NC}"
+fi
+
+if ! command -v pnpm &> /dev/null; then
+    echo -e "${YELLOW}   Installing pnpm...${NC}"
+    brew install pnpm
+else
+    echo -e "${GREEN}   ✓ pnpm already installed ($(pnpm --version))${NC}"
+fi
+
+# Install dependencies
+echo -e "${GREEN}📦 Installing dependencies with pnpm...${NC}"
+pnpm install
+
+# Install bun if not present
+echo -e "${GREEN}📦 Checking bun...${NC}"
+BUN_JUST_INSTALLED=false
+if ! command -v bun &> /dev/null; then
+    echo -e "${YELLOW}   Installing bun...${NC}"
+    curl -fsSL https://bun.sh/install | bash
+    BUN_JUST_INSTALLED=true
+else
+    echo -e "${GREEN}   ✓ bun already installed ($(bun --version))${NC}"
+fi
+
+# Always ensure bun is in PATH for this session
+export PATH="$HOME/.bun/bin:$PATH"
+
+# Copy resources
+echo -e "${GREEN}📂 Copying resources...${NC}"
+node ./scripts/copy-resources.js --dev
+
+# Start the harness
+echo -e "${GREEN}🎯 Starting Kimchi harness...${NC}"
+pnpm run dev
+
+# Remind user to add bun to shell profile if it was just installed
+if [ "$BUN_JUST_INSTALLED" = true ]; then
+    echo ""
+    echo -e "${YELLOW}⚠️  Important: bun was just installed. To use it in future terminal sessions,${NC}"
+    echo -e "${YELLOW}   add the following line to your shell profile:${NC}"
+    echo ""
+    echo -e "   ${GREEN}export PATH=\"\$HOME/.bun/bin:\$PATH\"${NC}"
+    echo ""
+    echo -e "   ${YELLOW}Shell profile locations:${NC}"
+    echo -e "   • bash: ~/.bashrc or ~/.bash_profile"
+    echo -e "   • zsh:  ~/.zshrc"
+fi


### PR DESCRIPTION


---
### Kimchi Summary
### What changed

Adds an automated development environment setup script (`scripts/dev-startup.sh`) that bootstraps required tooling and starts the Kimchi harness in a single step. Updates the README to feature this quick-start method alongside the existing manual instructions.

### Why

Reduces onboarding friction for new contributors by automating the installation of dependencies (node, pnpm, bun) and the initial resource setup.

### Key changes

- **Added `scripts/dev-startup.sh`**: Bash script that verifies Homebrew installation, installs `node` and `pnpm` via brew (if missing), installs `bun` via the official install script, runs `pnpm install`, copies resources via `node ./scripts/copy-resources.js`, and launches `pnpm run dev`
- **Updated `README.md`**: Replaced the single "Setup" section with separate "Quick Setup (Automated)" and "Manual Setup" sections, documenting the new `./scripts/dev-startup.sh` entry point

### Impact

The script requires Homebrew to be pre-installed. If `bun` is installed by the script, users must manually add `export PATH="$HOME/.bun/bin:$PATH"` to their shell profile for it to persist across terminal sessions (the script displays a reminder). No breaking changes to existing workflows.