### PR TITLE
NOJIRA: Drop hard 80-char cap in tool headers

### DIFF
--- a/src/extensions/tool-renderer.ts
+++ b/src/extensions/tool-renderer.ts
@@ -11,16 +11,11 @@ import type { TSchema } from "typebox"
 import { ToolBlockView, buildToolCallHeader, getTextContent } from "../components/tool-block.js"
 import { isToolExpanded, registerToolCall } from "../expand-state.js"
 
-function shortenPath(p: string): string {
-	const home = process.env.HOME ?? process.env.USERPROFILE ?? ""
-	return home && p.startsWith(home) ? `~${p.slice(home.length)}` : p
-}
-
 function formatArgs(toolName: string, args: Record<string, unknown>): string {
 	return (() => {
 		switch (toolName) {
 			case "read": {
-				const path = shortenPath(String(args.path ?? ""))
+				const path = String(args.path ?? "")
 				const range =
 					args.offset != null || args.limit != null
 						? ` [${args.offset ?? 0}..${args.limit != null ? Number(args.offset ?? 0) + Number(args.limit) : ""}]`
@@ -29,17 +24,17 @@ function formatArgs(toolName: string, args: Record<string, unknown>): string {
 			}
 			case "edit":
 			case "write":
-				return shortenPath(String(args.path ?? ""))
+				return String(args.path ?? "")
 			case "grep": {
 				const pattern = String(args.pattern ?? "")
-				const path = shortenPath(String(args.path ?? ""))
+				const path = String(args.path ?? "")
 				const include = args.include ? ` --include=${args.include}` : ""
 				return `${pattern} ${path}${include}`.trim()
 			}
 			case "find":
-				return `${String(args.pattern ?? "")} ${shortenPath(String(args.path ?? ""))}`.trim()
+				return `${String(args.pattern ?? "")} ${String(args.path ?? "")}`.trim()
 			case "ls":
-				return shortenPath(String(args.path ?? "."))
+				return String(args.path ?? ".")
 			default:
 				return JSON.stringify(args)
 		}

--- a/src/extensions/tool-renderer.ts
+++ b/src/extensions/tool-renderer.ts
@@ -11,11 +11,16 @@ import type { TSchema } from "typebox"
 import { ToolBlockView, buildToolCallHeader, getTextContent } from "../components/tool-block.js"
 import { isToolExpanded, registerToolCall } from "../expand-state.js"
 
+function shortenPath(p: string): string {
+	const home = process.env.HOME ?? process.env.USERPROFILE ?? ""
+	return home && p.startsWith(home) ? `~${p.slice(home.length)}` : p
+}
+
 function formatArgs(toolName: string, args: Record<string, unknown>): string {
-	const raw = (() => {
+	return (() => {
 		switch (toolName) {
 			case "read": {
-				const path = String(args.path ?? "")
+				const path = shortenPath(String(args.path ?? ""))
 				const range =
 					args.offset != null || args.limit != null
 						? ` [${args.offset ?? 0}..${args.limit != null ? Number(args.offset ?? 0) + Number(args.limit) : ""}]`
@@ -24,22 +29,21 @@ function formatArgs(toolName: string, args: Record<string, unknown>): string {
 			}
 			case "edit":
 			case "write":
-				return String(args.path ?? "")
+				return shortenPath(String(args.path ?? ""))
 			case "grep": {
 				const pattern = String(args.pattern ?? "")
-				const path = String(args.path ?? "")
+				const path = shortenPath(String(args.path ?? ""))
 				const include = args.include ? ` --include=${args.include}` : ""
 				return `${pattern} ${path}${include}`.trim()
 			}
 			case "find":
-				return `${String(args.pattern ?? "")} ${String(args.path ?? "")}`.trim()
+				return `${String(args.pattern ?? "")} ${shortenPath(String(args.path ?? ""))}`.trim()
 			case "ls":
-				return String(args.path ?? ".")
+				return shortenPath(String(args.path ?? "."))
 			default:
 				return JSON.stringify(args)
 		}
 	})()
-	return raw.length > 80 ? `${raw.slice(0, 77)}...` : raw
 }
 
 function formatSummary(toolName: string, content: string, isError: boolean): string {


### PR DESCRIPTION
Before:
<img width="990" height="378" alt="Screenshot 2026-05-10 at 12 50 48" src="https://github.com/user-attachments/assets/007b73cb-2b9e-4321-a3eb-ab4c5badb018" />

After:
<img width="1020" height="375" alt="Screenshot 2026-05-10 at 12 52 20" src="https://github.com/user-attachments/assets/35904af5-1a75-4944-a0ea-7e5d24e03a5e" />

Only truncated if it in fact don't fit the screen
<img width="959" height="262" alt="Screenshot 2026-05-10 at 13 50 35" src="https://github.com/user-attachments/assets/03ba4477-ab68-4183-9253-00d4f1035e0a" />

---
### Kimchi Summary
### What changed
Tool call headers now display the full formatted argument string instead of hard-capping it at 80 characters with an ellipsis.

### Why
The truncation in `formatArgs` was cutting off useful argument details in tool headers.

### Key changes
- `src/extensions/tool-renderer.ts`: Removed the `length > 80` truncation logic and the intermediate `raw` variable from `formatArgs`. The function now returns the complete formatted output for all tool types (`read`, `edit`, etc.).

### Impact
Tool headers may contain significantly longer text strings when arguments are large; UI layout should expect unbounded lengths.