### PR TITLE
make spinner messages to change less frequently

### DIFF
--- a/src/extensions/spinner.ts
+++ b/src/extensions/spinner.ts
@@ -63,7 +63,7 @@ const COOKING_FRAMES: readonly {
 const DOT_STATES = ["", ".", "..", "..."] as const
 
 const DOT_CYCLE_MS = 500
-const MESSAGE_CYCLE_MS = 1400
+const MESSAGE_CYCLE_MS = 6000
 
 let _resumeFrameIdx = 0
 


### PR DESCRIPTION


---
### Kimchi Summary
### What changed
Increases the display duration of each status message in the CLI spinner extension so text remains visible longer before advancing to the next frame.

### Why
The previous 1.4-second interval cycled too quickly for users to comfortably read each cooking status update.

### Key changes
- `src/extensions/spinner.ts`: Raised `MESSAGE_CYCLE_MS` from `1400` to `6000`.