### PR TITLE
LLM-1588: Fix OTEL provider identification

### DIFF
--- a/src/extensions/telemetry.ts
+++ b/src/extensions/telemetry.ts
@@ -1,6 +1,7 @@
 import type { AssistantMessage } from "@earendil-works/pi-ai"
 import type { ExtensionAPI } from "@earendil-works/pi-coding-agent"
 import type { TelemetryConfig } from "../config.js"
+import { getAvailableModels } from "../startup-context.js"
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -183,8 +184,10 @@ export default function telemetryExtension(config: TelemetryConfig) {
 				sentMessages.add(msgId)
 
 				const model = assistant.model ?? "unknown"
+				const availableModels = getAvailableModels()
+				const meta = availableModels.find((m) => m.slug === model)
 				const rawProvider = String(assistant.provider ?? "unknown")
-				const provider = rawProvider === "kimchi-dev" ? "ai-enabler" : rawProvider
+				const provider = meta?.provider ? meta.provider : rawProvider === "kimchi-dev" ? "ai-enabler" : rawProvider
 				const { input, output, cacheRead, cacheWrite } = assistant.usage
 				const costTotal = assistant.usage.cost.total
 				const sessionUptimeMs = Date.now() - sessionStartMs

--- a/src/models.test.ts
+++ b/src/models.test.ts
@@ -77,6 +77,7 @@ describe("updateModelsConfig", () => {
 				contextWindow: 262144,
 				maxTokens: 262144,
 				cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+				provider: "ai-enabler",
 			},
 		])
 	})

--- a/src/models.ts
+++ b/src/models.ts
@@ -56,6 +56,8 @@ interface PiModelConfig {
 	contextWindow: number
 	maxTokens: number
 	cost: { input: number; output: number; cacheRead: number; cacheWrite: number }
+	// Persisted so telemetry can resolve the actual upstream provider after cache round-trip.
+	provider: string
 	compat?: { supportsReasoningEffort?: boolean }
 }
 
@@ -70,8 +72,9 @@ function metadataToModel(m: ModelMetadata): PiModelConfig {
 		input: m.input_modalities,
 		contextWindow: m.limits.context_window,
 		maxTokens: m.limits.max_output_tokens,
-		// TODO: add costs support
 		cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+		// Store upstream provider for telemetry round-trip via models.json
+		provider: m.provider,
 		...(compat && { compat }),
 	}
 }
@@ -99,13 +102,11 @@ function modelToMetadata(m: PiModelConfig): ModelMetadata {
 	return {
 		slug: m.id,
 		display_name: m.name,
-		// `compat` is only set for anthropic models in metadataToModel, so its
-		// presence is a reliable indicator of the provider after a round-trip.
-		provider: m.compat ? "anthropic" : "",
+		// If `provider` was persisted by metadataToModel, use it. Fall back to the
+		// legacy compat heuristic for files written by older CLI versions.
+		provider: m.provider || (m.compat ? "anthropic" : ""),
 		reasoning: m.reasoning,
 		input_modalities: m.input,
-		// is_serverless is not persisted; sortModels will treat all cached models
-		// as serverless on fallback, which is acceptable for a degraded path.
 		is_serverless: true,
 		limits: { context_window: m.contextWindow, max_output_tokens: m.maxTokens },
 	}


### PR DESCRIPTION
Currently it always uses `ai-enabler` which is incorrect. This changed: the correct provider is used for the respective model. 

---
### Kimchi Summary
### What changed
Telemetry now resolves the correct upstream provider by looking up model metadata at runtime instead of relying on a hardcoded `kimchi-dev` → `ai-enabler` mapping. The upstream `provider` field is also persisted through the `models.json` cache round-trip.

### Why
Previously, provider detection was fragile: telemetry hardcoded one mapping and `modelToMetadata` inferred the provider from the presence of the `compat` field after a cache reload. This caused inaccurate provider attribution for cached models.

### Key changes
- `src/models.ts`: Added `provider` to the `PiModelConfig` interface. `metadataToModel` now stores the upstream `provider`, and `modelToMetadata` restores it rather than using the `compat` heuristic, with fallback for backward compatibility.
- `src/extensions/telemetry.ts`: Imports `getAvailableModels` and resolves the provider from the model's metadata when available.
- `src/models.test.ts`: Updated expected model config to include `provider: "ai-enabler"`.

### Impact
- Telemetry reports the accurate upstream provider even after models are cached and reloaded from disk.
- Backward compatible with older cached `models.json` files that lack the `provider` field.