### PR TITLE
feat: show active model in phase-change transcript

### DIFF
--- a/src/extensions/tags.ts
+++ b/src/extensions/tags.ts
@@ -489,7 +489,7 @@ export default function tagsExtension(pi: ExtensionAPI) {
 
 			return {
 				content: [{ type: "text", text: `Phase changed to: ${phase}` }],
-				details: { phase },
+				details: { phase, model: ctx.model?.id },
 			}
 		},
 
@@ -501,10 +501,13 @@ export default function tagsExtension(pi: ExtensionAPI) {
 			if (readHidePhaseChanges()) {
 				return new Text("", 0, 0)
 			}
-			const phase = (result.details as { phase: string } | undefined)?.phase ?? "unknown"
+			const details = result.details as { phase: string; model?: string } | undefined
+			const phase = details?.phase ?? "unknown"
+			const model = details?.model
 			const dash = theme.fg("dim", "- ")
 			const label = theme.bold(theme.fg("toolTitle", `Phase changed: ${phase}`))
-			return new Text(dash + label, 0, 0)
+			const modelSuffix = model ? theme.fg("dim", ` [${model}]`) : ""
+			return new Text(dash + label + modelSuffix, 0, 0)
 		},
 	})
 


### PR DESCRIPTION

<img width="320" height="55" alt="image" src="https://github.com/user-attachments/assets/687ce8c9-9045-4070-bdd0-f3f7e40b23e3" />


---
### Kimchi Summary
### What changed
Phase change notifications now capture and display the ID of the AI model that generated the change, making it visible to users when a model is associated with the context.

### Why
This allows users to track which model is being used for a given phase change, improving observability and debugging when multiple models may be in play.

### Key changes
- `src/extensions/tags.ts`
  - Added `model: ctx.model?.id` to the tool result `details` object alongside `phase`
  - Updated the render handler to extract the optional `model` field from result details
  - Appends a dimmed `[${model}]` suffix to the phase change label when a model ID is present

### Impact
Purely additive and low-risk. The model suffix is only rendered when `ctx.model?.id` resolves to a value; otherwise, the output remains unchanged. No breaking changes or migrations required.