### PR TITLE
docs: add upstream investigation workflow to AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -22,3 +22,77 @@ You are editing the kimchi-code CLI harness. This repo extends the pi-mono SDK (
 ## Documents Directory
 - `.kimchi/docs/` → Transient AI working files — git-ignored, do NOT commit
 - `/docs/` → Permanent project documentation — commit here
+
+## Before Adding Features
+
+This repo extends `@mariozechner/pi-coding-agent` (pi-mono). Most
+capabilities you might be asked to add already exist upstream or in a
+sibling package. Re-implementing them locally creates maintenance debt
+and divergence. Before writing any new feature, work through the phases
+below.
+
+### Phase A — Frame (sequential)
+
+1. **State the capability in one sentence.** What does the user actually
+   need? (e.g. "read pasted images from the clipboard", not "add a
+   clipboard extension".) This sentence is the search term every
+   investigation in Phase B uses.
+
+### Phase B — Investigate (run in parallel)
+
+Steps B1, B2, B3 are **independent lookups** — none of them depends on
+the others' results. Run them concurrently, not serially:
+
+- If you can do them yourself in a single turn, batch the tool calls
+  (one `grep`, one `web_fetch`/`web_search`, one issues lookup) in the
+  same response.
+- If they warrant delegation (large codebase scan, deep registry
+  triage), spawn up to 3 parallel subagents — one per step — per the
+  delegation rules in your system prompt. Do NOT spawn them serially.
+- Do NOT short-circuit Phase B when one step returns a hit. All three
+  results feed into Phase C; partial information leads to wrong layer
+  choices (e.g. picking "reimpl" because step B1 was empty, without
+  knowing step B2 found a sibling package).
+
+**B1. Search upstream source you already depend on.** The pinned
+pi-mono version is the source of truth for what your harness actually
+runs against:
+```bash
+grep -r "<concept>" node_modules/@mariozechner/pi-coding-agent/dist
+```
+Also check exported utilities, the `Extension` interface, and existing
+hooks (`onPasteImage`, `onSubmit` transforms, etc.).
+
+**B2. Check the pi.dev package registry.** Scan https://pi.dev/packages
+for sibling packages — especially under the `@mariozechner/*` scope.
+~60 seconds, names and one-line descriptions only. Goal: eliminate "I
+didn't know that package existed." Do NOT deep-read READMEs at this
+stage.
+
+**B3. Check upstream issues/PRs/discussions** for the capability. It
+may be in flight, recently merged, or explicitly rejected with a
+reason.
+
+### Phase C — Decide & implement (sequential, consumes all of Phase B)
+
+2. **Choose the implementation layer.** Stop at the FIRST layer that
+   fits. Do not "upgrade" to a heavier layer because it feels cleaner:
+   - **Re-export** — upstream is fine as-is.
+   - **Adapter / decorator** — wrap upstream, add pre/post-processing.
+   - **Extension hook** — register against an upstream callback API.
+   - **Patch** (`patches/*.patch`) — upstream needs a behavioural change;
+     MUST be paired with a tracking issue and an upstream PR plan.
+   - **From-scratch reimplementation** — last resort, only for genuinely
+     product-specific code (CastAI auth, branding, custom telemetry).
+
+3. **If from-scratch:** justify in the PR/commit description why all of
+   Phase B came up empty. If you find yourself duplicating ≥50% of an
+   upstream file, STOP and ask the user whether to upstream the fix
+   instead.
+
+### Patches are debt
+
+Every file in `patches/` must have a header comment naming the upstream
+tracking issue/PR and the removal criteria. Patches are temporary by
+definition — they expire when upstream merges or when the need
+disappears.


### PR DESCRIPTION
Adds the "Before Adding Features" section to AGENTS.md to guide agent development delegation patterns around pi-mono upstream capabilities.

### What's added
- **Phase A — Frame**: encourage stating the capability in one sentence to use as a search term.
- **Phase B — Investigate**: three parallel lookups (upstream source, pi.dev package registry, upstream issues/PRs).
- **Phase C — Decide & implement**: implementation layer hierarchy from "re-export" to "from-scratch reimplementation".
- **Patches are debt**: requirement for every patch to name an upstream tracking issue and removal criteria.

This is intended to reduce maintenance debt from re-implementing features already present upstream or in sibling packages.

Co-Authored-By: Kimchi <noreply@kimchi.dev>

---
### Kimchi Summary
### What changed
Introduces a mandatory three-phase feature development workflow in `AGENTS.md` requiring parallel investigation of upstream `@mariozechner/pi-coding-agent` sources, registry packages, and pending PRs before any local implementation.

### Why
Eliminates redundant reimplementation of existing SDK capabilities and sibling package features, enforcing extension via re-export, decoration, or upstream patches rather than divergent code duplication.

### Key changes
- `AGENTS.md`: Added "Before Adding Features" section prescribing:
  - **Phase A**: Frame capability as a single-sentence search term
  - **Phase B**: Parallel investigation (`grep` in `node_modules/@mariozechner/pi-coding-agent/dist`, scan `pi.dev/packages`, check upstream issues/PRs) — agents must complete all three steps regardless of early hits
  - **Phase C**: Hierarchical decision ladder (`Re-export` → `Adapter/decorator` → `Extension hook` → `Patch` → `From-scratch reimplementation`) with mandatory justification for reimplementation
- `AGENTS.md`: Added "Patches are debt" policy requiring header comments with upstream tracking issues and removal criteria for all files in `patches/`

### Impact
Documentation-only change establishing architectural governance rules for AI-generated contributions. No runtime or breaking changes.