### PR TITLE
feat: change multi-model shortcut from alt+tab to alt+m

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,7 +109,7 @@ To disable orchestration and run as a single, direct coding assistant:
 kimchi --multi-model=false
 ```
 
-You can also toggle the mode at any time during a session with the **option/alt+tab** keyboard shortcut. The current state is shown in the footer (`multi-model: on` / `multi-model: off`).
+You can also toggle the mode at any time during a session with the **alt+m** keyboard shortcut. The current state is shown in the footer (`multi-model: on` / `multi-model: off`).
 
 When multi-model is off the agent uses a single-model system prompt: environment, tools, research rules, guidelines, and phase tagging are all active, but task classification and delegation logic are disabled. The subagent tool is still available if you explicitly ask the agent to delegate a task.
 

--- a/src/components/footer.test.ts
+++ b/src/components/footer.test.ts
@@ -173,46 +173,16 @@ describe("compact-form builders", () => {
 	})
 
 	describe("buildMultiModelAbbrev", () => {
-		it("uses `m-m:` instead of `multi-model:` when enabled (darwin)", () => {
-			const restore = stubPlatform("darwin")
-			try {
-				const seg = buildMultiModelAbbrev(compactCtx, true)
-				expect(seg.id).toBe("multi-model")
-				expect(seg.text).toBe("m-m: on \u2192 option+tab")
-				expect(seg.raw).toEqual({ kind: "multi-model", enabled: true })
-			} finally {
-				restore()
-			}
+		it("uses `m-m:` instead of `multi-model:` when enabled", () => {
+			const seg = buildMultiModelAbbrev(compactCtx, true)
+			expect(seg.id).toBe("multi-model")
+			expect(seg.text).toBe("m-m: on \u2192 alt+m")
+			expect(seg.raw).toEqual({ kind: "multi-model", enabled: true })
 		})
 
-		it("shows `off` when disabled (darwin)", () => {
-			const restore = stubPlatform("darwin")
-			try {
-				const seg = buildMultiModelAbbrev(compactCtx, false)
-				expect(seg.text).toBe("m-m: off \u2192 option+tab")
-			} finally {
-				restore()
-			}
-		})
-
-		it("uses `alt+tab` shortcut on non-darwin (enabled)", () => {
-			const restore = stubPlatform("linux")
-			try {
-				const seg = buildMultiModelAbbrev(compactCtx, true)
-				expect(seg.text).toBe("m-m: on \u2192 alt+tab")
-			} finally {
-				restore()
-			}
-		})
-
-		it("uses `alt+tab` shortcut on non-darwin (disabled)", () => {
-			const restore = stubPlatform("linux")
-			try {
-				const seg = buildMultiModelAbbrev(compactCtx, false)
-				expect(seg.text).toBe("m-m: off \u2192 alt+tab")
-			} finally {
-				restore()
-			}
+		it("shows `off` when disabled", () => {
+			const seg = buildMultiModelAbbrev(compactCtx, false)
+			expect(seg.text).toBe("m-m: off \u2192 alt+m")
 		})
 	})
 
@@ -239,14 +209,8 @@ describe("SHORTCUT_TAIL regex", () => {
 		expect(text.replace(SHORTCUT_TAIL, "")).toBe("\u25cf default")
 	})
 
-	it("matches the multi-model trailing shortcut (darwin)", () => {
-		const text = "multi-model: on \x1b[38;5;242m\u2192 option+tab\x1b[39m"
-		expect(SHORTCUT_TAIL.test(text)).toBe(true)
-		expect(text.replace(SHORTCUT_TAIL, "")).toBe("multi-model: on")
-	})
-
-	it("matches the multi-model trailing shortcut (linux)", () => {
-		const text = "multi-model: on \x1b[38;5;242m\u2192 alt+tab\x1b[39m"
+	it("matches the multi-model trailing shortcut", () => {
+		const text = "multi-model: on \x1b[38;5;242m\u2192 alt+m\x1b[39m"
 		expect(SHORTCUT_TAIL.test(text)).toBe(true)
 		expect(text.replace(SHORTCUT_TAIL, "")).toBe("multi-model: on")
 	})
@@ -302,7 +266,7 @@ describe("StatsFooter behavioural acceptance at representative widths", () => {
 	it("width 160: full footer + `/ for commands` hint, padded to width", () => {
 		const { raw, visible } = renderAt(160)
 		expect(visible).toContain("\u25cf default \u2192 shift+tab")
-		expect(visible).toContain("multi-model: on \u2192 option+tab")
+		expect(visible).toContain("multi-model: on \u2192 alt+m")
 		expect(visible).toContain("claude-opus-4-7")
 		expect(visible).toContain("0% ctx")
 		expect(visible).toContain("phase:explore")

--- a/src/components/footer.ts
+++ b/src/components/footer.ts
@@ -10,7 +10,7 @@ import { getActiveAgentCount } from "../extensions/agents/index.js"
 import { getActiveFerment, getCurrentPhaseIndex } from "../extensions/ferment/index.js"
 import { formatCount } from "../extensions/format.js"
 import { getCurrentPermissionsMode } from "../extensions/permissions/index.js"
-import { getMultiModelEnabled } from "../extensions/prompt-construction/prompt-enrichment.js"
+import { MULTI_MODEL_SHORTCUT, getMultiModelEnabled } from "../extensions/prompt-construction/prompt-enrichment.js"
 import { getActiveTags, getCurrentPhase, parseTag } from "../extensions/tags.js"
 
 /** Stable identifier used by compaction steps to find segments. */
@@ -192,7 +192,7 @@ export function buildContextCompact(ctx: CompactionContext, percent: number, pct
 /** Compact form for multi-model: replaces "multi-model:" with "m-m:". */
 export function buildMultiModelAbbrev(ctx: CompactionContext, enabled: boolean): Segment {
 	const label = enabled ? ctx.accent("on") : ctx.dim("off")
-	const shortcut = process.platform === "darwin" ? "option+tab" : "alt+tab"
+	const shortcut = MULTI_MODEL_SHORTCUT
 	const text = `${ctx.dim("m-m:")} ${label} ${ctx.dim(`→ ${shortcut}`)}`
 	return {
 		id: "multi-model",
@@ -444,7 +444,7 @@ export class StatsFooter implements Component {
 	private multiModelSegment(): Segment {
 		const enabled = getMultiModelEnabled()
 		const label = enabled ? this.accent("on") : this.dim("off")
-		const shortcut = process.platform === "darwin" ? "option+tab" : "alt+tab"
+		const shortcut = MULTI_MODEL_SHORTCUT
 		const text = `${this.dim("multi-model:")} ${label} ${this.dim(`→ ${shortcut}`)}`
 		return { id: "multi-model", text, width: visibleWidth(text), raw: { kind: "multi-model", enabled } }
 	}

--- a/src/extensions/prompt-construction/prompt-enrichment.ts
+++ b/src/extensions/prompt-construction/prompt-enrichment.ts
@@ -115,9 +115,7 @@ function readMultiModelArgv(): boolean {
 
 let multiModelEnabled = readMultiModelArgv()
 
-// macOS terminals send the legacy escape sequence \x1b\t for Option+Tab
-// instead of the Kitty protocol / CSI-u sequences handled by matchesKey()
-const LEGACY_MACOS_ALT_TAB_SEQUENCE = "\x1b\t"
+export const MULTI_MODEL_SHORTCUT = "alt+m"
 
 /**
  * Shape of a tool-call content block as emitted in assistant messages.
@@ -216,21 +214,21 @@ export default function (skillPaths: string[]) {
 
 		pi.registerFlag("multi-model", {
 			type: "boolean",
-			description: "Enable multi-model orchestration (default: enabled). Toggle with alt+tab.",
+			description: `Enable multi-model orchestration (default: enabled). Toggle with ${MULTI_MODEL_SHORTCUT}.`,
 			default: true,
 		})
 
 		// For sub agents we don't want to transform the prompt sent from parent with model capabilities
 		const registry = new ModelRegistry(getAvailableModels())
 		if (!subagentMode) {
-			// Global terminal input listener so alt+tab works even when a
+			// Global terminal input listener so alt+m works even when a
 			// dialog (e.g. permission prompt) has focus instead of the editor.
-			let unsubAltTab: (() => void) | null = null
+			let unsubMultiModelToggle: (() => void) | null = null
 			pi.on("session_start", async (_event, ctx) => {
-				if (unsubAltTab) unsubAltTab()
+				if (unsubMultiModelToggle) unsubMultiModelToggle()
 				if (ctx.hasUI) {
-					unsubAltTab = ctx.ui.onTerminalInput((data) => {
-						if (matchesKey(data, "alt+tab") || data === LEGACY_MACOS_ALT_TAB_SEQUENCE) {
+					unsubMultiModelToggle = ctx.ui.onTerminalInput((data) => {
+						if (matchesKey(data, MULTI_MODEL_SHORTCUT)) {
 							if (!isKeyRelease(data)) {
 								multiModelEnabled = !multiModelEnabled
 								ctx.ui.setStatus("multi-model", undefined)

--- a/src/extensions/ui.ts
+++ b/src/extensions/ui.ts
@@ -14,7 +14,7 @@ import { LogoHeader } from "../components/logo.js"
 import { SplashHeader } from "../components/splash-header.js"
 import { collapseAll, expandNext, resetState } from "../expand-state.js"
 import { isBareExitAlias } from "./exit-utils.js"
-import { getMultiModelEnabled } from "./prompt-construction/prompt-enrichment.js"
+import { MULTI_MODEL_SHORTCUT, getMultiModelEnabled } from "./prompt-construction/prompt-enrichment.js"
 import { createWorkingAnimator } from "./spinner.js"
 
 function modelsAreEqual(a: Model<Api>, b: Model<Api>): boolean {
@@ -174,7 +174,7 @@ export default function uiExtension(pi: ExtensionAPI) {
 				if (perm) parts.push(perm)
 				const enabled = getMultiModelEnabled()
 				const label = enabled ? `${resolvedAccentFg(theme)}on${RST_FG}` : theme.fg("dim", "off")
-				const shortcut = process.platform === "darwin" ? "option+tab" : "alt+tab"
+				const shortcut = MULTI_MODEL_SHORTCUT
 				parts.push(`${theme.fg("dim", "multi-model:")} ${label} ${theme.fg("dim", `→ ${shortcut}`)}`)
 				return parts.join(` ${theme.fg("dim", "·")} `)
 			}


### PR DESCRIPTION


---
### Kimchi Summary
### What changed
Changes the keyboard shortcut for toggling multi-model orchestration from a platform-specific combination (`option+tab` on macOS, `alt+tab` elsewhere) to the unified `alt+m` shortcut on all platforms.

### Why
The previous shortcut conflicted with native OS window-switching behavior and required platform-specific handling. A single cross-platform key binding simplifies the UX and eliminates collision with system defaults.

### Key changes
- `src/extensions/prompt-construction/prompt-enrichment.ts`: Introduces exported constant `MULTI_MODEL_SHORTCUT` set to `"alt+m"`; removes `LEGACY_MACOS_ALT_TAB_SEQUENCE` and the dual `matchesKey`/`alt+tab` fallback; renames `unsubAltTab` to `unsubMultiModelToggle`; updates the `multi-model` flag description.
- `src/components/footer.ts`: Replaces `process.platform` ternary in `buildMultiModelAbbrev` and `multiModelSegment` with `MULTI_MODEL_SHORTCUT`.
- `src/extensions/ui.ts`: Replaces platform-specific shortcut logic in status-bar rendering with `MULTI_MODEL_SHORTCUT`.
- `src/components/footer.test.ts`: Collapses darwin/linux test branches into unified assertions expecting `alt+m`.
- `README.md`: Updates documented toggle shortcut from `option/alt+tab` to `alt+m`.

### Impact
This is a user-facing behavioral change: anyone previously using `alt+tab` or `option+tab` to toggle multi-model mode must use `alt+m` instead. The change applies consistently across macOS, Linux, and Windows.