### PR TITLE
UI-6661: visually uplift the ferment flow

### DIFF
--- a/src/extensions/ferment/breadcrumb-renderer.ts
+++ b/src/extensions/ferment/breadcrumb-renderer.ts
@@ -1,0 +1,46 @@
+import type { MessageRenderer } from "@earendil-works/pi-coding-agent"
+import { Container, Text } from "@earendil-works/pi-tui"
+import { pr_dim, pr_teal } from "./colors.js"
+
+interface BreadcrumbDetails {
+	text: string
+	/**
+	 * Visual variant — controls the leading glyph and color.
+	 * - "step"     → 🫧 dim   (default; scoping question announcements, generic breadcrumbs)
+	 * - "answer"   → ⚗️ dim   (echoes of the user's scoping answers)
+	 * - "ack"      → 🍺 teal  (ferment start / one-shot start / phase complete)
+	 * - "warning"  → ⚠  dim   (worktree warnings, oneshot failure, step failure)
+	 */
+	variant?: "step" | "answer" | "ack" | "warning"
+}
+
+function glyphFor(variant: BreadcrumbDetails["variant"]): string {
+	switch (variant) {
+		case "ack":
+			return pr_teal("🍺")
+		case "warning":
+			return pr_dim("⚠")
+		case "answer":
+			return pr_dim("⚗️")
+		default:
+			return pr_dim("🫧")
+	}
+}
+
+export const fermentBreadcrumbRenderer: MessageRenderer<BreadcrumbDetails> = (message, _options, _theme) => {
+	const d = message.details
+	if (!d || !d.text) return undefined
+
+	const container = new Container()
+	const lines = d.text.split("\n")
+	const glyph = glyphFor(d.variant)
+
+	container.addChild(new Text(`${glyph}  ${pr_dim(lines[0] ?? "")}`, 0, 0))
+
+	const indent = "    "
+	for (let i = 1; i < lines.length; i++) {
+		container.addChild(new Text(indent + pr_dim(lines[i] ?? ""), 0, 0))
+	}
+
+	return container
+}

--- a/src/extensions/ferment/commands.test.ts
+++ b/src/extensions/ferment/commands.test.ts
@@ -391,10 +391,15 @@ describe("registerFermentCommands", () => {
 		await fermentCommand.handler("manual", h.ctx)
 
 		expect(h.runtime.getContinuationPolicy()).toBe("manual")
-		expect(h.pi.sendMessage).not.toHaveBeenCalled()
-		expect(h.pi.appendEntry).toHaveBeenCalledWith(
-			"ferment_breadcrumb",
-			expect.objectContaining({ text: expect.stringContaining("Manual policy waiting at phase boundary") }),
+		expect(h.pi.appendEntry).not.toHaveBeenCalled()
+		expect(h.pi.sendMessage).toHaveBeenCalledWith(
+			expect.objectContaining({
+				customType: "ferment_breadcrumb",
+				details: expect.objectContaining({
+					text: expect.stringContaining("Manual policy waiting at phase boundary"),
+				}),
+			}),
+			expect.anything(),
 		)
 	})
 
@@ -918,10 +923,15 @@ describe("registerFermentCommands", () => {
 		active = h.storage.get(active.id) ?? active
 		expect(active.status).toBe("planned")
 		expect(active.phases[1].status).toBe("planned")
-		expect(h.pi.sendMessage).not.toHaveBeenCalled()
-		expect(h.pi.appendEntry).toHaveBeenCalledWith(
-			"ferment_breadcrumb",
-			expect.objectContaining({ text: expect.stringContaining("Manual policy waiting at phase boundary") }),
+		expect(h.pi.appendEntry).not.toHaveBeenCalled()
+		expect(h.pi.sendMessage).toHaveBeenCalledWith(
+			expect.objectContaining({
+				customType: "ferment_breadcrumb",
+				details: expect.objectContaining({
+					text: expect.stringContaining("Manual policy waiting at phase boundary"),
+				}),
+			}),
+			expect.anything(),
 		)
 		expect(h.ctx.ui.notify).toHaveBeenCalledWith(expect.stringContaining('is waiting before "Next". Choose Continue'))
 	})

--- a/src/extensions/ferment/commands.ts
+++ b/src/extensions/ferment/commands.ts
@@ -409,8 +409,9 @@ export class FermentCommandController {
 
 				await runScopingFlow(f, pi, ctx, runtime, rawIntent)
 			} catch (err) {
-				ctx.ui.setStatus?.("ferment-scoping", undefined)
 				ctx.ui.notify(err instanceof FermentError ? err.message : "Create failed.")
+			} finally {
+				ctx.ui.setStatus?.("ferment-scoping", undefined)
 			}
 			return { handled: true }
 		}
@@ -827,8 +828,9 @@ export class FermentCommandController {
 
 			await runScopingFlow(f, pi, ctx, runtime)
 		} catch (err) {
-			ctx.ui.setStatus?.("ferment-scoping", undefined)
 			ctx.ui.notify(err instanceof FermentError ? err.message : "Create failed.")
+		} finally {
+			ctx.ui.setStatus?.("ferment-scoping", undefined)
 		}
 		return { handled: true }
 	}

--- a/src/extensions/ferment/commands.ts
+++ b/src/extensions/ferment/commands.ts
@@ -31,6 +31,27 @@ import { applyFermentRuntimeToolProfile, setActiveFermentAndApplyProfile } from 
 import type { FermentUiContext } from "./ui.js"
 import { checkWorktree } from "./worktree.js"
 
+function sendBreadcrumb(
+	pi: ExtensionAPI,
+	text: string,
+	variant: "step" | "answer" | "ack" | "warning" = "step",
+	customType:
+		| "ferment_breadcrumb"
+		| "ferment_ack"
+		| "ferment_worktree_warning"
+		| "ferment_oneshot_failed" = "ferment_breadcrumb",
+): void {
+	void pi.sendMessage(
+		{
+			customType,
+			content: [{ type: "text", text }],
+			display: true,
+			details: { text, variant },
+		},
+		{ triggerTurn: false },
+	)
+}
+
 export type FermentCliCommand = FermentCommand
 
 interface FermentArgumentCompletion {
@@ -161,9 +182,7 @@ function recordManualBoundaryBreadcrumb(
 ): void {
 	const decision = decideContinuation(active, runtime.getContinuationPolicy())
 	if (decision.type !== "wait_manual_boundary") return
-	pi.appendEntry("ferment_breadcrumb", {
-		text: `Manual policy waiting at phase boundary for "${active.name}".`,
-	})
+	sendBreadcrumb(pi, `Manual policy waiting at phase boundary for "${active.name}".`, "step")
 }
 
 function setAutomatedContinuationPolicy(pi: ExtensionAPI, ctx: FermentUiContext, runtime: FermentRuntime): void {
@@ -354,15 +373,15 @@ export class FermentCommandController {
 		const storage = runtime.getStorage()
 
 		if (command.type === "interactive") {
+			if (!ctx.ui.input) {
+				ctx.ui.notify('No UI available. Use /ferment add "Name" instead.')
+				return { handled: true }
+			}
 			const active = runtime.getActive()
 			if (active && active.status === "running") {
 				ctx.ui.notify(
 					`A ferment is already running: "${active.name}". Use /ferment progress to check status or /ferment switch to change.`,
 				)
-				return { handled: true }
-			}
-			if (!ctx.ui.input) {
-				ctx.ui.notify('No UI available. Use /ferment new "Name" instead.')
 				return { handled: true }
 			}
 
@@ -373,6 +392,7 @@ export class FermentCommandController {
 				"e.g. 'Rewrite login flow' or 'Add OAuth support'",
 			)
 			if (!rawIntent) return { handled: true }
+			ctx.ui.setStatus?.("ferment-scoping", "Fermenting · naming…")
 			sendFermentRequestMessage(pi, rawIntent)
 			try {
 				const shortName = await shortenTitle(rawIntent)
@@ -380,12 +400,16 @@ export class FermentCommandController {
 				setActiveFermentAndApplyProfile(pi, runtime, f)
 				appendRefEntry(pi, f.id)
 
-				pi.appendEntry("ferment_ack", {
-					text: `🍺  Started ferment: "${f.name}"\nBranch: ${f.worktree.branch ?? "n/a"}  Path: ${f.worktree.path}\nPolicy: ${runtime.getContinuationPolicy()}`,
-				})
+				sendBreadcrumb(
+					pi,
+					`Started ferment: "${f.name}"\nBranch: ${f.worktree.branch ?? "n/a"}  Path: ${f.worktree.path}\nPolicy: ${runtime.getContinuationPolicy()}`,
+					"ack",
+					"ferment_ack",
+				)
 
 				await runScopingFlow(f, pi, ctx, runtime, rawIntent)
 			} catch (err) {
+				ctx.ui.setStatus?.("ferment-scoping", undefined)
 				ctx.ui.notify(err instanceof FermentError ? err.message : "Create failed.")
 			}
 			return { handled: true }
@@ -580,7 +604,7 @@ export class FermentCommandController {
 				}
 
 				const wtWarning = wtCheck.severity === "warn" ? `\n⚠️  ${wtCheck.message}` : ""
-				ctx.ui.notify(`Switched to "${f.name}" (${f.id}) [${f.status}].${wtWarning}`)
+				sendBreadcrumb(pi, `Switched to "${f.name}" [${f.status}]${wtWarning}`, "ack", "ferment_ack")
 				resumeFerment(pi, f.id, ctx, runtime)
 			} catch (err) {
 				ctx.ui.notify(err instanceof FermentError ? err.message : "Switch failed.")
@@ -729,6 +753,7 @@ export class FermentCommandController {
 				ctx.ui.notify('Usage: /ferment one-shot "description of what to build"')
 				return { handled: true }
 			}
+			ctx.ui.setStatus?.("ferment-scoping", "🫧  Fermenting · naming…")
 			try {
 				// One-shot is non-interactive by definition — only auto-init when the
 				// user opted in via flag or env var. Otherwise skip silently.
@@ -742,9 +767,12 @@ export class FermentCommandController {
 				const updated = f
 				setActiveFermentAndApplyProfile(pi, runtime, updated)
 				appendRefEntry(pi, updated.id)
-				pi.appendEntry("ferment_ack", {
-					text: `🍺  One-shot ferment: "${updated.name}"\nBranch: ${updated.worktree.branch ?? "n/a"}\nPolicy: automated`,
-				})
+				sendBreadcrumb(
+					pi,
+					`One-shot ferment: "${updated.name}"\nBranch: ${updated.worktree.branch ?? "n/a"}\nPolicy: automated`,
+					"ack",
+					"ferment_ack",
+				)
 				const nudge = buildOneshotNudge(updated, resolvedIntent)
 
 				void pi.sendMessage(
@@ -758,6 +786,8 @@ export class FermentCommandController {
 				)
 			} catch (err) {
 				ctx.ui.notify(err instanceof FermentError ? err.message : "One-shot create failed.")
+			} finally {
+				ctx.ui.setStatus?.("ferment-scoping", undefined)
 			}
 			return { handled: true }
 		}
@@ -778,6 +808,7 @@ export class FermentCommandController {
 			ctx.ui.notify('Usage: /ferment new "Name"')
 			return { handled: true }
 		}
+		ctx.ui.setStatus?.("ferment-scoping", "🫧  Fermenting · naming…")
 		try {
 			// Interactive path: ui.confirm is available, so ensureGitRepo will ask.
 			// User can decline; ferment still proceeds with no branch/commit info.
@@ -787,12 +818,16 @@ export class FermentCommandController {
 			setActiveFermentAndApplyProfile(pi, runtime, f)
 			appendRefEntry(pi, f.id)
 
-			pi.appendEntry("ferment_ack", {
-				text: `🍺  Started ferment: "${f.name}"\nBranch: ${f.worktree.branch ?? "n/a"}  Path: ${f.worktree.path}\nPolicy: ${runtime.getContinuationPolicy()}`,
-			})
+			sendBreadcrumb(
+				pi,
+				`Started ferment: "${f.name}"\nBranch: ${f.worktree.branch ?? "n/a"}  Path: ${f.worktree.path}\nPolicy: ${runtime.getContinuationPolicy()}`,
+				"ack",
+				"ferment_ack",
+			)
 
 			await runScopingFlow(f, pi, ctx, runtime)
 		} catch (err) {
+			ctx.ui.setStatus?.("ferment-scoping", undefined)
 			ctx.ui.notify(err instanceof FermentError ? err.message : "Create failed.")
 		}
 		return { handled: true }

--- a/src/extensions/ferment/events.ts
+++ b/src/extensions/ferment/events.ts
@@ -276,7 +276,8 @@ export function registerFermentEvents(pi: ExtensionAPI, runtime: FermentRuntime 
 				const activeStep = activePhase?.steps.find((s) => s.status === "running" || s.status === "pending")
 				const phaseInfo = activePhase ? ` — Phase ${activePhase.index}/${ferment.phases.length}` : ""
 				const stepInfo = activeStep ? ` · step ${activeStep.index}/${activePhase?.steps.length ?? 0}` : ""
-				const updatedMs = ferment.updatedAt ? new Date(ferment.updatedAt).getTime() : Date.now()
+				const parsed = ferment.updatedAt ? Date.parse(ferment.updatedAt) : Number.NaN
+				const updatedMs = Number.isFinite(parsed) ? parsed : runtime.now().getTime()
 				const ago = formatDuration(runtime.now().getTime() - updatedMs)
 				const banner = `🍺  Active ferment "${ferment.name}"${phaseInfo}${stepInfo} · ${ago}. Resume?`
 				const choice = await ctx.ui.select(banner, ["Resume", "Leave paused"])

--- a/src/extensions/ferment/events.ts
+++ b/src/extensions/ferment/events.ts
@@ -2,14 +2,15 @@ import type { ExtensionAPI, ExtensionContext } from "@earendil-works/pi-coding-a
 import { shortenTitle } from "../../ferment/shorten-title.js"
 import { clearFermentCache } from "../../ferment/store.js"
 import { isAgentWorker } from "../agent-worker-context.js"
-import { isStaleCtxError } from "../stale-ctx.js"
+import { formatDuration } from "./colors.js"
 import { extractContextualOptions, extractTrailingQuestion } from "./contextual-options.js"
 import { decideContinuation } from "./continuation.js"
 import { autoInitFromEnv, ensureGitRepo } from "./git-init.js"
 import { appendRefEntry, maybeInjectReactiveContinuationNudge, resetReactiveContinuationNudgeCount } from "./nudge.js"
 import { buildOneshotNudge } from "./oneshot.js"
+import { editPhaseProposal } from "./phase-editor.js"
 import { promptInput, promptSelect } from "./prompt-ui.js"
-import { resumeFerment } from "./resume.js"
+import { loadFermentSilently, resumeFerment } from "./resume.js"
 import { type FermentRuntime, defaultFermentRuntime } from "./runtime.js"
 import { scheduleFermentWakeUp } from "./scheduler.js"
 import { confirmPendingScope } from "./scoping-confirmation.js"
@@ -153,7 +154,35 @@ async function maybeRunUserInputDropdown(
 	} else if (prompt.contextualOptions?.includes(choice)) {
 		reply = choice
 	} else if (prompt.isDraft && choice === prompt.yesLabel) {
-		const outcome = confirmPendingScope(runtime, f.id, undefined, "turn_end", f.name, pi)
+		// Open the phase editor so the user can rename/reorder/delete/add
+		// before we persist. The pending phases are the LLM's proposal.
+		const pending = runtime.getPendingScope(f.id)
+		const startingPhases = pending?.phases
+		let edited = startingPhases
+		if (startingPhases && startingPhases.length > 0 && ctx) {
+			let result: typeof startingPhases | undefined
+			try {
+				result = await editPhaseProposal(ctx, startingPhases, runtime)
+			} catch (err) {
+				runtime.markHumanInput()
+				const msg = err instanceof Error ? err.message : String(err)
+				ctx.ui?.notify?.(`Phase editor failed: ${msg} — plan not saved.`)
+				void pi.sendUserMessage(
+					"Phase editor errored before the user could confirm. Ask the user to retry confirmation explicitly.",
+					{ deliverAs: "followUp" },
+				)
+				return true
+			}
+			if (!result) {
+				runtime.markHumanInput()
+				void pi.sendUserMessage("User chose to keep editing the phases — revise the plan in your next response.", {
+					deliverAs: "followUp",
+				})
+				return true
+			}
+			edited = result
+		}
+		const outcome = confirmPendingScope(runtime, f.id, edited, "turn_end", f.name, pi)
 		if (outcome.ok) {
 			ctx.ui.notify?.(
 				`Plan saved for "${outcome.outcome.ferment.name}". ${outcome.outcome.ferment.phases.length} phase(s) ready.`,
@@ -232,8 +261,34 @@ export function registerFermentEvents(pi: ExtensionAPI, runtime: FermentRuntime 
 
 		if (envId) {
 			pendingOneshot = false
-			resumeFerment(pi, envId, ctx, runtime)
 			Reflect.deleteProperty(process.env, "KIMCHI_ACTIVE_FERMENT")
+
+			if (ctx?.hasUI && ctx.ui?.select) {
+				// F27: ask user before auto-resuming so the planner doesn't
+				// hijack the session before they're ready.
+				const storage = runtime.getStorage()
+				const ferment = storage.get(envId)
+				if (!ferment) {
+					setActiveFermentAndApplyProfile(pi, runtime, undefined)
+					return
+				}
+				const activePhase = ferment.phases.find((p) => p.id === ferment.activePhaseId)
+				const activeStep = activePhase?.steps.find((s) => s.status === "running" || s.status === "pending")
+				const phaseInfo = activePhase ? ` — Phase ${activePhase.index}/${ferment.phases.length}` : ""
+				const stepInfo = activeStep ? ` · step ${activeStep.index}/${activePhase?.steps.length ?? 0}` : ""
+				const updatedMs = ferment.updatedAt ? new Date(ferment.updatedAt).getTime() : Date.now()
+				const ago = formatDuration(runtime.now().getTime() - updatedMs)
+				const banner = `🍺  Active ferment "${ferment.name}"${phaseInfo}${stepInfo} · ${ago}. Resume?`
+				const choice = await ctx.ui.select(banner, ["Resume", "Leave paused"])
+				runtime.markHumanInput()
+				if (choice === "Resume") {
+					resumeFerment(pi, envId, ctx, runtime)
+				} else {
+					loadFermentSilently(pi, envId, runtime)
+				}
+			} else {
+				resumeFerment(pi, envId, ctx, runtime)
+			}
 		} else if (pi.getFlag("ferment-oneshot") === true) {
 			pendingOneshot = true
 			setActiveFermentState(runtime, undefined)
@@ -287,14 +342,28 @@ export function registerFermentEvents(pi: ExtensionAPI, runtime: FermentRuntime 
 			const updated = f
 			setActiveFermentState(runtime, updated)
 			appendRefEntry(pi, updated.id)
-			pi.appendEntry("ferment_ack", {
-				text: `🍺  One-shot ferment: "${updated.name}"\nBranch: ${updated.worktree.branch ?? "n/a"}\nPolicy: automated`,
-			})
+			const ackText = `One-shot ferment: "${updated.name}"\nBranch: ${updated.worktree.branch ?? "n/a"}\nPolicy: automated`
+			void pi.sendMessage(
+				{
+					customType: "ferment_ack",
+					content: [{ type: "text", text: ackText }],
+					display: true,
+					details: { text: ackText, variant: "ack" },
+				},
+				{ triggerTurn: false },
+			)
 			return { action: "transform" as const, text: buildOneshotNudge(updated, intent), images: event.images }
 		} catch (err) {
-			pi.appendEntry("ferment_oneshot_failed", {
-				text: `One-shot ferment bootstrap failed: ${err instanceof Error ? err.message : String(err)}`,
-			})
+			const failText = `One-shot ferment bootstrap failed: ${err instanceof Error ? err.message : String(err)}`
+			void pi.sendMessage(
+				{
+					customType: "ferment_oneshot_failed",
+					content: [{ type: "text", text: failText }],
+					display: true,
+					details: { text: failText, variant: "warning" },
+				},
+				{ triggerTurn: false },
+			)
 			return
 		}
 	})

--- a/src/extensions/ferment/index.test.ts
+++ b/src/extensions/ferment/index.test.ts
@@ -186,9 +186,11 @@ describe("fermentExtension one-shot bootstrap", () => {
 		const next = await input({ type: "input", text: "follow-up", source: "interactive" }, {})
 		expect(next).toBeUndefined()
 
-		// Side-effects: ack entry + ferment_reference entry get appended.
-		const calls = (pi.appendEntry as ReturnType<typeof vi.fn>).mock.calls.map((c) => c[0])
-		expect(calls).toContain("ferment_ack")
+		// Side-effects: ack message sent + ferment_reference entry recorded.
+		expect(pi.sendMessage).toHaveBeenCalledWith(
+			expect.objectContaining({ customType: "ferment_ack" }),
+			expect.anything(),
+		)
 	})
 
 	it("records a diagnostic when one-shot bootstrap fails", async () => {
@@ -208,9 +210,12 @@ describe("fermentExtension one-shot bootstrap", () => {
 		const result = await input({ type: "input", text: "Fix the task", source: "interactive" }, {})
 
 		expect(result).toBeUndefined()
-		expect(pi.appendEntry).toHaveBeenCalledWith(
-			"ferment_oneshot_failed",
-			expect.objectContaining({ text: expect.stringContaining("storage unavailable") }),
+		expect(pi.sendMessage).toHaveBeenCalledWith(
+			expect.objectContaining({
+				customType: "ferment_oneshot_failed",
+				details: expect.objectContaining({ text: expect.stringContaining("storage unavailable") }),
+			}),
+			expect.anything(),
 		)
 	})
 

--- a/src/extensions/ferment/index.ts
+++ b/src/extensions/ferment/index.ts
@@ -14,6 +14,7 @@ import type { ExtensionAPI, MessageRenderer } from "@earendil-works/pi-coding-ag
 import { Container, Text } from "@earendil-works/pi-tui"
 import type { Step } from "../../ferment/types.js"
 import { createSystemPromptBlocks } from "../prompt-construction/index.js"
+import { fermentBreadcrumbRenderer } from "./breadcrumb-renderer.js"
 import { registerFermentCommands } from "./commands.js"
 import { registerFermentEvents } from "./events.js"
 import { buildFermentPromptBlock } from "./prompt-block.js"
@@ -93,6 +94,12 @@ export default function fermentExtension(pi: ExtensionAPI, runtime: FermentRunti
 	pi.registerMessageRenderer(FERMENT_REQUEST_MESSAGE_TYPE, fermentRequestRenderer)
 	registerFermentEvents(pi, runtime)
 	registerFermentCommands(pi, runtime)
+
+	// ─── Message renderers ────────────────────────────────────────────────────
+	pi.registerMessageRenderer("ferment_breadcrumb", fermentBreadcrumbRenderer)
+	pi.registerMessageRenderer("ferment_ack", fermentBreadcrumbRenderer)
+	pi.registerMessageRenderer("ferment_worktree_warning", fermentBreadcrumbRenderer)
+	pi.registerMessageRenderer("ferment_oneshot_failed", fermentBreadcrumbRenderer)
 
 	createSystemPromptBlocks(pi, "ferment").register({
 		id: "ferment-supplement",

--- a/src/extensions/ferment/nudge.test.ts
+++ b/src/extensions/ferment/nudge.test.ts
@@ -232,10 +232,16 @@ describe("ferment nudges", () => {
 		maybeInjectReactiveContinuationNudge(pi, runtime)
 		maybeInjectReactiveContinuationNudge(pi, runtime)
 
-		expect(pi.sendMessage).toHaveBeenCalledTimes(3)
-		expect(pi.appendEntry).toHaveBeenLastCalledWith(
-			"ferment_breadcrumb",
-			expect.objectContaining({ text: expect.stringContaining("Continuation nudge suppressed after 3") }),
+		// With cap=1: call 1 fires (schedules action), calls 2-4 each emit one
+		// suppression breadcrumb via pi.sendMessage. Assert on the last
+		// suppression message rather than total call count, which depends on
+		// scheduleNextFermentAction internals.
+		expect(pi.sendMessage).toHaveBeenLastCalledWith(
+			expect.objectContaining({
+				customType: "ferment_breadcrumb",
+				details: expect.objectContaining({ text: expect.stringContaining("Continuation nudge suppressed after 1") }),
+			}),
+			expect.anything(),
 		)
 	})
 
@@ -264,6 +270,9 @@ describe("ferment nudges", () => {
 		current = { ...current, status: "planned" }
 		maybeInjectReactiveContinuationNudge(pi, runtime)
 
+		// With cap=1: call 1 fires (1 msg via scheduler), call 2 suppressed (1 breadcrumb),
+		// call 3 suppressed (1 breadcrumb), call 4 paused resets the counter (0 msgs),
+		// call 5 fires again (1 msg). Total: 1 + 1 + 1 + 0 + 1 = 4.
 		expect(pi.sendMessage).toHaveBeenCalledTimes(4)
 	})
 

--- a/src/extensions/ferment/nudge.ts
+++ b/src/extensions/ferment/nudge.ts
@@ -29,7 +29,7 @@ export function appendRefEntry(pi: ExtensionAPI, fermentId: string): void {
 	})
 }
 
-const MAX_CONSECUTIVE_REACTIVE_NUDGES = 3
+const MAX_CONSECUTIVE_REACTIVE_NUDGES = 1
 const reactiveNudgeCounts = new Map<string, number>()
 
 export function resetReactiveContinuationNudgeCount(fermentId: string): void {
@@ -68,9 +68,16 @@ export function maybeInjectReactiveContinuationNudge(
 
 	const count = reactiveNudgeCounts.get(fresh.id) ?? 0
 	if (count >= MAX_CONSECUTIVE_REACTIVE_NUDGES) {
-		pi.appendEntry("ferment_breadcrumb", {
-			text: `Continuation nudge suppressed after ${count} consecutive text-only assistant turns for "${fresh.name}".`,
-		})
+		const suppressionText = `Continuation nudge suppressed after ${count} consecutive text-only assistant turns for "${fresh.name}".`
+		void pi.sendMessage(
+			{
+				customType: "ferment_breadcrumb",
+				content: [{ type: "text", text: suppressionText }],
+				display: true,
+				details: { text: suppressionText, variant: "step" },
+			},
+			{ triggerTurn: false },
+		)
 		return
 	}
 

--- a/src/extensions/ferment/phase-editor.test.ts
+++ b/src/extensions/ferment/phase-editor.test.ts
@@ -1,0 +1,174 @@
+import type { ExtensionContext } from "@earendil-works/pi-coding-agent"
+import { describe, expect, it, vi } from "vitest"
+import type { ScopePhaseInput } from "../../ferment/state-machine.js"
+import { editPhaseProposal } from "./phase-editor.js"
+import type { FermentRuntime } from "./runtime.js"
+
+type PhaseEditorCtx = Partial<Pick<ExtensionContext, "ui">>
+
+interface MockUi {
+	select?: ReturnType<typeof vi.fn>
+	input?: ReturnType<typeof vi.fn>
+	confirm?: ReturnType<typeof vi.fn>
+	notify?: ReturnType<typeof vi.fn>
+}
+
+function buildCtx(ui: MockUi | undefined): PhaseEditorCtx {
+	return { ui } as unknown as PhaseEditorCtx
+}
+
+function makeRuntime(): FermentRuntime & { markHumanInput: ReturnType<typeof vi.fn> } {
+	const markHumanInput = vi.fn()
+	return { markHumanInput } as unknown as FermentRuntime & { markHumanInput: ReturnType<typeof vi.fn> }
+}
+
+const PHASES: ScopePhaseInput[] = [
+	{ name: "Alpha", goal: "Build alpha" },
+	{ name: "Beta", goal: "Build beta" },
+	{ name: "Gamma", goal: "Build gamma" },
+]
+
+const ADD_LABEL = "+ Add phase"
+const CONFIRM_LABEL = "✓ Confirm and start"
+const CANCEL_LABEL = "✗ Cancel"
+
+describe("editPhaseProposal", () => {
+	it("returns the original phases when ui is undefined", async () => {
+		const result = await editPhaseProposal(buildCtx(undefined), PHASES)
+		expect(result).toEqual(PHASES)
+	})
+
+	it("returns the original phases when ui.select is missing", async () => {
+		const ui: MockUi = { input: vi.fn(), confirm: vi.fn(), notify: vi.fn() }
+		const result = await editPhaseProposal(buildCtx(ui), PHASES)
+		expect(result).toEqual(PHASES)
+	})
+
+	it("returns undefined when the user cancels", async () => {
+		const select = vi.fn().mockResolvedValueOnce(CANCEL_LABEL)
+		const result = await editPhaseProposal(buildCtx({ select }), PHASES)
+		expect(result).toBeUndefined()
+		expect(select).toHaveBeenCalledTimes(1)
+	})
+
+	it("returns undefined when select resolves to undefined (dropdown dismissed)", async () => {
+		const select = vi.fn().mockResolvedValueOnce(undefined)
+		const result = await editPhaseProposal(buildCtx({ select }), PHASES)
+		expect(result).toBeUndefined()
+	})
+
+	it("returns the working set untouched when the user picks confirm", async () => {
+		const select = vi.fn().mockResolvedValueOnce(CONFIRM_LABEL)
+		const result = await editPhaseProposal(buildCtx({ select }), PHASES)
+		expect(result).toEqual(PHASES)
+	})
+
+	it("notifies and re-prompts when confirming an empty list", async () => {
+		const select = vi.fn().mockResolvedValueOnce(CONFIRM_LABEL).mockResolvedValueOnce(CANCEL_LABEL)
+		const notify = vi.fn()
+		const result = await editPhaseProposal(buildCtx({ select, notify }), [])
+		expect(result).toBeUndefined()
+		expect(notify).toHaveBeenCalledWith("Add at least one phase before confirming.")
+		expect(select).toHaveBeenCalledTimes(2)
+	})
+
+	it("appends a new phase via the add flow", async () => {
+		const select = vi.fn().mockResolvedValueOnce(ADD_LABEL).mockResolvedValueOnce(CONFIRM_LABEL)
+		const input = vi.fn().mockResolvedValueOnce("Delta").mockResolvedValueOnce("Build delta")
+		const result = await editPhaseProposal(buildCtx({ select, input }), PHASES)
+		expect(result).toEqual([...PHASES, { name: "Delta", goal: "Build delta" }])
+	})
+
+	it("skips adding when the name is blank", async () => {
+		const select = vi.fn().mockResolvedValueOnce(ADD_LABEL).mockResolvedValueOnce(CONFIRM_LABEL)
+		const input = vi.fn().mockResolvedValueOnce("   ")
+		const result = await editPhaseProposal(buildCtx({ select, input }), PHASES)
+		expect(result).toEqual(PHASES)
+	})
+
+	it("renames the selected phase", async () => {
+		const select = vi
+			.fn()
+			.mockImplementationOnce(async (_title: string, options: string[]) => options[0])
+			.mockResolvedValueOnce("Rename")
+			.mockResolvedValueOnce(CONFIRM_LABEL)
+		const input = vi.fn().mockResolvedValueOnce("Alpha Prime")
+		const result = await editPhaseProposal(buildCtx({ select, input }), PHASES)
+		expect(result?.[0]).toEqual({ name: "Alpha Prime", goal: "Build alpha" })
+	})
+
+	it("edits the selected phase goal", async () => {
+		const select = vi
+			.fn()
+			.mockImplementationOnce(async (_title: string, options: string[]) => options[1])
+			.mockResolvedValueOnce("Edit goal")
+			.mockResolvedValueOnce(CONFIRM_LABEL)
+		const input = vi.fn().mockResolvedValueOnce("Polish beta")
+		const result = await editPhaseProposal(buildCtx({ select, input }), PHASES)
+		expect(result?.[1]).toEqual({ name: "Beta", goal: "Polish beta" })
+	})
+
+	it("moves the selected phase up", async () => {
+		const select = vi
+			.fn()
+			.mockImplementationOnce(async (_title: string, options: string[]) => options[1])
+			.mockResolvedValueOnce("Move up")
+			.mockResolvedValueOnce(CONFIRM_LABEL)
+		const result = await editPhaseProposal(buildCtx({ select }), PHASES)
+		expect(result?.map((p) => p.name)).toEqual(["Beta", "Alpha", "Gamma"])
+	})
+
+	it("moves the selected phase down", async () => {
+		const select = vi
+			.fn()
+			.mockImplementationOnce(async (_title: string, options: string[]) => options[0])
+			.mockResolvedValueOnce("Move down")
+			.mockResolvedValueOnce(CONFIRM_LABEL)
+		const result = await editPhaseProposal(buildCtx({ select }), PHASES)
+		expect(result?.map((p) => p.name)).toEqual(["Beta", "Alpha", "Gamma"])
+	})
+
+	it("deletes the selected phase when confirm returns true", async () => {
+		const select = vi
+			.fn()
+			.mockImplementationOnce(async (_title: string, options: string[]) => options[1])
+			.mockResolvedValueOnce("Delete phase")
+			.mockResolvedValueOnce(CONFIRM_LABEL)
+		const confirm = vi.fn().mockResolvedValueOnce(true)
+		const result = await editPhaseProposal(buildCtx({ select, confirm }), PHASES)
+		expect(result?.map((p) => p.name)).toEqual(["Alpha", "Gamma"])
+	})
+
+	it("keeps the phase when confirm returns false", async () => {
+		const select = vi
+			.fn()
+			.mockImplementationOnce(async (_title: string, options: string[]) => options[1])
+			.mockResolvedValueOnce("Delete phase")
+			.mockResolvedValueOnce(CONFIRM_LABEL)
+		const confirm = vi.fn().mockResolvedValueOnce(false)
+		const result = await editPhaseProposal(buildCtx({ select, confirm }), PHASES)
+		expect(result).toEqual(PHASES)
+	})
+
+	it("refuses delete when ui.confirm is missing (safe default)", async () => {
+		const select = vi
+			.fn()
+			.mockImplementationOnce(async (_title: string, options: string[]) => options[1])
+			.mockResolvedValueOnce("Delete phase")
+			.mockResolvedValueOnce(CONFIRM_LABEL)
+		const result = await editPhaseProposal(buildCtx({ select }), PHASES)
+		expect(result).toEqual(PHASES)
+	})
+
+	it("calls runtime.markHumanInput after each interactive step", async () => {
+		const select = vi
+			.fn()
+			.mockImplementationOnce(async (_title: string, options: string[]) => options[0])
+			.mockResolvedValueOnce("Rename")
+			.mockResolvedValueOnce(CONFIRM_LABEL)
+		const input = vi.fn().mockResolvedValueOnce("Alpha Prime")
+		const runtime = makeRuntime()
+		await editPhaseProposal(buildCtx({ select, input }), PHASES, runtime)
+		expect(runtime.markHumanInput.mock.calls.length).toBeGreaterThanOrEqual(3)
+	})
+})

--- a/src/extensions/ferment/phase-editor.ts
+++ b/src/extensions/ferment/phase-editor.ts
@@ -69,7 +69,7 @@ async function editPhaseDetails(
 	if (choice === deleteLabel) {
 		const confirmed = ui.confirm
 			? await ui.confirm(`Delete phase "${phase.name}"?`, "This cannot be undone within the editor.")
-			: true
+			: false
 		runtime?.markHumanInput()
 		if (confirmed) return { action: "delete", phase }
 	}

--- a/src/extensions/ferment/phase-editor.ts
+++ b/src/extensions/ferment/phase-editor.ts
@@ -1,0 +1,148 @@
+/**
+ * Phase-list editor — opens after `propose_scoping` so the user can rename,
+ * reorder, edit goals, delete, or add phases before confirming.
+ *
+ * Returns the edited `ScopePhaseInput[]` on confirm, or `undefined` if the
+ * user cancels. The caller passes the result to `confirmPendingScope`.
+ */
+
+import type { ExtensionContext } from "@earendil-works/pi-coding-agent"
+import type { ScopePhaseInput } from "../../ferment/state-machine.js"
+import { pr_bold, pr_dim, pr_teal, truncateLabel } from "./colors.js"
+import type { FermentRuntime } from "./runtime.js"
+
+type PhaseEditorContext = Partial<Pick<ExtensionContext, "ui">>
+type PhaseEditorUi = NonNullable<PhaseEditorContext["ui"]>
+
+const ADD_LABEL = "+ Add phase"
+const CONFIRM_LABEL = "✓ Confirm and start"
+const CANCEL_LABEL = "✗ Cancel"
+const DIVIDER_LABEL = "─────────────"
+
+function formatPhaseRow(p: ScopePhaseInput, idx: number): string {
+	const goalSnippet = p.goal ? `  ${pr_dim("—")} ${truncateLabel(p.goal, 60)}` : ""
+	return `${pr_teal(`${idx + 1}.`)} ${pr_bold(p.name)}${goalSnippet}`
+}
+
+async function editPhaseDetails(
+	ui: PhaseEditorUi,
+	phase: ScopePhaseInput,
+	canMoveUp: boolean,
+	canMoveDown: boolean,
+	runtime?: FermentRuntime,
+): Promise<{ action: "save" | "delete" | "moveUp" | "moveDown" | "back"; phase: ScopePhaseInput }> {
+	const renameLabel = "Rename"
+	const editGoalLabel = "Edit goal"
+	const moveUpLabel = "Move up"
+	const moveDownLabel = "Move down"
+	const deleteLabel = "Delete phase"
+	const backLabel = "Back"
+
+	const options: string[] = [renameLabel, editGoalLabel]
+	if (canMoveUp) options.push(moveUpLabel)
+	if (canMoveDown) options.push(moveDownLabel)
+	options.push(deleteLabel, backLabel)
+
+	const title = `${pr_bold(phase.name)}\n${pr_dim(phase.goal || "(no goal)")}`
+	const choice = await ui.select(title, options)
+	runtime?.markHumanInput()
+
+	if (!choice || choice === backLabel) return { action: "back", phase }
+
+	if (choice === renameLabel && ui.input) {
+		const next = await ui.input("Phase name:", phase.name)
+		runtime?.markHumanInput()
+		if (next?.trim()) return { action: "save", phase: { ...phase, name: next.trim() } }
+		return { action: "back", phase }
+	}
+
+	if (choice === editGoalLabel && ui.input) {
+		const next = await ui.input("Phase goal:", phase.goal ?? "")
+		runtime?.markHumanInput()
+		if (next !== undefined) return { action: "save", phase: { ...phase, goal: next.trim() } }
+		return { action: "back", phase }
+	}
+
+	if (choice === moveUpLabel) return { action: "moveUp", phase }
+	if (choice === moveDownLabel) return { action: "moveDown", phase }
+
+	if (choice === deleteLabel) {
+		const confirmed = ui.confirm
+			? await ui.confirm(`Delete phase "${phase.name}"?`, "This cannot be undone within the editor.")
+			: true
+		runtime?.markHumanInput()
+		if (confirmed) return { action: "delete", phase }
+	}
+
+	return { action: "back", phase }
+}
+
+async function addPhase(ui: PhaseEditorUi, runtime?: FermentRuntime): Promise<ScopePhaseInput | undefined> {
+	if (!ui.input) return undefined
+	const name = await ui.input("New phase name:", "")
+	runtime?.markHumanInput()
+	if (!name || !name.trim()) return undefined
+	const goal = await ui.input("Phase goal:", "")
+	runtime?.markHumanInput()
+	return { name: name.trim(), goal: (goal ?? "").trim() }
+}
+
+export async function editPhaseProposal(
+	ctx: PhaseEditorContext,
+	phases: ScopePhaseInput[],
+	runtime?: FermentRuntime,
+): Promise<ScopePhaseInput[] | undefined> {
+	const ui = ctx.ui
+	if (!ui?.select) return phases
+
+	let working: ScopePhaseInput[] = phases.map((p) => ({ ...p }))
+
+	while (true) {
+		const labelToIndex = new Map<string, number>()
+		const phaseLabels = working.map((p, i) => {
+			const label = formatPhaseRow(p, i)
+			labelToIndex.set(label, i)
+			return label
+		})
+		const options = [...phaseLabels, DIVIDER_LABEL, ADD_LABEL, CONFIRM_LABEL, CANCEL_LABEL]
+		const title = `${pr_teal("🍺")} ${pr_bold("Review the proposed phases")}  ${pr_dim(`(${working.length} phase${working.length === 1 ? "" : "s"})`)}`
+		const choice = await ui.select(title, options)
+		runtime?.markHumanInput()
+
+		if (!choice || choice === CANCEL_LABEL) return undefined
+		if (choice === DIVIDER_LABEL) continue
+		if (choice === CONFIRM_LABEL) {
+			if (working.length === 0) {
+				ui.notify("Add at least one phase before confirming.")
+				continue
+			}
+			return working
+		}
+		if (choice === ADD_LABEL) {
+			const next = await addPhase(ui, runtime)
+			runtime?.markHumanInput()
+			if (next) working.push(next)
+			continue
+		}
+
+		const idx = labelToIndex.get(choice)
+		if (idx === undefined) continue
+		const canMoveUp = idx > 0
+		const canMoveDown = idx < working.length - 1
+		const result = await editPhaseDetails(ui, working[idx], canMoveUp, canMoveDown, runtime)
+		runtime?.markHumanInput()
+		if (result.action === "save") {
+			working = working.map((p, i) => (i === idx ? result.phase : p))
+		} else if (result.action === "delete") {
+			working = working.filter((_, i) => i !== idx)
+		} else if (result.action === "moveUp" && canMoveUp) {
+			const swapped = [...working]
+			;[swapped[idx - 1], swapped[idx]] = [swapped[idx], swapped[idx - 1]]
+			working = swapped
+		} else if (result.action === "moveDown" && canMoveDown) {
+			const swapped = [...working]
+			;[swapped[idx], swapped[idx + 1]] = [swapped[idx + 1], swapped[idx]]
+			working = swapped
+		}
+	}
+}

--- a/src/extensions/ferment/resume.ts
+++ b/src/extensions/ferment/resume.ts
@@ -1,10 +1,48 @@
 import type { ExtensionAPI, ExtensionContext } from "@earendil-works/pi-coding-agent"
+import { determineNextAction, getScopingProgress } from "../../ferment/engine.js"
+import type { Ferment } from "../../ferment/types.js"
+import { formatActionNudgeLine } from "./action-tool-names.js"
 import { appendRefEntry } from "./nudge.js"
 import { type FermentRuntime, defaultFermentRuntime } from "./runtime.js"
 import { scheduleFermentWakeUp } from "./scheduler.js"
 import { createApplyAndPersist } from "./tool-helpers.js"
 import { setActiveFermentAndApplyProfile } from "./tool-scope.js"
 import { checkWorktree } from "./worktree.js"
+
+/**
+ * Load a ferment as the active one without engaging the planner.
+ * Used by the F27 resume banner when the user chooses "Leave paused":
+ * commands like /auto and /progress should work, but the LLM should not
+ * automatically resume.
+ */
+export function loadFermentSilently(
+	pi: ExtensionAPI,
+	fermentId: string,
+	runtime: FermentRuntime = defaultFermentRuntime,
+): Ferment | undefined {
+	const storage = runtime.getStorage()
+	const existing = storage.get(fermentId)
+	if (!existing) {
+		setActiveFermentAndApplyProfile(pi, runtime, undefined)
+		return undefined
+	}
+	setActiveFermentAndApplyProfile(pi, runtime, existing)
+	appendRefEntry(pi, existing.id)
+
+	const wtCheck = checkWorktree(existing)
+	if (wtCheck.severity !== "ok" && wtCheck.message) {
+		void pi.sendMessage(
+			{
+				customType: "ferment_worktree_warning",
+				content: [{ type: "text", text: wtCheck.message }],
+				display: true,
+				details: { text: wtCheck.message, variant: "warning" },
+			},
+			{ triggerTurn: false },
+		)
+	}
+	return existing
+}
 
 /**
  * Shared by session_start (env-var path) and the /ferment Continue picker.
@@ -43,7 +81,15 @@ export function resumeFerment(
 
 	const wtCheck = checkWorktree(existing)
 	if (wtCheck.severity !== "ok" && wtCheck.message) {
-		pi.appendEntry("ferment_worktree_warning", { text: wtCheck.message })
+		void pi.sendMessage(
+			{
+				customType: "ferment_worktree_warning",
+				content: [{ type: "text", text: wtCheck.message }],
+				display: true,
+				details: { text: wtCheck.message, variant: "warning" },
+			},
+			{ triggerTurn: false },
+		)
 		if (wtCheck.severity === "block") {
 			return
 		}
@@ -52,6 +98,35 @@ export function resumeFerment(
 	if (existing.status === "draft" && ctx?.hasUI) {
 		runtime.markScopingInteractive(existing.id)
 	}
+
+	const action = determineNextAction(existing)
+	const baseMsg = action ? formatActionNudgeLine(action) : ""
+	const scopeProgress = getScopingProgress(existing)
+	const breadcrumb = `Resumed ferment: "${existing.name}" [${existing.status}] ${runtime.getContinuationPolicy()} policy · scoping ${scopeProgress.answered}/${scopeProgress.total}`
+
+	const imperative =
+		existing.status === "running"
+			? `RESUMING ferment "${existing.name}" — the previous session was interrupted. Pick up the work immediately. Do NOT explain or summarize — execute the next action below.\n\n${baseMsg}`
+			: baseMsg
+
+	void pi.sendMessage(
+		{
+			customType: "ferment_breadcrumb",
+			content: [{ type: "text", text: breadcrumb }],
+			display: true,
+			details: { text: breadcrumb, variant: "step" },
+		},
+		{ triggerTurn: false },
+	)
+	void pi.sendMessage(
+		{
+			customType: "ferment_resume_nudge",
+			content: [{ type: "text", text: imperative }],
+			display: false,
+			details: undefined,
+		},
+		{ triggerTurn: true },
+	)
 
 	scheduleFermentWakeUp(pi, runtime, { ...opts, fermentId: existing.id, tag: "Resume wake-up" })
 }

--- a/src/extensions/ferment/scoping-flow.integration.test.ts
+++ b/src/extensions/ferment/scoping-flow.integration.test.ts
@@ -109,15 +109,16 @@ describe("runScopingFlow → propose_ferment_scoping end-to-end", () => {
 		// Step 1: invoke runScopingFlow
 		await runScopingFlow(ferment, h.pi, ctx, h.runtime)
 
-		// Assert the visible request echo and the hidden planning nudge both fire.
-		expect(h.pi.sendMessage).toHaveBeenCalledTimes(2)
-		expect(h.pi.sendMessage).toHaveBeenCalledWith(
-			expect.objectContaining({
-				customType: "ferment_request",
-				display: true,
-				details: { intent: "I want to add Google OAuth" },
-			}),
+		// Assert the breadcrumb + visible request echo + hidden planning nudge all fire.
+		expect(h.pi.sendMessage).toHaveBeenCalledTimes(3)
+		const requestCall = (h.pi.sendMessage as ReturnType<typeof vi.fn>).mock.calls.find(
+			(call) => (call[0] as { customType?: string }).customType === "ferment_request",
 		)
+		expect(requestCall?.[0]).toMatchObject({
+			customType: "ferment_request",
+			display: true,
+			details: { intent: "I want to add Google OAuth" },
+		})
 		const nudgeCall = (h.pi.sendMessage as ReturnType<typeof vi.fn>).mock.calls.find(
 			(call) => (call[0] as { customType?: string }).customType === "ferment_created_nudge",
 		)

--- a/src/extensions/ferment/scoping.test.ts
+++ b/src/extensions/ferment/scoping.test.ts
@@ -88,14 +88,16 @@ describe("runScopingFlow", () => {
 		await runScopingFlow(ferment, pi, ctx, runtime)
 
 		expect(markSpy).toHaveBeenCalledWith(ferment.id)
-		expect(pi.sendMessage).toHaveBeenCalledTimes(2)
-		expect(pi.sendMessage).toHaveBeenCalledWith(
-			expect.objectContaining({
-				customType: "ferment_request",
-				display: true,
-				details: { intent: "I want to build a login system" },
-			}),
-		)
+		// Now sends 3 messages: breadcrumb + request + nudge
+		expect(pi.sendMessage).toHaveBeenCalledTimes(3)
+		const requestCall = vi
+			.mocked(pi.sendMessage)
+			.mock.calls.find((call) => (call[0] as { customType?: string }).customType === "ferment_request")
+		expect(requestCall?.[0]).toMatchObject({
+			customType: "ferment_request",
+			display: true,
+			details: { intent: "I want to build a login system" },
+		})
 		const nudgeCall = vi
 			.mocked(pi.sendMessage)
 			.mock.calls.find((call) => (call[0] as { customType?: string }).customType === "ferment_created_nudge")
@@ -165,10 +167,13 @@ describe("runScopingFlow", () => {
 
 		expect(inputSpy).not.toHaveBeenCalled()
 		expect(markSpy).toHaveBeenCalledWith(ferment.id)
-		expect(pi.sendMessage).toHaveBeenCalledTimes(1)
+		// Now sends 2 messages: breadcrumb + nudge
+		expect(pi.sendMessage).toHaveBeenCalledTimes(2)
 		expect(pi.sendMessage).not.toHaveBeenCalledWith(expect.objectContaining({ customType: "ferment_request" }))
-		const call = vi.mocked(pi.sendMessage).mock.calls[0]
-		const msg = call[0] as { content: { type: string; text: string }[] }
+		const nudgeCall = vi
+			.mocked(pi.sendMessage)
+			.mock.calls.find((call) => (call[0] as { customType?: string }).customType === "ferment_created_nudge")
+		const msg = nudgeCall?.[0] as { content: { type: string; text: string }[] }
 		const text = msg.content.map((c) => c.text).join("")
 		expect(text).toContain("Pre-captured intent text")
 	})

--- a/src/extensions/ferment/scoping.ts
+++ b/src/extensions/ferment/scoping.ts
@@ -23,6 +23,24 @@ import type { ScopePhaseInput } from "../../ferment/state-machine.js"
 import type { Ferment } from "../../ferment/types.js"
 import { type FermentRuntime, defaultFermentRuntime } from "./runtime.js"
 
+const STATUS_KEY = "ferment-scoping"
+
+function setCookingStatus(ctx: ExtensionCommandContext, message: string | undefined): void {
+	ctx.ui.setStatus?.(STATUS_KEY, message)
+}
+
+function sendScopingBreadcrumb(pi: ExtensionAPI, text: string): void {
+	void pi.sendMessage(
+		{
+			customType: "ferment_breadcrumb",
+			content: [{ type: "text", text }],
+			display: true,
+			details: { text, variant: "step" },
+		},
+		{ triggerTurn: false },
+	)
+}
+
 // ─── Pending scope buffer ─────────────────────────────────────────────────────
 // Seeded as an empty buffer by runScopingFlow, then replaced wholesale by
 // propose_ferment_scoping on each call. Held until the user confirms via dropdown.
@@ -139,6 +157,9 @@ export async function runScopingFlow(
 	if (preIntent === undefined) {
 		sendFermentRequestMessage(pi, intent)
 	}
+
+	setCookingStatus(ctx, "Fermenting · drafting scope…")
+	sendScopingBreadcrumb(pi, "Scoping · drafting…")
 
 	void pi.sendMessage(
 		{

--- a/src/extensions/ferment/tools.integration.test.ts
+++ b/src/extensions/ferment/tools.integration.test.ts
@@ -511,16 +511,16 @@ describe("start_ferment_step", () => {
 
 		const ctx = {
 			ui: {
-				select: vi.fn().mockResolvedValue("Skip this step and move on"),
+				select: vi.fn().mockResolvedValue("Skip step"),
 			},
 		}
 		const result = await h.call("start_ferment_step", { ferment_id: id, phase_id: "phase-1", step_id: "step-1" }, ctx)
 
 		expect(ok(result)).toMatch(/skipped at user request/i)
 		expect(ctx.ui.select).toHaveBeenCalledWith(expect.stringContaining("has been started 3 times"), [
-			"Retry with a revised approach",
-			"Skip this step and move on",
-			"Pause the ferment for now",
+			"Retry",
+			"Skip step",
+			"Pause ferment",
 		])
 		expect(loadFerment(id).phases[0].steps[0].status).toBe("skipped")
 	})
@@ -532,7 +532,7 @@ describe("start_ferment_step", () => {
 
 		const ctx = {
 			ui: {
-				select: vi.fn().mockResolvedValue("Pause the ferment for now"),
+				select: vi.fn().mockResolvedValue("Pause ferment"),
 			},
 		}
 		const result = await h.call("start_ferment_step", { ferment_id: id, phase_id: "phase-1", step_id: "step-1" }, ctx)
@@ -548,7 +548,7 @@ describe("start_ferment_step", () => {
 
 		const ctx = {
 			ui: {
-				select: vi.fn().mockResolvedValue("Retry with a revised approach"),
+				select: vi.fn().mockResolvedValue("Retry"),
 			},
 		}
 		const result = await h.call("start_ferment_step", { ferment_id: id, phase_id: "phase-1", step_id: "step-1" }, ctx)

--- a/src/extensions/ferment/tools/phases.ts
+++ b/src/extensions/ferment/tools/phases.ts
@@ -11,6 +11,7 @@ import type { Static } from "typebox"
 import { findFirstPlannedPhase } from "../../../ferment/engine.js"
 import type { Ferment, Phase } from "../../../ferment/types.js"
 import { askUser } from "../ask-user.js"
+import { gradeColor } from "../colors.js"
 import { decideContinuation } from "../continuation.js"
 import { formatDecisionsAndMemories } from "../format.js"
 import { validateFsmTransitionWithFerment } from "../fsm-adapter.js"
@@ -34,6 +35,25 @@ import {
 } from "../tool-helpers.js"
 import { ActivateParams, CompletePhaseParams, FailPhaseParams, RefineParams, SkipPhaseParams } from "../tool-schemas.js"
 import type { FermentUi, FermentUiContext } from "../ui.js"
+
+function sendPhaseAck(pi: ExtensionAPI, text: string): void {
+	void pi.sendMessage(
+		{
+			customType: "ferment_ack",
+			content: [{ type: "text", text }],
+			display: true,
+			details: { text, variant: "ack" },
+		},
+		{ triggerTurn: false },
+	)
+}
+
+function countFilesChanged(evidence: PhaseEvidence | undefined): number {
+	if (!evidence?.available) return 0
+	const raw = evidence.filesChanged
+	if (!raw || raw === "(no changes)" || raw === "(git unavailable)") return 0
+	return raw.split("\n").filter((line) => line.trim().length > 0).length
+}
 
 type CompletePhaseArgs = Static<typeof CompletePhaseParams>
 type ToolResult = ReturnType<typeof toolOk> | ReturnType<typeof toolErr>
@@ -406,6 +426,15 @@ export async function completePhase(
 
 	services.onPhaseCompleted(runtime)
 	const fresh = completeOutcome.ferment
+
+	// Visual ack mirrors the step ✓ breadcrumb in steps.ts. The grade letter is
+	// the deterministic derivedGrade (A/B/F) from gate verdicts + project
+	// checks (post-#230 no LLM judge per phase), colorized via gradeColor for
+	// terminal output.
+	const filesCount = countFilesChanged(evidence)
+	const summaryLines = [`Phase ${phase.index} ✓  Grade ${gradeColor(derivedGrade)} — ${rationale}`]
+	if (filesCount > 0) summaryLines.push(`${filesCount} file${filesCount === 1 ? "" : "s"} touched`)
+	sendPhaseAck(pi, summaryLines.join("\n"))
 	const warnSection =
 		warnFlags.length > 0
 			? `\n\nAdvisory warnings carried over:\n${warnFlags.map((fl) => `  ⚠ ${fl.problem} — ${fl.redirect}`).join("\n")}`

--- a/src/extensions/ferment/tools/steps.test.ts
+++ b/src/extensions/ferment/tools/steps.test.ts
@@ -133,9 +133,9 @@ describe("startStep", () => {
 		)
 
 		const text = okText(result)
-		expect(text).toContain("Ferment goal:")
+		expect(text).toContain("Goal:")
 		expect(text).toContain("/app/output.toml")
-		expect(text).toContain("do NOT remove, summarize, or contradict the context block")
+		expect(text).toContain("Worker context (pass to subagent verbatim):")
 	})
 
 	it("maps concurrent non-parallel starts to the existing tool error", async () => {
@@ -182,7 +182,7 @@ describe("startStep", () => {
 		const pauseResult = await startStep(
 			pauseHarness.runtime,
 			{ ferment_id: pauseHarness.fermentId, phase_id: "phase-1", step_id: "step-1" },
-			{ pi: pauseHarness.pi, ctx: { ui: { select: vi.fn(async () => "Pause the ferment for now") } } },
+			{ pi: pauseHarness.pi, ctx: { ui: { select: vi.fn(async () => "Pause ferment") } } },
 			createServices(),
 		)
 		expect(okText(pauseResult)).toContain("paused")
@@ -196,7 +196,7 @@ describe("startStep", () => {
 		const skipResult = await startStep(
 			skipHarness.runtime,
 			{ ferment_id: skipHarness.fermentId, phase_id: "phase-1", step_id: "step-1" },
-			{ pi: skipHarness.pi, ctx: { ui: { select: vi.fn(async () => "Skip this step and move on") } } },
+			{ pi: skipHarness.pi, ctx: { ui: { select: vi.fn(async () => "Skip step") } } },
 			skipServices,
 		)
 		expect(okText(skipResult)).toContain("skipped")

--- a/src/extensions/ferment/tools/steps.ts
+++ b/src/extensions/ferment/tools/steps.ts
@@ -33,6 +33,18 @@ import { buildWorkerContext } from "../worker-prompt.js"
 
 const VERIFY_TIMEOUT_MS = 60_000
 
+function sendStepBreadcrumb(pi: ExtensionAPI, text: string, variant: "step" | "warning" = "step"): void {
+	void pi.sendMessage(
+		{
+			customType: "ferment_breadcrumb",
+			content: [{ type: "text", text }],
+			display: true,
+			details: { text, variant },
+		},
+		{ triggerTurn: false },
+	)
+}
+
 type StepActionArgs = Static<typeof StepActionParams>
 type CompleteStepArgs = Static<typeof CompleteStepParams>
 
@@ -149,9 +161,9 @@ export async function startStep(
 		const response = await askUser(
 			title,
 			[
-				{ id: "retry", label: "Retry with a revised approach" },
-				{ id: "skip", label: "Skip this step and move on" },
-				{ id: "pause", label: "Pause the ferment for now" },
+				{ id: "retry", label: "Retry" },
+				{ id: "skip", label: "Skip step" },
+				{ id: "pause", label: "Pause ferment" },
 			],
 			{ ferment: f, pi, ctx, runtime },
 		)
@@ -163,9 +175,9 @@ export async function startStep(
 
 What should we do?
 
-1) Retry with a revised approach
-2) Skip this step and move on
-3) Pause the ferment for now
+1) Retry
+2) Skip step
+3) Pause ferment
 
 Do NOT call start_ferment_step again without user input.`,
 			)
@@ -242,13 +254,11 @@ Do NOT call start_ferment_step again without user input.`,
 
 	const workerContext =
 		freshPhase && freshStep ? services.buildWorkerContext(outcome.ferment, freshPhase, freshStep) : ""
-	const contextBlock = workerContext
-		? `\n\n--- BEGIN WORKER PROMPT ---\n${workerContext}\n--- END WORKER PROMPT ---\n\nPaste the block above into the Agent's prompt. You may add a single concrete implementation directive at the end if the step description is ambiguous, but do NOT remove, summarize, or contradict the context block.`
-		: ""
+	const contextBlock = workerContext ? `\n\nWorker context (pass to subagent verbatim):\n${workerContext}` : ""
 
 	return toolOk(
 		withNextActionHint(
-			`Step ${step.index}: "${step.description}" started.\nphase_id: ${phase.id}\nstep_id: ${step.id}\n\nLaunch an Agent now with subagent_type "general-purpose". When it returns, call complete_ferment_step with its summary.${lowGradeCaution}${parallelNote}${contextBlock}`,
+			`Step ${step.index}: "${step.description}" started. Spawn a subagent with subagent_type "general-purpose". When it returns, call complete_ferment_step with its summary.${lowGradeCaution}${parallelNote}${contextBlock}`,
 			outcome.ferment,
 		),
 	)
@@ -298,6 +308,7 @@ export async function completeStep(
 		runtime.clearStepStart(f.id, phase.id, step.id)
 		runtime.bumpStepCompleteAttempt(f.id, phase.id, step.id)
 		services.onStepCompleted(runtime)
+		sendStepBreadcrumb(pi, `Step ${step.index} ✓ ${step.description}`)
 		return toolOk(
 			withNextActionHint(
 				`Step ${step.index}: "${step.description}" done.  ${params.summary ?? ""}`,
@@ -334,6 +345,7 @@ export async function completeStep(
 		// Verification passed + all gates pass → silent advance. No LLM call.
 		runtime.bumpStepCompleteAttempt(f.id, phase.id, step.id)
 		services.onStepCompleted(runtime)
+		sendStepBreadcrumb(pi, `Step ${step.index} ✓ verified — ${step.description}`)
 		return toolOk(
 			withNextActionHint(`Step ${step.index}: "${step.description}" done and verified ✓`, verifyOutcome.ferment),
 		)
@@ -355,6 +367,7 @@ export async function completeStep(
 		// verdicts already passed above, so advance.
 		runtime.bumpStepCompleteAttempt(f.id, phase.id, step.id)
 		services.onStepCompleted(runtime)
+		sendStepBreadcrumb(pi, `Step ${step.index} ✓  Judge passed: ${judgeVerdict.reason}`)
 		return toolOk(
 			withNextActionHint(
 				`Step ${step.index}: "${step.description}" done ✓  Judge: ${judgeVerdict.reason}`,
@@ -370,6 +383,88 @@ export async function completeStep(
 		error: `Verification failed (exit ${exitCode}): ${judgeVerdict.reason}`,
 	})
 	if (!failOutcome.ok) return failedToolResult(failOutcome.error, f)
+
+	sendStepBreadcrumb(pi, `Step ${step.index} ✗ failed verification — ${judgeVerdict.reason}`, "warning")
+
+	// D19: surface a recovery dropdown so the user picks an action explicitly
+	// instead of leaving the planner guessing.
+	if (ctx?.ui?.select) {
+		const retryLabel = "Retry"
+		const skipLabel = "Skip step"
+		const editLabel = "Edit prompt and retry"
+		const abandonLabel = "Abandon phase"
+		const cancelLabel = "Cancel (keep step failed)"
+		const title = `Step ${step.index} "${step.description}" failed verification.\nJudge: ${judgeVerdict.reason}`
+		const choice = await ctx.ui.select(title, [retryLabel, skipLabel, editLabel, abandonLabel, cancelLabel])
+		runtime.markHumanInput()
+
+		if (choice === retryLabel) {
+			const retryOut = applyAndPersist(params.ferment_id, {
+				type: "start_step",
+				phaseId: phase.id,
+				stepId: step.id,
+			})
+			if (!retryOut.ok) return failedToolResult(retryOut.error)
+			runtime.clearStepStart(f.id, phase.id, step.id)
+			return toolOk(
+				`Step ${step.index} reset to running at user request. Retry the work — spawn a worker and call complete_step when done.`,
+			)
+		}
+
+		if (choice === skipLabel) {
+			const skipOut = applyAndPersist(params.ferment_id, {
+				type: "skip_step",
+				phaseId: phase.id,
+				stepId: step.id,
+			})
+			if (!skipOut.ok) return failedToolResult(skipOut.error)
+			services.onStepCompleted(runtime)
+			return toolOk(`Step ${step.index} skipped at user request.`)
+		}
+
+		if (choice === editLabel && ctx.ui.input) {
+			const newPrompt = await ctx.ui.input("Revised step description:", step.description)
+			runtime.markHumanInput()
+			if (newPrompt?.trim()) {
+				const editOut = applyAndPersist(params.ferment_id, {
+					type: "update_step_description",
+					phaseId: phase.id,
+					stepId: step.id,
+					description: newPrompt.trim(),
+				})
+				if (!editOut.ok) return failedToolResult(editOut.error)
+				const retryOut = applyAndPersist(params.ferment_id, {
+					type: "start_step",
+					phaseId: phase.id,
+					stepId: step.id,
+				})
+				if (!retryOut.ok) return failedToolResult(retryOut.error)
+				runtime.clearStepStart(f.id, phase.id, step.id)
+				await pi.sendUserMessage(`Retry step ${step.index} with this revised approach: ${newPrompt.trim()}`, {
+					deliverAs: "followUp",
+				})
+				return toolOk(`Step ${step.index} reset with revised approach. Awaiting planner re-execution.`)
+			}
+			return toolOk(`Step ${step.index} remains failed (no revised approach provided).`)
+		}
+
+		if (choice === abandonLabel) {
+			const phaseFailOut = applyAndPersist(params.ferment_id, {
+				type: "fail_phase",
+				phaseId: phase.id,
+				reason: `Step ${step.index} failed: ${judgeVerdict.reason}`,
+			})
+			if (!phaseFailOut.ok) return failedToolResult(phaseFailOut.error)
+			return toolOk(`Phase ${phase.index} marked failed at user request after step ${step.index} verification failure.`)
+		}
+
+		// Cancel, Esc/dismiss, or any unrecognised choice → no-op. The step is
+		// already in failed state from the fail_step above; preserve the phase
+		// and let the planner decide the next move.
+		return toolOk(
+			`Step ${step.index} remains failed. User dismissed the recovery dropdown without choosing an action — phase preserved.`,
+		)
+	}
 
 	if (judgeVerdict.verdict === "retry") {
 		return toolErr(

--- a/src/extensions/ferment/worker-prompt.test.ts
+++ b/src/extensions/ferment/worker-prompt.test.ts
@@ -58,7 +58,7 @@ describe("buildWorkerContext", () => {
 		const f = makeFerment({ phases: [phase] })
 
 		const ctx = buildWorkerContext(f, phase, step)
-		expect(ctx).toContain("Verify when done:")
+		expect(ctx).toContain("verify:")
 		expect(ctx).toContain("pnpm test")
 	})
 
@@ -70,7 +70,7 @@ describe("buildWorkerContext", () => {
 
 		expect(ctx).toContain("Ferment docs directory:")
 		expect(ctx).toContain(".kimchi/ferments/ferment-docs-1/docs/")
-		expect(ctx).toContain("Do NOT create ad-hoc project-root scratch folders like `.ui-audit/`")
+		expect(ctx).toContain("Do NOT create ad-hoc project-root scratch folders like .ui-audit/")
 	})
 
 	it("includes ferment goal and success criteria when present", () => {
@@ -90,10 +90,10 @@ describe("buildWorkerContext", () => {
 		})
 
 		const ctx = buildWorkerContext(f, phase, phase.steps[0])
-		expect(ctx).toContain("Ferment goal:")
+		expect(ctx).toContain("Goal:")
 		expect(ctx).toContain("Write /app/jump_analyzer.py")
 		expect(ctx).toContain("/app/output.toml")
-		expect(ctx).toContain("Success criteria:")
+		expect(ctx).toContain("Criteria:")
 		expect(ctx).toContain("Running on /app/example_video.mp4 produces /app/output.toml")
 	})
 
@@ -102,8 +102,8 @@ describe("buildWorkerContext", () => {
 		const f = makeFerment({ phases: [phase] })
 
 		const ctx = buildWorkerContext(f, phase, phase.steps[0])
-		expect(ctx).not.toContain("Ferment goal:")
-		expect(ctx).not.toContain("Success criteria:")
+		expect(ctx).not.toContain("Goal:")
+		expect(ctx).not.toContain("Criteria:")
 	})
 
 	it("includes prior completed steps with their summaries", () => {
@@ -117,10 +117,10 @@ describe("buildWorkerContext", () => {
 		const f = makeFerment({ phases: [phase] })
 
 		const ctx = buildWorkerContext(f, phase, phase.steps[2])
-		expect(ctx).toContain("Prior steps in this phase (2)")
-		expect(ctx).toContain("Step 1")
+		expect(ctx).toContain("Prior:")
+		expect(ctx).toContain("✓1")
 		expect(ctx).toContain("Created the User type")
-		expect(ctx).toContain("Step 2")
+		expect(ctx).toContain("✓2")
 		expect(ctx).toContain("Wrote the migration")
 		// The current step itself should NOT be listed in prior steps
 		expect(ctx).not.toContain("Wire it up — ")
@@ -136,8 +136,8 @@ describe("buildWorkerContext", () => {
 		const f = makeFerment({ phases: [phase] })
 
 		const ctx = buildWorkerContext(f, phase, phase.steps[1])
-		expect(ctx).toContain("⊘ skipped")
-		expect(ctx).not.toMatch(/✓ Step 1/)
+		expect(ctx).toContain("⊘1")
+		expect(ctx).not.toContain("✓1")
 	})
 
 	it("excludes pending and running steps from prior list", () => {
@@ -151,7 +151,7 @@ describe("buildWorkerContext", () => {
 		const f = makeFerment({ phases: [phase] })
 
 		const ctx = buildWorkerContext(f, phase, phase.steps[2])
-		expect(ctx).not.toContain("Prior steps in this phase")
+		expect(ctx).not.toContain("Prior:")
 	})
 
 	it("truncates long prior step summaries", () => {
@@ -183,7 +183,7 @@ describe("buildWorkerContext", () => {
 		const f = makeFerment({ phases: [phase], decisions })
 
 		const ctx = buildWorkerContext(f, phase, phase.steps[0])
-		expect(ctx).toContain("Decisions to honor:")
+		expect(ctx).toContain("Decisions:")
 		expect(ctx).toContain("Use Zod for validation")
 	})
 
@@ -200,7 +200,7 @@ describe("buildWorkerContext", () => {
 		const f = makeFerment({ phases: [phase], memories })
 
 		const ctx = buildWorkerContext(f, phase, phase.steps[0])
-		expect(ctx).toContain("Memories to apply:")
+		expect(ctx).toContain("Memories:")
 		expect(ctx).toContain("[gotcha]")
 		expect(ctx).toContain("Date.parse")
 	})
@@ -223,26 +223,12 @@ describe("buildWorkerContext", () => {
 		expect(ctx).not.toContain("Decision 2")
 	})
 
-	it("includes constraints when set", () => {
-		const phase = makePhase({ steps: [makeStep()] })
-		const f = makeFerment({
-			phases: [phase],
-			scoping: {
-				constraints: { answer: "Must be backwards compatible", confirmedAt: "2026-05-09T00:00:00Z" },
-			},
-		})
-
-		const ctx = buildWorkerContext(f, phase, phase.steps[0])
-		expect(ctx).toContain("Constraints:")
-		expect(ctx).toContain("Must be backwards compatible")
-	})
-
 	it("opts.includeDecisions=false suppresses the decisions section", () => {
 		const decisions: Decision[] = [{ id: "d1", title: "Use Zod", description: "DX", createdAt: "2026-05-09T00:00:00Z" }]
 		const phase = makePhase({ steps: [makeStep()] })
 		const f = makeFerment({ phases: [phase], decisions })
 
 		const ctx = buildWorkerContext(f, phase, phase.steps[0], { includeDecisions: false })
-		expect(ctx).not.toContain("Decisions to honor")
+		expect(ctx).not.toContain("Decisions:")
 	})
 })

--- a/src/extensions/ferment/worker-prompt.ts
+++ b/src/extensions/ferment/worker-prompt.ts
@@ -1,23 +1,13 @@
 /**
  * Worker prompt builder.
  *
- * `start_ferment_step` returns a structured WORKER CONTEXT block the planner can paste
+ * `start_step` returns a compact worker-context block the planner can paste
  * into the subagent's prompt verbatim. Without this, every spawn re-asks the
  * planner to "describe what to implement" — and the planner does so from the
  * step description alone, missing phase goal and prior-step continuity.
  *
- * We give workers five kinds of context:
- *   1. The phase goal — so they know the bigger-picture deliverable
- *   2. The ferment goal and success criteria — so fixed deliverables survive
- *   3. Prior step summaries in the same phase — so they don't redo work
- *   4. Decisions and memories captured in the ferment — so they stay consistent
- *   5. Constraints — so they preserve externally visible contracts
- *
- * The rendered block puts goal/criteria near the top and constraints near the
- * bottom. This is bounded: only the active phase's prior steps, only the most
- * recent decisions/memories. We do not give the worker the whole ferment
- * context (phases ahead, future scope) — that risks scope creep and over-eager
- * implementation.
+ * The block is intentionally dense (one fact per line, no markdown headers).
+ * Workers don't need a markdown document; they need the facts.
  */
 
 import type { Ferment, Phase, Step } from "../../ferment/types.js"
@@ -31,76 +21,53 @@ export interface WorkerContextOpts {
 	includeMemories?: boolean
 }
 
-/**
- * Build a markdown worker-context block for a step the planner is about to
- * delegate. The block is short — just enough for the worker to do the right
- * thing without re-deriving context from scratch.
- */
 export function buildWorkerContext(ferment: Ferment, phase: Phase, step: Step, opts: WorkerContextOpts = {}): string {
 	const lines: string[] = []
 	lines.push("## Worker Context")
-	lines.push(`**Ferment:** ${ferment.name}`)
-	lines.push(`**Phase ${phase.index}:** ${phase.name} — ${phase.goal}`)
-	lines.push(`**Step ${step.index}:** ${step.description}`)
+	lines.push(`Ferment: ${ferment.name}`)
+	lines.push(`Phase ${phase.index}: ${phase.name} — ${phase.goal}`)
+	lines.push(`Step ${step.index}: ${step.description}`)
 	if (step.verification?.command) {
-		lines.push(`**Verify when done:** \`${step.verification.command}\``)
+		lines.push(`verify: ${step.verification.command}`)
 	}
 	lines.push("")
-	lines.push(`**Ferment docs directory:** \`.kimchi/ferments/${ferment.id}/docs/\``)
+	lines.push(`Ferment docs directory: .kimchi/ferments/${ferment.id}/docs/`)
 	lines.push(
-		"Write transient audit notes, investigation reports, implementation notes, and verification reports there. Do NOT create ad-hoc project-root scratch folders like `.ui-audit/` unless the user explicitly requested a product artifact in the app itself.",
+		"Write transient audit notes, investigation reports, implementation notes, and verification reports there. Do NOT create ad-hoc project-root scratch folders like .ui-audit/ unless the user explicitly requested a product artifact in the app itself.",
 	)
 	if (ferment.scoping.goal?.answer) {
 		lines.push("")
-		lines.push(`**Ferment goal:** ${ferment.scoping.goal.answer}`)
+		lines.push(`Goal: ${ferment.scoping.goal.answer}`)
 	}
 	if (ferment.scoping.criteria?.answer) {
-		lines.push(`**Success criteria:** ${ferment.scoping.criteria.answer}`)
+		lines.push(`Criteria: ${ferment.scoping.criteria.answer}`)
 	}
 
 	const priorSteps = phase.steps
 		.filter((s) => s.index < step.index)
 		.filter((s) => s.status === "done" || s.status === "verified" || s.status === "skipped")
-
 	if (priorSteps.length > 0) {
-		lines.push("")
-		lines.push(`**Prior steps in this phase (${priorSteps.length}):**`)
-		for (const s of priorSteps) {
-			const tag = s.status === "skipped" ? "⊘ skipped" : "✓"
+		const priorBits = priorSteps.map((s) => {
+			const tag = s.status === "skipped" ? `⊘${s.index}` : `✓${s.index}`
 			const summary = (s.summary ?? "").trim()
 			const trimmed =
 				summary.length > PRIOR_STEP_SUMMARY_MAX_CHARS ? `${summary.slice(0, PRIOR_STEP_SUMMARY_MAX_CHARS)}…` : summary
-			const summaryLine = trimmed ? ` — ${trimmed}` : ""
-			lines.push(`- ${tag} Step ${s.index} "${s.description}"${summaryLine}`)
-		}
+			return trimmed ? `${tag} "${s.description}" — ${trimmed}` : `${tag} "${s.description}"`
+		})
+		lines.push(`Prior: ${priorBits.join("; ")}`)
 	}
 
 	const includeDecisions = opts.includeDecisions ?? true
 	if (includeDecisions && ferment.decisions.length > 0) {
 		const recent = ferment.decisions.slice(-MAX_DECISIONS)
-		lines.push("")
-		lines.push("**Decisions to honor:**")
-		for (const d of recent) {
-			lines.push(`- ${d.title}: ${d.description}`)
-		}
+		lines.push(`Decisions: ${recent.map((d) => `${d.title}: ${d.description}`).join("; ")}`)
 	}
 
 	const includeMemories = opts.includeMemories ?? true
 	if (includeMemories && ferment.memories.length > 0) {
 		const recent = ferment.memories.slice(-MAX_MEMORIES)
-		lines.push("")
-		lines.push("**Memories to apply:**")
-		for (const m of recent) {
-			lines.push(`- [${m.category}] ${m.content}`)
-		}
+		lines.push(`Memories: ${recent.map((m) => `[${m.category}] ${m.content}`).join("; ")}`)
 	}
-
-	if (ferment.scoping.constraints?.answer) {
-		lines.push("")
-		lines.push(`**Constraints:** ${ferment.scoping.constraints.answer}`)
-	}
-
-	console.log("test prompt is printed")
 
 	return lines.join("\n")
 }

--- a/src/ferment/event-mapper.ts
+++ b/src/ferment/event-mapper.ts
@@ -246,6 +246,14 @@ export function commandToEvents(cmd: Command, pre: Ferment, post: Ferment, ctx: 
 			b.push("step_failed", { phaseId: cmd.phaseId, stepId: cmd.stepId, error: cmd.error, completedAt: ctx.now })
 			return b.events
 
+		case "update_step_description":
+			b.push("step_description_updated", {
+				phaseId: cmd.phaseId,
+				stepId: cmd.stepId,
+				description: cmd.description.trim(),
+			})
+			return b.events
+
 		case "complete_ferment": {
 			b.push("ferment_completed", { finalSummary: cmd.finalSummary, completedAt: ctx.now })
 			if (cmd.grade) {

--- a/src/ferment/event-store.ts
+++ b/src/ferment/event-store.ts
@@ -93,6 +93,7 @@ export type FermentEventType =
 	| "step_failed"
 	| "step_verified"
 	| "step_graded"
+	| "step_description_updated"
 	| "ferment_graded"
 	| "decision_added"
 	| "memory_added"
@@ -270,6 +271,12 @@ export interface StepGradedPayload {
 	gradedAt: string
 }
 
+export interface StepDescriptionUpdatedPayload {
+	phaseId: string
+	stepId: string
+	description: string
+}
+
 export interface FermentGradedPayload {
 	grade: JudgeGrade
 }
@@ -333,6 +340,10 @@ export type StepSkippedEvent = FermentEventBase & { type: "step_skipped"; payloa
 export type StepFailedEvent = FermentEventBase & { type: "step_failed"; payload: StepFailedPayload }
 export type StepVerifiedEvent = FermentEventBase & { type: "step_verified"; payload: StepVerifiedPayload }
 export type StepGradedEvent = FermentEventBase & { type: "step_graded"; payload: StepGradedPayload }
+export type StepDescriptionUpdatedEvent = FermentEventBase & {
+	type: "step_description_updated"
+	payload: StepDescriptionUpdatedPayload
+}
 export type FermentGradedEvent = FermentEventBase & { type: "ferment_graded"; payload: FermentGradedPayload }
 export type DecisionAddedEvent = FermentEventBase & { type: "decision_added"; payload: DecisionAddedPayload }
 export type MemoryAddedEvent = FermentEventBase & { type: "memory_added"; payload: MemoryAddedPayload }
@@ -367,6 +378,7 @@ export type FermentEvent =
 	| StepFailedEvent
 	| StepVerifiedEvent
 	| StepGradedEvent
+	| StepDescriptionUpdatedEvent
 	| FermentGradedEvent
 	| DecisionAddedEvent
 	| MemoryAddedEvent
@@ -1262,6 +1274,19 @@ export function applyFermentEvent(state: Ferment | undefined, event: FermentEven
 				phases: state.phases.map((ph) =>
 					ph.id === p.phaseId
 						? { ...ph, steps: ph.steps.map((s) => (s.id === p.stepId ? { ...s, grade: p.grade } : s)) }
+						: ph,
+				),
+				updatedAt: event.timestamp,
+			}
+		}
+		case "step_description_updated": {
+			if (!state) throw new Error("step_description_updated requires existing state")
+			const p = event.payload as StepDescriptionUpdatedPayload
+			return {
+				...state,
+				phases: state.phases.map((ph) =>
+					ph.id === p.phaseId
+						? { ...ph, steps: ph.steps.map((s) => (s.id === p.stepId ? { ...s, description: p.description } : s)) }
 						: ph,
 				),
 				updatedAt: event.timestamp,

--- a/src/ferment/state-machine.ts
+++ b/src/ferment/state-machine.ts
@@ -91,6 +91,7 @@ export type Command =
 	| { type: "verify_step"; phaseId: string; stepId: string; result: StepResult; summary?: string }
 	| { type: "skip_step"; phaseId: string; stepId: string }
 	| { type: "fail_step"; phaseId: string; stepId: string; error?: string }
+	| { type: "update_step_description"; phaseId: string; stepId: string; description: string }
 	| { type: "complete_ferment"; finalSummary?: string; grade?: JudgeGrade }
 	| { type: "pause" }
 	| { type: "resume" }
@@ -142,6 +143,7 @@ export type TransitionError =
 			runningDescription: string
 			message: string
 	  }
+	| { code: "INVALID_STEP_DESCRIPTION"; message: string }
 
 export interface TransitionContext {
 	/** ISO timestamp; injected so transitions are deterministic. */
@@ -191,6 +193,8 @@ export function applyCommand(ferment: Ferment, cmd: Command, ctx: TransitionCont
 			return handleSkipStep(ferment, cmd, ctx)
 		case "fail_step":
 			return handleFailStep(ferment, cmd, ctx)
+		case "update_step_description":
+			return handleUpdateStepDescription(ferment, cmd, ctx)
 		case "complete_ferment":
 			return handleCompleteFerment(ferment, cmd, ctx)
 		case "pause":
@@ -694,6 +698,36 @@ function handleFailStep(
 				completedAt: ctx.now,
 				result,
 			}),
+		}),
+	)
+}
+
+// ─── update_step_description ──────────────────────────────────────────────────
+
+function handleUpdateStepDescription(
+	ferment: Ferment,
+	cmd: Extract<Command, { type: "update_step_description" }>,
+	ctx: TransitionContext,
+): TransitionResult {
+	const phaseFound = requirePhase(ferment, cmd.phaseId)
+	if (isTransitionError(phaseFound)) return fail(phaseFound)
+	const { phase, index: phaseIndex } = phaseFound
+
+	const stepFound = requireStep(phase, cmd.stepId)
+	if (isTransitionError(stepFound)) return fail(stepFound)
+	const { index: stepIndex } = stepFound
+
+	const trimmed = cmd.description.trim()
+	if (!trimmed) {
+		return fail({
+			code: "INVALID_STEP_DESCRIPTION",
+			message: "Step description must not be empty.",
+		})
+	}
+
+	return ok(
+		touch(ferment, ctx, {
+			phases: setStep(ferment, phaseIndex, stepIndex, { description: trimmed }),
 		}),
 	)
 }


### PR DESCRIPTION


---
### Kimchi Summary
### What changed
Adds a TUI breadcrumb renderer for ferment status messages, an interactive phase editor before scoping confirmation, and a recovery dropdown for failed step verifications. Replaces hidden `appendEntry` calls with visible, themed `sendMessage` events.

### Why
Ferment progress was previously invisible to users because state changes were written to hidden log entries. This makes status updates, warnings, and completions scannable in the UI, and gives users direct control over both phase proposals and step recovery.

### Key changes
- `breadcrumb-renderer.ts`: New `MessageRenderer` mapping `ferment_breadcrumb`, `ferment_ack`, `ferment_worktree_warning`, and `ferment_oneshot_failed` to colored glyphs (`🫧`, `🍺`, `⚠`, etc.) based on `details.variant`.
- `phase-editor.ts`: New interactive editor to rename, reorder, add, or delete proposed phases before `confirmPendingScope`. Integrated into `events.ts` on draft-scope confirmation.
- `commands.ts`: Added `sendBreadcrumb` helper to replace `appendEntry` calls. Added `setStatus("ferment-scoping", ...)` spinners during async create/one-shot flows, and fixed the order of UI-availability checks.
- `scoping.ts`: Added scoping breadcrumbs via `sendScopingBreadcrumb` and status updates during the flow.
- `resume.ts`: Added `loadFermentSilently` to activate a ferment without engaging the planner. On session startup, if an active ferment env var exists and UI is available, prompts the user to "Resume" or "Leave paused" rather than auto-resuming.
- `tools/steps.ts`: Added recovery dropdown after step verification failure with options to retry, skip, edit the prompt, abandon the phase, or cancel. Sends step-completion breadcrumbs via `sendStepBreadcrumb`.
- `tools/phases.ts`: Sends a visual phase-completion ack with grade and touched-file count via `sendPhaseAck`.
- `nudge.ts`: Migrated suppression breadcrumbs from `appendEntry` to `sendMessage`. Reduced `MAX_CONSECUTIVE_REACTIVE_NUDGES` from `3` to `1`.
- `worker-prompt.ts`: Simplified worker context to dense one-line facts; removed markdown headers, verbose framing, and the constraints section.
- `state-machine.ts`, `event-store.ts`, `event-mapper.ts`: Added `update_step_description` command and event.

### Impact
- `MAX_CONSECUTIVE_REACTIVE_NUDGES` is now capped at `1` instead of `3`.
- Step action labels shortened in the UI: `Retry with a revised approach` → `Retry`, `Skip this step and move on` → `Skip step`, `Pause the ferment for now` → `Pause ferment`.
- Session restart now requires explicit user confirmation before resuming a ferment when the UI is present.