### PR TITLE
Better UX for API Key generation flow

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@ src/core/export-html/
 # IDE
 .idea/
 .vscode/
+.claude/
 *.swp
 *.swo
 

--- a/src/cli-auth/callback-server.test.ts
+++ b/src/cli-auth/callback-server.test.ts
@@ -1,0 +1,139 @@
+import { describe, expect, it, vi } from "vitest"
+import { generateState, startCallbackServer } from "./callback-server.js"
+
+describe("generateState", () => {
+	it("produces a 64-character hex string", () => {
+		const state = generateState()
+		expect(state).toMatch(/^[0-9a-f]{64}$/)
+	})
+
+	it("produces unique values on successive calls", () => {
+		const a = generateState()
+		const b = generateState()
+		expect(a).not.toBe(b)
+	})
+})
+
+describe("startCallbackServer", () => {
+	async function request(port: number, path: string, opts?: { remoteAddress?: string }): Promise<Response> {
+		const url = `http://127.0.0.1:${port}${path}`
+		const res = await fetch(url, { signal: AbortSignal.timeout(1000) })
+		return res
+	}
+
+	it("binds to an ephemeral localhost port", async () => {
+		const state = generateState()
+		const server = await startCallbackServer(state)
+		expect(server.port).toBeGreaterThan(0)
+		expect(server.url).toBe(`http://127.0.0.1:${server.port}/callback`)
+		server.close()
+	})
+
+	it("resolves with the token on a valid callback", async () => {
+		const state = generateState()
+		const server = await startCallbackServer(state)
+
+		// Simulate the browser hitting the callback
+		const res = await request(server.port, `/callback?token=my-secret-token&state=${state}`)
+		expect(res.status).toBe(200)
+		const body = await res.text()
+		expect(body).toContain("Authentication Successful")
+
+		const result = await server.result
+		expect(result.token).toBe("my-secret-token")
+		expect(result.error).toBeUndefined()
+		server.close()
+	})
+
+	it("rejects an invalid state parameter", async () => {
+		const state = generateState()
+		const server = await startCallbackServer(state)
+
+		const res = await request(server.port, "/callback?token=bad&state=wrong-state")
+		expect(res.status).toBe(400)
+		const body = await res.text()
+		expect(body).toContain("Login error")
+
+		const result = await server.result
+		expect(result.error).toMatch(/try logging in again/)
+		server.close()
+	})
+
+	it("rejects a missing state parameter", async () => {
+		const state = generateState()
+		const server = await startCallbackServer(state)
+
+		const res = await request(server.port, "/callback?token=bad")
+		expect(res.status).toBe(400)
+		const body = await res.text()
+		expect(body).toContain("Login error")
+
+		const result = await server.result
+		expect(result.error).toMatch(/try logging in again/)
+	})
+
+	it("handles error callbacks", async () => {
+		const state = generateState()
+		const server = await startCallbackServer(state)
+
+		const res = await request(server.port, `/callback?error=access_denied&error_description=User+denied&state=${state}`)
+		expect(res.status).toBe(200)
+		const body = await res.text()
+		expect(body).toContain("Authentication failed")
+
+		const result = await server.result
+		expect(result.error).toBe("User denied")
+		server.close()
+	})
+
+	it("handles missing token", async () => {
+		const state = generateState()
+		const server = await startCallbackServer(state)
+
+		const res = await request(server.port, `/callback?state=${state}&success=1`)
+		expect(res.status).toBe(400)
+		const body = await res.text()
+		expect(body).toContain("Missing token")
+
+		const result = await server.result
+		expect(result.error).toMatch(/No token/)
+		server.close()
+	})
+
+	it("returns 404 for non-callback paths", async () => {
+		const state = generateState()
+		const server = await startCallbackServer(state)
+
+		const res = await request(server.port, `/something-else?state=${state}`)
+		expect(res.status).toBe(404)
+
+		server.close()
+	})
+
+	it("times out after the configured duration", async () => {
+		vi.useFakeTimers({ shouldAdvanceTime: true })
+		const state = generateState()
+		const server = await startCallbackServer(state)
+
+		const resultPromise = server.result
+
+		// Fast-forward past the timeout
+		vi.advanceTimersByTime(5 * 60 * 1000 + 100)
+
+		const result = await resultPromise
+		expect(result.error).toMatch(/timed out/)
+
+		server.close()
+		vi.useRealTimers()
+	})
+
+	it("close() resolves the result with a cancellation error", async () => {
+		const state = generateState()
+		const server = await startCallbackServer(state)
+
+		server.close()
+
+		const result = await server.result
+		expect(result.error).toMatch(/cancelled/i)
+	})
+})

--- a/src/cli-auth/callback-server.ts
+++ b/src/cli-auth/callback-server.ts
@@ -1,0 +1,292 @@
+import { randomBytes } from "node:crypto"
+import { type IncomingMessage, type Server, type ServerResponse, createServer } from "node:http"
+
+const CALLBACK_PATH = "/callback"
+const CALLBACK_TIMEOUT_MS = 300_000 // 5 minutes
+
+export interface CallbackResult {
+	token?: string
+	error?: string
+}
+
+export interface CallbackServer {
+	port: number
+	url: string
+	result: Promise<CallbackResult>
+	close: () => void
+}
+
+const HTML_SUCCESS = `<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="utf-8">
+  <title>Authentication Successful</title>
+  <style>
+    body {
+      font-family: system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+      display: flex;
+      justify-content: center;
+      align-items: center;
+      height: 100vh;
+      margin: 0;
+      background: #0f172a;
+      color: #e2e8f0;
+    }
+    .container {
+      text-align: center;
+      padding: 2rem;
+      max-width: 420px;
+    }
+    .icon {
+      width: 64px;
+      height: 64px;
+      margin: 0 auto 1.5rem;
+      background: #10b981;
+      border-radius: 50%;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      font-size: 32px;
+    }
+    h1 {
+      font-size: 1.5rem;
+      font-weight: 600;
+      margin-bottom: 0.5rem;
+      color: #fff;
+    }
+    p {
+      color: #94a3b8;
+      line-height: 1.6;
+      margin: 0;
+    }
+  </style>
+</head>
+<body>
+  <div class="container">
+    <div class="icon">&#10003;</div>
+    <h1>Authentication Successful</h1>
+    <p>Your CLI is now connected. You can close this window and start using Kimchi.</p>
+  </div>
+</body>
+</html>`
+
+function escapeHtml(unsafe: string): string {
+	return unsafe
+		.replace(/&/g, "&amp;")
+		.replace(/</g, "&lt;")
+		.replace(/>/g, "&gt;")
+		.replace(/"/g, "&quot;")
+		.replace(/'/g, "&#039;")
+}
+
+function htmlError(message: string, details?: string): string {
+	const detailBlock = details
+		? `<div style="margin-top: 1rem; padding: 1rem; background: rgba(248,113,113,0.1); border-radius: 0.5rem; font-family: monospace; font-size: 0.875rem; color: #fca5a5; word-break: break-word;">${escapeHtml(details)}</div>`
+		: ""
+	return `<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="utf-8">
+  <meta http-equiv="refresh" content="5;url=about:blank" />
+  <title>Authentication Failed</title>
+  <style>
+    body {
+      font-family: system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+      display: flex;
+      justify-content: center;
+      align-items: center;
+      height: 100vh;
+      margin: 0;
+      background: #0f172a;
+      color: #e2e8f0;
+    }
+    .container {
+      text-align: center;
+      padding: 2rem;
+      max-width: 420px;
+    }
+    .icon {
+      width: 64px;
+      height: 64px;
+      margin: 0 auto 1.5rem;
+      background: #ef4444;
+      border-radius: 50%;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      font-size: 32px;
+    }
+    h1 {
+      font-size: 1.5rem;
+      font-weight: 600;
+      margin-bottom: 0.5rem;
+      color: #fff;
+    }
+    p {
+      color: #94a3b8;
+      line-height: 1.6;
+      margin: 0 0 1.5rem;
+    }
+    .timer {
+      color: #64748b;
+      font-size: 0.875rem;
+    }
+  </style>
+</head>
+<body>
+  <div class="container">
+    <div class="icon">&#10007;</div>
+    <h1>Authentication Failed</h1>
+    <p>${escapeHtml(message)}</p>
+    ${detailBlock}
+  </div>
+  <script>setTimeout(() => window.close(), 5000);</script>
+</body>
+</html>`
+}
+
+/**
+ * Start a temporary HTTP server on localhost to receive the token callback
+ * from the browser.
+ *
+ * - Binds only on 127.0.0.1 for security
+ * - Validates the `state` parameter against CSRF
+ * - Returns a success or error HTML page to the browser
+ * - Times out after 5 minutes if no callback arrives
+ */
+export function startCallbackServer(expectedState: string): Promise<CallbackServer> {
+	return new Promise<CallbackServer>((resolveStart, rejectStart) => {
+		let server: Server | undefined
+		let resolved = false
+		let resolvedResult: CallbackResult | undefined
+		let timeoutTimer: ReturnType<typeof setTimeout> | undefined
+		let resolveResult: ((r: CallbackResult) => void) | undefined
+
+		function finish(result: CallbackResult) {
+			if (resolved) return
+			resolved = true
+			resolvedResult = result
+			if (timeoutTimer) clearTimeout(timeoutTimer)
+			if (resolveResult) resolveResult(resolvedResult ?? { error: "Callback server closed unexpectedly" })
+			// Defer socket destruction so the HTTP response has time to flush
+			setTimeout(closeServer, 100)
+		}
+
+		function closeServer() {
+			if (!server) return
+			try {
+				server?.closeAllConnections?.()
+				server?.close?.()
+			} catch {
+				// Already closing or closed — safe to ignore
+			}
+			server = undefined
+		}
+
+		function onRequest(req: IncomingMessage, res: ServerResponse) {
+			try {
+				const url = new URL(req.url ?? "/", `http://${req.headers.host ?? "localhost"}`)
+
+				// Reject non-localhost connections
+				const remote = req.socket.remoteAddress ?? ""
+				// Only accept connections from the loopback interface
+				if (!(remote.startsWith("127.") || remote === "::1" || remote === "::ffff:127.0.0.1")) {
+					res.writeHead(403, { "Content-Type": "text/html", Connection: "close" })
+					res.end(htmlError("Forbidden", "Only localhost connections are allowed."))
+					return
+				}
+
+				// Only handle the callback path
+				if (url.pathname !== CALLBACK_PATH) {
+					res.writeHead(404, { "Content-Type": "text/plain", Connection: "close" })
+					res.end("Not found")
+					return
+				}
+
+				// Validate state parameter for CSRF protection
+				const state = url.searchParams.get("state")
+				if (!state || state !== expectedState) {
+					const errorMsg = "This request isn't valid. Please try logging in again from your terminal."
+					res.writeHead(400, { "Content-Type": "text/html", Connection: "close" })
+					res.end(htmlError("Login error", errorMsg))
+					finish({ error: errorMsg })
+					return
+				}
+
+				// Check for error first
+				const error = url.searchParams.get("error")
+				const errorDescription = url.searchParams.get("error_description")
+				if (error) {
+					const errorMsg = errorDescription || error
+					res.writeHead(200, { "Content-Type": "text/html", Connection: "close" })
+					res.end(htmlError("Authentication failed", errorMsg))
+					finish({ error: errorMsg })
+					return
+				}
+
+				// Extract token
+				const token = url.searchParams.get("token")
+				if (!token) {
+					const errorMsg = "No token was returned by the authentication server"
+					res.writeHead(400, { "Content-Type": "text/html", Connection: "close" })
+					res.end(htmlError("Missing token", errorMsg))
+					finish({ error: errorMsg })
+					return
+				}
+
+				// Success
+				res.writeHead(200, { "Content-Type": "text/html", Connection: "close" })
+				res.end(HTML_SUCCESS)
+				finish({ token })
+			} catch (err) {
+				const message = err instanceof Error ? err.message : String(err)
+				res.writeHead(500, { "Content-Type": "text/plain", Connection: "close" })
+				res.end("Internal server error")
+				finish({ error: `Unexpected server error: ${message}` })
+				req.socket.destroy()
+			}
+		}
+
+		server = createServer(onRequest)
+
+		server.listen(0, "127.0.0.1", () => {
+			const addr = server?.address()
+			if (!addr || typeof addr === "string") {
+				closeServer()
+				rejectStart(new Error("Could not determine callback server port"))
+				return
+			}
+
+			const port = addr.port
+
+			timeoutTimer = setTimeout(() => {
+				finish({ error: "Browser login timed out -- please try again" })
+			}, CALLBACK_TIMEOUT_MS)
+
+			const resultPromise = new Promise<CallbackResult>((resolve) => {
+				resolveResult = resolve
+			})
+
+			resolveStart({
+				port,
+				url: `http://127.0.0.1:${port}${CALLBACK_PATH}`,
+				result: resultPromise,
+				close: () => {
+					finish({ error: "Login cancelled" })
+				},
+			})
+		})
+
+		server.on("error", (err) => {
+			closeServer()
+			rejectStart(err)
+		})
+	})
+}
+
+/**
+ * Generate a random state string for CSRF protection.
+ */
+export function generateState(): string {
+	return randomBytes(32).toString("hex")
+}

--- a/src/cli-auth/index.test.ts
+++ b/src/cli-auth/index.test.ts
@@ -1,0 +1,66 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
+
+const openMock = vi.hoisted(() => vi.fn<(_url: string) => Promise<void>>())
+vi.mock("open", () => ({ default: openMock }))
+
+const { authenticateViaBrowser } = await import("./index.js")
+
+describe("authenticateViaBrowser", () => {
+	beforeEach(() => {
+		openMock.mockClear()
+		vi.spyOn(console, "log").mockImplementation(() => {})
+	})
+
+	afterEach(() => {
+		vi.restoreAllMocks()
+	})
+
+	it("returns the token when the callback succeeds", async () => {
+		openMock.mockResolvedValue(undefined)
+
+		const promise = authenticateViaBrowser({ webAppUrl: "https://app.kimchi.dev" })
+		await vi.waitFor(() => {
+			expect(openMock).toHaveBeenCalledTimes(1)
+		})
+
+		expect(openMock).toHaveBeenCalledTimes(1)
+		const browserUrl = openMock.mock.calls[0][0]
+		expect(browserUrl).toMatch(/https:\/\/app\.kimchi\.dev\/cli-auth\?callback=/)
+		expect(browserUrl).toMatch(/&state=[0-9a-f]{64}/)
+
+		const urlObj = new URL(browserUrl)
+		const callbackUrl = decodeURIComponent(urlObj.searchParams.get("callback") || "")
+		const state = urlObj.searchParams.get("state") || ""
+
+		const res = await fetch(`${callbackUrl}?token=castai_v1_test_token_123&state=${state}`)
+		expect(res.status).toBe(200)
+
+		const result = await promise
+		expect(result.token).toBe("castai_v1_test_token_123")
+	})
+
+	it("throws when the browser callback returns an error", async () => {
+		openMock.mockResolvedValue(undefined)
+
+		const promise = authenticateViaBrowser({ webAppUrl: "https://app.kimchi.dev" })
+		let rejection: Error | undefined
+		promise.catch((err) => {
+			rejection = err instanceof Error ? err : new Error(String(err))
+		})
+		await vi.waitFor(() => {
+			expect(openMock).toHaveBeenCalledTimes(1)
+		})
+
+		expect(openMock).toHaveBeenCalledTimes(1)
+		const browserUrl = openMock.mock.calls[0][0]
+		const urlObj = new URL(browserUrl)
+		const callbackUrl = decodeURIComponent(urlObj.searchParams.get("callback") || "")
+		const state = urlObj.searchParams.get("state") || ""
+
+		const res = await fetch(`${callbackUrl}?error=access_denied&error_description=User+cancelled&state=${state}`)
+		await res.text()
+
+		expect(rejection).toBeInstanceOf(Error)
+		expect((rejection as Error).message).toMatch(/User cancelled/)
+	})
+})

--- a/src/cli-auth/index.ts
+++ b/src/cli-auth/index.ts
@@ -1,0 +1,76 @@
+/**
+ * CLI Browser Authentication Orchestration
+ *
+ * Starts a localhost callback server, opens the user's browser to the
+ * Kimchi web app login page, and waits for the token to be delivered
+ * back to the callback.
+ */
+
+import type { ChildProcess } from "node:child_process"
+import open from "open"
+import { envConfig } from "../config.js"
+import { generateState, startCallbackServer } from "./callback-server.js"
+
+export interface BrowserAuthOptions {
+	/** Base URL of the Kimchi web app (default: https://app.kimchi.dev) */
+	webAppUrl?: string
+	/** Override for testing: bypass browser open and print URL instead */
+	quiet?: boolean
+	/** Injected open function for testing */
+	_open?: (url: string) => Promise<ChildProcess | undefined>
+}
+
+/**
+ * Authenticate via browser.  The user is redirected to the Kimchi web
+ * app, logs in if necessary, and the resulting API key is sent back to
+ * a transient localhost callback server.
+ *
+ * @returns The raw API key token (e.g. "castai_v1_…")
+ * @throws If the user cancels, the browser flow errors, or times out.
+ */
+export interface BrowserAuthResult {
+	token: string
+}
+
+export async function authenticateViaBrowser(options: BrowserAuthOptions = {}): Promise<BrowserAuthResult> {
+	const webAppUrl = options.webAppUrl ?? envConfig.KIMCHI_WEB_APP_URL
+	const state = generateState()
+
+	const callbackServer = await startCallbackServer(state)
+
+	try {
+		const callbackUrl = encodeURIComponent(callbackServer.url)
+		const browserUrl = `${webAppUrl}/cli-auth?callback=${callbackUrl}&state=${encodeURIComponent(state)}`
+
+		console.log(`Kimchi login: ${browserUrl}`)
+
+		if (options.quiet) {
+			console.log("If the browser did not open automatically, visit the URL above.")
+		} else {
+			console.log("Opening your browser to complete login…")
+			const opener = options._open ?? open
+			try {
+				await opener(browserUrl)
+			} catch {
+				console.log("Couldn't open your browser automatically. Please visit the URL above manually.")
+			}
+		}
+
+		const result = await callbackServer.result
+
+		if (result.error) {
+			throw new Error(`Browser login failed: ${result.error}`)
+		}
+
+		if (!result.token) {
+			throw new Error("Browser login completed but no token was received")
+		}
+
+		callbackServer.close()
+		return { token: result.token }
+	} catch (err) {
+		// Ensure the callback server is torn down on any error path
+		callbackServer.close()
+		throw err
+	}
+}

--- a/src/commands/login.ts
+++ b/src/commands/login.ts
@@ -1,0 +1,46 @@
+import { spinner } from "@clack/prompts"
+import { authenticateViaBrowser } from "../cli-auth/index.js"
+import { writeApiKey } from "../config.js"
+import { exportEnvToShellProfile } from "../setup-wizard/shell-profile.js"
+
+const KIMCHI_API_KEY_ENV = "KIMCHI_API_KEY"
+
+export async function runLogin(_args: string[]): Promise<number> {
+	const s = spinner()
+	s.start("Waiting for browser login…")
+
+	let token: string
+	try {
+		const result = await authenticateViaBrowser()
+		token = result.token
+		s.stop("Browser login succeeded.")
+	} catch (err) {
+		s.stop("Browser login failed.")
+		console.error(err instanceof Error ? err.message : String(err))
+		return 1
+	}
+
+	try {
+		writeApiKey(token)
+	} catch (err) {
+		console.error(`Failed to save API key to config: ${err instanceof Error ? err.message : String(err)}`)
+		return 1
+	}
+
+	const keyExport = exportEnvToShellProfile(KIMCHI_API_KEY_ENV, token)
+	if (keyExport.path) {
+		console.log(`${KIMCHI_API_KEY_ENV} exported to ${keyExport.path}`)
+	} else if (keyExport.error) {
+		console.warn(`Could not export ${KIMCHI_API_KEY_ENV} to shell profile: ${keyExport.error}`)
+	}
+
+	return 0
+}
+
+export function getLoginHelp(): string {
+	const lines: string[] = [
+		"Open the browser to log in to Kimchi via our web app and generate an API key.",
+		"Your shell profile will be updated with the key so future sessions pick it up.",
+	]
+	return lines.join("\n")
+}

--- a/src/commands/registry.ts
+++ b/src/commands/registry.ts
@@ -9,6 +9,7 @@ import { runClaude } from "./claude.js"
 import { runConfig } from "./config.js"
 import { runCursor } from "./cursor.js"
 import { runGsd2 } from "./gsd2.js"
+import { runLogin } from "./login.js"
 import { runOpenClaw } from "./openclaw.js"
 import { runOpenCode } from "./opencode.js"
 import { runSetup } from "./setup.js"
@@ -17,6 +18,7 @@ import { runVersion } from "./version.js"
 
 export const COMMANDS: CommandDefinition[] = [
 	{ name: "setup", summary: "Run the interactive setup wizard", run: runSetup },
+	{ name: "login", summary: "Log in via browser and update your API key", run: runLogin },
 	{ name: "claude", summary: "Configure Claude Code to use Kimchi (and launch it)", run: runClaude },
 	{ name: "opencode", summary: "Configure OpenCode to use Kimchi (and launch it)", run: runOpenCode },
 	{ name: "cursor", summary: "Configure Cursor to use Kimchi", run: runCursor },

--- a/src/config.ts
+++ b/src/config.ts
@@ -11,6 +11,10 @@ export const ALWAYS_SHOWN_SKILL_PATHS = [join(".config", "kimchi", "harness", "s
 
 export const OPTIONAL_SKILL_PATHS = [join(".pi", "agent", "skills"), join(".claude", "skills")]
 
+export const envConfig = {
+	KIMCHI_WEB_APP_URL: process.env.KIMCHI_WEB_APP_URL ?? "https://app.kimchi.dev",
+}
+
 export const DEFAULT_SKILL_PATHS = [...ALWAYS_SHOWN_SKILL_PATHS, ...OPTIONAL_SKILL_PATHS]
 
 export function buildSkillPathOptions(discoveredDirs: string[]): string[] {
@@ -249,7 +253,10 @@ export function getAgentConfigDir(): string {
 function writeConfigField(key: string, value: unknown, configPath: string): void {
 	let raw: Record<string, unknown> = {}
 	try {
-		raw = JSON.parse(readFileSync(configPath, "utf-8")) as Record<string, unknown>
+		const parsed = JSON.parse(readFileSync(configPath, "utf-8"))
+		if (parsed && typeof parsed === "object" && !Array.isArray(parsed)) {
+			raw = parsed as Record<string, unknown>
+		}
 	} catch {
 		// file missing or invalid — start fresh
 	}
@@ -269,7 +276,24 @@ export function writeSkillPaths(paths: string[], configPath?: string): void {
 }
 
 export function writeApiKey(key: string, configPath?: string): void {
-	writeConfigField("apiKey", key, configPath ?? KIMCHI_CONFIG_PATH)
+	const path = configPath ?? KIMCHI_CONFIG_PATH
+	let raw: Record<string, unknown> = {}
+	try {
+		const parsed = JSON.parse(readFileSync(path, "utf-8"))
+		if (parsed && typeof parsed === "object" && !Array.isArray(parsed)) {
+			raw = parsed as Record<string, unknown>
+		}
+	} catch {
+		// file missing or invalid — start fresh
+	}
+	raw.apiKey = key
+	// Clear legacy snake_case key so we don't keep stale data
+	// biome-ignore lint/performance/noDelete: explicit removal is clearer than relying on JSON.stringify to silently drop undefined values
+	delete raw.api_key
+	mkdirSync(dirname(path), { recursive: true })
+	const tmp = `${path}.${process.pid}.tmp`
+	writeFileSync(tmp, `${JSON.stringify(raw, null, 2)}\n`, "utf-8")
+	renameSync(tmp, path)
 }
 
 /**
@@ -283,7 +307,10 @@ export function writeTelemetryEnabled(enabled: boolean, configPath?: string): vo
 	const path = configPath ?? KIMCHI_CONFIG_PATH
 	let raw: Record<string, unknown> = {}
 	try {
-		raw = JSON.parse(readFileSync(path, "utf-8")) as Record<string, unknown>
+		const parsed = JSON.parse(readFileSync(path, "utf-8"))
+		if (parsed && typeof parsed === "object" && !Array.isArray(parsed)) {
+			raw = parsed as Record<string, unknown>
+		}
 	} catch {
 		// file missing or invalid — start fresh
 	}
@@ -300,7 +327,10 @@ export function clearApiKey(configPath?: string): void {
 	const path = configPath ?? KIMCHI_CONFIG_PATH
 	let raw: Record<string, unknown> = {}
 	try {
-		raw = JSON.parse(readFileSync(path, "utf-8")) as Record<string, unknown>
+		const parsed = JSON.parse(readFileSync(path, "utf-8"))
+		if (parsed && typeof parsed === "object" && !Array.isArray(parsed)) {
+			raw = parsed as Record<string, unknown>
+		}
 	} catch {
 		return
 	}

--- a/src/setup-wizard/prompt.ts
+++ b/src/setup-wizard/prompt.ts
@@ -117,7 +117,10 @@ export async function password(opts: {
 	validate?: (v: string | undefined) => string | undefined
 	backable: boolean
 }): Promise<Outcome<string>> {
-	return awaitWithCancelDetection(opts.backable, () =>
-		clackPassword({ message: opts.message, validate: opts.validate }),
+	const result = await awaitWithCancelDetection<string | undefined>(
+		opts.backable,
+		() => clackPassword({ message: opts.message, validate: opts.validate }) as Promise<string | symbol | undefined>,
 	)
+	if (result.kind !== "next") return result
+	return { kind: "next", value: result.value ?? "" }
 }

--- a/src/setup-wizard/steps/auth.test.ts
+++ b/src/setup-wizard/steps/auth.test.ts
@@ -1,0 +1,140 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
+import type { WizardState } from "../state.js"
+
+// Hoisted mocks so they are installed before the module under test is loaded.
+const validateApiKeyMock = vi.hoisted(() => vi.fn())
+const authenticateViaBrowserMock = vi.hoisted(() => vi.fn())
+const writeApiKeyMock = vi.hoisted(() => vi.fn())
+const readApiKeyFromConfigFileMock = vi.hoisted(() => vi.fn())
+const passwordMock = vi.hoisted(() => vi.fn())
+const confirmMock = vi.hoisted(() => vi.fn())
+
+vi.mock("../../auth/validator.js", () => ({ validateApiKey: validateApiKeyMock }))
+vi.mock("../../cli-auth/index.js", () => ({ authenticateViaBrowser: authenticateViaBrowserMock }))
+vi.mock("../../config.js", () => ({
+	readApiKeyFromConfigFile: readApiKeyFromConfigFileMock,
+	writeApiKey: writeApiKeyMock,
+}))
+vi.mock("../prompt.js", () => ({
+	password: passwordMock,
+	confirm: confirmMock,
+}))
+
+const { runAuthStep } = await import("./auth.js")
+
+describe("runAuthStep", () => {
+	let state: WizardState
+
+	beforeEach(() => {
+		state = {
+			apiKey: "",
+			mode: "override",
+			scope: "global",
+			selectedTools: [],
+			telemetryEnabled: false,
+			back: false,
+			cancelled: false,
+		}
+		process.env.KIMCHI_API_KEY = ""
+		validateApiKeyMock.mockReset()
+		authenticateViaBrowserMock.mockReset()
+		writeApiKeyMock.mockReset()
+		readApiKeyFromConfigFileMock.mockReset()
+		passwordMock.mockReset()
+		confirmMock.mockReset()
+		vi.spyOn(console, "log").mockImplementation(() => {})
+	})
+
+	afterEach(() => {
+		vi.restoreAllMocks()
+	})
+
+	it("validates and saves a pasted API key", async () => {
+		readApiKeyFromConfigFileMock.mockReturnValue(undefined)
+		passwordMock.mockResolvedValue({ kind: "next", value: "paste-key-123" })
+		validateApiKeyMock.mockResolvedValue({ valid: true })
+
+		await runAuthStep(state, { backable: false })
+
+		expect(validateApiKeyMock).toHaveBeenCalledWith("paste-key-123")
+		expect(state.apiKey).toBe("paste-key-123")
+		expect(writeApiKeyMock).toHaveBeenCalledWith("paste-key-123")
+	})
+
+	it("triggers browser auth when the user presses Enter (empty input)", async () => {
+		readApiKeyFromConfigFileMock.mockReturnValue(undefined)
+		passwordMock.mockResolvedValue({ kind: "next", value: "" })
+		authenticateViaBrowserMock.mockResolvedValue({ token: "browser-token-456" })
+		validateApiKeyMock.mockResolvedValue({ valid: true })
+
+		await runAuthStep(state, { backable: false })
+
+		expect(authenticateViaBrowserMock).toHaveBeenCalledTimes(1)
+		expect(validateApiKeyMock).toHaveBeenCalledTimes(0)
+		expect(state.apiKey).toBe("browser-token-456")
+		expect(writeApiKeyMock).toHaveBeenCalledWith("browser-token-456")
+	})
+
+	it("retries when browser auth fails and then asks for manual input", async () => {
+		readApiKeyFromConfigFileMock.mockReturnValue(undefined)
+		passwordMock
+			.mockResolvedValueOnce({ kind: "next", value: "" })
+			.mockResolvedValueOnce({ kind: "next", value: "fallback-key-789" })
+		authenticateViaBrowserMock.mockRejectedValue(new Error("Browser refused"))
+		validateApiKeyMock.mockResolvedValue({ valid: true })
+
+		await runAuthStep(state, { backable: false })
+
+		expect(authenticateViaBrowserMock).toHaveBeenCalledTimes(1)
+		// After browser failure it loops back and prompts again
+		expect(passwordMock).toHaveBeenCalledTimes(2)
+		expect(validateApiKeyMock).toHaveBeenCalledWith("fallback-key-789")
+		expect(state.apiKey).toBe("fallback-key-789")
+	})
+
+	it("uses the saved key without prompting when one exists and user confirms", async () => {
+		readApiKeyFromConfigFileMock.mockReturnValue("saved-key")
+		confirmMock.mockResolvedValue({ kind: "next", value: true })
+		validateApiKeyMock.mockResolvedValue({ valid: true })
+
+		await runAuthStep(state, { backable: true })
+
+		expect(confirmMock).toHaveBeenCalledTimes(1)
+		expect(validateApiKeyMock).toHaveBeenCalledWith("saved-key")
+		expect(passwordMock).not.toHaveBeenCalled()
+		expect(state.apiKey).toBe("saved-key")
+	})
+
+	it("prompts for a new key when the saved key is rejected and user opts to replace", async () => {
+		readApiKeyFromConfigFileMock.mockReturnValue("saved-key")
+		confirmMock.mockResolvedValue({ kind: "next", value: false }) // user says "don't keep it"
+		passwordMock.mockResolvedValue({ kind: "next", value: "new-key-abc" })
+		validateApiKeyMock.mockResolvedValue({ valid: true })
+
+		await runAuthStep(state, { backable: true })
+
+		expect(confirmMock).toHaveBeenCalledTimes(1)
+		expect(passwordMock).toHaveBeenCalledTimes(1)
+		expect(validateApiKeyMock).toHaveBeenCalledWith("new-key-abc")
+		expect(state.apiKey).toBe("new-key-abc")
+	})
+
+	it("sets state.back when user presses Esc in the prompt", async () => {
+		readApiKeyFromConfigFileMock.mockReturnValue(undefined)
+		passwordMock.mockResolvedValue({ kind: "back" })
+
+		await runAuthStep(state, { backable: true })
+
+		expect(state.back).toBe(true)
+		expect(authenticateViaBrowserMock).not.toHaveBeenCalled()
+	})
+
+	it("sets state.cancelled when user presses Ctrl-C", async () => {
+		readApiKeyFromConfigFileMock.mockReturnValue(undefined)
+		passwordMock.mockResolvedValue({ kind: "cancel" })
+
+		await runAuthStep(state, { backable: true })
+
+		expect(state.cancelled).toBe(true)
+	})
+})

--- a/src/setup-wizard/steps/auth.ts
+++ b/src/setup-wizard/steps/auth.ts
@@ -1,5 +1,6 @@
 import { spinner } from "@clack/prompts"
 import { validateApiKey } from "../../auth/validator.js"
+import { authenticateViaBrowser } from "../../cli-auth/index.js"
 import { readApiKeyFromConfigFile, writeApiKey } from "../../config.js"
 import { confirm, password } from "../prompt.js"
 import type { WizardState } from "../state.js"
@@ -66,8 +67,7 @@ export async function runAuthStep(state: WizardState, opts: { backable: boolean 
 async function promptAndValidateKey(state: WizardState, backable: boolean): Promise<void> {
 	for (;;) {
 		const entered = await password({
-			message: "Paste your kimchi API key (get one at https://app.kimchi.dev → API Keys → Create API Key)",
-			validate: (v) => (v && v.length > 0 ? undefined : "API key cannot be empty"),
+			message: "Paste your Kimchi API key, or press Enter to log in via browser",
 			backable,
 		})
 		if (entered.kind === "back") {
@@ -79,12 +79,46 @@ async function promptAndValidateKey(state: WizardState, backable: boolean): Prom
 			return
 		}
 
+		let tokenToValidate: string
+
+		if (entered.value.length === 0) {
+			// Browser-based authentication — token was just created by the backend,
+			// so it's valid. Skip the separate validation roundtrip, which may
+			// hit a different environment (e.g. prod validator vs dev-master token).
+			const s = spinner()
+			s.start("Waiting for browser login…")
+			let token: string
+			try {
+				const result = await authenticateViaBrowser()
+				token = result.token
+				s.stop("Browser login succeeded.")
+			} catch (err) {
+				s.stop("Browser login failed.")
+				console.error(`  ${err instanceof Error ? err.message : String(err)}`)
+				console.log("  Paste your API key below, or press Esc to go back.")
+				continue
+			}
+
+			try {
+				writeApiKey(token)
+			} catch (err) {
+				console.error(`  Failed to save API key to config: ${err instanceof Error ? err.message : String(err)}`)
+				console.log("  Paste your API key below, or press Esc to go back.")
+				continue
+			}
+
+			state.apiKey = token
+			return
+		}
+
+		tokenToValidate = entered.value
+
 		const s = spinner()
 		s.start("Validating API key…")
-		const result = await validateApiKey(entered.value)
+		const result = await validateApiKey(tokenToValidate)
 		if (result.valid) {
 			s.stop("API key valid.")
-			state.apiKey = entered.value
+			state.apiKey = tokenToValidate
 			writeApiKey(state.apiKey)
 			return
 		}


### PR DESCRIPTION
https://github.com/user-attachments/assets/4202a582-d8a1-4473-abc9-7913f0dbaf46


- Standalone /cli-auth route outside AppShell layout
- Multi-org support: fetches user's orgs, shows dropdown when >1
- Auto-selects single org, skips picker
- Auto-generates unique token names (Kimchi CLI, Kimchi CLI (2), ...)
- Auto-redirects on error after 5s so CLI doesn't hang
- Passes orgId back to CLI via callback URL parameter
- Security: validates callback is localhost only
- Error handling with back-to-CLI button

---
### Kimchi Summary
### What changed
Adds a `login` command and browser-based authentication flow so users can authenticate the Kimchi CLI via a web redirect instead of manually creating and pasting an API key. The interactive setup wizard now offers browser login when the user presses Enter at the API key prompt.

### Why
Manually copying API keys is friction for new users. A browser redirect lets the CLI receive a freshly issued token directly from the Kimchi web app.

### Key changes
- Add `src/cli-auth/callback-server.ts`: transient localhost HTTP server (`startCallbackServer`) that binds to `127.0.0.1`, validates the CSRF `state` parameter, returns styled success/error HTML pages, and enforces a 5-minute timeout.
- Add `src/cli-auth/index.ts`: `authenticateViaBrowser()` generates state, opens the user's browser, and resolves with the token delivered to the callback.
- Add `src/commands/login.ts`: implements `kimchi login`, which authenticates via browser, persists the token with `writeApiKey()`, and exports `KIMCHI_API_KEY` to the shell profile.
- Register the `login` command in `src/commands/registry.ts`.
- Update `src/setup-wizard/steps/auth.ts`: empty input at the API key prompt triggers browser auth; browser-issued tokens skip the separate `validateApiKey()` roundtrip. If browser auth fails the wizard falls back to manual key entry.
- Fix `password()` in `src/setup-wizard/prompt.ts` to return `""` instead of `undefined` so the wizard can detect Enter-without-input.
- Harden `writeApiKey()` and related config helpers in `src/config.ts`: guard against non-object JSON, write atomically via temp file + `renameSync`, clear the legacy `api_key` field, and add `envConfig.KIMCHI_WEB_APP_URL` for the browser login target.
- Add unit tests in `src/cli-auth/callback-server.test.ts`, `src/cli-auth/index.test.ts`, and `src/setup-wizard/steps/auth.test.ts`.

### Impact
- The callback server rejects non-loopback connections with `403`, mitigating token interception from remote hosts.
- Config writes are now atomic, reducing the risk of corrupt files on process crash.
- Browser auth falls back cleanly to manual API key entry if the browser cannot be opened or the user cancels.