### PR TITLE
NOJIRA: Forward CLI arguments to pnpm run dev in dev script

### DIFF
--- a/scripts/dev-startup.sh
+++ b/scripts/dev-startup.sh
@@ -62,7 +62,7 @@ node ./scripts/copy-resources.js --dev
 
 # Start the harness
 echo -e "${GREEN}🎯 Starting Kimchi harness...${NC}"
-pnpm run dev
+pnpm run dev "$@"
 
 # Remind user to add bun to shell profile if it was just installed
 if [ "$BUN_JUST_INSTALLED" = true ]; then


### PR DESCRIPTION
Makes e.g. `./scripts/dev-startup.sh --yolo` work as expected.

---
### Kimchi Summary
### What changed
Pass command-line arguments supplied to `scripts/dev-startup.sh` through to the underlying `pnpm run dev` command.

### Why
This allows developers to forward flags or additional arguments to the dev server via the startup script, rather than invoking `pnpm run dev` separately.

### Key changes
- `scripts/dev-startup.sh`: changed `pnpm run dev` to `pnpm run dev "$@"` to forward script arguments.