### PR TITLE
LLM-1292: Enable /stats command

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -30,7 +30,7 @@ import { reserveShiftTabForPermissions } from "./extensions/permissions/keybindi
 import promptSummaryExtension from "./extensions/prompt-summary.js"
 import shutdownMarkerExtension from "./extensions/shutdown-marker.js"
 import startupUpdateExtension from "./extensions/startup-update.js"
-// import statsExtension from "./extensions/stats/index.js"
+import statsExtension from "./extensions/stats/index.js"
 import subagentExtension from "./extensions/subagent.js"
 import tagsExtension from "./extensions/tags.js"
 import telemetryExtension from "./extensions/telemetry.js"
@@ -255,7 +255,7 @@ try {
 			startupUpdateExtension,
 			sessionIdCaptureExtension,
 			shutdownMarkerExtension,
-			// statsExtension,
+			statsExtension,
 			terminalColorsExtension,
 			kimchiMinimalTintsExtension,
 			bashCollapseExtension,

--- a/src/extensions/stats/api.ts
+++ b/src/extensions/stats/api.ts
@@ -5,40 +5,25 @@
  */
 
 import type {
-	GenerateAnalyticsRequest,
 	GenerateAnalyticsResponse,
-	GenerateProductivityMetricsTimeseriesRequest,
 	GenerateProductivityMetricsTimeseriesResponse,
-	GetProductivityMetricsRequest,
 	GetProductivityMetricsResponse,
 } from "./types.js"
 
 const BASE_URL = "https://api.cast.ai"
 
-// Hardcoded user ID as specified in requirements
-const HARDCODED_USER_ID = "d1c79c82-c230-4b19-9def-dbe49bf63368"
-
-// Hardcoded organization ID - needed for some endpoints
-const FALLBACK_ORG_ID = "516442fe-054a-49e2-ac2d-9dc9b104c3d2"
-
 interface ApiClientConfig {
 	apiKey: string
 	baseUrl?: string
-	userId?: string
-	organizationId?: string
 }
 
 export class CastAiStatsApi {
 	private apiKey: string
 	private baseUrl: string
-	private userId: string
-	private organizationId: string
 
 	constructor(config: ApiClientConfig) {
 		this.apiKey = config.apiKey
 		this.baseUrl = config.baseUrl ?? BASE_URL
-		this.userId = config.userId ?? HARDCODED_USER_ID
-		this.organizationId = config.organizationId ?? FALLBACK_ORG_ID
 	}
 
 	/**
@@ -66,33 +51,25 @@ export class CastAiStatsApi {
 
 	/**
 	 * Generates analytics data for the organization.
-	 * Endpoint: GET /ai-optimizer/v1beta/organizations/{id}:generateAnalyticsReport
+	 * Endpoint: GET /ai-optimizer/v1beta/analytics
 	 *
-	 * Note: This endpoint requires an organization ID. It supports filtering by castai_api_key_owner_id.
+	 * Passes inferUserFromApiKey=true so the user is inferred from the API key.
 	 */
-	async generateAnalytics(startTime: Date, endTime: Date, organizationId?: string): Promise<GenerateAnalyticsResponse> {
-		const orgId = organizationId ?? this.organizationId
-
-		// Build filter for user - uses CEL expression
-		// Filter format: castai_api_key_owner_id == "user-id"
-		const filter = `castai_api_key_owner_id == "${this.userId}"`
-
+	async generateAnalytics(startTime: Date, endTime: Date): Promise<GenerateAnalyticsResponse> {
 		const params = new URLSearchParams({
 			startTime: startTime.toISOString(),
 			endTime: endTime.toISOString(),
-			filter: filter,
+			inferUserFromApiKey: "true",
 		})
 
-		return this.request<GenerateAnalyticsResponse>(
-			`/ai-optimizer/v1beta/organizations/${orgId}:generateAnalyticsReport?${params.toString()}`,
-		)
+		return this.request<GenerateAnalyticsResponse>(`/ai-optimizer/v1beta/analytics?${params.toString()}`)
 	}
 
 	/**
 	 * Gets aggregated productivity metrics.
 	 * Endpoint: GET /ai-optimizer/v1beta/productivity-metrics
 	 *
-	 * Note: Supports user_id filtering.
+	 * Passes inferUserFromApiKey=true so the user is inferred from the API key.
 	 */
 	async getProductivityMetrics(
 		startTime: Date,
@@ -106,12 +83,9 @@ export class CastAiStatsApi {
 		const params = new URLSearchParams({
 			from: startTime.toISOString(),
 			to: endTime.toISOString(),
+			inferUserFromApiKey: "true",
 		})
 
-		// NOTE: Not filtering by user_id for productivity metrics - shows all org data
-		// Analytics endpoint still filters by user via CEL expression
-
-		// Optional provider filter
 		if (options.providerName) {
 			params.set("provider_name", options.providerName)
 		}
@@ -133,29 +107,24 @@ export class CastAiStatsApi {
 
 	/**
 	 * Generates productivity metrics as time series data points.
-	 * Endpoint: GET /ai-optimizer/v1beta/organizations/{organization_id}/productivity-metrics:generateTimeseries
+	 * Endpoint: GET /ai-optimizer/v1beta/productivity-metrics:generateTimeseries
 	 *
-	 * Note: This endpoint requires an organization ID. Supports user_id filtering.
+	 * Passes inferUserFromApiKey=true so the user is inferred from the API key.
 	 */
 	async generateProductivityMetricsTimeseries(
 		startTime: Date,
 		endTime: Date,
-		organizationId?: string,
 		options: {
 			metricNames?: string[]
 			sessionId?: string
 			providerName?: string
 		} = {},
 	): Promise<GenerateProductivityMetricsTimeseriesResponse> {
-		const orgId = organizationId ?? this.organizationId
-
 		const params = new URLSearchParams({
 			from: startTime.toISOString(),
 			to: endTime.toISOString(),
+			inferUserFromApiKey: "true",
 		})
-
-		// Note: Productivity timeseries is org-wide data (no user filter)
-		// No provider_name filter - show all providers (claude-code-otel, opencode-otel)
 
 		if (options.metricNames?.length) {
 			for (const name of options.metricNames) {
@@ -168,29 +137,8 @@ export class CastAiStatsApi {
 		}
 
 		return this.request<GenerateProductivityMetricsTimeseriesResponse>(
-			`/ai-optimizer/v1beta/organizations/${orgId}/productivity-metrics:generateTimeseries?${params.toString()}`,
+			`/ai-optimizer/v1beta/productivity-metrics:generateTimeseries?${params.toString()}`,
 		)
-	}
-
-	/**
-	 * Get the hardcoded user ID being used
-	 */
-	getUserId(): string {
-		return this.userId
-	}
-
-	/**
-	 * Get the organization ID being used
-	 */
-	getOrganizationId(): string {
-		return this.organizationId
-	}
-
-	/**
-	 * Set a different organization ID
-	 */
-	setOrganizationId(orgId: string): void {
-		this.organizationId = orgId
 	}
 }
 

--- a/src/extensions/stats/index.ts
+++ b/src/extensions/stats/index.ts
@@ -8,43 +8,18 @@
  */
 
 import type { ExtensionAPI, ExtensionCommandContext } from "@earendil-works/pi-coding-agent"
+import { loadConfig } from "../../config.js"
 import { exitSplashMode } from "../ui.js"
 import { CastAiStatsApi, getTimeRange } from "./api.js"
 import { formatError, formatHelp } from "./display.js"
 import { formatAnalyticsVisual, formatProductivityVisual } from "./visual.js"
 
-// API key used for Cast AI API requests - must be provided via CASTAI_API_KEY env var
-
-// Hardcoded user ID as specified
-const HARDCODED_USER_ID = "d1c79c82-c230-4b19-9def-dbe49bf63368"
-
-// Organization ID - provided by user
-const ORGANIZATION_ID = "516442fe-054a-49e2-ac2d-9dc9b104c3d2"
-
-interface StatsConfig {
-	apiKey: string
-	userId: string
-	organizationId: string
-}
-
-function getStatsConfig(): StatsConfig {
-	const envKey = process.env.CASTAI_API_KEY
-	const envOrg = process.env.CASTAI_ORG_ID
-
-	return {
-		apiKey: envKey || "",
-		userId: HARDCODED_USER_ID,
-		organizationId: envOrg || ORGANIZATION_ID,
-	}
-}
-
 function createApiClient(): CastAiStatsApi {
-	const config = getStatsConfig()
-	return new CastAiStatsApi({
-		apiKey: config.apiKey,
-		userId: config.userId,
-		organizationId: config.organizationId,
-	})
+	const apiKey = loadConfig().apiKey || process.env.CASTAI_API_KEY
+	if (!apiKey) {
+		throw new Error("No API key found. Please run `kimchi login` to set up your API key.")
+	}
+	return new CastAiStatsApi({ apiKey })
 }
 
 async function handleStatsCommand(args: string, ctx: ExtensionCommandContext): Promise<void> {
@@ -98,17 +73,7 @@ async function handleStatsCommand(args: string, ctx: ExtensionCommandContext): P
 			}
 		} catch (err) {
 			const msg = err instanceof Error ? err.message : String(err)
-			if (msg.includes("404") || msg.includes("organization")) {
-				outputLines.push(
-					...formatError(
-						"Analytics endpoint requires a valid organization ID. " +
-							"Set CASTAI_ORG_ID environment variable if needed.",
-						ctx.ui.theme,
-					),
-				)
-			} else {
-				outputLines.push(...formatError(`Analytics API: ${msg}`, ctx.ui.theme))
-			}
+			outputLines.push(...formatError(`Analytics API: ${msg}`, ctx.ui.theme))
 		}
 
 		// Fetch productivity metrics


### PR DESCRIPTION


---
### Kimchi Summary
### What changed
Re-enables the `stats` extension and migrates its API client to Cast AI's newer endpoints, eliminating all hardcoded user and organization identifiers.

### Why
The previous stats implementation relied on hardcoded IDs and organization-scoped API paths. The backend now infers the caller's user and organization directly from the API key, which removes the need for manual per-environment configuration and makes the extension work out of the box for any authenticated user.

### Key changes
- `src/cli.ts`: Uncommented `statsExtension` import and registration to activate the extension.
- `src/extensions/stats/api.ts`: Removed `HARDCODED_USER_ID`, `FALLBACK_ORG_ID`, and the `userId`/`organizationId` config fields; updated analytics to call `/ai-optimizer/v1beta/analytics`; updated productivity timeseries to call `/ai-optimizer/v1beta/productivity-metrics:generateTimeseries`; appended `inferUserFromApiKey=true` to all endpoint requests; removed CEL user filters.
- `src/extensions/stats/index.ts`: Replaced the env-var based `getStatsConfig` setup with `loadConfig().apiKey` (falling back to `CASTAI_API_KEY`); added an explicit error if no API key is configured; removed the organization-specific 404 error branch.

### Impact
Users must have a valid Cast AI API key configured via `kimchi login` or the `CASTAI_API_KEY` environment variable to use stats commands. The `CASTAI_ORG_ID` environment variable is no longer referenced and can be removed.