### PR TITLE
fix(auto-mode): show classifier response in case of unparseable output

### DIFF
--- a/src/extensions/permissions/classifier.test.ts
+++ b/src/extensions/permissions/classifier.test.ts
@@ -6,6 +6,7 @@ describe("parseClassifierOutput", () => {
 		const r = parseClassifierOutput(`{ "verdict": "safe", "reason": "project build" }`)
 		expect(r.verdict).toBe("safe")
 		expect(r.reason).toBe("project build")
+		expect(r.ok).toBe(true)
 	})
 
 	it("parses requires-confirmation", () => {
@@ -27,11 +28,13 @@ describe("parseClassifierOutput", () => {
 		const r = parseClassifierOutput("not json at all")
 		expect(r.verdict).toBe("requires-confirmation")
 		expect(r.reason).toContain("unparseable")
+		expect(r.ok).toBe(false)
 	})
 
 	it("falls back on unknown verdict", () => {
 		const r = parseClassifierOutput(`{"verdict":"maybe","reason":"x"}`)
 		expect(r.verdict).toBe("requires-confirmation")
+		expect(r.ok).toBe(false)
 	})
 
 	it("defaults reason when missing", () => {

--- a/src/extensions/permissions/classifier.ts
+++ b/src/extensions/permissions/classifier.ts
@@ -67,10 +67,22 @@ export async function classifyToolCall(
 			.map((c) => c.text)
 			.join("\n")
 
-		return parseClassifierOutput(text)
+		const result = parseClassifierOutput(text)
+
+		if (!result.ok) {
+			const diag = [
+				`model=${model.id}`,
+				`stopReason=${response.stopReason}`,
+				`text=${truncate(text, 200) || "(empty)"}`,
+			].join(" ")
+			return unavailable(`${result.reason} (${diag})`)
+		}
+
+		return result
 	} catch (err) {
 		const aborted = (err as Error)?.name === "AbortError" || controller.signal.aborted
-		return unavailable(aborted ? "classifier timeout" : `classifier error: ${(err as Error).message}`)
+		const reason = aborted ? "classifier timeout" : `classifier error: ${(err as Error).message}`
+		return unavailable(`${reason} (model=${model.id} tool=${call.toolName})`)
 	} finally {
 		clearTimeout(timeoutHandle)
 		signal?.removeEventListener("abort", onOuterAbort)
@@ -90,11 +102,11 @@ export function parseClassifierOutput(raw: string): ClassifierResult {
 	if (!verdict) return unavailable("classifier returned unknown verdict")
 
 	const reason = typeof json.reason === "string" && json.reason.trim() ? json.reason.trim() : "no reason provided"
-	return { verdict, reason }
+	return { verdict, reason, ok: true }
 }
 
 function unavailable(reason: string): ClassifierResult {
-	return { verdict: "requires-confirmation", reason }
+	return { verdict: "requires-confirmation", reason, ok: false }
 }
 
 function normalizeVerdict(v: unknown): ClassifierVerdict | undefined {

--- a/src/extensions/permissions/types.ts
+++ b/src/extensions/permissions/types.ts
@@ -18,6 +18,8 @@ export type ClassifierVerdict = "safe" | "requires-confirmation" | "blocked"
 export interface ClassifierResult {
 	verdict: ClassifierVerdict
 	reason: string
+	/** True when the classifier LLM returned a parseable, well-formed verdict. */
+	ok: boolean
 }
 
 export interface PermissionsConfig {


### PR DESCRIPTION
## Description

Currently it's really hard to pinpoint why classifier fails. All we see is: `Classifier: classifier returned unparseable output`.
This change adds more details: `Classifier: classifier returned unparseable output (model=nemotron-3-super-fp4 stopReason=stop text=I think this command is safe but let me explain why in detail...)`

## Type of Change

<!-- Select all that apply. -->

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

---
### Kimchi Summary
### What changed
Adds an `ok` success flag to `ClassifierResult` and enriches failure messages with diagnostic context when the permissions classifier returns an unparseable, unknown, or errored verdict.

### Why
When auto-mode classification fails, the previous messages gave little insight into which model produced the output or why parsing failed. Including the model ID, stop reason, and raw text in the reason makes it easier to debug downgrades to `requires-confirmation`.

### Key changes
- `src/extensions/permissions/types.ts`: Added `ok: boolean` to `ClassifierResult` to differentiate successful classifications from fallbacks and errors.
- `src/extensions/permissions/classifier.ts`:
  - `parseClassifierOutput` now returns `ok: true` for valid known verdicts and `ok: false` for malformed or unknown responses via `unavailable()`.
  - `classifyToolCall` checks `result.ok`; when false, it appends `model`, `stopReason`, and truncated raw `text` to the returned reason.
  - The `catch` block now embeds `model.id` and `call.toolName` into error reasons.
- `src/extensions/permissions/classifier.test.ts`: Updated assertions to verify `ok` is `true` for safe results and `false` for unparseable or unknown verdicts.

### Impact
Failure `reason` strings are now more verbose and may include raw LLM output (truncated to 200 characters), model IDs, and tool names. This is additive and does not alter verdict logic, but any logging or UI surfacing the reason will display the extra diagnostics.