### PR TITLE
 pass --target to build script and install cross-platform native dep

### DIFF
--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -24,18 +24,6 @@ runs:
         node-version: "22"
         cache: "pnpm"
 
-    - name: Configure cross-platform dependencies
-      shell: bash
-      run: |
-        cat >> .npmrc << 'EOF'
-        supportedArchitectures.cpu[]=current
-        supportedArchitectures.cpu[]=x64
-        supportedArchitectures.cpu[]=arm64
-        supportedArchitectures.os[]=current
-        supportedArchitectures.os[]=darwin
-        supportedArchitectures.os[]=linux
-        EOF
-
     - name: Install dependencies
       shell: bash
       run: pnpm install --frozen-lockfile

--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -24,6 +24,18 @@ runs:
         node-version: "22"
         cache: "pnpm"
 
+    - name: Configure cross-platform dependencies
+      shell: bash
+      run: |
+        cat >> .npmrc << 'EOF'
+        supportedArchitectures.cpu[]=current
+        supportedArchitectures.cpu[]=x64
+        supportedArchitectures.cpu[]=arm64
+        supportedArchitectures.os[]=current
+        supportedArchitectures.os[]=darwin
+        supportedArchitectures.os[]=linux
+        EOF
+
     - name: Install dependencies
       shell: bash
       run: pnpm install --frozen-lockfile

--- a/.github/workflows/canary.yml
+++ b/.github/workflows/canary.yml
@@ -155,8 +155,8 @@ jobs:
         run: pnpm run test:smoke
 
   release:
-    needs: [preflight, smoke-test]
     if: needs.preflight.outputs.should-build == 'true'
+    needs: [preflight, smoke-test]
     runs-on: ubuntu-latest
     timeout-minutes: 10
     permissions:

--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,6 @@
+supportedArchitectures.cpu[]=current
+supportedArchitectures.cpu[]=x64
+supportedArchitectures.cpu[]=arm64
+supportedArchitectures.os[]=current
+supportedArchitectures.os[]=darwin
+supportedArchitectures.os[]=linux


### PR DESCRIPTION
After adding --target to the build step for cross-compilation, the darwin-x64 build fails on the arm64 macos-15 runner:
Could not resolve: "@mariozechner/clipboard-darwin-x64/clipboard.darwin-x64.node"
Bun's bundler needs to embed the target platform's native .node file in the compiled binary, but pnpm skips installing it because the package declares cpu: ["x64"] and the host is arm64.

---
### Kimchi Summary
### What changed
Fixes the canary release workflow by reordering the `release` job fields and adds `.npmrc` configuration for cross-platform native dependency support.

### Why
Ensures the conditional `release` job correctly references its upstream dependencies, and prevents architecture-specific package installation failures on macOS and Linux.

### Key changes
- `.github/workflows/canary.yml`: Swapped the order of `needs` and `if` in the `release` job so the dependency list follows the conditional guard.
- `.npmrc`: Added `supportedArchitectures` entries enabling installation of native packages for `cpu` (`current`, `x64`, `arm64`) and `os` (`current`, `darwin`, `linux`).

### Impact
- CI and local installs will now download optional native dependencies for all declared platforms, avoiding build failures on Apple Silicon and Linux runners.