### PR TITLE
fix(ferment-scope-params): Allow assumptions to be be a list of strings and convert them to prose

### DIFF
--- a/src/extensions/ferment/tool-schemas.test.ts
+++ b/src/extensions/ferment/tool-schemas.test.ts
@@ -5,7 +5,7 @@
 
 import { Value } from "typebox/value"
 import { describe, expect, it } from "vitest"
-import { CompleteStepParams, ProposeScopingParams } from "./tool-schemas.js"
+import { CompleteStepParams, ProposeScopingParams, ScopeParams } from "./tool-schemas.js"
 
 // Minimal valid payload fixtures
 const passingGates = () => [
@@ -72,6 +72,18 @@ describe("ProposeScopingParams schema", () => {
 					],
 				},
 			]),
+			gates: passingGates(),
+		}
+
+		expect(Value.Check(ProposeScopingParams, payload)).toBe(true)
+	})
+
+	it("accepts assumptions as a real string array compatibility fallback", () => {
+		const payload = {
+			ferment_id: "f-123",
+			goal: "Do something",
+			assumptions: ["Go toolchain is installed", "The current directory is writable"],
+			phases: minimalPhases(),
 			gates: passingGates(),
 		}
 
@@ -189,6 +201,22 @@ describe("ProposeScopingParams schema", () => {
 		}
 
 		expect(Value.Check(ProposeScopingParams, payload)).toBe(false)
+	})
+})
+
+describe("ScopeParams schema", () => {
+	it("accepts assumptions as either text or a string array", () => {
+		const basePayload = {
+			ferment_id: "f-123",
+			goal: "Do something",
+			phases: [{ name: "Build", goal: "Implement" }],
+			gates: passingGates(),
+		}
+
+		expect(Value.Check(ScopeParams, { ...basePayload, assumptions: "Go is installed" })).toBe(true)
+		expect(Value.Check(ScopeParams, { ...basePayload, assumptions: ["Go is installed", "Repo is writable"] })).toBe(
+			true,
+		)
 	})
 })
 

--- a/src/extensions/ferment/tool-schemas.ts
+++ b/src/extensions/ferment/tool-schemas.ts
@@ -90,10 +90,16 @@ export const ScopeParams = Type.Object({
 	success_criteria: Type.Optional(Type.String()),
 	constraints: Type.Optional(Type.Array(Type.String())),
 	assumptions: Type.Optional(
-		Type.String({
-			description:
-				"Upfront assumptions the plan rests on. Will be surfaced to the planner. If the agent later discovers an assumption is false, record a decision and continue rather than asking the user.",
-		}),
+		Type.Union([
+			Type.String({
+				description:
+					"A single concise prose paragraph covering all upfront assumptions the plan rests on. Prefer prose over a bullet list. If the agent later discovers an assumption is false, record a decision and continue rather than asking the user.",
+			}),
+			Type.Array(Type.String(), {
+				description:
+					"Compatibility fallback: a real JSON array of assumption strings. The tool concatenates these into the stored assumptions prose.",
+			}),
+		]),
 	),
 	phases: Type.Optional(Type.Array(PhaseProposalSchema)),
 	gates: Type.Array(GateVerdictSchema, {
@@ -140,10 +146,16 @@ export const ProposeScopingParams = Type.Object({
 		]),
 	),
 	assumptions: Type.Optional(
-		Type.String({
-			description:
-				"Upfront assumptions the plan rests on. Will be surfaced to the planner. If the agent later discovers an assumption is false, record a decision and continue rather than asking the user.",
-		}),
+		Type.Union([
+			Type.String({
+				description:
+					"A single concise prose paragraph covering all upfront assumptions the plan rests on. Prefer prose over a bullet list. If the agent later discovers an assumption is false, record a decision and continue rather than asking the user.",
+			}),
+			Type.Array(Type.String(), {
+				description:
+					"Compatibility fallback: a real JSON array of assumption strings. Prefer concise prose, but the tool concatenates arrays into the stored assumptions prose.",
+			}),
+		]),
 	),
 	phases: Type.Union([
 		Type.Array(PhaseProposalSchema, {

--- a/src/extensions/ferment/tools.integration.test.ts
+++ b/src/extensions/ferment/tools.integration.test.ts
@@ -1130,11 +1130,33 @@ describe("propose_ferment_scoping", () => {
 		const f = loadFerment(id)
 		expect(f.status).toBe("planned")
 		expect(f.phases).toHaveLength(3)
-		expect(f.scoping?.assumptions?.answer).toBe("A web app exists; Local-first is acceptable")
+		expect(f.scoping?.assumptions?.answer).toBe("A web app exists. Local-first is acceptable.")
 		expect(result).toContain("Plan saved")
 		expect(result).toContain("## Constraints")
 		expect(result).toContain("- no backend")
 		expect(result).toContain("Here is the proposed plan")
+	})
+
+	it("normalizes assumption arrays before persisting a proposed scope", async () => {
+		const id = await createFerment("Array Assumptions")
+		seedPending(id)
+		const ctx = { ui: { select: vi.fn().mockResolvedValue("Start execution  ✓"), input: vi.fn() } }
+
+		const result = ok(
+			await h.call(
+				"propose_ferment_scoping",
+				basePayload(id, {
+					assumptions: ["Go toolchain is installed", "The current directory is writable"],
+				}),
+				ctx,
+			),
+		)
+
+		const f = loadFerment(id)
+		expect(f.status).toBe("planned")
+		expect(f.scoping?.assumptions?.answer).toBe("Go toolchain is installed. The current directory is writable.")
+		expect(result).toContain("Plan saved")
+		expect(result).toContain("- Go toolchain is installed. The current directory is writable.")
 	})
 
 	it("treats duplicate propose_ferment_scoping after plan save as a no-op", async () => {

--- a/src/extensions/ferment/tools/lifecycle.ts
+++ b/src/extensions/ferment/tools/lifecycle.ts
@@ -159,14 +159,25 @@ function renderStep(index: number, description: string): string {
 	return lines.map((line, lineIndex) => (lineIndex === 0 ? `${index}. ${line}` : `   ${line}`)).join("\n")
 }
 
+function concatenateAssumptionStrings(items: string[]): string | undefined {
+	const fragments = items.map((item) => item.trim()).filter(Boolean)
+	if (fragments.length === 0) return undefined
+	return fragments.map((item) => (/[\.\?!]$/.test(item) ? item : `${item}.`)).join(" ")
+}
+
 function normalizeAssumptions(value: unknown): string | undefined {
-	if (value === undefined || typeof value !== "string") return value as string | undefined
+	if (value === undefined) return undefined
+	if (Array.isArray(value)) {
+		if (!value.every((item) => typeof item === "string")) return undefined
+		return concatenateAssumptionStrings(value)
+	}
+	if (typeof value !== "string") return undefined
 	const trimmed = value.trim()
 	if (!trimmed.startsWith("[")) return value
 	try {
 		const parsed = JSON.parse(trimmed)
 		if (Array.isArray(parsed) && parsed.every((item) => typeof item === "string")) {
-			return parsed.join("; ")
+			return concatenateAssumptionStrings(parsed)
 		}
 	} catch {
 		// Leave the original text alone. `assumptions` is a string field, so a
@@ -393,7 +404,7 @@ export async function scopeFerment(
 		goal: params.goal,
 		successCriteria: params.success_criteria,
 		constraints: params.constraints,
-		assumptions: params.assumptions,
+		assumptions: normalizeAssumptions(params.assumptions),
 		phases: params.phases ?? [],
 	}
 	const outcome = applyAndPersist(params.ferment_id, cmd)


### PR DESCRIPTION
##Why

`propose_ferment_scoping` modeled assumptions as a prose scoping field, but the tool schema only accepted a string and the prompt described it in a way that could reasonably make smaller models emit `string[]`. In practice, Kimi K2.5 sent a real JSON array for assumptions, which failed schema validation before the tool handler could recover.

Assumptions are not currently modeled as individually addressable items in the ferment data model. They are stored as one confirmed scoping answer, so this PR fixes the tool-call compatibility issue without introducing a broader persistence refactor

## What

  - Allows scope_ferment and propose_ferment_scoping to accept assumptions as either a prose string or a string[] compatibility fallback.
  - Normalizes string[] assumptions into sentence prose before storing them in the existing ScopingAnswer.answer field.

---
### Kimchi Summary
### What changed
Updates the ferment scoping tool schemas to accept `assumptions` as either a prose string or a JSON string array, and normalizes arrays into punctuated prose before persisting.

### Why
LLMs sometimes emit assumptions as string arrays instead of the preferred prose paragraph. This provides a compatibility fallback so those calls still succeed rather than failing schema validation.

### Key changes
- `tool-schemas.ts`: Changed `assumptions` in `ScopeParams` and `ProposeScopingParams` from `Type.String()` to a `Type.Union()` of `Type.String()` and `Type.Array(Type.String())`, with updated descriptions.
- `tools/lifecycle.ts`: Added `normalizeAssumptions()` and `concatenateAssumptionStrings()` to convert string arrays into properly punctuated prose sentences. Wired normalization into `scopeFerment()` before persisting.
- `tool-schemas.test.ts`: Added test cases validating that `ProposeScopingParams` accepts assumption arrays and that `ScopeParams` accepts both strings and arrays.
- `tools.integration.test.ts`: Added integration test verifying that assumption arrays are normalized to prose and persisted correctly.

### Impact
- Fully backward compatible: existing string inputs continue to work unchanged.
- Malformed or non-string arrays fall back to `undefined` rather than causing crashes.
- No migration needed; stored assumptions remain prose strings.