### PR TITLE
feat: support rtk in kimchi

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,6 +139,12 @@ KIMCHI_RTK=0 kimchi   # disable for this session
 
 Set `KIMCHI_RTK` to `0`, `false`, or `off` to disable rewriting even when RTK is installed.
 
+You can also disable persistently in `~/.config/kimchi/harness/settings.json`:
+
+```json
+{ "rtk": false }
+```
+
 ### Subagent sessions
 
 Every `subagent` invocation writes its own persistent session file alongside the parent's, in the same session directory. The child's session header back-references its parent, and the parent's tool-result records the child's session id and file path. Nested subagents (sub-subagents) follow the same rule at any depth — all descendants land next to the original top-level parent.

--- a/README.md
+++ b/README.md
@@ -117,6 +117,28 @@ When multi-model is off the agent uses a single-model system prompt: environment
 
 kimchi respects `HTTP_PROXY` / `HTTPS_PROXY` environment variables for network requests.
 
+### Token optimization (RTK)
+
+When [RTK](https://github.com/rtk-ai/rtk) (`rtk`) is installed and on your `PATH`, kimchi automatically rewrites bash tool calls through `rtk rewrite` before execution. This compresses command output (git, cargo, npm, docker, etc.) by 60-90%, significantly reducing LLM context usage.
+
+**How it works:** before every bash tool execution, kimchi calls `rtk rewrite "<command>"`. If RTK returns a rewritten command (e.g. `git status` becomes `rtk git status`), the rewritten version is executed instead. The agent receives compact, filtered output without any workflow changes.
+
+**Installation:**
+
+```bash
+brew install rtk    # macOS / Linux
+```
+
+RTK is auto-detected at startup. No configuration is needed — if `rtk` is on your PATH, it's active.
+
+**Disabling:**
+
+```bash
+KIMCHI_RTK=0 kimchi   # disable for this session
+```
+
+Set `KIMCHI_RTK` to `0`, `false`, or `off` to disable rewriting even when RTK is installed.
+
 ### Subagent sessions
 
 Every `subagent` invocation writes its own persistent session file alongside the parent's, in the same session directory. The child's session header back-references its parent, and the parent's tool-result records the child's session id and file path. Nested subagents (sub-subagents) follow the same rule at any depth — all descendants land next to the original top-level parent.

--- a/src/extensions/bash-collapse.test.ts
+++ b/src/extensions/bash-collapse.test.ts
@@ -83,6 +83,19 @@ describe("detectRtk", () => {
 		expect(mockExecFile).toHaveBeenCalledTimes(1)
 	})
 
+	it("shares the in-flight promise for concurrent callers", async () => {
+		mockExecFile.mockImplementation((_cmd: string, _args: string[], _opts: unknown, cb: ExecFileCb) => {
+			// Simulate a slow response.
+			setTimeout(() => cb(null, "rtk 0.40.0\n", ""), 10)
+		})
+		// Fire two concurrent calls before the first resolves.
+		const [a, b] = await Promise.all([detectRtk(), detectRtk()])
+		expect(a).toBe(true)
+		expect(b).toBe(true)
+		// Only one execFile call — the second caller shares the in-flight promise.
+		expect(mockExecFile).toHaveBeenCalledTimes(1)
+	})
+
 	it("returns false immediately when KIMCHI_RTK=0", async () => {
 		process.env.KIMCHI_RTK = "0"
 		expect(await detectRtk()).toBe(false)

--- a/src/extensions/bash-collapse.test.ts
+++ b/src/extensions/bash-collapse.test.ts
@@ -1,5 +1,9 @@
-import { describe, expect, it } from "vitest"
-import { collapseCommand } from "./bash-collapse.js"
+import { type MockInstance, afterEach, beforeEach, describe, expect, it, vi } from "vitest"
+import { _resetRtkState, collapseCommand, detectRtk, rewriteWithRtk, rtkSpawnHook } from "./bash-collapse.js"
+
+// ---------------------------------------------------------------------------
+// collapseCommand
+// ---------------------------------------------------------------------------
 
 describe("collapseCommand", () => {
 	it("collapses consecutive newlines into a printable arrow", () => {
@@ -17,5 +21,221 @@ describe("collapseCommand", () => {
 
 	it("defaults to empty string when command is undefined", () => {
 		expect(collapseCommand(undefined)).toBe("")
+	})
+})
+
+// ---------------------------------------------------------------------------
+// RTK integration
+// ---------------------------------------------------------------------------
+
+type ExecFileCb = (err: Error | null, stdout: string, stderr: string) => void
+
+// We mock node:child_process at the module level so every `execFile` and
+// `execFileSync` call inside bash-collapse.ts is intercepted.
+vi.mock("node:child_process", () => ({
+	execFile: vi.fn(),
+	execFileSync: vi.fn(),
+}))
+
+// Import the mocked functions so we can control them per-test.
+import { execFile, execFileSync } from "node:child_process"
+const mockExecFile = execFile as unknown as MockInstance
+const mockExecFileSync = execFileSync as unknown as MockInstance
+
+function clearEnv(): void {
+	// biome-ignore lint/performance/noDelete: env vars must be fully removed, not set to "undefined" string
+	delete process.env.KIMCHI_RTK
+}
+
+describe("detectRtk", () => {
+	beforeEach(() => {
+		_resetRtkState()
+		clearEnv()
+		mockExecFile.mockReset()
+	})
+
+	afterEach(() => {
+		clearEnv()
+	})
+
+	it("returns true when rtk --version succeeds", async () => {
+		mockExecFile.mockImplementation((_cmd: string, _args: string[], _opts: unknown, cb: ExecFileCb) => {
+			cb(null, "rtk 0.40.0\n", "")
+		})
+		expect(await detectRtk()).toBe(true)
+	})
+
+	it("returns false when rtk is not found (ENOENT)", async () => {
+		mockExecFile.mockImplementation((_cmd: string, _args: string[], _opts: unknown, cb: ExecFileCb) => {
+			const err = Object.assign(new Error("spawn rtk ENOENT"), { code: "ENOENT" })
+			cb(err, "", "")
+		})
+		expect(await detectRtk()).toBe(false)
+	})
+
+	it("caches the result on subsequent calls", async () => {
+		mockExecFile.mockImplementation((_cmd: string, _args: string[], _opts: unknown, cb: ExecFileCb) => {
+			cb(null, "rtk 0.40.0\n", "")
+		})
+		await detectRtk()
+		await detectRtk()
+		// execFile should only be called once — the second call uses the cache.
+		expect(mockExecFile).toHaveBeenCalledTimes(1)
+	})
+
+	it("returns false immediately when KIMCHI_RTK=0", async () => {
+		process.env.KIMCHI_RTK = "0"
+		expect(await detectRtk()).toBe(false)
+		expect(mockExecFile).not.toHaveBeenCalled()
+	})
+
+	it("returns false immediately when KIMCHI_RTK=false", async () => {
+		process.env.KIMCHI_RTK = "false"
+		expect(await detectRtk()).toBe(false)
+		expect(mockExecFile).not.toHaveBeenCalled()
+	})
+
+	it("returns false immediately when KIMCHI_RTK=off", async () => {
+		process.env.KIMCHI_RTK = "off"
+		expect(await detectRtk()).toBe(false)
+		expect(mockExecFile).not.toHaveBeenCalled()
+	})
+})
+
+describe("rewriteWithRtk", () => {
+	beforeEach(() => {
+		_resetRtkState()
+		clearEnv()
+		mockExecFileSync.mockReset()
+		// Pre-seed rtkAvailable = true for most tests (detectRtk already passed).
+		mockExecFile.mockReset()
+	})
+
+	afterEach(() => {
+		clearEnv()
+	})
+
+	function seedRtkAvailable(): void {
+		// Mark rtk as available without going through async detectRtk.
+		// We do this by calling detectRtk with a mock that succeeds.
+		mockExecFile.mockImplementationOnce((_cmd: string, _args: string[], _opts: unknown, cb: ExecFileCb) => {
+			cb(null, "rtk 0.40.0\n", "")
+		})
+	}
+
+	it("returns the rewritten command when rtk exits 0 with different output", async () => {
+		seedRtkAvailable()
+		await detectRtk()
+
+		mockExecFileSync.mockReturnValueOnce("rtk git status\n")
+		expect(rewriteWithRtk("git status")).toBe("rtk git status")
+	})
+
+	it("returns the rewritten command when rtk exits 3 (rewrite success code)", async () => {
+		seedRtkAvailable()
+		await detectRtk()
+
+		// execFileSync throws on non-zero exit codes; RTK uses exit 3 for rewrites.
+		mockExecFileSync.mockImplementationOnce(() => {
+			throw Object.assign(new Error("Command failed"), { status: 3, stdout: "rtk cargo test\n" })
+		})
+		expect(rewriteWithRtk("cargo test")).toBe("rtk cargo test")
+	})
+
+	it("returns the original command when rtk output matches the input", async () => {
+		seedRtkAvailable()
+		await detectRtk()
+
+		mockExecFileSync.mockReturnValueOnce("echo hello\n")
+		expect(rewriteWithRtk("echo hello")).toBe("echo hello")
+	})
+
+	it("returns the original command when rtk output is empty", async () => {
+		seedRtkAvailable()
+		await detectRtk()
+
+		mockExecFileSync.mockReturnValueOnce("")
+		expect(rewriteWithRtk("git status")).toBe("git status")
+	})
+
+	it("returns the original command when execFileSync throws with non-3 exit", async () => {
+		seedRtkAvailable()
+		await detectRtk()
+
+		mockExecFileSync.mockImplementationOnce(() => {
+			throw Object.assign(new Error("exit code 2"), { status: 2 })
+		})
+		expect(rewriteWithRtk("git status")).toBe("git status")
+	})
+
+	it("returns the original command and caches negative on ENOENT", () => {
+		// rtkAvailable is still undefined (no detectRtk call).
+		mockExecFileSync.mockImplementationOnce(() => {
+			throw Object.assign(new Error("spawn rtk ENOENT"), { code: "ENOENT" })
+		})
+		expect(rewriteWithRtk("git status")).toBe("git status")
+
+		// After ENOENT, subsequent calls should not spawn at all.
+		mockExecFileSync.mockClear()
+		expect(rewriteWithRtk("cargo test")).toBe("cargo test")
+		expect(mockExecFileSync).not.toHaveBeenCalled()
+	})
+
+	it("short-circuits when KIMCHI_RTK=0 without spawning", () => {
+		process.env.KIMCHI_RTK = "0"
+		expect(rewriteWithRtk("git status")).toBe("git status")
+		expect(mockExecFileSync).not.toHaveBeenCalled()
+	})
+
+	it("passes the command as a single argv element (no shell injection)", async () => {
+		seedRtkAvailable()
+		await detectRtk()
+
+		mockExecFileSync.mockImplementationOnce((cmd: string, args: string[]) => {
+			// Verify the command is passed as a single argument, not split.
+			expect(cmd).toBe("rtk")
+			expect(args).toEqual(["rewrite", "git log --oneline -10 && echo done"])
+			return "rtk git log --oneline -10 && echo done\n"
+		})
+		rewriteWithRtk("git log --oneline -10 && echo done")
+	})
+})
+
+describe("rtkSpawnHook", () => {
+	beforeEach(() => {
+		_resetRtkState()
+		clearEnv()
+		mockExecFileSync.mockReset()
+		mockExecFile.mockReset()
+	})
+
+	afterEach(() => {
+		clearEnv()
+	})
+
+	it("rewrites the command in a BashSpawnContext", async () => {
+		// Seed rtk as available.
+		mockExecFile.mockImplementationOnce((_cmd: string, _args: string[], _opts: unknown, cb: ExecFileCb) => {
+			cb(null, "rtk 0.40.0\n", "")
+		})
+		await detectRtk()
+
+		mockExecFileSync.mockReturnValueOnce("rtk git status\n")
+		const ctx = { command: "git status", cwd: "/tmp", env: process.env }
+		const result = rtkSpawnHook(ctx)
+		expect(result.command).toBe("rtk git status")
+		expect(result.cwd).toBe("/tmp")
+	})
+
+	it("returns the original context when command is unchanged", async () => {
+		mockExecFile.mockImplementationOnce((_cmd: string, _args: string[], _opts: unknown, cb: ExecFileCb) => {
+			cb(null, "rtk 0.40.0\n", "")
+		})
+		await detectRtk()
+
+		mockExecFileSync.mockReturnValueOnce("echo hello\n")
+		const ctx = { command: "echo hello", cwd: "/tmp", env: process.env }
+		const result = rtkSpawnHook(ctx)
+		expect(result).toBe(ctx) // Same reference — no copy.
 	})
 })

--- a/src/extensions/bash-collapse.ts
+++ b/src/extensions/bash-collapse.ts
@@ -1,4 +1,7 @@
 import { execFile, execFileSync } from "node:child_process"
+import { readFileSync } from "node:fs"
+import { homedir } from "node:os"
+import { join } from "node:path"
 import type { BashSpawnContext, BashToolDetails, ExtensionAPI, ToolDefinition } from "@earendil-works/pi-coding-agent"
 import { createBashToolDefinition } from "@earendil-works/pi-coding-agent"
 import { Container, Spacer, Text } from "@earendil-works/pi-tui"
@@ -16,35 +19,63 @@ export function collapseCommand(command: string | undefined): string {
 // `rtk rewrite <cmd>` before execution.  This reduces LLM token consumption
 // by 60-90% on common dev commands (git, cargo, npm, etc.).
 //
-// Set KIMCHI_RTK=0 to disable even when rtk is installed.
+// Disable via:
+//   - KIMCHI_RTK=0 environment variable, or
+//   - "rtk": false  in ~/.config/kimchi/harness/settings.json (/settings)
+//
 // See https://github.com/rtk-ai/rtk
 // ---------------------------------------------------------------------------
 
+const HARNESS_SETTINGS_PATH = join(homedir(), ".config", "kimchi", "harness", "settings.json")
+
 /** Tri-state: undefined = not yet probed, true/false = cached result. */
 let rtkAvailable: boolean | undefined
+
+/** Cached in-flight detection promise to avoid concurrent spawns. */
+let rtkDetectPromise: Promise<boolean> | undefined
 
 function isRtkDisabledByEnv(): boolean {
 	const v = process.env.KIMCHI_RTK
 	return v === "0" || v === "false" || v === "off"
 }
 
+function isRtkDisabledBySettings(): boolean {
+	try {
+		const raw = readFileSync(HARNESS_SETTINGS_PATH, "utf-8")
+		const parsed = JSON.parse(raw)
+		if ("rtk" in parsed) return parsed.rtk === false
+	} catch {
+		// settings.json absent or unreadable — not disabled
+	}
+	return false
+}
+
+function isRtkDisabled(): boolean {
+	return isRtkDisabledByEnv() || isRtkDisabledBySettings()
+}
+
 /**
  * Probe for the `rtk` binary once per process.  Caches the result so
- * subsequent calls are free.  Returns true when rtk is installed and
- * responds to `--version` within 1 s.
+ * subsequent calls are free.  The in-flight promise is also cached so
+ * concurrent callers share a single `rtk --version` subprocess.
+ *
+ * Returns true when rtk is installed and responds to `--version` within 1 s.
  */
 export function detectRtk(): Promise<boolean> {
 	if (rtkAvailable !== undefined) return Promise.resolve(rtkAvailable)
-	if (isRtkDisabledByEnv()) {
+	if (isRtkDisabled()) {
 		rtkAvailable = false
 		return Promise.resolve(false)
 	}
-	return new Promise<boolean>((resolve) => {
+	if (rtkDetectPromise) return rtkDetectPromise
+	rtkDetectPromise = new Promise<boolean>((resolve) => {
 		execFile("rtk", ["--version"], { timeout: 1000 }, (err) => {
 			rtkAvailable = !err
+			rtkDetectPromise = undefined
 			resolve(rtkAvailable)
 		})
 	})
+	return rtkDetectPromise
 }
 
 /**
@@ -52,12 +83,12 @@ export function detectRtk(): Promise<boolean> {
  * Used as a pi-mono BashSpawnHook (which must be synchronous).
  *
  * Returns the original command unchanged when:
- *   - rtk is not available or disabled via KIMCHI_RTK
+ *   - rtk is not available or disabled via KIMCHI_RTK / settings.json
  *   - rtk returns empty output or the same string
  *   - the subprocess times out or fails to spawn
  */
 export function rewriteWithRtk(command: string): string {
-	if (isRtkDisabledByEnv()) return command
+	if (isRtkDisabled()) return command
 	if (rtkAvailable === false) return command
 
 	try {
@@ -80,18 +111,25 @@ export function rewriteWithRtk(command: string): string {
 	}
 }
 
+/** Cache of rewrite results so renderCall never spawns a subprocess. */
+const rewriteCache = new Map<string, string>()
+
 /**
  * BashSpawnHook for pi-mono's createBashToolDefinition.
  * Rewrites the command through `rtk rewrite` before the shell spawns.
+ * Caches the result so renderCall can display it without a subprocess.
  */
 export function rtkSpawnHook(context: BashSpawnContext): BashSpawnContext {
 	const rewritten = rewriteWithRtk(context.command)
+	rewriteCache.set(context.command, rewritten)
 	return rewritten !== context.command ? { ...context, command: rewritten } : context
 }
 
 /** Reset cached detection state (for tests). */
 export function _resetRtkState(): void {
 	rtkAvailable = undefined
+	rtkDetectPromise = undefined
+	rewriteCache.clear()
 }
 
 export default function (pi: ExtensionAPI) {
@@ -115,11 +153,10 @@ export default function (pi: ExtensionAPI) {
 
 		renderCall(args, theme, ctx) {
 			const view = ctx.lastComponent instanceof ToolBlockView ? ctx.lastComponent : new ToolBlockView()
-			// Show the rewritten command (if rtk is active) so the user sees
-			// exactly what will be executed.  rewriteWithRtk is synchronous and
-			// returns the original string unchanged when rtk is unavailable.
-			const rewritten = rewriteWithRtk(args.command ?? "")
-			const command = collapseCommand(rewritten)
+			// Use the cached rewrite result if available (populated by rtkSpawnHook
+			// during execute).  This avoids spawning a subprocess on the render path.
+			// Falls back to the original command when no cached result exists yet.
+			const command = collapseCommand(rewriteCache.get(args.command ?? "") ?? args.command ?? "")
 			buildToolCallHeader(view, "bash", command, theme, ctx)
 			return view
 		},
@@ -158,9 +195,4 @@ export default function (pi: ExtensionAPI) {
 	}
 
 	pi.registerTool(def)
-
-	// Log RTK availability once at session start (informational only).
-	pi.on("session_start", async () => {
-		await detectRtk()
-	})
 }

--- a/src/extensions/bash-collapse.ts
+++ b/src/extensions/bash-collapse.ts
@@ -1,4 +1,5 @@
-import type { BashToolDetails, ExtensionAPI, ToolDefinition } from "@earendil-works/pi-coding-agent"
+import { execFile, execFileSync } from "node:child_process"
+import type { BashSpawnContext, BashToolDetails, ExtensionAPI, ToolDefinition } from "@earendil-works/pi-coding-agent"
 import { createBashToolDefinition } from "@earendil-works/pi-coding-agent"
 import { Container, Spacer, Text } from "@earendil-works/pi-tui"
 import { ToolBlockView, buildToolCallHeader, getTextContent } from "../components/tool-block.js"
@@ -8,21 +9,117 @@ export function collapseCommand(command: string | undefined): string {
 	return (command ?? "").replace(/\n+/g, " ⏎ ")
 }
 
+// ---------------------------------------------------------------------------
+// RTK (Rust Token Killer) integration
+//
+// When the `rtk` binary is on PATH, bash commands are rewritten through
+// `rtk rewrite <cmd>` before execution.  This reduces LLM token consumption
+// by 60-90% on common dev commands (git, cargo, npm, etc.).
+//
+// Set KIMCHI_RTK=0 to disable even when rtk is installed.
+// See https://github.com/rtk-ai/rtk
+// ---------------------------------------------------------------------------
+
+/** Tri-state: undefined = not yet probed, true/false = cached result. */
+let rtkAvailable: boolean | undefined
+
+function isRtkDisabledByEnv(): boolean {
+	const v = process.env.KIMCHI_RTK
+	return v === "0" || v === "false" || v === "off"
+}
+
+/**
+ * Probe for the `rtk` binary once per process.  Caches the result so
+ * subsequent calls are free.  Returns true when rtk is installed and
+ * responds to `--version` within 1 s.
+ */
+export function detectRtk(): Promise<boolean> {
+	if (rtkAvailable !== undefined) return Promise.resolve(rtkAvailable)
+	if (isRtkDisabledByEnv()) {
+		rtkAvailable = false
+		return Promise.resolve(false)
+	}
+	return new Promise<boolean>((resolve) => {
+		execFile("rtk", ["--version"], { timeout: 1000 }, (err) => {
+			rtkAvailable = !err
+			resolve(rtkAvailable)
+		})
+	})
+}
+
+/**
+ * Synchronously ask `rtk rewrite` to compress / rewrite a command string.
+ * Used as a pi-mono BashSpawnHook (which must be synchronous).
+ *
+ * Returns the original command unchanged when:
+ *   - rtk is not available or disabled via KIMCHI_RTK
+ *   - rtk returns empty output or the same string
+ *   - the subprocess times out or fails to spawn
+ */
+export function rewriteWithRtk(command: string): string {
+	if (isRtkDisabledByEnv()) return command
+	if (rtkAvailable === false) return command
+
+	try {
+		const stdout = execFileSync("rtk", ["rewrite", command], { timeout: 2000, encoding: "utf-8" })
+		const rewritten = stdout.trim()
+		return rewritten && rewritten !== command ? rewritten : command
+	} catch (err) {
+		// execFileSync throws on any non-zero exit code.  RTK uses exit code 3
+		// to signal a successful rewrite, so we extract stdout from the error.
+		const execErr = err as { status?: number; stdout?: string; code?: string }
+		if (execErr.status === 3 && typeof execErr.stdout === "string") {
+			const rewritten = execErr.stdout.trim()
+			return rewritten && rewritten !== command ? rewritten : command
+		}
+		// On first ENOENT, cache the negative result so we stop spawning.
+		if (execErr.code === "ENOENT") {
+			rtkAvailable = false
+		}
+		return command
+	}
+}
+
+/**
+ * BashSpawnHook for pi-mono's createBashToolDefinition.
+ * Rewrites the command through `rtk rewrite` before the shell spawns.
+ */
+export function rtkSpawnHook(context: BashSpawnContext): BashSpawnContext {
+	const rewritten = rewriteWithRtk(context.command)
+	return rewritten !== context.command ? { ...context, command: rewritten } : context
+}
+
+/** Reset cached detection state (for tests). */
+export function _resetRtkState(): void {
+	rtkAvailable = undefined
+}
+
 export default function (pi: ExtensionAPI) {
-	const baseDef = createBashToolDefinition(process.cwd())
+	const baseDef = createBashToolDefinition(process.cwd(), { spawnHook: rtkSpawnHook })
+
+	// Eagerly probe for rtk at extension load time (non-blocking).
+	detectRtk()
 
 	const def: ToolDefinition<typeof baseDef.parameters, BashToolDetails | undefined> = {
 		...baseDef,
 
 		execute(toolCallId, params, signal, onUpdate, ctx) {
-			return createBashToolDefinition(ctx.cwd).execute(toolCallId, params, signal, onUpdate, ctx)
+			return createBashToolDefinition(ctx.cwd, { spawnHook: rtkSpawnHook }).execute(
+				toolCallId,
+				params,
+				signal,
+				onUpdate,
+				ctx,
+			)
 		},
 
 		renderCall(args, theme, ctx) {
 			const view = ctx.lastComponent instanceof ToolBlockView ? ctx.lastComponent : new ToolBlockView()
-			// Bash commands can be multiline (e.g. heredocs); collapse newlines
-			// so the single-line header doesn't overflow onto multiple rows.
-			const command = collapseCommand(args.command)
+			// Show the rewritten command (if rtk is active) so the user sees
+			// exactly what will be executed.  rewriteWithRtk is synchronous and
+			// returns the original string unchanged when rtk is unavailable.
+			const rewritten = rewriteWithRtk(args.command ?? "")
+			const command = collapseCommand(rewritten)
 			buildToolCallHeader(view, "bash", command, theme, ctx)
 			return view
 		},
@@ -61,4 +158,9 @@ export default function (pi: ExtensionAPI) {
 	}
 
 	pi.registerTool(def)
+
+	// Log RTK availability once at session start (informational only).
+	pi.on("session_start", async () => {
+		await detectRtk()
+	})
 }


### PR DESCRIPTION
- RTK is a compression tool to reduce token utilization https://github.com/rtk-ai/rtk
- hooking in bash collapse and render to allow using RTK
- updating readme

<img width="1377" height="979" alt="image" src="https://github.com/user-attachments/assets/b3c0479f-f04b-40df-9247-fa893246200c" />

---
### Kimchi Summary
### What changed
Integrates [RTK](https://github.com/rtk-ai/rtk) to automatically rewrite bash tool calls before execution, compressing command output (git, cargo, npm, docker, etc.) by 60-90% and reducing LLM context usage. RTK is auto-detected at startup if present on `PATH`; no configuration is required.

### Why
Large command outputs from common developer tools consume significant LLM context window space. By transparently routing supported commands through `rtk rewrite`, the agent receives compact, filtered output without any workflow changes.

### Key changes
- `src/extensions/bash-collapse.ts`
  - Adds `detectRtk()` to probe for the `rtk` binary once per process with a 1-second timeout, caching the result and deduplicating concurrent checks.
  - Adds `rewriteWithRtk()` to synchronously call `rtk rewrite <cmd>` with a 2-second timeout; handles RTK's exit code 3 (successful rewrite) and caches negative results on `ENOENT`.
  - Adds `rtkSpawnHook()` as a `BashSpawnHook` for `createBashToolDefinition`, caching rewrites so `renderCall` can display them without spawning subprocesses.
  - Reads `~/.config/kimchi/harness/settings.json` for `"rtk": false` and respects `KIMCHI_RTK=0/false/off` to disable rewriting.
  - Wires `rtkSpawnHook` into both the base tool definition and `execute` call.
- `src/extensions/bash-collapse.test.ts`
  - Adds comprehensive tests for `detectRtk`, `rewriteWithRtk`, and `rtkSpawnHook`, including concurrent detection deduplication, `ENOENT` caching, exit-code-3 handling, and shell-injection prevention.
- `README.md`
  - Documents RTK installation, auto-detection behavior, and the `KIMCHI_RTK` / `settings.json` disable options.

### Impact
Entirely additive and opt-in. If RTK is not installed, behavior is unchanged with negligible overhead from a single async probe at startup. Disabling via environment variable avoids any subprocess overhead entirely.