### PR TITLE
Feat add git repo to teleport

### DIFF
--- a/docs/teleport.md
+++ b/docs/teleport.md
@@ -38,7 +38,7 @@ Spawn a new remote worker with a copy of your current workspace.
 /teleport [name] [flags]
 ```
 
-**What it does:**
+**What it does (rsync mode — default):**
 
 1. Checks pre-flight conditions (idle session, rsync available, API key present, clean working tree).
 2. Prompts for a git token if a git remote is detected (see [Git credentials prompt](#git-credentials-prompt)).
@@ -47,6 +47,17 @@ Spawn a new remote worker with a copy of your current workspace.
 5. Exports and loads your current session history so the remote agent has full context.
 6. Propagates your local git identity (`user.name`, `user.email`) and credentials to the sandbox.
 7. Connects and switches the foreground to the remote session.
+
+**What it does (git-clone mode — with `--git-repo`):**
+
+1. Checks pre-flight conditions (idle session, API key present). Rsync, dirty tree, and workspace size checks are skipped.
+2. Prompts for a git token based on the repository URL's host (see [Git credentials prompt](#git-credentials-prompt)).
+3. Authenticates and provisions a cloud sandbox.
+4. Propagates git identity and credentials to the sandbox (before the clone, so private repos work).
+5. Shallow-clones the repository on the sandbox (`--depth 1`). If `--git-branch` is set, checks out that branch. Use `--no-shallow` for full history.
+6. Connects and switches the foreground to the remote session.
+
+Session history is not transferred in git-clone mode — the remote agent starts fresh.
 
 A progress indicator shows each stage as it completes. Input is locked during the teleport to prevent interference.
 
@@ -65,17 +76,23 @@ A progress indicator shows each stage as it completes. Input is locked during th
 | `--force` | Proceed even if the workspace exceeds the 5 GB size limit. |
 | `--skip-session` | Don't export or load the current session history on the remote. The remote agent starts fresh with no conversation context. |
 | `--no-git-token` | Skip the git token prompt entirely. The remote sandbox won't be able to push/pull from private repositories. |
-| `--exclude <glob>` | Exclude files matching the glob from the rsync. Can be specified multiple times (e.g. `--exclude "*.log" --exclude "tmp/"`). Applied on top of the default excludes (`.git/`, `node_modules/`, etc.). |
-| `--include-ignored` | Include files that are normally excluded by `.gitignore`. By default, gitignored files are not synced. |
+| `--git-repo <url>` | Clone from a git repository URL instead of rsyncing the local workspace. The sandbox will `git clone` the repository. Supports both HTTPS and SSH URLs. When this flag is set, rsync is not needed, and dirty-tree/workspace-size checks are skipped. |
+| `--git-branch <branch>` | Branch to check out after cloning. Requires `--git-repo`. When specified, the clone uses `--single-branch` for faster cloning. If omitted, the repository's default branch is used. |
+| `--no-shallow` | Clone the full git history instead of a shallow clone. Requires `--git-repo`. By default, git-clone mode uses `--depth 1` (only the latest commit) for speed. Use this flag if the agent needs access to git history (e.g. `git log`, `git blame`). |
+| `--exclude <glob>` | Exclude files matching the glob from the rsync. Can be specified multiple times (e.g. `--exclude "*.log" --exclude "tmp/"`). Applied on top of the default excludes (`.git/`, `node_modules/`, etc.). Only applies in rsync mode (without `--git-repo`). |
+| `--include-ignored` | Include files that are normally excluded by `.gitignore`. By default, gitignored files are not synced. Only applies in rsync mode (without `--git-repo`). |
 
 **Examples:**
 
 ```
-/teleport                              # spawn with defaults
+/teleport                              # spawn with defaults (rsync local workspace)
 /teleport my-feature                   # spawn with a name
 /teleport --allow-dirty                # ship uncommitted changes
 /teleport backend --exclude "*.log"    # named session, skip log files
 /teleport --skip-session --no-git-token  # minimal: no session history, no git credentials
+/teleport --git-repo https://github.com/org/repo.git                    # clone a repo instead of rsyncing
+/teleport --git-repo https://github.com/org/repo.git --git-branch main  # clone and check out a specific branch
+/teleport my-task --git-repo git@github.com:org/repo.git --git-branch feature-x  # named session with git clone
 ```
 
 After a successful teleport, a session indicator appears in the prompt (e.g. `(my-feature)` or `(remote)`) showing you're on a remote session.
@@ -273,6 +290,20 @@ On subsequent `/attach` or `/connect` calls, kimchi automatically propagates sav
 ---
 
 ## Common workflows
+
+### Clone a repo on a remote sandbox
+
+```
+/teleport --git-repo https://github.com/org/repo.git --git-branch feature-x
+# ... agent works on the cloned repo ...
+/sync down                     # pull changes back to local
+/detach
+```
+
+This is useful when:
+- You want the agent to work on a different repository than your current workspace.
+- You don't have the repo cloned locally.
+- You want a clean checkout without local modifications.
 
 ### Spawn, work, and return
 

--- a/src/modes/teleport/commands/args.test.ts
+++ b/src/modes/teleport/commands/args.test.ts
@@ -18,6 +18,9 @@ describe("parseTeleportArgs", () => {
 			force: false,
 			skipSession: false,
 			noGitToken: false,
+			gitRepo: undefined,
+			gitBranch: undefined,
+			noShallow: false,
 		})
 	})
 
@@ -65,6 +68,60 @@ describe("parseTeleportArgs", () => {
 	it("throws on an unknown flag", () => {
 		expect(() => parseTeleportArgs("--what")).toThrow(/Unknown flag/)
 	})
+})
+
+it("parses --git-repo", () => {
+	const r = parseTeleportArgs("--git-repo https://github.com/org/repo.git")
+	expect(r.gitRepo).toBe("https://github.com/org/repo.git")
+})
+
+it("parses --git-repo with --git-branch", () => {
+	const r = parseTeleportArgs("--git-repo https://github.com/org/repo.git --git-branch feature-x")
+	expect(r.gitRepo).toBe("https://github.com/org/repo.git")
+	expect(r.gitBranch).toBe("feature-x")
+})
+
+it("parses --git-repo with SSH URL", () => {
+	const r = parseTeleportArgs("--git-repo git@github.com:org/repo.git")
+	expect(r.gitRepo).toBe("git@github.com:org/repo.git")
+})
+
+it("parses --git-repo with name and other flags", () => {
+	const r = parseTeleportArgs("my-session --git-repo https://github.com/org/repo.git --git-branch main --skip-session")
+	expect(r.name).toBe("my-session")
+	expect(r.gitRepo).toBe("https://github.com/org/repo.git")
+	expect(r.gitBranch).toBe("main")
+	expect(r.skipSession).toBe(true)
+})
+
+it("throws when --git-repo has no argument", () => {
+	expect(() => parseTeleportArgs("--git-repo")).toThrow(/--git-repo/)
+})
+
+it("throws when --git-repo is followed by a flag", () => {
+	expect(() => parseTeleportArgs("--git-repo --force")).toThrow(/--git-repo/)
+})
+
+it("throws when --git-branch has no argument", () => {
+	expect(() => parseTeleportArgs("--git-branch")).toThrow(/--git-branch/)
+})
+
+it("throws when --git-branch is used without --git-repo", () => {
+	expect(() => parseTeleportArgs("--git-branch feature-x")).toThrow(/--git-branch requires --git-repo/)
+})
+
+it("parses --no-shallow with --git-repo", () => {
+	const r = parseTeleportArgs("--git-repo https://github.com/org/repo.git --no-shallow")
+	expect(r.noShallow).toBe(true)
+})
+
+it("defaults noShallow to false", () => {
+	const r = parseTeleportArgs("--git-repo https://github.com/org/repo.git")
+	expect(r.noShallow).toBe(false)
+})
+
+it("throws when --no-shallow is used without --git-repo", () => {
+	expect(() => parseTeleportArgs("--no-shallow")).toThrow(/--no-shallow requires --git-repo/)
 })
 
 describe("parseDetachArgs", () => {

--- a/src/modes/teleport/commands/args.ts
+++ b/src/modes/teleport/commands/args.ts
@@ -7,6 +7,12 @@ export interface TeleportArgs {
 	force: boolean
 	skipSession?: boolean
 	noGitToken?: boolean
+	/** Clone from a git repository URL instead of rsyncing the local workspace. */
+	gitRepo?: string
+	/** Branch to check out after cloning (requires --git-repo). */
+	gitBranch?: string
+	/** When true, clone the full history instead of a shallow (depth-1) clone. */
+	noShallow?: boolean
 }
 
 export interface DetachArgs {
@@ -42,6 +48,9 @@ export function parseTeleportArgs(raw: string): TeleportArgs {
 		force: false,
 		skipSession: false,
 		noGitToken: false,
+		gitRepo: undefined,
+		gitBranch: undefined,
+		noShallow: false,
 	}
 	for (let i = 0; i < tokens.length; i++) {
 		const t = tokens[i]
@@ -64,6 +73,28 @@ export function parseTeleportArgs(raw: string): TeleportArgs {
 			case "--no-git-token":
 				result.noGitToken = true
 				break
+			case "--git-repo": {
+				const next = tokens[i + 1]
+				if (!next || next.startsWith("--")) {
+					throw new TeleportArgsError("--git-repo requires a repository URL argument")
+				}
+				result.gitRepo = next
+				i++
+				break
+			}
+			case "--no-shallow": {
+				result.noShallow = true
+				break
+			}
+			case "--git-branch": {
+				const next = tokens[i + 1]
+				if (!next || next.startsWith("--")) {
+					throw new TeleportArgsError("--git-branch requires a branch name argument")
+				}
+				result.gitBranch = next
+				i++
+				break
+			}
 			case "--exclude": {
 				const next = tokens[i + 1]
 				if (!next || next.startsWith("--")) {
@@ -82,6 +113,12 @@ export function parseTeleportArgs(raw: string): TeleportArgs {
 				}
 				result.name = t
 		}
+	}
+	if (result.gitBranch && !result.gitRepo) {
+		throw new TeleportArgsError("--git-branch requires --git-repo")
+	}
+	if (result.noShallow && !result.gitRepo) {
+		throw new TeleportArgsError("--no-shallow requires --git-repo")
 	}
 	return result
 }

--- a/src/modes/teleport/commands/index.ts
+++ b/src/modes/teleport/commands/index.ts
@@ -13,6 +13,7 @@ export {
 	BUSY_WAIT_MS_REMOTE,
 } from "./types.js"
 export {
+	cloneRepoOnSandbox,
 	deriveSandboxDest,
 	isBusy,
 	waitUntilIdle,
@@ -22,7 +23,7 @@ export {
 	rsyncInstallHint,
 	sleep,
 } from "./teleport-helpers.js"
-export { runTeleport } from "./teleport.js"
+export { runTeleport, deriveSandboxDestFromRepoUrl } from "./teleport.js"
 export { runAttach } from "./attach.js"
 export { runDetach } from "./detach.js"
 export { runConnect, type RunConnectInternals } from "./connect.js"

--- a/src/modes/teleport/commands/teleport-helpers.test.ts
+++ b/src/modes/teleport/commands/teleport-helpers.test.ts
@@ -4,8 +4,13 @@ import { mkdtempSync, rmSync } from "node:fs"
 import { tmpdir } from "node:os"
 import { join } from "node:path"
 import { PassThrough } from "node:stream"
-import { afterEach, beforeEach, describe, expect, it } from "vitest"
-import { propagateGitConfigToSandbox, propagateGitCredentialToSandbox, readLocalGitConfig } from "./teleport-helpers.js"
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
+import {
+	cloneRepoOnSandbox,
+	propagateGitConfigToSandbox,
+	propagateGitCredentialToSandbox,
+	readLocalGitConfig,
+} from "./teleport-helpers.js"
 
 describe("readLocalGitConfig", () => {
 	let savedGlobal: string | undefined
@@ -294,5 +299,88 @@ describe("propagateGitCredentialToSandbox", () => {
 		await propagateGitCredentialToSandbox({ ...baseOpts, _spawn: spawner })
 		const opts = calls[0].opts as { env?: Record<string, string> }
 		expect(opts.env?.AUTH_TOKEN).toBe("test-token")
+	})
+})
+
+describe("cloneRepoOnSandbox", () => {
+	it("runs git clone with branch and --single-branch and --depth 1 by default", async () => {
+		const { spawner, calls } = createMockSpawn(0)
+
+		await cloneRepoOnSandbox({
+			remoteHost: "host.example.com",
+			remoteUser: "sandbox",
+			authToken: "test-token",
+			repoUrl: "https://github.com/org/repo.git",
+			destination: "/home/sandbox/repo/",
+			branch: "feature-x",
+			proxyCommand: "fake-proxy %h",
+			_spawn: spawner,
+		})
+
+		expect(calls).toHaveLength(1)
+		// The last SSH arg is the remote command
+		const remoteCmd = calls[0].args[calls[0].args.length - 1]
+		expect(remoteCmd).toContain("git clone")
+		expect(remoteCmd).toContain("--depth 1")
+		expect(remoteCmd).toContain("--branch")
+		expect(remoteCmd).toContain("'feature-x'")
+		expect(remoteCmd).toContain("--single-branch")
+		expect(remoteCmd).toContain("'https://github.com/org/repo.git'")
+		expect(remoteCmd).toContain("'/home/sandbox/repo/'")
+	})
+
+	it("runs git clone without branch flags when branch is omitted", async () => {
+		const { spawner, calls } = createMockSpawn(0)
+
+		await cloneRepoOnSandbox({
+			remoteHost: "host.example.com",
+			remoteUser: "sandbox",
+			authToken: "test-token",
+			repoUrl: "https://github.com/org/repo.git",
+			destination: "/home/sandbox/repo/",
+			proxyCommand: "fake-proxy %h",
+			_spawn: spawner,
+		})
+
+		const remoteCmd = calls[0].args[calls[0].args.length - 1]
+		expect(remoteCmd).toContain("git clone")
+		expect(remoteCmd).toContain("--depth 1")
+		expect(remoteCmd).not.toContain("--branch")
+		expect(remoteCmd).not.toContain("--single-branch")
+	})
+
+	it("omits --depth when shallow is false", async () => {
+		const { spawner, calls } = createMockSpawn(0)
+
+		await cloneRepoOnSandbox({
+			remoteHost: "host.example.com",
+			remoteUser: "sandbox",
+			authToken: "test-token",
+			repoUrl: "https://github.com/org/repo.git",
+			destination: "/home/sandbox/repo/",
+			shallow: false,
+			proxyCommand: "fake-proxy %h",
+			_spawn: spawner,
+		})
+
+		const remoteCmd = calls[0].args[calls[0].args.length - 1]
+		expect(remoteCmd).toContain("git clone")
+		expect(remoteCmd).not.toContain("--depth")
+	})
+
+	it("rejects when ssh exits non-zero", async () => {
+		const { spawner } = createMockSpawn(128)
+
+		await expect(
+			cloneRepoOnSandbox({
+				remoteHost: "host.example.com",
+				remoteUser: "sandbox",
+				authToken: "test-token",
+				repoUrl: "https://github.com/org/repo.git",
+				destination: "/home/sandbox/repo/",
+				proxyCommand: "fake-proxy %h",
+				_spawn: spawner,
+			}),
+		).rejects.toThrow(/ssh exited with code 128/)
 	})
 })

--- a/src/modes/teleport/commands/teleport-helpers.ts
+++ b/src/modes/teleport/commands/teleport-helpers.ts
@@ -7,8 +7,6 @@ import { FALLBACK_TARGET_NAME, SANDBOX_HOME } from "./types.js"
 
 const execAsync = promisify(exec)
 
-export const TELEPORT_DEBUG_LOG = "/tmp/kimchi-teleport-debug.log"
-
 export function sleep(ms: number, signal?: AbortSignal): Promise<void> {
 	return new Promise((resolve, reject) => {
 		const t = setTimeout(resolve, ms)

--- a/src/modes/teleport/commands/teleport-helpers.ts
+++ b/src/modes/teleport/commands/teleport-helpers.ts
@@ -333,3 +333,53 @@ export async function propagateGitConfigToSandbox(opts: PropagateGitConfigOption
 		})
 	}
 }
+
+// ── Git clone on sandbox ────────────────────────────────────────────────────
+
+export interface CloneRepoOnSandboxOptions {
+	remoteHost: string
+	remoteUser: string
+	authToken: string
+	/** Full git remote URL to clone (HTTPS or SSH). */
+	repoUrl: string
+	/** Destination directory on the sandbox. */
+	destination: string
+	/** Branch to check out after cloning. When omitted, the default branch is used. */
+	branch?: string
+	/** When true, perform a shallow clone (depth 1). Defaults to true. */
+	shallow?: boolean
+	signal?: AbortSignal
+	/** Override for the proxy command (test seam). */
+	proxyCommand?: string
+	/** Test seam: injectable spawner. */
+	_spawn?: typeof spawn
+}
+
+/**
+ * Clone a git repository on the remote sandbox via SSH.
+ *
+ * Runs `git clone <url> <dest>` and optionally `git checkout <branch>`.
+ * The clone uses `--single-branch` when a branch is specified for faster
+ * cloning. Throws on non-zero SSH exit (caller handles gracefully).
+ */
+export async function cloneRepoOnSandbox(opts: CloneRepoOnSandboxOptions): Promise<void> {
+	const shallow = opts.shallow ?? true
+	const cloneArgs = ["git clone"]
+	if (shallow) {
+		cloneArgs.push("--depth", "1")
+	}
+	if (opts.branch) {
+		cloneArgs.push("--branch", shellEscapeValue(opts.branch), "--single-branch")
+	}
+	cloneArgs.push(shellEscapeValue(opts.repoUrl), shellEscapeValue(opts.destination))
+
+	await runSshCommandOnSandbox({
+		remoteHost: opts.remoteHost,
+		remoteUser: opts.remoteUser,
+		authToken: opts.authToken,
+		remoteCommand: cloneArgs.join(" "),
+		signal: opts.signal,
+		proxyCommand: opts.proxyCommand,
+		_spawn: opts._spawn,
+	})
+}

--- a/src/modes/teleport/commands/teleport.ts
+++ b/src/modes/teleport/commands/teleport.ts
@@ -1,10 +1,10 @@
 import { randomUUID } from "node:crypto"
-import { dirname } from "node:path"
+import { basename, dirname } from "node:path"
 import type { AgentSession, SessionManager } from "@earendil-works/pi-coding-agent"
 import { readGitToken, writeGitToken } from "../../../config.js"
 import { authenticateRemoteSession, listRemoteSessions, waitForSessionReady } from "../api/index.js"
 import type { AuthenticateResponse } from "../api/types.js"
-import { getGitRemoteHost } from "../git-credentials.js"
+import { getGitRemoteHost, parseHostFromRemoteUrl } from "../git-credentials.js"
 import type { RemoteAgentSession } from "../proxy/agent-session.js"
 import { buildRemoteAgentSession } from "../proxy/builder.js"
 import { BASE_EXCLUDE_GLOBS, RsyncError, runRsync } from "../sync/rsync.js"
@@ -15,6 +15,7 @@ import type { TeleportArgs } from "./args.js"
 import { TeleportRefusal, info, refuse, status, warn } from "./errors.js"
 import { resolveSessionTarget } from "./session-resolve.js"
 import {
+	cloneRepoOnSandbox,
 	deriveSandboxDest,
 	estimateWorkspaceBytes,
 	gitWorkingTreeDirty,
@@ -28,6 +29,7 @@ import {
 } from "./teleport-helpers.js"
 import {
 	BUSY_WAIT_MS_LOCAL,
+	SANDBOX_HOME,
 	SANDBOX_USER,
 	type TeleportContext,
 	WORKSPACE_REFUSE_BYTES,
@@ -54,9 +56,39 @@ async function refreshUIAfterSwap(ctx: TeleportContext): Promise<void> {
 	await rebindAfterSwap(ctx)
 }
 
+/**
+ * Derive a sandbox destination directory from a git remote URL.
+ * Extracts the repository name from the URL path, stripping `.git` suffix.
+ * Falls back to "workspace" if the name cannot be determined.
+ */
+export function deriveSandboxDestFromRepoUrl(repoUrl: string): string {
+	// Try SSH shorthand: git@github.com:org/repo.git
+	const sshMatch = repoUrl.match(/:([^/]+\/)?([^/]+?)(?:\.git)?$/)
+	if (sshMatch?.[2]) return `${SANDBOX_HOME}/${sshMatch[2]}/`
+
+	// Try URL-style
+	try {
+		const parsed = new URL(repoUrl)
+		const segments = parsed.pathname.split("/").filter(Boolean)
+		const last = segments.at(-1)
+		if (last) {
+			const name = last.replace(/\.git$/, "")
+			if (name) return `${SANDBOX_HOME}/${name}/`
+		}
+	} catch {
+		// not a valid URL
+	}
+
+	// Last resort: use basename heuristic
+	const raw = basename(repoUrl.replace(/\.git$/, "").replace(/\/+$/, ""))
+	return raw ? `${SANDBOX_HOME}/${raw}/` : `${SANDBOX_HOME}/workspace/`
+}
+
 export async function runTeleport(args: TeleportArgs, ctx: TeleportContext): Promise<{ host: string }> {
 	const wrapper = ctx.wrapper
 	const homeBase = wrapper.homeBase as AgentSession
+	const isGitCloneMode = !!args.gitRepo
+	const gitRepoUrl = args.gitRepo ?? ""
 
 	// ── 1. Pre-flight ──
 	if (!wrapper.isForegroundHomeBase) {
@@ -79,31 +111,39 @@ export async function runTeleport(args: TeleportArgs, ctx: TeleportContext): Pro
 		}
 	}
 
-	if (!(await whichRsync())) {
-		refuse(ctx, `rsync is not on PATH. ${rsyncInstallHint()}`)
+	// rsync pre-flight only applies in workspace-sync mode
+	if (!isGitCloneMode) {
+		if (!(await whichRsync())) {
+			refuse(ctx, `rsync is not on PATH. ${rsyncInstallHint()}`)
+		}
 	}
 
 	if (!ctx.apiKey) {
 		refuse(ctx, "No API key configured. Run `kimchi setup` to authenticate.")
 	}
 
-	if (!args.allowDirty && (await gitWorkingTreeDirty(ctx.cwd))) {
-		refuse(ctx, "Working tree has uncommitted changes. Re-run with --allow-dirty to ship them.")
-	}
+	// Dirty tree / workspace size checks only apply in workspace-sync mode
+	if (!isGitCloneMode) {
+		if (!args.allowDirty && (await gitWorkingTreeDirty(ctx.cwd))) {
+			refuse(ctx, "Working tree has uncommitted changes. Re-run with --allow-dirty to ship them.")
+		}
 
-	const wsBytes = await estimateWorkspaceBytes(ctx.cwd)
-	if (wsBytes > WORKSPACE_REFUSE_BYTES && !args.force) {
-		const gb = (wsBytes / 1024 / 1024 / 1024).toFixed(1)
-		refuse(ctx, `Workspace is large (${gb} GB). Re-run with --force to proceed.`)
-	}
-	if (wsBytes > WORKSPACE_WARN_BYTES) {
-		const mb = (wsBytes / 1024 / 1024).toFixed(0)
-		warn(ctx, `Workspace is ${mb} MB — sync may take a while.`)
+		const wsBytes = await estimateWorkspaceBytes(ctx.cwd)
+		if (wsBytes > WORKSPACE_REFUSE_BYTES && !args.force) {
+			const gb = (wsBytes / 1024 / 1024 / 1024).toFixed(1)
+			refuse(ctx, `Workspace is large (${gb} GB). Re-run with --force to proceed.`)
+		}
+		if (wsBytes > WORKSPACE_WARN_BYTES) {
+			const mb = (wsBytes / 1024 / 1024).toFixed(0)
+			warn(ctx, `Workspace is ${mb} MB — sync may take a while.`)
+		}
 	}
 
 	// ── 2. Git credentials resolution ──
 	let gitToken: string | undefined
-	const gitHost = await getGitRemoteHost(ctx.cwd)
+	// In git-clone mode, derive the host from the provided repo URL.
+	// In rsync mode, detect from the local git remote.
+	const gitHost = isGitCloneMode ? parseHostFromRemoteUrl(gitRepoUrl) : await getGitRemoteHost(ctx.cwd)
 	if (!args.noGitToken) {
 		if (gitHost) {
 			// Check if we already have a stored token for this host
@@ -139,7 +179,7 @@ export async function runTeleport(args: TeleportArgs, ctx: TeleportContext): Pro
 			authResult = await authenticateRemoteSession(
 				sessionId,
 				ctx.apiKey,
-				`Remote session for ${require("node:path").basename(ctx.cwd)}`,
+				`Remote session for ${isGitCloneMode ? gitRepoUrl : require("node:path").basename(ctx.cwd)}`,
 				{ endpoint: ctx.endpoint },
 			)
 		} catch (err) {
@@ -147,7 +187,7 @@ export async function runTeleport(args: TeleportArgs, ctx: TeleportContext): Pro
 		}
 		progress.complete("Authenticated")
 
-		const sandboxDest = deriveSandboxDest(ctx.cwd)
+		const sandboxDest = isGitCloneMode ? deriveSandboxDestFromRepoUrl(gitRepoUrl) : deriveSandboxDest(ctx.cwd)
 
 		if (args.name) {
 			try {
@@ -172,107 +212,174 @@ export async function runTeleport(args: TeleportArgs, ctx: TeleportContext): Pro
 		}
 		progress.complete("Sandbox ready")
 
+		// ── Git identity & credentials propagation ──
+		// In git-clone mode, credentials MUST be set up before the clone so
+		// private repositories can be accessed. In rsync mode, the original
+		// ordering (after workspace sync) is preserved.
+		const localGitConfig = await readLocalGitConfig(ctx.cwd)
+
+		// Session export variable — used by rsync mode only, but declared here
+		// so it is accessible after the if/else block for session loading.
 		let sessionExport: { localDir: string; remotePath: string } | undefined
-		if (!args.skipSession) {
-			progress.step("Exporting session")
+
+		if (isGitCloneMode) {
+			// Set up identity and credentials before clone
+			if (localGitConfig.name || localGitConfig.email) {
+				progress.step("Setting git identity")
+				try {
+					await propagateGitConfigToSandbox({
+						remoteHost: authResult.host,
+						remoteUser: SANDBOX_USER,
+						authToken: authResult.connectToken,
+						gitName: localGitConfig.name,
+						gitEmail: localGitConfig.email,
+						signal: ctx.signal,
+					})
+					progress.complete("Git identity set")
+				} catch (err) {
+					const msg = err instanceof Error ? err.message : String(err)
+					warn(ctx, `Could not set git identity on sandbox: ${msg}`)
+					progress.complete("Git identity skipped")
+				}
+			}
+			if (gitHost && gitToken) {
+				progress.step("Configuring git credentials")
+				try {
+					await propagateGitCredentialToSandbox({
+						remoteHost: authResult.host,
+						remoteUser: SANDBOX_USER,
+						authToken: authResult.connectToken,
+						gitHost,
+						gitToken,
+						signal: ctx.signal,
+					})
+					wrapper.markGitCredentialsSynced(sessionId)
+					progress.complete("Git credentials configured")
+				} catch (err) {
+					const msg = err instanceof Error ? err.message : String(err)
+					warn(ctx, `Could not configure git credentials on sandbox: ${msg}`)
+					progress.complete("Git credentials skipped")
+				}
+			}
+
+			// ── Clone repository ──
+			progress.step("Cloning repository")
 			try {
-				sessionExport = exportSessionForTeleport({ homeBase, localCwd: ctx.cwd, sandboxDest })
+				await cloneRepoOnSandbox({
+					remoteHost: authResult.host,
+					remoteUser: SANDBOX_USER,
+					authToken: authResult.connectToken,
+					repoUrl: gitRepoUrl,
+					destination: sandboxDest,
+					branch: args.gitBranch,
+					shallow: !args.noShallow,
+					signal: ctx.signal,
+				})
 			} catch (err) {
-				warn(
-					ctx,
-					`Session export failed: ${err instanceof Error ? err.message : String(err)}. Continuing without session.`,
-				)
+				const msg = err instanceof Error ? err.message : String(err)
+				refuse(ctx, `git clone failed: ${msg}\nRemote session ${sessionId} will be cleaned up automatically.`)
 			}
-			progress.complete(sessionExport ? "Session exported" : "Session export skipped")
-		}
-
-		progress.step("Syncing workspace")
-		try {
-			await runRsync({
-				source: ctx.cwd,
-				destination: sandboxDest,
-				remoteHost: authResult.host,
-				remoteUser: SANDBOX_USER,
-				authToken: authResult.connectToken,
-				excludeGlobs: [...BASE_EXCLUDE_GLOBS, ...args.exclude],
-				includeIgnored: args.includeIgnored,
-				signal: ctx.signal,
-			})
-		} catch (err) {
-			let msg: string
-			if (err instanceof RsyncError) {
-				const stderrHead = err.stderr?.trim().slice(0, 1500) ?? ""
-				msg = stderrHead ? `${err.message}\nstderr:\n${stderrHead}` : err.message
-			} else {
-				msg = err instanceof Error ? err.message : String(err)
+			progress.complete("Repository cloned")
+		} else {
+			// ── Rsync mode (original flow) ──
+			if (!args.skipSession) {
+				progress.step("Exporting session")
+				try {
+					sessionExport = exportSessionForTeleport({ homeBase, localCwd: ctx.cwd, sandboxDest })
+				} catch (err) {
+					warn(
+						ctx,
+						`Session export failed: ${err instanceof Error ? err.message : String(err)}. Continuing without session.`,
+					)
+				}
+				progress.complete(sessionExport ? "Session exported" : "Session export skipped")
 			}
-			refuse(ctx, `rsync failed: ${msg}\nRemote session ${sessionId} will be cleaned up automatically.`)
-		}
-		progress.complete("Workspace synced")
 
-		if (!args.skipSession && sessionExport) {
-			progress.step("Syncing session")
+			progress.step("Syncing workspace")
 			try {
 				await runRsync({
-					source: sessionExport.localDir,
-					destination: dirname(sessionExport.remotePath),
+					source: ctx.cwd,
+					destination: sandboxDest,
 					remoteHost: authResult.host,
 					remoteUser: SANDBOX_USER,
 					authToken: authResult.connectToken,
+					excludeGlobs: [...BASE_EXCLUDE_GLOBS, ...args.exclude],
+					includeIgnored: args.includeIgnored,
 					signal: ctx.signal,
-					deleteExtraneous: false,
 				})
-				progress.complete("Session synced")
 			} catch (err) {
-				warn(
-					ctx,
-					`Session sync failed: ${err instanceof Error ? err.message : String(err)}. Continuing without session.`,
-				)
-				progress.complete("Session sync skipped")
-				sessionExport = undefined
+				let msg: string
+				if (err instanceof RsyncError) {
+					const stderrHead = err.stderr?.trim().slice(0, 1500) ?? ""
+					msg = stderrHead ? `${err.message}\nstderr:\n${stderrHead}` : err.message
+				} else {
+					msg = err instanceof Error ? err.message : String(err)
+				}
+				refuse(ctx, `rsync failed: ${msg}\nRemote session ${sessionId} will be cleaned up automatically.`)
 			}
-		}
+			progress.complete("Workspace synced")
 
-		// ── Git identity & credentials propagation ──
-		const localGitConfig = await readLocalGitConfig(ctx.cwd)
-		if (localGitConfig.name || localGitConfig.email) {
-			progress.step("Setting git identity")
-			try {
-				await propagateGitConfigToSandbox({
-					remoteHost: authResult.host,
-					remoteUser: SANDBOX_USER,
-					authToken: authResult.connectToken,
-					gitName: localGitConfig.name,
-					gitEmail: localGitConfig.email,
-					signal: ctx.signal,
-				})
-				progress.complete("Git identity set")
-			} catch (err) {
-				const msg = err instanceof Error ? err.message : String(err)
-				warn(ctx, `Could not set git identity on sandbox: ${msg}`)
-				progress.complete("Git identity skipped")
+			if (!args.skipSession && sessionExport) {
+				progress.step("Syncing session")
+				try {
+					await runRsync({
+						source: sessionExport.localDir,
+						destination: dirname(sessionExport.remotePath),
+						remoteHost: authResult.host,
+						remoteUser: SANDBOX_USER,
+						authToken: authResult.connectToken,
+						signal: ctx.signal,
+						deleteExtraneous: false,
+					})
+					progress.complete("Session synced")
+				} catch (err) {
+					warn(
+						ctx,
+						`Session sync failed: ${err instanceof Error ? err.message : String(err)}. Continuing without session.`,
+					)
+					progress.complete("Session sync skipped")
+					sessionExport = undefined
+				}
 			}
-		} else {
-		}
-		if (gitHost && gitToken) {
-			progress.step("Configuring git credentials")
-			try {
-				await propagateGitCredentialToSandbox({
-					remoteHost: authResult.host,
-					remoteUser: SANDBOX_USER,
-					authToken: authResult.connectToken,
-					gitHost,
-					gitToken,
-					signal: ctx.signal,
-				})
-				wrapper.markGitCredentialsSynced(sessionId)
-				progress.complete("Git credentials configured")
-			} catch (err) {
-				const msg = err instanceof Error ? err.message : String(err)
-				warn(ctx, `Could not configure git credentials on sandbox: ${msg}`)
-				progress.complete("Git credentials skipped")
+
+			// Git identity & credentials (rsync mode — after workspace sync)
+			if (localGitConfig.name || localGitConfig.email) {
+				progress.step("Setting git identity")
+				try {
+					await propagateGitConfigToSandbox({
+						remoteHost: authResult.host,
+						remoteUser: SANDBOX_USER,
+						authToken: authResult.connectToken,
+						gitName: localGitConfig.name,
+						gitEmail: localGitConfig.email,
+						signal: ctx.signal,
+					})
+					progress.complete("Git identity set")
+				} catch (err) {
+					const msg = err instanceof Error ? err.message : String(err)
+					warn(ctx, `Could not set git identity on sandbox: ${msg}`)
+					progress.complete("Git identity skipped")
+				}
 			}
-		} else {
+			if (gitHost && gitToken) {
+				progress.step("Configuring git credentials")
+				try {
+					await propagateGitCredentialToSandbox({
+						remoteHost: authResult.host,
+						remoteUser: SANDBOX_USER,
+						authToken: authResult.connectToken,
+						gitHost,
+						gitToken,
+						signal: ctx.signal,
+					})
+					wrapper.markGitCredentialsSynced(sessionId)
+					progress.complete("Git credentials configured")
+				} catch (err) {
+					const msg = err instanceof Error ? err.message : String(err)
+					warn(ctx, `Could not configure git credentials on sandbox: ${msg}`)
+					progress.complete("Git credentials skipped")
+				}
+			}
 		}
 
 		progress.step("Connecting")
@@ -300,7 +407,7 @@ export async function runTeleport(args: TeleportArgs, ctx: TeleportContext): Pro
 			}
 		}
 
-		if (!args.skipSession && sessionExport) {
+		if (!isGitCloneMode && !args.skipSession && sessionExport) {
 			progress.step("Loading session")
 			try {
 				await remote.switchSession(sessionExport.remotePath)

--- a/src/modes/teleport/teleport.test.ts
+++ b/src/modes/teleport/teleport.test.ts
@@ -13,6 +13,8 @@ import type { RemoteSessionSummary } from "./types.js"
 
 type ExecAsyncImpl = (cmd: string, opts?: unknown) => Promise<{ stdout: string; stderr: string }>
 
+const cloneMock = vi.hoisted(() => vi.fn())
+
 const { execAsyncMock, execMock, authMock, listMock, getMeMock, buildMock, rsyncMock, waitMock } = vi.hoisted(() => {
 	const execAsyncMock = vi.fn<ExecAsyncImpl>(async () => ({ stdout: "", stderr: "" }))
 	const PROMISIFY = Symbol.for("nodejs.util.promisify.custom")
@@ -65,10 +67,19 @@ vi.mock("./sync/rsync.js", () => ({
 	},
 }))
 
+vi.mock("./commands/teleport-helpers.js", async (importOriginal) => {
+	const original = await importOriginal<typeof import("./commands/teleport-helpers.js")>()
+	return {
+		...original,
+		cloneRepoOnSandbox: cloneMock,
+	}
+})
+
 // Imported after vi.mock so module resolution sees the mocks.
 import {
 	TeleportRefusal,
 	deriveSandboxDest,
+	deriveSandboxDestFromRepoUrl,
 	runAttach,
 	runConnect,
 	runDetach,
@@ -214,6 +225,8 @@ beforeEach(() => {
 	buildMock.mockReset()
 	rsyncMock.mockReset()
 	waitMock.mockReset()
+	cloneMock.mockReset()
+	cloneMock.mockResolvedValue(undefined)
 	waitMock.mockResolvedValue({
 		id: "sess",
 		organizationId: "org",
@@ -1076,5 +1089,33 @@ describe("deriveSandboxDest", () => {
 
 	it("keeps leading-dot names (e.g. .dotfiles dir is valid)", () => {
 		expect(deriveSandboxDest("/Users/me/.dotfiles")).toBe("/home/sandbox/.dotfiles/")
+	})
+})
+
+// ───────────────────────── deriveSandboxDestFromRepoUrl ─────────────────────────
+
+describe("deriveSandboxDestFromRepoUrl", () => {
+	it("extracts repo name from HTTPS URL", () => {
+		expect(deriveSandboxDestFromRepoUrl("https://github.com/org/my-repo.git")).toBe("/home/sandbox/my-repo/")
+	})
+
+	it("extracts repo name from HTTPS URL without .git", () => {
+		expect(deriveSandboxDestFromRepoUrl("https://github.com/org/my-repo")).toBe("/home/sandbox/my-repo/")
+	})
+
+	it("extracts repo name from SSH shorthand", () => {
+		expect(deriveSandboxDestFromRepoUrl("git@github.com:org/my-repo.git")).toBe("/home/sandbox/my-repo/")
+	})
+
+	it("extracts repo name from SSH shorthand without .git", () => {
+		expect(deriveSandboxDestFromRepoUrl("git@github.com:org/my-repo")).toBe("/home/sandbox/my-repo/")
+	})
+
+	it("handles nested paths in HTTPS URLs", () => {
+		expect(deriveSandboxDestFromRepoUrl("https://gitlab.com/group/subgroup/project.git")).toBe("/home/sandbox/project/")
+	})
+
+	it("falls back to workspace for unparseable URLs", () => {
+		expect(deriveSandboxDestFromRepoUrl("")).toBe("/home/sandbox/workspace/")
 	})
 })


### PR DESCRIPTION
## Description

<!-- What problem does this PR solve? What changes were made and why? -->


## Type of Change

<!-- Select all that apply. -->

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

---
### Kimchi Summary
### What changed

Adds a git-clone mode to `/teleport` via new flags `--git-repo`, `--git-branch`, and `--no-shallow`. When `--git-repo` is provided, the sandbox clones the specified repository instead of rsyncing the local workspace.

### Why

This supports workflows where the agent needs to work on a different repository than the local workspace, the repo isn't cloned locally, or a clean checkout without local modifications is desired.

### Key changes

- `src/modes/teleport/commands/args.ts`: Adds `--git-repo`, `--git-branch`, and `--no-shallow` to `TeleportArgs` with parsing and cross-flag validation.
- `src/modes/teleport/commands/teleport.ts`: Implements git-clone execution path; skips rsync pre-flight checks (rsync availability, dirty tree, workspace size); derives sandbox destination from repo URL; propagates git identity and credentials before the clone so private repositories work.
- `src/modes/teleport/commands/teleport-helpers.ts`: Adds `cloneRepoOnSandbox()` to run `git clone` over SSH with optional `--depth 1`, `--branch`, and `--single-branch`.
- `docs/teleport.md`: Documents the new flags, git-clone mode behavior, and examples.

### Impact

- Git-clone mode does **not** transfer local session history; the remote agent starts fresh unless `--skip-session` is used in rsync mode.
- Existing rsync-mode behavior is fully preserved when `--git-repo` is omitted.
- `--exclude` and `--include-ignored` only apply to rsync mode and are ignored in git-clone mode.
- `--git-branch` and `--no-shallow` require `--git-repo`.