### PR TITLE
fix(agent-runner): pass telemetryExtension to sub-agent DefaultResourceLoader (LLM-1765)

### DIFF
--- a/src/extensions/telemetry.test.ts
+++ b/src/extensions/telemetry.test.ts
@@ -1015,4 +1015,73 @@ describe("telemetryExtension", () => {
 			await getHandler(handlers, "session_shutdown")()
 		})
 	})
+
+	describe("shared accumulators across sub-agents", () => {
+		it("two extension instances with the same rootSessionId accumulate into shared state", async () => {
+			// Simulate main agent + sub-agent: two extension instances loaded for the same root session.
+			const { handlers: h1, api: api1 } = createMockApi()
+			const { handlers: h2, api: api2 } = createMockApi()
+			const ext1 = telemetryExtension(makeConfig())
+			const ext2 = telemetryExtension(makeConfig())
+			ext1(api1)
+			ext2(api2)
+
+			// Both session_start handlers fire (each agent starts its own session).
+			await getHandler(h1, "session_start")()
+			await getHandler(h2, "session_start")()
+
+			// Main agent records 100 output tokens.
+			await getHandler(
+				h1,
+				"message_end",
+			)({
+				message: {
+					role: "assistant",
+					model: "test-model",
+					provider: "test",
+					timestamp: 1,
+					usage: { input: 0, output: 100, cacheRead: 0, cacheWrite: 0, cost: { total: 0.01 } },
+				},
+			})
+
+			// Sub-agent records 50 output tokens.
+			await getHandler(
+				h2,
+				"message_end",
+			)({
+				message: {
+					role: "assistant",
+					model: "test-model",
+					provider: "test",
+					timestamp: 2,
+					usage: { input: 0, output: 50, cacheRead: 0, cacheWrite: 0, cost: { total: 0.005 } },
+				},
+			})
+
+			// Flush both sessions.
+			await getHandler(h1, "session_shutdown")()
+			await getHandler(h2, "session_shutdown")()
+
+			// There should be exactly one metrics POST (last flush wins, which is the total).
+			const metricsCalls = fetchMock.mock.calls.filter(
+				([url]) => String(url) === "https://api.cast.ai/ai-optimizer/v1beta/metrics:ingest",
+			)
+			expect(metricsCalls.length).toBeGreaterThanOrEqual(1)
+
+			// The last flush must contain the combined 150 output tokens — not just 50.
+			const lastPayload = JSON.parse(String((metricsCalls[metricsCalls.length - 1][1] as RequestInit).body))
+			const metrics = lastPayload.resourceMetrics[0].scopeMetrics[0].metrics
+			const outputMetric = metrics.find(
+				(m: {
+					name: string
+					sum?: {
+						dataPoints: Array<{ asInt?: string; attributes: Array<{ key: string; value: { stringValue: string } }> }>
+					}
+				}) =>
+					m.name === "claude_code.token.usage" &&
+					m.sum?.dataPoints[0]?.attributes?.some((a) => a.key === "type" && a.value.stringValue === "output"),
+			)
+			expect(outputMetric?.sum?.dataPoints[0]?.asInt).toBe("150")
+		})
+	})
 })

--- a/src/extensions/telemetry.ts
+++ b/src/extensions/telemetry.ts
@@ -218,15 +218,52 @@ const TELEMETRY_DRAIN_TIMEOUT_MS = 5_000
 const METRICS_FLUSH_INTERVAL_MS = 30_000
 
 // ---------------------------------------------------------------------------
-// Process-level root session ID
-// All agents (main + sub-agents) in the same process share this ID so that
-// telemetry for a single user request is rolled up under one session.
+// Process-level root session ID + shared accumulators
+//
+// All agents (main + sub-agents) in the same process share rootSessionId so
+// that telemetry rolls up under one session in the backend.
+//
+// Accumulators are keyed by rootSessionId (not per-instance) so that every
+// flush sends the monotonically increasing total across ALL agents. This is
+// required because the backend uses ReplacingMergeTree: rows with the same
+// ORDER BY key are deduplicated and the latest write wins. If each agent
+// flushed from its own isolated counters, the latest sub-agent flush would
+// silently overwrite and discard the main agent's accumulated data.
 // ---------------------------------------------------------------------------
 
+interface SharedAccumulators {
+	cumulativeTokensByModel: Record<string, { input: number; output: number; cacheRead: number; cacheWrite: number }>
+	cumulativeCostByModel: Record<string, number>
+	cumulativeCommitCount: number
+	cumulativePRCount: number
+	cumulativeLocByLanguage: Record<string, { added: number; removed: number }>
+	cumulativeEditDecisions: Record<string, number>
+	sessionStartNano: string
+}
+
 let rootSessionId: string | undefined
+const sharedAccumulators = new Map<string, SharedAccumulators>()
+
+function getOrCreateAccumulators(sessionId: string): SharedAccumulators {
+	if (!sharedAccumulators.has(sessionId)) {
+		sharedAccumulators.set(sessionId, {
+			cumulativeTokensByModel: {},
+			cumulativeCostByModel: {},
+			cumulativeCommitCount: 0,
+			cumulativePRCount: 0,
+			cumulativeLocByLanguage: {},
+			cumulativeEditDecisions: {},
+			sessionStartNano: String(Date.now() * 1_000_000),
+		})
+	}
+	const result = sharedAccumulators.get(sessionId)
+	if (!result) throw new Error(`[telemetry] accumulator missing for sessionId: ${sessionId}`)
+	return result
+}
 
 /** @internal — exposed for testing only */
 export function _resetRootSessionId(): void {
+	if (rootSessionId) sharedAccumulators.delete(rootSessionId)
 	rootSessionId = undefined
 }
 
@@ -240,26 +277,15 @@ export default function telemetryExtension(config: TelemetryConfig) {
 
 		if (!rootSessionId) rootSessionId = crypto.randomUUID()
 		let sessionId = rootSessionId
-		let sessionStartMs = Date.now()
-		let sessionStartNano = String(sessionStartMs * 1_000_000)
+		let sessionStartMs = Date.now() // used for per-instance message duration tracking
 		const sentMessages = new Set<string>()
 		const pendingArgs = new Map<string, { toolName: string; args: unknown }>()
 		const messageStartTimes = new Map<string, number>()
 		const inFlight = new Set<Promise<void>>()
 		let shuttingDown = false
 
-		// Accumulation state for metrics
-		const cumulativeTokensByModel: Record<
-			string,
-			{ input: number; output: number; cacheRead: number; cacheWrite: number }
-		> = {}
-		const cumulativeCostByModel: Record<string, number> = {}
-		let cumulativeCommitCount = 0
-		let cumulativePRCount = 0
-		// Accumulate lines of code per language
-		const cumulativeLocByLanguage: Record<string, { added: number; removed: number }> = {}
-		// Accumulate edit decisions keyed by dimension group
-		const cumulativeEditDecisions: Record<string, number> = {}
+		// Accumulators are shared across all instances with the same rootSessionId.
+		const acc = getOrCreateAccumulators(sessionId)
 
 		let flushTimer: NodeJS.Timeout | undefined
 
@@ -273,7 +299,7 @@ export default function telemetryExtension(config: TelemetryConfig) {
 			const allMetrics: MetricData[] = []
 
 			// Flush token metrics (keyed by model)
-			for (const [model, tokens] of Object.entries(cumulativeTokensByModel)) {
+			for (const [model, tokens] of Object.entries(acc.cumulativeTokensByModel)) {
 				if (tokens.input > 0) {
 					allMetrics.push({
 						name: "claude_code.token.usage",
@@ -309,7 +335,7 @@ export default function telemetryExtension(config: TelemetryConfig) {
 			}
 
 			// Flush cost metrics (keyed by model)
-			for (const [model, cost] of Object.entries(cumulativeCostByModel)) {
+			for (const [model, cost] of Object.entries(acc.cumulativeCostByModel)) {
 				if (cost > 0) {
 					allMetrics.push({
 						name: "claude_code.cost.usage",
@@ -321,27 +347,27 @@ export default function telemetryExtension(config: TelemetryConfig) {
 			}
 
 			// Flush commit count
-			if (cumulativeCommitCount > 0) {
+			if (acc.cumulativeCommitCount > 0) {
 				allMetrics.push({
 					name: "claude_code.commit.count",
 					type: "Sum",
-					value: cumulativeCommitCount,
+					value: acc.cumulativeCommitCount,
 					attrs: { tool_name: "bash", decision: "git_commit" },
 				})
 			}
 
 			// Flush PR count
-			if (cumulativePRCount > 0) {
+			if (acc.cumulativePRCount > 0) {
 				allMetrics.push({
 					name: "claude_code.pull_request.count",
 					type: "Sum",
-					value: cumulativePRCount,
+					value: acc.cumulativePRCount,
 					attrs: { tool_name: "bash", decision: "gh_pr_create" },
 				})
 			}
 
 			// Flush lines of code per language
-			for (const [language, counts] of Object.entries(cumulativeLocByLanguage)) {
+			for (const [language, counts] of Object.entries(acc.cumulativeLocByLanguage)) {
 				if (counts.added > 0) {
 					allMetrics.push({
 						name: "claude_code.lines_of_code.count",
@@ -361,7 +387,7 @@ export default function telemetryExtension(config: TelemetryConfig) {
 			}
 
 			// Flush edit decisions
-			for (const [key, count] of Object.entries(cumulativeEditDecisions)) {
+			for (const [key, count] of Object.entries(acc.cumulativeEditDecisions)) {
 				const parts = key.split("|")
 				const toolName = parts[0]
 				const decision = parts[1]
@@ -376,7 +402,7 @@ export default function telemetryExtension(config: TelemetryConfig) {
 			}
 
 			if (allMetrics.length > 0) {
-				track(sendMetrics(config, sessionId, allMetrics, sessionStartNano))
+				track(sendMetrics(config, sessionId, allMetrics, acc.sessionStartNano))
 			}
 		}
 
@@ -392,21 +418,14 @@ export default function telemetryExtension(config: TelemetryConfig) {
 			if (!rootSessionId) rootSessionId = crypto.randomUUID()
 			sessionId = rootSessionId
 			sessionStartMs = Date.now()
-			sessionStartNano = String(sessionStartMs * 1_000_000)
 			sentMessages.clear()
 			messageStartTimes.clear()
 			pendingArgs.clear()
 			shuttingDown = false
+			// Do NOT reset shared accumulators here — other agents may already have
+			// accumulated data under this rootSessionId that must not be discarded.
 
-			// Reset accumulation state
-			for (const key of Object.keys(cumulativeTokensByModel)) delete cumulativeTokensByModel[key]
-			for (const key of Object.keys(cumulativeCostByModel)) delete cumulativeCostByModel[key]
-			cumulativeCommitCount = 0
-			cumulativePRCount = 0
-			for (const key of Object.keys(cumulativeLocByLanguage)) delete cumulativeLocByLanguage[key]
-			for (const key of Object.keys(cumulativeEditDecisions)) delete cumulativeEditDecisions[key]
-
-			// Start periodic flush timer
+			// Start periodic flush timer for this instance.
 			if (flushTimer) clearInterval(flushTimer)
 			flushTimer = setInterval(() => {
 				flushMetrics()
@@ -465,19 +484,19 @@ export default function telemetryExtension(config: TelemetryConfig) {
 					}),
 				)
 
-				// Accumulate tokens and costs per model
-				if (!cumulativeTokensByModel[model]) {
-					cumulativeTokensByModel[model] = { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 }
+				// Accumulate tokens and costs per model into shared state.
+				if (!acc.cumulativeTokensByModel[model]) {
+					acc.cumulativeTokensByModel[model] = { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 }
 				}
-				cumulativeTokensByModel[model].input += input
-				cumulativeTokensByModel[model].output += output
-				cumulativeTokensByModel[model].cacheRead += cacheRead
-				cumulativeTokensByModel[model].cacheWrite += cacheWrite
+				acc.cumulativeTokensByModel[model].input += input
+				acc.cumulativeTokensByModel[model].output += output
+				acc.cumulativeTokensByModel[model].cacheRead += cacheRead
+				acc.cumulativeTokensByModel[model].cacheWrite += cacheWrite
 
-				if (!cumulativeCostByModel[model]) {
-					cumulativeCostByModel[model] = 0
+				if (!acc.cumulativeCostByModel[model]) {
+					acc.cumulativeCostByModel[model] = 0
 				}
-				cumulativeCostByModel[model] += costTotal
+				acc.cumulativeCostByModel[model] += costTotal
 			} catch (err) {
 				console.error("[telemetry] message_end handler error:", err)
 			}
@@ -497,10 +516,10 @@ export default function telemetryExtension(config: TelemetryConfig) {
 			if (toolName === "bash") {
 				const command = String(args?.command ?? "")
 				if (/git\s+commit\b/.test(command) && !/--dry-run/.test(command)) {
-					cumulativeCommitCount++
+					acc.cumulativeCommitCount++
 				}
 				if (/gh\s+pr\s+create\b/.test(command)) {
-					cumulativePRCount++
+					acc.cumulativePRCount++
 				}
 			}
 
@@ -508,11 +527,11 @@ export default function telemetryExtension(config: TelemetryConfig) {
 				const filePath = String(args?.filePath ?? "")
 				const language = inferLanguage(filePath)
 				const changes = countLineChanges(String(args?.oldString ?? ""), String(args?.newString ?? ""))
-				if (!cumulativeLocByLanguage[language]) cumulativeLocByLanguage[language] = { added: 0, removed: 0 }
-				cumulativeLocByLanguage[language].added += changes.added
-				cumulativeLocByLanguage[language].removed += changes.removed
+				if (!acc.cumulativeLocByLanguage[language]) acc.cumulativeLocByLanguage[language] = { added: 0, removed: 0 }
+				acc.cumulativeLocByLanguage[language].added += changes.added
+				acc.cumulativeLocByLanguage[language].removed += changes.removed
 				const key = ["edit", "accept", language, "auto"].join("|")
-				cumulativeEditDecisions[key] = (cumulativeEditDecisions[key] || 0) + 1
+				acc.cumulativeEditDecisions[key] = (acc.cumulativeEditDecisions[key] || 0) + 1
 			}
 
 			if (toolName === "write") {
@@ -521,10 +540,10 @@ export default function telemetryExtension(config: TelemetryConfig) {
 				const content = String(args?.content ?? "")
 				const trimmedContent = content.endsWith("\n") ? content.replace(/\n+$/, "") : content
 				const actualLines = trimmedContent ? trimmedContent.split("\n").length : 1
-				if (!cumulativeLocByLanguage[language]) cumulativeLocByLanguage[language] = { added: 0, removed: 0 }
-				cumulativeLocByLanguage[language].added += actualLines
+				if (!acc.cumulativeLocByLanguage[language]) acc.cumulativeLocByLanguage[language] = { added: 0, removed: 0 }
+				acc.cumulativeLocByLanguage[language].added += actualLines
 				const key = ["write", "accept", language, "auto"].join("|")
-				cumulativeEditDecisions[key] = (cumulativeEditDecisions[key] || 0) + 1
+				acc.cumulativeEditDecisions[key] = (acc.cumulativeEditDecisions[key] || 0) + 1
 			}
 
 			if (toolName === "multiedit") {
@@ -533,14 +552,14 @@ export default function telemetryExtension(config: TelemetryConfig) {
 				const edits = Array.isArray(args?.edits)
 					? (args.edits as Array<{ oldString?: string; newString?: string }>)
 					: []
-				if (!cumulativeLocByLanguage[language]) cumulativeLocByLanguage[language] = { added: 0, removed: 0 }
+				if (!acc.cumulativeLocByLanguage[language]) acc.cumulativeLocByLanguage[language] = { added: 0, removed: 0 }
 				for (const edit of edits) {
 					const changes = countLineChanges(String(edit.oldString ?? ""), String(edit.newString ?? ""))
-					cumulativeLocByLanguage[language].added += changes.added
-					cumulativeLocByLanguage[language].removed += changes.removed
+					acc.cumulativeLocByLanguage[language].added += changes.added
+					acc.cumulativeLocByLanguage[language].removed += changes.removed
 				}
 				const key = ["multiedit", "accept", language, "auto"].join("|")
-				cumulativeEditDecisions[key] = (cumulativeEditDecisions[key] || 0) + 1
+				acc.cumulativeEditDecisions[key] = (acc.cumulativeEditDecisions[key] || 0) + 1
 			}
 
 			if (toolName === "patch") {
@@ -550,11 +569,11 @@ export default function telemetryExtension(config: TelemetryConfig) {
 				if (typeof oldString === "string" && typeof newString === "string") {
 					const changes = countLineChanges(oldString, newString)
 					const language = inferLanguage(filePath)
-					if (!cumulativeLocByLanguage[language]) cumulativeLocByLanguage[language] = { added: 0, removed: 0 }
-					cumulativeLocByLanguage[language].added += changes.added
-					cumulativeLocByLanguage[language].removed += changes.removed
+					if (!acc.cumulativeLocByLanguage[language]) acc.cumulativeLocByLanguage[language] = { added: 0, removed: 0 }
+					acc.cumulativeLocByLanguage[language].added += changes.added
+					acc.cumulativeLocByLanguage[language].removed += changes.removed
 					const key = ["patch", "accept", language, "auto"].join("|")
-					cumulativeEditDecisions[key] = (cumulativeEditDecisions[key] || 0) + 1
+					acc.cumulativeEditDecisions[key] = (acc.cumulativeEditDecisions[key] || 0) + 1
 				}
 			}
 		})


### PR DESCRIPTION
## Problem

LLM-1765: Background sub-agents created via the Agent tool were not sending OTEL telemetry data. Only the main agent emitted logs and metrics.

## Root cause

The main CLI registers `telemetryExtension` in its `extensionFactories`, but `agent-runner.ts` created sub-agent `DefaultResourceLoader` instances without passing `extensionFactories`, so the telemetry extension was never loaded for sub-agent sessions.

## Fix

- Import `telemetryExtension` and `readTelemetryConfig` in `agent-runner.ts`
- Pass `extensionFactories: [telemetryExtension(readTelemetryConfig())]` to the `DefaultResourceLoader` constructor in `runAgentInner`
- Add a test in `agent-runner.test.ts` asserting that `DefaultResourceLoader` is constructed with `extensionFactories`

## Verification

- Local telemetry trap shows two distinct session IDs (main + sub-agent) both posting to the endpoint
- All agent-runner tests pass (19/19)
- TypeScript typecheck passes cleanly

Fixes LLM-1765

---
### Kimchi Summary
### What changed
Share telemetry accumulators across all extension instances that belong to the same process-level `rootSessionId`. Token usage, cost, commit/PR counts, and edit metrics from main and sub-agents are now aggregated so every flush sends the combined total.

### Why
The backend metrics store uses `ReplacingMergeTree`, which deduplicates rows with the same key and keeps only the latest write. When each agent instance maintained isolated counters, a sub-agent flush would overwrite the main agent's accumulated data and silently drop metrics.

### Key changes
- `src/extensions/telemetry.ts`
  - Added process-level `sharedAccumulators` (`Map<string, SharedAccumulators>`) and `getOrCreateAccumulators()` to share state keyed by `rootSessionId`.
  - Replaced per-instance accumulators (`cumulativeTokensByModel`, `cumulativeCostByModel`, `cumulativeCommitCount`, `cumulativePRCount`, `cumulativeLocByLanguage`, `cumulativeEditDecisions`) with a shared `acc` object.
  - Updated `_resetRootSessionId()` to delete the shared accumulators for the current session to avoid state leaking across tests.
  - Removed accumulator resets from the `session_start` handler so existing shared state is preserved when additional agent instances start.
- `src/extensions/telemetry.test.ts`
  - Added test case verifying that two extension instances sharing the same `rootSessionId` merge their counts into a single metric payload.

### Impact
- Prevents metric data loss when sub-agents flush after the main agent.
- `session_start` no longer wipes accumulation state for an active `rootSessionId`.