### PR TITLE
feat(orchestration): update model capabilities and delegation guidelines

### DIFF
--- a/src/extensions/orchestration/model-registry/builtin-models.ts
+++ b/src/extensions/orchestration/model-registry/builtin-models.ts
@@ -191,7 +191,7 @@ export const MODEL_CAPABILITIES: ReadonlyMap<string, ModelCapabilities | "ignore
 		"claude-opus-4-7",
 		{
 			vision: true,
-			strengths: ["explore", "research", "plan", "review"],
+			strengths: ["research", "plan", "review"],
 			tier: "heavy",
 			description: CLAUDE_OPUS_47_DESCRIPTION,
 			guidelines: {

--- a/src/extensions/orchestration/model-registry/by-strength.test.ts
+++ b/src/extensions/orchestration/model-registry/by-strength.test.ts
@@ -5,7 +5,8 @@ describe("modelsForStrength", () => {
 	it("explore strength returns all explore-capable models in registry insertion order", () => {
 		const result = modelsForStrength("explore")
 		// Order is MODEL_CAPABILITIES insertion order — NOT a tier ranking.
-		expect(result).toEqual(["kimchi-dev/nemotron-3-super-fp4", "kimchi-dev/claude-opus-4-7"])
+		// nemotron-3-super-fp4 is currently the only model with explore strength.
+		expect(result).toEqual(["kimchi-dev/nemotron-3-super-fp4"])
 	})
 
 	it("build strength returns build-capable models", () => {
@@ -22,8 +23,8 @@ describe("modelsForStrength", () => {
 	})
 
 	it("filters to availableIds when provided", () => {
-		const result = modelsForStrength("explore", { availableIds: new Set(["claude-opus-4-7"]) })
-		expect(result).toEqual(["kimchi-dev/claude-opus-4-7"])
+		const result = modelsForStrength("explore", { availableIds: new Set(["nemotron-3-super-fp4"]) })
+		expect(result).toEqual(["kimchi-dev/nemotron-3-super-fp4"])
 	})
 
 	it("returns empty array when no model matches the strength", () => {

--- a/src/extensions/orchestration/model-registry/recommend.test.ts
+++ b/src/extensions/orchestration/model-registry/recommend.test.ts
@@ -26,8 +26,8 @@ describe("recommendModel", () => {
 	})
 
 	it("respects vision filter — excludes non-vision models", () => {
-		// explore has vision models (kimi-k2.6, kimi-k2.5, claude-opus-4-7)
-		const result = recommendModel({ strengths: ["explore"], needsVision: true })
+		// research + vision: kimi-k2.6, kimi-k2.5, claude-opus-4-7 have research with vision
+		const result = recommendModel({ strengths: ["research"], needsVision: true })
 		expect(result).toBeDefined()
 		expect(result?.capabilities.vision).toBe(true)
 	})
@@ -62,10 +62,11 @@ describe("recommendModel", () => {
 	})
 
 	it("returns first by registry insertion order when multiple match same tier", () => {
-		// explore + heavy: only claude-opus-4-7 currently matches explore at heavy tier.
-		const result = recommendModel({ strengths: ["explore"], preferTier: "heavy" })
+		// plan + heavy: kimi-k2.6 and kimi-k2.5 and claude-opus-4-7 have plan at heavy tier.
+		// First by registry insertion order is kimi-k2.6.
+		const result = recommendModel({ strengths: ["plan"], preferTier: "heavy" })
 		expect(result).toBeDefined()
-		expect(result?.modelId).toBe("claude-opus-4-7")
+		expect(result?.modelId).toBe("kimi-k2.6")
 	})
 
 	it("returns undefined for empty strengths that somehow miss all models — sanity check with impossible combo", () => {

--- a/src/extensions/orchestration/orchestration-instructions.ts
+++ b/src/extensions/orchestration/orchestration-instructions.ts
@@ -93,6 +93,7 @@ Use the **Available Models** section above to pick the right model for each dele
 - Match the model's **tier** to the complexity: light for simple well-scoped work, heavy for ambiguous or multi-step work.
 - If the subtask involves images or visual content, you MUST select a model with \`Vision: yes\`.
 - Prefer cheaper models for mechanical work once the design is settled.
+- **Use the lightest model with the required capability.** Unless the task explicitly requires non-usual approach (e.g., deep architectural planning, complex task decomposition), prefer the lightest tier model that has the required strength. For example, use nemotron‑3‑super‑fp4 for exploration and simple well‑defined tasks rather than kimi‑k2.6 or claude‑opus‑4‑7.
 - **Tool call classification** (permission checks in auto mode) automatically uses the cheapest available model. Do not override this — it is handled by the runtime and should not influence your model selection for user-facing tasks.
 
 ### Review delegation
@@ -100,6 +101,7 @@ Use the **Available Models** section above to pick the right model for each dele
 Review is often the most token-intensive phase — it involves reading files, running tests, writing smoke harnesses, and iterating on fixes. Most of this work is mechanical verification, not architectural judgment.
 
 - **Delegate mechanical review to a standard-tier model.** File reads, test execution, lint checks, and smoke test scaffolding do not require heavy-tier reasoning. Spawn a standard-tier subagent with the diff and spec attached, a 150k budget, and a clear checklist of what to verify.
+- **Use a different model than build/plan when possible.** If the build subagent was a heavy‑tier model (e.g., minimax‑m2.7), avoid using that same model for review — delegate review to a different model (e.g., nemotron‑3‑super‑fp4 or kimi‑k2.5). Fresh eyes catch different issues and reduce over‑reliance on a single model's biases.
 - **Reserve the orchestrator for the final judgment call.** Once the review subagent returns its findings, assess the results yourself: is the architecture sound? Do the interfaces match the spec? Are there design-level issues the automated checks could not catch?
 - **Never run a full review loop yourself when a cheaper model can do it.** If you find yourself reading files, running \`go test\`, and fixing lint errors in sequence, that is mechanical work — delegate it.
 


### PR DESCRIPTION
## Summary

This PR updates the orchestration model registry and delegation guidelines:

### Changes

1. **Removed `explore` strength from claude-opus-4-7**
   - The Opus model no longer lists `explore` among its strengths (`research`, `plan`, `review` remain)

2. **Extended Review delegation guidance**
   - Added instruction to use a different model for review than was used for build/plan
   - This ensures fresh perspectives and reduces over-reliance on a single model's biases

3. **Added lightest-model selection guidance**
   - Orchestrator now instructed to prefer the lightest tier model with the required capability
   - Unless task explicitly requires claude-opus-4-7, use nemotron-3-super-fp4 for simple tasks

4. **Updated tests**
   - Fixed by-strength.test.ts and recommend.test.ts to reflect the new model capabilities

### Testing

- [x] Unit tests pass
- [x] Type check passes
- [x] Lint passes

---
### Kimchi Summary
### What changed
Removes `explore` from `claude-opus-4-7`'s strengths, leaving `nemotron-3-super-fp4` as the sole explore model, and updates orchestration instructions to prefer the lightest capable model and avoid reusing the same model for build and review.

### Why
Prevents over-use of heavy-tier models for exploration work and reduces model-specific bias during review by ensuring different models handle build and verification phases.

### Key changes
* `builtin-models.ts`: Removed `"explore"` from the `strengths` array of `claude-opus-4-7`.
* `by-strength.test.ts`: Updated `explore` strength expectations to return only `nemotron-3-super-fp4`, and adjusted `availableIds` filter tests accordingly.
* `recommend.test.ts`: Replaced `explore`-based test cases with `research` and `plan` strengths to align with the updated capability registry.
* `orchestration-instructions.ts`: Added guidance to always select the lightest tier model that provides the required capability. Added instruction to delegate review to a different model than the build/plan subagent to get fresh eyes and avoid single-model biases.

### Impact
`explore` tasks will now exclusively target `nemotron-3-super-fp4` instead of `claude-opus-4-7`. Review delegation should now use a distinct model from the build/plan phase where possible.