### PR TITLE
NOJIRA: remove useless padding

### DIFF
--- a/src/extensions/orchestration/prompt-enrichment.ts
+++ b/src/extensions/orchestration/prompt-enrichment.ts
@@ -276,13 +276,6 @@ export default function (skillPaths: string[]) {
 		// For sub agents we don't want to transform the prompt sent from parent with model capabilities
 		const registry = new ModelRegistry(getAvailableModels())
 		if (!subagentMode) {
-			// Announce newly available API models that have no capability entry yet.
-			for (const warning of registry.warnings) {
-				console.log(
-					`${fg(ANSI.accent, ` New model available: "kimchi-dev/${warning.modelId}"`)}\n${fg(ANSI.dim, " Update the app or add the new model to model capabilities config to unlock orchestration support.")}`,
-				)
-			}
-
 			// Global terminal input listener so alt+tab works even when a
 			// dialog (e.g. permission prompt) has focus instead of the editor.
 			let unsubAltTab: (() => void) | null = null

--- a/src/extensions/subagent.ts
+++ b/src/extensions/subagent.ts
@@ -21,7 +21,6 @@ import { getAllImages, getImagesByIds, parseImageReferences } from "../utils/ima
 import { formatCount, formatDuration } from "./format.js"
 import { filterThinkingForDisplay } from "./hide-thinking.js"
 import { type SpinnerState, clearSpinner, spinnerFrame, tickSpinner } from "./spinner.js"
-import { HORIZONTAL_PADDING } from "./ui.js"
 
 function modelSupportsImages(modelId: string | undefined): boolean {
 	if (!modelId) return false
@@ -1073,7 +1072,7 @@ export default function (pi: ExtensionAPI) {
 				const toolCall = state.lastToolCall
 				let partialDisplayText: string
 				let displayStyle: "dim" | "toolOutput"
-				const terminalWidth = Math.max(1, (process.stdout.columns ?? 80) - HORIZONTAL_PADDING * 2)
+				const terminalWidth = process.stdout.columns ?? 80
 				if (toolCall) {
 					const truncated = truncateToWidth(`> ${toolCall}`, terminalWidth * 5)
 					const toolCallVisualLines = wrapTextWithAnsi(truncated, terminalWidth)

--- a/src/extensions/ui.ts
+++ b/src/extensions/ui.ts
@@ -36,22 +36,6 @@ function getEnabledModelIds(): Set<string> | null {
 	return null
 }
 
-export const HORIZONTAL_PADDING = 2
-
-// Strip OSC 133 shell-integration marks emitted by pi-mono around each message.
-// iTerm2 renders a visible blue triangle at each mark, which is noisy in the TUI.
-// biome-ignore lint/suspicious/noControlCharactersInRegex: matching ANSI/OSC
-const OSC133_RE = /\x1b]133;[A-Z]\x07/g
-
-function patchTuiPadding(tui: TUI) {
-	const original = tui.render.bind(tui)
-	const pad = " ".repeat(HORIZONTAL_PADDING)
-	tui.render = (width: number): string[] => {
-		const lines = original(Math.max(1, width - HORIZONTAL_PADDING * 2))
-		return lines.map((line: string) => pad + line.replace(OSC133_RE, ""))
-	}
-}
-
 // Track splash state globally so other extensions can reset it
 let splashActive = false
 let currentEditor: PromptEditor | undefined
@@ -132,7 +116,6 @@ function runScript(scriptPath: string, payload: object, tui: TUI, footer: Script
 }
 
 export default function uiExtension(pi: ExtensionAPI) {
-	let tuiPatched = false
 	let unsubModelCycleInput: (() => void) | null = null
 	let scriptFooter: ScriptFooter | null = null
 	let scriptTui: TUI | null = null
@@ -211,10 +194,6 @@ export default function uiExtension(pi: ExtensionAPI) {
 		})
 
 		ctx.ui.setEditorComponent((tui, editorTheme, keybindings) => {
-			if (!tuiPatched) {
-				tuiPatched = true
-				patchTuiPadding(tui)
-			}
 			tui.setShowHardwareCursor(true)
 			const editor = new PromptEditor(tui, editorTheme, keybindings, ctx.ui.theme)
 			editor.setSplashMode(isSplash)


### PR DESCRIPTION
- Removed unactionable console log - updating doesn't necessarily mean we've added the new model to the orchestrator.
- Removed useless padding - it would keep increasing everytime you enter /new command

---
### Kimchi Summary
### What changed
Removes hard-coded horizontal padding from the TUI and the associated shell-integration mark stripping, allowing content to use the full terminal width. Also removes console warnings for unregistered API models during orchestration setup.

### Why
The fixed padding consumed terminal space without improving readability and added unnecessary complexity to width calculations across the UI and subagent extensions.

### Key changes
- `src/extensions/ui.ts`: Removed `HORIZONTAL_PADDING`, the `patchTuiPadding` helper, and the `OSC133_RE` regex that stripped shell-integration marks. Eliminated the conditional padding injection in the editor component setup.
- `src/extensions/subagent.ts`: Dropped the `HORIZONTAL_PADDING` import and simplified `terminalWidth` to `process.stdout.columns ?? 80`.
- `src/extensions/orchestration/prompt-enrichment.ts`: Removed the startup warning loop that announced newly available models lacking a capability entry.

### Impact
- TUI content now renders edge-to-edge instead of with 2-character horizontal margins.
- OSC 133 shell-integration marks are no longer stripped from TUI output; iTerm2 users may see blue triangle indicators at message boundaries.
- Subagent output wrapping now utilizes the full terminal width.