### PR TITLE
fix(bash-collapse): collapse newlines in multiline command headers

### DIFF
--- a/src/extensions/bash-collapse.test.ts
+++ b/src/extensions/bash-collapse.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, it } from "vitest"
+import { collapseCommand } from "./bash-collapse.js"
+
+describe("collapseCommand", () => {
+	it("collapses consecutive newlines into a printable arrow", () => {
+		expect(collapseCommand("echo hello\necho world")).toBe("echo hello ⏎ echo world")
+	})
+
+	it("handles multiple consecutive newlines", () => {
+		// Multiple consecutive newlines collapse into a single arrow.
+		expect(collapseCommand("cat << 'EOF'\nhello\n\nworld\nEOF")).toBe("cat << 'EOF' ⏎ hello ⏎ world ⏎ EOF")
+	})
+
+	it("leaves single-line commands untouched", () => {
+		expect(collapseCommand("git status")).toBe("git status")
+	})
+
+	it("defaults to empty string when command is undefined", () => {
+		expect(collapseCommand(undefined)).toBe("")
+	})
+})

--- a/src/extensions/bash-collapse.ts
+++ b/src/extensions/bash-collapse.ts
@@ -4,6 +4,10 @@ import { Container, Spacer, Text } from "@mariozechner/pi-tui"
 import { ToolBlockView, buildToolCallHeader, getTextContent } from "../components/tool-block.js"
 import { isToolExpanded, registerToolCall } from "../expand-state.js"
 
+export function collapseCommand(command: string | undefined): string {
+	return (command ?? "").replace(/\n+/g, " ⏎ ")
+}
+
 export default function (pi: ExtensionAPI) {
 	const baseDef = createBashToolDefinition(process.cwd())
 
@@ -16,7 +20,10 @@ export default function (pi: ExtensionAPI) {
 
 		renderCall(args, theme, ctx) {
 			const view = ctx.lastComponent instanceof ToolBlockView ? ctx.lastComponent : new ToolBlockView()
-			buildToolCallHeader(view, "bash", args.command ?? "", theme, ctx)
+			// Bash commands can be multiline (e.g. heredocs); collapse newlines
+			// so the single-line header doesn't overflow onto multiple rows.
+			const command = collapseCommand(args.command)
+			buildToolCallHeader(view, "bash", command, theme, ctx)
 			return view
 		},
 


### PR DESCRIPTION
When bash commands contain multiline heredocs, the raw command string is rendered by pi-tui's single-line header. The header width math doesn't handle embedded newlines: every newline breaks the visible-width count and causes fragments to over-print on subsequent rows, resulting in the garbled repeated-arrow artifact (⟳ ⟳ ⟳ ⟳ ⟳ ⟳ ✗).

Replace consecutive newlines with a single ⏎ character before passing to buildToolCallHeader.  Extract a pure helper so we can unit-test it.

---
### Kimchi Summary
### What changed
Fixes header overflow when displaying multiline bash commands (e.g., heredocs) by collapsing consecutive newlines into a visual arrow (`⏎`).

### Why
Bash tool calls can contain multiline scripts that caused the single-line tool header to wrap onto multiple rows, breaking the UI layout.

### Key changes
- **`src/extensions/bash-collapse.ts`**: Added `collapseCommand()` utility to replace consecutive newlines with ` ⏎ `; updated `renderCall()` to collapse `args.command` before rendering the header.
- **`src/extensions/bash-collapse.test.ts`**: Added test suite covering multiline collapse, single-line passthrough, and undefined input handling.