### PR TITLE
chore: add more readonly cmds to --auto mode

### DIFF
--- a/src/extensions/permissions/taxonomy.test.ts
+++ b/src/extensions/permissions/taxonomy.test.ts
@@ -59,6 +59,14 @@ describe("isReadOnlyBashCommand", () => {
 		expect(isReadOnlyBashCommand("rg foo")).toBe(true)
 	})
 
+	it("allows cd and directory stack commands", () => {
+		expect(isReadOnlyBashCommand("cd /tmp")).toBe(true)
+		expect(isReadOnlyBashCommand("cd /Users/rat/code && git status")).toBe(true)
+		expect(isReadOnlyBashCommand("cd /a && git log --oneline | head -20")).toBe(true)
+		expect(isReadOnlyBashCommand("pushd /tmp")).toBe(true)
+		expect(isReadOnlyBashCommand("popd")).toBe(true)
+	})
+
 	it("allows git subcommand allowlist", () => {
 		expect(isReadOnlyBashCommand("git status")).toBe(true)
 		expect(isReadOnlyBashCommand("git log --oneline")).toBe(true)

--- a/src/extensions/permissions/taxonomy.ts
+++ b/src/extensions/permissions/taxonomy.ts
@@ -41,12 +41,16 @@ export function isReadOnlyTool(toolName: string): boolean {
 // but cannot execute other programs, write files (beyond stdout), or mutate
 // system state. If you need to add a program here, confirm it has no flag that
 // runs a subcommand (-exec, -c, -e, --output, etc.) or writes outside stdout.
+// NOTE: cd/pushd/popd are included — they only change process cwd, no files.
 const READ_ONLY_PROGRAMS = new Set([
 	"cat",
 	"head",
 	"tail",
 	"ls",
 	"pwd",
+	"cd",
+	"pushd",
+	"popd",
 	"echo",
 	"printf",
 	"wc",
@@ -128,6 +132,16 @@ const READ_ONLY_SUBCOMMANDS: Record<string, Set<string>> = {
 		"config",
 		"tag",
 		"stash",
+		"reflog",
+		"shortlog",
+		"fsck",
+		"verify-pack",
+		"count-objects",
+		"for-each-ref",
+		"show-ref",
+		"symbolic-ref",
+		"name-rev",
+		"rev-list",
 	]),
 	npm: new Set(["list", "ls", "view", "info", "search", "outdated", "audit", "--version", "-v"]),
 	yarn: new Set(["list", "info", "why", "audit", "--version", "-v"]),


### PR DESCRIPTION


---
### Kimchi Summary
### What changed
Expands the read-only command taxonomy to permit shell directory navigation and additional non-mutating git subcommands.

### Why
`isReadOnlyBashCommand` needs to recognize safe working-directory changes and more git inspection operations so they are allowed in restricted execution contexts.

### Key changes
- `src/extensions/permissions/taxonomy.ts`:
  - Added `cd`, `pushd`, and `popd` to `READ_ONLY_PROGRAMS`; these only mutate process `cwd` and do not write files
  - Added `reflog`, `shortlog`, `fsck`, `verify-pack`, `count-objects`, `for-each-ref`, `show-ref`, `symbolic-ref`, `name-rev`, and `rev-list` to the `git` entry in `READ_ONLY_SUBCOMMANDS`
- `src/extensions/permissions/taxonomy.test.ts`:
  - Added test coverage for `cd`, `pushd`, `popd`, and chained commands such as `cd /tmp && git status`