### PR TITLE
fix: make sure startup position is not broken on warp terminal

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -49,7 +49,7 @@ import webSearchExtension from "./extensions/web-search/index.js"
 import { updateModelsConfig } from "./models.js"
 import { runSetupWizard } from "./setup-wizard.js"
 import { setAvailableModels } from "./startup-context.js"
-import { detectColorMode, hexToBgAnsi, probeTerminalBackground } from "./terminal-bg-probe.js"
+import { probeTerminalBackground } from "./terminal-bg-probe.js"
 import { installCloudflare524RetryPatch } from "./upstream-retry-patch.js"
 import { getVersion } from "./utils.js"
 
@@ -260,35 +260,9 @@ try {
 			if (destContent !== srcContent) writeFileSync(dest, srcContent)
 		}
 
-		// Paint the initial viewport background before pi-mono renders its first frame.
-		// This ensures blank areas of the terminal reflect the theme color from the start,
-		// on every terminal regardless of OSC 10/11 support.
+		// Clear the visible viewport and home the cursor so kimchi renders at the top.
 		if (!acpMode && process.stdout.isTTY) {
-			try {
-				const settings = JSON.parse(readFileSync(settingsPath, "utf-8"))
-				const themeName: string = settings.theme ?? "kimchi-minimal"
-				const themeRaw = readFileSync(resolve(themesDir, `${basename(themeName)}.json`), "utf-8")
-				const theme = JSON.parse(themeRaw)
-				const vars: Record<string, string> = theme.vars ?? {}
-				const oscBgRaw: string = theme.colors?.oscBg ?? ""
-				if (oscBgRaw) {
-					const bgHex: string = vars[oscBgRaw] ?? oscBgRaw
-					if (/^#[0-9a-fA-F]{6}$/.test(bgHex)) {
-						const bgAnsi = hexToBgAnsi(bgHex, detectColorMode())
-						const cols = process.stdout.columns || 80
-						const rows = process.stdout.rows || 24
-						const line = `${bgAnsi}${" ".repeat(cols)}`
-						process.stdout.write(`\x1b[H${Array.from({ length: rows }, () => line).join("\r\n")}\x1b[H\x1b[0m`)
-					}
-				}
-			} catch (err) {
-				// ENOENT is the expected first-run case (no settings.json or theme file yet);
-				// pi-mono will render normally. Surface anything else so corrupt JSON or
-				// unexpected I/O errors don't disappear silently.
-				if ((err as NodeJS.ErrnoException).code !== "ENOENT") {
-					console.warn(`Warning: startup viewport paint failed: ${(err as Error).message}`)
-				}
-			}
+			process.stdout.write("\x1b[2J\x1b[H")
 		}
 
 		// Suppress Node.js warnings (same as pi-mono's own cli.js)


### PR DESCRIPTION


---
### Kimchi Summary
### What changed
Replaces the theme-aware startup viewport painting with a simple clear-screen / home-cursor escape sequence so kimchi begins rendering from the top-left of the terminal.

### Why
The previous logic attempted to pre-paint the terminal background by reading `settings.json` and theme files before the first frame, which added unnecessary complexity and I/O failure modes for ensuring correct initial positioning.

### Key changes
- `src/cli.ts`: Removed `detectColorMode` and `hexToBgAnsi` imports from `./terminal-bg-probe.js`.
- `src/cli.ts`: Replaced ~25 lines of theme/ANSI background viewport painting with `process.stdout.write("\x1b[2J\x1b[H")` to clear the visible screen and home the cursor.
- `src/cli.ts`: Removed startup-time reads of `settings.json` and theme files, along with associated `ENOENT` handling and JSON parsing.

### Impact
- Eliminates first-run file-read errors and warnings when `settings.json` or theme files do not yet exist.
- The terminal is no longer pre-filled with the theme background color before the initial render; rendering starts from a standard cleared screen.