### PR TITLE
LLM-1577: Add session phase audit benchmark tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -213,6 +213,20 @@ User: "Add user authentication"
 → set_phase({"phase": "review"})      # Verify the implementation
 ```
 
+## Benchmarking
+
+The `benchmark/` directory contains tools for smoke-testing kimchi sessions and auditing their quality.
+
+### Manual benchmarks
+
+Run predefined tasks (simple, complex, research) against different models and compare results.
+See `benchmark/terminal-bench-2/README.md` for Apple Silicon caveats, timeout tuning, and result interpretation.
+
+### Session phase audit
+
+Audit a completed session for phase discipline, code quality, architecture, testing, model alignment, and cost efficiency. The audit agent parses the session JSONL, reconstructs the phase timeline, and produces a graded report.
+See `benchmark/audit-session/README.md` for the full evaluation criteria and an end-to-end example.
+
 ## Development
 
 ### Prerequisites

--- a/README.md
+++ b/README.md
@@ -219,7 +219,33 @@ The `benchmark/` directory contains tools for smoke-testing kimchi sessions and 
 
 ### Manual benchmarks
 
-Run predefined tasks (simple, complex, research) against different models and compare results.
+Run predefined tasks (simple, complex, research) against different models and compare results:
+
+```bash
+cd benchmark/manual
+./new-session.sh                              # create a new session with run scripts
+./sessions/session-01/run-all.sh              # run all task x model combinations
+python3 analyze-session.py                    # analyze the latest session
+python3 compare-sessions.py 1 2              # compare two sessions
+```
+
+See `benchmark/manual/README.md` for full documentation on tasks, session structure, and analysis.
+
+### Terminal-bench-2
+
+Run the [terminal-bench](https://www.harborframework.com/) suite (89 tasks) against kimchi inside Docker containers. The agent is installed in each task container and runs non-interactively; token and cost counters are parsed from the JSONL output.
+
+```bash
+cd benchmark/terminal-bench-2
+export KIMCHI_API_KEY=...
+
+# Single task (from local build)
+./scripts/run-local.sh -i terminal-bench/fix-git
+
+# Full suite, 8 parallel trials (from latest release)
+./scripts/run-release.sh -n 8
+```
+
 See `benchmark/terminal-bench-2/README.md` for Apple Silicon caveats, timeout tuning, and result interpretation.
 
 ### Session phase audit

--- a/benchmark/audit-session/README.md
+++ b/benchmark/audit-session/README.md
@@ -1,0 +1,138 @@
+# Session Phase Audit
+
+Audits a completed kimchi harness session, analyzing phase discipline, code quality, model alignment, and cost efficiency. Produces a graded report written to `.kimchi/audits/`.
+
+## Files
+
+- `audit-session.sh` -- entry point script; discovers sessions, handles selection, invokes the auditor
+- `audit-session-prompt.md` -- agent prompt template with placeholders for session file and ID
+
+## Usage
+
+```sh
+# Interactive session picker, default runner (kimchi)
+./benchmark/audit-session/audit-session.sh
+
+# Run with claude-code instead
+./benchmark/audit-session/audit-session.sh -r claude
+
+# Custom model
+./benchmark/audit-session/audit-session.sh -m kimchi-dev/kimi-k2.6
+./benchmark/audit-session/audit-session.sh -r claude -m opus
+
+# Audit a specific session file directly
+./benchmark/audit-session/audit-session.sh path/to/session.jsonl
+
+# Show only the last 5 sessions in the picker
+./benchmark/audit-session/audit-session.sh -n 5
+
+# List sessions without launching an audit
+./benchmark/audit-session/audit-session.sh -l
+./benchmark/audit-session/audit-session.sh -l -n 3
+```
+
+## Options
+
+| Flag | Description |
+|------|-------------|
+| `-l`, `--list` | List available sessions and exit |
+| `-n`, `--last N` | Show only the last N sessions (default: all) |
+| `-d`, `--dir DIR` | Use DIR instead of cwd to locate sessions |
+| `-r`, `--runner CMD` | Harness to use: `kimchi` (default) or `claude` |
+| `-m`, `--model MODEL` | Model override (default: `kimchi-dev/claude-opus-4-7` for kimchi, `claude-opus-4-7` for claude) |
+| `-h`, `--help` | Show help |
+
+## Runners
+
+| Runner | Mode | Permissions | Default model |
+|--------|------|-------------|---------------|
+| `kimchi` | interactive, yolo | all tools allowed | `kimchi-dev/claude-opus-4-7` |
+| `claude` | interactive | `--dangerously-skip-permissions` | `claude-opus-4-7` |
+
+## What the audit evaluates
+
+The agent grades the session across 6 dimensions:
+
+| Dimension | Weight | What it checks |
+|-----------|--------|----------------|
+| Phase Discipline | 15% | Logical phase ordering, timely transitions, phase-work alignment |
+| Architecture | 20% | Design decision timing, module boundaries, project conventions |
+| Code Quality | 20% | Lint results, naming, duplication, over-engineering |
+| Testing | 20% | Coverage, negative paths, test organization patterns |
+| Phase-Model Alignment | 10% | Expensive models for complex phases, cheap models for routine work |
+| Cost Efficiency | 15% | Per-phase cost breakdown, counterfactual analysis |
+
+## Output
+
+The audit report is written to `.kimchi/audits/{sessionId}-AUDIT.md` in the project directory. It includes:
+
+- Summary grade table
+- Phase timeline with duration, model, turn count, and cost per phase
+- Detailed findings per dimension
+- Tool usage breakdown by phase
+- Cost counterfactuals (opus-only, phase-optimized)
+- Top 3 actionable improvements
+
+## Example: benchmark a complex task then audit it
+
+This walkthrough runs a complex benchmark session with `kimi-k2.6`, then audits the result.
+
+### 1. Create a benchmark session (if needed)
+
+```sh
+cd benchmark/manual
+./new-session.sh
+```
+
+This creates `sessions/session-NN/` with run scripts for every task x model combination.
+
+### 2. Run the complex task
+
+```sh
+./sessions/session-02/run-complex-kimi-k2.6.sh
+```
+
+Wait for completion. The JSONL transcript is saved to:
+
+```
+sessions/session-02/runs/complex-kimi-k2.6/session-YYYYMMDD-HHMMSS.jsonl
+```
+
+### 3. Audit the session
+
+Pass the session file directly:
+
+```sh
+./benchmark/audit-session/audit-session.sh \
+    benchmark/manual/sessions/session-02/runs/complex-kimi-k2.6/session-20260511-124841.jsonl
+```
+
+Or use claude-code with Opus for the audit:
+
+```sh
+./benchmark/audit-session/audit-session.sh -r claude -m opus \
+    benchmark/manual/sessions/session-02/runs/complex-kimi-k2.6/session-20260511-124841.jsonl
+```
+
+### 4. Review the report
+
+The audit agent writes its findings to:
+
+```
+.kimchi/audits/session-20260511-124841-AUDIT.md
+```
+
+The report contains phase-by-phase cost breakdown, grade summary, and actionable improvements. Use it to decide whether to adjust model assignments, phase transitions, or task decomposition for future sessions.
+
+## How it works
+
+1. Encodes the working directory path to find the matching sessions directory
+2. Lists sessions with timestamps and first user prompt for easy identification
+3. Substitutes the selected session path into the prompt template
+4. Launches the chosen runner (kimchi or claude-code) in interactive mode with the prompt
+
+## Prerequisites
+
+- `kimchi` and/or `claude` CLI available on PATH
+- `jq` recommended (used for session parsing; falls back to grep)
+- Session JSONL files (from `~/.config/kimchi/harness/sessions/` or `benchmark/manual/`)

--- a/benchmark/audit-session/audit-session-prompt.md
+++ b/benchmark/audit-session/audit-session-prompt.md
@@ -1,0 +1,305 @@
+# Session Phase Quality & Cost Audit
+
+You are auditing session **{sessionId}** from file `{sessionFile}`. Your job is to produce a comprehensive, honest, evidence-based quality report analyzing how each phase (explore, research, plan, build, review) was used. You are not here to celebrate — you are here to find what worked, what didn't, and what to improve.
+
+## Instructions
+
+Execute each section below in order. Collect evidence via tool calls. Write findings to the audit artifact at the end.
+
+---
+
+### Step 1: Gather Evidence
+
+Run these commands and read these files to build your evidence base. Do NOT skip any step.
+
+```
+1. Read the session JSONL file: {sessionFile}
+   - Parse the header line (type: "session") for session metadata (id, cwd, timestamp)
+   - Extract all entries, noting their type, id, parentId, and timestamp
+2. Build the phase timeline:
+   a. The initial phase is always "explore" (set at session_start)
+   b. Scan all "message" entries for assistant tool_use blocks with name: "set_phase"
+   c. Extract the phase parameter from each set_phase call and its timestamp
+   d. Build a chronological map: [timestamp_range] -> phase
+3. Extract model changes:
+   - Scan for all "model_change" entries (type: "model_change")
+   - Record: timestamp, provider, modelId
+   - Correlate model changes with the phase timeline
+4. Extract per-turn usage data:
+   - For each "message" entry with role: "assistant", extract:
+     usage.input, usage.output, usage.cacheRead, usage.cacheWrite, usage.cost.total
+   - Tag each turn with its active phase (from the timeline in step 2)
+   - Tag each turn with its active model (from model_change entries in step 3)
+5. Extract tool usage:
+   - For each assistant message, scan content blocks for type: "tool_use"
+   - Record tool name, frequency, and which phase each tool call occurred in
+6. Extract behaviour data (if present):
+   - Scan for "behaviour_loaded", "behaviour_eval", "behaviour_session_summary" entries
+   - Note which behaviours fired and in which phases
+7. Read project context files (if they exist in the session's cwd):
+   - README.md
+   - CLAUDE.md
+   - .kimchi/ directory contents
+```
+
+For production code evidence:
+```
+8. Find new/modified source files produced during this session:
+    git log --oneline --since="<session_start_timestamp>" -- ':!.gsd/' ':!.kimchi/'
+    git diff --stat <first_session_commit>..HEAD -- ':!.gsd/' ':!.kimchi/'
+    (If no commits found, check: git status --short for uncommitted work)
+9. Count production LOC and test LOC changed:
+    wc -l <changed source files>
+    wc -l <changed test files>
+10. Run linter on changed code (if applicable):
+    For TypeScript: npx tsc --noEmit
+    For Go: go vet ./...
+    For Python: ruff check <directories>
+11. Run relevant tests:
+    npm test / go test ./... / pytest (as appropriate for the project)
+12. Check for stale temp files, build artifacts, or other items that shouldn't be committed
+```
+
+---
+
+### Step 2: Evaluate — 6 Dimensions
+
+Score each dimension on a **letter grade scale: A, A-, B+, B, B-, C+, C, C-, D, F**.
+
+Provide the grade, 2-4 bullet strengths, and 2-4 bullet weaknesses with specific evidence (timestamps, turn numbers, phase names, cost figures, file names). No hand-waving.
+
+#### 2.1 Phase Discipline
+
+Evaluate:
+- Was the session started in "explore" and did it progress through phases in a logical order?
+- Were phase transitions timely? (e.g., not staying in "explore" while already writing code)
+- Was the "plan" phase actually used before "build"? Did it produce a meaningful plan?
+- Was "review" used at the end? Did it catch anything?
+- Were there unnecessary phase transitions or phase churn?
+- Did the phase labels accurately reflect the work being done? (e.g., was exploration happening during "build"?)
+- Was time allocation across phases proportional to session goals?
+
+#### 2.2 Architecture & Design Decisions
+
+Evaluate:
+- Were design decisions made during "plan" or "research" phases (not ad-hoc during "build")?
+- Are module boundaries clean? (single-responsibility, clear public API)
+- Are cross-module dependencies sensible? (no circular imports, no god modules)
+- Does the code follow established project patterns? (check CLAUDE.md, existing conventions)
+- Are new abstractions justified? (no speculative frameworks)
+- Is error handling structural? (not just try/catch swallowing)
+- Are there deprecated API usages or dead code introduced?
+
+#### 2.3 Code Quality
+
+Evaluate:
+- Lint results: how many violations in new/changed code?
+- Are there dead variables, unused imports, or unreachable code?
+- Is there excessive code duplication? (same pattern repeated >3 times)
+- Are naming conventions consistent and self-explanatory? (per CLAUDE.md: no comments, use clear names)
+- Is logging structured and useful? (correlation IDs, no secrets, actionable messages)
+- Were unnecessary comments added? (CLAUDE.md says avoid comments, use self-explanatory names)
+- Is the code over-engineered for the task at hand?
+
+#### 2.4 Testing Strategy
+
+Evaluate:
+- Test count and pass/fail/skip breakdown
+- Test-to-production-code LOC ratio (target: >1.0)
+- Are negative paths tested? (auth failures, malformed input, errors, timeouts)
+- Is there an integration/e2e test that validates the full pipeline?
+- Do tests use struct-to-struct comparison where possible? (per CLAUDE.md)
+- Are test cases organized using maps? (per CLAUDE.md)
+- Are there deprecation warnings or test smells? (hardcoded counts, fragile assertions)
+
+#### 2.5 Phase-Model Alignment
+
+Evaluate:
+- Were expensive models (Opus) used primarily for complex phases (plan, review)?
+- Were cheaper models (Sonnet, Haiku) used for routine execution (build)?
+- Were model switches correlated with phase transitions or arbitrary?
+- Did model capabilities match phase requirements? (e.g., was a weak model used for planning?)
+- Were there missed opportunities to use a cheaper model?
+- Were there phases where a stronger model would have prevented rework?
+
+#### 2.6 Cost Efficiency
+
+Use the following model pricing reference for all cost calculations. Prices are per token.
+
+**Kimchi-dev model prices:**
+
+| Model | Input $/token | Output $/token | Input $/M | Output $/M |
+|-------|--------------|----------------|-----------|------------|
+| MiniMax-M2.5 | 3.0e-07 | 1.2e-06 | $0.30 | $1.20 |
+| MiniMax-M2.7 | 3.0e-07 | 1.2e-06 | $0.30 | $1.20 |
+| Qwen3-Coder-Next-FP8 | 5.0e-07 | 1.2e-06 | $0.50 | $1.20 |
+| Kimi-K2.5 | 6.0e-07 | 3.0e-06 | $0.60 | $3.00 |
+| Kimi-K2.6 | 1.2e-06 | 4.5e-06 | $1.20 | $4.50 |
+| Nemotron-3-Super-120B | 3.0e-07 | 7.5e-07 | $0.30 | $0.75 |
+
+**Anthropic model prices (for counterfactuals):**
+
+| Model | Input $/M | Output $/M |
+|-------|-----------|------------|
+| Claude Opus | $15.00 | $75.00 |
+| Claude Sonnet | $3.00 | $15.00 |
+
+When matching model IDs from session data, use substring matching (e.g., "kimi-k2.6" matches "Kimi-K2.6", "minimax-m2.5" matches "MiniMax-M2.5"). If a model is not in this table, note it and use the cost from the session's `usage.cost.total` field directly.
+
+Compute and present:
+
+**A. Actual cost breakdown by phase and model:**
+
+| Phase | Model | Turns | Input Tokens | Output Tokens | Cache Read | Cache Write | Cost |
+|-------|-------|-------|-------------|---------------|------------|-------------|------|
+| explore | (from session data) | | | | | | |
+| research | | | | | | | |
+| plan | | | | | | | |
+| build | | | | | | | |
+| review | | | | | | | |
+| **TOTAL** | | | | | | | |
+
+**B. Phase cost distribution:**
+
+| Phase | Cost | % of Total | Turns | Avg Cost/Turn |
+|-------|------|------------|-------|---------------|
+| explore | $X | X% | N | $X |
+| research | $X | X% | N | $X |
+| plan | $X | X% | N | $X |
+| build | $X | X% | N | $X |
+| review | $X | X% | N | $X |
+| **TOTAL** | $X | 100% | N | $X |
+
+**C. Counterfactual: Opus-only cost**
+- Apply Opus pricing ($15/M input, $75/M output) to ALL tokens across all phases
+
+**D. Counterfactual: Phase-optimized cost**
+- Opus for plan + review phases, Sonnet ($3/M input, $15/M output) for explore + research + build
+
+**E. Summary table:**
+
+| Approach | Cost | vs Actual |
+|----------|------|-----------|
+| Actual (multi-model) | $X | baseline |
+| Phase-optimized (Opus plan/review, Sonnet rest) | $X | X.Xx vs actual |
+| Opus only | $X | X.Xx vs actual |
+
+**F. Cost-quality tradeoff assessment:**
+- Did cheaper models in any phase miss things that a stronger model would have caught?
+- Was the planning phase's model cost proportional to the value of its output?
+- Were there build turns that were unnecessarily expensive or cheap?
+- Could any explore/research turns have been skipped entirely?
+
+---
+
+### Step 3: Write the Audit Report
+
+Write the full audit report to: `.kimchi/audits/{auditFilename}`
+
+Create the `.kimchi/audits/` directory if it does not exist.
+
+Use this format:
+
+```markdown
+# Session Phase Audit: {sessionId}
+
+**Session file:** {sessionFile}
+**Date:** {session_start_timestamp}
+**Duration:** {session_duration}
+**Working directory:** {cwd}
+
+## Audit Setup
+
+| Parameter | Value |
+|-----------|-------|
+| Runner | {auditRunner} |
+| Audit model | {auditModel} |
+| Audit file | {auditFilename} |
+
+## Summary
+
+| Dimension | Grade | Key Finding |
+|-----------|-------|-------------|
+| Phase Discipline | X | one line |
+| Architecture | X | one line |
+| Code Quality | X | one line |
+| Testing | X | one line |
+| Phase-Model Alignment | X | one line |
+| Cost Efficiency | — | $X actual ($X Opus-only = X.Xx savings) |
+
+**Overall Grade: X**
+(Weighted: Phase Discipline 15%, Architecture 20%, Code Quality 20%, Testing 20%, Phase-Model Alignment 10%, Cost Efficiency 15%)
+
+## Phase Timeline
+
+| # | Phase | Start | End | Duration | Model(s) | Turns | Cost |
+|---|-------|-------|-----|----------|----------|-------|------|
+| 1 | explore | HH:MM | HH:MM | Xm | model-id | N | $X |
+| 2 | plan | HH:MM | HH:MM | Xm | model-id | N | $X |
+| ... | | | | | | | |
+
+## Detailed Findings
+
+### Phase Discipline — Grade: X
+**Strengths:**
+- ...
+**Weaknesses:**
+- ...
+
+### Architecture & Design Decisions — Grade: X
+**Strengths:**
+- ...
+**Weaknesses:**
+- ...
+
+### Code Quality — Grade: X
+**Strengths:**
+- ...
+**Weaknesses:**
+- ...
+
+### Testing Strategy — Grade: X
+**Strengths:**
+- ...
+**Weaknesses:**
+- ...
+
+### Phase-Model Alignment — Grade: X
+**Strengths:**
+- ...
+**Weaknesses:**
+- ...
+
+### Cost Analysis
+
+(Full tables from Step 2.6)
+
+## Tool Usage by Phase
+
+| Tool | explore | research | plan | build | review | Total |
+|------|---------|----------|------|-------|--------|-------|
+| Read | N | N | N | N | N | N |
+| Edit | N | N | N | N | N | N |
+| Bash | N | N | N | N | N | N |
+| ... | | | | | | |
+
+## Top 3 Actionable Improvements
+
+1. **[specific action]** — [why, expected impact]
+2. **[specific action]** — [why, expected impact]
+3. **[specific action]** — [why, expected impact]
+
+## Model Usage Observations
+
+- Which model performed well in which phase? Which underperformed?
+- Any recommendations for model-phase assignment changes?
+- Were there phases where model switching mid-phase caused context loss?
+
+## Phase Workflow Recommendations
+
+- Should the phase order have been different for this type of task?
+- Were any phases skipped that should have been used?
+- Were any phases used that added no value?
+```
+
+After writing the artifact, say: "Audit complete for session {sessionId}. Report at .kimchi/audits/{auditFilename}"

--- a/benchmark/audit-session/audit-session.sh
+++ b/benchmark/audit-session/audit-session.sh
@@ -1,0 +1,236 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SESSIONS_BASE="${HOME}/.config/kimchi/harness/sessions"
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+PROMPT_FILE="${SCRIPT_DIR}/audit-session-prompt.md"
+
+usage() {
+    cat <<EOF
+Usage: $(basename "$0") [options] [session-file]
+
+Audit a kimchi harness session for phase quality and cost efficiency.
+Runs the audit agent in non-interactive mode using Opus.
+
+Arguments:
+  session-file     Path to a .jsonl session file (optional)
+
+Options:
+  -l, --list          List available sessions and exit
+  -n, --last N        Show only the last N sessions (default: all)
+  -d, --dir DIR       Use DIR to find sessions (default: current directory)
+  -r, --runner CMD    Harness to use: kimchi or claude (default: kimchi)
+  -m, --model MODEL   Model to use (default: kimchi-dev/claude-opus-4-7)
+  -h, --help          Show this help
+
+Examples:
+  $(basename "$0")                              # pick session, run with kimchi
+  $(basename "$0") -r claude                    # run with claude-code
+  $(basename "$0") -m claude-opus-4-7           # custom model
+  $(basename "$0") -r claude -m opus            # claude-code with opus
+  $(basename "$0") -n 5                         # pick from last 5 sessions
+  $(basename "$0") -l                           # list all sessions
+  $(basename "$0") -l -n 3                      # list last 3 sessions
+  $(basename "$0") path/to/session.jsonl        # audit a specific session file
+EOF
+    exit 0
+}
+
+encode_cwd() {
+    local dir="$1"
+    local encoded
+    encoded="$(echo "$dir" | sed 's|/|-|g' | sed 's/^-//')"
+    echo "--${encoded}--"
+}
+
+find_sessions_dir() {
+    local dir="$1"
+    local encoded
+    encoded="$(encode_cwd "$dir")"
+    local sessions_path="${SESSIONS_BASE}/${encoded}"
+    if [[ ! -d "$sessions_path" ]]; then
+        echo "No sessions directory found for: $dir" >&2
+        echo "Expected: $sessions_path" >&2
+        exit 1
+    fi
+    echo "$sessions_path"
+}
+
+first_user_prompt() {
+    local file="$1"
+    local max_chars="${2:-80}"
+    local prompt=""
+    if command -v jq &>/dev/null; then
+        prompt="$(jq -r '
+            select(.type == "message" and .message.role == "user")
+            | .message.content
+            | if type == "array" then
+                map(select(.type == "text") | .text) | join(" ")
+              elif type == "string" then .
+              else ""
+              end
+        ' "$file" 2>/dev/null | head -1)"
+    else
+        prompt="$(grep -m1 '"role":"user"' "$file" 2>/dev/null \
+            | grep -o '"text":"[^"]*"' | head -1 | cut -d'"' -f4)"
+    fi
+    prompt="$(echo "$prompt" | tr '\n' ' ' | sed 's/  */ /g' | head -c "$max_chars")"
+    if [[ ${#prompt} -ge $max_chars ]]; then
+        prompt="${prompt}..."
+    fi
+    echo "$prompt"
+}
+
+print_session_entry() {
+    local index="$1"
+    local file="$2"
+    local header
+    header="$(head -1 "$file" 2>/dev/null || echo '{}')"
+    local ts
+    ts="$(echo "$header" | grep -o '"timestamp":"[^"]*"' | head -1 | cut -d'"' -f4)"
+    local size
+    size="$(wc -l < "$file" | tr -d ' ')"
+    local prompt
+    prompt="$(first_user_prompt "$file")"
+    printf "  %2d. %s  (%s, %s lines)\n" "$index" "$(basename "$file")" "${ts:-unknown}" "$size"
+    if [[ -n "$prompt" ]]; then
+        printf "      %s\n" "$prompt"
+    fi
+}
+
+collect_sessions() {
+    local sessions_dir="$1"
+    local limit="$2"
+    local cmd="find \"$sessions_dir\" -name '*.jsonl' -type f -print0 | xargs -0 ls -t 2>/dev/null"
+    if [[ "$limit" -gt 0 ]]; then
+        eval "$cmd" | head -n "$limit"
+    else
+        eval "$cmd"
+    fi
+}
+
+list_sessions() {
+    local sessions_dir="$1"
+    local limit="$2"
+    echo "Sessions in: $sessions_dir"
+    echo ""
+    local count=0
+    while IFS= read -r f; do
+        count=$((count + 1))
+        print_session_entry "$count" "$f"
+    done < <(collect_sessions "$sessions_dir" "$limit")
+    if [[ $count -eq 0 ]]; then
+        echo "  (no session files found)"
+    fi
+}
+
+SESSION_FILE=""
+LIST=false
+LIMIT=0
+TARGET_DIR="$(pwd)"
+RUNNER="kimchi"
+MODEL=""
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        -h|--help) usage ;;
+        -l|--list) LIST=true; shift ;;
+        -n|--last) LIMIT="$2"; shift 2 ;;
+        -d|--dir) TARGET_DIR="$2"; shift 2 ;;
+        -r|--runner) RUNNER="$2"; shift 2 ;;
+        -m|--model) MODEL="$2"; shift 2 ;;
+        *)
+            if [[ -f "$1" ]]; then
+                SESSION_FILE="$1"
+            else
+                echo "Not a file: $1" >&2
+                exit 1
+            fi
+            shift
+            ;;
+    esac
+done
+
+if $LIST; then
+    sessions_dir="$(find_sessions_dir "$TARGET_DIR")"
+    list_sessions "$sessions_dir" "$LIMIT"
+    exit 0
+fi
+
+if [[ -z "$SESSION_FILE" ]]; then
+    sessions_dir="$(find_sessions_dir "$TARGET_DIR")"
+
+    mapfile -t session_files < <(collect_sessions "$sessions_dir" "$LIMIT")
+
+    if [[ ${#session_files[@]} -eq 0 ]]; then
+        echo "No session files found in: $sessions_dir" >&2
+        exit 1
+    fi
+
+    echo "Available sessions:"
+    echo ""
+    for i in "${!session_files[@]}"; do
+        print_session_entry "$((i + 1))" "${session_files[$i]}"
+    done
+
+    echo ""
+    printf "Select session [1-%d]: " "${#session_files[@]}"
+    read -r selection
+
+    if [[ -z "$selection" ]] || ! [[ "$selection" =~ ^[0-9]+$ ]] || [[ "$selection" -lt 1 ]] || [[ "$selection" -gt ${#session_files[@]} ]]; then
+        echo "Invalid selection" >&2
+        exit 1
+    fi
+
+    SESSION_FILE="${session_files[$((selection - 1))]}"
+fi
+
+if [[ ! -f "$PROMPT_FILE" ]]; then
+    echo "Prompt file not found: $PROMPT_FILE" >&2
+    exit 1
+fi
+
+SESSION_ID="$(basename "$SESSION_FILE" .jsonl)"
+
+case "$RUNNER" in
+    kimchi)  EFFECTIVE_MODEL="${MODEL:-kimchi-dev/claude-opus-4-7}" ;;
+    claude)  EFFECTIVE_MODEL="${MODEL:-claude-opus-4-7}" ;;
+    *)       echo "Unknown runner: $RUNNER (use 'kimchi' or 'claude')" >&2; exit 1 ;;
+esac
+
+MODEL_SLUG="$(echo "$EFFECTIVE_MODEL" | sed 's|.*/||' | tr '[:upper:]' '[:lower:]')"
+AUDIT_FILENAME="${SESSION_ID}-${RUNNER}-${MODEL_SLUG}-AUDIT.md"
+
+echo "Auditing session: $SESSION_FILE"
+echo "Session ID: $SESSION_ID"
+echo "Runner: $RUNNER"
+echo "Model: $EFFECTIVE_MODEL"
+echo "Audit file: .kimchi/audits/$AUDIT_FILENAME"
+echo ""
+
+TMPFILE="$(mktemp /tmp/audit-prompt-XXXXXX)"
+TMPFILE="${TMPFILE}.md"
+trap 'rm -f "$TMPFILE"' EXIT
+
+sed \
+    -e "s|{sessionFile}|${SESSION_FILE}|g" \
+    -e "s|{sessionId}|${SESSION_ID}|g" \
+    -e "s|{auditFilename}|${AUDIT_FILENAME}|g" \
+    -e "s|{auditRunner}|${RUNNER}|g" \
+    -e "s|{auditModel}|${EFFECTIVE_MODEL}|g" \
+    "$PROMPT_FILE" > "$TMPFILE"
+
+case "$RUNNER" in
+    kimchi)
+        exec kimchi \
+            --model "$EFFECTIVE_MODEL" \
+            --yolo \
+            "@${TMPFILE}"
+        ;;
+    claude)
+        PROMPT_CONTENT="$(cat "$TMPFILE")"
+        exec claude \
+            --model "$EFFECTIVE_MODEL" \
+            --dangerously-skip-permissions \
+            "$PROMPT_CONTENT"
+        ;;
+esac

--- a/benchmark/manual/analyze-session.py
+++ b/benchmark/manual/analyze-session.py
@@ -36,6 +36,12 @@ TASK_CRITERIA = {
         "max_tokens": 30_000,
         "max_duration_s": 120,
     },
+    "mega": {
+        "min_subagents": 3,
+        "max_subagents": 6,
+        "max_tokens": 800_000,
+        "max_duration_s": 900,
+    },
 }
 
 

--- a/benchmark/manual/new-session.sh
+++ b/benchmark/manual/new-session.sh
@@ -69,17 +69,42 @@ research_prompt = (
     "and a one-line example of defining a route with a path parameter."
 )
 
+mega_prompt = (
+    "Implement a Go CLI application that acts as a concurrent build system, similar to a simplified Make. "
+    "This is a multi-layer project — start with a plan before writing any code. "
+    "Requirements: Use standard library only (no frameworks, no external dependencies). "
+    "Parse a declarative build file (buildfile.txt) with this format:\n"
+    "    target: dep1 dep2\n"
+    "        command1\n"
+    "        command2\n"
+    "Indented lines under a target are shell commands. Dependencies are space-separated after the colon. "
+    "Resolve the full dependency graph using topological sort. Detect and report cycles with a clear error message listing the cycle path. "
+    "Execute independent targets concurrently using a worker pool. Targets whose dependencies are all satisfied should start immediately. "
+    "Stream command output per target with prefixed labels, e.g. '[compile] go build ./...'. "
+    "Graceful shutdown on SIGINT: finish in-progress targets, skip pending ones, print a summary of what completed and what was skipped. "
+    "CLI flags: -f <file> (build file path, default: buildfile.txt), -j <N> (max parallel workers, default: number of CPUs), "
+    "-target <name> (build a specific target and its transitive deps only, default: build all root targets). "
+    "Fail fast: on the first target error, cancel pending targets and report which target and command failed. "
+    "Layered architecture: separate packages for parsing, graph resolution, execution engine, and CLI. "
+    "Unit tests for: build file parsing (valid and malformed input), dependency resolution (diamond deps, cycle detection, single target extraction), "
+    "and execution ordering (verify concurrency-safe ordering). Use map-based test cases. "
+    "Put all code in directory: $DIR/buildtool/"
+)
+
+# Fourth element: include_in_run_all (default True)
 tasks = [
-    ("simple",         simple_prompt,  []),
-    ("complex",        complex_prompt, []),
-    ("complex-single", complex_prompt, ["--multi-model=false"]),
-    ("research",       research_prompt,[]),
+    ("simple",         simple_prompt,  [],                      True),
+    ("complex",        complex_prompt, [],                      True),
+    ("complex-single", complex_prompt, ["--multi-model=false"], True),
+    ("research",       research_prompt,[],                      True),
+    ("mega",           mega_prompt,    [],                      False),
 ]
 
 all_scripts = []
+run_all_scripts = []
 for model in models:
     print(f"model: kimchi-dev/{model}")
-    for task, task_prompt, extra_flags in tasks:
+    for task, task_prompt, extra_flags, in_run_all in tasks:
         run_dir = f"{task}-{model}"
         os.makedirs(os.path.join(session_dir, "runs", run_dir), exist_ok=True)
         slug = f"s{n}-{task}-{model}"
@@ -103,10 +128,14 @@ cd "$DIR"
             f.write(content)
         os.chmod(script_path, os.stat(script_path).st_mode | stat.S_IXUSR | stat.S_IXGRP | stat.S_IXOTH)
         all_scripts.append(script_path)
+        if in_run_all:
+            run_all_scripts.append(script_path)
 
 # run-all.sh — iTerm2 grid (cols=tasks, rows=models) with background fallback
+# Only includes tasks marked with in_run_all=True
 run_all = os.path.join(session_dir, "run-all.sh")
-cols = len(tasks)
+run_all_tasks = [t for t in tasks if t[3]]
+cols = len(run_all_tasks)
 rows = len(models)
 
 # Build AppleScript: create a NEW TAB, then split into a grid (cols=tasks, rows=models)
@@ -124,15 +153,15 @@ for r in range(1, rows):
 for r in range(rows):
     for c in range(cols):
         i = r * cols + c
-        if i < len(all_scripts):
+        if i < len(run_all_scripts):
                 # NOTE: iTerm2's `write text` sends keystrokes and returns immediately —
             # it does NOT wait for the command to finish.
-            as_lines.append(f'      tell g{c}_{r} to write text "{all_scripts[i]}"')
+            as_lines.append(f'      tell g{c}_{r} to write text "{run_all_scripts[i]}"')
 as_body = "\n".join(as_lines)
 
 # Background fallback: run each script with output to a per-script log file
 bg_lines = []
-for script in all_scripts:
+for script in run_all_scripts:
     name = os.path.basename(script).replace(".sh", "")
     log = os.path.join(session_dir, f"{name}.log")
     bg_lines.append(f'  "{script}" >"{log}" 2>&1 &')
@@ -152,7 +181,7 @@ tell application "iTerm2"
 end tell
 APPLESCRIPT
 else
-  echo "iTerm2 not available — running {len(all_scripts)} scripts in background (logs in {session_dir}/)..."
+  echo "iTerm2 not available — running {len(run_all_scripts)} scripts in background (logs in {session_dir}/)..."
 {bg_body}
   wait
   echo "All done."
@@ -160,6 +189,10 @@ fi
 """)
 os.chmod(run_all, os.stat(run_all).st_mode | stat.S_IXUSR | stat.S_IXGRP | stat.S_IXOTH)
 
+excluded = [s for s in all_scripts if s not in run_all_scripts]
 print(f"\nDone. {len(all_scripts)} scripts created in {session_dir}/")
+print(f"  run-all.sh includes {len(run_all_scripts)} tasks")
+if excluded:
+    print(f"  run separately: {', '.join(os.path.basename(s) for s in excluded)}")
 print(f"Next: {session_dir}/run-all.sh")
 PYEOF

--- a/benchmark/manual/tasks.md
+++ b/benchmark/manual/tasks.md
@@ -60,3 +60,35 @@ List the top 3 with: GitHub stars (approximate), key differentiators, and a one-
 3. **julienschmidt/httprouter** (~16k stars) — minimal, fastest, explicit method routing. `router.GET("/users/:id", handler)`
 
 ---
+
+## Task 4 — Mega coding: Go Concurrent Build System
+
+**Not included in run-all.sh** — run separately via `run-mega-<model>.sh`.
+
+**Prompt:**
+```
+Implement a Go CLI application that acts as a concurrent build system, similar to a simplified Make.
+This is a multi-layer project — start with a plan before writing any code.
+Requirements:
+- Use standard library only (no frameworks, no external dependencies).
+- Parse a declarative build file (buildfile.txt) with this format:
+    target: dep1 dep2
+        command1
+        command2
+  Indented lines under a target are shell commands. Dependencies are space-separated after the colon.
+- Resolve the full dependency graph using topological sort. Detect and report cycles with a clear error message listing the cycle path.
+- Execute independent targets concurrently using a worker pool. Targets whose dependencies are all satisfied should start immediately.
+- Stream command output per target with prefixed labels, e.g. "[compile] go build ./...".
+- Graceful shutdown on SIGINT: finish in-progress targets, skip pending ones, print a summary of what completed and what was skipped.
+- CLI flags: -f <file> (build file path, default: buildfile.txt), -j <N> (max parallel workers, default: number of CPUs), -target <name> (build a specific target and its transitive deps only, default: build all root targets).
+- Fail fast: on the first target error, cancel pending targets and report which target and command failed.
+- Layered architecture: separate packages for parsing, graph resolution, execution engine, and CLI.
+- Unit tests for: build file parsing (valid and malformed input), dependency resolution (diamond deps, cycle detection, single target extraction), and execution ordering (verify concurrency-safe ordering). Use map-based test cases.
+- Put all code in directory: $DIR/buildtool/
+```
+
+**Expected:** plan phase (heavy model) + multiple implementation subagents, 3–6 subagents, <15 min, clean package separation, comprehensive tests, stdlib only.
+
+**Baseline (Claude):** parser package (line-by-line state machine), graph package (Kahn's algorithm for topo sort, DFS for cycle detection), engine package (worker pool with channels, context cancellation, SIGINT trap), cli package (flag parsing), main.go wiring. Map-based tests covering: empty buildfile, single target, diamond dependencies, direct cycle, indirect cycle, malformed indentation, partial-target build, fail-fast propagation.
+
+---


### PR DESCRIPTION
Adds a new audit-session benchmark under `benchmark/audit-session/` for analyzing completed kimchi sessions across 6 dimensions: phase discipline, code quality, architecture, model alignment, and cost efficiency.

Also adds a "mega" benchmark task to `benchmark/manual/` — a concurrent build system (mini-Make) that exercises planning, graph algorithms, concurrency, and multi-package architecture. This task is excluded from `run-all.sh` and runs separately via `run-mega-<model>.sh`.

Includes:
- `audit-session.sh` — interactive session picker, supports kimchi and claude runners
- `audit-session-prompt.md` — agent prompt with pricing tables and grade rubric
- `README.md` — usage docs and end-to-end walkthrough
- Updated top-level `README.md` with audit section
- New mega benchmark: concurrent build system with topological sort, worker pool, SIGINT handling, fail-fast, and comprehensive tests

Jira: LLM-1577

Exemplary output file: 
[session-20260511-135520-kimchi-claude-opus-4-7-AUDIT.md](https://github.com/user-attachments/files/27594559/session-20260511-135520-kimchi-claude-opus-4-7-AUDIT.md)

---
### Kimchi Summary
### What changed

Added a session phase audit tool that analyzes completed kimchi sessions for phase discipline, code quality, and cost efficiency, plus a new "mega" manual benchmark task. The main README now documents the full benchmark suite including manual benchmarks, terminal-bench-2, and session auditing.

### Why

Provides an automated way to evaluate harness session quality across architecture, testing strategy, and cost efficiency. The audit produces graded reports with actionable improvements, enabling data-driven iteration on model assignments and phase workflows.

### Key changes

- **`benchmark/audit-session/audit-session.sh`** — New entry-point script that discovers sessions, presents an interactive picker, selects the runner (`kimchi` or `claude`), and launches the audit agent.
- **`benchmark/audit-session/audit-session-prompt.md`** — New agent prompt template that instructs the auditor to gather evidence from session JSONL, score across 6 dimensions (Phase Discipline, Architecture, Code Quality, Testing, Phase-Model Alignment, Cost Efficiency), compute cost counterfactuals, and write a structured report to `.kimchi/audits/`.
- **`benchmark/audit-session/README.md`** — New documentation covering usage, CLI flags (`-l`, `-n`, `-r`, `-m`), evaluation rubric with weights, and an end-to-end example.
- **`benchmark/manual/new-session.sh`** — Added `mega` task (Go concurrent build system) with a multi-layer prompt requiring topological sort, worker pools, and SIGINT handling; excluded from `run-all.sh` by default.
- **`benchmark/manual/analyze-session.py`** — Added `mega` configuration thresholds (`min_subagents: 3`, `max_subagents: 6`, `max_tokens: 800_000`, `max_duration_s: 900`).
- **`benchmark/manual/tasks.md`** — Documented the `mega` task requirements and baseline implementation.
- **`README.md`** — Added "Benchmarking" section describing manual benchmarks, terminal-bench-2, and session phase audit.