### PR TITLE
fix: no resume session suggestion when session isn't saved

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,7 +1,7 @@
 // CLI logic — imported dynamically by entry.ts after PI_PACKAGE_DIR is set.
 // All static imports here (extensions, pi-mono) are safe because the env is already configured.
 
-import { mkdirSync, readFileSync, writeFileSync } from "node:fs"
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs"
 import { dirname, resolve } from "node:path"
 import { fileURLToPath } from "node:url"
 import type { ExtensionAPI, ExtensionContext } from "@mariozechner/pi-coding-agent"
@@ -44,6 +44,7 @@ import { getVersion } from "./utils.js"
 const telemetryConfig = readTelemetryConfig()
 
 let sessionId: string | undefined
+let sessionFile: string | undefined
 // ACP mode runs JSON-RPC over stdio; the "To resume:" print (even remapped to
 // stderr via console.log = console.error inside runAcpMode) is noise in IDE
 // logs and not actionable — the IDE owns session continuation. Decide once,
@@ -53,7 +54,12 @@ const helpOrVersion = isHelpOrVersionArgs(process.argv.slice(2))
 
 process.on("exit", (code) => {
 	if (code === 0 && !acpMode) {
-		const resumeCmd = sessionId ? `kimchi-code --session ${sessionId}` : "kimchi-code --continue"
+		// Only print a session-specific hint if the session file was actually
+		// flushed to disk. Empty sessions (immediate exit) never get persisted,
+		// so `--session <id>` would fail to resolve. Fall back to --continue,
+		// which finds the most recent persisted session for this cwd.
+		const persisted = sessionId && sessionFile && existsSync(sessionFile)
+		const resumeCmd = persisted ? `kimchi --session ${sessionId}` : "kimchi --continue"
 		console.log(`\nTo resume: ${resumeCmd}`)
 	}
 })
@@ -62,6 +68,7 @@ function sessionIdCaptureExtension(pi: ExtensionAPI) {
 	pi.on("session_start", (_event, ctx: ExtensionContext) => {
 		try {
 			sessionId = ctx.sessionManager.getSessionId()
+			sessionFile = ctx.sessionManager.getSessionFile()
 		} catch {
 			// ignore — exit handler falls back to --continue
 		}

--- a/src/extensions/lsp/client.ts
+++ b/src/extensions/lsp/client.ts
@@ -172,7 +172,6 @@ export async function getOrCreateClient(config: ServerConfig, cwd: string): Prom
 		// Bun global available at runtime but not typed — use globalThis cast
 		// biome-ignore lint/suspicious/noExplicitAny: Bun not typed without @types/bun
 		const Bun = (globalThis as any).Bun
-		// biome-ignore lint/suspicious/noExplicitAny: Bun not typed without @types/bun
 		const proc = Bun.spawn([config.command, ...(config.args ?? [])], {
 			cwd,
 			stdin: "pipe",


### PR DESCRIPTION


---
### Kimchi Summary
### What changed
Updates the CLI exit handler to verify that a session file exists on disk before suggesting a session-specific resume command (`--session <id>`). For empty or immediately-terminated sessions that never persist, it now falls back to suggesting `--continue`. Also updates the suggested command name from `kimchi-code` to `kimchi` and removes a redundant lint suppression in the LSP client.

### Why
Session IDs are generated at startup but the backing file is only written once the session manager flushes state. If the process exits before this happens (e.g., immediate Ctrl+C or validation errors), recommending `--session <id>` would point to a non-existent file and fail on resume. Checking `existsSync(sessionFile)` ensures the hint is only shown when valid, and `--continue` correctly locates the most recent persisted session for the current working directory.

### Key changes
- `src/cli.ts`
  - Imports `existsSync` from `node:fs`.
  - Adds `sessionFile` variable to track the session storage path alongside `sessionId`.
  - Updates `process.on('exit')` handler to check `existsSync(sessionFile)` before recommending `kimchi --session ${sessionId}`.
  - Changes fallback resume command from `kimchi-code --continue` to `kimchi --continue`.
- `src/extensions/lsp/client.ts`
  - Removes redundant `biome-ignore` comment above `Bun.spawn`.

### Impact
Prevents confusing UX where users copy-paste a non-functional resume command after an ephemeral session. No breaking changes; the logic only affects console output on clean exit.