### PR TITLE
ci: fix proxy-helper ci build

### DIFF
--- a/.github/workflows/canary.yml
+++ b/.github/workflows/canary.yml
@@ -12,6 +12,7 @@ on:
       - 'tsconfig.json'
       - 'biome.json'
       - 'scripts/**'
+      - 'tools/proxy-helper/**'
   workflow_dispatch:
     inputs:
       force:
@@ -113,6 +114,17 @@ jobs:
       - uses: ./.github/actions/setup
         with:
           bun: "true"
+
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: tools/proxy-helper/go.mod
+          cache-dependency-path: tools/proxy-helper/go.sum
+
+      - name: Build proxy-helper
+        run: make -C tools/proxy-helper build
+        env:
+          GOOS: ${{ matrix.os }}
+          GOARCH: ${{ matrix.arch }}
 
       - name: Set version
         run: node scripts/set-version.js "${{ needs.preflight.outputs.version }}"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,9 +24,14 @@ jobs:
       - uses: actions/setup-go@v5
         with:
           go-version-file: tools/proxy-helper/go.mod
+          cache-dependency-path: tools/proxy-helper/go.sum
 
       - name: Build proxy-helper
         run: make build
+        working-directory: tools/proxy-helper
+
+      - name: Test proxy-helper
+        run: make test
         working-directory: tools/proxy-helper
 
       - name: Check (lint + type check)
@@ -59,9 +64,14 @@ jobs:
       - uses: actions/setup-go@v5
         with:
           go-version-file: tools/proxy-helper/go.mod
+          cache-dependency-path: tools/proxy-helper/go.sum
 
       - name: Build proxy-helper
         run: make build
+        working-directory: tools/proxy-helper
+
+      - name: Test proxy-helper
+        run: make test
         working-directory: tools/proxy-helper
 
       - name: Check (lint + type check)

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -82,6 +82,13 @@ jobs:
             *) echo "Unsupported arch: ${{ matrix.arch }}" >&2; exit 1 ;;
           esac
 
+          file dist/share/kimchi/bin/proxy-helper
+          case "${{ matrix.arch }}" in
+            amd64) file dist/share/kimchi/bin/proxy-helper | grep -Eq 'x86[_-]64|x86-64' ;;
+            arm64) file dist/share/kimchi/bin/proxy-helper | grep -Eq 'arm64|aarch64' ;;
+            *) echo "Unsupported arch: ${{ matrix.arch }}" >&2; exit 1 ;;
+          esac
+
       - name: Package binary
         run: tar -czf kimchi_${{ matrix.os }}_${{ matrix.arch }}.tar.gz -C dist bin share
 

--- a/tools/proxy-helper/Makefile
+++ b/tools/proxy-helper/Makefile
@@ -1,4 +1,7 @@
 build:
-	go build -o bin/proxy-helper .
+	go build -ldflags="-s -w" -o bin/proxy-helper .
 
-.PHONY: build
+test:
+	go test ./...
+
+.PHONY: build test


### PR DESCRIPTION


---
### Kimchi Summary
### What changed
Adds the `proxy-helper` Go tool to the canary build pipeline, runs its unit tests in CI, enables Go module caching, strips debug symbols to reduce binary size, and verifies cross-compiled architecture in releases.

### Why
Completes the CI/CD integration for the `proxy-helper` utility so it is built, tested, cached, and shipped correctly across all target platforms.

### Key changes
- `.github/workflows/canary.yml`: Triggers on changes to `tools/proxy-helper/**`; adds `actions/setup-go@v5` and a cross-compilation `make -C tools/proxy-helper build` step using matrix `GOOS` and `GOARCH`.
- `.github/workflows/ci.yml`: Adds `cache-dependency-path: tools/proxy-helper/go.sum` to the Go setup steps; introduces a `make test` step for `proxy-helper` in the lint and test jobs.
- `.github/workflows/release.yml`: Validates the architecture of `dist/share/kimchi/bin/proxy-helper` with the `file` command before packaging, ensuring it matches the target `amd64` or `arm64` platform.
- `tools/proxy-helper/Makefile`: Adds `-ldflags="-s -w"` to strip debug info and shrink binaries; adds a `test` target running `go test ./...`.