### PR TITLE
LLM-1633: Add `set_model` tool for dynamic model switching

### DIFF
--- a/benchmark/audit-session/audit-session.sh
+++ b/benchmark/audit-session/audit-session.sh
@@ -219,7 +219,6 @@ sed \
     -e "s|{auditModel}|${EFFECTIVE_MODEL}|g" \
     "$PROMPT_FILE" > "$TMPFILE"
 
-# Runs the audit harness. Output goes directly to stdout so the user sees live progress.
 run_audit_agent() {
     local runner="$1"
     local model="$2"
@@ -239,8 +238,6 @@ run_audit_agent() {
     esac
 }
 
-# Extract the last fenced JSON block from the markdown report and write a sidecar file.
-# Only the sidecar file path is printed to stdout; diagnostics go to stderr.
 extract_json_sidecar() {
     local audit_file="$1"
     local sidecar_file="${audit_file%.md}-AUDIT.json"
@@ -250,8 +247,6 @@ extract_json_sidecar() {
         return 1
     fi
 
-    # Extract the *last* ```json … ``` fenced block, strip the fence lines, and
-    # remove trailing whitespace so jq never sees a stray backslash before EOF.
     local json_content
     json_content="$(awk '
         /^```json$/     { buf=""; in_block=1; next }
@@ -283,8 +278,6 @@ extract_json_sidecar() {
 echo "Running audit agent ($RUNNER, $EFFECTIVE_MODEL)..."
 echo ""
 
-# Run agent interactively (no pipe — preserves TTY so the harness TUI uses the
-# full terminal width instead of falling back to the default 80 columns).
 run_audit_agent "$RUNNER" "$EFFECTIVE_MODEL" "$TMPFILE"
 
 echo ""

--- a/benchmark/audit-session/audit-session.sh
+++ b/benchmark/audit-session/audit-session.sh
@@ -240,7 +240,7 @@ run_audit_agent() {
 
 extract_json_sidecar() {
     local audit_file="$1"
-    local sidecar_file="${audit_file%.md}-AUDIT.json"
+    local sidecar_file="${audit_file%.md}.json"
 
     if [[ ! -f "$audit_file" ]]; then
         echo "Audit file not found: $audit_file" >&2
@@ -284,8 +284,11 @@ echo ""
 audit_file=".kimchi/audits/$AUDIT_FILENAME"
 if [[ -s "$audit_file" ]]; then
     echo "Audit report written: $audit_file"
-    sidecar=$(extract_json_sidecar "$audit_file")
-    echo "JSON sidecar written: $sidecar"
+    if sidecar=$(extract_json_sidecar "$audit_file"); then
+        echo "JSON sidecar written: $sidecar"
+    else
+        echo "Warning: JSON sidecar extraction failed" >&2
+    fi
 else
     echo "Warning: audit report is empty or was not written" >&2
 fi

--- a/benchmark/manual/README.md
+++ b/benchmark/manual/README.md
@@ -89,6 +89,7 @@ See `tasks.md` for full prompts, baseline implementations, and expected behavior
 | complex | Go REST API task management (layered architecture) | 2–6 subagents, <10 min, <700k tokens |
 | complex-single | Same as complex, single-model mode | 1–5 subagents, <10 min, <500k tokens |
 | research | Top 3 Go HTTP router libraries with stars and examples | 0 subagents, <2 min, <30k tokens |
+| explore | Find and fix missing input validation in existing Go API | 1–4 subagents, <10 min, <500k tokens |
 
 ## Session directory structure
 

--- a/benchmark/manual/analyze-session.py
+++ b/benchmark/manual/analyze-session.py
@@ -42,6 +42,12 @@ TASK_CRITERIA = {
         "max_tokens": 800_000,
         "max_duration_s": 900,
     },
+    "explore": {
+        "min_subagents": 1,
+        "max_subagents": 4,
+        "max_tokens": 500_000,
+        "max_duration_s": 600,
+    },
 }
 
 

--- a/benchmark/manual/check-session.py
+++ b/benchmark/manual/check-session.py
@@ -24,7 +24,7 @@ from pathlib import Path
 IMPROVEMENT_DIR = Path(__file__).parent
 SESSIONS_DIR = IMPROVEMENT_DIR / "sessions"
 
-INACTIVITY_THRESHOLD_S = 180  # 3 minutes with no log writes → stalled
+INACTIVITY_THRESHOLD_S = 600  # 10 minutes
 
 
 def check_jsonl(path: Path) -> dict:

--- a/benchmark/manual/check-session.py
+++ b/benchmark/manual/check-session.py
@@ -24,7 +24,7 @@ from pathlib import Path
 IMPROVEMENT_DIR = Path(__file__).parent
 SESSIONS_DIR = IMPROVEMENT_DIR / "sessions"
 
-INACTIVITY_THRESHOLD_S = 600  # 10 minutes
+INACTIVITY_THRESHOLD_S = 1800  # 30 minutes
 
 
 def check_jsonl(path: Path) -> dict:

--- a/benchmark/manual/new-session.sh
+++ b/benchmark/manual/new-session.sh
@@ -69,6 +69,23 @@ research_prompt = (
     "and a one-line example of defining a route with a path parameter."
 )
 
+explore_seed = os.path.join(os.path.dirname(benchmark_json), "seeds", "explore-refactor")
+explore_prompt = (
+    "The directory $DIR/usermgmt/ contains an existing Go HTTP API for user and team management. "
+    "Explore the codebase, find all HTTP handlers that are missing input validation, and fix them. "
+    "Requirements: "
+    "- First explore the entire codebase to build a map of all handlers and their validation status. "
+    "- Write a plan listing every handler endpoint, what validation is missing, and what you will add. "
+    "- Implement the validation fixes. Specific issues to find and fix: "
+    "  - Handlers that accept arbitrary strings for fields with a fixed set of valid values (e.g. roles) "
+    "  - Handlers that accept zero or negative integers for fields that must be positive "
+    "  - Handlers that accept empty strings for required fields at the HTTP layer (even if the service layer also checks) "
+    "  - Search/filter endpoints with no length limit on query parameters "
+    "  - Pagination parameters with no bounds checking (negative offsets, excessively large limits) "
+    "- Add unit tests for the validation logic using map-based test cases. "
+    "- Do not change the project structure or add external dependencies."
+)
+
 mega_prompt = (
     "Implement a Go CLI application that acts as a concurrent build system, similar to a simplified Make. "
     "This is a multi-layer project — start with a plan before writing any code. "
@@ -91,26 +108,30 @@ mega_prompt = (
     "Put all code in directory: $DIR/buildtool/"
 )
 
-# Fourth element: include_in_run_all (default True)
+# Fields: (name, prompt, extra_flags, include_in_run_all, setup_cmd or None)
 tasks = [
-    ("simple",         simple_prompt,  [],                      True),
-    ("complex",        complex_prompt, [],                      True),
-    ("complex-single", complex_prompt, ["--multi-model=false"], True),
-    ("research",       research_prompt,[],                      True),
-    ("mega",           mega_prompt,    [],                      False),
+    ("simple",         simple_prompt,  [],                      True,  None),
+    ("complex",        complex_prompt, [],                      True,  None),
+    ("complex-single", complex_prompt, ["--multi-model=false"], True,  None),
+    ("research",       research_prompt,[],                      True,  None),
+    ("explore",        explore_prompt, [],                      True,  f'mkdir -p "$DIR/usermgmt" && cp -R "{explore_seed}/"* "$DIR/usermgmt/"'),
+    ("mega",           mega_prompt,    [],                      False, None),
 ]
 
 all_scripts = []
 run_all_scripts = []
 for model in models:
     print(f"model: kimchi-dev/{model}")
-    for task, task_prompt, extra_flags, in_run_all in tasks:
+    for task, task_prompt, extra_flags, in_run_all, setup_cmd in tasks:
         run_dir = f"{task}-{model}"
         os.makedirs(os.path.join(session_dir, "runs", run_dir), exist_ok=True)
         slug = f"s{n}-{task}-{model}"
         script_path = os.path.join(session_dir, f"run-{task}-{model}.sh")
         flags = "\n".join(f"  {flag} \\" for flag in extra_flags)
         flags_block = (flags + "\n") if flags else ""
+        setup_block = ""
+        if setup_cmd:
+            setup_block = f"{setup_cmd}\n"
         content = f"""#!/bin/zsh
 TS=$(date +%Y%m%d-%H%M%S)
 SESSION_FILE="{session_dir}/runs/{run_dir}/session-${{TS}}.jsonl"
@@ -118,7 +139,7 @@ DIR=$(mktemp -d /private/tmp/kimchi-{slug}-XXXXXX)
 echo "Working directory: $DIR"
 echo "Session file: $SESSION_FILE"
 cd "$DIR"
-{binary} \\
+{setup_block}{binary} \\
   --yolo \\
   --model kimchi-dev/{model} \\
 {flags_block}  --session "$SESSION_FILE" \\

--- a/benchmark/manual/new-session.sh
+++ b/benchmark/manual/new-session.sh
@@ -51,6 +51,15 @@ simple_prompt = (
     "Put the code in directory: $DIR/rate-limiter/. Include a README.md explaining usage."
 )
 
+simple_model_switching_prompt = (
+    "Implement a Go HTTP middleware that rate-limits requests per client IP using a token bucket algorithm. "
+    "Requirements: Each IP gets 10 requests per second. Respond with HTTP 429 when limit is exceeded. "
+    "Thread-safe implementation. Include tests with map-based test cases. "
+    "Put the code in directory: $DIR/rate-limiter/. Include a README.md explaining usage. "
+    "Switch the main model to another available model in the kimchi-dev provider every time you change the phase. "
+    "Use the /model command or the model switching capability to do this."
+)
+
 complex_prompt = (
     "Implement a Go REST API for a task management system. "
     "This is a multi-layer project — start with a plan before writing any code. "
@@ -93,11 +102,12 @@ mega_prompt = (
 
 # Fourth element: include_in_run_all (default True)
 tasks = [
-    ("simple",         simple_prompt,  [],                      True),
-    ("complex",        complex_prompt, [],                      True),
-    ("complex-single", complex_prompt, ["--multi-model=false"], True),
-    ("research",       research_prompt,[],                      True),
-    ("mega",           mega_prompt,    [],                      False),
+    ("simple",                  simple_prompt,                [],                      True),
+    ("simple-model-switching",  simple_model_switching_prompt, [],                      False),
+    ("complex",                 complex_prompt,               [],                      True),
+    ("complex-single",          complex_prompt,               ["--multi-model=false"], True),
+    ("research",                research_prompt,              [],                      True),
+    ("mega",                    mega_prompt,                  [],                      False),
 ]
 
 all_scripts = []

--- a/benchmark/manual/new-session.sh
+++ b/benchmark/manual/new-session.sh
@@ -51,15 +51,6 @@ simple_prompt = (
     "Put the code in directory: $DIR/rate-limiter/. Include a README.md explaining usage."
 )
 
-simple_model_switching_prompt = (
-    "Implement a Go HTTP middleware that rate-limits requests per client IP using a token bucket algorithm. "
-    "Requirements: Each IP gets 10 requests per second. Respond with HTTP 429 when limit is exceeded. "
-    "Thread-safe implementation. Include tests with map-based test cases. "
-    "Put the code in directory: $DIR/rate-limiter/. Include a README.md explaining usage. "
-    "Switch the main model to another available model in the kimchi-dev provider every time you change the phase. "
-    "Use the /model command or the model switching capability to do this."
-)
-
 complex_prompt = (
     "Implement a Go REST API for a task management system. "
     "This is a multi-layer project — start with a plan before writing any code. "
@@ -102,12 +93,11 @@ mega_prompt = (
 
 # Fourth element: include_in_run_all (default True)
 tasks = [
-    ("simple",                  simple_prompt,                [],                      True),
-    ("simple-model-switching",  simple_model_switching_prompt, [],                      False),
-    ("complex",                 complex_prompt,               [],                      True),
-    ("complex-single",          complex_prompt,               ["--multi-model=false"], True),
-    ("research",                research_prompt,              [],                      True),
-    ("mega",                    mega_prompt,                  [],                      False),
+    ("simple",         simple_prompt,  [],                      True),
+    ("complex",        complex_prompt, [],                      True),
+    ("complex-single", complex_prompt, ["--multi-model=false"], True),
+    ("research",       research_prompt,[],                      True),
+    ("mega",           mega_prompt,    [],                      False),
 ]
 
 all_scripts = []

--- a/benchmark/manual/seeds/explore-refactor/cmd/server/main.go
+++ b/benchmark/manual/seeds/explore-refactor/cmd/server/main.go
@@ -1,0 +1,37 @@
+package main
+
+import (
+	"fmt"
+	"log"
+	"net/http"
+	"os"
+
+	"github.com/example/usermgmt/internal/handler"
+	"github.com/example/usermgmt/internal/repository"
+	"github.com/example/usermgmt/internal/service"
+)
+
+func main() {
+	userRepo := repository.NewUserRepository()
+	teamRepo := repository.NewTeamRepository()
+	invRepo := repository.NewInvitationRepository()
+	auditRepo := repository.NewAuditRepository()
+
+	userSvc := service.NewUserService(userRepo, teamRepo, auditRepo)
+	teamSvc := service.NewTeamService(teamRepo, auditRepo)
+	invSvc := service.NewInvitationService(invRepo, teamRepo, auditRepo)
+
+	mux := http.NewServeMux()
+	handler.NewUserHandler(userSvc).Register(mux)
+	handler.NewTeamHandler(teamSvc).Register(mux)
+	handler.NewInvitationHandler(invSvc).Register(mux)
+	handler.NewAuditHandler(auditRepo).Register(mux)
+
+	port := os.Getenv("PORT")
+	if port == "" {
+		port = "8080"
+	}
+	addr := fmt.Sprintf(":%s", port)
+	log.Printf("listening on %s", addr)
+	log.Fatal(http.ListenAndServe(addr, mux))
+}

--- a/benchmark/manual/seeds/explore-refactor/go.mod
+++ b/benchmark/manual/seeds/explore-refactor/go.mod
@@ -1,0 +1,3 @@
+module github.com/example/usermgmt
+
+go 1.22

--- a/benchmark/manual/seeds/explore-refactor/internal/handler/audit.go
+++ b/benchmark/manual/seeds/explore-refactor/internal/handler/audit.go
@@ -1,0 +1,39 @@
+package handler
+
+import (
+	"net/http"
+	"strconv"
+
+	"github.com/example/usermgmt/internal/repository"
+)
+
+type AuditHandler struct {
+	repo *repository.AuditRepository
+}
+
+func NewAuditHandler(repo *repository.AuditRepository) *AuditHandler {
+	return &AuditHandler{repo: repo}
+}
+
+func (h *AuditHandler) Register(mux *http.ServeMux) {
+	mux.HandleFunc("GET /audit", h.list)
+	mux.HandleFunc("GET /audit/user/{id}", h.listByUser)
+}
+
+func (h *AuditHandler) list(w http.ResponseWriter, r *http.Request) {
+	// BUG: no validation — offset/limit parsed from query without bounds checking
+	// negative values or extremely large limits are accepted
+	offsetStr := r.URL.Query().Get("offset")
+	limitStr := r.URL.Query().Get("limit")
+	offset, _ := strconv.Atoi(offsetStr)
+	limit, _ := strconv.Atoi(limitStr)
+	if limit == 0 {
+		limit = 50
+	}
+	writeJSON(w, http.StatusOK, h.repo.ListAll(offset, limit))
+}
+
+func (h *AuditHandler) listByUser(w http.ResponseWriter, r *http.Request) {
+	userID := r.PathValue("id")
+	writeJSON(w, http.StatusOK, h.repo.ListByUser(userID))
+}

--- a/benchmark/manual/seeds/explore-refactor/internal/handler/invitation.go
+++ b/benchmark/manual/seeds/explore-refactor/internal/handler/invitation.go
@@ -1,0 +1,56 @@
+package handler
+
+import (
+	"encoding/json"
+	"net/http"
+
+	"github.com/example/usermgmt/internal/service"
+)
+
+type InvitationHandler struct {
+	svc *service.InvitationService
+}
+
+func NewInvitationHandler(svc *service.InvitationService) *InvitationHandler {
+	return &InvitationHandler{svc: svc}
+}
+
+func (h *InvitationHandler) Register(mux *http.ServeMux) {
+	mux.HandleFunc("POST /invitations", h.create)
+	mux.HandleFunc("GET /invitations", h.listByTeam)
+	mux.HandleFunc("DELETE /invitations/{id}", h.revoke)
+}
+
+func (h *InvitationHandler) create(w http.ResponseWriter, r *http.Request) {
+	var body struct {
+		Email  string `json:"email"`
+		TeamID string `json:"team_id"`
+		Role   string `json:"role"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+		writeError(w, http.StatusBadRequest, "invalid JSON")
+		return
+	}
+	// BUG: no validation — email can be empty or malformed, role is arbitrary
+	inv, err := h.svc.Create(body.Email, body.TeamID, body.Role)
+	if err != nil {
+		writeError(w, http.StatusUnprocessableEntity, err.Error())
+		return
+	}
+	writeJSON(w, http.StatusCreated, inv)
+}
+
+func (h *InvitationHandler) listByTeam(w http.ResponseWriter, r *http.Request) {
+	// BUG: no validation — empty team_id returns empty list without error
+	teamID := r.URL.Query().Get("team_id")
+	writeJSON(w, http.StatusOK, h.svc.ListByTeam(teamID))
+}
+
+func (h *InvitationHandler) revoke(w http.ResponseWriter, r *http.Request) {
+	id := r.PathValue("id")
+	if err := h.svc.Revoke(id); err != nil {
+		writeError(w, http.StatusNotFound, err.Error())
+		return
+	}
+	w.WriteHeader(http.StatusNoContent)
+}

--- a/benchmark/manual/seeds/explore-refactor/internal/handler/team.go
+++ b/benchmark/manual/seeds/explore-refactor/internal/handler/team.go
@@ -1,0 +1,86 @@
+package handler
+
+import (
+	"encoding/json"
+	"net/http"
+
+	"github.com/example/usermgmt/internal/service"
+)
+
+type TeamHandler struct {
+	svc *service.TeamService
+}
+
+func NewTeamHandler(svc *service.TeamService) *TeamHandler {
+	return &TeamHandler{svc: svc}
+}
+
+func (h *TeamHandler) Register(mux *http.ServeMux) {
+	mux.HandleFunc("POST /teams", h.create)
+	mux.HandleFunc("GET /teams", h.list)
+	mux.HandleFunc("GET /teams/{id}", h.getByID)
+	mux.HandleFunc("PUT /teams/{id}", h.update)
+	mux.HandleFunc("DELETE /teams/{id}", h.delete)
+}
+
+func (h *TeamHandler) create(w http.ResponseWriter, r *http.Request) {
+	var body struct {
+		Name        string `json:"name"`
+		Description string `json:"description"`
+		MaxMembers  int    `json:"max_members"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+		writeError(w, http.StatusBadRequest, "invalid JSON")
+		return
+	}
+	// BUG: no validation — max_members can be 0 or negative
+	t, err := h.svc.Create(body.Name, body.Description, body.MaxMembers)
+	if err != nil {
+		writeError(w, http.StatusUnprocessableEntity, err.Error())
+		return
+	}
+	writeJSON(w, http.StatusCreated, t)
+}
+
+func (h *TeamHandler) list(w http.ResponseWriter, r *http.Request) {
+	writeJSON(w, http.StatusOK, h.svc.List())
+}
+
+func (h *TeamHandler) getByID(w http.ResponseWriter, r *http.Request) {
+	id := r.PathValue("id")
+	t, err := h.svc.GetByID(id)
+	if err != nil {
+		writeError(w, http.StatusNotFound, err.Error())
+		return
+	}
+	writeJSON(w, http.StatusOK, t)
+}
+
+func (h *TeamHandler) update(w http.ResponseWriter, r *http.Request) {
+	id := r.PathValue("id")
+	var body struct {
+		Name        string `json:"name"`
+		Description string `json:"description"`
+		MaxMembers  int    `json:"max_members"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+		writeError(w, http.StatusBadRequest, "invalid JSON")
+		return
+	}
+	// BUG: no validation — name can be empty, max_members can be negative
+	t, err := h.svc.Update(id, body.Name, body.Description, body.MaxMembers)
+	if err != nil {
+		writeError(w, http.StatusNotFound, err.Error())
+		return
+	}
+	writeJSON(w, http.StatusOK, t)
+}
+
+func (h *TeamHandler) delete(w http.ResponseWriter, r *http.Request) {
+	id := r.PathValue("id")
+	if err := h.svc.Delete(id); err != nil {
+		writeError(w, http.StatusNotFound, err.Error())
+		return
+	}
+	w.WriteHeader(http.StatusNoContent)
+}

--- a/benchmark/manual/seeds/explore-refactor/internal/handler/user.go
+++ b/benchmark/manual/seeds/explore-refactor/internal/handler/user.go
@@ -1,0 +1,126 @@
+package handler
+
+import (
+	"encoding/json"
+	"net/http"
+	"strings"
+
+	"github.com/example/usermgmt/internal/service"
+)
+
+type UserHandler struct {
+	svc *service.UserService
+}
+
+func NewUserHandler(svc *service.UserService) *UserHandler {
+	return &UserHandler{svc: svc}
+}
+
+func (h *UserHandler) Register(mux *http.ServeMux) {
+	mux.HandleFunc("POST /users", h.create)
+	mux.HandleFunc("GET /users", h.list)
+	mux.HandleFunc("GET /users/{id}", h.getByID)
+	mux.HandleFunc("PATCH /users/{id}/role", h.updateRole)
+	mux.HandleFunc("PATCH /users/{id}/team", h.assignTeam)
+	mux.HandleFunc("DELETE /users/{id}", h.delete)
+	mux.HandleFunc("GET /users/search", h.search)
+}
+
+func (h *UserHandler) create(w http.ResponseWriter, r *http.Request) {
+	var body struct {
+		Name   string `json:"name"`
+		Email  string `json:"email"`
+		Role   string `json:"role"`
+		TeamID string `json:"team_id"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+		writeError(w, http.StatusBadRequest, "invalid JSON")
+		return
+	}
+	u, err := h.svc.Create(body.Name, body.Email, body.Role, body.TeamID)
+	if err != nil {
+		writeError(w, http.StatusUnprocessableEntity, err.Error())
+		return
+	}
+	writeJSON(w, http.StatusCreated, u)
+}
+
+func (h *UserHandler) list(w http.ResponseWriter, r *http.Request) {
+	writeJSON(w, http.StatusOK, h.svc.List())
+}
+
+func (h *UserHandler) getByID(w http.ResponseWriter, r *http.Request) {
+	id := r.PathValue("id")
+	u, err := h.svc.GetByID(id)
+	if err != nil {
+		writeError(w, http.StatusNotFound, err.Error())
+		return
+	}
+	writeJSON(w, http.StatusOK, u)
+}
+
+func (h *UserHandler) updateRole(w http.ResponseWriter, r *http.Request) {
+	id := r.PathValue("id")
+	var body struct {
+		Role string `json:"role"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+		writeError(w, http.StatusBadRequest, "invalid JSON")
+		return
+	}
+	// BUG: no validation — any arbitrary string accepted as role
+	u, err := h.svc.UpdateRole(id, body.Role)
+	if err != nil {
+		writeError(w, http.StatusNotFound, err.Error())
+		return
+	}
+	writeJSON(w, http.StatusOK, u)
+}
+
+func (h *UserHandler) assignTeam(w http.ResponseWriter, r *http.Request) {
+	id := r.PathValue("id")
+	var body struct {
+		TeamID string `json:"team_id"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+		writeError(w, http.StatusBadRequest, "invalid JSON")
+		return
+	}
+	// BUG: no validation — empty team_id accepted without error
+	u, err := h.svc.AssignTeam(id, body.TeamID)
+	if err != nil {
+		writeError(w, http.StatusUnprocessableEntity, err.Error())
+		return
+	}
+	writeJSON(w, http.StatusOK, u)
+}
+
+func (h *UserHandler) delete(w http.ResponseWriter, r *http.Request) {
+	id := r.PathValue("id")
+	if err := h.svc.Delete(id); err != nil {
+		writeError(w, http.StatusNotFound, err.Error())
+		return
+	}
+	w.WriteHeader(http.StatusNoContent)
+}
+
+func (h *UserHandler) search(w http.ResponseWriter, r *http.Request) {
+	// BUG: no validation or length limit on filter — accepts any string, no max length
+	filter := r.URL.Query().Get("q")
+	results := h.svc.Search(filter)
+	writeJSON(w, http.StatusOK, results)
+}
+
+func writeJSON(w http.ResponseWriter, status int, v any) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(status)
+	json.NewEncoder(w).Encode(v)
+}
+
+func writeError(w http.ResponseWriter, status int, message string) {
+	writeJSON(w, status, map[string]string{"error": message})
+}
+
+func extractID(path, prefix string) string {
+	return strings.TrimPrefix(path, prefix)
+}

--- a/benchmark/manual/seeds/explore-refactor/internal/model/model.go
+++ b/benchmark/manual/seeds/explore-refactor/internal/model/model.go
@@ -1,0 +1,37 @@
+package model
+
+import "time"
+
+type User struct {
+	ID        string    `json:"id"`
+	Name      string    `json:"name"`
+	Email     string    `json:"email"`
+	Role      string    `json:"role"`
+	TeamID    string    `json:"team_id"`
+	CreatedAt time.Time `json:"created_at"`
+}
+
+type Team struct {
+	ID          string    `json:"id"`
+	Name        string    `json:"name"`
+	Description string    `json:"description"`
+	MaxMembers  int       `json:"max_members"`
+	CreatedAt   time.Time `json:"created_at"`
+}
+
+type Invitation struct {
+	ID        string    `json:"id"`
+	Email     string    `json:"email"`
+	TeamID    string    `json:"team_id"`
+	Role      string    `json:"role"`
+	ExpiresAt time.Time `json:"expires_at"`
+	CreatedAt time.Time `json:"created_at"`
+}
+
+type AuditEntry struct {
+	ID        string    `json:"id"`
+	UserID    string    `json:"user_id"`
+	Action    string    `json:"action"`
+	Detail    string    `json:"detail"`
+	CreatedAt time.Time `json:"created_at"`
+}

--- a/benchmark/manual/seeds/explore-refactor/internal/repository/audit.go
+++ b/benchmark/manual/seeds/explore-refactor/internal/repository/audit.go
@@ -1,0 +1,57 @@
+package repository
+
+import (
+	"fmt"
+	"sync"
+	"time"
+
+	"github.com/example/usermgmt/internal/model"
+)
+
+type AuditRepository struct {
+	mu      sync.RWMutex
+	entries []model.AuditEntry
+	seq     int
+}
+
+func NewAuditRepository() *AuditRepository {
+	return &AuditRepository{}
+}
+
+func (r *AuditRepository) Append(userID, action, detail string) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.seq++
+	r.entries = append(r.entries, model.AuditEntry{
+		ID:        fmt.Sprintf("a-%d", r.seq),
+		UserID:    userID,
+		Action:    action,
+		Detail:    detail,
+		CreatedAt: time.Now(),
+	})
+}
+
+func (r *AuditRepository) ListByUser(userID string) []model.AuditEntry {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	out := make([]model.AuditEntry, 0)
+	for _, e := range r.entries {
+		if e.UserID == userID {
+			out = append(out, e)
+		}
+	}
+	return out
+}
+
+func (r *AuditRepository) ListAll(offset, limit int) []model.AuditEntry {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	if offset >= len(r.entries) {
+		return nil
+	}
+	end := offset + limit
+	if end > len(r.entries) {
+		end = len(r.entries)
+	}
+	return r.entries[offset:end]
+}

--- a/benchmark/manual/seeds/explore-refactor/internal/repository/invitation.go
+++ b/benchmark/manual/seeds/explore-refactor/internal/repository/invitation.go
@@ -1,0 +1,58 @@
+package repository
+
+import (
+	"fmt"
+	"sync"
+	"time"
+
+	"github.com/example/usermgmt/internal/model"
+)
+
+type InvitationRepository struct {
+	mu          sync.RWMutex
+	invitations map[string]model.Invitation
+	seq         int
+}
+
+func NewInvitationRepository() *InvitationRepository {
+	return &InvitationRepository{invitations: make(map[string]model.Invitation)}
+}
+
+func (r *InvitationRepository) Create(inv model.Invitation) model.Invitation {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.seq++
+	inv.ID = fmt.Sprintf("inv-%d", r.seq)
+	inv.CreatedAt = time.Now()
+	r.invitations[inv.ID] = inv
+	return inv
+}
+
+func (r *InvitationRepository) GetByID(id string) (model.Invitation, bool) {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	inv, ok := r.invitations[id]
+	return inv, ok
+}
+
+func (r *InvitationRepository) ListByTeam(teamID string) []model.Invitation {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	out := make([]model.Invitation, 0)
+	for _, inv := range r.invitations {
+		if inv.TeamID == teamID {
+			out = append(out, inv)
+		}
+	}
+	return out
+}
+
+func (r *InvitationRepository) Delete(id string) bool {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if _, ok := r.invitations[id]; !ok {
+		return false
+	}
+	delete(r.invitations, id)
+	return true
+}

--- a/benchmark/manual/seeds/explore-refactor/internal/repository/team.go
+++ b/benchmark/manual/seeds/explore-refactor/internal/repository/team.go
@@ -1,0 +1,66 @@
+package repository
+
+import (
+	"fmt"
+	"sync"
+	"time"
+
+	"github.com/example/usermgmt/internal/model"
+)
+
+type TeamRepository struct {
+	mu    sync.RWMutex
+	teams map[string]model.Team
+	seq   int
+}
+
+func NewTeamRepository() *TeamRepository {
+	return &TeamRepository{teams: make(map[string]model.Team)}
+}
+
+func (r *TeamRepository) Create(t model.Team) model.Team {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.seq++
+	t.ID = fmt.Sprintf("t-%d", r.seq)
+	t.CreatedAt = time.Now()
+	r.teams[t.ID] = t
+	return t
+}
+
+func (r *TeamRepository) GetByID(id string) (model.Team, bool) {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	t, ok := r.teams[id]
+	return t, ok
+}
+
+func (r *TeamRepository) List() []model.Team {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	out := make([]model.Team, 0, len(r.teams))
+	for _, t := range r.teams {
+		out = append(out, t)
+	}
+	return out
+}
+
+func (r *TeamRepository) Update(t model.Team) bool {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if _, ok := r.teams[t.ID]; !ok {
+		return false
+	}
+	r.teams[t.ID] = t
+	return true
+}
+
+func (r *TeamRepository) Delete(id string) bool {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if _, ok := r.teams[id]; !ok {
+		return false
+	}
+	delete(r.teams, id)
+	return true
+}

--- a/benchmark/manual/seeds/explore-refactor/internal/repository/user.go
+++ b/benchmark/manual/seeds/explore-refactor/internal/repository/user.go
@@ -1,0 +1,91 @@
+package repository
+
+import (
+	"fmt"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/example/usermgmt/internal/model"
+)
+
+type UserRepository struct {
+	mu    sync.RWMutex
+	users map[string]model.User
+	seq   int
+}
+
+func NewUserRepository() *UserRepository {
+	return &UserRepository{users: make(map[string]model.User)}
+}
+
+func (r *UserRepository) Create(u model.User) model.User {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.seq++
+	u.ID = fmt.Sprintf("u-%d", r.seq)
+	u.CreatedAt = time.Now()
+	r.users[u.ID] = u
+	return u
+}
+
+func (r *UserRepository) GetByID(id string) (model.User, bool) {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	u, ok := r.users[id]
+	return u, ok
+}
+
+func (r *UserRepository) List() []model.User {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	out := make([]model.User, 0, len(r.users))
+	for _, u := range r.users {
+		out = append(out, u)
+	}
+	return out
+}
+
+func (r *UserRepository) FindByFilter(filter string) []model.User {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	out := make([]model.User, 0)
+	for _, u := range r.users {
+		if strings.Contains(u.Name, filter) || strings.Contains(u.Email, filter) {
+			out = append(out, u)
+		}
+	}
+	return out
+}
+
+func (r *UserRepository) Update(u model.User) bool {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if _, ok := r.users[u.ID]; !ok {
+		return false
+	}
+	r.users[u.ID] = u
+	return true
+}
+
+func (r *UserRepository) Delete(id string) bool {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if _, ok := r.users[id]; !ok {
+		return false
+	}
+	delete(r.users, id)
+	return true
+}
+
+func (r *UserRepository) CountByTeam(teamID string) int {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	count := 0
+	for _, u := range r.users {
+		if u.TeamID == teamID {
+			count++
+		}
+	}
+	return count
+}

--- a/benchmark/manual/seeds/explore-refactor/internal/service/invitation.go
+++ b/benchmark/manual/seeds/explore-refactor/internal/service/invitation.go
@@ -1,0 +1,45 @@
+package service
+
+import (
+	"errors"
+	"time"
+
+	"github.com/example/usermgmt/internal/model"
+	"github.com/example/usermgmt/internal/repository"
+)
+
+type InvitationService struct {
+	invitations *repository.InvitationRepository
+	teams       *repository.TeamRepository
+	audit       *repository.AuditRepository
+}
+
+func NewInvitationService(invitations *repository.InvitationRepository, teams *repository.TeamRepository, audit *repository.AuditRepository) *InvitationService {
+	return &InvitationService{invitations: invitations, teams: teams, audit: audit}
+}
+
+func (s *InvitationService) Create(email, teamID, role string) (model.Invitation, error) {
+	if _, ok := s.teams.GetByID(teamID); !ok {
+		return model.Invitation{}, errors.New("team not found")
+	}
+	inv := s.invitations.Create(model.Invitation{
+		Email:     email,
+		TeamID:    teamID,
+		Role:      role,
+		ExpiresAt: time.Now().Add(72 * time.Hour),
+	})
+	s.audit.Append("system", "invitation_created", inv.ID)
+	return inv, nil
+}
+
+func (s *InvitationService) ListByTeam(teamID string) []model.Invitation {
+	return s.invitations.ListByTeam(teamID)
+}
+
+func (s *InvitationService) Revoke(id string) error {
+	if !s.invitations.Delete(id) {
+		return errors.New("invitation not found")
+	}
+	s.audit.Append("system", "invitation_revoked", id)
+	return nil
+}

--- a/benchmark/manual/seeds/explore-refactor/internal/service/team.go
+++ b/benchmark/manual/seeds/explore-refactor/internal/service/team.go
@@ -1,0 +1,62 @@
+package service
+
+import (
+	"errors"
+
+	"github.com/example/usermgmt/internal/model"
+	"github.com/example/usermgmt/internal/repository"
+)
+
+type TeamService struct {
+	teams *repository.TeamRepository
+	audit *repository.AuditRepository
+}
+
+func NewTeamService(teams *repository.TeamRepository, audit *repository.AuditRepository) *TeamService {
+	return &TeamService{teams: teams, audit: audit}
+}
+
+func (s *TeamService) Create(name, description string, maxMembers int) (model.Team, error) {
+	if name == "" {
+		return model.Team{}, errors.New("name is required")
+	}
+	t := s.teams.Create(model.Team{
+		Name:        name,
+		Description: description,
+		MaxMembers:  maxMembers,
+	})
+	s.audit.Append("system", "team_created", t.ID)
+	return t, nil
+}
+
+func (s *TeamService) GetByID(id string) (model.Team, error) {
+	t, ok := s.teams.GetByID(id)
+	if !ok {
+		return model.Team{}, errors.New("team not found")
+	}
+	return t, nil
+}
+
+func (s *TeamService) List() []model.Team {
+	return s.teams.List()
+}
+
+func (s *TeamService) Update(id, name, description string, maxMembers int) (model.Team, error) {
+	t, ok := s.teams.GetByID(id)
+	if !ok {
+		return model.Team{}, errors.New("team not found")
+	}
+	t.Name = name
+	t.Description = description
+	t.MaxMembers = maxMembers
+	s.teams.Update(t)
+	return t, nil
+}
+
+func (s *TeamService) Delete(id string) error {
+	if !s.teams.Delete(id) {
+		return errors.New("team not found")
+	}
+	s.audit.Append("system", "team_deleted", id)
+	return nil
+}

--- a/benchmark/manual/seeds/explore-refactor/internal/service/user.go
+++ b/benchmark/manual/seeds/explore-refactor/internal/service/user.go
@@ -1,0 +1,94 @@
+package service
+
+import (
+	"errors"
+
+	"github.com/example/usermgmt/internal/model"
+	"github.com/example/usermgmt/internal/repository"
+)
+
+type UserService struct {
+	users  *repository.UserRepository
+	teams  *repository.TeamRepository
+	audit  *repository.AuditRepository
+}
+
+func NewUserService(users *repository.UserRepository, teams *repository.TeamRepository, audit *repository.AuditRepository) *UserService {
+	return &UserService{users: users, teams: teams, audit: audit}
+}
+
+func (s *UserService) Create(name, email, role, teamID string) (model.User, error) {
+	if name == "" {
+		return model.User{}, errors.New("name is required")
+	}
+	if email == "" {
+		return model.User{}, errors.New("email is required")
+	}
+	if teamID != "" {
+		if _, ok := s.teams.GetByID(teamID); !ok {
+			return model.User{}, errors.New("team not found")
+		}
+	}
+	u := s.users.Create(model.User{
+		Name:   name,
+		Email:  email,
+		Role:   role,
+		TeamID: teamID,
+	})
+	s.audit.Append(u.ID, "user_created", "")
+	return u, nil
+}
+
+func (s *UserService) GetByID(id string) (model.User, error) {
+	u, ok := s.users.GetByID(id)
+	if !ok {
+		return model.User{}, errors.New("user not found")
+	}
+	return u, nil
+}
+
+func (s *UserService) List() []model.User {
+	return s.users.List()
+}
+
+func (s *UserService) Search(filter string) []model.User {
+	return s.users.FindByFilter(filter)
+}
+
+func (s *UserService) UpdateRole(id, role string) (model.User, error) {
+	u, ok := s.users.GetByID(id)
+	if !ok {
+		return model.User{}, errors.New("user not found")
+	}
+	u.Role = role
+	s.users.Update(u)
+	s.audit.Append(id, "role_changed", role)
+	return u, nil
+}
+
+func (s *UserService) AssignTeam(userID, teamID string) (model.User, error) {
+	u, ok := s.users.GetByID(userID)
+	if !ok {
+		return model.User{}, errors.New("user not found")
+	}
+	team, ok := s.teams.GetByID(teamID)
+	if !ok {
+		return model.User{}, errors.New("team not found")
+	}
+	memberCount := s.users.CountByTeam(teamID)
+	if memberCount >= team.MaxMembers {
+		return model.User{}, errors.New("team is full")
+	}
+	u.TeamID = teamID
+	s.users.Update(u)
+	s.audit.Append(userID, "team_assigned", teamID)
+	return u, nil
+}
+
+func (s *UserService) Delete(id string) error {
+	if !s.users.Delete(id) {
+		return errors.New("user not found")
+	}
+	s.audit.Append(id, "user_deleted", "")
+	return nil
+}

--- a/benchmark/manual/tasks.md
+++ b/benchmark/manual/tasks.md
@@ -23,7 +23,29 @@ Requirements:
 
 ---
 
-## Task 2 — Complex coding: Go REST API Task Management
+## Task 2 — Simple coding with model switching: Go HTTP Rate Limiter Middleware
+
+**Not included in run-all.sh** — run separately via `run-simple-model-switching-<model>.sh`.
+
+**Prompt:**
+```
+Implement a Go HTTP middleware that rate-limits requests per client IP using a token bucket algorithm.
+Requirements:
+- Each IP gets 10 requests per second
+- Respond with HTTP 429 when limit is exceeded
+- Thread-safe implementation
+- Put the code in directory: rate-limiter/
+- Include a README.md explaining usage
+- Switch the main model to another available model in the kimchi-dev provider every time you change the phase. Use the /model command or the model switching capability to do this.
+```
+
+**Expected:** single subagent, light/standard model, <5 min, tests included, no external deps, model switches observed in session logs.
+
+**Baseline (Claude):** token bucket via sync.Map + per-bucket mutex, cleanup goroutine, net.SplitHostPort for IP, map-based tests, no comments, model cycled through all available models.
+
+---
+
+## Task 3 — Complex coding: Go REST API Task Management
 
 **Prompt:**
 ```
@@ -44,7 +66,7 @@ Requirements:
 
 ---
 
-## Task 3 — Research query: Most popular Go HTTP router libraries
+## Task 4 — Research query: Most popular Go HTTP router libraries
 
 **Prompt:**
 ```
@@ -61,7 +83,7 @@ List the top 3 with: GitHub stars (approximate), key differentiators, and a one-
 
 ---
 
-## Task 4 — Mega coding: Go Concurrent Build System
+## Task 5 — Mega coding: Go Concurrent Build System
 
 **Not included in run-all.sh** — run separately via `run-mega-<model>.sh`.
 

--- a/benchmark/manual/tasks.md
+++ b/benchmark/manual/tasks.md
@@ -117,8 +117,6 @@ Requirements:
 
 ## Task 5 — Explore + refactor: Add input validation to existing Go API
 
-**Not included in run-all.sh** — run separately via `run-explore-<model>.sh`.
-
 **Seed project:** `benchmark/manual/seeds/explore-refactor/` — a Go HTTP user-management API (~850 lines, 13 files) with layered architecture (handler -> service -> repository). Multiple handlers have intentional missing input validation.
 
 **Prompt:**

--- a/benchmark/manual/tasks.md
+++ b/benchmark/manual/tasks.md
@@ -114,3 +114,43 @@ Requirements:
 **Baseline (Claude):** parser package (line-by-line state machine), graph package (Kahn's algorithm for topo sort, DFS for cycle detection), engine package (worker pool with channels, context cancellation, SIGINT trap), cli package (flag parsing), main.go wiring. Map-based tests covering: empty buildfile, single target, diamond dependencies, direct cycle, indirect cycle, malformed indentation, partial-target build, fail-fast propagation.
 
 ---
+
+## Task 5 — Explore + refactor: Add input validation to existing Go API
+
+**Not included in run-all.sh** — run separately via `run-explore-<model>.sh`.
+
+**Seed project:** `benchmark/manual/seeds/explore-refactor/` — a Go HTTP user-management API (~850 lines, 13 files) with layered architecture (handler -> service -> repository). Multiple handlers have intentional missing input validation.
+
+**Prompt:**
+```
+The directory $DIR/usermgmt/ contains an existing Go HTTP API for user and team management.
+Explore the codebase, find all HTTP handlers that are missing input validation, and fix them.
+Requirements:
+- First explore the entire codebase to build a map of all handlers and their validation status.
+- Write a plan listing every handler endpoint, what validation is missing, and what you will add.
+- Implement the validation fixes. Specific issues to find and fix:
+  - Handlers that accept arbitrary strings for fields with a fixed set of valid values (e.g. roles)
+  - Handlers that accept zero or negative integers for fields that must be positive
+  - Handlers that accept empty strings for required fields at the HTTP layer (even if the service layer also checks)
+  - Search/filter endpoints with no length limit on query parameters
+  - Pagination parameters with no bounds checking (negative offsets, excessively large limits)
+- Add unit tests for the validation logic using map-based test cases.
+- Do not change the project structure or add external dependencies.
+```
+
+**Expected:** explore phase (light model) + plan phase (heavy model) + build phase (standard model), 2–4 subagents, <10 min, all validation gaps found and fixed, tests added.
+
+**Baseline (Claude):**
+Validation gaps in the seed project:
+1. `PATCH /users/{id}/role` — accepts any string as role (should be one of: admin, member, viewer)
+2. `PATCH /users/{id}/team` — accepts empty team_id
+3. `GET /users/search` — no length limit on `q` parameter
+4. `POST /teams` — max_members can be 0 or negative
+5. `PUT /teams/{id}` — name can be empty, max_members can be negative
+6. `POST /invitations` — email can be empty or malformed, role is arbitrary
+7. `GET /invitations` — empty team_id returns empty list without error
+8. `GET /audit` — offset/limit have no bounds checking (negative values, huge limits)
+
+Expected fixes: validate role against allowed set, require non-empty team_id, cap search query length, enforce positive max_members, require non-empty name on update, validate email format, require team_id on invitation list, clamp offset/limit to valid ranges. Handler-level tests with map-based test cases covering valid and invalid inputs.
+
+---

--- a/docs/expected-execution-scenarios.md
+++ b/docs/expected-execution-scenarios.md
@@ -1,0 +1,348 @@
+# Expected Execution Scenarios
+
+How each benchmark task should execute given the starting model and the
+available model pool. Two starting scenarios per task: **kimi-k2.6** (heavy,
+strengths: research/plan/review) and **minimax-m2.7** (standard, strengths:
+build/review).
+
+The orchestrator can either **spawn a subagent** with a different model or
+**switch the session model** mid-conversation. Model switching avoids the
+context-loss overhead of a subagent but means the remaining conversation
+runs on the new model's token pricing and capabilities.
+
+Available models:
+
+| Model | Tier | Strengths | Cost | Notes |
+|-------|------|-----------|------|-------|
+| kimi-k2.6 | heavy | research, plan, review | $$$ | Best reasoning, vision |
+| minimax-m2.7 | standard | build, review | $$ | Best coder |
+| nemotron-3-super | light | build, explore | $ | 1M context, cheapest, weakest at complex code |
+
+---
+
+## Task 1 — Simple (Go HTTP Rate Limiter)
+
+Single-file, no design decisions, no existing codebase.
+
+### Starting model: kimi-k2.6
+
+```
+classify  → simple
+steps     → build
+```
+
+Kimi does not have `build` in its strengths. Two options:
+
+**Option A — subagent (preferred):**
+Spawn one minimax-m2.7 subagent with the full prompt. Kimi's orchestration
+overhead is minimal (classify + one tool call). Total: ~20k kimi + ~200k
+minimax.
+
+**Option B — model switch:**
+Switch to minimax-m2.7, then build. Saves the subagent spawn overhead but
+wastes kimi tokens on the initial classify turn. Total: ~10k kimi + ~200k
+minimax. Slightly cheaper because no subagent framing.
+
+**Optimal:** Option B. The task is simple enough that the context loss from
+a subagent buys nothing — there is no plan or prior exploration to carry
+forward. Switching is cheaper.
+
+### Starting model: minimax-m2.7
+
+```
+classify  → simple
+steps     → build
+```
+
+Minimax has `build` in its strengths. Does the work itself, no delegation.
+Single-model run. Total: ~200k minimax.
+
+**Optimal:** Direct execution. No switching, no subagents.
+
+---
+
+## Task 2 — Complex (Go REST API, layered architecture)
+
+Multi-file, requires architectural decisions, greenfield.
+
+### Starting model: kimi-k2.6
+
+```
+classify  → complex
+steps     → plan, build
+```
+
+Kimi has `plan` in its strengths. Per the orchestrator rules, heavy-tier
+models always plan themselves.
+
+**Option A — plan then subagent:**
+Kimi writes the plan (interfaces, file paths, method signatures) to a spec
+file. Spawns one minimax-m2.7 subagent with the spec file attached for the
+build phase. After the subagent returns, kimi reads the output and verifies.
+Total: ~80k kimi (plan + verify) + ~300k minimax (build).
+
+**Option B — plan then model switch:**
+Kimi writes the plan, then switches to minimax-m2.7 for the build phase.
+Minimax inherits the full conversation context including the plan — no need
+to serialize it to a file. After building, minimax can also run tests
+(review is in its strengths). Total: ~80k kimi + ~300k minimax, but all
+minimax tokens carry the kimi context prefix, so the effective input cost
+is slightly higher per turn. However, minimax sees the plan inline which
+reduces misinterpretation risk.
+
+**Optimal:** Option B. The plan is short enough that context inheritance
+beats serialization. Avoids the risk of the subagent misreading the spec
+file. One fewer failure mode.
+
+### Starting model: minimax-m2.7
+
+```
+classify  → complex
+steps     → plan, build
+```
+
+Minimax does not have `plan` in its strengths. Per the orchestrator rules,
+standard-tier models must delegate planning.
+
+**Option A — subagent for plan, then build:**
+Spawn a kimi-k2.6 subagent for the plan phase. Kimi writes the spec to a
+file. Minimax reads the file, then builds. Total: ~80k kimi (subagent) +
+~300k minimax (build).
+
+**Option B — switch to kimi for plan, switch back for build:**
+Switch to kimi-k2.6. Kimi plans (writes spec to file or inline). Switch
+back to minimax-m2.7. Minimax builds from the plan already in context.
+Total: same token volume, but minimax has full plan context from the
+conversation history, reducing the chance of drift.
+
+**Optimal:** Option B. Two model switches but better context continuity.
+The plan stays in the conversation — minimax does not need to re-read a
+file. Downside: two switch operations add latency (~2-3s each).
+
+---
+
+## Task 3 — Research (Go HTTP router libraries)
+
+Pure information retrieval. No code, no codebase.
+
+### Starting model: kimi-k2.6
+
+```
+classify  → simple
+steps     → research
+```
+
+Kimi has `research` in its strengths. Per the simple-research exception in
+the orchestrator rules, any model can handle this directly via web_search.
+Kimi calls web_search, reads results, formats the answer. Total: ~20k kimi.
+
+**Optimal:** Direct execution. No switching, no subagents.
+
+### Starting model: minimax-m2.7
+
+```
+classify  → simple
+steps     → research
+```
+
+Minimax does not have `research` in its strengths, but the simple-research
+exception applies: "If a task only needs a quick factual lookup, call
+web_search directly — do NOT delegate to a subagent." Minimax calls
+web_search and answers. Total: ~20k minimax.
+
+**Optimal:** Direct execution. The simple-research exception overrides
+strengths-based delegation. Cheaper than kimi and equally correct for a
+3-item list.
+
+---
+
+## Task 4 — Mega (Go Concurrent Build System)
+
+Multi-package, complex algorithms, extensive tests. Requires deep planning.
+
+### Starting model: kimi-k2.6
+
+```
+classify  → complex
+steps     → plan, build, review
+```
+
+Kimi has `plan` and `review`. Does not have `build`.
+
+**Option A — plan, parallel subagents, review:**
+Kimi writes the plan (package interfaces, file layout, method signatures).
+Spawns 3 parallel minimax-m2.7 subagents:
+  - Subagent 1: parser package + tests
+  - Subagent 2: graph package (topo sort, cycle detection) + tests
+  - Subagent 3: engine package (worker pool, SIGINT) + cli + main.go + tests
+After all return, kimi reviews the output, runs `go build` and `go test`,
+spawns a fix-up subagent if needed. Total: ~100k kimi + ~600k minimax
+(3 x 200k).
+
+**Option B — plan, switch to minimax, build sequentially:**
+Kimi writes the plan, switches to minimax. Minimax builds all packages
+sequentially. Switches back to kimi for review. Total: ~100k kimi + ~400k
+minimax. Fewer total tokens (no subagent framing, no duplicated context)
+but longer wall-clock time because builds are sequential.
+
+**Option C — plan, switch to minimax for build, spawn parallel minimax subagents:**
+Kimi writes the plan, switches to minimax. Minimax spawns 2-3 minimax
+subagents for parallel package implementation while building one package
+itself. Switches back to kimi for review. Hybrid approach: best of both
+parallelism and context continuity.
+
+**Optimal:** Option A for wall-clock time, Option B for cost. Option C is
+a reasonable middle ground. The mega task benefits from parallelism because
+the packages are independently implementable — Option A is the expected
+path.
+
+### Starting model: minimax-m2.7
+
+```
+classify  → complex
+steps     → plan, build, review
+```
+
+Minimax does not have `plan`. Must delegate planning.
+
+**Option A — switch to kimi for plan, switch back for build:**
+Switch to kimi-k2.6. Kimi writes the plan. Switch back to minimax. Minimax
+builds all packages, possibly spawning parallel minimax subagents for
+independent packages. Minimax self-reviews (has `review` in strengths).
+Total: ~100k kimi + ~500k minimax.
+
+**Option B — kimi subagent for plan, minimax builds:**
+Spawn a kimi-k2.6 subagent for the plan. Minimax reads the spec file, then
+builds. Can spawn parallel minimax subagents for independent packages.
+Minimax self-reviews. Total: ~100k kimi + ~500k minimax. Similar cost but
+minimax loses the conversation context from the planning phase.
+
+**Option C — switch to kimi for plan, switch back, spawn parallel builds:**
+Switch to kimi. Kimi plans. Switch back to minimax. Minimax spawns 2-3
+parallel minimax subagents for independent packages, builds one package
+itself, then reviews. Total: ~100k kimi + ~500k minimax. Best balance of
+context continuity and parallelism.
+
+**Optimal:** Option C. Kimi plans in-session (full context preserved on
+switch-back), minimax parallelizes the build for wall-clock speed, minimax
+handles its own review.
+
+---
+
+## Task 5 — Explore + Refactor (Input validation on existing API)
+
+Existing codebase (~850 lines, 13 files). Requires reading before acting.
+
+### Starting model: kimi-k2.6
+
+```
+classify  → complex
+steps     → explore, plan, build
+```
+
+Kimi has `plan` but not `explore` or `build`.
+
+**Option A — nemotron subagent explores, kimi plans, minimax subagent builds:**
+Spawn a nemotron-3-super subagent to explore the codebase and produce a
+findings document (list of all handlers, their validation status, and
+identified gaps). Kimi reads the findings, writes a plan (which handlers
+to fix, what validation to add, what tests to write). Spawns a minimax-m2.7
+subagent with the plan + file paths to implement the fixes and tests.
+Total: ~50k nemotron (explore) + ~80k kimi (plan) + ~250k minimax (build).
+All three models used, each on its strength.
+
+**Option B — kimi explores itself (it can read files), then plans, then delegates build:**
+Kimi reads the handler files directly (it has tool access). Skips the
+explore subagent. Plans. Delegates build to minimax. Total: ~150k kimi
+(explore + plan) + ~250k minimax (build). Simpler but kimi's explore tokens
+are expensive. This violates the strengths rule — kimi does not have
+`explore` in its strengths.
+
+**Option C — nemotron explores, kimi plans, switch to minimax for build:**
+Spawn nemotron for explore. Kimi reads findings and plans. Switch to
+minimax for build. Minimax inherits the plan from context and builds.
+Total: ~50k nemotron + ~80k kimi + ~250k minimax. Same cost as Option A
+but minimax has better context continuity — it sees the plan inline instead
+of via a file attachment.
+
+**Optimal:** Option C. Three-model pipeline with model switching for the
+build phase. Nemotron is the cheapest explorer (1M context ingests the
+entire project in one pass). Kimi plans from the exploration findings.
+Minimax builds with full context. This is the flagship scenario for the
+explore task — all three tiers exercised.
+
+### Starting model: minimax-m2.7
+
+```
+classify  → complex
+steps     → explore, plan, build
+```
+
+Minimax does not have `explore` or `plan`. Must delegate both.
+
+**Option A — nemotron subagent explores, kimi subagent plans, minimax builds:**
+Spawn nemotron-3-super subagent to explore. Read the findings file. Spawn
+kimi-k2.6 subagent to plan (pass findings file as attachment). Read the
+plan file. Build the fixes (minimax has `build`). Total: ~50k nemotron +
+~80k kimi + ~250k minimax. Clean separation but two subagents lose context.
+
+**Option B — switch to nemotron for explore, switch to kimi for plan, switch back for build:**
+Switch to nemotron. Nemotron reads the codebase, writes findings (inline or
+to a file). Switch to kimi. Kimi reads the findings from context, writes
+the plan. Switch back to minimax. Minimax builds with full conversation
+history containing both explore findings and plan. Total: ~50k nemotron +
+~80k kimi + ~250k minimax. Three model switches but perfect context
+continuity throughout the pipeline.
+
+**Option C — switch to kimi (plan + explore combined), switch back for build:**
+Switch to kimi. Kimi has enough general capability to both explore and plan
+in a single pass (it can read files, it just does not list `explore` as a
+strength). Switch back to minimax for build. Total: ~150k kimi + ~250k
+minimax. Fewer switches but uses expensive kimi tokens for exploration work
+that nemotron could do cheaper.
+
+**Optimal:** Option B. The three-switch pipeline (nemotron -> kimi ->
+minimax) is the most cost-efficient path and exercises each model on its
+strength. The conversation history carries forward through each switch, so
+every model sees what the previous one did. This is the ideal execution for
+the explore task.
+
+---
+
+## Summary: Expected Execution Matrix
+
+### Starting model: kimi-k2.6
+
+| Task | Phases | Execution | Subagents | Switches | Est. cost |
+|------|--------|-----------|-----------|----------|-----------|
+| Simple | build | switch to minimax, build | 0 | 1 | $ |
+| Complex | plan, build | kimi plans, switch to minimax for build | 0 | 1 | $$ |
+| Research | research | kimi answers directly via web_search | 0 | 0 | $ |
+| Mega | plan, build, review | kimi plans, spawn 3 parallel minimax subagents, kimi reviews | 3 | 0 | $$$$ |
+| Explore | explore, plan, build | nemotron subagent explores, kimi plans, switch to minimax for build | 1 | 1 | $$$ |
+
+### Starting model: minimax-m2.7
+
+| Task | Phases | Execution | Subagents | Switches | Est. cost |
+|------|--------|-----------|-----------|----------|-----------|
+| Simple | build | minimax builds directly | 0 | 0 | $ |
+| Complex | plan, build | switch to kimi for plan, switch back for build | 0 | 2 | $$ |
+| Research | research | minimax answers directly via web_search | 0 | 0 | $ |
+| Mega | plan, build, review | switch to kimi for plan, switch back, spawn 2-3 parallel minimax subagents, minimax reviews | 2-3 | 2 | $$$$ |
+| Explore | explore, plan, build | switch to nemotron (explore), switch to kimi (plan), switch back (build) | 0 | 3 | $$$ |
+
+### Key design principle
+
+**Use model switching when context continuity matters and work is sequential.
+Use subagents when work can be parallelized or is fully self-contained.**
+
+Model switching preserves the full conversation history — the next model
+sees everything the previous model did. This eliminates the need to
+serialize context into files and the risk of the subagent misinterpreting
+a spec. The trade-off is that all subsequent tokens carry the accumulated
+context prefix cost and work must be sequential.
+
+Subagents are better when:
+- Multiple independent tasks can run in parallel (mega task build phase)
+- The subtask is fully self-contained and does not need prior conversation context
+- The parent model needs to continue doing other work while the subagent runs

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -29,6 +29,7 @@ import loginExtension from "./extensions/login/index.js"
 import loopGuardExtension from "./extensions/loop-guard.js"
 import lspExtension from "./extensions/lsp.js"
 import mcpAdapterExtension from "./extensions/mcp-adapter/index.js"
+import modelSwitchExtension from "./extensions/model-switch.js"
 import promptEnrichmentExtension from "./extensions/orchestration/prompt-enrichment.js"
 import permissionsExtension from "./extensions/permissions/index.js"
 import { reserveShiftTabForPermissions } from "./extensions/permissions/keybindings.js"
@@ -338,6 +339,7 @@ try {
 			loginExtension,
 			improveExtension,
 			curatorExtension,
+			modelSwitchExtension,
 		]
 
 		if (acpMode) {

--- a/src/extensions/model-switch.test.ts
+++ b/src/extensions/model-switch.test.ts
@@ -1,0 +1,187 @@
+import type { ExtensionAPI } from "@earendil-works/pi-coding-agent"
+import { describe, expect, it, vi } from "vitest"
+import modelSwitchExtension from "./model-switch.js"
+
+type RegisteredTool = {
+	name: string
+	label?: string
+	description?: string
+	parameters: unknown
+	execute: (
+		toolCallId: string,
+		params: { model: string },
+		signal: AbortSignal | undefined,
+		onUpdate: unknown,
+		ctx: unknown,
+	) => Promise<{ content: Array<{ type: string; text: string }>; details: unknown }>
+}
+
+type ModelEntry = { id: string; provider: string; name: string }
+
+interface Harness {
+	tool: RegisteredTool
+	setModel: ReturnType<typeof vi.fn>
+	find: ReturnType<typeof vi.fn>
+	getAvailable: ReturnType<typeof vi.fn>
+	exec: (
+		model: string,
+		opts?: { omitRegistry?: boolean },
+	) => Promise<{ content: Array<{ type: string; text: string }>; details: unknown }>
+}
+
+const MODELS: ModelEntry[] = [
+	{ id: "kimi-k2.6", provider: "kimchi-dev", name: "Kimi K2.6" },
+	{ id: "minimax-m2.7", provider: "kimchi-dev", name: "MiniMax M2.7" },
+	{ id: "claude-sonnet-4-20250514", provider: "anthropic", name: "Claude Sonnet 4" },
+]
+
+function createHarness(options: { setModelResult?: boolean } = {}): Harness {
+	const { setModelResult = true } = options
+	let registered: RegisteredTool | undefined
+	const setModel = vi.fn(async () => setModelResult)
+	const find = vi.fn((provider: string, id: string) => MODELS.find((m) => m.provider === provider && m.id === id))
+	const getAvailable = vi.fn(() => MODELS)
+	const pi = {
+		registerTool: (tool: RegisteredTool) => {
+			registered = tool
+		},
+		setModel,
+	} as unknown as ExtensionAPI
+
+	modelSwitchExtension(pi)
+
+	if (!registered) throw new Error("set_model tool was not registered")
+	const tool = registered
+
+	const exec: Harness["exec"] = (model, opts = {}) => {
+		const ctx = opts.omitRegistry ? {} : { modelRegistry: { find, getAvailable } }
+		return tool.execute("test-call-id", { model }, undefined, undefined, ctx)
+	}
+
+	return { tool, setModel, find, getAvailable, exec }
+}
+
+function textOf(result: { content: Array<{ type: string; text: string }> }): string {
+	return result.content.map((c) => c.text).join("\n")
+}
+
+describe("modelSwitchExtension", () => {
+	it("registers a single set_model tool with the documented metadata", () => {
+		const { tool } = createHarness()
+		expect(tool.name).toBe("set_model")
+		expect(tool.label).toBe("Switch Model")
+		expect(tool.description).toContain("provider/id format")
+		expect(tool.description).toContain("pi.setModel")
+		expect(tool.parameters).toBeDefined()
+	})
+
+	describe("input validation", () => {
+		const invalidInputs: Array<{ label: string; value: string }> = [
+			{ label: "empty string", value: "" },
+			{ label: "no slash", value: "kimi-k2.6" },
+			{ label: "leading slash (missing provider)", value: "/kimi-k2.6" },
+			{ label: "trailing slash (missing model)", value: "kimchi-dev/" },
+			{ label: "extra slash (three parts)", value: "kimchi-dev/kimi/k2.6" },
+		]
+
+		for (const { label, value } of invalidInputs) {
+			it(`rejects "${label}" without calling setModel`, async () => {
+				const h = createHarness()
+				const result = await h.exec(value)
+
+				expect(textOf(result)).toContain(`Invalid model format: "${value}"`)
+				expect(textOf(result)).toContain('Expected "provider/modelId"')
+				expect(textOf(result)).toContain("Available models:")
+				expect(textOf(result)).toContain("anthropic/claude-sonnet-4-20250514")
+				expect(textOf(result)).toContain("kimchi-dev/kimi-k2.6")
+				expect(textOf(result)).toContain("kimchi-dev/minimax-m2.7")
+				expect(h.setModel).not.toHaveBeenCalled()
+				expect(h.find).not.toHaveBeenCalled()
+				expect(result.details).toBeNull()
+			})
+		}
+
+		it("sorts available models alphabetically in invalid-format error message", async () => {
+			const h = createHarness()
+			const result = await h.exec("bad-format")
+			const text = textOf(result)
+			const idxAnthropic = text.indexOf("anthropic/claude-sonnet-4-20250514")
+			const idxKimi = text.indexOf("kimchi-dev/kimi-k2.6")
+			const idxMinimax = text.indexOf("kimchi-dev/minimax-m2.7")
+			expect(idxAnthropic).toBeGreaterThan(-1)
+			expect(idxKimi).toBeGreaterThan(idxAnthropic)
+			expect(idxMinimax).toBeGreaterThan(idxKimi)
+		})
+
+		it("handles missing modelRegistry on invalid format (empty available list)", async () => {
+			const h = createHarness()
+			const result = await h.exec("no-slash", { omitRegistry: true })
+			expect(textOf(result)).toContain('Invalid model format: "no-slash"')
+			expect(textOf(result)).toContain("Available models:")
+			expect(h.setModel).not.toHaveBeenCalled()
+		})
+	})
+
+	describe("model lookup", () => {
+		it("returns 'Model not found' when registry has no matching entry", async () => {
+			const h = createHarness()
+			const result = await h.exec("kimchi-dev/does-not-exist")
+
+			expect(h.find).toHaveBeenCalledWith("kimchi-dev", "does-not-exist")
+			expect(textOf(result)).toContain("Model not found: kimchi-dev/does-not-exist")
+			expect(textOf(result)).toContain("Available models:")
+			expect(textOf(result)).toContain("kimchi-dev/kimi-k2.6")
+			expect(h.setModel).not.toHaveBeenCalled()
+			expect(result.details).toBeNull()
+		})
+
+		it("handles missing modelRegistry on lookup (empty available list)", async () => {
+			const h = createHarness()
+			const result = await h.exec("kimchi-dev/kimi-k2.6", { omitRegistry: true })
+
+			expect(textOf(result)).toContain("Model not found: kimchi-dev/kimi-k2.6")
+			expect(h.setModel).not.toHaveBeenCalled()
+		})
+	})
+
+	describe("successful switch", () => {
+		it("calls pi.setModel with the resolved descriptor and reports success", async () => {
+			const h = createHarness()
+			const result = await h.exec("kimchi-dev/kimi-k2.6")
+
+			expect(h.find).toHaveBeenCalledWith("kimchi-dev", "kimi-k2.6")
+			expect(h.setModel).toHaveBeenCalledTimes(1)
+			expect(h.setModel).toHaveBeenCalledWith({
+				id: "kimi-k2.6",
+				provider: "kimchi-dev",
+				name: "Kimi K2.6",
+			})
+			expect(textOf(result)).toBe("Switched to model kimchi-dev/kimi-k2.6 (Kimi K2.6)")
+			expect(result.details).toBeNull()
+		})
+
+		it("works across providers (anthropic)", async () => {
+			const h = createHarness()
+			const result = await h.exec("anthropic/claude-sonnet-4-20250514")
+
+			expect(h.setModel).toHaveBeenCalledWith({
+				id: "claude-sonnet-4-20250514",
+				provider: "anthropic",
+				name: "Claude Sonnet 4",
+			})
+			expect(textOf(result)).toBe("Switched to model anthropic/claude-sonnet-4-20250514 (Claude Sonnet 4)")
+		})
+	})
+
+	describe("setModel failure", () => {
+		it("returns a 'no API key' style message when pi.setModel resolves false", async () => {
+			const h = createHarness({ setModelResult: false })
+			const result = await h.exec("kimchi-dev/kimi-k2.6")
+
+			expect(h.setModel).toHaveBeenCalledTimes(1)
+			expect(textOf(result)).toContain("Failed to switch to kimchi-dev/kimi-k2.6")
+			expect(textOf(result)).toContain("no API key available")
+			expect(result.details).toBeNull()
+		})
+	})
+})

--- a/src/extensions/model-switch.ts
+++ b/src/extensions/model-switch.ts
@@ -1,0 +1,77 @@
+import type { ExtensionAPI } from "@earendil-works/pi-coding-agent"
+import { Type } from "typebox"
+
+export default function modelSwitchExtension(pi: ExtensionAPI) {
+	pi.registerTool({
+		name: "set_model",
+		label: "Switch Model",
+		description:
+			'Change the active AI model to a different one. Provide the model in provider/id format, e.g. "kimchi-dev/kimi-k2.6". Uses pi.setModel() internally.',
+		parameters: Type.Object({
+			model: Type.String({
+				description:
+					'Target model identifier in "provider/modelId" format (e.g. "kimchi-dev/kimi-k2.6", "anthropic/claude-sonnet-4-20250514").',
+			}),
+		}),
+		async execute(_toolCallId, params, _signal, _onUpdate, ctx) {
+			const { model } = params
+			const parts = model.split("/")
+			if (parts.length !== 2 || !parts[0] || !parts[1]) {
+				const available =
+					ctx.modelRegistry
+						?.getAvailable()
+						?.map((m) => `${m.provider}/${m.id}`)
+						?.sort() ?? []
+				return {
+					content: [
+						{
+							type: "text" as const,
+							text: `Invalid model format: "${model}". Expected "provider/modelId".\n\nAvailable models:\n${available.join("\n")}`,
+						},
+					],
+					details: null,
+				}
+			}
+
+			const [provider, modelId] = parts
+			const target = ctx.modelRegistry?.find(provider, modelId)
+
+			if (!target) {
+				const available =
+					ctx.modelRegistry
+						?.getAvailable()
+						?.map((m) => `${m.provider}/${m.id}`)
+						?.sort() ?? []
+				return {
+					content: [
+						{
+							type: "text" as const,
+							text: `Model not found: ${provider}/${modelId}\n\nAvailable models:\n${available.join("\n")}`,
+						},
+					],
+					details: null,
+				}
+			}
+
+			const ok = await pi.setModel(target)
+			if (!ok) {
+				return {
+					content: [
+						{
+							type: "text" as const,
+							text: `Failed to switch to ${provider}/${modelId} — no API key available for this model's provider.`,
+						},
+					],
+					details: null,
+				}
+			}
+
+			return {
+				content: [
+					{ type: "text" as const, text: `Switched to model ${target.provider}/${target.id} (${target.name})` },
+				],
+				details: null,
+			}
+		},
+	})
+}


### PR DESCRIPTION
In order to build smart model routing solutions and (for now) setup repeatable testing scenarios for how switching models behave in the session runtime, we need a tool that will allow us to change the model by the agent themselves.

### Kimchi Summary
### What changed
Introduces a `set_model` tool that allows the agent to switch the active AI model mid-session using `provider/modelId` format. Also adds a dedicated benchmark task to exercise this model-switching capability, and extends the benchmark session inactivity timeout from 3 to 10 minutes.

### Why
Enables dynamic model switching during agent execution so that different models can be used for different phases of a task, and provides a standardized benchmark scenario to validate this behavior.

### Key changes
- `src/extensions/model-switch.ts` (new): Registers the `set_model` tool. Validates `provider/modelId` input, resolves the model descriptor via `ctx.modelRegistry`, calls `pi.setModel()`, and returns friendly error messages for invalid formats, missing models, or missing API keys.
- `src/extensions/model-switch.test.ts` (new): Unit tests covering format validation (empty, missing slash, extra slash), registry lookup failures, successful switches across providers, and `setModel` failure handling.
- `src/cli.ts`: Imports and registers `modelSwitchExtension` in the CLI extension pipeline.
- `benchmark/manual/new-session.sh`: Adds `simple_model_switching_prompt` and includes it as the `simple-model-switching` task (excluded from the default `run-all` set).
- `benchmark/manual/tasks.md`: Documents the new model-switching benchmark task and renumbers subsequent tasks.
- `benchmark/manual/check-session.py`: Increases `INACTIVITY_THRESHOLD_S` from `180` to `600` (10 minutes).

### Impact
- The `simple-model-switching` benchmark task must be run separately via its generated script; it is not executed as part of the default `run-all.sh` suite.
- No breaking changes to existing CLI behavior or benchmark workflows.

---
### Kimchi Summary
### What changed
Adds a new `explore` benchmark task that requires agents to find and fix missing input validation in an existing Go HTTP API, introduces a `set_model` tool for mid-session model switching, and documents the expected multi-model execution strategies for all benchmark tasks.

### Why
The benchmark suite previously focused on greenfield coding and research. The `explore` task evaluates refactoring and code-auditing skills on a real codebase, while the `set_model` extension lets the orchestrator delegate each phase (explore, plan, build) to the most appropriate model tier without losing conversation context.

### Key changes
- `src/extensions/model-switch.ts`: New extension registering a `set_model` tool. Validates `provider/modelId` input, resolves the model via the registry, and invokes `pi.setModel()`.
- `src/extensions/model-switch.test.ts`: Vitest suite covering format validation, missing models, cross-provider switching, and failure paths.
- `src/cli.ts`: Registers `modelSwitchExtension`.
- `benchmark/manual/seeds/explore-refactor/`: New seeded Go project (handlers, services, repositories, models) with intentional validation gaps such as unbounded pagination, arbitrary enum strings, and unchecked required fields.
- `benchmark/manual/new-session.sh`: Adds the `explore` task with a seed-copy `setup_cmd`; extends task tuples to support an optional setup command.
- `benchmark/manual/tasks.md`: Documents the new `explore` task baseline and a new simple model-switching task; renumbers existing tasks.
- `benchmark/manual/README.md` and `benchmark/manual/analyze-session.py`: Adds `explore` task budgets (1–4 subagents, <500k tokens, <10 min).
- `benchmark/manual/check-session.py`: Raises `INACTIVITY_THRESHOLD_S` from 180 to 1800 seconds (30 minutes).
- `docs/expected-execution-scenarios.md`: New reference doc mapping each task to optimal subagent and model-switch execution paths.
- `benchmark/audit-session/audit-session.sh`: Changes JSON sidecar suffix from `-AUDIT.json` to `.json` and adds error handling for extraction failures.

### Impact
- **Sidecar filename change:** Audit JSON sidecars now use `.json` instead of `-AUDIT.json`. Update any downstream scripts that rely on the old suffix.
- **Task tuple schema:** `new-session.sh` task tuples now include a fifth `setup_cmd` element; existing task arrays in the script must be updated.
- **Stall detection:** Inactivity threshold increased from 3 minutes to 30 minutes to support longer exploration phases.