### PR TITLE
Support per-project config via .kimchi/config.json

### DIFF
--- a/src/config.test.ts
+++ b/src/config.test.ts
@@ -1,6 +1,6 @@
-import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs"
+import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs"
 import { tmpdir } from "node:os"
-import { join } from "node:path"
+import { dirname, join } from "node:path"
 import { afterEach, beforeEach, describe, expect, it } from "vitest"
 import { clearApiKey, loadConfig, writeApiKey } from "./config.js"
 
@@ -38,6 +38,146 @@ describe("loadConfig", () => {
 	it("returns empty apiKey when no key is found", () => {
 		const config = loadConfig({ configPath })
 		expect(config.apiKey).toBe("")
+	})
+
+	it("reads project config from .kimchi/config.json overriding global", () => {
+		const globalDir = mkdtempSync(join(tmpdir(), "kimchi-test-"))
+		const projectDir = mkdtempSync(join(tmpdir(), "kimchi-test-"))
+		const globalPath = join(globalDir, "config.json")
+		const projectPath = join(projectDir, ".kimchi", "config.json")
+
+		writeFileSync(globalPath, JSON.stringify({ apiKey: "global-key" }))
+		mkdirSync(dirname(projectPath), { recursive: true })
+		writeFileSync(projectPath, JSON.stringify({ apiKey: "project-key" }))
+
+		const config = loadConfig({ configPath: globalPath, cwd: projectDir })
+		expect(config.apiKey).toBe("project-key")
+
+		rmSync(globalDir, { recursive: true, force: true })
+		rmSync(projectDir, { recursive: true, force: true })
+	})
+
+	it("merges mcpSearch shallowly (project overrides only provided keys)", () => {
+		const globalDir = mkdtempSync(join(tmpdir(), "kimchi-test-"))
+		const projectDir = mkdtempSync(join(tmpdir(), "kimchi-test-"))
+		const globalPath = join(globalDir, "config.json")
+		const projectPath = join(projectDir, ".kimchi", "config.json")
+
+		writeFileSync(globalPath, JSON.stringify({ mcpSearch: { strategy: "regex", bm25K1: 1.5 } }))
+		mkdirSync(dirname(projectPath), { recursive: true })
+		writeFileSync(projectPath, JSON.stringify({ mcpSearch: { strategy: "bm25" } }))
+
+		const config = loadConfig({ configPath: globalPath, cwd: projectDir })
+		expect(config.mcpSearch.strategy).toBe("bm25")
+		expect(config.mcpSearch.bm25K1).toBe(1.5) // inherited from global
+
+		rmSync(globalDir, { recursive: true, force: true })
+		rmSync(projectDir, { recursive: true, force: true })
+	})
+
+	it("falls back to global when .kimchi/config.json does not exist", () => {
+		const globalDir = mkdtempSync(join(tmpdir(), "kimchi-test-"))
+		const projectDir = mkdtempSync(join(tmpdir(), "kimchi-test-"))
+		const globalPath = join(globalDir, "config.json")
+
+		writeFileSync(globalPath, JSON.stringify({ apiKey: "global-key" }))
+
+		const config = loadConfig({ configPath: globalPath, cwd: projectDir })
+		expect(config.apiKey).toBe("global-key")
+
+		rmSync(globalDir, { recursive: true, force: true })
+		rmSync(projectDir, { recursive: true, force: true })
+	})
+
+	it("project llmEndpoint overrides global", () => {
+		const globalDir = mkdtempSync(join(tmpdir(), "kimchi-test-"))
+		const projectDir = mkdtempSync(join(tmpdir(), "kimchi-test-"))
+		const globalPath = join(globalDir, "config.json")
+		const projectPath = join(projectDir, ".kimchi", "config.json")
+
+		writeFileSync(globalPath, JSON.stringify({ apiKey: "key", llmEndpoint: "https://global.example.com" }))
+		mkdirSync(dirname(projectPath), { recursive: true })
+		writeFileSync(projectPath, JSON.stringify({ apiKey: "key", llmEndpoint: "https://project.example.com" }))
+
+		const config = loadConfig({ configPath: globalPath, cwd: projectDir })
+		expect(config.llmEndpoint).toBe("https://project.example.com")
+
+		rmSync(globalDir, { recursive: true, force: true })
+		rmSync(projectDir, { recursive: true, force: true })
+	})
+
+	it("project skillPaths replaces global (not concatenated)", () => {
+		const globalDir = mkdtempSync(join(tmpdir(), "kimchi-test-"))
+		const projectDir = mkdtempSync(join(tmpdir(), "kimchi-test-"))
+		const globalPath = join(globalDir, "config.json")
+		const projectPath = join(projectDir, ".kimchi", "config.json")
+
+		writeFileSync(globalPath, JSON.stringify({ apiKey: "key", skillPaths: ["/global/path"] }))
+		mkdirSync(dirname(projectPath), { recursive: true })
+		writeFileSync(projectPath, JSON.stringify({ apiKey: "key", skillPaths: ["/project/path"] }))
+
+		const config = loadConfig({ configPath: globalPath, cwd: projectDir })
+		expect(config.skillPaths).toEqual(["/project/path"])
+
+		rmSync(globalDir, { recursive: true, force: true })
+		rmSync(projectDir, { recursive: true, force: true })
+	})
+
+	it("gracefully ignores malformed project config JSON", () => {
+		const globalDir = mkdtempSync(join(tmpdir(), "kimchi-test-"))
+		const projectDir = mkdtempSync(join(tmpdir(), "kimchi-test-"))
+		const globalPath = join(globalDir, "config.json")
+		const projectPath = join(projectDir, ".kimchi", "config.json")
+
+		writeFileSync(globalPath, JSON.stringify({ apiKey: "global-key" }))
+		mkdirSync(dirname(projectPath), { recursive: true })
+		writeFileSync(projectPath, "{ not valid json }")
+
+		const config = loadConfig({ configPath: globalPath, cwd: projectDir })
+		expect(config.apiKey).toBe("global-key")
+
+		rmSync(globalDir, { recursive: true, force: true })
+		rmSync(projectDir, { recursive: true, force: true })
+	})
+
+	it("ignores empty-string project values and falls back to global", () => {
+		const globalDir = mkdtempSync(join(tmpdir(), "kimchi-test-"))
+		const projectDir = mkdtempSync(join(tmpdir(), "kimchi-test-"))
+		const globalPath = join(globalDir, "config.json")
+		const projectPath = join(projectDir, ".kimchi", "config.json")
+
+		writeFileSync(globalPath, JSON.stringify({ apiKey: "global-key", llmEndpoint: "https://global.example.com" }))
+		mkdirSync(dirname(projectPath), { recursive: true })
+		writeFileSync(projectPath, JSON.stringify({ apiKey: "", llmEndpoint: "" }))
+
+		const config = loadConfig({ configPath: globalPath, cwd: projectDir })
+		expect(config.apiKey).toBe("global-key")
+		expect(config.llmEndpoint).toBe("https://global.example.com")
+
+		rmSync(globalDir, { recursive: true, force: true })
+		rmSync(projectDir, { recursive: true, force: true })
+	})
+
+	it("does not walk up the directory tree from a subfolder", () => {
+		const globalDir = mkdtempSync(join(tmpdir(), "kimchi-test-"))
+		const rootDir = mkdtempSync(join(tmpdir(), "kimchi-test-"))
+		const subDir = join(rootDir, "src", "components")
+		const globalPath = join(globalDir, "config.json")
+		const rootProjectPath = join(rootDir, ".kimchi", "config.json")
+
+		writeFileSync(globalPath, JSON.stringify({ apiKey: "global-key" }))
+		mkdirSync(dirname(rootProjectPath), { recursive: true })
+		writeFileSync(rootProjectPath, JSON.stringify({ apiKey: "root-project-key" }))
+		mkdirSync(subDir, { recursive: true })
+
+		// cwd is a subfolder that does NOT have .kimchi/config.json
+		const config = loadConfig({ configPath: globalPath, cwd: subDir })
+		// Should NOT pick up rootDir/.kimchi/config.json
+		// Falls back to global only
+		expect(config.apiKey).toBe("global-key")
+
+		rmSync(globalDir, { recursive: true, force: true })
+		rmSync(rootDir, { recursive: true, force: true })
 	})
 })
 

--- a/src/config.ts
+++ b/src/config.ts
@@ -101,6 +101,8 @@ export function readApiKeyFromConfigFile(configPath: string = KIMCHI_CONFIG_PATH
 }
 
 function readConfigExtras(configPath: string): {
+	apiKey?: string
+	llmEndpoint?: string
 	maxToolResultChars?: number
 	mcpSearchLimit?: number
 	mcpSearch?: Partial<SearchStrategyConfig>
@@ -151,7 +153,19 @@ function readConfigExtras(configPath: string): {
 			parsed.migrationState === "done" || parsed.migrationState === "skip-forever"
 				? (parsed.migrationState as MigrationState)
 				: undefined
-		return { maxToolResultChars, mcpSearchLimit, mcpSearch, skillPaths, migrationState }
+		// Read apiKey (prefer camelCase, fall back to snake_case)
+		let apiKey: string | undefined
+		if (typeof parsed.apiKey === "string" && parsed.apiKey.length > 0) {
+			apiKey = parsed.apiKey
+		} else if (typeof parsed.api_key === "string" && parsed.api_key.length > 0) {
+			apiKey = parsed.api_key
+		}
+
+		// Read llmEndpoint
+		const llmEndpoint =
+			typeof parsed.llmEndpoint === "string" && parsed.llmEndpoint.length > 0 ? parsed.llmEndpoint : undefined
+
+		return { apiKey, llmEndpoint, maxToolResultChars, mcpSearchLimit, mcpSearch, skillPaths, migrationState }
 	} catch {
 		return {}
 	}
@@ -220,27 +234,44 @@ export function readTelemetryConfig(configPath?: string): TelemetryConfig {
 /**
  * Load the kimchi configuration.
  *
- * API key resolution order:
+ * Config precedence (highest to lowest):
  *   1. KIMCHI_API_KEY environment variable (highest precedence)
- *   2. ~/.config/kimchi/config.json field "APIKey"
+ *   2. Project .kimchi/config.json (if cwd provided)
+ *   3. Global ~/.config/kimchi/config.json
  *
- * Throws if no API key is found in either location.
+ * For mcpSearch, a shallow merge is performed: project config overrides
+ * individual keys, but global fills in any missing keys.
+ * For all other fields, project config completely replaces global.
+ *
+ * Returns `apiKey: ""` when no API key is present in either config file.
  */
-export function loadConfig(options?: { configPath?: string }): KimchiConfig {
-	const configPath = options?.configPath ?? KIMCHI_CONFIG_PATH
-	const extras = readConfigExtras(configPath)
-	const maxToolResultChars = extras.maxToolResultChars ?? 10_000
-	const mcpSearchLimit = extras.mcpSearchLimit ?? 5
-	const mcpSearch: SearchStrategyConfig = { ...SEARCH_STRATEGY_DEFAULTS, ...extras.mcpSearch }
+export function loadConfig(options?: { configPath?: string; cwd?: string }): KimchiConfig {
+	// Read global config
+	const globalConfigPath = options?.configPath ?? KIMCHI_CONFIG_PATH
+	const globalExtras = readConfigExtras(globalConfigPath)
 
-	const fileKey = readApiKeyFromConfigFile(configPath)
+	// Read project-level config
+	const projectPath = resolve(options?.cwd ?? process.cwd(), ".kimchi", "config.json")
+	const projectExtras = readConfigExtras(projectPath)
+
+	// Merge: project wins for scalars; shallow merge for mcpSearch
+	const extras = {
+		apiKey: projectExtras.apiKey ?? globalExtras.apiKey,
+		llmEndpoint: projectExtras.llmEndpoint ?? globalExtras.llmEndpoint,
+		maxToolResultChars: projectExtras.maxToolResultChars ?? globalExtras.maxToolResultChars,
+		mcpSearchLimit: projectExtras.mcpSearchLimit ?? globalExtras.mcpSearchLimit,
+		mcpSearch: { ...globalExtras.mcpSearch, ...projectExtras.mcpSearch },
+		skillPaths: projectExtras.skillPaths ?? globalExtras.skillPaths,
+		migrationState: projectExtras.migrationState ?? globalExtras.migrationState,
+	}
+
 	return {
-		apiKey: fileKey ?? "",
+		apiKey: extras.apiKey ?? "",
 		agentConfigDir: AGENT_CONFIG_DIR,
-		llmEndpoint: CAST_AI_LLM_ENDPOINT,
-		maxToolResultChars,
-		mcpSearchLimit,
-		mcpSearch,
+		llmEndpoint: extras.llmEndpoint ?? CAST_AI_LLM_ENDPOINT,
+		maxToolResultChars: extras.maxToolResultChars ?? 10_000,
+		mcpSearchLimit: extras.mcpSearchLimit ?? 5,
+		mcpSearch: { ...SEARCH_STRATEGY_DEFAULTS, ...extras.mcpSearch },
 		skillPaths: extras.skillPaths,
 		migrationState: extras.migrationState,
 	}


### PR DESCRIPTION
- loadConfig() now accepts optional cwd; defaults to process.cwd()
- Reads .kimchi/config.json in cwd and merges over global config:
  - Scalars (apiKey, llmEndpoint, etc.): project wins
  - mcpSearch: shallow merge (project overrides individual keys)
  - skillPaths: project replaces global
- readConfigExtras now parses fields from any config file
- Added 7 per-project tests covering override, merge, fallback, malformed JSON, and empty-string rejection

Closes LLM-1695

---
### Kimchi Summary
### What changed
`loadConfig` now discovers an optional per-project config file at `.kimchi/config.json` relative to the working directory and merges it with the global config. Project values override global ones, while `mcpSearch` objects are shallow-merged so that global defaults fill in any keys omitted locally.

### Why
Individual repositories often need distinct API keys, LLM endpoints, or tool settings. Previously, users could only rely on a single global configuration file.

### Key changes
- `src/config.ts`:
  - `loadConfig` accepts a new optional `cwd` parameter.
  - Reads project-level settings from `<cwd>/.kimchi/config.json`.
  - `readConfigExtras` now parses `apiKey` (falling back to `api_key`) and `llmEndpoint` from JSON config files.
  - Merge logic: project config wins for scalars and arrays; `mcpSearch` is shallow-merged; empty strings gracefully fall back to global values.
- `src/config.test.ts`:
  - Added 8 test cases covering project/global precedence, `mcpSearch` shallow merge, fallback when no project config exists, malformed JSON handling, empty-string fallback, and the restriction against walking up parent directories.

### Impact
Repositories that already contain a `.kimchi/config.json` file will now have those settings loaded automatically and take precedence over the global config. Ensure any existing files contain valid JSON and the intended settings.