### PR TITLE
chore: license under Apache 2.0 + add CLA governance

### DIFF
--- a/CLA.md
+++ b/CLA.md
@@ -1,0 +1,39 @@
+# Kimchi Contributor License Agreement
+
+Thank you for your interest in contributing to Kimchi ("the Project"). This agreement clarifies the terms under which you may contribute.
+
+## 1. Definitions
+
+- **"You"** means the individual or legal entity making a Contribution.
+- **"Contribution"** means any original work of authorship — including source code, documentation, designs, bug reports, and suggestions — that you intentionally submit to the Project for inclusion.
+
+## 2. Grant of Copyright License
+
+You hereby grant to CAST AI Group, Inc. ("CAST AI") a perpetual, worldwide, non-exclusive, royalty-free, irrevocable copyright license to reproduce, prepare derivative works of, publicly display, publicly perform, sublicense, and distribute your Contributions and such derivative works.
+
+## 3. Grant of Patent License
+
+You hereby grant to CAST AI a perpetual, worldwide, non-exclusive, royalty-free, irrevocable patent license to make, have made, use, offer to sell, sell, import, and otherwise transfer the Project, where such license applies only to those patent claims licensable by you that are necessarily infringed by your Contributions alone or by combination of your Contributions with the Project.
+
+## 4. Representation
+
+You represent that:
+- Each of your Contributions is your original creation.
+- To the best of your knowledge, your Contributions do not violate any third party's intellectual property rights.
+- If you are contributing on behalf of your employer, you have obtained their authorization to enter into this agreement.
+
+## 5. Authorship & Moral Rights
+
+You retain full authorship credit. This agreement does not assign your moral rights. Your Contributions remain attributed to you in the Project's commit history and contributor records.
+
+## 6. No Warranty
+
+Unless required by applicable law or agreed to in writing, you provide your Contributions on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND.
+
+## 7. Acceptance
+
+By submitting a pull request or otherwise contributing code, documentation, or other materials to the Project, you agree to the terms of this CLA.
+
+## 8. Future Relicensing
+
+CAST AI may, at its discretion and with reasonable community notice, relicense the Project or parts thereof under different open-source or source-available terms. This clause preserves the option to adapt the project's licensing to strategic needs while maintaining transparency with contributors.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,33 @@
+# Contributing to Kimchi
+
+Thank you for your interest in contributing to Kimchi! This document outlines the process for contributing and the governance model we follow.
+
+## Contributor License Agreement (CLA)
+
+Before we can accept your contribution, you must agree to the **Kimchi Contributor License Agreement (CLA)**.
+
+- **Why a CLA?** It ensures the project can freely distribute and relicense contributions while protecting both contributors and users. This preserves the option for the project to make future licensing decisions with community notice, without needing to track down every past contributor for consent.
+- **How to agree:** Review [CLA.md](CLA.md) in this repository. By opening a pull request, you agree to the terms set out there. We are also working on wiring up CLA Assistant for automated checks.
+
+All contributions — code, documentation, bug reports, design proposals — are welcome once the CLA is acknowledged.
+
+## License
+
+Kimchi is licensed under the **Apache License 2.0**. By contributing, you agree that your contributions will be licensed under the same terms.
+
+## Governance
+
+- CAST AI Group, Inc. stewards Kimchi as the primary maintainer.
+- We aim for open, transparent decision-making. Major architectural changes are discussed in issues before implementation.
+- We do not plan restrictive license shifts without clear advance notice to the community. If a license change is ever on the roadmap, it will be telegraphed early rather than sprung as a surprise.
+
+## Getting Started
+
+1. Open or find an issue describing the bug or feature.
+2. Fork the repo, create a feature branch, and make your changes.
+3. Ensure tests pass and code follows the existing style.
+4. Open a pull request and complete the CLA check.
+
+## Code of Conduct
+
+Be respectful, constructive, and assume good intent. We enforce the [Contributor Covenant Code of Conduct](https://www.contributor-covenant.org/version/2/1/code_of_conduct/).

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,203 @@
+Copyright 2024-2026 CAST AI Group, Inc.
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright 2024-2026 CAST AI Group, Inc.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/NOTICE
+++ b/NOTICE
@@ -1,0 +1,28 @@
+Kimchi
+Copyright 2024-2026 CAST AI Group, Inc.
+
+Kimchi is an open-source project stewarded by CAST AI Group, Inc. (https://cast.ai).
+
+================================================================================
+THIRD-PARTY COMPONENTS
+================================================================================
+
+This project bundles or references the following third-party software under
+their respective licenses:
+
+1. mcp-adapter
+   Location: src/extensions/mcp-adapter/
+   License: MIT
+   Copyright (c) 2026 Nico Bailon
+
+2. marked
+   Location: src/core/export-html/vendor/marked.min.js
+   License: MIT
+   Copyright (c) 2011-2024, Christopher Jeffrey
+   https://github.com/markedjs/marked
+
+3. Pi coding agent SDK
+   Location: npm dependency (pi packages)
+   License: MIT
+   Copyright (c) 2024-2025 Mario Zechner (Earendil Works)
+   https://github.com/earendil-works/pi

--- a/README.md
+++ b/README.md
@@ -450,4 +450,4 @@ Release assets follow the naming convention `kimchi_{os}_{arch}.tar.gz` with a `
 
 ## License
 
-MIT
+[Apache License 2.0](LICENSE) — see [CONTRIBUTING.md](CONTRIBUTING.md) for the CLA and contributor guidelines.

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
 	"version": "0.0.0",
 	"description": "kimchi — a coding agent CLI powered by Cast AI",
 	"type": "module",
-	"license": "MIT",
+	"license": "Apache-2.0",
 	"bin": {
 		"kimchi": "src/entry.ts"
 	},


### PR DESCRIPTION
## What changed
Adds Apache 2.0 license and formal contributor governance documents, including a Contributor License Agreement, contribution guidelines, and a third-party attribution notice.

## Why
Adopting Apache 2.0 provides explicit patent protection and a well-understood permissive framework. The CLA ensures the project can freely distribute and relicense contributions while protecting both contributors and users, as described in CONTRIBUTING.md.

## Key changes
- LICENSE: Added full Apache License 2.0 text (Copyright 2024-2026 CAST AI Group, Inc.).
- CLA.md: Added Kimchi Contributor License Agreement covering copyright and patent grants, original authorship retention, and future relicensing terms.
- CONTRIBUTING.md: Added contributor guidelines explaining CLA acceptance, governance, and the contribution workflow.
- NOTICE: Added copyright and third-party attribution for bundled MIT-licensed components (mcp-adapter, marked, pi SDK).
- README.md: Updated License section to reference Apache License 2.0 and CONTRIBUTING.md.
- package.json: Changed license field from MIT to Apache-2.0.

## No code changes
No source code was modified — this is a pure licensing / governance PR.