### PR TITLE
feat(ferment-plan-improvements): UX improvements for ferment plan refinements

### DIFF
--- a/src/extensions/ferment/commands.test.ts
+++ b/src/extensions/ferment/commands.test.ts
@@ -11,6 +11,7 @@ import {
 	registerFermentCommands,
 	startInteractiveFerment,
 } from "./commands.js"
+import { clearAllPendingPlanReviews, getPendingPlanReview, setPendingPlanReview } from "./plan-review.js"
 import { type FermentRuntime, createDefaultFermentRuntime } from "./runtime.js"
 import { createApplyAndPersist } from "./tool-helpers.js"
 
@@ -47,6 +48,7 @@ beforeEach(() => {
 afterEach(() => {
 	writeFileSyncMock.mockReset()
 	writeFileSyncMock.mockImplementation(actualFs.writeFileSync)
+	clearAllPendingPlanReviews()
 })
 
 interface RegisteredCommand {
@@ -318,6 +320,39 @@ describe("registerFermentCommands", () => {
 			}),
 		)
 		expect(getFermentArgumentCompletions("resume ", h.runtime)).toBeNull()
+	})
+
+	it("/ferment switch clears only the previous active pending plan review", async () => {
+		const h = createHarness()
+		const previous = h.storage.create("Previous Review")
+		const target = h.storage.create("Target Review")
+		h.runtime.setActive(previous)
+		setPendingPlanReview({
+			fermentId: previous.id,
+			fermentName: previous.name,
+			planMarkdown: "# Plan: Previous Review",
+		})
+		setPendingPlanReview({
+			fermentId: target.id,
+			fermentName: target.name,
+			planMarkdown: "# Plan: Target Review",
+		})
+
+		const commands = new Map<string, RegisteredCommand>()
+		const pi = {
+			...h.pi,
+			registerCommand: (name: string, command: RegisteredCommand) => {
+				commands.set(name, command)
+			},
+		} as unknown as ExtensionAPI
+		registerFermentCommands(pi, h.runtime)
+
+		const fermentCommand = commands.get("ferment")
+		if (!fermentCommand) throw new Error("ferment command was not registered")
+		await fermentCommand.handler(`switch "${target.name}"`, h.ctx)
+
+		expect(getPendingPlanReview(previous.id)).toBeUndefined()
+		expect(getPendingPlanReview(target.id)).toBeDefined()
 	})
 
 	it("completes /ferment nested static argument groups", () => {

--- a/src/extensions/ferment/commands.test.ts
+++ b/src/extensions/ferment/commands.test.ts
@@ -631,9 +631,7 @@ describe("registerFermentCommands", () => {
 		expect(h.pi.sendMessage).toHaveBeenCalledWith(
 			expect.objectContaining({
 				customType: "ferment_continuation_nudge",
-				content: [
-					expect.objectContaining({ text: expect.stringContaining("Re-read the current persisted ferment state") }),
-				],
+				content: [expect.objectContaining({ text: expect.stringContaining("Do not call list_ferments first") })],
 				details: expect.objectContaining({ action: "wake_up", expectedAction: "start_step" }),
 			}),
 			{ triggerTurn: true },
@@ -694,9 +692,7 @@ describe("registerFermentCommands", () => {
 		expect(h.pi.sendMessage).toHaveBeenCalledWith(
 			expect.objectContaining({
 				customType: "ferment_continuation_nudge",
-				content: [
-					expect.objectContaining({ text: expect.stringContaining("Re-read the current persisted ferment state") }),
-				],
+				content: [expect.objectContaining({ text: expect.stringContaining("Do not call list_ferments first") })],
 				details: expect.objectContaining({ action: "wake_up", expectedAction: "activate_phase" }),
 			}),
 			{ triggerTurn: true },
@@ -865,9 +861,7 @@ describe("registerFermentCommands", () => {
 		expect(h.pi.sendMessage).toHaveBeenCalledWith(
 			expect.objectContaining({
 				customType: "ferment_continuation_nudge",
-				content: [
-					expect.objectContaining({ text: expect.stringContaining("Re-read the current persisted ferment state") }),
-				],
+				content: [expect.objectContaining({ text: expect.stringContaining("Do not call list_ferments first") })],
 				details: expect.objectContaining({ action: "wake_up", expectedAction: "start_step" }),
 			}),
 			{ triggerTurn: true },
@@ -918,9 +912,7 @@ describe("registerFermentCommands", () => {
 		expect(h.pi.sendMessage).toHaveBeenCalledWith(
 			expect.objectContaining({
 				customType: "ferment_continuation_nudge",
-				content: [
-					expect.objectContaining({ text: expect.stringContaining("Re-read the current persisted ferment state") }),
-				],
+				content: [expect.objectContaining({ text: expect.stringContaining("Do not call list_ferments first") })],
 				details: expect.objectContaining({ action: "wake_up", expectedAction: "start_step" }),
 			}),
 			{ triggerTurn: true },
@@ -1047,9 +1039,7 @@ describe("registerFermentCommands", () => {
 		expect(h.pi.sendMessage).toHaveBeenCalledWith(
 			expect.objectContaining({
 				customType: "ferment_continuation_nudge",
-				content: [
-					expect.objectContaining({ text: expect.stringContaining("Re-read the current persisted ferment state") }),
-				],
+				content: [expect.objectContaining({ text: expect.stringContaining("Do not call list_ferments first") })],
 				details: expect.objectContaining({ action: "wake_up", expectedAction: "activate_phase" }),
 			}),
 			{ triggerTurn: true },

--- a/src/extensions/ferment/commands.test.ts
+++ b/src/extensions/ferment/commands.test.ts
@@ -666,7 +666,7 @@ describe("registerFermentCommands", () => {
 		expect(h.pi.sendMessage).toHaveBeenCalledWith(
 			expect.objectContaining({
 				customType: "ferment_continuation_nudge",
-				content: [expect.objectContaining({ text: expect.stringContaining("Do not call list_ferments first") })],
+				content: [expect.objectContaining({ text: expect.stringContaining("Call start_ferment_step") })],
 				details: expect.objectContaining({ action: "wake_up", expectedAction: "start_step" }),
 			}),
 			{ triggerTurn: true },
@@ -727,7 +727,7 @@ describe("registerFermentCommands", () => {
 		expect(h.pi.sendMessage).toHaveBeenCalledWith(
 			expect.objectContaining({
 				customType: "ferment_continuation_nudge",
-				content: [expect.objectContaining({ text: expect.stringContaining("Do not call list_ferments first") })],
+				content: [expect.objectContaining({ text: expect.stringContaining("Call activate_ferment_phase") })],
 				details: expect.objectContaining({ action: "wake_up", expectedAction: "activate_phase" }),
 			}),
 			{ triggerTurn: true },
@@ -896,7 +896,7 @@ describe("registerFermentCommands", () => {
 		expect(h.pi.sendMessage).toHaveBeenCalledWith(
 			expect.objectContaining({
 				customType: "ferment_continuation_nudge",
-				content: [expect.objectContaining({ text: expect.stringContaining("Do not call list_ferments first") })],
+				content: [expect.objectContaining({ text: expect.stringContaining("Call start_ferment_step") })],
 				details: expect.objectContaining({ action: "wake_up", expectedAction: "start_step" }),
 			}),
 			{ triggerTurn: true },
@@ -947,7 +947,7 @@ describe("registerFermentCommands", () => {
 		expect(h.pi.sendMessage).toHaveBeenCalledWith(
 			expect.objectContaining({
 				customType: "ferment_continuation_nudge",
-				content: [expect.objectContaining({ text: expect.stringContaining("Do not call list_ferments first") })],
+				content: [expect.objectContaining({ text: expect.stringContaining("Call start_ferment_step") })],
 				details: expect.objectContaining({ action: "wake_up", expectedAction: "start_step" }),
 			}),
 			{ triggerTurn: true },
@@ -1074,7 +1074,7 @@ describe("registerFermentCommands", () => {
 		expect(h.pi.sendMessage).toHaveBeenCalledWith(
 			expect.objectContaining({
 				customType: "ferment_continuation_nudge",
-				content: [expect.objectContaining({ text: expect.stringContaining("Do not call list_ferments first") })],
+				content: [expect.objectContaining({ text: expect.stringContaining("Call activate_ferment_phase") })],
 				details: expect.objectContaining({ action: "wake_up", expectedAction: "activate_phase" }),
 			}),
 			{ triggerTurn: true },

--- a/src/extensions/ferment/commands.ts
+++ b/src/extensions/ferment/commands.ts
@@ -10,6 +10,7 @@ import { formatFermentStatus } from "./format.js"
 import { autoInitFromEnv, ensureGitRepo } from "./git-init.js"
 import { appendRefEntry } from "./nudge.js"
 import { buildOneshotNudge } from "./oneshot.js"
+import { clearAllPendingPlanReviews, clearPendingPlanReview } from "./plan-review.js"
 import {
 	buildPhaseActionOptions,
 	buildPhaseDetailTitle,
@@ -293,6 +294,7 @@ async function confirmManualPhaseBoundaryForCommand(
 				return true
 			}
 			setActiveFermentAndApplyProfile(pi, runtime, outcome.ferment)
+			clearPendingPlanReview(active.id)
 			ctx.ui.notify(`Paused "${outcome.ferment.name}". Type /ferment resume to resume.`)
 			return true
 		}
@@ -342,6 +344,7 @@ async function openFermentProgress(pi: ExtensionAPI, ctx: FermentUiContext, runt
 				if (outcome.ok) setActiveFermentAndApplyProfile(pi, runtime, undefined)
 				runtime.clearFermentState(f.id)
 				runtime.clearPendingScope(f.id)
+				clearPendingPlanReview(f.id)
 				atPhaseList = false
 			}
 			continue
@@ -495,6 +498,7 @@ export class FermentCommandController {
 				storage.delete(selected.id)
 				runtime.clearFermentState(selected.id)
 				runtime.clearPendingScope(selected.id)
+				clearPendingPlanReview(selected.id)
 				if (runtime.getActiveId() === selected.id) setActiveFermentAndApplyProfile(pi, runtime, undefined)
 				ctx.ui.notify(`Deleted "${selected.name}"`)
 				return { handled: true }
@@ -542,6 +546,7 @@ export class FermentCommandController {
 			}
 
 			setActiveFermentAndApplyProfile(pi, runtime, outcome.ferment)
+			clearPendingPlanReview(active.id)
 			ctx.ui.notify(`Paused "${outcome.ferment.name}". Type /ferment resume to resume.`)
 			ctx.abort()
 			return { handled: true }
@@ -590,6 +595,7 @@ export class FermentCommandController {
 				storage.delete(f.id)
 				runtime.clearFermentState(f.id)
 				runtime.clearPendingScope(f.id)
+				clearPendingPlanReview(f.id)
 				if (runtime.getActiveId() === f.id) {
 					setActiveFermentAndApplyProfile(pi, runtime, undefined)
 				}
@@ -620,6 +626,7 @@ export class FermentCommandController {
 				}
 
 				const wtWarning = wtCheck.severity === "warn" ? `\n⚠️  ${wtCheck.message}` : ""
+				clearAllPendingPlanReviews()
 				sendBreadcrumb(pi, `Switched to "${f.name}" [${f.status}]${wtWarning}`, "ack", "ferment_ack")
 				resumeFerment(pi, f.id, ctx, runtime)
 			} catch (err) {
@@ -648,6 +655,7 @@ export class FermentCommandController {
 				setActiveFermentAndApplyProfile(pi, runtime, undefined)
 				runtime.clearFermentState(abandonedId)
 				runtime.clearPendingScope(abandonedId)
+				clearPendingPlanReview(abandonedId)
 				ctx.ui.notify(`Ferment "${out.ferment.name}" abandoned.`)
 			}
 			return { handled: true }

--- a/src/extensions/ferment/commands.ts
+++ b/src/extensions/ferment/commands.ts
@@ -10,7 +10,7 @@ import { formatFermentStatus } from "./format.js"
 import { autoInitFromEnv, ensureGitRepo } from "./git-init.js"
 import { appendRefEntry } from "./nudge.js"
 import { buildOneshotNudge } from "./oneshot.js"
-import { clearAllPendingPlanReviews, clearPendingPlanReview } from "./plan-review.js"
+import { clearPendingPlanReview } from "./plan-review.js"
 import {
 	buildPhaseActionOptions,
 	buildPhaseDetailTitle,
@@ -626,7 +626,8 @@ export class FermentCommandController {
 				}
 
 				const wtWarning = wtCheck.severity === "warn" ? `\n⚠️  ${wtCheck.message}` : ""
-				clearAllPendingPlanReviews()
+				const previousActiveId = runtime.getActiveId()
+				if (previousActiveId && previousActiveId !== f.id) clearPendingPlanReview(previousActiveId)
 				sendBreadcrumb(pi, `Switched to "${f.name}" [${f.status}]${wtWarning}`, "ack", "ferment_ack")
 				resumeFerment(pi, f.id, ctx, runtime)
 			} catch (err) {

--- a/src/extensions/ferment/commands.ts
+++ b/src/extensions/ferment/commands.ts
@@ -10,7 +10,6 @@ import { formatFermentStatus } from "./format.js"
 import { autoInitFromEnv, ensureGitRepo } from "./git-init.js"
 import { appendRefEntry } from "./nudge.js"
 import { buildOneshotNudge } from "./oneshot.js"
-import { clearPendingPlanReview } from "./plan-review.js"
 import {
 	buildPhaseActionOptions,
 	buildPhaseDetailTitle,
@@ -294,7 +293,7 @@ async function confirmManualPhaseBoundaryForCommand(
 				return true
 			}
 			setActiveFermentAndApplyProfile(pi, runtime, outcome.ferment)
-			clearPendingPlanReview(active.id)
+			runtime.clearPendingPlanReview(active.id)
 			ctx.ui.notify(`Paused "${outcome.ferment.name}". Type /ferment resume to resume.`)
 			return true
 		}
@@ -343,8 +342,6 @@ async function openFermentProgress(pi: ExtensionAPI, ctx: FermentUiContext, runt
 				const outcome = applyAndPersist(f.id, { type: "abandon" })
 				if (outcome.ok) setActiveFermentAndApplyProfile(pi, runtime, undefined)
 				runtime.clearFermentState(f.id)
-				runtime.clearPendingScope(f.id)
-				clearPendingPlanReview(f.id)
 				atPhaseList = false
 			}
 			continue
@@ -497,8 +494,6 @@ export class FermentCommandController {
 			if (action === "Delete") {
 				storage.delete(selected.id)
 				runtime.clearFermentState(selected.id)
-				runtime.clearPendingScope(selected.id)
-				clearPendingPlanReview(selected.id)
 				if (runtime.getActiveId() === selected.id) setActiveFermentAndApplyProfile(pi, runtime, undefined)
 				ctx.ui.notify(`Deleted "${selected.name}"`)
 				return { handled: true }
@@ -546,7 +541,7 @@ export class FermentCommandController {
 			}
 
 			setActiveFermentAndApplyProfile(pi, runtime, outcome.ferment)
-			clearPendingPlanReview(active.id)
+			runtime.clearPendingPlanReview(active.id)
 			ctx.ui.notify(`Paused "${outcome.ferment.name}". Type /ferment resume to resume.`)
 			ctx.abort()
 			return { handled: true }
@@ -594,8 +589,6 @@ export class FermentCommandController {
 				}
 				storage.delete(f.id)
 				runtime.clearFermentState(f.id)
-				runtime.clearPendingScope(f.id)
-				clearPendingPlanReview(f.id)
 				if (runtime.getActiveId() === f.id) {
 					setActiveFermentAndApplyProfile(pi, runtime, undefined)
 				}
@@ -627,7 +620,7 @@ export class FermentCommandController {
 
 				const wtWarning = wtCheck.severity === "warn" ? `\n⚠️  ${wtCheck.message}` : ""
 				const previousActiveId = runtime.getActiveId()
-				if (previousActiveId && previousActiveId !== f.id) clearPendingPlanReview(previousActiveId)
+				if (previousActiveId && previousActiveId !== f.id) runtime.clearPendingPlanReview(previousActiveId)
 				sendBreadcrumb(pi, `Switched to "${f.name}" [${f.status}]${wtWarning}`, "ack", "ferment_ack")
 				resumeFerment(pi, f.id, ctx, runtime)
 			} catch (err) {
@@ -655,8 +648,6 @@ export class FermentCommandController {
 			if (out.ok) {
 				setActiveFermentAndApplyProfile(pi, runtime, undefined)
 				runtime.clearFermentState(abandonedId)
-				runtime.clearPendingScope(abandonedId)
-				clearPendingPlanReview(abandonedId)
 				ctx.ui.notify(`Ferment "${out.ferment.name}" abandoned.`)
 			}
 			return { handled: true }

--- a/src/extensions/ferment/events.ts
+++ b/src/extensions/ferment/events.ts
@@ -9,6 +9,7 @@ import { autoInitFromEnv, ensureGitRepo } from "./git-init.js"
 import { appendRefEntry, maybeInjectReactiveContinuationNudge, resetReactiveContinuationNudgeCount } from "./nudge.js"
 import { buildOneshotNudge } from "./oneshot.js"
 import { editPhaseProposal } from "./phase-editor.js"
+import { clearAllPendingPlanReviews } from "./plan-review.js"
 import { promptInput, promptSelect } from "./prompt-ui.js"
 import { loadFermentSilently, resumeFerment } from "./resume.js"
 import { type FermentRuntime, defaultFermentRuntime } from "./runtime.js"
@@ -247,6 +248,7 @@ export function registerFermentEvents(pi: ExtensionAPI, runtime: FermentRuntime 
 		runtime.clearAllStepStarts()
 		runtime.clearAllScopingGates()
 		runtime.clearAllPendingScopes()
+		clearAllPendingPlanReviews()
 		clearFermentCache()
 
 		const envId = process.env.KIMCHI_ACTIVE_FERMENT
@@ -302,6 +304,7 @@ export function registerFermentEvents(pi: ExtensionAPI, runtime: FermentRuntime 
 
 	pi.on("session_shutdown", async () => {
 		if (isAgentWorker()) return
+		clearAllPendingPlanReviews()
 		const f = runtime.getActive()
 		if (!f) return
 		if (f.status === "running" || f.status === "planned") {

--- a/src/extensions/ferment/events.ts
+++ b/src/extensions/ferment/events.ts
@@ -9,7 +9,6 @@ import { autoInitFromEnv, ensureGitRepo } from "./git-init.js"
 import { appendRefEntry, maybeInjectReactiveContinuationNudge, resetReactiveContinuationNudgeCount } from "./nudge.js"
 import { buildOneshotNudge } from "./oneshot.js"
 import { editPhaseProposal } from "./phase-editor.js"
-import { clearAllPendingPlanReviews } from "./plan-review.js"
 import { promptInput, promptSelect } from "./prompt-ui.js"
 import { loadFermentSilently, resumeFerment } from "./resume.js"
 import { type FermentRuntime, defaultFermentRuntime } from "./runtime.js"
@@ -248,7 +247,7 @@ export function registerFermentEvents(pi: ExtensionAPI, runtime: FermentRuntime 
 		runtime.clearAllStepStarts()
 		runtime.clearAllScopingGates()
 		runtime.clearAllPendingScopes()
-		clearAllPendingPlanReviews()
+		runtime.clearAllPendingPlanReviews()
 		clearFermentCache()
 
 		const envId = process.env.KIMCHI_ACTIVE_FERMENT
@@ -304,7 +303,7 @@ export function registerFermentEvents(pi: ExtensionAPI, runtime: FermentRuntime 
 
 	pi.on("session_shutdown", async () => {
 		if (isAgentWorker()) return
-		clearAllPendingPlanReviews()
+		runtime.clearAllPendingPlanReviews()
 		const f = runtime.getActive()
 		if (!f) return
 		if (f.status === "running" || f.status === "planned") {

--- a/src/extensions/ferment/index.test.ts
+++ b/src/extensions/ferment/index.test.ts
@@ -901,12 +901,6 @@ describe("fermentExtension question dropdown", () => {
 				}),
 				expect.anything(),
 			)
-			expect(pi.sendMessage).toHaveBeenCalledWith(
-				expect.objectContaining({
-					content: [expect.objectContaining({ text: expect.stringContaining("Do not call list_ferments first") })],
-				}),
-				expect.anything(),
-			)
 		} finally {
 			vi.useRealTimers()
 		}
@@ -1024,7 +1018,7 @@ describe("fermentExtension question dropdown", () => {
 			)
 			expect(pi.sendMessage).toHaveBeenCalledWith(
 				expect.objectContaining({
-					content: expect.stringContaining("Do not call list_ferments or scope_ferment"),
+					content: expect.stringContaining("Do not call scope_ferment"),
 				}),
 				expect.anything(),
 			)

--- a/src/extensions/ferment/index.test.ts
+++ b/src/extensions/ferment/index.test.ts
@@ -912,6 +912,65 @@ describe("fermentExtension question dropdown", () => {
 		}
 	})
 
+	it("runs the pending plan review captured before the agent_end timer", async () => {
+		vi.useFakeTimers()
+		try {
+			const storage = new FermentEventStore(mkdtempSync(join(tmpdir(), "ferment-index-plan-review-race-test-")))
+			const runtime: FermentRuntime = {
+				...createDefaultFermentRuntime(),
+				getStorage: () => storage,
+			}
+			runtime.setContinuationPolicy("automated")
+			const firstDraft = storage.create("First Deferred Review")
+			const secondDraft = storage.create("Second Deferred Review")
+			runtime.setActive(firstDraft)
+			runtime.setPendingScope(firstDraft.id, {
+				goal: "First goal",
+				successCriteria: "First works",
+				constraints: [],
+				phases: [{ name: "First phase", goal: "Build first", steps: [] }],
+			})
+			runtime.setPendingScope(secondDraft.id, {
+				goal: "Second goal",
+				successCriteria: "Second works",
+				constraints: [],
+				phases: [{ name: "Second phase", goal: "Build second", steps: [] }],
+			})
+			setPendingPlanReview({
+				fermentId: firstDraft.id,
+				fermentName: firstDraft.name,
+				planMarkdown: "# Plan: First Deferred Review",
+			})
+			setPendingPlanReview({
+				fermentId: secondDraft.id,
+				fermentName: secondDraft.name,
+				planMarkdown: "# Plan: Second Deferred Review",
+			})
+
+			const { handlers } = registerFermentExtension(runtime)
+			const agentEnd = handlers.get("agent_end")
+			if (!agentEnd) throw new Error("agent_end handler was not registered")
+			const ctx = {
+				ui: {
+					custom: vi.fn().mockResolvedValue({ kind: "start" }),
+					notify: vi.fn(),
+					setWorkingVisible: vi.fn(),
+				},
+			}
+
+			await agentEnd({ type: "agent_end" }, ctx)
+			runtime.setActive(secondDraft)
+			await vi.runOnlyPendingTimersAsync()
+
+			expect(storage.get(firstDraft.id)?.status).toBe("planned")
+			expect(storage.get(secondDraft.id)?.status).toBe("draft")
+			expect(getPendingPlanReview(firstDraft.id)).toBeUndefined()
+			expect(getPendingPlanReview(secondDraft.id)).toBeDefined()
+		} finally {
+			vi.useRealTimers()
+		}
+	})
+
 	it("routes pending plan review feedback as hidden replanning input after agent_end", async () => {
 		vi.useFakeTimers()
 		try {
@@ -969,6 +1028,49 @@ describe("fermentExtension question dropdown", () => {
 				}),
 				expect.anything(),
 			)
+		} finally {
+			vi.useRealTimers()
+		}
+	})
+
+	it("keeps pending plan review when the review dialog is cancelled", async () => {
+		vi.useFakeTimers()
+		try {
+			const storage = new FermentEventStore(mkdtempSync(join(tmpdir(), "ferment-index-plan-review-cancel-test-")))
+			const runtime: FermentRuntime = {
+				...createDefaultFermentRuntime(),
+				getStorage: () => storage,
+			}
+			const draft = storage.create("Cancelled Review")
+			runtime.setActive(draft)
+			runtime.setPendingScope(draft.id, {
+				goal: "Goal",
+				successCriteria: "Works",
+				constraints: [],
+				phases: [{ name: "Phase", goal: "Build", steps: [] }],
+			})
+			setPendingPlanReview({
+				fermentId: draft.id,
+				fermentName: draft.name,
+				planMarkdown: "# Plan: Cancelled Review",
+			})
+
+			const { handlers, pi } = registerFermentExtension(runtime)
+			const agentEnd = handlers.get("agent_end")
+			if (!agentEnd) throw new Error("agent_end handler was not registered")
+			const ctx = {
+				ui: {
+					custom: vi.fn().mockResolvedValue({ kind: "cancelled", reason: "decision_cancelled" }),
+					setWorkingVisible: vi.fn(),
+				},
+			}
+
+			await agentEnd({ type: "agent_end" }, ctx)
+			await vi.runOnlyPendingTimersAsync()
+
+			expect(storage.get(draft.id)?.status).toBe("draft")
+			expect(getPendingPlanReview(draft.id)).toBeDefined()
+			expect(pi.sendMessage).not.toHaveBeenCalled()
 		} finally {
 			vi.useRealTimers()
 		}

--- a/src/extensions/ferment/index.test.ts
+++ b/src/extensions/ferment/index.test.ts
@@ -10,6 +10,7 @@ import type { Ferment } from "../../ferment/types.js"
 import { globalTipRegistry } from "../tips/registry.js"
 import fermentExtension from "./index.js"
 import { resetAllReactiveContinuationNudgeCounts } from "./nudge.js"
+import { clearAllPendingPlanReviews, getPendingPlanReview, setPendingPlanReview } from "./plan-review.js"
 import { type FermentRuntime, createDefaultFermentRuntime } from "./runtime.js"
 import { getActive, isAutomatedContinuationEnabled, setActive, setContinuationPolicy } from "./state.js"
 import { createApplyAndPersist } from "./tool-helpers.js"
@@ -80,6 +81,7 @@ afterEach(() => {
 	setActive(undefined)
 	setContinuationPolicy("manual")
 	globalTipRegistry.clear()
+	clearAllPendingPlanReviews()
 	requestSharedFooterRenderMock.mockClear()
 	resetAllReactiveContinuationNudgeCounts()
 	Reflect.deleteProperty(process.env, "KIMCHI_SUBAGENT")
@@ -839,6 +841,184 @@ describe("fermentExtension question dropdown", () => {
 			expect.objectContaining({ customType: "ferment_continuation_nudge" }),
 			expect.anything(),
 		)
+	})
+
+	it("opens pending plan review after agent_end macrotask and starts execution", async () => {
+		vi.useFakeTimers()
+		try {
+			const storage = new FermentEventStore(mkdtempSync(join(tmpdir(), "ferment-index-plan-review-start-test-")))
+			const runtime: FermentRuntime = {
+				...createDefaultFermentRuntime(),
+				getStorage: () => storage,
+			}
+			runtime.setContinuationPolicy("automated")
+			const draft = storage.create("Deferred Review")
+			runtime.setActive(draft)
+			runtime.setPendingScope(draft.id, {
+				goal: "Goal",
+				successCriteria: "Works",
+				constraints: [],
+				phases: [{ name: "Phase", goal: "Build", steps: [] }],
+			})
+			setPendingPlanReview({
+				fermentId: draft.id,
+				fermentName: draft.name,
+				planMarkdown: "# Plan: Deferred Review",
+			})
+
+			const { handlers, pi } = registerFermentExtension(runtime)
+			const agentEnd = handlers.get("agent_end")
+			if (!agentEnd) throw new Error("agent_end handler was not registered")
+			const ctx = {
+				ui: {
+					custom: vi.fn().mockResolvedValue({ kind: "start" }),
+					notify: vi.fn(),
+					setWorkingVisible: vi.fn(),
+				},
+			}
+
+			await agentEnd({ type: "agent_end" }, ctx)
+			expect(ctx.ui.custom).not.toHaveBeenCalled()
+
+			await vi.runOnlyPendingTimersAsync()
+
+			expect(ctx.ui.custom).toHaveBeenCalled()
+			expect(storage.get(draft.id)?.status).toBe("planned")
+			expect(getPendingPlanReview(draft.id)).toBeUndefined()
+			expect(pi.sendMessage).toHaveBeenCalledWith(
+				expect.objectContaining({ customType: "ferment_continuation_nudge", display: false }),
+				expect.objectContaining({ triggerTurn: true, deliverAs: "followUp" }),
+			)
+			expect(pi.sendMessage).toHaveBeenCalledWith(
+				expect.objectContaining({
+					content: [
+						expect.objectContaining({
+							text: expect.stringContaining(
+								`Call activate_ferment_phase with ferment_id "${draft.id}" and phase_id "phase-1"`,
+							),
+						}),
+					],
+				}),
+				expect.anything(),
+			)
+			expect(pi.sendMessage).toHaveBeenCalledWith(
+				expect.objectContaining({
+					content: [expect.objectContaining({ text: expect.stringContaining("Do not call list_ferments first") })],
+				}),
+				expect.anything(),
+			)
+		} finally {
+			vi.useRealTimers()
+		}
+	})
+
+	it("routes pending plan review feedback as hidden replanning input after agent_end", async () => {
+		vi.useFakeTimers()
+		try {
+			const storage = new FermentEventStore(mkdtempSync(join(tmpdir(), "ferment-index-plan-review-feedback-test-")))
+			const runtime: FermentRuntime = {
+				...createDefaultFermentRuntime(),
+				getStorage: () => storage,
+			}
+			const draft = storage.create("Deferred Feedback")
+			runtime.setActive(draft)
+			runtime.setPendingScope(draft.id, {
+				goal: "Goal",
+				successCriteria: "Works",
+				constraints: [],
+				phases: [{ name: "Phase", goal: "Build", steps: [] }],
+			})
+			setPendingPlanReview({
+				fermentId: draft.id,
+				fermentName: draft.name,
+				planMarkdown: "# Plan: Deferred Feedback",
+			})
+
+			const { handlers, pi } = registerFermentExtension(runtime)
+			const agentEnd = handlers.get("agent_end")
+			if (!agentEnd) throw new Error("agent_end handler was not registered")
+			const ctx = {
+				ui: {
+					custom: vi.fn().mockResolvedValue({ kind: "feedback", text: "drop phase 2" }),
+					setWorkingVisible: vi.fn(),
+				},
+			}
+
+			await agentEnd({ type: "agent_end" }, ctx)
+			await vi.runOnlyPendingTimersAsync()
+
+			expect(storage.get(draft.id)?.status).toBe("draft")
+			expect(getPendingPlanReview(draft.id)).toBeDefined()
+			expect(pi.sendMessage).toHaveBeenCalledWith(
+				expect.objectContaining({
+					customType: "ferment_scoping_iteration",
+					display: false,
+					content: expect.stringContaining("drop phase 2"),
+				}),
+				{ triggerTurn: true, deliverAs: "followUp" },
+			)
+			expect(pi.sendMessage).toHaveBeenCalledWith(
+				expect.objectContaining({
+					content: expect.stringContaining(`ferment_id "${draft.id}"`),
+				}),
+				expect.anything(),
+			)
+			expect(pi.sendMessage).toHaveBeenCalledWith(
+				expect.objectContaining({
+					content: expect.stringContaining("Do not call list_ferments or scope_ferment"),
+				}),
+				expect.anything(),
+			)
+		} finally {
+			vi.useRealTimers()
+		}
+	})
+
+	it("keeps pending plan review when start confirmation fails", async () => {
+		vi.useFakeTimers()
+		try {
+			const storage = new FermentEventStore(mkdtempSync(join(tmpdir(), "ferment-index-plan-review-fail-test-")))
+			const runtime: FermentRuntime = {
+				...createDefaultFermentRuntime(),
+				getStorage: () => storage,
+			}
+			const draft = storage.create("Failed Confirmation")
+			runtime.setActive(draft)
+			runtime.setPendingScope(draft.id, {
+				goal: "Goal",
+				successCriteria: "Works",
+				constraints: [],
+			})
+			setPendingPlanReview({
+				fermentId: draft.id,
+				fermentName: draft.name,
+				planMarkdown: "# Plan: Failed Confirmation",
+			})
+
+			const { handlers, pi } = registerFermentExtension(runtime)
+			const agentEnd = handlers.get("agent_end")
+			if (!agentEnd) throw new Error("agent_end handler was not registered")
+			const ctx = {
+				ui: {
+					custom: vi.fn().mockResolvedValue({ kind: "start" }),
+					notify: vi.fn(),
+					setWorkingVisible: vi.fn(),
+				},
+			}
+
+			await agentEnd({ type: "agent_end" }, ctx)
+			await vi.runOnlyPendingTimersAsync()
+
+			expect(storage.get(draft.id)?.status).toBe("draft")
+			expect(getPendingPlanReview(draft.id)).toBeDefined()
+			expect(ctx.ui.notify).toHaveBeenCalledWith(expect.stringContaining("Failed to save plan"), "error")
+			expect(pi.sendMessage).not.toHaveBeenCalledWith(
+				expect.objectContaining({ customType: "ferment_continuation_nudge" }),
+				expect.anything(),
+			)
+		} finally {
+			vi.useRealTimers()
+		}
 	})
 
 	it("intercepts a trailing confirmation question after tool calls", async () => {

--- a/src/extensions/ferment/index.ts
+++ b/src/extensions/ferment/index.ts
@@ -20,14 +20,7 @@ import { fermentBreadcrumbRenderer } from "./breadcrumb-renderer.js"
 import { registerFermentCommands } from "./commands.js"
 import { registerFermentEvents } from "./events.js"
 import { FERMENT_STOP_POLICY_SHORTCUT, canToggleFermentStopPolicy } from "./footer-status.js"
-import {
-	type PendingPlanReview,
-	clearAllPendingPlanReviews,
-	clearPendingPlanReview,
-	getCurrentPendingPlanReview,
-	getPendingPlanReview,
-	promptPlanReview,
-} from "./plan-review.js"
+import { type PendingPlanReview, promptPlanReview } from "./plan-review.js"
 import { buildFermentPromptBlock } from "./prompt-block.js"
 import { type FermentRuntime, defaultFermentRuntime } from "./runtime.js"
 import { scheduleFermentWakeUp } from "./scheduler.js"
@@ -133,7 +126,7 @@ export default function fermentExtension(pi: ExtensionAPI, runtime: FermentRunti
 	}
 
 	const isCurrentPendingReview = (review: PendingPlanReview): boolean =>
-		getPendingPlanReview(review.fermentId) === review
+		runtime.getPendingPlanReview(review.fermentId) === review
 
 	const runPendingPlanReview = async (ctx: Pick<ExtensionContext, "ui"> | undefined, review: PendingPlanReview) => {
 		if (planReviewRunning) return
@@ -155,7 +148,7 @@ export default function fermentExtension(pi: ExtensionAPI, runtime: FermentRunti
 					ctx?.ui?.notify?.(`Failed to save plan: ${scopeOutcome.error.message}`, "error")
 					return
 				}
-				clearPendingPlanReview(review.fermentId)
+				runtime.clearPendingPlanReview(review.fermentId)
 				scheduleFermentWakeUp(pi, runtime, {
 					deliverAsFollowUp: true,
 					fermentId: review.fermentId,
@@ -179,12 +172,12 @@ export default function fermentExtension(pi: ExtensionAPI, runtime: FermentRunti
 
 	pi.on("session_shutdown", () => {
 		clearPlanReviewTimer()
-		clearAllPendingPlanReviews()
+		runtime.clearAllPendingPlanReviews()
 		unregisterFermentTips()
 	})
 
 	pi.on("agent_end", (_event, ctx) => {
-		const review = getCurrentPendingPlanReview(runtime)
+		const review = runtime.getCurrentPendingPlanReview()
 		if (planReviewRunning || !review) return
 		clearPlanReviewTimer()
 		planReviewTimer = setTimeout(() => {

--- a/src/extensions/ferment/index.ts
+++ b/src/extensions/ferment/index.ts
@@ -21,11 +21,12 @@ import { registerFermentCommands } from "./commands.js"
 import { registerFermentEvents } from "./events.js"
 import { FERMENT_STOP_POLICY_SHORTCUT, canToggleFermentStopPolicy } from "./footer-status.js"
 import {
+	type PendingPlanReview,
 	clearAllPendingPlanReviews,
 	clearPendingPlanReview,
 	getCurrentPendingPlanReview,
+	getPendingPlanReview,
 	promptPlanReview,
-	stripFermentPlanReviewDisplayMessages,
 } from "./plan-review.js"
 import { buildFermentPromptBlock } from "./prompt-block.js"
 import { type FermentRuntime, defaultFermentRuntime } from "./runtime.js"
@@ -131,19 +132,22 @@ export default function fermentExtension(pi: ExtensionAPI, runtime: FermentRunti
 		}
 	}
 
-	const runPendingPlanReview = async (ctx: Pick<ExtensionContext, "ui"> | undefined) => {
+	const isCurrentPendingReview = (review: PendingPlanReview): boolean =>
+		getPendingPlanReview(review.fermentId) === review
+
+	const runPendingPlanReview = async (ctx: Pick<ExtensionContext, "ui"> | undefined, review: PendingPlanReview) => {
 		if (planReviewRunning) return
-		const review = getCurrentPendingPlanReview(runtime)
-		if (!review) return
+		if (!isCurrentPendingReview(review)) return
 
 		planReviewRunning = true
 		try {
 			const outcome = await promptPlanReview(ctx, { planMarkdown: review.planMarkdown })
 			if (!outcome) return
 			if (outcome.kind === "cancelled") {
-				clearPendingPlanReview(review.fermentId)
 				return
 			}
+
+			if (!isCurrentPendingReview(review)) return
 
 			if (outcome.kind === "start") {
 				const scopeOutcome = confirmPendingScope(runtime, review.fermentId, undefined, "turn_end", review.title, pi)
@@ -180,18 +184,13 @@ export default function fermentExtension(pi: ExtensionAPI, runtime: FermentRunti
 	})
 
 	pi.on("agent_end", (_event, ctx) => {
-		if (planReviewRunning || !getCurrentPendingPlanReview(runtime)) return
+		const review = getCurrentPendingPlanReview(runtime)
+		if (planReviewRunning || !review) return
 		clearPlanReviewTimer()
 		planReviewTimer = setTimeout(() => {
 			planReviewTimer = undefined
-			void runPendingPlanReview(ctx)
+			void runPendingPlanReview(ctx, review)
 		}, 0)
-	})
-
-	pi.on("context", (event) => ({ messages: stripFermentPlanReviewDisplayMessages(event.messages) }))
-	pi.on("session_before_compact", (event) => {
-		event.preparation.messagesToSummarize = stripFermentPlanReviewDisplayMessages(event.preparation.messagesToSummarize)
-		event.preparation.turnPrefixMessages = stripFermentPlanReviewDisplayMessages(event.preparation.turnPrefixMessages)
 	})
 
 	pi.registerMessageRenderer(FERMENT_REQUEST_MESSAGE_TYPE, fermentRequestRenderer)

--- a/src/extensions/ferment/index.ts
+++ b/src/extensions/ferment/index.ts
@@ -10,7 +10,7 @@
  * Public exports re-export from ./state.ts for cli.ts and components/footer.ts.
  */
 
-import type { ExtensionAPI, MessageRenderer } from "@earendil-works/pi-coding-agent"
+import type { ExtensionAPI, ExtensionContext, MessageRenderer } from "@earendil-works/pi-coding-agent"
 import { Container, Text } from "@earendil-works/pi-tui"
 import type { Step } from "../../ferment/types.js"
 import { createSystemPromptBlocks } from "../prompt-construction/index.js"
@@ -20,14 +20,23 @@ import { fermentBreadcrumbRenderer } from "./breadcrumb-renderer.js"
 import { registerFermentCommands } from "./commands.js"
 import { registerFermentEvents } from "./events.js"
 import { FERMENT_STOP_POLICY_SHORTCUT, canToggleFermentStopPolicy } from "./footer-status.js"
+import {
+	clearAllPendingPlanReviews,
+	clearPendingPlanReview,
+	getCurrentPendingPlanReview,
+	promptPlanReview,
+	stripFermentPlanReviewDisplayMessages,
+} from "./plan-review.js"
 import { buildFermentPromptBlock } from "./prompt-block.js"
 import { type FermentRuntime, defaultFermentRuntime } from "./runtime.js"
+import { scheduleFermentWakeUp } from "./scheduler.js"
+import { confirmPendingScope } from "./scoping-confirmation.js"
 import { FERMENT_REQUEST_MESSAGE_TYPE, type FermentRequestMessageDetails } from "./scoping.js"
 import { getActive, getActiveId, getContinuationPolicy } from "./state.js"
 import { createFermentTipProvider } from "./tips.js"
 import { applyFermentRuntimeToolProfile } from "./tool-scope.js"
 import { registerKnowledgeTools } from "./tools/knowledge.js"
-import { registerLifecycleTools } from "./tools/lifecycle.js"
+import { buildFreeformScopingFeedbackMessage, registerLifecycleTools } from "./tools/lifecycle.js"
 import { registerPhaseTools } from "./tools/phases.js"
 import { registerStepTools } from "./tools/steps.js"
 
@@ -112,8 +121,77 @@ const fermentRequestRenderer: MessageRenderer<FermentRequestMessageDetails> = (m
 
 export default function fermentExtension(pi: ExtensionAPI, runtime: FermentRuntime = defaultFermentRuntime) {
 	const unregisterFermentTips = registerTipProvider(createFermentTipProvider(runtime))
+	let planReviewTimer: ReturnType<typeof setTimeout> | undefined
+	let planReviewRunning = false
+
+	const clearPlanReviewTimer = () => {
+		if (planReviewTimer) {
+			clearTimeout(planReviewTimer)
+			planReviewTimer = undefined
+		}
+	}
+
+	const runPendingPlanReview = async (ctx: Pick<ExtensionContext, "ui"> | undefined) => {
+		if (planReviewRunning) return
+		const review = getCurrentPendingPlanReview(runtime)
+		if (!review) return
+
+		planReviewRunning = true
+		try {
+			const outcome = await promptPlanReview(ctx, { planMarkdown: review.planMarkdown })
+			if (!outcome) return
+			if (outcome.kind === "cancelled") {
+				clearPendingPlanReview(review.fermentId)
+				return
+			}
+
+			if (outcome.kind === "start") {
+				const scopeOutcome = confirmPendingScope(runtime, review.fermentId, undefined, "turn_end", review.title, pi)
+				if (!scopeOutcome.ok) {
+					ctx?.ui?.notify?.(`Failed to save plan: ${scopeOutcome.error.message}`, "error")
+					return
+				}
+				clearPendingPlanReview(review.fermentId)
+				scheduleFermentWakeUp(pi, runtime, {
+					deliverAsFollowUp: true,
+					fermentId: review.fermentId,
+					tag: "Plan review start",
+				})
+				return
+			}
+
+			void pi.sendMessage(
+				{
+					content: buildFreeformScopingFeedbackMessage(review.fermentId, outcome.text),
+					customType: "ferment_scoping_iteration",
+					display: false,
+				},
+				{ triggerTurn: true, deliverAs: "followUp" },
+			)
+		} finally {
+			planReviewRunning = false
+		}
+	}
+
 	pi.on("session_shutdown", () => {
+		clearPlanReviewTimer()
+		clearAllPendingPlanReviews()
 		unregisterFermentTips()
+	})
+
+	pi.on("agent_end", (_event, ctx) => {
+		if (planReviewRunning || !getCurrentPendingPlanReview(runtime)) return
+		clearPlanReviewTimer()
+		planReviewTimer = setTimeout(() => {
+			planReviewTimer = undefined
+			void runPendingPlanReview(ctx)
+		}, 0)
+	})
+
+	pi.on("context", (event) => ({ messages: stripFermentPlanReviewDisplayMessages(event.messages) }))
+	pi.on("session_before_compact", (event) => {
+		event.preparation.messagesToSummarize = stripFermentPlanReviewDisplayMessages(event.preparation.messagesToSummarize)
+		event.preparation.turnPrefixMessages = stripFermentPlanReviewDisplayMessages(event.preparation.turnPrefixMessages)
 	})
 
 	pi.registerMessageRenderer(FERMENT_REQUEST_MESSAGE_TYPE, fermentRequestRenderer)

--- a/src/extensions/ferment/plan-review.test.ts
+++ b/src/extensions/ferment/plan-review.test.ts
@@ -1,0 +1,160 @@
+import type { KeybindingsManager, Theme } from "@earendil-works/pi-coding-agent"
+import type { TUI } from "@earendil-works/pi-tui"
+import { beforeEach, describe, expect, it, vi } from "vitest"
+
+vi.mock("@earendil-works/pi-coding-agent", async () => {
+	const actual = await vi.importActual<typeof import("@earendil-works/pi-coding-agent")>(
+		"@earendil-works/pi-coding-agent",
+	)
+	const style = (s: string) => s
+	return {
+		...actual,
+		ExtensionEditorComponent: class {
+			focused = false
+			private value = ""
+
+			constructor(
+				_tui: TUI,
+				_keybindings: KeybindingsManager,
+				private readonly title: string,
+				_prefill: string | undefined,
+				private readonly onSubmit: (value: string) => void,
+				private readonly onCancel: () => void,
+			) {}
+
+			render(): string[] {
+				return [this.title]
+			}
+
+			handleInput(data: string): void {
+				if (data === "\r") {
+					this.onSubmit(this.value)
+					return
+				}
+				if (data === "\x1b") {
+					this.onCancel()
+					return
+				}
+				this.value += data
+			}
+
+			invalidate(): void {}
+		},
+		getMarkdownTheme: () => ({
+			heading: style,
+			link: style,
+			linkUrl: style,
+			code: style,
+			codeBlock: style,
+			codeBlockBorder: style,
+			quote: style,
+			quoteBorder: style,
+			hr: style,
+			listBullet: style,
+			bold: style,
+			italic: style,
+			strikethrough: style,
+			underline: style,
+		}),
+	}
+})
+
+import {
+	clearAllPendingPlanReviews,
+	createPlanReviewComponent,
+	getCurrentPendingPlanReview,
+	setPendingPlanReview,
+} from "./plan-review.js"
+
+const fakeTheme = {
+	bold: (s: string) => s,
+	fg: (_color: string, s: string) => s,
+} as Theme
+
+function createComponent(done = vi.fn()) {
+	const tui = { requestRender: vi.fn() } as unknown as TUI
+	const component = createPlanReviewComponent(tui, fakeTheme, {} as KeybindingsManager, "# Plan\n\n- Build it", done)
+	return { component, done, tui }
+}
+
+describe("plan review pending state", () => {
+	beforeEach(() => {
+		clearAllPendingPlanReviews()
+	})
+
+	it("returns only the active ferment pending review", () => {
+		setPendingPlanReview({ fermentId: "active", fermentName: "Active", planMarkdown: "# Active" })
+		setPendingPlanReview({ fermentId: "other", fermentName: "Other", planMarkdown: "# Other" })
+
+		expect(getCurrentPendingPlanReview({ getActiveId: () => "active" } as never)?.fermentId).toBe("active")
+		expect(getCurrentPendingPlanReview({ getActiveId: () => "missing" } as never)).toBeUndefined()
+		expect(getCurrentPendingPlanReview({ getActiveId: () => undefined } as never)).toBeUndefined()
+	})
+})
+
+describe("PlanReviewComponent", () => {
+	it("toggles the selected decision option with arrow keys", () => {
+		const { component, tui } = createComponent()
+
+		component.handleInput?.("\x1b[B")
+
+		expect(component.render(80).join("\n")).toContain("> Let me say something")
+		expect(tui.requestRender).toHaveBeenCalled()
+	})
+
+	it("submits start from the default decision option", () => {
+		const { component, done } = createComponent()
+
+		component.handleInput?.("\r")
+
+		expect(done).toHaveBeenCalledWith({ kind: "start" })
+	})
+
+	it("switches to feedback mode when the second decision option is submitted", () => {
+		const { component } = createComponent()
+
+		component.handleInput?.("\x1b[B")
+		component.handleInput?.("\r")
+
+		expect(component.render(80).join("\n")).toContain("Your direction:")
+	})
+
+	it("cancels from decision mode on escape", () => {
+		const { component, done } = createComponent()
+
+		component.handleInput?.("\x1b")
+
+		expect(done).toHaveBeenCalledWith({ kind: "cancelled", reason: "decision_cancelled" })
+	})
+
+	it("treats empty feedback submit as cancellation", () => {
+		const { component, done } = createComponent()
+
+		component.handleInput?.("\x1b[B")
+		component.handleInput?.("\r")
+		component.handleInput?.("\r")
+
+		expect(done).toHaveBeenCalledWith({ kind: "cancelled", reason: "empty_feedback" })
+	})
+
+	it("cancels from feedback mode on escape", () => {
+		const { component, done } = createComponent()
+
+		component.handleInput?.("\x1b[B")
+		component.handleInput?.("\r")
+		component.handleInput?.("\x1b")
+
+		expect(done).toHaveBeenCalledWith({ kind: "cancelled", reason: "feedback_cancelled" })
+	})
+
+	it("submits non-empty feedback text", () => {
+		const { component, done } = createComponent()
+
+		component.handleInput?.("\x1b[B")
+		component.handleInput?.("\r")
+		component.handleInput?.("drop phase 2")
+		component.handleInput?.("\r")
+
+		expect(done).toHaveBeenCalledWith({ kind: "feedback", text: "drop phase 2" })
+	})
+})

--- a/src/extensions/ferment/plan-review.ts
+++ b/src/extensions/ferment/plan-review.ts
@@ -7,7 +7,6 @@ import {
 } from "@earendil-works/pi-coding-agent"
 import { type Component, Container, Key, Markdown, Spacer, type TUI, Text, matchesKey } from "@earendil-works/pi-tui"
 import { getPromptUi, withWorkingHidden } from "./prompt-ui.js"
-import type { FermentRuntime } from "./runtime.js"
 
 export interface PendingPlanReview {
 	fermentId: string
@@ -31,7 +30,9 @@ export function getPendingPlanReview(fermentId: string): PendingPlanReview | und
 	return pendingPlanReviews.get(fermentId)
 }
 
-export function getCurrentPendingPlanReview(runtime: FermentRuntime): PendingPlanReview | undefined {
+export function getCurrentPendingPlanReview(runtime: { getActiveId(): string | undefined }):
+	| PendingPlanReview
+	| undefined {
 	const activeId = runtime.getActiveId()
 	return activeId ? pendingPlanReviews.get(activeId) : undefined
 }

--- a/src/extensions/ferment/plan-review.ts
+++ b/src/extensions/ferment/plan-review.ts
@@ -1,0 +1,212 @@
+import {
+	type ExtensionContext,
+	ExtensionEditorComponent,
+	type KeybindingsManager,
+	type Theme,
+	getMarkdownTheme,
+} from "@earendil-works/pi-coding-agent"
+import { type Component, Container, Key, Markdown, Spacer, type TUI, Text, matchesKey } from "@earendil-works/pi-tui"
+import { getPromptUi, withWorkingHidden } from "./prompt-ui.js"
+import type { FermentRuntime } from "./runtime.js"
+
+export const FERMENT_PLAN_REVIEW_DISPLAY_MESSAGE_TYPE = "ferment_plan_review_display"
+
+export interface PendingPlanReview {
+	fermentId: string
+	fermentName: string
+	title?: string
+	planMarkdown: string
+}
+
+export type PlanReviewOutcome =
+	| { kind: "start" }
+	| { kind: "feedback"; text: string }
+	| { kind: "cancelled"; reason: "decision_cancelled" | "feedback_cancelled" | "empty_feedback" }
+
+const pendingPlanReviews = new Map<string, PendingPlanReview>()
+
+export function setPendingPlanReview(review: PendingPlanReview): void {
+	pendingPlanReviews.set(review.fermentId, review)
+}
+
+export function getPendingPlanReview(fermentId: string): PendingPlanReview | undefined {
+	return pendingPlanReviews.get(fermentId)
+}
+
+export function getCurrentPendingPlanReview(runtime: FermentRuntime): PendingPlanReview | undefined {
+	const activeId = runtime.getActiveId()
+	return activeId ? pendingPlanReviews.get(activeId) : undefined
+}
+
+export function clearPendingPlanReview(fermentId: string): void {
+	pendingPlanReviews.delete(fermentId)
+}
+
+export function clearAllPendingPlanReviews(): void {
+	pendingPlanReviews.clear()
+}
+
+type CustomMessageLike = { role?: string; customType?: string }
+
+export function stripFermentPlanReviewDisplayMessages<T extends CustomMessageLike>(messages: T[]): T[] {
+	return messages.filter(
+		(message) =>
+			!(
+				message.role === "custom" &&
+				"customType" in message &&
+				message.customType === FERMENT_PLAN_REVIEW_DISPLAY_MESSAGE_TYPE
+			),
+	)
+}
+
+export async function promptPlanReview(
+	ctx: Pick<ExtensionContext, "ui"> | undefined,
+	opts: { planMarkdown: string },
+): Promise<PlanReviewOutcome | undefined> {
+	const ui = getPromptUi(ctx)
+	if (!ui?.custom) return undefined
+	return withWorkingHidden(
+		ui,
+		() =>
+			ui.custom?.<PlanReviewOutcome>((tui, theme, keybindings, done) =>
+				createPlanReviewComponent(tui, theme, keybindings, opts.planMarkdown, done),
+			) ?? Promise.resolve(undefined),
+	)
+}
+
+class PlanReviewComponent extends Container {
+	private static readonly rail = " ▍ "
+
+	private readonly markdown: Markdown
+	private readonly done: (result: PlanReviewOutcome) => void
+	private readonly theme: Theme
+	private readonly tui: TUI
+	private readonly keybindings: KeybindingsManager
+	private readonly decisionOptions = new Container()
+	private selectedIndex = 0
+	private mode: "decision" | "feedback" = "decision"
+	private editor: ExtensionEditorComponent | undefined
+
+	constructor(
+		tui: TUI,
+		theme: Theme,
+		keybindings: KeybindingsManager,
+		planMarkdown: string,
+		done: (result: PlanReviewOutcome) => void,
+	) {
+		super()
+		this.tui = tui
+		this.theme = theme
+		this.keybindings = keybindings
+		this.done = done
+		this.markdown = new Markdown(planMarkdown, 1, 0, getMarkdownTheme())
+		this.showDecision()
+	}
+
+	override render(width: number): string[] {
+		const contentWidth = Math.max(0, width - PlanReviewComponent.rail.length)
+		return this.withFrame(super.render(contentWidth), width)
+	}
+
+	handleInput(data: string): void {
+		if (this.mode === "feedback") {
+			this.ensureEditor()
+			this.editor?.handleInput(data)
+			return
+		}
+
+		if (matchesKey(data, Key.up) || matchesKey(data, Key.down)) {
+			this.selectedIndex = this.selectedIndex === 0 ? 1 : 0
+			this.updateDecisionOptions()
+			this.tui.requestRender()
+			return
+		}
+		if (matchesKey(data, Key.escape) || matchesKey(data, Key.esc)) {
+			this.done({ kind: "cancelled", reason: "decision_cancelled" })
+			return
+		}
+		if (matchesKey(data, Key.enter) || matchesKey(data, Key.return)) {
+			if (this.selectedIndex === 0) {
+				this.done({ kind: "start" })
+			} else {
+				this.mode = "feedback"
+				this.showFeedback()
+				this.tui.requestRender()
+			}
+		}
+	}
+
+	private showDecision(): void {
+		this.clear()
+		this.addStaticContent()
+		this.addChild(new Text(this.theme.fg("text", "Proceed with this plan?"), 0, 0))
+		this.addChild(this.decisionOptions)
+		this.addChild(new Spacer(1))
+		this.updateDecisionOptions()
+	}
+
+	private showFeedback(): void {
+		this.clear()
+		this.addStaticContent()
+		this.ensureEditor()
+		if (this.editor) {
+			this.editor.focused = true
+			this.addChild(this.editor)
+			this.addChild(new Spacer(1))
+		}
+	}
+
+	private addStaticContent(): void {
+		this.addChild(new Text(this.theme.fg("toolTitle", this.theme.bold("Plan review")), 0, 0))
+		this.addChild(this.markdown)
+		this.addChild(new Spacer(1))
+	}
+
+	private updateDecisionOptions(): void {
+		this.decisionOptions.clear()
+		for (const line of this.renderDecisionOptions()) {
+			this.decisionOptions.addChild(new Text(line, 0, 0))
+		}
+	}
+
+	private renderDecisionOptions(): string[] {
+		return ["Start execution", "Let me say something"].map((label, index) => {
+			const selected = index === this.selectedIndex
+			const marker = selected ? this.theme.fg("accent", "> ") : "  "
+			const styledLabel = selected ? this.theme.fg("accent", label) : this.theme.fg("text", label)
+			return `${marker}${styledLabel}`
+		})
+	}
+
+	private withFrame(lines: string[], width: number): string[] {
+		const rule = this.theme.fg("borderMuted", "─".repeat(Math.max(0, width)))
+		const rail = this.theme.fg("muted", PlanReviewComponent.rail)
+		return [rule, ...lines.map((line) => `${rail}${line}`), rule]
+	}
+
+	private ensureEditor(): void {
+		if (this.editor) return
+		this.editor = new ExtensionEditorComponent(
+			this.tui,
+			this.keybindings,
+			"Your direction:",
+			"",
+			(value) => {
+				const text = value.trim()
+				this.done(text ? { kind: "feedback", text } : { kind: "cancelled", reason: "empty_feedback" })
+			},
+			() => this.done({ kind: "cancelled", reason: "feedback_cancelled" }),
+		)
+		this.editor.focused = true
+	}
+}
+
+export function createPlanReviewComponent(
+	tui: TUI,
+	theme: Theme,
+	keybindings: KeybindingsManager,
+	planMarkdown: string,
+	done: (result: PlanReviewOutcome) => void,
+): Component {
+	return new PlanReviewComponent(tui, theme, keybindings, planMarkdown, done)
+}

--- a/src/extensions/ferment/plan-review.ts
+++ b/src/extensions/ferment/plan-review.ts
@@ -9,8 +9,6 @@ import { type Component, Container, Key, Markdown, Spacer, type TUI, Text, match
 import { getPromptUi, withWorkingHidden } from "./prompt-ui.js"
 import type { FermentRuntime } from "./runtime.js"
 
-export const FERMENT_PLAN_REVIEW_DISPLAY_MESSAGE_TYPE = "ferment_plan_review_display"
-
 export interface PendingPlanReview {
 	fermentId: string
 	fermentName: string
@@ -44,19 +42,6 @@ export function clearPendingPlanReview(fermentId: string): void {
 
 export function clearAllPendingPlanReviews(): void {
 	pendingPlanReviews.clear()
-}
-
-type CustomMessageLike = { role?: string; customType?: string }
-
-export function stripFermentPlanReviewDisplayMessages<T extends CustomMessageLike>(messages: T[]): T[] {
-	return messages.filter(
-		(message) =>
-			!(
-				message.role === "custom" &&
-				"customType" in message &&
-				message.customType === FERMENT_PLAN_REVIEW_DISPLAY_MESSAGE_TYPE
-			),
-	)
 }
 
 export async function promptPlanReview(

--- a/src/extensions/ferment/prompt-block.ts
+++ b/src/extensions/ferment/prompt-block.ts
@@ -72,6 +72,8 @@ Every \`propose_ferment_scoping\` call must include the full \`gates\` array for
 
 Do NOT call \`scope_ferment\` directly in the interactive flow — only \`propose_ferment_scoping\`. If a tool call fails (e.g. missing gate verdicts or invalid step shape), re-emit the FULL payload INCLUDING the questions you drafted and all P1/P2/P3 gates — never silently drop them on retry.
 
+After \`propose_ferment_scoping\` returns "Plan ready for review", the host will collect the user's review after your turn ends. Do not call \`propose_ferment_scoping\` again, do not summarize the plan in chat, and do not tell the user to wait for the TUI.
+
 After \`propose_ferment_scoping\` returns "Plan saved", the host confirmation already happened. Do not call \`propose_ferment_scoping\` again, do not tell the user the draft is waiting in the TUI, and do not summarize the plan in chat. Continue with the next state-machine action (usually \`activate_ferment_phase\`).`
 
 	const agentsSection = buildAgentsSection()

--- a/src/extensions/ferment/runtime.ts
+++ b/src/extensions/ferment/runtime.ts
@@ -2,6 +2,13 @@ import type { Api, Model } from "@earendil-works/pi-ai"
 import type { ModelRegistry } from "@earendil-works/pi-coding-agent"
 import type { FermentEventStore } from "../../ferment/event-store.js"
 import type { Ferment } from "../../ferment/types.js"
+import {
+	type PendingPlanReview,
+	clearAllPendingPlanReviews,
+	clearPendingPlanReview,
+	getPendingPlanReview,
+	setPendingPlanReview,
+} from "./plan-review.js"
 import type { AttachPendingProposalPartial, PendingScope } from "./scoping.js"
 import {
 	attachPendingProposal,
@@ -18,7 +25,7 @@ import {
 	clearAllScopingGates,
 	clearAllStepStarts,
 	clearBlockRetry,
-	clearFermentState,
+	clearFermentState as clearStateForFerment,
 	clearStepCompleteAttempt,
 	clearStepStart,
 	consumeScopingGate,
@@ -73,6 +80,11 @@ export interface FermentRuntime {
 	attachPendingProposal(fermentId: string, partial: AttachPendingProposalPartial): boolean
 	clearPendingScope(fermentId: string): void
 	clearAllPendingScopes(): void
+	setPendingPlanReview(review: PendingPlanReview): void
+	getPendingPlanReview(fermentId: string): PendingPlanReview | undefined
+	getCurrentPendingPlanReview(): PendingPlanReview | undefined
+	clearPendingPlanReview(fermentId: string): void
+	clearAllPendingPlanReviews(): void
 	setPhaseStartRef(fermentId: string, phaseId: string, ref: string): void
 	getPhaseStartRef(fermentId: string, phaseId: string): string | undefined
 	setStepStartRef(fermentId: string, phaseId: string, stepId: string, ref: string): void
@@ -84,6 +96,17 @@ export interface FermentRuntime {
 	bumpStepCompleteAttempt(fermentId: string, phaseId: string, stepId: string): number
 	clearStepCompleteAttempt(fermentId: string, phaseId: string, stepId: string): void
 	clearFermentState(fermentId: string): void
+}
+
+function getCurrentPendingPlanReview(): PendingPlanReview | undefined {
+	const activeId = getActiveId()
+	return activeId ? getPendingPlanReview(activeId) : undefined
+}
+
+function clearFermentState(fermentId: string): void {
+	clearStateForFerment(fermentId)
+	clearPendingScope(fermentId)
+	clearPendingPlanReview(fermentId)
 }
 
 export function createDefaultFermentRuntime(): FermentRuntime {
@@ -115,6 +138,11 @@ export function createDefaultFermentRuntime(): FermentRuntime {
 		attachPendingProposal,
 		clearPendingScope,
 		clearAllPendingScopes,
+		setPendingPlanReview,
+		getPendingPlanReview,
+		getCurrentPendingPlanReview,
+		clearPendingPlanReview,
+		clearAllPendingPlanReviews,
 		setPhaseStartRef,
 		getPhaseStartRef,
 		setStepStartRef,

--- a/src/extensions/ferment/scheduler.ts
+++ b/src/extensions/ferment/scheduler.ts
@@ -23,19 +23,19 @@ export function buildFermentWakeUpNudge(ferment: Ferment, action: DeclarativeAct
 	const prefix = `CONTINUING ferment "${ferment.name}" (${ferment.id}).`
 	switch (action.kind) {
 		case "activate_phase":
-			return `${prefix} Call activate_ferment_phase with ferment_id "${ferment.id}" and phase_id "${action.phaseId}". Do not call list_ferments first.`
+			return `${prefix} Call activate_ferment_phase with ferment_id "${ferment.id}" and phase_id "${action.phaseId}".`
 		case "refine":
-			return `${prefix} Call refine_ferment_phase with ferment_id "${ferment.id}" and phase_id "${action.phaseId}". Do not call list_ferments first.`
+			return `${prefix} Call refine_ferment_phase with ferment_id "${ferment.id}" and phase_id "${action.phaseId}".`
 		case "start_step":
-			return `${prefix} Call start_ferment_step with ferment_id "${ferment.id}", phase_id "${action.phaseId}", and step_id "${action.stepId}". Do not call list_ferments first.`
+			return `${prefix} Call start_ferment_step with ferment_id "${ferment.id}", phase_id "${action.phaseId}", and step_id "${action.stepId}".`
 		case "complete_step":
-			return `${prefix} Call complete_ferment_step with ferment_id "${ferment.id}", phase_id "${action.phaseId}", and step_id "${action.stepId}" when the step work is complete. Do not call list_ferments first.`
+			return `${prefix} Call complete_ferment_step with ferment_id "${ferment.id}", phase_id "${action.phaseId}", and step_id "${action.stepId}" when the step work is complete.`
 		case "verify_step":
-			return `${prefix} Call verify_ferment_step with ferment_id "${ferment.id}", phase_id "${action.phaseId}", and step_id "${action.stepId}". Do not call list_ferments first.`
+			return `${prefix} Call verify_ferment_step with ferment_id "${ferment.id}", phase_id "${action.phaseId}", and step_id "${action.stepId}".`
 		case "complete_phase":
-			return `${prefix} Call complete_ferment_phase with ferment_id "${ferment.id}" and phase_id "${action.phaseId}" when the phase is complete. Do not call list_ferments first.`
+			return `${prefix} Call complete_ferment_phase with ferment_id "${ferment.id}" and phase_id "${action.phaseId}" when the phase is complete.`
 		default:
-			return `${prefix} ${formatActionNudgeLine(action)}. Do not call list_ferments first.`
+			return `${prefix} ${formatActionNudgeLine(action)}.`
 	}
 }
 

--- a/src/extensions/ferment/scheduler.ts
+++ b/src/extensions/ferment/scheduler.ts
@@ -19,8 +19,24 @@ export interface ScheduleFermentWakeUpOptions {
 	tag?: string
 }
 
-export function buildFermentWakeUpNudge(ferment: Ferment): string {
-	return `CONTINUING ferment "${ferment.name}" (${ferment.id}). Re-read the current persisted ferment state and take the next legal ferment action now. Do not rely on earlier next-action text if current state differs. If the ferment is complete, abandoned, paused, or has no legal next action, explain that briefly instead of calling lifecycle tools.`
+export function buildFermentWakeUpNudge(ferment: Ferment, action: DeclarativeAction): string {
+	const prefix = `CONTINUING ferment "${ferment.name}" (${ferment.id}).`
+	switch (action.kind) {
+		case "activate_phase":
+			return `${prefix} Call activate_ferment_phase with ferment_id "${ferment.id}" and phase_id "${action.phaseId}". Do not call list_ferments first.`
+		case "refine":
+			return `${prefix} Call refine_ferment_phase with ferment_id "${ferment.id}" and phase_id "${action.phaseId}". Do not call list_ferments first.`
+		case "start_step":
+			return `${prefix} Call start_ferment_step with ferment_id "${ferment.id}", phase_id "${action.phaseId}", and step_id "${action.stepId}". Do not call list_ferments first.`
+		case "complete_step":
+			return `${prefix} Call complete_ferment_step with ferment_id "${ferment.id}", phase_id "${action.phaseId}", and step_id "${action.stepId}" when the step work is complete. Do not call list_ferments first.`
+		case "verify_step":
+			return `${prefix} Call verify_ferment_step with ferment_id "${ferment.id}", phase_id "${action.phaseId}", and step_id "${action.stepId}". Do not call list_ferments first.`
+		case "complete_phase":
+			return `${prefix} Call complete_ferment_phase with ferment_id "${ferment.id}" and phase_id "${action.phaseId}" when the phase is complete. Do not call list_ferments first.`
+		default:
+			return `${prefix} ${formatActionNudgeLine(action)}. Do not call list_ferments first.`
+	}
 }
 
 function freshFerment(runtime: FermentRuntime, fermentId?: string): Ferment | undefined {
@@ -106,7 +122,7 @@ export function scheduleFermentWakeUp(
 	void pi.sendMessage(
 		{
 			customType: "ferment_continuation_nudge",
-			content: [{ type: "text", text: buildFermentWakeUpNudge(ferment) }],
+			content: [{ type: "text", text: buildFermentWakeUpNudge(ferment, decision.action) }],
 			display: false,
 			details: { action: "wake_up", expectedAction: decision.action.kind },
 		},

--- a/src/extensions/ferment/tools.integration.test.ts
+++ b/src/extensions/ferment/tools.integration.test.ts
@@ -47,6 +47,7 @@ vi.mock("./judge.js", async () => {
 	}
 })
 import { pr_dim } from "./colors.js"
+import { clearAllPendingPlanReviews, getPendingPlanReview } from "./plan-review.js"
 import { registerKnowledgeTools } from "./tools/knowledge.js"
 import { registerLifecycleTools } from "./tools/lifecycle.js"
 import { registerPhaseTools } from "./tools/phases.js"
@@ -135,6 +136,7 @@ beforeEach(() => {
 	clearAllStepStarts()
 	clearAllScopingGates()
 	clearAllPendingScopes()
+	clearAllPendingPlanReviews()
 	setActive(undefined)
 })
 
@@ -143,6 +145,7 @@ afterEach(() => {
 	clearAllStepStarts()
 	clearAllScopingGates()
 	clearAllPendingScopes()
+	clearAllPendingPlanReviews()
 	setActive(undefined)
 })
 
@@ -1076,33 +1079,36 @@ describe("propose_ferment_scoping", () => {
 		expect(tool?.description).toContain("answer-agnostic")
 	})
 
-	// (a) zero-questions + Continue → planned
-	it("(a) zero-questions + Continue → ferment becomes planned", async () => {
-		const id = await createFerment("ZeroQ Continue")
+	// (a) zero-questions + interactive UI -> deferred local review
+	it("(a) zero-questions + interactive UI -> stores pending review without planning inside the tool", async () => {
+		const id = await createFerment("ZeroQ Review")
 		seedPending(id)
-		const ctx = { ui: { select: vi.fn().mockResolvedValue("Start execution  ✓"), input: vi.fn(), setStatus: vi.fn() } }
+		const ctx = { ui: { select: vi.fn(), custom: vi.fn() } }
 
 		const result = ok(await h.call("propose_ferment_scoping", basePayload(id), ctx))
 
 		const f = loadFerment(id)
-		expect(f.status).toBe("planned")
-		expect(f.phases).toHaveLength(3)
-		expect(f.scoping?.assumptions?.answer).toBe("API is stable")
-		expect(getPendingScope(id)).toBeUndefined()
-		expect(result).toContain("Plan saved")
-		expect(result).toContain("Here is the proposed plan")
-		expect(result).toContain("# Plan:")
-		expect(ctx.ui.setStatus).toHaveBeenCalledWith("ferment-scoping", undefined)
-		expect(ctx.ui.select).toHaveBeenCalledWith(expect.stringContaining("# Plan:"), expect.any(Array))
+		expect(f.status).toBe("draft")
+		expect(getPendingScope(id)).toBeDefined()
+		expect(result).toContain("Plan ready for review")
+		expect(result).not.toContain("# Plan:")
+		expect(ctx.ui.select).not.toHaveBeenCalled()
+		expect(ctx.ui.custom).not.toHaveBeenCalled()
+		expect(getPendingPlanReview(id)).toMatchObject({
+			fermentId: id,
+			fermentName: "ZeroQ Review",
+			planMarkdown: expect.stringContaining("# Plan: ZeroQ Review"),
+		})
+		expect(getPendingPlanReview(id)?.planMarkdown.includes(`${String.fromCharCode(27)}[`)).toBe(false)
 	})
 
-	it("normalizes stringified phases before rendering the plan UI", async () => {
+	it("normalizes stringified phases before storing the pending review markdown", async () => {
 		const id = await createFerment("Stringified")
 		seedPending(id)
 		const ctx = {
 			ui: {
-				select: vi.fn().mockResolvedValueOnce("Start execution  ✓"),
-				input: vi.fn(),
+				select: vi.fn(),
+				custom: vi.fn(),
 			},
 		}
 
@@ -1119,13 +1125,13 @@ describe("propose_ferment_scoping", () => {
 		)
 
 		const f = loadFerment(id)
-		expect(f.status).toBe("planned")
-		expect(f.phases).toHaveLength(3)
-		expect(f.scoping?.assumptions?.answer).toBe("A web app exists; Local-first is acceptable")
-		expect(result).toContain("Plan saved")
-		expect(result).toContain("## Constraints")
-		expect(result).toContain("- no backend")
-		expect(result).toContain("Here is the proposed plan")
+		expect(f.status).toBe("draft")
+		expect(result).toContain("Plan ready for review")
+		const review = getPendingPlanReview(id)
+		expect(review?.planMarkdown).toContain("## Constraints")
+		expect(review?.planMarkdown).toContain("- no backend")
+		expect(review?.planMarkdown).toContain("- A web app exists")
+		expect(review?.planMarkdown).toContain("- Local-first is acceptable")
 	})
 
 	it("normalizes assumption arrays before persisting a proposed scope", async () => {
@@ -1430,35 +1436,31 @@ describe("propose_ferment_scoping", () => {
 		expect(ctx.ui.select).not.toHaveBeenCalled()
 	})
 
-	// (d) say more → ctx.ui.input invoked, message echoed with triggerTurn
-	it("(d) say more → input invoked, sendMessage echoes user text with triggerTurn", async () => {
+	// (d) say more is handled by the deferred review dialog, not inside the tool.
+	it("(d) zero-question review does not open input or send iteration while the tool is running", async () => {
 		const id = await createFerment("SayMore")
 		seedPending(id)
 		const ctx = {
 			ui: {
-				select: vi.fn().mockResolvedValue("Let me say something"),
-				input: vi.fn().mockResolvedValue("actually drop phase 3"),
+				select: vi.fn(),
+				custom: vi.fn(),
+				input: vi.fn(),
 				setWorkingVisible: vi.fn(),
 			},
 		}
 
 		ok(await h.call("propose_ferment_scoping", basePayload(id), ctx))
 
-		expect(ctx.ui.input).toHaveBeenCalled()
-		expect(ctx.ui.setWorkingVisible).toHaveBeenCalledWith(false)
-		expect(ctx.ui.setWorkingVisible).toHaveBeenCalledWith(true)
+		expect(ctx.ui.input).not.toHaveBeenCalled()
+		expect(ctx.ui.custom).not.toHaveBeenCalled()
+		expect(ctx.ui.setWorkingVisible).not.toHaveBeenCalled()
 		expect(loadFerment(id).status).toBe("draft")
 
 		const sendMsg = h.pi.sendMessage as ReturnType<typeof vi.fn>
 		const iterCalls = sendMsg.mock.calls.filter(
 			(c: unknown[]) => (c[0] as { customType?: string })?.customType === "ferment_scoping_iteration",
 		)
-		expect(iterCalls).toHaveLength(1)
-		const msgContent: string =
-			typeof iterCalls[0][0].content === "string" ? iterCalls[0][0].content : (iterCalls[0][0].content?.[0]?.text ?? "")
-		expect(msgContent).toContain("actually drop phase 3")
-		const triggerTurn = iterCalls[0][1]?.triggerTurn ?? iterCalls[0][0]?.triggerTurn
-		expect(triggerTurn).toBe(true)
+		expect(iterCalls).toHaveLength(0)
 	})
 
 	// (e) P-gate flag blocks the call
@@ -1535,7 +1537,7 @@ describe("propose_ferment_scoping", () => {
 
 		// First call: set assumptions
 		const ctx1 = {
-			ui: { select: vi.fn().mockResolvedValue("Let me say something"), input: vi.fn().mockResolvedValue("") },
+			ui: { select: vi.fn(), custom: vi.fn(), input: vi.fn() },
 		}
 		await h.call("propose_ferment_scoping", basePayload(id, { assumptions: "X" }), ctx1)
 
@@ -1544,7 +1546,7 @@ describe("propose_ferment_scoping", () => {
 
 		// Second call: omit assumptions entirely
 		const ctx2 = {
-			ui: { select: vi.fn().mockResolvedValue("Let me say something"), input: vi.fn().mockResolvedValue("") },
+			ui: { select: vi.fn(), custom: vi.fn(), input: vi.fn() },
 		}
 		const payloadNoAssumptions = { ...basePayload(id), assumptions: undefined }
 		await h.call("propose_ferment_scoping", payloadNoAssumptions, ctx2)
@@ -1553,18 +1555,17 @@ describe("propose_ferment_scoping", () => {
 		expect(getPendingScope(id)?.assumptions).toBeUndefined()
 	})
 
-	// Fix 1: Esc on dropdown → returns toolOk wait message, no sendMessage, ferment stays draft
-	it("Esc on dropdown → returns toolOk wait message, no sendMessage, ferment stays draft", async () => {
-		const id = await createFerment("EscDropdown")
+	// Fix 1: old dropdown is gone; cancellation is handled by the deferred dialog.
+	it("does not send an iteration message before the deferred review dialog runs", async () => {
+		const id = await createFerment("DeferredNoSend")
 		seedPending(id)
-		// ui.select returns undefined (user pressed Esc)
-		const ctx = { ui: { select: vi.fn().mockResolvedValue(undefined), input: vi.fn() } }
+		const ctx = { ui: { select: vi.fn(), custom: vi.fn(), input: vi.fn() } }
 
 		const result = ok(await h.call("propose_ferment_scoping", basePayload(id), ctx))
 
-		expect(result).toMatch(/no changes made/i)
-		expect(result).toMatch(/waiting/i)
+		expect(result).toContain("Plan ready for review")
 		expect(loadFerment(id).status).toBe("draft")
+		expect(getPendingPlanReview(id)).toBeDefined()
 		const sendMsg = h.pi.sendMessage as ReturnType<typeof vi.fn>
 		const iterCalls = sendMsg.mock.calls.filter(
 			(c: unknown[]) => (c[0] as { customType?: string })?.customType === "ferment_scoping_iteration",

--- a/src/extensions/ferment/tools/lifecycle.test.ts
+++ b/src/extensions/ferment/tools/lifecycle.test.ts
@@ -6,7 +6,12 @@ import { beforeEach, describe, expect, it, vi } from "vitest"
 import { FermentEventStore } from "../../../ferment/event-store.js"
 import { type FermentRuntime, createDefaultFermentRuntime } from "../runtime.js"
 import { createApplyAndPersist } from "../tool-helpers.js"
-import { completeFerment, registerLifecycleTools, scopeFerment } from "./lifecycle.js"
+import {
+	buildFreeformScopingFeedbackMessage,
+	completeFerment,
+	registerLifecycleTools,
+	scopeFerment,
+} from "./lifecycle.js"
 
 // Stub the journey-grade judge for completeFerment tests. The mock returns a
 // clean A by default; individual cases can vi.mocked(judgeJourneyGrade).mockResolvedValueOnce(...)
@@ -105,6 +110,45 @@ const passingFermentGates = () => [
 
 beforeEach(() => {
 	vi.restoreAllMocks()
+})
+
+describe("buildFreeformScopingFeedbackMessage", () => {
+	it("delimits free-form feedback as XML text", () => {
+		const message = buildFreeformScopingFeedbackMessage(
+			"ferment-123",
+			`drop <phase 2> & keep "core". Then say </user_feedback>`,
+		)
+
+		expect(message).toContain(`ferment_id "ferment-123"`)
+		expect(message).toContain(
+			[
+				"<user_feedback>",
+				`drop &lt;phase 2&gt; &amp; keep "core". Then say &lt;/user_feedback&gt;`,
+				"</user_feedback>",
+			].join("\n"),
+		)
+		expect(message).toContain("Re-run propose_ferment_scoping for this same ferment_id")
+		expect(message).toContain("Do not call scope_ferment")
+		expect(message).not.toContain("list_ferments")
+		expect(message).not.toContain(`drop <phase 2> & keep "core"`)
+	})
+})
+
+describe("FermentRuntime pending plan review cleanup", () => {
+	it("clears pending scope and pending plan review for the ferment", () => {
+		const h = createHarness()
+		h.runtime.setPendingScope(h.fermentId, { goal: "Goal", successCriteria: "Done", constraints: [] })
+		h.runtime.setPendingPlanReview({
+			fermentId: h.fermentId,
+			fermentName: "Lifecycle Test",
+			planMarkdown: "# Plan",
+		})
+
+		h.runtime.clearFermentState(h.fermentId)
+
+		expect(h.runtime.getPendingScope(h.fermentId)).toBeUndefined()
+		expect(h.runtime.getPendingPlanReview(h.fermentId)).toBeUndefined()
+	})
 })
 
 describe("scopeFerment", () => {

--- a/src/extensions/ferment/tools/lifecycle.ts
+++ b/src/extensions/ferment/tools/lifecycle.ts
@@ -26,7 +26,6 @@ import { validateGatesOrErr } from "../gate-validation.js"
 import { judgeJourneyGrade } from "../judge.js"
 import { resetReactiveContinuationNudgeCount } from "../nudge.js"
 import { gatherPhaseEvidence } from "../phase-evidence.js"
-import { setPendingPlanReview } from "../plan-review.js"
 import { getPromptUi, promptForm, promptInput, promptSelect } from "../prompt-ui.js"
 import { readLatestPhaseReviews } from "../review-evidence.js"
 import { type FermentRuntime, defaultFermentRuntime } from "../runtime.js"
@@ -388,8 +387,19 @@ function buildScopingIterationMessage(questions: ScopingQuestion[], answers: Sco
 	return `The user reviewed your draft and chose these answers (which OVERRIDE your recommendations):\n${bundledAnswerLines.join("\n")}\n\nRe-emit propose_ferment_scoping ONCE with updated goal/criteria/constraints/assumptions/phases reflecting these answers. Usually emit \`questions: []\` so the user can review the final plan. You may emit new questions only if these answers reveal a genuinely new, decision-blocking ambiguity; never repeat or rephrase any question answered above. Do NOT ask questions in chat — call the tool directly.`
 }
 
+function escapeXmlText(value: string): string {
+	return value.replaceAll("&", "&amp;").replaceAll("<", "&lt;").replaceAll(">", "&gt;")
+}
+
 export function buildFreeformScopingFeedbackMessage(fermentId: string, userText: string): string {
-	return `User reviewed the pending plan for ferment_id "${fermentId}" and said: ${userText}. Re-run propose_ferment_scoping for this same ferment_id, incorporating this direction. Do not call list_ferments or scope_ferment.`
+	return [
+		`User reviewed the pending plan for ferment_id "${fermentId}" and provided this feedback:`,
+		"<user_feedback>",
+		escapeXmlText(userText),
+		"</user_feedback>",
+		"",
+		"Re-run propose_ferment_scoping for this same ferment_id, incorporating this direction. Do not call scope_ferment.",
+	].join("\n")
 }
 
 export async function scopeFerment(
@@ -766,7 +776,7 @@ ${renderGateGuidance("scope_ferment")}`,
 					)
 				}
 
-				setPendingPlanReview({
+				runtime.setPendingPlanReview({
 					fermentId: params.ferment_id,
 					fermentName: ferment.name,
 					title: params.title,

--- a/src/extensions/ferment/tools/lifecycle.ts
+++ b/src/extensions/ferment/tools/lifecycle.ts
@@ -26,6 +26,7 @@ import { validateGatesOrErr } from "../gate-validation.js"
 import { judgeJourneyGrade } from "../judge.js"
 import { resetReactiveContinuationNudgeCount } from "../nudge.js"
 import { gatherPhaseEvidence } from "../phase-evidence.js"
+import { setPendingPlanReview } from "../plan-review.js"
 import { getPromptUi, promptForm, promptInput, promptSelect } from "../prompt-ui.js"
 import { readLatestPhaseReviews } from "../review-evidence.js"
 import { type FermentRuntime, defaultFermentRuntime } from "../runtime.js"
@@ -341,7 +342,7 @@ function validateScopingQuestions(questions: ScopingQuestion[]): string | null {
 	return null
 }
 
-function buildPlanEntry(fermentName: string, params: NormalizedProposeScopingArgs): string {
+export function buildPlanMarkdown(fermentName: string, params: NormalizedProposeScopingArgs): string {
 	const phaseBlocks = params.phases.map((p, i) => {
 		const goalLines = wrapText(p.goal, 86)
 		const stepLines = (p.steps ?? []).map((s, j) => renderStep(j + 1, s.description)).join("\n")
@@ -353,8 +354,7 @@ function buildPlanEntry(fermentName: string, params: NormalizedProposeScopingArg
 			.filter(Boolean)
 			.join("\n")
 	})
-	const divider = pr_dim("╌".repeat(72))
-	const planBody = [
+	return [
 		`# Plan: ${fermentName}`,
 		"",
 		renderWrapped("## Goal", params.goal),
@@ -368,8 +368,10 @@ function buildPlanEntry(fermentName: string, params: NormalizedProposeScopingArg
 		"## Phases",
 		phaseBlocks.join("\n\n"),
 	].join("\n")
+}
 
-	return [pr_bold("Ready to execute?"), "Here is the proposed plan:", divider, planBody, divider].join("\n")
+function buildPlanEntry(fermentName: string, params: NormalizedProposeScopingArgs): string {
+	return buildPlanMarkdown(fermentName, params)
 }
 
 function buildAnswersEntry(questions: ScopingQuestion[], answers: ScopingAnswer[]): string {
@@ -388,6 +390,10 @@ function buildScopingIterationMessage(questions: ScopingQuestion[], answers: Sco
 		return `- "${q.text}" → ${answerText}`
 	})
 	return `The user reviewed your draft and chose these answers (which OVERRIDE your recommendations):\n${bundledAnswerLines.join("\n")}\n\nRe-emit propose_ferment_scoping ONCE with updated goal/criteria/constraints/assumptions/phases reflecting these answers. Usually emit \`questions: []\` so the user can review the final plan. You may emit new questions only if these answers reveal a genuinely new, decision-blocking ambiguity; never repeat or rephrase any question answered above. Do NOT ask questions in chat — call the tool directly.`
+}
+
+export function buildFreeformScopingFeedbackMessage(fermentId: string, userText: string): string {
+	return `User reviewed the pending plan for ferment_id "${fermentId}" and said: ${userText}. Re-run propose_ferment_scoping for this same ferment_id, incorporating this direction. Do not call list_ferments or scope_ferment.`
 }
 
 export async function scopeFerment(
@@ -707,17 +713,15 @@ ${renderGateGuidance("scope_ferment")}`,
 				proposeIterations: nextIterations,
 			})
 
-			// 4. Build the persistent plan entry. We only emit it at the real
-			// decision point: immediately for zero-question drafts, or after the
-			// user accepts recommendations. If the user changes answers, the
-			// agent re-drafts first so we never show a stale plan as final.
+			// 4. Build clean markdown for final/headless tool output and local review UI.
 			const planEntry = buildPlanEntry(ferment.name, params)
 			const formatPlanEntry = (suffix?: string): string => (suffix ? `${planEntry}\n\n${suffix}` : planEntry)
 			const planToolOk = (message: string, options: { includePlan?: boolean; suffix?: string } = {}) =>
 				toolOk(options.includePlan ? `${formatPlanEntry(options.suffix)}\n\n${message}` : message)
+			const promptUi = getPromptUi(ctx)
 
 			// 5. Headless path.
-			if (!getPromptUi(ctx)?.select) {
+			if (!promptUi?.select && !promptUi?.custom) {
 				if (questions.length === 0) {
 					const scopeOutcome = confirmPendingScope(
 						runtime,
@@ -742,18 +746,11 @@ ${renderGateGuidance("scope_ferment")}`,
 				)
 			}
 
-			// 6. Zero-questions path: plan is already in chat scrollback above.
-			// The dropdown just asks for the decision.
+			// 6. Zero-questions path: defer the local review dialog until the
+			// agent turn ends, so terminal scrollback is not fighting active-turn
+			// progress writes.
 			if (questions.length === 0) {
-				const startLabel = "Start execution  ✓"
-				const selected = await promptSelect(ctx, `${formatPlanEntry()}\n\nProceed with this plan?`, [
-					startLabel,
-					"Let me say something",
-				])
-				if (selected === undefined) {
-					return planToolOk("No changes made. Waiting for your next instruction.")
-				}
-				if (selected === startLabel) {
+				if (!promptUi?.custom) {
 					const scopeOutcome = confirmPendingScope(
 						runtime,
 						params.ferment_id,
@@ -771,17 +768,14 @@ ${renderGateGuidance("scope_ferment")}`,
 						{ includePlan: true },
 					)
 				}
-				// "Let me say something"
-				const userText = await promptInput(ctx, "Your direction:", "")
-				if (!userText) {
-					return planToolOk("No changes made. Waiting for your next instruction.")
-				}
-				const sayMoreContent = `User said: ${userText}. Re-run propose_ferment_scoping incorporating this direction.`
-				void pi.sendMessage(
-					{ content: sayMoreContent, customType: "ferment_scoping_iteration", display: false },
-					{ triggerTurn: true },
-				)
-				return planToolOk("Got it. Updating the plan with your direction...")
+
+				setPendingPlanReview({
+					fermentId: params.ferment_id,
+					fermentName: ferment.name,
+					title: params.title,
+					planMarkdown: planEntry,
+				})
+				return planToolOk("Plan ready for review. The review dialog will open when this turn finishes.")
 			}
 
 			// 7. Tabbed question form + review loop.
@@ -916,7 +910,7 @@ ${renderGateGuidance("scope_ferment")}`,
 					if (!userText) {
 						return planToolOk(`${answersEntry}\n\nNo changes made. Waiting for your next instruction.`)
 					}
-					const sayMoreContent = `User said: ${userText}. Re-run propose_ferment_scoping incorporating this direction.`
+					const sayMoreContent = buildFreeformScopingFeedbackMessage(params.ferment_id, userText)
 					void pi.sendMessage(
 						{ content: sayMoreContent, customType: "ferment_scoping_iteration", display: false },
 						{ triggerTurn: true },

--- a/src/extensions/ferment/tools/lifecycle.ts
+++ b/src/extensions/ferment/tools/lifecycle.ts
@@ -370,10 +370,6 @@ export function buildPlanMarkdown(fermentName: string, params: NormalizedPropose
 	].join("\n")
 }
 
-function buildPlanEntry(fermentName: string, params: NormalizedProposeScopingArgs): string {
-	return buildPlanMarkdown(fermentName, params)
-}
-
 function buildAnswersEntry(questions: ScopingQuestion[], answers: ScopingAnswer[]): string {
 	const answerLines = answers.map((a, i) => {
 		const q = questions.find((question) => question.id === a.questionId) ?? questions[i]
@@ -714,7 +710,7 @@ ${renderGateGuidance("scope_ferment")}`,
 			})
 
 			// 4. Build clean markdown for final/headless tool output and local review UI.
-			const planEntry = buildPlanEntry(ferment.name, params)
+			const planEntry = buildPlanMarkdown(ferment.name, params)
 			const formatPlanEntry = (suffix?: string): string => (suffix ? `${planEntry}\n\n${suffix}` : planEntry)
 			const planToolOk = (message: string, options: { includePlan?: boolean; suffix?: string } = {}) =>
 				toolOk(options.includePlan ? `${formatPlanEntry(options.suffix)}\n\n${message}` : message)
@@ -751,6 +747,7 @@ ${renderGateGuidance("scope_ferment")}`,
 			// progress writes.
 			if (questions.length === 0) {
 				if (!promptUi?.custom) {
+					// Some hosts expose select/input without custom components; keep them on the pre-review confirmation path.
 					const scopeOutcome = confirmPendingScope(
 						runtime,
 						params.ferment_id,


### PR DESCRIPTION
## Description

- Plan doesn't disappear when feedback is given
- Plan is displayed in markdown
- Editor is multiline

The review dialog opens after agent_end (deferred one macrotask) rather than from inside propose_ferment_scoping. This avoids Pi's OSC 9;4;3 progress keepalive fighting native terminal scroll during an active turn. The plan lives in a pending-review map keyed by ferment id; ctx.ui.custom renders the plan markdown alongside an inline multiline editor in one component. The system prompt steers the agent to stop after the tool returns "Plan ready for review".

---
### Kimchi Summary
### What changed
Replaces the synchronous, in-tool dropdown for zero-question scoping plans with a deferred, custom TUI review dialog that opens after the agent turn ends. Users can now review rendered plan markdown and choose to start execution or provide free-form feedback. Also replaces generic wake-up nudges with exact next-action instructions.

### Why
The previous dropdown rendered during the tool call, competing with active-turn stream output and causing flicker and scrollback issues. Deferring the UI until `agent_end` gives a stable, readable review experience.

### Key changes
- `src/extensions/ferment/plan-review.ts` (new): Adds `PlanReviewComponent`—a keyboard-navigable custom TUI component for reviewing plan markdown, choosing execution or feedback, and entering free-form direction. Exposes module-level pending-review state helpers (`setPendingPlanReview`, `getCurrentPendingPlanReview`, `clearAllPendingPlanReviews`).
- `src/extensions/ferment/tools/lifecycle.ts`: `propose_ferment_scoping` now defers zero-question reviews by calling `runtime.setPendingPlanReview(...)` and returning `"Plan ready for review"` instead of blocking on `ui.select`. Adds `buildPlanMarkdown` and `buildFreeformScopingFeedbackMessage` with XML-escaped feedback envelopes.
- `src/extensions/ferment/index.ts`: Registers an `agent_end` handler that asynchronously opens the pending plan review via `runPendingPlanReview`. Handles start (confirms scope, clears pending review, schedules wake-up), feedback (sends a hidden `ferment_scoping_iteration` message), and cancellation.
- `src/extensions/ferment/runtime.ts`: Extends `FermentRuntime` with pending plan review getters/setters/clears and folds `clearPendingScope`/`clearPendingPlanReview` into `clearFermentState`.
- `src/extensions/ferment/scheduler.ts`: `buildFermentWakeUpNudge` now generates precise tool-call instructions (e.g., `Call activate_ferment_phase with ...`) based on the expected `DeclarativeAction` rather than a generic re-read prompt.
- `src/extensions/ferment/commands.ts`: Switch and pause flows now clear the pending plan review for the affected ferment; redundant `clearPendingScope` calls removed where `clearFermentState` already covers them.
- `src/extensions/ferment/events.ts`: Clears all pending plan reviews on session start and shutdown.
- `src/extensions/ferment/prompt-block.ts`: Instructs the agent not to re-call `propose_ferment_scoping`, summarize the plan, or tell the user to wait when a plan is pending review.

### Impact
- `FermentRuntime` interface has new required methods for pending plan review management. Implementations outside `createDefaultFermentRuntime` must provide them.
- Existing test assertions expecting the generic `"Re-read the current persisted ferment state"` wake-up text must be updated to match the new action-specific nudges.
- Zero-question scoping in interactive hosts is now non-blocking inside the tool; the plan state remains `"draft"` until the user explicitly starts execution from the deferred dialog.