### PR TITLE
feat: detect Kitty keyboard protocol, show Ctrl+J hint for unsupported terminals (LLM-1561)

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -31,7 +31,7 @@ import lspExtension from "./extensions/lsp.js"
 import mcpAdapterExtension from "./extensions/mcp-adapter/index.js"
 import modelSwitchExtension from "./extensions/model-switch.js"
 import permissionsExtension from "./extensions/permissions/index.js"
-import { reserveShiftTabForPermissions } from "./extensions/permissions/keybindings.js"
+import { writeKimchiKeybindingDefaults } from "./extensions/permissions/keybindings.js"
 import promptEnrichmentExtension from "./extensions/prompt-construction/prompt-enrichment.js"
 import promptSummaryExtension from "./extensions/prompt-summary.js"
 import questionnaireExtension from "./extensions/questionnaire.js"
@@ -41,6 +41,8 @@ import statsExtension from "./extensions/stats/index.js"
 import tagsExtension from "./extensions/tags.js"
 import telemetryExtension from "./extensions/telemetry.js"
 import terminalColorsExtension from "./extensions/terminal-colors.js"
+import { probeKittyKeyboardSupport } from "./extensions/terminal-compat/keyboard-capability.js"
+import { emitTerminalCompatWarning } from "./extensions/terminal-compat/startup-warning.js"
 import toolRendererExtension from "./extensions/tool-renderer.js"
 import uiExtension from "./extensions/ui.js"
 import webFetchExtension from "./extensions/web-fetch/index.js"
@@ -178,7 +180,7 @@ try {
 
 		// Must run before main() so the keybindings file is loaded with the
 		// override in place.
-		reserveShiftTabForPermissions(agentDir)
+		writeKimchiKeybindingDefaults(agentDir)
 
 		// Share the discovered model metadata with extensions before main() runs.
 		// prompt-enrichment reads this to build ModelRegistry with live model IDs.
@@ -230,7 +232,14 @@ try {
 		// the kimchi-minimal-tints and terminal-colors extensions. Skip in ACP mode —
 		// stdout is the JSON-RPC channel and OSC escapes would corrupt the IDE's
 		// input stream.
-		if (!acpMode) await probeTerminalBackground()
+		if (!acpMode) {
+			await probeTerminalBackground()
+			await probeKittyKeyboardSupport()
+		}
+
+		// Emit warnings for terminals that don't support modifier-aware Enter.
+		// Runs after the keyboard-capability probe so the result is available.
+		emitTerminalCompatWarning(agentDir)
 
 		// Compare contents and only write when they differ. Restarts in a second
 		// terminal must be byte-identical no-ops because pi runs `fs.watch` on the

--- a/src/extensions/permissions/keybindings.test.ts
+++ b/src/extensions/permissions/keybindings.test.ts
@@ -1,0 +1,118 @@
+import { existsSync, mkdirSync, readFileSync, rmSync, writeFileSync } from "node:fs"
+import { dirname, resolve } from "node:path"
+import { fileURLToPath } from "node:url"
+import { afterEach, beforeEach, describe, expect, it } from "vitest"
+import { writeKimchiKeybindingDefaults } from "./keybindings.js"
+
+const __filename = fileURLToPath(import.meta.url)
+const __dirname = dirname(__filename)
+const testDir = resolve(__dirname, "../../.test-keybindings-fixture")
+
+function rmrf(path: string): void {
+	try {
+		if (!existsSync(path)) return
+		const stat = require("node:fs").statSync(path)
+		if (stat.isDirectory()) {
+			for (const entry of require("node:fs").readdirSync(path)) {
+				rmrf(resolve(path, entry))
+			}
+			rmSync(path, { recursive: true })
+		} else {
+			rmSync(path)
+		}
+	} catch {
+		// ignore errors during cleanup
+	}
+}
+
+beforeEach(() => {
+	rmrf(testDir)
+	mkdirSync(testDir, { recursive: true })
+})
+
+afterEach(() => {
+	rmrf(testDir)
+})
+
+describe("writeKimchiKeybindingDefaults", () => {
+	it("creates keybindings.json with shift+tab unbound and ctrl+j newline fallback", () => {
+		const keybindingsPath = resolve(testDir, "keybindings.json")
+
+		writeKimchiKeybindingDefaults(testDir)
+
+		expect(existsSync(keybindingsPath)).toBe(true)
+		const content = JSON.parse(readFileSync(keybindingsPath, "utf-8"))
+		expect(content["app.thinking.cycle"]).toBe("")
+		expect(content["tui.input.newLine"]).toBe("shift+enter,ctrl+j")
+	})
+
+	it("is idempotent - does not duplicate ctrl+j on re-run", () => {
+		const keybindingsPath = resolve(testDir, "keybindings.json")
+
+		writeKimchiKeybindingDefaults(testDir)
+		writeKimchiKeybindingDefaults(testDir)
+
+		const content = JSON.parse(readFileSync(keybindingsPath, "utf-8"))
+		expect(content["tui.input.newLine"]).toBe("shift+enter,ctrl+j")
+		// Should only have shift+enter and ctrl+j, no duplicates
+		const parts = content["tui.input.newLine"].split(",")
+		expect(parts.filter((p: string) => p === "ctrl+j").length).toBe(1)
+	})
+
+	it("preserves existing custom newLine binding and appends ctrl+j", () => {
+		const keybindingsPath = resolve(testDir, "keybindings.json")
+		writeFileSync(keybindingsPath, JSON.stringify({ "tui.input.newLine": "alt+enter" }))
+
+		writeKimchiKeybindingDefaults(testDir)
+
+		const content = JSON.parse(readFileSync(keybindingsPath, "utf-8"))
+		expect(content["tui.input.newLine"]).toBe("alt+enter,ctrl+j")
+	})
+
+	it("does NOT add ctrl+j if it's already bound elsewhere", () => {
+		const keybindingsPath = resolve(testDir, "keybindings.json")
+		// Simulate ctrl+j being used for submit
+		writeFileSync(keybindingsPath, JSON.stringify({ "tui.input.submit": "ctrl+j" }))
+
+		writeKimchiKeybindingDefaults(testDir)
+
+		const content = JSON.parse(readFileSync(keybindingsPath, "utf-8"))
+		// ctrl+j should NOT be added to newLine since it's used for submit
+		expect(content["tui.input.newLine"]).toBeUndefined()
+	})
+
+	it("does NOT add ctrl+j if newLine already contains it", () => {
+		const keybindingsPath = resolve(testDir, "keybindings.json")
+		writeFileSync(keybindingsPath, JSON.stringify({ "tui.input.newLine": "shift+enter,ctrl+j" }))
+
+		writeKimchiKeybindingDefaults(testDir)
+
+		const content = JSON.parse(readFileSync(keybindingsPath, "utf-8"))
+		expect(content["tui.input.newLine"]).toBe("shift+enter,ctrl+j")
+		const parts = content["tui.input.newLine"].split(",")
+		expect(parts.filter((p: string) => p === "ctrl+j").length).toBe(1)
+	})
+
+	it("handles malformed existing keybindings.json gracefully", () => {
+		const keybindingsPath = resolve(testDir, "keybindings.json")
+		writeFileSync(keybindingsPath, "not valid json {{{")
+
+		// Should not throw
+		expect(() => writeKimchiKeybindingDefaults(testDir)).not.toThrow()
+
+		const content = JSON.parse(readFileSync(keybindingsPath, "utf-8"))
+		expect(content["app.thinking.cycle"]).toBe("")
+		expect(content["tui.input.newLine"]).toBe("shift+enter,ctrl+j")
+	})
+
+	it("preserves other existing bindings", () => {
+		const keybindingsPath = resolve(testDir, "keybindings.json")
+		writeFileSync(keybindingsPath, JSON.stringify({ "some.other.binding": "value" }))
+
+		writeKimchiKeybindingDefaults(testDir)
+
+		const content = JSON.parse(readFileSync(keybindingsPath, "utf-8"))
+		expect(content["some.other.binding"]).toBe("value")
+		expect(content["app.thinking.cycle"]).toBe("")
+	})
+})

--- a/src/extensions/permissions/keybindings.ts
+++ b/src/extensions/permissions/keybindings.ts
@@ -5,8 +5,13 @@ import { dirname, resolve } from "node:path"
 // Returns true if the key appears in any binding value.
 function isKeyBoundElsewhere(current: Record<string, unknown>, key: string): boolean {
 	for (const [, value] of Object.entries(current)) {
-		if (typeof value === "string" && value.includes(key)) return true
-		if (Array.isArray(value) && value.some((v) => typeof v === "string" && v.includes(key))) return true
+		if (typeof value === "string") {
+			const parts = value.split(",").map((s) => s.trim())
+			if (parts.includes(key)) return true
+		}
+		if (Array.isArray(value)) {
+			if (value.some((v) => typeof v === "string" && v.trim() === key)) return true
+		}
 	}
 	return false
 }

--- a/src/extensions/permissions/keybindings.ts
+++ b/src/extensions/permissions/keybindings.ts
@@ -1,10 +1,50 @@
 import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs"
 import { dirname, resolve } from "node:path"
 
+// Check if a key is used as a binding value in any other binding.
+// Returns true if the key appears in any binding value.
+function isKeyBoundElsewhere(current: Record<string, unknown>, key: string): boolean {
+	for (const [, value] of Object.entries(current)) {
+		if (typeof value === "string" && value.includes(key)) return true
+		if (Array.isArray(value) && value.some((v) => typeof v === "string" && v.includes(key))) return true
+	}
+	return false
+}
+
+// Add ctrl+j as a fallback to tui.input.newLine if not already present
+// and not already bound elsewhere.
+function addNewlineFallback(current: Record<string, unknown>): boolean {
+	const fallback = "ctrl+j"
+	const existing = current["tui.input.newLine"]
+
+	// Don't add if it's already used as a binding elsewhere (conflict check)
+	if (isKeyBoundElsewhere(current, fallback)) return false
+
+	if (typeof existing === "string") {
+		const parts = existing.split(",").map((s) => s.trim())
+		if (!parts.includes(fallback)) {
+			current["tui.input.newLine"] = `${existing},${fallback}`
+			return true
+		}
+	} else if (Array.isArray(existing)) {
+		const list = existing.filter((s) => typeof s === "string") as string[]
+		if (!list.includes(fallback)) {
+			existing.push(fallback)
+			return true
+		}
+	} else {
+		current["tui.input.newLine"] = "shift+enter,ctrl+j"
+		return true
+	}
+	return false
+}
+
 // Unbind pi-mono's `app.thinking.cycle` so shift+tab is free for the
-// permissions extension to register. Must run before main() loads the
+// permissions extension to register. Also adds ctrl+j as a fallback for
+// newlines since many terminals (tmux, Terminal.app, VS Code terminal, etc.)
+// don't send modifier-aware Enter sequences. Must run before main() loads the
 // keybindings file. Idempotent.
-export function reserveShiftTabForPermissions(agentDir: string): void {
+export function writeKimchiKeybindingDefaults(agentDir: string): void {
 	const keybindingsPath = resolve(agentDir, "keybindings.json")
 	try {
 		let current: Record<string, unknown> = {}
@@ -18,12 +58,26 @@ export function reserveShiftTabForPermissions(agentDir: string): void {
 				// malformed; overwrite with a known-good default
 			}
 		}
-		if (current["app.thinking.cycle"] === "") return
 
-		current["app.thinking.cycle"] = ""
+		// Unbind shift+tab from thinking cycle
+		if (current["app.thinking.cycle"] !== "") {
+			current["app.thinking.cycle"] = ""
+		}
+
+		// Add ctrl+j as newline fallback if needed
+		const addedNewlineFallback = addNewlineFallback(current)
+
+		// Only write if we made changes
+		if (current["app.thinking.cycle"] === "" && !addedNewlineFallback && existsSync(keybindingsPath)) {
+			return
+		}
+
 		mkdirSync(dirname(keybindingsPath), { recursive: true })
 		writeFileSync(keybindingsPath, `${JSON.stringify(current, null, 2)}\n`, "utf-8")
 	} catch {
 		// best-effort; a failure here just means shift+tab stays bound to thinking
 	}
 }
+
+// Keep old name as deprecated alias for backwards compatibility
+export const reserveShiftTabForPermissions = writeKimchiKeybindingDefaults

--- a/src/extensions/terminal-compat/keyboard-capability.test.ts
+++ b/src/extensions/terminal-compat/keyboard-capability.test.ts
@@ -1,0 +1,17 @@
+import { describe, expect, it } from "vitest"
+import { getKittyKeyboardSupport, probeKittyKeyboardSupport } from "./keyboard-capability.js"
+
+describe("getKittyKeyboardSupport", () => {
+	it("returns undefined before probing", () => {
+		expect(getKittyKeyboardSupport()).toBeUndefined()
+	})
+})
+
+describe("probeKittyKeyboardSupport", () => {
+	it("returns false in non-TTY envs (CI / vitest)", async () => {
+		const result = await probeKittyKeyboardSupport()
+		// In CI stdin/stdout aren't TTYs, so shouldSkipProbe returns true.
+		expect(result).toBe(false)
+		expect(getKittyKeyboardSupport()).toBe(false)
+	})
+})

--- a/src/extensions/terminal-compat/keyboard-capability.ts
+++ b/src/extensions/terminal-compat/keyboard-capability.ts
@@ -1,0 +1,82 @@
+// Detect whether the terminal supports the Kitty keyboard protocol (CSI u),
+// which is required for modifier-aware Enter (Shift+Enter → newline).
+//
+// Unsupported terminals include:
+//   - macOS Terminal.app, Windows Conhost, many SSH clients
+//   - tmux without `extended-keys on`
+//   - screen / GNU screen
+// Supported terminals include:
+//   - Ghostty, Kitty, WezTerm, Alacritty, iTerm2, Warp, VS Code terminal
+//
+// Probe sequence: send CSI ? u, expect CSI ? <flags> u within the timeout.
+//
+// Adapted from the same pattern used in src/terminal-bg-probe.ts.
+
+export const QUERY_KITTY_KEYBOARD = "\x1b[?u"
+const QUERY_TIMEOUT_MS = 200
+const MAX_BUFFER_BYTES = 4096
+
+let cachedSupportsKittyKeyboard: boolean | undefined
+let probed = false
+
+export function getKittyKeyboardSupport(): boolean | undefined {
+	return cachedSupportsKittyKeyboard
+}
+
+function shouldSkipProbe(): boolean {
+	if (!process.stdin.isTTY || !process.stdout.isTTY) return true
+	// tmux intercepts and may not forward the query correctly.
+	if (process.env.TMUX) return true
+	// screen historically mangles unknown CSI sequences.
+	const term = process.env.TERM ?? ""
+	if (term === "dumb" || term.startsWith("screen")) return true
+	return false
+}
+
+export async function probeKittyKeyboardSupport(): Promise<boolean> {
+	if (probed) return cachedSupportsKittyKeyboard ?? false
+	probed = true
+
+	if (shouldSkipProbe()) {
+		cachedSupportsKittyKeyboard = false
+		return false
+	}
+
+	const wasRaw = process.stdin.isRaw
+	process.stdin.setRawMode?.(true)
+	process.stdin.resume()
+
+	return new Promise<boolean>((resolveResult) => {
+		let buffer = ""
+
+		const finish = (supported: boolean, leftover: string) => {
+			clearTimeout(timeout)
+			process.stdin.removeListener("data", handler)
+			cachedSupportsKittyKeyboard = supported
+			if (leftover.length > 0) process.stdin.unshift(Buffer.from(leftover, "utf8"))
+			if (!wasRaw) process.stdin.setRawMode?.(false)
+			process.stdin.pause()
+			resolveResult(supported)
+		}
+
+		const handler = (data: Buffer | string) => {
+			buffer += data.toString()
+			if (buffer.length > MAX_BUFFER_BYTES) {
+				buffer = buffer.slice(buffer.length - MAX_BUFFER_BYTES)
+			}
+			// Look for CSI ? <digits> u  response
+			// biome-ignore lint/suspicious/noControlCharactersInRegex: Kitty keyboard protocol response
+			const match = buffer.match(/\x1b\[\?(\d+)u/)
+			if (match) {
+				const idx = match.index ?? 0
+				const leftover = buffer.slice(0, idx) + buffer.slice(idx + match[0].length)
+				finish(true, leftover)
+			}
+		}
+
+		const timeout = setTimeout(() => finish(false, buffer), QUERY_TIMEOUT_MS)
+
+		process.stdin.on("data", handler)
+		process.stdout.write(QUERY_KITTY_KEYBOARD)
+	})
+}

--- a/src/extensions/terminal-compat/keyboard-capability.ts
+++ b/src/extensions/terminal-compat/keyboard-capability.ts
@@ -17,7 +17,7 @@ const QUERY_TIMEOUT_MS = 200
 const MAX_BUFFER_BYTES = 4096
 
 let cachedSupportsKittyKeyboard: boolean | undefined
-let probed = false
+let inFlightProbe: Promise<boolean> | undefined
 
 export function getKittyKeyboardSupport(): boolean | undefined {
 	return cachedSupportsKittyKeyboard
@@ -34,49 +34,52 @@ function shouldSkipProbe(): boolean {
 }
 
 export async function probeKittyKeyboardSupport(): Promise<boolean> {
-	if (probed) return cachedSupportsKittyKeyboard ?? false
-	probed = true
+	if (inFlightProbe) return inFlightProbe
 
-	if (shouldSkipProbe()) {
-		cachedSupportsKittyKeyboard = false
-		return false
-	}
-
-	const wasRaw = process.stdin.isRaw
-	process.stdin.setRawMode?.(true)
-	process.stdin.resume()
-
-	return new Promise<boolean>((resolveResult) => {
-		let buffer = ""
-
-		const finish = (supported: boolean, leftover: string) => {
-			clearTimeout(timeout)
-			process.stdin.removeListener("data", handler)
-			cachedSupportsKittyKeyboard = supported
-			if (leftover.length > 0) process.stdin.unshift(Buffer.from(leftover, "utf8"))
-			if (!wasRaw) process.stdin.setRawMode?.(false)
-			process.stdin.pause()
-			resolveResult(supported)
+	inFlightProbe = (async () => {
+		if (shouldSkipProbe()) {
+			cachedSupportsKittyKeyboard = false
+			return false
 		}
 
-		const handler = (data: Buffer | string) => {
-			buffer += data.toString()
-			if (buffer.length > MAX_BUFFER_BYTES) {
-				buffer = buffer.slice(buffer.length - MAX_BUFFER_BYTES)
-			}
-			// Look for CSI ? <digits> u  response
-			// biome-ignore lint/suspicious/noControlCharactersInRegex: Kitty keyboard protocol response
-			const match = buffer.match(/\x1b\[\?(\d+)u/)
-			if (match) {
-				const idx = match.index ?? 0
-				const leftover = buffer.slice(0, idx) + buffer.slice(idx + match[0].length)
-				finish(true, leftover)
-			}
-		}
+		const wasRaw = process.stdin.isRaw
+		process.stdin.setRawMode?.(true)
+		process.stdin.resume()
 
-		const timeout = setTimeout(() => finish(false, buffer), QUERY_TIMEOUT_MS)
+		return new Promise<boolean>((resolveResult) => {
+			let buffer = ""
 
-		process.stdin.on("data", handler)
-		process.stdout.write(QUERY_KITTY_KEYBOARD)
-	})
+			const finish = (supported: boolean, leftover: string) => {
+				clearTimeout(timeout)
+				process.stdin.removeListener("data", handler)
+				cachedSupportsKittyKeyboard = supported
+				if (leftover.length > 0) process.stdin.unshift(Buffer.from(leftover, "utf8"))
+				if (!wasRaw) process.stdin.setRawMode?.(false)
+				process.stdin.pause()
+				resolveResult(supported)
+			}
+
+			const handler = (data: Buffer | string) => {
+				buffer += data.toString()
+				if (buffer.length > MAX_BUFFER_BYTES) {
+					buffer = buffer.slice(buffer.length - MAX_BUFFER_BYTES)
+				}
+				// Look for CSI ? <digits> u  response
+				// biome-ignore lint/suspicious/noControlCharactersInRegex: Kitty keyboard protocol response
+				const match = buffer.match(/\[\?(\d+)u/)
+				if (match) {
+					const idx = match.index ?? 0
+					const leftover = buffer.slice(0, idx) + buffer.slice(idx + match[0].length)
+					finish(true, leftover)
+				}
+			}
+
+			const timeout = setTimeout(() => finish(false, buffer), QUERY_TIMEOUT_MS)
+
+			process.stdin.on("data", handler)
+			process.stdout.write(QUERY_KITTY_KEYBOARD)
+		})
+	})()
+
+	return inFlightProbe
 }

--- a/src/extensions/terminal-compat/startup-warning.test.ts
+++ b/src/extensions/terminal-compat/startup-warning.test.ts
@@ -1,0 +1,247 @@
+import { existsSync, mkdirSync, readFileSync, rmSync, writeFileSync } from "node:fs"
+import { dirname, resolve } from "node:path"
+import { fileURLToPath } from "node:url"
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
+
+const __filename = fileURLToPath(import.meta.url)
+const __dirname = dirname(__filename)
+const testDir = resolve(__dirname, "../../.test-startup-warning-fixture")
+
+function rmrf(path: string): void {
+	try {
+		if (!existsSync(path)) return
+		const stat = require("node:fs").statSync(path)
+		if (stat.isDirectory()) {
+			for (const entry of require("node:fs").readdirSync(path)) {
+				rmrf(resolve(path, entry))
+			}
+			rmSync(path, { recursive: true })
+		} else {
+			rmSync(path)
+		}
+	} catch {
+		// ignore errors during cleanup
+	}
+}
+
+beforeEach(() => {
+	rmrf(testDir)
+	mkdirSync(testDir, { recursive: true })
+	vi.resetModules()
+})
+
+afterEach(() => {
+	rmrf(testDir)
+})
+
+describe("emitTerminalCompatWarning", () => {
+	it("shows tmux warning when TMUX env is set", async () => {
+		const originalTmux = process.env.TMUX
+		const originalTermProgram = process.env.TERM_PROGRAM
+
+		try {
+			process.env.TMUX = "/tmp/tmux-1000/default,1234,0"
+			// biome-ignore lint/performance/noDelete: env-var cleanup needs a real delete; assigning undefined would coerce to the literal string "undefined".
+			delete process.env.TERM_PROGRAM
+			Object.defineProperty(process.stdin, "isTTY", { value: true, configurable: true })
+
+			const warnings: string[] = []
+			vi.spyOn(console, "warn").mockImplementation((msg: string) => {
+				warnings.push(msg)
+			})
+
+			const { emitTerminalCompatWarning } = await import("./startup-warning.js")
+			emitTerminalCompatWarning(testDir)
+
+			expect(warnings.length).toBeGreaterThan(0)
+			expect(warnings[0]).toContain("tmux")
+			expect(warnings[0]).toContain("extended-keys")
+		} finally {
+			if (originalTmux !== undefined) {
+				process.env.TMUX = originalTmux
+			} else {
+				// biome-ignore lint/performance/noDelete: env-var cleanup needs a real delete; assigning undefined would coerce to the literal string "undefined".
+				delete process.env.TMUX
+			}
+			if (originalTermProgram !== undefined) {
+				process.env.TERM_PROGRAM = originalTermProgram
+			} else {
+				// biome-ignore lint/performance/noDelete: env-var cleanup needs a real delete; assigning undefined would coerce to the literal string "undefined".
+				delete process.env.TERM_PROGRAM
+			}
+			Object.defineProperty(process.stdin, "isTTY", { value: true, configurable: true })
+		}
+	})
+
+	it("shows keyboard-protocol warning when getKittyKeyboardSupport returns false", async () => {
+		const originalTmux = process.env.TMUX
+
+		try {
+			// biome-ignore lint/performance/noDelete: env-var cleanup needs a real delete; assigning undefined would coerce to the literal string "undefined".
+			delete process.env.TMUX
+			Object.defineProperty(process.stdin, "isTTY", { value: true, configurable: true })
+
+			const warnings: string[] = []
+			vi.spyOn(console, "warn").mockImplementation((msg: string) => {
+				warnings.push(msg)
+			})
+
+			// Mock the keyboard capability getter so we appear unsupported.
+			const { getKittyKeyboardSupport } = await import("./keyboard-capability.js")
+			vi.spyOn(await import("./keyboard-capability.js"), "getKittyKeyboardSupport").mockReturnValue(false)
+
+			const { emitTerminalCompatWarning } = await import("./startup-warning.js")
+			emitTerminalCompatWarning(testDir)
+
+			expect(warnings.length).toBeGreaterThan(0)
+			expect(warnings[0]).toContain("does not send modifier keys")
+		} finally {
+			if (originalTmux !== undefined) {
+				process.env.TMUX = originalTmux
+			} else {
+				// biome-ignore lint/performance/noDelete: env-var cleanup needs a real delete; assigning undefined would coerce to the literal string "undefined".
+				delete process.env.TMUX
+			}
+			Object.defineProperty(process.stdin, "isTTY", { value: true, configurable: true })
+			vi.restoreAllMocks()
+		}
+	})
+
+	it("respects nag control - does not show warning twice same day", async () => {
+		const originalTmux = process.env.TMUX
+		const originalTermProgram = process.env.TERM_PROGRAM
+
+		try {
+			process.env.TMUX = "/tmp/tmux-1000/default,1234,0"
+			// biome-ignore lint/performance/noDelete: env-var cleanup needs a real delete; assigning undefined would coerce to the literal string "undefined".
+			delete process.env.TERM_PROGRAM
+			Object.defineProperty(process.stdin, "isTTY", { value: true, configurable: true })
+
+			const warnings: string[] = []
+			vi.spyOn(console, "warn").mockImplementation((msg: string) => {
+				warnings.push(msg)
+			})
+
+			// First call - should show warning
+			const { emitTerminalCompatWarning: emit1 } = await import("./startup-warning.js")
+			emit1(testDir)
+			expect(warnings.length).toBe(1)
+
+			// Second call - should NOT show warning (same day)
+			vi.resetModules()
+			const { emitTerminalCompatWarning: emit2 } = await import("./startup-warning.js")
+			emit2(testDir)
+			expect(warnings.length).toBe(1) // Still 1, no new warning
+		} finally {
+			if (originalTmux !== undefined) {
+				process.env.TMUX = originalTmux
+			} else {
+				// biome-ignore lint/performance/noDelete: env-var cleanup needs a real delete; assigning undefined would coerce to the literal string "undefined".
+				delete process.env.TMUX
+			}
+			if (originalTermProgram !== undefined) {
+				process.env.TERM_PROGRAM = originalTermProgram
+			} else {
+				// biome-ignore lint/performance/noDelete: env-var cleanup needs a real delete; assigning undefined would coerce to the literal string "undefined".
+				delete process.env.TERM_PROGRAM
+			}
+			Object.defineProperty(process.stdin, "isTTY", { value: true, configurable: true })
+		}
+	})
+
+	it("persists lastTerminalWarnings to settings.json", async () => {
+		const originalTmux = process.env.TMUX
+		const originalTermProgram = process.env.TERM_PROGRAM
+		const settingsPath = resolve(testDir, "settings.json")
+
+		try {
+			process.env.TMUX = "/tmp/tmux-1000/default,1234,0"
+			// biome-ignore lint/performance/noDelete: env-var cleanup needs a real delete; assigning undefined would coerce to the literal string "undefined".
+			delete process.env.TERM_PROGRAM
+			Object.defineProperty(process.stdin, "isTTY", { value: true, configurable: true })
+
+			const { emitTerminalCompatWarning } = await import("./startup-warning.js")
+			emitTerminalCompatWarning(testDir)
+
+			expect(existsSync(settingsPath)).toBe(true)
+			const settings = JSON.parse(readFileSync(settingsPath, "utf-8"))
+			expect(settings.lastTerminalWarnings).toBeDefined()
+			expect(settings.lastTerminalWarnings?.tmux).toBeDefined()
+			expect(settings.lastTerminalWarnings?.tmux).toMatch(/^\d{4}-\d{2}-\d{2}$/)
+		} finally {
+			if (originalTmux !== undefined) {
+				process.env.TMUX = originalTmux
+			} else {
+				// biome-ignore lint/performance/noDelete: env-var cleanup needs a real delete; assigning undefined would coerce to the literal string "undefined".
+				delete process.env.TMUX
+			}
+			if (originalTermProgram !== undefined) {
+				process.env.TERM_PROGRAM = originalTermProgram
+			} else {
+				// biome-ignore lint/performance/noDelete: env-var cleanup needs a real delete; assigning undefined would coerce to the literal string "undefined".
+				delete process.env.TERM_PROGRAM
+			}
+			Object.defineProperty(process.stdin, "isTTY", { value: true, configurable: true })
+		}
+	})
+
+	it("does not show warning when not a TTY", async () => {
+		try {
+			Object.defineProperty(process.stdin, "isTTY", { value: false, configurable: true })
+
+			const warnings: string[] = []
+			vi.spyOn(console, "warn").mockImplementation((msg: string) => {
+				warnings.push(msg)
+			})
+
+			const { emitTerminalCompatWarning } = await import("./startup-warning.js")
+			emitTerminalCompatWarning(testDir)
+
+			expect(warnings.length).toBe(0)
+		} finally {
+			Object.defineProperty(process.stdin, "isTTY", { value: true, configurable: true })
+		}
+	})
+
+	it("preserves existing settings.json fields", async () => {
+		const originalTmux = process.env.TMUX
+		const originalTermProgram = process.env.TERM_PROGRAM
+		const settingsPath = resolve(testDir, "settings.json")
+
+		try {
+			process.env.TMUX = "/tmp/tmux-1000/default,1234,0"
+			// biome-ignore lint/performance/noDelete: env-var cleanup needs a real delete; assigning undefined would coerce to the literal string "undefined".
+			delete process.env.TERM_PROGRAM
+			Object.defineProperty(process.stdin, "isTTY", { value: true, configurable: true })
+
+			// Create existing settings.json with custom fields
+			writeFileSync(
+				settingsPath,
+				JSON.stringify({ quietStartup: true, theme: "my-custom-theme", someOtherField: "value" }),
+			)
+
+			const { emitTerminalCompatWarning } = await import("./startup-warning.js")
+			emitTerminalCompatWarning(testDir)
+
+			const settings = JSON.parse(readFileSync(settingsPath, "utf-8"))
+			expect(settings.quietStartup).toBe(true)
+			expect(settings.theme).toBe("my-custom-theme")
+			expect(settings.someOtherField).toBe("value")
+			expect(settings.lastTerminalWarnings).toBeDefined()
+		} finally {
+			if (originalTmux !== undefined) {
+				process.env.TMUX = originalTmux
+			} else {
+				// biome-ignore lint/performance/noDelete: env-var cleanup needs a real delete; assigning undefined would coerce to the literal string "undefined".
+				delete process.env.TMUX
+			}
+			if (originalTermProgram !== undefined) {
+				process.env.TERM_PROGRAM = originalTermProgram
+			} else {
+				// biome-ignore lint/performance/noDelete: env-var cleanup needs a real delete; assigning undefined would coerce to the literal string "undefined".
+				delete process.env.TERM_PROGRAM
+			}
+			Object.defineProperty(process.stdin, "isTTY", { value: true, configurable: true })
+		}
+	})
+})

--- a/src/extensions/terminal-compat/startup-warning.ts
+++ b/src/extensions/terminal-compat/startup-warning.ts
@@ -1,0 +1,77 @@
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs"
+import { dirname, resolve } from "node:path"
+import { getKittyKeyboardSupport } from "./keyboard-capability.js"
+
+interface TerminalWarningSettings {
+	quietStartup?: boolean
+	theme?: string
+	lastTerminalWarnings?: Record<string, string>
+}
+
+// Check if a terminal warning should be shown based on nag control.
+// Returns true if the warning should be shown, false if it was shown recently.
+function shouldShowWarning(agentDir: string, terminalType: string): boolean {
+	const settingsPath = resolve(agentDir, "settings.json")
+	const today = new Date().toISOString().split("T")[0] // YYYY-MM-DD
+
+	let settings: TerminalWarningSettings = {}
+	if (existsSync(settingsPath)) {
+		try {
+			const parsed = JSON.parse(readFileSync(settingsPath, "utf-8"))
+			if (parsed && typeof parsed === "object" && !Array.isArray(parsed)) {
+				settings = parsed as TerminalWarningSettings
+			}
+		} catch {
+			// malformed; treat as no existing settings
+		}
+	}
+
+	const lastWarnings = settings.lastTerminalWarnings ?? {}
+	const lastShown = lastWarnings[terminalType]
+
+	// Show if never shown or shown more than 24h ago
+	if (!lastShown || lastShown < today) {
+		// Update the last shown date
+		settings.lastTerminalWarnings = { ...lastWarnings, [terminalType]: today }
+		try {
+			mkdirSync(dirname(settingsPath), { recursive: true })
+			writeFileSync(settingsPath, `${JSON.stringify(settings, null, 2)}\n`, "utf-8")
+		} catch {
+			// best-effort; showing the warning is more important than persisting the date
+		}
+		return true
+	}
+
+	return false
+}
+
+// Emit a warning about terminal compatibility issues if detected.
+// Call this before main() so the warning appears at startup.
+export function emitTerminalCompatWarning(agentDir: string): void {
+	if (!process.stdin.isTTY) return
+
+	const isTmux = !!process.env.TMUX
+
+	if (isTmux) {
+		if (shouldShowWarning(agentDir, "tmux")) {
+			console.warn(
+				"⚠  kimchi: Shift+Enter may not work in tmux.\n" +
+					"   Fix: add these to ~/.tmux.conf and restart tmux:\n" +
+					"     set -g extended-keys on\n" +
+					"     set -g extended-keys-format csi-u\n" +
+					"   Alternative: use Ctrl+J to insert newlines.\n",
+			)
+		}
+	}
+
+	if (getKittyKeyboardSupport() === false) {
+		if (shouldShowWarning(agentDir, "no_keyboard_protocol")) {
+			console.warn(
+				"⚠  kimchi: This terminal does not send modifier keys with Enter.\n" +
+					"   Shift+Enter won't insert newlines.\n" +
+					"   Alternative: use Ctrl+J to insert newlines.\n" +
+					"   Recommend: switch to Ghostty, Kitty, iTerm2, or WezTerm.\n",
+			)
+		}
+	}
+}

--- a/src/extensions/ui.ts
+++ b/src/extensions/ui.ts
@@ -5,6 +5,7 @@ import { join, resolve } from "node:path"
 import type { Api, Model } from "@earendil-works/pi-ai"
 import type { ExtensionAPI, ExtensionContext } from "@earendil-works/pi-coding-agent"
 import { isEditToolResult, isWriteToolResult } from "@earendil-works/pi-coding-agent"
+import { Box, Text } from "@earendil-works/pi-tui"
 import { isKeyRelease, matchesKey } from "@earendil-works/pi-tui"
 import type { TUI } from "@earendil-works/pi-tui"
 import { RST_FG, resolvedAccentFg } from "../ansi.js"
@@ -197,8 +198,6 @@ export default function uiExtension(pi: ExtensionAPI) {
 									const settingsFile = settingsPath
 									return {
 										render(width: number): string[] {
-											const { Box } = require("@mariozechner/pi-tui")
-											const { Text } = require("@mariozechner/pi-tui")
 											const box = new Box(2, 1)
 											box.addChild(new Text(theme.inverse("  ⚠  Shift+Enter doesn't work in this terminal  ")))
 											box.addChild(new Text(""))

--- a/src/extensions/ui.ts
+++ b/src/extensions/ui.ts
@@ -1,5 +1,5 @@
 import { spawn } from "node:child_process"
-import { existsSync, readFileSync } from "node:fs"
+import { existsSync, readFileSync, writeFileSync } from "node:fs"
 import { homedir } from "node:os"
 import { join, resolve } from "node:path"
 import type { Api, Model } from "@earendil-works/pi-ai"
@@ -184,9 +184,17 @@ export default function uiExtension(pi: ExtensionAPI) {
 					if (existsSync(kbPath)) {
 						const kb = JSON.parse(readFileSync(kbPath, "utf-8"))
 						const nl = kb["tui.input.newLine"]
-						if (typeof nl === "string" && nl.includes("ctrl+j")) {
+						const settingsPath = resolve(agentDir, "settings.json")
+						let settingsData: Record<string, unknown> = {}
+						if (existsSync(settingsPath)) {
+							try {
+								settingsData = JSON.parse(readFileSync(settingsPath, "utf-8"))
+							} catch {}
+						}
+						if (!settingsData.newlineHintDismissed && typeof nl === "string" && nl.includes("ctrl+j")) {
 							ctx.ui.custom(
 								(_tui, theme, _kb, done) => {
+									const settingsFile = settingsPath
 									return {
 										render(width: number): string[] {
 											const { Box } = require("@mariozechner/pi-tui")
@@ -194,10 +202,10 @@ export default function uiExtension(pi: ExtensionAPI) {
 											const box = new Box(2, 1)
 											box.addChild(new Text(theme.inverse("  ⚠  Shift+Enter doesn't work in this terminal  ")))
 											box.addChild(new Text(""))
-											box.addChild(new Text(`${theme.bold("Ctrl+J")}${" ".padEnd(12)}→  insert a newline`))
-											box.addChild(new Text(`\\ + Enter${" ".padEnd(9)}→  insert a newline`))
+											box.addChild(new Text(`${theme.bold("Ctrl+J")}${" ".padEnd(13)}→  insert a newline`))
+											box.addChild(new Text(`\\ + Enter${" ".padEnd(10)}→  insert a newline`))
 											box.addChild(new Text(""))
-											box.addChild(new Text(theme.fg("muted", "Press Enter to dismiss")))
+											box.addChild(new Text(theme.fg("muted", "Enter - dismiss   d - don't remind again")))
 											const accent = theme.getFgAnsi("accent")
 											const reset = "\x1b[0m"
 											const hbar = "─"
@@ -213,6 +221,19 @@ export default function uiExtension(pi: ExtensionAPI) {
 										invalidate() {},
 										handleInput(data: string): void {
 											if (matchesKey(data, "enter")) done(undefined)
+											if (data === "d") {
+												try {
+													const s: Record<string, unknown> = {}
+													if (existsSync(settingsFile)) {
+														try {
+															Object.assign(s, JSON.parse(readFileSync(settingsFile, "utf-8")))
+														} catch {}
+													}
+													s.newlineHintDismissed = true
+													writeFileSync(settingsFile, JSON.stringify(s, null, 2))
+												} catch {}
+												done(undefined)
+											}
 										},
 										wantsKeyRelease: false,
 									}

--- a/src/extensions/ui.ts
+++ b/src/extensions/ui.ts
@@ -106,7 +106,7 @@ export default function uiExtension(pi: ExtensionAPI) {
 	let sessionStartMs = 0
 	let linesAdded = 0
 	let linesRemoved = 0
-	let newlineHintShown = false
+	let newlineHintHandle: { hide(): void } | null = null
 
 	const refresh = (status: "idle" | "generating") => {
 		if (!currentCtx?.hasUI || !scriptFooter || !scriptTui || !scriptCmd) return
@@ -185,15 +185,46 @@ export default function uiExtension(pi: ExtensionAPI) {
 						const kb = JSON.parse(readFileSync(kbPath, "utf-8"))
 						const nl = kb["tui.input.newLine"]
 						if (typeof nl === "string" && nl.includes("ctrl+j")) {
-							ctx.ui.setWidget(
-								"newline-hint",
-								[
-									ctx.ui.theme.fg("accent", "Tip: ") +
-										ctx.ui.theme.fg("muted", "Shift+Enter doesn't work here. Use Ctrl+J to insert a newline."),
-								],
-								{ placement: "aboveEditor" },
+							ctx.ui.custom(
+								(_tui, theme, _kb, done) => {
+									return {
+										render(width: number): string[] {
+											const { Box } = require("@mariozechner/pi-tui")
+											const { Text } = require("@mariozechner/pi-tui")
+											const box = new Box(2, 1)
+											box.addChild(new Text(theme.inverse("  ⚠  Shift+Enter doesn't work in this terminal  ")))
+											box.addChild(new Text(""))
+											box.addChild(new Text(`${theme.bold("Ctrl+J")}${" ".padEnd(12)}→  insert a newline`))
+											box.addChild(new Text(`\\ + Enter${" ".padEnd(9)}→  insert a newline`))
+											box.addChild(new Text(""))
+											box.addChild(new Text(theme.fg("muted", "Press Enter to dismiss")))
+											const accent = theme.getFgAnsi("accent")
+											const reset = "\x1b[0m"
+											const hbar = "─"
+											const inner = width - 2
+											const lines = box.render(inner)
+											const bordered = lines.map((l: string, i: number) => {
+												if (i === 0) return `${accent}┌${hbar.repeat(inner)}┐${reset}`
+												if (i === lines.length - 1) return `${accent}└${hbar.repeat(inner)}┘${reset}`
+												return `${accent}│${reset}${l}${accent}│${reset}`
+											})
+											return bordered
+										},
+										invalidate() {},
+										handleInput(data: string): void {
+											if (matchesKey(data, "enter")) done(undefined)
+										},
+										wantsKeyRelease: false,
+									}
+								},
+								{
+									overlay: true,
+									overlayOptions: { anchor: "center" },
+									onHandle: (handle) => {
+										newlineHintHandle = handle
+									},
+								},
 							)
-							newlineHintShown = true
 						}
 					}
 				} catch {
@@ -258,9 +289,9 @@ export default function uiExtension(pi: ExtensionAPI) {
 			ctx.shutdown()
 		}
 
-		if (newlineHintShown) {
-			ctx.ui.setWidget("newline-hint", undefined)
-			newlineHintShown = false
+		if (newlineHintHandle) {
+			newlineHintHandle.hide()
+			newlineHintHandle = null
 		}
 	})
 

--- a/src/extensions/ui.ts
+++ b/src/extensions/ui.ts
@@ -1,7 +1,7 @@
 import { spawn } from "node:child_process"
-import { readFileSync } from "node:fs"
+import { existsSync, readFileSync } from "node:fs"
 import { homedir } from "node:os"
-import { join } from "node:path"
+import { join, resolve } from "node:path"
 import type { Api, Model } from "@earendil-works/pi-ai"
 import type { ExtensionAPI, ExtensionContext } from "@earendil-works/pi-coding-agent"
 import { isEditToolResult, isWriteToolResult } from "@earendil-works/pi-coding-agent"
@@ -15,6 +15,7 @@ import { collapseAll, expandNext, resetState } from "../expand-state.js"
 import { isBareExitAlias } from "./exit-utils.js"
 import { getMultiModelEnabled } from "./prompt-construction/prompt-enrichment.js"
 import { createWorkingAnimator } from "./spinner.js"
+import { getKittyKeyboardSupport } from "./terminal-compat/keyboard-capability.js"
 
 function modelsAreEqual(a: Model<Api>, b: Model<Api>): boolean {
 	return a.provider === b.provider && a.id === b.id
@@ -105,6 +106,7 @@ export default function uiExtension(pi: ExtensionAPI) {
 	let sessionStartMs = 0
 	let linesAdded = 0
 	let linesRemoved = 0
+	let newlineHintShown = false
 
 	const refresh = (status: "idle" | "generating") => {
 		if (!currentCtx?.hasUI || !scriptFooter || !scriptTui || !scriptCmd) return
@@ -169,6 +171,37 @@ export default function uiExtension(pi: ExtensionAPI) {
 			return scriptFooter
 		})
 
+		// Surface the Ctrl+J newline tip inside the TUI for terminals that don't
+		// support the Kitty keyboard protocol (the real root-cause behind Shift+Enter
+		// not working). The startup console warning is easy to miss (nag-throttled
+		// and swallowed by TUI init), so a persistent per-session widget is more
+		// visible than a one-time notification.
+		if (getKittyKeyboardSupport() === false && ctx.hasUI) {
+			const agentDir = process.env.KIMCHI_CODING_AGENT_DIR
+			if (agentDir) {
+				try {
+					const kbPath = resolve(agentDir, "keybindings.json")
+					if (existsSync(kbPath)) {
+						const kb = JSON.parse(readFileSync(kbPath, "utf-8"))
+						const nl = kb["tui.input.newLine"]
+						if (typeof nl === "string" && nl.includes("ctrl+j")) {
+							ctx.ui.setWidget(
+								"newline-hint",
+								[
+									ctx.ui.theme.fg("accent", "Tip: ") +
+										ctx.ui.theme.fg("muted", "Shift+Enter doesn't work here. Use Ctrl+J to insert a newline."),
+								],
+								{ placement: "aboveEditor" },
+							)
+							newlineHintShown = true
+						}
+					}
+				} catch {
+					// best-effort; don't break startup if keybindings are unreadable
+				}
+			}
+		}
+
 		ctx.ui.setEditorComponent((tui, editorTheme, keybindings) => {
 			tui.setShowHardwareCursor(true)
 			const editor = new PromptEditor(tui, editorTheme, keybindings, ctx.ui.theme)
@@ -223,6 +256,11 @@ export default function uiExtension(pi: ExtensionAPI) {
 	pi.on("input", (event, ctx) => {
 		if (isBareExitAlias(event.text)) {
 			ctx.shutdown()
+		}
+
+		if (newlineHintShown) {
+			ctx.ui.setWidget("newline-hint", undefined)
+			newlineHintShown = false
 		}
 	})
 


### PR DESCRIPTION
## Problem

Shift+Enter is supposed to insert a newline, but on many terminals it submits the message instead. The root cause is that **without the Kitty keyboard protocol (CSI u), Shift+Enter sends the exact same bytes as plain Enter (`\r`).** The application has no way to distinguish them.

## Affected terminals

| Terminal | Shift+Enter behavior | Notes |
|----------|----------------------|-------|
| macOS Terminal.app | submits (plain `\r`) | no modifier-aware key support |
| Windows Terminal | submits (plain `\r`) | supports CSI u in recent versions but not by default |
| tmux < 3.2 / without `extended-keys` | submits (plain `\r`) | intercepts and drops modifier sequences |
| xterm.js < 7.0 (Cursor, older editors) | submits (plain `\r`) | [xtermjs/xterm.js#5737](https://github.com/xtermjs/xterm.js/pull/5737) |
| zellij | submits | mixed protocol forwarding |
| Alacritty (default config) | submits | fixed via keybinding override |

## How we detect it

Rather than maintaining a hardcoded blocklist of `TERM_PROGRAM` values, we now **probe the terminal at startup** for Kitty keyboard protocol support:

1. Send `CSI ? u` (query progressive enhancement status)
2. Wait up to 200ms for `CSI ? <flags> u`
3. If no response → terminal does not support modifier-aware keys → show the hint

This pattern is documented in the Kitty spec and is the same approach used by [Ink](https://github.com/vadimdemedes/ink/pull/895) and `gsd-pi` (see [superset-sh/superset#2470](https://github.com/superset-sh/superset/issues/2470)).

## What the user sees

**Startup console warning** (nag-throttled to once per day):

```
⚠  kimchi: This terminal does not send modifier keys with Enter.
   Shift+Enter won't insert newlines.
   Alternative: use Ctrl+J to insert newlines.
```

**In-app TUI overlay** (centered modal, dismissible once per session):

```
┌──────────────────────────────────────┐
│   ⚠  Shift+Enter doesn't work in this terminal   │
│                                                │
│   Ctrl+J             →  insert a newline       │
│   \ + Enter          →  insert a newline       │
│                                                │
│   Enter  -  dismiss   d  -  don't remind again │
└──────────────────────────────────────────────┘
```

<img width="1146" height="732" alt="image" src="https://github.com/user-attachments/assets/e63dfe7c-2cd4-42f2-8dc0-19d0d3afeecf" />


The overlay reads `newlineHintDismissed` from `settings.json` and skips showing if already dismissed. Pressing `d` writes the flag to suppress future reminders.

## Keybinding fallback

On first run we now automatically add `ctrl+j` as a fallback to `tui.input.newLine` in `keybindings.json`:

```json
{
  "tui.input.newLine": "shift+enter,ctrl+j"
}
```

This is idempotent and only added when `ctrl+j` isn't already bound elsewhere.

## References

- Kovid Goyal (Kitty author) on why legacy terminals can't distinguish Shift+Enter: [kitty#477](https://github.com/kovidgoyal/kitty/issues/477)
- Kitty keyboard protocol detection spec: [kitty keyboard protocol § Detection](https://sw.kovidgoyal.net/kitty/keyboard-protocol/#detection)
- Ink adopted the same query-based detection instead of a whitelist: [ink#895](https://github.com/vadimdemedes/ink/pull/895)
- Similar issue in Claude Code (Anthropic): [claude-code#1758](https://github.com/anthropics/claude-code/issues/1758)
- xterm.js adding Kitty protocol support (v7.0): [xtermjs/xterm.js#5737](https://github.com/xtermjs/xterm.js/pull/5737)

## Testing

- `pnpm run typecheck` ✅
- `pnpm run test` — 1171 passed, 3 skipped ✅
- Manual: Terminal.app → probe detects no support → TUI overlay shown ✅

## Closes

- LLM-1561

---
### Kimchi Summary

### What changed

Adds automatic terminal keyboard compatibility detection and user guidance for terminals where Shift+Enter cannot insert newlines. It probes Kitty keyboard protocol support at startup, registers `Ctrl+J` as a fallback newline shortcut, emits targeted startup warnings with daily nag suppression, and renders a **centered overlay popup** listing workarounds with a "don't remind again" option.

### Why

Most terminals—including tmux, Terminal.app, VS Code integrated terminal, and Windows Terminal—do not send modifier-aware key sequences for Shift+Enter, leaving users without a discoverable way to insert newlines. This change detects those environments and surfaces reliable fallbacks.

### Key changes

- `src/extensions/terminal-compat/keyboard-capability.ts` — Probes Kitty keyboard protocol support via `CSI ? u` and caches the result; skips non-TTY, tmux, screen, and dumb terminals.
- `src/extensions/terminal-compat/startup-warning.ts` — Emits startup `console.warn` for tmux (with `extended-keys` fix) and generic unsupported terminals; persists `lastTerminalWarnings` in `settings.json` to throttle warnings to once per day.
- `src/extensions/permissions/keybindings.ts` — Renames `reserveShiftTabForPermissions` to `writeKimchiKeybindingDefaults`; now also appends `ctrl+j` to `tui.input.newLine` unless already used elsewhere. Keeps the old name as a deprecated alias.
- `src/extensions/ui.ts` — Shows a **centered overlay popup** (via `ctx.ui.custom({ overlay: true })`) using Box/Text from pi-tui wrapped in box-drawing characters. Displays `Ctrl+J` and `\ + Enter` as newline alternatives with a dismissible hint. Pressing `d` stores `newlineHintDismissed: true` in `settings.json` to suppress future reminders.
- `src/extensions/orchestration/prompt-enrichment.ts` — Handles the legacy macOS `Option+Tab` escape sequence (`\x1b\t`) for toggling multi-model mode.
- `docs/troubleshooting.md` — Documents universal workarounds and terminal-specific configuration steps.
- Test files — Adds coverage for keybinding default writing, keyboard capability probing, and startup warning nag control.

### Impact

- On first run, `keybindings.json` is updated to include `ctrl+j` in `tui.input.newLine`. Existing custom newline bindings are preserved (e.g., `alt+enter` becomes `alt+enter,ctrl+j`). If `ctrl+j` is already bound to another action, no fallback is added.
- `settings.json` gains a `lastTerminalWarnings` field to track warning dates, and a `newlineHintDismissed` flag when the user opts out of the overlay reminder.
- Non-TTY and ACP modes skip all probes and warnings.
- Entirely additive; no breaking changes.

---
### Kimchi Summary
### What changed
Adds terminal keyboard capability detection and fallback guidance for terminals that don't support modifier-aware Enter. The app now probes for Kitty keyboard protocol support, adds `Ctrl+J` as a newline fallback in keybindings, and warns users via startup messages and an in-TUI hint when Shift+Enter won't work.

### Why
Many common terminals—such as tmux (without `extended-keys`), macOS Terminal.app, and VS Code terminal—do not send distinct sequences for Shift+Enter, leaving users unable to insert newlines.

### Key changes
- `src/extensions/permissions/keybindings.ts`: Renamed `reserveShiftTabForPermissions` to `writeKimchiKeybindingDefaults`; now appends `ctrl+j` to `tui.input.newLine` if absent and unconflicted. Writes only when changes are made. Keeps the old name as a deprecated alias.
- `src/extensions/permissions/keybindings.test.ts`: Added tests for idempotency, preserving existing bindings, skipping `ctrl+j` when bound elsewhere, and handling malformed JSON.
- `src/extensions/terminal-compat/keyboard-capability.ts`: Added `probeKittyKeyboardSupport()` to detect CSI `u` support, skipping non-TTY, tmux, and screen sessions. Exports `getKittyKeyboardSupport()`.
- `src/extensions/terminal-compat/startup-warning.ts`: Added `emitTerminalCompatWarning()`, which prints once-per-day console warnings for tmux and unsupported terminals and persists nag state in `settings.json` (`lastTerminalWarnings`).
- `src/extensions/terminal-compat/startup-warning.test.ts`: Added tests for warning routing, nag suppression, TTY gating, and settings preservation.
- `src/extensions/ui.ts`: Added a dismissable center-overlay TUI hint when Kitty keyboard support is missing; press Enter to dismiss or `d` to permanently suppress (`newlineHintDismissed` in `settings.json`). Auto-hides on first input.
- `src/cli.ts`: Wired `writeKimchiKeybindingDefaults()`, `probeKittyKeyboardSupport()`, and `emitTerminalCompatWarning()` into the startup sequence.

### Impact
- No breaking changes; `reserveShiftTabForPermissions` is retained as a deprecated alias.
- `keybindings.json` is updated automatically on startup to include the `ctrl+j` fallback when safe.
- Users in unsupported terminals see a one-time-daily console warning and a persistent per-session TUI tip.
- The keyboard probe is skipped in ACP mode and non-TTY environments to avoid corrupting JSON-RPC channels or blocking CI.