### PR TITLE
Add resource management and RTK integration features to Kimchi

### DIFF
--- a/README.md
+++ b/README.md
@@ -282,6 +282,12 @@ Or persistently in `~/.config/kimchi/harness/settings.json`:
 { "rtk": false }
 ```
 
+### Hooks
+
+Users can add custom Bash hooks to rewrite or block shell commands before they run. Global hooks live in `~/.config/kimchi/harness/hooks/bash/`; project hooks live in `.kimchi/hooks/bash/` and default to disabled until enabled from `/resources` or `kimchi resources enable ...`.
+
+See `docs/hooks.md` for the hook protocol and examples.
+
 ### Migrating from another coding agent
 
 On first run, kimchi looks for an existing **Claude Code** or **OpenCode** installation and offers to migrate its MCP servers. If anything is migratable you will see a one-shot prompt:

--- a/README.md
+++ b/README.md
@@ -262,7 +262,7 @@ Kimchi respects `HTTP_PROXY` / `HTTPS_PROXY` environment variables for network r
 
 ### Token optimization (RTK)
 
-When [RTK](https://github.com/rtk-ai/rtk) is installed and on your `PATH`, kimchi automatically rewrites bash tool calls through `rtk rewrite` before execution. This compresses command output (git, cargo, npm, docker, etc.) by 60-90%, reducing LLM context usage.
+Kimchi installs [RTK](https://github.com/rtk-ai/rtk) during setup and keeps the `rtk` command available on startup. When enabled, kimchi rewrites bash tool calls through `rtk rewrite` before execution. This compresses command output (git, cargo, npm, docker, etc.) by 60-90%, reducing LLM context usage.
 
 Before every bash tool execution, kimchi calls `rtk rewrite "<command>"`. If RTK returns a rewritten command (e.g. `git status` becomes `rtk git status`), the rewritten version is executed instead.
 
@@ -270,16 +270,11 @@ Before every bash tool execution, kimchi calls `rtk rewrite "<command>"`. If RTK
 brew install rtk    # macOS / Linux
 ```
 
-RTK is auto-detected at startup. No configuration needed. To disable:
+RTK rewrite is managed from resources:
 
 ```bash
-KIMCHI_RTK=0 kimchi   # disable for this session
-```
-
-Or persistently in `~/.config/kimchi/harness/settings.json`:
-
-```json
-{ "rtk": false }
+kimchi resources disable hooks.rtk-rewrite
+kimchi resources enable hooks.rtk-rewrite
 ```
 
 ### Hooks

--- a/docs/hooks.md
+++ b/docs/hooks.md
@@ -1,0 +1,189 @@
+# Kimchi Hooks
+
+Kimchi supports user-owned Bash hooks for commands executed through the `bash` tool and interactive `!` / `!!` shell commands.
+
+Hooks can rewrite a command before it runs, or block it. Use them for local policy, command normalization, formatter wrappers, safety checks, and token-saving rewrites.
+
+## Hook Locations
+
+Global hooks:
+
+```bash
+~/.config/kimchi/harness/hooks/bash/*.sh
+~/.config/kimchi/harness/hooks/bash/*.bash
+```
+
+Project hooks:
+
+```bash
+.kimchi/hooks/bash/*.sh
+.kimchi/hooks/bash/*.bash
+```
+
+Global hooks are enabled by default. Project hooks are discovered but default to disabled, so a repository cannot silently add shell policy. Enable or disable hooks from:
+
+```text
+/resources
+/hooks
+```
+
+or from the CLI:
+
+```bash
+kimchi resources list
+kimchi resources enable hooks.bash.project.my-hook-sh
+kimchi resources disable hooks.bash.global.my-hook-sh
+```
+
+## Runtime Data
+
+Each hook runs with `bash <hook-path>`. It does not need executable mode, but making it executable is still fine.
+
+Kimchi passes the current command in environment variables:
+
+```bash
+KIMCHI_HOOK_EVENT=tool_call
+KIMCHI_TOOL_NAME=bash
+KIMCHI_TOOL_INPUT_COMMAND='git status'
+CRUSH_TOOL_INPUT_COMMAND='git status'
+```
+
+Kimchi also writes JSON to stdin:
+
+```json
+{
+  "tool_name": "bash",
+  "input": {
+    "command": "git status"
+  },
+  "cwd": "/path/to/project"
+}
+```
+
+`CRUSH_TOOL_INPUT_COMMAND` is provided so simple Crush-style hook examples can be adapted with minimal changes.
+
+## Output Protocol
+
+No output means "allow unchanged":
+
+```bash
+exit 0
+```
+
+Plain stdout rewrites the command:
+
+```bash
+echo "git status --short"
+```
+
+JSON stdout can rewrite the command:
+
+```bash
+printf '%s\n' '{"decision":"allow","command":"git status --short"}'
+```
+
+Crush-style JSON is also supported:
+
+```bash
+printf '%s\n' '{"decision":"allow","updated_input":"{\"command\":\"git status --short\"}"}'
+```
+
+Block by returning JSON:
+
+```bash
+printf '%s\n' '{"decision":"block","reason":"Use pnpm, not npm"}'
+```
+
+or by exiting with status `2` and writing a reason:
+
+```bash
+echo "Use pnpm, not npm" >&2
+exit 2
+```
+
+Any other failure is treated as allow unchanged. This keeps a broken local hook from breaking the agent session.
+
+## Examples
+
+### Rewrite `git status`
+
+Create a global hook:
+
+```bash
+mkdir -p ~/.config/kimchi/harness/hooks/bash
+cat > ~/.config/kimchi/harness/hooks/bash/git-status-short.sh <<'SH'
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [ "${KIMCHI_TOOL_INPUT_COMMAND:-}" = "git status" ]; then
+  echo "git status --short --branch"
+fi
+SH
+```
+
+Start Kimchi and ask it to run `git status`. The displayed Bash command should show the rewritten command.
+
+### Block `npm install`
+
+```bash
+mkdir -p ~/.config/kimchi/harness/hooks/bash
+cat > ~/.config/kimchi/harness/hooks/bash/pnpm-only.sh <<'SH'
+#!/usr/bin/env bash
+set -euo pipefail
+
+case "${KIMCHI_TOOL_INPUT_COMMAND:-}" in
+  npm\ install*|npm\ i*)
+    printf '%s\n' '{"decision":"block","reason":"Use pnpm install in this repository."}'
+    ;;
+esac
+SH
+```
+
+### Read JSON From Stdin
+
+Use stdin when you need the project cwd or want to avoid shell parsing.
+
+```bash
+mkdir -p .kimchi/hooks/bash
+cat > .kimchi/hooks/bash/block-rm-root.sh <<'SH'
+#!/usr/bin/env bash
+set -euo pipefail
+
+payload="$(cat)"
+command="$(node -e 'const p=JSON.parse(process.argv[1]); console.log(p.input.command)' "$payload")"
+
+if [ "$command" = "rm -rf /" ]; then
+  printf '%s\n' '{"decision":"block","reason":"Refusing to remove root."}'
+fi
+SH
+```
+
+Then enable the project hook:
+
+```bash
+kimchi resources enable hooks.bash.project.block-rm-root-sh
+```
+
+## RTK Hook
+
+Kimchi's built-in RTK integration is exposed as:
+
+```text
+hooks.rtk-rewrite
+```
+
+It runs before user Bash hooks. User hooks see the RTK-rewritten command when RTK changes it.
+
+Disable it with:
+
+```bash
+kimchi resources disable hooks.rtk-rewrite
+```
+
+## Notes
+
+- Hooks run synchronously before command execution.
+- Hook timeout is 5 seconds.
+- Hook output is interpreted as a command rewrite unless it is recognized JSON.
+- Use `/resources` to see discovered hook IDs.
+- Restart is not required for hook enable/disable changes, but adding or removing hook files is easiest to verify by restarting Kimchi.

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -20,6 +20,7 @@ import { isBunBinary } from "./env.js"
 import activityExtension from "./extensions/activity.js"
 import agentsExtension from "./extensions/agents/index.js"
 import assistantPrefixExtension from "./extensions/assistant-prefix.js"
+import bashCollapseExtension from "./extensions/bash-collapse.js"
 import behavioursExtension from "./extensions/behaviours/index.js"
 import clipboardImageExtension from "./extensions/clipboard-image.js"
 import contextCompactorExtension from "./extensions/context-compactor.js"
@@ -58,6 +59,9 @@ import { updateModelsConfig } from "./models.js"
 import { injectTraceIdsIntoEntries, injectTraceIdsIntoExport } from "./modes/teleport/sync/session-export.js"
 import { ensureDeviceId } from "./posthog-device.js"
 import { capturePostHogEvent } from "./posthog.js"
+import resourcesExtension from "./resources/extension.js"
+import { type ManagedExtensionFactory, enabledExtensionFactories } from "./resources/filter.js"
+import resourceToolBlockerExtension from "./resources/tool-blocker.js"
 import { runSetupWizard } from "./setup-wizard.js"
 import { setAvailableModels } from "./startup-context.js"
 import { probeTerminalBackground } from "./terminal-bg-probe.js"
@@ -460,12 +464,19 @@ try {
 			kimchiMinimalTintsExtension,
 			loopGuardExtension,
 			lspExtension,
-			mcpAdapterExtension,
+			...enabledExtensionFactories([
+				{ id: "plugins.mcp-apps", factory: mcpAdapterExtension },
+			] satisfies ManagedExtensionFactory[]),
 			// Ferment must see raw input before prompt enrichment rewrites print-mode text.
-			fermentExtension,
+			...enabledExtensionFactories([
+				{ id: "extensions.ferment", factory: fermentExtension },
+			] satisfies ManagedExtensionFactory[]),
 			questionnaireExtension,
 			promptEnrichmentExtension(skillPaths),
+			bashCollapseExtension,
 			permissionsExtension,
+			resourcesExtension,
+			resourceToolBlockerExtension,
 			behavioursExtension,
 			promptSummaryExtension,
 			contextCompactorExtension,
@@ -476,12 +487,16 @@ try {
 			uiExtension,
 			sessionModeOnboarding,
 			tipsExtension(),
-			agentsExtension,
+			...enabledExtensionFactories([
+				{ id: "extensions.agents", factory: agentsExtension },
+			] satisfies ManagedExtensionFactory[]),
 			tagsExtension,
 			telemetryExtension(telemetryConfig),
 			toolRenderingExtension,
-			webFetchExtension,
-			webSearchExtension,
+			...enabledExtensionFactories([
+				{ id: "tools.web_fetch", factory: webFetchExtension },
+				{ id: "tools.web_search", factory: webSearchExtension },
+			] satisfies ManagedExtensionFactory[]),
 			loginExtension,
 			modelSwitchExtension,
 			modelGuardExtension,

--- a/src/commands/registry.ts
+++ b/src/commands/registry.ts
@@ -12,6 +12,7 @@ import { runGsd2 } from "./gsd2.js"
 import { runLogin } from "./login.js"
 import { runOpenClaw } from "./openclaw.js"
 import { runOpenCode } from "./opencode.js"
+import { runResources } from "./resources.js"
 import { runSetup } from "./setup.js"
 import { runUpdate } from "./update.js"
 import { runVersion } from "./version.js"
@@ -26,6 +27,7 @@ export const COMMANDS: CommandDefinition[] = [
 	{ name: "gsd2", summary: "Install / configure GSD2 with Kimchi", run: runGsd2 },
 	{ name: "update", summary: "Check for and install kimchi updates", run: runUpdate },
 	{ name: "config", summary: "Inspect or change kimchi config (e.g. telemetry)", run: runConfig },
+	{ name: "resources", summary: "Enable or disable Kimchi hooks, tools, extensions, and plugins", run: runResources },
 	{ name: "version", summary: "Print the kimchi version", run: runVersion },
 ]
 

--- a/src/commands/resources.ts
+++ b/src/commands/resources.ts
@@ -68,9 +68,10 @@ function parseSwitch(value: string): boolean | null {
 
 function usage(code: number): number {
 	const out = code === 0 ? console.log : console.error
-	out("Usage: kimchi resources [list]")
+	out("Usage: kimchi resources [list|status]")
 	out("       kimchi resources enable <resource-id>")
 	out("       kimchi resources disable <resource-id>")
+	out("       kimchi resources set <resource-id> on|off")
 	out("       kimchi resources reset <resource-id>")
 	return code
 }

--- a/src/commands/resources.ts
+++ b/src/commands/resources.ts
@@ -1,0 +1,76 @@
+import { getResourceDefinitions } from "../resources/definitions.js"
+import { isResourceEnabled, resetResourceOverride, setResourceOverride } from "../resources/store.js"
+
+export async function runResources(args: string[]): Promise<number> {
+	const [sub, id, value] = args
+	switch (sub) {
+		case undefined:
+		case "list":
+		case "status":
+			printResources()
+			return 0
+		case "enable":
+		case "disable":
+			if (!id) return usage(2)
+			setResourceOverride(id, sub === "enable")
+			console.log(`${id}: ${sub === "enable" ? "enabled" : "disabled"}`)
+			return 0
+		case "set":
+			if (!id || !value) return usage(2)
+			{
+				const enabled = parseSwitch(value)
+				if (enabled === null) return usage(2)
+				setResourceOverride(id, enabled)
+				console.log(`${id}: ${enabled ? "enabled" : "disabled"}`)
+				return 0
+			}
+		case "reset":
+			if (!id) return usage(2)
+			resetResourceOverride(id)
+			console.log(`${id}: reset`)
+			return 0
+		case "--help":
+		case "-h":
+		case "help":
+			return usage(0)
+		default:
+			return usage(2)
+	}
+}
+
+function printResources(): void {
+	for (const resource of getResourceDefinitions()) {
+		const status = isResourceEnabled(resource.id) ? "enabled " : "disabled"
+		console.log(`${status}  ${resource.id}  ${resource.description}`)
+	}
+}
+
+function parseSwitch(value: string): boolean | null {
+	switch (value.toLowerCase()) {
+		case "on":
+		case "true":
+		case "yes":
+		case "1":
+		case "enable":
+		case "enabled":
+			return true
+		case "off":
+		case "false":
+		case "no":
+		case "0":
+		case "disable":
+		case "disabled":
+			return false
+		default:
+			return null
+	}
+}
+
+function usage(code: number): number {
+	const out = code === 0 ? console.log : console.error
+	out("Usage: kimchi resources [list]")
+	out("       kimchi resources enable <resource-id>")
+	out("       kimchi resources disable <resource-id>")
+	out("       kimchi resources reset <resource-id>")
+	return code
+}

--- a/src/extensions/bash-collapse.test.ts
+++ b/src/extensions/bash-collapse.test.ts
@@ -1,5 +1,12 @@
 import { type MockInstance, afterEach, beforeEach, describe, expect, it, vi } from "vitest"
-import { _resetRtkState, collapseCommand, detectRtk, rewriteWithRtk, rtkSpawnHook } from "./bash-collapse.js"
+import {
+	_resetRtkState,
+	collapseCommand,
+	detectRtk,
+	getBashCommandForDisplay,
+	rewriteWithRtk,
+	rtkSpawnHook,
+} from "./bash-collapse.js"
 
 // ---------------------------------------------------------------------------
 // collapseCommand
@@ -238,6 +245,7 @@ describe("rtkSpawnHook", () => {
 		const result = rtkSpawnHook(ctx)
 		expect(result.command).toBe("rtk git status")
 		expect(result.cwd).toBe("/tmp")
+		expect(getBashCommandForDisplay("git status")).toBe("rtk git status")
 	})
 
 	it("returns the original context when command is unchanged", async () => {

--- a/src/extensions/bash-collapse.test.ts
+++ b/src/extensions/bash-collapse.test.ts
@@ -1,3 +1,6 @@
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
 import { type MockInstance, afterEach, beforeEach, describe, expect, it, vi } from "vitest"
 import {
 	_resetRtkState,
@@ -123,15 +126,26 @@ describe("detectRtk", () => {
 })
 
 describe("rewriteWithRtk", () => {
+	let tmpRtkRoot: string | undefined
+	let previousKimchiDir: string | undefined
+
 	beforeEach(() => {
 		_resetRtkState()
 		clearEnv()
+		previousKimchiDir = process.env.KIMCHI_CODING_AGENT_DIR
+		tmpRtkRoot = mkdtempSync(join(tmpdir(), "kimchi-rtk-collapse-test-"))
+		process.env.KIMCHI_CODING_AGENT_DIR = tmpRtkRoot
 		mockExecFileSync.mockReset()
 		// Pre-seed rtkAvailable = true for most tests (detectRtk already passed).
 		mockExecFile.mockReset()
 	})
 
 	afterEach(() => {
+		if (tmpRtkRoot) rmSync(tmpRtkRoot, { recursive: true, force: true })
+		tmpRtkRoot = undefined
+		// biome-ignore lint/performance/noDelete: env-var cleanup needs a real delete.
+		if (previousKimchiDir === undefined) delete process.env.KIMCHI_CODING_AGENT_DIR
+		else process.env.KIMCHI_CODING_AGENT_DIR = previousKimchiDir
 		clearEnv()
 	})
 
@@ -160,6 +174,18 @@ describe("rewriteWithRtk", () => {
 			throw Object.assign(new Error("Command failed"), { status: 3, stdout: "rtk cargo test\n" })
 		})
 		expect(rewriteWithRtk("cargo test")).toBe("rtk cargo test")
+	})
+
+	it("keeps RTK rewrite output readable when it emits bare rtk", async () => {
+		if (!tmpRtkRoot) throw new Error("test rtk root missing")
+		const managed = join(tmpRtkRoot, "rtk", "rtk")
+		mkdirSync(join(tmpRtkRoot, "rtk"), { recursive: true })
+		writeFileSync(managed, "")
+		seedRtkAvailable()
+		await detectRtk()
+
+		mockExecFileSync.mockReturnValueOnce("rtk git status\n")
+		expect(rewriteWithRtk("git status")).toBe("rtk git status")
 	})
 
 	it("returns the original command when rtk output matches the input", async () => {
@@ -222,14 +248,25 @@ describe("rewriteWithRtk", () => {
 })
 
 describe("rtkSpawnHook", () => {
+	let tmpRtkRoot: string | undefined
+	let previousKimchiDir: string | undefined
+
 	beforeEach(() => {
 		_resetRtkState()
 		clearEnv()
+		previousKimchiDir = process.env.KIMCHI_CODING_AGENT_DIR
+		tmpRtkRoot = mkdtempSync(join(tmpdir(), "kimchi-rtk-spawn-test-"))
+		process.env.KIMCHI_CODING_AGENT_DIR = tmpRtkRoot
 		mockExecFileSync.mockReset()
 		mockExecFile.mockReset()
 	})
 
 	afterEach(() => {
+		if (tmpRtkRoot) rmSync(tmpRtkRoot, { recursive: true, force: true })
+		tmpRtkRoot = undefined
+		// biome-ignore lint/performance/noDelete: env-var cleanup needs a real delete.
+		if (previousKimchiDir === undefined) delete process.env.KIMCHI_CODING_AGENT_DIR
+		else process.env.KIMCHI_CODING_AGENT_DIR = previousKimchiDir
 		clearEnv()
 	})
 

--- a/src/extensions/bash-collapse.test.ts
+++ b/src/extensions/bash-collapse.test.ts
@@ -128,13 +128,16 @@ describe("detectRtk", () => {
 describe("rewriteWithRtk", () => {
 	let tmpRtkRoot: string | undefined
 	let previousKimchiDir: string | undefined
+	let previousHome: string | undefined
 
 	beforeEach(() => {
 		_resetRtkState()
 		clearEnv()
 		previousKimchiDir = process.env.KIMCHI_CODING_AGENT_DIR
+		previousHome = process.env.HOME
 		tmpRtkRoot = mkdtempSync(join(tmpdir(), "kimchi-rtk-collapse-test-"))
 		process.env.KIMCHI_CODING_AGENT_DIR = tmpRtkRoot
+		process.env.HOME = tmpRtkRoot
 		mockExecFileSync.mockReset()
 		// Pre-seed rtkAvailable = true for most tests (detectRtk already passed).
 		mockExecFile.mockReset()
@@ -146,6 +149,9 @@ describe("rewriteWithRtk", () => {
 		// biome-ignore lint/performance/noDelete: env-var cleanup needs a real delete.
 		if (previousKimchiDir === undefined) delete process.env.KIMCHI_CODING_AGENT_DIR
 		else process.env.KIMCHI_CODING_AGENT_DIR = previousKimchiDir
+		// biome-ignore lint/performance/noDelete: env-var cleanup needs a real delete.
+		if (previousHome === undefined) delete process.env.HOME
+		else process.env.HOME = previousHome
 		clearEnv()
 	})
 
@@ -250,13 +256,16 @@ describe("rewriteWithRtk", () => {
 describe("rtkSpawnHook", () => {
 	let tmpRtkRoot: string | undefined
 	let previousKimchiDir: string | undefined
+	let previousHome: string | undefined
 
 	beforeEach(() => {
 		_resetRtkState()
 		clearEnv()
 		previousKimchiDir = process.env.KIMCHI_CODING_AGENT_DIR
+		previousHome = process.env.HOME
 		tmpRtkRoot = mkdtempSync(join(tmpdir(), "kimchi-rtk-spawn-test-"))
 		process.env.KIMCHI_CODING_AGENT_DIR = tmpRtkRoot
+		process.env.HOME = tmpRtkRoot
 		mockExecFileSync.mockReset()
 		mockExecFile.mockReset()
 	})
@@ -267,6 +276,9 @@ describe("rtkSpawnHook", () => {
 		// biome-ignore lint/performance/noDelete: env-var cleanup needs a real delete.
 		if (previousKimchiDir === undefined) delete process.env.KIMCHI_CODING_AGENT_DIR
 		else process.env.KIMCHI_CODING_AGENT_DIR = previousKimchiDir
+		// biome-ignore lint/performance/noDelete: env-var cleanup needs a real delete.
+		if (previousHome === undefined) delete process.env.HOME
+		else process.env.HOME = previousHome
 		clearEnv()
 	})
 

--- a/src/extensions/bash-collapse.test.ts
+++ b/src/extensions/bash-collapse.test.ts
@@ -7,6 +7,7 @@ import {
 	collapseCommand,
 	detectRtk,
 	getBashCommandForDisplay,
+	rewritePreparedBashCommand,
 	rewriteWithRtk,
 	rtkSpawnHook,
 } from "./bash-collapse.js"
@@ -34,6 +35,22 @@ describe("collapseCommand", () => {
 	})
 })
 
+describe("rewritePreparedBashCommand", () => {
+	it("rewrites the plain command when no shell prefix was applied", () => {
+		expect(rewritePreparedBashCommand("git status", "git status", "rtk git status")).toBe("rtk git status")
+	})
+
+	it("preserves shell setup before the original command", () => {
+		expect(rewritePreparedBashCommand("shopt -s expand_aliases\ngit status", "git status", "rtk git status")).toBe(
+			"shopt -s expand_aliases\nrtk git status",
+		)
+	})
+
+	it("falls back to the rewritten command when the prepared command cannot be matched", () => {
+		expect(rewritePreparedBashCommand("git status && echo done", "git status", "rtk git status")).toBe("rtk git status")
+	})
+})
+
 // ---------------------------------------------------------------------------
 // RTK integration
 // ---------------------------------------------------------------------------
@@ -52,20 +69,10 @@ import { execFile, execFileSync } from "node:child_process"
 const mockExecFile = execFile as unknown as MockInstance
 const mockExecFileSync = execFileSync as unknown as MockInstance
 
-function clearEnv(): void {
-	// biome-ignore lint/performance/noDelete: env vars must be fully removed, not set to "undefined" string
-	delete process.env.KIMCHI_RTK
-}
-
 describe("detectRtk", () => {
 	beforeEach(() => {
 		_resetRtkState()
-		clearEnv()
 		mockExecFile.mockReset()
-	})
-
-	afterEach(() => {
-		clearEnv()
 	})
 
 	it("returns true when rtk --version succeeds", async () => {
@@ -105,24 +112,6 @@ describe("detectRtk", () => {
 		// Only one execFile call — the second caller shares the in-flight promise.
 		expect(mockExecFile).toHaveBeenCalledTimes(1)
 	})
-
-	it("returns false immediately when KIMCHI_RTK=0", async () => {
-		process.env.KIMCHI_RTK = "0"
-		expect(await detectRtk()).toBe(false)
-		expect(mockExecFile).not.toHaveBeenCalled()
-	})
-
-	it("returns false immediately when KIMCHI_RTK=false", async () => {
-		process.env.KIMCHI_RTK = "false"
-		expect(await detectRtk()).toBe(false)
-		expect(mockExecFile).not.toHaveBeenCalled()
-	})
-
-	it("returns false immediately when KIMCHI_RTK=off", async () => {
-		process.env.KIMCHI_RTK = "off"
-		expect(await detectRtk()).toBe(false)
-		expect(mockExecFile).not.toHaveBeenCalled()
-	})
 })
 
 describe("rewriteWithRtk", () => {
@@ -132,7 +121,6 @@ describe("rewriteWithRtk", () => {
 
 	beforeEach(() => {
 		_resetRtkState()
-		clearEnv()
 		previousKimchiDir = process.env.KIMCHI_CODING_AGENT_DIR
 		previousHome = process.env.HOME
 		tmpRtkRoot = mkdtempSync(join(tmpdir(), "kimchi-rtk-collapse-test-"))
@@ -152,7 +140,6 @@ describe("rewriteWithRtk", () => {
 		// biome-ignore lint/performance/noDelete: env-var cleanup needs a real delete.
 		if (previousHome === undefined) delete process.env.HOME
 		else process.env.HOME = previousHome
-		clearEnv()
 	})
 
 	function seedRtkAvailable(): void {
@@ -233,12 +220,6 @@ describe("rewriteWithRtk", () => {
 		expect(mockExecFileSync).not.toHaveBeenCalled()
 	})
 
-	it("short-circuits when KIMCHI_RTK=0 without spawning", () => {
-		process.env.KIMCHI_RTK = "0"
-		expect(rewriteWithRtk("git status")).toBe("git status")
-		expect(mockExecFileSync).not.toHaveBeenCalled()
-	})
-
 	it("passes the command as a single argv element (no shell injection)", async () => {
 		seedRtkAvailable()
 		await detectRtk()
@@ -260,7 +241,6 @@ describe("rtkSpawnHook", () => {
 
 	beforeEach(() => {
 		_resetRtkState()
-		clearEnv()
 		previousKimchiDir = process.env.KIMCHI_CODING_AGENT_DIR
 		previousHome = process.env.HOME
 		tmpRtkRoot = mkdtempSync(join(tmpdir(), "kimchi-rtk-spawn-test-"))
@@ -279,7 +259,6 @@ describe("rtkSpawnHook", () => {
 		// biome-ignore lint/performance/noDelete: env-var cleanup needs a real delete.
 		if (previousHome === undefined) delete process.env.HOME
 		else process.env.HOME = previousHome
-		clearEnv()
 	})
 
 	it("rewrites the command in a BashSpawnContext", async () => {

--- a/src/extensions/bash-collapse.ts
+++ b/src/extensions/bash-collapse.ts
@@ -1,7 +1,5 @@
 import { execFile, execFileSync } from "node:child_process"
-import { existsSync, readFileSync } from "node:fs"
-import { homedir } from "node:os"
-import { join } from "node:path"
+import { existsSync } from "node:fs"
 import {
 	type BashOperations,
 	type BashSpawnContext,
@@ -23,14 +21,10 @@ export function collapseCommand(command: string | undefined): string {
 // `rtk rewrite <cmd>` before execution.  This reduces LLM token consumption
 // by 60-90% on common dev commands (git, cargo, npm, etc.).
 //
-// Disable via:
-//   - KIMCHI_RTK=0 environment variable, or
-//   - "rtk": false  in ~/.config/kimchi/harness/settings.json (/settings)
+// Disable via hooks.rtk-rewrite in /resources.
 //
 // See https://github.com/rtk-ai/rtk
 // ---------------------------------------------------------------------------
-
-const HARNESS_SETTINGS_PATH = join(homedir(), ".config", "kimchi", "harness", "settings.json")
 
 /** Tri-state: undefined = not yet probed, true/false = cached result. */
 let rtkAvailable: boolean | undefined
@@ -38,24 +32,8 @@ let rtkAvailable: boolean | undefined
 /** Cached in-flight detection promise to avoid concurrent spawns. */
 let rtkDetectPromise: Promise<boolean> | undefined
 
-function isRtkDisabledByEnv(): boolean {
-	const v = process.env.KIMCHI_RTK
-	return v === "0" || v === "false" || v === "off"
-}
-
-function isRtkDisabledBySettings(): boolean {
-	try {
-		const raw = readFileSync(HARNESS_SETTINGS_PATH, "utf-8")
-		const parsed = JSON.parse(raw)
-		if ("rtk" in parsed) return parsed.rtk === false
-	} catch {
-		// settings.json absent or unreadable — not disabled
-	}
-	return false
-}
-
 function isRtkDisabled(): boolean {
-	return isRtkDisabledByEnv() || isRtkDisabledBySettings() || !isResourceEnabled("hooks.rtk-rewrite")
+	return !isResourceEnabled("hooks.rtk-rewrite")
 }
 
 function rtkBinary(): string {
@@ -94,7 +72,7 @@ export function detectRtk(): Promise<boolean> {
  * Used as a pi-mono BashSpawnHook (which must be synchronous).
  *
  * Returns the original command unchanged when:
- *   - rtk is not available or disabled via KIMCHI_RTK / settings.json
+ *   - rtk is not available or hooks.rtk-rewrite is disabled
  *   - rtk returns empty output or the same string
  *   - the subprocess times out or fails to spawn
  */
@@ -180,13 +158,20 @@ export default function (pi: ExtensionAPI) {
 		}
 		if (hooked.command === event.command) return
 		rewriteCache.set(event.command, hooked.command)
-		return { operations: fixedCommandOperations(hooked.command) }
+		return { operations: rewrittenCommandOperations(event.command, hooked.command) }
 	})
 }
 
-function fixedCommandOperations(command: string): BashOperations {
+function rewrittenCommandOperations(original: string, rewritten: string): BashOperations {
 	const local = createLocalBashOperations()
 	return {
-		exec: (_command, cwd, options) => local.exec(command, cwd, options),
+		exec: (command, cwd, options) => local.exec(rewritePreparedBashCommand(command, original, rewritten), cwd, options),
 	}
+}
+
+export function rewritePreparedBashCommand(prepared: string, original: string, rewritten: string): string {
+	if (prepared === original) return rewritten
+	const suffix = `\n${original}`
+	if (prepared.endsWith(suffix)) return `${prepared.slice(0, -original.length)}${rewritten}`
+	return rewritten
 }

--- a/src/extensions/bash-collapse.ts
+++ b/src/extensions/bash-collapse.ts
@@ -100,7 +100,7 @@ export function detectRtk(): Promise<boolean> {
  */
 export function rewriteWithRtk(command: string): string {
 	if (isRtkDisabled()) return command
-	if (rtkAvailable === false) return command
+	if (rtkAvailable === false && rtkBinary() === "rtk") return command
 
 	try {
 		const stdout = execFileSync(rtkBinary(), ["rewrite", command], { timeout: 2000, encoding: "utf-8" })

--- a/src/extensions/bash-collapse.ts
+++ b/src/extensions/bash-collapse.ts
@@ -157,7 +157,9 @@ export default function (pi: ExtensionAPI) {
 		const command = event.input.command
 		if (typeof command !== "string") return
 		const rewritten = rewriteWithRtk(command)
-		const hooked = applyEnabledBashHooks(rewritten)
+		const cwd =
+			typeof (event.input as { cwd?: unknown }).cwd === "string" ? (event.input as { cwd: string }).cwd : process.cwd()
+		const hooked = applyEnabledBashHooks(rewritten, cwd)
 		if (hooked.block) return { block: true, reason: hooked.reason }
 		rewriteCache.set(command, hooked.command)
 		if (rewritten !== hooked.command) rewriteCache.set(rewritten, hooked.command)

--- a/src/extensions/bash-collapse.ts
+++ b/src/extensions/bash-collapse.ts
@@ -1,12 +1,16 @@
 import { execFile, execFileSync } from "node:child_process"
-import { readFileSync } from "node:fs"
+import { existsSync, readFileSync } from "node:fs"
 import { homedir } from "node:os"
 import { join } from "node:path"
-import type { BashSpawnContext, BashToolDetails, ExtensionAPI, ToolDefinition } from "@earendil-works/pi-coding-agent"
-import { createBashToolDefinition } from "@earendil-works/pi-coding-agent"
-import { Container, Spacer, Text } from "@earendil-works/pi-tui"
-import { ToolBlockView, buildToolCallHeader, getTextContent } from "../components/tool-block.js"
-import { isToolExpanded, registerToolCall } from "../expand-state.js"
+import {
+	type BashOperations,
+	type BashSpawnContext,
+	type ExtensionAPI,
+	createLocalBashOperations,
+} from "@earendil-works/pi-coding-agent"
+import { applyEnabledBashHooks } from "../resources/bash-hooks.js"
+import { globalRtkLinkPath, managedRtkPath } from "../resources/rtk-install.js"
+import { isResourceEnabled } from "../resources/store.js"
 
 export function collapseCommand(command: string | undefined): string {
 	return (command ?? "").replace(/\n+/g, " ⏎ ")
@@ -51,7 +55,14 @@ function isRtkDisabledBySettings(): boolean {
 }
 
 function isRtkDisabled(): boolean {
-	return isRtkDisabledByEnv() || isRtkDisabledBySettings()
+	return isRtkDisabledByEnv() || isRtkDisabledBySettings() || !isResourceEnabled("hooks.rtk-rewrite")
+}
+
+function rtkBinary(): string {
+	const global = globalRtkLinkPath()
+	if (existsSync(global)) return global
+	const managed = managedRtkPath()
+	return existsSync(managed) ? managed : "rtk"
 }
 
 /**
@@ -69,7 +80,7 @@ export function detectRtk(): Promise<boolean> {
 	}
 	if (rtkDetectPromise) return rtkDetectPromise
 	rtkDetectPromise = new Promise<boolean>((resolve) => {
-		execFile("rtk", ["--version"], { timeout: 1000 }, (err) => {
+		execFile(rtkBinary(), ["--version"], { timeout: 1000 }, (err) => {
 			rtkAvailable = !err
 			rtkDetectPromise = undefined
 			resolve(rtkAvailable)
@@ -92,7 +103,7 @@ export function rewriteWithRtk(command: string): string {
 	if (rtkAvailable === false) return command
 
 	try {
-		const stdout = execFileSync("rtk", ["rewrite", command], { timeout: 2000, encoding: "utf-8" })
+		const stdout = execFileSync(rtkBinary(), ["rewrite", command], { timeout: 2000, encoding: "utf-8" })
 		const rewritten = stdout.trim()
 		return rewritten && rewritten !== command ? rewritten : command
 	} catch (err) {
@@ -114,6 +125,11 @@ export function rewriteWithRtk(command: string): string {
 /** Cache of rewrite results so renderCall never spawns a subprocess. */
 const rewriteCache = new Map<string, string>()
 
+export function getBashCommandForDisplay(command: string | undefined): string | undefined {
+	if (!command) return command
+	return rewriteCache.get(command) ?? command
+}
+
 /**
  * BashSpawnHook for pi-mono's createBashToolDefinition.
  * Rewrites the command through `rtk rewrite` before the shell spawns.
@@ -133,66 +149,42 @@ export function _resetRtkState(): void {
 }
 
 export default function (pi: ExtensionAPI) {
-	const baseDef = createBashToolDefinition(process.cwd(), { spawnHook: rtkSpawnHook })
-
 	// Eagerly probe for rtk at extension load time (non-blocking).
 	detectRtk()
 
-	const def: ToolDefinition<typeof baseDef.parameters, BashToolDetails | undefined> = {
-		...baseDef,
+	pi.on("tool_call", (event) => {
+		if (event.toolName !== "bash") return
+		const command = event.input.command
+		if (typeof command !== "string") return
+		const rewritten = rewriteWithRtk(command)
+		const hooked = applyEnabledBashHooks(rewritten)
+		if (hooked.block) return { block: true, reason: hooked.reason }
+		rewriteCache.set(command, hooked.command)
+		if (rewritten !== hooked.command) rewriteCache.set(rewritten, hooked.command)
+		event.input.command = hooked.command
+	})
 
-		execute(toolCallId, params, signal, onUpdate, ctx) {
-			return createBashToolDefinition(ctx.cwd, { spawnHook: rtkSpawnHook }).execute(
-				toolCallId,
-				params,
-				signal,
-				onUpdate,
-				ctx,
-			)
-		},
-
-		renderCall(args, theme, ctx) {
-			const view = ctx.lastComponent instanceof ToolBlockView ? ctx.lastComponent : new ToolBlockView()
-			// Use the cached rewrite result if available (populated by rtkSpawnHook
-			// during execute).  This avoids spawning a subprocess on the render path.
-			// Falls back to the original command when no cached result exists yet.
-			const command = collapseCommand(rewriteCache.get(args.command ?? "") ?? args.command ?? "")
-			buildToolCallHeader(view, "bash", command, theme, ctx)
-			return view
-		},
-
-		renderResult(result, options, theme, context) {
-			if (options.isPartial) {
-				const displayText = getTextContent(result).split("\n").slice(-5).join("\n")
-
-				const component = context.lastComponent instanceof Container ? context.lastComponent : new Container()
-				component.clear()
-				component.addChild(new Spacer(1))
-				component.addChild(new Text(theme.fg("toolOutput", displayText), 0, 0))
-				component.invalidate()
-				return component
+	pi.on("user_bash", (event) => {
+		const hooked = applyEnabledBashHooks(event.command, event.cwd)
+		if (hooked.block) {
+			return {
+				result: {
+					output: hooked.reason ?? "Bash hook blocked command",
+					exitCode: 2,
+					cancelled: false,
+					truncated: false,
+				},
 			}
+		}
+		if (hooked.command === event.command) return
+		rewriteCache.set(event.command, hooked.command)
+		return { operations: fixedCommandOperations(hooked.command) }
+	})
+}
 
-			registerToolCall(context.toolCallId)
-
-			if (isToolExpanded(context.toolCallId)) {
-				return baseDef.renderResult?.(result, options, theme, context) ?? new Text("", 0, 0)
-			}
-
-			const view = context.lastComponent instanceof ToolBlockView ? context.lastComponent : new ToolBlockView()
-			const trimmed = getTextContent(result).replace(/\n$/, "")
-			const lineCount = trimmed ? trimmed.split("\n").length : 0
-
-			view.setHeader("", "")
-			view.setBranchMode((s: string) => theme.fg("borderMuted", s))
-			view.setFooter(
-				theme.fg("dim", `${lineCount} line${lineCount === 1 ? "" : "s"} of output`),
-				theme.fg("dim", "ctrl+o"),
-			)
-			view.setExtra([])
-			return view
-		},
+function fixedCommandOperations(command: string): BashOperations {
+	const local = createLocalBashOperations()
+	return {
+		exec: (_command, cwd, options) => local.exec(command, cwd, options),
 	}
-
-	pi.registerTool(def)
 }

--- a/src/extensions/tool-rendering.ts
+++ b/src/extensions/tool-rendering.ts
@@ -33,6 +33,7 @@ import {
 } from "@earendil-works/pi-tui"
 
 import * as Diff from "diff"
+import { getBashCommandForDisplay } from "./bash-collapse.js"
 import type { BundledLanguage, BundledTheme } from "shiki"
 
 const RESET = "\x1b[0m"
@@ -3764,7 +3765,7 @@ export default function (pi: ExtensionAPI) {
 			return bashTool.execute(toolCallId, params, signal, onUpdate)
 		},
 		renderCall(args, theme, ctx) {
-			const summary = stableCallSummary(ctx, "_callSummary", () => summarizeText(args.command, 72))
+			const summary = summarizeText(getBashCommandForDisplay(args.command) ?? args.command, 72)
 			return makeText(ctx.lastComponent, toolHeader("Bash", summary, theme, toolStatusDot(ctx, theme)))
 		},
 		renderResult(result, { expanded, isPartial }, theme, ctx) {

--- a/src/resources/bash-hook-discovery.ts
+++ b/src/resources/bash-hook-discovery.ts
@@ -1,0 +1,69 @@
+import { existsSync, readdirSync, statSync } from "node:fs"
+import { homedir } from "node:os"
+import { basename, extname, join, resolve } from "node:path"
+import type { ResourceDefinition } from "./types.js"
+
+export type BashHookScope = "global" | "project"
+
+export interface BashHookResource extends ResourceDefinition {
+	kind: "hooks"
+	hookKind: "bash"
+	scope: BashHookScope
+	path: string
+}
+
+export function getGlobalBashHookDir(): string {
+	return process.env.KIMCHI_CODING_AGENT_DIR
+		? resolve(process.env.KIMCHI_CODING_AGENT_DIR, "hooks", "bash")
+		: join(homedir(), ".config", "kimchi", "harness", "hooks", "bash")
+}
+
+export function getProjectBashHookDir(cwd = process.cwd()): string {
+	return resolve(cwd, ".kimchi", "hooks", "bash")
+}
+
+export function discoverBashHookResources(cwd = process.cwd()): BashHookResource[] {
+	const hooks = [
+		...discoverBashHooksInDir(getGlobalBashHookDir(), "global"),
+		...discoverBashHooksInDir(getProjectBashHookDir(cwd), "project"),
+	]
+	return hooks.sort((a, b) => a.id.localeCompare(b.id))
+}
+
+function discoverBashHooksInDir(dir: string, scope: BashHookScope): BashHookResource[] {
+	if (!existsSync(dir)) return []
+	return readdirSync(dir)
+		.filter((name) => isBashHookFile(name, join(dir, name)))
+		.map((name) => {
+			const path = join(dir, name)
+			const id = `hooks.bash.${scope}.${slug(name)}`
+			return {
+				id,
+				kind: "hooks" as const,
+				hookKind: "bash" as const,
+				scope,
+				path,
+				label: `Bash: ${basename(name, extname(name))}`,
+				description: `${scope} Bash hook at ${path}`,
+				defaultEnabled: scope === "global",
+			}
+		})
+}
+
+function isBashHookFile(name: string, path: string): boolean {
+	if (name.startsWith(".")) return false
+	if (!name.endsWith(".sh") && !name.endsWith(".bash")) return false
+	try {
+		return statSync(path).isFile()
+	} catch {
+		return false
+	}
+}
+
+function slug(value: string): string {
+	const normalized = value
+		.toLowerCase()
+		.replace(/[^a-z0-9]+/g, "-")
+		.replace(/^-+|-+$/g, "")
+	return normalized || "hook"
+}

--- a/src/resources/bash-hooks.test.ts
+++ b/src/resources/bash-hooks.test.ts
@@ -1,0 +1,79 @@
+import { execFileSync } from "node:child_process"
+import { mkdirSync, rmSync, writeFileSync } from "node:fs"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
+import { discoverBashHookResources } from "./bash-hook-discovery.js"
+import { applyEnabledBashHooks, parseBashHookOutput } from "./bash-hooks.js"
+
+vi.mock("node:child_process", () => ({
+	execFileSync: vi.fn(),
+}))
+
+const mockExecFileSync = execFileSync as unknown as ReturnType<typeof vi.fn>
+
+let dir: string
+let oldAgentDir: string | undefined
+
+describe("bash hook discovery", () => {
+	beforeEach(() => {
+		dir = join(tmpdir(), `kimchi-bash-hooks-${process.pid}-${Math.random().toString(16).slice(2)}`)
+		mkdirSync(dir, { recursive: true })
+		oldAgentDir = process.env.KIMCHI_CODING_AGENT_DIR
+		process.env.KIMCHI_CODING_AGENT_DIR = join(dir, "agent")
+	})
+
+	afterEach(() => {
+		if (oldAgentDir === undefined) process.env.KIMCHI_CODING_AGENT_DIR = undefined
+		else process.env.KIMCHI_CODING_AGENT_DIR = oldAgentDir
+		rmSync(dir, { recursive: true, force: true })
+		mockExecFileSync.mockReset()
+	})
+
+	it("discovers global and project bash hooks", () => {
+		const globalDir = join(dir, "agent", "hooks", "bash")
+		const projectDir = join(dir, "project", ".kimchi", "hooks", "bash")
+		mkdirSync(globalDir, { recursive: true })
+		mkdirSync(projectDir, { recursive: true })
+		writeFileSync(join(globalDir, "rewrite.sh"), "echo global\n")
+		writeFileSync(join(projectDir, "guard.bash"), "echo project\n")
+		writeFileSync(join(projectDir, "notes.txt"), "ignore\n")
+
+		const hooks = discoverBashHookResources(join(dir, "project"))
+
+		expect(hooks.map((hook) => hook.id)).toEqual(["hooks.bash.global.rewrite-sh", "hooks.bash.project.guard-bash"])
+		expect(hooks.find((hook) => hook.scope === "global")?.defaultEnabled).toBe(true)
+		expect(hooks.find((hook) => hook.scope === "project")?.defaultEnabled).toBe(false)
+	})
+
+	it("parses Crush-style updated_input JSON", () => {
+		const output = JSON.stringify({
+			decision: "allow",
+			updated_input: JSON.stringify({ command: "rtk git status" }),
+		})
+
+		expect(parseBashHookOutput(output, "git status")).toEqual({ command: "rtk git status" })
+	})
+
+	it("parses plain stdout as a command rewrite", () => {
+		expect(parseBashHookOutput("git status --short\n", "git status")).toEqual({ command: "git status --short" })
+	})
+
+	it("parses block decisions", () => {
+		expect(parseBashHookOutput(JSON.stringify({ decision: "block", reason: "no rm" }), "rm -rf .")).toEqual({
+			command: "rm -rf .",
+			block: true,
+			reason: "no rm",
+		})
+	})
+
+	it("runs enabled global bash hooks in order", () => {
+		const globalDir = join(dir, "agent", "hooks", "bash")
+		mkdirSync(globalDir, { recursive: true })
+		writeFileSync(join(globalDir, "rewrite.sh"), "unused\n")
+		mockExecFileSync.mockReturnValueOnce("git status --short\n")
+
+		expect(applyEnabledBashHooks("git status", join(dir, "project"))).toEqual({ command: "git status --short" })
+		expect(mockExecFileSync).toHaveBeenCalledOnce()
+	})
+})

--- a/src/resources/bash-hooks.ts
+++ b/src/resources/bash-hooks.ts
@@ -1,0 +1,106 @@
+import { execFileSync } from "node:child_process"
+import { discoverBashHookResources } from "./bash-hook-discovery.js"
+import { getResourceOverride } from "./store.js"
+
+export interface BashHookResult {
+	command: string
+	block?: boolean
+	reason?: string
+}
+
+interface HookJsonOutput {
+	decision?: string
+	reason?: string
+	command?: string
+	input?: unknown
+	updated_input?: unknown
+}
+
+export function applyEnabledBashHooks(command: string, cwd = process.cwd()): BashHookResult {
+	let current = command
+	for (const hook of discoverBashHookResources(cwd)) {
+		if ((getResourceOverride(hook.id) ?? hook.defaultEnabled) !== true) continue
+		const result = runBashHook(hook.path, current, cwd)
+		if (result.block) return result
+		current = result.command
+	}
+	return { command: current }
+}
+
+export function parseBashHookOutput(stdout: string, command: string): BashHookResult {
+	const trimmed = stdout.trim()
+	if (!trimmed) return { command }
+
+	const parsed = parseJson(trimmed)
+	if (!parsed) return { command: trimmed }
+
+	const decision = typeof parsed.decision === "string" ? parsed.decision.toLowerCase() : "allow"
+	if (decision === "block" || decision === "deny") {
+		return { command, block: true, reason: parsed.reason ?? "Bash hook blocked command" }
+	}
+
+	const input = parseUpdatedInput(parsed.updated_input ?? parsed.input)
+	const next = input?.command ?? parsed.command
+	return typeof next === "string" && next.trim() ? { command: next } : { command }
+}
+
+function runBashHook(path: string, command: string, cwd: string): BashHookResult {
+	const payload = JSON.stringify({ tool_name: "bash", input: { command }, cwd })
+	const env = {
+		...process.env,
+		KIMCHI_HOOK_EVENT: "tool_call",
+		KIMCHI_TOOL_NAME: "bash",
+		KIMCHI_TOOL_INPUT_COMMAND: command,
+		// Compatibility with Crush-style bash hook examples.
+		CRUSH_TOOL_INPUT_COMMAND: command,
+	}
+
+	try {
+		const stdout = execFileSync(bashBinary(), [path], {
+			cwd,
+			env,
+			input: payload,
+			encoding: "utf-8",
+			timeout: 5000,
+		})
+		return parseBashHookOutput(stdout, command)
+	} catch (err) {
+		const execErr = err as { status?: number; stdout?: string; stderr?: string; code?: string; message?: string }
+		if (execErr.status === 2) {
+			return {
+				command,
+				block: true,
+				reason: firstLine(execErr.stderr) ?? firstLine(execErr.stdout) ?? `${path} blocked command`,
+			}
+		}
+		return { command }
+	}
+}
+
+function bashBinary(): string {
+	return process.platform === "win32" ? "bash.exe" : "bash"
+}
+
+function parseJson(value: string): HookJsonOutput | undefined {
+	try {
+		const parsed = JSON.parse(value)
+		return parsed && typeof parsed === "object" && !Array.isArray(parsed) ? (parsed as HookJsonOutput) : undefined
+	} catch {
+		return undefined
+	}
+}
+
+function parseUpdatedInput(value: unknown): { command?: string } | undefined {
+	if (typeof value === "string") {
+		const parsed = parseJson(value)
+		return parsed ? parseUpdatedInput(parsed) : undefined
+	}
+	if (!value || typeof value !== "object" || Array.isArray(value)) return undefined
+	const command = (value as Record<string, unknown>).command
+	return typeof command === "string" ? { command } : undefined
+}
+
+function firstLine(value: string | undefined): string | undefined {
+	const line = value?.trim().split(/\r?\n/).find(Boolean)
+	return line || undefined
+}

--- a/src/resources/bash-hooks.ts
+++ b/src/resources/bash-hooks.ts
@@ -1,6 +1,7 @@
 import { execFileSync } from "node:child_process"
 import { discoverBashHookResources } from "./bash-hook-discovery.js"
-import { getResourceOverride } from "./store.js"
+import { readResourceSettings } from "./store.js"
+import type { ResourceId } from "./types.js"
 
 export interface BashHookResult {
 	command: string
@@ -18,8 +19,9 @@ interface HookJsonOutput {
 
 export function applyEnabledBashHooks(command: string, cwd = process.cwd()): BashHookResult {
 	let current = command
+	const settings = readResourceSettings()
 	for (const hook of discoverBashHookResources(cwd)) {
-		if ((getResourceOverride(hook.id) ?? hook.defaultEnabled) !== true) continue
+		if ((settings.resources[hook.id as ResourceId] ?? hook.defaultEnabled) !== true) continue
 		const result = runBashHook(hook.path, current, cwd)
 		if (result.block) return result
 		current = result.command

--- a/src/resources/definitions.ts
+++ b/src/resources/definitions.ts
@@ -1,0 +1,73 @@
+import { discoverBashHookResources } from "./bash-hook-discovery.js"
+import type { ResourceDefinition, ResourceKind } from "./types.js"
+
+export const STATIC_RESOURCE_DEFINITIONS: readonly ResourceDefinition[] = [
+	{
+		id: "hooks.rtk-rewrite",
+		kind: "hooks",
+		label: "RTK rewrite",
+		description: "Rewrite Bash commands through rtk before execution.",
+		defaultEnabled: true,
+	},
+	{
+		id: "tools.web_search",
+		kind: "tools",
+		label: "Web search",
+		description: "Allow the web_search tool.",
+		defaultEnabled: true,
+		restartRequired: true,
+	},
+	{
+		id: "tools.web_fetch",
+		kind: "tools",
+		label: "Web fetch",
+		description: "Allow the web_fetch tool.",
+		defaultEnabled: true,
+		restartRequired: true,
+	},
+	{
+		id: "extensions.agents",
+		kind: "extensions",
+		label: "Agents",
+		description: "Enable subagent delegation tools.",
+		defaultEnabled: true,
+		restartRequired: true,
+	},
+	{
+		id: "extensions.ferment",
+		kind: "extensions",
+		label: "Ferment",
+		description: "Enable guided project workflow tools.",
+		defaultEnabled: true,
+		restartRequired: true,
+	},
+	{
+		id: "plugins.mcp-apps",
+		kind: "plugins",
+		label: "MCP apps",
+		description: "Enable MCP/app connector tools.",
+		defaultEnabled: true,
+		restartRequired: true,
+	},
+]
+
+export const RESOURCE_KINDS: readonly ResourceKind[] = ["hooks", "tools", "extensions", "plugins"]
+
+export const TOOL_RESOURCE_IDS: Readonly<Record<string, string>> = {
+	web_search: "tools.web_search",
+	web_fetch: "tools.web_fetch",
+}
+
+const staticDefinitionsById = new Map(STATIC_RESOURCE_DEFINITIONS.map((definition) => [definition.id, definition]))
+
+export function getResourceDefinitions(): ResourceDefinition[] {
+	return [...STATIC_RESOURCE_DEFINITIONS, ...discoverBashHookResources()]
+}
+
+export function getResourceDefinition(id: string): ResourceDefinition | undefined {
+	return staticDefinitionsById.get(id) ?? discoverBashHookResources().find((definition) => definition.id === id)
+}
+
+export function getResourcesByKind(kind: ResourceKind): ResourceDefinition[] {
+	return getResourceDefinitions().filter((definition) => definition.kind === kind)
+}

--- a/src/resources/extension.ts
+++ b/src/resources/extension.ts
@@ -1,6 +1,13 @@
 import type { ExtensionAPI, ExtensionContext } from "@earendil-works/pi-coding-agent"
 import { getResourceDefinition, getResourceDefinitions } from "./definitions.js"
-import { installRtk, isRtkInstalled, markRtkAutoInstallChecked, shouldCheckRtkAutoInstall } from "./rtk-install.js"
+import {
+	ensureRtkPath,
+	installRtk,
+	isRtkCommandAvailable,
+	isRtkInstalled,
+	markRtkAutoInstallChecked,
+	shouldCheckRtkAutoInstall,
+} from "./rtk-install.js"
 import { isResourceEnabled, setResourceOverride } from "./store.js"
 import type { ResourceKind } from "./types.js"
 import { createResourceManager } from "./ui.js"
@@ -29,16 +36,19 @@ async function ensureRtkOnStartup(ctx: ExtensionContext): Promise<void> {
 	if (!isResourceEnabled("hooks.rtk-rewrite")) return
 	if (process.env.KIMCHI_RTK_AUTO_INSTALL === "0") return
 
+	ensureRtkPath()
 	const missing = !isRtkInstalled()
-	if (!missing && !shouldCheckRtkAutoInstall()) return
+	const commandMissing = !isRtkCommandAvailable()
+	if (!missing && !commandMissing && !shouldCheckRtkAutoInstall()) return
 
 	try {
 		const result = await installRtk()
 		markRtkAutoInstallChecked()
-		if (missing && ctx.hasUI) ctx.ui.notify(`RTK installed at ${result.linkPath}`, "info")
+		if ((missing || commandMissing) && ctx.hasUI) ctx.ui.notify(`RTK ready at ${result.linkPath}`, "info")
 	} catch (err) {
 		markRtkAutoInstallChecked()
-		if (missing && ctx.hasUI) ctx.ui.notify(`RTK install failed: ${(err as Error).message}`, "warning")
+		if ((missing || commandMissing) && ctx.hasUI)
+			ctx.ui.notify(`RTK install failed: ${(err as Error).message}`, "warning")
 	}
 }
 

--- a/src/resources/extension.ts
+++ b/src/resources/extension.ts
@@ -1,0 +1,102 @@
+import type { ExtensionAPI, ExtensionContext } from "@earendil-works/pi-coding-agent"
+import { getResourceDefinition, getResourceDefinitions } from "./definitions.js"
+import { installRtk, isRtkInstalled, markRtkAutoInstallChecked, shouldCheckRtkAutoInstall } from "./rtk-install.js"
+import { isResourceEnabled, setResourceOverride } from "./store.js"
+import type { ResourceKind } from "./types.js"
+import { createResourceManager } from "./ui.js"
+
+export default function resourcesExtension(pi: ExtensionAPI): void {
+	pi.on("session_start", (_event, ctx) => {
+		void ensureRtkOnStartup(ctx)
+	})
+
+	pi.registerCommand("resources", {
+		description: "View/change Kimchi hooks, tools, extensions, and plugins",
+		handler: async (args, ctx) => {
+			await handleResourcesCommand(args, ctx)
+		},
+	})
+
+	pi.registerCommand("hooks", {
+		description: "View/change Kimchi hooks",
+		handler: async (_args, ctx) => {
+			await openResourceKindMenu(ctx, "hooks")
+		},
+	})
+}
+
+async function ensureRtkOnStartup(ctx: ExtensionContext): Promise<void> {
+	if (!isResourceEnabled("hooks.rtk-rewrite")) return
+	if (process.env.KIMCHI_RTK_AUTO_INSTALL === "0") return
+
+	const missing = !isRtkInstalled()
+	if (!missing && !shouldCheckRtkAutoInstall()) return
+
+	try {
+		const result = await installRtk()
+		markRtkAutoInstallChecked()
+		if (missing && ctx.hasUI) ctx.ui.notify(`RTK installed at ${result.linkPath}`, "info")
+	} catch (err) {
+		markRtkAutoInstallChecked()
+		if (missing && ctx.hasUI) ctx.ui.notify(`RTK install failed: ${(err as Error).message}`, "warning")
+	}
+}
+
+async function handleResourcesCommand(args: string, ctx: ExtensionContext): Promise<void> {
+	const [sub, id, value] = args.trim().split(/\s+/).filter(Boolean)
+
+	if (!sub) return openResourceMenu(ctx)
+	if (sub === "list" || sub === "status") return showResourceStatus(ctx)
+	if (sub === "enable" || sub === "disable") {
+		if (!id) {
+			ctx.ui.notify(`usage: /resources ${sub} <resource-id>`, "warning")
+			return
+		}
+		const enabled = sub === "enable"
+		setResourceOverride(id, enabled)
+		ctx.ui.notify(`${id}: ${enabled ? "enabled" : "disabled"}${restartSuffix(id)}`, "info")
+		return
+	}
+	if (sub === "set") {
+		if (!id || !value || !["on", "off", "true", "false", "1", "0"].includes(value)) {
+			ctx.ui.notify("usage: /resources set <resource-id> on|off", "warning")
+			return
+		}
+		const enabled = value === "on" || value === "true" || value === "1"
+		setResourceOverride(id, enabled)
+		ctx.ui.notify(`${id}: ${enabled ? "enabled" : "disabled"}${restartSuffix(id)}`, "info")
+		return
+	}
+
+	ctx.ui.notify(`resources: unknown subcommand "${sub}". Try /resources list.`, "warning")
+}
+
+async function openResourceMenu(ctx: ExtensionContext): Promise<void> {
+	if (!ctx.hasUI) return showResourceStatus(ctx)
+
+	await ctx.ui.custom<void>((tui, theme, _keybindings, done) => createResourceManager(tui, theme, done), {
+		overlay: true,
+		overlayOptions: { width: "70%", minWidth: 72, maxHeight: "70%" },
+	})
+}
+
+async function openResourceKindMenu(ctx: ExtensionContext, kind: ResourceKind): Promise<void> {
+	if (!ctx.hasUI) return showResourceStatus(ctx)
+
+	await ctx.ui.custom<void>((tui, theme, _keybindings, done) => createResourceManager(tui, theme, done, kind), {
+		overlay: true,
+		overlayOptions: { width: "70%", minWidth: 72, maxHeight: "70%" },
+	})
+}
+
+function showResourceStatus(ctx: ExtensionContext): void {
+	const lines = getResourceDefinitions().map((resource) => {
+		const status = isResourceEnabled(resource.id) ? "enabled " : "disabled"
+		return `${status}  ${resource.id}  ${resource.description}`
+	})
+	ctx.ui.notify(lines.join("\n"), "info")
+}
+
+function restartSuffix(id: string): string {
+	return getResourceDefinition(id)?.restartRequired ? " (restart required)" : ""
+}

--- a/src/resources/extension.ts
+++ b/src/resources/extension.ts
@@ -74,19 +74,13 @@ async function handleResourcesCommand(args: string, ctx: ExtensionContext): Prom
 async function openResourceMenu(ctx: ExtensionContext): Promise<void> {
 	if (!ctx.hasUI) return showResourceStatus(ctx)
 
-	await ctx.ui.custom<void>((tui, theme, _keybindings, done) => createResourceManager(tui, theme, done), {
-		overlay: true,
-		overlayOptions: { width: "70%", minWidth: 72, maxHeight: "70%" },
-	})
+	await ctx.ui.custom<void>((tui, theme, _keybindings, done) => createResourceManager(tui, theme, done))
 }
 
 async function openResourceKindMenu(ctx: ExtensionContext, kind: ResourceKind): Promise<void> {
 	if (!ctx.hasUI) return showResourceStatus(ctx)
 
-	await ctx.ui.custom<void>((tui, theme, _keybindings, done) => createResourceManager(tui, theme, done, kind), {
-		overlay: true,
-		overlayOptions: { width: "70%", minWidth: 72, maxHeight: "70%" },
-	})
+	await ctx.ui.custom<void>((tui, theme, _keybindings, done) => createResourceManager(tui, theme, done, kind))
 }
 
 function showResourceStatus(ctx: ExtensionContext): void {

--- a/src/resources/filter.ts
+++ b/src/resources/filter.ts
@@ -1,0 +1,11 @@
+import type { ExtensionFactory } from "@earendil-works/pi-coding-agent"
+import { isResourceEnabled } from "./store.js"
+
+export interface ManagedExtensionFactory {
+	id: string
+	factory: ExtensionFactory
+}
+
+export function enabledExtensionFactories(factories: readonly ManagedExtensionFactory[]): ExtensionFactory[] {
+	return factories.filter(({ id }) => isResourceEnabled(id)).map(({ factory }) => factory)
+}

--- a/src/resources/rtk-install.ts
+++ b/src/resources/rtk-install.ts
@@ -7,9 +7,9 @@ import {
 	mkdtempSync,
 	readFileSync,
 	readdirSync,
+	renameSync,
 	rmSync,
 	symlinkSync,
-	unlinkSync,
 	writeFileSync,
 } from "node:fs"
 import { chmod, writeFile } from "node:fs/promises"
@@ -35,6 +35,8 @@ export interface RtkInstallResult {
 	linkPath: string
 }
 
+let installPromise: Promise<RtkInstallResult> | undefined
+
 export function managedRtkPath(): string {
 	return join(rtkInstallDir(), process.platform === "win32" ? "rtk.exe" : "rtk")
 }
@@ -54,6 +56,14 @@ export function isRtkInstalled(): boolean {
 	}
 }
 
+export function installedRtkVersion(): string | undefined {
+	for (const binary of [globalRtkLinkPath(), managedRtkPath(), "rtk"]) {
+		const version = rtkVersion(binary)
+		if (version) return version
+	}
+	return undefined
+}
+
 export function shouldCheckRtkAutoInstall(now = Date.now(), path = settingsPath()): boolean {
 	const settings = readFullSettings(path)
 	const checkedAt = typeof settings.rtkAutoInstallCheckedAt === "number" ? settings.rtkAutoInstallCheckedAt : 0
@@ -67,7 +77,27 @@ export function markRtkAutoInstallChecked(now = Date.now(), path = settingsPath(
 }
 
 export async function installRtk(): Promise<RtkInstallResult> {
+	if (installPromise) return installPromise
+	installPromise = installRtkUnlocked().finally(() => {
+		installPromise = undefined
+	})
+	return installPromise
+}
+
+async function installRtkUnlocked(): Promise<RtkInstallResult> {
 	const release = await fetchJson<GitHubRelease>(LATEST_RELEASE_URL)
+	const managedPath = managedRtkPath()
+	const globalPath = globalRtkLinkPath()
+	const managedVersion = rtkVersion(managedPath)
+	const globalVersion = rtkVersion(globalPath)
+	if (managedVersion === release.tag_name) {
+		const linkPath = globalVersion === release.tag_name ? globalPath : linkGlobalRtk(managedPath)
+		return { version: release.tag_name, binaryPath: managedPath, linkPath }
+	}
+	if (globalVersion === release.tag_name) {
+		return { version: release.tag_name, binaryPath: globalPath, linkPath: globalPath }
+	}
+
 	const asset = selectAsset(release)
 	const archive = await download(asset.browser_download_url)
 	verifyDigest(asset, archive)
@@ -82,7 +112,7 @@ export async function installRtk(): Promise<RtkInstallResult> {
 		const extracted = findExtractedRtk(extractDir)
 		const target = managedRtkPath()
 		mkdirSync(dirname(target), { recursive: true })
-		copyFileSync(extracted, target)
+		replaceFile(extracted, target)
 		if (process.platform !== "win32") await chmod(target, 0o755)
 		const linkPath = linkGlobalRtk(target)
 		return { version: release.tag_name, binaryPath: target, linkPath }
@@ -105,15 +135,33 @@ function globalBinDir(): string {
 function linkGlobalRtk(target: string): string {
 	const linkPath = globalRtkLinkPath()
 	mkdirSync(dirname(linkPath), { recursive: true })
-	if (existsSync(linkPath)) unlinkSync(linkPath)
 
 	if (process.platform === "win32") {
-		copyFileSync(target, linkPath)
+		replaceFile(target, linkPath)
 		return linkPath
 	}
 
-	symlinkSync(target, linkPath)
+	const tmpLink = `${linkPath}.${process.pid}.${Date.now()}.tmp`
+	rmSync(tmpLink, { force: true })
+	symlinkSync(target, tmpLink)
+	renameSync(tmpLink, linkPath)
 	return linkPath
+}
+
+function replaceFile(src: string, dest: string): void {
+	const tmp = `${dest}.${process.pid}.${Date.now()}.tmp`
+	copyFileSync(src, tmp)
+	renameSync(tmp, dest)
+}
+
+function rtkVersion(binary: string): string | undefined {
+	try {
+		const output = execFileSync(binary, ["--version"], { encoding: "utf-8", timeout: 1000 })
+		const match = output.match(/\d+\.\d+\.\d+/)
+		return match ? `v${match[0]}` : undefined
+	} catch {
+		return undefined
+	}
 }
 
 function readFullSettings(path: string): Record<string, unknown> {
@@ -163,7 +211,8 @@ async function download(url: string): Promise<Buffer> {
 }
 
 function verifyDigest(asset: GitHubRelease["assets"][number], archive: Buffer): void {
-	if (!asset.digest?.startsWith("sha256:")) return
+	if (!asset.digest?.startsWith("sha256:"))
+		throw new Error(`RTK release asset ${asset.name} is missing a sha256 digest`)
 	const expected = asset.digest.slice("sha256:".length)
 	const actual = createHash("sha256").update(archive).digest("hex")
 	if (actual !== expected) throw new Error(`RTK checksum mismatch for ${asset.name}`)

--- a/src/resources/rtk-install.ts
+++ b/src/resources/rtk-install.ts
@@ -14,7 +14,7 @@ import {
 } from "node:fs"
 import { chmod, writeFile } from "node:fs/promises"
 import { homedir, tmpdir } from "node:os"
-import { basename, dirname, join } from "node:path"
+import { basename, delimiter, dirname, join } from "node:path"
 import { settingsPath } from "./store.js"
 
 const LATEST_RELEASE_URL = "https://api.github.com/repos/rtk-ai/rtk/releases/latest"
@@ -45,15 +45,25 @@ export function globalRtkLinkPath(): string {
 	return join(globalBinDir(), process.platform === "win32" ? "rtk.exe" : "rtk")
 }
 
-export function isRtkInstalled(): boolean {
-	if (existsSync(globalRtkLinkPath())) return true
-	if (existsSync(managedRtkPath())) return true
+export function ensureRtkPath(): void {
+	const bin = globalBinDir()
+	const entries = (process.env.PATH ?? "").split(delimiter).filter(Boolean)
+	if (!entries.includes(bin)) process.env.PATH = [bin, ...entries].join(delimiter)
+}
+
+export function isRtkCommandAvailable(): boolean {
 	try {
 		execFileSync("rtk", ["--version"], { stdio: "ignore", timeout: 1000 })
 		return true
 	} catch {
 		return false
 	}
+}
+
+export function isRtkInstalled(): boolean {
+	if (existsSync(globalRtkLinkPath())) return true
+	if (existsSync(managedRtkPath())) return true
+	return isRtkCommandAvailable()
 }
 
 export function installedRtkVersion(): string | undefined {
@@ -92,9 +102,11 @@ async function installRtkUnlocked(): Promise<RtkInstallResult> {
 	const globalVersion = rtkVersion(globalPath)
 	if (managedVersion === release.tag_name) {
 		const linkPath = globalVersion === release.tag_name ? globalPath : linkGlobalRtk(managedPath)
+		ensureRtkPath()
 		return { version: release.tag_name, binaryPath: managedPath, linkPath }
 	}
 	if (globalVersion === release.tag_name) {
+		ensureRtkPath()
 		return { version: release.tag_name, binaryPath: globalPath, linkPath: globalPath }
 	}
 
@@ -115,6 +127,7 @@ async function installRtkUnlocked(): Promise<RtkInstallResult> {
 		replaceFile(extracted, target)
 		if (process.platform !== "win32") await chmod(target, 0o755)
 		const linkPath = linkGlobalRtk(target)
+		ensureRtkPath()
 		return { version: release.tag_name, binaryPath: target, linkPath }
 	} finally {
 		rmSync(tempDir, { recursive: true, force: true })

--- a/src/resources/rtk-install.ts
+++ b/src/resources/rtk-install.ts
@@ -212,15 +212,25 @@ function assetName(): string {
 }
 
 async function fetchJson<T>(url: string): Promise<T> {
-	const res = await fetch(url, { headers: { "User-Agent": "kimchi" } })
+	const res = await fetch(url, { headers: requestHeaders() })
 	if (!res.ok) throw new Error(`Failed to fetch ${url}: ${res.status}`)
 	return (await res.json()) as T
 }
 
 async function download(url: string): Promise<Buffer> {
-	const res = await fetch(url, { headers: { "User-Agent": "kimchi" } })
+	const res = await fetch(url, { headers: requestHeaders() })
 	if (!res.ok) throw new Error(`Failed to download ${basename(url)}: ${res.status}`)
 	return Buffer.from(await res.arrayBuffer())
+}
+
+function requestHeaders(): Record<string, string> {
+	const headers: Record<string, string> = {
+		Accept: "application/vnd.github+json",
+		"User-Agent": "kimchi",
+	}
+	const token = process.env.GITHUB_TOKEN || process.env.GH_TOKEN
+	if (token) headers.Authorization = `Bearer ${token}`
+	return headers
 }
 
 function verifyDigest(asset: GitHubRelease["assets"][number], archive: Buffer): void {

--- a/src/resources/rtk-install.ts
+++ b/src/resources/rtk-install.ts
@@ -1,0 +1,203 @@
+import { execFileSync } from "node:child_process"
+import { createHash } from "node:crypto"
+import {
+	copyFileSync,
+	existsSync,
+	mkdirSync,
+	mkdtempSync,
+	readFileSync,
+	readdirSync,
+	rmSync,
+	symlinkSync,
+	unlinkSync,
+	writeFileSync,
+} from "node:fs"
+import { chmod, writeFile } from "node:fs/promises"
+import { homedir, tmpdir } from "node:os"
+import { basename, dirname, join } from "node:path"
+import { settingsPath } from "./store.js"
+
+const LATEST_RELEASE_URL = "https://api.github.com/repos/rtk-ai/rtk/releases/latest"
+const AUTO_INSTALL_INTERVAL_MS = 24 * 60 * 60 * 1000
+
+interface GitHubRelease {
+	tag_name: string
+	assets: Array<{
+		name: string
+		browser_download_url: string
+		digest?: string
+	}>
+}
+
+export interface RtkInstallResult {
+	version: string
+	binaryPath: string
+	linkPath: string
+}
+
+export function managedRtkPath(): string {
+	return join(rtkInstallDir(), process.platform === "win32" ? "rtk.exe" : "rtk")
+}
+
+export function globalRtkLinkPath(): string {
+	return join(globalBinDir(), process.platform === "win32" ? "rtk.exe" : "rtk")
+}
+
+export function isRtkInstalled(): boolean {
+	if (existsSync(globalRtkLinkPath())) return true
+	if (existsSync(managedRtkPath())) return true
+	try {
+		execFileSync("rtk", ["--version"], { stdio: "ignore", timeout: 1000 })
+		return true
+	} catch {
+		return false
+	}
+}
+
+export function shouldCheckRtkAutoInstall(now = Date.now(), path = settingsPath()): boolean {
+	const settings = readFullSettings(path)
+	const checkedAt = typeof settings.rtkAutoInstallCheckedAt === "number" ? settings.rtkAutoInstallCheckedAt : 0
+	return now - checkedAt > AUTO_INSTALL_INTERVAL_MS
+}
+
+export function markRtkAutoInstallChecked(now = Date.now(), path = settingsPath()): void {
+	const settings = readFullSettings(path)
+	settings.rtkAutoInstallCheckedAt = now
+	writeFullSettings(path, settings)
+}
+
+export async function installRtk(): Promise<RtkInstallResult> {
+	const release = await fetchJson<GitHubRelease>(LATEST_RELEASE_URL)
+	const asset = selectAsset(release)
+	const archive = await download(asset.browser_download_url)
+	verifyDigest(asset, archive)
+
+	const tempDir = mkdtempSync(join(tmpdir(), "kimchi-rtk-"))
+	try {
+		const archivePath = join(tempDir, asset.name)
+		await writeFile(archivePath, archive)
+		const extractDir = join(tempDir, "extract")
+		mkdirSync(extractDir, { recursive: true })
+		extractArchive(archivePath, extractDir)
+		const extracted = findExtractedRtk(extractDir)
+		const target = managedRtkPath()
+		mkdirSync(dirname(target), { recursive: true })
+		copyFileSync(extracted, target)
+		if (process.platform !== "win32") await chmod(target, 0o755)
+		const linkPath = linkGlobalRtk(target)
+		return { version: release.tag_name, binaryPath: target, linkPath }
+	} finally {
+		rmSync(tempDir, { recursive: true, force: true })
+	}
+}
+
+function rtkInstallDir(): string {
+	return join(process.env.KIMCHI_CODING_AGENT_DIR ?? join(homedir(), ".config", "kimchi", "harness"), "rtk")
+}
+
+function globalBinDir(): string {
+	if (process.platform === "win32") {
+		return join(process.env.LOCALAPPDATA ?? join(homedir(), "AppData", "Local"), "Programs", "kimchi", "bin")
+	}
+	return join(homedir(), ".local", "bin")
+}
+
+function linkGlobalRtk(target: string): string {
+	const linkPath = globalRtkLinkPath()
+	mkdirSync(dirname(linkPath), { recursive: true })
+	if (existsSync(linkPath)) unlinkSync(linkPath)
+
+	if (process.platform === "win32") {
+		copyFileSync(target, linkPath)
+		return linkPath
+	}
+
+	symlinkSync(target, linkPath)
+	return linkPath
+}
+
+function readFullSettings(path: string): Record<string, unknown> {
+	try {
+		const raw = existsSync(path) ? JSON.parse(readFileSync(path, "utf-8")) : {}
+		return raw && typeof raw === "object" && !Array.isArray(raw) ? (raw as Record<string, unknown>) : {}
+	} catch {
+		return {}
+	}
+}
+
+function writeFullSettings(path: string, settings: Record<string, unknown>): void {
+	mkdirSync(dirname(path), { recursive: true })
+	writeFileSync(path, `${JSON.stringify(settings, null, 2)}\n`, { mode: 0o600 })
+}
+
+function selectAsset(release: GitHubRelease): GitHubRelease["assets"][number] {
+	const wanted = assetName()
+	const asset = release.assets.find((candidate) => candidate.name === wanted)
+	if (!asset) throw new Error(`RTK release ${release.tag_name} has no asset for ${process.platform}/${process.arch}`)
+	return asset
+}
+
+function assetName(): string {
+	if (process.platform === "darwin") {
+		if (process.arch === "arm64") return "rtk-aarch64-apple-darwin.tar.gz"
+		if (process.arch === "x64") return "rtk-x86_64-apple-darwin.tar.gz"
+	}
+	if (process.platform === "linux") {
+		if (process.arch === "arm64") return "rtk-aarch64-unknown-linux-gnu.tar.gz"
+		if (process.arch === "x64") return "rtk-x86_64-unknown-linux-musl.tar.gz"
+	}
+	if (process.platform === "win32" && process.arch === "x64") return "rtk-x86_64-pc-windows-msvc.zip"
+	throw new Error(`Unsupported RTK platform: ${process.platform}/${process.arch}`)
+}
+
+async function fetchJson<T>(url: string): Promise<T> {
+	const res = await fetch(url, { headers: { "User-Agent": "kimchi" } })
+	if (!res.ok) throw new Error(`Failed to fetch ${url}: ${res.status}`)
+	return (await res.json()) as T
+}
+
+async function download(url: string): Promise<Buffer> {
+	const res = await fetch(url, { headers: { "User-Agent": "kimchi" } })
+	if (!res.ok) throw new Error(`Failed to download ${basename(url)}: ${res.status}`)
+	return Buffer.from(await res.arrayBuffer())
+}
+
+function verifyDigest(asset: GitHubRelease["assets"][number], archive: Buffer): void {
+	if (!asset.digest?.startsWith("sha256:")) return
+	const expected = asset.digest.slice("sha256:".length)
+	const actual = createHash("sha256").update(archive).digest("hex")
+	if (actual !== expected) throw new Error(`RTK checksum mismatch for ${asset.name}`)
+}
+
+function extractArchive(archivePath: string, extractDir: string): void {
+	if (archivePath.endsWith(".zip")) {
+		execFileSync("powershell.exe", [
+			"-NoProfile",
+			"-Command",
+			"Expand-Archive",
+			"-LiteralPath",
+			archivePath,
+			"-DestinationPath",
+			extractDir,
+			"-Force",
+		])
+		return
+	}
+	execFileSync("tar", ["-xzf", archivePath, "-C", extractDir])
+}
+
+function findExtractedRtk(dir: string): string {
+	const wanted = process.platform === "win32" ? "rtk.exe" : "rtk"
+	for (const entry of readdirSync(dir, { withFileTypes: true })) {
+		const path = join(dir, entry.name)
+		if (entry.isFile() && entry.name === wanted) return path
+		if (entry.isDirectory()) {
+			try {
+				return findExtractedRtk(path)
+			} catch {
+				// Keep searching siblings.
+			}
+		}
+	}
+	throw new Error("RTK archive did not contain rtk binary")
+}

--- a/src/resources/store.test.ts
+++ b/src/resources/store.test.ts
@@ -1,0 +1,112 @@
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
+import { afterEach, beforeEach, describe, expect, it } from "vitest"
+import {
+	getResourceOverride,
+	getResourceSettingsPath,
+	isResourceEnabled,
+	listResourceSettings,
+	readResourceSettings,
+	resetResourceOverride,
+	setResourceOverride,
+} from "./store.js"
+
+let dir: string
+let oldAgentDir: string | undefined
+
+describe("resource store", () => {
+	beforeEach(() => {
+		dir = mkdtempSync(join(tmpdir(), "kimchi-resources-"))
+		oldAgentDir = process.env.KIMCHI_CODING_AGENT_DIR
+		process.env.KIMCHI_CODING_AGENT_DIR = undefined
+	})
+
+	afterEach(() => {
+		if (oldAgentDir === undefined) process.env.KIMCHI_CODING_AGENT_DIR = undefined
+		else process.env.KIMCHI_CODING_AGENT_DIR = oldAgentDir
+		rmSync(dir, { recursive: true, force: true })
+	})
+
+	it("uses KIMCHI_CODING_AGENT_DIR settings.json when set", () => {
+		process.env.KIMCHI_CODING_AGENT_DIR = dir
+
+		expect(getResourceSettingsPath()).toBe(join(dir, "settings.json"))
+	})
+
+	it("defaults known resources from definitions", () => {
+		const path = tempSettingsPath()
+
+		expect(isResourceEnabled("hooks.rtk-rewrite", path)).toBe(true)
+		expect(getResourceOverride("hooks.rtk-rewrite", path)).toBeUndefined()
+	})
+
+	it("persists resource overrides without clobbering unrelated settings", () => {
+		const path = tempSettingsPath()
+		writeJson(path, { theme: "kimchi-minimal", resources: { "tools.web_fetch": false } })
+
+		setResourceOverride("hooks.rtk-rewrite", false, path)
+
+		expect(readResourceSettings(path).resources).toEqual({
+			"tools.web_fetch": false,
+			"hooks.rtk-rewrite": false,
+		})
+		expect(JSON.parse(readFileSync(path, "utf-8")).theme).toBe("kimchi-minimal")
+		expect(isResourceEnabled("hooks.rtk-rewrite", path)).toBe(false)
+	})
+
+	it("reads and lists valid resource ids only", () => {
+		const path = tempSettingsPath()
+		writeJson(path, {
+			resources: {
+				"hooks.rtk-rewrite": false,
+				"extensions.mcp-adapter": true,
+				"unknown.bad": false,
+				"tools.web_search": "no",
+			},
+		})
+
+		expect(readResourceSettings(path).resources).toEqual({
+			"hooks.rtk-rewrite": false,
+			"extensions.mcp-adapter": true,
+		})
+		expect(listResourceSettings(path)).toEqual([
+			{ id: "extensions.mcp-adapter", enabled: true, overridden: true },
+			{ id: "hooks.rtk-rewrite", enabled: false, overridden: true },
+		])
+	})
+
+	it("resets an override back to the default", () => {
+		const path = tempSettingsPath()
+		setResourceOverride("tools.web_search", false, path)
+
+		resetResourceOverride("tools.web_search", path)
+
+		expect(getResourceOverride("tools.web_search", path)).toBeUndefined()
+		expect(isResourceEnabled("tools.web_search", path)).toBe(true)
+	})
+
+	it("removes override when enabled is undefined", () => {
+		const path = tempSettingsPath()
+		setResourceOverride("plugins.mcp-apps", false, path)
+		setResourceOverride("plugins.mcp-apps", undefined, path)
+
+		expect(JSON.parse(readFileSync(path, "utf-8"))).toEqual({})
+		expect(isResourceEnabled("plugins.mcp-apps", path)).toBe(true)
+	})
+
+	it("rejects invalid resource ids", () => {
+		const path = tempSettingsPath()
+
+		expect(() => getResourceOverride("bad" as never, path)).toThrow("Invalid resource id")
+		expect(() => setResourceOverride("agents.foo" as never, false, path)).toThrow("Invalid resource id")
+	})
+})
+
+function tempSettingsPath(): string {
+	return join(dir, "settings.json")
+}
+
+function writeJson(path: string, data: unknown): void {
+	writeFileSync(path, `${JSON.stringify(data, null, 2)}\n`, "utf-8")
+}

--- a/src/resources/store.ts
+++ b/src/resources/store.ts
@@ -1,0 +1,76 @@
+import { homedir } from "node:os"
+import { join, resolve } from "node:path"
+import { readJson, writeJson } from "../config/json.js"
+import { getResourceDefinition } from "./definitions.js"
+import { type ListedResourceSetting, RESOURCE_KINDS, type ResourceId, type ResourceSettings } from "./types.js"
+
+const SETTINGS_KEY = "resources"
+
+export function getResourceSettingsPath(): string {
+	return process.env.KIMCHI_CODING_AGENT_DIR
+		? resolve(process.env.KIMCHI_CODING_AGENT_DIR, "settings.json")
+		: join(homedir(), ".config", "kimchi", "harness", "settings.json")
+}
+
+export const settingsPath = getResourceSettingsPath
+
+export function readResourceSettings(path = getResourceSettingsPath()): ResourceSettings {
+	const settings = readJson(path)
+	const raw = asRecord(settings[SETTINGS_KEY])
+	const resources: ResourceSettings["resources"] = {}
+	for (const [id, value] of Object.entries(raw)) {
+		if (isResourceId(id) && typeof value === "boolean") resources[id] = value
+	}
+	return { resources }
+}
+
+export function getResourceOverride(id: string, path = getResourceSettingsPath()): boolean | undefined {
+	assertResourceId(id)
+	return readResourceSettings(path).resources[id]
+}
+
+export function isResourceEnabled(id: string, path = getResourceSettingsPath()): boolean {
+	assertResourceId(id)
+	const definition = getResourceDefinition(id)
+	const fallback = definition?.defaultEnabled ?? true
+	return getResourceOverride(id, path) ?? fallback
+}
+
+export function listResourceSettings(path = getResourceSettingsPath()): ListedResourceSetting[] {
+	return Object.entries(readResourceSettings(path).resources)
+		.map(([id, enabled]) => ({ id: id as ResourceId, enabled: enabled ?? true, overridden: true as const }))
+		.sort((a, b) => a.id.localeCompare(b.id))
+}
+
+export function setResourceOverride(id: string, enabled: boolean | undefined, path = getResourceSettingsPath()): void {
+	assertResourceId(id)
+	const settings = readJson(path)
+	const resources = asRecord(settings[SETTINGS_KEY])
+	if (enabled === undefined) delete resources[id]
+	else resources[id] = enabled
+
+	if (Object.keys(resources).length > 0) {
+		settings[SETTINGS_KEY] = resources
+	} else {
+		delete settings[SETTINGS_KEY]
+	}
+	writeJson(path, settings)
+}
+
+export function resetResourceOverride(id: string, path = getResourceSettingsPath()): void {
+	setResourceOverride(id, undefined, path)
+}
+
+function isResourceId(value: string): value is ResourceId {
+	const dot = value.indexOf(".")
+	if (dot <= 0 || dot === value.length - 1) return false
+	return (RESOURCE_KINDS as readonly string[]).includes(value.slice(0, dot))
+}
+
+function assertResourceId(value: string): asserts value is ResourceId {
+	if (!isResourceId(value)) throw new Error(`Invalid resource id "${value}". Expected "<kind>.<name>".`)
+}
+
+function asRecord(value: unknown): Record<string, unknown> {
+	return value && typeof value === "object" && !Array.isArray(value) ? (value as Record<string, unknown>) : {}
+}

--- a/src/resources/tool-blocker.ts
+++ b/src/resources/tool-blocker.ts
@@ -1,0 +1,14 @@
+import type { ExtensionAPI } from "@earendil-works/pi-coding-agent"
+import { TOOL_RESOURCE_IDS } from "./definitions.js"
+import { isResourceEnabled } from "./store.js"
+
+export default function resourceToolBlockerExtension(pi: ExtensionAPI): void {
+	pi.on("tool_call", (event) => {
+		const resourceId = TOOL_RESOURCE_IDS[event.toolName]
+		if (!resourceId || isResourceEnabled(resourceId)) return
+		return {
+			block: true,
+			reason: `${event.toolName} is disabled in Kimchi resources. Enable ${resourceId} from /resources.`,
+		}
+	})
+}

--- a/src/resources/types.ts
+++ b/src/resources/types.ts
@@ -1,0 +1,23 @@
+export const RESOURCE_KINDS = ["hooks", "extensions", "tools", "plugins"] as const
+
+export type ResourceKind = (typeof RESOURCE_KINDS)[number]
+export type ResourceId = `${ResourceKind}.${string}`
+
+export interface ResourceDefinition {
+	id: string
+	kind: ResourceKind
+	label: string
+	description: string
+	defaultEnabled: boolean
+	restartRequired?: boolean
+}
+
+export interface ResourceSettings {
+	resources: Partial<Record<ResourceId, boolean>>
+}
+
+export interface ListedResourceSetting {
+	id: ResourceId
+	enabled: boolean
+	overridden: true
+}

--- a/src/resources/ui.ts
+++ b/src/resources/ui.ts
@@ -1,69 +1,128 @@
 import { type Theme, getSettingsListTheme } from "@earendil-works/pi-coding-agent"
-import { type SettingItem, SettingsList, type TUI } from "@earendil-works/pi-tui"
-import { RESOURCE_KINDS, getResourceDefinitions } from "./definitions.js"
+import { Key, type SettingItem, SettingsList, type TUI, matchesKey, truncateToWidth } from "@earendil-works/pi-tui"
+import { RESOURCE_KINDS, getResourceDefinitions, getResourcesByKind } from "./definitions.js"
 import { isResourceEnabled, setResourceOverride } from "./store.js"
 import type { ResourceKind } from "./types.js"
 
 const VALUE_ENABLED = "enabled"
 const VALUE_DISABLED = "disabled"
 
-export class ResourceManagerComponent {
-	private readonly list: SettingsList
+type ResourceTab = ResourceKind | "all"
 
-	constructor(_theme: Theme, done: () => void, kind?: ResourceKind) {
-		this.list = new SettingsList(
-			resourceItems(kind),
-			14,
-			getSettingsListTheme(),
-			(id, value) => {
-				setResourceOverride(id, value === VALUE_ENABLED)
-				this.list.updateValue(id, value)
-			},
-			done,
-			{ enableSearch: true },
-		)
+const TABS: readonly ResourceTab[] = ["all", ...RESOURCE_KINDS]
+
+export class ResourceManagerComponent {
+	private list: SettingsList
+	private activeTab: ResourceTab
+
+	constructor(
+		private readonly tui: TUI,
+		private readonly theme: Theme,
+		private readonly done: () => void,
+		initialKind?: ResourceKind,
+	) {
+		this.activeTab = initialKind ?? "all"
+		this.list = this.createList()
 	}
 
 	render(width: number): string[] {
-		return this.list.render(width)
+		const lines: string[] = []
+		const add = (line: string) => lines.push(truncateToWidth(line, width))
+
+		add(this.theme.fg("accent", "─".repeat(width)))
+		add(` ${this.theme.fg("text", "Kimchi resources")}`)
+		lines.push("")
+		add(` ${this.renderTabs()}`)
+		lines.push("")
+		for (const line of this.list.render(width)) add(line)
+		lines.push("")
+		add(this.theme.fg("dim", " Tab/←→ switch tabs · Enter/Space toggle · Esc close"))
+		add(this.theme.fg("accent", "─".repeat(width)))
+		return lines
 	}
 
 	handleInput(data: string): void {
+		if (matchesKey(data, Key.tab) || matchesKey(data, Key.right)) {
+			this.selectRelativeTab(1)
+			return
+		}
+		if (matchesKey(data, Key.shift("tab")) || matchesKey(data, Key.left)) {
+			this.selectRelativeTab(-1)
+			return
+		}
 		this.list.handleInput(data)
 	}
 
 	invalidate(): void {
 		this.list.invalidate()
 	}
+
+	private selectRelativeTab(delta: number): void {
+		const current = TABS.indexOf(this.activeTab)
+		this.activeTab = TABS[(current + delta + TABS.length) % TABS.length]
+		this.list = this.createList()
+		this.tui.requestRender()
+	}
+
+	private createList(): SettingsList {
+		return new SettingsList(
+			resourceItems(this.activeTab),
+			12,
+			getSettingsListTheme(),
+			(id, value) => {
+				setResourceOverride(id, value === VALUE_ENABLED)
+				this.list.updateValue(id, value)
+			},
+			this.done,
+			{ enableSearch: false },
+		)
+	}
+
+	private renderTabs(): string {
+		return TABS.map((tab) => {
+			const label = tabLabel(tab)
+			const count = enabledCount(tab)
+			const text = ` ${label} ${count} `
+			return tab === this.activeTab
+				? this.theme.bg("selectedBg", this.theme.fg("text", text))
+				: this.theme.fg("muted", text)
+		}).join(" ")
+	}
 }
 
 export function createResourceManager(
-	_tui: TUI,
+	tui: TUI,
 	theme: Theme,
 	done: () => void,
 	kind?: ResourceKind,
 ): ResourceManagerComponent {
-	return new ResourceManagerComponent(theme, done, kind)
+	return new ResourceManagerComponent(tui, theme, done, kind)
 }
 
-function resourceItems(kind?: ResourceKind): SettingItem[] {
+function resourceItems(tab: ResourceTab): SettingItem[] {
 	return getResourceDefinitions()
-		.filter((resource) => !kind || resource.kind === kind)
+		.filter((resource) => tab === "all" || resource.kind === tab)
 		.map((resource) => ({
 			id: resource.id,
-			label: `${kindPrefix(resource.kind, kind)}${resource.label}`,
+			label: `${kindPrefix(resource.kind, tab)}${resource.label}`,
 			description: `${resource.id} - ${resource.description}${resource.restartRequired ? " Restart required." : ""}`,
 			currentValue: isResourceEnabled(resource.id) ? VALUE_ENABLED : VALUE_DISABLED,
 			values: [VALUE_ENABLED, VALUE_DISABLED],
 		}))
 }
 
-function kindPrefix(kind: ResourceKind, filteredKind?: ResourceKind): string {
-	if (filteredKind) return ""
-	return `${kindLabel(kind)} / `
+function enabledCount(tab: ResourceTab): string {
+	const resources = tab === "all" ? getResourceDefinitions() : getResourcesByKind(tab)
+	const enabled = resources.filter((resource) => isResourceEnabled(resource.id)).length
+	return `${enabled}/${resources.length}`
 }
 
-function kindLabel(kind: ResourceKind): string {
-	const label = RESOURCE_KINDS.includes(kind) ? kind : "resources"
-	return label.slice(0, 1).toUpperCase() + label.slice(1)
+function kindPrefix(kind: ResourceKind, tab: ResourceTab): string {
+	if (tab !== "all") return ""
+	return `${tabLabel(kind)} / `
+}
+
+function tabLabel(tab: ResourceTab): string {
+	if (tab === "all") return "All"
+	return tab.slice(0, 1).toUpperCase() + tab.slice(1)
 }

--- a/src/resources/ui.ts
+++ b/src/resources/ui.ts
@@ -2,7 +2,7 @@ import { type Theme, getSettingsListTheme } from "@earendil-works/pi-coding-agen
 import { Key, type SettingItem, SettingsList, type TUI, matchesKey, truncateToWidth } from "@earendil-works/pi-tui"
 import { RESOURCE_KINDS, getResourceDefinitions, getResourcesByKind } from "./definitions.js"
 import { isResourceEnabled, setResourceOverride } from "./store.js"
-import type { ResourceKind } from "./types.js"
+import type { ResourceDefinition, ResourceKind } from "./types.js"
 
 const VALUE_ENABLED = "enabled"
 const VALUE_DISABLED = "disabled"
@@ -30,9 +30,10 @@ export class ResourceManagerComponent {
 		const add = (line: string) => lines.push(truncateToWidth(line, width))
 
 		add(this.theme.fg("accent", "─".repeat(width)))
-		add(` ${this.theme.fg("text", "Kimchi resources")}`)
+		add(` ${this.theme.bold(this.theme.fg("text", "Kimchi resources"))} ${this.renderSummary()}`)
 		lines.push("")
 		add(` ${this.renderTabs()}`)
+		add(` ${this.theme.fg("dim", tabDescription(this.activeTab))}`)
 		lines.push("")
 		for (const line of this.list.render(width)) add(line)
 		lines.push("")
@@ -71,7 +72,8 @@ export class ResourceManagerComponent {
 			getSettingsListTheme(),
 			(id, value) => {
 				setResourceOverride(id, value === VALUE_ENABLED)
-				this.list.updateValue(id, value)
+				this.list = this.createList()
+				this.tui.requestRender()
 			},
 			this.done,
 			{ enableSearch: false },
@@ -82,11 +84,24 @@ export class ResourceManagerComponent {
 		return TABS.map((tab) => {
 			const label = tabLabel(tab)
 			const count = enabledCount(tab)
-			const text = ` ${label} ${count} `
+			const text = ` ${tabIcon(tab)} ${label} ${count} `
 			return tab === this.activeTab
 				? this.theme.bg("selectedBg", this.theme.fg("text", text))
 				: this.theme.fg("muted", text)
 		}).join(" ")
+	}
+
+	private renderSummary(): string {
+		const resources = getResourceDefinitions()
+		const enabled = resources.filter((resource) => isResourceEnabled(resource.id)).length
+		const disabled = resources.length - enabled
+		const restarts = resources.filter((resource) => resource.restartRequired && isResourceEnabled(resource.id)).length
+		const enabledText = this.theme.fg("success", `${enabled} enabled`)
+		const disabledText =
+			disabled > 0 ? this.theme.fg("warning", `${disabled} disabled`) : this.theme.fg("dim", "0 disabled")
+		const restartText =
+			restarts > 0 ? this.theme.fg("muted", `${restarts} restart-gated`) : this.theme.fg("dim", "live")
+		return this.theme.fg("dim", "· ") + [enabledText, disabledText, restartText].join(this.theme.fg("dim", " · "))
 	}
 }
 
@@ -104,8 +119,8 @@ function resourceItems(tab: ResourceTab): SettingItem[] {
 		.filter((resource) => tab === "all" || resource.kind === tab)
 		.map((resource) => ({
 			id: resource.id,
-			label: `${kindPrefix(resource.kind, tab)}${resource.label}`,
-			description: `${resource.id} - ${resource.description}${resource.restartRequired ? " Restart required." : ""}`,
+			label: resourceLabel(resource, tab),
+			description: resourceDescription(resource),
 			currentValue: isResourceEnabled(resource.id) ? VALUE_ENABLED : VALUE_DISABLED,
 			values: [VALUE_ENABLED, VALUE_DISABLED],
 		}))
@@ -119,10 +134,51 @@ function enabledCount(tab: ResourceTab): string {
 
 function kindPrefix(kind: ResourceKind, tab: ResourceTab): string {
 	if (tab !== "all") return ""
-	return `${tabLabel(kind)} / `
+	return `${tabIcon(kind)} ${tabLabel(kind)} / `
 }
 
 function tabLabel(tab: ResourceTab): string {
 	if (tab === "all") return "All"
 	return tab.slice(0, 1).toUpperCase() + tab.slice(1)
+}
+
+function tabIcon(tab: ResourceTab): string {
+	switch (tab) {
+		case "all":
+			return "◆"
+		case "hooks":
+			return "↯"
+		case "tools":
+			return "⌘"
+		case "extensions":
+			return "▣"
+		case "plugins":
+			return "◈"
+	}
+}
+
+function tabDescription(tab: ResourceTab): string {
+	switch (tab) {
+		case "all":
+			return "Every controllable Kimchi capability in one place."
+		case "hooks":
+			return "Command interceptors and rewrite/block hooks."
+		case "tools":
+			return "Model-callable tools exposed to the agent."
+		case "extensions":
+			return "Built-in Kimchi feature modules."
+		case "plugins":
+			return "External connector and package surfaces."
+	}
+}
+
+function resourceLabel(resource: ResourceDefinition, tab: ResourceTab): string {
+	const status = isResourceEnabled(resource.id) ? "●" : "○"
+	const restart = resource.restartRequired ? " ↻" : ""
+	return `${status} ${kindPrefix(resource.kind, tab)}${resource.label}${restart}`
+}
+
+function resourceDescription(resource: ResourceDefinition): string {
+	const scope = resource.restartRequired ? "Applies after restart." : "Applies immediately."
+	return `${resource.id} — ${scope} ${resource.description}`
 }

--- a/src/resources/ui.ts
+++ b/src/resources/ui.ts
@@ -1,0 +1,69 @@
+import { type Theme, getSettingsListTheme } from "@earendil-works/pi-coding-agent"
+import { type SettingItem, SettingsList, type TUI } from "@earendil-works/pi-tui"
+import { RESOURCE_KINDS, getResourceDefinitions } from "./definitions.js"
+import { isResourceEnabled, setResourceOverride } from "./store.js"
+import type { ResourceKind } from "./types.js"
+
+const VALUE_ENABLED = "enabled"
+const VALUE_DISABLED = "disabled"
+
+export class ResourceManagerComponent {
+	private readonly list: SettingsList
+
+	constructor(_theme: Theme, done: () => void, kind?: ResourceKind) {
+		this.list = new SettingsList(
+			resourceItems(kind),
+			14,
+			getSettingsListTheme(),
+			(id, value) => {
+				setResourceOverride(id, value === VALUE_ENABLED)
+				this.list.updateValue(id, value)
+			},
+			done,
+			{ enableSearch: true },
+		)
+	}
+
+	render(width: number): string[] {
+		return this.list.render(width)
+	}
+
+	handleInput(data: string): void {
+		this.list.handleInput(data)
+	}
+
+	invalidate(): void {
+		this.list.invalidate()
+	}
+}
+
+export function createResourceManager(
+	_tui: TUI,
+	theme: Theme,
+	done: () => void,
+	kind?: ResourceKind,
+): ResourceManagerComponent {
+	return new ResourceManagerComponent(theme, done, kind)
+}
+
+function resourceItems(kind?: ResourceKind): SettingItem[] {
+	return getResourceDefinitions()
+		.filter((resource) => !kind || resource.kind === kind)
+		.map((resource) => ({
+			id: resource.id,
+			label: `${kindPrefix(resource.kind, kind)}${resource.label}`,
+			description: `${resource.id} - ${resource.description}${resource.restartRequired ? " Restart required." : ""}`,
+			currentValue: isResourceEnabled(resource.id) ? VALUE_ENABLED : VALUE_DISABLED,
+			values: [VALUE_ENABLED, VALUE_DISABLED],
+		}))
+}
+
+function kindPrefix(kind: ResourceKind, filteredKind?: ResourceKind): string {
+	if (filteredKind) return ""
+	return `${kindLabel(kind)} / `
+}
+
+function kindLabel(kind: ResourceKind): string {
+	const label = RESOURCE_KINDS.includes(kind) ? kind : "resources"
+	return label.slice(0, 1).toUpperCase() + label.slice(1)
+}

--- a/src/setup-wizard/index.ts
+++ b/src/setup-wizard/index.ts
@@ -12,6 +12,7 @@ import type { WizardResult, WizardState } from "./state.js"
 import { runAuthStep } from "./steps/auth.js"
 import { runDoneStep } from "./steps/done.js"
 import { runModeStep } from "./steps/mode.js"
+import { runRtkStep } from "./steps/rtk.js"
 import { runTelemetryStep } from "./steps/telemetry.js"
 import { runToolsStep } from "./steps/tools.js"
 import { runWelcomeStep } from "./steps/welcome.js"
@@ -25,6 +26,7 @@ interface Step {
 const STEPS: Step[] = [
 	{ name: "auth", run: runAuthStep },
 	{ name: "tools", run: runToolsStep },
+	{ name: "rtk", run: runRtkStep },
 	{ name: "mode", run: runModeStep },
 	{ name: "telemetry", skip: (s) => !s.selectedTools.includes("claudecode"), run: runTelemetryStep },
 ]
@@ -46,6 +48,7 @@ export async function runWizard(): Promise<WizardResult> {
 		mode: "override",
 		scope: "global",
 		selectedTools: [],
+		installRtk: false,
 		telemetryEnabled: true,
 		cancelled: false,
 		back: false,
@@ -60,6 +63,7 @@ export async function runWizard(): Promise<WizardResult> {
 		telemetryEnabled: state.telemetryEnabled,
 		selectedTools: [...state.selectedTools],
 		configuredTools: [],
+		rtkInstalled: false,
 	})
 
 	runWelcomeStep()
@@ -99,6 +103,7 @@ export async function runWizard(): Promise<WizardResult> {
 		configuredTools: state.selectedTools.filter((id) =>
 			outcome.successes.some((name) => name.toLowerCase().includes(id)),
 		),
+		rtkInstalled: outcome.rtkInstalled,
 	}
 }
 

--- a/src/setup-wizard/state.ts
+++ b/src/setup-wizard/state.ts
@@ -23,6 +23,7 @@ export interface WizardState {
 	mode: ConfigMode
 	scope: ConfigScope
 	selectedTools: ToolId[]
+	installRtk?: boolean
 	telemetryEnabled: boolean
 	cancelled: boolean
 	back: boolean
@@ -40,4 +41,5 @@ export interface WizardResult {
 	selectedTools: ToolId[]
 	/** Tools that were successfully configured (subset of selectedTools). */
 	configuredTools: ToolId[]
+	rtkInstalled?: boolean
 }

--- a/src/setup-wizard/steps/done.test.ts
+++ b/src/setup-wizard/steps/done.test.ts
@@ -122,6 +122,22 @@ describe("runDoneStep", () => {
 		writeSpy.mockRestore()
 	})
 
+	it("treats RTK install failure as a setup warning", async () => {
+		const tool = getClaudeCodeTool()
+		const writeSpy = vi.spyOn(tool, "write").mockResolvedValue()
+		installRtkMock.mockRejectedValueOnce(new Error("GitHub rate limited"))
+		const state = baseState()
+		state.installRtk = true
+
+		const outcome = await runDoneStep(state)
+
+		expect(outcome.successes).toEqual(["Claude Code"])
+		expect(outcome.failures).toEqual([])
+		expect(outcome.warnings).toEqual([{ id: "rtk", error: "GitHub rate limited" }])
+
+		writeSpy.mockRestore()
+	})
+
 	it("collects failures rather than aborting on a single broken writer", async () => {
 		const tool = getClaudeCodeTool()
 		const writeSpy = vi.spyOn(tool, "write").mockRejectedValue(new Error("disk full"))

--- a/src/setup-wizard/steps/done.test.ts
+++ b/src/setup-wizard/steps/done.test.ts
@@ -9,6 +9,12 @@ import * as modelsModule from "../../models.js"
 import type { WizardState } from "../state.js"
 import { runDoneStep } from "./done.js"
 
+const installRtkMock = vi.hoisted(() => vi.fn())
+
+vi.mock("../../resources/rtk-install.js", () => ({
+	installRtk: installRtkMock,
+}))
+
 describe("runDoneStep", () => {
 	let tmpHome: string
 	let prevHome: string | undefined
@@ -33,6 +39,12 @@ describe("runDoneStep", () => {
 		// Mock updateModelsConfig so we don't hit the real network.
 		vi.spyOn(modelsModule, "updateModelsConfig").mockResolvedValue({
 			models: TEST_MODELS as import("../../models.js").ModelMetadata[],
+		})
+		installRtkMock.mockReset()
+		installRtkMock.mockResolvedValue({
+			version: "v1.2.3",
+			binaryPath: "/tmp/kimchi-test/rtk",
+			linkPath: "/tmp/kimchi-test/bin/rtk",
 		})
 	})
 
@@ -90,6 +102,21 @@ describe("runDoneStep", () => {
 		// Tool still listed as a "success" so the user knows it's wired —
 		// just via the launcher rather than a config file.
 		expect(outcome.successes).toEqual(["Claude Code"])
+		expect(outcome.failures).toEqual([])
+
+		writeSpy.mockRestore()
+	})
+
+	it("ensures RTK when setup requests it", async () => {
+		const tool = getClaudeCodeTool()
+		const writeSpy = vi.spyOn(tool, "write").mockResolvedValue()
+		const state = baseState()
+		state.installRtk = true
+
+		const outcome = await runDoneStep(state)
+
+		expect(installRtkMock).toHaveBeenCalledTimes(1)
+		expect(outcome.rtkInstalled).toBe(true)
 		expect(outcome.failures).toEqual([])
 
 		writeSpy.mockRestore()

--- a/src/setup-wizard/steps/done.ts
+++ b/src/setup-wizard/steps/done.ts
@@ -95,7 +95,7 @@ export async function runDoneStep(state: WizardState): Promise<ApplyOutcome> {
 		try {
 			const result = await installRtk()
 			outcome.rtkInstalled = true
-			s.stop(`RTK ${result.version}: installed at ${result.linkPath}`)
+			s.stop(`RTK ${result.version}: ready at ${result.linkPath}`)
 		} catch (err) {
 			const msg = (err as Error).message
 			outcome.failures.push({ id: "rtk", error: msg })

--- a/src/setup-wizard/steps/done.ts
+++ b/src/setup-wizard/steps/done.ts
@@ -3,6 +3,7 @@ import { log, note, outro, spinner } from "@clack/prompts"
 import { byId } from "../../integrations/registry.js"
 import type { ToolId } from "../../integrations/types.js"
 import { updateModelsConfig } from "../../models.js"
+import { installRtk } from "../../resources/rtk-install.js"
 import { exportEnvToShellProfile } from "../shell-profile.js"
 import type { WizardState } from "../state.js"
 
@@ -11,6 +12,7 @@ const KIMCHI_API_KEY_ENV = "KIMCHI_API_KEY"
 interface ApplyOutcome {
 	successes: string[]
 	failures: Array<{ id: string; error: string }>
+	rtkInstalled: boolean
 }
 
 /**
@@ -28,7 +30,7 @@ interface ApplyOutcome {
  * having to run `kimchi setup` again.
  */
 export async function runDoneStep(state: WizardState): Promise<ApplyOutcome> {
-	const outcome: ApplyOutcome = { successes: [], failures: [] }
+	const outcome: ApplyOutcome = { successes: [], failures: [], rtkInstalled: false }
 
 	// Fetch live models before writing any tool config.
 	// Throws if no key or network fails; surface the error and abort gracefully.
@@ -87,6 +89,20 @@ export async function runDoneStep(state: WizardState): Promise<ApplyOutcome> {
 		}
 	}
 
+	if (state.installRtk) {
+		const s = spinner()
+		s.start("Installing RTK...")
+		try {
+			const result = await installRtk()
+			outcome.rtkInstalled = true
+			s.stop(`RTK ${result.version}: installed at ${result.linkPath}`)
+		} catch (err) {
+			const msg = (err as Error).message
+			outcome.failures.push({ id: "rtk", error: msg })
+			s.stop(`RTK: ${msg}`)
+		}
+	}
+
 	// Best-effort: persist KIMCHI_API_KEY to the user's shell profile so
 	// it's available in future shells. We never fail the wizard on this —
 	// the API key already lives in ~/.config/kimchi/config.json, the env
@@ -103,6 +119,7 @@ export async function runDoneStep(state: WizardState): Promise<ApplyOutcome> {
 		`Scope: ${state.scope}`,
 		`Telemetry: ${state.telemetryEnabled ? "enabled" : "disabled"}`,
 		outcome.successes.length > 0 ? `Configured: ${outcome.successes.join(", ")}` : "",
+		outcome.rtkInstalled ? "RTK: installed" : "",
 		outcome.failures.length > 0
 			? `Failed: ${outcome.failures.map((f) => byId(f.id as ToolId)?.name ?? f.id).join(", ")}`
 			: "",

--- a/src/setup-wizard/steps/done.ts
+++ b/src/setup-wizard/steps/done.ts
@@ -12,6 +12,7 @@ const KIMCHI_API_KEY_ENV = "KIMCHI_API_KEY"
 interface ApplyOutcome {
 	successes: string[]
 	failures: Array<{ id: string; error: string }>
+	warnings: Array<{ id: string; error: string }>
 	rtkInstalled: boolean
 }
 
@@ -30,7 +31,7 @@ interface ApplyOutcome {
  * having to run `kimchi setup` again.
  */
 export async function runDoneStep(state: WizardState): Promise<ApplyOutcome> {
-	const outcome: ApplyOutcome = { successes: [], failures: [], rtkInstalled: false }
+	const outcome: ApplyOutcome = { successes: [], failures: [], warnings: [], rtkInstalled: false }
 
 	// Fetch live models before writing any tool config.
 	// Throws if no key or network fails; surface the error and abort gracefully.
@@ -98,7 +99,7 @@ export async function runDoneStep(state: WizardState): Promise<ApplyOutcome> {
 			s.stop(`RTK ${result.version}: ready at ${result.linkPath}`)
 		} catch (err) {
 			const msg = (err as Error).message
-			outcome.failures.push({ id: "rtk", error: msg })
+			outcome.warnings.push({ id: "rtk", error: msg })
 			s.stop(`RTK: ${msg}`)
 		}
 	}
@@ -120,6 +121,7 @@ export async function runDoneStep(state: WizardState): Promise<ApplyOutcome> {
 		`Telemetry: ${state.telemetryEnabled ? "enabled" : "disabled"}`,
 		outcome.successes.length > 0 ? `Configured: ${outcome.successes.join(", ")}` : "",
 		outcome.rtkInstalled ? "RTK: installed" : "",
+		outcome.warnings.length > 0 ? `Warnings: ${outcome.warnings.map((f) => f.id).join(", ")}` : "",
 		outcome.failures.length > 0
 			? `Failed: ${outcome.failures.map((f) => byId(f.id as ToolId)?.name ?? f.id).join(", ")}`
 			: "",

--- a/src/setup-wizard/steps/rtk.ts
+++ b/src/setup-wizard/steps/rtk.ts
@@ -1,0 +1,11 @@
+import { isRtkInstalled } from "../../resources/rtk-install.js"
+import type { WizardState } from "../state.js"
+
+export async function runRtkStep(state: WizardState, opts: { backable: boolean }): Promise<void> {
+	void opts
+	if (isRtkInstalled()) {
+		state.installRtk = false
+		return
+	}
+	state.installRtk = true
+}

--- a/src/setup-wizard/steps/rtk.ts
+++ b/src/setup-wizard/steps/rtk.ts
@@ -1,11 +1,6 @@
-import { isRtkInstalled } from "../../resources/rtk-install.js"
 import type { WizardState } from "../state.js"
 
 export async function runRtkStep(state: WizardState, opts: { backable: boolean }): Promise<void> {
 	void opts
-	if (isRtkInstalled()) {
-		state.installRtk = false
-		return
-	}
 	state.installRtk = true
 }

--- a/src/setup-wizard/steps/welcome.ts
+++ b/src/setup-wizard/steps/welcome.ts
@@ -16,6 +16,7 @@ export function runWelcomeStep(): void {
 			"  · setup your Kimchi API key",
 			"  · help you configure tools (Claude Code, OpenCode, Cursor, OpenClaw, GSD2)",
 			"  · setup tool configs so they talk to the Kimchi proxy",
+			"  · install/update RTK for bash command rewriting",
 			"",
 			"Controls:",
 			"  ↑/↓     navigate options",


### PR DESCRIPTION


---
### Kimchi Summary
### What changed
Kimchi now installs and manages RTK automatically, and introduces a unified resource system (`/resources` and `kimchi resources`) to toggle hooks, tools, extensions, and plugins at runtime. It also adds support for custom Bash hooks that can rewrite or block shell commands.

### Why
This removes the manual RTK installation step, gives users a single interface to control agent capabilities, and enables safe, opt-in project-specific shell hooks without silent code execution.

### Key changes
- `src/resources/*`: Adds resource definitions, persistent store (`settings.json`), TUI manager, and CLI command for enabling/disabling capabilities.
- `src/resources/rtk-install.ts`: Downloads and installs RTK from GitHub releases on startup or during setup, keeping it on `PATH`.
- `src/resources/bash-hooks.ts` and `bash-hook-discovery.ts`: Discovers and executes Bash hooks from `~/.config/kimchi/harness/hooks/bash/` (enabled by default) and `.kimchi/hooks/bash/` (disabled by default).
- `src/extensions/bash-collapse.ts`: Integrates with the resource system; applies RTK rewrites and user bash hooks via `tool_call` and `user_bash` events instead of a custom tool definition.
- `src/extensions/tool-rendering.ts`: Shows the rewritten bash command in tool call headers using `getBashCommandForDisplay`.
- `src/cli.ts`: Conditionally loads extensions (`ferment`, `agents`, `mcp-apps`, `web_fetch`, `web_search`) based on resource state via `enabledExtensionFactories`.
- `src/commands/resources.ts`: New top-level `kimchi resources [list|enable|disable|set|reset]` command.
- `src/setup-wizard/steps/rtk.ts` and `done.ts`: Offers to install RTK during initial setup.
- `docs/hooks.md` and `README.md`: Documents the Bash hook protocol and RTK resource-based configuration.

### Impact
- **Breaking change:** The `KIMCHI_RTK` environment variable and the `"rtk": false` setting in `settings.json` are no longer honored. Disable RTK via `kimchi resources disable hooks.rtk-rewrite` or `/resources`.
- **Migration:** Project bash hooks default to disabled and must be explicitly enabled (e.g., `kimchi resources enable hooks.bash.project.<name>`) before they run.
- Some resource changes (tools, extensions, plugins) require a Kimchi restart to take effect; the UI indicates when this is necessary.