### PR TITLE
feat: Bundled behaviours loaded by harness based on signal

### DIFF
--- a/src/agent-discovery/agents/opencode.test.ts
+++ b/src/agent-discovery/agents/opencode.test.ts
@@ -306,8 +306,8 @@ describe("openCode AgentDefinition", () => {
 			})
 			const def = makeOpenCodeDefinition({ configPaths: [path] })
 			const result = discoverAgent(def)
-			expect(result.mcpServers.modern).toBeDefined()
-			expect(result.mcpServers.legacy).toBeDefined()
+			expect(result.mcpServers.modern.command).toBe("tool")
+			expect(result.mcpServers.legacy.command).toBe("ls")
 		})
 	})
 
@@ -444,7 +444,7 @@ describe("openCode AgentDefinition", () => {
 			expect(result.mcpServers.bad1).toBeUndefined()
 			expect(result.mcpServers.bad2).toBeUndefined()
 			expect(result.mcpServers.bad3).toBeUndefined()
-			expect(result.mcpServers.good).toBeDefined()
+			expect(result.mcpServers.good.command).toBe("ok")
 		})
 
 		it("empty skills dir still sets skillsDir", () => {

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -16,6 +16,7 @@ import {
 } from "./config.js"
 import { isBunBinary } from "./env.js"
 import bashCollapseExtension from "./extensions/bash-collapse.js"
+import behavioursExtension from "./extensions/behaviours/index.js"
 import clipboardImageExtension from "./extensions/clipboard-image.js"
 import contextCompactorExtension from "./extensions/context-compactor.js"
 import kimchiMinimalTintsExtension from "./extensions/kimchi-minimal-tints.js"
@@ -263,6 +264,7 @@ try {
 			mcpAdapterExtension,
 			permissionsExtension,
 			promptEnrichmentExtension(skillPaths),
+			behavioursExtension,
 			promptSummaryExtension,
 			contextCompactorExtension,
 			clipboardImageExtension,

--- a/src/extensions/behaviours/bash-tokenize.test.ts
+++ b/src/extensions/behaviours/bash-tokenize.test.ts
@@ -1,0 +1,125 @@
+import { describe, expect, it } from "vitest"
+import { bashExecutables, bashInvokesCommand } from "./bash-tokenize.js"
+
+describe("bashExecutables", () => {
+	it("returns the single executable of a simple command", () => {
+		expect(bashExecutables("ls -la")).toEqual(["ls"])
+	})
+
+	it("returns empty for an empty command", () => {
+		expect(bashExecutables("")).toEqual([])
+		expect(bashExecutables("   \n\t  ")).toEqual([])
+	})
+
+	it("walks pipeline stages", () => {
+		expect(bashExecutables("ls -la | grep foo | wc -l")).toEqual(["ls", "grep", "wc"])
+	})
+
+	it("walks sequence stages", () => {
+		expect(bashExecutables("a; b && c || d")).toEqual(["a", "b", "c", "d"])
+	})
+
+	it("treats newlines as stage separators", () => {
+		expect(bashExecutables("a\nb\nc")).toEqual(["a", "b", "c"])
+	})
+
+	it("treats `&` as a stage separator", () => {
+		expect(bashExecutables("server & client")).toEqual(["server", "client"])
+	})
+
+	it("does not split on `|` inside double quotes", () => {
+		expect(bashExecutables('echo "a | b" | wc')).toEqual(["echo", "wc"])
+	})
+
+	it("does not split on `;` inside single quotes", () => {
+		expect(bashExecutables("echo 'a; b' ; wc")).toEqual(["echo", "wc"])
+	})
+
+	it("recurses into command substitution", () => {
+		// `do` and `done` are shell keywords but the tokeniser is keyword-blind:
+		// after a `;` it sees a fresh stage and records the first token as the
+		// executable. That's fine for our use — we never match against keywords.
+		expect(bashExecutables("for x in $(ls -la); do echo $x; done")).toEqual(["for", "ls", "do", "done"])
+	})
+
+	it("recurses into backtick substitution", () => {
+		// Outer `echo` flushes when whitespace hits, then the recursive call
+		// emits `whoami`. Order is lexical-with-recursion-after-flush.
+		expect(bashExecutables("echo `whoami`")).toEqual(["echo", "whoami"])
+	})
+
+	it("recurses into subshell groups", () => {
+		expect(bashExecutables("(cd /tmp && ls)")).toEqual(["cd", "ls"])
+	})
+
+	it("strips env-var assignment prefixes", () => {
+		expect(bashExecutables("FOO=bar gh pr list")).toEqual(["gh"])
+		expect(bashExecutables("FOO=bar BAZ=qux gh pr list")).toEqual(["gh"])
+	})
+
+	it("treats `=` inside an arg as an arg, not an env var", () => {
+		// `--flag=value` is not a leading `WORD=value` because it begins with `-`.
+		expect(bashExecutables("cmd --flag=value")).toEqual(["cmd"])
+	})
+
+	it("skips `#` comments at token boundary", () => {
+		expect(bashExecutables("ls # gh pr list")).toEqual(["ls"])
+		expect(bashExecutables("# all commented\nls")).toEqual(["ls"])
+	})
+
+	it("does not treat `#` mid-token as a comment", () => {
+		expect(bashExecutables("echo a#b")).toEqual(["echo"])
+	})
+
+	it("preserves quoted token contents", () => {
+		expect(bashExecutables("'/usr/bin/gh' pr list")).toEqual(["/usr/bin/gh"])
+		expect(bashExecutables('"/usr/bin/gh" pr list')).toEqual(["/usr/bin/gh"])
+	})
+
+	it("handles backslash escapes outside quotes", () => {
+		expect(bashExecutables("\\ls -la")).toEqual(["ls"])
+	})
+
+	it("swallows heredoc bodies", () => {
+		expect(bashExecutables("cat <<EOF\ngh pr list\nEOF\nls")).toEqual(["cat", "ls"])
+	})
+
+	it("swallows heredoc bodies with `<<-` and tab-stripped delimiter", () => {
+		expect(bashExecutables("cat <<-END\n\tgh pr list\n\tEND\nls")).toEqual(["cat", "ls"])
+	})
+
+	it("swallows heredoc with quoted delimiter", () => {
+		expect(bashExecutables("cat <<'EOF'\ngh\nEOF\nls")).toEqual(["cat", "ls"])
+	})
+
+	it("does not break on `<<<` here-string", () => {
+		// Here-strings don't take a body; we treat the `<<` as a literal token,
+		// which is fine — the executable is still `cmd`.
+		expect(bashExecutables("cmd <<< 'input'")).toEqual(["cmd"])
+	})
+})
+
+describe("bashInvokesCommand", () => {
+	it("returns true when the target appears as any executable", () => {
+		expect(bashInvokesCommand("cd /tmp && gh pr list", "gh")).toBe(true)
+		expect(bashInvokesCommand("ls", "gh")).toBe(false)
+	})
+
+	it("does not match against substrings", () => {
+		expect(bashInvokesCommand("git fetch", "gh")).toBe(false)
+		expect(bashInvokesCommand("ghost", "gh")).toBe(false)
+	})
+
+	it("matches from inside command substitution", () => {
+		expect(bashInvokesCommand("count=$(gh pr list | wc -l)", "gh")).toBe(true)
+	})
+
+	it("does not match inside string literals", () => {
+		expect(bashInvokesCommand('echo "gh foo"', "gh")).toBe(false)
+		expect(bashInvokesCommand("echo 'gh'", "gh")).toBe(false)
+	})
+
+	it("does not match heredoc body lines", () => {
+		expect(bashInvokesCommand("cat <<EOF\ngh foo\nEOF", "gh")).toBe(false)
+	})
+})

--- a/src/extensions/behaviours/bash-tokenize.ts
+++ b/src/extensions/behaviours/bash-tokenize.ts
@@ -1,0 +1,272 @@
+/**
+ * Pragmatic shell tokeniser — extracts the *executable* of every command
+ * stage in a Bash one-liner, the way an agent might emit one.
+ *
+ * Not a full Bash parser. Handles the constructs that show up in
+ * agent-generated commands and that our gh/glab matchers need to be robust
+ * against:
+ *
+ * - Stage separators: `;`, `&&`, `||`, `|`, `&`, newline.
+ * - Command substitution: `$(...)` and backticks recurse as nested commands.
+ * - Subshell groups: `(...)` recurses as a nested command when it opens a
+ *   stage.
+ * - Quoting: single quotes (literal), double quotes (with `\` escapes and
+ *   `$()` / backtick recursion inside).
+ * - Backslash escapes outside single quotes.
+ * - Env-var prefixes: `FOO=bar BAZ=qux gh pr list` resolves to `gh`.
+ * - Comments: `#` at a token boundary skips to the next newline.
+ * - Heredocs: `<<EOF` / `<<-EOF` swallows lines until the closing delimiter.
+ *
+ * Deliberately not handled (rare in agent commands):
+ * - Process substitution `<(...)` / `>(...)`.
+ * - Brace groups `{ ...; }`.
+ * - Aliases, function definitions, `eval`.
+ *
+ * False-positive direction is preferred over false-negative — a missed
+ * heredoc body whose contents happen to start with `gh` is the kind of
+ * surprise we want to keep out of the registry.
+ */
+
+/**
+ * Return the executable token of every command stage in `command`.
+ *
+ * Order matches lexical order of the input. Each entry is the bare program
+ * name as written (no path resolution, no quote normalisation beyond the
+ * quoting rules above).
+ */
+export function bashExecutables(command: string): string[] {
+	const exes: string[] = []
+	walk(command, 0, undefined, exes)
+	return exes
+}
+
+/** True iff any stage of `command` invokes `target` as the executable. */
+export function bashInvokesCommand(command: string, target: string): boolean {
+	for (const exe of bashExecutables(command)) {
+		if (exe === target) return true
+	}
+	return false
+}
+
+const ENV_VAR_NAME = /^[A-Za-z_][A-Za-z0-9_]*$/
+
+/**
+ * Walk from `start`, emitting executables into `out`. Returns the index just
+ * past where walking stopped — either end of input, or the matching `closer`
+ * for a recursed substitution / subshell.
+ */
+function walk(s: string, start: number, closer: ")" | "`" | undefined, out: string[]): number {
+	let i = start
+	let expectingExe = true
+	let currentToken = ""
+	let tokenStarted = false
+
+	function flushToken(): void {
+		if (!tokenStarted) return
+		if (expectingExe) {
+			// An env-var assignment (WORD=value) keeps us in expectingExe state so
+			// the *next* token gets recorded as the executable.
+			const eq = currentToken.indexOf("=")
+			if (eq > 0 && ENV_VAR_NAME.test(currentToken.slice(0, eq))) {
+				// swallow assignment, stay in expectingExe
+			} else {
+				out.push(currentToken)
+				expectingExe = false
+			}
+		}
+		currentToken = ""
+		tokenStarted = false
+	}
+
+	function endStage(): void {
+		flushToken()
+		expectingExe = true
+	}
+
+	while (i < s.length) {
+		const c = s[i]
+
+		// Closer for a recursive call (subshell or backtick).
+		if (closer && c === closer) {
+			endStage()
+			return i + 1
+		}
+
+		// Whitespace ends the current token but stays within the stage.
+		if (c === " " || c === "\t") {
+			flushToken()
+			i++
+			continue
+		}
+
+		// Newline ends the stage.
+		if (c === "\n") {
+			endStage()
+			i++
+			continue
+		}
+
+		// Stage separators.
+		if (c === ";") {
+			endStage()
+			i++
+			continue
+		}
+		if (c === "&") {
+			endStage()
+			i += s[i + 1] === "&" ? 2 : 1
+			continue
+		}
+		if (c === "|") {
+			endStage()
+			i += s[i + 1] === "|" ? 2 : 1
+			continue
+		}
+
+		// Comment at token boundary.
+		if (c === "#" && !tokenStarted) {
+			while (i < s.length && s[i] !== "\n") i++
+			continue
+		}
+
+		// Subshell group `(...)` opens a stage.
+		if (c === "(" && expectingExe && !tokenStarted) {
+			i = walk(s, i + 1, ")", out)
+			// After `)` the outer stage is "done" — anything trailing is args.
+			expectingExe = false
+			continue
+		}
+
+		// Command substitution `$(...)`.
+		if (c === "$" && s[i + 1] === "(") {
+			flushToken()
+			i = walk(s, i + 2, ")", out)
+			// Substitution acts like a word in the outer command; if we were
+			// expecting an executable, the substitution result *is* it, but we
+			// can't know the value statically — treat as opaque, leave
+			// expectingExe true so a subsequent `cmd` after the substitution is
+			// still considered an executable. Common shape: `$(date) cmd …` is
+			// vanishingly rare; the alternative shape `cmd $(date)` only loses
+			// nothing because flushToken already emitted no-op.
+			continue
+		}
+
+		// Backtick command substitution.
+		if (c === "`") {
+			flushToken()
+			i = walk(s, i + 1, "`", out)
+			continue
+		}
+
+		// Single quotes — literal.
+		if (c === "'") {
+			tokenStarted = true
+			i++
+			while (i < s.length && s[i] !== "'") {
+				currentToken += s[i]
+				i++
+			}
+			if (i < s.length) i++ // consume closing quote
+			continue
+		}
+
+		// Double quotes — escapes + recursion.
+		if (c === '"') {
+			tokenStarted = true
+			i++
+			while (i < s.length && s[i] !== '"') {
+				const d = s[i]
+				if (d === "\\" && i + 1 < s.length) {
+					currentToken += s[i + 1]
+					i += 2
+					continue
+				}
+				if (d === "$" && s[i + 1] === "(") {
+					i = walk(s, i + 2, ")", out)
+					continue
+				}
+				if (d === "`") {
+					i = walk(s, i + 1, "`", out)
+					continue
+				}
+				currentToken += d
+				i++
+			}
+			if (i < s.length) i++ // consume closing quote
+			continue
+		}
+
+		// Backslash escape outside quotes.
+		if (c === "\\" && i + 1 < s.length) {
+			tokenStarted = true
+			currentToken += s[i + 1]
+			i += 2
+			continue
+		}
+
+		// Heredoc — `<<DELIM` or `<<-DELIM`. Swallow the body up to the line
+		// containing only the delimiter (with `<<-` allowing leading tabs).
+		if (c === "<" && s[i + 1] === "<") {
+			const stripTabs = s[i + 2] === "-"
+			let j = i + (stripTabs ? 3 : 2)
+			// Optional whitespace then a delimiter token (possibly quoted).
+			while (j < s.length && (s[j] === " " || s[j] === "\t")) j++
+			let delim = ""
+			if (s[j] === '"' || s[j] === "'") {
+				const q = s[j]
+				j++
+				while (j < s.length && s[j] !== q) {
+					delim += s[j]
+					j++
+				}
+				if (j < s.length) j++
+			} else {
+				while (j < s.length && /[A-Za-z0-9_]/.test(s[j])) {
+					delim += s[j]
+					j++
+				}
+			}
+			if (delim === "") {
+				// Not actually a heredoc (e.g. `<<<` here-string falls through to
+				// generic token handling). Emit the `<<` literally and move on.
+				tokenStarted = true
+				currentToken += "<<"
+				i += 2
+				continue
+			}
+			// Find end of current line, then scan for the delimiter line.
+			while (j < s.length && s[j] !== "\n") j++
+			if (j < s.length) j++ // step past newline into body
+			while (j < s.length) {
+				const lineStart = j
+				if (stripTabs) while (j < s.length && s[j] === "\t") j++
+				let lineEnd = j
+				while (lineEnd < s.length && s[lineEnd] !== "\n") lineEnd++
+				const line = s.slice(j, lineEnd)
+				if (line === delim) {
+					j = lineEnd
+					if (j < s.length) j++ // consume newline
+					break
+				}
+				j = lineEnd
+				if (j < s.length) j++
+				// Defensive: if we somehow loop without progress, bail out.
+				if (j <= lineStart) break
+			}
+			i = j
+			// The heredoc swallowed the trailing newline of the delimiter line,
+			// which in normal shell ends the surrounding command. Reset stage
+			// state so what follows is treated as a fresh command.
+			endStage()
+			continue
+		}
+
+		// Generic token character.
+		tokenStarted = true
+		currentToken += c
+		i++
+	}
+
+	endStage()
+	return i
+}

--- a/src/extensions/behaviours/bodies.d.ts
+++ b/src/extensions/behaviours/bodies.d.ts
@@ -1,0 +1,7 @@
+// Ambient declaration for bundled behaviour markdown bodies. Bun's bundler
+// inlines `import body from "./foo.md" with { type: "text" }` as a string
+// constant; this shim lets tsc resolve the same import during typecheck.
+declare module "*.md" {
+	const content: string
+	export default content
+}

--- a/src/extensions/behaviours/bodies/bound-tool-output.md
+++ b/src/extensions/behaviours/bodies/bound-tool-output.md
@@ -1,0 +1,11 @@
+---
+name: bound-tool-output
+description: Cap tool output at the source to preserve context.
+---
+
+Cap output before running a tool, not after — recovery from a flood is expensive:
+
+- Bash: pipe to `head`/`tail` or pass `-n`/`--tail`. `git log -n 20 --oneline`, `git diff --stat`, `2>&1 | tail -100` for build/test/install output, `--log-failed` for CI logs, `| head -c 5000` or `| jq` for large `curl` responses, `tree -L 2`, never `git status -uall` on large repos.
+- Content search: paths first (`files_with_matches` / `-l`), then content. Cap broad matches at ~50 hits, start with 2 lines of context, narrow scope with `--glob`/`--type` before searching.
+- File reads: never read a known-large file (lockfiles, generated, fixtures) without an offset. Search to locate, then read around the hit.
+- Don't `cat file | grep X` or `find . -name X` — use the harness's content/filename search tools instead.

--- a/src/extensions/behaviours/bodies/gh-cli.md
+++ b/src/extensions/behaviours/bodies/gh-cli.md
@@ -1,0 +1,80 @@
+---
+name: gh-cli
+description: Use the GitHub CLI (`gh`) for pull request review (as reviewer or author), workflow run troubleshooting, and general GitHub operations. Use when interacting with PRs, reviews, comments, CI checks, GitHub Actions runs, issues, or releases — including reading inline review comments, posting reviews, fetching CI logs, or triaging failures.
+---
+
+# gh CLI
+
+`gh` is the canonical interface for GitHub. Prefer it over scraping web URLs or guessing API paths. Discover flags with `gh <cmd> --help` rather than enumerating here.
+
+Auth: `gh auth status`. If logged out, ask the user to run `gh auth login`.
+
+Repo: inferred from cwd. Pass `-R OWNER/REPO` when outside the repo.
+
+## PR review — non-obvious bits
+
+Find PRs awaiting your review: `gh pr list --search "review-requested:@me"`.
+
+Existing review state — two endpoints, easy to confuse:
+```bash
+gh api repos/OWNER/REPO/pulls/123/comments  --paginate   # inline, line-anchored
+gh api repos/OWNER/REPO/issues/123/comments --paginate   # PR-level conversation
+```
+
+Post inline comments in one review (line-anchored, multi-comment) — no `gh pr review` flag for this; use the API:
+```bash
+gh api repos/OWNER/REPO/pulls/123/reviews -f event=COMMENT \
+  -f body="overall notes" \
+  -F 'comments[][path]=src/foo.py' -F 'comments[][line]=42' \
+  -F 'comments[][body]=this is wrong because…'
+```
+
+Resolve a review thread (GraphQL):
+```bash
+gh api graphql -f query='mutation($id:ID!){resolveReviewThread(input:{threadId:$id}){thread{isResolved}}}' -F id=THREAD_NODE_ID
+```
+
+Reply to a specific inline thread:
+```bash
+gh api repos/OWNER/REPO/pulls/123/comments/COMMENT_ID/replies -f body="fixed in abc1234"
+```
+
+Top-level review verbs: `gh pr review <N> --approve|--request-changes|--comment -b "…"` (see consent section before posting).
+
+## Workflow runs
+
+Default to **failed-only** logs, never the full log:
+```bash
+gh run view 123456 --log-failed          # preferred
+gh run view 123456 --log | tail -200     # only if --log-failed isn't enough
+```
+
+Find the run behind a PR's latest push: `gh pr checks 123 --json name,state,link,workflow`.
+
+## `gh api` cheatsheet
+
+- `-f key=val` — string param
+- `-F key=val` — typed (numbers, booleans, `@file`)
+- `-X METHOD` — HTTP verb
+- `--jq '.field'` — filter response
+- `--paginate` — follow `Link` headers
+
+## Never without explicit consent
+
+Anything that publishes, mutates, or notifies needs an explicit in-conversation request. Do **not** run these unprompted:
+
+- Posting to a PR/issue: `gh pr review` (any of `--approve`, `--request-changes`, `--comment`), `gh pr comment`, `gh issue comment`, posts via `gh api .../comments` or `.../reviews`.
+- State changes on PRs: `gh pr merge` (any flags), `gh pr close`, `gh pr reopen`, `gh pr ready` (and `--undo`), `gh pr edit`.
+- CI: `gh run rerun`, `gh run cancel`.
+- Issues: `gh issue close`, `gh issue reopen`, `gh issue edit`, `gh issue delete`.
+- Releases: `gh release create`, `gh release edit`, `gh release delete`.
+- Any `gh api -X POST/PATCH/PUT/DELETE` that mutates state, including resolving review threads.
+- Git remote ops: pushing branches, force-push, deleting branches/tags.
+
+Read-only commands (`list`, `view`, `diff`, `checks`, `status`, `gh api` GETs) are fine. When in doubt, surface the command and wait.
+
+## Output discipline
+
+- `gh run view --log` is huge — `--log-failed` or `| tail -N`.
+- `gh api ... --paginate` can be massive — add `--jq`.
+- `gh pr diff` on big PRs — `--name-only` first, then targeted reads.

--- a/src/extensions/behaviours/bodies/git-hygiene.md
+++ b/src/extensions/behaviours/bodies/git-hygiene.md
@@ -1,0 +1,11 @@
+---
+name: git-hygiene
+description: Conservative git practices around staging and protected branches.
+---
+
+When using git:
+
+- Stage files explicitly by name (e.g. `git add path/to/file`). Avoid `git add -A` and `git add .` — they sweep up untracked secrets, build artefacts, and stray files outside the change.
+- Never run destructive commands (`git reset --hard`, `git push --force`, `git branch -D`, `git clean -f`) on `main`, `master`, `release/*`, or other protected branches without explicit user approval.
+- Prefer creating new commits over amending published commits. Only amend when the user explicitly asks.
+- Never skip hooks (`--no-verify`) or bypass signing unless the user explicitly asks. If a hook fails, fix the underlying issue.

--- a/src/extensions/behaviours/bodies/glab-cli.md
+++ b/src/extensions/behaviours/bodies/glab-cli.md
@@ -1,0 +1,95 @@
+---
+name: glab-cli
+description: Use the GitLab CLI (`glab`) for merge request review (as reviewer or author), pipeline/job troubleshooting, and general GitLab operations. Use when interacting with MRs, reviews, comments, approvals, CI pipelines, jobs, issues, or releases on GitLab — including reading discussions, posting notes, fetching pipeline logs, or triaging job failures.
+---
+
+# glab CLI
+
+`glab` is the canonical CLI for GitLab. Prefer it over scraping web URLs or guessing API paths. Discover flags with `glab <cmd> --help` rather than enumerating here.
+
+Auth: `glab auth status`. If logged out, ask the user to run `glab auth login`.
+
+Project: inferred from cwd. Pass `-R OWNER/REPO` (or `GROUP/SUBGROUP/REPO`) when outside.
+
+Terminology: **MR** = merge request, **note** = comment, **discussion** = thread, **pipeline** = CI run, **job** = CI step.
+
+## MR review — non-obvious bits
+
+Find MRs awaiting your review: `glab mr list -r @me` (vs `-a @me` for assignee). `glab mr view 123 --unresolved` shows only open threads.
+
+Discussions vs notes — two endpoints:
+```bash
+glab api projects/:fullpath/merge_requests/123/discussions --paginate   # threaded, line-anchored
+glab api projects/:fullpath/merge_requests/123/notes       --paginate   # flat note stream
+```
+
+Resolve a discussion (need note ID from the discussions API):
+```bash
+glab mr note resolve 123 3107030349
+```
+
+Inline (line-anchored) review comments — `glab` has no flag yet; use the API:
+```bash
+glab api projects/:fullpath/merge_requests/123/discussions \
+  -X POST \
+  -f body="this is wrong" \
+  -f position[position_type]=text \
+  -f position[base_sha]=BASE_SHA \
+  -f position[start_sha]=START_SHA \
+  -f position[head_sha]=HEAD_SHA \
+  -f position[new_path]=src/foo.py \
+  -f position[new_line]=42
+```
+SHAs come from `glab api projects/:fullpath/merge_requests/123 --jq '.diff_refs'`.
+
+Reply to a specific thread:
+```bash
+glab api projects/:fullpath/merge_requests/123/discussions/DISCUSSION_ID/notes \
+  -X POST -f body="fixed in abc1234"
+```
+
+Approve with SHA pinning: `glab mr approve 123 -s abc1234`. MR-create shortcut: `glab mr create -f` fills title/description from commits.
+
+## Pipelines & jobs
+
+`glab ci view` is a **TUI** — never call from a headless harness. Use these instead:
+
+```bash
+glab ci trace lint -b feature-x                          # job by name + branch
+glab ci trace 224356863                                  # job by ID
+glab api projects/:fullpath/jobs/JOB_ID/trace | tail -200 # raw log, capped
+glab api projects/:fullpath/pipelines/12345/jobs --jq '.[] | {id,name,status}'
+```
+
+Bare `glab ci trace` (no args) is also interactive — avoid.
+
+## `glab api` cheatsheet
+
+- `-f key=val` — string field
+- `-F key=val` — typed (numbers, booleans, null)
+- `-X METHOD` — HTTP verb
+- `-H "Header: val"` — request header
+- `--paginate` — follow all pages
+- `--jq '.field'` — filter response
+- placeholders: `:fullpath`, `:repo`, `:group`, `:namespace`, `:branch`, `:user`, `:username`, `:id`
+
+## Never without explicit consent
+
+Anything that publishes, mutates, or notifies needs an explicit in-conversation request. Do **not** run these unprompted:
+
+- Posting to an MR/issue: `glab mr note` (top-level or replies), `glab mr note resolve`/`reopen`, `glab issue note`, posts via `glab api .../discussions` or `.../notes`.
+- State changes on MRs: `glab mr merge`, `glab mr rebase`, `glab mr close`, `glab mr reopen`, `glab mr update` (any flag, esp. `--ready`/`--draft`), `glab mr approve`, `glab mr revoke`.
+- CI: `glab ci retry`, `glab ci cancel`, `glab ci run`.
+- Issues: `glab issue close`, `glab issue reopen`, `glab issue update`, `glab issue delete`.
+- Releases: `glab release create`, `glab release update`, `glab release delete`.
+- Any `glab api -X POST/PUT/PATCH/DELETE` that mutates state.
+- Git remote ops: pushing branches, force-push, deleting branches/tags.
+
+Read-only commands (`list`, `view`, `diff`, `status`, `trace` with explicit args, `glab api` GETs) are fine. When in doubt, surface the command and wait.
+
+## Output discipline
+
+- `glab ci view` — TUI; never headless. Use `glab ci trace` or `glab api`.
+- `glab api .../trace` — full job logs; always `| tail -N`.
+- `--paginate` on busy projects is huge — combine with `--jq`.
+- `glab mr diff` on big MRs — file list via `glab api projects/:fullpath/merge_requests/123/changes --jq '.changes[].new_path'`, then targeted reads.

--- a/src/extensions/behaviours/bodies/python-edit.md
+++ b/src/extensions/behaviours/bodies/python-edit.md
@@ -5,6 +5,6 @@ description: Validate Python syntax with `ast.parse` after editing or creating .
 
 When editing or creating Python:
 
-- After every Edit/Write/NotebookEdit on a `.py` file or notebook code cell, validate the result parses with `python3 -c "import ast, sys; ast.parse(open(sys.argv[1]).read())" <path>`.
+- After every Edit/Write on a `.py` file, validate the result parses with `python3 -c "import ast, sys; ast.parse(open(sys.argv[1]).read())" <path>`.
 - On `SyntaxError`, fix the root cause with another Edit — never paper over by commenting out, wrapping in `try/except`, or skipping the rule. Re-validate after each fix.
 - Don't use `python3 file.py` to validate — that runs the file. Don't use `py_compile` — that writes `.pyc` artefacts. Stick to `ast.parse`.

--- a/src/extensions/behaviours/bodies/python-edit.md
+++ b/src/extensions/behaviours/bodies/python-edit.md
@@ -1,0 +1,10 @@
+---
+name: python-edit
+description: Validate Python syntax with `ast.parse` after editing or creating .py files.
+---
+
+When editing or creating Python:
+
+- After every Edit/Write/NotebookEdit on a `.py` file or notebook code cell, validate the result parses with `python3 -c "import ast, sys; ast.parse(open(sys.argv[1]).read())" <path>`.
+- On `SyntaxError`, fix the root cause with another Edit — never paper over by commenting out, wrapping in `try/except`, or skipping the rule. Re-validate after each fix.
+- Don't use `python3 file.py` to validate — that runs the file. Don't use `py_compile` — that writes `.pyc` artefacts. Stick to `ast.parse`.

--- a/src/extensions/behaviours/build.test.ts
+++ b/src/extensions/behaviours/build.test.ts
@@ -1,0 +1,82 @@
+/**
+ * Tests for `buildBehaviours` — the parse + uniqueness validator that the
+ * bundled registry uses at module load.
+ *
+ * The bundled `behaviours` array is not imported here: it transitively pulls
+ * in markdown bodies via Bun's `with { type: "text" }` text imports, which
+ * vitest/rollup cannot resolve without extra plugin config. Validating the
+ * pure builder against synthetic sources covers the contract — the bundled
+ * registry runs the same function on startup, so a duplicate would fail
+ * loudly at harness boot.
+ */
+
+import { describe, expect, it } from "vitest"
+import { type BehaviourSource, buildBehaviours } from "./build.js"
+
+const validBody = (name: string) => `---
+name: ${name}
+description: ${name} body
+---
+
+content of ${name}
+`
+
+describe("buildBehaviours", () => {
+	it("parses a single source and returns the corresponding Behaviour", () => {
+		const sources: BehaviourSource[] = [{ raw: validBody("a"), kind: "baseline" }]
+		const result = buildBehaviours(sources)
+		expect(result).toHaveLength(1)
+		expect(result[0].name).toBe("a")
+		expect(result[0].kind).toBe("baseline")
+		expect(result[0].body).toContain("content of a")
+	})
+
+	it("preserves source order in the output", () => {
+		const sources: BehaviourSource[] = [
+			{ raw: validBody("a"), kind: "baseline" },
+			{ raw: validBody("b"), kind: "triggered" },
+			{ raw: validBody("c"), kind: "baseline" },
+		]
+		expect(buildBehaviours(sources).map((b) => b.name)).toEqual(["a", "b", "c"])
+	})
+
+	it("throws when two sources declare the same name", () => {
+		const sources: BehaviourSource[] = [
+			{ raw: validBody("dup"), kind: "baseline" },
+			{ raw: validBody("dup"), kind: "triggered" },
+		]
+		expect(() => buildBehaviours(sources)).toThrowError(/duplicate bundled behaviour name: dup/)
+	})
+
+	it("throws when two sources declare the same name even with different bodies", () => {
+		const a = `---
+name: shared
+description: first
+---
+
+body a
+`
+		const b = `---
+name: shared
+description: second
+---
+
+body b
+`
+		expect(() =>
+			buildBehaviours([
+				{ raw: a, kind: "baseline" },
+				{ raw: b, kind: "triggered" },
+			]),
+		).toThrowError(/duplicate bundled behaviour name: shared/)
+	})
+
+	it("throws when a source has malformed frontmatter", () => {
+		const malformed = "no frontmatter here"
+		expect(() => buildBehaviours([{ raw: malformed, kind: "baseline" }])).toThrow()
+	})
+
+	it("returns an empty array for an empty source list", () => {
+		expect(buildBehaviours([])).toEqual([])
+	})
+})

--- a/src/extensions/behaviours/build.test.ts
+++ b/src/extensions/behaviours/build.test.ts
@@ -6,12 +6,13 @@
  * in markdown bodies via Bun's `with { type: "text" }` text imports, which
  * vitest/rollup cannot resolve without extra plugin config. Validating the
  * pure builder against synthetic sources covers the contract — the bundled
- * registry runs the same function on startup, so a duplicate would fail
- * loudly at harness boot.
+ * registry runs the same function on startup, so a duplicate or unreachable
+ * triggered source would fail loudly at harness boot.
  */
 
 import { describe, expect, it } from "vitest"
 import { type BehaviourSource, buildBehaviours } from "./build.js"
+import { tool } from "./triggers.js"
 
 const validBody = (name: string) => `---
 name: ${name}
@@ -34,7 +35,7 @@ describe("buildBehaviours", () => {
 	it("preserves source order in the output", () => {
 		const sources: BehaviourSource[] = [
 			{ raw: validBody("a"), kind: "baseline" },
-			{ raw: validBody("b"), kind: "triggered" },
+			{ raw: validBody("b"), kind: "triggered", triggers: { tool: tool("bash") } },
 			{ raw: validBody("c"), kind: "baseline" },
 		]
 		expect(buildBehaviours(sources).map((b) => b.name)).toEqual(["a", "b", "c"])
@@ -43,7 +44,7 @@ describe("buildBehaviours", () => {
 	it("throws when two sources declare the same name", () => {
 		const sources: BehaviourSource[] = [
 			{ raw: validBody("dup"), kind: "baseline" },
-			{ raw: validBody("dup"), kind: "triggered" },
+			{ raw: validBody("dup"), kind: "triggered", triggers: { tool: tool("bash") } },
 		]
 		expect(() => buildBehaviours(sources)).toThrowError(/duplicate bundled behaviour name: dup/)
 	})
@@ -66,9 +67,15 @@ body b
 		expect(() =>
 			buildBehaviours([
 				{ raw: a, kind: "baseline" },
-				{ raw: b, kind: "triggered" },
+				{ raw: b, kind: "triggered", triggers: { tool: tool("bash") } },
 			]),
 		).toThrowError(/duplicate bundled behaviour name: shared/)
+	})
+
+	it("throws when a triggered source has no session probe and no tool matcher", () => {
+		expect(() => buildBehaviours([{ raw: validBody("orphan"), kind: "triggered", triggers: {} }])).toThrowError(
+			/triggered behaviour orphan has no session or tool trigger/,
+		)
 	})
 
 	it("throws when a source has malformed frontmatter", () => {

--- a/src/extensions/behaviours/build.ts
+++ b/src/extensions/behaviours/build.ts
@@ -10,19 +10,28 @@
  */
 
 import { parseBehaviourBody } from "./frontmatter.js"
-import type { Behaviour, BehaviourEvals, BehaviourKind, BehaviourTriggers } from "./types.js"
+import type { Behaviour, BehaviourEvals, BehaviourTriggers } from "./types.js"
 
-export interface BehaviourSource {
+interface BaselineSource {
 	raw: string
-	kind: BehaviourKind
-	triggers?: BehaviourTriggers
+	kind: "baseline"
+}
+
+interface TriggeredSource {
+	raw: string
+	kind: "triggered"
+	triggers: BehaviourTriggers
 	evals?: BehaviourEvals
 }
+
+export type BehaviourSource = BaselineSource | TriggeredSource
 
 /**
  * Parse and validate a list of behaviour sources into a `Behaviour[]`.
  *
- * Throws on duplicate names. Pure over its inputs.
+ * Throws on duplicate names and on triggered sources whose `triggers` slot is
+ * empty (no session probe and no tool matcher — such a behaviour would be
+ * unreachable). Pure over its inputs.
  */
 export function buildBehaviours(sources: readonly BehaviourSource[]): Behaviour[] {
 	const result: Behaviour[] = []
@@ -34,11 +43,18 @@ export function buildBehaviours(sources: readonly BehaviourSource[]): Behaviour[
 			throw new Error(`duplicate bundled behaviour name: ${name}`)
 		}
 		seen.add(name)
+		if (src.kind === "baseline") {
+			result.push({ kind: "baseline", name, description, body: parsed.content })
+			continue
+		}
+		if (!src.triggers.session && !src.triggers.tool) {
+			throw new Error(`triggered behaviour ${name} has no session or tool trigger`)
+		}
 		result.push({
+			kind: "triggered",
 			name,
 			description,
 			body: parsed.content,
-			kind: src.kind,
 			triggers: src.triggers,
 			evals: src.evals,
 		})

--- a/src/extensions/behaviours/build.ts
+++ b/src/extensions/behaviours/build.ts
@@ -1,0 +1,47 @@
+/**
+ * Pure builder for the bundled behaviour registry — no markdown imports here
+ * so it can be loaded by vitest without a `.md` text-import plugin.
+ *
+ * `registry.ts` declares the bundled sources (which do import markdown bodies
+ * via Bun text imports) and feeds them through `buildBehaviours` exactly
+ * once at module load. The same function is exercised by the registry test
+ * suite against synthetic sources to verify the duplicate-name and
+ * malformed-body contracts.
+ */
+
+import { parseBehaviourBody } from "./frontmatter.js"
+import type { Behaviour, BehaviourEvals, BehaviourKind, BehaviourTriggers } from "./types.js"
+
+export interface BehaviourSource {
+	raw: string
+	kind: BehaviourKind
+	triggers?: BehaviourTriggers
+	evals?: BehaviourEvals
+}
+
+/**
+ * Parse and validate a list of behaviour sources into a `Behaviour[]`.
+ *
+ * Throws on duplicate names. Pure over its inputs.
+ */
+export function buildBehaviours(sources: readonly BehaviourSource[]): Behaviour[] {
+	const result: Behaviour[] = []
+	const seen = new Set<string>()
+	for (const src of sources) {
+		const parsed = parseBehaviourBody(src.raw)
+		const { name, description } = parsed.frontmatter
+		if (seen.has(name)) {
+			throw new Error(`duplicate bundled behaviour name: ${name}`)
+		}
+		seen.add(name)
+		result.push({
+			name,
+			description,
+			body: parsed.content,
+			kind: src.kind,
+			triggers: src.triggers,
+			evals: src.evals,
+		})
+	}
+	return result
+}

--- a/src/extensions/behaviours/engine.test.ts
+++ b/src/extensions/behaviours/engine.test.ts
@@ -165,6 +165,55 @@ function bashCall(command: string): ToolCallEvent {
 	return { toolName: "bash", input: { command } }
 }
 
+describe("TriggerEngine.requeueLoaded", () => {
+	it("repopulates pending with every loaded behaviour, preserving the loaded set", () => {
+		const a = makeBehaviour({ name: "a", kind: "triggered", triggers: { session: cli("foo") } })
+		const b = makeBehaviour({ name: "b", kind: "triggered", triggers: { session: cli("bar") } })
+		const engine = new TriggerEngine([a, b])
+		engine.evaluateSessionTriggers(makeContext({ clis: ["foo", "bar"] }), 0)
+
+		// Drain pending — simulating injector delivery on the first turn.
+		expect(engine.takePending("a")).toBe(true)
+		expect(engine.takePending("b")).toBe(true)
+		expect(engine.pendingNames()).toEqual([])
+
+		const requeued = engine.requeueLoaded()
+		expect(requeued).toEqual(["a", "b"])
+		expect(engine.pendingNames()).toEqual(["a", "b"])
+		expect(engine.loadedNames()).toEqual(["a", "b"])
+	})
+
+	it("does nothing when nothing is loaded", () => {
+		const engine = new TriggerEngine([])
+		expect(engine.requeueLoaded()).toEqual([])
+		expect(engine.pendingNames()).toEqual([])
+	})
+
+	it("returns names in registry order regardless of load order", () => {
+		const a = makeBehaviour({ name: "a", kind: "triggered", triggers: { tool: tool("bash") } })
+		const b = makeBehaviour({ name: "b", kind: "triggered", triggers: { tool: tool("bash") } })
+		const engine = new TriggerEngine([a, b])
+		// Load b first via tool, then a — registry order is still [a, b].
+		engine.evaluateToolTriggers(bashCall("ls"), 0)
+		expect(engine.requeueLoaded()).toEqual(["a", "b"])
+	})
+
+	it("does not re-emit load events when triggers are re-evaluated after requeue", () => {
+		const ghCli = makeBehaviour({
+			name: "gh-cli",
+			kind: "triggered",
+			triggers: { session: cli("gh") },
+		})
+		const engine = new TriggerEngine([ghCli])
+		const ctx = makeContext({ clis: ["gh"] })
+		expect(engine.evaluateSessionTriggers(ctx, 0)).toHaveLength(1)
+		engine.takePending("gh-cli")
+		engine.requeueLoaded()
+		// A second evaluateSessionTriggers pass must not produce a second load event.
+		expect(engine.evaluateSessionTriggers(ctx, 1)).toEqual([])
+	})
+})
+
 describe("TriggerEngine.evaluateToolTriggers", () => {
 	it("loads a triggered behaviour the first time a matching tool call fires", () => {
 		const ghCli = makeBehaviour({

--- a/src/extensions/behaviours/engine.test.ts
+++ b/src/extensions/behaviours/engine.test.ts
@@ -1,0 +1,162 @@
+import { describe, expect, it } from "vitest"
+import { TriggerEngine } from "./engine.js"
+import type { SessionContext } from "./session-context.js"
+import { any, cli, gitRemote } from "./triggers.js"
+import type { Behaviour } from "./types.js"
+
+function makeBehaviour(overrides: Partial<Behaviour> & Pick<Behaviour, "name" | "kind">): Behaviour {
+	return {
+		description: `${overrides.name} behaviour`,
+		body: `body of ${overrides.name}`,
+		triggers: undefined,
+		...overrides,
+	}
+}
+
+function makeContext(
+	overrides: Partial<{
+		clis: Iterable<string>
+		gitRemoteHost: string | undefined
+		paths: Iterable<string>
+	}> = {},
+): SessionContext {
+	return {
+		cliPresent: new Set(overrides.clis ?? []),
+		gitRemoteHost: overrides.gitRemoteHost,
+		pathMatches: new Set(overrides.paths ?? []),
+	}
+}
+
+describe("TriggerEngine.evaluateSessionTriggers", () => {
+	it("loads a triggered behaviour when its session probe matches", () => {
+		const ghCli = makeBehaviour({
+			name: "gh-cli",
+			kind: "triggered",
+			triggers: { session: any(cli("gh"), gitRemote("github.com")) },
+		})
+		const engine = new TriggerEngine([ghCli])
+		const events = engine.evaluateSessionTriggers(makeContext({ clis: ["gh"] }), 0)
+
+		expect(events).toEqual([{ name: "gh-cli", trigger: "session", turnIndex: 0 }])
+		expect(engine.isLoaded("gh-cli")).toBe(true)
+		expect(engine.pendingNames()).toEqual(["gh-cli"])
+	})
+
+	it("skips behaviours whose probes do not match", () => {
+		const glabCli = makeBehaviour({
+			name: "glab-cli",
+			kind: "triggered",
+			triggers: { session: gitRemote("gitlab.com") },
+		})
+		const engine = new TriggerEngine([glabCli])
+		const events = engine.evaluateSessionTriggers(makeContext({ gitRemoteHost: "github.com" }), 0)
+
+		expect(events).toEqual([])
+		expect(engine.isLoaded("glab-cli")).toBe(false)
+		expect(engine.pendingNames()).toEqual([])
+	})
+
+	it("does not double-load when the same probe matches twice", () => {
+		const ghCli = makeBehaviour({
+			name: "gh-cli",
+			kind: "triggered",
+			triggers: { session: cli("gh") },
+		})
+		const engine = new TriggerEngine([ghCli])
+		const ctx = makeContext({ clis: ["gh"] })
+
+		expect(engine.evaluateSessionTriggers(ctx, 0)).toHaveLength(1)
+		expect(engine.evaluateSessionTriggers(ctx, 1)).toHaveLength(0)
+		expect(engine.loadedNames()).toEqual(["gh-cli"])
+	})
+
+	it("ignores baseline behaviours even when they have a session probe", () => {
+		const baseline = makeBehaviour({
+			name: "git-hygiene",
+			kind: "baseline",
+			triggers: { session: cli("git") },
+		})
+		const engine = new TriggerEngine([baseline])
+		const events = engine.evaluateSessionTriggers(makeContext({ clis: ["git"] }), 0)
+
+		expect(events).toEqual([])
+		expect(engine.isLoaded("git-hygiene")).toBe(false)
+	})
+
+	it("loads multiple matching behaviours in registry order", () => {
+		const a = makeBehaviour({
+			name: "a",
+			kind: "triggered",
+			triggers: { session: cli("foo") },
+		})
+		const b = makeBehaviour({
+			name: "b",
+			kind: "triggered",
+			triggers: { session: cli("bar") },
+		})
+		const engine = new TriggerEngine([a, b])
+		const events = engine.evaluateSessionTriggers(makeContext({ clis: ["foo", "bar"] }), 0)
+
+		expect(events.map((e) => e.name)).toEqual(["a", "b"])
+		expect(engine.pendingNames()).toEqual(["a", "b"])
+	})
+
+	it("skips triggered behaviours without a session probe declared", () => {
+		const noTriggers = makeBehaviour({ name: "x", kind: "triggered" })
+		const engine = new TriggerEngine([noTriggers])
+		expect(engine.evaluateSessionTriggers(makeContext(), 0)).toEqual([])
+	})
+})
+
+describe("TriggerEngine.takePending", () => {
+	it("returns true the first time and false after draining", () => {
+		const b = makeBehaviour({
+			name: "gh-cli",
+			kind: "triggered",
+			triggers: { session: cli("gh") },
+		})
+		const engine = new TriggerEngine([b])
+		engine.evaluateSessionTriggers(makeContext({ clis: ["gh"] }), 0)
+
+		expect(engine.takePending("gh-cli")).toBe(true)
+		expect(engine.takePending("gh-cli")).toBe(false)
+		expect(engine.pendingNames()).toEqual([])
+		expect(engine.isLoaded("gh-cli")).toBe(true)
+	})
+
+	it("returns false for a name that was never queued", () => {
+		const engine = new TriggerEngine([])
+		expect(engine.takePending("absent")).toBe(false)
+	})
+})
+
+describe("TriggerEngine.reset", () => {
+	it("clears loaded and pending state", () => {
+		const b = makeBehaviour({
+			name: "gh-cli",
+			kind: "triggered",
+			triggers: { session: cli("gh") },
+		})
+		const engine = new TriggerEngine([b])
+		engine.evaluateSessionTriggers(makeContext({ clis: ["gh"] }), 0)
+		engine.reset()
+
+		expect(engine.isLoaded("gh-cli")).toBe(false)
+		expect(engine.pendingNames()).toEqual([])
+	})
+
+	it("allows re-loading a behaviour after reset", () => {
+		const b = makeBehaviour({
+			name: "gh-cli",
+			kind: "triggered",
+			triggers: { session: cli("gh") },
+		})
+		const engine = new TriggerEngine([b])
+		const ctx = makeContext({ clis: ["gh"] })
+		engine.evaluateSessionTriggers(ctx, 0)
+		engine.reset()
+		const events = engine.evaluateSessionTriggers(ctx, 1)
+
+		expect(events).toEqual([{ name: "gh-cli", trigger: "session", turnIndex: 1 }])
+	})
+})

--- a/src/extensions/behaviours/engine.test.ts
+++ b/src/extensions/behaviours/engine.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from "vitest"
 import { TriggerEngine } from "./engine.js"
 import type { SessionContext } from "./session-context.js"
-import { any, cli, gitRemote } from "./triggers.js"
+import { type ToolCallEvent, any, cli, gitRemote, tool } from "./triggers.js"
 import type { Behaviour } from "./types.js"
 
 function makeBehaviour(overrides: Partial<Behaviour> & Pick<Behaviour, "name" | "kind">): Behaviour {
@@ -158,5 +158,97 @@ describe("TriggerEngine.reset", () => {
 		const events = engine.evaluateSessionTriggers(ctx, 1)
 
 		expect(events).toEqual([{ name: "gh-cli", trigger: "session", turnIndex: 1 }])
+	})
+})
+
+function bashCall(command: string): ToolCallEvent {
+	return { toolName: "bash", input: { command } }
+}
+
+describe("TriggerEngine.evaluateToolTriggers", () => {
+	it("loads a triggered behaviour the first time a matching tool call fires", () => {
+		const ghCli = makeBehaviour({
+			name: "gh-cli",
+			kind: "triggered",
+			triggers: { tool: tool("bash", (i) => i.command.startsWith("gh ")) },
+		})
+		const engine = new TriggerEngine([ghCli])
+		const events = engine.evaluateToolTriggers(bashCall("gh pr list"), 3)
+
+		expect(events).toEqual([
+			{
+				name: "gh-cli",
+				trigger: "tool",
+				turnIndex: 3,
+				toolName: "bash",
+				toolArgs: { command: "gh pr list" },
+			},
+		])
+		expect(engine.isLoaded("gh-cli")).toBe(true)
+		expect(engine.pendingNames()).toEqual(["gh-cli"])
+	})
+
+	it("does not re-trigger after the behaviour has loaded", () => {
+		const ghCli = makeBehaviour({
+			name: "gh-cli",
+			kind: "triggered",
+			triggers: { tool: tool("bash", (i) => i.command.startsWith("gh ")) },
+		})
+		const engine = new TriggerEngine([ghCli])
+		expect(engine.evaluateToolTriggers(bashCall("gh pr list"), 0)).toHaveLength(1)
+		expect(engine.evaluateToolTriggers(bashCall("gh pr view"), 1)).toEqual([])
+	})
+
+	it("skips events that do not match the tool matcher", () => {
+		const ghCli = makeBehaviour({
+			name: "gh-cli",
+			kind: "triggered",
+			triggers: { tool: tool("bash", (i) => i.command.startsWith("gh ")) },
+		})
+		const engine = new TriggerEngine([ghCli])
+		expect(engine.evaluateToolTriggers(bashCall("ls"), 0)).toEqual([])
+		expect(engine.evaluateToolTriggers({ toolName: "read", input: { file_path: "x" } }, 0)).toEqual([])
+		expect(engine.isLoaded("gh-cli")).toBe(false)
+	})
+
+	it("does not re-load via tool trigger if a session trigger already loaded it", () => {
+		const ghCli = makeBehaviour({
+			name: "gh-cli",
+			kind: "triggered",
+			triggers: {
+				session: cli("gh"),
+				tool: tool("bash", (i) => i.command.startsWith("gh ")),
+			},
+		})
+		const engine = new TriggerEngine([ghCli])
+		engine.evaluateSessionTriggers({ cliPresent: new Set(["gh"]), gitRemoteHost: undefined, pathMatches: new Set() }, 0)
+		expect(engine.evaluateToolTriggers(bashCall("gh pr list"), 1)).toEqual([])
+	})
+
+	it("ignores baseline behaviours even when they declare a tool matcher", () => {
+		const baseline = makeBehaviour({
+			name: "always-on",
+			kind: "baseline",
+			triggers: { tool: tool("bash") },
+		})
+		const engine = new TriggerEngine([baseline])
+		expect(engine.evaluateToolTriggers(bashCall("anything"), 0)).toEqual([])
+		expect(engine.isLoaded("always-on")).toBe(false)
+	})
+
+	it("loads multiple matching behaviours in registry order", () => {
+		const a = makeBehaviour({
+			name: "a",
+			kind: "triggered",
+			triggers: { tool: tool("bash") },
+		})
+		const b = makeBehaviour({
+			name: "b",
+			kind: "triggered",
+			triggers: { tool: tool("bash") },
+		})
+		const engine = new TriggerEngine([a, b])
+		const events = engine.evaluateToolTriggers(bashCall("ls"), 0)
+		expect(events.map((e) => e.name)).toEqual(["a", "b"])
 	})
 })

--- a/src/extensions/behaviours/engine.test.ts
+++ b/src/extensions/behaviours/engine.test.ts
@@ -35,12 +35,14 @@ function makeContext(
 	overrides: Partial<{
 		clis: Iterable<string>
 		gitRemoteHost: string | undefined
+		inGitRepo: boolean
 		paths: Iterable<string>
 	}> = {},
 ): SessionContext {
 	return {
 		cliPresent: new Set(overrides.clis ?? []),
 		gitRemoteHost: overrides.gitRemoteHost,
+		inGitRepo: overrides.inGitRepo ?? false,
 		pathMatches: new Set(overrides.paths ?? []),
 	}
 }
@@ -318,7 +320,7 @@ describe("TriggerEngine.evaluateToolTriggers", () => {
 			},
 		})
 		const engine = new TriggerEngine([ghCli])
-		engine.evaluateSessionTriggers({ cliPresent: new Set(["gh"]), gitRemoteHost: undefined, pathMatches: new Set() }, 0)
+		engine.evaluateSessionTriggers(makeContext({ clis: ["gh"] }), 0)
 		expect(engine.evaluateToolTriggers(bashCall("gh pr list"), 1)).toEqual([])
 	})
 

--- a/src/extensions/behaviours/engine.test.ts
+++ b/src/extensions/behaviours/engine.test.ts
@@ -2,14 +2,32 @@ import { describe, expect, it } from "vitest"
 import { TriggerEngine } from "./engine.js"
 import type { SessionContext } from "./session-context.js"
 import { type ToolCallEvent, any, cli, gitRemote, tool } from "./triggers.js"
-import type { Behaviour } from "./types.js"
+import type { Behaviour, BehaviourEvals, BehaviourTriggers } from "./types.js"
 
-function makeBehaviour(overrides: Partial<Behaviour> & Pick<Behaviour, "name" | "kind">): Behaviour {
+type MakeArgs =
+	| { name: string; kind: "baseline"; description?: string; body?: string }
+	| {
+			name: string
+			kind: "triggered"
+			triggers?: BehaviourTriggers
+			evals?: BehaviourEvals
+			description?: string
+			body?: string
+	  }
+
+function makeBehaviour(args: MakeArgs): Behaviour {
+	const description = args.description ?? `${args.name} behaviour`
+	const body = args.body ?? `body of ${args.name}`
+	if (args.kind === "baseline") {
+		return { kind: "baseline", name: args.name, description, body }
+	}
 	return {
-		description: `${overrides.name} behaviour`,
-		body: `body of ${overrides.name}`,
-		triggers: undefined,
-		...overrides,
+		kind: "triggered",
+		name: args.name,
+		description,
+		body,
+		triggers: args.triggers ?? {},
+		evals: args.evals,
 	}
 }
 
@@ -70,12 +88,8 @@ describe("TriggerEngine.evaluateSessionTriggers", () => {
 		expect(engine.loadedNames()).toEqual(["gh-cli"])
 	})
 
-	it("ignores baseline behaviours even when they have a session probe", () => {
-		const baseline = makeBehaviour({
-			name: "git-hygiene",
-			kind: "baseline",
-			triggers: { session: cli("git") },
-		})
+	it("ignores baseline behaviours", () => {
+		const baseline = makeBehaviour({ name: "git-hygiene", kind: "baseline" })
 		const engine = new TriggerEngine([baseline])
 		const events = engine.evaluateSessionTriggers(makeContext({ clis: ["git"] }), 0)
 
@@ -101,8 +115,8 @@ describe("TriggerEngine.evaluateSessionTriggers", () => {
 		expect(engine.pendingNames()).toEqual(["a", "b"])
 	})
 
-	it("skips triggered behaviours without a session probe declared", () => {
-		const noTriggers = makeBehaviour({ name: "x", kind: "triggered" })
+	it("skips triggered behaviours whose triggers slot is empty", () => {
+		const noTriggers = makeBehaviour({ name: "x", kind: "triggered", triggers: {} })
 		const engine = new TriggerEngine([noTriggers])
 		expect(engine.evaluateSessionTriggers(makeContext(), 0)).toEqual([])
 	})
@@ -214,6 +228,40 @@ describe("TriggerEngine.requeueLoaded", () => {
 	})
 })
 
+describe("TriggerEngine.loadRecord", () => {
+	it("captures session-trigger metadata", () => {
+		const ghCli = makeBehaviour({
+			name: "gh-cli",
+			kind: "triggered",
+			triggers: { session: cli("gh") },
+		})
+		const engine = new TriggerEngine([ghCli])
+		engine.evaluateSessionTriggers(makeContext({ clis: ["gh"] }), 4)
+		expect(engine.loadRecord("gh-cli")).toEqual({ trigger: "session", turnIndex: 4 })
+	})
+
+	it("captures tool-trigger metadata including args", () => {
+		const ghCli = makeBehaviour({
+			name: "gh-cli",
+			kind: "triggered",
+			triggers: { tool: tool("bash", (i) => i.command.startsWith("gh ")) },
+		})
+		const engine = new TriggerEngine([ghCli])
+		engine.evaluateToolTriggers(bashCall("gh pr list"), 7)
+		expect(engine.loadRecord("gh-cli")).toEqual({
+			trigger: "tool",
+			turnIndex: 7,
+			toolName: "bash",
+			toolArgs: { command: "gh pr list" },
+		})
+	})
+
+	it("returns undefined for behaviours that never loaded", () => {
+		const engine = new TriggerEngine([])
+		expect(engine.loadRecord("missing")).toBeUndefined()
+	})
+})
+
 describe("TriggerEngine.evaluateToolTriggers", () => {
 	it("loads a triggered behaviour the first time a matching tool call fires", () => {
 		const ghCli = makeBehaviour({
@@ -274,12 +322,8 @@ describe("TriggerEngine.evaluateToolTriggers", () => {
 		expect(engine.evaluateToolTriggers(bashCall("gh pr list"), 1)).toEqual([])
 	})
 
-	it("ignores baseline behaviours even when they declare a tool matcher", () => {
-		const baseline = makeBehaviour({
-			name: "always-on",
-			kind: "baseline",
-			triggers: { tool: tool("bash") },
-		})
+	it("ignores baseline behaviours", () => {
+		const baseline = makeBehaviour({ name: "always-on", kind: "baseline" })
 		const engine = new TriggerEngine([baseline])
 		expect(engine.evaluateToolTriggers(bashCall("anything"), 0)).toEqual([])
 		expect(engine.isLoaded("always-on")).toBe(false)

--- a/src/extensions/behaviours/engine.ts
+++ b/src/extensions/behaviours/engine.ts
@@ -18,7 +18,7 @@
 
 import type { SessionContext } from "./session-context.js"
 import type { ToolCallEvent } from "./triggers.js"
-import type { Behaviour, TriggerSource } from "./types.js"
+import type { Behaviour, TriggerSource, TriggeredBehaviour } from "./types.js"
 
 export interface LoadEvent {
 	name: string
@@ -48,18 +48,11 @@ export class TriggerEngine {
 	 * that newly transitioned to loaded; already-loaded behaviours are skipped.
 	 */
 	evaluateSessionTriggers(ctx: SessionContext, turnIndex: number): LoadEvent[] {
-		const events: LoadEvent[] = []
-		for (const b of this.behaviours) {
-			if (b.kind !== "triggered") continue
-			if (this.loaded.has(b.name)) continue
+		return this.evaluateAll((b) => {
 			const probe = b.triggers.session
-			if (!probe) continue
-			if (!probe(ctx)) continue
-			this.loaded.set(b.name, { trigger: "session", turnIndex })
-			this.pending.add(b.name)
-			events.push({ name: b.name, trigger: "session", turnIndex })
-		}
-		return events
+			if (!probe || !probe(ctx)) return undefined
+			return { trigger: "session", turnIndex }
+		})
 	}
 
 	/**
@@ -69,27 +62,28 @@ export class TriggerEngine {
 	 * even when many subsequent calls also match the matcher.
 	 */
 	evaluateToolTriggers(event: ToolCallEvent, turnIndex: number): LoadEvent[] {
+		return this.evaluateAll((b) => {
+			const matcher = b.triggers.tool
+			if (!matcher || !matcher(event)) return undefined
+			return { trigger: "tool", turnIndex, toolName: event.toolName, toolArgs: event.input }
+		})
+	}
+
+	/**
+	 * Walk the registry and load every triggered behaviour for which `runCheck`
+	 * returns a `LoadRecord`. Skips baselines and already-loaded behaviours, so
+	 * the predicate only sees candidates it can actually transition.
+	 */
+	private evaluateAll(runCheck: (b: TriggeredBehaviour) => LoadRecord | undefined): LoadEvent[] {
 		const events: LoadEvent[] = []
 		for (const b of this.behaviours) {
 			if (b.kind !== "triggered") continue
 			if (this.loaded.has(b.name)) continue
-			const matcher = b.triggers.tool
-			if (!matcher) continue
-			if (!matcher(event)) continue
-			this.loaded.set(b.name, {
-				trigger: "tool",
-				turnIndex,
-				toolName: event.toolName,
-				toolArgs: event.input,
-			})
+			const record = runCheck(b)
+			if (!record) continue
+			this.loaded.set(b.name, record)
 			this.pending.add(b.name)
-			events.push({
-				name: b.name,
-				trigger: "tool",
-				turnIndex,
-				toolName: event.toolName,
-				toolArgs: event.input,
-			})
+			events.push({ name: b.name, ...record })
 		}
 		return events
 	}

--- a/src/extensions/behaviours/engine.ts
+++ b/src/extensions/behaviours/engine.ts
@@ -8,8 +8,11 @@
  * - `evaluateToolTriggers` — runs matchers against each tool-call event.
  *
  * Each behaviour transitions from unloaded to loaded at most once per session.
- * Once loaded, both trigger paths are skipped for that behaviour. On
- * compaction the loaded set is preserved; `requeueLoaded` repopulates the
+ * Once loaded, both trigger paths are skipped for that behaviour. The engine
+ * also records the load circumstances (turn, trigger source, tool args) so
+ * downstream consumers (session summary) don't need a parallel side-table.
+ *
+ * On compaction the loaded set is preserved; `requeueLoaded` repopulates the
  * pending queue so the injector re-delivers each loaded body once.
  */
 
@@ -27,8 +30,15 @@ export interface LoadEvent {
 	toolArgs?: Record<string, unknown>
 }
 
+export interface LoadRecord {
+	trigger: TriggerSource
+	turnIndex: number
+	toolName?: string
+	toolArgs?: Record<string, unknown>
+}
+
 export class TriggerEngine {
-	private readonly loaded = new Set<string>()
+	private readonly loaded = new Map<string, LoadRecord>()
 	private readonly pending = new Set<string>()
 
 	constructor(private readonly behaviours: readonly Behaviour[]) {}
@@ -42,10 +52,10 @@ export class TriggerEngine {
 		for (const b of this.behaviours) {
 			if (b.kind !== "triggered") continue
 			if (this.loaded.has(b.name)) continue
-			const probe = b.triggers?.session
+			const probe = b.triggers.session
 			if (!probe) continue
 			if (!probe(ctx)) continue
-			this.loaded.add(b.name)
+			this.loaded.set(b.name, { trigger: "session", turnIndex })
 			this.pending.add(b.name)
 			events.push({ name: b.name, trigger: "session", turnIndex })
 		}
@@ -63,10 +73,15 @@ export class TriggerEngine {
 		for (const b of this.behaviours) {
 			if (b.kind !== "triggered") continue
 			if (this.loaded.has(b.name)) continue
-			const matcher = b.triggers?.tool
+			const matcher = b.triggers.tool
 			if (!matcher) continue
 			if (!matcher(event)) continue
-			this.loaded.add(b.name)
+			this.loaded.set(b.name, {
+				trigger: "tool",
+				turnIndex,
+				toolName: event.toolName,
+				toolArgs: event.input,
+			})
 			this.pending.add(b.name)
 			events.push({
 				name: b.name,
@@ -84,6 +99,11 @@ export class TriggerEngine {
 		return this.loaded.has(name)
 	}
 
+	/** Load record for the named behaviour, or undefined if it never loaded. */
+	loadRecord(name: string): LoadRecord | undefined {
+		return this.loaded.get(name)
+	}
+
 	/**
 	 * Atomically take the named behaviour off the pending queue. Returns true
 	 * if it was pending (caller should deliver the body), false otherwise.
@@ -94,7 +114,7 @@ export class TriggerEngine {
 
 	/** Snapshot of currently-loaded names — primarily for tests. */
 	loadedNames(): string[] {
-		return [...this.loaded]
+		return [...this.loaded.keys()]
 	}
 
 	/** Snapshot of the pending injection queue — primarily for tests. */

--- a/src/extensions/behaviours/engine.ts
+++ b/src/extensions/behaviours/engine.ts
@@ -2,19 +2,28 @@
  * Trigger engine — pure state machine that decides when triggered behaviours
  * load and tracks pending injections for the injector to drain.
  *
- * Phase 2 evaluates session-probe triggers exactly once per session, on the
- * resolved `SessionContext`. Each behaviour transitions from unloaded to
- * loaded at most once; later phases extend the engine with tool-call triggers
- * and compaction-driven re-injection without changing this surface.
+ * Two evaluation paths share the same `loaded`/`pending` state:
+ * - `evaluateSessionTriggers` — runs probes against the resolved
+ *   `SessionContext` once at session start.
+ * - `evaluateToolTriggers` — runs matchers against each tool-call event.
+ *
+ * Each behaviour transitions from unloaded to loaded at most once per session.
+ * Once loaded, both trigger paths are skipped for that behaviour. Compaction
+ * handling and re-injection land in a later phase.
  */
 
 import type { SessionContext } from "./session-context.js"
+import type { ToolCallEvent } from "./triggers.js"
 import type { Behaviour, TriggerSource } from "./types.js"
 
 export interface LoadEvent {
 	name: string
 	trigger: TriggerSource
 	turnIndex: number
+	/** Tool name that triggered the load — present only for `trigger: "tool"`. */
+	toolName?: string
+	/** Tool args that triggered the load — present only for `trigger: "tool"`. */
+	toolArgs?: Record<string, unknown>
 }
 
 export class TriggerEngine {
@@ -38,6 +47,33 @@ export class TriggerEngine {
 			this.loaded.add(b.name)
 			this.pending.add(b.name)
 			events.push({ name: b.name, trigger: "session", turnIndex })
+		}
+		return events
+	}
+
+	/**
+	 * Run tool-call matchers against a single tool-call event. Returns load
+	 * events for behaviours that newly transitioned to loaded. Already-loaded
+	 * behaviours are skipped, so a behaviour cannot fire twice on tool events
+	 * even when many subsequent calls also match the matcher.
+	 */
+	evaluateToolTriggers(event: ToolCallEvent, turnIndex: number): LoadEvent[] {
+		const events: LoadEvent[] = []
+		for (const b of this.behaviours) {
+			if (b.kind !== "triggered") continue
+			if (this.loaded.has(b.name)) continue
+			const matcher = b.triggers?.tool
+			if (!matcher) continue
+			if (!matcher(event)) continue
+			this.loaded.add(b.name)
+			this.pending.add(b.name)
+			events.push({
+				name: b.name,
+				trigger: "tool",
+				turnIndex,
+				toolName: event.toolName,
+				toolArgs: event.input,
+			})
 		}
 		return events
 	}

--- a/src/extensions/behaviours/engine.ts
+++ b/src/extensions/behaviours/engine.ts
@@ -1,0 +1,73 @@
+/**
+ * Trigger engine — pure state machine that decides when triggered behaviours
+ * load and tracks pending injections for the injector to drain.
+ *
+ * Phase 2 evaluates session-probe triggers exactly once per session, on the
+ * resolved `SessionContext`. Each behaviour transitions from unloaded to
+ * loaded at most once; later phases extend the engine with tool-call triggers
+ * and compaction-driven re-injection without changing this surface.
+ */
+
+import type { SessionContext } from "./session-context.js"
+import type { Behaviour, TriggerSource } from "./types.js"
+
+export interface LoadEvent {
+	name: string
+	trigger: TriggerSource
+	turnIndex: number
+}
+
+export class TriggerEngine {
+	private readonly loaded = new Set<string>()
+	private readonly pending = new Set<string>()
+
+	constructor(private readonly behaviours: readonly Behaviour[]) {}
+
+	/**
+	 * Run session probes against the context. Returns load events for behaviours
+	 * that newly transitioned to loaded; already-loaded behaviours are skipped.
+	 */
+	evaluateSessionTriggers(ctx: SessionContext, turnIndex: number): LoadEvent[] {
+		const events: LoadEvent[] = []
+		for (const b of this.behaviours) {
+			if (b.kind !== "triggered") continue
+			if (this.loaded.has(b.name)) continue
+			const probe = b.triggers?.session
+			if (!probe) continue
+			if (!probe(ctx)) continue
+			this.loaded.add(b.name)
+			this.pending.add(b.name)
+			events.push({ name: b.name, trigger: "session", turnIndex })
+		}
+		return events
+	}
+
+	/** True iff the named behaviour has loaded in the current session. */
+	isLoaded(name: string): boolean {
+		return this.loaded.has(name)
+	}
+
+	/**
+	 * Atomically take the named behaviour off the pending queue. Returns true
+	 * if it was pending (caller should deliver the body), false otherwise.
+	 */
+	takePending(name: string): boolean {
+		return this.pending.delete(name)
+	}
+
+	/** Snapshot of currently-loaded names — primarily for tests. */
+	loadedNames(): string[] {
+		return [...this.loaded]
+	}
+
+	/** Snapshot of the pending injection queue — primarily for tests. */
+	pendingNames(): string[] {
+		return [...this.pending]
+	}
+
+	/** Drop all loaded/pending state. Used when a fresh session_start fires. */
+	reset(): void {
+		this.loaded.clear()
+		this.pending.clear()
+	}
+}

--- a/src/extensions/behaviours/engine.ts
+++ b/src/extensions/behaviours/engine.ts
@@ -8,8 +8,9 @@
  * - `evaluateToolTriggers` — runs matchers against each tool-call event.
  *
  * Each behaviour transitions from unloaded to loaded at most once per session.
- * Once loaded, both trigger paths are skipped for that behaviour. Compaction
- * handling and re-injection land in a later phase.
+ * Once loaded, both trigger paths are skipped for that behaviour. On
+ * compaction the loaded set is preserved; `requeueLoaded` repopulates the
+ * pending queue so the injector re-delivers each loaded body once.
  */
 
 import type { SessionContext } from "./session-context.js"
@@ -105,5 +106,21 @@ export class TriggerEngine {
 	reset(): void {
 		this.loaded.clear()
 		this.pending.clear()
+	}
+
+	/**
+	 * Repopulate the pending queue with every currently-loaded behaviour, in
+	 * registry order. The loaded set is preserved — triggers do not re-fire
+	 * and `behaviour_loaded` entries are not re-emitted. Used after compaction
+	 * to re-inject bodies the summarisation step replaced.
+	 */
+	requeueLoaded(): string[] {
+		const requeued: string[] = []
+		for (const b of this.behaviours) {
+			if (!this.loaded.has(b.name)) continue
+			this.pending.add(b.name)
+			requeued.push(b.name)
+		}
+		return requeued
 	}
 }

--- a/src/extensions/behaviours/eval-engine.test.ts
+++ b/src/extensions/behaviours/eval-engine.test.ts
@@ -1,0 +1,165 @@
+import { describe, expect, it } from "vitest"
+import { EVAL_SAMPLE_CAP, EvalEngine } from "./eval-engine.js"
+import { type ToolCallEvent, tool } from "./triggers.js"
+import type { Behaviour } from "./types.js"
+
+function makeBehaviour(overrides: Partial<Behaviour> & Pick<Behaviour, "name">): Behaviour {
+	return {
+		description: `${overrides.name} behaviour`,
+		body: `body of ${overrides.name}`,
+		kind: "triggered",
+		triggers: undefined,
+		evals: undefined,
+		...overrides,
+	}
+}
+
+function bashCall(command: string): ToolCallEvent {
+	return { toolName: "bash", input: { command } }
+}
+
+const ghMatcher = tool("bash", (i) => i.command.startsWith("gh "))
+const curlMatcher = tool("bash", (i) => i.command.startsWith("curl "))
+
+describe("EvalEngine.evaluate", () => {
+	it("emits an observed sample when the loaded behaviour's observed matcher fires", () => {
+		const b = makeBehaviour({
+			name: "gh-cli",
+			evals: { observed: ghMatcher },
+		})
+		const engine = new EvalEngine([b], () => true)
+		const events = engine.evaluate(bashCall("gh pr list"), 7)
+
+		expect(events).toEqual([
+			{
+				name: "gh-cli",
+				verdict: "observed",
+				turnIndex: 7,
+				toolName: "bash",
+				toolArgs: { command: "gh pr list" },
+			},
+		])
+	})
+
+	it("emits a violated sample independent of observed", () => {
+		const b = makeBehaviour({
+			name: "gh-cli",
+			evals: { observed: ghMatcher, violated: curlMatcher },
+		})
+		const engine = new EvalEngine([b], () => true)
+		const events = engine.evaluate(bashCall("curl https://api.github.com/repos"), 0)
+
+		expect(events.map((e) => e.verdict)).toEqual(["violated"])
+	})
+
+	it("emits both observed and violated when both matchers fire on the same call", () => {
+		const matcher = tool("bash")
+		const b = makeBehaviour({
+			name: "x",
+			evals: { observed: matcher, violated: matcher },
+		})
+		const engine = new EvalEngine([b], () => true)
+		const events = engine.evaluate(bashCall("anything"), 0)
+		expect(events.map((e) => e.verdict)).toEqual(["observed", "violated"])
+	})
+
+	it("does not score a behaviour that is not loaded", () => {
+		const b = makeBehaviour({
+			name: "gh-cli",
+			evals: { observed: ghMatcher },
+		})
+		const engine = new EvalEngine([b], () => false)
+		expect(engine.evaluate(bashCall("gh pr list"), 0)).toEqual([])
+	})
+
+	it("starts scoring a behaviour as soon as the isLoaded view returns true", () => {
+		const loaded = new Set<string>()
+		const b = makeBehaviour({
+			name: "gh-cli",
+			evals: { observed: ghMatcher },
+		})
+		const engine = new EvalEngine([b], (n) => loaded.has(n))
+
+		expect(engine.evaluate(bashCall("gh pr list"), 0)).toEqual([])
+		loaded.add("gh-cli")
+		expect(engine.evaluate(bashCall("gh pr list"), 1)).toHaveLength(1)
+	})
+
+	it("stops emitting samples past the cap but keeps counters advancing", () => {
+		const b = makeBehaviour({
+			name: "gh-cli",
+			evals: { observed: ghMatcher },
+		})
+		const engine = new EvalEngine([b], () => true)
+
+		for (let i = 0; i < EVAL_SAMPLE_CAP; i++) {
+			expect(engine.evaluate(bashCall("gh pr list"), i)).toHaveLength(1)
+		}
+		// 6th match: counter advances, no sample.
+		expect(engine.evaluate(bashCall("gh pr list"), EVAL_SAMPLE_CAP)).toEqual([])
+		// 7th match: still capped.
+		expect(engine.evaluate(bashCall("gh pr list"), EVAL_SAMPLE_CAP + 1)).toEqual([])
+
+		expect(engine.countersFor("gh-cli")).toEqual({
+			observed: EVAL_SAMPLE_CAP + 2,
+			violated: 0,
+		})
+	})
+
+	it("caps observed and violated independently", () => {
+		const b = makeBehaviour({
+			name: "x",
+			evals: { observed: ghMatcher, violated: curlMatcher },
+		})
+		const engine = new EvalEngine([b], () => true, 2)
+
+		// Two observed samples, then capped.
+		engine.evaluate(bashCall("gh a"), 0)
+		engine.evaluate(bashCall("gh b"), 0)
+		expect(engine.evaluate(bashCall("gh c"), 0)).toEqual([])
+
+		// Violated still has its own budget.
+		const v = engine.evaluate(bashCall("curl x"), 1)
+		expect(v.map((e) => e.verdict)).toEqual(["violated"])
+	})
+
+	it("interleaves multiple behaviours without cross-talk", () => {
+		const a = makeBehaviour({
+			name: "a",
+			evals: { observed: ghMatcher },
+		})
+		const b = makeBehaviour({
+			name: "b",
+			evals: { violated: curlMatcher },
+		})
+		const engine = new EvalEngine([a, b], () => true)
+
+		const e1 = engine.evaluate(bashCall("gh pr list"), 0)
+		expect(e1.map((e) => `${e.name}:${e.verdict}`)).toEqual(["a:observed"])
+
+		const e2 = engine.evaluate(bashCall("curl https://x"), 1)
+		expect(e2.map((e) => `${e.name}:${e.verdict}`)).toEqual(["b:violated"])
+	})
+
+	it("ignores behaviours without any evaluator slots", () => {
+		const b = makeBehaviour({ name: "no-evals", evals: undefined })
+		const engine = new EvalEngine([b], () => true)
+		expect(engine.evaluate(bashCall("anything"), 0)).toEqual([])
+	})
+})
+
+describe("EvalEngine.reset", () => {
+	it("clears counters and re-opens the cap budget", () => {
+		const b = makeBehaviour({
+			name: "x",
+			evals: { observed: ghMatcher },
+		})
+		const engine = new EvalEngine([b], () => true, 1)
+
+		expect(engine.evaluate(bashCall("gh a"), 0)).toHaveLength(1)
+		expect(engine.evaluate(bashCall("gh b"), 0)).toEqual([])
+		engine.reset()
+		expect(engine.countersFor("x")).toEqual({ observed: 0, violated: 0 })
+		expect(engine.evaluate(bashCall("gh c"), 1)).toHaveLength(1)
+	})
+})

--- a/src/extensions/behaviours/eval-engine.test.ts
+++ b/src/extensions/behaviours/eval-engine.test.ts
@@ -1,16 +1,16 @@
 import { describe, expect, it } from "vitest"
 import { EVAL_SAMPLE_CAP, EvalEngine } from "./eval-engine.js"
 import { type ToolCallEvent, tool } from "./triggers.js"
-import type { Behaviour } from "./types.js"
+import type { Behaviour, BehaviourEvals } from "./types.js"
 
-function makeBehaviour(overrides: Partial<Behaviour> & Pick<Behaviour, "name">): Behaviour {
+function makeBehaviour(args: { name: string; evals?: BehaviourEvals }): Behaviour {
 	return {
-		description: `${overrides.name} behaviour`,
-		body: `body of ${overrides.name}`,
 		kind: "triggered",
-		triggers: undefined,
-		evals: undefined,
-		...overrides,
+		name: args.name,
+		description: `${args.name} behaviour`,
+		body: `body of ${args.name}`,
+		triggers: {},
+		evals: args.evals,
 	}
 }
 

--- a/src/extensions/behaviours/eval-engine.ts
+++ b/src/extensions/behaviours/eval-engine.ts
@@ -13,7 +13,7 @@
  * guidance.
  */
 
-import type { ToolCallEvent } from "./triggers.js"
+import type { ToolCallEvent, ToolMatcher } from "./triggers.js"
 import type { Behaviour, EvalVerdict } from "./types.js"
 
 export const EVAL_SAMPLE_CAP = 5
@@ -53,34 +53,24 @@ export class EvalEngine {
 		for (const b of this.behaviours) {
 			if (b.kind !== "triggered") continue
 			if (!this.isLoaded(b.name)) continue
-			const observed = b.evals?.observed
-			const violated = b.evals?.violated
-			if (observed?.(event)) {
-				this.bump(b.name, "observed")
-				if (this.tryEmit(b.name, "observed")) {
-					out.push({
-						name: b.name,
-						verdict: "observed",
-						turnIndex,
-						toolName: event.toolName,
-						toolArgs: event.input,
-					})
-				}
-			}
-			if (violated?.(event)) {
-				this.bump(b.name, "violated")
-				if (this.tryEmit(b.name, "violated")) {
-					out.push({
-						name: b.name,
-						verdict: "violated",
-						turnIndex,
-						toolName: event.toolName,
-						toolArgs: event.input,
-					})
-				}
-			}
+			this.runVerdict(b.name, "observed", b.evals?.observed, event, turnIndex, out)
+			this.runVerdict(b.name, "violated", b.evals?.violated, event, turnIndex, out)
 		}
 		return out
+	}
+
+	private runVerdict(
+		name: string,
+		verdict: EvalVerdict,
+		matcher: ToolMatcher | undefined,
+		event: ToolCallEvent,
+		turnIndex: number,
+		out: EvalEvent[],
+	): void {
+		if (!matcher?.(event)) return
+		this.bump(name, verdict)
+		if (!this.tryEmit(name, verdict)) return
+		out.push({ name, verdict, turnIndex, toolName: event.toolName, toolArgs: event.input })
 	}
 
 	/** Uncapped counters for a behaviour. Defaults to `{ observed: 0, violated: 0 }`. */

--- a/src/extensions/behaviours/eval-engine.ts
+++ b/src/extensions/behaviours/eval-engine.ts
@@ -51,6 +51,7 @@ export class EvalEngine {
 	evaluate(event: ToolCallEvent, turnIndex: number): EvalEvent[] {
 		const out: EvalEvent[] = []
 		for (const b of this.behaviours) {
+			if (b.kind !== "triggered") continue
 			if (!this.isLoaded(b.name)) continue
 			const observed = b.evals?.observed
 			const violated = b.evals?.violated

--- a/src/extensions/behaviours/eval-engine.ts
+++ b/src/extensions/behaviours/eval-engine.ts
@@ -1,0 +1,113 @@
+/**
+ * Eval engine — pure state machine that scores tool-call events against the
+ * `evals.observed` / `evals.violated` matchers of currently-loaded behaviours.
+ *
+ * Output is a stream of verdict events with cap enforcement: at most
+ * `EVAL_SAMPLE_CAP` written samples per `(behaviour, verdict)` per session.
+ * Internal counters keep advancing past the cap so the session summary can
+ * report uncapped totals — only sample emission stops.
+ *
+ * The engine never evaluates a behaviour's evals before it is loaded; the
+ * caller passes an `isLoaded` view onto the trigger engine. Evaluating before
+ * load would let the engine score actions the agent took without seeing the
+ * guidance.
+ */
+
+import type { ToolCallEvent } from "./triggers.js"
+import type { Behaviour, EvalVerdict } from "./types.js"
+
+export const EVAL_SAMPLE_CAP = 5
+
+export interface EvalEvent {
+	name: string
+	verdict: EvalVerdict
+	turnIndex: number
+	toolName: string
+	toolArgs: Record<string, unknown>
+}
+
+export interface EvalCounters {
+	observed: number
+	violated: number
+}
+
+export type IsLoaded = (name: string) => boolean
+
+export class EvalEngine {
+	private readonly counters = new Map<string, EvalCounters>()
+	private readonly emitted = new Map<string, EvalCounters>()
+
+	constructor(
+		private readonly behaviours: readonly Behaviour[],
+		private readonly isLoaded: IsLoaded,
+		private readonly cap: number = EVAL_SAMPLE_CAP,
+	) {}
+
+	/**
+	 * Score a tool-call event. Returns sample events for verdicts that fired
+	 * on this event AND are still under the per-(behaviour, verdict) cap.
+	 * Counters always advance, even when sample emission is suppressed.
+	 */
+	evaluate(event: ToolCallEvent, turnIndex: number): EvalEvent[] {
+		const out: EvalEvent[] = []
+		for (const b of this.behaviours) {
+			if (!this.isLoaded(b.name)) continue
+			const observed = b.evals?.observed
+			const violated = b.evals?.violated
+			if (observed?.(event)) {
+				this.bump(b.name, "observed")
+				if (this.tryEmit(b.name, "observed")) {
+					out.push({
+						name: b.name,
+						verdict: "observed",
+						turnIndex,
+						toolName: event.toolName,
+						toolArgs: event.input,
+					})
+				}
+			}
+			if (violated?.(event)) {
+				this.bump(b.name, "violated")
+				if (this.tryEmit(b.name, "violated")) {
+					out.push({
+						name: b.name,
+						verdict: "violated",
+						turnIndex,
+						toolName: event.toolName,
+						toolArgs: event.input,
+					})
+				}
+			}
+		}
+		return out
+	}
+
+	/** Uncapped counters for a behaviour. Defaults to `{ observed: 0, violated: 0 }`. */
+	countersFor(name: string): EvalCounters {
+		return cloneCounters(this.counters.get(name))
+	}
+
+	/** Drop all counters. */
+	reset(): void {
+		this.counters.clear()
+		this.emitted.clear()
+	}
+
+	private bump(name: string, verdict: EvalVerdict): void {
+		const c = this.counters.get(name) ?? { observed: 0, violated: 0 }
+		c[verdict] += 1
+		this.counters.set(name, c)
+	}
+
+	private tryEmit(name: string, verdict: EvalVerdict): boolean {
+		const e = this.emitted.get(name) ?? { observed: 0, violated: 0 }
+		if (e[verdict] >= this.cap) return false
+		e[verdict] += 1
+		this.emitted.set(name, e)
+		return true
+	}
+}
+
+function cloneCounters(c: EvalCounters | undefined): EvalCounters {
+	return c ? { ...c } : { observed: 0, violated: 0 }
+}

--- a/src/extensions/behaviours/frontmatter.ts
+++ b/src/extensions/behaviours/frontmatter.ts
@@ -39,7 +39,7 @@ export function parseBehaviourBody(raw: string): ParsedBehaviourBody {
 		if (line.trim() === "") continue
 		const m = FIELD_RE.exec(line)
 		if (!m) throw new Error(`malformed frontmatter line: ${JSON.stringify(line)}`)
-		const value = m[2].trim().replace(/^["'](.*)["']$/, "$1")
+		const value = m[2].trim().replace(/^(["'])(.*)\1$/, "$2")
 		fields[m[1]] = value
 	}
 	const name = fields.name

--- a/src/extensions/behaviours/frontmatter.ts
+++ b/src/extensions/behaviours/frontmatter.ts
@@ -1,19 +1,4 @@
-/**
- * Minimal frontmatter parser for bundled behaviour bodies.
- *
- * Bodies look like:
- *
- *     ---
- *     name: git-hygiene
- *     description: ...
- *     ---
- *
- *     <markdown content>
- *
- * The parser is deliberately strict — both `name` and `description` must be
- * present, and the frontmatter delimiters must match the canonical form. Any
- * deviation throws so the build fails fast at registry load.
- */
+import { parseFrontmatter } from "@mariozechner/pi-coding-agent"
 
 export interface BehaviourFrontmatter {
 	name: string
@@ -25,29 +10,13 @@ export interface ParsedBehaviourBody {
 	content: string
 }
 
-const FRONTMATTER_RE = /^---\r?\n([\s\S]*?)\r?\n---\r?\n?([\s\S]*)$/
-const FIELD_RE = /^([a-zA-Z][\w-]*)\s*:\s*(.*)$/
-
 export function parseBehaviourBody(raw: string): ParsedBehaviourBody {
-	const match = FRONTMATTER_RE.exec(raw)
-	if (!match) {
+	const { frontmatter, body } = parseFrontmatter<Partial<BehaviourFrontmatter>>(raw)
+	if (!raw.trimStart().startsWith("---")) {
 		throw new Error("behaviour body is missing frontmatter delimited by '---' lines")
 	}
-	const [, block, rest] = match
-	const fields: Record<string, string> = {}
-	for (const line of block.split(/\r?\n/)) {
-		if (line.trim() === "") continue
-		const m = FIELD_RE.exec(line)
-		if (!m) throw new Error(`malformed frontmatter line: ${JSON.stringify(line)}`)
-		const value = m[2].trim().replace(/^(["'])(.*)\1$/, "$2")
-		fields[m[1]] = value
-	}
-	const name = fields.name
-	const description = fields.description
+	const { name, description } = frontmatter
 	if (!name) throw new Error("behaviour frontmatter is missing required field: name")
 	if (!description) throw new Error(`behaviour ${name} frontmatter is missing required field: description`)
-	return {
-		frontmatter: { name, description },
-		content: rest.trim(),
-	}
+	return { frontmatter: { name, description }, content: body.trim() }
 }

--- a/src/extensions/behaviours/frontmatter.ts
+++ b/src/extensions/behaviours/frontmatter.ts
@@ -1,0 +1,53 @@
+/**
+ * Minimal frontmatter parser for bundled behaviour bodies.
+ *
+ * Bodies look like:
+ *
+ *     ---
+ *     name: git-hygiene
+ *     description: ...
+ *     ---
+ *
+ *     <markdown content>
+ *
+ * The parser is deliberately strict — both `name` and `description` must be
+ * present, and the frontmatter delimiters must match the canonical form. Any
+ * deviation throws so the build fails fast at registry load.
+ */
+
+export interface BehaviourFrontmatter {
+	name: string
+	description: string
+}
+
+export interface ParsedBehaviourBody {
+	frontmatter: BehaviourFrontmatter
+	content: string
+}
+
+const FRONTMATTER_RE = /^---\r?\n([\s\S]*?)\r?\n---\r?\n?([\s\S]*)$/
+const FIELD_RE = /^([a-zA-Z][\w-]*)\s*:\s*(.*)$/
+
+export function parseBehaviourBody(raw: string): ParsedBehaviourBody {
+	const match = FRONTMATTER_RE.exec(raw)
+	if (!match) {
+		throw new Error("behaviour body is missing frontmatter delimited by '---' lines")
+	}
+	const [, block, rest] = match
+	const fields: Record<string, string> = {}
+	for (const line of block.split(/\r?\n/)) {
+		if (line.trim() === "") continue
+		const m = FIELD_RE.exec(line)
+		if (!m) throw new Error(`malformed frontmatter line: ${JSON.stringify(line)}`)
+		const value = m[2].trim().replace(/^["'](.*)["']$/, "$1")
+		fields[m[1]] = value
+	}
+	const name = fields.name
+	const description = fields.description
+	if (!name) throw new Error("behaviour frontmatter is missing required field: name")
+	if (!description) throw new Error(`behaviour ${name} frontmatter is missing required field: description`)
+	return {
+		frontmatter: { name, description },
+		content: rest.trim(),
+	}
+}

--- a/src/extensions/behaviours/index.ts
+++ b/src/extensions/behaviours/index.ts
@@ -1,27 +1,90 @@
 /**
- * Bundled-behaviours extension — phase 1.
+ * Bundled-behaviours extension.
  *
- * Concatenates baseline behaviour bodies into a `## Rules` block appended to
- * the system prompt at the start of each agent turn. Triggered behaviours are
- * registered but stay dormant until phase 2 wires session-probe triggers.
+ * Two delivery paths:
+ * - **Baseline** behaviours are concatenated into a `## Rules` block appended
+ *   to the system prompt at every turn. Always in effect, no per-call cost.
+ * - **Triggered** behaviours load when their session-probe triggers fire at
+ *   session start. Loaded bodies are delivered as hidden custom messages on
+ *   the next agent turn, once per behaviour per session.
+ *
+ * Triggered loads are written into the active session JSONL as
+ * `behaviour_loaded` custom entries so the load decisions can be audited
+ * offline.
  */
 
-import type { ExtensionAPI } from "@mariozechner/pi-coding-agent"
+import type { ExtensionAPI, ExtensionContext } from "@mariozechner/pi-coding-agent"
+import { TriggerEngine } from "./engine.js"
 import { behaviours } from "./registry.js"
+import { resolveSessionContext } from "./session-context.js"
+import { BEHAVIOUR_LOADED_TYPE, type BehaviourLoadedData } from "./stats.js"
+import type { ProbeSpec } from "./triggers.js"
+import type { Behaviour } from "./types.js"
 
 const RULES_HEADER = "## Rules"
+export const BEHAVIOUR_BODY_TYPE = "behaviour_body"
 
-function buildRulesBlock(): string {
-	const baselineBodies = behaviours.filter((b) => b.kind === "baseline").map((b) => b.body.trim())
-	if (baselineBodies.length === 0) return ""
-	return `\n\n${RULES_HEADER}\n\n${baselineBodies.join("\n\n")}\n`
+interface BehaviourBodyDetails {
+	name: string
+}
+
+function buildRulesBlock(all: readonly Behaviour[]): string {
+	const baseline = all.filter((b) => b.kind === "baseline").map((b) => b.body.trim())
+	if (baseline.length === 0) return ""
+	return `\n\n${RULES_HEADER}\n\n${baseline.join("\n\n")}\n`
+}
+
+function collectSessionSpecs(triggered: readonly Behaviour[]): ProbeSpec[] {
+	const specs: ProbeSpec[] = []
+	for (const b of triggered) {
+		const probe = b.triggers?.session
+		if (probe) specs.push(probe.__spec)
+	}
+	return specs
 }
 
 export default function behavioursExtension(pi: ExtensionAPI): void {
-	const rulesBlock = buildRulesBlock()
-	if (!rulesBlock) return
+	const rulesBlock = buildRulesBlock(behaviours)
+	const triggered = behaviours.filter((b) => b.kind === "triggered")
+	const sessionSpecs = collectSessionSpecs(triggered)
+	const engine = new TriggerEngine(behaviours)
 
-	pi.on("before_agent_start", async (event) => {
-		return { systemPrompt: event.systemPrompt + rulesBlock }
+	pi.on("session_start", async (_event, ctx: ExtensionContext) => {
+		// Reset per-session state so re-fired session_start events (reload, new,
+		// fork, resume) don't carry stale loads forward into a fresh session.
+		engine.reset()
+		const sessionContext = resolveSessionContext(sessionSpecs, ctx.cwd)
+		const events = engine.evaluateSessionTriggers(sessionContext, 0)
+		for (const e of events) {
+			pi.appendEntry<BehaviourLoadedData>(BEHAVIOUR_LOADED_TYPE, {
+				name: e.name,
+				trigger: e.trigger,
+				turnIndex: e.turnIndex,
+			})
+		}
 	})
+
+	if (rulesBlock) {
+		pi.on("before_agent_start", async (event) => {
+			return { systemPrompt: event.systemPrompt + rulesBlock }
+		})
+	}
+
+	// One injector handler per triggered behaviour. The runner aggregates
+	// messages across all `before_agent_start` handlers, so multiple pending
+	// bodies are delivered together on the next turn. Each handler closes over
+	// its behaviour and emits the body iff the engine still has it pending.
+	for (const b of triggered) {
+		pi.on("before_agent_start", async () => {
+			if (!engine.takePending(b.name)) return
+			return {
+				message: {
+					customType: BEHAVIOUR_BODY_TYPE,
+					content: b.body,
+					display: false,
+					details: { name: b.name } satisfies BehaviourBodyDetails,
+				},
+			}
+		})
+	}
 }

--- a/src/extensions/behaviours/index.ts
+++ b/src/extensions/behaviours/index.ts
@@ -7,14 +7,16 @@
  * - **Triggered** behaviours load when their session-probe triggers fire at
  *   session start, or when their tool-call matchers fire on a tool_call event.
  *   Loaded bodies are delivered as hidden custom messages on the next agent
- *   turn, once per behaviour per session.
+ *   turn, once per behaviour per session, plus once more after each
+ *   compaction (which summarises the body away).
  *
  * On each tool-call event the eval engine runs first against the prior loaded
  * set, then the trigger engine evaluates tool-call triggers; this ensures the
  * call that loads a behaviour is not also scored against its own evaluators.
  *
- * Triggered loads and eval verdicts are written into the active session JSONL
- * (`behaviour_loaded`, `behaviour_eval`) so decisions can be audited offline.
+ * Triggered loads, eval verdicts, and a per-session summary are written into
+ * the active session JSONL (`behaviour_loaded`, `behaviour_eval`,
+ * `behaviour_session_summary`) so decisions can be audited offline.
  */
 
 import type { ExtensionAPI, ExtensionContext } from "@mariozechner/pi-coding-agent"
@@ -25,17 +27,25 @@ import { resolveSessionContext } from "./session-context.js"
 import {
 	BEHAVIOUR_EVAL_TYPE,
 	BEHAVIOUR_LOADED_TYPE,
+	BEHAVIOUR_SESSION_SUMMARY_TYPE,
 	type BehaviourEvalData,
 	type BehaviourLoadedData,
+	type BehaviourSessionSummaryData,
+	type BehaviourSummaryEntry,
 } from "./stats.js"
 import type { ProbeSpec } from "./triggers.js"
-import type { Behaviour } from "./types.js"
+import type { Behaviour, TriggerSource } from "./types.js"
 
 const RULES_HEADER = "## Rules"
 export const BEHAVIOUR_BODY_TYPE = "behaviour_body"
 
 interface BehaviourBodyDetails {
 	name: string
+}
+
+interface LoadRecord {
+	loadedAtTurn: number
+	trigger: TriggerSource
 }
 
 function buildRulesBlock(all: readonly Behaviour[]): string {
@@ -59,16 +69,28 @@ export default function behavioursExtension(pi: ExtensionAPI): void {
 	const sessionSpecs = collectSessionSpecs(triggered)
 	const engine = new TriggerEngine(behaviours)
 	const evalEngine = new EvalEngine(behaviours, (name) => engine.isLoaded(name))
+	const loadRecords = new Map<string, LoadRecord>()
+	let summaryEmitted = false
 	let currentTurnIndex = 0
+
+	function recordLoads(events: { name: string; trigger: TriggerSource; turnIndex: number }[]): void {
+		for (const e of events) {
+			if (loadRecords.has(e.name)) continue
+			loadRecords.set(e.name, { loadedAtTurn: e.turnIndex, trigger: e.trigger })
+		}
+	}
 
 	pi.on("session_start", async (_event, ctx: ExtensionContext) => {
 		// Reset per-session state so re-fired session_start events (reload, new,
 		// fork, resume) don't carry stale loads forward into a fresh session.
 		engine.reset()
 		evalEngine.reset()
+		loadRecords.clear()
+		summaryEmitted = false
 		currentTurnIndex = 0
 		const sessionContext = resolveSessionContext(sessionSpecs, ctx.cwd)
 		const events = engine.evaluateSessionTriggers(sessionContext, currentTurnIndex)
+		recordLoads(events)
 		for (const e of events) {
 			pi.appendEntry<BehaviourLoadedData>(BEHAVIOUR_LOADED_TYPE, {
 				name: e.name,
@@ -99,6 +121,7 @@ export default function behavioursExtension(pi: ExtensionAPI): void {
 		}
 
 		const loadEvents = engine.evaluateToolTriggers(callEvent, currentTurnIndex)
+		recordLoads(loadEvents)
 		for (const e of loadEvents) {
 			pi.appendEntry<BehaviourLoadedData>(BEHAVIOUR_LOADED_TYPE, {
 				name: e.name,
@@ -107,6 +130,36 @@ export default function behavioursExtension(pi: ExtensionAPI): void {
 				toolArgs: e.toolArgs,
 			})
 		}
+	})
+
+	// After compaction, the summarisation step replaces the conversation window
+	// (including any prior behaviour bodies) with a synthesised summary. Re-queue
+	// every loaded behaviour for re-injection on the next agent turn. The loaded
+	// set is preserved — triggers do not re-fire, no duplicate `behaviour_loaded`
+	// entries are emitted.
+	pi.on("session_compact", async () => {
+		engine.requeueLoaded()
+	})
+
+	pi.on("session_shutdown", async () => {
+		if (summaryEmitted) return
+		summaryEmitted = true
+		const entries: BehaviourSummaryEntry[] = behaviours.map((b) => {
+			const counters = evalEngine.countersFor(b.name)
+			const record = loadRecords.get(b.name)
+			const entry: BehaviourSummaryEntry = {
+				name: b.name,
+				loaded: record !== undefined || b.kind === "baseline",
+				observed: counters.observed,
+				violated: counters.violated,
+			}
+			if (record) {
+				entry.loadedAtTurn = record.loadedAtTurn
+				entry.trigger = record.trigger
+			}
+			return entry
+		})
+		pi.appendEntry<BehaviourSessionSummaryData>(BEHAVIOUR_SESSION_SUMMARY_TYPE, { behaviours: entries })
 	})
 
 	if (rulesBlock) {

--- a/src/extensions/behaviours/index.ts
+++ b/src/extensions/behaviours/index.ts
@@ -5,19 +5,29 @@
  * - **Baseline** behaviours are concatenated into a `## Rules` block appended
  *   to the system prompt at every turn. Always in effect, no per-call cost.
  * - **Triggered** behaviours load when their session-probe triggers fire at
- *   session start. Loaded bodies are delivered as hidden custom messages on
- *   the next agent turn, once per behaviour per session.
+ *   session start, or when their tool-call matchers fire on a tool_call event.
+ *   Loaded bodies are delivered as hidden custom messages on the next agent
+ *   turn, once per behaviour per session.
  *
- * Triggered loads are written into the active session JSONL as
- * `behaviour_loaded` custom entries so the load decisions can be audited
- * offline.
+ * On each tool-call event the eval engine runs first against the prior loaded
+ * set, then the trigger engine evaluates tool-call triggers; this ensures the
+ * call that loads a behaviour is not also scored against its own evaluators.
+ *
+ * Triggered loads and eval verdicts are written into the active session JSONL
+ * (`behaviour_loaded`, `behaviour_eval`) so decisions can be audited offline.
  */
 
 import type { ExtensionAPI, ExtensionContext } from "@mariozechner/pi-coding-agent"
 import { TriggerEngine } from "./engine.js"
+import { EvalEngine } from "./eval-engine.js"
 import { behaviours } from "./registry.js"
 import { resolveSessionContext } from "./session-context.js"
-import { BEHAVIOUR_LOADED_TYPE, type BehaviourLoadedData } from "./stats.js"
+import {
+	BEHAVIOUR_EVAL_TYPE,
+	BEHAVIOUR_LOADED_TYPE,
+	type BehaviourEvalData,
+	type BehaviourLoadedData,
+} from "./stats.js"
 import type { ProbeSpec } from "./triggers.js"
 import type { Behaviour } from "./types.js"
 
@@ -48,18 +58,53 @@ export default function behavioursExtension(pi: ExtensionAPI): void {
 	const triggered = behaviours.filter((b) => b.kind === "triggered")
 	const sessionSpecs = collectSessionSpecs(triggered)
 	const engine = new TriggerEngine(behaviours)
+	const evalEngine = new EvalEngine(behaviours, (name) => engine.isLoaded(name))
+	let currentTurnIndex = 0
 
 	pi.on("session_start", async (_event, ctx: ExtensionContext) => {
 		// Reset per-session state so re-fired session_start events (reload, new,
 		// fork, resume) don't carry stale loads forward into a fresh session.
 		engine.reset()
+		evalEngine.reset()
+		currentTurnIndex = 0
 		const sessionContext = resolveSessionContext(sessionSpecs, ctx.cwd)
-		const events = engine.evaluateSessionTriggers(sessionContext, 0)
+		const events = engine.evaluateSessionTriggers(sessionContext, currentTurnIndex)
 		for (const e of events) {
 			pi.appendEntry<BehaviourLoadedData>(BEHAVIOUR_LOADED_TYPE, {
 				name: e.name,
 				trigger: e.trigger,
 				turnIndex: e.turnIndex,
+			})
+		}
+	})
+
+	pi.on("turn_start", async (event) => {
+		currentTurnIndex = event.turnIndex
+	})
+
+	pi.on("tool_call", async (event) => {
+		const callEvent = { toolName: event.toolName, input: event.input as Record<string, unknown> }
+
+		// Score evals against the prior loaded set first, so a behaviour loaded
+		// by this same tool-call does not get scored on the call that loaded it.
+		const evalEvents = evalEngine.evaluate(callEvent, currentTurnIndex)
+		for (const e of evalEvents) {
+			pi.appendEntry<BehaviourEvalData>(BEHAVIOUR_EVAL_TYPE, {
+				name: e.name,
+				verdict: e.verdict,
+				turnIndex: e.turnIndex,
+				toolName: e.toolName,
+				toolArgs: e.toolArgs,
+			})
+		}
+
+		const loadEvents = engine.evaluateToolTriggers(callEvent, currentTurnIndex)
+		for (const e of loadEvents) {
+			pi.appendEntry<BehaviourLoadedData>(BEHAVIOUR_LOADED_TYPE, {
+				name: e.name,
+				trigger: e.trigger,
+				turnIndex: e.turnIndex,
+				toolArgs: e.toolArgs,
 			})
 		}
 	})

--- a/src/extensions/behaviours/index.ts
+++ b/src/extensions/behaviours/index.ts
@@ -14,9 +14,10 @@
  * set, then the trigger engine evaluates tool-call triggers; this ensures the
  * call that loads a behaviour is not also scored against its own evaluators.
  *
- * Triggered loads, eval verdicts, and a per-session summary are written into
- * the active session JSONL (`behaviour_loaded`, `behaviour_eval`,
- * `behaviour_session_summary`) so decisions can be audited offline.
+ * Triggered loads, eval verdicts, post-compaction requeues, and a per-session
+ * summary are written into the active session JSONL (`behaviour_loaded`,
+ * `behaviour_eval`, `behaviour_requeued`, `behaviour_session_summary`) so
+ * decisions can be audited offline.
  */
 
 import type { ExtensionAPI, ExtensionContext } from "@mariozechner/pi-coding-agent"
@@ -27,14 +28,16 @@ import { resolveSessionContext } from "./session-context.js"
 import {
 	BEHAVIOUR_EVAL_TYPE,
 	BEHAVIOUR_LOADED_TYPE,
+	BEHAVIOUR_REQUEUED_TYPE,
 	BEHAVIOUR_SESSION_SUMMARY_TYPE,
 	type BehaviourEvalData,
 	type BehaviourLoadedData,
+	type BehaviourRequeuedData,
 	type BehaviourSessionSummaryData,
 	type BehaviourSummaryEntry,
 } from "./stats.js"
 import type { ProbeSpec } from "./triggers.js"
-import type { Behaviour, TriggerSource } from "./types.js"
+import type { Behaviour, TriggeredBehaviour } from "./types.js"
 
 const RULES_HEADER = "## Rules"
 export const BEHAVIOUR_BODY_TYPE = "behaviour_body"
@@ -43,54 +46,43 @@ interface BehaviourBodyDetails {
 	name: string
 }
 
-interface LoadRecord {
-	loadedAtTurn: number
-	trigger: TriggerSource
-}
-
 function buildRulesBlock(all: readonly Behaviour[]): string {
 	const baseline = all.filter((b) => b.kind === "baseline").map((b) => b.body.trim())
 	if (baseline.length === 0) return ""
 	return `\n\n${RULES_HEADER}\n\n${baseline.join("\n\n")}\n`
 }
 
-function collectSessionSpecs(triggered: readonly Behaviour[]): ProbeSpec[] {
+function collectSessionSpecs(triggered: readonly TriggeredBehaviour[]): ProbeSpec[] {
 	const specs: ProbeSpec[] = []
 	for (const b of triggered) {
-		const probe = b.triggers?.session
+		const probe = b.triggers.session
 		if (probe) specs.push(probe.__spec)
 	}
 	return specs
 }
 
+function isTriggered(b: Behaviour): b is TriggeredBehaviour {
+	return b.kind === "triggered"
+}
+
 export default function behavioursExtension(pi: ExtensionAPI): void {
 	const rulesBlock = buildRulesBlock(behaviours)
-	const triggered = behaviours.filter((b) => b.kind === "triggered")
+	const triggered = behaviours.filter(isTriggered)
 	const sessionSpecs = collectSessionSpecs(triggered)
 	const engine = new TriggerEngine(behaviours)
 	const evalEngine = new EvalEngine(behaviours, (name) => engine.isLoaded(name))
-	const loadRecords = new Map<string, LoadRecord>()
 	let summaryEmitted = false
 	let currentTurnIndex = 0
-
-	function recordLoads(events: { name: string; trigger: TriggerSource; turnIndex: number }[]): void {
-		for (const e of events) {
-			if (loadRecords.has(e.name)) continue
-			loadRecords.set(e.name, { loadedAtTurn: e.turnIndex, trigger: e.trigger })
-		}
-	}
 
 	pi.on("session_start", async (_event, ctx: ExtensionContext) => {
 		// Reset per-session state so re-fired session_start events (reload, new,
 		// fork, resume) don't carry stale loads forward into a fresh session.
 		engine.reset()
 		evalEngine.reset()
-		loadRecords.clear()
 		summaryEmitted = false
 		currentTurnIndex = 0
 		const sessionContext = resolveSessionContext(sessionSpecs, ctx.cwd)
 		const events = engine.evaluateSessionTriggers(sessionContext, currentTurnIndex)
-		recordLoads(events)
 		for (const e of events) {
 			pi.appendEntry<BehaviourLoadedData>(BEHAVIOUR_LOADED_TYPE, {
 				name: e.name,
@@ -121,7 +113,6 @@ export default function behavioursExtension(pi: ExtensionAPI): void {
 		}
 
 		const loadEvents = engine.evaluateToolTriggers(callEvent, currentTurnIndex)
-		recordLoads(loadEvents)
 		for (const e of loadEvents) {
 			pi.appendEntry<BehaviourLoadedData>(BEHAVIOUR_LOADED_TYPE, {
 				name: e.name,
@@ -136,29 +127,36 @@ export default function behavioursExtension(pi: ExtensionAPI): void {
 	// (including any prior behaviour bodies) with a synthesised summary. Re-queue
 	// every loaded behaviour for re-injection on the next agent turn. The loaded
 	// set is preserved — triggers do not re-fire, no duplicate `behaviour_loaded`
-	// entries are emitted.
+	// entries are emitted; instead a `behaviour_requeued` row signals the
+	// re-injection so offline analysis can distinguish first load from re-deliver.
 	pi.on("session_compact", async () => {
-		engine.requeueLoaded()
+		const requeued = engine.requeueLoaded()
+		for (const name of requeued) {
+			pi.appendEntry<BehaviourRequeuedData>(BEHAVIOUR_REQUEUED_TYPE, { name, turnIndex: currentTurnIndex })
+		}
 	})
 
 	pi.on("session_shutdown", async () => {
 		if (summaryEmitted) return
 		summaryEmitted = true
-		const entries: BehaviourSummaryEntry[] = behaviours.map((b) => {
+		const entries: BehaviourSummaryEntry[] = []
+		for (const b of behaviours) {
+			const record = engine.loadRecord(b.name)
+			const isBaseline = b.kind === "baseline"
+			if (!isBaseline && !record) continue
 			const counters = evalEngine.countersFor(b.name)
-			const record = loadRecords.get(b.name)
 			const entry: BehaviourSummaryEntry = {
 				name: b.name,
-				loaded: record !== undefined || b.kind === "baseline",
+				loaded: isBaseline || record !== undefined,
 				observed: counters.observed,
 				violated: counters.violated,
 			}
 			if (record) {
-				entry.loadedAtTurn = record.loadedAtTurn
+				entry.loadedAtTurn = record.turnIndex
 				entry.trigger = record.trigger
 			}
-			return entry
-		})
+			entries.push(entry)
+		}
 		pi.appendEntry<BehaviourSessionSummaryData>(BEHAVIOUR_SESSION_SUMMARY_TYPE, { behaviours: entries })
 	})
 

--- a/src/extensions/behaviours/index.ts
+++ b/src/extensions/behaviours/index.ts
@@ -18,169 +18,17 @@
  * summary are written into the active session JSONL (`behaviour_loaded`,
  * `behaviour_eval`, `behaviour_requeued`, `behaviour_session_summary`) so
  * decisions can be audited offline.
+ *
+ * The wiring layer lives in `wiring.ts` so tests can import it without
+ * resolving the markdown bodies pulled in by `registry.ts`.
  */
 
-import type { ExtensionAPI, ExtensionContext } from "@mariozechner/pi-coding-agent"
-import { TriggerEngine } from "./engine.js"
-import { EvalEngine } from "./eval-engine.js"
-import { behaviours } from "./registry.js"
-import { resolveSessionContext } from "./session-context.js"
-import {
-	BEHAVIOUR_EVAL_TYPE,
-	BEHAVIOUR_LOADED_TYPE,
-	BEHAVIOUR_REQUEUED_TYPE,
-	BEHAVIOUR_SESSION_SUMMARY_TYPE,
-	type BehaviourEvalData,
-	type BehaviourLoadedData,
-	type BehaviourRequeuedData,
-	type BehaviourSessionSummaryData,
-	type BehaviourSummaryEntry,
-} from "./stats.js"
-import type { ProbeSpec } from "./triggers.js"
-import type { Behaviour, TriggeredBehaviour } from "./types.js"
+import type { ExtensionAPI } from "@mariozechner/pi-coding-agent"
+import { behaviours as bundledBehaviours } from "./registry.js"
+import { wireBehaviours } from "./wiring.js"
 
-const RULES_HEADER = "## Rules"
-export const BEHAVIOUR_BODY_TYPE = "behaviour_body"
-
-interface BehaviourBodyDetails {
-	name: string
-}
-
-function buildRulesBlock(all: readonly Behaviour[]): string {
-	const baseline = all.filter((b) => b.kind === "baseline").map((b) => b.body.trim())
-	if (baseline.length === 0) return ""
-	return `\n\n${RULES_HEADER}\n\n${baseline.join("\n\n")}\n`
-}
-
-function collectSessionSpecs(triggered: readonly TriggeredBehaviour[]): ProbeSpec[] {
-	const specs: ProbeSpec[] = []
-	for (const b of triggered) {
-		const probe = b.triggers.session
-		if (probe) specs.push(probe.__spec)
-	}
-	return specs
-}
-
-function isTriggered(b: Behaviour): b is TriggeredBehaviour {
-	return b.kind === "triggered"
-}
+export { BEHAVIOUR_BODY_TYPE, type WireOptions, wireBehaviours } from "./wiring.js"
 
 export default function behavioursExtension(pi: ExtensionAPI): void {
-	const rulesBlock = buildRulesBlock(behaviours)
-	const triggered = behaviours.filter(isTriggered)
-	const sessionSpecs = collectSessionSpecs(triggered)
-	const engine = new TriggerEngine(behaviours)
-	const evalEngine = new EvalEngine(behaviours, (name) => engine.isLoaded(name))
-	let summaryEmitted = false
-	let currentTurnIndex = 0
-
-	pi.on("session_start", async (_event, ctx: ExtensionContext) => {
-		// Reset per-session state so re-fired session_start events (reload, new,
-		// fork, resume) don't carry stale loads forward into a fresh session.
-		engine.reset()
-		evalEngine.reset()
-		summaryEmitted = false
-		currentTurnIndex = 0
-		const sessionContext = resolveSessionContext(sessionSpecs, ctx.cwd)
-		const events = engine.evaluateSessionTriggers(sessionContext, currentTurnIndex)
-		for (const e of events) {
-			pi.appendEntry<BehaviourLoadedData>(BEHAVIOUR_LOADED_TYPE, {
-				name: e.name,
-				trigger: e.trigger,
-				turnIndex: e.turnIndex,
-			})
-		}
-	})
-
-	pi.on("turn_start", async (event) => {
-		currentTurnIndex = event.turnIndex
-	})
-
-	pi.on("tool_call", async (event) => {
-		const callEvent = { toolName: event.toolName, input: event.input as Record<string, unknown> }
-
-		// Score evals against the prior loaded set first, so a behaviour loaded
-		// by this same tool-call does not get scored on the call that loaded it.
-		const evalEvents = evalEngine.evaluate(callEvent, currentTurnIndex)
-		for (const e of evalEvents) {
-			pi.appendEntry<BehaviourEvalData>(BEHAVIOUR_EVAL_TYPE, {
-				name: e.name,
-				verdict: e.verdict,
-				turnIndex: e.turnIndex,
-				toolName: e.toolName,
-				toolArgs: e.toolArgs,
-			})
-		}
-
-		const loadEvents = engine.evaluateToolTriggers(callEvent, currentTurnIndex)
-		for (const e of loadEvents) {
-			pi.appendEntry<BehaviourLoadedData>(BEHAVIOUR_LOADED_TYPE, {
-				name: e.name,
-				trigger: e.trigger,
-				turnIndex: e.turnIndex,
-				toolArgs: e.toolArgs,
-			})
-		}
-	})
-
-	// After compaction, the summarisation step replaces the conversation window
-	// (including any prior behaviour bodies) with a synthesised summary. Re-queue
-	// every loaded behaviour for re-injection on the next agent turn. The loaded
-	// set is preserved — triggers do not re-fire, no duplicate `behaviour_loaded`
-	// entries are emitted; instead a `behaviour_requeued` row signals the
-	// re-injection so offline analysis can distinguish first load from re-deliver.
-	pi.on("session_compact", async () => {
-		const requeued = engine.requeueLoaded()
-		for (const name of requeued) {
-			pi.appendEntry<BehaviourRequeuedData>(BEHAVIOUR_REQUEUED_TYPE, { name, turnIndex: currentTurnIndex })
-		}
-	})
-
-	pi.on("session_shutdown", async () => {
-		if (summaryEmitted) return
-		summaryEmitted = true
-		const entries: BehaviourSummaryEntry[] = []
-		for (const b of behaviours) {
-			const record = engine.loadRecord(b.name)
-			const isBaseline = b.kind === "baseline"
-			if (!isBaseline && !record) continue
-			const counters = evalEngine.countersFor(b.name)
-			const entry: BehaviourSummaryEntry = {
-				name: b.name,
-				loaded: isBaseline || record !== undefined,
-				observed: counters.observed,
-				violated: counters.violated,
-			}
-			if (record) {
-				entry.loadedAtTurn = record.turnIndex
-				entry.trigger = record.trigger
-			}
-			entries.push(entry)
-		}
-		pi.appendEntry<BehaviourSessionSummaryData>(BEHAVIOUR_SESSION_SUMMARY_TYPE, { behaviours: entries })
-	})
-
-	if (rulesBlock) {
-		pi.on("before_agent_start", async (event) => {
-			return { systemPrompt: event.systemPrompt + rulesBlock }
-		})
-	}
-
-	// One injector handler per triggered behaviour. The runner aggregates
-	// messages across all `before_agent_start` handlers, so multiple pending
-	// bodies are delivered together on the next turn. Each handler closes over
-	// its behaviour and emits the body iff the engine still has it pending.
-	for (const b of triggered) {
-		pi.on("before_agent_start", async () => {
-			if (!engine.takePending(b.name)) return
-			return {
-				message: {
-					customType: BEHAVIOUR_BODY_TYPE,
-					content: b.body,
-					display: false,
-					details: { name: b.name } satisfies BehaviourBodyDetails,
-				},
-			}
-		})
-	}
+	wireBehaviours(pi, bundledBehaviours)
 }

--- a/src/extensions/behaviours/index.ts
+++ b/src/extensions/behaviours/index.ts
@@ -1,0 +1,27 @@
+/**
+ * Bundled-behaviours extension — phase 1.
+ *
+ * Concatenates baseline behaviour bodies into a `## Rules` block appended to
+ * the system prompt at the start of each agent turn. Triggered behaviours are
+ * registered but stay dormant until phase 2 wires session-probe triggers.
+ */
+
+import type { ExtensionAPI } from "@mariozechner/pi-coding-agent"
+import { behaviours } from "./registry.js"
+
+const RULES_HEADER = "## Rules"
+
+function buildRulesBlock(): string {
+	const baselineBodies = behaviours.filter((b) => b.kind === "baseline").map((b) => b.body.trim())
+	if (baselineBodies.length === 0) return ""
+	return `\n\n${RULES_HEADER}\n\n${baselineBodies.join("\n\n")}\n`
+}
+
+export default function behavioursExtension(pi: ExtensionAPI): void {
+	const rulesBlock = buildRulesBlock()
+	if (!rulesBlock) return
+
+	pi.on("before_agent_start", async (event) => {
+		return { systemPrompt: event.systemPrompt + rulesBlock }
+	})
+}

--- a/src/extensions/behaviours/matchers.test.ts
+++ b/src/extensions/behaviours/matchers.test.ts
@@ -123,6 +123,27 @@ describe("fetchesHost", () => {
 		expect(m(bash("echo github.com"))).toBe(false)
 	})
 
+	it("does not match when curl/wget appears only in a comment", () => {
+		const m = fetchesHost("github.com")
+		expect(m(bash("ls # curl github.com"))).toBe(false)
+	})
+
+	it("does not match when curl is named but not invoked", () => {
+		const m = fetchesHost("github.com")
+		expect(m(bash("echo curl github.com"))).toBe(false)
+	})
+
+	it("does not match curl/wget inside a heredoc body", () => {
+		const m = fetchesHost("github.com")
+		expect(m(bash("cat <<EOF\ncurl https://github.com\nEOF"))).toBe(false)
+	})
+
+	it("matches across pipeline / sequence stages", () => {
+		const m = fetchesHost("github.com")
+		expect(m(bash("ls && curl https://github.com/x"))).toBe(true)
+		expect(m(bash("curl https://github.com/x | jq"))).toBe(true)
+	})
+
 	it("accepts a RegExp host pattern for fuzzier matches", () => {
 		const m = fetchesHost(/(api\.)?github\.com/)
 		expect(m(webFetch("https://api.github.com/repos"))).toBe(true)

--- a/src/extensions/behaviours/matchers.test.ts
+++ b/src/extensions/behaviours/matchers.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest"
-import { bashCommand, bashStartsWith, fetchesHost, webFetchUrl, webSearchQuery } from "./matchers.js"
+import { bashCommand, bashInvokes, fetchesHost, webFetchUrl, webSearchQuery } from "./matchers.js"
 import type { ToolCallEvent } from "./triggers.js"
 
 function bash(command: string): ToolCallEvent {
@@ -32,29 +32,51 @@ describe("bashCommand", () => {
 	})
 })
 
-describe("bashStartsWith", () => {
-	it("matches the bare prefix", () => {
-		const m = bashStartsWith("gh")
+describe("bashInvokes", () => {
+	const m = bashInvokes("gh")
+
+	it("matches the bare invocation", () => {
 		expect(m(bash("gh pr list"))).toBe(true)
 	})
 
-	it("matches the prefix after a separator", () => {
-		const m = bashStartsWith("gh")
+	it("matches across pipeline / sequence / subshell stages", () => {
 		expect(m(bash("cd /tmp && gh pr list"))).toBe(true)
 		expect(m(bash("ls; gh pr list"))).toBe(true)
 		expect(m(bash("foo || gh pr list"))).toBe(true)
+		expect(m(bash("cmd|gh pr list"))).toBe(true)
+		expect(m(bash("for x in $(gh pr list); do echo $x; done"))).toBe(true)
+		expect(m(bash("(gh pr list)"))).toBe(true)
+		expect(m(bash("`gh pr list`"))).toBe(true)
 	})
 
-	it("does not match unrelated commands that contain the prefix as a substring", () => {
-		const m = bashStartsWith("gh")
+	it("matches after env-var prefixes", () => {
+		expect(m(bash("GH_TOKEN=xxx gh pr list"))).toBe(true)
+		expect(m(bash("FOO=1 BAR=2 gh pr list"))).toBe(true)
+	})
+
+	it("does not match substrings inside string literals", () => {
+		expect(m(bash('echo "gh is great"'))).toBe(false)
+		expect(m(bash("echo 'gh foo'"))).toBe(false)
+		expect(m(bash("echo gh"))).toBe(false)
+	})
+
+	it("does not match comments", () => {
+		expect(m(bash("ls # gh pr list"))).toBe(false)
+	})
+
+	it("does not match unrelated commands sharing a prefix", () => {
 		expect(m(bash("git fetch"))).toBe(false)
 		expect(m(bash("ghost --help"))).toBe(false)
+		expect(m(bash("ghi"))).toBe(false)
 	})
 
-	it("escapes regex metacharacters in the prefix", () => {
-		const m = bashStartsWith("a.b")
-		expect(m(bash("a.b run"))).toBe(true)
-		expect(m(bash("aXb run"))).toBe(false)
+	it("does not match heredoc bodies", () => {
+		expect(m(bash("cat <<EOF\ngh pr list\nEOF\n"))).toBe(false)
+		expect(m(bash("cat <<-END\n\tgh pr list\n\tEND\n"))).toBe(false)
+	})
+
+	it("matches bare executable with no args", () => {
+		expect(bashInvokes("glab")(bash("glab"))).toBe(true)
 	})
 })
 

--- a/src/extensions/behaviours/matchers.test.ts
+++ b/src/extensions/behaviours/matchers.test.ts
@@ -1,0 +1,110 @@
+import { describe, expect, it } from "vitest"
+import { bashCommand, bashStartsWith, fetchesHost, webFetchUrl, webSearchQuery } from "./matchers.js"
+import type { ToolCallEvent } from "./triggers.js"
+
+function bash(command: string): ToolCallEvent {
+	return { toolName: "bash", input: { command } }
+}
+
+function webFetch(url: string): ToolCallEvent {
+	return { toolName: "web_fetch", input: { url } }
+}
+
+function webSearch(query: string): ToolCallEvent {
+	return { toolName: "web_search", input: { query } }
+}
+
+describe("bashCommand", () => {
+	it("matches when the command satisfies the regex", () => {
+		const m = bashCommand(/^ls\b/)
+		expect(m(bash("ls -la"))).toBe(true)
+		expect(m(bash("rm -rf /"))).toBe(false)
+	})
+
+	it("matches when the predicate returns true", () => {
+		const m = bashCommand((c) => c.includes("danger"))
+		expect(m(bash("./danger.sh"))).toBe(true)
+		expect(m(bash("./safe.sh"))).toBe(false)
+	})
+
+	it("does not match other tools", () => {
+		expect(bashCommand(/.*/)(webFetch("https://x"))).toBe(false)
+	})
+})
+
+describe("bashStartsWith", () => {
+	it("matches the bare prefix", () => {
+		const m = bashStartsWith("gh")
+		expect(m(bash("gh pr list"))).toBe(true)
+	})
+
+	it("matches the prefix after a separator", () => {
+		const m = bashStartsWith("gh")
+		expect(m(bash("cd /tmp && gh pr list"))).toBe(true)
+		expect(m(bash("ls; gh pr list"))).toBe(true)
+		expect(m(bash("foo || gh pr list"))).toBe(true)
+	})
+
+	it("does not match unrelated commands that contain the prefix as a substring", () => {
+		const m = bashStartsWith("gh")
+		expect(m(bash("git fetch"))).toBe(false)
+		expect(m(bash("ghost --help"))).toBe(false)
+	})
+
+	it("escapes regex metacharacters in the prefix", () => {
+		const m = bashStartsWith("a.b")
+		expect(m(bash("a.b run"))).toBe(true)
+		expect(m(bash("aXb run"))).toBe(false)
+	})
+})
+
+describe("webFetchUrl", () => {
+	it("matches when the url satisfies the regex", () => {
+		const m = webFetchUrl(/github\.com/)
+		expect(m(webFetch("https://github.com/owner/repo"))).toBe(true)
+		expect(m(webFetch("https://example.com/"))).toBe(false)
+	})
+
+	it("does not match other tools", () => {
+		expect(webFetchUrl(/.*/)(bash("anything"))).toBe(false)
+	})
+})
+
+describe("webSearchQuery", () => {
+	it("matches by query regex", () => {
+		const m = webSearchQuery(/^how to/)
+		expect(m(webSearch("how to fix this"))).toBe(true)
+		expect(m(webSearch("just stuff"))).toBe(false)
+	})
+})
+
+describe("fetchesHost", () => {
+	it("matches web_fetch against the host", () => {
+		const m = fetchesHost("github.com")
+		expect(m(webFetch("https://github.com/x/y"))).toBe(true)
+		expect(m(webFetch("https://example.com"))).toBe(false)
+	})
+
+	it("matches bash curl against the host", () => {
+		const m = fetchesHost("github.com")
+		expect(m(bash("curl https://api.github.com/repos/x"))).toBe(true)
+		expect(m(bash("curl https://example.com"))).toBe(false)
+	})
+
+	it("matches bash wget against the host", () => {
+		const m = fetchesHost("github.com")
+		expect(m(bash("wget https://github.com/x.tar.gz"))).toBe(true)
+	})
+
+	it("does not match bash that mentions the host without curl/wget", () => {
+		const m = fetchesHost("github.com")
+		expect(m(bash("echo github.com"))).toBe(false)
+	})
+
+	it("accepts a RegExp host pattern for fuzzier matches", () => {
+		const m = fetchesHost(/(api\.)?github\.com/)
+		expect(m(webFetch("https://api.github.com/repos"))).toBe(true)
+		expect(m(webFetch("https://github.com/x"))).toBe(true)
+		expect(m(webFetch("https://gitlab.com/x"))).toBe(false)
+	})
+})

--- a/src/extensions/behaviours/matchers.ts
+++ b/src/extensions/behaviours/matchers.ts
@@ -1,0 +1,61 @@
+/**
+ * High-level matchers built on top of `tool(...)`.
+ *
+ * Behaviour authors should reach for these first; they encode the patterns
+ * that come up repeatedly (bash command regex, web_fetch URL regex, "fetched
+ * this host by any means"). Drop down to the raw `tool(...)` factory only
+ * when no helper fits.
+ *
+ * Every helper accepts a `RegExp` or a `(field: string) => boolean` predicate
+ * over the relevant string field of the tool input. Authors never type the
+ * full input shape themselves.
+ */
+
+import { type ToolMatcher, any, tool } from "./triggers.js"
+
+/** A condition over a single string field. RegExp form is the common case. */
+export type StringCondition = RegExp | ((value: string) => boolean)
+
+/** Match a `bash` tool call whose `command` matches `condition`. */
+export function bashCommand(condition: StringCondition): ToolMatcher {
+	return tool("bash", (input) => testString(condition, input.command))
+}
+
+/** Match a `bash` tool call whose `command` starts with `prefix` (`gh`, `glab`, …). */
+export function bashStartsWith(prefix: string): ToolMatcher {
+	const re = new RegExp(`(^|\\s|;|&&|\\|\\|)${escapeRegex(prefix)}(\\s|$)`)
+	return bashCommand(re)
+}
+
+/** Match a `web_fetch` tool call whose `url` matches `condition`. */
+export function webFetchUrl(condition: StringCondition): ToolMatcher {
+	return tool("web_fetch", (input) => testString(condition, input.url))
+}
+
+/** Match a `web_search` tool call whose `query` matches `condition`. */
+export function webSearchQuery(condition: StringCondition): ToolMatcher {
+	return tool("web_search", (input) => testString(condition, input.query))
+}
+
+/**
+ * Match any tool call that fetches a URL whose host matches `hostPattern` —
+ * `web_fetch` directly, or `bash` invoking `curl`/`wget` against that host.
+ *
+ * Pass a domain string (`"github.com"`) for an exact host match, or a RegExp
+ * for fuzzier matching (`/(api\.)?github\.com/`).
+ */
+export function fetchesHost(hostPattern: string | RegExp): ToolMatcher {
+	const hostRe = typeof hostPattern === "string" ? new RegExp(`\\b${escapeRegex(hostPattern)}\\b`) : hostPattern
+	return any(
+		bashCommand((command) => /\b(?:curl|wget)\b/.test(command) && hostRe.test(command)),
+		webFetchUrl(hostRe),
+	)
+}
+
+function testString(condition: StringCondition, value: string): boolean {
+	return condition instanceof RegExp ? condition.test(value) : condition(value)
+}
+
+function escapeRegex(s: string): string {
+	return s.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")
+}

--- a/src/extensions/behaviours/matchers.ts
+++ b/src/extensions/behaviours/matchers.ts
@@ -12,7 +12,7 @@
  */
 
 import { bashInvokesCommand } from "./bash-tokenize.js"
-import { type ToolMatcher, any, tool } from "./triggers.js"
+import { type ToolMatcher, all, any, tool } from "./triggers.js"
 
 /** A condition over a single string field. RegExp form is the common case. */
 export type StringCondition = RegExp | ((value: string) => boolean)
@@ -50,13 +50,14 @@ export function webSearchQuery(condition: StringCondition): ToolMatcher {
  *
  * Pass a domain string (`"github.com"`) for an exact host match, or a RegExp
  * for fuzzier matching (`/(api\.)?github\.com/`).
+ *
+ * The bash branch routes through the shell tokeniser (`bashInvokes`) rather
+ * than a raw regex, so `# curl github.com` (comment) and `echo curl github.com`
+ * (curl mentioned but not invoked) do not trigger.
  */
 export function fetchesHost(hostPattern: string | RegExp): ToolMatcher {
 	const hostRe = typeof hostPattern === "string" ? new RegExp(`\\b${escapeRegex(hostPattern)}\\b`) : hostPattern
-	return any(
-		bashCommand((command) => /\b(?:curl|wget)\b/.test(command) && hostRe.test(command)),
-		webFetchUrl(hostRe),
-	)
+	return any(all(any(bashInvokes("curl"), bashInvokes("wget")), bashCommand(hostRe)), webFetchUrl(hostRe))
 }
 
 function testString(condition: StringCondition, value: string): boolean {

--- a/src/extensions/behaviours/matchers.ts
+++ b/src/extensions/behaviours/matchers.ts
@@ -11,6 +11,7 @@
  * full input shape themselves.
  */
 
+import { bashInvokesCommand } from "./bash-tokenize.js"
 import { type ToolMatcher, any, tool } from "./triggers.js"
 
 /** A condition over a single string field. RegExp form is the common case. */
@@ -21,10 +22,16 @@ export function bashCommand(condition: StringCondition): ToolMatcher {
 	return tool("bash", (input) => testString(condition, input.command))
 }
 
-/** Match a `bash` tool call whose `command` starts with `prefix` (`gh`, `glab`, …). */
-export function bashStartsWith(prefix: string): ToolMatcher {
-	const re = new RegExp(`(^|\\s|;|&&|\\|\\|)${escapeRegex(prefix)}(\\s|$)`)
-	return bashCommand(re)
+/**
+ * Match a `bash` tool call that invokes `executable` as a program in any
+ * stage of the command (pipeline, sequence, subshell, command substitution).
+ *
+ * Uses a shell tokeniser, so substring matches inside string literals,
+ * comments, and heredoc bodies do not trigger; env-var prefixes
+ * (`FOO=bar gh ...`) and pipelines (`cmd | gh ...`) do.
+ */
+export function bashInvokes(executable: string): ToolMatcher {
+	return bashCommand((command) => bashInvokesCommand(command, executable))
 }
 
 /** Match a `web_fetch` tool call whose `url` matches `condition`. */

--- a/src/extensions/behaviours/registry.ts
+++ b/src/extensions/behaviours/registry.ts
@@ -13,21 +13,33 @@
 import ghCliBody from "./bodies/gh-cli.md" with { type: "text" }
 import gitHygieneBody from "./bodies/git-hygiene.md" with { type: "text" }
 import { parseBehaviourBody } from "./frontmatter.js"
+import { bashStartsWith, fetchesHost } from "./matchers.js"
 import { any, cli, gitRemote } from "./triggers.js"
-import type { Behaviour, BehaviourKind, BehaviourTriggers } from "./types.js"
+import type { Behaviour, BehaviourEvals, BehaviourKind, BehaviourTriggers } from "./types.js"
 
 interface BehaviourSource {
 	raw: string
 	kind: BehaviourKind
 	triggers?: BehaviourTriggers
+	evals?: BehaviourEvals
 }
+
+const ghInvocation = bashStartsWith("gh")
+const githubFromOtherTool = fetchesHost(/(api\.)?github\.com/)
 
 const sources: BehaviourSource[] = [
 	{ raw: gitHygieneBody, kind: "baseline" },
 	{
 		raw: ghCliBody,
 		kind: "triggered",
-		triggers: { session: any(cli("gh"), gitRemote("github.com")) },
+		triggers: {
+			session: any(cli("gh"), gitRemote("github.com")),
+			tool: ghInvocation,
+		},
+		evals: {
+			observed: ghInvocation,
+			violated: githubFromOtherTool,
+		},
 	},
 ]
 
@@ -47,6 +59,7 @@ export const behaviours: readonly Behaviour[] = (() => {
 			body: parsed.content,
 			kind: src.kind,
 			triggers: src.triggers,
+			evals: src.evals,
 		})
 	}
 	return result

--- a/src/extensions/behaviours/registry.ts
+++ b/src/extensions/behaviours/registry.ts
@@ -5,9 +5,10 @@
  * its kind — `baseline` bodies merge into the system prompt unconditionally,
  * `triggered` bodies stay dormant until their triggers fire.
  *
- * The IIFE at module load validates the registry: every body parses, every
- * name is unique. Adding a new behaviour requires only appending another
- * `BehaviourSource` entry below.
+ * `buildBehaviours` validates the registry at module load: every body parses,
+ * every name is unique, every triggered source has at least one trigger.
+ * Adding a new behaviour requires only appending another `BehaviourSource`
+ * entry below.
  */
 
 import boundToolOutputBody from "./bodies/bound-tool-output.md" with { type: "text" }

--- a/src/extensions/behaviours/registry.ts
+++ b/src/extensions/behaviours/registry.ts
@@ -18,18 +18,30 @@ import glabCliBody from "./bodies/glab-cli.md" with { type: "text" }
 import pythonEditBody from "./bodies/python-edit.md" with { type: "text" }
 import { type BehaviourSource, buildBehaviours } from "./build.js"
 import { bashInvokes, fetchesHost } from "./matchers.js"
-import { any, cli, gitRemote } from "./triggers.js"
+import { any, cli, gitRemote, gitRepo, tool } from "./triggers.js"
 import type { Behaviour } from "./types.js"
 
 const ghInvocation = bashInvokes("gh")
 const githubFromOtherTool = fetchesHost(/(api\.)?github\.com/)
 const glabInvocation = bashInvokes("glab")
 const gitlabFromOtherTool = fetchesHost(/(.+\.)?gitlab\.com/)
+const pythonFileEdit = any(
+	tool("edit", (i) => i.path.endsWith(".py")),
+	tool("write", (i) => i.path.endsWith(".py")),
+)
 
 const sources: BehaviourSource[] = [
-	{ raw: gitHygieneBody, kind: "baseline" },
-	{ raw: pythonEditBody, kind: "baseline" },
 	{ raw: boundToolOutputBody, kind: "baseline" },
+	{
+		raw: gitHygieneBody,
+		kind: "triggered",
+		triggers: { session: gitRepo() },
+	},
+	{
+		raw: pythonEditBody,
+		kind: "triggered",
+		triggers: { tool: pythonFileEdit },
+	},
 	{
 		raw: ghCliBody,
 		kind: "triggered",

--- a/src/extensions/behaviours/registry.ts
+++ b/src/extensions/behaviours/registry.ts
@@ -3,22 +3,33 @@
  *
  * Each entry pairs a markdown body (imported as text by Bun's bundler) with
  * its kind — `baseline` bodies merge into the system prompt unconditionally,
- * `triggered` bodies stay dormant until phases 2+ wire trigger evaluation.
+ * `triggered` bodies stay dormant until their triggers fire.
  *
- * The IIFE at module load validates the registry. Adding a new behaviour
- * requires only appending another `{ raw, kind }` entry below.
+ * The IIFE at module load validates the registry: every body parses, every
+ * name is unique. Adding a new behaviour requires only appending another
+ * `BehaviourSource` entry below.
  */
 
+import ghCliBody from "./bodies/gh-cli.md" with { type: "text" }
 import gitHygieneBody from "./bodies/git-hygiene.md" with { type: "text" }
 import { parseBehaviourBody } from "./frontmatter.js"
-import type { Behaviour, BehaviourKind } from "./types.js"
+import { any, cli, gitRemote } from "./triggers.js"
+import type { Behaviour, BehaviourKind, BehaviourTriggers } from "./types.js"
 
 interface BehaviourSource {
 	raw: string
 	kind: BehaviourKind
+	triggers?: BehaviourTriggers
 }
 
-const sources: BehaviourSource[] = [{ raw: gitHygieneBody, kind: "baseline" }]
+const sources: BehaviourSource[] = [
+	{ raw: gitHygieneBody, kind: "baseline" },
+	{
+		raw: ghCliBody,
+		kind: "triggered",
+		triggers: { session: any(cli("gh"), gitRemote("github.com")) },
+	},
+]
 
 export const behaviours: readonly Behaviour[] = (() => {
 	const result: Behaviour[] = []
@@ -30,7 +41,13 @@ export const behaviours: readonly Behaviour[] = (() => {
 			throw new Error(`duplicate bundled behaviour name: ${name}`)
 		}
 		seen.add(name)
-		result.push({ name, description, body: parsed.content, kind: src.kind })
+		result.push({
+			name,
+			description,
+			body: parsed.content,
+			kind: src.kind,
+			triggers: src.triggers,
+		})
 	}
 	return result
 })()

--- a/src/extensions/behaviours/registry.ts
+++ b/src/extensions/behaviours/registry.ts
@@ -10,25 +10,25 @@
  * `BehaviourSource` entry below.
  */
 
+import boundToolOutputBody from "./bodies/bound-tool-output.md" with { type: "text" }
 import ghCliBody from "./bodies/gh-cli.md" with { type: "text" }
 import gitHygieneBody from "./bodies/git-hygiene.md" with { type: "text" }
-import { parseBehaviourBody } from "./frontmatter.js"
-import { bashStartsWith, fetchesHost } from "./matchers.js"
+import glabCliBody from "./bodies/glab-cli.md" with { type: "text" }
+import pythonEditBody from "./bodies/python-edit.md" with { type: "text" }
+import { type BehaviourSource, buildBehaviours } from "./build.js"
+import { bashInvokes, fetchesHost } from "./matchers.js"
 import { any, cli, gitRemote } from "./triggers.js"
-import type { Behaviour, BehaviourEvals, BehaviourKind, BehaviourTriggers } from "./types.js"
+import type { Behaviour } from "./types.js"
 
-interface BehaviourSource {
-	raw: string
-	kind: BehaviourKind
-	triggers?: BehaviourTriggers
-	evals?: BehaviourEvals
-}
-
-const ghInvocation = bashStartsWith("gh")
+const ghInvocation = bashInvokes("gh")
 const githubFromOtherTool = fetchesHost(/(api\.)?github\.com/)
+const glabInvocation = bashInvokes("glab")
+const gitlabFromOtherTool = fetchesHost(/(.+\.)?gitlab\.com/)
 
 const sources: BehaviourSource[] = [
 	{ raw: gitHygieneBody, kind: "baseline" },
+	{ raw: pythonEditBody, kind: "baseline" },
+	{ raw: boundToolOutputBody, kind: "baseline" },
 	{
 		raw: ghCliBody,
 		kind: "triggered",
@@ -41,26 +41,18 @@ const sources: BehaviourSource[] = [
 			violated: githubFromOtherTool,
 		},
 	},
+	{
+		raw: glabCliBody,
+		kind: "triggered",
+		triggers: {
+			session: any(cli("glab"), gitRemote("gitlab.com")),
+			tool: glabInvocation,
+		},
+		evals: {
+			observed: glabInvocation,
+			violated: gitlabFromOtherTool,
+		},
+	},
 ]
 
-export const behaviours: readonly Behaviour[] = (() => {
-	const result: Behaviour[] = []
-	const seen = new Set<string>()
-	for (const src of sources) {
-		const parsed = parseBehaviourBody(src.raw)
-		const { name, description } = parsed.frontmatter
-		if (seen.has(name)) {
-			throw new Error(`duplicate bundled behaviour name: ${name}`)
-		}
-		seen.add(name)
-		result.push({
-			name,
-			description,
-			body: parsed.content,
-			kind: src.kind,
-			triggers: src.triggers,
-			evals: src.evals,
-		})
-	}
-	return result
-})()
+export const behaviours: readonly Behaviour[] = buildBehaviours(sources)

--- a/src/extensions/behaviours/registry.ts
+++ b/src/extensions/behaviours/registry.ts
@@ -1,0 +1,36 @@
+/**
+ * Bundled behaviour registry.
+ *
+ * Each entry pairs a markdown body (imported as text by Bun's bundler) with
+ * its kind — `baseline` bodies merge into the system prompt unconditionally,
+ * `triggered` bodies stay dormant until phases 2+ wire trigger evaluation.
+ *
+ * The IIFE at module load validates the registry. Adding a new behaviour
+ * requires only appending another `{ raw, kind }` entry below.
+ */
+
+import gitHygieneBody from "./bodies/git-hygiene.md" with { type: "text" }
+import { parseBehaviourBody } from "./frontmatter.js"
+import type { Behaviour, BehaviourKind } from "./types.js"
+
+interface BehaviourSource {
+	raw: string
+	kind: BehaviourKind
+}
+
+const sources: BehaviourSource[] = [{ raw: gitHygieneBody, kind: "baseline" }]
+
+export const behaviours: readonly Behaviour[] = (() => {
+	const result: Behaviour[] = []
+	const seen = new Set<string>()
+	for (const src of sources) {
+		const parsed = parseBehaviourBody(src.raw)
+		const { name, description } = parsed.frontmatter
+		if (seen.has(name)) {
+			throw new Error(`duplicate bundled behaviour name: ${name}`)
+		}
+		seen.add(name)
+		result.push({ name, description, body: parsed.content, kind: src.kind })
+	}
+	return result
+})()

--- a/src/extensions/behaviours/session-context.test.ts
+++ b/src/extensions/behaviours/session-context.test.ts
@@ -1,0 +1,189 @@
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
+import { afterEach, beforeEach, describe, expect, it } from "vitest"
+import {
+	type ResolverIO,
+	collectProbes,
+	parseRemoteHost,
+	resolveSessionContext,
+	walkAndMatch,
+} from "./session-context.js"
+import { path, all, any, cli, gitRemote } from "./triggers.js"
+
+describe("parseRemoteHost", () => {
+	const cases: Array<{ url: string; expected: string | undefined }> = [
+		{ url: "git@github.com:owner/repo.git", expected: "github.com" },
+		{ url: "git@gitlab.com:group/sub/repo.git", expected: "gitlab.com" },
+		{ url: "https://github.com/owner/repo.git", expected: "github.com" },
+		{ url: "https://user:token@gitlab.com/owner/repo", expected: "gitlab.com" },
+		{ url: "ssh://git@github.com/owner/repo.git", expected: "github.com" },
+		{ url: "", expected: undefined },
+		{ url: "not-a-url", expected: undefined },
+	]
+	for (const { url, expected } of cases) {
+		it(`parses ${JSON.stringify(url)}`, () => {
+			expect(parseRemoteHost(url)).toBe(expected)
+		})
+	}
+})
+
+describe("walkAndMatch", () => {
+	let cwd: string
+
+	beforeEach(() => {
+		cwd = mkdtempSync(join(tmpdir(), "kimchi-walk-"))
+	})
+
+	afterEach(() => {
+		rmSync(cwd, { recursive: true, force: true })
+	})
+
+	function touch(rel: string): void {
+		const abs = join(cwd, rel)
+		mkdirSync(join(abs, ".."), { recursive: true })
+		writeFileSync(abs, "")
+	}
+
+	it("matches a file at depth 1", () => {
+		touch("setup.py")
+		const matches = walkAndMatch(cwd, new Set(["**/*.py"]), 3)
+		expect([...matches]).toEqual(["**/*.py"])
+	})
+
+	it("matches a file at depth 2", () => {
+		touch("src/app.py")
+		const matches = walkAndMatch(cwd, new Set(["**/*.py"]), 3)
+		expect([...matches]).toEqual(["**/*.py"])
+	})
+
+	it("matches a file at depth 3", () => {
+		touch("src/pkg/mod.py")
+		const matches = walkAndMatch(cwd, new Set(["**/*.py"]), 3)
+		expect([...matches]).toEqual(["**/*.py"])
+	})
+
+	it("does not match a file buried at depth 4", () => {
+		touch("src/pkg/deep/mod.py")
+		const matches = walkAndMatch(cwd, new Set(["**/*.py"]), 3)
+		expect(matches.size).toBe(0)
+	})
+
+	it("returns empty when no file matches", () => {
+		touch("README.md")
+		touch("src/index.ts")
+		const matches = walkAndMatch(cwd, new Set(["**/*.py"]), 3)
+		expect(matches.size).toBe(0)
+	})
+
+	it("ignores files inside the standard ignore list", () => {
+		touch("node_modules/some-pkg/index.py")
+		touch(".git/hooks/pre-commit.py")
+		touch("dist/bundle.py")
+		touch("__pycache__/x.py")
+		const matches = walkAndMatch(cwd, new Set(["**/*.py"]), 3)
+		expect(matches.size).toBe(0)
+	})
+
+	it("matches multiple distinct globs in a single walk", () => {
+		touch("pyproject.toml")
+		touch("Cargo.toml")
+		const matches = walkAndMatch(cwd, new Set(["pyproject.toml", "Cargo.toml"]), 3)
+		expect(matches.has("pyproject.toml")).toBe(true)
+		expect(matches.has("Cargo.toml")).toBe(true)
+	})
+
+	it("returns empty when the cwd does not exist", () => {
+		const missing = join(cwd, "nope")
+		const matches = walkAndMatch(missing, new Set(["**/*"]), 3)
+		expect(matches.size).toBe(0)
+	})
+})
+
+describe("collectProbes", () => {
+	it("flattens nested any/all combinators into leaf probes", () => {
+		const probe = any(cli("gh"), all(gitRemote("github.com"), path("**/*.py")))
+		const probes = collectProbes([probe.__spec])
+		expect([...probes.cliCommands]).toEqual(["gh"])
+		expect(probes.needGitRemote).toBe(true)
+		expect([...probes.pathGlobs]).toEqual(["**/*.py"])
+	})
+
+	it("deduplicates probes shared across behaviours", () => {
+		const a = any(cli("gh"))
+		const b = any(cli("gh"), cli("glab"))
+		const probes = collectProbes([a.__spec, b.__spec])
+		expect([...probes.cliCommands].sort()).toEqual(["gh", "glab"])
+	})
+
+	it("never flags gitRemote when no behaviour declares it", () => {
+		const probes = collectProbes([cli("gh").__spec])
+		expect(probes.needGitRemote).toBe(false)
+	})
+})
+
+describe("resolveSessionContext", () => {
+	function fakeIO(opts: {
+		clis?: ReadonlySet<string>
+		gitRemoteHost?: string | undefined
+		paths?: ReadonlySet<string>
+	}): ResolverIO {
+		const clis = opts.clis ?? new Set<string>()
+		const paths = opts.paths ?? new Set<string>()
+		return {
+			hasCli: (name) => clis.has(name),
+			readGitRemoteHost: () => opts.gitRemoteHost,
+			walkPaths: (_cwd, globs) => {
+				const out = new Set<string>()
+				for (const g of globs) if (paths.has(g)) out.add(g)
+				return out
+			},
+		}
+	}
+
+	it("flags only present CLIs", () => {
+		const probe = any(cli("gh"), cli("glab"))
+		const ctx = resolveSessionContext([probe.__spec], "/x", fakeIO({ clis: new Set(["gh"]) }))
+		expect([...ctx.cliPresent]).toEqual(["gh"])
+		expect(probe(ctx)).toBe(true)
+	})
+
+	it("returns undefined gitRemoteHost when no remote is configured", () => {
+		const probe = gitRemote("github.com")
+		const ctx = resolveSessionContext([probe.__spec], "/x", fakeIO({ gitRemoteHost: undefined }))
+		expect(ctx.gitRemoteHost).toBeUndefined()
+		expect(probe(ctx)).toBe(false)
+	})
+
+	it("matches a github remote", () => {
+		const probe = gitRemote("github.com")
+		const ctx = resolveSessionContext([probe.__spec], "/x", fakeIO({ gitRemoteHost: "github.com" }))
+		expect(probe(ctx)).toBe(true)
+	})
+
+	it("does not match a gitlab remote when probing for github", () => {
+		const probe = gitRemote("github.com")
+		const ctx = resolveSessionContext([probe.__spec], "/x", fakeIO({ gitRemoteHost: "gitlab.com" }))
+		expect(probe(ctx)).toBe(false)
+	})
+
+	it("skips the git probe entirely when no behaviour declares one", () => {
+		let called = false
+		const ctx = resolveSessionContext([cli("gh").__spec], "/x", {
+			hasCli: () => false,
+			readGitRemoteHost: () => {
+				called = true
+				return "github.com"
+			},
+			walkPaths: () => new Set(),
+		})
+		expect(called).toBe(false)
+		expect(ctx.gitRemoteHost).toBeUndefined()
+	})
+
+	it("propagates path matches into the SessionContext", () => {
+		const probe = path("**/*.py")
+		const ctx = resolveSessionContext([probe.__spec], "/x", fakeIO({ paths: new Set(["**/*.py"]) }))
+		expect(probe(ctx)).toBe(true)
+	})
+})

--- a/src/extensions/behaviours/session-context.test.ts
+++ b/src/extensions/behaviours/session-context.test.ts
@@ -126,6 +126,7 @@ describe("resolveSessionContext", () => {
 	function fakeIO(opts: {
 		clis?: ReadonlySet<string>
 		gitRemoteHost?: string | undefined
+		inGitRepo?: boolean
 		paths?: ReadonlySet<string>
 	}): ResolverIO {
 		const clis = opts.clis ?? new Set<string>()
@@ -133,6 +134,7 @@ describe("resolveSessionContext", () => {
 		return {
 			hasCli: (name) => clis.has(name),
 			readGitRemoteHost: () => opts.gitRemoteHost,
+			isGitRepo: () => opts.inGitRepo ?? false,
 			walkPaths: (_cwd, globs) => {
 				const out = new Set<string>()
 				for (const g of globs) if (paths.has(g)) out.add(g)
@@ -175,6 +177,7 @@ describe("resolveSessionContext", () => {
 				called = true
 				return "github.com"
 			},
+			isGitRepo: () => false,
 			walkPaths: () => new Set(),
 		})
 		expect(called).toBe(false)

--- a/src/extensions/behaviours/session-context.ts
+++ b/src/extensions/behaviours/session-context.ts
@@ -16,7 +16,7 @@
 
 import { execFileSync } from "node:child_process"
 import type { Dirent } from "node:fs"
-import { readdirSync } from "node:fs"
+import { existsSync, readdirSync } from "node:fs"
 import { join } from "node:path"
 import micromatch from "micromatch"
 import { type ProbeSpec, walkLeaves } from "./triggers.js"
@@ -24,6 +24,7 @@ import { type ProbeSpec, walkLeaves } from "./triggers.js"
 export interface SessionContext {
 	readonly cliPresent: ReadonlySet<string>
 	readonly gitRemoteHost: string | undefined
+	readonly inGitRepo: boolean
 	readonly pathMatches: ReadonlySet<string>
 }
 
@@ -41,6 +42,7 @@ export const PATH_IGNORED_DIRS: ReadonlySet<string> = new Set([
 export interface ResolverProbes {
 	cliCommands: ReadonlySet<string>
 	needGitRemote: boolean
+	needGitRepo: boolean
 	pathGlobs: ReadonlySet<string>
 }
 
@@ -48,19 +50,22 @@ export function collectProbes(specs: Iterable<ProbeSpec>): ResolverProbes {
 	const cliCommands = new Set<string>()
 	const pathGlobs = new Set<string>()
 	let needGitRemote = false
+	let needGitRepo = false
 	for (const spec of specs) {
 		walkLeaves(spec, (leaf) => {
 			if (leaf.kind === "cli") cliCommands.add(leaf.name)
 			else if (leaf.kind === "gitRemote") needGitRemote = true
+			else if (leaf.kind === "gitRepo") needGitRepo = true
 			else if (leaf.kind === "path") pathGlobs.add(leaf.glob)
 		})
 	}
-	return { cliCommands, needGitRemote, pathGlobs }
+	return { cliCommands, needGitRemote, needGitRepo, pathGlobs }
 }
 
 export interface ResolverIO {
 	hasCli(name: string): boolean
 	readGitRemoteHost(cwd: string): string | undefined
+	isGitRepo(cwd: string): boolean
 	walkPaths(cwd: string, globs: ReadonlySet<string>): Set<string>
 }
 
@@ -84,6 +89,11 @@ export const defaultResolverIO: ResolverIO = {
 		} catch {
 			return undefined
 		}
+	},
+	isGitRepo(cwd: string): boolean {
+		// `.git` is a directory in a normal repo and a regular file in a linked
+		// worktree or submodule — `existsSync` covers both without a subprocess.
+		return existsSync(join(cwd, ".git"))
 	},
 	walkPaths(cwd, globs) {
 		return walkAndMatch(cwd, globs, PATH_DEPTH_CAP)
@@ -148,12 +158,13 @@ export function resolveSessionContext(
 	cwd: string,
 	io: ResolverIO = defaultResolverIO,
 ): SessionContext {
-	const { cliCommands, needGitRemote, pathGlobs } = collectProbes(specs)
+	const { cliCommands, needGitRemote, needGitRepo, pathGlobs } = collectProbes(specs)
 	const cliPresent = new Set<string>()
 	for (const name of cliCommands) {
 		if (io.hasCli(name)) cliPresent.add(name)
 	}
 	const gitRemoteHost = needGitRemote ? io.readGitRemoteHost(cwd) : undefined
+	const inGitRepo = needGitRepo ? io.isGitRepo(cwd) : false
 	const pathMatches = io.walkPaths(cwd, pathGlobs)
-	return { cliPresent, gitRemoteHost, pathMatches }
+	return { cliPresent, gitRemoteHost, inGitRepo, pathMatches }
 }

--- a/src/extensions/behaviours/session-context.ts
+++ b/src/extensions/behaviours/session-context.ts
@@ -1,0 +1,159 @@
+/**
+ * SessionContext — immutable snapshot of session-time facts probed once at
+ * session start. Subsequent reads by trigger predicates are pure lookups.
+ *
+ * Probes:
+ * - `cli(name)` — true iff `name` is found on PATH (`which`).
+ * - `gitRemote(host)` — true iff the host of `git remote get-url origin`
+ *   matches.
+ * - `path(glob)` — true iff at least one file under cwd matches the glob,
+ *   walking up to `PATH_DEPTH_CAP` and skipping `PATH_IGNORED_DIRS`.
+ *
+ * The resolver collects the leaf probes declared by all behaviours and runs
+ * each kind at most once. IO is injected so tests can stub `which` / git
+ * without mocking subprocesses.
+ */
+
+import { execFileSync } from "node:child_process"
+import type { Dirent } from "node:fs"
+import { readdirSync } from "node:fs"
+import { join } from "node:path"
+import micromatch from "micromatch"
+import { type ProbeSpec, walkLeaves } from "./triggers.js"
+
+export interface SessionContext {
+	readonly cliPresent: ReadonlySet<string>
+	readonly gitRemoteHost: string | undefined
+	readonly pathMatches: ReadonlySet<string>
+}
+
+export const PATH_DEPTH_CAP = 3
+export const PATH_IGNORED_DIRS: ReadonlySet<string> = new Set([
+	"node_modules",
+	".git",
+	"dist",
+	"build",
+	".venv",
+	"__pycache__",
+	"target",
+])
+
+export interface ResolverProbes {
+	cliCommands: ReadonlySet<string>
+	needGitRemote: boolean
+	pathGlobs: ReadonlySet<string>
+}
+
+export function collectProbes(specs: Iterable<ProbeSpec>): ResolverProbes {
+	const cliCommands = new Set<string>()
+	const pathGlobs = new Set<string>()
+	let needGitRemote = false
+	for (const spec of specs) {
+		walkLeaves(spec, (leaf) => {
+			if (leaf.kind === "cli") cliCommands.add(leaf.name)
+			else if (leaf.kind === "gitRemote") needGitRemote = true
+			else if (leaf.kind === "path") pathGlobs.add(leaf.glob)
+		})
+	}
+	return { cliCommands, needGitRemote, pathGlobs }
+}
+
+export interface ResolverIO {
+	hasCli(name: string): boolean
+	readGitRemoteHost(cwd: string): string | undefined
+	walkPaths(cwd: string, globs: ReadonlySet<string>): Set<string>
+}
+
+export const defaultResolverIO: ResolverIO = {
+	hasCli(name: string): boolean {
+		try {
+			execFileSync("which", [name], { stdio: "ignore" })
+			return true
+		} catch {
+			return false
+		}
+	},
+	readGitRemoteHost(cwd: string): string | undefined {
+		try {
+			const url = execFileSync("git", ["remote", "get-url", "origin"], {
+				cwd,
+				encoding: "utf8",
+				stdio: ["ignore", "pipe", "ignore"],
+			}).trim()
+			return parseRemoteHost(url)
+		} catch {
+			return undefined
+		}
+	},
+	walkPaths(cwd, globs) {
+		return walkAndMatch(cwd, globs, PATH_DEPTH_CAP)
+	},
+}
+
+/** Extract the hostname from an ssh-form (`git@host:owner/repo`) or http(s) git remote URL. */
+export function parseRemoteHost(url: string): string | undefined {
+	if (!url) return undefined
+	const ssh = /^[^@\s]+@([^:]+):/.exec(url)
+	if (ssh) return ssh[1]
+	try {
+		return new URL(url).host || undefined
+	} catch {
+		return undefined
+	}
+}
+
+/**
+ * Walk `cwd` up to `depthCap` levels deep, returning the subset of `globs`
+ * that match at least one file. Stops as soon as every glob has matched.
+ */
+export function walkAndMatch(cwd: string, globs: ReadonlySet<string>, depthCap: number): Set<string> {
+	const matched = new Set<string>()
+	if (globs.size === 0) return matched
+	const remaining = new Set(globs)
+
+	function visit(absDir: string, relDir: string, depth: number): void {
+		if (depth > depthCap) return
+		if (remaining.size === 0) return
+		let entries: Dirent[]
+		try {
+			entries = readdirSync(absDir, { withFileTypes: true })
+		} catch {
+			return
+		}
+		for (const entry of entries) {
+			if (remaining.size === 0) return
+			const relPath = relDir === "" ? entry.name : `${relDir}/${entry.name}`
+			if (entry.isDirectory()) {
+				if (PATH_IGNORED_DIRS.has(entry.name)) continue
+				visit(join(absDir, entry.name), relPath, depth + 1)
+				continue
+			}
+			if (!entry.isFile()) continue
+			for (const glob of remaining) {
+				if (micromatch.isMatch(relPath, glob, { dot: true })) {
+					matched.add(glob)
+					remaining.delete(glob)
+					if (remaining.size === 0) return
+				}
+			}
+		}
+	}
+
+	visit(cwd, "", 1)
+	return matched
+}
+
+export function resolveSessionContext(
+	specs: Iterable<ProbeSpec>,
+	cwd: string,
+	io: ResolverIO = defaultResolverIO,
+): SessionContext {
+	const { cliCommands, needGitRemote, pathGlobs } = collectProbes(specs)
+	const cliPresent = new Set<string>()
+	for (const name of cliCommands) {
+		if (io.hasCli(name)) cliPresent.add(name)
+	}
+	const gitRemoteHost = needGitRemote ? io.readGitRemoteHost(cwd) : undefined
+	const pathMatches = io.walkPaths(cwd, pathGlobs)
+	return { cliPresent, gitRemoteHost, pathMatches }
+}

--- a/src/extensions/behaviours/stats.ts
+++ b/src/extensions/behaviours/stats.ts
@@ -1,13 +1,16 @@
 /**
  * Stats writer — emits behaviour-related custom JSONL entries via
- * `pi.appendEntry`. Phase 3 emits `behaviour_loaded` and `behaviour_eval`;
- * the per-session summary lands in a later phase.
+ * `pi.appendEntry`. Three entry types: `behaviour_loaded` and `behaviour_eval`
+ * are per-event; `behaviour_session_summary` is emitted once on
+ * `session_shutdown` and carries the uncapped per-behaviour totals so
+ * cross-session aggregation is a single jq pass.
  */
 
 import type { EvalVerdict, TriggerSource } from "./types.js"
 
 export const BEHAVIOUR_LOADED_TYPE = "behaviour_loaded"
 export const BEHAVIOUR_EVAL_TYPE = "behaviour_eval"
+export const BEHAVIOUR_SESSION_SUMMARY_TYPE = "behaviour_session_summary"
 
 export interface BehaviourLoadedData {
 	name: string
@@ -22,6 +25,19 @@ export interface BehaviourEvalData {
 	turnIndex: number
 	toolName: string
 	toolArgs: unknown
+}
+
+export interface BehaviourSummaryEntry {
+	name: string
+	loaded: boolean
+	loadedAtTurn?: number
+	trigger?: TriggerSource
+	observed: number
+	violated: number
+}
+
+export interface BehaviourSessionSummaryData {
+	behaviours: BehaviourSummaryEntry[]
 }
 
 export type AppendEntry = <T = unknown>(customType: string, data?: T) => void

--- a/src/extensions/behaviours/stats.ts
+++ b/src/extensions/behaviours/stats.ts
@@ -1,12 +1,13 @@
 /**
  * Stats writer — emits behaviour-related custom JSONL entries via
- * `pi.appendEntry`. Phase 2 emits only `behaviour_loaded`; eval verdicts and
- * the per-session summary land in later phases.
+ * `pi.appendEntry`. Phase 3 emits `behaviour_loaded` and `behaviour_eval`;
+ * the per-session summary lands in a later phase.
  */
 
-import type { TriggerSource } from "./types.js"
+import type { EvalVerdict, TriggerSource } from "./types.js"
 
 export const BEHAVIOUR_LOADED_TYPE = "behaviour_loaded"
+export const BEHAVIOUR_EVAL_TYPE = "behaviour_eval"
 
 export interface BehaviourLoadedData {
 	name: string
@@ -15,8 +16,20 @@ export interface BehaviourLoadedData {
 	toolArgs?: unknown
 }
 
+export interface BehaviourEvalData {
+	name: string
+	verdict: EvalVerdict
+	turnIndex: number
+	toolName: string
+	toolArgs: unknown
+}
+
 export type AppendEntry = <T = unknown>(customType: string, data?: T) => void
 
 export function emitBehaviourLoaded(append: AppendEntry, data: BehaviourLoadedData): void {
 	append<BehaviourLoadedData>(BEHAVIOUR_LOADED_TYPE, data)
+}
+
+export function emitBehaviourEval(append: AppendEntry, data: BehaviourEvalData): void {
+	append<BehaviourEvalData>(BEHAVIOUR_EVAL_TYPE, data)
 }

--- a/src/extensions/behaviours/stats.ts
+++ b/src/extensions/behaviours/stats.ts
@@ -1,15 +1,20 @@
 /**
- * Stats writer — emits behaviour-related custom JSONL entries via
- * `pi.appendEntry`. Three entry types: `behaviour_loaded` and `behaviour_eval`
- * are per-event; `behaviour_session_summary` is emitted once on
- * `session_shutdown` and carries the uncapped per-behaviour totals so
- * cross-session aggregation is a single jq pass.
+ * Stats writer — defines the behaviour-related custom JSONL entry types
+ * appended via `pi.appendEntry`. Four entry types:
+ *
+ * - `behaviour_loaded` and `behaviour_eval` are per-event.
+ * - `behaviour_requeued` fires once per compaction per behaviour, signalling
+ *   that the body was re-injected after summarisation replaced it.
+ * - `behaviour_session_summary` is emitted once on `session_shutdown` and
+ *   carries the uncapped per-behaviour totals so cross-session aggregation is
+ *   a single jq pass.
  */
 
 import type { EvalVerdict, TriggerSource } from "./types.js"
 
 export const BEHAVIOUR_LOADED_TYPE = "behaviour_loaded"
 export const BEHAVIOUR_EVAL_TYPE = "behaviour_eval"
+export const BEHAVIOUR_REQUEUED_TYPE = "behaviour_requeued"
 export const BEHAVIOUR_SESSION_SUMMARY_TYPE = "behaviour_session_summary"
 
 export interface BehaviourLoadedData {
@@ -27,6 +32,11 @@ export interface BehaviourEvalData {
 	toolArgs: unknown
 }
 
+export interface BehaviourRequeuedData {
+	name: string
+	turnIndex: number
+}
+
 export interface BehaviourSummaryEntry {
 	name: string
 	loaded: boolean
@@ -38,14 +48,4 @@ export interface BehaviourSummaryEntry {
 
 export interface BehaviourSessionSummaryData {
 	behaviours: BehaviourSummaryEntry[]
-}
-
-export type AppendEntry = <T = unknown>(customType: string, data?: T) => void
-
-export function emitBehaviourLoaded(append: AppendEntry, data: BehaviourLoadedData): void {
-	append<BehaviourLoadedData>(BEHAVIOUR_LOADED_TYPE, data)
-}
-
-export function emitBehaviourEval(append: AppendEntry, data: BehaviourEvalData): void {
-	append<BehaviourEvalData>(BEHAVIOUR_EVAL_TYPE, data)
 }

--- a/src/extensions/behaviours/stats.ts
+++ b/src/extensions/behaviours/stats.ts
@@ -1,0 +1,22 @@
+/**
+ * Stats writer — emits behaviour-related custom JSONL entries via
+ * `pi.appendEntry`. Phase 2 emits only `behaviour_loaded`; eval verdicts and
+ * the per-session summary land in later phases.
+ */
+
+import type { TriggerSource } from "./types.js"
+
+export const BEHAVIOUR_LOADED_TYPE = "behaviour_loaded"
+
+export interface BehaviourLoadedData {
+	name: string
+	trigger: TriggerSource
+	turnIndex: number
+	toolArgs?: unknown
+}
+
+export type AppendEntry = <T = unknown>(customType: string, data?: T) => void
+
+export function emitBehaviourLoaded(append: AppendEntry, data: BehaviourLoadedData): void {
+	append<BehaviourLoadedData>(BEHAVIOUR_LOADED_TYPE, data)
+}

--- a/src/extensions/behaviours/tool-args.smoke.test.ts
+++ b/src/extensions/behaviours/tool-args.smoke.test.ts
@@ -1,0 +1,34 @@
+/**
+ * Smoke test asserting that `KNOWN_TOOL_NAMES` matches the names produced by
+ * pi-coding-agent's per-tool factories. If upstream renames a built-in tool
+ * (e.g. `"bash"` → `"shell"`), this test fails so the local `ToolArgs` map
+ * can be updated before behaviour matchers silently break.
+ */
+
+import {
+	createBashToolDefinition,
+	createEditToolDefinition,
+	createFindToolDefinition,
+	createGrepToolDefinition,
+	createLsToolDefinition,
+	createReadToolDefinition,
+	createWriteToolDefinition,
+} from "@mariozechner/pi-coding-agent"
+import { describe, expect, it } from "vitest"
+import { BUILTIN_TOOL_NAMES } from "./tool-args.js"
+
+describe("BUILTIN_TOOL_NAMES", () => {
+	it("matches pi-coding-agent's built-in tool names exactly", () => {
+		const cwd = "/tmp"
+		const upstream = new Set([
+			createBashToolDefinition(cwd).name,
+			createReadToolDefinition(cwd).name,
+			createEditToolDefinition(cwd).name,
+			createWriteToolDefinition(cwd).name,
+			createGrepToolDefinition(cwd).name,
+			createFindToolDefinition(cwd).name,
+			createLsToolDefinition(cwd).name,
+		])
+		expect(new Set(BUILTIN_TOOL_NAMES)).toEqual(upstream)
+	})
+})

--- a/src/extensions/behaviours/tool-args.smoke.test.ts
+++ b/src/extensions/behaviours/tool-args.smoke.test.ts
@@ -1,8 +1,8 @@
 /**
- * Smoke test asserting that `KNOWN_TOOL_NAMES` matches the names produced by
- * pi-coding-agent's per-tool factories. If upstream renames a built-in tool
- * (e.g. `"bash"` → `"shell"`), this test fails so the local `ToolArgs` map
- * can be updated before behaviour matchers silently break.
+ * Smoke test asserting that `BUILTIN_TOOL_NAMES` matches the names produced
+ * by pi-coding-agent's per-tool factories. If upstream renames a built-in
+ * tool (e.g. `"bash"` → `"shell"`), this test fails so the local `ToolArgs`
+ * map can be updated before behaviour matchers silently break.
  */
 
 import {

--- a/src/extensions/behaviours/tool-args.ts
+++ b/src/extensions/behaviours/tool-args.ts
@@ -1,0 +1,65 @@
+/**
+ * Map of tool name → tool argument type, for the typed `tool<TName>` overload.
+ *
+ * Two sources:
+ * - Pi-coding-agent built-ins (`bash`, `read`, ...) — listed in
+ *   `BUILTIN_TOOL_NAMES`, smoke-tested against pi-coding-agent's per-tool
+ *   create functions.
+ * - Kimchi-bundled custom tools (`web_fetch`, `web_search`) — declared
+ *   locally; the harness owns these so types live next to the matchers that
+ *   use them.
+ *
+ * Unknown tool names fall through to the untyped overload of `tool(...)`.
+ */
+
+import type {
+	BashToolInput,
+	EditToolInput,
+	FindToolInput,
+	GrepToolInput,
+	LsToolInput,
+	ReadToolInput,
+	WriteToolInput,
+} from "@mariozechner/pi-coding-agent"
+
+export interface BuiltinToolArgs {
+	bash: BashToolInput
+	read: ReadToolInput
+	edit: EditToolInput
+	write: WriteToolInput
+	grep: GrepToolInput
+	find: FindToolInput
+	ls: LsToolInput
+}
+
+export interface WebFetchToolInput {
+	url: string
+	format?: "markdown" | "text" | "html"
+	timeout?: number
+}
+
+export interface WebSearchToolInput {
+	query: string
+	recency?: "day" | "week" | "month" | "year"
+	search_depth?: "basic" | "deep"
+	max_content_chars?: number
+}
+
+export interface KimchiToolArgs {
+	web_fetch: WebFetchToolInput
+	web_search: WebSearchToolInput
+}
+
+export type ToolArgs = BuiltinToolArgs & KimchiToolArgs
+
+export type KnownToolName = keyof ToolArgs
+
+export const BUILTIN_TOOL_NAMES: readonly (keyof BuiltinToolArgs)[] = [
+	"bash",
+	"read",
+	"edit",
+	"write",
+	"grep",
+	"find",
+	"ls",
+]

--- a/src/extensions/behaviours/triggers.ts
+++ b/src/extensions/behaviours/triggers.ts
@@ -129,17 +129,20 @@ function combine(kind: "any" | "all", items: Array<SessionProbe | ToolMatcher>):
 			throw new Error(`${kind} cannot mix session probes and tool matchers`)
 		}
 	}
-	if (first === "tool") {
-		const matchers = items as ToolMatcher[]
-		const reducer = kind === "any" ? "some" : "every"
-		return withToolSpec((event) => matchers[reducer]((m) => m(event)), {
-			kind,
-			children: matchers.map((m) => m.__spec),
-		})
-	}
-	const probes = items as SessionProbe[]
+	return first === "tool" ? combineMatchers(kind, items as ToolMatcher[]) : combineProbes(kind, items as SessionProbe[])
+}
+
+function combineProbes(kind: "any" | "all", probes: SessionProbe[]): SessionProbe {
 	const reducer = kind === "any" ? "some" : "every"
 	return withProbeSpec((ctx) => probes[reducer]((p) => p(ctx)), { kind, children: probes.map((p) => p.__spec) })
+}
+
+function combineMatchers(kind: "any" | "all", matchers: ToolMatcher[]): ToolMatcher {
+	const reducer = kind === "any" ? "some" : "every"
+	return withToolSpec((event) => matchers[reducer]((m) => m(event)), {
+		kind,
+		children: matchers.map((m) => m.__spec),
+	})
 }
 
 // ============================================================================

--- a/src/extensions/behaviours/triggers.ts
+++ b/src/extensions/behaviours/triggers.ts
@@ -1,16 +1,26 @@
 /**
  * Trigger primitives for behaviour discovery.
  *
- * Factories return pure predicates over a pre-resolved `SessionContext` (probes)
- * with a `__spec` describing what they probe. The resolver walks the union of
- * declared specs at session start and runs each kind of probe at most once,
- * even when multiple behaviours declare the same probe.
+ * Two families of pure predicates:
+ * - **Session probes** evaluate a pre-resolved `SessionContext` (`cli`,
+ *   `gitRemote`, `path`).
+ * - **Tool matchers** evaluate a single tool-call event (`tool<T>`).
  *
- * Tool-call matchers and combinator parameterisation by tool args land in
- * later phases. The `any`/`all` combinators are session-probe-only here.
+ * `any`/`all` combinators are overloaded — they compose homogeneously within
+ * a slot (probes-with-probes, matchers-with-matchers). Mixing the two kinds
+ * is a type error and a runtime error.
+ *
+ * Each predicate carries a `__spec` describing what it probes / matches. The
+ * session resolver walks probe specs to deduplicate I/O; the engines apply
+ * the predicate at evaluation time.
  */
 
 import type { SessionContext } from "./session-context.js"
+import type { KnownToolName, ToolArgs } from "./tool-args.js"
+
+// ============================================================================
+// Session probes
+// ============================================================================
 
 export type ProbeSpec =
 	| { kind: "cli"; name: string }
@@ -21,34 +31,120 @@ export type ProbeSpec =
 
 export interface SessionProbe {
 	(ctx: SessionContext): boolean
+	__kind: "session"
 	__spec: ProbeSpec
 }
 
-function withSpec(fn: (ctx: SessionContext) => boolean, spec: ProbeSpec): SessionProbe {
+function withProbeSpec(fn: (ctx: SessionContext) => boolean, spec: ProbeSpec): SessionProbe {
 	const probe = fn as SessionProbe
+	probe.__kind = "session"
 	probe.__spec = spec
 	return probe
 }
 
 export function cli(name: string): SessionProbe {
-	return withSpec((ctx) => ctx.cliPresent.has(name), { kind: "cli", name })
+	return withProbeSpec((ctx) => ctx.cliPresent.has(name), { kind: "cli", name })
 }
 
 export function gitRemote(host: string): SessionProbe {
-	return withSpec((ctx) => ctx.gitRemoteHost === host, { kind: "gitRemote", host })
+	return withProbeSpec((ctx) => ctx.gitRemoteHost === host, { kind: "gitRemote", host })
 }
 
 export function path(glob: string): SessionProbe {
-	return withSpec((ctx) => ctx.pathMatches.has(glob), { kind: "path", glob })
+	return withProbeSpec((ctx) => ctx.pathMatches.has(glob), { kind: "path", glob })
 }
 
-export function any(...probes: SessionProbe[]): SessionProbe {
-	return withSpec((ctx) => probes.some((p) => p(ctx)), { kind: "any", children: probes.map((p) => p.__spec) })
+// ============================================================================
+// Tool-call matchers
+// ============================================================================
+
+export interface ToolCallEvent {
+	toolName: string
+	input: Record<string, unknown>
 }
 
-export function all(...probes: SessionProbe[]): SessionProbe {
-	return withSpec((ctx) => probes.every((p) => p(ctx)), { kind: "all", children: probes.map((p) => p.__spec) })
+export type ToolMatcherSpec =
+	| { kind: "tool"; toolName: string }
+	| { kind: "any"; children: ToolMatcherSpec[] }
+	| { kind: "all"; children: ToolMatcherSpec[] }
+
+export interface ToolMatcher {
+	(event: ToolCallEvent): boolean
+	__kind: "tool"
+	__spec: ToolMatcherSpec
 }
+
+function withToolSpec(fn: (event: ToolCallEvent) => boolean, spec: ToolMatcherSpec): ToolMatcher {
+	const matcher = fn as ToolMatcher
+	matcher.__kind = "tool"
+	matcher.__spec = spec
+	return matcher
+}
+
+/**
+ * Match a tool-call event by name, with an optional predicate over typed args.
+ *
+ * For built-in tool names, `predicate` receives the input typed via `ToolArgs`.
+ * Custom tools fall through to the untyped overload.
+ */
+export function tool<TName extends KnownToolName>(
+	name: TName,
+	predicate?: (input: ToolArgs[TName]) => boolean,
+): ToolMatcher
+export function tool(name: string, predicate?: (input: Record<string, unknown>) => boolean): ToolMatcher
+export function tool(name: string, predicate?: (input: never) => boolean): ToolMatcher {
+	return withToolSpec(
+		(event) => {
+			if (event.toolName !== name) return false
+			if (!predicate) return true
+			return predicate(event.input as never)
+		},
+		{ kind: "tool", toolName: name },
+	)
+}
+
+// ============================================================================
+// Combinators (homogeneous: probes-with-probes or matchers-with-matchers)
+// ============================================================================
+
+export function any(...probes: SessionProbe[]): SessionProbe
+export function any(...matchers: ToolMatcher[]): ToolMatcher
+export function any(...items: Array<SessionProbe | ToolMatcher>): SessionProbe | ToolMatcher {
+	return combine("any", items)
+}
+
+export function all(...probes: SessionProbe[]): SessionProbe
+export function all(...matchers: ToolMatcher[]): ToolMatcher
+export function all(...items: Array<SessionProbe | ToolMatcher>): SessionProbe | ToolMatcher {
+	return combine("all", items)
+}
+
+function combine(kind: "any" | "all", items: Array<SessionProbe | ToolMatcher>): SessionProbe | ToolMatcher {
+	if (items.length === 0) {
+		throw new Error(`${kind} requires at least one operand`)
+	}
+	const first = items[0].__kind
+	for (const item of items) {
+		if (item.__kind !== first) {
+			throw new Error(`${kind} cannot mix session probes and tool matchers`)
+		}
+	}
+	if (first === "tool") {
+		const matchers = items as ToolMatcher[]
+		const reducer = kind === "any" ? "some" : "every"
+		return withToolSpec((event) => matchers[reducer]((m) => m(event)), {
+			kind,
+			children: matchers.map((m) => m.__spec),
+		})
+	}
+	const probes = items as SessionProbe[]
+	const reducer = kind === "any" ? "some" : "every"
+	return withProbeSpec((ctx) => probes[reducer]((p) => p(ctx)), { kind, children: probes.map((p) => p.__spec) })
+}
+
+// ============================================================================
+// Spec walkers
+// ============================================================================
 
 /** Walk a probe spec tree, calling `visit` on each leaf (non-combinator) node. */
 export function walkLeaves(spec: ProbeSpec, visit: (leaf: ProbeSpec) => void): void {

--- a/src/extensions/behaviours/triggers.ts
+++ b/src/extensions/behaviours/triggers.ts
@@ -25,6 +25,7 @@ import type { KnownToolName, ToolArgs } from "./tool-args.js"
 export type ProbeSpec =
 	| { kind: "cli"; name: string }
 	| { kind: "gitRemote"; host: string }
+	| { kind: "gitRepo" }
 	| { kind: "path"; glob: string }
 	| { kind: "any"; children: ProbeSpec[] }
 	| { kind: "all"; children: ProbeSpec[] }
@@ -48,6 +49,10 @@ export function cli(name: string): SessionProbe {
 
 export function gitRemote(host: string): SessionProbe {
 	return withProbeSpec((ctx) => ctx.gitRemoteHost === host, { kind: "gitRemote", host })
+}
+
+export function gitRepo(): SessionProbe {
+	return withProbeSpec((ctx) => ctx.inGitRepo, { kind: "gitRepo" })
 }
 
 export function path(glob: string): SessionProbe {

--- a/src/extensions/behaviours/triggers.ts
+++ b/src/extensions/behaviours/triggers.ts
@@ -1,0 +1,60 @@
+/**
+ * Trigger primitives for behaviour discovery.
+ *
+ * Factories return pure predicates over a pre-resolved `SessionContext` (probes)
+ * with a `__spec` describing what they probe. The resolver walks the union of
+ * declared specs at session start and runs each kind of probe at most once,
+ * even when multiple behaviours declare the same probe.
+ *
+ * Tool-call matchers and combinator parameterisation by tool args land in
+ * later phases. The `any`/`all` combinators are session-probe-only here.
+ */
+
+import type { SessionContext } from "./session-context.js"
+
+export type ProbeSpec =
+	| { kind: "cli"; name: string }
+	| { kind: "gitRemote"; host: string }
+	| { kind: "path"; glob: string }
+	| { kind: "any"; children: ProbeSpec[] }
+	| { kind: "all"; children: ProbeSpec[] }
+
+export interface SessionProbe {
+	(ctx: SessionContext): boolean
+	__spec: ProbeSpec
+}
+
+function withSpec(fn: (ctx: SessionContext) => boolean, spec: ProbeSpec): SessionProbe {
+	const probe = fn as SessionProbe
+	probe.__spec = spec
+	return probe
+}
+
+export function cli(name: string): SessionProbe {
+	return withSpec((ctx) => ctx.cliPresent.has(name), { kind: "cli", name })
+}
+
+export function gitRemote(host: string): SessionProbe {
+	return withSpec((ctx) => ctx.gitRemoteHost === host, { kind: "gitRemote", host })
+}
+
+export function path(glob: string): SessionProbe {
+	return withSpec((ctx) => ctx.pathMatches.has(glob), { kind: "path", glob })
+}
+
+export function any(...probes: SessionProbe[]): SessionProbe {
+	return withSpec((ctx) => probes.some((p) => p(ctx)), { kind: "any", children: probes.map((p) => p.__spec) })
+}
+
+export function all(...probes: SessionProbe[]): SessionProbe {
+	return withSpec((ctx) => probes.every((p) => p(ctx)), { kind: "all", children: probes.map((p) => p.__spec) })
+}
+
+/** Walk a probe spec tree, calling `visit` on each leaf (non-combinator) node. */
+export function walkLeaves(spec: ProbeSpec, visit: (leaf: ProbeSpec) => void): void {
+	if (spec.kind === "any" || spec.kind === "all") {
+		for (const child of spec.children) walkLeaves(child, visit)
+		return
+	}
+	visit(spec)
+}

--- a/src/extensions/behaviours/types.ts
+++ b/src/extensions/behaviours/types.ts
@@ -2,10 +2,16 @@
  * Behaviour shape for the bundled-behaviours extension.
  *
  * A behaviour pairs guidance content with the conditions under which it
- * applies. Two trigger slots — `triggers.session` (probes) and `triggers.tool`
- * (matchers) — gate when a triggered behaviour loads. Two evaluator slots —
- * `evals.observed` and `evals.violated` — score post-load tool calls. Both
- * eval slots are restricted to tool matchers at the type level.
+ * applies. The kind is discriminated:
+ *
+ * - `baseline` behaviours always merge into the system prompt — they have no
+ *   triggers and no evals.
+ * - `triggered` behaviours load on demand. They carry a `triggers` slot
+ *   (session probe and/or tool matcher) and optional `evals` (`observed` /
+ *   `violated` matchers scored after load).
+ *
+ * The discriminated union keeps the type system honest: triggers/evals are
+ * unreachable on baselines, so the compiler refuses to set them.
  */
 
 import type { SessionProbe, ToolMatcher } from "./triggers.js"
@@ -24,11 +30,20 @@ export interface BehaviourEvals {
 	violated?: ToolMatcher
 }
 
-export interface Behaviour {
+interface BehaviourBase {
 	name: string
 	description: string
 	body: string
-	kind: BehaviourKind
-	triggers?: BehaviourTriggers
+}
+
+export interface BaselineBehaviour extends BehaviourBase {
+	kind: "baseline"
+}
+
+export interface TriggeredBehaviour extends BehaviourBase {
+	kind: "triggered"
+	triggers: BehaviourTriggers
 	evals?: BehaviourEvals
 }
+
+export type Behaviour = BaselineBehaviour | TriggeredBehaviour

--- a/src/extensions/behaviours/types.ts
+++ b/src/extensions/behaviours/types.ts
@@ -1,18 +1,27 @@
 /**
  * Behaviour shape for the bundled-behaviours extension.
  *
- * Phase 2 carries baseline metadata plus optional session-probe triggers.
- * Tool-call matchers and evaluator slots are added in later phases without
- * changing the file layout.
+ * A behaviour pairs guidance content with the conditions under which it
+ * applies. Two trigger slots — `triggers.session` (probes) and `triggers.tool`
+ * (matchers) — gate when a triggered behaviour loads. Two evaluator slots —
+ * `evals.observed` and `evals.violated` — score post-load tool calls. Both
+ * eval slots are restricted to tool matchers at the type level.
  */
 
-import type { SessionProbe } from "./triggers.js"
+import type { SessionProbe, ToolMatcher } from "./triggers.js"
 
 export type BehaviourKind = "baseline" | "triggered"
 export type TriggerSource = "session" | "tool"
+export type EvalVerdict = "observed" | "violated"
 
 export interface BehaviourTriggers {
 	session?: SessionProbe
+	tool?: ToolMatcher
+}
+
+export interface BehaviourEvals {
+	observed?: ToolMatcher
+	violated?: ToolMatcher
 }
 
 export interface Behaviour {
@@ -21,4 +30,5 @@ export interface Behaviour {
 	body: string
 	kind: BehaviourKind
 	triggers?: BehaviourTriggers
+	evals?: BehaviourEvals
 }

--- a/src/extensions/behaviours/types.ts
+++ b/src/extensions/behaviours/types.ts
@@ -1,0 +1,14 @@
+/**
+ * Behaviour shape for the bundled-behaviours extension.
+ *
+ * Phase 1 carries only what the baseline-merge path needs. Triggers and
+ * evaluators are added in later phases without changing the file layout.
+ */
+export type BehaviourKind = "baseline" | "triggered"
+
+export interface Behaviour {
+	name: string
+	description: string
+	body: string
+	kind: BehaviourKind
+}

--- a/src/extensions/behaviours/types.ts
+++ b/src/extensions/behaviours/types.ts
@@ -1,14 +1,24 @@
 /**
  * Behaviour shape for the bundled-behaviours extension.
  *
- * Phase 1 carries only what the baseline-merge path needs. Triggers and
- * evaluators are added in later phases without changing the file layout.
+ * Phase 2 carries baseline metadata plus optional session-probe triggers.
+ * Tool-call matchers and evaluator slots are added in later phases without
+ * changing the file layout.
  */
+
+import type { SessionProbe } from "./triggers.js"
+
 export type BehaviourKind = "baseline" | "triggered"
+export type TriggerSource = "session" | "tool"
+
+export interface BehaviourTriggers {
+	session?: SessionProbe
+}
 
 export interface Behaviour {
 	name: string
 	description: string
 	body: string
 	kind: BehaviourKind
+	triggers?: BehaviourTriggers
 }

--- a/src/extensions/behaviours/wiring.smoke.test.ts
+++ b/src/extensions/behaviours/wiring.smoke.test.ts
@@ -26,9 +26,15 @@ interface Appended {
 	data: unknown
 }
 
+interface Sent {
+	message: { customType: string; content: string; display: boolean; details?: unknown }
+	options?: { deliverAs?: string; triggerTurn?: boolean }
+}
+
 class FakePi {
 	readonly handlers = new Map<string, Handler[]>()
 	readonly appended: Appended[] = []
+	readonly sent: Sent[] = []
 
 	asExtensionAPI(): ExtensionAPI {
 		return this as unknown as ExtensionAPI
@@ -42,6 +48,10 @@ class FakePi {
 
 	appendEntry(type: string, data?: unknown): void {
 		this.appended.push({ type, data })
+	}
+
+	sendMessage(message: Sent["message"], options?: Sent["options"]): void {
+		this.sent.push({ message, options })
 	}
 
 	async fire<R = unknown>(event: string, payload: unknown, ctx: unknown = {}): Promise<R[]> {
@@ -165,6 +175,40 @@ describe("wireBehaviours — tool_call", () => {
 		await pi.fire("tool_call", { toolName: "bash", input: { command: "glab mr list" } })
 
 		expect(pi.entries(BEHAVIOUR_EVAL_TYPE)).toEqual([])
+	})
+})
+
+describe("wireBehaviours — tool_result", () => {
+	it("steers a tool-triggered body in the same turn as the trigger", async () => {
+		const pi = setupWired([glabCli])
+		await pi.fire("session_start", {}, { cwd: "/tmp" })
+		await pi.fire("turn_start", { turnIndex: 1 })
+		await pi.fire("tool_call", { toolName: "bash", input: { command: "glab mr list" } })
+		await pi.fire("tool_result", { toolName: "bash", input: { command: "glab mr list" } })
+
+		expect(pi.sent).toEqual([
+			{
+				message: expect.objectContaining({
+					customType: BEHAVIOUR_BODY_TYPE,
+					content: "Use glab for GitLab.",
+					display: false,
+				}),
+				options: { deliverAs: "steer" },
+			},
+		])
+
+		// Pending drained: a later before_agent_start does NOT re-deliver the body.
+		const next = await pi.fire<{ message?: unknown }>("before_agent_start", { prompt: "x", systemPrompt: "BASE" })
+		expect(next.flatMap((r) => (r.message ? [r.message] : []))).toEqual([])
+	})
+
+	it("does not steer for session-triggered bodies (already drained by before_agent_start)", async () => {
+		const pi = setupWired([ghCli])
+		await pi.fire("session_start", {}, { cwd: "/tmp" })
+		await pi.fire("before_agent_start", { prompt: "x", systemPrompt: "BASE" })
+		await pi.fire("tool_result", { toolName: "bash", input: { command: "gh pr list" } })
+
+		expect(pi.sent).toEqual([])
 	})
 })
 

--- a/src/extensions/behaviours/wiring.smoke.test.ts
+++ b/src/extensions/behaviours/wiring.smoke.test.ts
@@ -62,6 +62,7 @@ class FakePi {
 const stubIO: ResolverIO = {
 	hasCli: (name) => name === "gh",
 	readGitRemoteHost: () => undefined,
+	isGitRepo: () => false,
 	walkPaths: () => new Set<string>(),
 }
 

--- a/src/extensions/behaviours/wiring.smoke.test.ts
+++ b/src/extensions/behaviours/wiring.smoke.test.ts
@@ -1,0 +1,252 @@
+/**
+ * Integration smoke test for `wireBehaviours`. The unit tests for
+ * `TriggerEngine`, `EvalEngine`, and `resolveSessionContext` cover state
+ * transitions and matching logic. This file verifies the wiring layer:
+ * which `pi.on(...)` handlers fire, what they append to the JSONL, and what
+ * shape they return to the agent runner — without re-testing engine logic.
+ */
+
+import type { ExtensionAPI } from "@mariozechner/pi-coding-agent"
+import { describe, expect, it } from "vitest"
+import type { ResolverIO } from "./session-context.js"
+import {
+	BEHAVIOUR_EVAL_TYPE,
+	BEHAVIOUR_LOADED_TYPE,
+	BEHAVIOUR_REQUEUED_TYPE,
+	BEHAVIOUR_SESSION_SUMMARY_TYPE,
+} from "./stats.js"
+import { cli, tool } from "./triggers.js"
+import type { Behaviour } from "./types.js"
+import { BEHAVIOUR_BODY_TYPE, wireBehaviours } from "./wiring.js"
+
+type Handler = (event: unknown, ctx?: unknown) => unknown
+
+interface Appended {
+	type: string
+	data: unknown
+}
+
+class FakePi {
+	readonly handlers = new Map<string, Handler[]>()
+	readonly appended: Appended[] = []
+
+	asExtensionAPI(): ExtensionAPI {
+		return this as unknown as ExtensionAPI
+	}
+
+	on(event: string, handler: Handler): void {
+		const list = this.handlers.get(event) ?? []
+		list.push(handler)
+		this.handlers.set(event, list)
+	}
+
+	appendEntry(type: string, data?: unknown): void {
+		this.appended.push({ type, data })
+	}
+
+	async fire<R = unknown>(event: string, payload: unknown, ctx: unknown = {}): Promise<R[]> {
+		const list = this.handlers.get(event) ?? []
+		const out: R[] = []
+		for (const h of list) {
+			const r = await h(payload, ctx)
+			if (r !== undefined) out.push(r as R)
+		}
+		return out
+	}
+
+	entries(type: string): Appended[] {
+		return this.appended.filter((e) => e.type === type)
+	}
+}
+
+const stubIO: ResolverIO = {
+	hasCli: (name) => name === "gh",
+	readGitRemoteHost: () => undefined,
+	walkPaths: () => new Set<string>(),
+}
+
+const baseline: Behaviour = {
+	kind: "baseline",
+	name: "rule-1",
+	description: "always-on rule",
+	body: "Always do X.",
+}
+
+const ghCli: Behaviour = {
+	kind: "triggered",
+	name: "gh-cli",
+	description: "gh CLI guidance",
+	body: "Use gh for GitHub.",
+	triggers: { session: cli("gh") },
+	evals: {
+		observed: tool("bash", (i) => i.command.startsWith("gh ")),
+		violated: tool("bash", (i) => i.command.startsWith("curl ")),
+	},
+}
+
+const glabCli: Behaviour = {
+	kind: "triggered",
+	name: "glab-cli",
+	description: "glab CLI guidance",
+	body: "Use glab for GitLab.",
+	triggers: { tool: tool("bash", (i) => i.command.startsWith("glab ")) },
+}
+
+function setupWired(behaviours: Behaviour[]): FakePi {
+	const pi = new FakePi()
+	wireBehaviours(pi.asExtensionAPI(), behaviours, { resolverIO: stubIO })
+	return pi
+}
+
+describe("wireBehaviours — session_start", () => {
+	it("appends behaviour_loaded for a session-triggered behaviour", async () => {
+		const pi = setupWired([ghCli])
+		await pi.fire("session_start", {}, { cwd: "/tmp" })
+
+		expect(pi.entries(BEHAVIOUR_LOADED_TYPE)).toEqual([
+			{ type: BEHAVIOUR_LOADED_TYPE, data: { name: "gh-cli", trigger: "session", turnIndex: 0 } },
+		])
+	})
+
+	it("does not append when no session probe matches", async () => {
+		const pi = setupWired([glabCli])
+		await pi.fire("session_start", {}, { cwd: "/tmp" })
+
+		expect(pi.entries(BEHAVIOUR_LOADED_TYPE)).toEqual([])
+	})
+
+	it("re-fires cleanly: a second session_start drops stale state", async () => {
+		const pi = setupWired([ghCli])
+		await pi.fire("session_start", {}, { cwd: "/tmp" })
+		await pi.fire("session_start", {}, { cwd: "/tmp" })
+
+		// Two loads (one per session_start), not one duplicated row from the same session.
+		expect(pi.entries(BEHAVIOUR_LOADED_TYPE)).toHaveLength(2)
+	})
+})
+
+describe("wireBehaviours — tool_call", () => {
+	it("appends behaviour_loaded when a tool trigger fires", async () => {
+		const pi = setupWired([glabCli])
+		await pi.fire("session_start", {}, { cwd: "/tmp" })
+		await pi.fire("turn_start", { turnIndex: 3 })
+		await pi.fire("tool_call", { toolName: "bash", input: { command: "glab mr list" } })
+
+		expect(pi.entries(BEHAVIOUR_LOADED_TYPE)).toEqual([
+			{
+				type: BEHAVIOUR_LOADED_TYPE,
+				data: {
+					name: "glab-cli",
+					trigger: "tool",
+					turnIndex: 3,
+					toolArgs: { command: "glab mr list" },
+				},
+			},
+		])
+	})
+
+	it("appends behaviour_eval for loaded behaviours but not on the call that loaded them", async () => {
+		const pi = setupWired([ghCli])
+		await pi.fire("session_start", {}, { cwd: "/tmp" })
+		await pi.fire("turn_start", { turnIndex: 1 })
+		await pi.fire("tool_call", { toolName: "bash", input: { command: "gh pr list" } })
+		await pi.fire("tool_call", { toolName: "bash", input: { command: "curl https://x" } })
+
+		const evals = pi.entries(BEHAVIOUR_EVAL_TYPE).map((e) => (e.data as { verdict: string }).verdict)
+		expect(evals).toEqual(["observed", "violated"])
+	})
+
+	it("does not score evals before the behaviour loads", async () => {
+		const pi = setupWired([glabCli])
+		// session_start does NOT load glab-cli (no session probe). The first
+		// matching tool_call loads it; that same call must not score evals.
+		await pi.fire("session_start", {}, { cwd: "/tmp" })
+		await pi.fire("tool_call", { toolName: "bash", input: { command: "glab mr list" } })
+
+		expect(pi.entries(BEHAVIOUR_EVAL_TYPE)).toEqual([])
+	})
+})
+
+describe("wireBehaviours — before_agent_start", () => {
+	it("appends the rules block for baseline behaviours to the system prompt", async () => {
+		const pi = setupWired([baseline])
+		await pi.fire("session_start", {}, { cwd: "/tmp" })
+		const results = await pi.fire<{ systemPrompt?: string }>("before_agent_start", {
+			prompt: "hi",
+			systemPrompt: "BASE",
+		})
+
+		const sp = results.find((r) => r.systemPrompt !== undefined)?.systemPrompt
+		expect(sp).toContain("## Rules")
+		expect(sp).toContain("Always do X.")
+		expect(sp?.startsWith("BASE")).toBe(true)
+	})
+
+	it("delivers the body of a loaded triggered behaviour as a hidden message, exactly once", async () => {
+		const pi = setupWired([ghCli])
+		await pi.fire("session_start", {}, { cwd: "/tmp" })
+
+		const first = await pi.fire<{ message?: { customType: string; content: string; display: boolean } }>(
+			"before_agent_start",
+			{ prompt: "hi", systemPrompt: "BASE" },
+		)
+		const messages = first.flatMap((r) => (r.message ? [r.message] : []))
+		expect(messages).toEqual([
+			expect.objectContaining({
+				customType: BEHAVIOUR_BODY_TYPE,
+				content: "Use gh for GitHub.",
+				display: false,
+			}),
+		])
+
+		// Second turn — body already drained, no message returned.
+		const second = await pi.fire<{ message?: unknown }>("before_agent_start", { prompt: "hi", systemPrompt: "BASE" })
+		expect(second.flatMap((r) => (r.message ? [r.message] : []))).toEqual([])
+	})
+})
+
+describe("wireBehaviours — session_compact", () => {
+	it("appends behaviour_requeued for each loaded behaviour and re-delivers the body", async () => {
+		const pi = setupWired([ghCli])
+		await pi.fire("session_start", {}, { cwd: "/tmp" })
+		await pi.fire("turn_start", { turnIndex: 5 })
+		// Drain initial pending.
+		await pi.fire("before_agent_start", { prompt: "hi", systemPrompt: "BASE" })
+
+		await pi.fire("session_compact", {})
+		expect(pi.entries(BEHAVIOUR_REQUEUED_TYPE)).toEqual([
+			{ type: BEHAVIOUR_REQUEUED_TYPE, data: { name: "gh-cli", turnIndex: 5 } },
+		])
+
+		// Body re-delivered on next agent start.
+		const post = await pi.fire<{ message?: unknown }>("before_agent_start", { prompt: "hi", systemPrompt: "BASE" })
+		expect(post.flatMap((r) => (r.message ? [r.message] : []))).toHaveLength(1)
+	})
+})
+
+describe("wireBehaviours — session_shutdown", () => {
+	it("emits a session summary covering baseline + loaded behaviours", async () => {
+		const pi = setupWired([baseline, ghCli, glabCli])
+		await pi.fire("session_start", {}, { cwd: "/tmp" })
+		await pi.fire("turn_start", { turnIndex: 2 })
+		await pi.fire("tool_call", { toolName: "bash", input: { command: "gh pr list" } })
+		await pi.fire("session_shutdown", {})
+
+		const summary = pi.entries(BEHAVIOUR_SESSION_SUMMARY_TYPE)
+		expect(summary).toHaveLength(1)
+		const entries = (summary[0].data as { behaviours: Array<{ name: string; loaded: boolean; observed: number }> })
+			.behaviours
+		// glab-cli never loaded, so it's omitted by design.
+		expect(entries.map((e) => e.name)).toEqual(["rule-1", "gh-cli"])
+		expect(entries.find((e) => e.name === "gh-cli")?.observed).toBe(1)
+	})
+
+	it("is idempotent across repeated session_shutdown firings", async () => {
+		const pi = setupWired([baseline])
+		await pi.fire("session_start", {}, { cwd: "/tmp" })
+		await pi.fire("session_shutdown", {})
+		await pi.fire("session_shutdown", {})
+
+		expect(pi.entries(BEHAVIOUR_SESSION_SUMMARY_TYPE)).toHaveLength(1)
+	})
+})

--- a/src/extensions/behaviours/wiring.ts
+++ b/src/extensions/behaviours/wiring.ts
@@ -28,7 +28,7 @@ import type { ProbeSpec } from "./triggers.js"
 import type { Behaviour, TriggeredBehaviour } from "./types.js"
 
 const RULES_HEADER = "## Rules"
-export const BEHAVIOUR_BODY_TYPE = "behaviour_body"
+export const BEHAVIOUR_BODY_TYPE = "behaviour"
 
 interface BehaviourBodyDetails {
 	name: string
@@ -113,6 +113,26 @@ export function wireBehaviours(pi: ExtensionAPI, behaviours: readonly Behaviour[
 				turnIndex: e.turnIndex,
 				toolArgs: e.toolArgs,
 			})
+		}
+	})
+
+	// Drain any pending bodies as steer messages right after the tool result so
+	// the model sees them before its next inference within the same turn.
+	// `before_agent_start` only fires per user prompt, so without this hook a
+	// behaviour that loads on a tool_call mid-turn would never reach the model
+	// in that session.
+	pi.on("tool_result", async () => {
+		for (const b of triggered) {
+			if (!engine.takePending(b.name)) continue
+			pi.sendMessage(
+				{
+					customType: BEHAVIOUR_BODY_TYPE,
+					content: b.body,
+					display: false,
+					details: { name: b.name } satisfies BehaviourBodyDetails,
+				},
+				{ deliverAs: "steer" },
+			)
 		}
 	})
 

--- a/src/extensions/behaviours/wiring.ts
+++ b/src/extensions/behaviours/wiring.ts
@@ -1,0 +1,184 @@
+/**
+ * Pure wiring layer — connects a behaviour registry to an `ExtensionAPI`.
+ * Lives in its own module so vitest can import it without resolving the Bun
+ * text imports under `bodies/` (which `registry.ts` pulls in). Mirrors the
+ * `build.ts` / `registry.ts` split.
+ *
+ * The default-export extension in `index.ts` calls `wireBehaviours` with the
+ * bundled registry; tests pass synthetic behaviours and a stub IO to exercise
+ * the same handlers without filesystem/process dependencies.
+ */
+
+import type { ExtensionAPI, ExtensionContext } from "@mariozechner/pi-coding-agent"
+import { TriggerEngine } from "./engine.js"
+import { EvalEngine } from "./eval-engine.js"
+import { type ResolverIO, resolveSessionContext } from "./session-context.js"
+import {
+	BEHAVIOUR_EVAL_TYPE,
+	BEHAVIOUR_LOADED_TYPE,
+	BEHAVIOUR_REQUEUED_TYPE,
+	BEHAVIOUR_SESSION_SUMMARY_TYPE,
+	type BehaviourEvalData,
+	type BehaviourLoadedData,
+	type BehaviourRequeuedData,
+	type BehaviourSessionSummaryData,
+	type BehaviourSummaryEntry,
+} from "./stats.js"
+import type { ProbeSpec } from "./triggers.js"
+import type { Behaviour, TriggeredBehaviour } from "./types.js"
+
+const RULES_HEADER = "## Rules"
+export const BEHAVIOUR_BODY_TYPE = "behaviour_body"
+
+interface BehaviourBodyDetails {
+	name: string
+}
+
+export interface WireOptions {
+	/** Inject a stub IO for tests; falls back to the live filesystem/git probes. */
+	resolverIO?: ResolverIO
+}
+
+function buildRulesBlock(all: readonly Behaviour[]): string {
+	const baseline = all.filter((b) => b.kind === "baseline").map((b) => b.body.trim())
+	if (baseline.length === 0) return ""
+	return `\n\n${RULES_HEADER}\n\n${baseline.join("\n\n")}\n`
+}
+
+function collectSessionSpecs(triggered: readonly TriggeredBehaviour[]): ProbeSpec[] {
+	const specs: ProbeSpec[] = []
+	for (const b of triggered) {
+		const probe = b.triggers.session
+		if (probe) specs.push(probe.__spec)
+	}
+	return specs
+}
+
+function isTriggered(b: Behaviour): b is TriggeredBehaviour {
+	return b.kind === "triggered"
+}
+
+export function wireBehaviours(pi: ExtensionAPI, behaviours: readonly Behaviour[], options: WireOptions = {}): void {
+	const rulesBlock = buildRulesBlock(behaviours)
+	const triggered = behaviours.filter(isTriggered)
+	const sessionSpecs = collectSessionSpecs(triggered)
+	const engine = new TriggerEngine(behaviours)
+	const evalEngine = new EvalEngine(behaviours, (name) => engine.isLoaded(name))
+	let summaryEmitted = false
+	let currentTurnIndex = 0
+
+	pi.on("session_start", async (_event, ctx: ExtensionContext) => {
+		// Reset per-session state so re-fired session_start events (reload, new,
+		// fork, resume) don't carry stale loads forward into a fresh session.
+		engine.reset()
+		evalEngine.reset()
+		summaryEmitted = false
+		currentTurnIndex = 0
+		const sessionContext = resolveSessionContext(sessionSpecs, ctx.cwd, options.resolverIO)
+		const events = engine.evaluateSessionTriggers(sessionContext, currentTurnIndex)
+		for (const e of events) {
+			pi.appendEntry<BehaviourLoadedData>(BEHAVIOUR_LOADED_TYPE, {
+				name: e.name,
+				trigger: e.trigger,
+				turnIndex: e.turnIndex,
+			})
+		}
+	})
+
+	pi.on("turn_start", async (event) => {
+		currentTurnIndex = event.turnIndex
+	})
+
+	pi.on("tool_call", async (event) => {
+		const callEvent = { toolName: event.toolName, input: event.input as Record<string, unknown> }
+
+		// Score evals against the prior loaded set first, so a behaviour loaded
+		// by this same tool-call does not get scored on the call that loaded it.
+		const evalEvents = evalEngine.evaluate(callEvent, currentTurnIndex)
+		for (const e of evalEvents) {
+			pi.appendEntry<BehaviourEvalData>(BEHAVIOUR_EVAL_TYPE, {
+				name: e.name,
+				verdict: e.verdict,
+				turnIndex: e.turnIndex,
+				toolName: e.toolName,
+				toolArgs: e.toolArgs,
+			})
+		}
+
+		const loadEvents = engine.evaluateToolTriggers(callEvent, currentTurnIndex)
+		for (const e of loadEvents) {
+			pi.appendEntry<BehaviourLoadedData>(BEHAVIOUR_LOADED_TYPE, {
+				name: e.name,
+				trigger: e.trigger,
+				turnIndex: e.turnIndex,
+				toolArgs: e.toolArgs,
+			})
+		}
+	})
+
+	// After compaction, the summarisation step replaces the conversation window
+	// (including any prior behaviour bodies) with a synthesised summary. Re-queue
+	// every loaded behaviour for re-injection on the next agent turn. The loaded
+	// set is preserved — triggers do not re-fire, no duplicate `behaviour_loaded`
+	// entries are emitted; instead a `behaviour_requeued` row signals the
+	// re-injection so offline analysis can distinguish first load from re-deliver.
+	pi.on("session_compact", async () => {
+		const requeued = engine.requeueLoaded()
+		for (const name of requeued) {
+			pi.appendEntry<BehaviourRequeuedData>(BEHAVIOUR_REQUEUED_TYPE, { name, turnIndex: currentTurnIndex })
+		}
+	})
+
+	// Summary fires on graceful shutdown only — a hard crash (kill -9, OOM,
+	// power loss) skips this handler and the session ends without a summary
+	// row. Loaded/eval rows are durable (appended live), so offline analysis
+	// can still reconstruct totals from them; only the rolled-up snapshot is
+	// lost.
+	pi.on("session_shutdown", async () => {
+		if (summaryEmitted) return
+		summaryEmitted = true
+		const entries: BehaviourSummaryEntry[] = []
+		for (const b of behaviours) {
+			const record = engine.loadRecord(b.name)
+			const isBaseline = b.kind === "baseline"
+			if (!isBaseline && !record) continue
+			const counters = evalEngine.countersFor(b.name)
+			const entry: BehaviourSummaryEntry = {
+				name: b.name,
+				loaded: isBaseline || record !== undefined,
+				observed: counters.observed,
+				violated: counters.violated,
+			}
+			if (record) {
+				entry.loadedAtTurn = record.turnIndex
+				entry.trigger = record.trigger
+			}
+			entries.push(entry)
+		}
+		pi.appendEntry<BehaviourSessionSummaryData>(BEHAVIOUR_SESSION_SUMMARY_TYPE, { behaviours: entries })
+	})
+
+	if (rulesBlock) {
+		pi.on("before_agent_start", async (event) => {
+			return { systemPrompt: event.systemPrompt + rulesBlock }
+		})
+	}
+
+	// One injector handler per triggered behaviour. The runner aggregates
+	// messages across all `before_agent_start` handlers, so multiple pending
+	// bodies are delivered together on the next turn. Each handler closes over
+	// its behaviour and emits the body iff the engine still has it pending.
+	for (const b of triggered) {
+		pi.on("before_agent_start", async () => {
+			if (!engine.takePending(b.name)) return
+			return {
+				message: {
+					customType: BEHAVIOUR_BODY_TYPE,
+					content: b.body,
+					display: false,
+					details: { name: b.name } satisfies BehaviourBodyDetails,
+				},
+			}
+		})
+	}
+}

--- a/src/setup-wizard.test.ts
+++ b/src/setup-wizard.test.ts
@@ -1,6 +1,7 @@
 import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs"
 import { tmpdir } from "node:os"
 import { join } from "node:path"
+import { parseFrontmatter } from "@mariozechner/pi-coding-agent"
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
 import {
 	type DiscoveredCommand,
@@ -224,9 +225,10 @@ describe("migrateCommandToPrompt", () => {
 
 		expect(result).toBe(true)
 		const content = readFileSync(promptPath, "utf-8")
-		expect(content).toContain("---\nname: mr\n")
-		expect(content).toContain('description: "Create a GitLab MR following this process:"')
-		expect(content).toContain("1. Title")
+		const { frontmatter, body } = parseFrontmatter<{ name: string; description: string }>(content)
+		expect(frontmatter.name).toBe("mr")
+		expect(frontmatter.description).toBe("Create a GitLab MR following this process:")
+		expect(body).toContain("1. Title")
 	})
 
 	it("preserves existing description from frontmatter", () => {

--- a/src/update/state.test.ts
+++ b/src/update/state.test.ts
@@ -95,7 +95,7 @@ describe("update state cache", () => {
 		expect(got?.checked_at).toBe("2026-05-06T10:58:22.04543+03:00")
 	})
 
-	it("preserves a foreign-shape entry on save instead of overwriting it", () => {
+	it("saving one repo does not overwrite entries for other repos", () => {
 		writeRawState({
 			repos: {
 				"castai/kimchi": {


### PR DESCRIPTION
## Why
Open-source agents running in the kimchi-dev harness frequently fail at tasks that require knowledge they don't have in-weights - for example, the precise `gh api` endpoint for posting an inline review comment, or the GitLab discussion vs. note distinction. A prior attempt bundled five reference SKILL.md files into the harness and exposed them via a `read_skill` tool, with each skill's name and description injected into the system prompt so the agent could discover them. In practice, OSS models did not call `read_skill` even when a skill was directly relevant to the task.

The harness has no mechanism to deliver guidance content to the agent based on what the agent is actually doing or what environment it is operating in. Discoverability is delegated to the agent, and agents do not self-elect into reading reference material.

## What

Introduce a `Behaviours` extension that owns discovery on the harness side. A behaviour is bundled markdown content paired with deterministic triggers that decide when it loads, plus optional evaluators that observe whether the agent's subsequent actions match the guidance. Triggers and evaluators are imported TypeScript functions.

The harness ships a fixed set of behaviours embedded in the binary. Short procedural rules (tool-output bounding) are merged into the baseline system prompt unconditionally. Larger reference docs (gh-cli, glab-cli) are loaded on demand when their triggers fire - for example, when `gh` is detected on PATH, when the project's git remote points at github.com, or when the agent runs a `gh` command. Loaded bodies are injected into the conversation as hidden custom messages on the next turn.

Per-session statistics are written into the existing session JSONL stream as custom entries, capturing which behaviours loaded, what triggered them, and whether the agent's subsequent tool calls matched expected (observed) or anti- (violated) patterns. A summary entry is appended on session shutdown for fast aggregation. No correction or blocking - observability only for the first iteration.

---
### Kimchi Summary
### What changed
Introduces a **bundled-behaviours extension** that dynamically injects contextual guidance into the system prompt based on session-time discovery (available CLIs, git remotes, file paths) and tool-call patterns. Baseline behaviors always apply; triggered behaviors load once when their probes match and remain active for the session.

### Why
Operational guidance (e.g., “use `gh` for GitHub”, “cap output with `head`”) needs to reach the agent only when relevant. Shipping every rule in every prompt wastes context, while omitting them leads to suboptimal tool use. Triggered behaviors solve this by loading on demand while keeping the guidance corpus auditable and version-controlled as markdown.

### Key changes
- **`src/cli.ts`** – Added `behavioursExtension` to the extension pipeline.
- **`src/extensions/behaviours/registry.ts`** – Declares five bundled behaviors: `bound-tool-output` (baseline), `gh-cli`, `glab-cli`, `git-hygiene`, and `python-edit` (all triggered).
- **`src/extensions/behaviours/engine.ts`** – `TriggerEngine` evaluates session probes once at startup and tool matchers on every `tool_call`; tracks loaded/pending state and supports requeue after compaction.
- **`src/extensions/behaviours/eval-engine.ts`** – `EvalEngine` scores tool calls against loaded behaviors’ `observed`/`violated` matchers with a per-verdict sample cap (`EVAL_SAMPLE_CAP`).
- **`src/extensions/behaviours/session-context.ts`** – Resolves `SessionContext` by probing `PATH` for CLIs, parsing `git remote get-url origin`, and walking cwd for path globs (depth-capped, ignores `node_modules` etc.).
- **`src/extensions/behaviours/bash-tokenize.ts`** – Hand-written tokenizer that extracts executables from Bash one-liners, handling pipelines, subshells, command substitution, env-var prefixes, and heredocs so `bashInvokes("gh")` matches `FOO=bar gh pr list` but not `echo "gh"`.
- **`src/extensions/behaviours/triggers.ts`** – Predicate DSL: `cli("gh")`, `gitRemote("github.com")`, `path("**/*.py")`, `tool("bash", fn)`, plus `any`/`all` combinators.
- **`src/extensions/behaviours/wiring.ts`** – Hooks into `session_start`, `turn_start`, `tool_call`, `tool_result`, and `session_shutdown`, appending JSONL entries (`behaviour_loaded`, `behaviour_eval`, `behaviour_requeued`, `behaviour_session_summary`) and injecting behavior bodies as hidden custom messages.

### Impact
- **Breaking**: None (purely additive).
- **Performance**: Session probe I/O runs once at startup; tool evaluation is O(loaded behaviors) per call.
- **Observability**: Four new JSONL entry types are emitted; downstream consumers can aggregate `behaviour_session_summary` for compliance dashboards.
- **Dependencies**: Adds `micromatch` for glob matching in session context.