### PR TITLE
support images in ACP mode

### DIFF
--- a/src/modes/acp/server.test.ts
+++ b/src/modes/acp/server.test.ts
@@ -20,8 +20,9 @@ class FakeAgentSession {
 	aborted = false
 	model?: { provider: string; id: string }
 	modelRegistry = { getAvailable: () => [] as Array<{ provider: string; id: string; name: string }> }
-	promptImpl: (text: string) => Promise<void> = async () => {}
+	promptImpl: (text: string, opts?: { images?: unknown[] }) => Promise<void> = async () => {}
 	abortImpl: () => Promise<void> = async () => {}
+	lastPromptImages?: unknown[]
 
 	constructor(sessionId: string) {
 		this.sessionId = sessionId
@@ -38,8 +39,9 @@ class FakeAgentSession {
 		for (const l of [...this.listeners]) l(event)
 	}
 
-	async prompt(text: string, _opts?: unknown): Promise<void> {
-		await this.promptImpl(text)
+	async prompt(text: string, opts?: { images?: unknown[] }): Promise<void> {
+		this.lastPromptImages = opts?.images
+		await this.promptImpl(text, opts)
 	}
 
 	async setModel(model: { provider: string; id: string }): Promise<void> {
@@ -335,21 +337,21 @@ describe("KimchiAcpAgent turn lifecycle", () => {
 			const r1 = await agent.prompt({
 				sessionId,
 				// biome-ignore lint/suspicious/noExplicitAny: unsupported block on purpose
-				prompt: [{ type: "image" as any, data: "x" } as any],
+				prompt: [{ type: "audio" as any, data: "x" } as any],
 			})
 			expect(r1.stopReason).toBe("end_turn")
 			// Second call with same unsupported type: no new warning (deduped).
 			const r2 = await agent.prompt({
 				sessionId,
 				// biome-ignore lint/suspicious/noExplicitAny: unsupported block on purpose
-				prompt: [{ type: "image" as any, data: "y" } as any],
+				prompt: [{ type: "audio" as any, data: "y" } as any],
 			})
 			expect(r2.stopReason).toBe("end_turn")
 			// New unsupported type: warns again.
 			const r3 = await agent.prompt({
 				sessionId,
 				// biome-ignore lint/suspicious/noExplicitAny: unsupported block on purpose
-				prompt: [{ type: "audio" as any, data: "z" } as any],
+				prompt: [{ type: "embeddedContext" as any, data: "z" } as any],
 			})
 			expect(r3.stopReason).toBe("end_turn")
 		} finally {
@@ -357,8 +359,34 @@ describe("KimchiAcpAgent turn lifecycle", () => {
 		}
 		const matches = writes.filter((w) => w.includes("acp prompt: dropping unsupported block type"))
 		expect(matches).toHaveLength(2)
-		expect(matches.some((w) => w.includes('"image"'))).toBe(true)
 		expect(matches.some((w) => w.includes('"audio"'))).toBe(true)
+		expect(matches.some((w) => w.includes('"embeddedContext"'))).toBe(true)
+	})
+
+	// Image blocks are supported: they should be extracted and passed to
+	// session.prompt() without warnings, and the turn should proceed normally.
+	it("accepts image blocks and passes them to session.prompt", async () => {
+		fake.promptImpl = async () => {
+			fake.emit({ type: "agent_start" })
+			await delay(5)
+			fake.emit({ type: "agent_end", messages: [] })
+		}
+
+		const result = await agent.prompt({
+			sessionId,
+			prompt: [
+				{ type: "text", text: "describe this image" },
+				{ type: "image", data: "base64data", mimeType: "image/png" },
+			],
+		})
+		expect(result.stopReason).toBe("end_turn")
+		// Verify images were passed to session.prompt
+		expect(fake.lastPromptImages).toHaveLength(1)
+		expect(fake.lastPromptImages?.[0]).toMatchObject({
+			type: "image",
+			data: "base64data",
+			mimeType: "image/png",
+		})
 	})
 
 	// Defensive: once a turn is finalized (short-circuit, shutdown, cancel),

--- a/src/modes/acp/server.test.ts
+++ b/src/modes/acp/server.test.ts
@@ -1,6 +1,8 @@
+import { mkdirSync, rmSync, writeFileSync } from "node:fs"
+import { resolve } from "node:path"
 import type { AgentSideConnection, SessionNotification } from "@agentclientprotocol/sdk"
 import type { AgentSession, AgentSessionEvent, AgentSessionEventListener } from "@earendil-works/pi-coding-agent"
-import { beforeEach, describe, expect, it } from "vitest"
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
 import {
 	type AcpSessionFactory,
 	KimchiAcpAgent,
@@ -18,7 +20,7 @@ class FakeAgentSession {
 	private listeners = new Set<AgentSessionEventListener>()
 	disposed = false
 	aborted = false
-	model?: { provider: string; id: string }
+	model?: { provider: string; id: string; input?: string[] }
 	modelRegistry = { getAvailable: () => [] as Array<{ provider: string; id: string; name: string }> }
 	promptImpl: (text: string, opts?: { images?: unknown[] }) => Promise<void> = async () => {}
 	abortImpl: () => Promise<void> = async () => {}
@@ -100,6 +102,68 @@ describe("KimchiAcpAgent turn lifecycle", () => {
 		})
 		const res = await agent.newSession({ cwd: "/tmp", mcpServers: [] })
 		sessionId = res.sessionId
+	})
+
+	// initialize() should declare image support based on cached models.json
+	describe("initialize capability detection", () => {
+		const tempAgentDir = "/tmp/kimchi-acp-test-agent-dir"
+
+		beforeEach(() => {
+			// Clean up and create temp agent dir
+			try {
+				rmSync(tempAgentDir, { recursive: true, force: true })
+			} catch {}
+			mkdirSync(tempAgentDir, { recursive: true })
+		})
+
+		afterEach(() => {
+			try {
+				rmSync(tempAgentDir, { recursive: true, force: true })
+			} catch {}
+		})
+
+		it("declares image: true when cached models include vision models", async () => {
+			const modelsJson = {
+				providers: {
+					"kimchi-dev": {
+						models: [
+							{
+								id: "gpt-4o",
+								name: "GPT-4o",
+								provider: "openai",
+								input: ["text", "image"],
+							},
+						],
+					},
+				},
+			}
+			writeFileSync(resolve(tempAgentDir, "models.json"), JSON.stringify(modelsJson))
+
+			const testAgent = new KimchiAcpAgent(makeConn(), {
+				extensionFactories: [],
+				agentDir: tempAgentDir,
+				sessionFactory: async () => asSession(fake),
+			})
+
+			const response = await testAgent.initialize({ protocolVersion: 1 })
+			expect(response.agentCapabilities?.promptCapabilities?.image).toBe(true)
+		})
+
+		it("declares image capability based on available models", async () => {
+			// ModelRegistry merges cached models with built-in defaults.
+			// This test verifies the initialize() method correctly queries
+			// the registry and returns a boolean for image support.
+			const testAgent = new KimchiAcpAgent(makeConn(), {
+				extensionFactories: [],
+				agentDir: tempAgentDir,
+				sessionFactory: async () => asSession(fake),
+			})
+
+			const response = await testAgent.initialize({ protocolVersion: 1 })
+			// The result depends on merged models (cached + built-in).
+			// Just verify it's a boolean (the logic ran successfully).
+			expect(typeof response.agentCapabilities?.promptCapabilities?.image).toBe("boolean")
+		})
 	})
 
 	// The fragile scenario the previous setImmediate heuristic could trip on:
@@ -357,15 +421,16 @@ describe("KimchiAcpAgent turn lifecycle", () => {
 		} finally {
 			process.stderr.write = origWrite
 		}
-		const matches = writes.filter((w) => w.includes("acp prompt: dropping unsupported block type"))
+		const matches = writes.filter((w) => w.includes("acp prompt: dropping"))
 		expect(matches).toHaveLength(2)
-		expect(matches.some((w) => w.includes('"audio"'))).toBe(true)
-		expect(matches.some((w) => w.includes('"embeddedContext"'))).toBe(true)
+		expect(matches.some((w) => w.includes("audio block"))).toBe(true)
+		expect(matches.some((w) => w.includes("embeddedContext block"))).toBe(true)
 	})
 
-	// Image blocks are supported: they should be extracted and passed to
-	// session.prompt() without warnings, and the turn should proceed normally.
-	it("accepts image blocks and passes them to session.prompt", async () => {
+	// Image blocks are supported when model supports vision: they should be
+	// extracted and passed to session.prompt() without warnings.
+	it("accepts image blocks when model supports vision", async () => {
+		fake.model = { provider: "test", id: "vision-model", input: ["text", "image"] }
 		fake.promptImpl = async () => {
 			fake.emit({ type: "agent_start" })
 			await delay(5)
@@ -387,6 +452,45 @@ describe("KimchiAcpAgent turn lifecycle", () => {
 			data: "base64data",
 			mimeType: "image/png",
 		})
+	})
+
+	// Image blocks are dropped when model doesn't support vision: they should
+	// be silently discarded with a warning.
+	it("drops image blocks when model has no vision support", async () => {
+		fake.model = { provider: "test", id: "text-only-model", input: ["text"] }
+		fake.promptImpl = async () => {
+			fake.emit({ type: "agent_start" })
+			await delay(5)
+			fake.emit({ type: "agent_end", messages: [] })
+		}
+
+		const writes: string[] = []
+		const origWrite = process.stderr.write.bind(process.stderr)
+		// biome-ignore lint/suspicious/noExplicitAny: test-only stderr capture
+		;(process.stderr.write as any) = (chunk: string | Uint8Array) => {
+			writes.push(typeof chunk === "string" ? chunk : Buffer.from(chunk).toString("utf8"))
+			return true
+		}
+
+		try {
+			const result = await agent.prompt({
+				sessionId,
+				prompt: [
+					{ type: "text", text: "describe this image" },
+					{ type: "image", data: "base64data", mimeType: "image/png" },
+				],
+			})
+			expect(result.stopReason).toBe("end_turn")
+			// Images should be dropped, not passed to session.prompt (passed as empty array)
+			expect(fake.lastPromptImages).toEqual([])
+		} finally {
+			process.stderr.write = origWrite
+		}
+
+		const matches = writes.filter((w) =>
+			w.includes("acp prompt: dropping image block (active model has no vision input)"),
+		)
+		expect(matches).toHaveLength(1)
 	})
 
 	// Defensive: once a turn is finalized (short-circuit, shutdown, cancel),

--- a/src/modes/acp/server.test.ts
+++ b/src/modes/acp/server.test.ts
@@ -123,30 +123,43 @@ describe("KimchiAcpAgent turn lifecycle", () => {
 		})
 
 		it("declares image: true when cached models include vision models", async () => {
-			const modelsJson = {
-				providers: {
-					"kimchi-dev": {
-						models: [
-							{
-								id: "gpt-4o",
-								name: "GPT-4o",
-								provider: "openai",
-								input: ["text", "image"],
-							},
-						],
-					},
-				},
+			// Stub API key so models are considered "available" (configured auth)
+			const restoreEnv = (key: string, value: string | undefined) => {
+				const original = process.env[key]
+				process.env[key] = value
+				return () => {
+					process.env[key] = original
+				}
 			}
-			writeFileSync(resolve(tempAgentDir, "models.json"), JSON.stringify(modelsJson))
+			const cleanup = restoreEnv("OPENAI_API_KEY", "fake-key-for-testing")
 
-			const testAgent = new KimchiAcpAgent(makeConn(), {
-				extensionFactories: [],
-				agentDir: tempAgentDir,
-				sessionFactory: async () => asSession(fake),
-			})
+			try {
+				const modelsJson = {
+					providers: {
+						openai: {
+							models: [
+								{
+									id: "gpt-4o",
+									name: "GPT-4o",
+									input: ["text", "image"],
+								},
+							],
+						},
+					},
+				}
+				writeFileSync(resolve(tempAgentDir, "models.json"), JSON.stringify(modelsJson))
 
-			const response = await testAgent.initialize({ protocolVersion: 1 })
-			expect(response.agentCapabilities?.promptCapabilities?.image).toBe(true)
+				const testAgent = new KimchiAcpAgent(makeConn(), {
+					extensionFactories: [],
+					agentDir: tempAgentDir,
+					sessionFactory: async () => asSession(fake),
+				})
+
+				const response = await testAgent.initialize({ protocolVersion: 1 })
+				expect(response.agentCapabilities?.promptCapabilities?.image).toBe(true)
+			} finally {
+				cleanup()
+			}
 		})
 
 		it("declares image capability based on available models", async () => {

--- a/src/modes/acp/server.ts
+++ b/src/modes/acp/server.ts
@@ -1,6 +1,7 @@
 // ACP (Agent Client Protocol) mode: JSON-RPC 2.0 over stdio using
 // @agentclientprotocol/sdk. Lets Zed / openclaw drive kimchi in-process.
 
+import { join } from "node:path"
 import { Readable, Writable } from "node:stream"
 import {
 	type Agent,
@@ -91,8 +92,8 @@ export class KimchiAcpAgent implements Agent {
 	}
 
 	async initialize(_: InitializeRequest): Promise<InitializeResponse> {
-		const authStorage = AuthStorage.create(this.agentDir)
-		const modelRegistry = ModelRegistry.create(authStorage)
+		const authStorage = AuthStorage.create(join(this.agentDir, "auth.json"))
+		const modelRegistry = ModelRegistry.create(authStorage, join(this.agentDir, "models.json"))
 		const supportsImages = modelRegistry.getAvailable().some((m) => m.input?.includes("image"))
 		return {
 			protocolVersion: PROTOCOL_VERSION,

--- a/src/modes/acp/server.ts
+++ b/src/modes/acp/server.ts
@@ -30,8 +30,10 @@ import type { ImageContent } from "@earendil-works/pi-ai"
 import {
 	type AgentSession,
 	type AgentSessionEvent,
+	AuthStorage,
 	DefaultResourceLoader,
 	type ExtensionFactory,
+	ModelRegistry,
 	SettingsManager,
 	createAgentSession,
 } from "@earendil-works/pi-coding-agent"
@@ -74,6 +76,7 @@ type SessionEntry = {
 export class KimchiAcpAgent implements Agent {
 	private sessions = new Map<string, SessionEntry>()
 	private readonly sessionFactory: AcpSessionFactory
+	private readonly agentDir: string
 	// Track non-text prompt block types we've already warned about so a
 	// misbehaving client that sends 1000 image blocks doesn't flood stderr.
 	private warnedBlockTypes = new Set<string>()
@@ -84,14 +87,18 @@ export class KimchiAcpAgent implements Agent {
 		options: RunAcpOptions,
 	) {
 		this.sessionFactory = options.sessionFactory ?? defaultSessionFactory(options)
+		this.agentDir = options.agentDir
 	}
 
 	async initialize(_: InitializeRequest): Promise<InitializeResponse> {
+		const authStorage = AuthStorage.create(this.agentDir)
+		const modelRegistry = ModelRegistry.create(authStorage)
+		const supportsImages = modelRegistry.getAvailable().some((m) => m.input?.includes("image"))
 		return {
 			protocolVersion: PROTOCOL_VERSION,
 			agentCapabilities: {
 				loadSession: false,
-				promptCapabilities: { image: true, audio: false, embeddedContext: false },
+				promptCapabilities: { image: supportsImages, audio: false, embeddedContext: false },
 			},
 			authMethods: [],
 		}
@@ -164,26 +171,31 @@ export class KimchiAcpAgent implements Agent {
 		if (entry.turn) {
 			throw RequestError.invalidRequest(undefined, "a prompt is already in progress for this session")
 		}
+		// Image support is per-model; check if active model supports vision input.
+		const supportsImages = entry.session.model?.input?.includes("image") ?? false
 		// Warn about unsupported block types (audio, embeddedContext) once per type.
-		// Image blocks are supported and processed below.
+		// Also warn when dropping image blocks for non-vision models.
 		for (const b of params.prompt) {
-			if (b.type !== "text" && b.type !== "image" && !this.warnedBlockTypes.has(b.type)) {
+			if (b.type !== "text" && (b.type !== "image" || !supportsImages) && !this.warnedBlockTypes.has(b.type)) {
 				this.warnedBlockTypes.add(b.type)
-				process.stderr.write(`acp prompt: dropping unsupported block type "${b.type}"\n`)
+				const reason = b.type === "image" ? "active model has no vision input" : "unsupported block type"
+				process.stderr.write(`acp prompt: dropping ${b.type} block (${reason})\n`)
 			}
 		}
 		const text = params.prompt
 			.map((b: ContentBlock) => (b.type === "text" ? b.text : ""))
 			.join("")
 			.trim()
-		// Extract image blocks from the prompt.
-		const images: ImageContent[] = params.prompt
-			.filter((b: ContentBlock): b is ContentBlock & { type: "image" } => b.type === "image")
-			.map((b) => ({
-				type: "image" as const,
-				data: b.data,
-				mimeType: b.mimeType,
-			}))
+		// Extract image blocks from the prompt only if model supports vision.
+		const images: ImageContent[] = supportsImages
+			? params.prompt
+					.filter((b: ContentBlock): b is ContentBlock & { type: "image" } => b.type === "image")
+					.map((b) => ({
+						type: "image" as const,
+						data: b.data,
+						mimeType: b.mimeType,
+					}))
+			: []
 		if (!text && images.length === 0) {
 			return { stopReason: "end_turn" }
 		}

--- a/src/modes/acp/server.ts
+++ b/src/modes/acp/server.ts
@@ -26,6 +26,7 @@ import {
 	type ToolKind,
 	ndJsonStream,
 } from "@agentclientprotocol/sdk"
+import type { ImageContent } from "@earendil-works/pi-ai"
 import {
 	type AgentSession,
 	type AgentSessionEvent,
@@ -90,7 +91,7 @@ export class KimchiAcpAgent implements Agent {
 			protocolVersion: PROTOCOL_VERSION,
 			agentCapabilities: {
 				loadSession: false,
-				promptCapabilities: { image: false, audio: false, embeddedContext: false },
+				promptCapabilities: { image: true, audio: false, embeddedContext: false },
 			},
 			authMethods: [],
 		}
@@ -163,12 +164,10 @@ export class KimchiAcpAgent implements Agent {
 		if (entry.turn) {
 			throw RequestError.invalidRequest(undefined, "a prompt is already in progress for this session")
 		}
-		// Capabilities declare image/audio/embeddedContext: false, so a compliant
-		// client will only send text blocks. A misbehaving client that sends other
-		// block types gets them dropped — warn once per unseen type so the silent
-		// empty-turn isn't confusing to debug.
+		// Warn about unsupported block types (audio, embeddedContext) once per type.
+		// Image blocks are supported and processed below.
 		for (const b of params.prompt) {
-			if (b.type !== "text" && !this.warnedBlockTypes.has(b.type)) {
+			if (b.type !== "text" && b.type !== "image" && !this.warnedBlockTypes.has(b.type)) {
 				this.warnedBlockTypes.add(b.type)
 				process.stderr.write(`acp prompt: dropping unsupported block type "${b.type}"\n`)
 			}
@@ -177,7 +176,15 @@ export class KimchiAcpAgent implements Agent {
 			.map((b: ContentBlock) => (b.type === "text" ? b.text : ""))
 			.join("")
 			.trim()
-		if (!text) {
+		// Extract image blocks from the prompt.
+		const images: ImageContent[] = params.prompt
+			.filter((b: ContentBlock): b is ContentBlock & { type: "image" } => b.type === "image")
+			.map((b) => ({
+				type: "image" as const,
+				data: b.data,
+				mimeType: b.mimeType,
+			}))
+		if (!text && images.length === 0) {
 			return { stopReason: "end_turn" }
 		}
 		let turnResolve!: (r: PromptResponse) => void
@@ -199,7 +206,7 @@ export class KimchiAcpAgent implements Agent {
 		// paused on `await session.prompt()`. Instead, attach handlers that drive
 		// finalizeTurn/failTurn and return `result` directly; settling `result`
 		// propagates to the caller regardless of whether session.prompt ever resolves.
-		entry.session.prompt(text, { source: "rpc" }).then(
+		entry.session.prompt(text, { source: "rpc", images }).then(
 			() => {
 				// pi-coding-agent's session.prompt() short-circuits for extension commands,
 				// input-handler intercepts, and no-op paths — in those cases agent.prompt()


### PR DESCRIPTION


---
### Kimchi Summary
### What changed
Adds conditional image/vision support to the ACP server. `initialize()` now advertises image capabilities only when the model registry contains vision-capable models, and `prompt()` extracts image blocks for vision-enabled models instead of dropping them as unsupported.

### Why
The ACP server previously hardcoded `image: false` and treated image blocks as unsupported inputs. This prevented vision-capable models from receiving image prompts despite underlying support in the agent framework.

### Key changes
- `src/modes/acp/server.ts`:
  - `KimchiAcpAgent` now stores `agentDir` and uses it with `AuthStorage` and `ModelRegistry` to detect vision support during `initialize()`
  - `initialize()` dynamically sets `agentCapabilities.promptCapabilities.image` based on whether any available model includes `"image"` in its `input` array
  - `prompt()` checks if the active model supports vision via `entry.session.model?.input`, extracts valid `ImageContent` blocks, and passes them to `session.prompt()` in the `images` option
  - Non-vision models receive a specific warning when image blocks are dropped; other unsupported types (`audio`, `embeddedContext`) are still warned once per type
- `src/modes/acp/server.test.ts`:
  - Added tests for dynamic image capability detection in `initialize()` using temporary `models.json` fixtures
  - Added tests verifying image blocks are forwarded when the model supports vision and dropped with a warning when it does not
  - Refactored unsupported-block tests to use `audio` and `embeddedContext` since `image` is now conditionally supported

### Impact
- ACP clients will now see `promptCapabilities.image: true` during initialization when a vision model is available, enabling image prompt workflows that were previously rejected at the capability level.