### PR TITLE
Fix: Intel Mac binaries built with wrong architecture (arm64 instead of x86_64)fix build process for intels

### DIFF
--- a/.github/workflows/canary.yml
+++ b/.github/workflows/canary.yml
@@ -118,7 +118,7 @@ jobs:
         run: node scripts/set-version.js "${{ needs.preflight.outputs.version }}"
 
       - name: Build binary
-        run: node scripts/build-binary.js --target=${{ matrix.target }}
+        run: pnpm run build:binary -- --target=${{ matrix.target }}
 
       - name: Package binary
         run: tar -czf kimchi-code-canary_${{ matrix.os }}_${{ matrix.arch }}.tar.gz -C dist bin share

--- a/.github/workflows/canary.yml
+++ b/.github/workflows/canary.yml
@@ -88,19 +88,19 @@ jobs:
     strategy:
       matrix:
         include:
-          - target: bun-darwin-x64
+          - target: darwin-x64
             os: darwin
             arch: amd64
             runner: macos-15
-          - target: bun-darwin-arm64
+          - target: darwin-arm64
             os: darwin
             arch: arm64
             runner: macos-15
-          - target: bun-linux-x64
+          - target: linux-x64
             os: linux
             arch: amd64
             runner: ubuntu-latest
-          - target: bun-linux-arm64
+          - target: linux-arm64
             os: linux
             arch: arm64
             runner: ubuntu-24.04-arm
@@ -118,7 +118,7 @@ jobs:
         run: node scripts/set-version.js "${{ needs.preflight.outputs.version }}"
 
       - name: Build binary
-        run: pnpm run build:binary
+        run: node scripts/build-binary.js --target=${{ matrix.target }}
 
       - name: Package binary
         run: tar -czf kimchi-code-canary_${{ matrix.os }}_${{ matrix.arch }}.tar.gz -C dist bin share

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -34,19 +34,19 @@ jobs:
     strategy:
       matrix:
         include:
-          - target: bun-darwin-x64
+          - target: darwin-x64
             os: darwin
             arch: amd64
             runner: macos-15
-          - target: bun-darwin-arm64
+          - target: darwin-arm64
             os: darwin
             arch: arm64
             runner: macos-15
-          - target: bun-linux-x64
+          - target: linux-x64
             os: linux
             arch: amd64
             runner: ubuntu-latest
-          - target: bun-linux-arm64
+          - target: linux-arm64
             os: linux
             arch: arm64
             runner: ubuntu-24.04-arm
@@ -63,7 +63,7 @@ jobs:
         run: node scripts/set-version.js "$GITHUB_REF_NAME"
 
       - name: Build binary
-        run: pnpm run build:binary
+        run: pnpm run build:binary -- --target=${{ matrix.target }}
 
       - name: Package binary
         run: tar -czf kimchi_${{ matrix.os }}_${{ matrix.arch }}.tar.gz -C dist bin share

--- a/scripts/build-binary.js
+++ b/scripts/build-binary.js
@@ -2,14 +2,18 @@
 // Steps: clean → typecheck → compile → fix macOS codesign → copy binary resources.
 //
 // Usage:
-//   node scripts/build-binary.js                        # build for the host platform
-//   node scripts/build-binary.js --target linux-arm64   # cross-compile for Linux ARM64 (Apple Silicon Docker)
-//   node scripts/build-binary.js --target linux-x64     # cross-compile for Linux x86-64
+//   node scripts/build-binary.js                            # native build for current platform
+//   node scripts/build-binary.js --target darwin-x64        # cross-compile for macOS Intel
+//   node scripts/build-binary.js --target darwin-arm64      # cross-compile for macOS Apple Silicon
+//   node scripts/build-binary.js --target linux-arm64       # cross-compile for Linux ARM64
+//   node scripts/build-binary.js --target linux-x64         # cross-compile for Linux x86-64
 
 import { execSync } from "node:child_process"
 import { platform } from "node:os"
 
 const TARGET_MAP = {
+	"darwin-arm64": "bun-darwin-arm64",
+	"darwin-x64": "bun-darwin-x64",
 	"linux-arm64": "bun-linux-arm64",
 	"linux-x64": "bun-linux-x64",
 }
@@ -19,7 +23,6 @@ const targetArg =
 	(process.argv.includes("--target") ? process.argv[process.argv.indexOf("--target") + 1] : undefined)
 
 const crossTarget = targetArg ? (TARGET_MAP[targetArg] ?? targetArg) : undefined
-const isCrossCompile = !!crossTarget
 
 function run(label, cmd) {
 	console.log(`\n→ ${label}`)
@@ -44,7 +47,8 @@ run(
 // Bun --compile produces binaries with an invalid code signature on macOS.
 // The kernel kills badly-signed arm64 binaries immediately (SIGKILL, exit 137).
 // Strip the corrupt signature and re-sign ad-hoc. See: https://github.com/oven-sh/bun/issues/7208
-if (!isCrossCompile && platform() === "darwin") {
+const isDarwinTarget = crossTarget ? crossTarget.includes("darwin") : platform() === "darwin"
+if (isDarwinTarget && platform() === "darwin") {
 	run("codesign (strip)", "codesign --remove-signature dist/bin/kimchi")
 	run("codesign (ad-hoc)", "codesign -s - dist/bin/kimchi")
 }


### PR DESCRIPTION
## Problem
Users on Intel Macs got wrong CPU type in executable when running the install script. The downloaded kimchi_darwin_amd64.tar.gz actually contained an arm64 binary.
Root cause: The macos-15 CI runners are Apple Silicon (arm64). The build step ran pnpm run build:binary without forwarding a --target flag, so Bun compiled for the runner's native architecture. The resulting arm64 binary was silently packaged under the amd64 filename.

## Changes
- release.yml / canary.yml: Changed the "Build binary" step from pnpm run build:binary to node scripts/build-binary.js --target=${{ matrix.target }}, so the correct cross-compilation target is always passed. Matrix target values are now short-form (darwin-x64, darwin-arm64, linux-x64, linux-arm64).
- scripts/build-binary.js: Expanded TARGET_MAP with darwin entries so all four targets resolve to the correct Bun target format. Fixed the codesign condition to work correctly for cross-compiled darwin builds. Removed dead isCrossCompile variable. Updated usage comment to document all valid targets.
 
## Why it worked for everyone else
The Linux x64 and arm64 builds happened to be correct by accident — their native runner architectures matched their target architectures. Same for the arm64 darwin build. Only darwin-x64 (Intel Mac) was silently broken.

---
### Kimchi Summary
### What changed
Fixes CI cross-compilation so that macOS Intel (`darwin-x64`) and other platform-specific binaries are built for the declared target architecture rather than the host runner. The build script now maps Darwin targets and applies macOS code-signing when cross-compiling on a macOS host.

### Why
The workflow matrix previously used `bun-darwin-x64` style identifiers but never passed an explicit `--target` to the build script, so the runner always compiled for its native architecture. Additionally, the build script only signed non-cross-compiled macOS binaries, which produced invalid signatures when cross-compiling.

### Key changes
- `.github/workflows/canary.yml` and `.github/workflows/release.yml`:
  - Normalized matrix `target` values to `darwin-x64`, `darwin-arm64`, `linux-x64`, and `linux-arm64`.
  - Updated `Build binary` step to invoke `pnpm run build:binary -- --target=${{ matrix.target }}`.
- `scripts/build-binary.js`:
  - Added `darwin-arm64` and `darwin-x64` to `TARGET_MAP`.
  - Replaced `isCrossCompile` logic with `isDarwinTarget` so `codesign` runs for any Darwin target built on a macOS host.

### Impact
- Corrects architecture for cross-compiled macOS Intel (`darwin-x64`) artifacts.
- Ensures cross-compiled macOS binaries are properly ad-hoc signed, preventing SIGKILL on Apple Silicon Macs due to invalid signatures.