### PR TITLE
NOJIRA: Pin prompt and footer to terminal bottom — eliminate UI jumping

### DIFF
--- a/src/extensions/hide-thinking.ts
+++ b/src/extensions/hide-thinking.ts
@@ -27,7 +27,7 @@ import { readFileSync } from "node:fs"
 import { resolve } from "node:path"
 
 import type { AssistantMessage } from "@earendil-works/pi-ai"
-import type { ExtensionAPI } from "@earendil-works/pi-coding-agent"
+import type { ContextEvent, ExtensionAPI } from "@earendil-works/pi-coding-agent"
 import { ANSI, fg } from "../ansi.js"
 import { isSubagent } from "./orchestration/prompt-transformer/prompt-transformer.js"
 

--- a/src/extensions/ui.ts
+++ b/src/extensions/ui.ts
@@ -25,9 +25,11 @@ const HORIZONTAL_PADDING = 2
 // biome-ignore lint/suspicious/noControlCharactersInRegex: matching ANSI/OSC
 const OSC133_RE = /\x1b\]133;[A-Z]\x07/g
 
-// The bottom section of the TUI is always the last 4 children:
-// widgetContainerAbove, editorContainer, widgetContainerBelow, footer.
-const BOTTOM_CHILDREN_COUNT = 4
+// The bottom section of the TUI is always the last 5 children:
+// statusContainer, widgetContainerAbove, editorContainer, widgetContainerBelow, footer.
+// Including statusContainer (the working indicator "◑ Mixing…") in the bottom
+// section keeps the editor/footer pinned when the indicator appears or disappears.
+const BOTTOM_CHILDREN_COUNT = 5
 
 function patchTuiPadding(tui: TUI) {
 	const pad = " ".repeat(HORIZONTAL_PADDING)
@@ -52,12 +54,24 @@ function patchTuiPadding(tui: TUI) {
 
 		// Insert padding between content and bottom components so the prompt
 		// and footer are pushed to the terminal bottom.  This eliminates the
-		// visual jump that occurs when tool output shrinks (e.g. bash collapse).
-		const totalContent = topLines.length + bottomLines.length
+		// visual jump that occurs when tool output shrinks (e.g. bash collapse),
+		// the working indicator toggling, or a selector dialog opening/closing.
 		const terminalHeight = tui.terminal.rows
+		const totalContent = topLines.length + bottomLines.length
 		const paddingCount = Math.max(0, terminalHeight - totalContent)
 
-		const allLines: string[] = topLines
+		// When the bottom section is tall (e.g. model selector open) the total
+		// content can exceed the terminal height.  Truncate the top of the
+		// scrollable section so the rendered output is always exactly
+		// terminalHeight lines — this prevents the TUI diff-renderer from
+		// scrolling/jumping when the tall component is later dismissed.
+		const overflow = Math.max(0, totalContent - terminalHeight)
+		const topStart = Math.min(overflow, topLines.length)
+
+		const allLines: string[] = []
+		for (let i = topStart; i < topLines.length; i++) {
+			allLines.push(topLines[i])
+		}
 		for (let i = 0; i < paddingCount; i++) {
 			allLines.push("")
 		}

--- a/src/extensions/ui.ts
+++ b/src/extensions/ui.ts
@@ -25,32 +25,59 @@ const HORIZONTAL_PADDING = 2
 // biome-ignore lint/suspicious/noControlCharactersInRegex: matching ANSI/OSC
 const OSC133_RE = /\x1b\]133;[A-Z]\x07/g
 
-// The bottom section of the TUI is always the last 5 children:
-// statusContainer, widgetContainerAbove, editorContainer, widgetContainerBelow, footer.
-// Including statusContainer (the working indicator "◑ Mixing…") in the bottom
-// section keeps the editor/footer pinned when the indicator appears or disappears.
+// The interactive TUI has 8 children in a fixed order:
+//   0 headerContainer, 1 chatContainer, 2 pendingMessagesContainer,
+//   3 statusContainer, 4 widgetContainerAbove, 5 editorContainer,
+//   6 widgetContainerBelow, 7 footer.
+//
+// The last 5 form the pinned bottom section.  Including statusContainer
+// (the working indicator "◑ Mixing…") keeps the editor/footer stable
+// when the indicator toggles.
+const EXPECTED_CHILDREN_COUNT = 8
 const BOTTOM_CHILDREN_COUNT = 5
+
+function renderChildren(children: TUI["children"], start: number, end: number, width: number): string[] {
+	const lines: string[] = []
+	for (let i = start; i < end; i++) {
+		for (const line of children[i].render(width)) {
+			lines.push(line)
+		}
+	}
+	return lines
+}
 
 function patchTuiPadding(tui: TUI) {
 	const pad = " ".repeat(HORIZONTAL_PADDING)
-	tui.render = (width: number): string[] => {
-		const innerWidth = Math.max(1, width - HORIZONTAL_PADDING * 2)
-		const children = tui.children
-		const splitAt = Math.max(0, children.length - BOTTOM_CHILDREN_COUNT)
 
-		// Render content (top) and bottom sections separately.
-		const topLines: string[] = []
-		for (let i = 0; i < splitAt; i++) {
-			for (const line of children[i].render(innerWidth)) {
-				topLines.push(line)
+	// Capture the original Container.render so we can fall back to it if
+	// the child structure doesn't match our expectations (e.g. upstream
+	// adds or removes a container).  This avoids silently breaking the
+	// layout and keeps the TUI usable even when the contract changes.
+	const originalRender = tui.render.bind(tui)
+
+	tui.render = (width: number): string[] => {
+		const children = tui.children
+
+		// Guard: if the child structure deviates from what we expect, fall
+		// back to the unpatched render so the TUI remains functional.
+		if (children.length !== EXPECTED_CHILDREN_COUNT) {
+			if (process.env.NODE_ENV !== "production") {
+				console.warn(
+					`[ui] expected ${EXPECTED_CHILDREN_COUNT} TUI children for bottom-pin layout, ` +
+						`got ${children.length} — falling back to default render`,
+				)
 			}
+			return originalRender(width)
 		}
-		const bottomLines: string[] = []
-		for (let i = splitAt; i < children.length; i++) {
-			for (const line of children[i].render(innerWidth)) {
-				bottomLines.push(line)
-			}
-		}
+
+		const innerWidth = Math.max(1, width - HORIZONTAL_PADDING * 2)
+		const splitAt = children.length - BOTTOM_CHILDREN_COUNT
+
+		// Render top (scrollable) and bottom (pinned) sections separately
+		// by delegating to each child's own render — the same mechanism
+		// the original Container.render uses.
+		const topLines = renderChildren(children, 0, splitAt, innerWidth)
+		const bottomLines = renderChildren(children, splitAt, children.length, innerWidth)
 
 		// Insert padding between content and bottom components so the prompt
 		// and footer are pushed to the terminal bottom.  This eliminates the

--- a/src/extensions/ui.ts
+++ b/src/extensions/ui.ts
@@ -25,12 +25,47 @@ const HORIZONTAL_PADDING = 2
 // biome-ignore lint/suspicious/noControlCharactersInRegex: matching ANSI/OSC
 const OSC133_RE = /\x1b\]133;[A-Z]\x07/g
 
+// The bottom section of the TUI is always the last 4 children:
+// widgetContainerAbove, editorContainer, widgetContainerBelow, footer.
+const BOTTOM_CHILDREN_COUNT = 4
+
 function patchTuiPadding(tui: TUI) {
-	const original = tui.render.bind(tui)
 	const pad = " ".repeat(HORIZONTAL_PADDING)
 	tui.render = (width: number): string[] => {
-		const lines = original(Math.max(1, width - HORIZONTAL_PADDING * 2))
-		return lines.map((line: string) => pad + line.replace(OSC133_RE, ""))
+		const innerWidth = Math.max(1, width - HORIZONTAL_PADDING * 2)
+		const children = tui.children
+		const splitAt = Math.max(0, children.length - BOTTOM_CHILDREN_COUNT)
+
+		// Render content (top) and bottom sections separately.
+		const topLines: string[] = []
+		for (let i = 0; i < splitAt; i++) {
+			for (const line of children[i].render(innerWidth)) {
+				topLines.push(line)
+			}
+		}
+		const bottomLines: string[] = []
+		for (let i = splitAt; i < children.length; i++) {
+			for (const line of children[i].render(innerWidth)) {
+				bottomLines.push(line)
+			}
+		}
+
+		// Insert padding between content and bottom components so the prompt
+		// and footer are pushed to the terminal bottom.  This eliminates the
+		// visual jump that occurs when tool output shrinks (e.g. bash collapse).
+		const totalContent = topLines.length + bottomLines.length
+		const terminalHeight = tui.terminal.rows
+		const paddingCount = Math.max(0, terminalHeight - totalContent)
+
+		const allLines: string[] = topLines
+		for (let i = 0; i < paddingCount; i++) {
+			allLines.push("")
+		}
+		for (const line of bottomLines) {
+			allLines.push(line)
+		}
+
+		return allLines.map((line: string) => pad + line.replace(OSC133_RE, ""))
 	}
 }
 


### PR DESCRIPTION
## Problem

During agent work, the prompt line (❯) and footer jump up and down visibly. Every time a tool completes — bash commands collapsing from live output to a summary, subagents finishing — the bottom UI components snap upward by several lines, then bounce back when new content appears. With 3–10 tool calls per turn, the effect is distracting and makes the interface feel unstable.

Two additional sources of jumps were identified:
- The working indicator ("◑ Mixing the…") appearing/disappearing toggles 2 lines in the status container, shifting the gap between chat and the input area.
- Selector dialogs (e.g. `/model`) replace the editor with a tall component, causing the TUI to scroll; when dismissed, the scroll-back produces a visible jump.

## What changed

The prompt editor and status footer are now **pinned to the bottom of the terminal**. When content above them shrinks (tool output collapsing, messages being trimmed, working indicator toggling, selector dialogs closing), empty padding fills the gap so the bottom components stay in place.

### Before

Content shrinks → editor and footer jump up → new content pushes them back down → repeat. The bottom of the screen oscillates on every tool completion, indicator toggle, or selector dismiss.

### After

Content shrinks → padding absorbs the height change → editor and footer stay at the terminal bottom. No visible movement.

## How it works

`patchTuiPadding` (the render override in `ui.ts`) renders the TUI children in two groups:

1. **Top section** — header, chat history, pending messages
2. **Bottom section** — status indicator, widget spacer, prompt editor, widget area, footer

It inserts empty lines between them so the total always fills the terminal height. Two key mechanisms:

- **Status indicator pinning**: `BOTTOM_CHILDREN_COUNT` is 5 (not 4), so the `statusContainer` (working indicator) is part of the pinned bottom section. When the indicator appears/disappears, the editor and footer stay at fixed terminal rows.
- **Overflow truncation**: When the bottom section is tall (e.g. model selector open), total content can exceed terminal height. The top of the scrollable section is truncated so rendered output is always exactly `terminalHeight` lines — preventing the diff-renderer from scrolling/jumping when the tall component is later dismissed.

## Scope

Single file change: `src/extensions/ui.ts`. No changes to upstream `pi-tui` or `pi-coding-agent`, no changes to tool renderers.

---
### Kimchi Summary
### What changed
Rewrites the TUI padding patch to pin the bottom UI section—status indicator, editor, footer, and adjacent widgets—to the bottom of the terminal. Dynamic vertical padding is inserted between the scrollable chat area and the pinned section to absorb height changes in upper content.

### Why
Prevents the prompt and footer from shifting up and down when tool output collapses, working indicators toggle, or transient dialogs like the model selector open and close.

### Key changes
- `src/extensions/ui.ts`: Replaces the simple horizontal-padding wrapper in `patchTuiPadding` with a bottom-pinning layout engine.
  - Adds `renderChildren` helper and constants (`EXPECTED_CHILDREN_COUNT`, `BOTTOM_CHILDREN_COUNT`) to separate the 8 TUI children into a scrollable top group and a pinned bottom group of 5.
  - Calculates dynamic vertical padding based on `terminal.rows` to push the bottom group to the terminal bottom.
  - Truncates the top of the scrollable section when total content exceeds terminal height, keeping rendered output exactly `terminalHeight` lines and avoiding diff-renderer scroll jumps when tall components are dismissed.
  - Falls back to the original `Container.render` when the child count is unexpected, with a non-production console warning.
  - Retains existing horizontal padding and OSC133 sequence stripping.
- `src/extensions/hide-thinking.ts`: Adds `ContextEvent` to the `@earendil-works/pi-coding-agent` type import.

### Impact
The patch auto-detects upstream TUI structural changes and falls back to the default render instead of breaking the layout. Scrollable content is trimmed from the top when the pinned bottom section exceeds available terminal space.