### PR TITLE
feat: configurable mode defaults, phase visibility, and statusline phase integration

### DIFF
--- a/src/components/footer.ts
+++ b/src/components/footer.ts
@@ -94,6 +94,7 @@ export function buildScriptPayload(
 		multi_model: {
 			enabled: getMultiModelEnabled(),
 		},
+		phase: getCurrentPhase(),
 	}
 }
 

--- a/src/extensions/orchestration/prompt-enrichment.ts
+++ b/src/extensions/orchestration/prompt-enrichment.ts
@@ -21,7 +21,7 @@
  */
 
 import { execSync } from "node:child_process"
-import { existsSync } from "node:fs"
+import { existsSync, readFileSync } from "node:fs"
 import { homedir, platform, userInfo } from "node:os"
 import { isAbsolute, join, normalize, resolve } from "node:path"
 import type { AssistantMessage, ImageContent, TextContent } from "@earendil-works/pi-ai"
@@ -91,6 +91,19 @@ function readGitRemote(cwd: string): string | undefined {
 }
 
 // Workaround: pi-mono's applyExtensionFlagValues ignores the actual value for boolean flags (always sets true). Read argv directly until upstream is fixed.
+const HARNESS_SETTINGS_PATH = join(homedir(), ".config", "kimchi", "harness", "settings.json")
+
+function readHarnessSetting<T>(key: string, fallback: T): T {
+	try {
+		const raw = readFileSync(HARNESS_SETTINGS_PATH, "utf-8")
+		const parsed = JSON.parse(raw)
+		if (key in parsed) return parsed[key] as T
+	} catch {
+		// settings.json absent or unreadable — use fallback
+	}
+	return fallback
+}
+
 function readMultiModelArgv(): boolean {
 	const args = process.argv
 	for (let i = 0; i < args.length; i++) {
@@ -104,7 +117,8 @@ function readMultiModelArgv(): boolean {
 			return true
 		}
 	}
-	return true
+	// No CLI flag — fall back to settings.json, then hard-coded default
+	return readHarnessSetting("multiModel", true)
 }
 
 let multiModelEnabled = readMultiModelArgv()

--- a/src/extensions/permissions/config.test.ts
+++ b/src/extensions/permissions/config.test.ts
@@ -89,4 +89,13 @@ describe("loadConfig merging", () => {
 		expect(loaded.allowBySource.cli).toEqual(["bash(npm test)"])
 		expect(loaded.denyBySource.cli).toEqual(["write(.env)"])
 	})
+
+	it("accepts yolo as defaultMode and round-trips it", () => {
+		mkdirSync(join(tmpCwd, ".kimchi"), { recursive: true })
+		writeFileSync(join(tmpCwd, ".kimchi", "permissions.json"), JSON.stringify({ defaultMode: "yolo" }))
+
+		const { loaded, errors } = loadConfig({ cwd: tmpCwd })
+		expect(errors).toEqual([])
+		expect(loaded.config.defaultMode).toBe("yolo")
+	})
 })

--- a/src/extensions/permissions/config.ts
+++ b/src/extensions/permissions/config.ts
@@ -4,7 +4,7 @@ import { dirname, join, resolve } from "node:path"
 import { z } from "zod"
 import { DEFAULT_CONFIG, type PermissionsConfig } from "./types.js"
 
-const modeSchema = z.enum(["default", "plan", "auto"])
+const modeSchema = z.enum(["default", "plan", "auto", "yolo"])
 
 const configSchema = z
 	.object({

--- a/src/extensions/tags.ts
+++ b/src/extensions/tags.ts
@@ -12,7 +12,7 @@
 
 import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs"
 import { homedir } from "node:os"
-import { dirname, resolve } from "node:path"
+import { dirname, join, resolve } from "node:path"
 import type {
 	ExtensionAPI,
 	ExtensionCommandContext,
@@ -27,6 +27,22 @@ import { Type } from "typebox"
 
 const FOOTER_STATUS_KEY = "active-tags"
 const TAGS_CONFIG_FILE = resolve(homedir(), ".config", "kimchi", "tags.json")
+const HARNESS_SETTINGS_PATH = join(homedir(), ".config", "kimchi", "harness", "settings.json")
+
+function readHarnessSetting<T>(key: string, fallback: T): T {
+	try {
+		const raw = readFileSync(HARNESS_SETTINGS_PATH, "utf-8")
+		const parsed = JSON.parse(raw)
+		if (key in parsed) return parsed[key] as T
+	} catch {
+		// settings.json absent or unreadable — use fallback
+	}
+	return fallback
+}
+
+export function readHidePhaseChanges(): boolean {
+	return readHarnessSetting<boolean>("hidePhaseChanges", false)
+}
 
 const TAG_COLORS: ThemeColor[] = ["accent", "mdLink", "success", "warning"]
 
@@ -482,6 +498,9 @@ export default function tagsExtension(pi: ExtensionAPI) {
 		},
 
 		renderResult(result, _options, theme) {
+			if (readHidePhaseChanges()) {
+				return new Text("", 0, 0)
+			}
 			const phase = (result.details as { phase: string } | undefined)?.phase ?? "unknown"
 			const dash = theme.fg("dim", "- ")
 			const label = theme.bold(theme.fg("toolTitle", `Phase changed: ${phase}`))


### PR DESCRIPTION
## What

Closes three hard-coded-behaviour gaps in the harness:

1. **Action-mode (`yolo`) persistence** — `permissions.json` schema rejected `"yolo"`; only CLI flags (`--yolo`, `--dangerously-skip-permissions`) worked. Now it round-trips through config like the other modes.
2. **Multi-model startup default** — `multiModel` was hard-coded to `true` in `prompt-enrichment.ts`. It now reads from `~/.config/kimchi/harness/settings.json` (falls back to `true`).
3. **Phase-change printing** — `set_phase` always printed `Phase changed: X`. Added `hidePhaseChanges` setting (default `false`) so users can suppress it.
4. **Phase in external statusline** — `buildScriptPayload` now includes `phase` so custom statusline scripts can display it.

## Files changed

| File | Change |
|---|---|
| `src/extensions/permissions/config.ts` | Expand `modeSchema` → `z.enum([...,"yolo"])` |
| `src/extensions/permissions/config.test.ts` | Add `yolo` round-trip test |
| `src/extensions/orchestration/prompt-enrichment.ts` | Read `multiModel` from `settings.json` |
| `src/extensions/tags.ts` | Add `readHidePhaseChanges()`; gate `set_phase` render |
| `src/components/footer.ts` | Add `phase: getCurrentPhase()` to script payload |

## Example `settings.json` / `permissions.json`

```json
// ~/.config/kimchi/harness/settings.json
{
  "multiModel": true,
  "hidePhaseChanges": false,
  "statusLine": {
    "command": "~/.config/kimchi/harness/statusline.sh"
  }
}

// repo-root/.kimchi/permissions.json
{
  "defaultMode": "yolo"
}
```

## Example statusline output

With a script that consumes the JSON payload (e.g. `statusline.sh`):

```
⌘ kimi-k2.6 | ● explore | 📁 harness | ⎇ master
         ^^^^^   ^^^^^^^^
         model   phase (new)
```

Key snippet in the statusline script:

```js
const modelName = input?.model?.display_name || input?.model?.id || 'Claude';
const phase     = input?.phase || 'idle';

parts.push(`${c('gray', '⌘')} ${c('dim', modelName)}`);
parts.push(`${c('gray', '●')} ${c('dim', phase)}`);
```

## Verification

- `pnpm run test src/extensions/permissions/config.test.ts` — 6/6 pass
- `pnpm run lint` — clean

---
### Kimchi Summary
### What changed
Adds support for configuring runtime modes and phase visibility via harness settings, introduces a new `yolo` permission mode, and exposes the current execution phase in the footer script payload.

### Why
Enables persistent customization of automation behavior (multi-model defaults, phase-change UI) without relying solely on CLI flags, and supports more permissive execution workflows.

### Key changes
- `src/components/footer.ts`: adds `phase` field to the script payload using `getCurrentPhase()`.
- `src/extensions/orchestration/prompt-enrichment.ts`: introduces `readHarnessSetting()` to read from `~/.config/kimchi/harness/settings.json`; `readMultiModelArgv()` now falls back to the `multiModel` setting instead of hard-coding `true`.
- `src/extensions/tags.ts`: adds `readHidePhaseChanges()` backed by the same harness settings; `renderResult()` returns empty text when `hidePhaseChanges` is enabled, suppressing phase-change UI.
- `src/extensions/permissions/config.ts`: extends `modeSchema` to accept `"yolo"` as a valid `defaultMode`.
- `src/extensions/permissions/config.test.ts`: adds round-trip test for `yolo` default mode.

### Impact
- Users can create `~/.config/kimchi/harness/settings.json` to persistently configure:
  - `multiModel`: boolean fallback when no CLI flag is passed.
  - `hidePhaseChanges`: boolean to suppress phase-change annotations in the UI.
- All changes are additive; existing behavior is preserved when the settings file is absent.