### PR TITLE
UI-6569: handle shift+enter

### DIFF
--- a/src/components/editor.ts
+++ b/src/components/editor.ts
@@ -1,7 +1,7 @@
 import { CustomEditor, type Theme } from "@earendil-works/pi-coding-agent"
 import type { KeybindingsManager } from "@earendil-works/pi-coding-agent"
 import type { EditorTheme, TUI } from "@earendil-works/pi-tui"
-import { visibleWidth } from "@earendil-works/pi-tui"
+import { Editor, isKittyProtocolActive, visibleWidth } from "@earendil-works/pi-tui"
 import { RST_FG, TEAL_FG } from "../ansi.js"
 import { clampLines, splashBottomPaddingFor } from "./splash-layout.js"
 
@@ -76,6 +76,14 @@ export class PromptEditor extends CustomEditor {
 	override handleInput(data: string) {
 		if (this.expandHandler && this.kb.matches(data, "app.tools.expand")) {
 			this.expandHandler()
+			return
+		}
+		// tmux and some terminals send \x1b\r for Shift+Enter. Upstream parses
+		// it as alt+enter when kitty protocol is not active, so app.message.followUp
+		// intercepts it before Editor.handleInput can create a newline. Route it
+		// directly to the Editor as \n, which the Editor always treats as newline.
+		if (!isKittyProtocolActive() && (data === "\x1b\r" || data === "\x1b\n")) {
+			Editor.prototype.handleInput.call(this, "\n")
 			return
 		}
 		super.handleInput(data)

--- a/src/components/editor.ts
+++ b/src/components/editor.ts
@@ -83,7 +83,10 @@ export class PromptEditor extends CustomEditor {
 		// intercepts it before Editor.handleInput can create a newline. Route it
 		// directly to the Editor as \n, which the Editor always treats as newline.
 		if (!isKittyProtocolActive() && (data === "\x1b\r" || data === "\x1b\n")) {
-			Editor.prototype.handleInput.call(this, "\n")
+			// Re-emit as \n so Editor.handleInput treats it as a newline
+			// (its explicit fallback catches \n before the submit path).
+			// Going through super avoids brittle prototype-chain jumps.
+			super.handleInput("\n")
 			return
 		}
 		super.handleInput(data)


### PR DESCRIPTION


---
### Kimchi Summary
### What changed
Fixes Shift+Enter in tmux and terminals without the Kitty keyboard protocol by converting the `\x1b\r` escape sequence into a newline before upstream input handling misinterprets it as Alt+Enter.

### Why
In these environments, Shift+Enter sends `\x1b\r` (or `\x1b\n`), which upstream logic parses as Alt+Enter and routes to `app.message.followUp`, preventing the editor from inserting a line break.

### Key changes
- `src/components/editor.ts`
  - Import `Editor` and `isKittyProtocolActive` from `@earendil-works/pi-tui`
  - In `PromptEditor.handleInput`, intercept `\x1b\r` and `\x1b\n` when `!isKittyProtocolActive()`
  - Re-emit the input as `\n` via `super.handleInput` so the base editor treats it as a newline instead of follow-up submission