### PR TITLE
NOJIRA: Fix failing pipeline errors

### DIFF
--- a/src/extensions/hide-thinking.ts
+++ b/src/extensions/hide-thinking.ts
@@ -26,8 +26,8 @@
 import { readFileSync } from "node:fs"
 import { resolve } from "node:path"
 
-import type { AssistantMessage } from "@mariozechner/pi-ai"
-import type { ExtensionAPI } from "@mariozechner/pi-coding-agent"
+import type { AssistantMessage } from "@earendil-works/pi-ai"
+import type { ExtensionAPI } from "@earendil-works/pi-coding-agent"
 import { ANSI, fg } from "../ansi.js"
 import { isSubagent } from "./orchestration/prompt-transformer/prompt-transformer.js"
 


### PR DESCRIPTION
## Summary
- Fix stale imports in `hide-thinking` extension that referenced old `@mariozechner` packages instead of the correct `@earendil-works` packages, which broke `typecheck`, `build:binary`, and `test:smoke`.

## Test plan
- [x] `pnpm run check` passes (lint + typecheck)
- [x] `pnpm run test` passes (1191 tests)
- [x] `pnpm run build:binary` completes successfully
- [x] `pnpm run test:smoke` passes (8 passed, 12 skipped due to missing API key)

---
### Kimchi Summary
### What changed
Updates the npm package scope for AI agent dependencies in `src/extensions/hide-thinking.ts` from `@mariozechner` to `@earendil-works`.

### Why
Fixes failing pipeline errors caused by outdated package references that no longer resolve.

### Key changes
- `src/extensions/hide-thinking.ts`: Changed `AssistantMessage` import from `@mariozechner/pi-ai` to `@earendil-works/pi-ai`.
- `src/extensions/hide-thinking.ts`: Changed `ExtensionAPI` import from `@mariozechner/pi-coding-agent` to `@earendil-works/pi-coding-agent`.