### PR TITLE
Feat add kimi k2 6

### DIFF
--- a/src/extensions/orchestration/model-registry/builtin-models.ts
+++ b/src/extensions/orchestration/model-registry/builtin-models.ts
@@ -21,10 +21,11 @@ import type { ModelCapabilities } from "./types.js"
  */
 
 const KIMI_K26_DESCRIPTION = `\
-Flagship Kimi model with vision support — excels at complex reasoning, architectural \
-planning, and deep exploration across large codebases. When a hard problem needs a superior \
-plan or methodical analysis, this is the model to delegate to. Also excels at research \
-and review tasks. Best for complex multi-step tasks requiring careful analysis.`
+Flagship Kimi model with vision support — handles images, screenshots, and visual input \
+with complex reasoning, architectural planning, and deep exploration across large codebases. \
+When a hard problem needs a superior plan or methodical analysis, this is the model to \
+delegate to. Also excels at research and review tasks. Best for complex multi-step tasks \
+requiring careful analysis.`
 
 const KIMI_K25_DESCRIPTION = `\
 The only model in the pool with vision support — use it when the task involves images, \

--- a/src/extensions/orchestration/model-registry/builtin-models.ts
+++ b/src/extensions/orchestration/model-registry/builtin-models.ts
@@ -21,16 +21,16 @@ import type { ModelCapabilities } from "./types.js"
  */
 
 const KIMI_K26_DESCRIPTION = `\
-Flagship Kimi model with vision support — handles images, screenshots, and visual input \
-with complex reasoning, architectural planning, and deep exploration across large codebases. \
-When a hard problem needs a superior plan or methodical analysis, this is the model to \
-delegate to. Also excels at research and review tasks. Best for complex multi-step tasks \
-requiring careful analysis.`
+Flagship Kimi model with vision support — the key model for complex planning decisions \
+and deep research. Handles images, screenshots, and visual input with superior reasoning. \
+When a hard problem needs architectural planning, strategic analysis, or methodical \
+research, this is the model to delegate to. Best for complex multi-step tasks.`
 
 const KIMI_K25_DESCRIPTION = `\
-The only model in the pool with vision support — use it when the task involves images, \
-screenshots, or visual input. Best for exploration and research tasks, particularly those \
-requiring image understanding or visual context. Excellent for autonomous multi-tool workflows.`
+Kimi model with vision support — the workhorse for simpler execution tasks and \
+exploration. Handles images, screenshots, and visual input. Best for straightforward \
+coding tasks, quick exploration, and when vision input is needed but planning depth \
+isn't critical. Reliable and efficient for well-scoped subtasks.`
 
 const MINIMAX_M27_DESCRIPTION = `\
 The strongest coding model in the pool. \

--- a/src/extensions/orchestration/model-registry/builtin-models.ts
+++ b/src/extensions/orchestration/model-registry/builtin-models.ts
@@ -20,6 +20,12 @@ import type { ModelCapabilities } from "./types.js"
  * the API once the shape is stable.
  */
 
+const KIMI_K26_DESCRIPTION = `\
+Flagship Kimi model with vision support — excels at complex reasoning, architectural \
+planning, and deep exploration across large codebases. When a hard problem needs a superior \
+plan or methodical analysis, this is the model to delegate to. Also excels at research \
+and review tasks. Best for complex multi-step tasks requiring careful analysis.`
+
 const KIMI_K25_DESCRIPTION = `\
 The only model in the pool with vision support — use it when the task involves images, \
 screenshots, or visual input. Best for exploration and research tasks, particularly those \
@@ -56,6 +62,15 @@ export const MODEL_CAPABILITIES: ReadonlyMap<string, ModelCapabilities | "ignore
 	string,
 	ModelCapabilities | "ignored"
 >([
+	[
+		"kimi-k2.6",
+		{
+			vision: true,
+			strengths: ["explore", "research", "plan", "review"],
+			tier: "heavy",
+			description: KIMI_K26_DESCRIPTION,
+		},
+	],
 	[
 		"kimi-k2.5",
 		{


### PR DESCRIPTION
Our API now supports kimi k2.6 let's add it to the builtin models. 

---
### Kimchi Summary
### What changed
Adds support for the new `kimi-k2.6` model to the builtin model registry and updates the capability descriptions to differentiate between the flagship K2.6 (for complex planning and research) and K2.5 (for simpler execution tasks).

### Why
Introduces the latest Kimi model which offers superior reasoning capabilities for architectural planning and deep research tasks, while repositioning K2.5 as the efficient workhorse for straightforward coding and exploration subtasks.

### Key changes
- **`src/extensions/orchestration/model-registry/builtin-models.ts`**:
  - Adds `kimi-k2.6` entry to `MODEL_CAPABILITIES` with `vision: true`, `tier: "heavy"`, and strengths `["explore", "research", "plan", "review"]`
  - Adds `KIMI_K26_DESCRIPTION` constant describing the model as the flagship choice for complex multi-step tasks and strategic analysis
  - Updates `KIMI_K25_DESCRIPTION` to reflect its role as the workhorse for simpler execution tasks and quick exploration

### Impact
- **Task routing**: The orchestrator will now route complex planning and research tasks to `kimi-k2.6` (heavy tier) rather than `kimi-k2.5`
- **Model selection**: Existing workflows relying on K2.5 for complex tasks may now automatically upgrade to K2.6 based on the `strengths` mapping