### PR TITLE
fix(anthropic-prompt-caching): Don't include current time in the system prompt

### DIFF
--- a/src/extensions/behaviours/wiring.smoke.test.ts
+++ b/src/extensions/behaviours/wiring.smoke.test.ts
@@ -125,7 +125,6 @@ const testEnv: EnvironmentInfo = {
 	homeDir: "/home/testuser",
 	cwd: "/home/testuser/project",
 	documentsDir: "/home/testuser/project/.kimchi/docs",
-	currentTime: "2026-01-01T00:00:00.000Z",
 	localDate: "2026-01-01",
 	isGitRepo: false,
 }

--- a/src/extensions/mcp-adapter/index.test.ts
+++ b/src/extensions/mcp-adapter/index.test.ts
@@ -9,7 +9,6 @@ const testEnv: EnvironmentInfo = {
 	homeDir: "/home/testuser",
 	cwd: "/home/testuser/project",
 	documentsDir: "/home/testuser/project/.kimchi/docs",
-	currentTime: "2026-01-01T00:00:00.000Z",
 	localDate: "2026-01-01",
 	isGitRepo: false,
 }

--- a/src/extensions/prompt-construction/prompt-enrichment.ts
+++ b/src/extensions/prompt-construction/prompt-enrichment.ts
@@ -378,7 +378,6 @@ export default function (skillPaths: string[]) {
 				homeDir: cachedHomeDir,
 				cwd: ctx.cwd,
 				documentsDir: join(ctx.cwd, ".kimchi", "docs"),
-				currentTime: now.toISOString(),
 				localDate: now.toLocaleDateString("en-CA"),
 				isGitRepo,
 				gitBranch: isGitRepo ? getGitBranch(ctx.cwd) : undefined,

--- a/src/extensions/prompt-construction/system-prompt-blocks.test.ts
+++ b/src/extensions/prompt-construction/system-prompt-blocks.test.ts
@@ -11,7 +11,6 @@ const testEnv: EnvironmentInfo = {
 	homeDir: "/home/testuser",
 	cwd: "/home/testuser/project",
 	documentsDir: "/home/testuser/project/.kimchi/docs",
-	currentTime: "2026-01-01T00:00:00.000Z",
 	localDate: "2026-01-01",
 	isGitRepo: false,
 }

--- a/src/extensions/prompt-construction/system-prompt.test.ts
+++ b/src/extensions/prompt-construction/system-prompt.test.ts
@@ -10,7 +10,6 @@ const testEnv: EnvironmentInfo = {
 	homeDir: "/home/testuser",
 	cwd: "/home/testuser/projects/myapp",
 	documentsDir: "/home/testuser/projects/myapp/.kimchi/docs",
-	currentTime: "2026-01-01T00:00:00.000Z",
 	localDate: "2026-01-01",
 	isGitRepo: false,
 }
@@ -152,7 +151,8 @@ describe("buildSystemPrompt", () => {
 			expect(result).toContain(`Username: ${testEnv.username}`)
 			expect(result).toContain(`Home directory: "${testEnv.homeDir}"`)
 			expect(result).toContain(`Working directory: "${testEnv.cwd}"`)
-			expect(result).toContain(`Current time: ${testEnv.currentTime} (local date: ${testEnv.localDate})`)
+			expect(result).toContain(`Current date: ${testEnv.localDate}`)
+			expect(result).not.toContain("Current time:")
 			expect(result).toContain("Git repository: no")
 		})
 
@@ -328,7 +328,8 @@ describe("buildSystemPrompt", () => {
 			expect(result).toContain(`Username: ${testEnv.username}`)
 			expect(result).toContain(`Home directory: "${testEnv.homeDir}"`)
 			expect(result).toContain(`Working directory: "${testEnv.cwd}"`)
-			expect(result).toContain(`Current time: ${testEnv.currentTime} (local date: ${testEnv.localDate})`)
+			expect(result).toContain(`Current date: ${testEnv.localDate}`)
+			expect(result).not.toContain("Current time:")
 			expect(result).toContain("Git repository: no")
 		})
 

--- a/src/extensions/prompt-construction/system-prompt.ts
+++ b/src/extensions/prompt-construction/system-prompt.ts
@@ -22,7 +22,6 @@ export interface EnvironmentInfo {
 	homeDir: string
 	cwd: string
 	documentsDir: string
-	currentTime: string
 	localDate: string
 	isGitRepo: boolean
 	gitBranch?: string
@@ -179,7 +178,7 @@ function formatEnvironmentSection(env: EnvironmentInfo): string {
 		`- Home directory: "${env.homeDir}"`,
 		`- Working directory: "${env.cwd}"`,
 		`- Documents directory: "${env.documentsDir}"`,
-		`- Current time: ${env.currentTime} (local date: ${env.localDate})`,
+		`- Current date: ${env.localDate}`,
 		`- Git repository: ${env.isGitRepo ? "yes" : "no"}`,
 	]
 	if (env.gitBranch !== undefined) lines.push(`- Git branch: ${env.gitBranch}`)

--- a/src/extensions/tags.test.ts
+++ b/src/extensions/tags.test.ts
@@ -12,7 +12,6 @@ const testEnv: EnvironmentInfo = {
 	homeDir: "/home/testuser",
 	cwd: "/home/testuser/project",
 	documentsDir: "/home/testuser/project/.kimchi/docs",
-	currentTime: "2026-01-01T00:00:00.000Z",
 	localDate: "2026-01-01",
 	isGitRepo: false,
 }

--- a/src/models.test.ts
+++ b/src/models.test.ts
@@ -94,7 +94,7 @@ describe("updateModelsConfig", () => {
 		expect(config.providers["kimchi-dev"].models[0].input).toEqual(["text"])
 	})
 
-	it("disables supportsReasoningEffort for anthropic models", async () => {
+	it("sets Anthropic compat flags for anthropic models", async () => {
 		vi.mocked(fetch).mockResolvedValueOnce({
 			ok: true,
 			json: async () => ({ models: [OPUS_47] }),
@@ -103,7 +103,10 @@ describe("updateModelsConfig", () => {
 		await updateModelsConfig(modelsJsonPath, "test-key")
 
 		const config = JSON.parse(readFileSync(modelsJsonPath, "utf-8"))
-		expect(config.providers["kimchi-dev"].models[0].compat).toEqual({ supportsReasoningEffort: false })
+		expect(config.providers["kimchi-dev"].models[0].compat).toEqual({
+			supportsReasoningEffort: false,
+			cacheControlFormat: "anthropic",
+		})
 	})
 
 	it("omits compat for non-anthropic models", async () => {

--- a/src/models.ts
+++ b/src/models.ts
@@ -58,13 +58,16 @@ interface PiModelConfig {
 	cost: { input: number; output: number; cacheRead: number; cacheWrite: number }
 	// Persisted so telemetry can resolve the actual upstream provider after cache round-trip.
 	provider: string
-	compat?: { supportsReasoningEffort?: boolean }
+	compat?: { supportsReasoningEffort?: boolean; cacheControlFormat?: "anthropic" }
 }
 
 function metadataToModel(m: ModelMetadata): PiModelConfig {
 	// TODO: our LiteLLM gateway does not support `thinking.type.enabled` for Anthropic >Opus 4.6 models
 	// Therefore, we disable it for now. Revisit, once we upgrade our LiteLLM version.
-	const compat = m.provider === "anthropic" ? { supportsReasoningEffort: false } : undefined
+	const compat =
+		m.provider === "anthropic"
+			? ({ supportsReasoningEffort: false, cacheControlFormat: "anthropic" } as const)
+			: undefined
 	return {
 		id: m.slug,
 		name: m.display_name.trim().length > 0 ? m.display_name : m.slug,


### PR DESCRIPTION

<img width="4064" height="2574" alt="Screenshot 2026-05-20 at 14 41 47" src="https://github.com/user-attachments/assets/fa63d875-b75e-4544-a03b-cb0f899dc526" />


---
### Kimchi Summary
### What changed
Removes the exact timestamp from system prompts, keeping only the local date, and adds the `cacheControlFormat: "anthropic"` compatibility flag to Anthropic model configurations.

### Why
Dynamic `currentTime` values in system prompts change on every request, causing Anthropic prompt cache misses and increasing token costs. Stabilizing the prompt content and explicitly declaring the cache control format improves cache hit rates for Anthropic models.

### Key changes
- `EnvironmentInfo` interface (`system-prompt.ts`): removed the `currentTime` property.
- `prompt-enrichment.ts`: stopped generating the `currentTime` value.
- `system-prompt.ts`: replaced `Current time: ${env.currentTime} (local date: ${env.localDate})` with `Current date: ${env.localDate}` in `formatEnvironmentSection`.
- Tests across `system-prompt.test.ts`, `system-prompt-blocks.test.ts`, `tags.test.ts`, `mcp-adapter/index.test.ts`, and `behaviours/wiring.smoke.test.ts`: removed `currentTime` from test fixtures and updated assertions.
- `models.ts`: added `cacheControlFormat: "anthropic"` to the `compat` object for Anthropic provider models.
- `models.test.ts`: updated test expectations and title to cover both Anthropic compatibility flags.

### Impact
The `EnvironmentInfo` interface no longer contains `currentTime`; any consumers or test fixtures must be updated to match. The system prompt text presented to models now omits the exact time, which improves cacheability and should lower costs for Anthropic model usage.