### PR TITLE
fix: Playwright detection failing in prebuilt release binaries

### DIFF
--- a/package.json
+++ b/package.json
@@ -98,7 +98,8 @@
 		],
 		"patchedDependencies": {
 			"@earendil-works/pi-coding-agent": "patches/@earendil-works__pi-coding-agent.patch",
-			"@earendil-works/pi-tui": "patches/@earendil-works__pi-tui.patch"
+			"@earendil-works/pi-tui": "patches/@earendil-works__pi-tui.patch",
+			"playwright-core@1.59.1": "patches/playwright-core@1.59.1.patch"
 		}
 	}
 }

--- a/patches/playwright-core@1.59.1.patch
+++ b/patches/playwright-core@1.59.1.patch
@@ -1,21 +1,23 @@
 diff --git a/lib/server/utils/nodePlatform.js b/lib/server/utils/nodePlatform.js
-index 80d88fedf2c4d2b7bea8cfd4b9c8db454dedaa1d..ca0a8d6aa6ac9f66e2a18e2970cb3be12b02c6f7 100644
+index 80d88fedf2c4d2b7bea8cfd4b9c8db454dedaa1d..18eb6371f9efc3d0b0beef3b28815f98a902d4c2 100644
 --- a/lib/server/utils/nodePlatform.js
 +++ b/lib/server/utils/nodePlatform.js
-@@ -64,7 +64,15 @@ let boxedStackPrefixes = [];
+@@ -64,7 +64,17 @@ let boxedStackPrefixes = [];
  function setBoxedStackPrefixes(prefixes) {
    boxedStackPrefixes = prefixes;
  }
 -const coreDir = import_path.default.dirname(require.resolve("../../../package.json"));
 +// Wrapped in try-catch for Bun compiled binaries: require.resolve() with
 +// relative paths gets converted to absolute build-machine paths that don't
-+// exist at runtime. coreDir is only used for stack-trace filtering so an
-+// empty fallback is safe.
++// exist at runtime. The __dirname fallback computes the same playwright-core
++// root structurally (this file lives at playwright-core/lib/server/utils/).
 +// Upstream: https://github.com/microsoft/playwright/issues/XXXXX (TODO: file)
-+let coreDir = "";
++let coreDir;
 +try {
 +  coreDir = import_path.default.dirname(require.resolve("../../../package.json"));
-+} catch {}
++} catch {
++  coreDir = import_path.default.resolve(__dirname, "../../..");
++}
  const nodePlatform = {
    name: "node",
    boxedStackPrefixes: () => {

--- a/patches/playwright-core@1.59.1.patch
+++ b/patches/playwright-core@1.59.1.patch
@@ -1,0 +1,21 @@
+diff --git a/lib/server/utils/nodePlatform.js b/lib/server/utils/nodePlatform.js
+index 80d88fedf2c4d2b7bea8cfd4b9c8db454dedaa1d..ca0a8d6aa6ac9f66e2a18e2970cb3be12b02c6f7 100644
+--- a/lib/server/utils/nodePlatform.js
++++ b/lib/server/utils/nodePlatform.js
+@@ -64,7 +64,15 @@ let boxedStackPrefixes = [];
+ function setBoxedStackPrefixes(prefixes) {
+   boxedStackPrefixes = prefixes;
+ }
+-const coreDir = import_path.default.dirname(require.resolve("../../../package.json"));
++// Wrapped in try-catch for Bun compiled binaries: require.resolve() with
++// relative paths gets converted to absolute build-machine paths that don't
++// exist at runtime. coreDir is only used for stack-trace filtering so an
++// empty fallback is safe.
++// Upstream: https://github.com/microsoft/playwright/issues/XXXXX (TODO: file)
++let coreDir = "";
++try {
++  coreDir = import_path.default.dirname(require.resolve("../../../package.json"));
++} catch {}
+ const nodePlatform = {
+   name: "node",
+   boxedStackPrefixes: () => {

--- a/patches/playwright-core@1.59.1.patch
+++ b/patches/playwright-core@1.59.1.patch
@@ -1,8 +1,8 @@
 diff --git a/lib/server/utils/nodePlatform.js b/lib/server/utils/nodePlatform.js
-index 80d88fedf2c4d2b7bea8cfd4b9c8db454dedaa1d..18eb6371f9efc3d0b0beef3b28815f98a902d4c2 100644
+index 80d88fedf2c4d2b7bea8cfd4b9c8db454dedaa1d..670f37ff62fd984361b7cfac62e54064a416139d 100644
 --- a/lib/server/utils/nodePlatform.js
 +++ b/lib/server/utils/nodePlatform.js
-@@ -64,7 +64,17 @@ let boxedStackPrefixes = [];
+@@ -64,7 +64,18 @@ let boxedStackPrefixes = [];
  function setBoxedStackPrefixes(prefixes) {
    boxedStackPrefixes = prefixes;
  }
@@ -11,11 +11,12 @@ index 80d88fedf2c4d2b7bea8cfd4b9c8db454dedaa1d..18eb6371f9efc3d0b0beef3b28815f98
 +// relative paths gets converted to absolute build-machine paths that don't
 +// exist at runtime. The __dirname fallback computes the same playwright-core
 +// root structurally (this file lives at playwright-core/lib/server/utils/).
-+// Upstream: https://github.com/microsoft/playwright/issues/XXXXX (TODO: file)
++// Upstream: https://github.com/oven-sh/bun/pull/29066
 +let coreDir;
 +try {
 +  coreDir = import_path.default.dirname(require.resolve("../../../package.json"));
-+} catch {
++} catch (e) {
++  if (e.code !== 'MODULE_NOT_FOUND') throw e;
 +  coreDir = import_path.default.resolve(__dirname, "../../..");
 +}
  const nodePlatform = {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -12,7 +12,7 @@ patchedDependencies:
     hash: e432fee0f54b7321d104a08ff5a38561d9c2cd3b002f34e6b8cbc2377889c9d2
     path: patches/@earendil-works__pi-tui.patch
   playwright-core@1.59.1:
-    hash: c3cf1b35f0627fac95ff87378468a27499e77c12786dc429c25481e11fedf7ff
+    hash: 5467c614923562b25446c3fb250e5d51e49f453894d68c4dce7dab93fa3baf88
     path: patches/playwright-core@1.59.1.patch
 
 importers:
@@ -3574,11 +3574,11 @@ snapshots:
 
   pkce-challenge@5.0.1: {}
 
-  playwright-core@1.59.1(patch_hash=c3cf1b35f0627fac95ff87378468a27499e77c12786dc429c25481e11fedf7ff): {}
+  playwright-core@1.59.1(patch_hash=5467c614923562b25446c3fb250e5d51e49f453894d68c4dce7dab93fa3baf88): {}
 
   playwright@1.59.1:
     dependencies:
-      playwright-core: 1.59.1(patch_hash=c3cf1b35f0627fac95ff87378468a27499e77c12786dc429c25481e11fedf7ff)
+      playwright-core: 1.59.1(patch_hash=5467c614923562b25446c3fb250e5d51e49f453894d68c4dce7dab93fa3baf88)
     optionalDependencies:
       fsevents: 2.3.2
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -12,7 +12,7 @@ patchedDependencies:
     hash: e432fee0f54b7321d104a08ff5a38561d9c2cd3b002f34e6b8cbc2377889c9d2
     path: patches/@earendil-works__pi-tui.patch
   playwright-core@1.59.1:
-    hash: 5467c614923562b25446c3fb250e5d51e49f453894d68c4dce7dab93fa3baf88
+    hash: 1f27acbc8250451c9eea2efa9b19956afcb881a2b7a69ad4550cf8e59f15e102
     path: patches/playwright-core@1.59.1.patch
 
 importers:
@@ -3574,11 +3574,11 @@ snapshots:
 
   pkce-challenge@5.0.1: {}
 
-  playwright-core@1.59.1(patch_hash=5467c614923562b25446c3fb250e5d51e49f453894d68c4dce7dab93fa3baf88): {}
+  playwright-core@1.59.1(patch_hash=1f27acbc8250451c9eea2efa9b19956afcb881a2b7a69ad4550cf8e59f15e102): {}
 
   playwright@1.59.1:
     dependencies:
-      playwright-core: 1.59.1(patch_hash=5467c614923562b25446c3fb250e5d51e49f453894d68c4dce7dab93fa3baf88)
+      playwright-core: 1.59.1(patch_hash=1f27acbc8250451c9eea2efa9b19956afcb881a2b7a69ad4550cf8e59f15e102)
     optionalDependencies:
       fsevents: 2.3.2
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11,6 +11,9 @@ patchedDependencies:
   '@earendil-works/pi-tui':
     hash: e432fee0f54b7321d104a08ff5a38561d9c2cd3b002f34e6b8cbc2377889c9d2
     path: patches/@earendil-works__pi-tui.patch
+  playwright-core@1.59.1:
+    hash: c3cf1b35f0627fac95ff87378468a27499e77c12786dc429c25481e11fedf7ff
+    path: patches/playwright-core@1.59.1.patch
 
 importers:
 
@@ -3571,11 +3574,11 @@ snapshots:
 
   pkce-challenge@5.0.1: {}
 
-  playwright-core@1.59.1: {}
+  playwright-core@1.59.1(patch_hash=c3cf1b35f0627fac95ff87378468a27499e77c12786dc429c25481e11fedf7ff): {}
 
   playwright@1.59.1:
     dependencies:
-      playwright-core: 1.59.1
+      playwright-core: 1.59.1(patch_hash=c3cf1b35f0627fac95ff87378468a27499e77c12786dc429c25481e11fedf7ff)
     optionalDependencies:
       fsevents: 2.3.2
 


### PR DESCRIPTION
## Fix Playwright detection failing in prebuilt release binaries

### Problem

When installing kimchi from prebuilt release artifacts (`curl -fsSL .../install.sh | bash`), Playwright is never detected — users always see the fallback warning:

> Playwright is not installed. Fetching with native HTTP client — JavaScript-rendered content (SPAs) will not be captured. Run `npx playwright install chromium` to enable full SPA support.

Installing locally via `pnpm run build:binary && pnpm run install:local` works fine.

### Root Cause

When Bun compiles the binary with `bun build --compile`, it converts relative `require.resolve()` calls inside bundled dependencies into **absolute paths from the build machine**.

In `playwright-core/lib/server/utils/nodePlatform.js`, the line:

```js
const coreDir = path.dirname(require.resolve("../../../package.json"));
```

gets compiled to:

```js
var coreDir = path.dirname(require.resolve("/Users/runner/work/kimchi/kimchi/node_modules/.pnpm/playwright-core@1.59.1/..."));
```

This `require.resolve()` runs at **module initialization time** (top-level `const`). On any machine other than the build machine, this path doesn't exist, so `require.resolve` throws, the entire playwright-core module fails to initialize, and the error propagates up through `loadPlaywright()` → `playwrightAvailable = false` → fallback warning.

**Local build works** because the hardcoded path points to the developer's own `node_modules` which still exist on the same machine. **Release build fails** because the path points to the CI runner's filesystem (`/Users/runner/work/kimchi/kimchi/...`).

### Fix

Added a pnpm patch for `playwright-core@1.59.1` that wraps the `coreDir` initialization in a try-catch. `coreDir` is only used for stack-trace filtering (hiding playwright internals from error traces), so an empty string fallback is functionally safe.

### Patch removal criteria

This patch can be removed when either:
- **Bun fixes `require.resolve` in compiled binaries** — Bun PR [#29066](https://github.com/oven-sh/bun/pull/29066) fixed `__dirname`/`__filename` but `require.resolve()` with relative paths still gets hardcoded.
- **Playwright upstream wraps this in a try-catch** themselves.

---
### Kimchi Summary
### What changed
Patches `playwright-core` to prevent runtime `MODULE_NOT_FOUND` errors in Bun compiled binaries by falling back to `__dirname`-based path resolution when `require.resolve()` fails.

### Why
Bun compiles relative `require.resolve()` calls into absolute build-machine paths that are invalid at runtime. This causes `playwright-core` to crash when locating its package root inside a compiled binary.

### Key changes
- `patches/playwright-core@1.59.1.patch`: Wraps `require.resolve("../../../package.json")` in `lib/server/utils/nodePlatform.js` with a try-catch block and falls back to `path.resolve(__dirname, "../../..")` on `MODULE_NOT_FOUND`.
- `package.json`: Registered `playwright-core@1.59.1` under `patchedDependencies`.
- `pnpm-lock.yaml`: Updated `playwright-core` snapshots to apply the new patch hash.

### Impact
- Enables `playwright-core` to function correctly when bundled in Bun compiled binaries.
- Existing non-compiled environments are unaffected because the fallback only triggers on missing modules.