### PR TITLE
chore: remove trailing whitespace in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ Use `/tags` without arguments to see help and current static tag configuration.
 
 Tags use `key:value` format with these rules:
 - Must start and end with alphanumeric characters
-- Middle characters can include hyphens (`-`), underscores (`_`), and dots (`.`) 
+- Middle characters can include hyphens (`-`), underscores (`_`), and dots (`.`)
 - Key and value must each be 64 characters or less
 - Maximum 10 tags total (including static tags and the auto-added model tag)
 


### PR DESCRIPTION
## Summary
- Remove a single trailing space on README.md:83 in the tag-format bullet list.

## Test plan
- [x] `git diff` shows only whitespace removed; no rendered content changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
### Kimchi Summary
### What changed
Remove trailing whitespace from the tag format documentation in `README.md`.

### Key changes
- `README.md`: Removed trailing whitespace from the bullet point describing allowed middle characters in tags.