### PR TITLE
fix(agents): prevent line-overflow crash when agent widget is visible

### DIFF
--- a/src/components/tool-block.test.ts
+++ b/src/components/tool-block.test.ts
@@ -1,0 +1,75 @@
+import { visibleWidth } from "@earendil-works/pi-tui"
+import { describe, expect, it } from "vitest"
+import { buildAlignedLine } from "./tool-block.js"
+
+describe("buildAlignedLine", () => {
+	it("returns left as-is when right is empty and left fits", () => {
+		const out = buildAlignedLine("hello", "", 10)
+		expect(out).toBe("hello")
+	})
+
+	it("truncates left when right is empty and left exceeds width", () => {
+		const out = buildAlignedLine("hello world", "", 5)
+		expect(visibleWidth(out)).toBeLessThanOrEqual(5)
+	})
+
+	it("right exactly fills width: returns right alone", () => {
+		const right = "0123456789"
+		const out = buildAlignedLine("left", right, right.length)
+		expect(visibleWidth(out)).toBeLessThanOrEqual(right.length)
+	})
+
+	it("right wider than width: result still fits", () => {
+		const out = buildAlignedLine("left", "0123456789", 5)
+		expect(visibleWidth(out)).toBeLessThanOrEqual(5)
+	})
+
+	it("leftW + rightW + 2 == width: natural fit", () => {
+		const left = "abc"
+		const right = "xyz"
+		const out = buildAlignedLine(left, right, 8) // 3 + 2 + 3
+		expect(out).toBe("abc  xyz")
+		expect(visibleWidth(out)).toBe(8)
+	})
+
+	it("leftW + rightW + 2 == width + 1: truncates without overflow", () => {
+		const left = "abcd"
+		const right = "xyz"
+		const out = buildAlignedLine(left, right, 8) // 4 + 2 + 3 = 9 > 8
+		expect(visibleWidth(out)).toBeLessThanOrEqual(8)
+		expect(out.endsWith("xyz")).toBe(true)
+	})
+
+	it("leftW + rightW + 2 == width + 2: truncates without overflow", () => {
+		const left = "abcde"
+		const right = "xyz"
+		const out = buildAlignedLine(left, right, 8) // 5 + 2 + 3 = 10 > 8
+		expect(visibleWidth(out)).toBeLessThanOrEqual(8)
+		expect(out.endsWith("xyz")).toBe(true)
+	})
+
+	it("available <= 0 (right takes almost full width): drops left, no overflow", () => {
+		const left = "leftcontent"
+		const right = "0123456" // width 7
+		const out = buildAlignedLine(left, right, 8) // available = 8 - 7 - 2 = -1
+		expect(visibleWidth(out)).toBeLessThanOrEqual(8)
+		expect(out.endsWith(right)).toBe(true)
+	})
+
+	it("ansi-wrapped inputs: visible width respected", () => {
+		const left = `\x1b[31m${"description with color".padEnd(40, " ")}\x1b[0m`
+		const right = "\x1b[2m99.9s\x1b[0m" // visible width 5
+		const out = buildAlignedLine(left, right, 30)
+		expect(visibleWidth(out)).toBeLessThanOrEqual(30)
+	})
+
+	it("width <= 0: returns empty", () => {
+		expect(buildAlignedLine("left", "right", 0)).toBe("")
+		expect(buildAlignedLine("left", "right", -1)).toBe("")
+	})
+
+	it("matches exact width when natural fit applies", () => {
+		const out = buildAlignedLine("hi", "bye", 10) // 2 + 5 + 3 = 10
+		expect(visibleWidth(out)).toBe(10)
+	})
+})

--- a/src/components/tool-block.ts
+++ b/src/components/tool-block.ts
@@ -2,19 +2,27 @@ import type { Theme } from "@earendil-works/pi-coding-agent"
 import { Container, truncateToWidth, visibleWidth } from "@earendil-works/pi-tui"
 import { formatDuration } from "../extensions/format.js"
 
-function buildAlignedLine(left: string, right: string, width: number): string {
+const MIN_GAP = 2
+
+export function buildAlignedLine(left: string, right: string, width: number): string {
+	if (width <= 0) return ""
 	const leftW = visibleWidth(left)
-	if (!right) {
-		if (leftW > width) return truncateToWidth(left, width)
-		return left
-	}
+	if (!right) return leftW > width ? truncateToWidth(left, width) : left
+
 	const rightW = visibleWidth(right)
-	const available = width - rightW - 2
+	if (rightW >= width) return truncateToWidth(right, width)
+
+	const available = width - rightW - MIN_GAP
 	if (leftW > available) {
-		const truncLeft = truncateToWidth(left, Math.max(1, available))
-		return `${truncLeft}  ${right}`
+		if (available <= 0) {
+			const pad = width - rightW
+			return " ".repeat(Math.max(0, pad)) + right
+		}
+		const truncLeft = truncateToWidth(left, available)
+		const gap = width - visibleWidth(truncLeft) - rightW
+		return truncLeft + " ".repeat(Math.max(0, gap)) + right
 	}
-	const gap = Math.max(2, width - leftW - rightW)
+	const gap = width - leftW - rightW
 	return left + " ".repeat(gap) + right
 }
 

--- a/src/extensions/agents/ui/agent-widget.ts
+++ b/src/extensions/agents/ui/agent-widget.ts
@@ -33,7 +33,7 @@ export type UICtx = {
 	setStatus(key: string, text: string | undefined): void
 	setWidget(
 		key: string,
-		content: undefined | ((tui: unknown, theme: Theme) => { render(): string[]; invalidate(): void }),
+		content: undefined | ((tui: unknown, theme: Theme) => { render(width: number): string[]; invalidate(): void }),
 		options?: { placement?: "aboveEditor" | "belowEditor" },
 	): void
 }
@@ -241,7 +241,7 @@ export class AgentWidget {
 		return `${icon} ${theme.fg("dim", name)}${modeTag}  ${theme.fg("dim", a.description)} ${theme.fg("dim", "·")} ${theme.fg("dim", parts.join(" · "))}${statusText}`
 	}
 
-	private renderWidget(tui: unknown, theme: Theme): string[] {
+	private renderWidget(theme: Theme, width: number): string[] {
 		const allAgents = this.manager.listAgents()
 		const running = allAgents.filter((a) => a.status === "running")
 		const queued = allAgents.filter((a) => a.status === "queued")
@@ -255,9 +255,7 @@ export class AgentWidget {
 
 		if (!hasActive && !hasFinished) return []
 
-		const tuiTyped = tui as { terminal: { columns: number } }
-		const w = tuiTyped.terminal.columns
-		const truncate = (line: string) => truncateToWidth(line, w)
+		const truncate = (line: string) => truncateToWidth(line, width)
 		const headingColor = hasActive ? "accent" : "dim"
 		const headingIcon = hasActive ? "●" : "○"
 		const frame = SPINNER[this.widgetFrame % SPINNER.length]
@@ -423,7 +421,7 @@ export class AgentWidget {
 				(tui, theme) => {
 					this.tui = tui
 					return {
-						render: () => this.renderWidget(tui, theme),
+						render: (width: number) => this.renderWidget(theme, width),
 						invalidate: () => {
 							this.widgetRegistered = false
 							this.tui = undefined

--- a/src/extensions/subagent.ts
+++ b/src/extensions/subagent.ts
@@ -19,6 +19,7 @@ import { findExistingFile, resolveUserPath, stripAtPrefix } from "../fs-paths.js
 import { formatCount, formatDuration } from "./format.js"
 import { filterThinkingForDisplay } from "./hide-thinking.js"
 import { type SpinnerState, clearSpinner, spinnerFrame, tickSpinner } from "./spinner.js"
+import { HORIZONTAL_PADDING } from "./ui.js"
 
 const PROMPT_MAX_LENGTH = 60
 const FOOTER_STATUS_KEY = "subagent-sessions"
@@ -996,7 +997,7 @@ export default function (pi: ExtensionAPI) {
 				const toolCall = state.lastToolCall
 				let partialDisplayText: string
 				let displayStyle: "dim" | "toolOutput"
-				const terminalWidth = process.stdout.columns ?? 80
+				const terminalWidth = Math.max(1, (process.stdout.columns ?? 80) - HORIZONTAL_PADDING * 2)
 				if (toolCall) {
 					const truncated = truncateToWidth(`> ${toolCall}`, terminalWidth * 5)
 					const toolCallVisualLines = wrapTextWithAnsi(truncated, terminalWidth)

--- a/src/extensions/ui.ts
+++ b/src/extensions/ui.ts
@@ -36,7 +36,7 @@ function getEnabledModelIds(): Set<string> | null {
 	return null
 }
 
-const HORIZONTAL_PADDING = 2
+export const HORIZONTAL_PADDING = 2
 
 // Strip OSC 133 shell-integration marks emitted by pi-mono around each message.
 // iTerm2 renders a visible blue triangle at each mark, which is noisy in the TUI.


### PR DESCRIPTION


---
### Kimchi Summary
### What changed
Fixes broken text truncation and width calculations in the TUI agent widget and tool block to prevent layout overflow. The `buildAlignedLine` helper now correctly handles narrow terminals, wide right-side content, and ANSI escape codes, while the agent widget receives terminal width explicitly rather than accessing TUI internals.

### Why
Tool block lines and agent widget content could exceed the available terminal width when right-aligned content was wider than the terminal, padding was ignored, or edge cases like zero-width terminals occurred, resulting in broken UI rendering.

### Key changes
- `src/components/tool-block.ts`: Fixed `buildAlignedLine` to properly truncate when `right` exceeds width, handle `width <= 0`, calculate gaps exactly, and avoid visible overflow. Extracted `MIN_GAP` constant and exported the function.
- `src/components/tool-block.test.ts`: Added comprehensive unit tests for `buildAlignedLine` covering truncation, ANSI-wrapped inputs, natural fit, and boundary conditions.
- `src/extensions/agents/ui/agent-widget.ts`: Updated `renderWidget` to accept explicit `width` instead of reading `tui.terminal.columns`. Updated `UICtx.setWidget` callback type so `render` receives `width`.
- `src/extensions/subagent.ts`: Adjusted `terminalWidth` to subtract `HORIZONTAL_PADDING * 2`, preventing tool output from exceeding the padded content area.
- `src/extensions/ui.ts`: Exported `HORIZONTAL_PADDING` constant for reuse.

### Impact
- Breaking change for `UICtx.setWidget` consumers: the `render` callback now receives a required `width: number` argument instead of reading it from the TUI object.
- `buildAlignedLine` is now a public export.