### PR TITLE
NOJIRA: fix openclaw setup

### DIFF
--- a/src/integrations/openclaw.test.ts
+++ b/src/integrations/openclaw.test.ts
@@ -3,13 +3,7 @@ import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "nod
 import { tmpdir } from "node:os"
 import { join } from "node:path"
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
-import {
-	buildOpenClawModelsCatalog,
-	buildOpenClawProviderBlock,
-	getOpenClawVersion,
-	isBatchJsonSupported,
-	writeOpenClawEnv,
-} from "./openclaw.js"
+import { buildOpenClawModelsCatalog, buildOpenClawProviderBlock, writeOpenClawEnv } from "./openclaw.js"
 import { byId } from "./registry.js"
 
 type ExecFile = typeof ExecFileSync
@@ -42,38 +36,6 @@ describe("buildOpenClawModelsCatalog", () => {
 		expect(catalog["kimchi/kimi-k2.5"]).toEqual({ alias: "Kimi K2.5" })
 		expect(catalog["kimchi/nemotron-3-super-fp4"]).toEqual({ alias: "Nemotron 3 Super FP4" })
 		expect(catalog["kimchi/minimax-m2.7"]).toEqual({ alias: "MiniMax M2.7" })
-	})
-})
-
-describe("getOpenClawVersion", () => {
-	it("parses CalVer output", () => {
-		const exec = vi.fn().mockReturnValue("OpenClaw 2026.4.8 (9ece252)\n") as unknown as ExecFile
-		expect(getOpenClawVersion(exec)).toBe("2026.4.8")
-	})
-	it("returns null on missing binary", () => {
-		const exec = vi.fn().mockImplementation(() => {
-			throw new Error("ENOENT")
-		}) as unknown as ExecFile
-		expect(getOpenClawVersion(exec)).toBeNull()
-	})
-})
-
-describe("isBatchJsonSupported", () => {
-	it("returns true at the cutoff", () => {
-		expect(isBatchJsonSupported("2026.3.17")).toBe(true)
-	})
-	it("returns true for newer versions", () => {
-		expect(isBatchJsonSupported("2026.4.8")).toBe(true)
-	})
-	it("returns false for older versions", () => {
-		expect(isBatchJsonSupported("2026.3.16")).toBe(false)
-		expect(isBatchJsonSupported("2025.12.31")).toBe(false)
-	})
-	it("returns true when version cannot be detected (assume newest)", () => {
-		// Unknown → optimistically newest. Users who just installed via curl
-		// tend to have the newest version, so this avoids false-negativing
-		// into the slow sequential path.
-		expect(isBatchJsonSupported(null)).toBe(true)
 	})
 })
 

--- a/src/integrations/openclaw.test.ts
+++ b/src/integrations/openclaw.test.ts
@@ -1,12 +1,32 @@
-import type { execFileSync as ExecFileSync } from "node:child_process"
+import * as childProcess from "node:child_process"
 import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs"
 import { tmpdir } from "node:os"
 import { join } from "node:path"
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
-import { buildOpenClawModelsCatalog, buildOpenClawProviderBlock, writeOpenClawEnv } from "./openclaw.js"
+import { findBinary } from "./detect.js"
+import {
+	asObject,
+	buildOpenClawModelsCatalog,
+	buildOpenClawProviderBlock,
+	mergeFallbacks,
+	mergeModelsCatalog,
+	writeOpenClawEnv,
+} from "./openclaw.js"
 import { byId } from "./registry.js"
 
-type ExecFile = typeof ExecFileSync
+vi.mock("./detect.js", async () => {
+	const mockFindBinary = vi.fn().mockReturnValue(undefined)
+	return { findBinary: mockFindBinary }
+})
+
+vi.mock("node:child_process", async () => {
+	const actual = await vi.importActual("node:child_process")
+	return {
+		...actual,
+		execFileSync: vi.fn(),
+		spawnSync: vi.fn(),
+	}
+})
 
 describe("buildOpenClawProviderBlock", () => {
 	it("uses the kimchi base URL and ${KIMCHI_API_KEY} placeholder", () => {
@@ -50,8 +70,7 @@ describe("writeOpenClawEnv", () => {
 	})
 
 	afterEach(() => {
-		// biome-ignore lint/performance/noDelete: env-var cleanup needs a real delete; assigning undefined would coerce to the literal string "undefined".
-		if (prevHome === undefined) delete process.env.HOME
+		if (prevHome === undefined) process.env.HOME = undefined
 		else process.env.HOME = prevHome
 		rmSync(tmp, { recursive: true, force: true })
 	})
@@ -94,5 +113,177 @@ describe("openclaw tool registration", () => {
 	it("write() rejects an empty API key", async () => {
 		const tool = byId("openclaw")
 		await expect(tool?.write("global", "")).rejects.toThrow(/API key/)
+	})
+})
+
+describe("asObject", () => {
+	it("returns the object when passed a plain object", () => {
+		expect(asObject({ foo: "bar" })).toEqual({ foo: "bar" })
+	})
+	it("returns {} for null", () => {
+		expect(asObject(null)).toEqual({})
+	})
+	it("returns {} for arrays", () => {
+		expect(asObject([1, 2, 3])).toEqual({})
+	})
+	it("returns {} for primitives", () => {
+		expect(asObject("string")).toEqual({})
+		expect(asObject(42)).toEqual({})
+		expect(asObject(true)).toEqual({})
+	})
+	it("returns {} for undefined", () => {
+		expect(asObject(undefined)).toEqual({})
+	})
+})
+
+describe("mergeFallbacks", () => {
+	it("appends new fallbacks to an existing array", () => {
+		expect(mergeFallbacks(["a", "b"], ["c", "d"])).toEqual(["a", "b", "c", "d"])
+	})
+	it("dedupes entries across existing and new", () => {
+		expect(mergeFallbacks(["a", "b"], ["b", "c"])).toEqual(["a", "b", "c"])
+	})
+	it("treats non-array existing as empty", () => {
+		expect(mergeFallbacks(null, ["a"])).toEqual(["a"])
+		expect(mergeFallbacks("string", ["a"])).toEqual(["a"])
+		expect(mergeFallbacks({ foo: "bar" }, ["a"])).toEqual(["a"])
+	})
+	it("returns only new fallbacks when existing is undefined", () => {
+		expect(mergeFallbacks(undefined, ["a", "b"])).toEqual(["a", "b"])
+	})
+})
+
+describe("mergeModelsCatalog", () => {
+	it("merges catalog entries into existing object", () => {
+		expect(mergeModelsCatalog({ existing: true }, { newKey: "value" })).toEqual({
+			existing: true,
+			newKey: "value",
+		})
+	})
+	it("new catalog entries take precedence over existing keys", () => {
+		expect(mergeModelsCatalog({ same: "old" }, { same: "new" })).toEqual({ same: "new" })
+	})
+	it("treats non-object existing as empty", () => {
+		expect(mergeModelsCatalog(null, { a: 1 })).toEqual({ a: 1 })
+		expect(mergeModelsCatalog([1, 2], { a: 1 })).toEqual({ a: 1 })
+		expect(mergeModelsCatalog("string", { a: 1 })).toEqual({ a: 1 })
+	})
+})
+
+describe("writeOpenClawDirect integration", () => {
+	let tmp: string
+	let prevHome: string | undefined
+
+	beforeEach(() => {
+		tmp = mkdtempSync(join(tmpdir(), "kimchi-openclaw-direct-"))
+		prevHome = process.env.HOME
+		process.env.HOME = tmp
+		vi.mocked(findBinary).mockReturnValue(undefined)
+	})
+
+	afterEach(() => {
+		if (prevHome === undefined) process.env.HOME = undefined
+		else process.env.HOME = prevHome
+		rmSync(tmp, { recursive: true, force: true })
+		vi.mocked(findBinary).mockClear()
+	})
+
+	it("preserves existing user config keys like temperature and fallbacks", async () => {
+		const configDir = join(tmp, ".openclaw")
+		mkdirSync(configDir, { recursive: true })
+		const existing = {
+			agents: {
+				defaults: {
+					model: {
+						temperature: 0.7,
+						fallbacks: ["other/model"],
+					},
+					models: {
+						"other/model": { alias: "Other" },
+					},
+				},
+			},
+		}
+		writeFileSync(join(configDir, "openclaw.json"), JSON.stringify(existing), "utf-8")
+
+		const tool = byId("openclaw")
+		await tool?.write("global", "test-key-123")
+
+		const written = JSON.parse(readFileSync(join(configDir, "openclaw.json"), "utf-8"))
+
+		expect(written.agents.defaults.model.temperature).toBe(0.7)
+		expect(written.agents.defaults.model.fallbacks).toContain("other/model")
+		expect(written.agents.defaults.model.fallbacks).toContain("kimchi/nemotron-3-super-fp4")
+		expect(written.agents.defaults.model.fallbacks).toContain("kimchi/minimax-m2.7")
+		expect(written.agents.defaults.models["other/model"]).toEqual({ alias: "Other" })
+		expect(written.agents.defaults.models["kimchi/kimi-k2.6"]).toBeDefined()
+		expect(written.models.providers.kimchi).toBeDefined()
+	})
+})
+
+describe("writeOpenClawViaCLI integration", () => {
+	let tmp: string
+	let prevHome: string | undefined
+
+	beforeEach(() => {
+		tmp = mkdtempSync(join(tmpdir(), "kimchi-openclaw-cli-"))
+		prevHome = process.env.HOME
+		process.env.HOME = tmp
+		vi.mocked(findBinary).mockReturnValue("/usr/bin/openclaw")
+		vi.mocked(childProcess.execFileSync).mockReturnValue("not running")
+		vi.mocked(childProcess.spawnSync).mockImplementation((_cmd: unknown, args: unknown) => {
+			const cmdArgs = args as string[]
+			if (cmdArgs[0] === "config" && cmdArgs[1] === "get" && cmdArgs[2] === "agents.defaults.model.fallbacks") {
+				return { status: 0, stdout: JSON.stringify(["existing/model"]), stderr: "" } as ReturnType<
+					typeof childProcess.spawnSync
+				>
+			}
+			return { status: 0, stdout: "", stderr: "" } as ReturnType<typeof childProcess.spawnSync>
+		})
+	})
+
+	afterEach(() => {
+		if (prevHome === undefined) process.env.HOME = undefined
+		else process.env.HOME = prevHome
+		rmSync(tmp, { recursive: true, force: true })
+		vi.mocked(findBinary).mockClear()
+		vi.mocked(childProcess.execFileSync).mockClear()
+		vi.mocked(childProcess.spawnSync).mockClear()
+	})
+
+	it("preserves existing fallbacks and other keys via CLI merge", async () => {
+		const tool = byId("openclaw")
+		await tool?.write("global", "test-key-123")
+
+		const calls = vi.mocked(childProcess.spawnSync).mock.calls
+		const fallbackSetCall = calls.find((c) => {
+			const args = c[1] as string[] | undefined
+			return (
+				args &&
+				args[0] === "config" &&
+				args[1] === "set" &&
+				args[2] === "--replace" &&
+				args[3] === "agents.defaults.model.fallbacks"
+			)
+		})
+		expect(fallbackSetCall).toBeDefined()
+		const mergedFallbacks = JSON.parse((fallbackSetCall?.[1] as string[])[4])
+		expect(mergedFallbacks).toContain("existing/model")
+		expect(mergedFallbacks).toContain("kimchi/nemotron-3-super-fp4")
+
+		const modelsSetCall = calls.find((c) => {
+			const args = c[1] as string[] | undefined
+			return (
+				args &&
+				args[0] === "config" &&
+				args[1] === "set" &&
+				args[2] === "--merge" &&
+				args[3] === "agents.defaults.models"
+			)
+		})
+		expect(modelsSetCall).toBeDefined()
+
+		const envContent = readFileSync(join(tmp, ".openclaw", ".env"), "utf-8")
+		expect(envContent).toBe("KIMCHI_API_KEY=test-key-123\n")
 	})
 })

--- a/src/integrations/openclaw.ts
+++ b/src/integrations/openclaw.ts
@@ -51,28 +51,6 @@ export function buildOpenClawModelsCatalog(): Record<string, unknown> {
 	return out
 }
 
-/** `openclaw --version` SemVer parse; null if missing or unparseable. */
-export function getOpenClawVersion(execFile: typeof execFileSync = execFileSync): string | null {
-	try {
-		const out = execFile("openclaw", ["--version"], { encoding: "utf-8", stdio: ["ignore", "pipe", "ignore"] })
-		const match = out.match(OPENCLAW_VERSION_REGEX)
-		return match ? match[1] : null
-	} catch {
-		return null
-	}
-}
-
-/**
- * Whether OpenClaw supports the `config set --batch-json` flag (>= 2026.3.17).
- * An unknown version is treated as "probably newest", which is the right
- * call when users have just installed via curl. Older versions flip back
- * to sequential `config set` calls.
- */
-export function isBatchJsonSupported(version: string | null): boolean {
-	if (!version) return true
-	return compareSemverGte(version, OPENCLAW_BATCH_MIN_VERSION) || version === OPENCLAW_BATCH_MIN_VERSION
-}
-
 /** Detection: ~/.openclaw/ dir present OR `openclaw` on PATH. */
 function detectOpenClaw(): boolean {
 	const dir = join(homedir(), ".openclaw")
@@ -137,20 +115,11 @@ async function writeOpenClawViaCLI(apiKey: string): Promise<void> {
 	const fallbacks = [`${PROVIDER_NAME}/${CODING_MODEL.slug}`, `${PROVIDER_NAME}/${SUB_MODEL.slug}`]
 	const primary = `${PROVIDER_NAME}/${MAIN_MODEL.slug}`
 
-	if (isBatchJsonSupported(getOpenClawVersion())) {
-		const batch = [
-			{ path: "models.providers.kimchi", value: providerBlock },
-			{ path: "agents.defaults.model.primary", value: primary },
-			{ path: "agents.defaults.model.fallbacks", value: fallbacks },
-			{ path: "agents.defaults.models", value: modelsCatalog },
-		]
-		runOpenClawCmd(["config", "set", "--batch-json", JSON.stringify(batch)])
-	} else {
-		runOpenClawCmd(["config", "set", "models.providers.kimchi", JSON.stringify(providerBlock)])
-		runOpenClawCmd(["config", "set", "agents.defaults.model.primary", primary])
-		runOpenClawCmd(["config", "set", "agents.defaults.model.fallbacks", JSON.stringify(fallbacks)])
-		runOpenClawCmd(["config", "set", "agents.defaults.models", JSON.stringify(modelsCatalog)])
-	}
+	runOpenClawCmd(["config", "set", "models.providers.kimchi", JSON.stringify(providerBlock)])
+	runOpenClawCmd(["config", "set", "agents.defaults.model.primary", primary])
+	// Merge fields that may conflict with existing user config.
+	runOpenClawMerge("agents.defaults.model.fallbacks", (existing) => mergeFallbacks(existing, fallbacks))
+	runOpenClawCmd(["config", "set", "--merge", "agents.defaults.models", JSON.stringify(modelsCatalog)])
 
 	writeOpenClawEnv(apiKey)
 
@@ -182,31 +151,24 @@ async function writeOpenClawDirect(scope: ConfigScope, apiKey: string): Promise<
 	const path = resolveScopePath(scope, OPENCLAW_CONFIG_PATH)
 	const existing = readJson(path)
 
-	const modelsRoot =
-		existing.models && typeof existing.models === "object" && !Array.isArray(existing.models)
-			? (existing.models as Record<string, unknown>)
-			: {}
-	const providers =
-		modelsRoot.providers && typeof modelsRoot.providers === "object" && !Array.isArray(modelsRoot.providers)
-			? (modelsRoot.providers as Record<string, unknown>)
-			: {}
+	const modelsRoot = asObject(existing.models)
+	const providers = asObject(modelsRoot.providers)
 	providers[PROVIDER_NAME] = buildOpenClawProviderBlock()
 	modelsRoot.providers = providers
 	existing.models = modelsRoot
 
-	const agents =
-		existing.agents && typeof existing.agents === "object" && !Array.isArray(existing.agents)
-			? (existing.agents as Record<string, unknown>)
-			: {}
-	const defaults =
-		agents.defaults && typeof agents.defaults === "object" && !Array.isArray(agents.defaults)
-			? (agents.defaults as Record<string, unknown>)
-			: {}
-	defaults.model = {
-		primary: `${PROVIDER_NAME}/${MAIN_MODEL.slug}`,
-		fallbacks: [`${PROVIDER_NAME}/${CODING_MODEL.slug}`, `${PROVIDER_NAME}/${SUB_MODEL.slug}`],
-	}
-	defaults.models = buildOpenClawModelsCatalog()
+	const agents = asObject(existing.agents)
+	const defaults = asObject(agents.defaults)
+	// Merge into model config to preserve existing keys like temperature, max_tokens.
+	const modelMap = asObject(defaults.model)
+	modelMap.primary = `${PROVIDER_NAME}/${MAIN_MODEL.slug}`
+	modelMap.fallbacks = mergeFallbacks(modelMap.fallbacks, [
+		`${PROVIDER_NAME}/${CODING_MODEL.slug}`,
+		`${PROVIDER_NAME}/${SUB_MODEL.slug}`,
+	])
+	defaults.model = modelMap
+
+	defaults.models = mergeModelsCatalog(defaults.models, buildOpenClawModelsCatalog())
 	agents.defaults = defaults
 	existing.agents = agents
 
@@ -227,6 +189,45 @@ async function writeOpenClaw(scope: ConfigScope, apiKey: string): Promise<void> 
 	} else {
 		await writeOpenClawDirect(scope, apiKey)
 	}
+}
+
+/** Read a config value via `openclaw config get --json`; returns `null` if the path is missing or unreadable. */
+function openClawConfigGet(path: string): unknown | null {
+	try {
+		const result = spawnSync("openclaw", ["config", "get", path, "--json"], {
+			encoding: "utf-8",
+			stdio: ["ignore", "pipe", "pipe"],
+		})
+		if (result.status !== 0) return null
+		const raw = (result.stdout ?? "").trim()
+		if (!raw) return null
+		return JSON.parse(raw)
+	} catch {
+		return null
+	}
+}
+
+/** Narrow an unknown value to a plain object, defaulting to `{}` for any other type. */
+function asObject(v: unknown): Record<string, unknown> {
+	return v && typeof v === "object" && !Array.isArray(v) ? (v as Record<string, unknown>) : {}
+}
+
+/** Merge fallbacks with an existing array, deduping entries. */
+function mergeFallbacks(existing: unknown, fallbacks: string[]): string[] {
+	const current = Array.isArray(existing) ? (existing as string[]) : []
+	return [...new Set([...current, ...fallbacks])]
+}
+
+/** Merge models catalog with an existing object, with new entries taking precedence. */
+function mergeModelsCatalog(existing: unknown, catalog: Record<string, unknown>): Record<string, unknown> {
+	return { ...asObject(existing), ...catalog }
+}
+
+/** Read existing value, merge it, and write back with `--replace`. */
+function runOpenClawMerge(path: string, merger: (existing: unknown) => unknown): void {
+	const existing = openClawConfigGet(path)
+	const merged = merger(existing)
+	runOpenClawCmd(["config", "set", "--replace", path, JSON.stringify(merged)])
 }
 
 register({

--- a/src/integrations/openclaw.ts
+++ b/src/integrations/openclaw.ts
@@ -208,18 +208,18 @@ function openClawConfigGet(path: string): unknown | null {
 }
 
 /** Narrow an unknown value to a plain object, defaulting to `{}` for any other type. */
-function asObject(v: unknown): Record<string, unknown> {
+export function asObject(v: unknown): Record<string, unknown> {
 	return v && typeof v === "object" && !Array.isArray(v) ? (v as Record<string, unknown>) : {}
 }
 
 /** Merge fallbacks with an existing array, deduping entries. */
-function mergeFallbacks(existing: unknown, fallbacks: string[]): string[] {
+export function mergeFallbacks(existing: unknown, fallbacks: string[]): string[] {
 	const current = Array.isArray(existing) ? (existing as string[]) : []
 	return [...new Set([...current, ...fallbacks])]
 }
 
 /** Merge models catalog with an existing object, with new entries taking precedence. */
-function mergeModelsCatalog(existing: unknown, catalog: Record<string, unknown>): Record<string, unknown> {
+export function mergeModelsCatalog(existing: unknown, catalog: Record<string, unknown>): Record<string, unknown> {
 	return { ...asObject(existing), ...catalog }
 }
 


### PR DESCRIPTION


---
### Kimchi Summary
### What changed

Refactors the OpenClaw integration to preserve existing user configuration when registering the Kimchi provider. Replaces version-gated `--batch-json` updates with explicit merge logic that appends provider entries without overwriting unrelated keys such as `temperature` or custom fallbacks.

### Why

Previously, writing the Kimchi provider config destructively replaced the `agents.defaults.model` and `agents.defaults.models` blocks, wiping out user-defined settings. These changes merge Kimchi entries into the existing OpenClaw configuration, respecting prior user customizations and removing brittle version parsing.

### Key changes

- `src/integrations/openclaw.ts` — Removed `getOpenClawVersion` and `isBatchJsonSupported`; deleted the version-dependent `--batch-json` code path.
- `src/integrations/openclaw.ts` — Added `asObject`, `mergeFallbacks`, and `mergeModelsCatalog` utilities to safely merge new values into existing JSON config without overwriting unrelated keys.
- `src/integrations/openclaw.ts` — Added `openClawConfigGet` and `runOpenClawMerge` helpers for reading and merging values via the OpenClaw CLI using `--replace`.
- `src/integrations/openclaw.ts` — Updated `writeOpenClawDirect` and `writeOpenClawViaCLI` to merge provider blocks, model fallbacks, and catalogs into existing user config rather than replacing them.
- `src/integrations/openclaw.test.ts` — Replaced version-detection tests with unit tests for `asObject`, `mergeFallbacks`, and `mergeModelsCatalog`, plus integration tests verifying preservation of existing `temperature`, `fallbacks`, and model aliases.

### Impact

- Existing OpenClaw settings (e.g., `temperature`, custom fallbacks, third-party model aliases) are preserved during Kimchi setup.
- The integration no longer parses `openclaw --version` or checks for a CalVer cutoff, making it resilient to CLI output changes.
- No breaking changes or migration steps are required.