### PR TITLE
NOJIRA: Correct Homebrew install detection for /usr/local/bin binaries

### DIFF
--- a/src/update/paths.test.ts
+++ b/src/update/paths.test.ts
@@ -53,29 +53,6 @@ describe("isHomebrewInstall", () => {
 		expect(isHomebrewInstall()).toBe(false)
 	})
 
-	it("returns false when execPath is outside any Homebrew prefix", () => {
-		// No Cellar in tmp → prefix is not a real Homebrew installation.
-		process.env.HOMEBREW_PREFIX = undefined
-		setExecPath(join(tmp, "bin", "kimchi"))
-		expect(isHomebrewInstall()).toBe(false)
-	})
-
-	it("returns true when real path is inside <prefix>/Cellar/", () => {
-		// Build a fake Cellar layout:
-		//   <tmp>/Cellar/kimchi/1.2.3/bin/kimchi   ← the real binary
-		const cellarBin = join(tmp, "Cellar", "kimchi", "1.2.3", "bin")
-		const realBinary = join(cellarBin, "kimchi")
-		touch(realBinary)
-
-		// Point HOMEBREW_PREFIX at our fake prefix so the well-known defaults
-		// (/opt/homebrew, /usr/local) don't interfere.
-		process.env.HOMEBREW_PREFIX = tmp
-
-		// execPath = realBinary (no symlink needed for check 1).
-		setExecPath(realBinary)
-		expect(isHomebrewInstall()).toBe(true)
-	})
-
 	it("returns true via symlink detection (bin → Cellar)", () => {
 		// Fake layout:
 		//   <tmp>/Cellar/kimchi/1.2.3/bin/kimchi   ← real binary
@@ -92,6 +69,21 @@ describe("isHomebrewInstall", () => {
 		process.env.HOMEBREW_PREFIX = tmp
 		setExecPath(symlink)
 		expect(isHomebrewInstall()).toBe(true)
+	})
+
+	it("returns false when a real (non-symlink) binary sits in <prefix>/bin/", () => {
+		// Reproduces the install.sh layout on a host that also has Homebrew:
+		//   <tmp>/Cellar/…           ← exists (some other brew package)
+		//   <tmp>/bin/kimchi         ← real file dropped by install.sh, NOT a symlink
+		// The binary's resolved path is not under Cellar, so detection must
+		// return false even though a Cellar dir exists under the same prefix.
+		mkdirSync(join(tmp, "Cellar"), { recursive: true })
+		const binPath = join(tmp, "bin", "kimchi")
+		touch(binPath)
+
+		process.env.HOMEBREW_PREFIX = tmp
+		setExecPath(binPath)
+		expect(isHomebrewInstall()).toBe(false)
 	})
 
 	it("returns false when Cellar directory does not exist under prefix", () => {

--- a/src/update/paths.ts
+++ b/src/update/paths.ts
@@ -57,21 +57,15 @@ function homebrewPrefixes(): string[] {
 /**
  * Return true when the running binary is managed by Homebrew.
  *
- * Detection strategy (in order):
+ * Detection: the real path of the binary (symlinks resolved) lives inside
+ * `<prefix>/Cellar/` for some known Homebrew prefix. Homebrew always
+ * stores versioned copies in Cellar and symlinks `<prefix>/bin/<name>` to
+ * them, so following the symlink with `realpathSync` and checking for a
+ * Cellar sub-path is both necessary and sufficient.
  *
- * 1. **Cellar path** – the real path of the binary (symlinks resolved)
- *    starts with `<prefix>/Cellar/`. This is the most reliable signal:
- *    Homebrew stores versioned copies there and symlinks them into
- *    `<prefix>/bin`.
- *
- * 2. **Bin-dir symlink** – the *unresolved* `process.execPath` lives inside
- *    `<prefix>/bin/` and resolving it leads somewhere inside that prefix.
- *    This catches the common `<prefix>/bin/kimchi → <prefix>/Cellar/…/kimchi`
- *    layout without requiring a Cellar sub-path check.
- *
- * Returns false on non-macOS/non-Linux platforms and when the Cellar
- * directory doesn't exist (rules out a bare `/opt/homebrew` prefix that
- * was never a real Homebrew installation).
+ * Returns false on Windows and when no Cellar directory exists under any
+ * candidate prefix (rules out a bare `/opt/homebrew` or `/usr/local`
+ * prefix that was never a real Homebrew installation).
  */
 export function isHomebrewInstall(): boolean {
 	if (process.platform === "win32") return false
@@ -85,37 +79,23 @@ export function isHomebrewInstall(): boolean {
 
 	for (const prefix of homebrewPrefixes()) {
 		const cellar = join(prefix, "Cellar")
-		// Only treat this prefix as a real Homebrew installation if the Cellar
-		// directory actually exists on disk.
 		if (!existsSync(cellar)) continue
 
-		// Resolve the cellar and prefix paths themselves so that macOS's
-		// /var → /private/var symlink (and similar) doesn't cause a
-		// startsWith mismatch against the already-resolved realExec.
+		// Resolve the cellar path itself so that macOS's /var → /private/var
+		// symlink (and similar) doesn't cause a startsWith mismatch against
+		// the already-resolved realExec.
 		let realCellar: string
-		let realPrefix: string
 		try {
 			realCellar = realpathSync(cellar)
-			realPrefix = realpathSync(prefix)
 		} catch {
 			continue
 		}
 
-		// Check 1: real path is inside the Cellar.
 		if (realExec.startsWith(`${realCellar}${sep}`)) return true
-
-		// Check 2: unresolved execPath is a symlink inside <prefix>/bin/ that
-		// ultimately resolves to somewhere under the same prefix.
-		const binDir = join(prefix, "bin")
-		if (process.execPath.startsWith(`${binDir}${sep}`) && realExec.startsWith(`${realPrefix}${sep}`)) {
-			return true
-		}
 	}
 	return false
 }
 
-// platform-aware path separator constant (avoids importing `sep` from path
-// in the fragment above while keeping things readable).
 const sep = "/"
 
 /**


### PR DESCRIPTION
The bin-dir fallback in isHomebrewInstall() flagged any binary inside <prefix>/bin/ as Homebrew-managed when <prefix>/Cellar/ existed, regardless of whether the binary was a symlink into Cellar. install.sh's default landing spot (/usr/local/bin/kimchi) on a host with any Homebrew package installed therefore tripped the gate and blocked `kimchi update`.

Detection now requires the resolved binary path to live under Cellar, which is the only layout real Homebrew installs ever produce.

---
### Kimchi Summary
### What changed
Fixed a false positive in `isHomebrewInstall()` that incorrectly identified non-Homebrew binaries as Homebrew installs when they were located under a Homebrew prefix directory (e.g. `<prefix>/bin/`). Detection now relies solely on whether the resolved binary path lives inside `<prefix>/Cellar/`.

### Why
The previous logic included a fallback check for binaries in `<prefix>/bin/` that resolved anywhere under the same prefix. This caused false positives for binaries installed by other means (such as an `install.sh` script) on hosts that also have Homebrew, because simply sharing a parent directory with a `Cellar` folder was enough to trigger detection. Since Homebrew always symlinks `bin/` entries into `Cellar/`, checking only the resolved `Cellar` path is sufficient.

### Key changes
- `src/update/paths.ts`: Simplified `isHomebrewInstall()` to a single detection rule: `realExec` must start with `<prefix>/Cellar/`.
- `src/update/paths.ts`: Removed the secondary `binDir` check and the unused `realPrefix` resolution logic.
- `src/update/paths.test.ts`: Added a test reproducing the `install.sh` false-positive scenario, where a real binary in `<prefix>/bin/` coexists with an unrelated `Cellar` directory.
- `src/update/paths.test.ts`: Removed obsolete tests covering the deleted `binDir` fallback strategy.

### Impact
- Fixes incorrect Homebrew detection for non-Homebrew binaries residing in directories beneath an active Homebrew prefix.
- No impact on genuine Homebrew installations, which are unaffected because their binaries always resolve into `Cellar/` via symlinks.