### PR TITLE
fix: opencode-kimchi plugin setup

### DIFF
--- a/src/integrations/opencode.test.ts
+++ b/src/integrations/opencode.test.ts
@@ -61,6 +61,14 @@ describe("getOpenCodeVersion", () => {
 		const exec = vi.fn().mockReturnValue("opencode 1.13.0") as unknown as ExecFile
 		expect(getOpenCodeVersion(exec)).toBe("1.13.0")
 	})
+	it("parses bare version output (no opencode prefix)", () => {
+		const exec = vi.fn().mockReturnValue("1.15.5\n") as unknown as ExecFile
+		expect(getOpenCodeVersion(exec)).toBe("1.15.5")
+	})
+	it("parses bare version with v prefix", () => {
+		const exec = vi.fn().mockReturnValue("v1.16.0\n") as unknown as ExecFile
+		expect(getOpenCodeVersion(exec)).toBe("1.16.0")
+	})
 	it("returns null when the binary is missing", () => {
 		const exec = vi.fn().mockImplementation(() => {
 			throw new Error("ENOENT")
@@ -122,6 +130,23 @@ describe("buildUpdatedPlugins", () => {
 		const existing = [[KIMCHI, { stale: true }]]
 		const r = buildUpdatedPlugins({ plugins: existing, telemetryEnabled: false, latestVersion: "1.14.0" })
 		expect(r.plugins).toEqual([[`${KIMCHI}@1.14.0`, {}]])
+	})
+	it("handles legacy string format (no version pin) and re-adds with pinned version", () => {
+		const existing = ["@other/plugin", KIMCHI]
+		const r = buildUpdatedPlugins({ plugins: existing, telemetryEnabled: false, latestVersion: "1.14.0" })
+		expect(r.plugins).toEqual(["@other/plugin", [`${KIMCHI}@1.14.0`, {}]])
+		expect(r.skippedKimchiPlugin).toBe(false)
+	})
+	it("handles legacy string format with existing version and falls back to it when npm unavailable", () => {
+		const existing = ["@other/plugin", `${KIMCHI}@1.13.0`]
+		const r = buildUpdatedPlugins({ plugins: existing, telemetryEnabled: false, latestVersion: null })
+		expect(r.plugins).toEqual(["@other/plugin", [`${KIMCHI}@1.13.0`, {}]])
+		expect(r.skippedKimchiPlugin).toBe(false)
+	})
+	it("skips legacy string Kimchi plugin when no version anywhere (npm + no prior entry)", () => {
+		const r = buildUpdatedPlugins({ plugins: ["@other/plugin", KIMCHI], telemetryEnabled: false, latestVersion: null })
+		expect(r.plugins).toEqual(["@other/plugin"])
+		expect(r.skippedKimchiPlugin).toBe(true)
 	})
 })
 

--- a/src/integrations/opencode.ts
+++ b/src/integrations/opencode.ts
@@ -20,7 +20,7 @@ const NPM_REQUEST_TIMEOUT_MS = 10_000
 const TELEMETRY_LOGS_ENDPOINT = "https://api.cast.ai/ai-optimizer/v1beta/logs:ingest"
 const TELEMETRY_METRICS_ENDPOINT = "https://api.cast.ai/ai-optimizer/v1beta/metrics:ingest"
 
-const OPENCODE_VERSION_REGEX = /opencode\s+v?(\d+\.\d+\.\d+)/
+const OPENCODE_VERSION_REGEX = /^(?:opencode\s+)?v?(\d+\.\d+\.\d+)/m
 
 /**
  * Run `opencode --version` and parse out the SemVer. Returns null when the
@@ -143,6 +143,12 @@ export function buildUpdatedPlugins(inputs: PluginUpdateInputs): PluginUpdateRes
 			const pkgName = entry[0]
 			if (pkgName === OPENCODE_PLUGIN_PACKAGE || pkgName.startsWith(`${OPENCODE_PLUGIN_PACKAGE}@`)) {
 				existingVersion = extractVersionFromPluginName(pkgName)
+				continue
+			}
+		} else if (typeof entry === "string") {
+			// Legacy string format: "@kimchi-dev/opencode-kimchi" or "@kimchi-dev/opencode-kimchi@1.14.0"
+			if (entry === OPENCODE_PLUGIN_PACKAGE || entry.startsWith(`${OPENCODE_PLUGIN_PACKAGE}@`)) {
+				existingVersion = extractVersionFromPluginName(entry)
 				continue
 			}
 		}


### PR DESCRIPTION


---
### Kimchi Summary
### What changed
Fixes the OpenCode integration to correctly parse version outputs that lack the `opencode` prefix or include a `v` prefix, and updates plugin update logic to recognize legacy string-format entries.

### Why
The setup flow broke when OpenCode CLI returned bare SemVer strings or `v`-prefixed versions, and `buildUpdatedPlugins` previously only recognized tuple-format entries, missing legacy plain-string plugin declarations.

### Key changes
- `OPENCODE_VERSION_REGEX` in `src/integrations/opencode.ts`: updated to `/^(?:opencode\s+)?v?(\d+\.\d+\.\d+)/m` to match bare versions and `v` prefixes
- `getOpenCodeVersion`: now handles outputs like `"1.15.5\n"` and `"v1.16.0\n"`
- `buildUpdatedPlugins` in `src/integrations/opencode.ts`: added `else if (typeof entry === "string")` branch to detect legacy string entries for `OPENCODE_PLUGIN_PACKAGE` and extract existing version pins
- `src/integrations/opencode.test.ts`: added coverage for bare/`v`-prefixed version parsing and legacy string plugin migration (with and without npm, with and without prior version)

### Impact
- Legacy plugin configs using plain strings (e.g., `"@kimchi-dev/opencode-kimchi@1.13.0"`) are now correctly migrated to the pinned tuple format.
- If npm is unavailable and the legacy string entry contains no version, the Kimchi plugin is skipped (`skippedKimchiPlugin: true`).