### PR TITLE
feat(session-mode): restore first-run picker advertising /ferment workflow

### DIFF
--- a/src/config.test.ts
+++ b/src/config.test.ts
@@ -10,6 +10,8 @@ import {
 	writeApiKey,
 	writeDeviceId,
 	writeGitToken,
+	writeHideSessionModeDialog,
+	writeSessionModeWizardSeenAt,
 } from "./config.js"
 
 describe("loadConfig", () => {
@@ -216,6 +218,48 @@ describe("loadConfig", () => {
 		rmSync(globalDir, { recursive: true, force: true })
 		rmSync(rootDir, { recursive: true, force: true })
 	})
+
+	it("reads global onboarding state", () => {
+		writeFileSync(
+			configPath,
+			JSON.stringify({
+				onboarding: {
+					sessionModeWizardSeenAt: "2026-05-19T09:30:00.000Z",
+					hideSessionModeDialog: true,
+				},
+			}),
+		)
+
+		const config = loadConfig({ configPath })
+
+		expect(config.onboarding.sessionModeWizardSeenAt).toBe("2026-05-19T09:30:00.000Z")
+		expect(config.onboarding.hideSessionModeDialog).toBe(true)
+	})
+
+	it("reads hyphenated hide session mode dialog config for compatibility", () => {
+		writeFileSync(configPath, JSON.stringify({ onboarding: { "hide-session-mode-dialog": true } }))
+
+		const config = loadConfig({ configPath })
+
+		expect(config.onboarding.hideSessionModeDialog).toBe(true)
+	})
+
+	it("does not read project onboarding state as global first-run state", () => {
+		const globalDir = mkdtempSync(join(tmpdir(), "kimchi-test-"))
+		const projectDir = mkdtempSync(join(tmpdir(), "kimchi-test-"))
+		const globalPath = join(globalDir, "config.json")
+		const projectPath = join(projectDir, ".kimchi", "config.json")
+
+		writeFileSync(globalPath, JSON.stringify({ apiKey: "global-key" }))
+		mkdirSync(dirname(projectPath), { recursive: true })
+		writeFileSync(projectPath, JSON.stringify({ onboarding: { sessionModeWizardSeenAt: "project" } }))
+
+		const config = loadConfig({ configPath: globalPath, cwd: projectDir })
+		expect(config.onboarding.sessionModeWizardSeenAt).toBeUndefined()
+
+		rmSync(globalDir, { recursive: true, force: true })
+		rmSync(projectDir, { recursive: true, force: true })
+	})
 })
 
 describe("writeApiKey", () => {
@@ -366,6 +410,88 @@ describe("readTelemetryConfig", () => {
 		const config = readTelemetryConfig(configPath)
 		expect(config.enabled).toBe(false)
 		expect(config.metricsEndpoint).toBe("https://api.cast.ai/ai-optimizer/v1beta/metrics:ingest")
+	})
+})
+
+describe("writeSessionModeWizardSeenAt", () => {
+	let tempDir: string
+	let configPath: string
+
+	beforeEach(() => {
+		tempDir = mkdtempSync(join(tmpdir(), "kimchi-test-"))
+		configPath = join(tempDir, "config.json")
+	})
+
+	afterEach(() => {
+		rmSync(tempDir, { recursive: true, force: true })
+	})
+
+	it("writes onboarding.sessionModeWizardSeenAt", () => {
+		writeSessionModeWizardSeenAt("2026-05-19T09:30:00.000Z", configPath)
+		const raw = JSON.parse(readFileSync(configPath, "utf-8"))
+		expect(raw.onboarding.sessionModeWizardSeenAt).toBe("2026-05-19T09:30:00.000Z")
+	})
+
+	it("preserves unrelated fields and existing onboarding fields", () => {
+		writeFileSync(
+			configPath,
+			JSON.stringify({
+				apiKey: "key",
+				onboarding: { otherWizardSeenAt: "2026-05-18T10:00:00.000Z" },
+			}),
+		)
+
+		writeSessionModeWizardSeenAt("2026-05-19T09:30:00.000Z", configPath)
+		const raw = JSON.parse(readFileSync(configPath, "utf-8"))
+
+		expect(raw).toEqual({
+			apiKey: "key",
+			onboarding: {
+				otherWizardSeenAt: "2026-05-18T10:00:00.000Z",
+				sessionModeWizardSeenAt: "2026-05-19T09:30:00.000Z",
+			},
+		})
+	})
+})
+
+describe("writeHideSessionModeDialog", () => {
+	let tempDir: string
+	let configPath: string
+
+	beforeEach(() => {
+		tempDir = mkdtempSync(join(tmpdir(), "kimchi-test-"))
+		configPath = join(tempDir, "config.json")
+	})
+
+	afterEach(() => {
+		rmSync(tempDir, { recursive: true, force: true })
+	})
+
+	it("writes onboarding.hideSessionModeDialog", () => {
+		writeHideSessionModeDialog(true, configPath)
+		const raw = JSON.parse(readFileSync(configPath, "utf-8"))
+		expect(raw.onboarding.hideSessionModeDialog).toBe(true)
+	})
+
+	it("preserves unrelated fields and existing onboarding fields", () => {
+		writeFileSync(
+			configPath,
+			JSON.stringify({
+				apiKey: "key",
+				onboarding: { sessionModeWizardSeenAt: "2026-05-19T09:30:00.000Z" },
+			}),
+		)
+
+		writeHideSessionModeDialog(true, configPath)
+		const raw = JSON.parse(readFileSync(configPath, "utf-8"))
+
+		expect(raw).toEqual({
+			apiKey: "key",
+			onboarding: {
+				sessionModeWizardSeenAt: "2026-05-19T09:30:00.000Z",
+				hideSessionModeDialog: true,
+			},
+		})
 	})
 })
 

--- a/src/config.test.ts
+++ b/src/config.test.ts
@@ -10,7 +10,6 @@ import {
 	writeApiKey,
 	writeDeviceId,
 	writeGitToken,
-	writeHideSessionModeDialog,
 	writeSessionModeWizardSeenAt,
 } from "./config.js"
 
@@ -236,14 +235,6 @@ describe("loadConfig", () => {
 		expect(config.onboarding.hideSessionModeDialog).toBe(true)
 	})
 
-	it("reads hyphenated hide session mode dialog config for compatibility", () => {
-		writeFileSync(configPath, JSON.stringify({ onboarding: { "hide-session-mode-dialog": true } }))
-
-		const config = loadConfig({ configPath })
-
-		expect(config.onboarding.hideSessionModeDialog).toBe(true)
-	})
-
 	it("does not read project onboarding state as global first-run state", () => {
 		const globalDir = mkdtempSync(join(tmpdir(), "kimchi-test-"))
 		const projectDir = mkdtempSync(join(tmpdir(), "kimchi-test-"))
@@ -449,47 +440,6 @@ describe("writeSessionModeWizardSeenAt", () => {
 			onboarding: {
 				otherWizardSeenAt: "2026-05-18T10:00:00.000Z",
 				sessionModeWizardSeenAt: "2026-05-19T09:30:00.000Z",
-			},
-		})
-	})
-})
-
-describe("writeHideSessionModeDialog", () => {
-	let tempDir: string
-	let configPath: string
-
-	beforeEach(() => {
-		tempDir = mkdtempSync(join(tmpdir(), "kimchi-test-"))
-		configPath = join(tempDir, "config.json")
-	})
-
-	afterEach(() => {
-		rmSync(tempDir, { recursive: true, force: true })
-	})
-
-	it("writes onboarding.hideSessionModeDialog", () => {
-		writeHideSessionModeDialog(true, configPath)
-		const raw = JSON.parse(readFileSync(configPath, "utf-8"))
-		expect(raw.onboarding.hideSessionModeDialog).toBe(true)
-	})
-
-	it("preserves unrelated fields and existing onboarding fields", () => {
-		writeFileSync(
-			configPath,
-			JSON.stringify({
-				apiKey: "key",
-				onboarding: { sessionModeWizardSeenAt: "2026-05-19T09:30:00.000Z" },
-			}),
-		)
-
-		writeHideSessionModeDialog(true, configPath)
-		const raw = JSON.parse(readFileSync(configPath, "utf-8"))
-
-		expect(raw).toEqual({
-			apiKey: "key",
-			onboarding: {
-				sessionModeWizardSeenAt: "2026-05-19T09:30:00.000Z",
-				hideSessionModeDialog: true,
 			},
 		})
 	})

--- a/src/config.ts
+++ b/src/config.ts
@@ -218,8 +218,7 @@ function parseOnboardingConfig(value: unknown): OnboardingConfig | undefined {
 		typeof raw.sessionModeWizardSeenAt === "string" && raw.sessionModeWizardSeenAt.length > 0
 			? raw.sessionModeWizardSeenAt
 			: undefined
-	const hideSessionModeDialogValue = raw.hideSessionModeDialog ?? raw["hide-session-mode-dialog"]
-	const hideSessionModeDialog = typeof hideSessionModeDialogValue === "boolean" ? hideSessionModeDialogValue : undefined
+	const hideSessionModeDialog = typeof raw.hideSessionModeDialog === "boolean" ? raw.hideSessionModeDialog : undefined
 
 	return {
 		...(sessionModeWizardSeenAt ? { sessionModeWizardSeenAt } : {}),
@@ -393,13 +392,6 @@ export function writeSessionModeWizardSeenAt(seenAt: string, configPath?: string
 
 export function readHideSessionModeDialog(configPath?: string): boolean {
 	return readConfigExtras(configPath ?? KIMCHI_CONFIG_PATH).onboarding?.hideSessionModeDialog === true
-}
-
-export function writeHideSessionModeDialog(hidden: boolean, configPath?: string): void {
-	const path = configPath ?? KIMCHI_CONFIG_PATH
-	updateOnboardingConfig(path, (onboarding) => {
-		onboarding.hideSessionModeDialog = hidden
-	})
 }
 
 export function writeMigrationState(state: MigrationState, configPath?: string): void {

--- a/src/config.ts
+++ b/src/config.ts
@@ -62,7 +62,10 @@ export interface SearchStrategyConfig {
 	fieldWeights: { name: number; description: number; schemaKey: number }
 }
 
-export type OnboardingConfig = Record<string, unknown>
+export interface OnboardingConfig {
+	sessionModeWizardSeenAt?: string
+	hideSessionModeDialog?: boolean
+}
 
 export const SEARCH_STRATEGY_DEFAULTS: SearchStrategyConfig = {
 	strategy: "bm25",
@@ -161,7 +164,7 @@ function readConfigExtras(configPath: string): {
 			parsed.migrationState === "done" || parsed.migrationState === "skip-forever"
 				? (parsed.migrationState as MigrationState)
 				: undefined
-		const onboarding: OnboardingConfig = {}
+		const onboarding = parseOnboardingConfig(parsed.onboarding)
 		// Read apiKey (prefer camelCase, fall back to snake_case)
 		let apiKey: string | undefined
 		if (typeof parsed.apiKey === "string" && parsed.apiKey.length > 0) {
@@ -206,6 +209,22 @@ function readConfigObject(configPath: string): Record<string, unknown> | undefin
 		// file missing or invalid
 	}
 	return undefined
+}
+
+function parseOnboardingConfig(value: unknown): OnboardingConfig | undefined {
+	if (!value || typeof value !== "object" || Array.isArray(value)) return undefined
+	const raw = value as Record<string, unknown>
+	const sessionModeWizardSeenAt =
+		typeof raw.sessionModeWizardSeenAt === "string" && raw.sessionModeWizardSeenAt.length > 0
+			? raw.sessionModeWizardSeenAt
+			: undefined
+	const hideSessionModeDialogValue = raw.hideSessionModeDialog ?? raw["hide-session-mode-dialog"]
+	const hideSessionModeDialog = typeof hideSessionModeDialogValue === "boolean" ? hideSessionModeDialogValue : undefined
+
+	return {
+		...(sessionModeWizardSeenAt ? { sessionModeWizardSeenAt } : {}),
+		...(hideSessionModeDialog !== undefined ? { hideSessionModeDialog } : {}),
+	}
 }
 
 /**
@@ -347,6 +366,39 @@ function updateConfigFile(
 function writeConfigField(key: string, value: unknown, configPath: string): void {
 	updateConfigFile(configPath, (raw) => {
 		raw[key] = value
+	})
+}
+
+function updateOnboardingConfig(configPath: string, update: (onboarding: Record<string, unknown>) => void): void {
+	updateConfigFile(configPath, (raw) => {
+		const onboarding =
+			raw.onboarding && typeof raw.onboarding === "object" && !Array.isArray(raw.onboarding)
+				? { ...(raw.onboarding as Record<string, unknown>) }
+				: {}
+		update(onboarding)
+		raw.onboarding = onboarding
+	})
+}
+
+export function readSessionModeWizardSeenAt(configPath?: string): string | undefined {
+	return readConfigExtras(configPath ?? KIMCHI_CONFIG_PATH).onboarding?.sessionModeWizardSeenAt
+}
+
+export function writeSessionModeWizardSeenAt(seenAt: string, configPath?: string): void {
+	const path = configPath ?? KIMCHI_CONFIG_PATH
+	updateOnboardingConfig(path, (onboarding) => {
+		onboarding.sessionModeWizardSeenAt = seenAt
+	})
+}
+
+export function readHideSessionModeDialog(configPath?: string): boolean {
+	return readConfigExtras(configPath ?? KIMCHI_CONFIG_PATH).onboarding?.hideSessionModeDialog === true
+}
+
+export function writeHideSessionModeDialog(hidden: boolean, configPath?: string): void {
+	const path = configPath ?? KIMCHI_CONFIG_PATH
+	updateOnboardingConfig(path, (onboarding) => {
+		onboarding.hideSessionModeDialog = hidden
 	})
 }
 

--- a/src/extensions/onboarding/picker-editor.ts
+++ b/src/extensions/onboarding/picker-editor.ts
@@ -1,0 +1,22 @@
+import type { EditorComponent } from "@earendil-works/pi-tui"
+
+// Empty editor used while the session-mode picker is mounted. Returning [] from
+// render() reclaims the rows the real editor would occupy, so the picker is the
+// only visible UI element. Cleanup restores the previously installed factory
+// via the value captured from getEditorComponent() — never undefined — so
+// upstream wiring (PromptEditor, expand handler, hardware cursor) survives.
+export class NoOpPickerEditor implements EditorComponent {
+	getText(): string {
+		return ""
+	}
+
+	setText(_text: string): void {}
+
+	handleInput(_data: string): void {}
+
+	render(_width: number): string[] {
+		return []
+	}
+
+	invalidate(): void {}
+}

--- a/src/extensions/onboarding/session-mode-picker.test.ts
+++ b/src/extensions/onboarding/session-mode-picker.test.ts
@@ -47,10 +47,10 @@ describe("session mode picker reducer", () => {
 
 	it("returns the selected option on select", () => {
 		let state = initialSessionModePickerState()
-		expect(reduceSessionModePicker(state, "select").result).toEqual({ choice: "ferment", hideDialog: false })
+		expect(reduceSessionModePicker(state, "select").result).toBe("ferment")
 
 		state = reduceSessionModePicker(state, "down").state
-		expect(reduceSessionModePicker(state, "select").result).toEqual({ choice: "default", hideDialog: false })
+		expect(reduceSessionModePicker(state, "select").result).toBe("default")
 	})
 
 	it("returns cancellation on cancel", () => {
@@ -121,7 +121,7 @@ describe("SessionModePickerComponent", () => {
 		expect(requestRender).toHaveBeenCalledTimes(1)
 
 		component.handleInput("\r")
-		expect(onDone).toHaveBeenCalledWith({ choice: "default", hideDialog: false })
+		expect(onDone).toHaveBeenCalledWith("default")
 	})
 
 	it("calls onDone for cancellation", () => {

--- a/src/extensions/onboarding/session-mode-picker.test.ts
+++ b/src/extensions/onboarding/session-mode-picker.test.ts
@@ -1,0 +1,135 @@
+import type { Theme } from "@earendil-works/pi-coding-agent"
+import { describe, expect, it, vi } from "vitest"
+import {
+	SessionModePickerComponent,
+	initialSessionModePickerState,
+	keyToSessionModePickerEvent,
+	reduceSessionModePicker,
+	renderSessionModePickerLines,
+} from "./session-mode-picker.js"
+
+function theme(): Theme {
+	return {
+		fg: vi.fn((_color: string, text: string) => text),
+		bg: vi.fn((_color: string, text: string) => text),
+		bold: vi.fn((text: string) => text),
+		getFgAnsi: vi.fn(),
+		getBgAnsi: vi.fn(),
+		fgColors: {},
+		bgColors: {},
+		mode: "dark",
+		preproc: vi.fn(),
+		extensions: {},
+	} as unknown as Theme
+}
+
+describe("session mode picker reducer", () => {
+	it("starts on Ferment", () => {
+		expect(initialSessionModePickerState()).toEqual({ selectedIndex: 0 })
+	})
+
+	it("moves selection down and up", () => {
+		let state = initialSessionModePickerState()
+		state = reduceSessionModePicker(state, "down").state
+		expect(state.selectedIndex).toBe(1)
+		state = reduceSessionModePicker(state, "up").state
+		expect(state.selectedIndex).toBe(0)
+	})
+
+	it("keeps selection stable at list boundaries", () => {
+		let state = initialSessionModePickerState()
+		state = reduceSessionModePicker(state, "up").state
+		expect(state.selectedIndex).toBe(0)
+		state = reduceSessionModePicker(state, "down").state
+		state = reduceSessionModePicker(state, "down").state
+		expect(state.selectedIndex).toBe(1)
+	})
+
+	it("returns the selected option on select", () => {
+		let state = initialSessionModePickerState()
+		expect(reduceSessionModePicker(state, "select").result).toEqual({ choice: "ferment", hideDialog: false })
+
+		state = reduceSessionModePicker(state, "down").state
+		expect(reduceSessionModePicker(state, "select").result).toEqual({ choice: "default", hideDialog: false })
+	})
+
+	it("returns cancellation on cancel", () => {
+		expect(reduceSessionModePicker(initialSessionModePickerState(), "cancel").result).toBe("cancelled")
+	})
+})
+
+describe("session mode picker key mapping", () => {
+	it("maps navigation, selection, and cancellation keys", () => {
+		expect(keyToSessionModePickerEvent("\x1b[A")).toBe("up")
+		expect(keyToSessionModePickerEvent("\x1b[B")).toBe("down")
+		expect(keyToSessionModePickerEvent("\r")).toBe("select")
+		expect(keyToSessionModePickerEvent("\x1b")).toBe("cancel")
+		expect(keyToSessionModePickerEvent("\x03")).toBe("cancel")
+	})
+
+	it("ignores unrelated input", () => {
+		expect(keyToSessionModePickerEvent("x")).toBeUndefined()
+	})
+
+	it("ignores space input", () => {
+		expect(keyToSessionModePickerEvent(" ")).toBeUndefined()
+		expect(keyToSessionModePickerEvent("\x1b[32;1:2u")).toBeUndefined()
+		expect(keyToSessionModePickerEvent("\x1b[32;1:3u")).toBeUndefined()
+	})
+})
+
+describe("session mode picker rendering", () => {
+	it("renders the two workflow options with no heading or tip", () => {
+		const lines = renderSessionModePickerLines(initialSessionModePickerState(), theme(), 140)
+		const text = lines.join("\n")
+
+		expect(lines).toEqual([
+			"",
+			"  > Try a /ferment workflow",
+			"    The agent breaks the task into phases, self-evaluates its output and delivers with minimal interruptions.",
+			"",
+			"    Just chat and code",
+			"",
+		])
+		expect(text).toContain("Try a /ferment workflow")
+		expect(text).toContain(
+			"The agent breaks the task into phases, self-evaluates its output and delivers with minimal interruptions.",
+		)
+		expect(text).toContain("Just chat and code")
+		expect(text).not.toContain("Tip:")
+	})
+
+	it("marks the selected option", () => {
+		let lines = renderSessionModePickerLines(initialSessionModePickerState(), theme(), 100)
+		expect(lines.some((line) => line.includes("> Try a /ferment workflow"))).toBe(true)
+		expect(lines.some((line) => line.includes("> Just chat and code"))).toBe(false)
+
+		const state = reduceSessionModePicker(initialSessionModePickerState(), "down").state
+		lines = renderSessionModePickerLines(state, theme(), 100)
+		expect(lines.some((line) => line.includes("> Just chat and code"))).toBe(true)
+	})
+})
+
+describe("SessionModePickerComponent", () => {
+	it("handles keys and calls onDone for selection", () => {
+		const onDone = vi.fn()
+		const requestRender = vi.fn()
+		const component = new SessionModePickerComponent(theme(), onDone, requestRender)
+
+		component.handleInput("\x1b[B")
+		expect(component.getState().selectedIndex).toBe(1)
+		expect(requestRender).toHaveBeenCalledTimes(1)
+
+		component.handleInput("\r")
+		expect(onDone).toHaveBeenCalledWith({ choice: "default", hideDialog: false })
+	})
+
+	it("calls onDone for cancellation", () => {
+		const onDone = vi.fn()
+		const component = new SessionModePickerComponent(theme(), onDone, vi.fn())
+
+		component.handleInput("\x03")
+
+		expect(onDone).toHaveBeenCalledWith("cancelled")
+	})
+})

--- a/src/extensions/onboarding/session-mode-picker.ts
+++ b/src/extensions/onboarding/session-mode-picker.ts
@@ -2,14 +2,13 @@ import type { Theme } from "@earendil-works/pi-coding-agent"
 import { type Component, Key, matchesKey, truncateToWidth, wrapTextWithAnsi } from "@earendil-works/pi-tui"
 
 export type SessionModePickerChoice = "ferment" | "default"
-export type SessionModePickerResult = { choice: SessionModePickerChoice; hideDialog: boolean } | "cancelled"
+export type SessionModePickerResult = SessionModePickerChoice | "cancelled"
 export type SessionModePickerEvent = "up" | "down" | "select" | "cancel"
 
 export interface SessionModePickerOption {
 	value: SessionModePickerChoice
 	label: string
 	description?: string
-	hideDialog?: boolean
 }
 
 export interface SessionModePickerState {
@@ -45,10 +44,7 @@ export function reduceSessionModePicker(
 	if (event === "cancel") return { state, result: "cancelled" }
 	if (event === "select") {
 		const option = SESSION_MODE_PICKER_OPTIONS[state.selectedIndex]
-		return {
-			state,
-			result: { choice: option.value, hideDialog: option.hideDialog === true },
-		}
+		return { state, result: option.value }
 	}
 	if (event === "up") {
 		return { state: { ...state, selectedIndex: Math.max(0, state.selectedIndex - 1) } }

--- a/src/extensions/onboarding/session-mode-picker.ts
+++ b/src/extensions/onboarding/session-mode-picker.ts
@@ -96,14 +96,24 @@ export function renderSessionModePickerLines(state: SessionModePickerState, them
 	return lines
 }
 
+export interface SessionModePickerComponentOptions {
+	initialState?: SessionModePickerState
+	onStateChange?: (state: SessionModePickerState) => void
+}
+
 export class SessionModePickerComponent implements Component {
-	private state = initialSessionModePickerState()
+	private state: SessionModePickerState
+	private readonly onStateChange?: (state: SessionModePickerState) => void
 
 	constructor(
 		private readonly theme: Theme,
 		private readonly onDone: (result: SessionModePickerResult) => void,
 		private readonly requestRender: () => void,
-	) {}
+		options: SessionModePickerComponentOptions = {},
+	) {
+		this.state = options.initialState ?? initialSessionModePickerState()
+		this.onStateChange = options.onStateChange
+	}
 
 	getState(): SessionModePickerState {
 		return this.state
@@ -120,6 +130,7 @@ export class SessionModePickerComponent implements Component {
 		if (!event) return
 		const next = reduceSessionModePicker(this.state, event)
 		this.state = next.state
+		this.onStateChange?.(this.state)
 		if (next.result) {
 			this.onDone(next.result)
 			return

--- a/src/extensions/onboarding/session-mode-picker.ts
+++ b/src/extensions/onboarding/session-mode-picker.ts
@@ -1,0 +1,129 @@
+import type { Theme } from "@earendil-works/pi-coding-agent"
+import { type Component, Key, matchesKey, truncateToWidth, wrapTextWithAnsi } from "@earendil-works/pi-tui"
+
+export type SessionModePickerChoice = "ferment" | "default"
+export type SessionModePickerResult = { choice: SessionModePickerChoice; hideDialog: boolean } | "cancelled"
+export type SessionModePickerEvent = "up" | "down" | "select" | "cancel"
+
+export interface SessionModePickerOption {
+	value: SessionModePickerChoice
+	label: string
+	description?: string
+	hideDialog?: boolean
+}
+
+export interface SessionModePickerState {
+	selectedIndex: number
+}
+
+export interface SessionModePickerReduceResult {
+	state: SessionModePickerState
+	result?: SessionModePickerResult
+}
+
+export const SESSION_MODE_PICKER_OPTIONS: SessionModePickerOption[] = [
+	{
+		value: "ferment",
+		label: "Try a /ferment workflow",
+		description:
+			"The agent breaks the task into phases, self-evaluates its output and delivers with minimal interruptions.",
+	},
+	{
+		value: "default",
+		label: "Just chat and code",
+	},
+]
+
+export function initialSessionModePickerState(): SessionModePickerState {
+	return { selectedIndex: 0 }
+}
+
+export function reduceSessionModePicker(
+	state: SessionModePickerState,
+	event: SessionModePickerEvent,
+): SessionModePickerReduceResult {
+	if (event === "cancel") return { state, result: "cancelled" }
+	if (event === "select") {
+		const option = SESSION_MODE_PICKER_OPTIONS[state.selectedIndex]
+		return {
+			state,
+			result: { choice: option.value, hideDialog: option.hideDialog === true },
+		}
+	}
+	if (event === "up") {
+		return { state: { ...state, selectedIndex: Math.max(0, state.selectedIndex - 1) } }
+	}
+	if (event === "down") {
+		return {
+			state: { ...state, selectedIndex: Math.min(SESSION_MODE_PICKER_OPTIONS.length - 1, state.selectedIndex + 1) },
+		}
+	}
+	return { state }
+}
+
+export function keyToSessionModePickerEvent(data: string): SessionModePickerEvent | undefined {
+	if (matchesKey(data, Key.up)) return "up"
+	if (matchesKey(data, Key.down)) return "down"
+	if (matchesKey(data, Key.enter)) return "select"
+	if (matchesKey(data, Key.escape) || matchesKey(data, Key.ctrl("c"))) return "cancel"
+	return undefined
+}
+
+export function renderSessionModePickerLines(state: SessionModePickerState, theme: Theme, width: number): string[] {
+	const lines: string[] = []
+	const innerWidth = Math.max(1, width - 2)
+	const add = (line = "") => lines.push(truncateToWidth(line, width, ""))
+	const indent = "  "
+
+	add("")
+
+	for (let i = 0; i < SESSION_MODE_PICKER_OPTIONS.length; i += 1) {
+		const option = SESSION_MODE_PICKER_OPTIONS[i]
+		const selected = i === state.selectedIndex
+		const marker = selected ? "> " : "  "
+		const label = selected ? theme.fg("accent", option.label) : theme.fg("dim", option.label)
+		add(`${indent}${theme.fg(selected ? "accent" : "dim", marker)}${label}`)
+		if (option.description) {
+			const description = selected ? theme.fg("text", option.description) : theme.fg("dim", option.description)
+			for (const wrapped of wrapTextWithAnsi(description, Math.max(1, innerWidth - 4))) {
+				add(`${indent}  ${wrapped}`)
+			}
+		}
+		if (i < SESSION_MODE_PICKER_OPTIONS.length - 1) add("")
+	}
+
+	add("")
+	return lines
+}
+
+export class SessionModePickerComponent implements Component {
+	private state = initialSessionModePickerState()
+
+	constructor(
+		private readonly theme: Theme,
+		private readonly onDone: (result: SessionModePickerResult) => void,
+		private readonly requestRender: () => void,
+	) {}
+
+	getState(): SessionModePickerState {
+		return this.state
+	}
+
+	invalidate(): void {}
+
+	render(width: number): string[] {
+		return renderSessionModePickerLines(this.state, this.theme, width)
+	}
+
+	handleInput(data: string): void {
+		const event = keyToSessionModePickerEvent(data)
+		if (!event) return
+		const next = reduceSessionModePicker(this.state, event)
+		this.state = next.state
+		if (next.result) {
+			this.onDone(next.result)
+			return
+		}
+		this.requestRender()
+	}
+}

--- a/src/extensions/onboarding/session-mode-startup.test.ts
+++ b/src/extensions/onboarding/session-mode-startup.test.ts
@@ -1,10 +1,10 @@
-import { existsSync, mkdtempSync, readFileSync, rmSync } from "node:fs"
+import { existsSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs"
 import { tmpdir } from "node:os"
 import { join } from "node:path"
 import type { ExtensionAPI, Theme } from "@earendil-works/pi-coding-agent"
 import type { TUI } from "@earendil-works/pi-tui"
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
-import { writeHideSessionModeDialog, writeSessionModeWizardSeenAt } from "../../config.js"
+import { writeSessionModeWizardSeenAt } from "../../config.js"
 import { globalTipRegistry } from "../tips/registry.js"
 import { createSessionModeOnboardingForStartup } from "./session-mode-startup.js"
 
@@ -158,9 +158,18 @@ describe("session mode startup integration", () => {
 		expect(harness.ui.onTerminalInput).not.toHaveBeenCalled()
 	})
 
-	it("skips launches when the session mode dialog has been hidden", async () => {
-		writeSessionModeWizardSeenAt("2026-05-19T08:00:00.000Z", configPath)
-		writeHideSessionModeDialog(true, configPath)
+	it("skips launches when the session mode dialog has been hidden via manual config edit", async () => {
+		// hideSessionModeDialog is an escape-hatch flag: users opt out by
+		// editing the config file directly. No code path sets it from the UI.
+		writeFileSync(
+			configPath,
+			JSON.stringify({
+				onboarding: {
+					sessionModeWizardSeenAt: "2026-05-19T08:00:00.000Z",
+					hideSessionModeDialog: true,
+				},
+			}),
+		)
 		const harness = createHarness({ configPath, now })
 
 		await harness.start()

--- a/src/extensions/onboarding/session-mode-startup.test.ts
+++ b/src/extensions/onboarding/session-mode-startup.test.ts
@@ -1,17 +1,41 @@
-import type { ExtensionAPI } from "@earendil-works/pi-coding-agent"
+import { existsSync, mkdtempSync, readFileSync, rmSync } from "node:fs"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
+import type { ExtensionAPI, Theme } from "@earendil-works/pi-coding-agent"
 import type { TUI } from "@earendil-works/pi-tui"
-import { afterEach, describe, expect, it, vi } from "vitest"
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
+import { writeHideSessionModeDialog, writeSessionModeWizardSeenAt } from "../../config.js"
 import { globalTipRegistry } from "../tips/registry.js"
 import { createSessionModeOnboardingForStartup } from "./session-mode-startup.js"
 
 type SessionStartHandler = (event: unknown, ctx: unknown) => unknown
-const startupHarnesses: Array<{ shutdown: () => unknown }> = []
+type TerminalInputHandler = (data: string) => { consume?: boolean } | undefined
+type CustomComponent = { handleInput?(data: string): void }
+const startupHarnesses: Array<{ shutdown: () => unknown; settle: () => Promise<void> }> = []
+
+function theme(): Theme {
+	return {
+		fg: vi.fn((_color: string, text: string) => text),
+		bg: vi.fn((_color: string, text: string) => text),
+		bold: vi.fn((text: string) => text),
+		getFgAnsi: vi.fn(),
+		getBgAnsi: vi.fn(),
+		fgColors: {},
+		bgColors: {},
+		mode: "dark",
+		preproc: vi.fn(),
+		extensions: {},
+	} as unknown as Theme
+}
 
 function createHarness(options: {
 	rawArgs?: string[]
 	nonInteractiveMode?: boolean
 	stdinIsTTY?: boolean
 	stdoutIsTTY?: boolean
+	configPath: string
+	now: () => Date
+	startFerment?: ReturnType<typeof vi.fn>
 }) {
 	const handlers = new Map<string, SessionStartHandler>()
 	const api = {
@@ -20,8 +44,49 @@ function createHarness(options: {
 		}),
 	} as unknown as ExtensionAPI
 	const tui = { requestRender: vi.fn() } as unknown as TUI
+	let activeComponent: CustomComponent | undefined
+	let inputHandler: TerminalInputHandler | undefined
+	const unsubscribe = vi.fn()
+	let storedEditorFactory: unknown
 	const ui = {
-		setWidget: vi.fn(),
+		setWidget: vi.fn((_: string, content: unknown) => {
+			if (typeof content === "function") {
+				activeComponent = content(tui, theme()) as CustomComponent
+			} else {
+				activeComponent = undefined
+			}
+		}),
+		onTerminalInput: vi.fn((handler: TerminalInputHandler) => {
+			inputHandler = handler
+			return unsubscribe
+		}),
+		getEditorComponent: vi.fn(() => storedEditorFactory),
+		setEditorComponent: vi.fn((factory: unknown) => {
+			storedEditorFactory = factory
+		}),
+		custom: vi.fn((factory: (...args: unknown[]) => CustomComponent | Promise<CustomComponent>) => {
+			return new Promise((resolve, reject) => {
+				let doneCalled = false
+				const done = (result: unknown) => {
+					if (doneCalled) return
+					doneCalled = true
+					activeComponent = undefined
+					resolve(result)
+				}
+				try {
+					const content = factory(tui, theme(), {}, done)
+					if (content && typeof (content as Promise<CustomComponent>).then === "function") {
+						;(content as Promise<CustomComponent>).then((component) => {
+							if (!doneCalled) activeComponent = component
+						}, reject)
+					} else {
+						activeComponent = content as CustomComponent
+					}
+				} catch (err) {
+					reject(err)
+				}
+			})
+		}),
 		notify: vi.fn(),
 	}
 	const ctx = { hasUI: true, ui }
@@ -30,6 +95,9 @@ function createHarness(options: {
 		nonInteractiveMode: options.nonInteractiveMode ?? false,
 		stdinIsTTY: options.stdinIsTTY ?? true,
 		stdoutIsTTY: options.stdoutIsTTY ?? true,
+		configPath: options.configPath,
+		now: options.now,
+		startFerment: options.startFerment,
 	})
 
 	extension(api)
@@ -39,56 +107,122 @@ function createHarness(options: {
 		ctx,
 		ui,
 		tui,
+		unsubscribe,
 		start: () => handlers.get("session_start")?.({ reason: "startup" }, ctx),
 		shutdown: () => handlers.get("session_shutdown")?.({ reason: "quit" }, ctx),
+		input: (data: string) => inputHandler?.(data) ?? activeComponent?.handleInput?.(data),
+		activeComponent: () => activeComponent,
+		settle: async () => {
+			for (let i = 0; i < 4; i += 1) await Promise.resolve()
+		},
 	}
 	startupHarnesses.push(harness)
 	return harness
 }
 
 describe("session mode startup integration", () => {
-	afterEach(() => {
-		for (const harness of startupHarnesses.splice(0)) {
-			harness.shutdown()
-		}
-		globalTipRegistry.clear()
+	let tempDir: string
+	let configPath: string
+	const now = () => new Date("2026-05-19T09:30:00.000Z")
+
+	beforeEach(() => {
+		tempDir = mkdtempSync(join(tmpdir(), "kimchi-session-mode-startup-"))
+		configPath = join(tempDir, "config.json")
 	})
 
-	it("does not mount any widget on the first eligible interactive startup", async () => {
-		const harness = createHarness({})
+	afterEach(async () => {
+		for (const harness of startupHarnesses.splice(0)) {
+			harness.shutdown()
+			await harness.settle()
+		}
+		globalTipRegistry.clear()
+		rmSync(tempDir, { recursive: true, force: true })
+	})
+
+	it("mounts the picker on the first eligible interactive startup", async () => {
+		const harness = createHarness({ configPath, now })
+
+		await harness.start()
+
+		expect(harness.ui.setWidget).toHaveBeenCalled()
+		expect(harness.ui.onTerminalInput).toHaveBeenCalled()
+	})
+
+	it("skips returning launches once the dialog has been seen", async () => {
+		writeSessionModeWizardSeenAt("2026-05-19T08:00:00.000Z", configPath)
+		const harness = createHarness({ configPath, now })
 
 		await harness.start()
 
 		expect(harness.ui.setWidget).not.toHaveBeenCalled()
+		expect(harness.ui.onTerminalInput).not.toHaveBeenCalled()
 	})
 
 	it("skips launches when the session mode dialog has been hidden", async () => {
-		const harness = createHarness({})
+		writeSessionModeWizardSeenAt("2026-05-19T08:00:00.000Z", configPath)
+		writeHideSessionModeDialog(true, configPath)
+		const harness = createHarness({ configPath, now })
 
 		await harness.start()
 
 		expect(harness.ui.setWidget).not.toHaveBeenCalled()
+		expect(harness.ui.onTerminalInput).not.toHaveBeenCalled()
+		expect(harness.ui.custom).not.toHaveBeenCalled()
 	})
 
 	it("treats an explicit prompt launch as Default without mounting the picker", async () => {
-		const harness = createHarness({ rawArgs: ["fix tests"] })
+		const harness = createHarness({ rawArgs: ["fix tests"], configPath, now })
 
 		await harness.start()
 
+		const raw = JSON.parse(readFileSync(configPath, "utf-8"))
+		expect(raw.onboarding.sessionModeWizardSeenAt).toBe("2026-05-19T09:30:00.000Z")
 		expect(harness.ui.setWidget).not.toHaveBeenCalled()
+		expect(harness.ui.custom).not.toHaveBeenCalled()
 	})
 
 	it("stays silent for automation and non-interactive launches", async () => {
-		const automation = createHarness({ rawArgs: ["--mode", "json"] })
+		const automation = createHarness({ rawArgs: ["--mode", "json"], configPath, now })
 		await automation.start()
 		expect(automation.ui.setWidget).not.toHaveBeenCalled()
+		expect(existsSync(configPath)).toBe(false)
 
-		const acp = createHarness({ rawArgs: ["--mode", "acp"], nonInteractiveMode: true })
+		const acp = createHarness({ rawArgs: ["--mode", "acp"], nonInteractiveMode: true, configPath, now })
 		await acp.start()
 		expect(acp.ui.setWidget).not.toHaveBeenCalled()
+		expect(existsSync(configPath)).toBe(false)
 
-		const piped = createHarness({ stdinIsTTY: false })
+		const piped = createHarness({ stdinIsTTY: false, configPath, now })
 		await piped.start()
 		expect(piped.ui.setWidget).not.toHaveBeenCalled()
+		expect(existsSync(configPath)).toBe(false)
+	})
+
+	it("choosing Default marks seen without starting Ferment", async () => {
+		const startFerment = vi.fn()
+		const harness = createHarness({ configPath, now, startFerment })
+		await harness.start()
+
+		harness.input("\x1b[B")
+		harness.input("\r")
+		await harness.settle()
+
+		const raw = JSON.parse(readFileSync(configPath, "utf-8"))
+		expect(raw.onboarding.sessionModeWizardSeenAt).toBe("2026-05-19T09:30:00.000Z")
+		expect(startFerment).not.toHaveBeenCalled()
+		expect(harness.activeComponent()).toBeUndefined()
+	})
+
+	it("choosing Ferment starts the shared interactive Ferment entry", async () => {
+		const startFerment = vi.fn()
+		const harness = createHarness({ configPath, now, startFerment })
+		await harness.start()
+
+		harness.input("\r")
+		await harness.settle()
+
+		const raw = JSON.parse(readFileSync(configPath, "utf-8"))
+		expect(raw.onboarding.sessionModeWizardSeenAt).toBe("2026-05-19T09:30:00.000Z")
+		expect(startFerment).toHaveBeenCalledWith({ pi: harness.api, ctx: harness.ctx })
 	})
 })

--- a/src/extensions/onboarding/session-mode-startup.ts
+++ b/src/extensions/onboarding/session-mode-startup.ts
@@ -1,4 +1,5 @@
-import type { ExtensionFactory } from "@earendil-works/pi-coding-agent"
+import type { ExtensionAPI, ExtensionContext, ExtensionFactory } from "@earendil-works/pi-coding-agent"
+import { startInteractiveFerment } from "../ferment/commands.js"
 import sessionModeOnboardingExtension, { buildSessionModeLaunchContext } from "./session-mode.js"
 
 export interface SessionModeStartupOptions {
@@ -6,14 +7,28 @@ export interface SessionModeStartupOptions {
 	nonInteractiveMode: boolean
 	stdinIsTTY: boolean
 	stdoutIsTTY: boolean
+	configPath?: string
+	now?: () => Date
+	startFerment?: (params: { pi: ExtensionAPI; ctx: ExtensionContext }) => void | Promise<void>
 }
 
 export function createSessionModeOnboardingForStartup(options: SessionModeStartupOptions): ExtensionFactory {
+	const startFerment =
+		options.startFerment ??
+		(({ pi, ctx }) => {
+			return startInteractiveFerment({ pi, ctx })
+		})
+
 	return sessionModeOnboardingExtension({
 		launchContext: buildSessionModeLaunchContext(options.rawArgs, {
 			nonInteractiveMode: options.nonInteractiveMode,
 			stdinIsTTY: options.stdinIsTTY,
 			stdoutIsTTY: options.stdoutIsTTY,
 		}),
+		configPath: options.configPath,
+		now: options.now,
+		onOutcome: (outcome, ctx, pi) => {
+			if (outcome === "ferment") return startFerment({ pi, ctx })
+		},
 	})
 }

--- a/src/extensions/onboarding/session-mode.test.ts
+++ b/src/extensions/onboarding/session-mode.test.ts
@@ -71,7 +71,7 @@ function createExtensionHarness(options: { deferCustomFactory?: boolean; initial
 	const unsubscribe = vi.fn()
 	let storedEditorFactory: unknown = options.initialEditorFactory
 	const ui = {
-		setWidget: vi.fn((_: string, content: unknown) => {
+		setWidget: vi.fn((_key: string, content: unknown, _options?: unknown) => {
 			if (typeof content === "function") {
 				activeComponent = content(tui, theme()) as CustomComponent
 			} else {
@@ -404,6 +404,29 @@ describe("session-mode onboarding persistence", () => {
 		const raw = JSON.parse(readFileSync(configPath, "utf-8"))
 		expect(raw.onboarding.sessionModeWizardSeenAt).toBe("2026-05-19T09:30:00.000Z")
 		expect(harness.activeComponent()).toBeUndefined()
+	})
+
+	it("preserves picker selection when pi-tui re-invokes the widget factory", async () => {
+		const harness = createExtensionHarness()
+
+		sessionModeOnboardingExtension({ launchContext: launch([]), configPath, now })(
+			harness.api as unknown as Parameters<ReturnType<typeof sessionModeOnboardingExtension>>[0],
+		)
+
+		await harness.start()
+		harness.input("\x1b[B")
+		const before = harness.activeComponent() as { getState(): { selectedIndex: number } } | undefined
+		expect(before?.getState().selectedIndex).toBe(1)
+
+		// Simulate a resize / theme swap that re-invokes the most recent
+		// widget factory. The new component must start from the existing
+		// selection, not reset to 0.
+		const calls = harness.ui.setWidget.mock.calls
+		const lastFactory = calls[calls.length - 1][1] as (...args: unknown[]) => unknown
+		harness.ui.setWidget("kimchi-session-mode-onboarding", lastFactory, calls[calls.length - 1][2])
+		const after = harness.activeComponent() as { getState(): { selectedIndex: number } } | undefined
+		expect(after).not.toBe(before)
+		expect(after?.getState().selectedIndex).toBe(1)
 	})
 
 	it("shutdown cleans up the picker", async () => {

--- a/src/extensions/onboarding/session-mode.test.ts
+++ b/src/extensions/onboarding/session-mode.test.ts
@@ -1,16 +1,149 @@
-import { describe, expect, it } from "vitest"
-import {
-	type SessionModeLaunchContext,
-	type SessionModeOnboardingDecision,
+import { existsSync, mkdtempSync, readFileSync, rmSync } from "node:fs"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
+import type { Theme } from "@earendil-works/pi-coding-agent"
+import type { TUI } from "@earendil-works/pi-tui"
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
+import { globalTipRegistry } from "../tips/registry.js"
+import sessionModeOnboardingExtension, {
 	buildSessionModeLaunchContext,
 	decideSessionModeOnboarding,
+	recordSessionModeWizardOutcome,
+	type SessionModeLaunchContext,
+	type SessionModeOnboardingDecision,
 } from "./session-mode.js"
 
 const interactive = { stdinIsTTY: true, stdoutIsTTY: true, nonInteractiveMode: false }
 
+function theme(): Theme {
+	return {
+		fg: vi.fn((_color: string, text: string) => text),
+		bg: vi.fn((_color: string, text: string) => text),
+		bold: vi.fn((text: string) => text),
+		getFgAnsi: vi.fn(),
+		getBgAnsi: vi.fn(),
+		fgColors: {},
+		bgColors: {},
+		mode: "dark",
+		preproc: vi.fn(),
+		extensions: {},
+	} as unknown as Theme
+}
+
 function launch(rawArgs: string[], overrides: Partial<typeof interactive> = {}): SessionModeLaunchContext {
 	return buildSessionModeLaunchContext(rawArgs, { ...interactive, ...overrides })
 }
+
+function decide(
+	rawArgs: string[],
+	overrides: Partial<Parameters<typeof decideSessionModeOnboarding>[0]> = {},
+): SessionModeOnboardingDecision {
+	return decideSessionModeOnboarding({
+		launchContext: launch(rawArgs),
+		hasUI: true,
+		sessionStartReason: "startup",
+		...overrides,
+	})
+}
+
+type SessionStartHandler = (event: unknown, ctx: unknown) => unknown
+type TerminalInputHandler = (data: string) => { consume?: boolean } | undefined
+type CustomComponent = { handleInput?(data: string): void; render?(width: number): string[] }
+const extensionHarnesses: Array<{ shutdown: () => unknown; settle: () => Promise<void> }> = []
+
+function createExtensionHarness(options: { deferCustomFactory?: boolean; initialEditorFactory?: unknown } = {}) {
+	const handlers = new Map<string, SessionStartHandler>()
+	const api = {
+		on: vi.fn((event: string, handler: SessionStartHandler) => {
+			handlers.set(event, handler)
+		}),
+	}
+	let overlayActive = false
+	const setOverlay = (active: boolean) => {
+		overlayActive = active
+	}
+	const tui = {
+		requestRender: vi.fn(),
+		hasOverlay: vi.fn(() => overlayActive),
+	} as unknown as TUI
+	let activeComponent: CustomComponent | undefined
+	let inputHandler: TerminalInputHandler | undefined
+	const unsubscribe = vi.fn()
+	let storedEditorFactory: unknown = options.initialEditorFactory
+	const ui = {
+		setWidget: vi.fn((_: string, content: unknown) => {
+			if (typeof content === "function") {
+				activeComponent = content(tui, theme()) as CustomComponent
+			} else {
+				activeComponent = undefined
+			}
+		}),
+		onTerminalInput: vi.fn((handler: TerminalInputHandler) => {
+			inputHandler = handler
+			return unsubscribe
+		}),
+		getEditorComponent: vi.fn(() => storedEditorFactory),
+		setEditorComponent: vi.fn((factory: unknown) => {
+			storedEditorFactory = factory
+		}),
+		custom: vi.fn((factory: (...args: unknown[]) => CustomComponent | Promise<CustomComponent>) => {
+			return new Promise((resolve, reject) => {
+				let doneCalled = false
+				const done = (result: unknown) => {
+					if (doneCalled) return
+					doneCalled = true
+					activeComponent = undefined
+					resolve(result)
+				}
+				const mount = () => {
+					const content = factory(tui, theme(), {}, done)
+					if (content && typeof (content as Promise<CustomComponent>).then === "function") {
+						;(content as Promise<CustomComponent>).then((component) => {
+							if (!doneCalled) activeComponent = component
+						}, reject)
+					} else if (!doneCalled) {
+						activeComponent = content as CustomComponent
+					}
+				}
+				try {
+					if (options.deferCustomFactory === true) {
+						void Promise.resolve().then(mount).catch(reject)
+					} else {
+						mount()
+					}
+				} catch (err) {
+					reject(err)
+				}
+			})
+		}),
+		notify: vi.fn(),
+	}
+	const ctx = { hasUI: true, ui }
+	const harness = {
+		api,
+		ui,
+		tui,
+		unsubscribe,
+		start: () => handlers.get("session_start")?.({ reason: "startup" }, ctx),
+		shutdown: () => handlers.get("session_shutdown")?.({ reason: "quit" }, ctx),
+		input: (data: string) => inputHandler?.(data) ?? activeComponent?.handleInput?.(data),
+		activeComponent: () => activeComponent,
+		setOverlay,
+		settle: async () => {
+			for (let i = 0; i < 4; i += 1) await Promise.resolve()
+		},
+	}
+	extensionHarnesses.push(harness)
+	return harness
+}
+
+afterEach(async () => {
+	for (const harness of extensionHarnesses.splice(0)) {
+		harness.shutdown()
+		await harness.settle()
+	}
+	globalTipRegistry.clear()
+})
 
 describe("buildSessionModeLaunchContext", () => {
 	it("classifies a plain interactive launch as eligible launch context", () => {
@@ -56,24 +189,23 @@ describe("buildSessionModeLaunchContext", () => {
 })
 
 describe("decideSessionModeOnboarding", () => {
-	it("skips on plain interactive startup", () => {
-		expect(
-			decideSessionModeOnboarding({
-				launchContext: launch([]),
-				hasUI: true,
-				sessionStartReason: "startup",
-			}),
-		).toEqual({ action: "skip", reason: "default-chat" })
+	it("shows on first plain interactive startup", () => {
+		expect(decide([])).toEqual({ action: "show", reason: "eligible" })
+	})
+
+	it("skips when the session mode dialog is hidden", () => {
+		expect(decide([], { hideSessionModeDialog: true })).toEqual({
+			action: "skip",
+			reason: "hidden",
+		})
+	})
+
+	it("skips returning launches once the dialog has been seen", () => {
+		expect(decide([], { seenAt: "2026-05-19T08:00:00.000Z" })).toEqual({ action: "skip", reason: "already-seen" })
 	})
 
 	it("marks an explicit prompt launch as Default-session intent", () => {
-		expect(
-			decideSessionModeOnboarding({
-				launchContext: launch(["fix tests"]),
-				hasUI: true,
-				sessionStartReason: "startup",
-			}),
-		).toEqual({ action: "skip", reason: "explicit-default-session" })
+		expect(decide(["fix tests"])).toEqual({ action: "skip-and-mark-seen", reason: "explicit-default-session" })
 	})
 
 	it.each([
@@ -81,42 +213,265 @@ describe("decideSessionModeOnboarding", () => {
 		{ args: ["--mode", "json"], expected: { action: "skip", reason: "automation-mode" } },
 		{ args: ["--continue"], expected: { action: "skip", reason: "explicit-session" } },
 	])("skips for $args", ({ args, expected }) => {
-		expect(
-			decideSessionModeOnboarding({
-				launchContext: launch(args),
-				hasUI: true,
-				sessionStartReason: "startup",
-			}),
-		).toEqual(expected as SessionModeOnboardingDecision)
+		expect(decide(args)).toEqual(expected as SessionModeOnboardingDecision)
 	})
 
 	it("skips without marking when UI is unavailable", () => {
-		expect(
-			decideSessionModeOnboarding({
-				launchContext: launch(["fix tests"]),
-				hasUI: false,
-				sessionStartReason: "startup",
-			}),
-		).toEqual({ action: "skip", reason: "not-interactive-tty" })
+		expect(decide(["fix tests"], { hasUI: false })).toEqual({ action: "skip", reason: "not-interactive-tty" })
 	})
 
 	it("skips without marking in piped stdin mode", () => {
-		expect(
-			decideSessionModeOnboarding({
-				launchContext: launch(["fix tests"], { stdinIsTTY: false }),
-				hasUI: true,
-				sessionStartReason: "startup",
-			}),
-		).toEqual({ action: "skip", reason: "not-interactive-tty" })
+		expect(decide(["fix tests"], { launchContext: launch(["fix tests"], { stdinIsTTY: false }) })).toEqual({
+			action: "skip",
+			reason: "not-interactive-tty",
+		})
 	})
 
 	it("skips non-startup session_start events", () => {
-		expect(
-			decideSessionModeOnboarding({
-				launchContext: launch([]),
-				hasUI: true,
-				sessionStartReason: "resume",
-			}),
-		).toEqual({ action: "skip", reason: "explicit-session" })
+		expect(decide([], { sessionStartReason: "resume" })).toEqual({ action: "skip", reason: "explicit-session" })
+	})
+})
+
+describe("session-mode onboarding persistence", () => {
+	let tempDir: string
+	let configPath: string
+	const now = () => new Date("2026-05-19T09:30:00.000Z")
+
+	beforeEach(() => {
+		tempDir = mkdtempSync(join(tmpdir(), "kimchi-session-mode-onboarding-"))
+		configPath = join(tempDir, "config.json")
+	})
+
+	afterEach(() => {
+		rmSync(tempDir, { recursive: true, force: true })
+	})
+
+	it.each(["default", "ferment"] as const)("marks %s choices as seen", (outcome) => {
+		const seenAt = recordSessionModeWizardOutcome(outcome, { configPath, now })
+		const raw = JSON.parse(readFileSync(configPath, "utf-8"))
+
+		expect(seenAt).toBe("2026-05-19T09:30:00.000Z")
+		expect(raw.onboarding.sessionModeWizardSeenAt).toBe("2026-05-19T09:30:00.000Z")
+	})
+
+	it("persists the hide setting when the checkbox is selected", () => {
+		const seenAt = recordSessionModeWizardOutcome("default", { configPath, now, hideDialog: true })
+		const raw = JSON.parse(readFileSync(configPath, "utf-8"))
+
+		expect(seenAt).toBe("2026-05-19T09:30:00.000Z")
+		expect(raw.onboarding.sessionModeWizardSeenAt).toBe("2026-05-19T09:30:00.000Z")
+		expect(raw.onboarding.hideSessionModeDialog).toBe(true)
+	})
+
+	it("does not mark cancellation as seen", () => {
+		const seenAt = recordSessionModeWizardOutcome("cancelled", { configPath, now })
+
+		expect(seenAt).toBeUndefined()
+		expect(existsSync(configPath)).toBe(false)
+	})
+
+	it("extension marks explicit Default-session launches on startup", async () => {
+		const harness = createExtensionHarness()
+		sessionModeOnboardingExtension({ launchContext: launch(["fix tests"]), configPath, now })(
+			harness.api as unknown as Parameters<ReturnType<typeof sessionModeOnboardingExtension>>[0],
+		)
+
+		await harness.start()
+
+		const raw = JSON.parse(readFileSync(configPath, "utf-8"))
+		expect(raw.onboarding.sessionModeWizardSeenAt).toBe("2026-05-19T09:30:00.000Z")
+	})
+
+	it("extension mounts the picker and records Default selection", async () => {
+		const harness = createExtensionHarness()
+
+		sessionModeOnboardingExtension({ launchContext: launch([]), configPath, now })(
+			harness.api as unknown as Parameters<ReturnType<typeof sessionModeOnboardingExtension>>[0],
+		)
+
+		await harness.start()
+		expect(harness.ui.setWidget).toHaveBeenCalled()
+		expect(harness.ui.onTerminalInput).toHaveBeenCalled()
+		let raw = JSON.parse(readFileSync(configPath, "utf-8"))
+		expect(raw.onboarding.sessionModeWizardSeenAt).toBe("2026-05-19T09:30:00.000Z")
+
+		harness.input("\x1b[B")
+		expect(harness.tui.requestRender).toHaveBeenCalled()
+		harness.input("\r")
+		await harness.settle()
+
+		raw = JSON.parse(readFileSync(configPath, "utf-8"))
+		expect(raw.onboarding.sessionModeWizardSeenAt).toBe("2026-05-19T09:30:00.000Z")
+		expect(harness.activeComponent()).toBeUndefined()
+	})
+
+	it("swaps the editor immediately when no overlay is active at mount", async () => {
+		const upstreamFactory = vi.fn()
+		const harness = createExtensionHarness({ initialEditorFactory: upstreamFactory })
+
+		sessionModeOnboardingExtension({ launchContext: launch([]), configPath, now })(
+			harness.api as unknown as Parameters<ReturnType<typeof sessionModeOnboardingExtension>>[0],
+		)
+
+		await harness.start()
+
+		expect(harness.ui.getEditorComponent).toHaveBeenCalledTimes(1)
+		expect(harness.ui.setEditorComponent).toHaveBeenCalledTimes(1)
+		expect(harness.ui.setEditorComponent).not.toHaveBeenCalledWith(upstreamFactory)
+	})
+
+	it("defers the editor swap while an overlay is up so the overlay keeps input focus", async () => {
+		// Swapping the editor while an overlay is up steals pi-tui's input
+		// routing and prevents overlay dismissal — keep the editor visible
+		// (even if visually noisy) until the overlay clears.
+		const upstreamFactory = vi.fn()
+		const harness = createExtensionHarness({ initialEditorFactory: upstreamFactory })
+		harness.setOverlay(true)
+
+		sessionModeOnboardingExtension({ launchContext: launch([]), configPath, now })(
+			harness.api as unknown as Parameters<ReturnType<typeof sessionModeOnboardingExtension>>[0],
+		)
+
+		await harness.start()
+
+		expect(harness.ui.setEditorComponent).not.toHaveBeenCalled()
+		expect(harness.activeComponent()).toBeDefined()
+	})
+
+	it("swaps the editor on the first input after the overlay clears, then restores on cleanup", async () => {
+		const upstreamFactory = vi.fn()
+		const harness = createExtensionHarness({ initialEditorFactory: upstreamFactory })
+		harness.setOverlay(true)
+
+		sessionModeOnboardingExtension({ launchContext: launch([]), configPath, now })(
+			harness.api as unknown as Parameters<ReturnType<typeof sessionModeOnboardingExtension>>[0],
+		)
+
+		await harness.start()
+		expect(harness.ui.setEditorComponent).not.toHaveBeenCalled()
+
+		harness.setOverlay(false)
+		harness.input("\x1b[B")
+
+		expect(harness.ui.setEditorComponent).toHaveBeenCalledTimes(1)
+		const swappedFactory = harness.ui.setEditorComponent.mock.calls[0][0]
+		expect(swappedFactory).not.toBe(upstreamFactory)
+
+		harness.shutdown()
+		await harness.settle()
+		expect(harness.ui.setEditorComponent).toHaveBeenLastCalledWith(upstreamFactory)
+	})
+
+	it("hides the editor on the same keystroke that dismisses the overlay (deferred via setTimeout)", async () => {
+		vi.useFakeTimers()
+		try {
+			const upstreamFactory = vi.fn()
+			const harness = createExtensionHarness({ initialEditorFactory: upstreamFactory })
+			harness.setOverlay(true)
+
+			sessionModeOnboardingExtension({ launchContext: launch([]), configPath, now })(
+				harness.api as unknown as Parameters<ReturnType<typeof sessionModeOnboardingExtension>>[0],
+			)
+
+			await harness.start()
+			expect(harness.ui.setEditorComponent).not.toHaveBeenCalled()
+
+			// Simulate the dismiss keystroke: our handler fires while overlay is
+			// still up (schedules setTimeout retry), then overlay flips off as a
+			// synchronous side effect of the same key.
+			harness.input("x")
+			harness.setOverlay(false)
+			expect(harness.ui.setEditorComponent).not.toHaveBeenCalled()
+
+			vi.runAllTimers()
+			expect(harness.ui.setEditorComponent).toHaveBeenCalledTimes(1)
+		} finally {
+			vi.useRealTimers()
+		}
+	})
+
+	it("extension cancellation clears the picker after recording that the first dialog was shown", async () => {
+		const harness = createExtensionHarness()
+
+		sessionModeOnboardingExtension({ launchContext: launch([]), configPath, now })(
+			harness.api as unknown as Parameters<ReturnType<typeof sessionModeOnboardingExtension>>[0],
+		)
+
+		await harness.start()
+		harness.input("\x1b")
+		await harness.settle()
+
+		const raw = JSON.parse(readFileSync(configPath, "utf-8"))
+		expect(raw.onboarding.sessionModeWizardSeenAt).toBe("2026-05-19T09:30:00.000Z")
+		expect(harness.activeComponent()).toBeUndefined()
+	})
+
+	it("shutdown cleans up the picker", async () => {
+		const harness = createExtensionHarness()
+
+		sessionModeOnboardingExtension({ launchContext: launch([]), configPath, now })(
+			harness.api as unknown as Parameters<ReturnType<typeof sessionModeOnboardingExtension>>[0],
+		)
+
+		await harness.start()
+		expect(harness.activeComponent()).toBeDefined()
+		harness.shutdown()
+		await harness.settle()
+
+		expect(harness.activeComponent()).toBeUndefined()
+	})
+
+	it("extension exposes Ferment selection through the outcome callback", async () => {
+		const harness = createExtensionHarness()
+		const onOutcome = vi.fn()
+
+		sessionModeOnboardingExtension({ launchContext: launch([]), configPath, now, onOutcome })(
+			harness.api as unknown as Parameters<ReturnType<typeof sessionModeOnboardingExtension>>[0],
+		)
+
+		await harness.start()
+		harness.input("\r")
+		await harness.settle()
+
+		const raw = JSON.parse(readFileSync(configPath, "utf-8"))
+		expect(raw.onboarding.sessionModeWizardSeenAt).toBe("2026-05-19T09:30:00.000Z")
+		expect(onOutcome).toHaveBeenCalledWith("ferment", expect.objectContaining({ ui: harness.ui }), harness.api)
+	})
+
+	it("reports synchronous errors from the outcome callback", async () => {
+		const harness = createExtensionHarness()
+		const onOutcome = vi.fn(() => {
+			throw new Error("sync boom")
+		})
+
+		sessionModeOnboardingExtension({ launchContext: launch([]), configPath, now, onOutcome })(
+			harness.api as unknown as Parameters<ReturnType<typeof sessionModeOnboardingExtension>>[0],
+		)
+
+		await harness.start()
+		harness.input("\r")
+		await harness.settle()
+
+		expect(onOutcome).toHaveBeenCalledWith("ferment", expect.objectContaining({ ui: harness.ui }), harness.api)
+		expect(harness.ui.notify).toHaveBeenCalledWith("Session mode startup failed: sync boom", "warning")
+	})
+
+	it("extension exposes 'just chat and code' selection through the outcome callback", async () => {
+		const harness = createExtensionHarness()
+		const onOutcome = vi.fn()
+
+		sessionModeOnboardingExtension({ launchContext: launch([]), configPath, now, onOutcome })(
+			harness.api as unknown as Parameters<ReturnType<typeof sessionModeOnboardingExtension>>[0],
+		)
+
+		await harness.start()
+		harness.input("\x1b[B")
+		harness.input("\r")
+		await harness.settle()
+
+		const raw = JSON.parse(readFileSync(configPath, "utf-8"))
+		expect(raw.onboarding.hideSessionModeDialog).toBeUndefined()
+		expect(harness.activeComponent()).toBeUndefined()
+		expect(onOutcome).toHaveBeenCalledWith("default", expect.objectContaining({ ui: harness.ui }), harness.api)
 	})
 })

--- a/src/extensions/onboarding/session-mode.test.ts
+++ b/src/extensions/onboarding/session-mode.test.ts
@@ -254,15 +254,6 @@ describe("session-mode onboarding persistence", () => {
 		expect(raw.onboarding.sessionModeWizardSeenAt).toBe("2026-05-19T09:30:00.000Z")
 	})
 
-	it("persists the hide setting when the checkbox is selected", () => {
-		const seenAt = recordSessionModeWizardOutcome("default", { configPath, now, hideDialog: true })
-		const raw = JSON.parse(readFileSync(configPath, "utf-8"))
-
-		expect(seenAt).toBe("2026-05-19T09:30:00.000Z")
-		expect(raw.onboarding.sessionModeWizardSeenAt).toBe("2026-05-19T09:30:00.000Z")
-		expect(raw.onboarding.hideSessionModeDialog).toBe(true)
-	})
-
 	it("does not mark cancellation as seen", () => {
 		const seenAt = recordSessionModeWizardOutcome("cancelled", { configPath, now })
 
@@ -492,8 +483,6 @@ describe("session-mode onboarding persistence", () => {
 		harness.input("\r")
 		await harness.settle()
 
-		const raw = JSON.parse(readFileSync(configPath, "utf-8"))
-		expect(raw.onboarding.hideSessionModeDialog).toBeUndefined()
 		expect(harness.activeComponent()).toBeUndefined()
 		expect(onOutcome).toHaveBeenCalledWith("default", expect.objectContaining({ ui: harness.ui }), harness.api)
 	})

--- a/src/extensions/onboarding/session-mode.ts
+++ b/src/extensions/onboarding/session-mode.ts
@@ -2,12 +2,7 @@ import type { ExtensionAPI, ExtensionContext, SessionStartEvent } from "@earendi
 
 type EditorFactory = ReturnType<ExtensionContext["ui"]["getEditorComponent"]>
 import { getCliModeArg, isPreDispatchValueFlag } from "../../cli-args.js"
-import {
-	readHideSessionModeDialog,
-	readSessionModeWizardSeenAt,
-	writeHideSessionModeDialog,
-	writeSessionModeWizardSeenAt,
-} from "../../config.js"
+import { readHideSessionModeDialog, readSessionModeWizardSeenAt, writeSessionModeWizardSeenAt } from "../../config.js"
 
 import { setTipWidgetLocation } from "../tips/index.js"
 import { setSessionModeOnboardingFooterSuppressed } from "../ui.js"
@@ -205,11 +200,7 @@ function showSessionModeWizard(
 		finished = true
 		try {
 			if (result !== "cancelled") {
-				recordSessionModeWizardOutcome(result.choice, {
-					configPath: options.configPath,
-					now: options.now,
-					hideDialog: result.hideDialog,
-				})
+				recordSessionModeWizardOutcome(result, { configPath: options.configPath, now: options.now })
 			}
 		} catch (err) {
 			cleanup()
@@ -222,7 +213,7 @@ function showSessionModeWizard(
 		cleanup()
 		if (result !== "cancelled" && options.onOutcome) {
 			Promise.resolve()
-				.then(() => options.onOutcome?.(result.choice, ctx, pi))
+				.then(() => options.onOutcome?.(result, ctx, pi))
 				.catch((err: unknown) => {
 					ctx.ui.notify(`Session mode startup failed: ${err instanceof Error ? err.message : String(err)}`, "warning")
 				})
@@ -308,12 +299,10 @@ export function decideSessionModeOnboarding(input: SessionModeOnboardingInput): 
 
 export function recordSessionModeWizardOutcome(
 	outcome: SessionModeWizardOutcome,
-	options?: { configPath?: string; now?: () => Date; hideDialog?: boolean },
+	options?: { configPath?: string; now?: () => Date },
 ): string | undefined {
 	if (outcome === "cancelled") return undefined
-	const seenAt = markSessionModeWizardSeen(options)
-	if (options?.hideDialog === true) writeHideSessionModeDialog(true, options.configPath)
-	return seenAt
+	return markSessionModeWizardSeen(options)
 }
 
 export function markSessionModeWizardSeen(options?: { configPath?: string; now?: () => Date }): string {

--- a/src/extensions/onboarding/session-mode.ts
+++ b/src/extensions/onboarding/session-mode.ts
@@ -1,15 +1,33 @@
-import type { ExtensionAPI, SessionStartEvent } from "@earendil-works/pi-coding-agent"
-import { getCliModeArg, isPreDispatchValueFlag } from "../../cli-args.js"
+import type { ExtensionAPI, ExtensionContext, SessionStartEvent } from "@earendil-works/pi-coding-agent"
 
-export type SessionModeOnboardingAction = "skip"
+type EditorFactory = ReturnType<ExtensionContext["ui"]["getEditorComponent"]>
+import { getCliModeArg, isPreDispatchValueFlag } from "../../cli-args.js"
+import {
+	readHideSessionModeDialog,
+	readSessionModeWizardSeenAt,
+	writeHideSessionModeDialog,
+	writeSessionModeWizardSeenAt,
+} from "../../config.js"
+
+import { setTipWidgetLocation } from "../tips/index.js"
+import { setSessionModeOnboardingFooterSuppressed } from "../ui.js"
+import { NoOpPickerEditor } from "./picker-editor.js"
+import {
+	SessionModePickerComponent,
+	type SessionModePickerResult,
+	keyToSessionModePickerEvent,
+} from "./session-mode-picker.js"
+
+export type SessionModeOnboardingAction = "show" | "skip" | "skip-and-mark-seen"
 
 export type SessionModeOnboardingReason =
+	| "eligible"
 	| "hidden"
+	| "already-seen"
 	| "not-interactive-tty"
 	| "automation-mode"
 	| "explicit-session"
 	| "explicit-default-session"
-	| "default-chat"
 
 export interface SessionModeOnboardingDecision {
 	action: SessionModeOnboardingAction
@@ -33,12 +51,201 @@ export interface SessionModeLaunchContext {
 export interface SessionModeOnboardingInput {
 	launchContext: SessionModeLaunchContext
 	hasUI: boolean
+	seenAt?: string
+	hideSessionModeDialog?: boolean
 	sessionStartReason?: SessionStartEvent["reason"]
 }
 
-export default function sessionModeOnboardingExtension(_options: unknown): (pi: ExtensionAPI) => void {
+const SESSION_MODE_WIDGET_KEY = "kimchi-session-mode-onboarding"
+const SESSION_MODE_WIDGET_OPTIONS = { placement: "aboveEditor" } as const
+
+export type SessionModeWizardOutcome = "default" | "ferment" | "cancelled"
+
+export interface SessionModeOnboardingExtensionOptions {
+	launchContext: SessionModeLaunchContext
+	configPath?: string
+	now?: () => Date
+	onOutcome?: (
+		outcome: Extract<SessionModeWizardOutcome, "default" | "ferment">,
+		ctx: ExtensionContext,
+		pi: ExtensionAPI,
+	) => void | Promise<void>
+}
+
+export default function sessionModeOnboardingExtension(options: SessionModeOnboardingExtensionOptions) {
+	return (pi: ExtensionAPI) => {
+		let cleanupActiveWizard: (() => void) | undefined
+
+		pi.on("session_start", (event, ctx) => {
+			cleanupActiveWizard?.()
+			cleanupActiveWizard = undefined
+			const seenAt = readSessionModeWizardSeenAt(options.configPath)
+			const decision = decideSessionModeOnboarding({
+				launchContext: options.launchContext,
+				hasUI: ctx.hasUI,
+				seenAt,
+				hideSessionModeDialog: readHideSessionModeDialog(options.configPath),
+				sessionStartReason: event.reason,
+			})
+			if (decision.action === "skip-and-mark-seen") {
+				markSessionModeWizardSeen({ configPath: options.configPath, now: options.now })
+				return
+			}
+			if (decision.action === "show") {
+				// Reaching "show" means seenAt was undefined (already-seen short-circuits
+				// above), so this is the first run — mark seen immediately so a crash or
+				// kill before selection doesn't re-show the picker next time.
+				try {
+					markSessionModeWizardSeen({ configPath: options.configPath, now: options.now })
+				} catch (err) {
+					ctx.ui.notify(
+						`Could not save session mode onboarding state: ${err instanceof Error ? err.message : String(err)}`,
+						"warning",
+					)
+				}
+				cleanupActiveWizard = showSessionModeWizard(pi, ctx, options, () => {
+					cleanupActiveWizard = undefined
+				})
+			}
+		})
+
+		pi.on("session_shutdown", () => {
+			cleanupActiveWizard?.()
+			cleanupActiveWizard = undefined
+		})
+	}
+}
+
+function showSessionModeWizard(
+	pi: ExtensionAPI,
+	ctx: ExtensionContext,
+	options: SessionModeOnboardingExtensionOptions,
+	onCleanup: () => void,
+): () => void {
+	let finished = false
+	let activated = false
+	let unsubscribeInput: (() => void) | undefined
+	let restoreTips: (() => void) | undefined
+	let tuiRef: { hasOverlay(): boolean } | null = null
+	let component: SessionModePickerComponent | undefined
+	let editorSwapped = false
+	// Captured from getEditorComponent() right before we swap. ui.ts registers its
+	// session_start handler before ours (see cli.ts extension order), so by the
+	// time we read this, the upstream PromptEditor factory is already installed.
+	// We restore exactly this value on cleanup — passing undefined to
+	// setEditorComponent would drop to the library default instead.
+	let prevEditorFactory: EditorFactory | undefined
+
+	// Empty shim component mounted before activation. Renders nothing so the
+	// picker contributes zero visual footprint while we wait for any overlay
+	// (e.g. Mike's Shift+Enter terminal-compat warning) to clear. We still get
+	// the tui reference from setWidget's factory so we can poll hasOverlay().
+	const SHIM_COMPONENT = { render: () => [], invalidate: () => {} } as const
+
+	const activate = () => {
+		if (activated || finished) return
+		// pi-tui routes terminal input through the current editor. If we swap
+		// the editor (or mount a non-empty picker that consumes keys) while an
+		// overlay is up, the overlay loses its dismissal keys and becomes
+		// stuck. So we mount the picker + swap the editor atomically only once
+		// no overlay is present.
+		if (typeof tuiRef?.hasOverlay === "function" && tuiRef.hasOverlay()) return
+		activated = true
+		ctx.ui.setWidget(
+			SESSION_MODE_WIDGET_KEY,
+			(tui, theme) => {
+				tuiRef = tui as unknown as { hasOverlay(): boolean }
+				component = new SessionModePickerComponent(theme, finish, () => tui.requestRender())
+				return component
+			},
+			SESSION_MODE_WIDGET_OPTIONS,
+		)
+		prevEditorFactory = ctx.ui.getEditorComponent()
+		ctx.ui.setEditorComponent(() => new NoOpPickerEditor())
+		editorSwapped = true
+	}
+
+	const cleanup = () => {
+		unsubscribeInput?.()
+		unsubscribeInput = undefined
+		ctx.ui.setWidget(SESSION_MODE_WIDGET_KEY, undefined, SESSION_MODE_WIDGET_OPTIONS)
+		restoreTips?.()
+		restoreTips = undefined
+		setSessionModeOnboardingFooterSuppressed(false)
+		if (editorSwapped) {
+			ctx.ui.setEditorComponent(prevEditorFactory)
+			editorSwapped = false
+		}
+		onCleanup()
+	}
+
+	const finish = (result: SessionModePickerResult) => {
+		if (finished) return
+		finished = true
+		try {
+			if (result !== "cancelled") {
+				recordSessionModeWizardOutcome(result.choice, {
+					configPath: options.configPath,
+					now: options.now,
+					hideDialog: result.hideDialog,
+				})
+			}
+		} catch (err) {
+			cleanup()
+			ctx.ui.notify(
+				`Could not save session mode onboarding state: ${err instanceof Error ? err.message : String(err)}`,
+				"warning",
+			)
+			return
+		}
+		cleanup()
+		if (result !== "cancelled" && options.onOutcome) {
+			Promise.resolve()
+				.then(() => options.onOutcome?.(result.choice, ctx, pi))
+				.catch((err: unknown) => {
+					ctx.ui.notify(`Session mode startup failed: ${err instanceof Error ? err.message : String(err)}`, "warning")
+				})
+		}
+	}
+
+	restoreTips = setTipWidgetLocation("hidden")
+	setSessionModeOnboardingFooterSuppressed(true)
+	// Mount an invisible shim so we can capture the tui reference (needed for
+	// hasOverlay polling) without contributing any visual footprint. The shim
+	// is replaced by the real picker inside activate().
+	ctx.ui.setWidget(
+		SESSION_MODE_WIDGET_KEY,
+		(tui) => {
+			tuiRef = tui as unknown as { hasOverlay(): boolean }
+			// Defer the activation attempt to the next microtask so we don't
+			// recurse into setWidget from inside the factory call.
+			queueMicrotask(activate)
+			return SHIM_COMPONENT
+		},
+		SESSION_MODE_WIDGET_OPTIONS,
+	)
+	unsubscribeInput = ctx.ui.onTerminalInput((data) => {
+		if (typeof tuiRef?.hasOverlay === "function" && tuiRef.hasOverlay()) {
+			// The same keystroke that fires this handler may also dismiss the
+			// overlay (Mike's Shift+Enter warning dismisses on any key). Re-check
+			// on the next tick so the picker + editor swap happen as soon as the
+			// overlay clears — without requiring a second keypress.
+			if (!activated) setTimeout(activate, 0)
+			return undefined
+		}
+		if (!activated) activate()
+		const event = keyToSessionModePickerEvent(data)
+		if (event) {
+			component?.handleInput(data)
+			return { consume: true }
+		}
+		return undefined
+	})
+
 	return () => {
-		// No-op: the session-mode picker has been removed.
+		if (finished) return
+		finished = true
+		cleanup()
 	}
 }
 
@@ -57,6 +264,11 @@ export function buildSessionModeLaunchContext(
 }
 
 export function decideSessionModeOnboarding(input: SessionModeOnboardingInput): SessionModeOnboardingDecision {
+	if (input.hideSessionModeDialog) return { action: "skip", reason: "hidden" }
+	// Show-once semantics: once the picker has been displayed (sessionModeWizardSeenAt
+	// is written the moment the dialog mounts, even if the user cancels), never
+	// show it again on subsequent startups.
+	if (input.seenAt !== undefined) return { action: "skip", reason: "already-seen" }
 	if (input.sessionStartReason !== undefined && input.sessionStartReason !== "startup") {
 		return { action: "skip", reason: "explicit-session" }
 	}
@@ -66,9 +278,25 @@ export function decideSessionModeOnboarding(input: SessionModeOnboardingInput): 
 	if (input.launchContext.nonInteractiveMode) return { action: "skip", reason: "automation-mode" }
 	if (input.launchContext.explicitSession) return { action: "skip", reason: "explicit-session" }
 	if (input.launchContext.explicitDefaultIntent) {
-		return { action: "skip", reason: "explicit-default-session" }
+		return { action: "skip-and-mark-seen", reason: "explicit-default-session" }
 	}
-	return { action: "skip", reason: "default-chat" }
+	return { action: "show", reason: "eligible" }
+}
+
+export function recordSessionModeWizardOutcome(
+	outcome: SessionModeWizardOutcome,
+	options?: { configPath?: string; now?: () => Date; hideDialog?: boolean },
+): string | undefined {
+	if (outcome === "cancelled") return undefined
+	const seenAt = markSessionModeWizardSeen(options)
+	if (options?.hideDialog === true) writeHideSessionModeDialog(true, options.configPath)
+	return seenAt
+}
+
+export function markSessionModeWizardSeen(options?: { configPath?: string; now?: () => Date }): string {
+	const seenAt = (options?.now?.() ?? new Date()).toISOString()
+	writeSessionModeWizardSeenAt(seenAt, options?.configPath)
+	return seenAt
 }
 
 function scanLaunchArgs(rawArgs: string[]): {

--- a/src/extensions/onboarding/session-mode.ts
+++ b/src/extensions/onboarding/session-mode.ts
@@ -15,8 +15,15 @@ import { NoOpPickerEditor } from "./picker-editor.js"
 import {
 	SessionModePickerComponent,
 	type SessionModePickerResult,
+	type SessionModePickerState,
+	initialSessionModePickerState,
 	keyToSessionModePickerEvent,
 } from "./session-mode-picker.js"
+
+// Stateless editor — share a single instance across factory invocations so
+// pi-tui doesn't churn allocations if it re-instantiates the editor on resize
+// or theme change.
+const NO_OP_EDITOR = new NoOpPickerEditor()
 
 export type SessionModeOnboardingAction = "show" | "skip" | "skip-and-mark-seen"
 
@@ -129,11 +136,18 @@ function showSessionModeWizard(
 	let tuiRef: { hasOverlay(): boolean } | null = null
 	let component: SessionModePickerComponent | undefined
 	let editorSwapped = false
-	// Captured from getEditorComponent() right before we swap. ui.ts registers its
-	// session_start handler before ours (see cli.ts extension order), so by the
-	// time we read this, the upstream PromptEditor factory is already installed.
-	// We restore exactly this value on cleanup — passing undefined to
-	// setEditorComponent would drop to the library default instead.
+	// Held in the wizard closure so pi-tui re-invoking the widget factory
+	// (resize, theme swap, etc.) re-creates the component without resetting
+	// the user's highlight.
+	let pickerState: SessionModePickerState = initialSessionModePickerState()
+	const onPickerStateChange = (next: SessionModePickerState): void => {
+		pickerState = next
+	}
+	// Captured from getEditorComponent() right before we swap. ui.ts registers
+	// its session_start handler before ours (see cli.ts extension order), so in
+	// the normal launch path this holds the upstream PromptEditor factory.
+	// If it's undefined (no upstream editor installed yet), cleanup will pass
+	// undefined back through, which restores pi-tui's library default.
 	let prevEditorFactory: EditorFactory | undefined
 
 	// Empty shim component mounted before activation. Renders nothing so the
@@ -148,21 +162,28 @@ function showSessionModeWizard(
 		// the editor (or mount a non-empty picker that consumes keys) while an
 		// overlay is up, the overlay loses its dismissal keys and becomes
 		// stuck. So we mount the picker + swap the editor atomically only once
-		// no overlay is present.
-		if (typeof tuiRef?.hasOverlay === "function" && tuiRef.hasOverlay()) return
+		// no overlay is present. If tuiRef hasn't been set yet (shim factory
+		// not invoked), treat that as "unknown overlay state" and bail; the
+		// next input retry will re-attempt.
+		if (!tuiRef || (typeof tuiRef.hasOverlay === "function" && tuiRef.hasOverlay())) return
 		activated = true
 		ctx.ui.setWidget(
 			SESSION_MODE_WIDGET_KEY,
 			(tui, theme) => {
 				tuiRef = tui as unknown as { hasOverlay(): boolean }
-				component = new SessionModePickerComponent(theme, finish, () => tui.requestRender())
+				component = new SessionModePickerComponent(theme, finish, () => tui.requestRender(), {
+					initialState: pickerState,
+					onStateChange: onPickerStateChange,
+				})
 				return component
 			},
 			SESSION_MODE_WIDGET_OPTIONS,
 		)
 		prevEditorFactory = ctx.ui.getEditorComponent()
-		ctx.ui.setEditorComponent(() => new NoOpPickerEditor())
+		// Flip editorSwapped before the call so a throw mid-mutation still
+		// triggers a restore on cleanup.
 		editorSwapped = true
+		ctx.ui.setEditorComponent(() => NO_OP_EDITOR)
 	}
 
 	const cleanup = () => {
@@ -225,7 +246,9 @@ function showSessionModeWizard(
 		SESSION_MODE_WIDGET_OPTIONS,
 	)
 	unsubscribeInput = ctx.ui.onTerminalInput((data) => {
-		if (typeof tuiRef?.hasOverlay === "function" && tuiRef.hasOverlay()) {
+		const overlayUnknown = !tuiRef
+		const overlayUp = !overlayUnknown && typeof tuiRef?.hasOverlay === "function" ? tuiRef.hasOverlay() : false
+		if (overlayUnknown || overlayUp) {
 			// The same keystroke that fires this handler may also dismiss the
 			// overlay (Mike's Shift+Enter warning dismisses on any key). Re-check
 			// on the next tick so the picker + editor swap happen as soon as the


### PR DESCRIPTION

<img width="673" height="584" alt="Screenshot 2026-05-22 at 20 30 16" src="https://github.com/user-attachments/assets/bb554b5c-6c3b-4ce7-811c-cc9446d13850" />


Test with overlay:

https://github.com/user-attachments/assets/70e03418-8de7-4d59-a4d9-d7a43f655aed



Brings back the session-mode picker that 4f7fb38 removed, reworked as a first-run-only dialog with two options: "Try a /ferment workflow" (launches ferment) and "Just chat and code". Once the picker has been shown once (cancel counts), sessionModeWizardSeenAt is persisted and subsequent launches skip it.

The picker coexists with the Shift+Enter terminal-compat overlay added in c95b95d. pi-tui routes terminal input through the current editor, so calling setEditorComponent while an overlay is mounted steals its dismissal keys. To avoid that, the picker mounts initially as an invisible shim and defers both the real picker mount and the editor swap until hasOverlay() returns false. The overlay therefore renders first and keeps focus; on the dismissal keystroke the picker activates atomically with the editor hidden. Cleanup restores the upstream editor factory captured via getEditorComponent() so we never drop back to the library default.

---
### Kimchi Summary
### What changed
Restores the first-run session mode picker that lets users choose between starting a `/ferment` workflow or the default chat session. The picker mounts on the first eligible interactive startup, persists its state to global config, and temporarily swaps the editor so the picker owns the terminal input.

### Why
The session-mode onboarding picker was previously removed and replaced with a no-op. Bringing it back allows first-time users to discover the Ferment workflow while ensuring the prompt is shown only once and does not interfere with TUI overlays or input routing.

### Key changes
- `src/config.ts`: Replaced the generic `OnboardingConfig` type with a structured interface containing `sessionModeWizardSeenAt` and `hideSessionModeDialog`. Added `readSessionModeWizardSeenAt`, `writeSessionModeWizardSeenAt`, `readHideSessionModeDialog`, and `writeHideSessionModeDialog`, plus backward-compatible parsing for the legacy hyphenated `hide-session-mode-dialog` key.
- `src/extensions/onboarding/session-mode-picker.ts`: Added a new TUI picker component with reducer-based state management, keyboard navigation, and themed rendering for choosing between "Try a /ferment workflow" and "Just chat and code".
- `src/extensions/onboarding/picker-editor.ts`: Added `NoOpPickerEditor`, an empty editor shim that frees up terminal rows while the picker is visible.
- `src/extensions/onboarding/session-mode.ts`: Replaced the no-op extension with a complete onboarding flow that reads persisted state, defers picker activation until any TUI overlay clears, swaps in the `NoOpPickerEditor`, restores the previous editor on cleanup, and calls `onOutcome` when the user selects an option. Writes `sessionModeWizardSeenAt` immediately on mount so a crash does not reshow the dialog.
- `src/extensions/onboarding/session-mode-startup.ts`: Wired the startup extension to automatically launch interactive Ferment when the user chooses that option from the picker.

### Impact
- First-time interactive users will see the session mode picker exactly once; subsequent launches are suppressed by `sessionModeWizardSeenAt`.
- The picker respects `hideSessionModeDialog` to permanently skip the prompt.
- Editor component is briefly substituted during the picker lifecycle; upstream editor wiring is restored on finish, cancel, or shutdown.
- If the user selects `/ferment`, the shared interactive Ferment entry point starts automatically.

---
### Kimchi Summary
### What changed
Restores the interactive session-mode onboarding picker for first-time users. On an eligible interactive startup, the UI now presents a choice between starting a `/ferment` workflow or the default chat-and-code session. The dialog is shown only once; choosing Ferment automatically launches the interactive ferment entry point.

### Why
The onboarding picker had been removed and replaced with a no-op. Reinstating it gives new users a guided first-run choice between the structured Ferment workflow and the default experience.

### Key changes
- `src/config.ts`: Replaces opaque `OnboardingConfig` with typed fields `sessionModeWizardSeenAt` and `hideSessionModeDialog`. Adds `readSessionModeWizardSeenAt`, `readHideSessionModeDialog`, `writeSessionModeWizardSeenAt`, and an `updateOnboardingConfig` helper.
- `src/extensions/onboarding/session-mode.ts`: Replaces no-op extension with full wizard logic. Mounts the picker widget, suppresses footer tips, and safely swaps the editor component once any TUI overlay is dismissed. Writes the seen timestamp immediately on first display to avoid re-prompting after a crash.
- `src/extensions/onboarding/session-mode-picker.ts`: New reducer-driven picker component. Renders two options (Ferment and Default), handles arrow keys / Enter / Escape, and reports the chosen outcome.
- `src/extensions/onboarding/picker-editor.ts`: Adds `NoOpPickerEditor`, a zero-height editor shim that yields screen space to the picker while preserving upstream editor wiring.
- `src/extensions/onboarding/session-mode-startup.ts`: Adds an `onOutcome` callback that invokes `startInteractiveFerment` when the user selects the Ferment option.
- Tests: Adds comprehensive coverage in `config.test.ts`, `session-mode.test.ts`, `session-mode-startup.test.ts`, and `session-mode-picker.test.ts` for config persistence, decision logic, overlay handling, editor swap lifecycle, and selection state.

### Impact
- **User-visible**: Eligible first-time launches now display the session-mode picker. Automation and non-interactive launches remain unaffected.
- **Config migration**: Existing onboarding objects in config are parsed safely; unknown fields are ignored.
- **Escape hatch**: Setting `onboarding.hideSessionModeDialog` to `true` in config suppresses the picker permanently.
- **Editor focus**: The picker defers editor replacement until TUI overlays clear, preventing stuck dismissal states.