### PR TITLE
LLM-1387: PR1 — rename binary to `kimchi` and add subcommand dispatcher

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -27,7 +27,7 @@ body:
       description: |
         A one-liner that reproduces the issue. Pin the model with `--provider` and `--model` for consistency.
       placeholder: |
-        kimchi-code -p "your prompt here" --provider kimchi-dev --model kimi-k2.5
+        kimchi -p "your prompt here" --provider kimchi-dev --model kimi-k2.5
       render: shell
     validations:
       required: true
@@ -36,7 +36,7 @@ body:
     id: version
     attributes:
       label: Harness version
-      description: Output of `kimchi-code --version`
+      description: Output of `kimchi --version`
       placeholder: "0.5.0"
     validations:
       required: true
@@ -46,7 +46,7 @@ body:
     attributes:
       label: Session file
       description: |
-        If the bug occurred during an interactive session, paste the session file path. You can also export it to HTML for easier sharing: `kimchi-code --export <path-to-session.jsonl>`
+        If the bug occurred during an interactive session, paste the session file path. You can also export it to HTML for easier sharing: `kimchi --export <path-to-session.jsonl>`
       placeholder: ~/.config/kimchi/harness/sessions/--path--/session.jsonl
     validations:
       required: false
@@ -58,7 +58,7 @@ body:
       description: |
         Optional. Re-run your reproduction command with `--mode json --no-session` to capture a machine-readable event trace:
         ```
-        kimchi-code --mode json -p "your prompt" --no-session --provider kimchi-dev --model kimi-k2.5 > events.jsonl
+        kimchi --mode json -p "your prompt" --no-session --provider kimchi-dev --model kimi-k2.5 > events.jsonl
         ```
         Paste the contents or attach the file.
       render: json

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -66,13 +66,13 @@ jobs:
         run: pnpm run build:binary
 
       - name: Package binary
-        run: tar -czf kimchi-code_${{ matrix.os }}_${{ matrix.arch }}.tar.gz -C dist bin share
+        run: tar -czf kimchi_${{ matrix.os }}_${{ matrix.arch }}.tar.gz -C dist bin share
 
       - name: Upload artifact
         uses: actions/upload-artifact@v4
         with:
-          name: kimchi-code_${{ matrix.os }}_${{ matrix.arch }}
-          path: kimchi-code_${{ matrix.os }}_${{ matrix.arch }}.tar.gz
+          name: kimchi_${{ matrix.os }}_${{ matrix.arch }}
+          path: kimchi_${{ matrix.os }}_${{ matrix.arch }}.tar.gz
 
   smoke-test:
     needs: [build]
@@ -88,12 +88,12 @@ jobs:
       - name: Download linux binary
         uses: actions/download-artifact@v4
         with:
-          name: kimchi-code_linux_amd64
+          name: kimchi_linux_amd64
 
       - name: Extract binary into dist/
         run: |
           mkdir -p dist
-          tar -xzf kimchi-code_linux_amd64.tar.gz -C dist
+          tar -xzf kimchi_linux_amd64.tar.gz -C dist
 
       - name: Smoke tests
         run: pnpm run test:smoke
@@ -112,12 +112,12 @@ jobs:
       - name: Generate checksums
         run: |
           cd artifacts
-          sha256sum kimchi-code_*.tar.gz > checksums.txt
+          sha256sum kimchi_*.tar.gz > checksums.txt
 
       - name: Create GitHub release
         uses: softprops/action-gh-release@153bb8e04406b158c6c84fc1615b65b24149a1fe # v2
         with:
           files: |
-            artifacts/kimchi-code_*.tar.gz
+            artifacts/kimchi_*.tar.gz
             artifacts/checksums.txt
           generate_release_notes: true

--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,9 @@ Thumbs.db
 
 # Test coverage
 coverage/
+
+# Local merge-planning scratch (kimchi CLI repo + pi-mono source for reference)
+kimchi-cli-copy/
+kimchi-cli-src
+pi-mono-copy/
+pi-mono-src

--- a/README.md
+++ b/README.md
@@ -1,31 +1,29 @@
-# kimchi-code
+# kimchi
 
-A coding agent CLI powered by [kimchi-dev](https://github.com/castai/kimchi-dev). Built on the [pi-mono](https://github.com/badlogic/pi-mono) coding agent SDK, kimchi-code gives you an AI-powered development assistant in your terminal that connects to kimchi-dev's LLM infrastructure.
+A coding agent CLI powered by [kimchi-dev](https://github.com/castai/kimchi-dev). Built on the [pi-mono](https://github.com/badlogic/pi-mono) coding agent SDK, kimchi gives you an AI-powered development assistant in your terminal that connects to kimchi-dev's LLM infrastructure.
 
 ## Quick start
-
-The easiest way to use kimchi-code is through the `kimchi` CLI, which handles downloading and launching the agent automatically:
 
 ```bash
 kimchi
 ```
 
-You can also run `kimchi-code` directly if it's on your PATH.
+Run `kimchi --help` to see all available subcommands and flags.
 
 ## Configuration
 
 ### Authentication
 
-kimchi-code shares authentication with the `kimchi` CLI. The API key is resolved in this order:
+The API key is resolved in this order:
 
 1. `KIMCHI_API_KEY` environment variable (takes precedence)
 2. `~/.config/kimchi/config.json` field `api_key`
 
-If you're already logged in via `kimchi`, no additional setup is needed.
+Run `kimchi setup` for an interactive first-time configuration.
 
 ### Agent config
 
-kimchi-code stores its own configuration (settings, sessions, models) under:
+kimchi stores its own configuration (settings, sessions, models) under:
 
 ```
 ~/.config/kimchi/harness/
@@ -39,12 +37,12 @@ Use `/model` in the interactive CLI to switch between available models.
 
 ### Multi-model orchestration
 
-By default, kimchi-code runs in multi-model mode: the main agent classifies each task, executes what it can directly, and delegates the rest to specialised subagents picked from the available model roster.
+By default, kimchi runs in multi-model mode: the main agent classifies each task, executes what it can directly, and delegates the rest to specialised subagents picked from the available model roster.
 
 To disable orchestration and run as a single, direct coding assistant:
 
 ```bash
-kimchi-code --multi-model=false
+kimchi --multi-model=false
 ```
 
 You can also toggle the mode at any time during a session with the **option/alt+tab** keyboard shortcut. The current state is shown in the footer (`multi-model: on` / `multi-model: off`).
@@ -53,7 +51,7 @@ When multi-model is off the agent uses a single-model system prompt: environment
 
 ### HTTP proxy
 
-kimchi-code respects `HTTP_PROXY` / `HTTPS_PROXY` environment variables for network requests.
+kimchi respects `HTTP_PROXY` / `HTTPS_PROXY` environment variables for network requests.
 
 ### Subagent sessions
 
@@ -63,7 +61,7 @@ This means subagent runs are fully recoverable from disk: open the parent's `.js
 
 ## Tags
 
-kimchi-code supports tagging LLM requests for usage tracking and cost attribution. Tags are automatically included with every LLM request and displayed in the footer of the interactive UI.
+kimchi supports tagging LLM requests for usage tracking and cost attribution. Tags are automatically included with every LLM request and displayed in the footer of the interactive UI.
 
 ### Commands
 
@@ -114,7 +112,7 @@ Active tags are displayed in the footer, grouped by key with color coding for vi
 
 A `model:{model_id}` tag is automatically added to every LLM request (e.g., `model:kimi-k2.5`). This tag does not count toward the 10 tag limit and cannot be removed.
 
-A `phase:{phase}` tag is automatically added since kimchi-code supports phase tracking for usage analytics and cost attribution. Phases represent the high-level type of work being done (exploration, planning, building, reviewing, or researching).
+A `phase:{phase}` tag is automatically added since kimchi supports phase tracking for usage analytics and cost attribution. Phases represent the high-level type of work being done (exploration, planning, building, reviewing, or researching).
 
 ### Available phases
 
@@ -213,7 +211,7 @@ Or build a standalone binary and run it:
 
 ```bash
 pnpm run build:binary
-./dist/kimchi-code
+./dist/bin/kimchi
 ```
 
 ### Project structure
@@ -237,7 +235,7 @@ Supported platforms:
 - macOS (amd64, arm64)
 - Linux (amd64, arm64)
 
-Release assets follow the naming convention `kimchi-code_{os}_{arch}.tar.gz` with a `checksums.txt` (SHA256) for verification.
+Release assets follow the naming convention `kimchi_{os}_{arch}.tar.gz` with a `checksums.txt` (SHA256) for verification.
 
 ## License
 

--- a/docs/permissions.md
+++ b/docs/permissions.md
@@ -1,6 +1,6 @@
 # Permissions
 
-kimchi-code gates every tool call through a three-mode permission system.
+kimchi gates every tool call through a three-mode permission system.
 Switch modes at any time with **`shift+tab`** or `/permissions mode <name>`.
 
 ## Modes

--- a/docs/sandboxing.md
+++ b/docs/sandboxing.md
@@ -9,7 +9,7 @@ pnpm run build:binary-linux-arm64   # Apple Silicon (M1/M2/M3/M4)
 pnpm run build:binary-linux-x64     # Intel Mac or x86-64 Linux host
 ```
 
-Then start the sandbox from the kimchi-dev directory so `dist/kimchi-code` is available inside it.
+Then start the sandbox from the kimchi-dev directory so `dist/kimchi` is available inside it.
 
 Only your working directory and its subdirectories are shared with the host — everything else (`/tmp`, home directory, system paths) lives inside the sandbox. The network is proxied — HTTP/HTTPS goes through a policy-controlled proxy, non-HTTP protocols (raw TCP, UDP) are blocked entirely. The first run pulls the sandbox image and takes a while — subsequent runs start in seconds.
 
@@ -23,8 +23,8 @@ Both steps run in the same terminal:
 # 1. Create a named sandbox (shell = agent type, . = workspace to mount)
 docker sandbox create --name kimchi-sandbox shell .
 
-# 2. Launch kimchi-code with the API key (-w sets the working directory to the mounted workspace)
-docker sandbox exec -it -e KIMCHI_API_KEY -w "$(pwd)" kimchi-sandbox ./dist/kimchi-code --provider kimchi-dev --model kimi-k2.5
+# 2. Launch kimchi with the API key (-w sets the working directory to the mounted workspace)
+docker sandbox exec -it -e KIMCHI_API_KEY -w "$(pwd)" kimchi-sandbox ./dist/kimchi --provider kimchi-dev --model kimi-k2.5
 ```
 
 ### Run — create and enter a sandbox in one step
@@ -46,8 +46,8 @@ docker sandbox create --name kimchi-sandbox shell .
 Only `exec` supports forwarding host environment variables with `-e`:
 
 ```sh
-# Forward KIMCHI_API_KEY from the host and run kimchi-code
-docker sandbox exec -it -e KIMCHI_API_KEY -w "$(pwd)" kimchi-sandbox ./dist/kimchi-code -p "your prompt"
+# Forward KIMCHI_API_KEY from the host and run kimchi
+docker sandbox exec -it -e KIMCHI_API_KEY -w "$(pwd)" kimchi-sandbox ./dist/kimchi -p "your prompt"
 
 # Interactive shell with the API key available
 docker sandbox exec -it -e KIMCHI_API_KEY -w "$(pwd)" kimchi-sandbox bash

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -4,32 +4,32 @@
 
 ```sh
 # One-liner repro — pin provider/model, skip session state for a clean slate
-kimchi-code -p "your prompt" --no-session --provider kimchi-dev --model kimi-k2.5
+kimchi -p "your prompt" --no-session --provider kimchi-dev --model kimi-k2.5
 ```
 
 ## Diagnostic output
 
 ```sh
 # Machine-readable event stream (tool calls, responses, errors)
-kimchi-code --mode json -p "your prompt" --no-session --provider kimchi-dev --model kimi-k2.5 > events.jsonl
+kimchi --mode json -p "your prompt" --no-session --provider kimchi-dev --model kimi-k2.5 > events.jsonl
 
 # Full enriched prompt after orchestration
-kimchi-code -p "your prompt" --debug-prompts --provider kimchi-dev --model kimi-k2.5
+kimchi -p "your prompt" --debug-prompts --provider kimchi-dev --model kimi-k2.5
 
 # Startup diagnostics and model scope
-kimchi-code --verbose -p "your prompt" --provider kimchi-dev --model kimi-k2.5
+kimchi --verbose -p "your prompt" --provider kimchi-dev --model kimi-k2.5
 ```
 
 ## Isolating the problem
 
 ```sh
 # Disable extensions / skills / prompt templates
-kimchi-code -p "your prompt" --no-extensions --provider kimchi-dev --model kimi-k2.5
-kimchi-code -p "your prompt" --no-skills --provider kimchi-dev --model kimi-k2.5
+kimchi -p "your prompt" --no-extensions --provider kimchi-dev --model kimi-k2.5
+kimchi -p "your prompt" --no-skills --provider kimchi-dev --model kimi-k2.5
 
 # Restrict tools (available: read, bash, edit, write, grep, find, ls)
-kimchi-code -p "your prompt" --tools read,bash --provider kimchi-dev --model kimi-k2.5
-kimchi-code -p "your prompt" --no-tools --provider kimchi-dev --model kimi-k2.5
+kimchi -p "your prompt" --tools read,bash --provider kimchi-dev --model kimi-k2.5
+kimchi -p "your prompt" --no-tools --provider kimchi-dev --model kimi-k2.5
 ```
 
 ## Sessions
@@ -37,16 +37,16 @@ kimchi-code -p "your prompt" --no-tools --provider kimchi-dev --model kimi-k2.5
 Session files live at `~/.config/kimchi/harness/sessions/<encoded-cwd>/<session-id>.jsonl`.
 
 ```sh
-kimchi-code --continue                  # resume most recent session
-kimchi-code --session <path-or-prefix>  # resume a specific session
-kimchi-code --resume                    # browse past sessions interactively
-kimchi-code --export session.jsonl output.html  # export session to HTML
+kimchi --continue                  # resume most recent session
+kimchi --session <path-or-prefix>  # resume a specific session
+kimchi --resume                    # browse past sessions interactively
+kimchi --export session.jsonl output.html  # export session to HTML
 ```
 
 ## Quick reference
 
 ```sh
-kimchi-code --list-models        # list all available models
-kimchi-code --list-models kimi   # search for a model
-kimchi-code --version
+kimchi --list-models        # list all available models
+kimchi --list-models kimi   # search for a model
+kimchi --version
 ```

--- a/package.json
+++ b/package.json
@@ -1,11 +1,11 @@
 {
 	"name": "@kimchi-dev/cli",
 	"version": "0.1.0",
-	"description": "kimchi-code — a coding agent CLI powered by Cast AI",
+	"description": "kimchi — a coding agent CLI powered by Cast AI",
 	"type": "module",
 	"license": "MIT",
 	"bin": {
-		"kimchi-code": "src/entry.ts"
+		"kimchi": "src/entry.ts"
 	},
 	"scripts": {
 		"clean": "rm -rf dist",

--- a/package.json
+++ b/package.json
@@ -22,8 +22,7 @@
 		"test": "vitest run --dir src",
 		"test:smoke": "vitest run --config tests/smoke/vitest.config.ts",
 		"prepare": "husky",
-		"verify": "pnpm run check && pnpm run build:binary && pnpm run test && pnpm run test:smoke",
-		"prepare": "husky"
+		"verify": "pnpm run check && pnpm run build:binary && pnpm run test && pnpm run test:smoke"
 	},
 	"piConfig": {
 		"name": "kimchi",

--- a/scripts/build-binary.js
+++ b/scripts/build-binary.js
@@ -38,15 +38,15 @@ run("typecheck", "pnpm run typecheck")
 const targetFlag = crossTarget ? ` --target=${crossTarget}` : ""
 run(
 	"compile",
-	`bun build src/entry.ts --compile${targetFlag} --outfile dist/bin/kimchi-code --external chromium-bidi --external electron`,
+	`bun build src/entry.ts --compile${targetFlag} --outfile dist/bin/kimchi --external chromium-bidi --external electron`,
 )
 
 // Bun --compile produces binaries with an invalid code signature on macOS.
 // The kernel kills badly-signed arm64 binaries immediately (SIGKILL, exit 137).
 // Strip the corrupt signature and re-sign ad-hoc. See: https://github.com/oven-sh/bun/issues/7208
 if (!isCrossCompile && platform() === "darwin") {
-	run("codesign (strip)", "codesign --remove-signature dist/bin/kimchi-code")
-	run("codesign (ad-hoc)", "codesign -s - dist/bin/kimchi-code")
+	run("codesign (strip)", "codesign --remove-signature dist/bin/kimchi")
+	run("codesign (ad-hoc)", "codesign -s - dist/bin/kimchi")
 }
 
 run("copy resources", "node scripts/copy-resources.js")

--- a/scripts/install-local.js
+++ b/scripts/install-local.js
@@ -9,11 +9,11 @@ import { dirname, join } from "node:path"
 import { fileURLToPath } from "node:url"
 
 const projectRoot = join(dirname(fileURLToPath(import.meta.url)), "..")
-const distBin = join(projectRoot, "dist", "bin", "kimchi-code")
+const distBin = join(projectRoot, "dist", "bin", "kimchi")
 const distShare = join(projectRoot, "dist", "share", "kimchi")
 
 if (!existsSync(distBin)) {
-	console.error("dist/bin/kimchi-code not found — run `pnpm run build:binary` first.")
+	console.error("dist/bin/kimchi not found — run `pnpm run build:binary` first.")
 	process.exit(1)
 }
 if (!existsSync(distShare)) {
@@ -26,9 +26,9 @@ const binDest = join(prefix, "bin")
 const shareDest = join(prefix, "share", "kimchi")
 
 mkdirSync(binDest, { recursive: true })
-cpSync(distBin, join(binDest, "kimchi-code"))
+cpSync(distBin, join(binDest, "kimchi"))
 
 cpSync(distShare, shareDest, { recursive: true })
 
-console.log(`Installed binary  → ${join(binDest, "kimchi-code")}`)
+console.log(`Installed binary  → ${join(binDest, "kimchi")}`)
 console.log(`Installed share   → ${shareDest}`)

--- a/scripts/verify-acp.mjs
+++ b/scripts/verify-acp.mjs
@@ -7,7 +7,7 @@ import { Readable, Writable } from "node:stream"
 import { setTimeout as delay } from "node:timers/promises"
 import * as acp from "@agentclientprotocol/sdk"
 
-const binary = process.argv[2] ?? "./dist/kimchi-code"
+const binary = process.argv[2] ?? "./dist/bin/kimchi"
 
 class Client {
 	chunksBySession = new Map()

--- a/src/auxiliary-files/resolver.test.ts
+++ b/src/auxiliary-files/resolver.test.ts
@@ -53,7 +53,7 @@ describe("resolveAuxiliaryFilesDir", () => {
 
 		beforeEach(() => {
 			tmpBase = join(tmpdir(), `kimchi-resolver-test-${process.pid}`)
-			// Simulate dist/bin/kimchi-code + dist/share/kimchi/package.json
+			// Simulate dist/bin/kimchi + dist/share/kimchi/package.json
 			mkdirSync(join(tmpBase, "bin"), { recursive: true })
 			mkdirSync(join(tmpBase, "share", "kimchi"), { recursive: true })
 			writeFileSync(join(tmpBase, "share", "kimchi", "package.json"), "{}")
@@ -64,20 +64,20 @@ describe("resolveAuxiliaryFilesDir", () => {
 		})
 
 		it("returns sibling share dir when package.json exists next to the binary", () => {
-			const execPath = join(tmpBase, "bin", "kimchi-code")
+			const execPath = join(tmpBase, "bin", "kimchi")
 			const env: Record<string, string | undefined> = {}
 			expect(resolveAuxiliaryFilesDir(env, home, execPath)).toBe(join(tmpBase, "share", "kimchi"))
 		})
 
 		it("PI_PACKAGE_DIR takes precedence over sibling share dir", () => {
-			const execPath = join(tmpBase, "bin", "kimchi-code")
+			const execPath = join(tmpBase, "bin", "kimchi")
 			const env = { PI_PACKAGE_DIR: "/custom/path" }
 			expect(resolveAuxiliaryFilesDir(env, home, execPath)).toBe("/custom/path")
 		})
 
 		it("falls through to XDG when sibling share dir has no package.json", () => {
 			rmSync(join(tmpBase, "share", "kimchi", "package.json"))
-			const execPath = join(tmpBase, "bin", "kimchi-code")
+			const execPath = join(tmpBase, "bin", "kimchi")
 			const env = { XDG_DATA_HOME: "/xdg/data" }
 			expect(resolveAuxiliaryFilesDir(env, home, execPath)).toBe("/xdg/data/kimchi")
 		})

--- a/src/auxiliary-files/resolver.ts
+++ b/src/auxiliary-files/resolver.ts
@@ -10,7 +10,7 @@ export function resolveAuxiliaryFilesDir(
 		return env.PI_PACKAGE_DIR
 	}
 
-	// When running as a compiled binary (dist/bin/kimchi-code), share files
+	// When running as a compiled binary (dist/bin/kimchi), share files
 	// live at ../share/kimchi relative to the binary.
 	if (execPath) {
 		const siblingShare = join(execPath, "..", "..", "share", "kimchi")

--- a/src/auxiliary-files/validator.ts
+++ b/src/auxiliary-files/validator.ts
@@ -4,7 +4,7 @@ import { join } from "node:path"
 const REQUIRED_THEME_FILES = ["dark.json", "light.json"]
 
 function recoveryHint(dir: string): string {
-	return `\n\nExpected layout in ${dir}:\n  package.json\n  theme/dark.json\n  theme/light.json\n\nIf kimchi-code is installed elsewhere, set PI_PACKAGE_DIR to point to the correct directory.`
+	return `\n\nExpected layout in ${dir}:\n  package.json\n  theme/dark.json\n  theme/light.json\n\nIf kimchi is installed elsewhere, set PI_PACKAGE_DIR to point to the correct directory.`
 }
 
 export function validateAuxiliaryFiles(dir: string): void {

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -51,7 +51,7 @@ const helpOrVersion = isHelpOrVersionArgs(process.argv.slice(2))
 
 process.on("exit", (code) => {
 	if (code === 0 && !acpMode) {
-		const resumeCmd = sessionId ? `kimchi-code --session ${sessionId}` : "kimchi-code --continue"
+		const resumeCmd = sessionId ? `kimchi --session ${sessionId}` : "kimchi --continue"
 		console.log(`\nTo resume: ${resumeCmd}`)
 	}
 })

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -5,6 +5,7 @@ import { mkdirSync, readFileSync, writeFileSync } from "node:fs"
 import { dirname, resolve } from "node:path"
 import { fileURLToPath } from "node:url"
 import type { ExtensionAPI, ExtensionContext } from "@mariozechner/pi-coding-agent"
+import { dispatchSubcommand } from "./commands/dispatch.js"
 import {
 	DEFAULT_SKILL_PATHS,
 	loadConfig,
@@ -42,6 +43,7 @@ import { getVersion } from "./utils.js"
 const telemetryConfig = readTelemetryConfig()
 
 let sessionId: string | undefined
+let sessionStarted = false
 // ACP mode runs JSON-RPC over stdio; the "To resume:" print (even remapped to
 // stderr via console.log = console.error inside runAcpMode) is noise in IDE
 // logs and not actionable — the IDE owns session continuation. Decide once,
@@ -50,7 +52,13 @@ const acpMode = isAcpMode(process.argv.slice(2))
 const helpOrVersion = isHelpOrVersionArgs(process.argv.slice(2))
 
 process.on("exit", (code) => {
-	if (code === 0 && !acpMode) {
+	// Only print the resume hint after a real harness session ran. Subcommands
+	// (kimchi setup, kimchi version, …) and --help/--version short-circuit
+	// before any session starts, so sessionId stays undefined and we keep
+	// quiet. The non-resume case (sessionId still undefined after main exits)
+	// is preserved by checking whether session capture had a chance to run —
+	// done by the harness path setting sessionStarted = true below.
+	if (code === 0 && !acpMode && sessionStarted) {
 		const resumeCmd = sessionId ? `kimchi --session ${sessionId}` : "kimchi --continue"
 		console.log(`\nTo resume: ${resumeCmd}`)
 	}
@@ -86,10 +94,24 @@ function isAcpMode(args: string[]): boolean {
 }
 
 try {
+	// Top-level kimchi subcommands (setup, claude, opencode, …) and the merged
+	// --help take ownership before any harness setup runs. `--version` falls
+	// through to pi-coding-agent's main below so it prints the version using
+	// piConfig.name = "kimchi".
+	const dispatch = await dispatchSubcommand(process.argv.slice(2))
+	if (dispatch.kind === "handled") {
+		process.exit(dispatch.exitCode)
+	}
+
 	if (helpOrVersion) {
 		const { main } = await import("@mariozechner/pi-coding-agent")
 		await main(process.argv.slice(2), { extensionFactories: [] })
 	} else {
+		// We're entering the harness/ACP path. Subcommands and --help/--version
+		// short-circuit above without ever reaching here, which is why the exit
+		// hook keys off this flag instead of just running unconditionally on a
+		// 0-status exit.
+		sessionStarted = true
 		let config = loadConfig()
 
 		const envKey = process.env.KIMCHI_API_KEY || undefined

--- a/src/commands/_stub.ts
+++ b/src/commands/_stub.ts
@@ -1,0 +1,11 @@
+/**
+ * Placeholder used by command handlers that are wired into the dispatcher
+ * but not yet implemented. Lets us land the dispatcher (PR1) without the
+ * integration ports (PR2) or self-update (PR3). Replaced as each command
+ * gets a real implementation.
+ */
+export async function notYetImplemented(name: string): Promise<number> {
+	console.error(`kimchi ${name}: not implemented yet on this branch.`)
+	console.error("The dispatcher is wired up; the command logic lands in a follow-up.")
+	return 1
+}

--- a/src/commands/claude.ts
+++ b/src/commands/claude.ts
@@ -1,0 +1,5 @@
+import { notYetImplemented } from "./_stub.js"
+
+export async function runClaude(_args: string[]): Promise<number> {
+	return notYetImplemented("claude")
+}

--- a/src/commands/config.ts
+++ b/src/commands/config.ts
@@ -1,0 +1,5 @@
+import { notYetImplemented } from "./_stub.js"
+
+export async function runConfig(_args: string[]): Promise<number> {
+	return notYetImplemented("config")
+}

--- a/src/commands/cursor.ts
+++ b/src/commands/cursor.ts
@@ -1,0 +1,5 @@
+import { notYetImplemented } from "./_stub.js"
+
+export async function runCursor(_args: string[]): Promise<number> {
+	return notYetImplemented("cursor")
+}

--- a/src/commands/dispatch.test.ts
+++ b/src/commands/dispatch.test.ts
@@ -1,0 +1,65 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
+import { dispatchSubcommand } from "./dispatch.js"
+
+describe("dispatchSubcommand", () => {
+	let logSpy: ReturnType<typeof vi.spyOn>
+	let errSpy: ReturnType<typeof vi.spyOn>
+
+	beforeEach(() => {
+		logSpy = vi.spyOn(console, "log").mockImplementation(() => {})
+		errSpy = vi.spyOn(console, "error").mockImplementation(() => {})
+	})
+
+	afterEach(() => {
+		logSpy.mockRestore()
+		errSpy.mockRestore()
+	})
+
+	it("runs the version subcommand and returns its exit code", async () => {
+		const result = await dispatchSubcommand(["version"])
+		expect(result).toEqual({ kind: "handled", exitCode: 0 })
+		expect(logSpy).toHaveBeenCalled()
+	})
+
+	it("falls through when no args are given", async () => {
+		const result = await dispatchSubcommand([])
+		expect(result).toEqual({ kind: "fallthrough" })
+	})
+
+	it("falls through when the first arg is an unknown subcommand", async () => {
+		const result = await dispatchSubcommand(["definitely-not-a-command"])
+		expect(result).toEqual({ kind: "fallthrough" })
+	})
+
+	it("falls through for harness flags so pi parses them", async () => {
+		const result = await dispatchSubcommand(["--provider", "kimchi-dev", "--model", "kimi-k2.5"])
+		expect(result).toEqual({ kind: "fallthrough" })
+	})
+
+	it("falls through for --version (pi prints it)", async () => {
+		const result = await dispatchSubcommand(["--version"])
+		expect(result).toEqual({ kind: "fallthrough" })
+	})
+
+	it("handles --help by printing the merged help via pi", async () => {
+		// printMergedHelp dynamically imports pi-coding-agent which calls
+		// process.exit(0) inside its main(). That's hostile to a unit test —
+		// we'd kill vitest. Instead, verify dispatch picks the help branch by
+		// looking at the first subcommand name path: passing "version --help"
+		// routes to the subcommand, not the merged renderer, which proves the
+		// dispatch order is right.
+		const result = await dispatchSubcommand(["version", "--help"])
+		expect(result.kind).toBe("handled")
+	})
+
+	it("each known subcommand stub prints its own marker and returns 1", async () => {
+		const stubs = ["setup", "claude", "opencode", "cursor", "openclaw", "gsd2", "update", "config"]
+		for (const name of stubs) {
+			errSpy.mockClear()
+			const result = await dispatchSubcommand([name])
+			expect(result).toEqual({ kind: "handled", exitCode: 1 })
+			const first = errSpy.mock.calls[0]?.[0] as string | undefined
+			expect(first).toContain(`kimchi ${name}: not implemented yet`)
+		}
+	})
+})

--- a/src/commands/dispatch.test.ts
+++ b/src/commands/dispatch.test.ts
@@ -41,15 +41,34 @@ describe("dispatchSubcommand", () => {
 		expect(result).toEqual({ kind: "fallthrough" })
 	})
 
-	it("handles --help by printing the merged help via pi", async () => {
-		// printMergedHelp dynamically imports pi-coding-agent which calls
-		// process.exit(0) inside its main(). That's hostile to a unit test —
-		// we'd kill vitest. Instead, verify dispatch picks the help branch by
-		// looking at the first subcommand name path: passing "version --help"
-		// routes to the subcommand, not the merged renderer, which proves the
-		// dispatch order is right.
+	it("handles --help by printing the merged help text", async () => {
+		const result = await dispatchSubcommand(["--help"])
+		expect(result).toEqual({ kind: "handled", exitCode: 0 })
+
+		const printed = logSpy.mock.calls.map((c) => String(c[0] ?? "")).join("\n")
+		// Sections we expect from the custom renderer
+		expect(printed).toContain("Subcommands:")
+		expect(printed).toContain("kimchi setup")
+		expect(printed).toContain("kimchi claude")
+		expect(printed).toContain("Harness flags")
+		expect(printed).toContain("--provider")
+		expect(printed).toContain("--mode")
+		expect(printed).toContain("Environment variables:")
+		expect(printed).toContain("KIMCHI_API_KEY")
+		// Pi-internal commands must NOT leak into kimchi's help (we no longer
+		// delegate to pi.main for the lower section).
+		expect(printed).not.toContain("install <source>")
+		expect(printed).not.toContain("ANTHROPIC_API_KEY")
+	})
+
+	it("subcommand context wins over a trailing --help", async () => {
 		const result = await dispatchSubcommand(["version", "--help"])
 		expect(result.kind).toBe("handled")
+		// The version handler ran (printed something to stdout) rather than
+		// the merged help renderer. Either way is "handled", but checking
+		// stdout for the version banner confirms the dispatch order.
+		const printed = logSpy.mock.calls.map((c) => String(c[0] ?? "")).join("\n")
+		expect(printed).toMatch(/^kimchi \d+\.\d+\.\d+/m)
 	})
 
 	it("each known subcommand stub prints its own marker and returns 1", async () => {

--- a/src/commands/dispatch.ts
+++ b/src/commands/dispatch.ts
@@ -1,0 +1,40 @@
+import { printMergedHelp } from "./help.js"
+import { findCommand, isKnownCommand } from "./registry.js"
+
+export type DispatchResult = { kind: "handled"; exitCode: number } | { kind: "fallthrough" }
+
+/**
+ * Decide whether a top-level kimchi subcommand handles this argv.
+ *
+ * Returns "handled" with an exit code when the dispatcher took ownership
+ * (subcommand or merged --help). Returns "fallthrough" when the existing
+ * harness/help/ACP paths in cli.ts should run instead.
+ *
+ * Recognised subcommands live in {@link findCommand} — keep that registry
+ * the single source of truth. New top-level commands should be added there
+ * and pi-coding-agent's parser should not be involved.
+ */
+export async function dispatchSubcommand(args: string[]): Promise<DispatchResult> {
+	const first = args[0]
+
+	if (isKnownCommand(first)) {
+		const cmd = findCommand(first as string)
+		// isKnownCommand checked first; the type assertion above is safe.
+		if (!cmd) return { kind: "fallthrough" }
+		const rest = args.slice(1)
+		const code = (await cmd.run(rest)) ?? 0
+		return { kind: "handled", exitCode: code }
+	}
+
+	// Merged --help: only when there is NO subcommand context.
+	// `kimchi claude --help` is a subcommand call — the handler decides what to do.
+	// `kimchi --help` (or `kimchi -h`) falls here and prints the union view.
+	if (first === undefined || first.startsWith("-")) {
+		if (args.includes("--help") || args.includes("-h")) {
+			await printMergedHelp()
+			return { kind: "handled", exitCode: 0 }
+		}
+	}
+
+	return { kind: "fallthrough" }
+}

--- a/src/commands/gsd2.ts
+++ b/src/commands/gsd2.ts
@@ -1,0 +1,5 @@
+import { notYetImplemented } from "./_stub.js"
+
+export async function runGsd2(_args: string[]): Promise<number> {
+	return notYetImplemented("gsd2")
+}

--- a/src/commands/help.ts
+++ b/src/commands/help.ts
@@ -40,7 +40,7 @@ const KIMCHI_FLAGS: FlagDoc[] = [
 ]
 
 const KIMCHI_ENV: FlagDoc[] = [
-	{ name: "KIMCHI_API_KEY", description: "Cast AI / Kimchi API key (overrides config.json apiKey)" },
+	{ name: "KIMCHI_API_KEY", description: "Kimchi API key (overrides config.json apiKey)" },
 	{ name: "KIMCHI_PERMISSIONS", description: "Initial permissions mode: default | plan | auto" },
 	{ name: "KIMCHI_TELEMETRY_ENABLED", description: "Enable telemetry (1/true). Off by default." },
 	{ name: "KIMCHI_TAGS", description: "Comma-separated `key:value` tags applied to every LLM request" },
@@ -69,7 +69,7 @@ function maxNameWidth(rows: FlagDoc[]): number {
  * indefinitely.
  */
 export async function printMergedHelp(): Promise<void> {
-	console.log(`${bold("kimchi")} — coding agent CLI powered by Cast AI`)
+	console.log(`${bold("kimchi")} — code with powerful open-source LLMs`)
 	console.log()
 	console.log(`${bold("Usage:")} kimchi [subcommand] [options] [@files…] [messages…]`)
 	console.log()

--- a/src/commands/help.ts
+++ b/src/commands/help.ts
@@ -1,0 +1,45 @@
+import { ANSI, fg } from "../ansi.js"
+import { COMMANDS } from "./registry.js"
+
+const SECTION_HEADER = "\x1b[1m"
+const RESET = "\x1b[0m"
+
+function bold(text: string): string {
+	return `${SECTION_HEADER}${text}${RESET}`
+}
+
+function dim(text: string): string {
+	return fg(ANSI.dim, text)
+}
+
+/**
+ * Render kimchi's own commands section, then delegate the rest of --help
+ * (top-level options, examples, env vars) to pi-coding-agent's printHelp.
+ *
+ * Pi's printHelp uses APP_NAME from piConfig (= "kimchi"), so its output is
+ * already branded correctly — we just prepend our subcommand catalogue.
+ */
+export async function printMergedHelp(): Promise<void> {
+	console.log(`${bold("kimchi")} — coding agent CLI powered by Cast AI`)
+	console.log()
+	console.log(bold("Subcommands:"))
+	const widest = Math.max(...COMMANDS.map((c) => c.name.length))
+	for (const cmd of COMMANDS) {
+		const name = cmd.name.padEnd(widest + 4)
+		console.log(`  kimchi ${name}${cmd.summary}`)
+	}
+	console.log(`  kimchi ${"".padEnd(widest + 4)}${dim("(no subcommand)")} Launch the coding harness`)
+	console.log()
+	console.log(`${bold("Harness flags")} (apply to the default mode — when no subcommand is given):`)
+	console.log(`${dim("Note: pi-coding-agent's own install/remove/list/config commands listed below")}`)
+	console.log(`${dim("are not exposed by kimchi; the kimchi subcommands above take precedence.")}`)
+	console.log()
+
+	// Hand off to pi for the full options/examples/env-vars dump. pi prints
+	// directly to stdout via console.log; there's no exported helper. Calling
+	// main with --help and zero extension factories lets pi handle the full
+	// banner the same way cli.ts has always done — we just print our section
+	// first.
+	const { main } = await import("@mariozechner/pi-coding-agent")
+	await main(["--help"], { extensionFactories: [] })
+}

--- a/src/commands/help.ts
+++ b/src/commands/help.ts
@@ -12,34 +12,88 @@ function dim(text: string): string {
 	return fg(ANSI.dim, text)
 }
 
+interface FlagDoc {
+	name: string
+	description: string
+}
+
+const KIMCHI_FLAGS: FlagDoc[] = [
+	{ name: "--provider <name>", description: "Provider (default: kimchi-dev)" },
+	{ name: "--model <pattern>", description: "Model id or pattern, optionally `provider/id` and/or `:<thinking>`" },
+	{ name: "--thinking <level>", description: "Thinking level: off, minimal, low, medium, high, xhigh" },
+	{ name: "--mode <mode>", description: "Output mode: text (default), json, rpc, acp" },
+	{ name: "--print, -p", description: "Non-interactive mode: process prompt and exit" },
+	{ name: "--continue, -c", description: "Resume the most recent session" },
+	{ name: "--resume, -r", description: "Pick a previous session interactively" },
+	{ name: "--session <path>", description: "Resume a specific session file (full path or partial UUID)" },
+	{ name: "--no-session", description: "Run ephemerally — don't write a session file" },
+	{ name: "--export <file>", description: "Export a session to HTML and exit" },
+	{ name: "--list-models [search]", description: "Print available models (optionally fuzzy-filtered)" },
+	{ name: "--allow-tool <rule>", description: "Add session permission allow rules (comma-separated)" },
+	{ name: "--deny-tool <rule>", description: "Add session permission deny rules (comma-separated)" },
+	{ name: "--plan", description: "Start in plan mode (read-only)" },
+	{ name: "--auto", description: "Start in auto/yolo mode" },
+	{ name: "--permissions-config <path>", description: "Replace the merged permissions config with this file" },
+	{ name: "--verbose", description: "Force verbose startup (overrides quietStartup)" },
+	{ name: "--help, -h", description: "Show this help" },
+	{ name: "--version, -v", description: "Show the kimchi version" },
+]
+
+const KIMCHI_ENV: FlagDoc[] = [
+	{ name: "KIMCHI_API_KEY", description: "Cast AI / Kimchi API key (overrides config.json apiKey)" },
+	{ name: "KIMCHI_PERMISSIONS", description: "Initial permissions mode: default | plan | auto" },
+	{ name: "KIMCHI_TELEMETRY_ENABLED", description: "Enable telemetry (1/true). Off by default." },
+	{ name: "KIMCHI_TAGS", description: "Comma-separated `key:value` tags applied to every LLM request" },
+	{ name: "KIMCHI_NO_UPDATE_CHECK", description: "Disable the background self-update probe" },
+]
+
+function printSection(rows: FlagDoc[], pad: number): void {
+	for (const row of rows) {
+		console.log(`  ${row.name.padEnd(pad)}${row.description}`)
+	}
+}
+
+function maxNameWidth(rows: FlagDoc[]): number {
+	return Math.max(...rows.map((r) => r.name.length))
+}
+
 /**
- * Render kimchi's own commands section, then delegate the rest of --help
- * (top-level options, examples, env vars) to pi-coding-agent's printHelp.
+ * Print a self-contained help screen: kimchi-specific subcommands, flags, and
+ * env vars only. We deliberately don't delegate to pi-coding-agent's printer —
+ * that would surface options and env vars (e.g. ANTHROPIC_API_KEY) and
+ * extension-management commands that are not exposed by kimchi.
  *
- * Pi's printHelp uses APP_NAME from piConfig (= "kimchi"), so its output is
- * already branded correctly — we just prepend our subcommand catalogue.
+ * Flags listed here are forwarded verbatim to pi-coding-agent's parser when
+ * the user runs the harness (no subcommand). Keep the list curated: only flags
+ * that meaningfully affect kimchi behaviour and that we expect to support
+ * indefinitely.
  */
 export async function printMergedHelp(): Promise<void> {
 	console.log(`${bold("kimchi")} — coding agent CLI powered by Cast AI`)
 	console.log()
-	console.log(bold("Subcommands:"))
-	const widest = Math.max(...COMMANDS.map((c) => c.name.length))
-	for (const cmd of COMMANDS) {
-		const name = cmd.name.padEnd(widest + 4)
-		console.log(`  kimchi ${name}${cmd.summary}`)
-	}
-	console.log(`  kimchi ${"".padEnd(widest + 4)}${dim("(no subcommand)")} Launch the coding harness`)
-	console.log()
-	console.log(`${bold("Harness flags")} (apply to the default mode — when no subcommand is given):`)
-	console.log(`${dim("Note: pi-coding-agent's own install/remove/list/config commands listed below")}`)
-	console.log(`${dim("are not exposed by kimchi; the kimchi subcommands above take precedence.")}`)
+	console.log(`${bold("Usage:")} kimchi [subcommand] [options] [@files…] [messages…]`)
 	console.log()
 
-	// Hand off to pi for the full options/examples/env-vars dump. pi prints
-	// directly to stdout via console.log; there's no exported helper. Calling
-	// main with --help and zero extension factories lets pi handle the full
-	// banner the same way cli.ts has always done — we just print our section
-	// first.
-	const { main } = await import("@mariozechner/pi-coding-agent")
-	await main(["--help"], { extensionFactories: [] })
+	console.log(bold("Subcommands:"))
+	const cmdPad = Math.max(...COMMANDS.map((c) => c.name.length)) + 4
+	for (const cmd of COMMANDS) {
+		console.log(`  kimchi ${cmd.name.padEnd(cmdPad)}${cmd.summary}`)
+	}
+	console.log(`  kimchi ${"".padEnd(cmdPad)}${dim("(no subcommand)")} Launch the coding harness`)
+	console.log()
+
+	console.log(`${bold("Harness flags")} ${dim("(no subcommand)")}:`)
+	printSection(KIMCHI_FLAGS, maxNameWidth(KIMCHI_FLAGS) + 2)
+	console.log()
+
+	console.log(bold("Environment variables:"))
+	printSection(KIMCHI_ENV, maxNameWidth(KIMCHI_ENV) + 2)
+	console.log()
+
+	console.log(bold("Examples:"))
+	console.log(`  kimchi setup                                ${dim("# first-time interactive setup")}`)
+	console.log(`  kimchi                                      ${dim("# launch the interactive harness")}`)
+	console.log(`  kimchi -p "explain src/cli.ts"              ${dim("# one-shot prompt, no session")}`)
+	console.log(`  kimchi --continue                           ${dim("# resume the most recent session")}`)
+	console.log(`  kimchi claude -p "review this PR"           ${dim("# run Claude Code via Kimchi")}`)
 }

--- a/src/commands/openclaw.ts
+++ b/src/commands/openclaw.ts
@@ -1,0 +1,5 @@
+import { notYetImplemented } from "./_stub.js"
+
+export async function runOpenClaw(_args: string[]): Promise<number> {
+	return notYetImplemented("openclaw")
+}

--- a/src/commands/opencode.ts
+++ b/src/commands/opencode.ts
@@ -1,0 +1,5 @@
+import { notYetImplemented } from "./_stub.js"
+
+export async function runOpenCode(_args: string[]): Promise<number> {
+	return notYetImplemented("opencode")
+}

--- a/src/commands/registry.ts
+++ b/src/commands/registry.ts
@@ -1,0 +1,38 @@
+export interface CommandDefinition {
+	name: string
+	summary: string
+	/** Run this command. Receives args after the subcommand name. Should not return on success unless the command is purely informational. */
+	run: (args: string[]) => Promise<number | undefined>
+}
+
+import { runClaude } from "./claude.js"
+import { runConfig } from "./config.js"
+import { runCursor } from "./cursor.js"
+import { runGsd2 } from "./gsd2.js"
+import { runOpenClaw } from "./openclaw.js"
+import { runOpenCode } from "./opencode.js"
+import { runSetup } from "./setup.js"
+import { runUpdate } from "./update.js"
+import { runVersion } from "./version.js"
+
+export const COMMANDS: CommandDefinition[] = [
+	{ name: "setup", summary: "Run the interactive setup wizard", run: runSetup },
+	{ name: "claude", summary: "Configure Claude Code to use Kimchi (and launch it)", run: runClaude },
+	{ name: "opencode", summary: "Configure OpenCode to use Kimchi (and launch it)", run: runOpenCode },
+	{ name: "cursor", summary: "Configure Cursor to use Kimchi", run: runCursor },
+	{ name: "openclaw", summary: "Configure OpenClaw to use Kimchi", run: runOpenClaw },
+	{ name: "gsd2", summary: "Install / configure GSD2 with Kimchi", run: runGsd2 },
+	{ name: "update", summary: "Check for and install kimchi updates", run: runUpdate },
+	{ name: "config", summary: "Inspect or change kimchi config (e.g. telemetry)", run: runConfig },
+	{ name: "version", summary: "Print the kimchi version", run: runVersion },
+]
+
+const COMMAND_NAMES = new Set(COMMANDS.map((c) => c.name))
+
+export function isKnownCommand(name: string | undefined): boolean {
+	return name !== undefined && COMMAND_NAMES.has(name)
+}
+
+export function findCommand(name: string): CommandDefinition | undefined {
+	return COMMANDS.find((c) => c.name === name)
+}

--- a/src/commands/setup.ts
+++ b/src/commands/setup.ts
@@ -1,0 +1,5 @@
+import { notYetImplemented } from "./_stub.js"
+
+export async function runSetup(_args: string[]): Promise<number> {
+	return notYetImplemented("setup")
+}

--- a/src/commands/update.ts
+++ b/src/commands/update.ts
@@ -1,0 +1,5 @@
+import { notYetImplemented } from "./_stub.js"
+
+export async function runUpdate(_args: string[]): Promise<number> {
+	return notYetImplemented("update")
+}

--- a/src/commands/version.ts
+++ b/src/commands/version.ts
@@ -1,0 +1,9 @@
+import { arch, platform } from "node:os"
+import { getVersion } from "../utils.js"
+
+export async function runVersion(_args: string[]): Promise<number> {
+	console.log(`kimchi ${getVersion()}`)
+	console.log(`  platform: ${platform()}/${arch()}`)
+	console.log(`  node:     ${process.version}`)
+	return 0
+}

--- a/src/config.ts
+++ b/src/config.ts
@@ -184,7 +184,7 @@ export function readTelemetryConfig(configPath?: string): TelemetryConfig {
 }
 
 /**
- * Load the kimchi-code configuration.
+ * Load the kimchi configuration.
  *
  * API key resolution order:
  *   1. KIMCHI_API_KEY environment variable (highest precedence)

--- a/tests/smoke/binary.test.ts
+++ b/tests/smoke/binary.test.ts
@@ -25,6 +25,50 @@ describe("binary smoke tests", () => {
 		expect(result.stdout).toContain("Usage")
 	})
 
+	it("--help shows kimchi subcommands and pi harness flags together", () => {
+		const result = runBinary({
+			args: ["--help"],
+			extraEnv: { KIMCHI_API_KEY: "smoke-test-dummy" },
+		})
+		// Kimchi-side section
+		expect(result.stdout).toContain("Subcommands:")
+		expect(result.stdout).toContain("kimchi setup")
+		expect(result.stdout).toContain("kimchi claude")
+		expect(result.stdout).toContain("kimchi opencode")
+		expect(result.stdout).toContain("kimchi cursor")
+		expect(result.stdout).toContain("kimchi openclaw")
+		expect(result.stdout).toContain("kimchi gsd2")
+		// Pi-side section — proves the pi help printer ran after ours
+		expect(result.stdout).toContain("--provider")
+		expect(result.stdout).toContain("--mode")
+	})
+
+	it("version subcommand prints version + platform without launching the harness", () => {
+		const result = runBinary({
+			args: ["version"],
+			extraEnv: { KIMCHI_API_KEY: "smoke-test-dummy" },
+		})
+		expect(result.stdout).toMatch(/^kimchi \d+\.\d+\.\d+/)
+		expect(result.stdout).toContain("platform:")
+		// The harness exit hook prints "To resume:" on exit code 0; subcommands
+		// short-circuit before any session starts, so it must NOT appear.
+		expect(result.stdout).not.toContain("To resume:")
+	})
+
+	it("unknown arg falls through to the harness (pi prints the unrecognised-flag warning)", () => {
+		// Pi treats unknown flags as extension flags and surfaces a diagnostic.
+		// We just need to assert the dispatcher didn't intercept — the easiest
+		// signal is that the harness session attempts to run (stderr contains
+		// pi's startup diagnostics, not our "not implemented" stub message).
+		const result = runBinary({
+			args: ["--definitely-not-a-real-flag=value"],
+			extraEnv: { KIMCHI_API_KEY: "smoke-test-dummy" },
+			throwOnError: false,
+			timeoutMs: 5_000,
+		})
+		expect(result.stdout + result.stderr).not.toContain("not implemented yet on this branch")
+	})
+
 	it("prompt templates are embedded in binary (no extension errors on startup)", () => {
 		const result = runBinary({
 			args: ["-p", "hello"],

--- a/tests/smoke/binary.test.ts
+++ b/tests/smoke/binary.test.ts
@@ -25,12 +25,12 @@ describe("binary smoke tests", () => {
 		expect(result.stdout).toContain("Usage")
 	})
 
-	it("--help shows kimchi subcommands and pi harness flags together", () => {
+	it("--help shows kimchi subcommands, harness flags, and env vars (no pi internals)", () => {
 		const result = runBinary({
 			args: ["--help"],
 			extraEnv: { KIMCHI_API_KEY: "smoke-test-dummy" },
 		})
-		// Kimchi-side section
+		// Subcommand catalogue
 		expect(result.stdout).toContain("Subcommands:")
 		expect(result.stdout).toContain("kimchi setup")
 		expect(result.stdout).toContain("kimchi claude")
@@ -38,9 +38,17 @@ describe("binary smoke tests", () => {
 		expect(result.stdout).toContain("kimchi cursor")
 		expect(result.stdout).toContain("kimchi openclaw")
 		expect(result.stdout).toContain("kimchi gsd2")
-		// Pi-side section — proves the pi help printer ran after ours
+		// Curated harness flags forwarded to pi
 		expect(result.stdout).toContain("--provider")
 		expect(result.stdout).toContain("--mode")
+		expect(result.stdout).toContain("--continue")
+		// Kimchi-only env vars
+		expect(result.stdout).toContain("KIMCHI_API_KEY")
+		// Pi-internal extension management commands and provider-specific env
+		// vars must not leak into kimchi's help screen.
+		expect(result.stdout).not.toContain("install <source>")
+		expect(result.stdout).not.toContain("ANTHROPIC_API_KEY")
+		expect(result.stdout).not.toContain("OPENAI_API_KEY")
 	})
 
 	it("version subcommand prints version + platform without launching the harness", () => {

--- a/tests/smoke/harness.ts
+++ b/tests/smoke/harness.ts
@@ -2,7 +2,7 @@
  * Shared test harness utilities for smoke tests.
  *
  * Provides isolated temp directories and a helper to spawn the compiled
- * kimchi-code binary with a sandboxed HOME. The binary computes its agent
+ * kimchi binary with a sandboxed HOME. The binary computes its agent
  * config dir as HOME/.config/kimchi/harness, so we expose that derived
  * path for tests that need to place settings files there.
  */
@@ -17,7 +17,7 @@ import { afterAll, beforeAll } from "vitest"
 
 const nodeRequire = createRequire(import.meta.url)
 
-export const BINARY_PATH = resolve("dist/bin/kimchi-code")
+export const BINARY_PATH = resolve("dist/bin/kimchi")
 export const PACKAGE_DIR = resolve("dist/share/kimchi")
 
 let tempHome: string | undefined

--- a/tests/smoke/web-fetch.test.ts
+++ b/tests/smoke/web-fetch.test.ts
@@ -1,6 +1,6 @@
 /**
  * Smoke test — verify the web_fetch tool works end-to-end through the
- * kimchi-code harness.
+ * kimchi harness.
  *
  * Requires KIMCHI_API_KEY to be set (skipped otherwise).
  * The web_fetch tool is bundled into the compiled binary via inline

--- a/tests/smoke/web-search.test.ts
+++ b/tests/smoke/web-search.test.ts
@@ -1,6 +1,6 @@
 /**
  * Smoke test — verify the web_search tool works end-to-end through the
- * kimchi-code harness.
+ * kimchi harness.
  *
  * Requires KIMCHI_API_KEY to be set (skipped otherwise).
  * The web_search tool is bundled into the compiled binary via inline


### PR DESCRIPTION
First of three stacked PRs that fold the kimchi Go CLI into this harness, sharing the merge-cli integration branch.

This PR renames the compiled binary from `kimchi-code` to `kimchi` everywhere (package.json, build/install scripts, smoke harness, release artifact, docs, resume hint) and adds a thin top-level subcommand dispatcher in front of pi-coding-agent's parser. Recognised subcommands (setup, claude, opencode, cursor, openclaw, gsd2, update, config, version) intercept argv before pi runs; everything else still falls through to the harness so existing flags like `--provider`, `--model`, and `--mode acp` keep working.

`kimchi --help` now prints kimchi's subcommand catalogue followed by pi's full help body. `kimchi --version` continues to be handled by pi. Subcommand handlers (except `version`) print "not implemented yet" stubs — the actual integrations land in PR2 and self-update lands in PR3.

---
### Kimchi Summary
### What changed
Rename the CLI binary from `kimchi-code` to `kimchi` and introduce a top-level subcommand dispatcher. When invoked without a subcommand, the tool continues to launch the interactive coding harness; otherwise it routes to dedicated handlers like `kimchi version`, `kimchi setup`, etc.

### Why
Aligns the binary name with the project branding and establishes the architecture for a unified CLI that wraps the harness and integrates with external editors (Claude, Cursor, etc.) without exposing internal `pi-coding-agent` implementation details.

### Key changes
- **Binary rename**: Updated all references from `kimchi-code` to `kimchi` in `package.json`, CI workflows (`release.yml`), install scripts, documentation, and issue templates.
- **Command dispatcher** (`src/commands/dispatch.ts`): Intercepts argv before the harness runs; returns `handled` with exit code for subcommands or `fallthrough` for harness mode.
- **Command registry** (`src/commands/registry.ts`): Declares subcommands `setup`, `claude`, `opencode`, `cursor`, `openclaw`, `gsd2`, `update`, `config`, and `version`.
- **Stub implementations** (`src/commands/_stub.ts`): All new subcommands except `version` currently print "not implemented" and exit with code 1.
- **Merged help** (`src/commands/help.ts`): Custom help renderer that lists kimchi-specific flags and env vars (e.g., `KIMCHI_API_KEY`) without leaking `pi-coding-agent` internals like `ANTHROPIC_API_KEY` or `install` commands.
- **Session lifecycle** (`src/cli.ts`): Added `sessionStarted` flag so the "To resume" hint only appears after harness sessions, not after subcommands or `--help`.
- **Build scripts**: Updated `scripts/build-binary.js`, `scripts/install-local.js`, and `scripts/verify-acp.mjs` to output/expect `dist/bin/kimchi`.
- **Tests**: Added `src/commands/dispatch.test.ts` covering routing, fallthrough for harness flags, and help rendering.

### Impact
- **Breaking change**: Release asset filenames change from `kimchi-code_{os}_{arch}.tar.gz` to `kimchi_{os}_{arch}.tar.gz`; the binary inside is now named `kimchi`. Update any scripts or aliases referencing the old name.
- **Duplicate script removal**: Removed duplicate `"prepare": "husky"` entry from `package.json`.