### PR TITLE
feat: enhanced spinner with animated frames and cooking messages

### DIFF
--- a/src/extensions/spinner.ts
+++ b/src/extensions/spinner.ts
@@ -29,32 +29,39 @@ export function spinnerFrame(state: SpinnerState): string {
 }
 
 // Cooking animator — drives the global working indicator in the status bar
-const COOKING_FRAMES = [
-	{ frames: ["|", "/", "-", "\\"], message: "Stirring" },
-	{ frames: ["○", "◔", "◑", "◕", "●", "◕", "◑", "◔"], message: "Marinating" },
-	{ frames: ["|", "/", "-", "\\"], message: "Chopping" },
-	{ frames: ["◐", "◓", "◑", "◒"], message: "Mixing the gochugaru" },
-	{ frames: ["·", "+", "·", "×", "·", "+"], message: "Salting the cabbage" },
-	{ frames: ["|", "/", "-", "\\"], message: "Grinding spices" },
-	{ frames: ["_", "-", "_", "-"], message: "Packing the jar" },
-	{ frames: ["|", "/", "-", "\\"], message: "Massaging the leaves" },
-	{ frames: ["▁", "▂", "▃", "▄", "▅", "▆", "▇", "█", "▇", "▆", "▅", "▄", "▃", "▂"], message: "Reducing" },
-	{ frames: ["✦", "✧", "✦", "✧"], message: "Prepping aromatics" },
-	{ frames: ["·", "+", "·", "×", "·", "+"], message: "Simmering" },
-	{ frames: ["░", "▒", "▓", "█", "▓", "▒", "░"], message: "Fermenting" },
-	{ frames: ["·", "+", "·", "×", "·", "+"], message: "Seasoning" },
-	{ frames: ["ˊ", "`", "ˊ", "`"], message: "Tasting" },
-	{ frames: ["z", "Z", "z", "Z"], message: "Letting it rest" },
-	{ frames: ["~", "-", "~", "-"], message: "Rinsing" },
-	{ frames: ["•", "·", "•", "·"], message: "Building the brine" },
-	{ frames: ["⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "⠧", "⠇", "⠏"], message: "Cooking" },
-	{ frames: ["~", "-", "~", "-"], message: "Braising" },
-	{ frames: ["⊙", "⊚", "⊙", "⊚"], message: "Tossing everything together" },
-] as const
+const COOKING_FRAMES: readonly {
+	readonly frames: readonly string[]
+	readonly message: string
+	readonly intervalMs: number
+}[] = [
+	{ frames: ["|", "/", "-", "\\"], message: "Stirring", intervalMs: 140 },
+	{ frames: ["○", "◔", "◑", "◕", "●", "◕", "◑", "◔"], message: "Marinating", intervalMs: 80 },
+	{ frames: ["|", "/", "-", "\\"], message: "Chopping", intervalMs: 140 },
+	{ frames: ["◐", "◓", "◑", "◒"], message: "Mixing the gochugaru", intervalMs: 140 },
+	{ frames: ["·", "+", "·", "×", "·", "+"], message: "Salting the cabbage", intervalMs: 93 },
+	{ frames: ["|", "/", "-", "\\"], message: "Grinding spices", intervalMs: 140 },
+	{ frames: ["_", "-", "_", "-"], message: "Packing the jar", intervalMs: 140 },
+	{ frames: ["|", "/", "-", "\\"], message: "Massaging the leaves", intervalMs: 140 },
+	{
+		frames: ["▁", "▂", "▃", "▄", "▅", "▆", "▇", "█", "▇", "▆", "▅", "▄", "▃", "▂"],
+		message: "Reducing",
+		intervalMs: 40,
+	},
+	{ frames: ["✦", "✧", "✦", "✧"], message: "Prepping aromatics", intervalMs: 140 },
+	{ frames: ["·", "+", "·", "×", "·", "+"], message: "Simmering", intervalMs: 93 },
+	{ frames: ["░", "▒", "▓", "█", "▓", "▒", "░"], message: "Fermenting", intervalMs: 80 },
+	{ frames: ["·", "+", "·", "×", "·", "+"], message: "Seasoning", intervalMs: 93 },
+	{ frames: ["ˊ", "`", "ˊ", "`"], message: "Tasting", intervalMs: 100 },
+	{ frames: ["z", "Z", "z", "Z"], message: "Letting it rest", intervalMs: 140 },
+	{ frames: ["~", "-", "~", "-"], message: "Rinsing", intervalMs: 140 },
+	{ frames: ["•", "·", "•", "·"], message: "Building the brine", intervalMs: 140 },
+	{ frames: ["⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "⠧", "⠇", "⠏"], message: "Cooking", intervalMs: 56 },
+	{ frames: ["~", "-", "~", "-"], message: "Braising", intervalMs: 140 },
+	{ frames: ["⊙", "⊚", "⊙", "⊚"], message: "Tossing everything together", intervalMs: 140 },
+]
 
 const DOT_STATES = ["", ".", "..", "..."] as const
 
-const SPIN_MS = 80
 const DOT_CYCLE_MS = 500
 const MESSAGE_CYCLE_MS = 1400
 
@@ -64,22 +71,31 @@ export function createWorkingAnimator(onUpdate: (char: string, message: string) 
 	let frameIdx = _resumeFrameIdx
 	let spinIdx = 0
 	let dotIdx = 0
-	const frame = COOKING_FRAMES[frameIdx]
+	let spinId: ReturnType<typeof setInterval> | undefined
+
+	function render() {
+		const f = COOKING_FRAMES[frameIdx]
+		onUpdate(f.frames[spinIdx], f.message + DOT_STATES[dotIdx])
+	}
+
+	function restartSpin() {
+		if (spinId) clearInterval(spinId)
+		const interval = COOKING_FRAMES[frameIdx].intervalMs
+		spinId = setInterval(() => {
+			const f = COOKING_FRAMES[frameIdx]
+			spinIdx = (spinIdx + 1) % f.frames.length
+			onUpdate(f.frames[spinIdx], f.message + DOT_STATES[dotIdx])
+		}, interval)
+	}
 
 	const initId = setTimeout(() => {
-		onUpdate(frame.frames[spinIdx], frame.message + DOT_STATES[dotIdx])
+		render()
+		restartSpin()
 	}, 0)
-
-	const spinId = setInterval(() => {
-		const f = COOKING_FRAMES[frameIdx]
-		spinIdx = (spinIdx + 1) % f.frames.length
-		onUpdate(f.frames[spinIdx], f.message + DOT_STATES[dotIdx])
-	}, SPIN_MS)
 
 	const dotId = setInterval(() => {
 		dotIdx = (dotIdx + 1) % DOT_STATES.length
-		const f = COOKING_FRAMES[frameIdx]
-		onUpdate(f.frames[spinIdx], f.message + DOT_STATES[dotIdx])
+		render()
 	}, DOT_CYCLE_MS)
 
 	const msgId = setInterval(() => {
@@ -87,13 +103,13 @@ export function createWorkingAnimator(onUpdate: (char: string, message: string) 
 		spinIdx = 0
 		dotIdx = 0
 		_resumeFrameIdx = frameIdx
-		const f = COOKING_FRAMES[frameIdx]
-		onUpdate(f.frames[spinIdx], f.message + DOT_STATES[dotIdx])
+		render()
+		restartSpin()
 	}, MESSAGE_CYCLE_MS)
 
 	return () => {
 		clearTimeout(initId)
-		clearInterval(spinId)
+		if (spinId) clearInterval(spinId)
 		clearInterval(dotId)
 		clearInterval(msgId)
 		_resumeFrameIdx = (frameIdx + 1) % COOKING_FRAMES.length

--- a/src/extensions/spinner.ts
+++ b/src/extensions/spinner.ts
@@ -29,63 +29,73 @@ export function spinnerFrame(state: SpinnerState): string {
 }
 
 // Cooking animator — drives the global working indicator in the status bar
-interface SpinnerFrame {
-	char: string
-	message: string
-}
+const COOKING_FRAMES = [
+	{ frames: ["|", "/", "-", "\\"], message: "Stirring" },
+	{ frames: ["○", "◔", "◑", "◕", "●", "◕", "◑", "◔"], message: "Marinating" },
+	{ frames: ["|", "/", "-", "\\"], message: "Chopping" },
+	{ frames: ["◐", "◓", "◑", "◒"], message: "Mixing the gochugaru" },
+	{ frames: ["·", "+", "·", "×", "·", "+"], message: "Salting the cabbage" },
+	{ frames: ["|", "/", "-", "\\"], message: "Grinding spices" },
+	{ frames: ["_", "-", "_", "-"], message: "Packing the jar" },
+	{ frames: ["|", "/", "-", "\\"], message: "Massaging the leaves" },
+	{ frames: ["▁", "▂", "▃", "▄", "▅", "▆", "▇", "█", "▇", "▆", "▅", "▄", "▃", "▂"], message: "Reducing" },
+	{ frames: ["✦", "✧", "✦", "✧"], message: "Prepping aromatics" },
+	{ frames: ["·", "+", "·", "×", "·", "+"], message: "Simmering" },
+	{ frames: ["░", "▒", "▓", "█", "▓", "▒", "░"], message: "Fermenting" },
+	{ frames: ["·", "+", "·", "×", "·", "+"], message: "Seasoning" },
+	{ frames: ["ˊ", "`", "ˊ", "`"], message: "Tasting" },
+	{ frames: ["z", "Z", "z", "Z"], message: "Letting it rest" },
+	{ frames: ["~", "-", "~", "-"], message: "Rinsing" },
+	{ frames: ["•", "·", "•", "·"], message: "Building the brine" },
+	{ frames: ["⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "⠧", "⠇", "⠏"], message: "Cooking" },
+	{ frames: ["~", "-", "~", "-"], message: "Braising" },
+	{ frames: ["⊙", "⊚", "⊙", "⊚"], message: "Tossing everything together" },
+] as const
 
-const COOKING_FRAMES: SpinnerFrame[] = [
-	{ char: "\\", message: "Stirring" },
-	{ char: "○", message: "Marinating" },
-	{ char: "/", message: "Chopping" },
-	{ char: "◑", message: "Mixing the gochugaru" },
-	{ char: "·", message: "Salting the cabbage" },
-	{ char: "/", message: "Grinding spices" },
-	{ char: "_", message: "Packing the jar" },
-	{ char: "/", message: "Massaging the leaves" },
-	{ char: "▬", message: "Reducing" },
-	{ char: "✦", message: "Prepping aromatics" },
-	{ char: "·", message: "Simmering" },
-	{ char: "░", message: "Fermenting" },
-	{ char: "·", message: "Seasoning" },
-	{ char: "ˊ", message: "Tasting" },
-	{ char: "z", message: "Letting it rest" },
-	{ char: "~", message: "Rinsing" },
-	{ char: "•", message: "Building the brine" },
-	{ char: "⠋", message: "Cooking" },
-	{ char: "~", message: "Braising" },
-	{ char: "⊙", message: "Tossing everything together" },
-]
+const DOT_STATES = ["", ".", "..", "..."] as const
 
-const CHAR_INTERVAL_MS = 50
-const DOT_COUNT = 3
-const HOLD_TICKS = 40
+const SPIN_MS = 80
+const DOT_CYCLE_MS = 500
+const MESSAGE_CYCLE_MS = 1400
 
 let _resumeFrameIdx = 0
-let _resumeTickOffset = 0
 
 export function createWorkingAnimator(onUpdate: (char: string, message: string) => void): () => void {
 	let frameIdx = _resumeFrameIdx
-	let tickOffset = _resumeTickOffset
-	const id = setInterval(() => {
-		const frame = COOKING_FRAMES[frameIdx]
-		tickOffset++
-		if (tickOffset > frame.message.length + DOT_COUNT + HOLD_TICKS) {
-			frameIdx = (frameIdx + 1) % COOKING_FRAMES.length
-			tickOffset = 0
-		}
+	let spinIdx = 0
+	let dotIdx = 0
+	const frame = COOKING_FRAMES[frameIdx]
+
+	const initId = setTimeout(() => {
+		onUpdate(frame.frames[spinIdx], frame.message + DOT_STATES[dotIdx])
+	}, 0)
+
+	const spinId = setInterval(() => {
+		const f = COOKING_FRAMES[frameIdx]
+		spinIdx = (spinIdx + 1) % f.frames.length
+		onUpdate(f.frames[spinIdx], f.message + DOT_STATES[dotIdx])
+	}, SPIN_MS)
+
+	const dotId = setInterval(() => {
+		dotIdx = (dotIdx + 1) % DOT_STATES.length
+		const f = COOKING_FRAMES[frameIdx]
+		onUpdate(f.frames[spinIdx], f.message + DOT_STATES[dotIdx])
+	}, DOT_CYCLE_MS)
+
+	const msgId = setInterval(() => {
+		frameIdx = (frameIdx + 1) % COOKING_FRAMES.length
+		spinIdx = 0
+		dotIdx = 0
 		_resumeFrameIdx = frameIdx
-		_resumeTickOffset = tickOffset
-		const msg = frame.message
-		const partial =
-			tickOffset <= msg.length
-				? msg.slice(0, tickOffset)
-				: msg + ".".repeat(Math.min(tickOffset - msg.length, DOT_COUNT))
-		onUpdate(frame.char, partial)
-	}, CHAR_INTERVAL_MS)
+		const f = COOKING_FRAMES[frameIdx]
+		onUpdate(f.frames[spinIdx], f.message + DOT_STATES[dotIdx])
+	}, MESSAGE_CYCLE_MS)
+
 	return () => {
-		clearInterval(id)
+		clearTimeout(initId)
+		clearInterval(spinId)
+		clearInterval(dotId)
+		clearInterval(msgId)
 		_resumeFrameIdx = (frameIdx + 1) % COOKING_FRAMES.length
-		_resumeTickOffset = 0
 	}
 }


### PR DESCRIPTION


---
### Kimchi Summary
### What changed
Upgrades the status bar working indicator from a single static character per message to rich, per-message spinner animations with individual frame rates. Messages now rotate on a fixed timer and ellipses cycle independently instead of typing out.

### Why
The previous animation used a fixed 50 ms tick and a typewriter-style message reveal, which looked repetitive and choppy. Giving each state its own multi-frame sequence and timing produces smoother, more varied motion during long-running operations.

### Key changes
- `src/extensions/spinner.ts`: Converted `COOKING_FRAMES` entries from single `char` objects to `frames` arrays, each with its own `intervalMs`.
- `src/extensions/spinner.ts`: Replaced the single global interval with independent timers for message rotation (`MESSAGE_CYCLE_MS`), dot cycling (`DOT_CYCLE_MS`), and per-frame spinning.
- `src/extensions/spinner.ts`: Added `restartSpin()` to recreate the spin interval whenever the active message changes so each animation runs at the correct speed.
- `src/extensions/spinner.ts`: Dots now cycle through a fixed `DOT_STATES` array instead of being appended incrementally.
- `src/extensions/spinner.ts`: Removed `_resumeTickOffset`; resumption now only depends on `_resumeFrameIdx`, and the cleanup function clears all active timers.