### PR TITLE
chore: add .codegraph to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,3 +38,6 @@ kimchi-session-*.html
 
 *.bun-build
 bin
+
+# LLM tools
+.codegraph/


### PR DESCRIPTION
just adds `.codegraph` to gitignore

---
### Kimchi Summary
### What changed
Adds `.codegraph/` to `.gitignore` so that artifacts generated by LLM tools are excluded from version control.

### Why
Prevents local LLM tool directories from being accidentally committed to the repository.

### Key changes
- `.gitignore`: Added ignore rule for `.codegraph/` under a new `# LLM tools` section.