### PR TITLE
NOJIRA: Remove duplicated permissions warning

### DIFF
--- a/benchmark/manual/benchmark.json
+++ b/benchmark/manual/benchmark.json
@@ -1,7 +1,7 @@
 {
   "binary": "kimchi-code",
   "models": [
-    "kimi-k2.5",
+    "kimi-k2.6",
     "minimax-m2.7"
   ]
 }

--- a/src/extensions/permissions/index.ts
+++ b/src/extensions/permissions/index.ts
@@ -87,7 +87,6 @@ export default function permissionsExtension(pi: ExtensionAPI): void {
 	let cliMode: PermissionMode | undefined
 	let originalActiveTools: string[] | null = null
 	let planModeApplied = false
-	let yoloWarningShown = false
 	/** Tracks all active permission prompt abort controllers for concurrent tool calls. */
 	const activeAbortControllers = new Set<AbortController>()
 	let unsubscribeTerminalInput: (() => void) | null = null
@@ -182,13 +181,6 @@ export default function permissionsExtension(pi: ExtensionAPI): void {
 		for (const ctrl of activeAbortControllers) ctrl.abort()
 		activeAbortControllers.clear()
 		maybeShowYoloWarning(ctx, next)
-		// Show danger warning when switching to yolo mode (only once per session)
-		if (next === "yolo" && ctx.hasUI && !yoloWarningShown) {
-			yoloWarningShown = true
-			const dangerMsg =
-				"DANGER: Running in YOLO mode. All permission checks are disabled. The agent will execute commands without confirmation. This can modify or delete files. Intended for use in disposable or sandboxed environments only. Not recommended for production use."
-			ctx.ui.notify(ctx.ui.theme.fg("error", dangerMsg), "warning")
-		}
 	}
 
 	function doLoadConfig(ctx: ExtensionContext): { errors: string[] } {


### PR DESCRIPTION
This duplicated permissions warning was a result of incorrect merge of the recent changes. 

---
### Kimchi Summary
### What changed
Eliminated duplicate YOLO mode warning notifications when switching permission modes and updated the benchmark configuration to reference the latest model version.

### Why
The danger warning for YOLO mode was being displayed twice per session—once by `maybeShowYoloWarning()` and again by inline notification logic—causing redundant user alerts.

### Key changes
- `src/extensions/permissions/index.ts`: Removed the `yoloWarningShown` session flag and redundant inline warning notification block; the existing `maybeShowYoloWarning()` call now handles the single notification
- `benchmark/manual/benchmark.json`: Updated model reference from `kimi-k2.5` to `kimi-k2.6`

### Impact
Users will see the YOLO mode danger warning exactly once per session instead of twice. No breaking changes or migration steps required.