### PR TITLE
feat(system-prompt-scaffolding): API for system prompt scaffolding and active tools management

### DIFF
--- a/src/extensions/behaviours/wiring.smoke.test.ts
+++ b/src/extensions/behaviours/wiring.smoke.test.ts
@@ -259,6 +259,7 @@ describe("wireBehaviours — before_agent_start", () => {
 		await pi.fire("session_start", {}, { cwd: "/tmp" })
 
 		const sp = buildSystemPrompt({
+			pi: pi.asExtensionAPI(),
 			tools: [{ name: "read", description: "Read file contents" }],
 			env: testEnv,
 			contextFiles: [{ path: "/repo/AGENTS.md", content: "Project rule." }],

--- a/src/extensions/behaviours/wiring.smoke.test.ts
+++ b/src/extensions/behaviours/wiring.smoke.test.ts
@@ -7,7 +7,8 @@
  */
 
 import type { ExtensionAPI } from "@earendil-works/pi-coding-agent"
-import { describe, expect, it } from "vitest"
+import { afterEach, describe, expect, it } from "vitest"
+import { type EnvironmentInfo, buildSystemPrompt } from "../prompt-construction/system-prompt.js"
 import type { ResolverIO } from "./session-context.js"
 import {
 	BEHAVIOUR_EVAL_TYPE,
@@ -69,6 +70,8 @@ class FakePi {
 	}
 }
 
+const activePis: FakePi[] = []
+
 const stubIO: ResolverIO = {
 	hasCli: (name) => name === "gh",
 	readGitRemoteHost: () => undefined,
@@ -105,8 +108,26 @@ const glabCli: Behaviour = {
 
 function setupWired(behaviours: Behaviour[]): FakePi {
 	const pi = new FakePi()
+	activePis.push(pi)
 	wireBehaviours(pi.asExtensionAPI(), behaviours, { resolverIO: stubIO })
 	return pi
+}
+
+afterEach(async () => {
+	for (const pi of activePis.splice(0)) {
+		await pi.fire("session_shutdown", {})
+	}
+})
+
+const testEnv: EnvironmentInfo = {
+	os: "Linux",
+	username: "testuser",
+	homeDir: "/home/testuser",
+	cwd: "/home/testuser/project",
+	documentsDir: "/home/testuser/project/.kimchi/docs",
+	currentTime: "2026-01-01T00:00:00.000Z",
+	localDate: "2026-01-01",
+	isGitRepo: false,
 }
 
 describe("wireBehaviours — session_start", () => {
@@ -213,18 +234,41 @@ describe("wireBehaviours — tool_result", () => {
 })
 
 describe("wireBehaviours — before_agent_start", () => {
-	it("appends the rules block for baseline behaviours to the system prompt", async () => {
-		const pi = setupWired([baseline])
-		await pi.fire("session_start", {}, { cwd: "/tmp" })
-		const results = await pi.fire<{ systemPrompt?: string }>("before_agent_start", {
-			prompt: "hi",
-			systemPrompt: "BASE",
+	it("leaves the system prompt unaffected when no baseline rules exist", async () => {
+		const basePrompt = buildSystemPrompt({
+			tools: [{ name: "read", description: "Read file contents" }],
+			env: testEnv,
+			contextFiles: [{ path: "/repo/AGENTS.md", content: "Project rule." }],
+			mode: "orchestrator",
 		})
 
-		const sp = results.find((r) => r.systemPrompt !== undefined)?.systemPrompt
+		setupWired([ghCli])
+		const promptAfterWiring = buildSystemPrompt({
+			tools: [{ name: "read", description: "Read file contents" }],
+			env: testEnv,
+			contextFiles: [{ path: "/repo/AGENTS.md", content: "Project rule." }],
+			mode: "orchestrator",
+		})
+
+		expect(promptAfterWiring).toBe(basePrompt)
+		expect(promptAfterWiring).not.toContain("## Rules")
+	})
+
+	it("registers the rules block for baseline behaviours in the system prompt", async () => {
+		const pi = setupWired([baseline])
+		await pi.fire("session_start", {}, { cwd: "/tmp" })
+
+		const sp = buildSystemPrompt({
+			tools: [{ name: "read", description: "Read file contents" }],
+			env: testEnv,
+			contextFiles: [{ path: "/repo/AGENTS.md", content: "Project rule." }],
+			mode: "orchestrator",
+		})
+
 		expect(sp).toContain("## Rules")
 		expect(sp).toContain("Always do X.")
-		expect(sp?.startsWith("BASE")).toBe(true)
+		expect(sp.indexOf("Project rule.")).toBeLessThan(sp.indexOf("## Rules"))
+		expect(sp.indexOf("## Rules")).toBeLessThan(sp.indexOf("## Available Tools"))
 	})
 
 	it("delivers the body of a loaded triggered behaviour as a hidden message, exactly once", async () => {

--- a/src/extensions/behaviours/wiring.ts
+++ b/src/extensions/behaviours/wiring.ts
@@ -10,6 +10,7 @@
  */
 
 import type { ExtensionAPI, ExtensionContext } from "@earendil-works/pi-coding-agent"
+import { createSystemPromptBlocks } from "../prompt-construction/index.js"
 import { TriggerEngine } from "./engine.js"
 import { EvalEngine } from "./eval-engine.js"
 import { type ResolverIO, resolveSessionContext } from "./session-context.js"
@@ -42,7 +43,7 @@ export interface WireOptions {
 function buildRulesBlock(all: readonly Behaviour[]): string {
 	const baseline = all.filter((b) => b.kind === "baseline").map((b) => b.body.trim())
 	if (baseline.length === 0) return ""
-	return `\n\n${RULES_HEADER}\n\n${baseline.join("\n\n")}\n`
+	return `${RULES_HEADER}\n\n${baseline.join("\n\n")}`
 }
 
 function collectSessionSpecs(triggered: readonly TriggeredBehaviour[]): ProbeSpec[] {
@@ -179,8 +180,10 @@ export function wireBehaviours(pi: ExtensionAPI, behaviours: readonly Behaviour[
 	})
 
 	if (rulesBlock) {
-		pi.on("before_agent_start", async (event) => {
-			return { systemPrompt: event.systemPrompt + rulesBlock }
+		const blocks = createSystemPromptBlocks(pi, "behaviours")
+		blocks.register({
+			id: "rules",
+			render: () => rulesBlock.trim(),
 		})
 	}
 

--- a/src/extensions/mcp-adapter/index.test.ts
+++ b/src/extensions/mcp-adapter/index.test.ts
@@ -1,0 +1,76 @@
+import type { ExtensionAPI, ToolInfo } from "@earendil-works/pi-coding-agent"
+import { afterEach, describe, expect, it, vi } from "vitest"
+import { type EnvironmentInfo, buildSystemPrompt } from "../prompt-construction/system-prompt.js"
+import mcpAdapter from "./index.js"
+
+const testEnv: EnvironmentInfo = {
+	os: "Linux",
+	username: "testuser",
+	homeDir: "/home/testuser",
+	cwd: "/home/testuser/project",
+	documentsDir: "/home/testuser/project/.kimchi/docs",
+	currentTime: "2026-01-01T00:00:00.000Z",
+	localDate: "2026-01-01",
+	isGitRepo: false,
+}
+
+type Handler = (event: unknown, ctx: unknown) => unknown
+
+function makePi(): ExtensionAPI & { fireShutdown: () => Promise<void> } {
+	const handlers = new Map<string, Handler[]>()
+	const tools: ToolInfo[] = []
+	let activeTools: string[] = []
+	const pi = {
+		registerFlag: () => {},
+		registerCommand: () => {},
+		registerTool: (tool: ToolInfo) => {
+			tools.push(tool)
+			activeTools.push(tool.name)
+		},
+		on: (event: string, handler: Handler) => {
+			const list = handlers.get(event) ?? []
+			list.push(handler)
+			handlers.set(event, list)
+		},
+		getAllTools: () => tools,
+		getActiveTools: () => activeTools,
+		setActiveTools: (toolNames: string[]) => {
+			activeTools = toolNames
+		},
+		getFlag: () => undefined,
+		fireShutdown: async () => {
+			for (const handler of handlers.get("session_shutdown") ?? []) {
+				await handler({}, {})
+			}
+		},
+	}
+	return pi as unknown as ExtensionAPI & { fireShutdown: () => Promise<void> }
+}
+
+afterEach(() => {
+	vi.unstubAllEnvs()
+})
+
+describe("mcp adapter system prompt block", () => {
+	it("registers tool and MCP discovery instructions with the extension that owns mcp", async () => {
+		vi.stubEnv("MCP_DIRECT_TOOLS", "__none__")
+		const pi = makePi()
+		mcpAdapter(pi)
+
+		try {
+			const result = buildSystemPrompt({
+				pi,
+				tools: pi.getAllTools(),
+				env: testEnv,
+				mode: "orchestrator",
+			})
+
+			expect(result).toContain("## Tool and MCP Discovery")
+			expect(result).toContain('use mcp({ search: "query" })')
+			expect(result.indexOf("## Tool and MCP Discovery")).toBeLessThan(result.indexOf("## Available Tools"))
+			expect(result).toContain('<tool name="mcp">')
+		} finally {
+			await pi.fireShutdown()
+		}
+	})
+})

--- a/src/extensions/mcp-adapter/index.ts
+++ b/src/extensions/mcp-adapter/index.ts
@@ -5,6 +5,7 @@ import type { DirectToolSpec, ToolMetadata } from "./types.js"
 import { formatToolName } from "./types.js"
 import { type Component, Text } from "@earendil-works/pi-tui"
 import { registerToolCall, isToolExpanded } from "../../expand-state.js"
+import { createSystemPromptBlocks } from "../prompt-construction/index.js"
 import { authenticateServer, openMcpPanel, reconnectServers, showStatus, showTools } from "./commands.js"
 import { loadConfig } from "../../config.js"
 import { BM25_DEFAULTS, buildStrategy, buildToolEntries } from "./bm25.js"
@@ -27,6 +28,12 @@ import {
 } from "./proxy-modes.js"
 import type { McpExtensionState } from "./state.js"
 import { getConfigPathFromArgv, truncateAtWord } from "./utils.js"
+
+const TOOL_AND_MCP_DISCOVERY_PROMPT = `## Tool and MCP Discovery
+
+- Before resorting to web search, web fetch, or giving up on accessing external data, check your Available Tools list for a more direct way to get the information. MCP (Model Context Protocol) integrations often provide authenticated access to services like Jira, Confluence, GitHub, GitLab, and others that are inaccessible via unauthenticated web requests.
+- If you see an mcp tool in your tool list, use mcp({ search: "query" }) to discover what MCP servers and tools are available before assuming you have no way to access a service.
+- Prefer MCP tools over web_fetch for any service that requires authentication (Jira, Confluence, internal wikis, etc.). MCP tools already have credentials configured.`
 
 export default function mcpAdapter(pi: ExtensionAPI) {
 	let state: McpExtensionState | null = null
@@ -217,6 +224,11 @@ export default function mcpAdapter(pi: ExtensionAPI) {
 	pi.registerFlag("mcp-config", {
 		description: "Path to MCP config file",
 		type: "string",
+	})
+
+	createSystemPromptBlocks(pi, "mcp-adapter").register({
+		id: "tool-and-mcp-discovery",
+		render: () => TOOL_AND_MCP_DISCOVERY_PROMPT,
 	})
 
 	pi.on("session_start", async (_event, ctx) => {

--- a/src/extensions/permissions/index.ts
+++ b/src/extensions/permissions/index.ts
@@ -3,6 +3,7 @@ import type { Api, AssistantMessage, Model } from "@earendil-works/pi-ai"
 import type { ExtensionAPI, ExtensionContext, ToolCallEvent } from "@earendil-works/pi-coding-agent"
 import { isKeyRelease, matchesKey } from "@earendil-works/pi-tui"
 import { RST_FG, resolvedSemanticFg } from "../../ansi.js"
+import { createSystemPromptBlocks } from "../prompt-construction/index.js"
 import { resolveClassifierModel } from "./classifier-model.js"
 import { classifyToolCall } from "./classifier.js"
 import { registerCommands } from "./commands.js"
@@ -375,9 +376,13 @@ export default function permissionsExtension(pi: ExtensionAPI): void {
 		maybeShowYoloWarning(ctx, currentMode())
 	})
 
-	pi.on("before_agent_start", async (event): Promise<{ systemPrompt?: string }> => {
-		if (currentMode() !== "plan") return {}
-		return { systemPrompt: `${event.systemPrompt}\n\n${planModeSupplement.trim()}` }
+	const blocks = createSystemPromptBlocks(pi, "permissions")
+	blocks.register({
+		id: "plan-mode-supplement",
+		render: () => {
+			if (currentMode() !== "plan") return undefined
+			return planModeSupplement.trim()
+		},
 	})
 
 	// Reset plan-completion tracking on every new user input.

--- a/src/extensions/prompt-construction/index.ts
+++ b/src/extensions/prompt-construction/index.ts
@@ -1,0 +1,8 @@
+export {
+	createSystemPromptBlocks,
+	type RenderedSystemPromptBlock,
+	type SuppressibleSection,
+	type SystemPromptBlock,
+	type SystemPromptBlockContext,
+	type SystemPromptBlocksHandle,
+} from "./system-prompt-blocks.js"

--- a/src/extensions/prompt-construction/prompt-enrichment.test.ts
+++ b/src/extensions/prompt-construction/prompt-enrichment.test.ts
@@ -1,7 +1,9 @@
 import type { AssistantMessage, ToolResultMessage } from "@earendil-works/pi-ai"
+import type { ExtensionAPI, ToolInfo } from "@earendil-works/pi-coding-agent"
 import { describe, expect, it } from "vitest"
 import type { OrchestratorMessages } from "../orchestration/continuation-nudge.js"
-import { stripEmptyToolCalls } from "./prompt-enrichment.js"
+import promptEnrichmentExtension, { stripEmptyToolCalls } from "./prompt-enrichment.js"
+import { createToolVisibility } from "./tool-visibility.js"
 
 function makeUser(text: string): OrchestratorMessages[number] {
 	return { role: "user", content: [{ type: "text", text }], timestamp: Date.now() }
@@ -159,5 +161,85 @@ describe("stripEmptyToolCalls", () => {
 			expect((msg as AssistantMessage).role).toBe("assistant")
 			expect((msg as AssistantMessage).content).toHaveLength(1)
 		}
+	})
+})
+
+describe("prompt enrichment tool visibility", () => {
+	it("omits hidden tools from the rendered available tools section", async () => {
+		const handlers = new Map<string, (event: unknown, ctx: unknown) => Promise<unknown> | unknown>()
+		const tools = [
+			{ name: "read", description: "Read file contents" },
+			{ name: "bash", description: "Execute shell commands" },
+		] as ToolInfo[]
+		let activeTools = tools.map((tool) => tool.name)
+		const pi = {
+			registerFlag: () => {},
+			on: (event: string, handler: (event: unknown, ctx: unknown) => Promise<unknown> | unknown) => {
+				handlers.set(event, handler)
+			},
+			getAllTools: () => tools,
+			getActiveTools: () => activeTools,
+			setActiveTools: (toolNames: string[]) => {
+				activeTools = toolNames
+			},
+			getFlag: () => false,
+		} as unknown as ExtensionAPI
+
+		promptEnrichmentExtension([])(pi)
+		const visibility = createToolVisibility(pi)
+		visibility.disable(["bash"])
+
+		const beforeAgentStart = handlers.get("before_agent_start")
+		if (!beforeAgentStart) throw new Error("before_agent_start handler was not registered")
+
+		try {
+			const result = (await beforeAgentStart(
+				{},
+				{
+					cwd: "/tmp",
+					model: undefined,
+					hasUI: false,
+				},
+			)) as { systemPrompt: string }
+
+			expect(result.systemPrompt).toContain('<tool name="read">')
+			expect(result.systemPrompt).not.toContain('<tool name="bash">')
+		} finally {
+			visibility.enable(["bash"])
+		}
+	})
+
+	it("omits inactive tools from the rendered available tools section", async () => {
+		const handlers = new Map<string, (event: unknown, ctx: unknown) => Promise<unknown> | unknown>()
+		const tools = [
+			{ name: "read", description: "Read file contents" },
+			{ name: "bash", description: "Execute shell commands" },
+		] as ToolInfo[]
+		const pi = {
+			registerFlag: () => {},
+			on: (event: string, handler: (event: unknown, ctx: unknown) => Promise<unknown> | unknown) => {
+				handlers.set(event, handler)
+			},
+			getAllTools: () => tools,
+			getActiveTools: () => ["read"],
+			getFlag: () => false,
+		} as unknown as ExtensionAPI
+
+		promptEnrichmentExtension([])(pi)
+
+		const beforeAgentStart = handlers.get("before_agent_start")
+		if (!beforeAgentStart) throw new Error("before_agent_start handler was not registered")
+
+		const result = (await beforeAgentStart(
+			{},
+			{
+				cwd: "/tmp",
+				model: undefined,
+				hasUI: false,
+			},
+		)) as { systemPrompt: string }
+
+		expect(result.systemPrompt).toContain('<tool name="read">')
+		expect(result.systemPrompt).not.toContain('<tool name="bash">')
 	})
 })

--- a/src/extensions/prompt-construction/prompt-enrichment.ts
+++ b/src/extensions/prompt-construction/prompt-enrichment.ts
@@ -344,7 +344,8 @@ export default function (skillPaths: string[]) {
 		let cachedGitRemote: string | undefined | null = null
 
 		pi.on("before_agent_start", async (_event, ctx) => {
-			const tools = pi.getAllTools()
+			const activeToolNames = new Set(pi.getActiveTools())
+			const tools = pi.getAllTools().filter((tool) => activeToolNames.has(tool.name))
 			cachedContextFiles ??= loadProjectContextFiles(ctx.cwd)
 			if (cachedSkills === undefined) {
 				const allSkillPaths = [

--- a/src/extensions/prompt-construction/prompt-enrichment.ts
+++ b/src/extensions/prompt-construction/prompt-enrichment.ts
@@ -381,6 +381,7 @@ export default function (skillPaths: string[]) {
 			const mode: PromptMode = subagentMode ? "subagent" : multiModelEnabled ? "orchestrator" : "single"
 
 			const systemPrompt = buildSystemPrompt({
+				pi,
 				tools: tools as readonly ToolInfo[],
 				env,
 				contextFiles: cachedContextFiles,

--- a/src/extensions/prompt-construction/system-prompt-blocks.test.ts
+++ b/src/extensions/prompt-construction/system-prompt-blocks.test.ts
@@ -34,8 +34,9 @@ function makePi(): ExtensionAPI & { fireShutdown: () => void } {
 	return pi as unknown as ExtensionAPI & { fireShutdown: () => void }
 }
 
-function prompt(): string {
+function prompt(pi?: ExtensionAPI): string {
 	return buildSystemPrompt({
+		pi,
 		tools: testTools,
 		env: testEnv,
 		contextFiles: [{ path: "/repo/AGENTS.md", content: "Project rule." }],
@@ -59,7 +60,7 @@ describe("system prompt blocks", () => {
 		const bFirst = createSystemPromptBlocks(piA, "b")
 		bFirst.register({ id: "two", render: () => "## B Two" })
 		aFirst.register({ id: "one", render: () => "## A One" })
-		const first = prompt()
+		const first = prompt(piA)
 		piA.fireShutdown()
 
 		const piB = makePi()
@@ -67,7 +68,7 @@ describe("system prompt blocks", () => {
 		const aSecond = createSystemPromptBlocks(piB, "a")
 		aSecond.register({ id: "one", render: () => "## A One" })
 		bSecond.register({ id: "two", render: () => "## B Two" })
-		const second = prompt()
+		const second = prompt(piB)
 
 		expect(second).toBe(first)
 	})
@@ -82,7 +83,7 @@ describe("system prompt blocks", () => {
 		a.register({ id: "a", render: () => "## AA" })
 		z.register({ id: "a", render: () => "## ZA" })
 
-		const result = prompt()
+		const result = prompt(pi)
 		expect(result.indexOf("## AA")).toBeLessThan(result.indexOf("## AB"))
 		expect(result.indexOf("## AB")).toBeLessThan(result.indexOf("## ZA"))
 		expect(result.indexOf("## ZA")).toBeLessThan(result.indexOf("## ZB"))
@@ -97,7 +98,7 @@ describe("system prompt blocks", () => {
 			suppress: () => new Set(["orchestration"]),
 		})
 
-		const result = prompt()
+		const result = prompt(pi)
 		expect(result).not.toContain("inactive")
 		expect(result).toContain("Subagent delegation rules")
 	})
@@ -107,7 +108,7 @@ describe("system prompt blocks", () => {
 		const blocks = createSystemPromptBlocks(pi, "test")
 		blocks.register({ id: "empty", render: () => " \n\t " })
 
-		expect(prompt()).toBe(idlePrompt())
+		expect(prompt(pi)).toBe(idlePrompt())
 	})
 
 	it("skips a block whose render throws without failing the prompt build", () => {
@@ -122,7 +123,7 @@ describe("system prompt blocks", () => {
 		})
 		blocks.register({ id: "good", render: () => "## Good Block" })
 
-		const result = prompt()
+		const result = prompt(pi)
 		expect(result).toContain("## Good Block")
 		expect(result).not.toContain("bad-render")
 		expect(warn).toHaveBeenCalledWith("system-prompt-blocks: test/bad-render render failed: boom")
@@ -140,7 +141,7 @@ describe("system prompt blocks", () => {
 			},
 		})
 
-		const result = prompt()
+		const result = prompt(pi)
 		expect(result).toContain("## Bad Suppress Block")
 		expect(result).toContain("Subagent delegation rules")
 		expect(warn).toHaveBeenCalledWith("system-prompt-blocks: test/bad-suppress suppress failed: nope")
@@ -162,6 +163,7 @@ describe("system prompt blocks", () => {
 		})
 
 		const result = buildSystemPrompt({
+			pi,
 			tools: testTools,
 			env: testEnv,
 			contextFiles: [{ path: "/repo/AGENTS.md", content: "Project rule." }],
@@ -200,7 +202,7 @@ describe("system prompt blocks", () => {
 			suppress: () => new Set(["project-context"]),
 		})
 
-		const result = prompt()
+		const result = prompt(pi)
 		expect(result).toContain("## A Block")
 		expect(result).toContain("## B Block")
 		expect(result).not.toContain("Project rule.")
@@ -213,7 +215,7 @@ describe("system prompt blocks", () => {
 		const blocks = createSystemPromptBlocks(pi, "test")
 		blocks.register({ id: "frame", render: () => "## Frame\n\nUse this frame." })
 
-		const result = prompt()
+		const result = prompt(pi)
 		const project = result.indexOf("## Project Guidelines")
 		const frame = result.indexOf("## Frame")
 		const tools = result.indexOf("## Available Tools")
@@ -231,7 +233,7 @@ describe("system prompt blocks", () => {
 		blocks.register({ id: "a", render: () => "## First\n\nAlpha" })
 		blocks.register({ id: "b", render: () => "## Second\n\nBeta" })
 
-		const result = prompt()
+		const result = prompt(pi)
 		expect(result).toContain("Project rule.\n\n## First")
 		expect(result).toContain("Alpha\n\n## Second")
 		expect(result).toContain("Beta\n\n## Available Tools")
@@ -242,22 +244,37 @@ describe("system prompt blocks", () => {
 		const pi = makePi()
 		createSystemPromptBlocks(pi, "test").register({ id: "inactive", render: () => undefined })
 
-		expect(prompt()).toBe(before)
+		expect(prompt(pi)).toBe(before)
 	})
 
 	it("cleans up all blocks for a pi on session_shutdown", () => {
 		const pi = makePi()
 		createSystemPromptBlocks(pi, "test").register({ id: "one", render: () => "## One" })
-		expect(prompt()).toContain("## One")
+		expect(prompt(pi)).toContain("## One")
 
 		pi.fireShutdown()
 
-		expect(prompt()).not.toContain("## One")
+		expect(prompt(pi)).not.toContain("## One")
 		createSystemPromptBlocks(pi, "test").register({ id: "two", render: () => "## Two" })
-		expect(prompt()).toContain("## Two")
+		expect(prompt(pi)).toContain("## Two")
 	})
 
-	it("keeps registrations isolated across pi instances", () => {
+	it("renders only blocks registered to the pi building the prompt", () => {
+		const piA = makePi()
+		const piB = makePi()
+		createSystemPromptBlocks(piA, "a").register({ id: "one", render: () => "## Pi A Block" })
+		createSystemPromptBlocks(piB, "b").register({ id: "one", render: () => "## Pi B Block" })
+
+		const resultA = prompt(piA)
+		expect(resultA).toContain("## Pi A Block")
+		expect(resultA).not.toContain("## Pi B Block")
+
+		const resultB = prompt(piB)
+		expect(resultB).not.toContain("## Pi A Block")
+		expect(resultB).toContain("## Pi B Block")
+	})
+
+	it("keeps registrations isolated across pi instances after shutdown", () => {
 		const piA = makePi()
 		const piB = makePi()
 		createSystemPromptBlocks(piA, "a").register({ id: "one", render: () => "## Pi A Block" })
@@ -265,7 +282,7 @@ describe("system prompt blocks", () => {
 
 		piA.fireShutdown()
 
-		const result = prompt()
+		const result = prompt(piB)
 		expect(result).not.toContain("## Pi A Block")
 		expect(result).toContain("## Pi B Block")
 	})

--- a/src/extensions/prompt-construction/system-prompt-blocks.test.ts
+++ b/src/extensions/prompt-construction/system-prompt-blocks.test.ts
@@ -1,0 +1,272 @@
+import type { ExtensionAPI } from "@earendil-works/pi-coding-agent"
+import { afterEach, describe, expect, it, vi } from "vitest"
+import { createSystemPromptBlocks } from "./system-prompt-blocks.js"
+import { type EnvironmentInfo, buildSystemPrompt } from "./system-prompt.js"
+
+type ShutdownHandler = () => void
+
+const testEnv: EnvironmentInfo = {
+	os: "Linux",
+	username: "testuser",
+	homeDir: "/home/testuser",
+	cwd: "/home/testuser/project",
+	documentsDir: "/home/testuser/project/.kimchi/docs",
+	currentTime: "2026-01-01T00:00:00.000Z",
+	localDate: "2026-01-01",
+	isGitRepo: false,
+}
+
+const testTools = [{ name: "read", description: "Read file contents" }]
+
+const activePis: Array<{ fireShutdown: () => void }> = []
+
+function makePi(): ExtensionAPI & { fireShutdown: () => void } {
+	const shutdownHandlers: ShutdownHandler[] = []
+	const pi = {
+		on(event: string, handler: ShutdownHandler) {
+			if (event === "session_shutdown") shutdownHandlers.push(handler)
+		},
+		fireShutdown() {
+			for (const handler of shutdownHandlers) handler()
+		},
+	}
+	activePis.push(pi)
+	return pi as unknown as ExtensionAPI & { fireShutdown: () => void }
+}
+
+function prompt(): string {
+	return buildSystemPrompt({
+		tools: testTools,
+		env: testEnv,
+		contextFiles: [{ path: "/repo/AGENTS.md", content: "Project rule." }],
+		mode: "orchestrator",
+	})
+}
+
+function idlePrompt(): string {
+	return prompt()
+}
+
+afterEach(() => {
+	for (const pi of activePis.splice(0)) pi.fireShutdown()
+	vi.restoreAllMocks()
+})
+
+describe("system prompt blocks", () => {
+	it("produces byte-identical prompts when register call order changes", () => {
+		const piA = makePi()
+		const aFirst = createSystemPromptBlocks(piA, "a")
+		const bFirst = createSystemPromptBlocks(piA, "b")
+		bFirst.register({ id: "two", render: () => "## B Two" })
+		aFirst.register({ id: "one", render: () => "## A One" })
+		const first = prompt()
+		piA.fireShutdown()
+
+		const piB = makePi()
+		const bSecond = createSystemPromptBlocks(piB, "b")
+		const aSecond = createSystemPromptBlocks(piB, "a")
+		aSecond.register({ id: "one", render: () => "## A One" })
+		bSecond.register({ id: "two", render: () => "## B Two" })
+		const second = prompt()
+
+		expect(second).toBe(first)
+	})
+
+	it("renders active blocks in owner/id order regardless of registration order", () => {
+		const pi = makePi()
+		const z = createSystemPromptBlocks(pi, "z-owner")
+		const a = createSystemPromptBlocks(pi, "a-owner")
+
+		z.register({ id: "b", render: () => "## ZB" })
+		a.register({ id: "b", render: () => "## AB" })
+		a.register({ id: "a", render: () => "## AA" })
+		z.register({ id: "a", render: () => "## ZA" })
+
+		const result = prompt()
+		expect(result.indexOf("## AA")).toBeLessThan(result.indexOf("## AB"))
+		expect(result.indexOf("## AB")).toBeLessThan(result.indexOf("## ZA"))
+		expect(result.indexOf("## ZA")).toBeLessThan(result.indexOf("## ZB"))
+	})
+
+	it("treats render(undefined) as inactive and does not apply suppression", () => {
+		const pi = makePi()
+		const blocks = createSystemPromptBlocks(pi, "test")
+		blocks.register({
+			id: "inactive",
+			render: () => undefined,
+			suppress: () => new Set(["orchestration"]),
+		})
+
+		const result = prompt()
+		expect(result).not.toContain("inactive")
+		expect(result).toContain("Subagent delegation rules")
+	})
+
+	it("skips whitespace-only rendered content", () => {
+		const pi = makePi()
+		const blocks = createSystemPromptBlocks(pi, "test")
+		blocks.register({ id: "empty", render: () => " \n\t " })
+
+		expect(prompt()).toBe(idlePrompt())
+	})
+
+	it("skips a block whose render throws without failing the prompt build", () => {
+		const warn = vi.spyOn(console, "warn").mockImplementation(() => {})
+		const pi = makePi()
+		const blocks = createSystemPromptBlocks(pi, "test")
+		blocks.register({
+			id: "bad-render",
+			render: () => {
+				throw new Error("boom")
+			},
+		})
+		blocks.register({ id: "good", render: () => "## Good Block" })
+
+		const result = prompt()
+		expect(result).toContain("## Good Block")
+		expect(result).not.toContain("bad-render")
+		expect(warn).toHaveBeenCalledWith("system-prompt-blocks: test/bad-render render failed: boom")
+	})
+
+	it("keeps block content when suppress throws and treats suppression as empty", () => {
+		const warn = vi.spyOn(console, "warn").mockImplementation(() => {})
+		const pi = makePi()
+		const blocks = createSystemPromptBlocks(pi, "test")
+		blocks.register({
+			id: "bad-suppress",
+			render: () => "## Bad Suppress Block",
+			suppress: () => {
+				throw new Error("nope")
+			},
+		})
+
+		const result = prompt()
+		expect(result).toContain("## Bad Suppress Block")
+		expect(result).toContain("Subagent delegation rules")
+		expect(warn).toHaveBeenCalledWith("system-prompt-blocks: test/bad-suppress suppress failed: nope")
+	})
+
+	it("unions disjoint suppression from active blocks", () => {
+		const pi = makePi()
+		const a = createSystemPromptBlocks(pi, "a")
+		const b = createSystemPromptBlocks(pi, "b")
+		a.register({
+			id: "hide-core",
+			render: () => "## A Block",
+			suppress: () => new Set(["orchestration", "project-context"]),
+		})
+		b.register({
+			id: "hide-skills",
+			render: () => "## B Block",
+			suppress: () => new Set(["skills"]),
+		})
+
+		const result = buildSystemPrompt({
+			tools: testTools,
+			env: testEnv,
+			contextFiles: [{ path: "/repo/AGENTS.md", content: "Project rule." }],
+			skills: [
+				{
+					name: "deploy",
+					description: "Deploy app",
+					filePath: "/skills/deploy/SKILL.md",
+					baseDir: "/skills/deploy",
+					sourceInfo: { path: "/skills/deploy/SKILL.md", source: "local", scope: "project", origin: "top-level" },
+					disableModelInvocation: false,
+				},
+			],
+			mode: "orchestrator",
+		})
+
+		expect(result).toContain("## A Block")
+		expect(result).toContain("## B Block")
+		expect(result).not.toContain("Subagent delegation rules")
+		expect(result).not.toContain("Project rule.")
+		expect(result).not.toContain("available_skills")
+	})
+
+	it("suppression union is idempotent when multiple active blocks suppress the same section", () => {
+		const pi = makePi()
+		const a = createSystemPromptBlocks(pi, "a")
+		const b = createSystemPromptBlocks(pi, "b")
+		a.register({
+			id: "hide-project-a",
+			render: () => "## A Block",
+			suppress: () => new Set(["project-context"]),
+		})
+		b.register({
+			id: "hide-project-b",
+			render: () => "## B Block",
+			suppress: () => new Set(["project-context"]),
+		})
+
+		const result = prompt()
+		expect(result).toContain("## A Block")
+		expect(result).toContain("## B Block")
+		expect(result).not.toContain("Project rule.")
+		expect(result).toContain("Subagent delegation rules")
+		expect(result).toContain("## Available Tools")
+	})
+
+	it("places rendered blocks between project context and tools", () => {
+		const pi = makePi()
+		const blocks = createSystemPromptBlocks(pi, "test")
+		blocks.register({ id: "frame", render: () => "## Frame\n\nUse this frame." })
+
+		const result = prompt()
+		const project = result.indexOf("## Project Guidelines")
+		const frame = result.indexOf("## Frame")
+		const tools = result.indexOf("## Available Tools")
+
+		expect(project).toBeGreaterThan(-1)
+		expect(frame).toBeGreaterThan(-1)
+		expect(tools).toBeGreaterThan(-1)
+		expect(project).toBeLessThan(frame)
+		expect(frame).toBeLessThan(tools)
+	})
+
+	it("joins rendered blocks with blank lines and prepends a blank line before the first block", () => {
+		const pi = makePi()
+		const blocks = createSystemPromptBlocks(pi, "test")
+		blocks.register({ id: "a", render: () => "## First\n\nAlpha" })
+		blocks.register({ id: "b", render: () => "## Second\n\nBeta" })
+
+		const result = prompt()
+		expect(result).toContain("Project rule.\n\n## First")
+		expect(result).toContain("Alpha\n\n## Second")
+		expect(result).toContain("Beta\n\n## Available Tools")
+	})
+
+	it("matches the idle prompt when no blocks are active", () => {
+		const before = idlePrompt()
+		const pi = makePi()
+		createSystemPromptBlocks(pi, "test").register({ id: "inactive", render: () => undefined })
+
+		expect(prompt()).toBe(before)
+	})
+
+	it("cleans up all blocks for a pi on session_shutdown", () => {
+		const pi = makePi()
+		createSystemPromptBlocks(pi, "test").register({ id: "one", render: () => "## One" })
+		expect(prompt()).toContain("## One")
+
+		pi.fireShutdown()
+
+		expect(prompt()).not.toContain("## One")
+		createSystemPromptBlocks(pi, "test").register({ id: "two", render: () => "## Two" })
+		expect(prompt()).toContain("## Two")
+	})
+
+	it("keeps registrations isolated across pi instances", () => {
+		const piA = makePi()
+		const piB = makePi()
+		createSystemPromptBlocks(piA, "a").register({ id: "one", render: () => "## Pi A Block" })
+		createSystemPromptBlocks(piB, "b").register({ id: "one", render: () => "## Pi B Block" })
+
+		piA.fireShutdown()
+
+		const result = prompt()
+		expect(result).not.toContain("## Pi A Block")
+		expect(result).toContain("## Pi B Block")
+	})
+})

--- a/src/extensions/prompt-construction/system-prompt-blocks.ts
+++ b/src/extensions/prompt-construction/system-prompt-blocks.ts
@@ -75,18 +75,15 @@ interface PiRecord {
 }
 
 const recordsByPi = new WeakMap<ExtensionAPI, PiRecord>()
-const activeRecords = new Set<PiRecord>()
 
 function getRecord(pi: ExtensionAPI): PiRecord {
 	let record = recordsByPi.get(pi)
 	if (!record) {
 		record = { handles: new Set() }
 		recordsByPi.set(pi, record)
-		activeRecords.add(record)
 		const recordForHandler = record
 		pi.on("session_shutdown", () => {
 			recordsByPi.delete(pi)
-			activeRecords.delete(recordForHandler)
 			recordForHandler.handles.clear()
 		})
 	}
@@ -99,17 +96,18 @@ export function createSystemPromptBlocks(pi: ExtensionAPI, owner: string): Syste
 	return handle
 }
 
-export function renderSystemPromptBlocks(ctx: SystemPromptBlockContext): RenderedSystemPromptBlock[] {
+export function renderSystemPromptBlocks(pi: ExtensionAPI, ctx: SystemPromptBlockContext): RenderedSystemPromptBlock[] {
 	const rendered: RenderedSystemPromptBlock[] = []
-	for (const record of activeRecords) {
-		for (const handle of record.handles) {
-			rendered.push(...handle.render(ctx))
-		}
+	const record = recordsByPi.get(pi)
+	if (!record) return rendered
+	for (const handle of record.handles) {
+		rendered.push(...handle.render(ctx))
 	}
 	return rendered.sort((a, b) => {
-		const owner = a.owner.localeCompare(b.owner)
-		if (owner !== 0) return owner
-		const id = a.id.localeCompare(b.id)
-		return id
+		if (a.owner < b.owner) return -1
+		if (a.owner > b.owner) return 1
+		if (a.id < b.id) return -1
+		if (a.id > b.id) return 1
+		return 0
 	})
 }

--- a/src/extensions/prompt-construction/system-prompt-blocks.ts
+++ b/src/extensions/prompt-construction/system-prompt-blocks.ts
@@ -1,0 +1,115 @@
+import type { ExtensionAPI } from "@earendil-works/pi-coding-agent"
+import type { PromptMode } from "./system-prompt.js"
+
+export interface SystemPromptBlocksHandle {
+	register(block: SystemPromptBlock): void
+}
+
+export interface SystemPromptBlock {
+	id: string
+	render(ctx: SystemPromptBlockContext): string | undefined
+	suppress?(ctx: SystemPromptBlockContext): ReadonlySet<SuppressibleSection> | undefined
+}
+
+export type SuppressibleSection = "orchestration" | "phase-guidelines" | "project-context" | "skills"
+
+export interface SystemPromptBlockContext {
+	mode: PromptMode
+}
+
+export interface RenderedSystemPromptBlock {
+	owner: string
+	id: string
+	content: string
+	suppress: ReadonlySet<SuppressibleSection>
+}
+
+class BlocksHandle implements SystemPromptBlocksHandle {
+	private readonly blocks = new Map<string, SystemPromptBlock>()
+
+	constructor(
+		readonly pi: ExtensionAPI,
+		readonly owner: string,
+	) {}
+
+	register(block: SystemPromptBlock): void {
+		this.blocks.set(block.id, block)
+	}
+
+	render(ctx: SystemPromptBlockContext): RenderedSystemPromptBlock[] {
+		const rendered: RenderedSystemPromptBlock[] = []
+		for (const block of this.blocks.values()) {
+			let rawContent: string | undefined
+			try {
+				rawContent = block.render(ctx)
+			} catch (err) {
+				console.warn(`system-prompt-blocks: ${this.owner}/${block.id} render failed: ${formatError(err)}`)
+				continue
+			}
+			if (rawContent === undefined) continue
+			const content = rawContent.trim()
+			if (content === "") continue
+			let suppress: ReadonlySet<SuppressibleSection> = new Set()
+			try {
+				suppress = block.suppress?.(ctx) ?? suppress
+			} catch (err) {
+				console.warn(`system-prompt-blocks: ${this.owner}/${block.id} suppress failed: ${formatError(err)}`)
+			}
+			rendered.push({
+				owner: this.owner,
+				id: block.id,
+				content,
+				suppress,
+			})
+		}
+		return rendered
+	}
+}
+
+function formatError(err: unknown): string {
+	return err instanceof Error ? err.message : String(err)
+}
+
+interface PiRecord {
+	handles: Set<BlocksHandle>
+}
+
+const recordsByPi = new WeakMap<ExtensionAPI, PiRecord>()
+const activeRecords = new Set<PiRecord>()
+
+function getRecord(pi: ExtensionAPI): PiRecord {
+	let record = recordsByPi.get(pi)
+	if (!record) {
+		record = { handles: new Set() }
+		recordsByPi.set(pi, record)
+		activeRecords.add(record)
+		const recordForHandler = record
+		pi.on("session_shutdown", () => {
+			recordsByPi.delete(pi)
+			activeRecords.delete(recordForHandler)
+			recordForHandler.handles.clear()
+		})
+	}
+	return record
+}
+
+export function createSystemPromptBlocks(pi: ExtensionAPI, owner: string): SystemPromptBlocksHandle {
+	const handle = new BlocksHandle(pi, owner)
+	getRecord(pi).handles.add(handle)
+	return handle
+}
+
+export function renderSystemPromptBlocks(ctx: SystemPromptBlockContext): RenderedSystemPromptBlock[] {
+	const rendered: RenderedSystemPromptBlock[] = []
+	for (const record of activeRecords) {
+		for (const handle of record.handles) {
+			rendered.push(...handle.render(ctx))
+		}
+	}
+	return rendered.sort((a, b) => {
+		const owner = a.owner.localeCompare(b.owner)
+		if (owner !== 0) return owner
+		const id = a.id.localeCompare(b.id)
+		return id
+	})
+}

--- a/src/extensions/prompt-construction/system-prompt.test.ts
+++ b/src/extensions/prompt-construction/system-prompt.test.ts
@@ -80,6 +80,17 @@ describe("buildSystemPrompt", () => {
 			expect(result).toContain('<tool name="subagent">')
 		})
 
+		it("does not include phase tagging instructions without the tags extension", () => {
+			const result = buildSystemPrompt({
+				tools,
+				env: testEnv,
+				mode: "orchestrator",
+			})
+
+			expect(result).not.toContain("Phase Tagging for Analytics")
+			expect(result).not.toContain("You must call `set_phase`")
+		})
+
 		it("handles empty tools list", () => {
 			const result = buildSystemPrompt({
 				tools: [],

--- a/src/extensions/prompt-construction/system-prompt.test.ts
+++ b/src/extensions/prompt-construction/system-prompt.test.ts
@@ -265,7 +265,7 @@ describe("buildSystemPrompt", () => {
 			expect(result).toContain("Subagent response protocol")
 			expect(result).toContain('{"summary":')
 			expect(result).toContain("Factual Accuracy")
-			expect(result).toContain("Tool and MCP Discovery")
+			expect(result).not.toContain("Tool and MCP Discovery")
 		})
 
 		it("does not contain orchestration instructions", () => {

--- a/src/extensions/prompt-construction/system-prompt.ts
+++ b/src/extensions/prompt-construction/system-prompt.ts
@@ -125,11 +125,6 @@ const FACTUAL_ACCURACY = `
 - "I don't know" is a valid answer. When requirements, specifications, or factual details are not available through your tools or the user's messages, state that clearly and ask the user to provide them. Do not fill the gap with plausible-sounding content.
 - Distinguish what you found from what you assume. If you must reason about something uncertain, label it explicitly as an assumption and ask the user to confirm before acting on it.`
 
-const TOOL_DISCOVERY = `
-- Before resorting to web search, web fetch, or giving up on accessing external data, check your Available Tools list for a more direct way to get the information. MCP (Model Context Protocol) integrations often provide authenticated access to services like Jira, Confluence, GitHub, GitLab, and others that are inaccessible via unauthenticated web requests.
-- If you see an mcp tool in your tool list, use mcp({ search: "query" }) to discover what MCP servers and tools are available before assuming you have no way to access a service.
-- Prefer MCP tools over web_fetch for any service that requires authentication (Jira, Confluence, internal wikis, etc.). MCP tools already have credentials configured.`
-
 function buildPrompt(parts: PromptParts): string {
 	const sections: string[] = []
 
@@ -139,7 +134,6 @@ function buildPrompt(parts: PromptParts): string {
 	sections.push(`## Documents\n\n${DOCUMENTS_SECTION}`)
 	sections.push(`## Guidelines\n\n${CORE_GUIDELINES}`)
 	sections.push(`## Factual Accuracy\n\n${FACTUAL_ACCURACY}`)
-	sections.push(`## Tool and MCP Discovery\n\n${TOOL_DISCOVERY}`)
 
 	if (!parts.suppressed.has("orchestration") && parts.orchestrationSection) {
 		sections.push(parts.orchestrationSection)

--- a/src/extensions/prompt-construction/system-prompt.ts
+++ b/src/extensions/prompt-construction/system-prompt.ts
@@ -120,10 +120,6 @@ const CORE_GUIDELINES = `- Be concise in your responses. Do not restate what you
 - After every tool result, ALWAYS produce text — either the next tool call with explicit reasoning, or a final summary. Never re-issue the same tool call after a successful result.
 - Never emit tool calls with empty names, blank IDs, or malformed arguments. If a tool call fails to advance the task after 3 attempts, stop calling tools, summarize what is not working, and reassess in plain text before continuing.`
 
-const PHASE_TAGGING = `
-You must call \`set_phase\` before every block of work. Never take an action without the correct phase being set first. Use one of \`explore\`, \`research\`, \`plan\`, \`build\`, or \`review\` strictly matching current work type.
-The session starts in \`explore\` phase by default. Call \`set_phase\` immediately when your work type changes. Only one phase is active at a time — the most recent call wins.`
-
 const FACTUAL_ACCURACY = `
 - Never guess, assume, or fabricate information. Every claim you make must be backed by data you concretely obtained during this session. Do NOT escalate to escalation for minor issues or blame the user for poor request phrasing.
 - "I don't know" is a valid answer. When requirements, specifications, or factual details are not available through your tools or the user's messages, state that clearly and ask the user to provide them. Do not fill the gap with plausible-sounding content.
@@ -143,7 +139,6 @@ function buildPrompt(parts: PromptParts): string {
 	sections.push(`## Documents\n\n${DOCUMENTS_SECTION}`)
 	sections.push(`## Guidelines\n\n${CORE_GUIDELINES}`)
 	sections.push(`## Factual Accuracy\n\n${FACTUAL_ACCURACY}`)
-	sections.push(`## Phase Tagging for Analytics\n\n${PHASE_TAGGING}`)
 	sections.push(`## Tool and MCP Discovery\n\n${TOOL_DISCOVERY}`)
 
 	if (!parts.suppressed.has("orchestration") && parts.orchestrationSection) {

--- a/src/extensions/prompt-construction/system-prompt.ts
+++ b/src/extensions/prompt-construction/system-prompt.ts
@@ -14,6 +14,7 @@ import type { ModelRegistry } from "../orchestration/model-registry/index.js"
 import type { Phase } from "../orchestration/model-registry/types.js"
 import { resolveOrchestrationInstructions } from "../orchestration/orchestration-instructions.js"
 import type { ContextFile } from "./context-files.js"
+import { type SuppressibleSection, renderSystemPromptBlocks } from "./system-prompt-blocks.js"
 
 export interface EnvironmentInfo {
 	os: string
@@ -67,6 +68,11 @@ export function buildSystemPrompt(options: SystemPromptBuildOptions): string {
 	})
 
 	const phaseSection = buildPhaseGuidelinesSection(currentModelId, currentPhase, registry)
+	const blocks = renderSystemPromptBlocks({ mode })
+	const suppressed = new Set<SuppressibleSection>()
+	for (const block of blocks) {
+		for (const section of block.suppress) suppressed.add(section)
+	}
 
 	return buildPrompt({
 		mode,
@@ -76,6 +82,8 @@ export function buildSystemPrompt(options: SystemPromptBuildOptions): string {
 		skillsSection,
 		orchestrationSection,
 		phaseSection,
+		systemPromptBlocks: blocks.map((block) => block.content).join("\n\n"),
+		suppressed,
 	})
 }
 
@@ -91,6 +99,8 @@ interface PromptParts {
 	skillsSection: string
 	orchestrationSection: string
 	phaseSection: string
+	systemPromptBlocks: string
+	suppressed: ReadonlySet<SuppressibleSection>
 }
 
 const BASE_INSTRUCTIONS =
@@ -135,21 +145,25 @@ function buildPrompt(parts: PromptParts): string {
 	sections.push(`## Phase Tagging for Analytics\n\n${PHASE_TAGGING}`)
 	sections.push(`## Tool and MCP Discovery\n\n${TOOL_DISCOVERY}`)
 
-	if (parts.orchestrationSection) {
+	if (!parts.suppressed.has("orchestration") && parts.orchestrationSection) {
 		sections.push(parts.orchestrationSection)
 	}
 
-	if (parts.phaseSection) {
+	if (!parts.suppressed.has("phase-guidelines") && parts.phaseSection) {
 		sections.push(parts.phaseSection)
 	}
 
-	if (parts.projectContext) {
+	if (!parts.suppressed.has("project-context") && parts.projectContext) {
 		sections.push(parts.projectContext)
+	}
+
+	if (parts.systemPromptBlocks) {
+		sections.push(parts.systemPromptBlocks)
 	}
 
 	sections.push(parts.toolsSection)
 
-	if (parts.skillsSection) {
+	if (!parts.suppressed.has("skills") && parts.skillsSection) {
 		sections.push(parts.skillsSection)
 	}
 

--- a/src/extensions/prompt-construction/system-prompt.ts
+++ b/src/extensions/prompt-construction/system-prompt.ts
@@ -8,7 +8,7 @@
  * All mode-specific content lives in orchestration-instructions.ts.
  */
 
-import { type Skill, formatSkillsForPrompt } from "@earendil-works/pi-coding-agent"
+import { type ExtensionAPI, type Skill, formatSkillsForPrompt } from "@earendil-works/pi-coding-agent"
 import { buildPhaseGuidelinesSection } from "../orchestration/model-registry/guidelines/guidelines-resolver.js"
 import type { ModelRegistry } from "../orchestration/model-registry/index.js"
 import type { Phase } from "../orchestration/model-registry/types.js"
@@ -37,6 +37,7 @@ export interface ToolInfo {
 export type PromptMode = "orchestrator" | "subagent" | "single"
 
 export interface SystemPromptBuildOptions {
+	pi?: ExtensionAPI
 	tools: readonly ToolInfo[]
 	env: EnvironmentInfo
 	contextFiles?: readonly ContextFile[]
@@ -50,7 +51,7 @@ export interface SystemPromptBuildOptions {
 const SUBAGENT_TOOL_NAME = "subagent"
 
 export function buildSystemPrompt(options: SystemPromptBuildOptions): string {
-	const { tools, env, contextFiles, skills, currentModelId, currentPhase, registry, mode } = options
+	const { pi, tools, env, contextFiles, skills, currentModelId, currentPhase, registry, mode } = options
 
 	const effectiveTools = mode === "subagent" ? tools.filter((t) => t.name !== SUBAGENT_TOOL_NAME) : tools
 
@@ -68,7 +69,7 @@ export function buildSystemPrompt(options: SystemPromptBuildOptions): string {
 	})
 
 	const phaseSection = buildPhaseGuidelinesSection(currentModelId, currentPhase, registry)
-	const blocks = renderSystemPromptBlocks({ mode })
+	const blocks = pi ? renderSystemPromptBlocks(pi, { mode }) : []
 	const suppressed = new Set<SuppressibleSection>()
 	for (const block of blocks) {
 		for (const section of block.suppress) suppressed.add(section)

--- a/src/extensions/prompt-construction/tool-visibility.test.ts
+++ b/src/extensions/prompt-construction/tool-visibility.test.ts
@@ -1,0 +1,170 @@
+import type { ExtensionAPI, ToolInfo } from "@earendil-works/pi-coding-agent"
+import { describe, expect, it } from "vitest"
+import { createToolVisibility } from "./tool-visibility.js"
+
+type ShutdownHandler = () => void
+
+function makePi(toolNames: string[]): ExtensionAPI & { active: string[]; fireShutdown: () => void } {
+	const tools = toolNames.map((name) => ({ name }) as ToolInfo)
+	const shutdownHandlers: ShutdownHandler[] = []
+	const state = {
+		active: [...toolNames],
+		fireShutdown: () => {
+			for (const h of shutdownHandlers) h()
+		},
+		getAllTools: () => tools,
+		getActiveTools() {
+			return state.active
+		},
+		setActiveTools(names: string[]) {
+			state.active = names
+		},
+		on(event: string, handler: ShutdownHandler) {
+			if (event === "session_shutdown") shutdownHandlers.push(handler)
+		},
+	}
+	return state as unknown as ExtensionAPI & { active: string[]; fireShutdown: () => void }
+}
+
+describe("tool-visibility", () => {
+	it("disable removes named tools from pi.getActiveTools, enable restores them", () => {
+		const pi = makePi(["read", "bash", "edit"])
+		const v = createToolVisibility(pi)
+
+		v.disable(["bash"])
+		expect(pi.active).toEqual(["read", "edit"])
+
+		v.enable(["bash"])
+		expect(pi.active.sort()).toEqual(["bash", "edit", "read"])
+	})
+
+	it("disable is idempotent for a handle that already hid the tool", () => {
+		const pi = makePi(["read", "bash"])
+		const v = createToolVisibility(pi)
+
+		v.disable(["bash"])
+		v.disable(["bash"])
+		expect(pi.active).toEqual(["read"])
+
+		v.enable(["bash"])
+		expect(pi.active.sort()).toEqual(["bash", "read"])
+	})
+
+	it("enable is a no-op for names this handle never hid", () => {
+		const pi = makePi(["read", "bash"])
+		const v = createToolVisibility(pi)
+
+		v.enable(["bash"])
+		expect(pi.active).toEqual(["read", "bash"])
+	})
+
+	it("two handles refcount: tool stays hidden until every handle releases it", () => {
+		const pi = makePi(["bash"])
+		const extA = createToolVisibility(pi)
+		const extB = createToolVisibility(pi)
+
+		extA.disable(["bash"])
+		extB.disable(["bash"])
+		expect(pi.active).toEqual([])
+
+		extA.enable(["bash"])
+		expect(pi.active).toEqual([]) // extB still hides it
+
+		extB.enable(["bash"])
+		expect(pi.active).toEqual(["bash"])
+	})
+
+	it("one handle's enable cannot release another handle's hide", () => {
+		const pi = makePi(["bash"])
+		const extA = createToolVisibility(pi)
+		const extB = createToolVisibility(pi)
+
+		extA.disable(["bash"])
+		extB.enable(["bash"]) // extB never hid it — no-op
+		expect(pi.active).toEqual([])
+	})
+
+	it("isolates state across sessions", () => {
+		const piA = makePi(["bash"])
+		const piB = makePi(["bash"])
+
+		createToolVisibility(piA).disable(["bash"])
+
+		expect(piA.active).toEqual([])
+		expect(piB.active).toEqual(["bash"])
+	})
+
+	it("enable can broaden active beyond the baseline (reactivation from baseline inactive)", () => {
+		// Registry has both tools, but bash starts excluded from the active set —
+		// e.g. a peer extension narrowed it. This test documents the deliberate
+		// invariant that disable+enable restores bash to active even though it
+		// was never in the baseline active set.
+		const pi = makePi(["read", "bash"])
+		pi.active = ["read"]
+		const v = createToolVisibility(pi)
+
+		v.disable(["bash"])
+		expect(pi.active).toEqual(["read"])
+
+		v.enable(["bash"])
+		expect(pi.active.sort()).toEqual(["bash", "read"])
+	})
+
+	it("two handles starting from baseline inactive: last enable restores bash", () => {
+		const pi = makePi(["read", "bash"])
+		pi.active = ["read"]
+		const extA = createToolVisibility(pi)
+		const extB = createToolVisibility(pi)
+
+		extA.disable(["bash"])
+		extB.disable(["bash"])
+		expect(pi.active).toEqual(["read"])
+
+		extA.enable(["bash"])
+		expect(pi.active).toEqual(["read"]) // extB still disables it
+
+		extB.enable(["bash"])
+		expect(pi.active.sort()).toEqual(["bash", "read"])
+	})
+
+	it("after shutdown, a new handle on the same pi sees a fresh registry", () => {
+		const pi = makePi(["read", "bash"])
+		createToolVisibility(pi).disable(["bash"])
+		expect(pi.active).toEqual(["read"])
+
+		pi.fireShutdown()
+
+		// Real pi-mono discards the pi entirely and creates a new one; the test
+		// approximates this by resetting active to the baseline so we can
+		// observe handleB's operations independently of A's prior writes.
+		pi.active = ["read", "bash"]
+
+		const handleB = createToolVisibility(pi)
+
+		// B owns nothing — A's prior disable left no record in the registry.
+		handleB.enable(["bash"])
+		expect(pi.active).toEqual(["read", "bash"])
+
+		// B can disable/enable from a clean slate.
+		handleB.disable(["bash"])
+		expect(pi.active).toEqual(["read"])
+
+		handleB.enable(["bash"])
+		expect(pi.active.sort()).toEqual(["bash", "read"])
+	})
+
+	it("session_shutdown drops the per-session map for that pi only", () => {
+		const piA = makePi(["bash"])
+		const piB = makePi(["bash"])
+
+		createToolVisibility(piA).disable(["bash"])
+		const handleB = createToolVisibility(piB)
+		handleB.disable(["bash"])
+
+		piA.fireShutdown()
+
+		// piB's state is intact; its handle can still release normally.
+		handleB.enable(["bash"])
+		expect(piB.active).toEqual(["bash"])
+	})
+})

--- a/src/extensions/prompt-construction/tool-visibility.ts
+++ b/src/extensions/prompt-construction/tool-visibility.ts
@@ -1,0 +1,109 @@
+import type { ExtensionAPI } from "@earendil-works/pi-coding-agent"
+
+/**
+ * Cooperative tool visibility registry.
+ *
+ * Visibility is vote-based: each handle represents one extension's vote.
+ * Calling disable(name) records this handle's vote to hide the tool. Calling
+ * enable(name) removes only this handle's vote. A tool is visible iff no handle
+ * currently votes to hide it.
+ *
+ * This intentionally does not preserve a previous active-tool snapshot. Once
+ * the last disable vote is removed, the tool is activated again. During the
+ * migration period, direct pi.setActiveTools callers may still coexist with
+ * this registry; the intended steady state is that tool visibility is centrally
+ * derived from these votes.
+ */
+export interface ToolVisibilityAPI {
+	/** Add this extension's vote to disable the named tools. */
+	disable(names: readonly string[]): void
+
+	/** Remove this extension's disable vote. The tool is enabled only if no votes remain. */
+	enable(names: readonly string[]): void
+}
+
+// Per-tool aggregation record. Holds the set of handles that currently vote to
+// disable this tool. A tool is disabled iff this set is non-empty.
+class ToolVisibility {
+	private readonly disabledBy = new Set<Handle>()
+
+	/** Record a disable vote from this handle. Returns true if this is the first vote. */
+	disable(by: Handle): boolean {
+		if (this.disabledBy.has(by)) return false
+		const wasEnabled = this.disabledBy.size === 0
+		this.disabledBy.add(by)
+		return wasEnabled
+	}
+
+	/** Remove this handle's disable vote. Returns true if no votes remain. */
+	enable(by: Handle): boolean {
+		if (!this.disabledBy.has(by)) return false
+		this.disabledBy.delete(by)
+		return this.disabledBy.size === 0
+	}
+}
+
+// Per-extension handle. Each call to createToolVisibility(pi) returns a fresh
+// vote identity while sharing the session-level per-tool aggregation map.
+class Handle implements ToolVisibilityAPI {
+	private readonly owned = new Set<string>()
+	private readonly tools: Map<string, ToolVisibility>
+
+	constructor(private readonly pi: ExtensionAPI) {
+		let m = toolsByPi.get(pi)
+		if (!m) {
+			m = new Map()
+			toolsByPi.set(pi, m)
+			// Drop the per-session map on shutdown. We never touch `pi` from
+			// inside the handler — pi-mono marks the runtime stale at this
+			// point (packages/coding-agent/src/core/agent-session.ts:751) and
+			// any pi.* call would throw.
+			pi.on("session_shutdown", () => {
+				toolsByPi.delete(pi)
+			})
+		}
+		this.tools = m
+	}
+
+	disable(names: readonly string[]): void {
+		const newlyHidden: string[] = []
+		for (const name of names) {
+			if (this.owned.has(name)) continue
+			this.owned.add(name)
+			let tool = this.tools.get(name)
+			if (!tool) {
+				tool = new ToolVisibility()
+				this.tools.set(name, tool)
+			}
+			if (tool.disable(this)) newlyHidden.push(name)
+		}
+		if (newlyHidden.length === 0) return
+		const current = new Set(this.pi.getActiveTools())
+		for (const n of newlyHidden) current.delete(n)
+		this.pi.setActiveTools([...current])
+	}
+
+	enable(names: readonly string[]): void {
+		const fullyShown: string[] = []
+		for (const name of names) {
+			if (!this.owned.has(name)) continue
+			this.owned.delete(name)
+			const tool = this.tools.get(name)
+			if (!tool) continue
+			if (tool.enable(this)) {
+				this.tools.delete(name)
+				fullyShown.push(name)
+			}
+		}
+		if (fullyShown.length === 0) return
+		const current = new Set(this.pi.getActiveTools())
+		for (const n of fullyShown) current.add(n)
+		this.pi.setActiveTools([...current])
+	}
+}
+
+const toolsByPi = new WeakMap<ExtensionAPI, Map<string, ToolVisibility>>()
+
+export function createToolVisibility(pi: ExtensionAPI): ToolVisibilityAPI {
+	return new Handle(pi)
+}

--- a/src/extensions/tags.test.ts
+++ b/src/extensions/tags.test.ts
@@ -1,8 +1,38 @@
 import { mkdtempSync, rmSync, writeFileSync } from "node:fs"
 import { tmpdir } from "node:os"
 import { join } from "node:path"
+import type { ExtensionAPI } from "@earendil-works/pi-coding-agent"
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
-import { TagManager, isValidTag, parseTag } from "./tags.js"
+import { type EnvironmentInfo, buildSystemPrompt } from "./prompt-construction/system-prompt.js"
+import tagsExtension, { TagManager, isValidTag, parseTag } from "./tags.js"
+
+const testEnv: EnvironmentInfo = {
+	os: "Linux",
+	username: "testuser",
+	homeDir: "/home/testuser",
+	cwd: "/home/testuser/project",
+	documentsDir: "/home/testuser/project/.kimchi/docs",
+	currentTime: "2026-01-01T00:00:00.000Z",
+	localDate: "2026-01-01",
+	isGitRepo: false,
+}
+
+type Handler = (event: unknown, ctx: unknown) => unknown
+
+function makePi(): ExtensionAPI & { fireShutdown: () => void } {
+	const shutdownHandlers: Array<() => void> = []
+	const pi = {
+		registerCommand: () => {},
+		registerTool: () => {},
+		on: (event: string, handler: Handler) => {
+			if (event === "session_shutdown") shutdownHandlers.push(handler as () => void)
+		},
+		fireShutdown: () => {
+			for (const handler of shutdownHandlers) handler()
+		},
+	}
+	return pi as unknown as ExtensionAPI & { fireShutdown: () => void }
+}
 
 describe("isValidTag", () => {
 	const validCases = [
@@ -57,6 +87,31 @@ describe("parseTag", () => {
 			expect(parseTag(tag)).toEqual(expected)
 		})
 	}
+})
+
+describe("tags system prompt block", () => {
+	it("registers phase tagging instructions with the extension that owns set_phase", () => {
+		const pi = makePi()
+		tagsExtension(pi)
+
+		try {
+			const result = buildSystemPrompt({
+				pi,
+				tools: [
+					{ name: "read", description: "Read file contents" },
+					{ name: "set_phase", description: "Set the current work phase" },
+				],
+				env: testEnv,
+				mode: "orchestrator",
+			})
+
+			expect(result).toContain("## Phase Tagging for Analytics")
+			expect(result).toContain("You must call `set_phase` before every block of work")
+			expect(result.indexOf("## Phase Tagging for Analytics")).toBeLessThan(result.indexOf("## Available Tools"))
+		} finally {
+			pi.fireShutdown()
+		}
+	})
 })
 
 describe("TagManager persistence", () => {

--- a/src/extensions/tags.ts
+++ b/src/extensions/tags.ts
@@ -22,6 +22,7 @@ import type {
 } from "@earendil-works/pi-coding-agent"
 import { Container, Text } from "@earendil-works/pi-tui"
 import { Type } from "typebox"
+import { createSystemPromptBlocks } from "./prompt-construction/index.js"
 
 // ─── Constants ───────────────────────────────────────────────────────────────
 
@@ -49,6 +50,11 @@ const TAG_COLORS: ThemeColor[] = ["accent", "mdLink", "success", "warning"]
 // Valid phases for phase tracking
 const VALID_PHASES = ["explore", "plan", "build", "review", "research"] as const
 type Phase = (typeof VALID_PHASES)[number]
+
+const PHASE_TAGGING_PROMPT = `## Phase Tagging for Analytics
+
+You must call \`set_phase\` before every block of work. Never take an action without the correct phase being set first. Use one of \`explore\`, \`research\`, \`plan\`, \`build\`, or \`review\` strictly matching current work type.
+The session starts in \`explore\` phase by default. Call \`set_phase\` immediately when your work type changes. Only one phase is active at a time — the most recent call wins.`
 
 export function isValidPhase(phase: string): phase is Phase {
 	return VALID_PHASES.includes(phase as Phase)
@@ -591,6 +597,11 @@ export default function tagsExtension(pi: ExtensionAPI) {
 			const label = theme.bold(theme.fg("toolTitle", `Phase changed: ${phase}`))
 			return new Text(dash + label, 0, 0)
 		},
+	})
+
+	createSystemPromptBlocks(pi, "tags").register({
+		id: "phase-tagging",
+		render: () => PHASE_TAGGING_PROMPT,
 	})
 
 	// Initialize footer status and default phase on session start


### PR DESCRIPTION
# Why

Kimchi extensions need to coordinate prompt and tool changes without stepping on each other.

Previously, tool management relied on `pi.setActiveTools(...)`, which replaces the active tool list for the whole session. That makes extensions responsible for preserving everyone else’s choices, and it creates bugs when two extensions want to hide the same tool but one later restores it.

Prompt management had a similar problem: extensions appended raw strings to `systemPrompt` in `before_agent_start`. That made ordering implicit, made suppression difficult, and encouraged each extension to mutate the final prompt string directly.

This PR adds cooperative APIs for both cases. Ferment will use these APIs in a follow-up PR.

# What

## Tool Visibility API

Adds `createToolVisibility(pi)`, which lets each extension vote to disable or enable tools it cares about.

A tool is active only when no extension currently votes to disable it. This means overlapping disables compose correctly: if extension A and extension B both disable `bash`, and A later enables it, `bash` stays disabled until B also enables it.

This replaces “one extension rewrites the global active tool list” with reference-counted, per-extension ownership.

## System Prompt Blocks API

Adds `createSystemPromptBlocks(pi, owner)`, which lets extensions register owned prompt blocks.

Each block provides:

- `id`
- `render(ctx)`, which decides per prompt build whether the block is active and what content it contributes
- optional `suppress(ctx)`, which can remove named core prompt sections such as orchestration, phase guidelines,
project context, or skills

Blocks are rendered deterministically by `(owner, id)` and placed between project context and the available tools
section, so extension framing appears before the model reads the tool catalog.

## Migrations

Migrates two existing prompt appenders to the new block API:

- permissions plan-mode supplement
- behaviours baseline rules

## Behavioral Change

The system prompt now lists only active tools, not every registered tool. This makes the prompt match what the model
can actually call.

---
### Kimchi Summary
### What changed
Introduces a centralized system-prompt block registry and cooperative tool-visibility controls. Extensions now register declarative prompt blocks instead of mutating `systemPrompt` strings via `before_agent_start`, and the prompt builder renders only tools currently marked as active.

### Why
String concatenation in `before_agent_start` made prompt ordering and suppression brittle. Centralizing block registration and tool visibility gives extensions a predictable, conflict-free way to inject rules and hide tools.

### Key changes
- `src/extensions/prompt-construction/system-prompt-blocks.ts` (+ `.test.ts`): Added `createSystemPromptBlocks(pi, owner)` API. Extensions register blocks with `id`, `render`, and optional `suppress` to inject content and omit default sections (`orchestration`, `phase-guidelines`, `project-context`, `skills`).
- `src/extensions/prompt-construction/tool-visibility.ts` (+ `.test.ts`): Added `createToolVisibility(pi)` API. Extensions vote to `disable` or `enable` tools; only tools with no active hide votes remain in `pi.getActiveTools()`.
- `src/extensions/prompt-construction/system-prompt.ts`: Updated `buildSystemPrompt` to render registered blocks via `renderSystemPromptBlocks` and place them between project context and available tools, while respecting suppression flags.
- `src/extensions/prompt-construction/prompt-enrichment.ts`: Filters the available-tools list to only tools present in `pi.getActiveTools()`.
- `src/extensions/behaviours/wiring.ts`: Replaced `before_agent_start` string appending with `createSystemPromptBlocks(...).register(...)` for baseline behaviour rules.
- `src/extensions/permissions/index.ts`: Replaced `before_agent_start` string appending with `createSystemPromptBlocks(...).register(...)` for the plan-mode supplement.

### Impact
- Prompt block order is deterministic, sorted lexicographically by owner then id.
- Tool visibility is reference-counted per handle; a tool stays hidden until every handle that called `disable` has called `enable`.
- Extensions that previously appended to `systemPrompt` via `before_agent_start` should migrate to `createSystemPromptBlocks` for consistent placement and suppression support.

---
### Kimchi Summary
### What changed
Introduces a pluggable system-prompt block registry that lets extensions declaratively inject content and suppress default sections, replacing fragile `before_agent_start` string appending. Also adds a cooperative tool-visibility API so extensions can hide tools from the agent's active set.

### Why
Centralizes prompt construction so extensions can influence layout and content without mutating raw strings, and gives extensions a first-class mechanism to control which tools appear in the system prompt.

### Key changes
- `src/extensions/prompt-construction/system-prompt-blocks.ts` — New `createSystemPromptBlocks` API. Extensions register blocks with an `owner` and `id`; blocks are rendered in stable `owner/id` order and can suppress built-in sections (`orchestration`, `phase-guidelines`, `project-context`, `skills`).
- `src/extensions/prompt-construction/tool-visibility.ts` — New `createToolVisibility` API providing refcounted `disable`/`enable` votes per extension handle, which drives `pi.setActiveTools`.
- `src/extensions/prompt-construction/system-prompt.ts` — `buildSystemPrompt` now accepts an optional `pi` to pull registered blocks and suppression state. Removed hard-coded phase-tagging and tool-discovery text.
- `src/extensions/prompt-construction/prompt-enrichment.ts` — Passes `pi` to `buildSystemPrompt` and filters the tools list to only currently active tools.
- `src/extensions/behaviours/wiring.ts` — Emits baseline behaviour rules via a registered `rules` block instead of a `before_agent_start` handler.
- `src/extensions/permissions/index.ts` — Emits the plan-mode supplement via a registered `plan-mode-supplement` block.
- `src/extensions/mcp-adapter/index.ts` — Registers a `tool-and-mcp-discovery` block.
- `src/extensions/tags.ts` — Registers a `phase-tagging` block.

### Impact
- Extensions previously appending prompt content in `before_agent_start` should migrate to `createSystemPromptBlocks` for deterministic placement.
- Tool visibility is now governed by the vote registry; direct `setActiveTools` callers may temporarily coexist but should migrate to `createToolVisibility` to avoid conflicts.