### PR TITLE
fix(session-picker): Replace checkbox (hide this dialog) with an option

### DIFF
--- a/src/extensions/onboarding/session-mode-picker.test.ts
+++ b/src/extensions/onboarding/session-mode-picker.test.ts
@@ -2,8 +2,6 @@ import type { Theme } from "@earendil-works/pi-coding-agent"
 import { describe, expect, it, vi } from "vitest"
 import {
 	SESSION_MODE_PICKER_HEADING,
-	SESSION_MODE_PICKER_HIDE_HINT,
-	SESSION_MODE_PICKER_HIDE_LABEL,
 	SESSION_MODE_PICKER_HINT,
 	SessionModePickerComponent,
 	initialSessionModePickerState,
@@ -29,7 +27,7 @@ function theme(): Theme {
 
 describe("session mode picker reducer", () => {
 	it("starts on Ferment", () => {
-		expect(initialSessionModePickerState()).toEqual({ selectedIndex: 0, hideDialog: false })
+		expect(initialSessionModePickerState()).toEqual({ selectedIndex: 0 })
 	})
 
 	it("moves selection down and up", () => {
@@ -46,22 +44,8 @@ describe("session mode picker reducer", () => {
 		expect(state.selectedIndex).toBe(0)
 		state = reduceSessionModePicker(state, "down").state
 		state = reduceSessionModePicker(state, "down").state
-		expect(state.selectedIndex).toBe(1)
-	})
-
-	it("supports the returning-launch hide checkbox", () => {
-		let state = initialSessionModePickerState()
-
-		state = reduceSessionModePicker(state, "down", { showHideCheckbox: true }).state
-		state = reduceSessionModePicker(state, "down", { showHideCheckbox: true }).state
-		expect(state.selectedIndex).toBe(1)
-
-		state = reduceSessionModePicker(state, "toggle-hide", { showHideCheckbox: true }).state
-		expect(state.hideDialog).toBe(true)
-		expect(reduceSessionModePicker(state, "select", { showHideCheckbox: true }).result).toEqual({
-			choice: "default",
-			hideDialog: true,
-		})
+		state = reduceSessionModePicker(state, "down").state
+		expect(state.selectedIndex).toBe(2)
 	})
 
 	it("returns the selected option on select", () => {
@@ -70,6 +54,9 @@ describe("session mode picker reducer", () => {
 
 		state = reduceSessionModePicker(state, "down").state
 		expect(reduceSessionModePicker(state, "select").result).toEqual({ choice: "default", hideDialog: false })
+
+		state = reduceSessionModePicker(state, "down").state
+		expect(reduceSessionModePicker(state, "select").result).toEqual({ choice: "default", hideDialog: true })
 	})
 
 	it("returns cancellation on cancel", () => {
@@ -82,7 +69,6 @@ describe("session mode picker key mapping", () => {
 		expect(keyToSessionModePickerEvent("\x1b[A")).toBe("up")
 		expect(keyToSessionModePickerEvent("\x1b[B")).toBe("down")
 		expect(keyToSessionModePickerEvent("\r")).toBe("select")
-		expect(keyToSessionModePickerEvent(" ")).toBe("toggle-hide")
 		expect(keyToSessionModePickerEvent("\x1b")).toBe("cancel")
 		expect(keyToSessionModePickerEvent("\x03")).toBe("cancel")
 	})
@@ -91,7 +77,8 @@ describe("session mode picker key mapping", () => {
 		expect(keyToSessionModePickerEvent("x")).toBeUndefined()
 	})
 
-	it("ignores space repeat and release events", () => {
+	it("ignores space input", () => {
+		expect(keyToSessionModePickerEvent(" ")).toBeUndefined()
 		expect(keyToSessionModePickerEvent("\x1b[32;1:2u")).toBeUndefined()
 		expect(keyToSessionModePickerEvent("\x1b[32;1:3u")).toBeUndefined()
 	})
@@ -112,6 +99,9 @@ describe("session mode picker rendering", () => {
 			"    Coding session",
 			"    Chat with the agent and steer it as it goes. Stay in the loop.",
 			"",
+			"    Coding session, don't show this dialog again",
+			"    Start a normal coding session and skip this chooser on future launches.",
+			"",
 			"  Tip: Use /ferment anytime to start a Ferment workflow.",
 			"",
 		])
@@ -122,28 +112,12 @@ describe("session mode picker rendering", () => {
 		)
 		expect(text).toContain("Coding session")
 		expect(text).toContain("Chat with the agent and steer it as it goes. Stay in the loop.")
+		expect(text).toContain("Coding session, don't show this dialog again")
+		expect(text).toContain("Start a normal coding session and skip this chooser on future launches.")
 		expect(text).toContain(`Tip: ${SESSION_MODE_PICKER_HINT.replaceAll("`", "")}`)
 		expect(text).not.toContain("`")
-		expect(text).not.toContain(SESSION_MODE_PICKER_HIDE_LABEL)
-	})
-
-	it("renders the hide checkbox only when requested", () => {
-		const lines = renderSessionModePickerLines(initialSessionModePickerState(), theme(), 100, {
-			showHideCheckbox: true,
-		})
-		const text = lines.join("\n")
-
-		expect(text).toContain(`[ ] ${SESSION_MODE_PICKER_HIDE_LABEL}  ${SESSION_MODE_PICKER_HIDE_HINT}`)
-	})
-
-	it("renders the hide checkbox hint with the dim theme color", () => {
-		const t = theme()
-
-		renderSessionModePickerLines(initialSessionModePickerState(), t, 100, {
-			showHideCheckbox: true,
-		})
-
-		expect(t.fg).toHaveBeenCalledWith("dim", SESSION_MODE_PICKER_HIDE_HINT)
+		expect(text).not.toContain("[ ]")
+		expect(text).not.toContain("Space toggle")
 	})
 
 	it("marks the selected option", () => {
@@ -154,6 +128,10 @@ describe("session mode picker rendering", () => {
 		const state = reduceSessionModePicker(initialSessionModePickerState(), "down").state
 		lines = renderSessionModePickerLines(state, theme(), 100)
 		expect(lines.some((line) => line.includes("> Coding session"))).toBe(true)
+
+		const hiddenState = reduceSessionModePicker(state, "down").state
+		lines = renderSessionModePickerLines(hiddenState, theme(), 100)
+		expect(lines.some((line) => line.includes("> Coding session, don't show this dialog again"))).toBe(true)
 	})
 })
 
@@ -171,12 +149,11 @@ describe("SessionModePickerComponent", () => {
 		expect(onDone).toHaveBeenCalledWith({ choice: "default", hideDialog: false })
 	})
 
-	it("handles the hide checkbox when enabled", () => {
+	it("handles the hide dialog option", () => {
 		const onDone = vi.fn()
-		const component = new SessionModePickerComponent(theme(), onDone, vi.fn(), { showHideCheckbox: true })
+		const component = new SessionModePickerComponent(theme(), onDone, vi.fn())
 
-		component.handleInput(" ")
-		component.handleInput("\x1b[32;1:3u")
+		component.handleInput("\x1b[B")
 		component.handleInput("\x1b[B")
 		component.handleInput("\r")
 

--- a/src/extensions/onboarding/session-mode-picker.test.ts
+++ b/src/extensions/onboarding/session-mode-picker.test.ts
@@ -100,7 +100,6 @@ describe("session mode picker rendering", () => {
 			"    Chat with the agent and steer it as it goes. Stay in the loop.",
 			"",
 			"    Coding session, don't show this dialog again",
-			"    Start a normal coding session and skip this chooser on future launches.",
 			"",
 			"  Tip: Use /ferment anytime to start a Ferment workflow.",
 			"",
@@ -113,11 +112,7 @@ describe("session mode picker rendering", () => {
 		expect(text).toContain("Coding session")
 		expect(text).toContain("Chat with the agent and steer it as it goes. Stay in the loop.")
 		expect(text).toContain("Coding session, don't show this dialog again")
-		expect(text).toContain("Start a normal coding session and skip this chooser on future launches.")
 		expect(text).toContain(`Tip: ${SESSION_MODE_PICKER_HINT.replaceAll("`", "")}`)
-		expect(text).not.toContain("`")
-		expect(text).not.toContain("[ ]")
-		expect(text).not.toContain("Space toggle")
 	})
 
 	it("marks the selected option", () => {

--- a/src/extensions/onboarding/session-mode-picker.ts
+++ b/src/extensions/onboarding/session-mode-picker.ts
@@ -1,28 +1,20 @@
 import type { Theme } from "@earendil-works/pi-coding-agent"
-import {
-	type Component,
-	Key,
-	isKeyRelease,
-	isKeyRepeat,
-	matchesKey,
-	truncateToWidth,
-	wrapTextWithAnsi,
-} from "@earendil-works/pi-tui"
+import { type Component, Key, matchesKey, truncateToWidth, wrapTextWithAnsi } from "@earendil-works/pi-tui"
 import { renderTipText } from "../tips/tip-row.js"
 
 export type SessionModePickerChoice = "ferment" | "default"
 export type SessionModePickerResult = { choice: SessionModePickerChoice; hideDialog: boolean } | "cancelled"
-export type SessionModePickerEvent = "up" | "down" | "select" | "cancel" | "toggle-hide"
+export type SessionModePickerEvent = "up" | "down" | "select" | "cancel"
 
 export interface SessionModePickerOption {
 	value: SessionModePickerChoice
 	label: string
 	description: string
+	hideDialog?: boolean
 }
 
 export interface SessionModePickerState {
 	selectedIndex: number
-	hideDialog: boolean
 }
 
 export interface SessionModePickerReduceResult {
@@ -45,30 +37,28 @@ export const SESSION_MODE_PICKER_OPTIONS: SessionModePickerOption[] = [
 		label: "Coding session",
 		description: "Chat with the agent and steer it as it goes. Stay in the loop.",
 	},
+	{
+		value: "default",
+		label: "Coding session, don't show this dialog again",
+		description: "Start a normal coding session and skip this chooser on future launches.",
+		hideDialog: true,
+	},
 ]
 
-export const SESSION_MODE_PICKER_HIDE_LABEL = "Hide this dialog"
-export const SESSION_MODE_PICKER_HIDE_HINT = "Space toggle"
-
-export interface SessionModePickerOptions {
-	showHideCheckbox?: boolean
-}
-
 export function initialSessionModePickerState(): SessionModePickerState {
-	return { selectedIndex: 0, hideDialog: false }
+	return { selectedIndex: 0 }
 }
 
 export function reduceSessionModePicker(
 	state: SessionModePickerState,
 	event: SessionModePickerEvent,
-	options: SessionModePickerOptions = {},
 ): SessionModePickerReduceResult {
 	if (event === "cancel") return { state, result: "cancelled" }
 	if (event === "select") {
 		const option = SESSION_MODE_PICKER_OPTIONS[state.selectedIndex]
 		return {
 			state,
-			result: { choice: option.value, hideDialog: options.showHideCheckbox === true && state.hideDialog },
+			result: { choice: option.value, hideDialog: option.hideDialog === true },
 		}
 	}
 	if (event === "up") {
@@ -79,9 +69,6 @@ export function reduceSessionModePicker(
 			state: { ...state, selectedIndex: Math.min(SESSION_MODE_PICKER_OPTIONS.length - 1, state.selectedIndex + 1) },
 		}
 	}
-	if (event === "toggle-hide" && options.showHideCheckbox === true) {
-		return { state: { ...state, hideDialog: !state.hideDialog } }
-	}
 	return { state }
 }
 
@@ -89,17 +76,11 @@ export function keyToSessionModePickerEvent(data: string): SessionModePickerEven
 	if (matchesKey(data, Key.up)) return "up"
 	if (matchesKey(data, Key.down)) return "down"
 	if (matchesKey(data, Key.enter)) return "select"
-	if (matchesKey(data, Key.space) && !isKeyRelease(data) && !isKeyRepeat(data)) return "toggle-hide"
 	if (matchesKey(data, Key.escape) || matchesKey(data, Key.ctrl("c"))) return "cancel"
 	return undefined
 }
 
-export function renderSessionModePickerLines(
-	state: SessionModePickerState,
-	theme: Theme,
-	width: number,
-	options: SessionModePickerOptions = {},
-): string[] {
+export function renderSessionModePickerLines(state: SessionModePickerState, theme: Theme, width: number): string[] {
 	const lines: string[] = []
 	const innerWidth = Math.max(1, width - 2)
 	const add = (line = "") => lines.push(truncateToWidth(line, width, ""))
@@ -122,15 +103,6 @@ export function renderSessionModePickerLines(
 		if (i < SESSION_MODE_PICKER_OPTIONS.length - 1) add("")
 	}
 
-	if (options.showHideCheckbox === true) {
-		add("")
-		const checkbox = state.hideDialog ? theme.fg("success", "[x]") : theme.fg("dim", "[ ]")
-		const label = state.hideDialog
-			? theme.fg("success", SESSION_MODE_PICKER_HIDE_LABEL)
-			: theme.fg("text", SESSION_MODE_PICKER_HIDE_LABEL)
-		add(`${indent}${checkbox} ${label}  ${theme.fg("dim", SESSION_MODE_PICKER_HIDE_HINT)}`)
-	}
-
 	add("")
 	for (const line of renderTipText(SESSION_MODE_PICKER_HINT, theme, innerWidth)) {
 		add(`${indent}${line}`)
@@ -146,7 +118,6 @@ export class SessionModePickerComponent implements Component {
 		private readonly theme: Theme,
 		private readonly onDone: (result: SessionModePickerResult) => void,
 		private readonly requestRender: () => void,
-		private readonly options: SessionModePickerOptions = {},
 	) {}
 
 	getState(): SessionModePickerState {
@@ -156,13 +127,13 @@ export class SessionModePickerComponent implements Component {
 	invalidate(): void {}
 
 	render(width: number): string[] {
-		return renderSessionModePickerLines(this.state, this.theme, width, this.options)
+		return renderSessionModePickerLines(this.state, this.theme, width)
 	}
 
 	handleInput(data: string): void {
 		const event = keyToSessionModePickerEvent(data)
 		if (!event) return
-		const next = reduceSessionModePicker(this.state, event, this.options)
+		const next = reduceSessionModePicker(this.state, event)
 		this.state = next.state
 		if (next.result) {
 			this.onDone(next.result)

--- a/src/extensions/onboarding/session-mode-picker.ts
+++ b/src/extensions/onboarding/session-mode-picker.ts
@@ -9,7 +9,7 @@ export type SessionModePickerEvent = "up" | "down" | "select" | "cancel"
 export interface SessionModePickerOption {
 	value: SessionModePickerChoice
 	label: string
-	description: string
+	description?: string
 	hideDialog?: boolean
 }
 
@@ -40,7 +40,6 @@ export const SESSION_MODE_PICKER_OPTIONS: SessionModePickerOption[] = [
 	{
 		value: "default",
 		label: "Coding session, don't show this dialog again",
-		description: "Start a normal coding session and skip this chooser on future launches.",
 		hideDialog: true,
 	},
 ]
@@ -95,10 +94,12 @@ export function renderSessionModePickerLines(state: SessionModePickerState, them
 		const selected = i === state.selectedIndex
 		const marker = selected ? "> " : "  "
 		const label = selected ? theme.fg("accent", option.label) : theme.fg("dim", option.label)
-		const description = selected ? theme.fg("text", option.description) : theme.fg("dim", option.description)
 		add(`${indent}${theme.fg(selected ? "accent" : "dim", marker)}${label}`)
-		for (const wrapped of wrapTextWithAnsi(description, Math.max(1, innerWidth - 4))) {
-			add(`${indent}  ${wrapped}`)
+		if (option.description) {
+			const description = selected ? theme.fg("text", option.description) : theme.fg("dim", option.description)
+			for (const wrapped of wrapTextWithAnsi(description, Math.max(1, innerWidth - 4))) {
+				add(`${indent}  ${wrapped}`)
+			}
 		}
 		if (i < SESSION_MODE_PICKER_OPTIONS.length - 1) add("")
 	}

--- a/src/extensions/onboarding/session-mode-startup.test.ts
+++ b/src/extensions/onboarding/session-mode-startup.test.ts
@@ -206,13 +206,13 @@ describe("session mode startup integration", () => {
 		expect(harness.activeComponent()).toBeUndefined()
 	})
 
-	it("choosing Hide this dialog persists the hidden user config without starting Ferment", async () => {
+	it("choosing Coding session with hide persists the hidden user config without starting Ferment", async () => {
 		writeSessionModeWizardSeenAt("2026-05-19T08:00:00.000Z", configPath)
 		const startFerment = vi.fn()
 		const harness = createHarness({ configPath, now, startFerment })
 		await harness.start()
 
-		harness.input(" ")
+		harness.input("\x1b[B")
 		harness.input("\x1b[B")
 		harness.input("\r")
 		await harness.settle()

--- a/src/extensions/onboarding/session-mode.test.ts
+++ b/src/extensions/onboarding/session-mode.test.ts
@@ -391,7 +391,7 @@ describe("session-mode onboarding persistence", () => {
 		expect(harness.ui.notify).toHaveBeenCalledWith("Session mode startup failed: sync boom", "warning")
 	})
 
-	it("extension lets returning users hide the dialog while selecting a mode", async () => {
+	it("extension lets users choose Coding session and hide future dialogs", async () => {
 		const harness = createExtensionHarness()
 		const onOutcome = vi.fn()
 
@@ -401,7 +401,7 @@ describe("session-mode onboarding persistence", () => {
 		)
 
 		await harness.start()
-		harness.input(" ")
+		harness.input("\x1b[B")
 		harness.input("\x1b[B")
 		harness.input("\r")
 		await harness.settle()

--- a/src/extensions/onboarding/session-mode.ts
+++ b/src/extensions/onboarding/session-mode.ts
@@ -80,8 +80,7 @@ export default function sessionModeOnboardingExtension(options: SessionModeOnboa
 				return
 			}
 			if (decision.action === "show") {
-				const showHideOption = seenAt !== undefined
-				if (!showHideOption) {
+				if (seenAt === undefined) {
 					try {
 						markSessionModeWizardSeen({ configPath: options.configPath, now: options.now })
 					} catch (err) {
@@ -91,7 +90,7 @@ export default function sessionModeOnboardingExtension(options: SessionModeOnboa
 						)
 					}
 				}
-				cleanupActiveWizard = showSessionModeWizard(pi, ctx, options, showHideOption, () => {
+				cleanupActiveWizard = showSessionModeWizard(pi, ctx, options, () => {
 					cleanupActiveWizard = undefined
 				})
 			}
@@ -108,7 +107,6 @@ function showSessionModeWizard(
 	pi: ExtensionAPI,
 	ctx: ExtensionContext,
 	options: SessionModeOnboardingExtensionOptions,
-	showHideOption: boolean,
 	onCleanup: () => void,
 ): () => void {
 	let finished = false
@@ -169,9 +167,7 @@ function showSessionModeWizard(
 					if (cancelBeforePickerReady || finished) {
 						done("cancelled")
 					}
-					return new SessionModePickerComponent(theme, done, () => tui.requestRender(), {
-						showHideCheckbox: showHideOption,
-					})
+					return new SessionModePickerComponent(theme, done, () => tui.requestRender())
 				},
 				{ overlay: false },
 			)


### PR DESCRIPTION

<img width="1307" height="1022" alt="Screenshot 2026-05-21 at 13 58 00" src="https://github.com/user-attachments/assets/44ea7372-5b49-449f-99ab-10b9c51b8e40" />


---
### Kimchi Summary
### What changed
Replaced the session mode picker's separate "Hide this dialog" checkbox with a third selectable list option, removing the spacebar toggle interaction.

### Why
Consolidating the "don't show again" choice into the option list simplifies the UI and eliminates the need for a separate keyboard shortcut and checkbox state.

### Key changes
- **`src/extensions/onboarding/session-mode-picker.ts`**:
  - Added a third option to `SESSION_MODE_PICKER_OPTIONS`: `Coding session, don't show this dialog again` with `hideDialog: true`.
  - Removed `hideDialog` from `SessionModePickerState`; `reduceSessionModePicker` now derives the flag from the selected option's `hideDialog` property.
  - Removed the `toggle-hide` event, `showHideCheckbox` option, spacebar keybinding, and checkbox rendering logic.
  - Removed `SessionModePickerOptions` interface.
- **`src/extensions/onboarding/session-mode.ts`**:
  - Removed `showHideOption` parameter from `showSessionModeWizard`; all users now see the same three options regardless of prior visits.
- **Tests**:
  - Updated `session-mode-picker.test.ts`, `session-mode-startup.test.ts`, and `session-mode.test.ts` to navigate to the third option with arrow keys instead of using spacebar to toggle a checkbox.

### Impact
Users previously toggling the hide checkbox with the spacebar must now navigate to the third list option and press Enter. This is a breaking change to the `SessionModePickerComponent` constructor and `reduceSessionModePicker` signatures, which no longer accept options.