### PR TITLE
feat: P0 harness improvements - error fingerprint and cross-repo analysis

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,5 +1,0 @@
-## [Unreleased]
-
-### Added
-- Added 'kimchi' as an alias for 'kimchi-code' command
-- Both commands are now fully interchangeable for all flags

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,0 +1,5 @@
+## [Unreleased]
+
+### Added
+- Added 'kimchi' as an alias for 'kimchi-code' command
+- Both commands are now fully interchangeable for all flags

--- a/package.json
+++ b/package.json
@@ -1,78 +1,78 @@
 {
-	"name": "@kimchi-dev/cli",
-	"version": "0.1.0",
-	"description": "kimchi-code — a coding agent CLI powered by Cast AI",
-	"type": "module",
-	"license": "MIT",
-	"bin": {
-		"kimchi-code": "src/entry.ts"
-	},
-	"scripts": {
-		"clean": "rm -rf dist",
-		"build": "tsc --noEmit && node scripts/copy-resources.js --dev",
-		"build:binary": "node scripts/build-binary.js",
-		"install:local": "node scripts/install-local.js",
-		"build:binary-linux-arm64": "node scripts/build-binary.js --target linux-arm64",
-		"build:binary-linux-x64": "node scripts/build-binary.js --target linux-x64",
-		"dev": "bun run --preload ./src/set-package-dir.ts src/entry.ts",
-		"lint": "biome check src/ scripts/",
-		"lint:fix": "biome check --write src/ scripts/",
-		"typecheck": "tsc --noEmit",
-		"check": "pnpm run lint && pnpm run typecheck",
-		"test": "vitest run --dir src",
-		"test:smoke": "vitest run --config tests/smoke/vitest.config.ts",
-		"prepare": "husky",
-		"verify": "pnpm run check && pnpm run build:binary && pnpm run test && pnpm run test:smoke",
-		"prepare": "husky"
-	},
-	"piConfig": {
-		"name": "kimchi",
-		"configDir": ".config/kimchi/harness"
-	},
-	"dependencies": {
-		"@agentclientprotocol/sdk": "^0.19.0",
-		"@clack/prompts": "^1.2.0",
-		"@mariozechner/pi-coding-agent": "^0.67.68",
-		"@mariozechner/pi-tui": "^0.67.68",
-		"@modelcontextprotocol/ext-apps": "^1.2.2",
-		"@modelcontextprotocol/sdk": "^1.25.1",
-		"micromatch": "^4.0.8",
-		"open": "^10.2.0",
-		"shell-quote": "^1.8.3",
-		"undici": "^8.0.2",
-		"uuid": "^14.0.0",
-		"zod": "^4.0.0"
-	},
-	"peerDependencies": {
-		"@sinclair/typebox": "*"
-	},
-	"devDependencies": {
-		"@biomejs/biome": "^1.9.4",
-		"@mariozechner/pi-ai": "^0.67.68",
-		"@mixmark-io/domino": "^2.2.0",
-		"@types/micromatch": "^4.0.10",
-		"@types/node": "^22.15.2",
-		"@types/shell-quote": "^1.7.5",
-		"@types/turndown": "^5.0.5",
-		"husky": "^9.1.7",
-		"node-pty": "^1.1.0",
-		"playwright": "^1.52.0",
-		"tsx": "^4.21.0",
-		"turndown": "^7.2.0",
-		"typescript": "^5.7.3",
-		"vitest": "^3.1.1"
-	},
-	"engines": {
-		"node": ">=22.0.0"
-	},
-	"packageManager": "pnpm@10.8.1",
-	"pnpm": {
-		"onlyBuiltDependencies": [
-			"@biomejs/biome",
-			"esbuild",
-			"koffi",
-			"node-pty",
-			"protobufjs"
-		]
-	}
+  "name": "@kimchi-dev/cli",
+  "version": "0.1.0",
+  "description": "kimchi-code \u2014 a coding agent CLI powered by Cast AI",
+  "type": "module",
+  "license": "MIT",
+  "bin": {
+    "kimchi-code": "src/entry.ts",
+    "kimchi": "src/entry.ts"
+  },
+  "scripts": {
+    "clean": "rm -rf dist",
+    "build": "tsc --noEmit && node scripts/copy-resources.js --dev",
+    "build:binary": "node scripts/build-binary.js",
+    "install:local": "node scripts/install-local.js",
+    "build:binary-linux-arm64": "node scripts/build-binary.js --target linux-arm64",
+    "build:binary-linux-x64": "node scripts/build-binary.js --target linux-x64",
+    "dev": "bun run --preload ./src/set-package-dir.ts src/entry.ts",
+    "lint": "biome check src/ scripts/",
+    "lint:fix": "biome check --write src/ scripts/",
+    "typecheck": "tsc --noEmit",
+    "check": "pnpm run lint && pnpm run typecheck",
+    "test": "vitest run --dir src",
+    "test:smoke": "vitest run --config tests/smoke/vitest.config.ts",
+    "prepare": "husky",
+    "verify": "pnpm run check && pnpm run build:binary && pnpm run test && pnpm run test:smoke"
+  },
+  "piConfig": {
+    "name": "kimchi",
+    "configDir": ".config/kimchi/harness"
+  },
+  "dependencies": {
+    "@agentclientprotocol/sdk": "^0.19.0",
+    "@clack/prompts": "^1.2.0",
+    "@mariozechner/pi-coding-agent": "^0.67.68",
+    "@mariozechner/pi-tui": "^0.67.68",
+    "@modelcontextprotocol/ext-apps": "^1.2.2",
+    "@modelcontextprotocol/sdk": "^1.25.1",
+    "micromatch": "^4.0.8",
+    "open": "^10.2.0",
+    "shell-quote": "^1.8.3",
+    "undici": "^8.0.2",
+    "uuid": "^14.0.0",
+    "zod": "^4.0.0"
+  },
+  "peerDependencies": {
+    "@sinclair/typebox": "*"
+  },
+  "devDependencies": {
+    "@biomejs/biome": "^1.9.4",
+    "@mariozechner/pi-ai": "^0.67.68",
+    "@mixmark-io/domino": "^2.2.0",
+    "@types/micromatch": "^4.0.10",
+    "@types/node": "^22.15.2",
+    "@types/shell-quote": "^1.7.5",
+    "@types/turndown": "^5.0.5",
+    "husky": "^9.1.7",
+    "node-pty": "^1.1.0",
+    "playwright": "^1.52.0",
+    "tsx": "^4.21.0",
+    "turndown": "^7.2.0",
+    "typescript": "^5.7.3",
+    "vitest": "^3.1.1"
+  },
+  "engines": {
+    "node": ">=22.0.0"
+  },
+  "packageManager": "pnpm@10.8.1",
+  "pnpm": {
+    "onlyBuiltDependencies": [
+      "@biomejs/biome",
+      "esbuild",
+      "koffi",
+      "node-pty",
+      "protobufjs"
+    ]
+  }
 }

--- a/package.json
+++ b/package.json
@@ -1,78 +1,78 @@
 {
-  "name": "@kimchi-dev/cli",
-  "version": "0.1.0",
-  "description": "kimchi-code \u2014 a coding agent CLI powered by Cast AI",
-  "type": "module",
-  "license": "MIT",
-  "bin": {
-    "kimchi-code": "src/entry.ts",
-    "kimchi": "src/entry.ts"
-  },
-  "scripts": {
-    "clean": "rm -rf dist",
-    "build": "tsc --noEmit && node scripts/copy-resources.js --dev",
-    "build:binary": "node scripts/build-binary.js",
-    "install:local": "node scripts/install-local.js",
-    "build:binary-linux-arm64": "node scripts/build-binary.js --target linux-arm64",
-    "build:binary-linux-x64": "node scripts/build-binary.js --target linux-x64",
-    "dev": "bun run --preload ./src/set-package-dir.ts src/entry.ts",
-    "lint": "biome check src/ scripts/",
-    "lint:fix": "biome check --write src/ scripts/",
-    "typecheck": "tsc --noEmit",
-    "check": "pnpm run lint && pnpm run typecheck",
-    "test": "vitest run --dir src",
-    "test:smoke": "vitest run --config tests/smoke/vitest.config.ts",
-    "prepare": "husky",
-    "verify": "pnpm run check && pnpm run build:binary && pnpm run test && pnpm run test:smoke"
-  },
-  "piConfig": {
-    "name": "kimchi",
-    "configDir": ".config/kimchi/harness"
-  },
-  "dependencies": {
-    "@agentclientprotocol/sdk": "^0.19.0",
-    "@clack/prompts": "^1.2.0",
-    "@mariozechner/pi-coding-agent": "^0.67.68",
-    "@mariozechner/pi-tui": "^0.67.68",
-    "@modelcontextprotocol/ext-apps": "^1.2.2",
-    "@modelcontextprotocol/sdk": "^1.25.1",
-    "micromatch": "^4.0.8",
-    "open": "^10.2.0",
-    "shell-quote": "^1.8.3",
-    "undici": "^8.0.2",
-    "uuid": "^14.0.0",
-    "zod": "^4.0.0"
-  },
-  "peerDependencies": {
-    "@sinclair/typebox": "*"
-  },
-  "devDependencies": {
-    "@biomejs/biome": "^1.9.4",
-    "@mariozechner/pi-ai": "^0.67.68",
-    "@mixmark-io/domino": "^2.2.0",
-    "@types/micromatch": "^4.0.10",
-    "@types/node": "^22.15.2",
-    "@types/shell-quote": "^1.7.5",
-    "@types/turndown": "^5.0.5",
-    "husky": "^9.1.7",
-    "node-pty": "^1.1.0",
-    "playwright": "^1.52.0",
-    "tsx": "^4.21.0",
-    "turndown": "^7.2.0",
-    "typescript": "^5.7.3",
-    "vitest": "^3.1.1"
-  },
-  "engines": {
-    "node": ">=22.0.0"
-  },
-  "packageManager": "pnpm@10.8.1",
-  "pnpm": {
-    "onlyBuiltDependencies": [
-      "@biomejs/biome",
-      "esbuild",
-      "koffi",
-      "node-pty",
-      "protobufjs"
-    ]
-  }
+	"name": "@kimchi-dev/cli",
+	"version": "0.1.0",
+	"description": "kimchi-code — a coding agent CLI powered by Cast AI",
+	"type": "module",
+	"license": "MIT",
+	"bin": {
+		"kimchi-code": "src/entry.ts",
+		"kimchi": "src/entry.ts"
+	},
+	"scripts": {
+		"clean": "rm -rf dist",
+		"build": "tsc --noEmit && node scripts/copy-resources.js --dev",
+		"build:binary": "node scripts/build-binary.js",
+		"install:local": "node scripts/install-local.js",
+		"build:binary-linux-arm64": "node scripts/build-binary.js --target linux-arm64",
+		"build:binary-linux-x64": "node scripts/build-binary.js --target linux-x64",
+		"dev": "bun run --preload ./src/set-package-dir.ts src/entry.ts",
+		"lint": "biome check src/ scripts/",
+		"lint:fix": "biome check --write src/ scripts/",
+		"typecheck": "tsc --noEmit",
+		"check": "pnpm run lint && pnpm run typecheck",
+		"test": "vitest run --dir src",
+		"test:smoke": "vitest run --config tests/smoke/vitest.config.ts",
+		"prepare": "husky",
+		"verify": "pnpm run check && pnpm run build:binary && pnpm run test && pnpm run test:smoke"
+	},
+	"piConfig": {
+		"name": "kimchi",
+		"configDir": ".config/kimchi/harness"
+	},
+	"dependencies": {
+		"@agentclientprotocol/sdk": "^0.19.0",
+		"@clack/prompts": "^1.2.0",
+		"@mariozechner/pi-coding-agent": "^0.67.68",
+		"@mariozechner/pi-tui": "^0.67.68",
+		"@modelcontextprotocol/ext-apps": "^1.2.2",
+		"@modelcontextprotocol/sdk": "^1.25.1",
+		"micromatch": "^4.0.8",
+		"open": "^10.2.0",
+		"shell-quote": "^1.8.3",
+		"undici": "^8.0.2",
+		"uuid": "^14.0.0",
+		"zod": "^4.0.0"
+	},
+	"peerDependencies": {
+		"@sinclair/typebox": "*"
+	},
+	"devDependencies": {
+		"@biomejs/biome": "^1.9.4",
+		"@mariozechner/pi-ai": "^0.67.68",
+		"@mixmark-io/domino": "^2.2.0",
+		"@types/micromatch": "^4.0.10",
+		"@types/node": "^22.15.2",
+		"@types/shell-quote": "^1.7.5",
+		"@types/turndown": "^5.0.5",
+		"husky": "^9.1.7",
+		"node-pty": "^1.1.0",
+		"playwright": "^1.52.0",
+		"tsx": "^4.21.0",
+		"turndown": "^7.2.0",
+		"typescript": "^5.7.3",
+		"vitest": "^3.1.1"
+	},
+	"engines": {
+		"node": ">=22.0.0"
+	},
+	"packageManager": "pnpm@10.8.1",
+	"pnpm": {
+		"onlyBuiltDependencies": [
+			"@biomejs/biome",
+			"esbuild",
+			"koffi",
+			"node-pty",
+			"protobufjs"
+		]
+	}
 }

--- a/scripts/build-binary.js
+++ b/scripts/build-binary.js
@@ -7,7 +7,9 @@
 //   node scripts/build-binary.js --target linux-x64     # cross-compile for Linux x86-64
 
 import { execSync } from "node:child_process"
+import { existsSync, symlinkSync, unlinkSync } from "node:fs"
 import { platform } from "node:os"
+import { join } from "node:path"
 
 const TARGET_MAP = {
 	"linux-arm64": "bun-linux-arm64",
@@ -50,3 +52,10 @@ if (!isCrossCompile && platform() === "darwin") {
 }
 
 run("copy resources", "node scripts/copy-resources.js")
+// Create symlink for kimchi
+const kimchiPath = join("dist", "bin", "kimchi")
+if (existsSync(kimchiPath)) {
+	unlinkSync(kimchiPath)
+}
+// Create symlink with relative target (same directory)
+symlinkSync("kimchi-code", kimchiPath)

--- a/scripts/build-binary.js
+++ b/scripts/build-binary.js
@@ -52,10 +52,9 @@ if (!isCrossCompile && platform() === "darwin") {
 }
 
 run("copy resources", "node scripts/copy-resources.js")
-// Create symlink for kimchi
+
 const kimchiPath = join("dist", "bin", "kimchi")
 if (existsSync(kimchiPath)) {
 	unlinkSync(kimchiPath)
 }
-// Create symlink with relative target (same directory)
 symlinkSync("kimchi-code", kimchiPath)

--- a/scripts/install-local.js
+++ b/scripts/install-local.js
@@ -27,12 +27,11 @@ const shareDest = join(prefix, "share", "kimchi")
 
 mkdirSync(binDest, { recursive: true })
 cpSync(distBin, join(binDest, "kimchi-code"))
-// Create symlink for kimchi
+
 const kimchiPath = join(binDest, "kimchi")
 if (existsSync(kimchiPath)) {
 	unlinkSync(kimchiPath)
 }
-// Create symlink with relative target (same directory)
 symlinkSync("kimchi-code", kimchiPath)
 
 cpSync(distShare, shareDest, { recursive: true })

--- a/scripts/install-local.js
+++ b/scripts/install-local.js
@@ -3,7 +3,7 @@
 //
 // Usage: node scripts/install-local.js
 
-import { cpSync, existsSync, mkdirSync } from "node:fs"
+import { cpSync, existsSync, mkdirSync, symlinkSync, unlinkSync } from "node:fs"
 import { homedir } from "node:os"
 import { dirname, join } from "node:path"
 import { fileURLToPath } from "node:url"
@@ -27,8 +27,16 @@ const shareDest = join(prefix, "share", "kimchi")
 
 mkdirSync(binDest, { recursive: true })
 cpSync(distBin, join(binDest, "kimchi-code"))
+// Create symlink for kimchi
+const kimchiPath = join(binDest, "kimchi")
+if (existsSync(kimchiPath)) {
+	unlinkSync(kimchiPath)
+}
+// Create symlink with relative target (same directory)
+symlinkSync("kimchi-code", kimchiPath)
 
 cpSync(distShare, shareDest, { recursive: true })
 
 console.log(`Installed binary  → ${join(binDest, "kimchi-code")}`)
+console.log(`Installed symlink → ${join(binDest, "kimchi")}`)
 console.log(`Installed share   → ${shareDest}`)

--- a/src/extensions/orchestration/prompt-transformer/prompts/shared.ts
+++ b/src/extensions/orchestration/prompt-transformer/prompts/shared.ts
@@ -15,7 +15,52 @@ export const CORE_GUIDELINES = `- Be concise in your responses.
 - Do NOT introduce security vulnerabilities.
 - Do NOT add features, refactoring, or improvements beyond what was asked.
 - If you encounter an error, diagnose the root cause before retrying.
-- **Pattern recognition**: If the same implementation pattern is needed more than twice, define the abstraction first, then implement.`
+- **Pattern recognition**: If the same implementation pattern is needed more than twice, define the abstraction first, then implement.
+
+### Error fingerprint analysis (when investigating bugs with error messages)
+
+When investigating bugs that include error messages, you MUST analyze the errors as forensic evidence BEFORE searching for code matches.
+
+**Do NOT treat error messages as simple text to search for — analyze their STRUCTURE and ORIGIN.**
+
+**Error pattern recognition:**
+- \`Cannot find module 'X' from 'Y'\` → Node.js/Bun JavaScript module resolution
+- \`/$bunfs/root/PATH\` → Bun bundled binary virtual filesystem (external system)
+- \`invalid provider "X": must be one of [...]\` → Pydantic/LiteLLM Python validation
+- \`ValidationError:\` → Pydantic schema validation
+- \`panic: X\` → Go runtime error
+- \`ModuleNotFoundError\` → Python import error
+
+**System boundary detection:**
+- Error format incompatible with current repo's language → External system
+- Path references other binaries (e.g., \`kimchi-code\` vs \`kimchi\`) → External binary
+- Virtual/bundled paths (/bunfs/, /proc/) → Containerized/bundled runtime
+
+**If error fingerprint analysis suggests an external system:**
+- Identify the likely external system BEFORE extensive in-scope searching
+- Map the dependency chain: This repo → [intermediate] → Error source
+
+### Cross-scope investigation (when in-scope search yields no results)
+
+If your code search finds zero relevant matches for error-related terms, you MUST complete cross-scope analysis before concluding.
+
+**Do NOT say "bug not in this repo" without identifying WHERE it likely IS.**
+
+**Required for cross-repo bugs:**
+1. **Bug location hypothesis** with confidence level (High/Medium/Low)
+2. **Evidence chain** linking error fingerprints to external system
+3. **Specific fix location**: External repo file/config path where change must be made
+4. **Actionable output** including:
+   - External system name
+   - Specific file/config path in external repo
+   - Exact change required (with before/after example if applicable)
+   - Connection: how this repo relates to external system
+
+**Forbidden conclusions (unacceptable):**
+- ❌ "Bug not in this repo" — WITHOUT saying where it IS
+- ❌ "External issue" — WITHOUT naming the specific system
+- ❌ "Check other repos" — WITHOUT specific guidance
+- ❌ Any conclusion without documented evidence chain`
 
 export const DOCUMENTS_SECTION = `## Documents
 


### PR DESCRIPTION
## Summary

Adds Error Fingerprint Analysis and Cross-Scope Investigation requirements to CORE_GUIDELINES.

## Changes

Modified `src/extensions/orchestration/prompt-transformer/prompts/shared.ts` to add:

### Error Fingerprint Analysis
When investigating bugs with error messages, agents MUST analyze errors as forensic evidence BEFORE searching code:

- **Error pattern recognition**: Common patterns mapped to source systems
  - `Cannot find module` → Node.js/Bun JavaScript
  - `/$bunfs/root/` → Bun virtual filesystem (external)
  - `invalid provider "X"` → Pydantic/LiteLLM validation
  - `panic:` → Go runtime
  - etc.

- **System boundary detection**: How to identify external vs in-scope systems

### Cross-Scope Investigation
When in-scope search yields no results, agents MUST:

- Identify WHERE the bug likely IS (not just "not here")
- Provide bug location hypothesis with confidence level
- Document evidence chain
- Specify exact fix location in external repo
- Include actionable output format

**Forbidden**: "Not in this repo" without saying where it IS

## Background
Based on 2809e forensic analysis:
- kimi-k2.5: 17 tool calls, concluded "not here" with zero actionable follow-up
- opus 4.7: 7 tool calls, identified exact root cause in external repo

Key gaps addressed:
1. Errors treated as regex targets instead of forensic evidence
2. No cross-repo hypothesis formation
3. Zero actionable attribution for external bugs

---
### Kimchi Summary
### What changed
Introduces a `kimchi` CLI alias (symlinked to `kimchi-code`) and adds AI prompting guidelines for forensic error analysis and cross-repository debugging.

### Why
Provides a shorter, more ergonomic CLI command. The new error fingerprinting rules enable the AI to recognize when errors stem from external systems (bundlers, dependencies, or other repositories) based on error message structure and paths, preventing wasted in-scope searches.

### Key changes
- `package.json`: Added `kimchi` bin entry and removed duplicate `prepare` script
- `scripts/build-binary.js`: Creates `dist/bin/kimchi` symlink pointing to `kimchi-code` post-build
- `scripts/install-local.js`: Creates `kimchi` symlink in the install prefix bin directory
- `src/extensions/orchestration/prompt-transformer/prompts/shared.ts`: Added detailed `Error fingerprint analysis` guidelines (pattern recognition for Node.js/Bun/Pydantic/Go errors, system boundary detection) and `Cross-scope investigation` requirements (mandatory bug location hypothesis, evidence chains, and external fix locations when errors are not found in-scope)

### Impact
None. The symlink approach ensures `kimchi-code` continues to work while adding the shorter `kimchi` alternative.