### PR TITLE
chore: rename install script to match new repo name

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ brew install castai/tap/kimchi-dev
 **Install script:**
 
 ```bash
-curl -fsSL https://github.com/castai/kimchi-dev/releases/latest/download/install.sh | bash
+curl -fsSL https://github.com/castai/kimchi/releases/latest/download/install.sh | bash
 ```
 
 Then configure your API key and tools, and launch:

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -3,7 +3,7 @@
 # Install the kimchi coding-harness CLI from the latest GitHub release.
 #
 # Usage:
-#   curl -fsSL https://github.com/castai/kimchi-dev/releases/latest/download/install.sh | bash
+#   curl -fsSL https://github.com/castai/kimchi/releases/latest/download/install.sh | bash
 #
 # Optional env:
 #   KIMCHI_INSTALL_DIR  Override install dir. Defaults to /usr/local/bin if
@@ -20,7 +20,7 @@ BLUE='\033[0;34m'
 YELLOW='\033[0;33m'
 NC='\033[0m'
 
-REPO="${KIMCHI_REPO_OVERRIDE:-castai/kimchi-dev}"
+REPO="${KIMCHI_REPO_OVERRIDE:-castai/kimchi}"
 VERSION="${KIMCHI_VERSION:-latest}"
 
 echo -e "${BLUE}Installing Kimchi from ${REPO}${VERSION:+ (${VERSION})}…${NC}"


### PR DESCRIPTION


---
### Kimchi Summary
### What changed
Updates the default repository reference in the install script and README from `castai/kimchi-dev` to `castai/kimchi`.

### Why
The project repository has been renamed to `castai/kimchi`, so the install URLs and documentation need to point to the new location.

### Key changes
- `scripts/install.sh`: changed the default `REPO` value from `castai/kimchi-dev` to `castai/kimchi` and updated the usage comment URL
- `README.md`: updated the `curl` install command to download from `castai/kimchi` releases instead of `castai/kimchi-dev`