### PR TITLE
feat: add numeric key shortcuts to permission selection prompts

### DIFF
--- a/src/extensions/permissions/commands.ts
+++ b/src/extensions/permissions/commands.ts
@@ -2,6 +2,7 @@ import type { ExtensionAPI, ExtensionCommandContext, ExtensionContext } from "@e
 import { type LoadedConfig, appendToConfig, projectConfigPath, userConfigPath } from "./config.js"
 import { parseModeString } from "./mode.js"
 import { parseRule, stringifyRule } from "./rules.js"
+import { numberedChoices, stripChoiceNumber } from "./select-utils.js"
 import type { SessionMemory } from "./session-memory.js"
 import type { PermissionMode, Rule } from "./types.js"
 
@@ -87,7 +88,7 @@ async function openSelector(ctx: ExtensionContext, deps: CommandDeps): Promise<v
 	const RELOAD = "Reload config files"
 	const CANCEL = "Cancel"
 
-	const options = [
+	const options = numberedChoices([
 		CHANGE_MODE,
 		LIST_RULES,
 		ADD_ALLOW,
@@ -95,19 +96,21 @@ async function openSelector(ctx: ExtensionContext, deps: CommandDeps): Promise<v
 		...(sessionCount > 0 ? [SAVE_USER, SAVE_PROJECT] : []),
 		RELOAD,
 		CANCEL,
-	]
+	])
 
 	const title = `Permissions — mode: ${mode}${sessionCount ? ` · ${sessionCount} session rule(s)` : ""}`
 	const choice = await ctx.ui.select(title, options)
-	if (!choice || choice === CANCEL) return
+	if (!choice) return
+	const selected = stripChoiceNumber(choice)
+	if (selected === CANCEL) return
 
-	if (choice === CHANGE_MODE) return openModePicker(ctx, deps)
-	if (choice === LIST_RULES) return showStatus(ctx as ExtensionCommandContext, deps)
-	if (choice === ADD_ALLOW) return promptForRule(ctx, deps, "allow")
-	if (choice === ADD_DENY) return promptForRule(ctx, deps, "deny")
-	if (choice === SAVE_USER) return saveSessionRules(ctx, deps, "user")
-	if (choice === SAVE_PROJECT) return saveSessionRules(ctx, deps, "project")
-	if (choice === RELOAD) {
+	if (selected === CHANGE_MODE) return openModePicker(ctx, deps)
+	if (selected === LIST_RULES) return showStatus(ctx as ExtensionCommandContext, deps)
+	if (selected === ADD_ALLOW) return promptForRule(ctx, deps, "allow")
+	if (selected === ADD_DENY) return promptForRule(ctx, deps, "deny")
+	if (selected === SAVE_USER) return saveSessionRules(ctx, deps, "user")
+	if (selected === SAVE_PROJECT) return saveSessionRules(ctx, deps, "project")
+	if (selected === RELOAD) {
 		deps.reloadConfig(ctx)
 		ctx.ui.notify("permissions: config reloaded", "info")
 	}
@@ -127,17 +130,22 @@ async function openModePicker(ctx: ExtensionContext, deps: CommandDeps): Promise
 	const OPT_YOLO = `${marker("yolo")}  yolo — run freely, no classifier (DANGER)`
 	const CANCEL = "Cancel"
 
-	const choice = await ctx.ui.select("Select permission mode", [OPT_DEFAULT, OPT_PLAN, OPT_AUTO, OPT_YOLO, CANCEL])
-	if (!choice || choice === CANCEL) return
+	const choice = await ctx.ui.select(
+		"Select permission mode",
+		numberedChoices([OPT_DEFAULT, OPT_PLAN, OPT_AUTO, OPT_YOLO, CANCEL]),
+	)
+	if (!choice) return
+	const selected = stripChoiceNumber(choice)
+	if (selected === CANCEL) return
 
 	const picked: PermissionMode =
-		choice === OPT_DEFAULT
+		selected === OPT_DEFAULT
 			? "default"
-			: choice === OPT_PLAN
+			: selected === OPT_PLAN
 				? "plan"
-				: choice === OPT_AUTO
+				: selected === OPT_AUTO
 					? "auto"
-					: choice === OPT_YOLO
+					: selected === OPT_YOLO
 						? "yolo"
 						: "default"
 	handleMode(ctx, deps, picked)

--- a/src/extensions/permissions/prompts.ts
+++ b/src/extensions/permissions/prompts.ts
@@ -1,4 +1,5 @@
 import type { ExtensionContext } from "@earendil-works/pi-coding-agent"
+import { numberedChoices, stripChoiceNumber } from "./select-utils.js"
 import { suggestScope } from "./session-memory.js"
 import type { Rule } from "./types.js"
 
@@ -51,9 +52,9 @@ export async function promptForApproval(opts: PromptOptions): Promise<ApprovalOu
 		: undefined
 
 	// Add wildcard option for bash commands
-	const choices = yesWildcard
-		? [yesOnce, yesRemember, yesWildcard, noWithFeedback]
-		: [yesOnce, yesRemember, noWithFeedback]
+	const choices = numberedChoices(
+		yesWildcard ? [yesOnce, yesRemember, yesWildcard, noWithFeedback] : [yesOnce, yesRemember, noWithFeedback],
+	)
 
 	const choice = await ctx.ui.select(lines.join("\n"), choices, {
 		signal: opts.signal,
@@ -61,9 +62,11 @@ export async function promptForApproval(opts: PromptOptions): Promise<ApprovalOu
 
 	if (choice === undefined && opts.signal?.aborted) return { kind: "aborted" }
 
-	if (choice === yesOnce) return { kind: "allow-once" }
+	const selected = choice ? stripChoiceNumber(choice) : undefined
 
-	if (choice === yesRemember) {
+	if (selected === yesOnce) return { kind: "allow-once" }
+
+	if (selected === yesRemember) {
 		const rule: Rule = {
 			toolName: scope.toolName,
 			content: scope.content,
@@ -74,7 +77,7 @@ export async function promptForApproval(opts: PromptOptions): Promise<ApprovalOu
 	}
 
 	// Check if wildcard was selected (only applicable for bash)
-	if (yesWildcard && choice === yesWildcard) {
+	if (yesWildcard && selected === yesWildcard) {
 		const rule: Rule = {
 			toolName: scope.toolName,
 			content: `${scope.wildcardContent}`,
@@ -84,7 +87,7 @@ export async function promptForApproval(opts: PromptOptions): Promise<ApprovalOu
 		return { kind: "allow-remember-wildcard", rule }
 	}
 
-	if (choice === noWithFeedback) {
+	if (selected === noWithFeedback) {
 		const feedback = await ctx.ui.input("Tell the assistant what to do differently:")
 		const text = feedback?.trim()
 		if (text) return { kind: "deny-with-feedback", feedback: text }
@@ -115,12 +118,13 @@ export async function promptForCompoundApproval(opts: {
 	]
 	if (opts.subtitle) lines.push(opts.subtitle)
 
-	const choices = [
+	const compoundChoices = [
 		"Run all (once)",
 		"Allow all from now on",
 		"Pick permissions per subcommand",
 		"No — tell the assistant what to do differently",
 	]
+	const choices = numberedChoices(compoundChoices)
 
 	const choice = await ctx.ui.select(lines.join("\n"), choices, {
 		signal: opts.signal,
@@ -128,8 +132,10 @@ export async function promptForCompoundApproval(opts: {
 
 	if (choice === undefined && opts.signal?.aborted) return { kind: "aborted" }
 
-	if (choice === choices[0]) return { kind: "allow-all-once" }
-	if (choice === choices[1]) {
+	const selected = choice ? stripChoiceNumber(choice) : undefined
+
+	if (selected === compoundChoices[0]) return { kind: "allow-all-once" }
+	if (selected === compoundChoices[1]) {
 		const rules: Rule[] = commands.map((cmd) => ({
 			toolName: opts.toolName,
 			content: `${cmd.command.split(" ")[0]} *`,
@@ -138,8 +144,8 @@ export async function promptForCompoundApproval(opts: {
 		}))
 		return { kind: "allow-all-remember", rules }
 	}
-	if (choice === choices[2]) return { kind: "pick-per-subcommand" }
-	if (choice === choices[3]) {
+	if (selected === compoundChoices[2]) return { kind: "pick-per-subcommand" }
+	if (selected === compoundChoices[3]) {
 		const feedback = await ctx.ui.input("Tell the assistant what to do differently:")
 		const text = feedback?.trim()
 		if (text) return { kind: "deny-with-feedback", feedback: text }

--- a/src/extensions/permissions/select-utils.ts
+++ b/src/extensions/permissions/select-utils.ts
@@ -1,0 +1,2 @@
+export const numberedChoices = (items: string[]): string[] => items.map((c, i) => `${i + 1}. ${c}`)
+export const stripChoiceNumber = (choice: string): string => choice.replace(/^\d+\. /, "")


### PR DESCRIPTION


---
### Kimchi Summary
### What changed
Adds numeric shortcuts to all permission-related UI selection menus so users can quickly identify and select options by number.

### Why
Selection menus in the permissions extension previously required typing full option labels. Numeric prefixes make choices faster to scan and select.

### Key changes
- **`src/extensions/permissions/select-utils.ts`** — New utility module exporting `numberedChoices` (prefixes options with `1.`, `2.`, etc.) and `stripChoiceNumber` (removes the prefix for comparison).
- **`src/extensions/permissions/commands.ts`** — Updated `openSelector` and `openModePicker` to wrap choice arrays with `numberedChoices` and parse results with `stripChoiceNumber`.
- **`src/extensions/permissions/prompts.ts`** — Updated `promptForApproval` and `promptForCompoundApproval` to display numbered choices and strip prefixes before evaluating the selected action.