### PR TITLE
feat: layered sandbox cluster detection

### DIFF
--- a/src/extensions/activity.test.ts
+++ b/src/extensions/activity.test.ts
@@ -14,7 +14,7 @@ function connectClient(sockPath: string): { received: string[]; client: net.Sock
 	return { received, client, connected }
 }
 
-describe("ActivityBus – SANDBOX_ID guard", () => {
+describe("ActivityBus – sandbox detection", () => {
 	afterEach(() => {
 		vi.unstubAllEnvs()
 	})
@@ -27,7 +27,7 @@ describe("ActivityBus – SANDBOX_ID guard", () => {
 	})
 
 	it("starts a server when SANDBOX_ID is present", async () => {
-		vi.stubEnv("SANDBOX_ID", "sb-guard")
+		vi.stubEnv("KIMCHI_SANDBOX", "1")
 		const bus = new ActivityBus()
 		await bus.start("session-guard-present")
 		expect(bus.isActive()).toBe(true)
@@ -56,7 +56,7 @@ describe("ActivityBus – send and broadcast", () => {
 	})
 
 	it("broadcasts JSON events as NDJSON lines to connected clients", async () => {
-		vi.stubEnv("SANDBOX_ID", "sb-broadcast")
+		vi.stubEnv("KIMCHI_SANDBOX", "1")
 		bus = new ActivityBus()
 		await bus.start("sess-broadcast")
 
@@ -73,7 +73,7 @@ describe("ActivityBus – send and broadcast", () => {
 	})
 
 	it("does not throw when no clients are connected", async () => {
-		vi.stubEnv("SANDBOX_ID", "sb-noconn")
+		vi.stubEnv("KIMCHI_SANDBOX", "1")
 		bus = new ActivityBus()
 		const b = bus
 		await b.start("sess-noconn")
@@ -93,7 +93,7 @@ describe("ActivityBus – lifecycle", () => {
 	})
 
 	it("cleans up socket file on stop()", async () => {
-		vi.stubEnv("SANDBOX_ID", "sb-cleanup")
+		vi.stubEnv("KIMCHI_SANDBOX", "1")
 		const bus = new ActivityBus()
 		await bus.start("sess-cleanup")
 		expect(existsSync("/tmp/kimchi/sess-cleanup.sock")).toBe(true)
@@ -102,7 +102,7 @@ describe("ActivityBus – lifecycle", () => {
 	})
 
 	it("sends session_shutdown before closing on stop()", async () => {
-		vi.stubEnv("SANDBOX_ID", "sb-shutdownmsg")
+		vi.stubEnv("KIMCHI_SANDBOX", "1")
 		const bus = new ActivityBus()
 		await bus.start("sess-shutdown-msg")
 
@@ -143,7 +143,7 @@ describe("ActivityBus – incoming NDJSON no-op", () => {
 	})
 
 	it("does not crash on malformed or valid incoming data", async () => {
-		vi.stubEnv("SANDBOX_ID", "sb-incoming")
+		vi.stubEnv("KIMCHI_SANDBOX", "1")
 		bus = new ActivityBus()
 		await bus.start("sess-incoming")
 

--- a/src/extensions/activity.ts
+++ b/src/extensions/activity.ts
@@ -1,19 +1,21 @@
 /**
  * activity — Unix domain socket activity bus.
  *
- * Creates /tmp/kimchi/{sessionId}.sock as a net.Server when SANDBOX_ID is set.
+ * Creates /tmp/kimchi/{sessionId}.sock as a net.Server when running inside a
+ * sandbox cluster (detected via isInSandboxCluster(): KIMCHI_SANDBOX=1 or both
+ * homedir() === "/home/sandbox" AND username === "sandbox" as security fallback).
+ *
  * Broadcasts NDJSON activity events to all connected clients (typically one:
  * the kimchi-sandbox-worker sidecar).
  *
  * Incoming NDJSON from clients is parsed but treated as a no-op for now
  * (reserved for future hibernate signals from the worker).
- *
- * Only activates in sandbox environments (SANDBOX_ID env var must be set).
  */
 
 import { chmodSync, mkdirSync, unlinkSync } from "node:fs"
 import net from "node:net"
 import type { ExtensionAPI, ExtensionContext } from "@earendil-works/pi-coding-agent"
+import { isInSandboxCluster } from "../utils/sandbox.js"
 
 const SOCKET_DIR = "/tmp/kimchi"
 
@@ -22,17 +24,17 @@ export class ActivityBus {
 	private sockets: Set<net.Socket> = new Set()
 	private sockPath: string | null = null
 
-	/** True when the server is running (SANDBOX_ID was set and start() succeeded). */
+	/** True when the server is running (sandbox detected and start() succeeded). */
 	isActive(): boolean {
 		return this.server?.listening ?? false
 	}
 
 	/**
 	 * Create the socket dir, unlink any stale socket, and start listening.
-	 * No-op when SANDBOX_ID is not set.
+	 * No-op when not in a sandbox cluster.
 	 */
 	async start(sessionId: string): Promise<void> {
-		if (!process.env.SANDBOX_ID) return
+		if (!isInSandboxCluster()) return
 
 		const sockPath = `${SOCKET_DIR}/${sessionId}.sock`
 		this.sockPath = sockPath
@@ -145,7 +147,7 @@ export class ActivityBus {
 
 export function createActivityExtension(): (pi: ExtensionAPI) => void {
 	return (pi: ExtensionAPI): void => {
-		if (!process.env.SANDBOX_ID) return
+		if (!isInSandboxCluster()) return
 
 		const bus = new ActivityBus()
 

--- a/src/utils/sandbox.test.ts
+++ b/src/utils/sandbox.test.ts
@@ -1,0 +1,98 @@
+import { afterEach, describe, expect, it, vi } from "vitest"
+import { isInSandboxCluster } from "./sandbox.js"
+
+vi.mock("node:os", () => ({
+	homedir: vi.fn(),
+	userInfo: vi.fn(),
+}))
+
+import { homedir, userInfo } from "node:os"
+
+describe("isInSandboxCluster", () => {
+	afterEach(() => {
+		vi.unstubAllEnvs()
+		vi.mocked(homedir).mockReset()
+		vi.mocked(userInfo).mockReset()
+	})
+
+	it("returns true when KIMCHI_SANDBOX=1", () => {
+		vi.stubEnv("KIMCHI_SANDBOX", "1")
+		expect(isInSandboxCluster()).toBe(true)
+	})
+
+	it("returns true when KIMCHI_SANDBOX=true (case-insensitive)", () => {
+		vi.stubEnv("KIMCHI_SANDBOX", "true")
+		expect(isInSandboxCluster()).toBe(true)
+	})
+
+	it("returns false when KIMCHI_SANDBOX is not a truthy value", () => {
+		vi.stubEnv("KIMCHI_SANDBOX", "0")
+		expect(isInSandboxCluster()).toBe(false)
+	})
+
+	it("returns false when no sandbox signals are present", () => {
+		expect(isInSandboxCluster()).toBe(false)
+	})
+
+	it("prioritises KIMCHI_SANDBOX over security-fallback signals", () => {
+		vi.stubEnv("KIMCHI_SANDBOX", "1")
+		expect(isInSandboxCluster()).toBe(true)
+	})
+
+	// ─── Security fallback tests ─────────────────────────────────────────────
+
+	it("returns true when both homedir and username match sandbox signals", () => {
+		vi.mocked(homedir).mockReturnValue("/home/sandbox")
+		vi.mocked(userInfo).mockReturnValue({
+			username: "sandbox",
+			uid: 1000,
+			gid: 1000,
+			shell: "/bin/bash",
+			homedir: "/home/sandbox",
+		})
+		expect(isInSandboxCluster()).toBe(true)
+	})
+
+	it("returns false when only homedir matches but username does not", () => {
+		vi.mocked(homedir).mockReturnValue("/home/sandbox")
+		vi.mocked(userInfo).mockReturnValue({
+			username: "alice",
+			uid: 1000,
+			gid: 1000,
+			shell: "/bin/bash",
+			homedir: "/home/sandbox",
+		})
+		expect(isInSandboxCluster()).toBe(false)
+	})
+
+	it("returns false when only username matches but homedir does not", () => {
+		vi.mocked(homedir).mockReturnValue("/home/alice")
+		vi.mocked(userInfo).mockReturnValue({
+			username: "sandbox",
+			uid: 1000,
+			gid: 1000,
+			shell: "/bin/bash",
+			homedir: "/home/alice",
+		})
+		expect(isInSandboxCluster()).toBe(false)
+	})
+
+	it("returns false when neither fallback signal matches", () => {
+		vi.mocked(homedir).mockReturnValue("/home/alice")
+		vi.mocked(userInfo).mockReturnValue({
+			username: "alice",
+			uid: 1000,
+			gid: 1000,
+			shell: "/bin/bash",
+			homedir: "/home/alice",
+		})
+		expect(isInSandboxCluster()).toBe(false)
+	})
+
+	it("returns false when userInfo() throws (no /etc/passwd entry)", () => {
+		vi.mocked(userInfo).mockImplementation(() => {
+			throw new Error("current uid has no entry in /etc/passwd")
+		})
+		expect(isInSandboxCluster()).toBe(false)
+	})
+})

--- a/src/utils/sandbox.ts
+++ b/src/utils/sandbox.ts
@@ -1,0 +1,24 @@
+import { homedir, userInfo } from "node:os"
+
+/**
+ * Layered detection for CASTAI sandbox cluster environments.
+ *
+ * Used by extensions that behave differently when running inside a
+ * sandboxed worker (e.g. activity bus, permissions bypass, etc.).
+ *
+ * Detection layers (checked in order, first true wins):
+ *   1. KIMCHI_SANDBOX env var ("1" or "true", case-insensitive) — explicit sentinel set by container orchestrator
+ *   2. Security fallback: homedir() === "/home/sandbox" AND username === "sandbox"
+ *      — both must match to avoid false positives if user or home path changes
+ */
+export function isInSandboxCluster(): boolean {
+	if (process.env.KIMCHI_SANDBOX === "1" || process.env.KIMCHI_SANDBOX?.toLowerCase() === "true") return true
+	// Security fallback: both home and user must match to confirm sandbox environment.
+	// Single signal alone is ignored to prevent false positives on user switch/path change.
+	try {
+		if (homedir() === "/home/sandbox" && userInfo().username === "sandbox") return true
+	} catch {
+		// userInfo() throws if UID has no /etc/passwd entry (common in hardened containers)
+	}
+	return false
+}


### PR DESCRIPTION
## What

Replace the `SANDBOX_ID`-only activity bus guard with a layered `isInSandboxCluster()` utility that detects sandbox environments via multiple signals.

## Detection layers

1. `KIMCHI_SANDBOX` env var (`"1"` or `"true"`, case-insensitive) — explicit sentinel set by container orchestrator
2. Security fallback — `homedir() === "/home/sandbox"` AND `username === "sandbox"` — both must match; guarded in `try/catch` to handle `userInfo()` failures gracefully in hardened containers with arbitrary UIDs

## Changes

- `src/utils/sandbox.ts` — `isInSandboxCluster()` shared utility
- `src/utils/sandbox.test.ts` — unit tests for all detection paths including fallback and error paths
- `src/extensions/activity.ts` — replaced bare `SANDBOX_ID` guard with `isInSandboxCluster()`
- doc comments updated

## Container setup

Set `KIMCHI_SANDBOX=1` (or `KIMCHI_SANDBOX=true`) env var in the sandbox container.

Tests pass, lint and typecheck clean.