### PR TITLE
fix: suppress Shift+Enter warning in JetBrains terminals and fix overlay input blocking and fix shift+j creating new line

### DIFF
--- a/src/extensions/onboarding/session-mode.ts
+++ b/src/extensions/onboarding/session-mode.ts
@@ -8,7 +8,11 @@ import {
 } from "../../config.js"
 import { registerTipProvider } from "../tips/registry.js"
 import { setSessionModeOnboardingFooterSuppressed } from "../ui.js"
-import { SessionModePickerComponent, type SessionModePickerResult } from "./session-mode-picker.js"
+import {
+	SessionModePickerComponent,
+	type SessionModePickerResult,
+	keyToSessionModePickerEvent,
+} from "./session-mode-picker.js"
 import { createSessionModeTipProvider } from "./session-mode-tips.js"
 
 export type SessionModeOnboardingAction = "show" | "skip" | "skip-and-mark-seen"
@@ -168,9 +172,14 @@ function showSessionModeWizard(
 	}
 
 	setSessionModeOnboardingFooterSuppressed(true)
+	interface TuiWithOverlay {
+		hasOverlay(): boolean
+	}
+	let tuiRef: TuiWithOverlay | null = null
 	ctx.ui.setWidget(
 		SESSION_MODE_WIDGET_KEY,
 		(tui, theme) => {
+			tuiRef = tui as unknown as TuiWithOverlay
 			component = new SessionModePickerComponent(theme, finish, () => tui.requestRender(), {
 				showHideCheckbox: showHideOption,
 			})
@@ -179,8 +188,18 @@ function showSessionModeWizard(
 		SESSION_MODE_WIDGET_OPTIONS,
 	)
 	unsubscribeInput = ctx.ui.onTerminalInput((data) => {
-		component?.handleInput(data)
-		return { consume: true }
+		// When an overlay is visible (e.g. keyboard warning), let it receive
+		// input instead of the widget. Overlays are modal and should take
+		// precedence over background widgets.
+		if (typeof tuiRef?.hasOverlay === "function" && tuiRef.hasOverlay()) {
+			return undefined
+		}
+		const event = keyToSessionModePickerEvent(data)
+		if (event) {
+			component?.handleInput(data)
+			return { consume: true }
+		}
+		return undefined
 	})
 
 	return () => {

--- a/src/extensions/permissions/keybindings.test.ts
+++ b/src/extensions/permissions/keybindings.test.ts
@@ -43,7 +43,9 @@ describe("writeKimchiKeybindingDefaults", () => {
 		expect(existsSync(keybindingsPath)).toBe(true)
 		const content = JSON.parse(readFileSync(keybindingsPath, "utf-8"))
 		expect(content["app.thinking.cycle"]).toBe("")
-		expect(content["tui.input.newLine"]).toBe("shift+enter,ctrl+j")
+		// Must be an array so pi-tui parses each key separately (a comma-separated
+		// string like "shift+enter,ctrl+j" is misread as "shift+j" by parseKeyId).
+		expect(content["tui.input.newLine"]).toEqual(["shift+enter", "ctrl+j"])
 	})
 
 	it("is idempotent - does not duplicate ctrl+j on re-run", () => {
@@ -53,10 +55,9 @@ describe("writeKimchiKeybindingDefaults", () => {
 		writeKimchiKeybindingDefaults(testDir)
 
 		const content = JSON.parse(readFileSync(keybindingsPath, "utf-8"))
-		expect(content["tui.input.newLine"]).toBe("shift+enter,ctrl+j")
-		// Should only have shift+enter and ctrl+j, no duplicates
-		const parts = content["tui.input.newLine"].split(",")
-		expect(parts.filter((p: string) => p === "ctrl+j").length).toBe(1)
+		expect(content["tui.input.newLine"]).toEqual(["shift+enter", "ctrl+j"])
+		// Should only have ctrl+j once — no duplicates
+		expect((content["tui.input.newLine"] as string[]).filter((p) => p === "ctrl+j").length).toBe(1)
 	})
 
 	it("preserves existing custom newLine binding and appends ctrl+j", () => {
@@ -66,7 +67,7 @@ describe("writeKimchiKeybindingDefaults", () => {
 		writeKimchiKeybindingDefaults(testDir)
 
 		const content = JSON.parse(readFileSync(keybindingsPath, "utf-8"))
-		expect(content["tui.input.newLine"]).toBe("alt+enter,ctrl+j")
+		expect(content["tui.input.newLine"]).toEqual(["alt+enter", "ctrl+j"])
 	})
 
 	it("does NOT add ctrl+j if it's already bound elsewhere", () => {
@@ -81,16 +82,27 @@ describe("writeKimchiKeybindingDefaults", () => {
 		expect(content["tui.input.newLine"]).toBeUndefined()
 	})
 
-	it("does NOT add ctrl+j if newLine already contains it", () => {
+	it("migrates legacy comma-separated string to array and does not duplicate ctrl+j", () => {
 		const keybindingsPath = resolve(testDir, "keybindings.json")
+		// Old broken format: comma-separated string (parsed by pi-tui as "shift+j")
 		writeFileSync(keybindingsPath, JSON.stringify({ "tui.input.newLine": "shift+enter,ctrl+j" }))
 
 		writeKimchiKeybindingDefaults(testDir)
 
 		const content = JSON.parse(readFileSync(keybindingsPath, "utf-8"))
-		expect(content["tui.input.newLine"]).toBe("shift+enter,ctrl+j")
-		const parts = content["tui.input.newLine"].split(",")
-		expect(parts.filter((p: string) => p === "ctrl+j").length).toBe(1)
+		expect(content["tui.input.newLine"]).toEqual(["shift+enter", "ctrl+j"])
+		expect((content["tui.input.newLine"] as string[]).filter((p) => p === "ctrl+j").length).toBe(1)
+	})
+
+	it("does NOT add ctrl+j if newLine array already contains it", () => {
+		const keybindingsPath = resolve(testDir, "keybindings.json")
+		writeFileSync(keybindingsPath, JSON.stringify({ "tui.input.newLine": ["shift+enter", "ctrl+j"] }))
+
+		writeKimchiKeybindingDefaults(testDir)
+
+		const content = JSON.parse(readFileSync(keybindingsPath, "utf-8"))
+		expect(content["tui.input.newLine"]).toEqual(["shift+enter", "ctrl+j"])
+		expect((content["tui.input.newLine"] as string[]).filter((p) => p === "ctrl+j").length).toBe(1)
 	})
 
 	it("handles malformed existing keybindings.json gracefully", () => {
@@ -102,7 +114,7 @@ describe("writeKimchiKeybindingDefaults", () => {
 
 		const content = JSON.parse(readFileSync(keybindingsPath, "utf-8"))
 		expect(content["app.thinking.cycle"]).toBe("")
-		expect(content["tui.input.newLine"]).toBe("shift+enter,ctrl+j")
+		expect(content["tui.input.newLine"]).toEqual(["shift+enter", "ctrl+j"])
 	})
 
 	it("preserves other existing bindings", () => {

--- a/src/extensions/permissions/keybindings.ts
+++ b/src/extensions/permissions/keybindings.ts
@@ -1,10 +1,11 @@
 import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs"
 import { dirname, resolve } from "node:path"
 
-// Check if a key is used as a binding value in any other binding.
-// Returns true if the key appears in any binding value.
+// Check if a key is used as a binding value in any binding OTHER than
+// "tui.input.newLine" (which is the one we are trying to fix).
 function isKeyBoundElsewhere(current: Record<string, unknown>, key: string): boolean {
-	for (const [, value] of Object.entries(current)) {
+	for (const [bindingName, value] of Object.entries(current)) {
+		if (bindingName === "tui.input.newLine") continue
 		if (typeof value === "string") {
 			const parts = value.split(",").map((s) => s.trim())
 			if (parts.includes(key)) return true
@@ -18,6 +19,11 @@ function isKeyBoundElsewhere(current: Record<string, unknown>, key: string): boo
 
 // Add ctrl+j as a fallback to tui.input.newLine if not already present
 // and not already bound elsewhere.
+//
+// IMPORTANT: bindings must be stored as a JSON array, not a comma-separated
+// string. pi-tui's parseKeyId splits on "+" and takes the last segment, so
+// "shift+enter,ctrl+j" (string) is parsed as "shift+j" instead of two
+// separate bindings.
 function addNewlineFallback(current: Record<string, unknown>): boolean {
 	const fallback = "ctrl+j"
 	const existing = current["tui.input.newLine"]
@@ -26,19 +32,21 @@ function addNewlineFallback(current: Record<string, unknown>): boolean {
 	if (isKeyBoundElsewhere(current, fallback)) return false
 
 	if (typeof existing === "string") {
+		// Comma-separated strings are misread by pi-tui ("shift+enter,ctrl+j"
+		// becomes "shift+j"). Always convert to array format.
 		const parts = existing.split(",").map((s) => s.trim())
-		if (!parts.includes(fallback)) {
-			current["tui.input.newLine"] = `${existing},${fallback}`
-			return true
-		}
-	} else if (Array.isArray(existing)) {
+		const keys = parts.includes(fallback) ? parts : [...parts, fallback]
+		current["tui.input.newLine"] = keys
+		return true // always rewrite: string format must become an array
+	}
+	if (Array.isArray(existing)) {
 		const list = existing.filter((s) => typeof s === "string") as string[]
 		if (!list.includes(fallback)) {
-			existing.push(fallback)
+			current["tui.input.newLine"] = [...list, fallback]
 			return true
 		}
 	} else {
-		current["tui.input.newLine"] = "shift+enter,ctrl+j"
+		current["tui.input.newLine"] = ["shift+enter", fallback]
 		return true
 	}
 	return false

--- a/src/extensions/terminal-compat/keyboard-capability.test.ts
+++ b/src/extensions/terminal-compat/keyboard-capability.test.ts
@@ -1,17 +1,69 @@
-import { describe, expect, it } from "vitest"
-import { getKittyKeyboardSupport, probeKittyKeyboardSupport } from "./keyboard-capability.js"
+import { beforeEach, describe, expect, it, vi } from "vitest"
 
-describe("getKittyKeyboardSupport", () => {
-	it("returns undefined before probing", () => {
-		expect(getKittyKeyboardSupport()).toBeUndefined()
+describe("keyboard-capability", () => {
+	beforeEach(() => {
+		vi.resetModules()
 	})
-})
 
-describe("probeKittyKeyboardSupport", () => {
-	it("returns false in non-TTY envs (CI / vitest)", async () => {
-		const result = await probeKittyKeyboardSupport()
-		// In CI stdin/stdout aren't TTYs, so shouldSkipProbe returns true.
-		expect(result).toBe(false)
-		expect(getKittyKeyboardSupport()).toBe(false)
+	describe("getKittyKeyboardSupport", () => {
+		it("returns undefined before probing", async () => {
+			const { getKittyKeyboardSupport } = await import("./keyboard-capability.js")
+			expect(getKittyKeyboardSupport()).toBeUndefined()
+		})
+	})
+
+	describe("probeKittyKeyboardSupport", () => {
+		it("returns false in non-TTY envs (CI / vitest)", async () => {
+			const originalTermEmulator = process.env.TERMINAL_EMULATOR
+			try {
+				// biome-ignore lint/performance/noDelete: ensure no JetBrains detection leaks in.
+				delete process.env.TERMINAL_EMULATOR
+				const { probeKittyKeyboardSupport, getKittyKeyboardSupport } = await import("./keyboard-capability.js")
+				const result = await probeKittyKeyboardSupport()
+				// In CI stdin/stdout aren't TTYs, so shouldSkipProbe returns true.
+				expect(result).toBe(false)
+				expect(getKittyKeyboardSupport()).toBe(false)
+			} finally {
+				if (originalTermEmulator !== undefined) {
+					process.env.TERMINAL_EMULATOR = originalTermEmulator
+				}
+			}
+		})
+
+		it("returns true for JetBrains terminals regardless of TTY", async () => {
+			const originalTermEmulator = process.env.TERMINAL_EMULATOR
+			try {
+				process.env.TERMINAL_EMULATOR = "JetBrains-JediTerm"
+				const { probeKittyKeyboardSupport, getKittyKeyboardSupport } = await import("./keyboard-capability.js")
+				const result = await probeKittyKeyboardSupport()
+				expect(result).toBe(true)
+				expect(getKittyKeyboardSupport()).toBe(true)
+			} finally {
+				if (originalTermEmulator !== undefined) {
+					process.env.TERMINAL_EMULATOR = originalTermEmulator
+				} else {
+					// biome-ignore lint/performance/noDelete: env-var cleanup needs a real delete; assigning undefined would coerce to the literal string "undefined".
+					delete process.env.TERMINAL_EMULATOR
+				}
+			}
+		})
+
+		it("returns true for reworked JetBrains terminal", async () => {
+			const originalTermEmulator = process.env.TERMINAL_EMULATOR
+			try {
+				process.env.TERMINAL_EMULATOR = "JetBrains-Terminal-2025"
+				const { probeKittyKeyboardSupport, getKittyKeyboardSupport } = await import("./keyboard-capability.js")
+				const result = await probeKittyKeyboardSupport()
+				expect(result).toBe(true)
+				expect(getKittyKeyboardSupport()).toBe(true)
+			} finally {
+				if (originalTermEmulator !== undefined) {
+					process.env.TERMINAL_EMULATOR = originalTermEmulator
+				} else {
+					// biome-ignore lint/performance/noDelete: env-var cleanup needs a real delete; assigning undefined would coerce to the literal string "undefined".
+					delete process.env.TERMINAL_EMULATOR
+				}
+			}
+		})
 	})
 })

--- a/src/extensions/terminal-compat/keyboard-capability.ts
+++ b/src/extensions/terminal-compat/keyboard-capability.ts
@@ -23,6 +23,20 @@ export function getKittyKeyboardSupport(): boolean | undefined {
 	return cachedSupportsKittyKeyboard
 }
 
+function isJetBrainsTerminal(): boolean {
+	// JetBrains IDEs (GoLand, IntelliJ, etc.) intercept Shift+Enter at the
+	// terminal level and send ESC+CR (\x1b\r) when the setting is enabled,
+	// which our editor already handles. This works out of the box in
+	// 2025.3.3+ where the setting is enabled by default.
+	//
+	// We cannot reliably detect the IDE version from env vars, so we treat
+	// ALL JetBrains terminals as capable. The only downside is a missing
+	// warning on older versions where Shift+Enter genuinely doesn't work.
+	//
+	// https://github.com/JetBrains/intellij-community/blob/52370805ee903d9b3d38c2b0be72db34702bbc83/plugins/terminal/frontend/src/com/intellij/terminal/frontend/view/impl/TerminalKeyEventsHandlerImpl.kt#L113-L117
+	return process.env.TERMINAL_EMULATOR?.startsWith("JetBrains-") ?? false
+}
+
 function shouldSkipProbe(): boolean {
 	if (!process.stdin.isTTY || !process.stdout.isTTY) return true
 	// tmux intercepts and may not forward the query correctly.
@@ -37,6 +51,10 @@ export async function probeKittyKeyboardSupport(): Promise<boolean> {
 	if (inFlightProbe) return inFlightProbe
 
 	inFlightProbe = (async () => {
+		if (isJetBrainsTerminal()) {
+			cachedSupportsKittyKeyboard = true
+			return true
+		}
 		if (shouldSkipProbe()) {
 			cachedSupportsKittyKeyboard = false
 			return false

--- a/src/extensions/terminal-compat/startup-warning.test.ts
+++ b/src/extensions/terminal-compat/startup-warning.test.ts
@@ -203,6 +203,32 @@ describe("emitTerminalCompatWarning", () => {
 		}
 	})
 
+	it("does not show warning in JetBrains terminals", async () => {
+		const originalTermEmulator = process.env.TERMINAL_EMULATOR
+		try {
+			process.env.TERMINAL_EMULATOR = "JetBrains-JediTerm"
+			Object.defineProperty(process.stdin, "isTTY", { value: true, configurable: true })
+
+			const warnings: string[] = []
+			vi.spyOn(console, "warn").mockImplementation((msg: string) => {
+				warnings.push(msg)
+			})
+
+			const { emitTerminalCompatWarning } = await import("./startup-warning.js")
+			emitTerminalCompatWarning(testDir)
+
+			expect(warnings.length).toBe(0)
+		} finally {
+			if (originalTermEmulator !== undefined) {
+				process.env.TERMINAL_EMULATOR = originalTermEmulator
+			} else {
+				// biome-ignore lint/performance/noDelete: env-var cleanup needs a real delete; assigning undefined would coerce to the literal string "undefined".
+				delete process.env.TERMINAL_EMULATOR
+			}
+			Object.defineProperty(process.stdin, "isTTY", { value: true, configurable: true })
+		}
+	})
+
 	it("preserves existing settings.json fields", async () => {
 		const originalTmux = process.env.TMUX
 		const originalTermProgram = process.env.TERM_PROGRAM

--- a/src/extensions/ui.ts
+++ b/src/extensions/ui.ts
@@ -293,7 +293,10 @@ export default function uiExtension(pi: ExtensionAPI) {
 								settingsData = JSON.parse(readFileSync(settingsPath, "utf-8"))
 							} catch {}
 						}
-						if (!settingsData.newlineHintDismissed && typeof nl === "string" && nl.includes("ctrl+j")) {
+						const nlHasCtrlJ =
+							(typeof nl === "string" && nl.includes("ctrl+j")) ||
+							(Array.isArray(nl) && nl.some((k: unknown) => typeof k === "string" && k.includes("ctrl+j")))
+						if (!settingsData.newlineHintDismissed && nlHasCtrlJ) {
 							ctx.ui.custom(
 								(_tui, theme, _kb, done) => {
 									const settingsFile = settingsPath


### PR DESCRIPTION
## Changes

### 1. Suppress false Shift+Enter warning in JetBrains terminals

JetBrains IDEs (GoLand, IntelliJ, etc.) intercept Shift+Enter at the terminal level and send ESC+CR (\x1b\r) when the setting is enabled, which our editor already handles. This works out of the box since JetBrains 2025.3.3+.

- Detect via `TERMINAL_EMULATOR=JetBrains-*`
- Skip the 200ms CSI keyboard probe
- Return `true` for kitty keyboard support, suppressing both the startup and TUI warnings
- We cannot reliably detect the IDE version from env vars, so we treat all JetBrains terminals as capable

### 2. Fix session mode picker blocking overlay input

The session mode picker registered an `onTerminalInput` listener that consumed **all** recognized keys, preventing overlays (e.g. keyboard warning) from receiving Enter/"d" to dismiss.

Two changes:
1. Yield completely when any overlay is visible (`tui.hasOverlay()`) — overlays are modal and take precedence
2. Only consume input for keys the picker actually recognizes (arrows, Enter, Esc, space, Tab)

### Testing
- All 67 related tests pass
- Lint and typecheck pass

Co-Authored-By: Kimchi <noreply@kimchi.dev>

---
### Kimchi Summary
### What changed
Fixes keybinding parsing for multi-key shortcuts, suppresses false-positive keyboard warnings in JetBrains terminals, and prevents background widgets from intercepting input when modal overlays are visible.

### Why
pi-tui misinterprets comma-separated keybinding strings (e.g., `"shift+enter,ctrl+j"` is parsed incorrectly), breaking fallback newline bindings. JetBrains terminals handle `Shift+Enter` via `ESC+CR` and do not need capability probes. Background onboarding widgets were incorrectly consuming input meant for modal overlays.

### Key changes
- `src/extensions/permissions/keybindings.ts`: Stores `tui.input.newLine` as a JSON array instead of a comma-separated string. Adds migration logic to convert legacy string values and updates `isKeyBoundElsewhere` to skip `tui.input.newLine` when checking for duplicates.
- `src/extensions/terminal-compat/keyboard-capability.ts`: Detects JetBrains terminals via `TERMINAL_EMULATOR` and reports kitty keyboard support as `true` without probing.
- `src/extensions/onboarding/session-mode.ts`: Checks `tuiRef.hasOverlay()` before consuming terminal input in the session mode wizard, and filters input through `keyToSessionModePickerEvent` to avoid intercepting unrelated keys.
- `src/extensions/ui.ts`: Updates the newline hint logic to accept both string and array keybinding formats.

### Impact
- Legacy comma-separated keybinding strings are automatically rewritten to arrays on the next run.
- JetBrains IDE terminal users will no longer see spurious keyboard compatibility warnings.
- Session mode onboarding yields input to visible overlays instead of consuming it unconditionally.