### PR TITLE
Fix fatal error on init when there is empty git repo

### DIFF
--- a/src/extensions/ferment/commands.ts
+++ b/src/extensions/ferment/commands.ts
@@ -8,6 +8,7 @@ import type { FermentWorkMode } from "../../ferment/types.js"
 import { pr_bold, pr_dim, pr_orange, pr_success, pr_teal } from "./colors.js"
 import { type FermentCommand, parseFermentCommand } from "./command-parser.js"
 import { formatFermentStatus } from "./format.js"
+import { autoInitFromEnv, ensureGitRepo } from "./git-init.js"
 import { appendRefEntry, maybeInjectAutoNudge } from "./nudge.js"
 import { maybeRunOnboarding } from "./onboarding.js"
 import { buildOneshotNudge } from "./oneshot.js"
@@ -421,6 +422,12 @@ export class FermentCommandController {
 				return { handled: true }
 			}
 			try {
+				// One-shot is non-interactive by definition — only auto-init when the
+				// user opted in via flag or env var. Otherwise skip silently.
+				await ensureGitRepo({
+					ui: ctx.ui,
+					autoInit: pi.getFlag?.("init-git") === true || autoInitFromEnv(),
+				})
 				const shortName = await shortenTitle(resolvedIntent)
 				const f = storage.create(shortName, resolvedIntent)
 				const modeOut = applyAndPersist(f.id, { type: "set_mode", mode: "exec" })
@@ -460,6 +467,9 @@ export class FermentCommandController {
 			return { handled: true }
 		}
 		try {
+			// Interactive path: ui.confirm is available, so ensureGitRepo will ask.
+			// User can decline; ferment still proceeds with no branch/commit info.
+			await ensureGitRepo({ ui: ctx.ui })
 			const shortName = await shortenTitle(rawName)
 			const f = storage.create(shortName, rawName)
 			setActiveFerment(pi, runtime, f)

--- a/src/extensions/ferment/events.ts
+++ b/src/extensions/ferment/events.ts
@@ -2,6 +2,7 @@ import type { ExtensionAPI } from "@earendil-works/pi-coding-agent"
 import { shortenTitle } from "../../ferment/shorten-title.js"
 import { clearFermentCache } from "../../ferment/store.js"
 import { extractContextualOptions, extractTrailingQuestion } from "./contextual-options.js"
+import { autoInitFromEnv, ensureGitRepo } from "./git-init.js"
 import { appendRefEntry } from "./nudge.js"
 import { buildOneshotNudge } from "./oneshot.js"
 import { buildPlannerSupplement } from "./planner-supplement.js"
@@ -34,6 +35,10 @@ export function registerFermentEvents(pi: ExtensionAPI, runtime: FermentRuntime 
 	pi.registerFlag("ferment-oneshot", {
 		type: "boolean",
 		description: "Bootstrap the initial prompt as a one-shot exec-mode ferment.",
+	})
+	pi.registerFlag("init-git", {
+		type: "boolean",
+		description: "When the ferment cwd is not a git repo, run `git init` instead of skipping.",
 	})
 
 	pi.on("session_start", async (_event, ctx) => {
@@ -78,6 +83,11 @@ export function registerFermentEvents(pi: ExtensionAPI, runtime: FermentRuntime 
 		if (!intent) return
 
 		try {
+			// Bootstrap path: no UI available yet, so only auto-init when the user
+			// opted in via --init-git or KIMCHI_AUTO_GIT_INIT=1.
+			await ensureGitRepo({
+				autoInit: pi.getFlag?.("init-git") === true || autoInitFromEnv(),
+			})
 			const storage = runtime.getStorage()
 			let shortName: string
 			try {

--- a/src/extensions/ferment/git-init.ts
+++ b/src/extensions/ferment/git-init.ts
@@ -1,0 +1,55 @@
+import { execSync } from "node:child_process"
+import { existsSync } from "node:fs"
+import { join } from "node:path"
+import type { FermentUi } from "./ui.js"
+
+export type EnsureGitRepoOutcome = "already-repo" | "initialized" | "declined" | "skipped" | "init-failed"
+
+export interface EnsureGitRepoOptions {
+	cwd?: string
+	ui?: FermentUi
+	/**
+	 * When true, skip the interactive confirm and run `git init` unconditionally.
+	 * Set by callers in non-interactive flows (e.g. one-shot with --init-git flag
+	 * or KIMCHI_AUTO_GIT_INIT=1 env var).
+	 */
+	autoInit?: boolean
+}
+
+/**
+ * Make sure the cwd is a git repo before a ferment is created.
+ *
+ *   - Already a repo  → no-op.
+ *   - Interactive UI  → ask the user; init on yes, skip on no.
+ *   - autoInit        → run `git init` without asking.
+ *   - Otherwise       → skip silently (ferment still works, just without branch/commit).
+ *
+ * Returns the outcome so callers can surface a notification if they want to.
+ */
+export async function ensureGitRepo(opts: EnsureGitRepoOptions = {}): Promise<EnsureGitRepoOutcome> {
+	const cwd = opts.cwd ?? process.cwd()
+	if (existsSync(join(cwd, ".git"))) return "already-repo"
+
+	if (!opts.autoInit) {
+		if (typeof opts.ui?.confirm !== "function") return "skipped"
+		const ok = await opts.ui.confirm(
+			"Initialize git here?",
+			`This directory (${cwd}) is not a git repository. Initialize one so the ferment can track branch and commit info?`,
+		)
+		if (!ok) return "declined"
+	}
+
+	try {
+		execSync("git init", { cwd, stdio: ["ignore", "ignore", "ignore"], timeout: 5000 })
+		opts.ui?.notify(`Initialized empty git repository in ${cwd}`)
+		return "initialized"
+	} catch (err) {
+		opts.ui?.notify(`git init failed: ${err instanceof Error ? err.message : String(err)}`)
+		return "init-failed"
+	}
+}
+
+/** True if the user opted into auto-init via env var. */
+export function autoInitFromEnv(): boolean {
+	return process.env.KIMCHI_AUTO_GIT_INIT === "1"
+}

--- a/src/extensions/ferment/tools/lifecycle.ts
+++ b/src/extensions/ferment/tools/lifecycle.ts
@@ -12,6 +12,7 @@ import type { ExtensionAPI } from "@earendil-works/pi-coding-agent"
 import type { Static } from "typebox"
 import type { Command } from "../../../ferment/state-machine.js"
 import { validateFsmTransitionWithFerment } from "../fsm-adapter.js"
+import { autoInitFromEnv, ensureGitRepo } from "../git-init.js"
 import { type PlanReview, computeFermentGrade, judgePlan } from "../judge.js"
 import { appendRefEntry, maybeInjectAutoNudge } from "../nudge.js"
 import { type FermentRuntime, defaultFermentRuntime } from "../runtime.js"
@@ -187,6 +188,10 @@ export function registerLifecycleTools(pi: ExtensionAPI, runtime: FermentRuntime
 		async execute(_, params) {
 			// Creation is special — no existing ferment to transition from.
 			// Storage's create() handles uuid generation and worktree capture.
+			// LLM-driven, so no interactive prompt; opt-in auto-init only.
+			await ensureGitRepo({
+				autoInit: pi.getFlag?.("init-git") === true || autoInitFromEnv(),
+			})
 			const f = runtime.getStorage().create(params.name, params.description)
 			setActiveFerment(pi, runtime, f)
 			appendRefEntry(pi, f.id)

--- a/src/ferment/store.ts
+++ b/src/ferment/store.ts
@@ -106,12 +106,22 @@ export function captureWorktree(cwd?: string): import("./types.js").FermentWorkt
 	let branch: string | undefined
 	let commit: string | undefined
 	try {
-		branch = execSync("git rev-parse --abbrev-ref HEAD", { cwd: path, encoding: "utf-8", timeout: 1000 }).trim()
+		branch = execSync("git rev-parse --abbrev-ref HEAD", {
+			cwd: path,
+			encoding: "utf-8",
+			timeout: 1000,
+			stdio: ["ignore", "pipe", "ignore"],
+		}).trim()
 	} catch {
 		// not a git repo or git not available
 	}
 	try {
-		commit = execSync("git rev-parse HEAD", { cwd: path, encoding: "utf-8", timeout: 1000 }).trim()
+		commit = execSync("git rev-parse HEAD", {
+			cwd: path,
+			encoding: "utf-8",
+			timeout: 1000,
+			stdio: ["ignore", "pipe", "ignore"],
+		}).trim()
 	} catch {
 		// not a git repo or git not available
 	}


### PR DESCRIPTION
 ## Fix: stop leaking `fatal: not a git repository` to stderr; offer to init git when missing

  ### Problem

  When a ferment is created in a directory that isn't a git repository, `captureWorktree()` ran two `git rev-parse` calls inside try/catch but didn't suppress the
   child process's stderr. The JS exception was swallowed correctly, but git's `fatal: not a git repository (or any of the parent directories): .git` still leaked
   to the parent's stderr — twice per ferment creation — even though kimchi handled the missing-repo case internally.

  Reproducible by starting a ferment in any non-repo cwd (e.g. a fresh `~/Git/test` directory). The other call sites in the codebase (`worktree.ts`,
  `phase-evidence.ts`) already use `stdio: ["ignore", "pipe", "ignore"]`; `store.ts` was the outlier.

  ### Changes

  **1. Stop the stderr leak**

  `src/ferment/store.ts` — `captureWorktree()` now passes `stdio: ["ignore", "pipe", "ignore"]` to both `execSync` calls, matching the rest of the codebase. No
  behaviour change beyond silencing the noise.

  **2. Offer to initialize a repo when missing**

  New utility `src/extensions/ferment/git-init.ts` exporting `ensureGitRepo({ ui, autoInit })`:

  | Situation                                  | Behaviour                                                 |
  | ------------------------------------------ | --------------------------------------------------------- |
  | Already a git repo                         | No-op                                                     |
  | Interactive UI (`ui.confirm` available)    | Prompt the user; `git init` on yes, skip on no            |
  | `autoInit: true`                           | Run `git init` without asking                             |
  | Otherwise (non-interactive, no opt-in)     | Skip silently — ferment still works without branch/commit |

  Wired into all four ferment-creation entry points:

  - `commands.ts` — `/ferment add` (interactive path: prompts)
  - `commands.ts` — `/ferment one-shot` (gated on opt-in)
  - `events.ts` — `--ferment-oneshot` bootstrap path (gated on opt-in)
  - `tools/lifecycle.ts` — `create_ferment` tool (gated on opt-in)

  **3. Opt-in auto-init for non-interactive flows**

  Auto-init in scripted/automated contexts is opt-in only, to avoid silently mutating the filesystem when a user runs kimchi in an unexpected directory. Two
  equivalent escape hatches:

  - CLI flag: `--init-git`
  - Env var: `KIMCHI_AUTO_GIT_INIT=1`

  Both are checked via `pi.getFlag?.("init-git") === true || autoInitFromEnv()`.

  ### Design notes

  - **Why not auto-init unconditionally in one-shot mode?** A silent `git init` on every one-shot in a non-repo directory is the kind of surprise users remember —
   and a ferment functions fine without git (the `worktree` field already gracefully holds `undefined` for branch/commit). Explicit opt-in keeps automation
  predictable without losing scriptability.
  - **Why no follow-up empty commit?** `git init` leaves an unborn HEAD, so `git rev-parse HEAD` still fails until the user has a real commit. I chose not to
  paper over that with an `--allow-empty` initial commit — creating a phantom commit in the user's brand-new repo is more invasive than leaving `commit:
  undefined` for one call. `captureWorktree` already handles that path.
  - **Why `pi.getFlag?.(...)` and not `pi.getFlag(...)`?** Optional chaining matches the existing mock surface in the test suite. The flag-reading API isn't
  universally implemented across hosts; defensive read costs nothing.

  ### Test plan

  - [x] `pnpm typecheck` — clean.
  - [x] `pnpm vitest run src/extensions/ferment src/ferment` — 393 / 393 pass.
  - [x] Manual repro: `execSync git rev-parse` in a non-repo cwd with the new `stdio` option no longer prints `fatal: not a git repository` to stderr.
  - [ ] Manual end-to-end: run `/ferment add "x"` in a non-repo dir → confirm prompt appears, init on yes works, decline on no proceeds silently.
  - [ ] Manual end-to-end: run with `--init-git` flag in a non-repo dir → repo initialized without a prompt.
  - [ ] Manual end-to-end: run with `KIMCHI_AUTO_GIT_INIT=1` env → same.
  - [ ] Manual end-to-end: confirm `/ferment one-shot "x"` in non-repo without opt-in proceeds silently (no leaked stderr, no init).

  ### Files changed

  ```
  src/ferment/store.ts                                (stdio fix)
  src/extensions/ferment/git-init.ts                  (new utility)
  src/extensions/ferment/commands.ts                  (wire-in for add + one-shot)
  src/extensions/ferment/events.ts                    (wire-in for --ferment-oneshot, flag registration)
  src/extensions/ferment/tools/lifecycle.ts           (wire-in for create_ferment tool)
  ```

---
### Kimchi Summary
### What changed
Adds automatic `git init` before creating a ferment when the working directory is not already a git repository. Interactive sessions prompt the user; non-interactive flows (one-shot, bootstrap, and LLM-driven tools) only auto-initialize when opted in via the `--init-git` flag or `KIMCHI_AUTO_GIT_INIT=1` environment variable.

### Why
Prevents ferment creation from failing or capturing empty branch/commit metadata when started outside a git repository.

### Key changes
- Added `src/extensions/ferment/git-init.ts` — new `ensureGitRepo()` utility that checks for a `.git` directory, prompts interactively when a UI is available, or runs `git init` when `autoInit` is true; plus `autoInitFromEnv()` to read the `KIMCHI_AUTO_GIT_INIT` toggle.
- Registered `--init-git` boolean flag in `events.ts`.
- Updated `FermentCommandController` in `commands.ts` to call `ensureGitRepo()` before one-shot and interactive ferment creation.
- Updated bootstrap event handler in `events.ts` to call `ensureGitRepo()` with opt-in auto-init.
- Updated `lifecycle.ts` to call `ensureGitRepo()` before LLM-driven ferment creation.
- Hardened `captureWorktree()` in `src/ferment/store.ts` to suppress stderr and safely skip when git is unavailable.

### Impact
- Fully backward compatible; if initialization is declined or fails, ferment creation proceeds without branch/commit tracking.
- Non-interactive contexts never silently initialize a repo unless the user explicitly passes `--init-git` or sets `KIMCHI_AUTO_GIT_INIT=1`.