### PR TITLE
chore: disable skill manager extension

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -34,7 +34,6 @@ import permissionsExtension from "./extensions/permissions/index.js"
 import { reserveShiftTabForPermissions } from "./extensions/permissions/keybindings.js"
 import promptSummaryExtension from "./extensions/prompt-summary.js"
 import shutdownMarkerExtension from "./extensions/shutdown-marker.js"
-import skillsManagerExtension from "./extensions/skills-manager/index.js"
 import startupUpdateExtension from "./extensions/startup-update.js"
 import statsExtension from "./extensions/stats/index.js"
 import tagsExtension from "./extensions/tags.js"
@@ -334,7 +333,6 @@ try {
 			webFetchExtension,
 			webSearchExtension,
 			loginExtension,
-			skillsManagerExtension,
 			improveExtension,
 			curatorExtension,
 		]


### PR DESCRIPTION
Temporarily disables the skill manager extension by removing it from the CLI entry point.

---
### Kimchi Summary
### What changed
Disables the skills manager by removing `skillsManagerExtension` from the CLI bootstrap sequence.

### Key changes
- `src/cli.ts`: Removed the `skillsManagerExtension` import from `./extensions/skills-manager/index.js`
- `src/cli.ts`: Removed `skillsManagerExtension` from the array of extensions loaded at startup

### Impact
The skills manager feature will no longer be initialized or active during CLI runtime.