### PR TITLE
feat: allow read-only commands in default mode

### DIFF
--- a/src/extensions/permissions/index.test.ts
+++ b/src/extensions/permissions/index.test.ts
@@ -430,10 +430,10 @@ describe("handleCompoundConfirm", () => {
 })
 
 describe("compound command auto-mode fall-through", () => {
-	it("read-only compound returns prompt from checkCompoundCommand so auto-mode can approve it", () => {
+	it("read-only compound returns prompt from checkCompoundCommand so the handler can approve it", () => {
 		// The early gate in the handler ONLY short-circuits on allow/deny;
-		// "prompt" falls through to evaluateRules → auto-mode → classifier.
-		// For ls && pwd, isReadOnlyBashCommand returns true, so auto-mode
+		// "prompt" falls through to evaluateRules → read-only auto-approve.
+		// For ls && pwd, isReadOnlyBashCommand returns true, so the handler
 		// silently approves it. checkCompoundCommand must NOT block it.
 		const result = checkCompoundCommand("ls && pwd", [])
 		expect(result.decision).toBe("prompt")

--- a/src/extensions/permissions/index.ts
+++ b/src/extensions/permissions/index.ts
@@ -424,15 +424,15 @@ export default function permissionsExtension(pi: ExtensionAPI): void {
 			}
 			if (match.decision === "allow") return undefined
 
+			if (isReadOnlyTool(toolName)) return undefined
+			if (toolName === "bash") {
+				const command = typeof input.command === "string" ? input.command : ""
+				if (isReadOnlyBashCommand(command)) return undefined
+			}
+
 			// Auto mode + headless default mode (subagents) both go through the
 			// classifier; prompts without a UI fail closed.
 			if (mode === "auto" || !ctx.hasUI) {
-				if (isReadOnlyTool(toolName)) return undefined
-				if (toolName === "bash") {
-					const command = typeof input.command === "string" ? input.command : ""
-					if (isReadOnlyBashCommand(command)) return undefined
-				}
-
 				const classifierModel = resolveClassifierModel(ctx.model, ctx.modelRegistry)
 				if (!classifierModel) return { block: true, reason: "no model available for classifier" }
 


### PR DESCRIPTION


---
### Kimchi Summary
### What changed
Read-only tools and bash commands are now silently approved in all execution modes, including interactive sessions with a UI. Previously, this short-circuit only applied in auto-mode or headless contexts.

### Why
Eliminates unnecessary permission prompts and classifier overhead for operations that only read state.

### Key changes
- `src/extensions/permissions/index.ts`: Moved `isReadOnlyTool()` and `isReadOnlyBashCommand()` checks above the `mode === "auto" || !ctx.hasUI` branch so read-only commands return `undefined` (allow) before reaching the classifier or UI prompt logic.
- `src/extensions/permissions/index.test.ts`: Updated test title and comments to clarify that read-only compound commands are approved by the handler rather than by auto-mode.

### Impact
Interactive sessions will no longer display permission prompts for read-only bash commands (e.g., `ls`, `pwd`) or other read-only tools.