### PR TITLE
fix: ctrl+c should interrupt the flow

### DIFF
--- a/src/extensions/ui.test.ts
+++ b/src/extensions/ui.test.ts
@@ -1,3 +1,4 @@
+import { Key, matchesKey } from "@earendil-works/pi-tui"
 import { describe, expect, it } from "vitest"
 import { isBareExitAlias } from "./exit-utils.js"
 import { findNextCompatibleModel } from "./ui.js"
@@ -40,6 +41,23 @@ describe("isBareExitAlias", () => {
 		expect(isBareExitAlias("exit now")).toBe(false)
 		expect(isBareExitAlias("please exit")).toBe(false)
 		expect(isBareExitAlias("quit")).toBe(false)
+	})
+})
+
+describe("Ctrl+C abort key matching", () => {
+	it("matchesKey recognizes Ctrl+C raw byte (\\x03)", () => {
+		expect(matchesKey("\x03", Key.ctrl("c"))).toBe(true)
+	})
+
+	it("does not match other keys as Ctrl+C", () => {
+		expect(matchesKey("\x1b", Key.ctrl("c"))).toBe(false) // Escape
+		expect(matchesKey("\r", Key.ctrl("c"))).toBe(false) // Enter
+		expect(matchesKey("c", Key.ctrl("c"))).toBe(false) // plain c
+	})
+
+	it("matchesKey recognizes Escape separately from Ctrl+C", () => {
+		expect(matchesKey("\x1b", Key.escape)).toBe(true)
+		expect(matchesKey("\x03", Key.escape)).toBe(false)
 	})
 })
 

--- a/src/extensions/ui.ts
+++ b/src/extensions/ui.ts
@@ -6,7 +6,7 @@ import type { Api, Model } from "@earendil-works/pi-ai"
 import type { ExtensionAPI, ExtensionContext } from "@earendil-works/pi-coding-agent"
 import { isEditToolResult, isWriteToolResult } from "@earendil-works/pi-coding-agent"
 import { Box, Text } from "@earendil-works/pi-tui"
-import { isKeyRelease, matchesKey } from "@earendil-works/pi-tui"
+import { Key, isKeyRelease, matchesKey } from "@earendil-works/pi-tui"
 import type { Component, TUI } from "@earendil-works/pi-tui"
 import { RST_FG, resolvedAccentFg } from "../ansi.js"
 import { PromptEditor } from "../components/editor.js"
@@ -392,6 +392,16 @@ export default function uiExtension(pi: ExtensionAPI) {
 		if (unsubModelCycleInput) unsubModelCycleInput()
 		if (ctx.hasUI) {
 			unsubModelCycleInput = ctx.ui.onTerminalInput((data) => {
+				// In raw-mode terminals Ctrl+C arrives as \x03 rather than raising
+				// SIGINT.  The upstream TUI already maps Escape to abort, but does
+				// not handle Ctrl+C.  Bridge the gap so both keys cancel the active
+				// turn while the agent is working.
+				if (matchesKey(data, Key.ctrl("c")) && !isKeyRelease(data)) {
+					if (currentCtx && !currentCtx.isIdle()) {
+						currentCtx.abort()
+					}
+					return undefined
+				}
 				if (matchesKey(data, "ctrl+p")) {
 					if (!isKeyRelease(data)) {
 						if (getMultiModelEnabled()) return { consume: true }


### PR DESCRIPTION
## Description

<!-- What problem does this PR solve? What changes were made and why? -->

Ctrl+c wouldn't interrupt the flow. 

## Type of Change

<!-- Select all that apply. -->

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

---
### Kimchi Summary
### What changed
Enables aborting an active agent turn with Ctrl+C in raw-mode terminals, which previously only responded to Escape. Adds unit tests to verify the underlying key matching.

### Why
In raw-mode terminals, Ctrl+C arrives as the raw byte `\x03` instead of raising SIGINT. The upstream TUI already handled Escape for aborting but did not process Ctrl+C, leaving users without a familiar interrupt key during long-running operations.

### Key changes
- `src/extensions/ui.ts`: Imports `Key` and adds a `matchesKey(data, Key.ctrl("c"))` check in the terminal input handler; when matched and the agent is not idle, it calls `currentCtx.abort()`.
- `src/extensions/ui.test.ts`: Adds `Ctrl+C abort key matching` tests confirming `matchesKey` recognizes `\x03`, rejects non-matching keys (Escape, Enter, plain `c`), and correctly distinguishes Escape.