### PR TITLE
fix(agents): improve turn-limit steer message

### DIFF
--- a/src/extensions/agents/manager/agent-runner.ts
+++ b/src/extensions/agents/manager/agent-runner.ts
@@ -344,7 +344,9 @@ export async function runAgent(
 			if (maxTurns != null) {
 				if (!softLimitReached && turnCount >= maxTurns) {
 					softLimitReached = true
-					session.steer("You have reached your turn limit. Wrap up immediately — provide your final answer now.")
+					session.steer(
+						"You have reached your turn limit. Stop exploring. Complete your current edit, ensure file syntax is valid, undo any git state mutations so your work is visible on the filesystem, and summarize progress for the orchestrator. Do not start new edits.",
+					)
 				} else if (softLimitReached && turnCount >= maxTurns + graceTurns) {
 					aborted = true
 					session.abort()


### PR DESCRIPTION
## Problem

When an agent hits its turn limit, the harness calls `session.steer()` with:

> "You have reached your turn limit. Wrap up immediately — provide your final answer now."

This causes agents under pressure to rush and produce malformed output — a failure mode identified in post-mortem analysis of sessions where agents were killed mid-task. Worse, it gives no guidance on git state: agents that have run `git stash` or other mutations leave the workspace in a state the orchestrator can't read with `git status`.

## Change

New steer message:

> "You have reached your turn limit. Stop exploring. Complete your current edit, ensure file syntax is valid, undo any git state mutations so your work is visible on the filesystem, and summarize progress for the orchestrator. Do not start new edits."

Key differences:
- Frames the exit as a **state-transfer** rather than task completion — removes the implicit pressure to finish everything
- Explicitly instructs the agent to **undo git mutations** (stash, reset, checkout) before exiting, so completed work is visible on the filesystem for the orchestrator to inspect
- **"Do not start new edits"** prevents the agent from beginning work it cannot finish in the remaining grace turns

---
### Kimchi Summary
### What changed
Replaced the generic soft turn limit steer message in the agent runner with explicit instructions that direct the agent to safely finalize its current work before ending the session.

### Why
The previous prompt only told the agent to "wrap up immediately," which often left workspace edits incomplete or git state mutated. The new message prevents orphaned changes by commanding the agent to finish its current edit, validate syntax, undo git mutations, and summarize progress.

### Key changes
- `src/extensions/agents/manager/agent-runner.ts`: Updated the `session.steer()` message inside `runAgent` that fires when `turnCount` first reaches `maxTurns` and `softLimitReached` is set. The new text instructs the agent to stop exploring, complete the active edit, ensure valid file syntax, undo any git state mutations, and report progress to the orchestrator.

### Impact
Improves agent reliability at turn boundaries by reducing incomplete edits and unexpected git state. No breaking changes or migration steps.