### PR TITLE
LLM-1608: Ferment loop hangs after phase 1 is completed

### DIFF
--- a/docs/ferment.md
+++ b/docs/ferment.md
@@ -321,7 +321,7 @@ These tools are available to the agent during a ferment session. They are not me
 | `complete_phase` | Mark phase as completed. Judge grades it automatically. Leaves the ferment between phases unless another parallel phase remains active. |
 | `skip_phase` | Skip a phase (counts as terminal) |
 | `fail_phase` | Mark a phase as failed with a reason. The engine surfaces `recover_phase` before treating failed phases as terminal. |
-| `recover_phase` | Engine action for a failed phase. The planner chooses whether to retry with `activate_phase`, bypass with `skip_phase`, or abandon. |
+| `recover_phase` | Engine action for a failed phase. The planner chooses whether to retry with `activate_phase`, bypass with `skip_phase`, or ask the user to run `/ferment abandon`. |
 
 ### Step execution
 

--- a/docs/ferment.md
+++ b/docs/ferment.md
@@ -347,48 +347,66 @@ These tools are available to the agent during a ferment session. They are not me
 
 ## State machine (full)
 
+### Ferment lifecycle
+
 ```mermaid
 stateDiagram-v2
-    state "Ferment" as Ferment {
-        [*] --> Draft: create
-        Draft --> Planned: scope
-        Planned --> Running: activate_phase
-        Running --> Planned: complete_phase / skip_phase / fail_phase
-        Running --> Paused: pause
-        Planned --> Paused: pause
-        Paused --> Running: resume / active phase exists
-        Paused --> Planned: resume / no active phase
-        Planned --> Complete: complete_ferment
-        Running --> Complete: complete_ferment
-        Draft --> Abandoned: abandon
-        Planned --> Abandoned: abandon
-        Running --> Abandoned: abandon
-        Paused --> Abandoned: abandon
-    }
+    direction TB
 
-    state "Phase" as Phase {
-        [*] --> PhasePlanned
-        PhasePlanned --> PhaseActive: activate_phase
-        PhaseActive --> PhaseCompleted: complete_phase
-        PhaseActive --> PhaseSkipped: skip_phase
-        PhasePlanned --> PhaseSkipped: skip_phase
-        PhaseActive --> PhaseFailed: fail_phase
-        PhaseFailed --> PhaseActive: activate_phase / retry
-        PhaseFailed --> PhaseSkipped: skip_phase / bypass
-    }
+    [*] --> Draft: create
+    Draft --> Planned: scope
+    Planned --> Running: activate_phase
+    Running --> Planned: complete_phase / skip_phase / fail_phase
 
-    state "Step" as Step {
-        [*] --> StepPending
-        StepPending --> StepRunning: start_step
-        StepRunning --> StepDone: complete_step
-        StepRunning --> StepVerified: verify_step
-        StepPending --> StepSkipped: skip_step
-        StepRunning --> StepSkipped: skip_step
-        StepPending --> StepFailed: fail_step
-        StepRunning --> StepFailed: fail_step
-        StepFailed --> StepRunning: start_step / retry
-        StepFailed --> StepSkipped: skip_step / bypass
-    }
+    Running --> Paused: pause
+    Planned --> Paused: pause
+    Paused --> Running: resume / active phase exists
+    Paused --> Planned: resume / no active phase
+
+    Planned --> Complete: complete_ferment
+    Running --> Complete: complete_ferment
+
+    Draft --> Abandoned: abandon
+    Planned --> Abandoned: abandon
+    Running --> Abandoned: abandon
+    Paused --> Abandoned: abandon
+```
+
+### Phase lifecycle
+
+```mermaid
+stateDiagram-v2
+    direction TB
+
+    [*] --> Planned
+    Planned --> Active: activate_phase
+    Active --> Completed: complete_phase
+    Active --> Skipped: skip_phase
+    Planned --> Skipped: skip_phase
+    Active --> Failed: fail_phase
+
+    Failed --> Active: activate_phase / retry
+    Failed --> Skipped: skip_phase / bypass
+```
+
+### Step lifecycle
+
+```mermaid
+stateDiagram-v2
+    direction TB
+
+    [*] --> Pending
+    Pending --> Running: start_step
+    Running --> Done: complete_step
+    Running --> Verified: verify_step
+
+    Pending --> Skipped: skip_step
+    Running --> Skipped: skip_step
+
+    Pending --> Failed: fail_step
+    Running --> Failed: fail_step
+    Failed --> Running: start_step / retry
+    Failed --> Skipped: skip_step / bypass
 ```
 
 ---

--- a/docs/ferment.md
+++ b/docs/ferment.md
@@ -31,8 +31,13 @@ Ferment  ← the project ("Build Tetris")
 
 **Ferment status:**
 ```
-draft → planned → running ⇄ paused → complete
-                                    → abandoned
+draft → planned → running
+          ↑          │
+          └──────────┘ complete/skip/fail phase when no active phase remains
+
+planned/running → complete   (explicit complete_ferment)
+planned/running ⇄ paused     (internal user-intervention/session state)
+draft/planned/running/paused/complete → abandoned
 ```
 
 | Status | Meaning |
@@ -40,13 +45,16 @@ draft → planned → running ⇄ paused → complete
 | `draft` | Created, scoping in progress |
 | `planned` | Scoping confirmed, phases ready to execute |
 | `running` | At least one phase is active |
-| `paused` | User intervention requested (or session ended) |
-| `complete` | All phases terminal |
+| `paused` | Internal user-intervention/session state; ferment tools are blocked until resume |
+| `complete` | Explicitly finalized after all phases are terminal |
 | `abandoned` | Permanently stopped — cannot resume |
 
 **Phase status:** `planned → active → completed / skipped / failed`
 
-**Step status:** `pending → running → done / skipped / verified / failed`
+**Step status:** `pending → running → done / skipped / verified / failed` (`failed` steps can be recovered by starting them again)
+
+For the lower-level transition reference, see
+[`docs/ferment-state-transitions.md`](./ferment-state-transitions.md).
 
 ---
 
@@ -145,6 +153,10 @@ Run `/progress` for full phase/step navigation with grades and actions.
 /pause     ← stop auto-mode (ferment stays "running")
 /auto      ← resume
 ```
+
+`/pause` only disables auto-mode. It does not persist the ferment as `paused`.
+The persisted `paused` status is reserved for internal user-intervention and
+session-resume paths.
 
 Sessions resume automatically. When you close and reopen Kimchi with an active ferment, the agent picks up exactly where it left off.
 
@@ -300,7 +312,7 @@ These tools are available to the agent during a ferment session. They are not me
 | `scope_ferment` | Save confirmed scoping answers → `draft` to `planned` |
 | `update_scope_field` | Update a single scoping field mid-draft |
 | `set_ferment_mode` | Change work mode (`plan` / `exec` / `auto`) |
-| `complete_ferment` | Mark all phases done → `complete` |
+| `complete_ferment` | Mark the ferment `complete` after all phases are terminal |
 | `list_ferments` | List ferments, optionally filtered by status |
 
 ### Phase execution
@@ -309,9 +321,10 @@ These tools are available to the agent during a ferment session. They are not me
 |------|-------------|
 | `activate_phase` | Transition a planned phase to active. Activates all phases in a parallel group simultaneously. |
 | `refine_phase` | Populate a phase with concrete steps (3–6). Can set `worker_model`, `verification`, and `canRunParallel` per step. |
-| `complete_phase` | Mark phase as completed. Judge grades it automatically. In plan mode, shows a TUI dropdown before activating the next phase. |
+| `complete_phase` | Mark phase as completed. Judge grades it automatically. Leaves the ferment between phases unless another parallel phase remains active. |
 | `skip_phase` | Skip a phase (counts as terminal) |
-| `fail_phase` | Mark a phase as failed with a reason |
+| `fail_phase` | Mark a phase as failed with a reason. The engine surfaces `recover_phase` before treating failed phases as terminal. |
+| `recover_phase` | Engine action for a failed phase. The planner chooses whether to retry with `activate_phase`, bypass with `skip_phase`, or abandon. |
 
 ### Step execution
 
@@ -334,36 +347,48 @@ These tools are available to the agent during a ferment session. They are not me
 
 ## State machine (full)
 
-```
-                    ┌─────────────────────────────┐
-                    │           FERMENT            │
-                    │                              │
-  create ──► draft ──► planned ──► running ──► complete
-                                     │
-                                   paused ◄──► running
-                                     │
-                                  abandoned
-                    └─────────────────────────────┘
+```mermaid
+stateDiagram-v2
+    state "Ferment" as Ferment {
+        [*] --> Draft: create
+        Draft --> Planned: scope
+        Planned --> Running: activate_phase
+        Running --> Planned: complete_phase / skip_phase / fail_phase
+        Running --> Paused: pause
+        Planned --> Paused: pause
+        Paused --> Running: resume / active phase exists
+        Paused --> Planned: resume / no active phase
+        Planned --> Complete: complete_ferment
+        Running --> Complete: complete_ferment
+        Draft --> Abandoned: abandon
+        Planned --> Abandoned: abandon
+        Running --> Abandoned: abandon
+        Paused --> Abandoned: abandon
+    }
 
-                    ┌──────────────────────┐
-                    │         PHASE        │
-                    │                      │
-            planned ──► active ──► completed
-                           │
-                         failed
-                           │
-                         skipped
-                    └──────────────────────┘
+    state "Phase" as Phase {
+        [*] --> PhasePlanned
+        PhasePlanned --> PhaseActive: activate_phase
+        PhaseActive --> PhaseCompleted: complete_phase
+        PhaseActive --> PhaseSkipped: skip_phase
+        PhasePlanned --> PhaseSkipped: skip_phase
+        PhaseActive --> PhaseFailed: fail_phase
+        PhaseFailed --> PhaseActive: activate_phase / retry
+        PhaseFailed --> PhaseSkipped: skip_phase / bypass
+    }
 
-                    ┌─────────────────────────────┐
-                    │           STEP               │
-                    │                              │
-            pending ──► running ──► done ──► verified
-                           │
-                         failed
-                           │
-                         skipped
-                    └─────────────────────────────┘
+    state "Step" as Step {
+        [*] --> StepPending
+        StepPending --> StepRunning: start_step
+        StepRunning --> StepDone: complete_step
+        StepRunning --> StepVerified: verify_step
+        StepPending --> StepSkipped: skip_step
+        StepRunning --> StepSkipped: skip_step
+        StepPending --> StepFailed: fail_step
+        StepRunning --> StepFailed: fail_step
+        StepFailed --> StepRunning: start_step / retry
+        StepFailed --> StepSkipped: skip_step / bypass
+    }
 ```
 
 ---

--- a/docs/ferment.md
+++ b/docs/ferment.md
@@ -53,9 +53,6 @@ draft/planned/running/paused/complete → abandoned
 
 **Step status:** `pending → running → done / skipped / verified / failed` (`failed` steps can be recovered by starting them again)
 
-For the lower-level transition reference, see
-[`docs/ferment-state-transitions.md`](./ferment-state-transitions.md).
-
 ---
 
 ## Work modes

--- a/src/extensions/ferment/commands.test.ts
+++ b/src/extensions/ferment/commands.test.ts
@@ -170,4 +170,42 @@ describe("registerFermentCommands", () => {
 		expect(active.status).toBe("running")
 		expect(h.pi.setActiveTools).toHaveBeenLastCalledWith(["read", "bash", "create_ferment", "start_step"])
 	})
+
+	it("/pause disables auto-mode without changing ferment status", async () => {
+		const h = createHarness()
+		const applyAndPersist = createApplyAndPersist(h.runtime)
+		const ferment = h.storage.create("Running Ferment")
+		const scoped = applyAndPersist(ferment.id, {
+			type: "scope",
+			goal: "Goal",
+			successCriteria: "Works",
+			constraints: [],
+			phases: [{ name: "Phase", goal: "Build", steps: [{ description: "Do it" }] }],
+		})
+		if (!scoped.ok) throw new Error(scoped.error.message)
+		const activated = applyAndPersist(scoped.ferment.id, { type: "activate_phase", phaseId: "phase-1" })
+		if (!activated.ok) throw new Error(activated.error.message)
+
+		let active = activated.ferment
+		h.runtime.getActive = vi.fn(() => active)
+		h.runtime.setAutoModeEnabled = vi.fn()
+
+		const commands = new Map<string, RegisteredCommand>()
+		const pi = {
+			...h.pi,
+			registerCommand: (name: string, command: RegisteredCommand) => {
+				commands.set(name, command)
+			},
+		} as unknown as ExtensionAPI
+		registerFermentCommands(pi, h.runtime)
+
+		const pauseCommand = commands.get("pause")
+		if (!pauseCommand) throw new Error("pause command was not registered")
+		await pauseCommand.handler("", h.ctx)
+
+		active = h.storage.get(active.id) ?? active
+		expect(h.runtime.setAutoModeEnabled).toHaveBeenCalledWith(false)
+		expect(active.status).toBe("running")
+		expect(h.ctx.ui.notify).toHaveBeenCalledWith(expect.stringContaining('Ferment remains "running"'))
+	})
 })

--- a/src/extensions/ferment/commands.ts
+++ b/src/extensions/ferment/commands.ts
@@ -552,8 +552,7 @@ export function registerFermentCommands(pi: ExtensionAPI, runtime: FermentRuntim
 	})
 
 	pi.registerCommand("pause", {
-		description:
-			"Pause the active ferment — flips status to 'paused'; the state machine then refuses every ferment tool call until /auto.",
+		description: "Pause auto-mode for the active ferment without changing ferment state.",
 		async handler(_, ctx) {
 			runtime.setAutoModeEnabled(false)
 
@@ -563,18 +562,12 @@ export function registerFermentCommands(pi: ExtensionAPI, runtime: FermentRuntim
 				return
 			}
 
-			if (active.status === "running" || active.status === "planned") {
-				const outcome = applyAndPersist(active.id, { type: "pause" })
-				if (!outcome.ok) {
-					ctx.ui.notify(`Cannot pause: ${outcome.error.message}`)
-					return
-				}
-			} else if (active.status !== "paused") {
+			if (active.status !== "running" && active.status !== "planned" && active.status !== "paused") {
 				ctx.ui.notify(`Ferment is "${active.status}" — nothing to pause.`)
 				return
 			}
 
-			ctx.ui.notify(`Ferment "${active.name}" paused. Type /auto to resume.`)
+			ctx.ui.notify(`Auto-mode paused for "${active.name}". Ferment remains "${active.status}". Type /auto to resume.`)
 			syncFermentToolScope(pi, runtime.getActive())
 		},
 	})

--- a/src/extensions/ferment/events.test.ts
+++ b/src/extensions/ferment/events.test.ts
@@ -94,4 +94,38 @@ describe("registerFermentEvents", () => {
 		)
 		expect((result as { systemPrompt: string }).systemPrompt).toContain("Injected Runtime Plan")
 	})
+
+	it("keeps planner supplement active while a ferment is planned between phases", async () => {
+		const now = "2026-01-01T00:00:00.000Z"
+		const active: Ferment = {
+			id: "ferment-1",
+			name: "Between Phases",
+			status: "planned",
+			mode: "plan",
+			worktree: { path: "/repo" },
+			scoping: {},
+			phases: [
+				{ id: "phase-1", index: 1, name: "Done", goal: "G1", status: "completed", steps: [] },
+				{ id: "phase-2", index: 2, name: "Next", goal: "G2", status: "planned", steps: [] },
+			],
+			decisions: [],
+			memories: [],
+			createdAt: now,
+			updatedAt: now,
+		}
+		const runtime: FermentRuntime = {
+			...createDefaultFermentRuntime(),
+			getActive: () => active,
+		}
+		const { handlers, pi } = createPi()
+
+		registerFermentEvents(pi, runtime)
+		const beforeAgentStart = handlers.get("before_agent_start")
+		if (!beforeAgentStart) throw new Error("before_agent_start handler was not registered")
+
+		const result = await beforeAgentStart({ systemPrompt: "base prompt" }, {})
+
+		expect((result as { systemPrompt: string }).systemPrompt).toContain("Ferment Planner Role")
+		expect((result as { systemPrompt: string }).systemPrompt).toContain("Between Phases")
+	})
 })

--- a/src/extensions/ferment/events.ts
+++ b/src/extensions/ferment/events.ts
@@ -109,7 +109,7 @@ export function registerFermentEvents(pi: ExtensionAPI, runtime: FermentRuntime 
 			const pausedSupplement = `\n\n## Ferment Paused\n\nFerment "${f.name}" is paused by the user. Do NOT call any ferment tools (activate_phase, start_step, complete_step, etc.) — they will be rejected. Acknowledge any pending question briefly and wait for the user to resume with /auto.`
 			return { systemPrompt: `${event.systemPrompt}${pausedSupplement}` }
 		}
-		if (f.status !== "running") return {}
+		if (f.status !== "running" && f.status !== "planned") return {}
 		const supplement = buildPlannerSupplement(runtime)
 		return { systemPrompt: `${event.systemPrompt}${supplement}` }
 	})

--- a/src/extensions/ferment/nudge.test.ts
+++ b/src/extensions/ferment/nudge.test.ts
@@ -109,7 +109,9 @@ describe("ferment nudges", () => {
 			expect.objectContaining({
 				content: [
 					expect.objectContaining({
-						text: expect.stringContaining("call activate_phase to retry, skip_phase to bypass"),
+						text: expect.stringContaining(
+							"call activate_phase to retry, call skip_phase to bypass, or ask the user to run /ferment abandon",
+						),
 					}),
 				],
 			}),

--- a/src/extensions/ferment/nudge.test.ts
+++ b/src/extensions/ferment/nudge.test.ts
@@ -90,4 +90,30 @@ describe("ferment nudges", () => {
 		expect(setActiveSpy).toHaveBeenCalledWith(expect.objectContaining({ id: scoped.ferment.id }))
 		expect(getActive()).toBeUndefined()
 	})
+
+	it("nudges failed phase recovery with retry and bypass actions", () => {
+		const pi = createPi()
+		const runtime: FermentRuntime = {
+			...createDefaultFermentRuntime(),
+			getActive: () =>
+				makeDraftFerment({
+					status: "planned",
+					phases: [{ id: "phase-1", index: 1, name: "Phase", goal: "Build", status: "failed", steps: [] }],
+				}),
+			isAutoModeEnabled: () => true,
+		}
+
+		maybeInjectAutoNudge(pi, { force: true }, runtime)
+
+		expect(pi.sendMessage).toHaveBeenCalledWith(
+			expect.objectContaining({
+				content: [
+					expect.objectContaining({
+						text: expect.stringContaining("call activate_phase to retry, skip_phase to bypass"),
+					}),
+				],
+			}),
+			{ triggerTurn: true, deliverAs: "followUp" },
+		)
+	})
 })

--- a/src/extensions/ferment/nudge.ts
+++ b/src/extensions/ferment/nudge.ts
@@ -50,7 +50,7 @@ const TRANSITION_KINDS = new Set([
  *   activate_phase   → activate_phase
  *   complete_phase   → complete_phase
  *   recover_step     → fail_step / skip_step / start_step (host-decides)
- *   recover_phase    → activate_phase / skip_phase
+ *   recover_phase    → activate_phase / skip_phase / abandon (host-decides)
  */
 function buildResumeNudgeMessage(
 	action: DeclarativeAction,
@@ -72,7 +72,7 @@ function buildResumeNudgeMessage(
 		case "recover_step":
 			return `${preamble}\n\nThe step previously failed. Decide based on the failure: call start_step to retry, skip_step to bypass, or fail_step to mark it permanently failed. Pick one and call it now.`
 		case "recover_phase":
-			return `${preamble}\n\nThe phase previously failed. Decide based on the failure: call activate_phase to retry, or skip_phase to bypass. Pick one and call it now.`
+			return `${preamble}\n\nThe phase previously failed. Decide based on the failure: call activate_phase to retry, skip_phase to bypass, or abandon if the ferment should stop. Pick one and call it now.`
 		case "scope":
 			return `${preamble}\n\nAction: continue scoping — ${action.reason}.`
 		case "complete_step":
@@ -110,9 +110,11 @@ export function maybeInjectAutoNudge(
 	// `force` option overrides this to support explicit /auto resume.
 	if (!opts.force && !TRANSITION_KINDS.has(action.kind)) return
 
+	const actionPhase = "phaseId" in action ? f.phases.find((p) => p.id === action.phaseId) : undefined
 	const activePhase = f.phases.find((p) => p.id === f.activePhaseId)
+	const displayPhase = actionPhase ?? activePhase
 	const activeStep = activePhase?.steps.find((s) => s.status === "running" || s.status === "pending")
-	const phaseInfo = activePhase ? ` · phase ${activePhase.index}/${f.phases.length} "${activePhase.name}"` : ""
+	const phaseInfo = displayPhase ? ` · phase ${displayPhase.index}/${f.phases.length} "${displayPhase.name}"` : ""
 	const stepInfo = activeStep ? ` · step ${activeStep.index}/${activePhase?.steps.length}` : ""
 	const tag = opts.force ? "Resume" : "Auto-nudge"
 	const breadcrumb = `${tag} [${action.kind}]: "${f.name}" [${f.status}]${phaseInfo}${stepInfo}`
@@ -120,7 +122,7 @@ export function maybeInjectAutoNudge(
 	// Compose the message from the structured action rather than passing through
 	// the engine's prose. The reason field provides a one-sentence objective.
 	const messageText = opts.force
-		? buildResumeNudgeMessage(action, f.id, activePhase?.id, activeStep?.id)
+		? buildResumeNudgeMessage(action, f.id, displayPhase?.id, activeStep?.id)
 		: `${action.kind}: ${action.reason}`
 
 	pi.appendEntry("ferment_breadcrumb", { text: breadcrumb })

--- a/src/extensions/ferment/nudge.ts
+++ b/src/extensions/ferment/nudge.ts
@@ -50,7 +50,7 @@ const TRANSITION_KINDS = new Set([
  *   activate_phase   → activate_phase
  *   complete_phase   → complete_phase
  *   recover_step     → fail_step / skip_step / start_step (host-decides)
- *   recover_phase    → activate_phase / skip_phase / abandon (host-decides)
+ *   recover_phase    → activate_phase / skip_phase, or ask user for /ferment abandon
  */
 function buildResumeNudgeMessage(
 	action: DeclarativeAction,
@@ -72,7 +72,7 @@ function buildResumeNudgeMessage(
 		case "recover_step":
 			return `${preamble}\n\nThe step previously failed. Decide based on the failure: call start_step to retry, skip_step to bypass, or fail_step to mark it permanently failed. Pick one and call it now.`
 		case "recover_phase":
-			return `${preamble}\n\nThe phase previously failed. Decide based on the failure: call activate_phase to retry, skip_phase to bypass, or abandon if the ferment should stop. Pick one and call it now.`
+			return `${preamble}\n\nThe phase previously failed. Decide based on the failure: call activate_phase to retry, call skip_phase to bypass, or ask the user to run /ferment abandon if the ferment should stop. Pick a tool call now unless abandonment is required.`
 		case "scope":
 			return `${preamble}\n\nAction: continue scoping — ${action.reason}.`
 		case "complete_step":

--- a/src/extensions/ferment/tool-helpers.test.ts
+++ b/src/extensions/ferment/tool-helpers.test.ts
@@ -116,6 +116,6 @@ describe("createApplyAndPersist", () => {
 		const outcome = applyAndPersist(planned.id, { type: "resume" })
 
 		expect(outcome.ok).toBe(true)
-		if (outcome.ok) expect(outcome.ferment.status).toBe("running")
+		if (outcome.ok) expect(outcome.ferment.status).toBe("planned")
 	})
 })

--- a/src/extensions/ferment/tools.integration.test.ts
+++ b/src/extensions/ferment/tools.integration.test.ts
@@ -324,6 +324,20 @@ describe("activate_phase", () => {
 		expect(loadFerment(id).phases[0].status).toBe("active")
 	})
 
+	it("falls back to failed phase recovery before activating a planned phase", async () => {
+		const id = await createFerment("Retry Fallback")
+		await scopeFerment(id)
+		ok(await h.call("activate_phase", { ferment_id: id, phase_id: "phase-1" }))
+		ok(await h.call("fail_phase", { ferment_id: id, phase_id: "phase-1", reason: "tests failed" }))
+
+		ok(await h.call("activate_phase", { ferment_id: id }))
+
+		const f = loadFerment(id)
+		expect(f.phases[0].status).toBe("active")
+		expect(f.phases[1].status).toBe("planned")
+		expect(f.activePhaseId).toBe("phase-1")
+	})
+
 	it("activates all phases in a parallel group", async () => {
 		const id = await createFerment("Parallel Activate")
 		await scopeFerment(id, {
@@ -351,7 +365,7 @@ describe("activate_phase", () => {
 		s.skipPhase(id, "phase-2", "skip")
 
 		const result = await h.call("activate_phase", { ferment_id: id })
-		expect(err(result)).toMatch(/no planned phases/i)
+		expect(err(result)).toMatch(/no planned or failed phases/i)
 	})
 
 	it("returns error when ferment not found", async () => {

--- a/src/extensions/ferment/tools.integration.test.ts
+++ b/src/extensions/ferment/tools.integration.test.ts
@@ -887,8 +887,8 @@ describe("paused ferment blocks tool calls at the bridge", () => {
 		const id = await createFerment("Paused Test")
 		await scopeFerment(id)
 		ok(await h.call("activate_phase", { ferment_id: id, phase_id: "phase-1" }))
-		// Flip to paused via storage (the /pause command path is exercised by
-		// the index.ts handler; here we just need the state).
+		// Flip to paused via storage; here we just need bridge-level enforcement
+		// for an already-paused ferment.
 		const s = h.storage
 		s.updateStatus(id, "paused")
 		clearFermentCache()

--- a/src/extensions/ferment/tools/phases.ts
+++ b/src/extensions/ferment/tools/phases.ts
@@ -398,7 +398,7 @@ export function registerPhaseTools(pi: ExtensionAPI, runtime: FermentRuntime = d
 			})
 			if (!outcome.ok) return failedToolResult(outcome.error)
 			return toolOk(
-				`Phase marked as failed: ${params.reason}. Use activate_phase to retry, skip_phase to bypass, or abandon if the ferment should stop.`,
+				`Phase marked as failed: ${params.reason}. Use activate_phase to retry, skip_phase to bypass, or ask the user to run /ferment abandon if the ferment should stop.`,
 			)
 		},
 	})

--- a/src/extensions/ferment/tools/phases.ts
+++ b/src/extensions/ferment/tools/phases.ts
@@ -398,7 +398,7 @@ export function registerPhaseTools(pi: ExtensionAPI, runtime: FermentRuntime = d
 			})
 			if (!outcome.ok) return failedToolResult(outcome.error)
 			return toolOk(
-				`Phase marked as failed: ${params.reason}. Options: skip_phase to skip it, activate_phase to retry, or /ferment abandon.`,
+				`Phase marked as failed: ${params.reason}. Use activate_phase to retry, skip_phase to bypass, or abandon if the ferment should stop.`,
 			)
 		},
 	})

--- a/src/extensions/ferment/tools/phases.ts
+++ b/src/extensions/ferment/tools/phases.ts
@@ -221,8 +221,8 @@ export function registerPhaseTools(pi: ExtensionAPI, runtime: FermentRuntime = d
 				const name = params.phase_id.toLowerCase()
 				target = f.phases.find((p) => p.name.toLowerCase().includes(name))
 			}
-			if (!target) target = findFirstPlannedPhase(f)
-			if (!target) return toolErr("No planned phases to activate.")
+			if (!target) target = f.phases.find((p) => p.status === "failed") ?? findFirstPlannedPhase(f)
+			if (!target) return toolErr("No planned or failed phases to activate.")
 
 			// FSM validation: ensure phase activation is allowed
 			const fsmError = validateFsmTransition(f, "ACTIVATE_PHASE", { phaseId: target.id })

--- a/src/ferment/engine.test.ts
+++ b/src/ferment/engine.test.ts
@@ -57,6 +57,22 @@ describe("whatNext", () => {
 			}
 		})
 
+		it("planned after a failed phase → recover failed phase", () => {
+			const a = whatNext(
+				makeF({
+					status: "planned",
+					activePhaseId: "p1",
+					phases: [makeP({ status: "failed" }), makeP({ id: "p2", index: 2, name: "P2" })],
+				}),
+			)
+			expect(a.kind).toBe("recover_phase")
+			if (a.kind === "recover_phase") {
+				expect(a.phaseId).toBe("p1")
+				expect(a.message).toContain("activate_phase")
+				expect(a.message).toContain("skip_phase")
+			}
+		})
+
 		it("running with no steps → refine", () => {
 			const a = whatNext(makeF({ status: "running", activePhaseId: "p1", phases: [makeP({ status: "active" })] }))
 			expect(a.kind).toBe("refine")
@@ -130,7 +146,7 @@ describe("whatNext", () => {
 			expect(a.kind).toBe("recover_step")
 		})
 
-		it("running with failed phase → recover_phase", () => {
+		it("running with failed phase and all phases terminal → recover_phase", () => {
 			const a = whatNext(
 				makeF({ mode: "plan", status: "running", activePhaseId: "p1", phases: [makeP({ status: "failed" })] }),
 			)
@@ -205,7 +221,7 @@ describe("whatNext", () => {
 			expect(a.kind).toBe("recover_step")
 		})
 
-		it("running with failed phase → recover_phase", () => {
+		it("running with failed phase and all phases terminal → recover_phase", () => {
 			const a = whatNext(makeF({ status: "running", activePhaseId: "p1", phases: [makeP({ status: "failed" })] }))
 			expect(a.kind).toBe("recover_phase")
 		})

--- a/src/ferment/engine.test.ts
+++ b/src/ferment/engine.test.ts
@@ -44,6 +44,19 @@ describe("whatNext", () => {
 			}
 		})
 
+		it("planned between phases → activate next planned phase", () => {
+			const a = whatNext(
+				makeF({
+					status: "planned",
+					phases: [makeP({ status: "completed" }), makeP({ id: "p2", index: 2, name: "P2" })],
+				}),
+			)
+			expect(a.kind).toBe("activate_phase")
+			if (a.kind === "activate_phase") {
+				expect(a.phaseId).toBe("p2")
+			}
+		})
+
 		it("running with no steps → refine", () => {
 			const a = whatNext(makeF({ status: "running", activePhaseId: "p1", phases: [makeP({ status: "active" })] }))
 			expect(a.kind).toBe("refine")

--- a/src/ferment/engine.ts
+++ b/src/ferment/engine.ts
@@ -59,13 +59,11 @@ export function determineNextAction(ferment: Ferment): DeclarativeAction {
 		return { kind: "pause", reason: "ferment is paused" }
 	}
 
-	// 3. Active phase failed → recover (before all-terminal check)
-	if (active && active.status === "failed") {
-		return {
-			kind: "recover_phase",
-			phaseId: active.id,
-			reason: "handle failed phase",
-		}
+	// 3. Failed phase → recover_phase. This must run before all-terminal
+	// completion so failed phases can be retried or explicitly bypassed.
+	const failedPhase = ferment.phases.find((p) => p.status === "failed")
+	if (failedPhase) {
+		return { kind: "recover_phase", phaseId: failedPhase.id, reason: "handle failed phase" }
 	}
 
 	// 4. All phases terminal → complete_ferment
@@ -234,7 +232,7 @@ function toFermentAction(action: DeclarativeAction, ferment: Ferment): FermentAc
 			return {
 				kind: "recover_phase",
 				phaseId: action.phaseId,
-				message: `Phase ${phase?.index} "${phase?.name}" failed.`,
+				message: `Phase ${phase?.index} "${phase?.name}" failed. Retry it with activate_phase, bypass it with skip_phase, or abandon the ferment.`,
 			}
 
 		case "noop":
@@ -283,7 +281,7 @@ function findActivePhase(f: Ferment): Phase | undefined {
 		const byId = f.phases.find((p) => p.id === f.activePhaseId)
 		// Only trust activePhaseId if the phase is actually in an active state;
 		// fall back to status scan on data drift (e.g. recovered ferments).
-		if (byId && (byId.status === "active" || byId.status === "failed")) return byId
+		if (byId?.status === "active") return byId
 	}
 	return f.phases.find((p) => p.status === "active")
 }

--- a/src/ferment/engine.ts
+++ b/src/ferment/engine.ts
@@ -232,7 +232,7 @@ function toFermentAction(action: DeclarativeAction, ferment: Ferment): FermentAc
 			return {
 				kind: "recover_phase",
 				phaseId: action.phaseId,
-				message: `Phase ${phase?.index} "${phase?.name}" failed. Retry it with activate_phase, bypass it with skip_phase, or abandon the ferment.`,
+				message: `Phase ${phase?.index} "${phase?.name}" failed. Retry it with activate_phase, bypass it with skip_phase, or ask the user to run /ferment abandon if the ferment should stop.`,
 			}
 
 		case "noop":

--- a/src/ferment/event-store.test.ts
+++ b/src/ferment/event-store.test.ts
@@ -112,31 +112,56 @@ describe("FermentEventStore", () => {
 			expect(types).toContain("phase_activated")
 		})
 
-		it("phase completion replay clears active state so the next phase can be activated", () => {
-			const f = eventStore.create("Advance after phase completion")
+		it("complete_phase clears active metadata and replays the next phase as activatable", () => {
+			const f = eventStore.create("Phase advance test")
 			exec(eventStore, f.id, {
 				type: "scope",
 				goal: "Goal",
 				successCriteria: "criteria",
 				constraints: [],
 				phases: [
-					{ name: "P1", goal: "G1", steps: [] },
-					{ name: "P2", goal: "G2", steps: [] },
+					{ name: "P1", goal: "G1" },
+					{ name: "P2", goal: "G2" },
 				],
 			})
-			exec(eventStore, f.id, { type: "activate_phase", phaseId: "phase-1" })
-			exec(eventStore, f.id, { type: "complete_phase", phaseId: "phase-1", summary: "done" })
+			const scoped = eventStore.get(f.id)
+			if (!scoped) throw new Error("ferment missing")
+			exec(eventStore, f.id, { type: "activate_phase", phaseId: scoped.phases[0].id })
+			exec(eventStore, f.id, { type: "complete_phase", phaseId: scoped.phases[0].id, summary: "done" })
 
-			const afterComplete = eventStore.get(f.id)
-			expect(afterComplete?.phases[0].status).toBe("completed")
-			expect(afterComplete?.status).toBe("planned")
-			expect(afterComplete?.activePhaseId).toBeUndefined()
+			const completed = eventStore.get(f.id)
+			expect(completed?.status).toBe("planned")
+			expect(completed?.activePhaseId).toBeUndefined()
+			expect(completed?.phases[0].status).toBe("completed")
 
-			exec(eventStore, f.id, { type: "activate_phase", phaseId: "phase-2" })
-			const afterActivate = eventStore.get(f.id)
-			expect(afterActivate?.status).toBe("running")
-			expect(afterActivate?.activePhaseId).toBe("phase-2")
-			expect(afterActivate?.phases[1].status).toBe("active")
+			exec(eventStore, f.id, { type: "activate_phase", phaseId: scoped.phases[1].id })
+			const advanced = eventStore.get(f.id)
+			expect(advanced?.status).toBe("running")
+			expect(advanced?.activePhaseId).toBe(scoped.phases[1].id)
+			expect(advanced?.phases[1].status).toBe("active")
+		})
+
+		it("complete_phase leaves the final terminal ferment planned until complete_ferment", () => {
+			const f = eventStore.create("Explicit complete test")
+			exec(eventStore, f.id, {
+				type: "scope",
+				goal: "Goal",
+				successCriteria: "criteria",
+				constraints: [],
+				phases: [{ name: "P1", goal: "G1" }],
+			})
+			const scoped = eventStore.get(f.id)
+			if (!scoped) throw new Error("ferment missing")
+			exec(eventStore, f.id, { type: "activate_phase", phaseId: scoped.phases[0].id })
+			exec(eventStore, f.id, { type: "complete_phase", phaseId: scoped.phases[0].id, summary: "done" })
+
+			const phaseDone = eventStore.get(f.id)
+			expect(phaseDone?.status).toBe("planned")
+			expect(phaseDone?.activePhaseId).toBeUndefined()
+			expect(phaseDone?.phases.every((p) => p.status === "completed")).toBe(true)
+
+			exec(eventStore, f.id, { type: "complete_ferment" })
+			expect(eventStore.get(f.id)?.status).toBe("complete")
 		})
 
 		it("step lifecycle commands all emit corresponding events", () => {
@@ -190,6 +215,31 @@ describe("FermentEventStore", () => {
 			const types = readEvents(tempDir, f.id).map((e) => e.type)
 			expect(types).toContain("ferment_paused")
 			expect(types).toContain("ferment_resumed")
+		})
+
+		it("resume replays to planned when paused between phases", () => {
+			const f = eventStore.create("Resume between phases")
+			exec(eventStore, f.id, {
+				type: "scope",
+				goal: "Goal",
+				successCriteria: "c",
+				constraints: [],
+				phases: [
+					{ name: "P1", goal: "G1" },
+					{ name: "P2", goal: "G2" },
+				],
+			})
+			const scoped = eventStore.get(f.id)
+			if (!scoped) throw new Error("ferment missing")
+			exec(eventStore, f.id, { type: "activate_phase", phaseId: scoped.phases[0].id })
+			exec(eventStore, f.id, { type: "complete_phase", phaseId: scoped.phases[0].id, summary: "done" })
+			exec(eventStore, f.id, { type: "pause" })
+			exec(eventStore, f.id, { type: "resume" })
+
+			const resumed = eventStore.get(f.id)
+			expect(resumed?.status).toBe("planned")
+			expect(resumed?.activePhaseId).toBeUndefined()
+			expect(resumed?.phases[1].status).toBe("planned")
 		})
 
 		// Regression: §4.2 — replaying N independent phase_activated events for a

--- a/src/ferment/event-store.test.ts
+++ b/src/ferment/event-store.test.ts
@@ -112,6 +112,33 @@ describe("FermentEventStore", () => {
 			expect(types).toContain("phase_activated")
 		})
 
+		it("phase completion replay clears active state so the next phase can be activated", () => {
+			const f = eventStore.create("Advance after phase completion")
+			exec(eventStore, f.id, {
+				type: "scope",
+				goal: "Goal",
+				successCriteria: "criteria",
+				constraints: [],
+				phases: [
+					{ name: "P1", goal: "G1", steps: [] },
+					{ name: "P2", goal: "G2", steps: [] },
+				],
+			})
+			exec(eventStore, f.id, { type: "activate_phase", phaseId: "phase-1" })
+			exec(eventStore, f.id, { type: "complete_phase", phaseId: "phase-1", summary: "done" })
+
+			const afterComplete = eventStore.get(f.id)
+			expect(afterComplete?.phases[0].status).toBe("completed")
+			expect(afterComplete?.status).toBe("planned")
+			expect(afterComplete?.activePhaseId).toBeUndefined()
+
+			exec(eventStore, f.id, { type: "activate_phase", phaseId: "phase-2" })
+			const afterActivate = eventStore.get(f.id)
+			expect(afterActivate?.status).toBe("running")
+			expect(afterActivate?.activePhaseId).toBe("phase-2")
+			expect(afterActivate?.phases[1].status).toBe("active")
+		})
+
 		it("step lifecycle commands all emit corresponding events", () => {
 			const f = eventStore.create("Step lifecycle")
 			exec(eventStore, f.id, {

--- a/src/ferment/event-store.test.ts
+++ b/src/ferment/event-store.test.ts
@@ -141,6 +141,32 @@ describe("FermentEventStore", () => {
 			expect(advanced?.phases[1].status).toBe("active")
 		})
 
+		it("replaying fail_phase then activate_phase reactivates without stale terminal metadata", () => {
+			const f = eventStore.create("Phase retry replay test")
+			exec(eventStore, f.id, {
+				type: "scope",
+				goal: "Goal",
+				successCriteria: "criteria",
+				constraints: [],
+				phases: [{ name: "P1", goal: "G1" }],
+			})
+			const scoped = eventStore.get(f.id)
+			if (!scoped) throw new Error("ferment missing")
+			const phaseId = scoped.phases[0].id
+
+			exec(eventStore, f.id, { type: "activate_phase", phaseId })
+			exec(eventStore, f.id, { type: "fail_phase", phaseId, reason: "tests failed" })
+			exec(eventStore, f.id, { type: "activate_phase", phaseId })
+
+			const replayed = new FermentEventStore(tempDir).get(f.id)
+			expect(replayed?.status).toBe("running")
+			expect(replayed?.activePhaseId).toBe(phaseId)
+			expect(replayed?.phases[0].status).toBe("active")
+			expect(replayed?.phases[0].completedAt).toBeUndefined()
+			expect(replayed?.phases[0].summary).toBeUndefined()
+			expect(replayed?.phases[0].grade).toBeUndefined()
+		})
+
 		it("complete_phase leaves the final terminal ferment planned until complete_ferment", () => {
 			const f = eventStore.create("Explicit complete test")
 			exec(eventStore, f.id, {

--- a/src/ferment/event-store.test.ts
+++ b/src/ferment/event-store.test.ts
@@ -3,7 +3,7 @@ import { tmpdir } from "node:os"
 import { join } from "node:path"
 import { afterEach, beforeEach, describe, expect, it } from "vitest"
 import { commandToEvents } from "./event-mapper.js"
-import { FermentEventStore } from "./event-store.js"
+import { FermentEventStore, stateHash } from "./event-store.js"
 import { applyCommand } from "./state-machine.js"
 import { FermentStorage, clearFermentCache } from "./store.js"
 import type { Phase } from "./types.js"
@@ -53,6 +53,12 @@ describe("FermentEventStore", () => {
 	})
 
 	// ─── create + read-back ────────────────────────────────────────────────────
+
+	describe("stateHash", () => {
+		it("is stable for equivalent object shapes with different key insertion order", () => {
+			expect(stateHash({ a: 1, b: { c: 2 }, d: undefined })).toBe(stateHash({ d: undefined, b: { c: 2 }, a: 1 }))
+		})
+	})
 
 	describe("create", () => {
 		it("creates ferment, writes one ferment_created event", () => {

--- a/src/ferment/event-store.ts
+++ b/src/ferment/event-store.ts
@@ -887,6 +887,24 @@ export class FermentEventStore {
 
 // ─── Pure fold step ───────────────────────────────────────────────────────────
 
+function settleAfterPhaseTerminal(state: Ferment, phases: Phase[], timestamp: string): Ferment {
+	const activePhase = phases.find((p) => p.status === "active")
+	if (activePhase) {
+		return { ...state, status: "running", activePhaseId: activePhase.id, phases, updatedAt: timestamp }
+	}
+	const { activePhaseId: _activePhaseId, ...rest } = state
+	return { ...rest, status: "planned", phases, updatedAt: timestamp }
+}
+
+function settleAfterResume(state: Ferment, timestamp: string): Ferment {
+	const activePhase = state.phases.find((p) => p.status === "active")
+	if (activePhase) {
+		return { ...state, status: "running", activePhaseId: activePhase.id, updatedAt: timestamp }
+	}
+	const { activePhaseId: _activePhaseId, ...rest } = state
+	return { ...rest, status: "planned", updatedAt: timestamp }
+}
+
 /**
  * Apply one event to a (possibly undefined) ferment state and return the new
  * state. Pure — no I/O.
@@ -977,7 +995,7 @@ export function applyFermentEvent(state: Ferment | undefined, event: FermentEven
 			return { ...state, status: "paused", updatedAt: event.timestamp }
 		case "ferment_resumed":
 			if (!state) throw new Error("ferment_resumed requires existing state")
-			return { ...state, status: "running", updatedAt: event.timestamp }
+			return settleAfterResume(state, event.timestamp)
 		case "ferment_completed": {
 			if (!state) throw new Error("ferment_completed requires existing state")
 			const p = event.payload as FermentCompletedPayload
@@ -1042,61 +1060,37 @@ export function applyFermentEvent(state: Ferment | undefined, event: FermentEven
 		case "phase_completed": {
 			if (!state) throw new Error("phase_completed requires existing state")
 			const p = event.payload as PhaseCompletedPayload
-			const { activePhaseId: _activePhaseId, lastActiveAt, ...rest } = state
 			const phases = state.phases.map((ph) =>
 				ph.id === p.phaseId
 					? { ...ph, status: "completed" as const, summary: p.summary, completedAt: event.timestamp }
 					: ph,
 			)
-			const remainingActivePhase = phases.find((ph) => ph.status === "active")
-			if (remainingActivePhase) {
-				return {
-					...state,
-					phases,
-					activePhaseId: remainingActivePhase.id,
-					status: "running",
-					updatedAt: event.timestamp,
-				}
-			}
-			return {
-				...rest,
-				phases,
-				lastActiveAt,
-				activePhaseId: undefined,
-				status: "planned",
-				updatedAt: event.timestamp,
-			}
+			return settleAfterPhaseTerminal(state, phases, event.timestamp)
 		}
 		case "phase_skipped": {
 			if (!state) throw new Error("phase_skipped requires existing state")
 			const p = event.payload as PhaseSkippedPayload
-			return {
-				...state,
-				phases: state.phases.map((ph) =>
-					ph.id === p.phaseId
-						? {
-								...ph,
-								status: "skipped" as const,
-								summary: p.reason ?? "Skipped",
-								completedAt: event.timestamp,
-							}
-						: ph,
-				),
-				updatedAt: event.timestamp,
-			}
+			const phases = state.phases.map((ph) =>
+				ph.id === p.phaseId
+					? {
+							...ph,
+							status: "skipped" as const,
+							summary: p.reason ?? "Skipped",
+							completedAt: event.timestamp,
+						}
+					: ph,
+			)
+			return settleAfterPhaseTerminal(state, phases, event.timestamp)
 		}
 		case "phase_failed": {
 			if (!state) throw new Error("phase_failed requires existing state")
 			const p = event.payload as PhaseFailedPayload
-			return {
-				...state,
-				phases: state.phases.map((ph) =>
-					ph.id === p.phaseId
-						? { ...ph, status: "failed" as const, summary: p.reason, completedAt: event.timestamp }
-						: ph,
-				),
-				updatedAt: event.timestamp,
-			}
+			const phases = state.phases.map((ph) =>
+				ph.id === p.phaseId
+					? { ...ph, status: "failed" as const, summary: p.reason, completedAt: event.timestamp }
+					: ph,
+			)
+			return settleAfterPhaseTerminal(state, phases, event.timestamp)
 		}
 		case "phase_refined": {
 			if (!state) throw new Error("phase_refined requires existing state")

--- a/src/ferment/event-store.ts
+++ b/src/ferment/event-store.ts
@@ -1027,7 +1027,14 @@ export function applyFermentEvent(state: Ferment | undefined, event: FermentEven
 				...state,
 				phases: state.phases.map((ph) =>
 					ph.id === p.phaseId
-						? { ...ph, status: "active" as const, startedAt: event.timestamp }
+						? {
+								...ph,
+								status: "active" as const,
+								startedAt: event.timestamp,
+								completedAt: undefined,
+								summary: undefined,
+								grade: undefined,
+							}
 						: ph.status === "active"
 							? { ...ph, status: "planned" as const }
 							: ph,

--- a/src/ferment/event-store.ts
+++ b/src/ferment/event-store.ts
@@ -1042,13 +1042,28 @@ export function applyFermentEvent(state: Ferment | undefined, event: FermentEven
 		case "phase_completed": {
 			if (!state) throw new Error("phase_completed requires existing state")
 			const p = event.payload as PhaseCompletedPayload
+			const { activePhaseId: _activePhaseId, lastActiveAt, ...rest } = state
+			const phases = state.phases.map((ph) =>
+				ph.id === p.phaseId
+					? { ...ph, status: "completed" as const, summary: p.summary, completedAt: event.timestamp }
+					: ph,
+			)
+			const remainingActivePhase = phases.find((ph) => ph.status === "active")
+			if (remainingActivePhase) {
+				return {
+					...state,
+					phases,
+					activePhaseId: remainingActivePhase.id,
+					status: "running",
+					updatedAt: event.timestamp,
+				}
+			}
 			return {
-				...state,
-				phases: state.phases.map((ph) =>
-					ph.id === p.phaseId
-						? { ...ph, status: "completed" as const, summary: p.summary, completedAt: event.timestamp }
-						: ph,
-				),
+				...rest,
+				phases,
+				lastActiveAt,
+				activePhaseId: undefined,
+				status: "planned",
 				updatedAt: event.timestamp,
 			}
 		}

--- a/src/ferment/event-store.ts
+++ b/src/ferment/event-store.ts
@@ -44,7 +44,23 @@ import type {
 
 /** Simple deterministic hash of a serialisable value. */
 export function stateHash(value: unknown): string {
-	return createHash("sha256").update(JSON.stringify(value)).digest("hex").slice(0, 16)
+	return createHash("sha256")
+		.update(JSON.stringify(canonicalizeForHash(value)))
+		.digest("hex")
+		.slice(0, 16)
+}
+
+function canonicalizeForHash(value: unknown): unknown {
+	if (Array.isArray(value)) return value.map(canonicalizeForHash)
+	if (value && typeof value === "object") {
+		const out: Record<string, unknown> = {}
+		for (const key of Object.keys(value).sort()) {
+			const v = (value as Record<string, unknown>)[key]
+			if (v !== undefined) out[key] = canonicalizeForHash(v)
+		}
+		return out
+	}
+	return value
 }
 
 // ─── Event types ──────────────────────────────────────────────────────────────
@@ -1018,8 +1034,8 @@ export function applyFermentEvent(state: Ferment | undefined, event: FermentEven
 			return {
 				...state,
 				phases: activateSinglePhase(state.phases, p.phaseId, event.timestamp),
-				activePhaseId: p.phaseId,
 				lastActiveAt: event.timestamp,
+				activePhaseId: p.phaseId,
 				updatedAt: event.timestamp,
 			}
 		}

--- a/src/ferment/event-store.ts
+++ b/src/ferment/event-store.ts
@@ -25,6 +25,7 @@ import { resolve } from "node:path"
 import { lockSync, unlockSync } from "proper-lockfile"
 import { v7 as uuidv7 } from "uuid"
 
+import { activateSinglePhase, settleAfterPhaseTerminal } from "./lifecycle.js"
 import { FermentStorage, resolveFermentsDir } from "./store.js"
 import type {
 	Decision,
@@ -887,15 +888,6 @@ export class FermentEventStore {
 
 // ─── Pure fold step ───────────────────────────────────────────────────────────
 
-function settleAfterPhaseTerminal(state: Ferment, phases: Phase[], timestamp: string): Ferment {
-	const activePhase = phases.find((p) => p.status === "active")
-	if (activePhase) {
-		return { ...state, status: "running", activePhaseId: activePhase.id, phases, updatedAt: timestamp }
-	}
-	const { activePhaseId: _activePhaseId, ...rest } = state
-	return { ...rest, status: "planned", phases, updatedAt: timestamp }
-}
-
 function settleAfterResume(state: Ferment, timestamp: string): Ferment {
 	const activePhase = state.phases.find((p) => p.status === "active")
 	if (activePhase) {
@@ -1025,20 +1017,7 @@ export function applyFermentEvent(state: Ferment | undefined, event: FermentEven
 			const p = event.payload as PhaseActivatedPayload
 			return {
 				...state,
-				phases: state.phases.map((ph) =>
-					ph.id === p.phaseId
-						? {
-								...ph,
-								status: "active" as const,
-								startedAt: event.timestamp,
-								completedAt: undefined,
-								summary: undefined,
-								grade: undefined,
-							}
-						: ph.status === "active"
-							? { ...ph, status: "planned" as const }
-							: ph,
-				),
+				phases: activateSinglePhase(state.phases, p.phaseId, event.timestamp),
 				activePhaseId: p.phaseId,
 				lastActiveAt: event.timestamp,
 				updatedAt: event.timestamp,

--- a/src/ferment/fsm.test.ts
+++ b/src/ferment/fsm.test.ts
@@ -146,6 +146,18 @@ describe("Valid Transitions", () => {
 			expect(result.state).toBe(FSM_STATES.PHASE_ACTIVE)
 			expect(result.error).toBeUndefined()
 		})
+
+		it("handles ACTIVATE_PHASE for a failed phase", () => {
+			const ctx = makeContext({
+				fermentStatus: "planned",
+				phases: [makePhaseContext("phase-1", 1, "failed")],
+			})
+			const result = transition(FSM_STATES.PLANNED, FSM_EVENTS.ACTIVATE_PHASE, ctx, {
+				phaseId: "phase-1",
+			})
+			expect(result.state).toBe(FSM_STATES.PHASE_ACTIVE)
+			expect(result.error).toBeUndefined()
+		})
 	})
 
 	describe("PHASE_ACTIVE state", () => {
@@ -307,6 +319,18 @@ describe("Illegal Transitions (Guards)", () => {
 			expect(result.error).toBeDefined()
 			expect(result.error).toContain('expected "planned"')
 		})
+
+		it("accepts ACTIVATE_PHASE for failed phase", () => {
+			const ctx = makeContext({
+				fermentStatus: "planned",
+				phases: [makePhaseContext("phase-1", 1, "failed")],
+			})
+			const result = transition(FSM_STATES.PLANNED, FSM_EVENTS.ACTIVATE_PHASE, ctx, {
+				phaseId: "phase-1",
+			})
+			expect(result.state).toBe(FSM_STATES.PHASE_ACTIVE)
+			expect(result.error).toBeUndefined()
+		})
 	})
 
 	describe("START_STEP guards", () => {
@@ -423,7 +447,7 @@ describe("Parallel Phase Group Transitions", () => {
 		expect(result.error).toContain("active")
 	})
 
-	it("allows phase completion when all parallel group phases are terminal", () => {
+	it("settles to planned when the active phase is the last active parallel sibling", () => {
 		const ctx = makeContext({
 			fermentStatus: "running",
 			activePhaseId: "phase-1",
@@ -432,14 +456,24 @@ describe("Parallel Phase Group Transitions", () => {
 				makePhaseContext("phase-2", 2, "skipped", [], 1), // same group, terminal
 			],
 		})
-		// Note: COMPLETE_PHASE checks allPhasesTerminal, not just the group
-		// So this would fail because phase-1 itself isn't terminal yet
-		// This is correct behavior - must complete the active phase first
 		const result = transition(FSM_STATES.PHASE_ACTIVE, FSM_EVENTS.SKIP_PHASE, ctx, {
 			phaseId: "phase-1",
 		})
-		// skip_phase has phaseActive guard, should work
 		expect(result.error).toBeUndefined()
+		expect(result.state).toBe(FSM_STATES.PLANNED)
+	})
+
+	it("stays phase-active when another parallel phase remains active", () => {
+		const ctx = makeContext({
+			fermentStatus: "running",
+			activePhaseId: "phase-1",
+			phases: [makePhaseContext("phase-1", 1, "active", [], 1), makePhaseContext("phase-2", 2, "active", [], 1)],
+		})
+		const result = transition(FSM_STATES.PHASE_ACTIVE, FSM_EVENTS.COMPLETE_PHASE, ctx, {
+			phaseId: "phase-1",
+		})
+		expect(result.error).toBeUndefined()
+		expect(result.state).toBe(FSM_STATES.PHASE_ACTIVE)
 	})
 })
 
@@ -567,18 +601,16 @@ describe("Edge Cases", () => {
 		expect(result.state).toBe(FSM_STATES.COMPLETE)
 	})
 
-	it("handles SKIP_PHASE with no remaining phases → COMPLETE", () => {
+	it("handles SKIP_PHASE with no remaining active phases → PLANNED", () => {
 		const ctx = makeContext({
 			fermentStatus: "running",
 			activePhaseId: "phase-1",
 			phases: [makePhaseContext("phase-1", 1, "active")],
 		})
-		// When skipping the last (and only) phase, should transition to COMPLETE
-		// via the dynamic target function
 		const result = transition(FSM_STATES.PHASE_ACTIVE, FSM_EVENTS.SKIP_PHASE, ctx, {
 			phaseId: "phase-1",
 		})
-		expect(result.state).toBe(FSM_STATES.COMPLETE)
+		expect(result.state).toBe(FSM_STATES.PLANNED)
 		expect(result.error).toBeUndefined()
 	})
 

--- a/src/ferment/fsm.test.ts
+++ b/src/ferment/fsm.test.ts
@@ -244,14 +244,13 @@ describe("Valid Transitions", () => {
 			expect(result.error).toBeUndefined()
 		})
 
-		it("handles RESUME → PHASE_ACTIVE when resuming planned phase", () => {
+		it("handles RESUME → PLANNED when resuming between phases", () => {
 			const ctx = makeContext({
 				fermentStatus: "paused",
 				phases: [makePhaseContext("phase-1", 1, "planned")],
 			})
-			// Note: RESUME without active phase uses RESUME__PLANNED logic
 			const result = transition(FSM_STATES.PAUSED, FSM_EVENTS.RESUME, ctx)
-			expect(result.state).toBe(FSM_STATES.PHASE_ACTIVE)
+			expect(result.state).toBe(FSM_STATES.PLANNED)
 			expect(result.error).toBeUndefined()
 		})
 	})
@@ -380,14 +379,14 @@ describe("Illegal Transitions (Guards)", () => {
 	})
 
 	describe("RESUME guards", () => {
-		it("rejects RESUME when no phase is active or planned", () => {
+		it("allows RESUME when all phases are terminal so complete_ferment can run", () => {
 			const ctx = makeContext({
 				fermentStatus: "paused",
 				phases: [makePhaseContext("phase-1", 1, "completed")], // all phases done
 			})
 			const result = transition(FSM_STATES.PAUSED, FSM_EVENTS.RESUME, ctx)
-			// Should fail because no planned phases and no active phase
-			expect(result.error).toBeDefined()
+			expect(result.state).toBe(FSM_STATES.PLANNED)
+			expect(result.error).toBeUndefined()
 		})
 	})
 
@@ -465,6 +464,7 @@ describe("Pause/Resume Cycle", () => {
 		expect(result.state).toBe(FSM_STATES.PHASE_ACTIVE)
 
 		// Step 4: Pause
+		ctx = makeContext({ activePhaseId: "phase-1", phases: [makePhaseContext("phase-1", 1, "active")] })
 		result = transition(FSM_STATES.PHASE_ACTIVE, FSM_EVENTS.PAUSE, ctx)
 		expect(result.state).toBe(FSM_STATES.PAUSED)
 

--- a/src/ferment/fsm.ts
+++ b/src/ferment/fsm.ts
@@ -152,6 +152,8 @@ function hasNonParallelRunningStep(ctx: FermentFsmContext, newStepId: string): s
 
 function phaseTerminalTarget(ctx: FermentFsmContext, params: EventParams): FsmState {
 	const terminalPhaseId = params.phaseId
+	// applyCommand keeps non-parallel phases mutually exclusive; any other active
+	// phase here represents a parallel sibling that should keep the ferment running.
 	const anotherActivePhase = ctx.phases.find((p) => p.status === "active" && p.id !== terminalPhaseId)
 	return anotherActivePhase ? FSM_STATES.PHASE_ACTIVE : FSM_STATES.PLANNED
 }

--- a/src/ferment/fsm.ts
+++ b/src/ferment/fsm.ts
@@ -322,11 +322,8 @@ const TRANSITIONS: TransitionMap = {
 					const phase = ctx.phases.find((p) => p.id === ctx.activePhaseId)
 					if (phase && phase.status === "active") return FSM_STATES.PHASE_ACTIVE
 				}
-				const nextPhase = ctx.phases.find((p) => p.status === "planned")
-				if (nextPhase) return FSM_STATES.PHASE_ACTIVE
-				return FSM_STATES.PAUSED
+				return FSM_STATES.PLANNED
 			},
-			guard: "hasActiveOrPlannedPhase",
 		},
 		[FSM_EVENTS.ABANDON]: { target: FSM_STATES.ABANDONED },
 	},

--- a/src/ferment/fsm.ts
+++ b/src/ferment/fsm.ts
@@ -150,12 +150,10 @@ function hasNonParallelRunningStep(ctx: FermentFsmContext, newStepId: string): s
 	return GUARD_ERRORS.CONCURRENT_STEP(runningStep.id)
 }
 
-function isPhaseTerminal(phase: PhaseContext): boolean {
-	return phase.status === "completed" || phase.status === "skipped" || phase.status === "failed"
-}
-
-function areAllPhasesTerminal(ctx: FermentFsmContext): boolean {
-	return ctx.phases.length > 0 && ctx.phases.every((p) => isPhaseTerminal(p))
+function phaseTerminalTarget(ctx: FermentFsmContext, params: EventParams): FsmState {
+	const terminalPhaseId = params.phaseId
+	const anotherActivePhase = ctx.phases.find((p) => p.status === "active" && p.id !== terminalPhaseId)
+	return anotherActivePhase ? FSM_STATES.PHASE_ACTIVE : FSM_STATES.PLANNED
 }
 
 // ─── Guard registry ───────────────────────────────────────────────────────────
@@ -171,8 +169,8 @@ const GUARDS: Record<string, GuardFn> = {
 		if (!params.phaseId) return "Missing phaseId"
 		const phase = findPhaseById(ctx, params.phaseId)
 		if (typeof phase === "string") return phase
-		if (phase.status !== "planned") {
-			return `Phase "${phase.id}" is "${phase.status}", expected "planned".`
+		if (phase.status !== "planned" && phase.status !== "failed") {
+			return `Phase "${phase.id}" is "${phase.status}", expected "planned" or "failed".`
 		}
 		return null
 	},
@@ -242,7 +240,7 @@ const GUARDS: Record<string, GuardFn> = {
 // ─── Transition Entry ─────────────────────────────────────────────────────────
 
 interface TransitionEntry {
-	target: FsmState | ((ctx: FermentFsmContext) => FsmState)
+	target: FsmState | ((ctx: FermentFsmContext, params: EventParams) => FsmState)
 	guard?: string
 }
 
@@ -282,21 +280,15 @@ const TRANSITIONS: TransitionMap = {
 		[FSM_EVENTS.REFINE_PHASE]: { target: FSM_STATES.PHASE_ACTIVE },
 		[FSM_EVENTS.START_STEP]: { target: FSM_STATES.STEP_RUNNING, guard: "noConcurrentNonParallelStep" },
 		[FSM_EVENTS.COMPLETE_PHASE]: {
-			target: (ctx) => (areAllPhasesTerminal(ctx) ? FSM_STATES.COMPLETE : FSM_STATES.PHASE_ACTIVE),
+			target: phaseTerminalTarget,
 			guard: "phaseActive",
 		},
 		[FSM_EVENTS.SKIP_PHASE]: {
-			target: (ctx) => {
-				const otherPhases = ctx.phases.filter((p) => p.id !== ctx.activePhaseId)
-				return otherPhases.every((p) => isPhaseTerminal(p)) ? FSM_STATES.COMPLETE : FSM_STATES.PHASE_ACTIVE
-			},
+			target: phaseTerminalTarget,
 			guard: "phaseActive",
 		},
 		[FSM_EVENTS.FAIL_PHASE]: {
-			target: (ctx) => {
-				const otherPhases = ctx.phases.filter((p) => p.id !== ctx.activePhaseId)
-				return otherPhases.every((p) => isPhaseTerminal(p)) ? FSM_STATES.COMPLETE : FSM_STATES.PHASE_ACTIVE
-			},
+			target: phaseTerminalTarget,
 			guard: "phaseActive",
 		},
 		[FSM_EVENTS.SKIP_STEP]: { target: FSM_STATES.PHASE_ACTIVE, guard: "stepSkipped" },
@@ -375,7 +367,8 @@ export function transition(
 		}
 	}
 
-	const target = typeof transitionEntry.target === "function" ? transitionEntry.target(ctx) : transitionEntry.target
+	const target =
+		typeof transitionEntry.target === "function" ? transitionEntry.target(ctx, params) : transitionEntry.target
 	return { state: target }
 }
 

--- a/src/ferment/lifecycle.ts
+++ b/src/ferment/lifecycle.ts
@@ -9,7 +9,12 @@ export function settleAfterPhaseTerminalPatch(phases: Phase[]): Pick<Ferment, "p
 }
 
 export function settleAfterPhaseTerminal(ferment: Ferment, phases: Phase[], timestamp: string): Ferment {
-	return { ...ferment, ...settleAfterPhaseTerminalPatch(phases), updatedAt: timestamp }
+	const activePhase = phases.find((p) => p.status === "active")
+	if (activePhase) {
+		return { ...ferment, status: "running", activePhaseId: activePhase.id, phases, updatedAt: timestamp }
+	}
+	const { activePhaseId: _activePhaseId, ...rest } = ferment
+	return { ...rest, status: "planned", phases, updatedAt: timestamp }
 }
 
 export function activateSinglePhase(phases: Phase[], phaseId: string, timestamp: string): Phase[] {

--- a/src/ferment/lifecycle.ts
+++ b/src/ferment/lifecycle.ts
@@ -1,0 +1,30 @@
+import type { Ferment, Phase } from "./types.js"
+
+export function settleAfterPhaseTerminalPatch(phases: Phase[]): Pick<Ferment, "phases" | "status" | "activePhaseId"> {
+	const activePhase = phases.find((p) => p.status === "active")
+	if (activePhase) {
+		return { phases, activePhaseId: activePhase.id, status: "running" }
+	}
+	return { phases, activePhaseId: undefined, status: "planned" }
+}
+
+export function settleAfterPhaseTerminal(ferment: Ferment, phases: Phase[], timestamp: string): Ferment {
+	return { ...ferment, ...settleAfterPhaseTerminalPatch(phases), updatedAt: timestamp }
+}
+
+export function activateSinglePhase(phases: Phase[], phaseId: string, timestamp: string): Phase[] {
+	return phases.map((phase) => {
+		if (phase.id === phaseId) {
+			return {
+				...phase,
+				status: "active" as const,
+				startedAt: timestamp,
+				completedAt: undefined,
+				summary: undefined,
+				grade: undefined,
+			}
+		}
+		if (phase.status === "active") return { ...phase, status: "planned" as const }
+		return phase
+	})
+}

--- a/src/ferment/state-machine.test.ts
+++ b/src/ferment/state-machine.test.ts
@@ -624,6 +624,27 @@ describe("applyCommand: complete_phase", () => {
 		const error = expectError(applyCommand(f, { type: "complete_phase", phaseId: "phase-1", summary: "x" }, ctx))
 		expect(error.code).toBe("PHASE_NOT_IN_STATUS")
 	})
+
+	it("clears active phase state so the next planned phase can be activated", () => {
+		const f = makeFerment({
+			status: "running",
+			activePhaseId: "phase-1",
+			phases: [
+				makePhase({ id: "phase-1", index: 1, name: "Phase 1", status: "active" }),
+				makePhase({ id: "phase-2", index: 2, name: "Phase 2", status: "planned" }),
+			],
+		})
+
+		const completed = expectOk(applyCommand(f, { type: "complete_phase", phaseId: "phase-1", summary: "done" }, ctx))
+		expect(completed.phases[0].status).toBe("completed")
+		expect(completed.status).toBe("planned")
+		expect(completed.activePhaseId).toBeUndefined()
+
+		const activated = expectOk(applyCommand(completed, { type: "activate_phase", phaseId: "phase-2" }, ctx))
+		expect(activated.status).toBe("running")
+		expect(activated.activePhaseId).toBe("phase-2")
+		expect(activated.phases[1].status).toBe("active")
+	})
 })
 
 // ─── skip_phase ───────────────────────────────────────────────────────────────

--- a/src/ferment/state-machine.test.ts
+++ b/src/ferment/state-machine.test.ts
@@ -602,12 +602,54 @@ describe("applyCommand: fail_step", () => {
 describe("applyCommand: complete_phase", () => {
 	it("transitions active → completed", () => {
 		const f = makeFerment({
+			status: "running",
+			activePhaseId: "phase-1",
 			phases: [makePhase({ status: "active" })],
 		})
 		const result = expectOk(applyCommand(f, { type: "complete_phase", phaseId: "phase-1", summary: "done" }, ctx))
+		expect(result.status).toBe("planned")
+		expect(result.activePhaseId).toBeUndefined()
 		expect(result.phases[0].status).toBe("completed")
 		expect(result.phases[0].summary).toBe("done")
 		expect(result.phases[0].completedAt).toBe(NOW)
+	})
+
+	it("clears the completed active phase so the next planned phase can activate", () => {
+		const f = makeFerment({
+			status: "running",
+			activePhaseId: "phase-1",
+			phases: [
+				makePhase({ id: "phase-1", status: "active" }),
+				makePhase({ id: "phase-2", index: 2, name: "P2", status: "planned" }),
+			],
+		})
+
+		const completed = expectOk(applyCommand(f, { type: "complete_phase", phaseId: "phase-1", summary: "done" }, ctx))
+		expect(completed.status).toBe("planned")
+		expect(completed.activePhaseId).toBeUndefined()
+		expect(completed.phases[0].status).toBe("completed")
+
+		const activated = expectOk(applyCommand(completed, { type: "activate_phase", phaseId: "phase-2" }, ctx))
+		expect(activated.status).toBe("running")
+		expect(activated.activePhaseId).toBe("phase-2")
+		expect(activated.phases[1].status).toBe("active")
+	})
+
+	it("keeps running and selects another active phase when completing one parallel phase", () => {
+		const f = makeFerment({
+			status: "running",
+			activePhaseId: "phase-1",
+			phases: [
+				makePhase({ id: "phase-1", status: "active", groupIndex: 1 }),
+				makePhase({ id: "phase-2", index: 2, name: "P2", status: "active", groupIndex: 1 }),
+			],
+		})
+
+		const result = expectOk(applyCommand(f, { type: "complete_phase", phaseId: "phase-1", summary: "done" }, ctx))
+		expect(result.status).toBe("running")
+		expect(result.activePhaseId).toBe("phase-2")
+		expect(result.phases[0].status).toBe("completed")
+		expect(result.phases[1].status).toBe("active")
 	})
 
 	it("attaches grade when provided", () => {
@@ -662,14 +704,28 @@ describe("applyCommand: skip_phase", () => {
 		const result = expectOk(applyCommand(f, { type: "skip_phase", phaseId: "phase-1" }, ctx))
 		expect(result.phases[0].summary).toBe("Skipped")
 	})
+
+	it("clears active phase metadata when skipping the active phase", () => {
+		const f = makeFerment({
+			status: "running",
+			activePhaseId: "phase-1",
+			phases: [makePhase({ status: "active" })],
+		})
+		const result = expectOk(applyCommand(f, { type: "skip_phase", phaseId: "phase-1" }, ctx))
+		expect(result.status).toBe("planned")
+		expect(result.activePhaseId).toBeUndefined()
+		expect(result.phases[0].status).toBe("skipped")
+	})
 })
 
 // ─── fail_phase ───────────────────────────────────────────────────────────────
 
 describe("applyCommand: fail_phase", () => {
 	it("transitions to failed with reason", () => {
-		const f = makeFerment({ phases: [makePhase({ status: "active" })] })
+		const f = makeFerment({ status: "running", activePhaseId: "phase-1", phases: [makePhase({ status: "active" })] })
 		const result = expectOk(applyCommand(f, { type: "fail_phase", phaseId: "phase-1", reason: "tests failed" }, ctx))
+		expect(result.status).toBe("planned")
+		expect(result.activePhaseId).toBeUndefined()
 		expect(result.phases[0].status).toBe("failed")
 		expect(result.phases[0].summary).toBe("tests failed")
 	})
@@ -704,6 +760,22 @@ describe("applyCommand: complete_ferment", () => {
 		const result = expectOk(applyCommand(f, { type: "complete_ferment", grade }, ctx))
 		expect(result.grade).toEqual(grade)
 	})
+
+	it("completes explicitly after the final phase leaves the ferment planned", () => {
+		const f = makeFerment({
+			status: "running",
+			activePhaseId: "phase-1",
+			phases: [makePhase({ status: "active" })],
+		})
+
+		const phaseDone = expectOk(applyCommand(f, { type: "complete_phase", phaseId: "phase-1", summary: "done" }, ctx))
+		expect(phaseDone.status).toBe("planned")
+		expect(phaseDone.activePhaseId).toBeUndefined()
+		expect(phaseDone.phases.every((p) => p.status === "completed")).toBe(true)
+
+		const result = expectOk(applyCommand(phaseDone, { type: "complete_ferment" }, ctx))
+		expect(result.status).toBe("complete")
+	})
 })
 
 // ─── pause / resume ───────────────────────────────────────────────────────────
@@ -736,9 +808,35 @@ describe("applyCommand: pause", () => {
 })
 
 describe("applyCommand: resume", () => {
-	it("transitions paused → running", () => {
-		const result = expectOk(applyCommand(makeFerment({ status: "paused" }), { type: "resume" }, ctx))
+	it("transitions paused with active phase → running", () => {
+		const result = expectOk(
+			applyCommand(
+				makeFerment({ status: "paused", activePhaseId: "phase-1", phases: [makePhase({ status: "active" })] }),
+				{ type: "resume" },
+				ctx,
+			),
+		)
 		expect(result.status).toBe("running")
+		expect(result.activePhaseId).toBe("phase-1")
+	})
+
+	it("transitions paused between phases → planned", () => {
+		const result = expectOk(
+			applyCommand(
+				makeFerment({
+					status: "paused",
+					activePhaseId: "phase-1",
+					phases: [
+						makePhase({ id: "phase-1", status: "completed" }),
+						makePhase({ id: "phase-2", index: 2, name: "P2", status: "planned" }),
+					],
+				}),
+				{ type: "resume" },
+				ctx,
+			),
+		)
+		expect(result.status).toBe("planned")
+		expect(result.activePhaseId).toBeUndefined()
 	})
 
 	it("rejects resume from running", () => {

--- a/src/ferment/state-machine.test.ts
+++ b/src/ferment/state-machine.test.ts
@@ -257,16 +257,37 @@ describe("applyCommand: activate_phase", () => {
 		expect(result.activePhaseId).toBe("phase-2")
 	})
 
-	it("rejects when phase is not in planned status", () => {
+	it("rejects when phase is not in planned or failed status", () => {
 		const f = makeFerment({
 			phases: [makePhase({ id: "phase-1", status: "completed" })],
 		})
 		const error = expectError(applyCommand(f, { type: "activate_phase", phaseId: "phase-1" }, ctx))
 		expect(error.code).toBe("PHASE_NOT_IN_STATUS")
 		if (error.code === "PHASE_NOT_IN_STATUS") {
-			expect(error.expected).toEqual(["planned"])
+			expect(error.expected).toEqual(["planned", "failed"])
 			expect(error.actual).toBe("completed")
 		}
+	})
+
+	it("reactivates a failed phase and clears stale terminal metadata", () => {
+		const f = makeFerment({
+			status: "planned",
+			phases: [
+				makePhase({
+					id: "phase-1",
+					status: "failed",
+					summary: "failed before",
+					completedAt: "2024-01-01T00:00:00.000Z",
+					grade: makeGrade("F"),
+				}),
+			],
+		})
+		const result = expectOk(applyCommand(f, { type: "activate_phase", phaseId: "phase-1" }, ctx))
+		expect(result.status).toBe("running")
+		expect(result.phases[0].status).toBe("active")
+		expect(result.phases[0].completedAt).toBeUndefined()
+		expect(result.phases[0].summary).toBeUndefined()
+		expect(result.phases[0].grade).toBeUndefined()
 	})
 
 	it("rejects when phase not found", () => {

--- a/src/ferment/state-machine.ts
+++ b/src/ferment/state-machine.ts
@@ -443,12 +443,21 @@ function handleActivatePhase(
 	if (isTransitionError(found)) return fail(found)
 	const { phase, index } = found
 
-	const guard = requirePhaseStatus(phase, ["planned"])
+	const guard = requirePhaseStatus(phase, ["planned", "failed"])
 	if (guard) return fail(guard)
 
 	// Deactivate any other active phase, then activate this one.
 	const phases = ferment.phases.map((p, i) => {
-		if (i === index) return { ...p, status: "active" as const, startedAt: ctx.now }
+		if (i === index) {
+			return {
+				...p,
+				status: "active" as const,
+				startedAt: ctx.now,
+				completedAt: undefined,
+				summary: undefined,
+				grade: undefined,
+			}
+		}
 		if (p.status === "active") return { ...p, status: "planned" as const }
 		return p
 	})

--- a/src/ferment/state-machine.ts
+++ b/src/ferment/state-machine.ts
@@ -702,14 +702,19 @@ function handleCompletePhase(
 	const guard = requirePhaseStatus(phase, ["active"])
 	if (guard) return fail(guard)
 
+	const phases = setPhase(ferment, index, {
+		status: "completed",
+		summary: cmd.summary,
+		completedAt: ctx.now,
+		grade: cmd.grade,
+	})
+	const remainingActivePhase = phases.find((p) => p.status === "active")
+
 	return ok(
 		touch(ferment, ctx, {
-			phases: setPhase(ferment, index, {
-				status: "completed",
-				summary: cmd.summary,
-				completedAt: ctx.now,
-				grade: cmd.grade,
-			}),
+			phases,
+			activePhaseId: remainingActivePhase?.id,
+			status: remainingActivePhase ? "running" : "planned",
 		}),
 	)
 }

--- a/src/ferment/state-machine.ts
+++ b/src/ferment/state-machine.ts
@@ -292,6 +292,14 @@ function setPhase(ferment: Ferment, phaseIndex: number, patch: Partial<Phase>): 
 	return ferment.phases.map((p, i) => (i === phaseIndex ? { ...p, ...patch } : p))
 }
 
+function settleAfterPhaseTerminal(phases: Phase[]): Partial<Ferment> {
+	const activePhase = phases.find((p) => p.status === "active")
+	if (activePhase) {
+		return { phases, activePhaseId: activePhase.id, status: "running" }
+	}
+	return { phases, activePhaseId: undefined, status: "planned" }
+}
+
 function setStep(ferment: Ferment, phaseIndex: number, stepIndex: number, patch: Partial<Step>): Phase[] {
 	return ferment.phases.map((p, i) => {
 		if (i !== phaseIndex) return p
@@ -708,15 +716,8 @@ function handleCompletePhase(
 		completedAt: ctx.now,
 		grade: cmd.grade,
 	})
-	const remainingActivePhase = phases.find((p) => p.status === "active")
 
-	return ok(
-		touch(ferment, ctx, {
-			phases,
-			activePhaseId: remainingActivePhase?.id,
-			status: remainingActivePhase ? "running" : "planned",
-		}),
-	)
+	return ok(touch(ferment, ctx, settleAfterPhaseTerminal(phases)))
 }
 
 // ─── skip_phase ───────────────────────────────────────────────────────────────
@@ -730,15 +731,13 @@ function handleSkipPhase(
 	if (isTransitionError(found)) return fail(found)
 	const { index } = found
 
-	return ok(
-		touch(ferment, ctx, {
-			phases: setPhase(ferment, index, {
-				status: "skipped",
-				summary: cmd.reason ?? "Skipped",
-				completedAt: ctx.now,
-			}),
-		}),
-	)
+	const phases = setPhase(ferment, index, {
+		status: "skipped",
+		summary: cmd.reason ?? "Skipped",
+		completedAt: ctx.now,
+	})
+
+	return ok(touch(ferment, ctx, settleAfterPhaseTerminal(phases)))
 }
 
 // ─── fail_phase ───────────────────────────────────────────────────────────────
@@ -752,15 +751,13 @@ function handleFailPhase(
 	if (isTransitionError(found)) return fail(found)
 	const { index } = found
 
-	return ok(
-		touch(ferment, ctx, {
-			phases: setPhase(ferment, index, {
-				status: "failed",
-				summary: cmd.reason,
-				completedAt: ctx.now,
-			}),
-		}),
-	)
+	const phases = setPhase(ferment, index, {
+		status: "failed",
+		summary: cmd.reason,
+		completedAt: ctx.now,
+	})
+
+	return ok(touch(ferment, ctx, settleAfterPhaseTerminal(phases)))
 }
 
 // ─── complete_ferment ─────────────────────────────────────────────────────────
@@ -810,10 +807,13 @@ function handleResume(
 ): TransitionResult {
 	const guard = requireFermentStatus(ferment, ["paused"])
 	if (guard) return fail(guard)
-	// Resume always returns to "running". A ferment that was "planned" before
-	// pause loses the distinction — the planner can navigate from running by
-	// calling skip_phase or activate_phase as needed.
-	return ok(touch(ferment, ctx, { status: "running" }))
+	const activePhase = ferment.phases.find((p) => p.status === "active")
+	return ok(
+		touch(ferment, ctx, {
+			status: activePhase ? "running" : "planned",
+			activePhaseId: activePhase?.id,
+		}),
+	)
 }
 
 // ─── abandon ──────────────────────────────────────────────────────────────────

--- a/src/ferment/state-machine.ts
+++ b/src/ferment/state-machine.ts
@@ -22,6 +22,7 @@
  * parameter so transitions remain deterministic and unit-testable.
  */
 
+import { activateSinglePhase, settleAfterPhaseTerminalPatch } from "./lifecycle.js"
 import type {
 	Decision,
 	Ferment,
@@ -292,14 +293,6 @@ function setPhase(ferment: Ferment, phaseIndex: number, patch: Partial<Phase>): 
 	return ferment.phases.map((p, i) => (i === phaseIndex ? { ...p, ...patch } : p))
 }
 
-function settleAfterPhaseTerminal(phases: Phase[]): Partial<Ferment> {
-	const activePhase = phases.find((p) => p.status === "active")
-	if (activePhase) {
-		return { phases, activePhaseId: activePhase.id, status: "running" }
-	}
-	return { phases, activePhaseId: undefined, status: "planned" }
-}
-
 function setStep(ferment: Ferment, phaseIndex: number, stepIndex: number, patch: Partial<Step>): Phase[] {
 	return ferment.phases.map((p, i) => {
 		if (i !== phaseIndex) return p
@@ -447,20 +440,7 @@ function handleActivatePhase(
 	if (guard) return fail(guard)
 
 	// Deactivate any other active phase, then activate this one.
-	const phases = ferment.phases.map((p, i) => {
-		if (i === index) {
-			return {
-				...p,
-				status: "active" as const,
-				startedAt: ctx.now,
-				completedAt: undefined,
-				summary: undefined,
-				grade: undefined,
-			}
-		}
-		if (p.status === "active") return { ...p, status: "planned" as const }
-		return p
-	})
+	const phases = activateSinglePhase(ferment.phases, phase.id, ctx.now)
 
 	return ok(
 		touch(ferment, ctx, {
@@ -726,7 +706,7 @@ function handleCompletePhase(
 		grade: cmd.grade,
 	})
 
-	return ok(touch(ferment, ctx, settleAfterPhaseTerminal(phases)))
+	return ok(touch(ferment, ctx, settleAfterPhaseTerminalPatch(phases)))
 }
 
 // ─── skip_phase ───────────────────────────────────────────────────────────────
@@ -746,7 +726,7 @@ function handleSkipPhase(
 		completedAt: ctx.now,
 	})
 
-	return ok(touch(ferment, ctx, settleAfterPhaseTerminal(phases)))
+	return ok(touch(ferment, ctx, settleAfterPhaseTerminalPatch(phases)))
 }
 
 // ─── fail_phase ───────────────────────────────────────────────────────────────
@@ -766,7 +746,7 @@ function handleFailPhase(
 		completedAt: ctx.now,
 	})
 
-	return ok(touch(ferment, ctx, settleAfterPhaseTerminal(phases)))
+	return ok(touch(ferment, ctx, settleAfterPhaseTerminalPatch(phases)))
 }
 
 // ─── complete_ferment ─────────────────────────────────────────────────────────

--- a/src/ferment/store.ts
+++ b/src/ferment/store.ts
@@ -585,7 +585,16 @@ export class FermentStorage {
 		const updated: Ferment = {
 			...f,
 			phases: f.phases.map((p) => {
-				if (p.id === phaseId) return { ...p, status: "active" as const, startedAt: now }
+				if (p.id === phaseId) {
+					return {
+						...p,
+						status: "active" as const,
+						startedAt: now,
+						completedAt: undefined,
+						summary: undefined,
+						grade: undefined,
+					}
+				}
 				if (p.status === "active") return { ...p, status: "planned" as const }
 				return p
 			}),

--- a/src/ferment/store.ts
+++ b/src/ferment/store.ts
@@ -39,6 +39,14 @@ export interface FermentListItem {
 	createdAt: string
 }
 
+function settleAfterPhaseTerminal(ferment: Ferment, phases: Phase[], timestamp: string): Ferment {
+	const activePhase = phases.find((p) => p.status === "active")
+	if (activePhase) {
+		return { ...ferment, status: "running", activePhaseId: activePhase.id, phases, updatedAt: timestamp }
+	}
+	return { ...ferment, status: "planned", activePhaseId: undefined, phases, updatedAt: timestamp }
+}
+
 export class FermentError extends Error {
 	constructor(
 		message: string,
@@ -526,13 +534,10 @@ export class FermentStorage {
 		const f = this.get(id)
 		if (!f) return undefined
 		const now = new Date().toISOString()
-		const updated: Ferment = {
-			...f,
-			phases: f.phases.map((p) =>
-				p.id === phaseId ? { ...p, status: "failed" as const, summary: reason, completedAt: now } : p,
-			),
-			updatedAt: now,
-		}
+		const phases = f.phases.map((p) =>
+			p.id === phaseId ? { ...p, status: "failed" as const, summary: reason, completedAt: now } : p,
+		)
+		const updated = settleAfterPhaseTerminal(f, phases, now)
 		this.write(updated)
 		return updated
 	}
@@ -627,13 +632,10 @@ export class FermentStorage {
 		const f = this.get(id)
 		if (!f) return undefined
 		const now = new Date().toISOString()
-		const updated: Ferment = {
-			...f,
-			phases: f.phases.map((p) =>
-				p.id === phaseId ? { ...p, status: "completed" as const, summary, completedAt: now } : p,
-			),
-			updatedAt: now,
-		}
+		const phases = f.phases.map((p) =>
+			p.id === phaseId ? { ...p, status: "completed" as const, summary, completedAt: now } : p,
+		)
+		const updated = settleAfterPhaseTerminal(f, phases, now)
 		this.write(updated)
 		return updated
 	}
@@ -643,13 +645,10 @@ export class FermentStorage {
 		const f = this.get(id)
 		if (!f) return undefined
 		const now = new Date().toISOString()
-		const updated: Ferment = {
-			...f,
-			phases: f.phases.map((p) =>
-				p.id === phaseId ? { ...p, status: "skipped" as const, summary: reason ?? "Skipped", completedAt: now } : p,
-			),
-			updatedAt: now,
-		}
+		const phases = f.phases.map((p) =>
+			p.id === phaseId ? { ...p, status: "skipped" as const, summary: reason ?? "Skipped", completedAt: now } : p,
+		)
+		const updated = settleAfterPhaseTerminal(f, phases, now)
 		this.write(updated)
 		return updated
 	}

--- a/src/ferment/store.ts
+++ b/src/ferment/store.ts
@@ -15,6 +15,7 @@ import { homedir } from "node:os"
 import { dirname, resolve } from "node:path"
 import { v7 as uuidv7 } from "uuid"
 
+import { activateSinglePhase, settleAfterPhaseTerminal } from "./lifecycle.js"
 import type {
 	Decision,
 	Ferment,
@@ -37,14 +38,6 @@ export interface FermentListItem {
 	status: FermentStatus
 	phaseCount: number
 	createdAt: string
-}
-
-function settleAfterPhaseTerminal(ferment: Ferment, phases: Phase[], timestamp: string): Ferment {
-	const activePhase = phases.find((p) => p.status === "active")
-	if (activePhase) {
-		return { ...ferment, status: "running", activePhaseId: activePhase.id, phases, updatedAt: timestamp }
-	}
-	return { ...ferment, status: "planned", activePhaseId: undefined, phases, updatedAt: timestamp }
 }
 
 export class FermentError extends Error {
@@ -584,20 +577,7 @@ export class FermentStorage {
 		const now = new Date().toISOString()
 		const updated: Ferment = {
 			...f,
-			phases: f.phases.map((p) => {
-				if (p.id === phaseId) {
-					return {
-						...p,
-						status: "active" as const,
-						startedAt: now,
-						completedAt: undefined,
-						summary: undefined,
-						grade: undefined,
-					}
-				}
-				if (p.status === "active") return { ...p, status: "planned" as const }
-				return p
-			}),
+			phases: activateSinglePhase(f.phases, phaseId, now),
 			activePhaseId: phaseId,
 			lastActiveAt: now,
 			updatedAt: now,


### PR DESCRIPTION
## Why

The ferment state machine can get stuck after completing a phase. In the observed session, phase 1 completed, but the ferment still reported itself as running and kept stale active-phase metadata. After that, the next phase could not be activated.

The agent retried phase activation several times, then bypassed the ferment workflow and continued working directly on files.

---
### Kimchi Summary
### What changed
Redesigns the ferment lifecycle so that completing, skipping, or failing the last active phase leaves the ferment in `planned` rather than immediately `complete`. This introduces an explicit inter-phase pause where the planner stays active, enables retrying failed phases via `activate_phase`, and changes `/pause` to only disable auto-mode without persisting a `paused` status.

### Why
Fixes the engine getting stuck or prematurely finalizing after a phase completes. By settling to `planned` between phases, the system can prompt the planner to activate the next phase or explicitly call `complete_ferment` once all work is done.

### Key changes
- `docs/ferment.md` — Updates state diagrams and tool descriptions to reflect `planned` between phases, explicit `complete_ferment`, internal/session-only `paused` semantics, and `recover_phase` for failed phases.
- `src/extensions/ferment/commands.ts` — `/pause` now disables auto-mode via `setAutoModeEnabled(false)` without mutating the persisted ferment status.
- `src/extensions/ferment/events.ts` — Injects the planner supplement when the ferment is `planned` or `running`, keeping the planner engaged between phases.
- `src/extensions/ferment/tools/phases.ts` — `activate_phase` falls back to failed phases before planned ones, clearing stale terminal metadata on retry; `fail_phase` output now mentions recovery options.
- `src/extensions/ferment/nudge.ts` — `recover_phase` nudges suggest `activate_phase` to retry, `skip_phase` to bypass, or `/ferment abandon` to stop.
- `src/ferment/fsm.ts`, `state-machine.ts`, `event-store.ts`, `store.ts` — Terminal phase transitions settle the ferment to `planned` when no parallel sibling remains active; `resume` returns to `running` or `planned` depending on active phase presence.
- `src/ferment/engine.ts` — Failed-phase recovery is prioritized before the all-terminal completion check; `findActivePhase` no longer treats failed phases as active.
- `src/ferment/lifecycle.ts` — New shared helpers (`activateSinglePhase`, `settleAfterPhaseTerminal`) unify state-settling logic across storage, event-store, and state-machine.
- `src/ferment/event-store.ts` — `stateHash` now canonicalizes objects (sorted keys, stripped `undefined`) for deterministic hashing.

### Impact
- **Breaking**: `complete_ferment` must now be called explicitly after all phases are terminal; automatic completion is removed.
- **Behavioral**: `/pause` is strictly an auto-mode toggle and does not block ferment tools by flipping persisted state.
- **Behavioral**: Failed phases block final completion until they are retried, skipped, or the ferment is abandoned.