### PR TITLE
Gate activity extension on isInSandboxCluster() at registration level

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -63,6 +63,7 @@ import { setAvailableModels } from "./startup-context.js"
 import { probeTerminalBackground } from "./terminal-bg-probe.js"
 import { installCloudflare524RetryPatch } from "./upstream-retry-patch.js"
 import { getVersion } from "./utils.js"
+import { isInSandboxCluster } from "./utils/sandbox.js"
 
 installCloudflare524RetryPatch()
 
@@ -464,7 +465,7 @@ try {
 			modelGuardExtension,
 			stripImagesExtension,
 			traceIdExtension,
-			activityExtension,
+			...(isInSandboxCluster() ? [activityExtension] : []),
 		]
 
 		if (acpMode) {


### PR DESCRIPTION
Skip registering the activity extension entirely when not running inside a sandbox cluster. The extension already had an internal early-return guard, but this moves the gate to the extensions array so the factory is never invoked outside sandbox.