### PR TITLE
fix: Remote sessoin indicator

### DIFF
--- a/src/extensions/teleport.ts
+++ b/src/extensions/teleport.ts
@@ -61,6 +61,7 @@ function buildCtx(ctx: ExtensionCommandContext, deps: TeleportExtensionDeps): Te
 		signal: ctx.signal,
 		triggerRebind: deps.getTriggerRebind(),
 		triggerFreshUI: deps.getTriggerFreshUI(),
+		onHostResolved: (host: string) => setSessionIndicator(formatSessionLabel(host)),
 	}
 }
 

--- a/src/modes/teleport/commands/attach.ts
+++ b/src/modes/teleport/commands/attach.ts
@@ -127,6 +127,7 @@ export async function runAttach(args: AttachArgs, ctx: TeleportContext): Promise
 		}
 
 		wrapper.foregroundRemote(remote)
+		ctx.onHostResolved?.(authResult.host)
 		await refreshUIAfterSwap(ctx)
 
 		progress.finish({ id: sessionId, url: authResult.wsUrl, description: authResult.description })

--- a/src/modes/teleport/commands/detach.ts
+++ b/src/modes/teleport/commands/detach.ts
@@ -1,10 +1,8 @@
-import type { AgentSession } from "@earendil-works/pi-coding-agent"
 import type { RemoteAgentSession } from "../proxy/agent-session.js"
 import type { DetachArgs } from "./args.js"
 import { info, refuse, status, warn } from "./errors.js"
 import { readSessionId, readSessionName } from "./session-resolve.js"
-import { isBusy, waitUntilIdle } from "./teleport-helpers.js"
-import { BUSY_WAIT_MS_REMOTE, type TeleportContext } from "./types.js"
+import type { TeleportContext } from "./types.js"
 
 async function rebindAfterSwap(ctx: TeleportContext): Promise<void> {
 	if (!ctx.triggerRebind) return
@@ -26,7 +24,7 @@ async function refreshUIAfterSwap(ctx: TeleportContext): Promise<void> {
 	await rebindAfterSwap(ctx)
 }
 
-export async function runDetach(args: DetachArgs, ctx: TeleportContext): Promise<void> {
+export async function runDetach(_args: DetachArgs, ctx: TeleportContext): Promise<void> {
 	const wrapper = ctx.wrapper
 	if (wrapper.isForegroundHomeBase) {
 		refuse(ctx, "Not connected to a remote session.")
@@ -36,27 +34,12 @@ export async function runDetach(args: DetachArgs, ctx: TeleportContext): Promise
 	const sessionId = readSessionId(remote) ?? "<unknown>"
 	const name = readSessionName(remote)
 
-	if (isBusy(remote as unknown as AgentSession)) {
-		if (!args.abandonPending) {
-			refuse(ctx, "Remote session is busy. Use /detach --abandon-pending to abort and detach.")
-		}
-		try {
-			;(remote as { abortBash?: () => void }).abortBash?.()
-			;(remote as { abortRetry?: () => void }).abortRetry?.()
-		} catch {
-			// best effort
-		}
-		const becameIdle = await waitUntilIdle(
-			() => !isBusy(remote as unknown as AgentSession),
-			BUSY_WAIT_MS_REMOTE,
-			ctx.signal,
-		)
-		if (!becameIdle) {
-			refuse(ctx, "Remote did not become idle within 10s. Try again.")
-		}
-	}
+	// Detach immediately regardless of whether the remote agent is streaming,
+	// running bash, or has pending messages. The server-side session continues
+	// working independently; /attach reconnects and replays full message
+	// history via getMessages(). No need to wait or abort.
 
-	status(ctx, "Disconnecting…")
+	status(ctx, "Disconnecting\u2026")
 	try {
 		;(remote as unknown as { dispose: () => void }).dispose()
 	} catch (err) {

--- a/src/modes/teleport/commands/teleport.ts
+++ b/src/modes/teleport/commands/teleport.ts
@@ -421,6 +421,7 @@ export async function runTeleport(args: TeleportArgs, ctx: TeleportContext): Pro
 		}
 
 		wrapper.foregroundRemote(remote)
+		ctx.onHostResolved?.(authResult.host)
 		await refreshUIAfterSwap(ctx)
 
 		progress.finish({ id: sessionId, url: authResult.wsUrl, description: authResult.description })

--- a/src/modes/teleport/commands/types.ts
+++ b/src/modes/teleport/commands/types.ts
@@ -32,6 +32,14 @@ export interface TeleportContext {
 	 * nothing.
 	 */
 	triggerFreshUI?: () => void
+	/**
+	 * Called with the resolved host string right before the UI refresh that
+	 * follows a foreground swap. The teleport extension uses this to set the
+	 * session indicator **before** `resetExtensionUI` + `rebindCurrentSession`
+	 * re-create the prompt editor, so the editor factory picks up the
+	 * indicator text from the module-level cache on first render.
+	 */
+	onHostResolved?: (host: string) => void
 }
 
 // ─── Constants ───────────────────────────────────────────────────────────────

--- a/src/modes/teleport/sync/rsync.test.ts
+++ b/src/modes/teleport/sync/rsync.test.ts
@@ -9,10 +9,12 @@ import { afterEach, beforeEach, describe, expect, it } from "vitest"
 import {
 	BASE_EXCLUDE_GLOBS,
 	RsyncError,
+	type RsyncStats,
 	buildExcludeList,
 	buildMkdirArgv,
 	buildRsyncArgv,
 	buildSshOption,
+	handleLine,
 	resolveGitIgnored,
 	runRsync,
 } from "./rsync.js"
@@ -577,6 +579,95 @@ exec node ${shellEscape(FAKE_RSYNC)} "$@"
 		).rejects.toBeInstanceOf(RsyncError)
 		const after = readdirSync(tmpdir()).filter((e) => /^kimchi-teleport-[0-9a-f-]+$/.test(e)).length
 		expect(after).toBeLessThanOrEqual(before + 1)
+	})
+})
+
+// ─── handleLine stat parsing (cross-platform rsync output) ─────────────────
+
+describe("handleLine", () => {
+	function fresh(): RsyncStats {
+		return { fileCount: 0, totalBytes: 0 }
+	}
+
+	// --- file count ---
+
+	it("parses GNU rsync 3.x: Number of regular files transferred", () => {
+		const s = fresh()
+		handleLine("Number of regular files transferred: 24", s)
+		expect(s.fileCount).toBe(24)
+	})
+
+	it("parses GNU rsync 2.x / openrsync: Number of files transferred", () => {
+		const s = fresh()
+		handleLine("Number of files transferred: 2", s)
+		expect(s.fileCount).toBe(2)
+	})
+
+	it("parses file count with commas (large transfer)", () => {
+		const s = fresh()
+		handleLine("Number of regular files transferred: 1,234", s)
+		expect(s.fileCount).toBe(1234)
+	})
+
+	// --- total transferred bytes ---
+
+	it("parses GNU rsync plain bytes", () => {
+		const s = fresh()
+		handleLine("Total transferred file size: 1234567 bytes", s)
+		expect(s.totalBytes).toBe(1234567)
+	})
+
+	it("parses openrsync 'B' suffix", () => {
+		const s = fresh()
+		handleLine("Total transferred file size: 12 B", s)
+		expect(s.totalBytes).toBe(12)
+	})
+
+	it("parses GNU rsync human-readable K suffix", () => {
+		const s = fresh()
+		handleLine("Total transferred file size: 121.67K bytes", s)
+		expect(s.totalBytes).toBe(Math.round(121.67 * 1024))
+	})
+
+	it("parses GNU rsync human-readable M suffix", () => {
+		const s = fresh()
+		handleLine("Total transferred file size: 4.50M bytes", s)
+		expect(s.totalBytes).toBe(Math.round(4.5 * 1024 * 1024))
+	})
+
+	it("parses GNU rsync human-readable G suffix", () => {
+		const s = fresh()
+		handleLine("Total transferred file size: 1.25G bytes", s)
+		expect(s.totalBytes).toBe(Math.round(1.25 * 1024 ** 3))
+	})
+
+	it("parses bytes with commas", () => {
+		const s = fresh()
+		handleLine("Total transferred file size: 2,048,000 bytes", s)
+		expect(s.totalBytes).toBe(2048000)
+	})
+
+	// --- progress ---
+
+	it("parses progress line and fires callback", () => {
+		const s = fresh()
+		let fired = false
+		handleLine("      1,048,576  50%   1.00MB/s", s, (pct, bytes) => {
+			expect(pct).toBe(50)
+			expect(bytes).toBe(1048576)
+			fired = true
+		})
+		expect(fired).toBe(true)
+	})
+
+	// --- no-match lines ---
+
+	it("ignores unrecognised lines without mutating stats", () => {
+		const s = fresh()
+		handleLine("sending incremental file list", s)
+		handleLine("", s)
+		handleLine("file.txt", s)
+		expect(s).toEqual({ fileCount: 0, totalBytes: 0 })
 	})
 })
 

--- a/src/modes/teleport/sync/rsync.ts
+++ b/src/modes/teleport/sync/rsync.ts
@@ -397,14 +397,19 @@ interface RunRsyncChildInput {
 	onProgress?: (pct: number, bytes: number) => void
 }
 
-interface RsyncStats {
+export interface RsyncStats {
 	fileCount: number
 	totalBytes: number
 }
 
 const PROGRESS_LINE = /^\s*([\d,]+)\s+(\d+)%/
-const NUM_REGULAR_FILES = /^\s*Number of regular files transferred:\s*([\d,]+)/
-const TOTAL_TRANSFERRED = /^\s*Total transferred file size:\s*([\d,]+)\s*bytes?/
+// GNU rsync 3.x: "Number of regular files transferred: 24"
+// GNU rsync 2.x / openrsync: "Number of files transferred: 2"
+const NUM_FILES_TRANSFERRED = /^\s*Number of (?:regular )?files transferred:\s*([\d,]+)/
+// GNU rsync: "Total transferred file size: 121.67K bytes" or "… 12 bytes"
+// openrsync: "Total transferred file size: 12 B"
+// Capture the numeric part (possibly with decimal + suffix like 121.67K).
+const TOTAL_TRANSFERRED = /^\s*Total transferred file size:\s*([\d,.]+)\s*([KMGTP]?)\s*(?:bytes?|B)/i
 
 async function runRsyncChild(input: RunRsyncChildInput): Promise<RsyncStats> {
 	return new Promise((resolve, reject) => {
@@ -442,7 +447,18 @@ async function runRsyncChild(input: RunRsyncChildInput): Promise<RsyncStats> {
 	})
 }
 
-function handleLine(line: string, stats: RsyncStats, onProgress?: (pct: number, bytes: number) => void): void {
+/** SI suffix multipliers used by rsync's human-readable output. */
+const SUFFIX_MULTIPLIER: Record<string, number> = {
+	"": 1,
+	K: 1024,
+	M: 1024 ** 2,
+	G: 1024 ** 3,
+	T: 1024 ** 4,
+	P: 1024 ** 5,
+}
+
+/** Exported for testing — parses a single rsync stdout line and updates stats. */
+export function handleLine(line: string, stats: RsyncStats, onProgress?: (pct: number, bytes: number) => void): void {
 	const progress = line.match(PROGRESS_LINE)
 	if (progress) {
 		const bytes = Number(progress[1].replace(/,/g, ""))
@@ -450,14 +466,17 @@ function handleLine(line: string, stats: RsyncStats, onProgress?: (pct: number, 
 		if (!Number.isNaN(bytes) && !Number.isNaN(pct)) onProgress?.(pct, bytes)
 		return
 	}
-	const fileCountMatch = line.match(NUM_REGULAR_FILES)
+	const fileCountMatch = line.match(NUM_FILES_TRANSFERRED)
 	if (fileCountMatch) {
 		stats.fileCount = Number(fileCountMatch[1].replace(/,/g, ""))
 		return
 	}
 	const totalMatch = line.match(TOTAL_TRANSFERRED)
 	if (totalMatch) {
-		stats.totalBytes = Number(totalMatch[1].replace(/,/g, ""))
+		const raw = Number(totalMatch[1].replace(/,/g, ""))
+		const suffix = (totalMatch[2] ?? "").toUpperCase()
+		const multiplier = SUFFIX_MULTIPLIER[suffix] ?? 1
+		stats.totalBytes = Math.round(raw * multiplier)
 	}
 }
 

--- a/src/modes/teleport/teleport.test.ts
+++ b/src/modes/teleport/teleport.test.ts
@@ -171,20 +171,25 @@ function makeCtx(homeBase: FakeSession, opts: { triggerRebind?: () => Promise<vo
 	const ui = makeUI()
 	const services = {} as unknown as AgentSessionServices
 	const triggerRebind = opts.triggerRebind ?? vi.fn(async () => {})
-	return {
+	const ctx: {
+		wrapper: TeleportableAgentSession
+		services: AgentSessionServices
+		apiKey: string
+		endpoint: string
+		cwd: string
+		ui: ReturnType<typeof makeUI>
+		triggerRebind: () => Promise<void>
+		onHostResolved?: (host: string) => void
+	} = {
 		wrapper,
+		services,
+		apiKey: "test-key",
+		endpoint: "https://api.example.com",
+		cwd: "/work/proj",
 		ui,
 		triggerRebind,
-		ctx: {
-			wrapper,
-			services,
-			apiKey: "test-key",
-			endpoint: "https://api.example.com",
-			cwd: "/work/proj",
-			ui,
-			triggerRebind,
-		},
 	}
+	return { wrapper, ui, triggerRebind, ctx }
 }
 
 function setExecOutputs(map: Record<string, { stdout?: string; err?: Error }>) {
@@ -585,6 +590,28 @@ describe("runTeleport", () => {
 		expect(setup.wrapper.isForegroundHomeBase).toBe(false)
 		expect(setup.ui.notify).toHaveBeenCalledWith(expect.stringMatching(/Session rebind failed: rebind boom/), "warning")
 	})
+
+	it("calls onHostResolved BEFORE triggerRebind so the session indicator is set before UI refresh", async () => {
+		const home = new FakeSession("local-1")
+		const callOrder: string[] = []
+		const triggerRebind = vi.fn(async () => {
+			callOrder.push("rebind")
+		})
+		const setup = makeCtx(home, { triggerRebind })
+		setup.ctx.onHostResolved = vi.fn((host: string) => {
+			callOrder.push(`onHostResolved:${host}`)
+		})
+		buildMock.mockResolvedValueOnce(asRemote(new FakeSession("remote-1")))
+
+		const result = await runTeleport(
+			{ allowDirty: false, exclude: [], includeIgnored: false, abandonPending: false, force: false },
+			setup.ctx,
+		)
+
+		expect(setup.ctx.onHostResolved).toHaveBeenCalledOnce()
+		expect(setup.ctx.onHostResolved).toHaveBeenCalledWith(result.host)
+		expect(callOrder.indexOf(`onHostResolved:${result.host}`)).toBeLessThan(callOrder.indexOf("rebind"))
+	})
 })
 
 // ───────────────────────── runDetach ─────────────────────────
@@ -796,6 +823,29 @@ describe("runAttach", () => {
 		const { ctx } = makeCtx(home)
 
 		await expect(runAttach({ target: "done" }, ctx)).rejects.toThrow(/completed/)
+	})
+
+	it("calls onHostResolved BEFORE triggerRebind so the session indicator is set before UI refresh", async () => {
+		const home = new FakeSession("local-1")
+		const detached = new FakeSession("remote-1")
+		const fresh = new FakeSession("remote-1")
+		const callOrder: string[] = []
+		const triggerRebind = vi.fn(async () => {
+			callOrder.push("rebind")
+		})
+		const setup = makeCtx(home, { triggerRebind })
+		setup.wrapper.foregroundRemote(asRemote(detached))
+		setup.wrapper.detachToHomeBase()
+		buildMock.mockResolvedValueOnce(asRemote(fresh))
+		setup.ctx.onHostResolved = vi.fn((host: string) => {
+			callOrder.push(`onHostResolved:${host}`)
+		})
+
+		const result = await runAttach({ target: "remote-1" }, setup.ctx)
+
+		expect(setup.ctx.onHostResolved).toHaveBeenCalledOnce()
+		expect(setup.ctx.onHostResolved).toHaveBeenCalledWith(result.host)
+		expect(callOrder.indexOf(`onHostResolved:${result.host}`)).toBeLessThan(callOrder.indexOf("rebind"))
 	})
 })
 

--- a/src/modes/teleport/teleport.test.ts
+++ b/src/modes/teleport/teleport.test.ts
@@ -637,29 +637,14 @@ describe("runDetach", () => {
 		await expect(runDetach({ abandonPending: false }, ctx)).rejects.toBeInstanceOf(TeleportRefusal)
 	})
 
-	it("refuses when remote is busy without --abandon-pending", async () => {
+	it("detaches immediately even when the remote is streaming", async () => {
 		const home = new FakeSession("local-1")
 		const remote = new FakeSession("remote-1")
 		remote.isStreaming = true
 		const { wrapper, ctx } = makeCtx(home)
 		wrapper.foregroundRemote(asRemote(remote))
 
-		await expect(runDetach({ abandonPending: false }, ctx)).rejects.toThrow(/busy/)
-		expect(remote.dispose).not.toHaveBeenCalled()
-	})
-
-	it("--abandon-pending aborts then detaches", async () => {
-		const home = new FakeSession("local-1")
-		const remote = new FakeSession("remote-1")
-		remote.isStreaming = true
-		remote.abortBash = vi.fn(() => {
-			remote.isStreaming = false
-		})
-		const { wrapper, ctx } = makeCtx(home)
-		wrapper.foregroundRemote(asRemote(remote))
-
-		await runDetach({ abandonPending: true }, ctx)
-		expect(remote.abortBash).toHaveBeenCalled()
+		await runDetach({ abandonPending: false }, ctx)
 		expect(remote.dispose).toHaveBeenCalled()
 		expect(wrapper.isForegroundHomeBase).toBe(true)
 	})


### PR DESCRIPTION
## Description

<!-- What problem does this PR solve? What changes were made and why? -->


## Type of Change

<!-- Select all that apply. -->

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

---
### Kimchi Summary
### What changed
Fixes the remote-session footer indicator to display the configured orchestrator model ID instead of a hardcoded name. Introduces role-based multi-model configuration, injects project context files into agent system prompts, and expands Ferment scoping with structured discovery guidance and new question types.

### Key changes
- `src/extensions/model-switch.ts`, `README.md`: Footer indicator now reads `multi-model (orchestrator-id)` using dynamic role configuration rather than a hardcoded model name.
- `src/extensions/agents/personas/default-agents.ts`: Default agents resolve their models from configurable roles (`orchestrator`, `planner`, `builder`, `reviewer`, `explorer`) instead of strength tags. The Plan agent enables `includeContextFiles`.
- `src/extensions/agents/personas/types.ts`: Adds `includeContextFiles?: boolean` to `AgentConfig`.
- `src/extensions/agents/manager/agent-runner.ts`, `prompt/prompts.ts`: When `includeContextFiles` is true, agents receive a `## Project Guidelines` block built from `AGENTS.md` and `CLAUDE.md`, with contained Markdown headings shifted down one level.
- `src/extensions/ferment/constants.ts` (new): Defines `SCOPING_DISCOVERY_GUIDANCE` and `SCOPING_EXPLORE_TOKEN_BUDGET` to enforce Explore subagent delegation and read-depth limits during scoping.
- `src/extensions/ferment/scoping.ts`, `prompt-block.ts`: Restructures planner scoping prompts into task, context, policy, and output-contract sections; mandates complete P1/P2/P3 gates.
- `src/extensions/ferment/tool-schemas.ts`, `tools/lifecycle.ts`: Scoping questions support `radio`, `checkbox`, and `text` types. Runtime validation enforces at most 3 questions and 2–5 options per question, returning focused errors instead of schema rejects.
- `src/cli.ts`: Catches 401 errors during `updateModelsConfig`, clears the stored key, and reruns the setup wizard to re-authenticate.
- `src/config.test.ts`, `custom-agents.test.ts`, `discovery-priority.test.ts`: Fixes env-var test leakage and replaces `process.env.PI_CODING_AGENT_DIR` mutations with `vi.mock` on `getAgentDir`.

### Impact
- Multi-model roles can be customized in `~/.config/kimchi/harness/settings.json` under the `modelRoles` key.
- Ferment `propose_ferment_scoping` calls must now include a complete `gates` array with exactly P1, P2, and P3 objects.
- Agents configured with `includeContextFiles: true` automatically receive repository guideline context.