### PR TITLE
LLM-1638: Extend session audit to capture routing & orchestration metrics

### DIFF
--- a/benchmark/audit-session/README.md
+++ b/benchmark/audit-session/README.md
@@ -131,8 +131,87 @@ The report contains phase-by-phase cost breakdown, grade summary, and actionable
 3. Substitutes the selected session path into the prompt template
 4. Launches the chosen runner (kimchi or claude-code) in interactive mode with the prompt
 
+## Metrics Captured
+
+The audit evaluates 13 dimensions of session quality. Sections 1–6 are graded; 7–13 produce structural metrics.
+
+| # | Metric | Description |
+|---|--------|-------------|
+| 1 | Phase Discipline | Logical phase ordering, timely transitions, phase-work alignment |
+| 2 | Architecture & Design | Decision timing, module boundaries, project conventions |
+| 3 | Code Quality | Lint results, naming, duplication, over-engineering |
+| 4 | Testing Strategy | Coverage, negative paths, test organization patterns |
+| 5 | Phase-Model Alignment | Expensive models for complex phases, cheap for routine work |
+| 6 | Cost Efficiency | Per-phase cost breakdown, counterfactual analysis |
+| 7 | Per-Turn Model Attribution | Active model per turn, provider, switch boundaries |
+| 8 | Routing Decision Rationale | What triggered each model switch (phase, tool call, explicit text) |
+| 9 | Switching Latency | ms between model_change and first assistant message per model |
+| 10 | Subagent Lifecycle | Loops, budget usage, context completeness per subagent invocation |
+| 11 | Token Consumption per Task Class | Tokens/cost per class (explore, plan, build, review, research, orchestration) |
+| 12 | Cost per Completed Task | Cost of each task block from start to terminal state |
+| 13 | OSS vs Non-OSS Utilization | Token-based and cost-based ratio of OSS model usage |
+
+## Structured Output
+
+Every audit run produces two files:
+
+| File | Description |
+|------|-------------|
+| `.kimchi/audits/{sessionId}-{runner}-{model}-AUDIT.md` | Human-readable graded report |
+| `.kimchi/audits/{sessionId}-{runner}-{model}-AUDIT.json` | Machine-readable sidecar for automated comparison |
+
+The JSON sidecar conforms to schema version `1.0.0` with these top-level keys:
+
+```json
+{
+  "schemaVersion": "1.0.0",
+  "sessionId": "<session-id>",
+  "timestamp": "<iso-timestamp>",
+  "modelsUsed": [{ "modelId", "provider", "turns", "tokens": {...}, "cost", "isOss" }],
+  "switches": [{ "from", "to", "timestamp", "latencyMs", "rationale" }],
+  "subagents": [{ "delegateModel", "budget", "looped", "completed" }],
+  "taskClasses": { "explore": { "tokens": {...}, "cost" }, ... },
+  "completedTasks": [{ "label", "turnRange", "cost", "terminalState" }],
+  "ossRatio": { "byTokens": 0.0, "byCost": 0.0 },
+  "aggregates": { "totalTokens", "totalCost", "totalTurns", "totalSwitches", "totalSubagents", "errors" }
+}
+```
+
+`jq` is recommended (but optional) for validation — if `jq` is present, the script validates the JSON before writing the sidecar.
+
+## Usage for Automated Comparison
+
+Compare two audit runs with `jq`:
+
+```sh
+# Compare total cost between two sessions
+jq -s '.[0].aggregates.totalCost as $a | .[1].aggregates.totalCost as $b |
+  "Session 1: $\($a)" , "Session 2: $\($b)" , "Delta: $\($b - $a)"' \
+  .kimchi/audits/session-AUDIT.json .kimchi/audits/session-BUDIT.json
+
+# Compare OSS ratio between two runs
+jq -s '"Run 1 OSS cost ratio: \(.[0].ossRatio.byCost * 100 | . * 100 | floor / 100)%",
+       "Run 2 OSS cost ratio: \(.[1].ossRatio.byCost * 100 | . * 100 | floor / 100)%"' \
+  .kimchi/audits/session-AUDIT.json .kimchi/audits/session-BUDIT.json
+
+# Find which model consumed the most in each session
+jq -s 'map(.modelsUsed | max_by(.cost)) | .
+  | "Session 1 most expensive: \(.[0].modelId) ($\([0].cost))",
+       "Session 2 most expensive: \(.[1].modelId) ($\([1].cost))"' \
+  .kimchi/audits/session-AUDIT.json .kimchi/audits/session-BUDIT.json
+
+# Compare subagent loop rates
+jq -s 'map(.subagents | map(.looped) | add / length) | .
+  | "Run 1 loop rate: \(.[0] * 100 | . * 10 | floor / 10)%",
+       "Run 2 loop rate: \(.[1] * 100 | . * 10 | floor / 10)%"' \
+  .kimchi/audits/session-AUDIT.json .kimchi/audits/session-BUDIT.json
+
+# Aggregate cost across many runs (for batch comparison)
+jq -s 'map(.aggregates.totalCost) | add' .kimchi/audits/*-AUDIT.json
+```
+
 ## Prerequisites
 
 - `kimchi` and/or `claude` CLI available on PATH
-- `jq` recommended (used for session parsing; falls back to grep)
+- `jq` recommended (used for session parsing and JSON sidecar validation; falls back to grep)
 - Session JSONL files (from `~/.config/kimchi/harness/sessions/` or `benchmark/manual/`)

--- a/benchmark/audit-session/audit-session-prompt.md
+++ b/benchmark/audit-session/audit-session-prompt.md
@@ -303,3 +303,237 @@ Use this format:
 ```
 
 After writing the artifact, say: "Audit complete for session {sessionId}. Report at .kimchi/audits/{auditFilename}"
+
+---
+
+### Step 4: Per-Turn Model Attribution
+
+Iterate every assistant turn (type: "message", role: "assistant"). Determine active model per turn by walking `model_change` entries in chronological order. The first assistant message after a `model_change` marks the start of that model's turns.
+
+Output a table:
+
+| Turn | Model | Provider | Duration (since previous turn) | Notes |
+|------|-------|----------|-------------------------------|-------|
+| 1 | model-id | provider | Xs | first turn |
+| 2 | model-id | provider | Xs | |
+| ... | | | | |
+
+For the first turn of each model, annotate that this is a **switch boundary**.
+
+---
+
+### Step 5: Routing Decision Rationale
+
+When a new model appears (model_change), look backward for the preceding assistant message that contains clues about why the switch happened (e.g. tool calls `Agent`/`set_phase`, deployment rules in system prompts, explicit orchestration text).
+
+Record:
+
+| Switch # | From | To | Trigger (phase, tool call, or explicit text) | Evidence (message ID or turn #) |
+|----------|------|----|----------------------------------------------|--------------------------------|
+| 1 | model-a | model-b | phase: plan | turn #4 |
+| 2 | model-b | model-c | Agent delegation to kimi-k2.6 | turn #12 |
+
+If no evidence is found, note "inferred from session bootstrap".
+
+---
+
+### Step 6: Switching Latency
+
+Measure `switch_latency_ms` = timestamp(first assistant message after model_change) - timestamp(model_change entry).
+
+Aggregate across all switches:
+
+| Metric | Value |
+|--------|-------|
+| Mean latency | Xms |
+| Max latency | Xms |
+| Min latency | Xms |
+| Total switches | N |
+
+Per-model-pair breakdown:
+
+| From | To | Count | Mean Latency | Max Latency |
+|------|----|-------|--------------|-------------|
+| model-a | model-b | 2 | Xms | Xms |
+| model-b | model-c | 1 | Xms | Xms |
+
+---
+
+### Step 7: Subagent Lifecycle Metrics
+
+Search for all `Agent` tool calls within assistant turns. For each, capture:
+- The `turnIndex` when invoked
+- The model delegated to (from tool arguments: `model` field)
+- The `tokenBudget` requested
+- Whether a `get_subagent_result` or `steer_subagent` appears later in the session (indicating lifecycle completion or intervention)
+
+Count subagent loops: # of `Agent` calls that precede a `steer_subagent` for the same subagent.
+
+Output table:
+
+| Subagent # | Turn Invoked | Delegate Model | Budget | Looped? | Completed? | Context-Complete? |
+|------------|-------------|----------------|--------|---------|------------|-------------------|
+| 1 | 4 | kimi-k2.6 | 150000 | No | Yes | Yes |
+| 2 | 12 | minimax-m2.7 | 200000 | Yes | Yes | No |
+
+Definitions:
+- **Looped**: a `steer_subagent` was sent to this subagent before it completed
+- **Completed**: a `get_subagent_result` was received for this subagent
+- **Context-Complete**: no `steer_subagent` was needed (subagent self-completed)
+
+---
+
+### Step 8: Token Consumption per Task Class
+
+Map each assistant turn to a **task class** based on the dominant activity in that turn:
+
+| Task Class | Detection heuristics |
+|------------|---------------------|
+| `explore` | `read`, `grep`, `find`, `ls` tool calls dominate |
+| `plan` | `edit`/`write` of `.md` spec files, `set_phase("plan")`, or explicit planning tool calls |
+| `build` | `edit`, `write`, `bash` (compilation / test execution) dominates |
+| `review` | `lsp_diagnostics`, review comments, `set_phase("review")` |
+| `research` | `web_search`, `web_fetch` calls |
+| `orchestration` | `Agent`, `set_phase`, `start_step`, `complete_step`, `get_subagent_result` |
+
+If a turn has mixed tools, classify by the most frequent tool family. If tie, prefer: orchestration > plan > build > review > research > explore.
+
+Aggregate token usage per class across all turns and per-model:
+
+| Task Class | Turns | Input | Output | CacheRead | CacheWrite | Total Tokens | Cost |
+|------------|-------|-------|--------|-----------|------------|--------------|------|
+| explore | N | X | X | X | X | X | $X |
+| plan | N | X | X | X | X | X | $X |
+| build | N | X | X | X | X | X | $X |
+| review | N | X | X | X | X | X | $X |
+| research | N | X | X | X | X | X | $X |
+| orchestration | N | X | X | X | X | X | $X |
+| **TOTAL** | N | X | X | X | X | X | $X |
+
+---
+
+### Step 9: Cost per Completed Task
+
+A "task" is defined as a contiguous block of turns bounded by:
+- A phase switch (set_phase to a different phase), OR
+- A terminal outcome (all tests passing, human-explicit completion, or branch commit/push)
+
+Compute cost per task = sum of `usage.cost.total` for all turns within the block.
+
+Only count tasks that reach a terminal state (tests pass, user confirms done, branch commit/push, etc.).
+
+Output:
+
+| Task # | Label | Phase | Turn Range | Cost | Terminal State |
+|--------|-------|-------|------------|------|----------------|
+| 1 | fix-auth-bug | build | 3–7 | $X.XX | tests pass |
+| 2 | add-tests | build | 8–14 | $X.XX | PR created |
+
+If a task does not reach a terminal state, note "incomplete" and exclude from efficiency analysis.
+
+---
+
+### Step 10: OSS vs Non-OSS Utilization
+
+Classify each model as OSS or non-OSS using this mapping:
+
+| Model | Provider | OSS? |
+|-------|----------|------|
+| minimax-m2.5 | MiniMax | No |
+| minimax-m2.7 | MiniMax | No |
+| qwen3-coder-next-fp8 | Qwen | Yes |
+| kimi-k2.5 | Kimi | No |
+| kimi-k2.6 | Kimi | No |
+| nemotron-3-super-120b | NVIDIA | Yes |
+| claude-opus-4-7 | Anthropic | No |
+| claude-sonnet-4-7 | Anthropic | No |
+
+If a model is not in this table, classify it based on provider (Qwen/NVIDIA = OSS; others = non-OSS) unless you have specific knowledge.
+
+Compute:
+- **Token-based ratio**: (tokens sent to OSS models) / (total tokens)
+- **Cost-based ratio**: (cost for OSS models) / (total cost)
+
+Report both. Provide per-model breakdown:
+
+| Model | OSS? | Input Tokens | Output Tokens | Total Tokens | Cost |
+|-------|------|-------------|---------------|--------------|------|
+| kimi-k2.6 | No | X | X | X | $X |
+| qwen3-coder-next-fp8 | Yes | X | X | X | $X |
+
+Summary:
+- OSS token ratio: X.X%
+- OSS cost ratio: X.X%
+
+---
+
+### Step 11: Write the JSON Sidecar
+
+Append the following fenced JSON block to the audit report (after the markdown content). This is the machine-readable sidecar for automated comparison between experiment runs.
+
+After the markdown content and before the "Audit complete" message, append:
+
+\`\`\`json
+{
+  "schemaVersion": "1.0.0",
+  "sessionId": "{sessionId}",
+  "timestamp": "<session_start_timestamp>",
+  "modelsUsed": [
+    {
+      "modelId": "<model-id>",
+      "provider": "<provider>",
+      "turns": <count>,
+      "tokens": { "input": <n>, "output": <n>, "cacheRead": <n>, "cacheWrite": <n> },
+      "cost": <total-cost>,
+      "isOss": <true|false>
+    }
+  ],
+  "switches": [
+    {
+      "from": "<model-a>",
+      "to": "<model-b>",
+      "timestamp": "<iso-timestamp>",
+      "latencyMs": <ms>,
+      "rationale": "<trigger description>"
+    }
+  ],
+  "subagents": [
+    {
+      "delegateModel": "<model>",
+      "budget": <token-budget>,
+      "looped": <true|false>,
+      "completed": <true|false>
+    }
+  ],
+  "taskClasses": {
+    "explore": { "tokens": { "input": 0, "output": 0, "cacheRead": 0, "cacheWrite": 0 }, "cost": 0 },
+    "plan": { "tokens": { "input": 0, "output": 0, "cacheRead": 0, "cacheWrite": 0 }, "cost": 0 },
+    "build": { "tokens": { "input": 0, "output": 0, "cacheRead": 0, "cacheWrite": 0 }, "cost": 0 },
+    "review": { "tokens": { "input": 0, "output": 0, "cacheRead": 0, "cacheWrite": 0 }, "cost": 0 },
+    "research": { "tokens": { "input": 0, "output": 0, "cacheRead": 0, "cacheWrite": 0 }, "cost": 0 },
+    "orchestration": { "tokens": { "input": 0, "output": 0, "cacheRead": 0, "cacheWrite": 0 }, "cost": 0 }
+  },
+  "completedTasks": [
+    {
+      "label": "<task-label>",
+      "turnRange": [<start>, <end>],
+      "cost": <cost>,
+      "terminalState": "<state>"
+    }
+  ],
+  "ossRatio": {
+    "byTokens": 0.0,
+    "byCost": 0.0
+  },
+  "aggregates": {
+    "totalTokens": 0,
+    "totalCost": 0,
+    "totalTurns": 0,
+    "totalSwitches": 0,
+    "totalSubagents": 0,
+    "errors": 0
+  }
+}
+\`\`\`
+
+After writing the artifact (both markdown and JSON), say: "Audit complete for session {sessionId}. Report at .kimchi/audits/{auditFilename}"

--- a/benchmark/audit-session/audit-session.sh
+++ b/benchmark/audit-session/audit-session.sh
@@ -219,18 +219,84 @@ sed \
     -e "s|{auditModel}|${EFFECTIVE_MODEL}|g" \
     "$PROMPT_FILE" > "$TMPFILE"
 
-case "$RUNNER" in
-    kimchi)
-        exec kimchi \
-            --model "$EFFECTIVE_MODEL" \
-            --yolo \
-            "@${TMPFILE}"
-        ;;
-    claude)
-        PROMPT_CONTENT="$(cat "$TMPFILE")"
-        exec claude \
-            --model "$EFFECTIVE_MODEL" \
-            --dangerously-skip-permissions \
-            "$PROMPT_CONTENT"
-        ;;
-esac
+audit_report_content=""
+
+run_audit_agent() {
+    local runner="$1"
+    local model="$2"
+    local prompt_file="$3"
+
+    local audit_content
+    case "$runner" in
+        kimchi)
+            audit_content="$(kimchi \
+                --model "$model" \
+                --yolo \
+                "@${prompt_file}" 2>&1)"
+            ;;
+        claude)
+            audit_content="$(claude \
+                --model "$model" \
+                --dangerously-skip-permissions \
+                "$(cat "$prompt_file")" 2>&1)"
+            ;;
+        *)
+            echo "Unknown runner: $runner" >&2
+            return 1
+            ;;
+    esac
+    echo "$audit_content"
+}
+
+extract_json_sidecar() {
+    local audit_file="$1"
+    local sidecar_file="${audit_file%.md}-AUDIT.json"
+
+    if [[ ! -f "$audit_file" ]]; then
+        echo "Audit file not found: $audit_file" >&2
+        return 1
+    fi
+
+    local json_content
+    json_content="$(grep -A 200 '^```json' "$audit_file" 2>/dev/null \
+        | grep -v '^```' \
+        | grep -v '^```json' \
+        | sed '/^[[:space:]]*$/d' \
+        | head -c 50000)"
+
+    if [[ -z "$json_content" ]]; then
+        echo "No JSON appendix found in audit report" >&2
+        return 1
+    fi
+
+    echo "$json_content" > "$sidecar_file"
+
+    if command -v jq &>/dev/null; then
+        if jq empty "$sidecar_file" 2>/dev/null; then
+            echo "JSON sidecar written: $sidecar_file (validated)"
+        else
+            echo "JSON sidecar written but may be malformed: $sidecar_file" >&2
+        fi
+    else
+        echo "JSON sidecar written (jq not available for validation): $sidecar_file"
+    fi
+
+    echo "$sidecar_file"
+}
+
+echo "Running audit agent ($RUNNER, $EFFECTIVE_MODEL)..."
+echo ""
+
+audit_report_content="$(run_audit_agent "$RUNNER" "$EFFECTIVE_MODEL" "$TMPFILE")"
+
+mkdir -p "$(dirname ".kimchi/audits/$AUDIT_FILENAME")"
+echo "$audit_report_content" > ".kimchi/audits/$AUDIT_FILENAME"
+
+echo ""
+if [[ -s ".kimchi/audits/$AUDIT_FILENAME" ]]; then
+    echo "Audit report written: .kimchi/audits/$AUDIT_FILENAME"
+    sidecar=$(extract_json_sidecar ".kimchi/audits/$AUDIT_FILENAME")
+    echo "JSON sidecar written: $sidecar"
+else
+    echo "Warning: audit report is empty or was not written" >&2
+fi

--- a/benchmark/audit-session/audit-session.sh
+++ b/benchmark/audit-session/audit-session.sh
@@ -280,27 +280,18 @@ extract_json_sidecar() {
     printf '%s\n' "$sidecar_file"
 }
 
-AUDIT_TMP="$(mktemp /tmp/audit-report-XXXXXX)"
-trap 'rm -f "$TMPFILE" "$AUDIT_TMP"' EXIT
-
 echo "Running audit agent ($RUNNER, $EFFECTIVE_MODEL)..."
 echo ""
 
-# Stream output live to stdout and simultaneously capture to a temp file.
-run_audit_agent "$RUNNER" "$EFFECTIVE_MODEL" "$TMPFILE" | tee "$AUDIT_TMP"
-
-# Read the captured report for post-processing.
-audit_report_content="$(cat "$AUDIT_TMP")"
-rm -f "$AUDIT_TMP"
-trap 'rm -f "$TMPFILE"' EXIT
-
-mkdir -p "$(dirname ".kimchi/audits/$AUDIT_FILENAME")"
-printf '%s\n' "$audit_report_content" > ".kimchi/audits/$AUDIT_FILENAME"
+# Run agent interactively (no pipe — preserves TTY so the harness TUI uses the
+# full terminal width instead of falling back to the default 80 columns).
+run_audit_agent "$RUNNER" "$EFFECTIVE_MODEL" "$TMPFILE"
 
 echo ""
-if [[ -s ".kimchi/audits/$AUDIT_FILENAME" ]]; then
-    echo "Audit report written: .kimchi/audits/$AUDIT_FILENAME"
-    sidecar=$(extract_json_sidecar ".kimchi/audits/$AUDIT_FILENAME")
+audit_file=".kimchi/audits/$AUDIT_FILENAME"
+if [[ -s "$audit_file" ]]; then
+    echo "Audit report written: $audit_file"
+    sidecar=$(extract_json_sidecar "$audit_file")
     echo "JSON sidecar written: $sidecar"
 else
     echo "Warning: audit report is empty or was not written" >&2

--- a/benchmark/audit-session/audit-session.sh
+++ b/benchmark/audit-session/audit-session.sh
@@ -219,35 +219,28 @@ sed \
     -e "s|{auditModel}|${EFFECTIVE_MODEL}|g" \
     "$PROMPT_FILE" > "$TMPFILE"
 
-audit_report_content=""
-
+# Runs the audit harness. Output goes directly to stdout so the user sees live progress.
 run_audit_agent() {
     local runner="$1"
     local model="$2"
     local prompt_file="$3"
 
-    local audit_content
     case "$runner" in
         kimchi)
-            audit_content="$(kimchi \
-                --model "$model" \
-                --yolo \
-                "@${prompt_file}" 2>&1)"
+            kimchi --model "$model" --yolo "@${prompt_file}"
             ;;
         claude)
-            audit_content="$(claude \
-                --model "$model" \
-                --dangerously-skip-permissions \
-                "$(cat "$prompt_file")" 2>&1)"
+            claude --model "$model" --dangerously-skip-permissions "$(cat "$prompt_file")"
             ;;
         *)
             echo "Unknown runner: $runner" >&2
             return 1
             ;;
     esac
-    echo "$audit_content"
 }
 
+# Extract the last fenced JSON block from the markdown report and write a sidecar file.
+# Only the sidecar file path is printed to stdout; diagnostics go to stderr.
 extract_json_sidecar() {
     local audit_file="$1"
     local sidecar_file="${audit_file%.md}-AUDIT.json"
@@ -257,40 +250,52 @@ extract_json_sidecar() {
         return 1
     fi
 
+    # Extract the *last* ```json … ``` fenced block, strip the fence lines, and
+    # remove trailing whitespace so jq never sees a stray backslash before EOF.
     local json_content
-    json_content="$(grep -A 200 '^```json' "$audit_file" 2>/dev/null \
-        | grep -v '^```' \
-        | grep -v '^```json' \
-        | sed '/^[[:space:]]*$/d' \
-        | head -c 50000)"
+    json_content="$(awk '
+        /^```json$/     { buf=""; in_block=1; next }
+        in_block && /^```$/ { in_block=0 }
+        in_block        { buf = buf $0 "\n" }
+        END             { printf "%s", buf }
+    ' "$audit_file" | sed -e 's/[[:space:]]*$//')"
 
     if [[ -z "$json_content" ]]; then
         echo "No JSON appendix found in audit report" >&2
         return 1
     fi
 
-    echo "$json_content" > "$sidecar_file"
+    printf '%s\n' "$json_content" > "$sidecar_file"
 
     if command -v jq &>/dev/null; then
         if jq empty "$sidecar_file" 2>/dev/null; then
-            echo "JSON sidecar written: $sidecar_file (validated)"
+            echo "JSON sidecar written: $sidecar_file (validated)" >&2
         else
             echo "JSON sidecar written but may be malformed: $sidecar_file" >&2
         fi
     else
-        echo "JSON sidecar written (jq not available for validation): $sidecar_file"
+        echo "JSON sidecar written (jq not available for validation): $sidecar_file" >&2
     fi
 
-    echo "$sidecar_file"
+    printf '%s\n' "$sidecar_file"
 }
+
+AUDIT_TMP="$(mktemp /tmp/audit-report-XXXXXX)"
+trap 'rm -f "$TMPFILE" "$AUDIT_TMP"' EXIT
 
 echo "Running audit agent ($RUNNER, $EFFECTIVE_MODEL)..."
 echo ""
 
-audit_report_content="$(run_audit_agent "$RUNNER" "$EFFECTIVE_MODEL" "$TMPFILE")"
+# Stream output live to stdout and simultaneously capture to a temp file.
+run_audit_agent "$RUNNER" "$EFFECTIVE_MODEL" "$TMPFILE" | tee "$AUDIT_TMP"
+
+# Read the captured report for post-processing.
+audit_report_content="$(cat "$AUDIT_TMP")"
+rm -f "$AUDIT_TMP"
+trap 'rm -f "$TMPFILE"' EXIT
 
 mkdir -p "$(dirname ".kimchi/audits/$AUDIT_FILENAME")"
-echo "$audit_report_content" > ".kimchi/audits/$AUDIT_FILENAME"
+printf '%s\n' "$audit_report_content" > ".kimchi/audits/$AUDIT_FILENAME"
 
 echo ""
 if [[ -s ".kimchi/audits/$AUDIT_FILENAME" ]]; then

--- a/benchmark/manual/run-evaluation.sh
+++ b/benchmark/manual/run-evaluation.sh
@@ -144,13 +144,20 @@ done
 # --- Step 5: Run audits with Claude Opus 4.7 in separate iTerm2 tabs ---
 echo "=== Spawning iTerm2 tabs for audits ==="
 
-declare -A AUDIT_OUTPUT_FILES
+# Build expected output paths that match audit-session.sh naming.
+# audit-session.sh writes: <sessionId>-<runner>-<model_slug>-AUDIT.md
+# and its JSON sidecar:   <sessionId>-<runner>-<model_slug>-AUDIT.json
+declare -A AUDIT_MD_FILES
+declare -A AUDIT_JSON_FILES
 for task in "${TASKS[@]}"; do
-  # Compute the expected audit output path from the session JSONL filename
   jsonl_basename=$(basename "${JSONL_FILES["$task"]}")
-  audit_slug=$(echo "$task" | tr ' ' '-' | tr '_' '-')
-  audit_name="audit-${audit_slug}--${jsonl_basename%.jsonl}"
-  AUDIT_OUTPUT_FILES["$task"]="${REPO_ROOT}/.kimchi/audits/${audit_name}.html"
+  session_id="${jsonl_basename%.jsonl}"
+  audit_runner="kimchi"
+  audit_model="kimchi-dev/claude-opus-4-7"
+  model_slug="$(echo "$audit_model" | sed 's|.*/||' | tr '[:upper:]' '[:lower:]')"
+  audit_name="${session_id}-${audit_runner}-${model_slug}-AUDIT"
+  AUDIT_MD_FILES["$task"]="${REPO_ROOT}/.kimchi/audits/${audit_name}.md"
+  AUDIT_JSON_FILES["$task"]="${REPO_ROOT}/.kimchi/audits/${audit_name}.json"
 done
 
 for task in "${TASKS[@]}"; do
@@ -162,7 +169,7 @@ tell application "iTerm2"
     set auditTab to (create tab with default profile)
     tell auditTab
       tell current session
-        write text "$audit_cmd_escaped"
+        write text "${audit_cmd_escaped}"
       end tell
     end tell
   end tell
@@ -180,8 +187,13 @@ for ((i = 1; i <= 120; i++)); do
   echo "--- Audit poll $i/120 ---"
   all_done=true
   for task in "${TASKS[@]}"; do
-    if [[ -f "${AUDIT_OUTPUT_FILES["$task"]}" ]]; then
-      echo "  ${task}: done (${AUDIT_OUTPUT_FILES["$task"]})"
+    md_file="${AUDIT_MD_FILES["$task"]}"
+    json_file="${AUDIT_JSON_FILES["$task"]}"
+    if [[ -f "$md_file" && -f "$json_file" ]]; then
+      echo "  ${task}: done (md + json sidecar)"
+    elif [[ -f "$md_file" ]]; then
+      echo "  ${task}: md done, json pending..."
+      all_done=false
     else
       echo "  ${task}: still running..."
       all_done=false


### PR DESCRIPTION
## LLM-1638: Extend session audit to capture routing & orchestration metrics

### Summary

Upgrades the `benchmark/audit-session` tooling so that every audited run produces both a human-readable markdown report **and** a machine-readable JSON sidecar. The sidecar contains structured metrics needed to compare experiment runs automatically.

### Changes

**`benchmark/audit-session/audit-session-prompt.md`** — 8 new analysis sections appended after the existing 6 dimensions:

| # | Section | What it captures |
|---|---------|-------------------|
| 4 | Per-Turn Model Attribution | Active model per turn, provider, switch-boundary annotations |
| 5 | Routing Decision Rationale | Evidence for why each model switch happened (phase, tool call, explicit text) |
| 6 | Switching Latency | Mean / max / min / count per model-pair |
| 7 | Subagent Lifecycle Metrics | Loops, budget usage, context completeness |
| 8 | Token Consumption per Task Class | explore / plan / build / review / research / orchestration |
| 9 | Cost per Completed Task | Cost bounded by phase switches or terminal outcomes |
| 10 | OSS vs Non-OSS Utilization | Token-based and cost-based ratios |
| 11 | JSON Sidecar | Machine-readable appendix with schema version `1.0.0` |

**`benchmark/audit-session/audit-session.sh`** — Refactored to:
- Stream audit agent output live to stdout (visible progress)
- Capture the report via `tee` to a temp file for post-processing
- Extract the fenced JSON appendix and write a `.kimchi/audits/*-AUDIT.json` sidecar
- Validate JSON with `jq` when available

**`benchmark/audit-session/README.md`** — Added:
- Metrics Captured — table of all 13 dimensions
- Structured Output — dual-file output explanation
- Usage for Automated Comparison — 5 `jq` recipes for cross-run analysis

### JSON Schema (`1.0.0`)

Top-level keys: `schemaVersion`, `sessionId`, `timestamp`, `modelsUsed`, `switches`, `subagents`, `taskClasses`, `completedTasks`, `ossRatio`, `aggregates`.

### Acceptance Criteria

- [x] Session audit captures model used per turn, provider, and routing decision rationale
- [x] Switching latency between models is measured and recorded
- [x] Subagent lifecycle metrics are tracked (loops, budget, context completeness)
- [x] Token consumption per task class is recorded and comparable across sessions
- [x] Cost per completed task is calculated and available
- [x] OSS vs non-OSS utilization ratio is derivable from audit data
- [x] Audit data is structured for automated comparison between experiment runs

Co-Authored-By: Kimchi <noreply@kimchi.dev>

---
### Kimchi Summary
### What changed
Expands the session audit framework from 6 graded quality dimensions to 13 by adding deep structural telemetry—including per-turn model attribution, routing rationale, switching latency, subagent lifecycle, task-class token consumption, cost-per-task, and OSS utilization ratios. It also introduces a machine-readable JSON sidecar (schema `1.0.0`) alongside the human-readable markdown report, and updates the evaluation orchestrator to track both outputs.

### Why
To enable automated, repeatable comparison of session behavior across benchmark runs by providing structured data for model routing decisions, cost attribution, and OSS vs. proprietary model usage.

### Key changes
- `benchmark/audit-session/audit-session-prompt.md`: Added 8 new analysis steps (Steps 4–11) covering model attribution, routing decisions, switch latency, subagent loops, task-class token/cost aggregation, terminal-state task costs, OSS classification, and generation of a fenced JSON appendix.
- `benchmark/audit-session/audit-session.sh`: Refactored runner execution into `run_audit_agent`; added `extract_json_sidecar` to parse the JSON block from the markdown report, validate it with `jq` when available, and write a `.json` file; preserved TTY for interactive harness rendering.
- `benchmark/audit-session/README.md`: Documented the full 13-metric matrix, JSON schema structure, dual output files (`.md` and `.json`), and example `jq` queries for cross-run comparison.
- `benchmark/manual/run-evaluation.sh`: Aligned expected audit file paths with the `{sessionId}-{runner}-{model}-AUDIT.{md,json}` naming convention; updated polling logic to wait for both markdown report and JSON sidecar.

### Impact
- The benchmark orchestrator now requires both `.md` and `.json` files to consider an audit complete.
- `jq` remains optional but is used for sidecar validation when present.
- Existing audit markdown content remains human-readable; the JSON appendix is appended for machine consumption.