### PR TITLE
LLM-1628: Load models from API for all tools

### DIFF
--- a/src/commands/_helpers.ts
+++ b/src/commands/_helpers.ts
@@ -2,6 +2,7 @@ import { readApiKeyFromConfigFile } from "../config.js"
 import type { ConfigScope } from "../config/scope.js"
 import { byId } from "../integrations/registry.js"
 import type { ToolId } from "../integrations/types.js"
+import { getAvailableModels } from "../startup-context.js"
 import { printBanner } from "./banner.js"
 
 /**
@@ -51,7 +52,11 @@ export function popScope(args: string[]): ConfigScope {
 export function prepareTool(
 	toolId: ToolId,
 	mode: "inject" | "override",
-): { apiKey: string; tool: NonNullable<ReturnType<typeof byId>> } | null {
+): {
+	apiKey: string
+	tool: NonNullable<ReturnType<typeof byId>>
+	models: readonly import("../models.js").ModelMetadata[]
+} | null {
 	const apiKey = resolveApiKey()
 	if (!apiKey) {
 		console.error("kimchi: no API key configured. Run `kimchi setup` or set $KIMCHI_API_KEY.")
@@ -65,6 +70,10 @@ export function prepareTool(
 		console.error(`kimchi: integration "${toolId}" not registered.`)
 		return null
 	}
-	printBanner({ toolId, gsdActive: byId("gsd2")?.isInstalled() ?? false, mode })
-	return { apiKey, tool }
+	// Use models cached at startup (populated by cli.ts before main() runs).
+	// If the cache is empty (e.g. subcommand invoked directly) the banner
+	// renders a "dynamic models" placeholder.
+	const models = getAvailableModels()
+	printBanner({ toolId, gsdActive: byId("gsd2")?.isInstalled() ?? false, mode, availableModels: models })
+	return { apiKey, tool, models }
 }

--- a/src/commands/_helpers.ts
+++ b/src/commands/_helpers.ts
@@ -1,8 +1,10 @@
+import { resolve } from "node:path"
 import { readApiKeyFromConfigFile } from "../config.js"
 import type { ConfigScope } from "../config/scope.js"
 import { byId } from "../integrations/registry.js"
 import type { ToolId } from "../integrations/types.js"
-import { getAvailableModels } from "../startup-context.js"
+import { updateModelsConfig } from "../models.js"
+import { getAvailableModels, setAvailableModels } from "../startup-context.js"
 import { printBanner } from "./banner.js"
 
 /**
@@ -49,14 +51,14 @@ export function popScope(args: string[]): ConfigScope {
  * null + writes a stderr message when the API key isn't available, so
  * the caller can simply `return 1` from runX().
  */
-export function prepareTool(
+export async function prepareTool(
 	toolId: ToolId,
 	mode: "inject" | "override",
-): {
+): Promise<{
 	apiKey: string
 	tool: NonNullable<ReturnType<typeof byId>>
 	models: readonly import("../models.js").ModelMetadata[]
-} | null {
+} | null> {
 	const apiKey = resolveApiKey()
 	if (!apiKey) {
 		console.error("kimchi: no API key configured. Run `kimchi setup` or set $KIMCHI_API_KEY.")
@@ -70,10 +72,16 @@ export function prepareTool(
 		console.error(`kimchi: integration "${toolId}" not registered.`)
 		return null
 	}
-	// Use models cached at startup (populated by cli.ts before main() runs).
-	// If the cache is empty (e.g. subcommand invoked directly) the banner
-	// renders a "dynamic models" placeholder.
-	const models = getAvailableModels()
+	let models = getAvailableModels()
+	if (models.length === 0) {
+		const agentDir = process.env.KIMCHI_CODING_AGENT_DIR
+		if (!agentDir) {
+			throw new Error("KIMCHI_CODING_AGENT_DIR is not set; cli.ts must be entered via entry.ts")
+		}
+		const result = await updateModelsConfig(resolve(agentDir, "models.json"), apiKey)
+		models = result.models
+		setAvailableModels(models)
+	}
 	printBanner({ toolId, gsdActive: byId("gsd2")?.isInstalled() ?? false, mode, availableModels: models })
 	return { apiKey, tool, models }
 }

--- a/src/commands/banner.ts
+++ b/src/commands/banner.ts
@@ -1,5 +1,5 @@
 import { RST, TRUECOLOR } from "../ansi.js"
-import { CODING_MODEL, MAIN_MODEL } from "../integrations/models.js"
+import { formatModelPair } from "../integrations/models.js"
 import type { ToolId } from "../integrations/types.js"
 
 /**
@@ -7,11 +7,15 @@ import type { ToolId } from "../integrations/types.js"
  * (`kimchi claude`, `kimchi opencode`, …). It states which tool we're
  * configuring, the model pair, GSD status, and config mode so the user
  * has a quick at-a-glance summary before the tool boots.
+ *
+ * If `availableModels` is provided, the model pair is rendered dynamically
+ * from the live API list. Otherwise falls back to "dynamic models" placeholder.
  */
 export interface BannerSummary {
 	toolId: ToolId
 	gsdActive: boolean
 	mode: "inject" | "override"
+	availableModels?: readonly import("../models.js").ModelMetadata[]
 }
 
 const BOLD = "\x1b[1m"
@@ -31,7 +35,7 @@ function colorEnabled(): boolean {
 
 export function renderBanner(summary: BannerSummary): string {
 	const line = "─".repeat(45)
-	const models = `${MAIN_MODEL.slug} (reasoning) / ${CODING_MODEL.slug} (coding)`
+	const models = summary.availableModels ? formatModelPair(summary.availableModels) : "dynamic models"
 	const gsd = summary.gsdActive ? "active" : "not installed"
 
 	if (!colorEnabled()) {

--- a/src/commands/claude.ts
+++ b/src/commands/claude.ts
@@ -15,7 +15,7 @@ import { prepareTool } from "./_helpers.js"
  * having to know Claude's flag set.
  */
 export async function runClaude(args: string[]): Promise<number> {
-	const prepped = prepareTool("claudecode", "inject")
+	const prepped = await prepareTool("claudecode", "inject")
 	if (!prepped) return 1
 
 	const telemetryEnabled = readTelemetryConfig().enabled

--- a/src/commands/cursor.ts
+++ b/src/commands/cursor.ts
@@ -4,7 +4,7 @@ import { popScope, prepareTool } from "./_helpers.js"
 
 export async function runCursor(args: string[]): Promise<number> {
 	const scope = popScope(args)
-	const prepped = prepareTool("cursor", "override")
+	const prepped = await prepareTool("cursor", "override")
 	if (!prepped) return 1
 
 	try {

--- a/src/commands/cursor.ts
+++ b/src/commands/cursor.ts
@@ -13,7 +13,7 @@ export async function runCursor(args: string[]): Promise<number> {
 			console.error("kimchi cursor: integration not registered")
 			return 1
 		}
-		await tool.write(scope, prepped.apiKey)
+		await tool.write(scope, prepped.apiKey, prepped.models)
 		console.log("kimchi cursor: configuration written. Restart Cursor to pick up the kimchi provider.")
 		return 0
 	} catch (err) {

--- a/src/commands/gsd2.ts
+++ b/src/commands/gsd2.ts
@@ -13,7 +13,7 @@ export async function runGsd2(args: string[]): Promise<number> {
 			console.error("kimchi gsd2: integration not registered")
 			return 1
 		}
-		await tool.write(scope, prepped.apiKey)
+		await tool.write(scope, prepped.apiKey, prepped.models)
 		console.log("kimchi gsd2: configuration written. Run `gsd` to use kimchi-routed models.")
 		return 0
 	} catch (err) {

--- a/src/commands/gsd2.ts
+++ b/src/commands/gsd2.ts
@@ -4,7 +4,7 @@ import { popScope, prepareTool } from "./_helpers.js"
 
 export async function runGsd2(args: string[]): Promise<number> {
 	const scope = popScope(args)
-	const prepped = prepareTool("gsd2", "override")
+	const prepped = await prepareTool("gsd2", "override")
 	if (!prepped) return 1
 
 	try {

--- a/src/commands/openclaw.ts
+++ b/src/commands/openclaw.ts
@@ -13,7 +13,7 @@ export async function runOpenClaw(args: string[]): Promise<number> {
 			console.error("kimchi openclaw: integration not registered")
 			return 1
 		}
-		await tool.write(scope, prepped.apiKey)
+		await tool.write(scope, prepped.apiKey, prepped.models)
 		console.log("kimchi openclaw: configuration written.")
 		return 0
 	} catch (err) {

--- a/src/commands/openclaw.ts
+++ b/src/commands/openclaw.ts
@@ -4,7 +4,7 @@ import { popScope, prepareTool } from "./_helpers.js"
 
 export async function runOpenClaw(args: string[]): Promise<number> {
 	const scope = popScope(args)
-	const prepped = prepareTool("openclaw", "override")
+	const prepped = await prepareTool("openclaw", "override")
 	if (!prepped) return 1
 
 	try {

--- a/src/commands/opencode.ts
+++ b/src/commands/opencode.ts
@@ -13,7 +13,7 @@ import { popScope, prepareTool } from "./_helpers.js"
  */
 export async function runOpenCode(args: string[]): Promise<number> {
 	const scope = popScope(args)
-	const prepped = prepareTool("opencode", "override")
+	const prepped = await prepareTool("opencode", "override")
 	if (!prepped) return 1
 
 	try {

--- a/src/commands/opencode.ts
+++ b/src/commands/opencode.ts
@@ -22,7 +22,7 @@ export async function runOpenCode(args: string[]): Promise<number> {
 			console.error("kimchi opencode: integration not registered")
 			return 1
 		}
-		await tool.write(scope, prepped.apiKey)
+		await tool.write(scope, prepped.apiKey, prepped.models)
 		return await runForeground("opencode", args)
 	} catch (err) {
 		console.error(`kimchi opencode: ${(err as Error).message}`)

--- a/src/integrations/__fixtures__/models.ts
+++ b/src/integrations/__fixtures__/models.ts
@@ -1,0 +1,72 @@
+import type { ModelMetadata } from "../../models.js"
+
+/**
+ * Shared test fixture for `ModelMetadata[]`. Covers all roles (main, coding,
+ * sub, opus, sonnet) so tests can exercise the full role resolution logic
+ * without any network calls.
+ *
+ * Slugs match what the real API returns. Role resolution depends on these
+ * exact slugs — if the API changes slugs, update this fixture accordingly.
+ */
+export const TEST_MODELS: readonly ModelMetadata[] = [
+	{
+		slug: "kimi-k2.6",
+		display_name: "Kimi K2.6",
+		provider: "ai-enabler",
+		reasoning: true,
+		input_modalities: ["text", "image"],
+		is_serverless: true,
+		limits: { context_window: 262_144, max_output_tokens: 32_768 },
+	},
+	{
+		slug: "kimi-k2.5",
+		display_name: "Kimi K2.5",
+		provider: "ai-enabler",
+		reasoning: true,
+		input_modalities: ["text", "image"],
+		is_serverless: true,
+		limits: { context_window: 262_144, max_output_tokens: 32_768 },
+	},
+	{
+		slug: "nemotron-3-super-fp4",
+		display_name: "Nemotron 3 Super FP4",
+		provider: "ai-enabler",
+		reasoning: true,
+		input_modalities: ["text"],
+		is_serverless: true,
+		limits: { context_window: 1_048_576, max_output_tokens: 256_000 },
+	},
+	{
+		slug: "minimax-m2.7",
+		display_name: "MiniMax M2.7",
+		provider: "ai-enabler",
+		reasoning: true,
+		input_modalities: ["text"],
+		is_serverless: true,
+		limits: { context_window: 196_608, max_output_tokens: 32_768 },
+	},
+	{
+		slug: "claude-opus-4-7",
+		display_name: "Claude Opus 4.7",
+		provider: "anthropic",
+		reasoning: true,
+		input_modalities: ["text"],
+		is_serverless: false,
+		limits: { context_window: 1_000_000, max_output_tokens: 128_000 },
+	},
+	{
+		slug: "claude-sonnet-4-7",
+		display_name: "Claude Sonnet 4.7",
+		provider: "anthropic",
+		reasoning: true,
+		input_modalities: ["text"],
+		is_serverless: false,
+		limits: { context_window: 1_000_000, max_output_tokens: 128_000 },
+	},
+]
+
+/** Subset containing only serverless models — for role resolution tests. */
+export const TEST_SERVERLESS_MODELS = TEST_MODELS.filter((m) => m.is_serverless)
+
+/** Subset containing only Anthropic models — for opus/sonnet tests. */
+export const TEST_ANTHROPIC_MODELS = TEST_MODELS.filter((m) => m.provider === "anthropic")

--- a/src/integrations/claude-code.test.ts
+++ b/src/integrations/claude-code.test.ts
@@ -2,6 +2,7 @@ import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "nod
 import { tmpdir } from "node:os"
 import { join } from "node:path"
 import { afterEach, beforeEach, describe, expect, it } from "vitest"
+import { TEST_MODELS } from "./__fixtures__/models.js"
 import { claudeCodeEnv, injectClaudeCodeEnv } from "./claude-code.js"
 import { byId } from "./registry.js"
 
@@ -216,7 +217,7 @@ describe("claude-code tool registration", () => {
 
 		const tool = byId("claudecode")
 		expect(tool).toBeDefined()
-		await tool?.write("global", "test-key")
+		await tool?.write("global", "test-key", TEST_MODELS)
 
 		const written = JSON.parse(readFileSync(settings, "utf-8"))
 		expect(written.theme).toBe("dark")
@@ -230,7 +231,7 @@ describe("claude-code tool registration", () => {
 	it("write() creates the directory and file when they don't exist yet", async () => {
 		const tool = byId("claudecode")
 		expect(tool).toBeDefined()
-		await tool?.write("global", "fresh-key")
+		await tool?.write("global", "fresh-key", TEST_MODELS)
 
 		const settings = join(scratchHome, ".claude", "settings.json")
 		const written = JSON.parse(readFileSync(settings, "utf-8"))
@@ -241,7 +242,7 @@ describe("claude-code tool registration", () => {
 	it("write() includes OTEL env vars when telemetryEnabled is true", async () => {
 		const tool = byId("claudecode")
 		expect(tool).toBeDefined()
-		await tool?.write("global", "key-123", { telemetryEnabled: true })
+		await tool?.write("global", "key-123", TEST_MODELS, { telemetryEnabled: true })
 
 		const settings = join(scratchHome, ".claude", "settings.json")
 		const written = JSON.parse(readFileSync(settings, "utf-8"))
@@ -253,7 +254,7 @@ describe("claude-code tool registration", () => {
 	it("write() does not include OTEL env vars when telemetryEnabled is false", async () => {
 		const tool = byId("claudecode")
 		expect(tool).toBeDefined()
-		await tool?.write("global", "key-456", { telemetryEnabled: false })
+		await tool?.write("global", "key-456", TEST_MODELS, { telemetryEnabled: false })
 
 		const settings = join(scratchHome, ".claude", "settings.json")
 		const written = JSON.parse(readFileSync(settings, "utf-8"))
@@ -282,7 +283,7 @@ describe("claude-code tool registration", () => {
 
 		const tool = byId("claudecode")
 		expect(tool).toBeDefined()
-		await tool?.write("global", "new-key", { telemetryEnabled: false })
+		await tool?.write("global", "new-key", TEST_MODELS, { telemetryEnabled: false })
 
 		const written = JSON.parse(readFileSync(settings, "utf-8"))
 		expect(written.env.ANTHROPIC_AUTH_TOKEN).toBe("new-key")
@@ -323,7 +324,7 @@ describe("claude-code tool registration", () => {
 
 		const tool = byId("claudecode")
 		expect(tool).toBeDefined()
-		await tool?.write("global", "new-key", { telemetryEnabled: false })
+		await tool?.write("global", "new-key", TEST_MODELS, { telemetryEnabled: false })
 
 		const written = JSON.parse(readFileSync(settings, "utf-8"))
 		// The 4 Cast-AI-specific keys should be gone
@@ -368,7 +369,7 @@ describe("claude-code tool registration", () => {
 
 		const tool = byId("claudecode")
 		expect(tool).toBeDefined()
-		await tool?.write("global", "new-key", { telemetryEnabled: false })
+		await tool?.write("global", "new-key", TEST_MODELS, { telemetryEnabled: false })
 
 		const written = JSON.parse(readFileSync(settings, "utf-8"))
 		expect(written.env.ANTHROPIC_AUTH_TOKEN).toBe("new-key")
@@ -382,6 +383,6 @@ describe("claude-code tool registration", () => {
 	it("write() rejects an empty API key", async () => {
 		const tool = byId("claudecode")
 		expect(tool).toBeDefined()
-		await expect(tool?.write("global", "")).rejects.toThrow(/API key/)
+		await expect(tool?.write("global", "", TEST_MODELS)).rejects.toThrow(/API key/)
 	})
 })

--- a/src/integrations/claude-code.ts
+++ b/src/integrations/claude-code.ts
@@ -4,6 +4,7 @@ import { log } from "@clack/prompts"
 import { readJson, writeJson } from "../config/json.js"
 import { resolveScopePath } from "../config/scope.js"
 import type { ConfigScope } from "../config/scope.js"
+import type { ModelMetadata } from "../models.js"
 import { confirm } from "../setup-wizard/prompt.js"
 import { ANTHROPIC_BASE_URL } from "./constants.js"
 import { detectBinaryFactory } from "./detect.js"
@@ -137,6 +138,7 @@ function formatDiff(diffs: EnvDiff[]): string {
 async function writeClaudeCode(
 	scope: ConfigScope,
 	apiKey: string,
+	_models: readonly ModelMetadata[],
 	options?: { telemetryEnabled?: boolean },
 ): Promise<void> {
 	if (!apiKey) {

--- a/src/integrations/cursor.test.ts
+++ b/src/integrations/cursor.test.ts
@@ -1,16 +1,19 @@
 import { describe, expect, it } from "vitest"
+import { TEST_MODELS } from "./__fixtures__/models.js"
 import { mergeCursorConfig } from "./cursor.js"
 import { byId } from "./registry.js"
 
 describe("mergeCursorConfig", () => {
 	it("sets the base URL and useOpenAIKey on a fresh blob", () => {
-		const out = mergeCursorConfig({})
+		const out = mergeCursorConfig({}, TEST_MODELS)
 		expect(out.openAIBaseUrl).toBe("https://llm.kimchi.dev/openai/v1")
 		expect(out.useOpenAIKey).toBe(true)
 	})
 
 	it("populates aiSettings.modelConfig with the kimchi-routed surfaces", () => {
-		const out = mergeCursorConfig({}) as { aiSettings: { modelConfig: Record<string, { modelName: string }> } }
+		const out = mergeCursorConfig({}, TEST_MODELS) as {
+			aiSettings: { modelConfig: Record<string, { modelName: string }> }
+		}
 		const mc = out.aiSettings.modelConfig
 		// Composer / spec / deep-search / background / ensemble run on Main; cmd-k +
 		// plan-execution on Coding; quick-agent on Sub.
@@ -24,30 +27,40 @@ describe("mergeCursorConfig", () => {
 		expect(mc["quick-agent"].modelName).toBe("kimchi/minimax-m2.7")
 	})
 
-	it("appends our model slugs to userAddedModels without duplicating existing ones", () => {
+	it("appends ALL model slugs to userAddedModels without duplicating existing ones", () => {
 		const initial = {
 			aiSettings: {
 				userAddedModels: ["other/model-a", "kimchi/kimi-k2.6"],
 			},
 		}
-		const out = mergeCursorConfig(initial) as { aiSettings: { userAddedModels: string[] } }
-		// "other/model-a" is preserved, "kimchi/kimi-k2.6" isn't duplicated, the
-		// other two kimchi slugs are appended.
+		const out = mergeCursorConfig(initial, TEST_MODELS) as { aiSettings: { userAddedModels: string[] } }
+		// ALL models from the API are added to the Cursor picker. "other/model-a"
+		// is preserved, "kimchi/kimi-k2.6" isn't duplicated. Anthropic model
+		// names are aliased (claude-opus-→claude-op-, claude-sonnet-→claude-so-)
+		// to prevent Cursor from using its native Anthropic integration.
 		expect(out.aiSettings.userAddedModels).toEqual([
 			"other/model-a",
 			"kimchi/kimi-k2.6",
+			"kimchi/kimi-k2.5",
 			"kimchi/nemotron-3-super-fp4",
 			"kimchi/minimax-m2.7",
+			"kimchi/claude-op-4-7",
+			"kimchi/claude-so-4-7",
 		])
 	})
 
-	it("removes our slugs from modelOverrideDisabled while leaving unrelated entries alone", () => {
+	it("removes ALL our slugs from modelOverrideDisabled while leaving unrelated entries alone", () => {
 		const initial = {
 			aiSettings: {
-				modelOverrideDisabled: ["kimchi/kimi-k2.6", "other/keep-me", "kimchi/minimax-m2.7"],
+				modelOverrideDisabled: [
+					"kimchi/kimi-k2.6",
+					"other/keep-me",
+					"kimchi/claude-op-4-7",
+					"kimchi/nemotron-3-super-fp4",
+				],
 			},
 		}
-		const out = mergeCursorConfig(initial) as { aiSettings: { modelOverrideDisabled: string[] } }
+		const out = mergeCursorConfig(initial, TEST_MODELS) as { aiSettings: { modelOverrideDisabled: string[] } }
 		expect(out.aiSettings.modelOverrideDisabled).toEqual(["other/keep-me"])
 	})
 
@@ -59,7 +72,9 @@ describe("mergeCursorConfig", () => {
 				},
 			},
 		}
-		const out = mergeCursorConfig(initial) as { aiSettings: { modelConfig: Record<string, { modelName: string }> } }
+		const out = mergeCursorConfig(initial, TEST_MODELS) as {
+			aiSettings: { modelConfig: Record<string, { modelName: string }> }
+		}
 		expect(out.aiSettings.modelConfig["unknown-surface"].modelName).toBe("user/custom")
 	})
 })
@@ -76,6 +91,6 @@ describe("cursor tool registration", () => {
 
 	it("write() rejects an empty API key", async () => {
 		const tool = byId("cursor")
-		await expect(tool?.write("global", "")).rejects.toThrow(/API key/)
+		await expect(tool?.write("global", "", TEST_MODELS)).rejects.toThrow(/API key/)
 	})
 })

--- a/src/integrations/cursor.ts
+++ b/src/integrations/cursor.ts
@@ -2,8 +2,9 @@ import { existsSync } from "node:fs"
 import { platform } from "node:os"
 import type { ConfigScope } from "../config/scope.js"
 import { resolveScopePath } from "../config/scope.js"
+import type { ModelMetadata } from "../models.js"
 import { BASE_URL, PROVIDER_NAME } from "./constants.js"
-import { CODING_MODEL, type KimchiModel, MAIN_MODEL, SUB_MODEL } from "./models.js"
+import { resolveModelRole } from "./models.js"
 import { register } from "./registry.js"
 
 const CURSOR_REACTIVE_STORAGE_KEY =
@@ -23,8 +24,18 @@ function detectCursor(): boolean {
 	return false
 }
 
-function modelSlug(model: KimchiModel): string {
-	return `${PROVIDER_NAME}/${model.slug}`
+/**
+ * Cursor detects model names containing "sonnet-", "opus-", "haiku-" and
+ * switches to its native Anthropic API integration, bypassing the OpenAI compat
+ * layer. Alias those substrings so Cursor always routes through kimchi's gateway
+ * regardless of the underlying provider.
+ */
+function modelSlug(model: ModelMetadata): string {
+	const slug = model.slug
+		.replace(/claude-sonnet-/g, "claude-so-")
+		.replace(/claude-opus-/g, "claude-op-")
+		.replace(/claude-haiku-/g, "claude-ha-")
+	return `${PROVIDER_NAME}/${slug}`
 }
 
 function modelEntry(slug: string): Record<string, unknown> {
@@ -65,8 +76,16 @@ function removeAll(slice: string[], remove: readonly string[]): string[] {
  * at different models; we map those onto Main/Coding/Sub. The user's
  * pre-existing model lists are preserved (kimchi models are added
  * uniquely, no clobber).
+ *
+ * @param storage - The parsed reactive-storage blob from Cursor's SQLite DB.
+ * @param models  - Live `ModelMetadata[]` fetched from the API.
  */
-export function mergeCursorConfig(storage: Record<string, unknown>): Record<string, unknown> {
+export function mergeCursorConfig(
+	storage: Record<string, unknown>,
+	models: readonly ModelMetadata[],
+): Record<string, unknown> {
+	if (!models || models.length === 0) return storage
+
 	storage.openAIBaseUrl = BASE_URL
 	storage.useOpenAIKey = true
 
@@ -75,28 +94,33 @@ export function mergeCursorConfig(storage: Record<string, unknown>): Record<stri
 			? (storage.aiSettings as Record<string, unknown>)
 			: {}
 
-	const main = modelSlug(MAIN_MODEL)
-	const coding = modelSlug(CODING_MODEL)
-	const sub = modelSlug(SUB_MODEL)
-	const slugs = [main, coding, sub]
+	const main = resolveModelRole(models, "main")
+	const coding = resolveModelRole(models, "coding", main)
+	const sub = resolveModelRole(models, "sub", main)
 
-	aiSettings.userAddedModels = appendUnique(toStringArray(aiSettings.userAddedModels), slugs)
-	aiSettings.modelOverrideEnabled = appendUnique(toStringArray(aiSettings.modelOverrideEnabled), slugs)
-	aiSettings.modelOverrideDisabled = removeAll(toStringArray(aiSettings.modelOverrideDisabled), slugs)
+	// Add all available models to Cursor's picker — Cursor is a flat list, not a
+	// provider block, so there is no downside to including everything the API knows
+	// about. Role resolution only determines which surface maps to which model.
+	const allSlugs = models.map(modelSlug)
+
+	aiSettings.userAddedModels = appendUnique(toStringArray(aiSettings.userAddedModels), allSlugs)
+	aiSettings.modelOverrideEnabled = appendUnique(toStringArray(aiSettings.modelOverrideEnabled), allSlugs)
+	aiSettings.modelOverrideDisabled = removeAll(toStringArray(aiSettings.modelOverrideDisabled), allSlugs)
 
 	const modelConfig =
 		(aiSettings.modelConfig as Record<string, unknown> | undefined) && typeof aiSettings.modelConfig === "object"
 			? (aiSettings.modelConfig as Record<string, unknown>)
 			: {}
 
-	modelConfig.composer = modelEntry(main)
-	modelConfig["cmd-k"] = modelEntry(coding)
-	modelConfig["background-composer"] = modelEntry(main)
-	modelConfig["plan-execution"] = modelEntry(coding)
-	modelConfig.spec = modelEntry(main)
-	modelConfig["deep-search"] = modelEntry(main)
-	modelConfig["quick-agent"] = modelEntry(sub)
-	modelConfig["composer-ensemble"] = modelEntry(main)
+	// Only write surface mappings for models that were successfully resolved.
+	if (main) modelConfig.composer = modelEntry(modelSlug(main))
+	if (coding) modelConfig["cmd-k"] = modelEntry(modelSlug(coding))
+	if (main) modelConfig["background-composer"] = modelEntry(modelSlug(main))
+	if (coding) modelConfig["plan-execution"] = modelEntry(modelSlug(coding))
+	if (main) modelConfig.spec = modelEntry(modelSlug(main))
+	if (main) modelConfig["deep-search"] = modelEntry(modelSlug(main))
+	if (sub) modelConfig["quick-agent"] = modelEntry(modelSlug(sub))
+	if (main) modelConfig["composer-ensemble"] = modelEntry(modelSlug(main))
 
 	aiSettings.modelConfig = modelConfig
 	storage.aiSettings = aiSettings
@@ -113,10 +137,14 @@ export function mergeCursorConfig(storage: Record<string, unknown>): Record<stri
 async function writeCursor(
 	_scope: ConfigScope,
 	apiKey: string,
+	models: readonly ModelMetadata[],
 	_options?: { telemetryEnabled?: boolean },
 ): Promise<void> {
 	if (!apiKey) {
 		throw new Error("API key not configured")
+	}
+	if (!models || models.length === 0) {
+		throw new Error("No models available — is the API key valid?")
 	}
 	const dbPath = resolveScopePath("global", cursorDbPath())
 	if (!existsSync(dbPath)) {
@@ -136,7 +164,7 @@ async function writeCursor(
 				.query<{ value: string }, [string]>("SELECT value FROM ItemTable WHERE key = ?")
 				.get(CURSOR_REACTIVE_STORAGE_KEY)
 			const storage: Record<string, unknown> = row?.value ? JSON.parse(row.value) : {}
-			mergeCursorConfig(storage)
+			mergeCursorConfig(storage, models)
 			db.run("INSERT OR REPLACE INTO ItemTable (key, value) VALUES (?, ?)", [
 				CURSOR_REACTIVE_STORAGE_KEY,
 				JSON.stringify(storage),

--- a/src/integrations/gsd2.test.ts
+++ b/src/integrations/gsd2.test.ts
@@ -2,29 +2,31 @@ import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "nod
 import { tmpdir } from "node:os"
 import { join } from "node:path"
 import { afterEach, beforeEach, describe, expect, it } from "vitest"
+import { TEST_MODELS } from "./__fixtures__/models.js"
 import { buildGsd2KimchiProvider, buildGsd2Preferences } from "./gsd2.js"
 import { byId } from "./registry.js"
 
 describe("buildGsd2KimchiProvider", () => {
 	it("returns the provider block with apiKey, baseUrl, and defaultModel", () => {
-		const p = buildGsd2KimchiProvider("test-key") as {
+		const p = buildGsd2KimchiProvider("test-key", TEST_MODELS) as {
 			apiKey: string
 			baseUrl: string
 			defaultModel: string
 		}
 		expect(p.apiKey).toBe("test-key")
 		expect(p.baseUrl).toBe("https://llm.kimchi.dev/openai/v1")
+		// defaultModel is the resolved main model (first serverless vision model).
 		expect(p.defaultModel).toBe("kimi-k2.6")
 	})
 
-	it("emits all six models with cost metadata (Opus/Sonnet billed, kimchi models free)", () => {
-		const p = buildGsd2KimchiProvider("k") as {
+	it("emits all models with cost metadata (Opus/Sonnet billed at sticker, kimchi models free)", () => {
+		const p = buildGsd2KimchiProvider("k", TEST_MODELS) as {
 			models: Array<{ id: string; cost: { input: number } }>
 		}
-		expect(p.models.length).toBe(6)
-		const opus = p.models.find((m) => m.id === "claude-opus-4-6")
+		expect(p.models.length).toBe(TEST_MODELS.length)
+		const opus = p.models.find((m) => m.id === "claude-opus-4-7")
 		expect(opus?.cost).toEqual({ input: 5, output: 25, cacheRead: 0.5, cacheWrite: 6.25 })
-		const sonnet = p.models.find((m) => m.id === "claude-sonnet-4-6")
+		const sonnet = p.models.find((m) => m.id === "claude-sonnet-4-7")
 		expect(sonnet?.cost).toEqual({ input: 3, output: 15, cacheRead: 0.3, cacheWrite: 3.75 })
 		for (const slug of ["kimi-k2.6", "kimi-k2.5", "nemotron-3-super-fp4", "minimax-m2.7"]) {
 			const m = p.models.find((x) => x.id === slug)
@@ -33,16 +35,16 @@ describe("buildGsd2KimchiProvider", () => {
 	})
 
 	it("Kimi models accept text+image input, others text only", () => {
-		const p = buildGsd2KimchiProvider("k") as { models: Array<{ id: string; input: string[] }> }
+		const p = buildGsd2KimchiProvider("k", TEST_MODELS) as { models: Array<{ id: string; input: string[] }> }
 		expect(p.models.find((m) => m.id === "kimi-k2.6")?.input).toEqual(["text", "image"])
 		expect(p.models.find((m) => m.id === "kimi-k2.5")?.input).toEqual(["text", "image"])
 		expect(p.models.find((m) => m.id === "nemotron-3-super-fp4")?.input).toEqual(["text"])
-		expect(p.models.find((m) => m.id === "claude-opus-4-6")?.input).toEqual(["text"])
+		expect(p.models.find((m) => m.id === "claude-opus-4-7")?.input).toEqual(["text"])
 	})
 })
 
 describe("buildGsd2Preferences", () => {
-	const prefs = buildGsd2Preferences()
+	const prefs = buildGsd2Preferences(TEST_MODELS)
 
 	it("starts and ends with a YAML frontmatter fence", () => {
 		expect(prefs.startsWith("---\n")).toBe(true)
@@ -50,22 +52,23 @@ describe("buildGsd2Preferences", () => {
 	})
 
 	it("routes the high-level task buckets to the right model tiers", () => {
-		// Opus for planning/validation/auto_supervisor (heavy reasoning).
-		expect(prefs).toContain("planning: kimchi/claude-opus-4-6")
-		expect(prefs).toContain("validation: kimchi/claude-opus-4-6")
-		expect(prefs).toMatch(/auto_supervisor:\s*\n\s*model: kimchi\/claude-opus-4-6/)
-		// Coding model for research + subagent + light tier.
+		// Opus for planning/validation/auto_supervisor (heavy reasoning); falls back
+		// to main (kimi-k2.6) if opus isn't available.
+		expect(prefs).toMatch(/planning: kimchi\/(claude-opus-4-7|kimi-k2\.6)/)
+		expect(prefs).toMatch(/validation: kimchi\/(claude-opus-4-7|kimi-k2\.6)/)
+		expect(prefs).toMatch(/auto_supervisor:\s*\n\s*model: kimchi\/(claude-opus-4-7|kimi-k2\.6)/)
+		// Coding model for research + subagent.
 		expect(prefs).toContain("research: kimchi/nemotron-3-super-fp4")
 		expect(prefs).toContain("subagent: kimchi/nemotron-3-super-fp4")
-		// Sub model for execution_simple + discuss + standard tier.
+		// Sub model for execution_simple + discuss.
 		expect(prefs).toContain("discuss: kimchi/minimax-m2.7")
 		expect(prefs).toContain("execution_simple: kimchi/minimax-m2.7")
 	})
 
-	it("uses the new tier_models shape (light → coding, standard → sub, heavy → [main, opus])", () => {
+	it("uses the new tier_models shape (light → coding, standard → sub, heavy → [main, planning])", () => {
 		expect(prefs).toContain("light: kimchi/nemotron-3-super-fp4")
 		expect(prefs).toContain("standard: kimchi/minimax-m2.7")
-		expect(prefs).toMatch(/heavy:\s*\n\s*- kimchi\/kimi-k2\.6\s*\n\s*- kimchi\/claude-opus-4-6/)
+		expect(prefs).toMatch(/heavy:\s*\n\s*- kimchi\/kimi-k2\.6\s*\n\s*- kimchi\/(claude-opus-4-7|kimi-k2\.6)/)
 	})
 
 	it("hardcodes the worktree+squash git defaults", () => {
@@ -100,18 +103,18 @@ describe("gsd2 tool registration", () => {
 
 	it("write() rejects an empty API key", async () => {
 		const tool = byId("gsd2")
-		await expect(tool?.write("global", "")).rejects.toThrow(/API key/)
+		await expect(tool?.write("global", "", TEST_MODELS)).rejects.toThrow(/API key/)
 	})
 
 	it("write() emits both ~/.gsd/agent/models.json and ~/.gsd/preferences.md", async () => {
 		const tool = byId("gsd2")
-		await tool?.write("global", "secret-123")
+		await tool?.write("global", "secret-123", TEST_MODELS)
 
 		const models = JSON.parse(readFileSync(join(tmp, ".gsd", "agent", "models.json"), "utf-8"))
 		expect(models.providers.kimchi.apiKey).toBe("secret-123")
 
 		const prefs = readFileSync(join(tmp, ".gsd", "preferences.md"), "utf-8")
-		expect(prefs).toContain("planning: kimchi/claude-opus-4-6")
+		expect(prefs).toMatch(/planning: kimchi\/(claude-opus-4-7|kimi-k2\.6)/)
 	})
 
 	it("write() preserves other providers and top-level keys in models.json", async () => {
@@ -129,7 +132,7 @@ describe("gsd2 tool registration", () => {
 		)
 
 		const tool = byId("gsd2")
-		await tool?.write("global", "fresh-kimchi-key")
+		await tool?.write("global", "fresh-kimchi-key", TEST_MODELS)
 
 		const models = JSON.parse(readFileSync(modelsPath, "utf-8"))
 		expect(models.version).toBe(7)

--- a/src/integrations/gsd2.ts
+++ b/src/integrations/gsd2.ts
@@ -1,9 +1,10 @@
 import { readJson, writeFileAtomic, writeJson } from "../config/json.js"
 import type { ConfigScope } from "../config/scope.js"
 import { resolveScopePath } from "../config/scope.js"
+import type { ModelMetadata } from "../models.js"
 import { BASE_URL, PROVIDER_NAME } from "./constants.js"
 import { findBinary } from "./detect.js"
-import { CODING_MODEL, KIMI_K25_MODEL, MAIN_MODEL, OPUS_MODEL, SONNET_MODEL, SUB_MODEL } from "./models.js"
+import { type ModelRole, resolveAllModelRoles, resolveModelRole } from "./models.js"
 import { register } from "./registry.js"
 
 const GSD_PREFERENCES_PATH = "~/.gsd/preferences.md"
@@ -20,73 +21,95 @@ const COST_OPUS: ModelCost = { input: 5, output: 25, cacheRead: 0.5, cacheWrite:
 const COST_SONNET: ModelCost = { input: 3, output: 15, cacheRead: 0.3, cacheWrite: 3.75 }
 const COST_FREE: ModelCost = { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 }
 
-interface CatalogEntry {
-	model: typeof MAIN_MODEL
-	input: ReadonlyArray<"text" | "image">
-	cost: ModelCost
+/**
+ * Determine cost for a model based on its provider. Anthropic models get
+ * billed at sticker price; everything else is free (kimchi-internal).
+ * This heuristic replaces the hardcoded CATALOG cost array.
+ */
+function computeCost(model: ModelMetadata): ModelCost {
+	if (model.provider === "anthropic") {
+		if (model.slug.includes("opus")) return COST_OPUS
+		if (model.slug.includes("sonnet")) return COST_SONNET
+	}
+	return COST_FREE
 }
-
-const CATALOG: CatalogEntry[] = [
-	{ model: OPUS_MODEL, input: ["text"], cost: COST_OPUS },
-	{ model: SONNET_MODEL, input: ["text"], cost: COST_SONNET },
-	{ model: MAIN_MODEL, input: ["text", "image"], cost: COST_FREE },
-	{ model: KIMI_K25_MODEL, input: ["text", "image"], cost: COST_FREE },
-	{ model: CODING_MODEL, input: ["text"], cost: COST_FREE },
-	{ model: SUB_MODEL, input: ["text"], cost: COST_FREE },
-]
 
 /**
  * Build the kimchi provider block for ~/.gsd/agent/models.json. GSD2 reads
- * this to populate the kimchi provider in its UI. Cost numbers: Opus/Sonnet
- * at sticker price, the free kimchi-internal models at zero so GSD's budget
- * tracker doesn't double-charge.
+ * this to populate the kimchi provider in its UI. All available models from
+ * the API are included; cost is derived from provider (anthropic = billed,
+ * rest = free) so GSD's budget tracker doesn't double-charge kimchi users.
+ *
+ * @param apiKey - Raw API key (written directly; models.json is user-private).
+ * @param models - Live `ModelMetadata[]` fetched from the API.
  */
-export function buildGsd2KimchiProvider(apiKey: string): Record<string, unknown> {
+export function buildGsd2KimchiProvider(apiKey: string, models: readonly ModelMetadata[]): Record<string, unknown> {
+	if (models.length === 0) {
+		throw new Error("No models available — is the API key valid?")
+	}
+	const main = resolveModelRole(models, "main")
 	return {
 		name: "Kimchi",
 		baseUrl: BASE_URL,
 		apiKey,
 		api: "openai-completions",
-		defaultModel: MAIN_MODEL.slug,
-		models: CATALOG.map(({ model, input, cost }) => ({
-			id: model.slug,
-			name: model.displayName,
-			contextWindow: model.limits.contextWindow,
-			maxTokens: model.limits.maxOutputTokens,
-			reasoning: model.reasoning,
-			input,
-			cost,
+		defaultModel: main?.slug ?? models[0].slug,
+		models: models.map((m) => ({
+			id: m.slug,
+			name: m.display_name || m.slug,
+			contextWindow: m.limits.context_window,
+			maxTokens: m.limits.max_output_tokens,
+			reasoning: m.reasoning,
+			input: m.input_modalities,
+			cost: computeCost(m),
 		})),
 	}
 }
 
 /**
  * Build the YAML-frontmatter Markdown that lives at ~/.gsd/preferences.md.
- * Each task type is mapped to a kimchi-prefixed model slug.
+ * Task-type routing uses resolved model roles so it adapts to whatever
+ * models the API has available.
+ *
+ * @param models - Live `ModelMetadata[]` fetched from the API.
  */
-export function buildGsd2Preferences(): string {
-	const slug = (m: typeof MAIN_MODEL): string => `${PROVIDER_NAME}/${m.slug}`
+export function buildGsd2Preferences(models: readonly ModelMetadata[]): string {
+	if (models.length === 0) {
+		throw new Error("No models available — is the API key valid?")
+	}
+	const resolved = resolveAllModelRoles(models, ["main", "coding", "sub", "opus"] as readonly ModelRole[])
+	const main = resolved.main
+	const coding = resolved.coding
+	const sub = resolved.sub
+	const opus = resolved.opus
+
+	// Fallbacks when some roles aren't available.
+	const planning = opus ?? main
+	const validation = opus ?? main
+
+	const slug = (m?: ModelMetadata): string => (m ? `${PROVIDER_NAME}/${m.slug}` : `${PROVIDER_NAME}/unknown`)
+
 	return `---
 version: 1
 models:
-  research: ${slug(CODING_MODEL)}
-  planning: ${slug(OPUS_MODEL)}
-  discuss: ${slug(SUB_MODEL)}
-  execution: ${slug(MAIN_MODEL)}
-  execution_simple: ${slug(SUB_MODEL)}
-  completion: ${slug(MAIN_MODEL)}
-  validation: ${slug(OPUS_MODEL)}
-  subagent: ${slug(CODING_MODEL)}
+  research: ${slug(coding)}
+  planning: ${slug(planning)}
+  discuss: ${slug(sub)}
+  execution: ${slug(main)}
+  execution_simple: ${slug(sub)}
+  completion: ${slug(main)}
+  validation: ${slug(validation)}
+  subagent: ${slug(coding)}
 auto_supervisor:
-  model: ${slug(OPUS_MODEL)}
+  model: ${slug(planning)}
 dynamic_routing:
   enabled: false
   tier_models:
-    light: ${slug(CODING_MODEL)}
-    standard: ${slug(SUB_MODEL)}
+    light: ${slug(coding)}
+    standard: ${slug(sub)}
     heavy:
-      - ${slug(MAIN_MODEL)}
-      - ${slug(OPUS_MODEL)}
+      - ${slug(main)}
+      - ${slug(planning)}
   budget_pressure: false
 token_profile: balanced
 skill_discovery: suggest
@@ -101,22 +124,31 @@ function detectGsd2(): boolean {
 	return findBinary("gsd") !== undefined || findBinary("gsd-cli") !== undefined
 }
 
-async function writeGsd2(scope: ConfigScope, apiKey: string, _options?: { telemetryEnabled?: boolean }): Promise<void> {
+async function writeGsd2(
+	scope: ConfigScope,
+	apiKey: string,
+	models: readonly ModelMetadata[],
+	_options?: { telemetryEnabled?: boolean },
+): Promise<void> {
 	if (!apiKey) {
 		throw new Error("API key not configured")
 	}
+	if (!models || models.length === 0) {
+		throw new Error("No models available — is the API key valid?")
+	}
+
 	const modelsPath = resolveScopePath(scope, GSD_MODELS_PATH)
 	const existing = readJson(modelsPath)
 	const providers =
 		existing.providers && typeof existing.providers === "object" && !Array.isArray(existing.providers)
 			? (existing.providers as Record<string, unknown>)
 			: {}
-	providers.kimchi = buildGsd2KimchiProvider(apiKey)
+	providers.kimchi = buildGsd2KimchiProvider(apiKey, models)
 	existing.providers = providers
 	writeJson(modelsPath, existing)
 
 	const prefsPath = resolveScopePath(scope, GSD_PREFERENCES_PATH)
-	writeFileAtomic(prefsPath, buildGsd2Preferences())
+	writeFileAtomic(prefsPath, buildGsd2Preferences(models))
 }
 
 register({

--- a/src/integrations/models.ts
+++ b/src/integrations/models.ts
@@ -4,6 +4,10 @@
  * startup (src/models.ts); this static list is only used by tool config
  * writers, which configure tools to talk to a known set of model IDs
  * without an online round-trip.
+ *
+ * @deprecated Use `resolveModelRole(models, role)` instead — it picks models
+ * dynamically from the API-fetched `ModelMetadata[]` list. This static
+ * catalogue will be removed in a future release.
  */
 export interface ModelLimits {
 	contextWindow: number
@@ -91,3 +95,118 @@ export const ALL_MODELS: ReadonlyArray<KimchiModel> = [
 	SONNET_MODEL,
 	KIMI_K25_MODEL,
 ]
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Dynamic model role resolution (replaces the static constants above)
+// ─────────────────────────────────────────────────────────────────────────────
+
+import type { ModelMetadata } from "../models.js"
+
+export type ModelRole = "main" | "coding" | "sub" | "opus" | "sonnet"
+
+/**
+ * Resolve a conceptual model role to a concrete `ModelMetadata` from the
+ * available API-fetched list.
+ *
+ * Role resolution strategy:
+ *
+ * | Role   | Selection logic                                                                                                    |
+ * |--------|---------------------------------------------------------------------------------------------------------------------|
+ * | main   | First serverless model that has vision (input_modalities includes "image") and "Kimi" in display_name → first serverless fallback |
+ * | coding | First serverless model whose slug matches /nemotron|minimax/ → first serverless non-main                            |
+ * | sub    | Smallest serverless model that is not main (sorted by context_window)                                                  |
+ * | opus   | First model with provider=anthropic whose slug contains "opus" → any anthropic model                                  |
+ * | sonnet | First model with provider=anthropic whose slug contains "sonnet" → any anthropic model                               |
+ *
+ * @param models          - The live `ModelMetadata[]` fetched from the API via `updateModelsConfig()`.
+ * @param role            - Which conceptual role to resolve.
+ * @param precomputedMain - Optional precomputed main model. If omitted, `main` is resolved internally (safe for single-role calls).
+ */
+export function resolveModelRole(
+	models: readonly ModelMetadata[],
+	role: ModelRole,
+	precomputedMain?: ModelMetadata | undefined,
+): ModelMetadata | undefined {
+	if (models.length === 0) return undefined
+
+	const serverless = models.filter((m) => m.is_serverless)
+	const anthropic = models.filter((m) => m.provider === "anthropic")
+
+	// Cache main once so coding/sub don't recurse into it.
+	const main =
+		precomputedMain ??
+		((): ModelMetadata | undefined => {
+			const vision = serverless.find(
+				(m) =>
+					m.input_modalities.includes("image") &&
+					(m.display_name.toLowerCase().includes("kimi") || m.slug.toLowerCase().includes("kimi")),
+			)
+			return vision ?? serverless[0] ?? models[0]
+		})()
+
+	switch (role) {
+		case "main":
+			return main
+
+		case "coding": {
+			// Prefer known coding-optimised slugs; then any serverless non-main.
+			if (main) {
+				const coding = serverless.find((m) => /nemotron|minimax/.test(m.slug) && m.slug !== main.slug)
+				if (coding) return coding
+				const fallback = serverless.find((m) => m.slug !== main.slug)
+				if (fallback) return fallback
+			}
+			return serverless.length > 0 ? serverless[0] : models.length > 1 ? models[1] : undefined
+		}
+
+		case "sub": {
+			// Smallest serverless model that is not main.
+			const nonMain = serverless.filter((m) => !main || m.slug !== main.slug)
+			if (nonMain.length === 0) return models.find((m) => !main || m.slug !== main.slug)
+			nonMain.sort((a, b) => a.limits.context_window - b.limits.context_window)
+			return nonMain[0]
+		}
+
+		case "opus":
+			return models.find((m) => m.provider === "anthropic" && m.slug.includes("opus")) ?? anthropic[0]
+
+		case "sonnet":
+			return models.find((m) => m.provider === "anthropic" && m.slug.includes("sonnet")) ?? anthropic[0]
+
+		default:
+			return undefined
+	}
+}
+
+/**
+ * Resolve multiple model roles in a single pass, computing `main` only once.
+ * Returns a record keyed by role name. Use this when you need several roles
+ * at once to avoid redundant resolution.
+ */
+export function resolveAllModelRoles(
+	models: readonly ModelMetadata[],
+	roles: readonly ModelRole[],
+): Partial<Record<ModelRole, ModelMetadata>> {
+	const result: Partial<Record<ModelRole, ModelMetadata>> = {}
+	let main: ModelMetadata | undefined
+	for (const role of roles) {
+		if (result[role]) continue // already resolved
+		const resolved = resolveModelRole(models, role, main)
+		result[role] = resolved
+		if (role === "main" && resolved) main = resolved
+	}
+	return result
+}
+
+/**
+ * Build a human-readable model pair string for CLI banners.
+ * e.g. "kimi-k2.6 (reasoning) / nemotron-3-super-fp4 (coding)"
+ */
+export function formatModelPair(models: readonly ModelMetadata[]): string {
+	if (models.length === 0) return "dynamic models"
+	const main = resolveModelRole(models, "main")
+	const coding = resolveModelRole(models, "coding", main)
+	if (!main) return "dynamic models"
+	if (!coding) return main.slug
+	return `${main.slug} (reasoning) / ${coding.slug} (coding)`
+}

--- a/src/integrations/openclaw.test.ts
+++ b/src/integrations/openclaw.test.ts
@@ -3,6 +3,7 @@ import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "nod
 import { tmpdir } from "node:os"
 import { join } from "node:path"
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
+import { TEST_MODELS } from "./__fixtures__/models.js"
 import { findBinary } from "./detect.js"
 import {
 	asObject,
@@ -30,15 +31,20 @@ vi.mock("node:child_process", async () => {
 
 describe("buildOpenClawProviderBlock", () => {
 	it("uses the kimchi base URL and ${KIMCHI_API_KEY} placeholder", () => {
-		const block = buildOpenClawProviderBlock() as { baseUrl: string; apiKey: string; api: string; models: unknown[] }
+		const block = buildOpenClawProviderBlock(TEST_MODELS) as {
+			baseUrl: string
+			apiKey: string
+			api: string
+			models: unknown[]
+		}
 		expect(block.baseUrl).toBe("https://llm.kimchi.dev/openai/v1")
 		expect(block.apiKey).toBe("${KIMCHI_API_KEY}")
 		expect(block.api).toBe("openai-completions")
-		expect(block.models.length).toBe(6)
+		expect(block.models.length).toBe(TEST_MODELS.length)
 	})
 
 	it("includes per-model id/name/contextWindow/maxTokens", () => {
-		const block = buildOpenClawProviderBlock() as {
+		const block = buildOpenClawProviderBlock(TEST_MODELS) as {
 			models: Array<{ id: string; name: string; contextWindow: number; maxTokens: number }>
 		}
 		const main = block.models.find((m) => m.id === "kimchi/kimi-k2.6")
@@ -51,7 +57,7 @@ describe("buildOpenClawProviderBlock", () => {
 
 describe("buildOpenClawModelsCatalog", () => {
 	it("maps each model id to its display alias", () => {
-		const catalog = buildOpenClawModelsCatalog()
+		const catalog = buildOpenClawModelsCatalog(TEST_MODELS)
 		expect(catalog["kimchi/kimi-k2.6"]).toEqual({ alias: "Kimi K2.6" })
 		expect(catalog["kimchi/kimi-k2.5"]).toEqual({ alias: "Kimi K2.5" })
 		expect(catalog["kimchi/nemotron-3-super-fp4"]).toEqual({ alias: "Nemotron 3 Super FP4" })
@@ -112,7 +118,7 @@ describe("openclaw tool registration", () => {
 	})
 	it("write() rejects an empty API key", async () => {
 		const tool = byId("openclaw")
-		await expect(tool?.write("global", "")).rejects.toThrow(/API key/)
+		await expect(tool?.write("global", "", TEST_MODELS)).rejects.toThrow(/API key/)
 	})
 })
 
@@ -207,7 +213,7 @@ describe("writeOpenClawDirect integration", () => {
 		writeFileSync(join(configDir, "openclaw.json"), JSON.stringify(existing), "utf-8")
 
 		const tool = byId("openclaw")
-		await tool?.write("global", "test-key-123")
+		await tool?.write("global", "test-key-123", TEST_MODELS)
 
 		const written = JSON.parse(readFileSync(join(configDir, "openclaw.json"), "utf-8"))
 
@@ -253,7 +259,7 @@ describe("writeOpenClawViaCLI integration", () => {
 
 	it("preserves existing fallbacks and other keys via CLI merge", async () => {
 		const tool = byId("openclaw")
-		await tool?.write("global", "test-key-123")
+		await tool?.write("global", "test-key-123", TEST_MODELS)
 
 		const calls = vi.mocked(childProcess.spawnSync).mock.calls
 		const fallbackSetCall = calls.find((c) => {

--- a/src/integrations/openclaw.ts
+++ b/src/integrations/openclaw.ts
@@ -7,7 +7,7 @@ import type { ConfigScope } from "../config/scope.js"
 import { resolveScopePath } from "../config/scope.js"
 import { API_KEY_ENV, BASE_URL, PROVIDER_NAME } from "./constants.js"
 import { findBinary } from "./detect.js"
-import { ALL_MODELS, CODING_MODEL, MAIN_MODEL, SUB_MODEL } from "./models.js"
+import { type ModelRole, resolveAllModelRoles, resolveModelRole } from "./models.js"
 import { compareSemverGte } from "./opencode.js"
 import { register } from "./registry.js"
 
@@ -25,28 +25,34 @@ const OPENCLAW_VERSION_REGEX = /OpenClaw\s+(\d{4}\.\d+\.\d+)/
  * key so the JSON can be checked into version control without leaking
  * credentials; the daemon resolves the env var from ~/.openclaw/.env at
  * launch time.
+ *
+ * @param models - Live `ModelMetadata[]` fetched from the API.
  */
-export function buildOpenClawProviderBlock(): Record<string, unknown> {
+export function buildOpenClawProviderBlock(
+	models: readonly import("../models.js").ModelMetadata[],
+): Record<string, unknown> {
 	return {
 		baseUrl: BASE_URL,
 		apiKey: `\${${API_KEY_ENV}}`,
 		api: "openai-completions",
-		models: ALL_MODELS.map((m) => ({
+		models: models.map((m) => ({
 			id: `${PROVIDER_NAME}/${m.slug}`,
-			name: m.displayName,
+			name: m.display_name,
 			reasoning: m.reasoning,
-			input: m.inputModalities,
-			contextWindow: m.limits.contextWindow,
-			maxTokens: m.limits.maxOutputTokens,
+			input: m.input_modalities,
+			contextWindow: m.limits.context_window,
+			maxTokens: m.limits.max_output_tokens,
 		})),
 	}
 }
 
 /** Map of `<provider>/<slug>` → `{ alias: displayName }` for agents.defaults.models. */
-export function buildOpenClawModelsCatalog(): Record<string, unknown> {
+export function buildOpenClawModelsCatalog(
+	models: readonly import("../models.js").ModelMetadata[],
+): Record<string, unknown> {
 	const out: Record<string, unknown> = {}
-	for (const m of ALL_MODELS) {
-		out[`${PROVIDER_NAME}/${m.slug}`] = { alias: m.displayName }
+	for (const m of models) {
+		out[`${PROVIDER_NAME}/${m.slug}`] = { alias: m.display_name }
 	}
 	return out
 }
@@ -109,11 +115,20 @@ function runOpenClawCmd(args: string[]): void {
 }
 
 /** Configure OpenClaw via the `openclaw config set` CLI (preferred when binary is present). */
-async function writeOpenClawViaCLI(apiKey: string): Promise<void> {
-	const providerBlock = buildOpenClawProviderBlock()
-	const modelsCatalog = buildOpenClawModelsCatalog()
-	const fallbacks = [`${PROVIDER_NAME}/${CODING_MODEL.slug}`, `${PROVIDER_NAME}/${SUB_MODEL.slug}`]
-	const primary = `${PROVIDER_NAME}/${MAIN_MODEL.slug}`
+async function writeOpenClawViaCLI(
+	apiKey: string,
+	models: readonly import("../models.js").ModelMetadata[],
+): Promise<void> {
+	if (models.length === 0) throw new Error("No models available — is the API key valid?")
+
+	const providerBlock = buildOpenClawProviderBlock(models)
+	const modelsCatalog = buildOpenClawModelsCatalog(models)
+
+	const resolved = resolveAllModelRoles(models, ["main", "coding", "sub"] as readonly ModelRole[])
+	const primary = resolved.main ? `${PROVIDER_NAME}/${resolved.main.slug}` : `${PROVIDER_NAME}/${models[0].slug}`
+	const fallbacks = ([resolved.coding, resolved.sub] as Array<import("../models.js").ModelMetadata>)
+		.filter((m): m is import("../models.js").ModelMetadata => m !== undefined)
+		.map((m) => `${PROVIDER_NAME}/${m.slug}`)
 
 	runOpenClawCmd(["config", "set", "models.providers.kimchi", JSON.stringify(providerBlock)])
 	runOpenClawCmd(["config", "set", "agents.defaults.model.primary", primary])
@@ -147,28 +162,37 @@ async function writeOpenClawViaCLI(apiKey: string): Promise<void> {
 }
 
 /** Configure OpenClaw by writing JSON directly when no CLI is available. */
-async function writeOpenClawDirect(scope: ConfigScope, apiKey: string): Promise<void> {
+async function writeOpenClawDirect(
+	scope: ConfigScope,
+	apiKey: string,
+	models: readonly import("../models.js").ModelMetadata[],
+): Promise<void> {
+	if (models.length === 0) throw new Error("No models available — is the API key valid?")
+
 	const path = resolveScopePath(scope, OPENCLAW_CONFIG_PATH)
 	const existing = readJson(path)
 
 	const modelsRoot = asObject(existing.models)
 	const providers = asObject(modelsRoot.providers)
-	providers[PROVIDER_NAME] = buildOpenClawProviderBlock()
+	providers[PROVIDER_NAME] = buildOpenClawProviderBlock(models)
 	modelsRoot.providers = providers
 	existing.models = modelsRoot
+
+	const resolved = resolveAllModelRoles(models, ["main", "coding", "sub"] as readonly ModelRole[])
+	const mainSlug = resolved.main?.slug ?? models[0].slug
+	const fallbacks = ([resolved.coding, resolved.sub] as Array<import("../models.js").ModelMetadata>)
+		.filter((m): m is import("../models.js").ModelMetadata => m !== undefined)
+		.map((m) => `${PROVIDER_NAME}/${m.slug}`)
 
 	const agents = asObject(existing.agents)
 	const defaults = asObject(agents.defaults)
 	// Merge into model config to preserve existing keys like temperature, max_tokens.
 	const modelMap = asObject(defaults.model)
-	modelMap.primary = `${PROVIDER_NAME}/${MAIN_MODEL.slug}`
-	modelMap.fallbacks = mergeFallbacks(modelMap.fallbacks, [
-		`${PROVIDER_NAME}/${CODING_MODEL.slug}`,
-		`${PROVIDER_NAME}/${SUB_MODEL.slug}`,
-	])
+	modelMap.primary = `${PROVIDER_NAME}/${mainSlug}`
+	modelMap.fallbacks = mergeFallbacks(modelMap.fallbacks, fallbacks)
 	defaults.model = modelMap
 
-	defaults.models = mergeModelsCatalog(defaults.models, buildOpenClawModelsCatalog())
+	defaults.models = mergeModelsCatalog(defaults.models, buildOpenClawModelsCatalog(models))
 	agents.defaults = defaults
 	existing.agents = agents
 
@@ -179,19 +203,23 @@ async function writeOpenClawDirect(scope: ConfigScope, apiKey: string): Promise<
 async function writeOpenClaw(
 	scope: ConfigScope,
 	apiKey: string,
+	models: readonly import("../models.js").ModelMetadata[],
 	_options?: { telemetryEnabled?: boolean },
 ): Promise<void> {
 	if (!apiKey) {
 		throw new Error("API key not configured")
+	}
+	if (!models || models.length === 0) {
+		throw new Error("No models available — is the API key valid?")
 	}
 	// CLI route preferred when the binary is on PATH — OpenClaw uses JSON5
 	// internally and the CLI's setter is the only path that round-trips
 	// cleanly through that parser. Fall back to direct JSON write only when
 	// there's no openclaw binary to ask.
 	if (findBinary("openclaw")) {
-		await writeOpenClawViaCLI(apiKey)
+		await writeOpenClawViaCLI(apiKey, models)
 	} else {
-		await writeOpenClawDirect(scope, apiKey)
+		await writeOpenClawDirect(scope, apiKey, models)
 	}
 }
 

--- a/src/integrations/opencode.test.ts
+++ b/src/integrations/opencode.test.ts
@@ -3,6 +3,7 @@ import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "nod
 import { tmpdir } from "node:os"
 import { join } from "node:path"
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
+import { TEST_MODELS } from "./__fixtures__/models.js"
 import {
 	buildUpdatedPlugins,
 	compareSemverGte,
@@ -150,7 +151,7 @@ describe("opencode tool registration", () => {
 
 	it("write() rejects an empty API key", async () => {
 		const tool = byId("opencode")
-		await expect(tool?.write("global", "")).rejects.toThrow(/API key/)
+		await expect(tool?.write("global", "", TEST_MODELS)).rejects.toThrow(/API key/)
 	})
 
 	it("write() merges provider + plugin into opencode.json without clobbering unrelated keys", async () => {
@@ -173,7 +174,7 @@ describe("opencode tool registration", () => {
 			writeFileSync(path, JSON.stringify({ theme: "dark", provider: { other: { keep: true } } }), "utf-8")
 
 			const tool = byId("opencode")
-			await tool?.write("global", "test-key-123")
+			await tool?.write("global", "test-key-123", TEST_MODELS)
 
 			const written = JSON.parse(readFileSync(path, "utf-8"))
 			expect(written.theme).toBe("dark")

--- a/src/integrations/opencode.ts
+++ b/src/integrations/opencode.ts
@@ -3,6 +3,7 @@ import { readTelemetryConfig } from "../config.js"
 import { readJson, writeJson } from "../config/json.js"
 import type { ConfigScope } from "../config/scope.js"
 import { resolveScopePath } from "../config/scope.js"
+import type { ModelMetadata } from "../models.js"
 import {
 	NPM_REGISTRY_BASE_URL,
 	OPENCODE_PLUGIN_ARRAY_MIN_VERSION,
@@ -10,7 +11,7 @@ import {
 	PROVIDER_NAME,
 } from "./constants.js"
 import { detectBinaryFactory } from "./detect.js"
-import { MAIN_MODEL } from "./models.js"
+import { resolveModelRole } from "./models.js"
 import { openCodeProviderConfig } from "./provider/opencode.js"
 import { register } from "./registry.js"
 
@@ -160,10 +161,15 @@ export function buildUpdatedPlugins(inputs: PluginUpdateInputs): PluginUpdateRes
 async function writeOpenCode(
 	scope: ConfigScope,
 	apiKey: string,
+	models: readonly ModelMetadata[],
 	_options?: { telemetryEnabled?: boolean },
 ): Promise<void> {
 	if (!apiKey) {
 		throw new Error("API key not configured")
+	}
+
+	if (!models || models.length === 0) {
+		throw new Error("No models available — is the API key valid?")
 	}
 
 	const path = resolveScopePath(scope, OPENCODE_CONFIG_PATH)
@@ -175,10 +181,11 @@ async function writeOpenCode(
 		existing.provider && typeof existing.provider === "object" && !Array.isArray(existing.provider)
 			? (existing.provider as Record<string, unknown>)
 			: {}
-	providers[PROVIDER_NAME] = openCodeProviderConfig(apiKey)
+	providers[PROVIDER_NAME] = openCodeProviderConfig(apiKey, models)
 	existing.provider = providers
 
-	existing.model = `${PROVIDER_NAME}/${MAIN_MODEL.slug}`
+	const main = resolveModelRole(models, "main")
+	existing.model = `${PROVIDER_NAME}/${main?.slug ?? models[0].slug}`
 
 	if (!("compaction" in existing)) {
 		existing.compaction = { auto: true }

--- a/src/integrations/provider/opencode.ts
+++ b/src/integrations/provider/opencode.ts
@@ -1,16 +1,16 @@
+import type { ModelMetadata } from "../../models.js"
 import { BASE_URL } from "../constants.js"
-import { CODING_MODEL, type KimchiModel, MAIN_MODEL, SUB_MODEL } from "../models.js"
 
 /**
  * Build the OpenCode provider config block for the kimchi provider.
  * OpenCode pickers fail silently on unknown keys, so keep the schema
  * exact.
  *
- * The shape is `existing.provider.kimchi = …` in opencode.json. Each model
- * entry only lists the three models the writer cares about (Main/Coding/Sub);
- * Opus and Sonnet are exposed via the harness, not OpenCode directly.
+ * The shape is `existing.provider.kimchi = …` in opencode.json. All
+ * available models from the API are included — OpenCode's picker will
+ * surface whichever ones it supports.
  */
-export function openCodeProviderConfig(apiKey: string): Record<string, unknown> {
+export function openCodeProviderConfig(apiKey: string, models: readonly ModelMetadata[]): Record<string, unknown> {
 	return {
 		npm: "@ai-sdk/openai-compatible",
 		name: "Kimchi",
@@ -19,22 +19,19 @@ export function openCodeProviderConfig(apiKey: string): Record<string, unknown> 
 			litellmProxy: true,
 			apiKey,
 		},
-		models: {
-			[MAIN_MODEL.slug]: openCodeModelEntry(MAIN_MODEL),
-			[CODING_MODEL.slug]: openCodeModelEntry(CODING_MODEL),
-			[SUB_MODEL.slug]: openCodeModelEntry(SUB_MODEL),
-		},
+		models: Object.fromEntries(models.map((m) => [m.slug, openCodeModelEntry(m)])),
 	}
 }
 
-function openCodeModelEntry(model: KimchiModel): Record<string, unknown> {
+function openCodeModelEntry(model: ModelMetadata): Record<string, unknown> {
 	return {
 		name: model.slug,
-		tool_call: model.toolCall,
+		// `tool_call` is not in ModelMetadata; all models served through kimchi support it.
+		tool_call: true,
 		reasoning: model.reasoning,
 		limit: {
-			context: model.limits.contextWindow,
-			output: model.limits.maxOutputTokens,
+			context: model.limits.context_window,
+			output: model.limits.max_output_tokens,
 		},
 	}
 }

--- a/src/integrations/types.ts
+++ b/src/integrations/types.ts
@@ -1,4 +1,5 @@
 import type { ConfigScope } from "../config/scope.js"
+import type { ModelMetadata } from "../models.js"
 
 export type ToolId = "opencode" | "claudecode" | "cursor" | "openclaw" | "gsd2"
 
@@ -23,5 +24,10 @@ export interface ToolDefinition {
 	/** Detect whether the tool is installed locally (PATH probe, well-known dir, etc). */
 	isInstalled: () => boolean
 	/** Write configuration so this tool talks to kimchi's LLM endpoints. */
-	write: (scope: ConfigScope, apiKey: string, options?: { telemetryEnabled?: boolean }) => Promise<void>
+	write: (
+		scope: ConfigScope,
+		apiKey: string,
+		models: readonly ModelMetadata[],
+		options?: { telemetryEnabled?: boolean },
+	) => Promise<void>
 }

--- a/src/setup-wizard/steps/done.test.ts
+++ b/src/setup-wizard/steps/done.test.ts
@@ -2,8 +2,10 @@ import { mkdtempSync, realpathSync, rmSync } from "node:fs"
 import { tmpdir } from "node:os"
 import { join } from "node:path"
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
+import { TEST_MODELS } from "../../integrations/__fixtures__/models.js"
 import "../../integrations/claude-code.js"
 import { byId } from "../../integrations/registry.js"
+import * as modelsModule from "../../models.js"
 import type { WizardState } from "../state.js"
 import { runDoneStep } from "./done.js"
 
@@ -27,6 +29,11 @@ describe("runDoneStep", () => {
 		// runner output stays focused on assertions.
 		vi.spyOn(process.stdout, "write").mockImplementation(() => true)
 		vi.spyOn(console, "warn").mockImplementation(() => {})
+
+		// Mock updateModelsConfig so we don't hit the real network.
+		vi.spyOn(modelsModule, "updateModelsConfig").mockResolvedValue({
+			models: TEST_MODELS as import("../../models.js").ModelMetadata[],
+		})
 	})
 
 	afterEach(() => {
@@ -58,12 +65,13 @@ describe("runDoneStep", () => {
 		return tool
 	}
 
-	it("override mode invokes the integration writer", async () => {
+	it("override mode invokes the integration writer with models from the API", async () => {
 		const tool = getClaudeCodeTool()
 		const writeSpy = vi.spyOn(tool, "write").mockResolvedValue()
 
 		const outcome = await runDoneStep(baseState())
-		expect(writeSpy).toHaveBeenCalledWith("global", "test-key", { telemetryEnabled: true })
+		// write is called with (scope, apiKey, models, options)
+		expect(writeSpy).toHaveBeenCalledWith("global", "test-key", TEST_MODELS, { telemetryEnabled: true })
 		expect(outcome.successes).toEqual(["Claude Code"])
 		expect(outcome.failures).toEqual([])
 

--- a/src/setup-wizard/steps/done.ts
+++ b/src/setup-wizard/steps/done.ts
@@ -1,6 +1,8 @@
+import { resolve } from "node:path"
 import { log, note, outro } from "@clack/prompts"
 import { byId } from "../../integrations/registry.js"
 import type { ToolId } from "../../integrations/types.js"
+import { updateModelsConfig } from "../../models.js"
 import { exportEnvToShellProfile } from "../shell-profile.js"
 import type { WizardState } from "../state.js"
 
@@ -28,6 +30,30 @@ interface ApplyOutcome {
 export async function runDoneStep(state: WizardState): Promise<ApplyOutcome> {
 	const outcome: ApplyOutcome = { successes: [], failures: [] }
 
+	// Fetch live models before writing any tool config.
+	// Throws if no key or network fails; surface the error and abort gracefully.
+	const agentDir =
+		process.env.KIMCHI_CODING_AGENT_DIR ?? resolve(process.env.HOME ?? "~", ".config/kimchi-coding-agent")
+	const modelsJsonPath = resolve(agentDir, "models.json")
+	let models: readonly import("../../models.js").ModelMetadata[] = []
+	try {
+		const result = await updateModelsConfig(modelsJsonPath, state.apiKey)
+		models = result.models
+	} catch (err) {
+		const msg = (err as Error).message
+		log.error(`Could not fetch available models: ${msg}`)
+		outcome.failures.push({ id: "*", error: `model fetch failed: ${msg}` })
+		outro("Aborted.")
+		return outcome
+	}
+
+	if (models.length === 0) {
+		log.error("API returned an empty model list — is your API key valid?")
+		outcome.failures.push({ id: "*", error: "empty model list from API" })
+		outro("Aborted.")
+		return outcome
+	}
+
 	for (const id of state.selectedTools as ToolId[]) {
 		const tool = byId(id)
 		if (!tool) {
@@ -43,7 +69,7 @@ export async function runDoneStep(state: WizardState): Promise<ApplyOutcome> {
 			continue
 		}
 		try {
-			await tool.write(state.scope, state.apiKey, { telemetryEnabled: state.telemetryEnabled })
+			await tool.write(state.scope, state.apiKey, models, { telemetryEnabled: state.telemetryEnabled })
 			outcome.successes.push(tool.name)
 			log.success(`${tool.name}: configured`)
 		} catch (err) {


### PR DESCRIPTION


---
### Kimchi Summary
### What changed
Refactors all tool integrations to fetch the available model list from the API at runtime instead of relying on hardcoded model constants. Each tool now receives a live `ModelMetadata[]` array and uses role-based resolution (`main`, `coding`, `sub`, `opus`, `sonnet`) to determine which model to configure for each surface or task.

### Why
Eliminates the need to release a new CLI version every time the backend adds, removes, or renames models. Tool configurations now automatically reflect the current API catalogue.

### Key changes
- `src/commands/_helpers.ts`: `prepareTool` is now async. It fetches models via `updateModelsConfig` on first call (using `KIMCHI_CODING_AGENT_DIR`), caches them in startup context, and passes them to the banner and tool writers.
- `src/integrations/models.ts`: Introduces `resolveModelRole()` and `resolveAllModelRoles()` to dynamically map API models to conceptual roles based on provider, slug patterns, and capabilities (e.g., vision, serverless). Deprecates the static `KimchiModel` catalogue.
- `src/integrations/types.ts`: Updates `ToolDefinition.write` signature to require `models: readonly ModelMetadata[]`.
- `src/integrations/cursor.ts`: Consumes live models; aliases Anthropic slugs (`claude-opus-` → `claude-op-`, etc.) to force Cursor to use the OpenAI-compatible gateway instead of its native Anthropic integration. Adds all available models to `userAddedModels`.
- `src/integrations/gsd2.ts`: Builds provider blocks and preferences from live models. Computes per-model costs (Anthropic = sticker price, others = free) and maps task types to resolved roles.
- `src/integrations/openclaw.ts`, `src/integrations/opencode.ts`, `src/integrations/claude-code.ts`, `src/integrations/provider/opencode.ts`: Updated to accept and propagate the live model list instead of static constants.
- `src/setup-wizard/steps/done.ts`: Wizard now fetches models before applying any tool config and aborts with a clear error if the API returns an empty list.
- `src/integrations/__fixtures__/models.ts`: Added shared test fixtures so unit tests exercise role resolution without network calls.

### Impact
- `prepareTool` and all `runX()` entry points are now async.
- `KIMCHI_CODING_AGENT_DIR` is required at runtime for CLI commands; missing it throws.
- `ToolDefinition.write` callers must pass the live model list — this is a breaking interface change for any external integrations.
- If the API is unreachable or returns no models, tool configuration fails fast with an explicit error instead of silently writing stale model IDs.