### PR TITLE
LLM-1516: Fix prompt summary

### DIFF
--- a/src/extensions/prompt-summary.ts
+++ b/src/extensions/prompt-summary.ts
@@ -67,7 +67,7 @@ function formatUsageRows(rows: Array<{ label: string; totals: UsageTotals }>, th
 
 	return rows.map((row, ri) => {
 		const cols = colSets[ri]
-		const padded = cols.map((c, i) => c.padEnd(colWidths[i]))
+		const padded = colWidths.map((width, i) => (cols[i] ?? "").padEnd(width))
 		const values = padded.join(COL_GAP)
 		return INDENT + theme.fg("dim", row.label.padEnd(LABEL_WIDTH)) + values
 	})
@@ -117,19 +117,19 @@ export default function promptSummaryExtension(pi: ExtensionAPI) {
 	const subagents = emptyTotals()
 	let startedAt = Date.now()
 
-	pi.on("agent_start", async () => {
+	pi.on("agent_start", () => {
 		Object.assign(orchestrator, emptyTotals())
 		Object.assign(subagents, emptyTotals())
 		startedAt = Date.now()
 	})
 
-	pi.on("message_end", async (event) => {
+	pi.on("message_end", (event) => {
 		const message = event.message as AssistantMessage
 		if (message.role !== "assistant") return
 		addUsage(orchestrator, message.usage)
 	})
 
-	pi.on("tool_result", async (event) => {
+	pi.on("tool_result", (event) => {
 		if (event.toolName !== "subagent") return
 		const stats = event.details as SubagentStats | undefined
 		if (!stats?.tokenUsage) return

--- a/src/extensions/prompt-summary.ts
+++ b/src/extensions/prompt-summary.ts
@@ -52,26 +52,23 @@ const LABEL_WIDTH = 16
 const INDENT = "  "
 
 function usageRawCols(totals: UsageTotals): string[] {
-	const total = totals.input + totals.output + totals.cacheRead + totals.cacheWrite
 	const cols = [`↑${formatCount(totals.input)}`, `↓${formatCount(totals.output)}`]
 	if (totals.cacheRead > 0 || totals.cacheWrite > 0) {
 		cols.push(`cache-read ${formatCount(totals.cacheRead)}`)
 		cols.push(`cache-write ${formatCount(totals.cacheWrite)}`)
 	}
-	cols.push(formatCount(total))
 	return cols
 }
 
 function formatUsageRows(rows: Array<{ label: string; totals: UsageTotals }>, theme: Theme): string[] {
 	const colSets = rows.map((r) => usageRawCols(r.totals))
 	const colCount = Math.max(...colSets.map((c) => c.length))
-	const colWidths = Array.from({ length: colCount - 1 }, (_, i) => Math.max(...colSets.map((c) => (c[i] ?? "").length)))
+	const colWidths = Array.from({ length: colCount }, (_, i) => Math.max(...colSets.map((c) => (c[i] ?? "").length)))
 
 	return rows.map((row, ri) => {
 		const cols = colSets[ri]
-		const padded = cols.slice(0, -1).map((c, i) => c.padEnd(colWidths[i]))
-		const totalCol = theme.fg("dim", "total ") + cols[cols.length - 1]
-		const values = [...padded, totalCol].join(COL_GAP)
+		const padded = cols.map((c, i) => c.padEnd(colWidths[i]))
+		const values = padded.join(COL_GAP)
 		return INDENT + theme.fg("dim", row.label.padEnd(LABEL_WIDTH)) + values
 	})
 }
@@ -86,15 +83,26 @@ const promptSummaryRenderer: MessageRenderer<PromptSummaryData> = (message, _opt
 	const header = theme.bold(theme.fg("toolTitle", "Prompt summary"))
 	container.addChild(new Text(dash + header, 0, 0))
 
-	container.addChild(new Text(INDENT + theme.fg("dim", "execution:".padEnd(LABEL_WIDTH)) + data.elapsed, 0, 0))
+	container.addChild(new Text(INDENT + theme.fg("dim", "execution".padEnd(LABEL_WIDTH)) + data.elapsed, 0, 0))
 
-	const rows: Array<{ label: string; totals: UsageTotals }> = []
-	if (data.orchestrator) rows.push({ label: "model:", totals: data.orchestrator })
-	if (data.subagents) rows.push({ label: "subagents:", totals: data.subagents })
-	rows.push({ label: "total:", totals: data.total })
+	if (!data.subagents) {
+		// No subagents — single compact "tokens" row
+		const t = data.total
+		let values = `↑${formatCount(t.input)}${COL_GAP}↓${formatCount(t.output)}`
+		if (t.cacheRead > 0 || t.cacheWrite > 0) {
+			values += `${COL_GAP}cache-read ${formatCount(t.cacheRead)}${COL_GAP}cache-write ${formatCount(t.cacheWrite)}`
+		}
+		container.addChild(new Text(INDENT + theme.fg("dim", "tokens".padEnd(LABEL_WIDTH)) + values, 0, 0))
+	} else {
+		// Multi-row breakdown when subagents were involved
+		const rows: Array<{ label: string; totals: UsageTotals }> = []
+		if (data.orchestrator) rows.push({ label: "main model:", totals: data.orchestrator })
+		rows.push({ label: "subagents:", totals: data.subagents })
+		rows.push({ label: "total:", totals: data.total })
 
-	for (const line of formatUsageRows(rows, theme)) {
-		container.addChild(new Text(line, 0, 0))
+		for (const line of formatUsageRows(rows, theme)) {
+			container.addChild(new Text(line, 0, 0))
+		}
 	}
 
 	return container
@@ -107,7 +115,13 @@ export default function promptSummaryExtension(pi: ExtensionAPI) {
 
 	const orchestrator = emptyTotals()
 	const subagents = emptyTotals()
-	const startedAt = Date.now()
+	let startedAt = Date.now()
+
+	pi.on("agent_start", async () => {
+		Object.assign(orchestrator, emptyTotals())
+		Object.assign(subagents, emptyTotals())
+		startedAt = Date.now()
+	})
 
 	pi.on("message_end", async (event) => {
 		const message = event.message as AssistantMessage


### PR DESCRIPTION
- Show execution time and tokens used only for the current prompt and not the whole session.
- Slight redesign - more compact; different summary based on whether subagents were involved. I can also rollback the redesign changes to be done in another ticket, and only leave the fix.

<img width="236" height="60" alt="Screenshot 2026-05-07 at 00 22 36" src="https://github.com/user-attachments/assets/15462688-1e5f-4d0b-a105-d200b4eb9af5" />
<img width="244" height="96" alt="Screenshot 2026-05-07 at 00 13 29" src="https://github.com/user-attachments/assets/44eaa601-e600-49c6-8f3e-44c9f3530547" />

---
### Kimchi Summary
### What changed
Fixes prompt summary execution time drifting across agent runs by resetting counters on `agent_start`. Simplifies the UI to a single compact `tokens` row when no subagents were used, and shows a detailed multi-row breakdown only when subagents are involved.

### Why
The `startedAt` timestamp was initialized once at extension load, causing elapsed time to reflect the extension lifetime rather than the current agent run. The summary also rendered a full breakdown for every run, adding unnecessary noise to simple interactions.

### Key changes
- `promptSummaryExtension`: adds an `agent_start` handler to reset `orchestrator`, `subagents`, and `startedAt`; removes unnecessary `async` modifiers from `message_end` and `tool_result` listeners.
- `promptSummaryRenderer`: renders a compact single-line `tokens` summary when `data.subagents` is absent; renders a multi-row breakdown (`main model`, `subagents`, `total`) only when subagents are present; strips the trailing colon from the `execution` label.
- `usageRawCols`: removes the calculated total token count column.
- `formatUsageRows`: adjusts column width calculation and padding to align all columns uniformly.

### Impact
Elapsed execution time now correctly tracks per-agent-run duration. The summary output is more concise for simple runs. No breaking changes.