### PR TITLE
LLM-1377: Filter thinking tags from subagent tool output display

### DIFF
--- a/src/extensions/hide-thinking.test.ts
+++ b/src/extensions/hide-thinking.test.ts
@@ -1,6 +1,11 @@
 import { beforeEach, describe, expect, it, vi } from "vitest"
 import { ANSI, fg } from "../ansi.js"
-import hideThinkingExtension, { _getDisplayToOriginal, _resetState, _setHideThinking } from "./hide-thinking.js"
+import hideThinkingExtension, {
+	_getDisplayToOriginal,
+	_resetState,
+	_setHideThinking,
+	filterThinkingForDisplay,
+} from "./hide-thinking.js"
 
 type Handler = (event: unknown) => unknown
 
@@ -268,4 +273,50 @@ describe("hideThinkingExtension", () => {
 		})
 		expect(result).toBeUndefined()
 	})
+})
+
+describe("filterThinkingForDisplay", () => {
+	beforeEach(() => {
+		_resetState()
+	})
+
+	const cases: Record<string, { input: string; hideThinking: boolean; expected: string }> = {
+		"strips thinking blocks when hideThinking is true": {
+			input: "Before <think>reasoning</think> After",
+			hideThinking: true,
+			expected: "Before  After",
+		},
+		"dims thinking blocks when hideThinking is false": {
+			input: "Before <think>reasoning</think> After",
+			hideThinking: false,
+			expected: `Before ${fg(ANSI.dim, "reasoning")} After`,
+		},
+		"returns text unchanged when no thinking tags present": {
+			input: "plain text without thinking",
+			hideThinking: true,
+			expected: "plain text without thinking",
+		},
+		"handles multiple thinking blocks": {
+			input: "A <think>first</think> B <think>second</think> C",
+			hideThinking: true,
+			expected: "A  B  C",
+		},
+		"handles unclosed think tag by hiding trailing content when hideThinking is true": {
+			input: "Before <think>still streaming",
+			hideThinking: true,
+			expected: "Before ",
+		},
+		"handles unclosed think tag by dimming trailing content when hideThinking is false": {
+			input: "Before <think>still streaming",
+			hideThinking: false,
+			expected: `Before ${fg(ANSI.dim, "still streaming")}`,
+		},
+	}
+
+	for (const [name, { input, hideThinking, expected }] of Object.entries(cases)) {
+		it(name, () => {
+			_setHideThinking(hideThinking)
+			expect(filterThinkingForDisplay(input)).toBe(expected)
+		})
+	}
 })

--- a/src/extensions/hide-thinking.ts
+++ b/src/extensions/hide-thinking.ts
@@ -144,6 +144,10 @@ let streamingBlocks: Map<number, StreamingBlockState> | null = null
 // Test helpers
 // ---------------------------------------------------------------------------
 
+export function filterThinkingForDisplay(text: string): string {
+	return applyStreamingDisplay(text, readHideThinkingSetting())
+}
+
 export function _setHideThinking(value: boolean | undefined): void {
 	hideThinkingOverride = value
 }

--- a/src/extensions/hide-thinking.ts
+++ b/src/extensions/hide-thinking.ts
@@ -116,6 +116,10 @@ function applyStreamingDisplay(text: string, hideThinking: boolean): string {
 	return result
 }
 
+export function filterThinkingForDisplay(text: string): string {
+	return applyStreamingDisplay(text, readHideThinkingSetting())
+}
+
 // ---------------------------------------------------------------------------
 // Shadow map — transformed display text → original text with thinking tags.
 // Used by the context handler to restore originals before LLM calls.
@@ -143,10 +147,6 @@ let streamingBlocks: Map<number, StreamingBlockState> | null = null
 // ---------------------------------------------------------------------------
 // Test helpers
 // ---------------------------------------------------------------------------
-
-export function filterThinkingForDisplay(text: string): string {
-	return applyStreamingDisplay(text, readHideThinkingSetting())
-}
 
 export function _setHideThinking(value: boolean | undefined): void {
 	hideThinkingOverride = value

--- a/src/extensions/subagent.ts
+++ b/src/extensions/subagent.ts
@@ -17,6 +17,7 @@ import { isBunBinary, isRunningUnderBun } from "../env.js"
 import { isToolExpanded, registerToolCall } from "../expand-state.js"
 import { findExistingFile, resolveUserPath, stripAtPrefix } from "../fs-paths.js"
 import { formatCount, formatDuration } from "./format.js"
+import { filterThinkingForDisplay } from "./hide-thinking.js"
 import { type SpinnerState, clearSpinner, spinnerFrame, tickSpinner } from "./spinner.js"
 
 const PROMPT_MAX_LENGTH = 60
@@ -819,10 +820,11 @@ export default function (pi: ExtensionAPI) {
 
 			const text = getTextContent(result)
 			if (!text) return new Text("", 0, 0)
+			const displayText = filterThinkingForDisplay(text)
 
 			if (options.isPartial) {
 				const toolCall = state.lastToolCall
-				let displayText: string
+				let partialDisplayText: string
 				let displayStyle: "dim" | "toolOutput"
 				const terminalWidth = process.stdout.columns ?? 80
 				if (toolCall) {
@@ -832,27 +834,27 @@ export default function (pi: ExtensionAPI) {
 						...toolCallVisualLines.slice(0, 5),
 						...Array(5 - Math.min(toolCallVisualLines.length, 5)).fill(""),
 					]
-					displayText = paddedLines.join("\n")
+					partialDisplayText = paddedLines.join("\n")
 					displayStyle = "dim"
 				} else {
-					const nonEmptyLines = text.split("\n").filter((l: string) => l.trim())
+					const nonEmptyLines = displayText.split("\n").filter((l: string) => l.trim())
 					const visualLines = nonEmptyLines.flatMap((l: string) => wrapTextWithAnsi(l, terminalWidth))
 					const last5 = visualLines.slice(-5)
 					const paddedLines = [...Array(5 - last5.length).fill(""), ...last5]
-					displayText = paddedLines.join("\n")
+					partialDisplayText = paddedLines.join("\n")
 					displayStyle = "toolOutput"
 				}
 
 				const component = context.lastComponent instanceof Container ? context.lastComponent : new Container()
 				component.clear()
 				component.addChild(new Spacer(1))
-				component.addChild(new Text(theme.fg(displayStyle, displayText), 0, 0))
+				component.addChild(new Text(theme.fg(displayStyle, partialDisplayText), 0, 0))
 				return component
 			}
 
 			const view = context.lastComponent instanceof ToolBlockView ? context.lastComponent : new ToolBlockView()
 			const stats = result.details as SubagentStats | undefined
-			const nonEmptyLines = text.split("\n").filter((l: string) => l.trim())
+			const nonEmptyLines = displayText.split("\n").filter((l: string) => l.trim())
 			const lineCount = nonEmptyLines.length
 
 			registerToolCall(context.toolCallId)
@@ -861,7 +863,7 @@ export default function (pi: ExtensionAPI) {
 
 			if (isToolExpanded(context.toolCallId)) {
 				const statsLine = stats !== undefined ? formatStats(stats, theme) : ""
-				view.setFooter(theme.fg("toolOutput", text), "")
+				view.setFooter(theme.fg("toolOutput", displayText), "")
 				view.setExtra(statsLine ? [statsLine] : [])
 			} else {
 				const outputSummary = theme.fg("dim", `${lineCount} line${lineCount === 1 ? "" : "s"} written`)

--- a/src/paste-interceptor.ts
+++ b/src/paste-interceptor.ts
@@ -39,7 +39,7 @@ export function installPasteInterceptor(stdin: NodeJS.ReadStream = process.stdin
 				return originalEmit("data", wrapAsBracketedPaste(text))
 			}
 		}
-		return originalEmit(event as string, ...args)
+		return originalEmit(event, ...args)
 	}
 	wrapped.installed = true
 	stdin.emit = wrapped


### PR DESCRIPTION
## Summary

Subagent tool output was not passing through the hide-thinking filter, causing internal reasoning/thinking blocks to remain visible even when the user had the hide-thinking setting enabled.

## Changes

- **`src/extensions/hide-thinking.ts`** — Export `filterThinkingForDisplay()` to allow non-streaming callers to apply the thinking filter.
- **`src/extensions/subagent.ts`** — Apply `filterThinkingForDisplay` to subagent result text before rendering partial output, line counts, and the expanded tool footer.
- **`src/paste-interceptor.ts`** — Remove redundant `as string` type assertion on the `originalEmit` call.

## Testing

Lint and type checks pass.

---
### Kimchi Summary
### What changed
Filters thinking/reasoning tags from subagent tool output based on the user's hide-thinking setting. Introduces a reusable `filterThinkingForDisplay` helper in the hide-thinking extension and cleans up a type cast in the paste interceptor.

### Why
Subagent outputs were previously rendering raw thinking blocks, which cluttered the terminal regardless of the user's configured hide-thinking preference.

### Key changes
- `src/extensions/hide-thinking.ts`: Exports `filterThinkingForDisplay(text)` to apply the current hide-thinking logic to an arbitrary string.
- `src/extensions/hide-thinking.test.ts`: Adds unit tests for `filterThinkingForDisplay` covering tag stripping, dimmed display, multiple blocks, and unclosed tags.
- `src/extensions/subagent.ts`: Applies `filterThinkingForDisplay` to subagent result text before rendering both partial updates and the final `ToolBlockView`.
- `src/paste-interceptor.ts`: Removes an unnecessary `as string` cast from the wrapped `stdin.emit` call.