### PR TITLE
LLM-1498: Harness improvements from self-improvement loop sessions

### DIFF
--- a/src/extensions/orchestration/continuation-nudge.test.ts
+++ b/src/extensions/orchestration/continuation-nudge.test.ts
@@ -262,21 +262,21 @@ describe("EmptyTurnNudge", () => {
 		expect(guard.evaluateTurn(emptyMessage)).toBe(true)
 	})
 
-	it("does not nudge on an empty turn without a preceding tool-call-only turn", () => {
+	it("nudges on an empty first turn (no preceding turn at all)", () => {
 		const guard = new EmptyTurnNudge()
-		expect(guard.evaluateTurn(emptyMessage)).toBe(false)
+		expect(guard.evaluateTurn(emptyMessage)).toBe(true)
 	})
 
-	it("does not nudge on an empty turn after a text-only turn", () => {
+	it("nudges on an empty turn after a text-only turn", () => {
 		const guard = new EmptyTurnNudge()
 		guard.evaluateTurn(textOnlyMessage)
-		expect(guard.evaluateTurn(emptyMessage)).toBe(false)
+		expect(guard.evaluateTurn(emptyMessage)).toBe(true)
 	})
 
-	it("does not nudge on an empty turn after a text-and-tool-call turn", () => {
+	it("nudges on an empty turn after a text-and-tool-call turn", () => {
 		const guard = new EmptyTurnNudge()
 		guard.evaluateTurn(textAndToolCallMessage)
-		expect(guard.evaluateTurn(emptyMessage)).toBe(false)
+		expect(guard.evaluateTurn(emptyMessage)).toBe(true)
 	})
 
 	it("treats whitespace-only text as empty", () => {
@@ -302,18 +302,13 @@ describe("EmptyTurnNudge", () => {
 		expect(guard.evaluateTurn(emptyMessage)).toBe(false)
 	})
 
-	it("resets on new user input", () => {
+	it("re-arms after resetForNewUserInput", () => {
 		const guard = new EmptyTurnNudge()
-		guard.evaluateTurn(toolCallMessage)
-		guard.resetForNewUserInput()
-		expect(guard.evaluateTurn(emptyMessage)).toBe(false)
-	})
-
-	it("re-arms after a new tool-call-only turn", () => {
-		const guard = new EmptyTurnNudge()
-		guard.evaluateTurn(toolCallMessage)
 		expect(guard.evaluateTurn(emptyMessage)).toBe(true)
-		guard.evaluateTurn(toolCallMessage)
+		// Already nudged this cycle — second empty should not nudge
+		expect(guard.evaluateTurn(emptyMessage)).toBe(false)
+		// Reset re-arms the nudge for the next user-input cycle
+		guard.resetForNewUserInput()
 		expect(guard.evaluateTurn(emptyMessage)).toBe(true)
 	})
 })

--- a/src/extensions/orchestration/continuation-nudge.ts
+++ b/src/extensions/orchestration/continuation-nudge.ts
@@ -92,28 +92,35 @@ export class ContinuationNudge {
 }
 
 /**
- * Tracks whether the previous assistant turn was tool-call-only so the `turn_end` handler can send a followUp nudge only when the empty response follows a tool-result → LLM-call sequence. Models that never produce empty responses never see the nudge.
+ * Nudges the model when it returns a completely empty response (no text,
+ * no tool calls). Some model deployments occasionally return empty
+ * responses — either after receiving tool results from a tool-call-only
+ * turn, or as the very first response to a user prompt. Without the
+ * nudge the agent loop stalls because there is nothing to execute or
+ * display.
  *
- * Some model deployments (notably Kimi K2.x) return an empty response — no text, no tool calls — after receiving tool results from a tool-call-only turn. The agent loop stalls because there is nothing to execute or display.
+ * Fires at most once per user-input cycle to avoid infinite nudge loops
+ * when a model persistently returns empty responses.
  */
 export class EmptyTurnNudge {
-	private previousTurnWasToolCallOnly = false
+	private nudgedSinceLastUserInput = false
 
 	evaluateTurn(message: AssistantMessage): boolean {
+		if (this.nudgedSinceLastUserInput) return false
+
 		const hasText = message.content.some((c) => c.type === "text" && c.text.trim().length > 0)
 		const hasToolCalls = message.content.some((c) => c.type === "toolCall")
 
-		if (!hasText && !hasToolCalls && this.previousTurnWasToolCallOnly) {
-			this.previousTurnWasToolCallOnly = false
+		if (!hasText && !hasToolCalls) {
+			this.nudgedSinceLastUserInput = true
 			return true
 		}
 
-		this.previousTurnWasToolCallOnly = hasToolCalls && !hasText
 		return false
 	}
 
 	resetForNewUserInput(): void {
-		this.previousTurnWasToolCallOnly = false
+		this.nudgedSinceLastUserInput = false
 	}
 }
 

--- a/src/extensions/orchestration/prompt-enrichment.test.ts
+++ b/src/extensions/orchestration/prompt-enrichment.test.ts
@@ -1,6 +1,7 @@
+import type { AssistantMessage, ToolResultMessage } from "@mariozechner/pi-ai"
 import { describe, expect, it } from "vitest"
 import type { OrchestratorMessages } from "./continuation-nudge.js"
-import { EnrichmentGuard, deduplicateEnrichedPrompts } from "./prompt-enrichment.js"
+import { EnrichmentGuard, deduplicateEnrichedPrompts, stripEmptyToolCalls } from "./prompt-enrichment.js"
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -20,10 +21,10 @@ function makeUser(text: string): OrchestratorMessages[number] {
 	return { role: "user", content: [{ type: "text", text }], timestamp: Date.now() }
 }
 
-function makeAssistant(): OrchestratorMessages[number] {
+function makeAssistant(content: AssistantMessage["content"] = [{ type: "text", text: "Done." }]): AssistantMessage {
 	return {
 		role: "assistant",
-		content: [{ type: "text", text: "Done." }],
+		content,
 		api: "openai-completions",
 		provider: "kimchi-dev",
 		model: "kimi-k2.6",
@@ -36,6 +37,18 @@ function makeAssistant(): OrchestratorMessages[number] {
 			cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
 		},
 		stopReason: "stop",
+		timestamp: Date.now(),
+	}
+}
+
+function makeToolResult(toolCallId: string, text = "Tool  not found", isError = true): ToolResultMessage {
+	return {
+		role: "toolResult",
+		toolCallId,
+		toolName: "",
+		content: [{ type: "text", text }],
+		details: undefined,
+		isError,
 		timestamp: Date.now(),
 	}
 }
@@ -167,5 +180,136 @@ describe("deduplicateEnrichedPrompts", () => {
 		const messages: OrchestratorMessages = [makeEnrichedPrompt(), makeEnrichedPrompt(), nudge, makeUser("q")]
 		const result = deduplicateEnrichedPrompts(messages)
 		expect(result).toContain(nudge)
+	})
+})
+
+// ---------------------------------------------------------------------------
+// stripEmptyToolCalls
+// ---------------------------------------------------------------------------
+
+describe("stripEmptyToolCalls", () => {
+	it("returns the same array reference when there are no empty tool calls", () => {
+		const messages: OrchestratorMessages = [
+			makeUser("hi"),
+			makeAssistant([
+				{ type: "text", text: "writing file" },
+				{ type: "toolCall", id: "call_1", name: "write", arguments: { path: "a.ts", content: "x" } },
+			]),
+		]
+		expect(stripEmptyToolCalls(messages)).toBe(messages)
+	})
+
+	it("returns the same array reference for an empty messages list", () => {
+		const messages: OrchestratorMessages = []
+		expect(stripEmptyToolCalls(messages)).toBe(messages)
+	})
+
+	it("strips an empty-name tool call from an assistant message", () => {
+		const messages: OrchestratorMessages = [
+			makeAssistant([
+				{ type: "toolCall", id: "call_1", name: "write", arguments: { path: "a.ts", content: "x" } },
+				{ type: "text", text: "Valid" },
+				{ type: "toolCall", id: "", name: "", arguments: {} },
+				{ type: "text", text: " " },
+			]),
+		]
+		const result = stripEmptyToolCalls(messages)
+		expect(result).not.toBe(messages)
+		expect(result).toHaveLength(1)
+		const content = (result[0] as AssistantMessage).content
+		expect(content).toHaveLength(3)
+		for (const block of content) {
+			if (typeof block === "object" && block !== null && "type" in block && block.type === "toolCall") {
+				expect((block as { name: string }).name).toBe("write")
+			}
+		}
+	})
+
+	it("removes the paired toolResult by toolCallId", () => {
+		const messages: OrchestratorMessages = [
+			makeAssistant([{ type: "toolCall", id: "empty-1", name: "", arguments: {} }]),
+			makeToolResult("empty-1"),
+			makeUser("next"),
+		]
+		const result = stripEmptyToolCalls(messages)
+		expect(result).not.toBe(messages)
+		// Both the assistant turn (which becomes empty after stripping) and the
+		// orphaned toolResult should be gone, leaving only the user message.
+		expect(result).toHaveLength(1)
+		expect(result[0]).toBe(messages[2])
+	})
+
+	it("keeps the assistant message when only some blocks are stripped", () => {
+		const messages: OrchestratorMessages = [
+			makeAssistant([
+				{ type: "text", text: "keep me" },
+				{ type: "toolCall", id: "", name: "", arguments: {} },
+			]),
+		]
+		const result = stripEmptyToolCalls(messages)
+		expect(result).toHaveLength(1)
+		const content = (result[0] as AssistantMessage).content
+		expect(content).toHaveLength(1)
+		expect(content[0]).toEqual({ type: "text", text: "keep me" })
+	})
+
+	it("drops an assistant message that becomes empty after stripping", () => {
+		const messages: OrchestratorMessages = [
+			makeUser("q"),
+			makeAssistant([{ type: "toolCall", id: "", name: "", arguments: {} }]),
+			makeUser("q2"),
+		]
+		const result = stripEmptyToolCalls(messages)
+		expect(result).toHaveLength(2)
+		expect(result[0]).toBe(messages[0])
+		expect(result[1]).toBe(messages[2])
+	})
+
+	it("treats whitespace-only names as empty", () => {
+		const messages: OrchestratorMessages = [
+			makeAssistant([{ type: "toolCall", id: "ws-1", name: "   ", arguments: {} }]),
+		]
+		const result = stripEmptyToolCalls(messages)
+		expect(result).toHaveLength(0)
+	})
+
+	it("does not strip toolResults that pair with valid (non-empty) tool calls", () => {
+		const messages: OrchestratorMessages = [
+			makeAssistant([
+				{ type: "toolCall", id: "good-1", name: "bash", arguments: { command: "ls" } },
+				{ type: "toolCall", id: "empty-1", name: "", arguments: {} },
+			]),
+			makeToolResult("good-1", "output", false),
+			makeToolResult("empty-1"),
+		]
+		const result = stripEmptyToolCalls(messages)
+		// Assistant kept (with one block), good toolResult kept, empty toolResult dropped.
+		expect(result).toHaveLength(2)
+		const assistantContent = (result[0] as AssistantMessage).content
+		expect(assistantContent).toHaveLength(1)
+		expect((assistantContent[0] as { name: string }).name).toBe("bash")
+		expect((result[1] as ToolResultMessage).toolCallId).toBe("good-1")
+	})
+
+	it("handles multiple empty tool calls across multiple assistant turns", () => {
+		const messages: OrchestratorMessages = [
+			makeAssistant([
+				{ type: "text", text: "t1" },
+				{ type: "toolCall", id: "e1", name: "", arguments: {} },
+			]),
+			makeToolResult("e1"),
+			makeAssistant([
+				{ type: "text", text: "t2" },
+				{ type: "toolCall", id: "e2", name: "", arguments: {} },
+			]),
+			makeToolResult("e2"),
+		]
+		const result = stripEmptyToolCalls(messages)
+		// Two assistant turns kept (with text blocks), both toolResults dropped.
+		expect(result).toHaveLength(2)
+		for (const msg of result) {
+			expect((msg as AssistantMessage).role).toBe("assistant")
+			expect((msg as AssistantMessage).content).toHaveLength(1)
+		}
 	})
 })

--- a/src/extensions/orchestration/prompt-enrichment.ts
+++ b/src/extensions/orchestration/prompt-enrichment.ts
@@ -128,6 +128,78 @@ export class EnrichmentGuard {
 	}
 }
 
+/**
+ * Strip empty-name tool calls and their error results from the context.
+ *
+ * Some models (notably Kimi K2.x) emit tool calls with empty name/id fields.
+ * The runtime rejects these before the extension hook fires, producing
+ * "Tool  not found" error results that accumulate in the context window and
+ * waste tokens on every subsequent LLM call. This filter removes those
+ * dead-end pairs so they do not inflate the context.
+ */
+export function stripEmptyToolCalls(messages: OrchestratorMessages): OrchestratorMessages {
+	// Collect tool-call IDs that have empty names so we can remove their results.
+	const emptyCallIds = new Set<string>()
+	let changed = false
+
+	for (const msg of messages) {
+		if (msg.role === "assistant" && "content" in msg && Array.isArray(msg.content)) {
+			for (const block of msg.content) {
+				if (
+					typeof block === "object" &&
+					block !== null &&
+					"type" in block &&
+					(block as { type: string }).type === "toolCall" &&
+					"name" in block &&
+					!(block as { name: string }).name.trim()
+				) {
+					const id = (block as { id?: string }).id ?? ""
+					emptyCallIds.add(id)
+				}
+			}
+		}
+	}
+
+	if (emptyCallIds.size === 0) return messages
+
+	const filtered: OrchestratorMessages = []
+	for (const msg of messages) {
+		if (msg.role === "assistant" && "content" in msg && Array.isArray(msg.content)) {
+			const cleaned = msg.content.filter((block) => {
+				if (
+					typeof block === "object" &&
+					block !== null &&
+					"type" in block &&
+					(block as { type: string }).type === "toolCall" &&
+					"name" in block &&
+					!(block as { name: string }).name.trim()
+				) {
+					return false
+				}
+				return true
+			})
+			if (cleaned.length !== msg.content.length) {
+				changed = true
+				if (cleaned.length > 0) {
+					filtered.push({ ...msg, content: cleaned } as OrchestratorMessages[number])
+				}
+				continue
+			}
+		}
+		if (
+			msg.role === "toolResult" &&
+			"toolCallId" in msg &&
+			emptyCallIds.has((msg as { toolCallId: string }).toolCallId)
+		) {
+			changed = true
+			continue
+		}
+		filtered.push(msg)
+	}
+
+	return changed ? filtered : messages
+}
+
 export function deduplicateEnrichedPrompts(messages: OrchestratorMessages): OrchestratorMessages {
 	const lastIdx = messages.findLastIndex(
 		(m) =>
@@ -317,6 +389,17 @@ export default function (skillPaths: string[]) {
 			pi.on("context", async (event) => {
 				let messages = stripStaleNudges(event.messages)
 				messages = deduplicateEnrichedPrompts(messages)
+				messages = stripEmptyToolCalls(messages)
+				if (messages !== event.messages) return { messages }
+			})
+		} else {
+			// Subagents skip orchestrator-specific transforms but still benefit from
+			// stripping phantom empty-name tool calls. Some models (notably Kimi K2.x
+			// and MiniMax M2.7) emit empty tool calls after a real write/edit call,
+			// which the runtime rejects with a "Tool  not found" result that would
+			// otherwise accumulate in the subagent's context across turns.
+			pi.on("context", async (event) => {
+				const messages = stripEmptyToolCalls(event.messages)
 				if (messages !== event.messages) return { messages }
 			})
 		}

--- a/src/extensions/orchestration/prompt-enrichment.ts
+++ b/src/extensions/orchestration/prompt-enrichment.ts
@@ -129,6 +129,28 @@ export class EnrichmentGuard {
 }
 
 /**
+ * Shape of a tool-call content block as emitted in assistant messages.
+ * Defined narrowly here because the upstream `OrchestratorMessages` type does
+ * not export the per-block discriminated-union members we need to narrow on.
+ */
+type ToolCallBlock = { type: "toolCall"; name: string; id?: string }
+
+function isToolCallBlock(block: unknown): block is ToolCallBlock {
+	return (
+		typeof block === "object" &&
+		block !== null &&
+		"type" in block &&
+		(block as { type: unknown }).type === "toolCall" &&
+		"name" in block &&
+		typeof (block as { name: unknown }).name === "string"
+	)
+}
+
+function isEmptyToolCallBlock(block: unknown): block is ToolCallBlock {
+	return isToolCallBlock(block) && block.name.trim() === ""
+}
+
+/**
  * Strip empty-name tool calls and their error results from the context.
  *
  * Some models (notably Kimi K2.x) emit tool calls with empty name/id fields.
@@ -136,25 +158,19 @@ export class EnrichmentGuard {
  * "Tool  not found" error results that accumulate in the context window and
  * waste tokens on every subsequent LLM call. This filter removes those
  * dead-end pairs so they do not inflate the context.
+ *
+ * Returns the original `messages` reference unchanged when there is nothing
+ * to strip, so callers can use referential equality to detect a no-op.
  */
 export function stripEmptyToolCalls(messages: OrchestratorMessages): OrchestratorMessages {
 	// Collect tool-call IDs that have empty names so we can remove their results.
 	const emptyCallIds = new Set<string>()
-	let changed = false
 
 	for (const msg of messages) {
 		if (msg.role === "assistant" && "content" in msg && Array.isArray(msg.content)) {
 			for (const block of msg.content) {
-				if (
-					typeof block === "object" &&
-					block !== null &&
-					"type" in block &&
-					(block as { type: string }).type === "toolCall" &&
-					"name" in block &&
-					!(block as { name: string }).name.trim()
-				) {
-					const id = (block as { id?: string }).id ?? ""
-					emptyCallIds.add(id)
+				if (isEmptyToolCallBlock(block)) {
+					emptyCallIds.add(block.id ?? "")
 				}
 			}
 		}
@@ -162,22 +178,11 @@ export function stripEmptyToolCalls(messages: OrchestratorMessages): Orchestrato
 
 	if (emptyCallIds.size === 0) return messages
 
+	let changed = false
 	const filtered: OrchestratorMessages = []
 	for (const msg of messages) {
 		if (msg.role === "assistant" && "content" in msg && Array.isArray(msg.content)) {
-			const cleaned = msg.content.filter((block) => {
-				if (
-					typeof block === "object" &&
-					block !== null &&
-					"type" in block &&
-					(block as { type: string }).type === "toolCall" &&
-					"name" in block &&
-					!(block as { name: string }).name.trim()
-				) {
-					return false
-				}
-				return true
-			})
+			const cleaned = msg.content.filter((block) => !isEmptyToolCallBlock(block))
 			if (cleaned.length !== msg.content.length) {
 				changed = true
 				if (cleaned.length > 0) {

--- a/src/extensions/orchestration/prompt-transformer/prompts/orchestrator-system-prompt.ts
+++ b/src/extensions/orchestration/prompt-transformer/prompts/orchestrator-system-prompt.ts
@@ -32,10 +32,11 @@ Omit steps that add no value. A simple fix may need only \`build\`. A complex fe
 
 Look at **Your Capabilities** in the user message. Your strengths are the authoritative signal — not your confidence, not your general intelligence:
 
-- If a step matches your strengths, do it yourself.
+- If a step matches your strengths, **do it yourself**. This is non-negotiable — even if a model description in *Available Models* labels another model as the "specialist", "flagship", or "key model" for that step. The strengths list is the authoritative signal; marketing copy in model descriptions is not. In particular: if \`plan\` is in your strengths, you write the plan yourself; if \`explore\` is in your strengths, you read the codebase yourself. Delegating a step you already own to another model is a rule violation, not a defensible decision.
 - If a step does not match your strengths, delegate it to a model whose strengths fit — regardless of whether you think you could attempt it.
-- If your tier is \`heavy\`, delegate each step you don't own to a separate subagent. Write a plan first (spec file with interfaces and file paths) to the Documents directory, then delegate only \`build\` to a cheaper model — passing the spec file path. Never delegate an unplanned task in a single subagent call.
-- If your tier is \`standard\` or \`light\` and the task requires \`explore\`, \`research\`, or \`plan\` steps: you must delegate those steps. Your strengths list is the gate — if a step type is not listed there, you are not qualified to perform it regardless of task scope or apparent simplicity. Only start \`build\` once a plan exists, whether you produced it or a subagent did.
+- If your tier is \`heavy\`: for each step the task needs, apply the previous two rules. In practice that means **you write the plan yourself in-process** (heavy-tier orchestrators always list \`plan\` among their strengths), save the spec file (interfaces, file paths, method signatures) to the Documents directory, then delegate only the steps you do not own — typically \`build\` — to a cheaper subagent, passing the spec file path. Never delegate an unplanned task in a single subagent call, and never delegate planning when you own it.
+- If your tier is \`standard\` or \`light\` and the task requires \`explore\` or \`plan\` steps: you must delegate those steps. Your strengths list is the gate — if a step type is not listed there, you are not qualified to perform it regardless of task scope or apparent simplicity. Only start \`build\` once a plan exists, whether you produced it or a subagent did.
+- **Exception — simple research (overrides every rule above)**: If a task only needs a quick factual lookup (e.g. library comparisons, version numbers, API references, "top N libraries", a single fact), call \`web_search\` directly and answer from the results — do NOT delegate to a subagent, even if \`research\` is not in your strengths list. Every model in the pool can call \`web_search\` and read its results; for simple lookups this is strictly cheaper, faster, and more reliable than spawning a subagent. The strengths-based delegation rules above apply only when research requires deep analysis, reading multiple long documents, or synthesising information across many sources.
 
 The goal is to use the model best suited to each step, not the one already running.
 
@@ -64,22 +65,25 @@ The user message contains an "## Available Models" section. Use it to pick the r
 
 ## Token budgets
 
-Include a \`tokenBudget\` for every subagent call:
+Include a \`tokenBudget\` for every subagent call. Match the budget to the **subagent's task scope**, not the overall project complexity:
 
-- Simple, single-file tasks: 150,000 tokens
-- Standard multi-file implementation: 200,000 tokens
-- Complex multi-layer architecture or large codebase exploration: 500,000 tokens
-- Research or design tasks producing a design document: 200,000 tokens
+| Subagent task scope | tokenBudget |
+|---|---|
+| Single file (one module, one test file, one doc) | 150000 |
+| Multi-file implementation (2–5 files, one layer) | 200000 |
+| Full project or large codebase exploration | 500000 |
+| Plan or research document (writing, not coding) | 200000 |
 
 If a subagent hits its budget, spawn a follow-up with the remaining work rather than raising the budget.
 
 ## Inactivity timeout
 
-By default subagents are killed after 3 minutes of silence. For steps where a model may reason silently or perform extensive file I/O before producing output, set \`inactivityTimeoutMs\` explicitly:
+By default subagents are killed after 3 minutes of silence. Heavy-tier models (check the model's Tier attribute) often think silently before responding — always set \`inactivityTimeoutMs\` when delegating to them:
 
-- \`explore\` on a large codebase: 300000 (5 minutes)
-- \`plan\` or \`research\` delegated to a heavy model: 600000 (10 minutes)
-- \`build\` or \`review\`: omit (default is sufficient)`,
+| Subagent model tier | inactivityTimeoutMs |
+|---|---|
+| \`heavy\` | 600000 (10 minutes) |
+| \`standard\` or \`light\` | omit (default 3 minutes is sufficient) |`,
 	TOOLS_SECTION,
 	DOCUMENTS_SECTION,
 	RESEARCH_RULES,

--- a/src/extensions/orchestration/prompt-transformer/prompts/shared.ts
+++ b/src/extensions/orchestration/prompt-transformer/prompts/shared.ts
@@ -6,9 +6,11 @@ export const RESEARCH_RULES = `## Research Rules
 
 - Use \`web_search\` only during the \`research\` step — not during \`explore\`, \`plan\`, or \`build\`.
 - **Avoid web_fetch.** It returns raw website content that can flood your context window. Prefer \`web_search\` for most research. Use \`web_fetch\` only when the information is frequently updated and unlikely to be indexed (e.g. changelogs, latest release notes), or when the user's message contains an explicit URL. When you do use it, request markdown or text format and delegate to a subagent to keep the output out of the main context.
-- **Run at most one web_search per task.** Do NOT run a second search to verify or refine.`
+- **Run at most one web_search per task.** Do NOT run a second search to verify or refine.
+- **Skip research for well-known patterns.** Do not search the web for standard algorithms, common library APIs, or language features you already know. Only research when the task involves unfamiliar libraries, specific version constraints, or facts you genuinely do not know.`
 
 export const CORE_GUIDELINES = `- Be concise in your responses. Do not restate what you are about to do, repeat what you just did, or summarize completed steps — act and move on.
+- **Batch independent tool calls.** When you need to write or create multiple files, make all independent tool calls in the same response. Each turn adds to the context window, so fewer turns with more tool calls is strictly better than many single-call turns.
 - Show file paths clearly when working with files.
 - Read files before modifying them.
 - Prefer editing existing files over creating new ones.

--- a/src/extensions/subagent.ts
+++ b/src/extensions/subagent.ts
@@ -490,12 +490,19 @@ export function parseSubagentResponse(text: string): SubagentResponse | null {
 		if (fromFence !== null) return fromFence
 	}
 
+	// Walk backwards through candidate `{` positions, trying each as the
+	// start of the JSON object. This handles cases where the accumulated
+	// text contains brace patterns like Go route placeholders
+	// (e.g. `/tasks/{id}`) that precede the actual JSON response.
 	const lastClose = trimmed.lastIndexOf("}")
 	if (lastClose !== -1) {
-		const firstOpen = trimmed.lastIndexOf("{", lastClose)
-		if (firstOpen !== -1) {
-			const fromBlock = tryParse(trimmed.slice(firstOpen, lastClose + 1))
+		let searchFrom = lastClose
+		while (searchFrom >= 0) {
+			const openIdx = trimmed.lastIndexOf("{", searchFrom)
+			if (openIdx === -1) break
+			const fromBlock = tryParse(trimmed.slice(openIdx, lastClose + 1))
 			if (fromBlock !== null) return fromBlock
+			searchFrom = openIdx - 1
 		}
 	}
 


### PR DESCRIPTION
This PR collects targeted harness changes discovered by running the self-improvement loop (see companion PR #142 / `LLM-1498-self-improvement-loop`) against the benchmark suite. Only changes whose evidence crossed the loop's "≥2 models or ≥2 task types" bar are included.

## Goals

1. Reduce token consumption on `complex-single` tasks while keeping other task types unchanged.
2. Investigate empty/phantom tool calls — eliminate them, or reduce the context bloat they cause.
3. Reduce harness terminations / stuck-in-a-loop / stale state to 0%.

## Problems found and solutions

### 1. Phantom empty-name tool calls bloat subagent context

**Problem.** Multiple models (Kimi K2.5, MiniMax M2.7) emit an empty tool call (`{ name: "", id: "", arguments: {} }`) immediately after a successful `write` or `edit`. The runtime rejects it with a `Tool  not found` toolResult that accumulates across every subsequent turn.

**Solution (`prompt-enrichment.ts`).** Introduce `stripEmptyToolCalls(messages)` — removes empty-name `toolCall` blocks and their paired `toolResult`. Wired into both orchestrator and subagent context hooks.

### 2. `parseSubagentResponse` mis-locates JSON when the message body contains `{`

**Problem.** The parser walked back from the last `}` to the *last* `{` before it. When the assistant body contains brace tokens (e.g. Go route placeholders like `/tasks/{id}`), the parse picks the wrong slice and fails.

**Solution (`subagent.ts`).** Walk `{` candidates backwards from the last `}` and return the first slice that parses successfully.

### 3. Empty-turn nudge fails to recover stalled orchestrator turns

**Problem.** Some orchestrator turns produced no text and no tool calls. The previous `EmptyTurnNudge` only nudged when a tool-call-only turn was followed by an empty turn, missing empty first turns and text-only-then-empty patterns.

**Solution (`continuation-nudge.ts`).** Trigger on any empty turn (no text, no tool calls). Cap to once per user-input cycle to prevent infinite loops.

### 4. Orchestrator system prompt allows delegation drift

**Problem.** Heavy-tier orchestrators occasionally delegated planning to other models whose marketing copy claimed "planning specialist", despite owning `plan` in their strengths list. Also: spawning research subagents for trivial factual lookups.

**Solution (`orchestrator-system-prompt.ts`).** Tighten delegation rules: strengths list is authoritative, not model descriptions. Add "simple research" exception for `web_search`. Convert budget guidance to tables keyed by subagent tier.

### 5. Shared prompt rules drive avoidable token spend

**Problem.** `web_search` calls for well-known patterns the model already knew; chains of single-call turns where N independent writes each got their own turn.

**Solution (`shared.ts`).** Add "skip research for well-known patterns" and "batch independent tool calls" guidelines.

## Out of scope

- Root cause of phantom empty tool calls (upstream PI runtime streaming parser) — harness can only mitigate downstream.
- `complex-single` token regression looked like run-to-run variance; marked unconfirmed.

## Verification

- `pnpm run check` — PASS (lint + typecheck)
- `pnpm run test` — PASS (39 files, 727 tests)
- All changes scoped to `src/extensions/`

---
### Kimchi Summary
### What changed
Broadens the empty-turn nudge logic to trigger on any empty assistant response (not just after tool calls), adds filtering to strip phantom empty-name tool calls from context, updates orchestrator delegation and research rules, and fixes subagent JSON parsing to handle preceding brace patterns.

### Why
Models like Kimi K2.x occasionally emit empty responses or tool calls with empty name fields, causing agent stalls or accumulating invalid "Tool  not found" errors that waste context tokens. These changes improve robustness against such edge cases while clarifying orchestration rules to prevent unnecessary subagent delegation for simple tasks.

### Key changes
- **`src/extensions/orchestration/continuation-nudge.ts`**: Replaces `previousTurnWasToolCallOnly` logic with `nudgedSinceLastUserInput` flag so `EmptyTurnNudge` fires once per user-input cycle on any empty response (including first turn or after text-only turns).
- **`src/extensions/orchestration/prompt-enrichment.ts`**: Adds `stripEmptyToolCalls()` to remove tool calls with empty names and their paired error results from context; applied to both orchestrator and subagent pipelines to prevent token waste.
- **`src/extensions/orchestration/prompt-transformer/prompts/orchestrator-system-prompt.ts`**: Clarifies that model strengths (not marketing labels) govern delegation; adds exception for simple research tasks to use `web_search` directly; updates token budget and inactivity timeout guidance by model tier.
- **`src/extensions/orchestration/prompt-transformer/prompts/shared.ts`**: Adds guidelines to batch independent tool calls and skip web search for well-known patterns.
- **`src/extensions/subagent.ts`**: Fixes `parseSubagentResponse` to walk backwards through candidate `{` positions, correctly extracting JSON when responses contain preceding brace patterns (e.g., Go route placeholders like `/tasks/{id}`).

### Impact
- **Behavioral change**: `EmptyTurnNudge` now fires in more scenarios (initial turn, post-text) but is limited to once per user input cycle to prevent infinite loops.
- **Context filtering**: Empty-name tool calls and orphaned error results are automatically stripped; callers can detect no-op via referential equality check.
- **Orchestration**: Heavy-tier models must write plans in-process rather than delegating; simple factual lookups should use `web_search` directly instead of spawning subagents.