### PR TITLE
LLM-1436: Parse compound shell commands and prompt per subcommand

### DIFF
--- a/src/extensions/permissions/index.test.ts
+++ b/src/extensions/permissions/index.test.ts
@@ -428,3 +428,30 @@ describe("handleCompoundConfirm", () => {
 		expect(result).toEqual({ block: true, reason: "Declined by user" })
 	})
 })
+
+describe("compound command auto-mode fall-through", () => {
+	it("read-only compound returns prompt from checkCompoundCommand so auto-mode can approve it", () => {
+		// The early gate in the handler ONLY short-circuits on allow/deny;
+		// "prompt" falls through to evaluateRules → auto-mode → classifier.
+		// For ls && pwd, isReadOnlyBashCommand returns true, so auto-mode
+		// silently approves it. checkCompoundCommand must NOT block it.
+		const result = checkCompoundCommand("ls && pwd", [])
+		expect(result.decision).toBe("prompt")
+		expect(result.subcommands).toEqual(["ls", "pwd"])
+	})
+
+	it("hard-blocked compound is denied by the early gate (not auto-mode)", () => {
+		const result = checkCompoundCommand("sudo whoami && ls", [])
+		expect(result.decision).toBe("deny")
+		expect(result.deniedReason).toContain("Hard-blocked")
+	})
+
+	it("explicitly-allowed compound is allowed by the early gate (no auto-mode needed)", () => {
+		const rules: Rule[] = [
+			{ toolName: "bash", content: "ls *", behavior: "allow", source: "session" },
+			{ toolName: "bash", content: "pwd", behavior: "allow", source: "session" },
+		]
+		const result = checkCompoundCommand("ls -la && pwd", rules)
+		expect(result.decision).toBe("allow")
+	})
+})

--- a/src/extensions/permissions/index.test.ts
+++ b/src/extensions/permissions/index.test.ts
@@ -1,0 +1,430 @@
+import type { ExtensionContext, ToolCallEvent } from "@earendil-works/pi-coding-agent"
+import { beforeEach, describe, expect, it, vi } from "vitest"
+import { checkCompoundCommand, handleCompoundConfirm } from "./index.js"
+import { SessionMemory } from "./session-memory.js"
+import type { Rule } from "./types.js"
+
+// Helper to create mock ExtensionContext with ui.select
+// When an AbortSignal is passed and aborted=true, returns undefined to trigger "aborted" outcome
+function createMockContext(
+	selectResults: (string | undefined)[],
+	opts?: { abortOnFirstSelect?: boolean },
+): ExtensionContext {
+	let callIndex = 0
+	return {
+		hasUI: true,
+		cwd: "/test",
+		ui: {
+			select: vi.fn(async (_: string, __: string[], selectOpts?: { signal?: AbortSignal }) => {
+				// If signal is aborted when select is called, return undefined to trigger "aborted" outcome
+				if (selectOpts?.signal?.aborted) {
+					return undefined
+				}
+				const result = selectResults[callIndex]
+				callIndex++
+				return result
+			}),
+			input: vi.fn(async () => ""),
+			notify: vi.fn(),
+			setStatus: vi.fn(),
+			theme: {
+				fg: vi.fn((_, s) => s),
+			},
+			onTerminalInput: vi.fn(() => () => {}),
+		},
+	} as unknown as ExtensionContext
+}
+
+// Helper to create a mock tool call event
+function createMockEvent(): ToolCallEvent {
+	return {
+		toolName: "bash",
+		input: { command: "echo a && echo b" },
+		cwd: "/test",
+	} as unknown as ToolCallEvent
+}
+
+describe("checkCompoundCommand", () => {
+	it("returns prompt for compound command with no rules", () => {
+		const result = checkCompoundCommand('echo "hello" && whoami', [])
+		expect(result.decision).toBe("prompt")
+		expect(result.subcommands).toEqual(["echo hello", "whoami"])
+	})
+
+	it("returns deny when subcommand matches deny rule", () => {
+		const rules: Rule[] = [{ toolName: "bash", content: "ps *", behavior: "deny", source: "session" }]
+		const result = checkCompoundCommand('echo "before" && ps aux && echo "after"', rules)
+		expect(result.decision).toBe("deny")
+		expect(result.deniedReason).toContain("ps aux")
+	})
+
+	it("returns allow when all subcommands match allow rules", () => {
+		const rules: Rule[] = [
+			{ toolName: "bash", content: "echo *", behavior: "allow", source: "session" },
+			{ toolName: "bash", content: "whoami *", behavior: "allow", source: "session" },
+		]
+		const result = checkCompoundCommand('echo "test" && whoami', rules)
+		expect(result.decision).toBe("allow")
+	})
+
+	it("returns prompt when some subcommands lack rules", () => {
+		const rules: Rule[] = [{ toolName: "bash", content: "echo *", behavior: "allow", source: "session" }]
+		const result = checkCompoundCommand('echo "test" && whoami', rules)
+		expect(result.decision).toBe("prompt")
+		expect(result.subcommands).toEqual(["echo test", "whoami"])
+	})
+
+	it("splits on &&, ||, and ;", () => {
+		const result = checkCompoundCommand("echo a || echo b ; echo c && echo d", [])
+		expect(result.subcommands).toEqual(["echo a", "echo b", "echo c", "echo d"])
+	})
+
+	it("keeps pipes inside segments", () => {
+		const result = checkCompoundCommand("echo a && cat file | grep x", [])
+		expect(result.decision).toBe("prompt")
+		expect(result.subcommands).toEqual(["echo a", "cat file | grep x"])
+	})
+
+	it("returns deny for hard-blocked program in subcommand", () => {
+		const result = checkCompoundCommand('echo "start" && sudo whoami', [])
+		expect(result.decision).toBe("deny")
+		expect(result.deniedReason).toContain("Hard-blocked")
+	})
+
+	it("handles non-compound commands", () => {
+		const result = checkCompoundCommand("echo hello", [])
+		expect(result.decision).toBe("prompt")
+		expect(result.subcommands).toBeUndefined()
+	})
+})
+
+describe("compound command with session rules", () => {
+	let session: SessionMemory
+
+	beforeEach(() => {
+		session = new SessionMemory()
+		session.clear()
+	})
+
+	it("session rules are checked correctly", () => {
+		session.add({
+			toolName: "bash",
+			content: "echo *",
+			behavior: "allow",
+			source: "session",
+		})
+
+		const rules = session.all()
+		const result = checkCompoundCommand('echo "test" && whoami', rules)
+
+		expect(result.decision).toBe("prompt")
+		expect(result.subcommands).toContain("echo test")
+		expect(result.subcommands).toContain("whoami")
+	})
+
+	it("all allowed subcommands result in allow decision", () => {
+		session.add({
+			toolName: "bash",
+			content: "echo *",
+			behavior: "allow",
+			source: "session",
+		})
+		session.add({
+			toolName: "bash",
+			content: "whoami *",
+			behavior: "allow",
+			source: "session",
+		})
+
+		const result = checkCompoundCommand('echo "test" && whoami', session.all())
+		expect(result.decision).toBe("allow")
+	})
+
+	it("deny rule takes precedence over allows", () => {
+		session.add({
+			toolName: "bash",
+			content: "echo *",
+			behavior: "allow",
+			source: "session",
+		})
+		session.add({
+			toolName: "bash",
+			content: "ps *",
+			behavior: "deny",
+			source: "session",
+		})
+
+		const result = checkCompoundCommand('echo "test" && ps aux', session.all())
+		expect(result.decision).toBe("deny")
+	})
+
+	it("complex compound with mixed operators", () => {
+		session.add({ toolName: "bash", content: "echo *", behavior: "allow", source: "session" })
+		session.add({ toolName: "bash", content: "whoami *", behavior: "allow", source: "session" })
+		session.add({ toolName: "bash", content: "pwd *", behavior: "allow", source: "session" })
+
+		const result = checkCompoundCommand("echo a || whoami ; pwd", session.all())
+		expect(result.decision).toBe("allow")
+	})
+})
+
+describe("handleCompoundConfirm", () => {
+	let session: SessionMemory
+	let activeAborts: Set<AbortController>
+
+	beforeEach(() => {
+		session = new SessionMemory()
+		session.clear()
+		activeAborts = new Set()
+	})
+
+	it("returns undefined for allow-all-once", async () => {
+		const ctx = createMockContext(["Run all (once)"])
+		const event = createMockEvent()
+
+		const result = await handleCompoundConfirm(event, {
+			ctx,
+			session,
+			activeAborts,
+			subcommands: ["echo a", "echo b"],
+		})
+
+		expect(result).toBeUndefined()
+	})
+
+	it("adds wildcard rules to session for allow-all-remember", async () => {
+		const ctx = createMockContext(["Allow all from now on"])
+		const event = createMockEvent()
+
+		const result = await handleCompoundConfirm(event, {
+			ctx,
+			session,
+			activeAborts,
+			subcommands: ["echo a", "whoami"],
+		})
+
+		expect(result).toBeUndefined()
+		expect(session.all()).toHaveLength(2)
+		expect(session.all()[0].content).toBe("echo *")
+		expect(session.all()[1].content).toBe("whoami *")
+	})
+
+	it("inputs feedback for deny-with-feedback", async () => {
+		const ctx = createMockContext(["No — tell the assistant what to do differently"])
+		ctx.ui.input = vi.fn(async () => "Changed my mind")
+		const event = createMockEvent()
+
+		const result = await handleCompoundConfirm(event, {
+			ctx,
+			session,
+			activeAborts,
+			subcommands: ["echo a"],
+		})
+
+		expect(result).toEqual({ block: true, reason: "Changed my mind" })
+	})
+
+	it("returns block with feedback for deny-with-feedback", async () => {
+		const ctx = createMockContext(["No — tell the assistant what to do differently", ""])
+		ctx.ui.input = vi.fn(async () => "Use individual commands instead")
+		const event = createMockEvent()
+
+		const result = await handleCompoundConfirm(event, {
+			ctx,
+			session,
+			activeAborts,
+			subcommands: ["echo a", "echo b"],
+		})
+
+		expect(result).toEqual({ block: true, reason: "Use individual commands instead" })
+	})
+
+	it("returns block with default reason when deny-with-feedback is empty", async () => {
+		const ctx = createMockContext(["No — tell the assistant what to do differently", ""])
+		ctx.ui.input = vi.fn(async () => "")
+		const event = createMockEvent()
+
+		const result = await handleCompoundConfirm(event, {
+			ctx,
+			session,
+			activeAborts,
+			subcommands: ["echo a", "echo b"],
+		})
+
+		expect(result).toEqual({ block: true, reason: "Declined by user" })
+	})
+
+	it("returns undefined for pick-per-subcommand when all subcommands already allowed", async () => {
+		// Pre-add rules so all subcommands are allowed
+		session.add({ toolName: "bash", content: "echo *", behavior: "allow", source: "session" })
+		session.add({ toolName: "bash", content: "whoami *", behavior: "allow", source: "session" })
+
+		const ctx = createMockContext(["Pick permissions per subcommand"])
+		const event = createMockEvent()
+
+		const result = await handleCompoundConfirm(event, {
+			ctx,
+			session,
+			activeAborts,
+			subcommands: ["echo a", "whoami"],
+		})
+
+		expect(result).toBeUndefined()
+		// No subcommand prompts should have been shown
+		expect(ctx.ui.select).toHaveBeenCalledTimes(1)
+	})
+
+	it("returns undefined for pick-per-subcommand when user approves each subcommand", async () => {
+		const ctx = createMockContext(["Pick permissions per subcommand", "Yes — just this call", "Yes — just this call"])
+		const event = createMockEvent()
+
+		const result = await handleCompoundConfirm(event, {
+			ctx,
+			session,
+			activeAborts,
+			subcommands: ["echo a", "whoami"],
+		})
+
+		expect(result).toBeUndefined()
+		expect(ctx.ui.select).toHaveBeenCalledTimes(3) // compound prompt + 2 subcommand prompts
+	})
+
+	it("returns block when user denies a subcommand in pick-per-subcommand mode", async () => {
+		const ctx = createMockContext(["Pick permissions per subcommand", "No — tell the assistant what to do differently"])
+		ctx.ui.input = vi.fn(async () => "Please use echo separately")
+		const event = createMockEvent()
+
+		const result = await handleCompoundConfirm(event, {
+			ctx,
+			session,
+			activeAborts,
+			subcommands: ["echo a", "whoami"],
+		})
+
+		expect(result).toEqual({ block: true, reason: "Please use echo separately" })
+	})
+
+	it("returns block when subcommand prompt returns undefined in pick-per-subcommand mode", async () => {
+		// When select returns undefined, falls through to deny behavior
+		const ctx = createMockContext([
+			"Pick permissions per subcommand",
+			"Yes — just this call", // Approve first subcommand
+			undefined, // Second subcommand prompt returns undefined
+		])
+		const event = createMockEvent()
+
+		const result = await handleCompoundConfirm(event, {
+			ctx,
+			session,
+			activeAborts,
+			subcommands: ["echo a", "whoami"],
+		})
+
+		expect(result).toEqual({ block: true, reason: "Declined by user" })
+	})
+
+	it("returns undefined for empty subcommands array with allow-all-once", async () => {
+		const ctx = createMockContext(["Run all (once)"])
+		const event = createMockEvent()
+
+		const result = await handleCompoundConfirm(event, {
+			ctx,
+			session,
+			activeAborts,
+			subcommands: [],
+		})
+
+		expect(result).toBeUndefined()
+		// Empty array still prompts but with no subcommands listed
+		expect(ctx.ui.select).toHaveBeenCalledTimes(1)
+	})
+
+	it("returns undefined for single subcommand with allow-all-once", async () => {
+		const ctx = createMockContext(["Run all (once)"])
+		const event = createMockEvent()
+
+		const result = await handleCompoundConfirm(event, {
+			ctx,
+			session,
+			activeAborts,
+			subcommands: ["echo hello"],
+		})
+
+		expect(result).toBeUndefined()
+		expect(ctx.ui.select).toHaveBeenCalledTimes(1)
+	})
+
+	it("returns block when a subcommand matches deny rule in pick-per-subcommand mode", async () => {
+		session.add({ toolName: "bash", content: "whoami *", behavior: "allow", source: "session" })
+		// Add deny rule for echo
+		session.add({ toolName: "bash", content: "echo *", behavior: "deny", source: "session" })
+
+		const ctx = createMockContext(["Pick permissions per subcommand"])
+		const event = createMockEvent()
+
+		const result = await handleCompoundConfirm(event, {
+			ctx,
+			session,
+			activeAborts,
+			subcommands: ["echo a", "whoami"],
+		})
+
+		expect(result).toEqual({ block: true, reason: "Subcommand blocked by rule: echo a" })
+	})
+
+	it("remembers subcommand permission in pick-per-subcommand mode", async () => {
+		// No pre-existing rules - both subcommands need approval
+		// The label for bash subcommands is "bash(command)" via recommendScope
+		// We use assert to dynamically check what label the implementation uses
+		const mockSelect = vi.fn()
+		let yesRememberLabel = ""
+		mockSelect.mockImplementation(async (_title: string, choices: string[]) => {
+			// Find the "Yes — don't ask again" choice that matches
+			yesRememberLabel = choices.find((c) => c.includes("don't ask again")) || ""
+			if (mockSelect.mock.calls.length === 1) return "Pick permissions per subcommand"
+			if (mockSelect.mock.calls.length === 2) return "Yes — just this call" // First subcommand
+			return yesRememberLabel // Second subcommand - remember it
+		})
+
+		const ctx = {
+			hasUI: true,
+			cwd: "/test",
+			ui: {
+				select: mockSelect,
+				input: vi.fn(async () => ""),
+				notify: vi.fn(),
+				setStatus: vi.fn(),
+				theme: { fg: vi.fn((_, s) => s) },
+				onTerminalInput: vi.fn(() => () => {}),
+			},
+		} as unknown as ExtensionContext
+
+		const event = createMockEvent()
+
+		const result = await handleCompoundConfirm(event, {
+			ctx,
+			session,
+			activeAborts,
+			subcommands: ["echo hello", "whoami"],
+		})
+
+		expect(result).toBeUndefined()
+		// Should have added a session rule for whoami
+		expect(session.all().length).toBeGreaterThanOrEqual(1)
+	})
+
+	it("returns block with default reason for unrecognized choice", async () => {
+		// Mock returns an unrecognized choice
+		const ctx = createMockContext(["Unknown choice"])
+		const event = createMockEvent()
+
+		const result = await handleCompoundConfirm(event, {
+			ctx,
+			session,
+			activeAborts,
+			subcommands: ["echo a"],
+		})
+
+		expect(result).toEqual({ block: true, reason: "Declined by user" })
+	})
+})

--- a/src/extensions/permissions/index.ts
+++ b/src/extensions/permissions/index.ts
@@ -305,28 +305,20 @@ export default function permissionsExtension(pi: ExtensionAPI): void {
 
 			if (BUILTIN_ALLOW_TOOL_NAMES.includes(toolName)) return undefined
 
-			// Check for compound bash commands FIRST (before general rule evaluation)
-			// Compound commands should not match individual subcommand rules
+			// Compound bash commands: early gate for deny/allow only.
+			// If the check returns "prompt", fall through to
+			// evaluateRules → auto-mode/classifier → prompt site below.
 			if (toolName === "bash") {
 				const command = typeof input.command === "string" ? input.command : ""
-				const compoundCheck = checkCompoundCommand(command, allRules())
-				if (compoundCheck.decision === "deny") {
-					return { block: true, reason: compoundCheck.deniedReason ?? "Subcommand denied" }
-				}
-				if (compoundCheck.decision === "allow") {
-					return undefined
-				}
-
-				if (compoundCheck.decision === "prompt" && compoundCheck.subcommands) {
-					// Go to compound confirm flow
-					const result = await handleCompoundConfirm(event, {
-						ctx,
-						session,
-						activeAborts: activeAbortControllers,
-						subcommands: compoundCheck.subcommands,
-					})
-					if (result === "aborted") continue
-					return result
+				if (isCompoundCommand(command)) {
+					const compoundCheck = checkCompoundCommand(command, allRules())
+					if (compoundCheck.decision === "deny") {
+						return { block: true, reason: compoundCheck.deniedReason ?? "Subcommand denied" }
+					}
+					if (compoundCheck.decision === "allow") {
+						return undefined
+					}
+					// "prompt" → fall through to existing flow
 				}
 			}
 
@@ -368,12 +360,31 @@ export default function permissionsExtension(pi: ExtensionAPI): void {
 					subtitle: `Classifier: ${verdict.reason}`,
 					session,
 					activeAborts: activeAbortControllers,
+					allRules,
 				})
 				if (result === "aborted") continue // mode changed, re-evaluate
 				return result
 			}
 
-			const result = await handleConfirm(event, { ctx, session, activeAborts: activeAbortControllers })
+			// Prompt site — branch to compound or single-command flow
+			if (toolName === "bash") {
+				const command = typeof input.command === "string" ? input.command : ""
+				if (isCompoundCommand(command)) {
+					const subcommands = splitCompoundCommand(command)
+					if (subcommands && subcommands.length > 0) {
+						const result = await handleCompoundConfirm(event, {
+							ctx,
+							session,
+							activeAborts: activeAbortControllers,
+							subcommands,
+							allRules,
+						})
+						if (result === "aborted") continue // mode changed, re-evaluate
+						return result
+					}
+				}
+			}
+			const result = await handleConfirm(event, { ctx, session, activeAborts: activeAbortControllers, allRules })
 			if (result === "aborted") continue // mode changed, re-evaluate
 			return result
 		}
@@ -409,6 +420,7 @@ interface ConfirmOptions {
 	session: SessionMemory
 	subtitle?: string
 	activeAborts: Set<AbortController>
+	allRules?: () => Rule[]
 }
 
 async function handleConfirm(
@@ -478,7 +490,9 @@ export async function handleCompoundConfirm(
 			// For each subcommand, evaluate rules and prompt if needed
 			for (const subcommand of opts.subcommands) {
 				// Re-evaluate rules (user may have added rules during the prompt)
-				const match = evaluateRules(opts.session.all(), "bash", { command: subcommand })
+				const match = evaluateRules(opts.allRules ? opts.allRules() : opts.session.all(), "bash", {
+					command: subcommand,
+				})
 				if (match.decision === "allow") {
 					continue
 				}

--- a/src/extensions/permissions/index.ts
+++ b/src/extensions/permissions/index.ts
@@ -445,7 +445,7 @@ async function handleConfirm(
 	}
 }
 
-async function handleCompoundConfirm(
+export async function handleCompoundConfirm(
 	event: ToolCallEvent,
 	opts: ConfirmOptions & { subcommands: string[] },
 ): Promise<{ block: true; reason: string } | "aborted" | undefined> {
@@ -536,8 +536,9 @@ interface CompoundCheckResult {
 
 /**
  * Check if a compound bash command can be allowed, denied, or needs prompting.
+ * Exported for testing.
  */
-function checkCompoundCommand(command: string, rules: Rule[]): CompoundCheckResult {
+export function checkCompoundCommand(command: string, rules: Rule[]): CompoundCheckResult {
 	// First check for hard-blocked programs
 	if (isHardBlockedBash(command)) {
 		return { decision: "deny", deniedReason: `Hard-blocked program in command: ${command}` }

--- a/src/extensions/permissions/index.ts
+++ b/src/extensions/permissions/index.ts
@@ -7,11 +7,17 @@ import { classifyToolCall } from "./classifier.js"
 import { registerCommands } from "./commands.js"
 import { type LoadedConfig, loadConfig } from "./config.js"
 import { resolveMode } from "./mode.js"
-import { promptForApproval } from "./prompts.js"
+import { type CompoundSubcommand, promptForApproval, promptForCompoundApproval } from "./prompts.js"
 import planModeSupplement from "./prompts/plan-mode-supplement.js"
 import { evaluateRules, parseRules, stringifyRule } from "./rules.js"
 import { SessionMemory } from "./session-memory.js"
-import { isReadOnlyBashCommand, isReadOnlyTool } from "./taxonomy.js"
+import {
+	isCompoundCommand,
+	isHardBlockedBash,
+	isReadOnlyBashCommand,
+	isReadOnlyTool,
+	splitCompoundCommand,
+} from "./taxonomy.js"
 import { BUILTIN_DENY, DEFAULT_CONFIG, type PermissionMode, type Rule } from "./types.js"
 
 /**
@@ -297,13 +303,38 @@ export default function permissionsExtension(pi: ExtensionAPI): void {
 				return undefined
 			}
 
+			if (BUILTIN_ALLOW_TOOL_NAMES.includes(toolName)) return undefined
+
+			// Check for compound bash commands FIRST (before general rule evaluation)
+			// Compound commands should not match individual subcommand rules
+			if (toolName === "bash") {
+				const command = typeof input.command === "string" ? input.command : ""
+				const compoundCheck = checkCompoundCommand(command, allRules())
+				if (compoundCheck.decision === "deny") {
+					return { block: true, reason: compoundCheck.deniedReason ?? "Subcommand denied" }
+				}
+				if (compoundCheck.decision === "allow") {
+					return undefined
+				}
+
+				if (compoundCheck.decision === "prompt" && compoundCheck.subcommands) {
+					// Go to compound confirm flow
+					const result = await handleCompoundConfirm(event, {
+						ctx,
+						session,
+						activeAborts: activeAbortControllers,
+						subcommands: compoundCheck.subcommands,
+					})
+					if (result === "aborted") continue
+					return result
+				}
+			}
+
 			const match = evaluateRules(allRules(), toolName, input)
 			if (match.decision === "deny") {
 				return { block: true, reason: `Denied by rule ${formatRule(match.rule)}` }
 			}
 			if (match.decision === "allow") return undefined
-
-			if (BUILTIN_ALLOW_TOOL_NAMES.includes(toolName)) return undefined
 
 			// Auto mode + headless default mode (subagents) both go through the
 			// classifier; prompts without a UI fail closed.
@@ -401,9 +432,79 @@ async function handleConfirm(
 			opts.session.add(outcome.rule)
 			return undefined
 		}
+		if (outcome.kind === "allow-remember-wildcard") {
+			opts.session.add(outcome.rule)
+			return undefined
+		}
 		if (outcome.kind === "deny-with-feedback") {
 			return { block: true, reason: outcome.feedback }
 		}
+		return { block: true, reason: "Declined by user" }
+	} finally {
+		opts.activeAborts.delete(abort)
+	}
+}
+
+async function handleCompoundConfirm(
+	event: ToolCallEvent,
+	opts: ConfirmOptions & { subcommands: string[] },
+): Promise<{ block: true; reason: string } | "aborted" | undefined> {
+	const abort = new AbortController()
+	opts.activeAborts.add(abort)
+	try {
+		const compoundSubs: CompoundSubcommand[] = opts.subcommands.map((cmd) => ({
+			command: cmd,
+			description: `bash(${truncate(cmd, 100)})`,
+		}))
+
+		const outcome = await promptForCompoundApproval({
+			toolName: event.toolName,
+			commands: compoundSubs,
+			ctx: opts.ctx,
+			signal: abort.signal,
+		})
+
+		if (outcome.kind === "aborted") return "aborted"
+		if (outcome.kind === "allow-all-once") return undefined
+
+		if (outcome.kind === "allow-all-remember") {
+			for (const rule of outcome.rules) {
+				opts.session.add(rule)
+			}
+			return undefined
+		}
+
+		if (outcome.kind === "pick-per-subcommand") {
+			// For each subcommand, evaluate rules and prompt if needed
+			for (const subcommand of opts.subcommands) {
+				// Re-evaluate rules (user may have added rules during the prompt)
+				const match = evaluateRules(opts.session.all(), "bash", { command: subcommand })
+				if (match.decision === "allow") {
+					continue
+				}
+				if (match.decision === "deny") {
+					return { block: true, reason: `Subcommand blocked by rule: ${subcommand}` }
+				}
+
+				// Create a fake bash event for this subcommand
+				const subEvent: ToolCallEvent = {
+					...event,
+					input: { command: subcommand },
+				}
+				const result = await handleConfirm(subEvent, opts)
+				if (result === "aborted") return "aborted"
+				if (result !== undefined) {
+					// Blocked
+					return { block: true, reason: result.reason }
+				}
+			}
+			return undefined
+		}
+
+		if (outcome.kind === "deny-with-feedback") {
+			return { block: true, reason: outcome.feedback }
+		}
+
 		return { block: true, reason: "Declined by user" }
 	} finally {
 		opts.activeAborts.delete(abort)
@@ -418,6 +519,61 @@ function splitFlag(raw: boolean | string | undefined): string[] {
 		.filter(Boolean)
 }
 
+function truncate(s: string, max: number): string {
+	if (s.length <= max) return s
+	return `${s.slice(0, max - 1)}…`
+}
+
 function formatRule(rule: Rule): string {
 	return `${stringifyRule(rule)} [${rule.source}]`
+}
+
+interface CompoundCheckResult {
+	decision: "allow" | "deny" | "prompt"
+	deniedReason?: string
+	subcommands?: string[]
+}
+
+/**
+ * Check if a compound bash command can be allowed, denied, or needs prompting.
+ */
+function checkCompoundCommand(command: string, rules: Rule[]): CompoundCheckResult {
+	// First check for hard-blocked programs
+	if (isHardBlockedBash(command)) {
+		return { decision: "deny", deniedReason: `Hard-blocked program in command: ${command}` }
+	}
+
+	// If not compound, fall through to normal flow
+	if (!isCompoundCommand(command)) {
+		return { decision: "prompt" }
+	}
+
+	// Split into subcommands
+	const subcommands = splitCompoundCommand(command)
+	if (!subcommands || subcommands.length === 0) {
+		return { decision: "prompt" }
+	}
+
+	// Check each subcommand — track if all are allowed or any denied
+	let allAllowed = true
+	for (const subcommand of subcommands) {
+		// Check for hard-blocked programs in subcommand
+		if (isHardBlockedBash(subcommand)) {
+			return { decision: "deny", deniedReason: `Hard-blocked program in command: ${subcommand}` }
+		}
+		const match = evaluateRules(rules, "bash", { command: subcommand })
+		if (match.decision === "deny") {
+			return { decision: "deny", deniedReason: `Subcommand blocked by rule: ${subcommand}` }
+		}
+		if (match.decision !== "allow") {
+			allAllowed = false
+		}
+	}
+
+	// If all subcommands explicitly allowed by rules, allow the compound
+	if (allAllowed) {
+		return { decision: "allow" }
+	}
+
+	return { decision: "prompt", subcommands }
 }

--- a/src/extensions/permissions/prompts.test.ts
+++ b/src/extensions/permissions/prompts.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, it } from "vitest"
+
+// Test helper truncation function used internally in prompts.ts
+function truncate(s: string, max: number): string {
+	if (s.length <= max) return s
+	return `${s.slice(0, max - 1)}…`
+}
+
+describe("truncate helper", () => {
+	it("returns original string if under max length", () => {
+		expect(truncate("short", 10)).toBe("short")
+	})
+
+	it("truncates strings exceeding max length", () => {
+		expect(truncate("hello world", 5)).toBe("hell…")
+	})
+
+	it("handles exact length strings", () => {
+		expect(truncate("hello", 5)).toBe("hello")
+	})
+})

--- a/src/extensions/permissions/prompts.test.ts
+++ b/src/extensions/permissions/prompts.test.ts
@@ -1,10 +1,5 @@
 import { describe, expect, it } from "vitest"
-
-// Test helper truncation function used internally in prompts.ts
-function truncate(s: string, max: number): string {
-	if (s.length <= max) return s
-	return `${s.slice(0, max - 1)}…`
-}
+import { truncate } from "./prompts.js"
 
 describe("truncate helper", () => {
 	it("returns original string if under max length", () => {

--- a/src/extensions/permissions/prompts.ts
+++ b/src/extensions/permissions/prompts.ts
@@ -5,6 +5,20 @@ import type { Rule } from "./types.js"
 export type ApprovalOutcome =
 	| { kind: "allow-once" }
 	| { kind: "allow-remember"; rule: Rule }
+	| { kind: "allow-remember-wildcard"; rule: Rule }
+	| { kind: "deny-with-feedback"; feedback: string }
+	| { kind: "deny" }
+	| { kind: "aborted" }
+
+export interface CompoundSubcommand {
+	command: string
+	description: string
+}
+
+export type CompoundApprovalOutcome =
+	| { kind: "allow-all-once" }
+	| { kind: "allow-all-remember"; rules: Rule[] }
+	| { kind: "pick-per-subcommand" }
 	| { kind: "deny-with-feedback"; feedback: string }
 	| { kind: "deny" }
 	| { kind: "aborted" }
@@ -33,7 +47,12 @@ export async function promptForApproval(opts: PromptOptions): Promise<ApprovalOu
 	const yesRemember = `Yes — don't ask again for ${scope.label} this session`
 	const noWithFeedback = "No — tell the assistant what to do differently"
 
-	const choice = await ctx.ui.select(lines.join("\n"), [yesOnce, yesRemember, noWithFeedback], {
+	// Add wildcard option for bash commands
+	const choices = scope.wildcardContent
+		? [yesOnce, yesRemember, `Yes — don't ask again for ${scope.wildcardContent} this session`, noWithFeedback]
+		: [yesOnce, yesRemember, noWithFeedback]
+
+	const choice = await ctx.ui.select(lines.join("\n"), choices, {
 		signal: opts.signal,
 	})
 
@@ -51,7 +70,73 @@ export async function promptForApproval(opts: PromptOptions): Promise<ApprovalOu
 		return { kind: "allow-remember", rule }
 	}
 
+	// Check if wildcard was selected (only applicable for bash)
+	if (scope.wildcardContent && choice?.includes(scope.wildcardContent)) {
+		const rule: Rule = {
+			toolName: scope.toolName,
+			content: `${scope.wildcardContent}`,
+			behavior: "allow",
+			source: "session",
+		}
+		return { kind: "allow-remember-wildcard", rule }
+	}
+
 	if (choice === noWithFeedback) {
+		const feedback = await ctx.ui.input("Tell the assistant what to do differently:")
+		const text = feedback?.trim()
+		if (text) return { kind: "deny-with-feedback", feedback: text }
+		return { kind: "deny" }
+	}
+
+	return { kind: "deny" }
+}
+
+/**
+ * Prompt the user for compound command approval.
+ * Returns the user's choice of how to handle the compound command.
+ */
+export async function promptForCompoundApproval(opts: {
+	toolName: string
+	commands: CompoundSubcommand[]
+	ctx: ExtensionContext
+	subtitle?: string
+	signal?: AbortSignal
+}): Promise<CompoundApprovalOutcome> {
+	const { ctx, commands } = opts
+	if (!ctx.hasUI) return { kind: "deny" }
+
+	const descriptions = commands.map((c) => c.description)
+	const lines = [
+		`The assistant wants to run a compound command with ${commands.length} subcommand(s):`,
+		...descriptions,
+	]
+	if (opts.subtitle) lines.push(opts.subtitle)
+
+	const choices = [
+		"Run all (once)",
+		"Allow all from now on",
+		"Pick permissions per subcommand",
+		"No — tell the assistant what to do differently",
+	]
+
+	const choice = await ctx.ui.select(lines.join("\n"), choices, {
+		signal: opts.signal,
+	})
+
+	if (choice === undefined && opts.signal?.aborted) return { kind: "aborted" }
+
+	if (choice === choices[0]) return { kind: "allow-all-once" }
+	if (choice === choices[1]) {
+		const rules: Rule[] = commands.map((cmd) => ({
+			toolName: opts.toolName,
+			content: `${cmd.command.split(" ")[0]} *`,
+			behavior: "allow",
+			source: "session",
+		}))
+		return { kind: "allow-all-remember", rules }
+	}
+	if (choice === choices[2]) return { kind: "pick-per-subcommand" }
+	if (choice === choices[3]) {
 		const feedback = await ctx.ui.input("Tell the assistant what to do differently:")
 		const text = feedback?.trim()
 		if (text) return { kind: "deny-with-feedback", feedback: text }

--- a/src/extensions/permissions/prompts.ts
+++ b/src/extensions/permissions/prompts.ts
@@ -46,10 +46,13 @@ export async function promptForApproval(opts: PromptOptions): Promise<ApprovalOu
 	const yesOnce = "Yes — just this call"
 	const yesRemember = `Yes — don't ask again for ${scope.label} this session`
 	const noWithFeedback = "No — tell the assistant what to do differently"
+	const yesWildcard = scope.wildcardContent
+		? `Yes — don't ask again for ${scope.wildcardContent} this session`
+		: undefined
 
 	// Add wildcard option for bash commands
-	const choices = scope.wildcardContent
-		? [yesOnce, yesRemember, `Yes — don't ask again for ${scope.wildcardContent} this session`, noWithFeedback]
+	const choices = yesWildcard
+		? [yesOnce, yesRemember, yesWildcard, noWithFeedback]
 		: [yesOnce, yesRemember, noWithFeedback]
 
 	const choice = await ctx.ui.select(lines.join("\n"), choices, {
@@ -71,7 +74,7 @@ export async function promptForApproval(opts: PromptOptions): Promise<ApprovalOu
 	}
 
 	// Check if wildcard was selected (only applicable for bash)
-	if (scope.wildcardContent && choice?.includes(scope.wildcardContent)) {
+	if (yesWildcard && choice === yesWildcard) {
 		const rule: Rule = {
 			toolName: scope.toolName,
 			content: `${scope.wildcardContent}`,
@@ -162,7 +165,8 @@ function describeCall(toolName: string, input: Record<string, unknown>): string 
 	}
 }
 
-function truncate(s: string, max: number): string {
+// Exported for testing
+export function truncate(s: string, max: number): string {
 	if (s.length <= max) return s
 	return `${s.slice(0, max - 1)}…`
 }

--- a/src/extensions/permissions/session-memory.ts
+++ b/src/extensions/permissions/session-memory.ts
@@ -4,6 +4,7 @@ import type { Rule } from "./types.js"
 export interface Scope {
 	toolName: string
 	content?: string
+	wildcardContent?: string
 	label: string
 }
 
@@ -38,7 +39,12 @@ export function suggestScope(toolName: string, input: Record<string, unknown>): 
 		const command = typeof input.command === "string" ? input.command : ""
 		const prefix = bashPrefixScope(command)
 		if (prefix) {
-			return { toolName: lower, content: `${prefix}:*`, label: `bash(${prefix}:*)` }
+			return {
+				toolName: lower,
+				content: `${prefix}:*`,
+				wildcardContent: `${bashProgramOnly(command)} *`,
+				label: `bash(${prefix}:*)`,
+			}
 		}
 		return { toolName: lower, content: undefined, label: "bash" }
 	}
@@ -53,6 +59,13 @@ export function suggestScope(toolName: string, input: Record<string, unknown>): 
 	}
 
 	return { toolName: lower, content: undefined, label: lower }
+}
+
+function bashProgramOnly(command: string): string {
+	const trimmed = command.trim()
+	if (!trimmed) return ""
+	const { program } = extractBashProgram(trimmed)
+	return program
 }
 
 function bashPrefixScope(command: string): string | null {

--- a/src/extensions/permissions/taxonomy.test.ts
+++ b/src/extensions/permissions/taxonomy.test.ts
@@ -2,9 +2,11 @@ import { describe, expect, it } from "vitest"
 import {
 	classifyTool,
 	extractBashProgram,
+	isCompoundCommand,
 	isHardBlockedBash,
 	isReadOnlyBashCommand,
 	isReadOnlyTool,
+	splitCompoundCommand,
 } from "./taxonomy.js"
 
 describe("classifyTool", () => {
@@ -185,5 +187,90 @@ describe("isHardBlockedBash", () => {
 		expect(isHardBlockedBash("rm -rf ./build")).toBe(false)
 		expect(isHardBlockedBash("rm foo.txt")).toBe(false)
 		expect(isHardBlockedBash("rm -f node_modules/.cache")).toBe(false)
+	})
+})
+
+describe("isCompoundCommand", () => {
+	it("detects && operator", () => {
+		expect(isCompoundCommand("cd docs && ls")).toBe(true)
+		expect(isCompoundCommand("git status && git push")).toBe(true)
+	})
+
+	it("detects || operator", () => {
+		expect(isCompoundCommand("cd docs || ls")).toBe(true)
+		expect(isCompoundCommand("test -f file || touch file")).toBe(true)
+	})
+
+	it("detects ; operator", () => {
+		expect(isCompoundCommand("cd docs; ls")).toBe(true)
+		expect(isCompoundCommand("ls; pwd; echo done")).toBe(true)
+	})
+
+	it("does not detect pipes as compound", () => {
+		expect(isCompoundCommand("cat foo | grep bar")).toBe(false)
+		expect(isCompoundCommand("ls -la | head -n 5")).toBe(false)
+		expect(isCompoundCommand("echo hi | tee file.txt")).toBe(false)
+	})
+
+	it("detects compound with pipes inside segments", () => {
+		expect(isCompoundCommand("cd docs && git status | grep foo")).toBe(true)
+		expect(isCompoundCommand("ls | wc -l && echo done")).toBe(true)
+	})
+
+	it("returns false for simple commands", () => {
+		expect(isCompoundCommand("ls -la")).toBe(false)
+		expect(isCompoundCommand("git status")).toBe(false)
+		expect(isCompoundCommand("")).toBe(false)
+	})
+})
+
+describe("splitCompoundCommand", () => {
+	it("splits on &&", () => {
+		expect(splitCompoundCommand("cd docs && ls")).toEqual(["cd docs", "ls"])
+		expect(splitCompoundCommand("git status && git push origin main")).toEqual(["git status", "git push origin main"])
+	})
+
+	it("splits on ||", () => {
+		expect(splitCompoundCommand("cd docs || ls")).toEqual(["cd docs", "ls"])
+		expect(splitCompoundCommand("test -f file || touch file")).toEqual(["test -f file", "touch file"])
+	})
+
+	it("splits on ;", () => {
+		expect(splitCompoundCommand("cd docs; ls")).toEqual(["cd docs", "ls"])
+		expect(splitCompoundCommand("ls; pwd; echo done")).toEqual(["ls", "pwd", "echo done"])
+	})
+
+	it("keeps pipes inside segments", () => {
+		// Pipe-only commands are not "compound" — they return null
+		expect(splitCompoundCommand("cat foo | grep bar")).toBeNull()
+		// Pipes inside compound segments are preserved
+		expect(splitCompoundCommand("cd docs && git status | grep foo")).toEqual(["cd docs", "git status | grep foo"])
+	})
+
+	it("strips leading env-var assignments from subcommands", () => {
+		expect(splitCompoundCommand("FOO=bar ls && FOO=baz pwd")).toEqual(["ls", "pwd"])
+	})
+
+	it("strips whitespace", () => {
+		expect(splitCompoundCommand("  cd docs  &&  ls  ")).toEqual(["cd docs", "ls"])
+	})
+
+	it("filters empty segments", () => {
+		expect(splitCompoundCommand("cmd1 && && cmd2")).toEqual(["cmd1", "cmd2"])
+		expect(splitCompoundCommand("; cmd")).toEqual(["cmd"])
+	})
+
+	it("returns null for non-compound commands", () => {
+		expect(splitCompoundCommand("ls -la")).toBeNull()
+		expect(splitCompoundCommand("git status")).toBeNull()
+		expect(splitCompoundCommand("")).toBeNull()
+	})
+
+	it("handles mixed operators", () => {
+		expect(splitCompoundCommand("cd a && cd b || cd c; cd d")).toEqual(["cd a", "cd b", "cd c", "cd d"])
+	})
+
+	it("preserves redirect targets", () => {
+		expect(splitCompoundCommand("echo hi > file.txt && cat file.txt")).toEqual(["echo hi > file.txt", "cat file.txt"])
 	})
 })

--- a/src/extensions/permissions/taxonomy.ts
+++ b/src/extensions/permissions/taxonomy.ts
@@ -173,6 +173,81 @@ export function isHardBlockedBash(command: string): boolean {
 	return false
 }
 
+/**
+ * Returns true if the command contains top-level `&&`, `||`, or `;` operators.
+ * Pipes (`|`) do NOT make a command compound for this purpose — they are a
+ * single data-flow pipeline and are already handled by isReadOnlyBashCommand.
+ */
+export function isCompoundCommand(command: string): boolean {
+	const entries = parseShell(command) as ParseEntry[]
+	for (const entry of entries) {
+		if (typeof entry === "object" && "op" in entry) {
+			const op = entry.op
+			if (op === "&&" || op === "||" || op === ";") {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+/**
+ * Split a compound command into individual subcommands.
+ * Only splits on `&&`, `||`, `;` — NOT on `|` (pipes).
+ * Strips leading/trailing whitespace from each subcommand.
+ * Returns null if the command is not compound.
+ */
+export function splitCompoundCommand(command: string): string[] | null {
+	if (!isCompoundCommand(command)) return null
+
+	const entries = parseShell(command) as ParseEntry[]
+	const segments: string[] = []
+	let currentTokens: string[] = []
+
+	for (let i = 0; i < entries.length; i++) {
+		const entry = entries[i]
+		if (typeof entry === "string") {
+			// Strip leading env-var assignments
+			if (currentTokens.length === 0 && /^[A-Za-z_][\w]*=/.test(entry)) {
+				continue
+			}
+			currentTokens.push(entry)
+			continue
+		}
+		if ("comment" in entry) continue
+		if ("op" in entry && entry.op === "glob") {
+			currentTokens.push(entry.pattern)
+			continue
+		}
+		if ("op" in entry) {
+			const op = entry.op
+			// Only split on compound operators, not pipes
+			if (op === "&&" || op === "||" || op === ";") {
+				const reconstructed = currentTokens.join(" ").trim()
+				if (reconstructed) segments.push(reconstructed)
+				currentTokens = []
+				continue
+			}
+			if (op === "|" || op === "|&") {
+				currentTokens.push(entry.op)
+				continue
+			}
+			if ((op === ">" || op === ">>") && typeof entries[i + 1] === "string") {
+				// Consume the redirect target
+				currentTokens.push(entry.op)
+				currentTokens.push(entries[i + 1] as string)
+				i++
+			}
+		}
+	}
+
+	// Append the last segment
+	const reconstructed = currentTokens.join(" ").trim()
+	if (reconstructed) segments.push(reconstructed)
+
+	return segments.filter((s) => s.length > 0)
+}
+
 export function extractBashProgram(command: string): { program: string; subcommand: string | undefined } {
 	const tokens = firstSegmentTokens(command)
 	return { program: tokens[0] ?? "", subcommand: tokens[1] }

--- a/src/extensions/permissions/taxonomy.ts
+++ b/src/extensions/permissions/taxonomy.ts
@@ -233,7 +233,10 @@ export function splitCompoundCommand(command: string): string[] | null {
 				continue
 			}
 			if ((op === ">" || op === ">>") && typeof entries[i + 1] === "string") {
-				// Consume the redirect target
+				// Consume the redirect target.
+				// NOTE: We intentionally handle only > and >>. Other redirects (<, >&, <<)
+				// are intentionally not supported — they would not change the program
+				// classification outcome for permission evaluation.
 				currentTokens.push(entry.op)
 				currentTokens.push(entries[i + 1] as string)
 				i++


### PR DESCRIPTION
Checkout the branch and try this out! 

1 small improvement that can be added after review: show x/y commands when approving 1by1 so it is easy to keep track of how many are left.


---
### Kimchi Summary
### What changed
Adds detection and handling for compound bash commands (containing `&&`, `||`, or `;`). The extension now parses these commands into individual subcommands, validates each against permission rules and hard-blocked programs, and surfaces a dedicated approval UI when subcommands lack explicit permissions.

### Key changes
- `src/extensions/permissions/taxonomy.ts`: Introduces `isCompoundCommand()` and `splitCompoundCommand()` to identify compound operators and extract subcommands while preserving pipes within segments.
- `src/extensions/permissions/index.ts`: Adds `checkCompoundCommand()` to evaluate subcommands against existing rules and hard-blocked lists (e.g., `sudo`); adds `handleCompoundConfirm()` for compound-specific approval flows with per-subcommand granularity.
- `src/extensions/permissions/prompts.ts`: Introduces `promptForCompoundApproval()` supporting "allow all once", "allow all and remember", or "pick per subcommand" workflows; adds `allow-remember-wildcard` outcome type for creating program-level wildcards (e.g., `ls *`).
- `src/extensions/permissions/session-memory.ts`: Enhances `suggestScope()` to include `wildcardContent` for bash commands, enabling session rules that match any arguments to a specific program.
- `src/extensions/permissions/index.test.ts` and `taxonomy.test.ts`: Adds comprehensive test coverage for compound command parsing and permission evaluation logic.

### Impact
Users executing compound commands will now encounter a new approval dialog listing each subcommand. Hard-blocked programs are now detected even when embedded within compound statements. Existing session rules for simple commands will apply to matching subcommands automatically, but compound statements without explicit coverage will prompt for user confirmation.

---
### Kimchi Summary
### What changed
Adds first-class support for compound bash commands (joined with `&&`, `||`, or `;`) in the permissions extension. Compound commands are now split into subcommands, each evaluated against rules, with a dedicated prompt that lets users run all once, allow all going forward, or review permissions per subcommand.

### Why
Compound commands were previously treated as opaque strings, making rule matching ineffective and approval prompts overly broad. This change enables fine-grained safety checks and user control over multi-part bash tool calls common in agent-generated workflows.

### Key changes
- `src/extensions/permissions/taxonomy.ts`: Added `isCompoundCommand` and `splitCompoundCommand` to detect compound operators and split commands while preserving pipes and redirects inside individual segments.
- `src/extensions/permissions/index.ts`: Added `checkCompoundCommand` for early-gate deny/allow/prompt logic and `handleCompoundConfirm` for interactive compound approval; updated the main tool-call handler to route compound bash commands through the new flow.
- `src/extensions/permissions/prompts.ts`: Added `promptForCompoundApproval` with compound-specific choices; added `allow-remember-wildcard` outcome to `promptForApproval` so users can remember `program *` rules for bash.
- `src/extensions/permissions/session-memory.ts`: Added `wildcardContent` to `Scope` and `suggestScope` to generate program-level wildcard bash rules.
- Added comprehensive tests in `src/extensions/permissions/index.test.ts`, `prompts.test.ts`, and `taxonomy.test.ts`.

### Impact
- Bash tool calls containing `&&`, `||`, or `;` now use the compound flow instead of single-command evaluation. A hard-blocked program or deny rule in any subcommand blocks the entire compound; if all subcommands are explicitly allowed, the compound is silently approved.
- Existing single-command and auto-mode behavior is unchanged.