### PR TITLE
Preserve user-added providers when updating models.json

### DIFF
--- a/src/models.test.ts
+++ b/src/models.test.ts
@@ -160,8 +160,8 @@ describe("updateModelsConfig", () => {
 		expect(result.models.map((m) => m.slug)).toEqual(["kimi-k2.5", "glm-5-fp8"])
 	})
 
-	it("overwrites an existing models.json with fetched metadata", async () => {
-		writeFileSync(modelsJsonPath, JSON.stringify({ providers: { custom: {} } }))
+	it("preserves user-added providers when updating models.json", async () => {
+		writeFileSync(modelsJsonPath, JSON.stringify({ providers: { custom: { models: [] } } }))
 		vi.mocked(fetch).mockResolvedValueOnce({
 			ok: true,
 			json: async () => ({ models: [KIMI] }),
@@ -171,6 +171,7 @@ describe("updateModelsConfig", () => {
 
 		const config = JSON.parse(readFileSync(modelsJsonPath, "utf-8"))
 		expect(config.providers["kimchi-dev"].models.map((m: { id: string }) => m.id)).toEqual(["kimi-k2.5"])
+		expect(config.providers.custom).toEqual({ models: [] })
 	})
 
 	it("throws on fetch failure when no cached config exists", async () => {

--- a/src/models.ts
+++ b/src/models.ts
@@ -1,4 +1,4 @@
-import { mkdirSync, readFileSync, writeFileSync } from "node:fs"
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs"
 import { dirname } from "node:path"
 import { getVersion } from "./utils.js"
 
@@ -125,6 +125,19 @@ function readCachedMetadata(modelsJsonPath: string): ModelMetadata[] | undefined
 	}
 }
 
+function readExistingProviders(modelsJsonPath: string): Record<string, unknown> {
+	if (!existsSync(modelsJsonPath)) return {}
+	try {
+		const raw = readFileSync(modelsJsonPath, "utf-8")
+		const config = JSON.parse(raw)
+		const providers = config?.providers ?? {}
+		const { "kimchi-dev": _kimchi, ...rest } = providers as Record<string, unknown>
+		return rest
+	} catch {
+		return {}
+	}
+}
+
 export async function validateApiKey(apiKey: string): Promise<void> {
 	await fetchAvailableModels(apiKey)
 }
@@ -136,6 +149,9 @@ export async function validateApiKey(apiKey: string): Promise<void> {
  * If the fetch fails and the previous models.json is still on disk, returns
  * the cached models with a warning. Throws only when a key is present but
  * there is no cache to fall back on.
+ *
+ * User-added providers (anything other than "kimchi-dev") are preserved across
+ * updates so custom model configurations are not lost on startup.
  */
 export async function updateModelsConfig(modelsJsonPath: string, apiKey: string): Promise<ModelsConfigResult> {
 	const dir = dirname(modelsJsonPath)
@@ -144,6 +160,8 @@ export async function updateModelsConfig(modelsJsonPath: string, apiKey: string)
 	if (!apiKey) {
 		return { models: readCachedMetadata(modelsJsonPath) ?? [] }
 	}
+
+	const otherProviders = readExistingProviders(modelsJsonPath)
 
 	let fetched: ModelMetadata[]
 	try {
@@ -157,6 +175,7 @@ export async function updateModelsConfig(modelsJsonPath: string, apiKey: string)
 	}
 
 	const models = sortModels(fetched)
-	writeFileSync(modelsJsonPath, JSON.stringify(buildModelsConfig(models), null, "\t"), "utf-8")
+	const merged = { providers: { ...otherProviders, ...buildModelsConfig(models).providers } }
+	writeFileSync(modelsJsonPath, JSON.stringify(merged, null, "\t"), "utf-8")
 	return { models }
 }


### PR DESCRIPTION
## Problem

Every time `kimchi` starts up, `updateModelsConfig()` overwrites the entire `models.json` file with only the `kimchi-dev` provider block. Any user-added custom providers (e.g. Moonshot, Ollama, vLLM, LM Studio) are silently discarded.

## Fix

1. Read existing providers from `models.json` before writing (excluding `kimchi-dev`).
2. Merge the fetched `kimchi-dev` block back together with the user's custom providers.
3. Updated the test to assert preservation instead of asserting the old destructive overwrite behavior.

## Verification

- All 17 `updateModelsConfig()` unit tests pass.
- Custom providers like `moonshot` are retained across `kimchi` restarts.

---
### Kimchi Summary
### What changed
`updateModelsConfig` now preserves user-added providers in `models.json` when fetching updated model metadata. Custom provider entries are merged with the latest fetched configuration instead of being overwritten.

### Why
Previously, refreshing models on startup overwrote the entire `models.json` file, erasing any manually configured custom providers.

### Key changes
- `src/models.ts`: Added `readExistingProviders()` to extract existing non-`kimchi-dev` providers from the current `models.json`.
- `src/models.ts`: `updateModelsConfig()` merges preserved user providers with fetched `kimchi-dev` metadata before writing the file.
- `src/models.test.ts`: Updated test to verify that custom providers survive config updates.