### PR TITLE
fix(check-session): use exact task name match instead of substring

### DIFF
--- a/benchmark/manual/check-session.py
+++ b/benchmark/manual/check-session.py
@@ -137,11 +137,12 @@ def main():
 
     total_runs = len(run_dirs)
 
-    # Filter runs by task substrings (case-insensitive)
+    # Filter runs by exact directory-name match (case-insensitive)
     if task_filters:
+        filters_lower = [f.lower() for f in task_filters]
         run_dirs = [
             d for d in run_dirs
-            if any(f.lower() in d.name.lower() for f in task_filters)
+            if d.name.lower() in filters_lower
         ]
         if not run_dirs:
             print("No runs matched the provided task filters.", file=sys.stderr)


### PR DESCRIPTION
The task filter in `check-session.py` used substring matching, causing `complex` to match `complex`, `complex-single-kimi-k2.6`, and `complex-single-minimax-m2.7`. This made `run-evaluation.sh` wait for 4 runs instead of the intended 2 (`complex` + `mega`).

Change the filter to exact directory-name matching so only the specified tasks are tracked and audited.

---
### Kimchi Summary
### What changed
Updated `check-session.py` to filter benchmark runs by exact directory-name match instead of substring matching when `--task` filters are provided.

### Why
Substring matching caused overly broad filtering when task directory names share common substrings. Requiring exact names ensures only the intended runs are selected.

### Key changes
- `benchmark/manual/check-session.py`: Replaced substring filter logic with exact case-insensitive directory-name matching against `task_filters`.

### Impact
**Behavior change**: Users passing `--task` arguments must now supply the exact run directory name. Partial strings that previously matched will no longer return results.