### PR TITLE
fix(openclaw): empty display_name and unsupported config set flags

### DIFF
--- a/src/integrations/openclaw.test.ts
+++ b/src/integrations/openclaw.test.ts
@@ -53,6 +53,18 @@ describe("buildOpenClawProviderBlock", () => {
 		expect(main?.contextWindow).toBe(262_144)
 		expect(main?.maxTokens).toBe(32_768)
 	})
+
+	it("falls back to slug when display_name is empty", () => {
+		const modelsWithEmptyName = [
+			{ ...TEST_MODELS[0], display_name: "" },
+			{ ...TEST_MODELS[1], display_name: "   " },
+		]
+		const block = buildOpenClawProviderBlock(modelsWithEmptyName) as {
+			models: Array<{ id: string; name: string }>
+		}
+		expect(block.models[0].name).toBe(modelsWithEmptyName[0].slug)
+		expect(block.models[1].name).toBe(modelsWithEmptyName[1].slug)
+	})
 })
 
 describe("buildOpenClawModelsCatalog", () => {
@@ -62,6 +74,16 @@ describe("buildOpenClawModelsCatalog", () => {
 		expect(catalog["kimchi/kimi-k2.5"]).toEqual({ alias: "Kimi K2.5" })
 		expect(catalog["kimchi/nemotron-3-super-fp4"]).toEqual({ alias: "Nemotron 3 Super FP4" })
 		expect(catalog["kimchi/minimax-m2.7"]).toEqual({ alias: "MiniMax M2.7" })
+	})
+
+	it("falls back to slug when display_name is empty", () => {
+		const modelsWithEmptyName = [
+			{ ...TEST_MODELS[0], display_name: "" },
+			{ ...TEST_MODELS[1], display_name: "   " },
+		]
+		const catalog = buildOpenClawModelsCatalog(modelsWithEmptyName)
+		expect(catalog["kimchi/kimi-k2.6"]).toEqual({ alias: "kimi-k2.6" })
+		expect(catalog["kimchi/kimi-k2.5"]).toEqual({ alias: "kimi-k2.5" })
 	})
 })
 
@@ -244,6 +266,11 @@ describe("writeOpenClawViaCLI integration", () => {
 					typeof childProcess.spawnSync
 				>
 			}
+			if (cmdArgs[0] === "config" && cmdArgs[1] === "get" && cmdArgs[2] === "agents.defaults.models") {
+				return { status: 0, stdout: JSON.stringify({ "other/model": { alias: "Other" } }), stderr: "" } as ReturnType<
+					typeof childProcess.spawnSync
+				>
+			}
 			return { status: 0, stdout: "", stderr: "" } as ReturnType<typeof childProcess.spawnSync>
 		})
 	})
@@ -264,30 +291,22 @@ describe("writeOpenClawViaCLI integration", () => {
 		const calls = vi.mocked(childProcess.spawnSync).mock.calls
 		const fallbackSetCall = calls.find((c) => {
 			const args = c[1] as string[] | undefined
-			return (
-				args &&
-				args[0] === "config" &&
-				args[1] === "set" &&
-				args[2] === "--replace" &&
-				args[3] === "agents.defaults.model.fallbacks"
-			)
+			return args && args[0] === "config" && args[1] === "set" && args[2] === "agents.defaults.model.fallbacks"
 		})
 		expect(fallbackSetCall).toBeDefined()
-		const mergedFallbacks = JSON.parse((fallbackSetCall?.[1] as string[])[4])
+		const mergedFallbacks = JSON.parse((fallbackSetCall?.[1] as string[])[3])
 		expect(mergedFallbacks).toContain("existing/model")
 		expect(mergedFallbacks).toContain("kimchi/nemotron-3-super-fp4")
 
 		const modelsSetCall = calls.find((c) => {
 			const args = c[1] as string[] | undefined
-			return (
-				args &&
-				args[0] === "config" &&
-				args[1] === "set" &&
-				args[2] === "--merge" &&
-				args[3] === "agents.defaults.models"
-			)
+			return args && args[0] === "config" && args[1] === "set" && args[2] === "agents.defaults.models"
 		})
 		expect(modelsSetCall).toBeDefined()
+		const mergedModels = JSON.parse((modelsSetCall?.[1] as string[])[3]) as Record<string, unknown>
+		expect(mergedModels["other/model"]).toEqual({ alias: "Other" })
+		expect(mergedModels["kimchi/kimi-k2.6"]).toBeDefined()
+		expect(mergedModels["kimchi/nemotron-3-super-fp4"]).toBeDefined()
 
 		const envContent = readFileSync(join(tmp, ".openclaw", ".env"), "utf-8")
 		expect(envContent).toBe("KIMCHI_API_KEY=test-key-123\n")

--- a/src/integrations/openclaw.ts
+++ b/src/integrations/openclaw.ts
@@ -37,7 +37,7 @@ export function buildOpenClawProviderBlock(
 		api: "openai-completions",
 		models: models.map((m) => ({
 			id: `${PROVIDER_NAME}/${m.slug}`,
-			name: m.display_name,
+			name: (m.display_name ?? "").trim().length > 0 ? m.display_name : m.slug,
 			reasoning: m.reasoning,
 			input: m.input_modalities,
 			contextWindow: m.limits.context_window,
@@ -52,7 +52,8 @@ export function buildOpenClawModelsCatalog(
 ): Record<string, unknown> {
 	const out: Record<string, unknown> = {}
 	for (const m of models) {
-		out[`${PROVIDER_NAME}/${m.slug}`] = { alias: m.display_name }
+		const alias = (m.display_name ?? "").trim().length > 0 ? m.display_name : m.slug
+		out[`${PROVIDER_NAME}/${m.slug}`] = { alias }
 	}
 	return out
 }
@@ -134,7 +135,7 @@ async function writeOpenClawViaCLI(
 	runOpenClawCmd(["config", "set", "agents.defaults.model.primary", primary])
 	// Merge fields that may conflict with existing user config.
 	runOpenClawMerge("agents.defaults.model.fallbacks", (existing) => mergeFallbacks(existing, fallbacks))
-	runOpenClawCmd(["config", "set", "--merge", "agents.defaults.models", JSON.stringify(modelsCatalog)])
+	runOpenClawMerge("agents.defaults.models", (existing) => mergeModelsCatalog(existing, modelsCatalog))
 
 	writeOpenClawEnv(apiKey)
 
@@ -255,11 +256,11 @@ export function mergeModelsCatalog(existing: unknown, catalog: Record<string, un
 	return { ...asObject(existing), ...catalog }
 }
 
-/** Read existing value, merge it, and write back with `--replace`. */
+/** Read existing value, merge it, and write back. */
 function runOpenClawMerge(path: string, merger: (existing: unknown) => unknown): void {
 	const existing = openClawConfigGet(path)
 	const merged = merger(existing)
-	runOpenClawCmd(["config", "set", "--replace", path, JSON.stringify(merged)])
+	runOpenClawCmd(["config", "set", path, JSON.stringify(merged)])
 }
 
 register({

--- a/src/setup-wizard/steps/done.ts
+++ b/src/setup-wizard/steps/done.ts
@@ -1,5 +1,5 @@
 import { resolve } from "node:path"
-import { log, note, outro } from "@clack/prompts"
+import { log, note, outro, spinner } from "@clack/prompts"
 import { byId } from "../../integrations/registry.js"
 import type { ToolId } from "../../integrations/types.js"
 import { updateModelsConfig } from "../../models.js"
@@ -36,12 +36,15 @@ export async function runDoneStep(state: WizardState): Promise<ApplyOutcome> {
 		process.env.KIMCHI_CODING_AGENT_DIR ?? resolve(process.env.HOME ?? "~", ".config/kimchi-coding-agent")
 	const modelsJsonPath = resolve(agentDir, "models.json")
 	let models: readonly import("../../models.js").ModelMetadata[] = []
+	const modelSpinner = spinner()
+	modelSpinner.start("Fetching available models…")
 	try {
 		const result = await updateModelsConfig(modelsJsonPath, state.apiKey)
 		models = result.models
+		modelSpinner.stop("Models fetched.")
 	} catch (err) {
 		const msg = (err as Error).message
-		log.error(`Could not fetch available models: ${msg}`)
+		modelSpinner.stop(`Could not fetch available models: ${msg}`)
 		outcome.failures.push({ id: "*", error: `model fetch failed: ${msg}` })
 		outro("Aborted.")
 		return outcome
@@ -68,14 +71,16 @@ export async function runDoneStep(state: WizardState): Promise<ApplyOutcome> {
 			log.info(`${tool.name}: ready (launch via 'kimchi ${launchCmd}')`)
 			continue
 		}
+		const s = spinner()
+		s.start(`Configuring ${tool.name}…`)
 		try {
 			await tool.write(state.scope, state.apiKey, models, { telemetryEnabled: state.telemetryEnabled })
 			outcome.successes.push(tool.name)
-			log.success(`${tool.name}: configured`)
+			s.stop(`${tool.name}: configured`)
 		} catch (err) {
 			const msg = (err as Error).message
 			outcome.failures.push({ id, error: msg })
-			log.error(`${tool.name}: ${msg}`)
+			s.stop(`${tool.name}: ${msg}`)
 		}
 	}
 

--- a/src/setup-wizard/steps/done.ts
+++ b/src/setup-wizard/steps/done.ts
@@ -73,6 +73,9 @@ export async function runDoneStep(state: WizardState): Promise<ApplyOutcome> {
 		}
 		const s = spinner()
 		s.start(`Configuring ${tool.name}…`)
+		// Yield briefly so clack can render the first spinner frame before
+		// potentially blocking sync work (e.g. spawnSync calls).
+		await new Promise<void>((resolve) => setTimeout(() => resolve(), 80))
 		try {
 			await tool.write(state.scope, state.apiKey, models, { telemetryEnabled: state.telemetryEnabled })
 			outcome.successes.push(tool.name)


### PR DESCRIPTION
## Problem

When running `kimchi setup` with OpenClaw selected, the integration fails with:

1. `Config validation failed: models.providers.kimchi.models.1.name: Too small: expected string to have >=1 characters`
   - This happens when the API returns a model with an empty or whitespace-only `display_name`. The OpenClaw provider block was passing this through directly without a fallback.

2. `openclaw config set failed: error: unknown option '--replace'`
   - The OpenClaw CLI (tested on v2026.4.5) does not support `--replace` or `--merge` flags on `config set`.

## Changes

- **`buildOpenClawProviderBlock`**: fall back to `slug` when `display_name` is empty/whitespace.
- **`buildOpenClawModelsCatalog`**: same fallback for model aliases.
- **`runOpenClawMerge`**: remove `--replace` flag; the merge is already done in-memory, so a plain `config set <path> <value>` suffices.
- **models catalog write**: switch from unsupported `--merge` to `runOpenClawMerge` with `mergeModelsCatalog`.
- Added tests for empty `display_name` and updated existing CLI tests to assert merged models catalog contents.

---
### Kimchi Summary
### What changed
Fixes OpenClaw configuration to merge with existing user settings and fall back to model slugs when `display_name` is empty or whitespace. Adds CLI spinners to the setup wizard during model fetching and tool configuration.

### Why
Empty or whitespace-only `display_name` values were producing blank model aliases. The `openclaw config set` command with `--merge`/`--replace` flags did not reliably preserve existing catalog entries. The wizard also appeared to hang during blocking subprocess calls because no progress feedback was shown.

### Key changes
- `src/integrations/openclaw.ts`:
  - `buildOpenClawProviderBlock` and `buildOpenClawModelsCatalog` now fall back to `slug` when `display_name` is empty or whitespace
  - `writeOpenClawViaCLI` uses `runOpenClawMerge` with `mergeModelsCatalog` to read existing `agents.defaults.models`, merge in-memory, and write back without `--merge` or `--replace` flags
  - `runOpenClawMerge` no longer passes `--replace` to `config set`
- `src/setup-wizard/steps/done.ts`:
  - Wraps `updateModelsConfig` and each tool `write()` call in `@clack/prompts` spinners
  - Adds an 80 ms yield before synchronous tool setup so spinner frames render

### Impact
- Existing model aliases in `agents.defaults.models` are preserved across setup runs instead of being overwritten
- OpenClaw integration is resilient to models lacking display metadata
- Wizard provides live progress feedback and no longer appears frozen during blocking `spawnSync` calls