### PR TITLE
fix(ferment): show Yes/No options during draft planning even with tool calls

### DIFF
--- a/src/extensions/ferment/index.ts
+++ b/src/extensions/ferment/index.ts
@@ -348,9 +348,11 @@ export default function fermentExtension(pi: ExtensionAPI) {
 
 		if (!text.endsWith("?")) return
 
-		// Don't intercept if the turn also had tool calls (mid-execution text)
+		// Don't intercept if the turn also had tool calls (mid-execution text),
+		// except during draft where a propose_phases tool call may accompany the
+		// confirmation question and the user still needs to respond.
 		const hasToolCalls = event.message.content.some((c: { type: string }) => c.type === "toolCall")
-		if (hasToolCalls) return
+		if (f.status !== "draft" && hasToolCalls) return
 
 		const isDraft = f.status === "draft"
 		const yesLabel = isDraft ? "Yes, this looks right" : "Yes, proceed"


### PR DESCRIPTION
## Problem

When using `/ferment` during planning (draft phase), the LLM generates a confirmation message ending in "?" (e.g. "Does this plan look right?") alongside a `propose_phases` tool call. The user was seeing the plan text rendered, but **no Yes/No/Let me say something else options** appeared at the bottom.

## Root Cause

In `src/extensions/ferment/index.ts`, the `turn_end` event handler unconditionally suppressed the `ExtensionSelectorComponent` whenever ANY `toolCall` existed in the assistant message:

```ts
if (hasToolCalls) return
```

During draft planning, the LLM calls `propose_phases` (a tool call) in the **same message** as the confirmation question. This caused the guard to return early, hiding the selector dialog.

## Fix

Narrow the guard to only suppress the selector during **non-draft** phases, where tool calls indicate mid-execution text:

```ts
if (f.status !== "draft" && hasToolCalls) return
```

This preserves the correct behavior during running phases while restoring the Yes/No dialog during planning.

## Verification

- `biome check` passes on the changed file
- The target file is lint-clean (no issues introduced)
