### PR TITLE
fix(multi-mode): correctly switch the model via /model when multi-model is on

### DIFF
--- a/src/extensions/model-switch.ts
+++ b/src/extensions/model-switch.ts
@@ -231,11 +231,20 @@ export default function modelSwitchExtension(pi: ExtensionAPI) {
 		// Tier-downgrade info — non-blocking
 		const prevTier = getModelTier(event.previousModel as never, MODEL_CAPABILITIES)
 		const nextTier = getModelTier(event.model as never, MODEL_CAPABILITIES)
+		// Explicit model selection (e.g. /model) disables multi-model unless the orchestrator itself was picked
 		if (prevTier && nextTier && TIER_ORDER.indexOf(prevTier) < TIER_ORDER.indexOf(nextTier)) {
 			ctx.ui?.notify(
 				`Switching from ${prevTier}-tier to ${nextTier}-tier model. Reasoning quality may be reduced for complex tasks.`,
 				"info",
 			)
+		}
+
+		if (event.source === "set") {
+			const orchRef = getOrchestratorModelRef()
+			const selectedRef = `${event.model.provider}/${event.model.id}`
+			if (selectedRef !== orchRef) {
+				setMultiModelEnabled(false)
+			}
 		}
 	})
 }


### PR DESCRIPTION
Fixes https://castai.slack.com/archives/C0AF2DFLGRZ/p1779449490077299 

---
### Kimchi Summary
### What changed
When a user explicitly selects a model (e.g., via `/model`), the extension now automatically disables multi-model mode unless the chosen model is the orchestrator itself.

### Why
Fixes a bug where manually switching models while multi-model mode was active left orchestration enabled, causing unexpected behavior because the system continued to treat the session as multi-model.

### Key changes
- `src/extensions/model-switch.ts`: After a model switch, checks if `event.source === "set"`. If the selected model reference does not match the orchestrator model reference (`getOrchestratorModelRef()`), calls `setMultiModelEnabled(false)` to exit multi-model mode.

### Impact
Explicit model selections now correctly opt out of multi-model orchestration. No migration steps are required.