### PR TITLE
NOJIRA: Add factual accuracy and tool discovery guidelines to system prompts

### DIFF
--- a/src/extensions/orchestration/prompt-transformer/prompts/orchestrator-system-prompt.ts
+++ b/src/extensions/orchestration/prompt-transformer/prompts/orchestrator-system-prompt.ts
@@ -1,4 +1,13 @@
-import { CORE_GUIDELINES, DOCUMENTS_SECTION, FOOTER, PHASE_TAGGING, RESEARCH_RULES, TOOLS_SECTION } from "./shared.js"
+import {
+	CORE_GUIDELINES,
+	DOCUMENTS_SECTION,
+	FACTUAL_ACCURACY,
+	FOOTER,
+	PHASE_TAGGING,
+	RESEARCH_RULES,
+	TOOLS_SECTION,
+	TOOL_DISCOVERY,
+} from "./shared.js"
 
 export default [
 	`You are an expert coding assistant. Your available tools are listed under **Available Tools** below — use only those, never guess or invent tool names. You can also spawn subagents when delegation is more appropriate than doing the work yourself.
@@ -88,6 +97,8 @@ By default subagents are killed after 3 minutes of silence. Heavy-tier models (c
 	TOOLS_SECTION,
 	DOCUMENTS_SECTION,
 	RESEARCH_RULES,
+	FACTUAL_ACCURACY,
+	TOOL_DISCOVERY,
 	`## Guidelines
 
 ${CORE_GUIDELINES}

--- a/src/extensions/orchestration/prompt-transformer/prompts/shared.ts
+++ b/src/extensions/orchestration/prompt-transformer/prompts/shared.ts
@@ -43,6 +43,18 @@ You must call \`set_phase\` before every block of work. Never take an action wit
 
 The session starts in \`explore\` phase by default. Call \`set_phase\` immediately when your work type changes. Only one phase is active at a time — the most recent call wins.`
 
+export const FACTUAL_ACCURACY = `## Factual Accuracy
+
+- **Never guess, assume, or fabricate information.** Every claim you make must be backed by data you concretely obtained during this session — from tool results, file contents, search results, or user messages. If you cannot access a resource (e.g. a URL returns a login page, a file does not exist, a tool call fails), say explicitly that the information is unavailable. Do not reconstruct, infer, or hypothesize what it might contain based on indirect signals such as branch names, file names, code patterns, or your training data.
+- **"I don't know" is a valid answer.** When requirements, specifications, or factual details are not available through your tools or the user's messages, state that clearly and ask the user to provide them. Do not fill the gap with plausible-sounding content.
+- **Distinguish what you found from what you assume.** If you must reason about something uncertain, label it explicitly as an assumption and ask the user to confirm before acting on it.`
+
+export const TOOL_DISCOVERY = `## Tool and MCP Discovery
+
+- Before resorting to web search, web fetch, or giving up on accessing external data, **check your Available Tools list for a more direct way to get the information.** MCP (Model Context Protocol) integrations often provide authenticated access to services like Jira, Confluence, GitHub, GitLab, and others that are inaccessible via unauthenticated web requests.
+- If you see an \`mcp\` tool in your tool list, use \`mcp({ search: "query" })\` to discover what MCP servers and tools are available before assuming you have no way to access a service.
+- Prefer MCP tools over web_fetch for any service that requires authentication (Jira, Confluence, internal wikis, etc.). MCP tools already have credentials configured.`
+
 export const FOOTER = `{{PROJECT_CONTEXT}}
 
 {{SKILLS}}`

--- a/src/extensions/orchestration/prompt-transformer/prompts/shared.ts
+++ b/src/extensions/orchestration/prompt-transformer/prompts/shared.ts
@@ -45,7 +45,7 @@ The session starts in \`explore\` phase by default. Call \`set_phase\` immediate
 
 export const FACTUAL_ACCURACY = `## Factual Accuracy
 
-- **Never guess, assume, or fabricate information.** Every claim you make must be backed by data you concretely obtained during this session — from tool results, file contents, search results, or user messages. If you cannot access a resource (e.g. a URL returns a login page, a file does not exist, a tool call fails), say explicitly that the information is unavailable. Do not reconstruct, infer, or hypothesize what it might contain based on indirect signals such as branch names, file names, code patterns, or your training data.
+- **Never guess, assume, or fabricate information.** Every claim you make must be backed by data you concretely obtained during this session … Do not reconstruct, infer, or hypothesize what it might contain based on indirect signals such as branch names, file names, code patterns, or your training data. If you need to reference a specific person, reviewer, code owner, file, tool name, or other concrete detail and it is not explicitly present in your context, use generic language or ask the user. Never fabricate names, IDs, paths, or other specifics.
 - **"I don't know" is a valid answer.** When requirements, specifications, or factual details are not available through your tools or the user's messages, state that clearly and ask the user to provide them. Do not fill the gap with plausible-sounding content.
 - **Distinguish what you found from what you assume.** If you must reason about something uncertain, label it explicitly as an assumption and ask the user to confirm before acting on it.`
 

--- a/src/extensions/orchestration/prompt-transformer/prompts/single-model-system-prompt.ts
+++ b/src/extensions/orchestration/prompt-transformer/prompts/single-model-system-prompt.ts
@@ -1,4 +1,13 @@
-import { CORE_GUIDELINES, DOCUMENTS_SECTION, FOOTER, PHASE_TAGGING, RESEARCH_RULES, TOOLS_SECTION } from "./shared.js"
+import {
+	CORE_GUIDELINES,
+	DOCUMENTS_SECTION,
+	FACTUAL_ACCURACY,
+	FOOTER,
+	PHASE_TAGGING,
+	RESEARCH_RULES,
+	TOOLS_SECTION,
+	TOOL_DISCOVERY,
+} from "./shared.js"
 
 export default [
 	`You are an expert coding assistant. Your available tools are listed under **Available Tools** below — use only those, never guess or invent tool names.
@@ -7,6 +16,8 @@ export default [
 	TOOLS_SECTION,
 	DOCUMENTS_SECTION,
 	RESEARCH_RULES,
+	FACTUAL_ACCURACY,
+	TOOL_DISCOVERY,
 	`## Guidelines
 
 ${CORE_GUIDELINES}`,

--- a/src/extensions/orchestration/prompt-transformer/prompts/subagent-system-prompt.ts
+++ b/src/extensions/orchestration/prompt-transformer/prompts/subagent-system-prompt.ts
@@ -1,4 +1,12 @@
-import { CORE_GUIDELINES, DOCUMENTS_SECTION, FOOTER, SUBAGENT_RESPONSE_PROTOCOL, TOOLS_SECTION } from "./shared.js"
+import {
+	CORE_GUIDELINES,
+	DOCUMENTS_SECTION,
+	FACTUAL_ACCURACY,
+	FOOTER,
+	SUBAGENT_RESPONSE_PROTOCOL,
+	TOOLS_SECTION,
+	TOOL_DISCOVERY,
+} from "./shared.js"
 
 export default [
 	`You are an expert coding assistant. You operate inside a coding agent harness. Use only the tools listed under **Available Tools** below — never guess or invent tool names.
@@ -7,6 +15,8 @@ export default [
 	TOOLS_SECTION,
 	DOCUMENTS_SECTION,
 	SUBAGENT_RESPONSE_PROTOCOL,
+	FACTUAL_ACCURACY,
+	TOOL_DISCOVERY,
 	`## Guidelines
 
 ${CORE_GUIDELINES}


### PR DESCRIPTION
This PR adds two new guideline sections to all system prompts:

## Changes

### 1. Factual Accuracy Guidelines (FACTUAL_ACCURACY)
Added new section emphasizing:
- Never guess, assume, or fabricate information
- I do not know is a valid answer
- Distinguish findings from assumptions

### 2. Tool and MCP Discovery Guidelines (TOOL_DISCOVERY)
Added new section instructing agents to:
- Check Available Tools list before web search/fetch
- Use mcp({ search: ... }) to discover MCP servers/tools
- Prefer MCP tools over web_fetch for authenticated services

## Files Modified
- src/extensions/orchestration/prompt-transformer/prompts/shared.ts - Added new exported constants
- src/extensions/orchestration/prompt-transformer/prompts/orchestrator-system-prompt.ts - Integrated new sections
- src/extensions/orchestration/prompt-transformer/prompts/single-model-system-prompt.ts - Integrated new sections
- src/extensions/orchestration/prompt-transformer/prompts/subagent-system-prompt.ts - Integrated new sections

---
### Kimchi Summary
### What changed
Adds explicit factual accuracy and tool discovery guidelines to all system prompts (orchestrator, single-model, and subagent) to prevent hallucinations and improve MCP tool utilization.

### Why
Prevents the AI from fabricating names, IDs, or specifications when concrete data is unavailable. Directs agents to leverage available MCP tools and authenticated integrations before resorting to web searches or giving up.

### Key changes
- **`shared.ts`**: Added `FACTUAL_ACCURACY` section requiring concrete data verification, explicitly allowing "I don't know" responses, and prohibiting reconstruction of information from indirect signals; added `TOOL_DISCOVERY` section instructing agents to check `Available Tools` and use `mcp({ search: "query" })` before web searches
- **`orchestrator-system-prompt.ts`**, **`single-model-system-prompt.ts`**, **`subagent-system-prompt.ts`**: Imported and inserted `FACTUAL_ACCURACY` and `TOOL_DISCOVERY` sections into the prompt arrays

### Impact
Improved response accuracy across all agent types with reduced hallucination of specific names, paths, or technical details. Agents will now prefer authenticated MCP tools (Jira, Confluence, GitHub, etc.) over unauthenticated web requests.