### PR TITLE
Add user-agent to OTLP headers and resource attributes

### DIFF
--- a/src/commands/dispatch.test.ts
+++ b/src/commands/dispatch.test.ts
@@ -68,7 +68,7 @@ describe("dispatchSubcommand", () => {
 		// the merged help renderer. Either way is "handled", but checking
 		// stdout for the version banner confirms the dispatch order.
 		const printed = logSpy.mock.calls.map((c) => String(c[0] ?? "")).join("\n")
-		expect(printed).toMatch(/^kimchi \d+\.\d+\.\d+/m)
+		expect(printed).toMatch(/^kimchi (?:dev|\d+\.\d+\.\d+)/m)
 	})
 
 	it("update --help prints usage and returns 0", async () => {

--- a/src/config.test.ts
+++ b/src/config.test.ts
@@ -367,6 +367,68 @@ describe("readTelemetryConfig", () => {
 		expect(config.enabled).toBe(false)
 		expect(config.metricsEndpoint).toBe("https://api.cast.ai/ai-optimizer/v1beta/metrics:ingest")
 	})
+
+	it("injects User-Agent into telemetry headers", () => {
+		writeFileSync(
+			configPath,
+			JSON.stringify({
+				telemetry: {
+					enabled: true,
+					apiKey: "test-api-key",
+				},
+			}),
+		)
+		const config = readTelemetryConfig(configPath)
+		expect(config.headers["User-Agent"]).toBeDefined()
+		expect(config.headers["User-Agent"]).toMatch(/^kimchi\//)
+	})
+
+	it("injects User-Agent even with no apiKey and no custom headers", () => {
+		writeFileSync(
+			configPath,
+			JSON.stringify({
+				telemetry: {
+					enabled: true,
+				},
+			}),
+		)
+		const config = readTelemetryConfig(configPath)
+		expect(config.headers["User-Agent"]).toBeDefined()
+		expect(config.headers["User-Agent"]).toMatch(/^kimchi\//)
+	})
+
+	it("preserves custom user-agent header when user sets one", () => {
+		writeFileSync(
+			configPath,
+			JSON.stringify({
+				telemetry: {
+					enabled: true,
+					headers: {
+						"user-agent": "my-custom-agent/1.0",
+					},
+				},
+			}),
+		)
+		const config = readTelemetryConfig(configPath)
+		expect(config.headers["user-agent"]).toBe("my-custom-agent/1.0")
+		expect(config.headers["User-Agent"]).toBeUndefined()
+	})
+
+	it("injects User-Agent even when telemetry is disabled (config still prepared)", () => {
+		writeFileSync(
+			configPath,
+			JSON.stringify({
+				telemetry: {
+					enabled: false,
+					apiKey: "test-api-key",
+				},
+			}),
+		)
+		const config = readTelemetryConfig(configPath)
+		expect(config.enabled).toBe(false)
+		expect(config.headers["User-Agent"]).toBeDefined()
+		expect(config.headers["User-Agent"]).toMatch(/^kimchi\//)
+	})
 })
 
 describe("readGitToken / writeGitToken", () => {

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,6 +1,7 @@
 import { existsSync, mkdirSync, readFileSync, renameSync, writeFileSync } from "node:fs"
 import { homedir } from "node:os"
 import { dirname, join, relative, resolve } from "node:path"
+import { getVersion } from "./utils.js"
 
 const KIMCHI_CONFIG_PATH = resolve(homedir(), ".config", "kimchi", "config.json")
 const AGENT_CONFIG_DIR = resolve(homedir(), ".config", "kimchi", "harness")
@@ -262,6 +263,12 @@ export function readTelemetryConfig(configPath?: string): TelemetryConfig {
 	const defaultEnabled = fileHeaders ? Object.keys(fileHeaders).length > 0 : !!apiKey
 	const enabled =
 		envEnabled !== undefined ? envEnabled !== "0" && envEnabled !== "false" : (fileEnabled ?? defaultEnabled)
+
+	// Always inject a User-Agent so telemetry is traceable on the server side.
+	const hasUserAgent = Object.keys(headers).some((k) => k.toLowerCase() === "user-agent")
+	if (!hasUserAgent) {
+		headers["User-Agent"] = `kimchi/${getVersion()}`
+	}
 
 	return {
 		enabled,

--- a/src/extensions/telemetry.test.ts
+++ b/src/extensions/telemetry.test.ts
@@ -111,6 +111,86 @@ describe("telemetryExtension", () => {
 			expect(names).toContain("claude_code.cost.usage")
 		})
 
+		it("includes user_agent.original in metrics resource attributes", async () => {
+			const { handlers, api } = createMockApi()
+			const ext = telemetryExtension(makeConfig())
+			ext(api)
+
+			await getHandler(handlers, "session_start")()
+
+			await getHandler(
+				handlers,
+				"message_end",
+			)({
+				message: {
+					role: "assistant",
+					model: "test-model",
+					provider: "test-provider",
+					timestamp: Date.now(),
+					usage: {
+						input: 10,
+						output: 5,
+						cacheRead: 0,
+						cacheWrite: 0,
+						cost: { total: 0.001 },
+					},
+				},
+			})
+
+			await getHandler(handlers, "session_shutdown")()
+
+			const metricsCalls = fetchMock.mock.calls.filter(
+				([url]) => String(url) === "https://api.cast.ai/ai-optimizer/v1beta/metrics:ingest",
+			)
+			expect(metricsCalls.length).toBe(1)
+
+			const payload = JSON.parse(String((metricsCalls[0][1] as RequestInit).body))
+			const resourceAttrs = payload.resourceMetrics[0].resource.attributes
+			const uaAttr = resourceAttrs.find((a: { key: string }) => a.key === "user_agent.original")
+			expect(uaAttr).toBeDefined()
+			expect(uaAttr.value.stringValue).toMatch(/^kimchi\//)
+		})
+
+		it("includes user_agent.original in logs resource attributes", async () => {
+			const { handlers, api } = createMockApi()
+			const ext = telemetryExtension(makeConfig())
+			ext(api)
+
+			await getHandler(handlers, "session_start")()
+
+			await getHandler(
+				handlers,
+				"message_end",
+			)({
+				message: {
+					role: "assistant",
+					model: "test-model",
+					provider: "test-provider",
+					timestamp: Date.now(),
+					usage: {
+						input: 10,
+						output: 5,
+						cacheRead: 0,
+						cacheWrite: 0,
+						cost: { total: 0.001 },
+					},
+				},
+			})
+
+			await getHandler(handlers, "session_shutdown")()
+
+			const logCalls = fetchMock.mock.calls.filter(
+				([url]) => String(url) === "https://api.cast.ai/ai-optimizer/v1beta/logs:ingest",
+			)
+			expect(logCalls.length).toBeGreaterThanOrEqual(1)
+
+			const payload = JSON.parse(String((logCalls[0][1] as RequestInit).body))
+			const resourceAttrs = payload.resourceLogs[0].resource.attributes
+			const uaAttr = resourceAttrs.find((a: { key: string }) => a.key === "user_agent.original")
+			expect(uaAttr).toBeDefined()
+			expect(uaAttr.value.stringValue).toMatch(/^kimchi\//)
+		})
+
 		it("deduplicates duplicate assistant messages using message id", async () => {
 			const { handlers, api } = createMockApi()
 			const ext = telemetryExtension(makeConfig())

--- a/src/extensions/telemetry.ts
+++ b/src/extensions/telemetry.ts
@@ -2,6 +2,7 @@ import type { AssistantMessage } from "@earendil-works/pi-ai"
 import type { ExtensionAPI } from "@earendil-works/pi-coding-agent"
 import type { TelemetryConfig } from "../config.js"
 import { getAvailableModels } from "../startup-context.js"
+import { getVersion } from "../utils.js"
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -99,7 +100,10 @@ async function sendLog(
 	const payload = {
 		resourceLogs: [
 			{
-				resource: { attributes: [strAttr("service.name", "kimchi")], droppedAttributesCount: 0 },
+				resource: {
+					attributes: [strAttr("service.name", "kimchi"), strAttr("user_agent.original", `kimchi/${getVersion()}`)],
+					droppedAttributesCount: 0,
+				},
 				scopeLogs: [
 					{
 						scope: { name: "kimchi", version: "1.0.0" },
@@ -165,7 +169,10 @@ async function sendMetrics(
 	const payload = {
 		resourceMetrics: [
 			{
-				resource: { attributes: [strAttr("service.name", "kimchi")], droppedAttributesCount: 0 },
+				resource: {
+					attributes: [strAttr("service.name", "kimchi"), strAttr("user_agent.original", `kimchi/${getVersion()}`)],
+					droppedAttributesCount: 0,
+				},
 				scopeMetrics: [
 					{
 						scope: { name: "kimchi", version: "1.0.0" },

--- a/src/utils.test.ts
+++ b/src/utils.test.ts
@@ -1,0 +1,38 @@
+import { mkdtempSync, writeFileSync } from "node:fs"
+import { tmpdir } from "node:os"
+import { resolve } from "node:path"
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
+
+describe("getVersion", () => {
+	beforeEach(() => {
+		vi.resetModules()
+	})
+
+	afterEach(() => {
+		vi.unstubAllEnvs()
+	})
+
+	it("returns 'dev' when package.json has 0.0.0 and no PI_PACKAGE_DIR", async () => {
+		// Ensure PI_PACKAGE_DIR is not set so getVersion falls back to workspace package.json
+		vi.stubEnv("PI_PACKAGE_DIR", "")
+		const { getVersion } = await import("./utils.js")
+		const v = getVersion()
+		expect(v).toBe("dev")
+	})
+
+	it("returns the real version from PI_PACKAGE_DIR package.json", async () => {
+		const tmpDir = mkdtempSync(resolve(tmpdir(), "kimchi-test-"))
+		writeFileSync(resolve(tmpDir, "package.json"), JSON.stringify({ name: "kimchi-test", version: "1.2.3" }))
+		vi.stubEnv("PI_PACKAGE_DIR", tmpDir)
+		const { getVersion } = await import("./utils.js")
+		const v = getVersion()
+		expect(v).toBe("1.2.3")
+	})
+
+	it("memoizes the result (returns the same value on repeated calls)", async () => {
+		const { getVersion } = await import("./utils.js")
+		const v1 = getVersion()
+		const v2 = getVersion()
+		expect(v1).toBe(v2)
+	})
+})

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -35,7 +35,14 @@ export function getVersion(): string {
 			? resolve(pkgDir, "package.json")
 			: resolve(dirname(fileURLToPath(import.meta.url)), "../package.json")
 		const pkg = JSON.parse(readFileSync(pkgPath, "utf-8"))
-		cachedVersion = pkg.version ?? "unknown"
+		let version = pkg.version ?? "unknown"
+		// When the version field is the development placeholder (0.0.0)
+		// report a simple "dev" string so that the transform backend does
+		// not have to deal with stale/partial git-describe noise.
+		if (version === "0.0.0") {
+			version = "dev"
+		}
+		cachedVersion = version
 	} catch {
 		cachedVersion = "unknown"
 	}

--- a/tests/smoke/binary.test.ts
+++ b/tests/smoke/binary.test.ts
@@ -56,7 +56,7 @@ describe("binary smoke tests", () => {
 			args: ["version"],
 			extraEnv: { KIMCHI_API_KEY: "smoke-test-dummy" },
 		})
-		expect(result.stdout).toMatch(/^kimchi \d+\.\d+\.\d+/)
+		expect(result.stdout).toMatch(/^kimchi (?:dev|\d+\.\d+\.\d+)/)
 		expect(result.stdout).toContain("platform:")
 		// The harness exit hook prints "To resume:" on exit code 0; subcommands
 		// short-circuit before any session starts, so it must NOT appear.


### PR DESCRIPTION
### Kimchi Summary
### What changed
Telemetry HTTP requests and OTLP payloads now identify the client using a `User-Agent` header and a `user_agent.original` resource attribute containing the kimchi version. Development builds report `"dev"` instead of the placeholder `0.0.0` version.

### Why
This allows the telemetry backend to trace and identify incoming requests by client version, improving observability and debugging.

### Key changes
- `src/config.ts`: `readTelemetryConfig` now injects a `User-Agent: kimchi/<version>` header into the telemetry configuration when no custom `User-Agent` is defined.
- `src/extensions/telemetry.ts`: `sendLog` and `sendMetrics` include `strAttr("user_agent.original", "kimchi/<version>")` in OTLP resource attributes.
- `src/utils.ts`: `getVersion()` returns `"dev"` when the local `package.json` version is `"0.0.0"`.
- `src/utils.test.ts`: Added tests for `getVersion` covering version resolution, development placeholder handling, and memoization.
- `src/config.test.ts` and `src/extensions/telemetry.test.ts`: Added coverage for User-Agent header injection and resource attribute propagation.

### Impact
- Custom `User-Agent` headers explicitly configured by users are preserved and take precedence over the default.
- No breaking changes; telemetry remains opt-in via existing configuration.

Closes LLM-1767

---
### Kimchi Summary
### What changed
Injects a `kimchi/<version>` `User-Agent` header into telemetry HTTP requests and adds `user_agent.original` to OTLP logs and metrics resource attributes. Development builds now report their version as `dev` instead of the placeholder `0.0.0`.

### Why
Makes client requests traceable on the server side and prevents development builds from emitting stale git-describe noise to the telemetry backend.

### Key changes
- `src/config.ts`: `readTelemetryConfig` injects `User-Agent: kimchi/<version>` into telemetry `headers` when no user-agent is already configured.
- `src/extensions/telemetry.ts`: Adds `user_agent.original` attribute to OTLP `resourceLogs` and `resourceMetrics` payloads.
- `src/utils.ts`: `getVersion()` returns `"dev"` when the resolved `package.json` version is `"0.0.0"`.
- `src/utils.test.ts`: Added tests for `getVersion` covering the `0.0.0` → `dev` fallback, `PI_PACKAGE_DIR` resolution, and memoization.
- Updated tests across `src/commands/dispatch.test.ts`, `src/config.test.ts`, `src/extensions/telemetry.test.ts`, and `tests/smoke/binary.test.ts` to accept `dev` as a valid version string.