### PR TITLE
LLM-1387: fix update flow

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # kimchi
 
-A coding agent CLI powered by [kimchi](https://github.com/castai/kimchi). Built on the [pi-mono](https://github.com/badlogic/pi-mono) coding agent SDK, kimchi gives you an AI-powered development assistant in your terminal that connects to kimchi's LLM infrastructure.
+A coding agent CLI powered by [kimchi](https://kimchi.dev/). Built on the [pi-mono](https://github.com/badlogic/pi-mono) coding agent SDK, kimchi gives you an AI-powered development assistant in your terminal that connects to kimchi's LLM infrastructure.
 
 ## Quick start
 

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -3,7 +3,7 @@
 # Install the kimchi coding-harness CLI from the latest GitHub release.
 #
 # Usage:
-#   curl -fsSL https://github.com/castai/kimchi/releases/latest/download/install.sh | bash
+#   curl -fsSL https://github.com/castai/kimchi-dev/releases/latest/download/install.sh | bash
 #
 # Optional env:
 #   KIMCHI_INSTALL_DIR  Override install dir. Defaults to /usr/local/bin if
@@ -20,7 +20,7 @@ BLUE='\033[0;34m'
 YELLOW='\033[0;33m'
 NC='\033[0m'
 
-REPO="${KIMCHI_REPO_OVERRIDE:-castai/kimchi}"
+REPO="${KIMCHI_REPO_OVERRIDE:-castai/kimchi-dev}"
 VERSION="${KIMCHI_VERSION:-latest}"
 
 echo -e "${BLUE}Installing Kimchi from ${REPO}${VERSION:+ (${VERSION})}…${NC}"

--- a/src/update/install.test.ts
+++ b/src/update/install.test.ts
@@ -1,0 +1,51 @@
+import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
+import { afterEach, beforeEach, describe, expect, it } from "vitest"
+import { copySupportingFiles } from "./install.js"
+
+describe("copySupportingFiles", () => {
+	let srcDir: string
+	let dstDir: string
+
+	beforeEach(() => {
+		srcDir = mkdtempSync(join(tmpdir(), "kimchi-install-src-"))
+		dstDir = mkdtempSync(join(tmpdir(), "kimchi-install-dst-"))
+	})
+
+	afterEach(() => {
+		rmSync(srcDir, { recursive: true, force: true })
+		rmSync(dstDir, { recursive: true, force: true })
+	})
+
+	// Regression: copyFileSync's third argument is COPYFILE_* flags (range 0–7),
+	// not file mode. Passing stat.mode (e.g. 33188) used to throw
+	// "mode is out of range: >= 0 && <= 7" on the very first regular file.
+	it("copies a top-level file without throwing on file mode", () => {
+		writeFileSync(join(srcDir, "config.json"), '{"hello":"world"}')
+
+		expect(() => copySupportingFiles(srcDir, dstDir)).not.toThrow()
+		expect(readFileSync(join(dstDir, "config.json"), "utf-8")).toBe('{"hello":"world"}')
+	})
+
+	it("recursively copies nested files", () => {
+		mkdirSync(join(srcDir, "nested", "deeper"), { recursive: true })
+		writeFileSync(join(srcDir, "nested", "a.txt"), "alpha")
+		writeFileSync(join(srcDir, "nested", "deeper", "b.txt"), "beta")
+
+		copySupportingFiles(srcDir, dstDir)
+
+		expect(readFileSync(join(dstDir, "nested", "a.txt"), "utf-8")).toBe("alpha")
+		expect(readFileSync(join(dstDir, "nested", "deeper", "b.txt"), "utf-8")).toBe("beta")
+	})
+
+	it("skips entries matching skipName", () => {
+		writeFileSync(join(srcDir, "kimchi"), "binary")
+		writeFileSync(join(srcDir, "keepme.txt"), "ok")
+
+		copySupportingFiles(srcDir, dstDir, "kimchi")
+
+		expect(readFileSync(join(dstDir, "keepme.txt"), "utf-8")).toBe("ok")
+		expect(() => readFileSync(join(dstDir, "kimchi"))).toThrow()
+	})
+})

--- a/src/update/install.ts
+++ b/src/update/install.ts
@@ -155,9 +155,10 @@ function copyDir(src: string, dst: string): void {
 }
 
 /**
- * Copy a single file from src to dst, preserving permissions.
+ * Copy a single file from src to dst. copyFileSync preserves the source's
+ * mode bits on POSIX by default — its third argument is for COPYFILE_*
+ * behavioral flags (range 0–7), not file permissions.
  */
 function copyFile(src: string, dst: string): void {
-	const stat = statSync(src)
-	copyFileSync(src, dst, stat.mode)
+	copyFileSync(src, dst)
 }

--- a/src/update/workflow.test.ts
+++ b/src/update/workflow.test.ts
@@ -1,0 +1,57 @@
+import { mkdtempSync, rmSync } from "node:fs"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
+import { afterEach, beforeEach, describe, expect, it } from "vitest"
+import type { GitHubClient, ReleaseInfo, Repo } from "./github.js"
+import { checkForUpdate } from "./workflow.js"
+
+const REPO: Repo = { owner: "castai", name: "kimchi-dev", binary: "kimchi" }
+
+function fakeClient(release: ReleaseInfo): GitHubClient {
+	return {
+		latestRelease: async () => release,
+	} as unknown as GitHubClient
+}
+
+describe("checkForUpdate version comparison", () => {
+	let tmp: string
+	let prevHome: string | undefined
+	let prevXdg: string | undefined
+
+	beforeEach(() => {
+		tmp = mkdtempSync(join(tmpdir(), "kimchi-workflow-test-"))
+		prevHome = process.env.HOME
+		prevXdg = process.env.XDG_CACHE_HOME
+		process.env.XDG_CACHE_HOME = tmp
+	})
+
+	afterEach(() => {
+		// biome-ignore lint/performance/noDelete: env-var cleanup needs a real delete; assigning undefined would coerce to the literal string "undefined".
+		if (prevHome === undefined) delete process.env.HOME
+		else process.env.HOME = prevHome
+		// biome-ignore lint/performance/noDelete: same as above.
+		if (prevXdg === undefined) delete process.env.XDG_CACHE_HOME
+		else process.env.XDG_CACHE_HOME = prevXdg
+		rmSync(tmp, { recursive: true, force: true })
+	})
+
+	it("does not flag a v-prefixed older tag as an update", async () => {
+		const client = fakeClient({ tagName: "v0.0.23", htmlUrl: "https://example/release" })
+		const result = await checkForUpdate({ repo: REPO, currentVersion: "0.1.0", skipCache: true, client })
+		expect(result.hasUpdate).toBe(false)
+		// display string keeps the "v" — only the comparison should be normalized
+		expect(result.latestVersion).toBe("v0.0.23")
+	})
+
+	it("flags a v-prefixed newer tag as an update", async () => {
+		const client = fakeClient({ tagName: "v0.2.0", htmlUrl: "https://example/release" })
+		const result = await checkForUpdate({ repo: REPO, currentVersion: "0.1.0", skipCache: true, client })
+		expect(result.hasUpdate).toBe(true)
+	})
+
+	it("still works for an unprefixed newer tag", async () => {
+		const client = fakeClient({ tagName: "0.2.0", htmlUrl: "https://example/release" })
+		const result = await checkForUpdate({ repo: REPO, currentVersion: "0.1.0", skipCache: true, client })
+		expect(result.hasUpdate).toBe(true)
+	})
+})

--- a/src/update/workflow.ts
+++ b/src/update/workflow.ts
@@ -76,7 +76,11 @@ export async function checkForUpdate(opts: CheckOptions): Promise<CheckResult> {
 		})
 	}
 
-	const hasUpdate = !compareSemverGte(opts.currentVersion, latestVersion)
+	// GitHub release tags carry a leading "v" (e.g. "v0.0.23"); compareSemverGte
+	// only parses bare semver, so strip the prefix here. We keep `latestVersion`
+	// itself unchanged so cached state and user-facing messages still show the
+	// canonical tag name.
+	const hasUpdate = !compareSemverGte(opts.currentVersion, latestVersion.replace(/^v/, ""))
 	return {
 		currentVersion: opts.currentVersion,
 		latestVersion,


### PR DESCRIPTION


---
### Kimchi Summary
### What changed
Fixes two bugs in the self-update flow: a crash when copying files caused by passing file mode as `copyFileSync` flags, and incorrect version comparison when GitHub release tags carry a "v" prefix. Also updates documentation and install script to reference the `castai/kimchi-dev` repository.

### Why
The update mechanism failed when installing new versions because `copyFileSync` was called with `stat.mode` (e.g., 33188) as its third argument, which expects COPYFILE_* flags in the range 0–7. Additionally, version checks incorrectly flagged newer local versions as outdated because they compared bare semver (e.g., "0.1.0") against GitHub's "v"-prefixed tags (e.g., "v0.0.23").

### Key changes
- `src/update/install.ts`: Removes the third argument from `copyFileSync` in `copyFile`; `copyFileSync` already preserves POSIX permissions by default, and the parameter expects COPYFILE_* flags, not mode bits.
- `src/update/workflow.ts`: Strips the leading "v" from `latestVersion` before passing it to `compareSemverGte` in `checkForUpdate`, ensuring correct comparison against the current bare semver version while preserving the original tag name for display.
- `scripts/install.sh`: Updates the default `REPO` from `castai/kimchi` to `castai/kimchi-dev` and updates the usage comment URL accordingly.
- `README.md`: Updates the kimchi hyperlink to point to `https://kimchi.dev/`.
- `src/update/install.test.ts`: New test suite for `copySupportingFiles`, covering file mode handling, recursive copying, and skip patterns.
- `src/update/workflow.test.ts`: New test suite for `checkForUpdate` version comparison logic, verifying correct handling of "v"-prefixed and bare semver tags.