### PR TITLE
Revert fixed footer

### DIFF
--- a/src/extensions/hide-thinking.ts
+++ b/src/extensions/hide-thinking.ts
@@ -27,7 +27,7 @@ import { readFileSync } from "node:fs"
 import { resolve } from "node:path"
 
 import type { AssistantMessage } from "@earendil-works/pi-ai"
-import type { ContextEvent, ExtensionAPI } from "@earendil-works/pi-coding-agent"
+import type { ExtensionAPI } from "@earendil-works/pi-coding-agent"
 import { ANSI, fg } from "../ansi.js"
 import { isSubagent } from "./orchestration/prompt-transformer/prompt-transformer.js"
 

--- a/src/extensions/ui.ts
+++ b/src/extensions/ui.ts
@@ -25,88 +25,12 @@ const HORIZONTAL_PADDING = 2
 // biome-ignore lint/suspicious/noControlCharactersInRegex: matching ANSI/OSC
 const OSC133_RE = /\x1b\]133;[A-Z]\x07/g
 
-// The interactive TUI has 8 children in a fixed order:
-//   0 headerContainer, 1 chatContainer, 2 pendingMessagesContainer,
-//   3 statusContainer, 4 widgetContainerAbove, 5 editorContainer,
-//   6 widgetContainerBelow, 7 footer.
-//
-// The last 5 form the pinned bottom section.  Including statusContainer
-// (the working indicator "◑ Mixing…") keeps the editor/footer stable
-// when the indicator toggles.
-const EXPECTED_CHILDREN_COUNT = 8
-const BOTTOM_CHILDREN_COUNT = 5
-
-function renderChildren(children: TUI["children"], start: number, end: number, width: number): string[] {
-	const lines: string[] = []
-	for (let i = start; i < end; i++) {
-		for (const line of children[i].render(width)) {
-			lines.push(line)
-		}
-	}
-	return lines
-}
-
 function patchTuiPadding(tui: TUI) {
+	const original = tui.render.bind(tui)
 	const pad = " ".repeat(HORIZONTAL_PADDING)
-
-	// Capture the original Container.render so we can fall back to it if
-	// the child structure doesn't match our expectations (e.g. upstream
-	// adds or removes a container).  This avoids silently breaking the
-	// layout and keeps the TUI usable even when the contract changes.
-	const originalRender = tui.render.bind(tui)
-
 	tui.render = (width: number): string[] => {
-		const children = tui.children
-
-		// Guard: if the child structure deviates from what we expect, fall
-		// back to the unpatched render so the TUI remains functional.
-		if (children.length !== EXPECTED_CHILDREN_COUNT) {
-			if (process.env.NODE_ENV !== "production") {
-				console.warn(
-					`[ui] expected ${EXPECTED_CHILDREN_COUNT} TUI children for bottom-pin layout, ` +
-						`got ${children.length} — falling back to default render`,
-				)
-			}
-			return originalRender(width)
-		}
-
-		const innerWidth = Math.max(1, width - HORIZONTAL_PADDING * 2)
-		const splitAt = children.length - BOTTOM_CHILDREN_COUNT
-
-		// Render top (scrollable) and bottom (pinned) sections separately
-		// by delegating to each child's own render — the same mechanism
-		// the original Container.render uses.
-		const topLines = renderChildren(children, 0, splitAt, innerWidth)
-		const bottomLines = renderChildren(children, splitAt, children.length, innerWidth)
-
-		// Insert padding between content and bottom components so the prompt
-		// and footer are pushed to the terminal bottom.  This eliminates the
-		// visual jump that occurs when tool output shrinks (e.g. bash collapse),
-		// the working indicator toggling, or a selector dialog opening/closing.
-		const terminalHeight = tui.terminal.rows
-		const totalContent = topLines.length + bottomLines.length
-		const paddingCount = Math.max(0, terminalHeight - totalContent)
-
-		// When the bottom section is tall (e.g. model selector open) the total
-		// content can exceed the terminal height.  Truncate the top of the
-		// scrollable section so the rendered output is always exactly
-		// terminalHeight lines — this prevents the TUI diff-renderer from
-		// scrolling/jumping when the tall component is later dismissed.
-		const overflow = Math.max(0, totalContent - terminalHeight)
-		const topStart = Math.min(overflow, topLines.length)
-
-		const allLines: string[] = []
-		for (let i = topStart; i < topLines.length; i++) {
-			allLines.push(topLines[i])
-		}
-		for (let i = 0; i < paddingCount; i++) {
-			allLines.push("")
-		}
-		for (const line of bottomLines) {
-			allLines.push(line)
-		}
-
-		return allLines.map((line: string) => pad + line.replace(OSC133_RE, ""))
+		const lines = original(Math.max(1, width - HORIZONTAL_PADDING * 2))
+		return lines.map((line: string) => pad + line.replace(OSC133_RE, ""))
 	}
 }
 

--- a/src/extensions/ui.ts
+++ b/src/extensions/ui.ts
@@ -49,20 +49,17 @@ function renderChildren(children: TUI["children"], start: number, end: number, w
 function patchTuiPadding(tui: TUI) {
 	const pad = " ".repeat(HORIZONTAL_PADDING)
 
+	// Capture the original Container.render so we can fall back to it if
+	// the child structure doesn't match our expectations (e.g. upstream
+	// adds or removes a container).  This avoids silently breaking the
+	// layout and keeps the TUI usable even when the contract changes.
 	const originalRender = tui.render.bind(tui)
-
-	// Track the highest line count we ever emitted.  When content shrinks
-	// (e.g. model selector dismissed, tool output collapsed) we pad back
-	// to this mark so the TUI's diff renderer never sees fewer lines than
-	// before — which would trigger a fullRender(clear=true) that clears
-	// the terminal scrollback and repositions the bottom UI.  Keeping the
-	// count monotonically non-decreasing lets old content scroll into the
-	// terminal scrollback naturally, just like Claude Code.
-	let highWaterMark = 0
 
 	tui.render = (width: number): string[] => {
 		const children = tui.children
 
+		// Guard: if the child structure deviates from what we expect, fall
+		// back to the unpatched render so the TUI remains functional.
 		if (children.length !== EXPECTED_CHILDREN_COUNT) {
 			if (process.env.NODE_ENV !== "production") {
 				console.warn(
@@ -76,17 +73,31 @@ function patchTuiPadding(tui: TUI) {
 		const innerWidth = Math.max(1, width - HORIZONTAL_PADDING * 2)
 		const splitAt = children.length - BOTTOM_CHILDREN_COUNT
 
+		// Render top (scrollable) and bottom (pinned) sections separately
+		// by delegating to each child's own render — the same mechanism
+		// the original Container.render uses.
 		const topLines = renderChildren(children, 0, splitAt, innerWidth)
 		const bottomLines = renderChildren(children, splitAt, children.length, innerWidth)
 
+		// Insert padding between content and bottom components so the prompt
+		// and footer are pushed to the terminal bottom.  This eliminates the
+		// visual jump that occurs when tool output shrinks (e.g. bash collapse),
+		// the working indicator toggling, or a selector dialog opening/closing.
 		const terminalHeight = tui.terminal.rows
 		const totalContent = topLines.length + bottomLines.length
-		const minLines = Math.max(terminalHeight, totalContent, highWaterMark)
-		const paddingCount = minLines - totalContent
+		const paddingCount = Math.max(0, terminalHeight - totalContent)
+
+		// When the bottom section is tall (e.g. model selector open) the total
+		// content can exceed the terminal height.  Truncate the top of the
+		// scrollable section so the rendered output is always exactly
+		// terminalHeight lines — this prevents the TUI diff-renderer from
+		// scrolling/jumping when the tall component is later dismissed.
+		const overflow = Math.max(0, totalContent - terminalHeight)
+		const topStart = Math.min(overflow, topLines.length)
 
 		const allLines: string[] = []
-		for (const line of topLines) {
-			allLines.push(line)
+		for (let i = topStart; i < topLines.length; i++) {
+			allLines.push(topLines[i])
 		}
 		for (let i = 0; i < paddingCount; i++) {
 			allLines.push("")
@@ -94,8 +105,6 @@ function patchTuiPadding(tui: TUI) {
 		for (const line of bottomLines) {
 			allLines.push(line)
 		}
-
-		highWaterMark = allLines.length
 
 		return allLines.map((line: string) => pad + line.replace(OSC133_RE, ""))
 	}


### PR DESCRIPTION
Removing the fixed footer as it is unreliable and adds extra space when you split terminals, open tools, etc.

---
### Kimchi Summary
### What changed
Reverts the fixed footer TUI layout and restores the original simple padding wrapper in `patchTuiPadding`. Also removes an unused type import.

### Why
The bottom-pin layout logic required fragile tracking of terminal height, line-count watermarks, and child ordering to keep the footer stable. Rolling this back defers layout handling to the default TUI renderer.

### Key changes
- `src/extensions/ui.ts`: Removed the bottom-pin layout implementation including `renderChildren`, `highWaterMark`, terminal-height calculations, and hard-coded child counts. `patchTuiPadding` now simply wraps the original `render` with horizontal padding and strips `OSC133` escape sequences.
- `src/extensions/hide-thinking.ts`: Removed unused `ContextEvent` import.

### Impact
The footer, editor, and status containers will no longer remain anchored to the bottom of the terminal viewport; the TUI will render using its default scrolling behavior.