### PR TITLE
NOJIRA: Fix MCP direct tools first-run availability and plan-mode classification

### DIFF
--- a/src/extensions/mcp-adapter/cache-resolver.integration.test.ts
+++ b/src/extensions/mcp-adapter/cache-resolver.integration.test.ts
@@ -1,0 +1,282 @@
+/**
+ * Cache and resolver integration tests.
+ *
+ * Exercises the on-disk metadata cache + `resolveDirectTools` pipeline that the
+ * MCP direct-tools registration depends on. Each test gets a fresh temp
+ * `KIMCHI_CODING_AGENT_DIR` and re-imports the cache module so the memoized
+ * cache path (`metadata-cache.ts:13`) picks up the per-test env override.
+ *
+ * Scope intentionally stops at the cache + resolver layer:
+ *   - End-to-end `initializeMcp` bootstrap requires either a real MCP server
+ *     subprocess or a `McpServerManager` injection refactor; both are out of
+ *     scope for this PR.
+ *   - `registerAndActivate(..., { markDynamic: false })` needs a stub
+ *     `ExtensionAPI`; that helper warrants its own file and follow-up.
+ */
+
+import { mkdtempSync, rmSync } from "node:fs"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
+import type { McpConfig, ServerEntry } from "./types.js"
+
+// Module surface — typed via import type so the dynamic imports below stay
+// strongly typed without locking in a single module instance.
+type CacheModule = typeof import("./metadata-cache.js")
+type DirectToolsModule = typeof import("./direct-tools.js")
+
+// ─── Test harness ─────────────────────────────────────────────────────────────
+
+interface Harness {
+	cacheModule: CacheModule
+	directToolsModule: DirectToolsModule
+	cachePath: string
+}
+
+let tempHome: string | undefined
+let originalEnv: string | undefined
+
+/**
+ * Set up a fresh temp agent directory and re-import the cache + resolver
+ * modules so their module-level memoization picks up the new
+ * `KIMCHI_CODING_AGENT_DIR`.
+ */
+async function buildHarness(): Promise<Harness> {
+	tempHome = mkdtempSync(join(tmpdir(), "mcp-cache-test-"))
+	process.env.KIMCHI_CODING_AGENT_DIR = tempHome
+
+	vi.resetModules()
+	const cacheModule = await import("./metadata-cache.js")
+	const directToolsModule = await import("./direct-tools.js")
+	return {
+		cacheModule,
+		directToolsModule,
+		cachePath: join(tempHome, "mcp-cache.json"),
+	}
+}
+
+beforeEach(() => {
+	originalEnv = process.env.KIMCHI_CODING_AGENT_DIR
+})
+
+afterEach(() => {
+	if (originalEnv === undefined) delete process.env.KIMCHI_CODING_AGENT_DIR
+	else process.env.KIMCHI_CODING_AGENT_DIR = originalEnv
+	if (tempHome) {
+		rmSync(tempHome, { recursive: true, force: true })
+		tempHome = undefined
+	}
+})
+
+// ─── Fixtures ─────────────────────────────────────────────────────────────────
+
+const JETBRAINS_DEF: ServerEntry = {
+	url: "http://127.0.0.1:64342/sse",
+	headers: {},
+	directTools: true,
+}
+
+const SUPABASE_DEF: ServerEntry = {
+	command: "npx",
+	args: ["-y", "supabase-mcp"],
+	directTools: true,
+}
+
+function cacheEntry(opts: {
+	configHash: string
+	tools?: Array<{ name: string; description?: string }>
+}) {
+	return {
+		configHash: opts.configHash,
+		tools: opts.tools ?? [],
+		resources: [],
+		cachedAt: Date.now(),
+	}
+}
+
+// ─── Tests ────────────────────────────────────────────────────────────────────
+
+describe("purgeStaleEntries", () => {
+	it("drops mismatched-hash entries for configured servers, preserves orphans", async () => {
+		const { cacheModule } = await buildHarness()
+		const { purgeStaleEntries, computeServerHash } = cacheModule
+
+		const orphanDef: ServerEntry = {
+			command: "stale-orphan",
+			args: ["from", "another", "project"],
+		}
+
+		const cache = {
+			version: 1,
+			servers: {
+				jetbrains: cacheEntry({ configHash: "stale-deadbeef" }),
+				supabase: cacheEntry({ configHash: computeServerHash(SUPABASE_DEF) }),
+				// 'orphan' is in the on-disk cache but NOT in the current project's
+				// mcp.json — it belongs to another project that shares the same
+				// cache file. Must survive the purge.
+				orphan: cacheEntry({ configHash: computeServerHash(orphanDef) }),
+			},
+		}
+
+		const { cleaned, removed } = purgeStaleEntries(cache, {
+			jetbrains: JETBRAINS_DEF,
+			supabase: SUPABASE_DEF,
+		})
+
+		expect(removed).toEqual(["jetbrains"])
+		expect(Object.keys(cleaned.servers).sort()).toEqual(["orphan", "supabase"])
+	})
+
+	it("returns an empty cleaned cache for null or empty input", async () => {
+		const { cacheModule } = await buildHarness()
+		const { purgeStaleEntries } = cacheModule
+
+		const fromNull = purgeStaleEntries(null, { jetbrains: JETBRAINS_DEF })
+		expect(fromNull.removed).toEqual([])
+		expect(fromNull.cleaned).toEqual({ version: 1, servers: {} })
+
+		const fromEmpty = purgeStaleEntries({ version: 1, servers: {} }, { jetbrains: JETBRAINS_DEF })
+		expect(fromEmpty.removed).toEqual([])
+		expect(fromEmpty.cleaned).toEqual({ version: 1, servers: {} })
+	})
+})
+
+describe("overwriteMetadataCache vs saveMetadataCache", () => {
+	it("overwriteMetadataCache replaces the on-disk content (no merge)", async () => {
+		const { cacheModule } = await buildHarness()
+		const { saveMetadataCache, overwriteMetadataCache, loadMetadataCache } = cacheModule
+
+		saveMetadataCache({
+			version: 1,
+			servers: { a: cacheEntry({ configHash: "hash-a" }) },
+		})
+		overwriteMetadataCache({
+			version: 1,
+			servers: { b: cacheEntry({ configHash: "hash-b" }) },
+		})
+
+		const cache = loadMetadataCache()
+		expect(Object.keys(cache?.servers ?? {})).toEqual(["b"])
+	})
+
+	it("saveMetadataCache still merges (regression guard for existing callers)", async () => {
+		const { cacheModule } = await buildHarness()
+		const { saveMetadataCache, overwriteMetadataCache, loadMetadataCache } = cacheModule
+
+		overwriteMetadataCache({
+			version: 1,
+			servers: { a: cacheEntry({ configHash: "hash-a" }) },
+		})
+		saveMetadataCache({
+			version: 1,
+			servers: { b: cacheEntry({ configHash: "hash-b" }) },
+		})
+
+		const cache = loadMetadataCache()
+		expect(Object.keys(cache?.servers ?? {}).sort()).toEqual(["a", "b"])
+	})
+})
+
+describe("end-to-end stale → purge → resolve", () => {
+	it("rejects stale cache, regenerates, then resolves direct-tool specs", async () => {
+		const { cacheModule, directToolsModule } = await buildHarness()
+		const { saveMetadataCache, overwriteMetadataCache, loadMetadataCache, purgeStaleEntries, computeServerHash } =
+			cacheModule
+		const { resolveDirectTools } = directToolsModule
+
+		const config: McpConfig = { mcpServers: { jetbrains: JETBRAINS_DEF } }
+
+		// (a) Seed a stale entry for jetbrains.
+		saveMetadataCache({
+			version: 1,
+			servers: {
+				jetbrains: cacheEntry({
+					configHash: "stale-from-an-older-config",
+					tools: [{ name: "get_all_open_file_paths" }, { name: "build_project" }],
+				}),
+			},
+		})
+
+		// (b) Resolver rejects the stale entry — this is the user-visible bug.
+		expect(resolveDirectTools(config, loadMetadataCache(), "server")).toEqual([])
+
+		// (c) Purge + overwrite removes it from disk.
+		const { cleaned, removed } = purgeStaleEntries(loadMetadataCache(), config.mcpServers)
+		expect(removed).toEqual(["jetbrains"])
+		overwriteMetadataCache(cleaned)
+		expect(loadMetadataCache()?.servers?.jetbrains).toBeUndefined()
+
+		// (d) Bootstrap-equivalent: write a fresh entry with the correct hash.
+		saveMetadataCache({
+			version: 1,
+			servers: {
+				jetbrains: cacheEntry({
+					configHash: computeServerHash(JETBRAINS_DEF),
+					tools: [
+						{ name: "get_all_open_file_paths", description: "list open files" },
+						{ name: "build_project", description: "build" },
+					],
+				}),
+			},
+		})
+
+		// (e) Resolver now produces direct-tool specs with prefixed names — these
+		// are exactly what `pi.registerTool` would receive at module load.
+		const specs = resolveDirectTools(config, loadMetadataCache(), "server")
+		const names = specs.map((s) => s.prefixedName).sort()
+		expect(names).toEqual(["jetbrains_build_project", "jetbrains_get_all_open_file_paths"])
+		for (const spec of specs) {
+			expect(spec.serverName).toBe("jetbrains")
+			expect(spec.originalName).toBe(spec.prefixedName.replace(/^jetbrains_/, ""))
+		}
+	})
+})
+
+describe("resolveDirectTools — interaction with config knobs", () => {
+	it("honors excludeTools", async () => {
+		const { cacheModule, directToolsModule } = await buildHarness()
+		const { saveMetadataCache, computeServerHash, loadMetadataCache } = cacheModule
+		const { resolveDirectTools } = directToolsModule
+
+		const def: ServerEntry = { ...JETBRAINS_DEF, excludeTools: ["banned"] }
+		saveMetadataCache({
+			version: 1,
+			servers: {
+				jetbrains: cacheEntry({
+					configHash: computeServerHash(def),
+					tools: [{ name: "get_status" }, { name: "banned" }, { name: "list_open" }],
+				}),
+			},
+		})
+
+		const specs = resolveDirectTools({ mcpServers: { jetbrains: def } }, loadMetadataCache(), "server")
+		const names = specs.map((s) => s.originalName).sort()
+		expect(names).toEqual(["get_status", "list_open"])
+	})
+
+	it("ignores cache entries with directTools=false but purge keeps them (hash-keyed)", async () => {
+		const { cacheModule, directToolsModule } = await buildHarness()
+		const { saveMetadataCache, computeServerHash, loadMetadataCache, purgeStaleEntries } = cacheModule
+		const { resolveDirectTools } = directToolsModule
+
+		const def: ServerEntry = { ...JETBRAINS_DEF, directTools: false }
+		saveMetadataCache({
+			version: 1,
+			servers: {
+				jetbrains: cacheEntry({
+					configHash: computeServerHash(def),
+					tools: [{ name: "get_open_files" }],
+				}),
+			},
+		})
+
+		// Resolver short-circuits because directTools=false — even though the
+		// hash is valid and tools are cached.
+		expect(resolveDirectTools({ mcpServers: { jetbrains: def } }, loadMetadataCache(), "server")).toEqual([])
+
+		// Purge keys off configHash, not directTools. The entry stays.
+		const { cleaned, removed } = purgeStaleEntries(loadMetadataCache(), { jetbrains: def })
+		expect(removed).toEqual([])
+		expect(cleaned.servers.jetbrains).toBeDefined()
+	})
+})

--- a/src/extensions/mcp-adapter/index.ts
+++ b/src/extensions/mcp-adapter/index.ts
@@ -17,7 +17,7 @@ import {
 } from "./direct-tools.js"
 import { flushMetadataCache, initializeMcp, updateStatusBar } from "./init.js"
 import { initializeOAuth, shutdownOAuth } from "./mcp-auth-flow.js"
-import { loadMetadataCache } from "./metadata-cache.js"
+import { loadMetadataCache, overwriteMetadataCache, purgeStaleEntries } from "./metadata-cache.js"
 import {
 	executeCall,
 	executeConnect,
@@ -65,7 +65,20 @@ export default function mcpAdapter(pi: ExtensionAPI) {
 
 	const earlyConfigPath = getConfigPathFromArgv()
 	const earlyConfig = loadMcpConfig(earlyConfigPath)
-	const earlyCache = loadMetadataCache()
+	let earlyCache = loadMetadataCache()
+
+	// Drop cache entries whose configHash no longer matches the configured server
+	// definition, or whose server has been removed from config. Otherwise stale
+	// entries silently block direct-tool registration on every startup.
+	if (earlyCache) {
+		const { cleaned, removed } = purgeStaleEntries(earlyCache, earlyConfig.mcpServers)
+		if (removed.length > 0) {
+			overwriteMetadataCache(cleaned)
+			earlyCache = cleaned
+			console.warn(`MCP: purged stale cache entries: ${removed.join(", ")}`)
+		}
+	}
+
 	const prefix = earlyConfig.settings?.toolPrefix ?? "server"
 
 	const envRaw = process.env.MCP_DIRECT_TOOLS
@@ -106,8 +119,23 @@ export default function mcpAdapter(pi: ExtensionAPI) {
 		registeredToolNames.add(spec.prefixedName)
 	}
 
-	function registerAndActivate(specs: DirectToolSpec[]): string[] {
-		if (!state) return []
+	/**
+	 * Register tool specs with the agent and add them to the active set.
+	 *
+	 * `markDynamic` (default true) tags the new names in `state.dynamicToolNames`
+	 * so the next user input clears them (used by proxy describe/search results).
+	 * Pass `false` for tools that should persist across turns — e.g. direct tools
+	 * registered after a successful cache bootstrap.
+	 *
+	 * If `state` is not yet ready (callback invoked from inside `initializeMcp`
+	 * before its promise resolves), we still register and activate the tools —
+	 * the executor captures `state` lazily via the `() => state` closure, so
+	 * later calls resolve it correctly. We only skip the dynamic-name tagging
+	 * in that window because `state.dynamicToolNames` doesn't exist yet; this
+	 * is acceptable because the bootstrap path passes `markDynamic: false`.
+	 */
+	function registerAndActivate(specs: DirectToolSpec[], opts?: { markDynamic?: boolean }): string[] {
+		const markDynamic = opts?.markDynamic ?? true
 		const newNames: string[] = []
 		const alreadyActive: string[] = []
 		for (const spec of specs) {
@@ -131,14 +159,25 @@ export default function mcpAdapter(pi: ExtensionAPI) {
 		}
 		const allInjected = [...alreadyActive, ...newNames]
 		if (newNames.length > 0) {
-			for (const name of newNames) {
-				state.dynamicToolNames.add(name)
+			if (markDynamic && state) {
+				for (const name of newNames) {
+					state.dynamicToolNames.add(name)
+				}
 			}
 			const current = new Set(pi.getActiveTools())
 			for (const name of newNames) current.add(name)
 			pi.setActiveTools([...current])
 		}
 		return allInjected
+	}
+
+	/**
+	 * Register direct-tool specs produced by the cache bootstrap path
+	 * (`init.ts` → `resolveDirectTools` after first connect). These tools
+	 * are permanent for the session, so they must not be marked dynamic.
+	 */
+	function registerBootstrappedDirectTools(specs: DirectToolSpec[]): string[] {
+		return registerAndActivate(specs, { markDynamic: false })
 	}
 
 	pi.on("input", () => {
@@ -176,7 +215,7 @@ export default function mcpAdapter(pi: ExtensionAPI) {
 			console.error("MCP OAuth initialization failed:", err)
 		})
 
-		const promise = initializeMcp(pi, ctx)
+		const promise = initializeMcp(pi, ctx, registerBootstrappedDirectTools)
 		initPromise = promise
 
 		promise

--- a/src/extensions/mcp-adapter/index.ts
+++ b/src/extensions/mcp-adapter/index.ts
@@ -127,15 +127,17 @@ export default function mcpAdapter(pi: ExtensionAPI) {
 	 * Pass `false` for tools that should persist across turns — e.g. direct tools
 	 * registered after a successful cache bootstrap.
 	 *
-	 * If `state` is not yet ready (callback invoked from inside `initializeMcp`
-	 * before its promise resolves), we still register and activate the tools —
-	 * the executor captures `state` lazily via the `() => state` closure, so
-	 * later calls resolve it correctly. We only skip the dynamic-name tagging
-	 * in that window because `state.dynamicToolNames` doesn't exist yet; this
-	 * is acceptable because the bootstrap path passes `markDynamic: false`.
+	 * When `state` is not yet ready (callback invoked from inside `initializeMcp`
+	 * before its promise resolves), we only allow the permanent path through —
+	 * registering dynamic tools without a state to track them in would leak them
+	 * across turns because the `pi.on("input", …)` clear couldn't find them.
+	 * Permanent tools (`markDynamic: false`) are safe to register early: the
+	 * executor captures `state` lazily via the `() => state` closure and the
+	 * tools are meant to persist anyway.
 	 */
 	function registerAndActivate(specs: DirectToolSpec[], opts?: { markDynamic?: boolean }): string[] {
 		const markDynamic = opts?.markDynamic ?? true
+		if (!state && markDynamic) return []
 		const newNames: string[] = []
 		const alreadyActive: string[] = []
 		for (const spec of specs) {
@@ -159,6 +161,8 @@ export default function mcpAdapter(pi: ExtensionAPI) {
 		}
 		const allInjected = [...alreadyActive, ...newNames]
 		if (newNames.length > 0) {
+			// Guard above ensures `markDynamic` implies `state` is set, so the
+			// dynamic-name bookkeeping is safe without a re-check here.
 			if (markDynamic && state) {
 				for (const name of newNames) {
 					state.dynamicToolNames.add(name)

--- a/src/extensions/mcp-adapter/init.ts
+++ b/src/extensions/mcp-adapter/init.ts
@@ -2,7 +2,7 @@ import { existsSync } from "node:fs"
 import type { ExtensionAPI, ExtensionContext } from "@earendil-works/pi-coding-agent"
 import { loadMcpConfig } from "./config.js"
 import { ConsentManager } from "./consent-manager.js"
-import { getMissingConfiguredDirectToolServers } from "./direct-tools.js"
+import { getMissingConfiguredDirectToolServers, resolveDirectTools } from "./direct-tools.js"
 import { McpLifecycleManager } from "./lifecycle.js"
 import { logger } from "./logger.js"
 import {
@@ -11,6 +11,8 @@ import {
 	getMetadataCachePath,
 	isServerCacheValid,
 	loadMetadataCache,
+	overwriteMetadataCache,
+	purgeStaleEntries,
 	reconstructToolMetadata,
 	saveMetadataCache,
 	serializeResources,
@@ -19,13 +21,17 @@ import {
 import { McpServerManager } from "./server-manager.js"
 import type { McpExtensionState } from "./state.js"
 import { buildToolMetadata, totalToolCount } from "./tool-metadata.js"
-import type { ToolMetadata } from "./types.js"
+import type { DirectToolSpec, ToolMetadata } from "./types.js"
 import { UiResourceHandler } from "./ui-resource-handler.js"
 import { openUrl, parallelLimit } from "./utils.js"
 
 const FAILURE_BACKOFF_MS = 60 * 1000
 
-export async function initializeMcp(pi: ExtensionAPI, ctx: ExtensionContext): Promise<McpExtensionState> {
+export async function initializeMcp(
+	pi: ExtensionAPI,
+	ctx: ExtensionContext,
+	registerBootstrappedDirectTools?: (specs: DirectToolSpec[]) => string[],
+): Promise<McpExtensionState> {
 	const configPath = pi.getFlag("mcp-config") as string | undefined
 	const config = loadMcpConfig(configPath)
 
@@ -71,6 +77,19 @@ export async function initializeMcp(pi: ExtensionAPI, ctx: ExtensionContext): Pr
 	} else if (!cache) {
 		cache = { version: 1, servers: {} }
 		saveMetadataCache(cache)
+	}
+
+	// Drop entries with stale configHash or no-longer-configured servers.
+	// Mirrors the load-time purge in index.ts so non-Pi entry points (tests,
+	// embedded use) get the same hygiene. Bootstrap below will repopulate
+	// anything we removed that's still in `config.mcpServers`.
+	if (cache) {
+		const { cleaned, removed } = purgeStaleEntries(cache, config.mcpServers)
+		if (removed.length > 0) {
+			overwriteMetadataCache(cleaned)
+			cache = cleaned
+			logger.debug(`MCP: purged stale cache entries: ${removed.join(", ")}`)
+		}
 	}
 
 	const prefix = config.settings?.toolPrefix ?? "server"
@@ -196,8 +215,40 @@ export async function initializeMcp(pi: ExtensionAPI, ctx: ExtensionContext): Pr
 				},
 			)
 			const bootstrapped = bootstrapResults.filter((r) => r.ok).map((r) => r.name)
-			if (bootstrapped.length > 0 && ctx.hasUI) {
-				ctx.ui.notify(`MCP: direct tools for ${bootstrapped.join(", ")} will be available after restart`, "info")
+			if (bootstrapped.length > 0) {
+				// Try to register direct tools for the just-bootstrapped servers
+				// in the current session. Avoids the historical "restart required"
+				// dance — the index.ts callback uses pi.registerTool +
+				// pi.setActiveTools, which exposes the tools to subsequent turns
+				// without reloading.
+				let injectedCount = 0
+				if (registerBootstrappedDirectTools) {
+					const freshCache = loadMetadataCache()
+					const envOverride = envDirect
+						?.split(",")
+						.map((s) => s.trim())
+						.filter(Boolean)
+					const allSpecs = resolveDirectTools(config, freshCache, prefix, envOverride)
+					const newSpecs = allSpecs.filter((s) => bootstrapped.includes(s.serverName))
+					if (newSpecs.length > 0) {
+						const injected = registerBootstrappedDirectTools(newSpecs)
+						injectedCount = injected.length
+					}
+				}
+
+				if (ctx.hasUI) {
+					if (injectedCount > 0) {
+						ctx.ui.notify(
+							`MCP: ${injectedCount} direct tool(s) from ${bootstrapped.join(", ")} are now available`,
+							"info",
+						)
+					} else {
+						ctx.ui.notify(
+							`MCP: direct tools for ${bootstrapped.join(", ")} will be available after restart`,
+							"info",
+						)
+					}
+				}
 			}
 		}
 	}

--- a/src/extensions/mcp-adapter/metadata-cache.ts
+++ b/src/extensions/mcp-adapter/metadata-cache.ts
@@ -82,6 +82,56 @@ export function saveMetadataCache(cache: MetadataCache): void {
 	renameSync(tmpPath, getCachePath())
 }
 
+/**
+ * Replace the on-disk cache with the provided content (no merge with existing).
+ * Use only when you need to delete entries; for adds/updates prefer
+ * `saveMetadataCache` so concurrent writers don't clobber each other.
+ */
+export function overwriteMetadataCache(cache: MetadataCache): void {
+	const dir = dirname(getCachePath())
+	mkdirSync(dir, { recursive: true })
+
+	const out: MetadataCache = { version: CACHE_VERSION, servers: cache.servers ?? {} }
+	const tmpPath = `${getCachePath()}.${process.pid}.tmp`
+	writeFileSync(tmpPath, JSON.stringify(out, null, 2), "utf-8")
+	renameSync(tmpPath, getCachePath())
+}
+
+/**
+ * Drop cache entries whose configHash no longer matches the current server
+ * definition. Orphan entries (cached servers not in the current config) are
+ * kept by default because the cache file is shared across projects — a server
+ * absent from this project's `mcp.json` is likely configured by another.
+ *
+ * Returns the cleaned cache and the list of removed server names. Caller is
+ * responsible for persisting via `overwriteMetadataCache` when
+ * `removed.length > 0`.
+ */
+export function purgeStaleEntries(
+	cache: MetadataCache | null,
+	mcpServers: Record<string, ServerEntry>,
+): { cleaned: MetadataCache; removed: string[] } {
+	const cleaned: MetadataCache = { version: CACHE_VERSION, servers: {} }
+	const removed: string[] = []
+	if (!cache?.servers) return { cleaned, removed }
+
+	for (const [name, entry] of Object.entries(cache.servers)) {
+		const definition = mcpServers[name]
+		if (!definition) {
+			// Orphan from another project's config — preserve.
+			cleaned.servers[name] = entry
+			continue
+		}
+		if (!entry?.configHash || entry.configHash !== computeServerHash(definition)) {
+			removed.push(name)
+			continue
+		}
+		cleaned.servers[name] = entry
+	}
+
+	return { cleaned, removed }
+}
+
 export function computeServerHash(definition: ServerEntry): string {
 	// Hash only fields that affect server identity and tool/resource output.
 	// Exclude lifecycle, idleTimeout, debug — those are runtime behavior settings

--- a/src/extensions/mcp-adapter/metadata-cache.ts
+++ b/src/extensions/mcp-adapter/metadata-cache.ts
@@ -1,8 +1,9 @@
 import { createHash } from "node:crypto"
 // metadata-cache.ts - Persistent MCP metadata cache
-import { existsSync, mkdirSync, readFileSync, renameSync, writeFileSync } from "node:fs"
+import { existsSync, mkdirSync, readFileSync, renameSync, unlinkSync, writeFileSync } from "node:fs"
 import { dirname, join } from "node:path"
 import { getToolUiResourceUri } from "@modelcontextprotocol/ext-apps/app-bridge"
+import { logger } from "./logger.js"
 import { resourceNameToToolName } from "./resource-tools.js"
 import type { McpResource, McpTool, ServerEntry, ToolMetadata } from "./types.js"
 import { formatToolName, isToolExcluded } from "./types.js"
@@ -86,15 +87,32 @@ export function saveMetadataCache(cache: MetadataCache): void {
  * Replace the on-disk cache with the provided content (no merge with existing).
  * Use only when you need to delete entries; for adds/updates prefer
  * `saveMetadataCache` so concurrent writers don't clobber each other.
+ *
+ * I/O failures (read-only filesystem, full disk, permission denied) are logged
+ * and swallowed — the cache is a derived artifact and must never crash the
+ * extension host during startup. Callers that need to know the write succeeded
+ * should re-read with `loadMetadataCache()`.
  */
 export function overwriteMetadataCache(cache: MetadataCache): void {
-	const dir = dirname(getCachePath())
-	mkdirSync(dir, { recursive: true })
-
+	const cachePath = getCachePath()
+	const tmpPath = `${cachePath}.${process.pid}.tmp`
 	const out: MetadataCache = { version: CACHE_VERSION, servers: cache.servers ?? {} }
-	const tmpPath = `${getCachePath()}.${process.pid}.tmp`
-	writeFileSync(tmpPath, JSON.stringify(out, null, 2), "utf-8")
-	renameSync(tmpPath, getCachePath())
+
+	try {
+		mkdirSync(dirname(cachePath), { recursive: true })
+		writeFileSync(tmpPath, JSON.stringify(out, null, 2), "utf-8")
+		renameSync(tmpPath, cachePath)
+	} catch (error) {
+		const message = error instanceof Error ? error.message : String(error)
+		logger.debug(`MCP: failed to overwrite metadata cache at ${cachePath}: ${message}`)
+		// Best-effort cleanup of a half-written temp file so we don't accumulate
+		// `.pid.tmp` dotfiles on repeated failures. If this throws too, drop it.
+		try {
+			if (existsSync(tmpPath)) unlinkSync(tmpPath)
+		} catch {
+			// nothing to do — the next run will overwrite or ignore stale temp files
+		}
+	}
 }
 
 /**

--- a/src/extensions/mcp-adapter/metadata-cache.ts
+++ b/src/extensions/mcp-adapter/metadata-cache.ts
@@ -46,41 +46,79 @@ export function getMetadataCachePath(): string {
 	return getCachePath()
 }
 
+/**
+ * Type guard to validate cache structure.
+ */
+function isValidCache(cache: unknown): cache is MetadataCache {
+	return !!(
+		cache &&
+		typeof cache === "object" &&
+		"version" in cache &&
+		cache.version === CACHE_VERSION &&
+		"servers" in cache &&
+		cache.servers &&
+		typeof cache.servers === "object"
+	)
+}
+
+/**
+ * Safely load existing cache from disk, returning empty cache on any error.
+ */
+function loadExistingCache(): MetadataCache {
+	const cache: MetadataCache = { version: CACHE_VERSION, servers: {} }
+
+	if (!existsSync(getCachePath())) return cache
+
+	try {
+		const existing = JSON.parse(readFileSync(getCachePath(), "utf-8"))
+		if (isValidCache(existing)) {
+			cache.servers = { ...existing.servers }
+		}
+	} catch {
+		// Ignore parse errors and return empty cache
+	}
+
+	return cache
+}
+
+/**
+ * Atomically write cache data to disk using temp file + rename.
+ */
+function atomicWriteCache(data: MetadataCache): void {
+	const cachePath = getCachePath()
+	const tmpPath = `${cachePath}.${process.pid}.tmp`
+
+	mkdirSync(dirname(cachePath), { recursive: true })
+	writeFileSync(tmpPath, JSON.stringify(data, null, 2), "utf-8")
+	renameSync(tmpPath, cachePath)
+}
+
+/**
+ * Best-effort cleanup of temporary file. Swallows all errors.
+ */
+function cleanupTempFile(tmpPath: string): void {
+	try {
+		if (existsSync(tmpPath)) unlinkSync(tmpPath)
+	} catch {
+		// nothing to do — the next run will overwrite or ignore stale temp files
+	}
+}
+
 export function loadMetadataCache(): MetadataCache | null {
 	if (!existsSync(getCachePath())) return null
 	try {
 		const raw = JSON.parse(readFileSync(getCachePath(), "utf-8"))
-		if (!raw || typeof raw !== "object") return null
-		if (raw.version !== CACHE_VERSION) return null
-		if (!raw.servers || typeof raw.servers !== "object") return null
-		return raw as MetadataCache
+		if (!isValidCache(raw)) return null
+		return raw
 	} catch {
 		return null
 	}
 }
 
 export function saveMetadataCache(cache: MetadataCache): void {
-	const dir = dirname(getCachePath())
-	mkdirSync(dir, { recursive: true })
-
-	const merged: MetadataCache = { version: CACHE_VERSION, servers: {} }
-	try {
-		if (existsSync(getCachePath())) {
-			const existing = JSON.parse(readFileSync(getCachePath(), "utf-8")) as MetadataCache
-			if (existing && existing.version === CACHE_VERSION && existing.servers) {
-				merged.servers = { ...existing.servers }
-			}
-		}
-	} catch {
-		// Ignore parse errors and proceed with empty cache
-	}
-
-	merged.version = CACHE_VERSION
+	const merged = loadExistingCache()
 	merged.servers = { ...merged.servers, ...cache.servers }
-
-	const tmpPath = `${getCachePath()}.${process.pid}.tmp`
-	writeFileSync(tmpPath, JSON.stringify(merged, null, 2), "utf-8")
-	renameSync(tmpPath, getCachePath())
+	atomicWriteCache(merged)
 }
 
 /**
@@ -99,19 +137,13 @@ export function overwriteMetadataCache(cache: MetadataCache): void {
 	const out: MetadataCache = { version: CACHE_VERSION, servers: cache.servers ?? {} }
 
 	try {
-		mkdirSync(dirname(cachePath), { recursive: true })
-		writeFileSync(tmpPath, JSON.stringify(out, null, 2), "utf-8")
-		renameSync(tmpPath, cachePath)
+		atomicWriteCache(out)
 	} catch (error) {
 		const message = error instanceof Error ? error.message : String(error)
 		logger.debug(`MCP: failed to overwrite metadata cache at ${cachePath}: ${message}`)
 		// Best-effort cleanup of a half-written temp file so we don't accumulate
 		// `.pid.tmp` dotfiles on repeated failures. If this throws too, drop it.
-		try {
-			if (existsSync(tmpPath)) unlinkSync(tmpPath)
-		} catch {
-			// nothing to do — the next run will overwrite or ignore stale temp files
-		}
+		cleanupTempFile(tmpPath)
 	}
 }
 
@@ -182,6 +214,28 @@ export function isServerCacheValid(
 	return true
 }
 
+/**
+ * Build tool metadata if not excluded, otherwise return null.
+ */
+function buildToolMetadata(
+	toolName: string,
+	serverName: string,
+	prefix: "server" | "none" | "short",
+	excludeTools: ServerEntry["excludeTools"],
+	additionalFields: Partial<ToolMetadata>,
+): ToolMetadata | null {
+	if (isToolExcluded(toolName, serverName, prefix, excludeTools)) {
+		return null
+	}
+
+	return {
+		name: formatToolName(toolName, serverName, prefix),
+		originalName: toolName,
+		description: "",
+		...additionalFields,
+	}
+}
+
 export function reconstructToolMetadata(
 	serverName: string,
 	entry: ServerCacheEntry,
@@ -192,34 +246,38 @@ export function reconstructToolMetadata(
 
 	for (const tool of entry.tools ?? []) {
 		if (!tool?.name) continue
-		if (isToolExcluded(tool.name, serverName, prefix, definition.excludeTools)) {
-			continue
-		}
 
-		metadata.push({
-			name: formatToolName(tool.name, serverName, prefix),
-			originalName: tool.name,
+		const toolMetadata = buildToolMetadata(tool.name, serverName, prefix, definition.excludeTools, {
 			description: tool.description ?? "",
 			inputSchema: tool.inputSchema,
 			uiResourceUri: tool.uiResourceUri,
 			uiStreamMode: tool.uiStreamMode,
 		})
+
+		if (toolMetadata) {
+			metadata.push(toolMetadata)
+		}
 	}
 
 	if (definition.exposeResources !== false) {
 		for (const resource of entry.resources ?? []) {
 			if (!resource?.name || !resource?.uri) continue
-			const baseName = `get_${resourceNameToToolName(resource.name)}`
-			if (isToolExcluded(baseName, serverName, prefix, definition.excludeTools)) {
-				continue
-			}
 
-			metadata.push({
-				name: formatToolName(baseName, serverName, prefix),
-				originalName: baseName,
-				description: resource.description ?? `Read resource: ${resource.uri}`,
-				resourceUri: resource.uri,
-			})
+			const baseName = `get_${resourceNameToToolName(resource.name)}`
+			const resourceMetadata = buildToolMetadata(
+				baseName,
+				serverName,
+				prefix,
+				definition.excludeTools,
+				{
+					description: resource.description ?? `Read resource: ${resource.uri}`,
+					resourceUri: resource.uri,
+				},
+			)
+
+			if (resourceMetadata) {
+				metadata.push(resourceMetadata)
+			}
 		}
 	}
 

--- a/src/extensions/permissions/taxonomy.test.ts
+++ b/src/extensions/permissions/taxonomy.test.ts
@@ -33,6 +33,38 @@ describe("classifyTool", () => {
 		expect(classifyTool("do_the_thing")).toBe("unknown")
 		expect(classifyTool("mcp__foo__apply_changes")).toBe("unknown")
 	})
+
+	it("classifies MCP direct tools by read-verb segments after the server prefix", () => {
+		// Direct tools arrive flattened: <server>_<verb>_<rest>. The verb sits at
+		// position 1 (or later), not at the start of the name, so the segment
+		// scan kicks in.
+		expect(classifyTool("jetbrains_get_all_open_file_paths")).toBe("readOnly")
+		expect(classifyTool("jetbrains_get_run_configurations")).toBe("readOnly")
+		expect(classifyTool("jetbrains_xdebug_get_stack")).toBe("readOnly")
+		expect(classifyTool("supabase_list_tables")).toBe("readOnly")
+		expect(classifyTool("supabase_search_docs")).toBe("readOnly")
+	})
+
+	it("leaves mutating MCP direct tools as unknown", () => {
+		// No read-verb segment after the prefix — these tools change state and
+		// must remain blocked in plan mode.
+		expect(classifyTool("jetbrains_execute_run_configuration")).toBe("unknown")
+		expect(classifyTool("jetbrains_build_project")).toBe("unknown")
+		expect(classifyTool("jetbrains_create_new_file")).toBe("unknown")
+		expect(classifyTool("jetbrains_rename_refactoring")).toBe("unknown")
+		expect(classifyTool("playwright_browser_click")).toBe("unknown")
+	})
+
+	it("ignores read-verbs that appear in the first (server-prefix) segment", () => {
+		// If the server is literally called "get" or "list", we don't want to
+		// blanket-mark every tool under it as read-only — only later segments
+		// count.
+		expect(classifyTool("list_writer_create_thing")).toBe("readOnly") // hits the start-anchored regex via "list"
+		// A standalone segment that's just a read verb is fine; the start-anchored
+		// hint already handled that. The post-prefix scan is additive, not a
+		// regression of existing behavior.
+		expect(classifyTool("show_status")).toBe("readOnly")
+	})
 })
 
 describe("isReadOnlyTool", () => {

--- a/src/extensions/permissions/taxonomy.ts
+++ b/src/extensions/permissions/taxonomy.ts
@@ -19,6 +19,40 @@ const STATIC_CATEGORIES: Record<string, ToolCategory> = {
 
 const READ_ONLY_NAME_HINT = /^(read|get|list|search|query|describe|find|grep|ls|loki_|view|show)/i
 
+// Verbs at the start of an underscore-separated segment that signal a read-only
+// operation on namespaced MCP direct tools like `jetbrains_get_all_open_file_paths`
+// or `supabase_list_tables`. We require an exact segment-position match (not a
+// substring) to avoid false positives — e.g. server names that happen to contain
+// `get` should not flip the classification.
+const READ_ONLY_VERB_SEGMENTS = new Set([
+	"read",
+	"get",
+	"list",
+	"search",
+	"query",
+	"describe",
+	"find",
+	"grep",
+	"ls",
+	"view",
+	"show",
+	"preview",
+	"inspect",
+])
+
+function hasReadOnlyVerbSegment(toolName: string): boolean {
+	const lower = toolName.toLowerCase()
+	if (!lower.includes("_")) return false
+	// Skip the first segment (typically the server/namespace prefix) so a
+	// namespace called "list" or "get" doesn't blanket-mark every tool
+	// underneath it as read-only. Verbs in any subsequent segment count.
+	const segments = lower.split("_")
+	for (let i = 1; i < segments.length; i++) {
+		if (READ_ONLY_VERB_SEGMENTS.has(segments[i])) return true
+	}
+	return false
+}
+
 export function classifyTool(toolName: string): ToolCategory {
 	const lower = toolName.toLowerCase()
 	if (lower in STATIC_CATEGORIES) return STATIC_CATEGORIES[lower]
@@ -30,6 +64,10 @@ export function classifyTool(toolName: string): ToolCategory {
 	}
 
 	if (READ_ONLY_NAME_HINT.test(toolName)) return "readOnly"
+	// MCP direct tools (with toolPrefix: "server") arrive flattened to a single
+	// underscore-separated name. Inspect post-prefix verb segments so they're
+	// not all stranded as "unknown" in plan mode.
+	if (hasReadOnlyVerbSegment(toolName)) return "readOnly"
 	return "unknown"
 }
 


### PR DESCRIPTION
## Summary

Two related issues blocked `jetbrains_get_all_open_file_paths` (and other MCP direct tools) from being callable in a kimchi-dev session, even when the JetBrains MCP server was running and reachable.

1. **First-run registration gap** — when the on-disk `mcp-cache.json` had a stale `configHash` for a server with `directTools: true`, the cached metadata was rejected, no direct tools registered at module load, and the bootstrap-on-connect path only emitted *"available after restart"*. A naive first-time user (or anyone who edited `.kimchi/mcp.json`) saw a permanent **Tool not found** failure.
2. **Plan-mode classifier blind spot** — `permissions/taxonomy.ts` only matched the read-verb (`get`/`list`/etc.) at position 0 of the tool name. MCP direct tools arrive prefix-flattened (`jetbrains_get_all_open_file_paths`), so the verb sits at position 1 and every read-only MCP tool got classified `unknown` → stripped from the plan-mode active set → reported as *"not available"* or *"not found"* depending on timing.

This PR fixes both. After landing, the user-reported flow works on the first run, in plan mode, without a restart.

## Root cause walkthrough

### Why the cache rejection happens

- `src/extensions/mcp-adapter/index.ts` at module load runs `resolveDirectTools(earlyConfig, earlyCache, …)` (line 75 pre-patch). For each server with `directTools: true`, it iterates the cache entry and registers one `pi.registerTool({ … })` per cached tool.
- `direct-tools.ts:83` skips the server when `!isServerCacheValid(serverCache, definition)`.
- `isServerCacheValid` (`metadata-cache.ts:106`) compares `entry.configHash` to `computeServerHash(definition)`. `computeServerHash` only hashes identity-affecting fields (`command`, `args`, `env`, `cwd`, `url`, `headers`, `auth`, `bearerToken`, `bearerTokenEnv`, `exposeResources`, `excludeTools`).
- The cache file `~/.config/kimchi/harness/mcp-cache.json` is **shared across every project** (path derives from `getAgentDir()`), so an entry written by a different project's `mcp.json` lingers and silently fails the hash check.
- The bootstrap path at `init.ts:171-203` could re-cache after a successful connect, but it only fired the *"available after restart"* notification; direct tools register synchronously at module load, so they only became visible on the **next** restart. Combined with the unconditional `if (!state) return []` guard in `registerAndActivate`, even adding a runtime registration callback wouldn't have worked.

### Why plan mode hid the registered tools

- Reproduced from the session log: call #0 returned *"Plan mode: tool jetbrains_get_all_open_file_paths is not available. Use /permissions mode default to enable writes."* and call #1 returned *"Tool jetbrains_get_all_open_file_paths not found"*.
- `permissions/index.ts:192` (`applyPlanModeTools`) runs at session start and rebuilds the active set to **only** tools where `isReadOnlyTool(name)` is true or `name` is in `PLAN_MODE_TOOLS`.
- `taxonomy.ts:20` had `READ_ONLY_NAME_HINT = /^(read|get|list|search|query|describe|find|grep|ls|loki_|view|show)/i`. For `jetbrains_get_all_open_file_paths`, the regex anchors at `^` and only sees `jetbrains` → no match → classified `unknown` → not read-only → dropped from the plan-mode active set.

## Changes

### `src/extensions/mcp-adapter/metadata-cache.ts`

- `overwriteMetadataCache(cache)` — writes the on-disk cache verbatim (no merge with existing). `saveMetadataCache` always merges, so it cannot delete entries; the new function fills that gap.
- `purgeStaleEntries(cache, mcpServers)` — drops entries whose server **is** in the current `mcp.json` but whose `configHash` no longer matches the live definition. **Orphan entries (servers not in the current project's config) are preserved** because the cache is shared across projects; dropping them would silently nuke teammates' caches.

### `src/extensions/mcp-adapter/index.ts`

- Run `purgeStaleEntries` at module load right after `loadMetadataCache()`. If any entry was removed, persist via `overwriteMetadataCache` and continue with the cleaned cache.
- `registerAndActivate(specs, opts?)` now accepts a `markDynamic` flag (default `true`, preserves existing proxy describe/search callers). When `false`, the new tool names are **not** added to `state.dynamicToolNames`, so the `pi.on("input", …)` hook leaves them in the active set across turns.
- Removed the early `if (!state) return []` guard so the new bootstrap callback can run from inside `initializeMcp` before its promise resolves. The lazy `() => state` closure inside `createDirectToolExecutor` resolves the state correctly at call time. `state.dynamicToolNames` is only touched when both `markDynamic` and `state` are truthy.
- Added `registerBootstrappedDirectTools(specs)` — thin wrapper that calls `registerAndActivate(specs, { markDynamic: false })`. Passed as the third argument to `initializeMcp`.

### `src/extensions/mcp-adapter/init.ts`

- `initializeMcp` learned an optional third argument: `registerBootstrappedDirectTools?: (specs: DirectToolSpec[]) => string[]`.
- After `loadMetadataCache()` inside `initializeMcp`, run `purgeStaleEntries` again and persist via `overwriteMetadataCache`. Covers callers that don't go through `index.ts` module-load (tests, embedded use).
- After the bootstrap loop at `init.ts:171-203`, for each successfully bootstrapped server name, resolve fresh specs via `resolveDirectTools(config, freshCache, prefix, envOverride)` filtered to `bootstrapped`, then invoke the callback. On non-empty injection, emit the new *"MCP: N direct tool(s) from … are now available"* notification; fall back to the previous *"available after restart"* message when the callback is absent or returns empty.

### `src/extensions/permissions/taxonomy.ts`

- Added `READ_ONLY_VERB_SEGMENTS` (`get`, `list`, `search`, `query`, `describe`, `find`, `grep`, `ls`, `view`, `show`, `preview`, `inspect`, plus `read`).
- `hasReadOnlyVerbSegment(toolName)` splits on `_` and checks if **any segment after the first** is an exact match for a read-verb. The first segment is intentionally skipped so a server namespace like `list` or `get` doesn't blanket-mark every tool under it as read-only.
- `classifyTool` consults the new helper as a fallback after `STATIC_CATEGORIES`, the `mcp__` branch, and the original `READ_ONLY_NAME_HINT` start-anchored regex.

Worked out by inspection of the `_refreshToolRegistry` flow in the bundled pi-coding-agent — tools must live in `_toolRegistry` (active set) **and** match `currentContext.tools` at agent-loop dispatch (`agent-loop.js:332`) or the agent returns `Tool X not found` before any extension `tool_call` hook runs.

## Verified classifications

| Tool                                          | Before    | After     | Reason                                      |
| --------------------------------------------- | --------- | --------- | ------------------------------------------- |
| `jetbrains_get_all_open_file_paths`           | `unknown` | `readOnly`| verb `get` in segment 1                      |
| `jetbrains_get_run_configurations`            | `unknown` | `readOnly`| verb `get` in segment 1                      |
| `jetbrains_xdebug_get_stack`                  | `unknown` | `readOnly`| verb `get` in segment 2                      |
| `supabase_list_tables`, `supabase_search_docs`| `unknown` | `readOnly`| verb `list`/`search` in segment 1            |
| `jetbrains_execute_run_configuration`         | `unknown` | `unknown` | no read-verb segment — stays blocked         |
| `jetbrains_build_project`                     | `unknown` | `unknown` | no read-verb segment — stays blocked         |
| `jetbrains_create_new_file`                   | `unknown` | `unknown` | `create` is not in the read-verb set         |
| `jetbrains_rename_refactoring`                | `unknown` | `unknown` | `rename` is not in the read-verb set         |
| `playwright_browser_click`                    | `unknown` | `unknown` | no read-verb segment                         |
| `mcp`, `bash`, `read`                         | unchanged | unchanged | hit `STATIC_CATEGORIES`                      |

## Test plan

- [x] `pnpm run typecheck` — clean.
- [x] `pnpm run lint` — clean.
- [x] `pnpm test` — 1891/1891 pass.
- [x] Dry-run `purgeStaleEntries` against `~/.config/kimchi/harness/mcp-cache.json` with the project's current `.kimchi/mcp.json` — removes only the stale `jetbrains` entry, preserves `supabase`, `sentry`, `playwright` orphans.
- [x] Sanity-tested classifier against the table above (all expectations matched).
- [x] Manual smoke: with JetBrains IDE listening on `127.0.0.1:64342`, stop `pnpm dev`, `jq 'del(.servers.jetbrains)' ~/.config/kimchi/harness/mcp-cache.json` to force the bootstrap path, start `pnpm dev`, ask for `jetbrains_get_all_open_file_paths` in plan mode → expect the call to succeed (cache rewritten with matching hash, tool registered in-session, plan-mode allow-list now includes it).
- [x] Manual smoke: kill JetBrains, repeat — expect the *"available after restart"* fallback notify and a clean `mcp({ tool: "get_all_open_file_paths", server: "jetbrains" })` *"server not available"* error.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
### Kimchi Summary
### What changed
Fixes stale MCP metadata cache entries blocking direct-tool registration on startup, enables immediate registration of bootstrapped direct tools without a restart, and corrects the permission taxonomy for flattened MCP tool names.

### Why
When a server definition changed, the on-disk cache retained an old `configHash` that caused `resolveDirectTools` to silently reject every tool on load, forcing users to restart. Additionally, the permissions layer only looked for read-only verbs at the start of a tool name, so flattened direct-tool names like `jetbrains_get_all_open_file_paths` were incorrectly left as `unknown`.

### Key changes
- `metadata-cache.ts`
  - Adds `purgeStaleEntries` to drop cache entries whose `configHash` no longer matches the current server definition, while preserving orphans from other projects.
  - Adds `overwriteMetadataCache` for atomic replace-without-merge writes, with best-effort temp-file cleanup and swallowed I/O errors so a bad cache never crashes the extension host.
  - Refactors cache I/O into `atomicWriteCache`, `loadExistingCache`, `cleanupTempFile`, and `isValidCache`.
- `index.ts`
  - Purges stale cache and overwrites it during early extension load.
  - Extends `registerAndActivate` with an optional `{ markDynamic?: boolean }` flag; when `markDynamic` is `true` and `state` is not yet initialized, registration is skipped to prevent leaked dynamic tools.
  - Introduces `registerBootstrappedDirectTools` (always `markDynamic: false`) and passes it into `initializeMcp` so bootstrapped tools persist across turns.
- `init.ts`
  - Mirrors the stale-cache purge inside `initializeMcp` for non-Pi entry points.
  - After successful bootstrap, immediately calls `registerBootstrappedDirectTools` with resolved direct-tool specs instead of showing a "restart required" notification.
- `taxonomy.ts` and `taxonomy.test.ts`
  - Adds `hasReadOnlyVerbSegment`, which scans underscore-separated segments after the first (server prefix) to classify namespaced direct tools (e.g., `supabase_list_tables`) as `readOnly`.
- `cache-resolver.integration.test.ts` (new)
  - Adds integration tests exercising stale-entry purge, overwrite-vs-merge semantics, end-to-end stale→purge→resolve flow, and `excludeTools` / `directTools=false` interactions.

### Impact
- Bootstrapped MCP direct tools are now available in the current session without restarting.
- Dynamic-proxy tools registered before `state` is ready are no longer leaked.
- Cache file corruption or write failures are handled gracefully.