### PR TITLE
feat: pause the working indicator while user is prompted for permissions

### DIFF
--- a/src/extensions/permissions/index.test.ts
+++ b/src/extensions/permissions/index.test.ts
@@ -28,6 +28,7 @@ function createMockContext(
 			input: vi.fn(async () => ""),
 			notify: vi.fn(),
 			setStatus: vi.fn(),
+			setWorkingVisible: vi.fn(),
 			theme: {
 				fg: vi.fn((_, s) => s),
 				getFgAnsi: vi.fn(() => ""),
@@ -493,6 +494,7 @@ describe("handleCompoundConfirm", () => {
 				input: vi.fn(async () => ""),
 				notify: vi.fn(),
 				setStatus: vi.fn(),
+				setWorkingVisible: vi.fn(),
 				theme: { fg: vi.fn((_, s) => s), getFgAnsi: vi.fn(() => "") },
 				onTerminalInput: vi.fn(() => () => {}),
 			},

--- a/src/extensions/permissions/index.ts
+++ b/src/extensions/permissions/index.ts
@@ -10,7 +10,7 @@ import { classifyToolCall } from "./classifier.js"
 import { registerCommands } from "./commands.js"
 import { type LoadedConfig, loadConfig } from "./config.js"
 import { resolveMode } from "./mode.js"
-import { type CompoundSubcommand, promptForApproval, promptForCompoundApproval } from "./prompts.js"
+import { type CompoundSubcommand, promptForApproval, promptForCompoundApproval, withWorkingHidden } from "./prompts.js"
 import planModeSupplement from "./prompts/plan-mode-supplement.js"
 import { evaluateRules, parseRules, stringifyRule } from "./rules.js"
 import { SessionMemory } from "./session-memory.js"
@@ -420,11 +420,9 @@ export default function permissionsExtension(pi: ExtensionAPI): void {
 		const EXECUTE_AUTO = "Yes — execute (auto-approve)"
 		const DECLINE = "No, do something else"
 
-		const choice = await ctx.ui.select("Plan complete. How would you like to proceed?", [
-			EXECUTE,
-			EXECUTE_AUTO,
-			DECLINE,
-		])
+		const choice = await withWorkingHidden(ctx, () =>
+			ctx.ui.select("Plan complete. How would you like to proceed?", [EXECUTE, EXECUTE_AUTO, DECLINE]),
+		)
 
 		if (choice === EXECUTE) {
 			switchFromPlanAndExecute(ctx, "default")

--- a/src/extensions/permissions/prompts.test.ts
+++ b/src/extensions/permissions/prompts.test.ts
@@ -1,5 +1,5 @@
-import { describe, expect, it } from "vitest"
-import { truncate } from "./prompts.js"
+import { describe, expect, it, vi } from "vitest"
+import { promptForApproval, truncate } from "./prompts.js"
 
 describe("truncate helper", () => {
 	it("returns original string if under max length", () => {
@@ -12,5 +12,56 @@ describe("truncate helper", () => {
 
 	it("handles exact length strings", () => {
 		expect(truncate("hello", 5)).toBe("hello")
+	})
+})
+
+describe("promptForApproval — withWorkingHidden", () => {
+	function fakeCtx() {
+		return {
+			hasUI: true,
+			ui: {
+				select: vi.fn(async () => "Yes — just this call"),
+				input: vi.fn(),
+				setWorkingVisible: vi.fn(),
+			},
+			// biome-ignore lint/suspicious/noExplicitAny: minimal stub for test
+		} as any
+	}
+
+	it("hides working indicator before select and shows it after", async () => {
+		const ctx = fakeCtx()
+		await promptForApproval({ toolName: "bash", input: { command: "echo hello" }, ctx })
+
+		expect(ctx.ui.setWorkingVisible).toHaveBeenNthCalledWith(1, false)
+		expect(ctx.ui.setWorkingVisible).toHaveBeenNthCalledWith(2, true)
+		// Should be called exactly twice: hide before, show after
+		expect(ctx.ui.setWorkingVisible).toHaveBeenCalledTimes(2)
+	})
+
+	it("shows working indicator even if select throws", async () => {
+		const ctx = fakeCtx()
+		ctx.ui.select = vi.fn(async () => {
+			throw new Error("select failed")
+		})
+		await expect(promptForApproval({ toolName: "bash", input: { command: "echo hello" }, ctx })).rejects.toThrow(
+			"select failed",
+		)
+
+		expect(ctx.ui.setWorkingVisible).toHaveBeenNthCalledWith(1, false)
+		expect(ctx.ui.setWorkingVisible).toHaveBeenNthCalledWith(2, true)
+	})
+
+	it("hides working indicator before feedback input and shows it after", async () => {
+		const ctx = fakeCtx()
+		ctx.ui.select = vi.fn(async () => "No — tell the assistant what to do differently")
+		ctx.ui.input = vi.fn(async () => "Changed my mind")
+
+		const result = await promptForApproval({ toolName: "bash", input: { command: "echo hello" }, ctx })
+
+		expect(result).toEqual({ kind: "deny-with-feedback", feedback: "Changed my mind" })
+		expect(ctx.ui.setWorkingVisible).toHaveBeenNthCalledWith(1, false)
+		expect(ctx.ui.setWorkingVisible).toHaveBeenNthCalledWith(2, true)
+		expect(ctx.ui.setWorkingVisible).toHaveBeenNthCalledWith(3, false)
+		expect(ctx.ui.setWorkingVisible).toHaveBeenNthCalledWith(4, true)
 	})
 })

--- a/src/extensions/permissions/prompts.ts
+++ b/src/extensions/permissions/prompts.ts
@@ -3,6 +3,15 @@ import { numberedChoices, stripChoiceNumber } from "./select-utils.js"
 import { suggestScope } from "./session-memory.js"
 import type { Rule } from "./types.js"
 
+export async function withWorkingHidden<T>(ctx: ExtensionContext, fn: () => Promise<T>): Promise<T> {
+	ctx.ui.setWorkingVisible?.(false)
+	try {
+		return await fn()
+	} finally {
+		ctx.ui.setWorkingVisible?.(true)
+	}
+}
+
 export type ApprovalOutcome =
 	| { kind: "allow-once" }
 	| { kind: "allow-remember"; rule: Rule }
@@ -56,9 +65,7 @@ export async function promptForApproval(opts: PromptOptions): Promise<ApprovalOu
 		yesWildcard ? [yesOnce, yesRemember, yesWildcard, noWithFeedback] : [yesOnce, yesRemember, noWithFeedback],
 	)
 
-	const choice = await ctx.ui.select(lines.join("\n"), choices, {
-		signal: opts.signal,
-	})
+	const choice = await withWorkingHidden(ctx, () => ctx.ui.select(lines.join("\n"), choices, { signal: opts.signal }))
 
 	if (choice === undefined && opts.signal?.aborted) return { kind: "aborted" }
 
@@ -88,7 +95,7 @@ export async function promptForApproval(opts: PromptOptions): Promise<ApprovalOu
 	}
 
 	if (selected === noWithFeedback) {
-		const feedback = await ctx.ui.input("Tell the assistant what to do differently:")
+		const feedback = await withWorkingHidden(ctx, () => ctx.ui.input("Tell the assistant what to do differently:"))
 		const text = feedback?.trim()
 		if (text) return { kind: "deny-with-feedback", feedback: text }
 		return { kind: "deny" }
@@ -126,9 +133,7 @@ export async function promptForCompoundApproval(opts: {
 	]
 	const choices = numberedChoices(compoundChoices)
 
-	const choice = await ctx.ui.select(lines.join("\n"), choices, {
-		signal: opts.signal,
-	})
+	const choice = await withWorkingHidden(ctx, () => ctx.ui.select(lines.join("\n"), choices, { signal: opts.signal }))
 
 	if (choice === undefined && opts.signal?.aborted) return { kind: "aborted" }
 
@@ -146,7 +151,7 @@ export async function promptForCompoundApproval(opts: {
 	}
 	if (selected === compoundChoices[2]) return { kind: "pick-per-subcommand" }
 	if (selected === compoundChoices[3]) {
-		const feedback = await ctx.ui.input("Tell the assistant what to do differently:")
+		const feedback = await withWorkingHidden(ctx, () => ctx.ui.input("Tell the assistant what to do differently:"))
 		const text = feedback?.trim()
 		if (text) return { kind: "deny-with-feedback", feedback: text }
 		return { kind: "deny" }


### PR DESCRIPTION

<img width="1148" height="243" alt="image" src="https://github.com/user-attachments/assets/9b7dfa75-31ca-4ff1-8b3d-8953ab593324" />


---
### Kimchi Summary
### What changed
Temporarily hides the working indicator while permission prompts and feedback inputs are displayed, restoring it once the user responds or if an error occurs.

### Why
Keeps the UI clean by stopping the working animation while the extension is blocked waiting for user input, avoiding the impression that background work is still ongoing.

### Key changes
- `src/extensions/permissions/prompts.ts`: Introduced `withWorkingHidden` helper to wrap async UI interactions with `setWorkingVisible(false)` before and `setWorkingVisible(true)` after (via `finally`). Applied it to `ui.select` and `ui.input` calls in `promptForApproval` and `promptForCompoundApproval`.
- `src/extensions/permissions/index.ts`: Wrapped the plan-completion `ui.select` call with `withWorkingHidden`.
- `src/extensions/permissions/prompts.test.ts`: Added tests for `promptForApproval` asserting the working indicator is hidden before prompts and restored after, including error paths and multi-step feedback flows.
- `src/extensions/permissions/index.test.ts`: Added `setWorkingVisible` mock to existing test contexts to satisfy the UI interface.

### Impact
Working indicator now pauses during all interactive approval prompts instead of continuing in the background.

---
### Kimchi Summary
### What changed
Adds a `withWorkingHidden` helper that temporarily hides the working indicator while presenting `ui.select` and `ui.input` prompts during tool approval flows, restoring it once the user responds.

### Why
The working/loading spinner was visible during interactive approval prompts, cluttering the interface. Hiding it while waiting for user input keeps the prompt readable and focused.

### Key changes
- `src/extensions/permissions/prompts.ts`: Introduced `withWorkingHidden` wrapper; applied it to `promptForApproval` and `promptForCompoundApproval` around `ui.select` and `ui.input` calls.
- `src/extensions/permissions/index.ts`: Wrapped the plan-completion `ui.select` prompt with `withWorkingHidden`.
- `src/extensions/permissions/prompts.test.ts`: Added tests verifying the working indicator is hidden before prompts and restored after (including on error).
- `src/extensions/permissions/index.test.ts`: Updated mock contexts to include `setWorkingVisible`.

### Impact
Safe to roll out: `withWorkingHidden` uses optional chaining (`?.`) when calling `setWorkingVisible`, so UIs that do not implement the method are unaffected.