### PR TITLE
feat: add /clear command as alias for /new

### DIFF
--- a/src/extensions/ui.ts
+++ b/src/extensions/ui.ts
@@ -303,4 +303,11 @@ export default function uiExtension(pi: ExtensionAPI) {
 			ctx.shutdown()
 		},
 	})
+
+	pi.registerCommand("clear", {
+		description: "Start a new session (alias for /new)",
+		handler: async (_args, ctx) => {
+			await ctx.newSession()
+		},
+	})
 }


### PR DESCRIPTION


---
### Kimchi Summary
### What changed
Adds a `clear` command that starts a new session by invoking `ctx.newSession()`, providing an alias for the existing `new` command.

### Why
Gives users a more intuitive, terminal-familiar way to reset their conversation context.

### Key changes
- `src/extensions/ui.ts`: registers the new `"clear"` command via `pi.registerCommand`. Its handler calls `await ctx.newSession()` to start a fresh session.