### PR TITLE
Fix MiniMax thinking tokens leaking into subagent output

### DIFF
--- a/src/extensions/output-filter-extension.ts
+++ b/src/extensions/output-filter-extension.ts
@@ -1,9 +1,14 @@
-import type { AssistantMessage } from "@mariozechner/pi-ai"
+import type { AssistantMessage, ThinkingContent } from "@mariozechner/pi-ai"
 import { type ExtensionAPI, SettingsManager } from "@mariozechner/pi-coding-agent"
-import { filterOutputTags, stripOutputTagWrappers } from "./output-tag-filter.js"
+import { filterOutputTags, splitOutputTags } from "./output-tag-filter.js"
 
 export default function outputFilterExtension(pi: ExtensionAPI) {
 	const rawByIndex = new Map<number, string>()
+	// Tracks the ThinkingContent block inserted for a given content index, plus
+	// a direct reference to the original TextContent block so we can continue
+	// updating it after the splice shifts its position in message.content.
+	type IndexEntry = { thinkingBlock: ThinkingContent; textRef: { text: string } }
+	const insertedByIndex = new Map<number, IndexEntry>()
 
 	const settingsManager = SettingsManager.create()
 
@@ -14,6 +19,7 @@ export default function outputFilterExtension(pi: ExtensionAPI) {
 	pi.on("message_start", (event) => {
 		if (event.message.role === "assistant") {
 			rawByIndex.clear()
+			insertedByIndex.clear()
 		}
 	})
 
@@ -25,11 +31,68 @@ export default function outputFilterExtension(pi: ExtensionAPI) {
 		const raw = (rawByIndex.get(idx) ?? "") + ame.delta
 		rawByIndex.set(idx, raw)
 
-		const processed = settingsManager.getHideThinkingBlock() ? filterOutputTags(raw) : stripOutputTagWrappers(raw)
 		const message = event.message as AssistantMessage
-		const content = message.content[idx]
-		if (content?.type === "text") {
-			content.text = processed
+
+		if (settingsManager.getHideThinkingBlock()) {
+			const content = message.content[idx]
+			if (!content || content.type !== "text") return
+			content.text = filterOutputTags(raw)
+		} else {
+			// Split inline <think>...</think> blocks from the visible text so the
+			// framework renders them as proper ThinkingContent blocks (italic,
+			// collapsible) rather than as plain inline text.
+			const { visible, thinking } = splitOutputTags(raw)
+
+			const existing = insertedByIndex.get(idx)
+			if (existing) {
+				// We already spliced a ThinkingContent block before the text block;
+				// use the saved references — don't look up by index which has shifted.
+				existing.thinkingBlock.thinking = thinking
+				existing.textRef.text = visible
+			} else {
+				const content = message.content[idx]
+				if (!content || content.type !== "text") return
+				content.text = visible
+
+				if (thinking) {
+					// Insert a ThinkingContent block immediately before the text block
+					// and save references to both so future deltas can update them
+					// without relying on the now-shifted content index.
+					const thinkingBlock: ThinkingContent = { type: "thinking", thinking }
+					message.content.splice(idx, 0, thinkingBlock)
+					insertedByIndex.set(idx, { thinkingBlock, textRef: content })
+				}
+			}
+		}
+	})
+
+	pi.on("message_end", (event) => {
+		// Restore the raw accumulated text (with <think>...</think> tags intact) into
+		// the text content blocks before the message is persisted to history.
+		// This ensures models like MiniMax that require interleaved thinking tokens
+		// to be passed back in their original <think>...</think> format receive them
+		// correctly on subsequent turns.
+		// The ThinkingContent blocks we inserted are removed since the raw text
+		// already carries the thinking inline; leaving them would cause double-sending.
+		if (event.message.role !== "assistant") return
+		if (insertedByIndex.size === 0) return
+
+		const message = event.message as AssistantMessage
+
+		for (const [, { thinkingBlock, textRef }] of insertedByIndex) {
+			// Find and remove the ThinkingContent block we inserted
+			const thinkIdx = message.content.indexOf(thinkingBlock)
+			if (thinkIdx !== -1) {
+				message.content.splice(thinkIdx, 1)
+			}
+		}
+
+		// Restore raw text (with tags) to each text block
+		for (const [idx, raw] of rawByIndex) {
+			const entry = insertedByIndex.get(idx)
+			if (entry) {
+				entry.textRef.text = raw
+			}
 		}
 	})
 }

--- a/src/extensions/output-filter-extension.ts
+++ b/src/extensions/output-filter-extension.ts
@@ -79,8 +79,7 @@ export default function outputFilterExtension(pi: ExtensionAPI) {
 
 		const message = event.message as AssistantMessage
 
-		for (const [, { thinkingBlock, textRef }] of insertedByIndex) {
-			// Find and remove the ThinkingContent block we inserted
+		for (const [, { thinkingBlock }] of insertedByIndex) {
 			const thinkIdx = message.content.indexOf(thinkingBlock)
 			if (thinkIdx !== -1) {
 				message.content.splice(thinkIdx, 1)
@@ -94,5 +93,19 @@ export default function outputFilterExtension(pi: ExtensionAPI) {
 				entry.textRef.text = raw
 			}
 		}
+
+		// Re-apply display filtering after the framework has had a chance to
+		// persist the raw text to history. queueMicrotask runs after the current
+		// synchronous call stack (where history persistence happens) but before
+		// the next I/O callback, which is before the TUI renders.
+		const snapshot = new Map(rawByIndex)
+		queueMicrotask(() => {
+			for (const [idx, raw] of snapshot) {
+				const entry = insertedByIndex.get(idx)
+				if (!entry) continue
+				const { visible } = splitOutputTags(raw)
+				if (visible.trim()) entry.textRef.text = visible
+			}
+		})
 	})
 }

--- a/src/extensions/output-tag-filter.test.ts
+++ b/src/extensions/output-tag-filter.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest"
-import { filterOutputTags, stripOutputTagWrappers } from "./output-tag-filter.js"
+import { filterOutputTags, splitOutputTags, stripOutputTagWrappers } from "./output-tag-filter.js"
 
 describe("stripOutputTagWrappers", () => {
 	const cases: Record<string, { input: string; expected: string }> = {
@@ -103,6 +103,65 @@ describe("filterOutputTags", () => {
 	for (const [name, { input, expected }] of Object.entries(cases)) {
 		it(name, () => {
 			expect(filterOutputTags(input)).toBe(expected)
+		})
+	}
+})
+
+describe("splitOutputTags", () => {
+	const cases: Record<string, { input: string; expected: { visible: string; thinking: string } }> = {
+		"splits complete think block from answer": {
+			input: "<think>some reasoning</think>answer",
+			expected: { visible: "answer", thinking: "some reasoning" },
+		},
+		"splits multiline think block": {
+			input: "<think>\nline one\nline two\n</think>answer",
+			expected: { visible: "answer", thinking: "\nline one\nline two\n" },
+		},
+		"splits multiple think blocks": {
+			input: "<think>first</think>middle<think>second</think>end",
+			expected: { visible: "middleend", thinking: "firstsecond" },
+		},
+		"holds incomplete think block at start (streaming hold)": {
+			input: "<think>incomplete reasoning",
+			expected: { visible: "", thinking: "" },
+		},
+		"holds incomplete think block after complete block at start": {
+			input: "<think>done</think><think>incomplete",
+			expected: { visible: "", thinking: "done" },
+		},
+		"keeps incomplete think block in visible when it follows visible text": {
+			input: "prefix<think>incomplete reasoning",
+			expected: { visible: "prefix<think>incomplete reasoning", thinking: "" },
+		},
+		"keeps visible text when second incomplete think block follows": {
+			input: "<think>done</think>visible<think>incomplete",
+			expected: { visible: "visible<think>incomplete", thinking: "done" },
+		},
+		"passes through text without think tags": {
+			input: "plain text without tags",
+			expected: { visible: "plain text without tags", thinking: "" },
+		},
+		"returns empty for empty string": {
+			input: "",
+			expected: { visible: "", thinking: "" },
+		},
+		"leaves unrelated tags in visible": {
+			input: "<b>bold</b> and <i>italic</i>",
+			expected: { visible: "<b>bold</b> and <i>italic</i>", thinking: "" },
+		},
+		"splits think block at start with content after": {
+			input: "<think>reasoning</think> actual output",
+			expected: { visible: " actual output", thinking: "reasoning" },
+		},
+		"splits text before and after think block": {
+			input: "before <think>hidden</think> after",
+			expected: { visible: "before  after", thinking: "hidden" },
+		},
+	}
+
+	for (const [name, { input, expected }] of Object.entries(cases)) {
+		it(name, () => {
+			expect(splitOutputTags(input)).toEqual(expected)
 		})
 	}
 })

--- a/src/extensions/output-tag-filter.ts
+++ b/src/extensions/output-tag-filter.ts
@@ -26,3 +26,59 @@ export function filterOutputTags(text: string): string {
 	}
 	return result
 }
+
+/**
+ * Splits accumulated text into separate visible and thinking channels.
+ *
+ * Completed <think>...</think> blocks have their inner content routed to
+ * `thinking`. Everything else (including text before/after think blocks, and
+ * incomplete think blocks that follow visible text) goes to `visible`.
+ *
+ * Incomplete think blocks at the very start of the text (only whitespace
+ * before them) are held — neither channel grows — so the caller's length
+ * comparison won't emit anything until the block is closed or more context
+ * arrives.
+ */
+export function splitOutputTags(text: string): { visible: string; thinking: string } {
+	const tag = "think"
+	const open = `<${tag}>`
+	const close = `</${tag}>`
+
+	let visible = ""
+	let thinking = ""
+	let remaining = text
+
+	while (remaining.length > 0) {
+		const openIdx = remaining.indexOf(open)
+		if (openIdx === -1) {
+			// No open tag — everything is visible
+			visible += remaining
+			break
+		}
+
+		// Text before the open tag is always visible
+		const before = remaining.slice(0, openIdx)
+		const afterOpen = remaining.slice(openIdx + open.length)
+		const closeIdx = afterOpen.indexOf(close)
+
+		if (closeIdx === -1) {
+			// Incomplete block — no closing tag yet.
+			// If only whitespace precedes this open tag (and visible is empty so far),
+			// hold the entire remainder so neither channel grows (streaming hold).
+			// Otherwise keep the prefix visible and hold the incomplete block.
+			if (visible === "" && before.trim() === "") {
+				// Hold — don't advance either channel
+				break
+			}
+			visible += before + open + afterOpen
+			break
+		}
+
+		// Completed block
+		visible += before
+		thinking += afterOpen.slice(0, closeIdx)
+		remaining = afterOpen.slice(closeIdx + close.length)
+	}
+
+	return { visible, thinking }
+}

--- a/src/extensions/subagent.ts
+++ b/src/extensions/subagent.ts
@@ -18,7 +18,7 @@ import { isBunBinary, isRunningUnderBun } from "../env.js"
 import { isToolExpanded, registerToolCall } from "../expand-state.js"
 import { findExistingFile, resolveUserPath, stripAtPrefix } from "../fs-paths.js"
 import { formatCount, formatDuration } from "./format.js"
-import { filterOutputTags, stripOutputTagWrappers } from "./output-tag-filter.js"
+import { filterOutputTags, splitOutputTags } from "./output-tag-filter.js"
 import { type SpinnerState, clearSpinner, spinnerFrame, tickSpinner } from "./spinner.js"
 
 const PROMPT_MAX_LENGTH = 60
@@ -398,7 +398,7 @@ function spawnSubagent(
 			} = parseSubagentEvent(line)
 			if (delta !== null) {
 				accumulated += delta
-				onToken(hideThinkingBlock ? filterOutputTags(accumulated) : stripOutputTagWrappers(accumulated))
+				onToken(hideThinkingBlock ? filterOutputTags(accumulated) : splitOutputTags(accumulated).visible)
 			}
 			if (lineInput > 0 || lineOutput > 0) {
 				inputTokens += lineInput
@@ -743,8 +743,7 @@ export default function (pi: ExtensionAPI) {
 				}
 			}
 
-			const resultText =
-				(hideThinkingBlock ? filterOutputTags(accumulated) : stripOutputTagWrappers(accumulated)) || "(no output)"
+			const resultText = filterOutputTags(accumulated) || "(no output)"
 			const parsed = parseSubagentResponse(resultText)
 			if (parsed === null) {
 				return {

--- a/src/models.ts
+++ b/src/models.ts
@@ -55,7 +55,12 @@ interface PiModelConfig {
 	input: ("text" | "image")[]
 	contextWindow: number
 	maxTokens: number
-	cost: { input: number; output: number; cacheRead: number; cacheWrite: number }
+	cost: {
+		input: number
+		output: number
+		cacheRead: number
+		cacheWrite: number
+	}
 	compat?: { supportsReasoningEffort?: boolean }
 }
 

--- a/src/modes/acp/server.ts
+++ b/src/modes/acp/server.ts
@@ -31,7 +31,7 @@ import {
 	SettingsManager,
 	createAgentSession,
 } from "@mariozechner/pi-coding-agent"
-import { filterOutputTags, stripOutputTagWrappers } from "../../extensions/output-tag-filter.js"
+import { filterOutputTags, splitOutputTags, stripOutputTagWrappers } from "../../extensions/output-tag-filter.js"
 
 /**
  * Produces a ready-to-use AgentSession for a newSession request. The returned
@@ -59,7 +59,7 @@ type TurnContext = {
 	turnActive: boolean
 	resolve: (res: PromptResponse) => void
 	reject: (err: unknown) => void
-	streamState: { rawAccumulated: string; emittedFiltered: string }
+	streamState: { rawAccumulated: string; emittedFiltered: string; emittedThinking: string }
 }
 
 type SessionEntry = {
@@ -160,7 +160,7 @@ export class KimchiAcpAgent implements Agent {
 			turnActive: false,
 			resolve: turnResolve,
 			reject: turnReject,
-			streamState: { rawAccumulated: "", emittedFiltered: "" },
+			streamState: { rawAccumulated: "", emittedFiltered: "", emittedThinking: "" },
 		}
 		// Kick off session.prompt but don't await inside the async function body —
 		// shutdown() needs to be able to reject `result` and have the caller's await
@@ -252,19 +252,46 @@ export class KimchiAcpAgent implements Agent {
 				if (ame.type === "text_delta" && ame.delta) {
 					const hideThinkingBlock = entry.session.settingsManager.getHideThinkingBlock()
 					turn.streamState.rawAccumulated += ame.delta
-					const newProcessed = hideThinkingBlock
-						? filterOutputTags(turn.streamState.rawAccumulated)
-						: stripOutputTagWrappers(turn.streamState.rawAccumulated)
-					if (newProcessed.length > turn.streamState.emittedFiltered.length) {
-						const processedDelta = newProcessed.slice(turn.streamState.emittedFiltered.length)
-						turn.streamState.emittedFiltered = newProcessed
-						this.send({
-							sessionId,
-							update: {
-								sessionUpdate: "agent_message_chunk",
-								content: { type: "text", text: processedDelta },
-							},
-						})
+					if (hideThinkingBlock) {
+						const newProcessed = filterOutputTags(turn.streamState.rawAccumulated)
+						if (newProcessed.length > turn.streamState.emittedFiltered.length) {
+							const processedDelta = newProcessed.slice(turn.streamState.emittedFiltered.length)
+							turn.streamState.emittedFiltered = newProcessed
+							this.send({
+								sessionId,
+								update: {
+									sessionUpdate: "agent_message_chunk",
+									content: { type: "text", text: processedDelta },
+								},
+							})
+						}
+					} else {
+						// Route <think>...</think> blocks to agent_thought_chunk and
+						// non-thinking text to agent_message_chunk so inline thinking
+						// (e.g. MiniMax) is displayed as a proper thought block.
+						const { visible, thinking } = splitOutputTags(turn.streamState.rawAccumulated)
+						if (thinking.length > turn.streamState.emittedThinking.length) {
+							const thinkingDelta = thinking.slice(turn.streamState.emittedThinking.length)
+							turn.streamState.emittedThinking = thinking
+							this.send({
+								sessionId,
+								update: {
+									sessionUpdate: "agent_thought_chunk",
+									content: { type: "text", text: thinkingDelta },
+								},
+							})
+						}
+						if (visible.length > turn.streamState.emittedFiltered.length) {
+							const visibleDelta = visible.slice(turn.streamState.emittedFiltered.length)
+							turn.streamState.emittedFiltered = visible
+							this.send({
+								sessionId,
+								update: {
+									sessionUpdate: "agent_message_chunk",
+									content: { type: "text", text: visibleDelta },
+								},
+							})
+						}
 					}
 				} else if (ame.type === "thinking_delta" && ame.delta) {
 					this.send({


### PR DESCRIPTION
## Summary

- `subagent.ts`: replace `stripOutputTagWrappers` with `splitOutputTags(…).visible` for display and `filterOutputTags` for result parsing — prevents raw `<think>` content from appearing inline
- `output-filter-extension.ts`: use `splitOutputTags` for streaming display, restore raw accumulated text on `message_end`
- `server.ts` (ACP): route `agent_thought_chunk` events to the thinking channel correctly
- `output-tag-filter.ts` / `.test.ts`: add `splitOutputTags` function and tests

## Test plan

- [ ] Start subagent with MiniMax model — thinking tokens should not appear in streamed output
- [ ] Subagent result text should contain only visible content (no `<think>` blocks)
- [ ] ACP mode: `agent_thought_chunk` events routed separately from text chunks
- [ ] `pnpm run lint` passes (warning in lsp/client.ts is pre-existing, unrelated)

---
### Kimchi Summary
` tags (represented as ` <think> ...一` in the code, looks like special Unicode characters or placeholders) for reasoning. The PR makes these render as proper collapsible thinking blocks instead of inline text, while ensuring the raw tags are preserved in history for subsequent turns.

Structure:
- **What changed**: Render `<think>` content as proper thinking blocks instead of inline text; preserve raw tags in history for models like MiniMax
- **Why**: MiniMax and similar models use inline thinking tags that need to be split for display but preserved for history
- **Key changes**: 
  - Added `splitOutputTags` function to separate visible and thinking content
  - `output-filter-extension.ts` inserts `ThinkingContent` blocks during streaming, restores raw text on `message_end`
  - `subagent.ts` uses `splitOutputTags` for token output
  - `server.ts` routes thinking to `agent_thought_chunk`
- **Impact**: None mentioned, but ensures models requiring interleaved thinking tokens receive them correctly

Wait, looking at the diff again, the tags appear to be ` <think> ` and `一` (or similar Unicode). The code mentions "MiniMax" in comments. The PR title mentions "minimax-think-tags".

Actually looking closely at the code:
- `const tag = "think"` 
- `const open = `<${tag}>``
- `const close = `</${tag}>``

And in the test:
- "splits complete think block from answer": `input: " <think> some reasoning一answer"`

So it looks like the actual tags are `<think>` and `</think>` but rendered as ` <think> ` and `一` in the test strings? Or perhaps ` <think> ` is `<think>` with some encoding? Actually looking at the raw text in the diff, it seems like ` <think> ` represents the opening tag and `一` represents the closing tag in the test cases.

But the description should probably refer to them as "thinking tags" or `<think>` tags generally.

Key points:
1. Splits inline `<think>` blocks into separate `ThinkingContent` blocks for proper UI rendering (italic, collapsible)
2. Preserves raw text with tags intact in message history for models like MiniMax that require them in subsequent turns
3. Handles streaming deltas correctly by tracking references to blocks after array splicing
4. Routes thinking content to `agent_thought_chunk` in ACP mode

Let me draft the content:

**What changed**
Adds support for rendering inline `<think>` tags (used by MiniMax and similar models) as collapsible thinking blocks instead of plain text. The raw tagged text is preserved in conversation history for subsequent turns while displaying only the visible content to users.

**Why**
Models like MiniMax return reasoning inside `<think>...</think>` tags inline with the response text. Previously this was either stripped or shown as raw inline text. This change parses these tags to show reasoning in dedicated thinking UI blocks while ensuring the original format is preserved for history (required by models that expect the full tagged context on follow-up messages).

**Key changes**
- `src/extensions/output-tag-filter.ts`: Added `splitOutputTags()` to separate visible text from thinking content within `<think>` tags.
- `src/extensions/output-filter-extension.ts`: 
  - Inserts `ThinkingContent` blocks before text content when thinking tags are detected.
  - On `message_end`, restores raw tagged text to message history and removes temporary thinking blocks to prevent duplication.
  - Uses `queueMicrotask` to re-apply display filtering after history persistence.
- `src/extensions/subagent.ts`: Updated token streaming to use `splitOutputTags().visible` instead of `stripOutputTagWrappers`.
- `src/modes/acp/server.ts`: Routes thinking content to `agent_thought_chunk` events and visible text to `agent_message_chunk` events.

**Impact**
- Ensures models requiring interleaved thinking tokens (like MiniMax) receive correctly formatted context on subsequent turns.
- No breaking changes; behavior only affects how thinking content is displayed and stored. </think> ### What changed
Adds support for rendering inline `<think>` tags (used by MiniMax and similar models) as collapsible thinking blocks instead of plain text. The raw tagged text is preserved in conversation history for subsequent turns while displaying only the visible content to users.

### Why
Models like MiniMax return reasoning inside `<think>...</think>` tags inline with the response text. Previously this was either stripped or shown as raw inline text. This change parses these tags to show reasoning in dedicated thinking UI blocks while ensuring the original format is preserved for history (required by models that expect the full tagged context on follow-up messages).

### Key changes
- `src/extensions/output-tag-filter.ts`: Added `splitOutputTags()` to separate visible text from thinking content within `<think>` tags, with special handling for incomplete blocks during streaming.
- `src/extensions/output-filter-extension.ts`: 
  - Tracks inserted `ThinkingContent` blocks and text references by index to handle streaming deltas after array splicing.
  - Inserts `ThinkingContent` blocks before text content when thinking tags are detected.
  - On `message_end`, restores raw tagged text to message history and removes temporary thinking blocks to prevent duplication.
  - Uses `queueMicrotask` to re-apply display filtering after history persistence.
- `src/extensions/subagent.ts`: Updated token streaming to use `splitOutputTags().visible` instead of `stripOutputTagWrappers`.
- `src/modes/acp/server.ts`: Routes thinking content to `agent_thought_chunk` events and visible text to `agent_message_chunk` events, tracking `emittedThinking` and `emittedFiltered` separately.

### Impact
- Ensures models requiring interleaved thinking tokens in their original tagged format (like MiniMax) receive correctly formatted context on subsequent turns.
- No breaking changes; behavior only affects how thinking content is displayed and persisted.