### PR TITLE
NOJIRA: Extract ferment command parser

### DIFF
--- a/src/extensions/ferment/command-parser.test.ts
+++ b/src/extensions/ferment/command-parser.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it } from "vitest"
+import { parseFermentCommand } from "./command-parser.js"
+
+describe("parseFermentCommand", () => {
+	it("parses empty input as the interactive flow", () => {
+		expect(parseFermentCommand("")).toEqual({ type: "interactive" })
+		expect(parseFermentCommand("   ")).toEqual({ type: "interactive" })
+	})
+
+	it("strips the add subcommand from quoted titles", () => {
+		expect(parseFermentCommand('add "Rewrite login"')).toEqual({ type: "add", title: "Rewrite login" })
+	})
+
+	it("keeps bare text as add shorthand", () => {
+		expect(parseFermentCommand("Rewrite login")).toEqual({ type: "add", title: "Rewrite login" })
+	})
+
+	it("parses switch force before the target", () => {
+		expect(parseFermentCommand('switch --force "Rewrite login"')).toEqual({
+			type: "switch",
+			verb: "switch",
+			target: "Rewrite login",
+			force: true,
+		})
+	})
+
+	it("parses switch force after the target", () => {
+		expect(parseFermentCommand('resume "Rewrite login" --force')).toEqual({
+			type: "switch",
+			verb: "resume",
+			target: "Rewrite login",
+			force: true,
+		})
+	})
+
+	it("parses one-shot intent", () => {
+		expect(parseFermentCommand('one-shot "Fix failing tests"')).toEqual({
+			type: "one-shot",
+			intent: "Fix failing tests",
+		})
+	})
+})

--- a/src/extensions/ferment/command-parser.ts
+++ b/src/extensions/ferment/command-parser.ts
@@ -1,0 +1,52 @@
+export type FermentCommand =
+	| { type: "interactive" }
+	| { type: "list" }
+	| { type: "mode"; mode?: string }
+	| { type: "delete"; target: string }
+	| { type: "switch"; verb: "switch" | "use" | "resume"; target: string; force: boolean }
+	| { type: "abandon"; reason?: string }
+	| { type: "revise"; field: string }
+	| { type: "export" }
+	| { type: "one-shot"; intent: string }
+	| { type: "add"; title: string }
+
+export function stripOuterQuotes(value: string): string {
+	const trimmed = value.trim()
+	if (trimmed.length >= 2) {
+		const first = trimmed[0]
+		const last = trimmed[trimmed.length - 1]
+		if ((first === `"` && last === `"`) || (first === `'` && last === `'`)) {
+			return trimmed.slice(1, -1).trim()
+		}
+	}
+	return trimmed
+}
+
+function parseSwitch(raw: string, verb: "switch" | "use" | "resume"): FermentCommand {
+	const rest = raw.slice(verb.length).trim()
+	const force = /(?:^|\s)--force(?:\s|$)/.test(rest)
+	const target = stripOuterQuotes(rest.replace(/(?:^|\s)--force(?:\s|$)/g, " ").trim())
+	return { type: "switch", verb, target, force }
+}
+
+export function parseFermentCommand(args: string): FermentCommand {
+	const raw = args.trim()
+	const lo = raw.toLowerCase()
+
+	if (raw === "") return { type: "interactive" }
+	if (lo === "list") return { type: "list" }
+	if (lo === "mode") return { type: "mode" }
+	if (lo.startsWith("mode ")) return { type: "mode", mode: lo.slice("mode ".length).trim() }
+	if (lo.startsWith("delete ")) return { type: "delete", target: stripOuterQuotes(raw.slice("delete ".length)) }
+	if (lo.startsWith("switch ")) return parseSwitch(raw, "switch")
+	if (lo.startsWith("use ")) return parseSwitch(raw, "use")
+	if (lo.startsWith("resume ")) return parseSwitch(raw, "resume")
+	if (lo === "abandon") return { type: "abandon" }
+	if (lo.startsWith("abandon ")) return { type: "abandon", reason: stripOuterQuotes(raw.slice("abandon".length)) }
+	if (lo.startsWith("revise ")) return { type: "revise", field: lo.slice("revise ".length).trim() }
+	if (lo === "export" || lo.startsWith("export ")) return { type: "export" }
+	if (lo.startsWith("one-shot")) return { type: "one-shot", intent: stripOuterQuotes(raw.slice("one-shot".length)) }
+	if (lo === "add") return { type: "add", title: "" }
+	if (lo.startsWith("add ")) return { type: "add", title: stripOuterQuotes(raw.slice("add ".length)) }
+	return { type: "add", title: stripOuterQuotes(raw) }
+}

--- a/src/extensions/ferment/index.test.ts
+++ b/src/extensions/ferment/index.test.ts
@@ -1,17 +1,26 @@
 import type { ExtensionAPI } from "@earendil-works/pi-coding-agent"
 import { afterEach, describe, expect, it, vi } from "vitest"
+import { FermentStorage, clearFermentCache } from "../../ferment/store.js"
 import fermentExtension from "./index.js"
 import { getActive, setActive } from "./state.js"
 
+vi.mock("../../ferment/shorten-title.js", () => ({
+	shortenTitle: vi.fn(async (input: string) => input),
+}))
+
 type EventHandler = (event: unknown, ctx: unknown) => Promise<unknown> | unknown
+type CommandHandler = (args: string, ctx: unknown) => Promise<unknown> | unknown
 
 function registerFermentExtension() {
 	const handlers = new Map<string, EventHandler>()
+	const commands = new Map<string, CommandHandler>()
 	const pi = {
 		on: (event: string, handler: EventHandler) => {
 			handlers.set(event, handler)
 		},
-		registerCommand: vi.fn(),
+		registerCommand: (name: string, command: { handler: CommandHandler }) => {
+			commands.set(name, command.handler)
+		},
 		registerTool: vi.fn(),
 		appendEntry: vi.fn(),
 		sendMessage: vi.fn(),
@@ -19,13 +28,18 @@ function registerFermentExtension() {
 	} as unknown as ExtensionAPI
 
 	fermentExtension(pi)
-	return { handlers, pi }
+	return { commands, handlers, pi }
 }
 
 afterEach(() => {
 	setActive(undefined)
 	Reflect.deleteProperty(process.env, "KIMCHI_SUBAGENT")
 	Reflect.deleteProperty(process.env, "KIMCHI_ACTIVE_FERMENT")
+	clearFermentCache()
+	const storage = new FermentStorage()
+	for (const item of storage.list()) {
+		storage.delete(item.id)
+	}
 })
 
 describe("fermentExtension session resume", () => {
@@ -40,5 +54,20 @@ describe("fermentExtension session resume", () => {
 		expect(getActive()).toBeUndefined()
 		expect(process.env.KIMCHI_ACTIVE_FERMENT).toBeUndefined()
 		expect(Object.hasOwn(process.env, "KIMCHI_ACTIVE_FERMENT")).toBe(false)
+	})
+})
+
+describe("/ferment command", () => {
+	it('strips the add subcommand from /ferment add "Title"', async () => {
+		const { commands } = registerFermentExtension()
+		const fermentCommand = commands.get("ferment")
+		if (!fermentCommand) throw new Error("ferment command was not registered")
+
+		await fermentCommand('add "Rewrite login"', { hasUI: false, ui: { notify: vi.fn() } })
+
+		const created = new FermentStorage().list()
+		expect(created).toHaveLength(1)
+		expect(created[0].name).toBe("Rewrite login")
+		expect(created[0].description).toBe("Rewrite login")
 	})
 })

--- a/src/extensions/ferment/index.ts
+++ b/src/extensions/ferment/index.ts
@@ -19,6 +19,7 @@ import { computeStats, serializeStats } from "../../ferment/stats.js"
 import { FermentError, clearFermentCache } from "../../ferment/store.js"
 import type { Ferment, FermentWorkMode, Step } from "../../ferment/types.js"
 import { pr_bold, pr_dim, pr_orange, pr_success, pr_teal } from "./colors.js"
+import { parseFermentCommand } from "./command-parser.js"
 import { formatDecisionsAndMemories, formatFermentStatus, formatScopingContext, stripToolRefs } from "./format.js"
 import { isPlanMode } from "./modes.js"
 import { appendRefEntry, maybeInjectAutoNudge } from "./nudge.js"
@@ -424,10 +425,11 @@ export default function fermentExtension(pi: ExtensionAPI) {
 		async handler(args, ctx) {
 			const raw = args.trim()
 			const lo = raw.toLowerCase()
+			const command = parseFermentCommand(args)
 			const storage = getStorage()
 
 			/* ── /ferment  (no args) → interactive prompt ── */
-			if (raw === "") {
+			if (command.type === "interactive") {
 				const active = getActive()
 				if (active && active.status === "running") {
 					ctx.ui.notify(
@@ -467,7 +469,7 @@ export default function fermentExtension(pi: ExtensionAPI) {
 			}
 
 			/* ── /ferment list ── */
-			if (lo === "list") {
+			if (command.type === "list") {
 				const items = storage.list().sort((a, b) => b.createdAt.localeCompare(a.createdAt))
 				if (items.length === 0) {
 					ctx.ui.notify("No ferments. Use /ferment to start one.")
@@ -539,8 +541,8 @@ export default function fermentExtension(pi: ExtensionAPI) {
 			}
 
 			/* ── /ferment mode ── */
-			if (lo === "mode" || lo.startsWith("mode ")) {
-				const modeArg = lo === "mode" ? "" : lo.slice("mode ".length).trim()
+			if (command.type === "mode") {
+				const modeArg = command.mode ?? ""
 				const active = getActive()
 				if (!modeArg) {
 					if (!active) {
@@ -613,11 +615,8 @@ export default function fermentExtension(pi: ExtensionAPI) {
 			}
 
 			/* ── /ferment delete ... ── */
-			if (lo.startsWith("delete ")) {
-				const target = raw
-					.slice("delete ".length)
-					.trim()
-					.replace(/^["']|["']$/g, "")
+			if (command.type === "delete") {
+				const target = command.target
 				if (!target) {
 					ctx.ui.notify('Usage: /ferment delete <full-id> or /ferment delete "Name"')
 					return
@@ -640,13 +639,8 @@ export default function fermentExtension(pi: ExtensionAPI) {
 			}
 
 			/* ── /ferment switch | use | resume ... ── */
-			if (lo.startsWith("switch ") || lo.startsWith("use ") || lo.startsWith("resume ")) {
-				const sub = lo.startsWith("switch ") ? "switch" : lo.startsWith("use ") ? "use" : "resume"
-				const target = raw
-					.trim()
-					.slice(sub.length)
-					.trim()
-					.replace(/^["']|["']$/g, "")
+			if (command.type === "switch") {
+				const target = command.target
 				if (!target) {
 					ctx.ui.notify('Usage: /ferment switch <full-id> or /ferment switch "Name"')
 					return
@@ -658,9 +652,8 @@ export default function fermentExtension(pi: ExtensionAPI) {
 						return
 					}
 
-					const isForce = raw.includes("--force")
 					const wtCheck = checkWorktree(f)
-					if (wtCheck.severity === "block" && !isForce) {
+					if (wtCheck.severity === "block" && !command.force) {
 						ctx.ui.notify(`${wtCheck.message}\n\nUse /ferment switch --force "${target}" to override.`)
 						return
 					}
@@ -676,16 +669,13 @@ export default function fermentExtension(pi: ExtensionAPI) {
 			}
 
 			/* ── /ferment abandon ── */
-			if (lo === "abandon" || lo.startsWith("abandon ")) {
+			if (command.type === "abandon") {
 				const active = getActive()
 				if (!active) {
 					ctx.ui.notify("No active ferment.")
 					return
 				}
-				const reason = raw
-					.slice("abandon".length)
-					.trim()
-					.replace(/^["']|["']$/g, "")
+				const reason = command.reason ?? ""
 				if (ctx.ui.select) {
 					const choice = await ctx.ui.select(`Abandon "${active.name}"?`, ["Yes, abandon it", "No, keep it"])
 					if (!choice || !choice.startsWith("Yes")) {
@@ -705,13 +695,13 @@ export default function fermentExtension(pi: ExtensionAPI) {
 			}
 
 			/* ── /ferment revise <field> ── */
-			if (lo.startsWith("revise ")) {
+			if (command.type === "revise") {
 				const active = getActive()
 				if (!active) {
 					ctx.ui.notify("No active ferment.")
 					return
 				}
-				const field = lo.slice("revise ".length).trim()
+				const field = command.field
 
 				if (field === "goal") {
 					if (!ctx.ui.input) {
@@ -787,7 +777,7 @@ export default function fermentExtension(pi: ExtensionAPI) {
 			}
 
 			/* ── /ferment export ── */
-			if (lo === "export" || lo.startsWith("export ")) {
+			if (command.type === "export") {
 				const active = getActive()
 				if (!active) {
 					ctx.ui.notify("No active ferment.")
@@ -802,16 +792,13 @@ export default function fermentExtension(pi: ExtensionAPI) {
 			}
 
 			/* ── /ferment one-shot <description> ── */
-			if (lo.startsWith("one-shot")) {
+			if (command.type === "one-shot") {
 				const active = getActive()
 				if (active && active.status === "running") {
 					ctx.ui.notify(`A ferment is already running: "${active.name}". Use /progress to check status.`)
 					return
 				}
-				const intent = raw
-					.slice("one-shot".length)
-					.trim()
-					.replace(/^["']|["']$/g, "")
+				const intent = command.intent
 				let resolvedIntent = intent
 				if (!resolvedIntent && ctx.ui.input) {
 					const typed = await ctx.ui.input("🍺  One-shot: what should be done?", "Describe the full task…")
@@ -872,7 +859,7 @@ CRITICAL: Do NOT use any tools other than ferment tools to research or explore f
 				)
 				return
 			}
-			const rawName = raw.replace(/^["']|["']$/g, "")
+			const rawName = command.type === "add" ? command.title : raw
 			if (!rawName) {
 				ctx.ui.notify('Usage: /ferment add "Name"')
 				return

--- a/src/extensions/ferment/index.ts
+++ b/src/extensions/ferment/index.ts
@@ -424,7 +424,6 @@ export default function fermentExtension(pi: ExtensionAPI) {
 		description: 'Manage ferments: /ferment list, /ferment add "Name", /ferment one-shot "task", /ferment switch <id>',
 		async handler(args, ctx) {
 			const raw = args.trim()
-			const lo = raw.toLowerCase()
 			const command = parseFermentCommand(args)
 			const storage = getStorage()
 


### PR DESCRIPTION
Fix parsing of ferment add and ferment switch subcommands

## Why
Before this change, /ferment parsing was inline string slicing inside the command handler.

Two concrete problems came from that:

* `/ferment add "Rewrite login"` did not strip add. That polluted the ferment name/description/scoping prompt.

* `/ferment switch --force "Name"` could not resolve the target

  The handler resolved the target before removing `--force`, so target became `--force "Name`. Then `storage.resolve(target)` failed.

Now those cases are parsed by a pure `parseFermentCommand()` function with direct tests.

---
### Kimchi Summary
### What changed
Extracted `/ferment` slash-command parsing into a dedicated, tested module. The extension’s command handler now consumes structured `FermentCommand` objects instead of performing inline string slicing and prefix checks.

### Why
Centralizing the parser eliminates brittle ad-hoc `startsWith`/`slice` logic, makes edge cases (quoted arguments, `--force` placement) easier to unit-test, and simplifies adding new subcommands.

### Key changes
- `src/extensions/ferment/command-parser.ts`: New module exporting `FermentCommand` union type, `parseFermentCommand`, and `stripOuterQuotes`. Parses all subcommands (`add`, `switch`, `one-shot`, `mode`, etc.) and correctly handles `--force` before or after the target.
- `src/extensions/ferment/command-parser.test.ts`: Added unit tests for empty input, bare-text shorthand, quoted title stripping, and `--force` positioning.
- `src/extensions/ferment/index.ts`: Replaced manual lowercase and prefix checks in the `/ferment` handler with `parseFermentCommand`. `delete`, `switch`, `abandon`, `revise`, `one-shot`, and `add` branches now read fields from the parsed command object.
- `src/extensions/ferment/index.test.ts`: Added `clearFermentCache` and storage cleanup between tests, plus an integration test verifying that `/ferment add "Title"` strips the subcommand and creates the ferment correctly.

### Impact
No breaking changes. Argument parsing is slightly more robust (e.g., `--force` is now matched as a discrete token rather than a substring match).