### PR TITLE
NOJIRA: Fix loop guard and reduce model verbosity

### DIFF
--- a/src/extensions/loop-guard.ts
+++ b/src/extensions/loop-guard.ts
@@ -263,11 +263,18 @@ function extractOutputText(content: ToolResultEvent["content"]): string {
 export default function loopGuardExtension(pi: ExtensionAPI) {
 	const guard = new LoopGuard()
 
-	pi.on("input", () => {
+	pi.on("input", (event) => {
+		if (event.source === "extension") return
 		guard.reset()
 	})
 
 	pi.on("tool_call", (event) => {
+		if (!event.toolName) {
+			return {
+				block: true,
+				reason: "Tool name is empty. Check your tool call syntax and use only the tools listed under Available Tools.",
+			}
+		}
 		if (guard.isTriggered()) {
 			return { block: true, reason: TERMINATION_MESSAGE }
 		}

--- a/src/extensions/orchestration/prompt-transformer/prompts/shared.ts
+++ b/src/extensions/orchestration/prompt-transformer/prompts/shared.ts
@@ -8,7 +8,7 @@ export const RESEARCH_RULES = `## Research Rules
 - **Avoid web_fetch.** It returns raw website content that can flood your context window. Prefer \`web_search\` for most research. Use \`web_fetch\` only when the information is frequently updated and unlikely to be indexed (e.g. changelogs, latest release notes), or when the user's message contains an explicit URL. When you do use it, request markdown or text format and delegate to a subagent to keep the output out of the main context.
 - **Run at most one web_search per task.** Do NOT run a second search to verify or refine.`
 
-export const CORE_GUIDELINES = `- Be concise in your responses.
+export const CORE_GUIDELINES = `- Be concise in your responses. Do not restate what you are about to do, repeat what you just did, or summarize completed steps — act and move on.
 - Show file paths clearly when working with files.
 - Read files before modifying them.
 - Prefer editing existing files over creating new ones.


### PR DESCRIPTION
## Problem

Two independent issues caused runaway token consumption and model verbosity after recent changes were merged.

### Loop guard was reset by continuation nudges

The loop guard reset its history on every `input` event, including extension-sourced messages such as continuation nudges. In sessions where nudges fired repeatedly (the common case for kimi-k2.5 on multi-turn tasks), the guard never accumulated enough tool call history to detect a loop and terminate it. The result was unbounded iteration — `simple-kimi` consumed 483K tokens and `complex-single-kimi` consumed 966K tokens in session-32, compared to 16K and 258K on master.

### Models emitting empty-name tool calls

kimi-k2.5 was emitting tool calls with an empty name, each returning a generic "Tool not found" error. With 10 such calls in a single session, the loop guard should have caught it — but didn't, because of the nudge-reset bug above. Even after the reset bug is fixed, the empty-name calls waste a turn each time they occur.

### Model output repetition

Models (particularly minimax-m2.7) were restating what they were about to do, summarising steps they had just completed, and repeating conclusions — inflating output tokens without adding value.

## Changes

### Fix loop guard reset on nudge events (`loop-guard.ts`)

The `input` handler now skips events with `source === "extension"`, matching the behaviour of the continuation nudge handler itself. The guard history now persists across nudge boundaries, allowing it to detect loops that span multiple nudge/response cycles.

### Block empty-name tool calls (`loop-guard.ts`)

Tool calls with an empty or missing name are blocked immediately with a clear error message. The model receives actionable feedback ("check your tool call syntax") instead of a silent "Tool not found", and the wasted turn is eliminated.

### Suppress output repetition (`shared.ts`)

Added a no-repetition guideline to `CORE_GUIDELINES` (applies to both orchestrator and subagent system prompts): do not restate what you are about to do, repeat what you just did, or summarise completed steps.