### PR TITLE
fix(subagents): change from Agent(twin) to General Purpose

### DIFF
--- a/src/extensions/agents/index.ts
+++ b/src/extensions/agents/index.ts
@@ -82,7 +82,6 @@ import {
 	formatTokens,
 	formatTurns,
 	getDisplayName,
-	getPromptModeLabel,
 } from "./ui/agent-widget.js"
 
 // ---- Shared helpers ----
@@ -1072,8 +1071,6 @@ Model selection — YOU choose based on task complexity:
 								.toLowerCase()
 						: undefined
 				const agentTags: string[] = []
-				const modeLabel = getPromptModeLabel(subagentType)
-				if (modeLabel) agentTags.push(modeLabel)
 				if (thinking) agentTags.push(`thinking: ${thinking}`)
 				if (resolvedConfig.tokenBudget != null) agentTags.push(`budget: ${formatTokens(resolvedConfig.tokenBudget)}`)
 				if (isolated) agentTags.push("isolated")

--- a/src/extensions/agents/personas/agent-types.ts
+++ b/src/extensions/agents/personas/agent-types.ts
@@ -140,8 +140,8 @@ export function getConfig(type: string): {
 	}
 
 	return {
-		displayName: "Agent",
-		description: "General-purpose agent for complex, multi-step tasks",
+		displayName: "General Purpose",
+		description: "General purpose agent for all kind of tasks.",
 		builtinToolNames: BUILTIN_TOOL_NAMES,
 		extensions: true,
 		skills: true,

--- a/src/extensions/agents/personas/default-agents.ts
+++ b/src/extensions/agents/personas/default-agents.ts
@@ -37,7 +37,7 @@ function buildDefaultAgents(): Map<string, AgentConfig> {
 			AGENT_GENERAL_PURPOSE,
 			{
 				name: AGENT_GENERAL_PURPOSE,
-				displayName: "Agent",
+				displayName: "General Purpose",
 				description: "General-purpose agent for complex, multi-step tasks",
 				extensions: true,
 				skills: true,

--- a/src/extensions/agents/ui/agent-widget.ts
+++ b/src/extensions/agents/ui/agent-widget.ts
@@ -107,11 +107,6 @@ export function getDisplayName(type: SubagentType): string {
 	return getConfig(type).displayName
 }
 
-export function getPromptModeLabel(type: SubagentType): string | undefined {
-	const config = getConfig(type)
-	return config.promptMode === "append" ? "twin" : undefined
-}
-
 function truncateLine(text: string, len = 60): string {
 	const line =
 		text
@@ -214,7 +209,6 @@ export class AgentWidget {
 		theme: Theme,
 	): string {
 		const name = getDisplayName(a.type)
-		const modeLabel = getPromptModeLabel(a.type)
 		const duration = formatMs((a.completedAt ?? Date.now()) - a.startedAt)
 
 		let icon: string
@@ -245,9 +239,8 @@ export class AgentWidget {
 		if (a.toolUses > 0) parts.push(`${a.toolUses} tool use${a.toolUses === 1 ? "" : "s"}`)
 		parts.push(duration)
 
-		const modeTag = modeLabel ? ` ${theme.fg("dim", `(${modeLabel})`)}` : ""
 		const modelTag = a.modelId ? ` ${theme.fg("dim", `[${a.modelId}]`)}` : ""
-		return `${icon} ${theme.fg("dim", name)}${modeTag}${modelTag}  ${theme.fg("dim", a.description)} ${theme.fg("dim", "·")} ${theme.fg("dim", parts.join(" · "))}${statusText}`
+		return `${icon} ${theme.fg("dim", name)}${modelTag}  ${theme.fg("dim", a.description)} ${theme.fg("dim", "·")} ${theme.fg("dim", parts.join(" · "))}${statusText}`
 	}
 
 	private renderWidget(theme: Theme, width: number): string[] {
@@ -277,8 +270,6 @@ export class AgentWidget {
 		const runningLines: string[][] = []
 		for (const a of running) {
 			const name = getDisplayName(a.type)
-			const modeLabel = getPromptModeLabel(a.type)
-			const modeTag = modeLabel ? ` ${theme.fg("dim", `(${modeLabel})`)}` : ""
 			const elapsed = formatMs(Date.now() - a.startedAt)
 
 			const bg = this.agentActivity.get(a.id)
@@ -299,7 +290,7 @@ export class AgentWidget {
 			const modelTag = a.modelId ? ` ${theme.fg("dim", `[${a.modelId}]`)}` : ""
 			runningLines.push([
 				truncate(
-					`${theme.fg("dim", "├─")} ${theme.fg("accent", frame)} ${theme.bold(name)}${modeTag}${modelTag}  ${theme.fg("muted", a.description)} ${theme.fg("dim", "·")} ${theme.fg("dim", statsText)}`,
+					`${theme.fg("dim", "├─")} ${theme.fg("accent", frame)} ${theme.bold(name)}${modelTag}  ${theme.fg("muted", a.description)} ${theme.fg("dim", "·")} ${theme.fg("dim", statsText)}`,
 				),
 				truncate(theme.fg("dim", "│  ") + theme.fg("dim", `  ⎿  ${activity}`)),
 			])

--- a/src/extensions/agents/ui/conversation-viewer.ts
+++ b/src/extensions/agents/ui/conversation-viewer.ts
@@ -28,7 +28,6 @@ import {
 	formatDuration,
 	formatSessionTokens,
 	getDisplayName,
-	getPromptModeLabel,
 } from "./agent-widget.js"
 
 const CHROME_LINES = 6
@@ -107,8 +106,6 @@ export class ConversationViewer implements Component {
 
 		lines.push(hrTop)
 		const name = getDisplayName(this.record.type)
-		const modeLabel = getPromptModeLabel(this.record.type)
-		const modeTag = modeLabel ? ` ${th.fg("dim", `(${modeLabel})`)}` : ""
 		const statusIcon =
 			this.record.status === "running"
 				? th.fg("accent", "●")
@@ -130,7 +127,7 @@ export class ConversationViewer implements Component {
 
 		lines.push(
 			row(
-				`${statusIcon} ${th.bold(name)}${modeTag}  ${th.fg("muted", this.record.description)} ${th.fg("dim", "·")} ${th.fg("dim", headerParts.join(" · "))}`,
+				`${statusIcon} ${th.bold(name)}  ${th.fg("muted", this.record.description)} ${th.fg("dim", "·")} ${th.fg("dim", headerParts.join(" · "))}`,
 			),
 		)
 		lines.push(hrMid)


### PR DESCRIPTION


---
### Kimchi Summary
### What changed
Renames the default subagent display name from **"Agent"** to **"General Purpose"** and removes the **"(twin)"** prompt-mode label that was appended to subagent names in the UI.

### Why
Clarifies the identity of the default catch-all agent and eliminates internal "twin" terminology from user-facing labels.

### Key changes
- `src/extensions/agents/personas/agent-types.ts`: Changed `displayName` to `"General Purpose"` and updated `description`.
- `src/extensions/agents/personas/default-agents.ts`: Changed `displayName` to `"General Purpose"`.
- `src/extensions/agents/ui/agent-widget.ts`: Removed `getPromptModeLabel` helper and all `(twin)` mode tag rendering from finished and running agent widgets.
- `src/extensions/agents/index.ts`: Removed `getPromptModeLabel` import and stopped adding the mode label to agent tags.
- `src/extensions/agents/ui/conversation-viewer.ts`: Removed `getPromptModeLabel` import and stopped rendering the mode tag in conversation headers.

### Impact
Cosmetic UI-only changes with no functional or breaking effects.