### PR TITLE
feat: Migrate smoke tests to terminal bench runner

### DIFF
--- a/benchmark/terminal-bench-2/src/kimchi_agent/agent.py
+++ b/benchmark/terminal-bench-2/src/kimchi_agent/agent.py
@@ -155,6 +155,11 @@ class KimchiCode(BaseInstalledAgent):
             )
 
         cli_flags = self.build_cli_flags()
+        # KIMCHI_MULTI_MODEL=false (forwarded via --ae) → append --multi-model=false.
+        # Lets a single task be run in either orchestrator or single-model mode without
+        # duplicating the task definition; the mode is purely run-time config.
+        if self._extra_env.get("KIMCHI_MULTI_MODEL", "").strip().lower() in ("false", "0", "off", "no"):
+            cli_flags = f"{cli_flags} --multi-model=false" if cli_flags else "--multi-model=false"
         if cli_flags:
             cli_flags += " "
 

--- a/benchmark/terminal-bench-smoke/.gitignore
+++ b/benchmark/terminal-bench-smoke/.gitignore
@@ -1,0 +1,3 @@
+jobs/
+.harbor/
+__pycache__/

--- a/benchmark/terminal-bench-smoke/README.md
+++ b/benchmark/terminal-bench-smoke/README.md
@@ -1,0 +1,46 @@
+# terminal-bench-smoke
+
+Three-task smoke suite for kimchi-code, ported from `benchmark/manual/`. Runs through the same harbor harness as `benchmark/terminal-bench-2/` (reuses its `kimchi_agent` package and venv).
+
+| Task | Graded? | Verifier |
+| --- | --- | --- |
+| `go-rate-limiter` | yes | builds the agent's server, asserts 11th burst request returns 429, runs `go test ./...` |
+| `go-task-api` | yes | builds the agent's server, exercises POST/GET/PATCH/DELETE end-to-end, runs `go test ./...` |
+| `go-router-research` | no (trivial) | only asserts `/app/answer.md` exists and is ≥200 bytes — compare runs by session artifacts, not reward |
+
+## Prereqs
+
+Same as `terminal-bench-2/`. See its README for Apple Silicon caveats.
+
+## Usage
+
+```bash
+export KIMCHI_API_KEY=...
+
+# Whole dataset (all 3 tasks, default 4 trials in parallel)
+./scripts/run-local.sh
+
+# One task by name
+./scripts/run-local.sh -i go-rate-limiter
+
+# One task by directory
+./scripts/run-local.sh --path tasks/go-task-api
+
+# Run go-task-api in single-model mode, tagged for slicing
+./scripts/run-local.sh \
+  -i go-task-api \
+  --ae KIMCHI_MULTI_MODEL=false \
+  --ae KIMCHI_TAGS=mode:single
+```
+
+`run-release.sh` is the same but pulls the latest published kimchi-code release instead of cross-building from the working tree.
+
+## How the single-model toggle works
+
+The `kimchi_agent` package translates `KIMCHI_MULTI_MODEL=false` (forwarded via `--ae`) into `--multi-model=false` on the binary invocation. Same task definition, two runs, distinguishable server-side by tags.
+
+## Results
+
+`benchmark/terminal-bench-smoke/jobs/<timestamp>/<task>__<trial>/` — `result.json` for the reward, `agent/kimchi.txt` for the raw JSONL stream, `agent/sessions/*.jsonl` for resumable sessions (parent + each subagent).
+
+For the `go-router-research` task, ignore reward; look at `agent/sessions/main.jsonl` token totals and the presence/absence of subagent session files.

--- a/benchmark/terminal-bench-smoke/scripts/run-local.sh
+++ b/benchmark/terminal-bench-smoke/scripts/run-local.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+# Run the smoke dataset against the current working tree. Cross-builds a
+# Linux amd64 kimchi-code binary like terminal-bench-2/scripts/run-local.sh.
+#
+# Usage:
+#   ./scripts/run-local.sh                       # all 3 tasks
+#   ./scripts/run-local.sh -i go-rate-limiter    # one task by name
+#   ./scripts/run-local.sh --path tasks/go-task-api  # one task by path
+#   ./scripts/run-local.sh --ae KIMCHI_MULTI_MODEL=false --ae KIMCHI_TAGS=mode:single
+set -euo pipefail
+
+: "${KIMCHI_API_KEY:?set KIMCHI_API_KEY in env}"
+
+BENCH_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+SMOKE_TASKS_DIR="$BENCH_DIR/tasks"
+AGENT_DIR="$(cd "$BENCH_DIR/../terminal-bench-2" && pwd)"
+REPO_ROOT="$(git -C "$BENCH_DIR" rev-parse --show-toplevel)"
+
+echo "==> Cross-building kimchi-code (target=linux-x64)"
+(cd "$REPO_ROOT" && pnpm run build:binary-linux-x64)
+export KIMCHI_CODE_BINARY="$REPO_ROOT/dist/bin/kimchi-code"
+
+# Default to the whole smoke dataset; user-supplied --path / -p wins.
+DEFAULT_PATH=("--path" "$SMOKE_TASKS_DIR")
+for arg in "$@"; do
+    case "$arg" in
+        --path|-p) DEFAULT_PATH=() ;;
+    esac
+done
+
+cd "$AGENT_DIR"
+exec uv run --python 3.14 harbor run \
+    --agent-import-path kimchi_agent:KimchiCode \
+    --env docker \
+    --model "${MODEL:-kimchi-dev/kimi-k2.5}" \
+    --ae "KIMCHI_API_KEY=$KIMCHI_API_KEY" \
+    --jobs-dir "$BENCH_DIR/jobs" \
+    "${DEFAULT_PATH[@]}" \
+    "$@"

--- a/benchmark/terminal-bench-smoke/scripts/run-release.sh
+++ b/benchmark/terminal-bench-smoke/scripts/run-release.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+# Run the smoke dataset against the latest published kimchi-code release.
+set -euo pipefail
+
+: "${KIMCHI_API_KEY:?set KIMCHI_API_KEY in env}"
+
+BENCH_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+SMOKE_TASKS_DIR="$BENCH_DIR/tasks"
+AGENT_DIR="$(cd "$BENCH_DIR/../terminal-bench-2" && pwd)"
+
+unset KIMCHI_CODE_BINARY
+
+DEFAULT_PATH=("--path" "$SMOKE_TASKS_DIR")
+for arg in "$@"; do
+    case "$arg" in
+        --path|-p) DEFAULT_PATH=() ;;
+    esac
+done
+
+cd "$AGENT_DIR"
+exec uv run --python 3.14 harbor run \
+    --agent-import-path kimchi_agent:KimchiCode \
+    --env docker \
+    --model "${MODEL:-kimchi-dev/kimi-k2.5}" \
+    --ae "KIMCHI_API_KEY=$KIMCHI_API_KEY" \
+    --jobs-dir "$BENCH_DIR/jobs" \
+    "${DEFAULT_PATH[@]}" \
+    "$@"

--- a/benchmark/terminal-bench-smoke/tasks/go-rate-limiter/environment/Dockerfile
+++ b/benchmark/terminal-bench-smoke/tasks/go-rate-limiter/environment/Dockerfile
@@ -1,0 +1,10 @@
+FROM golang:1.23-bookworm
+
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends curl ca-certificates procps && \
+    rm -rf /var/lib/apt/lists/*
+
+ENV GOFLAGS=-mod=mod \
+    GOTOOLCHAIN=local
+
+WORKDIR /app

--- a/benchmark/terminal-bench-smoke/tasks/go-rate-limiter/instruction.md
+++ b/benchmark/terminal-bench-smoke/tasks/go-rate-limiter/instruction.md
@@ -1,0 +1,16 @@
+Implement a Go HTTP middleware that rate-limits requests per client IP using a token bucket algorithm.
+
+Requirements:
+- Each IP gets 10 requests per second (refill rate).
+- Respond with HTTP 429 when the limit is exceeded.
+- Thread-safe implementation.
+- Standard library only (no external dependencies).
+- Put all code in directory `/app/rate-limiter/`.
+- The package must be named `ratelimiter` and live at `/app/rate-limiter/ratelimiter.go`.
+- Export a function with the exact signature:
+    `func Middleware(next http.Handler) http.Handler`
+- Provide a `go.mod` for module path `ratelimiter` (Go 1.22 or newer).
+- Provide a runnable demo at `/app/rate-limiter/cmd/server/main.go` that wraps a handler returning HTTP 200 "ok" on `GET /` and listens on the port from the `PORT` env var (default `8080`).
+- The middleware MUST identify the client IP from the `X-Forwarded-For` header when present (using the first comma-separated value), falling back to `r.RemoteAddr` otherwise.
+- Include a `README.md` in `/app/rate-limiter/` explaining usage.
+- Include unit tests using map-based test cases.

--- a/benchmark/terminal-bench-smoke/tasks/go-rate-limiter/task.toml
+++ b/benchmark/terminal-bench-smoke/tasks/go-rate-limiter/task.toml
@@ -1,0 +1,32 @@
+version = "1.0"
+
+[task]
+name = "kimchi-smoke/go-rate-limiter"
+description = "Implement a per-IP token-bucket HTTP rate limiter middleware in Go using the standard library."
+keywords = ["go", "http", "rate-limit", "middleware"]
+[[task.authors]]
+name = "kimchi-dev"
+
+[metadata]
+difficulty = "easy"
+category = "coding"
+tags = ["go", "smoke"]
+
+[verifier]
+timeout_sec = 600.0
+
+[agent]
+timeout_sec = 900.0
+
+[environment]
+build_timeout_sec = 900.0
+cpus = 2
+memory_mb = 2048
+storage_mb = 4096
+gpus = 0
+allow_internet = true
+mcp_servers = []
+
+[verifier.env]
+
+[solution.env]

--- a/benchmark/terminal-bench-smoke/tasks/go-rate-limiter/tests/test.sh
+++ b/benchmark/terminal-bench-smoke/tasks/go-rate-limiter/tests/test.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+set -uo pipefail
+
+mkdir -p /logs/verifier
+
+curl -LsSf https://astral.sh/uv/0.9.5/install.sh | sh >/dev/null 2>&1
+source "$HOME/.local/bin/env"
+
+uvx -p 3.13 -w pytest==8.4.1 -w pytest-json-ctrf==0.3.5 -w httpx==0.27.2 \
+    pytest --ctrf /logs/verifier/ctrf.json /tests/test_rate_limiter.py -rA
+status=$?
+
+if [ $status -eq 0 ]; then
+    echo 1 > /logs/verifier/reward.txt
+else
+    echo 0 > /logs/verifier/reward.txt
+fi
+exit $status

--- a/benchmark/terminal-bench-smoke/tasks/go-rate-limiter/tests/test_rate_limiter.py
+++ b/benchmark/terminal-bench-smoke/tasks/go-rate-limiter/tests/test_rate_limiter.py
@@ -1,0 +1,115 @@
+"""Black-box verifier for the go-rate-limiter task.
+
+Builds the agent's demo server, runs it, and checks:
+- agent's own `go test` passes
+- 10 reqs/s succeed; the 11th in a burst returns 429
+- Two distinct IPs are tracked independently
+"""
+
+import os
+import socket
+import subprocess
+import time
+from pathlib import Path
+
+import httpx
+import pytest
+
+APP_DIR = Path("/app/rate-limiter")
+SERVER_BIN = "/tmp/rl-server"
+
+
+def _free_port() -> int:
+    with socket.socket() as s:
+        s.bind(("127.0.0.1", 0))
+        return s.getsockname()[1]
+
+
+def test_directory_exists():
+    assert APP_DIR.is_dir(), f"missing {APP_DIR}"
+    assert (APP_DIR / "ratelimiter.go").is_file(), "missing ratelimiter.go"
+    assert (APP_DIR / "go.mod").is_file(), "missing go.mod"
+    assert (APP_DIR / "cmd" / "server" / "main.go").is_file(), "missing cmd/server/main.go"
+
+
+def test_unit_tests_pass():
+    res = subprocess.run(
+        ["go", "test", "./..."],
+        cwd=APP_DIR,
+        capture_output=True,
+        text=True,
+        timeout=180,
+    )
+    assert res.returncode == 0, f"go test failed:\nstdout:\n{res.stdout}\nstderr:\n{res.stderr}"
+
+
+@pytest.fixture(scope="module")
+def server():
+    build = subprocess.run(
+        ["go", "build", "-o", SERVER_BIN, "./cmd/server"],
+        cwd=APP_DIR,
+        capture_output=True,
+        text=True,
+        timeout=180,
+    )
+    assert build.returncode == 0, f"go build failed:\n{build.stderr}"
+
+    port = _free_port()
+    env = os.environ.copy()
+    env["PORT"] = str(port)
+    proc = subprocess.Popen(
+        [SERVER_BIN],
+        env=env,
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.DEVNULL,
+    )
+
+    base_url = f"http://127.0.0.1:{port}"
+    deadline = time.time() + 10
+    while time.time() < deadline:
+        try:
+            httpx.get(base_url + "/", timeout=0.5)
+            break
+        except httpx.HTTPError:
+            time.sleep(0.1)
+    else:
+        proc.kill()
+        raise RuntimeError("server did not become ready on :%d" % port)
+
+    yield base_url
+
+    proc.terminate()
+    try:
+        proc.wait(timeout=5)
+    except subprocess.TimeoutExpired:
+        proc.kill()
+
+
+def _burst(url: str, ip: str, n: int) -> list[int]:
+    statuses = []
+    with httpx.Client(timeout=2.0) as c:
+        for _ in range(n):
+            r = c.get(url, headers={"X-Forwarded-For": ip})
+            statuses.append(r.status_code)
+    return statuses
+
+
+def test_within_limit_passes(server):
+    statuses = _burst(server + "/", "10.0.0.1", 10)
+    assert statuses.count(200) == 10, f"expected 10x 200, got {statuses}"
+
+
+def test_burst_exceeds_returns_429(server):
+    statuses = _burst(server + "/", "10.0.0.2", 30)
+    assert 429 in statuses, f"expected at least one 429, got {statuses}"
+    # Token bucket: 10 burst capacity + refill during ~hundreds of ms of HTTP roundtrips.
+    # Loose ceiling guarding against an effectively-disabled limiter.
+    assert statuses.count(200) <= 20, f"too many 200s, limiter not enforcing: {statuses}"
+
+
+def test_per_ip_isolation(server):
+    time.sleep(1.1)
+    a = _burst(server + "/", "10.0.0.3", 10)
+    b = _burst(server + "/", "10.0.0.4", 10)
+    assert a.count(200) == 10, f"ip A: {a}"
+    assert b.count(200) == 10, f"ip B: {b}"

--- a/benchmark/terminal-bench-smoke/tasks/go-router-research/environment/Dockerfile
+++ b/benchmark/terminal-bench-smoke/tasks/go-router-research/environment/Dockerfile
@@ -1,0 +1,7 @@
+FROM debian:bookworm-slim
+
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends curl ca-certificates && \
+    rm -rf /var/lib/apt/lists/*
+
+WORKDIR /app

--- a/benchmark/terminal-bench-smoke/tasks/go-router-research/instruction.md
+++ b/benchmark/terminal-bench-smoke/tasks/go-router-research/instruction.md
@@ -1,0 +1,8 @@
+What are the most popular third-party HTTP router libraries for Go?
+
+List the top 3, and for each include:
+- GitHub stars (approximate is fine)
+- key differentiators
+- a one-line example of defining a route with a path parameter
+
+Write your answer as Markdown to `/app/answer.md`. Do not write any other source files.

--- a/benchmark/terminal-bench-smoke/tasks/go-router-research/task.toml
+++ b/benchmark/terminal-bench-smoke/tasks/go-router-research/task.toml
@@ -1,0 +1,33 @@
+version = "1.0"
+
+[task]
+name = "kimchi-smoke/go-router-research"
+description = "Research-style task: research the top 3 third-party Go HTTP router libraries and write a brief comparison."
+keywords = ["research", "web-search", "go", "non-coding"]
+[[task.authors]]
+name = "kimchi-dev"
+
+[metadata]
+difficulty = "easy"
+category = "research"
+tags = ["research", "smoke"]
+note = "Verifier only checks that the agent produced a non-trivial answer. Compare runs via session artifacts (tokens, subagent count, duration), not reward."
+
+[verifier]
+timeout_sec = 120.0
+
+[agent]
+timeout_sec = 300.0
+
+[environment]
+build_timeout_sec = 600.0
+cpus = 1
+memory_mb = 1024
+storage_mb = 2048
+gpus = 0
+allow_internet = true
+mcp_servers = []
+
+[verifier.env]
+
+[solution.env]

--- a/benchmark/terminal-bench-smoke/tasks/go-router-research/tests/test.sh
+++ b/benchmark/terminal-bench-smoke/tasks/go-router-research/tests/test.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+# Trivial verifier: only checks that the agent produced a non-trivial answer.
+# Real signal for this task lives in session artifacts (tokens, subagent count,
+# duration), which the harness captures regardless of reward.
+set -uo pipefail
+
+mkdir -p /logs/verifier
+
+curl -LsSf https://astral.sh/uv/0.9.5/install.sh | sh >/dev/null 2>&1
+source "$HOME/.local/bin/env"
+
+uvx -p 3.13 -w pytest==8.4.1 -w pytest-json-ctrf==0.3.5 \
+    pytest --ctrf /logs/verifier/ctrf.json /tests/test_research.py -rA
+status=$?
+
+if [ $status -eq 0 ]; then
+    echo 1 > /logs/verifier/reward.txt
+else
+    echo 0 > /logs/verifier/reward.txt
+fi
+exit $status

--- a/benchmark/terminal-bench-smoke/tasks/go-router-research/tests/test_research.py
+++ b/benchmark/terminal-bench-smoke/tasks/go-router-research/tests/test_research.py
@@ -1,0 +1,20 @@
+"""Trivial verifier — only asserts the agent produced a non-trivial answer file.
+
+This task exists in the smoke set so research-style runs share the harness
+plumbing (tagging, jobs/, session JSONL) with the coding tasks. Reward here
+is not a quality signal; compare runs by tokens / subagent count / duration.
+"""
+
+from pathlib import Path
+
+ANSWER = Path("/app/answer.md")
+MIN_BYTES = 500
+
+
+def test_answer_exists():
+    assert ANSWER.is_file(), f"agent did not produce {ANSWER}"
+
+
+def test_answer_non_trivial():
+    size = ANSWER.stat().st_size
+    assert size >= MIN_BYTES, f"answer too short ({size} bytes < {MIN_BYTES})"

--- a/benchmark/terminal-bench-smoke/tasks/go-task-api/environment/Dockerfile
+++ b/benchmark/terminal-bench-smoke/tasks/go-task-api/environment/Dockerfile
@@ -1,0 +1,10 @@
+FROM golang:1.23-bookworm
+
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends curl ca-certificates procps && \
+    rm -rf /var/lib/apt/lists/*
+
+ENV GOFLAGS=-mod=mod \
+    GOTOOLCHAIN=local
+
+WORKDIR /app

--- a/benchmark/terminal-bench-smoke/tasks/go-task-api/instruction.md
+++ b/benchmark/terminal-bench-smoke/tasks/go-task-api/instruction.md
@@ -1,0 +1,18 @@
+Implement a Go REST API for a task management system.
+
+Requirements:
+- Use the Go standard library only (no frameworks, no external dependencies).
+- Layered architecture: handler → service → repository.
+- In-memory repository.
+- Endpoints:
+  - `POST /tasks` — create a task. Body: `{"title": "...", "description": "..."}`. Response: 201 with the created task as JSON.
+  - `GET /tasks` — list all tasks as a JSON array.
+  - `GET /tasks/{id}` — get one task; 404 if missing.
+  - `PATCH /tasks/{id}` — update status. Body: `{"status": "todo" | "in-progress" | "done"}`. 400 on invalid status, 404 if missing.
+  - `DELETE /tasks/{id}` — delete; 204 on success, 404 if missing.
+- All responses use proper HTTP status codes and `Content-Type: application/json` (where there is a body).
+- Each task has an auto-generated string `id`, a `title`, a `description`, and a `status` (default `"todo"`).
+- Unit tests for the service layer using map-based test cases.
+- Put all code in directory `/app/task-api/`.
+- The `go.mod` module path must be `taskapi` (Go 1.22+).
+- Provide a runnable demo at `/app/task-api/cmd/server/main.go` that listens on the port from the `PORT` env var (default `8080`).

--- a/benchmark/terminal-bench-smoke/tasks/go-task-api/task.toml
+++ b/benchmark/terminal-bench-smoke/tasks/go-task-api/task.toml
@@ -1,0 +1,32 @@
+version = "1.0"
+
+[task]
+name = "kimchi-smoke/go-task-api"
+description = "Implement a layered Go REST API for task management using only the standard library."
+keywords = ["go", "rest", "stdlib", "layered-architecture"]
+[[task.authors]]
+name = "kimchi-dev"
+
+[metadata]
+difficulty = "medium"
+category = "coding"
+tags = ["go", "smoke"]
+
+[verifier]
+timeout_sec = 600.0
+
+[agent]
+timeout_sec = 1500.0
+
+[environment]
+build_timeout_sec = 900.0
+cpus = 2
+memory_mb = 2048
+storage_mb = 4096
+gpus = 0
+allow_internet = true
+mcp_servers = []
+
+[verifier.env]
+
+[solution.env]

--- a/benchmark/terminal-bench-smoke/tasks/go-task-api/tests/test.sh
+++ b/benchmark/terminal-bench-smoke/tasks/go-task-api/tests/test.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+set -uo pipefail
+
+mkdir -p /logs/verifier
+
+curl -LsSf https://astral.sh/uv/0.9.5/install.sh | sh >/dev/null 2>&1
+source "$HOME/.local/bin/env"
+
+uvx -p 3.13 -w pytest==8.4.1 -w pytest-json-ctrf==0.3.5 -w httpx==0.27.2 \
+    pytest --ctrf /logs/verifier/ctrf.json /tests/test_task_api.py -rA
+status=$?
+
+if [ $status -eq 0 ]; then
+    echo 1 > /logs/verifier/reward.txt
+else
+    echo 0 > /logs/verifier/reward.txt
+fi
+exit $status

--- a/benchmark/terminal-bench-smoke/tasks/go-task-api/tests/test_task_api.py
+++ b/benchmark/terminal-bench-smoke/tasks/go-task-api/tests/test_task_api.py
@@ -1,0 +1,145 @@
+"""Black-box verifier for the go-task-api task.
+
+Builds the agent's server binary, runs it, and exercises the documented
+HTTP contract end-to-end. Also runs the agent's own service-layer unit tests.
+"""
+
+import os
+import socket
+import subprocess
+import time
+from pathlib import Path
+
+import httpx
+import pytest
+
+APP_DIR = Path("/app/task-api")
+SERVER_BIN = "/tmp/taskapi-server"
+
+
+def _free_port() -> int:
+    with socket.socket() as s:
+        s.bind(("127.0.0.1", 0))
+        return s.getsockname()[1]
+
+
+def test_directory_exists():
+    assert APP_DIR.is_dir(), f"missing {APP_DIR}"
+    assert (APP_DIR / "go.mod").is_file(), "missing go.mod"
+    assert (APP_DIR / "cmd" / "server" / "main.go").is_file(), "missing cmd/server/main.go"
+
+
+def test_unit_tests_pass():
+    res = subprocess.run(
+        ["go", "test", "./..."],
+        cwd=APP_DIR,
+        capture_output=True,
+        text=True,
+        timeout=180,
+    )
+    assert res.returncode == 0, f"go test failed:\nstdout:\n{res.stdout}\nstderr:\n{res.stderr}"
+
+
+@pytest.fixture(scope="module")
+def server():
+    build = subprocess.run(
+        ["go", "build", "-o", SERVER_BIN, "./cmd/server"],
+        cwd=APP_DIR,
+        capture_output=True,
+        text=True,
+        timeout=180,
+    )
+    assert build.returncode == 0, f"go build failed:\n{build.stderr}"
+
+    port = _free_port()
+    env = os.environ.copy()
+    env["PORT"] = str(port)
+    proc = subprocess.Popen(
+        [SERVER_BIN],
+        env=env,
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.DEVNULL,
+    )
+
+    base_url = f"http://127.0.0.1:{port}"
+    deadline = time.time() + 10
+    while time.time() < deadline:
+        try:
+            httpx.get(base_url + "/tasks", timeout=0.5)
+            break
+        except httpx.HTTPError:
+            time.sleep(0.1)
+    else:
+        proc.kill()
+        raise RuntimeError("server did not become ready")
+
+    yield base_url
+
+    proc.terminate()
+    try:
+        proc.wait(timeout=5)
+    except subprocess.TimeoutExpired:
+        proc.kill()
+
+
+def test_create_returns_201_with_id(server):
+    r = httpx.post(server + "/tasks", json={"title": "buy milk", "description": "2L"})
+    assert r.status_code == 201, r.text
+    body = r.json()
+    assert body.get("id"), f"missing id in {body}"
+    assert body.get("title") == "buy milk"
+    assert body.get("description") == "2L"
+    assert body.get("status") == "todo"
+
+
+def test_list_includes_created(server):
+    r = httpx.post(server + "/tasks", json={"title": "task A", "description": ""})
+    assert r.status_code == 201
+    created_id = r.json()["id"]
+
+    r = httpx.get(server + "/tasks")
+    assert r.status_code == 200
+    items = r.json()
+    assert isinstance(items, list)
+    assert any(t.get("id") == created_id for t in items)
+
+
+def test_get_by_id_and_404(server):
+    r = httpx.post(server + "/tasks", json={"title": "x", "description": ""})
+    tid = r.json()["id"]
+
+    r = httpx.get(f"{server}/tasks/{tid}")
+    assert r.status_code == 200
+    assert r.json()["id"] == tid
+
+    r = httpx.get(f"{server}/tasks/does-not-exist-xyz")
+    assert r.status_code == 404
+
+
+def test_patch_status(server):
+    r = httpx.post(server + "/tasks", json={"title": "p", "description": ""})
+    tid = r.json()["id"]
+
+    r = httpx.patch(f"{server}/tasks/{tid}", json={"status": "in-progress"})
+    assert r.status_code == 200, r.text
+    assert r.json()["status"] == "in-progress"
+
+    r = httpx.patch(f"{server}/tasks/{tid}", json={"status": "bogus"})
+    assert r.status_code == 400
+
+    r = httpx.patch(f"{server}/tasks/missing-xyz", json={"status": "done"})
+    assert r.status_code == 404
+
+
+def test_delete(server):
+    r = httpx.post(server + "/tasks", json={"title": "d", "description": ""})
+    tid = r.json()["id"]
+
+    r = httpx.delete(f"{server}/tasks/{tid}")
+    assert r.status_code == 204
+
+    r = httpx.get(f"{server}/tasks/{tid}")
+    assert r.status_code == 404
+
+    r = httpx.delete(f"{server}/tasks/missing-xyz")
+    assert r.status_code == 404


### PR DESCRIPTION


---
### Kimchi Summary
### What changed
Adds a new `terminal-bench-smoke` benchmark suite with three tasks (two Go coding tasks and one research task) that reuse the `terminal-bench-2` harness. Also extends the `kimchi_agent` to support runtime toggling between orchestrator and single-model execution modes via the `KIMCHI_MULTI_MODEL` environment variable.

### Why
Provides a lightweight, fast-feedback smoke test suite for validating kimchi-code changes without running the full benchmark. The single-model toggle eliminates the need to duplicate task definitions when comparing orchestrator behavior against standalone model performance.

### Key changes
- **`benchmark/terminal-bench-2/src/kimchi_agent/agent.py`**: Detects `KIMCHI_MULTI_MODEL=false` (via `--ae` flags) and appends `--multi-model=false` to CLI invocation, allowing single-model execution of any task.
- **`benchmark/terminal-bench-smoke/`**: New smoke test directory containing:
  - `tasks/go-rate-limiter/`: Token-bucket HTTP middleware implementation task with black-box verifier testing burst limits and per-IP isolation.
  - `tasks/go-task-api/`: Layered REST API task (POST/GET/PATCH/DELETE) with end-to-end HTTP contract verification.
  - `tasks/go-router-research/`: Research task with trivial verifier (only checks `/app/answer.md` exists and is non-empty); intended for comparing token usage and subagent behavior rather than reward.
  - `scripts/run-local.sh`: Cross-builds Linux binary from working tree and executes smoke suite.
  - `scripts/run-release.sh`: Executes smoke suite against latest published kimchi-code release.
  - `README.md`: Usage examples including single-model tagging syntax (`--ae KIMCHI_MULTI_MODEL=false --ae KIMCHI_TAGS=mode:single`).