### PR TITLE
BugFix: Stop prompt enrichment with same data on each user message

### DIFF
--- a/src/extensions/orchestration/prompt-enrichment.test.ts
+++ b/src/extensions/orchestration/prompt-enrichment.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest"
-import { EnrichmentGuard, deduplicateEnrichedPrompts } from "./prompt-enrichment.js"
 import type { OrchestratorMessages } from "./continuation-nudge.js"
+import { EnrichmentGuard, deduplicateEnrichedPrompts } from "./prompt-enrichment.js"
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -27,7 +27,14 @@ function makeAssistant(): OrchestratorMessages[number] {
 		api: "openai-completions",
 		provider: "kimchi-dev",
 		model: "kimi-k2.6",
-		usage: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, totalTokens: 0, cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 } },
+		usage: {
+			input: 0,
+			output: 0,
+			cacheRead: 0,
+			cacheWrite: 0,
+			totalTokens: 0,
+			cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+		},
 		stopReason: "stop",
 		timestamp: Date.now(),
 	}
@@ -118,10 +125,17 @@ describe("deduplicateEnrichedPrompts", () => {
 	it("removes all but the last when many duplicates have accumulated", () => {
 		const copies = [makeEnrichedPrompt(), makeEnrichedPrompt(), makeEnrichedPrompt(), makeEnrichedPrompt()]
 		const messages: OrchestratorMessages = [
-			copies[0], makeUser("q1"), makeAssistant(),
-			copies[1], makeUser("q2"), makeAssistant(),
-			copies[2], makeUser("q3"), makeAssistant(),
-			copies[3], makeUser("q4"),
+			copies[0],
+			makeUser("q1"),
+			makeAssistant(),
+			copies[1],
+			makeUser("q2"),
+			makeAssistant(),
+			copies[2],
+			makeUser("q3"),
+			makeAssistant(),
+			copies[3],
+			makeUser("q4"),
 		]
 		const result = deduplicateEnrichedPrompts(messages)
 		const remaining = result.filter(
@@ -143,7 +157,13 @@ describe("deduplicateEnrichedPrompts", () => {
 	})
 
 	it("does not remove non-enriched-prompt custom messages", () => {
-		const nudge = { role: "custom" as const, customType: "nudge", content: "nudge", display: false, timestamp: Date.now() }
+		const nudge = {
+			role: "custom" as const,
+			customType: "nudge",
+			content: "nudge",
+			display: false,
+			timestamp: Date.now(),
+		}
 		const messages: OrchestratorMessages = [makeEnrichedPrompt(), makeEnrichedPrompt(), nudge, makeUser("q")]
 		const result = deduplicateEnrichedPrompts(messages)
 		expect(result).toContain(nudge)

--- a/src/extensions/orchestration/prompt-enrichment.test.ts
+++ b/src/extensions/orchestration/prompt-enrichment.test.ts
@@ -1,0 +1,151 @@
+import { describe, expect, it } from "vitest"
+import { EnrichmentGuard, deduplicateEnrichedPrompts } from "./prompt-enrichment.js"
+import type { OrchestratorMessages } from "./continuation-nudge.js"
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function makeEnrichedPrompt(): OrchestratorMessages[number] {
+	return {
+		role: "custom" as const,
+		customType: "enriched-prompt",
+		content: [{ type: "text" as const, text: "## Your Capabilities\n..." }],
+		display: false,
+		timestamp: Date.now(),
+	}
+}
+
+function makeUser(text: string): OrchestratorMessages[number] {
+	return { role: "user", content: [{ type: "text", text }], timestamp: Date.now() }
+}
+
+function makeAssistant(): OrchestratorMessages[number] {
+	return {
+		role: "assistant",
+		content: [{ type: "text", text: "Done." }],
+		api: "openai-completions",
+		provider: "kimchi-dev",
+		model: "kimi-k2.6",
+		usage: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, totalTokens: 0, cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 } },
+		stopReason: "stop",
+		timestamp: Date.now(),
+	}
+}
+
+// ---------------------------------------------------------------------------
+// EnrichmentGuard
+// ---------------------------------------------------------------------------
+
+describe("EnrichmentGuard", () => {
+	it("injects on the first turn (no model seen yet)", () => {
+		const guard = new EnrichmentGuard()
+		expect(guard.shouldEnrich("kimi-k2.6")).toBe(true)
+	})
+
+	it("does not inject again on the same model", () => {
+		const guard = new EnrichmentGuard()
+		guard.shouldEnrich("kimi-k2.6")
+		expect(guard.shouldEnrich("kimi-k2.6")).toBe(false)
+	})
+
+	it("does not inject on any subsequent turn with the same model", () => {
+		const guard = new EnrichmentGuard()
+		guard.shouldEnrich("kimi-k2.6")
+		for (let i = 0; i < 5; i++) {
+			expect(guard.shouldEnrich("kimi-k2.6")).toBe(false)
+		}
+	})
+
+	it("re-injects when the model changes", () => {
+		const guard = new EnrichmentGuard()
+		guard.shouldEnrich("kimi-k2.6")
+		expect(guard.shouldEnrich("claude-opus-4-7")).toBe(true)
+	})
+
+	it("does not re-inject on the turn after a model change", () => {
+		const guard = new EnrichmentGuard()
+		guard.shouldEnrich("kimi-k2.6")
+		guard.shouldEnrich("claude-opus-4-7")
+		expect(guard.shouldEnrich("claude-opus-4-7")).toBe(false)
+	})
+
+	it("re-injects if model switches back to a previously seen model", () => {
+		const guard = new EnrichmentGuard()
+		guard.shouldEnrich("kimi-k2.6")
+		guard.shouldEnrich("claude-opus-4-7")
+		expect(guard.shouldEnrich("kimi-k2.6")).toBe(true)
+	})
+
+	it("treats empty string model ID as a valid first-turn key", () => {
+		const guard = new EnrichmentGuard()
+		expect(guard.shouldEnrich("")).toBe(true)
+		expect(guard.shouldEnrich("")).toBe(false)
+	})
+
+	it("re-injects after reset", () => {
+		const guard = new EnrichmentGuard()
+		guard.shouldEnrich("kimi-k2.6")
+		guard.reset()
+		expect(guard.shouldEnrich("kimi-k2.6")).toBe(true)
+	})
+})
+
+// ---------------------------------------------------------------------------
+// deduplicateEnrichedPrompts  (safety-net for accumulated duplicates)
+// ---------------------------------------------------------------------------
+
+describe("deduplicateEnrichedPrompts", () => {
+	it("returns the same array when there are no enriched-prompt messages", () => {
+		const messages: OrchestratorMessages = [makeUser("hi"), makeAssistant()]
+		expect(deduplicateEnrichedPrompts(messages)).toBe(messages)
+	})
+
+	it("returns the same array when there is exactly one enriched-prompt", () => {
+		const messages: OrchestratorMessages = [makeEnrichedPrompt(), makeUser("hi"), makeAssistant()]
+		expect(deduplicateEnrichedPrompts(messages)).toBe(messages)
+	})
+
+	it("keeps only the last enriched-prompt when duplicates exist", () => {
+		const first = makeEnrichedPrompt()
+		const second = makeEnrichedPrompt()
+		const messages: OrchestratorMessages = [first, makeUser("q1"), makeAssistant(), second, makeUser("q2")]
+		const result = deduplicateEnrichedPrompts(messages)
+		expect(result).not.toContain(first)
+		expect(result).toContain(second)
+	})
+
+	it("removes all but the last when many duplicates have accumulated", () => {
+		const copies = [makeEnrichedPrompt(), makeEnrichedPrompt(), makeEnrichedPrompt(), makeEnrichedPrompt()]
+		const messages: OrchestratorMessages = [
+			copies[0], makeUser("q1"), makeAssistant(),
+			copies[1], makeUser("q2"), makeAssistant(),
+			copies[2], makeUser("q3"), makeAssistant(),
+			copies[3], makeUser("q4"),
+		]
+		const result = deduplicateEnrichedPrompts(messages)
+		const remaining = result.filter(
+			(m) => m.role === "custom" && "customType" in m && (m as { customType: string }).customType === "enriched-prompt",
+		)
+		expect(remaining).toHaveLength(1)
+		expect(remaining[0]).toBe(copies[3])
+	})
+
+	it("preserves all non-enriched-prompt messages", () => {
+		const user1 = makeUser("q1")
+		const assistant1 = makeAssistant()
+		const user2 = makeUser("q2")
+		const messages: OrchestratorMessages = [makeEnrichedPrompt(), user1, assistant1, makeEnrichedPrompt(), user2]
+		const result = deduplicateEnrichedPrompts(messages)
+		expect(result).toContain(user1)
+		expect(result).toContain(assistant1)
+		expect(result).toContain(user2)
+	})
+
+	it("does not remove non-enriched-prompt custom messages", () => {
+		const nudge = { role: "custom" as const, customType: "nudge", content: "nudge", display: false, timestamp: Date.now() }
+		const messages: OrchestratorMessages = [makeEnrichedPrompt(), makeEnrichedPrompt(), nudge, makeUser("q")]
+		const result = deduplicateEnrichedPrompts(messages)
+		expect(result).toContain(nudge)
+	})
+})

--- a/src/extensions/orchestration/prompt-enrichment.ts
+++ b/src/extensions/orchestration/prompt-enrichment.ts
@@ -108,7 +108,27 @@ let multiModelEnabled = readMultiModelArgv()
 
 const ENRICHED_PROMPT_CUSTOM_TYPE = "enriched-prompt"
 
-function deduplicateEnrichedPrompts(messages: OrchestratorMessages): OrchestratorMessages {
+/**
+ * Tracks which model last received an enriched-prompt injection so the
+ * capabilities block is only sent once per model, not on every user turn.
+ */
+export class EnrichmentGuard {
+	private lastModelId: string | null = null
+
+	/** Returns true if enrichment should be injected for this model ID. */
+	shouldEnrich(modelId: string): boolean {
+		if (modelId === this.lastModelId) return false
+		this.lastModelId = modelId
+		return true
+	}
+
+	/** Resets the guard, e.g. when multi-model is toggled off and back on. */
+	reset(): void {
+		this.lastModelId = null
+	}
+}
+
+export function deduplicateEnrichedPrompts(messages: OrchestratorMessages): OrchestratorMessages {
 	const lastIdx = messages.findLastIndex(
 		(m) =>
 			m.role === "custom" &&
@@ -190,6 +210,7 @@ export default function (skillPaths: string[]) {
 			// circuits the input-handler chain.
 			const continuationNudge = new ContinuationNudge()
 			const emptyTurnNudge = new EmptyTurnNudge()
+			const enrichmentGuard = new EnrichmentGuard()
 
 			pi.on("input", async (event) => {
 				if (event.source === "extension") return
@@ -254,6 +275,14 @@ export default function (skillPaths: string[]) {
 				}
 
 				const currentModel = ctx.model ? { id: ctx.model.id, name: ctx.model.id } : undefined
+				const currentModelId = currentModel?.id ?? ""
+
+				// Only inject capabilities on the first turn or when the model changes.
+				// Re-injecting every turn accumulates duplicate capability blocks in the
+				// context window, inflating token usage and confusing the model.
+				if (!enrichmentGuard.shouldEnrich(currentModelId)) {
+					return { action: "continue" as const }
+				}
 
 				// Non-interactive (--print/--mode rpc) and debug-prompts mode: replace the user
 				// text inline. The "handled" + sendUserMessage path below relies on the TUI event


### PR DESCRIPTION
## Problem

  Every user message triggered a fresh injection of the **enriched-prompt capabilities block** (~4 KB of model identity, strengths, and available subagent list) into the conversation context, regardless of whether
  it had already been sent. In a multi-turn session this meant the block accumulated once per turn:

  [enriched-prompt] [user msg 1] [assistant]
  [enriched-prompt] [user msg 2] [assistant]   ← duplicate
  [enriched-prompt] [user msg 3] [assistant]   ← duplicate
  [enriched-prompt] [user msg 4] ...           ← duplicate

  A 4-turn session sent the block 4 times — ~16 KB of redundant scaffolding the model had to re-read on every API call. This was confirmed by inspecting session export files where the same `enriched-prompt` custom
  message appeared once per user turn.

  The existing `deduplicateEnrichedPrompts` function on the `context` event partially mitigated this by stripping old copies before the API call, but it was a cleanup after the fact — the blocks were still being
  generated and stored in session history on every turn, growing context and costing tokens unnecessarily.

  In practice this contributed to Cloudflare 524 gateway timeouts: the inflated context pushed long-running model calls (e.g. reviewing a large file) past the ~100 s gateway threshold before the first token was
  returned.

  ## Fix

  ### Prevention — `EnrichmentGuard` class

  Added `EnrichmentGuard`, a small stateful class that tracks the model ID that last received an enriched-prompt injection. The `input` handler calls `shouldEnrich(modelId)` before doing any work:

  - Returns `true` (and records the model ID) on the first turn or when the model has changed since the last injection.
  - Returns `false` on all subsequent turns with the same model — the handler exits early with `{ action: "continue" }` and the raw user message passes through untouched.

  This means the capabilities block is sent exactly once per model per session, and re-sent only when the user switches models mid-session (which is correct — the new model needs to know its own identity and the
  pool it can delegate to).

  ### Fallback — `deduplicateEnrichedPrompts` (unchanged)

  Left in place on the `context` event as a defensive safety net. It is now a no-op in normal operation but will catch any edge case where duplicates slip through (e.g. rapid model switching, extension restarts).

  ### Subagents — no change

  The entire enrichment path is guarded by `if (!subagentMode)`. Subagents were never enriched before and are still not enriched after this change.

  ## Files changed

  | File | Change |
  |---|---|
  | `src/extensions/orchestration/prompt-enrichment.ts` | Added `EnrichmentGuard` class (exported), replaced inline `lastEnrichedModelId` variable with `enrichmentGuard.shouldEnrich()` call in the `input` handler |
  | `src/extensions/orchestration/prompt-enrichment.test.ts` | New test file — 14 tests covering `EnrichmentGuard` (first turn, same model, model change, model switch-back, empty ID, reset) and
  `deduplicateEnrichedPrompts` (no duplicates, single, many accumulated, message preservation, non-enriched custom messages) |

---
### Kimchi Summary
### What changed
Fixes a bug where enriched prompts (capability blocks) were injected on every user turn. The enrichment is now only injected on the first turn or when the model changes, preventing duplicate accumulation in the context window.

### Why
Injecting capabilities on every turn caused duplicate blocks to accumulate in the conversation history, inflating token usage and potentially confusing the model with redundant context.

### Key changes
- Added `EnrichmentGuard` class to track `lastModelId` and gate injection via `shouldEnrich(modelId)` 
- Modified `prompt-enrichment.ts` main handler to check `enrichmentGuard.shouldEnrich(currentModelId)` before injecting; returns early with `{ action: "continue" }` if enrichment not needed
- Exported `deduplicateEnrichedPrompts()` function (previously internal) as a safety net for cleaning up any accumulated duplicate enriched prompts
- Added `prompt-enrichment.test.ts` with comprehensive tests for `EnrichmentGuard` (model switching, reset behavior) and `deduplicateEnrichedPrompts`

### Impact
- Reduced token usage in multi-turn conversations by sending capabilities once per model instead of every message
- Cleaner context window for the model
- No breaking changes or migration steps required