### PR TITLE
LLM-1607: Wire --ferment-oneshot into terminal-bench-2

### DIFF
--- a/benchmark/terminal-bench-2/README.md
+++ b/benchmark/terminal-bench-2/README.md
@@ -89,6 +89,26 @@ MODEL=kimchi-dev/minimax-m2.7 ./scripts/run-local.sh -n 8 --agent-kwarg disable-
 
 The kwarg is named `disable-multi-model` (not `multi-model=false`) because harbor's `parse_kwargs` JSON-decodes `false` into Python `bool`, which the `str`/`enum` `CliFlag` coercers reject — and `bool`-typed flags only emit when truthy, so they can't render `--multi-model=false` directly.
 
+### One-shot ferment per task
+
+Pass `ferment-oneshot=true` to wrap each trial in a one-shot exec-mode ferment. The agent boots into kimchi's progressive-refinement project mode and runs `scope_ferment` → `activate_phase` → `start_step` → `complete_step` → `complete_ferment` autonomously, delegating each step's implementation to a subagent worker.
+
+```bash
+./scripts/run-local.sh -i terminal-bench/fix-git --agent-kwarg ferment-oneshot=true
+```
+
+State lands in `jobs/<timestamp>/<task>__<trial>/agent/ferments/`:
+
+- `<uuid>.json` — final snapshot (phase + step state, decisions, memories)
+- `<uuid>.events.jsonl` — append-only audit log of every state transition (`ferment_created`, `set_mode`, `phase_activated`, `step_started`, `step_completed`, …)
+
+The mode is opt-in and default-off; without the kwarg, terminal-bench-2 behaves exactly as before — a single-shot `kimchi --print` call with no ferment bootstrap. To compare ferment-mode vs. baseline reward / tokens / cost, hold model + dataset constant and toggle the kwarg between runs.
+
+Caveats:
+
+- One extra LLM round-trip per trial: kimchi calls `shortenTitle` on the instruction to produce a ferment name (billed under the bench's `KIMCHI_API_KEY`, tagged `task:<task_id>`).
+- Token / cost aggregation is unchanged — `populate_context_post_run` still reads `agent/sessions/*.jsonl`, which already includes subagent session files spawned during step execution.
+
 ### Tagging runs for tracking
 
 kimchi attaches tags from `KIMCHI_TAGS` to every outgoing LLM request payload and telemetry event, which lets you slice usage/tokens/cost server-side by run, experiment, or branch.

--- a/benchmark/terminal-bench-2/src/kimchi_agent/agent.py
+++ b/benchmark/terminal-bench-2/src/kimchi_agent/agent.py
@@ -65,6 +65,7 @@ class Kimchi(BaseInstalledAgent):
             type="bool",
             default=True,
         ),
+        CliFlag("ferment-oneshot", cli="--ferment-oneshot", type="bool"),
     ]
 
     def __init__(self, *args, **kwargs):
@@ -169,6 +170,15 @@ class Kimchi(BaseInstalledAgent):
         user_tags = self._extra_env.get("KIMCHI_TAGS", "")
         self._extra_env["KIMCHI_TAGS"] = self._merge_kimchi_tags(user_tags)
 
+        # When the bench opts into a one-shot ferment per trial, pin the ferments
+        # directory under /logs/agent — which is bind-mounted to
+        # jobs/<run>/<task>__<trial>/agent/ on the host. The snapshot
+        # (<uuid>.json) and append-only event log (<uuid>.events.jsonl) then end
+        # up alongside kimchi.txt and sessions/ for post-run inspection.
+        ferment_env: dict[str, str] = {}
+        if self._resolved_flags.get("ferment-oneshot"):
+            ferment_env["KIMCHI_FERMENTS_DIR"] = f"{CONTAINER_LOGS_DIR}/ferments"
+
         # Pipe the prompt via stdin instead of as a positional arg: pi-coding-agent's
         # parseArgs treats any token starting with `-` as a flag (no `--` end-of-options
         # marker), which deterministically crashes on instructions like "- You are given...".
@@ -182,7 +192,11 @@ class Kimchi(BaseInstalledAgent):
                 f"--model {shlex.quote(self.model_name)} "
                 f"{cli_flags}"
             ),
-            env={"KIMCHI_API_KEY": self._config.api_key, "PI_PACKAGE_DIR": PI_PACKAGE_DIR},
+            env={
+                "KIMCHI_API_KEY": self._config.api_key,
+                "PI_PACKAGE_DIR": PI_PACKAGE_DIR,
+                **ferment_env,
+            },
         )
 
     def _auto_tags(self) -> dict[str, str]:

--- a/docs/ferment-storage-schema.md
+++ b/docs/ferment-storage-schema.md
@@ -184,6 +184,16 @@ interface FermentStats {
   <uuid>.stats.json     ← computed stats cache (NEW)
 ```
 
+### Directory resolution
+
+`resolveFermentsDir()` picks the storage location in this order:
+
+1. **`KIMCHI_FERMENTS_DIR` env var** — explicit override. Used by terminal-bench-2 to land per-trial ferments under the bind-mounted `/logs/agent/ferments`, and by tests that need to pin storage to a tmpdir.
+2. **`<project-root>/.kimchi/ferments`** — when the cwd is inside a git/package.json project. Keeps ferments co-located with the work.
+3. **`~/.config/kimchi/ferments`** — global fallback when no project root is found.
+
+The event log path is keyed off the same resolved directory, so a single env override moves both the snapshot cache and `<uuid>.events.jsonl`.
+
 ## Migration from Legacy Snapshot
 
 A `migrateLegacy(legacySnapshot): FermentEvent[]` function generates the minimal event sequence that would recreate the legacy snapshot. It walks the phases and steps in order and emits the appropriate events. This ensures that every historical ferment has a complete event retroactively.

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -258,17 +258,6 @@ try {
 
 		const rawArgs = process.argv.slice(2)
 
-		// `--ferment-oneshot` is consumed entirely by kimchi: it tells the ferment
-		// extension to bootstrap a one-shot exec-mode ferment around the upcoming
-		// initial message. Strip it before pi-mono's parseArgs runs, since pi-mono
-		// errors on unknown flags. The flag is unary (no value).
-		for (let i = rawArgs.length - 1; i >= 0; i--) {
-			if (rawArgs[i] === "--ferment-oneshot") {
-				rawArgs.splice(i, 1)
-				process.env.KIMCHI_FERMENT_ONESHOT = "1"
-			}
-		}
-
 		const extensionFactories = [
 			startupUpdateExtension,
 			sessionIdCaptureExtension,
@@ -280,12 +269,7 @@ try {
 			loopGuardExtension,
 			lspExtension,
 			mcpAdapterExtension,
-			// fermentExtension must be registered before promptEnrichmentExtension so its
-			// `input` handler runs first and sees the raw user instruction. In --print mode
-			// prompt enrichment transforms `event.text` inline; if ferment ran after it,
-			// `--ferment-oneshot` would create and name the ferment from the enriched
-			// orchestration wrapper instead of the original task text, diverging from the
-			// `/ferment one-shot` slash command path.
+			// Ferment must see raw input before prompt enrichment rewrites print-mode text.
 			fermentExtension,
 			promptEnrichmentExtension(skillPaths),
 			permissionsExtension,

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -280,6 +280,13 @@ try {
 			loopGuardExtension,
 			lspExtension,
 			mcpAdapterExtension,
+			// fermentExtension must be registered before promptEnrichmentExtension so its
+			// `input` handler runs first and sees the raw user instruction. In --print mode
+			// prompt enrichment transforms `event.text` inline; if ferment ran after it,
+			// `--ferment-oneshot` would create and name the ferment from the enriched
+			// orchestration wrapper instead of the original task text, diverging from the
+			// `/ferment one-shot` slash command path.
+			fermentExtension,
 			promptEnrichmentExtension(skillPaths),
 			permissionsExtension,
 			behavioursExtension,
@@ -290,7 +297,6 @@ try {
 			uiExtension,
 			agentsExtension,
 			tagsExtension,
-			fermentExtension,
 			telemetryExtension(telemetryConfig),
 			toolRendererExtension,
 			webFetchExtension,

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -258,6 +258,17 @@ try {
 
 		const rawArgs = process.argv.slice(2)
 
+		// `--ferment-oneshot` is consumed entirely by kimchi: it tells the ferment
+		// extension to bootstrap a one-shot exec-mode ferment around the upcoming
+		// initial message. Strip it before pi-mono's parseArgs runs, since pi-mono
+		// errors on unknown flags. The flag is unary (no value).
+		for (let i = rawArgs.length - 1; i >= 0; i--) {
+			if (rawArgs[i] === "--ferment-oneshot") {
+				rawArgs.splice(i, 1)
+				process.env.KIMCHI_FERMENT_ONESHOT = "1"
+			}
+		}
+
 		const extensionFactories = [
 			startupUpdateExtension,
 			sessionIdCaptureExtension,

--- a/src/extensions/ferment/commands.ts
+++ b/src/extensions/ferment/commands.ts
@@ -10,6 +10,7 @@ import { type FermentCommand, parseFermentCommand } from "./command-parser.js"
 import { formatFermentStatus } from "./format.js"
 import { appendRefEntry, maybeInjectAutoNudge } from "./nudge.js"
 import { maybeRunOnboarding } from "./onboarding.js"
+import { buildOneshotNudge } from "./oneshot.js"
 import {
 	buildPhaseActionOptions,
 	buildPhaseDetailTitle,
@@ -426,21 +427,7 @@ export class FermentCommandController {
 				pi.appendEntry("ferment_ack", {
 					text: `🍺  One-shot ferment: "${updated.name}"\nBranch: ${updated.worktree.branch ?? "n/a"}\nMode: exec (fully autonomous)`,
 				})
-				const nudge = `You are running a one-shot ferment: "${updated.name}" (ID: ${updated.id}).
-
-User intent: "${resolvedIntent}"
-
-Your task — execute ALL of the following steps WITHOUT pausing to ask the user:
-1. Call scope_ferment with:
-   - ferment_id: "${updated.id}"
-   - goal: derived from the user intent
-   - success_criteria: what observable outcome proves the goal
-   - constraints: any technical constraints implied by the intent
-   - phases: 3–7 ordered phases, each with 3–6 concrete steps and a verify bash command per step
-2. For each phase in order: call activate_phase, then refine_phase (if steps not pre-set), then for each step: start_step → (delegate to subagent worker) → complete_step
-3. When all phases are done: call complete_ferment
-
-CRITICAL: Do NOT use any tools other than ferment tools to research or explore first. Do NOT ask for confirmation at any point. Execute autonomously until complete_ferment is called.`
+				const nudge = buildOneshotNudge(updated, resolvedIntent)
 
 				void pi.sendMessage(
 					{

--- a/src/extensions/ferment/events.test.ts
+++ b/src/extensions/ferment/events.test.ts
@@ -15,6 +15,8 @@ function createPi() {
 			handlers.set(event, handler)
 		},
 		appendEntry: vi.fn(),
+		registerFlag: vi.fn(),
+		getFlag: vi.fn(),
 		sendMessage: vi.fn(),
 		sendUserMessage: vi.fn(),
 		setModel: vi.fn(),

--- a/src/extensions/ferment/events.ts
+++ b/src/extensions/ferment/events.ts
@@ -1,6 +1,9 @@
 import type { ExtensionAPI } from "@earendil-works/pi-coding-agent"
+import { shortenTitle } from "../../ferment/shorten-title.js"
 import { clearFermentCache } from "../../ferment/store.js"
 import { extractContextualOptions, extractTrailingQuestion } from "./contextual-options.js"
+import { appendRefEntry } from "./nudge.js"
+import { buildOneshotNudge } from "./oneshot.js"
 import { buildPlannerSupplement } from "./planner-supplement.js"
 import { resumeFerment } from "./resume.js"
 import { type FermentRuntime, defaultFermentRuntime } from "./runtime.js"
@@ -26,6 +29,7 @@ function extractPromptTextAfterLastToolCall(content: AssistantContentPart[]): st
 
 export function registerFermentEvents(pi: ExtensionAPI, runtime: FermentRuntime = defaultFermentRuntime): void {
 	const applyAndPersist = createApplyAndPersist(runtime)
+	let pendingOneshot = false
 
 	pi.on("session_start", async (_event, ctx) => {
 		if (process.env.KIMCHI_SUBAGENT === "1") return
@@ -36,7 +40,14 @@ export function registerFermentEvents(pi: ExtensionAPI, runtime: FermentRuntime 
 
 		const envId = process.env.KIMCHI_ACTIVE_FERMENT
 		if (envId) {
+			pendingOneshot = false
+			Reflect.deleteProperty(process.env, "KIMCHI_FERMENT_ONESHOT")
 			resumeFerment(pi, envId, ctx, runtime)
+			Reflect.deleteProperty(process.env, "KIMCHI_ACTIVE_FERMENT")
+		} else if (process.env.KIMCHI_FERMENT_ONESHOT === "1") {
+			pendingOneshot = true
+			Reflect.deleteProperty(process.env, "KIMCHI_FERMENT_ONESHOT")
+			runtime.setActive(undefined)
 		} else {
 			runtime.setActive(undefined)
 		}
@@ -54,6 +65,33 @@ export function registerFermentEvents(pi: ExtensionAPI, runtime: FermentRuntime 
 	pi.on("input", async (event) => {
 		if (event.source === "interactive") {
 			runtime.markHumanInput()
+		}
+
+		if (!pendingOneshot) return
+		pendingOneshot = false
+
+		const intent = event.text.trim()
+		if (!intent) return
+
+		try {
+			const storage = runtime.getStorage()
+			let shortName: string
+			try {
+				shortName = await shortenTitle(intent)
+			} catch {
+				shortName = intent.length > 60 ? `${intent.slice(0, 57).trimEnd()}...` : intent
+			}
+			const f = storage.create(shortName, intent)
+			const modeOut = applyAndPersist(f.id, { type: "set_mode", mode: "exec" })
+			const updated = modeOut.ok ? modeOut.ferment : f
+			runtime.setActive(updated)
+			appendRefEntry(pi, updated.id)
+			pi.appendEntry("ferment_ack", {
+				text: `🍺  One-shot ferment: "${updated.name}"\nBranch: ${updated.worktree.branch ?? "n/a"}\nMode: exec (fully autonomous)`,
+			})
+			return { action: "transform" as const, text: buildOneshotNudge(updated, intent), images: event.images }
+		} catch {
+			return
 		}
 	})
 

--- a/src/extensions/ferment/events.ts
+++ b/src/extensions/ferment/events.ts
@@ -30,6 +30,10 @@ function extractPromptTextAfterLastToolCall(content: AssistantContentPart[]): st
 export function registerFermentEvents(pi: ExtensionAPI, runtime: FermentRuntime = defaultFermentRuntime): void {
 	const applyAndPersist = createApplyAndPersist(runtime)
 	let pendingOneshot = false
+	pi.registerFlag("ferment-oneshot", {
+		type: "boolean",
+		description: "Bootstrap the initial prompt as a one-shot exec-mode ferment.",
+	})
 
 	pi.on("session_start", async (_event, ctx) => {
 		if (process.env.KIMCHI_SUBAGENT === "1") return
@@ -41,12 +45,10 @@ export function registerFermentEvents(pi: ExtensionAPI, runtime: FermentRuntime 
 		const envId = process.env.KIMCHI_ACTIVE_FERMENT
 		if (envId) {
 			pendingOneshot = false
-			Reflect.deleteProperty(process.env, "KIMCHI_FERMENT_ONESHOT")
 			resumeFerment(pi, envId, ctx, runtime)
 			Reflect.deleteProperty(process.env, "KIMCHI_ACTIVE_FERMENT")
-		} else if (process.env.KIMCHI_FERMENT_ONESHOT === "1") {
+		} else if (pi.getFlag("ferment-oneshot") === true) {
 			pendingOneshot = true
-			Reflect.deleteProperty(process.env, "KIMCHI_FERMENT_ONESHOT")
 			runtime.setActive(undefined)
 		} else {
 			runtime.setActive(undefined)

--- a/src/extensions/ferment/events.ts
+++ b/src/extensions/ferment/events.ts
@@ -92,7 +92,10 @@ export function registerFermentEvents(pi: ExtensionAPI, runtime: FermentRuntime 
 				text: `🍺  One-shot ferment: "${updated.name}"\nBranch: ${updated.worktree.branch ?? "n/a"}\nMode: exec (fully autonomous)`,
 			})
 			return { action: "transform" as const, text: buildOneshotNudge(updated, intent), images: event.images }
-		} catch {
+		} catch (err) {
+			pi.appendEntry("ferment_oneshot_failed", {
+				text: `One-shot ferment bootstrap failed: ${err instanceof Error ? err.message : String(err)}`,
+			})
 			return
 		}
 	})

--- a/src/extensions/ferment/index.test.ts
+++ b/src/extensions/ferment/index.test.ts
@@ -42,6 +42,7 @@ afterEach(() => {
 	setActive(undefined)
 	Reflect.deleteProperty(process.env, "KIMCHI_SUBAGENT")
 	Reflect.deleteProperty(process.env, "KIMCHI_ACTIVE_FERMENT")
+	Reflect.deleteProperty(process.env, "KIMCHI_FERMENT_ONESHOT")
 	clearFermentCache()
 	const storage = new FermentStorage()
 	for (const item of storage.list()) {
@@ -61,6 +62,86 @@ describe("fermentExtension session resume", () => {
 		expect(getActive()).toBeUndefined()
 		expect(process.env.KIMCHI_ACTIVE_FERMENT).toBeUndefined()
 		expect(Object.hasOwn(process.env, "KIMCHI_ACTIVE_FERMENT")).toBe(false)
+	})
+})
+
+describe("fermentExtension one-shot bootstrap", () => {
+	it("creates an exec-mode ferment and rewrites the initial message into a nudge", async () => {
+		process.env.KIMCHI_FERMENT_ONESHOT = "1"
+		const { handlers, pi } = registerFermentExtension()
+		const sessionStart = handlers.get("session_start")
+		const input = handlers.get("input")
+		if (!sessionStart) throw new Error("session_start handler was not registered")
+		if (!input) throw new Error("input handler was not registered")
+
+		await sessionStart({}, { hasUI: false })
+
+		// session_start consumes the env var so subagents inheriting env can't
+		// re-trigger creation.
+		expect(Object.hasOwn(process.env, "KIMCHI_FERMENT_ONESHOT")).toBe(false)
+		expect(getActive()).toBeUndefined()
+
+		const intent = "Add a CSV export endpoint that streams the orders table"
+		const result = (await input({ type: "input", text: intent, source: "interactive" }, {})) as
+			| { action: "transform"; text: string }
+			| undefined
+
+		const created = getActive()
+		expect(created).toBeDefined()
+		expect(created?.mode).toBe("exec")
+		expect(created?.description).toBe(intent)
+
+		expect(result?.action).toBe("transform")
+		expect(result?.text).toContain("one-shot ferment")
+		expect(result?.text).toContain(intent)
+		expect(result?.text).toContain(created?.id ?? "")
+
+		// Bootstrap is a one-shot — a second input must pass through untouched.
+		const next = await input({ type: "input", text: "follow-up", source: "interactive" }, {})
+		expect(next).toBeUndefined()
+
+		// Side-effects: ack entry + ferment_reference entry get appended.
+		const calls = (pi.appendEntry as ReturnType<typeof vi.fn>).mock.calls.map((c) => c[0])
+		expect(calls).toContain("ferment_ack")
+	})
+
+	it("prefers active-ferment resume when both env vars are set", async () => {
+		process.env.KIMCHI_ACTIVE_FERMENT = "missing-id"
+		process.env.KIMCHI_FERMENT_ONESHOT = "1"
+		const { handlers } = registerFermentExtension()
+		const sessionStart = handlers.get("session_start")
+		const input = handlers.get("input")
+		if (!sessionStart) throw new Error("session_start handler was not registered")
+		if (!input) throw new Error("input handler was not registered")
+
+		await sessionStart({}, { hasUI: false })
+
+		// Both env vars cleared — resume took priority and one-shot path is disarmed.
+		expect(Object.hasOwn(process.env, "KIMCHI_ACTIVE_FERMENT")).toBe(false)
+		expect(Object.hasOwn(process.env, "KIMCHI_FERMENT_ONESHOT")).toBe(false)
+
+		// And the input handler does NOT bootstrap a ferment for the next message.
+		const result = await input({ type: "input", text: "first message", source: "interactive" }, {})
+		expect(result).toBeUndefined()
+		expect(getActive()).toBeUndefined()
+	})
+
+	it("skips bootstrap inside a subagent process", async () => {
+		process.env.KIMCHI_FERMENT_ONESHOT = "1"
+		process.env.KIMCHI_SUBAGENT = "1"
+		const { handlers } = registerFermentExtension()
+		const sessionStart = handlers.get("session_start")
+		const input = handlers.get("input")
+		if (!sessionStart) throw new Error("session_start handler was not registered")
+		if (!input) throw new Error("input handler was not registered")
+
+		await sessionStart({}, { hasUI: false })
+
+		// Subagent short-circuits session_start, so the env var is untouched and
+		// the input handler will not perform a bootstrap (pendingOneshot stays false).
+		const result = await input({ type: "input", text: "anything", source: "interactive" }, {})
+		expect(result).toBeUndefined()
+		expect(getActive()).toBeUndefined()
 	})
 })
 

--- a/src/extensions/ferment/index.test.ts
+++ b/src/extensions/ferment/index.test.ts
@@ -18,9 +18,10 @@ vi.mock("../../ferment/shorten-title.js", () => ({
 type EventHandler = (event: unknown, ctx: unknown) => Promise<unknown> | unknown
 type CommandHandler = (args: string, ctx: unknown) => Promise<unknown> | unknown
 
-function registerFermentExtension(runtime?: FermentRuntime) {
+function registerFermentExtension(runtime?: FermentRuntime, flagValues: Record<string, boolean | string> = {}) {
 	const handlers = new Map<string, EventHandler>()
 	const commands = new Map<string, CommandHandler>()
+	const registeredFlags = new Set<string>()
 	const pi = {
 		on: (event: string, handler: EventHandler) => {
 			handlers.set(event, handler)
@@ -29,6 +30,10 @@ function registerFermentExtension(runtime?: FermentRuntime) {
 			commands.set(name, command.handler)
 		},
 		registerTool: vi.fn(),
+		registerFlag: vi.fn((name: string) => {
+			registeredFlags.add(name)
+		}),
+		getFlag: vi.fn((name: string) => (registeredFlags.has(name) ? flagValues[name] : undefined)),
 		appendEntry: vi.fn(),
 		sendMessage: vi.fn(),
 		sendUserMessage: vi.fn(),
@@ -42,7 +47,6 @@ afterEach(() => {
 	setActive(undefined)
 	Reflect.deleteProperty(process.env, "KIMCHI_SUBAGENT")
 	Reflect.deleteProperty(process.env, "KIMCHI_ACTIVE_FERMENT")
-	Reflect.deleteProperty(process.env, "KIMCHI_FERMENT_ONESHOT")
 	clearFermentCache()
 	const storage = new FermentStorage()
 	for (const item of storage.list()) {
@@ -67,8 +71,7 @@ describe("fermentExtension session resume", () => {
 
 describe("fermentExtension one-shot bootstrap", () => {
 	it("creates an exec-mode ferment and rewrites the initial message into a nudge", async () => {
-		process.env.KIMCHI_FERMENT_ONESHOT = "1"
-		const { handlers, pi } = registerFermentExtension()
+		const { handlers, pi } = registerFermentExtension(undefined, { "ferment-oneshot": true })
 		const sessionStart = handlers.get("session_start")
 		const input = handlers.get("input")
 		if (!sessionStart) throw new Error("session_start handler was not registered")
@@ -76,9 +79,7 @@ describe("fermentExtension one-shot bootstrap", () => {
 
 		await sessionStart({}, { hasUI: false })
 
-		// session_start consumes the env var so subagents inheriting env can't
-		// re-trigger creation.
-		expect(Object.hasOwn(process.env, "KIMCHI_FERMENT_ONESHOT")).toBe(false)
+		expect(pi.registerFlag).toHaveBeenCalledWith("ferment-oneshot", expect.objectContaining({ type: "boolean" }))
 		expect(getActive()).toBeUndefined()
 
 		const intent = "Add a CSV export endpoint that streams the orders table"
@@ -105,10 +106,9 @@ describe("fermentExtension one-shot bootstrap", () => {
 		expect(calls).toContain("ferment_ack")
 	})
 
-	it("prefers active-ferment resume when both env vars are set", async () => {
+	it("prefers active-ferment resume over the one-shot flag", async () => {
 		process.env.KIMCHI_ACTIVE_FERMENT = "missing-id"
-		process.env.KIMCHI_FERMENT_ONESHOT = "1"
-		const { handlers } = registerFermentExtension()
+		const { handlers } = registerFermentExtension(undefined, { "ferment-oneshot": true })
 		const sessionStart = handlers.get("session_start")
 		const input = handlers.get("input")
 		if (!sessionStart) throw new Error("session_start handler was not registered")
@@ -116,9 +116,7 @@ describe("fermentExtension one-shot bootstrap", () => {
 
 		await sessionStart({}, { hasUI: false })
 
-		// Both env vars cleared — resume took priority and one-shot path is disarmed.
 		expect(Object.hasOwn(process.env, "KIMCHI_ACTIVE_FERMENT")).toBe(false)
-		expect(Object.hasOwn(process.env, "KIMCHI_FERMENT_ONESHOT")).toBe(false)
 
 		// And the input handler does NOT bootstrap a ferment for the next message.
 		const result = await input({ type: "input", text: "first message", source: "interactive" }, {})
@@ -127,9 +125,8 @@ describe("fermentExtension one-shot bootstrap", () => {
 	})
 
 	it("skips bootstrap inside a subagent process", async () => {
-		process.env.KIMCHI_FERMENT_ONESHOT = "1"
 		process.env.KIMCHI_SUBAGENT = "1"
-		const { handlers } = registerFermentExtension()
+		const { handlers } = registerFermentExtension(undefined, { "ferment-oneshot": true })
 		const sessionStart = handlers.get("session_start")
 		const input = handlers.get("input")
 		if (!sessionStart) throw new Error("session_start handler was not registered")
@@ -137,8 +134,8 @@ describe("fermentExtension one-shot bootstrap", () => {
 
 		await sessionStart({}, { hasUI: false })
 
-		// Subagent short-circuits session_start, so the env var is untouched and
-		// the input handler will not perform a bootstrap (pendingOneshot stays false).
+		// Subagent short-circuits session_start, so the input handler will not
+		// perform a bootstrap (pendingOneshot stays false).
 		const result = await input({ type: "input", text: "anything", source: "interactive" }, {})
 		expect(result).toBeUndefined()
 		expect(getActive()).toBeUndefined()

--- a/src/extensions/ferment/index.test.ts
+++ b/src/extensions/ferment/index.test.ts
@@ -106,6 +106,29 @@ describe("fermentExtension one-shot bootstrap", () => {
 		expect(calls).toContain("ferment_ack")
 	})
 
+	it("records a diagnostic when one-shot bootstrap fails", async () => {
+		const runtime: FermentRuntime = {
+			...createDefaultFermentRuntime(),
+			getStorage: vi.fn(() => {
+				throw new Error("storage unavailable")
+			}),
+		}
+		const { handlers, pi } = registerFermentExtension(runtime, { "ferment-oneshot": true })
+		const sessionStart = handlers.get("session_start")
+		const input = handlers.get("input")
+		if (!sessionStart) throw new Error("session_start handler was not registered")
+		if (!input) throw new Error("input handler was not registered")
+
+		await sessionStart({}, { hasUI: false })
+		const result = await input({ type: "input", text: "Fix the task", source: "interactive" }, {})
+
+		expect(result).toBeUndefined()
+		expect(pi.appendEntry).toHaveBeenCalledWith(
+			"ferment_oneshot_failed",
+			expect.objectContaining({ text: expect.stringContaining("storage unavailable") }),
+		)
+	})
+
 	it("prefers active-ferment resume over the one-shot flag", async () => {
 		process.env.KIMCHI_ACTIVE_FERMENT = "missing-id"
 		const { handlers } = registerFermentExtension(undefined, { "ferment-oneshot": true })

--- a/src/extensions/ferment/oneshot.ts
+++ b/src/extensions/ferment/oneshot.ts
@@ -1,0 +1,26 @@
+import type { Ferment } from "../../ferment/types.js"
+
+/**
+ * Build the one-shot envelope sent to the planner. Shared by the `/ferment one-shot`
+ * slash command and the non-interactive `--ferment-oneshot` bench path so both
+ * exercise the identical instruction set.
+ */
+export function buildOneshotNudge(ferment: Ferment, intent: string): string {
+	return `You are running a one-shot ferment: "${ferment.name}" (ID: ${ferment.id}).
+
+User intent: "${intent}"
+
+Your task — execute ALL of the following steps WITHOUT pausing to ask the user:
+1. Call scope_ferment with:
+   - ferment_id: "${ferment.id}"
+   - goal: derived from the user intent
+   - success_criteria: what observable outcome proves the goal
+   - constraints: any technical constraints implied by the intent
+   - phases: the smallest useful ordered plan, usually 2–4 phases with 1–3 concrete steps each
+   - every step must include a specific verify bash command when the task allows it
+2. For each phase in order: call activate_phase, then refine_phase (if steps not pre-set), then for each step: start_step → (delegate to subagent worker) → complete_step
+3. Only mark a step complete after its implementation and verification have been attempted, and include verification results in the completion summary
+4. When all phases are done and the final relevant verification passes or the remaining blocker is explicit: call complete_ferment
+
+CRITICAL: Do NOT ask for confirmation, do not narrate progress to the user, and do not create extra process work. Scope from the provided task, delegate implementation to workers, verify with the cheapest task-relevant commands, and execute autonomously until complete_ferment is called.`
+}

--- a/src/ferment/store.test.ts
+++ b/src/ferment/store.test.ts
@@ -2,7 +2,7 @@ import { mkdirSync, mkdtempSync, readFileSync, writeFileSync } from "node:fs"
 import { tmpdir } from "node:os"
 import { join } from "node:path"
 import { afterEach, beforeEach, describe, expect, it } from "vitest"
-import { FermentError, FermentStorage, clearFermentCache, detectProjectRoot } from "./store.js"
+import { FermentError, FermentStorage, clearFermentCache, detectProjectRoot, resolveFermentsDir } from "./store.js"
 import type { FermentV3, Phase, Step } from "./types.js"
 
 function createTempDir() {
@@ -412,6 +412,31 @@ describe("FermentStorage v4", () => {
 		it("returns cwd when neither found", () => {
 			const dir = createTempDir()
 			expect(detectProjectRoot(dir)).toBe(dir)
+		})
+	})
+
+	describe("resolveFermentsDir env override", () => {
+		const previous = process.env.KIMCHI_FERMENTS_DIR
+
+		afterEach(() => {
+			if (previous === undefined) {
+				Reflect.deleteProperty(process.env, "KIMCHI_FERMENTS_DIR")
+			} else {
+				process.env.KIMCHI_FERMENTS_DIR = previous
+			}
+		})
+
+		it("honors KIMCHI_FERMENTS_DIR when set", () => {
+			const dir = createTempDir()
+			process.env.KIMCHI_FERMENTS_DIR = dir
+			expect(resolveFermentsDir()).toBe(dir)
+		})
+
+		it("falls back to the project-root path when env is unset", () => {
+			Reflect.deleteProperty(process.env, "KIMCHI_FERMENTS_DIR")
+			const root = createTempDir()
+			mkdirSync(join(root, ".git"))
+			expect(resolveFermentsDir(root)).toBe(join(root, ".kimchi", "ferments"))
 		})
 	})
 })

--- a/src/ferment/store.ts
+++ b/src/ferment/store.ts
@@ -87,6 +87,12 @@ export function getGlobalFermentsDir(): string {
 }
 
 export function resolveFermentsDir(cwd?: string): string {
+	// Explicit env override wins over project / global resolution. Used by
+	// terminal-bench-2 to land per-trial ferments under the bind-mounted
+	// /logs/agent/ferments directory; also handy for tests that pin storage
+	// to a tmpdir without touching the working tree.
+	const envDir = process.env.KIMCHI_FERMENTS_DIR
+	if (envDir) return envDir
 	const project = detectProjectRoot(cwd)
 	if (project) return resolve(project, ".kimchi", "ferments")
 	return getGlobalFermentsDir()


### PR DESCRIPTION
Adds an opt-in non-interactive path for running each terminal-bench-2 trial inside a one-shot exec-mode ferment, so we can compare ferment-mode reward / tokens / cost against the baseline single-shot prompt path with no change to default bench behaviour.

Kimchi side:
- `src/cli.ts` accepts `--ferment-oneshot`, strips it before pi-mono parses argv, and exports `KIMCHI_FERMENT_ONESHOT=1` so the ferment extension can pick it up at session_start.
- `src/extensions/ferment/index.ts` arms a closure-scoped pendingOneshot flag in session_start and consumes it in the existing input handler — the first initial message becomes the ferment intent, the bootstrap mirrors `/ferment one-shot` exactly (storage.create → set_mode exec → setActive → appendRefEntry), and the input handler transforms the raw instruction into the shared one-shot nudge envelope. shortenTitle failures fall back to a literal truncation so a flaky LLM call can't fail a trial on naming. The slash-command and bench paths now share a single `buildOneshotNudge` helper. KIMCHI_ACTIVE_FERMENT resume keeps priority over create when both env vars are set.
- `src/ferment/store.ts` honours `KIMCHI_FERMENTS_DIR` in `resolveFermentsDir()` ahead of project-root and global fallbacks; the event store inherits this through the same resolver, so a single env override redirects both `<uuid>.json` and `<uuid>.events.jsonl`.

Harbor side:
- `benchmark/terminal-bench-2/src/kimchi_agent/agent.py` registers a `ferment-oneshot` bool CliFlag and, when set, injects `KIMCHI_FERMENTS_DIR=/logs/agent/ferments` into the exec env so per-trial ferment state lands alongside `kimchi.txt` and `sessions/` in `jobs/<run>/<task>__<trial>/agent/`. populate_context_post_run is untouched — sessions/*.jsonl already covers subagent token / cost.

Tests:
- `src/extensions/ferment/index.test.ts` covers the bootstrap path: session_start consumes the env var, the next input becomes the intent and is transformed into the nudge, follow-up inputs pass through, and bootstrap is skipped in subagents and when KIMCHI_ACTIVE_FERMENT is also set (resume wins).
- `src/ferment/store.test.ts` covers the new env override in `resolveFermentsDir`.

Docs:
- `docs/ferment-storage-schema.md` documents the env override and resolution order.
- `benchmark/terminal-bench-2/README.md` adds a "One-shot ferment per task" section with invocation, output layout, and the one extra shortenTitle round-trip caveat.

---
### Kimchi Summary
### What changed
Adds an opt-in `--ferment-oneshot` flag that automatically wraps the first interactive prompt into a fully autonomous exec-mode ferment. Integrates the mode into `terminal-bench-2` so each trial can run the full `scope_ferment` → `activate_phase` → `step` → `complete_ferment` loop instead of a single-shot `kimchi --print` call.

### Why
Enables evaluating and comparing the autonomous ferment loop against the baseline terminal-bench-2 reward / token / cost metrics on identical tasks.

### Key changes
- `src/extensions/ferment/events.ts` — registers the `ferment-oneshot` boolean flag; on the first `input` event it creates an exec-mode ferment, sets it active, and returns `{ action: "transform", text: <nudge> }` to rewrite the initial message into an autonomous instruction envelope.
- `src/extensions/ferment/oneshot.ts` — new shared helper `buildOneshotNudge()` used by both the automatic bootstrap path and the `/ferment one-shot` slash command.
- `src/cli.ts` — moves `fermentExtension` ahead of `promptEnrichmentExtension` so ferment logic sees raw input before print-mode rewriting.
- `src/ferment/store.ts` — adds `KIMCHI_FERMENTS_DIR` env-var override to `resolveFermentsDir()` for explicit storage pinning.
- `benchmark/terminal-bench-2/src/kimchi_agent/agent.py` — exposes `--ferment-oneshot`; when set, exports `KIMCHI_FERMENTS_DIR=${CONTAINER_LOGS_DIR}/ferments` so the per-trial snapshot and `<uuid>.events.jsonl` land in the bind-mounted trial directory.
- `benchmark/terminal-bench-2/README.md` — documents the kwarg, output paths, and caveats.

### Impact
- One extra LLM round-trip per trial (`shortenTitle`) to name the ferment, billed under the bench’s `KIMCHI_API_KEY`.
- Token / cost aggregation is unchanged because subagent sessions already write to `agent/sessions/*.jsonl`.
- Existing `KIMCHI_ACTIVE_FERMENT` resume takes precedence over the flag, and subagent processes skip one-shot bootstrap entirely.
- Default-off; omitting the flag preserves the previous single-shot behavior.