### PR TITLE
fix(release): build Darwin amd64 on Intel runner

### DIFF
--- a/.github/workflows/canary.yml
+++ b/.github/workflows/canary.yml
@@ -91,7 +91,7 @@ jobs:
           - target: bun-darwin-x64
             os: darwin
             arch: amd64
-            runner: macos-15
+            runner: macos-15-intel
           - target: bun-darwin-arm64
             os: darwin
             arch: arm64
@@ -119,6 +119,15 @@ jobs:
 
       - name: Build binary
         run: pnpm run build:binary
+
+      - name: Verify binary architecture
+        run: |
+          file dist/bin/kimchi
+          case "${{ matrix.arch }}" in
+            amd64) file dist/bin/kimchi | grep -Eq 'x86[_-]64|x86-64' ;;
+            arm64) file dist/bin/kimchi | grep -Eq 'arm64|aarch64' ;;
+            *) echo "Unsupported arch: ${{ matrix.arch }}" >&2; exit 1 ;;
+          esac
 
       - name: Package binary
         run: tar -czf kimchi_${{ matrix.os }}_${{ matrix.arch }}.tar.gz -C dist bin share

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -37,7 +37,7 @@ jobs:
           - target: bun-darwin-x64
             os: darwin
             arch: amd64
-            runner: macos-15
+            runner: macos-15-intel
           - target: bun-darwin-arm64
             os: darwin
             arch: arm64
@@ -64,6 +64,15 @@ jobs:
 
       - name: Build binary
         run: pnpm run build:binary
+
+      - name: Verify binary architecture
+        run: |
+          file dist/bin/kimchi
+          case "${{ matrix.arch }}" in
+            amd64) file dist/bin/kimchi | grep -Eq 'x86[_-]64|x86-64' ;;
+            arm64) file dist/bin/kimchi | grep -Eq 'arm64|aarch64' ;;
+            *) echo "Unsupported arch: ${{ matrix.arch }}" >&2; exit 1 ;;
+          esac
 
       - name: Package binary
         run: tar -czf kimchi_${{ matrix.os }}_${{ matrix.arch }}.tar.gz -C dist bin share


### PR DESCRIPTION
Use the macos-15-intel GitHub Actions runner for Darwin amd64 release artifacts so the packaged kimchi binary is x86_64 instead of arm64.

Add a file-based architecture check before packaging release and canary artifacts to catch future runner or matrix mismatches.

---
### Kimchi Summary
### What changed
Fixes Darwin amd64 release and canary builds by switching to Intel-based runners and adds a build-time verification step to ensure compiled binaries match their target architecture.

### Why
The `macos-15` runner was producing arm64 binaries for the amd64 target, causing published artifacts to have the wrong CPU architecture.

### Key changes
- `.github/workflows/canary.yml` and `.github/workflows/release.yml`:
  - Changed the `bun-darwin-x64` matrix `runner` from `macos-15` to `macos-15-intel`
  - Added `Verify binary architecture` step that inspects `dist/bin/kimchi` with the `file` command and asserts the output contains `x86_64`/`x86-64` for amd64 or `arm64`/`aarch64` for arm64

### Impact
Builds will now fail immediately if a binary's architecture does not match the intended matrix target, preventing incorrect artifacts from being packaged and published.