### PR TITLE
fix: add kimchi as config into gsd2, instead of overwriting all mode cfg

### DIFF
--- a/src/integrations/gsd2.test.ts
+++ b/src/integrations/gsd2.test.ts
@@ -1,45 +1,43 @@
-import { mkdtempSync, readFileSync, rmSync } from "node:fs"
+import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs"
 import { tmpdir } from "node:os"
 import { join } from "node:path"
 import { afterEach, beforeEach, describe, expect, it } from "vitest"
-import { buildGsd2ModelsConfig, buildGsd2Preferences } from "./gsd2.js"
+import { buildGsd2KimchiProvider, buildGsd2Preferences } from "./gsd2.js"
 import { byId } from "./registry.js"
 
-describe("buildGsd2ModelsConfig", () => {
-	it("nests the kimchi provider under providers.kimchi", () => {
-		const cfg = buildGsd2ModelsConfig("test-key") as {
-			providers: { kimchi: { apiKey: string; baseUrl: string; defaultModel: string } }
+describe("buildGsd2KimchiProvider", () => {
+	it("returns the provider block with apiKey, baseUrl, and defaultModel", () => {
+		const p = buildGsd2KimchiProvider("test-key") as {
+			apiKey: string
+			baseUrl: string
+			defaultModel: string
 		}
-		expect(cfg.providers.kimchi.apiKey).toBe("test-key")
-		expect(cfg.providers.kimchi.baseUrl).toBe("https://llm.kimchi.dev/openai/v1")
-		expect(cfg.providers.kimchi.defaultModel).toBe("kimi-k2.6")
+		expect(p.apiKey).toBe("test-key")
+		expect(p.baseUrl).toBe("https://llm.kimchi.dev/openai/v1")
+		expect(p.defaultModel).toBe("kimi-k2.6")
 	})
 
 	it("emits all six models with cost metadata (Opus/Sonnet billed, kimchi models free)", () => {
-		const cfg = buildGsd2ModelsConfig("k") as {
-			providers: { kimchi: { models: Array<{ id: string; cost: { input: number } }> } }
+		const p = buildGsd2KimchiProvider("k") as {
+			models: Array<{ id: string; cost: { input: number } }>
 		}
-		const models = cfg.providers.kimchi.models
-		expect(models.length).toBe(6)
-		const opus = models.find((m) => m.id === "claude-opus-4-6")
+		expect(p.models.length).toBe(6)
+		const opus = p.models.find((m) => m.id === "claude-opus-4-6")
 		expect(opus?.cost).toEqual({ input: 5, output: 25, cacheRead: 0.5, cacheWrite: 6.25 })
-		const sonnet = models.find((m) => m.id === "claude-sonnet-4-6")
+		const sonnet = p.models.find((m) => m.id === "claude-sonnet-4-6")
 		expect(sonnet?.cost).toEqual({ input: 3, output: 15, cacheRead: 0.3, cacheWrite: 3.75 })
 		for (const slug of ["kimi-k2.6", "kimi-k2.5", "nemotron-3-super-fp4", "minimax-m2.7"]) {
-			const m = models.find((x) => x.id === slug)
+			const m = p.models.find((x) => x.id === slug)
 			expect(m?.cost).toEqual({ input: 0, output: 0, cacheRead: 0, cacheWrite: 0 })
 		}
 	})
 
 	it("Kimi models accept text+image input, others text only", () => {
-		const cfg = buildGsd2ModelsConfig("k") as {
-			providers: { kimchi: { models: Array<{ id: string; input: string[] }> } }
-		}
-		const models = cfg.providers.kimchi.models
-		expect(models.find((m) => m.id === "kimi-k2.6")?.input).toEqual(["text", "image"])
-		expect(models.find((m) => m.id === "kimi-k2.5")?.input).toEqual(["text", "image"])
-		expect(models.find((m) => m.id === "nemotron-3-super-fp4")?.input).toEqual(["text"])
-		expect(models.find((m) => m.id === "claude-opus-4-6")?.input).toEqual(["text"])
+		const p = buildGsd2KimchiProvider("k") as { models: Array<{ id: string; input: string[] }> }
+		expect(p.models.find((m) => m.id === "kimi-k2.6")?.input).toEqual(["text", "image"])
+		expect(p.models.find((m) => m.id === "kimi-k2.5")?.input).toEqual(["text", "image"])
+		expect(p.models.find((m) => m.id === "nemotron-3-super-fp4")?.input).toEqual(["text"])
+		expect(p.models.find((m) => m.id === "claude-opus-4-6")?.input).toEqual(["text"])
 	})
 })
 
@@ -114,5 +112,32 @@ describe("gsd2 tool registration", () => {
 
 		const prefs = readFileSync(join(tmp, ".gsd", "preferences.md"), "utf-8")
 		expect(prefs).toContain("planning: kimchi/claude-opus-4-6")
+	})
+
+	it("write() preserves other providers and top-level keys in models.json", async () => {
+		const modelsPath = join(tmp, ".gsd", "agent", "models.json")
+		mkdirSync(join(tmp, ".gsd", "agent"), { recursive: true })
+		writeFileSync(
+			modelsPath,
+			JSON.stringify({
+				version: 7,
+				providers: {
+					anthropic: { apiKey: "user-anthropic-key", baseUrl: "https://api.anthropic.com" },
+					kimchi: { apiKey: "stale-kimchi-key", legacy: true },
+				},
+			}),
+		)
+
+		const tool = byId("gsd2")
+		await tool?.write("global", "fresh-kimchi-key")
+
+		const models = JSON.parse(readFileSync(modelsPath, "utf-8"))
+		expect(models.version).toBe(7)
+		expect(models.providers.anthropic).toEqual({
+			apiKey: "user-anthropic-key",
+			baseUrl: "https://api.anthropic.com",
+		})
+		expect(models.providers.kimchi.apiKey).toBe("fresh-kimchi-key")
+		expect(models.providers.kimchi.legacy).toBeUndefined()
 	})
 })

--- a/src/integrations/gsd2.ts
+++ b/src/integrations/gsd2.ts
@@ -1,4 +1,4 @@
-import { writeFileAtomic, writeJson } from "../config/json.js"
+import { readJson, writeFileAtomic, writeJson } from "../config/json.js"
 import type { ConfigScope } from "../config/scope.js"
 import { resolveScopePath } from "../config/scope.js"
 import { BASE_URL, PROVIDER_NAME } from "./constants.js"
@@ -36,31 +36,27 @@ const CATALOG: CatalogEntry[] = [
 ]
 
 /**
- * Build the JSON dropped at ~/.gsd/agent/models.json. GSD2 reads this to
- * populate the kimchi provider in its UI. Cost numbers: Opus/Sonnet at
- * sticker price, the free kimchi-internal models at zero so GSD's budget
+ * Build the kimchi provider block for ~/.gsd/agent/models.json. GSD2 reads
+ * this to populate the kimchi provider in its UI. Cost numbers: Opus/Sonnet
+ * at sticker price, the free kimchi-internal models at zero so GSD's budget
  * tracker doesn't double-charge.
  */
-export function buildGsd2ModelsConfig(apiKey: string): Record<string, unknown> {
+export function buildGsd2KimchiProvider(apiKey: string): Record<string, unknown> {
 	return {
-		providers: {
-			kimchi: {
-				name: "Kimchi",
-				baseUrl: BASE_URL,
-				apiKey,
-				api: "openai-completions",
-				defaultModel: MAIN_MODEL.slug,
-				models: CATALOG.map(({ model, input, cost }) => ({
-					id: model.slug,
-					name: model.displayName,
-					contextWindow: model.limits.contextWindow,
-					maxTokens: model.limits.maxOutputTokens,
-					reasoning: model.reasoning,
-					input,
-					cost,
-				})),
-			},
-		},
+		name: "Kimchi",
+		baseUrl: BASE_URL,
+		apiKey,
+		api: "openai-completions",
+		defaultModel: MAIN_MODEL.slug,
+		models: CATALOG.map(({ model, input, cost }) => ({
+			id: model.slug,
+			name: model.displayName,
+			contextWindow: model.limits.contextWindow,
+			maxTokens: model.limits.maxOutputTokens,
+			reasoning: model.reasoning,
+			input,
+			cost,
+		})),
 	}
 }
 
@@ -110,7 +106,14 @@ async function writeGsd2(scope: ConfigScope, apiKey: string): Promise<void> {
 		throw new Error("API key not configured")
 	}
 	const modelsPath = resolveScopePath(scope, GSD_MODELS_PATH)
-	writeJson(modelsPath, buildGsd2ModelsConfig(apiKey))
+	const existing = readJson(modelsPath)
+	const providers =
+		existing.providers && typeof existing.providers === "object" && !Array.isArray(existing.providers)
+			? (existing.providers as Record<string, unknown>)
+			: {}
+	providers.kimchi = buildGsd2KimchiProvider(apiKey)
+	existing.providers = providers
+	writeJson(modelsPath, existing)
 
 	const prefsPath = resolveScopePath(scope, GSD_PREFERENCES_PATH)
 	writeFileAtomic(prefsPath, buildGsd2Preferences())


### PR DESCRIPTION


---
### Kimchi Summary
### What changed
Fixes GSD2 integration to merge Kimchi provider configuration into existing `models.json` instead of overwriting the entire file. Prevents accidental deletion of other provider settings (e.g., Anthropic) when configuring Kimchi.

### Why
Previously, running the GSD2 setup tool would wipe any existing providers and top-level metadata from the user's `~/.gsd/agent/models.json`. This caused data loss for users who had other LLM providers configured.

### Key changes
- **`src/integrations/gsd2.ts`**: 
  - Renamed `buildGsd2ModelsConfig` to `buildGsd2KimchiProvider`; now returns the provider block directly instead of the full config structure
  - Modified `writeGsd2` to read existing JSON via `readJson`, merge the Kimchi provider into the existing `providers` object, and preserve other top-level keys (like `version`)
- **`src/integrations/gsd2.test.ts`**: 
  - Updated existing tests to reflect the renamed function and new return structure
  - Added test case verifying that `write()` preserves other providers and top-level keys in `models.json`