### PR TITLE
feat(tool-visibility-api): Migrate MCP adapter and permissions to the API for managing tools

### DIFF
--- a/src/extensions/mcp-adapter/direct-tool-visibility.test.ts
+++ b/src/extensions/mcp-adapter/direct-tool-visibility.test.ts
@@ -1,0 +1,61 @@
+import type { ExtensionAPI, ToolInfo } from "@earendil-works/pi-coding-agent"
+import { describe, expect, it, vi } from "vitest"
+import { createDirectToolVisibility } from "./direct-tool-visibility.js"
+
+function makePi(toolNames: string[]): ExtensionAPI & { active: string[] } {
+	const tools = toolNames.map((name) => ({ name }) as ToolInfo)
+	const state = {
+		active: [...toolNames],
+		on: vi.fn(),
+		getAllTools: vi.fn(() => tools),
+		getActiveTools: vi.fn(() => state.active),
+		setActiveTools: vi.fn((names: string[]) => {
+			state.active = names
+		}),
+	}
+	return state as unknown as ExtensionAPI & { active: string[] }
+}
+
+describe("direct MCP tool visibility", () => {
+	it("hides dynamic tools on input and re-exposes already registered dynamic tools", () => {
+		const pi = makePi(["jira_search"])
+		const controller = createDirectToolVisibility(pi)
+		const dynamicToolNames = new Set(["jira_search"])
+
+		controller.hideDynamic(dynamicToolNames)
+		expect(pi.active).toEqual([])
+		expect(dynamicToolNames.size).toBe(0)
+
+		controller.expose(["jira_search"], { markDynamic: true, dynamicToolNames })
+		expect(pi.active).toEqual(["jira_search"])
+		expect([...dynamicToolNames]).toEqual(["jira_search"])
+	})
+
+	it("does not treat permanent tools as transient when discovered through search", () => {
+		const pi = makePi(["jira_search"])
+		const controller = createDirectToolVisibility(pi)
+		const dynamicToolNames = new Set<string>()
+
+		controller.markPermanent(["jira_search"], dynamicToolNames)
+		controller.expose(["jira_search"], { markDynamic: true, dynamicToolNames })
+		controller.hideDynamic(dynamicToolNames)
+
+		expect(pi.active).toEqual(["jira_search"])
+		expect(dynamicToolNames.size).toBe(0)
+	})
+
+	it("promoting a previously dynamic tool to permanent releases the transient hide", () => {
+		const pi = makePi(["jira_search"])
+		const controller = createDirectToolVisibility(pi)
+		const dynamicToolNames = new Set(["jira_search"])
+
+		controller.hideDynamic(dynamicToolNames)
+		expect(pi.active).toEqual([])
+
+		controller.expose(["jira_search"], { markDynamic: false, dynamicToolNames })
+		controller.hideDynamic(dynamicToolNames)
+
+		expect(pi.active).toEqual(["jira_search"])
+		expect(dynamicToolNames.size).toBe(0)
+	})
+})

--- a/src/extensions/mcp-adapter/direct-tool-visibility.ts
+++ b/src/extensions/mcp-adapter/direct-tool-visibility.ts
@@ -1,0 +1,47 @@
+import type { ExtensionAPI } from "@earendil-works/pi-coding-agent"
+import { type ToolVisibilityAPI, createToolVisibility } from "../prompt-construction/tool-visibility.js"
+
+export interface DirectToolVisibilityController {
+	markPermanent(names: readonly string[], dynamicToolNames?: Set<string>): void
+	expose(names: readonly string[], opts: { markDynamic: boolean; dynamicToolNames?: Set<string> }): void
+	hideDynamic(dynamicToolNames: Set<string>): void
+}
+
+export function createDirectToolVisibility(pi: ExtensionAPI): DirectToolVisibilityController {
+	const visibility = createToolVisibility(pi)
+	const permanentToolNames = new Set<string>()
+
+	return {
+		markPermanent(names, dynamicToolNames) {
+			markPermanent(names, permanentToolNames, dynamicToolNames)
+			visibility.enable(names)
+		},
+		expose(names, opts) {
+			if (names.length === 0) return
+			visibility.enable(names)
+			if (opts.markDynamic) {
+				for (const name of names) {
+					if (!permanentToolNames.has(name)) opts.dynamicToolNames?.add(name)
+				}
+				return
+			}
+			markPermanent(names, permanentToolNames, opts.dynamicToolNames)
+		},
+		hideDynamic(dynamicToolNames) {
+			if (dynamicToolNames.size === 0) return
+			visibility.disable([...dynamicToolNames])
+			dynamicToolNames.clear()
+		},
+	}
+}
+
+function markPermanent(
+	names: readonly string[],
+	permanentToolNames: Set<string>,
+	dynamicToolNames: Set<string> | undefined,
+): void {
+	for (const name of names) {
+		permanentToolNames.add(name)
+		dynamicToolNames?.delete(name)
+	}
+}

--- a/src/extensions/mcp-adapter/index.ts
+++ b/src/extensions/mcp-adapter/index.ts
@@ -16,6 +16,7 @@ import {
 	getMissingConfiguredDirectToolServers,
 	resolveDirectTools,
 } from "./direct-tools.js"
+import { createDirectToolVisibility } from "./direct-tool-visibility.js"
 import { flushMetadataCache, initializeMcp, updateStatusBar } from "./init.js"
 import { initializeOAuth, shutdownOAuth } from "./mcp-auth-flow.js"
 import { loadMetadataCache, overwriteMetadataCache, purgeStaleEntries } from "./metadata-cache.js"
@@ -109,6 +110,7 @@ export default function mcpAdapter(pi: ExtensionAPI) {
 
 	// Track all registered tool names to avoid double-registration
 	const registeredToolNames = new Set<string>()
+	const directToolVisibility = createDirectToolVisibility(pi)
 
 	for (const spec of directSpecs) {
 		const cachedServer = earlyCache?.servers?.[spec.serverName]
@@ -136,15 +138,18 @@ export default function mcpAdapter(pi: ExtensionAPI) {
 			),
 		})
 		registeredToolNames.add(spec.prefixedName)
+		directToolVisibility.markPermanent([spec.prefixedName])
 	}
 
 	/**
-	 * Register tool specs with the agent and add them to the active set.
+	 * Register tool specs with the agent and expose them in the active set.
 	 *
 	 * `markDynamic` (default true) tags the new names in `state.dynamicToolNames`
 	 * so the next user input clears them (used by proxy describe/search results).
 	 * Pass `false` for tools that should persist across turns — e.g. direct tools
-	 * registered after a successful cache bootstrap.
+	 * registered after a successful cache bootstrap. `pi.registerTool` activates
+	 * newly registered tools; the visibility controller releases any prior
+	 * transient hide when a previously registered dynamic tool is injected again.
 	 *
 	 * When `state` is not yet ready (callback invoked from inside `initializeMcp`
 	 * before its promise resolves), we only allow the permanent path through —
@@ -162,10 +167,10 @@ export default function mcpAdapter(pi: ExtensionAPI) {
 		const markDynamic = opts?.markDynamic ?? true
 		if (!state && markDynamic) return []
 		const newNames: string[] = []
-		const alreadyActive: string[] = []
+		const alreadyRegistered: string[] = []
 		for (const spec of specs) {
 			if (registeredToolNames.has(spec.prefixedName)) {
-				alreadyActive.push(spec.prefixedName)
+				alreadyRegistered.push(spec.prefixedName)
 				continue
 			}
 			pi.registerTool({
@@ -183,19 +188,11 @@ export default function mcpAdapter(pi: ExtensionAPI) {
 			registeredToolNames.add(spec.prefixedName)
 			newNames.push(spec.prefixedName)
 		}
-		const allInjected = [...alreadyActive, ...newNames]
-		if (newNames.length > 0) {
-			// Guard above ensures `markDynamic` implies `state` is set, so the
-			// dynamic-name bookkeeping is safe without a re-check here.
-			if (markDynamic && state) {
-				for (const name of newNames) {
-					state.dynamicToolNames.add(name)
-				}
-			}
-			const current = new Set(pi.getActiveTools())
-			for (const name of newNames) current.add(name)
-			pi.setActiveTools([...current])
-		}
+		const allInjected = [...alreadyRegistered, ...newNames]
+		directToolVisibility.expose(allInjected, {
+			markDynamic,
+			dynamicToolNames: state?.dynamicToolNames,
+		})
 		return allInjected
 	}
 
@@ -213,10 +210,7 @@ export default function mcpAdapter(pi: ExtensionAPI) {
 
 	pi.on("input", () => {
 		if (!state || state.dynamicToolNames.size === 0) return
-		const dynamic = state.dynamicToolNames
-		const cleaned = pi.getActiveTools().filter((n) => !dynamic.has(n))
-		pi.setActiveTools(cleaned)
-		state.dynamicToolNames.clear()
+		directToolVisibility.hideDynamic(state.dynamicToolNames)
 	})
 
 	const getPiTools = (): ToolInfo[] => pi.getAllTools()

--- a/src/extensions/mcp-adapter/init.ts
+++ b/src/extensions/mcp-adapter/init.ts
@@ -218,8 +218,8 @@ export async function initializeMcp(
 			if (bootstrapped.length > 0) {
 				// Try to register direct tools for the just-bootstrapped servers
 				// in the current session. Avoids the historical "restart required"
-				// dance — the index.ts callback uses pi.registerTool +
-				// pi.setActiveTools, which exposes the tools to subsequent turns
+				// dance — the index.ts callback registers the tools and releases any
+				// transient visibility hide, which exposes them to subsequent turns
 				// without reloading.
 				let injectedCount = 0
 				if (registerBootstrappedDirectTools) {

--- a/src/extensions/permissions/index.test.ts
+++ b/src/extensions/permissions/index.test.ts
@@ -1,6 +1,7 @@
-import type { ExtensionContext, ToolCallEvent } from "@earendil-works/pi-coding-agent"
+import type { ExtensionAPI, ExtensionContext, ToolCallEvent, ToolInfo } from "@earendil-works/pi-coding-agent"
 import { beforeEach, describe, expect, it, vi } from "vitest"
-import { checkCompoundCommand, handleCompoundConfirm } from "./index.js"
+import { createToolVisibility } from "../prompt-construction/tool-visibility.js"
+import permissionsExtension, { checkCompoundCommand, handleCompoundConfirm } from "./index.js"
 import { SessionMemory } from "./session-memory.js"
 import type { Rule } from "./types.js"
 
@@ -29,6 +30,7 @@ function createMockContext(
 			setStatus: vi.fn(),
 			theme: {
 				fg: vi.fn((_, s) => s),
+				getFgAnsi: vi.fn(() => ""),
 			},
 			onTerminalInput: vi.fn(() => () => {}),
 		},
@@ -43,6 +45,103 @@ function createMockEvent(): ToolCallEvent {
 		cwd: "/test",
 	} as unknown as ToolCallEvent
 }
+
+type ExtensionHandler = (event: unknown, ctx: ExtensionContext) => unknown | Promise<unknown>
+type RegisteredCommand = {
+	handler: (args: string, ctx: ExtensionContext) => unknown | Promise<unknown>
+}
+
+function createPermissionsHarness(
+	toolNames: string[],
+	flags: Record<string, boolean | string | undefined> = {},
+	initialActiveTools: string[] = toolNames,
+) {
+	const handlers = new Map<string, ExtensionHandler[]>()
+	const commands = new Map<string, RegisteredCommand>()
+	const tools = toolNames.map((name) => ({ name, description: `${name} tool` }) as ToolInfo)
+	let activeTools = [...initialActiveTools]
+
+	const pi = {
+		registerFlag: vi.fn(),
+		getFlag: vi.fn((name: string) => flags[name]),
+		registerCommand: vi.fn((name: string, command: RegisteredCommand) => {
+			commands.set(name, command)
+		}),
+		on: vi.fn((event: string, handler: ExtensionHandler) => {
+			const list = handlers.get(event) ?? []
+			list.push(handler)
+			handlers.set(event, list)
+		}),
+		getAllTools: vi.fn(() => tools),
+		getActiveTools: vi.fn(() => activeTools),
+		setActiveTools: vi.fn((names: string[]) => {
+			const known = new Set(toolNames)
+			activeTools = names.filter((name) => known.has(name))
+		}),
+		sendMessage: vi.fn(),
+	} as unknown as ExtensionAPI
+
+	permissionsExtension(pi)
+
+	return {
+		pi,
+		commands,
+		activeTools: () => activeTools,
+		async fire(event: string, payload: unknown, ctx: ExtensionContext = createMockContext([])) {
+			for (const handler of handlers.get(event) ?? []) {
+				await handler(payload, ctx)
+			}
+		},
+	}
+}
+
+describe("permissions plan-mode tool visibility", () => {
+	it("leaving plan mode does not restore tools hidden by another extension", async () => {
+		const previousEnv = process.env.KIMCHI_PERMISSIONS
+		try {
+			const harness = createPermissionsHarness(["read", "bash", "write", "edit", "grep"], { plan: true })
+			const peerVisibility = createToolVisibility(harness.pi)
+			peerVisibility.disable(["bash"])
+
+			await harness.fire("session_start", {}, createMockContext([]))
+			expect(harness.activeTools().sort()).toEqual(["grep", "read"])
+
+			const command = harness.commands.get("permissions")
+			expect(command).toBeDefined()
+			await command?.handler("mode default", createMockContext([]))
+
+			expect(harness.activeTools().sort()).toEqual(["edit", "grep", "read", "write"])
+
+			peerVisibility.enable(["bash"])
+			expect(harness.activeTools().sort()).toEqual(["bash", "edit", "grep", "read", "write"])
+		} finally {
+			process.env.KIMCHI_PERMISSIONS = previousEnv
+		}
+	})
+
+	it("leaving plan mode does not activate mutating tools that were already inactive", async () => {
+		const previousEnv = process.env.KIMCHI_PERMISSIONS
+		try {
+			const harness = createPermissionsHarness(["read", "bash", "write", "edit", "grep"], { plan: true }, [
+				"read",
+				"bash",
+				"write",
+				"grep",
+			])
+
+			await harness.fire("session_start", {}, createMockContext([]))
+			expect(harness.activeTools().sort()).toEqual(["bash", "grep", "read"])
+
+			const command = harness.commands.get("permissions")
+			expect(command).toBeDefined()
+			await command?.handler("mode default", createMockContext([]))
+
+			expect(harness.activeTools().sort()).toEqual(["bash", "grep", "read", "write"])
+		} finally {
+			process.env.KIMCHI_PERMISSIONS = previousEnv
+		}
+	})
+})
 
 describe("checkCompoundCommand", () => {
 	it("returns prompt for compound command with no rules", () => {
@@ -394,7 +493,7 @@ describe("handleCompoundConfirm", () => {
 				input: vi.fn(async () => ""),
 				notify: vi.fn(),
 				setStatus: vi.fn(),
-				theme: { fg: vi.fn((_, s) => s) },
+				theme: { fg: vi.fn((_, s) => s), getFgAnsi: vi.fn(() => "") },
 				onTerminalInput: vi.fn(() => () => {}),
 			},
 		} as unknown as ExtensionContext

--- a/src/extensions/permissions/index.ts
+++ b/src/extensions/permissions/index.ts
@@ -4,6 +4,7 @@ import type { ExtensionAPI, ExtensionContext, ToolCallEvent } from "@earendil-wo
 import { isKeyRelease, matchesKey } from "@earendil-works/pi-tui"
 import { RST_FG, resolvedSemanticFg } from "../../ansi.js"
 import { createSystemPromptBlocks } from "../prompt-construction/index.js"
+import { type ToolVisibilityAPI, createToolVisibility } from "../prompt-construction/tool-visibility.js"
 import { resolveClassifierModel } from "./classifier-model.js"
 import { classifyToolCall } from "./classifier.js"
 import { registerCommands } from "./commands.js"
@@ -55,6 +56,7 @@ const EMPTY_LOADED_CONFIG: LoadedConfig = {
 
 // bash is allowed but gated per-command by isReadOnlyBashCommand.
 const PLAN_MODE_TOOLS = ["read", "grep", "find", "ls", "web_search", "web_fetch", "questionnaire", "bash"]
+const PLAN_MODE_TOOL_SET = new Set<string>(PLAN_MODE_TOOLS)
 
 // Tools that auto-approve in headless/auto modes without LLM classification.
 // `set_phase` is a kimchi built-in. `agent`/`get_subagent_result`/`steer_subagent`
@@ -154,8 +156,9 @@ export default function permissionsExtension(pi: ExtensionAPI): void {
 	let configRules: Rule[] = []
 	let runtimeMode: PermissionMode | undefined
 	let cliMode: PermissionMode | undefined
-	let originalActiveTools: string[] | null = null
 	let planModeApplied = false
+	let planModeHiddenTools: string[] = []
+	const planToolVisibility: ToolVisibilityAPI = createToolVisibility(pi)
 	/** Tracks all active permission prompt abort controllers for concurrent tool calls. */
 	const activeAbortControllers = new Set<AbortController>()
 	let unsubscribeTerminalInput: (() => void) | null = null
@@ -195,35 +198,29 @@ export default function permissionsExtension(pi: ExtensionAPI): void {
 		return [...session.all(), ...configRules, ...builtinRules]
 	}
 
+	function isPlanModeTool(name: string): boolean {
+		return PLAN_MODE_TOOL_SET.has(name) || isReadOnlyTool(name)
+	}
+
 	function applyPlanModeTools(): void {
 		if (planModeApplied) return
 		try {
-			if (originalActiveTools === null) {
-				originalActiveTools = pi.getActiveTools()
-			}
-			const allTools = pi.getAllTools()
-			const planTools = new Set<string>()
-			for (const tool of allTools) {
-				if (PLAN_MODE_TOOLS.includes(tool.name) || isReadOnlyTool(tool.name)) {
-					planTools.add(tool.name)
-				}
-			}
-			pi.setActiveTools([...planTools])
+			planModeHiddenTools = pi.getActiveTools().filter((name) => !isPlanModeTool(name))
+			planToolVisibility.disable(planModeHiddenTools)
 			planModeApplied = true
 		} catch {
-			// setActiveTools may be unavailable; tool_call handler still enforces the policy.
+			// Tool visibility may be unavailable; tool_call handler still enforces the policy.
 		}
 	}
 
 	function restoreToolsFromPlanMode(): void {
 		if (!planModeApplied) return
-		if (originalActiveTools) {
-			try {
-				pi.setActiveTools(originalActiveTools)
-			} catch {
-				// best-effort restore
-			}
+		try {
+			planToolVisibility.enable(planModeHiddenTools)
+		} catch {
+			// best-effort restore
 		}
+		planModeHiddenTools = []
 		planModeApplied = false
 	}
 


### PR DESCRIPTION


---
### Kimchi Summary
### What changed
Integrates the `tool-visibility` helper into the MCP adapter and permissions extension. The MCP adapter now uses a dedicated controller to manage direct-tool visibility, and the permissions extension isolates plan-mode changes so they no longer overwrite tool state managed by other extensions.

### Why
Previously, the permissions extension saved a full snapshot of active tools when entering plan mode and restored it on exit, which clobbered visibility changes made by the MCP adapter (e.g., hiding dynamic search results). Direct MCP tools also lacked a clean mechanism to distinguish permanent registrations from transient ones.

### Key changes
*   `src/extensions/mcp-adapter/direct-tool-visibility.ts`: Adds `createDirectToolVisibility`, a controller wrapping `createToolVisibility` that exposes tools, marks them permanent or dynamic, and hides dynamic tools on user input.
*   `src/extensions/mcp-adapter/index.ts`: Replaces inline `pi.setActiveTools` and `dynamicToolNames` bookkeeping with `directToolVisibility.expose`, `hideDynamic`, and `markPermanent`. Marks direct-spec tools permanent on initial registration.
*   `src/extensions/permissions/index.ts`: Refactors plan mode to use `createToolVisibility`. Instead of snapshotting all active tools with `originalActiveTools`, it now records only `planModeHiddenTools` and calls `planToolVisibility.disable`/`enable`, avoiding interference with external visibility changes.
*   `src/extensions/mcp-adapter/direct-tool-visibility.test.ts` and `src/extensions/permissions/index.test.ts`: Added/expanded tests to verify that leaving plan mode respects externally hidden tools and pre-existing inactive tools, and that direct-tool lifecycle transitions (dynamic → permanent) work correctly.

### Impact
*   **Fixes:** Leaving plan mode no longer restores tools that were hidden by the MCP adapter or other extensions, and does not force-enable tools that were inactive before plan mode started.
*   **Behavior:** MCP direct tools registered at startup are treated as permanent; tools discovered dynamically (e.g., via search) remain transient and are hidden on the next user input.