### PR TITLE
fix: add legacy escape sequence handling for Option+Tab on macOS

### DIFF
--- a/src/extensions/orchestration/prompt-enrichment.ts
+++ b/src/extensions/orchestration/prompt-enrichment.ts
@@ -186,7 +186,9 @@ export default function (skillPaths: string[]) {
 				if (unsubAltTab) unsubAltTab()
 				if (ctx.hasUI) {
 					unsubAltTab = ctx.ui.onTerminalInput((data) => {
-						if (matchesKey(data, "alt+tab")) {
+						// matchesKey() handles Kitty protocol and CSI-u sequences;
+						// \x1b\t is the legacy sequence sent by macOS terminals for Option+Tab
+						if (matchesKey(data, "alt+tab") || data === "\x1b\t") {
 							if (!isKeyRelease(data)) {
 								multiModelEnabled = !multiModelEnabled
 								ctx.ui.setStatus("multi-model", undefined)

--- a/src/extensions/orchestration/prompt-enrichment.ts
+++ b/src/extensions/orchestration/prompt-enrichment.ts
@@ -106,6 +106,10 @@ function readMultiModelArgv(): boolean {
 
 let multiModelEnabled = readMultiModelArgv()
 
+// macOS terminals send the legacy escape sequence \x1b\t for Option+Tab
+// instead of the Kitty protocol / CSI-u sequences handled by matchesKey()
+const LEGACY_MACOS_ALT_TAB_SEQUENCE = "\x1b\t"
+
 const ENRICHED_PROMPT_CUSTOM_TYPE = "enriched-prompt"
 
 /**
@@ -186,9 +190,7 @@ export default function (skillPaths: string[]) {
 				if (unsubAltTab) unsubAltTab()
 				if (ctx.hasUI) {
 					unsubAltTab = ctx.ui.onTerminalInput((data) => {
-						// matchesKey() handles Kitty protocol and CSI-u sequences;
-						// \x1b\t is the legacy sequence sent by macOS terminals for Option+Tab
-						if (matchesKey(data, "alt+tab") || data === "\x1b\t") {
+						if (matchesKey(data, "alt+tab") || data === LEGACY_MACOS_ALT_TAB_SEQUENCE) {
 							if (!isKeyRelease(data)) {
 								multiModelEnabled = !multiModelEnabled
 								ctx.ui.setStatus("multi-model", undefined)


### PR DESCRIPTION
On macOS, terminals send the legacy escape sequence \x1b\t (ESC+TAB) for Option+Tab, but pi-tui's matchesKey() only recognizes Kitty protocol and CSI-u sequences. Add explicit check for the legacy sequence to make the multi-model toggle work on macOS.

---
### Kimchi Summary
### What changed
Fixes the Option+Tab keyboard shortcut on macOS by adding support for the legacy escape sequence `\x1b\t` that macOS terminals emit, instead of only relying on Kitty protocol / CSI-u sequences.

### Why
macOS terminals send a legacy escape sequence for Option+Tab that `matchesKey()` does not recognize, causing the multi-model toggle to fail on macOS.

### Key changes
- **`src/extensions/orchestration/prompt-enrichment.ts`**: 
  - Added `LEGACY_MACOS_ALT_TAB_SEQUENCE` constant (`\x1b\t`) to identify the macOS-specific escape sequence.
  - Updated the terminal input handler to check for this legacy sequence in addition to the standard `matchesKey(data, "alt+tab")` check.