### PR TITLE
fix(ui): improve newline hint overlay UX

### DIFF
--- a/src/extensions/ui.ts
+++ b/src/extensions/ui.ts
@@ -306,17 +306,23 @@ export default function uiExtension(pi: ExtensionAPI) {
 							ctx.ui.custom(
 								(_tui, theme, _kb, done) => {
 									const settingsFile = settingsPath
+									const dismiss = () => {
+										_tui.setShowHardwareCursor(true)
+										done(undefined)
+									}
 									return {
 										render(width: number): string[] {
+											_tui.setShowHardwareCursor(false)
+											const accent = theme.getFgAnsi("accent")
+											const reset = "\x1b[0m"
 											const box = new Box(2, 1)
 											box.addChild(new Text(theme.inverse("  ⚠  Shift+Enter doesn't work in this terminal  ")))
 											box.addChild(new Text(""))
-											box.addChild(new Text(`${theme.bold("Ctrl+J")}${" ".padEnd(13)}→  insert a newline`))
+											box.addChild(new Text(`Ctrl+J${" ".padEnd(13)}→  insert a newline`))
 											box.addChild(new Text(`\\ + Enter${" ".padEnd(10)}→  insert a newline`))
 											box.addChild(new Text(""))
-											box.addChild(new Text(theme.fg("muted", "Enter - dismiss   d - don't remind again")))
-											const accent = theme.getFgAnsi("accent")
-											const reset = "\x1b[0m"
+											box.addChild(new Text(`Any key${" ".padEnd(12)}→  dismiss`))
+											box.addChild(new Text(`${accent}d${" ".padEnd(18)}→  don't remind again${reset}`))
 											const hbar = "─"
 											const inner = width - 2
 											const lines = box.render(inner)
@@ -329,7 +335,6 @@ export default function uiExtension(pi: ExtensionAPI) {
 										},
 										invalidate() {},
 										handleInput(data: string): void {
-											if (matchesKey(data, "enter")) done(undefined)
 											if (data === "d") {
 												try {
 													const s: Record<string, unknown> = {}
@@ -341,8 +346,8 @@ export default function uiExtension(pi: ExtensionAPI) {
 													s.newlineHintDismissed = true
 													writeFileSync(settingsFile, JSON.stringify(s, null, 2))
 												} catch {}
-												done(undefined)
 											}
+											dismiss()
 										},
 										wantsKeyRelease: false,
 									}


### PR DESCRIPTION
### JIRA: [LLM-1752](https://castai.atlassian.net/browse/LLM-1752)

<img width="946" height="493" alt="Screenshot 2026-05-21 at 14 14 28" src="https://github.com/user-attachments/assets/8b4e53d3-490e-4926-b081-315f5fb344e0" />


[LLM-1752]: https://castai.atlassian.net/browse/LLM-1752?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

---
### Kimchi Summary
### What changed
Updates the `Shift+Enter` terminal hint modal so any key dismisses it instead of only Enter. The modal now hides the hardware cursor while open and restores it on close.

### Why
Requiring a specific key to dismiss the hint is restrictive; allowing any keypress provides a smoother user experience. Properly toggling `setShowHardwareCursor` also prevents the terminal cursor from interfering with the custom rendered alert.

### Key changes
- `src/extensions/ui.ts`:
  - Added a `dismiss` helper that re-enables the hardware cursor via `_tui.setShowHardwareCursor(true)` before invoking `done(undefined)`.
  - Disabled the hardware cursor via `_tui.setShowHardwareCursor(false)` when the alert renders.
  - Changed `handleInput` to call `dismiss()` for any keystroke; pressing `d` still persists `newlineHintDismissed` to the settings file before dismissing.
  - Split the footer into two lines: `Any key → dismiss` and `d → don't remind again`, and applied the theme `accent` ANSI color to the `d` prompt.
  - Removed bold styling from the `Ctrl+J` label in the hint text.

### Impact
No breaking changes or migration steps required.