### PR TITLE
fix(ui): strip empty lines in tool renderings

### DIFF
--- a/src/extensions/tool-rendering.ts
+++ b/src/extensions/tool-rendering.ts
@@ -190,7 +190,8 @@ function stripAnsi(text: string): string {
 }
 
 function isBlankLine(text: string): boolean {
-	return stripAnsi(text).trim().length === 0
+	// Strip ANSI escapes and the ▍ stroke prefix (with its trailing space) before checking.
+	return stripAnsi(text).replace(/▍ ?/g, "").trim().length === 0
 }
 
 function borderLine(width: number): string {


### PR DESCRIPTION
## Description

Makes the tools calls much more compact:
<img width="715" height="460" alt="Screenshot 2026-05-24 at 19 29 04" src="https://github.com/user-attachments/assets/fa2a6d9d-8594-454f-adf7-04ffe176bdb6" />


## Type of Change

<!-- Select all that apply. -->

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

---
### Kimchi Summary
### What changed
Updated the `isBlankLine` helper in tool rendering to treat lines containing only the `▍` stroke prefix as blank, preventing extra empty lines in compact output.

### Why
Lines consisting solely of the `▍` prefix were incorrectly classified as non-blank, causing unwanted vertical spacing or malformed borders when collapsing tool render output.

### Key changes
- `src/extensions/tool-rendering.ts`: Modified `isBlankLine` to strip the `▍` stroke prefix and optional trailing space with `replace(/▍ ?/g, "")` before checking if the line is empty.