### PR TITLE
feat(mcp-adapter): auto-fill required tool params from extension context

### DIFF
--- a/src/extensions/mcp-adapter/context-providers.test.ts
+++ b/src/extensions/mcp-adapter/context-providers.test.ts
@@ -79,6 +79,12 @@ describe('fillMissingRequired', () => {
     expect('projectPath' in result).toBe(false)
   })
 
+  it('fills missing required param with empty string when cwd is empty string', () => {
+    const meta = makeMeta(['projectPath'])
+    const result = fillMissingRequired(meta, {}, { cwd: '' })
+    expect(result.projectPath).toBe('')
+  })
+
   it('does NOT overwrite a caller-supplied null value', () => {
     const meta = makeMeta(['projectPath'])
     const result = fillMissingRequired(meta, { projectPath: null }, { cwd: '/kimchi' })

--- a/src/extensions/mcp-adapter/context-providers.test.ts
+++ b/src/extensions/mcp-adapter/context-providers.test.ts
@@ -1,0 +1,117 @@
+import { describe, expect, it, vi } from 'vitest'
+import { CWD_REGEX, fillMissingRequired, PROJECT_PATH_REGEX } from './context-providers.js'
+import type { ToolMetadata } from './types.js'
+
+function makeMeta(required: string[], additionalProperties = {}): ToolMetadata {
+  return {
+    name: 'test_tool',
+    originalName: 'test_tool',
+    description: '',
+    prefix: '',
+    serverName: 'test',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        projectPath: { type: 'string' },
+        cwd: { type: 'string' },
+        optionalParam: { type: 'string' },
+        ...additionalProperties,
+      },
+      required,
+    },
+  } as ToolMetadata
+}
+
+describe('fillMissingRequired', () => {
+  it('fills missing required projectPath from cwd', () => {
+    const meta = makeMeta(['projectPath'])
+    const result = fillMissingRequired(meta, {}, { cwd: '/kimchi' })
+    expect(result.projectPath).toBe('/kimchi')
+  })
+
+  it('does NOT overwrite a caller-supplied value', () => {
+    const meta = makeMeta(['projectPath'])
+    const result = fillMissingRequired(meta, { projectPath: '/other' }, { cwd: '/kimchi' })
+    expect(result.projectPath).toBe('/other')
+  })
+
+  it('does NOT fill optional params even if empty', () => {
+    const meta = makeMeta(['projectPath'])
+    const result = fillMissingRequired(meta, {}, { cwd: '/kimchi' })
+    expect('optionalParam' in result).toBe(false)
+  })
+
+  it('does NOT fill when inputSchema is missing', () => {
+    const result = fillMissingRequired(undefined, { a: 1 }, { cwd: '/' })
+    expect(result).toEqual({ a: 1 })
+  })
+
+  it('fills cwd param from cwd context', () => {
+    const meta = makeMeta(['cwd'])
+    const result = fillMissingRequired(meta, {}, { cwd: '/work' })
+    expect(result.cwd).toBe('/work')
+  })
+
+  it('logs each fill when logger provided', () => {
+    const log = vi.fn()
+    const meta = makeMeta(['projectPath'])
+    fillMissingRequired(meta, {}, { cwd: '/kimchi' }, log)
+    expect(log).toHaveBeenCalledOnce()
+    expect(log.mock.calls[0][0]).toMatch(/auto-fill: projectPath.*provider:/)
+  })
+
+  it('does not fill empty string — preserves caller value', () => {
+    const meta = makeMeta(['projectPath'])
+    const result = fillMissingRequired(meta, { projectPath: '' }, { cwd: '/kimchi' })
+    expect(result.projectPath).toBe('')
+  })
+
+  it('does NOT fill when inputSchema has no required array', () => {
+    const meta = {
+      name: 'test_tool',
+      originalName: 'test_tool',
+      description: '',
+      prefix: '',
+      serverName: 'test',
+      inputSchema: { type: 'object', properties: { projectPath: { type: 'string' } } },
+    } as ToolMetadata
+    const result = fillMissingRequired(meta, {}, { cwd: '/kimchi' })
+    expect('projectPath' in result).toBe(false)
+  })
+
+  it('does NOT overwrite a caller-supplied null value', () => {
+    const meta = makeMeta(['projectPath'])
+    const result = fillMissingRequired(meta, { projectPath: null }, { cwd: '/kimchi' })
+    expect(result.projectPath).toBeNull()
+  })
+})
+
+describe('PROJECT_PATH_REGEX — matches project-path-like property names', () => {
+  it.each([
+    'projectPath',
+    'project_path',
+    'project-path',
+    'projectRoot',
+    'project_root',
+    'project-root',
+    'repoRoot',
+    'repo_root',
+    'repo-root',
+  ])('matches "%s"', (name) => {
+    expect(PROJECT_PATH_REGEX.test(name)).toBe(true)
+  })
+
+  it.each(['path', 'projectDir', 'root', 'repo', 'project_path_extra', 'cwd', 'workingDirectory'])('does NOT match "%s"', (name) => {
+    expect(PROJECT_PATH_REGEX.test(name)).toBe(false)
+  })
+})
+
+describe('CWD_REGEX — matches working-directory-like property names', () => {
+  it.each(['cwd', 'workingDirectory', 'working_directory'])('matches "%s"', (name) => {
+    expect(CWD_REGEX.test(name)).toBe(true)
+  })
+
+  it.each(['wd', 'directory', 'workDir', 'workingDir', 'projectPath'])('does NOT match "%s"', (name) => {
+    expect(CWD_REGEX.test(name)).toBe(false)
+  })
+})

--- a/src/extensions/mcp-adapter/context-providers.ts
+++ b/src/extensions/mcp-adapter/context-providers.ts
@@ -1,0 +1,55 @@
+import type { ExtensionContext } from '@earendil-works/pi-coding-agent'
+import type { ToolMetadata } from './types.js'
+
+type ContextProvider = {
+  matchName: RegExp
+  resolve: (ctx: Pick<ExtensionContext, 'cwd'>) => string | undefined
+}
+
+export const PROJECT_PATH_REGEX = /^(project[_-]?path|project[_-]?root|repo[_-]?root)$/i
+export const CWD_REGEX = /^(cwd|working[_-]?directory)$/i
+
+const DEFAULT_PROVIDERS: ContextProvider[] = [
+  {
+    matchName: PROJECT_PATH_REGEX,
+    resolve: (c) => c.cwd,
+  },
+  {
+    matchName: CWD_REGEX,
+    resolve: (c) => c.cwd,
+  },
+]
+
+/**
+ * Merge caller-supplied args with auto-filled required params.
+ * Only fills required params that are missing/null/empty string.
+ * Never overwrites a caller-supplied non-empty value.
+ */
+export function fillMissingRequired(
+  metadata: ToolMetadata | undefined,
+  callerArgs: Record<string, unknown>,
+  ctx: Pick<ExtensionContext, 'cwd'>,
+  log?: (msg: string) => void,
+): Record<string, unknown> {
+  const out: Record<string, unknown> = { ...callerArgs }
+  if (!metadata?.inputSchema) return out
+
+  // ToolMetadata.inputSchema is typed 'unknown' because JSON Schema shapes vary by MCP server.
+  const schema = metadata.inputSchema as { required?: string[] } | undefined
+  const required = schema?.required ?? []
+  for (const key of required) {
+    // Skip if caller provided a value (even empty string — preserve explicit caller intent)
+    if (key in out) continue
+
+    for (const p of DEFAULT_PROVIDERS) {
+      if (!p.matchName.test(key)) continue
+      const value = p.resolve(ctx)
+      if (value != null) {
+        out[key] = value
+        log?.(`[mcp-adapter] auto-fill: ${key} = "${value}" (provider: ${p.matchName.source})`)
+        break
+      }
+    }
+  }
+  return out
+}

--- a/src/extensions/mcp-adapter/context-providers.ts
+++ b/src/extensions/mcp-adapter/context-providers.ts
@@ -22,8 +22,8 @@ const DEFAULT_PROVIDERS: ContextProvider[] = [
 
 /**
  * Merge caller-supplied args with auto-filled required params.
- * Only fills required params that are missing/null/empty string.
- * Never overwrites a caller-supplied non-empty value.
+ * Only fills required params that are missing or null.
+ * Never overwrites a caller-supplied value.
  */
 export function fillMissingRequired(
   metadata: ToolMetadata | undefined,

--- a/src/extensions/mcp-adapter/direct-tools.ts
+++ b/src/extensions/mcp-adapter/direct-tools.ts
@@ -1,4 +1,6 @@
-import type { ToolDefinition } from "@earendil-works/pi-coding-agent"
+import type { ExtensionContext, ToolDefinition } from "@earendil-works/pi-coding-agent"
+import type { CallToolResult } from "@modelcontextprotocol/sdk/types.js"
+import { fillMissingRequired } from "./context-providers.js"
 import { getFailureAgeSeconds, lazyConnect } from "./init.js"
 import { authenticate, supportsOAuth } from "./mcp-auth-flow.js"
 import type { MetadataCache } from "./metadata-cache.js"
@@ -232,6 +234,7 @@ export function createDirectToolExecutor(
 	getState: () => McpExtensionState | null,
 	getInitPromise: () => Promise<McpExtensionState> | null,
 	spec: DirectToolSpec,
+	ctx?: Pick<ExtensionContext, "cwd">,
 ): DirectToolExecute {
 	return async function execute(_toolCallId, params) {
 		let state = getState()
@@ -303,6 +306,13 @@ export function createDirectToolExecutor(
 			}
 		}
 
+		const mergedArgs = fillMissingRequired(
+			spec.metadata,
+			(params ?? {}) as Record<string, unknown>,
+			ctx ?? { cwd: process.cwd() },
+			(msg) => console.debug(msg),
+		)
+
 		let uiSession: UiSessionRuntime | null = null
 
 		try {
@@ -331,20 +341,18 @@ export function createDirectToolExecutor(
 				? await maybeStartUiSession(state, {
 						serverName: spec.serverName,
 						toolName: spec.originalName,
-						toolArgs: (params ?? {}) as Record<string, unknown>,
+						toolArgs: mergedArgs,
 						uiResourceUri: spec.uiResourceUri!,
 						streamMode: spec.uiStreamMode,
 					})
 				: null
 
-			const resultPromise = connection.client.callTool({
+			const result = await connection.client.callTool({
 				name: spec.originalName,
-				arguments: (params ?? {}) as Record<string, unknown>,
+				arguments: mergedArgs,
 				_meta: uiSession?.requestMeta,
 			})
-
-			const result = await resultPromise
-			uiSession?.sendToolResult(result as unknown as import("@modelcontextprotocol/sdk/types.js").CallToolResult)
+			uiSession?.sendToolResult(result as unknown as CallToolResult)
 
 			const mcpContent = (result.content ?? []) as McpContent[]
 			const content = transformMcpContent(mcpContent)

--- a/src/extensions/mcp-adapter/index.ts
+++ b/src/extensions/mcp-adapter/index.ts
@@ -1,7 +1,7 @@
-import type { ExtensionAPI, ToolInfo, ToolRenderResultOptions } from "@earendil-works/pi-coding-agent"
+import type { ExtensionAPI, ExtensionContext, ToolInfo, ToolRenderResultOptions } from "@earendil-works/pi-coding-agent"
 import { Theme, keyHint } from "@earendil-works/pi-coding-agent"
 import { Type } from "typebox"
-import type { DirectToolSpec } from "./types.js"
+import type { DirectToolSpec, ToolMetadata } from "./types.js"
 import { formatToolName } from "./types.js"
 import { type Component, Text } from "@earendil-works/pi-tui"
 import { registerToolCall, isToolExpanded } from "../../expand-state.js"
@@ -104,6 +104,18 @@ export default function mcpAdapter(pi: ExtensionAPI) {
 	const registeredToolNames = new Set<string>()
 
 	for (const spec of directSpecs) {
+		const cachedServer = earlyCache?.servers?.[spec.serverName]
+		const cachedTool = cachedServer?.tools?.find((t) => t.name === spec.originalName)
+		const metadata: ToolMetadata | undefined = cachedTool
+			? {
+					name: spec.prefixedName,
+					originalName: spec.originalName,
+					description: spec.description,
+					inputSchema: cachedTool.inputSchema,
+					uiResourceUri: cachedTool.uiResourceUri,
+					uiStreamMode: cachedTool.uiStreamMode,
+				}
+			: undefined
 		pi.registerTool({
 			name: spec.prefixedName,
 			label: `MCP: ${spec.originalName}`,
@@ -113,7 +125,7 @@ export default function mcpAdapter(pi: ExtensionAPI) {
 			execute: createDirectToolExecutor(
 				() => state,
 				() => initPromise,
-				spec,
+				{ ...spec, metadata },
 			),
 		})
 		registeredToolNames.add(spec.prefixedName)
@@ -135,7 +147,11 @@ export default function mcpAdapter(pi: ExtensionAPI) {
 	 * executor captures `state` lazily via the `() => state` closure and the
 	 * tools are meant to persist anyway.
 	 */
-	function registerAndActivate(specs: DirectToolSpec[], opts?: { markDynamic?: boolean }): string[] {
+	function registerAndActivate(
+		specs: DirectToolSpec[],
+		opts?: { markDynamic?: boolean },
+		ctx?: Pick<ExtensionContext, "cwd">,
+	): string[] {
 		const markDynamic = opts?.markDynamic ?? true
 		if (!state && markDynamic) return []
 		const newNames: string[] = []
@@ -154,6 +170,7 @@ export default function mcpAdapter(pi: ExtensionAPI) {
 					() => state,
 					() => initPromise,
 					spec,
+					ctx,
 				),
 			})
 			registeredToolNames.add(spec.prefixedName)
@@ -180,8 +197,11 @@ export default function mcpAdapter(pi: ExtensionAPI) {
 	 * (`init.ts` → `resolveDirectTools` after first connect). These tools
 	 * are permanent for the session, so they must not be marked dynamic.
 	 */
-	function registerBootstrappedDirectTools(specs: DirectToolSpec[]): string[] {
-		return registerAndActivate(specs, { markDynamic: false })
+	function registerBootstrappedDirectTools(
+		specs: DirectToolSpec[],
+		ctx?: Pick<ExtensionContext, "cwd">,
+	): string[] {
+		return registerAndActivate(specs, { markDynamic: false }, ctx)
 	}
 
 	pi.on("input", () => {
@@ -438,7 +458,7 @@ export default function mcpAdapter(pi: ExtensionAPI) {
 				}
 				if (params.describe) {
 					return executeDescribe(state, params.describe, (specs) =>
-						registerAndActivate(specs.map((s) => ({ ...s, prefixedName: formatToolName(s.originalName, s.serverName, prefix) })))
+						registerAndActivate(specs.map((s) => ({ ...s, prefixedName: formatToolName(s.originalName, s.serverName, prefix) })), undefined, ctx)
 					)
 				}
 				if (params.search) {
@@ -450,7 +470,7 @@ export default function mcpAdapter(pi: ExtensionAPI) {
 					// no API key configured; default is fine
 				}
 				return executeSearch(state, params.search, params.regex, params.server, params.includeSchemas, getPiTools, params.limit ?? mcpSearchLimit, state.searchStrategy, (specs) =>
-					registerAndActivate(specs.map((s) => ({ ...s, prefixedName: formatToolName(s.originalName, s.serverName, prefix) })))
+					registerAndActivate(specs.map((s) => ({ ...s, prefixedName: formatToolName(s.originalName, s.serverName, prefix) })), undefined, ctx)
 				)
 				}
 				return {

--- a/src/extensions/mcp-adapter/init.ts
+++ b/src/extensions/mcp-adapter/init.ts
@@ -30,7 +30,7 @@ const FAILURE_BACKOFF_MS = 60 * 1000
 export async function initializeMcp(
 	pi: ExtensionAPI,
 	ctx: ExtensionContext,
-	registerBootstrappedDirectTools?: (specs: DirectToolSpec[]) => string[],
+	registerBootstrappedDirectTools?: (specs: DirectToolSpec[], ctx?: Pick<ExtensionContext, "cwd">) => string[],
 ): Promise<McpExtensionState> {
 	const configPath = pi.getFlag("mcp-config") as string | undefined
 	const config = loadMcpConfig(configPath)
@@ -231,7 +231,7 @@ export async function initializeMcp(
 					const allSpecs = resolveDirectTools(config, freshCache, prefix, envOverride)
 					const newSpecs = allSpecs.filter((s) => bootstrapped.includes(s.serverName))
 					if (newSpecs.length > 0) {
-						const injected = registerBootstrappedDirectTools(newSpecs)
+						const injected = registerBootstrappedDirectTools(newSpecs, { cwd: ctx.cwd })
 						injectedCount = injected.length
 					}
 				}

--- a/src/extensions/mcp-adapter/proxy-modes.ts
+++ b/src/extensions/mcp-adapter/proxy-modes.ts
@@ -3,6 +3,7 @@ import { mkdirSync, writeFileSync } from "node:fs"
 import { tmpdir, userInfo } from "node:os"
 import { dirname, join } from "node:path"
 import type { AgentToolResult, ExtensionContext, ToolInfo } from "@earendil-works/pi-coding-agent"
+import type { CallToolResult } from "@modelcontextprotocol/sdk/types.js"
 import { truncateTail } from "@earendil-works/pi-coding-agent"
 import type { SearchStrategy } from "./bm25.js"
 import {
@@ -906,7 +907,7 @@ export async function executeCall(
 
 		if (toolMeta.uiResourceUri) {
 			const result = await resultPromise
-			uiSession?.sendToolResult(result as unknown as import("@modelcontextprotocol/sdk/types.js").CallToolResult)
+			uiSession?.sendToolResult(result as unknown as CallToolResult)
 			const mcpContent = (result.content ?? []) as McpContent[]
 			const content = transformMcpContent(mcpContent)
 

--- a/src/extensions/mcp-adapter/types.ts
+++ b/src/extensions/mcp-adapter/types.ts
@@ -342,6 +342,8 @@ export interface DirectToolSpec {
 	resourceUri?: string
 	uiResourceUri?: string
 	uiStreamMode?: UiStreamMode
+	/** Cached schema for auto-fill and retry decisions */
+	metadata?: ToolMetadata
 }
 
 export interface ServerProvenance {


### PR DESCRIPTION
Add fillMissingRequired() to automatically populate required MCP tool parameters (projectPath, cwd, projectRoot, etc.) from the extension context when the caller omits them.

- PROJECT_PATH_REGEX matches project-path-like property names
- CWD_REGEX matches working-directory-like property names
- Preserves caller-supplied values (including null and empty string)
- Only fills required params, never optional ones
- Includes comprehensive unit tests

---
### Kimchi Summary
### What changed
Automatically backfills missing required MCP tool parameters—such as `projectPath`, `cwd`, and `workingDirectory`—from the extension's current working directory context before executing direct tools.

### Why
Prevents unnecessary tool call failures when the caller omits required path arguments that the extension already knows, and reduces redundant context passing.

### Key changes
- `context-providers.ts` (new): Introduces `fillMissingRequired()`, `PROJECT_PATH_REGEX`, and `CWD_REGEX` to match and inject `cwd` into required tool args without overwriting caller-supplied values (including empty strings or `null`).
- `direct-tools.ts`: Integrates `fillMissingRequired()` into `createDirectToolExecutor()` to merge auto-filled args before invoking `connection.client.callTool()`.
- `index.ts`: Attaches cached `ToolMetadata`/`inputSchema` to `DirectToolSpec` at registration time; threads `Pick<ExtensionContext, "cwd">` through `registerAndActivate()`, `registerBootstrappedDirectTools()`, and the `executeDescribe`/`executeSearch` flows.
- `init.ts`: Passes `{ cwd: ctx.cwd }` to `registerBootstrappedDirectTools()` when re-registering tools after a server reconnect.
- `types.ts`: Adds optional `metadata?: ToolMetadata` field to `DirectToolSpec`.
- `proxy-modes.ts`: Replaces inline dynamic `import()` type with direct `CallToolResult` import.

### Impact
- Required path parameters are silently auto-filled only when absent from caller args.
- No breaking changes; falls back to `process.cwd()` if extension context is unavailable.