### PR TITLE
Revert "Fix: Intel Mac binaries built with wrong architecture (arm64 instead of x86_64)fix build process for intels"

### DIFF
--- a/.github/workflows/canary.yml
+++ b/.github/workflows/canary.yml
@@ -88,19 +88,19 @@ jobs:
     strategy:
       matrix:
         include:
-          - target: darwin-x64
+          - target: bun-darwin-x64
             os: darwin
             arch: amd64
             runner: macos-15
-          - target: darwin-arm64
+          - target: bun-darwin-arm64
             os: darwin
             arch: arm64
             runner: macos-15
-          - target: linux-x64
+          - target: bun-linux-x64
             os: linux
             arch: amd64
             runner: ubuntu-latest
-          - target: linux-arm64
+          - target: bun-linux-arm64
             os: linux
             arch: arm64
             runner: ubuntu-24.04-arm
@@ -118,7 +118,7 @@ jobs:
         run: node scripts/set-version.js "${{ needs.preflight.outputs.version }}"
 
       - name: Build binary
-        run: pnpm run build:binary -- --target=${{ matrix.target }}
+        run: pnpm run build:binary
 
       - name: Package binary
         run: tar -czf kimchi-code-canary_${{ matrix.os }}_${{ matrix.arch }}.tar.gz -C dist bin share

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -34,19 +34,19 @@ jobs:
     strategy:
       matrix:
         include:
-          - target: darwin-x64
+          - target: bun-darwin-x64
             os: darwin
             arch: amd64
             runner: macos-15
-          - target: darwin-arm64
+          - target: bun-darwin-arm64
             os: darwin
             arch: arm64
             runner: macos-15
-          - target: linux-x64
+          - target: bun-linux-x64
             os: linux
             arch: amd64
             runner: ubuntu-latest
-          - target: linux-arm64
+          - target: bun-linux-arm64
             os: linux
             arch: arm64
             runner: ubuntu-24.04-arm
@@ -63,7 +63,7 @@ jobs:
         run: node scripts/set-version.js "$GITHUB_REF_NAME"
 
       - name: Build binary
-        run: pnpm run build:binary -- --target=${{ matrix.target }}
+        run: pnpm run build:binary
 
       - name: Package binary
         run: tar -czf kimchi_${{ matrix.os }}_${{ matrix.arch }}.tar.gz -C dist bin share

--- a/scripts/build-binary.js
+++ b/scripts/build-binary.js
@@ -2,18 +2,14 @@
 // Steps: clean → typecheck → compile → fix macOS codesign → copy binary resources.
 //
 // Usage:
-//   node scripts/build-binary.js                            # native build for current platform
-//   node scripts/build-binary.js --target darwin-x64        # cross-compile for macOS Intel
-//   node scripts/build-binary.js --target darwin-arm64      # cross-compile for macOS Apple Silicon
-//   node scripts/build-binary.js --target linux-arm64       # cross-compile for Linux ARM64
-//   node scripts/build-binary.js --target linux-x64         # cross-compile for Linux x86-64
+//   node scripts/build-binary.js                        # build for the host platform
+//   node scripts/build-binary.js --target linux-arm64   # cross-compile for Linux ARM64 (Apple Silicon Docker)
+//   node scripts/build-binary.js --target linux-x64     # cross-compile for Linux x86-64
 
 import { execSync } from "node:child_process"
 import { platform } from "node:os"
 
 const TARGET_MAP = {
-	"darwin-arm64": "bun-darwin-arm64",
-	"darwin-x64": "bun-darwin-x64",
 	"linux-arm64": "bun-linux-arm64",
 	"linux-x64": "bun-linux-x64",
 }
@@ -23,6 +19,7 @@ const targetArg =
 	(process.argv.includes("--target") ? process.argv[process.argv.indexOf("--target") + 1] : undefined)
 
 const crossTarget = targetArg ? (TARGET_MAP[targetArg] ?? targetArg) : undefined
+const isCrossCompile = !!crossTarget
 
 function run(label, cmd) {
 	console.log(`\n→ ${label}`)
@@ -47,8 +44,7 @@ run(
 // Bun --compile produces binaries with an invalid code signature on macOS.
 // The kernel kills badly-signed arm64 binaries immediately (SIGKILL, exit 137).
 // Strip the corrupt signature and re-sign ad-hoc. See: https://github.com/oven-sh/bun/issues/7208
-const isDarwinTarget = crossTarget ? crossTarget.includes("darwin") : platform() === "darwin"
-if (isDarwinTarget && platform() === "darwin") {
+if (!isCrossCompile && platform() === "darwin") {
 	run("codesign (strip)", "codesign --remove-signature dist/bin/kimchi")
 	run("codesign (ad-hoc)", "codesign -s - dist/bin/kimchi")
 }


### PR DESCRIPTION
Reverts castai/kimchi-dev#176

---
### Kimchi Summary
### What changed
Reverts CI changes that introduced incorrect cross-compilation settings for macOS. Restores native compilation for all platforms by removing the `--target` argument from GitHub Actions build steps. Updates matrix target labels to Bun's `bun-<os>-<arch>` format and restricts macOS code signing to native builds only.

### Why
The previous build configuration broke macOS binary generation by passing Darwin cross-compilation targets on macOS runners, which produced invalid code signatures and failed execution.

### Key changes
- `.github/workflows/canary.yml` and `.github/workflows/release.yml`:
  - Renamed matrix `target` values from `darwin-x64`, `darwin-arm64`, `linux-x64`, `linux-arm64` to their `bun-*` equivalents
  - Removed `-- --target=${{ matrix.target }}` from the `pnpm run build:binary` step so CI runners compile natively
- `scripts/build-binary.js`:
  - Removed `darwin-arm64` and `darwin-x64` entries from `TARGET_MAP`
  - Introduced `isCrossCompile` flag and updated the macOS `codesign` logic to run only during native macOS builds (`!isCrossCompile && platform() === "darwin"`)
  - Updated CLI usage comments to reflect that cross-compilation is only supported for `linux-arm64` and `linux-x64`

### Impact
macOS binaries must now be built natively on `macos-15` runners. Local or Docker cross-compilation remains supported for Linux (`linux-x64`, `linux-arm64`) targets only.