### PR TITLE
LLM-1731: TUI gets stuck - requires Enter key press to proceed

### DIFF
--- a/src/integrations/claude-code.ts
+++ b/src/integrations/claude-code.ts
@@ -192,4 +192,5 @@ register({
 	binaryName: "claude",
 	isInstalled: detectBinaryFactory("claude"),
 	write: writeClaudeCode,
+	interactiveWrite: true,
 })

--- a/src/integrations/types.ts
+++ b/src/integrations/types.ts
@@ -21,6 +21,8 @@ export interface ToolDefinition {
 	installUrl?: string
 	/** Extra args passed to the install script. */
 	installArgs?: string[]
+	/** Whether the tool may prompt the user during write(). If true, no spinner is shown. */
+	interactiveWrite?: boolean
 	/** Detect whether the tool is installed locally (PATH probe, well-known dir, etc). */
 	isInstalled: () => boolean
 	/** Write configuration so this tool talks to kimchi's LLM endpoints. */

--- a/src/setup-wizard/steps/done.test.ts
+++ b/src/setup-wizard/steps/done.test.ts
@@ -2,8 +2,37 @@ import { mkdtempSync, realpathSync, rmSync } from "node:fs"
 import { tmpdir } from "node:os"
 import { join } from "node:path"
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
+
+const clackMock = vi.hoisted(() => {
+	const spinnerInstance = {
+		start: vi.fn(),
+		stop: vi.fn(),
+		message: vi.fn(),
+	}
+	return {
+		spinner: vi.fn(() => spinnerInstance),
+		spinnerInstance,
+		log: {
+			info: vi.fn(),
+			error: vi.fn(),
+			warn: vi.fn(),
+		},
+		note: vi.fn(),
+		outro: vi.fn(),
+	}
+})
+
+vi.mock("@clack/prompts", () => ({
+	spinner: clackMock.spinner,
+	log: clackMock.log,
+	note: clackMock.note,
+	outro: clackMock.outro,
+	isCancel: vi.fn(() => false),
+}))
+
 import { TEST_MODELS } from "../../integrations/__fixtures__/models.js"
 import "../../integrations/claude-code.js"
+import "../../integrations/cursor.js"
 import { byId } from "../../integrations/registry.js"
 import * as modelsModule from "../../models.js"
 import type { WizardState } from "../state.js"
@@ -46,6 +75,16 @@ describe("runDoneStep", () => {
 			binaryPath: "/tmp/kimchi-test/rtk",
 			linkPath: "/tmp/kimchi-test/bin/rtk",
 		})
+
+		clackMock.spinnerInstance.start.mockClear()
+		clackMock.spinnerInstance.stop.mockClear()
+		clackMock.spinnerInstance.message.mockClear()
+		clackMock.spinner.mockClear()
+		clackMock.log.info.mockClear()
+		clackMock.log.error.mockClear()
+		clackMock.log.warn.mockClear()
+		clackMock.note.mockClear()
+		clackMock.outro.mockClear()
 	})
 
 	afterEach(() => {
@@ -168,6 +207,38 @@ describe("runDoneStep", () => {
 		const { readFileSync } = await import("node:fs")
 		const zshrc = readFileSync(join(tmpHome, ".zshrc"), "utf-8")
 		expect(zshrc).toContain("export KIMCHI_API_KEY=test-key")
+
+		writeSpy.mockRestore()
+	})
+
+	it("skips the spinner for interactive-write tools", async () => {
+		const tool = getClaudeCodeTool()
+		const writeSpy = vi.spyOn(tool, "write").mockResolvedValue()
+
+		await runDoneStep(baseState())
+		const toolSpinnerStarts = clackMock.spinnerInstance.start.mock.calls.filter(
+			(call: unknown[]) => typeof call[0] === "string" && call[0].includes("Claude Code"),
+		)
+		expect(toolSpinnerStarts).toEqual([])
+		expect(clackMock.log.info).toHaveBeenCalledWith("Configuring Claude Code…")
+		expect(clackMock.log.info).toHaveBeenCalledWith("Claude Code: configured")
+
+		writeSpy.mockRestore()
+	})
+
+	it("uses the spinner for non-interactive tools", async () => {
+		const state = baseState()
+		state.selectedTools = ["cursor"]
+
+		const tool = byId("cursor")
+		if (!tool) throw new Error("cursor integration not registered")
+		const writeSpy = vi.spyOn(tool, "write").mockResolvedValue()
+
+		await runDoneStep(state)
+		const toolSpinnerStarts = clackMock.spinnerInstance.start.mock.calls.filter(
+			(call: unknown[]) => typeof call[0] === "string" && call[0].includes("Cursor"),
+		)
+		expect(toolSpinnerStarts).toEqual([["Configuring Cursor…"]])
 
 		writeSpy.mockRestore()
 	})

--- a/src/setup-wizard/steps/done.ts
+++ b/src/setup-wizard/steps/done.ts
@@ -74,19 +74,25 @@ export async function runDoneStep(state: WizardState): Promise<ApplyOutcome> {
 			log.info(`${tool.name}: ready (launch via 'kimchi ${launchCmd}')`)
 			continue
 		}
-		const s = spinner()
-		s.start(`Configuring ${tool.name}…`)
-		// Yield briefly so clack can render the first spinner frame before
-		// potentially blocking sync work (e.g. spawnSync calls).
-		await new Promise<void>((resolve) => setTimeout(() => resolve(), 80))
+		const s = tool.interactiveWrite ? null : spinner()
+		if (s) {
+			s.start(`Configuring ${tool.name}…`)
+			// Yield briefly so clack can render the first spinner frame before
+			// potentially blocking sync work (e.g. spawnSync calls).
+			await new Promise<void>((resolve) => setTimeout(() => resolve(), 80))
+		} else {
+			log.info(`Configuring ${tool.name}…`)
+		}
 		try {
 			await tool.write(state.scope, state.apiKey, models, { telemetryEnabled: state.telemetryEnabled })
 			outcome.successes.push(tool.name)
-			s.stop(`${tool.name}: configured`)
+			if (s) s.stop(`${tool.name}: configured`)
+			else log.info(`${tool.name}: configured`)
 		} catch (err) {
 			const msg = (err as Error).message
 			outcome.failures.push({ id, error: msg })
-			s.stop(`${tool.name}: ${msg}`)
+			if (s) s.stop(`${tool.name}: ${msg}`)
+			else log.error(`${tool.name}: ${msg}`)
 		}
 	}
 


### PR DESCRIPTION
## Description

<!-- What problem does this PR solve? What changes were made and why? -->


## Type of Change

<!-- Select all that apply. -->

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

---
### Kimchi Summary
### What changed
Adds an `interactiveWrite` flag to tool definitions that suppresses the setup wizard's progress spinner for integrations that prompt the user during configuration. Enables the flag for Claude Code.

### Why
 During kimchi setup, when configuring Claude Code, a spinner (`◒ Configuring Claude
 Code…`) kept animating while the wizard waited for the user to answer the `◆ Apply these changes?` prompt.
 This made it look like work was happening when the program was actually blocked on user input.

### Key changes
- **`src/integrations/types.ts`** — Introduces `interactiveWrite?: boolean` on `ToolDefinition`.
- **`src/integrations/claude-code.ts`** — Registers the Claude Code integration with `interactiveWrite: true`.
- **`src/setup-wizard/steps/done.ts`** — Uses `spinner()` only when `interactiveWrite` is not set; otherwise logs progress with `log.info` and results with `log.info`/`log.error`.
- **`src/setup-wizard/steps/done.test.ts`** — Adds tests verifying that interactive tools skip the spinner while non-interactive tools (e.g., Cursor) continue to display it.