### PR TITLE
NOJIRA: Reduce token consumption in multi-model orchestration

### DIFF
--- a/src/extensions/orchestration/prompt-enrichment.ts
+++ b/src/extensions/orchestration/prompt-enrichment.ts
@@ -219,7 +219,6 @@ export default function (skillPaths: string[]) {
 				}
 
 				const currentModel = ctx.model ? { id: ctx.model.id, name: ctx.model.id } : undefined
-				const enrichedPrompt = transformPrompt(event.text, registry, currentModel)
 
 				// Non-interactive (--print/--mode rpc) and debug-prompts mode: replace the user
 				// text inline. The "handled" + sendUserMessage path below relies on the TUI event
@@ -229,9 +228,13 @@ export default function (skillPaths: string[]) {
 				// caller's await session.prompt(enrichedPrompt) do the work synchronously.
 				const debugPrompts = pi.getFlag("debug-prompts") === true
 				if (debugPrompts || !ctx.hasUI) {
+					const enrichedPrompt = transformPrompt(event.text, registry, currentModel)
 					return { action: "transform" as const, text: enrichedPrompt, images: event.images }
 				}
 
+				// In UI mode the original user message is sent separately via sendUserMessage,
+				// so the task text must not be duplicated inside the enriched-prompt header.
+				const enrichedPrompt = transformPrompt(event.text, registry, currentModel, false)
 				pi.sendMessage(
 					{ customType: "enriched-prompt", content: [{ type: "text", text: enrichedPrompt }], display: false },
 					{ deliverAs: "nextTurn" },

--- a/src/extensions/orchestration/prompt-enrichment.ts
+++ b/src/extensions/orchestration/prompt-enrichment.ts
@@ -35,6 +35,7 @@ import {
 	EMPTY_TURN_NUDGE_TEXT,
 	EmptyTurnNudge,
 	NUDGE_CUSTOM_TYPE,
+	type OrchestratorMessages,
 	stripStaleNudges,
 } from "./continuation-nudge.js"
 import { ModelRegistry } from "./model-registry/index.js"
@@ -103,6 +104,28 @@ function readMultiModelArgv(): boolean {
 }
 
 let multiModelEnabled = readMultiModelArgv()
+
+const ENRICHED_PROMPT_CUSTOM_TYPE = "enriched-prompt"
+
+function deduplicateEnrichedPrompts(messages: OrchestratorMessages): OrchestratorMessages {
+	const lastIdx = messages.findLastIndex(
+		(m) =>
+			m.role === "custom" &&
+			"customType" in m &&
+			(m as { customType: string }).customType === ENRICHED_PROMPT_CUSTOM_TYPE,
+	)
+	if (lastIdx === -1) return messages
+	const filtered = messages.filter(
+		(m, i) =>
+			i === lastIdx ||
+			!(
+				m.role === "custom" &&
+				"customType" in m &&
+				(m as { customType: string }).customType === ENRICHED_PROMPT_CUSTOM_TYPE
+			),
+	)
+	return filtered.length === messages.length ? messages : filtered
+}
 
 export function getMultiModelEnabled(): boolean {
 	return multiModelEnabled
@@ -236,7 +259,11 @@ export default function (skillPaths: string[]) {
 				// so the task text must not be duplicated inside the enriched-prompt header.
 				const enrichedPrompt = transformPrompt(event.text, registry, currentModel, false)
 				pi.sendMessage(
-					{ customType: "enriched-prompt", content: [{ type: "text", text: enrichedPrompt }], display: false },
+					{
+						customType: ENRICHED_PROMPT_CUSTOM_TYPE,
+						content: [{ type: "text", text: enrichedPrompt }],
+						display: false,
+					},
 					{ deliverAs: "nextTurn" },
 				)
 				const userContent: (TextContent | ImageContent)[] = [{ type: "text", text: event.text }]
@@ -247,8 +274,9 @@ export default function (skillPaths: string[]) {
 			})
 
 			pi.on("context", async (event) => {
-				const cleaned = stripStaleNudges(event.messages)
-				if (cleaned !== event.messages) return { messages: cleaned }
+				let messages = stripStaleNudges(event.messages)
+				messages = deduplicateEnrichedPrompts(messages)
+				if (messages !== event.messages) return { messages }
 			})
 		}
 

--- a/src/extensions/orchestration/prompt-transformer/prompt-transformer.ts
+++ b/src/extensions/orchestration/prompt-transformer/prompt-transformer.ts
@@ -5,7 +5,7 @@ import type { ContextFile } from "./context-files.js"
 import systemPromptTemplate from "./prompts/orchestrator-system-prompt.js"
 import singleModelSystemPromptTemplate from "./prompts/single-model-system-prompt.js"
 import subagentSystemPromptTemplate from "./prompts/subagent-system-prompt.js"
-import userPromptTemplate from "./prompts/transformed-user-prompt.js"
+import { userPromptHeader, userPromptTaskSection } from "./prompts/transformed-user-prompt.js"
 
 export interface EnvironmentInfo {
 	os: string
@@ -78,10 +78,7 @@ export function transformPrompt(
 		? formatCurrentModelCapabilities(currentDescriptor)
 		: "No capability information available for this model."
 
-	let template = userPromptTemplate
-	if (!includeTask) {
-		template = template.replace(/\n## Task\n\n\{\{USER_PROMPT\}\}\n?$/, "")
-	}
+	const template = includeTask ? userPromptHeader + userPromptTaskSection : userPromptHeader
 
 	return template
 		.replace("{{CURRENT_MODEL_NAME}}", () => currentModelName)

--- a/src/extensions/orchestration/prompt-transformer/prompt-transformer.ts
+++ b/src/extensions/orchestration/prompt-transformer/prompt-transformer.ts
@@ -58,7 +58,12 @@ export interface CurrentModelInfo {
 	name: string
 }
 
-export function transformPrompt(userPrompt: string, registry: ModelRegistry, currentModel?: CurrentModelInfo): string {
+export function transformPrompt(
+	userPrompt: string,
+	registry: ModelRegistry,
+	currentModel?: CurrentModelInfo,
+	includeTask = true,
+): string {
 	const subagentModels = registry.getModelsWithCapabilities().filter((m) => m.id !== currentModel?.id)
 	const modelsSection = formatModelsSection(subagentModels)
 
@@ -73,7 +78,12 @@ export function transformPrompt(userPrompt: string, registry: ModelRegistry, cur
 		? formatCurrentModelCapabilities(currentDescriptor)
 		: "No capability information available for this model."
 
-	return userPromptTemplate
+	let template = userPromptTemplate
+	if (!includeTask) {
+		template = template.replace(/\n## Task\n\n\{\{USER_PROMPT\}\}\n?$/, "")
+	}
+
+	return template
 		.replace("{{CURRENT_MODEL_NAME}}", () => currentModelName)
 		.replace("{{CURRENT_MODEL_CAPABILITIES}}", () => currentModelCapabilities)
 		.replace("{{MODELS}}", () => modelsSection)

--- a/src/extensions/orchestration/prompt-transformer/prompts/orchestrator-system-prompt.ts
+++ b/src/extensions/orchestration/prompt-transformer/prompts/orchestrator-system-prompt.ts
@@ -48,7 +48,8 @@ Run the steps in order. For steps you own, use your tools directly. For steps yo
 - Write subagent prompts that are fully self-contained. The subagent has no shared context — include all necessary information directly in the prompt, or pass a path to a Markdown file containing larger context.
 - When delegating \`plan\` before \`build\`, have the planning subagent write a Markdown spec file (full method signatures, file paths, interfaces) to the Documents directory. Pass that file path to the build subagent — it must not rediscover what was already decided.
 - Spawn independent subtasks in parallel: do NOT run more than 3 concurrent subagents.
-- After a subagent returns, review the output. If corrections are needed, spawn a follow-up with the correction task.
+- After a subagent returns, read the output file it wrote to the Documents directory — do not rely on the inline tool result text for decisions. The tool result is a short status signal; the file is the source of truth.
+- After reading the output file, if corrections are needed, spawn a follow-up with the correction task.
 - Do NOT spawn a subagent for work you can do in a single tool call.
 - Every file the subagent needs must go in the \`attachments\` field — never paste file contents or \`@path\` tokens into the prompt. The subagent sees each attachment as an image or file block before your prompt; refer to them by name.
 
@@ -70,7 +71,14 @@ Include a \`tokenBudget\` for every subagent call:
 - Complex multi-layer architecture or large codebase exploration: 500,000 tokens
 - Research or design tasks producing a design document: 200,000 tokens
 
-If a subagent hits its budget, spawn a follow-up with the remaining work rather than raising the budget.`,
+If a subagent hits its budget, spawn a follow-up with the remaining work rather than raising the budget.
+
+## Inactivity timeout
+
+By default subagents are killed after 3 minutes of silence. For steps where a thinking-heavy model may reason silently before producing output, set \`inactivityTimeoutMs\` explicitly:
+
+- \`plan\` or \`research\` delegated to a heavy model: 600000 (10 minutes)
+- \`build\` or \`review\`: omit (default is sufficient)`,
 	TOOLS_SECTION,
 	DOCUMENTS_SECTION,
 	RESEARCH_RULES,

--- a/src/extensions/orchestration/prompt-transformer/prompts/orchestrator-system-prompt.ts
+++ b/src/extensions/orchestration/prompt-transformer/prompts/orchestrator-system-prompt.ts
@@ -75,8 +75,9 @@ If a subagent hits its budget, spawn a follow-up with the remaining work rather 
 
 ## Inactivity timeout
 
-By default subagents are killed after 3 minutes of silence. For steps where a thinking-heavy model may reason silently before producing output, set \`inactivityTimeoutMs\` explicitly:
+By default subagents are killed after 3 minutes of silence. For steps where a model may reason silently or perform extensive file I/O before producing output, set \`inactivityTimeoutMs\` explicitly:
 
+- \`explore\` on a large codebase: 300000 (5 minutes)
 - \`plan\` or \`research\` delegated to a heavy model: 600000 (10 minutes)
 - \`build\` or \`review\`: omit (default is sufficient)`,
 	TOOLS_SECTION,

--- a/src/extensions/orchestration/prompt-transformer/prompts/orchestrator-system-prompt.ts
+++ b/src/extensions/orchestration/prompt-transformer/prompts/orchestrator-system-prompt.ts
@@ -48,8 +48,7 @@ Run the steps in order. For steps you own, use your tools directly. For steps yo
 - Write subagent prompts that are fully self-contained. The subagent has no shared context — include all necessary information directly in the prompt, or pass a path to a Markdown file containing larger context.
 - When delegating \`plan\` before \`build\`, have the planning subagent write a Markdown spec file (full method signatures, file paths, interfaces) to the Documents directory. Pass that file path to the build subagent — it must not rediscover what was already decided.
 - Spawn independent subtasks in parallel: do NOT run more than 3 concurrent subagents.
-- After a subagent returns, read the output file it wrote to the Documents directory — do not rely on the inline tool result text for decisions. The tool result is a short status signal; the file is the source of truth.
-- After reading the output file, if corrections are needed, spawn a follow-up with the correction task.
+- After a subagent returns, check the \`Files:\` line in the tool result. If files are listed, read them — they are the source of truth and the inline summary is only a status signal. If no files are listed, the summary is the complete result. Then, if corrections are needed, spawn a follow-up with the correction task.
 - Do NOT spawn a subagent for work you can do in a single tool call.
 - Every file the subagent needs must go in the \`attachments\` field — never paste file contents or \`@path\` tokens into the prompt. The subagent sees each attachment as an image or file block before your prompt; refer to them by name.
 

--- a/src/extensions/orchestration/prompt-transformer/prompts/shared.ts
+++ b/src/extensions/orchestration/prompt-transformer/prompts/shared.ts
@@ -22,6 +22,15 @@ export const DOCUMENTS_SECTION = `## Documents
 
 The Documents directory is shown in the Environment section. Use it for **all** intermediate and output files: plans, specs, research notes, findings, or any file passed between agents. Never write working documents to the project directory or a temporary directory.`
 
+export const SUBAGENT_RESPONSE_PROTOCOL = `## Subagent response protocol
+
+When you finish your work, your final response to the orchestrator must follow this format:
+
+1. Write all substantive output (plans, specs, research notes, findings) to a file in the Documents directory.
+2. Return a concise summary — at most 5 sentences — covering: what was done, the exact path of every file written, and any critical decisions or blockers the orchestrator must know about.
+
+Do NOT return file contents, code blocks, or lengthy explanations inline. The orchestrator will read the files from disk. Inline text beyond the short summary is wasted tokens.`
+
 export const PHASE_TAGGING = `## Phase Tagging for Analytics
 
 You must call \`set_phase\` before every block of work. Never take an action without the correct phase being set first. Use one of \`explore\`, \`research\`, \`plan\`, \`build\`, or \`review\` strictly matching current work type.

--- a/src/extensions/orchestration/prompt-transformer/prompts/shared.ts
+++ b/src/extensions/orchestration/prompt-transformer/prompts/shared.ts
@@ -24,12 +24,16 @@ The Documents directory is shown in the Environment section. Use it for **all** 
 
 export const SUBAGENT_RESPONSE_PROTOCOL = `## Subagent response protocol
 
-When you finish your work, your final response must follow this format:
+Your final response must be a single JSON object with no other text before or after it:
 
-1. Write all substantive output (plans, specs, research notes, findings) to a file in the Documents directory.
-2. Return a concise summary — at most 5 sentences — covering: what was done, the exact path of every file written, and any critical decisions or blockers the caller must know about.
+\`\`\`
+{"summary": "...", "files": ["path1", "path2"]}
+\`\`\`
 
-Do NOT return file contents, code blocks, or lengthy explanations inline. The caller will read the files from disk. Inline text beyond the short summary is wasted tokens.`
+- \`summary\`: one paragraph (at most 5 sentences) covering what was done, any critical decisions, and any blockers.
+- \`files\`: array of absolute paths to every file written to the Documents directory. Empty array if none.
+
+Write all substantive output (plans, specs, research notes, findings) to files in the Documents directory — never inline in the summary. Do NOT add any text before or after the JSON. Do NOT wrap it in a markdown code fence.`
 
 export const PHASE_TAGGING = `## Phase Tagging for Analytics
 

--- a/src/extensions/orchestration/prompt-transformer/prompts/shared.ts
+++ b/src/extensions/orchestration/prompt-transformer/prompts/shared.ts
@@ -24,12 +24,12 @@ The Documents directory is shown in the Environment section. Use it for **all** 
 
 export const SUBAGENT_RESPONSE_PROTOCOL = `## Subagent response protocol
 
-When you finish your work, your final response to the orchestrator must follow this format:
+When you finish your work, your final response must follow this format:
 
 1. Write all substantive output (plans, specs, research notes, findings) to a file in the Documents directory.
-2. Return a concise summary — at most 5 sentences — covering: what was done, the exact path of every file written, and any critical decisions or blockers the orchestrator must know about.
+2. Return a concise summary — at most 5 sentences — covering: what was done, the exact path of every file written, and any critical decisions or blockers the caller must know about.
 
-Do NOT return file contents, code blocks, or lengthy explanations inline. The orchestrator will read the files from disk. Inline text beyond the short summary is wasted tokens.`
+Do NOT return file contents, code blocks, or lengthy explanations inline. The caller will read the files from disk. Inline text beyond the short summary is wasted tokens.`
 
 export const PHASE_TAGGING = `## Phase Tagging for Analytics
 

--- a/src/extensions/orchestration/prompt-transformer/prompts/subagent-system-prompt.ts
+++ b/src/extensions/orchestration/prompt-transformer/prompts/subagent-system-prompt.ts
@@ -1,4 +1,4 @@
-import { CORE_GUIDELINES, DOCUMENTS_SECTION, FOOTER, TOOLS_SECTION } from "./shared.js"
+import { CORE_GUIDELINES, DOCUMENTS_SECTION, FOOTER, SUBAGENT_RESPONSE_PROTOCOL, TOOLS_SECTION } from "./shared.js"
 
 export default [
 	`You are an expert coding assistant. You operate inside a coding agent harness. Use only the tools listed under **Available Tools** below — never guess or invent tool names.
@@ -6,6 +6,7 @@ export default [
 {{ENVIRONMENT}}`,
 	TOOLS_SECTION,
 	DOCUMENTS_SECTION,
+	SUBAGENT_RESPONSE_PROTOCOL,
 	`## Guidelines
 
 ${CORE_GUIDELINES}

--- a/src/extensions/orchestration/prompt-transformer/prompts/transformed-user-prompt.ts
+++ b/src/extensions/orchestration/prompt-transformer/prompts/transformed-user-prompt.ts
@@ -1,4 +1,4 @@
-export default `## Your Capabilities
+export const userPromptHeader = `## Your Capabilities
 
 You are **{{CURRENT_MODEL_NAME}}**.
 
@@ -38,9 +38,6 @@ All models (including yourself) are described with the following attributes:
 
 ## Available Models
 
-{{MODELS}}
+{{MODELS}}`
 
-## Task
-
-{{USER_PROMPT}}
-`
+export const userPromptTaskSection = "\n\n## Task\n\n{{USER_PROMPT}}"

--- a/src/extensions/subagent.test.ts
+++ b/src/extensions/subagent.test.ts
@@ -4,10 +4,12 @@ import { join, resolve } from "node:path"
 import { CURRENT_SESSION_VERSION } from "@mariozechner/pi-coding-agent"
 import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it } from "vitest"
 import {
+	RESULT_MAX_CHARS,
 	buildSubagentArgs,
 	parseSubagentEvent,
 	parseSubagentResponse,
 	prepareChildSessionFile,
+	truncateSubagentResult,
 	validateAttachments,
 } from "./subagent.js"
 
@@ -419,6 +421,59 @@ describe("parseSubagentResponse", () => {
 	for (const [name, { input, expected }] of Object.entries(cases)) {
 		it(name, () => {
 			expect(parseSubagentResponse(input)).toEqual(expected)
+		})
+	}
+})
+
+describe("truncateSubagentResult", () => {
+	const cases: Record<
+		string,
+		{ text: string; sessionFile: string | undefined; expectTruncated: boolean; expectSessionRef: boolean }
+	> = {
+		"returns text unchanged when under limit": {
+			text: "short output",
+			sessionFile: undefined,
+			expectTruncated: false,
+			expectSessionRef: false,
+		},
+		"returns text unchanged at exact limit": {
+			text: "x".repeat(RESULT_MAX_CHARS),
+			sessionFile: undefined,
+			expectTruncated: false,
+			expectSessionRef: false,
+		},
+		"truncates text one character over limit": {
+			text: "x".repeat(RESULT_MAX_CHARS + 1),
+			sessionFile: undefined,
+			expectTruncated: true,
+			expectSessionRef: false,
+		},
+		"truncates and includes session file reference when provided": {
+			text: "x".repeat(RESULT_MAX_CHARS + 100),
+			sessionFile: "/sessions/child.jsonl",
+			expectTruncated: true,
+			expectSessionRef: true,
+		},
+		"handles empty string": {
+			text: "",
+			sessionFile: undefined,
+			expectTruncated: false,
+			expectSessionRef: false,
+		},
+	}
+
+	for (const [name, { text, sessionFile, expectTruncated, expectSessionRef }] of Object.entries(cases)) {
+		it(name, () => {
+			const result = truncateSubagentResult(text, sessionFile)
+			if (expectTruncated) {
+				expect(result).toContain("[Output truncated")
+				expect(result.length).toBeLessThanOrEqual(RESULT_MAX_CHARS + 200)
+			} else {
+				expect(result).toBe(text)
+			}
+			if (expectSessionRef) {
+				expect(result).toContain(sessionFile)
+			}
 		})
 	}
 })

--- a/src/extensions/subagent.test.ts
+++ b/src/extensions/subagent.test.ts
@@ -3,7 +3,13 @@ import { tmpdir } from "node:os"
 import { join, resolve } from "node:path"
 import { CURRENT_SESSION_VERSION } from "@mariozechner/pi-coding-agent"
 import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it } from "vitest"
-import { buildSubagentArgs, parseSubagentEvent, prepareChildSessionFile, validateAttachments } from "./subagent.js"
+import {
+	buildSubagentArgs,
+	parseSubagentEvent,
+	parseSubagentResponse,
+	prepareChildSessionFile,
+	validateAttachments,
+} from "./subagent.js"
 
 describe("parseSubagentEvent", () => {
 	const cases: Record<
@@ -364,4 +370,55 @@ describe("prepareChildSessionFile", () => {
 		const ids = Array.from({ length: 8 }, () => prepareChildSessionFile(tmp, parentFile, "/work/dir")?.sessionId)
 		expect(new Set(ids).size).toBe(ids.length)
 	})
+})
+
+describe("parseSubagentResponse", () => {
+	const cases: Record<string, { input: string; expected: { summary: string; files: string[] } | null }> = {
+		"parses clean JSON": {
+			input: '{"summary": "Done.", "files": ["/docs/plan.md"]}',
+			expected: { summary: "Done.", files: ["/docs/plan.md"] },
+		},
+		"parses JSON with no files": {
+			input: '{"summary": "Task complete.", "files": []}',
+			expected: { summary: "Task complete.", files: [] },
+		},
+		"parses JSON missing files field": {
+			input: '{"summary": "Done."}',
+			expected: { summary: "Done.", files: [] },
+		},
+		"parses JSON wrapped in code fence": {
+			input: '```json\n{"summary": "Done.", "files": ["/docs/out.md"]}\n```',
+			expected: { summary: "Done.", files: ["/docs/out.md"] },
+		},
+		"parses JSON wrapped in plain code fence": {
+			input: '```\n{"summary": "Done.", "files": []}\n```',
+			expected: { summary: "Done.", files: [] },
+		},
+		"parses JSON with leading preamble": {
+			input: 'Here is my response:\n\n{"summary": "Done.", "files": ["/docs/out.md"]}',
+			expected: { summary: "Done.", files: ["/docs/out.md"] },
+		},
+		"filters out non-string file entries": {
+			input: '{"summary": "Done.", "files": ["/docs/a.md", 42, null, "/docs/b.md"]}',
+			expected: { summary: "Done.", files: ["/docs/a.md", "/docs/b.md"] },
+		},
+		"returns null for plain text": {
+			input: "I completed the task successfully.",
+			expected: null,
+		},
+		"returns null for JSON without summary": {
+			input: '{"result": "done", "files": []}',
+			expected: null,
+		},
+		"returns null for empty string": {
+			input: "",
+			expected: null,
+		},
+	}
+
+	for (const [name, { input, expected }] of Object.entries(cases)) {
+		it(name, () => {
+			expect(parseSubagentResponse(input)).toEqual(expected)
+		})
+	}
 })

--- a/src/extensions/subagent.test.ts
+++ b/src/extensions/subagent.test.ts
@@ -466,8 +466,13 @@ describe("truncateSubagentResult", () => {
 		it(name, () => {
 			const result = truncateSubagentResult(text, sessionFile)
 			if (expectTruncated) {
-				expect(result).toContain("[Output truncated")
+				expect(result).toContain("[… middle elided")
+				// head + elision notice + tail should stay within ~RESULT_MAX_CHARS + small overhead
 				expect(result.length).toBeLessThanOrEqual(RESULT_MAX_CHARS + 200)
+				// both the start and end of the original text are preserved
+				const half = Math.floor(RESULT_MAX_CHARS / 2)
+				expect(result).toContain(text.slice(0, half))
+				expect(result).toContain(text.slice(-half))
 			} else {
 				expect(result).toBe(text)
 			}

--- a/src/extensions/subagent.ts
+++ b/src/extensions/subagent.ts
@@ -35,7 +35,7 @@ export function getActiveSubagentCount(): number {
 }
 const STDERR_MAX = 8192
 const TIMEOUT_MS = 30 * 60 * 1000
-const INACTIVITY_TIMEOUT_MS = 60 * 1000
+const INACTIVITY_TIMEOUT_MS = 3 * 60 * 1000
 const CHECKPOINT_END_TYPE = "subagent-end"
 const RECOVERY_MESSAGE_TYPE = "subagent-recovery"
 const INTERRUPTED_MESSAGE_TYPE = "subagent-interrupted"

--- a/src/extensions/subagent.ts
+++ b/src/extensions/subagent.ts
@@ -23,7 +23,7 @@ import { type SpinnerState, clearSpinner, spinnerFrame, tickSpinner } from "./sp
 
 const PROMPT_MAX_LENGTH = 60
 const FOOTER_STATUS_KEY = "subagent-sessions"
-const RESULT_MAX_CHARS = 8000
+export const RESULT_MAX_CHARS = 8000
 
 let activeSessionCounts: Map<string, number> | null = null
 
@@ -510,7 +510,7 @@ function truncatePrompt(prompt: string): string {
 	return `${prompt.slice(0, PROMPT_MAX_LENGTH)}...`
 }
 
-function truncateSubagentResult(text: string, sessionFile: string | undefined): string {
+export function truncateSubagentResult(text: string, sessionFile: string | undefined): string {
 	if (text.length <= RESULT_MAX_CHARS) return text
 	const tail = text.slice(-RESULT_MAX_CHARS)
 	const sessionRef = sessionFile ? ` Full output in: ${sessionFile}` : ""
@@ -557,7 +557,7 @@ const SubagentParams = Type.Object({
 		}),
 	),
 	inactivityTimeoutMs: Type.Optional(
-		Type.Union([Type.Integer({ minimum: 1000 }), Type.String({ pattern: "^[1-9][0-9]*$" })], {
+		Type.Union([Type.Integer({ minimum: 1000 }), Type.String({ pattern: "^[1-9][0-9]{3,}$" })], {
 			description:
 				"Milliseconds of silence before the subagent is killed with output_stalled. Defaults to 3 minutes. Increase for planning or research steps where a thinking-heavy model may reason silently for an extended period before producing output.",
 		}),

--- a/src/extensions/subagent.ts
+++ b/src/extensions/subagent.ts
@@ -512,9 +512,11 @@ function truncatePrompt(prompt: string): string {
 
 export function truncateSubagentResult(text: string, sessionFile: string | undefined): string {
 	if (text.length <= RESULT_MAX_CHARS) return text
-	const tail = text.slice(-RESULT_MAX_CHARS)
+	const half = Math.floor(RESULT_MAX_CHARS / 2)
+	const head = text.slice(0, half)
+	const tail = text.slice(-half)
 	const sessionRef = sessionFile ? ` Full output in: ${sessionFile}` : ""
-	return `[Output truncated — showing last ${RESULT_MAX_CHARS} characters.${sessionRef}]\n\n${tail}`
+	return `${head}\n\n[… middle elided.${sessionRef}]\n\n${tail}`
 }
 
 function formatFooterStatus(counts: Map<string, number>, theme: Theme): string {

--- a/src/extensions/subagent.ts
+++ b/src/extensions/subagent.ts
@@ -459,6 +459,52 @@ function spawnSubagent(
 	})
 }
 
+interface SubagentResponse {
+	summary: string
+	files: string[]
+}
+
+export function parseSubagentResponse(text: string): SubagentResponse | null {
+	const trimmed = text.trim()
+
+	const tryParse = (s: string): SubagentResponse | null => {
+		try {
+			const parsed = JSON.parse(s)
+			if (typeof parsed?.summary === "string") {
+				return {
+					summary: parsed.summary,
+					files: Array.isArray(parsed.files)
+						? (parsed.files as unknown[]).filter((f): f is string => typeof f === "string")
+						: [],
+				}
+			}
+		} catch {
+			// fall through
+		}
+		return null
+	}
+
+	const direct = tryParse(trimmed)
+	if (direct !== null) return direct
+
+	const fenceMatch = trimmed.match(/```(?:json)?\s*\n([\s\S]*?)\n```/)
+	if (fenceMatch) {
+		const fromFence = tryParse(fenceMatch[1].trim())
+		if (fromFence !== null) return fromFence
+	}
+
+	const lastClose = trimmed.lastIndexOf("}")
+	if (lastClose !== -1) {
+		const firstOpen = trimmed.lastIndexOf("{", lastClose)
+		if (firstOpen !== -1) {
+			const fromBlock = tryParse(trimmed.slice(firstOpen, lastClose + 1))
+			if (fromBlock !== null) return fromBlock
+		}
+	}
+
+	return null
+}
+
 function truncatePrompt(prompt: string): string {
 	if (prompt.length <= PROMPT_MAX_LENGTH) return prompt
 	return `${prompt.slice(0, PROMPT_MAX_LENGTH)}...`
@@ -692,13 +738,22 @@ export default function (pi: ExtensionAPI) {
 
 			const resultText =
 				(hideThinkingBlock ? filterOutputTags(accumulated) : stripOutputTagWrappers(accumulated)) || "(no output)"
+			const parsed = parseSubagentResponse(resultText)
+			if (parsed === null) {
+				return {
+					content: [
+						{
+							type: "text",
+							text: `Protocol violation: subagent response is not valid JSON.\n\nRaw output:\n\n${truncateSubagentResult(resultText, childSessionFile)}`,
+						},
+					],
+					details: stats,
+					isError: true,
+				}
+			}
+			const filesLine = parsed.files.length > 0 ? `\nFiles: ${parsed.files.join(", ")}` : ""
 			return {
-				content: [
-					{
-						type: "text",
-						text: truncateSubagentResult(resultText, childSessionFile),
-					},
-				],
+				content: [{ type: "text", text: `${parsed.summary}${filesLine}` }],
 				details: stats,
 			}
 		},

--- a/src/extensions/subagent.ts
+++ b/src/extensions/subagent.ts
@@ -23,6 +23,7 @@ import { type SpinnerState, clearSpinner, spinnerFrame, tickSpinner } from "./sp
 
 const PROMPT_MAX_LENGTH = 60
 const FOOTER_STATUS_KEY = "subagent-sessions"
+const RESULT_MAX_CHARS = 8000
 
 let activeSessionCounts: Map<string, number> | null = null
 
@@ -319,6 +320,7 @@ function spawnSubagent(
 	cwd: string,
 	signal: AbortSignal | undefined,
 	tokenBudget: number | undefined,
+	inactivityTimeoutMs: number,
 	hideThinkingBlock: boolean,
 	onToken: (accumulated: string) => void,
 	onToolCall: (name: string, args: Record<string, unknown>, accumulated: string) => void,
@@ -349,11 +351,11 @@ function spawnSubagent(
 		let failureReason: SubagentFailureReason | undefined
 		let closed = false
 
-		let inactivityHandle = setTimeout(() => kill("output_stalled"), INACTIVITY_TIMEOUT_MS)
+		let inactivityHandle = setTimeout(() => kill("output_stalled"), inactivityTimeoutMs)
 		const resetInactivity = () => {
 			if (closed) return
 			clearTimeout(inactivityHandle)
-			inactivityHandle = setTimeout(() => kill("output_stalled"), INACTIVITY_TIMEOUT_MS)
+			inactivityHandle = setTimeout(() => kill("output_stalled"), inactivityTimeoutMs)
 		}
 
 		const finish = (exitCode: number) => {
@@ -462,6 +464,13 @@ function truncatePrompt(prompt: string): string {
 	return `${prompt.slice(0, PROMPT_MAX_LENGTH)}...`
 }
 
+function truncateSubagentResult(text: string, sessionFile: string | undefined): string {
+	if (text.length <= RESULT_MAX_CHARS) return text
+	const tail = text.slice(-RESULT_MAX_CHARS)
+	const sessionRef = sessionFile ? ` Full output in: ${sessionFile}` : ""
+	return `[Output truncated — showing last ${RESULT_MAX_CHARS} characters.${sessionRef}]\n\n${tail}`
+}
+
 function formatFooterStatus(counts: Map<string, number>, theme: Theme): string {
 	const entries = [...counts.entries()].map(([model, n]) => `${model} [${n}]`).join(" | ")
 	return theme.fg("dim", `subagents: ${entries}`)
@@ -499,6 +508,12 @@ const SubagentParams = Type.Object({
 		Type.Union([Type.Integer({ minimum: 1 }), Type.String({ pattern: "^[1-9][0-9]*$" })], {
 			description:
 				"Maximum total tokens (input + output) the subagent may consume. Subagent is killed when exceeded. Omit unless you have an explicit reason to cap token usage — do not set this speculatively.",
+		}),
+	),
+	inactivityTimeoutMs: Type.Optional(
+		Type.Union([Type.Integer({ minimum: 1000 }), Type.String({ pattern: "^[1-9][0-9]*$" })], {
+			description:
+				"Milliseconds of silence before the subagent is killed with output_stalled. Defaults to 3 minutes. Increase for planning or research steps where a thinking-heavy model may reason silently for an extended period before producing output.",
 		}),
 	),
 })
@@ -622,12 +637,15 @@ export default function (pi: ExtensionAPI) {
 
 			let lastToolCall: string | undefined
 			const tokenBudget = params.tokenBudget !== undefined ? Number(params.tokenBudget) : undefined
+			const inactivityTimeoutMs =
+				params.inactivityTimeoutMs !== undefined ? Number(params.inactivityTimeoutMs) : INACTIVITY_TIMEOUT_MS
 			const hideThinkingBlock = settingsManager.getHideThinkingBlock()
 			const { exitCode, accumulated, stderr, tokenUsage, failureReason, durationMs } = await spawnSubagent(
 				invocation,
 				ctx.cwd,
 				signal,
 				tokenBudget,
+				inactivityTimeoutMs,
 				hideThinkingBlock,
 				(text) => {
 					lastToolCall = undefined
@@ -657,12 +675,13 @@ export default function (pi: ExtensionAPI) {
 			const stats: SubagentStats = { durationMs, tokenUsage, sessionId, sessionFile: childSessionFile }
 
 			if (failureReason !== undefined || exitCode !== 0) {
+				const rawDetail = stderr.trim() || accumulated || "(no output)"
 				const error: SubagentError = {
 					reason: failureReason ?? "exit_error",
 					model: params.model,
 					tokenUsage,
 					durationMs,
-					detail: stderr.trim() || accumulated || "(no output)",
+					detail: truncateSubagentResult(rawDetail, childSessionFile),
 				}
 				return {
 					content: [{ type: "text", text: JSON.stringify(error) }],
@@ -671,13 +690,13 @@ export default function (pi: ExtensionAPI) {
 				}
 			}
 
+			const resultText =
+				(hideThinkingBlock ? filterOutputTags(accumulated) : stripOutputTagWrappers(accumulated)) || "(no output)"
 			return {
 				content: [
 					{
 						type: "text",
-						text:
-							(hideThinkingBlock ? filterOutputTags(accumulated) : stripOutputTagWrappers(accumulated)) ||
-							"(no output)",
+						text: truncateSubagentResult(resultText, childSessionFile),
 					},
 				],
 				details: stats,


### PR DESCRIPTION
## Problem

Benchmarking multi-model sessions revealed patterns that caused runaway token consumption in the orchestrator context: task prompts duplicated on every turn, verbatim subagent output flooding context, subagents killed too early and retried repeatedly, and no enforcement keeping inter-agent communication concise.

## Changes

### Stop duplicating the task prompt on every turn

In UI mode, the enriched-prompt header included the full user task under a `## Task` section while the original user message was also sent separately — placing the task text in the LLM context twice on every orchestrator turn. The fix scopes `includeTask = false` to the UI path only; the non-UI/`--print` path is unchanged. The template is now split into `userPromptHeader` and `userPromptTaskSection` exports, removing the fragile regex that previously stripped the section.

### Cap subagent result size returned to orchestrator

The full accumulated subagent output was returned verbatim as the tool result. In complex sessions this produced blobs large enough to spike the orchestrator input by 30,000+ tokens in a single step, with compounding growth across all subsequent turns. Both success and error return paths now cap at 8,000 characters, keeping the tail of the output. A truncation notice with the full session file path is prepended when the cap applies.

### Fix inactivity timeout default and add per-call override

The default inactivity timeout constant was 60 seconds but the orchestrator prompt stated 3 minutes — causing premature subagent kills and retry loops that wasted tokens. The constant is aligned to 3 minutes. A new optional `inactivityTimeoutMs` parameter on the subagent tool lets the caller override for steps that need more time. The orchestrator prompt now instructs: 5 minutes for `explore` on large codebases, 10 minutes for `plan`/`research` with heavy models.

### Enforce structured JSON responses from subagents

Subagents returning verbose inline prose caused the orchestrator to base decisions on large text blobs rather than reading the Documents files written by the subagent. Subagents are now required to return a single JSON object `{"summary": "...", "files": [...]}` with no other text. The `parseSubagentResponse` function validates the response with three fallback strategies (direct parse, code-fence extraction, last-block extraction). A non-compliant response returns `isError: true` with a protocol violation message, signalling the orchestrator to retry rather than silently consuming the verbose output.

---
### Kimchi Summary
### What changed
Deduplicates orchestrator prompt enrichment messages to prevent token accumulation, enforces a structured JSON response protocol for subagents (`{"summary": "...", "files": [...]}`), and adds configurable inactivity timeouts for long-running reasoning tasks.

### Why
Accumulated enriched-prompt headers and duplicated task text in UI mode were inflating token usage. Free-form subagent outputs required manual parsing to identify output files. The previous 60-second inactivity timeout terminated planning and research tasks prematurely during silent reasoning periods.

### Key changes
- `prompt-enrichment.ts`: Adds `deduplicateEnrichedPrompts()` to retain only the latest enriched-prompt message; avoids duplicating task text in UI mode by passing `includeTask: false` to `transformPrompt()`.
- `prompt-transformer/prompts/transformed-user-prompt.ts`: Exports `userPromptHeader` and `userPromptTaskSection` separately to allow conditional inclusion of the task section.
- `shared.ts`: Introduces `SUBAGENT_RESPONSE_PROTOCOL` defining the required JSON schema for subagent final responses.
- `subagent.ts`: Implements `parseSubagentResponse()` to extract structured output; adds `truncateSubagentResult()` enforcing 8000-character limit with session file reference; changes default `INACTIVITY_TIMEOUT_MS` to 3 minutes and exposes `inactivityTimeoutMs` parameter.
- `orchestrator-system-prompt.ts`: Updates guidance to check the `Files:` line in tool results (files are source of truth) and adds inactivity timeout recommendations for different workflow steps.

### Impact
- **Breaking**: Subagents must return valid JSON matching `{"summary": string, "files": string[]}` or receive a protocol violation error. Plain text responses are no longer accepted.
- Subagent results exceeding 8000 characters are truncated with a pointer to the full session file.