### PR TITLE
feat: compact segments in the footer when they don't fit the screen

### DIFF
--- a/src/components/footer.test.ts
+++ b/src/components/footer.test.ts
@@ -1,8 +1,9 @@
 import type { ExtensionContext, ReadonlyFooterDataProvider, Theme } from "@earendil-works/pi-coding-agent"
+import { visibleWidth } from "@earendil-works/pi-tui"
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
 import * as AGENTS from "../extensions/agents/index.js"
 import * as FERMENT from "../extensions/ferment/index.js"
-import * as ORCHESTRATION from "../extensions/orchestration/prompt-enrichment.js"
+import * as ORCHESTRATION from "../extensions/prompt-construction/prompt-enrichment.js"
 import * as TAGS from "../extensions/tags.js"
 import { SHORTCUT_TAIL, StatsFooter, buildContextCompact, buildMultiModelAbbrev, buildPhaseCompact } from "./footer.js"
 
@@ -11,7 +12,7 @@ const ANSI_ESCAPE = /\x1b\[[\d;]*m/g
 const stripAnsi = (s: string): string => s.replace(ANSI_ESCAPE, "")
 
 /** A theme that wraps text in identifiable markers but reports zero visible
- *  width for those markers \u2014 mimicking how real ANSI behaves with visibleWidth. */
+ *  width for those markers — mimicking how real ANSI behaves with visibleWidth. */
 function createMockTheme(): Theme {
 	// Real-shaped SGR ANSI escapes (terminated with `m`) so that visibleWidth in
 	// production code and stripAnsi in test assertions agree on what's visible.
@@ -37,15 +38,26 @@ function createMockTheme(): Theme {
 	} as unknown as Theme
 }
 
-function createMockContext(opts?: { percent?: number; modelId?: string }): ExtensionContext {
+interface MockContextOpts {
+	percent?: number
+	modelId?: string
+	/** Assistant messages to include in the session, for usage-segment tests. */
+	assistantMessages?: Array<{ input: number; output: number }>
+}
+
+function createMockContext(opts?: MockContextOpts): ExtensionContext {
 	const percent = opts?.percent ?? 0
 	const modelId = opts?.modelId ?? "claude-opus-4-7"
+	const entries = (opts?.assistantMessages ?? []).map((u) => ({
+		type: "message" as const,
+		message: { role: "assistant", usage: { input: u.input, output: u.output } },
+	}))
 	return {
 		model: { id: modelId, name: modelId },
 		cwd: "/test",
 		getContextUsage: vi.fn(() => ({ tokens: 0, percent, contextWindow: 100000 })),
 		sessionManager: {
-			getEntries: vi.fn(() => []),
+			getEntries: vi.fn(() => entries),
 			getBranch: vi.fn(() => []),
 			getSessionId: vi.fn(() => "test-session"),
 			getSessionName: vi.fn(() => "test"),
@@ -68,8 +80,17 @@ function createMockFooterData(opts?: {
 	} as unknown as ReadonlyFooterDataProvider
 }
 
-/** CompactionContext stub using plain markers \u2014 used to unit-test the builder
- *  functions in isolation, with predictable visible output. */
+/** Save the current platform and stub it to `value`. Returns a cleanup fn. */
+function stubPlatform(value: NodeJS.Platform): () => void {
+	const original = process.platform
+	Object.defineProperty(process, "platform", { value })
+	return () => Object.defineProperty(process, "platform", { value: original })
+}
+
+/** CompactionContext stub using plain markers — used to unit-test the builder
+ *  functions in isolation, with predictable visible output. The builders only
+ *  rely on dim/accent for ANSI wrapping, so identity functions are safe here
+ *  as long as we assert on raw text rather than computed widths against ANSI. */
 const compactCtx = {
 	dim: (s: string) => s,
 	accent: (s: string) => s,
@@ -101,37 +122,44 @@ describe("compact-form builders", () => {
 
 	describe("buildMultiModelAbbrev", () => {
 		it("uses `m-m:` instead of `multi-model:` when enabled (darwin)", () => {
-			const orig = process.platform
-			Object.defineProperty(process, "platform", { value: "darwin" })
+			const restore = stubPlatform("darwin")
 			try {
 				const seg = buildMultiModelAbbrev(compactCtx, true)
 				expect(seg.id).toBe("multi-model")
 				expect(seg.text).toBe("m-m: on \u2192 option+tab")
 				expect(seg.raw).toEqual({ kind: "multi-model", enabled: true })
 			} finally {
-				Object.defineProperty(process, "platform", { value: orig })
+				restore()
 			}
 		})
 
-		it("shows `off` when disabled", () => {
-			const orig = process.platform
-			Object.defineProperty(process, "platform", { value: "darwin" })
+		it("shows `off` when disabled (darwin)", () => {
+			const restore = stubPlatform("darwin")
 			try {
 				const seg = buildMultiModelAbbrev(compactCtx, false)
 				expect(seg.text).toBe("m-m: off \u2192 option+tab")
 			} finally {
-				Object.defineProperty(process, "platform", { value: orig })
+				restore()
 			}
 		})
 
-		it("uses `alt+tab` shortcut on non-darwin", () => {
-			const orig = process.platform
-			Object.defineProperty(process, "platform", { value: "linux" })
+		it("uses `alt+tab` shortcut on non-darwin (enabled)", () => {
+			const restore = stubPlatform("linux")
 			try {
 				const seg = buildMultiModelAbbrev(compactCtx, true)
 				expect(seg.text).toBe("m-m: on \u2192 alt+tab")
 			} finally {
-				Object.defineProperty(process, "platform", { value: orig })
+				restore()
+			}
+		})
+
+		it("uses `alt+tab` shortcut on non-darwin (disabled)", () => {
+			const restore = stubPlatform("linux")
+			try {
+				const seg = buildMultiModelAbbrev(compactCtx, false)
+				expect(seg.text).toBe("m-m: off \u2192 alt+tab")
+			} finally {
+				restore()
 			}
 		})
 	})
@@ -149,12 +177,11 @@ describe("compact-form builders", () => {
 
 describe("SHORTCUT_TAIL regex", () => {
 	// Real ANSI from the production code paths.
-	//   permissions: this.theme.fg(\"dim\", \"\u2192 shift+tab\")
-	//   multi-model: this.dim(`\u2192 ${shortcut}`)
-	// Both end up as `<ANSI-open>\u2192 <key><ANSI-close>` preceded by a space.
+	//   permissions: this.theme.fg("dim", "→ shift+tab")
+	//   multi-model: this.dim(`→ ${shortcut}`)
+	// Both end up as `<ANSI-open>→ <key><ANSI-close>` preceded by a space.
 
 	it("matches the permissions-extension trailing shortcut", () => {
-		// Real-shaped: leading space, ANSI open, arrow + key, ANSI close.
 		const text = "\u25cf default \x1b[38;5;242m\u2192 shift+tab\x1b[39m"
 		expect(SHORTCUT_TAIL.test(text)).toBe(true)
 		expect(text.replace(SHORTCUT_TAIL, "")).toBe("\u25cf default")
@@ -186,12 +213,13 @@ describe("SHORTCUT_TAIL regex", () => {
 describe("StatsFooter behavioural acceptance at representative widths", () => {
 	let theme: Theme
 	let footerData: ReadonlyFooterDataProvider
+	let restorePlatform: () => void
 
 	beforeEach(() => {
 		theme = createMockTheme()
 		// Mirror production format: the permissions extension calls
-		// `theme.fg("dim", "\u2192 shift+tab")` and appends. We hand-build the same shape
-		// so the SHORTCUT_TAIL regex can find it.
+		// `theme.fg("dim", "→ shift+tab")` and appends. We hand-build the same
+		// shape so the SHORTCUT_TAIL regex can find it.
 		const permissionsMode = "\u25cf default \x1b[2m\u2192 shift+tab\x1b[0m"
 		footerData = createMockFooterData({ permissionsMode })
 		vi.spyOn(ORCHESTRATION, "getMultiModelEnabled").mockReturnValue(true)
@@ -200,42 +228,51 @@ describe("StatsFooter behavioural acceptance at representative widths", () => {
 		vi.spyOn(FERMENT, "getCurrentPhaseIndex").mockReturnValue(undefined)
 		vi.spyOn(TAGS, "getActiveTags").mockReturnValue([])
 		vi.spyOn(TAGS, "getCurrentPhase").mockReturnValue("explore")
-		// Stub platform-dependent shortcut so test is stable across CI.
-		Object.defineProperty(process, "platform", { value: "darwin" })
+		// Stub platform-dependent shortcut so tests are stable across CI.
+		restorePlatform = stubPlatform("darwin")
 	})
 
 	afterEach(() => {
 		vi.restoreAllMocks()
+		restorePlatform()
 	})
 
-	/** Run render at the given width and return the visible (ANSI-stripped) status line. */
-	function renderAt(width: number, ctxOpts?: { percent?: number }): string {
+	/** Render at the given width and return the status line both raw (with ANSI)
+	 *  and visible (ANSI-stripped). Use `visible` for content assertions and
+	 *  `visibleWidth(raw)` for width assertions. */
+	function renderAt(width: number, ctxOpts?: MockContextOpts): { raw: string; visible: string } {
 		const footer = new StatsFooter(createMockContext(ctxOpts), theme, footerData)
 		const lines = footer.render(width)
-		return stripAnsi(lines[lines.length - 1])
+		const raw = lines[lines.length - 1]
+		return { raw, visible: stripAnsi(raw) }
 	}
 
-	it("width 160: full footer + `/ for commands` hint", () => {
-		const visible = renderAt(160)
+	it("width 160: full footer + `/ for commands` hint, padded to width", () => {
+		const { raw, visible } = renderAt(160)
 		expect(visible).toContain("\u25cf default \u2192 shift+tab")
 		expect(visible).toContain("multi-model: on \u2192 option+tab")
 		expect(visible).toContain("claude-opus-4-7")
 		expect(visible).toContain("0% ctx")
 		expect(visible).toContain("phase:explore")
 		expect(visible).toContain("/ for commands")
+		// When the hint fits, the line is padded to exactly `width` columns
+		// (with whitespace between the segments and the right-aligned hint).
+		expect(visibleWidth(raw)).toBe(160)
+		// The hint sits at the right edge.
+		expect(visible.endsWith("/ for commands")).toBe(true)
 	})
 
-	it("width 100: hint and context-bar dropped, multi-model abbreviated, shortcuts stripped", () => {
-		const visible = renderAt(100)
+	it("width 100: hint and context-bar dropped, segments still present", () => {
+		const { raw, visible } = renderAt(100)
 		// Hint gone (step 1)
 		expect(visible).not.toContain("/ for commands")
 		// Bar gone, percentage kept (step 2)
 		expect(visible).not.toContain("\u2588")
 		expect(visible).not.toContain("\u2591")
 		expect(visible).toContain("0% ctx")
-		// At width 100, only steps 1\u20132 should be needed; verify the line fits.
-		expect(visible.length).toBeLessThanOrEqual(100)
-		// All segments still present.
+		// Line fits.
+		expect(visibleWidth(raw)).toBeLessThanOrEqual(100)
+		// All segments still present (compaction shrinks, never drops).
 		expect(visible).toContain("default")
 		expect(visible).toContain("multi-model")
 		expect(visible).toContain("claude-opus-4-7")
@@ -243,9 +280,8 @@ describe("StatsFooter behavioural acceptance at representative widths", () => {
 	})
 
 	it("width 60: shortcuts stripped, multi-model abbreviated, phase prefix dropped", () => {
-		const visible = renderAt(60)
-		expect(visible.length).toBeLessThanOrEqual(60)
-		// No `/ for commands`, no shortcut tails.
+		const { raw, visible } = renderAt(60)
+		expect(visibleWidth(raw)).toBeLessThanOrEqual(60)
 		expect(visible).not.toContain("/ for commands")
 		expect(visible).not.toContain("shift+tab")
 		expect(visible).not.toContain("option+tab")
@@ -253,23 +289,36 @@ describe("StatsFooter behavioural acceptance at representative widths", () => {
 		expect(visible).toContain("claude-opus-4-7")
 	})
 
-	it("width 20: line is hard-truncated to fit", () => {
-		const visible = renderAt(20)
+	it("width 20: line is hard-truncated to fit, leftmost content survives", () => {
+		const { raw, visible } = renderAt(20)
 		// Critical invariant: never overflow.
-		expect(visible.length).toBeLessThanOrEqual(20)
-		// Truncation produces *something* non-empty.
+		expect(visibleWidth(raw)).toBeLessThanOrEqual(20)
 		expect(visible.length).toBeGreaterThan(0)
+		// Truncation cuts the tail, so the start of the line — beginning with
+		// the permissions bullet — must survive. We check it appears somewhere
+		// near the front, rather than asserting `startsWith` in case
+		// `truncateToWidth` adds an ellipsis or other leading marker.
+		expect(visible).toContain("\u25cf")
 	})
 
 	it("never overflows width across a range of terminal sizes", () => {
 		for (const w of [200, 160, 137, 121, 112, 104, 100, 75, 60, 50, 40, 30, 20, 10]) {
-			const visible = renderAt(w)
-			expect(visible.length, `width=${w}`).toBeLessThanOrEqual(w)
+			const { raw } = renderAt(w)
+			expect(visibleWidth(raw), `width=${w}`).toBeLessThanOrEqual(w)
+		}
+	})
+
+	it("never overflows when phase contains wide (CJK) characters", () => {
+		// CJK characters are single code units but take TWO visible columns.
+		// This is the case `visibleWidth` catches and `.length` would miss.
+		vi.spyOn(TAGS, "getCurrentPhase").mockReturnValue("\u63a2\u7d22\u4e2d")
+		for (const w of [200, 100, 60, 40, 20]) {
+			const { raw } = renderAt(w)
+			expect(visibleWidth(raw), `width=${w}`).toBeLessThanOrEqual(w)
 		}
 	})
 
 	it("with an active ferment, drops the `ferment:` prefix when overflowing", () => {
-		// Install an active ferment so the segment shows up.
 		const ferment = {
 			id: "f-1",
 			name: "my-ferment",
@@ -283,19 +332,129 @@ describe("StatsFooter behavioural acceptance at representative widths", () => {
 
 		// At a generous width every compaction is unneeded and `ferment:` shows.
 		const wide = renderAt(200)
-		expect(wide).toContain("ferment:my-ferment")
+		expect(wide.visible).toContain("ferment:my-ferment")
 
-		// At a width where every earlier compaction has fired but the line is
-		// still too wide, the ferment-prefix step must also have fired. Use a
-		// width small enough to force it; the active-ferment line is longer than
-		// the no-ferment line, so 70 is well past the prefix-drop threshold.
+		// At a narrow width all earlier compactions have fired and the ferment
+		// prefix has also been dropped.
 		const narrow = renderAt(70)
-		expect(narrow).toContain("my-ferment")
-		expect(narrow).not.toContain("ferment:")
+		expect(narrow.visible).toContain("my-ferment")
+		expect(narrow.visible).not.toContain("ferment:")
 	})
 })
 
-describe("StatsFooter regression tests", () => {
+describe("StatsFooter segment coverage", () => {
+	let theme: Theme
+	let restorePlatform: () => void
+
+	beforeEach(() => {
+		theme = createMockTheme()
+		vi.spyOn(ORCHESTRATION, "getMultiModelEnabled").mockReturnValue(true)
+		vi.spyOn(AGENTS, "getActiveAgentCount").mockReturnValue(0)
+		vi.spyOn(FERMENT, "getActiveFerment").mockReturnValue(undefined)
+		vi.spyOn(FERMENT, "getCurrentPhaseIndex").mockReturnValue(undefined)
+		vi.spyOn(TAGS, "getActiveTags").mockReturnValue([])
+		vi.spyOn(TAGS, "getCurrentPhase").mockReturnValue("explore")
+		restorePlatform = stubPlatform("darwin")
+	})
+
+	afterEach(() => {
+		vi.restoreAllMocks()
+		restorePlatform()
+	})
+
+	function renderVisible(footer: StatsFooter, width: number): string {
+		const lines = footer.render(width)
+		return stripAnsi(lines[lines.length - 1])
+	}
+
+	it("usage segment appears when there are assistant messages with token usage", () => {
+		const ctx = createMockContext({
+			assistantMessages: [
+				{ input: 1200, output: 340 },
+				{ input: 800, output: 200 },
+			],
+		})
+		const footer = new StatsFooter(ctx, theme, createMockFooterData())
+		const visible = renderVisible(footer, 200)
+		// Both up- and down-arrow indicators present with formatted counts.
+		expect(visible).toContain("\u2191")
+		expect(visible).toContain("\u2193")
+	})
+
+	it("usage segment is hidden when there is no token activity", () => {
+		const footer = new StatsFooter(createMockContext(), theme, createMockFooterData())
+		const visible = renderVisible(footer, 200)
+		expect(visible).not.toContain("\u2191")
+		expect(visible).not.toContain("\u2193")
+	})
+
+	it("agents segment shows count when active agents present", () => {
+		vi.spyOn(AGENTS, "getActiveAgentCount").mockReturnValue(3)
+		const footer = new StatsFooter(createMockContext(), theme, createMockFooterData())
+		const visible = renderVisible(footer, 200)
+		expect(visible).toContain("3 agents")
+	})
+
+	it("agents segment uses singular form for count=1", () => {
+		vi.spyOn(AGENTS, "getActiveAgentCount").mockReturnValue(1)
+		const footer = new StatsFooter(createMockContext(), theme, createMockFooterData())
+		const visible = renderVisible(footer, 200)
+		expect(visible).toContain("1 agent")
+		expect(visible).not.toContain("1 agents")
+	})
+
+	it("agents segment is hidden when count is zero", () => {
+		vi.spyOn(AGENTS, "getActiveAgentCount").mockReturnValue(0)
+		const footer = new StatsFooter(createMockContext(), theme, createMockFooterData())
+		const visible = renderVisible(footer, 200)
+		expect(visible).not.toContain("agent")
+	})
+
+	it("tags segment shows non-team, non-phase tags", () => {
+		vi.spyOn(TAGS, "getActiveTags").mockReturnValue(["env:prod", "region:eu", "team:platform", "phase:explore"])
+		const footer = new StatsFooter(createMockContext(), theme, createMockFooterData())
+		const visible = renderVisible(footer, 200)
+		expect(visible).toContain("tags:")
+		expect(visible).toContain("env:prod")
+		expect(visible).toContain("region:eu")
+		// `team` has its own segment, not part of `tags:`.
+		// `phase` has its own segment (already in the line as `phase:explore`).
+		// `tags:` itself should not list either.
+		// We verify by looking at the substring after `tags:` up to the next `·`.
+		const tagsIdx = visible.indexOf("tags:")
+		const afterTags = visible.slice(tagsIdx)
+		const sectionEnd = afterTags.indexOf(" \u00b7 ", "tags:".length)
+		const tagsSection = sectionEnd === -1 ? afterTags : afterTags.slice(0, sectionEnd)
+		expect(tagsSection).not.toContain("team:")
+		// `phase:` may legitimately appear elsewhere as the phase segment, but
+		// must not appear inside the tags section.
+		expect(tagsSection).not.toContain("phase:")
+	})
+
+	it("tags segment is hidden when only team and phase tags are present", () => {
+		vi.spyOn(TAGS, "getActiveTags").mockReturnValue(["team:platform", "phase:explore"])
+		const footer = new StatsFooter(createMockContext(), theme, createMockFooterData())
+		const visible = renderVisible(footer, 200)
+		expect(visible).not.toContain("tags:")
+	})
+
+	it("team segment shows team value", () => {
+		vi.spyOn(TAGS, "getActiveTags").mockReturnValue(["team:platform"])
+		const footer = new StatsFooter(createMockContext(), theme, createMockFooterData())
+		const visible = renderVisible(footer, 200)
+		expect(visible).toContain("team:")
+		expect(visible).toContain("platform")
+	})
+
+	it("team segment is hidden when no team tag present", () => {
+		vi.spyOn(TAGS, "getActiveTags").mockReturnValue(["env:prod"])
+		const footer = new StatsFooter(createMockContext(), theme, createMockFooterData())
+		const visible = renderVisible(footer, 200)
+		expect(visible).not.toContain("team:")
+	})
+})
+
+describe("StatsFooter info line", () => {
 	let theme: Theme
 
 	beforeEach(() => {
@@ -330,15 +489,74 @@ describe("StatsFooter regression tests", () => {
 		expect(stripAnsi(lines[0])).toContain("Update")
 	})
 
+	it("right-aligns update segment when both warning and update are present", () => {
+		const data = createMockFooterData({
+			permissionsWarning: "Warning: check permissions",
+			updateAvailable: "Update available: v1.2.0",
+		})
+		const footer = new StatsFooter(createMockContext(), theme, data)
+		const lines = footer.render(160)
+
+		expect(lines.length).toBe(2)
+		const infoLine = stripAnsi(lines[0])
+		expect(infoLine).toContain("Warning")
+		expect(infoLine).toContain("Update available")
+		// Warning is left-aligned, update is right-aligned with spaces between.
+		const warningIdx = infoLine.indexOf("Warning")
+		const updateIdx = infoLine.indexOf("Update available")
+		expect(warningIdx).toBeLessThan(updateIdx)
+		// The update segment ends at (or near) the right edge of the width.
+		expect(visibleWidth(lines[0])).toBeLessThanOrEqual(160)
+		expect(infoLine.trimEnd().endsWith("Update available: v1.2.0")).toBe(true)
+	})
+
+	it("drops the update segment when there is no room for it after the warning", () => {
+		// Warning consumes nearly all of width=30, leaving < update.width + 2 columns.
+		const data = createMockFooterData({
+			permissionsWarning: "Warning: long permissions message text here",
+			updateAvailable: "Update available: v1.2.0",
+		})
+		const footer = new StatsFooter(createMockContext(), theme, data)
+		const lines = footer.render(30)
+
+		expect(lines.length).toBe(2)
+		const infoLine = stripAnsi(lines[0])
+		// The update segment must not appear; the warning may be truncated.
+		expect(infoLine).not.toContain("Update available")
+		expect(visibleWidth(lines[0])).toBeLessThanOrEqual(30)
+	})
+})
+
+describe("StatsFooter regression tests", () => {
+	let theme: Theme
+	let restorePlatform: () => void
+
+	beforeEach(() => {
+		theme = createMockTheme()
+		vi.spyOn(ORCHESTRATION, "getMultiModelEnabled").mockReturnValue(true)
+		vi.spyOn(AGENTS, "getActiveAgentCount").mockReturnValue(0)
+		vi.spyOn(FERMENT, "getActiveFerment").mockReturnValue(undefined)
+		vi.spyOn(FERMENT, "getCurrentPhaseIndex").mockReturnValue(undefined)
+		vi.spyOn(TAGS, "getActiveTags").mockReturnValue([])
+		vi.spyOn(TAGS, "getCurrentPhase").mockReturnValue("explore")
+		restorePlatform = stubPlatform("darwin")
+	})
+
+	afterEach(() => {
+		vi.restoreAllMocks()
+		restorePlatform()
+	})
+
 	it("never produces an orphan ` \u00b7  \u00b7 ` double separator at any width", () => {
 		// Compaction never removes whole segments, so we should never see two
 		// adjacent separators. Truncation cuts the tail, not the middle.
-		vi.spyOn(TAGS, "getActiveTags").mockReturnValue([{ key: "team", value: "platform" } as never, "foo:bar" as never])
+		vi.spyOn(TAGS, "getActiveTags").mockReturnValue(["team:platform", "env:prod"])
 		const data = createMockFooterData({ permissionsMode: "\u25cf default" })
 		const footer = new StatsFooter(createMockContext(), theme, data)
 
 		for (const w of [40, 50, 60, 75, 100]) {
-			const visible = stripAnsi(footer.render(w)[0])
+			const lines = footer.render(w)
+			const visible = stripAnsi(lines[lines.length - 1])
 			expect(visible, `width=${w}: orphan separator in "${visible}"`).not.toMatch(/\u00b7\s*\u00b7/)
 		}
 	})

--- a/src/components/footer.test.ts
+++ b/src/components/footer.test.ts
@@ -94,6 +94,7 @@ function stubPlatform(value: NodeJS.Platform): () => void {
 const compactCtx = {
 	dim: (s: string) => s,
 	accent: (s: string) => s,
+	semantic: (name: string, s: string) => `[${name}:${s}]`,
 	showCommandHint: true,
 }
 
@@ -104,7 +105,7 @@ describe("compact-form builders", () => {
 			expect(seg.id).toBe("context")
 			expect(seg.text).toBe("13% ctx")
 			expect(seg.width).toBe(7)
-			expect(seg.raw).toEqual({ kind: "context", percent: 13 })
+			expect(seg.raw).toEqual({ kind: "context", percent: 13, pctColor: undefined })
 			expect(seg.text).not.toContain("\u2588")
 			expect(seg.text).not.toContain("\u2591")
 		})
@@ -117,6 +118,57 @@ describe("compact-form builders", () => {
 		it("handles 0%", () => {
 			const seg = buildContextCompact(compactCtx, 0)
 			expect(seg.text).toBe("0% ctx")
+		})
+
+		it("preserves warning color at 75%", () => {
+			const seen: Array<[string, string]> = []
+			const ctx = {
+				...compactCtx,
+				semantic: (name: string, s: string) => {
+					seen.push([name, s])
+					return `[${name}:${s}]`
+				},
+			}
+			const seg = buildContextCompact(ctx, 75, "warning")
+			expect(seg.text).toBe("[warning:75%] ctx")
+			expect(seen).toEqual([["warning", "75%"]])
+			expect(seg.raw).toEqual({ kind: "context", percent: 75, pctColor: "warning" })
+		})
+
+		it("preserves error color at 95%", () => {
+			const seen: Array<[string, string]> = []
+			const ctx = {
+				...compactCtx,
+				semantic: (name: string, s: string) => {
+					seen.push([name, s])
+					return `[${name}:${s}]`
+				},
+			}
+			const seg = buildContextCompact(ctx, 95, "error")
+			expect(seg.text).toBe("[error:95%] ctx")
+			expect(seen).toEqual([["error", "95%"]])
+			expect(seg.raw).toEqual({ kind: "context", percent: 95, pctColor: "error" })
+		})
+
+		it("falls back to accent when no semantic color", () => {
+			const seenAccent: string[] = []
+			const seenSemantic: Array<[string, string]> = []
+			const ctx = {
+				...compactCtx,
+				accent: (s: string) => {
+					seenAccent.push(s)
+					return `[accent:${s}]`
+				},
+				semantic: (name: string, s: string) => {
+					seenSemantic.push([name, s])
+					return `[${name}:${s}]`
+				},
+			}
+			const seg = buildContextCompact(ctx, 50)
+			expect(seg.text).toBe("[accent:50%] ctx")
+			expect(seenAccent).toEqual(["50%"])
+			expect(seenSemantic).toEqual([])
+			expect(seg.raw).toEqual({ kind: "context", percent: 50, pctColor: undefined })
 		})
 	})
 
@@ -285,6 +337,12 @@ describe("StatsFooter behavioural acceptance at representative widths", () => {
 		expect(visible).not.toContain("/ for commands")
 		expect(visible).not.toContain("shift+tab")
 		expect(visible).not.toContain("option+tab")
+		// multi-model label is abbreviated to `m-m:`.
+		expect(visible).toContain("m-m:")
+		expect(visible).not.toContain("multi-model:")
+		// phase prefix is dropped; value survives.
+		expect(visible).toContain("explore")
+		expect(visible).not.toContain("phase:")
 		// The model is the highest-priority segment and should survive.
 		expect(visible).toContain("claude-opus-4-7")
 	})
@@ -311,7 +369,7 @@ describe("StatsFooter behavioural acceptance at representative widths", () => {
 	it("never overflows when phase contains wide (CJK) characters", () => {
 		// CJK characters are single code units but take TWO visible columns.
 		// This is the case `visibleWidth` catches and `.length` would miss.
-		vi.spyOn(TAGS, "getCurrentPhase").mockReturnValue("\u63a2\u7d22\u4e2d")
+		vi.spyOn(TAGS, "getCurrentPhase").mockReturnValue("\u63a2\u7d22\u4e2d" as ReturnType<typeof TAGS.getCurrentPhase>)
 		for (const w of [200, 100, 60, 40, 20]) {
 			const { raw } = renderAt(w)
 			expect(visibleWidth(raw), `width=${w}`).toBeLessThanOrEqual(w)

--- a/src/components/footer.test.ts
+++ b/src/components/footer.test.ts
@@ -1,0 +1,345 @@
+import type { ExtensionContext, ReadonlyFooterDataProvider, Theme } from "@earendil-works/pi-coding-agent"
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
+import * as AGENTS from "../extensions/agents/index.js"
+import * as FERMENT from "../extensions/ferment/index.js"
+import * as ORCHESTRATION from "../extensions/orchestration/prompt-enrichment.js"
+import * as TAGS from "../extensions/tags.js"
+import { SHORTCUT_TAIL, StatsFooter, buildContextCompact, buildMultiModelAbbrev, buildPhaseCompact } from "./footer.js"
+
+// biome-ignore lint/suspicious/noControlCharactersInRegex: ANSI escape stripping in test assertions
+const ANSI_ESCAPE = /\x1b\[[\d;]*m/g
+const stripAnsi = (s: string): string => s.replace(ANSI_ESCAPE, "")
+
+/** A theme that wraps text in identifiable markers but reports zero visible
+ *  width for those markers \u2014 mimicking how real ANSI behaves with visibleWidth. */
+function createMockTheme(): Theme {
+	// Real-shaped SGR ANSI escapes (terminated with `m`) so that visibleWidth in
+	// production code and stripAnsi in test assertions agree on what's visible.
+	const COLOR_CODE: Record<string, string> = {
+		dim: "\x1b[2m",
+		accent: "\x1b[36m",
+		warning: "\x1b[33m",
+		error: "\x1b[31m",
+		success: "\x1b[32m",
+	}
+	const RESET = "\x1b[0m"
+	const fg = vi.fn((color: string, s: string) => `${COLOR_CODE[color] ?? "\x1b[39m"}${s}${RESET}`)
+	return {
+		fg,
+		bg: vi.fn(),
+		getFgAnsi: vi.fn(() => "\x1b[36m"),
+		getBgAnsi: vi.fn(),
+		fgColors: {},
+		bgColors: {},
+		mode: "light",
+		preproc: vi.fn(),
+		extensions: {},
+	} as unknown as Theme
+}
+
+function createMockContext(opts?: { percent?: number; modelId?: string }): ExtensionContext {
+	const percent = opts?.percent ?? 0
+	const modelId = opts?.modelId ?? "claude-opus-4-7"
+	return {
+		model: { id: modelId, name: modelId },
+		cwd: "/test",
+		getContextUsage: vi.fn(() => ({ tokens: 0, percent, contextWindow: 100000 })),
+		sessionManager: {
+			getEntries: vi.fn(() => []),
+			getBranch: vi.fn(() => []),
+			getSessionId: vi.fn(() => "test-session"),
+			getSessionName: vi.fn(() => "test"),
+			getSessionFile: vi.fn(() => "/test/session.md"),
+		},
+	} as unknown as ExtensionContext
+}
+
+function createMockFooterData(opts?: {
+	permissionsMode?: string
+	permissionsWarning?: string
+	updateAvailable?: string
+}): ReadonlyFooterDataProvider {
+	const statuses = new Map<string, string>()
+	if (opts?.permissionsMode) statuses.set("permissions-mode", opts.permissionsMode)
+	if (opts?.permissionsWarning) statuses.set("permissions-warning", opts.permissionsWarning)
+	if (opts?.updateAvailable) statuses.set("update-available", opts.updateAvailable)
+	return {
+		getExtensionStatuses: vi.fn(() => statuses),
+	} as unknown as ReadonlyFooterDataProvider
+}
+
+/** CompactionContext stub using plain markers \u2014 used to unit-test the builder
+ *  functions in isolation, with predictable visible output. */
+const compactCtx = {
+	dim: (s: string) => s,
+	accent: (s: string) => s,
+	showCommandHint: true,
+}
+
+describe("compact-form builders", () => {
+	describe("buildContextCompact", () => {
+		it("returns `N% ctx` with no bar", () => {
+			const seg = buildContextCompact(compactCtx, 13)
+			expect(seg.id).toBe("context")
+			expect(seg.text).toBe("13% ctx")
+			expect(seg.width).toBe(7)
+			expect(seg.raw).toEqual({ kind: "context", percent: 13 })
+			expect(seg.text).not.toContain("\u2588")
+			expect(seg.text).not.toContain("\u2591")
+		})
+
+		it("rounds non-integer percentages", () => {
+			const seg = buildContextCompact(compactCtx, 13.7)
+			expect(seg.text).toBe("14% ctx")
+		})
+
+		it("handles 0%", () => {
+			const seg = buildContextCompact(compactCtx, 0)
+			expect(seg.text).toBe("0% ctx")
+		})
+	})
+
+	describe("buildMultiModelAbbrev", () => {
+		it("uses `m-m:` instead of `multi-model:` when enabled (darwin)", () => {
+			const orig = process.platform
+			Object.defineProperty(process, "platform", { value: "darwin" })
+			try {
+				const seg = buildMultiModelAbbrev(compactCtx, true)
+				expect(seg.id).toBe("multi-model")
+				expect(seg.text).toBe("m-m: on \u2192 option+tab")
+				expect(seg.raw).toEqual({ kind: "multi-model", enabled: true })
+			} finally {
+				Object.defineProperty(process, "platform", { value: orig })
+			}
+		})
+
+		it("shows `off` when disabled", () => {
+			const orig = process.platform
+			Object.defineProperty(process, "platform", { value: "darwin" })
+			try {
+				const seg = buildMultiModelAbbrev(compactCtx, false)
+				expect(seg.text).toBe("m-m: off \u2192 option+tab")
+			} finally {
+				Object.defineProperty(process, "platform", { value: orig })
+			}
+		})
+
+		it("uses `alt+tab` shortcut on non-darwin", () => {
+			const orig = process.platform
+			Object.defineProperty(process, "platform", { value: "linux" })
+			try {
+				const seg = buildMultiModelAbbrev(compactCtx, true)
+				expect(seg.text).toBe("m-m: on \u2192 alt+tab")
+			} finally {
+				Object.defineProperty(process, "platform", { value: orig })
+			}
+		})
+	})
+
+	describe("buildPhaseCompact", () => {
+		it("returns just the phase value, no `phase:` prefix", () => {
+			const seg = buildPhaseCompact(compactCtx, "explore")
+			expect(seg.id).toBe("phase")
+			expect(seg.text).toBe("explore")
+			expect(seg.width).toBe(7)
+			expect(seg.raw).toEqual({ kind: "phase", phase: "explore" })
+		})
+	})
+})
+
+describe("SHORTCUT_TAIL regex", () => {
+	// Real ANSI from the production code paths.
+	//   permissions: this.theme.fg(\"dim\", \"\u2192 shift+tab\")
+	//   multi-model: this.dim(`\u2192 ${shortcut}`)
+	// Both end up as `<ANSI-open>\u2192 <key><ANSI-close>` preceded by a space.
+
+	it("matches the permissions-extension trailing shortcut", () => {
+		// Real-shaped: leading space, ANSI open, arrow + key, ANSI close.
+		const text = "\u25cf default \x1b[38;5;242m\u2192 shift+tab\x1b[39m"
+		expect(SHORTCUT_TAIL.test(text)).toBe(true)
+		expect(text.replace(SHORTCUT_TAIL, "")).toBe("\u25cf default")
+	})
+
+	it("matches the multi-model trailing shortcut (darwin)", () => {
+		const text = "multi-model: on \x1b[38;5;242m\u2192 option+tab\x1b[39m"
+		expect(SHORTCUT_TAIL.test(text)).toBe(true)
+		expect(text.replace(SHORTCUT_TAIL, "")).toBe("multi-model: on")
+	})
+
+	it("matches the multi-model trailing shortcut (linux)", () => {
+		const text = "multi-model: on \x1b[38;5;242m\u2192 alt+tab\x1b[39m"
+		expect(SHORTCUT_TAIL.test(text)).toBe(true)
+		expect(text.replace(SHORTCUT_TAIL, "")).toBe("multi-model: on")
+	})
+
+	it("does NOT match text that has no trailing arrow", () => {
+		const text = "claude-opus-4-7"
+		expect(SHORTCUT_TAIL.test(text)).toBe(false)
+	})
+
+	it("does NOT match an arrow in the middle of text", () => {
+		const text = "foo \x1b[38;5;242m\u2192 bar\x1b[39m baz"
+		expect(SHORTCUT_TAIL.test(text)).toBe(false)
+	})
+})
+
+describe("StatsFooter behavioural acceptance at representative widths", () => {
+	let theme: Theme
+	let footerData: ReadonlyFooterDataProvider
+
+	beforeEach(() => {
+		theme = createMockTheme()
+		// Mirror production format: the permissions extension calls
+		// `theme.fg("dim", "\u2192 shift+tab")` and appends. We hand-build the same shape
+		// so the SHORTCUT_TAIL regex can find it.
+		const permissionsMode = "\u25cf default \x1b[2m\u2192 shift+tab\x1b[0m"
+		footerData = createMockFooterData({ permissionsMode })
+		vi.spyOn(ORCHESTRATION, "getMultiModelEnabled").mockReturnValue(true)
+		vi.spyOn(AGENTS, "getActiveAgentCount").mockReturnValue(0)
+		vi.spyOn(FERMENT, "getActiveFerment").mockReturnValue(undefined)
+		vi.spyOn(FERMENT, "getCurrentPhaseIndex").mockReturnValue(undefined)
+		vi.spyOn(TAGS, "getActiveTags").mockReturnValue([])
+		vi.spyOn(TAGS, "getCurrentPhase").mockReturnValue("explore")
+		// Stub platform-dependent shortcut so test is stable across CI.
+		Object.defineProperty(process, "platform", { value: "darwin" })
+	})
+
+	afterEach(() => {
+		vi.restoreAllMocks()
+	})
+
+	/** Run render at the given width and return the visible (ANSI-stripped) status line. */
+	function renderAt(width: number, ctxOpts?: { percent?: number }): string {
+		const footer = new StatsFooter(createMockContext(ctxOpts), theme, footerData)
+		const lines = footer.render(width)
+		return stripAnsi(lines[lines.length - 1])
+	}
+
+	it("width 160: full footer + `/ for commands` hint", () => {
+		const visible = renderAt(160)
+		expect(visible).toContain("\u25cf default \u2192 shift+tab")
+		expect(visible).toContain("multi-model: on \u2192 option+tab")
+		expect(visible).toContain("claude-opus-4-7")
+		expect(visible).toContain("0% ctx")
+		expect(visible).toContain("phase:explore")
+		expect(visible).toContain("/ for commands")
+	})
+
+	it("width 100: hint and context-bar dropped, multi-model abbreviated, shortcuts stripped", () => {
+		const visible = renderAt(100)
+		// Hint gone (step 1)
+		expect(visible).not.toContain("/ for commands")
+		// Bar gone, percentage kept (step 2)
+		expect(visible).not.toContain("\u2588")
+		expect(visible).not.toContain("\u2591")
+		expect(visible).toContain("0% ctx")
+		// At width 100, only steps 1\u20132 should be needed; verify the line fits.
+		expect(visible.length).toBeLessThanOrEqual(100)
+		// All segments still present.
+		expect(visible).toContain("default")
+		expect(visible).toContain("multi-model")
+		expect(visible).toContain("claude-opus-4-7")
+		expect(visible).toContain("phase:explore")
+	})
+
+	it("width 60: shortcuts stripped, multi-model abbreviated, phase prefix dropped", () => {
+		const visible = renderAt(60)
+		expect(visible.length).toBeLessThanOrEqual(60)
+		// No `/ for commands`, no shortcut tails.
+		expect(visible).not.toContain("/ for commands")
+		expect(visible).not.toContain("shift+tab")
+		expect(visible).not.toContain("option+tab")
+		// The model is the highest-priority segment and should survive.
+		expect(visible).toContain("claude-opus-4-7")
+	})
+
+	it("width 20: line is hard-truncated to fit", () => {
+		const visible = renderAt(20)
+		// Critical invariant: never overflow.
+		expect(visible.length).toBeLessThanOrEqual(20)
+		// Truncation produces *something* non-empty.
+		expect(visible.length).toBeGreaterThan(0)
+	})
+
+	it("never overflows width across a range of terminal sizes", () => {
+		for (const w of [200, 160, 137, 121, 112, 104, 100, 75, 60, 50, 40, 30, 20, 10]) {
+			const visible = renderAt(w)
+			expect(visible.length, `width=${w}`).toBeLessThanOrEqual(w)
+		}
+	})
+
+	it("with an active ferment, drops the `ferment:` prefix when overflowing", () => {
+		// Install an active ferment so the segment shows up.
+		const ferment = {
+			id: "f-1",
+			name: "my-ferment",
+			status: "running",
+			mode: "yolo",
+			phases: [],
+			activePhaseId: undefined,
+		} as unknown as ReturnType<typeof FERMENT.getActiveFerment>
+		vi.spyOn(FERMENT, "getActiveFerment").mockReturnValue(ferment)
+		vi.spyOn(FERMENT, "getCurrentPhaseIndex").mockReturnValue(undefined)
+
+		// At a generous width every compaction is unneeded and `ferment:` shows.
+		const wide = renderAt(200)
+		expect(wide).toContain("ferment:my-ferment")
+
+		// At a width where every earlier compaction has fired but the line is
+		// still too wide, the ferment-prefix step must also have fired. Use a
+		// width small enough to force it; the active-ferment line is longer than
+		// the no-ferment line, so 70 is well past the prefix-drop threshold.
+		const narrow = renderAt(70)
+		expect(narrow).toContain("my-ferment")
+		expect(narrow).not.toContain("ferment:")
+	})
+})
+
+describe("StatsFooter regression tests", () => {
+	let theme: Theme
+
+	beforeEach(() => {
+		theme = createMockTheme()
+		vi.spyOn(ORCHESTRATION, "getMultiModelEnabled").mockReturnValue(true)
+		vi.spyOn(AGENTS, "getActiveAgentCount").mockReturnValue(0)
+		vi.spyOn(FERMENT, "getActiveFerment").mockReturnValue(undefined)
+		vi.spyOn(FERMENT, "getCurrentPhaseIndex").mockReturnValue(undefined)
+		vi.spyOn(TAGS, "getActiveTags").mockReturnValue([])
+		vi.spyOn(TAGS, "getCurrentPhase").mockReturnValue("explore")
+	})
+
+	afterEach(() => {
+		vi.restoreAllMocks()
+	})
+
+	it("renders an info line above the status line when permissions-warning is set", () => {
+		const data = createMockFooterData({ permissionsWarning: "Warning: check permissions" })
+		const footer = new StatsFooter(createMockContext(), theme, data)
+		const lines = footer.render(160)
+
+		expect(lines.length).toBe(2)
+		expect(stripAnsi(lines[0])).toContain("Warning")
+	})
+
+	it("renders an info line above the status line when update-available is set", () => {
+		const data = createMockFooterData({ updateAvailable: "Update available: v1.2.0" })
+		const footer = new StatsFooter(createMockContext(), theme, data)
+		const lines = footer.render(160)
+
+		expect(lines.length).toBe(2)
+		expect(stripAnsi(lines[0])).toContain("Update")
+	})
+
+	it("never produces an orphan ` \u00b7  \u00b7 ` double separator at any width", () => {
+		// Compaction never removes whole segments, so we should never see two
+		// adjacent separators. Truncation cuts the tail, not the middle.
+		vi.spyOn(TAGS, "getActiveTags").mockReturnValue([{ key: "team", value: "platform" } as never, "foo:bar" as never])
+		const data = createMockFooterData({ permissionsMode: "\u25cf default" })
+		const footer = new StatsFooter(createMockContext(), theme, data)
+
+		for (const w of [40, 50, 60, 75, 100]) {
+			const visible = stripAnsi(footer.render(w)[0])
+			expect(visible, `width=${w}: orphan separator in "${visible}"`).not.toMatch(/\u00b7\s*\u00b7/)
+		}
+	})
+})

--- a/src/components/footer.ts
+++ b/src/components/footer.ts
@@ -13,9 +13,61 @@ import { getCurrentPermissionsMode } from "../extensions/permissions/index.js"
 import { getMultiModelEnabled } from "../extensions/prompt-construction/prompt-enrichment.js"
 import { getActiveTags, getCurrentPhase, parseTag } from "../extensions/tags.js"
 
-interface FooterSegment {
+/** Stable identifier used by compaction steps to find segments. */
+type SegmentId =
+	| "permissions"
+	| "multi-model"
+	| "model"
+	| "ferment"
+	| "agents"
+	| "context"
+	| "usage"
+	| "phase"
+	| "tags"
+	| "team"
+
+/** Raw inputs preserved on segments that have compact forms, so compaction
+ *  steps can rebuild the colorized text without round-tripping through ANSI.
+ *
+ *  `ferment` is the odd one out: instead of storing inputs and rebuilding the
+ *  whole segment, it just stashes the leading colorized `ferment:` substring
+ *  so the compaction step can slice it off in place. Cheaper than a rebuild
+ *  and the segment's tail is identical in both forms anyway. */
+type SegmentRaw =
+	| { kind: "context"; percent: number }
+	| { kind: "multi-model"; enabled: boolean }
+	| { kind: "phase"; phase: string }
+	| { kind: "ferment"; prefix: string; prefixWidth: number }
+
+/** A single piece of the footer line. */
+interface Segment {
+	/** Stable identifier used by compaction steps to find this segment. */
+	id: SegmentId
+	/** Already-colorized text (includes ANSI). */
 	text: string
+	/** Visible width of `text`, precomputed. */
 	width: number
+	/** Original inputs, present only on segments that participate in the
+	 *  UX-ladder compaction steps. Compact-form builders use these. */
+	raw?: SegmentRaw
+}
+
+/** A single compaction action in the UX ladder. */
+interface CompactionStep {
+	/** Human label, used in tests/debug. */
+	name: string
+	/** Mutate the segment array in place. Returning `false` means "no-op";
+	 *  the layout engine will move on to the next step. */
+	apply(segments: Segment[], ctx: CompactionContext): boolean
+}
+
+/** Context passed to compaction steps so they can rebuild colorized text. */
+interface CompactionContext {
+	/** Theme accessors so steps can rebuild colorized text when shortening. */
+	dim: (s: string) => string
+	accent: (s: string) => string
+	/** Set to `false` once the command hint should no longer be appended. */
+	showCommandHint: boolean
 }
 
 const HARNESS_SETTINGS_PATH = join(homedir(), ".config", "kimchi", "harness", "settings.json")
@@ -120,15 +172,192 @@ export class ScriptFooter implements Component {
 
 const BAR_WIDTH = 16
 
-function seg(text: string): FooterSegment {
-	return { text, width: visibleWidth(text) }
+/** Compact form builders */
+
+/** Compact form for the context segment: drops the bar, keeps `N% ctx`. */
+export function buildContextCompact(ctx: CompactionContext, percent: number): Segment {
+	const pctStr = ctx.accent(`${Math.round(percent)}%`)
+	const ctxStr = ctx.dim("ctx")
+	const text = `${pctStr} ${ctxStr}`
+	return {
+		id: "context",
+		text,
+		width: visibleWidth(text),
+		raw: { kind: "context", percent },
+	}
+}
+
+/** Compact form for multi-model: replaces "multi-model:" with "m-m:". */
+export function buildMultiModelAbbrev(ctx: CompactionContext, enabled: boolean): Segment {
+	const label = enabled ? ctx.accent("on") : ctx.dim("off")
+	const shortcut = process.platform === "darwin" ? "option+tab" : "alt+tab"
+	const text = `${ctx.dim("m-m:")} ${label} ${ctx.dim(`→ ${shortcut}`)}`
+	return {
+		id: "multi-model",
+		text,
+		width: visibleWidth(text),
+		raw: { kind: "multi-model", enabled },
+	}
+}
+
+/** Compact form for phase: drops the "phase:" prefix, keeps just the value. */
+export function buildPhaseCompact(ctx: CompactionContext, phase: string): Segment {
+	const text = ctx.accent(phase)
+	return {
+		id: "phase",
+		text,
+		width: visibleWidth(text),
+		raw: { kind: "phase", phase },
+	}
+}
+
+/** Compaction action for ferment: drop the leading colorized `ferment:`
+ *  substring in place. The rest of the segment is unchanged, so no rebuild. */
+function dropFermentPrefix(segs: Segment[]): boolean {
+	const idx = segs.findIndex((s) => s.id === "ferment")
+	if (idx === -1) return false
+	const seg = segs[idx]
+	if (seg.raw?.kind !== "ferment") return false
+	if (!seg.text.startsWith(seg.raw.prefix)) return false
+	const newText = seg.text.slice(seg.raw.prefix.length)
+	segs[idx] = { id: seg.id, text: newText, width: seg.width - seg.raw.prefixWidth }
+	return true
+}
+
+/** Regex to strip trailing shortcut hints like "→ shift+tab" or "→ option+tab"
+ *  from segments that have them. Matches the dim/text colored shortcut at the end. */
+// biome-ignore lint/suspicious/noControlCharactersInRegex: ANSI escape sequences are required for matching real terminal output
+export const SHORTCUT_TAIL = /\s*\x1b\[[\d;]*m\s*→\s+[\w+]+\x1b\[[\d;]*m\s*$/
+
+/** Strip shortcut hints from the named segments. Returns true if any were stripped. */
+function stripShortcutHintsAcross(segments: Segment[], ids: SegmentId[]): boolean {
+	let changed = false
+	for (const id of ids) {
+		const i = segments.findIndex((s) => s.id === id)
+		if (i === -1) continue
+		const stripped = segments[i].text.replace(SHORTCUT_TAIL, "")
+		if (stripped !== segments[i].text) {
+			segments[i] = { id, text: stripped, width: visibleWidth(stripped) }
+			changed = true
+		}
+	}
+	return changed
+}
+
+/** Replace a segment by ID with a new Segment (or null to skip). Returns true if changed. */
+function replaceSegment(segs: Segment[], id: SegmentId, next: Segment | null): boolean {
+	const i = segs.findIndex((s) => s.id === id)
+	if (i === -1 || !next) return false
+	if (segs[i].text === next.text) return false
+	segs[i] = next
+	return true
+}
+
+/** Helper for compaction steps: rebuild a segment in place from its raw inputs.
+ *  Type-safe: only matches segments whose `raw.kind` equals the requested kind. */
+function recompactSegment<K extends SegmentRaw["kind"]>(
+	segs: Segment[],
+	id: SegmentId,
+	kind: K,
+	builder: (raw: Extract<SegmentRaw, { kind: K }>) => Segment,
+): boolean {
+	const seg = segs.find((s) => s.id === id)
+	if (!seg || seg.raw?.kind !== kind) return false
+	return replaceSegment(segs, id, builder(seg.raw as Extract<SegmentRaw, { kind: K }>))
+}
+
+/** The ordered compaction steps */
+const STEPS: CompactionStep[] = [
+	{
+		name: "drop-command-hint",
+		apply: (_segs, ctx) => {
+			if (!ctx.showCommandHint) return false
+			ctx.showCommandHint = false
+			return true
+		},
+	},
+	{
+		name: "drop-context-bar",
+		apply: (segs, ctx) => recompactSegment(segs, "context", "context", (raw) => buildContextCompact(ctx, raw.percent)),
+	},
+	{
+		name: "abbrev-multi-model-label",
+		apply: (segs, ctx) =>
+			recompactSegment(segs, "multi-model", "multi-model", (raw) => buildMultiModelAbbrev(ctx, raw.enabled)),
+	},
+	{
+		name: "drop-shortcut-hints",
+		apply: (segs) => stripShortcutHintsAcross(segs, ["permissions", "multi-model"]),
+	},
+	{
+		name: "drop-phase-prefix",
+		apply: (segs, ctx) => recompactSegment(segs, "phase", "phase", (raw) => buildPhaseCompact(ctx, raw.phase)),
+	},
+	{
+		name: "drop-ferment-prefix",
+		apply: (segs) => dropFermentPrefix(segs),
+	},
+]
+
+/** Render a line from segments, separator, and optional command hint. */
+function renderLine(
+	segments: Segment[],
+	ctx: CompactionContext,
+	sep: string,
+	sepWidth: number,
+	commandHint: { text: string; width: number },
+	width: number,
+): { text: string; width: number } {
+	if (segments.length === 0) {
+		return { text: "", width: 0 }
+	}
+
+	const joinedText = segments.map((s) => s.text).join(sep)
+	const joinedWidth = segments.reduce((sum, s) => sum + s.width, 0) + (segments.length - 1) * sepWidth
+
+	// Try to fit command hint if requested
+	if (ctx.showCommandHint && joinedWidth + 2 + commandHint.width <= width) {
+		const padding = width - joinedWidth - commandHint.width
+		return {
+			text: `${joinedText}${" ".repeat(padding)}${commandHint.text}`,
+			width, // text fills exactly `width` columns
+		}
+	}
+
+	return { text: joinedText, width: joinedWidth }
+}
+
+/** Main layout function — applies compaction steps in order, then truncates if
+ *  the fully-compacted line still doesn't fit. We deliberately do not shed
+ *  whole segments: disappearing elements look worse than a clean tail truncation. */
+function layoutFooter(
+	segments: Segment[],
+	width: number,
+	ctx: CompactionContext,
+	sep: string,
+	sepWidth: number,
+	commandHint: { text: string; width: number },
+): string {
+	// Initial attempt with no compaction.
+	let line = renderLine(segments, ctx, sep, sepWidth, commandHint, width)
+	if (line.width <= width) return line.text
+
+	// Apply each compaction step in order, re-rendering and stopping the first time we fit.
+	for (const step of STEPS) {
+		step.apply(segments, ctx)
+		line = renderLine(segments, ctx, sep, sepWidth, commandHint, width)
+		if (line.width <= width) return line.text
+	}
+
+	// Fully compacted line still overflows — truncate the tail.
+	return truncateToWidth(line.text, width)
 }
 
 export class StatsFooter implements Component {
 	constructor(
 		private ctx: ExtensionContext,
 		private theme: Theme,
-		private _footerData: ReadonlyFooterDataProvider,
+		private footerData: ReadonlyFooterDataProvider,
 	) {}
 
 	invalidate(): void {}
@@ -142,12 +371,12 @@ export class StatsFooter implements Component {
 		return `${ansi}${s}${RST_FG}`
 	}
 
-	private modelSegment(): FooterSegment {
+	private modelSegment(): Segment {
 		const modelId = this.ctx.model?.id ?? "n/a"
-		return seg(this.accent(modelId))
+		return { id: "model", text: this.accent(modelId), width: visibleWidth(modelId) }
 	}
 
-	private usageSegment(): FooterSegment | null {
+	private usageSegment(): Segment | null {
 		let totalInput = 0
 		let totalOutput = 0
 		for (const entry of this.ctx.sessionManager.getEntries()) {
@@ -163,10 +392,10 @@ export class StatsFooter implements Component {
 		const tokens = [totalInput ? `↑${formatCount(totalInput)}` : "", totalOutput ? `↓${formatCount(totalOutput)}` : ""]
 			.filter(Boolean)
 			.join(" ")
-		return seg(this.dim(tokens))
+		return { id: "usage", text: this.dim(tokens), width: visibleWidth(tokens) }
 	}
 
-	private contextSegment(): FooterSegment {
+	private contextSegment(): Segment {
 		const contextUsage = this.ctx.getContextUsage()
 		const pct = contextUsage?.percent ?? 0
 
@@ -177,47 +406,53 @@ export class StatsFooter implements Component {
 		const pctStr = pctColor
 			? `${resolvedSemanticFg(this.theme, pctColor)}${Math.round(pct)}%${RST_FG}`
 			: this.accent(`${Math.round(pct)}%`)
-		return seg(`${bar} ${pctStr} ${this.dim("ctx")}`)
+		const text = `${bar} ${pctStr} ${this.dim("ctx")}`
+		return { id: "context", text, width: visibleWidth(text), raw: { kind: "context", percent: pct } }
 	}
 
-	private phaseSegment(): FooterSegment {
+	private phaseSegment(): Segment {
 		const phase = getCurrentPhase() ?? "n/a"
-		return seg(`${this.dim("phase:")}${this.accent(phase)}`)
+		const text = `${this.dim("phase:")}${this.accent(phase)}`
+		return { id: "phase", text, width: visibleWidth(text), raw: { kind: "phase", phase } }
 	}
 
-	private tagsSegment(parsed: Array<{ key: string; value: string }>): FooterSegment | null {
+	private tagsSegment(parsed: Array<{ key: string; value: string }>): Segment | null {
 		const display = parsed.filter((t) => t.key !== "team" && t.key !== "phase")
 		if (display.length === 0) return null
 		const formatted = display.map((t) => this.dim(`${t.key}:${t.value}`)).join(this.dim(" "))
-		return seg(`${this.dim("tags:")}${formatted}`)
+		const text = `${this.dim("tags:")}${formatted}`
+		return { id: "tags", text, width: visibleWidth(text) }
 	}
 
-	private teamSegment(parsed: Array<{ key: string; value: string }>): FooterSegment | null {
+	private teamSegment(parsed: Array<{ key: string; value: string }>): Segment | null {
 		const team = parsed.find((t) => t.key === "team")
 		if (!team) return null
-		return seg(`${this.dim("team:")}${this.accent(team.value)}`)
+		const text = `${this.dim("team:")}${this.accent(team.value)}`
+		return { id: "team", text, width: visibleWidth(text) }
 	}
 
-	private permissionsSegment(): FooterSegment | null {
-		const mode = this._footerData.getExtensionStatuses().get("permissions-mode")
+	private permissionsSegment(): Segment | null {
+		const mode = this.footerData.getExtensionStatuses().get("permissions-mode")
 		if (!mode) return null
-		return seg(mode)
+		return { id: "permissions", text: mode, width: visibleWidth(mode) }
 	}
 
-	private multiModelSegment(): FooterSegment {
+	private multiModelSegment(): Segment {
 		const enabled = getMultiModelEnabled()
 		const label = enabled ? this.accent("on") : this.dim("off")
 		const shortcut = process.platform === "darwin" ? "option+tab" : "alt+tab"
-		return seg(`${this.dim("multi-model:")} ${label} ${this.dim(`→ ${shortcut}`)}`)
+		const text = `${this.dim("multi-model:")} ${label} ${this.dim(`→ ${shortcut}`)}`
+		return { id: "multi-model", text, width: visibleWidth(text), raw: { kind: "multi-model", enabled } }
 	}
 
-	private subagentSegment(): FooterSegment | null {
+	private subagentSegment(): Segment | null {
 		const count = getActiveAgentCount()
 		if (count === 0) return null
-		return seg(this.accent(`${count} agent${count === 1 ? "" : "s"}`))
+		const text = this.accent(`${count} agent${count === 1 ? "" : "s"}`)
+		return { id: "agents", text, width: visibleWidth(text) }
 	}
 
-	private fermentSegment(): FooterSegment | null {
+	private fermentSegment(): Segment | null {
 		const ferment = getActiveFerment()
 		if (!ferment) return null
 		const phaseIdx = getCurrentPhaseIndex()
@@ -227,7 +462,12 @@ export class StatsFooter implements Component {
 			(s) => s.status === "running" || s.status === "pending" || s.status === "failed",
 		)
 
-		const parts: string[] = [`${this.dim("ferment:")}${this.accent(ferment.name)}`]
+		// Capture the colorized `ferment:` prefix so the compaction step can
+		// slice it off in place. `visibleWidth("ferment:")` is 8 (ASCII).
+		const prefix = this.dim("ferment:")
+		const PREFIX_WIDTH = visibleWidth(prefix)
+
+		const parts: string[] = [`${prefix}${this.accent(ferment.name)}`]
 		parts.push(this.dim(`[${ferment.status}]`))
 		parts.push(this.dim(ferment.mode))
 
@@ -236,25 +476,33 @@ export class StatsFooter implements Component {
 			const phaseInfo = phaseName ? ` "${phaseName}"` : ""
 			parts.push(this.dim(`· phase ${phaseIdx}/${totalPhases}${phaseInfo}`))
 		}
-
 		if (activeStep && activePhase) {
-			const totalSteps = activePhase.steps.length
-			parts.push(this.dim(`· step ${activeStep.index}/${totalSteps}`))
+			parts.push(this.dim(`· step ${activeStep.index}/${activePhase.steps.length}`))
 		}
 
-		return seg(parts.join(" "))
+		const text = parts.join(" ")
+		return {
+			id: "ferment",
+			text,
+			width: visibleWidth(text),
+			raw: { kind: "ferment", prefix, prefixWidth: PREFIX_WIDTH },
+		}
 	}
 
-	private permissionsWarning(_width: number): string | null {
-		const text = this._footerData.getExtensionStatuses().get("permissions-warning")
+	private permissionsWarning(): string | null {
+		const text = this.footerData.getExtensionStatuses().get("permissions-warning")
 		if (!text) return null
 		return this.theme.fg("warning", text)
 	}
 
-	private updateAvailableSegment(): FooterSegment | null {
-		const text = this._footerData.getExtensionStatuses().get("update-available")
+	private updateAvailableSegment(): { text: string; width: number } | null {
+		// Info-line segment (rendered above the status line), NOT one of the
+		// status-line `Segment`s above — it has no SegmentId because it never
+		// participates in compaction.
+		const text = this.footerData.getExtensionStatuses().get("update-available")
 		if (!text) return null
-		return seg(this.theme.fg("accent", text))
+		const segText = this.theme.fg("accent", text)
+		return { text: segText, width: visibleWidth(text) }
 	}
 
 	render(width: number): string[] {
@@ -262,7 +510,7 @@ export class StatsFooter implements Component {
 			.map(parseTag)
 			.filter((t): t is { key: string; value: string } => t !== null)
 
-		const segments = [
+		const segments: Segment[] = [
 			this.permissionsSegment(),
 			this.multiModelSegment(),
 			this.modelSegment(),
@@ -273,21 +521,21 @@ export class StatsFooter implements Component {
 			this.phaseSegment(),
 			this.tagsSegment(tags),
 			this.teamSegment(tags),
-		].filter((s): s is FooterSegment => s !== null)
+		].filter((s): s is Segment => s !== null)
 
 		const sep = ` ${this.dim("·")} `
-		const left = segments.map((s) => s.text).join(sep)
-		const leftWidth = visibleWidth(left)
+		const sepWidth = visibleWidth(sep)
 
-		const hint = this.dim("/ for commands")
-		const hintWidth = visibleWidth(hint)
+		const hintText = this.dim("/ for commands")
+		const hintWidth = visibleWidth(hintText)
 
-		let line: string
-		if (leftWidth + 2 + hintWidth <= width) {
-			line = `${left}${" ".repeat(width - leftWidth - hintWidth)}${hint}`
-		} else {
-			line = truncateToWidth(left, width)
+		const ctx: CompactionContext = {
+			dim: (s) => this.dim(s),
+			accent: (s) => this.accent(s),
+			showCommandHint: true,
 		}
+
+		const line = layoutFooter(segments, width, ctx, sep, sepWidth, { text: hintText, width: hintWidth })
 
 		const infoLine = this.buildInfoLine(width)
 		return infoLine ? [infoLine, line] : [line]

--- a/src/components/footer.ts
+++ b/src/components/footer.ts
@@ -34,7 +34,7 @@ type SegmentId =
  *  so the compaction step can slice it off in place. Cheaper than a rebuild
  *  and the segment's tail is identical in both forms anyway. */
 type SegmentRaw =
-	| { kind: "context"; percent: number }
+	| { kind: "context"; percent: number; pctColor?: "error" | "warning" }
 	| { kind: "multi-model"; enabled: boolean }
 	| { kind: "phase"; phase: string }
 	| { kind: "ferment"; prefix: string; prefixWidth: number }
@@ -66,6 +66,8 @@ interface CompactionContext {
 	/** Theme accessors so steps can rebuild colorized text when shortening. */
 	dim: (s: string) => string
 	accent: (s: string) => string
+	/** Apply a named semantic color (e.g. "error", "warning") to a string. */
+	semantic: (color: string, s: string) => string
 	/** Set to `false` once the command hint should no longer be appended. */
 	showCommandHint: boolean
 }
@@ -175,15 +177,15 @@ const BAR_WIDTH = 16
 /** Compact form builders */
 
 /** Compact form for the context segment: drops the bar, keeps `N% ctx`. */
-export function buildContextCompact(ctx: CompactionContext, percent: number): Segment {
-	const pctStr = ctx.accent(`${Math.round(percent)}%`)
+export function buildContextCompact(ctx: CompactionContext, percent: number, pctColor?: "error" | "warning"): Segment {
+	const pctStr = pctColor ? ctx.semantic(pctColor, `${Math.round(percent)}%`) : ctx.accent(`${Math.round(percent)}%`)
 	const ctxStr = ctx.dim("ctx")
 	const text = `${pctStr} ${ctxStr}`
 	return {
 		id: "context",
 		text,
 		width: visibleWidth(text),
-		raw: { kind: "context", percent },
+		raw: { kind: "context", percent, pctColor },
 	}
 }
 
@@ -278,7 +280,8 @@ const STEPS: CompactionStep[] = [
 	},
 	{
 		name: "drop-context-bar",
-		apply: (segs, ctx) => recompactSegment(segs, "context", "context", (raw) => buildContextCompact(ctx, raw.percent)),
+		apply: (segs, ctx) =>
+			recompactSegment(segs, "context", "context", (raw) => buildContextCompact(ctx, raw.percent, raw.pctColor)),
 	},
 	{
 		name: "abbrev-multi-model-label",
@@ -373,7 +376,8 @@ export class StatsFooter implements Component {
 
 	private modelSegment(): Segment {
 		const modelId = this.ctx.model?.id ?? "n/a"
-		return { id: "model", text: this.accent(modelId), width: visibleWidth(modelId) }
+		const text = this.accent(modelId)
+		return { id: "model", text, width: visibleWidth(text) }
 	}
 
 	private usageSegment(): Segment | null {
@@ -407,7 +411,7 @@ export class StatsFooter implements Component {
 			? `${resolvedSemanticFg(this.theme, pctColor)}${Math.round(pct)}%${RST_FG}`
 			: this.accent(`${Math.round(pct)}%`)
 		const text = `${bar} ${pctStr} ${this.dim("ctx")}`
-		return { id: "context", text, width: visibleWidth(text), raw: { kind: "context", percent: pct } }
+		return { id: "context", text, width: visibleWidth(text), raw: { kind: "context", percent: pct, pctColor } }
 	}
 
 	private phaseSegment(): Segment {
@@ -532,6 +536,8 @@ export class StatsFooter implements Component {
 		const ctx: CompactionContext = {
 			dim: (s) => this.dim(s),
 			accent: (s) => this.accent(s),
+			semantic: (color, s) =>
+				`${resolvedSemanticFg(this.theme, color as "success" | "warning" | "error")}${s}${RST_FG}`,
 			showCommandHint: true,
 		}
 
@@ -541,7 +547,7 @@ export class StatsFooter implements Component {
 		return infoLine ? [infoLine, line] : [line]
 	}
 
-	buildInfoLine(width: number): string {
+	private buildInfoLine(width: number): string {
 		let line = ""
 		const permissionsWarningText = this.permissionsWarning()
 		const updateSeg = this.updateAvailableSegment()

--- a/src/components/footer.ts
+++ b/src/components/footer.ts
@@ -543,7 +543,7 @@ export class StatsFooter implements Component {
 
 	buildInfoLine(width: number): string {
 		let line = ""
-		const permissionsWarningText = this.permissionsWarning(width)
+		const permissionsWarningText = this.permissionsWarning()
 		const updateSeg = this.updateAvailableSegment()
 
 		let remainingWidth = width


### PR DESCRIPTION
Closes #LLM-1606

When everything fits
<img width="1266" height="41" alt="image" src="https://github.com/user-attachments/assets/9f93800d-382b-4542-a1e6-faa8aa8bc35b" />

Compacting steps:
<img width="1124" height="56" alt="image" src="https://github.com/user-attachments/assets/6e0c34c7-912c-40fb-aa92-b542b736855c" />

<img width="1005" height="52" alt="image" src="https://github.com/user-attachments/assets/20e2f737-3842-4152-b664-b817da02a8e6" />

<img width="836" height="59" alt="image" src="https://github.com/user-attachments/assets/909a0914-ae34-4afb-b058-aaad7a61d7c2" />

<img width="660" height="54" alt="image" src="https://github.com/user-attachments/assets/fe735ea2-0cd6-4d61-af32-b13299a91f63" />

When the screen is very narrow and compacted elements doesn't fit they are truncated:
<img width="506" height="61" alt="image" src="https://github.com/user-attachments/assets/f8409c69-08c0-457d-a263-68d4f28a5707" />


---
### Kimchi Summary
### What changed
Added responsive compaction to the status footer so it gracefully narrows for smaller terminals instead of overflowing. When space is constrained, the footer progressively abbreviates labels, drops decorative prefixes, and strips shortcut hints before falling back to tail truncation.

### Why
The footer previously overflowed when terminal width was insufficient, causing elements to run off-screen. This makes the footer readable in narrow terminals or split-pane layouts.

### Key changes
- `src/components/footer.ts`: Replaced fixed string concatenation with a `Segment`-based layout engine (`layoutFooter`, `renderLine`) that applies an ordered UX-ladder of `CompactionStep`s.
- `src/components/footer.ts`: Each footer segment now carries a stable `SegmentId` and optional `raw` inputs, enabling type-safe rebuilds during compaction without re-parsing ANSI.
- `src/components/footer.ts`: Added compact-form builders `buildContextCompact` (drops bar, keeps `N% ctx`), `buildMultiModelAbbrev` (`multi-model:` → `m-m:`), and `buildPhaseCompact` (drops `phase:` prefix).
- `src/components/footer.ts`: Added `SHORTCUT_TAIL` regex and `stripShortcutHintsAcross` to remove trailing shortcut hints (e.g. `→ shift+tab`) from `permissions` and `multi-model` segments.
- `src/components/footer.ts`: Added `dropFermentPrefix` to slice off the `ferment:` label in place when space is constrained.
- `src/components/footer.test.ts`: Added comprehensive behavioral tests rendering the footer at widths 160, 100, 60, 20, 10, plus regression tests for orphan separators, info lines, and shortcut-tail regex matching.

### Impact
- Footer width is now strictly bounded by the terminal width; it will never overflow.
- No breaking changes or migration steps required. At generous widths the rendered output remains identical.