### PR TITLE
feat(terminal-bench-opencode-adapter): add OpenCode Kimchi runner

### DIFF
--- a/benchmark/terminal-bench-2/README.md
+++ b/benchmark/terminal-bench-2/README.md
@@ -38,6 +38,7 @@ You will hit one of two failure modes:
 | --- | --- |
 | `./scripts/run-local.sh` | Cross-builds `kimchi` for linux-amd64 from the current working tree (`pnpm run build:binary-linux-x64`) |
 | `./scripts/run-release.sh` | Downloads the latest release from `castai/kimchi` |
+| `./scripts/run-opencode-kimchi.sh` | Installs OpenCode in the task container and configures it to use the Kimchi gateway |
 
 Both scripts target the `terminal-bench/terminal-bench-2` dataset. Extra arguments are forwarded to `harbor run`, so everything below works for either script.
 
@@ -80,6 +81,38 @@ MODEL=kimchi-dev/kimi-k2.5 ./scripts/run-local.sh -i terminal-bench/fix-git
 ```
 
 `MODEL` must be `<provider>/<id>`. Available `kimchi-dev` models include `kimi-k2.5`, `glm-5-fp8`, `minimax-m2.7`, `nemotron-3-super-fp4` (run `kimchi --list-models` for the live list). The qualifier is required because kimchi's built-in catalog also registers some IDs (notably `kimi-k2.5`) under the `opencode` provider — without `kimchi-dev/` the resolver picks `opencode` and fails auth with the kimchi key.
+
+### OpenCode with the Kimchi gateway
+
+Use `run-opencode-kimchi.sh` when the benchmark should evaluate the OpenCode scaffold while routing model calls through `llm.kimchi.dev`.
+
+```bash
+export KIMCHI_API_KEY=...
+MODEL=kimchi-dev/kimi-k2.5 ./scripts/run-opencode-kimchi.sh -i terminal-bench/fix-git
+```
+
+The script requires `KIMCHI_API_KEY` in the host environment and forwards it to Harbor with `--ae KIMCHI_API_KEY=$KIMCHI_API_KEY`; you do not need to pass that `--ae` manually when using the script.
+
+The OpenCode adapter accepts any `kimchi-dev/<model-id>` returned by Kimchi's model metadata endpoint (`/v1/models/metadata?include_in_cli=true`). It writes an OpenCode provider config for the selected model at runtime, using the live model limits and reasoning flag, then runs OpenCode in JSON mode. Reasoning-capable models include `--thinking`:
+
+```bash
+opencode --model=<MODEL> run --format=json --thinking --dangerously-skip-permissions -- <instruction>
+```
+
+To change models, change only `MODEL`:
+
+```bash
+MODEL=kimchi-dev/minimax-m2.7 ./scripts/run-opencode-kimchi.sh -i terminal-bench/fix-git
+```
+
+By default OpenCode uses the benchmark model for `small_model` too, keeping the whole run on the selected model. To use a cheaper Kimchi model for summary/title work, set `OPENCODE_SMALL_MODEL=kimchi-dev/<model-id>`; the adapter registers that model from the same metadata endpoint.
+
+By default Harbor installs the latest `opencode-ai` package. Pin OpenCode for reproducible runs with `OPENCODE_VERSION`:
+
+```bash
+OPENCODE_VERSION=1.14.33 MODEL=kimchi-dev/kimi-k2.5 \
+  ./scripts/run-opencode-kimchi.sh -i terminal-bench/fix-git
+```
 
 ### Single-model run (no orchestration)
 

--- a/benchmark/terminal-bench-2/scripts/run-opencode-kimchi.sh
+++ b/benchmark/terminal-bench-2/scripts/run-opencode-kimchi.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+# Run terminal-bench with the OpenCode scaffold, configured to use the Kimchi
+# OpenAI-compatible gateway. The selected model is controlled by MODEL.
+#
+# Usage examples:
+#   MODEL=kimchi-dev/kimi-k2.5 ./scripts/run-opencode-kimchi.sh -i terminal-bench/fix-git
+#   MODEL=kimchi-dev/minimax-m2.7 ./scripts/run-opencode-kimchi.sh -i terminal-bench/fix-git -k 3
+#   OPENCODE_VERSION=1.14.33 MODEL=kimchi-dev/kimi-k2.5 ./scripts/run-opencode-kimchi.sh -i terminal-bench/fix-git
+set -euo pipefail
+
+DATASET="terminal-bench/terminal-bench-2"
+
+: "${KIMCHI_API_KEY:?set KIMCHI_API_KEY in env}"
+
+BENCH_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+cd "$BENCH_DIR"
+
+HARBOR_ARGS=(
+    --agent-import-path kimchi_agent:OpenCodeKimchi
+    --env docker
+    --model "${MODEL:-kimchi-dev/kimi-k2.5}"
+    --ae "KIMCHI_API_KEY=$KIMCHI_API_KEY"
+    -d "$DATASET"
+)
+
+if [[ -n "${OPENCODE_VERSION:-}" ]]; then
+    HARBOR_ARGS+=(--agent-kwarg "version=$OPENCODE_VERSION")
+fi
+
+exec uv run --python 3.14 harbor run "${HARBOR_ARGS[@]}" "$@"

--- a/benchmark/terminal-bench-2/src/kimchi_agent/__init__.py
+++ b/benchmark/terminal-bench-2/src/kimchi_agent/__init__.py
@@ -1,3 +1,4 @@
 from kimchi_agent.agent import Kimchi
+from kimchi_agent.opencode_kimchi import OpenCodeKimchi
 
-__all__ = ["Kimchi"]
+__all__ = ["Kimchi", "OpenCodeKimchi"]

--- a/benchmark/terminal-bench-2/src/kimchi_agent/opencode_kimchi.py
+++ b/benchmark/terminal-bench-2/src/kimchi_agent/opencode_kimchi.py
@@ -1,0 +1,227 @@
+import copy
+import json
+import os
+import shlex
+from typing import Any
+
+import httpx
+from harbor.agents.installed.base import with_prompt_template
+from harbor.agents.installed.opencode import OpenCode
+from harbor.environments.base import BaseEnvironment
+from harbor.models.agent.context import AgentContext
+from pydantic import BaseModel, ConfigDict, Field, StrictBool, StrictInt, ValidationError
+
+KIMCHI_API = "https://llm.kimchi.dev"
+KIMCHI_PROVIDER = "kimchi-dev"
+KIMCHI_BASE_URL = f"{KIMCHI_API}/openai/v1"
+KIMCHI_MODELS_METADATA_URL = f"{KIMCHI_API}/v1/models/metadata?include_in_cli=true"
+KIMCHI_API_KEY_ENV = "KIMCHI_API_KEY"
+
+FETCH_TIMEOUT_SEC = 5
+SMALL_MODEL_ENV = "OPENCODE_SMALL_MODEL"
+
+
+class KimchiModelLimits(BaseModel):
+    model_config = ConfigDict(extra="ignore")
+
+    context_window: StrictInt = Field(gt=0)
+    max_output_tokens: StrictInt = Field(gt=0)
+
+
+class KimchiModelMetadata(BaseModel):
+    model_config = ConfigDict(extra="ignore")
+
+    slug: str = Field(min_length=1)
+    reasoning: StrictBool = False
+    limits: KimchiModelLimits
+
+
+class KimchiModelsMetadataResponse(BaseModel):
+    model_config = ConfigDict(extra="ignore")
+
+    models: list[KimchiModelMetadata] = Field(min_length=1)
+
+
+class OpenCodeKimchi(OpenCode):
+    """Harbor OpenCode agent wired to the Kimchi OpenAI-compatible gateway.
+
+    The model remains Harbor-configurable: pass ``--model kimchi-dev/<id>`` or
+    set ``MODEL=kimchi-dev/<id>`` in the runner script. The adapter registers
+    that selected model in OpenCode's config at runtime before invoking
+    ``opencode run``.
+    """
+
+    @staticmethod
+    def name() -> str:
+        return "opencode-kimchi"
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self._model_metadata_cache: tuple[str, list[KimchiModelMetadata]] | None = None
+
+    @staticmethod
+    def _split_model(model_name: str | None) -> tuple[str, str]:
+        if not model_name or "/" not in model_name:
+            raise ValueError("--model is required and must use provider/model format, e.g. kimchi-dev/kimi-k2.5")
+        provider, model_id = model_name.split("/", 1)
+        if provider != KIMCHI_PROVIDER:
+            raise ValueError(
+                f"OpenCodeKimchi only supports {KIMCHI_PROVIDER}/<model-id> models; got {model_name!r}"
+            )
+        if not model_id:
+            raise ValueError("--model must include a model id after kimchi-dev/")
+        return provider, model_id
+
+    def _fetch_model_metadata(self, api_key: str) -> list[KimchiModelMetadata]:
+        try:
+            response = httpx.get(
+                KIMCHI_MODELS_METADATA_URL,
+                headers={"Authorization": f"Bearer {api_key}"},
+                timeout=FETCH_TIMEOUT_SEC,
+            )
+            response.raise_for_status()
+            body = response.json()
+        except httpx.HTTPStatusError as exc:
+            raise RuntimeError(f"Failed to fetch Kimchi model metadata: HTTP {exc.response.status_code}") from exc
+        except (httpx.HTTPError, json.JSONDecodeError) as exc:
+            raise RuntimeError(f"Failed to fetch Kimchi model metadata: {exc}") from exc
+
+        try:
+            metadata = KimchiModelsMetadataResponse.model_validate(body)
+        except ValidationError as exc:
+            raise RuntimeError(f"Failed to parse Kimchi model metadata: {exc}") from exc
+
+        return metadata.models
+
+    def _model_metadata(self, api_key: str) -> list[KimchiModelMetadata]:
+        if self._model_metadata_cache is None or self._model_metadata_cache[0] != api_key:
+            self._model_metadata_cache = (api_key, self._fetch_model_metadata(api_key))
+        return self._model_metadata_cache[1]
+
+    def _model_metadata_for(self, api_key: str, model_name: str | None) -> KimchiModelMetadata:
+        _, model_id = self._split_model(model_name)
+        for model in self._model_metadata(api_key):
+            if model.slug == model_id:
+                return model
+        raise ValueError(f"Model {model_name!r} was not returned by {KIMCHI_MODELS_METADATA_URL}")
+
+    def _selected_model_metadata(self, api_key: str) -> KimchiModelMetadata:
+        return self._model_metadata_for(api_key, self.model_name)
+
+    def _model_config(self, api_key: str, model_name: str | None) -> dict[str, Any]:
+        model = self._model_metadata_for(api_key, model_name)
+        return {
+            "name": model.slug,
+            # The current metadata endpoint does not expose tool-call capability.
+            # Kimchi's OpenCode integration treats gateway-served models as tool-capable.
+            "tool_call": True,
+            "reasoning": model.reasoning,
+            "limit": {
+                "context": model.limits.context_window,
+                "output": model.limits.max_output_tokens,
+            },
+        }
+
+    def _selected_model_config(self, api_key: str) -> dict[str, Any]:
+        return self._model_config(api_key, self.model_name)
+
+    def _small_model_name(self) -> str | None:
+        return self._get_env(SMALL_MODEL_ENV) or self.model_name
+
+    def _build_register_config_command(self, api_key: str) -> str:
+        _, model_id = self._split_model(self.model_name)
+        small_model_name = self._small_model_name()
+        _, small_model_id = self._split_model(small_model_name)
+        models = {model_id: self._selected_model_config(api_key)}
+        if small_model_id != model_id:
+            models[small_model_id] = self._model_config(api_key, small_model_name)
+
+        mcp: dict[str, dict[str, Any]] = {}
+        for server in self.mcp_servers:
+            if server.transport == "stdio":
+                cmd_list = [server.command, *server.args] if server.command else []
+                mcp[server.name] = {"type": "local", "command": cmd_list}
+            else:
+                mcp[server.name] = {"type": "remote", "url": server.url}
+
+        config: dict[str, Any] = {
+            "$schema": "https://opencode.ai/config.json",
+            "provider": {
+                KIMCHI_PROVIDER: {
+                    "npm": "@ai-sdk/openai-compatible",
+                    "name": "Kimchi",
+                    "options": {
+                        "baseURL": KIMCHI_BASE_URL,
+                        # kimchi: the gateway is served through LiteLLM, matching
+                        # the first-party Kimchi OpenCode provider integration.
+                        "litellmProxy": True,
+                        "apiKey": f"{{env:{KIMCHI_API_KEY_ENV}}}",
+                    },
+                    "models": models,
+                }
+            },
+            "model": self.model_name,
+            # Defaults to the benchmark model for reproducibility; override with
+            # OPENCODE_SMALL_MODEL=kimchi-dev/<id> if summary/title work should
+            # use a cheaper Kimchi model.
+            "small_model": small_model_name,
+        }
+        if mcp:
+            config["mcp"] = mcp
+
+        config = self._deep_merge(copy.deepcopy(self._DEFAULT_CONFIG), config)
+        config = self._deep_merge(config, self._opencode_config)
+        config_json = json.dumps(config, indent=2)
+        return f"mkdir -p ~/.config/opencode && echo {shlex.quote(config_json)} > ~/.config/opencode/opencode.json"
+
+    def _build_env(self) -> dict[str, str]:
+        api_key = self._get_env(KIMCHI_API_KEY_ENV)
+        if not api_key:
+            raise ValueError(
+                f"{KIMCHI_API_KEY_ENV} is required. Export it on the host and forward it with "
+                f"`--ae {KIMCHI_API_KEY_ENV}=${KIMCHI_API_KEY_ENV}`."
+            )
+        env = self._passthrough_env(("OPENCODE_",))
+        env.update({
+            KIMCHI_API_KEY_ENV: api_key,
+        })
+        env.setdefault("OPENCODE_FAKE_VCS", "git")
+        return env
+
+    def _passthrough_env(self, prefixes: tuple[str, ...]) -> dict[str, str]:
+        env = {key: value for key, value in os.environ.items() if key.startswith(prefixes)}
+        env.update({key: value for key, value in self._extra_env.items() if key.startswith(prefixes)})
+        return env
+
+    def _thinking_flag(self, api_key: str) -> str:
+        return " --thinking" if self._selected_model_metadata(api_key).reasoning else ""
+
+    @with_prompt_template
+    async def run(
+        self,
+        instruction: str,
+        environment: BaseEnvironment,
+        context: AgentContext,
+    ) -> None:
+        self._split_model(self.model_name)
+        escaped_instruction = shlex.quote(instruction)
+        env = self._build_env()
+        api_key = env[KIMCHI_API_KEY_ENV]
+
+        skills_command = self._build_register_skills_command()
+        if skills_command:
+            await self.exec_as_agent(environment, command=skills_command, env=env)
+
+        await self.exec_as_agent(environment, command=self._build_register_config_command(api_key), env=env)
+
+        await self.exec_as_agent(
+            environment,
+            command=(
+                ". ~/.nvm/nvm.sh; "
+                f"opencode --model={shlex.quote(self.model_name or '')} "
+                f"run --format=json{self._thinking_flag(api_key)} --dangerously-skip-permissions -- "
+                f"{escaped_instruction} "
+                f"2>&1 </dev/null | stdbuf -oL tee /logs/agent/{self._OUTPUT_FILENAME}"
+            ),
+            env=env,
+        )

--- a/benchmark/terminal-bench-2/src/kimchi_agent/opencode_kimchi.py
+++ b/benchmark/terminal-bench-2/src/kimchi_agent/opencode_kimchi.py
@@ -221,7 +221,7 @@ class OpenCodeKimchi(OpenCode):
                 f"opencode --model={shlex.quote(self.model_name or '')} "
                 f"run --format=json{self._thinking_flag(api_key)} --dangerously-skip-permissions -- "
                 f"{escaped_instruction} "
-                f"2>&1 </dev/null | stdbuf -oL tee /logs/agent/{self._OUTPUT_FILENAME}"
+                f"2>&1 </dev/null | stdbuf -oL tee /logs/agent/{shlex.quote(self._OUTPUT_FILENAME)}"
             ),
             env=env,
         )

--- a/benchmark/terminal-bench-2/src/kimchi_agent/opencode_kimchi_test.py
+++ b/benchmark/terminal-bench-2/src/kimchi_agent/opencode_kimchi_test.py
@@ -1,0 +1,290 @@
+import json
+import os
+import shlex
+import tempfile
+import unittest
+from pathlib import Path
+from typing import ClassVar
+from unittest.mock import patch
+
+from harbor.models.agent.context import AgentContext
+from harbor.models.task.config import MCPServerConfig
+
+from kimchi_agent.opencode_kimchi import (
+    KIMCHI_BASE_URL,
+    KIMCHI_MODELS_METADATA_URL,
+    KIMCHI_PROVIDER,
+    KimchiModelMetadata,
+    KimchiModelsMetadataResponse,
+    OpenCodeKimchi,
+)
+
+
+class FakeMetadataResponse:
+    def __init__(self, body: dict[str, object]) -> None:
+        self._body = body
+
+    def raise_for_status(self) -> None:
+        return None
+
+    def json(self) -> dict[str, object]:
+        return self._body
+
+
+class RecordingOpenCodeKimchi(OpenCodeKimchi):
+    metadata: ClassVar[list[dict[str, object]]] = [
+        {
+            "slug": "kimi-k2.5",
+            "display_name": "Kimi K2.5",
+            "reasoning": True,
+            "limits": {"context_window": 262144, "max_output_tokens": 262144},
+        },
+        {
+            "slug": "minimax-m2.7",
+            "display_name": "MiniMax M2.7",
+            "reasoning": True,
+            "limits": {"context_window": 196608, "max_output_tokens": 196608},
+        },
+        {
+            "slug": "new-model",
+            "display_name": "New Model",
+            "reasoning": False,
+            "limits": {"context_window": 12345, "max_output_tokens": 6789},
+        },
+    ]
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.agent_commands: list[str] = []
+        self.agent_envs: list[dict[str, str] | None] = []
+        self.metadata_fetch_count = 0
+
+    async def exec_as_agent(self, _environment, command: str, env=None, cwd=None, timeout_sec=None):
+        self.agent_commands.append(command)
+        self.agent_envs.append(env)
+
+    def _fetch_model_metadata(self, api_key: str) -> list[KimchiModelMetadata]:
+        self.metadata_fetch_count += 1
+        self.fetched_with_api_key = api_key
+        return KimchiModelsMetadataResponse.model_validate({"models": self.metadata}).models
+
+
+def extract_echo_json(command: str) -> dict:
+    tokens = shlex.split(command)
+    echo_index = tokens.index("echo")
+    return json.loads(tokens[echo_index + 1])
+
+
+class OpenCodeKimchiTest(unittest.IsolatedAsyncioTestCase):
+    def setUp(self) -> None:
+        self._old_api_key = os.environ.get("KIMCHI_API_KEY")
+        os.environ["KIMCHI_API_KEY"] = "test-key"
+
+    def tearDown(self) -> None:
+        if self._old_api_key is None:
+            os.environ.pop("KIMCHI_API_KEY", None)
+        else:
+            os.environ["KIMCHI_API_KEY"] = self._old_api_key
+
+    async def test_registers_and_runs_selected_kimchi_model(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            agent = RecordingOpenCodeKimchi(
+                logs_dir=Path(tmp) / "jobs" / "run-1" / "task__trial" / "agent",
+                model_name="kimchi-dev/minimax-m2.7",
+            )
+
+            await agent.run("solve it", object(), AgentContext())
+
+        self.assertEqual(len(agent.agent_commands), 2)
+        config = extract_echo_json(agent.agent_commands[0])
+        self.assertEqual(config["model"], "kimchi-dev/minimax-m2.7")
+        self.assertEqual(config["small_model"], "kimchi-dev/minimax-m2.7")
+        self.assertIn("minimax-m2.7", config["provider"][KIMCHI_PROVIDER]["models"])
+        self.assertNotIn("kimi-k2.5", config["provider"][KIMCHI_PROVIDER]["models"])
+        self.assertEqual(config["provider"][KIMCHI_PROVIDER]["options"]["baseURL"], KIMCHI_BASE_URL)
+        self.assertEqual(config["provider"][KIMCHI_PROVIDER]["options"]["apiKey"], "{env:KIMCHI_API_KEY}")
+
+        run_command = agent.agent_commands[1]
+        self.assertIn("opencode --model=kimchi-dev/minimax-m2.7", run_command)
+        self.assertIn("run --format=json --thinking --dangerously-skip-permissions --", run_command)
+        self.assertEqual(agent.agent_envs[0]["KIMCHI_API_KEY"], "test-key")
+        self.assertEqual(agent.agent_envs[0]["OPENCODE_FAKE_VCS"], "git")
+        self.assertEqual(agent.metadata_fetch_count, 1)
+        self.assertEqual(agent.fetched_with_api_key, "test-key")
+
+    async def test_rejects_non_kimchi_provider(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            agent = RecordingOpenCodeKimchi(
+                logs_dir=Path(tmp) / "jobs" / "run-1" / "task__trial" / "agent",
+                model_name="openai/gpt-4.1",
+            )
+
+            with self.assertRaisesRegex(ValueError, "only supports kimchi-dev"):
+                await agent.run("solve it", object(), AgentContext())
+
+    async def test_allows_unknown_kimchi_model_id(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            agent = RecordingOpenCodeKimchi(
+                logs_dir=Path(tmp) / "jobs" / "run-1" / "task__trial" / "agent",
+                model_name="kimchi-dev/new-model",
+            )
+
+            await agent.run("solve it", object(), AgentContext())
+
+        config = extract_echo_json(agent.agent_commands[0])
+        model_config = config["provider"][KIMCHI_PROVIDER]["models"]["new-model"]
+        self.assertFalse(model_config["reasoning"])
+        self.assertTrue(model_config["tool_call"])
+        self.assertEqual(model_config["limit"], {"context": 12345, "output": 6789})
+        self.assertIn("opencode --model=kimchi-dev/new-model", agent.agent_commands[1])
+        self.assertNotIn("--thinking", agent.agent_commands[1])
+
+    async def test_rejects_model_missing_from_metadata_endpoint(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            agent = RecordingOpenCodeKimchi(
+                logs_dir=Path(tmp) / "jobs" / "run-1" / "task__trial" / "agent",
+                model_name="kimchi-dev/not-returned",
+            )
+
+            with self.assertRaisesRegex(ValueError, "was not returned"):
+                await agent.run("solve it", object(), AgentContext())
+
+    async def test_missing_kimchi_api_key_fails_before_commands(self) -> None:
+        os.environ.pop("KIMCHI_API_KEY", None)
+        with tempfile.TemporaryDirectory() as tmp:
+            agent = RecordingOpenCodeKimchi(
+                logs_dir=Path(tmp) / "jobs" / "run-1" / "task__trial" / "agent",
+                model_name="kimchi-dev/kimi-k2.5",
+            )
+
+            with self.assertRaisesRegex(ValueError, "KIMCHI_API_KEY is required"):
+                await agent.run("solve it", object(), AgentContext())
+
+        self.assertEqual(agent.agent_commands, [])
+
+    async def test_rejects_empty_model_id(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            agent = RecordingOpenCodeKimchi(
+                logs_dir=Path(tmp) / "jobs" / "run-1" / "task__trial" / "agent",
+                model_name="kimchi-dev/",
+            )
+
+            with self.assertRaisesRegex(ValueError, "include a model id"):
+                await agent.run("solve it", object(), AgentContext())
+
+    async def test_preserves_mcp_servers_in_opencode_config(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            agent = RecordingOpenCodeKimchi(
+                logs_dir=Path(tmp) / "jobs" / "run-1" / "task__trial" / "agent",
+                model_name="kimchi-dev/kimi-k2.5",
+                mcp_servers=[
+                    MCPServerConfig(name="local-tools", transport="stdio", command="tool-server", args=["--fast"]),
+                    MCPServerConfig(name="remote-tools", transport="sse", url="https://example.test/mcp"),
+                ],
+            )
+
+            await agent.run("solve it", object(), AgentContext())
+
+        config = extract_echo_json(agent.agent_commands[0])
+        self.assertEqual(config["mcp"]["local-tools"], {"type": "local", "command": ["tool-server", "--fast"]})
+        self.assertEqual(config["mcp"]["remote-tools"], {"type": "remote", "url": "https://example.test/mcp"})
+
+    async def test_opencode_config_deep_merge_allows_job_overrides(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            agent = RecordingOpenCodeKimchi(
+                logs_dir=Path(tmp) / "jobs" / "run-1" / "task__trial" / "agent",
+                model_name="kimchi-dev/kimi-k2.5",
+                opencode_config={
+                    "share": "disabled",
+                    "provider": {
+                        KIMCHI_PROVIDER: {
+                            "options": {"timeout": 600000},
+                            "models": {"kimi-k2.5": {"reasoning": False}},
+                        }
+                    },
+                },
+            )
+
+            await agent.run("solve it", object(), AgentContext())
+
+        config = extract_echo_json(agent.agent_commands[0])
+        provider = config["provider"][KIMCHI_PROVIDER]
+        self.assertEqual(config["share"], "disabled")
+        self.assertEqual(provider["options"]["baseURL"], KIMCHI_BASE_URL)
+        self.assertEqual(provider["options"]["timeout"], 600000)
+        self.assertFalse(provider["models"]["kimi-k2.5"]["reasoning"])
+
+    async def test_registers_skills_before_config_and_run(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            agent = RecordingOpenCodeKimchi(
+                logs_dir=Path(tmp) / "jobs" / "run-1" / "task__trial" / "agent",
+                model_name="kimchi-dev/kimi-k2.5",
+                skills_dir="/skills",
+            )
+
+            await agent.run("solve it", object(), AgentContext())
+
+        self.assertEqual(len(agent.agent_commands), 3)
+        self.assertIn("~/.config/opencode/skills", agent.agent_commands[0])
+        self.assertIn("opencode.json", agent.agent_commands[1])
+        self.assertIn("opencode --model=kimchi-dev/kimi-k2.5", agent.agent_commands[2])
+
+    async def test_opencode_extra_env_overrides_default_fake_vcs(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            agent = RecordingOpenCodeKimchi(
+                logs_dir=Path(tmp) / "jobs" / "run-1" / "task__trial" / "agent",
+                model_name="kimchi-dev/kimi-k2.5",
+                extra_env={"OPENCODE_FAKE_VCS": "none", "OPENCODE_CLIENT": "terminal-bench"},
+            )
+
+            await agent.run("solve it", object(), AgentContext())
+
+        self.assertEqual(agent.agent_envs[0]["OPENCODE_FAKE_VCS"], "none")
+        self.assertEqual(agent.agent_envs[0]["OPENCODE_CLIENT"], "terminal-bench")
+
+    async def test_registers_distinct_small_model_from_metadata(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            agent = RecordingOpenCodeKimchi(
+                logs_dir=Path(tmp) / "jobs" / "run-1" / "task__trial" / "agent",
+                model_name="kimchi-dev/kimi-k2.5",
+                extra_env={"OPENCODE_SMALL_MODEL": "kimchi-dev/minimax-m2.7"},
+            )
+
+            await agent.run("solve it", object(), AgentContext())
+
+        config = extract_echo_json(agent.agent_commands[0])
+        models = config["provider"][KIMCHI_PROVIDER]["models"]
+        self.assertEqual(config["small_model"], "kimchi-dev/minimax-m2.7")
+        self.assertIn("kimi-k2.5", models)
+        self.assertIn("minimax-m2.7", models)
+
+    async def test_rejects_invalid_metadata_response(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            agent = OpenCodeKimchi(
+                logs_dir=Path(tmp) / "jobs" / "run-1" / "task__trial" / "agent",
+                model_name="kimchi-dev/kimi-k2.5",
+            )
+            response = FakeMetadataResponse({
+                "models": [
+                    {
+                        "slug": "kimi-k2.5",
+                        "reasoning": "true",
+                        "limits": {"context_window": "262144", "max_output_tokens": 262144},
+                    }
+                ]
+            })
+
+            with (
+                patch("kimchi_agent.opencode_kimchi.httpx.get", return_value=response) as http_get,
+                self.assertRaisesRegex(RuntimeError, "Failed to parse Kimchi model metadata"),
+            ):
+                await agent.run("solve it", object(), AgentContext())
+
+        http_get.assert_called_once()
+        self.assertEqual(http_get.call_args.kwargs["headers"], {"Authorization": "Bearer test-key"})
+        self.assertEqual(http_get.call_args.kwargs["timeout"], 5)
+        self.assertEqual(http_get.call_args.args, (KIMCHI_MODELS_METADATA_URL,))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION


---
### Kimchi Summary
### What changed
Adds `OpenCodeKimchi`, a Harbor agent adapter that benchmarks the OpenCode scaffold while routing model calls through the Kimchi OpenAI-compatible gateway (`llm.kimchi.dev`). It ships with a convenience runner script and updated documentation for the `terminal-bench-2` suite.

### Why
This enables evaluating OpenCode-based agents against Kimchi-hosted models using live model metadata and gateway-specific provider configuration, which was previously unsupported in the benchmark suite.

### Key changes
- `src/kimchi_agent/opencode_kimchi.py`: New `OpenCodeKimchi` agent. At runtime it fetches model metadata from `llm.kimchi.dev/v1/models/metadata?include_in_cli=true`, validates the selected `kimchi-dev/<model>` against the live catalog, builds an OpenCode provider config with `baseURL` and `pointing to the Kimchi gateway, and conditionally injects `--thinking` for reasoning-capable models.
- `scripts/run-opencode-kimchi.sh`: New runner script that selects `OpenCodeKimchi`, forwards `KIMCHI_API_KEY` into Harbor via `--ae`, and supports optional `OPENCODE_VERSION` pinning.
- `src/kimchi_agent/opencode_kimchi_test.py`: Unit tests covering config generation, metadata caching, MCP serialization, `OPENCODE_SMALL_MODEL` selection, deep-merge overrides, and missing-key / invalid-model error paths.
- `src/kimchi_agent/__init__.py`: Exports `OpenCodeKimchi`.
- `benchmark/terminal-bench-2/README.md`: Documents the new script, environment variables (`KIMCHI_API_KEY`, `OPENCODE_SMALL_MODEL`), and model selection rules.

### Impact
- Entirely additive; existing `run-local.sh` and `run-release.sh` workflows are unchanged.
- `OpenCodeKimchi` requires a valid `KIMCHI_API_KEY` and raises at runtime if the requested model is absent from the Kimchi metadata endpoint or does not use the `kimchi-dev/` provider prefix.