### PR TITLE
LLM-1604: kimchi update fails with EXDEV: cross-device link not permitted when /tmp and ~/.local/bin are on different filesystems

### DIFF
--- a/src/commands/update.ts
+++ b/src/commands/update.ts
@@ -108,12 +108,9 @@ export async function runUpdate(args: string[]): Promise<number> {
 	} catch (err) {
 		console.error(`kimchi update: update failed — ${(err as Error).message}`)
 		console.error("")
-		console.error("Troubleshooting:")
-		console.error("  · Ensure the installation directory is writable")
 		console.error(
-			"  · If /tmp and the install path are on different filesystems, the installer now handles this automatically",
+			"Please copy the error message above and create a bug report at https://github.com/castai/kimchi/issues",
 		)
-		console.error("  · Report problems at: https://github.com/castai/kimchi-dev/issues")
 		return 1
 	}
 

--- a/src/commands/update.ts
+++ b/src/commands/update.ts
@@ -106,7 +106,14 @@ export async function runUpdate(args: string[]): Promise<number> {
 	try {
 		await applyUpdate({ tag: check.tag })
 	} catch (err) {
-		console.error(`kimchi update: ${(err as Error).message}`)
+		console.error(`kimchi update: update failed — ${(err as Error).message}`)
+		console.error("")
+		console.error("Troubleshooting:")
+		console.error("  · Ensure the installation directory is writable")
+		console.error(
+			"  · If /tmp and the install path are on different filesystems, the installer now handles this automatically",
+		)
+		console.error("  · Report problems at: https://github.com/castai/kimchi-dev/issues")
 		return 1
 	}
 

--- a/src/update/install.test.ts
+++ b/src/update/install.test.ts
@@ -1,4 +1,4 @@
-import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs"
+import { chmodSync, mkdirSync, mkdtempSync, readFileSync, rmSync, statSync, writeFileSync } from "node:fs"
 import { tmpdir } from "node:os"
 import { join } from "node:path"
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
@@ -124,6 +124,7 @@ describe("atomicInstall", () => {
 		mkdirSync(join(tmp, "new"), { recursive: true })
 		writeFileSync(currentPath, "old-binary")
 		writeFileSync(newPath, "new-binary")
+		chmodSync(newPath, 0o755)
 
 		const { renameSync: realRename } = await vi.importActual<typeof import("node:fs")>("node:fs")
 		mocks.renameSync = (oldPath: string, newPathArg: string) => {
@@ -141,6 +142,9 @@ describe("atomicInstall", () => {
 		expect(readFileSync(currentPath, "utf-8")).toBe("new-binary")
 		expect(result.backupPath).toBeDefined()
 		expect(readFileSync(result.backupPath as string, "utf-8")).toBe("old-binary")
+
+		// The temp copy → rename fallback must preserve the executable bit.
+		expect(statSync(currentPath).mode & 0o111).toBeGreaterThan(0)
 	})
 
 	it("propagates non-EXDEV errors and leaves current binary intact", async () => {

--- a/src/update/install.test.ts
+++ b/src/update/install.test.ts
@@ -1,8 +1,27 @@
 import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs"
 import { tmpdir } from "node:os"
 import { join } from "node:path"
-import { afterEach, beforeEach, describe, expect, it } from "vitest"
-import { copySupportingFiles } from "./install.js"
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
+import { atomicInstall, copySupportingFiles } from "./install.js"
+
+const { mocks } = vi.hoisted(() => ({
+	mocks: {
+		renameSync: null as ((oldPath: string, newPath: string) => void) | null,
+	},
+}))
+
+vi.mock("node:fs", async (importOriginal) => {
+	const actual = await importOriginal<typeof import("node:fs")>()
+	return {
+		...actual,
+		renameSync: (oldPath: string, newPath: string) => {
+			if (mocks.renameSync) {
+				return mocks.renameSync(oldPath, newPath)
+			}
+			return actual.renameSync(oldPath, newPath)
+		},
+	}
+})
 
 describe("copySupportingFiles", () => {
 	let srcDir: string
@@ -47,5 +66,141 @@ describe("copySupportingFiles", () => {
 
 		expect(readFileSync(join(dstDir, "keepme.txt"), "utf-8")).toBe("ok")
 		expect(() => readFileSync(join(dstDir, "kimchi"))).toThrow()
+	})
+})
+
+describe("atomicInstall", () => {
+	let tmp: string
+	let prevXdg: string | undefined
+	let prevPlatform: PropertyDescriptor | undefined
+
+	beforeEach(() => {
+		tmp = mkdtempSync(join(tmpdir(), "kimchi-atomic-install-test-"))
+		prevXdg = process.env.XDG_CACHE_HOME
+		process.env.XDG_CACHE_HOME = tmp
+		mocks.renameSync = null
+	})
+
+	afterEach(() => {
+		if (prevXdg === undefined) process.env.XDG_CACHE_HOME = undefined
+		else process.env.XDG_CACHE_HOME = prevXdg
+		rmSync(tmp, { recursive: true, force: true })
+		mocks.renameSync = null
+		if (prevPlatform) {
+			Object.defineProperty(process, "platform", prevPlatform)
+			prevPlatform = undefined
+		}
+	})
+
+	function setPlatform(platform: string) {
+		prevPlatform = Object.getOwnPropertyDescriptor(process, "platform")
+		Object.defineProperty(process, "platform", {
+			value: platform,
+			configurable: true,
+		})
+	}
+
+	it("same-fs rename: replaces current binary and creates backup on POSIX", () => {
+		setPlatform("linux")
+		const currentPath = join(tmp, "bin", "kimchi")
+		const newPath = join(tmp, "new", "kimchi")
+		mkdirSync(join(tmp, "bin"), { recursive: true })
+		mkdirSync(join(tmp, "new"), { recursive: true })
+		writeFileSync(currentPath, "old-binary")
+		writeFileSync(newPath, "new-binary")
+
+		const result = atomicInstall(newPath, currentPath)
+
+		expect(readFileSync(currentPath, "utf-8")).toBe("new-binary")
+		expect(result.backupPath).toBeDefined()
+		expect(readFileSync(result.backupPath as string, "utf-8")).toBe("old-binary")
+	})
+
+	it("EXDEV fallback: copies and renames when rename crosses filesystems", async () => {
+		setPlatform("linux")
+		const currentPath = join(tmp, "bin", "kimchi")
+		const newPath = join(tmp, "new", "kimchi")
+		mkdirSync(join(tmp, "bin"), { recursive: true })
+		mkdirSync(join(tmp, "new"), { recursive: true })
+		writeFileSync(currentPath, "old-binary")
+		writeFileSync(newPath, "new-binary")
+
+		const { renameSync: realRename } = await vi.importActual<typeof import("node:fs")>("node:fs")
+		mocks.renameSync = (oldPath: string, newPathArg: string) => {
+			if (oldPath === newPath) {
+				const err = new Error("EXDEV: cross-device link not permitted") as NodeJS.ErrnoException
+				err.code = "EXDEV"
+				err.syscall = "rename"
+				throw err
+			}
+			return realRename(oldPath, newPathArg)
+		}
+
+		const result = atomicInstall(newPath, currentPath)
+
+		expect(readFileSync(currentPath, "utf-8")).toBe("new-binary")
+		expect(result.backupPath).toBeDefined()
+		expect(readFileSync(result.backupPath as string, "utf-8")).toBe("old-binary")
+	})
+
+	it("propagates non-EXDEV errors and leaves current binary intact", async () => {
+		setPlatform("linux")
+		const currentPath = join(tmp, "bin", "kimchi")
+		const newPath = join(tmp, "new", "kimchi")
+		mkdirSync(join(tmp, "bin"), { recursive: true })
+		mkdirSync(join(tmp, "new"), { recursive: true })
+		writeFileSync(currentPath, "old-binary")
+		writeFileSync(newPath, "new-binary")
+
+		const { renameSync: realRename } = await vi.importActual<typeof import("node:fs")>("node:fs")
+		mocks.renameSync = (oldPath: string, newPathArg: string) => {
+			if (oldPath === newPath) {
+				const err = new Error("EPERM: operation not permitted") as NodeJS.ErrnoException
+				err.code = "EPERM"
+				throw err
+			}
+			return realRename(oldPath, newPathArg)
+		}
+
+		expect(() => atomicInstall(newPath, currentPath)).toThrow("EPERM")
+		expect(readFileSync(currentPath, "utf-8")).toBe("old-binary")
+	})
+
+	it("cleans up temp file when EXDEV rename of temp fails", async () => {
+		setPlatform("linux")
+		const currentPath = join(tmp, "bin", "kimchi")
+		const newPath = join(tmp, "new", "kimchi")
+		mkdirSync(join(tmp, "bin"), { recursive: true })
+		mkdirSync(join(tmp, "new"), { recursive: true })
+		writeFileSync(currentPath, "old-binary")
+		writeFileSync(newPath, "new-binary")
+
+		const { renameSync: realRename } = await vi.importActual<typeof import("node:fs")>("node:fs")
+		let tempPathSeen = ""
+		mocks.renameSync = (oldPath: string, newPathArg: string) => {
+			if (oldPath === newPath) {
+				const err = new Error("EXDEV: cross-device link not permitted") as NodeJS.ErrnoException
+				err.code = "EXDEV"
+				throw err
+			}
+			if (newPathArg === currentPath && oldPath !== newPath) {
+				// This is the temp -> current rename. Fail it once.
+				if (!tempPathSeen) {
+					tempPathSeen = oldPath
+					const err = new Error("EIO: I/O error") as NodeJS.ErrnoException
+					err.code = "EIO"
+					throw err
+				}
+			}
+			return realRename(oldPath, newPathArg)
+		}
+
+		expect(() => atomicInstall(newPath, currentPath)).toThrow("EIO")
+		expect(readFileSync(currentPath, "utf-8")).toBe("old-binary")
+		// Temp file should have been cleaned up
+		expect(tempPathSeen).not.toBe("")
+		if (tempPathSeen) {
+			expect(() => readFileSync(tempPathSeen)).toThrow()
+		}
 	})
 })

--- a/src/update/install.ts
+++ b/src/update/install.ts
@@ -1,5 +1,5 @@
 import { spawnSync } from "node:child_process"
-import { copyFileSync, mkdirSync, readdirSync, renameSync, statSync, unlinkSync } from "node:fs"
+import { chmodSync, copyFileSync, mkdirSync, readdirSync, renameSync, statSync, unlinkSync } from "node:fs"
 import { dirname, join } from "node:path"
 import { backupDir } from "./paths.js"
 
@@ -121,7 +121,12 @@ export function atomicInstall(newPath: string, currentPath: string): { backupPat
 		// atomically renaming it into place.
 		if ((err as NodeJS.ErrnoException).code === "EXDEV") {
 			const tempPath = `${currentPath}.new.${Date.now()}`
+			const { mode } = statSync(newPath)
 			copyFileSync(newPath, tempPath)
+			// copyFileSync does not preserve the source mode. Restore the
+			// executable bit (and any other permissions) so the renamed
+			// binary remains runnable.
+			chmodSync(tempPath, mode)
 			try {
 				renameSync(tempPath, currentPath)
 			} catch (renameErr) {

--- a/src/update/install.ts
+++ b/src/update/install.ts
@@ -56,6 +56,11 @@ export function macosCodesignReSign(newPath: string): void {
  *   up the new one. ETXTBSY only fires on attempts to *write to* the
  *   running binary, which we never do.
  *
+ *   When source and destination are on different filesystems rename(2)
+ *   returns EXDEV. In that case we copy the new binary to a temp file on
+ *   the target filesystem and rename it into place — the final rename is
+ *   still atomic.
+ *
  * - **Windows**: cannot rename or delete a running .exe (the OS holds an
  *   exclusive lock). Strategy used by `bun upgrade` and `deno upgrade`:
  *   rename `kimchi.exe` → `kimchi.exe.old`, drop the new binary in as
@@ -107,7 +112,38 @@ export function atomicInstall(newPath: string, currentPath: string): { backupPat
 
 	// Atomic swap. fs.renameSync uses POSIX rename(2) under the hood.
 	mkdirSync(dirname(currentPath), { recursive: true })
-	renameSync(newPath, currentPath)
+	try {
+		renameSync(newPath, currentPath)
+	} catch (err) {
+		// EXDEV: source and destination are on different filesystems.
+		// rename(2) cannot cross mount points. Fall back to copying the
+		// new binary to a temp file on the target filesystem and then
+		// atomically renaming it into place.
+		if ((err as NodeJS.ErrnoException).code === "EXDEV") {
+			const tempPath = `${currentPath}.new.${Date.now()}`
+			copyFileSync(newPath, tempPath)
+			try {
+				renameSync(tempPath, currentPath)
+			} catch (renameErr) {
+				// Clean up the temp file so we don't leave litter.
+				try {
+					unlinkSync(tempPath)
+				} catch {
+					// non-fatal — continue
+				}
+				throw renameErr
+			}
+			// Clean up the original extracted binary on the source fs.
+			try {
+				unlinkSync(newPath)
+			} catch {
+				// non-fatal — the extract cleanup in applyUpdate will
+				// handle the containing directory.
+			}
+			return { backupPath }
+		}
+		throw err
+	}
 
 	return { backupPath }
 }


### PR DESCRIPTION
…tted when /tmp and ~/.local/bin are on different filesystems

## Description

<!-- What problem does this PR solve? What changes were made and why? -->


## Type of Change

<!-- Select all that apply. -->

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

---
### Kimchi Summary
### What changed
Improves the error message shown when `kimchi update` fails and fixes self-updates when the current binary and the downloaded update reside on different filesystems.

### Why
POSIX `rename(2)` cannot move files across mount points, causing `EXDEV` failures during updates whenever the temporary download directory and the installation path are on separate filesystems.

### Key changes
- `src/commands/update.ts`: Prefixes the error log with "update failed" and directs users to create a bug report at `https://github.com/castai/kimchi/issues`.
- `src/update/install.ts`: Extended `atomicInstall` to catch `EXDEV` errors during `renameSync`. On cross-filesystem moves it copies the new binary to a temp file on the target filesystem, restores the original permissions with `chmodSync`, and atomically renames the temp file into place. Also cleans up the temp file and original extracted binary on success or failure.
- `src/update/install.test.ts`: Added `atomicInstall` test suite covering same-filesystem atomic renames, `EXDEV` fallback with executable-bit preservation, non-`EXDEV` error propagation, and temp-file cleanup when the fallback rename fails.

### Testing
Tested locally on Ubuntu LTS 24.04 machine
<img width="2522" height="1086" alt="image" src="https://github.com/user-attachments/assets/fb52d9aa-6d81-40c2-b367-2aec4d8a93fe" />


### Impact
- Self-updates now succeed when the download cache and install directory are on different filesystems.
- Executable permissions are preserved during cross-filesystem installs.
- Non-`EXDEV` rename errors continue to fail safely without altering the running binary.