### PR TITLE
LLM-1593 preserve user language after compaction

### DIFF
--- a/src/extensions/context-compactor.test.ts
+++ b/src/extensions/context-compactor.test.ts
@@ -260,6 +260,27 @@ describe("contextCompactorExtension", () => {
 		expect(data.cutoff).toBe(1)
 	})
 
+	it("extends the protected window to include the most recent user message", async () => {
+		const { pi, trigger, entries } = makeMockPI()
+		contextCompactorExtension(pi)
+		await trigger("message_end", makeMessageEndEvent(40_000))
+
+		// oldTool (index 0) is prunable, userMsg (index 1) must be preserved,
+		// and 30 tool results (indices 2-31) fill the protected window.
+		// baseCutoff = 2 would drop userMsg; floor brings it down to 1.
+		const oldTool = makeToolResult("bash", "x".repeat(600))
+		const userMsg = makeUser()
+		const recent = Array.from({ length: 30 }, () => makeToolResult("bash", "x".repeat(600)))
+		const messages = [oldTool, userMsg, ...recent] as ContextEvent["messages"]
+
+		const result = (await trigger("context", { messages })) as { messages: ContextEvent["messages"] }
+		expect(result).toBeDefined()
+		expect(result.messages[1]).toBe(userMsg) // user message preserved
+		expect(entries).toHaveLength(1)
+		const data = entries[0].data as { cutoff: number }
+		expect(data.cutoff).toBe(1)
+	})
+
 	it("does not emit entry when no messages are actually pruned", async () => {
 		const { pi, trigger, entries } = makeMockPI()
 		contextCompactorExtension(pi)

--- a/src/extensions/context-compactor.ts
+++ b/src/extensions/context-compactor.ts
@@ -48,6 +48,21 @@ export function computeCutoff(
 }
 
 /**
+ * Find the index of the most recent message with role "user".
+ * This ensures the LLM always retains the user's language, tone,
+ * and task framing even during long tool-call chains.
+ */
+function findLastUserMessageIndex(messages: ContextEvent["messages"]): number {
+	for (let i = messages.length - 1; i >= 0; i--) {
+		const m = messages[i] as { role?: string }
+		if (m.role === "user") {
+			return i
+		}
+	}
+	return -1
+}
+
+/**
  * Return a pruned copy of a ToolResultMessage.
  * - Large text blocks are replaced with a placeholder (preserves all other fields).
  * - Error outputs keep the last 2000 chars so the agent can still read the crash reason.
@@ -90,8 +105,15 @@ export default function contextCompactorExtension(pi: ExtensionAPI) {
 		if (lastInputTokens < PRUNE_THRESHOLD) return
 
 		const { messages } = event
-		const cutoff = computeCutoff(messages, PROTECT_WINDOW, MAX_PROTECTED_CHARS)
-		if (cutoff === 0) return
+		const baseCutoff = computeCutoff(messages, PROTECT_WINDOW, MAX_PROTECTED_CHARS)
+		if (baseCutoff === 0) return
+
+		// If the most recent user message falls outside the protected window
+		// (i.e. it's before `baseCutoff`), extend the window backward so that
+		// the user message is still visible. This prevents the model from losing
+		// the user's language, tone, or task framing during long tool-call chains.
+		const lastUserIndex = findLastUserMessageIndex(messages)
+		const cutoff = lastUserIndex >= 0 ? Math.min(baseCutoff, lastUserIndex) : baseCutoff
 
 		let prunedCount = 0
 		let totalCharsRemoved = 0


### PR DESCRIPTION
## Problem

During long tool-call chains, the context compactor's protected window (`PROTECT_WINDOW = 30` messages / `MAX_PROTECTED_CHARS = 100k`) could push the user's last message out of view. With 30+ compacted `[compacted: ...]` tool results filling the window, the LLM loses the language and tone anchor from the user's input. The model then drifts into the user's locale — for example, switching into Danish mid-session.

## Fix

Surgically extend the protected window backward so the **most recent user message** is always visible. The model retains whatever language, tone, and framing the user actually chose.

### How it works

```
Before:
  baseCutoff = computeCutoff(...)  // purely window/char based
After:
  baseCutoff = computeCutoff(...)
  lastUserIndex = findLastUserMessageIndex(messages)  // latest role:"user"
  cutoff = min(baseCutoff, lastUserIndex)  // never prune past the user message
```

### Why not other approaches?

| Approach | Problem | This fix |
|---|---|---|
| Hard-code "always English" in system prompt | Breaks legitimate Danish/German/Chinese sessions | Respects user's language |
| Keep last N messages | 100k char budget can still eat user message | User message always visible |
| Inject language annotation during pruning | Complex, fragile, still strips user content | Simple, no annotations needed |

## Changes

- `src/extensions/context-compactor.ts` — floor pruning at the most recent user message
- `src/extensions/context-compactor.test.ts` — coverage for the new floor behavior

## Testing

All 18 context-compactor tests pass.

---
### Kimchi Summary
### What changed
Extends the context compactor's protected window to always retain the most recent user message, preventing it from being pruned during long tool-call chains.

### Why
Without this guard, an extended sequence of tool results could push the user's original message past the pruning boundary, causing the LLM to lose their language, tone, and task framing.

### Key changes
- `src/extensions/context-compactor.ts`: Added `findLastUserMessageIndex()` helper to locate the latest user message in context.
- `src/extensions/context-compactor.ts`: Updated cutoff calculation to `Math.min(baseCutoff, lastUserIndex)`, expanding the protected window backward when necessary.
- `src/extensions/context-compactor.test.ts`: Added test verifying that a user message is preserved even when 30 subsequent tool results fill the protected window.

### Impact
Pruning becomes slightly less aggressive whenever the most recent user message falls outside the standard protected window. No breaking changes or migration steps are required.