### PR TITLE
LLM-1524: Use cheaper available model for permissions classifier

### DIFF
--- a/src/extensions/orchestration/model-registry/index.ts
+++ b/src/extensions/orchestration/model-registry/index.ts
@@ -1,4 +1,4 @@
-export { ModelRegistry } from "./model-registry.js"
+export { KIMCHI_DEV_PROVIDER, ModelRegistry } from "./model-registry.js"
 export { MODEL_CAPABILITIES } from "./builtin-models.js"
 export type { ModelRegistryWarning } from "./model-registry.js"
 export type { ModelStrength, ModelTier, ModelCapabilities, OrchestrationModelDescriptor } from "./types.js"

--- a/src/extensions/orchestration/model-registry/model-registry.ts
+++ b/src/extensions/orchestration/model-registry/model-registry.ts
@@ -24,7 +24,7 @@ import type { ModelMetadata } from "../../../models.js"
 import { MODEL_CAPABILITIES } from "./builtin-models.js"
 import type { ModelCapabilities, OrchestrationModelDescriptor } from "./types.js"
 
-const PROVIDER = "kimchi-dev"
+export const KIMCHI_DEV_PROVIDER = "kimchi-dev"
 
 const GENERIC_CAPABILITIES: ModelCapabilities = {
 	vision: false,
@@ -65,14 +65,14 @@ export class ModelRegistry {
 				warnings.push({ kind: "unknown_model", modelId: m.slug })
 				allModels.push({
 					id: m.slug,
-					provider: PROVIDER,
+					provider: KIMCHI_DEV_PROVIDER,
 					name: deriveName(m),
 					capabilities: GENERIC_CAPABILITIES,
 				})
 			} else {
 				allModels.push({
 					id: m.slug,
-					provider: PROVIDER,
+					provider: KIMCHI_DEV_PROVIDER,
 					name: deriveName(m),
 					capabilities: entry,
 				})

--- a/src/extensions/orchestration/prompt-transformer/prompts/orchestrator-system-prompt.ts
+++ b/src/extensions/orchestration/prompt-transformer/prompts/orchestrator-system-prompt.ts
@@ -61,6 +61,7 @@ The user message contains an "## Available Models" section. Use it to pick the r
 - Match the model's **tier** to the complexity: light for simple well-scoped work, heavy for ambiguous or multi-step work.
 - If the subtask involves images or visual content, you MUST select a model with \`Vision: yes\`.
 - Prefer cheaper models for mechanical work once the design is settled.
+- **Tool call classification** (permission checks in auto mode) automatically uses the cheapest available model. Do not override this — it is handled by the runtime and should not influence your model selection for user-facing tasks.
 
 ## Token budgets
 

--- a/src/extensions/permissions/classifier-model.test.ts
+++ b/src/extensions/permissions/classifier-model.test.ts
@@ -5,13 +5,17 @@ import { KIMCHI_DEV_PROVIDER, MODEL_CAPABILITIES } from "../orchestration/model-
 import { resolveClassifierModel } from "./classifier-model.js"
 
 /** Minimal Model stub — only the fields resolveClassifierModel inspects. */
-function fakeModel(provider: string, id = "test-model"): Model<Api> {
-	return { provider, id } as Model<Api>
+function fakeModel(
+	provider: string,
+	id = "test-model",
+	cost = { input: 10, output: 30, cacheRead: 0, cacheWrite: 0 },
+): Model<Api> {
+	return { provider, id, cost } as Model<Api>
 }
 
-/** Minimal ModelRegistry stub with a controllable find(). */
-function fakeRegistry(findResult: Model<Api> | undefined = undefined): ModelRegistry {
-	return { find: () => findResult } as unknown as ModelRegistry
+/** Minimal ModelRegistry stub with controllable find() and getAvailable(). */
+function fakeRegistry(findResult: Model<Api> | undefined = undefined, available: Model<Api>[] = []): ModelRegistry {
+	return { find: () => findResult, getAvailable: () => available } as unknown as ModelRegistry
 }
 
 /** The first light-tier model ID in MODEL_CAPABILITIES. */
@@ -24,60 +28,131 @@ describe("resolveClassifierModel", () => {
 		expect(resolveClassifierModel(undefined, fakeRegistry())).toBeUndefined()
 	})
 
-	it("returns the current model for a non-kimchi-dev provider", () => {
-		const model = fakeModel("anthropic", "claude-sonnet")
-		const result = resolveClassifierModel(model, fakeRegistry())
-		expect(result).toBe(model)
+	describe("non-kimchi-dev provider", () => {
+		it("steps down two cost tiers when three cheaper models exist", () => {
+			const opus = fakeModel("anthropic", "claude-opus", { input: 15, output: 75, cacheRead: 0, cacheWrite: 0 })
+			const sonnet = fakeModel("anthropic", "claude-sonnet", { input: 3, output: 15, cacheRead: 0, cacheWrite: 0 })
+			const haiku = fakeModel("anthropic", "claude-haiku", { input: 0.25, output: 1.25, cacheRead: 0, cacheWrite: 0 })
+			const nano = fakeModel("anthropic", "claude-nano", { input: 0.1, output: 0.4, cacheRead: 0, cacheWrite: 0 })
+
+			const registry = fakeRegistry(undefined, [opus, sonnet, haiku, nano])
+			const result = resolveClassifierModel(opus, registry)
+			// Two steps down from opus: sonnet → haiku.
+			expect(result).toBe(haiku)
+		})
+
+		it("steps down one tier when only one cheaper model exists", () => {
+			const current = fakeModel("openai", "gpt-4o", { input: 5, output: 15, cacheRead: 0, cacheWrite: 0 })
+			const mini = fakeModel("openai", "gpt-4o-mini", { input: 0.15, output: 0.6, cacheRead: 0, cacheWrite: 0 })
+
+			const registry = fakeRegistry(undefined, [current, mini])
+			const result = resolveClassifierModel(current, registry)
+			expect(result).toBe(mini)
+		})
+
+		it("steps down exactly two when only two cheaper models exist", () => {
+			const opus = fakeModel("anthropic", "claude-opus", { input: 15, output: 75, cacheRead: 0, cacheWrite: 0 })
+			const sonnet = fakeModel("anthropic", "claude-sonnet", { input: 3, output: 15, cacheRead: 0, cacheWrite: 0 })
+			const haiku = fakeModel("anthropic", "claude-haiku", { input: 0.25, output: 1.25, cacheRead: 0, cacheWrite: 0 })
+
+			const registry = fakeRegistry(undefined, [opus, sonnet, haiku])
+			const result = resolveClassifierModel(opus, registry)
+			expect(result).toBe(haiku)
+		})
+
+		it("ignores models from other providers", () => {
+			const current = fakeModel("openai", "gpt-4o", { input: 5, output: 15, cacheRead: 0, cacheWrite: 0 })
+			const cheapOther = fakeModel("anthropic", "claude-haiku", {
+				input: 0.25,
+				output: 1.25,
+				cacheRead: 0,
+				cacheWrite: 0,
+			})
+			const sameProvider = fakeModel("openai", "gpt-4o-mini", { input: 0.15, output: 0.6, cacheRead: 0, cacheWrite: 0 })
+
+			const registry = fakeRegistry(undefined, [current, cheapOther, sameProvider])
+			const result = resolveClassifierModel(current, registry)
+			expect(result).toBe(sameProvider)
+		})
+
+		it("falls back to current model when no models from the same provider are available", () => {
+			const current = fakeModel("openai", "gpt-4o")
+			const registry = fakeRegistry(undefined, [])
+
+			const result = resolveClassifierModel(current, registry)
+			expect(result).toBe(current)
+		})
+
+		it("returns current model when it is already the cheapest", () => {
+			const current = fakeModel("openai", "gpt-4o-mini", { input: 0.15, output: 0.6, cacheRead: 0, cacheWrite: 0 })
+			const expensive = fakeModel("openai", "gpt-4o", { input: 5, output: 15, cacheRead: 0, cacheWrite: 0 })
+
+			const registry = fakeRegistry(undefined, [current, expensive])
+			const result = resolveClassifierModel(current, registry)
+			expect(result).toBe(current)
+		})
+
+		it("returns current model when all same-provider models cost the same", () => {
+			const current = fakeModel("openai", "gpt-4o", { input: 5, output: 15, cacheRead: 0, cacheWrite: 0 })
+			const twin = fakeModel("openai", "gpt-4o-copy", { input: 5, output: 15, cacheRead: 0, cacheWrite: 0 })
+
+			const registry = fakeRegistry(undefined, [current, twin])
+			const result = resolveClassifierModel(current, registry)
+			expect(result).toBe(current)
+		})
+
+		it("does not call registry.find for a non-kimchi-dev provider", () => {
+			const calls: string[] = []
+			const model = fakeModel("openai", "gpt-4o")
+			const registry = {
+				find: (_provider: string, id: string) => {
+					calls.push(id)
+					return undefined
+				},
+				getAvailable: () => [model],
+			} as unknown as ModelRegistry
+
+			resolveClassifierModel(model, registry)
+			expect(calls).toHaveLength(0)
+		})
 	})
 
-	it("returns a light-tier model from the registry for kimchi-dev provider", () => {
-		const lightModel = fakeModel(KIMCHI_DEV_PROVIDER, LIGHT_MODEL_ID)
-		const current = fakeModel(KIMCHI_DEV_PROVIDER, "kimi-k2.6")
-		const registry = fakeRegistry(lightModel)
+	describe("kimchi-dev provider", () => {
+		it("returns a light-tier model from the registry", () => {
+			const lightModel = fakeModel(KIMCHI_DEV_PROVIDER, LIGHT_MODEL_ID)
+			const current = fakeModel(KIMCHI_DEV_PROVIDER, "kimi-k2.6")
+			const registry = fakeRegistry(lightModel)
 
-		const result = resolveClassifierModel(current, registry)
-		expect(result).toBe(lightModel)
-		expect(result?.id).toBe(LIGHT_MODEL_ID)
-	})
+			const result = resolveClassifierModel(current, registry)
+			expect(result).toBe(lightModel)
+			expect(result?.id).toBe(LIGHT_MODEL_ID)
+		})
 
-	it("falls back to current model when registry.find returns undefined for kimchi-dev", () => {
-		const current = fakeModel(KIMCHI_DEV_PROVIDER, "kimi-k2.6")
-		const registry = fakeRegistry(undefined)
+		it("falls back to current model when registry.find returns undefined", () => {
+			const current = fakeModel(KIMCHI_DEV_PROVIDER, "kimi-k2.6")
+			const registry = fakeRegistry(undefined)
 
-		const result = resolveClassifierModel(current, registry)
-		expect(result).toBe(current)
-	})
+			const result = resolveClassifierModel(current, registry)
+			expect(result).toBe(current)
+		})
 
-	it("calls registry.find with kimchi-dev provider and a light-tier model ID", () => {
-		const calls: Array<{ provider: string; id: string }> = []
-		const registry = {
-			find: (provider: string, id: string) => {
-				calls.push({ provider, id })
-				return undefined
-			},
-		} as unknown as ModelRegistry
+		it("calls registry.find with kimchi-dev provider and a light-tier model ID", () => {
+			const calls: Array<{ provider: string; id: string }> = []
+			const registry = {
+				find: (provider: string, id: string) => {
+					calls.push({ provider, id })
+					return undefined
+				},
+				getAvailable: () => [],
+			} as unknown as ModelRegistry
 
-		const current = fakeModel(KIMCHI_DEV_PROVIDER, "kimi-k2.6")
-		resolveClassifierModel(current, registry)
+			const current = fakeModel(KIMCHI_DEV_PROVIDER, "kimi-k2.6")
+			resolveClassifierModel(current, registry)
 
-		// Should have searched for at least one light-tier model.
-		expect(calls.length).toBeGreaterThan(0)
-		expect(calls.every((c) => c.provider === KIMCHI_DEV_PROVIDER)).toBe(true)
-		expect(calls.some((c) => c.id === LIGHT_MODEL_ID)).toBe(true)
-	})
-
-	it("does not call registry.find for a non-kimchi-dev provider", () => {
-		const calls: string[] = []
-		const registry = {
-			find: (_provider: string, id: string) => {
-				calls.push(id)
-				return undefined
-			},
-		} as unknown as ModelRegistry
-
-		const model = fakeModel("openai", "gpt-4o")
-		resolveClassifierModel(model, registry)
-
-		expect(calls).toHaveLength(0)
+			// Should have searched for at least one light-tier model.
+			expect(calls.length).toBeGreaterThan(0)
+			expect(calls.every((c) => c.provider === KIMCHI_DEV_PROVIDER)).toBe(true)
+			expect(calls.some((c) => c.id === LIGHT_MODEL_ID)).toBe(true)
+		})
 	})
 })

--- a/src/extensions/permissions/classifier-model.test.ts
+++ b/src/extensions/permissions/classifier-model.test.ts
@@ -1,0 +1,83 @@
+import type { Api, Model } from "@mariozechner/pi-ai"
+import type { ModelRegistry } from "@mariozechner/pi-coding-agent"
+import { describe, expect, it } from "vitest"
+import { KIMCHI_DEV_PROVIDER, MODEL_CAPABILITIES } from "../orchestration/model-registry/index.js"
+import { resolveClassifierModel } from "./classifier-model.js"
+
+/** Minimal Model stub — only the fields resolveClassifierModel inspects. */
+function fakeModel(provider: string, id = "test-model"): Model<Api> {
+	return { provider, id } as Model<Api>
+}
+
+/** Minimal ModelRegistry stub with a controllable find(). */
+function fakeRegistry(findResult: Model<Api> | undefined = undefined): ModelRegistry {
+	return { find: () => findResult } as unknown as ModelRegistry
+}
+
+/** The first light-tier model ID in MODEL_CAPABILITIES. */
+const LIGHT_MODEL_ID = [...MODEL_CAPABILITIES.entries()].find(
+	([, caps]) => caps !== "ignored" && caps.tier === "light",
+)?.[0]
+
+describe("resolveClassifierModel", () => {
+	it("returns undefined when currentModel is undefined", () => {
+		expect(resolveClassifierModel(undefined, fakeRegistry())).toBeUndefined()
+	})
+
+	it("returns the current model for a non-kimchi-dev provider", () => {
+		const model = fakeModel("anthropic", "claude-sonnet")
+		const result = resolveClassifierModel(model, fakeRegistry())
+		expect(result).toBe(model)
+	})
+
+	it("returns a light-tier model from the registry for kimchi-dev provider", () => {
+		const lightModel = fakeModel(KIMCHI_DEV_PROVIDER, LIGHT_MODEL_ID)
+		const current = fakeModel(KIMCHI_DEV_PROVIDER, "kimi-k2.6")
+		const registry = fakeRegistry(lightModel)
+
+		const result = resolveClassifierModel(current, registry)
+		expect(result).toBe(lightModel)
+		expect(result?.id).toBe(LIGHT_MODEL_ID)
+	})
+
+	it("falls back to current model when registry.find returns undefined for kimchi-dev", () => {
+		const current = fakeModel(KIMCHI_DEV_PROVIDER, "kimi-k2.6")
+		const registry = fakeRegistry(undefined)
+
+		const result = resolveClassifierModel(current, registry)
+		expect(result).toBe(current)
+	})
+
+	it("calls registry.find with kimchi-dev provider and a light-tier model ID", () => {
+		const calls: Array<{ provider: string; id: string }> = []
+		const registry = {
+			find: (provider: string, id: string) => {
+				calls.push({ provider, id })
+				return undefined
+			},
+		} as unknown as ModelRegistry
+
+		const current = fakeModel(KIMCHI_DEV_PROVIDER, "kimi-k2.6")
+		resolveClassifierModel(current, registry)
+
+		// Should have searched for at least one light-tier model.
+		expect(calls.length).toBeGreaterThan(0)
+		expect(calls.every((c) => c.provider === KIMCHI_DEV_PROVIDER)).toBe(true)
+		expect(calls.some((c) => c.id === LIGHT_MODEL_ID)).toBe(true)
+	})
+
+	it("does not call registry.find for a non-kimchi-dev provider", () => {
+		const calls: string[] = []
+		const registry = {
+			find: (_provider: string, id: string) => {
+				calls.push(id)
+				return undefined
+			},
+		} as unknown as ModelRegistry
+
+		const model = fakeModel("openai", "gpt-4o")
+		resolveClassifierModel(model, registry)
+
+		expect(calls).toHaveLength(0)
+	})
+})

--- a/src/extensions/permissions/classifier-model.test.ts
+++ b/src/extensions/permissions/classifier-model.test.ts
@@ -75,28 +75,38 @@ describe("resolveClassifierModel", () => {
 			expect(result).toBe(sameProvider)
 		})
 
-		it("falls back to current model when no models from the same provider are available", () => {
-			const current = fakeModel("openai", "gpt-4o")
-			const registry = fakeRegistry(undefined, [])
-
-			const result = resolveClassifierModel(current, registry)
-			expect(result).toBe(current)
-		})
-
-		it("returns current model when it is already the cheapest", () => {
+		it("picks the least expensive more-expensive model when current is already the cheapest", () => {
 			const current = fakeModel("openai", "gpt-4o-mini", { input: 0.15, output: 0.6, cacheRead: 0, cacheWrite: 0 })
-			const expensive = fakeModel("openai", "gpt-4o", { input: 5, output: 15, cacheRead: 0, cacheWrite: 0 })
+			const mid = fakeModel("openai", "gpt-4o", { input: 5, output: 15, cacheRead: 0, cacheWrite: 0 })
+			const expensive = fakeModel("openai", "o3", { input: 10, output: 40, cacheRead: 0, cacheWrite: 0 })
 
-			const registry = fakeRegistry(undefined, [current, expensive])
+			const registry = fakeRegistry(undefined, [current, mid, expensive])
 			const result = resolveClassifierModel(current, registry)
-			expect(result).toBe(current)
+			// Should pick gpt-4o (least expensive among more-expensive), not o3.
+			expect(result).toBe(mid)
 		})
 
-		it("returns current model when all same-provider models cost the same", () => {
+		it("picks a different model even when all same-provider models cost the same", () => {
 			const current = fakeModel("openai", "gpt-4o", { input: 5, output: 15, cacheRead: 0, cacheWrite: 0 })
 			const twin = fakeModel("openai", "gpt-4o-copy", { input: 5, output: 15, cacheRead: 0, cacheWrite: 0 })
 
 			const registry = fakeRegistry(undefined, [current, twin])
+			const result = resolveClassifierModel(current, registry)
+			expect(result).toBe(twin)
+		})
+
+		it("falls back to current model only when it is the sole model in the provider", () => {
+			const current = fakeModel("openai", "gpt-4o")
+			const registry = fakeRegistry(undefined, [current])
+
+			const result = resolveClassifierModel(current, registry)
+			expect(result).toBe(current)
+		})
+
+		it("falls back to current model when no models from the same provider are available", () => {
+			const current = fakeModel("openai", "gpt-4o")
+			const registry = fakeRegistry(undefined, [])
+
 			const result = resolveClassifierModel(current, registry)
 			expect(result).toBe(current)
 		})
@@ -118,7 +128,7 @@ describe("resolveClassifierModel", () => {
 	})
 
 	describe("kimchi-dev provider", () => {
-		it("returns a light-tier model from the registry", () => {
+		it("returns a light-tier model from the registry when current is not light", () => {
 			const lightModel = fakeModel(KIMCHI_DEV_PROVIDER, LIGHT_MODEL_ID)
 			const current = fakeModel(KIMCHI_DEV_PROVIDER, "kimi-k2.6")
 			const registry = fakeRegistry(lightModel)
@@ -128,7 +138,76 @@ describe("resolveClassifierModel", () => {
 			expect(result?.id).toBe(LIGHT_MODEL_ID)
 		})
 
-		it("falls back to current model when registry.find returns undefined", () => {
+		it("returns a different light-tier model when current is already light-tier", () => {
+			const current = fakeModel(KIMCHI_DEV_PROVIDER, LIGHT_MODEL_ID)
+			const otherLight = fakeModel(KIMCHI_DEV_PROVIDER, "other-light")
+
+			// Registry returns otherLight for the light-tier ID lookup
+			// We need a registry that returns different models for different IDs.
+			const lightIds = [...MODEL_CAPABILITIES.entries()]
+				.filter(([, caps]) => caps !== "ignored" && caps.tier === "light")
+				.map(([id]) => id)
+
+			// If there's only one light-tier in capabilities, we need to test
+			// the "step up to next tier" path instead.
+			if (lightIds.length <= 1) {
+				// Current is the sole light-tier model. Registry should find a
+				// standard-tier model as fallback.
+				const standardId = [...MODEL_CAPABILITIES.entries()].find(
+					([, caps]) => caps !== "ignored" && caps.tier === "standard",
+				)?.[0]
+
+				const standardModel = fakeModel(KIMCHI_DEV_PROVIDER, standardId ?? "standard-fallback")
+				const registry = {
+					find: (_p: string, id: string) => {
+						if (id === LIGHT_MODEL_ID) return current
+						if (standardId && id === standardId) return standardModel
+						return undefined
+					},
+					getAvailable: () => [],
+				} as unknown as ModelRegistry
+
+				const result = resolveClassifierModel(current, registry)
+				expect(result).not.toBe(current)
+				expect(result?.id).toBe(standardModel.id)
+			} else {
+				// Multiple light-tier models exist — should pick the other one.
+				const otherId = lightIds.find((id) => id !== LIGHT_MODEL_ID)
+				const registry = {
+					find: (_p: string, id: string) => {
+						if (id === LIGHT_MODEL_ID) return current
+						if (otherId && id === otherId) return otherLight
+						return undefined
+					},
+					getAvailable: () => [],
+				} as unknown as ModelRegistry
+
+				const result = resolveClassifierModel(current, registry)
+				expect(result).not.toBe(current)
+			}
+		})
+
+		it("steps up to next tier when current is the sole light-tier model", () => {
+			const current = fakeModel(KIMCHI_DEV_PROVIDER, LIGHT_MODEL_ID)
+			const standardId = [...MODEL_CAPABILITIES.entries()].find(
+				([, caps]) => caps !== "ignored" && caps.tier === "standard",
+			)?.[0]
+
+			const standardModel = fakeModel(KIMCHI_DEV_PROVIDER, standardId ?? "standard-fallback")
+			const registry = {
+				find: (_p: string, id: string) => {
+					if (id === LIGHT_MODEL_ID) return current
+					if (standardId && id === standardId) return standardModel
+					return undefined
+				},
+				getAvailable: () => [],
+			} as unknown as ModelRegistry
+
+			const result = resolveClassifierModel(current, registry)
+			expect(result).not.toBe(current)
+		})
+
+		it("falls back to current model only when no other models are available", () => {
 			const current = fakeModel(KIMCHI_DEV_PROVIDER, "kimi-k2.6")
 			const registry = fakeRegistry(undefined)
 

--- a/src/extensions/permissions/classifier-model.ts
+++ b/src/extensions/permissions/classifier-model.ts
@@ -3,14 +3,24 @@ import type { ModelRegistry } from "@mariozechner/pi-coding-agent"
 import { KIMCHI_DEV_PROVIDER, MODEL_CAPABILITIES } from "../orchestration/model-registry/index.js"
 
 /**
+ * Compute a single scalar cost for a model so we can compare cheapness.
+ * Uses the sum of input and output per-token costs.
+ */
+function modelCost(model: Model<Api>): number {
+	return (model.cost?.input ?? 0) + (model.cost?.output ?? 0)
+}
+
+/**
  * Pick the model to use for the classifier.
  *
  * Strategy:
  *   - kimchi-dev provider: select the lightest-tier model from the
  *     orchestration model registry (MODEL_CAPABILITIES) so classification
  *     runs on the cheapest purpose-built model.
- *   - Any other provider: reuse the current model so users running their
- *     own keys don't need kimchi-dev models configured.
+ *   - Any other provider: step down up to two cost tiers within the same
+ *     provider. This saves tokens on classification while still picking a
+ *     model capable enough for the task. Falls back to the current model
+ *     when no cheaper alternative exists.
  */
 export function resolveClassifierModel(
 	currentModel: Model<Api> | undefined,
@@ -18,7 +28,9 @@ export function resolveClassifierModel(
 ): Model<Api> | undefined {
 	if (!currentModel) return undefined
 
-	if (currentModel.provider !== KIMCHI_DEV_PROVIDER) return currentModel
+	if (currentModel.provider !== KIMCHI_DEV_PROVIDER) {
+		return cheaperFromSameProvider(currentModel, modelRegistry)
+	}
 
 	// Find a light-tier model from the orchestration capability map.
 	for (const [id, caps] of MODEL_CAPABILITIES) {
@@ -31,4 +43,30 @@ export function resolveClassifierModel(
 
 	// No light-tier model available — fall back to current model.
 	return currentModel
+}
+
+/**
+ * Among all available models from the same provider, step down up to two
+ * cost tiers from `currentModel`.
+ *
+ * Sorts same-provider models by descending cost, finds the current model's
+ * position, then returns the model two ranks below it (or the cheapest
+ * available if fewer than two cheaper models exist).
+ *
+ * Falls back to `currentModel` when no cheaper alternative is found.
+ */
+function cheaperFromSameProvider(currentModel: Model<Api>, modelRegistry: ModelRegistry): Model<Api> {
+	const currentCost = modelCost(currentModel)
+
+	// Collect same-provider models that are strictly cheaper, sorted descending by cost.
+	const cheaper = modelRegistry
+		.getAvailable()
+		.filter((m) => m.provider === currentModel.provider && modelCost(m) < currentCost)
+		.sort((a, b) => modelCost(b) - modelCost(a))
+
+	if (cheaper.length === 0) return currentModel
+
+	// Step down up to 2 tiers: index 0 = one step, index 1 = two steps.
+	const stepsDown = Math.min(1, cheaper.length - 1)
+	return cheaper[stepsDown]
 }

--- a/src/extensions/permissions/classifier-model.ts
+++ b/src/extensions/permissions/classifier-model.ts
@@ -1,6 +1,10 @@
 import type { Api, Model } from "@mariozechner/pi-ai"
 import type { ModelRegistry } from "@mariozechner/pi-coding-agent"
 import { KIMCHI_DEV_PROVIDER, MODEL_CAPABILITIES } from "../orchestration/model-registry/index.js"
+import type { ModelTier } from "../orchestration/model-registry/types.js"
+
+/** Tier ordering from cheapest to most expensive. */
+const TIER_RANK: Record<ModelTier, number> = { light: 0, standard: 1, heavy: 2 }
 
 /**
  * Compute a single scalar cost for a model so we can compare cheapness.
@@ -13,14 +17,21 @@ function modelCost(model: Model<Api>): number {
 /**
  * Pick the model to use for the classifier.
  *
+ * The goal is to always use a *different* model than the current one to
+ * avoid wasting expensive tokens on a simple classification task. The
+ * current model is only returned as a last resort when no other model
+ * from the same provider is available.
+ *
  * Strategy:
  *   - kimchi-dev provider: select the lightest-tier model from the
- *     orchestration model registry (MODEL_CAPABILITIES) so classification
- *     runs on the cheapest purpose-built model.
+ *     orchestration model registry (MODEL_CAPABILITIES). If the current
+ *     model is already light-tier, try another light-tier model first,
+ *     then step up to the next tier. Falls back to the current model
+ *     only when it is the sole available model.
  *   - Any other provider: step down up to two cost tiers within the same
- *     provider. This saves tokens on classification while still picking a
- *     model capable enough for the task. Falls back to the current model
- *     when no cheaper alternative exists.
+ *     provider. If the current model is already the cheapest, pick the
+ *     least expensive model that costs more. Falls back to the current
+ *     model only when it is the sole available model.
  */
 export function resolveClassifierModel(
 	currentModel: Model<Api> | undefined,
@@ -32,41 +43,108 @@ export function resolveClassifierModel(
 		return cheaperFromSameProvider(currentModel, modelRegistry)
 	}
 
-	// Find a light-tier model from the orchestration capability map.
+	return resolveKimchiDevClassifier(currentModel, modelRegistry)
+}
+
+/**
+ * Resolve a classifier model for the kimchi-dev provider.
+ *
+ * Preference order:
+ *   1. A light-tier model that is NOT the current model.
+ *   2. Any other light-tier model (even the current one — covered by step 1 only
+ *      when there are multiple lights).
+ *   3. The next tier up (standard, then heavy) — any model other than current.
+ *   4. The current model as an absolute fallback.
+ */
+function resolveKimchiDevClassifier(currentModel: Model<Api>, modelRegistry: ModelRegistry): Model<Api> {
+	const currentCaps = MODEL_CAPABILITIES.get(currentModel.id)
+	const currentTier = currentCaps !== undefined && currentCaps !== "ignored" ? currentCaps.tier : undefined
+
+	// 1. Try light-tier models, preferring one that is NOT the current model.
+	const lightModels: Model<Api>[] = []
 	for (const [id, caps] of MODEL_CAPABILITIES) {
 		if (caps === "ignored") continue
 		if (caps.tier === "light") {
 			const resolved = modelRegistry.find(KIMCHI_DEV_PROVIDER, id)
-			if (resolved) return resolved
+			if (resolved) lightModels.push(resolved)
 		}
 	}
 
-	// No light-tier model available — fall back to current model.
+	const differentLight = lightModels.find((m) => m.id !== currentModel.id)
+	if (differentLight) return differentLight
+
+	// Current model is the only light-tier model — if current is already
+	// light-tier, try the next tier up instead.
+	if (currentTier === "light") {
+		const nextUp = findNextTierUp(currentModel, modelRegistry, "light")
+		if (nextUp) return nextUp
+	}
+
+	// Return the single light-tier model if one exists (even if it is current).
+	if (lightModels.length > 0) return lightModels[0]
+
+	// No light-tier available at all — fall back to current.
 	return currentModel
+}
+
+/**
+ * Find the lowest-cost model at the next tier above `belowTier` that is
+ * not the current model.
+ *
+ * Tier ordering: light < standard < heavy.
+ */
+function findNextTierUp(
+	currentModel: Model<Api>,
+	modelRegistry: ModelRegistry,
+	belowTier: ModelTier,
+): Model<Api> | undefined {
+	const tiersAscending: ModelTier[] = ["light", "standard", "heavy"]
+	const startRank = TIER_RANK[belowTier] + 1
+
+	for (const tier of tiersAscending) {
+		if (TIER_RANK[tier] < startRank) continue
+		for (const [id, caps] of MODEL_CAPABILITIES) {
+			if (caps === "ignored") continue
+			if (caps.tier === tier && id !== currentModel.id) {
+				const resolved = modelRegistry.find(KIMCHI_DEV_PROVIDER, id)
+				if (resolved) return resolved
+			}
+		}
+	}
+
+	return undefined
 }
 
 /**
  * Among all available models from the same provider, step down up to two
  * cost tiers from `currentModel`.
  *
- * Sorts same-provider models by descending cost, finds the current model's
- * position, then returns the model two ranks below it (or the cheapest
- * available if fewer than two cheaper models exist).
- *
- * Falls back to `currentModel` when no cheaper alternative is found.
+ * If no cheaper model exists, pick the least more expensive model to
+ * still avoid reusing the current model. Falls back to the current model
+ * only when it is the sole available model from that provider.
  */
 function cheaperFromSameProvider(currentModel: Model<Api>, modelRegistry: ModelRegistry): Model<Api> {
 	const currentCost = modelCost(currentModel)
 
-	// Collect same-provider models that are strictly cheaper, sorted descending by cost.
-	const cheaper = modelRegistry
-		.getAvailable()
-		.filter((m) => m.provider === currentModel.provider && modelCost(m) < currentCost)
-		.sort((a, b) => modelCost(b) - modelCost(a))
+	const sameProvider = modelRegistry.getAvailable().filter((m) => m.provider === currentModel.provider)
 
-	if (cheaper.length === 0) return currentModel
+	// Collect models that are strictly cheaper, sorted descending by cost.
+	const cheaper = sameProvider.filter((m) => modelCost(m) < currentCost).sort((a, b) => modelCost(b) - modelCost(a))
 
-	// Step down up to 2 tiers: index 0 = one step, index 1 = two steps.
-	const stepsDown = Math.min(1, cheaper.length - 1)
-	return cheaper[stepsDown]
+	if (cheaper.length > 0) {
+		// Step down up to 2 tiers: index 0 = one step, index 1 = two steps.
+		const stepsDown = Math.min(1, cheaper.length - 1)
+		return cheaper[stepsDown]
+	}
+
+	// No cheaper model — pick the least more expensive alternative to avoid
+	// reusing the current model.
+	const moreExpensive = sameProvider
+		.filter((m) => m.id !== currentModel.id && modelCost(m) >= currentCost)
+		.sort((a, b) => modelCost(a) - modelCost(b))
+
+	if (moreExpensive.length > 0) return moreExpensive[0]
+
+	// Sole model in the provider — no choice.
+	return currentModel
 }

--- a/src/extensions/permissions/classifier-model.ts
+++ b/src/extensions/permissions/classifier-model.ts
@@ -1,0 +1,34 @@
+import type { Api, Model } from "@mariozechner/pi-ai"
+import type { ModelRegistry } from "@mariozechner/pi-coding-agent"
+import { KIMCHI_DEV_PROVIDER, MODEL_CAPABILITIES } from "../orchestration/model-registry/index.js"
+
+/**
+ * Pick the model to use for the classifier.
+ *
+ * Strategy:
+ *   - kimchi-dev provider: select the lightest-tier model from the
+ *     orchestration model registry (MODEL_CAPABILITIES) so classification
+ *     runs on the cheapest purpose-built model.
+ *   - Any other provider: reuse the current model so users running their
+ *     own keys don't need kimchi-dev models configured.
+ */
+export function resolveClassifierModel(
+	currentModel: Model<Api> | undefined,
+	modelRegistry: ModelRegistry,
+): Model<Api> | undefined {
+	if (!currentModel) return undefined
+
+	if (currentModel.provider !== KIMCHI_DEV_PROVIDER) return currentModel
+
+	// Find a light-tier model from the orchestration capability map.
+	for (const [id, caps] of MODEL_CAPABILITIES) {
+		if (caps === "ignored") continue
+		if (caps.tier === "light") {
+			const resolved = modelRegistry.find(KIMCHI_DEV_PROVIDER, id)
+			if (resolved) return resolved
+		}
+	}
+
+	// No light-tier model available — fall back to current model.
+	return currentModel
+}

--- a/src/extensions/permissions/classifier.ts
+++ b/src/extensions/permissions/classifier.ts
@@ -27,6 +27,8 @@ export async function classifyToolCall(
 	const auth = await modelRegistry.getApiKeyAndHeaders(model)
 	if (!auth.ok || !auth.apiKey) return unavailable("no API key for classifier")
 
+	if (signal?.aborted) return unavailable("classifier aborted")
+
 	const controller = new AbortController()
 	const timeoutHandle = setTimeout(() => controller.abort(), options.timeoutMs)
 	const onOuterAbort = () => controller.abort()

--- a/src/extensions/permissions/classifier.ts
+++ b/src/extensions/permissions/classifier.ts
@@ -1,7 +1,11 @@
 import { complete } from "@mariozechner/pi-ai"
-import type { ExtensionContext } from "@mariozechner/pi-coding-agent"
+import type { Api, Model } from "@mariozechner/pi-ai"
+import type { ModelRegistry } from "@mariozechner/pi-coding-agent"
 import classifierSystemPrompt from "./prompts/classifier-system-prompt.js"
 import type { ClassifierResult, ClassifierVerdict } from "./types.js"
+
+/** Tag added to every classifier LLM request for cost tracking. */
+export const CLASSIFIER_REQUEST_TAG = "source:classifier"
 
 export interface ClassifyInput {
 	toolName: string
@@ -14,21 +18,19 @@ export interface ClassifierOptions {
 }
 
 export async function classifyToolCall(
-	ctx: ExtensionContext,
+	model: Model<Api>,
+	modelRegistry: ModelRegistry,
 	call: ClassifyInput,
 	options: ClassifierOptions,
+	signal?: AbortSignal,
 ): Promise<ClassifierResult> {
-	const model = ctx.model
-	if (!model) return unavailable("no model configured")
-
-	const auth = await ctx.modelRegistry.getApiKeyAndHeaders(model)
+	const auth = await modelRegistry.getApiKeyAndHeaders(model)
 	if (!auth.ok || !auth.apiKey) return unavailable("no API key for classifier")
 
 	const controller = new AbortController()
 	const timeoutHandle = setTimeout(() => controller.abort(), options.timeoutMs)
-	const outerSignal = ctx.signal
 	const onOuterAbort = () => controller.abort()
-	outerSignal?.addEventListener("abort", onOuterAbort)
+	signal?.addEventListener("abort", onOuterAbort)
 
 	try {
 		const response = await complete(
@@ -43,7 +45,19 @@ export async function classifyToolCall(
 					},
 				],
 			},
-			{ apiKey: auth.apiKey, headers: auth.headers, signal: controller.signal },
+			{
+				apiKey: auth.apiKey,
+				headers: auth.headers,
+				signal: controller.signal,
+				onPayload: (payload: unknown) => {
+					if (payload && typeof payload === "object") {
+						const p = payload as Record<string, unknown>
+						const existing = Array.isArray(p.tags) ? (p.tags as string[]) : []
+						p.tags = [CLASSIFIER_REQUEST_TAG, ...existing]
+					}
+					return payload
+				},
+			},
 		)
 
 		const text = response.content
@@ -57,7 +71,7 @@ export async function classifyToolCall(
 		return unavailable(aborted ? "classifier timeout" : `classifier error: ${(err as Error).message}`)
 	} finally {
 		clearTimeout(timeoutHandle)
-		outerSignal?.removeEventListener("abort", onOuterAbort)
+		signal?.removeEventListener("abort", onOuterAbort)
 	}
 }
 

--- a/src/extensions/permissions/index.ts
+++ b/src/extensions/permissions/index.ts
@@ -1,3 +1,4 @@
+import type { Api, Model } from "@mariozechner/pi-ai"
 import type { ExtensionAPI, ExtensionContext, ToolCallEvent } from "@mariozechner/pi-coding-agent"
 import { isKeyRelease, matchesKey } from "@mariozechner/pi-tui"
 import { RST_FG, resolvedSemanticFg } from "../../ansi.js"
@@ -312,10 +313,15 @@ export default function permissionsExtension(pi: ExtensionAPI): void {
 					if (isReadOnlyBashCommand(command)) return undefined
 				}
 
+				const classifierModel = resolveClassifierModel(ctx)
+				if (!classifierModel) return { block: true, reason: "no model available for classifier" }
+
 				const verdict = await classifyToolCall(
-					ctx,
+					classifierModel,
+					ctx.modelRegistry,
 					{ toolName, input, cwd: ctx.cwd },
 					{ timeoutMs: loaded.config.classifierTimeoutMs },
+					ctx.signal,
 				)
 
 				if (verdict.verdict === "safe") return undefined
@@ -401,6 +407,22 @@ async function handleConfirm(
 	} finally {
 		opts.activeAborts.delete(abort)
 	}
+}
+
+/**
+ * Pick the cheapest available model for the classifier.
+ *
+ * Strategy: prefer the model with the lowest per-token input cost that has
+ * a configured API key. Falls back to `ctx.model` (the orchestrator's model)
+ * when no cheaper alternative is available.
+ */
+function resolveClassifierModel(ctx: ExtensionContext): Model<Api> | undefined {
+	const available = ctx.modelRegistry.getAvailable()
+	if (available.length === 0) return ctx.model
+
+	// Sort ascending by input cost — cheapest first.
+	const sorted = [...available].sort((a, b) => a.cost.input - b.cost.input)
+	return sorted[0] ?? ctx.model
 }
 
 function splitFlag(raw: boolean | string | undefined): string[] {

--- a/src/extensions/permissions/index.ts
+++ b/src/extensions/permissions/index.ts
@@ -412,9 +412,9 @@ async function handleConfirm(
 /**
  * Pick the cheapest available model for the classifier.
  *
- * Strategy: prefer the model with the lowest per-token input cost that has
- * a configured API key. Falls back to `ctx.model` (the orchestrator's model)
- * when no cheaper alternative is available.
+ * Strategy: prefer the model with the lowest per-token input cost.
+ * Falls back to `ctx.model` (the orchestrator's model) when no
+ * alternatives are available in the registry.
  */
 function resolveClassifierModel(ctx: ExtensionContext): Model<Api> | undefined {
 	const available = ctx.modelRegistry.getAvailable()
@@ -422,7 +422,7 @@ function resolveClassifierModel(ctx: ExtensionContext): Model<Api> | undefined {
 
 	// Sort ascending by input cost — cheapest first.
 	const sorted = [...available].sort((a, b) => a.cost.input - b.cost.input)
-	return sorted[0] ?? ctx.model
+	return sorted[0]
 }
 
 function splitFlag(raw: boolean | string | undefined): string[] {

--- a/src/extensions/permissions/index.ts
+++ b/src/extensions/permissions/index.ts
@@ -2,6 +2,7 @@ import type { Api, Model } from "@mariozechner/pi-ai"
 import type { ExtensionAPI, ExtensionContext, ToolCallEvent } from "@mariozechner/pi-coding-agent"
 import { isKeyRelease, matchesKey } from "@mariozechner/pi-tui"
 import { RST_FG, resolvedSemanticFg } from "../../ansi.js"
+import { resolveClassifierModel } from "./classifier-model.js"
 import { classifyToolCall } from "./classifier.js"
 import { registerCommands } from "./commands.js"
 import { type LoadedConfig, loadConfig } from "./config.js"
@@ -313,7 +314,7 @@ export default function permissionsExtension(pi: ExtensionAPI): void {
 					if (isReadOnlyBashCommand(command)) return undefined
 				}
 
-				const classifierModel = resolveClassifierModel(ctx)
+				const classifierModel = resolveClassifierModel(ctx.model, ctx.modelRegistry)
 				if (!classifierModel) return { block: true, reason: "no model available for classifier" }
 
 				const verdict = await classifyToolCall(
@@ -407,22 +408,6 @@ async function handleConfirm(
 	} finally {
 		opts.activeAborts.delete(abort)
 	}
-}
-
-/**
- * Pick the cheapest available model for the classifier.
- *
- * Strategy: prefer the model with the lowest per-token input cost.
- * Falls back to `ctx.model` (the orchestrator's model) when no
- * alternatives are available in the registry.
- */
-function resolveClassifierModel(ctx: ExtensionContext): Model<Api> | undefined {
-	const available = ctx.modelRegistry.getAvailable()
-	if (available.length === 0) return ctx.model
-
-	// Sort ascending by input cost — cheapest first.
-	const sorted = [...available].sort((a, b) => a.cost.input - b.cost.input)
-	return sorted[0]
 }
 
 function splitFlag(raw: boolean | string | undefined): string[] {


### PR DESCRIPTION
## Problem

The permissions classifier — which runs on every tool call in auto mode — inherits the currently selected model. When running an expensive model (e.g. Opus), every classification burns expensive tokens on a simple task.

## Solution

The classifier now automatically selects a different, cheaper model. The current model is only reused as a last resort when it's the sole available model from that provider.

### `resolveClassifierModel(currentModel, modelRegistry)`

Returns `undefined` if no current model.

**kimchi-dev provider:**
1. Find all light-tier models → pick one that isn't the current model.
2. If current is the only light-tier → step up: try standard, then heavy (any model ≠ current).
3. If nothing else found → return current model.

**Any other provider:**
1. Collect same-provider models strictly cheaper than current, sort by cost descending.
2. Pick index 1 (two steps down) — or index 0 if only one cheaper model exists.
3. If no cheaper model exists → pick the least expensive model that costs ≥ current and isn't current.
4. If sole model in provider → return current model.

**Invariant:** always pick a different model unless current is the only option.

### Example: Anthropic lineup

| Current model | Available | Selected | Why |
|---|---|---|---|
| Opus | Opus, Sonnet, Haiku | **Haiku** | Two steps down |
| Sonnet | Opus, Sonnet, Haiku | **Haiku** | One step down (only one cheaper) |
| Haiku | Opus, Sonnet, Haiku | **Sonnet** | No cheaper → least more expensive |
| Haiku | Haiku | **Haiku** | Sole model → no choice |