### PR TITLE
feat: add hallucination-prevention guideline to system prompts

### DIFF
--- a/src/extensions/orchestration/prompt-transformer/prompt-transformer.test.ts
+++ b/src/extensions/orchestration/prompt-transformer/prompt-transformer.test.ts
@@ -137,6 +137,11 @@ describe("buildOrchestratorSystemPrompt", () => {
 		expect(result).toContain("delegate")
 	})
 
+	it("includes the hallucination-prevention guideline", () => {
+		const result = buildOrchestratorSystemPrompt(tools, testEnv)
+		expect(result).toContain("Do not hallucinate missing facts")
+	})
+
 	it("replaces the {{TOOLS}} placeholder", () => {
 		const result = buildOrchestratorSystemPrompt(tools, testEnv)
 		expect(result).not.toContain("{{TOOLS}}")

--- a/src/extensions/orchestration/prompt-transformer/prompts/shared.ts
+++ b/src/extensions/orchestration/prompt-transformer/prompts/shared.ts
@@ -16,6 +16,7 @@ export const CORE_GUIDELINES = `- Be concise in your responses. Do not restate w
 - Prefer editing existing files over creating new ones.
 - Do NOT introduce security vulnerabilities.
 - Do NOT add features, refactoring, or improvements beyond what was asked.
+- **Do not hallucinate missing facts.** If you need to reference a specific person, file, tool name, or other concrete detail and it is not explicitly present in your context (tool results, files read, or user input), use generic language or ask the user. Never fabricate names, IDs, paths, or other specifics.
 - If you encounter an error, diagnose the root cause before retrying.
 - **Pattern recognition**: If the same implementation pattern is needed more than twice, define the abstraction first, then implement.
 - **Git commits**: Always end every commit message with a blank line followed by \`Co-Authored-By: Kimchi <noreply@kimchi.dev>\`.`


### PR DESCRIPTION
Adds a guard-rail instructing the model never to fabricate names, IDs, paths, or other specifics not explicitly present in context. This prevents LLM hallucinations like inventing reviewer names when PR metadata contains no human reviewer.

LLM-1533

---
### Kimchi Summary
### What changed
Added an anti-hallucination guideline to the orchestrator system prompt that instructs the LLM to use generic language or ask the user when specific details (names, IDs, paths) are not explicitly present in context, rather than fabricating them.

### Why
Prevents the model from inventing concrete facts such as file paths, tool names, or identifiers when they are missing from the available context (tool results, files read, or user input), improving accuracy and trustworthiness.

### Key changes
- Added `**Do not hallucinate missing facts.**` instruction to `CORE_GUIDELINES` in `src/extensions/orchestration/prompt-transformer/prompts/shared.ts`
- Added test case in `src/extensions/orchestration/prompt-transformer/prompt-transformer.test.ts` verifying that `buildOrchestratorSystemPrompt` includes the hallucination-prevention guideline