### PR TITLE
ci: add gate to not push rc release to homebrew

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -127,6 +127,7 @@ jobs:
 
   homebrew:
     needs: [release]
+    if: ${{ !contains(github.ref_name, '.rc.') }}
     runs-on: ubuntu-latest
 
     steps:


### PR DESCRIPTION


---
### Kimchi Summary
### What changed
Skips the Homebrew release job for release candidate tags by adding a conditional check on the Git reference name.

### Why
Prevents pre-release or unstable versions from being published to the Homebrew tap when an RC tag is pushed.

### Key changes
- `.github/workflows/release.yml`: Added `if: ${{ !contains(github.ref_name, '.rc.') }}` condition to the `homebrew` job so it only runs for stable releases.

### Impact
Low risk — this is a workflow-only change that avoids publishing RC builds to the Homebrew tap. No migration or breaking changes.