### PR TITLE
UI-6686: format `get_subagent_result` tool's output

### DIFF
--- a/src/extensions/agents/index.ts
+++ b/src/extensions/agents/index.ts
@@ -22,6 +22,7 @@ import {
 import { Text } from "@earendil-works/pi-tui"
 import { Type } from "typebox"
 import { isToolExpanded, registerToolCall } from "../../expand-state.js"
+import { filterThinkingForDisplay } from "../hide-thinking.js"
 import { KIMCHI_DEV_PROVIDER, MODEL_CAPABILITIES } from "../orchestration/model-registry/index.js"
 import { AgentManager } from "./manager/agent-manager.js"
 import {
@@ -76,8 +77,28 @@ import {
 
 // ---- Shared helpers ----
 
-function textResult(msg: string, details?: AgentDetails) {
+function textResult(msg: string, details?: unknown) {
 	return { content: [{ type: "text" as const, text: msg }], details: details as unknown }
+}
+
+interface GetSubagentResultDetails {
+	agentId: string
+	displayName: string
+	description: string
+	status: string
+	toolUses: number
+	tokens: string
+	contextPercent: number | null
+	compactionCount?: number
+	durationMs?: number
+	error?: string
+	bodyText: string
+	spinnerFrame?: number
+}
+
+function formatAgentBodyForDisplay(raw: string): string {
+	const cleaned = filterThinkingForDisplay(raw)
+	return cleaned.replace(/\n{3,}/g, "\n\n").trimEnd()
 }
 
 function formatLifetimeTokens(o: { lifetimeUsage: LifetimeUsage }): string {
@@ -1040,6 +1061,73 @@ Model selection — YOU choose based on task complexity:
 					}),
 				),
 			}),
+
+			renderResult(result, { expanded: piExpanded }, theme, context) {
+				if (context?.toolCallId) registerToolCall(context.toolCallId)
+				const expanded = piExpanded || (context?.toolCallId ? isToolExpanded(context.toolCallId) : false)
+
+				const details = result.details as GetSubagentResultDetails | undefined
+				if (!details) {
+					const text = result.content[0]?.type === "text" ? result.content[0].text : ""
+					return new Text(text, 0, 0)
+				}
+
+				const statsLine = (d: GetSubagentResultDetails) => {
+					const parts: string[] = [d.status]
+					if (d.toolUses > 0) parts.push(`${d.toolUses} tool use${d.toolUses === 1 ? "" : "s"}`)
+					if (d.tokens) parts.push(d.tokens)
+					if (d.contextPercent != null) parts.push(`${Math.round(d.contextPercent)}% ctx`)
+					if (d.compactionCount && d.compactionCount > 0) {
+						parts.push(`${d.compactionCount} compaction${d.compactionCount === 1 ? "" : "s"}`)
+					}
+					return parts.map((p) => theme.fg("dim", p)).join(` ${theme.fg("dim", "·")} `)
+				}
+
+				const icon =
+					details.status === "running" || details.status === "queued"
+						? theme.fg("accent", SPINNER[0])
+						: details.status === "error"
+							? theme.fg("error", "✗")
+							: details.status === "stopped"
+								? theme.fg("dim", "■")
+								: details.status === "steered" || details.status === "aborted"
+									? theme.fg("warning", "✓")
+									: theme.fg("success", "✓")
+
+				const headerName = theme.fg("toolTitle", theme.bold("Get Agent Result"))
+				const headerDesc = details.description ? `  ${theme.fg("muted", details.description)}` : ""
+				const durationTail =
+					details.durationMs != null ? ` ${theme.fg("dim", "·")} ${theme.fg("dim", formatMs(details.durationMs))}` : ""
+
+				let line = `${icon} ${headerName}${headerDesc}${durationTail}`
+				const stats = statsLine(details)
+				if (stats) line += `\n${theme.fg("dim", "  ⎿  ")}${stats}`
+
+				const bodyText = details.bodyText ?? ""
+				if (expanded && bodyText) {
+					const lines = bodyText.split("\n")
+					const maxLines = 50
+					const visible = lines.slice(0, maxLines)
+					for (const l of visible) {
+						line += `\n${theme.fg("dim", `  ${l}`)}`
+					}
+					if (lines.length > maxLines) {
+						line += `\n${theme.fg("muted", `  … (${lines.length - maxLines} more lines — use verbose: true for full output)`)}`
+					}
+				} else if (!expanded) {
+					const firstErrLine = details.error?.split("\n")[0]?.trim() || "unknown"
+					const summary =
+						details.status === "running" || details.status === "queued"
+							? "Still running"
+							: details.status === "error"
+								? `Error: ${firstErrLine.slice(0, 80)}`
+								: "Done"
+					line += `\n${theme.fg("dim", `  ⎿  ${summary}`)}`
+				}
+
+				return new Text(line, 0, 0)
+			},
+
 			execute: async (_toolCallId, params, _signal, _onUpdate, _ctx) => {
 				const record = manager.getRecord(params.agent_id as string)
 				if (!record) {
@@ -1067,12 +1155,16 @@ Model selection — YOU choose based on task complexity:
 					`Type: ${displayName} | Status: ${record.status} | ${statsParts.join(" | ")}\n` +
 					`Description: ${record.description}\n\n`
 
+				let bodyForDisplay: string
 				if (record.status === "running") {
-					output += "Agent is still running. Use wait: true or check back later."
+					bodyForDisplay = "Agent is still running. Use wait: true or check back later."
+					output += bodyForDisplay
 				} else if (record.status === "error") {
-					output += `Error: ${record.error}`
+					bodyForDisplay = `Error: ${record.error}`
+					output += bodyForDisplay
 				} else {
-					output += record.result?.trim() || "No output."
+					bodyForDisplay = record.result?.trim() || "No output."
+					output += bodyForDisplay
 				}
 
 				if (record.status !== "running" && record.status !== "queued") {
@@ -1083,11 +1175,29 @@ Model selection — YOU choose based on task complexity:
 				if (params.verbose && record.session) {
 					const conversation = getAgentConversation(record.session)
 					if (conversation) {
-						output += `\n\n--- Agent Conversation ---\n${conversation}`
+						const verboseTail = `\n\n--- Agent Conversation ---\n${conversation}`
+						output += verboseTail
+						bodyForDisplay += verboseTail
 					}
 				}
 
-				return textResult(output)
+				const completedAt = record.completedAt ?? Date.now()
+				const durationMs = completedAt - record.startedAt
+				const details: GetSubagentResultDetails = {
+					agentId: record.id,
+					displayName,
+					description: record.description,
+					status: record.status,
+					toolUses: record.toolUses,
+					tokens,
+					contextPercent,
+					compactionCount: record.compactionCount,
+					durationMs,
+					error: record.error,
+					bodyText: formatAgentBodyForDisplay(bodyForDisplay),
+				}
+
+				return textResult(output, details)
 			},
 		}),
 	)

--- a/src/extensions/agents/index.ts
+++ b/src/extensions/agents/index.ts
@@ -65,6 +65,7 @@ import {
 	type AgentDetails,
 	AgentWidget,
 	SPINNER,
+	type Theme,
 	type UICtx,
 	describeActivity,
 	formatDuration,
@@ -77,7 +78,7 @@ import {
 
 // ---- Shared helpers ----
 
-function textResult(msg: string, details?: unknown) {
+function textResult<T = AgentDetails>(msg: string, details?: T) {
 	return { content: [{ type: "text" as const, text: msg }], details: details as unknown }
 }
 
@@ -93,12 +94,48 @@ interface GetSubagentResultDetails {
 	durationMs?: number
 	error?: string
 	bodyText: string
-	spinnerFrame?: number
 }
 
 function formatAgentBodyForDisplay(raw: string): string {
 	const cleaned = filterThinkingForDisplay(raw)
 	return cleaned.replace(/\n{3,}/g, "\n\n").trimEnd()
+}
+
+function getSubagentResultIcon(status: string, theme: Theme): string {
+	switch (status) {
+		case "running":
+		case "queued":
+			return theme.fg("accent", SPINNER[0])
+		case "error":
+		case "aborted":
+			return theme.fg("error", "✗")
+		case "stopped":
+			return theme.fg("dim", "■")
+		case "steered":
+			return theme.fg("warning", "✓")
+		default:
+			return theme.fg("success", "✓")
+	}
+}
+
+function summaryForStatus(status: string, error?: string): string {
+	switch (status) {
+		case "running":
+		case "queued":
+			return "Still running"
+		case "completed":
+			return "Done"
+		case "steered":
+			return "Wrapped up (turn limit)"
+		case "aborted":
+			return "Aborted (max turns exceeded)"
+		case "stopped":
+			return "Stopped"
+		case "error":
+			return `Error: ${error?.split("\n")[0]?.trim() || "unknown"}`
+		default:
+			return status
+	}
 }
 
 function formatLifetimeTokens(o: { lifetimeUsage: LifetimeUsage }): string {
@@ -1083,16 +1120,7 @@ Model selection — YOU choose based on task complexity:
 					return parts.map((p) => theme.fg("dim", p)).join(` ${theme.fg("dim", "·")} `)
 				}
 
-				const icon =
-					details.status === "running" || details.status === "queued"
-						? theme.fg("accent", SPINNER[0])
-						: details.status === "error"
-							? theme.fg("error", "✗")
-							: details.status === "stopped"
-								? theme.fg("dim", "■")
-								: details.status === "steered" || details.status === "aborted"
-									? theme.fg("warning", "✓")
-									: theme.fg("success", "✓")
+				const icon = getSubagentResultIcon(details.status, theme)
 
 				const headerName = theme.fg("toolTitle", theme.bold("Get Agent Result"))
 				const headerDesc = details.description ? `  ${theme.fg("muted", details.description)}` : ""
@@ -1115,13 +1143,7 @@ Model selection — YOU choose based on task complexity:
 						line += `\n${theme.fg("muted", `  … (${lines.length - maxLines} more lines — use verbose: true for full output)`)}`
 					}
 				} else if (!expanded) {
-					const firstErrLine = details.error?.split("\n")[0]?.trim() || "unknown"
-					const summary =
-						details.status === "running" || details.status === "queued"
-							? "Still running"
-							: details.status === "error"
-								? `Error: ${firstErrLine.slice(0, 80)}`
-								: "Done"
+					const summary = summaryForStatus(details.status, details.error)
 					line += `\n${theme.fg("dim", `  ⎿  ${summary}`)}`
 				}
 
@@ -1182,7 +1204,7 @@ Model selection — YOU choose based on task complexity:
 				}
 
 				const completedAt = record.completedAt ?? Date.now()
-				const durationMs = completedAt - record.startedAt
+				const durationMs = record.startedAt != null ? completedAt - record.startedAt : undefined
 				const details: GetSubagentResultDetails = {
 					agentId: record.id,
 					displayName,


### PR DESCRIPTION


---
### Kimchi Summary
### What changed
Add rich TUI formatting for `get_subagent_result` tool output. Subagent results now render with status icons, metadata stats, collapsible body text, and filtered thinking content instead of plain text.

### Why
Improve readability of subagent tool results in the terminal UI by surfacing status, duration, token usage, and errors in a scannable format while hiding internal reasoning from the display.

### Key changes
- **`src/extensions/agents/index.ts`**:
  - Added `GetSubagentResultDetails` interface and helper functions `formatAgentBodyForDisplay`, `getSubagentResultIcon`, and `summaryForStatus`.
  - Implemented `renderResult` on the `get_subagent_result` tool to produce themed, structured output with an icon header, stats line, and expandable body text capped at 50 lines.
  - Updated the tool's `execute` method to compute structured `details` (including `durationMs`, `contextPercent`, `compactionCount`, and filtered `bodyText`) and return it via `textResult`.
  - Imported `filterThinkingForDisplay` to strip thinking tags from displayed agent output.

### Impact
- Subagent results now render as formatted cards in the TUI rather than raw text blocks.
- Agent body output is truncated to 50 lines when collapsed; use `verbose: true` or expand the tool call to see full conversation history.
- Internal thinking content is hidden from the rendered display.