### PR TITLE
fix: truncate TUI lines to terminal width to prevent crash

### DIFF
--- a/src/extensions/tool-rendering.ts
+++ b/src/extensions/tool-rendering.ts
@@ -394,6 +394,7 @@ function insertUserPromptPrefix(line: string, theme: any): string {
 	// Line structure from Box(paddingX=1, bgFn):
 	//   [1 plain space][ANSI color][▍ ][ANSI reset][content][1+ trailing spaces]
 	// We insert "❯ " right after the stroke and trim trailing spaces to maintain width.
+	const originalWidth = visibleWidth(line)
 	let i = 0
 
 	// Skip leading plain spaces (leftPad = paddingX = 1)
@@ -420,7 +421,13 @@ function insertUserPromptPrefix(line: string, theme: any): string {
 		end--
 		removed++
 	}
-	return inserted.slice(0, end)
+	const result = inserted.slice(0, end)
+	// Guard: if content nearly filled the line and there were not enough trailing
+	// spaces to trim, the result could overflow. Truncate to the original width.
+	if (visibleWidth(result) > originalWidth) {
+		return truncateToWidth(result, originalWidth)
+	}
+	return result
 }
 
 function patchUserMessageRender(): void {

--- a/src/modes/teleport/ui/progress.ts
+++ b/src/modes/teleport/ui/progress.ts
@@ -1,4 +1,5 @@
 import type { ExtensionUIContext } from "@earendil-works/pi-coding-agent"
+import { truncateToWidth } from "@earendil-works/pi-tui"
 import { LogoHeader } from "../../../components/logo.js"
 
 const SPIN_FRAMES = ["⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "⠧", "⠇", "⠏"]
@@ -47,24 +48,25 @@ export function createTeleportProgress(ui: ExtensionUIContext) {
 		return TELEPORT_FUN_PHASES[phaseIdx]
 	}
 
-	function renderProgress(theme: { fg(color: string, text: string): string }): string[] {
+	function renderProgress(theme: { fg(color: string, text: string): string }, width: number): string[] {
 		const lines: string[] = []
 		const dim = (t: string) => theme.fg("dim", t)
+		const trunc = (line: string) => truncateToWidth(line, width)
 
 		if (finished) {
-			lines.push(`${theme.fg("success", "✓")} ${theme.fg("success", "Teleported")}`)
+			lines.push(trunc(`${theme.fg("success", "✓")} ${theme.fg("success", "Teleported")}`))
 		} else {
 			const p = currentPhase()
 			const char = p.frames[phaseFrameIdx % p.frames.length]
-			lines.push(`${theme.fg("accent", char)} ${theme.fg("accent", p.message)}`)
+			lines.push(trunc(`${theme.fg("accent", char)} ${theme.fg("accent", p.message)}`))
 		}
 
 		for (const s of steps) {
 			if (s.done) {
-				lines.push(`  ${theme.fg("success", "✓")} ${dim(s.label)}`)
+				lines.push(trunc(`  ${theme.fg("success", "✓")} ${dim(s.label)}`))
 			} else {
 				const frame = SPIN_FRAMES[stepSpinIdx]
-				lines.push(`  ${theme.fg("accent", frame)} ${s.label}`)
+				lines.push(trunc(`  ${theme.fg("accent", frame)} ${s.label}`))
 			}
 		}
 
@@ -72,9 +74,9 @@ export function createTeleportProgress(ui: ExtensionUIContext) {
 			lines.push("")
 			const labelW = 4
 			const pad = (l: string) => l.padEnd(labelW)
-			lines.push(`  ${dim("┌")} ${theme.fg("success", sessionInfo.description)}`)
-			lines.push(`  ${dim("│")} ${dim(pad("id"))} ${sessionInfo.id}`)
-			lines.push(`  ${dim("└")} ${dim(pad("url"))} ${sessionInfo.url}`)
+			lines.push(trunc(`  ${dim("┌")} ${theme.fg("success", sessionInfo.description)}`))
+			lines.push(trunc(`  ${dim("│")} ${dim(pad("id"))} ${sessionInfo.id}`))
+			lines.push(trunc(`  ${dim("└")} ${dim(pad("url"))} ${sessionInfo.url}`))
 		}
 
 		return lines
@@ -91,7 +93,7 @@ export function createTeleportProgress(ui: ExtensionUIContext) {
 				render(width: number) {
 					headerTui = _tui
 					const lines = logo.render(width)
-					lines.push(...renderProgress(theme))
+					lines.push(...renderProgress(theme, width))
 					lines.push("")
 					return lines
 				},
@@ -130,7 +132,7 @@ export function createTeleportProgress(ui: ExtensionUIContext) {
 	ui.setWidget(
 		"teleport-lock",
 		(_tui, theme) => ({
-			render: () => [theme.fg("dim", "🔒 Input sealed - in transit…")],
+			render: (width: number) => [truncateToWidth(theme.fg("dim", "🔒 Input sealed - in transit…"), width)],
 			invalidate: () => {},
 		}),
 		{ placement: "aboveEditor" },


### PR DESCRIPTION
Two components were rendering lines that could exceed the terminal width, causing an uncaughtException crash from the TUI renderer:

1. tool-rendering.ts: insertUserPromptPrefix() inserts a 2-char prefix and compensates by removing trailing spaces. When user message content nearly fills the line, fewer than 2 trailing spaces exist, causing a 1-2 char overflow. Added a visibleWidth guard that falls back to truncateToWidth when the trailing-space removal is insufficient.

2. progress.ts: renderProgress() generated lines (session URL, UUID, description) without any width constraint. Plumbed the width parameter through and wrapped all output lines in truncateToWidth(). Also fixed the teleport-lock widget render to respect width.

## Description

<!-- What problem does this PR solve? What changes were made and why? -->


## Type of Change

<!-- Select all that apply. -->

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

---
### Kimchi Summary
### What changed
Prevents line overflow in teleport mode and prompt rendering by truncating all UI output to the available terminal width.

### Why
Long labels, session info, or narrow terminals could cause rendered lines to exceed their boundaries, resulting in layout corruption or crashes.

### Key changes
- `src/extensions/tool-rendering.ts`: Adds width overflow guard to `insertUserPromptPrefix`; it now records `originalWidth` and uses `truncateToWidth` if the prefixed result is too wide.
- `src/modes/teleport/ui/progress.ts`: Passes terminal `width` into `renderProgress`, applies `truncateToWidth` to every progress, step, and session-info line, and truncates the `teleport-lock` widget text to fit.

### Impact
Eliminates teleport-mode crashes caused by render overflow. No migration steps needed.