### PR TITLE
LLM-1498: Self-improvement loop tweaks

### DIFF
--- a/benchmark/manual/check-session.py
+++ b/benchmark/manual/check-session.py
@@ -1,0 +1,171 @@
+#!/usr/bin/env python3
+"""Check whether all runs in a benchmark session have completed.
+
+Completion is determined by examining session log files (.jsonl) for terminal
+events — not by checking OS processes.  A run is considered done when its log
+contains an `agent_end` or `agent_terminated` entry.  A run is considered
+stalled when its log file has not been modified for longer than a configurable
+inactivity threshold (default: 3 minutes).
+
+Exit codes:
+  0 — all runs finished (either ended or terminated)
+  1 — some runs are still in progress
+  2 — error (missing session, no runs, etc.)
+
+Output: one status line per run, then a summary.
+"""
+
+import json
+import os
+import sys
+import time
+from pathlib import Path
+
+IMPROVEMENT_DIR = Path(__file__).parent
+SESSIONS_DIR = IMPROVEMENT_DIR / "sessions"
+
+INACTIVITY_THRESHOLD_S = 180  # 3 minutes with no log writes → stalled
+
+
+def check_jsonl(path: Path) -> dict:
+    has_agent_end = False
+    has_terminated = False
+    has_prompt_summary = False
+    last_ts = None
+    line_count = 0
+
+    with open(path) as f:
+        for raw in f:
+            raw = raw.strip()
+            if not raw:
+                continue
+            line_count += 1
+            try:
+                event = json.loads(raw)
+            except json.JSONDecodeError:
+                continue
+
+            custom_type = event.get("customType", "")
+            if custom_type == "prompt-summary":
+                has_prompt_summary = True
+
+            entry_type = event.get("type", "")
+            if entry_type == "agent_end" or custom_type == "agent_end":
+                has_agent_end = True
+            if entry_type == "agent_terminated" or custom_type == "agent_terminated":
+                has_terminated = True
+
+            ts = event.get("timestamp")
+            if ts:
+                last_ts = ts
+
+    mtime = path.stat().st_mtime
+    age_s = time.time() - mtime
+
+    return {
+        "file": str(path),
+        "lines": line_count,
+        "has_agent_end": has_agent_end,
+        "has_terminated": has_terminated,
+        "has_prompt_summary": has_prompt_summary,
+        "file_age_s": round(age_s, 1),
+        "stalled": age_s > INACTIVITY_THRESHOLD_S and not has_agent_end and not has_terminated,
+    }
+
+
+def find_latest_jsonl(run_dir: Path) -> Path | None:
+    jsonls = sorted(run_dir.glob("*.jsonl"), key=lambda p: p.stat().st_mtime)
+    return jsonls[-1] if jsonls else None
+
+
+def resolve_session(arg: str) -> Path:
+    if arg.isdigit():
+        return SESSIONS_DIR / f"session-{int(arg):02d}"
+    return SESSIONS_DIR / arg
+
+
+def main():
+    if len(sys.argv) >= 2:
+        session_dir = resolve_session(sys.argv[1])
+    else:
+        sessions = sorted(
+            (d for d in SESSIONS_DIR.iterdir() if d.is_dir() and d.name.startswith("session-")),
+            key=lambda d: d.name,
+        ) if SESSIONS_DIR.exists() else []
+        if not sessions:
+            print("No sessions found.", file=sys.stderr)
+            sys.exit(2)
+        session_dir = sessions[-1]
+
+    runs_dir = session_dir / "runs"
+    if not runs_dir.exists():
+        print(f"No runs directory in {session_dir}", file=sys.stderr)
+        sys.exit(2)
+
+    run_dirs = sorted(d for d in runs_dir.iterdir() if d.is_dir())
+    if not run_dirs:
+        print(f"No run directories in {runs_dir}", file=sys.stderr)
+        sys.exit(2)
+
+    results = {}
+    for run_dir in run_dirs:
+        jsonl = find_latest_jsonl(run_dir)
+        if jsonl:
+            results[run_dir.name] = check_jsonl(jsonl)
+        else:
+            results[run_dir.name] = {
+                "file": None,
+                "lines": 0,
+                "has_agent_end": False,
+                "has_terminated": False,
+                "has_prompt_summary": False,
+                "file_age_s": 0,
+                "stalled": False,
+                "no_log": True,
+            }
+
+    finished = 0
+    stalled = 0
+    in_progress = 0
+    no_log = 0
+
+    print(f"Session: {session_dir.name}")
+    print("=" * 60)
+
+    for name, info in sorted(results.items()):
+        if info.get("no_log"):
+            status = "NO LOG"
+            no_log += 1
+        elif info["has_agent_end"]:
+            status = "DONE"
+            finished += 1
+        elif info["has_terminated"]:
+            status = "TERMINATED"
+            finished += 1
+        elif info["stalled"]:
+            status = f"STALLED (no writes for {info['file_age_s']:.0f}s)"
+            stalled += 1
+        else:
+            status = f"IN PROGRESS (last write {info['file_age_s']:.0f}s ago)"
+            in_progress += 1
+
+        print(f"  {name}: {status}")
+
+    total = len(results)
+    print()
+    print(f"Total: {total}  Done: {finished}  Stalled: {stalled}  In progress: {in_progress}  No log: {no_log}")
+
+    all_done = finished + stalled == total and in_progress == 0 and no_log == 0
+    if all_done:
+        if stalled > 0:
+            print(f"\nAll runs finished but {stalled} stalled — their processes should be killed.")
+        else:
+            print("\nAll runs completed.")
+        sys.exit(0)
+    else:
+        print(f"\n{in_progress + no_log} run(s) still in progress.")
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/benchmark/manual/self-improvement.md
+++ b/benchmark/manual/self-improvement.md
@@ -47,9 +47,22 @@ cd benchmark/manual
 | complex-single | 10 min | 500k | 0 |
 | research | 2 min | 30k | 0–1 |
 
-**Overall timeout:** 30 minutes for all runs combined. If any run is still active after its individual timeout, kill it and record it as a timeout failure.
+**Overall timeout:** 30 minutes for all runs combined.
 
-**Do not proceed to Phase 3 until all runs have completed or timed out.**
+**Completion detection — use log files, not processes:**
+
+Do not rely on OS processes to determine whether runs are done. Harness processes may stay alive while the model is idle. Instead, poll the session logs:
+
+```bash
+python3 check-session.py              # checks the latest session
+python3 check-session.py <session-NN> # checks a specific session
+```
+
+The script inspects each run's `.jsonl` log for terminal events (`agent_end` or `agent_terminated`). It also detects stalled runs — logs that have not been written to for over 3 minutes without a terminal event.
+
+Poll every 60 seconds until the script exits with code 0 (all done) or the 30-minute overall timeout is reached. When a run is reported as STALLED, kill its process — the model is not doing useful work.
+
+**Do not proceed to Phase 3 until `check-session.py` reports all runs as DONE, TERMINATED, or STALLED (with stalled processes killed).**
 
 ---
 
@@ -69,11 +82,18 @@ Review the output for:
 - Unexpected tool call patterns in orchestrator output
 - Terminated sessions (look for `(terminated)` tag)
 
-Write a structured findings summary covering:
-1. What improved vs previous session (with numbers)
-2. What regressed vs previous session (with numbers)
-3. Hard failures and their likely causes
-4. Proposed changes with expected impact
+Write a structured findings summary. Report regressions and failures first — improvements second. For every metric, state the exact before and after values and give a one-word verdict: WORSE, SAME, or BETTER. Do not use softening language ("slightly", "marginally", "only") — state the numbers and let them speak.
+
+**Regressions-first format:**
+
+1. What REGRESSED vs previous session (with exact numbers and percentage)
+2. Hard FAILURES and their root causes
+3. What IMPROVED vs previous session (with exact numbers and percentage)
+4. What stayed the SAME
+5. Honest overall verdict: did this iteration make things better or worse on balance?
+6. Proposed changes with expected impact
+
+**Anti-sycophancy rule:** Do not rationalise regressions as acceptable trade-offs unless you can cite a specific, measurable gain that outweighs the regression by at least 2x. If a change made things worse, say so plainly and propose reverting it. Never omit a regression from the summary — every metric that got worse must appear in section 1 regardless of magnitude.
 
 **Verification requirement:** For each proposed change, you must identify the specific session log evidence that supports it. Do not propose a change based on a single run of a single task. If a finding appears in only one run, mark it as unconfirmed and do not act on it in this iteration.
 
@@ -113,15 +133,27 @@ Write a summary to `benchmark/manual/iterations/iteration-NN.md` (create the dir
 - Pre-change: session-XX
 - Post-change: session-YY
 
+## Regressions (list every metric that got worse — omit nothing)
+- <metric>: <before> → <after> (<+X%>) — root cause: <explanation>
+
+## Failures
+- <task/model>: <failure description> — root cause: <explanation>
+
+## Improvements
+- <metric>: <before> → <after> (<-X%>)
+
+## Unchanged
+- <metric>: <before> → <after> (within noise)
+
+## Overall Verdict
+- BETTER / WORSE / MIXED — one sentence honest summary
+
 ## Findings
 - [confirmed] <finding> — evidence: <run>, metric delta: <X>
 - [unconfirmed] <finding> — insufficient evidence, deferred
 
 ## Changes Applied
 - <file>: <what changed and why>
-
-## Regression Check
-- PASS / FAIL (detail any regressions)
 
 ## Net Impact
 - Token delta: <+/- X%> across all tasks
@@ -131,12 +163,32 @@ Write a summary to `benchmark/manual/iterations/iteration-NN.md` (create the dir
 
 ---
 
+## Stagnation Breaker
+
+If 2 consecutive iterations produce no confirmed findings or no measurable improvement, you are stagnating. Do not stop — instead, shift to creative exploration mode:
+
+1. Re-read the improvement goals (if provided) and the orchestrator/subagent system prompts end to end.
+2. Brainstorm at least 5 non-obvious ideas that could move the needle. Think beyond incremental prompt tweaks — consider structural changes like:
+   - Reordering prompt sections to change what the model sees first
+   - Removing instructions that may be confusing or contradictory
+   - Changing token budget allocation between orchestrator and subagents
+   - Adjusting model selection heuristics or tier assignments
+   - Simplifying complex prompt logic that models may be ignoring
+   - Changing the default behaviour when the model is uncertain
+3. Pick the most promising idea and test it in the next iteration.
+4. If the creative idea also produces no improvement, try a different one from your list — do not repeat the same class of change.
+
+The loop must not close just because incremental changes stopped working. Exhaust creative options before concluding that no further improvement is possible.
+
+---
+
 ## Stopping Conditions
 
 Stop the loop and report final status when any of the following is true:
 
 - 20 iterations completed
 - Total elapsed time exceeds 8 hours
+- At least 3 creative exploration attempts (from the stagnation breaker) have been tried and none produced measurable improvement — in this case, document all attempted ideas and their results before stopping
 
 ---
 


### PR DESCRIPTION
## Summary

The self-improvement loop had three pain points that made it less effective in practice:

- **Overly positive reporting**: The agent would emphasize improvements while downplaying or omitting regressions, making it hard to trust iteration summaries and spot real problems.
- **Premature loop closure**: When incremental changes stopped producing results, the loop would effectively stall instead of exploring creative alternatives to move metrics forward.
- **False "still running" detection**: Benchmark runs were considered active as long as the OS process was alive, even when the model had gone idle — wasting time waiting for stalled sessions.

## What changed

- **Honest analysis**: Iteration summaries now lead with regressions and failures before listing improvements. Every metric that got worse must be reported with exact numbers — no softening language, no omissions.
- **Stagnation breaker**: After 2 stalled iterations, the loop shifts to creative exploration mode — brainstorming structural changes (prompt reordering, budget reallocation, simplification) instead of giving up. The loop cannot close until at least 3 creative ideas have been tried.
- **Log-based completion detection**: A new `check-session.py` script determines run completion by inspecting `.jsonl` session logs for terminal events (`agent_end` / `agent_terminated`) instead of checking OS processes. Runs with no log activity for 3+ minutes are flagged as stalled so their processes can be killed.