### PR TITLE
feat: proxy support for mitmproxy / traffic inspection

### DIFF
--- a/src/entry.ts
+++ b/src/entry.ts
@@ -11,6 +11,7 @@ import { resolve } from "node:path"
 import { resolveAuxiliaryFilesDir } from "./auxiliary-files/resolver.js"
 import { validateAuxiliaryFiles } from "./auxiliary-files/validator.js"
 import { installPasteInterceptor } from "./paste-interceptor.js"
+import { installProxyAgent } from "./proxy.js"
 
 const preSet = !!process.env.PI_PACKAGE_DIR
 const auxiliaryDir = resolveAuxiliaryFilesDir(process.env, homedir(), process.execPath)
@@ -29,6 +30,8 @@ process.env.KIMCHI_CODING_AGENT_DIR = agentDir
 
 process.title = "kimchi"
 process.env.PI_SKIP_VERSION_CHECK = "1"
+
+installProxyAgent()
 
 // Install before the dynamic cli.js import - the interceptor must wrap process.stdin.emit before any pi-* listener attaches. See src/paste-interceptor.ts for the rationale (LLM-1358).
 installPasteInterceptor()

--- a/src/proxy.test.ts
+++ b/src/proxy.test.ts
@@ -1,43 +1,36 @@
 import { EnvHttpProxyAgent, getGlobalDispatcher } from "undici"
-import { describe, expect, it } from "vitest"
+import { afterEach, describe, expect, it, vi } from "vitest"
 
 describe("installProxyAgent", () => {
+	afterEach(() => {
+		vi.unstubAllEnvs()
+	})
+
 	it("installs EnvHttpProxyAgent when KIMCHI_PROXY is set", async () => {
-		process.env.KIMCHI_PROXY = "http://localhost:8080"
-		process.env.HTTP_PROXY = undefined
-		process.env.HTTPS_PROXY = undefined
-		process.env.NO_PROXY = undefined
+		vi.stubEnv("KIMCHI_PROXY", "http://localhost:8080")
 
 		const { installProxyAgent } = await import("./proxy.js")
 		installProxyAgent()
 
-		const dispatcher = getGlobalDispatcher()
-		expect(dispatcher).toBeInstanceOf(EnvHttpProxyAgent)
+		expect(getGlobalDispatcher()).toBeInstanceOf(EnvHttpProxyAgent)
 	})
 
 	it("installs EnvHttpProxyAgent when HTTP_PROXY is set", async () => {
-		process.env.HTTP_PROXY = "http://proxy.local:3128"
-		process.env.KIMCHI_PROXY = undefined
-		process.env.HTTPS_PROXY = undefined
-		process.env.NO_PROXY = undefined
+		vi.stubEnv("HTTP_PROXY", "http://proxy.local:3128")
 
 		const { installProxyAgent } = await import("./proxy.js")
 		installProxyAgent()
 
-		const dispatcher = getGlobalDispatcher()
-		expect(dispatcher).toBeInstanceOf(EnvHttpProxyAgent)
+		expect(getGlobalDispatcher()).toBeInstanceOf(EnvHttpProxyAgent)
 	})
 
 	it("prefers KIMCHI_PROXY over HTTP_PROXY", async () => {
-		process.env.KIMCHI_PROXY = "http://kimchi-proxy:9090"
-		process.env.HTTP_PROXY = "http://wrong-proxy:3128"
-		process.env.HTTPS_PROXY = undefined
-		process.env.NO_PROXY = undefined
+		vi.stubEnv("KIMCHI_PROXY", "http://kimchi-proxy:9090")
+		vi.stubEnv("HTTP_PROXY", "http://wrong-proxy:3128")
 
 		const { installProxyAgent } = await import("./proxy.js")
 		installProxyAgent()
 
-		const dispatcher = getGlobalDispatcher()
-		expect(dispatcher).toBeInstanceOf(EnvHttpProxyAgent)
+		expect(getGlobalDispatcher()).toBeInstanceOf(EnvHttpProxyAgent)
 	})
 })

--- a/src/proxy.test.ts
+++ b/src/proxy.test.ts
@@ -1,0 +1,43 @@
+import { EnvHttpProxyAgent, getGlobalDispatcher } from "undici"
+import { describe, expect, it } from "vitest"
+
+describe("installProxyAgent", () => {
+	it("installs EnvHttpProxyAgent when KIMCHI_PROXY is set", async () => {
+		process.env.KIMCHI_PROXY = "http://localhost:8080"
+		process.env.HTTP_PROXY = undefined
+		process.env.HTTPS_PROXY = undefined
+		process.env.NO_PROXY = undefined
+
+		const { installProxyAgent } = await import("./proxy.js")
+		installProxyAgent()
+
+		const dispatcher = getGlobalDispatcher()
+		expect(dispatcher).toBeInstanceOf(EnvHttpProxyAgent)
+	})
+
+	it("installs EnvHttpProxyAgent when HTTP_PROXY is set", async () => {
+		process.env.HTTP_PROXY = "http://proxy.local:3128"
+		process.env.KIMCHI_PROXY = undefined
+		process.env.HTTPS_PROXY = undefined
+		process.env.NO_PROXY = undefined
+
+		const { installProxyAgent } = await import("./proxy.js")
+		installProxyAgent()
+
+		const dispatcher = getGlobalDispatcher()
+		expect(dispatcher).toBeInstanceOf(EnvHttpProxyAgent)
+	})
+
+	it("prefers KIMCHI_PROXY over HTTP_PROXY", async () => {
+		process.env.KIMCHI_PROXY = "http://kimchi-proxy:9090"
+		process.env.HTTP_PROXY = "http://wrong-proxy:3128"
+		process.env.HTTPS_PROXY = undefined
+		process.env.NO_PROXY = undefined
+
+		const { installProxyAgent } = await import("./proxy.js")
+		installProxyAgent()
+
+		const dispatcher = getGlobalDispatcher()
+		expect(dispatcher).toBeInstanceOf(EnvHttpProxyAgent)
+	})
+})

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -1,0 +1,36 @@
+import { EnvHttpProxyAgent, setGlobalDispatcher } from "undici"
+
+/**
+ * Install undici's EnvHttpProxyAgent as the global dispatcher so that
+ * Node's native fetch (and anything else using undici underneath) honours
+ * proxy environment variables.
+ *
+ * Supported env vars (in precedence order):
+ *   KIMCHI_PROXY      – explicit override, used for both HTTP and HTTPS
+ *   HTTP_PROXY        – standard, http:// scheme
+ *   HTTPS_PROXY       – standard, https:// scheme
+ *   NO_PROXY          – comma/space separated list of hosts to bypass
+ *   KIMCHI_NO_PROXY   – explicit override for the no-proxy list
+ *
+ * The upstream pi-coding-agent cli.js does the same thing, but kimchi
+ * bypasses that entry point, so we replicate it here.
+ */
+export function installProxyAgent(): void {
+	const httpProxy = process.env.KIMCHI_PROXY ?? process.env.HTTP_PROXY ?? process.env.http_proxy
+	const httpsProxy = process.env.KIMCHI_PROXY ?? process.env.HTTPS_PROXY ?? process.env.https_proxy
+	const noProxy = process.env.KIMCHI_NO_PROXY ?? process.env.NO_PROXY ?? process.env.no_proxy
+
+	setGlobalDispatcher(
+		new EnvHttpProxyAgent({
+			// bodyTimeout/headersTimeout default to 300s in undici; long local-LLM
+			// stalls (e.g. vLLM buffering a large tool call) exceed that and abort
+			// the SSE stream with UND_ERR_BODY_TIMEOUT. Disable both — provider
+			// SDKs enforce their own AbortController-based deadlines.
+			bodyTimeout: 0,
+			headersTimeout: 0,
+			httpProxy,
+			httpsProxy,
+			noProxy,
+		}),
+	)
+}


### PR DESCRIPTION
## Summary

- Adds `src/proxy.ts` with `installProxyAgent()` that installs undici's `EnvHttpProxyAgent` as the global dispatcher before `cli.js` is imported
- All `fetch()` calls across the harness (models, telemetry, ferment, web-search, etc.) automatically route through the proxy
- Also disables undici's default 300s body/headers timeouts, which were killing long-running SSE streams from local LLMs

## Usage

```sh
# Standard proxy env vars
HTTPS_PROXY=http://localhost:8080 kimchi

# With mitmproxy CA cert to avoid TLS errors
NODE_EXTRA_CA_CERTS=~/.mitmproxy/mitmproxy-ca-cert.pem HTTPS_PROXY=http://localhost:8080 kimchi

# Or skip TLS verification entirely (dev only)
NODE_TLS_REJECT_UNAUTHORIZED=0 HTTPS_PROXY=http://localhost:8080 kimchi
```

## Supported env vars

| Var | Description |
|-----|-------------|
| `KIMCHI_PROXY` | Explicit override for both HTTP and HTTPS (takes precedence) |
| `HTTP_PROXY` / `http_proxy` | Standard HTTP proxy |
| `HTTPS_PROXY` / `https_proxy` | Standard HTTPS proxy |
| `NO_PROXY` / `no_proxy` | Comma-separated bypass list |
| `KIMCHI_NO_PROXY` | Explicit override for bypass list |

## Test plan

- [ ] `HTTPS_PROXY=http://localhost:8080 kimchi` routes traffic through mitmproxy
- [ ] `NO_PROXY=localhost kimchi` bypasses proxy for localhost
- [ ] Unit tests pass: `src/proxy.test.ts`

---
### Kimchi Summary
### What changed
Adds proxy support by installing undici's `EnvHttpProxyAgent` during kimchi startup. The agent respects `KIMCHI_PROXY`, `HTTP_PROXY`, `HTTPS_PROXY`, `NO_PROXY`, and `KIMCHI_NO_PROXY`. Default `bodyTimeout` and `headersTimeout` are disabled to avoid aborting long-running local LLM SSE streams.

### Why
The upstream `pi-coding-agent` CLI configures a proxy agent, but kimchi bypasses that entry point. This change replicates the behaviour so Node's native fetch routes traffic correctly in environments that require a proxy.

### Key changes
- `src/entry.ts`: calls `installProxyAgent()` early in startup before importing the dynamic CLI module.
- `src/proxy.ts` (new): exports `installProxyAgent()`, creates an `EnvHttpProxyAgent` using proxy env vars, and sets it as undici's global dispatcher with `bodyTimeout: 0` and `headersTimeout: 0`.
- `src/proxy.test.ts` (new): adds tests verifying the agent is installed when `KIMCHI_PROXY` or `HTTP_PROXY` is set, and that `KIMCHI_PROXY` takes precedence.

### Impact
Transport-layer request timeouts are now disabled; callers must rely on their own `AbortController`-based deadlines to avoid hung requests. No breaking changes for users not using proxy environment variables.