### PR TITLE
fix(models): remove cacheControlFormat from provider config

### DIFF
--- a/src/models.ts
+++ b/src/models.ts
@@ -87,7 +87,6 @@ function buildModelsConfig(models: ModelMetadata[]) {
 				apiKey: "KIMCHI_API_KEY",
 				api: "openai-completions",
 				authHeader: true,
-				cacheControlFormat: "anthropic",
 				headers: { "User-Agent": `kimchi/${getVersion()}` },
 				models: models.map(metadataToModel),
 			},


### PR DESCRIPTION
## Summary

Removes the `cacheControlFormat: 'anthropic'` setting from the kimchi provider configuration.

## Problem

The `cacheControlFormat` was incorrectly set to `'anthropic'` for the kimchi provider. This format is provider-specific and doesn't apply to the general openai-completions API, causing cache control headers to be formatted incorrectly for non-Anthropic model requests.

## Changes

- Removed `cacheControlFormat: 'anthropic'` from the openai-completions provider config in `src/models.ts`

---
### Kimchi Summary
### What changed
Removed the `cacheControlFormat: "anthropic"` override from the default `openai-completions` model configuration.

### Why
The default model config incorrectly applied Anthropic-style cache control formatting to the OpenAI completions API endpoint.

### Key changes
- `src/models.ts`: Removed `cacheControlFormat: "anthropic"` from the object returned by `buildModelsConfig`.

### Impact
Ensures cache control headers are formatted correctly for OpenAI-compatible endpoints instead of using the Anthropic format.