### PR TITLE
chore: unload improve and curator extensions

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -21,10 +21,8 @@ import assistantPrefixExtension from "./extensions/assistant-prefix.js"
 import behavioursExtension from "./extensions/behaviours/index.js"
 import clipboardImageExtension from "./extensions/clipboard-image.js"
 import contextCompactorExtension from "./extensions/context-compactor.js"
-import curatorExtension from "./extensions/curator/index.js"
 import fermentExtension from "./extensions/ferment/index.js"
 import hideThinkingExtension from "./extensions/hide-thinking.js"
-import improveExtension from "./extensions/improve/index.js"
 import kimchiMinimalTintsExtension from "./extensions/kimchi-minimal-tints.js"
 import loginExtension from "./extensions/login/index.js"
 import loopGuardExtension from "./extensions/loop-guard.js"
@@ -335,8 +333,6 @@ try {
 			webFetchExtension,
 			webSearchExtension,
 			loginExtension,
-			improveExtension,
-			curatorExtension,
 			modelSwitchExtension,
 			modelGuardExtension,
 			stripImagesExtension,


### PR DESCRIPTION
Follow-up to #235 which removed `skillsManagerExtension` but left `improveExtension` and `curatorExtension` still wired in `src/cli.ts`.

This PR removes both remaining extensions from the CLI pipeline while keeping their source code intact, consistent with the decision to keep the code around but stop loading it.

---
### Kimchi Summary
### What changed
Removes the `improveExtension` and `curatorExtension` from the CLI startup sequence, unloading both features from the default runtime.

### Key changes
- `src/cli.ts`: Removed imports for `curatorExtension` and `improveExtension`.
- `src/cli.ts`: Deregistered both extensions from the extension initialization list.