### PR TITLE
LLM-1576: Fix displaying and selecting MCP servers via /mcp command

### DIFF
--- a/src/extensions/mcp-adapter/commands.ts
+++ b/src/extensions/mcp-adapter/commands.ts
@@ -219,10 +219,13 @@ export async function openMcpPanel(
 						ctx.ui.notify("Direct tools updated. Restart pi to apply.", "info")
 					}
 					done(undefined)
+					// Force a clean redraw so any overlay artifacts are cleared from
+					// scrollback when the panel closes.
+					tui.requestRender(true)
 					resolve()
 				})
 			},
-			{ overlay: true, overlayOptions: { anchor: "center", width: 82 } },
+			{ overlay: true, overlayOptions: { anchor: "center", width: 82, maxHeight: "100%" } },
 		)
 	})
 }

--- a/src/extensions/mcp-adapter/mcp-panel.test.ts
+++ b/src/extensions/mcp-adapter/mcp-panel.test.ts
@@ -1,0 +1,87 @@
+import { describe, expect, it } from "vitest"
+import { computeVisibleWindow } from "./mcp-panel.js"
+
+const LIMITS = { maxVisible: 12, minVisible: 3, fixedOverheadRows: 16 }
+
+describe("computeVisibleWindow", () => {
+	describe("maxVis clamping by terminal height", () => {
+		it("clamps to MIN_VISIBLE when terminal is too small (rows < overhead)", () => {
+			const { maxVis } = computeVisibleWindow(5, 0, 50, LIMITS)
+			expect(maxVis).toBe(3)
+		})
+
+		it("clamps to MIN_VISIBLE when terminal exactly matches overhead", () => {
+			const { maxVis } = computeVisibleWindow(16, 0, 50, LIMITS)
+			expect(maxVis).toBe(3)
+		})
+
+		it("scales with terminal height between MIN and MAX", () => {
+			const { maxVis } = computeVisibleWindow(20, 0, 50, LIMITS)
+			expect(maxVis).toBe(4)
+		})
+
+		it("clamps to MAX_VISIBLE when terminal is large enough", () => {
+			const { maxVis } = computeVisibleWindow(28, 0, 50, LIMITS)
+			expect(maxVis).toBe(12)
+		})
+
+		it("stays at MAX_VISIBLE for very large terminals", () => {
+			const { maxVis } = computeVisibleWindow(100, 0, 50, LIMITS)
+			expect(maxVis).toBe(12)
+		})
+	})
+
+	describe("startIdx/endIdx windowing", () => {
+		it("starts at 0 when cursor is at the top", () => {
+			const { startIdx, endIdx } = computeVisibleWindow(100, 0, 78, LIMITS)
+			expect(startIdx).toBe(0)
+			expect(endIdx).toBe(12)
+		})
+
+		it("centers cursor in the middle of the list", () => {
+			const { startIdx, endIdx } = computeVisibleWindow(100, 40, 78, LIMITS)
+			expect(startIdx).toBe(34)
+			expect(endIdx).toBe(46)
+		})
+
+		it("clamps startIdx so the window stays within total at end of list", () => {
+			const { startIdx, endIdx } = computeVisibleWindow(100, 77, 78, LIMITS)
+			expect(startIdx).toBe(66)
+			expect(endIdx).toBe(78)
+		})
+
+		it("does not exceed total when list is shorter than maxVis", () => {
+			const { startIdx, endIdx } = computeVisibleWindow(100, 0, 5, LIMITS)
+			expect(startIdx).toBe(0)
+			expect(endIdx).toBe(5)
+		})
+
+		it("does not exceed total when list is exactly maxVis", () => {
+			const { startIdx, endIdx } = computeVisibleWindow(100, 6, 12, LIMITS)
+			expect(startIdx).toBe(0)
+			expect(endIdx).toBe(12)
+		})
+
+		it("handles empty list gracefully", () => {
+			const { startIdx, endIdx } = computeVisibleWindow(100, 0, 0, LIMITS)
+			expect(startIdx).toBe(0)
+			expect(endIdx).toBe(0)
+		})
+	})
+
+	describe("interaction between small terminal and large list", () => {
+		it("scrolls correctly with reduced maxVis on small terminal", () => {
+			const { maxVis, startIdx, endIdx } = computeVisibleWindow(20, 50, 78, LIMITS)
+			expect(maxVis).toBe(4)
+			expect(startIdx).toBe(48)
+			expect(endIdx).toBe(52)
+		})
+
+		it("end-of-list windowing works on small terminal", () => {
+			const { maxVis, startIdx, endIdx } = computeVisibleWindow(20, 77, 78, LIMITS)
+			expect(maxVis).toBe(4)
+			expect(startIdx).toBe(74)
+			expect(endIdx).toBe(78)
+		})
+	})
+})

--- a/src/extensions/mcp-adapter/mcp-panel.ts
+++ b/src/extensions/mcp-adapter/mcp-panel.ts
@@ -118,10 +118,14 @@ class McpPanel {
 	private authNotice: string | null = null
 	private inactivityTimeout: ReturnType<typeof setTimeout> | null = null
 	private visibleItems: VisibleItem[] = []
-	private tui: { requestRender(): void }
+	private tui: { requestRender(force?: boolean): void; terminal: { rows: number } }
 	private t = DEFAULT_THEME
 
 	private static readonly MAX_VISIBLE = 12
+	// Borders, search row, dividers, empty rows, progress row, stats row, ~2 hint rows.
+	// Subtract from terminal rows to bound visible items so the bottom controls stay on-screen.
+	private static readonly FIXED_OVERHEAD_ROWS = 16
+	private static readonly MIN_VISIBLE = 3
 	private static readonly INACTIVITY_MS = 60_000
 
 	constructor(
@@ -129,7 +133,7 @@ class McpPanel {
 		cache: MetadataCache | null,
 		provenance: Map<string, ServerProvenance>,
 		private callbacks: McpPanelCallbacks,
-		tui: { requestRender(): void },
+		tui: { requestRender(force?: boolean): void; terminal: { rows: number } },
 		private done: (result: McpPanelResult) => void,
 	) {
 		this.tui = tui
@@ -584,7 +588,11 @@ class McpPanel {
 			lines.push(row(fg(t.hint, italic("No MCP servers configured."))))
 			lines.push(emptyRow())
 		} else {
-			const maxVis = McpPanel.MAX_VISIBLE
+			const terminalRows = this.tui.terminal.rows
+			const maxVis = Math.max(
+				McpPanel.MIN_VISIBLE,
+				Math.min(McpPanel.MAX_VISIBLE, terminalRows - McpPanel.FIXED_OVERHEAD_ROWS),
+			)
 			const total = this.visibleItems.length
 			const startIdx = Math.max(0, Math.min(this.cursorIndex - Math.floor(maxVis / 2), total - maxVis))
 			const endIdx = Math.min(startIdx + maxVis, total)
@@ -721,9 +729,13 @@ class McpPanel {
 
 		const prefixLen = 7 + visibleWidth(tool.name)
 		const maxDescLen = Math.max(0, innerW - prefixLen - 8)
+		// Tool descriptions are often multi-line docstrings (e.g. "Args:\n  ..."). The
+		// newlines have visible width 0 but break terminal layout when emitted. Collapse
+		// any whitespace/control sequence to a single space before truncating.
+		const flatDesc = tool.description ? tool.description.replace(/\s+/g, " ").trim() : ""
 		const descStr =
-			maxDescLen > 5 && tool.description
-				? fg(t.description, "— " + truncateToWidth(tool.description, maxDescLen, "…"))
+			maxDescLen > 5 && flatDesc
+				? fg(t.description, "— " + truncateToWidth(flatDesc, maxDescLen, "…"))
 				: ""
 
 		return `  ${cursor} ${toggleIcon} ${nameStr} ${descStr}`
@@ -741,7 +753,7 @@ export function createMcpPanel(
 	cache: MetadataCache | null,
 	provenance: Map<string, ServerProvenance>,
 	callbacks: McpPanelCallbacks,
-	tui: { requestRender(): void },
+	tui: { requestRender(force?: boolean): void; terminal: { rows: number } },
 	done: (result: McpPanelResult) => void,
 ): McpPanel & { dispose(): void } {
 	return new McpPanel(config, cache, provenance, callbacks, tui, done)

--- a/src/extensions/mcp-adapter/mcp-panel.ts
+++ b/src/extensions/mcp-adapter/mcp-panel.ts
@@ -104,6 +104,35 @@ interface VisibleItem {
 	toolIndex?: number
 }
 
+/**
+ * Compute the visible-item window for the panel given the terminal height,
+ * cursor position, and total item count.
+ *
+ * - `maxVis` adapts to the terminal so the bottom controls stay on-screen
+ *   on small terminals: it's clamped to [MIN_VISIBLE, MAX_VISIBLE] around
+ *   `terminalRows - FIXED_OVERHEAD_ROWS`.
+ * - `startIdx`/`endIdx` slide the visible window so the cursor stays roughly
+ *   centered while staying within `[0, total]`.
+ */
+export function computeVisibleWindow(
+	terminalRows: number,
+	cursorIndex: number,
+	total: number,
+	limits: { maxVisible: number; minVisible: number; fixedOverheadRows: number } = {
+		maxVisible: 12,
+		minVisible: 3,
+		fixedOverheadRows: 16,
+	},
+): { maxVis: number; startIdx: number; endIdx: number } {
+	const maxVis = Math.max(
+		limits.minVisible,
+		Math.min(limits.maxVisible, terminalRows - limits.fixedOverheadRows),
+	)
+	const startIdx = Math.max(0, Math.min(cursorIndex - Math.floor(maxVis / 2), total - maxVis))
+	const endIdx = Math.min(startIdx + maxVis, total)
+	return { maxVis, startIdx, endIdx }
+}
+
 class McpPanel {
 	private prefix: "server" | "none" | "short"
 	private servers: ServerState[] = []
@@ -588,14 +617,17 @@ class McpPanel {
 			lines.push(row(fg(t.hint, italic("No MCP servers configured."))))
 			lines.push(emptyRow())
 		} else {
-			const terminalRows = this.tui.terminal.rows
-			const maxVis = Math.max(
-				McpPanel.MIN_VISIBLE,
-				Math.min(McpPanel.MAX_VISIBLE, terminalRows - McpPanel.FIXED_OVERHEAD_ROWS),
-			)
 			const total = this.visibleItems.length
-			const startIdx = Math.max(0, Math.min(this.cursorIndex - Math.floor(maxVis / 2), total - maxVis))
-			const endIdx = Math.min(startIdx + maxVis, total)
+			const { maxVis, startIdx, endIdx } = computeVisibleWindow(
+				this.tui.terminal.rows,
+				this.cursorIndex,
+				total,
+				{
+					maxVisible: McpPanel.MAX_VISIBLE,
+					minVisible: McpPanel.MIN_VISIBLE,
+					fixedOverheadRows: McpPanel.FIXED_OVERHEAD_ROWS,
+				},
+			)
 
 			lines.push(emptyRow())
 


### PR DESCRIPTION
Displaying MCP servers works correctly now. Actual MCP server calls works correctly as well.

Few things worth improving - (created separate task https://castai.atlassian.net/browse/LLM-1590):
- disabling mcp doesn't have any effect - it is still accessible by harness
- the output includes raw API response - perhaps it can be useful in some cases but there is no way of collapsing it.
- changes (e.g. toggling mcp server) are applied only on kimchi restart and there is no information about it 
- expanding description doesn't work - hitting enter does the same as toggle
<img width="168" height="19" alt="image" src="https://github.com/user-attachments/assets/1adff666-1150-4aa7-b1cc-9607899b3244" />


---

<img width="598" height="489" alt="image" src="https://github.com/user-attachments/assets/fab8c0e9-781b-4b23-a87d-3795e1751833" />

<img width="348" height="347" alt="image" src="https://github.com/user-attachments/assets/47ec68d2-e7a6-453d-8a2a-47ab827d90b8" />

<img width="912" height="325" alt="image" src="https://github.com/user-attachments/assets/bdb36d0d-8ef1-45ed-9d0f-b99ba66257f9" />
<img width="1157" height="604" alt="image" src="https://github.com/user-attachments/assets/4150e508-872a-4d70-a68f-ee19babd3976" />


---
### Kimchi Summary
### What changed
Fixes three UI defects in the MCP server selection panel: it now sizes itself to fit within the available terminal height, forces a full redraw when dismissed to clear overlay residue, and normalizes multi-line tool descriptions so they don't break layout.

### Why
The panel previously used a fixed maximum height that could overflow small terminals, left visual artifacts in scrollback on exit, and broke rendering when tool descriptions contained literal newlines (e.g. docstrings).

### Key changes
- `src/extensions/mcp-adapter/commands.ts`
  - Adds `tui.requestRender(true)` after closing the panel to force a clean scrollback redraw.
  - Adds `maxHeight: "100%"` to `overlayOptions` so the overlay does not exceed the terminal size.
- `src/extensions/mcp-adapter/mcp-panel.ts`
  - Updates the `tui` type to include `terminal.rows` and makes `requestRender` accept an optional `force` flag.
  - Introduces `FIXED_OVERHEAD_ROWS` and `MIN_VISIBLE` constants to calculate the correct number of visible items based on the current terminal height instead of hard-coding `MAX_VISIBLE`.
  - Collapses whitespace (including newlines) in `tool.description` to a single space before truncating, preventing layout breaks from multi-line docstrings.

### Impact
- The panel now adapts to smaller terminals instead of always showing up to 12 items.
- No breaking changes or migration steps required.

---
### Kimchi Summary
### What changed
Fixes MCP panel rendering and layout issues by making the visible tool list adapt to terminal height, sanitizing multi-line tool descriptions, and forcing a full TUI redraw when the panel closes to clear overlay artifacts.

### Why
The MCP selection panel overflowed on smaller terminals, multi-line docstrings in tool descriptions corrupted the TUI layout, and closing the panel left visual artifacts in scrollback.

### Key changes
- `src/extensions/mcp-adapter/mcp-panel.ts`:
  - Added `computeVisibleWindow()` to dynamically clamp visible items based on `terminal.rows` minus `FIXED_OVERHEAD_ROWS`, keeping bottom controls on-screen while respecting `MIN_VISIBLE` and `MAX_VISIBLE`.
  - Updated `McpPanel` and `createMcpPanel` to consume `tui.terminal.rows` for dynamic sizing.
  - Flattened whitespace sequences (including `\n` from docstrings) in tool descriptions to a single space before truncation to prevent layout breakage.
- `src/extensions/mcp-adapter/commands.ts`:
  - Added `maxHeight: "100%"` to the overlay options.
  - Called `tui.requestRender(true)` after the panel closes to force a clean redraw and clear scrollback artifacts.
- `src/extensions/mcp-adapter/mcp-panel.test.ts`:
  - Added unit tests for `computeVisibleWindow()` covering terminal-height clamping, cursor-centered windowing, and boundary conditions.

### Impact
Callers of `createMcpPanel` must now provide a `tui` object that includes `terminal.rows`; the internal caller in `commands.ts` has been updated accordingly.