### PR TITLE
fix(session-mode): prevent picker from stealing focus from warning overlay

### DIFF
--- a/src/extensions/onboarding/session-mode-startup.test.ts
+++ b/src/extensions/onboarding/session-mode-startup.test.ts
@@ -49,7 +49,11 @@ function createHarness(options: {
 	const unsubscribe = vi.fn()
 	const ui = {
 		setWidget: vi.fn((_: string, content: unknown) => {
-			if (typeof content === "function") content(tui, theme())
+			if (typeof content === "function") {
+				activeComponent = content(tui, theme()) as CustomComponent
+			} else {
+				activeComponent = undefined
+			}
 		}),
 		onTerminalInput: vi.fn((handler: TerminalInputHandler) => {
 			inputHandler = handler
@@ -135,9 +139,8 @@ describe("session mode startup integration", () => {
 
 		await harness.start()
 
-		expect(harness.ui.custom).toHaveBeenCalled()
-		expect(harness.ui.setWidget).not.toHaveBeenCalled()
-		expect(harness.ui.onTerminalInput).not.toHaveBeenCalled()
+		expect(harness.ui.setWidget).toHaveBeenCalled()
+		expect(harness.ui.onTerminalInput).toHaveBeenCalled()
 	})
 
 	it("shows returning launches with existing onboarding state", async () => {
@@ -146,9 +149,8 @@ describe("session mode startup integration", () => {
 
 		await harness.start()
 
-		expect(harness.ui.custom).toHaveBeenCalled()
-		expect(harness.ui.setWidget).not.toHaveBeenCalled()
-		expect(harness.ui.onTerminalInput).not.toHaveBeenCalled()
+		expect(harness.ui.setWidget).toHaveBeenCalled()
+		expect(harness.ui.onTerminalInput).toHaveBeenCalled()
 	})
 
 	it("skips launches when the session mode dialog has been hidden", async () => {

--- a/src/extensions/onboarding/session-mode.test.ts
+++ b/src/extensions/onboarding/session-mode.test.ts
@@ -65,7 +65,11 @@ function createExtensionHarness(options: { deferCustomFactory?: boolean } = {}) 
 	const unsubscribe = vi.fn()
 	const ui = {
 		setWidget: vi.fn((_: string, content: unknown) => {
-			if (typeof content === "function") content(tui, theme())
+			if (typeof content === "function") {
+				activeComponent = content(tui, theme()) as CustomComponent
+			} else {
+				activeComponent = undefined
+			}
 		}),
 		onTerminalInput: vi.fn((handler: TerminalInputHandler) => {
 			inputHandler = handler
@@ -274,9 +278,8 @@ describe("session-mode onboarding persistence", () => {
 		)
 
 		await harness.start()
-		expect(harness.ui.custom).toHaveBeenCalled()
-		expect(harness.ui.setWidget).not.toHaveBeenCalled()
-		expect(harness.ui.onTerminalInput).not.toHaveBeenCalled()
+		expect(harness.ui.setWidget).toHaveBeenCalled()
+		expect(harness.ui.onTerminalInput).toHaveBeenCalled()
 		let raw = JSON.parse(readFileSync(configPath, "utf-8"))
 		expect(raw.onboarding.sessionModeWizardSeenAt).toBe("2026-05-19T09:30:00.000Z")
 
@@ -302,9 +305,8 @@ describe("session-mode onboarding persistence", () => {
 		harness.input("hello")
 		harness.input("x")
 
-		expect(harness.ui.custom).toHaveBeenCalled()
-		expect(harness.ui.setWidget).not.toHaveBeenCalled()
-		expect(harness.ui.onTerminalInput).not.toHaveBeenCalled()
+		expect(harness.ui.setWidget).toHaveBeenCalled()
+		expect(harness.ui.onTerminalInput).toHaveBeenCalled()
 		expect(harness.activeComponent()).toBeDefined()
 	})
 
@@ -342,14 +344,15 @@ describe("session-mode onboarding persistence", () => {
 		expect(harness.activeComponent()).toBeUndefined()
 	})
 
-	it("does not mount the picker after cancellation when the host delays the custom factory", async () => {
-		const harness = createExtensionHarness({ deferCustomFactory: true })
+	it("shutdown cleans up the picker", async () => {
+		const harness = createExtensionHarness()
 
 		sessionModeOnboardingExtension({ launchContext: launch([]), configPath, now })(
 			harness.api as unknown as Parameters<ReturnType<typeof sessionModeOnboardingExtension>>[0],
 		)
 
-		harness.start()
+		await harness.start()
+		expect(harness.activeComponent()).toBeDefined()
 		harness.shutdown()
 		await harness.settle()
 

--- a/src/extensions/onboarding/session-mode.ts
+++ b/src/extensions/onboarding/session-mode.ts
@@ -6,9 +6,14 @@ import {
 	writeHideSessionModeDialog,
 	writeSessionModeWizardSeenAt,
 } from "../../config.js"
+
 import { setTipWidgetLocation } from "../tips/index.js"
 import { setSessionModeOnboardingFooterSuppressed } from "../ui.js"
-import { SessionModePickerComponent, type SessionModePickerResult } from "./session-mode-picker.js"
+import {
+	SessionModePickerComponent,
+	type SessionModePickerResult,
+	keyToSessionModePickerEvent,
+} from "./session-mode-picker.js"
 
 export type SessionModeOnboardingAction = "show" | "skip" | "skip-and-mark-seen"
 
@@ -47,6 +52,9 @@ export interface SessionModeOnboardingInput {
 	sessionStartReason?: SessionStartEvent["reason"]
 }
 
+const SESSION_MODE_WIDGET_KEY = "kimchi-session-mode-onboarding"
+const SESSION_MODE_WIDGET_OPTIONS = { placement: "aboveEditor" } as const
+
 export type SessionModeWizardOutcome = "default" | "ferment" | "cancelled"
 
 export interface SessionModeOnboardingExtensionOptions {
@@ -80,7 +88,8 @@ export default function sessionModeOnboardingExtension(options: SessionModeOnboa
 				return
 			}
 			if (decision.action === "show") {
-				if (seenAt === undefined) {
+				const showHideOption = seenAt !== undefined
+				if (!showHideOption) {
 					try {
 						markSessionModeWizardSeen({ configPath: options.configPath, now: options.now })
 					} catch (err) {
@@ -110,11 +119,15 @@ function showSessionModeWizard(
 	onCleanup: () => void,
 ): () => void {
 	let finished = false
-	let closePicker: ((result: SessionModePickerResult) => void) | undefined
+	let unsubscribeInput: (() => void) | undefined
 	let restoreTips: (() => void) | undefined
-	let cancelBeforePickerReady = false
+	let tuiRef: { hasOverlay(): boolean } | null = null
+	let component: SessionModePickerComponent | undefined
 
 	const cleanup = () => {
+		unsubscribeInput?.()
+		unsubscribeInput = undefined
+		ctx.ui.setWidget(SESSION_MODE_WIDGET_KEY, undefined, SESSION_MODE_WIDGET_OPTIONS)
 		restoreTips?.()
 		restoreTips = undefined
 		setSessionModeOnboardingFooterSuppressed(false)
@@ -150,38 +163,32 @@ function showSessionModeWizard(
 		}
 	}
 
-	const fail = (err: unknown) => {
-		if (finished) return
-		finished = true
-		cleanup()
-		ctx.ui.notify(`Session mode picker failed: ${err instanceof Error ? err.message : String(err)}`, "warning")
-	}
-
 	restoreTips = setTipWidgetLocation("hidden")
 	setSessionModeOnboardingFooterSuppressed(true)
-	try {
-		ctx.ui
-			.custom<SessionModePickerResult>(
-				(tui, theme, _keybindings, done) => {
-					closePicker = done
-					if (cancelBeforePickerReady || finished) {
-						done("cancelled")
-					}
-					return new SessionModePickerComponent(theme, done, () => tui.requestRender())
-				},
-				{ overlay: false },
-			)
-			.then(finish)
-			.catch(fail)
-	} catch (err) {
-		fail(err)
-	}
+	ctx.ui.setWidget(
+		SESSION_MODE_WIDGET_KEY,
+		(tui, theme) => {
+			tuiRef = tui as unknown as { hasOverlay(): boolean }
+			component = new SessionModePickerComponent(theme, finish, () => tui.requestRender())
+			return component
+		},
+		SESSION_MODE_WIDGET_OPTIONS,
+	)
+	unsubscribeInput = ctx.ui.onTerminalInput((data) => {
+		if (typeof tuiRef?.hasOverlay === "function" && tuiRef.hasOverlay()) {
+			return undefined
+		}
+		const event = keyToSessionModePickerEvent(data)
+		if (event) {
+			component?.handleInput(data)
+			return { consume: true }
+		}
+		return undefined
+	})
 
 	return () => {
 		if (finished) return
 		finished = true
-		if (!closePicker) cancelBeforePickerReady = true
-		closePicker?.("cancelled")
 		cleanup()
 	}
 }


### PR DESCRIPTION
## Problem

Between v0.0.60 and v0.0.63, the session mode picker was refactored to use `ctx.ui.custom(..., { overlay: false })`. This makes the picker the keyboard-focused component. When the shift+enter warning overlay is shown afterwards, the picker steals focus and the warning can no longer be dismissed with Enter/d.

## Fix

Restores the v0.0.60 pattern:
- `setWidget()` renders the picker as a non-focused widget
- `onTerminalInput()` intercepts input, checking `hasOverlay()` before consuming picker keys so overlays receive input

Adapted to upstream changes that removed `showHideCheckbox` from `SessionModePickerComponent`.

## Verification

- All 45 session-mode tests pass
- `pnpm run typecheck` clean

---
### Kimchi Summary
### What changed
Fixes a regression in the session mode onboarding picker by migrating from `ctx.ui.custom` to `ctx.ui.setWidget` and `ctx.ui.onTerminalInput`. The picker now mounts as a named widget and receives keyboard input directly, restoring the expected interaction flow.

### Why
The previous implementation relied on the `ui.custom` factory pattern, which broke terminal input handling for the session mode wizard. Switching to the explicit widget and input APIs resolves the input regression and aligns with the current UI extension model.

### Key changes
- `src/extensions/onboarding/session-mode.ts`
  - Replaced `ctx.ui.custom` with `ctx.ui.setWidget(SESSION_MODE_WIDGET_KEY, ...)` and `ctx.ui.onTerminalInput` to mount `SessionModePickerComponent` and route keyboard events via `keyToSessionModePickerEvent`.
  - Added `SESSION_MODE_WIDGET_KEY` and `SESSION_MODE_WIDGET_OPTIONS` constants for widget identity and placement (`aboveEditor`).
  - Refactored cleanup to explicitly call `unsubscribeInput` and remove the widget on finish or shutdown.
- `src/extensions/onboarding/session-mode.test.ts`, `session-mode-startup.test.ts`
  - Updated test harness mocks to capture the component returned by `setWidget` callbacks.
  - Replaced assertions expecting `ui.custom` with assertions for `ui.setWidget` and `ui.onTerminalInput`.
  - Replaced the delayed custom factory cancellation test with a shutdown cleanup test.

### Impact
- Fixes broken keyboard navigation in the session mode onboarding dialog.
- Shutdown or cancellation now reliably tears down the widget and input handler, preventing stuck overlays or orphaned subscriptions.