### PR TITLE
feat: unify model selection into two-mode UX

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,21 +115,15 @@ Adding support for another coding agent (Cursor, Cline, Aider, Cody, ...) is a s
 
 The supported model list is fetched at startup from the kimchi metadata service.
 
-Use `/model` in the interactive CLI to switch between available models.
+Use `/model` or `ctrl+p` in the interactive CLI to switch between available models.
 
 ### Multi-model orchestration
 
-By default, kimchi runs in multi-model mode: the main agent classifies each task, executes what it can directly, and delegates the rest to specialised subagents picked from the available model roster.
+By default, kimchi runs in multi-model mode: the main agent classifies each task, executes what it can directly, and delegates the rest to specialised subagents picked from the available model roster. The footer shows `multi-model (kimi-k2.6)` when this mode is active.
 
-To disable orchestration and run as a single, direct coding assistant:
+To switch to single-model mode, use `ctrl+p` to cycle through models or open the `/model` picker and select a specific model. To re-enable multi-model, cycle with `ctrl+p` past the last model or select `multi-model` from the `/model` picker.
 
-```bash
-kimchi --multi-model=false
-```
-
-You can also toggle the mode at any time during a session with the **option/alt+tab** keyboard shortcut. The current state is shown in the footer (`multi-model: on` / `multi-model: off`).
-
-When multi-model is off the agent uses a single-model system prompt: environment, tools, research rules, guidelines, and phase tagging are all active, but task classification and delegation logic are disabled. The subagent tool is still available if you explicitly ask the agent to delegate a task.
+When using a single model the agent uses a single-model system prompt: environment, tools, research rules, guidelines, and phase tagging are all active, but task classification and delegation logic are disabled. The subagent tool is still available if you explicitly ask the agent to delegate a task.
 
 ### HTTP proxy
 

--- a/benchmark/manual/lib.sh
+++ b/benchmark/manual/lib.sh
@@ -121,11 +121,7 @@ bench_generate_runner_script() {
   local content
 
   if [[ "$runner_type" == "kimchi" ]]; then
-    # Determine extra flags per task
     local extra_flags=""
-    if [[ "$task_name" == "complex-single" ]]; then
-      extra_flags='  --multi-model=false \'
-    fi
 
     local setup_block=""
     if [[ -n "$setup_cmd" ]]; then

--- a/benchmark/manual/new-session.sh
+++ b/benchmark/manual/new-session.sh
@@ -70,7 +70,7 @@ binary           = os.environ["BINARY"]
 tasks = [
     ("simple",         simple_prompt,  [],                      True,  None),
     ("complex",        complex_prompt, [],                      True,  None),
-    ("complex-single", complex_prompt, ["--multi-model=false"], True,  None),
+    ("complex-single", complex_prompt, [], True,  None),
     ("research",       research_prompt,[],                      True,  None),
     ("explore",        explore_prompt, [],                      True,  f'mkdir -p "$DIR/usermgmt" && cp -R "{explore_seed}/." "$DIR/usermgmt/" && ls -la "$DIR/usermgmt/"'),
     ("mega",           mega_prompt,    [],                      False, None),

--- a/benchmark/terminal-bench-2/README.md
+++ b/benchmark/terminal-bench-2/README.md
@@ -83,13 +83,11 @@ MODEL=kimchi-dev/kimi-k2.5 ./scripts/run-local.sh -i terminal-bench/fix-git
 
 ### Single-model run (no orchestration)
 
-To benchmark a model on its own, bypassing kimchi's multi-model orchestration, pass `disable-multi-model=true`. The agent forwards `--multi-model=false` to kimchi.
+To benchmark a model on its own, bypassing kimchi's multi-model orchestration, pass `--model <provider>/<id>` to select a specific model. This starts kimchi in single-model mode.
 
 ```bash
-MODEL=kimchi-dev/minimax-m2.7 ./scripts/run-local.sh -n 8 --agent-kwarg disable-multi-model=true
+MODEL=kimchi-dev/minimax-m2.7 ./scripts/run-local.sh -n 8
 ```
-
-The kwarg is named `disable-multi-model` (not `multi-model=false`) because harbor's `parse_kwargs` JSON-decodes `false` into Python `bool`, which the `str`/`enum` `CliFlag` coercers reject — and `bool`-typed flags only emit when truthy, so they can't render `--multi-model=false` directly.
 
 ### One-shot ferment per task
 

--- a/patches/@earendil-works__pi-coding-agent.patch
+++ b/patches/@earendil-works__pi-coding-agent.patch
@@ -162,3 +162,93 @@ index fe7086d4b68a38a945016ea4274f6c6a8093f5b5..2880acd74317eddfce891ef935fa16f0
          this.contentBox.addChild(new Markdown(text, 0, 0, markdownTheme, {
              color: (content) => theme.fg("userMessageText", content),
          }));
+diff --git a/dist/modes/interactive/components/model-selector.js b/dist/modes/interactive/components/model-selector.js
+index 879b90f6c1f150a30d05af9f09455b93b5dd15f0..91401aa8880f52d847605a27a920b2d6e9cb6505 100644
+--- a/dist/modes/interactive/components/model-selector.js
++++ b/dist/modes/interactive/components/model-selector.js
+@@ -117,6 +117,16 @@ export class ModelSelectorComponent extends Container {
+             return;
+         }
+         this.allModels = this.sortModels(models);
++        // Inject multi-model orchestration entry at the top
++        const orchestratorEntry = models.find(m => m.id === "kimi-k2.6");
++        if (orchestratorEntry) {
++            this.allModels.unshift({
++                provider: "orchestration",
++                id: "multi-model",
++                model: orchestratorEntry.model,
++                _isMultiModel: true,
++            });
++        }
+         this.scopedModels = this.scopedModels.map((scoped) => {
+             const refreshed = this.modelRegistry.find(scoped.model.provider, scoped.model.id);
+             return refreshed ? { ...scoped, model: refreshed } : scoped;
+@@ -184,17 +194,21 @@ export class ModelSelectorComponent extends Container {
+             if (!item)
+                 continue;
+             const isSelected = i === this.selectedIndex;
+-            const isCurrent = modelsAreEqual(this.currentModel, item.model);
++            const isMultiModelEnabled = !!process.__kimchiMultiModelEnabled;
++            const isCurrent = item._isMultiModel
++                ? isMultiModelEnabled
++                : !isMultiModelEnabled && modelsAreEqual(this.currentModel, item.model);
++            const displayId = item._isMultiModel ? "multi-model" : item.id;
+             let line = "";
+             if (isSelected) {
+                 const prefix = theme.fg("accent", "→ ");
+-                const modelText = `${item.id}`;
++                const modelText = `${displayId}`;
+                 const providerBadge = theme.fg("muted", `[${item.provider}]`);
+                 const checkmark = isCurrent ? theme.fg("success", " ✓") : "";
+                 line = `${prefix + theme.fg("accent", modelText)} ${providerBadge}${checkmark}`;
+             }
+             else {
+-                const modelText = `  ${item.id}`;
++                const modelText = `  ${displayId}`;
+                 const providerBadge = theme.fg("muted", `[${item.provider}]`);
+                 const checkmark = isCurrent ? theme.fg("success", " ✓") : "";
+                 line = `${modelText} ${providerBadge}${checkmark}`;
+@@ -267,6 +281,13 @@ export class ModelSelectorComponent extends Container {
+         }
+     }
+     handleSelect(model) {
++        // Signal multi-model selection so kimchi can detect it
++        const selectedItem = this.filteredModels[this.selectedIndex];
++        if (selectedItem?._isMultiModel) {
++            process.__kimchiMultiModelPending = true;
++        } else {
++            process.__kimchiMultiModelEnabled = false;
++        }
+         // Save as new default
+         this.settingsManager.setDefaultModelAndProvider(model.provider, model.id);
+         this.onSelectCallback(model);
+diff --git a/dist/modes/interactive/interactive-mode.js b/dist/modes/interactive/interactive-mode.js
+index 408e38417da84ba9e729cfd5f3dd95b285e57e91..5d4225f409fd7e4ef7dfcbda5e16fded6910a5ed 100644
+--- a/dist/modes/interactive/interactive-mode.js
++++ b/dist/modes/interactive/interactive-mode.js
+@@ -3301,6 +3301,25 @@ ${chalk.cyan("Tip:")} ${this.getTip()}`;
+             this.showModelSelector();
+             return;
+         }
++        // Handle "multi-model" as a virtual model selection
++        if (searchTerm === "multi-model") {
++            const orchestratorModel = this.session.modelRegistry.find("kimchi-dev", "kimi-k2.6");
++            if (orchestratorModel) {
++                process.__kimchiMultiModelPending = true;
++                try {
++                    await this.session.setModel(orchestratorModel);
++                    this.footer.invalidate();
++                    this.updateEditorBorderColor();
++                    this.showStatus("Model: multi-model");
++                } catch (error) {
++                    delete process.__kimchiMultiModelPending;
++                    this.showError(error instanceof Error ? error.message : String(error));
++                }
++            } else {
++                this.showError("Multi-model orchestrator (kimi-k2.6) is not available.");
++            }
++            return;
++        }
+         const model = await this.findExactModelMatch(searchTerm);
+         if (model) {
+             try {

--- a/patches/@earendil-works__pi-coding-agent.patch
+++ b/patches/@earendil-works__pi-coding-agent.patch
@@ -208,17 +208,12 @@ index 879b90f6c1f150a30d05af9f09455b93b5dd15f0..91401aa8880f52d847605a27a920b2d6
                  const providerBadge = theme.fg("muted", `[${item.provider}]`);
                  const checkmark = isCurrent ? theme.fg("success", " ✓") : "";
                  line = `${modelText} ${providerBadge}${checkmark}`;
-@@ -267,6 +281,13 @@ export class ModelSelectorComponent extends Container {
+@@ -267,6 +281,8 @@ export class ModelSelectorComponent extends Container {
          }
      }
      handleSelect(model) {
-+        // Signal multi-model selection so kimchi can detect it
 +        const selectedItem = this.filteredModels[this.selectedIndex];
-+        if (selectedItem?._isMultiModel) {
-+            process.__kimchiMultiModelPending = true;
-+        } else {
-+            process.__kimchiMultiModelEnabled = false;
-+        }
++        process.__kimchiMultiModelEnabled = !!selectedItem?._isMultiModel;
          // Save as new default
          this.settingsManager.setDefaultModelAndProvider(model.provider, model.id);
          this.onSelectCallback(model);
@@ -234,14 +229,14 @@ index 408e38417da84ba9e729cfd5f3dd95b285e57e91..5d4225f409fd7e4ef7dfcbda5e16fded
 +        if (searchTerm === "multi-model") {
 +            const orchestratorModel = this.session.modelRegistry.find("kimchi-dev", "kimi-k2.6");
 +            if (orchestratorModel) {
-+                process.__kimchiMultiModelPending = true;
++                process.__kimchiMultiModelEnabled = true;
 +                try {
 +                    await this.session.setModel(orchestratorModel);
 +                    this.footer.invalidate();
 +                    this.updateEditorBorderColor();
 +                    this.showStatus("Model: multi-model");
 +                } catch (error) {
-+                    delete process.__kimchiMultiModelPending;
++                    process.__kimchiMultiModelEnabled = false;
 +                    this.showError(error instanceof Error ? error.message : String(error));
 +                }
 +            } else {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6,7 +6,7 @@ settings:
 
 patchedDependencies:
   '@earendil-works/pi-coding-agent':
-    hash: 4785605e3a4803fd16997a45b591e1ebaea55506797d5fdc4e56639d4d1531b4
+    hash: 3c383f24896add875711770afae8352e36e7d6a48455ad7615f59fdfff729556
     path: patches/@earendil-works__pi-coding-agent.patch
   '@earendil-works/pi-tui':
     hash: e432fee0f54b7321d104a08ff5a38561d9c2cd3b002f34e6b8cbc2377889c9d2
@@ -24,7 +24,7 @@ importers:
         version: 1.3.0
       '@earendil-works/pi-coding-agent':
         specifier: ^0.75.1
-        version: 0.75.1(patch_hash=4785605e3a4803fd16997a45b591e1ebaea55506797d5fdc4e56639d4d1531b4)(@modelcontextprotocol/sdk@1.29.0(zod@4.4.3))(ws@8.20.1)(zod@4.4.3)
+        version: 0.75.1(patch_hash=3c383f24896add875711770afae8352e36e7d6a48455ad7615f59fdfff729556)(@modelcontextprotocol/sdk@1.29.0(zod@4.4.3))(ws@8.20.1)(zod@4.4.3)
       '@earendil-works/pi-tui':
         specifier: ^0.75.1
         version: 0.75.1(patch_hash=e432fee0f54b7321d104a08ff5a38561d9c2cd3b002f34e6b8cbc2377889c9d2)
@@ -2375,7 +2375,7 @@ snapshots:
       - ws
       - zod
 
-  '@earendil-works/pi-coding-agent@0.75.1(patch_hash=4785605e3a4803fd16997a45b591e1ebaea55506797d5fdc4e56639d4d1531b4)(@modelcontextprotocol/sdk@1.29.0(zod@4.4.3))(ws@8.20.1)(zod@4.4.3)':
+  '@earendil-works/pi-coding-agent@0.75.1(patch_hash=3c383f24896add875711770afae8352e36e7d6a48455ad7615f59fdfff729556)(@modelcontextprotocol/sdk@1.29.0(zod@4.4.3))(ws@8.20.1)(zod@4.4.3)':
     dependencies:
       '@earendil-works/pi-agent-core': 0.75.1(@modelcontextprotocol/sdk@1.29.0(zod@4.4.3))(ws@8.20.1)(zod@4.4.3)
       '@earendil-works/pi-ai': 0.75.1(@modelcontextprotocol/sdk@1.29.0(zod@4.4.3))(ws@8.20.1)(zod@4.4.3)

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6,7 +6,7 @@ settings:
 
 patchedDependencies:
   '@earendil-works/pi-coding-agent':
-    hash: 3c383f24896add875711770afae8352e36e7d6a48455ad7615f59fdfff729556
+    hash: 5f611222f23d465ba6b392ac0eb0c5ed1b0745525ad106d827967b62cc724d3c
     path: patches/@earendil-works__pi-coding-agent.patch
   '@earendil-works/pi-tui':
     hash: e432fee0f54b7321d104a08ff5a38561d9c2cd3b002f34e6b8cbc2377889c9d2
@@ -24,7 +24,7 @@ importers:
         version: 1.3.0
       '@earendil-works/pi-coding-agent':
         specifier: ^0.75.1
-        version: 0.75.1(patch_hash=3c383f24896add875711770afae8352e36e7d6a48455ad7615f59fdfff729556)(@modelcontextprotocol/sdk@1.29.0(zod@4.4.3))(ws@8.20.1)(zod@4.4.3)
+        version: 0.75.1(patch_hash=5f611222f23d465ba6b392ac0eb0c5ed1b0745525ad106d827967b62cc724d3c)(@modelcontextprotocol/sdk@1.29.0(zod@4.4.3))(ws@8.20.1)(zod@4.4.3)
       '@earendil-works/pi-tui':
         specifier: ^0.75.1
         version: 0.75.1(patch_hash=e432fee0f54b7321d104a08ff5a38561d9c2cd3b002f34e6b8cbc2377889c9d2)
@@ -2375,7 +2375,7 @@ snapshots:
       - ws
       - zod
 
-  '@earendil-works/pi-coding-agent@0.75.1(patch_hash=3c383f24896add875711770afae8352e36e7d6a48455ad7615f59fdfff729556)(@modelcontextprotocol/sdk@1.29.0(zod@4.4.3))(ws@8.20.1)(zod@4.4.3)':
+  '@earendil-works/pi-coding-agent@0.75.1(patch_hash=5f611222f23d465ba6b392ac0eb0c5ed1b0745525ad106d827967b62cc724d3c)(@modelcontextprotocol/sdk@1.29.0(zod@4.4.3))(ws@8.20.1)(zod@4.4.3)':
     dependencies:
       '@earendil-works/pi-agent-core': 0.75.1(@modelcontextprotocol/sdk@1.29.0(zod@4.4.3))(ws@8.20.1)(zod@4.4.3)
       '@earendil-works/pi-ai': 0.75.1(@modelcontextprotocol/sdk@1.29.0(zod@4.4.3))(ws@8.20.1)(zod@4.4.3)

--- a/src/components/footer.test.ts
+++ b/src/components/footer.test.ts
@@ -5,7 +5,7 @@ import * as AGENTS from "../extensions/agents/index.js"
 import * as FERMENT from "../extensions/ferment/index.js"
 import * as ORCHESTRATION from "../extensions/prompt-construction/prompt-enrichment.js"
 import * as TAGS from "../extensions/tags.js"
-import { SHORTCUT_TAIL, StatsFooter, buildContextCompact, buildMultiModelAbbrev, buildPhaseCompact } from "./footer.js"
+import { SHORTCUT_TAIL, StatsFooter, buildContextCompact, buildModelAbbrev, buildPhaseCompact } from "./footer.js"
 
 // biome-ignore lint/suspicious/noControlCharactersInRegex: ANSI escape stripping in test assertions
 const ANSI_ESCAPE = /\x1b\[[\d;]*m/g
@@ -172,17 +172,18 @@ describe("compact-form builders", () => {
 		})
 	})
 
-	describe("buildMultiModelAbbrev", () => {
-		it("uses `m-m:` instead of `multi-model:` when enabled", () => {
-			const seg = buildMultiModelAbbrev(compactCtx, true)
-			expect(seg.id).toBe("multi-model")
-			expect(seg.text).toBe(`m-m: on \u2192 ${ORCHESTRATION.MULTI_MODEL_SHORTCUT}`)
-			expect(seg.raw).toEqual({ kind: "multi-model", enabled: true })
+	describe("buildModelAbbrev", () => {
+		it("abbreviates multi-model label", () => {
+			const seg = buildModelAbbrev(compactCtx, true, "kimi-k2.6")
+			expect(seg.id).toBe("model")
+			expect(seg.text).toBe("m-m (kimi-k2.6) \u2192 ctrl+p")
+			expect(seg.raw).toEqual({ kind: "model", multiModel: true, modelId: "kimi-k2.6" })
 		})
 
-		it("shows `off` when disabled", () => {
-			const seg = buildMultiModelAbbrev(compactCtx, false)
-			expect(seg.text).toBe(`m-m: off \u2192 ${ORCHESTRATION.MULTI_MODEL_SHORTCUT}`)
+		it("keeps model id when not multi-model", () => {
+			const seg = buildModelAbbrev(compactCtx, false, "claude-opus-4-7")
+			expect(seg.text).toBe("claude-opus-4-7 \u2192 ctrl+p")
+			expect(seg.raw).toEqual({ kind: "model", multiModel: false, modelId: "claude-opus-4-7" })
 		})
 	})
 
@@ -209,10 +210,10 @@ describe("SHORTCUT_TAIL regex", () => {
 		expect(text.replace(SHORTCUT_TAIL, "")).toBe("\u25cf default")
 	})
 
-	it("matches the multi-model trailing shortcut", () => {
-		const text = "multi-model: on \x1b[38;5;242m\u2192 alt+m\x1b[39m"
+	it("matches the model segment trailing shortcut", () => {
+		const text = "multi-model (kimi-k2.6) \x1b[38;5;242m\u2192 ctrl+p\x1b[39m"
 		expect(SHORTCUT_TAIL.test(text)).toBe(true)
-		expect(text.replace(SHORTCUT_TAIL, "")).toBe("multi-model: on")
+		expect(text.replace(SHORTCUT_TAIL, "")).toBe("multi-model (kimi-k2.6)")
 	})
 
 	it("matches the ferment trailing shortcut", () => {
@@ -272,45 +273,34 @@ describe("StatsFooter behavioural acceptance at representative widths", () => {
 	it("width 160: full footer + `/ for commands` hint, padded to width", () => {
 		const { raw, visible } = renderAt(160)
 		expect(visible).toContain("\u25cf default \u2192 shift+tab")
-		expect(visible).toContain(`multi-model: on \u2192 ${ORCHESTRATION.MULTI_MODEL_SHORTCUT}`)
-		expect(visible).not.toContain("claude-opus-4-6")
+		expect(visible).toContain("multi-model (claude-opus-4-7) \u2192 ctrl+p")
 		expect(visible).toContain("0% ctx")
 		expect(visible).toContain("phase:explore")
 		expect(visible).toContain("/ for commands")
-		// When the hint fits, the line is padded to exactly `width` columns
-		// (with whitespace between the segments and the right-aligned hint).
 		expect(visibleWidth(raw)).toBe(160)
-		// The hint sits at the right edge.
 		expect(visible.endsWith("/ for commands")).toBe(true)
 	})
 
 	it("width 100: hint dropped, remaining segments still present", () => {
 		const { raw, visible } = renderAt(100)
-		// Hint gone (step 1)
 		expect(visible).not.toContain("/ for commands")
-		// Line fits.
 		expect(visibleWidth(raw)).toBeLessThanOrEqual(100)
-		// All segments still present.
 		expect(visible).toContain("default")
 		expect(visible).toContain("multi-model")
-		expect(visible).not.toContain("claude-opus-4-6")
 		expect(visible).toContain("0% ctx")
 		expect(visible).toContain("phase:explore")
 	})
 
-	it("width 60: shortcuts stripped, multi-model abbreviated", () => {
+	it("width 60: shortcuts stripped, model abbreviated", () => {
 		const { raw, visible } = renderAt(60)
 		expect(visibleWidth(raw)).toBeLessThanOrEqual(60)
 		expect(visible).not.toContain("/ for commands")
 		expect(visible).not.toContain("shift+tab")
-		expect(visible).not.toContain(ORCHESTRATION.MULTI_MODEL_SHORTCUT)
-		// multi-model label is abbreviated to `m-m:`.
-		expect(visible).toContain("m-m:")
-		expect(visible).not.toContain("multi-model:")
+		expect(visible).not.toContain("ctrl+p")
+		// multi-model label is abbreviated to `m-m`.
+		expect(visible).toContain("m-m")
 		// phase value survives.
 		expect(visible).toContain("explore")
-		// Model segment is hidden in multi-model mode.
-		expect(visible).not.toContain("claude-opus-4-6")
 	})
 
 	it("width 20: line is hard-truncated to fit, leftmost content survives", () => {

--- a/src/components/footer.test.ts
+++ b/src/components/footer.test.ts
@@ -273,7 +273,7 @@ describe("StatsFooter behavioural acceptance at representative widths", () => {
 	it("width 160: full footer + `/ for commands` hint, padded to width", () => {
 		const { raw, visible } = renderAt(160)
 		expect(visible).toContain("\u25cf default \u2192 shift+tab")
-		expect(visible).toContain("multi-model (claude-opus-4-7) \u2192 ctrl+p")
+		expect(visible).toContain("multi-model (claude-opus-4-6) \u2192 ctrl+p")
 		expect(visible).toContain("0% ctx")
 		expect(visible).toContain("phase:explore")
 		expect(visible).toContain("/ for commands")

--- a/src/components/footer.ts
+++ b/src/components/footer.ts
@@ -11,21 +11,11 @@ import { formatFermentFooterDisplay } from "../extensions/ferment/footer-status.
 import { getActiveFerment, getFermentContinuationPolicy } from "../extensions/ferment/index.js"
 import { formatCount } from "../extensions/format.js"
 import { getCurrentPermissionsMode } from "../extensions/permissions/index.js"
-import { MULTI_MODEL_SHORTCUT, getMultiModelEnabled } from "../extensions/prompt-construction/prompt-enrichment.js"
+import { ORCHESTRATOR_MODEL_ID, getMultiModelEnabled } from "../extensions/prompt-construction/prompt-enrichment.js"
 import { getActiveTags, getCurrentPhase, parseTag } from "../extensions/tags.js"
 
 /** Stable identifier used by compaction steps to find segments. */
-type SegmentId =
-	| "permissions"
-	| "multi-model"
-	| "model"
-	| "ferment"
-	| "agents"
-	| "context"
-	| "usage"
-	| "phase"
-	| "tags"
-	| "team"
+type SegmentId = "permissions" | "model" | "ferment" | "agents" | "context" | "usage" | "phase" | "tags" | "team"
 
 /** Raw inputs preserved on segments that have compact forms, so compaction
  *  steps can rebuild the colorized text without round-tripping through ANSI.
@@ -36,7 +26,7 @@ type SegmentId =
  *  and the segment's tail is identical in both forms anyway. */
 type SegmentRaw =
 	| { kind: "context"; percent: number; pctColor?: "error" | "warning" }
-	| { kind: "multi-model"; enabled: boolean }
+	| { kind: "model"; multiModel: boolean; modelId: string }
 	| { kind: "phase"; phase: string }
 	| { kind: "ferment"; prefix: string; prefixWidth: number }
 
@@ -190,16 +180,15 @@ export function buildContextCompact(ctx: CompactionContext, percent: number, pct
 	}
 }
 
-/** Compact form for multi-model: replaces "multi-model:" with "m-m:". */
-export function buildMultiModelAbbrev(ctx: CompactionContext, enabled: boolean): Segment {
-	const label = enabled ? ctx.accent("on") : ctx.dim("off")
-	const shortcut = MULTI_MODEL_SHORTCUT
-	const text = `${ctx.dim("m-m:")} ${label} ${ctx.dim(`→ ${shortcut}`)}`
+/** Compact form for model: abbreviates "multi-model (kimi-k2.6)" to "m-m (kimi-k2.6)". */
+export function buildModelAbbrev(ctx: CompactionContext, multiModel: boolean, modelId: string): Segment {
+	const label = multiModel ? `m-m (${modelId})` : modelId
+	const text = `${ctx.accent(label)} ${ctx.dim("→ ctrl+p")}`
 	return {
-		id: "multi-model",
+		id: "model",
 		text,
 		width: visibleWidth(text),
-		raw: { kind: "multi-model", enabled },
+		raw: { kind: "model", multiModel, modelId },
 	}
 }
 
@@ -285,13 +274,13 @@ const STEPS: CompactionStep[] = [
 			recompactSegment(segs, "context", "context", (raw) => buildContextCompact(ctx, raw.percent, raw.pctColor)),
 	},
 	{
-		name: "abbrev-multi-model-label",
+		name: "abbrev-model-label",
 		apply: (segs, ctx) =>
-			recompactSegment(segs, "multi-model", "multi-model", (raw) => buildMultiModelAbbrev(ctx, raw.enabled)),
+			recompactSegment(segs, "model", "model", (raw) => buildModelAbbrev(ctx, raw.multiModel, raw.modelId)),
 	},
 	{
 		name: "drop-shortcut-hints",
-		apply: (segs) => stripShortcutHintsAcross(segs, ["permissions", "multi-model", "ferment"]),
+		apply: (segs) => stripShortcutHintsAcross(segs, ["permissions", "model", "ferment"]),
 	},
 	{
 		name: "drop-phase-prefix",
@@ -375,11 +364,12 @@ export class StatsFooter implements Component {
 		return `${ansi}${s}${RST_FG}`
 	}
 
-	private modelSegment(): Segment | null {
-		if (getMultiModelEnabled()) return null
-		const modelId = this.ctx.model?.id ?? "n/a"
-		const text = this.accent(modelId)
-		return { id: "model", text, width: visibleWidth(text) }
+	private modelSegment(): Segment {
+		const multiModel = getMultiModelEnabled()
+		const rawModelId = this.ctx.model?.id ?? "n/a"
+		const label = multiModel ? `multi-model (${rawModelId})` : rawModelId
+		const text = `${this.accent(label)} ${this.dim("→ ctrl+p")}`
+		return { id: "model", text, width: visibleWidth(text), raw: { kind: "model", multiModel, modelId: rawModelId } }
 	}
 
 	private usageSegment(): Segment | null {
@@ -443,14 +433,6 @@ export class StatsFooter implements Component {
 		return { id: "permissions", text: mode, width: visibleWidth(mode) }
 	}
 
-	private multiModelSegment(): Segment {
-		const enabled = getMultiModelEnabled()
-		const label = enabled ? this.accent("on") : this.dim("off")
-		const shortcut = MULTI_MODEL_SHORTCUT
-		const text = `${this.dim("multi-model:")} ${label} ${this.dim(`→ ${shortcut}`)}`
-		return { id: "multi-model", text, width: visibleWidth(text), raw: { kind: "multi-model", enabled } }
-	}
-
 	private subagentSegment(): Segment | null {
 		const count = getActiveAgentCount()
 		if (count === 0) return null
@@ -497,7 +479,6 @@ export class StatsFooter implements Component {
 		const segments: Segment[] = [
 			this.fermentSegment(),
 			this.permissionsSegment(),
-			this.multiModelSegment(),
 			this.modelSegment(),
 			this.subagentSegment(),
 			this.contextSegment(),

--- a/src/extensions/agents/index.ts
+++ b/src/extensions/agents/index.ts
@@ -422,6 +422,15 @@ export function getActiveAgentCount(): number {
 	return activeManager?.getRunningCount() ?? 0
 }
 
+export function getActiveAgentModelIds(): string[] {
+	if (!activeManager) return []
+	return activeManager
+		.listAgents()
+		.filter((a) => a.status === "running" || a.status === "queued")
+		.map((a) => a.modelId)
+		.filter((id): id is string => id != null)
+}
+
 export default function (pi: ExtensionAPI) {
 	pi.on("message_start", (event) => {
 		if (event.message.role === "user") budgetRetryBlock = undefined

--- a/src/extensions/agents/manager/agent-manager.ts
+++ b/src/extensions/agents/manager/agent-manager.ts
@@ -92,6 +92,7 @@ export class AgentManager {
 			description: options.description,
 			visibility: options.visibility ?? "user",
 			status: options.isBackground ? "queued" : "running",
+			modelId: (options.model as { id?: string } | undefined)?.id,
 			toolUses: 0,
 			startedAt: Date.now(),
 			abortController,

--- a/src/extensions/agents/personas/types.ts
+++ b/src/extensions/agents/personas/types.ts
@@ -105,6 +105,7 @@ export interface AgentRecord {
 	/** user = visible in UI/notifications; system = hidden technical/background work. */
 	visibility: AgentVisibility
 	status: "queued" | "running" | "completed" | "steered" | "aborted" | "stopped" | "error"
+	modelId?: string
 	abortReason?: AgentAbortReason
 	result?: string
 	error?: string

--- a/src/extensions/agents/ui/agent-widget.ts
+++ b/src/extensions/agents/ui/agent-widget.ts
@@ -209,6 +209,7 @@ export class AgentWidget {
 			completedAt?: number
 			error?: string
 			abortReason?: AgentAbortReason
+			modelId?: string
 		},
 		theme: Theme,
 	): string {
@@ -245,7 +246,8 @@ export class AgentWidget {
 		parts.push(duration)
 
 		const modeTag = modeLabel ? ` ${theme.fg("dim", `(${modeLabel})`)}` : ""
-		return `${icon} ${theme.fg("dim", name)}${modeTag}  ${theme.fg("dim", a.description)} ${theme.fg("dim", "·")} ${theme.fg("dim", parts.join(" · "))}${statusText}`
+		const modelTag = a.modelId ? ` ${theme.fg("dim", `[${a.modelId}]`)}` : ""
+		return `${icon} ${theme.fg("dim", name)}${modeTag}${modelTag}  ${theme.fg("dim", a.description)} ${theme.fg("dim", "·")} ${theme.fg("dim", parts.join(" · "))}${statusText}`
 	}
 
 	private renderWidget(theme: Theme, width: number): string[] {
@@ -294,9 +296,10 @@ export class AgentWidget {
 
 			const activity = bg ? describeActivity(bg.activeTools, bg.responseText) : "thinking…"
 
+			const modelTag = a.modelId ? ` ${theme.fg("dim", `[${a.modelId}]`)}` : ""
 			runningLines.push([
 				truncate(
-					`${theme.fg("dim", "├─")} ${theme.fg("accent", frame)} ${theme.bold(name)}${modeTag}  ${theme.fg("muted", a.description)} ${theme.fg("dim", "·")} ${theme.fg("dim", statsText)}`,
+					`${theme.fg("dim", "├─")} ${theme.fg("accent", frame)} ${theme.bold(name)}${modeTag}${modelTag}  ${theme.fg("muted", a.description)} ${theme.fg("dim", "·")} ${theme.fg("dim", statsText)}`,
 				),
 				truncate(theme.fg("dim", "│  ") + theme.fg("dim", `  ⎿  ${activity}`)),
 			])

--- a/src/extensions/model-switch.test.ts
+++ b/src/extensions/model-switch.test.ts
@@ -3,6 +3,7 @@ import { beforeEach, describe, expect, it, vi } from "vitest"
 import createModelGuardExtension from "./model-guard.js"
 import { __resetImagesDetectedForTest, sessionHasImages } from "./model-guard.js"
 import modelSwitchExtension, { __resetModelSwitchStateForTest, getModelTier } from "./model-switch.js"
+import { getMultiModelEnabled, setMultiModelEnabled } from "./prompt-construction/prompt-enrichment.js"
 
 type RegisteredTool = {
 	name: string
@@ -735,6 +736,27 @@ describe("modelSwitchExtension", () => {
 				mockCtx({ tokens: 10_000, ui: { notify } }),
 			)
 			expect(notify).not.toHaveBeenCalled()
+		})
+
+		it("syncs multi-model process flag to extension state on model_select from /models UI", async () => {
+			const { pi, trigger } = createHarnessWithTrigger()
+			modelSwitchExtension(pi)
+
+			setMultiModelEnabled(true)
+			;(process as NodeJS.Process & { __kimchiMultiModelEnabled?: boolean }).__kimchiMultiModelEnabled = false
+
+			await trigger(
+				"model_select",
+				{
+					type: "model_select",
+					model: { id: "nemotron-3-super-fp4", provider: "kimchi-dev", input: ["text"], contextWindow: 1_000_000 },
+					previousModel: { id: "kimi-k2.6", provider: "kimchi-dev", input: ["text", "image"] },
+					source: "set",
+				},
+				mockCtx({ tokens: 10_000 }),
+			)
+
+			expect(getMultiModelEnabled()).toBe(false)
 		})
 	})
 })

--- a/src/extensions/model-switch.ts
+++ b/src/extensions/model-switch.ts
@@ -183,19 +183,6 @@ export default function modelSwitchExtension(pi: ExtensionAPI) {
 		// Skip if ferment is reverting (its own rollback path)
 		if (isRestoringModel()) return
 
-		// Detect multi-model selection from the /model picker (framework patch sets this flag)
-		const proc = process as NodeJS.Process & { __kimchiMultiModelPending?: boolean }
-		if (proc.__kimchiMultiModelPending) {
-			proc.__kimchiMultiModelPending = undefined
-			setMultiModelEnabled(true)
-			return
-		}
-
-		// User explicitly selected a specific model via /model picker — exit multi-model mode
-		if (event.source === "set") {
-			setMultiModelEnabled(false)
-		}
-
 		// Nothing to revert to
 		if (!event.previousModel) return
 

--- a/src/extensions/model-switch.ts
+++ b/src/extensions/model-switch.ts
@@ -5,6 +5,7 @@ import { isRestoringModel } from "./ferment/state.js"
 import { contextFitsModel, getSafeContextWindow, sessionHasImages } from "./model-guard.js"
 import { MODEL_CAPABILITIES } from "./orchestration/model-registry/builtin-models.js"
 import type { ModelTier } from "./orchestration/model-registry/types.js"
+import { ORCHESTRATOR_MODEL_ID, setMultiModelEnabled } from "./prompt-construction/prompt-enrichment.js"
 
 /** Tier ordering for downgrade detection: higher index = lower tier. */
 const TIER_ORDER: ModelTier[] = ["heavy", "standard", "light"]
@@ -49,6 +50,33 @@ export default function modelSwitchExtension(pi: ExtensionAPI) {
 		}),
 		async execute(_toolCallId, params, _signal, _onUpdate, ctx) {
 			const { model } = params
+
+			if (model === "multi-model") {
+				const orchestrator = ctx.modelRegistry?.find("kimchi-dev", ORCHESTRATOR_MODEL_ID)
+				if (!orchestrator) {
+					return {
+						content: [{ type: "text" as const, text: "Multi-model orchestrator (kimi-k2.6) is not available." }],
+						details: null,
+					}
+				}
+				setMultiModelEnabled(true)
+				suppressModelSelectGuard = true
+				try {
+					await pi.setModel(orchestrator)
+				} finally {
+					suppressModelSelectGuard = false
+				}
+				return {
+					content: [
+						{
+							type: "text" as const,
+							text: `Switched to multi-model mode (orchestrator: ${ORCHESTRATOR_MODEL_ID})`,
+						},
+					],
+					details: null,
+				}
+			}
+
 			const parts = model.split("/")
 			if (parts.length !== 2 || !parts[0] || !parts[1]) {
 				const available =
@@ -60,7 +88,7 @@ export default function modelSwitchExtension(pi: ExtensionAPI) {
 					content: [
 						{
 							type: "text" as const,
-							text: `Invalid model format: "${model}". Expected "provider/modelId".\n\nAvailable models:\n${available.join("\n")}`,
+							text: `Invalid model format: "${model}". Expected "provider/modelId" or "multi-model".\n\nAvailable models:\nmulti-model\n${available.join("\n")}`,
 						},
 					],
 					details: null,
@@ -113,6 +141,7 @@ export default function modelSwitchExtension(pi: ExtensionAPI) {
 				}
 			}
 
+			setMultiModelEnabled(false)
 			let ok: boolean
 			suppressModelSelectGuard = true
 			try {
@@ -153,6 +182,20 @@ export default function modelSwitchExtension(pi: ExtensionAPI) {
 		if (event.source === "cycle" || event.source === "restore") return
 		// Skip if ferment is reverting (its own rollback path)
 		if (isRestoringModel()) return
+
+		// Detect multi-model selection from the /model picker (framework patch sets this flag)
+		const proc = process as NodeJS.Process & { __kimchiMultiModelPending?: boolean }
+		if (proc.__kimchiMultiModelPending) {
+			proc.__kimchiMultiModelPending = undefined
+			setMultiModelEnabled(true)
+			return
+		}
+
+		// User explicitly selected a specific model via /model picker — exit multi-model mode
+		if (event.source === "set") {
+			setMultiModelEnabled(false)
+		}
+
 		// Nothing to revert to
 		if (!event.previousModel) return
 

--- a/src/extensions/model-switch.ts
+++ b/src/extensions/model-switch.ts
@@ -5,7 +5,11 @@ import { isRestoringModel } from "./ferment/state.js"
 import { contextFitsModel, getSafeContextWindow, sessionHasImages } from "./model-guard.js"
 import { MODEL_CAPABILITIES } from "./orchestration/model-registry/builtin-models.js"
 import type { ModelTier } from "./orchestration/model-registry/types.js"
-import { ORCHESTRATOR_MODEL_ID, setMultiModelEnabled } from "./prompt-construction/prompt-enrichment.js"
+import {
+	ORCHESTRATOR_MODEL_ID,
+	getMultiModelEnabled,
+	setMultiModelEnabled,
+} from "./prompt-construction/prompt-enrichment.js"
 
 /** Tier ordering for downgrade detection: higher index = lower tier. */
 const TIER_ORDER: ModelTier[] = ["heavy", "standard", "light"]
@@ -182,6 +186,13 @@ export default function modelSwitchExtension(pi: ExtensionAPI) {
 		if (event.source === "cycle" || event.source === "restore") return
 		// Skip if ferment is reverting (its own rollback path)
 		if (isRestoringModel()) return
+
+		// Flush the multi-model flag that the harness /models UI sets via
+		// process.__kimchiMultiModelEnabled.  getMultiModelEnabled() detects a
+		// mismatch between the process flag and the extension variable and
+		// persists it to disk.  Without this, the disk value can go stale if the
+		// session ends before the footer polls the flag.
+		getMultiModelEnabled()
 
 		// Nothing to revert to
 		if (!event.previousModel) return

--- a/src/extensions/permissions/keybindings.ts
+++ b/src/extensions/permissions/keybindings.ts
@@ -52,24 +52,6 @@ function addNewlineFallback(current: Record<string, unknown>): boolean {
 	return false
 }
 
-// Unbind pi-mono's `app.thinking.cycle` so shift+tab is free for the
-// permissions extension to register. Also adds ctrl+j as a fallback for
-// newlines since many terminals (tmux, Terminal.app, VS Code terminal, etc.)
-// don't send modifier-aware Enter sequences. Must run before main() loads the
-// keybindings file. Idempotent.
-export function readMultiModelShortcutFromKeybindings(agentDir: string): string | undefined {
-	const keybindingsPath = resolve(agentDir, "keybindings.json")
-	try {
-		if (!existsSync(keybindingsPath)) return undefined
-		const parsed = JSON.parse(readFileSync(keybindingsPath, "utf-8"))
-		const val = parsed?.["app.multiModel.toggle"]
-		if (typeof val === "string" && val.length > 0) return val
-	} catch {
-		// missing or malformed
-	}
-	return undefined
-}
-
 export function writeKimchiKeybindingDefaults(agentDir: string): void {
 	const keybindingsPath = resolve(agentDir, "keybindings.json")
 	try {

--- a/src/extensions/prompt-construction/prompt-enrichment.ts
+++ b/src/extensions/prompt-construction/prompt-enrichment.ts
@@ -22,7 +22,7 @@
 
 import { execSync } from "node:child_process"
 import { randomUUID } from "node:crypto"
-import { existsSync, mkdirSync, writeFileSync } from "node:fs"
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs"
 import { homedir, platform, userInfo } from "node:os"
 import { isAbsolute, join, normalize, resolve } from "node:path"
 import type { AssistantMessage } from "@earendil-works/pi-ai"
@@ -82,6 +82,36 @@ function readGitRemote(cwd: string): string | undefined {
 	}
 }
 
+const HARNESS_SETTINGS_PATH = join(homedir(), ".config", "kimchi", "harness", "settings.json")
+
+function readMultiModelSetting(): boolean {
+	try {
+		const raw = readFileSync(HARNESS_SETTINGS_PATH, "utf-8")
+		const parsed = JSON.parse(raw)
+		if (typeof parsed.multiModel === "boolean") return parsed.multiModel
+	} catch {
+		// absent or unreadable
+	}
+	return true
+}
+
+function writeMultiModelSetting(enabled: boolean): void {
+	try {
+		let current: Record<string, unknown> = {}
+		try {
+			current = JSON.parse(readFileSync(HARNESS_SETTINGS_PATH, "utf-8"))
+		} catch {
+			// absent or malformed — start fresh
+		}
+		current.multiModel = enabled
+		const dir = join(homedir(), ".config", "kimchi", "harness")
+		if (!existsSync(dir)) mkdirSync(dir, { recursive: true })
+		writeFileSync(HARNESS_SETTINGS_PATH, `${JSON.stringify(current, null, 2)}\n`)
+	} catch {
+		// best-effort
+	}
+}
+
 function hasExplicitModelFlag(): boolean {
 	const args = process.argv
 	for (let i = 0; i < args.length; i++) {
@@ -90,7 +120,7 @@ function hasExplicitModelFlag(): boolean {
 	return false
 }
 
-const initialMultiModel = !hasExplicitModelFlag()
+const initialMultiModel = hasExplicitModelFlag() ? false : readMultiModelSetting()
 let multiModelEnabled = initialMultiModel
 ;(process as NodeJS.Process & { __kimchiMultiModelEnabled?: boolean }).__kimchiMultiModelEnabled = initialMultiModel
 
@@ -178,13 +208,21 @@ export function stripEmptyToolCalls(messages: OrchestratorMessages): Orchestrato
 	return changed ? filtered : messages
 }
 
+type ProcessWithMultiModel = NodeJS.Process & { __kimchiMultiModelEnabled?: boolean }
+
 export function getMultiModelEnabled(): boolean {
+	const processFlag = (process as ProcessWithMultiModel).__kimchiMultiModelEnabled
+	if (processFlag !== undefined && processFlag !== multiModelEnabled) {
+		multiModelEnabled = processFlag
+		writeMultiModelSetting(processFlag)
+	}
 	return multiModelEnabled
 }
 
 export function setMultiModelEnabled(enabled: boolean): void {
 	multiModelEnabled = enabled
-	;(process as NodeJS.Process & { __kimchiMultiModelEnabled?: boolean }).__kimchiMultiModelEnabled = enabled
+	;(process as ProcessWithMultiModel).__kimchiMultiModelEnabled = enabled
+	writeMultiModelSetting(enabled)
 }
 
 export function isSubagent(): boolean {

--- a/src/extensions/prompt-construction/prompt-enrichment.ts
+++ b/src/extensions/prompt-construction/prompt-enrichment.ts
@@ -22,13 +22,11 @@
 
 import { execSync } from "node:child_process"
 import { randomUUID } from "node:crypto"
-import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs"
+import { existsSync, mkdirSync, writeFileSync } from "node:fs"
 import { homedir, platform, userInfo } from "node:os"
 import { isAbsolute, join, normalize, resolve } from "node:path"
 import type { AssistantMessage } from "@earendil-works/pi-ai"
 import { type ExtensionAPI, type Skill, getAgentDir, loadSkills } from "@earendil-works/pi-coding-agent"
-import { type KeyId, isKeyRelease, matchesKey } from "@earendil-works/pi-tui"
-import { getAgentConfigDir } from "../../config.js"
 import { getAvailableModels } from "../../startup-context.js"
 import { getGitBranch } from "../../utils.js"
 import { isAgentWorker } from "../agent-worker-context.js"
@@ -43,7 +41,6 @@ import {
 	stripStaleNudges,
 } from "../orchestration/continuation-nudge.js"
 import { ModelRegistry } from "../orchestration/model-registry/index.js"
-import { readMultiModelShortcutFromKeybindings } from "../permissions/keybindings.js"
 import { getCurrentPhase } from "../tags.js"
 import { type ContextFile, loadProjectContextFiles } from "./context-files.js"
 import { type EnvironmentInfo, type PromptMode, type ToolInfo, buildSystemPrompt } from "./system-prompt.js"
@@ -85,38 +82,17 @@ function readGitRemote(cwd: string): string | undefined {
 	}
 }
 
-// Workaround: pi-mono's applyExtensionFlagValues ignores the actual value for boolean flags (always sets true). Read argv directly until upstream is fixed.
-const HARNESS_SETTINGS_PATH = join(homedir(), ".config", "kimchi", "harness", "settings.json")
-
-function readHarnessSetting<T>(key: string, fallback: T): T {
-	try {
-		const raw = readFileSync(HARNESS_SETTINGS_PATH, "utf-8")
-		const parsed = JSON.parse(raw)
-		if (key in parsed) return parsed[key] as T
-	} catch {
-		// settings.json absent or unreadable — use fallback
-	}
-	return fallback
-}
-
-function readMultiModelArgv(): boolean {
+function hasExplicitModelFlag(): boolean {
 	const args = process.argv
 	for (let i = 0; i < args.length; i++) {
-		const arg = args[i]
-		if (arg === "--multi-model=false") return false
-		if (arg === "--multi-model=true") return true
-		if (arg === "--multi-model") {
-			const next = args[i + 1]
-			if (next === "false") return false
-			if (next === "true") return true
-			return true
-		}
+		if (args[i] === "--model" || args[i]?.startsWith("--model=")) return true
 	}
-	// No CLI flag — fall back to settings.json, then hard-coded default
-	return readHarnessSetting("multiModel", true)
+	return false
 }
 
-let multiModelEnabled = readMultiModelArgv()
+const initialMultiModel = !hasExplicitModelFlag()
+let multiModelEnabled = initialMultiModel
+;(process as NodeJS.Process & { __kimchiMultiModelEnabled?: boolean }).__kimchiMultiModelEnabled = initialMultiModel
 
 export const ORCHESTRATOR_MODEL_ID = "kimi-k2.6"
 const DELEGATION_TOOL_NAMES = new Set(["Agent", "subagent"])
@@ -124,11 +100,6 @@ const DELEGATION_TOOL_NAMES = new Set(["Agent", "subagent"])
 function isDelegationToolCallName(name: string | undefined): boolean {
 	return name != null && DELEGATION_TOOL_NAMES.has(name)
 }
-
-const DEFAULT_MULTI_MODEL_KEY = "ctrl+n"
-const MULTI_MODEL_KEY = readMultiModelShortcutFromKeybindings(getAgentConfigDir()) ?? DEFAULT_MULTI_MODEL_KEY
-export const MULTI_MODEL_SHORTCUT =
-	process.platform === "darwin" ? MULTI_MODEL_KEY.replace(/\balt\b/, "option") : MULTI_MODEL_KEY
 
 /**
  * Shape of a tool-call content block as emitted in assistant messages.
@@ -211,6 +182,11 @@ export function getMultiModelEnabled(): boolean {
 	return multiModelEnabled
 }
 
+export function setMultiModelEnabled(enabled: boolean): void {
+	multiModelEnabled = enabled
+	;(process as NodeJS.Process & { __kimchiMultiModelEnabled?: boolean }).__kimchiMultiModelEnabled = enabled
+}
+
 export function isSubagent(): boolean {
 	return isAgentWorker()
 }
@@ -225,33 +201,10 @@ export default function (skillPaths: string[]) {
 			default: process.env.KIMCHI_DEBUG_PROMPTS === "1",
 		})
 
-		pi.registerFlag("multi-model", {
-			type: "boolean",
-			description: `Enable multi-model orchestration (default: enabled). Toggle with ${MULTI_MODEL_SHORTCUT}.`,
-			default: true,
-		})
-
 		// For sub agents we don't want to transform the prompt sent from parent with model capabilities
 		const registry = new ModelRegistry(getAvailableModels())
 		if (!subagentMode) {
-			// Global terminal input listener so the shortcut works even when a
-			// dialog (e.g. permission prompt) has focus instead of the editor.
-			let unsubMultiModelToggle: (() => void) | null = null
 			pi.on("session_start", async (_event, ctx) => {
-				if (unsubMultiModelToggle) unsubMultiModelToggle()
-				if (ctx.hasUI) {
-					unsubMultiModelToggle = ctx.ui.onTerminalInput((data) => {
-						if (matchesKey(data, MULTI_MODEL_KEY as KeyId)) {
-							if (!isKeyRelease(data)) {
-								multiModelEnabled = !multiModelEnabled
-								ctx.ui.setStatus("multi-model", undefined)
-							}
-							return { consume: true }
-						}
-						return undefined
-					})
-				}
-
 				// In multi-model mode the orchestrator must always be kimi-k2.6.
 				// Force-switch if the user has a different model selected via /models.
 				if (multiModelEnabled && ctx.model?.id !== ORCHESTRATOR_MODEL_ID) {

--- a/src/extensions/tips/general-tips.test.ts
+++ b/src/extensions/tips/general-tips.test.ts
@@ -13,7 +13,8 @@ describe("GENERAL_TIPS", () => {
 
 		expect(messages).toContain("Press `shift+tab` to change permissions mode.")
 		expect(messages).toContain("Run `/settings > Themes` to change colors.")
-		expect(messages).toContain("Press `ctrl+p` to choose a model from multi-model mode.")
+		expect(messages).toContain("Use `ctrl+p` or `/model` to select multi-model for auto routing.")
+		expect(messages).toContain("Use `/model` to select single model for entire session")
 		expect(messages).toContain("Tag requests with `/tags add key:value`, e.g. `project:myapp` `team:backend`.")
 		expect(messages).toContain('Set default tags: `export KIMCHI_TAGS="team:backend,project:api"`.')
 		expect(messages).toContain("Resume the latest session with `kimchi --continue`.")

--- a/src/extensions/tips/general-tips.ts
+++ b/src/extensions/tips/general-tips.ts
@@ -14,7 +14,12 @@ export const GENERAL_TIPS = [
 	{
 		id: "multi-model-switch",
 		scope: "general",
-		message: "Press `ctrl+p` to choose a model from multi-model mode.",
+		message: "Use `ctrl+p` or `/model` to select multi-model for auto routing.",
+	},
+	{
+		id: "single-model-mode",
+		scope: "general",
+		message: "Use `/model` to select single model for entire session",
 	},
 	{
 		id: "add-tags",

--- a/src/extensions/ui.ts
+++ b/src/extensions/ui.ts
@@ -405,23 +405,29 @@ export default function uiExtension(pi: ExtensionAPI) {
 						const current = ctx.model
 						const orchestratorModel = ctx.modelRegistry.find("kimchi-dev", ORCHESTRATOR_MODEL_ID)
 
+						// Cycle order: model[0] → ... → model[last] → multi-model → model[0]
+						// kimi-k2.6 appears as a regular model AND multi-model appears
+						// as a separate virtual entry right after the last real model.
 						if (getMultiModelEnabled()) {
-							// Currently in multi-model mode — cycle to first compatible real model
-							const usage = ctx.getContextUsage()
-							const orchIdx = orchestratorModel ? available.findIndex((m) => modelsAreEqual(m, orchestratorModel)) : -1
-							const startIdx = orchIdx !== -1 ? orchIdx : available.length - 1
-							const { model: firstReal } = findNextCompatibleModel(
-								available,
-								startIdx,
-								usage?.tokens ?? null,
-								sessionHasImages(),
-								current ?? undefined,
-							)
-							if (firstReal) {
-								setMultiModelEnabled(false)
-								pi.setModel(firstReal).catch((err) => {
-									ctx.ui.notify(`Failed to cycle model: ${err instanceof Error ? err.message : String(err)}`, "warning")
-								})
+							// Currently on the virtual multi-model entry — wrap to first real model
+							if (available.length > 0) {
+								const usage = ctx.getContextUsage()
+								const { model: firstReal } = findNextCompatibleModel(
+									available,
+									available.length - 1,
+									usage?.tokens ?? null,
+									sessionHasImages(),
+									current ?? undefined,
+								)
+								if (firstReal) {
+									setMultiModelEnabled(false)
+									pi.setModel(firstReal).catch((err) => {
+										ctx.ui.notify(
+											`Failed to cycle model: ${err instanceof Error ? err.message : String(err)}`,
+											"warning",
+										)
+									})
+								}
 							}
 						} else if (available.length > 0 && current) {
 							let idx = available.findIndex((m) => modelsAreEqual(m, current))
@@ -436,10 +442,11 @@ export default function uiExtension(pi: ExtensionAPI) {
 								current,
 							)
 
-							// If the next compatible model would wrap around (its index <= current),
-							// insert multi-model before the wrap.
 							const nextIdx = next ? available.findIndex((m) => modelsAreEqual(m, next)) : -1
-							if (orchestratorModel && (next === undefined || nextIdx <= idx)) {
+							const wouldWrap = next === undefined || nextIdx <= idx
+
+							if (wouldWrap && orchestratorModel) {
+								// Reached end of real models — enter multi-model
 								setMultiModelEnabled(true)
 								if (!modelsAreEqual(current, orchestratorModel)) {
 									pi.setModel(orchestratorModel).catch((err) => {

--- a/src/extensions/ui.ts
+++ b/src/extensions/ui.ts
@@ -18,7 +18,11 @@ import { formatFermentFooterDisplay } from "./ferment/footer-status.js"
 import { getActiveFerment, getFermentContinuationPolicy } from "./ferment/index.js"
 import { formatDuration } from "./format.js"
 import { sessionHasImages } from "./model-guard.js"
-import { MULTI_MODEL_SHORTCUT, getMultiModelEnabled } from "./prompt-construction/prompt-enrichment.js"
+import {
+	ORCHESTRATOR_MODEL_ID,
+	getMultiModelEnabled,
+	setMultiModelEnabled,
+} from "./prompt-construction/prompt-enrichment.js"
 import {
 	isSessionModeOnboardingFooterSuppressed,
 	registerSharedFooterRenderer,
@@ -257,10 +261,8 @@ export default function uiExtension(pi: ExtensionAPI) {
 				if (ferment) parts.push(ferment.text)
 				const perm = footerData.getExtensionStatuses().get("permissions-mode")
 				if (perm) parts.push(perm)
-				const enabled = getMultiModelEnabled()
-				const label = enabled ? `${resolvedAccentFg(theme)}on${RST_FG}` : theme.fg("dim", "off")
-				const shortcut = MULTI_MODEL_SHORTCUT
-				parts.push(`${theme.fg("dim", "multi-model:")} ${label} ${theme.fg("dim", `→ ${shortcut}`)}`)
+				const modelId = getMultiModelEnabled() ? `multi-model (${ORCHESTRATOR_MODEL_ID})` : (ctx.model?.id ?? "n/a")
+				parts.push(`${resolvedAccentFg(theme)}${modelId}${RST_FG} ${theme.fg("dim", "→ ctrl+p")}`)
 				return parts.join(` ${theme.fg("dim", "·")} `)
 			}
 			scriptFooter = new ScriptFooter(getControlsLine)
@@ -389,21 +391,42 @@ export default function uiExtension(pi: ExtensionAPI) {
 
 		// Register a global terminal input listener so ctrl+p (model cycle forward)
 		// works even when a permission prompt or other dialog has focus.
+		// The cycle includes a virtual "multi-model" entry after the last real model.
 		if (unsubModelCycleInput) unsubModelCycleInput()
 		if (ctx.hasUI) {
 			unsubModelCycleInput = ctx.ui.onTerminalInput((data) => {
 				if (matchesKey(data, "ctrl+p")) {
 					if (!isKeyRelease(data)) {
-						if (getMultiModelEnabled()) return { consume: true }
 						const allAvailable = ctx.modelRegistry.getAvailable()
 						const enabledIds = getEnabledModelIds()
 						const available = enabledIds
 							? allAvailable.filter((m) => enabledIds.has(`${m.provider}/${m.id}`))
 							: allAvailable
 						const current = ctx.model
-						if (available.length > 1 && current) {
+						const orchestratorModel = ctx.modelRegistry.find("kimchi-dev", ORCHESTRATOR_MODEL_ID)
+
+						if (getMultiModelEnabled()) {
+							// Currently in multi-model mode — cycle to first compatible real model
+							const usage = ctx.getContextUsage()
+							const orchIdx = orchestratorModel ? available.findIndex((m) => modelsAreEqual(m, orchestratorModel)) : -1
+							const startIdx = orchIdx !== -1 ? orchIdx : available.length - 1
+							const { model: firstReal } = findNextCompatibleModel(
+								available,
+								startIdx,
+								usage?.tokens ?? null,
+								sessionHasImages(),
+								current ?? undefined,
+							)
+							if (firstReal) {
+								setMultiModelEnabled(false)
+								pi.setModel(firstReal).catch((err) => {
+									ctx.ui.notify(`Failed to cycle model: ${err instanceof Error ? err.message : String(err)}`, "warning")
+								})
+							}
+						} else if (available.length > 0 && current) {
 							let idx = available.findIndex((m) => modelsAreEqual(m, current))
 							if (idx === -1) idx = 0
+
 							const usage = ctx.getContextUsage()
 							const { model: next, skipped } = findNextCompatibleModel(
 								available,
@@ -412,13 +435,21 @@ export default function uiExtension(pi: ExtensionAPI) {
 								sessionHasImages(),
 								current,
 							)
-							if (!next) {
-								const lines = skipped.map((s) => `  • ${s.model.id}: ${s.reason}`)
-								ctx.ui.notify(
-									`No compatible model available.\n${lines.join("\n")}\n\nUse /compact to unlock models blocked by context size, or /strip-images for models without vision support.`,
-									"warning",
-								)
-							} else if (!modelsAreEqual(next, current)) {
+
+							// If the next compatible model would wrap around (its index <= current),
+							// insert multi-model before the wrap.
+							const nextIdx = next ? available.findIndex((m) => modelsAreEqual(m, next)) : -1
+							if (orchestratorModel && (next === undefined || nextIdx <= idx)) {
+								setMultiModelEnabled(true)
+								if (!modelsAreEqual(current, orchestratorModel)) {
+									pi.setModel(orchestratorModel).catch((err) => {
+										ctx.ui.notify(
+											`Failed to switch to multi-model: ${err instanceof Error ? err.message : String(err)}`,
+											"warning",
+										)
+									})
+								}
+							} else if (next && !modelsAreEqual(next, current)) {
 								if (skipped.length > 0) {
 									const lines = skipped.map((s) => `  • ${s.model.id}: ${s.reason}`)
 									ctx.ui.notify(


### PR DESCRIPTION
## Summary

- Replaces the confusing dual-control model selection (ctrl+n toggle + ctrl+p cycle) with a single unified picker where **multi-model** is a selectable option alongside regular models
- Users can switch between single-model and multi-model using either `ctrl+p` (cycle) or `/model` (picker) — both now include `multi-model` as an entry
- The selected mode (single vs multi-model) is persisted across sessions via `settings.json`
- Running agents now display their model ID in the agent widget for better visibility

## Changes

**Model selection UX:**
- `ctrl+p` cycles through: `model-A → model-B → ... → kimi-k2.6 → multi-model → model-A`
- `/model` picker shows `multi-model` at the top alongside all regular models (including kimi-k2.6)
- `set_model` tool accepts `"multi-model"` as a target
- `--model <id>` CLI flag starts in single-model mode

**Footer:**
- Single model: `kimi-k2.6 → ctrl+p`
- Multi-model: `multi-model (kimi-k2.6) → ctrl+p`

**Removed:**
- `ctrl+n` multi-model toggle
- `--multi-model` CLI flag
- `multiModel.toggle` keybinding config

**Added:**
- Model ID display in agent widget rows (e.g. `Agent (twin) [minimax-m2.7]`)
- Mode persistence to `~/.config/kimchi/harness/settings.json`

## Test plan

- [x] `pnpm run check` passes (lint + typecheck)
- [x] All 3041 tests pass
- [x] Manual: `ctrl+p` cycles through all models then multi-model then wraps
- [x] Manual: `/model` picker shows multi-model entry, selecting it activates orchestration
- [x] Manual: selecting kimi-k2.6 (regular entry) while in multi-model exits multi-model
- [x] Manual: `/model multi-model` text command activates multi-model
- [x] Manual: `--model foo` starts in single-model mode
- [x] Manual: mode persists across session restarts
- [x] Manual: agent widget shows model IDs for running agents

---
### Kimchi Summary
### What changed
Unified single- and multi-model selection into one flow: `ctrl+p` now cycles through all available models plus a virtual "multi-model" orchestration entry, and the `/model` picker can select either a specific model or multi-model mode. Removed the `--multi-model` CLI flag; the active mode is persisted across sessions in harness settings.

### Why
The previous `--multi-model=false` flag and separate `alt+tab` shortcut forced users to learn two different mechanisms to change modes. Treating multi-model as a first-class option in the model cycle simplifies the UX and removes the need for a restart to switch modes.

### Key changes
- `src/extensions/prompt-construction/prompt-enrichment.ts` — Dropped `--multi-model` argv parsing. Mode is now read from `~/.config/kimchi/harness/settings.json`, with `setMultiModelEnabled()` and `getMultiModelEnabled()` synchronizing state through `process.__kimchiMultiModelEnabled` for the patched UI harness.
- `src/extensions/ui.ts` — `ctrl+p` cycles real model → … → last real model → multi-model → first real model. Wrapping past the last model enables multi-model and switches to the orchestrator; wrapping from multi-model selects the first real model.
- `patches/@earendil-works__pi-coding-agent.patch` — Injected a virtual "multi-model" entry at the top of the interactive model selector and wired `/models` search term `multi-model` to trigger orchestration mode.
- `src/extensions/model-switch.ts` — Added `"multi-model"` as a valid target for the model-switch tool, which enables orchestration and selects the orchestrator model.
- `src/components/footer.ts` — Collapsed separate `multi-model` and `model` footer segments into a single `model` segment that displays `multi-model (kimi-k2.6)` when orchestration is active, otherwise the current model ID.
- `src/extensions/agents/` — `AgentRecord` now stores `modelId`; the agent widget renders the model badge for running subagents.
- Benchmark scripts and docs — Removed deprecated `--multi-model=false` usage; single-model benchmarks now rely on explicit `--model` selection.

### Impact
- **Breaking**: The `--multi-model` CLI flag has been removed. Use `--model <provider/id>` to start in single-model mode, or select multi-model via `ctrl+p` / `/model`.
- **Breaking**: The `alt+tab` / `option+tab` keyboard shortcut for toggling multi-model has been removed; use `ctrl+p` instead.
- Multi-model preference persists across restarts unless an explicit `--model` flag is provided.