### PR TITLE
LLM-1575: Fix auto-enter when pasting large text

### DIFF
--- a/src/paste-interceptor.test.ts
+++ b/src/paste-interceptor.test.ts
@@ -1,6 +1,6 @@
 import { EventEmitter } from "node:events"
 import { describe, expect, it } from "vitest"
-import { installPasteInterceptor, looksLikeRawPaste, wrapAsBracketedPaste } from "./paste-interceptor.js"
+import { installPasteInterceptor, looksLikeRawPaste, rewriteCRToLF } from "./paste-interceptor.js"
 
 const ESC = String.fromCharCode(0x1b)
 
@@ -33,15 +33,18 @@ describe("looksLikeRawPaste", () => {
 	})
 })
 
-describe("wrapAsBracketedPaste", () => {
-	it("wraps with ESC[200~ … ESC[201~ and normalizes \\r to \\n", () => {
-		const out = wrapAsBracketedPaste("one\rtwo\rthree")
-		expect(out).toBe(`${ESC}[200~one\ntwo\nthree${ESC}[201~`)
+describe("rewriteCRToLF", () => {
+	it("rewrites bare \\r to \\n", () => {
+		expect(rewriteCRToLF("one\rtwo\rthree")).toBe("one\ntwo\nthree")
 	})
 
-	it("normalizes \\r\\n as well as bare \\r", () => {
-		const out = wrapAsBracketedPaste("a\r\nb\rc")
-		expect(out).toBe(`${ESC}[200~a\nb\nc${ESC}[201~`)
+	it("rewrites \\r\\n to \\n (does not double-emit)", () => {
+		expect(rewriteCRToLF("a\r\nb\rc")).toBe("a\nb\nc")
+	})
+
+	it("leaves chunks without \\r unchanged", () => {
+		expect(rewriteCRToLF("hello")).toBe("hello")
+		expect(rewriteCRToLF("a\nb")).toBe("a\nb")
 	})
 })
 
@@ -51,7 +54,17 @@ describe("installPasteInterceptor", () => {
 		return new EventEmitter()
 	}
 
-	it("wraps raw-paste-burst chunks in bracketed-paste markers before listeners see them", () => {
+	function makeClock(start = 1_000_000): { now: () => number; advance: (ms: number) => void } {
+		let t = start
+		return {
+			now: () => t,
+			advance: (ms) => {
+				t += ms
+			},
+		}
+	}
+
+	it("rewrites \\r to \\n in raw-paste-burst chunks before listeners see them", () => {
 		const stdin = makeFakeStdin()
 		installPasteInterceptor(stdin as unknown as NodeJS.ReadStream)
 		const received: string[] = []
@@ -59,11 +72,59 @@ describe("installPasteInterceptor", () => {
 
 		stdin.emit("data", "one\rtwo\rthree")
 
-		expect(received).toHaveLength(1)
-		expect(received[0]).toBe(`${ESC}[200~one\ntwo\nthree${ESC}[201~`)
+		expect(received).toEqual(["one\ntwo\nthree"])
 	})
 
-	it("passes through chunks that don't look like a paste", () => {
+	it("rewrites a trailing fragment that arrives within the 5 ms window", () => {
+		const stdin = makeFakeStdin()
+		const clock = makeClock()
+		installPasteInterceptor(stdin as unknown as NodeJS.ReadStream, clock.now)
+		const received: string[] = []
+		stdin.on("data", (chunk) => received.push(chunk.toString()))
+
+		// Seeding paste burst.
+		stdin.emit("data", "A\rB\rC\rD\r")
+		// 1 ms later: the kernel-scheduled tail of the same paste — too small to seed on its own (1 \r), but it must still be rewritten.
+		clock.advance(1)
+		stdin.emit("data", "\rZ")
+
+		// Without the trailing-window rule, the bare \r in the second chunk would reach the Editor as Enter and submit the buffer mid-paste.
+		expect(received).toEqual(["A\nB\nC\nD\n", "\nZ"])
+	})
+
+	it("extends the trailing window for each subsequent fragment", () => {
+		const stdin = makeFakeStdin()
+		const clock = makeClock()
+		installPasteInterceptor(stdin as unknown as NodeJS.ReadStream, clock.now)
+		const received: string[] = []
+		stdin.on("data", (chunk) => received.push(chunk.toString()))
+
+		stdin.emit("data", "A\rB\rC\r")
+		clock.advance(3)
+		stdin.emit("data", "D\rE")
+		// 3 ms after the last fragment — still within the rolling 5 ms window.
+		clock.advance(3)
+		stdin.emit("data", "\rF")
+
+		expect(received).toEqual(["A\nB\nC\n", "D\nE", "\nF"])
+	})
+
+	it("does NOT rewrite a \\r that arrives after the trailing window has lapsed", () => {
+		const stdin = makeFakeStdin()
+		const clock = makeClock()
+		installPasteInterceptor(stdin as unknown as NodeJS.ReadStream, clock.now)
+		const received: string[] = []
+		stdin.on("data", (chunk) => received.push(chunk.toString()))
+
+		stdin.emit("data", "A\rB\rC\r")
+		// 30 ms gap — well past the 5 ms window. A \r arriving now is a typed Enter, not paste.
+		clock.advance(30)
+		stdin.emit("data", "\r")
+
+		expect(received).toEqual(["A\nB\nC\n", "\r"])
+	})
+
+	it("passes through chunks that don't look like a paste and have no active window", () => {
 		const stdin = makeFakeStdin()
 		installPasteInterceptor(stdin as unknown as NodeJS.ReadStream)
 		const received: string[] = []
@@ -71,9 +132,24 @@ describe("installPasteInterceptor", () => {
 
 		stdin.emit("data", "\r")
 		stdin.emit("data", "hello")
-		stdin.emit("data", `${ESC}[A`) // arrow key — should not be swallowed
+		stdin.emit("data", `${ESC}[A`) // arrow key — must not be rewritten
 
 		expect(received).toEqual(["\r", "hello", `${ESC}[A`])
+	})
+
+	it("never rewrites chunks that contain ESC, even inside the trailing window", () => {
+		const stdin = makeFakeStdin()
+		const clock = makeClock()
+		installPasteInterceptor(stdin as unknown as NodeJS.ReadStream, clock.now)
+		const received: string[] = []
+		stdin.on("data", (chunk) => received.push(chunk.toString()))
+
+		stdin.emit("data", "A\rB\rC\r")
+		clock.advance(1)
+		// An arrow key arriving immediately after a paste — must reach the Editor unmodified or cursor movement breaks.
+		stdin.emit("data", `${ESC}[A`)
+
+		expect(received).toEqual(["A\nB\nC\n", `${ESC}[A`])
 	})
 
 	it("passes non-data events through unchanged", () => {
@@ -94,11 +170,10 @@ describe("installPasteInterceptor", () => {
 		installPasteInterceptor(stdin as unknown as NodeJS.ReadStream)
 		expect(stdin.emit).toBe(emitAfterFirst)
 
-		// Sanity: a paste chunk still produces exactly one wrapped data event, not two.
+		// Sanity: a paste chunk still produces exactly one rewritten data event, not two.
 		const received: string[] = []
 		stdin.on("data", (chunk) => received.push(chunk.toString()))
 		stdin.emit("data", "one\rtwo\rthree")
-		expect(received).toHaveLength(1)
-		expect(received[0]).toBe(`${ESC}[200~one\ntwo\nthree${ESC}[201~`)
+		expect(received).toEqual(["one\ntwo\nthree"])
 	})
 })

--- a/src/paste-interceptor.test.ts
+++ b/src/paste-interceptor.test.ts
@@ -75,7 +75,7 @@ describe("installPasteInterceptor", () => {
 		expect(received).toEqual(["one\ntwo\nthree"])
 	})
 
-	it("rewrites a trailing fragment that arrives within the 5 ms window", () => {
+	it("rewrites a trailing fragment that arrives within the 100 ms TRAILING_WINDOW_MS", () => {
 		const stdin = makeFakeStdin()
 		const clock = makeClock()
 		installPasteInterceptor(stdin as unknown as NodeJS.ReadStream, clock.now)
@@ -102,7 +102,7 @@ describe("installPasteInterceptor", () => {
 		stdin.emit("data", "A\rB\rC\r")
 		clock.advance(3)
 		stdin.emit("data", "D\rE")
-		// 3 ms after the last fragment — still within the rolling 5 ms window.
+		// 3 ms after the last fragment — still within the rolling 100 ms window.
 		clock.advance(3)
 		stdin.emit("data", "\rF")
 

--- a/src/paste-interceptor.test.ts
+++ b/src/paste-interceptor.test.ts
@@ -117,8 +117,8 @@ describe("installPasteInterceptor", () => {
 		stdin.on("data", (chunk) => received.push(chunk.toString()))
 
 		stdin.emit("data", "A\rB\rC\r")
-		// 30 ms gap — well past the 5 ms window. A \r arriving now is a typed Enter, not paste.
-		clock.advance(30)
+		// 250 ms gap — well past the 100 ms window. A \r arriving now is a typed Enter (perceive-decide-press takes ≥300 ms), not paste.
+		clock.advance(250)
 		stdin.emit("data", "\r")
 
 		expect(received).toEqual(["A\nB\nC\n", "\r"])

--- a/src/paste-interceptor.ts
+++ b/src/paste-interceptor.ts
@@ -1,6 +1,6 @@
 // Heuristic fallback for terminals that don't honor bracketed-paste mode (ESC[?2004h).
 // Without bracketed paste, a pasted multi-line block arrives as raw \r-separated keystrokes — every \r matches the Editor's Enter keybinding and submits the first line as a message. The intent (a single multi-line prompt) is lost.
-// This interceptor watches process.stdin and, when a chunk looks like a paste burst, rewrites \r → \n in place so the Editor treats the bytes as newlines (tui.input.newLine matches \n) instead of submits (tui.input.submit matches \r). A short trailing-fragment window catches chunk-boundary tails (e.g. the trailing "\rZ" that follows a large paste's main chunk by ~1 ms of kernel TTY scheduling).
+// This interceptor watches process.stdin and, when a chunk looks like a paste burst, rewrites \r → \n in place so the Editor treats the bytes as newlines (tui.input.newLine matches \n) instead of submits (tui.input.submit matches \r). A 100 ms trailing-fragment window catches chunk-boundary tails (e.g. the trailing "\rZ" that follows a large paste's main chunk after kernel TTY scheduling, tmux forwarding, or SSH transport latency).
 // Why \r → \n rewriting instead of bracketed-paste wrapping: wrapping interacted poorly with pi-tui's StdinBuffer paste-mode tracking and required a debounce/coalesce buffer that reordered events and could swallow a user's Enter immediately after a paste. Direct rewriting transforms each chunk synchronously, with no cross-layer state, no buffering, and no event reordering. See the LLM-1358 follow-up plan in /Users/michal/.claude/plans/paste-auto-send-fix-v2-cr-to-lf-rewriter.md.
 
 // Use String.fromCharCode — biome strips literal control bytes from string literals.
@@ -9,8 +9,8 @@ const ESC = String.fromCharCode(0x1b)
 const MIN_CHUNK_LEN = 4
 const MIN_CR_COUNT = 2
 
-// How long after a seeding paste-burst we treat additional \r-bearing chunks as paste tails. Kernel TTY reads land in immediate succession (~1 ms); human Enter keypresses are bounded below by reaction time (≥100 ms), so a 5 ms window catches chunk-boundary tails without ever capturing a typed Enter.
-const TRAILING_WINDOW_MS = 5
+// How long after a seeding paste-burst we treat additional \r-bearing chunks as paste tails. The window only opens after a multi-\r seeding chunk, so a typed Enter (single \r, length 1) cannot trigger it on its own. The realistic threats it must cover are inter-chunk gaps under tmux, SSH (including cross-continent latency), and Windows ConPTY — observed up to ~100 ms. The realistic threat it must NOT cover is a user pressing Enter to submit *after* a paste, which requires perceive-decide-press latency of ≥300 ms. 100 ms sits comfortably between the two.
+const TRAILING_WINDOW_MS = 100
 
 // Count \r only, not \n. In raw mode Enter is \r, so human pastes arrive as \r-separated; \n in a stdin chunk means programmatic input, not a paste. Adding \n to the count would treat benign program output as a paste.
 export function looksLikeRawPaste(chunk: string): boolean {

--- a/src/paste-interceptor.ts
+++ b/src/paste-interceptor.ts
@@ -1,16 +1,18 @@
 // Heuristic fallback for terminals that don't honor bracketed-paste mode (ESC[?2004h).
-// Without bracketed paste, a pasted multi-line block arrives as raw keystrokes — every \r matches the Editor's Enter keybinding and submits the first line as a message. The intent (a single multi-line prompt) is lost.
-// This interceptor watches process.stdin and, when a single chunk looks like a burst paste, re-emits it wrapped in ESC[200~...ESC[201~ so pi-tui's existing bracketed-paste pipeline handles it. If the heuristic doesn't fire, behavior is unchanged.
+// Without bracketed paste, a pasted multi-line block arrives as raw \r-separated keystrokes — every \r matches the Editor's Enter keybinding and submits the first line as a message. The intent (a single multi-line prompt) is lost.
+// This interceptor watches process.stdin and, when a chunk looks like a paste burst, rewrites \r → \n in place so the Editor treats the bytes as newlines (tui.input.newLine matches \n) instead of submits (tui.input.submit matches \r). A short trailing-fragment window catches chunk-boundary tails (e.g. the trailing "\rZ" that follows a large paste's main chunk by ~1 ms of kernel TTY scheduling).
+// Why \r → \n rewriting instead of bracketed-paste wrapping: wrapping interacted poorly with pi-tui's StdinBuffer paste-mode tracking and required a debounce/coalesce buffer that reordered events and could swallow a user's Enter immediately after a paste. Direct rewriting transforms each chunk synchronously, with no cross-layer state, no buffering, and no event reordering. See the LLM-1358 follow-up plan in /Users/michal/.claude/plans/paste-auto-send-fix-v2-cr-to-lf-rewriter.md.
 
 // Use String.fromCharCode — biome strips literal control bytes from string literals.
 const ESC = String.fromCharCode(0x1b)
-const BRACKETED_START = `${ESC}[200~`
-const BRACKETED_END = `${ESC}[201~`
 
 const MIN_CHUNK_LEN = 4
 const MIN_CR_COUNT = 2
 
-// Count \r only, not \n. In raw mode Enter is \r, so human pastes arrive as \r-separated; \n in a stdin chunk means programmatic input, not a paste. Adding \n to the count would wrap benign program output in bracketed-paste markers.
+// How long after a seeding paste-burst we treat additional \r-bearing chunks as paste tails. Kernel TTY reads land in immediate succession (~1 ms); human Enter keypresses are bounded below by reaction time (≥100 ms), so a 5 ms window catches chunk-boundary tails without ever capturing a typed Enter.
+const TRAILING_WINDOW_MS = 5
+
+// Count \r only, not \n. In raw mode Enter is \r, so human pastes arrive as \r-separated; \n in a stdin chunk means programmatic input, not a paste. Adding \n to the count would treat benign program output as a paste.
 export function looksLikeRawPaste(chunk: string): boolean {
 	if (chunk.length < MIN_CHUNK_LEN) return false
 	// Conservative guard: if the chunk contains any escape byte, leave it alone. A real paste is plain text; an ESC here likely means the chunk also carries a key sequence we shouldn't corrupt.
@@ -22,21 +24,34 @@ export function looksLikeRawPaste(chunk: string): boolean {
 	return false
 }
 
-export function wrapAsBracketedPaste(chunk: string): string {
-	return BRACKETED_START + chunk.replace(/\r\n?/g, "\n") + BRACKETED_END
+// Replace \r\n and bare \r with \n. The Editor's tui.input.newLine binding accepts \n (see editor.js handleInput) and inserts a newline; tui.input.submit binds to \r, so any \r left in the chunk would still submit. Rewriting is safe inside an active bracketed paste too — Editor.handlePaste's normalizeText collapses both \r and \n to \n before inserting.
+export function rewriteCRToLF(chunk: string): string {
+	return chunk.replace(/\r\n?/g, "\n")
 }
 
 type MarkedEmit = NodeJS.ReadStream["emit"] & { installed?: boolean }
 
-export function installPasteInterceptor(stdin: NodeJS.ReadStream = process.stdin): void {
+// `now` is injectable so tests can advance time without sleeping. Defaults to Date.now in production.
+export function installPasteInterceptor(stdin: NodeJS.ReadStream = process.stdin, now: () => number = Date.now): void {
 	if ((stdin.emit as MarkedEmit).installed) return
 	const originalEmit = stdin.emit.bind(stdin)
+	let lastRewriteAt = 0
+
 	const wrapped: MarkedEmit = (event: string | symbol, ...args: unknown[]) => {
 		if (event === "data" && args.length > 0) {
 			const chunk = args[0]
 			const text = typeof chunk === "string" ? chunk : Buffer.isBuffer(chunk) ? chunk.toString("utf8") : null
-			if (text !== null && looksLikeRawPaste(text)) {
-				return originalEmit("data", wrapAsBracketedPaste(text))
+			if (text !== null && !text.includes(ESC) && text.includes("\r")) {
+				// Seeding: a chunk that's plainly a multi-line burst.
+				if (looksLikeRawPaste(text)) {
+					lastRewriteAt = now()
+					return originalEmit("data", rewriteCRToLF(text))
+				}
+				// Trailing fragment: tail of a paste whose head we just rewrote.
+				if (now() - lastRewriteAt < TRAILING_WINDOW_MS) {
+					lastRewriteAt = now()
+					return originalEmit("data", rewriteCRToLF(text))
+				}
 			}
 		}
 		return originalEmit(event, ...args)

--- a/tests/smoke/interactive-paste.test.ts
+++ b/tests/smoke/interactive-paste.test.ts
@@ -87,7 +87,7 @@ describe.skip("interactive multi-line paste (LLM-1358)", () => {
 		}
 	})
 
-	// LLM-1358 fix verification. When the terminal (or tmux/SSH layer) doesn't honor pi-tui's bracketed-paste enable sequence, a multi-line paste arrives as raw `\r`-separated keystrokes, which would normally submit each line as its own message. The paste interceptor in src/paste-interceptor.ts detects such bursts and re-emits them wrapped in ESC[200~...ESC[201~ so pi-tui's existing bracketed-paste pipeline handles them correctly. This test confirms the fallback path produces the same result as the bracketed-paste path.
+	// LLM-1358 fix verification. When the terminal (or tmux/SSH layer) doesn't honor pi-tui's bracketed-paste enable sequence, a multi-line paste arrives as raw `\r`-separated keystrokes, which would normally submit each line as its own message. The paste interceptor in src/paste-interceptor.ts detects such bursts and rewrites the `\r` bytes to `\n` in place so the Editor inserts newlines instead of submitting. This test confirms the fallback path produces the same result as the bracketed-paste path.
 	it("paste without bracketed-paste markers is recovered by the interceptor", { timeout: 60_000 }, async () => {
 		const session = spawnInteractive()
 		try {
@@ -130,6 +130,36 @@ describe.skip("interactive multi-line paste (LLM-1358)", () => {
 
 			// A misfire would wrap `\r\r\r\r\r\r\r\r\r\r` into a single bracketed paste and push ten `\n`-separated empty rows into the editor buffer — showing up as a long run of blank rows between the editor border dividers. Six or more consecutive empty/whitespace-only lines is well beyond anything the idle TUI renders.
 			expect(plain).not.toMatch(/(\n\s*){6,}\n/)
+		} finally {
+			await session.kill()
+		}
+	})
+
+	// Regression for the auto-send / trailing-line bug. The original LLM-1358 interceptor had a per-chunk heuristic (≥2 \r, ≥4 bytes) that missed the small tail chunk a large paste's final fragment lands in — the bare `\r` in that tail reached the Editor as Enter and submitted everything before it, leaving the trailing letter dangling in the input. The v2 fix rewrites \r→\n in the seeding chunk and extends the rewrite to subsequent \r-bearing chunks within a 5 ms window. This test simulates that exact split: the main chunk is a paste-burst, the second chunk is a single \r + final character arriving ~1 ms later.
+	it("trailing fragment after a paste-burst chunk is not treated as Enter", { timeout: 60_000 }, async () => {
+		const session = spawnInteractive()
+		try {
+			await waitForPrompt(session)
+
+			// Main paste-burst: A\rB\r…\rY\r — meets the seeding heuristic (24 \r, 48 bytes).
+			const mainChunk = "ABCDEFGHIJKLMNOPQRSTUVWXY".split("").join("\r") + "\r"
+			session.pty.write(mainChunk)
+			// 1 ms gap simulates the kernel TTY scheduling delay between adjacent reads of one OS-level paste burst. Far below the 5 ms trailing-window.
+			await new Promise((r) => setTimeout(r, 1))
+			// The trailing fragment: leading bare \r (the last paste-internal newline) then the final letter Z. Pre-fix, this \r submitted A..Y and Z was left in the input.
+			session.pty.write("\rZ")
+
+			// Wait for all 26 letters to render in the editor on their own rows.
+			const rowRegexes = "ABCDEFGHIJKLMNOPQRSTUVWXYZ".split("").map(onOwnRow)
+			await session.waitFor((out) => rowRegexes.every((re) => re.test(stripAnsi(out))), 5_000)
+
+			const plain = stripAnsi(session.output())
+			for (const re of rowRegexes) {
+				expect(plain).toMatch(re)
+			}
+			// Auto-send guard: if the bug had recurred, the prompt would have been submitted mid-paste and the editor would have re-rendered with the placeholder text shown again after submission. The placeholder must NOT reappear after the paste lands.
+			const placeholderHits = plain.match(/ask anything or type \/ for commands/g)?.length ?? 0
+			expect(placeholderHits).toBeLessThanOrEqual(1)
 		} finally {
 			await session.kill()
 		}

--- a/tests/smoke/interactive-paste.test.ts
+++ b/tests/smoke/interactive-paste.test.ts
@@ -135,7 +135,7 @@ describe.skip("interactive multi-line paste (LLM-1358)", () => {
 		}
 	})
 
-	// Regression for the auto-send / trailing-line bug. The original LLM-1358 interceptor had a per-chunk heuristic (≥2 \r, ≥4 bytes) that missed the small tail chunk a large paste's final fragment lands in — the bare `\r` in that tail reached the Editor as Enter and submitted everything before it, leaving the trailing letter dangling in the input. The v2 fix rewrites \r→\n in the seeding chunk and extends the rewrite to subsequent \r-bearing chunks within a 5 ms window. This test simulates that exact split: the main chunk is a paste-burst, the second chunk is a single \r + final character arriving ~1 ms later.
+	// Regression for the auto-send / trailing-line bug. The original LLM-1358 interceptor had a per-chunk heuristic (≥2 \r, ≥4 bytes) that missed the small tail chunk a large paste's final fragment lands in — the bare `\r` in that tail reached the Editor as Enter and submitted everything before it, leaving the trailing letter dangling in the input. The v2 fix rewrites \r→\n in the seeding chunk and extends the rewrite to subsequent \r-bearing chunks within the TRAILING_WINDOW_MS (100 ms) window. This test simulates that exact split: the main chunk is a paste-burst, the second chunk is a single \r + final character arriving ~1 ms later.
 	it("trailing fragment after a paste-burst chunk is not treated as Enter", { timeout: 60_000 }, async () => {
 		const session = spawnInteractive()
 		try {
@@ -144,7 +144,7 @@ describe.skip("interactive multi-line paste (LLM-1358)", () => {
 			// Main paste-burst: A\rB\r…\rY\r — meets the seeding heuristic (24 \r, 48 bytes).
 			const mainChunk = "ABCDEFGHIJKLMNOPQRSTUVWXY".split("").join("\r") + "\r"
 			session.pty.write(mainChunk)
-			// 1 ms gap simulates the kernel TTY scheduling delay between adjacent reads of one OS-level paste burst. Far below the 5 ms trailing-window.
+			// 1 ms gap simulates the kernel TTY scheduling delay between adjacent reads of one OS-level paste burst. Far below the 100 ms TRAILING_WINDOW_MS.
 			await new Promise((r) => setTimeout(r, 1))
 			// The trailing fragment: leading bare \r (the last paste-internal newline) then the final letter Z. Pre-fix, this \r submitted A..Y and Z was left in the input.
 			session.pty.write("\rZ")


### PR DESCRIPTION

<img width="484" height="311" alt="image" src="https://github.com/user-attachments/assets/2381b4b1-06a3-4ca2-9ca4-cd9fa3fe07ff" />


---
### Kimchi Summary
### What changed
Replaces the bracketed-paste wrapping heuristic in `installPasteInterceptor` with direct in-place rewriting of `\r` to `\n`. A 100 ms trailing-fragment window now catches small tail chunks (e.g. the trailing `\rZ` of a large paste) that immediately follow a detected paste burst, preventing them from being treated as Enter keypresses.

### Why
Wrapping raw paste chunks in bracketed-paste escape sequences interacted poorly with pi-tui's `StdinBuffer` paste-mode tracking and required debounce/coalesce buffering that could reorder events or swallow a subsequent Enter. Rewriting `\r` → `\n` synchronously avoids cross-layer state and fixes the bug where the trailing fragment of a large paste was left hanging or caused auto-submission.

### Key changes
- `src/paste-interceptor.ts`
  - Removed `wrapAsBracketedPaste`; added `rewriteCRToLF` to normalize `\r\n` and bare `\r` to `\n` without emitting bracketed-paste markers.
  - `installPasteInterceptor` now applies a `TRAILING_WINDOW_MS` (100 ms) after a seeding paste burst so subsequent small `\r`-bearing fragments are also rewritten.
  - Added an `ESC` guard: chunks containing escape bytes are always passed through unmodified, even inside the trailing window.
  - Made `now` injectable in `installPasteInterceptor` for testability.
- `src/paste-interceptor.test.ts`
  - Updated unit tests for `rewriteCRToLF`.
  - Added coverage for trailing-window behavior, window expiry, and ESC passthrough.
- `tests/smoke/interactive-paste.test.ts`
  - Updated comments to describe the new rewrite strategy.
  - Added a regression test for the large-paste trailing-fragment auto-submit bug.

### Impact
Lower risk than the previous wrapping approach: no event buffering or reordering. Arrow keys and other escape sequences arriving immediately after a paste are preserved unmodified, preventing broken cursor movement. No migration steps are required.

---
### Kimchi Summary
### What changed
Rewrites the raw-paste interceptor to convert `\r` to `\n` inline instead of wrapping bursts in bracketed-paste markers. Adds a 100 ms trailing-fragment window so small tail pieces of a split paste (e.g. a lone `\r` followed by the final character) are normalized too, preventing premature submission of the last line.

### Why
The previous bracketed-paste wrapper interacted poorly with `StdinBuffer` paste tracking and required buffering that reordered events or swallowed a real Enter after a paste. Its per-chunk heuristic also missed the trailing fragment of large pastes, causing that bare `\r` to auto-submit and leave trailing text hanging (LLM-1575).

### Key changes
- `src/paste-interceptor.ts`:
  - Replaced `wrapAsBracketedPaste` and bracketed-paste constants with `rewriteCRToLF`, which normalizes `\r\n` and bare `\r` to `\n`.
  - Added `TRAILING_WINDOW_MS` (100 ms): after a seeding paste chunk, subsequent `\r`-bearing fragments arriving within the window are also rewritten and extend the window.
  - Made `installPasteInterceptor` accept an injectable `now()` for deterministic tests.
  - Preserved the guard that chunks containing `ESC` pass through unmodified, even inside the trailing window.
- `src/paste-interceptor.test.ts`:
  - Migrated tests from bracketed-paste wrapping to `rewriteCRToLF` and trailing-window behavior (extension, expiration, ESC passthrough).
- `tests/smoke/interactive-paste.test.ts`:
  - Added regression test that simulates a split paste where a `\rZ` tail arrives 1 ms after the main burst.

### Impact
- The fallback interceptor no longer emits `ESC[200~`/`ESC[201~`; newlines are now driven by `\n` bytes matching the Editor's `newLine` binding.
- Typed Enter (single `\r`) arriving outside the 100 ms window is unaffected.
- Eliminates buffering and event reordering because each chunk is transformed synchronously.