### PR TITLE
NOJIRA: Canary Builds

### DIFF
--- a/.github/workflows/canary.yml
+++ b/.github/workflows/canary.yml
@@ -6,6 +6,7 @@ on:
       - master
     paths:
       - 'src/**'
+      - 'patches/**'
       - 'package.json'
       - 'pnpm-lock.yaml'
       - 'tsconfig.json'

--- a/.github/workflows/canary.yml
+++ b/.github/workflows/canary.yml
@@ -1,12 +1,20 @@
-name: Nightly
+name: Canary
 
 on:
-  schedule:
-    - cron: "0 6 * * *"
+  push:
+    branches:
+      - master
+    paths:
+      - 'src/**'
+      - 'package.json'
+      - 'pnpm-lock.yaml'
+      - 'tsconfig.json'
+      - 'biome.json'
+      - 'scripts/**'
   workflow_dispatch:
     inputs:
       force:
-        description: "Build even if HEAD hasn't moved since the last nightly"
+        description: "Build even if HEAD hasn't moved since the last canary"
         type: boolean
         default: false
 
@@ -14,7 +22,7 @@ permissions:
   contents: read
 
 concurrency:
-  group: nightly
+  group: canary
   cancel-in-progress: false
 
 jobs:
@@ -32,7 +40,7 @@ jobs:
         run: |
           DATE=$(date -u +%Y%m%d)
           SHA=${GITHUB_SHA::7}
-          echo "version=0.0.0-nightly.${DATE}.${SHA}" >> "$GITHUB_OUTPUT"
+          echo "version=0.0.0-canary.${DATE}.${SHA}" >> "$GITHUB_OUTPUT"
 
       - name: Skip if HEAD unchanged
         id: gate
@@ -44,9 +52,9 @@ jobs:
             echo "should-build=true" >> "$GITHUB_OUTPUT"
             exit 0
           fi
-          PREV=$(gh release view nightly --json targetCommitish -q .targetCommitish 2>/dev/null || echo "")
+          PREV=$(gh release view canary --json targetCommitish -q .targetCommitish 2>/dev/null || echo "")
           if [ -n "$PREV" ] && [ "$PREV" = "$GITHUB_SHA" ]; then
-            echo "Nightly already built for $GITHUB_SHA"
+            echo "Canary already built for $GITHUB_SHA"
             echo "should-build=false" >> "$GITHUB_OUTPUT"
           else
             echo "should-build=true" >> "$GITHUB_OUTPUT"
@@ -112,13 +120,13 @@ jobs:
         run: pnpm run build:binary
 
       - name: Package binary
-        run: tar -czf kimchi-code-nightly_${{ matrix.os }}_${{ matrix.arch }}.tar.gz -C dist bin share
+        run: tar -czf kimchi-code-canary_${{ matrix.os }}_${{ matrix.arch }}.tar.gz -C dist bin share
 
       - name: Upload artifact
         uses: actions/upload-artifact@v4
         with:
-          name: kimchi-code-nightly_${{ matrix.os }}_${{ matrix.arch }}
-          path: kimchi-code-nightly_${{ matrix.os }}_${{ matrix.arch }}.tar.gz
+          name: kimchi-code-canary_${{ matrix.os }}_${{ matrix.arch }}
+          path: kimchi-code-canary_${{ matrix.os }}_${{ matrix.arch }}.tar.gz
 
   smoke-test:
     needs: [preflight, build]
@@ -135,12 +143,12 @@ jobs:
       - name: Download linux binary
         uses: actions/download-artifact@v4
         with:
-          name: kimchi-code-nightly_linux_amd64
+          name: kimchi-code-canary_linux_amd64
 
       - name: Extract binary into dist/
         run: |
           mkdir -p dist
-          tar -xzf kimchi-code-nightly_linux_amd64.tar.gz -C dist
+          tar -xzf kimchi-code-canary_linux_amd64.tar.gz -C dist
 
       - name: Smoke tests
         run: pnpm run test:smoke
@@ -167,40 +175,40 @@ jobs:
       - name: Generate checksums
         run: |
           cd artifacts
-          sha256sum kimchi-code-nightly_*.tar.gz > checksums.txt
+          sha256sum kimchi-code-canary_*.tar.gz > checksums.txt
 
       - name: Build release notes
         env:
           GH_TOKEN: ${{ github.token }}
           VERSION: ${{ needs.preflight.outputs.version }}
         run: |
-          PREV_SHA=$(gh release view nightly --json targetCommitish -q .targetCommitish 2>/dev/null || echo "")
+          PREV_SHA=$(gh release view canary --json targetCommitish -q .targetCommitish 2>/dev/null || echo "")
           {
-            echo "> ⚠️ **Unstable nightly build.** No support. Use a tagged release for production."
+            echo "> ⚠️ **Unstable canary build.** No support. Use a tagged release for production."
             echo
-            echo "Nightly build of \`master\` at \`${GITHUB_SHA::7}\`."
+            echo "Canary build of \`master\` at \`${GITHUB_SHA::7}\`."
             echo
             echo "Version: \`$VERSION\`"
             echo
             if [ -n "$PREV_SHA" ] && git rev-parse "$PREV_SHA" >/dev/null 2>&1; then
-              echo "## Changes since last nightly"
+              echo "## Changes since last canary"
               echo
               git log --pretty=format:"- %s (%h)" "${PREV_SHA}..HEAD"
             else
-              echo "Initial nightly."
+              echo "Initial canary."
             fi
           } > release-notes.md
 
-      - name: Replace nightly release
+      - name: Replace canary release
         env:
           GH_TOKEN: ${{ github.token }}
           VERSION: ${{ needs.preflight.outputs.version }}
         run: |
-          gh release delete nightly --yes --cleanup-tag 2>/dev/null || true
-          gh release create nightly \
-            --title "Nightly $VERSION" \
+          gh release delete canary --yes --cleanup-tag 2>/dev/null || true
+          gh release create canary \
+            --title "Canary $VERSION" \
             --notes-file release-notes.md \
             --prerelease \
             --target "$GITHUB_SHA" \
-            artifacts/kimchi-code-nightly_*.tar.gz \
+            artifacts/kimchi-code-canary_*.tar.gz \
             artifacts/checksums.txt

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -168,6 +168,8 @@ jobs:
         run: |
           PREV_SHA=$(gh release view nightly --json targetCommitish -q .targetCommitish 2>/dev/null || echo "")
           {
+            echo "> ⚠️ **Unstable nightly build.** No support. Use a tagged release for production."
+            echo
             echo "Nightly build of \`master\` at \`${GITHUB_SHA::7}\`."
             echo
             echo "Version: \`$VERSION\`"

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -11,7 +11,11 @@ on:
         default: false
 
 permissions:
-  contents: write
+  contents: read
+
+concurrency:
+  group: nightly
+  cancel-in-progress: false
 
 jobs:
   preflight:
@@ -93,6 +97,7 @@ jobs:
             runner: ubuntu-24.04-arm
 
     runs-on: ${{ matrix.runner }}
+    timeout-minutes: 20
 
     steps:
       - uses: actions/checkout@v4
@@ -144,6 +149,9 @@ jobs:
     needs: [preflight, smoke-test]
     if: needs.preflight.outputs.should-build == 'true'
     runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      contents: write
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -1,0 +1,196 @@
+name: Nightly
+
+on:
+  schedule:
+    - cron: "0 6 * * *"
+  workflow_dispatch:
+    inputs:
+      force:
+        description: "Build even if HEAD hasn't moved since the last nightly"
+        type: boolean
+        default: false
+
+permissions:
+  contents: write
+
+jobs:
+  preflight:
+    runs-on: ubuntu-latest
+    timeout-minutes: 2
+    outputs:
+      should-build: ${{ steps.gate.outputs.should-build }}
+      version: ${{ steps.version.outputs.version }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Compute version
+        id: version
+        run: |
+          DATE=$(date -u +%Y%m%d)
+          SHA=${GITHUB_SHA::7}
+          echo "version=0.0.0-nightly.${DATE}.${SHA}" >> "$GITHUB_OUTPUT"
+
+      - name: Skip if HEAD unchanged
+        id: gate
+        env:
+          GH_TOKEN: ${{ github.token }}
+          FORCE: ${{ inputs.force }}
+        run: |
+          if [ "$FORCE" = "true" ]; then
+            echo "should-build=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          PREV=$(gh release view nightly --json targetCommitish -q .targetCommitish 2>/dev/null || echo "")
+          if [ -n "$PREV" ] && [ "$PREV" = "$GITHUB_SHA" ]; then
+            echo "Nightly already built for $GITHUB_SHA"
+            echo "should-build=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "should-build=true" >> "$GITHUB_OUTPUT"
+          fi
+
+  checks:
+    needs: [preflight]
+    if: needs.preflight.outputs.should-build == 'true'
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v4
+      - uses: ./.github/actions/setup
+        with:
+          bun: "true"
+          playwright: "true"
+
+      - name: Build
+        run: pnpm run build
+
+      - name: Check (lint + type check)
+        run: pnpm run check
+
+      - name: Test
+        run: pnpm run test
+
+  build:
+    needs: [preflight, checks]
+    if: needs.preflight.outputs.should-build == 'true'
+    strategy:
+      matrix:
+        include:
+          - target: bun-darwin-x64
+            os: darwin
+            arch: amd64
+            runner: macos-15
+          - target: bun-darwin-arm64
+            os: darwin
+            arch: arm64
+            runner: macos-15
+          - target: bun-linux-x64
+            os: linux
+            arch: amd64
+            runner: ubuntu-latest
+          - target: bun-linux-arm64
+            os: linux
+            arch: arm64
+            runner: ubuntu-24.04-arm
+
+    runs-on: ${{ matrix.runner }}
+
+    steps:
+      - uses: actions/checkout@v4
+      - uses: ./.github/actions/setup
+        with:
+          bun: "true"
+
+      - name: Set version
+        run: node scripts/set-version.js "${{ needs.preflight.outputs.version }}"
+
+      - name: Build binary
+        run: pnpm run build:binary
+
+      - name: Package binary
+        run: tar -czf kimchi-code-nightly_${{ matrix.os }}_${{ matrix.arch }}.tar.gz -C dist bin share
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: kimchi-code-nightly_${{ matrix.os }}_${{ matrix.arch }}
+          path: kimchi-code-nightly_${{ matrix.os }}_${{ matrix.arch }}.tar.gz
+
+  smoke-test:
+    needs: [preflight, build]
+    if: needs.preflight.outputs.should-build == 'true'
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+
+    steps:
+      - uses: actions/checkout@v4
+      - uses: ./.github/actions/setup
+        with:
+          bun: "true"
+
+      - name: Download linux binary
+        uses: actions/download-artifact@v4
+        with:
+          name: kimchi-code-nightly_linux_amd64
+
+      - name: Extract binary into dist/
+        run: |
+          mkdir -p dist
+          tar -xzf kimchi-code-nightly_linux_amd64.tar.gz -C dist
+
+      - name: Smoke tests
+        run: pnpm run test:smoke
+
+  release:
+    needs: [preflight, smoke-test]
+    if: needs.preflight.outputs.should-build == 'true'
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Download all artifacts
+        uses: actions/download-artifact@v4
+        with:
+          path: artifacts
+          merge-multiple: true
+
+      - name: Generate checksums
+        run: |
+          cd artifacts
+          sha256sum kimchi-code-nightly_*.tar.gz > checksums.txt
+
+      - name: Build release notes
+        env:
+          GH_TOKEN: ${{ github.token }}
+          VERSION: ${{ needs.preflight.outputs.version }}
+        run: |
+          PREV_SHA=$(gh release view nightly --json targetCommitish -q .targetCommitish 2>/dev/null || echo "")
+          {
+            echo "Nightly build of \`master\` at \`${GITHUB_SHA::7}\`."
+            echo
+            echo "Version: \`$VERSION\`"
+            echo
+            if [ -n "$PREV_SHA" ] && git rev-parse "$PREV_SHA" >/dev/null 2>&1; then
+              echo "## Changes since last nightly"
+              echo
+              git log --pretty=format:"- %s (%h)" "${PREV_SHA}..HEAD"
+            else
+              echo "Initial nightly."
+            fi
+          } > release-notes.md
+
+      - name: Replace nightly release
+        env:
+          GH_TOKEN: ${{ github.token }}
+          VERSION: ${{ needs.preflight.outputs.version }}
+        run: |
+          gh release delete nightly --yes --cleanup-tag 2>/dev/null || true
+          gh release create nightly \
+            --title "Nightly $VERSION" \
+            --notes-file release-notes.md \
+            --prerelease \
+            --target "$GITHUB_SHA" \
+            artifacts/kimchi-code-nightly_*.tar.gz \
+            artifacts/checksums.txt


### PR DESCRIPTION
Create a new realease of the master branch after every change of source files. The release is marked as `prerelease` so it should not collide with the standard update process (preflight releases are skipped by GitHub when querying the latest version). The workflow can be also triggered manually for rolling out changes for internal testing.

---
### Kimchi Summary
### What changed
Adds a GitHub Actions workflow that builds and publishes nightly releases of the `master` branch. The workflow runs daily at 06:00 UTC (or on demand via `workflow_dispatch`) and produces multi-platform binaries for macOS and Linux (x64 and arm64).

### Why
Provides automated, frequent builds of the latest `master` branch for users who need bleeding-edge features without waiting for formal tagged releases.

### Key changes
- `.github/workflows/nightly.yml`: New workflow with five jobs:
  - `preflight`: Computes version string (`0.0.0-nightly.DATE.SHORTSHA`) and skips redundant builds if `HEAD` hasn't changed since the last nightly run (override via `workflow_dispatch` with `force: true`)
  - `checks`: Runs `pnpm run build`, `pnpm run check`, and `pnpm run test`
  - `build`: Compiles Bun binaries for `darwin/amd64`, `darwin/arm64`, `linux/amd64`, and `linux/arm64`, packaging them as `kimchi-code-nightly_${os}_${arch}.tar.gz`
  - `smoke-test`: Downloads the Linux binary and runs `pnpm run test:smoke`
  - `release`: Deletes and recreates the `nightly` GitHub release, uploads all artifacts with SHA256 checksums, and generates release notes including the commit log since the previous nightly

### Impact
- The `nightly` release tag is deleted and recreated on each run; direct links to previous nightly artifacts will break.
- Consumes CI minutes across macOS runners (`macos-15`) and ARM64 runners (`ubuntu-24.04-arm`).
- Requires `contents: write` permission for release management.