### PR TITLE
UI-6638: keep animated progress indicator while thinking

### DIFF
--- a/src/extensions/ui.ts
+++ b/src/extensions/ui.ts
@@ -289,9 +289,9 @@ export default function uiExtension(pi: ExtensionAPI) {
 	})
 	pi.on("message_start", (event, ctx) => {
 		if (event.message.role !== "assistant") return
-		stopWorkingAnimation?.()
-		stopWorkingAnimation = undefined
-		ctx.ui.setWorkingVisible(false)
+		// Keep the working animator visible during assistant response
+		// (including the thinking phase). The upstream hides it when
+		// appropriate (e.g. at agent_end).
 	})
 	pi.on("tool_execution_start", (_, ctx) => {
 		startIndicator(ctx)


### PR DESCRIPTION


---
### Kimchi Summary
### What changed
Prevents the working animator from being hidden when an assistant message begins. The indicator now remains visible throughout the assistant's response and thinking phase, with upstream lifecycle events (e.g., `agent_end`) responsible for dismissing it.

### Why
Immediately stopping the working animation at `message_start` caused the UI to look idle during the assistant's thinking phase. Deferring the hide operation ensures users see continuous activity while the assistant is processing.

### Key changes
- `src/extensions/ui.ts`: Removed `stopWorkingAnimation()`, `stopWorkingAnimation = undefined`, and `ctx.ui.setWorkingVisible(false)` from the assistant branch of the `message_start` handler. Added comments clarifying that the working indicator stays visible and is hidden by upstream events.

### Impact
- Working indicator now persists across the assistant's thinking and response generation, rather than disappearing at the start of the message.