### PR TITLE
LLM-1387: show update notification

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ A coding agent CLI powered by [kimchi](https://kimchi.dev/). Built on the [pi-mo
 Install the latest release:
 
 ```bash
-curl -fsSL https://github.com/castai/kimchi/releases/latest/download/install.sh | bash
+curl -fsSL https://github.com/castai/kimchi-dev/releases/latest/download/install.sh | bash
 ```
 
 Then configure your API key and tools, and launch:

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -28,6 +28,7 @@ import permissionsExtension from "./extensions/permissions/index.js"
 import { reserveShiftTabForPermissions } from "./extensions/permissions/keybindings.js"
 import promptSummaryExtension from "./extensions/prompt-summary.js"
 import shutdownMarkerExtension from "./extensions/shutdown-marker.js"
+import startupUpdateExtension from "./extensions/startup-update.js"
 // import statsExtension from "./extensions/stats/index.js"
 import subagentExtension from "./extensions/subagent.js"
 import tagsExtension from "./extensions/tags.js"
@@ -250,6 +251,7 @@ try {
 		}
 
 		const extensionFactories = [
+			startupUpdateExtension,
 			sessionIdCaptureExtension,
 			shutdownMarkerExtension,
 			// statsExtension,

--- a/src/components/footer.ts
+++ b/src/components/footer.ts
@@ -215,10 +215,16 @@ export class StatsFooter implements Component {
 		return seg(teal(`${count} subagent${count === 1 ? "" : "s"}`))
 	}
 
-	private permissionsWarning(width: number): string | null {
+	private permissionsWarning(): FooterSegment | null {
 		const text = this._footerData.getExtensionStatuses().get("permissions-warning")
 		if (!text) return null
-		return truncateToWidth(this.theme.fg("warning", text), width)
+		return seg(this.theme.fg("warning", text))
+	}
+
+	private updateAvailableSegment(): FooterSegment | null {
+		const text = this._footerData.getExtensionStatuses().get("update-available")
+		if (!text) return null
+		return seg(this.theme.fg("accent", text))
 	}
 
 	render(width: number): string[] {
@@ -252,7 +258,25 @@ export class StatsFooter implements Component {
 			line = truncateToWidth(left, width)
 		}
 
-		const warning = this.permissionsWarning(width)
-		return warning ? [warning, line] : [line]
+		const infoLine = this.buildInfoLine(width)
+		return infoLine ? [infoLine, line] : [line]
+	}
+
+	buildInfoLine(width: number): string {
+		let line = ""
+		const permissionsWarningSeg = this.permissionsWarning()
+		const updateSeg = this.updateAvailableSegment()
+
+		let remainingWidth = width
+		if (permissionsWarningSeg) {
+			line = truncateToWidth(permissionsWarningSeg.text, remainingWidth)
+			remainingWidth -= visibleWidth(line)
+		}
+
+		if (updateSeg && remainingWidth >= updateSeg.width + 2) {
+			line = `${line}${" ".repeat(remainingWidth - updateSeg.width)}${updateSeg.text}`
+		}
+
+		return line
 	}
 }

--- a/src/extensions/permissions/index.ts
+++ b/src/extensions/permissions/index.ts
@@ -207,7 +207,7 @@ export default function permissionsExtension(pi: ExtensionAPI): void {
 		if (mode === "yolo") {
 			ctx.ui.setStatus(
 				"permissions-warning",
-				"WARNING: all permission checks disabled. YOLO mode is recommended for sandbox/disposable environments only.",
+				"WARNING: all permission checks disabled. Recommended for sandbox environments only.",
 			)
 		} else {
 			ctx.ui.setStatus("permissions-warning", undefined)

--- a/src/extensions/startup-update.ts
+++ b/src/extensions/startup-update.ts
@@ -1,0 +1,29 @@
+import type { ExtensionAPI, ExtensionContext } from "@mariozechner/pi-coding-agent"
+import { checkForUpdate } from "../update/workflow.js"
+import { getVersion } from "../utils.js"
+
+const UPDATE_STATUS_KEY = "update-available"
+
+/**
+ * Startup-time check for new kimchi versions. Uses cache (24h) and displays
+ * a message on the footer (right side, centered) if an update is available.
+ * Silently fails on errors to not block harness launch.
+ *
+ * The message is displayed via setStatus and read by the footer renderer.
+ */
+export default function startupUpdateExtension(pi: ExtensionAPI) {
+	pi.on("session_start", async (_event, ctx: ExtensionContext) => {
+		if (!ctx.hasUI) return
+
+		const current = getVersion()
+		try {
+			const result = await checkForUpdate({ currentVersion: current, skipCache: false })
+			if (result.hasUpdate) {
+				const updateCmd = ctx.ui.theme.bold("kimchi update")
+				ctx.ui.setStatus(UPDATE_STATUS_KEY, `Update available! Run ${updateCmd}`)
+			}
+		} catch {
+			// Silently ignore errors - don't block harness launch
+		}
+	})
+}

--- a/src/update/state.test.ts
+++ b/src/update/state.test.ts
@@ -1,4 +1,4 @@
-import { existsSync, mkdtempSync, readFileSync, rmSync } from "node:fs"
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs"
 import { tmpdir } from "node:os"
 import { join } from "node:path"
 import { afterEach, beforeEach, describe, expect, it } from "vitest"
@@ -28,52 +28,161 @@ describe("update state cache", () => {
 		rmSync(tmp, { recursive: true, force: true })
 	})
 
+	function statePathFor(): string {
+		return join(tmp, "kimchi", "state.json")
+	}
+
+	function writeRawState(json: unknown): void {
+		const path = statePathFor()
+		mkdirSync(join(tmp, "kimchi"), { recursive: true })
+		writeFileSync(path, JSON.stringify(json, null, 2))
+	}
+
 	it("returns null for a missing state file", () => {
 		expect(loadRepoState("castai", "kimchi")).toBeNull()
 	})
 
 	it("round-trips per-repo state through saveRepoState + loadRepoState", () => {
 		saveRepoState("castai", "kimchi", {
-			checkedAt: 1_700_000_000_000,
-			latestVersion: "1.2.3",
-			releaseUrl: "https://github.com/castai/kimchi/releases/tag/v1.2.3",
+			checked_at: "2023-11-14T22:13:20.000Z",
+			latest_version: "1.2.3",
+			release_url: "https://github.com/castai/kimchi/releases/tag/v1.2.3",
 		})
 		const got = loadRepoState("castai", "kimchi")
 		expect(got).toEqual({
-			checkedAt: 1_700_000_000_000,
-			latestVersion: "1.2.3",
-			releaseUrl: "https://github.com/castai/kimchi/releases/tag/v1.2.3",
+			checked_at: "2023-11-14T22:13:20.000Z",
+			latest_version: "1.2.3",
+			release_url: "https://github.com/castai/kimchi/releases/tag/v1.2.3",
 		})
 	})
 
 	it("preserves entries for other repos when updating one", () => {
-		saveRepoState("a", "b", { checkedAt: 1, latestVersion: "1.0.0" })
-		saveRepoState("c", "d", { checkedAt: 2, latestVersion: "2.0.0" })
-		expect(loadRepoState("a", "b")?.latestVersion).toBe("1.0.0")
-		expect(loadRepoState("c", "d")?.latestVersion).toBe("2.0.0")
+		saveRepoState("a", "b", { checked_at: "2026-01-01T00:00:00Z", latest_version: "1.0.0" })
+		saveRepoState("c", "d", { checked_at: "2026-01-02T00:00:00Z", latest_version: "2.0.0" })
+		expect(loadRepoState("a", "b")?.latest_version).toBe("1.0.0")
+		expect(loadRepoState("c", "d")?.latest_version).toBe("2.0.0")
 	})
 
-	it("writes the file with 0600 perms via tmp+rename (atomic)", () => {
-		saveRepoState("a", "b", { checkedAt: 1, latestVersion: "1.0.0" })
-		const path = join(tmp, "kimchi", "state.json")
+	it("writes on disk in snake_case + RFC3339", () => {
+		saveRepoState("a", "b", {
+			checked_at: "2023-11-14T22:13:20.000Z",
+			latest_version: "1.0.0",
+			release_url: "https://example/release",
+		})
+		const path = statePathFor()
 		expect(existsSync(path)).toBe(true)
-		// Smoke-check that the JSON parses back rather than asserting on
-		// fs mode bits, which differ between OSes/file-systems.
-		const raw = readFileSync(path, "utf-8")
-		expect(JSON.parse(raw).repos["a/b"]).toEqual({ checkedAt: 1, latestVersion: "1.0.0" })
+		const raw = JSON.parse(readFileSync(path, "utf-8"))
+		expect(raw.repos["a/b"]).toEqual({
+			checked_at: "2023-11-14T22:13:20.000Z",
+			latest_version: "1.0.0",
+			release_url: "https://example/release",
+		})
+	})
+
+	it("reads snake_case + RFC3339 with timezone offset entry", () => {
+		writeRawState({
+			repos: {
+				"castai/kimchi-dev": {
+					checked_at: "2026-05-06T10:58:22.04543+03:00",
+					latest_version: "v0.0.22",
+					release_url: "https://github.com/castai/kimchi-dev/releases/tag/v0.0.22",
+				},
+			},
+		})
+		const got = loadRepoState("castai", "kimchi-dev")
+		expect(got?.latest_version).toBe("v0.0.22")
+		expect(got?.release_url).toBe("https://github.com/castai/kimchi-dev/releases/tag/v0.0.22")
+		expect(got?.checked_at).toBe("2026-05-06T10:58:22.04543+03:00")
+	})
+
+	it("preserves a foreign-shape entry on save instead of overwriting it", () => {
+		writeRawState({
+			repos: {
+				"castai/kimchi": {
+					checked_at: "2026-05-06T10:05:19+03:00",
+					latest_version: "v0.1.52",
+					release_url: "https://github.com/castai/kimchi/releases/tag/v0.1.52",
+				},
+			},
+		})
+		saveRepoState("castai", "kimchi-dev", { checked_at: "2023-11-14T22:13:20.000Z", latest_version: "v0.0.22" })
+		const raw = JSON.parse(readFileSync(statePathFor(), "utf-8"))
+		expect(raw.repos["castai/kimchi"]).toEqual({
+			checked_at: "2026-05-06T10:05:19+03:00",
+			latest_version: "v0.1.52",
+			release_url: "https://github.com/castai/kimchi/releases/tag/v0.1.52",
+		})
+		expect(raw.repos["castai/kimchi-dev"]).toEqual({
+			checked_at: "2023-11-14T22:13:20.000Z",
+			latest_version: "v0.0.22",
+		})
+	})
+
+	describe("defensive parsing — malformed cache entries return null (no throw)", () => {
+		it("returns null when latest_version is missing", () => {
+			writeRawState({ repos: { "a/b": { checked_at: "2026-01-01T00:00:00Z" } } })
+			expect(loadRepoState("a", "b")).toBeNull()
+		})
+
+		it("returns null when latest_version is the wrong type", () => {
+			writeRawState({ repos: { "a/b": { checked_at: "2026-01-01T00:00:00Z", latest_version: 123 } } })
+			expect(loadRepoState("a", "b")).toBeNull()
+		})
+
+		it("returns null when latest_version is empty string", () => {
+			writeRawState({ repos: { "a/b": { checked_at: "2026-01-01T00:00:00Z", latest_version: "" } } })
+			expect(loadRepoState("a", "b")).toBeNull()
+		})
+
+		it("returns null when checked_at is missing", () => {
+			writeRawState({ repos: { "a/b": { latest_version: "1.0.0" } } })
+			expect(loadRepoState("a", "b")).toBeNull()
+		})
+
+		it("returns null when checked_at is unparseable", () => {
+			writeRawState({ repos: { "a/b": { checked_at: "not-a-date", latest_version: "1.0.0" } } })
+			expect(loadRepoState("a", "b")).toBeNull()
+		})
+
+		it("returns null for a camelCase entry written by a different schema", () => {
+			writeRawState({ repos: { "a/b": { checkedAt: 1_700_000_000_000, latestVersion: "1.0.0" } } })
+			expect(loadRepoState("a", "b")).toBeNull()
+		})
+
+		it("returns null when the entry is not an object", () => {
+			writeRawState({ repos: { "a/b": "garbage" } })
+			expect(loadRepoState("a", "b")).toBeNull()
+		})
+
+		it("returns null when the file is invalid JSON", () => {
+			const path = statePathFor()
+			mkdirSync(join(tmp, "kimchi"), { recursive: true })
+			writeFileSync(path, "{not valid json")
+			expect(loadRepoState("a", "b")).toBeNull()
+		})
+
+		it("returns null when the top-level shape has no repos field", () => {
+			writeRawState({ something_else: 1 })
+			expect(loadRepoState("a", "b")).toBeNull()
+		})
 	})
 })
 
 describe("isStale", () => {
 	const day = 24 * 60 * 60 * 1000
+	const t0 = Date.parse("2026-01-01T00:00:00Z")
+
 	it("returns false for a fresh check", () => {
-		expect(isStale({ checkedAt: 1_000, latestVersion: "" }, 1_000)).toBe(false)
+		expect(isStale({ checked_at: "2026-01-01T00:00:00Z", latest_version: "1" }, t0)).toBe(false)
 	})
 	it("returns false within 24h", () => {
-		expect(isStale({ checkedAt: 1_000, latestVersion: "" }, 1_000 + day - 1)).toBe(false)
+		expect(isStale({ checked_at: "2026-01-01T00:00:00Z", latest_version: "1" }, t0 + day - 1)).toBe(false)
 	})
 	it("returns true past 24h", () => {
-		expect(isStale({ checkedAt: 1_000, latestVersion: "" }, 1_000 + day + 1)).toBe(true)
+		expect(isStale({ checked_at: "2026-01-01T00:00:00Z", latest_version: "1" }, t0 + day + 1)).toBe(true)
+	})
+	it("returns true when checked_at is unparseable (defensive)", () => {
+		expect(isStale({ checked_at: "garbage", latest_version: "1" }, t0)).toBe(true)
 	})
 })
 

--- a/src/update/state.ts
+++ b/src/update/state.ts
@@ -3,29 +3,47 @@ import { dirname } from "node:path"
 import { statePath } from "./paths.js"
 
 export interface RepoState {
-	checkedAt: number
-	latestVersion: string
-	releaseUrl?: string
+	checked_at: string
+	latest_version: string
+	release_url?: string
 }
 
 interface PersistedState {
-	repos?: Record<string, RepoState>
+	repos?: Record<string, unknown>
 }
 
 const TTL_MS = 24 * 60 * 60 * 1_000
 
 export function isStale(rs: RepoState, now: number = Date.now()): boolean {
-	return now - rs.checkedAt > TTL_MS
+	const t = Date.parse(rs.checked_at)
+	if (Number.isNaN(t)) return true
+	return now - t > TTL_MS
 }
 
 function repoKey(owner: string, name: string): string {
 	return `${owner}/${name}`
 }
 
+function parseRepoState(raw: unknown): RepoState | null {
+	if (!raw || typeof raw !== "object") return null
+	const v = raw as Partial<RepoState>
+	if (typeof v.checked_at !== "string") return null
+	if (Number.isNaN(Date.parse(v.checked_at))) return null
+	if (typeof v.latest_version !== "string" || v.latest_version === "") return null
+	const out: RepoState = {
+		checked_at: v.checked_at,
+		latest_version: v.latest_version,
+	}
+	if (typeof v.release_url === "string") out.release_url = v.release_url
+	return out
+}
+
 function loadState(): PersistedState | null {
 	try {
 		const raw = readFileSync(statePath(), "utf-8")
-		return JSON.parse(raw) as PersistedState
+		const parsed = JSON.parse(raw) as unknown
+		if (!parsed || typeof parsed !== "object") return null
+		return parsed as PersistedState
 	} catch (err) {
 		if ((err as NodeJS.ErrnoException).code === "ENOENT") return null
 		// Treat corruption as missing — the next save will overwrite.
@@ -41,11 +59,15 @@ function saveState(state: PersistedState): void {
 	renameSync(tmp, path)
 }
 
-/** Read cached state for a repo, returning null when missing or unparseable. */
+/**
+ * Read cached state for a repo. Returns null when missing, unparseable,
+ * or in an unexpected shape (defensive: no schema mismatch should ever
+ * crash the caller — they fall through to a refetch instead).
+ */
 export function loadRepoState(owner: string, name: string): RepoState | null {
 	const state = loadState()
 	if (!state?.repos) return null
-	return state.repos[repoKey(owner, name)] ?? null
+	return parseRepoState(state.repos[repoKey(owner, name)])
 }
 
 /**
@@ -57,7 +79,7 @@ export function loadRepoState(owner: string, name: string): RepoState | null {
 export function saveRepoState(owner: string, name: string, rs: RepoState): void {
 	try {
 		const state = loadState() ?? {}
-		const repos = state.repos ?? {}
+		const repos = (state.repos ?? {}) as Record<string, unknown>
 		repos[repoKey(owner, name)] = rs
 		saveState({ ...state, repos })
 	} catch {

--- a/src/update/workflow.ts
+++ b/src/update/workflow.ts
@@ -58,9 +58,9 @@ export async function checkForUpdate(opts: CheckOptions): Promise<CheckResult> {
 
 	if (!opts.skipCache) {
 		const cachedState = loadRepoState(repo.owner, repo.name)
-		if (cachedState && !isStale(cachedState) && cachedState.latestVersion !== "") {
-			latestVersion = cachedState.latestVersion
-			releaseUrl = cachedState.releaseUrl ?? ""
+		if (cachedState && !isStale(cachedState)) {
+			latestVersion = cachedState.latest_version
+			releaseUrl = cachedState.release_url ?? ""
 			cached = true
 		}
 	}
@@ -70,9 +70,9 @@ export async function checkForUpdate(opts: CheckOptions): Promise<CheckResult> {
 		latestVersion = info.tagName
 		releaseUrl = info.htmlUrl
 		saveRepoState(repo.owner, repo.name, {
-			checkedAt: Date.now(),
-			latestVersion,
-			releaseUrl,
+			checked_at: new Date().toISOString(),
+			latest_version: latestVersion,
+			release_url: releaseUrl,
 		})
 	}
 
@@ -80,7 +80,8 @@ export async function checkForUpdate(opts: CheckOptions): Promise<CheckResult> {
 	// only parses bare semver, so strip the prefix here. We keep `latestVersion`
 	// itself unchanged so cached state and user-facing messages still show the
 	// canonical tag name.
-	const hasUpdate = !compareSemverGte(opts.currentVersion, latestVersion.replace(/^v/, ""))
+	const tag = (latestVersion ?? "").replace(/^v/, "")
+	const hasUpdate = tag !== "" && !compareSemverGte(opts.currentVersion, tag)
 	return {
 		currentVersion: opts.currentVersion,
 		latestVersion,


### PR DESCRIPTION


---
### Kimchi Summary
### What changed
Adds a startup-time version check that notifies users when a new release is available, displaying the notice in the CLI footer. Also fixes the install script URL in the README and switches the update cache from camelCase timestamps to snake_case ISO8601 dates for better robustness.

### Why
Users previously had no way to know when updates were available without manually checking GitHub. This introduces a lightweight, cached check (24h TTL) that runs on session start and surfaces upgrade instructions unobtrusively in the footer.

### Key changes
- **`src/extensions/startup-update.ts`** (new): Extension that checks for updates on `session_start`, caches results, and sets the `update-available` status for the footer.
- **`src/components/footer.ts`**: Added `updateAvailableSegment()` and `buildInfoLine()` to render update notices (right-aligned, accent color) alongside permission warnings.
- **`src/update/state.ts`**: Migrated cache schema from camelCase (`checkedAt`, `latestVersion`) to snake_case (`checked_at`, `latest_version`) with RFC3339 ISO strings; added defensive parsing in `parseRepoState()` to prevent crashes on malformed cache entries.
- **`src/update/workflow.ts`**: Updated to write ISO dates and handle empty version tags safely.
- **`README.md`**: Fixed install URL from `castai/kimchi` to `castai/kimchi-dev`.
- **`src/extensions/permissions/index.ts`**: Shortened YOLO mode warning text to save footer space.

### Impact
- **Breaking**: Existing update cache files (`~/.kimchi/state.json`) using the old camelCase+timestamp schema will be treated as invalid and re-fetched automatically (no crash, but first launch after upgrade may trigger a network request).
- **UI**: Footer now shows "Update available! Run `kimchi update`" in accent color when applicable, positioned right of the permissions warning if present.