### PR TITLE
fix: prevent stale-ctx errors when /new session runs mid-generation

### DIFF
--- a/src/extensions/curator/index.ts
+++ b/src/extensions/curator/index.ts
@@ -58,9 +58,15 @@ export default function curatorExtension(pi: ExtensionAPI, options?: CuratorExte
 	let knownAgentSkills = new Set<string>()
 
 	// Capture provider/model from the first real LLM request — works regardless of how kimchi is invoked.
+	// If a request from a torn-down session reaches us after `/new`, ctx.model throws via assertActive.
 	pi.on("before_provider_request", (_event, ctx) => {
-		if (!providerModel && ctx.model?.provider && ctx.model?.id) {
-			providerModel = { provider: ctx.model.provider, model: ctx.model.id }
+		if (providerModel) return
+		try {
+			if (ctx.model?.provider && ctx.model?.id) {
+				providerModel = { provider: ctx.model.provider, model: ctx.model.id }
+			}
+		} catch {
+			// stale ctx — ignore
 		}
 	})
 

--- a/src/extensions/curator/index.ts
+++ b/src/extensions/curator/index.ts
@@ -6,6 +6,7 @@ import { Container, Text } from "@earendil-works/pi-tui"
 import { isSubagent } from "../prompt-construction/prompt-enrichment.js"
 import { SkillManager } from "../skills-manager/skill-manager.js"
 import { UsageTracker } from "../skills-manager/usage.js"
+import { isStaleCtxError } from "../stale-ctx.js"
 import { debugLog, runCuratorReview, spawnSessionReview } from "./review.js"
 import { loadState, saveState, shouldRunNow } from "./state.js"
 import type { CuratorState } from "./state.js"
@@ -66,7 +67,7 @@ export default function curatorExtension(pi: ExtensionAPI, options?: CuratorExte
 				providerModel = { provider: ctx.model.provider, model: ctx.model.id }
 			}
 		} catch (err) {
-			if (err instanceof Error && err.message.startsWith("This extension ctx is stale")) return
+			if (isStaleCtxError(err)) return
 			throw err
 		}
 	})

--- a/src/extensions/curator/index.ts
+++ b/src/extensions/curator/index.ts
@@ -65,8 +65,9 @@ export default function curatorExtension(pi: ExtensionAPI, options?: CuratorExte
 			if (ctx.model?.provider && ctx.model?.id) {
 				providerModel = { provider: ctx.model.provider, model: ctx.model.id }
 			}
-		} catch {
-			// stale ctx — ignore
+		} catch (err) {
+			if (err instanceof Error && err.message.startsWith("This extension ctx is stale")) return
+			throw err
 		}
 	})
 

--- a/src/extensions/ferment/events.ts
+++ b/src/extensions/ferment/events.ts
@@ -1,6 +1,7 @@
 import type { ExtensionAPI, ExtensionContext } from "@earendil-works/pi-coding-agent"
 import { shortenTitle } from "../../ferment/shorten-title.js"
 import { clearFermentCache } from "../../ferment/store.js"
+import { isStaleCtxError } from "../stale-ctx.js"
 import { extractContextualOptions, extractTrailingQuestion } from "./contextual-options.js"
 import { decideContinuation } from "./continuation.js"
 import { autoInitFromEnv, ensureGitRepo } from "./git-init.js"

--- a/src/extensions/stale-ctx.ts
+++ b/src/extensions/stale-ctx.ts
@@ -1,0 +1,15 @@
+// Helper for detecting the "stale extension ctx" error thrown by pi-coding-agent's
+// `assertActive()` when an event handler runs against a torn-down session
+// (e.g. an in-flight provider request still firing `before_provider_request` after `/new`).
+//
+// The library throws a plain `new Error(staleMessage)` with no custom class or `code`
+// property, so message-prefix matching is the only stable signal available. Centralized
+// here so a future wording change is a one-line fix.
+//
+// Reference: node_modules/@earendil-works/pi-coding-agent/dist/core/extensions/runner.js
+//            (`invalidate(message = "This extension ctx is stale...")`)
+const STALE_CTX_MESSAGE_PREFIX = "This extension ctx is stale"
+
+export function isStaleCtxError(err: unknown): boolean {
+	return err instanceof Error && err.message.startsWith(STALE_CTX_MESSAGE_PREFIX)
+}

--- a/src/extensions/tags.ts
+++ b/src/extensions/tags.ts
@@ -23,6 +23,7 @@ import type {
 import { Container, Text } from "@earendil-works/pi-tui"
 import { Type } from "typebox"
 import { createSystemPromptBlocks } from "./prompt-construction/index.js"
+import { isStaleCtxError } from "./stale-ctx.js"
 
 // ─── Constants ───────────────────────────────────────────────────────────────
 
@@ -622,7 +623,7 @@ export default function tagsExtension(pi: ExtensionAPI) {
 		try {
 			model = ctx.model ?? undefined
 		} catch (err) {
-			if (err instanceof Error && err.message.startsWith("This extension ctx is stale")) return
+			if (isStaleCtxError(err)) return
 			throw err
 		}
 		if (model?.provider !== "kimchi-dev") return

--- a/src/extensions/tags.ts
+++ b/src/extensions/tags.ts
@@ -621,8 +621,9 @@ export default function tagsExtension(pi: ExtensionAPI) {
 		let model: { provider?: string; id?: string } | undefined
 		try {
 			model = ctx.model ?? undefined
-		} catch {
-			return
+		} catch (err) {
+			if (err instanceof Error && err.message.startsWith("This extension ctx is stale")) return
+			throw err
 		}
 		if (model?.provider !== "kimchi-dev") return
 

--- a/src/extensions/tags.ts
+++ b/src/extensions/tags.ts
@@ -615,8 +615,16 @@ export default function tagsExtension(pi: ExtensionAPI) {
 
 	// Inject tags into every LLM request
 	pi.on("before_provider_request", async (event, ctx) => {
-		// Tags are a Cast AI-specific API field; skip for other providers
-		if (ctx.model?.provider !== "kimchi-dev") return
+		// Tags are a Cast AI-specific API field; skip for other providers.
+		// If a request from a torn-down session reaches us after `/new` (etc.),
+		// any ctx getter throws via assertActive — bail silently in that case.
+		let model: { provider?: string; id?: string } | undefined
+		try {
+			model = ctx.model ?? undefined
+		} catch {
+			return
+		}
+		if (model?.provider !== "kimchi-dev") return
 
 		const payload = event.payload as Record<string, unknown> | null
 		if (!payload || typeof payload !== "object") return
@@ -625,8 +633,8 @@ export default function tagsExtension(pi: ExtensionAPI) {
 
 		// Build reserved tags first (model + phase) so they are never dropped by the cap
 		const reservedTags: string[] = []
-		if (ctx.model?.id) {
-			reservedTags.push(`model:${ctx.model.id}`)
+		if (model?.id) {
+			reservedTags.push(`model:${model.id}`)
 		}
 		const phaseTag = tagManager.getPhaseTag()
 		if (phaseTag) {

--- a/src/extensions/ui.ts
+++ b/src/extensions/ui.ts
@@ -214,6 +214,12 @@ export default function uiExtension(pi: ExtensionAPI) {
 		}
 	})
 
+	pi.on("session_shutdown", () => {
+		stopWorkingAnimation?.()
+		stopWorkingAnimation = undefined
+		currentCtx = null
+	})
+
 	pi.on("input", (event, ctx) => {
 		if (isBareExitAlias(event.text)) {
 			ctx.shutdown()


### PR DESCRIPTION
Add guards which protect against same root cause: after `/new` is executed mid-generation, the old session's in-flight provider stream keeps emitting `before_provider_request` against the now-disposed extension runner, where every ctx/pi accessor throws via `assetActive`.

Closes #LLM-1662

---
### Kimchi Summary
### What changed
Hardens multiple extensions against race conditions where in-flight `before_provider_request` events arrive after a session is torn down (e.g., via `/new`), and ensures the UI extension cleans up its animation state on `session_shutdown`.

### Why
Running `/new` while a model request is still in-flight causes stale context or runtime accesses to throw via `assertActive`. These changes gracefully ignore events from dead sessions instead of crashing.

### Key changes
- `src/extensions/curator/index.ts`: Wraps `ctx.model` access in `try/catch` inside the `before_provider_request` handler and adds an early return when `providerModel` is already captured.
- `src/extensions/ferment/events.ts`: Wraps `pi.getFlag("ferment-oneshot")` in `try/catch` in the `before_provider_request` handler to avoid throws on a stale runtime.
- `src/extensions/tags.ts`: Wraps `ctx.model` access in `try/catch` in the `before_provider_request` handler and uses the captured `model` reference for tag injection.
- `src/extensions/ui.ts`: Adds a `session_shutdown` event handler that stops the working animation and clears `currentCtx`.

---
### Kimchi Summary
### What changed
Prevents exceptions when provider request events arrive after a session is torn down (e.g., via `/new`). Adds a shared helper to detect stale extension context errors and handles them gracefully in affected event handlers. Also clears UI animation state on `session_shutdown`.

### Why
The `pi-coding-agent` library throws a plain `Error` when extension event handlers access a torn-down session's `ctx`. If a user starts a new session while the model is thinking, in-flight `before_provider_request` events crash because `ctx.model` calls `assertActive()`.

### Key changes
- **`src/extensions/stale-ctx.ts`** (new): Introduces `isStaleCtxError`, a helper that identifies stale extension context errors by their message prefix.
- **`src/extensions/curator/index.ts`**: Wraps `ctx.model` access in the `before_provider_request` handler with a try/catch that ignores stale context errors.
- **`src/extensions/tags.ts`**: Wraps `ctx.model` access in the `before_provider_request` handler with a try/catch for stale context errors, storing the model locally to avoid redundant context reads.
- **`src/extensions/ui.ts`**: Adds a `session_shutdown` event handler that stops the working animation and resets `currentCtx`.

### Impact
Eliminates crashes during rapid session cycling while requests are in-flight. Changes are entirely defensive and low-risk.