### PR TITLE
NOJIRA: Make user prompt visually distinct from tool output in minimal theme

### DIFF
--- a/src/extensions/kimchi-minimal-tints.ts
+++ b/src/extensions/kimchi-minimal-tints.ts
@@ -35,7 +35,7 @@ const SURFACE_TINTS: ReadonlyArray<[token: string, delta: number, redBias: numbe
 	["toolPendingBg", 6, 0],
 	["toolSuccessBg", 12, 0],
 	["toolErrorBg", 14, 10],
-	["userMessageBg", 14, 0],
+	["userMessageBg", 40, 0],
 	["customMessageBg", 22, 0],
 	["selectedBg", 30, 0],
 ]


### PR DESCRIPTION
Other themes already have this, while in "minimal" theme prompts and tool invocation had the same background.

Before:
<img width="963" height="193" alt="image" src="https://github.com/user-attachments/assets/b82d210a-33f5-4469-bdae-7f8ac35cebf0" />

After:
<img width="956" height="195" alt="image" src="https://github.com/user-attachments/assets/4d747b44-9a45-4de3-8fb9-f649e1d3ebcf" />

---
### Kimchi Summary
### What changed
Increases the background tint delta for user messages in the Kimchi minimal theme so they stand out more clearly from tool messages.

### Why
User prompts were visually similar to tool output because their background tints were close, making it hard to tell user content apart from tool status at a glance.

### Key changes
- `src/extensions/kimchi-minimal-tints.ts`: increased the `userMessageBg` delta value from `14` to `40`.

### Impact
User messages will render with a stronger background tint, creating a clearer visual separation from tool messages in the minimal theme. No breaking changes or migration steps are required.