### PR TITLE
Revert "telemetry: verbose fetch + Connection: close for socket error diagnosis"

### DIFF
--- a/src/extensions/telemetry.ts
+++ b/src/extensions/telemetry.ts
@@ -132,8 +132,6 @@ async function sendLog(
 			method: "POST",
 			headers,
 			body: JSON.stringify(payload),
-			// @ts-ignore — Bun-only option for detailed socket error messages
-			verbose: true,
 		})
 		if (!res.ok) {
 			console.error(`[telemetry] send failed: ${res.status} ${await res.text()}`)
@@ -207,8 +205,6 @@ async function sendMetrics(
 			method: "POST",
 			headers,
 			body: JSON.stringify(payload),
-			// @ts-ignore — Bun-only option for detailed socket error messages
-			verbose: true,
 		})
 		if (!res.ok) {
 			console.error(`[telemetry] metrics send failed: ${res.status} ${await res.text()}`)


### PR DESCRIPTION
Reverts castai/kimchi#345

---
### Kimchi Summary
### What changed
Reverts the Bun-only `verbose` fetch option from telemetry logging and metrics requests, removing the enhanced socket error diagnostics added in PR #345.

### Why
The `verbose` flag is a non-standard Bun extension that introduces runtime-specific behavior into the telemetry module.

### Key changes
- `src/extensions/telemetry.ts`: Removed `verbose: true` and the associated `@ts-ignore` comments from the `fetch` calls in `sendLog` and `sendMetrics`.

### Impact
Socket-level error details will no longer be emitted for telemetry fetch failures. Standard fetch behavior is restored.