### PR TITLE
LLM-1292: Add data source and sorting to the /stats results

### DIFF
--- a/src/extensions/stats/display.ts
+++ b/src/extensions/stats/display.ts
@@ -221,8 +221,12 @@ export function formatHelp(theme: Theme): string[] {
 		theme.bold("Stats Command Usage"),
 		"",
 		"  /stats                    Show analytics and productivity metrics (last 30 days)",
-		"  /stats 7                  Show metrics for last 7 days (1-30 days supported)",
+		"  /stats 7                  Show metrics for last 7 days",
+		"  /stats tokens             Sort by tokens",
+		"  /stats 7 model            Sort by model name (7 days)",
 		"  /stats help               Show this help message",
+		"",
+		"  Sort: cost (default), tokens, model, source",
 		"",
 	]
 }

--- a/src/extensions/stats/index.ts
+++ b/src/extensions/stats/index.ts
@@ -12,7 +12,7 @@ import { loadConfig } from "../../config.js"
 import { exitSplashMode } from "../ui.js"
 import { CastAiStatsApi, getTimeRange } from "./api.js"
 import { formatError, formatHelp } from "./display.js"
-import { formatAnalyticsVisual, formatProductivityVisual } from "./visual.js"
+import { type SortBy, formatAnalyticsVisual, formatProductivityVisual } from "./visual.js"
 
 function createApiClient(): CastAiStatsApi {
 	const apiKey = loadConfig().apiKey || process.env.CASTAI_API_KEY
@@ -20,6 +20,32 @@ function createApiClient(): CastAiStatsApi {
 		throw new Error("No API key found. Please run `kimchi login` to set up your API key.")
 	}
 	return new CastAiStatsApi({ apiKey })
+}
+
+/**
+ * Parse /stats command arguments into days and sortBy values.
+ * Exported for unit testing.
+ */
+export function parseStatsArgs(args: string): { days: number; sortBy: SortBy } {
+	const trimmed = args.trim().toLowerCase()
+	let days = 30
+	let sortBy: SortBy = "cost"
+
+	if (trimmed) {
+		const parts = trimmed.split(/\s+/)
+		const sortValues: SortBy[] = ["cost", "tokens", "model", "source"]
+
+		for (const part of parts) {
+			const parsedDays = Number.parseInt(part, 10)
+			if (!Number.isNaN(parsedDays) && parsedDays > 0 && parsedDays <= 365) {
+				days = parsedDays
+			} else if (sortValues.includes(part as SortBy)) {
+				sortBy = part as SortBy
+			}
+		}
+	}
+
+	return { days, sortBy }
 }
 
 async function handleStatsCommand(args: string, ctx: ExtensionCommandContext): Promise<void> {
@@ -39,14 +65,8 @@ async function handleStatsCommand(args: string, ctx: ExtensionCommandContext): P
 		return
 	}
 
-	// Parse number of days (e.g., "/stats 7" for last 7 days)
-	let days = 30 // default
-	if (trimmed) {
-		const parsedDays = Number.parseInt(trimmed, 10)
-		if (!Number.isNaN(parsedDays) && parsedDays > 0 && parsedDays <= 365) {
-			days = parsedDays
-		}
-	}
+	// Parse arguments
+	const { days, sortBy } = parseStatsArgs(args)
 
 	const api = createApiClient()
 	const { startTime, endTime } = getTimeRange(days)
@@ -68,7 +88,7 @@ async function handleStatsCommand(args: string, ctx: ExtensionCommandContext): P
 			if (!hasTokenData && !hasCostData && !hasApiCalls) {
 				outputLines.push("", ctx.ui.theme.fg("dim", "No analytics data found for the selected period."), "")
 			} else {
-				const analyticsLines = formatAnalyticsVisual(analytics, ctx.ui.theme, terminalWidth, days)
+				const analyticsLines = formatAnalyticsVisual(analytics, ctx.ui.theme, terminalWidth, days, sortBy)
 				outputLines.push(...analyticsLines)
 			}
 		} catch (err) {

--- a/src/extensions/stats/stats.test.ts
+++ b/src/extensions/stats/stats.test.ts
@@ -1,7 +1,8 @@
 import { describe, expect, it } from "vitest"
 import { formatCount } from "../format.js"
 import { getTimeRange } from "./api.js"
-import { formatCurrency, getProviderDisplayName } from "./visual.js"
+import { parseStatsArgs } from "./index.js"
+import { type SortBy, formatCurrency, getProviderDisplayName, getSourceName, sortFn } from "./visual.js"
 
 describe("getTimeRange", () => {
 	it("returns correct time range for 30 days", () => {
@@ -60,8 +61,8 @@ describe("formatCurrency", () => {
 })
 
 describe("getProviderDisplayName", () => {
-	it("maps claude-code-otel to Claude Code", () => {
-		expect(getProviderDisplayName("claude-code-otel")).toBe("Claude Code")
+	it("maps cloud-code-otel to Claude Code", () => {
+		expect(getProviderDisplayName("cloud-code-otel")).toBe("Claude Code")
 	})
 
 	it("maps opencode-otel to OpenCode", () => {
@@ -78,5 +79,167 @@ describe("getProviderDisplayName", () => {
 
 	it("handles empty string", () => {
 		expect(getProviderDisplayName("")).toBe("")
+	})
+})
+
+describe("getSourceName", () => {
+	it("maps cloud-code-otel to Claude Code", () => {
+		expect(getSourceName("cloud-code-otel")).toBe("Claude Code")
+	})
+
+	it("maps opencode-otel to OpenCode", () => {
+		expect(getSourceName("opencode-otel")).toBe("OpenCode")
+	})
+
+	it("maps pi-otel to Kimchi", () => {
+		expect(getSourceName("pi-otel")).toBe("Kimchi")
+	})
+
+	it("maps unknown providers to Proxy", () => {
+		expect(getSourceName("unknown-provider")).toBe("Proxy")
+	})
+
+	it("maps empty string to Proxy", () => {
+		expect(getSourceName("")).toBe("Proxy")
+	})
+})
+
+describe("parseStatsArgs", () => {
+	it("returns defaults for empty string", () => {
+		const result = parseStatsArgs("")
+		expect(result.days).toBe(30)
+		expect(result.sortBy).toBe("cost")
+	})
+
+	it("parses days only", () => {
+		const result = parseStatsArgs("7")
+		expect(result.days).toBe(7)
+		expect(result.sortBy).toBe("cost")
+	})
+
+	it("parses sortBy only", () => {
+		const result = parseStatsArgs("tokens")
+		expect(result.days).toBe(30)
+		expect(result.sortBy).toBe("tokens")
+	})
+
+	it("parses days and sortBy combined", () => {
+		const result = parseStatsArgs("7 model")
+		expect(result.days).toBe(7)
+		expect(result.sortBy).toBe("model")
+	})
+
+	it("handles reversed order", () => {
+		const result = parseStatsArgs("tokens 7")
+		expect(result.days).toBe(7)
+		expect(result.sortBy).toBe("tokens")
+	})
+
+	it("ignores invalid tokens", () => {
+		const result = parseStatsArgs("7 foo model")
+		expect(result.days).toBe(7)
+		expect(result.sortBy).toBe("model")
+	})
+
+	it("ignores day 0", () => {
+		const result = parseStatsArgs("0")
+		expect(result.days).toBe(30)
+	})
+
+	it("ignores day over 365", () => {
+		const result = parseStatsArgs("366")
+		expect(result.days).toBe(30)
+	})
+
+	it("handles all sort values", () => {
+		const sortValues: SortBy[] = ["cost", "tokens", "model", "source"]
+		for (const sortBy of sortValues) {
+			const result = parseStatsArgs(sortBy)
+			expect(result.sortBy).toBe(sortBy)
+		}
+	})
+})
+
+describe("sortFn", () => {
+	const fixtures = [
+		{ modelName: "gpt-4", source: "Proxy", cost: 10, inputTokens: 1000, outputTokens: 500 },
+		{ modelName: "claude-3", source: "Claude Code", cost: 5, inputTokens: 2000, outputTokens: 1000 },
+		{ modelName: "gpt-4", source: "Kimchi", cost: 8, inputTokens: 800, outputTokens: 400 },
+	]
+
+	describe("sort by cost", () => {
+		it("sorts by cost descending", () => {
+			const sorted = [...fixtures].sort((a, b) => sortFn(a, b, "cost"))
+			expect(sorted[0].modelName).toBe("gpt-4")
+			expect(sorted[0].source).toBe("Proxy")
+			expect(sorted[1].cost).toBe(8)
+			expect(sorted[2].cost).toBe(5)
+		})
+
+		it("uses modelName then source as tiebreaker", () => {
+			const tied = [
+				{ modelName: "gpt-4", source: "Proxy", cost: 10, inputTokens: 100, outputTokens: 100 },
+				{ modelName: "gpt-4", source: "Kimchi", cost: 10, inputTokens: 200, outputTokens: 200 },
+				{ modelName: "claude-3", source: "Proxy", cost: 10, inputTokens: 300, outputTokens: 300 },
+			]
+			const sorted = [...tied].sort((a, b) => sortFn(a, b, "cost"))
+			expect(sorted[0].modelName).toBe("claude-3")
+			expect(sorted[1].modelName).toBe("gpt-4")
+			expect(sorted[1].source).toBe("Kimchi")
+			expect(sorted[2].source).toBe("Proxy")
+		})
+	})
+
+	describe("sort by tokens", () => {
+		it("sorts by total tokens descending", () => {
+			const sorted = [...fixtures].sort((a, b) => sortFn(a, b, "tokens"))
+			expect(sorted[0].modelName).toBe("claude-3")
+			expect(sorted[0].inputTokens + sorted[0].outputTokens).toBe(3000)
+		})
+
+		it("uses modelName then source as tiebreaker", () => {
+			const tied = [
+				{ modelName: "gpt-4", source: "Proxy", cost: 1, inputTokens: 1000, outputTokens: 1000 },
+				{ modelName: "gpt-4", source: "Kimchi", cost: 2, inputTokens: 1000, outputTokens: 1000 },
+			]
+			const sorted = [...tied].sort((a, b) => sortFn(a, b, "tokens"))
+			expect(sorted[0].source).toBe("Kimchi")
+			expect(sorted[1].source).toBe("Proxy")
+		})
+	})
+
+	describe("sort by model", () => {
+		it("sorts by modelName ascending", () => {
+			const sorted = [...fixtures].sort((a, b) => sortFn(a, b, "model"))
+			expect(sorted[0].modelName).toBe("claude-3")
+			expect(sorted[1].modelName).toBe("gpt-4")
+			expect(sorted[2].modelName).toBe("gpt-4")
+		})
+
+		it("uses source as tiebreaker for same model", () => {
+			const sorted = [...fixtures].sort((a, b) => sortFn(a, b, "model"))
+			const gpt4Entries = sorted.filter((x) => x.modelName === "gpt-4")
+			expect(gpt4Entries[0].source).toBe("Kimchi")
+			expect(gpt4Entries[1].source).toBe("Proxy")
+		})
+	})
+
+	describe("sort by source", () => {
+		it("sorts by source ascending", () => {
+			const sorted = [...fixtures].sort((a, b) => sortFn(a, b, "source"))
+			expect(sorted[0].source).toBe("Claude Code")
+			expect(sorted[1].source).toBe("Kimchi")
+			expect(sorted[2].source).toBe("Proxy")
+		})
+
+		it("uses modelName as tiebreaker for same source", () => {
+			const withSameSource = [
+				{ modelName: "gpt-4", source: "Proxy", cost: 10, inputTokens: 100, outputTokens: 100 },
+				{ modelName: "claude-3", source: "Proxy", cost: 5, inputTokens: 200, outputTokens: 200 },
+			]
+			const sorted = [...withSameSource].sort((a, b) => sortFn(a, b, "source"))
+			expect(sorted[0].modelName).toBe("claude-3")
+			expect(sorted[1].modelName).toBe("gpt-4")
+		})
 	})
 })

--- a/src/extensions/stats/visual.ts
+++ b/src/extensions/stats/visual.ts
@@ -32,11 +32,57 @@ export function formatDurationCompact(seconds: number): string {
  */
 export function getProviderDisplayName(providerName: string): string {
 	const mapping: Record<string, string> = {
-		"claude-code-otel": "Claude Code",
+		"cloud-code-otel": "Claude Code",
 		"opencode-otel": "OpenCode",
 		"pi-otel": "Kimchi",
 	}
 	return mapping[providerName] || providerName
+}
+
+/**
+ * Maps provider name to source category for analytics table.
+ * Unknown providers are classified as "Proxy".
+ */
+export function getSourceName(providerName: string): string {
+	if (!providerName) return "Proxy"
+	const mapping: Record<string, string> = {
+		"cloud-code-otel": "Claude Code",
+		"opencode-otel": "OpenCode",
+		"pi-otel": "Kimchi",
+	}
+	return mapping[providerName] || "Proxy"
+}
+
+export type SortBy = "cost" | "tokens" | "model" | "source"
+
+type SortStats = {
+	modelName: string
+	source: string
+	cost: number
+	inputTokens: number
+	outputTokens: number
+}
+
+/**
+ * Sort function for model stats with configurable sort criteria.
+ * Exported for unit testing.
+ */
+export function sortFn(a: SortStats, b: SortStats, sortBy: SortBy): number {
+	switch (sortBy) {
+		case "tokens": {
+			const aTokens = a.inputTokens + a.outputTokens
+			const bTokens = b.inputTokens + b.outputTokens
+			return bTokens - aTokens || a.modelName.localeCompare(b.modelName) || a.source.localeCompare(b.source)
+		}
+		case "model":
+			return a.modelName.localeCompare(b.modelName) || a.source.localeCompare(b.source)
+		case "source":
+			return a.source.localeCompare(b.source) || a.modelName.localeCompare(b.modelName)
+		default: {
+			// cost
+			return b.cost - a.cost || a.modelName.localeCompare(b.modelName) || a.source.localeCompare(b.source)
+		}
+	}
 }
 
 export function formatAnalyticsVisual(
@@ -44,6 +90,7 @@ export function formatAnalyticsVisual(
 	theme: Theme,
 	termWidth = 100,
 	days = 30,
+	sortBy: SortBy = "cost",
 ): string[] {
 	const lines: string[] = []
 
@@ -52,10 +99,18 @@ export function formatAnalyticsVisual(
 	lines.push(theme.fg("dim", `  Last ${days} Days`))
 	lines.push("")
 
-	// Collect model stats
+	// Collect model+source stats
 	const modelStats = new Map<
 		string,
-		{ cost: number; inputTokens: number; outputTokens: number; inputCost: number; outputCost: number }
+		{
+			modelName: string
+			source: string
+			cost: number
+			inputTokens: number
+			outputTokens: number
+			inputCost: number
+			outputCost: number
+		}
 	>()
 
 	if (data.cost?.items) {
@@ -64,7 +119,11 @@ export function formatAnalyticsVisual(
 				for (const model of item.models) {
 					const cost = Number.parseFloat(model.totalCost || "0")
 					if (cost > 0) {
-						const existing = modelStats.get(model.model) || {
+						const source = getSourceName(model.providerName)
+						const key = `${model.model}\t${source}`
+						const existing = modelStats.get(key) || {
+							modelName: model.model,
+							source,
 							cost: 0,
 							inputTokens: 0,
 							outputTokens: 0,
@@ -74,7 +133,7 @@ export function formatAnalyticsVisual(
 						existing.cost += cost
 						existing.inputCost += Number.parseFloat(model.inputTokenCost || "0")
 						existing.outputCost += Number.parseFloat(model.outputTokenCost || "0")
-						modelStats.set(model.model, existing)
+						modelStats.set(key, existing)
 					}
 				}
 			}
@@ -85,7 +144,11 @@ export function formatAnalyticsVisual(
 		for (const item of data.inputTokens.items) {
 			if (item.models) {
 				for (const model of item.models) {
-					const stats = modelStats.get(model.model) || {
+					const source = getSourceName(model.providerName)
+					const key = `${model.model}\t${source}`
+					const stats = modelStats.get(key) || {
+						modelName: model.model,
+						source,
 						cost: 0,
 						inputTokens: 0,
 						outputTokens: 0,
@@ -93,7 +156,7 @@ export function formatAnalyticsVisual(
 						outputCost: 0,
 					}
 					stats.inputTokens += model.totalCount || 0
-					modelStats.set(model.model, stats)
+					modelStats.set(key, stats)
 				}
 			}
 		}
@@ -103,7 +166,11 @@ export function formatAnalyticsVisual(
 		for (const item of data.outputTokens.items) {
 			if (item.models) {
 				for (const model of item.models) {
-					const stats = modelStats.get(model.model) || {
+					const source = getSourceName(model.providerName)
+					const key = `${model.model}\t${source}`
+					const stats = modelStats.get(key) || {
+						modelName: model.model,
+						source,
 						cost: 0,
 						inputTokens: 0,
 						outputTokens: 0,
@@ -111,7 +178,7 @@ export function formatAnalyticsVisual(
 						outputCost: 0,
 					}
 					stats.outputTokens += model.totalCount || 0
-					modelStats.set(model.model, stats)
+					modelStats.set(key, stats)
 				}
 			}
 		}
@@ -120,14 +187,15 @@ export function formatAnalyticsVisual(
 	if (modelStats.size > 0) {
 		// Fixed column widths for compact display
 		const modelCol = 20
-		const tokensCol = 12
-		const ioCol = 18
-		const costCol = 12
-		const costIoCol = 18
-		const lineWidth = modelCol + tokensCol + ioCol + costCol + costIoCol + 4
+		const sourceCol = 12
+		const tokensCol = 10
+		const ioCol = 16
+		const costCol = 10
+		const costIoCol = 16
+		const lineWidth = modelCol + sourceCol + tokensCol + ioCol + costCol + costIoCol + 5
 
 		lines.push(
-			`  ${"Model".padEnd(modelCol)} ${"Tokens".padStart(tokensCol)} ${"(I / O)".padStart(ioCol)} ${"Cost".padStart(costCol)} ${"(I / O)".padStart(costIoCol)}`,
+			`  ${"Model".padEnd(modelCol)} ${theme.fg("dim", "Source".padStart(sourceCol))} ${theme.fg("dim", "Tokens".padStart(tokensCol))} ${theme.fg("dim", "(I / O)".padStart(ioCol))} ${theme.fg("dim", "Cost".padStart(costCol))} ${theme.fg("dim", "(I / O)".padStart(costIoCol))}`,
 		)
 		lines.push(`  ${theme.fg("dim", "─".repeat(lineWidth))}`)
 
@@ -137,15 +205,17 @@ export function formatAnalyticsVisual(
 		let totalInputCost = 0
 		let totalOutputCost = 0
 
-		const sortedModels = Array.from(modelStats.entries()).sort((a, b) => b[1].cost - a[1].cost)
-		for (const [model, stats] of sortedModels.slice(0, 6)) {
-			const label = model.length > 15 ? `${model.slice(0, 12)}...` : model
+		const sortedModels = Array.from(modelStats.values()).sort((a, b) => sortFn(a, b, sortBy))
+		for (const stats of sortedModels) {
+			const label = stats.modelName.length > 15 ? `${stats.modelName.slice(0, 12)}...` : stats.modelName
 			const totalTokens = stats.inputTokens + stats.outputTokens
 			const tokenStr = formatCount(totalTokens).padStart(tokensCol)
 			const ioStr = `${formatCount(stats.inputTokens)} / ${formatCount(stats.outputTokens)}`.padStart(ioCol)
 			const costStr = formatCurrency(stats.cost).padStart(costCol)
 			const costIoStr = `${formatCurrency(stats.inputCost)} / ${formatCurrency(stats.outputCost)}`.padStart(costIoCol)
-			lines.push(`  ${theme.fg("accent", label.padEnd(modelCol))} ${tokenStr} ${ioStr} ${costStr} ${costIoStr}`)
+			lines.push(
+				`  ${theme.fg("accent", label.padEnd(modelCol))} ${theme.fg("accent", stats.source.padStart(sourceCol))} ${tokenStr} ${ioStr} ${costStr} ${costIoStr}`,
+			)
 
 			totalInputTokens += stats.inputTokens
 			totalOutputTokens += stats.outputTokens
@@ -159,7 +229,9 @@ export function formatAnalyticsVisual(
 		const totalIoStr = `${formatCount(totalInputTokens)} / ${formatCount(totalOutputTokens)}`.padStart(ioCol)
 		const totalCostStr = formatCurrency(totalModelCost).padStart(costCol)
 		const totalCostIoStr = `${formatCurrency(totalInputCost)} / ${formatCurrency(totalOutputCost)}`.padStart(costIoCol)
-		lines.push(`  ${"Total".padEnd(modelCol)} ${totalTokensStr} ${totalIoStr} ${totalCostStr} ${totalCostIoStr}`)
+		lines.push(
+			`  ${theme.fg("dim", "Total".padEnd(modelCol))} ${"".padStart(sourceCol)} ${totalTokensStr} ${totalIoStr} ${totalCostStr} ${totalCostIoStr}`,
+		)
 	}
 
 	return lines


### PR DESCRIPTION
<img width="650" height="230" alt="Screenshot 2026-05-08 at 16 28 56" src="https://github.com/user-attachments/assets/9b435784-83ce-45f6-8e4e-7e96e0517422" />
<img width="696" height="709" alt="Screenshot 2026-05-08 at 16 29 18" src="https://github.com/user-attachments/assets/b25cb257-3ff0-4733-970c-e8aa993d4724" />
<img width="706" height="744" alt="Screenshot 2026-05-08 at 16 30 18" src="https://github.com/user-attachments/assets/e3c428d8-b0b7-4bc0-a8b1-6e1ecc00d675" />

---
### Kimchi Summary
### What changed
Adds configurable sorting and source-level breakdown to the `/stats` command. Users can now sort analytics by `cost`, `tokens`, `model`, or `source`, and view usage broken down by both model and client source. The accepted day range has been expanded from 1–30 to 1–365 days.

### Why
Provides more flexibility when inspecting usage analytics, making it easier to analyze token consumption, model distribution, and traffic origin without being restricted to a hardcoded top-6 cost view.

### Key changes
- `src/extensions/stats/index.ts`: Introduced `parseStatsArgs()` to parse `days` (1–365) and `sortBy` from command arguments in any order. Exported for unit testing.
- `src/extensions/stats/visual.ts`:
  - Added `SortBy` type and `sortFn()` for sorting by cost, total tokens, model name, or source.
  - Updated `formatAnalyticsVisual()` to aggregate stats by model **and** source using the new `getSourceName()` helper, added a **Source** column, and removed the previous 6-row display limit.
  - Fixed provider mapping key from `"claude-code-otel"` to `"cloud-code-otel"`.
- `src/extensions/stats/display.ts`: Updated help output to document new sort options and usage patterns.
- `src/extensions/stats/stats.test.ts`: Added comprehensive tests for `parseStatsArgs`, `sortFn`, and `getSourceName`.

### Impact
- The analytics table now displays **all** model/source rows instead of only the top 6 by cost.
- Existing `/stats <days>` patterns remain supported; new sort keywords can be appended in any order (e.g., `/stats 7 tokens`).