### PR TITLE
NOJIRA: Install canary

### DIFF
--- a/.github/workflows/canary.yml
+++ b/.github/workflows/canary.yml
@@ -121,13 +121,13 @@ jobs:
         run: pnpm run build:binary
 
       - name: Package binary
-        run: tar -czf kimchi-code-canary_${{ matrix.os }}_${{ matrix.arch }}.tar.gz -C dist bin share
+        run: tar -czf kimchi_${{ matrix.os }}_${{ matrix.arch }}.tar.gz -C dist bin share
 
       - name: Upload artifact
         uses: actions/upload-artifact@v4
         with:
-          name: kimchi-code-canary_${{ matrix.os }}_${{ matrix.arch }}
-          path: kimchi-code-canary_${{ matrix.os }}_${{ matrix.arch }}.tar.gz
+          name: kimchi_${{ matrix.os }}_${{ matrix.arch }}
+          path: kimchi_${{ matrix.os }}_${{ matrix.arch }}.tar.gz
 
   smoke-test:
     needs: [preflight, build]
@@ -144,12 +144,12 @@ jobs:
       - name: Download linux binary
         uses: actions/download-artifact@v4
         with:
-          name: kimchi-code-canary_linux_amd64
+          name: kimchi_linux_amd64
 
       - name: Extract binary into dist/
         run: |
           mkdir -p dist
-          tar -xzf kimchi-code-canary_linux_amd64.tar.gz -C dist
+          tar -xzf kimchi_linux_amd64.tar.gz -C dist
 
       - name: Smoke tests
         run: pnpm run test:smoke
@@ -176,7 +176,7 @@ jobs:
       - name: Generate checksums
         run: |
           cd artifacts
-          sha256sum kimchi-code-canary_*.tar.gz > checksums.txt
+          sha256sum kimchi_*.tar.gz > checksums.txt
 
       - name: Build release notes
         env:
@@ -211,5 +211,5 @@ jobs:
             --notes-file release-notes.md \
             --prerelease \
             --target "$GITHUB_SHA" \
-            artifacts/kimchi-code-canary_*.tar.gz \
+            artifacts/kimchi_*.tar.gz \
             artifacts/checksums.txt

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@kimchi-dev/cli",
-	"version": "0.1.0",
+	"version": "0.0.0",
 	"description": "kimchi — a coding agent CLI powered by Cast AI",
 	"type": "module",
 	"license": "MIT",

--- a/src/commands/update.test.ts
+++ b/src/commands/update.test.ts
@@ -1,0 +1,136 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
+
+const isHomebrewInstallMock = vi.fn(() => false)
+const checkForUpdateMock = vi.fn()
+const applyUpdateMock = vi.fn()
+const getVersionMock = vi.fn(() => "v0.0.23")
+
+vi.mock("../update/paths.js", () => ({
+	isHomebrewInstall: () => isHomebrewInstallMock(),
+}))
+vi.mock("../update/workflow.js", () => ({
+	checkForUpdate: (...args: unknown[]) => checkForUpdateMock(...args),
+	applyUpdate: (...args: unknown[]) => applyUpdateMock(...args),
+}))
+vi.mock("../utils.js", () => ({
+	getVersion: () => getVersionMock(),
+}))
+
+const { runUpdate } = await import("./update.js")
+
+describe("runUpdate flag parsing", () => {
+	let logSpy: ReturnType<typeof vi.spyOn>
+	let errSpy: ReturnType<typeof vi.spyOn>
+
+	beforeEach(() => {
+		logSpy = vi.spyOn(console, "log").mockImplementation(() => {})
+		errSpy = vi.spyOn(console, "error").mockImplementation(() => {})
+		isHomebrewInstallMock.mockReset()
+		isHomebrewInstallMock.mockReturnValue(false)
+		checkForUpdateMock.mockReset()
+		applyUpdateMock.mockReset()
+	})
+
+	afterEach(() => {
+		logSpy.mockRestore()
+		errSpy.mockRestore()
+	})
+
+	it("--help documents --canary", async () => {
+		const code = await runUpdate(["--help"])
+		expect(code).toBe(0)
+		const out = logSpy.mock.calls.map((c) => String(c[0] ?? "")).join("\n")
+		expect(out).toContain("--canary")
+		expect(out).toContain("Usage: kimchi update")
+	})
+
+	it("rejects unknown flags", async () => {
+		const code = await runUpdate(["--bogus"])
+		expect(code).toBe(2)
+		expect(errSpy).toHaveBeenCalled()
+	})
+})
+
+describe("runUpdate Homebrew branch", () => {
+	let logSpy: ReturnType<typeof vi.spyOn>
+
+	beforeEach(() => {
+		logSpy = vi.spyOn(console, "log").mockImplementation(() => {})
+		vi.spyOn(console, "error").mockImplementation(() => {})
+		isHomebrewInstallMock.mockReset()
+		checkForUpdateMock.mockReset()
+		applyUpdateMock.mockReset()
+	})
+
+	afterEach(() => {
+		vi.restoreAllMocks()
+	})
+
+	it("prints canary-specific message on Homebrew + --canary and skips download", async () => {
+		isHomebrewInstallMock.mockReturnValue(true)
+		const code = await runUpdate(["--canary"])
+		expect(code).toBe(0)
+		const out = logSpy.mock.calls.map((c) => String(c[0] ?? "")).join("\n")
+		expect(out).toContain("Canary builds are not published to Homebrew")
+		expect(out).toContain("brew uninstall kimchi")
+		expect(out).toContain("install.sh")
+		expect(out).toContain("kimchi update --canary")
+		expect(out).not.toContain("brew upgrade kimchi")
+		expect(checkForUpdateMock).not.toHaveBeenCalled()
+		expect(applyUpdateMock).not.toHaveBeenCalled()
+	})
+
+	it("prints generic Homebrew message on bare update (no --canary)", async () => {
+		isHomebrewInstallMock.mockReturnValue(true)
+		const code = await runUpdate([])
+		expect(code).toBe(0)
+		const out = logSpy.mock.calls.map((c) => String(c[0] ?? "")).join("\n")
+		expect(out).toContain("brew upgrade kimchi")
+		expect(out).not.toContain("brew uninstall kimchi")
+		expect(checkForUpdateMock).not.toHaveBeenCalled()
+	})
+})
+
+describe("runUpdate non-interactive composition", () => {
+	let logSpy: ReturnType<typeof vi.spyOn>
+
+	beforeEach(() => {
+		logSpy = vi.spyOn(console, "log").mockImplementation(() => {})
+		vi.spyOn(console, "error").mockImplementation(() => {})
+		isHomebrewInstallMock.mockReset()
+		isHomebrewInstallMock.mockReturnValue(false)
+		checkForUpdateMock.mockReset()
+		applyUpdateMock.mockReset()
+	})
+
+	afterEach(() => {
+		vi.restoreAllMocks()
+	})
+
+	it("--canary --dry-run reports the canary version without installing", async () => {
+		checkForUpdateMock.mockResolvedValue({
+			hasUpdate: true,
+			latestVersion: "0.0.0-canary.20260509.abc1234",
+			tag: "canary",
+			releaseUrl: "https://example/releases/tag/canary",
+		})
+		const code = await runUpdate(["--canary", "--dry-run"])
+		expect(code).toBe(0)
+		expect(applyUpdateMock).not.toHaveBeenCalled()
+		expect(checkForUpdateMock).toHaveBeenCalledWith(expect.objectContaining({ canary: true, skipCache: true }))
+		const out = logSpy.mock.calls.map((c) => String(c[0] ?? "")).join("\n")
+		expect(out).toContain("0.0.0-canary.20260509.abc1234")
+	})
+
+	it("--canary --force installs without prompting", async () => {
+		checkForUpdateMock.mockResolvedValue({
+			hasUpdate: true,
+			latestVersion: "0.0.0-canary.20260509.abc1234",
+			tag: "canary",
+		})
+		applyUpdateMock.mockResolvedValue(undefined)
+		const code = await runUpdate(["--canary", "--force"])
+		expect(code).toBe(0)
+		expect(applyUpdateMock).toHaveBeenCalledWith({ tag: "canary" })
+	})
+})

--- a/src/commands/update.ts
+++ b/src/commands/update.ts
@@ -5,17 +5,20 @@ import { getVersion } from "../utils.js"
 interface UpdateFlags {
 	force: boolean
 	dryRun: boolean
+	canary: boolean
 }
 
 function parseFlags(args: string[]): UpdateFlags | string {
-	const flags: UpdateFlags = { force: false, dryRun: false }
+	const flags: UpdateFlags = { force: false, dryRun: false, canary: false }
 	for (const a of args) {
 		if (a === "--force" || a === "-f") flags.force = true
 		else if (a === "--dry-run") flags.dryRun = true
+		else if (a === "--canary") flags.canary = true
 		else if (a === "--help" || a === "-h") {
 			return [
-				"Usage: kimchi update [--force] [--dry-run]",
+				"Usage: kimchi update [--canary] [--force] [--dry-run]",
 				"",
+				"  --canary      Install the latest canary build from master",
 				"  --force, -f   Skip the confirmation prompt",
 				"  --dry-run     Check for updates without installing",
 			].join("\n")
@@ -60,7 +63,7 @@ export async function runUpdate(args: string[]): Promise<number> {
 	const current = getVersion()
 	let check: Awaited<ReturnType<typeof checkForUpdate>>
 	try {
-		check = await checkForUpdate({ currentVersion: current, skipCache: true })
+		check = await checkForUpdate({ currentVersion: current, skipCache: true, canary: flags.canary })
 	} catch (err) {
 		console.error(`kimchi update: failed to check for updates: ${(err as Error).message}`)
 		return 1
@@ -90,7 +93,7 @@ export async function runUpdate(args: string[]): Promise<number> {
 
 	console.log(`Updating to ${check.latestVersion}…`)
 	try {
-		await applyUpdate({ tag: check.latestVersion })
+		await applyUpdate({ tag: check.tag })
 	} catch (err) {
 		console.error(`kimchi update: ${(err as Error).message}`)
 		return 1

--- a/src/commands/update.ts
+++ b/src/commands/update.ts
@@ -52,6 +52,17 @@ export async function runUpdate(args: string[]): Promise<number> {
 	// losing the installation on the next `brew cleanup`. Direct the user to
 	// the correct upgrade path instead.
 	if (isHomebrewInstall()) {
+		if (flags.canary) {
+			console.log("kimchi is managed by Homebrew. Canary builds are not published to Homebrew.")
+			console.log("")
+			console.log("To use canary, uninstall the Homebrew package and reinstall directly:")
+			console.log("")
+			console.log("  brew uninstall kimchi")
+			console.log("  curl -fsSL https://github.com/castai/kimchi-dev/releases/latest/download/install.sh | bash")
+			console.log("")
+			console.log("Then re-run: kimchi update --canary")
+			return 0
+		}
 		console.log("kimchi is managed by Homebrew. Use Homebrew to update:")
 		console.log("")
 		console.log("  brew upgrade kimchi")

--- a/src/extensions/startup-update.test.ts
+++ b/src/extensions/startup-update.test.ts
@@ -1,0 +1,126 @@
+import { beforeEach, describe, expect, it, vi } from "vitest"
+
+const checkForUpdateMock = vi.fn()
+const getVersionMock = vi.fn()
+const isHomebrewInstallMock = vi.fn(() => false)
+
+vi.mock("../update/workflow.js", () => ({
+	checkForUpdate: (...args: unknown[]) => checkForUpdateMock(...args),
+}))
+vi.mock("../utils.js", () => ({
+	getVersion: () => getVersionMock(),
+}))
+vi.mock("../update/paths.js", () => ({
+	isHomebrewInstall: () => isHomebrewInstallMock(),
+}))
+
+const { default: startupUpdateExtension } = await import("./startup-update.js")
+
+type Handler = (event: unknown, ctx: unknown) => unknown
+
+function createMockApi() {
+	const handlers = new Map<string, Handler>()
+	const api = {
+		on: (event: string, handler: Handler) => {
+			handlers.set(event, handler)
+		},
+	}
+	return { handlers, api: api as unknown as Parameters<typeof startupUpdateExtension>[0] }
+}
+
+function makeCtx(opts: { hasUI: boolean }) {
+	const setStatus = vi.fn()
+	const ctx = {
+		hasUI: opts.hasUI,
+		ui: {
+			setStatus,
+			theme: { bold: (s: string) => s },
+		},
+	}
+	return { ctx, setStatus }
+}
+
+describe("startupUpdateExtension", () => {
+	beforeEach(() => {
+		checkForUpdateMock.mockReset()
+		getVersionMock.mockReset()
+		isHomebrewInstallMock.mockReset()
+		isHomebrewInstallMock.mockReturnValue(false)
+	})
+
+	it("checks for update on bare 0.0.0 dev build", async () => {
+		getVersionMock.mockReturnValue("0.0.0")
+		checkForUpdateMock.mockResolvedValue({ hasUpdate: true })
+		const { handlers, api } = createMockApi()
+		startupUpdateExtension(api)
+		const handler = handlers.get("session_start")
+		if (!handler) throw new Error("no session_start handler")
+
+		const { ctx, setStatus } = makeCtx({ hasUI: true })
+		await handler({}, ctx)
+
+		expect(checkForUpdateMock).toHaveBeenCalledOnce()
+		expect(setStatus).toHaveBeenCalledOnce()
+	})
+
+	it("does not check or set status when local version is canary", async () => {
+		getVersionMock.mockReturnValue("0.0.0-canary.20260509.abc1234")
+		const { handlers, api } = createMockApi()
+		startupUpdateExtension(api)
+		const handler = handlers.get("session_start")
+		if (!handler) throw new Error("no session_start handler")
+
+		const { ctx, setStatus } = makeCtx({ hasUI: true })
+		await handler({}, ctx)
+
+		expect(checkForUpdateMock).not.toHaveBeenCalled()
+		expect(setStatus).not.toHaveBeenCalled()
+	})
+
+	it("sets update-available status on stable when remote is newer", async () => {
+		getVersionMock.mockReturnValue("v0.0.23")
+		checkForUpdateMock.mockResolvedValue({ hasUpdate: true })
+		const { handlers, api } = createMockApi()
+		startupUpdateExtension(api)
+		const handler = handlers.get("session_start")
+		if (!handler) throw new Error("no session_start handler")
+
+		const { ctx, setStatus } = makeCtx({ hasUI: true })
+		await handler({}, ctx)
+
+		expect(checkForUpdateMock).toHaveBeenCalledOnce()
+		expect(setStatus).toHaveBeenCalledOnce()
+		const [key, msg] = setStatus.mock.calls[0]
+		expect(key).toBe("update-available")
+		expect(msg).toContain("kimchi update")
+	})
+
+	it("does not set status on stable when no update", async () => {
+		getVersionMock.mockReturnValue("v0.0.23")
+		checkForUpdateMock.mockResolvedValue({ hasUpdate: false })
+		const { handlers, api } = createMockApi()
+		startupUpdateExtension(api)
+		const handler = handlers.get("session_start")
+		if (!handler) throw new Error("no session_start handler")
+
+		const { ctx, setStatus } = makeCtx({ hasUI: true })
+		await handler({}, ctx)
+
+		expect(checkForUpdateMock).toHaveBeenCalledOnce()
+		expect(setStatus).not.toHaveBeenCalled()
+	})
+
+	it("skips entirely when hasUI is false", async () => {
+		getVersionMock.mockReturnValue("v0.0.23")
+		const { handlers, api } = createMockApi()
+		startupUpdateExtension(api)
+		const handler = handlers.get("session_start")
+		if (!handler) throw new Error("no session_start handler")
+
+		const { ctx, setStatus } = makeCtx({ hasUI: false })
+		await handler({}, ctx)
+
+		expect(checkForUpdateMock).not.toHaveBeenCalled()
+		expect(setStatus).not.toHaveBeenCalled()
+	})
+})

--- a/src/extensions/startup-update.test.ts
+++ b/src/extensions/startup-update.test.ts
@@ -4,9 +4,13 @@ const checkForUpdateMock = vi.fn()
 const getVersionMock = vi.fn()
 const isHomebrewInstallMock = vi.fn(() => false)
 
-vi.mock("../update/workflow.js", () => ({
-	checkForUpdate: (...args: unknown[]) => checkForUpdateMock(...args),
-}))
+vi.mock(import("../update/workflow.js"), async (importOriginal) => {
+	const actual = await importOriginal()
+	return {
+		...actual,
+		checkForUpdate: (...args: unknown[]) => checkForUpdateMock(...args),
+	}
+})
 vi.mock("../utils.js", () => ({
 	getVersion: () => getVersionMock(),
 }))

--- a/src/extensions/startup-update.ts
+++ b/src/extensions/startup-update.ts
@@ -17,6 +17,9 @@ export default function startupUpdateExtension(pi: ExtensionAPI) {
 		if (!ctx.hasUI) return
 
 		const current = getVersion()
+		// Canary users opted into the canary track; don't nag them about
+		// stable. Currency on canary is checked by `kimchi update --canary`.
+		if (current.startsWith("0.0.0-canary.")) return
 		try {
 			const result = await checkForUpdate({ currentVersion: current, skipCache: false })
 			if (result.hasUpdate) {

--- a/src/extensions/startup-update.ts
+++ b/src/extensions/startup-update.ts
@@ -1,6 +1,6 @@
 import type { ExtensionAPI, ExtensionContext } from "@earendil-works/pi-coding-agent"
 import { isHomebrewInstall } from "../update/paths.js"
-import { checkForUpdate } from "../update/workflow.js"
+import { checkForUpdate, parseCanarySha7 } from "../update/workflow.js"
 import { getVersion } from "../utils.js"
 
 const UPDATE_STATUS_KEY = "update-available"
@@ -19,7 +19,7 @@ export default function startupUpdateExtension(pi: ExtensionAPI) {
 		const current = getVersion()
 		// Canary users opted into the canary track; don't nag them about
 		// stable. Currency on canary is checked by `kimchi update --canary`.
-		if (current.startsWith("0.0.0-canary.")) return
+		if (parseCanarySha7(current) !== null) return
 		try {
 			const result = await checkForUpdate({ currentVersion: current, skipCache: false })
 			if (result.hasUpdate) {

--- a/src/update/github.test.ts
+++ b/src/update/github.test.ts
@@ -59,6 +59,43 @@ describe("GitHubClient.latestRelease", () => {
 	})
 })
 
+describe("GitHubClient.canaryRelease", () => {
+	it("parses tag_name + target_commitish + name out of the API response", async () => {
+		const fetchImpl = vi.fn().mockResolvedValue({
+			ok: true,
+			status: 200,
+			json: async () => ({
+				tag_name: "canary",
+				target_commitish: "abc1234abc1234abc1234abc1234abc1234abc12",
+				html_url: "https://github.com/x/y/releases/tag/canary",
+				name: "Canary 0.0.0-canary.20260509.abc1234",
+			}),
+		}) as unknown as typeof fetch
+		const client = new GitHubClient({ fetch: fetchImpl })
+		const got = await client.canaryRelease(REPO)
+		expect(got.tagName).toBe("canary")
+		expect(got.targetCommitish).toBe("abc1234abc1234abc1234abc1234abc1234abc12")
+		expect(got.htmlUrl).toBe("https://github.com/x/y/releases/tag/canary")
+		expect(got.name).toBe("Canary 0.0.0-canary.20260509.abc1234")
+	})
+
+	it("throws on non-200 response", async () => {
+		const fetchImpl = vi.fn().mockResolvedValue({ ok: false, status: 404 }) as unknown as typeof fetch
+		const client = new GitHubClient({ fetch: fetchImpl })
+		await expect(client.canaryRelease(REPO)).rejects.toThrow(/404/)
+	})
+
+	it("throws when target_commitish is missing", async () => {
+		const fetchImpl = vi.fn().mockResolvedValue({
+			ok: true,
+			status: 200,
+			json: async () => ({ tag_name: "canary", html_url: "..." }),
+		}) as unknown as typeof fetch
+		const client = new GitHubClient({ fetch: fetchImpl })
+		await expect(client.canaryRelease(REPO)).rejects.toThrow(/target_commitish/)
+	})
+})
+
 describe("GitHubClient.fetchChecksum", () => {
 	it("finds the checksum line for our platform's asset", async () => {
 		const origPlat = process.platform

--- a/src/update/github.ts
+++ b/src/update/github.ts
@@ -18,6 +18,14 @@ export interface ReleaseInfo {
 	htmlUrl: string
 }
 
+export interface CanaryReleaseInfo {
+	tagName: string
+	targetCommitish: string
+	htmlUrl: string
+	/** Release title, e.g. "Canary 0.0.0-canary.20260509.abc1234". */
+	name: string
+}
+
 export interface GitHubClientOptions {
 	apiBase?: string
 	downloadBase?: string
@@ -84,6 +92,35 @@ export class GitHubClient {
 		return {
 			tagName: json.tag_name,
 			htmlUrl: typeof json.html_url === "string" ? json.html_url : "",
+		}
+	}
+
+	/** GET /repos/{owner}/{name}/releases/tags/canary. */
+	async canaryRelease(repo: Repo): Promise<CanaryReleaseInfo> {
+		const url = `${this.apiBase}/repos/${repo.owner}/${repo.name}/releases/tags/canary`
+		const res = await this.fetchImpl(url, {
+			headers: { Accept: "application/vnd.github+json" },
+		})
+		if (!res.ok) {
+			throw new Error(`github API returned ${res.status}`)
+		}
+		const json = (await res.json()) as {
+			tag_name?: unknown
+			html_url?: unknown
+			target_commitish?: unknown
+			name?: unknown
+		}
+		if (typeof json.tag_name !== "string" || json.tag_name.length === 0) {
+			throw new Error("github API response missing tag_name")
+		}
+		if (typeof json.target_commitish !== "string" || json.target_commitish.length === 0) {
+			throw new Error("github API response missing target_commitish")
+		}
+		return {
+			tagName: json.tag_name,
+			targetCommitish: json.target_commitish,
+			htmlUrl: typeof json.html_url === "string" ? json.html_url : "",
+			name: typeof json.name === "string" ? json.name : "",
 		}
 	}
 

--- a/src/update/workflow.test.ts
+++ b/src/update/workflow.test.ts
@@ -2,7 +2,7 @@ import { mkdtempSync, rmSync } from "node:fs"
 import { tmpdir } from "node:os"
 import { join } from "node:path"
 import { afterEach, beforeEach, describe, expect, it } from "vitest"
-import type { GitHubClient, ReleaseInfo, Repo } from "./github.js"
+import type { CanaryReleaseInfo, GitHubClient, ReleaseInfo, Repo } from "./github.js"
 import { checkForUpdate } from "./workflow.js"
 
 const REPO: Repo = { owner: "castai", name: "kimchi-dev", binary: "kimchi" }
@@ -10,6 +10,12 @@ const REPO: Repo = { owner: "castai", name: "kimchi-dev", binary: "kimchi" }
 function fakeClient(release: ReleaseInfo): GitHubClient {
 	return {
 		latestRelease: async () => release,
+	} as unknown as GitHubClient
+}
+
+function fakeCanaryClient(release: CanaryReleaseInfo): GitHubClient {
+	return {
+		canaryRelease: async () => release,
 	} as unknown as GitHubClient
 }
 
@@ -53,5 +59,61 @@ describe("checkForUpdate version comparison", () => {
 		const client = fakeClient({ tagName: "0.2.0", htmlUrl: "https://example/release" })
 		const result = await checkForUpdate({ repo: REPO, currentVersion: "0.1.0", skipCache: true, client })
 		expect(result.hasUpdate).toBe(true)
+	})
+
+	it("stable path returns the tag for downloads", async () => {
+		const client = fakeClient({ tagName: "v0.2.0", htmlUrl: "https://example/release" })
+		const result = await checkForUpdate({ repo: REPO, currentVersion: "0.1.0", skipCache: true, client })
+		expect(result.tag).toBe("v0.2.0")
+		expect(result.latestVersion).toBe("v0.2.0")
+	})
+})
+
+describe("checkForUpdate canary path", () => {
+	let tmp: string
+	let prevHome: string | undefined
+	let prevXdg: string | undefined
+
+	beforeEach(() => {
+		tmp = mkdtempSync(join(tmpdir(), "kimchi-workflow-canary-test-"))
+		prevHome = process.env.HOME
+		prevXdg = process.env.XDG_CACHE_HOME
+		process.env.XDG_CACHE_HOME = tmp
+	})
+
+	afterEach(() => {
+		// biome-ignore lint/performance/noDelete: env-var cleanup needs a real delete; assigning undefined would coerce to the literal string "undefined".
+		if (prevHome === undefined) delete process.env.HOME
+		else process.env.HOME = prevHome
+		// biome-ignore lint/performance/noDelete: same as above.
+		if (prevXdg === undefined) delete process.env.XDG_CACHE_HOME
+		else process.env.XDG_CACHE_HOME = prevXdg
+		rmSync(tmp, { recursive: true, force: true })
+	})
+
+	it("returns the canary tag for downloads and the version parsed from the title", async () => {
+		const client = fakeCanaryClient({
+			tagName: "canary",
+			targetCommitish: "abc1234abc1234abc1234abc1234abc1234abc12",
+			htmlUrl: "https://example/canary",
+			name: "Canary 0.0.0-canary.20260509.abc1234",
+		})
+		const result = await checkForUpdate({ repo: REPO, currentVersion: "0.1.0", canary: true, client })
+		expect(result.tag).toBe("canary")
+		expect(result.latestVersion).toBe("0.0.0-canary.20260509.abc1234")
+		expect(result.hasUpdate).toBe(true)
+		expect(result.releaseUrl).toBe("https://example/canary")
+		expect(result.cached).toBe(false)
+	})
+
+	it("falls back to the tag when the release title is missing", async () => {
+		const client = fakeCanaryClient({
+			tagName: "canary",
+			targetCommitish: "abc1234abc1234abc1234abc1234abc1234abc12",
+			htmlUrl: "",
+			name: "",
+		})
+		const result = await checkForUpdate({ repo: REPO, currentVersion: "0.1.0", canary: true, client })
+		expect(result.latestVersion).toBe("canary")
 	})
 })

--- a/src/update/workflow.test.ts
+++ b/src/update/workflow.test.ts
@@ -3,7 +3,7 @@ import { tmpdir } from "node:os"
 import { join } from "node:path"
 import { afterEach, beforeEach, describe, expect, it } from "vitest"
 import type { CanaryReleaseInfo, GitHubClient, ReleaseInfo, Repo } from "./github.js"
-import { checkForUpdate } from "./workflow.js"
+import { checkForUpdate, parseCanarySha7 } from "./workflow.js"
 
 const REPO: Repo = { owner: "castai", name: "kimchi-dev", binary: "kimchi" }
 
@@ -115,5 +115,126 @@ describe("checkForUpdate canary path", () => {
 		})
 		const result = await checkForUpdate({ repo: REPO, currentVersion: "0.1.0", canary: true, client })
 		expect(result.latestVersion).toBe("canary")
+	})
+
+	it("reports already-current when local SHA7 matches targetCommitish", async () => {
+		const client = fakeCanaryClient({
+			tagName: "canary",
+			targetCommitish: "abc1234abc1234abc1234abc1234abc1234abc12",
+			htmlUrl: "https://example/canary",
+			name: "Canary 0.0.0-canary.20260509.abc1234",
+		})
+		const result = await checkForUpdate({
+			repo: REPO,
+			currentVersion: "0.0.0-canary.20260509.abc1234",
+			canary: true,
+			client,
+		})
+		expect(result.hasUpdate).toBe(false)
+	})
+
+	it("reports an update when local SHA7 differs from targetCommitish", async () => {
+		const client = fakeCanaryClient({
+			tagName: "canary",
+			targetCommitish: "def5678def5678def5678def5678def5678def56",
+			htmlUrl: "https://example/canary",
+			name: "Canary 0.0.0-canary.20260509.def5678",
+		})
+		const result = await checkForUpdate({
+			repo: REPO,
+			currentVersion: "0.0.0-canary.20260508.abc1234",
+			canary: true,
+			client,
+		})
+		expect(result.hasUpdate).toBe(true)
+	})
+
+	it("treats date-only difference (same SHA) as already current", async () => {
+		// Two canaries can land on the same UTC day; matching SHA wins
+		// regardless of date stamp drift.
+		const client = fakeCanaryClient({
+			tagName: "canary",
+			targetCommitish: "abc1234abc1234abc1234abc1234abc1234abc12",
+			htmlUrl: "https://example/canary",
+			name: "Canary 0.0.0-canary.20260510.abc1234",
+		})
+		const result = await checkForUpdate({
+			repo: REPO,
+			currentVersion: "0.0.0-canary.20260509.abc1234",
+			canary: true,
+			client,
+		})
+		expect(result.hasUpdate).toBe(false)
+	})
+
+	it("treats a non-hex targetCommitish (branch name) as update available", async () => {
+		// gh release create --target "$GITHUB_SHA" guarantees a SHA today, but
+		// targetCommitish is whatever was passed and could be a branch like
+		// "master". Don't silently match the junk prefix.
+		const client = fakeCanaryClient({
+			tagName: "canary",
+			targetCommitish: "master",
+			htmlUrl: "https://example/canary",
+			name: "Canary 0.0.0-canary.20260509.mastert",
+		})
+		const result = await checkForUpdate({
+			repo: REPO,
+			currentVersion: "0.0.0-canary.20260509.mastert",
+			canary: true,
+			client,
+		})
+		expect(result.hasUpdate).toBe(true)
+	})
+
+	it("treats a non-canary local as update available under --canary", async () => {
+		const client = fakeCanaryClient({
+			tagName: "canary",
+			targetCommitish: "abc1234abc1234abc1234abc1234abc1234abc12",
+			htmlUrl: "https://example/canary",
+			name: "Canary 0.0.0-canary.20260509.abc1234",
+		})
+		const result = await checkForUpdate({ repo: REPO, currentVersion: "0.1.0", canary: true, client })
+		expect(result.hasUpdate).toBe(true)
+	})
+})
+
+describe("checkForUpdate: bare update from a canary install", () => {
+	it("flags stable as an update when local is a canary build (0.0.0-* < any stable)", async () => {
+		const client = fakeClient({ tagName: "v0.0.23", htmlUrl: "https://example/release" })
+		const result = await checkForUpdate({
+			repo: REPO,
+			currentVersion: "0.0.0-canary.20260509.abc1234",
+			skipCache: true,
+			client,
+		})
+		expect(result.hasUpdate).toBe(true)
+		expect(result.tag).toBe("v0.0.23")
+	})
+})
+
+describe("parseCanarySha7", () => {
+	it("extracts the SHA7 from a well-formed canary version", () => {
+		expect(parseCanarySha7("0.0.0-canary.20260509.abc1234")).toBe("abc1234")
+	})
+
+	it("returns null for a stable version", () => {
+		expect(parseCanarySha7("0.1.0")).toBeNull()
+		expect(parseCanarySha7("v0.0.23")).toBeNull()
+	})
+
+	it("returns null for a malformed canary version", () => {
+		// uppercase hex
+		expect(parseCanarySha7("0.0.0-canary.20260509.ABC1234")).toBeNull()
+		// SHA too short
+		expect(parseCanarySha7("0.0.0-canary.20260509.abc123")).toBeNull()
+		// SHA too long
+		expect(parseCanarySha7("0.0.0-canary.20260509.abc12345")).toBeNull()
+		// date wrong length
+		expect(parseCanarySha7("0.0.0-canary.2026050.abc1234")).toBeNull()
+		// trailing garbage
+		expect(parseCanarySha7("0.0.0-canary.20260509.abc1234-dirty")).toBeNull()
+		// empty / unrelated
+		expect(parseCanarySha7("")).toBeNull()
+		expect(parseCanarySha7("canary")).toBeNull()
 	})
 })

--- a/src/update/workflow.ts
+++ b/src/update/workflow.ts
@@ -40,6 +40,22 @@ function canaryVersionFromName(name: string): string {
 	return m ? m[1] : "canary"
 }
 
+const SHA7_LEN = 7
+const SHA7_RE = /^[0-9a-f]{7}$/
+const CANARY_VERSION_RE = new RegExp(`^0\\.0\\.0-canary\\.\\d{8}\\.([0-9a-f]{${SHA7_LEN}})$`)
+
+/**
+ * Extract the SHA7 from a canary version string. Returns null for any input
+ * that isn't a canary version of the form `0.0.0-canary.YYYYMMDD.SHA7`.
+ * Used to detect "already on the latest canary" by comparing against the
+ * release's `target_commitish.slice(0, 7)` — date stamp is ignored, since
+ * multiple canaries can land on the same UTC day.
+ */
+export function parseCanarySha7(version: string): string | null {
+	const m = CANARY_VERSION_RE.exec(version)
+	return m ? m[1] : null
+}
+
 /**
  * Resolve the latest release for `repo`, hitting the 24h-cached state file
  * when fresh and falling back to the GitHub API otherwise. Honors
@@ -69,12 +85,22 @@ export async function checkForUpdate(opts: CheckOptions): Promise<CheckResult> {
 		// on every master push, and a stale `latest_version: "canary"` entry
 		// would mask new builds.
 		const info = await client.canaryRelease(repo)
+		// Currency by SHA7, not date: two canaries can land on the same UTC
+		// day. A non-canary local (e.g. user on stable invoking --canary)
+		// returns null and falls through to hasUpdate=true — the explicit
+		// flag is the user's intent. The remote prefix is hex-validated:
+		// `target_commitish` is whatever was passed to `gh release create
+		// --target` and could be a branch name; treat non-hex as "update
+		// available" rather than silently matching a junk prefix.
+		const localSha = parseCanarySha7(opts.currentVersion)
+		const remoteSha = info.targetCommitish.slice(0, SHA7_LEN)
+		const sameSha = SHA7_RE.test(remoteSha) && localSha === remoteSha
 		return {
 			currentVersion: opts.currentVersion,
 			latestVersion: canaryVersionFromName(info.name),
 			tag: info.tagName,
 			releaseUrl: info.htmlUrl,
-			hasUpdate: true,
+			hasUpdate: !sameSha,
 			cached: false,
 		}
 	}

--- a/src/update/workflow.ts
+++ b/src/update/workflow.ts
@@ -10,7 +10,10 @@ import { isStale, isUpdateCheckDisabled, loadRepoState, saveRepoState } from "./
 
 export interface CheckResult {
 	currentVersion: string
+	/** User-facing version string (e.g. "v0.0.23" or "0.0.0-canary.20260509.abc1234"). */
 	latestVersion: string
+	/** GitHub release tag used for download URLs ("v0.0.23" or "canary"). */
+	tag: string
 	releaseUrl: string
 	hasUpdate: boolean
 	cached: boolean
@@ -27,6 +30,14 @@ export interface CheckOptions {
 	skipCache?: boolean
 	currentVersion: string
 	client?: GitHubClient
+	/** Resolve the floating `canary` release instead of latest stable. */
+	canary?: boolean
+}
+
+/** Strip the "Canary " title prefix to recover the embedded version string. */
+function canaryVersionFromName(name: string): string {
+	const m = /^Canary\s+(.+)$/.exec(name)
+	return m ? m[1] : "canary"
 }
 
 /**
@@ -46,8 +57,24 @@ export async function checkForUpdate(opts: CheckOptions): Promise<CheckResult> {
 		return {
 			currentVersion: opts.currentVersion,
 			latestVersion: opts.currentVersion,
+			tag: "",
 			releaseUrl: "",
 			hasUpdate: false,
+			cached: false,
+		}
+	}
+
+	if (opts.canary) {
+		// Canary always bypasses cache: the floating `canary` tag is replaced
+		// on every master push, and a stale `latest_version: "canary"` entry
+		// would mask new builds.
+		const info = await client.canaryRelease(repo)
+		return {
+			currentVersion: opts.currentVersion,
+			latestVersion: canaryVersionFromName(info.name),
+			tag: info.tagName,
+			releaseUrl: info.htmlUrl,
+			hasUpdate: true,
 			cached: false,
 		}
 	}
@@ -80,11 +107,12 @@ export async function checkForUpdate(opts: CheckOptions): Promise<CheckResult> {
 	// only parses bare semver, so strip the prefix here. We keep `latestVersion`
 	// itself unchanged so cached state and user-facing messages still show the
 	// canonical tag name.
-	const tag = (latestVersion ?? "").replace(/^v/, "")
-	const hasUpdate = tag !== "" && !compareSemverGte(opts.currentVersion, tag)
+	const semver = (latestVersion ?? "").replace(/^v/, "")
+	const hasUpdate = semver !== "" && !compareSemverGte(opts.currentVersion, semver)
 	return {
 		currentVersion: opts.currentVersion,
 		latestVersion,
+		tag: latestVersion,
 		releaseUrl,
 		hasUpdate,
 		cached,


### PR DESCRIPTION
## Why

Canary builds are published on every merge to master, but there's no supported way for an existing kimchi install to switch onto the canary track or stay current on it. Users on stable have to uninstall and re-run install.sh manually, and once on canary there's no command to pull the next build - making canary impractical to dogfood.

## What

Adds `kimchi update --canary`, which resolves the floating canary GitHub release, compares the local build's embedded SHA7 against the release's  target_commitish, and installs if they differ. Date stamps are ignored so same-day rebuilds don't churn.

Supporting changes:
  - Canary CI artifacts renamed `kimchi-code-canary_*` → `kimchi_*` so the updater's download URLs resolve.
  - package.json version reset to `0.0.0` as the canary versioning baseline (`0.0.0-canary.YYYYMMDD.SHA7`).


---
### Kimchi Summary
### What changed
Adds a `--canary` flag to `kimchi update` so users can switch to or stay on the latest canary build from the `master` branch. The canary CI workflow now produces `kimchi_*` tarballs instead of `kimchi-code-canary_*`, and the package version is reset to `0.0.0` to align with canary versioning.

### Why
Canary builds are published continuously on every merge to `master`, but there was no supported way for existing installations to update to that floating release track.

### Key changes
- `src/commands/update.ts` — adds `--canary` flag parsing. When Homebrew is detected, prints instructions to uninstall and reinstall via the install script. For direct installs, passes `canary: true` to the update checker and uses the release `tag` (e.g. `canary`) for downloads instead of the display version.
- `src/update/github.ts` — adds `canaryRelease()` method and `CanaryReleaseInfo` type to fetch the floating `canary` release tag and its `target_commitish`.
- `src/update/workflow.ts` — adds `parseCanarySha7()` and canary update logic. Canary updates bypass the cache, compare local vs. remote builds by the embedded 7-character SHA, and return the release `tag` separately from `latestVersion`.
- `src/extensions/startup-update.ts` — skips automatic stable-update checks when the current version is already a canary build.
- `.github/workflows/canary.yml` — renames artifacts and checksums from `kimchi-code-canary_*` to `kimchi_*`.
- `package.json` — version reset to `0.0.0`.
- `src/commands/update.test.ts`, `src/update/workflow.test.ts`, `src/update/github.test.ts`, `src/extensions/startup-update.test.ts` — added tests covering `--canary` flag handling, SHA7 comparison, Homebrew messaging, and startup behavior.

### Impact
- Users who installed via Homebrew and want canary builds must `brew uninstall kimchi` and reinstall using the direct install script; the CLI will print the exact steps when `kimchi update --canary` is run under Homebrew.
- Canary artifacts have shorter, simpler filenames.
- Canary users will no longer receive stable-version update nags on startup.

---
### Kimchi Summary
### What changed
Adds a `--canary` flag to `kimchi update` so users can switch to (or stay on) the latest master/canary build. Also renames CI artifacts to `kimchi_*` and resets the package version to `0.0.0`.

### Why
Provides an explicit, supported upgrade path for users who want to test bleeding-edge changes before they reach a stable release.

### Key changes
- `.github/workflows/canary.yml`: Renames release artifacts, upload names, and checksums from `kimchi-code-canary_*` to `kimchi_*` for consistency.
- `package.json`: Sets version to `0.0.0` to identify dev/canary builds.
- `src/commands/update.ts`: Adds `--canary` flag parsing; when used with Homebrew it prints migration instructions (`brew uninstall kimchi` + install script) instead of downloading; wires the flag through to `checkForUpdate` and passes the release `tag` (not the parsed version) to `applyUpdate` so canary installs pull from the floating `canary` tag.
- `src/update/github.ts`: Adds `canaryRelease()` method to fetch the floating `canary` release and its `targetCommitish`.
- `src/update/workflow.ts`: Implements canary update detection: bypasses cache, resolves the version from the release title, and compares the local build’s SHA7 prefix with the remote `targetCommitish` to determine currency. Adds `parseCanarySha7()` helper and a `tag` field to `CheckResult`.
- `src/extensions/startup-update.ts`: Skips the background update check entirely when the current version is a canary build.

### Impact
- Canary update checks always bypass the local cache because the `canary` release tag is recreated on every master push.
- Homebrew-managed installations cannot directly switch to canary; users must migrate to the direct-install path.
- Existing canary builds will no longer receive spurious "update available" notifications for stable releases on startup.