### PR TITLE
Suppress orchestration model routing when ferment is active

### DIFF
--- a/src/extensions/ferment/state.ts
+++ b/src/extensions/ferment/state.ts
@@ -40,6 +40,10 @@ export function setActive(f: Ferment | undefined): void {
 	notifyFermentActive(isResumable)
 }
 
+export function isFermentRunning(): boolean {
+	return activeFerment !== undefined && activeFerment.status === "running"
+}
+
 // ─── Auto-mode toggle (set by /pause and /auto commands) ──────────────────────
 
 let autoModeEnabled = true

--- a/src/extensions/orchestration/prompt-enrichment.ts
+++ b/src/extensions/orchestration/prompt-enrichment.ts
@@ -32,6 +32,7 @@ import { getCurrentPhase } from "../../extensions/tags.js"
 import { getAvailableModels } from "../../startup-context.js"
 import { getGitBranch } from "../../utils.js"
 import { getInstalledPackageResourceDirs } from "../agents/package-resources.js"
+import { isFermentRunning } from "../ferment/state.js"
 import {
 	CONTINUATION_NUDGE_TEXT,
 	ContinuationNudge,
@@ -502,6 +503,7 @@ export default function (skillPaths: string[]) {
 				currentModelId: ctx.model?.id,
 				currentPhase: getCurrentPhase(),
 				registry: registry,
+				suppressOrchestrationGuidelines: isFermentRunning(),
 			}
 
 			if (subagentMode) {

--- a/src/extensions/orchestration/prompt-transformer/prompt-transformer.test.ts
+++ b/src/extensions/orchestration/prompt-transformer/prompt-transformer.test.ts
@@ -513,6 +513,17 @@ describe("guideline injection into system prompts", () => {
 		expect(phasePos).toBeGreaterThan(-1)
 		expect(orchPos).toBeLessThan(phasePos)
 	})
+
+	it("suppresses orchestration guidelines when suppressOrchestrationGuidelines is set", () => {
+		const result = buildOrchestratorSystemPrompt(tools, testEnv, undefined, undefined, {
+			currentModelId: "minimax-m2.7",
+			currentPhase: "build",
+			registry,
+			suppressOrchestrationGuidelines: true,
+		})
+		expect(result).not.toContain("## Orchestration Guidelines")
+		expect(result).toContain("## Phase Guidelines (build)")
+	})
 })
 
 describe("builtin-model guideline content", () => {

--- a/src/extensions/orchestration/prompt-transformer/prompt-transformer.ts
+++ b/src/extensions/orchestration/prompt-transformer/prompt-transformer.ts
@@ -54,6 +54,10 @@ export interface PromptContext {
 	currentModelId?: string
 	currentPhase?: Phase
 	registry?: ModelRegistry
+	/** When true, omit orchestration guidelines (model routing/delegation).
+	 *  Used when ferment is running — it manages its own delegation via
+	 *  the planner supplement. */
+	suppressOrchestrationGuidelines?: boolean
 }
 
 export interface ToolInfo {
@@ -111,7 +115,9 @@ export function buildOrchestratorSystemPrompt(
 		.replace("{{ENVIRONMENT}}", () => environmentSection)
 		.replace("{{PROJECT_CONTEXT}}", () => projectContext)
 		.replace("{{SKILLS}}", () => skillsSection)
-	const orchestrationSection = buildOrchestrationGuidelinesSection(promptCtx?.currentModelId, promptCtx?.registry)
+	const orchestrationSection = promptCtx?.suppressOrchestrationGuidelines
+		? ""
+		: buildOrchestrationGuidelinesSection(promptCtx?.currentModelId, promptCtx?.registry)
 	const phaseSection = buildPhaseGuidelinesSection(
 		promptCtx?.currentModelId,
 		promptCtx?.currentPhase,


### PR DESCRIPTION
## Summary

- When a ferment is in `running` state, the orchestrator system prompt now omits the orchestration guidelines section (model routing, delegation rules, tier matching)
- Ferment manages its own delegation via the planner supplement, so these guidelines were redundant and potentially contradictory
- Phase guidelines and all other prompt sections (tools, environment, context, skills) remain intact
- Adds `isFermentRunning()` to ferment state module and `suppressOrchestrationGuidelines` flag to `PromptContext`

## Test plan

- [ ] Run `npx vitest run src/extensions/orchestration/prompt-transformer/prompt-transformer.test.ts` — verify suppression test passes
- [ ] Start a ferment and confirm system prompt is shorter (no "Orchestration Guidelines" section)
- [ ] Verify normal (non-ferment) sessions still include orchestration guidelines

---
### Kimchi Summary
### What changed
Suppresses orchestration guidelines (model routing and delegation instructions) from the orchestrator system prompt while a ferment is running.

### Why
Ferment manages its own delegation via the planner supplement, so the standard orchestration guidelines are redundant or conflicting during active fermentation.

### Key changes
- `src/extensions/ferment/state.ts`: Added `isFermentRunning()` helper to expose whether an active ferment has `"running"` status.
- `src/extensions/orchestration/prompt-enrichment.ts`: Passes `suppressOrchestrationGuidelines: isFermentRunning()` into the prompt context.
- `src/extensions/orchestration/prompt-transformer/prompt-transformer.ts`: Added `suppressOrchestrationGuidelines` option to `PromptContext`; conditionally skips `buildOrchestrationGuidelinesSection()` when the flag is true.
- `src/extensions/orchestration/prompt-transformer/prompt-transformer.test.ts`: Added test to verify orchestration guidelines are omitted while phase guidelines remain present when suppression is enabled.