### PR TITLE
feat(ferment-multi-line-editor): Switch ferment definition to use multi-line editors

### DIFF
--- a/src/extensions/behaviours/wiring.smoke.test.ts
+++ b/src/extensions/behaviours/wiring.smoke.test.ts
@@ -222,13 +222,24 @@ describe("wireBehaviours — tool_result", () => {
 		expect(next.flatMap((r) => (r.message ? [r.message] : []))).toEqual([])
 	})
 
-	it("does not steer for session-triggered bodies (already drained by before_agent_start)", async () => {
+	it("does not steer for session-triggered bodies that are still pending", async () => {
 		const pi = setupWired([ghCli])
 		await pi.fire("session_start", {}, { cwd: "/tmp" })
-		await pi.fire("before_agent_start", { prompt: "x", systemPrompt: "BASE" })
 		await pi.fire("tool_result", { toolName: "bash", input: { command: "gh pr list" } })
 
 		expect(pi.sent).toEqual([])
+
+		const next = await pi.fire<{ message?: { customType: string; content: string; display: boolean } }>(
+			"before_agent_start",
+			{ prompt: "x", systemPrompt: "BASE" },
+		)
+		expect(next.flatMap((r) => (r.message ? [r.message] : []))).toEqual([
+			expect.objectContaining({
+				customType: BEHAVIOUR_BODY_TYPE,
+				content: "Use gh for GitHub.",
+				display: false,
+			}),
+		])
 	})
 })
 

--- a/src/extensions/behaviours/wiring.ts
+++ b/src/extensions/behaviours/wiring.ts
@@ -117,13 +117,16 @@ export function wireBehaviours(pi: ExtensionAPI, behaviours: readonly Behaviour[
 		}
 	})
 
-	// Drain any pending bodies as steer messages right after the tool result so
-	// the model sees them before its next inference within the same turn.
+	// Drain tool-triggered bodies as steer messages right after the tool result
+	// so the model sees them before its next inference within the same turn.
 	// `before_agent_start` only fires per user prompt, so without this hook a
 	// behaviour that loads on a tool_call mid-turn would never reach the model
-	// in that session.
+	// in that session. Session-triggered bodies stay on the normal
+	// before_agent_start path; injecting them here can wake custom-message
+	// workflows after a host handoff, such as Ferment plan review.
 	pi.on("tool_result", async () => {
 		for (const b of triggered) {
+			if (engine.loadRecord(b.name)?.trigger !== "tool") continue
 			if (!engine.takePending(b.name)) continue
 			pi.sendMessage(
 				{

--- a/src/extensions/ferment/commands.test.ts
+++ b/src/extensions/ferment/commands.test.ts
@@ -175,6 +175,13 @@ describe("FermentCommandController", () => {
 		expect(h.runtime.setActive).toHaveBeenCalledWith(expect.objectContaining({ id: created?.id }))
 		expect(h.pi.sendMessage).toHaveBeenCalledWith(
 			expect.objectContaining({
+				customType: "ferment_request",
+				display: true,
+				details: { intent: "make reports better\ninclude tests" },
+			}),
+		)
+		expect(h.pi.sendMessage).toHaveBeenCalledWith(
+			expect.objectContaining({
 				customType: "ferment_created_nudge",
 				content: [expect.objectContaining({ text: expect.stringContaining("make reports better\ninclude tests") })],
 			}),
@@ -295,6 +302,52 @@ describe("FermentCommandController", () => {
 		expect(h.ctx.ui.notify).toHaveBeenCalledWith('Usage: /ferment one-shot "description of what to build"')
 		expect(h.storage.list()).toHaveLength(0)
 		expect(h.pi.sendMessage).not.toHaveBeenCalled()
+	})
+
+	it("keeps UI one-shot without prompt handlers on the usage path", async () => {
+		const h = createHarness()
+		const controller = new FermentCommandController()
+		const ctx = {
+			hasUI: true,
+			ui: { notify: vi.fn() },
+		} as unknown as ExtensionCommandContext
+
+		const result = await controller.execute(
+			{ type: "one-shot", intent: "" },
+			{ raw: "one-shot", pi: h.pi, ctx, runtime: h.runtime },
+		)
+
+		expect(result).toEqual({ handled: true })
+		expect(ctx.ui.notify).toHaveBeenCalledWith('Usage: /ferment one-shot "description of what to build"')
+		expect(h.storage.list()).toHaveLength(0)
+		expect(h.pi.sendMessage).not.toHaveBeenCalled()
+	})
+
+	it("uses the multi-line editor for free-form goal revisions", async () => {
+		const h = createHarness()
+		const controller = new FermentCommandController()
+		const active = h.storage.create("Revise Goal")
+		h.runtime.setActive(active)
+		const ui = {
+			notify: vi.fn(),
+			editor: vi.fn().mockResolvedValueOnce("new goal\nwith detail"),
+			input: vi.fn().mockResolvedValueOnce("single-line fallback"),
+		}
+		const ctx = {
+			hasUI: true,
+			ui,
+		} as unknown as ExtensionCommandContext
+
+		const result = await controller.execute(
+			{ type: "revise", field: "goal" },
+			{ raw: "revise goal", pi: h.pi, ctx, runtime: h.runtime },
+		)
+
+		expect(result).toEqual({ handled: true })
+		expect(ui.editor).toHaveBeenCalledWith("Revise goal:", "")
+		expect(ui.input).not.toHaveBeenCalled()
+		expect(h.storage.get(active.id)?.goal).toBe("new goal\nwith detail")
+		expect(ui.notify).toHaveBeenCalledWith('Goal updated: "new goal\nwith detail"')
 	})
 
 	it("reports export write failures without throwing", async () => {

--- a/src/extensions/ferment/commands.test.ts
+++ b/src/extensions/ferment/commands.test.ts
@@ -114,12 +114,81 @@ describe("FermentCommandController", () => {
 		)
 	})
 
+	it("accepts an inline new title without opening an editor in UI mode", async () => {
+		const h = createHarness()
+		const controller = new FermentCommandController()
+		const ui = {
+			notify: vi.fn(),
+			editor: vi.fn().mockResolvedValueOnce("unexpected editor text"),
+			input: vi.fn().mockResolvedValueOnce("unexpected input text"),
+		}
+		const ctx = {
+			hasUI: true,
+			ui,
+		} as unknown as ExtensionCommandContext
+
+		const result = await controller.execute(
+			{ type: "new", title: "Inline Title" },
+			{ raw: 'new "Inline Title"', pi: h.pi, ctx, runtime: h.runtime },
+		)
+
+		const created = h.storage.list().find((f) => f.description === "Inline Title")
+		expect(result).toEqual({ handled: true })
+		expect(ui.editor).not.toHaveBeenCalled()
+		expect(ui.input).not.toHaveBeenCalled()
+		expect(created).toBeDefined()
+		expect(h.pi.sendMessage).toHaveBeenCalledWith(
+			expect.objectContaining({
+				customType: "ferment_created_nudge",
+				content: [expect.objectContaining({ text: expect.stringContaining("Inline Title") })],
+			}),
+			{ triggerTurn: true },
+		)
+	})
+
+	it("prompts bare new commands with the multi-line editor in UI mode", async () => {
+		const h = createHarness()
+		const controller = new FermentCommandController()
+		const ui = {
+			notify: vi.fn(),
+			editor: vi.fn().mockResolvedValueOnce("make reports better\ninclude tests"),
+			input: vi.fn().mockResolvedValueOnce("single-line fallback"),
+		}
+		const ctx = {
+			hasUI: true,
+			ui,
+		} as unknown as ExtensionCommandContext
+
+		const result = await controller.execute(
+			{ type: "new", title: "" },
+			{ raw: "new", pi: h.pi, ctx, runtime: h.runtime },
+		)
+
+		const created = h.storage.list().find((f) => f.description === "make reports better\ninclude tests")
+		expect(result).toEqual({ handled: true })
+		expect(ui.editor).toHaveBeenCalledWith(
+			"🍺  What would you like to ferment?\ne.g. 'Rewrite login flow' or 'Add OAuth support'",
+			"",
+		)
+		expect(ui.input).not.toHaveBeenCalled()
+		expect(created).toBeDefined()
+		expect(h.runtime.setActive).toHaveBeenCalledWith(expect.objectContaining({ id: created?.id }))
+		expect(h.pi.sendMessage).toHaveBeenCalledWith(
+			expect.objectContaining({
+				customType: "ferment_created_nudge",
+				content: [expect.objectContaining({ text: expect.stringContaining("make reports better\ninclude tests") })],
+			}),
+			{ triggerTurn: true },
+		)
+	})
+
 	it("echoes the interactive request before starting the hidden scoping turn", async () => {
 		const h = createHarness()
 		const controller = new FermentCommandController()
 		const ui = {
 			notify: vi.fn(),
-			input: vi.fn().mockResolvedValueOnce("make the todo app glassy"),
+			editor: vi.fn().mockResolvedValueOnce("make the todo app glassy\nwith tests"),
+			input: vi.fn().mockResolvedValueOnce("single-line fallback"),
 			select: vi.fn(),
 		}
 		const ctx = {
@@ -130,18 +199,23 @@ describe("FermentCommandController", () => {
 		const result = await controller.execute({ type: "interactive" }, { raw: "", pi: h.pi, ctx, runtime: h.runtime })
 
 		expect(result).toEqual({ handled: true })
+		expect(ui.editor).toHaveBeenCalledWith(
+			"🍺  What would you like to ferment?\ne.g. 'Rewrite login flow' or 'Add OAuth support'",
+			"",
+		)
+		expect(ui.input).not.toHaveBeenCalled()
 		expect(ui.select).not.toHaveBeenCalled()
 		expect(h.pi.sendMessage).toHaveBeenCalledWith(
 			expect.objectContaining({
 				customType: "ferment_request",
 				display: true,
-				details: { intent: "make the todo app glassy" },
+				details: { intent: "make the todo app glassy\nwith tests" },
 			}),
 		)
 		expect(h.pi.sendMessage).toHaveBeenCalledWith(
 			expect.objectContaining({
 				customType: "ferment_created_nudge",
-				content: [expect.objectContaining({ text: expect.stringContaining("make the todo app glassy") })],
+				content: [expect.objectContaining({ text: expect.stringContaining("make the todo app glassy\nwith tests") })],
 			}),
 			{ triggerTurn: true },
 		)
@@ -206,6 +280,21 @@ describe("FermentCommandController", () => {
 		expect(result).toEqual({ handled: true })
 		expect(h.storage.list()).toHaveLength(0)
 		expect(h.ctx.ui.notify).toHaveBeenCalledWith(expect.stringContaining("Unknown /ferment command"))
+	})
+
+	it("keeps headless one-shot without intent on the usage path", async () => {
+		const h = createHarness()
+		const controller = new FermentCommandController()
+
+		const result = await controller.execute(
+			{ type: "one-shot", intent: "" },
+			{ raw: "one-shot", pi: h.pi, ctx: h.ctx, runtime: h.runtime },
+		)
+
+		expect(result).toEqual({ handled: true })
+		expect(h.ctx.ui.notify).toHaveBeenCalledWith('Usage: /ferment one-shot "description of what to build"')
+		expect(h.storage.list()).toHaveLength(0)
+		expect(h.pi.sendMessage).not.toHaveBeenCalled()
 	})
 
 	it("reports export write failures without throwing", async () => {

--- a/src/extensions/ferment/commands.ts
+++ b/src/extensions/ferment/commands.ts
@@ -21,7 +21,7 @@ import {
 	handlePhaseAction,
 	handleStepAction,
 } from "./progress-overlay.js"
-import { promptInput } from "./prompt-ui.js"
+import { promptEditor } from "./prompt-ui.js"
 import { resumeFerment } from "./resume.js"
 import { type FermentRuntime, defaultFermentRuntime } from "./runtime.js"
 import { scheduleFermentWakeUp } from "./scheduler.js"
@@ -174,12 +174,12 @@ export async function startInteractiveFerment({
 		)
 		return
 	}
-	if (!ctx.ui.input) {
+	if (!ctx.ui.editor && !ctx.ui.input) {
 		ctx.ui.notify('No UI available. Use /ferment new "Name" instead.')
 		return
 	}
 
-	const rawIntent = await promptInput(
+	const rawIntent = await promptEditor(
 		ctx,
 		"🍺  What would you like to ferment?",
 		"e.g. 'Rewrite login flow' or 'Add OAuth support'",
@@ -760,8 +760,12 @@ export class FermentCommandController {
 			}
 			const intent = command.intent
 			let resolvedIntent = intent
-			if (!resolvedIntent && ctx.ui.input) {
-				const typed = await ctx.ui.input("🍺  One-shot: what should be done?", "Describe the full task…")
+			if (!resolvedIntent) {
+				if (!ctx.hasUI) {
+					ctx.ui.notify('Usage: /ferment one-shot "description of what to build"')
+					return { handled: true }
+				}
+				const typed = await promptEditor(ctx, "🍺  One-shot: what should be done?", "Describe the full task…")
 				if (!typed) return { handled: true }
 				resolvedIntent = typed
 			}
@@ -819,10 +823,21 @@ export class FermentCommandController {
 			ctx.ui.notify(FERMENT_COMMAND_USAGE)
 			return { handled: true }
 		}
-		const rawName = command.title
+		let rawName = command.title
+		let scopingIntent: string | undefined = rawName || undefined
 		if (!rawName) {
-			ctx.ui.notify('Usage: /ferment new "Name"')
-			return { handled: true }
+			if (!ctx.hasUI || (!ctx.ui.editor && !ctx.ui.input)) {
+				ctx.ui.notify('Usage: /ferment new "Name"')
+				return { handled: true }
+			}
+			const typed = await promptEditor(
+				ctx,
+				"🍺  What would you like to ferment?",
+				"e.g. 'Rewrite login flow' or 'Add OAuth support'",
+			)
+			if (!typed) return { handled: true }
+			rawName = typed
+			scopingIntent = typed
 		}
 		ctx.ui.setStatus?.("ferment-scoping", "🫧  Fermenting · naming…")
 		try {
@@ -841,7 +856,7 @@ export class FermentCommandController {
 				"ferment_ack",
 			)
 
-			await runScopingFlow(f, pi, ctx, runtime)
+			await runScopingFlow(f, pi, ctx, runtime, scopingIntent)
 		} catch (err) {
 			ctx.ui.notify(err instanceof FermentError ? err.message : "Create failed.")
 		} finally {

--- a/src/extensions/ferment/commands.ts
+++ b/src/extensions/ferment/commands.ts
@@ -21,7 +21,7 @@ import {
 	handlePhaseAction,
 	handleStepAction,
 } from "./progress-overlay.js"
-import { promptEditor, promptEditorPrefill } from "./prompt-ui.js"
+import { promptEditor } from "./prompt-ui.js"
 import { resumeFerment } from "./resume.js"
 import { type FermentRuntime, defaultFermentRuntime } from "./runtime.js"
 import { scheduleFermentWakeUp } from "./scheduler.js"
@@ -179,11 +179,9 @@ export async function startInteractiveFerment({
 		return
 	}
 
-	const rawIntent = await promptEditor(
-		ctx,
-		"🍺  What would you like to ferment?",
-		"e.g. 'Rewrite login flow' or 'Add OAuth support'",
-	)
+	const rawIntent = await promptEditor(ctx, "🍺  What would you like to ferment?", {
+		placeholder: "e.g. 'Rewrite login flow' or 'Add OAuth support'",
+	})
 	if (!rawIntent) return
 
 	const storage = runtime.getStorage()
@@ -666,7 +664,7 @@ export class FermentCommandController {
 					ctx.ui.notify("No UI available for interactive revision. Ask the agent to update the goal.")
 					return { handled: true }
 				}
-				const newGoal = await promptEditorPrefill(ctx, "Revise goal:", active.goal ?? "")
+				const newGoal = await promptEditor(ctx, "Revise goal:", { prefill: active.goal ?? "" })
 				if (newGoal) {
 					const out = applyAndPersist(active.id, { type: "update_scope_field", field: "goal", value: newGoal })
 					if (out.ok) {
@@ -684,7 +682,9 @@ export class FermentCommandController {
 					ctx.ui.notify("No UI available for interactive revision.")
 					return { handled: true }
 				}
-				const newCriteria = await promptEditorPrefill(ctx, "Revise success criteria:", active.successCriteria ?? "")
+				const newCriteria = await promptEditor(ctx, "Revise success criteria:", {
+					prefill: active.successCriteria ?? "",
+				})
 				if (newCriteria) {
 					const out = applyAndPersist(active.id, {
 						type: "update_scope_field",
@@ -765,7 +765,9 @@ export class FermentCommandController {
 					ctx.ui.notify('Usage: /ferment one-shot "description of what to build"')
 					return { handled: true }
 				}
-				const typed = await promptEditor(ctx, "🍺  One-shot: what should be done?", "Describe the full task…")
+				const typed = await promptEditor(ctx, "🍺  One-shot: what should be done?", {
+					placeholder: "Describe the full task…",
+				})
 				if (!typed) return { handled: true }
 				resolvedIntent = typed
 			}
@@ -826,11 +828,9 @@ export class FermentCommandController {
 				ctx.ui.notify('Usage: /ferment new "Name"')
 				return { handled: true }
 			}
-			const typed = await promptEditor(
-				ctx,
-				"🍺  What would you like to ferment?",
-				"e.g. 'Rewrite login flow' or 'Add OAuth support'",
-			)
+			const typed = await promptEditor(ctx, "🍺  What would you like to ferment?", {
+				placeholder: "e.g. 'Rewrite login flow' or 'Add OAuth support'",
+			})
 			if (!typed) return { handled: true }
 			rawName = typed
 			scopingIntent = typed

--- a/src/extensions/ferment/commands.ts
+++ b/src/extensions/ferment/commands.ts
@@ -21,7 +21,7 @@ import {
 	handlePhaseAction,
 	handleStepAction,
 } from "./progress-overlay.js"
-import { promptEditor } from "./prompt-ui.js"
+import { promptEditor, promptEditorPrefill } from "./prompt-ui.js"
 import { resumeFerment } from "./resume.js"
 import { type FermentRuntime, defaultFermentRuntime } from "./runtime.js"
 import { scheduleFermentWakeUp } from "./scheduler.js"
@@ -662,11 +662,11 @@ export class FermentCommandController {
 			const field = command.field
 
 			if (field === "goal") {
-				if (!ctx.ui.input) {
+				if (!ctx.ui.editor && !ctx.ui.input) {
 					ctx.ui.notify("No UI available for interactive revision. Ask the agent to update the goal.")
 					return { handled: true }
 				}
-				const newGoal = await ctx.ui.input("Revise goal:", active.goal ?? "")
+				const newGoal = await promptEditorPrefill(ctx, "Revise goal:", active.goal ?? "")
 				if (newGoal) {
 					const out = applyAndPersist(active.id, { type: "update_scope_field", field: "goal", value: newGoal })
 					if (out.ok) {
@@ -680,11 +680,11 @@ export class FermentCommandController {
 			}
 
 			if (field === "criteria") {
-				if (!ctx.ui.input) {
+				if (!ctx.ui.editor && !ctx.ui.input) {
 					ctx.ui.notify("No UI available for interactive revision.")
 					return { handled: true }
 				}
-				const newCriteria = await ctx.ui.input("Revise success criteria:", active.successCriteria ?? "")
+				const newCriteria = await promptEditorPrefill(ctx, "Revise success criteria:", active.successCriteria ?? "")
 				if (newCriteria) {
 					const out = applyAndPersist(active.id, {
 						type: "update_scope_field",
@@ -761,17 +761,13 @@ export class FermentCommandController {
 			const intent = command.intent
 			let resolvedIntent = intent
 			if (!resolvedIntent) {
-				if (!ctx.hasUI) {
+				if (!ctx.hasUI || (!ctx.ui.editor && !ctx.ui.input)) {
 					ctx.ui.notify('Usage: /ferment one-shot "description of what to build"')
 					return { handled: true }
 				}
 				const typed = await promptEditor(ctx, "🍺  One-shot: what should be done?", "Describe the full task…")
 				if (!typed) return { handled: true }
 				resolvedIntent = typed
-			}
-			if (!resolvedIntent) {
-				ctx.ui.notify('Usage: /ferment one-shot "description of what to build"')
-				return { handled: true }
 			}
 			ctx.ui.setStatus?.("ferment-scoping", "🫧  Fermenting · naming…")
 			try {
@@ -838,6 +834,7 @@ export class FermentCommandController {
 			if (!typed) return { handled: true }
 			rawName = typed
 			scopingIntent = typed
+			sendFermentRequestMessage(pi, typed)
 		}
 		ctx.ui.setStatus?.("ferment-scoping", "🫧  Fermenting · naming…")
 		try {

--- a/src/extensions/ferment/events.ts
+++ b/src/extensions/ferment/events.ts
@@ -9,7 +9,7 @@ import { autoInitFromEnv, ensureGitRepo } from "./git-init.js"
 import { appendRefEntry, maybeInjectReactiveContinuationNudge, resetReactiveContinuationNudgeCount } from "./nudge.js"
 import { buildOneshotNudge } from "./oneshot.js"
 import { editPhaseProposal } from "./phase-editor.js"
-import { promptInput, promptSelect } from "./prompt-ui.js"
+import { promptEditor, promptSelect } from "./prompt-ui.js"
 import { loadFermentSilently, resumeFerment } from "./resume.js"
 import { type FermentRuntime, defaultFermentRuntime } from "./runtime.js"
 import { scheduleFermentWakeUp } from "./scheduler.js"
@@ -138,7 +138,7 @@ async function maybeRunUserInputDropdown(
 	if (!prompt) return false
 	const boundaryHandled = await maybeRunManualBoundaryDropdown(pi, ctx, prompt, f, runtime)
 	if (boundaryHandled) return true
-	if (!ctx?.ui?.select || !ctx.ui.input) return true
+	if (!ctx?.ui?.select || (!ctx.ui.editor && !ctx.ui.input)) return true
 
 	const choice = await promptSelect(ctx, prompt.title, prompt.options)
 	if (!choice) return true
@@ -146,7 +146,7 @@ async function maybeRunUserInputDropdown(
 	let reply: string
 
 	if (choice === "Let me say something else") {
-		const custom = await promptInput(ctx, "Your message:", "")
+		const custom = await promptEditor(ctx, "Your message:")
 		if (!custom) return true
 		reply = custom
 	} else if (choice === prompt.noLabel) {

--- a/src/extensions/ferment/progress-overlay.ts
+++ b/src/extensions/ferment/progress-overlay.ts
@@ -29,7 +29,7 @@ import {
 	stepBulletChar,
 	truncateLabel,
 } from "./colors.js"
-import { promptInput } from "./prompt-ui.js"
+import { promptEditor } from "./prompt-ui.js"
 import { type FermentRuntime, defaultFermentRuntime } from "./runtime.js"
 import { createApplyAndPersist } from "./tool-helpers.js"
 import type { FermentUiContext } from "./ui.js"
@@ -266,7 +266,7 @@ export async function handlePhaseAction(
 			break
 		}
 		case "Mark phase failed": {
-			const reason = await promptInput(ctx, "Reason for failure:", "")
+			const reason = await promptEditor(ctx, "Reason for failure:")
 			const out = applyAndPersist(f.id, {
 				type: "fail_phase",
 				phaseId: p.id,

--- a/src/extensions/ferment/prompt-ui.test.ts
+++ b/src/extensions/ferment/prompt-ui.test.ts
@@ -1,7 +1,7 @@
 import type { Theme } from "@earendil-works/pi-coding-agent"
 import type { TUI } from "@earendil-works/pi-tui"
 import { beforeEach, describe, expect, it, vi } from "vitest"
-import { createPromptFormComponent, promptEditor, promptInput, promptSelect } from "./prompt-ui.js"
+import { createPromptFormComponent, promptEditor, promptEditorPrefill, promptInput, promptSelect } from "./prompt-ui.js"
 
 const tipWidgetLocationMock = vi.hoisted(() => ({
 	restore: vi.fn(),
@@ -56,6 +56,23 @@ describe("ferment prompt UI", () => {
 		)
 
 		expect(ui.editor).toHaveBeenCalledWith("What would you like to ferment?\nDescribe it", "")
+		expect(ui.input).not.toHaveBeenCalled()
+		expect(tipWidgetLocationMock.set).toHaveBeenCalledWith("hidden")
+		expect(ui.setWorkingVisible).toHaveBeenNthCalledWith(1, false)
+		expect(ui.setWorkingVisible).toHaveBeenNthCalledWith(2, true)
+		expect(tipWidgetLocationMock.restore).toHaveBeenCalledTimes(1)
+	})
+
+	it("passes existing content as editor prefill for edit prompts", async () => {
+		const ui = {
+			editor: vi.fn(async () => "updated\ncontent"),
+			input: vi.fn(async () => "single line"),
+			setWorkingVisible: vi.fn(),
+		}
+
+		await expect(promptEditorPrefill({ ui }, "Revise goal:", "old\ncontent")).resolves.toBe("updated\ncontent")
+
+		expect(ui.editor).toHaveBeenCalledWith("Revise goal:", "old\ncontent")
 		expect(ui.input).not.toHaveBeenCalled()
 		expect(tipWidgetLocationMock.set).toHaveBeenCalledWith("hidden")
 		expect(ui.setWorkingVisible).toHaveBeenNthCalledWith(1, false)

--- a/src/extensions/ferment/prompt-ui.test.ts
+++ b/src/extensions/ferment/prompt-ui.test.ts
@@ -1,7 +1,7 @@
 import type { Theme } from "@earendil-works/pi-coding-agent"
 import type { TUI } from "@earendil-works/pi-tui"
 import { beforeEach, describe, expect, it, vi } from "vitest"
-import { createPromptFormComponent, promptEditor, promptEditorPrefill, promptInput, promptSelect } from "./prompt-ui.js"
+import { createPromptFormComponent, promptEditor, promptInput, promptSelect } from "./prompt-ui.js"
 
 const tipWidgetLocationMock = vi.hoisted(() => ({
 	restore: vi.fn(),
@@ -51,7 +51,7 @@ describe("ferment prompt UI", () => {
 			setWorkingVisible: vi.fn(),
 		}
 
-		await expect(promptEditor({ ui }, "What would you like to ferment?", "Describe it")).resolves.toBe(
+		await expect(promptEditor({ ui }, "What would you like to ferment?", { placeholder: "Describe it" })).resolves.toBe(
 			"line one\nline two",
 		)
 
@@ -70,7 +70,7 @@ describe("ferment prompt UI", () => {
 			setWorkingVisible: vi.fn(),
 		}
 
-		await expect(promptEditorPrefill({ ui }, "Revise goal:", "old\ncontent")).resolves.toBe("updated\ncontent")
+		await expect(promptEditor({ ui }, "Revise goal:", { prefill: "old\ncontent" })).resolves.toBe("updated\ncontent")
 
 		expect(ui.editor).toHaveBeenCalledWith("Revise goal:", "old\ncontent")
 		expect(ui.input).not.toHaveBeenCalled()

--- a/src/extensions/ferment/prompt-ui.test.ts
+++ b/src/extensions/ferment/prompt-ui.test.ts
@@ -1,7 +1,7 @@
 import type { Theme } from "@earendil-works/pi-coding-agent"
 import type { TUI } from "@earendil-works/pi-tui"
 import { beforeEach, describe, expect, it, vi } from "vitest"
-import { createPromptFormComponent, promptInput, promptSelect } from "./prompt-ui.js"
+import { createPromptFormComponent, promptEditor, promptInput, promptSelect } from "./prompt-ui.js"
 
 const tipWidgetLocationMock = vi.hoisted(() => ({
 	restore: vi.fn(),
@@ -41,6 +41,25 @@ describe("ferment prompt UI", () => {
 
 		await expect(pending).resolves.toBe("build it")
 		expect(ui.setWorkingVisible).toHaveBeenLastCalledWith(true)
+		expect(tipWidgetLocationMock.restore).toHaveBeenCalledTimes(1)
+	})
+
+	it("prefers the multi-line editor for editor prompts", async () => {
+		const ui = {
+			editor: vi.fn(async () => "line one\nline two"),
+			input: vi.fn(async () => "single line"),
+			setWorkingVisible: vi.fn(),
+		}
+
+		await expect(promptEditor({ ui }, "What would you like to ferment?", "Describe it")).resolves.toBe(
+			"line one\nline two",
+		)
+
+		expect(ui.editor).toHaveBeenCalledWith("What would you like to ferment?\nDescribe it", "")
+		expect(ui.input).not.toHaveBeenCalled()
+		expect(tipWidgetLocationMock.set).toHaveBeenCalledWith("hidden")
+		expect(ui.setWorkingVisible).toHaveBeenNthCalledWith(1, false)
+		expect(ui.setWorkingVisible).toHaveBeenNthCalledWith(2, true)
 		expect(tipWidgetLocationMock.restore).toHaveBeenCalledTimes(1)
 	})
 

--- a/src/extensions/ferment/prompt-ui.ts
+++ b/src/extensions/ferment/prompt-ui.ts
@@ -107,6 +107,18 @@ export function promptEditor(ctx: unknown, title: string, placeholder?: string):
 	return Promise.resolve(undefined)
 }
 
+export function promptEditorPrefill(ctx: unknown, title: string, prefill?: string): Promise<string | undefined> {
+	const ui = getPromptUi(ctx)
+	if (!ui) return Promise.resolve(undefined)
+	if (ui.editor) {
+		return withWorkingHidden(ui, () => ui.editor?.(title, prefill ?? "") ?? Promise.resolve(undefined))
+	}
+	if (ui.input) {
+		return withWorkingHidden(ui, () => ui.input?.(title, prefill) ?? Promise.resolve(undefined))
+	}
+	return Promise.resolve(undefined)
+}
+
 export async function promptForm(ctx: unknown, spec: PromptFormSpec): Promise<PromptFormResult | undefined> {
 	const ui = getPromptUi(ctx)
 	if (!ui) return undefined

--- a/src/extensions/ferment/prompt-ui.ts
+++ b/src/extensions/ferment/prompt-ui.ts
@@ -25,6 +25,11 @@ export type PromptUi = {
 	setWorkingVisible?: (visible: boolean) => void
 }
 
+export interface PromptEditorOptions {
+	placeholder?: string
+	prefill?: string
+}
+
 export interface PromptChoiceOption {
 	label: string
 	description?: string
@@ -94,27 +99,22 @@ export function promptInput(ctx: unknown, title: string, placeholder?: string): 
 	return withWorkingHidden(ui, () => ui.input?.(title, placeholder) ?? Promise.resolve(undefined))
 }
 
-export function promptEditor(ctx: unknown, title: string, placeholder?: string): Promise<string | undefined> {
+export function promptEditor(
+	ctx: unknown,
+	title: string,
+	options: PromptEditorOptions = {},
+): Promise<string | undefined> {
 	const ui = getPromptUi(ctx)
 	if (!ui) return Promise.resolve(undefined)
 	if (ui.editor) {
-		const editorTitle = placeholder ? `${title}\n${placeholder}` : title
-		return withWorkingHidden(ui, () => ui.editor?.(editorTitle, "") ?? Promise.resolve(undefined))
+		const editorTitle = options.placeholder ? `${title}\n${options.placeholder}` : title
+		return withWorkingHidden(ui, () => ui.editor?.(editorTitle, options.prefill ?? "") ?? Promise.resolve(undefined))
 	}
 	if (ui.input) {
-		return withWorkingHidden(ui, () => ui.input?.(title, placeholder) ?? Promise.resolve(undefined))
-	}
-	return Promise.resolve(undefined)
-}
-
-export function promptEditorPrefill(ctx: unknown, title: string, prefill?: string): Promise<string | undefined> {
-	const ui = getPromptUi(ctx)
-	if (!ui) return Promise.resolve(undefined)
-	if (ui.editor) {
-		return withWorkingHidden(ui, () => ui.editor?.(title, prefill ?? "") ?? Promise.resolve(undefined))
-	}
-	if (ui.input) {
-		return withWorkingHidden(ui, () => ui.input?.(title, prefill) ?? Promise.resolve(undefined))
+		return withWorkingHidden(
+			ui,
+			() => ui.input?.(title, options.prefill ?? options.placeholder) ?? Promise.resolve(undefined),
+		)
 	}
 	return Promise.resolve(undefined)
 }

--- a/src/extensions/ferment/prompt-ui.ts
+++ b/src/extensions/ferment/prompt-ui.ts
@@ -20,6 +20,7 @@ import { setTipWidgetLocation } from "../tips/index.js"
 export type PromptUi = {
 	select?: (title: string, options: string[]) => Promise<string | undefined>
 	input?: (title: string, placeholder?: string) => Promise<string | undefined>
+	editor?: (title: string, prefill?: string) => Promise<string | undefined>
 	custom?: ExtensionUIContext["custom"]
 	setWorkingVisible?: (visible: boolean) => void
 }
@@ -91,6 +92,19 @@ export function promptInput(ctx: unknown, title: string, placeholder?: string): 
 	const ui = getPromptUi(ctx)
 	if (!ui?.input) return Promise.resolve(undefined)
 	return withWorkingHidden(ui, () => ui.input?.(title, placeholder) ?? Promise.resolve(undefined))
+}
+
+export function promptEditor(ctx: unknown, title: string, placeholder?: string): Promise<string | undefined> {
+	const ui = getPromptUi(ctx)
+	if (!ui) return Promise.resolve(undefined)
+	if (ui.editor) {
+		const editorTitle = placeholder ? `${title}\n${placeholder}` : title
+		return withWorkingHidden(ui, () => ui.editor?.(editorTitle, "") ?? Promise.resolve(undefined))
+	}
+	if (ui.input) {
+		return withWorkingHidden(ui, () => ui.input?.(title, placeholder) ?? Promise.resolve(undefined))
+	}
+	return Promise.resolve(undefined)
 }
 
 export async function promptForm(ctx: unknown, spec: PromptFormSpec): Promise<PromptFormResult | undefined> {

--- a/src/extensions/ferment/scoping.test.ts
+++ b/src/extensions/ferment/scoping.test.ts
@@ -134,6 +134,32 @@ describe("runScopingFlow", () => {
 		expect(text).toContain("Call propose_ferment_scoping")
 	})
 
+	it("prefers ctx.ui.editor for the free-form scoping prompt", async () => {
+		const { runtime, storage } = createRuntime()
+		const ferment = storage.create("My Ferment")
+		const pi = makePi()
+		const ui = {
+			notify: vi.fn(),
+			editor: vi.fn().mockResolvedValue("I want to build reports\nwith export tests"),
+			input: vi.fn().mockResolvedValue("single-line fallback"),
+		}
+		const ctx = {
+			hasUI: true,
+			ui,
+		} as unknown as ExtensionCommandContext
+
+		await runScopingFlow(ferment, pi, ctx, runtime)
+
+		expect(ui.editor).toHaveBeenCalledWith("What do you want to do?\nDescribe what you want to accomplish…", "")
+		expect(ui.input).not.toHaveBeenCalled()
+		expect(pi.sendMessage).toHaveBeenCalledWith(
+			expect.objectContaining({
+				customType: "ferment_request",
+				details: { intent: "I want to build reports\nwith export tests" },
+			}),
+		)
+	})
+
 	it("undefined input (Esc) → no sendMessage, no markScopingInteractive, no pendingScope", async () => {
 		const { runtime, storage } = createRuntime()
 		const ferment = storage.create("My Ferment")

--- a/src/extensions/ferment/scoping.ts
+++ b/src/extensions/ferment/scoping.ts
@@ -3,8 +3,8 @@
  *
  * Single-input handshake:
  *
- *   1. `runScopingFlow` shows ONE free-form text input ("What do you want to
- *      do?"). On non-empty input it seeds the pending-scope buffer and fires a
+ *   1. `runScopingFlow` shows ONE free-form editor prompt ("What do you want
+ *      to do?"). On non-empty input it seeds the pending-scope buffer and fires a
  *      single LLM turn asking the model to call `propose_ferment_scoping` with the
  *      full draft (goal, criteria, constraints, assumptions, phases, and
  *      optional clarifying questions).
@@ -22,7 +22,7 @@ import { determineNextAction } from "../../ferment/engine.js"
 import type { ScopePhaseInput } from "../../ferment/state-machine.js"
 import type { Ferment } from "../../ferment/types.js"
 import { SCOPING_DISCOVERY_GUIDANCE } from "./constants.js"
-import { promptInput } from "./prompt-ui.js"
+import { promptEditor } from "./prompt-ui.js"
 import { type FermentRuntime, defaultFermentRuntime } from "./runtime.js"
 import type { FermentUiContext } from "./ui.js"
 
@@ -133,7 +133,7 @@ export async function runScopingFlow(
 	runtime: FermentRuntime = defaultFermentRuntime,
 	preIntent?: string,
 ): Promise<void> {
-	if (!ctx.ui.input) {
+	if (!ctx.ui.editor && !ctx.ui.input) {
 		// Headless fallback: let the LLM handle scoping conversationally
 		const prompt = buildScopePrompt(runtime, f.id)
 		void pi.sendMessage(
@@ -150,7 +150,7 @@ export async function runScopingFlow(
 
 	let intent: string | undefined = preIntent
 	if (!intent) {
-		intent = await promptInput(ctx, "What do you want to do?", "Describe what you want to accomplish…")
+		intent = await promptEditor(ctx, "What do you want to do?", "Describe what you want to accomplish…")
 	}
 	if (intent === undefined || intent === "") return
 

--- a/src/extensions/ferment/scoping.ts
+++ b/src/extensions/ferment/scoping.ts
@@ -13,7 +13,7 @@
  *      wholesale, shows a combined dropdown, and either confirms the scope or
  *      queues a re-run turn for iteration.
  *
- * In headless sessions (no `ctx.ui.input`), the existing nudge path fires
+ * In headless sessions (no prompt UI), the existing nudge path fires
  * unchanged — the LLM handles scoping conversationally.
  */
 

--- a/src/extensions/ferment/scoping.ts
+++ b/src/extensions/ferment/scoping.ts
@@ -150,7 +150,9 @@ export async function runScopingFlow(
 
 	let intent: string | undefined = preIntent
 	if (!intent) {
-		intent = await promptEditor(ctx, "What do you want to do?", "Describe what you want to accomplish…")
+		intent = await promptEditor(ctx, "What do you want to do?", {
+			placeholder: "Describe what you want to accomplish…",
+		})
 	}
 	if (intent === undefined || intent === "") return
 

--- a/src/extensions/ferment/tools.integration.test.ts
+++ b/src/extensions/ferment/tools.integration.test.ts
@@ -1631,8 +1631,7 @@ describe("propose_ferment_scoping", () => {
 		expect(ctx4.ui.select).not.toHaveBeenCalled()
 	})
 
-	// New: Custom answer option opens ctx.ui.input and free-form text is recorded
-	it("Custom answer option opens ctx.ui.input and free-form text is included in sendMessage", async () => {
+	it("Custom answer option opens ctx.ui.editor and free-form text is included in sendMessage", async () => {
 		const id = await createFerment("CustomAnswer")
 		seedPending(id)
 		const questions = [
@@ -1650,14 +1649,16 @@ describe("propose_ferment_scoping", () => {
 		const ctx = {
 			ui: {
 				select: vi.fn().mockResolvedValueOnce(customLabel).mockResolvedValueOnce(continueLabel),
-				input: vi.fn().mockResolvedValue("my custom thing"),
+				editor: vi.fn().mockResolvedValue("my custom thing"),
+				input: vi.fn().mockResolvedValue("single-line fallback"),
 				setWorkingVisible: vi.fn(),
 			},
 		}
 
 		ok(await h.call("propose_ferment_scoping", basePayload(id, { questions }), ctx))
 
-		expect(ctx.ui.input).toHaveBeenCalledWith(expect.stringContaining("Approach?"), "")
+		expect(ctx.ui.editor).toHaveBeenCalledWith(expect.stringContaining("Approach?"), "")
+		expect(ctx.ui.input).not.toHaveBeenCalled()
 		expect(ctx.ui.setWorkingVisible).toHaveBeenCalledWith(false)
 		expect(ctx.ui.setWorkingVisible).toHaveBeenCalledWith(true)
 		expect(loadFerment(id).status).toBe("draft")

--- a/src/extensions/ferment/tools/lifecycle.ts
+++ b/src/extensions/ferment/tools/lifecycle.ts
@@ -26,7 +26,7 @@ import { validateGatesOrErr } from "../gate-validation.js"
 import { judgeJourneyGrade } from "../judge.js"
 import { resetReactiveContinuationNudgeCount } from "../nudge.js"
 import { gatherPhaseEvidence } from "../phase-evidence.js"
-import { getPromptUi, promptForm, promptInput, promptSelect } from "../prompt-ui.js"
+import { getPromptUi, promptEditor, promptForm, promptSelect } from "../prompt-ui.js"
 import { readLatestPhaseReviews } from "../review-evidence.js"
 import { type FermentRuntime, defaultFermentRuntime } from "../runtime.js"
 import { confirmPendingScope } from "../scoping-confirmation.js"
@@ -803,7 +803,7 @@ ${renderGateGuidance("scope_ferment")}`,
 						const chosen = await promptSelect(ctx, title, optionLabels)
 						if (chosen === undefined) return { kind: "dismiss", qn: n + 1 }
 						if (chosen === customLabel) {
-							const freeForm = await promptInput(ctx, `[Q${n + 1}/${questions.length}] Your answer for: ${q.text}`, "")
+							const freeForm = await promptEditor(ctx, `[Q${n + 1}/${questions.length}] Your answer for: ${q.text}`)
 							if (!freeForm) return "cancelled"
 							answers.push({ questionId: q.id, optionId: "custom", label: freeForm, recommended: false })
 							continue
@@ -913,7 +913,7 @@ ${renderGateGuidance("scope_ferment")}`,
 				}
 
 				if (reviewChoice === "Let me say something") {
-					const userText = await promptInput(ctx, "Your direction:", "")
+					const userText = await promptEditor(ctx, "Your direction:")
 					if (!userText) {
 						return planToolOk(`${answersEntry}\n\nNo changes made. Waiting for your next instruction.`)
 					}

--- a/src/extensions/ferment/tools/steps.ts
+++ b/src/extensions/ferment/tools/steps.ts
@@ -16,6 +16,7 @@ import { validateGatesOrErr } from "../gate-validation.js"
 import { type JudgeVerdict, judgeStepVerification } from "../judge.js"
 import { onStepCompleted } from "../nudge.js"
 import { type PhaseEvidence, captureGitHead, gatherPhaseEvidence } from "../phase-evidence.js"
+import { promptEditorPrefill } from "../prompt-ui.js"
 import { type FermentRuntime, defaultFermentRuntime } from "../runtime.js"
 import {
 	createApplyAndPersist,
@@ -422,8 +423,8 @@ export async function completeStep(
 			return toolOk(`Step ${step.index} skipped at user request.`)
 		}
 
-		if (choice === editLabel && ctx.ui.input) {
-			const newPrompt = await ctx.ui.input("Revised step description:", step.description)
+		if (choice === editLabel && (ctx.ui.editor || ctx.ui.input)) {
+			const newPrompt = await promptEditorPrefill(ctx, "Revised step description:", step.description)
 			runtime.markHumanInput()
 			if (newPrompt?.trim()) {
 				const editOut = applyAndPersist(params.ferment_id, {

--- a/src/extensions/ferment/tools/steps.ts
+++ b/src/extensions/ferment/tools/steps.ts
@@ -16,7 +16,7 @@ import { validateGatesOrErr } from "../gate-validation.js"
 import { type JudgeVerdict, judgeStepVerification } from "../judge.js"
 import { onStepCompleted } from "../nudge.js"
 import { type PhaseEvidence, captureGitHead, gatherPhaseEvidence } from "../phase-evidence.js"
-import { promptEditorPrefill } from "../prompt-ui.js"
+import { promptEditor } from "../prompt-ui.js"
 import { type FermentRuntime, defaultFermentRuntime } from "../runtime.js"
 import {
 	createApplyAndPersist,
@@ -424,7 +424,7 @@ export async function completeStep(
 		}
 
 		if (choice === editLabel && (ctx.ui.editor || ctx.ui.input)) {
-			const newPrompt = await promptEditorPrefill(ctx, "Revised step description:", step.description)
+			const newPrompt = await promptEditor(ctx, "Revised step description:", { prefill: step.description })
 			runtime.markHumanInput()
 			if (newPrompt?.trim()) {
 				const editOut = applyAndPersist(params.ferment_id, {

--- a/src/extensions/ferment/ui.ts
+++ b/src/extensions/ferment/ui.ts
@@ -4,6 +4,7 @@ import type { ExtensionUIContext, ModelRegistry } from "@earendil-works/pi-codin
 export interface FermentUi {
 	notify(message: string, level?: string): void
 	input?(label: string, placeholder?: string): Promise<string | undefined>
+	editor?(title: string, prefill?: string): Promise<string | undefined>
 	select?(title: string, options: string[]): Promise<string | undefined>
 	custom?: ExtensionUIContext["custom"]
 	confirm?(title: string, description?: string): Promise<boolean>

--- a/src/ferment/shorten-title.ts
+++ b/src/ferment/shorten-title.ts
@@ -6,8 +6,9 @@ const SYSTEM_PROMPT =
 /** Deterministic fallback when LLM is unavailable. */
 function autoShortTitle(name: string): string {
 	const max = 35
-	if (name.length <= max) return name.trim()
-	const truncated = name.slice(0, max)
+	const normalized = name.replace(/\s+/g, " ").trim()
+	if (normalized.length <= max) return normalized
+	const truncated = normalized.slice(0, max)
 	const lastSpace = truncated.lastIndexOf(" ")
 	return (lastSpace > 0 ? truncated.slice(0, lastSpace) : truncated).trim()
 }


### PR DESCRIPTION


---
### Kimchi Summary
### What changed
Introduces a multi-line `editor` prompt across the Ferment extension, replacing single-line `input` fields wherever users provide free-form intent, goals, criteria, or revisions. Bare `/ferment new` and `/ferment one-shot` commands in UI mode now open this editor instead of returning usage errors. Also adjusts behaviour wiring to drain only tool-triggered bodies on `tool_result`, keeping session-triggered bodies for the `before_agent_start` path.

### Why
Multi-line input is required for users to articulate complex ferment definitions and step-level details naturally. The wiring fix prevents session-triggered steer bodies from incorrectly surfacing during mid-turn tool results after a host handoff, which would prematurely wake custom-message workflows like Ferment plan review.

### Key changes
- **`src/extensions/ferment/ui.ts`**: Adds optional `editor(title, prefill?)` to the `FermentUi` interface.
- **`src/extensions/ferment/prompt-ui.ts`**: Adds `promptEditor` helper that prefers `ui.editor` and falls back to `ui.input`; accepts `placeholder` and `prefill` options.
- **`src/extensions/ferment/commands.ts`**:
  - Bare `/ferment new` launches the editor and passes the resulting text into scoping.
  - Bare `/ferment one-shot` launches the editor when no intent is provided.
  - `revise goal`, `revise criteria`, and interactive start use `promptEditor`.
- **`src/extensions/ferment/scoping.ts`**: Adopts `promptEditor` for the scoping question; accepts optional `preIntent` to forward editor input.
- **`src/extensions/ferment/tools/lifecycle.ts`**, **`steps.ts`**, **`events.ts`**, **`progress-overlay.ts`**: Switch custom answers, user direction, failure reasons, and step edits to `promptEditor`.
- **`src/extensions/behaviours/wiring.ts`**: `tool_result` handler now only drains pending bodies whose `trigger` is `"tool"`.
- **`src/ferment/shorten-title.ts`**: Normalizes whitespace before applying length limits.

### Impact
- **UI hosts**: A multi-line `editor` implementation unlocks the new UX; `input`-only hosts continue to work via fallback.
- **Command behavior**: `/ferment new` and `/ferment one-shot` without arguments are now interactive in UI mode rather than returning usage strings.
- **Steering timing**: Session-triggered behaviour bodies now arrive at `before_agent_start` instead of being drained on `tool_result`, which avoids premature message injection during host handoffs.