### PR TITLE
NOJIRA: Always show controls line in script footer

### DIFF
--- a/src/components/footer.ts
+++ b/src/components/footer.ts
@@ -8,6 +8,7 @@ import { truncateToWidth, visibleWidth } from "@mariozechner/pi-tui"
 import { RST_FG, TEAL_FG, resolvedSemanticFg } from "../ansi.js"
 import { formatCount } from "../extensions/format.js"
 import { getMultiModelEnabled } from "../extensions/orchestration/prompt-enrichment.js"
+import { getCurrentPermissionsMode } from "../extensions/permissions/index.js"
 import { getActiveSubagentCount } from "../extensions/subagent.js"
 import { getActiveTags, getCurrentPhase, parseTag } from "../extensions/tags.js"
 
@@ -87,11 +88,19 @@ export function buildScriptPayload(
 			total_output_tokens: totalOutput,
 		},
 		exceeds_200k_tokens: (usage?.tokens ?? 0) > 200_000,
+		permissions: {
+			mode: getCurrentPermissionsMode(),
+		},
+		multi_model: {
+			enabled: getMultiModelEnabled(),
+		},
 	}
 }
 
 export class ScriptFooter implements Component {
 	private cachedLines: string[] = []
+
+	constructor(private getControlsLine: () => string | null) {}
 
 	setLines(lines: string[]): void {
 		this.cachedLines = lines
@@ -100,7 +109,9 @@ export class ScriptFooter implements Component {
 	invalidate(): void {}
 
 	render(width: number): string[] {
-		return this.cachedLines.map((line) => truncateToWidth(line, width))
+		const controls = this.getControlsLine()
+		const scriptLines = this.cachedLines.map((line) => truncateToWidth(line, width))
+		return controls ? [truncateToWidth(controls, width), ...scriptLines] : scriptLines
 	}
 }
 

--- a/src/components/footer.ts
+++ b/src/components/footer.ts
@@ -113,7 +113,7 @@ export class ScriptFooter implements Component {
 		const scriptLines = this.cachedLines.map((line) => truncateToWidth(line, width))
 		if (!controls) return scriptLines
 		const sep = `\x1b[2m${"─".repeat(width)}\x1b[0m`
-		return [truncateToWidth(controls, width), sep, ...scriptLines]
+		return [...scriptLines, sep, truncateToWidth(controls, width)]
 	}
 }
 

--- a/src/components/footer.ts
+++ b/src/components/footer.ts
@@ -112,7 +112,7 @@ export class ScriptFooter implements Component {
 		const controls = this.getControlsLine()
 		const scriptLines = this.cachedLines.map((line) => truncateToWidth(line, width))
 		if (!controls) return scriptLines
-		const sep = `\x1b[2m${"─".repeat(width)}\x1b[0m`
+		const sep = `\x1b[90m${"─".repeat(width)}\x1b[0m`
 		return [...scriptLines, sep, truncateToWidth(controls, width)]
 	}
 }

--- a/src/components/footer.ts
+++ b/src/components/footer.ts
@@ -112,8 +112,7 @@ export class ScriptFooter implements Component {
 		const controls = this.getControlsLine()
 		const scriptLines = this.cachedLines.map((line) => truncateToWidth(line, width))
 		if (!controls) return scriptLines
-		const sep = `\x1b[90m${"─".repeat(width)}\x1b[0m`
-		return [...scriptLines, sep, truncateToWidth(controls, width)]
+		return [...scriptLines, "", truncateToWidth(controls, width)]
 	}
 }
 

--- a/src/components/footer.ts
+++ b/src/components/footer.ts
@@ -111,7 +111,9 @@ export class ScriptFooter implements Component {
 	render(width: number): string[] {
 		const controls = this.getControlsLine()
 		const scriptLines = this.cachedLines.map((line) => truncateToWidth(line, width))
-		return controls ? [truncateToWidth(controls, width), ...scriptLines] : scriptLines
+		if (!controls) return scriptLines
+		const sep = `\x1b[2m${"─".repeat(width)}\x1b[0m`
+		return [truncateToWidth(controls, width), sep, ...scriptLines]
 	}
 }
 

--- a/src/extensions/permissions/index.ts
+++ b/src/extensions/permissions/index.ts
@@ -41,6 +41,12 @@ const MODES: Array<{ mode: PermissionMode; label: string; color: "success" | "wa
 	{ mode: "yolo", label: "yolo", color: "error" },
 ]
 
+let _currentPermissionsMode: PermissionMode = "default"
+
+export function getCurrentPermissionsMode(): PermissionMode {
+	return _currentPermissionsMode
+}
+
 export default function permissionsExtension(pi: ExtensionAPI): void {
 	pi.registerFlag("plan", {
 		description: "Start in plan mode (read-only exploration).",
@@ -155,6 +161,7 @@ export default function permissionsExtension(pi: ExtensionAPI): void {
 	function updateStatus(ctx: ExtensionContext): void {
 		if (!ctx.hasUI) return
 		const mode = currentMode()
+		_currentPermissionsMode = mode
 		const active = MODES.find((m) => m.mode === mode) ?? MODES[0]
 		// Filled dot + active label hardcode kimchi palette so the cue stays legible
 		// under kimchi-minimal; unfilled dots + hint use the "text" token to match

--- a/src/extensions/ui.ts
+++ b/src/extensions/ui.ts
@@ -87,7 +87,9 @@ function runScript(scriptPath: string, payload: object, tui: TUI, footer: Script
 
 	child.on("close", (code) => {
 		if (code === 0 && stdout) {
-			settle(stdout.split("\n").filter((l) => l.trim() !== ""))
+			const lines = stdout.split("\n")
+			while (lines.length > 0 && lines[lines.length - 1].trim() === "") lines.pop()
+			settle(lines)
 		} else if (stderr) {
 			settle([`\x1b[31m[statusline error] ${stderr.trim()}\x1b[0m`])
 		} else {

--- a/src/extensions/ui.ts
+++ b/src/extensions/ui.ts
@@ -4,12 +4,14 @@ import type { ExtensionAPI, ExtensionContext } from "@mariozechner/pi-coding-age
 import { isEditToolResult, isWriteToolResult } from "@mariozechner/pi-coding-agent"
 import { isKeyRelease, matchesKey } from "@mariozechner/pi-tui"
 import type { TUI } from "@mariozechner/pi-tui"
+import { RST_FG, TEAL_FG } from "../ansi.js"
 import { PromptEditor } from "../components/editor.js"
 import { ScriptFooter, StatsFooter, buildScriptPayload, readStatusLineCommand } from "../components/footer.js"
 import { LogoHeader } from "../components/logo.js"
 import { SplashHeader } from "../components/splash-header.js"
 import { collapseAll, expandNext, resetState } from "../expand-state.js"
 import { isBareExitAlias } from "./exit-utils.js"
+import { getMultiModelEnabled } from "./orchestration/prompt-enrichment.js"
 
 function modelsAreEqual(a: Model<Api>, b: Model<Api>): boolean {
 	return a.provider === b.provider && a.id === b.id
@@ -143,7 +145,17 @@ export default function uiExtension(pi: ExtensionAPI) {
 				return new StatsFooter(ctx, theme, footerData)
 			}
 			scriptCmd = cmd
-			scriptFooter = new ScriptFooter()
+			const getControlsLine = (): string | null => {
+				const parts: string[] = []
+				const perm = footerData.getExtensionStatuses().get("permissions-mode")
+				if (perm) parts.push(perm)
+				const enabled = getMultiModelEnabled()
+				const label = enabled ? `${TEAL_FG}on${RST_FG}` : theme.fg("dim", "off")
+				const shortcut = process.platform === "darwin" ? "option+tab" : "alt+tab"
+				parts.push(`${theme.fg("dim", "multi-model:")} ${label} ${theme.fg("dim", `→ ${shortcut}`)}`)
+				return parts.join(` ${theme.fg("dim", "·")} `)
+			}
+			scriptFooter = new ScriptFooter(getControlsLine)
 			scriptTui = tui
 			scriptPending = true
 			const gen = scriptGeneration


### PR DESCRIPTION
## Summary

When a custom script-based statusline is configured, `ScriptFooter` completely replaced `StatsFooter`, hiding the permissions mode indicator (○ ○ ● ○ auto → shift+tab) and multi-model toggle.

- `ScriptFooter` now accepts a `getControlsLine` callback and prepends its output as the first line
- The callback is built in the `setFooter` factory from `footerData` + `theme`, rendering permissions mode and multi-model state identically to `StatsFooter`
- `buildScriptPayload` includes `permissions.mode` and `multi_model.enabled` for kimchi-aware scripts
- `getCurrentPermissionsMode()` exported from the permissions extension (module-level var updated in `updateStatus`)

## Test plan

- [ ] Start kimchi with `statusLine.command` set → controls line visible above script output
- [ ] Press shift+tab → dots update on next render
- [ ] Press alt+tab → multi-model label toggles on next render  
- [ ] Remove `statusLine.command` → `StatsFooter` unchanged

---
### Kimchi Summary
### What changed
Adds a dynamic controls line to the script footer displaying the current permissions mode and multi-model status, and exposes the permissions mode state to other extensions.

### Why
Users need visibility into active permission modes and multi-model orchestration settings when viewing script output, and extensions require programmatic access to the current permissions mode.

### Key changes
- **`src/components/footer.ts`**: 
  - Modified `ScriptFooter` constructor to accept a `getControlsLine` callback for dynamic footer content
  - Updated `render()` to append the controls line below script output when available
  - Extended `buildScriptPayload()` to include `permissions.mode` and `multi_model.enabled` metadata fields
- **`src/extensions/permissions/index.ts`**: 
  - Added `getCurrentPermissionsMode()` export to expose current mode state
  - Added `_currentPermissionsMode` internal state updated on status changes
- **`src/extensions/ui.ts`**: 
  - Implemented `getControlsLine` showing permissions status, multi-model toggle state (colored `on`/`off`), and platform-specific shortcut (`option+tab` or `alt+tab`)
  - Fixed `runScript()` to preserve intentional empty lines in output while trimming only trailing whitespace

### Impact
- **Visual**: Script footers now display live controls for permissions mode and multi-model settings
- **API**: Extensions can import `getCurrentPermissionsMode()` to read the current mode
- **Behavior**: Script output parsing preserves middle empty lines; only trailing empty lines are removed