### PR TITLE
ci: update release workflow to push latest release to homebrew tap

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -124,3 +124,76 @@ jobs:
             artifacts/checksums.txt
             scripts/install.sh
           generate_release_notes: true
+
+  homebrew:
+    needs: [release]
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Download checksums
+        uses: actions/download-artifact@v4
+        with:
+          name: kimchi_darwin_amd64
+          path: artifacts
+
+      - name: Download remaining artifacts
+        uses: actions/download-artifact@v4
+        with:
+          name: kimchi_darwin_arm64
+          path: artifacts
+
+      - uses: actions/download-artifact@v4
+        with:
+          name: kimchi_linux_amd64
+          path: artifacts
+
+      - uses: actions/download-artifact@v4
+        with:
+          name: kimchi_linux_arm64
+          path: artifacts
+
+      - name: Compute SHA256 values
+        id: sha
+        run: |
+          echo "darwin_amd64=$(sha256sum artifacts/kimchi_darwin_amd64.tar.gz | awk '{print $1}')" >> "$GITHUB_OUTPUT"
+          echo "darwin_arm64=$(sha256sum artifacts/kimchi_darwin_arm64.tar.gz | awk '{print $1}')" >> "$GITHUB_OUTPUT"
+          echo "linux_amd64=$(sha256sum artifacts/kimchi_linux_amd64.tar.gz  | awk '{print $1}')" >> "$GITHUB_OUTPUT"
+          echo "linux_arm64=$(sha256sum artifacts/kimchi_linux_arm64.tar.gz  | awk '{print $1}')" >> "$GITHUB_OUTPUT"
+
+      - name: Checkout homebrew-tap
+        uses: actions/checkout@v4
+        with:
+          repository: castai/homebrew-tap
+          token: ${{ secrets.HOMEBREW_TAP_TOKEN }}
+          path: homebrew-tap
+
+      - name: Update Formula/kimchi-dev.rb
+        env:
+          VERSION: ${{ github.ref_name }}
+          SHA_DARWIN_AMD64: ${{ steps.sha.outputs.darwin_amd64 }}
+          SHA_DARWIN_ARM64: ${{ steps.sha.outputs.darwin_arm64 }}
+          SHA_LINUX_AMD64: ${{ steps.sha.outputs.linux_amd64 }}
+          SHA_LINUX_ARM64: ${{ steps.sha.outputs.linux_arm64 }}
+        run: |
+          FORMULA=homebrew-tap/Formula/kimchi-dev.rb
+          # Strip leading 'v' from tag (e.g. v1.2.3 → 1.2.3)
+          VER="${VERSION#v}"
+
+          sed -i \
+            -e "s/^  version \".*\"/  version \"${VER}\"/" \
+            -e "/kimchi_darwin_arm64/{n; s/sha256 \".*\"/sha256 \"${SHA_DARWIN_ARM64}\"/}" \
+            -e "/kimchi_darwin_amd64/{n; s/sha256 \".*\"/sha256 \"${SHA_DARWIN_AMD64}\"/}" \
+            -e "/kimchi_linux_arm64/{n; s/sha256 \".*\"/sha256 \"${SHA_LINUX_ARM64}\"/}" \
+            -e "/kimchi_linux_amd64/{n; s/sha256 \".*\"/sha256 \"${SHA_LINUX_AMD64}\"/}" \
+            "$FORMULA"
+
+      - name: Commit and push
+        run: |
+          cd homebrew-tap
+          git config user.name  "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add Formula/kimchi-dev.rb
+          git commit -m "kimchi-dev ${GITHUB_REF_NAME}"
+          git push
+        env:
+          GITHUB_REF_NAME: ${{ github.ref_name }}


### PR DESCRIPTION


---
### Kimchi Summary
### What changed
Automatically publishes new releases to the CAST AI Homebrew tap. After a release is built, the workflow updates `Formula/kimchi-dev.rb` in `castai/homebrew-tap` with the new version and SHA256 checksums for all supported platforms.

### Why
Enables users to install and upgrade `kimchi-dev` via Homebrew rather than manual downloads.

### Key changes
- `.github/workflows/release.yml`: Added a `homebrew` job that depends on the `release` job
- Downloads release artifacts for `kimchi_darwin_amd64`, `kimchi_darwin_arm64`, `kimchi_linux_amd64`, and `kimchi_linux_arm64`
- Computes per-platform SHA256 checksums and exposes them as step outputs
- Checks out `castai/homebrew-tap` using the `HOMEBREW_TAP_TOKEN` secret
- Updates `Formula/kimchi-dev.rb` `version` and per-platform `sha256` values with `sed`
- Commits and pushes the formula update as `github-actions[bot]`

### Impact
- Requires the `HOMEBREW_TAP_TOKEN` repository secret to be configured with write access to `castai/homebrew-tap`