### PR TITLE
NOJIRA: fix incorrect brew upgrade message

### DIFF
--- a/src/commands/update.ts
+++ b/src/commands/update.ts
@@ -51,7 +51,7 @@ export async function runUpdate(args: string[]): Promise<number> {
 	if (isHomebrewInstall()) {
 		console.log("kimchi is managed by Homebrew. Use Homebrew to update:")
 		console.log("")
-		console.log("  brew upgrade kimchi")
+		console.log("  brew upgrade kimchi-dev")
 		console.log("")
 		console.log("If you want the self-update behaviour, install kimchi outside of Homebrew.")
 		return 0

--- a/src/extensions/startup-update.ts
+++ b/src/extensions/startup-update.ts
@@ -20,7 +20,7 @@ export default function startupUpdateExtension(pi: ExtensionAPI) {
 		try {
 			const result = await checkForUpdate({ currentVersion: current, skipCache: false })
 			if (result.hasUpdate) {
-				const updateCmd = ctx.ui.theme.bold(isHomebrewInstall() ? "brew upgrade kimchi" : "kimchi update")
+				const updateCmd = ctx.ui.theme.bold(isHomebrewInstall() ? "brew upgrade kimchi-dev" : "kimchi update")
 				ctx.ui.setStatus(UPDATE_STATUS_KEY, `Update available! Run ${updateCmd}`)
 			}
 		} catch {


### PR DESCRIPTION


---
### Kimchi Summary
### What changed
Updates user-facing Homebrew upgrade instructions to use the correct package name `kimchi-dev` instead of `kimchi`.

### Why
The previous instructions referenced `kimchi`, which is not the correct Homebrew package name and would cause the command to fail for users.

### Key changes
- `src/commands/update.ts`: Changed the logged Homebrew command in `runUpdate` to `brew upgrade kimchi-dev`.
- `src/extensions/startup-update.ts`: Updated the update notification status message to suggest `brew upgrade kimchi-dev` for Homebrew installations.