### PR TITLE
fix: show "option+m" shortcut label on macOS

### DIFF
--- a/src/components/footer.test.ts
+++ b/src/components/footer.test.ts
@@ -176,13 +176,13 @@ describe("compact-form builders", () => {
 		it("uses `m-m:` instead of `multi-model:` when enabled", () => {
 			const seg = buildMultiModelAbbrev(compactCtx, true)
 			expect(seg.id).toBe("multi-model")
-			expect(seg.text).toBe("m-m: on \u2192 alt+m")
+			expect(seg.text).toBe(`m-m: on \u2192 ${ORCHESTRATION.MULTI_MODEL_SHORTCUT}`)
 			expect(seg.raw).toEqual({ kind: "multi-model", enabled: true })
 		})
 
 		it("shows `off` when disabled", () => {
 			const seg = buildMultiModelAbbrev(compactCtx, false)
-			expect(seg.text).toBe("m-m: off \u2192 alt+m")
+			expect(seg.text).toBe(`m-m: off \u2192 ${ORCHESTRATION.MULTI_MODEL_SHORTCUT}`)
 		})
 	})
 
@@ -266,7 +266,7 @@ describe("StatsFooter behavioural acceptance at representative widths", () => {
 	it("width 160: full footer + `/ for commands` hint, padded to width", () => {
 		const { raw, visible } = renderAt(160)
 		expect(visible).toContain("\u25cf default \u2192 shift+tab")
-		expect(visible).toContain("multi-model: on \u2192 alt+m")
+		expect(visible).toContain(`multi-model: on \u2192 ${ORCHESTRATION.MULTI_MODEL_SHORTCUT}`)
 		expect(visible).toContain("claude-opus-4-7")
 		expect(visible).toContain("0% ctx")
 		expect(visible).toContain("phase:explore")

--- a/src/extensions/prompt-construction/prompt-enrichment.ts
+++ b/src/extensions/prompt-construction/prompt-enrichment.ts
@@ -121,7 +121,7 @@ function isDelegationToolCallName(name: string | undefined): boolean {
 	return name != null && DELEGATION_TOOL_NAMES.has(name)
 }
 
-export const MULTI_MODEL_SHORTCUT = "alt+m"
+export const MULTI_MODEL_SHORTCUT = process.platform === "darwin" ? "option+m" : "alt+m"
 
 /**
  * Shape of a tool-call content block as emitted in assistant messages.
@@ -234,7 +234,7 @@ export default function (skillPaths: string[]) {
 				if (unsubMultiModelToggle) unsubMultiModelToggle()
 				if (ctx.hasUI) {
 					unsubMultiModelToggle = ctx.ui.onTerminalInput((data) => {
-						if (matchesKey(data, MULTI_MODEL_SHORTCUT)) {
+						if (matchesKey(data, MULTI_MODEL_SHORTCUT) || data === "µ") {
 							if (!isKeyRelease(data)) {
 								multiModelEnabled = !multiModelEnabled
 								ctx.ui.setStatus("multi-model", undefined)


### PR DESCRIPTION


---
### Kimchi Summary
### What changed

Fixes the multi-model keyboard shortcut to render `option+m` on macOS and `alt+m` on other platforms. The terminal input handler now also detects the `µ` character produced by `option+m` on macOS so the toggle actually works on that platform.

### Why

On macOS, pressing `option+m` inputs the `µ` character rather than a standard `alt+m` key sequence, which caused the existing shortcut to be ignored.

### Key changes

- `src/extensions/prompt-construction/prompt-enrichment.ts`
  - Made `MULTI_MODEL_SHORTCUT` platform-aware: returns `"option+m"` when `process.platform === "darwin"`, otherwise `"alt+m"`.
  - Added a check for `data === "µ"` in the `onTerminalInput` callback alongside `matchesKey(data, MULTI_MODEL_SHORTCUT)` so macOS `option+m` keystrokes correctly toggle multi-model mode.

- `src/components/footer.test.ts`
  - Replaced hardcoded `"alt+m"` strings in test expectations with `` `m-m: on \u2192 ${ORCHESTRATION.MULTI_MODEL_SHORTCUT}` `` to stay aligned with the cross-platform constant.