### PR TITLE
NOJIRA: Hide /stats command for now

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -25,7 +25,7 @@ import permissionsExtension from "./extensions/permissions/index.js"
 import { reserveShiftTabForPermissions } from "./extensions/permissions/keybindings.js"
 import promptSummaryExtension from "./extensions/prompt-summary.js"
 import shutdownMarkerExtension from "./extensions/shutdown-marker.js"
-import statsExtension from "./extensions/stats/index.js"
+// import statsExtension from "./extensions/stats/index.js"
 import subagentExtension from "./extensions/subagent.js"
 import tagsExtension from "./extensions/tags.js"
 import telemetryExtension from "./extensions/telemetry.js"
@@ -222,7 +222,7 @@ try {
 			sessionIdCaptureExtension,
 			outputFilterExtension,
 			shutdownMarkerExtension,
-			statsExtension,
+			// statsExtension,
 			terminalColorsExtension,
 			kimchiMinimalTintsExtension,
 			bashCollapseExtension,

--- a/src/extensions/stats/index.ts
+++ b/src/extensions/stats/index.ts
@@ -13,8 +13,7 @@ import { CastAiStatsApi, getTimeRange } from "./api.js"
 import { formatError, formatHelp } from "./display.js"
 import { formatAnalyticsVisual, formatProductivityVisual } from "./visual.js"
 
-// API key used for Cast AI API requests
-const DEFAULT_API_KEY = "c7b7ea88b9c92c21d2487634e62884aa5d167fb188be676a30fe99639b3a81b1"
+// API key used for Cast AI API requests - must be provided via CASTAI_API_KEY env var
 
 // Hardcoded user ID as specified
 const HARDCODED_USER_ID = "d1c79c82-c230-4b19-9def-dbe49bf63368"
@@ -33,7 +32,7 @@ function getStatsConfig(): StatsConfig {
 	const envOrg = process.env.CASTAI_ORG_ID
 
 	return {
-		apiKey: envKey || DEFAULT_API_KEY,
+		apiKey: envKey || "",
 		userId: HARDCODED_USER_ID,
 		organizationId: envOrg || ORGANIZATION_ID,
 	}


### PR DESCRIPTION


---
### Kimchi Summary
### What changed
Disables the stats extension by default and removes a hardcoded API key from the source code. The stats functionality now requires the `CASTAI_API_KEY` environment variable to be set explicitly.

### Why
Eliminates a security risk from embedding credentials in the codebase. Hardcoded API keys should never be committed to version control as they can be extracted and abused.

### Key changes
- `src/cli.ts`: Commented out `statsExtension` import and removed it from the extensions list, effectively disabling the feature.
- `src/extensions/stats/index.ts`: Removed the hardcoded `DEFAULT_API_KEY` constant. The `getStatsConfig` function now returns an empty string for `apiKey` if `CASTAI_API_KEY` environment variable is not set, making the key a required configuration.

### Impact
**Breaking change**: Users relying on automatic stats collection will need to explicitly:
1. Re-enable the extension by uncommenting the `statsExtension` lines in `src/cli.ts`
2. Set the `CASTAI_API_KEY` environment variable with a valid API key

Stats functionality will fail silently or with authentication errors until both steps are completed.