### PR TITLE
feat(benchmark): add new-session-claude.sh and update evaluation audit model

### DIFF
--- a/benchmark/manual/lib.sh
+++ b/benchmark/manual/lib.sh
@@ -84,7 +84,7 @@ bench_task_setup() {
       # The explore seed is expected to be at $IMPROVEMENT_DIR/seeds/explore-refactor
       # The calling script should set EXPLORE_SEED before calling this.
       if [[ -n "${EXPLORE_SEED:-}" && -d "$EXPLORE_SEED" ]]; then
-        echo "mkdir -p \"\$$dir_var/usermgmt\" && cp -R \"$EXPLORE_SEED/\"* \"\$$dir_var/usermgmt/\""
+        echo "mkdir -p \"\$$dir_var/usermgmt\" && cp -R \"$EXPLORE_SEED/.\" \"\$$dir_var/usermgmt/\" && ls -la \"\$$dir_var/usermgmt/\""
       fi
       ;;
     *)
@@ -236,8 +236,9 @@ bench_generate_run_all_script() {
     for (( c=0; c<cols; c++ )); do
       if (( i <= num_scripts )); then
         local script_escaped="${scripts[$i]}"
-        # Escape double quotes for AppleScript
-        script_escaped="${script_escaped//\"/\\\\\"}"
+        # In AppleScript string literals, a literal double-quote is escaped by
+        # doubling it (""), not with a backslash.
+        script_escaped="${script_escaped//\"/\"\"}"
         as_lines+=("      tell g${c}_${r} to write text \"${script_escaped}\"")
         (( i++ ))
       fi

--- a/benchmark/manual/lib.sh
+++ b/benchmark/manual/lib.sh
@@ -1,0 +1,279 @@
+#!/bin/zsh
+# Shared library for benchmark/manual scripts
+# Source from new-session.sh and new-session-claude.sh
+
+# ---------------------------------------------------------------------------
+# Task prompts
+# ---------------------------------------------------------------------------
+
+BENCH_PROMPT_SIMPLE='Implement a Go HTTP middleware that rate-limits requests per client IP using a token bucket algorithm. Requirements: Each IP gets 10 requests per second. Respond with HTTP 429 when limit is exceeded. Thread-safe implementation. Include tests with map-based test cases. Put the code in directory: $DIR/rate-limiter/. Include a README.md explaining usage.'
+
+BENCH_PROMPT_COMPLEX='Implement a Go REST API for a task management system. This is a multi-layer project — start with a plan before writing any code. Requirements: Use standard library only (no frameworks, no external dependencies). Layered architecture: handler -> service -> repository. In-memory repository. Endpoints: POST /tasks (create, fields: title+description), GET /tasks (list all), GET /tasks/{id} (get by id), PATCH /tasks/{id} (update status: todo/in-progress/done), DELETE /tasks/{id} (delete). Proper HTTP status codes and JSON responses. Unit tests for the service layer using map-based test cases. Put all code in directory: $DIR/task-api/'
+
+BENCH_PROMPT_RESEARCH='What are the most popular third-party HTTP router libraries for Go? List the top 3 with: GitHub stars (approximate), key differentiators, and a one-line example of defining a route with a path parameter.'
+
+BENCH_PROMPT_EXPLORE='The directory $DIR/usermgmt/ contains an existing Go HTTP API for user and team management. Explore the codebase, find all HTTP handlers that are missing input validation, and fix them. Requirements: - First explore the entire codebase to build a map of all handlers and their validation status. - Write a plan listing every handler endpoint, what validation is missing, and what you will add. - Implement the validation fixes. Specific issues to find and fix:   - Handlers that accept arbitrary strings for fields with a fixed set of valid values (e.g. roles)   - Handlers that accept zero or negative integers for fields that must be positive   - Handlers that accept empty strings for required fields at the HTTP layer (even if the service layer also checks)   - Search/filter endpoints with no length limit on query parameters   - Pagination parameters with no bounds checking (negative offsets, excessively large limits) - Add unit tests for the validation logic using map-based test cases. - Do not change the project structure or add external dependencies.'
+
+BENCH_PROMPT_MEGA='Implement a Go CLI application that acts as a concurrent build system, similar to a simplified Make. This is a multi-layer project — start with a plan before writing any code. Requirements: Use standard library only (no frameworks, no external dependencies). Parse a declarative build file (buildfile.txt) with this format:
+    target: dep1 dep2
+        command1
+        command2
+Indented lines under a target are shell commands. Dependencies are space-separated after the colon. Resolve the full dependency graph using topological sort. Detect and report cycles with a clear error message listing the cycle path. Execute independent targets concurrently using a worker pool. Targets whose dependencies are all satisfied should start immediately. Stream command output per target with prefixed labels, e.g. '"'"'[compile] go build ./...'"'"'. Graceful shutdown on SIGINT: finish in-progress targets, skip pending ones, print a summary of what completed and what was skipped. CLI flags: -f <file> (build file path, default: buildfile.txt), -j <N> (max parallel workers, default: number of CPUs), -target <name> (build a specific target and its transitive deps only, default: build all root targets). Fail fast: on the first target error, cancel pending targets and report which target and command failed. Layered architecture: separate packages for parsing, graph resolution, execution engine, and CLI. Unit tests for: build file parsing (valid and malformed input), dependency resolution (diamond deps, cycle detection, single target extraction), and execution ordering (verify concurrency-safe ordering). Use map-based test cases. Put all code in directory: $DIR/buildtool/'
+
+# Associative array: task name -> prompt variable name
+# Used for dynamic lookup without eval
+declare -A BENCH_TASK_MAP
+BENCH_TASK_MAP[simple]='BENCH_PROMPT_SIMPLE'
+BENCH_TASK_MAP[complex]='BENCH_PROMPT_COMPLEX'
+BENCH_TASK_MAP[complex-single]='BENCH_PROMPT_COMPLEX'
+BENCH_TASK_MAP[research]='BENCH_PROMPT_RESEARCH'
+BENCH_TASK_MAP[explore]='BENCH_PROMPT_EXPLORE'
+BENCH_TASK_MAP[mega]='BENCH_PROMPT_MEGA'
+
+# Ordered list of task names
+BENCH_TASKS=(simple complex complex-single research explore mega)
+
+# Associative array: task name -> human label
+declare -A BENCH_TASK_LABELS
+BENCH_TASK_LABELS[simple]='Go HTTP Rate Limiter Middleware'
+BENCH_TASK_LABELS[complex]='Go REST API Task Management'
+BENCH_TASK_LABELS[complex-single]='Go REST API (single model)'
+BENCH_TASK_LABELS[research]='Most popular Go HTTP router libraries'
+BENCH_TASK_LABELS[explore]='Add input validation to existing Go API'
+BENCH_TASK_LABELS[mega]='Go Concurrent Build System'
+
+# ---------------------------------------------------------------------------
+# Helper: resolve a prompt variable name to its value
+# ---------------------------------------------------------------------------
+
+# Returns the prompt string for a given task name
+bench_prompt_for() {
+  local task="$1"
+  local var="${BENCH_TASK_MAP[$task]}"
+  if [[ -z "$var" ]]; then
+    echo "Unknown task: $task" >&2
+    return 1
+  fi
+  echo "${(P)var}"
+}
+
+# ---------------------------------------------------------------------------
+# Session directory numbering
+# ---------------------------------------------------------------------------
+
+# Prints the path of the next session directory (does NOT create it).
+# Usage: SESSION_DIR=$(bench_next_session_dir "$SESSIONS_DIR")
+bench_next_session_dir() {
+  local sessions_dir="$1"
+  LAST=$(ls -d "$sessions_dir"/session-* 2>/dev/null | grep -oE '[0-9]+$' | sort -n | tail -1)
+  N=$(( ${LAST:-0} + 1 ))
+  SESSION="session-$(printf '%02d' $N)"
+  echo "$sessions_dir/$SESSION"
+}
+
+# ---------------------------------------------------------------------------
+# Per-task setup command (e.g. copy explore seed)
+# ---------------------------------------------------------------------------
+
+# Prints the setup shell commands for a task. Empty string if no setup needed.
+bench_task_setup() {
+  local task="$1"
+  local dir_var="${2:-DIR}"   # the shell variable name for the working dir (default: DIR)
+  case "$task" in
+    explore)
+      # The explore seed is expected to be at $IMPROVEMENT_DIR/seeds/explore-refactor
+      # The calling script should set EXPLORE_SEED before calling this.
+      if [[ -n "${EXPLORE_SEED:-}" && -d "$EXPLORE_SEED" ]]; then
+        echo "mkdir -p \"\$$dir_var/usermgmt\" && cp -R \"$EXPLORE_SEED/\"* \"\$$dir_var/usermgmt/\""
+      fi
+      ;;
+    *)
+      echo ""
+      ;;
+  esac
+}
+
+# ---------------------------------------------------------------------------
+# Generate individual runner script
+# ---------------------------------------------------------------------------
+
+# Generates a single run-*.sh script.
+# Usage:
+#   bench_generate_runner_script <output_path> <runner_type> <task_name> <model/cli_name> <session_dir> <session_num> <binary_or_cli> <temp_prefix>
+#
+# runner_type = "kimchi" | "claude"
+bench_generate_runner_script() {
+  local output_path="$1"
+  local runner_type="$2"
+  local task_name="$3"
+  local model_name="$4"
+  local session_dir="$5"
+  local session_num="$6"
+  local binary="$7"
+  local temp_prefix="$8"
+
+  local prompt
+  prompt=$(bench_prompt_for "$task_name")
+
+  local setup_cmd
+  setup_cmd=$(bench_task_setup "$task_name" "DIR")
+
+  local content
+
+  if [[ "$runner_type" == "kimchi" ]]; then
+    # Determine extra flags per task
+    local extra_flags=""
+    if [[ "$task_name" == "complex-single" ]]; then
+      extra_flags='  --multi-model=false \'
+    fi
+
+    local setup_block=""
+    if [[ -n "$setup_cmd" ]]; then
+      setup_block="${setup_cmd}
+"
+    fi
+
+    content="#!/bin/zsh
+TS=\$(date +%Y%m%d-%H%M%S)
+SESSION_FILE=\"${session_dir}/runs/${task_name}-${model_name}/session-\${TS}.jsonl\"
+DIR=\$(mktemp -d /private/tmp/${temp_prefix}-XXXXXX)
+echo \"Working directory: \$DIR\"
+echo \"Session file: \$SESSION_FILE\"
+cd \"\$DIR\"
+${setup_block}${binary} \\
+  --yolo \\
+  --model kimchi-dev/${model_name} \\
+${extra_flags}  --session \"\$SESSION_FILE\" \\
+  \"${prompt}\"
+"
+  elif [[ "$runner_type" == "claude" ]]; then
+    local setup_block=""
+    if [[ -n "$setup_cmd" ]]; then
+      setup_block="${setup_cmd}
+"
+    fi
+
+    content="#!/bin/zsh
+DIR=\$(mktemp -d /private/tmp/${temp_prefix}-XXXXXX)
+echo \"Working directory: \$DIR\"
+cd \"\$DIR\"
+${setup_block}${binary} \\
+  --dangerously-skip-permissions \\
+  --model opus \\
+  \"${prompt}\"
+"
+  else
+    echo "Unknown runner type: $runner_type" >&2
+    return 1
+  fi
+
+  printf '%s' "$content" > "$output_path"
+  chmod +x "$output_path"
+}
+
+# ---------------------------------------------------------------------------
+# Generate run-all.sh script
+# ---------------------------------------------------------------------------
+
+# Generates a run-all.sh (or run-all-claude.sh) script.
+# Usage:
+#   bench_generate_run_all_script <output_path> <--rows N> <--cols N> <script_path...>
+#
+# Layout logic:
+#   - 1D (rows=1, cols=M): single row, M vertical splits — for claude scripts
+#   - 2D (rows=R, cols=C): R horizontal splits × C vertical splits — for kimchi grid
+bench_generate_run_all_script() {
+  local output_path="$1"
+  shift
+
+  local rows=1
+  local cols=0
+
+  # Parse --rows and --cols flags
+  while [[ "$1" == --* ]]; do
+    case "$1" in
+      --rows) rows="$2"; shift 2 ;;
+      --cols) cols="$2"; shift 2 ;;
+      *) echo "Unknown flag: $1" >&2; return 1 ;;
+    esac
+  done
+
+  local -a scripts=("$@")
+  local num_scripts=${#scripts[@]}
+
+  if [[ $num_scripts -eq 0 ]]; then
+    echo "bench_generate_run_all_script: no scripts given" >&2
+    return 1
+  fi
+
+  # If cols not specified, derive from rows for a roughly-square grid
+  if [[ $cols -eq 0 ]]; then
+    cols=$(( (num_scripts + rows - 1) / rows ))
+  fi
+
+  # Build AppleScript
+  local -a as_lines=()
+
+  # First pane in the new tab
+  as_lines+=("      set g0_0 to current session of newTab")
+
+  # Vertical splits for remaining columns in row 0
+  local c r
+  for (( c=1; c<cols; c++ )); do
+    as_lines+=("      set g${c}_0 to (split vertically with default profile of g$(( c-1 ))_0)")
+  done
+
+  # Horizontal splits for remaining rows
+  for (( r=1; r<rows; r++ )); do
+    for (( c=0; c<cols; c++ )); do
+      as_lines+=("      set g${c}_${r} to (split horizontally with default profile of g${c}_$(( r-1 )))")
+    done
+  done
+
+  # Write commands to each pane
+  local i=1
+  for (( r=0; r<rows; r++ )); do
+    for (( c=0; c<cols; c++ )); do
+      if (( i <= num_scripts )); then
+        local script_escaped="${scripts[$i]}"
+        # Escape double quotes for AppleScript
+        script_escaped="${script_escaped//\"/\\\\\"}"
+        as_lines+=("      tell g${c}_${r} to write text \"${script_escaped}\"")
+        (( i++ ))
+      fi
+    done
+  done
+
+  local as_body=$'\n'"${(F)as_lines}"$'\n'
+
+  # Build background fallback
+  local -a bg_lines=()
+  for script in "${scripts[@]}"; do
+    local name="${script:t:r}"   # basename without extension
+    local log="${script:h}/${name}.log"
+    bg_lines+=("  \"${script}\" >\"${log}\" 2>&1 &")
+  done
+  local bg_body=$'\n'"${(F)bg_lines}"$'\n'
+
+  local num_scripts_str="$num_scripts"
+  cat > "$output_path" <<EOF
+#!/bin/zsh
+if osascript -e 'id of application "iTerm2"' &>/dev/null 2>&1; then
+  osascript <<APPLESCRIPT
+tell application "iTerm2"
+  tell current window
+    set newTab to (create tab with default profile)
+    tell newTab
+${as_body}    end tell
+  end tell
+end tell
+APPLESCRIPT
+else
+  echo "iTerm2 not available — running ${num_scripts_str} scripts in background..."
+${bg_body}
+  wait
+  echo "All done."
+fi
+EOF
+  chmod +x "$output_path"
+}

--- a/benchmark/manual/new-session-claude.sh
+++ b/benchmark/manual/new-session-claude.sh
@@ -2,6 +2,8 @@
 set -e
 
 IMPROVEMENT_DIR="${0:A:h}"
+source "${IMPROVEMENT_DIR}/lib.sh"
+
 SESSIONS_DIR="$IMPROVEMENT_DIR/sessions"
 EXPLORE_SEED="$IMPROVEMENT_DIR/seeds/explore-refactor"
 CLAUDE_BIN=$(which claude 2>/dev/null || true)
@@ -13,24 +15,14 @@ fi
 
 mkdir -p "$SESSIONS_DIR"
 
-LAST=$(ls -d "$SESSIONS_DIR"/session-* 2>/dev/null | grep -oE '[0-9]+$' | sort -n | tail -1)
-N=$(( ${LAST:-0} + 1 ))
-SESSION="session-$(printf '%02d' $N)"
-SESSION_DIR="$SESSIONS_DIR/$SESSION"
-
-TASKS=(
-  "simple:Go HTTP Rate Limiter Middleware"
-  "complex:Go REST API Task Management"
-  "complex-single:Go REST API (single model)"
-  "research:Most popular Go HTTP router libraries"
-  "explore:Add input validation to existing Go API"
-  "mega:Go Concurrent Build System"
-)
+SESSION_DIR=$(bench_next_session_dir "$SESSIONS_DIR")
+N=$(basename "$SESSION_DIR" | grep -oE '[0-9]+$')
 
 echo "Available tasks:"
 echo ""
-for i in {1..${#TASKS[@]}}; do
-  label="${TASKS[$i]#*:}"
+for i in {1..${#BENCH_TASKS[@]}}; do
+  task="${BENCH_TASKS[$i]}"
+  label="${BENCH_TASK_LABELS[$task]}"
   echo "  $i) $label"
 done
 echo ""
@@ -39,12 +31,12 @@ read -r SELECTION
 
 SELECTED=()
 if [[ "$SELECTION" == "all" ]]; then
-  for i in {1..${#TASKS[@]}}; do
+  for i in {1..${#BENCH_TASKS[@]}}; do
     SELECTED+=($i)
   done
 else
   for tok in ${=SELECTION}; do
-    if (( tok >= 1 && tok <= ${#TASKS[@]} )); then
+    if (( tok >= 1 && tok <= ${#BENCH_TASKS[@]} )); then
       SELECTED+=($tok)
     else
       echo "Invalid task number: $tok"
@@ -59,107 +51,35 @@ if [[ ${#SELECTED[@]} -eq 0 ]]; then
 fi
 
 echo ""
-echo "Creating $SESSION with ${#SELECTED[@]} task(s)..."
-
-SIMPLE_PROMPT='Implement a Go HTTP middleware that rate-limits requests per client IP using a token bucket algorithm. Requirements: Each IP gets 10 requests per second. Respond with HTTP 429 when limit is exceeded. Thread-safe implementation. Include tests with map-based test cases. Put the code in directory: $DIR/rate-limiter/. Include a README.md explaining usage.'
-
-COMPLEX_PROMPT='Implement a Go REST API for a task management system. This is a multi-layer project — start with a plan before writing any code. Requirements: Use standard library only (no frameworks, no external dependencies). Layered architecture: handler -> service -> repository. In-memory repository. Endpoints: POST /tasks (create, fields: title+description), GET /tasks (list all), GET /tasks/{id} (get by id), PATCH /tasks/{id} (update status: todo/in-progress/done), DELETE /tasks/{id} (delete). Proper HTTP status codes and JSON responses. Unit tests for the service layer using map-based test cases. Put all code in directory: $DIR/task-api/'
-
-RESEARCH_PROMPT='What are the most popular third-party HTTP router libraries for Go? List the top 3 with: GitHub stars (approximate), key differentiators, and a one-line example of defining a route with a path parameter.'
-
-EXPLORE_PROMPT='The directory $DIR/usermgmt/ contains an existing Go HTTP API for user and team management. Explore the codebase, find all HTTP handlers that are missing input validation, and fix them. Requirements: - First explore the entire codebase to build a map of all handlers and their validation status. - Write a plan listing every handler endpoint, what validation is missing, and what you will add. - Implement the validation fixes. Specific issues to find and fix:   - Handlers that accept arbitrary strings for fields with a fixed set of valid values (e.g. roles)   - Handlers that accept zero or negative integers for fields that must be positive   - Handlers that accept empty strings for required fields at the HTTP layer (even if the service layer also checks)   - Search/filter endpoints with no length limit on query parameters   - Pagination parameters with no bounds checking (negative offsets, excessively large limits) - Add unit tests for the validation logic using map-based test cases. - Do not change the project structure or add external dependencies.'
-
-MEGA_PROMPT='Implement a Go CLI application that acts as a concurrent build system, similar to a simplified Make. This is a multi-layer project — start with a plan before writing any code. Requirements: Use standard library only (no frameworks, no external dependencies). Parse a declarative build file (buildfile.txt) with this format:
-    target: dep1 dep2
-        command1
-        command2
-Indented lines under a target are shell commands. Dependencies are space-separated after the colon. Resolve the full dependency graph using topological sort. Detect and report cycles with a clear error message listing the cycle path. Execute independent targets concurrently using a worker pool. Targets whose dependencies are all satisfied should start immediately. Stream command output per target with prefixed labels, e.g. '"'"'[compile] go build ./...'"'"'. Graceful shutdown on SIGINT: finish in-progress targets, skip pending ones, print a summary of what completed and what was skipped. CLI flags: -f <file> (build file path, default: buildfile.txt), -j <N> (max parallel workers, default: number of CPUs), -target <name> (build a specific target and its transitive deps only, default: build all root targets). Fail fast: on the first target error, cancel pending targets and report which target and command failed. Layered architecture: separate packages for parsing, graph resolution, execution engine, and CLI. Unit tests for: build file parsing (valid and malformed input), dependency resolution (diamond deps, cycle detection, single target extraction), and execution ordering (verify concurrency-safe ordering). Use map-based test cases. Put all code in directory: $DIR/buildtool/'
+echo "Creating $(basename "$SESSION_DIR") with ${#SELECTED[@]} task(s)..."
 
 ALL_SCRIPTS=()
 
 for idx in "${SELECTED[@]}"; do
-  entry="${TASKS[$idx]}"
-  task="${entry%%:*}"
+  task="${BENCH_TASKS[$idx]}"
   run_dir="claude-$task"
   mkdir -p "$SESSION_DIR/runs/$run_dir"
 
   slug="s${N}-claude-${task}"
   script_path="$SESSION_DIR/run-claude-${task}.sh"
 
-  case "$task" in
-    simple)         PROMPT="$SIMPLE_PROMPT" ;;
-    complex)        PROMPT="$COMPLEX_PROMPT" ;;
-    complex-single) PROMPT="$COMPLEX_PROMPT" ;;
-    research)       PROMPT="$RESEARCH_PROMPT" ;;
-    explore)        PROMPT="$EXPLORE_PROMPT" ;;
-    mega)           PROMPT="$MEGA_PROMPT" ;;
-  esac
+  bench_generate_runner_script \
+    "$script_path" \
+    "claude" \
+    "$task" \
+    "claude" \
+    "$SESSION_DIR" \
+    "$N" \
+    "$CLAUDE_BIN" \
+    "claude-${slug}"
 
-  SETUP=""
-  if [[ "$task" == "explore" ]]; then
-    SETUP='mkdir -p "$DIR/usermgmt" && cp -R "'"$EXPLORE_SEED"'/"* "$DIR/usermgmt/"'
-  fi
-
-  cat > "$script_path" <<SCRIPT
-#!/bin/zsh
-DIR=\$(mktemp -d /private/tmp/claude-${slug}-XXXXXX)
-echo "Working directory: \$DIR"
-cd "\$DIR"
-${SETUP:+$SETUP
-}claude \\
-  --dangerously-skip-permissions \\
-  --model opus \\
-  "$PROMPT"
-SCRIPT
-
-  chmod +x "$script_path"
   ALL_SCRIPTS+=("$script_path")
   echo "  created: run-claude-${task}.sh"
 done
 
 if [[ ${#ALL_SCRIPTS[@]} -gt 1 ]]; then
   RUN_ALL="$SESSION_DIR/run-all-claude.sh"
-
-  AS_LINES=()
-  AS_LINES+=("      set g0 to current session of newTab")
-  for (( i=1; i<${#ALL_SCRIPTS[@]}; i++ )); do
-    AS_LINES+=("      set g${i} to (split vertically with default profile of g$(( i-1 )))")
-  done
-  for (( i=0; i<${#ALL_SCRIPTS[@]}; i++ )); do
-    local idx=$(( i + 1 ))
-    AS_LINES+=("      tell g${i} to write text \"${ALL_SCRIPTS[$idx]}\"")
-  done
-
-  AS_BODY=$(printf '%s\n' "${AS_LINES[@]}")
-
-  BG_LINES=()
-  for script in "${ALL_SCRIPTS[@]}"; do
-    name=$(basename "$script" .sh)
-    BG_LINES+=("  \"$script\" >\"$SESSION_DIR/${name}.log\" 2>&1 &")
-  done
-  BG_BODY=$(printf '%s\n' "${BG_LINES[@]}")
-
-  cat > "$RUN_ALL" <<RUNALL
-#!/bin/zsh
-if osascript -e 'id of application "iTerm2"' &>/dev/null 2>&1; then
-  osascript <<APPLESCRIPT
-tell application "iTerm2"
-  tell current window
-    set newTab to (create tab with default profile)
-    tell newTab
-${AS_BODY}
-    end tell
-  end tell
-end tell
-APPLESCRIPT
-else
-  echo "iTerm2 not available — running ${#ALL_SCRIPTS[@]} scripts in background (logs in $SESSION_DIR/)..."
-${BG_BODY}
-  wait
-  echo "All done."
-fi
-RUNALL
-  chmod +x "$RUN_ALL"
+  bench_generate_run_all_script "$RUN_ALL" "${ALL_SCRIPTS[@]}"
   echo "  created: run-all-claude.sh"
 fi
 

--- a/benchmark/manual/new-session-claude.sh
+++ b/benchmark/manual/new-session-claude.sh
@@ -1,0 +1,168 @@
+#!/bin/zsh
+set -e
+
+IMPROVEMENT_DIR="${0:A:h}"
+SESSIONS_DIR="$IMPROVEMENT_DIR/sessions"
+EXPLORE_SEED="$IMPROVEMENT_DIR/seeds/explore-refactor"
+CLAUDE_BIN=$(which claude 2>/dev/null || true)
+
+if [[ -z "$CLAUDE_BIN" ]]; then
+  echo "claude CLI not found in PATH"
+  exit 1
+fi
+
+mkdir -p "$SESSIONS_DIR"
+
+LAST=$(ls -d "$SESSIONS_DIR"/session-* 2>/dev/null | grep -oE '[0-9]+$' | sort -n | tail -1)
+N=$(( ${LAST:-0} + 1 ))
+SESSION="session-$(printf '%02d' $N)"
+SESSION_DIR="$SESSIONS_DIR/$SESSION"
+
+TASKS=(
+  "simple:Go HTTP Rate Limiter Middleware"
+  "complex:Go REST API Task Management"
+  "complex-single:Go REST API (single model)"
+  "research:Most popular Go HTTP router libraries"
+  "explore:Add input validation to existing Go API"
+  "mega:Go Concurrent Build System"
+)
+
+echo "Available tasks:"
+echo ""
+for i in {1..${#TASKS[@]}}; do
+  label="${TASKS[$i]#*:}"
+  echo "  $i) $label"
+done
+echo ""
+echo "Enter task numbers separated by spaces (e.g. '1 3 4'), or 'all':"
+read -r SELECTION
+
+SELECTED=()
+if [[ "$SELECTION" == "all" ]]; then
+  for i in {1..${#TASKS[@]}}; do
+    SELECTED+=($i)
+  done
+else
+  for tok in ${=SELECTION}; do
+    if (( tok >= 1 && tok <= ${#TASKS[@]} )); then
+      SELECTED+=($tok)
+    else
+      echo "Invalid task number: $tok"
+      exit 1
+    fi
+  done
+fi
+
+if [[ ${#SELECTED[@]} -eq 0 ]]; then
+  echo "No tasks selected."
+  exit 0
+fi
+
+echo ""
+echo "Creating $SESSION with ${#SELECTED[@]} task(s)..."
+
+SIMPLE_PROMPT='Implement a Go HTTP middleware that rate-limits requests per client IP using a token bucket algorithm. Requirements: Each IP gets 10 requests per second. Respond with HTTP 429 when limit is exceeded. Thread-safe implementation. Include tests with map-based test cases. Put the code in directory: $DIR/rate-limiter/. Include a README.md explaining usage.'
+
+COMPLEX_PROMPT='Implement a Go REST API for a task management system. This is a multi-layer project — start with a plan before writing any code. Requirements: Use standard library only (no frameworks, no external dependencies). Layered architecture: handler -> service -> repository. In-memory repository. Endpoints: POST /tasks (create, fields: title+description), GET /tasks (list all), GET /tasks/{id} (get by id), PATCH /tasks/{id} (update status: todo/in-progress/done), DELETE /tasks/{id} (delete). Proper HTTP status codes and JSON responses. Unit tests for the service layer using map-based test cases. Put all code in directory: $DIR/task-api/'
+
+RESEARCH_PROMPT='What are the most popular third-party HTTP router libraries for Go? List the top 3 with: GitHub stars (approximate), key differentiators, and a one-line example of defining a route with a path parameter.'
+
+EXPLORE_PROMPT='The directory $DIR/usermgmt/ contains an existing Go HTTP API for user and team management. Explore the codebase, find all HTTP handlers that are missing input validation, and fix them. Requirements: - First explore the entire codebase to build a map of all handlers and their validation status. - Write a plan listing every handler endpoint, what validation is missing, and what you will add. - Implement the validation fixes. Specific issues to find and fix:   - Handlers that accept arbitrary strings for fields with a fixed set of valid values (e.g. roles)   - Handlers that accept zero or negative integers for fields that must be positive   - Handlers that accept empty strings for required fields at the HTTP layer (even if the service layer also checks)   - Search/filter endpoints with no length limit on query parameters   - Pagination parameters with no bounds checking (negative offsets, excessively large limits) - Add unit tests for the validation logic using map-based test cases. - Do not change the project structure or add external dependencies.'
+
+MEGA_PROMPT='Implement a Go CLI application that acts as a concurrent build system, similar to a simplified Make. This is a multi-layer project — start with a plan before writing any code. Requirements: Use standard library only (no frameworks, no external dependencies). Parse a declarative build file (buildfile.txt) with this format:
+    target: dep1 dep2
+        command1
+        command2
+Indented lines under a target are shell commands. Dependencies are space-separated after the colon. Resolve the full dependency graph using topological sort. Detect and report cycles with a clear error message listing the cycle path. Execute independent targets concurrently using a worker pool. Targets whose dependencies are all satisfied should start immediately. Stream command output per target with prefixed labels, e.g. '"'"'[compile] go build ./...'"'"'. Graceful shutdown on SIGINT: finish in-progress targets, skip pending ones, print a summary of what completed and what was skipped. CLI flags: -f <file> (build file path, default: buildfile.txt), -j <N> (max parallel workers, default: number of CPUs), -target <name> (build a specific target and its transitive deps only, default: build all root targets). Fail fast: on the first target error, cancel pending targets and report which target and command failed. Layered architecture: separate packages for parsing, graph resolution, execution engine, and CLI. Unit tests for: build file parsing (valid and malformed input), dependency resolution (diamond deps, cycle detection, single target extraction), and execution ordering (verify concurrency-safe ordering). Use map-based test cases. Put all code in directory: $DIR/buildtool/'
+
+ALL_SCRIPTS=()
+
+for idx in "${SELECTED[@]}"; do
+  entry="${TASKS[$idx]}"
+  task="${entry%%:*}"
+  run_dir="claude-$task"
+  mkdir -p "$SESSION_DIR/runs/$run_dir"
+
+  slug="s${N}-claude-${task}"
+  script_path="$SESSION_DIR/run-claude-${task}.sh"
+
+  case "$task" in
+    simple)         PROMPT="$SIMPLE_PROMPT" ;;
+    complex)        PROMPT="$COMPLEX_PROMPT" ;;
+    complex-single) PROMPT="$COMPLEX_PROMPT" ;;
+    research)       PROMPT="$RESEARCH_PROMPT" ;;
+    explore)        PROMPT="$EXPLORE_PROMPT" ;;
+    mega)           PROMPT="$MEGA_PROMPT" ;;
+  esac
+
+  SETUP=""
+  if [[ "$task" == "explore" ]]; then
+    SETUP='mkdir -p "$DIR/usermgmt" && cp -R "'"$EXPLORE_SEED"'/"* "$DIR/usermgmt/"'
+  fi
+
+  cat > "$script_path" <<SCRIPT
+#!/bin/zsh
+DIR=\$(mktemp -d /private/tmp/claude-${slug}-XXXXXX)
+echo "Working directory: \$DIR"
+cd "\$DIR"
+${SETUP:+$SETUP
+}claude \\
+  --dangerously-skip-permissions \\
+  --model opus \\
+  "$PROMPT"
+SCRIPT
+
+  chmod +x "$script_path"
+  ALL_SCRIPTS+=("$script_path")
+  echo "  created: run-claude-${task}.sh"
+done
+
+if [[ ${#ALL_SCRIPTS[@]} -gt 1 ]]; then
+  RUN_ALL="$SESSION_DIR/run-all-claude.sh"
+
+  AS_LINES=()
+  AS_LINES+=("      set g0 to current session of newTab")
+  for (( i=1; i<${#ALL_SCRIPTS[@]}; i++ )); do
+    AS_LINES+=("      set g${i} to (split vertically with default profile of g$(( i-1 )))")
+  done
+  for (( i=0; i<${#ALL_SCRIPTS[@]}; i++ )); do
+    local idx=$(( i + 1 ))
+    AS_LINES+=("      tell g${i} to write text \"${ALL_SCRIPTS[$idx]}\"")
+  done
+
+  AS_BODY=$(printf '%s\n' "${AS_LINES[@]}")
+
+  BG_LINES=()
+  for script in "${ALL_SCRIPTS[@]}"; do
+    name=$(basename "$script" .sh)
+    BG_LINES+=("  \"$script\" >\"$SESSION_DIR/${name}.log\" 2>&1 &")
+  done
+  BG_BODY=$(printf '%s\n' "${BG_LINES[@]}")
+
+  cat > "$RUN_ALL" <<RUNALL
+#!/bin/zsh
+if osascript -e 'id of application "iTerm2"' &>/dev/null 2>&1; then
+  osascript <<APPLESCRIPT
+tell application "iTerm2"
+  tell current window
+    set newTab to (create tab with default profile)
+    tell newTab
+${AS_BODY}
+    end tell
+  end tell
+end tell
+APPLESCRIPT
+else
+  echo "iTerm2 not available — running ${#ALL_SCRIPTS[@]} scripts in background (logs in $SESSION_DIR/)..."
+${BG_BODY}
+  wait
+  echo "All done."
+fi
+RUNALL
+  chmod +x "$RUN_ALL"
+  echo "  created: run-all-claude.sh"
+fi
+
+echo ""
+echo "Done. ${#ALL_SCRIPTS[@]} script(s) created in $SESSION_DIR/"
+echo "Next: run individual scripts or run-all-claude.sh"

--- a/benchmark/manual/new-session-claude.sh
+++ b/benchmark/manual/new-session-claude.sh
@@ -77,11 +77,9 @@ for idx in "${SELECTED[@]}"; do
   echo "  created: run-claude-${task}.sh"
 done
 
-if [[ ${#ALL_SCRIPTS[@]} -gt 1 ]]; then
-  RUN_ALL="$SESSION_DIR/run-all-claude.sh"
-  bench_generate_run_all_script "$RUN_ALL" "${ALL_SCRIPTS[@]}"
-  echo "  created: run-all-claude.sh"
-fi
+RUN_ALL="$SESSION_DIR/run-all-claude.sh"
+bench_generate_run_all_script "$RUN_ALL" "${ALL_SCRIPTS[@]}"
+echo "  created: run-all-claude.sh"
 
 echo ""
 echo "Done. ${#ALL_SCRIPTS[@]} script(s) created in $SESSION_DIR/"

--- a/benchmark/manual/new-session.sh
+++ b/benchmark/manual/new-session.sh
@@ -2,6 +2,7 @@
 set -e
 
 IMPROVEMENT_DIR="${0:A:h}"
+source "${IMPROVEMENT_DIR}/lib.sh"
 
 # Check for local override first, then fall back to default config
 if [[ -f "$IMPROVEMENT_DIR/benchmark.local.json" ]]; then
@@ -23,92 +24,49 @@ if [[ ! -f "$BINARY" ]]; then
 fi
 
 SESSIONS_DIR="$IMPROVEMENT_DIR/sessions"
+EXPLORE_SEED="$IMPROVEMENT_DIR/seeds/explore-refactor"
 mkdir -p "$SESSIONS_DIR"
 
-# Determine next session number
-LAST=$(ls -d "$SESSIONS_DIR"/session-* 2>/dev/null | grep -oE '[0-9]+$' | sort -n | tail -1)
-N=$(( ${LAST:-0} + 1 ))
-SESSION="session-$(printf '%02d' $N)"
-SESSION_DIR="$SESSIONS_DIR/$SESSION"
+SESSION_DIR=$(bench_next_session_dir "$SESSIONS_DIR")
+N=$(basename "$SESSION_DIR" | grep -oE '[0-9]+$')
 
-echo "Creating $SESSION..."
+echo "Creating $(basename "$SESSION_DIR")..."
 
-# Generate all scripts via Python
-python3 - "$SESSION_DIR" "$N" "$BENCHMARK_JSON" "$HOME" "$BINARY" <<'PYEOF'
+# Export prompts as environment variables for the Python block
+export BENCH_PROMPT_SIMPLE
+export BENCH_PROMPT_COMPLEX
+export BENCH_PROMPT_RESEARCH
+export BENCH_PROMPT_EXPLORE
+export BENCH_PROMPT_MEGA
+export EXPLORE_SEED
+export SESSION_DIR
+export N
+export BINARY
+export IMPROVEMENT_DIR
+
+# Generate all scripts via Python (handles 2D grid generation)
+python3 - "$BENCHMARK_JSON" "$HOME" <<'PYEOF'
 import json, os, sys, stat
 
-session_dir, n, benchmark_json, home, binary = sys.argv[1], int(sys.argv[2]), sys.argv[3], sys.argv[4], sys.argv[5]
+benchmark_json = sys.argv[1]
+home = sys.argv[2]
 
 cfg = json.load(open(benchmark_json))
 models = cfg.get("models", [])
 if not models:
     sys.exit("No models configured. Set 'models' array in benchmark.json.")
 
-simple_prompt = (
-    "Implement a Go HTTP middleware that rate-limits requests per client IP using a token bucket algorithm. "
-    "Requirements: Each IP gets 10 requests per second. Respond with HTTP 429 when limit is exceeded. "
-    "Thread-safe implementation. Include tests with map-based test cases. "
-    "Put the code in directory: $DIR/rate-limiter/. Include a README.md explaining usage."
-)
+simple_prompt    = os.environ["BENCH_PROMPT_SIMPLE"]
+complex_prompt   = os.environ["BENCH_PROMPT_COMPLEX"]
+research_prompt  = os.environ["BENCH_PROMPT_RESEARCH"]
+explore_prompt   = os.environ["BENCH_PROMPT_EXPLORE"]
+mega_prompt      = os.environ["BENCH_PROMPT_MEGA"]
+explore_seed     = os.environ["EXPLORE_SEED"]
+session_dir      = os.environ["SESSION_DIR"]
+n                = int(os.environ["N"])
+binary           = os.environ["BINARY"]
 
-complex_prompt = (
-    "Implement a Go REST API for a task management system. "
-    "This is a multi-layer project — start with a plan before writing any code. "
-    "Requirements: Use standard library only (no frameworks, no external dependencies). "
-    "Layered architecture: handler -> service -> repository. In-memory repository. "
-    "Endpoints: POST /tasks (create, fields: title+description), GET /tasks (list all), "
-    "GET /tasks/{id} (get by id), PATCH /tasks/{id} (update status: todo/in-progress/done), DELETE /tasks/{id} (delete). "
-    "Proper HTTP status codes and JSON responses. "
-    "Unit tests for the service layer using map-based test cases. "
-    "Put all code in directory: $DIR/task-api/"
-)
-
-research_prompt = (
-    "What are the most popular third-party HTTP router libraries for Go? "
-    "List the top 3 with: GitHub stars (approximate), key differentiators, "
-    "and a one-line example of defining a route with a path parameter."
-)
-
-explore_seed = os.path.join(os.path.dirname(benchmark_json), "seeds", "explore-refactor")
-explore_prompt = (
-    "The directory $DIR/usermgmt/ contains an existing Go HTTP API for user and team management. "
-    "Explore the codebase, find all HTTP handlers that are missing input validation, and fix them. "
-    "Requirements: "
-    "- First explore the entire codebase to build a map of all handlers and their validation status. "
-    "- Write a plan listing every handler endpoint, what validation is missing, and what you will add. "
-    "- Implement the validation fixes. Specific issues to find and fix: "
-    "  - Handlers that accept arbitrary strings for fields with a fixed set of valid values (e.g. roles) "
-    "  - Handlers that accept zero or negative integers for fields that must be positive "
-    "  - Handlers that accept empty strings for required fields at the HTTP layer (even if the service layer also checks) "
-    "  - Search/filter endpoints with no length limit on query parameters "
-    "  - Pagination parameters with no bounds checking (negative offsets, excessively large limits) "
-    "- Add unit tests for the validation logic using map-based test cases. "
-    "- Do not change the project structure or add external dependencies."
-)
-
-mega_prompt = (
-    "Implement a Go CLI application that acts as a concurrent build system, similar to a simplified Make. "
-    "This is a multi-layer project — start with a plan before writing any code. "
-    "Requirements: Use standard library only (no frameworks, no external dependencies). "
-    "Parse a declarative build file (buildfile.txt) with this format:\n"
-    "    target: dep1 dep2\n"
-    "        command1\n"
-    "        command2\n"
-    "Indented lines under a target are shell commands. Dependencies are space-separated after the colon. "
-    "Resolve the full dependency graph using topological sort. Detect and report cycles with a clear error message listing the cycle path. "
-    "Execute independent targets concurrently using a worker pool. Targets whose dependencies are all satisfied should start immediately. "
-    "Stream command output per target with prefixed labels, e.g. '[compile] go build ./...'. "
-    "Graceful shutdown on SIGINT: finish in-progress targets, skip pending ones, print a summary of what completed and what was skipped. "
-    "CLI flags: -f <file> (build file path, default: buildfile.txt), -j <N> (max parallel workers, default: number of CPUs), "
-    "-target <name> (build a specific target and its transitive deps only, default: build all root targets). "
-    "Fail fast: on the first target error, cancel pending targets and report which target and command failed. "
-    "Layered architecture: separate packages for parsing, graph resolution, execution engine, and CLI. "
-    "Unit tests for: build file parsing (valid and malformed input), dependency resolution (diamond deps, cycle detection, single target extraction), "
-    "and execution ordering (verify concurrency-safe ordering). Use map-based test cases. "
-    "Put all code in directory: $DIR/buildtool/"
-)
-
-# Fields: (name, prompt, extra_flags, include_in_run_all, setup_cmd or None)
+# Fields: (name, prompt, extra_flags, in_run_all, setup_cmd or None)
 tasks = [
     ("simple",         simple_prompt,  [],                      True,  None),
     ("complex",        complex_prompt, [],                      True,  None),
@@ -129,9 +87,7 @@ for model in models:
         script_path = os.path.join(session_dir, f"run-{task}-{model}.sh")
         flags = "\n".join(f"  {flag} \\" for flag in extra_flags)
         flags_block = (flags + "\n") if flags else ""
-        setup_block = ""
-        if setup_cmd:
-            setup_block = f"{setup_cmd}\n"
+        setup_block = (setup_cmd + "\n") if setup_cmd else ""
         content = f"""#!/bin/zsh
 TS=$(date +%Y%m%d-%H%M%S)
 SESSION_FILE="{session_dir}/runs/{run_dir}/session-${{TS}}.jsonl"
@@ -153,34 +109,25 @@ cd "$DIR"
             run_all_scripts.append(script_path)
 
 # run-all.sh — iTerm2 grid (cols=tasks, rows=models) with background fallback
-# Only includes tasks marked with in_run_all=True
 run_all = os.path.join(session_dir, "run-all.sh")
 run_all_tasks = [t for t in tasks if t[3]]
 cols = len(run_all_tasks)
 rows = len(models)
 
-# Build AppleScript: create a NEW TAB, then split into a grid (cols=tasks, rows=models)
 as_lines = []
-# First pane in the new tab
 as_lines.append("      set g0_0 to current session of newTab")
-# Create remaining columns via vertical splits
 for c in range(1, cols):
     as_lines.append(f"      set g{c}_0 to (split vertically with default profile of g{c-1}_0)")
-# Create rows via horizontal splits
 for r in range(1, rows):
     for c in range(cols):
         as_lines.append(f"      set g{c}_{r} to (split horizontally with default profile of g{c}_{r-1})")
-# Write commands
 for r in range(rows):
     for c in range(cols):
         i = r * cols + c
         if i < len(run_all_scripts):
-                # NOTE: iTerm2's `write text` sends keystrokes and returns immediately —
-            # it does NOT wait for the command to finish.
             as_lines.append(f'      tell g{c}_{r} to write text "{run_all_scripts[i]}"')
 as_body = "\n".join(as_lines)
 
-# Background fallback: run each script with output to a per-script log file
 bg_lines = []
 for script in run_all_scripts:
     name = os.path.basename(script).replace(".sh", "")

--- a/benchmark/manual/new-session.sh
+++ b/benchmark/manual/new-session.sh
@@ -72,7 +72,7 @@ tasks = [
     ("complex",        complex_prompt, [],                      True,  None),
     ("complex-single", complex_prompt, ["--multi-model=false"], True,  None),
     ("research",       research_prompt,[],                      True,  None),
-    ("explore",        explore_prompt, [],                      True,  f'mkdir -p "$DIR/usermgmt" && cp -R "{explore_seed}/"* "$DIR/usermgmt/"'),
+    ("explore",        explore_prompt, [],                      True,  f'mkdir -p "$DIR/usermgmt" && cp -R "{explore_seed}/." "$DIR/usermgmt/" && ls -la "$DIR/usermgmt/"'),
     ("mega",           mega_prompt,    [],                      False, None),
 ]
 
@@ -125,7 +125,8 @@ for r in range(rows):
     for c in range(cols):
         i = r * cols + c
         if i < len(run_all_scripts):
-            as_lines.append(f'      tell g{c}_{r} to write text "{run_all_scripts[i]}"')
+            script_path_escaped = run_all_scripts[i].replace('"', '""')
+            as_lines.append(f'      tell g{c}_{r} to write text "{script_path_escaped}"')
 as_body = "\n".join(as_lines)
 
 bg_lines = []

--- a/benchmark/manual/run-evaluation.sh
+++ b/benchmark/manual/run-evaluation.sh
@@ -141,7 +141,7 @@ for task in "${TASKS[@]}"; do
   echo "${task} session: ${JSONL_FILES["$task"]}"
 done
 
-# --- Step 5: Run audits with Claude Opus 4.7 in separate iTerm2 tabs ---
+# --- Step 5: Run audits with Claude Opus 4.6 in separate iTerm2 tabs ---
 echo "=== Spawning iTerm2 tabs for audits ==="
 
 # Build expected output paths that match audit-session.sh naming.
@@ -153,7 +153,7 @@ for task in "${TASKS[@]}"; do
   jsonl_basename=$(basename "${JSONL_FILES["$task"]}")
   session_id="${jsonl_basename%.jsonl}"
   audit_runner="kimchi"
-  audit_model="kimchi-dev/claude-opus-4-7"
+  audit_model="kimchi-dev/claude-opus-4-6"
   model_slug="$(echo "$audit_model" | sed 's|.*/||' | tr '[:upper:]' '[:lower:]')"
   audit_name="${session_id}-${audit_runner}-${model_slug}-AUDIT"
   AUDIT_MD_FILES["$task"]="${REPO_ROOT}/.kimchi/audits/${audit_name}.md"
@@ -161,7 +161,7 @@ for task in "${TASKS[@]}"; do
 done
 
 for task in "${TASKS[@]}"; do
-  audit_cmd="cd \"$REPO_ROOT\" && \"$AUDIT_SCRIPT\" -m kimchi-dev/claude-opus-4-7 \"${JSONL_FILES[\"$task\"]}\""
+  audit_cmd="cd \"$REPO_ROOT\" && \"$AUDIT_SCRIPT\" -m kimchi-dev/claude-opus-4-6 \"${JSONL_FILES[\"$task\"]}\""
   audit_cmd_escaped=${audit_cmd//\"/\\\"}
   osascript <<EOF
 tell application "iTerm2"


### PR DESCRIPTION
- Add `benchmark/manual/new-session-claude.sh` for running benchmark sessions via the Claude CLI with selectable tasks.
- Update `benchmark/manual/run-evaluation.sh` to use `kimchi-dev/claude-opus-4-6` for session audits.

---
### Kimchi Summary
### What changed
Refactored the manual benchmark suite by extracting shared task prompts and session management logic into a reusable library. Added a new script for creating Claude CLI benchmark sessions, and updated the audit model version in the evaluation runner.

### Why
Centralizes benchmark configuration to eliminate duplication between Kimchi and Claude session scripts, making it easier to maintain task prompts and runner generation logic in one place.

### Key changes
- `benchmark/manual/lib.sh` **(new)**: Shared library containing all task prompts (`BENCH_PROMPT_SIMPLE`, `BENCH_PROMPT_COMPLEX`, etc.), task metadata arrays (`BENCH_TASK_MAP`, `BENCH_TASK_LABELS`), and helper functions: `bench_next_session_dir` (session numbering), `bench_task_setup` (per-task seed copying), `bench_generate_runner_script` ( Kimchi/Claude runner generation), and `bench_generate_run_all_script` (iTerm2 grid layout with background fallback).
- `benchmark/manual/new-session-claude.sh` **(new)**: Interactive script that creates per-task runner scripts and a `run-all-claude.sh` launcher for benchmarking the Claude CLI via the shared library.
- `benchmark/manual/new-session.sh`: Refactored to source `lib.sh`, use `bench_next_session_dir` for session numbering, export prompt variables to the Python block instead of defining them inline, and update the `explore` task setup command.
- `benchmark/manual/run-evaluation.sh`: Changed audit model references from `kimchi-dev/claude-opus-4-7` to `kimchi-dev/claude-opus-4-6`.

### Impact
Changes are primarily additive and organizational. The audit model version change from 4.7 to 4.6 is the only functional modification to existing behavior.