### PR TITLE
LLM-1577: Add evaluation script

### DIFF
--- a/benchmark/manual/check-session.py
+++ b/benchmark/manual/check-session.py
@@ -78,6 +78,13 @@ def find_latest_jsonl(run_dir: Path) -> Path | None:
     return jsonls[-1] if jsonls else None
 
 
+def is_session_arg(arg: str) -> bool:
+    """Return True if arg looks like a session identifier (digits or existing dir name)."""
+    if arg.isdigit():
+        return True
+    return (SESSIONS_DIR / arg).is_dir()
+
+
 def resolve_session(arg: str) -> Path:
     if arg.isdigit():
         return SESSIONS_DIR / f"session-{int(arg):02d}"
@@ -85,9 +92,30 @@ def resolve_session(arg: str) -> Path:
 
 
 def main():
-    if len(sys.argv) >= 2:
-        session_dir = resolve_session(sys.argv[1])
-    else:
+    args = sys.argv[1:]
+
+    # Determine session and task filters
+    session_dir = None
+    task_filters: list[str] = []
+
+    if args:
+        # Collect leading args that look like session identifiers
+        session_args: list[str] = []
+        for arg in args:
+            if is_session_arg(arg):
+                session_args.append(arg)
+            else:
+                break
+
+        if session_args:
+            # Last session arg wins; rest are task filters
+            session_dir = resolve_session(session_args[-1])
+            task_filters = args[len(session_args):]
+        else:
+            # No session arg found — all args are task filters; use latest session
+            task_filters = args
+
+    if session_dir is None:
         sessions = sorted(
             (d for d in SESSIONS_DIR.iterdir() if d.is_dir() and d.name.startswith("session-")),
             key=lambda d: d.name,
@@ -106,6 +134,18 @@ def main():
     if not run_dirs:
         print(f"No run directories in {runs_dir}", file=sys.stderr)
         sys.exit(2)
+
+    total_runs = len(run_dirs)
+
+    # Filter runs by task substrings (case-insensitive)
+    if task_filters:
+        run_dirs = [
+            d for d in run_dirs
+            if any(f.lower() in d.name.lower() for f in task_filters)
+        ]
+        if not run_dirs:
+            print("No runs matched the provided task filters.", file=sys.stderr)
+            sys.exit(2)
 
     results = {}
     for run_dir in run_dirs:
@@ -153,7 +193,11 @@ def main():
 
     total = len(results)
     print()
-    print(f"Total: {total}  Done: {finished}  Stalled: {stalled}  In progress: {in_progress}  No log: {no_log}")
+    if task_filters:
+        print(f"Showing {len(results)} of {total_runs} runs (filter: {', '.join(task_filters)})")
+        print(f"Total: {len(results)}  Done: {finished}  Stalled: {stalled}  In progress: {in_progress}  No log: {no_log}")
+    else:
+        print(f"Total: {total}  Done: {finished}  Stalled: {stalled}  In progress: {in_progress}  No log: {no_log}")
 
     all_done = finished + stalled == total and in_progress == 0 and no_log == 0
     if all_done:

--- a/benchmark/manual/run-evaluation.sh
+++ b/benchmark/manual/run-evaluation.sh
@@ -1,0 +1,156 @@
+#!/bin/zsh
+set -euo pipefail
+
+# run-evaluation.sh
+#
+# Generate a new benchmark/manual session, run selected tasks in separate
+# iTerm2 tabs, wait for completion, then run a session audit on each using
+# the kimchi harness with kimi-k2.6.
+#
+# Usage:
+#   ./run-evaluation.sh              # run default tasks (complex-kimi-k2.6, mega-kimi-k2.6)
+#   ./run-evaluation.sh complex-kimi-k2.6
+#   ./run-evaluation.sh complex-kimi-k2.6 mega-kimi-k2.6
+
+SCRIPT_DIR="${0:A:h}"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+AUDIT_SCRIPT="${SCRIPT_DIR}/../audit-session/audit-session.sh"
+SESSIONS_DIR="${SCRIPT_DIR}/sessions"
+
+# --- Verify dependencies ---
+if [[ ! -f "$AUDIT_SCRIPT" ]]; then
+  echo "ERROR: audit-session.sh not found at: $AUDIT_SCRIPT" >&2
+  exit 1
+fi
+
+which osascript &>/dev/null || { echo "ERROR: osascript not found. This script requires macOS." >&2; exit 1; }
+
+# --- Parse CLI arguments ---
+REQUESTED_TASKS=("$@")
+
+# --- Step 1: Create a new session ---
+echo "=== Creating new benchmark session ==="
+cd "$SCRIPT_DIR"
+"${SCRIPT_DIR}/new-session.sh"
+
+# Find the newest session directory
+if [[ ! -d "$SESSIONS_DIR" ]]; then
+  echo "ERROR: No sessions directory found at $SESSIONS_DIR" >&2
+  exit 1
+fi
+SESSION_DIR=$(ls -dt "${SESSIONS_DIR}"/session-* 2>/dev/null | head -1)
+if [[ -z "$SESSION_DIR" ]]; then
+  echo "ERROR: No session directory found" >&2
+  exit 1
+fi
+SESSION_NAME=$(basename "$SESSION_DIR")
+echo "Using session: $SESSION_NAME  ($SESSION_DIR)"
+
+# --- Determine which tasks to run ---
+RUNS_DIR="${SESSION_DIR}/runs"
+if [[ ! -d "$RUNS_DIR" ]]; then
+  echo "ERROR: No runs directory found at $RUNS_DIR" >&2
+  exit 1
+fi
+
+AVAILABLE_TASKS=($RUNS_DIR/*(/:t))
+if (( ${#AVAILABLE_TASKS[@]} == 0 )); then
+  echo "ERROR: No tasks found in $RUNS_DIR" >&2
+  exit 1
+fi
+
+if (( ${#REQUESTED_TASKS[@]} == 0 )); then
+  TASKS=(complex-kimi-k2.6 mega-kimi-k2.6)
+else
+  TASKS=("${REQUESTED_TASKS[@]}")
+fi
+
+# Validate requested tasks
+for task in "${TASKS[@]}"; do
+  if [[ ! -d "$RUNS_DIR/$task" ]]; then
+    echo "ERROR: Task '$task' not found in $RUNS_DIR" >&2
+    exit 1
+  fi
+done
+
+echo ""
+echo "Tasks selected: ${(j:, :)TASKS}"
+echo ""
+
+# --- Step 2: Run selected tasks in separate iTerm2 tabs ---
+for task in "${TASKS[@]}"; do
+  TASK_SCRIPT="${SESSION_DIR}/run-${task}.sh"
+  if [[ ! -f "$TASK_SCRIPT" ]]; then
+    echo "ERROR: Missing run script: $TASK_SCRIPT" >&2
+    exit 1
+  fi
+done
+
+echo "=== Spawning iTerm2 tabs ==="
+
+if ! osascript -e 'id of application "iTerm2"' &>/dev/null; then
+  echo "ERROR: iTerm2 is not running. Please start iTerm2 first." >&2
+  exit 1
+fi
+
+for task in "${TASKS[@]}"; do
+  task_script="${SESSION_DIR}/run-${task}.sh"
+  osascript <<EOF
+tell application "iTerm2"
+  tell current window
+    set taskTab to (create tab with default profile)
+    tell taskTab
+      tell current session
+        write text "${task_script}"
+      end tell
+    end tell
+  end tell
+end tell
+EOF
+done
+
+echo "iTerm2 tabs spawned. Commands are running in the background."
+
+# --- Step 3: Poll until runs complete ---
+echo "=== Waiting for runs to complete (poll every 60s, max 90 min) ==="
+echo ""
+
+for ((i = 1; i <= 90; i++)); do
+  echo "--- Poll $i/90 ---"
+  if python3 "${SCRIPT_DIR}/check-session.py" "$SESSION_NAME" "${TASKS[@]}" 2>&1; then
+    echo "=== All runs finished ==="
+    break
+  fi
+  sleep 60
+done
+
+# --- Step 4: Find the JSONL files for each run ---
+declare -A JSONL_FILES
+for task in "${TASKS[@]}"; do
+  jsonl=$(ls -t "${SESSION_DIR}/runs/${task}/"session-*.jsonl 2>/dev/null | head -1)
+  if [[ -z "$jsonl" ]]; then
+    echo "ERROR: No session JSONL found for $task" >&2
+    exit 1
+  fi
+  JSONL_FILES["$task"]="$jsonl"
+done
+
+echo ""
+for task in "${TASKS[@]}"; do
+  echo "${task} session: ${JSONL_FILES["$task"]}"
+done
+
+# --- Step 5: Run audits with Claude Opus 4.7 ---
+for task in "${TASKS[@]}"; do
+  echo ""
+  echo "=== Auditing ${task} session with Claude Opus 4.7 ==="
+  cd "$REPO_ROOT"
+  "$AUDIT_SCRIPT" -m kimchi-dev/claude-opus-4-7 "${JSONL_FILES["$task"]}"
+done
+
+echo ""
+echo "========================================"
+echo "All tasks complete!"
+echo "Session:     $SESSION_DIR"
+echo "Audit reports should be in: ${REPO_ROOT}/.kimchi/audits/"
+echo "========================================"

--- a/benchmark/manual/run-evaluation.sh
+++ b/benchmark/manual/run-evaluation.sh
@@ -53,7 +53,7 @@ if [[ ! -d "$RUNS_DIR" ]]; then
   exit 1
 fi
 
-AVAILABLE_TASKS=($RUNS_DIR/*(/:t))
+AVAILABLE_TASKS=("$RUNS_DIR"/*(/:t))
 if (( ${#AVAILABLE_TASKS[@]} == 0 )); then
   echo "ERROR: No tasks found in $RUNS_DIR" >&2
   exit 1
@@ -95,13 +95,14 @@ fi
 
 for task in "${TASKS[@]}"; do
   task_script="${SESSION_DIR}/run-${task}.sh"
+  task_script_escaped=${task_script//\"/\\\"}
   osascript <<EOF
 tell application "iTerm2"
   tell current window
     set taskTab to (create tab with default profile)
     tell taskTab
       tell current session
-        write text "${task_script}"
+        write text "${task_script_escaped}"
       end tell
     end tell
   end tell
@@ -127,12 +128,12 @@ done
 # --- Step 4: Find the JSONL files for each run ---
 declare -A JSONL_FILES
 for task in "${TASKS[@]}"; do
-  jsonl=$(ls -t "${SESSION_DIR}/runs/${task}/"session-*.jsonl 2>/dev/null | head -1)
-  if [[ -z "$jsonl" ]]; then
+  local jsonls=("${SESSION_DIR}/runs/${task}"/session-*.jsonl(NOm))
+  if (( ${#jsonls} == 0 )); then
     echo "ERROR: No session JSONL found for $task" >&2
     exit 1
   fi
-  JSONL_FILES["$task"]="$jsonl"
+  JSONL_FILES["$task"]=$jsonls[1]
 done
 
 echo ""
@@ -154,13 +155,14 @@ done
 
 for task in "${TASKS[@]}"; do
   audit_cmd="cd \"$REPO_ROOT\" && \"$AUDIT_SCRIPT\" -m kimchi-dev/claude-opus-4-7 \"${JSONL_FILES[\"$task\"]}\""
+  audit_cmd_escaped=${audit_cmd//\"/\\\"}
   osascript <<EOF
 tell application "iTerm2"
   tell current window
     set auditTab to (create tab with default profile)
     tell auditTab
       tell current session
-        write text "$audit_cmd"
+        write text "$audit_cmd_escaped"
       end tell
     end tell
   end tell

--- a/benchmark/manual/run-evaluation.sh
+++ b/benchmark/manual/run-evaluation.sh
@@ -140,13 +140,61 @@ for task in "${TASKS[@]}"; do
   echo "${task} session: ${JSONL_FILES["$task"]}"
 done
 
-# --- Step 5: Run audits with Claude Opus 4.7 ---
+# --- Step 5: Run audits with Claude Opus 4.7 in separate iTerm2 tabs ---
+echo "=== Spawning iTerm2 tabs for audits ==="
+
+declare -A AUDIT_OUTPUT_FILES
 for task in "${TASKS[@]}"; do
-  echo ""
-  echo "=== Auditing ${task} session with Claude Opus 4.7 ==="
-  cd "$REPO_ROOT"
-  "$AUDIT_SCRIPT" -m kimchi-dev/claude-opus-4-7 "${JSONL_FILES["$task"]}"
+  # Compute the expected audit output path from the session JSONL filename
+  jsonl_basename=$(basename "${JSONL_FILES["$task"]}")
+  audit_slug=$(echo "$task" | tr ' ' '-' | tr '_' '-')
+  audit_name="audit-${audit_slug}--${jsonl_basename%.jsonl}"
+  AUDIT_OUTPUT_FILES["$task"]="${REPO_ROOT}/.kimchi/audits/${audit_name}.html"
 done
+
+for task in "${TASKS[@]}"; do
+  audit_cmd="cd \"$REPO_ROOT\" && \"$AUDIT_SCRIPT\" -m kimchi-dev/claude-opus-4-7 \"${JSONL_FILES[\"$task\"]}\""
+  osascript <<EOF
+tell application "iTerm2"
+  tell current window
+    set auditTab to (create tab with default profile)
+    tell auditTab
+      tell current session
+        write text "$audit_cmd"
+      end tell
+    end tell
+  end tell
+end tell
+EOF
+done
+
+echo "Audit tabs spawned in iTerm2."
+
+# --- Step 6: Poll until audits complete ---
+echo "=== Waiting for audits to complete (poll every 30s, max 60 min) ==="
+echo ""
+
+for ((i = 1; i <= 120; i++)); do
+  echo "--- Audit poll $i/120 ---"
+  all_done=true
+  for task in "${TASKS[@]}"; do
+    if [[ -f "${AUDIT_OUTPUT_FILES["$task"]}" ]]; then
+      echo "  ${task}: done (${AUDIT_OUTPUT_FILES["$task"]})"
+    else
+      echo "  ${task}: still running..."
+      all_done=false
+    fi
+  done
+  if $all_done; then
+    echo "=== All audits finished ==="
+    break
+  fi
+  sleep 30
+done
+
+if ! $all_done; then
+  echo "WARNING: Timed out waiting for audits. Check iTerm2 tabs for status." >&2
+fi
 
 echo ""
 echo "========================================"


### PR DESCRIPTION
### Kimchi Summary
### What changed
Adds `run-evaluation.sh`, an end-to-end macOS benchmark orchestration script that creates a session, executes tasks in iTerm2 tabs, monitors progress, and spawns audits. Also extends `check-session.py` to support case-insensitive task filtering alongside session selection.

### Why
Manual benchmark workflows require coordinating session creation, multi-task execution, and audit generation across separate terminal tabs. Automating this reduces operator overhead and ensures a consistent session-to-audit pipeline.

### Key changes
- **`benchmark/manual/run-evaluation.sh`** (new): Orchestrates the full evaluation lifecycle. Creates a session via `new-session.sh`, launches requested tasks in iTerm2 tabs, polls for completion with `check-session.py`, then spawns `audit-session.sh` jobs (using `claude-opus-4-7`) in new tabs and waits for audit artifacts to appear in `.kimchi/audits/`.
- **`benchmark/manual/check-session.py`**:
  - Adds `is_session_arg()` to distinguish session identifiers (digits or existing directory names) from task filter strings.
  - Updates `main()` argument parsing so leading session-like args resolve to a target session (last one wins) while remaining args are treated as case-insensitive substring filters against run directory names.
  - Adds filtered run counts to the summary output when task filters are active.

### Impact
- `run-evaluation.sh` requires macOS with **iTerm2** and `zsh` (relies on `osascript` and zsh-specific parameter expansion).
- `run-evaluation.sh` defaults to tasks `complex-kimi-k2.6` and `mega-kimi-k2.6` when no tasks are specified on the command line.
- `check-session.py` changes are backward-compatible; existing single-argument invocations continue to work.