### PR TITLE
UI-6595: fixed quit command text

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,13 +31,14 @@
 	"dependencies": {
 		"@agentclientprotocol/sdk": "^0.19.0",
 		"@clack/prompts": "^1.2.0",
-		"@mariozechner/pi-coding-agent": "^0.67.68",
-		"@mariozechner/pi-tui": "^0.67.68",
+		"@mariozechner/pi-coding-agent": "0.73.0",
+		"@mariozechner/pi-tui": "0.73.0",
 		"@modelcontextprotocol/ext-apps": "^1.2.2",
 		"@modelcontextprotocol/sdk": "^1.25.1",
 		"micromatch": "^4.0.8",
 		"open": "^10.2.0",
 		"shell-quote": "^1.8.3",
+		"typebox": "1.1.37",
 		"undici": "^8.0.2",
 		"uuid": "^14.0.0",
 		"zod": "^4.0.0"
@@ -47,7 +48,7 @@
 	},
 	"devDependencies": {
 		"@biomejs/biome": "^1.9.4",
-		"@mariozechner/pi-ai": "^0.67.68",
+		"@mariozechner/pi-ai": "0.73.0",
 		"@mixmark-io/domino": "^2.2.0",
 		"@types/micromatch": "^4.0.10",
 		"@types/node": "^22.15.2",

--- a/package.json
+++ b/package.json
@@ -31,8 +31,8 @@
 	"dependencies": {
 		"@agentclientprotocol/sdk": "^0.19.0",
 		"@clack/prompts": "^1.2.0",
-		"@mariozechner/pi-coding-agent": "0.73.0",
-		"@mariozechner/pi-tui": "0.73.0",
+		"@mariozechner/pi-coding-agent": "^0.73.0",
+		"@mariozechner/pi-tui": "^0.73.0",
 		"@modelcontextprotocol/ext-apps": "^1.2.2",
 		"@modelcontextprotocol/sdk": "^1.25.1",
 		"micromatch": "^4.0.8",
@@ -48,7 +48,7 @@
 	},
 	"devDependencies": {
 		"@biomejs/biome": "^1.9.4",
-		"@mariozechner/pi-ai": "0.73.0",
+		"@mariozechner/pi-ai": "^0.73.0",
 		"@mixmark-io/domino": "^2.2.0",
 		"@types/micromatch": "^4.0.10",
 		"@types/node": "^22.15.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -20,10 +20,10 @@ importers:
         specifier: ^1.2.0
         version: 1.2.0
       '@mariozechner/pi-coding-agent':
-        specifier: 0.73.0
+        specifier: ^0.73.0
         version: 0.73.0(patch_hash=abb877a867e699ad24e2f72cb410d78bab73ece3c24663625133b61c0fbc513f)(@modelcontextprotocol/sdk@1.29.0(zod@4.3.6))(ws@8.20.0)(zod@4.3.6)
       '@mariozechner/pi-tui':
-        specifier: 0.73.0
+        specifier: ^0.73.0
         version: 0.73.0
       '@modelcontextprotocol/ext-apps':
         specifier: ^1.2.2
@@ -60,7 +60,7 @@ importers:
         specifier: ^1.9.4
         version: 1.9.4
       '@mariozechner/pi-ai':
-        specifier: 0.73.0
+        specifier: ^0.73.0
         version: 0.73.0(@modelcontextprotocol/sdk@1.29.0(zod@4.3.6))(ws@8.20.0)(zod@4.3.6)
       '@mixmark-io/domino':
         specifier: ^2.2.0

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -20,11 +20,11 @@ importers:
         specifier: ^1.2.0
         version: 1.2.0
       '@mariozechner/pi-coding-agent':
-        specifier: ^0.67.68
-        version: 0.67.68(patch_hash=abb877a867e699ad24e2f72cb410d78bab73ece3c24663625133b61c0fbc513f)(@modelcontextprotocol/sdk@1.29.0(zod@4.3.6))(ws@8.20.0)(zod@4.3.6)
+        specifier: 0.73.0
+        version: 0.73.0(patch_hash=abb877a867e699ad24e2f72cb410d78bab73ece3c24663625133b61c0fbc513f)(@modelcontextprotocol/sdk@1.29.0(zod@4.3.6))(ws@8.20.0)(zod@4.3.6)
       '@mariozechner/pi-tui':
-        specifier: ^0.67.68
-        version: 0.67.68
+        specifier: 0.73.0
+        version: 0.73.0
       '@modelcontextprotocol/ext-apps':
         specifier: ^1.2.2
         version: 1.5.0(@modelcontextprotocol/sdk@1.29.0(zod@4.3.6))(zod@4.3.6)
@@ -43,6 +43,9 @@ importers:
       shell-quote:
         specifier: ^1.8.3
         version: 1.8.3
+      typebox:
+        specifier: 1.1.37
+        version: 1.1.37
       undici:
         specifier: ^8.0.2
         version: 8.0.2
@@ -57,8 +60,8 @@ importers:
         specifier: ^1.9.4
         version: 1.9.4
       '@mariozechner/pi-ai':
-        specifier: ^0.67.68
-        version: 0.67.68(@modelcontextprotocol/sdk@1.29.0(zod@4.3.6))(ws@8.20.0)(zod@4.3.6)
+        specifier: 0.73.0
+        version: 0.73.0(@modelcontextprotocol/sdk@1.29.0(zod@4.3.6))(ws@8.20.0)(zod@4.3.6)
       '@mixmark-io/domino':
         specifier: ^2.2.0
         version: 2.2.0
@@ -103,8 +106,8 @@ packages:
     peerDependencies:
       zod: ^3.25.0 || ^4.0.0
 
-  '@anthropic-ai/sdk@0.90.0':
-    resolution: {integrity: sha512-MzZtPabJF1b0FTDl6Z6H5ljphPwACLGP13lu8MTiB8jXaW/YXlpOp+Po2cVou3MPM5+f5toyLnul9whKCy7fBg==}
+  '@anthropic-ai/sdk@0.91.1':
+    resolution: {integrity: sha512-LAmu761tSN9r66ixvmciswUj/ZC+1Q4iAfpedTfSVLeswRwnY3n2Nb6Tsk+cLPP28aLOPWeMgIuTuCcMC6W/iw==}
     hasBin: true
     peerDependencies:
       zod: ^3.25.0 || ^4.0.0
@@ -544,30 +547,30 @@ packages:
     cpu: [x64]
     os: [win32]
 
-  '@mariozechner/clipboard@0.3.2':
-    resolution: {integrity: sha512-IHQpksNjo7EAtGuHFU+tbWDp5LarH3HU/8WiB9O70ZEoBPHOg0/6afwSLK0QyNMMmx4Bpi/zl6+DcBXe95nWYA==}
+  '@mariozechner/clipboard@0.3.5':
+    resolution: {integrity: sha512-D3F+UrU9CR7roJt0zDLp6Oc+4/KlLDIrN4frH+6V90SJNW2KKUec1oCQIPaaDjCqeOsQyX9dyqYbImIQIM45PA==}
     engines: {node: '>= 10'}
 
   '@mariozechner/jiti@2.6.5':
     resolution: {integrity: sha512-faGUlTcXka5l7rv0lP3K3vGW/ejRuOS24RR2aSFWREUQqzjgdsuWNo/IiPqL3kWRGt6Ahl2+qcDAwtdeWeuGUw==}
     hasBin: true
 
-  '@mariozechner/pi-agent-core@0.67.68':
-    resolution: {integrity: sha512-anwFuzeUL7Qjbyih4DWY7w1zrOTrBxaz1L6+duLUuuzpHOun0EiP4KWIGTXPT5oJA7ZaeRNTyXJ7PlWfGQG33g==}
+  '@mariozechner/pi-agent-core@0.73.0':
+    resolution: {integrity: sha512-ugcpvq0X9fr9fTSK29/3S4+KU/eeVMrBb7ZU3HqiF3xD7I1GlgumLj4FYmDrYSEA6+rzgNWlJUKwjKh9o0Z6AA==}
     engines: {node: '>=20.0.0'}
 
-  '@mariozechner/pi-ai@0.67.68':
-    resolution: {integrity: sha512-DWWQmcb3IV3mbGXmzYBScfKA6kA52n/stY029eiBikrIxVT7DGLG6n7KSvTA2R4qBSgi1iFL3nGHtwxmtIn6Lg==}
+  '@mariozechner/pi-ai@0.73.0':
+    resolution: {integrity: sha512-phKOpcde/ssz6UYszkmaGJ9LF9mgt/AP8LrtSwsfap+kMSeFfSQ2/mCSBT1mLJ2BqVuff9uXs1/+op1aQeaafQ==}
     engines: {node: '>=20.0.0'}
     hasBin: true
 
-  '@mariozechner/pi-coding-agent@0.67.68':
-    resolution: {integrity: sha512-Bai2yUBpgjftqGvg3GNV9pxcMAatqJwQYsqM+7j39+tm+IpoW7hbMBnzXZQvykAwXIrTXpZFF5yp5ajeDI5Atg==}
+  '@mariozechner/pi-coding-agent@0.73.0':
+    resolution: {integrity: sha512-Fs2dRIgtjDT8X5VDGNGzxj251B0FvkRsgX03YJv1FK4wg5Maj+jkf8/5A6tbPnPcXsCgs41xxJRf3tF5vJRccA==}
     engines: {node: '>=20.6.0'}
     hasBin: true
 
-  '@mariozechner/pi-tui@0.67.68':
-    resolution: {integrity: sha512-RhcMaGz88lNOm5+9yx+YCIfXZALLbMxB2cwsoHzyOzs+OZAItw8tz6xJZPAnX0RHY+ENQEGMMDY9TF6pxxnkbA==}
+  '@mariozechner/pi-tui@0.73.0':
+    resolution: {integrity: sha512-St1W+tMPKHatfK+lblsKfL+SsFyFVMK2tW6xHpBfCiMuevbOCRo/CMatso7mu1642UO04ncmfCrrpUK5L9aoog==}
     engines: {node: '>=20.0.0'}
 
   '@mistralai/mistralai@2.2.0':
@@ -2004,6 +2007,9 @@ packages:
     resolution: {integrity: sha512-OZs6gsjF4vMp32qrCbiVSkrFmXtG/AZhY3t0iAMrMBiAZyV9oALtXO8hsrHbMXF9x6L3grlFuwW2oAz7cav+Gw==}
     engines: {node: '>= 0.6'}
 
+  typebox@1.1.37:
+    resolution: {integrity: sha512-jb7jp6KvOvvy5sd+11AfJ0/e0F0AS9RcOXd55oGi2ZnRHIGmFvrTaNF+ZidRmGBmmNTkM5KKl0Z37KzxJ+owEQ==}
+
   typescript@5.9.3:
     resolution: {integrity: sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==}
     engines: {node: '>=14.17'}
@@ -2027,10 +2033,6 @@ packages:
   unpipe@1.0.0:
     resolution: {integrity: sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==}
     engines: {node: '>= 0.8'}
-
-  uuid@11.1.0:
-    resolution: {integrity: sha512-0/A9rDy9P7cJ+8w1c9WD9V//9Wj15Ce2MPz8Ri6032usz+NfePxx5AcN3bN+r6ZL6jEo066/yNYB3tn4pQEx+A==}
-    hasBin: true
 
   uuid@14.0.0:
     resolution: {integrity: sha512-Qo+uWgilfSmAhXCMav1uYFynlQO7fMFiMVZsQqZRMIXp0O7rR7qjkj+cPvBHLgBqi960QCoo/PH2/6ZtVqKvrg==}
@@ -2188,7 +2190,7 @@ snapshots:
     dependencies:
       zod: 4.3.6
 
-  '@anthropic-ai/sdk@0.90.0(zod@4.3.6)':
+  '@anthropic-ai/sdk@0.91.1(zod@4.3.6)':
     dependencies:
       json-schema-to-ts: 3.1.1
     optionalDependencies:
@@ -2748,7 +2750,7 @@ snapshots:
   '@mariozechner/clipboard-win32-x64-msvc@0.3.2':
     optional: true
 
-  '@mariozechner/clipboard@0.3.2':
+  '@mariozechner/clipboard@0.3.5':
     optionalDependencies:
       '@mariozechner/clipboard-darwin-arm64': 0.3.2
       '@mariozechner/clipboard-darwin-universal': 0.3.2
@@ -2767,9 +2769,10 @@ snapshots:
       std-env: 3.10.0
       yoctocolors: 2.1.2
 
-  '@mariozechner/pi-agent-core@0.67.68(@modelcontextprotocol/sdk@1.29.0(zod@4.3.6))(ws@8.20.0)(zod@4.3.6)':
+  '@mariozechner/pi-agent-core@0.73.0(@modelcontextprotocol/sdk@1.29.0(zod@4.3.6))(ws@8.20.0)(zod@4.3.6)':
     dependencies:
-      '@mariozechner/pi-ai': 0.67.68(@modelcontextprotocol/sdk@1.29.0(zod@4.3.6))(ws@8.20.0)(zod@4.3.6)
+      '@mariozechner/pi-ai': 0.73.0(@modelcontextprotocol/sdk@1.29.0(zod@4.3.6))(ws@8.20.0)(zod@4.3.6)
+      typebox: 1.1.37
     transitivePeerDependencies:
       - '@modelcontextprotocol/sdk'
       - aws-crt
@@ -2779,19 +2782,17 @@ snapshots:
       - ws
       - zod
 
-  '@mariozechner/pi-ai@0.67.68(@modelcontextprotocol/sdk@1.29.0(zod@4.3.6))(ws@8.20.0)(zod@4.3.6)':
+  '@mariozechner/pi-ai@0.73.0(@modelcontextprotocol/sdk@1.29.0(zod@4.3.6))(ws@8.20.0)(zod@4.3.6)':
     dependencies:
-      '@anthropic-ai/sdk': 0.90.0(zod@4.3.6)
+      '@anthropic-ai/sdk': 0.91.1(zod@4.3.6)
       '@aws-sdk/client-bedrock-runtime': 3.1032.0
       '@google/genai': 1.48.0(@modelcontextprotocol/sdk@1.29.0(zod@4.3.6))
       '@mistralai/mistralai': 2.2.0
-      '@sinclair/typebox': 0.34.49
-      ajv: 8.18.0
-      ajv-formats: 3.0.1(ajv@8.18.0)
       chalk: 5.6.2
       openai: 6.26.0(ws@8.20.0)(zod@4.3.6)
       partial-json: 0.1.7
       proxy-agent: 6.5.0
+      typebox: 1.1.37
       undici: 7.24.7
       zod-to-json-schema: 3.25.2(zod@4.3.6)
     transitivePeerDependencies:
@@ -2803,14 +2804,13 @@ snapshots:
       - ws
       - zod
 
-  '@mariozechner/pi-coding-agent@0.67.68(patch_hash=abb877a867e699ad24e2f72cb410d78bab73ece3c24663625133b61c0fbc513f)(@modelcontextprotocol/sdk@1.29.0(zod@4.3.6))(ws@8.20.0)(zod@4.3.6)':
+  '@mariozechner/pi-coding-agent@0.73.0(patch_hash=abb877a867e699ad24e2f72cb410d78bab73ece3c24663625133b61c0fbc513f)(@modelcontextprotocol/sdk@1.29.0(zod@4.3.6))(ws@8.20.0)(zod@4.3.6)':
     dependencies:
       '@mariozechner/jiti': 2.6.5
-      '@mariozechner/pi-agent-core': 0.67.68(@modelcontextprotocol/sdk@1.29.0(zod@4.3.6))(ws@8.20.0)(zod@4.3.6)
-      '@mariozechner/pi-ai': 0.67.68(@modelcontextprotocol/sdk@1.29.0(zod@4.3.6))(ws@8.20.0)(zod@4.3.6)
-      '@mariozechner/pi-tui': 0.67.68
+      '@mariozechner/pi-agent-core': 0.73.0(@modelcontextprotocol/sdk@1.29.0(zod@4.3.6))(ws@8.20.0)(zod@4.3.6)
+      '@mariozechner/pi-ai': 0.73.0(@modelcontextprotocol/sdk@1.29.0(zod@4.3.6))(ws@8.20.0)(zod@4.3.6)
+      '@mariozechner/pi-tui': 0.73.0
       '@silvia-odwyer/photon-node': 0.3.4
-      ajv: 8.18.0
       chalk: 5.6.2
       cli-highlight: 2.1.11
       diff: 8.0.4
@@ -2823,11 +2823,12 @@ snapshots:
       minimatch: 10.2.5
       proper-lockfile: 4.1.2
       strip-ansi: 7.2.0
+      typebox: 1.1.37
       undici: 7.24.7
-      uuid: 11.1.0
+      uuid: 14.0.0
       yaml: 2.8.3
     optionalDependencies:
-      '@mariozechner/clipboard': 0.3.2
+      '@mariozechner/clipboard': 0.3.5
     transitivePeerDependencies:
       - '@modelcontextprotocol/sdk'
       - aws-crt
@@ -2837,7 +2838,7 @@ snapshots:
       - ws
       - zod
 
-  '@mariozechner/pi-tui@0.67.68':
+  '@mariozechner/pi-tui@0.73.0':
     dependencies:
       '@types/mime-types': 2.1.4
       chalk: 5.6.2
@@ -4402,6 +4403,8 @@ snapshots:
       media-typer: 1.1.0
       mime-types: 3.0.2
 
+  typebox@1.1.37: {}
+
   typescript@5.9.3: {}
 
   uint8array-extras@1.5.0: {}
@@ -4413,8 +4416,6 @@ snapshots:
   undici@8.0.2: {}
 
   unpipe@1.0.0: {}
-
-  uuid@11.1.0: {}
 
   uuid@14.0.0: {}
 

--- a/src/extensions/orchestration/prompt-enrichment.ts
+++ b/src/extensions/orchestration/prompt-enrichment.ts
@@ -25,7 +25,7 @@ import { existsSync } from "node:fs"
 import { homedir, platform, userInfo } from "node:os"
 import { isAbsolute, join, normalize, resolve } from "node:path"
 import type { AssistantMessage, ImageContent, TextContent } from "@mariozechner/pi-ai"
-import { type ExtensionAPI, type Skill, loadSkills } from "@mariozechner/pi-coding-agent"
+import { type ExtensionAPI, type Skill, getAgentDir, loadSkills } from "@mariozechner/pi-coding-agent"
 import { isKeyRelease, matchesKey } from "@mariozechner/pi-tui"
 import { ANSI, fg } from "../../ansi.js"
 import { getAvailableModels } from "../../startup-context.js"
@@ -335,7 +335,9 @@ export default function (skillPaths: string[]) {
 			cachedContextFiles ??= loadProjectContextFiles(ctx.cwd)
 			cachedSkills ??= loadSkills({
 				cwd: ctx.cwd,
+				agentDir: getAgentDir(),
 				skillPaths: expandSkillPaths(skillPaths, ctx.cwd),
+				includeDefaults: true,
 			}).skills
 
 			const now = new Date()

--- a/src/extensions/tool-renderer.ts
+++ b/src/extensions/tool-renderer.ts
@@ -1,14 +1,16 @@
 import type { ExtensionAPI, ToolDefinition } from "@mariozechner/pi-coding-agent"
 import {
-	editToolDefinition,
-	findToolDefinition,
-	grepToolDefinition,
-	lsToolDefinition,
-	readToolDefinition,
-	writeToolDefinition,
+	createEditToolDefinition,
+	createFindToolDefinition,
+	createGrepToolDefinition,
+	createLsToolDefinition,
+	createReadToolDefinition,
+	createWriteToolDefinition,
 } from "@mariozechner/pi-coding-agent"
 import { ToolBlockView, buildToolCallHeader, getTextContent } from "../components/tool-block.js"
 import { isToolExpanded, registerToolCall } from "../expand-state.js"
+
+type ToolFactory = (cwd: string) => ToolDefinition
 
 function formatArgs(toolName: string, args: Record<string, unknown>): string {
 	const raw = (() => {
@@ -61,23 +63,30 @@ function formatSummary(toolName: string, content: string, isError: boolean): str
 	}
 }
 
-const builtins = [
-	readToolDefinition,
-	editToolDefinition,
-	writeToolDefinition,
-	grepToolDefinition,
-	findToolDefinition,
-	lsToolDefinition,
+const builtinFactories: ToolFactory[] = [
+	createReadToolDefinition as ToolFactory,
+	createEditToolDefinition as ToolFactory,
+	createWriteToolDefinition as ToolFactory,
+	createGrepToolDefinition as ToolFactory,
+	createFindToolDefinition as ToolFactory,
+	createLsToolDefinition as ToolFactory,
 ]
 
 export default function toolRendererExtension(pi: ExtensionAPI) {
-	for (const builtin of builtins) {
+	for (const factory of builtinFactories) {
+		const baseDef = factory(process.cwd())
+		const toolName = baseDef.name
+
 		pi.registerTool({
-			...(builtin as unknown as ToolDefinition),
+			...baseDef,
+
+			execute(toolCallId, params, signal, onUpdate, ctx) {
+				return factory(ctx.cwd).execute(toolCallId, params, signal, onUpdate, ctx)
+			},
 
 			renderCall(args, theme, ctx) {
 				const view = ctx.lastComponent instanceof ToolBlockView ? ctx.lastComponent : new ToolBlockView()
-				buildToolCallHeader(view, builtin.name, formatArgs(builtin.name, args as Record<string, unknown>), theme, ctx)
+				buildToolCallHeader(view, toolName, formatArgs(toolName, args as Record<string, unknown>), theme, ctx)
 				return view
 			},
 
@@ -92,7 +101,7 @@ export default function toolRendererExtension(pi: ExtensionAPI) {
 					view.setFooter(theme.fg("toolOutput", content), "")
 					view.setExtra([])
 				} else {
-					const summary = formatSummary(builtin.name, content, ctx.isError)
+					const summary = formatSummary(toolName, content, ctx.isError)
 					view.setFooter(theme.fg("dim", summary), theme.fg("dim", "ctrl+o to expand"))
 					view.setExtra([])
 				}

--- a/src/extensions/web-fetch/index.ts
+++ b/src/extensions/web-fetch/index.ts
@@ -8,7 +8,7 @@
 import { StringEnum } from "@mariozechner/pi-ai"
 import type { ExtensionAPI } from "@mariozechner/pi-coding-agent"
 import { Container, Spacer, Text } from "@mariozechner/pi-tui"
-import { Type } from "@sinclair/typebox"
+import { Type } from "typebox"
 import { formatCount } from "../format.js"
 import { type SpinnerState, clearSpinner, spinnerFrame, tickSpinner } from "../spinner.js"
 import { shutdownBrowserPool } from "./browser-pool.js"

--- a/src/extensions/web-search/index.ts
+++ b/src/extensions/web-search/index.ts
@@ -8,7 +8,7 @@
 import { StringEnum } from "@mariozechner/pi-ai"
 import type { ExtensionAPI } from "@mariozechner/pi-coding-agent"
 import { Container, Text } from "@mariozechner/pi-tui"
-import { Type } from "@sinclair/typebox"
+import { Type } from "typebox"
 import { formatCount } from "../format.js"
 import { type SpinnerState, clearSpinner, spinnerFrame, tickSpinner } from "../spinner.js"
 import { executeWebSearch } from "./execute-handler.js"

--- a/src/modes/acp/server.ts
+++ b/src/modes/acp/server.ts
@@ -222,7 +222,10 @@ export class KimchiAcpAgent implements Agent {
 			// calling dispose(). dispose() is synchronous and returns void, so
 			// async extension handlers (e.g. telemetry drain, shutdown marker)
 			// would be fire-and-forgotten if we relied on dispose() alone.
-			await entry.session.extensionRunner?.emit({ type: "session_shutdown", cause } as { type: "session_shutdown" })
+			await entry.session.extensionRunner?.emit({ type: "session_shutdown", reason: "quit", cause } as {
+				type: "session_shutdown"
+				reason: "quit"
+			})
 			entry.session.dispose()
 		}
 		this.sessions.clear()


### PR DESCRIPTION
Display 'quit kimchi' instead of 'quit pi' when typing `/quit`

---
### Kimchi Summary
### What changed
Update `@mariozechner/pi-*` dependencies to v0.73.0 and add `reason: "quit"` to session shutdown events. Tool definitions are now instantiated via factory functions with working directory context, and schema validation migrates from `@sinclair/typebox` to `typebox`.

### Why
Aligns with breaking API changes in the pi-coding-agent ecosystem and properly identifies the termination cause in session shutdown telemetry.

### Key changes
- `package.json`: Bump `@mariozechner/pi-coding-agent`, `pi-tui`, and `pi-ai` to `^0.73.0`; add `typebox@1.1.37` dependency; remove redundant `uuid` version
- `src/modes/acp/server.ts`: Add `reason: "quit"` field to the `session_shutdown` event payload
- `src/extensions/tool-renderer.ts`: Migrate from static tool definitions (`readToolDefinition`, etc.) to factory functions (`createReadToolDefinition`, etc.) that accept `cwd`; tools now execute within the session's working directory context
- `src/extensions/orchestration/prompt-enrichment.ts`: Update `loadSkills` call to include `agentDir: getAgentDir()` and `includeDefaults: true` parameters
- `src/extensions/web-fetch/index.ts` & `src/extensions/web-search/index.ts`: Replace `@sinclair/typebox` import with `typebox`

### Impact
- **Breaking**: Tool definitions now require a `cwd` context for execution; the extension API for registering built-in tools has changed from static imports to factory invocations
- **Event schema**: Consumers of `session_shutdown` events must handle the new `reason` field
- **Dependencies**: Downstream packages must use compatible `typebox` version for schema validation