### PR TITLE
telemetry: verbose fetch + Connection: close for socket error diagnosis

### DIFF
--- a/src/extensions/telemetry.ts
+++ b/src/extensions/telemetry.ts
@@ -95,7 +95,7 @@ async function sendLog(
 ): Promise<void> {
 	if (!config.enabled || !config.endpoint) return
 	const now = nowNano()
-	const headers: Record<string, string> = { "Content-Type": "application/json", ...config.headers }
+	const headers: Record<string, string> = { "Content-Type": "application/json", ...config.headers, Connection: "close" }
 	const payload = {
 		resourceLogs: [
 			{
@@ -132,6 +132,8 @@ async function sendLog(
 			method: "POST",
 			headers,
 			body: JSON.stringify(payload),
+			// @ts-ignore — Bun-only option for detailed socket error messages
+			verbose: true,
 		})
 		if (!res.ok) {
 			console.error(`[telemetry] send failed: ${res.status} ${await res.text()}`)
@@ -161,7 +163,7 @@ async function sendMetrics(
 	if (!config.enabled || !config.metricsEndpoint) return
 	if (metrics.length === 0) return
 	const now = nowNano()
-	const headers: Record<string, string> = { "Content-Type": "application/json", ...config.headers }
+	const headers: Record<string, string> = { "Content-Type": "application/json", ...config.headers, Connection: "close" }
 	const payload = {
 		resourceMetrics: [
 			{
@@ -205,6 +207,8 @@ async function sendMetrics(
 			method: "POST",
 			headers,
 			body: JSON.stringify(payload),
+			// @ts-ignore — Bun-only option for detailed socket error messages
+			verbose: true,
 		})
 		if (!res.ok) {
 			console.error(`[telemetry] metrics send failed: ${res.status} ${await res.text()}`)

--- a/src/extensions/telemetry.ts
+++ b/src/extensions/telemetry.ts
@@ -95,7 +95,7 @@ async function sendLog(
 ): Promise<void> {
 	if (!config.enabled || !config.endpoint) return
 	const now = nowNano()
-	const headers: Record<string, string> = { "Content-Type": "application/json", ...config.headers, Connection: "close" }
+	const headers: Record<string, string> = { "Content-Type": "application/json", ...config.headers }
 	const payload = {
 		resourceLogs: [
 			{
@@ -163,7 +163,7 @@ async function sendMetrics(
 	if (!config.enabled || !config.metricsEndpoint) return
 	if (metrics.length === 0) return
 	const now = nowNano()
-	const headers: Record<string, string> = { "Content-Type": "application/json", ...config.headers, Connection: "close" }
+	const headers: Record<string, string> = { "Content-Type": "application/json", ...config.headers }
 	const payload = {
 		resourceMetrics: [
 			{


### PR DESCRIPTION
## Summary

Adds `verbose: true` to both telemetry fetch calls (`sendLog`, `sendMetrics`) to get detailed socket error messages from Bun instead of the generic "pass verbose: true" hint.

## Context

Two socket errors reported on the telemetry path:
- `[telemetry] send error` (`:140`) — logs endpoint
- `[telemetry] metrics send error` (`:213`) — metrics endpoint (30s flush interval)

Server-side Loki confirms the failing requests never reach the `ai-optimizer` pod. Root cause is unconfirmed — `verbose: true` will expose the underlying TCP error code on next occurrence to distinguish between keep-alive race, NAT timeout, CDN rejection, etc.

---
### Kimchi Summary
### What changed
Adds the Bun-only `verbose` option to `fetch` calls in the telemetry sender so that detailed socket error messages are captured when posting logs and metrics.

### Why
Improves debuggability of transient telemetry network failures by surfacing low-level socket errors that are otherwise swallowed.

### Key changes
- `src/extensions/telemetry.ts`: Added `verbose: true` to the `fetch` request options inside `sendLog` and `sendMetrics`. The option is guarded with `// @ts-ignore` because it is only recognized by Bun’s fetch implementation.