### PR TITLE
LLM-1408: Inject Claude Code OTEL env vars via kimchi setup

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
 		"build:binary-linux-arm64": "node scripts/build-binary.js --target linux-arm64",
 		"build:binary-linux-x64": "node scripts/build-binary.js --target linux-x64",
 		"dev": "bun run --preload ./src/set-package-dir.ts src/entry.ts",
+		"dev:setup": "bun run --preload ./src/set-package-dir.ts src/entry.ts setup",
 		"lint": "biome check src/ scripts/",
 		"lint:fix": "biome check --write src/ scripts/",
 		"typecheck": "tsc --noEmit",

--- a/src/commands/claude.ts
+++ b/src/commands/claude.ts
@@ -1,4 +1,5 @@
 import "../integrations/claude-code.js" // side-effect: register integration
+import { readTelemetryConfig } from "../config.js"
 import { claudeCodeEnv } from "../integrations/claude-code.js"
 import { runForeground } from "../integrations/spawn.js"
 import { prepareTool } from "./_helpers.js"
@@ -17,8 +18,9 @@ export async function runClaude(args: string[]): Promise<number> {
 	const prepped = prepareTool("claudecode", "inject")
 	if (!prepped) return 1
 
+	const telemetryEnabled = readTelemetryConfig().enabled
 	try {
-		return await runForeground("claude", args, claudeCodeEnv(prepped.apiKey))
+		return await runForeground("claude", args, claudeCodeEnv(prepped.apiKey, undefined, { telemetryEnabled }))
 	} catch (err) {
 		console.error(`kimchi claude: ${(err as Error).message}`)
 		return 1

--- a/src/integrations/claude-code.test.ts
+++ b/src/integrations/claude-code.test.ts
@@ -20,6 +20,37 @@ describe("claudeCodeEnv", () => {
 		const env = claudeCodeEnv("k", "https://example.com/anthropic")
 		expect(env.ANTHROPIC_BASE_URL).toBe("https://example.com/anthropic")
 	})
+
+	it("includes OTEL env vars when telemetryEnabled is true", () => {
+		const env = claudeCodeEnv("my-key", undefined, { telemetryEnabled: true })
+		expect(env.ANTHROPIC_AUTH_TOKEN).toBe("my-key")
+		expect(env.CLAUDE_CODE_ENABLE_TELEMETRY).toBe("1")
+		expect(env.OTEL_EXPORTER_OTLP_LOGS_ENDPOINT).toBe("https://api.cast.ai/ai-optimizer/v1beta/logs:ingest")
+		expect(env.OTEL_EXPORTER_OTLP_LOGS_HEADERS).toBe("Authorization=Bearer my-key")
+		expect(env.OTEL_EXPORTER_OTLP_LOGS_PROTOCOL).toBe("http/json")
+		expect(env.OTEL_LOGS_EXPORTER).toBe("otlp")
+		expect(env.OTEL_LOGS_EXPORT_INTERVAL).toBe("15000")
+		expect(env.OTEL_EXPORTER_OTLP_METRICS_ENDPOINT).toBe("https://api.cast.ai/ai-optimizer/v1beta/metrics:ingest")
+		expect(env.OTEL_EXPORTER_OTLP_METRICS_HEADERS).toBe("Authorization=Bearer my-key")
+		expect(env.OTEL_EXPORTER_OTLP_METRICS_PROTOCOL).toBe("http/json")
+		expect(env.OTEL_METRICS_EXPORTER).toBe("otlp")
+		expect(env.OTEL_METRIC_EXPORT_INTERVAL).toBe("15000")
+		expect(env.OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE).toBe("cumulative")
+		expect(env.OTEL_LOG_TOOL_DETAILS).toBe("1")
+	})
+
+	it("does not include OTEL env vars when telemetryEnabled is false", () => {
+		const env = claudeCodeEnv("my-key", undefined, { telemetryEnabled: false })
+		expect(env.OTEL_LOGS_EXPORTER).toBeUndefined()
+		expect(env.OTEL_METRICS_EXPORTER).toBeUndefined()
+	})
+
+	it("does not include OTEL env vars when options is omitted (default)", () => {
+		const env = claudeCodeEnv("my-key")
+		expect(env.CLAUDE_CODE_ENABLE_TELEMETRY).toBeUndefined()
+		expect(env.OTEL_LOGS_EXPORTER).toBeUndefined()
+		expect(env.OTEL_METRICS_EXPORTER).toBeUndefined()
+	})
 })
 
 describe("injectClaudeCodeEnv", () => {
@@ -36,6 +67,113 @@ describe("injectClaudeCodeEnv", () => {
 		injectClaudeCodeEnv(env, "https://b", "new")
 		expect(env.ANTHROPIC_API_KEY).toBe("")
 		expect(env.ANTHROPIC_AUTH_TOKEN).toBe("new")
+	})
+
+	it("adds OTEL env vars when telemetryEnabled is true", () => {
+		const env: Record<string, unknown> = {}
+		injectClaudeCodeEnv(env, "https://b", "k", { telemetryEnabled: true })
+		expect(env.OTEL_LOGS_EXPORTER).toBe("otlp")
+		expect(env.OTEL_METRICS_EXPORTER).toBe("otlp")
+		expect(env.OTEL_EXPORTER_OTLP_LOGS_HEADERS).toBe("Authorization=Bearer k")
+	})
+
+	it("does not add OTEL env vars when telemetryEnabled is false", () => {
+		const env: Record<string, unknown> = {}
+		injectClaudeCodeEnv(env, "https://b", "k", { telemetryEnabled: false })
+		expect(env.OTEL_LOGS_EXPORTER).toBeUndefined()
+		expect(env.OTEL_METRICS_EXPORTER).toBeUndefined()
+	})
+
+	it("overwrites previously set OTEL env vars when telemetryEnabled is true", () => {
+		const env: Record<string, unknown> = {
+			OTEL_LOGS_EXPORTER: "old-exporter",
+			OTEL_EXPORTER_OTLP_LOGS_HEADERS: "Authorization=Bearer old-key",
+		}
+		injectClaudeCodeEnv(env, "https://b", "k", { telemetryEnabled: true })
+		expect(env.OTEL_LOGS_EXPORTER).toBe("otlp")
+		expect(env.OTEL_EXPORTER_OTLP_LOGS_HEADERS).toBe("Authorization=Bearer k")
+		expect(env.OTEL_METRICS_EXPORTER).toBe("otlp")
+	})
+
+	it("removes matching OTEL endpoint/header vars when telemetryEnabled is false", () => {
+		const env: Record<string, unknown> = {
+			FOO: "bar",
+			CLAUDE_CODE_ENABLE_TELEMETRY: "1",
+			OTEL_EXPORTER_OTLP_LOGS_ENDPOINT: "https://api.cast.ai/ai-optimizer/v1beta/logs:ingest",
+			OTEL_EXPORTER_OTLP_LOGS_HEADERS: "Authorization=Bearer k",
+			OTEL_EXPORTER_OTLP_METRICS_ENDPOINT: "https://api.cast.ai/ai-optimizer/v1beta/metrics:ingest",
+			OTEL_EXPORTER_OTLP_METRICS_HEADERS: "Authorization=Bearer k",
+		}
+		injectClaudeCodeEnv(env, "https://b", "k", { telemetryEnabled: false })
+		expect(env.FOO).toBe("bar")
+		expect(env.CLAUDE_CODE_ENABLE_TELEMETRY).toBe("1")
+		expect(env.OTEL_EXPORTER_OTLP_LOGS_ENDPOINT).toBeUndefined()
+		expect(env.OTEL_EXPORTER_OTLP_LOGS_HEADERS).toBeUndefined()
+		expect(env.OTEL_EXPORTER_OTLP_METRICS_ENDPOINT).toBeUndefined()
+		expect(env.OTEL_EXPORTER_OTLP_METRICS_HEADERS).toBeUndefined()
+	})
+
+	it("preserves custom OTEL endpoint/header vars when telemetryEnabled is false", () => {
+		const env: Record<string, unknown> = {
+			FOO: "bar",
+			OTEL_EXPORTER_OTLP_LOGS_ENDPOINT: "https://my-otel.com/logs",
+			OTEL_EXPORTER_OTLP_LOGS_HEADERS: "Authorization=Bearer my-token",
+			OTEL_EXPORTER_OTLP_METRICS_ENDPOINT: "https://my-otel.com/metrics",
+			OTEL_EXPORTER_OTLP_METRICS_HEADERS: "X-Api-Key=abc",
+		}
+		injectClaudeCodeEnv(env, "https://b", "k", { telemetryEnabled: false })
+		expect(env.FOO).toBe("bar")
+		expect(env.OTEL_EXPORTER_OTLP_LOGS_ENDPOINT).toBe("https://my-otel.com/logs")
+		expect(env.OTEL_EXPORTER_OTLP_LOGS_HEADERS).toBe("Authorization=Bearer my-token")
+		expect(env.OTEL_EXPORTER_OTLP_METRICS_ENDPOINT).toBe("https://my-otel.com/metrics")
+		expect(env.OTEL_EXPORTER_OTLP_METRICS_HEADERS).toBe("X-Api-Key=abc")
+	})
+
+	it("removes Cast AI endpoint but keeps custom headers when telemetryEnabled is false", () => {
+		const env: Record<string, unknown> = {
+			OTEL_EXPORTER_OTLP_LOGS_ENDPOINT: "https://api.cast.ai/ai-optimizer/v1beta/logs:ingest",
+			OTEL_EXPORTER_OTLP_LOGS_HEADERS: "X-Api-Key=custom",
+			OTEL_EXPORTER_OTLP_METRICS_ENDPOINT: "https://api.cast.ai/ai-optimizer/v1beta/metrics:ingest",
+			OTEL_EXPORTER_OTLP_METRICS_HEADERS: "Authorization=Basic base64",
+		}
+		injectClaudeCodeEnv(env, "https://b", "k", { telemetryEnabled: false })
+		expect(env.OTEL_EXPORTER_OTLP_LOGS_ENDPOINT).toBeUndefined()
+		expect(env.OTEL_EXPORTER_OTLP_LOGS_HEADERS).toBe("X-Api-Key=custom")
+		expect(env.OTEL_EXPORTER_OTLP_METRICS_ENDPOINT).toBeUndefined()
+		expect(env.OTEL_EXPORTER_OTLP_METRICS_HEADERS).toBe("Authorization=Basic base64")
+	})
+
+	it("preserves all non-endpoint OTEL vars when telemetryEnabled is false", () => {
+		const env: Record<string, unknown> = {
+			OTEL_EXPORTER_OTLP_LOGS_ENDPOINT: "https://api.cast.ai/ai-optimizer/v1beta/logs:ingest",
+			OTEL_EXPORTER_OTLP_LOGS_HEADERS: "Authorization=Bearer old-key",
+			OTEL_EXPORTER_OTLP_LOGS_PROTOCOL: "http/json",
+			OTEL_LOGS_EXPORTER: "otlp",
+			OTEL_LOGS_EXPORT_INTERVAL: "15000",
+			OTEL_EXPORTER_OTLP_METRICS_ENDPOINT: "https://api.cast.ai/ai-optimizer/v1beta/metrics:ingest",
+			OTEL_EXPORTER_OTLP_METRICS_HEADERS: "Authorization=Bearer old-key",
+			OTEL_EXPORTER_OTLP_METRICS_PROTOCOL: "http/json",
+			OTEL_METRICS_EXPORTER: "otlp",
+			OTEL_METRIC_EXPORT_INTERVAL: "15000",
+			OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE: "cumulative",
+			OTEL_LOG_TOOL_DETAILS: "1",
+		}
+		injectClaudeCodeEnv(env, "https://b", "k", { telemetryEnabled: false })
+		// The 4 Cast-AI-specific endpoint+header keys are removed
+		expect(env.OTEL_EXPORTER_OTLP_LOGS_ENDPOINT).toBeUndefined()
+		expect(env.OTEL_EXPORTER_OTLP_LOGS_HEADERS).toBeUndefined()
+		expect(env.OTEL_EXPORTER_OTLP_METRICS_ENDPOINT).toBeUndefined()
+		expect(env.OTEL_EXPORTER_OTLP_METRICS_HEADERS).toBeUndefined()
+
+		// The other 9 OTEL vars remain intact
+		expect(env.OTEL_EXPORTER_OTLP_LOGS_PROTOCOL).toBe("http/json")
+		expect(env.OTEL_LOGS_EXPORTER).toBe("otlp")
+		expect(env.OTEL_LOGS_EXPORT_INTERVAL).toBe("15000")
+		expect(env.OTEL_EXPORTER_OTLP_METRICS_PROTOCOL).toBe("http/json")
+		expect(env.OTEL_METRICS_EXPORTER).toBe("otlp")
+		expect(env.OTEL_METRIC_EXPORT_INTERVAL).toBe("15000")
+		expect(env.OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE).toBe("cumulative")
+		expect(env.OTEL_LOG_TOOL_DETAILS).toBe("1")
 	})
 })
 
@@ -86,6 +224,7 @@ describe("claude-code tool registration", () => {
 		expect(written.env.ANTHROPIC_AUTH_TOKEN).toBe("test-key")
 		expect(written.env.ANTHROPIC_API_KEY).toBe("")
 		expect(written.env.ANTHROPIC_BASE_URL).toBe("https://llm.kimchi.dev/anthropic")
+		expect(written.env.OTEL_LOGS_EXPORTER).toBeUndefined()
 	})
 
 	it("write() creates the directory and file when they don't exist yet", async () => {
@@ -96,6 +235,148 @@ describe("claude-code tool registration", () => {
 		const settings = join(scratchHome, ".claude", "settings.json")
 		const written = JSON.parse(readFileSync(settings, "utf-8"))
 		expect(written.env.ANTHROPIC_AUTH_TOKEN).toBe("fresh-key")
+		expect(written.env.OTEL_LOGS_EXPORTER).toBeUndefined()
+	})
+
+	it("write() includes OTEL env vars when telemetryEnabled is true", async () => {
+		const tool = byId("claudecode")
+		expect(tool).toBeDefined()
+		await tool?.write("global", "key-123", { telemetryEnabled: true })
+
+		const settings = join(scratchHome, ".claude", "settings.json")
+		const written = JSON.parse(readFileSync(settings, "utf-8"))
+		expect(written.env.OTEL_LOGS_EXPORTER).toBe("otlp")
+		expect(written.env.OTEL_METRICS_EXPORTER).toBe("otlp")
+		expect(written.env.OTEL_EXPORTER_OTLP_LOGS_HEADERS).toBe("Authorization=Bearer key-123")
+	})
+
+	it("write() does not include OTEL env vars when telemetryEnabled is false", async () => {
+		const tool = byId("claudecode")
+		expect(tool).toBeDefined()
+		await tool?.write("global", "key-456", { telemetryEnabled: false })
+
+		const settings = join(scratchHome, ".claude", "settings.json")
+		const written = JSON.parse(readFileSync(settings, "utf-8"))
+		expect(written.env.OTEL_LOGS_EXPORTER).toBeUndefined()
+		expect(written.env.OTEL_METRICS_EXPORTER).toBeUndefined()
+	})
+
+	it("write() removes matching Cast AI OTEL vars when telemetry is disabled after previously enabled", async () => {
+		const settings = join(scratchHome, ".claude", "settings.json")
+		mkdirSync(join(scratchHome, ".claude"), { recursive: true })
+		writeFileSync(
+			settings,
+			JSON.stringify({
+				env: {
+					ANTHROPIC_AUTH_TOKEN: "old-key",
+					CLAUDE_CODE_ENABLE_TELEMETRY: "1",
+					OTEL_EXPORTER_OTLP_LOGS_ENDPOINT: "https://api.cast.ai/ai-optimizer/v1beta/logs:ingest",
+					OTEL_EXPORTER_OTLP_LOGS_HEADERS: "Authorization=Bearer old-key",
+					OTEL_EXPORTER_OTLP_METRICS_ENDPOINT: "https://api.cast.ai/ai-optimizer/v1beta/metrics:ingest",
+					OTEL_EXPORTER_OTLP_METRICS_HEADERS: "Authorization=Bearer old-key",
+					CUSTOM_FLAG: "yes",
+				},
+			}),
+			"utf-8",
+		)
+
+		const tool = byId("claudecode")
+		expect(tool).toBeDefined()
+		await tool?.write("global", "new-key", { telemetryEnabled: false })
+
+		const written = JSON.parse(readFileSync(settings, "utf-8"))
+		expect(written.env.ANTHROPIC_AUTH_TOKEN).toBe("new-key")
+		expect(written.env.CUSTOM_FLAG).toBe("yes")
+		expect(written.env.CLAUDE_CODE_ENABLE_TELEMETRY).toBe("1")
+		expect(written.env.OTEL_EXPORTER_OTLP_LOGS_ENDPOINT).toBeUndefined()
+		expect(written.env.OTEL_EXPORTER_OTLP_LOGS_HEADERS).toBeUndefined()
+		expect(written.env.OTEL_EXPORTER_OTLP_METRICS_ENDPOINT).toBeUndefined()
+		expect(written.env.OTEL_EXPORTER_OTLP_METRICS_HEADERS).toBeUndefined()
+	})
+
+	it("write() only removes the 4 Cast-AI-specific OTEL vars after previously enabled", async () => {
+		const settings = join(scratchHome, ".claude", "settings.json")
+		mkdirSync(join(scratchHome, ".claude"), { recursive: true })
+		writeFileSync(
+			settings,
+			JSON.stringify({
+				env: {
+					ANTHROPIC_AUTH_TOKEN: "old-key",
+					CLAUDE_CODE_ENABLE_TELEMETRY: "1",
+					OTEL_EXPORTER_OTLP_LOGS_ENDPOINT: "https://api.cast.ai/ai-optimizer/v1beta/logs:ingest",
+					OTEL_EXPORTER_OTLP_LOGS_HEADERS: "Authorization=Bearer old-key",
+					OTEL_EXPORTER_OTLP_LOGS_PROTOCOL: "http/json",
+					OTEL_LOGS_EXPORTER: "otlp",
+					OTEL_LOGS_EXPORT_INTERVAL: "15000",
+					OTEL_EXPORTER_OTLP_METRICS_ENDPOINT: "https://api.cast.ai/ai-optimizer/v1beta/metrics:ingest",
+					OTEL_EXPORTER_OTLP_METRICS_HEADERS: "Authorization=Bearer old-key",
+					OTEL_EXPORTER_OTLP_METRICS_PROTOCOL: "http/json",
+					OTEL_METRICS_EXPORTER: "otlp",
+					OTEL_METRIC_EXPORT_INTERVAL: "15000",
+					OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE: "cumulative",
+					OTEL_LOG_TOOL_DETAILS: "1",
+					CUSTOM_FLAG: "yes",
+				},
+			}),
+			"utf-8",
+		)
+
+		const tool = byId("claudecode")
+		expect(tool).toBeDefined()
+		await tool?.write("global", "new-key", { telemetryEnabled: false })
+
+		const written = JSON.parse(readFileSync(settings, "utf-8"))
+		// The 4 Cast-AI-specific keys should be gone
+		expect(written.env.OTEL_EXPORTER_OTLP_LOGS_ENDPOINT).toBeUndefined()
+		expect(written.env.OTEL_EXPORTER_OTLP_LOGS_HEADERS).toBeUndefined()
+		expect(written.env.OTEL_EXPORTER_OTLP_METRICS_ENDPOINT).toBeUndefined()
+		expect(written.env.OTEL_EXPORTER_OTLP_METRICS_HEADERS).toBeUndefined()
+
+		// Base key and custom flag preserved
+		expect(written.env.ANTHROPIC_AUTH_TOKEN).toBe("new-key")
+		expect(written.env.CUSTOM_FLAG).toBe("yes")
+
+		// All the other OTEL vars should still be present
+		expect(written.env.CLAUDE_CODE_ENABLE_TELEMETRY).toBe("1")
+		expect(written.env.OTEL_EXPORTER_OTLP_LOGS_PROTOCOL).toBe("http/json")
+		expect(written.env.OTEL_LOGS_EXPORTER).toBe("otlp")
+		expect(written.env.OTEL_LOGS_EXPORT_INTERVAL).toBe("15000")
+		expect(written.env.OTEL_EXPORTER_OTLP_METRICS_PROTOCOL).toBe("http/json")
+		expect(written.env.OTEL_METRICS_EXPORTER).toBe("otlp")
+		expect(written.env.OTEL_METRIC_EXPORT_INTERVAL).toBe("15000")
+		expect(written.env.OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE).toBe("cumulative")
+		expect(written.env.OTEL_LOG_TOOL_DETAILS).toBe("1")
+	})
+
+	it("write() preserves custom OTEL vars when telemetry is disabled", async () => {
+		const settings = join(scratchHome, ".claude", "settings.json")
+		mkdirSync(join(scratchHome, ".claude"), { recursive: true })
+		writeFileSync(
+			settings,
+			JSON.stringify({
+				env: {
+					ANTHROPIC_AUTH_TOKEN: "old-key",
+					OTEL_EXPORTER_OTLP_LOGS_ENDPOINT: "https://my-otel.com/logs",
+					OTEL_EXPORTER_OTLP_LOGS_HEADERS: "X-Api-Key=custom",
+					OTEL_EXPORTER_OTLP_METRICS_ENDPOINT: "https://my-otel.com/metrics",
+					OTEL_EXPORTER_OTLP_METRICS_HEADERS: "Authorization=Bearer my-token",
+					CUSTOM_FLAG: "yes",
+				},
+			}),
+			"utf-8",
+		)
+
+		const tool = byId("claudecode")
+		expect(tool).toBeDefined()
+		await tool?.write("global", "new-key", { telemetryEnabled: false })
+
+		const written = JSON.parse(readFileSync(settings, "utf-8"))
+		expect(written.env.ANTHROPIC_AUTH_TOKEN).toBe("new-key")
+		expect(written.env.CUSTOM_FLAG).toBe("yes")
+		expect(written.env.OTEL_EXPORTER_OTLP_LOGS_ENDPOINT).toBe("https://my-otel.com/logs")
+		expect(written.env.OTEL_EXPORTER_OTLP_LOGS_HEADERS).toBe("X-Api-Key=custom")
+		expect(written.env.OTEL_EXPORTER_OTLP_METRICS_ENDPOINT).toBe("https://my-otel.com/metrics")
+		expect(written.env.OTEL_EXPORTER_OTLP_METRICS_HEADERS).toBe("Authorization=Bearer my-token")
 	})
 
 	it("write() rejects an empty API key", async () => {

--- a/src/integrations/claude-code.ts
+++ b/src/integrations/claude-code.ts
@@ -1,8 +1,10 @@
 import { mkdirSync } from "node:fs"
 import { dirname } from "node:path"
+import { log } from "@clack/prompts"
 import { readJson, writeJson } from "../config/json.js"
 import { resolveScopePath } from "../config/scope.js"
 import type { ConfigScope } from "../config/scope.js"
+import { confirm } from "../setup-wizard/prompt.js"
 import { ANTHROPIC_BASE_URL } from "./constants.js"
 import { detectBinaryFactory } from "./detect.js"
 import { register } from "./registry.js"
@@ -10,19 +12,42 @@ import type { ToolDefinition } from "./types.js"
 
 const CLAUDE_CONFIG_PATH = "~/.claude/settings.json"
 
+const TELEMETRY_LOGS_ENDPOINT = "https://api.cast.ai/ai-optimizer/v1beta/logs:ingest"
+const TELEMETRY_METRICS_ENDPOINT = "https://api.cast.ai/ai-optimizer/v1beta/metrics:ingest"
+
 /**
  * Build the env-var map Claude Code reads from `~/.claude/settings.json`'s
  * `env` block. Setting ANTHROPIC_API_KEY to "" is important — Claude Code
  * picks the first non-empty of (ANTHROPIC_API_KEY, ANTHROPIC_AUTH_TOKEN)
  * and we want it to use AUTH_TOKEN with our key.
  */
-export function claudeCodeEnv(apiKey: string, baseUrl: string = ANTHROPIC_BASE_URL): Record<string, string> {
-	return {
+export function claudeCodeEnv(
+	apiKey: string,
+	baseUrl: string = ANTHROPIC_BASE_URL,
+	options?: { telemetryEnabled?: boolean },
+): Record<string, string> {
+	const env: Record<string, string> = {
 		ANTHROPIC_BASE_URL: baseUrl,
 		ANTHROPIC_API_KEY: "",
 		ANTHROPIC_AUTH_TOKEN: apiKey,
 		CLAUDE_CODE_DISABLE_EXPERIMENTAL_BETAS: "1",
 	}
+	if (options?.telemetryEnabled) {
+		env.CLAUDE_CODE_ENABLE_TELEMETRY = "1"
+		env.OTEL_EXPORTER_OTLP_LOGS_ENDPOINT = TELEMETRY_LOGS_ENDPOINT
+		env.OTEL_EXPORTER_OTLP_LOGS_HEADERS = `Authorization=Bearer ${apiKey}`
+		env.OTEL_EXPORTER_OTLP_LOGS_PROTOCOL = "http/json"
+		env.OTEL_LOGS_EXPORTER = "otlp"
+		env.OTEL_LOGS_EXPORT_INTERVAL = "15000"
+		env.OTEL_EXPORTER_OTLP_METRICS_ENDPOINT = TELEMETRY_METRICS_ENDPOINT
+		env.OTEL_EXPORTER_OTLP_METRICS_HEADERS = `Authorization=Bearer ${apiKey}`
+		env.OTEL_EXPORTER_OTLP_METRICS_PROTOCOL = "http/json"
+		env.OTEL_METRICS_EXPORTER = "otlp"
+		env.OTEL_METRIC_EXPORT_INTERVAL = "15000"
+		env.OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE = "cumulative"
+		env.OTEL_LOG_TOOL_DETAILS = "1"
+	}
+	return env
 }
 
 /**
@@ -31,14 +56,89 @@ export function claudeCodeEnv(apiKey: string, baseUrl: string = ANTHROPIC_BASE_U
  * to compute the env block without writing to disk (e.g. the inject-mode
  * launcher in `kimchi claude`).
  */
-export function injectClaudeCodeEnv(env: Record<string, unknown>, baseUrl: string, apiKey: string): void {
-	const pairs = claudeCodeEnv(apiKey, baseUrl)
-	for (const [k, v] of Object.entries(pairs)) {
-		env[k] = v
+function removeCastAiOtelVar(
+	env: Record<string, unknown>,
+	endpointKey: string,
+	expectedEndpoint: string,
+	headerKey: string,
+): void {
+	if (env[endpointKey] !== expectedEndpoint) return
+	env[endpointKey] = undefined
+	const headers = env[headerKey]
+	if (typeof headers === "string" && headers.startsWith("Authorization=Bearer ")) {
+		env[headerKey] = undefined
 	}
 }
 
-async function writeClaudeCode(scope: ConfigScope, apiKey: string): Promise<void> {
+export function injectClaudeCodeEnv(
+	env: Record<string, unknown>,
+	baseUrl: string,
+	apiKey: string,
+	options?: { telemetryEnabled?: boolean },
+): void {
+	const pairs = claudeCodeEnv(apiKey, baseUrl, options)
+	for (const [k, v] of Object.entries(pairs)) {
+		env[k] = v
+	}
+	if (!options?.telemetryEnabled) {
+		removeCastAiOtelVar(
+			env,
+			"OTEL_EXPORTER_OTLP_LOGS_ENDPOINT",
+			TELEMETRY_LOGS_ENDPOINT,
+			"OTEL_EXPORTER_OTLP_LOGS_HEADERS",
+		)
+		removeCastAiOtelVar(
+			env,
+			"OTEL_EXPORTER_OTLP_METRICS_ENDPOINT",
+			TELEMETRY_METRICS_ENDPOINT,
+			"OTEL_EXPORTER_OTLP_METRICS_HEADERS",
+		)
+	}
+}
+
+interface EnvDiff {
+	kind: "add" | "remove" | "change"
+	key: string
+	old?: string
+	new?: string
+}
+
+function envDiff(before: Record<string, unknown>, after: Record<string, unknown>): EnvDiff[] {
+	const diffs: ReturnType<typeof envDiff> = []
+	const allKeys = new Set([...Object.keys(before), ...Object.keys(after)])
+	for (const key of allKeys) {
+		const a = String(before[key] ?? "")
+		const b = String(after[key] ?? "")
+		if (a === b) continue
+
+		if (before[key] === undefined || !(key in before)) {
+			diffs.push({ kind: "add", key, new: b })
+		} else if (after[key] === undefined || !(key in after)) {
+			diffs.push({ kind: "remove", key, old: a })
+		} else {
+			diffs.push({ kind: "change", key, old: a, new: b })
+		}
+	}
+	return diffs
+}
+
+function formatDiff(diffs: EnvDiff[]): string {
+	if (diffs.length === 0) return "No changes."
+
+	const lines: string[] = []
+	for (const d of diffs) {
+		if (d.kind === "add") lines.push(`  + ${d.key}: ${d.new}`)
+		else if (d.kind === "remove") lines.push(`  - ${d.key}: ${d.old}`)
+		else lines.push(`  ~ ${d.key}: ${d.old} → ${d.new}`)
+	}
+	return lines.join("\n")
+}
+
+async function writeClaudeCode(
+	scope: ConfigScope,
+	apiKey: string,
+	options?: { telemetryEnabled?: boolean },
+): Promise<void> {
 	if (!apiKey) {
 		throw new Error("API key not configured")
 	}
@@ -49,11 +149,36 @@ async function writeClaudeCode(scope: ConfigScope, apiKey: string): Promise<void
 	const existing = readJson(path)
 	const envBlock =
 		existing.env && typeof existing.env === "object" && !Array.isArray(existing.env)
-			? (existing.env as Record<string, unknown>)
+			? structuredClone
+				? (structuredClone(existing.env) as Record<string, unknown>)
+				: (JSON.parse(JSON.stringify(existing.env)) as Record<string, unknown>)
 			: {}
-	injectClaudeCodeEnv(envBlock, ANTHROPIC_BASE_URL, apiKey)
-	existing.env = envBlock
 
+	const before = structuredClone
+		? structuredClone(envBlock)
+		: (JSON.parse(JSON.stringify(envBlock)) as Record<string, unknown>)
+	injectClaudeCodeEnv(envBlock, ANTHROPIC_BASE_URL, apiKey, options)
+	const diffs = envDiff(before, envBlock)
+
+	if (diffs.length > 0 && process.stdin?.isTTY) {
+		log.message(`Claude Code environment variable changes (${path}):`)
+		log.message(formatDiff(diffs))
+
+		const answer = await confirm({
+			message: "Apply these changes to Claude Code environment variables?",
+			initialValue: true,
+			backable: false,
+		})
+
+		if (answer.kind === "cancel") {
+			throw new Error("User cancelled the settings update.")
+		}
+		if (answer.kind === "next" && !answer.value) {
+			throw new Error("User declined the settings update.")
+		}
+	}
+
+	existing.env = envBlock
 	writeJson(path, existing)
 }
 

--- a/src/integrations/cursor.ts
+++ b/src/integrations/cursor.ts
@@ -110,7 +110,11 @@ export function mergeCursorConfig(storage: Record<string, unknown>): Record<stri
  * equivalent, so the `scope` argument is accepted for the ToolDefinition
  * contract but ignored — the writer always targets the global path.
  */
-async function writeCursor(_scope: ConfigScope, apiKey: string): Promise<void> {
+async function writeCursor(
+	_scope: ConfigScope,
+	apiKey: string,
+	_options?: { telemetryEnabled?: boolean },
+): Promise<void> {
 	if (!apiKey) {
 		throw new Error("API key not configured")
 	}

--- a/src/integrations/gsd2.ts
+++ b/src/integrations/gsd2.ts
@@ -101,7 +101,7 @@ function detectGsd2(): boolean {
 	return findBinary("gsd") !== undefined || findBinary("gsd-cli") !== undefined
 }
 
-async function writeGsd2(scope: ConfigScope, apiKey: string): Promise<void> {
+async function writeGsd2(scope: ConfigScope, apiKey: string, _options?: { telemetryEnabled?: boolean }): Promise<void> {
 	if (!apiKey) {
 		throw new Error("API key not configured")
 	}

--- a/src/integrations/openclaw.ts
+++ b/src/integrations/openclaw.ts
@@ -176,7 +176,11 @@ async function writeOpenClawDirect(scope: ConfigScope, apiKey: string): Promise<
 	writeOpenClawEnv(apiKey)
 }
 
-async function writeOpenClaw(scope: ConfigScope, apiKey: string): Promise<void> {
+async function writeOpenClaw(
+	scope: ConfigScope,
+	apiKey: string,
+	_options?: { telemetryEnabled?: boolean },
+): Promise<void> {
 	if (!apiKey) {
 		throw new Error("API key not configured")
 	}

--- a/src/integrations/opencode.ts
+++ b/src/integrations/opencode.ts
@@ -157,7 +157,11 @@ export function buildUpdatedPlugins(inputs: PluginUpdateInputs): PluginUpdateRes
 	return { plugins: [...filtered, updatedEntry], skippedKimchiPlugin: false }
 }
 
-async function writeOpenCode(scope: ConfigScope, apiKey: string): Promise<void> {
+async function writeOpenCode(
+	scope: ConfigScope,
+	apiKey: string,
+	_options?: { telemetryEnabled?: boolean },
+): Promise<void> {
 	if (!apiKey) {
 		throw new Error("API key not configured")
 	}

--- a/src/integrations/types.ts
+++ b/src/integrations/types.ts
@@ -23,5 +23,5 @@ export interface ToolDefinition {
 	/** Detect whether the tool is installed locally (PATH probe, well-known dir, etc). */
 	isInstalled: () => boolean
 	/** Write configuration so this tool talks to kimchi's LLM endpoints. */
-	write: (scope: ConfigScope, apiKey: string) => Promise<void>
+	write: (scope: ConfigScope, apiKey: string, options?: { telemetryEnabled?: boolean }) => Promise<void>
 }

--- a/src/setup-wizard/steps/done.test.ts
+++ b/src/setup-wizard/steps/done.test.ts
@@ -63,7 +63,7 @@ describe("runDoneStep", () => {
 		const writeSpy = vi.spyOn(tool, "write").mockResolvedValue()
 
 		const outcome = await runDoneStep(baseState())
-		expect(writeSpy).toHaveBeenCalledWith("global", "test-key")
+		expect(writeSpy).toHaveBeenCalledWith("global", "test-key", { telemetryEnabled: true })
 		expect(outcome.successes).toEqual(["Claude Code"])
 		expect(outcome.failures).toEqual([])
 

--- a/src/setup-wizard/steps/done.ts
+++ b/src/setup-wizard/steps/done.ts
@@ -37,11 +37,13 @@ export async function runDoneStep(state: WizardState): Promise<ApplyOutcome> {
 		if (state.mode === "inject") {
 			// No disk writes in inject mode — the launcher sets env per-process.
 			outcome.successes.push(tool.name)
-			log.info(`${tool.name}: ready (launch via 'kimchi ${id}')`)
+			// 'claudecode' is the tool ID but the CLI command is 'claude'
+			const launchCmd = id === "claudecode" ? "claude" : id
+			log.info(`${tool.name}: ready (launch via 'kimchi ${launchCmd}')`)
 			continue
 		}
 		try {
-			await tool.write(state.scope, state.apiKey)
+			await tool.write(state.scope, state.apiKey, { telemetryEnabled: state.telemetryEnabled })
 			outcome.successes.push(tool.name)
 			log.success(`${tool.name}: configured`)
 		} catch (err) {
@@ -67,7 +69,9 @@ export async function runDoneStep(state: WizardState): Promise<ApplyOutcome> {
 		`Scope: ${state.scope}`,
 		`Telemetry: ${state.telemetryEnabled ? "enabled" : "disabled"}`,
 		outcome.successes.length > 0 ? `Configured: ${outcome.successes.join(", ")}` : "",
-		outcome.failures.length > 0 ? `Failed: ${outcome.failures.map((f) => f.id).join(", ")}` : "",
+		outcome.failures.length > 0
+			? `Failed: ${outcome.failures.map((f) => byId(f.id as ToolId)?.name ?? f.id).join(", ")}`
+			: "",
 		shellExport.path ? `${KIMCHI_API_KEY_ENV}: exported to ${shellExport.path}` : "",
 	].filter((l) => l.length > 0)
 


### PR DESCRIPTION
When telemetry is enabled during `kimchi setup`, inject 13 OpenTelemetry env vars into Claude Code's settings.json so Claude Code reports its own usage telemetry back to Cast AI's endpoints.

- claudeCodeEnv() adds OTEL env vars when telemetryEnabled=true
- Conditional cleanup: removes 4 Cast-AI-specific endpoint/header keys when telemetry is disabled, preserving custom user OTEL configs
- Diff preview before writing to claude's settings.json
- Launch hint: 'kimchi claude' instead of 'kimchi claudecode'

---
### Kimchi Summary
### What changed

Adds conditional OpenTelemetry environment variable injection for Claude Code based on the user's telemetry preference. When enabled, it routes Claude Code logs and metrics to Cast AI telemetry endpoints; when disabled, it strips previously injected Cast AI OTEL variables while preserving custom user settings. It also introduces a `dev:setup` script and adds an interactive confirmation prompt before modifying Claude Code's `settings.json`.

### Why

To support centralized telemetry collection for Claude Code through both the setup wizard and runtime launcher, and to prevent stale Cast AI endpoint configuration from lingering when telemetry is turned off.

### Key changes

- `package.json`: Adds `dev:setup` script for running the setup entry point in development.
- `src/integrations/types.ts`: Updates `ToolDefinition.write` signature to accept an optional `telemetryEnabled` option.
- `src/integrations/claude-code.ts`: Extends `claudeCodeEnv` and `injectClaudeCodeEnv` to inject Cast AI OTEL exporter endpoints and headers when `telemetryEnabled` is `true`.
- `src/integrations/claude-code.ts`: Adds cleanup logic that removes only Cast AI-specific OTEL endpoint and bearer-token header variables when telemetry is disabled, leaving unrelated OTEL configuration intact.
- `src/integrations/claude-code.ts`: Displays a diff of environment variable changes and requires user confirmation before writing to `~/.claude/settings.json` in a TTY.
- `src/commands/claude.ts`: Reads `telemetryEnabled` via `readTelemetryConfig` and passes it to the Claude Code environment builder.
- `src/setup-wizard/steps/done.ts`: Forwards `state.telemetryEnabled` to tool `write()` calls and fixes the launch command hint for `claudecode` and failure message names.
- `src/integrations/claude-code.test.ts`: Adds tests for OTEL variable injection, selective cleanup, and interactive write behavior.
- `src/setup-wizard/steps/done.test.ts`: Updates expectations to assert `telemetryEnabled` is passed to tool writers.

### Impact

- Users will be prompted to confirm Claude Code environment variable changes when running `kimchi setup` or related flows in an interactive terminal.
- Disabling telemetry no longer leaves orphaned Cast AI OTEL configuration in Claude Code's environment; those specific variables are removed automatically on the next configuration update.