### PR TITLE
LLM-1498: Add self-improvement loop for the benchmark harness

### DIFF
--- a/benchmark/manual/.gitignore
+++ b/benchmark/manual/.gitignore
@@ -1,2 +1,3 @@
 sessions/
 benchmark.local.json
+improvement-goals.md

--- a/benchmark/manual/README.md
+++ b/benchmark/manual/README.md
@@ -8,12 +8,12 @@ Edit `benchmark.json` to match your environment:
 
 ```json
 {
-  "binary": "/path/to/your/kimchi-code",
+  "binary": "/path/to/your/kimchi",
   "models": ["kimi-k2.5", "minimax-m2.7"]
 }
 ```
 
-- `binary` — path to the kimchi-code binary (`~` is expanded)
+- `binary` — path to the kimchi binary (`~` is expanded)
 - `models` — list of model IDs to benchmark; scripts are generated for every model × task combination
 
 ## Workflow
@@ -136,7 +136,7 @@ From the repo root:
 ./benchmark/manual/start-self-improvement.sh
 ```
 
-This launches `kimchi-code` in `--yolo` mode with the self-improvement prompt. The agent will cycle through build → benchmark → analyse → code change phases automatically, stopping when a stopping condition is met (see `self-improvement.md` for details).
+This launches `kimchi` in `--yolo` mode with the self-improvement prompt. The agent will cycle through build → benchmark → analyse → code change phases automatically, stopping when a stopping condition is met (see `self-improvement.md` for details).
 
 ### Custom improvement goals
 

--- a/benchmark/manual/README.md
+++ b/benchmark/manual/README.md
@@ -124,6 +124,37 @@ sessions/session-01/
 
 `compare-sessions.py` calls `analyze-session.py` automatically if `analysis.json` is missing for either session.
 
+## Self-Improvement Loop
+
+The self-improvement loop is an autonomous process that iteratively builds, benchmarks, analyses, and applies targeted code changes to improve harness performance. See `self-improvement.md` for the full protocol.
+
+### Running
+
+From the repo root:
+
+```bash
+./benchmark/manual/start-self-improvement.sh
+```
+
+This launches `kimchi-code` in `--yolo` mode with the self-improvement prompt. The agent will cycle through build → benchmark → analyse → code change phases automatically, stopping when a stopping condition is met (see `self-improvement.md` for details).
+
+### Custom improvement goals
+
+To steer the self-improvement loop toward specific areas, create an `improvement-goals.md` file in the benchmark directory:
+
+```bash
+cat > benchmark/manual/improvement-goals.md << 'EOF'
+## Improvement Goals
+
+- Reduce token consumption on complex-single tasks by 30%
+- Investigate why kimi-k2.5 generates empty tool calls
+EOF
+```
+
+When `improvement-goals.md` exists, its contents are automatically appended to the self-improvement prompt. Delete or rename the file to run without custom goals.
+
+The file is gitignored — each developer can maintain their own goals without affecting others.
+
 ## Historical findings
 
 See `SUMMARY.md` for a token trajectory table across the first 10 sessions and the five changes that had the largest measurable impact on token consumption and output quality.

--- a/benchmark/manual/analyze-session.py
+++ b/benchmark/manual/analyze-session.py
@@ -13,26 +13,26 @@ SESSIONS_DIR = IMPROVEMENT_DIR / "sessions"
 
 TASK_CRITERIA = {
     "simple": {
-        "min_subagents": 1,
+        "min_subagents": 0,
         "max_subagents": 2,
         "max_tokens": 300_000,
         "max_duration_s": 300,
     },
     "complex": {
-        "min_subagents": 2,
-        "max_subagents": 6,
+        "min_subagents": 1,
+        "max_subagents": 5,
         "max_tokens": 700_000,
         "max_duration_s": 600,
     },
     "complex-single": {
-        "min_subagents": 1,
-        "max_subagents": 5,
+        "min_subagents": 0,
+        "max_subagents": 0,
         "max_tokens": 500_000,
         "max_duration_s": 600,
     },
     "research": {
         "min_subagents": 0,
-        "max_subagents": 0,
+        "max_subagents": 1,
         "max_tokens": 30_000,
         "max_duration_s": 120,
     },

--- a/benchmark/manual/benchmark.json
+++ b/benchmark/manual/benchmark.json
@@ -1,5 +1,5 @@
 {
-  "binary": "kimchi-code",
+  "binary": "kimchi",
   "models": [
     "kimi-k2.5",
     "minimax-m2.7"

--- a/benchmark/manual/new-session.sh
+++ b/benchmark/manual/new-session.sh
@@ -14,7 +14,7 @@ else
   exit 1
 fi
 
-BINARY=$(python3 -c "import json,os; cfg=json.load(open('$BENCHMARK_JSON')); print(os.path.expanduser(cfg.get('binary','~/_dev/kimchi-dev/dist/bin/kimchi-code')))")
+BINARY=$(python3 -c "import json,os; cfg=json.load(open('$BENCHMARK_JSON')); print(os.path.expanduser(cfg.get('binary','~/_dev/kimchi-dev/dist/bin/kimchi')))")
 
 if [[ ! -f "$BINARY" ]]; then
   echo "Binary not found: $BINARY"

--- a/benchmark/manual/new-session.sh
+++ b/benchmark/manual/new-session.sh
@@ -125,6 +125,8 @@ for r in range(rows):
     for c in range(cols):
         i = r * cols + c
         if i < len(all_scripts):
+                # NOTE: iTerm2's `write text` sends keystrokes and returns immediately —
+            # it does NOT wait for the command to finish.
             as_lines.append(f'      tell g{c}_{r} to write text "{all_scripts[i]}"')
 as_body = "\n".join(as_lines)
 

--- a/benchmark/manual/new-session.sh
+++ b/benchmark/manual/new-session.sh
@@ -109,13 +109,18 @@ run_all = os.path.join(session_dir, "run-all.sh")
 cols = len(tasks)
 rows = len(models)
 
-# Build AppleScript: create top row with vertical splits, then add rows with horizontal splits
-as_lines = ["      set g0_0 to current session"]
+# Build AppleScript: create a NEW TAB, then split into a grid (cols=tasks, rows=models)
+as_lines = []
+# First pane in the new tab
+as_lines.append("      set g0_0 to current session of newTab")
+# Create remaining columns via vertical splits
 for c in range(1, cols):
     as_lines.append(f"      set g{c}_0 to (split vertically with default profile of g{c-1}_0)")
+# Create rows via horizontal splits
 for r in range(1, rows):
     for c in range(cols):
         as_lines.append(f"      set g{c}_{r} to (split horizontally with default profile of g{c}_{r-1})")
+# Write commands
 for r in range(rows):
     for c in range(cols):
         i = r * cols + c
@@ -137,7 +142,8 @@ if osascript -e 'id of application "iTerm2"' &>/dev/null 2>&1; then
   osascript <<APPLESCRIPT
 tell application "iTerm2"
   tell current window
-    tell current tab
+    set newTab to (create tab with default profile)
+    tell newTab
 {as_body}
     end tell
   end tell

--- a/benchmark/manual/self-improvement.md
+++ b/benchmark/manual/self-improvement.md
@@ -17,7 +17,7 @@ pnpm install                     # install dependencies first
 pnpm run check                   # lint + typecheck — must pass before proceeding
 pnpm run test                    # unit tests — must pass before proceeding
 pnpm run build:binary            # compile the binary
-dist/bin/kimchi-code --version   # verify the binary is functional
+dist/bin/kimchi --version   # verify the binary is functional
 ```
 
 **Timeout:** 10 minutes total for this phase.

--- a/benchmark/manual/self-improvement.md
+++ b/benchmark/manual/self-improvement.md
@@ -1,0 +1,151 @@
+# Self-Improvement Loop
+
+You are an expert developer of the kimchi-dev harness running an autonomous self-improvement loop. Your goal is to improve harness correctness, orchestration behaviour, and token efficiency — measured by benchmark results across sessions.
+
+---
+
+## Iteration Protocol
+
+Each iteration follows these phases in order. Do not skip or reorder them.
+
+### Phase 1 — Build
+
+Build a fresh binary and run all checks. From the repo root:
+
+```bash
+pnpm run check                   # lint + typecheck — must pass before proceeding
+pnpm run test                    # unit tests — must pass before proceeding
+pnpm run install                 # install
+pnpm run build:binary            # compile the binary
+dist/bin/kimchi-code --version   # verify the binary is functional
+```
+
+**Timeout:** 10 minutes total for this phase.
+
+**On failure:** Analyse the build output. Identify the root cause. Apply a fix limited to the minimum change needed. Re-run from `pnpm run check`. If the build fails again after one fix attempt, stop the iteration and report the blocker.
+
+---
+
+### Phase 2 — Benchmark
+
+Create a new session and run all benchmark tasks:
+
+```bash
+cd benchmark/manual
+./new-session.sh
+./sessions/session-NN/run-all.sh   # replace NN with the session number printed above
+```
+
+**If you are running in iTerm2, run tasks in foreground so the user can monitor progress in a separate tab. Close the tab when all tasks are done.**
+
+**Per-task timeouts** (enforced by task criteria, not by you):
+
+| Task | Max duration | Max tokens | Expected subagents |
+|---|---|---|---|
+| simple | 5 min | 300k | 0–2 |
+| complex | 10 min | 700k | 1–5 |
+| complex-single | 10 min | 500k | 0 |
+| research | 2 min | 30k | 0 |
+
+**Overall timeout:** 30 minutes for all runs combined. If any run is still active after its individual timeout, kill it and record it as a timeout failure.
+
+**Do not proceed to Phase 3 until all runs have completed or timed out.**
+
+---
+
+### Phase 3 — Analyse
+
+Analyse the session and compare against the previous one:
+
+```bash
+python3 analyze-session.py              # analyse current session
+python3 compare-sessions.py             # compare with previous session
+```
+
+Review the output for:
+- `[x] FAIL` entries — token budget exceeded, wrong subagent count, duration exceeded
+- `[!] WARN` entries — outside expected range but not a hard failure
+- Regression in any metric vs the previous session (token delta, duration delta, subagent count)
+- Unexpected tool call patterns in orchestrator output
+- Terminated sessions (look for `(terminated)` tag)
+
+Write a structured findings summary covering:
+1. What improved vs previous session (with numbers)
+2. What regressed vs previous session (with numbers)
+3. Hard failures and their likely causes
+4. Proposed changes with expected impact
+
+**Verification requirement:** For each proposed change, you must identify the specific session log evidence that supports it. Do not propose a change based on a single run of a single task. If a finding appears in only one run, mark it as unconfirmed and do not act on it in this iteration.
+
+---
+
+### Phase 4 — Code Changes
+
+Apply changes based on confirmed findings only. Before touching any code:
+
+1. State the finding, the evidence (session + run name), and the expected impact.
+2. Apply the change.
+3. Run verification:
+
+```bash
+pnpm run check   # must pass
+pnpm run test    # must pass
+```
+
+If either fails, revert the change and record it as a failed attempt. Do not force-pass by suppressing linter rules or deleting tests.
+
+**Constraints:**
+- Maximum 3 source files changed per iteration
+- Changes limited to `src/` only — never modify `benchmark/`, `tests/`, or `scripts/`
+- No structural refactors — only targeted fixes addressing confirmed findings
+- No changes to prompt templates based on a single model's behaviour — findings must appear across at least two models or two task types
+
+---
+
+### Phase 5 — Iteration Summary
+
+Write a summary to `benchmark/manual/iterations/iteration-NN.md` (create the directory if it does not exist):
+
+```
+# Iteration NN — YYYY-MM-DD
+
+## Sessions
+- Pre-change: session-XX
+- Post-change: session-YY
+
+## Findings
+- [confirmed] <finding> — evidence: <run>, metric delta: <X>
+- [unconfirmed] <finding> — insufficient evidence, deferred
+
+## Changes Applied
+- <file>: <what changed and why>
+
+## Regression Check
+- PASS / FAIL (detail any regressions)
+
+## Net Impact
+- Token delta: <+/- X%> across all tasks
+- Duration delta: <+/- X%>
+- Failures: <before> → <after>
+```
+
+---
+
+## Stopping Conditions
+
+Stop the loop and report final status when any of the following is true:
+
+- 20 iterations completed
+- Total elapsed time exceeds 8 hours
+
+---
+
+## Hard Guardrails
+
+These rules cannot be overridden under any circumstances:
+
+- Never suppress linter errors or skip tests to force a passing check
+- Never apply a change that was not directly motivated by a confirmed benchmark finding
+- Never commit changes — leave all changes staged for human review
+- Never run more than one benchmark session in parallel within the same iteration
+- Never act on a finding seen in only one run of one task across one model

--- a/benchmark/manual/self-improvement.md
+++ b/benchmark/manual/self-improvement.md
@@ -13,9 +13,9 @@ Each iteration follows these phases in order. Do not skip or reorder them.
 Build a fresh binary and run all checks. From the repo root:
 
 ```bash
+pnpm install                     # install dependencies first
 pnpm run check                   # lint + typecheck — must pass before proceeding
 pnpm run test                    # unit tests — must pass before proceeding
-pnpm run install                 # install
 pnpm run build:binary            # compile the binary
 dist/bin/kimchi-code --version   # verify the binary is functional
 ```
@@ -45,7 +45,7 @@ cd benchmark/manual
 | simple | 5 min | 300k | 0–2 |
 | complex | 10 min | 700k | 1–5 |
 | complex-single | 10 min | 500k | 0 |
-| research | 2 min | 30k | 0 |
+| research | 2 min | 30k | 0–1 |
 
 **Overall timeout:** 30 minutes for all runs combined. If any run is still active after its individual timeout, kill it and record it as a timeout failure.
 

--- a/benchmark/manual/start-self-improvement.sh
+++ b/benchmark/manual/start-self-improvement.sh
@@ -1,0 +1,16 @@
+#!/bin/zsh
+set -e
+
+PROMPT="$(cat benchmark/manual/self-improvement.md)"
+
+GOALS_FILE="benchmark/manual/improvement-goals.md"
+if [[ -f "$GOALS_FILE" ]]; then
+  PROMPT="$PROMPT
+
+---
+
+$(cat "$GOALS_FILE")"
+  echo "Custom improvement goals loaded from $GOALS_FILE"
+fi
+
+dist/bin/kimchi-code "$PROMPT" --yolo

--- a/benchmark/manual/start-self-improvement.sh
+++ b/benchmark/manual/start-self-improvement.sh
@@ -1,16 +1,19 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-BINARY="dist/bin/kimchi-code"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+
+BINARY="$REPO_ROOT/dist/bin/kimchi-code"
 if [[ ! -x "$BINARY" ]]; then
   echo "Error: $BINARY not found or not executable." >&2
   echo "Run 'pnpm run build:binary' first." >&2
   exit 1
 fi
 
-PROMPT="$(cat benchmark/manual/self-improvement.md)"
+PROMPT="$(cat "$SCRIPT_DIR/self-improvement.md")"
 
-GOALS_FILE="benchmark/manual/improvement-goals.md"
+GOALS_FILE="$SCRIPT_DIR/improvement-goals.md"
 if [[ -f "$GOALS_FILE" ]]; then
   PROMPT="$PROMPT
 
@@ -20,4 +23,5 @@ $(cat "$GOALS_FILE")"
   echo "Custom improvement goals loaded from $GOALS_FILE"
 fi
 
+cd "$REPO_ROOT"
 "$BINARY" "$PROMPT" --yolo

--- a/benchmark/manual/start-self-improvement.sh
+++ b/benchmark/manual/start-self-improvement.sh
@@ -4,7 +4,7 @@ set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
 
-BINARY="$REPO_ROOT/dist/bin/kimchi-code"
+BINARY="$REPO_ROOT/dist/bin/kimchi"
 if [[ ! -x "$BINARY" ]]; then
   echo "Error: $BINARY not found or not executable." >&2
   echo "Run 'pnpm run build:binary' first." >&2

--- a/benchmark/manual/start-self-improvement.sh
+++ b/benchmark/manual/start-self-improvement.sh
@@ -1,5 +1,12 @@
-#!/bin/zsh
-set -e
+#!/usr/bin/env bash
+set -euo pipefail
+
+BINARY="dist/bin/kimchi-code"
+if [[ ! -x "$BINARY" ]]; then
+  echo "Error: $BINARY not found or not executable." >&2
+  echo "Run 'pnpm run build:binary' first." >&2
+  exit 1
+fi
 
 PROMPT="$(cat benchmark/manual/self-improvement.md)"
 
@@ -13,4 +20,4 @@ $(cat "$GOALS_FILE")"
   echo "Custom improvement goals loaded from $GOALS_FILE"
 fi
 
-dist/bin/kimchi-code "$PROMPT" --yolo
+"$BINARY" "$PROMPT" --yolo


### PR DESCRIPTION
## What this is

A repeatable, autonomous improvement loop that drives the benchmark harness (`benchmark/manual/`) through build → benchmark → analyse → code-change cycles, using the existing benchmark tasks as the fitness function. Runs inside a `kimchi-code --yolo` session; stops after 20 iterations or 8 hours.

This PR contains only the loop infrastructure and benchmark tooling. No `src/` (harness) code is touched here — harness changes discovered by running this loop land in a separate PR (#143).

## What it can be used for

- Tightening the orchestrator/subagent harness against regressions found by real benchmark runs.
- Reducing token consumption on inefficient tasks.
- Spotting and eliminating empty/phantom tool calls, runaway loops, and stale-state hangs.
- Comparing model behaviour across sessions via `analyze-session.py` / `compare-sessions.py`.
- General experimentation: drop a custom `improvement-goals.md` and re-run.

## How to use it

```bash
./benchmark/manual/start-self-improvement.sh
```

The loop then: (1) builds and verifies the binary, (2) creates a fresh session and runs all benchmark tasks, (3) analyses results and compares against the previous session, (4) applies targeted code changes (only when confirmed by ≥2 models or ≥2 task types), (5) writes an iteration summary to `benchmark/manual/iterations/iteration-NN.md`.

### Custom goals (optional)

Drop an `improvement-goals.md` in `benchmark/manual/` to steer the loop. The file is gitignored so each developer keeps their own goals locally.

## Hard guardrails

- Never suppress linter errors or skip tests.
- Never apply a change not motivated by a confirmed benchmark finding.
- Never commit — leave everything staged for human review.
- Never run more than one benchmark session in parallel per iteration.
- Never act on a finding seen in only one run of one task across one model.
- Max 3 source files changed per iteration; changes limited to `src/` only.

## Files in this PR

- `self-improvement.md` — loop protocol fed to `kimchi-code` as the system prompt.
- `start-self-improvement.sh` — launcher that reads the protocol, optionally appends `improvement-goals.md`, and starts `kimchi-code --yolo`.
- `.gitignore` — ignores `improvement-goals.md`.
- `README.md` — documents the loop and custom-goals file.
- `new-session.sh` — opens the benchmark grid in a new iTerm tab.
- `analyze-session.py` — recalibrated task criteria to match observed reality across runs.

---
### Kimchi Summary
### What changed
Implements an autonomous self-improvement loop that iteratively builds, benchmarks, analyzes, and edits the harness to optimize token efficiency and correctness. Also renames the binary reference from `kimchi-code` to `kimchi` throughout the benchmark tooling and adjusts task criteria thresholds.

### Why
Enable hands-off iterative optimization of the harness through automated build-benchmark-analyze-edit cycles, reducing manual tuning overhead. The binary rename aligns the benchmark configuration with the actual build output name.

### Key changes
- `start-self-improvement.sh` (new): Entry script that launches `kimchi` in `--yolo` mode with the self-improvement protocol; optionally appends custom goals from `improvement-goals.md`
- `self-improvement.md` (new): 5-phase iteration protocol (build → benchmark → analyze → code changes → summary) with strict guardrails, verification requirements, and stopping conditions after 20 iterations or 8 hours
- `README.md`: Added documentation for running the self-improvement loop and configuring custom goals via the optional `improvement-goals.md` file
- `analyze-session.py`: Adjusted `TASK_CRITERIA` thresholds—reduced minimum subagent requirements for `simple` (1→0), `complex` (2→1), and `complex-single` (1→0); reduced maximum subagents for `complex` (6→5) and `complex-single` (5→0); increased maximum for `research` (0→1)
- `new-session.sh`: Fixed iTerm2 automation to create a new tab (`create tab with default profile`) instead of splitting the current tab, preventing interference with existing terminal sessions
- `benchmark.json`, `new-session.sh`, `README.md`: Renamed binary reference from `kimchi-code` to `kimchi`
- `.gitignore`: Added `improvement-goals.md` to support developer-specific goal configurations without affecting others

### Impact
The self-improvement loop modifies source files in `src/` automatically based on benchmark findings, leaving changes staged for human review. Developers should verify that local `benchmark.json` configurations are updated to reference `kimchi` instead of `kimchi-code` if they override the default binary path.