### PR TITLE
fix: Align top border of sessions modal

### DIFF
--- a/src/modes/teleport/ui/sessions-panel.ts
+++ b/src/modes/teleport/ui/sessions-panel.ts
@@ -111,7 +111,7 @@ export class SessionsPanel implements Component {
 		const statusWidth = Math.max(HEADERS.status.length, ...rows.map((r) => (r.status ?? "-").length))
 		const lastWidth = HEADERS.lastActivity.length
 		// prefix "> " / "  " = 2 chars
-		const fixed = 2 + idWidth + 1 + hostWidth + 1 + statusWidth + 1 + lastWidth
+		const fixed = 2 + idWidth + 1 + hostWidth + 1 + 1 + statusWidth + 1 + lastWidth
 		const longestName = Math.max(HEADERS.name.length, ...rows.map((r) => (r.name || "-").length))
 		const available = Math.max(MIN_NAME_WIDTH, contentW - fixed)
 		const nameWidth = Math.min(longestName, available)
@@ -127,9 +127,9 @@ export class SessionsPanel implements Component {
 		}
 
 		// Wrap a text line inside border │ ... │, padded to innerW
-		const row = (content: string) => `${b("│")} ${pad(content, contentW)}${b("│")}`
+		const row = (content: string) => `${b("│")} ${pad(content, contentW)} ${b("│")}`
 		const ansiRow = (content: string, rawLen: number) =>
-			`${b("│")} ${content}${" ".repeat(Math.max(0, contentW - rawLen))}${b("│")}`
+			`${b("│")} ${content}${" ".repeat(Math.max(0, contentW - rawLen))} ${b("│")}`
 		const emptyRow = () => `${b("│")}${" ".repeat(innerW)}${b("│")}`
 
 		const lines: string[] = []
@@ -179,7 +179,7 @@ export class SessionsPanel implements Component {
 		}
 
 		// Hint
-		emptyRow() // spacing
+		lines.push(emptyRow()) // spacing
 		const hintText = "↑/↓ j/k: navigate  enter/a: attach  s: connect  D: delete  esc: close"
 		lines.push(ansiRow(dim(`  ${hintText}`), hintText.length + 2))
 


### PR DESCRIPTION


---
### Kimchi Summary
### What changed
Fixes the right-border alignment and missing spacer in the sessions panel table UI.

### Why
The table border `│` was misaligned because row padding and the fixed-width calculation did not account for all separators, causing the layout to render inconsistently.

### Key changes
- `src/modes/teleport/ui/sessions-panel.ts`
  - `fixed`: adds missing `+ 1` separator offset to the total fixed-width calculation
  - `row` and `ansiRow`: inserts a space before the right `│` border to restore correct inner padding
  - Hint spacing: changes `emptyRow()` to `lines.push(emptyRow())` so the empty spacer line is actually rendered before the keyboard hints