### PR TITLE
fix: remove autodetected providers

### DIFF
--- a/patches/@earendil-works__pi-coding-agent.patch
+++ b/patches/@earendil-works__pi-coding-agent.patch
@@ -10,6 +10,20 @@ index d9722b792a5e2c0020bd842ea6ddb1754a51b44c..6d64db9876b8be6ae6af34322d5748cf
    ANTHROPIC_API_KEY                - Anthropic Claude API key
    ANTHROPIC_OAUTH_TOKEN            - Anthropic OAuth token (alternative to API key)
    OPENAI_API_KEY                   - OpenAI GPT API key
+diff --git a/dist/core/model-registry.js b/dist/core/model-registry.js
+index 2d88adfd072b1f656f4f82a24f2df5ae6984287b..ec99d306d53a8753c52d2f5f8df190c716356375 100644
+--- a/dist/core/model-registry.js
++++ b/dist/core/model-registry.js
+@@ -292,7 +292,8 @@ export class ModelRegistry {
+     }
+     /** Load built-in models and apply provider/model overrides */
+     loadBuiltInModels(overrides, modelOverrides) {
+-        return getProviders().flatMap((provider) => {
++        const allowed = process.env.KIMCHI_DISABLE_BUILTIN_PROVIDERS ? new Set(["kimchi-dev"]) : null;
++        return getProviders().filter((p) => !allowed || allowed.has(p)).flatMap((provider) => {
+             const models = getModels(provider);
+             const providerOverride = overrides.get(provider);
+             const perModelOverrides = modelOverrides.get(provider);
 diff --git a/dist/core/model-resolver.js b/dist/core/model-resolver.js
 index afdb0b720f9e57875d9493fe932b4912afa9807f..c644bee905695ca37f4d124cc81fd327840e6911 100644
 --- a/dist/core/model-resolver.js
@@ -18,7 +32,7 @@ index afdb0b720f9e57875d9493fe932b4912afa9807f..c644bee905695ca37f4d124cc81fd327
      opencode: "kimi-k2.6",
      "opencode-go": "kimi-k2.6",
      "kimi-coding": "kimi-for-coding",
-+    "kimchi-dev": "kimi-k2.5",
++    "kimchi-dev": "kimi-k2.6",
      "cloudflare-workers-ai": "@cf/moonshotai/kimi-k2.6",
      "cloudflare-ai-gateway": "workers-ai/@cf/moonshotai/kimi-k2.6",
      xiaomi: "mimo-v2.5-pro",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6,7 +6,7 @@ settings:
 
 patchedDependencies:
   '@earendil-works/pi-coding-agent':
-    hash: bfe614021e3f7c6dd196bece1a61f27bf88584dae8e2cebc720678f890d287ab
+    hash: 4785605e3a4803fd16997a45b591e1ebaea55506797d5fdc4e56639d4d1531b4
     path: patches/@earendil-works__pi-coding-agent.patch
   '@earendil-works/pi-tui':
     hash: e432fee0f54b7321d104a08ff5a38561d9c2cd3b002f34e6b8cbc2377889c9d2
@@ -24,7 +24,7 @@ importers:
         version: 1.3.0
       '@earendil-works/pi-coding-agent':
         specifier: ^0.75.1
-        version: 0.75.1(patch_hash=bfe614021e3f7c6dd196bece1a61f27bf88584dae8e2cebc720678f890d287ab)(@modelcontextprotocol/sdk@1.29.0(zod@4.4.3))(ws@8.20.1)(zod@4.4.3)
+        version: 0.75.1(patch_hash=4785605e3a4803fd16997a45b591e1ebaea55506797d5fdc4e56639d4d1531b4)(@modelcontextprotocol/sdk@1.29.0(zod@4.4.3))(ws@8.20.1)(zod@4.4.3)
       '@earendil-works/pi-tui':
         specifier: ^0.75.1
         version: 0.75.1(patch_hash=e432fee0f54b7321d104a08ff5a38561d9c2cd3b002f34e6b8cbc2377889c9d2)
@@ -2189,7 +2189,7 @@ snapshots:
       - ws
       - zod
 
-  '@earendil-works/pi-coding-agent@0.75.1(patch_hash=bfe614021e3f7c6dd196bece1a61f27bf88584dae8e2cebc720678f890d287ab)(@modelcontextprotocol/sdk@1.29.0(zod@4.4.3))(ws@8.20.1)(zod@4.4.3)':
+  '@earendil-works/pi-coding-agent@0.75.1(patch_hash=4785605e3a4803fd16997a45b591e1ebaea55506797d5fdc4e56639d4d1531b4)(@modelcontextprotocol/sdk@1.29.0(zod@4.4.3))(ws@8.20.1)(zod@4.4.3)':
     dependencies:
       '@earendil-works/pi-agent-core': 0.75.1(@modelcontextprotocol/sdk@1.29.0(zod@4.4.3))(ws@8.20.1)(zod@4.4.3)
       '@earendil-works/pi-ai': 0.75.1(@modelcontextprotocol/sdk@1.29.0(zod@4.4.3))(ws@8.20.1)(zod@4.4.3)

--- a/src/entry.ts
+++ b/src/entry.ts
@@ -39,6 +39,7 @@ process.env.KIMCHI_CODING_AGENT_DIR = agentDir
 
 process.title = "kimchi"
 process.env.PI_SKIP_VERSION_CHECK = "1"
+process.env.KIMCHI_DISABLE_BUILTIN_PROVIDERS = "1"
 
 installProxyAgent()
 


### PR DESCRIPTION
Env vars such as `AWS_ACCESS_KEY_ID` `AWS_SECRET_ACCESS_KEY` etc. trigger pi coding agent's provider autodetect flow, but we only want to support the kimchi provider.

There's no entry point to filter out these providers
So for now, we patch the pi coding agent and filter them out this way.