### PR TITLE
fix: copy all bundled themes in copy-resources.js

### DIFF
--- a/scripts/copy-resources.js
+++ b/scripts/copy-resources.js
@@ -10,7 +10,7 @@
 //                                   plus package.json → dist/share/kimchi/
 //                                   so the compiled binary resolves assets from the shared data directory
 
-import { cpSync, mkdirSync } from "node:fs"
+import { cpSync, mkdirSync, readdirSync } from "node:fs"
 import { dirname, join } from "node:path"
 import { fileURLToPath } from "node:url"
 
@@ -44,9 +44,10 @@ cpSync(exportHtmlSrc, exportHtmlDest, {
 })
 
 // kimchi's own themes live outside node_modules — copy them alongside the upstream themes
-const bundledKimchiThemes = ["kimchi.json", "kimchi-minimal.json", "dark.json", "light.json"]
-for (const file of bundledKimchiThemes) {
-	cpSync(join(projectRoot, "themes", file), join(themeDest, file))
+const kimchiThemesSrc = join(projectRoot, "themes")
+const kimchiThemeFiles = readdirSync(kimchiThemesSrc).filter((f) => f.endsWith(".json"))
+for (const file of kimchiThemeFiles) {
+	cpSync(join(kimchiThemesSrc, file), join(themeDest, file))
 }
 
 if (!isDev) {


### PR DESCRIPTION
PR #178 added 12 new community themes to `themes/` and updated `cli.ts` to sync them at startup, but `copy-resources.js` was never updated. It only copied 4 themes, leaving the rest unstaged. At startup the bundled-theme sync loop warns about each missing file.

### Changes
- Replace the hardcoded 4-entry `bundledKimchiThemes` array with a dynamic `readdirSync` of the `themes/` directory so all `.json` themes are copied automatically.

### Why
- Fixes the "bundled theme X not found... skipping" warnings at startup.
- Prevents future drift when new themes are added — no need to update two places anymore.

---
### Kimchi Summary
### What changed
Updates `scripts/copy-resources.js` to dynamically discover and copy all `.json` theme files from the `themes/` directory, replacing the previous hardcoded list.

### Why
Prevents bundled themes from being accidentally omitted from the build when new themes are added or existing ones are renamed.

### Key changes
- `scripts/copy-resources.js`
  - Imports `readdirSync` from `node:fs`
  - Replaces the static `bundledKimchiThemes` array with a dynamic `readdirSync` call on `themes/` filtered to `.json` files
  - Copies all discovered Kimchi theme files to the destination directory without manual enumeration