### PR TITLE
fix: pause, auto

### DIFF
--- a/src/extensions/ferment/commands.test.ts
+++ b/src/extensions/ferment/commands.test.ts
@@ -50,6 +50,7 @@ function createHarness() {
 	const ctx = {
 		hasUI: false,
 		ui: { notify: vi.fn() },
+		abort: vi.fn(),
 	} as unknown as ExtensionCommandContext
 	return { storage, runtime, pi, ctx }
 }
@@ -171,7 +172,7 @@ describe("registerFermentCommands", () => {
 		expect(h.pi.setActiveTools).toHaveBeenLastCalledWith(["read", "bash", "create_ferment", "start_step"])
 	})
 
-	it("/pause disables auto-mode without changing ferment status", async () => {
+	it("/pause transitions running ferment to paused status", async () => {
 		const h = createHarness()
 		const applyAndPersist = createApplyAndPersist(h.runtime)
 		const ferment = h.storage.create("Running Ferment")
@@ -205,7 +206,110 @@ describe("registerFermentCommands", () => {
 
 		active = h.storage.get(active.id) ?? active
 		expect(h.runtime.setAutoModeEnabled).toHaveBeenCalledWith(false)
+		expect(active.status).toBe("paused")
+		expect(h.ctx.ui.notify).toHaveBeenCalledWith(expect.stringContaining("Paused"))
+		expect(h.pi.setActiveTools).toHaveBeenLastCalledWith(["read", "bash"])
+		expect(h.ctx.abort).toHaveBeenCalled()
+	})
+
+	it("/pause is a no-op when already paused", async () => {
+		const h = createHarness()
+		const applyAndPersist = createApplyAndPersist(h.runtime)
+		const ferment = h.storage.create("Already Paused Ferment")
+		const scoped = applyAndPersist(ferment.id, {
+			type: "scope",
+			goal: "Goal",
+			successCriteria: "Works",
+			constraints: [],
+			phases: [{ name: "Phase", goal: "Build", steps: [{ description: "Do it" }] }],
+		})
+		if (!scoped.ok) throw new Error(scoped.error.message)
+		const paused = applyAndPersist(ferment.id, { type: "pause" })
+		if (!paused.ok) throw new Error(paused.error.message)
+
+		let active = paused.ferment
+		h.runtime.getActive = vi.fn(() => active)
+		h.runtime.setAutoModeEnabled = vi.fn()
+
+		const commands = new Map<string, RegisteredCommand>()
+		const pi = {
+			...h.pi,
+			registerCommand: (name: string, command: RegisteredCommand) => {
+				commands.set(name, command)
+			},
+		} as unknown as ExtensionAPI
+		registerFermentCommands(pi, h.runtime)
+
+		const pauseCommand = commands.get("pause")
+		if (!pauseCommand) throw new Error("pause command was not registered")
+		await pauseCommand.handler("", h.ctx)
+
+		active = h.storage.get(active.id) ?? active
+		expect(active.status).toBe("paused")
+		expect(h.ctx.ui.notify).toHaveBeenCalledWith(expect.stringContaining("already paused"))
+		expect(h.ctx.abort).not.toHaveBeenCalled()
+	})
+
+	it("implements pause → resume lifecycle with auto-mode toggle and tool restoration", async () => {
+		const h = createHarness()
+		const applyAndPersist = createApplyAndPersist(h.runtime)
+		const ferment = h.storage.create("Lifecycle Ferment")
+		const scoped = applyAndPersist(ferment.id, {
+			type: "scope",
+			goal: "Goal",
+			successCriteria: "Works",
+			constraints: [],
+			phases: [{ name: "Phase", goal: "Build", steps: [{ description: "Do it" }, { description: "Test it" }] }],
+		})
+		if (!scoped.ok) throw new Error(scoped.error.message)
+		const activated = applyAndPersist(scoped.ferment.id, { type: "activate_phase", phaseId: "phase-1" })
+		if (!activated.ok) throw new Error(activated.error.message)
+
+		let active = activated.ferment
+		h.runtime.getActive = vi.fn(() => active)
+		h.runtime.setActive = vi.fn((f) => {
+			active = f ?? active
+		})
+		h.runtime.setAutoModeEnabled = vi.fn()
+		h.pi.setActiveTools = vi.fn()
+
+		const commands = new Map<string, RegisteredCommand>()
+		const pi = {
+			...h.pi,
+			registerCommand: (name: string, command: RegisteredCommand) => {
+				commands.set(name, command)
+			},
+		} as unknown as ExtensionAPI
+		registerFermentCommands(pi, h.runtime)
+
+		// Step 1: Verify initial state (running with active phase)
 		expect(active.status).toBe("running")
-		expect(h.ctx.ui.notify).toHaveBeenCalledWith(expect.stringContaining('Ferment remains "running"'))
+		expect(active.phases[0].status).toBe("active")
+
+		// Step 2: Call /pause handler → status becomes "paused", steps reset to "pending"
+		const pauseCommand = commands.get("pause")
+		if (!pauseCommand) throw new Error("pause command was not registered")
+		await pauseCommand.handler("", h.ctx)
+
+		active = h.storage.get(active.id) ?? active
+		expect(h.runtime.setAutoModeEnabled).toHaveBeenCalledWith(false)
+		expect(active.status).toBe("paused")
+		expect(active.phases[0].steps[0].status).toBe("pending")
+		expect(active.phases[0].steps[1].status).toBe("pending")
+		expect(h.ctx.abort).toHaveBeenCalled()
+
+		// Step 3: Call /auto handler → status becomes "running", active phase restored, setActiveTools called
+		const autoCommand = commands.get("auto")
+		if (!autoCommand) throw new Error("auto command was not registered")
+		await autoCommand.handler("", h.ctx)
+
+		active = h.storage.get(active.id) ?? active
+		expect(h.runtime.setAutoModeEnabled).toHaveBeenCalledWith(true)
+		expect(active.status).toBe("running")
+		expect(active.phases[0].status).toBe("active")
+		expect(h.pi.setActiveTools).toHaveBeenLastCalledWith(["read", "bash", "create_ferment", "start_step"])
+
+		// Step 4: Verify setAutoModeEnabled was called with both false and true
+		expect(h.runtime.setAutoModeEnabled).toHaveBeenCalledTimes(2)
 	})
 })

--- a/src/extensions/ferment/commands.ts
+++ b/src/extensions/ferment/commands.ts
@@ -562,7 +562,7 @@ export function registerFermentCommands(pi: ExtensionAPI, runtime: FermentRuntim
 	})
 
 	pi.registerCommand("pause", {
-		description: "Pause auto-mode for the active ferment without changing ferment state.",
+		description: "Pause the active ferment and disable auto-mode.",
 		async handler(_, ctx) {
 			runtime.setAutoModeEnabled(false)
 
@@ -577,8 +577,21 @@ export function registerFermentCommands(pi: ExtensionAPI, runtime: FermentRuntim
 				return
 			}
 
-			ctx.ui.notify(`Auto-mode paused for "${active.name}". Ferment remains "${active.status}". Type /auto to resume.`)
-			syncFermentToolScope(pi, runtime.getActive())
+			if (active.status === "paused") {
+				ctx.ui.notify(`"${active.name}" is already paused. Type /auto to resume.`)
+				syncFermentToolScope(pi, active)
+				return
+			}
+
+			const outcome = applyAndPersist(active.id, { type: "pause" })
+			if (!outcome.ok) {
+				ctx.ui.notify(`Failed to pause: ${outcome.error.message}`)
+				return
+			}
+
+			ctx.ui.notify(`Paused "${outcome.ferment.name}". Type /auto to resume.`)
+			syncFermentToolScope(pi, outcome.ferment)
+			ctx.abort()
 		},
 	})
 


### PR DESCRIPTION


---
### Kimchi Summary
### What changed
The `/pause` command now transitions the active ferment to `paused` status, resets active phase steps to `pending`, and aborts the current execution context. It also short-circuits as a no-op when the ferment is already paused.

### Why
Previously, `/pause` only disabled auto-mode while leaving the ferment in a `running` state, which misrepresented the halted execution. This change ensures the command accurately reflects a paused workflow.

### Key changes
- `src/extensions/ferment/commands.ts`
  - Updated `/pause` handler to call `applyAndPersist(id, { type: "pause" })` instead of only disabling auto-mode.
  - Added early-return guard for `active.status === "paused"` that notifies without mutating state or calling `abort`.
  - Appended `ctx.abort()` after a successful pause to terminate the active turn.
  - Updated command description to "Pause the active ferment and disable auto-mode."
- `src/extensions/ferment/commands.test.ts`
  - Updated existing `/pause` test to assert status becomes `paused`, steps reset to `pending`, and `ctx.abort` is invoked.
  - Added no-op test for pausing an already paused ferment.
  - Added lifecycle test verifying pause → resume toggles `setAutoModeEnabled`, restores tools, and reactivates the phase.

### Impact
- **Behavior change**: `/pause` now mutates ferment state and aborts execution. Logic that assumed pause was stateless will need adjustment.
- Tool scope is narrowed to `["read", "bash"]` on pause and restored to the full ferment set on resume via `/auto`.