### PR TITLE
feat: add homebrew detection in update command

### DIFF
--- a/src/commands/update.ts
+++ b/src/commands/update.ts
@@ -1,3 +1,4 @@
+import { isHomebrewInstall } from "../update/paths.js"
 import { applyUpdate, checkForUpdate } from "../update/workflow.js"
 import { getVersion } from "../utils.js"
 
@@ -42,6 +43,19 @@ export async function runUpdate(args: string[]): Promise<number> {
 		return 2
 	}
 	const flags = parsed
+
+	// Homebrew manages its own package lifecycle. Self-patching a Homebrew
+	// binary would bypass its shim layer, break the Cellar layout, and risk
+	// losing the installation on the next `brew cleanup`. Direct the user to
+	// the correct upgrade path instead.
+	if (isHomebrewInstall()) {
+		console.log("kimchi is managed by Homebrew. Use Homebrew to update:")
+		console.log("")
+		console.log("  brew upgrade kimchi")
+		console.log("")
+		console.log("If you want the self-update behaviour, install kimchi outside of Homebrew.")
+		return 0
+	}
 
 	const current = getVersion()
 	let check: Awaited<ReturnType<typeof checkForUpdate>>

--- a/src/extensions/startup-update.ts
+++ b/src/extensions/startup-update.ts
@@ -1,4 +1,5 @@
 import type { ExtensionAPI, ExtensionContext } from "@mariozechner/pi-coding-agent"
+import { isHomebrewInstall } from "../update/paths.js"
 import { checkForUpdate } from "../update/workflow.js"
 import { getVersion } from "../utils.js"
 
@@ -19,7 +20,7 @@ export default function startupUpdateExtension(pi: ExtensionAPI) {
 		try {
 			const result = await checkForUpdate({ currentVersion: current, skipCache: false })
 			if (result.hasUpdate) {
-				const updateCmd = ctx.ui.theme.bold("kimchi update")
+				const updateCmd = ctx.ui.theme.bold(isHomebrewInstall() ? "brew upgrade kimchi" : "kimchi update")
 				ctx.ui.setStatus(UPDATE_STATUS_KEY, `Update available! Run ${updateCmd}`)
 			}
 		} catch {

--- a/src/update/paths.test.ts
+++ b/src/update/paths.test.ts
@@ -1,0 +1,105 @@
+import { mkdirSync, mkdtempSync, rmSync, symlinkSync, writeFileSync } from "node:fs"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
+import { afterEach, beforeEach, describe, expect, it } from "vitest"
+import { isHomebrewInstall } from "./paths.js"
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/** Write an empty file, creating parent dirs as needed. */
+function touch(p: string): void {
+	mkdirSync(join(p, ".."), { recursive: true })
+	writeFileSync(p, "")
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("isHomebrewInstall", () => {
+	let tmp: string
+	let origExecPath: PropertyDescriptor | undefined
+	let origPlatform: PropertyDescriptor | undefined
+	let origEnv: string | undefined
+
+	beforeEach(() => {
+		tmp = mkdtempSync(join(tmpdir(), "kimchi-paths-test-"))
+		origExecPath = Object.getOwnPropertyDescriptor(process, "execPath")
+		origPlatform = Object.getOwnPropertyDescriptor(process, "platform")
+		origEnv = process.env.HOMEBREW_PREFIX
+	})
+
+	afterEach(() => {
+		if (origExecPath) Object.defineProperty(process, "execPath", origExecPath)
+		if (origPlatform) Object.defineProperty(process, "platform", origPlatform)
+		if (origEnv === undefined) process.env.HOMEBREW_PREFIX = undefined
+		else process.env.HOMEBREW_PREFIX = origEnv
+		rmSync(tmp, { recursive: true, force: true })
+	})
+
+	function setExecPath(p: string) {
+		Object.defineProperty(process, "execPath", { value: p, writable: true, configurable: true })
+	}
+
+	function setPlatform(p: string) {
+		Object.defineProperty(process, "platform", { value: p, writable: true, configurable: true })
+	}
+
+	it("returns false on win32 regardless of path", () => {
+		setPlatform("win32")
+		setExecPath("C:\\Program Files\\kimchi\\kimchi.exe")
+		expect(isHomebrewInstall()).toBe(false)
+	})
+
+	it("returns false when execPath is outside any Homebrew prefix", () => {
+		// No Cellar in tmp → prefix is not a real Homebrew installation.
+		process.env.HOMEBREW_PREFIX = undefined
+		setExecPath(join(tmp, "bin", "kimchi"))
+		expect(isHomebrewInstall()).toBe(false)
+	})
+
+	it("returns true when real path is inside <prefix>/Cellar/", () => {
+		// Build a fake Cellar layout:
+		//   <tmp>/Cellar/kimchi/1.2.3/bin/kimchi   ← the real binary
+		const cellarBin = join(tmp, "Cellar", "kimchi", "1.2.3", "bin")
+		const realBinary = join(cellarBin, "kimchi")
+		touch(realBinary)
+
+		// Point HOMEBREW_PREFIX at our fake prefix so the well-known defaults
+		// (/opt/homebrew, /usr/local) don't interfere.
+		process.env.HOMEBREW_PREFIX = tmp
+
+		// execPath = realBinary (no symlink needed for check 1).
+		setExecPath(realBinary)
+		expect(isHomebrewInstall()).toBe(true)
+	})
+
+	it("returns true via symlink detection (bin → Cellar)", () => {
+		// Fake layout:
+		//   <tmp>/Cellar/kimchi/1.2.3/bin/kimchi   ← real binary
+		//   <tmp>/bin/kimchi                        ← symlink → Cellar path
+		const cellarBin = join(tmp, "Cellar", "kimchi", "1.2.3", "bin")
+		const realBinary = join(cellarBin, "kimchi")
+		touch(realBinary)
+
+		const prefixBin = join(tmp, "bin")
+		mkdirSync(prefixBin, { recursive: true })
+		const symlink = join(prefixBin, "kimchi")
+		symlinkSync(realBinary, symlink)
+
+		process.env.HOMEBREW_PREFIX = tmp
+		setExecPath(symlink)
+		expect(isHomebrewInstall()).toBe(true)
+	})
+
+	it("returns false when Cellar directory does not exist under prefix", () => {
+		// prefix exists but has no Cellar/ → not treated as a Homebrew install.
+		const fakePrefix = join(tmp, "fake-prefix")
+		mkdirSync(fakePrefix, { recursive: true })
+		process.env.HOMEBREW_PREFIX = fakePrefix
+		setExecPath(join(fakePrefix, "bin", "kimchi"))
+		expect(isHomebrewInstall()).toBe(false)
+	})
+})

--- a/src/update/paths.ts
+++ b/src/update/paths.ts
@@ -1,6 +1,6 @@
-import { realpathSync } from "node:fs"
+import { existsSync, realpathSync } from "node:fs"
 import { homedir } from "node:os"
-import { dirname, join } from "node:path"
+import { dirname, join, normalize } from "node:path"
 
 const APP_DIR = "kimchi"
 
@@ -35,6 +35,88 @@ export function resolveExecutablePath(): string {
 	// path is only meant to run from the compiled binary, so this is fine.
 	return realpathSync(process.execPath)
 }
+
+/**
+ * Return every plausible Homebrew prefix we should consider, in order:
+ *  1. $HOMEBREW_PREFIX (user override or set by `brew shellenv`)
+ *  2. Apple-Silicon default: /opt/homebrew
+ *  3. Intel-macOS / Linux default: /usr/local
+ */
+function homebrewPrefixes(): string[] {
+	const prefixes: string[] = []
+	const env = process.env.HOMEBREW_PREFIX
+	if (env && env.length > 0) prefixes.push(normalize(env))
+	// Always include the two well-known defaults so detection works even when
+	// the user hasn't sourced `brew shellenv` in the current shell.
+	for (const p of ["/opt/homebrew", "/usr/local"]) {
+		if (!prefixes.includes(p)) prefixes.push(p)
+	}
+	return prefixes
+}
+
+/**
+ * Return true when the running binary is managed by Homebrew.
+ *
+ * Detection strategy (in order):
+ *
+ * 1. **Cellar path** – the real path of the binary (symlinks resolved)
+ *    starts with `<prefix>/Cellar/`. This is the most reliable signal:
+ *    Homebrew stores versioned copies there and symlinks them into
+ *    `<prefix>/bin`.
+ *
+ * 2. **Bin-dir symlink** – the *unresolved* `process.execPath` lives inside
+ *    `<prefix>/bin/` and resolving it leads somewhere inside that prefix.
+ *    This catches the common `<prefix>/bin/kimchi → <prefix>/Cellar/…/kimchi`
+ *    layout without requiring a Cellar sub-path check.
+ *
+ * Returns false on non-macOS/non-Linux platforms and when the Cellar
+ * directory doesn't exist (rules out a bare `/opt/homebrew` prefix that
+ * was never a real Homebrew installation).
+ */
+export function isHomebrewInstall(): boolean {
+	if (process.platform === "win32") return false
+
+	let realExec: string
+	try {
+		realExec = realpathSync(process.execPath)
+	} catch {
+		return false
+	}
+
+	for (const prefix of homebrewPrefixes()) {
+		const cellar = join(prefix, "Cellar")
+		// Only treat this prefix as a real Homebrew installation if the Cellar
+		// directory actually exists on disk.
+		if (!existsSync(cellar)) continue
+
+		// Resolve the cellar and prefix paths themselves so that macOS's
+		// /var → /private/var symlink (and similar) doesn't cause a
+		// startsWith mismatch against the already-resolved realExec.
+		let realCellar: string
+		let realPrefix: string
+		try {
+			realCellar = realpathSync(cellar)
+			realPrefix = realpathSync(prefix)
+		} catch {
+			continue
+		}
+
+		// Check 1: real path is inside the Cellar.
+		if (realExec.startsWith(`${realCellar}${sep}`)) return true
+
+		// Check 2: unresolved execPath is a symlink inside <prefix>/bin/ that
+		// ultimately resolves to somewhere under the same prefix.
+		const binDir = join(prefix, "bin")
+		if (process.execPath.startsWith(`${binDir}${sep}`) && realExec.startsWith(`${realPrefix}${sep}`)) {
+			return true
+		}
+	}
+	return false
+}
+
+// platform-aware path separator constant (avoids importing `sep` from path
+// in the fragment above while keeping things readable).
+const sep = "/"
 
 /**
  * Data directory for supporting files (share/kimchi contents), honoring


### PR DESCRIPTION
When kimchi-dev is installed through homebrew, the update command will now fail and log an error, that it has to be upgraded through `brew upgrade`.

---
### Kimchi Summary
### What changed
Detects when `kimchi` is installed via Homebrew and prevents self-updates. The `update` command now directs users to run `brew upgrade kimchi`, and the startup update notification shows the correct upgrade command for Homebrew-managed binaries.

### Why
Homebrew manages its own package lifecycle. Self-patching a Homebrew binary would bypass its shim layer, break the Cellar layout, and risk losing the installation during the next `brew cleanup`.

### Key changes
- `src/update/paths.ts`: Added `isHomebrewInstall()` to detect Homebrew installations by checking whether the resolved binary path lives under a Homebrew prefix and `Cellar` directory. Returns `false` on `win32`.
- `src/commands/update.ts`: Added early return in `runUpdate()` when `isHomebrewInstall()` is true, printing instructions to use `brew upgrade kimchi` instead.
- `src/extensions/startup-update.ts`: Updated startup update banner to recommend `brew upgrade kimchi` (instead of `kimchi update`) for Homebrew installs.
- `src/update/paths.test.ts`: Added unit tests for `isHomebrewInstall()` covering symlink resolution, `Cellar` path detection, platform guards, and missing prefix directories.