### PR TITLE
Feat: Improve ferment questioner

### DIFF
--- a/src/extensions/ferment/ask-user.test.ts
+++ b/src/extensions/ferment/ask-user.test.ts
@@ -1,7 +1,7 @@
 import type { ExtensionAPI } from "@earendil-works/pi-coding-agent"
 import { describe, expect, it, vi } from "vitest"
 import type { Ferment } from "../../ferment/types.js"
-import { type AskUserOption, askJudge, askUser } from "./ask-user.js"
+import { type AskUserOption, askJudge, askJudgeForm, askUser, askUserForm } from "./ask-user.js"
 import type { JudgeApiResult } from "./judge.js"
 
 function makeFerment(overrides: Partial<Ferment> = {}): Ferment {
@@ -101,6 +101,7 @@ describe("askUser routing", () => {
 		const select = vi.fn(async () => "Proceed")
 		const fakeJudge = vi.fn(async () => ({
 			choice: "pause",
+			response_type: "single" as const,
 			answered_by: "judge" as const,
 			rationale: "Preserves optionality.",
 		}))
@@ -120,6 +121,92 @@ describe("askUser routing", () => {
 		expect(result.choice).toBe("pause")
 		expect(result.answered_by).toBe("judge")
 		expect(result.rationale).toBe("Preserves optionality.")
+	})
+
+	it("routes text questions to TUI input", async () => {
+		const input = vi.fn(async () => "Use the conservative path.")
+		const result = await askUser(
+			"What else should I know?",
+			[],
+			{
+				ferment: makeFerment(),
+				pi: makePi(),
+				ctx: { ui: { input } as never },
+			},
+			"text",
+		)
+		expect(result.failed).toBeFalsy()
+		if (result.failed) return
+		expect(result.response_type).toBe("text")
+		expect(result.text).toBe("Use the conservative path.")
+		expect(result.answered_by).toBe("user")
+	})
+
+	it("routes multi questions through comma-separated input fallback when custom UI is unavailable", async () => {
+		const input = vi.fn(async () => "1, Abandon")
+		const result = await askUser(
+			"Pick all acceptable actions.",
+			opts,
+			{
+				ferment: makeFerment(),
+				pi: makePi(),
+				ctx: { ui: { input } as never },
+			},
+			"multi",
+		)
+		expect(result.failed).toBeFalsy()
+		if (result.failed) return
+		expect(result.response_type).toBe("multi")
+		expect(result.choices).toEqual(["proceed", "abandon"])
+	})
+
+	it("routes form questions through fallback UI when custom UI is unavailable", async () => {
+		const select = vi.fn(async () => "Type your own answer")
+		const input = vi
+			.fn<() => Promise<string>>()
+			.mockResolvedValueOnce("custom answer")
+			.mockResolvedValueOnce("1, Type your own answer")
+			.mockResolvedValueOnce("custom answer")
+		const result = await askUserForm(
+			"Clarify plan",
+			"Pick the shape.",
+			[
+				{
+					id: "approach",
+					type: "radio",
+					prompt: "Which approach?",
+					options: [{ id: "safe", label: "Safe path" }],
+					allowOther: true,
+				},
+				{
+					id: "scope",
+					type: "checkbox",
+					prompt: "What is in scope?",
+					options: [{ id: "tests", label: "Tests" }],
+					allowOther: true,
+				},
+			],
+			{
+				ferment: makeFerment(),
+				pi: makePi(),
+				ctx: { ui: { select, input } as never },
+			},
+		)
+		expect(result.failed).toBeFalsy()
+		if (result.failed) return
+		expect(result.response_type).toBe("form")
+		expect(result.answers).toEqual([
+			{ id: "approach", type: "radio", value: "custom answer", label: "custom answer", wasCustom: true },
+			{
+				id: "scope",
+				type: "checkbox",
+				value: "tests, custom answer",
+				label: "Tests, custom answer",
+				wasCustom: true,
+				values: ["tests", "custom answer"],
+				labels: ["Tests", "custom answer"],
+			},
+		])
 	})
 })
 
@@ -181,6 +268,92 @@ describe("askJudge", () => {
 		expect(result.failed).toBe(true)
 		if (!result.failed) return
 		expect(result.detail).toContain("timeout after 45s")
+	})
+
+	it("parses multi-select judge responses", async () => {
+		const apiCall = vi.fn(async () => ok('{"choices":["proceed","pause"],"rationale":"both are acceptable"}'))
+		const result = await askJudge("What now?", opts, makeFerment(), "multi", apiCall)
+		expect(result.failed).toBeFalsy()
+		if (result.failed) return
+		expect(result.response_type).toBe("multi")
+		expect(result.choices).toEqual(["proceed", "pause"])
+	})
+
+	it("parses text judge responses", async () => {
+		const apiCall = vi.fn(async () => ok('{"text":"Ask for a reversible plan.","rationale":"safer"}'))
+		const result = await askJudge("What should the user say?", [], makeFerment(), "text", apiCall)
+		expect(result.failed).toBeFalsy()
+		if (result.failed) return
+		expect(result.response_type).toBe("text")
+		expect(result.text).toBe("Ask for a reversible plan.")
+	})
+
+	it("parses structured form judge responses", async () => {
+		const apiCall = vi.fn(async () =>
+			ok(
+				'{"answers":[{"id":"approach","value":"safe"},{"id":"scope","value":["tests","extra docs"]},{"id":"note","value":"Keep it reversible."}],"rationale":"safer"}',
+			),
+		)
+		const result = await askJudgeForm(
+			"Clarify plan",
+			undefined,
+			[
+				{
+					id: "approach",
+					type: "radio",
+					prompt: "Which approach?",
+					options: [{ id: "safe", label: "Safe path" }],
+				},
+				{
+					id: "scope",
+					type: "checkbox",
+					prompt: "What is in scope?",
+					options: [{ id: "tests", label: "Tests" }],
+					allowOther: true,
+				},
+				{ id: "note", type: "text", prompt: "Anything else?" },
+			],
+			makeFerment(),
+			apiCall,
+		)
+		expect(result.failed).toBeFalsy()
+		if (result.failed) return
+		expect(result.response_type).toBe("form")
+		expect(result.answered_by).toBe("judge")
+		expect(result.answers).toEqual([
+			{ id: "approach", type: "radio", value: "safe", label: "Safe path", wasCustom: false },
+			{
+				id: "scope",
+				type: "checkbox",
+				value: "tests, extra docs",
+				label: "Tests, extra docs",
+				wasCustom: true,
+				values: ["tests", "extra docs"],
+				labels: ["Tests", "extra docs"],
+			},
+			{ id: "note", type: "text", value: "Keep it reversible.", label: "Keep it reversible.", wasCustom: true },
+		])
+	})
+
+	it("rejects form judge responses with invalid non-custom options", async () => {
+		const apiCall = vi.fn(async () => ok('{"answers":[{"id":"approach","value":"made_up"}],"rationale":"bad"}'))
+		const result = await askJudgeForm(
+			"Clarify plan",
+			undefined,
+			[
+				{
+					id: "approach",
+					type: "radio",
+					prompt: "Which approach?",
+					options: [{ id: "safe", label: "Safe path" }],
+				},
+			],
+			makeFerment(),
+			apiCall,
+		)
+		expect(result.failed).toBe(true)
+		if (!result.failed) return
+		expect(result.reason).toBe("judge_unparseable")
 	})
 
 	it("includes ferment goal and active phase in the judge prompt", async () => {

--- a/src/extensions/ferment/ask-user.ts
+++ b/src/extensions/ferment/ask-user.ts
@@ -5,7 +5,8 @@
  * with one function that handles three audiences:
  *
  *   1. Interactive sessions (plan / exec / auto with a TUI attached) — routes
- *      to `ctx.ui.select`. The user picks; we return their choice.
+ *      to a richer TUI prompt. The user picks or writes; we return structured
+ *      data.
  *   2. One-shot sessions (no human at the keyboard) — routes to an Opus judge
  *      that stands in for the user. The judge sees the ferment goal + success
  *      criteria + current phase/step + question + options, picks one with a
@@ -28,7 +29,7 @@
 import type { ExtensionAPI } from "@earendil-works/pi-coding-agent"
 import type { Ferment } from "../../ferment/types.js"
 import { type JudgeApiResult, judgeApiCall } from "./judge.js"
-import { promptSelect } from "./prompt-ui.js"
+import { promptForm } from "./prompt-ui.js"
 import type { FermentRuntime } from "./runtime.js"
 import type { FermentUi } from "./ui.js"
 
@@ -43,11 +44,47 @@ export interface AskUserOption {
 }
 
 export type AskUserAnsweredBy = "user" | "judge"
+export type AskUserResponseType = "single" | "multi" | "text"
+export type AskUserQuestionType = "radio" | "checkbox" | "text"
+
+export interface AskUserQuestion {
+	id: string
+	type: AskUserQuestionType
+	prompt: string
+	label?: string
+	options?: AskUserOption[]
+	allowOther?: boolean
+	required?: boolean
+	placeholder?: string
+}
+
+export interface AskUserAnswer {
+	id: string
+	type: AskUserQuestionType
+	/** Single value for radio/text, or comma-joined values for checkbox. */
+	value: string
+	/** Display label for radio/text, or comma-joined labels for checkbox. */
+	label: string
+	/** True when the answer came from free text / Other. */
+	wasCustom: boolean
+	/** Checkbox values. */
+	values?: string[]
+	/** Checkbox display labels. */
+	labels?: string[]
+}
 
 export interface AskUserSuccess {
 	failed?: false
-	/** The selected option's `id`. */
-	choice: string
+	/** Shape of answer requested from the user/judge. */
+	response_type: AskUserResponseType | "form"
+	/** The selected option's `id`, for single-choice questions. */
+	choice?: string
+	/** Selected option ids, for multi-select questions. */
+	choices?: string[]
+	/** User/judge-written answer, for text questions. */
+	text?: string
+	/** One or more structured answers, for form questions. */
+	answers?: AskUserAnswer[]
 	/** Who answered: "user" in interactive sessions, "judge" in one-shot. */
 	answered_by: AskUserAnsweredBy
 	/** Present when `answered_by === "judge"` — the model's one-line rationale. */
@@ -63,6 +100,11 @@ export interface AskUserFailure {
 }
 
 export type AskUserResponse = AskUserSuccess | AskUserFailure
+
+export interface AskUserOverrides {
+	askJudge?: typeof askJudge
+	askJudgeForm?: typeof askJudgeForm
+}
 
 export interface AskUserContext {
 	ferment: Ferment
@@ -96,11 +138,42 @@ You will be given:
 - The set of options, each with an id and a label (sometimes a description).
 
 Return EXACTLY one JSON object, no markdown, no prose:
+For single-choice questions return:
 {"choice":"<option_id>","rationale":"<one sentence justifying the choice>"}
 
-The "choice" MUST be one of the provided option ids verbatim. If you cannot in good faith pick any option, choose the option whose id contains "pause", "abandon", or "cancel" — falling back to the FIRST option only as a last resort.`
+The "choice" MUST be one of the provided option ids verbatim. If you cannot in good faith pick any option, choose the option whose id contains "pause", "abandon", or "cancel" — falling back to the FIRST option only as a last resort.
 
-function buildAskJudgeUserMsg(question: string, options: ReadonlyArray<AskUserOption>, ferment: Ferment): string {
+For multi-select questions return:
+{"choices":["<option_id>"],"rationale":"<one sentence justifying the choices>"}
+
+Every item in "choices" MUST be one of the provided option ids verbatim. Choose one or more.
+
+For text questions return:
+{"text":"<answer>","rationale":"<one sentence justifying the answer>"}
+
+The text answer should be concise and directly usable by the planner.`
+
+const ASK_USER_FORM_SYSTEM = `You are standing in for the user during an autonomous ferment run. A planner agent has reached decision points it cannot resolve from context alone and is asking a structured form. There is no human available — you decide.
+
+Your bias:
+- Choose answers that best serve the ferment's stated goal and success criteria, NOT whatever moves work forward fastest.
+- When two answers seem equivalent, prefer the more conservative one (less destructive, more revertible).
+- When you genuinely cannot tell, choose or write the answer that preserves optionality.
+
+Return EXACTLY one JSON object, no markdown, no prose:
+{"answers":[{"id":"<question_id>","value":"<answer>"}],"rationale":"<one sentence justifying the answers>"}
+
+For radio questions, "value" MUST be one provided option id unless allowOther is true.
+For checkbox questions, "value" MUST be an array of one or more provided option ids unless allowOther is true.
+For text questions, "value" MUST be a concise directly usable string.
+Optional questions may be omitted. Required questions must be answered.`
+
+function buildAskJudgeUserMsg(
+	question: string,
+	options: ReadonlyArray<AskUserOption>,
+	ferment: Ferment,
+	responseType: AskUserResponseType,
+): string {
 	const activePhase = ferment.phases.find((p) => p.status === "active")
 	const activeStep = activePhase?.steps.find((s) => s.status === "running")
 	const optionLines = options
@@ -113,17 +186,50 @@ function buildAskJudgeUserMsg(question: string, options: ReadonlyArray<AskUserOp
 	if (activePhase) parts.push(`Active phase: ${activePhase.index}. "${activePhase.name}" — ${activePhase.goal}`)
 	if (activeStep) parts.push(`Active step: ${activeStep.index}. "${activeStep.description}"`)
 	parts.push("")
+	parts.push(`Requested response type: ${responseType}`)
 	parts.push(`Question: ${question}`)
-	parts.push("")
-	parts.push("Options:")
-	parts.push(optionLines)
+	if (options.length > 0) {
+		parts.push("")
+		parts.push("Options:")
+		parts.push(optionLines)
+	}
 	return parts.join("\n")
 }
 
-function parseJudgeChoice(
-	text: string,
-	options: ReadonlyArray<AskUserOption>,
-): { choice: string; rationale: string } | undefined {
+function buildAskJudgeFormUserMsg(
+	title: string | undefined,
+	description: string | undefined,
+	questions: ReadonlyArray<AskUserQuestion>,
+	ferment: Ferment,
+): string {
+	const activePhase = ferment.phases.find((p) => p.status === "active")
+	const activeStep = activePhase?.steps.find((s) => s.status === "running")
+	const parts: string[] = []
+	parts.push(`Ferment: "${ferment.name}"`)
+	parts.push(`Goal: ${ferment.goal ?? "(none specified)"}`)
+	parts.push(`Success criteria: ${ferment.successCriteria ?? "(none specified)"}`)
+	if (activePhase) parts.push(`Active phase: ${activePhase.index}. "${activePhase.name}" — ${activePhase.goal}`)
+	if (activeStep) parts.push(`Active step: ${activeStep.index}. "${activeStep.description}"`)
+	parts.push("")
+	if (title) parts.push(`Form title: ${title}`)
+	if (description) parts.push(`Form context: ${description}`)
+	parts.push("Questions:")
+	for (const q of questions) {
+		parts.push(
+			`  - id="${q.id}" type="${q.type}" required="${q.required !== false}" allowOther="${q.allowOther === true}" prompt="${q.prompt}"`,
+		)
+		if (q.options && q.options.length > 0) {
+			for (const o of q.options) {
+				parts.push(
+					`      option id="${o.id}" label="${o.label}"${o.description ? ` description="${o.description}"` : ""}`,
+				)
+			}
+		}
+	}
+	return parts.join("\n")
+}
+
+function parseJudgeJson(text: string): unknown {
 	let s = text.trim()
 	if (s.startsWith("```")) {
 		s = s
@@ -131,27 +237,172 @@ function parseJudgeChoice(
 			.replace(/```$/, "")
 			.trim()
 	}
-	let parsed: unknown
 	try {
-		parsed = JSON.parse(s)
+		return JSON.parse(s)
 	} catch {
 		const m = s.match(/\{[\s\S]*\}/)
 		if (!m) return undefined
 		try {
-			parsed = JSON.parse(m[0])
+			return JSON.parse(m[0])
 		} catch {
 			return undefined
 		}
 	}
+}
+
+function parseJudgeAnswer(
+	text: string,
+	options: ReadonlyArray<AskUserOption>,
+	responseType: AskUserResponseType,
+): Omit<AskUserSuccess, "answered_by" | "response_type"> | undefined {
+	const parsed = parseJudgeJson(text)
 	if (!parsed || typeof parsed !== "object") return undefined
-	const obj = parsed as { choice?: unknown; rationale?: unknown }
-	if (typeof obj.choice !== "string") return undefined
-	// Validate the choice matches one of the offered option ids. This is
-	// important — silently accepting a hallucinated id would route the agent
-	// down an option it never offered.
-	if (!options.some((o) => o.id === obj.choice)) return undefined
+	const obj = parsed as { choice?: unknown; choices?: unknown; text?: unknown; rationale?: unknown }
 	const rationale = typeof obj.rationale === "string" ? obj.rationale : "(no rationale provided)"
+
+	if (responseType === "text") {
+		if (typeof obj.text !== "string" || obj.text.trim() === "") return undefined
+		return { text: obj.text.trim().slice(0, 4000), rationale: rationale.slice(0, 400) }
+	}
+
+	if (responseType === "multi") {
+		if (!Array.isArray(obj.choices)) return undefined
+		const choices = obj.choices.filter((choice): choice is string => typeof choice === "string")
+		if (choices.length === 0) return undefined
+		if (choices.some((choice) => !options.some((o) => o.id === choice))) return undefined
+		return { choices: Array.from(new Set(choices)), rationale: rationale.slice(0, 400) }
+	}
+
+	if (typeof obj.choice !== "string") return undefined
+	if (!options.some((o) => o.id === obj.choice)) return undefined
 	return { choice: obj.choice, rationale: rationale.slice(0, 400) }
+}
+
+function validateFormQuestions(questions: ReadonlyArray<AskUserQuestion>): string | undefined {
+	if (questions.length === 0) return "askUserForm called with no questions."
+	const seen = new Set<string>()
+	for (const q of questions) {
+		if (!q.id.trim()) return "askUserForm question id must be non-empty."
+		if (seen.has(q.id)) return `askUserForm question id "${q.id}" is duplicated.`
+		seen.add(q.id)
+		if (!q.prompt.trim()) return `askUserForm question "${q.id}" prompt must be non-empty.`
+		if ((q.type === "radio" || q.type === "checkbox") && (q.options?.length ?? 0) === 0 && !q.allowOther) {
+			return `askUserForm question "${q.id}" is type "${q.type}" but has no options and allowOther is false.`
+		}
+	}
+	return undefined
+}
+
+function answerFromValue(q: AskUserQuestion, rawValue: unknown): AskUserAnswer | undefined {
+	const type = q.type
+	if (type === "text") {
+		if (typeof rawValue !== "string") return undefined
+		const text = rawValue.trim().slice(0, 4000)
+		if (!text) return undefined
+		return { id: q.id, type, value: text, label: text, wasCustom: true }
+	}
+
+	if (type === "radio") {
+		if (typeof rawValue !== "string") return undefined
+		const value = rawValue.trim()
+		if (!value) return undefined
+		const option = q.options?.find((o) => o.id === value)
+		if (option) return { id: q.id, type, value: option.id, label: option.label, wasCustom: false }
+		if (q.allowOther)
+			return { id: q.id, type, value: value.slice(0, 1000), label: value.slice(0, 1000), wasCustom: true }
+		return undefined
+	}
+
+	const rawValues = Array.isArray(rawValue)
+		? rawValue
+		: typeof rawValue === "string"
+			? rawValue
+					.split(",")
+					.map((v) => v.trim())
+					.filter(Boolean)
+			: []
+	const values: string[] = []
+	const labels: string[] = []
+	let wasCustom = false
+	for (const raw of rawValues) {
+		if (typeof raw !== "string") return undefined
+		const value = raw.trim()
+		if (!value || values.includes(value)) continue
+		const option = q.options?.find((o) => o.id === value)
+		if (option) {
+			values.push(option.id)
+			labels.push(option.label)
+		} else if (q.allowOther) {
+			const custom = value.slice(0, 1000)
+			values.push(custom)
+			labels.push(custom)
+			wasCustom = true
+		} else {
+			return undefined
+		}
+	}
+	if (values.length === 0) return undefined
+	return {
+		id: q.id,
+		type,
+		value: values.join(", "),
+		label: labels.join(", "),
+		wasCustom,
+		values,
+		labels,
+	}
+}
+
+function parseJudgeFormAnswer(
+	text: string,
+	questions: ReadonlyArray<AskUserQuestion>,
+): Pick<AskUserSuccess, "answers" | "rationale"> | undefined {
+	const parsed = parseJudgeJson(text)
+	if (!parsed || typeof parsed !== "object") return undefined
+	const obj = parsed as { answers?: unknown; rationale?: unknown }
+	if (!Array.isArray(obj.answers)) return undefined
+	const rationale = typeof obj.rationale === "string" ? obj.rationale : "(no rationale provided)"
+	const byId = new Map<string, unknown>()
+	for (const rawAnswer of obj.answers) {
+		if (!rawAnswer || typeof rawAnswer !== "object") return undefined
+		const answer = rawAnswer as { id?: unknown; value?: unknown }
+		if (typeof answer.id !== "string") return undefined
+		byId.set(answer.id, answer.value)
+	}
+
+	const answers: AskUserAnswer[] = []
+	for (const q of questions) {
+		if (!byId.has(q.id)) {
+			if (q.required !== false) return undefined
+			continue
+		}
+		const answer = answerFromValue(q, byId.get(q.id))
+		if (!answer) {
+			if (q.required === false) continue
+			return undefined
+		}
+		answers.push(answer)
+	}
+	return { answers, rationale: rationale.slice(0, 400) }
+}
+
+function mapPromptFormAnswers(
+	questions: ReadonlyArray<AskUserQuestion>,
+	answers: ReadonlyArray<import("./prompt-ui.js").PromptFormAnswer>,
+): AskUserAnswer[] {
+	return answers.map((answer) => {
+		const question = questions.find((q) => q.id === answer.id)
+		const type = question?.type ?? (answer.values ? "checkbox" : answer.wasCustom ? "text" : "radio")
+		return {
+			id: answer.id,
+			type,
+			value: answer.values ? answer.values.join(", ") : answer.value,
+			label: answer.labels ? answer.labels.join(", ") : answer.label,
+			wasCustom: answer.wasCustom,
+			values: answer.values,
+			labels: answer.labels,
+		}
+	})
 }
 
 /** Ask the judge as a stand-in user. Returns a structured success or a typed
@@ -161,9 +412,15 @@ export async function askJudge(
 	question: string,
 	options: ReadonlyArray<AskUserOption>,
 	ferment: Ferment,
-	apiCall: (sys: string, msg: string, maxTokens?: number) => Promise<JudgeApiResult> = judgeApiCall,
+	responseTypeOrApiCall:
+		| AskUserResponseType
+		| ((sys: string, msg: string, maxTokens?: number) => Promise<JudgeApiResult>) = "single",
+	apiCallOverride?: (sys: string, msg: string, maxTokens?: number) => Promise<JudgeApiResult>,
 ): Promise<AskUserResponse> {
-	const userMsg = buildAskJudgeUserMsg(question, options, ferment)
+	const responseType = typeof responseTypeOrApiCall === "string" ? responseTypeOrApiCall : "single"
+	const apiCall =
+		typeof responseTypeOrApiCall === "function" ? responseTypeOrApiCall : (apiCallOverride ?? judgeApiCall)
+	const userMsg = buildAskJudgeUserMsg(question, options, ferment, responseType)
 	const result = await apiCall(ASK_USER_SYSTEM, userMsg, 200)
 	if (!result.ok) {
 		return {
@@ -172,7 +429,7 @@ export async function askJudge(
 			detail: `Judge unreachable (${result.reason}${result.detail ? `: ${result.detail}` : ""}).`,
 		}
 	}
-	const parsed = parseJudgeChoice(result.text, options)
+	const parsed = parseJudgeAnswer(result.text, options, responseType)
 	if (!parsed) {
 		return {
 			failed: true,
@@ -180,7 +437,77 @@ export async function askJudge(
 			detail: `Judge returned unparseable output: ${result.text.slice(0, 200)}`,
 		}
 	}
-	return { choice: parsed.choice, answered_by: "judge", rationale: parsed.rationale }
+	return { ...parsed, response_type: responseType, answered_by: "judge" }
+}
+
+export async function askJudgeForm(
+	title: string | undefined,
+	description: string | undefined,
+	questions: ReadonlyArray<AskUserQuestion>,
+	ferment: Ferment,
+	apiCall: (sys: string, msg: string, maxTokens?: number) => Promise<JudgeApiResult> = judgeApiCall,
+): Promise<AskUserResponse> {
+	const validationError = validateFormQuestions(questions)
+	if (validationError) {
+		return { failed: true, reason: "invalid_choice", detail: validationError }
+	}
+	const userMsg = buildAskJudgeFormUserMsg(title, description, questions, ferment)
+	const result = await apiCall(ASK_USER_FORM_SYSTEM, userMsg, 500)
+	if (!result.ok) {
+		return {
+			failed: true,
+			reason: "judge_unavailable",
+			detail: `Judge unreachable (${result.reason}${result.detail ? `: ${result.detail}` : ""}).`,
+		}
+	}
+	const parsed = parseJudgeFormAnswer(result.text, questions)
+	if (!parsed) {
+		return {
+			failed: true,
+			reason: "judge_unparseable",
+			detail: `Judge returned unparseable output: ${result.text.slice(0, 200)}`,
+		}
+	}
+	return { ...parsed, response_type: "form", answered_by: "judge" }
+}
+
+export async function askUserForm(
+	title: string | undefined,
+	description: string | undefined,
+	questions: ReadonlyArray<AskUserQuestion>,
+	context: AskUserContext,
+	overrides?: AskUserOverrides,
+): Promise<AskUserResponse> {
+	const validationError = validateFormQuestions(questions)
+	if (validationError) {
+		return { failed: true, reason: "invalid_choice", detail: validationError }
+	}
+
+	const oneShot = isOneShotSession(context.pi)
+	if (oneShot) {
+		const judge = overrides?.askJudgeForm ?? askJudgeForm
+		return judge(title, description, questions, context.ferment)
+	}
+
+	const ui = context.ctx?.ui
+	if (ui) {
+		const result = await promptForm(context.ctx, { title, description, questions })
+		if (!result || result.cancelled) {
+			return { failed: true, reason: "user_cancelled", detail: "User cancelled the prompt." }
+		}
+		context.runtime?.markHumanInput()
+		return {
+			response_type: "form",
+			answers: mapPromptFormAnswers(questions, result.answers),
+			answered_by: "user",
+		}
+	}
+
+	return {
+		failed: true,
+		reason: "no_ui_no_judge",
+		detail: "No TUI attached and not in one-shot mode — cannot route the questions to any audience.",
+	}
 }
 
 /** Routing entry point. Picks the right audience for the question, returns
@@ -189,10 +516,17 @@ export async function askUser(
 	question: string,
 	options: ReadonlyArray<AskUserOption>,
 	context: AskUserContext,
-	overrides?: { askJudge?: typeof askJudge },
+	responseTypeOrOverrides: AskUserResponseType | AskUserOverrides = "single",
+	overrides?: AskUserOverrides,
 ): Promise<AskUserResponse> {
-	if (options.length === 0) {
-		return { failed: true, reason: "invalid_choice", detail: "askUser called with empty options array." }
+	const responseType = typeof responseTypeOrOverrides === "string" ? responseTypeOrOverrides : "single"
+	const effectiveOverrides = typeof responseTypeOrOverrides === "string" ? overrides : responseTypeOrOverrides
+	if (responseType !== "text" && options.length === 0) {
+		return {
+			failed: true,
+			reason: "invalid_choice",
+			detail: `askUser called with empty options array for ${responseType} question.`,
+		}
 	}
 
 	const oneShot = isOneShotSession(context.pi)
@@ -201,31 +535,62 @@ export async function askUser(
 		// One-shot: judge is the only legitimate audience. No fallback to TUI
 		// even if a UI happens to be attached — the contract says one-shot
 		// runs are unattended, and we don't want to half-prompt a CLI user.
-		const judge = overrides?.askJudge ?? askJudge
-		return judge(question, options, context.ferment)
+		const judge = effectiveOverrides?.askJudge ?? askJudge
+		return judge(question, options, context.ferment, responseType)
 	}
 
 	// Interactive: route to TUI when available.
-	const select = context.ctx?.ui?.select
-	if (select) {
-		const labels = options.map((o) => o.label)
-		const chosenLabel = await promptSelect(context.ctx, question, labels)
-		if (!chosenLabel) {
+	const ui = context.ctx?.ui
+	if (ui) {
+		const result = await promptForm(context.ctx, {
+			questions: [
+				{
+					id: "answer",
+					type: responseType === "multi" ? "checkbox" : responseType === "text" ? "text" : "radio",
+					prompt: question,
+					options,
+					allowOther: false,
+				},
+			],
+		})
+		if (!result || result.cancelled || result.answers.length === 0) {
+			if (result && !result.cancelled && result.answers.length === 0) {
+				return { failed: true, reason: "invalid_choice", detail: "UI returned no valid answer." }
+			}
 			return { failed: true, reason: "user_cancelled", detail: "User cancelled the prompt." }
 		}
-		const match = options.find((o) => o.label === chosenLabel)
-		if (!match) {
+		const answer = result.answers[0]
+		if (!answer) {
+			return { failed: true, reason: "user_cancelled", detail: "User cancelled the prompt." }
+		}
+		if (responseType === "text") {
+			context.runtime?.markHumanInput()
+			return { text: answer.value, response_type: "text", answered_by: "user" }
+		}
+		if (responseType === "multi") {
+			const choices = answer.values ?? answer.value.split(",").map((value) => value.trim())
+			if (choices.length === 0 || choices.some((choice) => !options.some((o) => o.id === choice))) {
+				return {
+					failed: true,
+					reason: "invalid_choice",
+					detail: `UI returned a value not in the options set: ${choices.join(", ")}`,
+				}
+			}
+			context.runtime?.markHumanInput()
+			return { choices, response_type: "multi", answered_by: "user" }
+		}
+		if (!options.some((o) => o.id === answer.value)) {
 			return {
 				failed: true,
 				reason: "invalid_choice",
-				detail: `UI returned a label not in the options set: ${chosenLabel}`,
+				detail: `UI returned a value not in the options set: ${answer.value}`,
 			}
 		}
 		// Side effect: mark human input so downstream signals (nudge throttling,
 		// planner-supplement freshness) reflect that the user just interacted.
 		// Skipped for judge-answered responses since no human was involved.
 		context.runtime?.markHumanInput()
-		return { choice: match.id, answered_by: "user" }
+		return { choice: answer.value, response_type: "single", answered_by: "user" }
 	}
 
 	return {

--- a/src/extensions/ferment/planner-supplement.ts
+++ b/src/extensions/ferment/planner-supplement.ts
@@ -30,7 +30,7 @@ export function buildPlannerSupplement(runtime: FermentRuntime = defaultFermentR
 
 When the user answers scoping questions and the host asks you to replan, treat those answers as final decisions. Re-emit the full updated plan. Usually set \`questions: []\`. Ask follow-up questions only for genuinely new, decision-blocking ambiguity introduced by the answers. Never repeat, rephrase, or "double check" a question the user already answered. After two question rounds, converge: make the best assumption, record it in \`assumptions\`, and let the user review the final plan.
 
-For each question: 2-4 options with stable ids, emitted as a real JSON array of objects. Keep options in the display order you want; the host preserves your order and appends "Custom answer..." last. Mark ONE option as \`recommended: true\` (what you'd pick if no answer came back), but do not move it to the top unless that is also the natural ordering. No reason text on recommendations.
+For each question: 2-5 options with stable ids, emitted as a real JSON array of objects. Keep options in the display order you want; the host preserves your order and appends "Custom answer..." last. Mark ONE option as \`recommended: true\` (what you'd pick if no answer came back), but do not move it to the top unless that is also the natural ordering. No reason text on recommendations.
 
 Plans are rendered by the host in markdown style. Keep plan field content markdown-friendly: concise sentences, bullet-like success criteria separated by newlines or semicolons, concrete phase names, and step descriptions that read well as numbered markdown lists.
 
@@ -38,7 +38,7 @@ Plans are rendered by the host in markdown style. Keep plan field content markdo
 
 **Do NOT chat-list the questions to the user after calling propose_scoping.** The host displays them in dropdowns; repeating them in prose is duplicate noise. After the tool call, output nothing or a one-line confirmation at most.
 
-**Do NOT include a "Let me say something" or similar escape-hatch option in your questions.options array.** The host adds that affordance on the review screen. Your options array is just real choices.
+**Do NOT include a "Let me say something" or similar escape-hatch option in your questions.options array.** The host adds the free-form affordance where appropriate. Your options array is just real choices.
 
 Every option label must be a SINGLE concrete choice. Never use compound "X or Y" labels (e.g. "React or Vue", "Keep existing or rewrite"). Each "or" branch deserves its own option row. A label like "React (CRA or Next.js)" is OK only when both halves describe the SAME single choice (a React app, flavor unspecified).
 

--- a/src/extensions/ferment/prompt-ui.ts
+++ b/src/extensions/ferment/prompt-ui.ts
@@ -1,7 +1,64 @@
+import type { ExtensionUIContext, Theme } from "@earendil-works/pi-coding-agent"
+import { Input, Key, type TUI, matchesKey, truncateToWidth } from "@earendil-works/pi-tui"
+import type { Component } from "@earendil-works/pi-tui"
+import {
+	type Answer,
+	type Question,
+	type QuestionnaireEffect,
+	type QuestionnaireEvent,
+	type QuestionnaireState,
+	allRequiredAnswered,
+	currentOptions,
+	currentQuestion,
+	initialState,
+	isSubmitTab,
+	reduce,
+} from "../questionnaire-reducer.js"
+
 export type PromptUi = {
 	select?: (title: string, options: string[]) => Promise<string | undefined>
 	input?: (title: string, placeholder?: string) => Promise<string | undefined>
+	custom?: ExtensionUIContext["custom"]
 	setWorkingVisible?: (visible: boolean) => void
+}
+
+export interface PromptChoiceOption {
+	label: string
+	description?: string
+}
+
+export type PromptFormQuestionType = "radio" | "checkbox" | "text"
+
+export interface PromptFormOption {
+	id: string
+	label: string
+	description?: string
+}
+
+export interface PromptFormQuestion {
+	id: string
+	type: PromptFormQuestionType
+	prompt: string
+	label?: string
+	options?: ReadonlyArray<PromptFormOption>
+	allowOther?: boolean
+	required?: boolean
+	default?: string | string[]
+	placeholder?: string
+}
+
+export interface PromptFormSpec {
+	title?: string
+	description?: string
+	questions: ReadonlyArray<PromptFormQuestion>
+}
+
+export type PromptFormAnswer = Answer
+
+export interface PromptFormResult {
+	questions: Question[]
+	answers: PromptFormAnswer[]
+	cancelled: boolean
 }
 
 export function getPromptUi(ctx: unknown): PromptUi | undefined {
@@ -27,4 +84,450 @@ export function promptInput(ctx: unknown, title: string, placeholder?: string): 
 	const ui = getPromptUi(ctx)
 	if (!ui?.input) return Promise.resolve(undefined)
 	return withWorkingHidden(ui, () => ui.input?.(title, placeholder) ?? Promise.resolve(undefined))
+}
+
+export async function promptForm(ctx: unknown, spec: PromptFormSpec): Promise<PromptFormResult | undefined> {
+	const ui = getPromptUi(ctx)
+	if (!ui) return undefined
+	const questions = spec.questions.map(normalizePromptFormQuestion)
+	if (questions.length === 0) return undefined
+
+	if (ui.custom) {
+		const customResult = await withWorkingHidden(
+			ui,
+			() =>
+				ui.custom?.<PromptFormResult | null>((tui, theme, _keybindings, done) =>
+					createPromptFormComponent(tui, theme, questions, spec.title, spec.description, done),
+				) ?? Promise.resolve(undefined),
+		)
+		if (customResult !== undefined) return customResult ?? undefined
+	}
+
+	return promptFormFallback(ui, questions, spec.title, spec.description)
+}
+
+function normalizePromptFormQuestion(q: PromptFormQuestion, index: number): Question {
+	const type = q.type === "radio" ? "single" : q.type === "checkbox" ? "multi" : "text"
+	return {
+		id: q.id,
+		label: q.label || `Q${index + 1}`,
+		prompt: q.prompt,
+		type,
+		options: (q.options ?? []).map((o) => ({ value: o.id, label: o.label, description: o.description })),
+		allowOther: q.allowOther ?? false,
+		required: q.required !== false,
+	}
+}
+
+async function promptFormFallback(
+	ui: PromptUi,
+	questions: Question[],
+	title: string | undefined,
+	description: string | undefined,
+): Promise<PromptFormResult | undefined> {
+	const answers: Answer[] = []
+	const heading = [title, description].filter(Boolean).join("\n\n")
+	for (const question of questions) {
+		const promptTitle = [heading, question.prompt].filter(Boolean).join("\n\n")
+		if (question.type === "text") {
+			const value = await withWorkingHidden(ui, () => ui.input?.(promptTitle, "") ?? Promise.resolve(undefined))
+			if (!value && question.required) return { questions, answers, cancelled: true }
+			if (value) answers.push({ id: question.id, value, label: value, wasCustom: true })
+			continue
+		}
+
+		const choices: PromptChoiceOption[] = question.options.map((o) => ({ label: o.label, description: o.description }))
+		const otherLabel = "Type your own answer"
+		if (question.allowOther) choices.push({ label: otherLabel })
+		if (question.type === "multi") {
+			const selected = await promptMultiChoiceWithUi(ui, promptTitle, choices)
+			if ((!selected || selected.length === 0) && question.required) return { questions, answers, cancelled: true }
+			if (!selected || selected.length === 0) continue
+			const values: string[] = []
+			const labels: string[] = []
+			const indices: number[] = []
+			for (const label of selected) {
+				if (label === otherLabel && question.allowOther) {
+					const custom = await withWorkingHidden(
+						ui,
+						() => ui.input?.(`${promptTitle}\n\nYour answer:`, "") ?? Promise.resolve(undefined),
+					)
+					if (custom) {
+						values.push(custom)
+						labels.push(custom)
+						indices.push(question.options.length + 1)
+					}
+					continue
+				}
+				const index = question.options.findIndex((o) => o.label === label)
+				const option = question.options[index]
+				if (option) {
+					values.push(option.value)
+					labels.push(option.label)
+					indices.push(index + 1)
+				}
+			}
+			if (values.length > 0) {
+				answers.push({
+					id: question.id,
+					value: values.join(", "),
+					label: labels.join(", "),
+					wasCustom: selected.includes(otherLabel),
+					values,
+					labels,
+					indices,
+				})
+			}
+			continue
+		}
+
+		const selected = await promptChoiceWithUi(ui, promptTitle, choices)
+		if (!selected && question.required) return { questions, answers, cancelled: true }
+		if (!selected) continue
+		if (selected === otherLabel && question.allowOther) {
+			const custom = await withWorkingHidden(
+				ui,
+				() => ui.input?.(`${promptTitle}\n\nYour answer:`, "") ?? Promise.resolve(undefined),
+			)
+			if (!custom && question.required) return { questions, answers, cancelled: true }
+			if (custom) answers.push({ id: question.id, value: custom, label: custom, wasCustom: true })
+			continue
+		}
+		const index = question.options.findIndex((o) => o.label === selected)
+		const option = question.options[index]
+		if (option) {
+			answers.push({ id: question.id, value: option.value, label: option.label, wasCustom: false, index: index + 1 })
+		}
+	}
+	return { questions, answers, cancelled: false }
+}
+
+async function promptChoiceWithUi(
+	ui: PromptUi,
+	title: string,
+	options: ReadonlyArray<PromptChoiceOption>,
+): Promise<string | undefined> {
+	if (!ui.select) return undefined
+	return withWorkingHidden(
+		ui,
+		() =>
+			ui.select?.(
+				title,
+				options.map((o) => o.label),
+			) ?? Promise.resolve(undefined),
+	)
+}
+
+async function promptMultiChoiceWithUi(
+	ui: PromptUi,
+	title: string,
+	options: ReadonlyArray<PromptChoiceOption>,
+): Promise<string[] | undefined> {
+	if (!ui.input) return undefined
+	const optionText = options
+		.map((o, i) => `${i + 1}. ${o.label}${o.description ? ` - ${o.description}` : ""}`)
+		.join("\n")
+	const raw = await withWorkingHidden(
+		ui,
+		() =>
+			ui.input?.(`${title}\n\nSelect one or more:\n${optionText}`, "Numbers or labels, comma-separated") ??
+			Promise.resolve(undefined),
+	)
+	if (!raw) return undefined
+	const labels = parseMultiChoiceInput(raw, options)
+	return labels.length > 0 ? labels : undefined
+}
+
+function createPromptFormComponent(
+	tui: TUI,
+	theme: Theme,
+	questions: Question[],
+	title: string | undefined,
+	description: string | undefined,
+	done: (result: PromptFormResult | null) => void,
+): Component {
+	let state: QuestionnaireState = initialState(questions)
+	let cachedLines: string[] | undefined
+	const isMulti = questions.length > 1
+	const editor = new Input()
+	editor.focused = true
+
+	function applyEffects(effects: QuestionnaireEffect[]): void {
+		for (const eff of effects) {
+			switch (eff.kind) {
+				case "render":
+					cachedLines = undefined
+					tui.requestRender()
+					break
+				case "editor-set-text":
+					editor.setValue(eff.text)
+					break
+				case "editor-handle-input":
+					editor.handleInput(eff.data)
+					break
+				case "done":
+					done({ questions, answers: Array.from(state.answers.values()), cancelled: eff.cancelled })
+					break
+			}
+		}
+	}
+
+	function dispatch(event: QuestionnaireEvent): void {
+		const result = reduce(state, event)
+		state = result.state
+		applyEffects(result.effects)
+	}
+
+	editor.onSubmit = (value: string) => dispatch({ kind: "editor-submit", value })
+
+	function handleInput(data: string): void {
+		if (state.inputMode) {
+			if (matchesKey(data, Key.escape)) {
+				dispatch({ kind: "key-escape" })
+				return
+			}
+			editor.handleInput(data)
+			cachedLines = undefined
+			tui.requestRender()
+			return
+		}
+
+		if (matchesKey(data, Key.up)) {
+			dispatch({ kind: "key-up" })
+			return
+		}
+		if (matchesKey(data, Key.down)) {
+			dispatch({ kind: "key-down" })
+			return
+		}
+		if (matchesKey(data, Key.tab) || matchesKey(data, Key.right)) {
+			dispatch({ kind: "key-right" })
+			return
+		}
+		if (matchesKey(data, Key.shift("tab")) || matchesKey(data, Key.left)) {
+			dispatch({ kind: "key-left" })
+			return
+		}
+		if (matchesKey(data, Key.enter)) {
+			dispatch({ kind: "key-enter" })
+			return
+		}
+		if (matchesKey(data, Key.escape)) {
+			dispatch({ kind: "key-escape" })
+			return
+		}
+		if (data === " ") {
+			dispatch({ kind: "key-space" })
+			return
+		}
+		if (data.length === 1 && data >= " ") {
+			dispatch({ kind: "char-typed", char: data })
+		}
+	}
+
+	function render(width: number): string[] {
+		if (cachedLines) return cachedLines
+
+		const lines: string[] = []
+		const q = currentQuestion(state)
+		const opts = currentOptions(state)
+		const add = (s: string) => lines.push(truncateToWidth(s, width))
+		const questionTitle = q ? `${isMulti ? `[${q.label}/${questions.length}] ` : ""}${q.prompt}` : ""
+		add(theme.fg("accent", "─".repeat(width)))
+
+		if (title || description) {
+			if (title) add(` ${theme.fg("text", theme.bold(title))}`)
+			if (description) {
+				for (const line of wrapWords(description, width - 2)) add(` ${theme.fg("muted", line)}`)
+			}
+			lines.push("")
+		}
+
+		if (isMulti) {
+			const tabs: string[] = ["<- "]
+			for (let i = 0; i < questions.length; i++) {
+				const isActive = i === state.currentTab
+				const isAnswered = state.answers.has(questions[i].id)
+				const lbl = questions[i].label
+				const box = isAnswered ? "[x]" : "[ ]"
+				const color = isAnswered ? "success" : "muted"
+				const text = ` ${box} ${lbl} `
+				const styled = isActive ? theme.bg("selectedBg", theme.fg("text", text)) : theme.fg(color, text)
+				tabs.push(`${styled} `)
+			}
+			const canSubmit = allRequiredAnswered(state)
+			const onSubmitTab = isSubmitTab(state)
+			const submitText = " Submit "
+			const submitStyled = onSubmitTab
+				? theme.bg("selectedBg", theme.fg("text", submitText))
+				: theme.fg(canSubmit ? "success" : "dim", submitText)
+			tabs.push(`${submitStyled} ->`)
+			add(` ${tabs.join("")}`)
+			lines.push("")
+		}
+
+		function renderOptions(): void {
+			const toggled = q ? (state.multiToggles.get(q.id) ?? new Set()) : new Set()
+			const customText = q ? state.multiCustomText.get(q.id) : undefined
+			for (let i = 0; i < opts.length; i++) {
+				const opt = opts[i]
+				const selected = i === state.optionIndex
+				const isOther = opt.isOther === true
+
+				if (q?.type === "multi") {
+					const checked = toggled.has(i)
+					const box = checked ? "[x]" : "[ ]"
+					const prefix = selected ? theme.fg("accent", "> ") : "  "
+					const color = selected ? "accent" : "text"
+					if (isOther) {
+						const labelText = customText ?? opt.label
+						const suffix = state.inputMode && q.id === state.inputQuestionId ? " *" : customText ? " *" : ""
+						add(`${prefix}${theme.fg(color, `${box} ${i + 1}. ${labelText}${suffix}`)}`)
+					} else {
+						add(`${prefix}${theme.fg(color, `${box} ${i + 1}. ${opt.label}`)}`)
+					}
+				} else {
+					const prefix = selected ? theme.fg("accent", "> ") : "  "
+					const color = selected ? "accent" : "text"
+					if (isOther && state.inputMode) {
+						add(`${prefix}${theme.fg("accent", `${i + 1}. ${opt.label} *`)}`)
+					} else {
+						add(`${prefix}${theme.fg(color, `${i + 1}. ${opt.label}`)}`)
+					}
+				}
+				if (opt.description) {
+					for (const descLine of wrapWords(opt.description, Math.max(12, width - 8))) {
+						add(`     ${theme.fg("muted", descLine)}`)
+					}
+				}
+			}
+		}
+
+		if (state.inputMode && q) {
+			add(theme.fg("text", ` ${questionTitle}`))
+			lines.push("")
+			if (opts.length > 0) renderOptions()
+			lines.push("")
+			add(theme.fg("muted", " Your answer:"))
+			for (const line of editor.render(width - 2)) add(` ${line}`)
+			lines.push("")
+			add(theme.fg("dim", " Enter to submit | Esc to cancel"))
+		} else if (isSubmitTab(state)) {
+			add(theme.fg("accent", theme.bold(" Ready to submit")))
+			lines.push("")
+			for (const question of questions) {
+				const answer = state.answers.get(question.id)
+				if (answer) {
+					const prefix = answer.wasCustom ? "(wrote) " : ""
+					const display = answer.values ? (answer.labels?.join(", ") ?? answer.label) : prefix + answer.label
+					add(`${theme.fg("muted", ` ${question.label}: `)}${theme.fg("text", display)}`)
+				} else if (!question.required) {
+					add(`${theme.fg("muted", ` ${question.label}: `)}${theme.fg("dim", "(skipped)")}`)
+				}
+			}
+			lines.push("")
+			if (allRequiredAnswered(state)) {
+				add(theme.fg("success", " Press Enter to submit"))
+			} else {
+				const missing = questions
+					.filter((qq) => qq.required && !state.answers.has(qq.id))
+					.map((qq) => qq.label)
+					.join(", ")
+				add(theme.fg("warning", ` Unanswered: ${missing}`))
+			}
+		} else if (q?.type === "text") {
+			add(theme.fg("text", ` ${questionTitle}`))
+			lines.push("")
+			const existing = state.answers.get(q.id)
+			if (existing) {
+				add(theme.fg("muted", ` Current: ${existing.label}`))
+				lines.push("")
+			}
+			add(theme.fg("dim", " Press Enter or start typing to answer"))
+		} else if (q) {
+			add(theme.fg("text", ` ${questionTitle}`))
+			lines.push("")
+			renderOptions()
+		}
+
+		lines.push("")
+		if (!state.inputMode) {
+			let help: string
+			if (q?.type === "multi") {
+				help = isMulti
+					? " Tab/Shift+Tab move | Up/Down option | Space toggle | Enter advance | Esc cancel"
+					: " Up/Down option | Space toggle | Enter submit | Esc cancel"
+			} else if (q?.type === "text") {
+				help = isMulti
+					? " Tab/Shift+Tab move | Type answer | Enter edit | Esc cancel"
+					: " Type answer | Enter edit | Esc cancel"
+			} else {
+				help = isMulti
+					? " Tab/Shift+Tab move | Up/Down option | Enter select/advance | Esc cancel"
+					: " Up/Down option | Enter select | Esc cancel"
+			}
+			add(theme.fg("dim", help))
+		}
+		add(theme.fg("accent", "─".repeat(width)))
+
+		cachedLines = lines
+		return lines
+	}
+
+	return {
+		render,
+		invalidate: () => {
+			cachedLines = undefined
+		},
+		handleInput,
+	}
+}
+
+function wrapWords(text: string, width: number): string[] {
+	const limit = Math.max(8, width)
+	const words = text.trim().split(/\s+/).filter(Boolean)
+	if (words.length === 0) return [""]
+
+	const lines: string[] = []
+	let current = ""
+	for (const word of words) {
+		if (word.length > limit) {
+			if (current) {
+				lines.push(current)
+				current = ""
+			}
+			for (let i = 0; i < word.length; i += limit) lines.push(word.slice(i, i + limit))
+			continue
+		}
+		if (!current) {
+			current = word
+		} else if (current.length + 1 + word.length <= limit) {
+			current += ` ${word}`
+		} else {
+			lines.push(current)
+			current = word
+		}
+	}
+	if (current) lines.push(current)
+	return lines
+}
+
+function parseMultiChoiceInput(input: string, options: ReadonlyArray<PromptChoiceOption>): string[] {
+	const out: string[] = []
+	const seen = new Set<string>()
+	const parts = input
+		.split(",")
+		.map((p) => p.trim())
+		.filter(Boolean)
+	for (const part of parts) {
+		const numeric = Number(part)
+		const option = Number.isInteger(numeric)
+			? options[numeric - 1]
+			: options.find((o) => o.label.toLowerCase() === part.toLowerCase())
+		if (option && !seen.has(option.label)) {
+			seen.add(option.label)
+			out.push(option.label)
+		}
+	}
+	return out
 }

--- a/src/extensions/ferment/prompt-ui.ts
+++ b/src/extensions/ferment/prompt-ui.ts
@@ -453,7 +453,9 @@ function createPromptFormComponent(
 		lines.push("")
 		if (!state.inputMode) {
 			let help: string
-			if (q?.type === "multi") {
+			if (isSubmitTab(state)) {
+				help = isMulti ? " Tab/Shift+Tab move | Enter submit | Esc cancel" : " Enter submit | Esc cancel"
+			} else if (q?.type === "multi") {
 				help = isMulti
 					? " Tab/Shift+Tab move | Up/Down option | Space toggle | Enter advance | Esc cancel"
 					: " Up/Down option | Space toggle | Enter submit | Esc cancel"

--- a/src/extensions/ferment/tool-schemas.test.ts
+++ b/src/extensions/ferment/tool-schemas.test.ts
@@ -166,7 +166,7 @@ describe("ProposeScopingParams schema", () => {
 		expect(Value.Check(ProposeScopingParams, payload)).toBe(false)
 	})
 
-	it("rejects question with more than 4 options (maxItems: 4)", () => {
+	it("rejects question with more than 5 options (maxItems: 5)", () => {
 		const payload = {
 			ferment_id: "f-123",
 			goal: "Do something",
@@ -181,6 +181,7 @@ describe("ProposeScopingParams schema", () => {
 						{ id: "c", label: "C" },
 						{ id: "d", label: "D" },
 						{ id: "e", label: "E" },
+						{ id: "f", label: "F" },
 					],
 				},
 			],

--- a/src/extensions/ferment/tool-schemas.ts
+++ b/src/extensions/ferment/tool-schemas.ts
@@ -118,8 +118,8 @@ export const ScopingQuestionSchema = Type.Object({
 	text: Type.String({ description: "The question text shown to the user." }),
 	options: Type.Array(ScopingQuestionOptionSchema, {
 		minItems: 2,
-		maxItems: 4,
-		description: "2–4 candidate options for the question.",
+		maxItems: 5,
+		description: "2–5 candidate options for the question.",
 	}),
 })
 
@@ -162,7 +162,7 @@ export const ProposeScopingParams = Type.Object({
 			Type.Array(ScopingQuestionSchema, {
 				maxItems: 3,
 				description:
-					"Emit ONLY when truly uncertain. At most 3. Must be a real JSON array of question objects, never a quoted string. Each question needs 2-4 options in the display order you want; the host preserves that order and appends Custom answer last. Mark at most ONE option per question with `recommended: true`. No reason text. On replans after user answers, ask only NEW decision-blocking questions; never repeat answered questions.",
+					"Emit ONLY when truly uncertain. At most 3. Must be a real JSON array of question objects, never a quoted string. Each question needs 2-5 options in the display order you want; the host preserves that order and appends Custom answer last. Mark at most ONE option per question with `recommended: true`. No reason text. On replans after user answers, ask only NEW decision-blocking questions; never repeat answered questions.",
 			}),
 			Type.String({
 				description:
@@ -322,14 +322,62 @@ const AskUserOptionSchema = Type.Object({
 	),
 })
 
+const AskUserQuestionSchema = Type.Object({
+	id: Type.String({ description: "Stable identifier for this question. Returned with the answer." }),
+	type: Type.Union([Type.Literal("radio"), Type.Literal("checkbox"), Type.Literal("text")], {
+		description: "radio = single-select, checkbox = multi-select, text = free-form input.",
+	}),
+	prompt: Type.String({ description: "The full question text shown to the user or judge." }),
+	label: Type.Optional(Type.String({ description: "Short label shown in the TUI tab bar. Defaults to Q1, Q2, etc." })),
+	options: Type.Optional(
+		Type.Array(AskUserOptionSchema, {
+			description: "Options for radio/checkbox questions. Omit for text questions.",
+		}),
+	),
+	allowOther: Type.Optional(
+		Type.Boolean({
+			description:
+				"When true, the TUI adds an Other/free-text option. The judge may also return a custom value. Default: false.",
+		}),
+	),
+	required: Type.Optional(Type.Boolean({ description: "Whether this question must be answered. Default: true." })),
+	placeholder: Type.Optional(Type.String({ description: "Optional placeholder hint for text/custom answers." })),
+})
+
 export const AskUserParams = Type.Object({
 	ferment_id: Type.String(),
-	question: Type.String({
-		description:
-			"The decision the agent cannot resolve from context alone. Be concrete and self-contained — the user (or the judge standing in for the user in one-shot mode) sees only this text plus the options.",
-	}),
-	options: Type.Array(AskUserOptionSchema, {
-		description:
-			"2–5 options. Each option needs a stable id and a human label. Include 'pause' or 'abandon' as an explicit option when relevant — the judge prefers these when uncertain.",
-	}),
+	title: Type.Optional(
+		Type.String({
+			description: "Optional title for a multi-question form. Use with questions[].",
+		}),
+	),
+	description: Type.Optional(
+		Type.String({
+			description: "Optional short context shown above a multi-question form and given to the judge.",
+		}),
+	),
+	response_type: Type.Optional(
+		Type.Union([Type.Literal("single"), Type.Literal("multi"), Type.Literal("text")], {
+			description:
+				"Compatibility shorthand for a single question. single returns choice, multi returns choices, text returns text. Default: single.",
+		}),
+	),
+	question: Type.Optional(
+		Type.String({
+			description:
+				"Compatibility shorthand for one question. For 1:1 TUI behavior, prefer questions[] with radio/checkbox/text.",
+		}),
+	),
+	options: Type.Optional(
+		Type.Array(AskUserOptionSchema, {
+			description:
+				"Compatibility shorthand options for single/multi questions. Each option needs a stable id and a human label. Omit for text questions.",
+		}),
+	),
+	questions: Type.Optional(
+		Type.Array(AskUserQuestionSchema, {
+			description:
+				"One or more form questions. Supports radio, checkbox, and text; radio/checkbox support allowOther. Multiple questions use Tab/Shift+Tab navigation and a Submit tab.",
+		}),
+	),
 })

--- a/src/extensions/ferment/tools/lifecycle.ts
+++ b/src/extensions/ferment/tools/lifecycle.ts
@@ -12,7 +12,7 @@ import type { ExtensionAPI } from "@earendil-works/pi-coding-agent"
 import type { Static } from "typebox"
 import type { Command, ScopePhaseInput } from "../../../ferment/state-machine.js"
 import type { Grade, ScopingQuestion } from "../../../ferment/types.js"
-import { askUser } from "../ask-user.js"
+import { askUser, askUserForm } from "../ask-user.js"
 import { pr_bold, pr_dim } from "../colors.js"
 import { validateFsmTransitionWithFerment } from "../fsm-adapter.js"
 import { renderGateGuidance } from "../gate-registry.js"
@@ -21,7 +21,7 @@ import { autoInitFromEnv, ensureGitRepo } from "../git-init.js"
 import { judgeJourneyGrade } from "../judge.js"
 import { appendRefEntry, injectResumeAutoNudge, resetReactiveAutoNudgeCount } from "../nudge.js"
 import { gatherPhaseEvidence } from "../phase-evidence.js"
-import { getPromptUi, promptInput, promptSelect } from "../prompt-ui.js"
+import { getPromptUi, promptForm, promptInput, promptSelect } from "../prompt-ui.js"
 import { readLatestPhaseReviews } from "../review-evidence.js"
 import { type FermentRuntime, defaultFermentRuntime } from "../runtime.js"
 import { confirmPendingScope } from "../scoping-confirmation.js"
@@ -230,8 +230,8 @@ function normalizeQuestions(value: ProposeScopingArgs["questions"]): ScopingQues
 		if (typeof q.id !== "string") return `questions.${questionIndex}.id must be a string.`
 		if (typeof q.text !== "string") return `questions.${questionIndex}.text must be a string.`
 		if (!Array.isArray(q.options)) return `questions.${questionIndex}.options must be an array.`
-		if (q.options.length < 2 || q.options.length > 4) {
-			return `questions.${questionIndex}.options must contain 2-4 options.`
+		if (q.options.length < 2 || q.options.length > 5) {
+			return `questions.${questionIndex}.options must contain 2-5 options.`
 		}
 		for (const [optionIndex, rawOption] of q.options.entries()) {
 			if (!rawOption || typeof rawOption !== "object") {
@@ -321,15 +321,16 @@ function buildPlanEntry(fermentName: string, params: NormalizedProposeScopingArg
 
 function buildAnswersEntry(questions: ScopingQuestion[], answers: ScopingAnswer[]): string {
 	const answerLines = answers.map((a, i) => {
+		const q = questions.find((question) => question.id === a.questionId) ?? questions[i]
 		const recMarker = a.recommended ? " ★" : ""
-		return `Q${i + 1}: ${questions[i].text}\n    · ${a.label}${recMarker}`
+		return `Q${i + 1}: ${q.text}\n    · ${a.label}${recMarker}`
 	})
 	return `${pr_bold("Your answers")}\n${answerLines.join("\n")}`
 }
 
 function buildScopingIterationMessage(questions: ScopingQuestion[], answers: ScopingAnswer[]): string {
 	const bundledAnswerLines = answers.map((a, i) => {
-		const q = questions[i]
+		const q = questions.find((question) => question.id === a.questionId) ?? questions[i]
 		const answerText = a.optionId === "custom" ? `free-form: "${a.label}"` : `option "${a.optionId}" ("${a.label}")`
 		return `- "${q.text}" → ${answerText}`
 	})
@@ -711,47 +712,74 @@ ${renderGateGuidance("scope_ferment")}`,
 				return planToolOk("Got it. Updating the plan with your direction...")
 			}
 
-			// 7. Sequential per-question screens + review loop.
-			const N = questions.length
-			const CUSTOM_LABEL = `✎ ${pr_dim("Custom answer...")}`
-
+			// 7. Tabbed question form + review loop.
 			const runQuestions = async (): Promise<ScopingAnswer[] | "cancelled" | { kind: "dismiss"; qn: number }> => {
-				const answers: ScopingAnswer[] = []
-				for (let n = 0; n < N; n++) {
-					const q = questions[n]
-					const labeledOptions = q.options.map((o) => ({
-						option: o,
-						label: o.recommended === true ? `${o.label}  ★ Recommended` : o.label,
-					}))
-					const optionLabels = labeledOptions.map((o) => o.label)
-					optionLabels.push(CUSTOM_LABEL)
+				if (!getPromptUi(ctx)?.custom) {
+					const answers: ScopingAnswer[] = []
+					const customLabel = `✎ ${pr_dim("Custom answer...")}`
+					for (let n = 0; n < questions.length; n++) {
+						const q = questions[n]
+						const labeledOptions = q.options.map((o) => ({
+							option: o,
+							label: o.recommended === true ? `${o.label}  ★ Recommended` : o.label,
+						}))
+						const optionLabels = labeledOptions.map((o) => o.label)
+						optionLabels.push(customLabel)
 
-					const title = `[Q${n + 1}/${N}] ${q.text}`
-					const chosen = await promptSelect(ctx, title, optionLabels)
-
-					if (chosen === undefined) {
-						return { kind: "dismiss", qn: n + 1 }
-					}
-
-					if (chosen === CUSTOM_LABEL) {
-						const freeForm = await promptInput(ctx, `[Q${n + 1}/${N}] Your answer for: ${q.text}`, "")
-						if (!freeForm) {
-							return "cancelled"
+						const title = `[Q${n + 1}/${questions.length}] ${q.text}`
+						const chosen = await promptSelect(ctx, title, optionLabels)
+						if (chosen === undefined) return { kind: "dismiss", qn: n + 1 }
+						if (chosen === customLabel) {
+							const freeForm = await promptInput(ctx, `[Q${n + 1}/${questions.length}] Your answer for: ${q.text}`, "")
+							if (!freeForm) return "cancelled"
+							answers.push({ questionId: q.id, optionId: "custom", label: freeForm, recommended: false })
+							continue
 						}
-						answers.push({ questionId: q.id, optionId: "custom", label: freeForm, recommended: false })
+						const matched = labeledOptions.find((o) => o.label === chosen)
+						if (matched) {
+							answers.push({
+								questionId: q.id,
+								optionId: matched.option.id,
+								label: matched.option.label,
+								recommended: matched.option.recommended === true,
+							})
+						}
+					}
+					return answers
+				}
+
+				const result = await promptForm(ctx, {
+					questions: questions.map((q, index) => ({
+						id: q.id,
+						type: "radio",
+						label: `Q${index + 1}`,
+						prompt: q.text,
+						options: q.options.map((o) => ({
+							id: o.id,
+							label: o.recommended === true ? `${o.label}  ★ Recommended` : o.label,
+						})),
+						allowOther: true,
+					})),
+				})
+				if (!result) return { kind: "dismiss", qn: 1 }
+				if (result.cancelled) return "cancelled"
+
+				const answers: ScopingAnswer[] = []
+				for (const q of questions) {
+					const answer = result.answers.find((a) => a.id === q.id)
+					if (!answer) return { kind: "dismiss", qn: questions.indexOf(q) + 1 }
+					if (answer.wasCustom) {
+						answers.push({ questionId: q.id, optionId: "custom", label: answer.label, recommended: false })
 						continue
 					}
-
-					// Decode which real option was chosen.
-					const matched = labeledOptions.find((o) => o.label === chosen)
-					if (matched) {
-						answers.push({
-							questionId: q.id,
-							optionId: matched.option.id,
-							label: matched.option.label,
-							recommended: matched.option.recommended === true,
-						})
-					}
+					const matched = q.options.find((o) => o.id === answer.value)
+					if (!matched) return { kind: "dismiss", qn: questions.indexOf(q) + 1 }
+					answers.push({
+						questionId: q.id,
+						optionId: matched.id,
+						label: matched.label,
+						recommended: matched.recommended === true,
+					})
 				}
 				return answers
 			}
@@ -771,6 +799,31 @@ ${renderGateGuidance("scope_ferment")}`,
 
 				const answersEntry = buildAnswersEntry(questions, answers)
 				const allRecommended = answers.every((a) => a.recommended === true)
+				if (getPromptUi(ctx)?.custom) {
+					if (allRecommended) {
+						const scopeOutcome = confirmPendingScope(
+							runtime,
+							params.ferment_id,
+							params.phases,
+							"propose_scoping",
+							params.title,
+							pi,
+						)
+						if (!scopeOutcome.ok) return failedToolResult(scopeOutcome.error)
+						return planToolOk(
+							`Plan saved. Ferment "${scopeOutcome.outcome.ferment.name}" is planned with ${scopeOutcome.outcome.ferment.phases.length} phase(s). Starting execution.`,
+							{ includePlan: true, suffix: answersEntry },
+						)
+					}
+
+					const content = buildScopingIterationMessage(questions, answers)
+					void pi.sendMessage(
+						{ content, customType: "ferment_scoping_iteration", display: false },
+						{ triggerTurn: true },
+					)
+					return planToolOk(`${answersEntry}\n\nAnswers recorded. Updating the plan with your choices...`)
+				}
+
 				const continueLabel = allRecommended ? "Start execution  ✓" : "Update plan  ✓"
 				const reviewOptions = [continueLabel, "Restart questions", "Let me say something"]
 
@@ -924,33 +977,52 @@ ${renderGateGuidance("complete_ferment")}`,
 	pi.registerTool({
 		name: "ask_user",
 		label: "Ask User",
-		description: `Ask the user a structured question with a small set of options. Use ONLY at genuine decision points the agent cannot resolve from context (e.g. ambiguous requirements, choice between two viable approaches, user-only authorization).
+		description: `Ask the user a structured question. Use ONLY at genuine decision points the agent cannot resolve from context (e.g. ambiguous requirements, choice between viable approaches, user-only authorization).
 
 Behavior depends on session mode:
-  - Interactive (with TUI): the user picks an option. Returns { choice, answered_by: "user" }.
-  - One-shot (no human attached): an Opus judge stands in for the user. Returns { choice, answered_by: "judge", rationale }.
+  - Interactive (with TUI): the user answers in a structured TUI. Returns { choice | choices | text | answers, answered_by: "user" }.
+  - One-shot (no human attached): an Opus judge stands in for the user. Returns { choice | choices | text | answers, answered_by: "judge", rationale }.
 
 Hard contract: in one-shot mode, if the judge is unreachable (no API key, timeout, unparseable response) the ferment is ABANDONED — there is no fallback. False-pass is the worst outcome.
 
 The agent should:
-  1. Frame the question concretely. The user/judge sees only the question + options.
-  2. Provide 2–5 options with stable snake-case ids and short labels.
-  3. Include "pause" or "abandon" as an explicit option when one is appropriate — the judge prefers these when uncertain.
-  4. Act on the returned \`choice\` field.
+  1. Frame the question concretely. The user/judge sees only the question plus options/context in this call.
+  2. Prefer questions[] for the full TUI: radio, checkbox, text; allowOther enables a custom free-text option.
+  3. Use response_type="single" | "multi" | "text" only as a compatibility shorthand for one question.
+  4. For radio/checkbox, provide stable snake-case option ids and short labels.
+  5. Include "pause" or "abandon" as an explicit option when one is appropriate — the judge prefers these when uncertain.
+  6. Act on the returned \`answers\`, \`choice\`, \`choices\`, or \`text\` field.
 
-Returns: { choice, answered_by, rationale? } on success, or a tool error if no audience can be reached.`,
+TUI controls for questions[]:
+  - Tab / Shift+Tab moves between questions
+  - Up/Down navigates options
+  - Space toggles checkboxes
+  - Enter selects radio / submits text / advances
+  - Esc cancels
+
+Returns structured answer fields on success, or a tool error if no audience can be reached.`,
 		parameters: AskUserParams,
 		async execute(_, params, _signal, _onUpdate, ctx) {
 			const applyAndPersist = createApplyAndPersist(runtime)
 			const ferment = runtime.getStorage().get(params.ferment_id)
 			if (!ferment) return toolErr("Ferment not found.")
 
-			const response = await askUser(params.question, params.options, {
+			const askContext = {
 				ferment,
 				pi,
 				ctx: ctx as { ui?: Partial<import("../ui.js").FermentUi> } | undefined,
 				runtime,
-			})
+			}
+			const response =
+				params.questions && params.questions.length > 0
+					? await askUserForm(params.title ?? params.question, params.description, params.questions, askContext)
+					: params.question
+						? await askUser(params.question, params.options ?? [], askContext, params.response_type ?? "single")
+						: undefined
+
+			if (!response) {
+				return toolErr("ask_user requires either question or questions[].")
+			}
 
 			if (response.failed) {
 				// One-shot hard-fail: when the judge is the only legitimate audience
@@ -972,9 +1044,20 @@ Returns: { choice, answered_by, rationale? } on success, or a tool error if no a
 			}
 
 			const rationaleLine = response.rationale ? `\nRationale: ${response.rationale}` : ""
-			return toolOk(
-				`Answer received.\nChoice: ${response.choice}\nAnswered by: ${response.answered_by}${rationaleLine}`,
-			)
+			const answerLine =
+				response.response_type === "form"
+					? `Answers:\n${(response.answers ?? [])
+							.map((answer) => {
+								const value = answer.values ? answer.values.join(", ") : answer.value
+								return `- ${answer.id}: ${value}${answer.wasCustom ? " (custom)" : ""}`
+							})
+							.join("\n")}`
+					: response.response_type === "multi"
+						? `Choices: ${(response.choices ?? []).join(", ")}`
+						: response.response_type === "text"
+							? `Text: ${response.text ?? ""}`
+							: `Choice: ${response.choice ?? ""}`
+			return toolOk(`Answer received.\n${answerLine}\nAnswered by: ${response.answered_by}${rationaleLine}`)
 		},
 	})
 }

--- a/src/extensions/ferment/ui.ts
+++ b/src/extensions/ferment/ui.ts
@@ -1,10 +1,11 @@
 import type { Api, Model } from "@earendil-works/pi-ai"
-import type { ModelRegistry } from "@earendil-works/pi-coding-agent"
+import type { ExtensionUIContext, ModelRegistry } from "@earendil-works/pi-coding-agent"
 
 export interface FermentUi {
 	notify(message: string, level?: string): void
 	input?(label: string, placeholder?: string): Promise<string | undefined>
 	select?(title: string, options: string[]): Promise<string | undefined>
+	custom?: ExtensionUIContext["custom"]
 	confirm?(title: string, description?: string): Promise<boolean>
 }
 

--- a/src/extensions/questionnaire.ts
+++ b/src/extensions/questionnaire.ts
@@ -16,7 +16,7 @@
  */
 
 import type { ExtensionAPI } from "@earendil-works/pi-coding-agent"
-import { Editor, type EditorTheme, Key, Text, matchesKey, truncateToWidth } from "@earendil-works/pi-tui"
+import { Input, Key, Text, matchesKey, truncateToWidth } from "@earendil-works/pi-tui"
 import { type Static, Type } from "typebox"
 
 import {
@@ -175,17 +175,8 @@ export default function questionnaireExtension(pi: ExtensionAPI): void {
 				let state: QuestionnaireState = initialState(questions)
 				let cachedLines: string[] | undefined
 
-				const editorTheme: EditorTheme = {
-					borderColor: (s) => theme.fg("accent", s),
-					selectList: {
-						selectedPrefix: (t) => theme.fg("accent", t),
-						selectedText: (t) => theme.fg("accent", t),
-						description: (t) => theme.fg("muted", t),
-						scrollInfo: (t) => theme.fg("dim", t),
-						noMatch: (t) => theme.fg("warning", t),
-					},
-				}
-				const editor = new Editor(tui, editorTheme)
+				const editor = new Input()
+				editor.focused = true
 
 				// ── Effects & dispatch ──
 				function applyEffects(effects: QuestionnaireEffect[]): void {
@@ -196,7 +187,7 @@ export default function questionnaireExtension(pi: ExtensionAPI): void {
 								tui.requestRender()
 								break
 							case "editor-set-text":
-								editor.setText(eff.text)
+								editor.setValue(eff.text)
 								break
 							case "editor-handle-input":
 								editor.handleInput(eff.data)
@@ -214,7 +205,7 @@ export default function questionnaireExtension(pi: ExtensionAPI): void {
 					applyEffects(result.effects)
 				}
 
-				// ── Editor wiring ──
+				// ── Text input wiring ──
 				editor.onSubmit = (value: string) => dispatch({ kind: "editor-submit", value })
 
 				// ── Input handling (pure key→event mapper) ──
@@ -277,7 +268,7 @@ export default function questionnaireExtension(pi: ExtensionAPI): void {
 					add(theme.fg("accent", "\u2500".repeat(width)))
 
 					// Header
-					if (params.header && state.currentTab === 0 && !state.inputMode) {
+					if (params.header) {
 						add(` ${theme.fg("text", params.header)}`)
 						lines.push("")
 					}
@@ -401,6 +392,10 @@ export default function questionnaireExtension(pi: ExtensionAPI): void {
 							help = isMulti
 								? " Tab/\u2190\u2192 navigate \u2022 \u2191\u2193 select \u2022 Space toggle \u2022 Enter submit \u2022 Esc cancel"
 								: " \u2191\u2193 navigate \u2022 Space toggle \u2022 Enter submit \u2022 Esc cancel"
+						} else if (q?.type === "text") {
+							help = isMulti
+								? " Tab/\u2190\u2192 navigate \u2022 Type answer \u2022 Enter edit \u2022 Esc cancel"
+								: " Type answer \u2022 Enter edit \u2022 Esc cancel"
 						} else {
 							help = isMulti
 								? " Tab/\u2190\u2192 navigate \u2022 \u2191\u2193 select \u2022 Enter confirm \u2022 Esc cancel"

--- a/src/extensions/questionnaire.ts
+++ b/src/extensions/questionnaire.ts
@@ -388,7 +388,11 @@ export default function questionnaireExtension(pi: ExtensionAPI): void {
 					lines.push("")
 					if (!state.inputMode) {
 						let help: string
-						if (q?.type === "multi") {
+						if (isSubmitTab(state)) {
+							help = isMulti
+								? " Tab/\u2190\u2192 navigate \u2022 Enter submit \u2022 Esc cancel"
+								: " Enter submit \u2022 Esc cancel"
+						} else if (q?.type === "multi") {
 							help = isMulti
 								? " Tab/\u2190\u2192 navigate \u2022 \u2191\u2193 select \u2022 Space toggle \u2022 Enter submit \u2022 Esc cancel"
 								: " \u2191\u2193 navigate \u2022 Space toggle \u2022 Enter submit \u2022 Esc cancel"


### PR DESCRIPTION
<img width="1441" height="410" alt="image" src="https://github.com/user-attachments/assets/5752f856-a45d-4af5-ae3d-0951e4f256c3" />

<img width="1312" height="408" alt="image" src="https://github.com/user-attachments/assets/7079dc8a-cee2-4726-b41d-f75ed7c36530" />

<img width="1304" height="521" alt="image" src="https://github.com/user-attachments/assets/4982afbc-f2f7-4761-9006-88841db4d007" />

<img width="1333" height="444" alt="image" src="https://github.com/user-attachments/assets/620f03e2-600b-47ab-8f73-f482f2abc230" />

<img width="1192" height="425" alt="image" src="https://github.com/user-attachments/assets/34b868b7-4abe-4f7e-90ed-4116d1942d67" />

<img width="1190" height="461" alt="image" src="https://github.com/user-attachments/assets/99fdd8c4-1ef3-432f-b96b-d4ee046154e2" />

---
### Kimchi Summary
### What changed
Extended the `ask_user` tool to support free-text responses, multi-select answers, and structured multi-question forms. Added a tabbed TUI form renderer with keyboard navigation and a fallback for basic terminals, and taught the judge to return `text`, `multi`-choice, and form-shaped JSON.

### Why
The agent previously could only ask single-choice questions, limiting how it resolved ambiguities. Supporting text, multi-select, and form layouts lets a single tool call gather richer user input in both interactive and one-shot sessions.

### Key changes
- `src/extensions/ferment/ask-user.ts`: Introduced `response_type` (`single`/`multi`/`text`), `AskUserQuestion`/`AskUserAnswer` interfaces, `askJudgeForm`, `askUserForm`, and updated routing and parser logic for all response shapes.
- `src/extensions/ferment/prompt-ui.ts`: Added `promptForm` with a full `custom` TUI component (tabs, radio/checkbox/text, inline editing) plus a fallback using basic `select`/`input`.
- `src/extensions/ferment/tools/lifecycle.ts`: `ask_user` execution now routes to `askUserForm` when `questions[]` is supplied; scoping confirmation uses `promptForm` when a rich UI is available; question option limit raised from 4 to 5.
- `src/extensions/ferment/tool-schemas.ts`: Expanded `AskUserParams` with `questions[]`, `response_type`, `title`, and `description`; relaxed scoping `maxItems` to 5.
- `src/extensions/ferment/ui.ts`: Added `custom` TUI context to `FermentUi`.
- `src/extensions/questionnaire.ts`: Switched from `Editor` to `Input` for text fields and corrected help text rendering.

### Impact
- `AskUserSuccess` now requires consumers to inspect `response_type` (`single` | `multi` | `text` | `form`) before accessing `choice`, `choices`, `text`, or `answers`. Existing single-question calls remain backward compatible at the tool parameter level.
- Scoping questions now allow up to **5** options (was 4).