### PR TITLE
docs: extend README to feature install instructions via brew

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,15 @@ A coding agent CLI powered by [kimchi](https://kimchi.dev/). Built on the [pi-mo
 
 Install the latest release:
 
+**Homebrew (macOS / Linux):**
+
+```bash
+brew tap castai/tap
+brew install castai/tap/kimchi-dev
+```
+
+**Install script:**
+
 ```bash
 curl -fsSL https://github.com/castai/kimchi-dev/releases/latest/download/install.sh | bash
 ```


### PR DESCRIPTION


---
### Kimchi Summary
### What changed
Adds Homebrew installation instructions to `README.md` so macOS and Linux users can install `kimchi-dev` via `brew`.

### Why
Providing a native Homebrew tap offers a familiar, version-managed alternative to the curl-based install script.

### Key changes
- `README.md`: Inserted a **Homebrew (macOS / Linux):** section with `brew tap castai/tap` and `brew install castai/tap/kimchi-dev` commands, and moved the existing curl one-liner under a new **Install script:** heading.