### PR TITLE
LLM-1377: Hide model thinking tags from display

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -19,6 +19,7 @@ import bashCollapseExtension from "./extensions/bash-collapse.js"
 import behavioursExtension from "./extensions/behaviours/index.js"
 import clipboardImageExtension from "./extensions/clipboard-image.js"
 import contextCompactorExtension from "./extensions/context-compactor.js"
+import hideThinkingExtension from "./extensions/hide-thinking.js"
 import kimchiMinimalTintsExtension from "./extensions/kimchi-minimal-tints.js"
 import loginExtension from "./extensions/login/index.js"
 import loopGuardExtension from "./extensions/loop-guard.js"
@@ -267,6 +268,7 @@ try {
 			behavioursExtension,
 			promptSummaryExtension,
 			contextCompactorExtension,
+			hideThinkingExtension,
 			clipboardImageExtension,
 			uiExtension,
 			subagentExtension,

--- a/src/extensions/hide-thinking.test.ts
+++ b/src/extensions/hide-thinking.test.ts
@@ -1,0 +1,271 @@
+import { beforeEach, describe, expect, it, vi } from "vitest"
+import { ANSI, fg } from "../ansi.js"
+import hideThinkingExtension, { _getDisplayToOriginal, _resetState, _setHideThinking } from "./hide-thinking.js"
+
+type Handler = (event: unknown) => unknown
+
+function createMockApi() {
+	const handlers = new Map<string, Handler[]>()
+	const on = vi.fn((event: string, handler: Handler) => {
+		if (!handlers.has(event)) handlers.set(event, [])
+		handlers.get(event)?.push(handler)
+	})
+	return { on, handlers, api: { on } as unknown as Parameters<typeof hideThinkingExtension>[0] }
+}
+
+function getHandler(handlers: Map<string, Handler[]>, event: string): Handler {
+	const list = handlers.get(event)
+	if (!list || list.length === 0) throw new Error(`No handler registered for ${event}`)
+	return list[0]
+}
+
+interface Handlers {
+	messageStart: Handler
+	messageUpdate: Handler
+	messageEnd: Handler
+	context: Handler
+}
+
+function setupExtension(): Handlers {
+	const { handlers, api } = createMockApi()
+	hideThinkingExtension(api)
+	return {
+		messageStart: getHandler(handlers, "message_start"),
+		messageUpdate: getHandler(handlers, "message_update"),
+		messageEnd: getHandler(handlers, "message_end"),
+		context: getHandler(handlers, "context"),
+	}
+}
+
+/** Simulate streaming: message_start, then message_update per token, then message_end. */
+async function simulateStreaming(h: Handlers, tokens: string[]) {
+	const content = [{ type: "text" as const, text: "" }]
+	const message = { role: "assistant" as const, content }
+
+	await h.messageStart({ type: "message_start", message })
+	for (const token of tokens) {
+		content[0].text += token
+		await h.messageUpdate({ type: "message_update", message, assistantMessageEvent: {} })
+	}
+	const endResult = await h.messageEnd({ type: "message_end", message })
+	return { message, content, endResult }
+}
+
+describe("hideThinkingExtension", () => {
+	let h: Handlers
+
+	beforeEach(() => {
+		_resetState()
+		h = setupExtension()
+	})
+
+	it("registers message_start, message_update, message_end, and context handlers", () => {
+		const { handlers, api } = createMockApi()
+		hideThinkingExtension(api)
+		for (const event of ["message_start", "message_update", "message_end", "context"]) {
+			expect(handlers.has(event), `missing handler for ${event}`).toBe(true)
+		}
+	})
+
+	// --- Default behaviour (hideThinking = false → dim) ---
+
+	it("dims thinking content by default (hideThinking not set)", async () => {
+		const { endResult } = await simulateStreaming(h, ["Before ", "<think>", "reason", "</think>", " After"])
+		expect(endResult).toBeDefined()
+		const text = (endResult as { message: { content: Array<{ text: string }> } }).message.content[0].text
+		expect(text).toBe(`Before ${fg(ANSI.dim, "reason")} After`)
+	})
+
+	// --- Explicit hideThinking = true (strip entirely) ---
+
+	it("strips <think> tags from display when hideThinking is true", async () => {
+		_setHideThinking(true)
+		const { endResult } = await simulateStreaming(h, ["Hello ", "<think>", "let me think...", "</think>", " World"])
+
+		expect(endResult).toBeDefined()
+		const text = (endResult as { message: { content: Array<{ text: string }> } }).message.content[0].text
+		expect(text).toBe("Hello  World")
+	})
+
+	// --- Explicit hideThinking = false (dim, last 5 lines) ---
+
+	it("shows only last 5 lines dimmed when hideThinking is false", async () => {
+		_setHideThinking(false)
+
+		const thinkingLines = Array.from({ length: 7 }, (_, i) => `Step ${i + 1}`)
+		const { endResult } = await simulateStreaming(h, [
+			"Before ",
+			"<think>",
+			thinkingLines.join("\n"),
+			"</think>",
+			" After",
+		])
+
+		expect(endResult).toBeDefined()
+		const text = (endResult as { message: { content: Array<{ text: string }> } }).message.content[0].text
+		const expected = thinkingLines.slice(-5).join("\n")
+		expect(text).toBe(`Before ${fg(ANSI.dim, expected)} After`)
+	})
+
+	// --- Streaming display ---
+
+	it("hides <think> tag and dims content during streaming", async () => {
+		const content = [{ type: "text" as const, text: "" }]
+		const message = { role: "assistant" as const, content }
+
+		await h.messageStart({ type: "message_start", message })
+
+		// Tokens before <think> — unmodified
+		content[0].text += "Hello "
+		await h.messageUpdate({ type: "message_update", message, assistantMessageEvent: {} })
+		expect(content[0].text).toBe("Hello ")
+
+		// <think> tag arrives — should be hidden
+		content[0].text += "<think>"
+		await h.messageUpdate({ type: "message_update", message, assistantMessageEvent: {} })
+		expect(content[0].text).toBe("Hello ")
+
+		// Thinking content streams in — should be dimmed
+		content[0].text += "reasoning"
+		await h.messageUpdate({ type: "message_update", message, assistantMessageEvent: {} })
+		expect(content[0].text).toBe(`Hello ${fg(ANSI.dim, "reasoning")}`)
+
+		// </think> closes — content stays dimmed
+		content[0].text += "</think>"
+		await h.messageUpdate({ type: "message_update", message, assistantMessageEvent: {} })
+		expect(content[0].text).toBe(`Hello ${fg(ANSI.dim, "reasoning")}`)
+
+		// More text after closing
+		content[0].text += " World"
+		await h.messageUpdate({ type: "message_update", message, assistantMessageEvent: {} })
+		expect(content[0].text).toBe(`Hello ${fg(ANSI.dim, "reasoning")} World`)
+	})
+
+	it("hides thinking content entirely during streaming when hideThinking is true", async () => {
+		_setHideThinking(true)
+		const content = [{ type: "text" as const, text: "" }]
+		const message = { role: "assistant" as const, content }
+
+		await h.messageStart({ type: "message_start", message })
+
+		content[0].text += "Hello "
+		await h.messageUpdate({ type: "message_update", message, assistantMessageEvent: {} })
+		expect(content[0].text).toBe("Hello ")
+
+		// <think> tag arrives — hidden
+		content[0].text += "<think>"
+		await h.messageUpdate({ type: "message_update", message, assistantMessageEvent: {} })
+		expect(content[0].text).toBe("Hello ")
+
+		// Thinking content streams in — also hidden (not dimmed)
+		content[0].text += "secret reasoning"
+		await h.messageUpdate({ type: "message_update", message, assistantMessageEvent: {} })
+		expect(content[0].text).toBe("Hello ")
+
+		// </think> closes — still just "Hello "
+		content[0].text += "</think>"
+		await h.messageUpdate({ type: "message_update", message, assistantMessageEvent: {} })
+		expect(content[0].text).toBe("Hello ")
+
+		// Text after closing is visible
+		content[0].text += " World"
+		await h.messageUpdate({ type: "message_update", message, assistantMessageEvent: {} })
+		expect(content[0].text).toBe("Hello  World")
+	})
+
+	// --- Context restoration round-trip ---
+
+	it("restores original thinking content in context event after streaming", async () => {
+		_setHideThinking(true)
+		const { endResult } = await simulateStreaming(h, ["Before ", "<think>", "deep reasoning", "</think>", " After"])
+		const displayText = (endResult as { message: { content: Array<{ text: string }> } }).message.content[0].text
+		expect(displayText).toBe("Before  After")
+
+		// Simulate structuredClone (context event gets cloned messages)
+		const contextResult = await h.context({
+			type: "context",
+			messages: [
+				{ role: "user", content: [{ type: "text", text: "question" }] },
+				{ role: "assistant", content: [{ type: "text", text: displayText }] },
+			],
+		})
+
+		expect(contextResult).toBeDefined()
+		const restored = (contextResult as { messages: Array<{ content: Array<{ text: string }> }> }).messages
+		expect(restored[1].content[0].text).toBe("Before <think>deep reasoning</think> After")
+		expect(restored[0].content[0].text).toBe("question")
+	})
+
+	it("populates shadow map for each transformed block", async () => {
+		_setHideThinking(true)
+		await simulateStreaming(h, ["A ", "<think>", "reasoning", "</think>", " B"])
+
+		const map = _getDisplayToOriginal()
+		expect(map.size).toBe(1)
+		expect(map.get("A  B")).toBe("A <think>reasoning</think> B")
+	})
+
+	it("does not modify non-assistant messages", async () => {
+		const result = await h.messageEnd({
+			type: "message_end",
+			message: {
+				role: "user",
+				content: [{ type: "text", text: "<think>user typed this</think>" }],
+			},
+		})
+		expect(result).toBeUndefined()
+	})
+
+	it("does not modify messages without think tags", async () => {
+		const result = await h.messageEnd({
+			type: "message_end",
+			message: {
+				role: "assistant",
+				content: [{ type: "text", text: "Hello World" }],
+			},
+		})
+		expect(result).toBeUndefined()
+	})
+
+	it("does not touch native thinking content blocks", async () => {
+		const result = await h.messageEnd({
+			type: "message_end",
+			message: {
+				role: "assistant",
+				content: [
+					{ type: "text", text: "Hello" },
+					{ type: "thinking", thinking: "Let me think..." },
+					{ type: "text", text: " World" },
+				],
+			},
+		})
+		expect(result).toBeUndefined()
+	})
+
+	it("handles multiple think blocks in one text block", async () => {
+		_setHideThinking(true)
+		const { endResult } = await simulateStreaming(h, [
+			"A ",
+			"<think>",
+			"first",
+			"</think>",
+			" B ",
+			"<think>",
+			"second",
+			"</think>",
+			" C",
+		])
+
+		expect(endResult).toBeDefined()
+		const text = (endResult as { message: { content: Array<{ text: string }> } }).message.content[0].text
+		expect(text).toBe("A  B  C")
+	})
+
+	it("context handler is a no-op when shadow map is empty", async () => {
+		const result = await h.context({
+			type: "context",
+			messages: [{ role: "assistant", content: [{ type: "text", text: "plain text" }] }],
+		})
+		expect(result).toBeUndefined()
+	})
+})

--- a/src/extensions/hide-thinking.ts
+++ b/src/extensions/hide-thinking.ts
@@ -1,0 +1,285 @@
+/**
+ * Hides <think></think> text tags from the UI without affecting LLM context.
+ *
+ * Some models (DeepSeek, QwQ, etc.) emit reasoning inside <think>...</think>
+ * tags in regular text content. This extension transforms those for display
+ * while preserving the original content in the LLM context via a shadow map.
+ *
+ * Native `thinking` content blocks (type: "thinking") are handled by the
+ * upstream framework and are NOT touched by this extension.
+ *
+ * Behaviour controlled by `hideThinkingBlock` in settings.json:
+ * - true: hides thinking content entirely from display
+ * - false (default): strips tags, dims content (last 5 lines shown)
+ *
+ * Architecture:
+ * - message_start: initialises per-message streaming state
+ * - message_update: mutates block.text in-place with ANSI dim codes so the
+ *   TUI (which renders AFTER extensions) shows dimmed thinking and hidden
+ *   tags during streaming. Tracks the un-modified original text per block.
+ * - message_end: applies the final transform (strip or dim based on setting)
+ *   using the tracked originals, stores in shadow map.
+ * - context: restores original text before LLM calls (emitContext uses
+ *   structuredClone, so matching is content-based, not reference-based)
+ */
+
+import { readFileSync } from "node:fs"
+import { resolve } from "node:path"
+
+import type { AssistantMessage } from "@mariozechner/pi-ai"
+import type { ExtensionAPI } from "@mariozechner/pi-coding-agent"
+import { ANSI, fg } from "../ansi.js"
+import { isSubagent } from "./orchestration/prompt-transformer/prompt-transformer.js"
+
+const THINK_TAG_PATTERN = /<think>[\s\S]*?<\/think>/g
+
+function containsThinkTags(text: string): boolean {
+	return text.includes("<think>") && text.includes("</think>")
+}
+
+// ---------------------------------------------------------------------------
+// Settings
+// ---------------------------------------------------------------------------
+
+function getSettingsPath(): string | undefined {
+	const agentDir = process.env.KIMCHI_CODING_AGENT_DIR
+	if (!agentDir) return undefined
+	return resolve(agentDir, "settings.json")
+}
+
+/** Override for tests — bypasses settings.json when set. */
+let hideThinkingOverride: boolean | undefined
+
+function readHideThinkingSetting(): boolean {
+	if (hideThinkingOverride !== undefined) return hideThinkingOverride
+	const settingsPath = getSettingsPath()
+	if (!settingsPath) return false
+	try {
+		const raw = readFileSync(settingsPath, "utf-8")
+		const parsed = JSON.parse(raw)
+		if (parsed && typeof parsed === "object" && "hideThinkingBlock" in parsed) {
+			return Boolean((parsed as { hideThinkingBlock: unknown }).hideThinkingBlock)
+		}
+		return false
+	} catch {
+		return false
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Text transforms
+// ---------------------------------------------------------------------------
+
+function lastNLines(text: string, n: number): string {
+	const lines = text.split("\n")
+	if (lines.length <= n) return text.trimEnd()
+	return lines.slice(-n).join("\n").trimEnd()
+}
+
+function stripThinkingTags(text: string): string {
+	return text.replace(THINK_TAG_PATTERN, "")
+}
+
+function replaceThinkingTagsWithDimmed(text: string): string {
+	return text.replace(THINK_TAG_PATTERN, (match) => {
+		const content = match.slice("<think>".length, -"</think>".length)
+		const visible = lastNLines(content, 5)
+		return visible ? fg(ANSI.dim, visible) : ""
+	})
+}
+
+/**
+ * Streaming display transform — applied on every message_update.
+ * When hideThinking is true, strips thinking content entirely.
+ * When false, dims content and hides tags. Unlike the final transform
+ * this keeps all lines (no last-5-lines truncation) so the display is
+ * stable during streaming.
+ */
+function applyStreamingDisplay(text: string, hideThinking: boolean): string {
+	// 1. Replace fully closed <think>…</think> blocks
+	let result = text.replace(THINK_TAG_PATTERN, (match) => {
+		if (hideThinking) return ""
+		const inner = match.slice("<think>".length, -"</think>".length)
+		return inner ? fg(ANSI.dim, inner) : ""
+	})
+	// 2. Handle an unclosed <think> tag (thinking content still streaming)
+	const openIdx = result.indexOf("<think>")
+	if (openIdx !== -1) {
+		const before = result.slice(0, openIdx)
+		if (hideThinking) {
+			result = before
+		} else {
+			const inner = result.slice(openIdx + "<think>".length)
+			result = before + (inner ? fg(ANSI.dim, inner) : "")
+		}
+	}
+	return result
+}
+
+// ---------------------------------------------------------------------------
+// Shadow map — transformed display text → original text with thinking tags.
+// Used by the context handler to restore originals before LLM calls.
+// emitContext() deep-clones messages, so we match by text content, not
+// object reference.
+// ---------------------------------------------------------------------------
+
+const displayToOriginal = new Map<string, string>()
+
+// ---------------------------------------------------------------------------
+// Streaming state — reset per assistant message.
+// Tracks the un-modified original text for each content block so that
+// message_end can apply the final transform from clean source.
+// ---------------------------------------------------------------------------
+
+interface StreamingBlockState {
+	/** Accumulated original text (no ANSI modifications). */
+	original: string
+	/** Length of block.text after our last in-place mutation. */
+	lastDisplayLength: number
+}
+
+let streamingBlocks: Map<number, StreamingBlockState> | null = null
+
+// ---------------------------------------------------------------------------
+// Test helpers
+// ---------------------------------------------------------------------------
+
+export function _setHideThinking(value: boolean | undefined): void {
+	hideThinkingOverride = value
+}
+
+export function _resetState(): void {
+	hideThinkingOverride = undefined
+	displayToOriginal.clear()
+	streamingBlocks = null
+}
+
+/** Exposed for assertions only. */
+export function _getDisplayToOriginal(): ReadonlyMap<string, string> {
+	return displayToOriginal
+}
+
+// ---------------------------------------------------------------------------
+// Extension
+// ---------------------------------------------------------------------------
+
+export default function hideThinkingExtension(pi: ExtensionAPI): void {
+	if (isSubagent()) return
+
+	// Initialise per-message streaming state.
+	pi.on("message_start", (event) => {
+		streamingBlocks = event.message.role === "assistant" ? new Map() : null
+	})
+
+	// During streaming: mutate block.text in-place so the TUI renders dimmed
+	// thinking content with hidden tags. Extensions run before TUI listeners
+	// (_emitExtensionEvent then _emit), so our mutation is visible in the
+	// same render frame.
+	pi.on("message_update", (event) => {
+		if (!streamingBlocks || event.message.role !== "assistant") return
+		const msg = event.message as AssistantMessage
+
+		for (let i = 0; i < msg.content.length; i++) {
+			const block = msg.content[i]
+			if (block.type !== "text") continue
+
+			let state = streamingBlocks.get(i)
+			if (!state) {
+				state = { original: "", lastDisplayLength: 0 }
+				streamingBlocks.set(i, state)
+			}
+
+			// New content = everything the provider appended after our last mutation.
+			const newContent = block.text.slice(state.lastDisplayLength)
+			if (!newContent) continue
+			state.original += newContent
+
+			// Only touch the block when there is (or might be) a <think> tag.
+			if (!state.original.includes("<think>")) {
+				state.lastDisplayLength = block.text.length
+				continue
+			}
+
+			const display = applyStreamingDisplay(state.original, readHideThinkingSetting())
+			block.text = display
+			state.lastDisplayLength = display.length
+		}
+	})
+
+	// At message_end: apply the final transform using clean originals from
+	// streaming state (or from the message directly when no streaming state
+	// is available, e.g. resumed sessions).
+	pi.on("message_end", (event) => {
+		if (event.message.role !== "assistant") return
+		const msg = event.message as AssistantMessage
+		const currentStreaming = streamingBlocks
+		streamingBlocks = null
+
+		// Collect original text for each block that contains thinking tags.
+		const blockOriginals = new Map<number, string>()
+		for (let i = 0; i < msg.content.length; i++) {
+			const block = msg.content[i]
+			if (block.type !== "text") continue
+
+			const streamState = currentStreaming?.get(i)
+			if (streamState) {
+				// Capture any trailing content added after our last message_update.
+				const remaining = block.text.slice(streamState.lastDisplayLength)
+				const fullOriginal = streamState.original + remaining
+				if (containsThinkTags(fullOriginal)) {
+					blockOriginals.set(i, fullOriginal)
+				}
+			} else if (containsThinkTags(block.text)) {
+				blockOriginals.set(i, block.text)
+			}
+		}
+
+		if (blockOriginals.size === 0) return
+
+		const hideThinking = readHideThinkingSetting()
+		let changed = false
+		const displayContent = msg.content.map((block, i) => {
+			const original = blockOriginals.get(i)
+			if (!original || block.type !== "text") return block
+			const displayText = hideThinking ? stripThinkingTags(original) : replaceThinkingTagsWithDimmed(original)
+			if (displayText !== original) {
+				displayToOriginal.set(displayText, original)
+				changed = true
+				return { ...block, text: displayText }
+			}
+			return block
+		})
+
+		if (changed) {
+			return { message: { ...msg, content: displayContent } }
+		}
+	})
+
+	// Restore original thinking content before LLM calls so it stays in context.
+	pi.on("context", (event) => {
+		if (displayToOriginal.size === 0) return
+
+		let modified = false
+		const messages = event.messages.map((msg) => {
+			if (msg.role !== "assistant") return msg
+			const assistantMsg = msg as AssistantMessage
+			let blockModified = false
+			const content = assistantMsg.content.map((block) => {
+				if (block.type !== "text") return block
+				const original = displayToOriginal.get(block.text)
+				if (original) {
+					blockModified = true
+					return { ...block, text: original }
+				}
+				return block
+			})
+			if (blockModified) {
+				modified = true
+				return { ...assistantMsg, content }
+			}
+			return msg
+		})
+
+		if (modified) return { messages }
+	})
+}


### PR DESCRIPTION
## What

Some models like MiniMax emit their reasoning inside `<think>...</think>` tags as regular text content alongside their responses. This can clutter the UI with internal reasoning the user doesn't need to see.

## How it works

This change adds a rendering layer that transforms `<think>...</think>` content for display **without ever modifying what gets sent back to the LLM**. The original message content is preserved in a shadow map and restored before any context is emitted to the model.

Two modes via `hideThinkingBlock` in `settings.json`:
- **`true`**: Completely hides thinking content from the display
- **`false`** (default): Strips the tags and dims the content, showing only the last 5 lines so users can still glimpse reasoning if curious

The context/memory sent to the LLM is never mutated — it's always the original, unmodified content.

---
### Kimchi Summary
` tags (or rather ` <think> ... \u003c/think>` based on the code? Wait, looking closely at the code... The code mentions ` <think> ` and `</think>`? Let me check. Ah, the code has `THINK_TAG_PATTERN = / \u003cthink[\s\S]*?\u003c\/think>/g`. Wait, that says ` \u003cthink`? No, looking carefully: `const THINK_TAG_PATTERN = / \u003cthink[\s\S]*?\u003c\/think>/g`. Hmm, actually let me look at the exact text in the diff.
Ah, the code shows:
`const THINK_TAG_PATTERN = / \u003cthink[\s\S]*?\u003c\/think>/g`

Wait, looking at the diff text, it seems there might be formatting issues. Let me re-read... No, the diff shows exactly:
`const THINK_TAG_PATTERN = / \u003cthink[\s\S]*?\u003c\/think>/g`

But then in the comments and test cases, it mentions ` <think> ` and `</think>`? Wait, in the test file I see strings like `" \u003cthink"` and `"</think>"`. Let me look... Ah, the test has `"Before ", " \u003cthink", "reason", " \u003c/think>", " After"`. So yes, the tags are ` \u003cthink` and ` \u003c/think>`.

The extension:
- Hides or dims thinking content wrapped in `<think>...</think>` tags from the UI.
- Controlled by `hideThinkingBlock` in `settings.json` (or `settings.json` under `KIMCHI_CODING_AGENT_DIR`).
- `true`: strips thinking content entirely from display.
- `false` (default): strips tags, dims content (last 5 lines shown).
- Works during streaming via `message_update` (mutates text in-place with ANSI dim codes).
- At `message_end`, applies final transform and stores a mapping from display text to original text.
- At `context`, restores original text so the LLM still sees the thinking content in context.
- Doesn't affect native `thinking` content blocks (type: "thinking").
- Doesn't affect non-assistant messages.

Why:
- Some models (DeepSeek, QwQ, etc.) emit reasoning inside `<think>...</think>` tags in regular text. This keeps the UI clean while preserving the reasoning for the LLM context.

Key changes:
- `src/cli.ts`: Registers `hideThinkingExtension`.
- `src/extensions/hide-thinking.ts`: New extension implementing the logic via `message_start`, `message_update`, `message_end`, and `context` handlers.
- `src/extensions/hide-thinking.test.ts`: Adds tests for default dimming, full hiding, streaming behavior, context restoration round-trip, and edge cases.

Impact:
- Adds `hideThinkingBlock` boolean setting to `settings.json` (defaults to false). When true, reasoning is hidden from display.
- Uses ANSI dim codes for display; mutates streaming text in-place.
- Non-breaking additive change.

I need to ensure I follow the exact formatting requested:
- Plain Markdown only, no preamble, no code fence wrapper.
- Standard Markdown headings: `### What changed`, `### Why`, `### Key changes`, `### Impact`.
- Omit sections if not relevant (but all seem relevant here).
- Concise, specific, easy to scan.
- Wrap identifiers in backticks.

Let me draft:

### What changed
Adds a `hideThinkingExtension` that intercepts assistant messages containing `<think>…</think>` reasoning tags and transforms them for display—either dimming the content (default) or hiding it entirely based on a setting—while preserving the original text in the LLM context.

Wait, looking at the code more carefully, the tags appear to be ` \u003cthink` and `</think>` in the regex, but the comments say ` \u003cthink` ... `</think>`. I'll refer to them as ` \u003cthink`...`\u003c/think>` or just `<think>`. But looking at the code comments: `Some models (DeepSeek, QwQ, etc.) emit reasoning inside <think>... </think> tags`. And the regex is `const THINK_TAG_PATTERN = / \u003cthink[\s\S]*?\u003c\/think>/g`. The space before think? Let me check... ` / \u003cthink`. Yes, there's a space before `<think` in the regex? Or is that just how it's rendered? Actually, looking at the raw text: `const THINK_TAG_PATTERN = / \u003cthink[\s\S]*?\u003c\/think>/g`. Wait, that is a space after the slash. No, it's `/ \u003cthink`. Hmm, maybe it's just `<think>` and the formatting is odd. But the tests clearly use `" \u003cthink"` and `"</think>"` as separate tokens. Actually, in the tests: `tokens: ["Before ", " \u003cthink", "reason", " \u003c/think>", " After"]`. So the tag literally includes a leading space? Or is that just how the model outputs it? The regex ` / \u003cthink` would match a space before `<think`. But in the replace functions, `match.slice(" \u003cthink".length, -" \u003c/think>".length)`. Wait, the slice uses `" \u003cthink"` which is 7 characters? Let's count: space (1) + `<` (1) + `t` (1) + `h` (1) + `i` (1) + `n` (1) + `k` (1) = 7. And `-" \u003c/think>"` is space + `</think>` which is 1 + 8 = 9? Actually `</think>` is 8 characters. So 9 total.
The regex has ` / \u003cthink...`. Hmm. I shouldn't get bogged down in the exact characters; the summary just needs to say `<think>` tags or `` ` \u003cthink` tags``. But the PR description should be understandable. I'll refer to them as `<think>` tags since that's what the code comments say.

Let me verify the exact setting name: `hideThinkingBlock`. The code reads `hideThinkingBlock` from `settings.json`.

One more check on Impact: Is there any breaking change? No, it's additive. The default is false (dim). So Impact is low-risk/additive. The only notable thing is the new setting.

Let's refine:

### What changed
Adds a `hideThinkingExtension` that filters `<think>…</think>` reasoning blocks from assistant message UI output—either dimming the content or hiding it completely—while restoring the original tagged text before LLM context assembly.

### Why
Some models (e.g., DeepSeek, QwQ) inline reasoning inside `<think>` tags. This clutters the terminal UI and should be visually suppressed without stripping it from the conversation history sent back to the model.

### Key changes
- `src/cli.ts`: Registers the new `hideThinkingExtension` in the extension pipeline.
- `src/extensions/hide-thinking.ts`: New extension implementing:
  - `message_start` / `message_update`: In-place ANSI dimming of streaming thinking content (or complete hiding when `hideThinkingBlock` is `true`).
  - `message_end`: Final transform that strips or dims tags and populates a display-to-original shadow map.
  - `context`: Restores original `<think>` content so it remains part of the LLM context.
  - Reads `hideThinkingBlock` from `settings.json` (via `KIMCHI_CODING_AGENT_DIR`) to toggle between dimming (default) and full hiding.
- `src/extensions/hide-thinking.test.ts`: Adds tests covering default dimming, full hiding, streaming display, context restoration, multiple think blocks, and non-assistant passthrough.

### Impact
- **New setting**: `hideThinkingBlock` in `settings.json` controls visibility. Default `false` dims the last 5 lines of reasoning; `true` removes reasoning from display entirely.
- **Additive / non-breaking**: Native `thinking` content blocks and non-assistant messages are left untouched.
- The extension mutates streaming `block.text` in place with ANSI codes so the TUI renders transformed output in the same frame.

Does this read well? It's concise and specific.
Check wrapping: all code identifiers are backticked.
- `hideThinkingExtension`
- `src/cli.ts`
- `src/extensions/hide-thinking.ts`
- `message_start`
- `message_update`
- `message_end`
- `context`
- `hideThinkingBlock`
- `settings.json`
- `KIMCHI_CODING_AGENT_DIR`
- `src/extensions/hide-thinking.test.ts`
- `<think>`
- `block.text`
- ANSI (maybe should be backticked? It's an acronym, but fine.)

Wait, the instructions say "Wrap all code identifiers in backticks: function names, method names, variable names, type names, file paths, config keys, CLI commands." So ANSI is probably fine without, but I can leave it. `settings.json` is a file path. `KIMCHI_CODING_AGENT_DIR` is an env var, so code identifier.

One small thing: the test uses ` \u003cthink` and `</think>` tokens (with leading space in open tag). But the summary refers to `<think>`. Is that accurate? The code comments say `<think>... </think>` tags. The regex handles `<think>` and `</think>`. The leading space in the test is just because it's tokenized that way. I'll stick with `<think>…</think>` as it's clearer.

Double check: Does the diff contain any other modifications? No, just the three files.

The output must be plain Markdown, no preamble, no code fence wrapper. I will start directly with the heading.

Final check on structure:
- What changed: 1–3 sentences. Good.
- Why: Brief motivation. Good.
- Key changes: Bullets with files and specific changes. Good.
- Impact: Side effects, settings, breaking. Good.

Looks ready. </think> ### What changed
Adds a `hideThinkingExtension` that intercepts assistant messages containing `<think>…</think>` reasoning tags and transforms them for display—either dimming the content (default) or hiding it entirely—while preserving the original text in the LLM context.

### Why
Some models (e.g., DeepSeek, QwQ) emit reasoning inside `<think>` tags inline with regular text. This clutters the terminal UI and needs to be visually suppressed without stripping it from the conversation history sent back to the model.

### Key changes
- `src/cli.ts`: Registers the new `hideThinkingExtension` in the extension pipeline.
- `src/extensions/hide-thinking.ts`: New extension implementing:
  - `message_start` and `message_update`: In-place ANSI dimming (or complete hiding) of streaming thinking content so the TUI renders transformed output in the same frame.
  - `message_end`: Applies the final strip-or-dim transform and populates a display-to-original shadow map.
  - `context`: Restores original `<think>` content so it remains part of the LLM context.
  - Reads the `hideThinkingBlock` boolean from `settings.json` (resolved via `KIMCHI_CODING_AGENT_DIR`) to toggle behaviour.
- `src/extensions/hide-thinking.test.ts`: Adds tests covering default dimming, full hiding, streaming display, context restoration round-trip, multiple think blocks, and passthrough for non-assistant or native `thinking` blocks.

### Impact
- **New setting**: `hideThinkingBlock` in `settings.json`. Default `false` dims the last 5 lines of reasoning; set to `true` to remove reasoning from display entirely.
- **Additive / non-breaking**: Native `thinking` content blocks and non-assistant messages are left untouched. The extension only mutates text blocks that contain `<think>` tags.