### PR TITLE
fix(ferment): remove silent phase auto-advance; agent owns phase activation

### DIFF
--- a/src/extensions/ferment/modes.ts
+++ b/src/extensions/ferment/modes.ts
@@ -2,7 +2,7 @@
  * Mode predicates for the active ferment.
  *
  * `plan`: conversational, asks for confirmations.
- * `exec`: fully autonomous, auto-advances on phase completion.
+ * `exec`: fully autonomous; the agent calls activate_phase / start_step / complete_phase explicitly.
  * `auto`: balanced — full instructions, planner decides when to act.
  */
 

--- a/src/extensions/ferment/nudge.ts
+++ b/src/extensions/ferment/nudge.ts
@@ -14,10 +14,9 @@
  */
 
 import type { ExtensionAPI } from "@earendil-works/pi-coding-agent"
-import { determineNextAction, findFirstPlannedPhase } from "../../ferment/engine.js"
+import { determineNextAction } from "../../ferment/engine.js"
 import type { DeclarativeAction } from "../../ferment/engine.js"
 import { type FermentRuntime, defaultFermentRuntime } from "./runtime.js"
-import { createApplyAndPersist } from "./tool-helpers.js"
 
 export function appendRefEntry(pi: ExtensionAPI, fermentId: string): void {
 	void pi.sendMessage({
@@ -148,20 +147,16 @@ export function onStepCompleted(pi: ExtensionAPI, runtime: FermentRuntime = defa
 }
 
 export function onPhaseCompleted(pi: ExtensionAPI, runtime: FermentRuntime = defaultFermentRuntime): void {
+	// Refresh the in-memory active ferment cache after the storage write. The agent
+	// drives state — no silent activate_phase here. Prior versions auto-advanced
+	// the next planned phase in exec mode, which left the FSM in PHASE_ACTIVE
+	// behind the agent's back and caused every subsequent agent-initiated
+	// activate_phase to be rejected.
 	const id = runtime.getActiveId()
 	if (!id) return
 	const fresh = runtime.getStorage().get(id)
 	if (fresh) {
 		runtime.setActive(fresh)
-		// Auto-advance only in exec mode — auto/plan modes leave activation to the planner
-		if (fresh.mode === "exec") {
-			const next = findFirstPlannedPhase(fresh)
-			if (next) {
-				const applyAndPersist = createApplyAndPersist(runtime)
-				const out = applyAndPersist(fresh.id, { type: "activate_phase", phaseId: next.id })
-				if (out.ok) runtime.setActive(out.ferment)
-			}
-		}
 		maybeInjectAutoNudge(pi, {}, runtime)
 	}
 }

--- a/src/ferment/fsm.ts
+++ b/src/ferment/fsm.ts
@@ -342,6 +342,45 @@ const TRANSITIONS: TransitionMap = {
 // ─── Transition function ──────────────────────────────────────────────────────
 
 /**
+ * Recovery hints for the most common "wrong event in this state" mistakes.
+ * Returned alongside the base "not valid in state" message so the agent has
+ * something actionable instead of having to guess at the next call.
+ *
+ * Key is `${state}:${event}`. Hints describe what the agent should do
+ * *instead* — not why the rejection happened.
+ */
+const RECOVERY_HINTS: Partial<Record<string, string>> = {
+	[`${FSM_STATES.PHASE_ACTIVE}:${FSM_EVENTS.ACTIVATE_PHASE}`]:
+		"A phase is already active. Call start_step to begin its work, or complete_phase / skip_phase / fail_phase to finish it before activating another.",
+	[`${FSM_STATES.STEP_RUNNING}:${FSM_EVENTS.ACTIVATE_PHASE}`]:
+		"A step is currently running in the active phase. Call complete_step / skip_step / fail_step first, then complete_phase, then activate the next phase.",
+	[`${FSM_STATES.PHASE_ACTIVE}:${FSM_EVENTS.COMPLETE_STEP}`]:
+		"No step is currently running. Call start_step to begin a step before completing it.",
+	[`${FSM_STATES.PHASE_ACTIVE}:${FSM_EVENTS.VERIFY_STEP}`]:
+		"No step is currently running. Call start_step to begin a step before verifying it.",
+	[`${FSM_STATES.PHASE_ACTIVE}:${FSM_EVENTS.SET_MODE}`]:
+		"set_mode is only valid before a phase is active. Pause the ferment first if you need to change mode.",
+	[`${FSM_STATES.STEP_RUNNING}:${FSM_EVENTS.SET_MODE}`]:
+		"set_mode is only valid before a phase is active. Pause the ferment first if you need to change mode.",
+	[`${FSM_STATES.STEP_RUNNING}:${FSM_EVENTS.COMPLETE_PHASE}`]:
+		"A step is still running in this phase. Finish or fail the running step before completing the phase.",
+	[`${FSM_STATES.PLANNED}:${FSM_EVENTS.START_STEP}`]: "No phase is active. Call activate_phase first, then start_step.",
+	[`${FSM_STATES.PLANNED}:${FSM_EVENTS.COMPLETE_STEP}`]:
+		"No phase is active. Call activate_phase then start_step before completing a step.",
+	[`${FSM_STATES.PLANNED}:${FSM_EVENTS.COMPLETE_PHASE}`]: "No phase is active. Call activate_phase first.",
+	[`${FSM_STATES.COMPLETE}:${FSM_EVENTS.ACTIVATE_PHASE}`]:
+		"This ferment is complete. Start a new ferment to do more work.",
+}
+
+function describeValidEvents(state: FsmState): string {
+	const stateTransitions = TRANSITIONS[state]
+	if (!stateTransitions) return ""
+	const valid = Object.keys(stateTransitions)
+	if (valid.length === 0) return ""
+	return `Valid events in state "${state}": ${valid.join(", ")}.`
+}
+
+/**
  * Validate a transition. Returns the new state (or the current state with an
  * `error` if the transition was rejected). Pure — no I/O, no side effects.
  */
@@ -358,7 +397,11 @@ export function transition(
 
 	const transitionEntry = stateTransitions[event]
 	if (!transitionEntry) {
-		return { state, error: `Event "${event}" is not valid in state "${state}".` }
+		const base = `Event "${event}" is not valid in state "${state}".`
+		const hint = RECOVERY_HINTS[`${state}:${event}`]
+		const fallback = hint ? "" : ` ${describeValidEvents(state)}`
+		const tail = hint ? ` ${hint}` : fallback
+		return { state, error: `${base}${tail}` }
 	}
 
 	if (transitionEntry.guard) {

--- a/src/ferment/store.ts
+++ b/src/ferment/store.ts
@@ -417,7 +417,6 @@ export class FermentStorage {
 	// These helpers remain for:
 	//   - TUI command handlers (/progress overlay, /ferment switch/abandon)
 	//   - Test fixtures that need to bypass the state machine
-	//   - Internal callers (nudge.ts auto-advance) that pre-validate themselves
 	//
 	// They write directly without going through the state machine, so they DO
 	// NOT enforce invariants. Caller is responsible for state validity.


### PR DESCRIPTION
 After `complete_phase`, `onPhaseCompleted` was silently calling
  `activate_phase` for the next planned phase in exec mode. The agent then
  read "Next: <phase>" in the tool response and reasonably called
  `activate_phase` itself — which the FSM rejected with "Event
  'activate_phase' is not valid in state 'PHASE_ACTIVE'" because the next
  phase was already active.

  Analysis of 43 terminal-bench runs showed 41 sessions hit this rejection;
  passing tasks only succeeded when the agent stumbled into calling
  `start_step` directly (which works because the phase is already active).
  Failing tasks looped on `activate_phase` retries until timeout.

  The state machine was correctly modelled as agent-driven — PHASE_ACTIVE
  has no `activate_phase` transition because the agent is expected to
  complete the current phase first. The auto-advance was the only thing
  violating that contract.

  Changes:
  - nudge.ts: drop the auto-advance block from `onPhaseCompleted`; keep
    only the active-ferment cache refresh.
  - fsm.ts: add `RECOVERY_HINTS` table that appends an actionable hint to
    "not valid in state" errors for the common wrong-event cases
    (activate_phase in PHASE_ACTIVE, set_mode in PHASE_ACTIVE,
    complete_step without a running step, etc.). Falls back to listing the
    valid events for the current state when no specific hint exists.
  - modes.ts, store.ts: doc updates removing stale references to the
    auto-advance behaviour.

---
### Kimchi Summary
### What changed
Stopped auto-advancing phases in `exec` mode after phase completion so the agent explicitly controls state transitions. Invalid FSM transitions now return actionable recovery hints instead of generic error messages.

### Why
Auto-advancing the next planned phase in `exec` mode silently placed the state machine into `PHASE_ACTIVE`, which caused subsequent agent-initiated `activate_phase` calls to be rejected.

### Key changes
- `src/extensions/ferment/nudge.ts`: Removed the `exec` mode auto-advance logic and related imports (`findFirstPlannedPhase`, `createApplyAndPersist`) from `onPhaseCompleted`. Now only refreshes the active ferment cache after storage writes.
- `src/extensions/ferment/modes.ts`: Updated `exec` mode documentation to state the agent explicitly calls `activate_phase`, `start_step`, and `complete_phase`.
- `src/ferment/fsm.ts`: Added `RECOVERY_HINTS` and `describeValidEvents` to the transition validator. Rejection messages include state-specific guidance (e.g., *"Call start_step to begin its work..."*) or a list of valid events.
- `src/ferment/store.ts`: Removed the outdated comment referencing internal callers that pre-validated state changes.

### Impact
- **Behavioral change**: `exec` mode no longer silently advances to the next planned phase. Callers must explicitly send `activate_phase`.
- **Debuggability**: FSM rejection errors from `transition()` now include hints for the most common state-event mismatches.