### PR TITLE
fix(agent-widget): add safety margin to prevent terminal width overflow

### DIFF
--- a/src/extensions/agents/ui/agent-widget.ts
+++ b/src/extensions/agents/ui/agent-widget.ts
@@ -257,7 +257,10 @@ export class AgentWidget {
 
 		const tuiTyped = tui as { terminal: { columns: number } }
 		const w = tuiTyped.terminal.columns
-		const truncate = (line: string) => truncateToWidth(line, w)
+		// Use width - 1 to add a safety margin. The widget lines often operate close to terminal
+		// width boundaries, and visibleWidth() can have off-by-one differences due to Unicode/ANSI
+		// handling. Subtracting 1 ensures we stay safely within the terminal width.
+		const truncate = (line: string) => truncateToWidth(line, w - 1)
 		const headingColor = hasActive ? "accent" : "dim"
 		const headingIcon = hasActive ? "●" : "○"
 		const frame = SPINNER[this.widgetFrame % SPINNER.length]
@@ -289,12 +292,9 @@ export class AgentWidget {
 
 			const activity = bg ? describeActivity(bg.activeTools, bg.responseText) : "thinking…"
 
-			runningLines.push([
-				truncate(
-					`${theme.fg("dim", "├─")} ${theme.fg("accent", frame)} ${theme.bold(name)}${modeTag}  ${theme.fg("muted", a.description)} ${theme.fg("dim", "·")} ${theme.fg("dim", statsText)}`,
-				),
-				truncate(theme.fg("dim", "│  ") + theme.fg("dim", `  ⎿  ${activity}`)),
-			])
+			const treeLine = `${theme.fg("dim", "├─")} ${theme.fg("accent", frame)} ${theme.bold(name)}${modeTag}  ${theme.fg("muted", a.description)} ${theme.fg("dim", "·")} ${theme.fg("dim", statsText)}`
+			const activityLine = theme.fg("dim", "│  ") + theme.fg("dim", `  ⎿  ${activity}`)
+			runningLines.push([truncate(treeLine), truncate(activityLine)])
 		}
 
 		const queuedLine =


### PR DESCRIPTION
## Problem

TUI crashes with "Rendered line exceeds terminal width" when agent status lines approach terminal width boundaries.

## Root Cause

The `AgentWidget` component truncates lines to the full terminal width, but `visibleWidth()` can have off-by-one differences when measuring lines with complex Unicode characters (e.g. spinner characters like ⠸) or ANSI escape codes. This causes the widget to produce lines 1 character too wide, triggering the TUI's strict width validation error.

## Fix

Use `w - 1` instead of `w` when truncating widget lines. This adds a 1-character safety margin that ensures lines always stay within the terminal width, even when `visibleWidth()` has edge-case measurement differences.

## Verification

- TypeScript typecheck: ✅
- biome lint: ✅
- All 1946 tests: ✅

---
### Kimchi Summary
### What changed
Fixes a width overrun bug in the agent widget by adding a one-column safety margin before truncating lines to the terminal width. Also refactors the running agent line formatting for readability.

### Why
Widget lines rendered near the terminal boundary could slightly exceed the available width because `visibleWidth()` calculations for Unicode and ANSI sequences occasionally produce off-by-one results, causing layout glitches.

### Key changes
- `src/extensions/agents/ui/agent-widget.ts`:
  - Changed the `truncate` helper to call `truncateToWidth(line, w - 1)` instead of `truncateToWidth(line, w)`.
  - Extracted the running agent tree and activity strings into `treeLine` and `activityLine` variables before truncation and pushing to `runningLines`.