### PR TITLE
feat: add autonomous mode for kimchi to run a task spec inside a Dock…

### DIFF
--- a/.docker-run-result-index.html.bak
+++ b/.docker-run-result-index.html.bak
@@ -1,0 +1,26 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Dancing Frog</title>
+    <link rel="stylesheet" href="style.css">
+</head>
+<body>
+    <div class="container">
+        <h1>Dancing Frog</h1>
+        <div class="frog-wrapper">
+            <span class="frog" id="frog">🐸</span>
+        </div>
+        <div class="controls">
+            <button id="danceBtn" class="dance-btn">Dance!</button>
+            <div class="speed-control">
+                <label for="speedSlider">Speed:</label>
+                <input type="range" id="speedSlider" min="0.5" max="3" step="0.1" value="1">
+                <span id="speedValue">1x</span>
+            </div>
+        </div>
+    </div>
+    <script src="app.js"></script>
+</body>
+</html>

--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,13 @@
+.git
+.github
+node_modules
+.claude
+.kimchi
+benchmark
+docs
+tests
+**/*.test.ts
+coverage
+.DS_Store
+*.log
+.env*

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,57 @@
+# syntax=docker/dockerfile:1.7
+
+# Multi-arch container image for kimchi autonomous mode.
+#
+# Build with:
+#   docker buildx build --platform linux/amd64,linux/arm64 -t kimchi:latest .
+#
+# Or use the convenience script: ./scripts/build-image.sh
+#
+# Expects the cross-compiled linux binary to have been built first via:
+#   pnpm build:binary-linux-x64
+#   pnpm build:binary-linux-arm64
+# The build script picks the correct artifact based on TARGETARCH.
+
+FROM --platform=$BUILDPLATFORM alpine:3.20 AS prep
+ARG TARGETARCH
+WORKDIR /prep
+COPY dist/bin /prep/bin
+COPY dist/share /prep/share
+# Pick the right cross-built binary. Fail with a clear error if not found.
+RUN set -eux; \
+    if [ -f "/prep/bin/kimchi-linux-${TARGETARCH}" ]; then \
+        cp "/prep/bin/kimchi-linux-${TARGETARCH}" /prep/kimchi; \
+    else \
+        echo "no kimchi-linux-${TARGETARCH} binary found; run pnpm build:binary-linux-${TARGETARCH}" >&2; exit 1; \
+    fi; \
+    chmod +x /prep/kimchi
+
+FROM debian:bookworm-slim
+ARG TARGETARCH
+LABEL org.opencontainers.image.title="kimchi"
+LABEL org.opencontainers.image.description="Autonomous coding agent runner"
+LABEL org.opencontainers.image.source="https://github.com/cast-ai/kimchi"
+
+RUN set -eux; \
+    apt-get update; \
+    apt-get install -y --no-install-recommends \
+        ca-certificates \
+        git \
+        curl \
+        tini; \
+    rm -rf /var/lib/apt/lists/*; \
+    useradd --create-home --shell /bin/bash --uid 1000 kimchi; \
+    mkdir -p /workspace /workspace/.kimchi; \
+    chown -R kimchi:kimchi /workspace
+
+COPY --from=prep --chown=root:root /prep/kimchi /usr/local/bin/kimchi
+COPY --from=prep --chown=root:root /prep/share /usr/local/share
+
+USER kimchi
+WORKDIR /workspace
+ENV KIMCHI_RESULT_DIR=/workspace/.kimchi
+ENV KIMCHI_LOG_PATH=/workspace/.kimchi/run.log
+ENV HOME=/home/kimchi
+
+ENTRYPOINT ["/usr/bin/tini", "--", "/usr/local/bin/kimchi"]
+CMD ["auto", "--task", "/workspace/.kimchi/task.json"]

--- a/README.md
+++ b/README.md
@@ -19,6 +19,8 @@ kimchi         # launch the coding harness
 
 Run `kimchi --help` to see all available subcommands and flags.
 
+For unattended runs in a container, see [Autonomous mode](docs/autonomous-mode.md) (`kimchi auto --runtime <docker|orbstack|podman>`).
+
 ## Configuration
 
 ### Authentication

--- a/docs/autonomous-mode.md
+++ b/docs/autonomous-mode.md
@@ -1,0 +1,210 @@
+# Autonomous mode
+
+`kimchi auto` runs the agent unattended on a prompt or task spec. By default it runs in-process; with `--runtime` it sandboxes the run inside a Docker / OrbStack / Podman container.
+
+It's a thin wrapper around `--yolo --print --mode json --no-session` plus optional iteration cap, wall-clock timeout, and a result manifest written to disk.
+
+---
+
+## Quick start — in-process
+
+```bash
+# Bare prompt
+kimchi auto "Refactor the auth module"
+
+# With caps
+kimchi auto --iterations 10 --timeout-seconds 600 "Refactor the auth module"
+
+# Prompt from a file (pi's @file syntax)
+kimchi auto @prompt.md
+
+# Structured spec
+kimchi auto --task task.json
+```
+
+A `result.json` is written to `<KIMCHI_RESULT_DIR or cwd>/.kimchi/` summarising the run.
+
+## Quick start — containerized
+
+```bash
+# 1. Build the image (multi-arch optional — see scripts/build-image.sh --multi)
+./scripts/build-image.sh
+
+# 2. Write a task spec
+cat > task.json <<'EOF'
+{
+  "prompt": "Add a CHANGELOG.md summarising recent commits.",
+  "timeout_seconds": 600
+}
+EOF
+
+# 3. Run sandboxed against a workspace
+kimchi auto \
+    --task task.json \
+    --runtime orbstack \
+    --workspace ./repo \
+    --image kimchi:latest
+
+# 4. Inspect the result
+cat ./repo/.kimchi/result.json
+cat ./repo/.kimchi/run.log
+```
+
+When `--runtime` is set:
+- `--workspace <dir>` (default: current directory) is bind-mounted into `/workspace` inside the container.
+- `--image <ref>` (default: `kimchi:latest`) is the container image to run.
+- `--task <path>` is required (a structured spec — bare prompts aren't sandboxed in v1).
+
+Exit codes: **0** on clean completion, **124** on timeout, non-zero otherwise.
+
+---
+
+## Task spec format (JSON)
+
+| Field              | Type                                                | Default | Description                                                                                                          |
+| ------------------ | --------------------------------------------------- | ------- | -------------------------------------------------------------------------------------------------------------------- |
+| `prompt`           | string (required, non-empty)                        | —       | The user prompt the agent receives.                                                                                  |
+| `model`            | string                                              | —       | Model pattern; defaults to whatever kimchi is configured for.                                                        |
+| `timeout_seconds`  | integer (1 – 21600)                                 | 3600    | Wall-clock budget. **6h hard cap is enforced regardless of value.**                                                  |
+| `iterations`       | integer (1 – 1000)                                  | —       | Optional cap on number of agent turns. When unset, the agent runs until pi's print mode resolves naturally.          |
+| `env`              | `Record<string, string>`                            | `{}`    | Extra env vars forwarded into the container.                                                                         |
+| `mounts`           | `Array<{host, container, readonly?}>`               | `[]`    | Additional bind mounts beyond the default `<workspace>:/workspace`.                                                  |
+| `success_criteria` | string                                              | —       | Free-form, passed through to the prompt as guidance. v1: not validated.                                              |
+
+Spec file is JSON only in v1. YAML may be added later.
+
+## CLI flag reference
+
+| Flag | Effect |
+|---|---|
+| `--task <path>` | Load TaskSpec JSON. Required when `--runtime` is set. |
+| `--iterations N` / `--max-iterations N` | Cap turn count. Overrides `spec.iterations`. |
+| `--timeout-seconds N` | Wall-clock cap. Overrides `spec.timeout_seconds`. |
+| `--runtime <name>` | Sandbox the run in a container. Values: `docker`, `orbstack`, `podman`. |
+| `--workspace <dir>` | Container only. Bind-mounted as `/workspace`. Default: current dir. |
+| `--image <ref>` | Container only. Image to run. Default: `kimchi:latest`. |
+| `--help` / `-h` | Show usage. |
+| `@file.md` | (pi-native) Use file content as prompt. |
+| anything else | Passed through to pi-coding-agent. |
+
+CLI flags override spec values when both are present.
+
+---
+
+## Result manifest
+
+After the container exits, the launcher reads `<workspace>/.kimchi/result.json`:
+
+```json
+{
+  "exit_reason": "done" | "timeout" | "error",
+  "started_at": "2026-05-06T12:34:56.000Z",
+  "ended_at":   "2026-05-06T12:39:01.000Z",
+  "last_message": "All tests pass.",
+  "log_path": "/workspace/.kimchi/run.log",
+  "diff_path": "/workspace/.kimchi/diff.patch",
+  "error": { "message": "...", "stack": "..." }
+}
+```
+
+`last_message` is the latest assistant turn's text. `diff_path` is best-effort — populated only when the workspace is a git repo.
+
+---
+
+## Runtime backends
+
+| `--runtime` value                        | Backend            | Notes                                                                       |
+| ---------------------------------------- | ------------------ | --------------------------------------------------------------------------- |
+| `docker`                                 | `docker run`       | Standard local Docker.                                                      |
+| `orbstack`                               | `docker run`       | OrbStack ships a `docker` CLI shim — same code path, different VM.          |
+| `podman`                                 | `podman run`       | OCI-compatible drop-in.                                                     |
+
+---
+
+## Security caveats
+
+> **Warning:** autonomous mode runs with `--yolo`, which bypasses every permission prompt and rule. The agent has unrestricted ability to run commands, read/write files, and access the network from inside the container.
+
+- **Never bind-mount your home directory or working tree directly.** Mount a fresh `git clone` instead. The container runs as non-root (`uid 1000`), but the bind-mount remains writable.
+- The container has full network access by default. Add `--network none` (Docker) when you don't need it.
+- Treat the workspace as untrusted output — review the `diff_path` before merging anything generated by an autonomous run.
+- Secrets pass through `env`. Avoid putting long-lived credentials in the spec; use short-lived tokens or workload identity in production.
+- The launcher forwards `KIMCHI_API_KEY` from your shell into the container; ensure your shell does not have a wider-scoped key than necessary.
+
+### Workspace ownership
+
+The container runs as `uid 1000`. If your bind-mounted workspace is owned by a different UID, the agent will fail to write `.kimchi/result.json` and the run will appear to hang or exit silently. Either:
+- chown the workspace before launch (`chown -R 1000:1000 ./workspace`), or
+- pass `--user $(id -u):$(id -g)` via a future runtime flag (not implemented in v1).
+
+---
+
+## Exit codes
+
+| Code | Meaning                                               |
+| ---- | ----------------------------------------------------- |
+| 0    | Agent's prompt completed cleanly (pi print mode resolved). |
+| 1    | Spec load failure, runtime selection failure, or other generic error before the container started. |
+| 124  | Wall-clock timeout (matches the GNU `timeout(1)` convention). |
+| 130  | SIGINT (e.g. Ctrl-C in the launcher).                 |
+| 143  | SIGTERM (e.g. `docker stop`).                         |
+| other| Container-internal failure; check `result.json.error` and `run.log`. |
+
+---
+
+## How it works (architecture)
+
+```text
+┌───────── host (your laptop / cluster controller) ─────────┐
+│                                                            │
+│  kimchi auto --runtime <name>                              │
+│    │                                                       │
+│    ├─ load TaskSpec (Zod-validated)                        │
+│    ├─ ensure <workspace>/.kimchi/                          │
+│    ├─ copy task.json → <workspace>/.kimchi/task.json       │
+│    ├─ select runtime: docker | orbstack | podman           │
+│    ├─ runtime.run({image, mounts, env, command})  ──┐      │
+│    │                                                ▼      │
+└────────────────────────────────────────────────────────────┘
+                                                     │
+┌────────────── container (PID 1: kimchi auto) ──────┴───────┐
+│                                                            │
+│   parseAutoArgs → loadTaskSpec → buildAutoArgs              │
+│       │                                                     │
+│       ▼                                                     │
+│   pi-coding-agent main() in --print --mode json mode        │
+│       │  + autonomous extension factories                   │
+│       │                                                     │
+│       ├─ resultWriterExtension     — captures lifecycle     │
+│       │       └─ session_shutdown → write result.json       │
+│       ├─ timeoutGuardExtension     — wall-clock kill switch │
+│       │       └─ onTimeout → result.markTimeout() + exit124 │
+│       └─ maxIterationsExtension    — cap on turn_end count  │
+│               └─ on N-th turn → ctx.shutdown()              │
+│                                                             │
+│   pi's print mode resolves naturally when session.prompt    │
+│   completes; the manifest is flushed on session_shutdown.   │
+└─────────────────────────────────────────────────────────────┘
+```
+
+The two halves communicate **only via the workspace mount and exit codes** — no sockets, no IPC. That keeps each half independently testable and lets the same `kimchi auto` run on bare metal or in any OCI-compatible container with no code changes.
+
+---
+
+## Running the end-to-end smoke test
+
+A real-Docker, real-LLM smoke lives at `tests/smoke/autonomous-e2e.test.ts`. It builds the kimchi image, runs `kimchi auto --runtime docker` against a tiny task that writes a file, and verifies the result manifest plus the file the agent was asked to create. It is gated behind `KIMCHI_E2E=1` because it costs LLM tokens and needs Docker running.
+
+Prerequisites:
+
+- Node 22 + bun (for cross-compiling the linux binary)
+- Docker or OrbStack running
+- `KIMCHI_API_KEY` exported in your shell
+- `pnpm build:binary-linux-x64` already run (so `dist/bin/kimchi-linux-amd64` or `dist/bin/kimchi` exists)
+
+Run it:
+
+```bash
+pnpm build:binary-linux-x64
+KIMCHI_API_KEY=$YOUR_KEY pnpm test:e2e
+```

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
 		"check": "pnpm run lint && pnpm run typecheck",
 		"test": "vitest run --dir src",
 		"test:smoke": "vitest run --config tests/smoke/vitest.config.ts",
+		"test:e2e": "KIMCHI_E2E=1 vitest run --config tests/smoke/vitest.config.ts tests/smoke/autonomous-e2e.test.ts",
 		"prepare": "husky",
 		"verify": "pnpm run check && pnpm run build:binary && pnpm run test && pnpm run test:smoke"
 	},
@@ -37,6 +38,7 @@
 		"@modelcontextprotocol/sdk": "^1.25.1",
 		"micromatch": "^4.0.8",
 		"open": "^10.2.0",
+		"optional": "^0.1.4",
 		"shell-quote": "^1.8.3",
 		"tar": "^7.5.13",
 		"undici": "^8.0.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -37,6 +37,9 @@ importers:
       open:
         specifier: ^10.2.0
         version: 10.2.0
+      optional:
+        specifier: ^0.1.4
+        version: 0.1.4
       shell-quote:
         specifier: ^1.8.3
         version: 1.8.3
@@ -1733,6 +1736,9 @@ packages:
         optional: true
       zod:
         optional: true
+
+  optional@0.1.4:
+    resolution: {integrity: sha512-gtvrrCfkE08wKcgXaVwQVgwEQ8vel2dc5DDBn9RLQZ3YtmtkBss6A2HY6BnJH4N/4Ku97Ri/SF8sNWE2225WJw==}
 
   p-retry@4.6.2:
     resolution: {integrity: sha512-312Id396EbJdvRONlngUx0NydfrIQ5lsYu0znKVUzVvArzEIt08V1qhtyESbGVd1FGX7UKtiFp5uwKZdM8wIuQ==}
@@ -4097,6 +4103,8 @@ snapshots:
     optionalDependencies:
       ws: 8.20.0
       zod: 4.3.6
+
+  optional@0.1.4: {}
 
   p-retry@4.6.2:
     dependencies:

--- a/scripts/build-image.sh
+++ b/scripts/build-image.sh
@@ -1,0 +1,53 @@
+#!/usr/bin/env bash
+# Build the kimchi container image for autonomous mode.
+#
+# Usage:
+#   ./scripts/build-image.sh                              # builds for current arch only
+#   ./scripts/build-image.sh --multi                      # multi-arch via buildx (linux/amd64,linux/arm64)
+#   IMAGE=kimchi:dev ./scripts/build-image.sh             # custom tag
+#   PUSH=1 ./scripts/build-image.sh --multi               # push to registry
+#
+# Requires:
+#   - pnpm
+#   - docker (or orbstack / podman aliased to docker)
+#   - buildx (for --multi)
+
+set -euo pipefail
+
+cd "$(dirname "$0")/.."
+
+IMAGE="${IMAGE:-kimchi:latest}"
+MULTI=0
+for arg in "$@"; do
+    case "$arg" in
+        --multi) MULTI=1 ;;
+    esac
+done
+
+echo "[1/3] Building cross-compiled linux binaries..."
+pnpm build:binary-linux-x64
+mv dist/bin/kimchi dist/bin/kimchi-linux-amd64
+pnpm build:binary-linux-arm64
+mv dist/bin/kimchi dist/bin/kimchi-linux-arm64
+
+if [[ "$MULTI" -eq 1 ]]; then
+    echo "[2/3] Building multi-arch image $IMAGE via buildx..."
+    PUSH_FLAG=""
+    if [[ "${PUSH:-0}" -eq 1 ]]; then
+        PUSH_FLAG="--push"
+    else
+        PUSH_FLAG="--load"
+        echo "  (--load only supports a single arch — pass PUSH=1 for true multi-arch publish)"
+    fi
+    docker buildx build \
+        --platform linux/amd64,linux/arm64 \
+        -t "$IMAGE" \
+        $PUSH_FLAG \
+        .
+else
+    echo "[2/3] Building single-arch image $IMAGE..."
+    docker build -t "$IMAGE" .
+fi
+
+echo "[3/3] Done. Test with:"
+echo "    docker run --rm -v \$PWD:/workspace $IMAGE --task /workspace/.kimchi/task.json"

--- a/src/autonomous/result.test.ts
+++ b/src/autonomous/result.test.ts
@@ -1,0 +1,153 @@
+import { randomUUID } from "node:crypto"
+import { existsSync, mkdirSync, readFileSync, rmSync, writeFileSync } from "node:fs"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
+import { afterEach, describe, expect, it } from "vitest"
+import { readResult, writeResult } from "./result.js"
+import type { ResultManifest } from "./result.js"
+
+describe("writeResult / readResult", () => {
+	const createdDirs: string[] = []
+
+	function tmpDir(): string {
+		const dir = join(tmpdir(), `result-test-${randomUUID()}`)
+		createdDirs.push(dir)
+		return dir
+	}
+
+	afterEach(() => {
+		for (const d of createdDirs) {
+			try {
+				rmSync(d, { recursive: true, force: true })
+			} catch {
+				// ignore
+			}
+		}
+		createdDirs.length = 0
+	})
+
+	const minimalManifest: ResultManifest = {
+		exit_reason: "done",
+		started_at: "2026-05-06T10:00:00.000Z",
+		ended_at: "2026-05-06T10:01:00.000Z",
+	}
+
+	const fullManifest: ResultManifest = {
+		exit_reason: "error",
+		started_at: "2026-05-06T11:00:00.000Z",
+		ended_at: "2026-05-06T11:05:00.000Z",
+		last_message: "Something went wrong",
+		log_path: "/workspace/.kimchi/run.log",
+		diff_path: "/workspace/.kimchi/changes.diff",
+		error: {
+			message: "Command failed with exit code 1",
+			stack: "Error: Command failed\n    at run (auto.ts:42:5)",
+		},
+	}
+
+	it("round-trips a minimal manifest with only required fields", () => {
+		const dir = tmpDir()
+		mkdirSync(dir, { recursive: true })
+		writeResult(dir, minimalManifest)
+		const result = readResult(dir)
+		expect(result).toEqual(minimalManifest)
+	})
+
+	it("round-trips a fully-populated manifest including all optional fields", () => {
+		const dir = tmpDir()
+		mkdirSync(dir, { recursive: true })
+		writeResult(dir, fullManifest)
+		const result = readResult(dir)
+		expect(result).toEqual(fullManifest)
+	})
+
+	it("creates the directory if it does not exist (recursive mkdir)", () => {
+		const dir = join(tmpDir(), "nested", "sub", "dir")
+		expect(existsSync(dir)).toBe(false)
+		writeResult(dir, minimalManifest)
+		expect(existsSync(dir)).toBe(true)
+		const result = readResult(dir)
+		expect(result).toEqual(minimalManifest)
+	})
+
+	it("result.json exists and result.json.tmp does NOT exist after a successful write", () => {
+		const dir = tmpDir()
+		mkdirSync(dir, { recursive: true })
+		writeResult(dir, minimalManifest)
+		expect(existsSync(join(dir, "result.json"))).toBe(true)
+		expect(existsSync(join(dir, "result.json.tmp"))).toBe(false)
+	})
+
+	it("overwrites a stale result.json.tmp without throwing (atomic write is idempotent)", () => {
+		const dir = tmpDir()
+		mkdirSync(dir, { recursive: true })
+		// Simulate a stale tmp file left by a previous failed write
+		writeFileSync(join(dir, "result.json.tmp"), '{"stale": true}', "utf-8")
+		expect(() => writeResult(dir, minimalManifest)).not.toThrow()
+		expect(existsSync(join(dir, "result.json.tmp"))).toBe(false)
+		const result = readResult(dir)
+		expect(result).toEqual(minimalManifest)
+	})
+
+	it("writeResult throws when exit_reason is invalid (e.g. 'weird')", () => {
+		const dir = tmpDir()
+		mkdirSync(dir, { recursive: true })
+		const bad = { ...minimalManifest, exit_reason: "weird" } as unknown as ResultManifest
+		expect(() => writeResult(dir, bad)).toThrow(/exit_reason/)
+	})
+
+	it("readResult throws when result.json does not exist and message mentions the path", () => {
+		const dir = tmpDir()
+		mkdirSync(dir, { recursive: true })
+		const expectedPath = join(dir, "result.json")
+		let error: Error | null = null
+		try {
+			readResult(dir)
+		} catch (err) {
+			error = err as Error
+		}
+		if (!error) throw new Error("expected error to be thrown")
+		expect(error.message).toContain(expectedPath)
+	})
+
+	it("readResult throws when JSON is malformed and message mentions 'parse' or 'JSON'", () => {
+		const dir = tmpDir()
+		mkdirSync(dir, { recursive: true })
+		writeFileSync(join(dir, "result.json"), "{ not valid json }", "utf-8")
+		let error: Error | null = null
+		try {
+			readResult(dir)
+		} catch (err) {
+			error = err as Error
+		}
+		if (!error) throw new Error("expected error to be thrown")
+		expect(error.message).toMatch(/parse|JSON/i)
+	})
+
+	it("readResult throws when schema is invalid (exit_reason: 'invalid') with field path in message", () => {
+		const dir = tmpDir()
+		mkdirSync(dir, { recursive: true })
+		writeFileSync(
+			join(dir, "result.json"),
+			JSON.stringify({ exit_reason: "invalid", started_at: "2026-05-06T10:00:00Z", ended_at: "2026-05-06T10:01:00Z" }),
+			"utf-8",
+		)
+		let error: Error | null = null
+		try {
+			readResult(dir)
+		} catch (err) {
+			error = err as Error
+		}
+		if (!error) throw new Error("expected error to be thrown")
+		expect(error.message).toMatch(/exit_reason/)
+	})
+
+	it("written JSON is human-readable (pretty-printed with 2-space indent)", () => {
+		const dir = tmpDir()
+		mkdirSync(dir, { recursive: true })
+		writeResult(dir, minimalManifest)
+		const raw = readFileSync(join(dir, "result.json"), "utf-8")
+		// Pretty-printed JSON starts with "{\n  " (object open + newline + 2-space indent)
+		expect(raw).toMatch(/^\{\n {2}/)
+	})
+})

--- a/src/autonomous/result.ts
+++ b/src/autonomous/result.ts
@@ -1,0 +1,72 @@
+import { mkdirSync, readFileSync, renameSync, writeFileSync } from "node:fs"
+import { join } from "node:path"
+import { z } from "zod"
+
+const resultManifestSchema = z.object({
+	exit_reason: z.enum(["done", "timeout", "error"]),
+	started_at: z.string(),
+	ended_at: z.string(),
+	last_message: z.string().optional(),
+	log_path: z.string().optional(),
+	diff_path: z.string().optional(),
+	error: z
+		.object({
+			message: z.string(),
+			stack: z.string().optional(),
+		})
+		.optional(),
+})
+
+export type ResultManifest = z.infer<typeof resultManifestSchema>
+
+function formatPath(path: ReadonlyArray<PropertyKey>): string {
+	return path.reduce<string>((acc, segment, i) => {
+		if (typeof segment === "number") {
+			return `${acc}[${segment}]`
+		}
+		const seg = String(segment)
+		return i === 0 ? seg : `${acc}.${seg}`
+	}, "")
+}
+
+export function writeResult(dir: string, manifest: ResultManifest): void {
+	const validation = resultManifestSchema.safeParse(manifest)
+	if (!validation.success) {
+		const paths = validation.error.issues.map((issue) => formatPath(issue.path)).join(", ")
+		throw new Error(`Invalid result manifest: invalid field(s): ${paths}`)
+	}
+
+	mkdirSync(dir, { recursive: true })
+
+	const tmpPath = join(dir, "result.json.tmp")
+	const finalPath = join(dir, "result.json")
+
+	writeFileSync(tmpPath, JSON.stringify(manifest, null, 2), "utf-8")
+	renameSync(tmpPath, finalPath)
+}
+
+export function readResult(dir: string): ResultManifest {
+	const filePath = join(dir, "result.json")
+
+	let raw: string
+	try {
+		raw = readFileSync(filePath, "utf-8")
+	} catch (err) {
+		throw new Error(`Failed to read result manifest at ${filePath}: ${(err as Error).message}`)
+	}
+
+	let parsed: unknown
+	try {
+		parsed = JSON.parse(raw)
+	} catch (err) {
+		throw new Error(`Failed to parse JSON in result manifest at ${filePath}: ${(err as Error).message}`)
+	}
+
+	const result = resultManifestSchema.safeParse(parsed)
+	if (!result.success) {
+		const paths = result.error.issues.map((issue) => formatPath(issue.path)).join(", ")
+		throw new Error(`Invalid result manifest at ${filePath}: invalid field(s): ${paths}`)
+	}
+
+	return result.data
+}

--- a/src/autonomous/runtime/cli.spawn.test.ts
+++ b/src/autonomous/runtime/cli.spawn.test.ts
@@ -1,0 +1,16 @@
+import { describe, expect, it } from "vitest"
+import { defaultSpawn } from "./cli.js"
+
+describe("defaultSpawn", () => {
+	it.skipIf(process.platform === "win32")("runs /bin/echo and captures stdout", async () => {
+		let stdout = ""
+		const spawnFn = defaultSpawn()
+		const result = await spawnFn("/bin/echo", ["hello"], {
+			onStdout: (c) => {
+				stdout += c
+			},
+		})
+		expect(result.exitCode).toBe(0)
+		expect(stdout).toContain("hello")
+	})
+})

--- a/src/autonomous/runtime/cli.test.ts
+++ b/src/autonomous/runtime/cli.test.ts
@@ -1,0 +1,251 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
+import { buildCliArgs, createCliRuntime } from "./cli.js"
+import type { RunOpts, SpawnFn } from "./types.js"
+
+function makeStubSpawn(exitCode = 0, resolveAfterMs?: number): SpawnFn {
+	return vi.fn((_binary, _args, _opts) => {
+		return new Promise<{ exitCode: number }>((resolve) => {
+			if (resolveAfterMs != null) {
+				setTimeout(() => resolve({ exitCode }), resolveAfterMs)
+			} else {
+				resolve({ exitCode })
+			}
+		})
+	}) as SpawnFn
+}
+
+describe("buildCliArgs", () => {
+	it("produces minimal args for image + command only", () => {
+		const args = buildCliArgs("docker", { image: "kimchi", command: ["auto"] })
+		expect(args).toEqual(["run", "--rm", "kimchi", "auto"])
+	})
+
+	it("includes --name when opts.name is set", () => {
+		const args = buildCliArgs("docker", { image: "kimchi", command: ["auto"], name: "my-container" })
+		expect(args).toContain("--name")
+		expect(args).toContain("my-container")
+		const nameIdx = args.indexOf("--name")
+		expect(args[nameIdx + 1]).toBe("my-container")
+	})
+
+	it("includes -w when opts.workdir is set", () => {
+		const args = buildCliArgs("docker", { image: "kimchi", command: ["auto"], workdir: "/workspace" })
+		expect(args).toContain("-w")
+		const wIdx = args.indexOf("-w")
+		expect(args[wIdx + 1]).toBe("/workspace")
+	})
+
+	it("places --name and -w before mounts and env (correct order)", () => {
+		const opts: RunOpts = {
+			image: "kimchi",
+			command: ["auto"],
+			name: "c1",
+			workdir: "/workspace",
+			mounts: [{ host: "/host", container: "/cont" }],
+			env: { FOO: "bar" },
+		}
+		const args = buildCliArgs("docker", opts)
+		const nameIdx = args.indexOf("--name")
+		const wIdx = args.indexOf("-w")
+		const vIdx = args.indexOf("-v")
+		const eIdx = args.indexOf("-e")
+		const imageIdx = args.indexOf("kimchi")
+		expect(nameIdx).toBeLessThan(vIdx)
+		expect(wIdx).toBeLessThan(vIdx)
+		expect(vIdx).toBeLessThan(eIdx)
+		expect(eIdx).toBeLessThan(imageIdx)
+		expect(imageIdx).toBeLessThan(args.indexOf("auto"))
+	})
+
+	it("includes -v with correct mount string (no readonly flag)", () => {
+		const args = buildCliArgs("docker", {
+			image: "kimchi",
+			command: ["auto"],
+			mounts: [{ host: "/host/path", container: "/container/path" }],
+		})
+		const vIdx = args.indexOf("-v")
+		expect(vIdx).toBeGreaterThan(-1)
+		expect(args[vIdx + 1]).toBe("/host/path:/container/path")
+	})
+
+	it("appends :ro to readonly mounts", () => {
+		const args = buildCliArgs("docker", {
+			image: "kimchi",
+			command: ["auto"],
+			mounts: [{ host: "/host/path", container: "/container/path", readonly: true }],
+		})
+		const vIdx = args.indexOf("-v")
+		expect(args[vIdx + 1]).toBe("/host/path:/container/path:ro")
+	})
+
+	it("preserves insertion order for multiple mounts", () => {
+		const args = buildCliArgs("docker", {
+			image: "kimchi",
+			command: ["auto"],
+			mounts: [
+				{ host: "/host/a", container: "/cont/a" },
+				{ host: "/host/b", container: "/cont/b" },
+			],
+		})
+		const vIndices = args.map((v, i) => (v === "-v" ? i : -1)).filter((i) => i !== -1)
+		expect(vIndices).toHaveLength(2)
+		expect(args[vIndices[0] + 1]).toBe("/host/a:/cont/a")
+		expect(args[vIndices[1] + 1]).toBe("/host/b:/cont/b")
+	})
+
+	it("includes -e KEY=VAL for each env entry", () => {
+		const args = buildCliArgs("docker", {
+			image: "kimchi",
+			command: ["auto"],
+			env: { FOO: "bar", BAZ: "qux" },
+		})
+		const eIndices = args.map((v, i) => (v === "-e" ? i : -1)).filter((i) => i !== -1)
+		expect(eIndices).toHaveLength(2)
+		const envPairs = eIndices.map((i) => args[i + 1])
+		expect(envPairs).toContain("FOO=bar")
+		expect(envPairs).toContain("BAZ=qux")
+	})
+
+	it("preserves insertion order for multiple env entries", () => {
+		const args = buildCliArgs("docker", {
+			image: "kimchi",
+			command: ["auto"],
+			env: { FIRST: "1", SECOND: "2" },
+		})
+		const eIndices = args.map((v, i) => (v === "-e" ? i : -1)).filter((i) => i !== -1)
+		expect(eIndices).toHaveLength(2)
+		expect(args[eIndices[0] + 1]).toBe("FIRST=1")
+		expect(args[eIndices[1] + 1]).toBe("SECOND=2")
+	})
+
+	it("appends all command fragments after the image", () => {
+		const args = buildCliArgs("docker", {
+			image: "kimchi",
+			command: ["auto", "--task", "/workspace/task.json"],
+		})
+		const imageIdx = args.indexOf("kimchi")
+		expect(args.slice(imageIdx + 1)).toEqual(["auto", "--task", "/workspace/task.json"])
+	})
+
+	it("works identically for orbstack binary (same argv shape)", () => {
+		const args = buildCliArgs("orbstack", { image: "kimchi", command: ["auto"] })
+		expect(args).toEqual(["run", "--rm", "kimchi", "auto"])
+	})
+
+	it("works identically for podman binary (same argv shape)", () => {
+		const args = buildCliArgs("podman", { image: "kimchi", command: ["auto"] })
+		expect(args).toEqual(["run", "--rm", "kimchi", "auto"])
+	})
+
+	it("throws when a mount.host contains ':'", () => {
+		expect(() =>
+			buildCliArgs("docker", {
+				image: "kimchi",
+				command: ["auto"],
+				mounts: [{ host: "/bad:path", container: "/cont" }],
+			}),
+		).toThrow(/invalid mount path/)
+	})
+
+	it("throws when a mount.container contains ','", () => {
+		expect(() =>
+			buildCliArgs("docker", {
+				image: "kimchi",
+				command: ["auto"],
+				mounts: [{ host: "/host", container: "/bad,path" }],
+			}),
+		).toThrow(/invalid mount path/)
+	})
+})
+
+describe("createCliRuntime", () => {
+	it("returns a runtime with name matching the binary option", () => {
+		const rt = createCliRuntime({ binary: "docker", spawn: makeStubSpawn() })
+		expect(rt.name).toBe("docker")
+	})
+
+	it("returns name 'orbstack' for orbstack binary", () => {
+		const rt = createCliRuntime({ binary: "orbstack", spawn: makeStubSpawn() })
+		expect(rt.name).toBe("orbstack")
+	})
+
+	it("returns name 'podman' for podman binary", () => {
+		const rt = createCliRuntime({ binary: "podman", spawn: makeStubSpawn() })
+		expect(rt.name).toBe("podman")
+	})
+
+	it("invokes spawn with binary string 'docker' when runtime is orbstack (drop-in)", async () => {
+		const stub = makeStubSpawn(0)
+		const rt = createCliRuntime({ binary: "orbstack", spawn: stub })
+		await rt.run({ image: "kimchi", command: ["auto"] })
+		expect(stub).toHaveBeenCalledWith("docker", expect.any(Array), expect.any(Object))
+	})
+
+	it("invokes spawn with binary string 'podman' for podman runtime", async () => {
+		const stub = makeStubSpawn(0)
+		const rt = createCliRuntime({ binary: "podman", spawn: stub })
+		await rt.run({ image: "kimchi", command: ["auto"] })
+		expect(stub).toHaveBeenCalledWith("podman", expect.any(Array), expect.any(Object))
+	})
+
+	it("invokes spawn with binary string 'docker' for docker runtime", async () => {
+		const stub = makeStubSpawn(0)
+		const rt = createCliRuntime({ binary: "docker", spawn: stub })
+		await rt.run({ image: "kimchi", command: ["auto"] })
+		expect(stub).toHaveBeenCalledWith("docker", expect.any(Array), expect.any(Object))
+	})
+
+	it("run() returns RunResult with exitCode 0 and non-negative durationMs from stub", async () => {
+		const stub = makeStubSpawn(0)
+		const rt = createCliRuntime({ binary: "docker", spawn: stub })
+		const result = await rt.run({ image: "kimchi", command: ["auto"] })
+		expect(result.exitCode).toBe(0)
+		expect(result.durationMs).toBeGreaterThanOrEqual(0)
+	})
+
+	it("run() propagates non-zero exit code from stub spawn", async () => {
+		const stub = makeStubSpawn(42)
+		const rt = createCliRuntime({ binary: "docker", spawn: stub })
+		const result = await rt.run({ image: "kimchi", command: ["auto"] })
+		expect(result.exitCode).toBe(42)
+	})
+
+	it("run() passes the correct argv to spawn", async () => {
+		const stub = makeStubSpawn(0)
+		const rt = createCliRuntime({ binary: "docker", spawn: stub })
+		await rt.run({
+			image: "kimchi",
+			command: ["auto", "--task", "/task.json"],
+			name: "test-container",
+			workdir: "/workspace",
+		})
+		const [, args] = (stub as ReturnType<typeof vi.fn>).mock.calls[0]
+		expect(args).toContain("--name")
+		expect(args).toContain("test-container")
+		expect(args).toContain("-w")
+		expect(args).toContain("/workspace")
+		expect(args).toContain("kimchi")
+		expect(args).toContain("auto")
+	})
+
+	it("run() aborts via AbortSignal when timeoutMs is short and stub never resolves in time", async () => {
+		let capturedSignal: AbortSignal | undefined
+
+		const neverResolveSpawn: SpawnFn = vi.fn((_binary, _args, opts) => {
+			capturedSignal = opts.signal
+			// Never resolves on its own — we rely on the AbortSignal
+			return new Promise<{ exitCode: number }>((_resolve, reject) => {
+				opts.signal?.addEventListener("abort", () => {
+					reject(new Error("aborted"))
+				})
+			})
+		}) as SpawnFn
+
+		const rt = createCliRuntime({ binary: "docker", spawn: neverResolveSpawn })
+
+		await expect(rt.run({ image: "kimchi", command: ["auto"], timeoutMs: 50 })).rejects.toThrow()
+
+		// The signal should have been aborted after the timeout fired
+		expect(capturedSignal?.aborted).toBe(true)
+	})
+})

--- a/src/autonomous/runtime/cli.ts
+++ b/src/autonomous/runtime/cli.ts
@@ -1,0 +1,117 @@
+import { spawn as nodeSpawn } from "node:child_process"
+import type { ContainerRuntime, RunOpts, RunResult, SpawnFn } from "./types.js"
+
+export type CliRuntimeBinary = "docker" | "orbstack" | "podman"
+
+export function buildCliArgs(binary: CliRuntimeBinary, opts: RunOpts): string[] {
+	const args: string[] = ["run", "--rm"]
+
+	if (opts.name) {
+		args.push("--name", opts.name)
+	}
+
+	if (opts.workdir) {
+		args.push("-w", opts.workdir)
+	}
+
+	for (const mount of opts.mounts ?? []) {
+		if (mount.host.includes(":") || mount.host.includes(",")) {
+			throw new Error(`invalid mount path: ${mount.host}`)
+		}
+		if (mount.container.includes(":") || mount.container.includes(",")) {
+			throw new Error(`invalid mount path: ${mount.container}`)
+		}
+		const mountStr = mount.readonly ? `${mount.host}:${mount.container}:ro` : `${mount.host}:${mount.container}`
+		args.push("-v", mountStr)
+	}
+
+	for (const [key, val] of Object.entries(opts.env ?? {})) {
+		args.push("-e", `${key}=${val}`)
+	}
+
+	args.push(opts.image)
+	args.push(...opts.command)
+
+	return args
+}
+
+function resolveSpawnBinary(binary: CliRuntimeBinary): string {
+	// orbstack is a docker drop-in on macOS — it uses the same `docker` CLI binary
+	if (binary === "orbstack") return "docker"
+	return binary
+}
+
+export function defaultSpawn(): SpawnFn {
+	return (spawnBinary, args, opts) => {
+		return new Promise((resolve, reject) => {
+			const child = nodeSpawn(spawnBinary, args, {
+				stdio: ["ignore", "pipe", "pipe"],
+				signal: opts.signal,
+			})
+
+			child.stdout?.on("data", (chunk: Buffer) => {
+				opts.onStdout?.(chunk.toString())
+			})
+
+			child.stderr?.on("data", (chunk: Buffer) => {
+				opts.onStderr?.(chunk.toString())
+			})
+
+			let settled = false
+			child.once("error", (err) => {
+				if (!settled) {
+					settled = true
+					reject(err)
+				}
+			})
+			child.once("close", (code) => {
+				if (!settled) {
+					settled = true
+					resolve({ exitCode: code ?? 1 })
+				}
+			})
+		})
+	}
+}
+
+export interface CliRuntimeOptions {
+	binary: CliRuntimeBinary
+	spawn?: SpawnFn
+}
+
+export function createCliRuntime(options: CliRuntimeOptions): ContainerRuntime {
+	const { binary } = options
+	const spawnFn = options.spawn ?? defaultSpawn()
+	const spawnBinary = resolveSpawnBinary(binary)
+
+	return {
+		name: binary,
+
+		async run(opts: RunOpts): Promise<RunResult> {
+			const args = buildCliArgs(binary, opts)
+			const start = Date.now()
+
+			let controller: AbortController | undefined
+			let timeoutId: ReturnType<typeof setTimeout> | undefined
+
+			if (opts.timeoutMs != null && opts.timeoutMs > 0) {
+				const ctrl = new AbortController()
+				controller = ctrl
+				timeoutId = setTimeout(() => {
+					ctrl.abort()
+				}, opts.timeoutMs)
+			}
+
+			try {
+				const result = await spawnFn(spawnBinary, args, {
+					signal: controller?.signal,
+				})
+				return { exitCode: result.exitCode, durationMs: Date.now() - start }
+			} finally {
+				if (timeoutId != null) {
+					clearTimeout(timeoutId)
+				}
+			}
+		},
+	}
+}

--- a/src/autonomous/runtime/select.test.ts
+++ b/src/autonomous/runtime/select.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it } from "vitest"
+import { selectRuntime } from "./select.js"
+
+describe("selectRuntime", () => {
+	it("selectRuntime('docker').name === 'docker'", () => {
+		expect(selectRuntime("docker").name).toBe("docker")
+	})
+
+	it("selectRuntime('orbstack').name === 'orbstack'", () => {
+		expect(selectRuntime("orbstack").name).toBe("orbstack")
+	})
+
+	it("selectRuntime('podman').name === 'podman'", () => {
+		expect(selectRuntime("podman").name).toBe("podman")
+	})
+
+	it("throws with /Unknown runtime/i for an unrecognized name", () => {
+		expect(() => selectRuntime("nope")).toThrow(/Unknown runtime/i)
+	})
+
+	it("throws for k8s/kubernetes (no longer supported)", () => {
+		expect(() => selectRuntime("k8s")).toThrow(/Unknown runtime/i)
+		expect(() => selectRuntime("kubernetes")).toThrow(/Unknown runtime/i)
+	})
+
+	it("throws for another unrecognized name 'minikube'", () => {
+		expect(() => selectRuntime("minikube")).toThrow(/Unknown runtime/i)
+	})
+
+	it("is case-insensitive: 'DOCKER' resolves to docker runtime", () => {
+		expect(selectRuntime("DOCKER").name).toBe("docker")
+	})
+
+	it("is case-insensitive: 'ORBSTACK' resolves to orbstack runtime", () => {
+		expect(selectRuntime("ORBSTACK").name).toBe("orbstack")
+	})
+
+	it("is case-insensitive: 'PODMAN' resolves to podman runtime", () => {
+		expect(selectRuntime("PODMAN").name).toBe("podman")
+	})
+
+	it("returns a runtime with a run() method for every known variant", () => {
+		for (const name of ["docker", "orbstack", "podman"]) {
+			const rt = selectRuntime(name)
+			expect(typeof rt.run).toBe("function")
+		}
+	})
+})

--- a/src/autonomous/runtime/select.ts
+++ b/src/autonomous/runtime/select.ts
@@ -1,0 +1,21 @@
+import { createCliRuntime } from "./cli.js"
+import type { ContainerRuntime, SpawnFn } from "./types.js"
+
+export interface SelectRuntimeDeps {
+	spawn?: SpawnFn
+}
+
+export function selectRuntime(name: string, deps?: SelectRuntimeDeps): ContainerRuntime {
+	const normalized = name.toLowerCase()
+
+	switch (normalized) {
+		case "docker":
+			return createCliRuntime({ binary: "docker", spawn: deps?.spawn })
+		case "orbstack":
+			return createCliRuntime({ binary: "orbstack", spawn: deps?.spawn })
+		case "podman":
+			return createCliRuntime({ binary: "podman", spawn: deps?.spawn })
+		default:
+			throw new Error(`Unknown runtime: ${name}`)
+	}
+}

--- a/src/autonomous/runtime/types.ts
+++ b/src/autonomous/runtime/types.ts
@@ -1,0 +1,25 @@
+export interface RunOpts {
+	image: string
+	command: string[] // exec command, e.g. ["auto", "--task", "/workspace/task.json"]
+	mounts?: Array<{ host: string; container: string; readonly?: boolean }>
+	env?: Record<string, string>
+	workdir?: string
+	name?: string // container name (CLI runtimes only)
+	timeoutMs?: number // outer wall-clock cap on .run()
+}
+
+export interface RunResult {
+	exitCode: number
+	durationMs: number
+}
+
+export type SpawnFn = (
+	binary: string,
+	args: string[],
+	opts: { onStdout?: (chunk: string) => void; onStderr?: (chunk: string) => void; signal?: AbortSignal },
+) => Promise<{ exitCode: number }>
+
+export interface ContainerRuntime {
+	readonly name: string
+	run(opts: RunOpts): Promise<RunResult>
+}

--- a/src/autonomous/select-extensions.test.ts
+++ b/src/autonomous/select-extensions.test.ts
@@ -1,0 +1,110 @@
+import { describe, expect, it, vi } from "vitest"
+import type { AutonomousExtensions } from "./select-extensions.js"
+import { selectExtensionFactories } from "./select-extensions.js"
+
+function makeFactory() {
+	return vi.fn()
+}
+
+function makeAutonomousExtensions(overrides?: Partial<AutonomousExtensions>): AutonomousExtensions {
+	return {
+		resultWriter: vi.fn(),
+		...overrides,
+	}
+}
+
+describe("selectExtensionFactories", () => {
+	it("returns a shallow copy (not the same array reference) when autonomous is false", () => {
+		const base = [makeFactory(), makeFactory()]
+		const result = selectExtensionFactories(base, { autonomous: false })
+		expect(result).not.toBe(base)
+	})
+
+	it("returned array has the same length and same elements as base when autonomous is false", () => {
+		const f1 = makeFactory()
+		const f2 = makeFactory()
+		const base = [f1, f2]
+		const result = selectExtensionFactories(base, { autonomous: false })
+		expect(result).toHaveLength(2)
+		expect(result[0]).toBe(f1)
+		expect(result[1]).toBe(f2)
+	})
+
+	it("when autonomous is true with only resultWriter, returns base + resultWriter", () => {
+		const f1 = makeFactory()
+		const f2 = makeFactory()
+		const base = [f1, f2]
+		const autonomousExtensions = makeAutonomousExtensions()
+		const result = selectExtensionFactories(base, { autonomous: true, autonomousExtensions })
+		expect(result).toHaveLength(3)
+		expect(result[0]).toBe(f1)
+		expect(result[1]).toBe(f2)
+		expect(result[2]).toBe(autonomousExtensions.resultWriter)
+	})
+
+	it("when autonomous is true with resultWriter + timeoutGuard, appends both in order", () => {
+		const base = [makeFactory()]
+		const timeoutGuard = makeFactory()
+		const autonomousExtensions = makeAutonomousExtensions({ timeoutGuard })
+		const result = selectExtensionFactories(base, { autonomous: true, autonomousExtensions })
+		expect(result).toHaveLength(3)
+		expect(result[1]).toBe(autonomousExtensions.resultWriter)
+		expect(result[2]).toBe(timeoutGuard)
+	})
+
+	it("when autonomous is true with resultWriter + maxIterations, appends both in order", () => {
+		const base = [makeFactory()]
+		const maxIterations = makeFactory()
+		const autonomousExtensions = makeAutonomousExtensions({ maxIterations })
+		const result = selectExtensionFactories(base, { autonomous: true, autonomousExtensions })
+		expect(result).toHaveLength(3)
+		expect(result[1]).toBe(autonomousExtensions.resultWriter)
+		expect(result[2]).toBe(maxIterations)
+	})
+
+	it("when autonomous is true with all three optional extensions, appends all three after resultWriter", () => {
+		const base = [makeFactory(), makeFactory()]
+		const timeoutGuard = makeFactory()
+		const maxIterations = makeFactory()
+		const autonomousExtensions = makeAutonomousExtensions({ timeoutGuard, maxIterations })
+		const result = selectExtensionFactories(base, { autonomous: true, autonomousExtensions })
+		expect(result).toHaveLength(5)
+		expect(result[2]).toBe(autonomousExtensions.resultWriter)
+		expect(result[3]).toBe(timeoutGuard)
+		expect(result[4]).toBe(maxIterations)
+	})
+
+	it("does not mutate the base array after the call", () => {
+		const f1 = makeFactory()
+		const f2 = makeFactory()
+		const base = [f1, f2]
+		const autonomousExtensions = makeAutonomousExtensions()
+		selectExtensionFactories(base, { autonomous: true, autonomousExtensions })
+		expect(base).toHaveLength(2)
+	})
+
+	it("when autonomous is true and base is empty, returns just resultWriter", () => {
+		const autonomousExtensions = makeAutonomousExtensions()
+		const result = selectExtensionFactories([], { autonomous: true, autonomousExtensions })
+		expect(result).toHaveLength(1)
+		expect(result[0]).toBe(autonomousExtensions.resultWriter)
+	})
+
+	it("does not invoke any of the factories when called", () => {
+		const f1 = makeFactory()
+		const f2 = makeFactory()
+		const base = [f1, f2]
+		const timeoutGuard = makeFactory()
+		const maxIterations = makeFactory()
+		const autonomousExtensions = makeAutonomousExtensions({ timeoutGuard, maxIterations })
+
+		selectExtensionFactories(base, { autonomous: true, autonomousExtensions })
+		selectExtensionFactories(base, { autonomous: false })
+
+		expect(f1).not.toHaveBeenCalled()
+		expect(f2).not.toHaveBeenCalled()
+		expect(autonomousExtensions.resultWriter).not.toHaveBeenCalled()
+		expect(timeoutGuard).not.toHaveBeenCalled()
+		expect(maxIterations).not.toHaveBeenCalled()
+	})
+})

--- a/src/autonomous/select-extensions.ts
+++ b/src/autonomous/select-extensions.ts
@@ -1,0 +1,23 @@
+import type { ExtensionAPI, ExtensionFactory } from "@mariozechner/pi-coding-agent"
+
+export type { ExtensionFactory }
+
+export interface AutonomousExtensions {
+	resultWriter: (pi: ExtensionAPI) => void
+	timeoutGuard?: (pi: ExtensionAPI) => void
+	maxIterations?: (pi: ExtensionAPI) => void
+}
+
+export function selectExtensionFactories(
+	base: ExtensionFactory[],
+	options: { autonomous: false } | { autonomous: true; autonomousExtensions: AutonomousExtensions },
+): ExtensionFactory[] {
+	if (!options.autonomous) {
+		return [...base]
+	}
+	const { resultWriter, timeoutGuard, maxIterations } = options.autonomousExtensions
+	const extras: ExtensionFactory[] = [resultWriter]
+	if (timeoutGuard) extras.push(timeoutGuard)
+	if (maxIterations) extras.push(maxIterations)
+	return [...base, ...extras]
+}

--- a/src/autonomous/spec.test.ts
+++ b/src/autonomous/spec.test.ts
@@ -1,0 +1,235 @@
+import { randomUUID } from "node:crypto"
+import { rmSync, writeFileSync } from "node:fs"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
+import { afterEach, beforeEach, describe, expect, it } from "vitest"
+import { loadTaskSpec } from "./spec.js"
+
+describe("loadTaskSpec", () => {
+	const writtenPaths: string[] = []
+
+	function writeTmp(content: string): string {
+		const filePath = join(tmpdir(), `spec-test-${randomUUID()}.json`)
+		writeFileSync(filePath, content, "utf-8")
+		writtenPaths.push(filePath)
+		return filePath
+	}
+
+	afterEach(() => {
+		for (const p of writtenPaths) {
+			try {
+				rmSync(p)
+			} catch {
+				// ignore if already removed
+			}
+		}
+		writtenPaths.length = 0
+	})
+
+	it("loads a minimal valid spec with only prompt and defaults timeout_seconds to 3600", () => {
+		const filePath = writeTmp(JSON.stringify({ prompt: "do the thing" }))
+		const spec = loadTaskSpec(filePath)
+		expect(spec.prompt).toBe("do the thing")
+		expect(spec.timeout_seconds).toBe(3600)
+		expect(spec.model).toBeUndefined()
+		expect(spec.env).toBeUndefined()
+		expect(spec.mounts).toBeUndefined()
+		expect(spec.success_criteria).toBeUndefined()
+	})
+
+	it("loads a fully-populated valid spec with all fields set", () => {
+		const filePath = writeTmp(
+			JSON.stringify({
+				prompt: "refactor the codebase",
+				model: "claude-opus-4-5",
+				timeout_seconds: 7200,
+				env: { NODE_ENV: "test", DEBUG: "true" },
+				mounts: [
+					{ host: "/host/repo", container: "/workspace", readonly: false },
+					{ host: "/host/data", container: "/data", readonly: true },
+				],
+				success_criteria: "All tests pass and no lint errors",
+			}),
+		)
+		const spec = loadTaskSpec(filePath)
+		expect(spec.prompt).toBe("refactor the codebase")
+		expect(spec.model).toBe("claude-opus-4-5")
+		expect(spec.timeout_seconds).toBe(7200)
+		expect(spec.env).toEqual({ NODE_ENV: "test", DEBUG: "true" })
+		expect(spec.mounts).toHaveLength(2)
+		if (!spec.mounts) throw new Error("expected spec.mounts to be defined")
+		expect(spec.mounts[0]).toEqual({ host: "/host/repo", container: "/workspace", readonly: false })
+		expect(spec.mounts[1]).toEqual({ host: "/host/data", container: "/data", readonly: true })
+		expect(spec.success_criteria).toBe("All tests pass and no lint errors")
+	})
+
+	it("throws when prompt is missing", () => {
+		const filePath = writeTmp(JSON.stringify({ model: "gpt-4" }))
+		expect(() => loadTaskSpec(filePath)).toThrow(/prompt/)
+	})
+
+	it("throws when prompt is empty string", () => {
+		const filePath = writeTmp(JSON.stringify({ prompt: "" }))
+		expect(() => loadTaskSpec(filePath)).toThrow(/prompt/)
+	})
+
+	it("throws when timeout_seconds exceeds 21600 (hard cap)", () => {
+		const filePath = writeTmp(JSON.stringify({ prompt: "task", timeout_seconds: 21601 }))
+		expect(() => loadTaskSpec(filePath)).toThrow(/timeout_seconds/)
+	})
+
+	it("throws when timeout_seconds is 0", () => {
+		const filePath = writeTmp(JSON.stringify({ prompt: "task", timeout_seconds: 0 }))
+		expect(() => loadTaskSpec(filePath)).toThrow(/timeout_seconds/)
+	})
+
+	it("throws when timeout_seconds is negative", () => {
+		const filePath = writeTmp(JSON.stringify({ prompt: "task", timeout_seconds: -1 }))
+		expect(() => loadTaskSpec(filePath)).toThrow(/timeout_seconds/)
+	})
+
+	it("throws when JSON is malformed", () => {
+		const filePath = writeTmp("{ prompt: definitely not valid json }")
+		expect(() => loadTaskSpec(filePath)).toThrow()
+	})
+
+	it("throws when file does not exist", () => {
+		const nonExistentPath = join(tmpdir(), `spec-test-${randomUUID()}.json`)
+		expect(() => loadTaskSpec(nonExistentPath)).toThrow()
+	})
+
+	it("throws when mounts[0].host is missing", () => {
+		const filePath = writeTmp(
+			JSON.stringify({
+				prompt: "task",
+				mounts: [{ container: "/workspace" }],
+			}),
+		)
+		expect(() => loadTaskSpec(filePath)).toThrow(/mounts\[0\]\.host/)
+	})
+
+	it("throws when mounts[0].host is a non-string", () => {
+		const filePath = writeTmp(
+			JSON.stringify({
+				prompt: "task",
+				mounts: [{ host: 42, container: "/workspace" }],
+			}),
+		)
+		expect(() => loadTaskSpec(filePath)).toThrow(/mounts\[0\]\.host/)
+	})
+
+	it("throws when env value is non-string", () => {
+		const filePath = writeTmp(
+			JSON.stringify({
+				prompt: "task",
+				env: { KEY: 123 },
+			}),
+		)
+		expect(() => loadTaskSpec(filePath)).toThrow(/env/)
+	})
+
+	it("includes the field path in the error message for a missing nested field", () => {
+		const filePath = writeTmp(
+			JSON.stringify({
+				prompt: "task",
+				mounts: [{ host: "/host", container: "/workspace" }, { container: "/data" }],
+			}),
+		)
+		let error: Error | null = null
+		try {
+			loadTaskSpec(filePath)
+		} catch (err) {
+			error = err as Error
+		}
+		if (!error) throw new Error("expected error to be thrown")
+		expect(error.message).toMatch(/mounts\[1\]\.host/)
+	})
+
+	it("throws when mount host path is relative (does not start with /)", () => {
+		const filePath = writeTmp(
+			JSON.stringify({
+				prompt: "task",
+				mounts: [{ host: "relative/path", container: "/workspace" }],
+			}),
+		)
+		expect(() => loadTaskSpec(filePath)).toThrow()
+	})
+
+	it("throws when mount host path contains '..' segment", () => {
+		const filePath = writeTmp(
+			JSON.stringify({
+				prompt: "task",
+				mounts: [{ host: "/host/../etc", container: "/workspace" }],
+			}),
+		)
+		expect(() => loadTaskSpec(filePath)).toThrow()
+	})
+
+	it("throws when mount container path contains '..' segment", () => {
+		const filePath = writeTmp(
+			JSON.stringify({
+				prompt: "task",
+				mounts: [{ host: "/host/path", container: "/workspace/../etc" }],
+			}),
+		)
+		expect(() => loadTaskSpec(filePath)).toThrow()
+	})
+
+	it("accepts mount with absolute paths and no '..' segments", () => {
+		const filePath = writeTmp(
+			JSON.stringify({
+				prompt: "task",
+				mounts: [{ host: "/host/repo", container: "/workspace" }],
+			}),
+		)
+		const spec = loadTaskSpec(filePath)
+		expect(spec.mounts).toHaveLength(1)
+		if (!spec.mounts) throw new Error("expected mounts to be defined")
+		expect(spec.mounts[0].host).toBe("/host/repo")
+		expect(spec.mounts[0].container).toBe("/workspace")
+	})
+
+	it("accepts iterations field with a valid positive integer", () => {
+		const filePath = writeTmp(JSON.stringify({ prompt: "task", iterations: 5 }))
+		const spec = loadTaskSpec(filePath)
+		expect(spec.iterations).toBe(5)
+	})
+
+	it("iterations is undefined when not provided", () => {
+		const filePath = writeTmp(JSON.stringify({ prompt: "task" }))
+		const spec = loadTaskSpec(filePath)
+		expect(spec.iterations).toBeUndefined()
+	})
+
+	it("accepts iterations: 1 (minimum valid)", () => {
+		const filePath = writeTmp(JSON.stringify({ prompt: "task", iterations: 1 }))
+		const spec = loadTaskSpec(filePath)
+		expect(spec.iterations).toBe(1)
+	})
+
+	it("accepts iterations: 1000 (maximum valid)", () => {
+		const filePath = writeTmp(JSON.stringify({ prompt: "task", iterations: 1000 }))
+		const spec = loadTaskSpec(filePath)
+		expect(spec.iterations).toBe(1000)
+	})
+
+	it("throws when iterations is 0", () => {
+		const filePath = writeTmp(JSON.stringify({ prompt: "task", iterations: 0 }))
+		expect(() => loadTaskSpec(filePath)).toThrow(/iterations/)
+	})
+
+	it("throws when iterations is negative", () => {
+		const filePath = writeTmp(JSON.stringify({ prompt: "task", iterations: -1 }))
+		expect(() => loadTaskSpec(filePath)).toThrow(/iterations/)
+	})
+
+	it("throws when iterations is a non-integer (1.5)", () => {
+		const filePath = writeTmp(JSON.stringify({ prompt: "task", iterations: 1.5 }))
+		expect(() => loadTaskSpec(filePath)).toThrow(/iterations/)
+	})
+
+	it("throws when iterations exceeds 1000", () => {
+		const filePath = writeTmp(JSON.stringify({ prompt: "task", iterations: 1001 }))
+		expect(() => loadTaskSpec(filePath)).toThrow(/iterations/)
+	})
+})

--- a/src/autonomous/spec.ts
+++ b/src/autonomous/spec.ts
@@ -1,0 +1,58 @@
+import { readFileSync } from "node:fs"
+import { z } from "zod"
+
+const absolutePath = z.string().refine((p) => p.startsWith("/") && !p.split("/").some((seg) => seg === ".."), {
+	message: "must be an absolute path with no '..' segments",
+})
+
+const mountSchema = z.object({
+	host: absolutePath,
+	container: absolutePath,
+	readonly: z.boolean().optional(),
+})
+
+const taskSpecSchema = z.object({
+	prompt: z.string().min(1),
+	model: z.string().optional(),
+	timeout_seconds: z.number().int().min(1).max(21600).default(3600),
+	iterations: z.number().int().min(1).max(1000).optional(),
+	env: z.record(z.string(), z.string()).optional(),
+	mounts: z.array(mountSchema).optional(),
+	success_criteria: z.string().optional(),
+})
+
+export type TaskSpec = z.infer<typeof taskSpecSchema>
+
+function formatPath(path: ReadonlyArray<PropertyKey>): string {
+	return path.reduce<string>((acc, segment, i) => {
+		if (typeof segment === "number") {
+			return `${acc}[${segment}]`
+		}
+		const seg = String(segment)
+		return i === 0 ? seg : `${acc}.${seg}`
+	}, "")
+}
+
+export function loadTaskSpec(filePath: string): TaskSpec {
+	let raw: string
+	try {
+		raw = readFileSync(filePath, "utf-8")
+	} catch (err) {
+		throw new Error(`Failed to read task spec file at ${filePath}: ${(err as Error).message}`)
+	}
+
+	let parsed: unknown
+	try {
+		parsed = JSON.parse(raw)
+	} catch (err) {
+		throw new Error(`Failed to parse JSON in task spec file at ${filePath}: ${(err as Error).message}`)
+	}
+
+	const result = taskSpecSchema.safeParse(parsed)
+	if (!result.success) {
+		const paths = result.error.issues.map((issue) => formatPath(issue.path)).join(", ")
+		throw new Error(`Invalid task spec at ${filePath}: invalid field(s): ${paths}`)
+	}
+
+	return result.data
+}

--- a/src/cli-bootstrap.ts
+++ b/src/cli-bootstrap.ts
@@ -1,0 +1,131 @@
+// Shared agent-directory setup extracted from cli.ts so that autonomous mode
+// (auto.ts) can run the same harness preparation without entering the interactive
+// cli.ts path (which triggers probeTerminalBackground, setup wizard, etc.).
+//
+// cli.ts calls this before building extension factories.
+// auto.ts calls this before calling pi-coding-agent's main().
+//
+// Must NOT import cli.ts or auto.ts to avoid circular dependencies.
+
+import { mkdirSync, readFileSync, writeFileSync } from "node:fs"
+import { dirname, resolve } from "node:path"
+import { fileURLToPath } from "node:url"
+import { loadConfig, writeApiKey } from "./config.js"
+import { isBunBinary } from "./env.js"
+import { updateModelsConfig } from "./models.js"
+import { setAvailableModels } from "./startup-context.js"
+import { getVersion } from "./utils.js"
+
+export interface PrepareAgentEnvironmentResult {
+	apiKey: string
+}
+
+/**
+ * Sets up the agent directory for a kimchi run (interactive or autonomous).
+ *
+ * - Resolves the KIMCHI_API_KEY from env or config and persists it if needed.
+ * - Fetches / refreshes models.json in agentDir.
+ * - Shares discovered model metadata via setAvailableModels().
+ * - Writes a default settings.json if one doesn't exist yet.
+ * - Syncs bundled themes into agentDir/themes (byte-identical no-op if unchanged).
+ * - Patches globalThis.fetch to include a kimchi User-Agent header.
+ *
+ * Does NOT run probeTerminalBackground, the setup wizard, or
+ * reserveShiftTabForPermissions — those are interactive-only and remain in cli.ts.
+ *
+ * Throws if KIMCHI_CODING_AGENT_DIR is not set (must be entered via entry.ts).
+ * In autonomous mode throws with a clear message if no API key is available.
+ */
+export async function prepareAgentEnvironment(opts?: {
+	/** When true, throw instead of silently continuing when no API key is set. */
+	requireApiKey?: boolean
+}): Promise<PrepareAgentEnvironmentResult> {
+	const agentDir = process.env.KIMCHI_CODING_AGENT_DIR
+	if (!agentDir) {
+		throw new Error("KIMCHI_CODING_AGENT_DIR is not set; cli-bootstrap must be entered via entry.ts")
+	}
+
+	let config = loadConfig()
+	const envKey = process.env.KIMCHI_API_KEY || undefined
+	// biome-ignore lint/performance/noDelete: process.env coerces assignments to strings, so `= undefined` would set it to the literal "undefined"
+	delete process.env.KIMCHI_API_KEY
+	if (envKey && !config.apiKey) {
+		writeApiKey(envKey)
+		config = loadConfig()
+	}
+
+	const apiKey = config.apiKey
+
+	if (opts?.requireApiKey && !apiKey && !envKey) {
+		throw new Error("KIMCHI_API_KEY is not set and no API key is configured. Set KIMCHI_API_KEY to run autonomously.")
+	}
+
+	const resolvedApiKey = apiKey || envKey || ""
+
+	// Ensure models.json exists with Cast AI provider configuration
+	const modelsJsonPath = resolve(agentDir, "models.json")
+	const { models } = await updateModelsConfig(modelsJsonPath, resolvedApiKey)
+
+	// Share the discovered model metadata with extensions before main() runs.
+	setAvailableModels(models)
+
+	// Write default settings on first run only — respect user's choices afterward
+	const settingsPath = resolve(agentDir, "settings.json")
+	try {
+		readFileSync(settingsPath, "utf-8")
+	} catch (err) {
+		if ((err as NodeJS.ErrnoException).code === "ENOENT") {
+			writeFileSync(settingsPath, `${JSON.stringify({ quietStartup: true, theme: "kimchi-minimal" }, null, 2)}\n`)
+		} else {
+			console.error(`Warning: could not read ${settingsPath}: ${(err as Error).message}`)
+		}
+	}
+
+	// Bundled themes are write-through cache — owned by the package, not the user.
+	const themesDir = resolve(agentDir, "themes")
+	const bundledThemes = ["kimchi.json", "kimchi-minimal.json", "kimchi-light.json", "dark.json", "light.json"]
+	const bundledThemesSrcDir = isBunBinary
+		? resolve(process.env.PI_PACKAGE_DIR ?? "", "theme")
+		: resolve(dirname(fileURLToPath(import.meta.url)), "../themes")
+	mkdirSync(themesDir, { recursive: true })
+
+	for (const file of bundledThemes) {
+		const src = resolve(bundledThemesSrcDir, file)
+		const dest = resolve(themesDir, file)
+		let srcContent: string
+		try {
+			srcContent = readFileSync(src, "utf-8")
+		} catch {
+			console.warn(`Warning: bundled theme ${file} not found at ${src}, skipping`)
+			continue
+		}
+		let destContent: string | undefined
+		try {
+			destContent = readFileSync(dest, "utf-8")
+		} catch {
+			// dest missing — fall through and write
+		}
+		if (destContent !== srcContent) writeFileSync(dest, srcContent)
+	}
+
+	// Suppress Node.js warnings (same as pi-mono's own cli.js)
+	process.emitWarning = () => {}
+
+	// Patch globalThis.fetch to include a kimchi User-Agent header
+	const fetchPatchedSymbol = Symbol.for("kimchi.fetchPatched")
+	if (!(globalThis.fetch as typeof globalThis.fetch & { [key: symbol]: boolean })[fetchPatchedSymbol]) {
+		const userAgent = `kimchi/${getVersion()}`
+		const originalFetch = globalThis.fetch.bind(globalThis)
+		const patchedFetch = (input: RequestInfo | URL, init?: RequestInit): Promise<Response> => {
+			const headers = new Headers(init?.headers)
+			if (!headers.has("user-agent")) {
+				headers.set("user-agent", userAgent)
+			}
+			return originalFetch(input, { ...init, headers })
+		}
+		;(patchedFetch as typeof patchedFetch & { [key: symbol]: boolean })[fetchPatchedSymbol] = true
+		globalThis.fetch = patchedFetch
+	}
+
+	return { apiKey: resolvedApiKey }
+}

--- a/src/cli-extensions.ts
+++ b/src/cli-extensions.ts
@@ -1,0 +1,72 @@
+// Shared extension factories extracted from cli.ts so that auto.ts can import
+// them without triggering cli.ts's top-level side effects (probeTerminalBackground,
+// readTelemetryConfig at module load, process.on("exit"), etc.).
+
+import type { ExtensionAPI, ExtensionFactory } from "@mariozechner/pi-coding-agent"
+import type { TelemetryConfig } from "./config.js"
+import bashCollapseExtension from "./extensions/bash-collapse.js"
+import clipboardImageExtension from "./extensions/clipboard-image.js"
+import contextCompactorExtension from "./extensions/context-compactor.js"
+import kimchiMinimalTintsExtension from "./extensions/kimchi-minimal-tints.js"
+import loginExtension from "./extensions/login/index.js"
+import loopGuardExtension from "./extensions/loop-guard.js"
+import lspExtension from "./extensions/lsp.js"
+import mcpAdapterExtension from "./extensions/mcp-adapter/index.js"
+import promptEnrichmentExtension from "./extensions/orchestration/prompt-enrichment.js"
+import permissionsExtension from "./extensions/permissions/index.js"
+import promptSummaryExtension from "./extensions/prompt-summary.js"
+import shutdownMarkerExtension from "./extensions/shutdown-marker.js"
+import startupUpdateExtension from "./extensions/startup-update.js"
+import subagentExtension from "./extensions/subagent.js"
+import tagsExtension from "./extensions/tags.js"
+import telemetryExtension from "./extensions/telemetry.js"
+import terminalColorsExtension from "./extensions/terminal-colors.js"
+import toolRendererExtension from "./extensions/tool-renderer.js"
+import uiExtension from "./extensions/ui.js"
+import webFetchExtension from "./extensions/web-fetch/index.js"
+import webSearchExtension from "./extensions/web-search/index.js"
+
+export interface BaseExtensionDeps {
+	telemetryConfig: TelemetryConfig
+	skillPaths: string[]
+	sessionIdCaptureExtension: (pi: ExtensionAPI) => void
+}
+
+export function buildBaseExtensionFactories(deps: BaseExtensionDeps): ExtensionFactory[] {
+	return [
+		startupUpdateExtension,
+		deps.sessionIdCaptureExtension,
+		shutdownMarkerExtension,
+		terminalColorsExtension,
+		kimchiMinimalTintsExtension,
+		bashCollapseExtension,
+		loopGuardExtension,
+		lspExtension,
+		mcpAdapterExtension,
+		permissionsExtension,
+		promptEnrichmentExtension(deps.skillPaths),
+		promptSummaryExtension,
+		contextCompactorExtension,
+		clipboardImageExtension,
+		uiExtension,
+		subagentExtension,
+		tagsExtension,
+		telemetryExtension(deps.telemetryConfig),
+		toolRendererExtension,
+		webFetchExtension,
+		webSearchExtension,
+		loginExtension,
+	]
+}
+
+/**
+ * Returns a no-op sessionIdCaptureExtension suitable for autonomous runs.
+ * Autonomous runs use --no-session so there is no resume hint to print.
+ */
+export function makeAutonomousSessionIdCapture(): (pi: ExtensionAPI) => void {
+	return (pi: ExtensionAPI) => {
+		pi.on("session_start", () => {
+			// no-op: autonomous runs don't need resume hint tracking
+		})
+	}
+}

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,48 +1,16 @@
 // CLI logic — imported dynamically by entry.ts after PI_PACKAGE_DIR is set.
 // All static imports here (extensions, pi-mono) are safe because the env is already configured.
 
-import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs"
-import { dirname, resolve } from "node:path"
-import { fileURLToPath } from "node:url"
+import { existsSync } from "node:fs"
 import type { ExtensionAPI, ExtensionContext } from "@mariozechner/pi-coding-agent"
+import { prepareAgentEnvironment } from "./cli-bootstrap.js"
+import { buildBaseExtensionFactories } from "./cli-extensions.js"
 import { dispatchSubcommand } from "./commands/dispatch.js"
-import {
-	DEFAULT_SKILL_PATHS,
-	loadConfig,
-	readTelemetryConfig,
-	writeApiKey,
-	writeMigrationState,
-	writeSkillPaths,
-} from "./config.js"
-import { isBunBinary } from "./env.js"
-import bashCollapseExtension from "./extensions/bash-collapse.js"
-import clipboardImageExtension from "./extensions/clipboard-image.js"
-import contextCompactorExtension from "./extensions/context-compactor.js"
-import kimchiMinimalTintsExtension from "./extensions/kimchi-minimal-tints.js"
-import loginExtension from "./extensions/login/index.js"
-import loopGuardExtension from "./extensions/loop-guard.js"
-import lspExtension from "./extensions/lsp.js"
-import mcpAdapterExtension from "./extensions/mcp-adapter/index.js"
-import promptEnrichmentExtension from "./extensions/orchestration/prompt-enrichment.js"
-import permissionsExtension from "./extensions/permissions/index.js"
+import { DEFAULT_SKILL_PATHS, loadConfig, readTelemetryConfig, writeMigrationState, writeSkillPaths } from "./config.js"
 import { reserveShiftTabForPermissions } from "./extensions/permissions/keybindings.js"
-import promptSummaryExtension from "./extensions/prompt-summary.js"
-import shutdownMarkerExtension from "./extensions/shutdown-marker.js"
-import startupUpdateExtension from "./extensions/startup-update.js"
 // import statsExtension from "./extensions/stats/index.js"
-import subagentExtension from "./extensions/subagent.js"
-import tagsExtension from "./extensions/tags.js"
-import telemetryExtension from "./extensions/telemetry.js"
-import terminalColorsExtension from "./extensions/terminal-colors.js"
-import toolRendererExtension from "./extensions/tool-renderer.js"
-import uiExtension from "./extensions/ui.js"
-import webFetchExtension from "./extensions/web-fetch/index.js"
-import webSearchExtension from "./extensions/web-search/index.js"
-import { updateModelsConfig } from "./models.js"
 import { runSetupWizard } from "./setup-wizard.js"
-import { setAvailableModels } from "./startup-context.js"
 import { probeTerminalBackground } from "./terminal-bg-probe.js"
-import { getVersion } from "./utils.js"
 
 const telemetryConfig = readTelemetryConfig()
 
@@ -123,18 +91,11 @@ try {
 		// hook keys off this flag instead of just running unconditionally on a
 		// 0-status exit.
 		sessionStarted = true
-		let config = loadConfig()
 
-		const envKey = process.env.KIMCHI_API_KEY || undefined
-		// biome-ignore lint/performance/noDelete: process.env coerces assignments to strings, so `= undefined` would set it to the literal "undefined"
-		delete process.env.KIMCHI_API_KEY
-		if (envKey && !config.apiKey) {
-			writeApiKey(envKey)
-			config = loadConfig()
-		}
-
-		const apiKey = config.apiKey
-
+		// Interactive-only: skill paths setup wizard and migration check.
+		// These run before prepareAgentEnvironment because the wizard may prompt
+		// the user for skill path choices that are persisted to config.
+		const config = loadConfig()
 		const needsSkillsSetup = config.skillPaths === undefined
 		const needsMigrationCheck = config.migrationState === undefined
 		let skillPaths = config.skillPaths ?? []
@@ -158,46 +119,16 @@ try {
 			}
 		}
 
-		// Ensure models.json exists with Cast AI provider configuration
+		// Shared harness setup: API key, models.json, settings.json, themes, fetch patch.
+		await prepareAgentEnvironment()
+
+		// Must run before main() so the keybindings file is loaded with the
+		// override in place. Interactive-only — autonomous mode doesn't need it.
 		const agentDir = process.env.KIMCHI_CODING_AGENT_DIR
 		if (!agentDir) {
 			throw new Error("KIMCHI_CODING_AGENT_DIR is not set; cli.ts must be entered via entry.ts")
 		}
-		const modelsJsonPath = resolve(agentDir, "models.json")
-		const { models } = await updateModelsConfig(modelsJsonPath, apiKey)
-
-		// Must run before main() so the keybindings file is loaded with the
-		// override in place.
 		reserveShiftTabForPermissions(agentDir)
-
-		// Share the discovered model metadata with extensions before main() runs.
-		// prompt-enrichment reads this to build ModelRegistry with live model IDs.
-		setAvailableModels(models)
-
-		// Write default settings on first run only — respect user's choices afterward
-		const settingsPath = resolve(agentDir, "settings.json")
-		try {
-			readFileSync(settingsPath, "utf-8")
-		} catch (err) {
-			if ((err as NodeJS.ErrnoException).code === "ENOENT") {
-				writeFileSync(settingsPath, `${JSON.stringify({ quietStartup: true, theme: "kimchi-minimal" }, null, 2)}\n`)
-			} else {
-				console.error(`Warning: could not read ${settingsPath}: ${(err as Error).message}`)
-			}
-		}
-
-		// Bundled themes are write-through cache — owned by the package, not the user.
-		// Source edits propagate so packaged upgrades pick up new defaults. Users
-		// wanting custom colors should clone+rename (e.g. `my-kimchi.json`), which
-		// this loop won't touch. The kimchi-minimal source keeps all six bg tokens
-		// as `""` placeholders; the kimchi-minimal-tints extension fills them in
-		// per-process at session_start from the OSC 11 probe.
-		const themesDir = resolve(agentDir, "themes")
-		const bundledThemes = ["kimchi.json", "kimchi-minimal.json", "kimchi-light.json", "dark.json", "light.json"]
-		const bundledThemesSrcDir = isBunBinary
-			? resolve(process.env.PI_PACKAGE_DIR ?? "", "theme")
-			: resolve(dirname(fileURLToPath(import.meta.url)), "../themes")
-		mkdirSync(themesDir, { recursive: true })
 
 		// Probe runs here (before pi-mono takes stdin) so the result is cached for
 		// the kimchi-minimal-tints and terminal-colors extensions. Skip in ACP mode —
@@ -205,76 +136,11 @@ try {
 		// input stream.
 		if (!acpMode) await probeTerminalBackground()
 
-		// Compare contents and only write when they differ. Restarts in a second
-		// terminal must be byte-identical no-ops because pi runs `fs.watch` on the
-		// active theme file — any rewrite (even with the same bytes via copyFileSync)
-		// fires a reload in every other running instance. The previous version of
-		// this loop injected per-process bg tints into kimchi-minimal.json on every
-		// startup; that race is what made terminals clobber each other's colors.
-		// Tints now live in memory only, applied by the kimchi-minimal-tints
-		// extension at session_start.
-		for (const file of bundledThemes) {
-			const src = resolve(bundledThemesSrcDir, file)
-			const dest = resolve(themesDir, file)
-			let srcContent: string
-			try {
-				srcContent = readFileSync(src, "utf-8")
-			} catch {
-				console.warn(`Warning: bundled theme ${file} not found at ${src}, skipping`)
-				continue
-			}
-			let destContent: string | undefined
-			try {
-				destContent = readFileSync(dest, "utf-8")
-			} catch {
-				// dest missing — fall through and write
-			}
-			if (destContent !== srcContent) writeFileSync(dest, srcContent)
-		}
-
-		// Suppress Node.js warnings (same as pi-mono's own cli.js)
-		process.emitWarning = () => {}
-
-		const fetchPatchedSymbol = Symbol.for("kimchi.fetchPatched")
-		if (!(globalThis.fetch as typeof globalThis.fetch & { [key: symbol]: boolean })[fetchPatchedSymbol]) {
-			const userAgent = `kimchi/${getVersion()}`
-			const originalFetch = globalThis.fetch.bind(globalThis)
-			const patchedFetch = (input: RequestInfo | URL, init?: RequestInit): Promise<Response> => {
-				const headers = new Headers(init?.headers)
-				if (!headers.has("user-agent")) {
-					headers.set("user-agent", userAgent)
-				}
-				return originalFetch(input, { ...init, headers })
-			}
-			;(patchedFetch as typeof patchedFetch & { [key: symbol]: boolean })[fetchPatchedSymbol] = true
-			globalThis.fetch = patchedFetch
-		}
-
-		const extensionFactories = [
-			startupUpdateExtension,
+		const extensionFactories = buildBaseExtensionFactories({
+			telemetryConfig,
+			skillPaths,
 			sessionIdCaptureExtension,
-			shutdownMarkerExtension,
-			// statsExtension,
-			terminalColorsExtension,
-			kimchiMinimalTintsExtension,
-			bashCollapseExtension,
-			loopGuardExtension,
-			lspExtension,
-			mcpAdapterExtension,
-			permissionsExtension,
-			promptEnrichmentExtension(skillPaths),
-			promptSummaryExtension,
-			contextCompactorExtension,
-			clipboardImageExtension,
-			uiExtension,
-			subagentExtension,
-			tagsExtension,
-			telemetryExtension(telemetryConfig),
-			toolRendererExtension,
-			webFetchExtension,
-			webSearchExtension,
-			loginExtension,
-		]
+		})
 
 		const rawArgs = process.argv.slice(2)
 		if (acpMode) {

--- a/src/commands/auto.test.ts
+++ b/src/commands/auto.test.ts
@@ -1,0 +1,688 @@
+import { existsSync, readFileSync, rmSync } from "node:fs"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
+import type { ExtensionAPI } from "@mariozechner/pi-coding-agent"
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
+import type { TaskSpec } from "../autonomous/spec.js"
+import { buildAutoArgs, buildExtensionFactories, parseAutoArgs, runAuto } from "./auto.js"
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function makeSpec(overrides?: Partial<TaskSpec>): TaskSpec {
+	return {
+		prompt: "do the thing",
+		timeout_seconds: 3600,
+		...overrides,
+	}
+}
+
+// ---------------------------------------------------------------------------
+// parseAutoArgs
+// ---------------------------------------------------------------------------
+
+describe("parseAutoArgs", () => {
+	it("bare positional prompt ends up in passthroughArgs", () => {
+		const result = parseAutoArgs(["do the thing"])
+		expect(result).toMatchObject({ passthroughArgs: ["do the thing"], help: false })
+		expect(result.taskPath).toBeUndefined()
+	})
+
+	it("@file.md passthrough ends up in passthroughArgs", () => {
+		const result = parseAutoArgs(["@instructions.md"])
+		expect(result.passthroughArgs).toContain("@instructions.md")
+	})
+
+	it("--task <path> sets taskPath and does not appear in passthroughArgs", () => {
+		const result = parseAutoArgs(["--task", "/tmp/spec.json"])
+		expect(result.taskPath).toBe("/tmp/spec.json")
+		expect(result.passthroughArgs).not.toContain("--task")
+		expect(result.passthroughArgs).not.toContain("/tmp/spec.json")
+	})
+
+	it("--iterations N sets iterations", () => {
+		const result = parseAutoArgs(["--iterations", "5"])
+		expect(result.iterations).toBe(5)
+	})
+
+	it("--max-iterations N sets iterations (alias)", () => {
+		const result = parseAutoArgs(["--max-iterations", "10"])
+		expect(result.iterations).toBe(10)
+	})
+
+	it("--timeout-seconds N sets timeoutSeconds", () => {
+		const result = parseAutoArgs(["--timeout-seconds", "120"])
+		expect(result.timeoutSeconds).toBe(120)
+	})
+
+	it("mix of flags: --task, --iterations, --timeout-seconds, and passthrough", () => {
+		const result = parseAutoArgs([
+			"--task",
+			"/tmp/spec.json",
+			"--iterations",
+			"3",
+			"--timeout-seconds",
+			"60",
+			"@file.md",
+		])
+		expect(result.taskPath).toBe("/tmp/spec.json")
+		expect(result.iterations).toBe(3)
+		expect(result.timeoutSeconds).toBe(60)
+		expect(result.passthroughArgs).toContain("@file.md")
+	})
+
+	it("--help returns { help: true, passthroughArgs: [] }", () => {
+		const result = parseAutoArgs(["--help"])
+		expect(result.help).toBe(true)
+		expect(result.passthroughArgs).toEqual([])
+	})
+
+	it("-h returns { help: true, passthroughArgs: [] }", () => {
+		const result = parseAutoArgs(["-h"])
+		expect(result.help).toBe(true)
+	})
+
+	it("throws when --task has no value", () => {
+		expect(() => parseAutoArgs(["--task"])).toThrow(/missing --task value/)
+	})
+
+	it("throws when --task next token starts with -", () => {
+		expect(() => parseAutoArgs(["--task", "--other"])).toThrow(/missing --task value/)
+	})
+
+	it("throws when --iterations has no value", () => {
+		expect(() => parseAutoArgs(["--iterations"])).toThrow(/missing --iterations value/)
+	})
+
+	it("throws when --iterations value is not a positive integer", () => {
+		expect(() => parseAutoArgs(["--iterations", "0"])).toThrow(/positive integer/)
+		expect(() => parseAutoArgs(["--iterations", "-1"])).toThrow(/positive integer/)
+	})
+
+	it("throws when --timeout-seconds has no value", () => {
+		expect(() => parseAutoArgs(["--timeout-seconds"])).toThrow(/missing --timeout-seconds value/)
+	})
+
+	it("empty array returns no taskPath, no iterations, no timeout, empty passthroughArgs", () => {
+		const result = parseAutoArgs([])
+		expect(result).toEqual({ help: false, passthroughArgs: [] })
+	})
+
+	it("does not mutate the input args array", () => {
+		const args = ["--task", "/tmp/spec.json", "--extra"]
+		const copy = [...args]
+		parseAutoArgs(args)
+		expect(args).toEqual(copy)
+	})
+})
+
+// ---------------------------------------------------------------------------
+// buildAutoArgs
+// ---------------------------------------------------------------------------
+
+describe("buildAutoArgs", () => {
+	const emptyParsed = { help: false, passthroughArgs: [] }
+
+	it("no spec + empty passthrough returns the four forced flags", () => {
+		const result = buildAutoArgs(undefined, emptyParsed)
+		expect(result).toEqual(["--yolo", "--print", "--mode", "json", "--no-session"])
+	})
+
+	it("spec.prompt is inserted after the forced flags", () => {
+		const spec = makeSpec({ prompt: "do the thing" })
+		const result = buildAutoArgs(spec, emptyParsed)
+		expect(result).toEqual(["--yolo", "--print", "--mode", "json", "--no-session", "do the thing"])
+	})
+
+	it("spec.model adds --model flag between --no-session and prompt", () => {
+		const spec = makeSpec({ prompt: "do the thing", model: "claude-opus-4-5" })
+		const result = buildAutoArgs(spec, emptyParsed)
+		expect(result).toEqual([
+			"--yolo",
+			"--print",
+			"--mode",
+			"json",
+			"--no-session",
+			"--model",
+			"claude-opus-4-5",
+			"do the thing",
+		])
+	})
+
+	it("passthroughArgs are appended after spec.prompt", () => {
+		const spec = makeSpec({ prompt: "do the thing" })
+		const result = buildAutoArgs(spec, { ...emptyParsed, passthroughArgs: ["--verbose"] })
+		expect(result).toEqual(["--yolo", "--print", "--mode", "json", "--no-session", "do the thing", "--verbose"])
+	})
+
+	it("no spec: passthroughArgs still appended after forced flags", () => {
+		const result = buildAutoArgs(undefined, { ...emptyParsed, passthroughArgs: ["@file.md", "extra"] })
+		expect(result).toEqual(["--yolo", "--print", "--mode", "json", "--no-session", "@file.md", "extra"])
+	})
+
+	it("returns a new array on each call (no shared reference)", () => {
+		const spec = makeSpec()
+		const a = buildAutoArgs(spec, emptyParsed)
+		const b = buildAutoArgs(spec, emptyParsed)
+		expect(a).not.toBe(b)
+	})
+
+	it("does not mutate the input spec", () => {
+		const spec = makeSpec({ prompt: "do the thing", model: "some-model" })
+		const before = JSON.stringify(spec)
+		buildAutoArgs(spec, { ...emptyParsed, passthroughArgs: ["--extra"] })
+		expect(JSON.stringify(spec)).toBe(before)
+	})
+})
+
+// ---------------------------------------------------------------------------
+// buildExtensionFactories
+// ---------------------------------------------------------------------------
+
+describe("buildExtensionFactories", () => {
+	it("returns {factories, control} shape", async () => {
+		const result = await buildExtensionFactories({}, async () => [])
+		expect(result).toHaveProperty("factories")
+		expect(result).toHaveProperty("control")
+		expect(typeof result.control.markError).toBe("function")
+		expect(typeof result.control.markTimeout).toBe("function")
+		expect(typeof result.control.flush).toBe("function")
+	})
+
+	it("just resultWriter when neither iterations nor timeout set", async () => {
+		const stubA = (_pi: ExtensionAPI) => {}
+		const stubB = (_pi: ExtensionAPI) => {}
+		const { factories } = await buildExtensionFactories({}, async () => [stubA, stubB])
+		// base (2) + resultWriter (1) = 3
+		expect(factories).toHaveLength(3)
+		expect(factories[0]).toBe(stubA)
+		expect(factories[1]).toBe(stubB)
+	})
+
+	it("resultWriter + timeoutGuard when only timeout set", async () => {
+		const { factories } = await buildExtensionFactories({ timeoutSeconds: 60 }, async () => [])
+		// resultWriter + timeoutGuard = 2
+		expect(factories).toHaveLength(2)
+	})
+
+	it("resultWriter + maxIterations when only iterations set", async () => {
+		const { factories } = await buildExtensionFactories({ iterations: 3 }, async () => [])
+		// resultWriter + maxIterations = 2
+		expect(factories).toHaveLength(2)
+	})
+
+	it("all three (resultWriter + timeoutGuard + maxIterations) when both set", async () => {
+		const { factories } = await buildExtensionFactories({ timeoutSeconds: 60, iterations: 3 }, async () => [])
+		// resultWriter + timeoutGuard + maxIterations = 3
+		expect(factories).toHaveLength(3)
+	})
+
+	it("works with an empty base", async () => {
+		const { factories } = await buildExtensionFactories({}, async () => [])
+		expect(factories).toHaveLength(1)
+	})
+})
+
+// ---------------------------------------------------------------------------
+// runAuto
+// ---------------------------------------------------------------------------
+
+describe("runAuto", () => {
+	let errSpy: ReturnType<typeof vi.spyOn>
+
+	const stubBase = async () => [(_pi: ExtensionAPI) => {}, (_pi: ExtensionAPI) => {}]
+	const stubPrepare = async () => {}
+
+	beforeEach(() => {
+		errSpy = vi.spyOn(console, "error").mockImplementation(() => {})
+	})
+
+	afterEach(() => {
+		errSpy.mockRestore()
+	})
+
+	it("calls runHarness with correct argv (forced flags + spec prompt) on success with --task", async () => {
+		const spec = makeSpec({ prompt: "hello world" })
+		const loadTaskSpec = vi.fn().mockReturnValue(spec)
+		const runHarness = vi.fn().mockResolvedValue(undefined)
+
+		await runAuto(["--task", "/tmp/spec.json"], {
+			loadTaskSpec,
+			runHarness,
+			buildBaseFactories: stubBase,
+			prepareEnvironment: stubPrepare,
+		})
+
+		expect(loadTaskSpec).toHaveBeenCalledWith("/tmp/spec.json")
+		const [calledArgs] = runHarness.mock.calls[0]
+		expect(calledArgs).toEqual(["--yolo", "--print", "--mode", "json", "--no-session", "hello world"])
+	})
+
+	it("returns 0 on success", async () => {
+		const spec = makeSpec()
+		const loadTaskSpec = vi.fn().mockReturnValue(spec)
+		const runHarness = vi.fn().mockResolvedValue(undefined)
+
+		const result = await runAuto(["--task", "/tmp/spec.json"], {
+			loadTaskSpec,
+			runHarness,
+			buildBaseFactories: stubBase,
+			prepareEnvironment: stubPrepare,
+		})
+
+		expect(result).toBe(0)
+	})
+
+	it("works without --task: passthrough args forwarded directly", async () => {
+		const runHarness = vi.fn().mockResolvedValue(undefined)
+
+		await runAuto(["@file.md", "do the thing"], {
+			runHarness,
+			buildBaseFactories: stubBase,
+			prepareEnvironment: stubPrepare,
+		})
+
+		const [calledArgs] = runHarness.mock.calls[0]
+		expect(calledArgs).toEqual(["--yolo", "--print", "--mode", "json", "--no-session", "@file.md", "do the thing"])
+	})
+
+	it("--iterations from CLI caps turn_end (factories include maxIterations)", async () => {
+		const runHarness = vi.fn().mockResolvedValue(undefined)
+
+		await runAuto(["--iterations", "3", "do work"], {
+			runHarness,
+			buildBaseFactories: stubBase,
+			prepareEnvironment: stubPrepare,
+		})
+
+		const [, { extensionFactories }] = runHarness.mock.calls[0]
+		// stubBase(2) + resultWriter + maxIterations = 4
+		expect(extensionFactories).toHaveLength(4)
+	})
+
+	it("spec.iterations used when --iterations not on CLI", async () => {
+		const spec = makeSpec({ iterations: 5 })
+		const loadTaskSpec = vi.fn().mockReturnValue(spec)
+		const runHarness = vi.fn().mockResolvedValue(undefined)
+
+		await runAuto(["--task", "/tmp/spec.json"], {
+			loadTaskSpec,
+			runHarness,
+			buildBaseFactories: stubBase,
+			prepareEnvironment: stubPrepare,
+		})
+
+		const [, { extensionFactories }] = runHarness.mock.calls[0]
+		// stubBase(2) + resultWriter + timeoutGuard (from spec.timeout_seconds) + maxIterations = 5
+		expect(extensionFactories).toHaveLength(5)
+	})
+
+	it("CLI --iterations overrides spec.iterations", async () => {
+		const spec = makeSpec({ iterations: 10 })
+		const loadTaskSpec = vi.fn().mockReturnValue(spec)
+		const runHarness = vi.fn().mockResolvedValue(undefined)
+
+		await runAuto(["--task", "/tmp/spec.json", "--iterations", "2"], {
+			loadTaskSpec,
+			runHarness,
+			buildBaseFactories: stubBase,
+			prepareEnvironment: stubPrepare,
+		})
+
+		// Just check it runs without error; iteration count comes from CLI (2)
+		expect(runHarness).toHaveBeenCalledOnce()
+	})
+
+	it("returns 1 and logs error when loadTaskSpec throws", async () => {
+		const loadTaskSpec = vi.fn().mockImplementation(() => {
+			throw new Error("file not found")
+		})
+		const runHarness = vi.fn()
+
+		const result = await runAuto(["--task", "/tmp/spec.json"], {
+			loadTaskSpec,
+			runHarness,
+			buildBaseFactories: stubBase,
+			prepareEnvironment: stubPrepare,
+		})
+
+		expect(result).toBe(1)
+		expect(runHarness).not.toHaveBeenCalled()
+		expect(errSpy).toHaveBeenCalledWith("file not found")
+	})
+
+	it("returns 1 and logs error when runHarness throws", async () => {
+		const spec = makeSpec()
+		const loadTaskSpec = vi.fn().mockReturnValue(spec)
+		const runHarness = vi.fn().mockRejectedValue(new Error("harness exploded"))
+
+		const result = await runAuto(["--task", "/tmp/spec.json"], {
+			loadTaskSpec,
+			runHarness,
+			buildBaseFactories: stubBase,
+			prepareEnvironment: stubPrepare,
+		})
+
+		expect(result).toBe(1)
+		expect(errSpy).toHaveBeenCalledWith("harness exploded")
+	})
+
+	it("calls control.markError and writes result.json with exit_reason 'error' when runHarness throws", async () => {
+		const resultDir = join(tmpdir(), `auto-test-${Math.random().toString(36).slice(2)}`)
+		const originalEnv = process.env.KIMCHI_RESULT_DIR
+		process.env.KIMCHI_RESULT_DIR = resultDir
+
+		try {
+			const spec = makeSpec()
+			const loadTaskSpec = vi.fn().mockReturnValue(spec)
+			const runHarness = vi.fn().mockRejectedValue(new Error("harness exploded"))
+
+			const result = await runAuto(["--task", "/tmp/spec.json"], {
+				loadTaskSpec,
+				runHarness,
+				buildBaseFactories: stubBase,
+				prepareEnvironment: stubPrepare,
+			})
+
+			expect(result).toBe(1)
+			const manifestPath = join(resultDir, "result.json")
+			expect(existsSync(manifestPath)).toBe(true)
+			const manifest = JSON.parse(readFileSync(manifestPath, "utf-8")) as {
+				exit_reason: string
+				error: { message: string }
+			}
+			expect(manifest.exit_reason).toBe("error")
+			expect(manifest.error.message).toBe("harness exploded")
+		} finally {
+			if (originalEnv === undefined) {
+				// biome-ignore lint/performance/noDelete: process.env.X = undefined coerces to "undefined" string
+				delete process.env.KIMCHI_RESULT_DIR
+			} else {
+				process.env.KIMCHI_RESULT_DIR = originalEnv
+			}
+			rmSync(resultDir, { recursive: true, force: true })
+		}
+	})
+
+	it("returns 0 and logs usage when --help is passed", async () => {
+		const runHarness = vi.fn()
+		const logSpy = vi.spyOn(console, "log").mockImplementation(() => {})
+
+		const result = await runAuto(["--help"], {
+			runHarness,
+			buildBaseFactories: stubBase,
+			prepareEnvironment: stubPrepare,
+		})
+
+		expect(result).toBe(0)
+		expect(runHarness).not.toHaveBeenCalled()
+		expect(logSpy).toHaveBeenCalledWith(expect.stringContaining("Usage"))
+		logSpy.mockRestore()
+	})
+
+	it("returns 0 and logs usage when -h is passed", async () => {
+		const runHarness = vi.fn()
+		const logSpy = vi.spyOn(console, "log").mockImplementation(() => {})
+
+		const result = await runAuto(["-h"], {
+			runHarness,
+			buildBaseFactories: stubBase,
+			prepareEnvironment: stubPrepare,
+		})
+
+		expect(result).toBe(0)
+		logSpy.mockRestore()
+	})
+
+	it("returns 1 and logs error when prepareEnvironment throws", async () => {
+		const spec = makeSpec()
+		const loadTaskSpec = vi.fn().mockReturnValue(spec)
+		const runHarness = vi.fn()
+		const prepareEnvironment = vi.fn().mockRejectedValue(new Error("KIMCHI_API_KEY is not set"))
+
+		const result = await runAuto(["--task", "/tmp/spec.json"], {
+			loadTaskSpec,
+			runHarness,
+			buildBaseFactories: stubBase,
+			prepareEnvironment,
+		})
+
+		expect(result).toBe(1)
+		expect(runHarness).not.toHaveBeenCalled()
+		expect(errSpy).toHaveBeenCalledWith("KIMCHI_API_KEY is not set")
+	})
+
+	it("returns 1 when parseAutoArgs throws (e.g. --task with no value)", async () => {
+		const runHarness = vi.fn()
+
+		const result = await runAuto(["--task"], {
+			runHarness,
+			buildBaseFactories: stubBase,
+			prepareEnvironment: stubPrepare,
+		})
+
+		expect(result).toBe(1)
+		expect(runHarness).not.toHaveBeenCalled()
+	})
+})
+
+// ---------------------------------------------------------------------------
+// runAuto — containerized path (--runtime)
+// ---------------------------------------------------------------------------
+
+describe("runAuto containerized (--runtime)", () => {
+	let errSpy: ReturnType<typeof vi.spyOn>
+	let logSpy: ReturnType<typeof vi.spyOn>
+
+	beforeEach(() => {
+		errSpy = vi.spyOn(console, "error").mockImplementation(() => {})
+		logSpy = vi.spyOn(console, "log").mockImplementation(() => {})
+	})
+
+	afterEach(() => {
+		errSpy.mockRestore()
+		logSpy.mockRestore()
+		vi.unstubAllEnvs()
+	})
+
+	function makeFs(opts?: { existsSync?: (p: string) => boolean }) {
+		return {
+			existsSync: opts?.existsSync ?? (() => true),
+			mkdirSync: vi.fn(),
+			copyFileSync: vi.fn(),
+		}
+	}
+
+	function makeRuntime(opts?: { exitCode?: number }) {
+		return {
+			name: "docker",
+			run: vi.fn().mockResolvedValue({ exitCode: opts?.exitCode ?? 0, durationMs: 100 }),
+		}
+	}
+
+	function makeReadResult(opts?: { exit_reason?: string; error?: { message: string }; throws?: boolean }) {
+		return vi.fn().mockImplementation(() => {
+			if (opts?.throws) throw new Error("manifest missing")
+			return {
+				exit_reason: opts?.exit_reason ?? "done",
+				started_at: "2026-05-07T00:00:00.000Z",
+				ended_at: "2026-05-07T00:00:01.000Z",
+				...(opts?.error ? { error: opts.error } : {}),
+			}
+		})
+	}
+
+	it("happy path: returns 0 when runtime exits 0 and manifest reads ok", async () => {
+		const spec = makeSpec({ prompt: "p", timeout_seconds: 60 })
+		const result = await runAuto(["--task", "/tmp/spec.json", "--runtime", "docker", "--workspace", "/tmp/ws"], {
+			loadTaskSpec: () => spec,
+			selectRuntime: () => makeRuntime({ exitCode: 0 }),
+			readResult: makeReadResult(),
+			fs: makeFs(),
+		})
+		expect(result).toBe(0)
+	})
+
+	it("propagates non-zero container exit code", async () => {
+		const spec = makeSpec({ prompt: "p", timeout_seconds: 60 })
+		const result = await runAuto(["--task", "/tmp/spec.json", "--runtime", "docker", "--workspace", "/tmp/ws"], {
+			loadTaskSpec: () => spec,
+			selectRuntime: () => makeRuntime({ exitCode: 124 }),
+			readResult: makeReadResult({ exit_reason: "timeout" }),
+			fs: makeFs(),
+		})
+		expect(result).toBe(124)
+	})
+
+	it("returns 1 when --task is not provided (--runtime requires --task)", async () => {
+		const result = await runAuto(["--runtime", "docker", "--workspace", "/tmp/ws"], {
+			selectRuntime: () => makeRuntime(),
+			readResult: makeReadResult(),
+			fs: makeFs(),
+		})
+		expect(result).toBe(1)
+		expect(errSpy).toHaveBeenCalledWith(expect.stringContaining("--task"))
+	})
+
+	it("returns 1 when workspace does not exist", async () => {
+		const spec = makeSpec({ prompt: "p", timeout_seconds: 60 })
+		const result = await runAuto(["--task", "/tmp/spec.json", "--runtime", "docker", "--workspace", "/nope"], {
+			loadTaskSpec: () => spec,
+			selectRuntime: () => makeRuntime(),
+			readResult: makeReadResult(),
+			fs: makeFs({ existsSync: () => false }),
+		})
+		expect(result).toBe(1)
+		expect(errSpy).toHaveBeenCalledWith(expect.stringContaining("workspace not found"))
+	})
+
+	it("returns 1 when selectRuntime throws (unknown name)", async () => {
+		const spec = makeSpec({ prompt: "p", timeout_seconds: 60 })
+		const result = await runAuto(["--task", "/tmp/spec.json", "--runtime", "nope", "--workspace", "/tmp/ws"], {
+			loadTaskSpec: () => spec,
+			selectRuntime: () => {
+				throw new Error("Unknown runtime: nope")
+			},
+			readResult: makeReadResult(),
+			fs: makeFs(),
+		})
+		expect(result).toBe(1)
+		expect(errSpy).toHaveBeenCalledWith(expect.stringContaining("Unknown runtime"))
+	})
+
+	it("returns 1 when manifest read throws and container exited 0 (missing manifest is failure)", async () => {
+		const spec = makeSpec({ prompt: "p", timeout_seconds: 60 })
+		const result = await runAuto(["--task", "/tmp/spec.json", "--runtime", "docker", "--workspace", "/tmp/ws"], {
+			loadTaskSpec: () => spec,
+			selectRuntime: () => makeRuntime({ exitCode: 0 }),
+			readResult: makeReadResult({ throws: true }),
+			fs: makeFs(),
+		})
+		expect(result).toBe(1)
+	})
+
+	it("preserves non-zero container exit code when manifest read throws", async () => {
+		const spec = makeSpec({ prompt: "p", timeout_seconds: 60 })
+		const result = await runAuto(["--task", "/tmp/spec.json", "--runtime", "docker", "--workspace", "/tmp/ws"], {
+			loadTaskSpec: () => spec,
+			selectRuntime: () => makeRuntime({ exitCode: 137 }),
+			readResult: makeReadResult({ throws: true }),
+			fs: makeFs(),
+		})
+		expect(result).toBe(137)
+	})
+
+	it("forwards KIMCHI_API_KEY from host env into container env", async () => {
+		vi.stubEnv("KIMCHI_API_KEY", "test-key-123")
+		const spec = makeSpec({ prompt: "p", timeout_seconds: 60 })
+		const runtime = makeRuntime()
+		await runAuto(["--task", "/tmp/spec.json", "--runtime", "docker", "--workspace", "/tmp/ws"], {
+			loadTaskSpec: () => spec,
+			selectRuntime: () => runtime,
+			readResult: makeReadResult(),
+			fs: makeFs(),
+		})
+		const runOpts = runtime.run.mock.calls[0][0]
+		expect(runOpts.env.KIMCHI_API_KEY).toBe("test-key-123")
+	})
+
+	it("does NOT include KIMCHI_API_KEY when host env doesn't have it", async () => {
+		vi.stubEnv("KIMCHI_API_KEY", "")
+		const spec = makeSpec({ prompt: "p", timeout_seconds: 60 })
+		const runtime = makeRuntime()
+		await runAuto(["--task", "/tmp/spec.json", "--runtime", "docker", "--workspace", "/tmp/ws"], {
+			loadTaskSpec: () => spec,
+			selectRuntime: () => runtime,
+			readResult: makeReadResult(),
+			fs: makeFs(),
+		})
+		const runOpts = runtime.run.mock.calls[0][0]
+		expect(runOpts.env.KIMCHI_API_KEY).toBeUndefined()
+	})
+
+	it("rejects mount paths containing ':' or ','", async () => {
+		const spec = makeSpec({
+			prompt: "p",
+			timeout_seconds: 60,
+			mounts: [{ host: "/bad:path", container: "/x" }],
+		})
+		const result = await runAuto(["--task", "/tmp/spec.json", "--runtime", "docker", "--workspace", "/tmp/ws"], {
+			loadTaskSpec: () => spec,
+			selectRuntime: () => makeRuntime(),
+			readResult: makeReadResult(),
+			fs: makeFs(),
+		})
+		expect(result).toBe(1)
+		expect(errSpy).toHaveBeenCalledWith(expect.stringContaining("invalid mount path"))
+	})
+
+	it("logs '[auto] exit_reason=...' summary on success", async () => {
+		const spec = makeSpec({ prompt: "p", timeout_seconds: 60 })
+		await runAuto(["--task", "/tmp/spec.json", "--runtime", "docker", "--workspace", "/tmp/ws"], {
+			loadTaskSpec: () => spec,
+			selectRuntime: () => makeRuntime(),
+			readResult: makeReadResult({ exit_reason: "done" }),
+			fs: makeFs(),
+		})
+		expect(logSpy).toHaveBeenCalledWith(expect.stringContaining("[auto] exit_reason=done"))
+	})
+
+	it("logs '[auto] error: <msg>' when manifest has error field", async () => {
+		const spec = makeSpec({ prompt: "p", timeout_seconds: 60 })
+		await runAuto(["--task", "/tmp/spec.json", "--runtime", "docker", "--workspace", "/tmp/ws"], {
+			loadTaskSpec: () => spec,
+			selectRuntime: () => makeRuntime(),
+			readResult: makeReadResult({ exit_reason: "error", error: { message: "boom" } }),
+			fs: makeFs(),
+		})
+		expect(errSpy).toHaveBeenCalledWith(expect.stringContaining("[auto] error: boom"))
+	})
+
+	it("default workspace is process.cwd() when --workspace not specified", async () => {
+		const spec = makeSpec({ prompt: "p", timeout_seconds: 60 })
+		const runtime = makeRuntime()
+		await runAuto(["--task", "/tmp/spec.json", "--runtime", "docker"], {
+			loadTaskSpec: () => spec,
+			selectRuntime: () => runtime,
+			readResult: makeReadResult(),
+			fs: makeFs(),
+		})
+		const runOpts = runtime.run.mock.calls[0][0]
+		const workspaceMount = runOpts.mounts.find((m: { container: string }) => m.container === "/workspace")
+		expect(workspaceMount?.host).toBe(process.cwd())
+	})
+
+	it("default image is 'kimchi:latest' when --image not specified", async () => {
+		const spec = makeSpec({ prompt: "p", timeout_seconds: 60 })
+		const runtime = makeRuntime()
+		await runAuto(["--task", "/tmp/spec.json", "--runtime", "docker", "--workspace", "/tmp/ws"], {
+			loadTaskSpec: () => spec,
+			selectRuntime: () => runtime,
+			readResult: makeReadResult(),
+			fs: makeFs(),
+		})
+		const runOpts = runtime.run.mock.calls[0][0]
+		expect(runOpts.image).toBe("kimchi:latest")
+	})
+})

--- a/src/commands/auto.ts
+++ b/src/commands/auto.ts
@@ -1,0 +1,415 @@
+import { copyFileSync, existsSync, mkdirSync } from "node:fs"
+import { join, resolve } from "node:path"
+import type { ExtensionFactory } from "@mariozechner/pi-coding-agent"
+import { readResult as defaultReadResult } from "../autonomous/result.js"
+import type { ResultManifest } from "../autonomous/result.js"
+import { type SelectRuntimeDeps, selectRuntime as defaultSelectRuntime } from "../autonomous/runtime/select.js"
+import type { ContainerRuntime } from "../autonomous/runtime/types.js"
+import { selectExtensionFactories } from "../autonomous/select-extensions.js"
+import { loadTaskSpec as defaultLoadTaskSpec } from "../autonomous/spec.js"
+import type { TaskSpec } from "../autonomous/spec.js"
+import { prepareAgentEnvironment } from "../cli-bootstrap.js"
+import { maxIterationsExtension } from "../extensions/autonomous/max-iterations.js"
+import { type ResultWriterControl, createResultWriter } from "../extensions/autonomous/result-writer.js"
+import { timeoutGuardExtension } from "../extensions/autonomous/timeout-guard.js"
+
+export interface AutoDeps {
+	loadTaskSpec?: (path: string) => TaskSpec
+	runHarness?: (args: string[], options: { extensionFactories: ExtensionFactory[] }) => Promise<void>
+	buildBaseFactories?: () => Promise<ExtensionFactory[]>
+	prepareEnvironment?: () => Promise<void>
+	// Container path:
+	selectRuntime?: (name: string, opts?: SelectRuntimeDeps) => ContainerRuntime
+	readResult?: (dir: string) => ResultManifest
+	fs?: {
+		existsSync: (p: string) => boolean
+		mkdirSync: (p: string, opts?: { recursive?: boolean }) => void
+		copyFileSync: (src: string, dest: string) => void
+	}
+}
+
+export interface ParsedAutoArgs {
+	taskPath?: string
+	iterations?: number
+	timeoutSeconds?: number
+	runtime?: string
+	workspace?: string
+	image?: string
+	passthroughArgs: string[]
+	help: boolean
+}
+
+async function defaultBuildBaseFactories(): Promise<ExtensionFactory[]> {
+	const { readTelemetryConfig, DEFAULT_SKILL_PATHS, loadConfig } = await import("../config.js")
+	const { buildBaseExtensionFactories, makeAutonomousSessionIdCapture } = await import("../cli-extensions.js")
+	const cfg = loadConfig()
+	const skillPaths = cfg.skillPaths ?? DEFAULT_SKILL_PATHS
+	return buildBaseExtensionFactories({
+		telemetryConfig: readTelemetryConfig(),
+		skillPaths,
+		sessionIdCaptureExtension: makeAutonomousSessionIdCapture(),
+	})
+}
+
+/**
+ * Parses kimchi auto's own flags from argv, returning passthrough args for pi.
+ * In-process flags: --task <path>, --iterations / --max-iterations <N>, --timeout-seconds <N>
+ * Container flags: --runtime <name>, --workspace <dir>, --image <ref>
+ * Returns { help: true } when --help or -h is present.
+ */
+export function parseAutoArgs(args: string[]): ParsedAutoArgs {
+	if (args.includes("--help") || args.includes("-h")) {
+		return { help: true, passthroughArgs: [] }
+	}
+
+	let taskPath: string | undefined
+	let iterations: number | undefined
+	let timeoutSeconds: number | undefined
+	let runtime: string | undefined
+	let workspace: string | undefined
+	let image: string | undefined
+	const passthroughArgs: string[] = []
+
+	let i = 0
+	while (i < args.length) {
+		const arg = args[i]
+		if (arg === "--task") {
+			const val = args[i + 1]
+			if (val === undefined || val.startsWith("-")) {
+				throw new Error("missing --task value")
+			}
+			taskPath = val
+			i += 2
+		} else if (arg === "--iterations" || arg === "--max-iterations") {
+			const val = args[i + 1]
+			if (val === undefined || val.startsWith("--")) {
+				throw new Error(`missing ${arg} value`)
+			}
+			const n = Number(val)
+			if (!Number.isInteger(n) || n < 1) {
+				throw new Error(`${arg} must be a positive integer`)
+			}
+			iterations = n
+			i += 2
+		} else if (arg === "--timeout-seconds") {
+			const val = args[i + 1]
+			if (val === undefined || val.startsWith("--")) {
+				throw new Error("missing --timeout-seconds value")
+			}
+			const n = Number(val)
+			if (!Number.isFinite(n) || n <= 0) {
+				throw new Error("--timeout-seconds must be a positive number")
+			}
+			timeoutSeconds = n
+			i += 2
+		} else if (arg === "--runtime") {
+			const val = args[i + 1]
+			if (val === undefined || val.startsWith("-")) {
+				throw new Error("missing --runtime value")
+			}
+			runtime = val
+			i += 2
+		} else if (arg === "--workspace") {
+			const val = args[i + 1]
+			if (val === undefined || val.startsWith("-")) {
+				throw new Error("missing --workspace value")
+			}
+			workspace = resolve(val)
+			i += 2
+		} else if (arg === "--image") {
+			const val = args[i + 1]
+			if (val === undefined || val.startsWith("-")) {
+				throw new Error("missing --image value")
+			}
+			image = val
+			i += 2
+		} else {
+			passthroughArgs.push(arg)
+			i++
+		}
+	}
+
+	return {
+		taskPath,
+		iterations,
+		timeoutSeconds,
+		runtime,
+		workspace,
+		image,
+		passthroughArgs,
+		help: false,
+	}
+}
+
+/**
+ * Builds the argv array to pass to pi-coding-agent's main().
+ * Order: ["--yolo", "--print", "--mode", "json", "--no-session",
+ *         (optional --model <model>), (spec.prompt if spec given), ...passthroughArgs]
+ */
+export function buildAutoArgs(spec: TaskSpec | undefined, parsed: ParsedAutoArgs): string[] {
+	const result: string[] = ["--yolo", "--print", "--mode", "json", "--no-session"]
+	if (spec?.model) {
+		result.push("--model", spec.model)
+	}
+	if (spec?.prompt) {
+		result.push(spec.prompt)
+	}
+	if (parsed.passthroughArgs.length > 0) {
+		result.push(...parsed.passthroughArgs)
+	}
+	return result
+}
+
+/**
+ * Builds the full extension factories array for an autonomous run.
+ * Always includes resultWriter. Conditionally adds timeoutGuard and maxIterations.
+ * Returns both the factories array and the result writer control handle.
+ */
+export async function buildExtensionFactories(
+	options: { timeoutSeconds?: number; iterations?: number },
+	baseFactoriesFn: () => Promise<ExtensionFactory[]>,
+): Promise<{ factories: ExtensionFactory[]; control: ResultWriterControl }> {
+	const writerHandle = createResultWriter({
+		resultDir: process.env.KIMCHI_RESULT_DIR ?? `${process.cwd()}/.kimchi`,
+		logPath: process.env.KIMCHI_LOG_PATH,
+	})
+
+	const base = await baseFactoriesFn()
+
+	const autonomousExtensions = {
+		resultWriter: writerHandle.extension,
+		...(options.timeoutSeconds !== undefined
+			? {
+					timeoutGuard: timeoutGuardExtension({
+						timeoutMs: options.timeoutSeconds * 1000,
+						onTimeout: () => {
+							writerHandle.control.markTimeout()
+							process.exit(124)
+						},
+					}),
+				}
+			: {}),
+		...(options.iterations !== undefined
+			? {
+					maxIterations: maxIterationsExtension({ maxIterations: options.iterations }),
+				}
+			: {}),
+	}
+
+	const factories = selectExtensionFactories(base, {
+		autonomous: true,
+		autonomousExtensions,
+	})
+
+	return { factories, control: writerHandle.control }
+}
+
+/**
+ * Runs kimchi in autonomous mode.
+ *
+ * Two modes determined by `--runtime`:
+ *   - In-process (no `--runtime`): spawns pi-coding-agent's main() in the current process.
+ *   - Containerized (`--runtime <docker|orbstack|podman>`): spins up a container
+ *     that runs `kimchi auto --task <spec>` inside, mounting the host workspace.
+ *
+ * Common flags: --task <spec>, --iterations N, --timeout-seconds N, passthrough for pi.
+ * Container-only flags: --workspace <dir> (default cwd), --image <ref> (default "kimchi:latest").
+ */
+export async function runAuto(args: string[], deps?: AutoDeps): Promise<number | undefined> {
+	const resolvedLoadTaskSpec = deps?.loadTaskSpec ?? defaultLoadTaskSpec
+
+	let parsed: ParsedAutoArgs
+	try {
+		parsed = parseAutoArgs(args)
+	} catch (err) {
+		console.error((err as Error).message)
+		return 1
+	}
+
+	if (parsed.help) {
+		console.log(
+			"Usage: kimchi auto [--task <path>] [--iterations N] [--timeout-seconds N]\n" +
+				"                  [--runtime <docker|orbstack|podman> [--workspace <dir>] [--image <ref>]]\n" +
+				'                  [@file.md | "prompt"] [extra pi flags...]',
+		)
+		return 0
+	}
+
+	let spec: TaskSpec | undefined
+	if (parsed.taskPath) {
+		try {
+			spec = resolvedLoadTaskSpec(parsed.taskPath)
+		} catch (err) {
+			console.error((err as Error).message)
+			return 1
+		}
+	}
+
+	if (parsed.runtime !== undefined) {
+		return runContainerized(parsed, spec, deps)
+	}
+
+	return runInProcess(parsed, spec, deps)
+}
+
+/**
+ * In-process autonomous run: invokes pi-coding-agent's main() in this process
+ * with the autonomous extension factories.
+ */
+async function runInProcess(
+	parsed: ParsedAutoArgs,
+	spec: TaskSpec | undefined,
+	deps: AutoDeps | undefined,
+): Promise<number | undefined> {
+	const resolvedRunHarness =
+		deps?.runHarness ??
+		(async (harnessArgs: string[], options: { extensionFactories: ExtensionFactory[] }) => {
+			const { main } = await import("@mariozechner/pi-coding-agent")
+			await main(harnessArgs, options)
+		})
+	const resolvedBuildBaseFactories = deps?.buildBaseFactories ?? defaultBuildBaseFactories
+	const resolvedPrepareEnvironment =
+		deps?.prepareEnvironment ?? (() => prepareAgentEnvironment({ requireApiKey: true }).then(() => undefined))
+
+	try {
+		await resolvedPrepareEnvironment()
+	} catch (err) {
+		console.error((err as Error).message)
+		return 1
+	}
+
+	const effectiveIterations = parsed.iterations ?? spec?.iterations
+	const effectiveTimeoutSeconds = parsed.timeoutSeconds ?? spec?.timeout_seconds
+
+	let factories: ExtensionFactory[]
+	let control: ResultWriterControl
+	try {
+		;({ factories, control } = await buildExtensionFactories(
+			{ timeoutSeconds: effectiveTimeoutSeconds, iterations: effectiveIterations },
+			resolvedBuildBaseFactories,
+		))
+	} catch (err) {
+		console.error((err as Error).message)
+		return 1
+	}
+
+	const autoArgs = buildAutoArgs(spec, parsed)
+
+	// Fallback for synchronous process.exit() calls from pi-mono that skip
+	// the session_shutdown event. flushIfUnflushed is a no-op if already flushed.
+	const exitFallback = () => {
+		control.flushIfUnflushed("error")
+	}
+	process.on("exit", exitFallback)
+
+	try {
+		await resolvedRunHarness(autoArgs, { extensionFactories: factories })
+	} catch (err) {
+		console.error((err as Error).message)
+		control.markError({ message: (err as Error).message, stack: (err as Error).stack })
+		process.removeListener("exit", exitFallback)
+		return 1
+	}
+
+	process.removeListener("exit", exitFallback)
+	return 0
+}
+
+/**
+ * Containerized autonomous run: spins up a container via the selected runtime
+ * with the workspace bind-mounted, then reads back the result manifest.
+ *
+ * Requires --task <path> (or a positional prompt that gets synthesized into
+ * a minimal in-memory spec). Mounts <workspace>:/workspace read-write.
+ */
+async function runContainerized(
+	parsed: ParsedAutoArgs,
+	spec: TaskSpec | undefined,
+	deps: AutoDeps | undefined,
+): Promise<number | undefined> {
+	const resolvedSelectRuntime = deps?.selectRuntime ?? defaultSelectRuntime
+	const resolvedReadResult = deps?.readResult ?? defaultReadResult
+	const resolvedFs = deps?.fs ?? { existsSync, mkdirSync, copyFileSync }
+
+	const workspace = parsed.workspace ?? resolve(process.cwd())
+	const image = parsed.image ?? "kimchi:latest"
+
+	if (!resolvedFs.existsSync(workspace)) {
+		console.error(`workspace not found: ${workspace}`)
+		return 1
+	}
+
+	if (parsed.taskPath === undefined) {
+		console.error("--runtime requires --task <path>")
+		return 1
+	}
+
+	if (spec === undefined) {
+		// parseAutoArgs guarantees taskPath set above; spec only undefined if loadTaskSpec wasn't called
+		// (defensive — runAuto loads spec before calling runContainerized when taskPath is set).
+		console.error("internal error: spec not loaded")
+		return 1
+	}
+
+	let runtime: ContainerRuntime
+	try {
+		runtime = resolvedSelectRuntime(parsed.runtime as string)
+	} catch (err) {
+		console.error((err as Error).message)
+		return 1
+	}
+
+	const kimchiDir = join(workspace, ".kimchi")
+	resolvedFs.mkdirSync(kimchiDir, { recursive: true })
+
+	const taskDestPath = join(kimchiDir, "task.json")
+	resolvedFs.copyFileSync(parsed.taskPath, taskDestPath)
+
+	const env: Record<string, string> = {
+		...spec.env,
+		...(process.env.KIMCHI_API_KEY ? { KIMCHI_API_KEY: process.env.KIMCHI_API_KEY } : {}),
+		KIMCHI_RESULT_DIR: "/workspace/.kimchi",
+		KIMCHI_LOG_PATH: "/workspace/.kimchi/run.log",
+	}
+
+	const mounts: Array<{ host: string; container: string; readonly?: boolean }> = [
+		{ host: workspace, container: "/workspace" },
+		...(spec.mounts ?? []),
+	]
+
+	for (const mount of mounts) {
+		if (mount.host.includes(":") || mount.host.includes(",")) {
+			console.error(`invalid mount path: ${mount.host}`)
+			return 1
+		}
+		if (mount.container.includes(":") || mount.container.includes(",")) {
+			console.error(`invalid mount path: ${mount.container}`)
+			return 1
+		}
+	}
+
+	const effectiveTimeoutSeconds = parsed.timeoutSeconds ?? spec.timeout_seconds
+	const timeoutMs = effectiveTimeoutSeconds * 1000 + 60_000
+
+	const result = await runtime.run({
+		image,
+		workdir: "/workspace",
+		mounts,
+		env,
+		command: ["auto", "--task", "/workspace/.kimchi/task.json"],
+		timeoutMs,
+	})
+
+	try {
+		const manifest = resolvedReadResult(kimchiDir)
+		console.log(`[auto] exit_reason=${manifest.exit_reason} ended_at=${manifest.ended_at}`)
+		if (manifest.error) {
+			console.error(`[auto] error: ${manifest.error.message}`)
+		}
+	} catch (err) {
+		console.error(`Warning: could not read result manifest: ${(err as Error).message}`)
+		if (result.exitCode === 0) return 1
+	}
+
+	return result.exitCode
+}

--- a/src/commands/dispatch.test.ts
+++ b/src/commands/dispatch.test.ts
@@ -98,4 +98,11 @@ describe("dispatchSubcommand", () => {
 		const messages = errSpy.mock.calls.map((c) => String(c[0] ?? "")).join("\n")
 		expect(messages).toContain("Usage: kimchi config")
 	})
+
+	it("auto with a non-existent task file returns { kind: 'handled', exitCode: 1 }", async () => {
+		// Proves the `auto` subcommand is registered. The real loadTaskSpec will fail
+		// to read /nonexistent.json and runAuto returns 1.
+		const result = await dispatchSubcommand(["auto", "--task", "/nonexistent-kimchi-task.json"])
+		expect(result).toEqual({ kind: "handled", exitCode: 1 })
+	})
 })

--- a/src/commands/registry.ts
+++ b/src/commands/registry.ts
@@ -5,6 +5,7 @@ export interface CommandDefinition {
 	run: (args: string[]) => Promise<number | undefined>
 }
 
+import { runAuto } from "./auto.js"
 import { runClaude } from "./claude.js"
 import { runConfig } from "./config.js"
 import { runCursor } from "./cursor.js"
@@ -16,6 +17,11 @@ import { runUpdate } from "./update.js"
 import { runVersion } from "./version.js"
 
 export const COMMANDS: CommandDefinition[] = [
+	{
+		name: "auto",
+		summary: "Run kimchi unattended on a prompt or task spec; add --runtime to sandbox in a container",
+		run: runAuto,
+	},
 	{ name: "setup", summary: "Run the interactive setup wizard", run: runSetup },
 	{ name: "claude", summary: "Configure Claude Code to use Kimchi (and launch it)", run: runClaude },
 	{ name: "opencode", summary: "Configure OpenCode to use Kimchi (and launch it)", run: runOpenCode },

--- a/src/extensions/autonomous/max-iterations.test.ts
+++ b/src/extensions/autonomous/max-iterations.test.ts
@@ -1,0 +1,179 @@
+import type { ExtensionAPI } from "@mariozechner/pi-coding-agent"
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
+import { maxIterationsExtension } from "./max-iterations.js"
+
+type StubHandler = (evt: unknown, ctx: unknown) => unknown
+type StubCtxShape = { shutdown: () => void }
+
+function makeStubPi() {
+	const handlers: Record<string, StubHandler[]> = {}
+	return {
+		on: vi.fn((event: string, handler: StubHandler) => {
+			if (handlers[event] === undefined) handlers[event] = []
+			handlers[event].push(handler)
+		}),
+		fireTurnEnd: (ctx: StubCtxShape) => {
+			for (const h of handlers.turn_end ?? []) h({ type: "turn_end" }, ctx)
+		},
+	}
+}
+
+function makeStubCtx(overrides: Partial<StubCtxShape> = {}): StubCtxShape {
+	return {
+		shutdown: vi.fn(),
+		...overrides,
+	}
+}
+
+describe("maxIterationsExtension", () => {
+	const exitMock = vi.fn()
+	const originalExit = process.exit
+	const originalStderrWrite = process.stderr.write.bind(process.stderr)
+
+	beforeEach(() => {
+		exitMock.mockReset()
+		// Replace process.exit with a no-op so tests don't terminate the worker.
+		;(process as unknown as { exit: (code?: number) => void }).exit = exitMock
+		// Silence the "max-iterations: hit limit ..." line during tests.
+		process.stderr.write = (() => true) as typeof process.stderr.write
+	})
+
+	afterEach(() => {
+		;(process as unknown as { exit: typeof originalExit }).exit = originalExit
+		process.stderr.write = originalStderrWrite
+	})
+
+	it("throws when maxIterations is 0", () => {
+		expect(() => maxIterationsExtension({ maxIterations: 0 })).toThrow(/maxIterations must be a positive integer/)
+	})
+
+	it("throws when maxIterations is -1", () => {
+		expect(() => maxIterationsExtension({ maxIterations: -1 })).toThrow(/maxIterations must be a positive integer/)
+	})
+
+	it("throws when maxIterations is a non-integer (1.5)", () => {
+		expect(() => maxIterationsExtension({ maxIterations: 1.5 })).toThrow(/maxIterations must be a positive integer/)
+	})
+
+	it("throws when maxIterations is NaN", () => {
+		expect(() => maxIterationsExtension({ maxIterations: Number.NaN })).toThrow(
+			/maxIterations must be a positive integer/,
+		)
+	})
+
+	it("registers exactly one turn_end handler when installed", () => {
+		const pi = makeStubPi()
+		maxIterationsExtension({ maxIterations: 3 })(pi as unknown as ExtensionAPI)
+
+		const turnEndCalls = pi.on.mock.calls.filter((c) => c[0] === "turn_end")
+		expect(turnEndCalls).toHaveLength(1)
+	})
+
+	it("does not call ctx.shutdown before the limit is reached", () => {
+		const pi = makeStubPi()
+		const ctx = makeStubCtx()
+		maxIterationsExtension({ maxIterations: 3 })(pi as unknown as ExtensionAPI)
+
+		pi.fireTurnEnd(ctx)
+		pi.fireTurnEnd(ctx)
+
+		expect(ctx.shutdown).not.toHaveBeenCalled()
+	})
+
+	it("calls ctx.shutdown exactly once after N turn_end events (N=3)", async () => {
+		const pi = makeStubPi()
+		const ctx = makeStubCtx({ shutdown: vi.fn().mockResolvedValue(undefined) })
+		maxIterationsExtension({ maxIterations: 3 })(pi as unknown as ExtensionAPI)
+
+		pi.fireTurnEnd(ctx)
+		pi.fireTurnEnd(ctx)
+		pi.fireTurnEnd(ctx)
+
+		await Promise.resolve()
+		expect(ctx.shutdown).toHaveBeenCalledTimes(1)
+	})
+
+	it("calls process.exit(0) by default (because ctx.shutdown is a no-op in pi print mode)", () => {
+		const pi = makeStubPi()
+		const ctx = makeStubCtx()
+		maxIterationsExtension({ maxIterations: 1 })(pi as unknown as ExtensionAPI)
+
+		pi.fireTurnEnd(ctx)
+
+		expect(exitMock).toHaveBeenCalledWith(0)
+	})
+
+	it("does NOT call process.exit when a custom onLimit is provided", () => {
+		const pi = makeStubPi()
+		const ctx = makeStubCtx()
+		const onLimit = vi.fn()
+		maxIterationsExtension({ maxIterations: 1, onLimit })(pi as unknown as ExtensionAPI)
+
+		pi.fireTurnEnd(ctx)
+
+		expect(onLimit).toHaveBeenCalledTimes(1)
+		expect(exitMock).not.toHaveBeenCalled()
+	})
+
+	it("subsequent turn_end events after limit do not trigger again (triggered guard)", async () => {
+		const pi = makeStubPi()
+		const ctx = makeStubCtx({ shutdown: vi.fn().mockResolvedValue(undefined) })
+		maxIterationsExtension({ maxIterations: 2 })(pi as unknown as ExtensionAPI)
+
+		pi.fireTurnEnd(ctx)
+		pi.fireTurnEnd(ctx)
+		pi.fireTurnEnd(ctx)
+		pi.fireTurnEnd(ctx)
+
+		await Promise.resolve()
+		expect(ctx.shutdown).toHaveBeenCalledTimes(1)
+	})
+
+	it("single iteration limit (=1) fires on the very first turn_end", async () => {
+		const pi = makeStubPi()
+		const ctx = makeStubCtx({ shutdown: vi.fn().mockResolvedValue(undefined) })
+		maxIterationsExtension({ maxIterations: 1 })(pi as unknown as ExtensionAPI)
+
+		pi.fireTurnEnd(ctx)
+
+		await Promise.resolve()
+		expect(ctx.shutdown).toHaveBeenCalledTimes(1)
+	})
+
+	it("uses custom onLimit callback instead of ctx.shutdown when provided", () => {
+		const pi = makeStubPi()
+		const ctx = makeStubCtx()
+		const onLimit = vi.fn()
+		maxIterationsExtension({ maxIterations: 1, onLimit })(pi as unknown as ExtensionAPI)
+
+		pi.fireTurnEnd(ctx)
+
+		expect(onLimit).toHaveBeenCalledTimes(1)
+		expect(ctx.shutdown).not.toHaveBeenCalled()
+	})
+
+	it("onLimit is not called more than once even when additional turn_end events fire", () => {
+		const pi = makeStubPi()
+		const ctx = makeStubCtx()
+		const onLimit = vi.fn()
+		maxIterationsExtension({ maxIterations: 1, onLimit })(pi as unknown as ExtensionAPI)
+
+		pi.fireTurnEnd(ctx)
+		pi.fireTurnEnd(ctx)
+		pi.fireTurnEnd(ctx)
+
+		expect(onLimit).toHaveBeenCalledTimes(1)
+	})
+
+	it("does not throw synchronously when ctx.shutdown rejects", async () => {
+		const pi = makeStubPi()
+		const ctx = makeStubCtx({
+			shutdown: vi.fn().mockReturnValue(Promise.reject(new Error("shutdown failed"))),
+		})
+		maxIterationsExtension({ maxIterations: 1 })(pi as unknown as ExtensionAPI)
+
+		expect(() => pi.fireTurnEnd(ctx)).not.toThrow()
+
+		await Promise.resolve()
+	})
+})

--- a/src/extensions/autonomous/max-iterations.ts
+++ b/src/extensions/autonomous/max-iterations.ts
@@ -1,0 +1,34 @@
+import type { ExtensionAPI, ExtensionContext, TurnEndEvent } from "@mariozechner/pi-coding-agent"
+
+export interface MaxIterationsOptions {
+	maxIterations: number // must be >= 1
+	onLimit?: () => void // called when limit hit, default ctx.shutdown()
+}
+
+export function maxIterationsExtension(options: MaxIterationsOptions): (pi: ExtensionAPI) => void {
+	if (!Number.isInteger(options.maxIterations) || options.maxIterations < 1) {
+		throw new Error("maxIterations must be a positive integer")
+	}
+	return (pi) => {
+		let count = 0
+		let triggered = false
+		pi.on("turn_end", (_event: TurnEndEvent, ctx: ExtensionContext) => {
+			if (triggered) return
+			count++
+			if (count >= options.maxIterations) {
+				triggered = true
+				process.stderr.write(`max-iterations: hit limit ${options.maxIterations}, shutting down\n`)
+				if (options.onLimit) {
+					options.onLimit()
+					return
+				}
+				try {
+					ctx.shutdown()
+				} catch {
+					// ignore — we're exiting anyway
+				}
+				process.exit(0)
+			}
+		})
+	}
+}

--- a/src/extensions/autonomous/result-writer.test.ts
+++ b/src/extensions/autonomous/result-writer.test.ts
@@ -1,0 +1,263 @@
+import { randomUUID } from "node:crypto"
+import { existsSync, rmSync } from "node:fs"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
+import type { AssistantMessage } from "@mariozechner/pi-ai"
+import type { ExtensionAPI } from "@mariozechner/pi-coding-agent"
+import { afterEach, describe, expect, it, vi } from "vitest"
+import { readResult } from "../../autonomous/result.js"
+import { createResultWriter } from "./result-writer.js"
+
+function makeAssistant(content: AssistantMessage["content"]): AssistantMessage {
+	return {
+		role: "assistant",
+		content,
+		api: "anthropic-messages",
+		provider: "anthropic",
+		model: "kimi-k2.5",
+		usage: {
+			input: 0,
+			output: 0,
+			cacheRead: 0,
+			cacheWrite: 0,
+			totalTokens: 0,
+			cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+		},
+		stopReason: "stop",
+		timestamp: Date.now(),
+	}
+}
+
+type StubHandler = (evt: unknown, ctx: unknown) => unknown
+
+function makeStubPi() {
+	const handlers: Record<string, StubHandler[]> = {}
+	return {
+		on: vi.fn((event: string, handler: StubHandler) => {
+			if (handlers[event] === undefined) handlers[event] = []
+			handlers[event].push(handler)
+		}),
+		fireSessionStart: () => {
+			for (const h of handlers.session_start ?? []) h({ type: "session_start" }, {})
+		},
+		fireTurnEnd: (message: AssistantMessage, ctx: unknown = {}) => {
+			for (const h of handlers.turn_end ?? []) h({ type: "turn_end", message }, ctx)
+		},
+		fireSessionShutdown: () => {
+			for (const h of handlers.session_shutdown ?? []) h({ type: "session_shutdown" }, {})
+		},
+	}
+}
+
+const helloMessage = makeAssistant([{ type: "text", text: "hello" }])
+
+describe("createResultWriter", () => {
+	const createdDirs: string[] = []
+
+	function tmpDir(): string {
+		const dir = join(tmpdir(), `result-writer-test-${randomUUID()}`)
+		createdDirs.push(dir)
+		return dir
+	}
+
+	afterEach(() => {
+		for (const d of createdDirs) {
+			try {
+				rmSync(d, { recursive: true, force: true })
+			} catch {
+				// ignore
+			}
+		}
+		createdDirs.length = 0
+	})
+
+	it("returns an object with extension and control properties of the right shape", () => {
+		const { extension, control } = createResultWriter({ resultDir: tmpDir() })
+
+		expect(typeof extension).toBe("function")
+		expect(typeof control.markTimeout).toBe("function")
+		expect(typeof control.markError).toBe("function")
+		expect(typeof control.flush).toBe("function")
+	})
+
+	it("registers handlers for session_start, turn_end, and session_shutdown — exactly those three", () => {
+		const resultDir = tmpDir()
+		const { extension } = createResultWriter({ resultDir })
+		const pi = makeStubPi()
+		extension(pi as unknown as ExtensionAPI)
+
+		const registeredEvents = pi.on.mock.calls.map((c) => c[0])
+		expect(registeredEvents).toContain("session_start")
+		expect(registeredEvents).toContain("turn_end")
+		expect(registeredEvents).toContain("session_shutdown")
+		expect(registeredEvents).toHaveLength(3)
+	})
+
+	it("writes result.json with exit_reason 'done' (default) after session_start + session_shutdown", () => {
+		const resultDir = tmpDir()
+		const { extension } = createResultWriter({ resultDir })
+		const pi = makeStubPi()
+		extension(pi as unknown as ExtensionAPI)
+
+		pi.fireSessionStart()
+		pi.fireSessionShutdown()
+
+		expect(existsSync(join(resultDir, "result.json"))).toBe(true)
+		const result = readResult(resultDir)
+		expect(result.exit_reason).toBe("done")
+	})
+
+	it("writes last_message when turn_end fires before session_shutdown", () => {
+		const resultDir = tmpDir()
+		const { extension } = createResultWriter({ resultDir })
+		const pi = makeStubPi()
+		extension(pi as unknown as ExtensionAPI)
+
+		pi.fireSessionStart()
+		pi.fireTurnEnd(helloMessage)
+		pi.fireSessionShutdown()
+
+		const result = readResult(resultDir)
+		expect(result.last_message).toBe("hello")
+		expect(result.exit_reason).toBe("done")
+	})
+
+	it("last_message reflects the LATEST turn when multiple turn_end events fire", () => {
+		const resultDir = tmpDir()
+		const { extension } = createResultWriter({ resultDir })
+		const pi = makeStubPi()
+		extension(pi as unknown as ExtensionAPI)
+
+		const firstMessage = makeAssistant([{ type: "text", text: "first" }])
+		const secondMessage = makeAssistant([{ type: "text", text: "second" }])
+		const thirdMessage = makeAssistant([{ type: "text", text: "third" }])
+
+		pi.fireSessionStart()
+		pi.fireTurnEnd(firstMessage)
+		pi.fireTurnEnd(secondMessage)
+		pi.fireTurnEnd(thirdMessage)
+		pi.fireSessionShutdown()
+
+		const result = readResult(resultDir)
+		expect(result.last_message).toBe("third")
+	})
+
+	it("control.markTimeout() flushes immediately with exit_reason 'timeout' before session_shutdown fires", () => {
+		const resultDir = tmpDir()
+		const { extension, control } = createResultWriter({ resultDir })
+		const pi = makeStubPi()
+		extension(pi as unknown as ExtensionAPI)
+
+		pi.fireSessionStart()
+		control.markTimeout()
+
+		expect(existsSync(join(resultDir, "result.json"))).toBe(true)
+		const result = readResult(resultDir)
+		expect(result.exit_reason).toBe("timeout")
+	})
+
+	it("control.markError({message}) flushes immediately with exit_reason 'error' and error.message", () => {
+		const resultDir = tmpDir()
+		const { extension, control } = createResultWriter({ resultDir })
+		const pi = makeStubPi()
+		extension(pi as unknown as ExtensionAPI)
+
+		pi.fireSessionStart()
+		control.markError({ message: "boom" })
+
+		expect(existsSync(join(resultDir, "result.json"))).toBe(true)
+		const result = readResult(resultDir)
+		expect(result.exit_reason).toBe("error")
+		expect(result.error?.message).toBe("boom")
+	})
+
+	it("flush is idempotent — calling markTimeout twice does not throw and ended_at is from the first call", () => {
+		const resultDir = tmpDir()
+		const { extension, control } = createResultWriter({ resultDir })
+		const pi = makeStubPi()
+		extension(pi as unknown as ExtensionAPI)
+
+		pi.fireSessionStart()
+
+		control.markTimeout()
+		const firstResult = readResult(resultDir)
+		const firstEndedAt = firstResult.ended_at
+
+		// small delay to ensure time advances
+		const laterDate = new Date(new Date(firstEndedAt).getTime() + 1000).toISOString()
+		vi.setSystemTime(new Date(laterDate))
+
+		control.markTimeout()
+
+		const secondResult = readResult(resultDir)
+		expect(secondResult.ended_at).toBe(firstEndedAt)
+
+		vi.useRealTimers()
+	})
+
+	it("started_at and ended_at are valid ISO strings with ended_at >= started_at", () => {
+		const resultDir = tmpDir()
+		const { extension } = createResultWriter({ resultDir })
+		const pi = makeStubPi()
+		extension(pi as unknown as ExtensionAPI)
+
+		pi.fireSessionStart()
+		pi.fireSessionShutdown()
+
+		const result = readResult(resultDir)
+
+		expect(new Date(result.started_at).toISOString()).toBe(result.started_at)
+		expect(new Date(result.ended_at).toISOString()).toBe(result.ended_at)
+		expect(result.ended_at >= result.started_at).toBe(true)
+	})
+
+	it("logPath option is passed through to the manifest as log_path", () => {
+		const resultDir = tmpDir()
+		const logPath = "/workspace/.kimchi/run.log"
+		const { extension } = createResultWriter({ resultDir, logPath })
+		const pi = makeStubPi()
+		extension(pi as unknown as ExtensionAPI)
+
+		pi.fireSessionStart()
+		pi.fireSessionShutdown()
+
+		const result = readResult(resultDir)
+		expect(result.log_path).toBe(logPath)
+	})
+
+	it("flushIfUnflushed is a no-op when already flushed via markTimeout", () => {
+		const resultDir = tmpDir()
+		const { extension, control } = createResultWriter({ resultDir })
+		const pi = makeStubPi()
+		extension(pi as unknown as ExtensionAPI)
+
+		pi.fireSessionStart()
+		control.markTimeout()
+
+		const firstResult = readResult(resultDir)
+		expect(firstResult.exit_reason).toBe("timeout")
+
+		// calling flushIfUnflushed after already flushed should not overwrite
+		control.flushIfUnflushed("error")
+
+		const secondResult = readResult(resultDir)
+		expect(secondResult.exit_reason).toBe("timeout")
+	})
+
+	it("flushIfUnflushed writes the manifest with the given exit_reason when not yet flushed", () => {
+		const resultDir = tmpDir()
+		const { extension, control } = createResultWriter({ resultDir })
+		const pi = makeStubPi()
+		extension(pi as unknown as ExtensionAPI)
+
+		pi.fireSessionStart()
+
+		expect(existsSync(join(resultDir, "result.json"))).toBe(false)
+
+		control.flushIfUnflushed("error")
+
+		expect(existsSync(join(resultDir, "result.json"))).toBe(true)
+		const result = readResult(resultDir)
+		expect(result.exit_reason).toBe("error")
+	})
+})

--- a/src/extensions/autonomous/result-writer.ts
+++ b/src/extensions/autonomous/result-writer.ts
@@ -1,0 +1,90 @@
+import type { ExtensionAPI, TurnEndEvent } from "@mariozechner/pi-coding-agent"
+import type { ResultManifest } from "../../autonomous/result.js"
+import { writeResult } from "../../autonomous/result.js"
+
+export interface ResultWriterControl {
+	markTimeout(): void
+	markError(error: { message: string; stack?: string }): void
+	flush(): void
+	flushIfUnflushed(reason: ResultManifest["exit_reason"]): void
+}
+
+export interface ResultWriterHandle {
+	extension: (pi: ExtensionAPI) => void
+	control: ResultWriterControl
+}
+
+export function createResultWriter(options: { resultDir: string; logPath?: string }): ResultWriterHandle {
+	const { resultDir, logPath } = options
+
+	let startedAt: string | undefined
+	let exitReason: "done" | "timeout" | "error" = "error"
+	let lastMessage: string | undefined
+	let errorDetail: { message: string; stack?: string } | undefined
+	let flushed = false
+
+	const control: ResultWriterControl = {
+		markTimeout() {
+			exitReason = "timeout"
+			errorDetail = undefined
+			if (!flushed) {
+				control.flush()
+			}
+		},
+
+		markError(error: { message: string; stack?: string }) {
+			exitReason = "error"
+			errorDetail = error
+			if (!flushed) {
+				control.flush()
+			}
+		},
+
+		flush() {
+			if (flushed) return
+			flushed = true
+
+			writeResult(resultDir, {
+				exit_reason: exitReason,
+				started_at: startedAt ?? new Date().toISOString(),
+				ended_at: new Date().toISOString(),
+				...(lastMessage !== undefined ? { last_message: lastMessage } : {}),
+				...(logPath !== undefined ? { log_path: logPath } : {}),
+				...(errorDetail !== undefined ? { error: errorDetail } : {}),
+			})
+		},
+
+		flushIfUnflushed(reason: ResultManifest["exit_reason"]) {
+			if (flushed) return
+			exitReason = reason
+			control.flush()
+		},
+	}
+
+	function extension(pi: ExtensionAPI): void {
+		pi.on("session_start", () => {
+			startedAt = new Date().toISOString()
+			exitReason = "done"
+			lastMessage = undefined
+			errorDetail = undefined
+			flushed = false
+		})
+
+		pi.on("turn_end", (event: TurnEndEvent) => {
+			const { message } = event
+			if (message.role !== "assistant") return
+			const textItems = message.content.filter((c) => c.type === "text")
+			const combined = textItems.map((c) => (c.type === "text" ? c.text : "")).join("\n")
+
+			if (combined.length > 0) {
+				lastMessage = combined
+			}
+		})
+
+		pi.on("session_shutdown", () => {
+			control.flush()
+		})
+	}
+
+	return { extension, control }
+}

--- a/src/extensions/autonomous/timeout-guard.test.ts
+++ b/src/extensions/autonomous/timeout-guard.test.ts
@@ -1,0 +1,149 @@
+import type { ExtensionAPI } from "@mariozechner/pi-coding-agent"
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
+import { MAX_TIMEOUT_MS, timeoutGuardExtension } from "./timeout-guard.js"
+
+type StubHandler = (evt: unknown, ctx: unknown) => unknown
+
+function makeStubPi() {
+	const handlers: Record<string, StubHandler[]> = {}
+	return {
+		on: vi.fn((event: string, handler: StubHandler) => {
+			if (handlers[event] === undefined) handlers[event] = []
+			handlers[event].push(handler)
+		}),
+		fireSessionStart: (ctx: unknown = {}) => {
+			for (const h of handlers.session_start ?? []) h({ type: "session_start" }, ctx)
+		},
+		fireSessionShutdown: () => {
+			for (const h of handlers.session_shutdown ?? []) h({ type: "session_shutdown" }, {})
+		},
+	}
+}
+
+describe("timeoutGuardExtension", () => {
+	beforeEach(() => {
+		vi.useFakeTimers()
+	})
+
+	afterEach(() => {
+		vi.useRealTimers()
+	})
+
+	it("registers session_start and session_shutdown handlers (exactly those, no others)", () => {
+		const pi = makeStubPi()
+		const onTimeout = vi.fn()
+		timeoutGuardExtension({ timeoutMs: 1000, onTimeout })(pi as unknown as ExtensionAPI)
+
+		const registeredEvents = pi.on.mock.calls.map((c) => c[0])
+		expect(registeredEvents).toContain("session_start")
+		expect(registeredEvents).toContain("session_shutdown")
+		expect(registeredEvents).toHaveLength(2)
+	})
+
+	it("throws synchronously when constructed with timeoutMs: 0", () => {
+		expect(() => timeoutGuardExtension({ timeoutMs: 0, onTimeout: vi.fn() })).toThrow(/timeoutMs/)
+	})
+
+	it("throws synchronously when timeoutMs: -1", () => {
+		expect(() => timeoutGuardExtension({ timeoutMs: -1, onTimeout: vi.fn() })).toThrow(/timeoutMs/)
+	})
+
+	it("calls onTimeout after timeoutMs ms have advanced past session_start", () => {
+		const pi = makeStubPi()
+		const onTimeout = vi.fn()
+		timeoutGuardExtension({ timeoutMs: 5000, onTimeout })(pi as unknown as ExtensionAPI)
+
+		pi.fireSessionStart()
+		vi.advanceTimersByTime(4999)
+		expect(onTimeout).not.toHaveBeenCalled()
+
+		vi.advanceTimersByTime(1)
+		expect(onTimeout).toHaveBeenCalledTimes(1)
+	})
+
+	it("does NOT call onTimeout if session_shutdown fires before the timer expires", () => {
+		const pi = makeStubPi()
+		const onTimeout = vi.fn()
+		timeoutGuardExtension({ timeoutMs: 5000, onTimeout })(pi as unknown as ExtensionAPI)
+
+		pi.fireSessionStart()
+		vi.advanceTimersByTime(3000)
+		pi.fireSessionShutdown()
+		vi.advanceTimersByTime(5000)
+
+		expect(onTimeout).not.toHaveBeenCalled()
+	})
+
+	it("does NOT call onTimeout if no session_start ever fires (timer not armed)", () => {
+		const pi = makeStubPi()
+		const onTimeout = vi.fn()
+		timeoutGuardExtension({ timeoutMs: 5000, onTimeout })(pi as unknown as ExtensionAPI)
+
+		vi.advanceTimersByTime(10000)
+
+		expect(onTimeout).not.toHaveBeenCalled()
+	})
+
+	it("clamps timeoutMs > MAX_TIMEOUT_MS to MAX_TIMEOUT_MS", () => {
+		const pi = makeStubPi()
+		const onTimeout = vi.fn()
+		timeoutGuardExtension({ timeoutMs: MAX_TIMEOUT_MS + 1, onTimeout })(pi as unknown as ExtensionAPI)
+
+		pi.fireSessionStart()
+		vi.advanceTimersByTime(MAX_TIMEOUT_MS - 1)
+		expect(onTimeout).not.toHaveBeenCalled()
+
+		vi.advanceTimersByTime(1)
+		expect(onTimeout).toHaveBeenCalledTimes(1)
+	})
+
+	it("calls ctx.shutdown() before onTimeout when the timer fires", () => {
+		const pi = makeStubPi()
+		const onTimeout = vi.fn()
+		const shutdown = vi.fn()
+		const callOrder: string[] = []
+		shutdown.mockImplementation(() => callOrder.push("shutdown"))
+		onTimeout.mockImplementation(() => callOrder.push("onTimeout"))
+
+		timeoutGuardExtension({ timeoutMs: 5000, onTimeout })(pi as unknown as ExtensionAPI)
+		pi.fireSessionStart({ shutdown })
+
+		vi.advanceTimersByTime(5000)
+
+		expect(shutdown).toHaveBeenCalledTimes(1)
+		expect(onTimeout).toHaveBeenCalledTimes(1)
+		expect(callOrder).toEqual(["shutdown", "onTimeout"])
+	})
+
+	it("does not throw when ctx.shutdown() throws synchronously", () => {
+		const pi = makeStubPi()
+		const onTimeout = vi.fn()
+		const shutdown = vi.fn(() => {
+			throw new Error("teardown failed")
+		})
+
+		timeoutGuardExtension({ timeoutMs: 5000, onTimeout })(pi as unknown as ExtensionAPI)
+		pi.fireSessionStart({ shutdown })
+
+		expect(() => vi.advanceTimersByTime(5000)).not.toThrow()
+		expect(onTimeout).toHaveBeenCalledTimes(1)
+	})
+
+	it("multiple session_start events: only one timer is armed at a time", () => {
+		const pi = makeStubPi()
+		const onTimeout = vi.fn()
+		timeoutGuardExtension({ timeoutMs: 5000, onTimeout })(pi as unknown as ExtensionAPI)
+
+		// First session_start arms the timer
+		pi.fireSessionStart()
+		vi.advanceTimersByTime(3000)
+
+		// Second session_start re-arms; the prior timer should be cleared
+		pi.fireSessionStart()
+		vi.advanceTimersByTime(4999)
+		expect(onTimeout).not.toHaveBeenCalled()
+
+		vi.advanceTimersByTime(1)
+		expect(onTimeout).toHaveBeenCalledTimes(1)
+	})
+})

--- a/src/extensions/autonomous/timeout-guard.ts
+++ b/src/extensions/autonomous/timeout-guard.ts
@@ -1,0 +1,53 @@
+import type { ExtensionAPI, ExtensionContext } from "@mariozechner/pi-coding-agent"
+
+export const MAX_TIMEOUT_MS = 6 * 60 * 60 * 1000
+
+/**
+ * Extension that arms a wall-clock kill switch after `timeoutMs` milliseconds.
+ * The timer is started on `session_start` and cleared on `session_shutdown`.
+ *
+ * When the timer fires, the most recent session ctx's `shutdown()` is called
+ * to allow extension cleanup hooks (telemetry flush, MCP teardown) to run,
+ * then the user-supplied `onTimeout` callback fires (typically
+ * `() => process.exit(124)` in production).
+ */
+export function timeoutGuardExtension(options: { timeoutMs: number; onTimeout: () => void }): (
+	pi: ExtensionAPI,
+) => void {
+	const { onTimeout } = options
+
+	if (options.timeoutMs <= 0) {
+		throw new Error("timeoutMs must be a positive number")
+	}
+
+	const timeoutMs = Math.min(options.timeoutMs, MAX_TIMEOUT_MS)
+
+	return (pi: ExtensionAPI) => {
+		let timer: ReturnType<typeof setTimeout> | undefined
+		let activeCtx: ExtensionContext | undefined
+
+		pi.on("session_start", (_event, ctx) => {
+			activeCtx = ctx
+			if (timer !== undefined) {
+				clearTimeout(timer)
+			}
+			timer = setTimeout(() => {
+				timer = undefined
+				try {
+					activeCtx?.shutdown()
+				} catch {
+					// best-effort cleanup; do not block onTimeout
+				}
+				onTimeout()
+			}, timeoutMs)
+		})
+
+		pi.on("session_shutdown", () => {
+			if (timer !== undefined) {
+				clearTimeout(timer)
+				timer = undefined
+			}
+			activeCtx = undefined
+		})
+	}
+}

--- a/tests/smoke/autonomous-e2e.test.ts
+++ b/tests/smoke/autonomous-e2e.test.ts
@@ -1,0 +1,146 @@
+/**
+ * End-to-end smoke for autonomous mode.
+ *
+ * Builds the kimchi container image, runs `kimchi run-autonomous` against a
+ * tiny task spec that asks the agent to write a file and emit <done>, then
+ * asserts the container exited 0 and the result manifest is well-formed.
+ *
+ * Gated by KIMCHI_E2E=1 because it:
+ *   - shells out to `docker build` and `docker run`
+ *   - requires the cross-built linux binary at dist/bin/kimchi-linux-amd64
+ *     (built via `pnpm build:binary-linux-x64`, which needs Node 22 + bun)
+ *   - calls the live LLM (uses KIMCHI_API_KEY from the host env)
+ *
+ * Skipped automatically when any prerequisite is missing, so the test never
+ * fails for environmental reasons — only for genuine regressions.
+ */
+
+import { execSync, spawnSync } from "node:child_process"
+import { existsSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs"
+import { tmpdir } from "node:os"
+import { join, resolve } from "node:path"
+import { afterEach, beforeAll, describe, expect, it } from "vitest"
+
+const REPO_ROOT = resolve(__dirname, "..", "..")
+const BINARY_PATH = join(REPO_ROOT, "dist", "bin", "kimchi-linux-amd64")
+const IMAGE_TAG = "kimchi:e2e-test"
+
+const e2eEnabled = process.env.KIMCHI_E2E === "1"
+const apiKey = process.env.KIMCHI_API_KEY
+const haveDocker = (() => {
+	try {
+		execSync("docker --version", { stdio: "ignore" })
+		return true
+	} catch {
+		return false
+	}
+})()
+const haveBinary = existsSync(BINARY_PATH)
+
+// Surface ONE clear reason for skipping so debugging a CI miss is fast.
+const skipReason = !e2eEnabled
+	? "set KIMCHI_E2E=1 to enable"
+	: !haveDocker
+		? "docker not available on PATH"
+		: !haveBinary
+			? `linux binary not built (expected ${BINARY_PATH}; run pnpm build:binary-linux-x64)`
+			: !apiKey
+				? "KIMCHI_API_KEY not set"
+				: undefined
+
+const runE2E = skipReason === undefined
+
+const tempDirs: string[] = []
+
+afterEach(() => {
+	for (const dir of tempDirs.splice(0)) {
+		rmSync(dir, { recursive: true, force: true })
+	}
+})
+
+describe.skipIf(!runE2E)("autonomous mode end-to-end", () => {
+	beforeAll(() => {
+		// Build the image once for the whole suite. Single-arch (current host) is fine.
+		execSync(`docker build -t ${IMAGE_TAG} .`, {
+			cwd: REPO_ROOT,
+			stdio: "inherit",
+		})
+	}, 600_000)
+
+	it("runs a write-file task to completion and writes a valid result manifest", () => {
+		const workspace = mkdtempSync(join(tmpdir(), "kimchi-e2e-"))
+		tempDirs.push(workspace)
+
+		const task = {
+			prompt:
+				"Create a file at /workspace/output.txt with the exact content 'hello from kimchi' (no trailing newline). " +
+				"Verify it was written by reading it back. Then respond with <done>.",
+			timeout_seconds: 300,
+		}
+		const taskPath = join(workspace, "task.json")
+		writeFileSync(taskPath, JSON.stringify(task, null, 2))
+
+		// Invoke the launcher directly via tsx so we don't depend on a host-side
+		// kimchi install. The launcher itself shells out to `docker run` for the
+		// container, which is what we actually want to exercise.
+		const result = spawnSync(
+			"pnpm",
+			[
+				"exec",
+				"tsx",
+				"src/entry.ts",
+				"run-autonomous",
+				"--task",
+				taskPath,
+				"--runtime",
+				"docker",
+				"--workspace",
+				workspace,
+				"--image",
+				IMAGE_TAG,
+			],
+			{
+				cwd: REPO_ROOT,
+				encoding: "utf-8",
+				env: {
+					...process.env,
+					KIMCHI_API_KEY: apiKey,
+				},
+				timeout: 360_000,
+			},
+		)
+
+		// Surface logs on failure so the dev sees what the agent actually did.
+		if (result.status !== 0) {
+			console.error("stdout:\n", result.stdout)
+			console.error("stderr:\n", result.stderr)
+		}
+
+		expect(result.status).toBe(0)
+
+		// Result manifest exists and reports done.
+		const manifestPath = join(workspace, ".kimchi", "result.json")
+		expect(existsSync(manifestPath)).toBe(true)
+		const manifest = JSON.parse(readFileSync(manifestPath, "utf-8"))
+		expect(manifest.exit_reason).toBe("done")
+		expect(typeof manifest.started_at).toBe("string")
+		expect(typeof manifest.ended_at).toBe("string")
+		expect(new Date(manifest.ended_at).getTime()).toBeGreaterThanOrEqual(new Date(manifest.started_at).getTime())
+
+		// The file the agent was asked to create exists with the right content.
+		const outputPath = join(workspace, "output.txt")
+		expect(existsSync(outputPath)).toBe(true)
+		expect(readFileSync(outputPath, "utf-8").trim()).toBe("hello from kimchi")
+
+		// run.log was captured.
+		const logPath = join(workspace, ".kimchi", "run.log")
+		if (existsSync(logPath)) {
+			expect(readFileSync(logPath, "utf-8").length).toBeGreaterThan(0)
+		}
+	}, 420_000)
+})
+
+if (!runE2E) {
+	// Emit a one-line note so it's obvious why this suite didn't contribute coverage.
+	console.log(`[autonomous-e2e] skipped: ${skipReason}`)
+}

--- a/tests/smoke/autonomous-wiring.test.ts
+++ b/tests/smoke/autonomous-wiring.test.ts
@@ -1,0 +1,318 @@
+/**
+ * Wiring test (unit-level): WI-14
+ *
+ * Exercises the autonomous extensions composed together (createResultWriter +
+ * maxIterationsExtension); does NOT run pi-coding-agent's main() against an LLM.
+ *
+ * Verifies that the extensions cooperate correctly when driven through the
+ * same event sequence the real harness produces:
+ *
+ *   session_start → turn_end → session_shutdown
+ *   → result-writer flushes manifest with exit_reason "done" (clean shutdown)
+ *
+ * This test is entirely in-process; no binary or real LLM is required.
+ * The FakeLlmServer (Part A) is also exercised in a lightweight way to
+ * confirm the fixture task spec is valid and the server wires up properly.
+ */
+
+import { randomUUID } from "node:crypto"
+import { existsSync, readFileSync, rmSync } from "node:fs"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
+import type { AssistantMessage } from "@mariozechner/pi-ai"
+import type { ExtensionAPI } from "@mariozechner/pi-coding-agent"
+import { afterEach, describe, expect, it, vi } from "vitest"
+import { buildAutoArgs } from "../../src/commands/auto.js"
+import { maxIterationsExtension } from "../../src/extensions/autonomous/max-iterations.js"
+import { createResultWriter } from "../../src/extensions/autonomous/result-writer.js"
+import { type FakeLlmServer, startFakeLlmServer } from "./fake-llm/server.js"
+
+// ---------------------------------------------------------------------------
+// Helpers shared across tests
+// ---------------------------------------------------------------------------
+
+function makeAssistant(text: string): AssistantMessage {
+	return {
+		role: "assistant",
+		content: [{ type: "text", text }],
+		api: "anthropic-messages",
+		provider: "anthropic",
+		model: "kimi-k2.5",
+		usage: {
+			input: 0,
+			output: 0,
+			cacheRead: 0,
+			cacheWrite: 0,
+			totalTokens: 0,
+			cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+		},
+		stopReason: "stop",
+		timestamp: Date.now(),
+	}
+}
+
+/**
+ * Minimal stub for pi's ExtensionAPI — only exposes the on() method needed
+ * to register event handlers; fire* helpers simulate harness event dispatch.
+ */
+function makeStubPi() {
+	const handlers: Record<string, ((evt: unknown, ctx: unknown) => void)[]> = {}
+
+	const pi = {
+		on: vi.fn((event: string, handler: (evt: unknown, ctx: unknown) => void) => {
+			if (handlers[event] === undefined) handlers[event] = []
+			handlers[event].push(handler)
+		}),
+	}
+
+	function fire(event: string, payload: unknown, ctx: unknown = {}): void {
+		for (const h of handlers[event] ?? []) h(payload, ctx)
+	}
+
+	return {
+		pi,
+		fireSessionStart: () => fire("session_start", { type: "session_start" }),
+		fireTurnEnd: (msg: AssistantMessage, ctx: unknown = {}) =>
+			fire("turn_end", { type: "turn_end", message: msg }, ctx),
+		fireSessionShutdown: () => fire("session_shutdown", { type: "session_shutdown" }),
+	}
+}
+
+function tmpResultDir(): string {
+	return join(tmpdir(), `autonomous-wiring-test-${randomUUID()}`)
+}
+
+// ---------------------------------------------------------------------------
+// Fixture: autonomous-task.json
+// ---------------------------------------------------------------------------
+
+describe("autonomous-task.json fixture", () => {
+	it("fixture file exists at tests/smoke/fixtures/autonomous-task.json", () => {
+		const fixturePath = join(
+			import.meta.dirname ?? new URL(".", import.meta.url).pathname,
+			"fixtures",
+			"autonomous-task.json",
+		)
+		expect(existsSync(fixturePath)).toBe(true)
+	})
+
+	it("fixture is valid JSON with prompt and timeout_seconds fields", () => {
+		const fixturePath = join(
+			import.meta.dirname ?? new URL(".", import.meta.url).pathname,
+			"fixtures",
+			"autonomous-task.json",
+		)
+		const raw = readFileSync(fixturePath, "utf-8")
+		const parsed = JSON.parse(raw) as { prompt: unknown; timeout_seconds: unknown }
+		expect(typeof parsed.prompt).toBe("string")
+		expect(typeof parsed.timeout_seconds).toBe("number")
+	})
+})
+
+// ---------------------------------------------------------------------------
+// WI-8 re-verification at integration level: buildAutoArgs from fixture spec
+// ---------------------------------------------------------------------------
+
+describe("buildAutoArgs integration check", () => {
+	it("returns argv starting with standard flags followed by the fixture prompt", () => {
+		const spec = { prompt: "say done", timeout_seconds: 60 }
+		const argv = buildAutoArgs(spec, { help: false, passthroughArgs: [] })
+		expect(argv).toEqual(["--yolo", "--print", "--mode", "json", "--no-session", "say done"])
+	})
+})
+
+// ---------------------------------------------------------------------------
+// FakeLlmServer sanity: server starts + returns response text
+// ---------------------------------------------------------------------------
+
+describe("FakeLlmServer — wiring sanity", () => {
+	const servers: FakeLlmServer[] = []
+
+	afterEach(async () => {
+		for (const srv of servers.splice(0)) {
+			await srv.close().catch(() => {})
+		}
+	})
+
+	it("server starts with a response and baseUrl ends in /v1", async () => {
+		const srv = await startFakeLlmServer({ responses: ["task complete"] })
+		servers.push(srv)
+		expect(srv.baseUrl).toMatch(/\/v1$/)
+	})
+
+	it("non-streaming call returns the response as message content", async () => {
+		const srv = await startFakeLlmServer({ responses: ["task complete"] })
+		servers.push(srv)
+		const res = await fetch(`${srv.baseUrl}/chat/completions`, {
+			method: "POST",
+			headers: { "Content-Type": "application/json" },
+			body: JSON.stringify({ stream: false }),
+		})
+		const json = (await res.json()) as {
+			choices: Array<{ message: { content: string } }>
+		}
+		expect(json.choices[0].message.content).toBe("task complete")
+	})
+})
+
+// ---------------------------------------------------------------------------
+// Core integration: createResultWriter — clean shutdown writes exit_reason "done"
+// ---------------------------------------------------------------------------
+
+describe("createResultWriter integration", () => {
+	const createdDirs: string[] = []
+
+	afterEach(() => {
+		for (const d of createdDirs.splice(0)) {
+			rmSync(d, { recursive: true, force: true })
+		}
+	})
+
+	function makeResultDir(): string {
+		const d = tmpResultDir()
+		createdDirs.push(d)
+		return d
+	}
+
+	it("clean session_start + session_shutdown writes exit_reason 'done'", () => {
+		const resultDir = makeResultDir()
+		const { extension: writerExtension } = createResultWriter({ resultDir })
+
+		const stub = makeStubPi()
+		writerExtension(stub.pi as unknown as ExtensionAPI)
+
+		stub.fireSessionStart()
+		stub.fireSessionShutdown()
+
+		const manifest = JSON.parse(readFileSync(join(resultDir, "result.json"), "utf-8")) as {
+			exit_reason: string
+		}
+		expect(manifest.exit_reason).toBe("done")
+	})
+
+	it("turn_end before session_shutdown captures last_message", () => {
+		const resultDir = makeResultDir()
+		const { extension: writerExtension } = createResultWriter({ resultDir })
+
+		const stub = makeStubPi()
+		writerExtension(stub.pi as unknown as ExtensionAPI)
+
+		stub.fireSessionStart()
+		stub.fireTurnEnd(makeAssistant("all done"))
+		stub.fireSessionShutdown()
+
+		const manifest = JSON.parse(readFileSync(join(resultDir, "result.json"), "utf-8")) as {
+			exit_reason: string
+			last_message: string
+		}
+		expect(manifest.exit_reason).toBe("done")
+		expect(manifest.last_message).toBe("all done")
+	})
+
+	it("manifest written after session_shutdown contains started_at and ended_at ISO strings", () => {
+		const resultDir = makeResultDir()
+		const { extension: writerExtension } = createResultWriter({ resultDir })
+
+		const stub = makeStubPi()
+		writerExtension(stub.pi as unknown as ExtensionAPI)
+
+		stub.fireSessionStart()
+		stub.fireTurnEnd(makeAssistant("finished"))
+		stub.fireSessionShutdown()
+
+		const manifest = JSON.parse(readFileSync(join(resultDir, "result.json"), "utf-8")) as {
+			started_at: string
+			ended_at: string
+		}
+		expect(new Date(manifest.started_at).toISOString()).toBe(manifest.started_at)
+		expect(new Date(manifest.ended_at).toISOString()).toBe(manifest.ended_at)
+	})
+
+	it("manifest last_message reflects the final turn text", () => {
+		const resultDir = makeResultDir()
+		const { extension: writerExtension } = createResultWriter({ resultDir })
+
+		const stub = makeStubPi()
+		writerExtension(stub.pi as unknown as ExtensionAPI)
+
+		stub.fireSessionStart()
+		stub.fireTurnEnd(makeAssistant("final result"))
+		stub.fireSessionShutdown()
+
+		const manifest = JSON.parse(readFileSync(join(resultDir, "result.json"), "utf-8")) as {
+			last_message: string
+			exit_reason: string
+		}
+		expect(manifest.last_message).toBe("final result")
+		expect(manifest.exit_reason).toBe("done")
+	})
+})
+
+// ---------------------------------------------------------------------------
+// maxIterationsExtension + createResultWriter cooperate
+// ---------------------------------------------------------------------------
+
+describe("maxIterationsExtension + createResultWriter integration", () => {
+	const createdDirs: string[] = []
+
+	afterEach(() => {
+		for (const d of createdDirs.splice(0)) {
+			rmSync(d, { recursive: true, force: true })
+		}
+	})
+
+	function makeResultDir(): string {
+		const d = tmpResultDir()
+		createdDirs.push(d)
+		return d
+	}
+
+	it("maxIterations=1 fires onLimit on first turn_end (custom callback supplied)", async () => {
+		const resultDir = makeResultDir()
+		const { extension: writerExtension } = createResultWriter({ resultDir })
+		const onLimit = vi.fn()
+		const iterExtension = maxIterationsExtension({ maxIterations: 1, onLimit })
+
+		const stub = makeStubPi()
+		writerExtension(stub.pi as unknown as ExtensionAPI)
+		iterExtension(stub.pi as unknown as ExtensionAPI)
+
+		const ctx = { shutdown: vi.fn().mockResolvedValue(undefined) }
+
+		stub.fireSessionStart()
+		stub.fireTurnEnd(makeAssistant("step 1"), ctx)
+
+		await Promise.resolve()
+		expect(onLimit).toHaveBeenCalledTimes(1)
+	})
+
+	it("two extensions registered on the same pi stub both fire on turn_end", () => {
+		const resultDir = makeResultDir()
+		const { extension: writerExtension } = createResultWriter({ resultDir })
+		const iterExtension = maxIterationsExtension({ maxIterations: 5 })
+
+		const stub = makeStubPi()
+		writerExtension(stub.pi as unknown as ExtensionAPI)
+		iterExtension(stub.pi as unknown as ExtensionAPI)
+
+		const turnEndCalls = stub.pi.on.mock.calls.filter((c) => c[0] === "turn_end")
+		expect(turnEndCalls).toHaveLength(2)
+	})
+
+	it("shutdown after maxIterations leaves exit_reason 'done' in manifest", () => {
+		const resultDir = makeResultDir()
+		const { extension: writerExtension } = createResultWriter({ resultDir })
+
+		const stub = makeStubPi()
+		writerExtension(stub.pi as unknown as ExtensionAPI)
+
+		stub.fireSessionStart()
+		stub.fireTurnEnd(makeAssistant("done"))
+		stub.fireSessionShutdown()
+
+		const manifest = JSON.parse(readFileSync(join(resultDir, "result.json"), "utf-8")) as {
+			exit_reason: string
+		}
+		expect(manifest.exit_reason).toBe("done")
+	})
+})

--- a/tests/smoke/fake-llm/server.test.ts
+++ b/tests/smoke/fake-llm/server.test.ts
@@ -1,0 +1,161 @@
+import { afterEach, describe, expect, it } from "vitest"
+import { type FakeLlmServer, startFakeLlmServer } from "./server.js"
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+async function postCompletions(baseUrl: string, body: Record<string, unknown>): Promise<Response> {
+	return fetch(`${baseUrl}/chat/completions`, {
+		method: "POST",
+		headers: { "Content-Type": "application/json" },
+		body: JSON.stringify(body),
+	})
+}
+
+async function readStreamingText(res: Response): Promise<string> {
+	const text = await res.text()
+	return text
+}
+
+function extractDeltaContents(sseBody: string): string[] {
+	const contents: string[] = []
+	for (const line of sseBody.split("\n")) {
+		if (!line.startsWith("data: ")) continue
+		const payload = line.slice("data: ".length).trim()
+		if (payload === "[DONE]") continue
+		try {
+			const parsed = JSON.parse(payload) as {
+				choices: Array<{ delta: { content?: string }; finish_reason?: string }>
+			}
+			const content = parsed.choices?.[0]?.delta?.content
+			if (content !== undefined) {
+				contents.push(content)
+			}
+		} catch {
+			// ignore malformed lines
+		}
+	}
+	return contents
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("startFakeLlmServer", () => {
+	const servers: FakeLlmServer[] = []
+
+	async function start(...args: Parameters<typeof startFakeLlmServer>): Promise<FakeLlmServer> {
+		const srv = await startFakeLlmServer(...args)
+		servers.push(srv)
+		return srv
+	}
+
+	afterEach(async () => {
+		for (const srv of servers.splice(0)) {
+			await srv.close().catch(() => {})
+		}
+	})
+
+	it("returns a baseUrl ending in /v1", async () => {
+		const srv = await start({ responses: ["hello"] })
+		expect(srv.baseUrl).toMatch(/\/v1$/)
+	})
+
+	it("returns a port number that is > 0", async () => {
+		const srv = await start({ responses: ["hello"] })
+		expect(srv.port).toBeGreaterThan(0)
+	})
+
+	it("baseUrl includes the port", async () => {
+		const srv = await start({ responses: ["hello"] })
+		expect(srv.baseUrl).toContain(String(srv.port))
+	})
+
+	it("streaming request returns Content-Type text/event-stream", async () => {
+		const srv = await start({ responses: ["hello"] })
+		const res = await postCompletions(srv.baseUrl, { stream: true })
+		expect(res.headers.get("content-type")).toMatch(/text\/event-stream/)
+	})
+
+	it("streaming request body contains the response text across delta.content chunks", async () => {
+		const srv = await start({ responses: ["hello"] })
+		const res = await postCompletions(srv.baseUrl, { stream: true })
+		const body = await readStreamingText(res)
+		const chunks = extractDeltaContents(body)
+		expect(chunks.join("")).toBe("hello")
+	})
+
+	it("streaming request body ends with [DONE]", async () => {
+		const srv = await start({ responses: ["hello"] })
+		const res = await postCompletions(srv.baseUrl, { stream: true })
+		const body = await readStreamingText(res)
+		expect(body).toContain("data: [DONE]")
+	})
+
+	it("non-streaming request (stream: false) returns JSON with choices[0].message.content", async () => {
+		const srv = await start({ responses: ["hello"] })
+		const res = await postCompletions(srv.baseUrl, { stream: false })
+		const json = (await res.json()) as {
+			choices: Array<{ message: { content: string } }>
+		}
+		expect(json.choices[0].message.content).toBe("hello")
+	})
+
+	it("two sequential calls consume two responses in order", async () => {
+		const srv = await start({ responses: ["first", "second"] })
+
+		const res1 = await postCompletions(srv.baseUrl, { stream: false })
+		const json1 = (await res1.json()) as {
+			choices: Array<{ message: { content: string } }>
+		}
+		expect(json1.choices[0].message.content).toBe("first")
+
+		const res2 = await postCompletions(srv.baseUrl, { stream: false })
+		const json2 = (await res2.json()) as {
+			choices: Array<{ message: { content: string } }>
+		}
+		expect(json2.choices[0].message.content).toBe("second")
+	})
+
+	it("third call after exhaustion returns HTTP 500", async () => {
+		const srv = await start({ responses: ["first", "second"] })
+		await postCompletions(srv.baseUrl, { stream: false })
+		await postCompletions(srv.baseUrl, { stream: false })
+		const res = await postCompletions(srv.baseUrl, { stream: false })
+		expect(res.status).toBe(500)
+	})
+
+	it("500 error body contains 'no more scripted responses'", async () => {
+		const srv = await start({ responses: [] })
+		const res = await postCompletions(srv.baseUrl, { stream: false })
+		const json = (await res.json()) as { error: string }
+		expect(json.error).toBe("no more scripted responses")
+	})
+
+	it("close() resolves and subsequent fetch rejects or errors", async () => {
+		const srv = await start({ responses: ["hello"] })
+		await srv.close()
+		// Remove from cleanup list since we already closed it
+		const idx = servers.indexOf(srv)
+		if (idx !== -1) servers.splice(idx, 1)
+
+		await expect(postCompletions(srv.baseUrl, { stream: false })).rejects.toThrow()
+	})
+
+	it("object response with text field works the same as string response", async () => {
+		const srv = await start({ responses: [{ text: "from object" }] })
+		const res = await postCompletions(srv.baseUrl, { stream: false })
+		const json = (await res.json()) as {
+			choices: Array<{ message: { content: string } }>
+		}
+		expect(json.choices[0].message.content).toBe("from object")
+	})
+
+	it("default (no stream field) behaves as streaming", async () => {
+		const srv = await start({ responses: ["implicit stream"] })
+		const res = await postCompletions(srv.baseUrl, {})
+		expect(res.headers.get("content-type")).toMatch(/text\/event-stream/)
+	})
+})

--- a/tests/smoke/fake-llm/server.ts
+++ b/tests/smoke/fake-llm/server.ts
@@ -1,0 +1,130 @@
+/**
+ * Fake LLM SSE server for smoke tests.
+ *
+ * Speaks the OpenAI chat completions wire format (POST /v1/chat/completions).
+ * Supports both streaming (stream: true → text/event-stream) and non-streaming
+ * (stream: false → single JSON) requests.
+ *
+ * Each POST to /v1/chat/completions consumes the next scripted response in
+ * order. Once exhausted, returns 500 {"error":"no more scripted responses"}.
+ */
+
+import * as http from "node:http"
+
+export interface FakeLlmConfig {
+	/** Port to listen on. 0 = pick a random available port. Default: 0 */
+	port?: number
+	responses: Array<string | { text: string; toolCalls?: Array<{ name: string; args: unknown }> }>
+}
+
+export interface FakeLlmServer {
+	/** e.g. "http://127.0.0.1:54321/v1" */
+	baseUrl: string
+	port: number
+	close(): Promise<void>
+}
+
+const CHUNK_SIZE = 8
+
+function toText(response: FakeLlmConfig["responses"][number]): string {
+	return typeof response === "string" ? response : response.text
+}
+
+function buildStreamingChunks(text: string): string {
+	const parts: string[] = []
+
+	// Split text into ~CHUNK_SIZE-char pieces for realism
+	for (let i = 0; i < text.length; i += CHUNK_SIZE) {
+		const piece = text.slice(i, i + CHUNK_SIZE)
+		const data = JSON.stringify({
+			choices: [{ delta: { content: piece }, finish_reason: null }],
+		})
+		parts.push(`data: ${data}\n\n`)
+	}
+
+	// Final chunk: finish_reason stop
+	const stop = JSON.stringify({
+		choices: [{ delta: {}, finish_reason: "stop" }],
+	})
+	parts.push(`data: ${stop}\n\n`)
+	parts.push("data: [DONE]\n\n")
+
+	return parts.join("")
+}
+
+function buildNonStreamingBody(text: string): string {
+	return JSON.stringify({
+		choices: [{ message: { role: "assistant", content: text } }],
+	})
+}
+
+export function startFakeLlmServer(config: FakeLlmConfig): Promise<FakeLlmServer> {
+	const port = config.port ?? 0
+	const responses = [...config.responses]
+	let cursor = 0
+
+	return new Promise((resolve, reject) => {
+		const server = http.createServer((req, res) => {
+			// Only handle POST /v1/chat/completions
+			if (req.method !== "POST" || req.url !== "/v1/chat/completions") {
+				res.writeHead(404)
+				res.end("Not found")
+				return
+			}
+
+			// Consume request body to parse stream flag
+			const chunks: Buffer[] = []
+			req.on("data", (chunk: Buffer) => chunks.push(chunk))
+			req.on("end", () => {
+				let body: { stream?: boolean } = {}
+				try {
+					body = JSON.parse(Buffer.concat(chunks).toString("utf-8"))
+				} catch {
+					// ignore parse errors; default to streaming
+				}
+
+				// Check if we still have responses
+				if (cursor >= responses.length) {
+					res.writeHead(500, { "Content-Type": "application/json" })
+					res.end(JSON.stringify({ error: "no more scripted responses" }))
+					return
+				}
+
+				const response = responses[cursor++]
+				const text = toText(response)
+				const wantsStream = body.stream !== false // default to streaming
+
+				if (wantsStream) {
+					res.writeHead(200, {
+						"Content-Type": "text/event-stream",
+						"Cache-Control": "no-cache",
+						Connection: "keep-alive",
+					})
+					res.end(buildStreamingChunks(text))
+				} else {
+					res.writeHead(200, { "Content-Type": "application/json" })
+					res.end(buildNonStreamingBody(text))
+				}
+			})
+		})
+
+		server.on("error", reject)
+
+		server.listen(port, "127.0.0.1", () => {
+			const addr = server.address() as { port: number }
+			const listenPort = addr.port
+
+			const fakeLlmServer: FakeLlmServer = {
+				baseUrl: `http://127.0.0.1:${listenPort}/v1`,
+				port: listenPort,
+				close(): Promise<void> {
+					return new Promise((res, rej) => {
+						server.close((err) => (err ? rej(err) : res()))
+					})
+				},
+			}
+
+			resolve(fakeLlmServer)
+		})
+	})
+}

--- a/tests/smoke/fixtures/autonomous-task.json
+++ b/tests/smoke/fixtures/autonomous-task.json
@@ -1,0 +1,1 @@
+{"prompt":"say done","timeout_seconds":60}


### PR DESCRIPTION


---
### Kimchi Summary
### What changed
Introduces `kimchi auto`, an unattended execution mode for the coding agent. It supports bare prompts, file references, or structured JSON task specs, with an optional `--runtime` flag to sandbox runs inside Docker, OrbStack, or Podman containers. On completion, a `result.json` manifest is written summarizing exit reason, timing, and any error.

### Why
Enables CI pipelines and other unattended environments to run the agent without interactivity. Container sandboxing isolates the agent from the host filesystem and provides a reproducible execution environment.

### Key changes
- `src/commands/auto.ts` — Core `auto` command implementation. Parses CLI args (`--task`, `--iterations`, `--timeout-seconds`, `--runtime`, `--workspace`, `--image`), builds the agent argument list (`--yolo --print --mode json --no-session`), and manages both in-process and containerized runs.
- `src/autonomous/spec.ts` — Loads and validates `TaskSpec` JSON via Zod, enforcing field constraints such as the `timeout_seconds` hard cap of 21600 and absolute mount paths without `..` segments.
- `src/autonomous/result.ts` — Atomically writes and reads a typed `ResultManifest` to `.kimchi/result.json` with full schema validation.
- `src/autonomous/runtime/cli.ts` & `select.ts` — CLI-based container runtime abstraction supporting `docker`, `orbstack`, and `podman` with configurable bind mounts, environment variables, and an `AbortController`-driven wall-clock timeout.
- `src/autonomous/select-extensions.ts` — Injects autonomous-specific extension factories (`resultWriter`, `timeoutGuard`, `maxIterations`) into the base extension pipeline.
- `Dockerfile` — Multi-arch image based on `debian:bookworm-slim` that packages cross-compiled Linux binaries, runs as non-root `uid 1000`, and uses `tini` as init.
- `scripts/build-image.sh` — Convenience script for single- or multi-arch (`--multi`) image builds via `docker buildx`.
- `src/cli-bootstrap.ts` & `src/cli-extensions.ts` — Refactors shared harness initialization (API key resolution, `models.json` refresh, settings/themes sync, User-Agent fetch patching) and the base extension factory list out of `src/cli.ts` so both interactive and autonomous modes share the same boot path.
- `docs/autonomous-mode.md` — Documents task spec format, CLI flags, runtime backends, result manifest schema, exit codes, and security caveats.
- `package.json` — Adds the `test:e2e` script and the `optional` dependency.

### Impact
- Autonomous mode implicitly enables `--yolo`, which bypasses all permission prompts. Bind mounts should target isolated workspace clones only.
- The container runs as `uid 1000`. The workspace directory must be writable by that user, or the agent will fail to write `.kimchi/result.json`.
- Deterministic exit codes are introduced: `0` for clean completion, `124` for timeout, `1` for pre-run/spec errors, and `130`/`143` for SIGINT/SIGTERM.
- `src/cli.ts` delegates setup to `src/cli-bootstrap.ts`; interactive behavior is unchanged.