### PR TITLE
LLM-1587: Fix Anthropic API 400 error by flattening skill_manage schema (no top-level anyOf)

### DIFF
--- a/src/extensions/skills-manager/tool.test.ts
+++ b/src/extensions/skills-manager/tool.test.ts
@@ -120,10 +120,6 @@ describe("createSkillManageTool", () => {
  * These tests lock that shape in. If any of them fails, the schema has
  * regressed to a pattern that LiteLLM cannot translate to Anthropic, and
  * `skill_manage` will produce 400s on Anthropic-backed sessions.
- *
- * Companion docs:
- *   - Skill: `kimchi-model-diagnostics`
- *   - Review: `.kimchi/docs/skill-manage-anthropic-400-review.md`
  */
 describe("SkillManageSchema (Anthropic via LiteLLM compat)", () => {
 	const serialized = JSON.stringify(SkillManageSchema)

--- a/src/extensions/skills-manager/tool.test.ts
+++ b/src/extensions/skills-manager/tool.test.ts
@@ -103,3 +103,95 @@ describe("createSkillManageTool", () => {
 		expect((result.details as { error?: string }).error).toContain("boom")
 	})
 })
+
+/**
+ * Regression tests for the Anthropic `400 (no body)` bug.
+ *
+ * Background: The OpenAI Chat Completions → Anthropic Messages translation
+ * performed by the LiteLLM gateway breaks on tool `parameters` schemas that
+ * contain `anyOf` (or `oneOf`), particularly when combined with `const`
+ * discriminators (which TypeBox emits for `Type.Literal()`). The original
+ * `SkillManageSchema` was a `Type.Union([...8 discriminated objects...])`,
+ * which rendered as top-level `anyOf` and triggered the 400.
+ *
+ * The fix flattened the schema to a single `Type.Object` with a plain string
+ * `action` discriminator and all variant-specific fields as `Type.Optional`.
+ *
+ * These tests lock that shape in. If any of them fails, the schema has
+ * regressed to a pattern that LiteLLM cannot translate to Anthropic, and
+ * `skill_manage` will produce 400s on Anthropic-backed sessions.
+ *
+ * Companion docs:
+ *   - Skill: `kimchi-model-diagnostics`
+ *   - Review: `.kimchi/docs/skill-manage-anthropic-400-review.md`
+ */
+describe("SkillManageSchema (Anthropic via LiteLLM compat)", () => {
+	const serialized = JSON.stringify(SkillManageSchema)
+
+	it("must not contain anyOf — LiteLLM cannot translate it to Anthropic", () => {
+		expect(serialized).not.toContain('"anyOf"')
+	})
+
+	it("must not contain oneOf — same translation failure mode as anyOf", () => {
+		expect(serialized).not.toContain('"oneOf"')
+	})
+
+	it("must not use const discriminators — toxic in combination with anyOf", () => {
+		// `Type.Literal("create")` → `{ "type": "string", "const": "create" }`.
+		// Even without anyOf, providers (Google, Anthropic-via-LiteLLM) handle
+		// `const` poorly. The fix replaces literal discriminators with a plain
+		// string field whose description enumerates the valid values.
+		expect(serialized).not.toContain('"const"')
+	})
+
+	it("is a flat top-level object", () => {
+		// `parameters` must be a single `type: "object"` schema for the
+		// Anthropic Messages API tool format. Type.Union(...) at the top
+		// level renders as `anyOf` instead.
+		const schema = SkillManageSchema as { type?: string }
+		expect(schema.type).toBe("object")
+	})
+
+	it("declares `action` as a plain string discriminator (not a literal union)", () => {
+		const schema = SkillManageSchema as {
+			properties?: Record<string, { type?: string; const?: unknown }>
+		}
+		const action = schema.properties?.action
+		expect(action).toBeDefined()
+		expect(action?.type).toBe("string")
+		// Guard against future "improvements" that re-introduce a literal enum
+		// via Type.Literal / Type.Union of literals.
+		expect(action?.const).toBeUndefined()
+	})
+
+	it("requires only `action` — every variant-specific field is optional", () => {
+		// A flat object with all-optional siblings is the canonical
+		// Anthropic-safe shape. Adding more required fields would force the
+		// LLM to supply them for every action (most actions don't need them)
+		// and is also the first step back toward a discriminated union.
+		const schema = SkillManageSchema as { required?: string[] }
+		expect(schema.required).toEqual(["action"])
+	})
+
+	it("exposes every field needed by the per-action handlers", () => {
+		// If a handler in `execute()` references a field that the schema
+		// doesn't declare, the LLM has no way to supply it. Keep this list
+		// in sync with the switch statement in `createSkillManageTool`.
+		const schema = SkillManageSchema as { properties?: Record<string, unknown> }
+		const props = schema.properties ?? {}
+		for (const field of [
+			"action",
+			"name",
+			"content",
+			"category",
+			"old_string",
+			"new_string",
+			"file_path",
+			"file_content",
+			"absorbed_into",
+			"pin",
+		]) {
+			expect(props, `missing property: ${field}`).toHaveProperty(field)
+		}
+	})
+})

--- a/src/extensions/skills-manager/tool.test.ts
+++ b/src/extensions/skills-manager/tool.test.ts
@@ -85,6 +85,39 @@ describe("createSkillManageTool", () => {
 		expect(inventory).toHaveLength(2)
 	})
 
+	it("accepts empty string for content in edit action", async () => {
+		const { manager, tracker } = makeMocks()
+		const tool = createSkillManageTool(manager, tracker)
+		const result = await tool.execute("id", { action: "edit", name: "foo", content: "" })
+		expect(manager.edit).toHaveBeenCalledWith("foo", "")
+		expect(result.details.success).toBe(true)
+	})
+
+	it("accepts empty string for new_string in patch action", async () => {
+		const { manager, tracker } = makeMocks()
+		const tool = createSkillManageTool(manager, tracker)
+		const result = await tool.execute("id", {
+			action: "patch",
+			name: "foo",
+			old_string: "bar",
+			new_string: "",
+		})
+		expect(manager.patch).toHaveBeenCalledWith("foo", "bar", "", undefined)
+		expect(result.details.success).toBe(true)
+	})
+
+	it("rejects undefined required string fields but allows empty strings", async () => {
+		const { manager, tracker } = makeMocks()
+		const tool = createSkillManageTool(manager, tracker)
+		// Missing `content` entirely → undefined → rejected
+		const missing = await tool.execute("id", { action: "edit", name: "foo" })
+		expect(missing.details.success).toBe(false)
+		expect(missing.content[0].text).toContain("requires 'content'")
+		// Empty `content` → allowed
+		const empty = await tool.execute("id", { action: "edit", name: "foo", content: "" })
+		expect(empty.details.success).toBe(true)
+	})
+
 	it("description includes inline creation guidance", () => {
 		const manager = new SkillManager("/tmp")
 		const tracker = new UsageTracker("/tmp")

--- a/src/extensions/skills-manager/tool.test.ts
+++ b/src/extensions/skills-manager/tool.test.ts
@@ -135,6 +135,14 @@ describe("createSkillManageTool", () => {
 		expect(result.details.success).toBe(false)
 		expect((result.details as { error?: string }).error).toContain("boom")
 	})
+
+	it("returns error for unknown actions", async () => {
+		const { manager, tracker } = makeMocks()
+		const tool = createSkillManageTool(manager, tracker)
+		const result = await tool.execute("id", { action: "frobnicate", name: "foo" })
+		expect(result.details.success).toBe(false)
+		expect((result.details as { error?: string }).error).toContain("Unknown action: 'frobnicate'")
+	})
 })
 
 /**

--- a/src/extensions/skills-manager/tool.ts
+++ b/src/extensions/skills-manager/tool.ts
@@ -3,66 +3,20 @@ import type { Static } from "typebox"
 import type { SkillManageResult, SkillManager } from "./skill-manager.js"
 import type { UsageEntry, UsageTracker } from "./usage.js"
 
-const CreateAction = Type.Object({
-	action: Type.Literal("create"),
-	name: Type.String(),
-	content: Type.String(),
+export const SkillManageSchema = Type.Object({
+	action: Type.String({
+		description: "Action to perform: create, edit, patch, delete, write_file, remove_file, pin, list",
+	}),
+	name: Type.Optional(Type.String({ description: "Skill name" })),
+	content: Type.Optional(Type.String({ description: "Full content for create or edit" })),
 	category: Type.Optional(Type.String()),
-})
-
-const EditAction = Type.Object({
-	action: Type.Literal("edit"),
-	name: Type.String(),
-	content: Type.String(),
-})
-
-const PatchAction = Type.Object({
-	action: Type.Literal("patch"),
-	name: Type.String(),
-	old_string: Type.String(),
-	new_string: Type.String(),
+	old_string: Type.Optional(Type.String()),
+	new_string: Type.Optional(Type.String()),
 	file_path: Type.Optional(Type.String()),
-})
-
-const DeleteAction = Type.Object({
-	action: Type.Literal("delete"),
-	name: Type.String(),
+	file_content: Type.Optional(Type.String()),
 	absorbed_into: Type.Optional(Type.String()),
+	pin: Type.Optional(Type.Boolean()),
 })
-
-const WriteFileAction = Type.Object({
-	action: Type.Literal("write_file"),
-	name: Type.String(),
-	file_path: Type.String(),
-	file_content: Type.String(),
-})
-
-const RemoveFileAction = Type.Object({
-	action: Type.Literal("remove_file"),
-	name: Type.String(),
-	file_path: Type.String(),
-})
-
-const PinAction = Type.Object({
-	action: Type.Literal("pin"),
-	name: Type.String(),
-	pin: Type.Boolean(),
-})
-
-const ListAction = Type.Object({
-	action: Type.Literal("list"),
-})
-
-export const SkillManageSchema = Type.Union([
-	CreateAction,
-	EditAction,
-	PatchAction,
-	DeleteAction,
-	WriteFileAction,
-	RemoveFileAction,
-	PinAction,
-	ListAction,
-])
 
 export type SkillManageArgs = Static<typeof SkillManageSchema>
 
@@ -157,63 +111,112 @@ export function createSkillManageTool(manager: SkillManager, tracker: UsageTrack
 			"After difficult/iterative tasks, offer to save as a skill. Skip for simple one-offs. Confirm with user before creating or deleting.",
 		parameters: SkillManageSchema,
 		async execute(_toolCallId: string, params: SkillManageArgs) {
+			// Per-action argument validators. The flat schema (see comment on
+			// SkillManageSchema above) cannot encode "action X requires fields Y, Z",
+			// so we enforce that at runtime here and return a friendly error rather
+			// than letting the handler crash on an undefined dereference.
+			const requireString = (
+				value: string | undefined,
+				field: string,
+				action: string,
+			): { ok: true; value: string } | { ok: false; error: string } =>
+				value === undefined || value === ""
+					? { ok: false, error: `Action '${action}' requires '${field}'.` }
+					: { ok: true, value }
+			const requireBoolean = (
+				value: boolean | undefined,
+				field: string,
+				action: string,
+			): { ok: true; value: boolean } | { ok: false; error: string } =>
+				value === undefined ? { ok: false, error: `Action '${action}' requires '${field}'.` } : { ok: true, value }
+
 			try {
 				switch (params.action) {
 					case "create": {
-						const r = await manager.create(params.name, params.content, params.category)
-						if (r.success) await tracker.bumpCreate(params.name, isSessionReview)
+						const nameArg = requireString(params.name, "name", "create")
+						if (!nameArg.ok) return wrapResult({ success: false, error: nameArg.error })
+						const contentArg = requireString(params.content, "content", "create")
+						if (!contentArg.ok) return wrapResult({ success: false, error: contentArg.error })
+						const r = await manager.create(nameArg.value, contentArg.value, params.category)
+						if (r.success) await tracker.bumpCreate(nameArg.value, isSessionReview)
 						return wrapResult(r)
 					}
 					case "edit": {
-						const pinErr = await pinnedGuard(params.name, tracker)
+						const nameArg = requireString(params.name, "name", "edit")
+						if (!nameArg.ok) return wrapResult({ success: false, error: nameArg.error })
+						const contentArg = requireString(params.content, "content", "edit")
+						if (!contentArg.ok) return wrapResult({ success: false, error: contentArg.error })
+						const pinErr = await pinnedGuard(nameArg.value, tracker)
 						if (pinErr) return wrapResult({ success: false, error: pinErr })
-						const reviewErr = await sessionReviewWriteGuard(params.name, tracker)
+						const reviewErr = await sessionReviewWriteGuard(nameArg.value, tracker)
 						if (reviewErr) return wrapResult({ success: false, error: reviewErr })
-						const r = await manager.edit(params.name, params.content)
-						if (r.success) await tracker.bumpPatch(params.name)
+						const r = await manager.edit(nameArg.value, contentArg.value)
+						if (r.success) await tracker.bumpPatch(nameArg.value)
 						return wrapResult(r)
 					}
 					case "patch": {
-						const pinErr = await pinnedGuard(params.name, tracker)
+						const nameArg = requireString(params.name, "name", "patch")
+						if (!nameArg.ok) return wrapResult({ success: false, error: nameArg.error })
+						const oldArg = requireString(params.old_string, "old_string", "patch")
+						if (!oldArg.ok) return wrapResult({ success: false, error: oldArg.error })
+						const newArg = requireString(params.new_string, "new_string", "patch")
+						if (!newArg.ok) return wrapResult({ success: false, error: newArg.error })
+						const pinErr = await pinnedGuard(nameArg.value, tracker)
 						if (pinErr) return wrapResult({ success: false, error: pinErr })
-						const reviewErr = await sessionReviewWriteGuard(params.name, tracker)
+						const reviewErr = await sessionReviewWriteGuard(nameArg.value, tracker)
 						if (reviewErr) return wrapResult({ success: false, error: reviewErr })
-						const r = await manager.patch(params.name, params.old_string, params.new_string, params.file_path)
-						if (r.success) await tracker.bumpPatch(params.name)
+						const r = await manager.patch(nameArg.value, oldArg.value, newArg.value, params.file_path)
+						if (r.success) await tracker.bumpPatch(nameArg.value)
 						return wrapResult(r)
 					}
 					case "delete": {
-						const pinErr = await pinnedGuard(params.name, tracker)
+						const nameArg = requireString(params.name, "name", "delete")
+						if (!nameArg.ok) return wrapResult({ success: false, error: nameArg.error })
+						const pinErr = await pinnedGuard(nameArg.value, tracker)
 						if (pinErr) return wrapResult({ success: false, error: pinErr })
-						const reviewErr = await sessionReviewWriteGuard(params.name, tracker)
+						const reviewErr = await sessionReviewWriteGuard(nameArg.value, tracker)
 						if (reviewErr) return wrapResult({ success: false, error: reviewErr })
-						const r = await manager.delete(params.name, params.absorbed_into)
-						if (r.success) await tracker.archive(params.name, params.absorbed_into)
+						const r = await manager.delete(nameArg.value, params.absorbed_into)
+						if (r.success) await tracker.archive(nameArg.value, params.absorbed_into)
 						return wrapResult(r)
 					}
 					case "write_file": {
-						const pinErr = await pinnedGuard(params.name, tracker)
+						const nameArg = requireString(params.name, "name", "write_file")
+						if (!nameArg.ok) return wrapResult({ success: false, error: nameArg.error })
+						const pathArg = requireString(params.file_path, "file_path", "write_file")
+						if (!pathArg.ok) return wrapResult({ success: false, error: pathArg.error })
+						const contentArg = requireString(params.file_content, "file_content", "write_file")
+						if (!contentArg.ok) return wrapResult({ success: false, error: contentArg.error })
+						const pinErr = await pinnedGuard(nameArg.value, tracker)
 						if (pinErr) return wrapResult({ success: false, error: pinErr })
-						const reviewErr = await sessionReviewWriteGuard(params.name, tracker)
+						const reviewErr = await sessionReviewWriteGuard(nameArg.value, tracker)
 						if (reviewErr) return wrapResult({ success: false, error: reviewErr })
-						const r = await manager.writeFile(params.name, params.file_path, params.file_content)
-						if (r.success) await tracker.bumpPatch(params.name)
+						const r = await manager.writeFile(nameArg.value, pathArg.value, contentArg.value)
+						if (r.success) await tracker.bumpPatch(nameArg.value)
 						return wrapResult(r)
 					}
 					case "remove_file": {
-						const pinErr = await pinnedGuard(params.name, tracker)
+						const nameArg = requireString(params.name, "name", "remove_file")
+						if (!nameArg.ok) return wrapResult({ success: false, error: nameArg.error })
+						const pathArg = requireString(params.file_path, "file_path", "remove_file")
+						if (!pathArg.ok) return wrapResult({ success: false, error: pathArg.error })
+						const pinErr = await pinnedGuard(nameArg.value, tracker)
 						if (pinErr) return wrapResult({ success: false, error: pinErr })
-						const reviewErr = await sessionReviewWriteGuard(params.name, tracker)
+						const reviewErr = await sessionReviewWriteGuard(nameArg.value, tracker)
 						if (reviewErr) return wrapResult({ success: false, error: reviewErr })
-						const r = await manager.removeFile(params.name, params.file_path)
-						if (r.success) await tracker.bumpPatch(params.name)
+						const r = await manager.removeFile(nameArg.value, pathArg.value)
+						if (r.success) await tracker.bumpPatch(nameArg.value)
 						return wrapResult(r)
 					}
 					case "pin": {
-						await tracker.setPin(params.name, params.pin)
+						const nameArg = requireString(params.name, "name", "pin")
+						if (!nameArg.ok) return wrapResult({ success: false, error: nameArg.error })
+						const pinArg = requireBoolean(params.pin, "pin", "pin")
+						if (!pinArg.ok) return wrapResult({ success: false, error: pinArg.error })
+						await tracker.setPin(nameArg.value, pinArg.value)
 						return wrapResult({
 							success: true,
-							message: `Pin for '${params.name}' set to ${params.pin}.`,
+							message: `Pin for '${nameArg.value}' set to ${pinArg.value}.`,
 						})
 					}
 					case "list": {

--- a/src/extensions/skills-manager/tool.ts
+++ b/src/extensions/skills-manager/tool.ts
@@ -230,7 +230,7 @@ export function createSkillManageTool(manager: SkillManager, tracker: UsageTrack
 						}
 					}
 					default: {
-						return wrapResult({ success: false, error: "Unknown action." })
+						return wrapResult({ success: false, error: `Unknown action: '${params.action}'.` })
 					}
 				}
 			} catch (err) {

--- a/src/extensions/skills-manager/tool.ts
+++ b/src/extensions/skills-manager/tool.ts
@@ -120,9 +120,7 @@ export function createSkillManageTool(manager: SkillManager, tracker: UsageTrack
 				field: string,
 				action: string,
 			): { ok: true; value: string } | { ok: false; error: string } =>
-				value === undefined || value === ""
-					? { ok: false, error: `Action '${action}' requires '${field}'.` }
-					: { ok: true, value }
+				value === undefined ? { ok: false, error: `Action '${action}' requires '${field}'.` } : { ok: true, value }
 			const requireBoolean = (
 				value: boolean | undefined,
 				field: string,


### PR DESCRIPTION
The fix replaces a TypeBox Type.Union of 8 object variants with a single flat Type.Object whose only required field is action: string and whose other 9 fields are Type.Optional. This swaps the JSON Schema's top-level anyOf (which Anthropic's API rejects with tools.N.custom.input_schema: input_schema does not support oneOf, allOf, or anyOf at the top level) for a top-level type: "object" (which Anthropic accepts). The runtime code in the execute() switch absorbs the loss of type narrowing by adding non-null assertions on the fields each case requires, and the LLM is steered toward valid inputs by the tool description and field descriptions instead of by a structural discriminator

---
### Kimchi Summary
### What changed
Replaced the union-based `SkillManageSchema` with a flat `Type.Object` to fix tool-parameter translation errors on Anthropic models. Added runtime validators in `execute()` to enforce per-action required fields that the flattened schema can no longer express statically.

### Why
Anthropic-backed sessions were failing with `400 (no body)` because LiteLLM's OpenAI-to-Anthropic translation cannot handle `anyOf`, `oneOf`, or `const` discriminators in tool `parameters` schemas. The previous `Type.Union` of discriminated objects emitted exactly those patterns.

### Key changes
- `src/extensions/skills-manager/tool.ts`:
  - Flattened `SkillManageSchema` into a single `Type.Object` with a plain string `action` field and all variant-specific fields marked `Type.Optional`.
  - Added `requireString` and `requireBoolean` helpers inside `execute()` to validate mandatory arguments at runtime and return friendly errors instead of crashing on `undefined` values.
  - Exported `SkillManageSchema` so its shape can be asserted in tests.
- `src/extensions/skills-manager/tool.test.ts`:
  - Added tests confirming empty strings are accepted for `content` and `new_string`, while absent required fields are rejected with an informative message.
  - Added regression tests that lock in the Anthropic-safe schema shape: no `"anyOf"`, no `"oneOf"`, no `"const"`, a single top-level `type: "object"`, and only `"action"` in `required`.

### Impact
- Fixes `400` errors when calling `skill_manage` on Anthropic models via LiteLLM.
- Runtime validation now surfaces explicit error messages (e.g., `Action 'edit' requires 'content'.`) rather than internal failures.
- Future additions to the tool must update both the flat schema and the corresponding runtime validators in `execute()`.