### PR TITLE
chore: rename homebrew formula to kimchi

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -177,7 +177,7 @@ jobs:
           token: ${{ secrets.HOMEBREW_TAP_TOKEN }}
           path: homebrew-tap
 
-      - name: Update Formula/kimchi-dev.rb
+      - name: Update Formula/kimchi.rb
         env:
           VERSION: ${{ github.ref_name }}
           SHA_DARWIN_AMD64: ${{ steps.sha.outputs.darwin_amd64 }}
@@ -185,7 +185,7 @@ jobs:
           SHA_LINUX_AMD64: ${{ steps.sha.outputs.linux_amd64 }}
           SHA_LINUX_ARM64: ${{ steps.sha.outputs.linux_arm64 }}
         run: |
-          FORMULA=homebrew-tap/Formula/kimchi-dev.rb
+          FORMULA=homebrew-tap/Formula/kimchi.rb
           # Strip leading 'v' from tag (e.g. v1.2.3 → 1.2.3)
           VER="${VERSION#v}"
 
@@ -202,8 +202,8 @@ jobs:
           cd homebrew-tap
           git config user.name  "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
-          git add Formula/kimchi-dev.rb
-          git commit -m "kimchi-dev ${GITHUB_REF_NAME}"
+          git add Formula/kimchi.rb
+          git commit -m "kimchi ${GITHUB_REF_NAME}"
           git push
         env:
           GITHUB_REF_NAME: ${{ github.ref_name }}

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Install the latest release:
 
 ```bash
 brew tap castai/tap
-brew install castai/tap/kimchi-dev
+brew install castai/tap/kimchi
 ```
 
 **Install script:**

--- a/src/commands/update.ts
+++ b/src/commands/update.ts
@@ -65,7 +65,7 @@ export async function runUpdate(args: string[]): Promise<number> {
 		}
 		console.log("kimchi is managed by Homebrew. Use Homebrew to update:")
 		console.log("")
-		console.log("  brew upgrade kimchi-dev")
+		console.log("  brew upgrade kimchi")
 		console.log("")
 		console.log("If you want the self-update behaviour, install kimchi outside of Homebrew.")
 		return 0

--- a/src/extensions/startup-update.ts
+++ b/src/extensions/startup-update.ts
@@ -23,7 +23,7 @@ export default function startupUpdateExtension(pi: ExtensionAPI) {
 		try {
 			const result = await checkForUpdate({ currentVersion: current, skipCache: false })
 			if (result.hasUpdate) {
-				const updateCmd = ctx.ui.theme.bold(isHomebrewInstall() ? "brew upgrade kimchi-dev" : "kimchi update")
+				const updateCmd = ctx.ui.theme.bold(isHomebrewInstall() ? "brew upgrade kimchi" : "kimchi update")
 				ctx.ui.setStatus(UPDATE_STATUS_KEY, `Update available! Run ${updateCmd}`)
 			}
 		} catch {

--- a/src/update/state.test.ts
+++ b/src/update/state.test.ts
@@ -169,17 +169,17 @@ describe("update state cache", () => {
 })
 
 describe("isStale", () => {
-	const day = 24 * 60 * 60 * 1000
+	const hour = 60 * 60 * 1000
 	const t0 = Date.parse("2026-01-01T00:00:00Z")
 
 	it("returns false for a fresh check", () => {
 		expect(isStale({ checked_at: "2026-01-01T00:00:00Z", latest_version: "1" }, t0)).toBe(false)
 	})
-	it("returns false within 24h", () => {
-		expect(isStale({ checked_at: "2026-01-01T00:00:00Z", latest_version: "1" }, t0 + day - 1)).toBe(false)
+	it("returns false within 1h", () => {
+		expect(isStale({ checked_at: "2026-01-01T00:00:00Z", latest_version: "1" }, t0 + hour - 1)).toBe(false)
 	})
-	it("returns true past 24h", () => {
-		expect(isStale({ checked_at: "2026-01-01T00:00:00Z", latest_version: "1" }, t0 + day + 1)).toBe(true)
+	it("returns true past 1h", () => {
+		expect(isStale({ checked_at: "2026-01-01T00:00:00Z", latest_version: "1" }, t0 + hour + 1)).toBe(true)
 	})
 	it("returns true when checked_at is unparseable (defensive)", () => {
 		expect(isStale({ checked_at: "garbage", latest_version: "1" }, t0)).toBe(true)

--- a/src/update/state.ts
+++ b/src/update/state.ts
@@ -12,7 +12,7 @@ interface PersistedState {
 	repos?: Record<string, unknown>
 }
 
-const TTL_MS = 24 * 60 * 60 * 1_000
+const TTL_MS = 60 * 60 * 1_000 // 1 Hour
 
 export function isStale(rs: RepoState, now: number = Date.now()): boolean {
 	const t = Date.parse(rs.checked_at)


### PR DESCRIPTION


---
### Kimchi Summary
### What changed
Renames the Homebrew formula from `kimchi-dev` to `kimchi` across the release workflow, documentation, and CLI output. Also reduces the update-check cache TTL from 24 hours to 1 hour.

### Why
Aligns the published Homebrew package name with the `kimchi` binary and shortens the feedback loop for update notifications.

### Key changes
- `.github/workflows/release.yml`: Publishes to `Formula/kimchi.rb` instead of `Formula/kimchi-dev.rb` and updates the commit message to `kimchi`
- `README.md`: Changes install command example to `brew install castai/tap/kimchi`
- `src/commands/update.ts` and `src/extensions/startup-update.ts`: Update suggested Homebrew upgrade command from `brew upgrade kimchi-dev` to `brew upgrade kimchi`
- `src/update/state.ts`: Lowers `TTL_MS` from 24 hours to 1 hour (`60 * 60 * 1_000`)
- `src/update/state.test.ts`: Adjusts `isStale` test boundaries from a 24-hour window to a 1-hour window

### Impact
The release workflow will create and update the `kimchi` formula going forward, and the CLI will prompt users to run `brew upgrade kimchi`. The tool checks for available updates more frequently due to the shorter cache TTL.