### PR TITLE
fix: wrap instead of truncate text in ask_user questionaire

### DIFF
--- a/src/extensions/ferment/prompt-ui.test.ts
+++ b/src/extensions/ferment/prompt-ui.test.ts
@@ -1,5 +1,7 @@
+import type { Theme } from "@earendil-works/pi-coding-agent"
+import type { TUI } from "@earendil-works/pi-tui"
 import { beforeEach, describe, expect, it, vi } from "vitest"
-import { promptInput, promptSelect } from "./prompt-ui.js"
+import { createPromptFormComponent, promptInput, promptSelect } from "./prompt-ui.js"
 
 const tipWidgetLocationMock = vi.hoisted(() => ({
 	restore: vi.fn(),
@@ -56,5 +58,205 @@ describe("ferment prompt UI", () => {
 		expect(ui.setWorkingVisible).toHaveBeenNthCalledWith(1, false)
 		expect(ui.setWorkingVisible).toHaveBeenNthCalledWith(2, true)
 		expect(tipWidgetLocationMock.restore).toHaveBeenCalledTimes(1)
+	})
+})
+
+// Minimal Theme mock — only methods actually used by createPromptFormComponent are stubbed.
+function noopTheme(): Theme {
+	return {
+		fg: (_role: string, text: string) => text,
+		bg: (_role: string, text: string) => text,
+		bold: (text: string) => text,
+		italic: (text: string) => text,
+		underline: (text: string) => text,
+		inverse: (text: string) => text,
+		strikethrough: (text: string) => text,
+		getFgAnsi: () => "",
+		getBgAnsi: () => "",
+		getColorMode: () => "truecolor" as const,
+		getThinkingBorderColor: () => (s: string) => s,
+		getBashModeBorderColor: () => (s: string) => s,
+	} as unknown as Theme
+}
+
+function makeMockTui(): TUI {
+	return {
+		cursorTo: vi.fn(),
+		hideCursor: vi.fn(),
+		showCursor: vi.fn(),
+		moveCursor: vi.fn(),
+		clearLine: vi.fn(),
+		clearScreen: vi.fn(),
+		write: vi.fn(),
+		eraseDisplay: vi.fn(),
+		keybinding: vi.fn(),
+		width: 80,
+	} as unknown as TUI
+}
+
+/** A question with a single-option answer for simple render tests. */
+function singleQuestion(
+	overrides: Partial<{
+		prompt: string
+		label: string
+		options: { value: string; label: string; description?: string }[]
+	}> = {},
+) {
+	return {
+		id: "q1",
+		label: "Q1",
+		prompt: "Pick one:",
+		type: "single" as const,
+		options: [{ value: "a", label: "Option A" }],
+		allowOther: false,
+		required: true,
+		...overrides,
+	}
+}
+
+function renderLines(
+	prompt: string,
+	width: number,
+	questionOverrides: Parameters<typeof singleQuestion>[0] = {},
+): string[] {
+	const tui = makeMockTui()
+	const theme = noopTheme()
+	const comp = createPromptFormComponent(
+		tui,
+		theme,
+		[singleQuestion(questionOverrides)],
+		undefined,
+		undefined,
+		() => {},
+	)
+	return comp.render(width)
+}
+
+describe("createPromptFormComponent render wrapping", () => {
+	describe("question prompts wrap at terminal width", () => {
+		it("short prompt fits on one line", () => {
+			const lines = renderLines("Pick one:", 80, { prompt: "Pick one:" })
+			// The question prompt may be on any line, but every line must be <= width
+			for (const line of lines) {
+				expect(line.length).toBeLessThanOrEqual(80)
+			}
+		})
+
+		it("long prompt wraps to multiple lines, none exceeding width", () => {
+			const longPrompt = "A ".repeat(60) // ~120 chars
+			const lines = renderLines(longPrompt, 40, { prompt: longPrompt })
+			expect(lines.length).toBeGreaterThan(1)
+			for (const line of lines) {
+				expect(line.length).toBeLessThanOrEqual(40)
+			}
+		})
+
+		it("very long prompt produces multiple wrapped lines", () => {
+			const veryLong = "Word ".repeat(100) // ~500 chars
+			const lines = renderLines(veryLong, 60, { prompt: veryLong })
+			expect(lines.length).toBeGreaterThan(5)
+			for (const line of lines) {
+				expect(line.length).toBeLessThanOrEqual(60)
+			}
+		})
+
+		it("wraps correctly at narrow terminal width", () => {
+			const longPrompt = "Some very long question text that exceeds the narrow width".repeat(3)
+			const lines = renderLines(longPrompt, 20, { prompt: longPrompt })
+			for (const line of lines) {
+				expect(line.length).toBeLessThanOrEqual(20)
+			}
+		})
+	})
+
+	describe("option labels wrap at terminal width", () => {
+		it("short label fits on one line", () => {
+			const lines = renderLines("Pick one:", 80, {
+				options: [{ value: "x", label: "Yes" }],
+			})
+			for (const line of lines) {
+				expect(line.length).toBeLessThanOrEqual(80)
+			}
+		})
+
+		it("long label wraps without exceeding width", () => {
+			const longLabel =
+				"This is an extremely long option label that should wrap across multiple lines when rendered in the terminal".repeat(
+					2,
+				)
+			const lines = renderLines("Pick one:", 80, {
+				options: [{ value: "x", label: longLabel }],
+			})
+			expect(lines.length).toBeGreaterThan(1)
+			for (const line of lines) {
+				expect(line.length).toBeLessThanOrEqual(80)
+			}
+		})
+
+		it("long label at narrow width produces many short lines", () => {
+			const longLabel = "Option".repeat(30)
+			const lines = renderLines("Pick one:", 30, {
+				options: [{ value: "x", label: longLabel }],
+			})
+			for (const line of lines) {
+				expect(line.length).toBeLessThanOrEqual(30)
+			}
+		})
+	})
+
+	describe("option descriptions wrap at terminal width", () => {
+		it("short description fits on one line", () => {
+			const lines = renderLines("Pick one:", 80, {
+				options: [{ value: "x", label: "Opt", description: "Brief." }],
+			})
+			for (const line of lines) {
+				expect(line.length).toBeLessThanOrEqual(80)
+			}
+		})
+
+		it("long description wraps without exceeding width", () => {
+			const longDesc =
+				"This is a detailed description that explains what this option does in extensive prose to ensure wrapping works correctly at various terminal widths".repeat(
+					3,
+				)
+			const lines = renderLines("Pick one:", 60, {
+				options: [{ value: "x", label: "Opt", description: longDesc }],
+			})
+			for (const line of lines) {
+				expect(line.length).toBeLessThanOrEqual(60)
+			}
+		})
+	})
+
+	describe("width changes produce correct re-wrapping", () => {
+		it("narrow width produces more lines than wide width", () => {
+			const longPrompt =
+				"Lorem ipsum dolor sit amet consectetur adipiscing elit sed do eiusmod tempor incididunt ut labore".repeat(2)
+			const wide = renderLines(longPrompt, 100, { prompt: longPrompt })
+			const narrow = renderLines(longPrompt, 40, { prompt: longPrompt })
+			expect(narrow.length).toBeGreaterThan(wide.length)
+		})
+	})
+
+	describe("edge cases", () => {
+		it("empty prompt renders without error", () => {
+			expect(() => renderLines("", 80, { prompt: "" })).not.toThrow()
+		})
+
+		it("width of 1 still produces valid output", () => {
+			const lines = renderLines("Hello world", 1, { prompt: "Hello world" })
+			// Each character gets its own line (or word-wrap splits)
+			for (const line of lines) {
+				expect(line.length).toBeLessThanOrEqual(1)
+			}
+			expect(lines.length).toBeGreaterThan(1)
+		})
+
+		it("very wide terminal produces fewer or equal lines", () => {
+			const longPrompt = "A ".repeat(100)
+			const wide = renderLines(longPrompt, 200, { prompt: longPrompt })
+			const wider = renderLines(longPrompt, 500, { prompt: longPrompt })
+			expect(wider.length).toBeLessThanOrEqual(wide.length)
+		})
 	})
 })

--- a/src/extensions/ferment/prompt-ui.ts
+++ b/src/extensions/ferment/prompt-ui.ts
@@ -1,5 +1,5 @@
 import type { ExtensionUIContext, Theme } from "@earendil-works/pi-coding-agent"
-import { Input, Key, type TUI, matchesKey, truncateToWidth } from "@earendil-works/pi-tui"
+import { Input, Key, type TUI, matchesKey, wrapTextWithAnsi } from "@earendil-works/pi-tui"
 import type { Component } from "@earendil-works/pi-tui"
 import {
 	type Answer,
@@ -244,7 +244,7 @@ async function promptMultiChoiceWithUi(
 	return labels.length > 0 ? labels : undefined
 }
 
-function createPromptFormComponent(
+export function createPromptFormComponent(
 	tui: TUI,
 	theme: Theme,
 	questions: Question[],
@@ -254,6 +254,7 @@ function createPromptFormComponent(
 ): Component {
 	let state: QuestionnaireState = initialState(questions)
 	let cachedLines: string[] | undefined
+	let cachedWidth = 0
 	const isMulti = questions.length > 1
 	const editor = new Input()
 	editor.focused = true
@@ -332,19 +333,23 @@ function createPromptFormComponent(
 	}
 
 	function render(width: number): string[] {
-		if (cachedLines) return cachedLines
+		if (cachedLines && cachedWidth === width) return cachedLines
 
 		const lines: string[] = []
 		const q = currentQuestion(state)
 		const opts = currentOptions(state)
-		const add = (s: string) => lines.push(truncateToWidth(s, width))
+		const add = (s: string) => {
+			for (const line of wrapTextWithAnsi(s, width)) {
+				lines.push(line)
+			}
+		}
 		const questionTitle = q ? `${isMulti ? `[${q.label}/${questions.length}] ` : ""}${q.prompt}` : ""
 		add(theme.fg("accent", "─".repeat(width)))
 
 		if (title || description) {
 			if (title) add(` ${theme.fg("text", theme.bold(title))}`)
 			if (description) {
-				for (const line of wrapWords(description, width - 2)) add(` ${theme.fg("muted", line)}`)
+				for (const line of wrapTextWithAnsi(description, Math.max(1, width - 2))) add(` ${theme.fg("muted", line)}`)
 			}
 			lines.push("")
 		}
@@ -402,7 +407,7 @@ function createPromptFormComponent(
 					}
 				}
 				if (opt.description) {
-					for (const descLine of wrapWords(opt.description, Math.max(12, width - 8))) {
+					for (const descLine of wrapTextWithAnsi(opt.description, Math.max(1, width - 8))) {
 						add(`     ${theme.fg("muted", descLine)}`)
 					}
 				}
@@ -479,6 +484,7 @@ function createPromptFormComponent(
 		add(theme.fg("accent", "─".repeat(width)))
 
 		cachedLines = lines
+		cachedWidth = width
 		return lines
 	}
 
@@ -486,38 +492,10 @@ function createPromptFormComponent(
 		render,
 		invalidate: () => {
 			cachedLines = undefined
+			cachedWidth = 0
 		},
 		handleInput,
 	}
-}
-
-function wrapWords(text: string, width: number): string[] {
-	const limit = Math.max(8, width)
-	const words = text.trim().split(/\s+/).filter(Boolean)
-	if (words.length === 0) return [""]
-
-	const lines: string[] = []
-	let current = ""
-	for (const word of words) {
-		if (word.length > limit) {
-			if (current) {
-				lines.push(current)
-				current = ""
-			}
-			for (let i = 0; i < word.length; i += limit) lines.push(word.slice(i, i + limit))
-			continue
-		}
-		if (!current) {
-			current = word
-		} else if (current.length + 1 + word.length <= limit) {
-			current += ` ${word}`
-		} else {
-			lines.push(current)
-			current = word
-		}
-	}
-	if (current) lines.push(current)
-	return lines
 }
 
 function parseMultiChoiceInput(input: string, options: ReadonlyArray<PromptChoiceOption>): string[] {

--- a/src/extensions/questionnaire.ts
+++ b/src/extensions/questionnaire.ts
@@ -16,7 +16,7 @@
  */
 
 import type { ExtensionAPI } from "@earendil-works/pi-coding-agent"
-import { Input, Key, Text, matchesKey, truncateToWidth } from "@earendil-works/pi-tui"
+import { Input, Key, Text, matchesKey, truncateToWidth, wrapTextWithAnsi } from "@earendil-works/pi-tui"
 import { type Static, Type } from "typebox"
 
 import {
@@ -174,6 +174,7 @@ export default function questionnaireExtension(pi: ExtensionAPI): void {
 				// ── State ──
 				let state: QuestionnaireState = initialState(questions)
 				let cachedLines: string[] | undefined
+				let cachedWidth = 0
 
 				const editor = new Input()
 				editor.focused = true
@@ -258,13 +259,17 @@ export default function questionnaireExtension(pi: ExtensionAPI): void {
 
 				// ── Rendering ──
 				function render(width: number): string[] {
-					if (cachedLines) return cachedLines
+					if (cachedLines && cachedWidth === width) return cachedLines
 
 					const lines: string[] = []
 					const q = currentQuestion(state)
 					const opts = currentOptions(state)
 
-					const add = (s: string) => lines.push(truncateToWidth(s, width))
+					const add = (s: string) => {
+						for (const line of wrapTextWithAnsi(s, width)) {
+							lines.push(line)
+						}
+					}
 					add(theme.fg("accent", "\u2500".repeat(width)))
 
 					// Header
@@ -410,6 +415,7 @@ export default function questionnaireExtension(pi: ExtensionAPI): void {
 					add(theme.fg("accent", "\u2500".repeat(width)))
 
 					cachedLines = lines
+					cachedWidth = width
 					return lines
 				}
 
@@ -417,6 +423,7 @@ export default function questionnaireExtension(pi: ExtensionAPI): void {
 					render,
 					invalidate: () => {
 						cachedLines = undefined
+						cachedWidth = 0
 					},
 					handleInput,
 				}


### PR DESCRIPTION
Currently:

<img width="847" height="204" alt="Screenshot 2026-05-20 at 18 28 55" src="https://github.com/user-attachments/assets/4cae5af9-abf7-4e50-9ead-0619cf076606" />


With this patch:

<img width="847" height="366" alt="Screenshot 2026-05-20 at 18 29 30" src="https://github.com/user-attachments/assets/ed30db34-e7db-4543-ae48-df9060329196" />

---
### Kimchi Summary
### What changed
Fixes text wrapping in the interactive questionnaire and ferment prompt form renderers so that question prompts, option labels, and descriptions correctly wrap to fit the terminal width instead of overflowing or being truncated.

### Why
Long question text, option labels, and descriptions were exceeding terminal boundaries, breaking the TUI layout. This ensures content reflows correctly across all terminal sizes.

### Key changes
- `src/extensions/ferment/prompt-ui.ts`: Exported `createPromptFormComponent`; replaced `truncateToWidth` and the local `wrapWords` helper with `wrapTextWithAnsi` from `@earendil-works/pi-tui`; added `cachedWidth` so the render cache invalidates when terminal width changes.
- `src/extensions/questionnaire.ts`: Replaced `truncateToWidth` with `wrapTextWithAnsi` in the questionnaire renderer; added `cachedWidth` for width-sensitive cache invalidation.
- `src/extensions/ferment/prompt-ui.test.ts`: Added comprehensive tests for `createPromptFormComponent` covering prompt wrapping, option label wrapping, option description wrapping, dynamic width changes, and edge cases such as empty prompts and a terminal width of `1`.

### Impact
- Render output now wraps to multiple lines instead of truncating long strings.
- Cache is correctly invalidated when the terminal resizes, preventing stale line counts and incorrect layout.