### PR TITLE
Terminal Bench Adapters for ClaudeCode and GSD

### DIFF
--- a/benchmark/terminal-bench-2/README.md
+++ b/benchmark/terminal-bench-2/README.md
@@ -32,15 +32,17 @@ You will hit one of two failure modes:
 - **Do not trust reward numbers from local Apple Silicon runs.** A `0.0` may be the verifier crashing under emulation, not the model failing. Compare your numbers against published terminal-bench results only after running on real x86_64.
 - **For trusted reward numbers, run on real Linux x86_64 hardware** — a CI runner (GitHub Actions `ubuntu-latest`, etc.).
 
-## Two ways to run
+## Ways to run
 
 | Script | Binary source |
 | --- | --- |
 | `./scripts/run-local.sh` | Cross-builds `kimchi` for linux-amd64 from the current working tree (`pnpm run build:binary-linux-x64`) |
 | `./scripts/run-release.sh` | Downloads the latest release from `castai/kimchi` |
 | `./scripts/run-opencode-kimchi.sh` | Installs OpenCode in the task container and configures it to use the Kimchi gateway |
+| `./scripts/run-claude-code-kimchi.sh` | Installs Claude Code in the task container and configures it to use the Kimchi gateway |
+| `./scripts/run-gsd-kimchi.sh` | Installs GSD in the task container and configures it to use one selected Kimchi model |
 
-Both scripts target the `terminal-bench/terminal-bench-2` dataset. Extra arguments are forwarded to `harbor run`, so everything below works for either script.
+All helper scripts target the `terminal-bench/terminal-bench-2` dataset. Extra arguments are forwarded to `harbor run`, so everything below works for any script.
 
 ### Running a task
 
@@ -114,13 +116,79 @@ OPENCODE_VERSION=1.14.33 MODEL=kimchi-dev/kimi-k2.5 \
   ./scripts/run-opencode-kimchi.sh -i terminal-bench/fix-git
 ```
 
-### Single-model run (no orchestration)
+### Claude Code with the Kimchi gateway
 
-To benchmark a model on its own, bypassing kimchi's multi-model orchestration, pass `--model <provider>/<id>` to select a specific model. This starts kimchi in single-model mode.
+Use `run-claude-code-kimchi.sh` when the benchmark should evaluate the Claude Code scaffold while routing model calls through `llm.kimchi.dev`.
 
 ```bash
-MODEL=kimchi-dev/minimax-m2.7 ./scripts/run-local.sh -n 8
+export KIMCHI_API_KEY=...
+MODEL=kimchi-dev/kimi-k2.5 ./scripts/run-claude-code-kimchi.sh -i terminal-bench/fix-git
 ```
+
+The Claude Code adapter accepts any `kimchi-dev/<model-id>` returned by Kimchi's model metadata endpoint (`/v1/models/metadata?include_in_cli=true`). It configures Claude Code with Kimchi's Anthropic-compatible endpoint (`https://llm.kimchi.dev/anthropic`), maps `KIMCHI_API_KEY` to `ANTHROPIC_AUTH_TOKEN`, clears `ANTHROPIC_API_KEY`, and pins Claude Code's default Sonnet/Opus/Haiku/subagent aliases to the selected model.
+
+To change models, change only `MODEL`:
+
+```bash
+MODEL=kimchi-dev/minimax-m2.7 ./scripts/run-claude-code-kimchi.sh -i terminal-bench/fix-git
+```
+
+By default Harbor installs the latest Claude Code package. Pin Claude Code for reproducible runs with `CLAUDE_CODE_VERSION`:
+
+```bash
+CLAUDE_CODE_VERSION=2.1.144 MODEL=kimchi-dev/kimi-k2.5 \
+  ./scripts/run-claude-code-kimchi.sh -i terminal-bench/fix-git
+```
+
+### GSD with the Kimchi gateway
+
+Use `run-gsd-kimchi.sh` when the benchmark should evaluate the GSD scaffold while routing model calls through `llm.kimchi.dev`.
+
+```bash
+export KIMCHI_API_KEY=...
+MODEL=kimchi-dev/kimi-k2.5 ./scripts/run-gsd-kimchi.sh -i terminal-bench/fix-git
+```
+
+The GSD adapter accepts any `kimchi-dev/<model-id>` returned by Kimchi's model metadata endpoint (`/v1/models/metadata?include_in_cli=true`). It installs `gsd-pi@latest` by default, writes `~/.gsd/agent/models.json` with only the selected model, writes minimal GSD preferences that route every role to that model, and runs GSD in non-interactive print mode:
+
+```bash
+gsd --mode text --print --model <MODEL> <instruction>
+```
+
+GSD's text output is captured at `agent/gsd.txt`, the resolved version at `agent/gsd-version.txt`, and the per-task `.gsd/` directory is copied to `agent/gsd/` after the run. The adapter records GSD's raw exit code in `agent/gsd-exit-code.txt` and normalized status in `agent/gsd-status.json`; if GSD returns its blocked exit code, Harbor still proceeds to verification. GSD's home is pinned to `agent/gsd-home/`, and the underlying pi session JSONL is persisted under `agent/gsd-home/agent/sessions/` for token accounting. GSD stdout JSON event streams are intentionally not captured because they can grow very large and are not needed for Terminal Bench scoring.
+
+To change models, change only `MODEL`:
+
+```bash
+MODEL=kimchi-dev/minimax-m2.7 ./scripts/run-gsd-kimchi.sh -i terminal-bench/fix-git
+```
+
+Override the GSD package version with `GSD_VERSION`:
+
+```bash
+GSD_VERSION=3.0.0 MODEL=kimchi-dev/kimi-k2.5 \
+  ./scripts/run-gsd-kimchi.sh -i terminal-bench/fix-git
+```
+
+### Single-model run (no orchestration)
+
+To benchmark a model on its own, bypassing kimchi's multi-model orchestration, pass `--model <provider>/<id>` to select a specific model. The helper scripts do this by default through `MODEL`, which starts kimchi in single-model mode.
+
+```bash
+MODEL=kimchi-dev/kimi-k2.6 ./scripts/run-local.sh -n 8 -k 3
+```
+
+Do not use `--agent-kwarg disable-multi-model=true`; the adapter accepts that legacy kwarg for compatibility, but current kimchi has no `--multi-model` CLI flag.
+
+### Multi-model run (orchestrator)
+
+To run kimchi's multi-model orchestrator, opt into the adapter-level kwarg. In this mode the adapter intentionally does not pass `--model` to kimchi, because an explicit model flag is what disables orchestration in the kimchi CLI.
+
+```bash
+./scripts/run-local.sh -n 8 -k 3 --agent-kwarg multi-model=true
+```
+
+With no custom role config in the task container, the orchestrator model defaults to `kimchi-dev/kimi-k2.6`. The adapter writes `{"multiModel":true}` to the in-container harness settings before launching kimchi so orchestration is enabled even in a fresh benchmark image.
 
 ### One-shot ferment per task
 
@@ -170,6 +238,9 @@ Tag format is `key:value`, comma-separated; keys and values are alphanumeric plu
 | `KIMCHI_CODE_BINARY` | no | Host path to a prebuilt Linux `kimchi` binary (produced by `pnpm run build:binary-linux-x64` at `dist/bin/kimchi`). The agent uploads the binary's grandparent directory (the build/tarball root containing `bin/` + `share/kimchi/`), so the auxiliary files travel with it. When set, the agent skips the GitHub release download. `./scripts/run-local.sh` sets this for you. |
 | `GITHUB_TOKEN` | no | Raises GitHub API rate limits when fetching the latest release. Not required for public repos |
 | `MODEL` | no | Default `kimchi-dev/kimi-k2.5`. See "Picking a model" for the `<provider>/<id>` requirement |
+| `OPENCODE_VERSION` | no | Pins the OpenCode version used by `run-opencode-kimchi.sh` |
+| `CLAUDE_CODE_VERSION` | no | Pins the Claude Code version used by `run-claude-code-kimchi.sh` |
+| `GSD_VERSION` | no | Overrides the GSD package version used by `run-gsd-kimchi.sh`; default install target is `gsd-pi@latest` |
 
 ## Results
 
@@ -185,6 +256,6 @@ Tag format is `key:value`, comma-separated; keys and values are alphanumeric plu
 
 **`sha256 mismatch for kimchi_linux_*.tar.gz`** — cached tarball at `~/.cache/kimchi-bench/releases/<tag>/` is corrupt or the release was replaced. `rm -rf` that tag's directory and retry.
 
-**`KIMCHI_API_KEY is required`** — env var didn't reach the container. Set it on the host before invoking the script; both scripts forward it via `--ae`.
+**`KIMCHI_API_KEY is required`** — env var didn't reach the container. Set it on the host before invoking the script; the helper scripts forward it via `--ae`.
 
-**`harbor: command not found`** — run via `uv run`; both scripts already do.
+**`harbor: command not found`** — run via `uv run`; the helper scripts already do.

--- a/benchmark/terminal-bench-2/README.md
+++ b/benchmark/terminal-bench-2/README.md
@@ -149,13 +149,13 @@ export KIMCHI_API_KEY=...
 MODEL=kimchi-dev/kimi-k2.5 ./scripts/run-gsd-kimchi.sh -i terminal-bench/fix-git
 ```
 
-The GSD adapter accepts any `kimchi-dev/<model-id>` returned by Kimchi's model metadata endpoint (`/v1/models/metadata?include_in_cli=true`). It installs `gsd-pi@latest` by default, writes `~/.gsd/agent/models.json` with only the selected model, writes minimal GSD preferences that route every role to that model, and runs GSD in non-interactive print mode:
+The GSD adapter accepts any `kimchi-dev/<model-id>` returned by Kimchi's model metadata endpoint (`/v1/models/metadata?include_in_cli=true`). It installs `gsd-pi@latest` by default, writes a temporary GSD home with only the selected model, writes minimal GSD preferences that route every role to that model, and runs GSD in non-interactive print mode:
 
 ```bash
 gsd --mode text --print --model <MODEL> <instruction>
 ```
 
-GSD's text output is captured at `agent/gsd.txt`, the resolved version at `agent/gsd-version.txt`, and the per-task `.gsd/` directory is copied to `agent/gsd/` after the run. The adapter records GSD's raw exit code in `agent/gsd-exit-code.txt` and normalized status in `agent/gsd-status.json`; if GSD returns its blocked exit code, Harbor still proceeds to verification. GSD's home is pinned to `agent/gsd-home/`, and the underlying pi session JSONL is persisted under `agent/gsd-home/agent/sessions/` for token accounting. GSD stdout JSON event streams are intentionally not captured because they can grow very large and are not needed for Terminal Bench scoring.
+GSD's text output is captured at `agent/gsd.txt`, the resolved version at `agent/gsd-version.txt`, and the per-task `.gsd/` directory is copied to `agent/gsd/` after the run. The adapter records GSD's raw exit code in `agent/gsd-exit-code.txt` and normalized status in `agent/gsd-status.json`; if GSD returns its blocked exit code, Harbor still proceeds to verification. GSD's managed home stays under `/tmp` during execution and is removed before artifacts are collected; only the underlying pi session JSONL is copied to `agent/gsd-sessions/` for token accounting. GSD stdout JSON event streams are intentionally not captured because they can grow very large and are not needed for Terminal Bench scoring.
 
 To change models, change only `MODEL`:
 

--- a/benchmark/terminal-bench-2/scripts/run-claude-code-kimchi.sh
+++ b/benchmark/terminal-bench-2/scripts/run-claude-code-kimchi.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+# Run terminal-bench with the Claude Code scaffold, configured to use the
+# Kimchi Anthropic-compatible gateway. The selected model is controlled by MODEL.
+#
+# Usage examples:
+#   MODEL=kimchi-dev/kimi-k2.5 ./scripts/run-claude-code-kimchi.sh -i terminal-bench/fix-git
+#   MODEL=kimchi-dev/minimax-m2.7 ./scripts/run-claude-code-kimchi.sh -i terminal-bench/fix-git -k 3
+#   CLAUDE_CODE_VERSION=2.1.144 MODEL=kimchi-dev/kimi-k2.5 ./scripts/run-claude-code-kimchi.sh -i terminal-bench/fix-git
+#   CLAUDE_CODE_API_MAX_RETRIES=0 ./scripts/run-claude-code-kimchi.sh -i terminal-bench/fix-git
+set -euo pipefail
+
+DATASET="terminal-bench/terminal-bench-2"
+
+: "${KIMCHI_API_KEY:?set KIMCHI_API_KEY in env}"
+
+BENCH_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+cd "$BENCH_DIR"
+
+HARBOR_ARGS=(
+    --agent-import-path kimchi_agent:ClaudeCodeKimchi
+    --env docker
+    --model "${MODEL:-kimchi-dev/kimi-k2.5}"
+    --ae "KIMCHI_API_KEY=$KIMCHI_API_KEY"
+    --max-retries "${CLAUDE_CODE_API_MAX_RETRIES:-2}"
+    --retry-include RetryableApiError
+    -d "$DATASET"
+)
+
+if [[ -n "${CLAUDE_CODE_VERSION:-}" ]]; then
+    HARBOR_ARGS+=(--agent-kwarg "version=$CLAUDE_CODE_VERSION")
+fi
+
+exec uv run --python 3.14 harbor run "${HARBOR_ARGS[@]}" "$@"

--- a/benchmark/terminal-bench-2/scripts/run-gsd-kimchi.sh
+++ b/benchmark/terminal-bench-2/scripts/run-gsd-kimchi.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+# Run terminal-bench with GSD, configured to use one selected Kimchi model.
+#
+# Usage examples:
+#   MODEL=kimchi-dev/kimi-k2.5 ./scripts/run-gsd-kimchi.sh -i terminal-bench/fix-git
+#   MODEL=kimchi-dev/minimax-m2.7 ./scripts/run-gsd-kimchi.sh -i terminal-bench/fix-git -k 3
+#   GSD_VERSION=3.0.0 MODEL=kimchi-dev/kimi-k2.5 ./scripts/run-gsd-kimchi.sh -i terminal-bench/fix-git
+set -euo pipefail
+
+DATASET="terminal-bench/terminal-bench-2"
+
+: "${KIMCHI_API_KEY:?set KIMCHI_API_KEY in env}"
+
+BENCH_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+cd "$BENCH_DIR"
+
+HARBOR_ARGS=(
+    --agent-import-path kimchi_agent:GsdKimchi
+    --env docker
+    --model "${MODEL:-kimchi-dev/kimi-k2.5}"
+    --ae "KIMCHI_API_KEY=$KIMCHI_API_KEY"
+    -d "$DATASET"
+)
+
+if [[ -n "${GSD_VERSION:-}" ]]; then
+    HARBOR_ARGS+=(--agent-kwarg "version=$GSD_VERSION")
+fi
+
+exec uv run --python 3.14 harbor run "${HARBOR_ARGS[@]}" "$@"

--- a/benchmark/terminal-bench-2/scripts/run-local.sh
+++ b/benchmark/terminal-bench-2/scripts/run-local.sh
@@ -6,6 +6,7 @@
 # Usage examples:
 #   ./scripts/run-local.sh -i terminal-bench/fix-git
 #   MODEL=kimchi-dev/kimi-k2.5 ./scripts/run-local.sh -i terminal-bench/fix-git -k 3
+#   ./scripts/run-local.sh -i terminal-bench/fix-git -k 3 --agent-kwarg multi-model=true
 set -euo pipefail
 
 DATASET="terminal-bench/terminal-bench-2"

--- a/benchmark/terminal-bench-2/scripts/run-release.sh
+++ b/benchmark/terminal-bench-2/scripts/run-release.sh
@@ -6,6 +6,7 @@
 # Usage examples:
 #   ./scripts/run-release.sh -i terminal-bench/fix-git
 #   MODEL=kimchi-dev/minimax-m2.7 ./scripts/run-release.sh -i terminal-bench/fix-git
+#   ./scripts/run-release.sh -i terminal-bench/fix-git -k 3 --agent-kwarg multi-model=true
 set -euo pipefail
 
 DATASET="terminal-bench/terminal-bench-2"

--- a/benchmark/terminal-bench-2/src/kimchi_agent/__init__.py
+++ b/benchmark/terminal-bench-2/src/kimchi_agent/__init__.py
@@ -1,4 +1,5 @@
 from kimchi_agent.agent import Kimchi
+from kimchi_agent.claude_code_kimchi import ClaudeCodeKimchi
 from kimchi_agent.opencode_kimchi import OpenCodeKimchi
 
-__all__ = ["Kimchi", "OpenCodeKimchi"]
+__all__ = ["ClaudeCodeKimchi", "Kimchi", "OpenCodeKimchi"]

--- a/benchmark/terminal-bench-2/src/kimchi_agent/__init__.py
+++ b/benchmark/terminal-bench-2/src/kimchi_agent/__init__.py
@@ -1,5 +1,6 @@
 from kimchi_agent.agent import Kimchi
 from kimchi_agent.claude_code_kimchi import ClaudeCodeKimchi
+from kimchi_agent.gsd_kimchi import GsdKimchi
 from kimchi_agent.opencode_kimchi import OpenCodeKimchi
 
-__all__ = ["ClaudeCodeKimchi", "Kimchi", "OpenCodeKimchi"]
+__all__ = ["ClaudeCodeKimchi", "GsdKimchi", "Kimchi", "OpenCodeKimchi"]

--- a/benchmark/terminal-bench-2/src/kimchi_agent/agent.py
+++ b/benchmark/terminal-bench-2/src/kimchi_agent/agent.py
@@ -252,14 +252,19 @@ class Kimchi(BaseInstalledAgent):
 
     def _kimchi_launch_command(self, instruction: str, cli_flags: str) -> str:
         runner = self._kimchi_command(cli_flags)
-        return (
+        parts = [
             # Ensure kimchi has a stable location for the main session and any
             # subagent session files before the process starts.
-            f"mkdir -p {shlex.quote(CONTAINER_SESSIONS_DIR)} && "
+            f"mkdir -p {shlex.quote(CONTAINER_SESSIONS_DIR)}",
             # Drop stale state from a previous interrupted attempt in the same
             # mounted logs directory.
-            f"rm -f {shlex.quote(CONTAINER_AGENT_PGID_FILE)} && "
-            f"{self._multi_model_settings_command()}"
+            f"rm -f {shlex.quote(CONTAINER_AGENT_PGID_FILE)}",
+        ]
+        multi_model_settings = self._multi_model_settings_command()
+        if multi_model_settings:
+            parts.append(multi_model_settings)
+
+        parts.append(
             # Enable job control so the backgrounded kimchi pipeline gets a
             # process group that can be terminated as a unit on timeout.
             "set -m && { "
@@ -285,6 +290,7 @@ class Kimchi(BaseInstalledAgent):
             'exit "$agent_status"; '
             "}"
         )
+        return " && ".join(parts)
 
     def _multi_model_settings_command(self) -> str:
         if not self._multi_model_enabled:
@@ -293,7 +299,7 @@ class Kimchi(BaseInstalledAgent):
         settings_json = '{"multiModel":true}'
         return (
             f"mkdir -p {CONTAINER_HARNESS_SETTINGS_DIR} && "
-            f"printf '%s\\n' {shlex.quote(settings_json)} > {CONTAINER_HARNESS_SETTINGS} && "
+            f"printf '%s\\n' {shlex.quote(settings_json)} > {CONTAINER_HARNESS_SETTINGS}"
         )
 
     def _kimchi_command(self, cli_flags: str) -> str:

--- a/benchmark/terminal-bench-2/src/kimchi_agent/agent.py
+++ b/benchmark/terminal-bench-2/src/kimchi_agent/agent.py
@@ -8,6 +8,7 @@ from harbor.agents.installed.base import (
     CliFlag,
     with_prompt_template,
 )
+from harbor.models.trial.result import AgentInfo, ModelInfo
 from pydantic import ValidationError
 
 from kimchi_agent.config import KimchiAgentConfig
@@ -33,6 +34,38 @@ CONTAINER_LOGS_DIR = "/logs/agent"
 CONTAINER_SESSIONS_DIR = f"{CONTAINER_LOGS_DIR}/sessions"
 CONTAINER_MAIN_SESSION = f"{CONTAINER_SESSIONS_DIR}/main.jsonl"
 CONTAINER_AGENT_PGID_FILE = f"{CONTAINER_LOGS_DIR}/kimchi-agent.pgid"
+CONTAINER_HARNESS_SETTINGS_DIR = "~/.config/kimchi/harness"
+CONTAINER_HARNESS_SETTINGS = f"{CONTAINER_HARNESS_SETTINGS_DIR}/settings.json"
+KIMCHI_API_KEY_ENV = "KIMCHI_API_KEY"
+
+
+def _coerce_bool_kwarg(value: object, name: str) -> bool:
+    if value is None:
+        return False
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, str):
+        match value.strip().lower():
+            case "true" | "1" | "yes":
+                return True
+            case "false" | "0" | "no":
+                return False
+    raise ValueError(
+        f"Invalid value for '{name}': expected true/false/1/0/yes/no, got {value!r}"
+    )
+
+
+def _validate_model_name(model_name: str | None) -> None:
+    if not model_name or "/" not in model_name:
+        raise ValueError(
+            "--model is required and must be qualified with a provider "
+            "(e.g. kimchi-dev/kimi-k2.5, kimchi-dev/glm-5-fp8, kimchi-dev/minimax-m2.7)"
+        )
+    provider, model_id = model_name.split("/", 1)
+    if not provider or not model_id:
+        raise ValueError(
+            f"--model must be qualified as <provider>/<id> (got {model_name!r}); use e.g. kimchi-dev/kimi-k2.5"
+        )
 
 
 class Kimchi(BaseInstalledAgent):
@@ -57,11 +90,6 @@ class Kimchi(BaseInstalledAgent):
         CliFlag("tools", cli="--tools", type="str"),
         CliFlag("yolo", cli="--yolo", type="bool"),
         CliFlag(
-            "disable-multi-model",
-            cli="--multi-model=false",
-            type="bool",
-        ),
-        CliFlag(
             "dangerously-skip-permissions",
             cli="--dangerously-skip-permissions",
             type="bool",
@@ -71,12 +99,35 @@ class Kimchi(BaseInstalledAgent):
     ]
 
     def __init__(self, *args, **kwargs):
+        multi_model = _coerce_bool_kwarg(kwargs.pop("multi-model", False), "multi-model")
+        disable_multi_model = _coerce_bool_kwarg(
+            kwargs.pop("disable-multi-model", False), "disable-multi-model"
+        )
+        if multi_model and disable_multi_model:
+            raise ValueError(
+                "'multi-model=true' conflicts with legacy 'disable-multi-model=true'"
+            )
+
         super().__init__(*args, **kwargs)
-        self._config = KimchiAgentConfig()
+        self._multi_model_enabled = multi_model
+        config_kwargs = {}
+        api_key = self._get_env(KIMCHI_API_KEY_ENV)
+        if api_key is not None:
+            config_kwargs[KIMCHI_API_KEY_ENV] = api_key
+        self._config = KimchiAgentConfig(**config_kwargs)
 
     @staticmethod
     def name() -> str:
         return "kimchi"
+
+    def to_agent_info(self) -> AgentInfo:
+        if self._multi_model_enabled:
+            return AgentInfo(
+                name=self.name(),
+                version=self.version() or "unknown",
+                model_info=ModelInfo(name="multi-model", provider="kimchi"),
+            )
+        return super().to_agent_info()
 
     def get_version_command(self) -> str | None:
         # PI_PACKAGE_DIR tells entry.ts where to find package.json + theme/; without it
@@ -149,18 +200,11 @@ class Kimchi(BaseInstalledAgent):
         environment: BaseEnvironment,
         context: AgentContext,
     ) -> None:
-        if not self.model_name:
-            raise ValueError(
-                "--model is required and must be qualified with a provider "
-                "(e.g. kimchi-dev/kimi-k2.5, kimchi-dev/glm-5-fp8, kimchi-dev/minimax-m2.7)"
-            )
-        if "/" not in self.model_name:
+        if not self._multi_model_enabled:
             # kimchi's built-in pi-ai catalog also registers models like kimi-k2.5 under
             # the opencode provider. Without a qualifier the resolver may pick opencode and
             # fail auth with the kimchi key, so we force the caller to be explicit.
-            raise ValueError(
-                f"--model must be qualified as <provider>/<id> (got {self.model_name!r}); use e.g. kimchi-dev/kimi-k2.5"
-            )
+            _validate_model_name(self.model_name)
 
         cli_flags = self.build_cli_flags()
         if cli_flags:
@@ -215,6 +259,7 @@ class Kimchi(BaseInstalledAgent):
             # Drop stale state from a previous interrupted attempt in the same
             # mounted logs directory.
             f"rm -f {shlex.quote(CONTAINER_AGENT_PGID_FILE)} && "
+            f"{self._multi_model_settings_command()}"
             # Enable job control so the backgrounded kimchi pipeline gets a
             # process group that can be terminated as a unit on timeout.
             "set -m && { "
@@ -241,11 +286,25 @@ class Kimchi(BaseInstalledAgent):
             "}"
         )
 
+    def _multi_model_settings_command(self) -> str:
+        if not self._multi_model_enabled:
+            return ""
+
+        settings_json = '{"multiModel":true}'
+        return (
+            f"mkdir -p {CONTAINER_HARNESS_SETTINGS_DIR} && "
+            f"printf '%s\\n' {shlex.quote(settings_json)} > {CONTAINER_HARNESS_SETTINGS} && "
+        )
+
     def _kimchi_command(self, cli_flags: str) -> str:
+        model_flag = ""
+        if not self._multi_model_enabled:
+            model_flag = f"--model {shlex.quote(self.model_name or '')} "
+
         return (
             f"{shlex.quote(BINARY_PATH)} "
             f"--print --session {shlex.quote(CONTAINER_MAIN_SESSION)} "
-            f"--model {shlex.quote(self.model_name or '')} "
+            f"{model_flag}"
             f"{cli_flags}"
         )
 

--- a/benchmark/terminal-bench-2/src/kimchi_agent/agent_test.py
+++ b/benchmark/terminal-bench-2/src/kimchi_agent/agent_test.py
@@ -97,6 +97,8 @@ class KimchiHarnessTest(unittest.IsolatedAsyncioTestCase):
             self.assertNotIn("--multi-model", command)
             self.assertIn("~/.config/kimchi/harness/settings.json", command)
             self.assertIn('{"multiModel":true}', command)
+            self.assertFalse(agent._multi_model_settings_command().endswith("&& "))
+            self.assertIn(f"{agent._multi_model_settings_command()} && set -m", command)
             self.assertEqual(agent.to_agent_info().model_info.provider, "kimchi")
             self.assertEqual(agent.to_agent_info().model_info.name, "multi-model")
 

--- a/benchmark/terminal-bench-2/src/kimchi_agent/agent_test.py
+++ b/benchmark/terminal-bench-2/src/kimchi_agent/agent_test.py
@@ -66,6 +66,101 @@ class KimchiHarnessTest(unittest.IsolatedAsyncioTestCase):
             self.assertIn(f"rm -f {CONTAINER_AGENT_PGID_FILE}", agent.root_commands[0])
             self.assertNotIn("pkill", agent.root_commands[0])
 
+    async def test_single_model_run_passes_model_without_multi_model_cli_flag(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            agent = RecordingKimchi(
+                logs_dir=Path(tmp) / "jobs" / "run-1" / "task__trial" / "agent",
+                model_name="kimchi-dev/kimi-k2.6",
+            )
+
+            with self.assertRaises(asyncio.CancelledError):
+                await agent.run("hello", object(), AgentContext())
+
+            command = agent.agent_commands[0]
+            self.assertIn("--model kimchi-dev/kimi-k2.6", command)
+            self.assertNotIn("--multi-model", command)
+            self.assertNotIn(".config/kimchi/harness/settings.json", command)
+
+    async def test_multi_model_run_omits_model_and_enables_harness_setting(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            agent = RecordingKimchi(
+                logs_dir=Path(tmp) / "jobs" / "run-1" / "task__trial" / "agent",
+                model_name="kimchi-dev/kimi-k2.6",
+                **{"multi-model": True},
+            )
+
+            with self.assertRaises(asyncio.CancelledError):
+                await agent.run("hello", object(), AgentContext())
+
+            command = agent.agent_commands[0]
+            self.assertNotIn("--model", command)
+            self.assertNotIn("--multi-model", command)
+            self.assertIn("~/.config/kimchi/harness/settings.json", command)
+            self.assertIn('{"multiModel":true}', command)
+            self.assertEqual(agent.to_agent_info().model_info.provider, "kimchi")
+            self.assertEqual(agent.to_agent_info().model_info.name, "multi-model")
+
+    async def test_multi_model_run_does_not_require_model_name(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            agent = RecordingKimchi(
+                logs_dir=Path(tmp) / "jobs" / "run-1" / "task__trial" / "agent",
+                **{"multi-model": "true"},
+            )
+
+            with self.assertRaises(asyncio.CancelledError):
+                await agent.run("hello", object(), AgentContext())
+
+            self.assertNotIn("--model", agent.agent_commands[0])
+
+    async def test_api_key_can_come_from_agent_extra_env(self) -> None:
+        os.environ.pop("KIMCHI_API_KEY", None)
+        with tempfile.TemporaryDirectory() as tmp:
+            agent = RecordingKimchi(
+                logs_dir=Path(tmp) / "jobs" / "run-1" / "task__trial" / "agent",
+                model_name="kimchi-dev/kimi-k2.6",
+                extra_env={"KIMCHI_API_KEY": "extra-key"},
+            )
+
+            with self.assertRaises(asyncio.CancelledError):
+                await agent.run("hello", object(), AgentContext())
+
+            self.assertEqual(agent.agent_envs[0]["KIMCHI_API_KEY"], "extra-key")
+
+    async def test_legacy_disable_multi_model_kwarg_does_not_emit_removed_cli_flag(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            agent = RecordingKimchi(
+                logs_dir=Path(tmp) / "jobs" / "run-1" / "task__trial" / "agent",
+                model_name="kimchi-dev/kimi-k2.6",
+                **{"disable-multi-model": True},
+            )
+
+            with self.assertRaises(asyncio.CancelledError):
+                await agent.run("hello", object(), AgentContext())
+
+            command = agent.agent_commands[0]
+            self.assertIn("--model kimchi-dev/kimi-k2.6", command)
+            self.assertNotIn("--multi-model", command)
+
+    def test_multi_model_and_legacy_disable_multi_model_conflict(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp, self.assertRaises(ValueError):
+            RecordingKimchi(
+                logs_dir=Path(tmp) / "jobs" / "run-1" / "task__trial" / "agent",
+                model_name="kimchi-dev/kimi-k2.6",
+                **{"multi-model": True, "disable-multi-model": True},
+            )
+
+    async def test_single_model_rejects_empty_model_id(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            agent = RecordingKimchi(
+                logs_dir=Path(tmp) / "jobs" / "run-1" / "task__trial" / "agent",
+                model_name="kimchi-dev/",
+            )
+
+            with self.assertRaisesRegex(ValueError, "<provider>/<id>"):
+                await agent.run("hello", object(), AgentContext())
+
+            self.assertEqual(agent.agent_commands, [])
+
     async def test_populate_context_skips_unreadable_session_files(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:
             logs_dir = Path(tmp) / "jobs" / "run-1" / "task__trial" / "agent"

--- a/benchmark/terminal-bench-2/src/kimchi_agent/claude_code_kimchi.py
+++ b/benchmark/terminal-bench-2/src/kimchi_agent/claude_code_kimchi.py
@@ -97,13 +97,20 @@ class ClaudeCodeKimchi(KimchiGatewayMixin, ClaudeCode):
         api_key = self._required_kimchi_api_key()
         model = self._selected_model_metadata(api_key)
         model_id = model.slug
+        blocked_env_keys = FORCED_ENV_KEYS | DENIED_ENV_KEYS
         env = self._passthrough_env(
             prefixes=CLAUDE_PASSTHROUGH_ENV_PREFIXES,
             keys=CLAUDE_PASSTHROUGH_ENV_KEYS,
             blocked_prefixes=BLOCKED_ENV_PREFIXES,
-            blocked_keys=FORCED_ENV_KEYS | DENIED_ENV_KEYS,
+            blocked_keys=blocked_env_keys,
         )
-        env.update(self._resolved_env_vars)
+        env.update(
+            {
+                key: value
+                for key, value in self._resolved_env_vars.items()
+                if key not in blocked_env_keys and not key.startswith(BLOCKED_ENV_PREFIXES)
+            }
+        )
         env.update({
             "ANTHROPIC_API_KEY": "",
             "ANTHROPIC_AUTH_TOKEN": api_key,
@@ -128,7 +135,7 @@ class ClaudeCodeKimchi(KimchiGatewayMixin, ClaudeCode):
         # Harbor merges _extra_env over env=. Remove keys from that channel so
         # per-call env= remains authoritative without copying secrets there.
         self._scrub_extra_env(
-            keys=FORCED_ENV_KEYS | DENIED_ENV_KEYS,
+            keys=blocked_env_keys,
             prefixes=BLOCKED_ENV_PREFIXES,
         )
 
@@ -163,6 +170,7 @@ class ClaudeCodeKimchi(KimchiGatewayMixin, ClaudeCode):
         extra_flags = (cli_flags + " ") if cli_flags else ""
         return (
             'export PATH="$HOME/.local/bin:$PATH"; '
+            "set -o pipefail; "
             f"claude --verbose --output-format=stream-json "
             f"--permission-mode=bypassPermissions "
             f"{extra_flags}"

--- a/benchmark/terminal-bench-2/src/kimchi_agent/claude_code_kimchi.py
+++ b/benchmark/terminal-bench-2/src/kimchi_agent/claude_code_kimchi.py
@@ -1,6 +1,8 @@
+import json
 import shlex
+from typing import Any
 
-from harbor.agents.installed.base import with_prompt_template
+from harbor.agents.installed.base import NonZeroAgentExitCodeError, with_prompt_template
 from harbor.agents.installed.claude_code import ClaudeCode
 from harbor.environments.base import BaseEnvironment
 from harbor.models.agent.context import AgentContext
@@ -12,7 +14,12 @@ from kimchi_agent.gateway import (
     KimchiModelMetadata,
 )
 
-CLAUDE_CODE_AUTO_COMPACT_PERCENT = 92
+CLAUDE_CODE_AUTO_COMPACT_PERCENT = 85
+CLAUDE_CODE_OUTPUT_RESERVE_TOKENS = 32_768
+CLAUDE_CODE_CONTEXT_SAFETY_MARGIN_TOKENS = 8_192
+CLAUDE_CODE_OUTPUT_PATH = "/logs/agent/claude-code.txt"
+RETRYABLE_API_STATUSES = frozenset({408, 409, 425, 429, 500, 502, 503, 504, 524, 529})
+RETRYABLE_API_ERROR_MESSAGE_LIMIT = 2_000
 CLAUDE_PASSTHROUGH_ENV_PREFIXES = ("CLAUDE_CODE_", "OTEL_")
 CLAUDE_PASSTHROUGH_ENV_KEYS = {
     "API_TIMEOUT_MS",
@@ -60,6 +67,16 @@ FORCED_ENV_KEYS = {
 }
 
 
+class RetryableApiError(RuntimeError):
+    """Raised when the agent failed because an upstream API returned a transient error."""
+
+    def __init__(self, status: int, detail: str) -> None:
+        self.status = status
+        detail = detail.strip()
+        suffix = f": {detail}" if detail else ""
+        super().__init__(f"Retryable API error {status}{suffix}")
+
+
 class ClaudeCodeKimchi(KimchiGatewayMixin, ClaudeCode):
     """Harbor Claude Code agent wired to the Kimchi Anthropic gateway."""
 
@@ -69,7 +86,12 @@ class ClaudeCodeKimchi(KimchiGatewayMixin, ClaudeCode):
 
     @staticmethod
     def _auto_compact_window(model: KimchiModelMetadata) -> str:
-        return str(max(1, model.limits.context_window * CLAUDE_CODE_AUTO_COMPACT_PERCENT // 100))
+        context_window = model.limits.context_window
+        output_reserve = min(CLAUDE_CODE_OUTPUT_RESERVE_TOKENS, max(1, context_window // 4))
+        safety_margin = min(CLAUDE_CODE_CONTEXT_SAFETY_MARGIN_TOKENS, max(1, context_window // 16))
+        percent_window = context_window * CLAUDE_CODE_AUTO_COMPACT_PERCENT // 100
+        reserved_window = context_window - output_reserve - safety_margin
+        return str(max(1, min(percent_window, reserved_window)))
 
     def _build_env(self) -> dict[str, str]:
         api_key = self._required_kimchi_api_key()
@@ -145,8 +167,99 @@ class ClaudeCodeKimchi(KimchiGatewayMixin, ClaudeCode):
             f"--permission-mode=bypassPermissions "
             f"{extra_flags}"
             f"--print -- {shlex.quote(instruction)} 2>&1 </dev/null | tee "
-            "/logs/agent/claude-code.txt"
+            f"{shlex.quote(CLAUDE_CODE_OUTPUT_PATH)}"
         )
+
+    @staticmethod
+    def _coerce_status(value: Any) -> int | None:
+        if isinstance(value, bool):
+            return None
+        if isinstance(value, int):
+            return value
+        if isinstance(value, str):
+            try:
+                return int(value)
+            except ValueError:
+                return None
+        return None
+
+    @staticmethod
+    def _event_text(event: dict[str, Any]) -> str:
+        result = event.get("result")
+        if isinstance(result, str):
+            return result
+
+        message = event.get("message")
+        if isinstance(message, dict):
+            content = message.get("content")
+            if isinstance(content, str):
+                return content
+            if isinstance(content, list):
+                parts: list[str] = []
+                for item in content:
+                    if isinstance(item, dict):
+                        text = item.get("text")
+                        if isinstance(text, str):
+                            parts.append(text)
+                    elif isinstance(item, str):
+                        parts.append(item)
+                if parts:
+                    return "\n".join(parts)
+
+        error = event.get("error")
+        return error if isinstance(error, str) else ""
+
+    @classmethod
+    def _retryable_api_error_from_event(cls, event: dict[str, Any]) -> RetryableApiError | None:
+        status = cls._coerce_status(event.get("api_error_status"))
+        if status not in RETRYABLE_API_STATUSES:
+            return None
+
+        is_result_error = event.get("type") == "result" and event.get("is_error") is True
+        has_error_marker = event.get("error") is not None
+        if not is_result_error and not has_error_marker:
+            return None
+
+        detail = cls._event_text(event)
+        if len(detail) > RETRYABLE_API_ERROR_MESSAGE_LIMIT:
+            detail = f"{detail[:RETRYABLE_API_ERROR_MESSAGE_LIMIT]}..."
+        return RetryableApiError(status, detail)
+
+    @classmethod
+    def _retryable_api_error_from_stream(cls, stream: str) -> RetryableApiError | None:
+        retryable_error: RetryableApiError | None = None
+        for line in stream.splitlines():
+            line = line.strip()
+            if not line:
+                continue
+            try:
+                event = json.loads(line)
+            except json.JSONDecodeError:
+                continue
+            if not isinstance(event, dict):
+                continue
+
+            event_error = cls._retryable_api_error_from_event(event)
+            if event_error is not None:
+                retryable_error = event_error
+        return retryable_error
+
+    async def _retryable_api_error_from_remote_log(
+        self,
+        environment: BaseEnvironment,
+    ) -> RetryableApiError | None:
+        try:
+            result = await environment.exec(
+                f"cat {shlex.quote(CLAUDE_CODE_OUTPUT_PATH)}",
+                timeout_sec=10,
+            )
+        except Exception:
+            self.logger.debug("Failed to read Claude Code output for API error classification", exc_info=True)
+            return None
+
+        if result.return_code != 0 or not result.stdout:
+            return None
+        return self._retryable_api_error_from_stream(result.stdout)
 
     @with_prompt_template
     async def run(
@@ -162,8 +275,14 @@ class ClaudeCodeKimchi(KimchiGatewayMixin, ClaudeCode):
             command=self._build_setup_command(),
             env=env,
         )
-        await self.exec_as_agent(
-            environment,
-            command=self._build_run_command(instruction),
-            env=env,
-        )
+        try:
+            await self.exec_as_agent(
+                environment,
+                command=self._build_run_command(instruction),
+                env=env,
+            )
+        except NonZeroAgentExitCodeError as exc:
+            retryable_error = await self._retryable_api_error_from_remote_log(environment)
+            if retryable_error is not None:
+                raise retryable_error from exc
+            raise

--- a/benchmark/terminal-bench-2/src/kimchi_agent/claude_code_kimchi.py
+++ b/benchmark/terminal-bench-2/src/kimchi_agent/claude_code_kimchi.py
@@ -1,0 +1,169 @@
+import shlex
+
+from harbor.agents.installed.base import with_prompt_template
+from harbor.agents.installed.claude_code import ClaudeCode
+from harbor.environments.base import BaseEnvironment
+from harbor.models.agent.context import AgentContext
+from harbor.models.trial.paths import EnvironmentPaths
+
+from kimchi_agent.gateway import (
+    KIMCHI_ANTHROPIC_BASE_URL,
+    KimchiGatewayMixin,
+    KimchiModelMetadata,
+)
+
+CLAUDE_CODE_AUTO_COMPACT_PERCENT = 92
+CLAUDE_PASSTHROUGH_ENV_PREFIXES = ("CLAUDE_CODE_", "OTEL_")
+CLAUDE_PASSTHROUGH_ENV_KEYS = {
+    "API_TIMEOUT_MS",
+    "MAX_THINKING_TOKENS",
+}
+BLOCKED_ENV_PREFIXES = ("BASH",)
+DENIED_ENV_KEYS = {
+    "ANTHROPIC_SMALL_FAST_MODEL_AWS_REGION",
+    "ANTHROPIC_VERTEX_PROJECT_ID",
+    "AWS_ACCESS_KEY_ID",
+    "AWS_BEARER_TOKEN_BEDROCK",
+    "AWS_DEFAULT_REGION",
+    "AWS_PROFILE",
+    "AWS_REGION",
+    "AWS_SECRET_ACCESS_KEY",
+    "AWS_SESSION_TOKEN",
+    "CLAUDE_CODE_OAUTH_TOKEN",
+    "CLAUDE_CODE_USE_BEDROCK",
+    "CLAUDE_CODE_USE_VERTEX",
+    "CLOUD_ML_REGION",
+    "DISABLE_PROMPT_CACHING",
+    "GOOGLE_APPLICATION_CREDENTIALS",
+    "GOOGLE_CLOUD_LOCATION",
+    "GOOGLE_CLOUD_PROJECT",
+}
+
+FORCED_ENV_KEYS = {
+    "ANTHROPIC_API_KEY",
+    "ANTHROPIC_AUTH_TOKEN",
+    "ANTHROPIC_BASE_URL",
+    "ANTHROPIC_MODEL",
+    "ANTHROPIC_DEFAULT_SONNET_MODEL",
+    "ANTHROPIC_DEFAULT_OPUS_MODEL",
+    "ANTHROPIC_DEFAULT_HAIKU_MODEL",
+    "ANTHROPIC_SMALL_FAST_MODEL",
+    "ANTHROPIC_CUSTOM_MODEL_OPTION",
+    "CLAUDE_CODE_SUBAGENT_MODEL",
+    "CLAUDE_CODE_DISABLE_EXPERIMENTAL_BETAS",
+    "CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC",
+    "CLAUDE_CODE_AUTO_COMPACT_WINDOW",
+    "CLAUDE_CONFIG_DIR",
+    "ENABLE_BACKGROUND_TASKS",
+    "FORCE_AUTO_BACKGROUND_TASKS",
+    "IS_SANDBOX",
+}
+
+
+class ClaudeCodeKimchi(KimchiGatewayMixin, ClaudeCode):
+    """Harbor Claude Code agent wired to the Kimchi Anthropic gateway."""
+
+    @staticmethod
+    def name() -> str:
+        return "claude-code-kimchi"
+
+    @staticmethod
+    def _auto_compact_window(model: KimchiModelMetadata) -> str:
+        return str(max(1, model.limits.context_window * CLAUDE_CODE_AUTO_COMPACT_PERCENT // 100))
+
+    def _build_env(self) -> dict[str, str]:
+        api_key = self._required_kimchi_api_key()
+        model = self._selected_model_metadata(api_key)
+        model_id = model.slug
+        env = self._passthrough_env(
+            prefixes=CLAUDE_PASSTHROUGH_ENV_PREFIXES,
+            keys=CLAUDE_PASSTHROUGH_ENV_KEYS,
+            blocked_prefixes=BLOCKED_ENV_PREFIXES,
+            blocked_keys=FORCED_ENV_KEYS | DENIED_ENV_KEYS,
+        )
+        env.update(self._resolved_env_vars)
+        env.update({
+            "ANTHROPIC_API_KEY": "",
+            "ANTHROPIC_AUTH_TOKEN": api_key,
+            "ANTHROPIC_BASE_URL": KIMCHI_ANTHROPIC_BASE_URL,
+            "ANTHROPIC_MODEL": model_id,
+            "ANTHROPIC_DEFAULT_SONNET_MODEL": model_id,
+            "ANTHROPIC_DEFAULT_OPUS_MODEL": model_id,
+            "ANTHROPIC_DEFAULT_HAIKU_MODEL": model_id,
+            "ANTHROPIC_SMALL_FAST_MODEL": model_id,
+            "ANTHROPIC_CUSTOM_MODEL_OPTION": model_id,
+            "CLAUDE_CODE_SUBAGENT_MODEL": model_id,
+            "CLAUDE_CODE_DISABLE_EXPERIMENTAL_BETAS": "1",
+            "CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC": "1",
+            "CLAUDE_CODE_AUTO_COMPACT_WINDOW": self._auto_compact_window(model),
+            "CLAUDE_CONFIG_DIR": (EnvironmentPaths.agent_dir / "sessions").as_posix(),
+            "ENABLE_BACKGROUND_TASKS": "1",
+            "FORCE_AUTO_BACKGROUND_TASKS": "1",
+            "IS_SANDBOX": "1",
+        })
+        env.update({key: "" for key in DENIED_ENV_KEYS})
+
+        # Harbor merges _extra_env over env=. Remove keys from that channel so
+        # per-call env= remains authoritative without copying secrets there.
+        self._scrub_extra_env(
+            keys=FORCED_ENV_KEYS | DENIED_ENV_KEYS,
+            prefixes=BLOCKED_ENV_PREFIXES,
+        )
+
+        return {key: value for key, value in env.items() if value is not None}
+
+    def _build_setup_command(self) -> str:
+        setup_command = (
+            "mkdir -p $CLAUDE_CONFIG_DIR/debug $CLAUDE_CONFIG_DIR/projects/-app "
+            "$CLAUDE_CONFIG_DIR/shell-snapshots $CLAUDE_CONFIG_DIR/statsig "
+            "$CLAUDE_CONFIG_DIR/todos $CLAUDE_CONFIG_DIR/skills && "
+            "if [ -d ~/.claude/skills ]; then "
+            "cp -r ~/.claude/skills/. $CLAUDE_CONFIG_DIR/skills/ 2>/dev/null || true; "
+            "fi"
+        )
+
+        skills_command = self._build_register_skills_command()
+        if skills_command:
+            setup_command += f" && {skills_command}"
+
+        memory_command = self._build_register_memory_command()
+        if memory_command:
+            setup_command += f" && {memory_command}"
+
+        mcp_command = self._build_register_mcp_servers_command()
+        if mcp_command:
+            setup_command += f" && {mcp_command}"
+
+        return setup_command
+
+    def _build_run_command(self, instruction: str) -> str:
+        cli_flags = self.build_cli_flags()
+        extra_flags = (cli_flags + " ") if cli_flags else ""
+        return (
+            'export PATH="$HOME/.local/bin:$PATH"; '
+            f"claude --verbose --output-format=stream-json "
+            f"--permission-mode=bypassPermissions "
+            f"{extra_flags}"
+            f"--print -- {shlex.quote(instruction)} 2>&1 </dev/null | tee "
+            "/logs/agent/claude-code.txt"
+        )
+
+    @with_prompt_template
+    async def run(
+        self,
+        instruction: str,
+        environment: BaseEnvironment,
+        context: AgentContext,
+    ) -> None:
+        env = self._build_env()
+
+        await self.exec_as_agent(
+            environment,
+            command=self._build_setup_command(),
+            env=env,
+        )
+        await self.exec_as_agent(
+            environment,
+            command=self._build_run_command(instruction),
+            env=env,
+        )

--- a/benchmark/terminal-bench-2/src/kimchi_agent/claude_code_kimchi_test.py
+++ b/benchmark/terminal-bench-2/src/kimchi_agent/claude_code_kimchi_test.py
@@ -1,0 +1,302 @@
+import os
+import tempfile
+import unittest
+from pathlib import Path
+from typing import ClassVar
+from unittest.mock import patch
+
+from harbor.models.agent.context import AgentContext
+
+from kimchi_agent.claude_code_kimchi import (
+    KIMCHI_ANTHROPIC_BASE_URL,
+    ClaudeCodeKimchi,
+)
+from kimchi_agent.gateway import (
+    KIMCHI_MODELS_METADATA_URL,
+    KimchiModelMetadata,
+    KimchiModelsMetadataResponse,
+)
+
+
+class FakeMetadataResponse:
+    def __init__(self, body: dict[str, object]) -> None:
+        self._body = body
+
+    def raise_for_status(self) -> None:
+        return None
+
+    def json(self) -> dict[str, object]:
+        return self._body
+
+
+class RecordingClaudeCodeKimchi(ClaudeCodeKimchi):
+    metadata: ClassVar[list[dict[str, object]]] = [
+        {
+            "slug": "kimi-k2.5",
+            "display_name": "Kimi K2.5",
+            "reasoning": True,
+            "limits": {"context_window": 262144, "max_output_tokens": 262144},
+        },
+        {
+            "slug": "minimax-m2.7",
+            "display_name": "MiniMax M2.7",
+            "reasoning": True,
+            "limits": {"context_window": 196608, "max_output_tokens": 196608},
+        },
+    ]
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.agent_commands: list[str] = []
+        self.agent_envs: list[dict[str, str] | None] = []
+        self.effective_agent_envs: list[dict[str, str]] = []
+        self.metadata_fetch_count = 0
+
+    async def exec_as_agent(self, _environment, command: str, env=None, cwd=None, timeout_sec=None):
+        self.agent_commands.append(command)
+        self.agent_envs.append(env)
+        merged_env = dict(env) if env else {}
+        merged_env.update(self._extra_env)
+        self.effective_agent_envs.append(merged_env)
+
+    def _fetch_model_metadata(self, api_key: str) -> list[KimchiModelMetadata]:
+        self.metadata_fetch_count += 1
+        self.fetched_with_api_key = api_key
+        return KimchiModelsMetadataResponse.model_validate({"models": self.metadata}).models
+
+
+class ClaudeCodeKimchiTest(unittest.IsolatedAsyncioTestCase):
+    def setUp(self) -> None:
+        self._old_api_key = os.environ.get("KIMCHI_API_KEY")
+        os.environ["KIMCHI_API_KEY"] = "test-key"
+
+    def tearDown(self) -> None:
+        if self._old_api_key is None:
+            os.environ.pop("KIMCHI_API_KEY", None)
+        else:
+            os.environ["KIMCHI_API_KEY"] = self._old_api_key
+
+    async def test_runs_claude_code_against_selected_kimchi_model(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            agent = RecordingClaudeCodeKimchi(
+                logs_dir=Path(tmp) / "jobs" / "run-1" / "task__trial" / "agent",
+                model_name="kimchi-dev/minimax-m2.7",
+            )
+
+            await agent.run("solve it", object(), AgentContext())
+
+        self.assertEqual(len(agent.agent_commands), 2)
+        setup_command, run_command = agent.agent_commands
+        env = agent.agent_envs[0]
+        self.assertIsNotNone(env)
+
+        self.assertIn("$CLAUDE_CONFIG_DIR/projects/-app", setup_command)
+        self.assertIn("claude --verbose --output-format=stream-json", run_command)
+        self.assertIn("--permission-mode=bypassPermissions", run_command)
+        self.assertIn("--print -- 'solve it'", run_command)
+
+        self.assertEqual(env["ANTHROPIC_BASE_URL"], KIMCHI_ANTHROPIC_BASE_URL)
+        self.assertEqual(env["ANTHROPIC_AUTH_TOKEN"], "test-key")
+        self.assertEqual(env["ANTHROPIC_API_KEY"], "")
+        self.assertEqual(env["ANTHROPIC_MODEL"], "minimax-m2.7")
+        for key in (
+            "ANTHROPIC_DEFAULT_SONNET_MODEL",
+            "ANTHROPIC_DEFAULT_OPUS_MODEL",
+            "ANTHROPIC_DEFAULT_HAIKU_MODEL",
+            "ANTHROPIC_SMALL_FAST_MODEL",
+            "ANTHROPIC_CUSTOM_MODEL_OPTION",
+            "CLAUDE_CODE_SUBAGENT_MODEL",
+        ):
+            self.assertEqual(env[key], "minimax-m2.7")
+        self.assertEqual(env["CLAUDE_CODE_DISABLE_EXPERIMENTAL_BETAS"], "1")
+        self.assertEqual(env["CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC"], "1")
+        self.assertLess(int(env["CLAUDE_CODE_AUTO_COMPACT_WINDOW"]), 196608)
+        self.assertEqual(env["IS_SANDBOX"], "1")
+        self.assertEqual(agent.agent_envs[1], env)
+        self.assertEqual(agent.metadata_fetch_count, 1)
+        self.assertEqual(agent.fetched_with_api_key, "test-key")
+
+    async def test_api_key_can_come_from_agent_extra_env(self) -> None:
+        os.environ.pop("KIMCHI_API_KEY", None)
+        with tempfile.TemporaryDirectory() as tmp:
+            agent = RecordingClaudeCodeKimchi(
+                logs_dir=Path(tmp) / "jobs" / "run-1" / "task__trial" / "agent",
+                model_name="kimchi-dev/kimi-k2.5",
+                extra_env={"KIMCHI_API_KEY": "extra-key"},
+            )
+
+            await agent.run("solve it", object(), AgentContext())
+
+        self.assertEqual(agent.agent_envs[0]["ANTHROPIC_AUTH_TOKEN"], "extra-key")
+        self.assertEqual(agent.fetched_with_api_key, "extra-key")
+
+    async def test_rejects_non_kimchi_provider(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            agent = RecordingClaudeCodeKimchi(
+                logs_dir=Path(tmp) / "jobs" / "run-1" / "task__trial" / "agent",
+                model_name="anthropic/claude-opus-4-6",
+            )
+
+            with self.assertRaisesRegex(ValueError, "only supports kimchi-dev"):
+                await agent.run("solve it", object(), AgentContext())
+
+        self.assertEqual(agent.agent_commands, [])
+
+    async def test_rejects_model_missing_from_metadata_endpoint(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            agent = RecordingClaudeCodeKimchi(
+                logs_dir=Path(tmp) / "jobs" / "run-1" / "task__trial" / "agent",
+                model_name="kimchi-dev/not-returned",
+            )
+
+            with self.assertRaisesRegex(ValueError, "was not returned"):
+                await agent.run("solve it", object(), AgentContext())
+
+        self.assertEqual(agent.agent_commands, [])
+
+    async def test_missing_kimchi_api_key_fails_before_commands(self) -> None:
+        os.environ.pop("KIMCHI_API_KEY", None)
+        with tempfile.TemporaryDirectory() as tmp:
+            agent = RecordingClaudeCodeKimchi(
+                logs_dir=Path(tmp) / "jobs" / "run-1" / "task__trial" / "agent",
+                model_name="kimchi-dev/kimi-k2.5",
+            )
+
+            with self.assertRaisesRegex(ValueError, "KIMCHI_API_KEY is required"):
+                await agent.run("solve it", object(), AgentContext())
+
+        self.assertEqual(agent.agent_commands, [])
+
+    async def test_extra_env_cannot_override_forced_anthropic_routing(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            agent = RecordingClaudeCodeKimchi(
+                logs_dir=Path(tmp) / "jobs" / "run-1" / "task__trial" / "agent",
+                model_name="kimchi-dev/kimi-k2.5",
+                extra_env={
+                    "ANTHROPIC_BASE_URL": "https://api.anthropic.com",
+                    "ANTHROPIC_AUTH_TOKEN": "wrong-key",
+                    "ANTHROPIC_API_KEY": "wrong-key",
+                    "ANTHROPIC_MODEL": "claude-opus-4-6",
+                    "CLAUDE_CODE_MAX_OUTPUT_TOKENS": "8192",
+                },
+            )
+
+            await agent.run("solve it", object(), AgentContext())
+
+        env = agent.agent_envs[0]
+        self.assertEqual(env["ANTHROPIC_BASE_URL"], KIMCHI_ANTHROPIC_BASE_URL)
+        self.assertEqual(env["ANTHROPIC_AUTH_TOKEN"], "test-key")
+        self.assertEqual(env["ANTHROPIC_API_KEY"], "")
+        self.assertEqual(env["ANTHROPIC_MODEL"], "kimi-k2.5")
+        self.assertEqual(env["CLAUDE_CODE_MAX_OUTPUT_TOKENS"], "8192")
+        effective_env = agent.effective_agent_envs[0]
+        self.assertEqual(effective_env["ANTHROPIC_BASE_URL"], KIMCHI_ANTHROPIC_BASE_URL)
+        self.assertEqual(effective_env["ANTHROPIC_AUTH_TOKEN"], "test-key")
+        self.assertEqual(effective_env["ANTHROPIC_API_KEY"], "")
+
+    async def test_clears_off_gateway_claude_auth_envs(self) -> None:
+        off_gateway_env = {
+            "AWS_ACCESS_KEY_ID": "aws-id",
+            "AWS_BEARER_TOKEN_BEDROCK": "bedrock-token",
+            "AWS_REGION": "us-east-1",
+            "AWS_SECRET_ACCESS_KEY": "aws-secret",
+            "CLAUDE_CODE_OAUTH_TOKEN": "oauth-token",
+            "CLAUDE_CODE_USE_BEDROCK": "1",
+            "CLAUDE_CODE_USE_VERTEX": "1",
+            "GOOGLE_APPLICATION_CREDENTIALS": "/tmp/google-creds.json",
+        }
+        with patch.dict(os.environ, off_gateway_env), tempfile.TemporaryDirectory() as tmp:
+            agent = RecordingClaudeCodeKimchi(
+                logs_dir=Path(tmp) / "jobs" / "run-1" / "task__trial" / "agent",
+                model_name="kimchi-dev/kimi-k2.5",
+                extra_env={
+                    **off_gateway_env,
+                    "CLAUDE_CODE_MAX_OUTPUT_TOKENS": "8192",
+                },
+            )
+
+            await agent.run("solve it", object(), AgentContext())
+
+        env = agent.agent_envs[0]
+        effective_env = agent.effective_agent_envs[0]
+        self.assertEqual(env["CLAUDE_CODE_MAX_OUTPUT_TOKENS"], "8192")
+        for key in off_gateway_env:
+            self.assertEqual(effective_env.get(key), "")
+
+    async def test_declared_env_vars_cannot_override_forced_anthropic_routing(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            agent = RecordingClaudeCodeKimchi(
+                logs_dir=Path(tmp) / "jobs" / "run-1" / "task__trial" / "agent",
+                model_name="kimchi-dev/kimi-k2.5",
+            )
+            agent._resolved_env_vars.update({
+                "ANTHROPIC_MODEL": "claude-opus-4-6",
+                "CLAUDE_CODE_OAUTH_TOKEN": "oauth-token",
+                "CLAUDE_CODE_AUTO_COMPACT_WINDOW": "999999",
+                "CLAUDE_CODE_USE_BEDROCK": "1",
+                "MAX_THINKING_TOKENS": "2048",
+            })
+
+            await agent.run("solve it", object(), AgentContext())
+
+        env = agent.agent_envs[0]
+        self.assertEqual(env["ANTHROPIC_MODEL"], "kimi-k2.5")
+        self.assertLess(int(env["CLAUDE_CODE_AUTO_COMPACT_WINDOW"]), 262144)
+        self.assertEqual(env["CLAUDE_CODE_OAUTH_TOKEN"], "")
+        self.assertEqual(env["CLAUDE_CODE_USE_BEDROCK"], "")
+        self.assertEqual(env["MAX_THINKING_TOKENS"], "2048")
+
+    async def test_does_not_passthrough_bash_environment(self) -> None:
+        bash_env = {
+            "BASH_ENV": "/tmp/evil",
+            "BASH_FUNC_bad%%": "() { echo shellshock; }",
+            "BASH_VERSION": "5.2.0",
+        }
+        with patch.dict(os.environ, bash_env), tempfile.TemporaryDirectory() as tmp:
+            agent = RecordingClaudeCodeKimchi(
+                logs_dir=Path(tmp) / "jobs" / "run-1" / "task__trial" / "agent",
+                model_name="kimchi-dev/kimi-k2.5",
+                extra_env=bash_env,
+            )
+
+            await agent.run("solve it", object(), AgentContext())
+
+        env = agent.agent_envs[0]
+        self.assertNotIn("BASH_ENV", env)
+        self.assertNotIn("BASH_FUNC_bad%%", env)
+        self.assertNotIn("BASH_VERSION", env)
+        effective_env = agent.effective_agent_envs[0]
+        self.assertNotIn("BASH_ENV", effective_env)
+        self.assertNotIn("BASH_FUNC_bad%%", effective_env)
+        self.assertNotIn("BASH_VERSION", effective_env)
+
+    async def test_rejects_invalid_metadata_response(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            agent = ClaudeCodeKimchi(
+                logs_dir=Path(tmp) / "jobs" / "run-1" / "task__trial" / "agent",
+                model_name="kimchi-dev/kimi-k2.5",
+            )
+            response = FakeMetadataResponse({
+                "models": [
+                    {
+                        "slug": "kimi-k2.5",
+                        "reasoning": "true",
+                        "limits": {"context_window": "262144", "max_output_tokens": 262144},
+                    }
+                ]
+            })
+
+            with (
+                patch("kimchi_agent.gateway.httpx.get", return_value=response) as http_get,
+                self.assertRaisesRegex(RuntimeError, "Failed to parse Kimchi model metadata"),
+            ):
+                await agent.run("solve it", object(), AgentContext())
+
+        http_get.assert_called_once()
+        self.assertEqual(http_get.call_args.kwargs["headers"], {"Authorization": "Bearer test-key"})
+        self.assertEqual(http_get.call_args.kwargs["timeout"], 5)
+        self.assertEqual(http_get.call_args.args, (KIMCHI_MODELS_METADATA_URL,))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/benchmark/terminal-bench-2/src/kimchi_agent/claude_code_kimchi_test.py
+++ b/benchmark/terminal-bench-2/src/kimchi_agent/claude_code_kimchi_test.py
@@ -1,3 +1,4 @@
+import json
 import os
 import tempfile
 import unittest
@@ -5,11 +6,16 @@ from pathlib import Path
 from typing import ClassVar
 from unittest.mock import patch
 
+from harbor.agents.installed.base import NonZeroAgentExitCodeError
+from harbor.environments.base import ExecResult
 from harbor.models.agent.context import AgentContext
 
 from kimchi_agent.claude_code_kimchi import (
+    CLAUDE_CODE_CONTEXT_SAFETY_MARGIN_TOKENS,
+    CLAUDE_CODE_OUTPUT_RESERVE_TOKENS,
     KIMCHI_ANTHROPIC_BASE_URL,
     ClaudeCodeKimchi,
+    RetryableApiError,
 )
 from kimchi_agent.gateway import (
     KIMCHI_MODELS_METADATA_URL,
@@ -65,6 +71,28 @@ class RecordingClaudeCodeKimchi(ClaudeCodeKimchi):
         return KimchiModelsMetadataResponse.model_validate({"models": self.metadata}).models
 
 
+class FailingClaudeCodeKimchi(RecordingClaudeCodeKimchi):
+    def __init__(self, *args, failure: Exception, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.failure = failure
+
+    async def exec_as_agent(self, _environment, command: str, env=None, cwd=None, timeout_sec=None):
+        await super().exec_as_agent(_environment, command, env=env, cwd=cwd, timeout_sec=timeout_sec)
+        if len(self.agent_commands) == 2:
+            raise self.failure
+
+
+class FakeEnvironment:
+    def __init__(self, stdout: str, return_code: int = 0) -> None:
+        self.stdout = stdout
+        self.return_code = return_code
+        self.commands: list[str] = []
+
+    async def exec(self, command: str, cwd=None, env=None, timeout_sec=None, user=None):
+        self.commands.append(command)
+        return ExecResult(stdout=self.stdout, stderr="", return_code=self.return_code)
+
+
 class ClaudeCodeKimchiTest(unittest.IsolatedAsyncioTestCase):
     def setUp(self) -> None:
         self._old_api_key = os.environ.get("KIMCHI_API_KEY")
@@ -94,6 +122,9 @@ class ClaudeCodeKimchiTest(unittest.IsolatedAsyncioTestCase):
         self.assertIn("claude --verbose --output-format=stream-json", run_command)
         self.assertIn("--permission-mode=bypassPermissions", run_command)
         self.assertIn("--print -- 'solve it'", run_command)
+        self.assertIn("| tee /logs/agent/claude-code.txt", run_command)
+        self.assertNotIn("attempt=", run_command)
+        self.assertNotIn("retryable", run_command)
 
         self.assertEqual(env["ANTHROPIC_BASE_URL"], KIMCHI_ANTHROPIC_BASE_URL)
         self.assertEqual(env["ANTHROPIC_AUTH_TOKEN"], "test-key")
@@ -111,6 +142,11 @@ class ClaudeCodeKimchiTest(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(env["CLAUDE_CODE_DISABLE_EXPERIMENTAL_BETAS"], "1")
         self.assertEqual(env["CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC"], "1")
         self.assertLess(int(env["CLAUDE_CODE_AUTO_COMPACT_WINDOW"]), 196608)
+        self.assertEqual(
+            int(env["CLAUDE_CODE_AUTO_COMPACT_WINDOW"]),
+            196608 - CLAUDE_CODE_OUTPUT_RESERVE_TOKENS - CLAUDE_CODE_CONTEXT_SAFETY_MARGIN_TOKENS,
+        )
+        self.assertNotIn("MAX_THINKING_TOKENS", env)
         self.assertEqual(env["IS_SANDBOX"], "1")
         self.assertEqual(agent.agent_envs[1], env)
         self.assertEqual(agent.metadata_fetch_count, 1)
@@ -166,6 +202,65 @@ class ClaudeCodeKimchiTest(unittest.IsolatedAsyncioTestCase):
                 await agent.run("solve it", object(), AgentContext())
 
         self.assertEqual(agent.agent_commands, [])
+
+    async def test_retryable_api_status_is_reclassified_for_harbor_retry(self) -> None:
+        stream = "\n".join([
+            json.dumps({"type": "system", "subtype": "init"}),
+            json.dumps({
+                "type": "result",
+                "is_error": True,
+                "api_error_status": 524,
+                "result": "API Error: 524 origin_response_timeout",
+            }),
+        ])
+        with tempfile.TemporaryDirectory() as tmp:
+            agent = FailingClaudeCodeKimchi(
+                logs_dir=Path(tmp) / "jobs" / "run-1" / "task__trial" / "agent",
+                model_name="kimchi-dev/kimi-k2.5",
+                failure=NonZeroAgentExitCodeError("claude exited 1"),
+            )
+            environment = FakeEnvironment(stream)
+
+            with self.assertRaises(RetryableApiError) as raised:
+                await agent.run("solve it", environment, AgentContext())
+
+        self.assertEqual(raised.exception.status, 524)
+        self.assertIn("origin_response_timeout", str(raised.exception))
+        self.assertIn("cat /logs/agent/claude-code.txt", environment.commands)
+
+    async def test_nonretryable_api_status_remains_nonzero_exit(self) -> None:
+        stream = json.dumps({
+            "type": "result",
+            "is_error": True,
+            "api_error_status": 401,
+            "result": "API Error: 401 unauthorized",
+        })
+        original_error = NonZeroAgentExitCodeError("claude exited 1")
+        with tempfile.TemporaryDirectory() as tmp:
+            agent = FailingClaudeCodeKimchi(
+                logs_dir=Path(tmp) / "jobs" / "run-1" / "task__trial" / "agent",
+                model_name="kimchi-dev/kimi-k2.5",
+                failure=original_error,
+            )
+
+            with self.assertRaises(NonZeroAgentExitCodeError) as raised:
+                await agent.run("solve it", FakeEnvironment(stream), AgentContext())
+
+        self.assertIs(raised.exception, original_error)
+
+    async def test_non_api_nonzero_exit_remains_nonzero_exit(self) -> None:
+        original_error = NonZeroAgentExitCodeError("claude exited 1")
+        with tempfile.TemporaryDirectory() as tmp:
+            agent = FailingClaudeCodeKimchi(
+                logs_dir=Path(tmp) / "jobs" / "run-1" / "task__trial" / "agent",
+                model_name="kimchi-dev/kimi-k2.5",
+                failure=original_error,
+            )
+
+            with self.assertRaises(NonZeroAgentExitCodeError) as raised:
+                await agent.run("solve it", FakeEnvironment("not json"), AgentContext())
+
+        self.assertIs(raised.exception, original_error)
 
     async def test_extra_env_cannot_override_forced_anthropic_routing(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:
@@ -242,6 +337,10 @@ class ClaudeCodeKimchiTest(unittest.IsolatedAsyncioTestCase):
         env = agent.agent_envs[0]
         self.assertEqual(env["ANTHROPIC_MODEL"], "kimi-k2.5")
         self.assertLess(int(env["CLAUDE_CODE_AUTO_COMPACT_WINDOW"]), 262144)
+        self.assertEqual(
+            int(env["CLAUDE_CODE_AUTO_COMPACT_WINDOW"]),
+            262144 - CLAUDE_CODE_OUTPUT_RESERVE_TOKENS - CLAUDE_CODE_CONTEXT_SAFETY_MARGIN_TOKENS,
+        )
         self.assertEqual(env["CLAUDE_CODE_OAUTH_TOKEN"], "")
         self.assertEqual(env["CLAUDE_CODE_USE_BEDROCK"], "")
         self.assertEqual(env["MAX_THINKING_TOKENS"], "2048")

--- a/benchmark/terminal-bench-2/src/kimchi_agent/claude_code_kimchi_test.py
+++ b/benchmark/terminal-bench-2/src/kimchi_agent/claude_code_kimchi_test.py
@@ -120,6 +120,7 @@ class ClaudeCodeKimchiTest(unittest.IsolatedAsyncioTestCase):
 
         self.assertIn("$CLAUDE_CONFIG_DIR/projects/-app", setup_command)
         self.assertIn("claude --verbose --output-format=stream-json", run_command)
+        self.assertIn("set -o pipefail", run_command)
         self.assertIn("--permission-mode=bypassPermissions", run_command)
         self.assertIn("--print -- 'solve it'", run_command)
         self.assertIn("| tee /logs/agent/claude-code.txt", run_command)
@@ -357,6 +358,7 @@ class ClaudeCodeKimchiTest(unittest.IsolatedAsyncioTestCase):
                 model_name="kimchi-dev/kimi-k2.5",
                 extra_env=bash_env,
             )
+            agent._resolved_env_vars.update(bash_env)
 
             await agent.run("solve it", object(), AgentContext())
 

--- a/benchmark/terminal-bench-2/src/kimchi_agent/gateway.py
+++ b/benchmark/terminal-bench-2/src/kimchi_agent/gateway.py
@@ -1,0 +1,132 @@
+import json
+import os
+from collections.abc import Iterable
+
+import httpx
+from pydantic import BaseModel, ConfigDict, Field, StrictBool, StrictInt, ValidationError
+
+KIMCHI_API = "https://llm.kimchi.dev"
+KIMCHI_PROVIDER = "kimchi-dev"
+KIMCHI_OPENAI_BASE_URL = f"{KIMCHI_API}/openai/v1"
+KIMCHI_ANTHROPIC_BASE_URL = f"{KIMCHI_API}/anthropic"
+KIMCHI_MODELS_METADATA_URL = f"{KIMCHI_API}/v1/models/metadata?include_in_cli=true"
+KIMCHI_API_KEY_ENV = "KIMCHI_API_KEY"
+
+FETCH_TIMEOUT_SEC = 5
+
+
+class KimchiModelLimits(BaseModel):
+    model_config = ConfigDict(extra="ignore")
+
+    context_window: StrictInt = Field(gt=0)
+    max_output_tokens: StrictInt = Field(gt=0)
+
+
+class KimchiModelMetadata(BaseModel):
+    model_config = ConfigDict(extra="ignore")
+
+    slug: str = Field(min_length=1)
+    reasoning: StrictBool = False
+    limits: KimchiModelLimits
+
+
+class KimchiModelsMetadataResponse(BaseModel):
+    model_config = ConfigDict(extra="ignore")
+
+    models: list[KimchiModelMetadata] = Field(min_length=1)
+
+
+class KimchiGatewayMixin:
+    def _passthrough_env(
+        self,
+        *,
+        prefixes: tuple[str, ...] = (),
+        keys: Iterable[str] = (),
+        blocked_prefixes: tuple[str, ...] = (),
+        blocked_keys: Iterable[str] = (),
+    ) -> dict[str, str]:
+        allowed_keys = set(keys)
+        denied_keys = set(blocked_keys)
+
+        def allowed(key: str) -> bool:
+            if key in denied_keys or key.startswith(blocked_prefixes):
+                return False
+            return key in allowed_keys or key.startswith(prefixes)
+
+        env = {key: value for key, value in os.environ.items() if allowed(key)}
+        env.update({key: value for key, value in self._extra_env.items() if allowed(key)})
+        return env
+
+    def _scrub_extra_env(
+        self,
+        *,
+        keys: Iterable[str] = (),
+        prefixes: tuple[str, ...] = (),
+        allow_keys: Iterable[str] = (),
+    ) -> None:
+        scrub_keys = set(keys)
+        allowed_keys = set(allow_keys)
+        for key in list(self._extra_env):
+            if key in allowed_keys:
+                continue
+            if key in scrub_keys or key.startswith(prefixes):
+                self._extra_env.pop(key, None)
+
+    def _split_model(self, model_name: str | None) -> tuple[str, str]:
+        if not model_name or "/" not in model_name:
+            raise ValueError("--model is required and must use provider/model format, e.g. kimchi-dev/kimi-k2.5")
+        provider, model_id = model_name.split("/", 1)
+        if provider != KIMCHI_PROVIDER:
+            raise ValueError(
+                f"{type(self).__name__} only supports {KIMCHI_PROVIDER}/<model-id> models; got {model_name!r}"
+            )
+        if not model_id:
+            raise ValueError("--model must include a model id after kimchi-dev/")
+        return provider, model_id
+
+    def _required_kimchi_api_key(self) -> str:
+        api_key = self._get_env(KIMCHI_API_KEY_ENV)
+        if not api_key:
+            raise ValueError(
+                f"{KIMCHI_API_KEY_ENV} is required. Export it on the host and forward it with "
+                f"`--ae {KIMCHI_API_KEY_ENV}=${KIMCHI_API_KEY_ENV}`."
+            )
+        return api_key
+
+    def _fetch_model_metadata(self, api_key: str) -> list[KimchiModelMetadata]:
+        try:
+            response = httpx.get(
+                KIMCHI_MODELS_METADATA_URL,
+                headers={"Authorization": f"Bearer {api_key}"},
+                timeout=FETCH_TIMEOUT_SEC,
+            )
+            response.raise_for_status()
+            body = response.json()
+        except httpx.HTTPStatusError as exc:
+            raise RuntimeError(f"Failed to fetch Kimchi model metadata: HTTP {exc.response.status_code}") from exc
+        except (httpx.HTTPError, json.JSONDecodeError) as exc:
+            raise RuntimeError(f"Failed to fetch Kimchi model metadata: {exc}") from exc
+
+        try:
+            metadata = KimchiModelsMetadataResponse.model_validate(body)
+        except ValidationError as exc:
+            raise RuntimeError(f"Failed to parse Kimchi model metadata: {exc}") from exc
+
+        return metadata.models
+
+    def _model_metadata(self, api_key: str) -> list[KimchiModelMetadata]:
+        cache = getattr(self, "_kimchi_model_metadata_cache", None)
+        if cache is None or cache[0] != api_key:
+            cache = (api_key, self._fetch_model_metadata(api_key))
+            self._kimchi_model_metadata_cache = cache
+        return cache[1]
+
+    def _model_metadata_for(self, api_key: str, model_name: str | None) -> KimchiModelMetadata:
+        _, model_id = self._split_model(model_name)
+        for model in self._model_metadata(api_key):
+            if model.slug == model_id:
+                return model
+        raise ValueError(f"Model {model_name!r} was not returned by {KIMCHI_MODELS_METADATA_URL}")
+
+    def _selected_model_metadata(self, api_key: str) -> KimchiModelMetadata:
+        return self._model_metadata_for(api_key, self.model_name)

--- a/benchmark/terminal-bench-2/src/kimchi_agent/gateway.py
+++ b/benchmark/terminal-bench-2/src/kimchi_agent/gateway.py
@@ -26,7 +26,9 @@ class KimchiModelMetadata(BaseModel):
     model_config = ConfigDict(extra="ignore")
 
     slug: str = Field(min_length=1)
+    display_name: str | None = None
     reasoning: StrictBool = False
+    input_modalities: list[str] = Field(default_factory=lambda: ["text"])
     limits: KimchiModelLimits
 
 

--- a/benchmark/terminal-bench-2/src/kimchi_agent/gsd_kimchi.py
+++ b/benchmark/terminal-bench-2/src/kimchi_agent/gsd_kimchi.py
@@ -1,0 +1,330 @@
+import json
+import shlex
+from pathlib import Path
+from typing import Any
+
+from harbor.agents.installed.base import BaseInstalledAgent, with_prompt_template
+from harbor.environments.base import BaseEnvironment
+from harbor.models.agent.context import AgentContext
+from pydantic import ValidationError
+
+from kimchi_agent.gateway import (
+    KIMCHI_API_KEY_ENV,
+    KIMCHI_OPENAI_BASE_URL,
+    KIMCHI_PROVIDER,
+    KimchiGatewayMixin,
+    KimchiModelMetadata,
+)
+from kimchi_agent.messages import SessionEntry
+
+CONTAINER_LOGS_DIR = "/logs/agent"
+CONTAINER_GSD_HOME = f"{CONTAINER_LOGS_DIR}/gsd-home"
+CONTAINER_GSD_AGENT_DIR = f"{CONTAINER_GSD_HOME}/agent"
+CONTAINER_GSD_SESSION_DIR = f"{CONTAINER_GSD_AGENT_DIR}/sessions"
+# Keep the transcript as text. GSD JSON mode emits repeated partial state that
+# can grow to many GB, while Terminal Bench scoring only needs verifier results
+# plus the exit/status artifacts below.
+GSD_OUTPUT_FILENAME = "gsd.txt"
+GSD_VERSION_FILENAME = "gsd-version.txt"
+GSD_EXIT_CODE_FILENAME = "gsd-exit-code.txt"
+GSD_STATUS_FILENAME = "gsd-status.json"
+GSD_INSTRUCTION_PATH = "/tmp/terminal-bench-gsd-instruction.md"
+
+# gsd-pi exits 10 when a headless run becomes blocked. Harbor should still run
+# task verification, but the adapter preserves the blocked status in artifacts.
+GSD_BLOCKED_EXIT_CODE = 10
+GSD_MODEL_API = "openai-completions"
+GSD_COST_FREE = {"input": 0, "output": 0, "cacheRead": 0, "cacheWrite": 0}
+GSD_ROLE_KEYS = (
+    "research",
+    "planning",
+    "discuss",
+    "execution",
+    "execution_simple",
+    "completion",
+    "validation",
+    "subagent",
+)
+
+
+class GsdKimchi(KimchiGatewayMixin, BaseInstalledAgent):
+    """Harbor GSD agent wired to one selected Kimchi OpenAI-compatible model."""
+
+    SUPPORTS_ATIF: bool = False
+
+    @staticmethod
+    def name() -> str:
+        return "gsd-kimchi"
+
+    def get_version_command(self) -> str | None:
+        return 'export NVM_DIR="$HOME/.nvm"; [ ! -s "$NVM_DIR/nvm.sh" ] || . "$NVM_DIR/nvm.sh"; gsd --version'
+
+    async def install(self, environment: BaseEnvironment) -> None:
+        await self.exec_as_root(
+            environment,
+            command=(
+                "if command -v apk &> /dev/null; then"
+                "  apk add --no-cache curl bash git nodejs npm;"
+                " elif command -v apt-get &> /dev/null; then"
+                "  apt-get update && apt-get install -y curl git;"
+                " elif command -v yum &> /dev/null; then"
+                "  yum install -y curl git;"
+                " else"
+                '  echo "Warning: No known package manager found, assuming curl is available" >&2;'
+                " fi"
+            ),
+            env={"DEBIAN_FRONTEND": "noninteractive"},
+        )
+
+        version_spec = f"@{self._version}" if self._version else "@latest"
+        await self.exec_as_agent(
+            environment,
+            command=(
+                "set -euo pipefail; "
+                "if command -v node &>/dev/null && command -v npm &>/dev/null; then"
+                "  npm -v;"
+                " else"
+                "  curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.40.2/install.sh | bash &&"
+                '  export NVM_DIR="$HOME/.nvm" &&'
+                '  \\. "$NVM_DIR/nvm.sh" || true &&'
+                "  command -v nvm &>/dev/null || { echo 'Error: NVM failed to load' >&2; exit 1; } &&"
+                "  nvm install 22 && nvm alias default 22 && npm -v;"
+                " fi && "
+                f"npm install -g gsd-pi{version_spec} && "
+                "gsd --version"
+            ),
+        )
+
+    @staticmethod
+    def _model_ref(model: KimchiModelMetadata) -> str:
+        return f"{KIMCHI_PROVIDER}/{model.slug}"
+
+    @staticmethod
+    def _gsd_input_modalities(model: KimchiModelMetadata) -> list[str]:
+        allowed = [modality for modality in model.input_modalities if modality in {"text", "image"}]
+        return allowed or ["text"]
+
+    def _models_config(self, model: KimchiModelMetadata) -> dict[str, Any]:
+        return {
+            "providers": {
+                KIMCHI_PROVIDER: {
+                    "name": "Kimchi Dev",
+                    "baseUrl": KIMCHI_OPENAI_BASE_URL,
+                    "apiKey": KIMCHI_API_KEY_ENV,
+                    "api": GSD_MODEL_API,
+                    "models": [
+                        {
+                            "id": model.slug,
+                            "name": model.display_name or model.slug,
+                            "contextWindow": model.limits.context_window,
+                            "maxTokens": model.limits.max_output_tokens,
+                            "reasoning": model.reasoning,
+                            "input": self._gsd_input_modalities(model),
+                            "cost": GSD_COST_FREE,
+                        }
+                    ],
+                }
+            }
+        }
+
+    def _settings_config(self, model: KimchiModelMetadata) -> dict[str, Any]:
+        return {
+            "defaultProvider": KIMCHI_PROVIDER,
+            "defaultModel": model.slug,
+            "quietStartup": True,
+            "collapseChangelog": True,
+        }
+
+    def _preferences(self, model: KimchiModelMetadata) -> str:
+        model_ref = self._model_ref(model)
+        role_lines = "\n".join(f"  {role}: {model_ref}" for role in GSD_ROLE_KEYS)
+        return f"""---
+version: 1
+models:
+{role_lines}
+auto_supervisor:
+  model: {model_ref}
+dynamic_routing:
+  enabled: false
+  tier_models:
+    light: {model_ref}
+    standard: {model_ref}
+    heavy:
+      - {model_ref}
+  budget_pressure: false
+token_profile: balanced
+skill_discovery: suggest
+git:
+  isolation: worktree
+  merge_strategy: squash
+---
+"""
+
+    def _build_config_command(self, model: KimchiModelMetadata) -> str:
+        models_json = json.dumps(self._models_config(model), indent=2)
+        settings_json = json.dumps(self._settings_config(model), indent=2)
+        preferences = self._preferences(model)
+        return (
+            f"mkdir -p {shlex.quote(CONTAINER_GSD_AGENT_DIR)} {shlex.quote(CONTAINER_GSD_HOME)} && "
+            f"printf '%s\\n' {shlex.quote(models_json)} > "
+            f"{shlex.quote(f'{CONTAINER_GSD_AGENT_DIR}/models.json')} && "
+            f"printf '%s\\n' {shlex.quote(settings_json)} > "
+            f"{shlex.quote(f'{CONTAINER_GSD_AGENT_DIR}/settings.json')} && "
+            f"printf '%s\\n' {shlex.quote(preferences)} > "
+            f"{shlex.quote(f'{CONTAINER_GSD_HOME}/preferences.md')}"
+        )
+
+    def _build_run_command(self, instruction: str, model: KimchiModelMetadata) -> str:
+        instruction_text = (
+            "Terminal Bench task. Work fully non-interactively. Do not ask the user questions.\n\n"
+            f"{instruction}"
+        )
+        model_ref = self._model_ref(model)
+        status_path = f"{CONTAINER_LOGS_DIR}/{GSD_STATUS_FILENAME}"
+        gsd_snapshot_path = f"{CONTAINER_LOGS_DIR}/gsd"
+        return (
+            f"mkdir -p {shlex.quote(CONTAINER_LOGS_DIR)} "
+            f"{shlex.quote(CONTAINER_GSD_SESSION_DIR)} && "
+            "project_dir=$(pwd -P) && "
+            f"printf '%s' {shlex.quote(instruction_text)} > {shlex.quote(GSD_INSTRUCTION_PATH)} && "
+            'export NVM_DIR="$HOME/.nvm" && '
+            '[ ! -s "$NVM_DIR/nvm.sh" ] || . "$NVM_DIR/nvm.sh"; '
+            f"gsd --version > {shlex.quote(f'{CONTAINER_LOGS_DIR}/{GSD_VERSION_FILENAME}')} 2>&1 || true; "
+            "status=0; "
+            # GSD/pi ignores positional args that start with "-", and its parser
+            # does not treat "--" as an end-of-options marker. The instruction is
+            # therefore prefixed above and passed as one positional argument.
+            # Use a direct redirect instead of tee/pipelines so the shell keeps
+            # GSD's exit code; a pipeline would report tee's status instead.
+            f"gsd --mode text --print --model {shlex.quote(model_ref)} "
+            f'"$(cat {shlex.quote(GSD_INSTRUCTION_PATH)})" '
+            f"> {shlex.quote(f'{CONTAINER_LOGS_DIR}/{GSD_OUTPUT_FILENAME}')} 2>&1 </dev/null "
+            "|| status=$?; "
+            f"printf '%s\\n' \"$status\" > {shlex.quote(f'{CONTAINER_LOGS_DIR}/{GSD_EXIT_CODE_FILENAME}')}; "
+            f"if [ \"$status\" -eq 0 ]; then gsd_status=success; "
+            f"elif [ \"$status\" -eq {GSD_BLOCKED_EXIT_CODE} ]; then gsd_status=blocked; "
+            "else gsd_status=error; fi; "
+            f"printf '{{\"status\":\"%s\",\"exit_code\":%s}}\\n' \"$gsd_status\" \"$status\" "
+            f"> {shlex.quote(status_path)}; "
+            f"rm -rf {shlex.quote(gsd_snapshot_path)} && "
+            f"if [ -d \"$project_dir/.gsd\" ]; then cp -a \"$project_dir/.gsd\" "
+            f"{shlex.quote(gsd_snapshot_path)}; fi; "
+            f"if [ \"$status\" -eq {GSD_BLOCKED_EXIT_CODE} ]; then exit 0; fi; "
+            'exit "$status"'
+        )
+
+    def _build_env(self) -> dict[str, str]:
+        return {
+            KIMCHI_API_KEY_ENV: self._required_kimchi_api_key(),
+            # GSD 3.x derives the embedded pi agent dir from GSD_HOME; older
+            # gsd-pi builds used PI_CODING_AGENT_DIR directly. Pin both paths
+            # to the Harbor log mount so token sessions are captured.
+            "GSD_HOME": CONTAINER_GSD_HOME,
+            "GSD_CODING_AGENT_DIR": CONTAINER_GSD_AGENT_DIR,
+            "PI_CODING_AGENT_DIR": CONTAINER_GSD_AGENT_DIR,
+        }
+
+    def _force_session_env(self) -> None:
+        # Harbor merges _extra_env over env= at exec time. Keep the GSD/pi
+        # session store on the log mount even if --ae passes the same key.
+        self._extra_env["GSD_HOME"] = CONTAINER_GSD_HOME
+        self._extra_env["GSD_CODING_AGENT_DIR"] = CONTAINER_GSD_AGENT_DIR
+        self._extra_env["PI_CODING_AGENT_DIR"] = CONTAINER_GSD_AGENT_DIR
+
+    @with_prompt_template
+    async def run(
+        self,
+        instruction: str,
+        environment: BaseEnvironment,
+        context: AgentContext,
+    ) -> None:
+        env = self._build_env()
+        self._force_session_env()
+        api_key = env[KIMCHI_API_KEY_ENV]
+        model = self._selected_model_metadata(api_key)
+
+        await self.exec_as_agent(
+            environment,
+            command=self._build_config_command(model),
+            env=env,
+        )
+        await self.exec_as_agent(
+            environment,
+            command=self._build_run_command(instruction, model),
+            env=env,
+        )
+
+    def _read_exit_status(self) -> dict[str, Any]:
+        exit_code_path = self.logs_dir / GSD_EXIT_CODE_FILENAME
+        if not exit_code_path.exists():
+            return {}
+
+        try:
+            exit_code = int(exit_code_path.read_text().strip())
+        except (OSError, ValueError):
+            return {}
+
+        if exit_code == GSD_BLOCKED_EXIT_CODE:
+            status = "blocked"
+        elif exit_code == 0:
+            status = "success"
+        else:
+            status = "error"
+        return {"gsd_exit_code": exit_code, "gsd_status": status}
+
+    def _session_files(self) -> list[Path]:
+        sessions_dir = self.logs_dir / "gsd-home" / "agent" / "sessions"
+        if not sessions_dir.is_dir():
+            return []
+        return sorted(sessions_dir.rglob("*.jsonl"))
+
+    def _populate_token_context(self, context: AgentContext) -> None:
+        session_files = self._session_files()
+        if not session_files:
+            return
+
+        total_input_tokens = 0
+        total_output_tokens = 0
+        total_cache_read_tokens = 0
+        total_cache_write_tokens = 0
+        total_cost = 0.0
+
+        for session_file in session_files:
+            try:
+                with session_file.open(encoding="utf-8") as handle:
+                    for raw_line in handle:
+                        line = raw_line.strip()
+                        if not line:
+                            continue
+                        try:
+                            entry = SessionEntry.model_validate_json(line)
+                        except ValidationError:
+                            continue
+                        if entry.type != "message" or entry.message.role != "assistant":
+                            continue
+                        usage = entry.message.usage
+                        total_input_tokens += usage.input
+                        total_output_tokens += usage.output
+                        total_cache_read_tokens += usage.cache_read
+                        total_cache_write_tokens += usage.cache_write
+                        total_cost += usage.cost.total
+            except OSError as exc:
+                self.logger.warning(
+                    "Skipping unreadable GSD/pi session file during token aggregation",
+                    extra={"path": str(session_file), "error": str(exc)},
+                )
+                continue
+
+        # pi-ai treats input, cacheRead, cacheWrite as disjoint summing to totalTokens.
+        context.n_input_tokens = total_input_tokens + total_cache_read_tokens + total_cache_write_tokens
+        context.n_output_tokens = total_output_tokens
+        context.n_cache_tokens = total_cache_read_tokens
+        context.cost_usd = total_cost if total_cost > 0 else None
+
+    def populate_context_post_run(self, context: AgentContext) -> None:
+        exit_status = self._read_exit_status()
+        if exit_status:
+            context.metadata = {**(context.metadata or {}), **exit_status}
+        self._populate_token_context(context)
+        # Do not parse gsd.txt here. It is a human transcript and can be large;
+        # Terminal Bench correctness comes from the verifier, not ATIF tokens.

--- a/benchmark/terminal-bench-2/src/kimchi_agent/gsd_kimchi.py
+++ b/benchmark/terminal-bench-2/src/kimchi_agent/gsd_kimchi.py
@@ -18,9 +18,10 @@ from kimchi_agent.gateway import (
 from kimchi_agent.messages import SessionEntry
 
 CONTAINER_LOGS_DIR = "/logs/agent"
-CONTAINER_GSD_HOME = f"{CONTAINER_LOGS_DIR}/gsd-home"
+CONTAINER_GSD_HOME = "/tmp/terminal-bench-gsd-home"
 CONTAINER_GSD_AGENT_DIR = f"{CONTAINER_GSD_HOME}/agent"
 CONTAINER_GSD_SESSION_DIR = f"{CONTAINER_GSD_AGENT_DIR}/sessions"
+CONTAINER_CAPTURED_SESSION_DIR = f"{CONTAINER_LOGS_DIR}/gsd-sessions"
 # Keep the transcript as text. GSD JSON mode emits repeated partial state that
 # can grow to many GB, while Terminal Bench scoring only needs verifier results
 # plus the exit/status artifacts below.
@@ -184,7 +185,8 @@ git:
         gsd_snapshot_path = f"{CONTAINER_LOGS_DIR}/gsd"
         return (
             f"mkdir -p {shlex.quote(CONTAINER_LOGS_DIR)} "
-            f"{shlex.quote(CONTAINER_GSD_SESSION_DIR)} && "
+            f"{shlex.quote(CONTAINER_GSD_SESSION_DIR)} "
+            f"{shlex.quote(CONTAINER_CAPTURED_SESSION_DIR)} && "
             "project_dir=$(pwd -P) && "
             f"printf '%s' {shlex.quote(instruction_text)} > {shlex.quote(GSD_INSTRUCTION_PATH)} && "
             'export NVM_DIR="$HOME/.nvm" && '
@@ -206,6 +208,14 @@ git:
             "else gsd_status=error; fi; "
             f"printf '{{\"status\":\"%s\",\"exit_code\":%s}}\\n' \"$gsd_status\" \"$status\" "
             f"> {shlex.quote(status_path)}; "
+            # GSD has to populate its managed runtime home on launch. Keep that
+            # home in /tmp, then preserve only session JSONL needed for tokens.
+            f"rm -rf {shlex.quote(CONTAINER_CAPTURED_SESSION_DIR)} && "
+            f"if [ -d {shlex.quote(CONTAINER_GSD_SESSION_DIR)} ]; then "
+            f"mkdir -p {shlex.quote(CONTAINER_CAPTURED_SESSION_DIR)} && "
+            f"cp -a {shlex.quote(f'{CONTAINER_GSD_SESSION_DIR}/.')} "
+            f"{shlex.quote(CONTAINER_CAPTURED_SESSION_DIR)}; fi; "
+            f"rm -rf {shlex.quote(CONTAINER_GSD_HOME)}; "
             f"rm -rf {shlex.quote(gsd_snapshot_path)} && "
             f"if [ -d \"$project_dir/.gsd\" ]; then cp -a \"$project_dir/.gsd\" "
             f"{shlex.quote(gsd_snapshot_path)}; fi; "
@@ -218,15 +228,15 @@ git:
             KIMCHI_API_KEY_ENV: self._required_kimchi_api_key(),
             # GSD 3.x derives the embedded pi agent dir from GSD_HOME; older
             # gsd-pi builds used PI_CODING_AGENT_DIR directly. Pin both paths
-            # to the Harbor log mount so token sessions are captured.
+            # to a temporary home and copy only sessions into Harbor logs.
             "GSD_HOME": CONTAINER_GSD_HOME,
             "GSD_CODING_AGENT_DIR": CONTAINER_GSD_AGENT_DIR,
             "PI_CODING_AGENT_DIR": CONTAINER_GSD_AGENT_DIR,
         }
 
     def _force_session_env(self) -> None:
-        # Harbor merges _extra_env over env= at exec time. Keep the GSD/pi
-        # session store on the log mount even if --ae passes the same key.
+        # Harbor merges _extra_env over env= at exec time. Keep GSD's managed
+        # home temporary even if --ae passes the same keys.
         self._extra_env["GSD_HOME"] = CONTAINER_GSD_HOME
         self._extra_env["GSD_CODING_AGENT_DIR"] = CONTAINER_GSD_AGENT_DIR
         self._extra_env["PI_CODING_AGENT_DIR"] = CONTAINER_GSD_AGENT_DIR
@@ -273,7 +283,7 @@ git:
         return {"gsd_exit_code": exit_code, "gsd_status": status}
 
     def _session_files(self) -> list[Path]:
-        sessions_dir = self.logs_dir / "gsd-home" / "agent" / "sessions"
+        sessions_dir = self.logs_dir / "gsd-sessions"
         if not sessions_dir.is_dir():
             return []
         return sorted(sessions_dir.rglob("*.jsonl"))

--- a/benchmark/terminal-bench-2/src/kimchi_agent/gsd_kimchi_test.py
+++ b/benchmark/terminal-bench-2/src/kimchi_agent/gsd_kimchi_test.py
@@ -14,8 +14,10 @@ from kimchi_agent.gateway import (
     KimchiModelsMetadataResponse,
 )
 from kimchi_agent.gsd_kimchi import (
+    CONTAINER_CAPTURED_SESSION_DIR,
     CONTAINER_GSD_AGENT_DIR,
     CONTAINER_GSD_HOME,
+    CONTAINER_GSD_SESSION_DIR,
     GSD_BLOCKED_EXIT_CODE,
     GSD_EXIT_CODE_FILENAME,
     GSD_OUTPUT_FILENAME,
@@ -115,12 +117,13 @@ class GsdKimchiTest(unittest.IsolatedAsyncioTestCase):
 
         self.assertEqual(len(agent.agent_commands), 2)
         config_command, run_command = agent.agent_commands
-        self.assertIn("/logs/agent/gsd-home/agent/models.json", config_command)
-        self.assertIn("/logs/agent/gsd-home/agent/settings.json", config_command)
-        self.assertIn("/logs/agent/gsd-home/preferences.md", config_command)
+        self.assertIn("/tmp/terminal-bench-gsd-home/agent/models.json", config_command)
+        self.assertIn("/tmp/terminal-bench-gsd-home/agent/settings.json", config_command)
+        self.assertIn("/tmp/terminal-bench-gsd-home/preferences.md", config_command)
         self.assertIn("gsd --mode text --print --model kimchi-dev/minimax-m2.7", run_command)
         self.assertIn("Terminal Bench task. Work fully non-interactively.", run_command)
-        self.assertIn("mkdir -p /logs/agent /logs/agent/gsd-home/agent/sessions", run_command)
+        self.assertIn("mkdir -p /logs/agent /tmp/terminal-bench-gsd-home/agent/sessions", run_command)
+        self.assertIn("/logs/agent/gsd-sessions", run_command)
         self.assertIn("> /logs/agent/gsd.txt 2>&1 </dev/null || status=$?", run_command)
         self.assertNotIn("--no-session", run_command)
         self.assertNotIn("tee", run_command)
@@ -133,6 +136,10 @@ class GsdKimchiTest(unittest.IsolatedAsyncioTestCase):
         self.assertIn("/logs/agent/gsd-status.json", run_command)
         self.assertIn("gsd_status=blocked", run_command)
         self.assertIn("/logs/agent/gsd", run_command)
+        self.assertIn(f"rm -rf {CONTAINER_CAPTURED_SESSION_DIR}", run_command)
+        self.assertIn(f"cp -a {CONTAINER_GSD_SESSION_DIR}/.", run_command)
+        self.assertIn(f"rm -rf {CONTAINER_GSD_HOME}", run_command)
+        self.assertNotIn("/logs/agent/gsd-home", run_command)
         self.assertEqual(
             agent.agent_envs[0],
             {
@@ -166,7 +173,6 @@ class GsdKimchiTest(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(agent.agent_envs[0]["GSD_HOME"], CONTAINER_GSD_HOME)
         self.assertEqual(agent.agent_envs[0]["GSD_CODING_AGENT_DIR"], CONTAINER_GSD_AGENT_DIR)
         self.assertEqual(agent.agent_envs[0]["PI_CODING_AGENT_DIR"], CONTAINER_GSD_AGENT_DIR)
-
 
     async def test_models_config_contains_only_selected_model(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:
@@ -255,7 +261,7 @@ class GsdKimchiTest(unittest.IsolatedAsyncioTestCase):
     def test_populate_context_aggregates_pi_session_tokens(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:
             logs_dir = Path(tmp) / "jobs" / "run-1" / "task__trial" / "agent"
-            session_dir = logs_dir / "gsd-home" / "agent" / "sessions" / "--work--"
+            session_dir = logs_dir / "gsd-sessions" / "--work--"
             session_dir.mkdir(parents=True)
             entries = [
                 {"type": "session", "id": "session-1"},

--- a/benchmark/terminal-bench-2/src/kimchi_agent/gsd_kimchi_test.py
+++ b/benchmark/terminal-bench-2/src/kimchi_agent/gsd_kimchi_test.py
@@ -1,0 +1,298 @@
+import json
+import os
+import tempfile
+import unittest
+from pathlib import Path
+from typing import ClassVar
+
+from harbor.models.agent.context import AgentContext
+
+from kimchi_agent.gateway import (
+    KIMCHI_OPENAI_BASE_URL,
+    KIMCHI_PROVIDER,
+    KimchiModelMetadata,
+    KimchiModelsMetadataResponse,
+)
+from kimchi_agent.gsd_kimchi import (
+    CONTAINER_GSD_AGENT_DIR,
+    CONTAINER_GSD_HOME,
+    GSD_BLOCKED_EXIT_CODE,
+    GSD_EXIT_CODE_FILENAME,
+    GSD_OUTPUT_FILENAME,
+    GsdKimchi,
+)
+
+
+class RecordingGsdKimchi(GsdKimchi):
+    metadata: ClassVar[list[dict[str, object]]] = [
+        {
+            "slug": "kimi-k2.5",
+            "display_name": "Kimi K2.5",
+            "reasoning": True,
+            "input_modalities": ["text", "image"],
+            "limits": {"context_window": 262144, "max_output_tokens": 262144},
+        },
+        {
+            "slug": "minimax-m2.7",
+            "display_name": "MiniMax M2.7",
+            "reasoning": False,
+            "limits": {"context_window": 196608, "max_output_tokens": 65536},
+        },
+    ]
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.root_commands: list[str] = []
+        self.agent_commands: list[str] = []
+        self.agent_envs: list[dict[str, str] | None] = []
+        self.metadata_fetch_count = 0
+
+    async def exec_as_root(self, _environment, command: str, env=None, cwd=None, timeout_sec=None):
+        self.root_commands.append(command)
+
+    async def exec_as_agent(self, _environment, command: str, env=None, cwd=None, timeout_sec=None):
+        self.agent_commands.append(command)
+        self.agent_envs.append(env)
+
+    def _fetch_model_metadata(self, api_key: str) -> list[KimchiModelMetadata]:
+        self.metadata_fetch_count += 1
+        self.fetched_with_api_key = api_key
+        return KimchiModelsMetadataResponse.model_validate({"models": self.metadata}).models
+
+
+class GsdKimchiTest(unittest.IsolatedAsyncioTestCase):
+    def setUp(self) -> None:
+        self._old_api_key = os.environ.get("KIMCHI_API_KEY")
+        os.environ["KIMCHI_API_KEY"] = "test-key"
+
+    def tearDown(self) -> None:
+        if self._old_api_key is None:
+            os.environ.pop("KIMCHI_API_KEY", None)
+        else:
+            os.environ["KIMCHI_API_KEY"] = self._old_api_key
+
+    async def test_install_defaults_to_latest_gsd_package(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            agent = RecordingGsdKimchi(logs_dir=Path(tmp), model_name="kimchi-dev/kimi-k2.5")
+
+            await agent.install(object())
+
+        self.assertEqual(len(agent.root_commands), 1)
+        self.assertEqual(len(agent.agent_commands), 1)
+        self.assertIn("git", agent.root_commands[0])
+        self.assertIn("npm install -g gsd-pi@latest", agent.agent_commands[0])
+        self.assertIn("gsd --version", agent.agent_commands[0])
+
+    def test_version_command_tolerates_system_node_install(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            agent = RecordingGsdKimchi(logs_dir=Path(tmp), model_name="kimchi-dev/kimi-k2.5")
+
+            command = agent.get_version_command()
+
+        self.assertIn('[ ! -s "$NVM_DIR/nvm.sh" ] || . "$NVM_DIR/nvm.sh"', command)
+        self.assertIn("gsd --version", command)
+
+    async def test_install_accepts_version_override(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            agent = RecordingGsdKimchi(
+                logs_dir=Path(tmp),
+                model_name="kimchi-dev/kimi-k2.5",
+                version="3.0.0",
+            )
+
+            await agent.install(object())
+
+        self.assertIn("npm install -g gsd-pi@3.0.0", agent.agent_commands[0])
+
+    async def test_registers_and_runs_selected_kimchi_model(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            agent = RecordingGsdKimchi(
+                logs_dir=Path(tmp) / "jobs" / "run-1" / "task__trial" / "agent",
+                model_name="kimchi-dev/minimax-m2.7",
+            )
+
+            await agent.run("solve it", object(), AgentContext())
+
+        self.assertEqual(len(agent.agent_commands), 2)
+        config_command, run_command = agent.agent_commands
+        self.assertIn("/logs/agent/gsd-home/agent/models.json", config_command)
+        self.assertIn("/logs/agent/gsd-home/agent/settings.json", config_command)
+        self.assertIn("/logs/agent/gsd-home/preferences.md", config_command)
+        self.assertIn("gsd --mode text --print --model kimchi-dev/minimax-m2.7", run_command)
+        self.assertIn("Terminal Bench task. Work fully non-interactively.", run_command)
+        self.assertIn("mkdir -p /logs/agent /logs/agent/gsd-home/agent/sessions", run_command)
+        self.assertIn("> /logs/agent/gsd.txt 2>&1 </dev/null || status=$?", run_command)
+        self.assertNotIn("--no-session", run_command)
+        self.assertNotIn("tee", run_command)
+        self.assertNotIn("gsd.jsonl", run_command)
+        self.assertIn(f"[ \"$status\" -eq {GSD_BLOCKED_EXIT_CODE} ]; then exit 0", run_command)
+        self.assertIn("project_dir=$(pwd -P)", run_command)
+        self.assertIn('"$project_dir/.gsd"', run_command)
+        self.assertIn("/logs/agent/gsd-version.txt", run_command)
+        self.assertIn("/logs/agent/gsd-exit-code.txt", run_command)
+        self.assertIn("/logs/agent/gsd-status.json", run_command)
+        self.assertIn("gsd_status=blocked", run_command)
+        self.assertIn("/logs/agent/gsd", run_command)
+        self.assertEqual(
+            agent.agent_envs[0],
+            {
+                "KIMCHI_API_KEY": "test-key",
+                "GSD_HOME": CONTAINER_GSD_HOME,
+                "GSD_CODING_AGENT_DIR": CONTAINER_GSD_AGENT_DIR,
+                "PI_CODING_AGENT_DIR": CONTAINER_GSD_AGENT_DIR,
+            },
+        )
+        self.assertEqual(agent.agent_envs[1], agent.agent_envs[0])
+        self.assertEqual(agent.metadata_fetch_count, 1)
+        self.assertEqual(agent.fetched_with_api_key, "test-key")
+
+    async def test_forces_pi_session_env_even_when_extra_env_overrides_it(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            agent = RecordingGsdKimchi(
+                logs_dir=Path(tmp) / "jobs" / "run-1" / "task__trial" / "agent",
+                model_name="kimchi-dev/kimi-k2.5",
+                extra_env={
+                    "GSD_HOME": "/tmp/wrong",
+                    "GSD_CODING_AGENT_DIR": "/tmp/wrong",
+                    "PI_CODING_AGENT_DIR": "/tmp/wrong",
+                },
+            )
+
+            await agent.run("solve it", object(), AgentContext())
+
+        self.assertEqual(agent._extra_env["GSD_HOME"], CONTAINER_GSD_HOME)
+        self.assertEqual(agent._extra_env["GSD_CODING_AGENT_DIR"], CONTAINER_GSD_AGENT_DIR)
+        self.assertEqual(agent._extra_env["PI_CODING_AGENT_DIR"], CONTAINER_GSD_AGENT_DIR)
+        self.assertEqual(agent.agent_envs[0]["GSD_HOME"], CONTAINER_GSD_HOME)
+        self.assertEqual(agent.agent_envs[0]["GSD_CODING_AGENT_DIR"], CONTAINER_GSD_AGENT_DIR)
+        self.assertEqual(agent.agent_envs[0]["PI_CODING_AGENT_DIR"], CONTAINER_GSD_AGENT_DIR)
+
+
+    async def test_models_config_contains_only_selected_model(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            agent = RecordingGsdKimchi(logs_dir=Path(tmp), model_name="kimchi-dev/kimi-k2.5")
+            model = agent._model_metadata_for("test-key", "kimchi-dev/kimi-k2.5")
+
+            config = agent._models_config(model)
+
+        provider = config["providers"][KIMCHI_PROVIDER]
+        self.assertEqual(provider["name"], "Kimchi Dev")
+        self.assertEqual(provider["baseUrl"], KIMCHI_OPENAI_BASE_URL)
+        self.assertEqual(provider["apiKey"], "KIMCHI_API_KEY")
+        self.assertEqual(provider["api"], "openai-completions")
+        self.assertEqual(len(provider["models"]), 1)
+        self.assertEqual(provider["models"][0]["id"], "kimi-k2.5")
+        self.assertEqual(provider["models"][0]["name"], "Kimi K2.5")
+        self.assertEqual(provider["models"][0]["contextWindow"], 262144)
+        self.assertEqual(provider["models"][0]["maxTokens"], 262144)
+        self.assertTrue(provider["models"][0]["reasoning"])
+        self.assertEqual(provider["models"][0]["input"], ["text", "image"])
+        self.assertEqual(provider["models"][0]["cost"], {"input": 0, "output": 0, "cacheRead": 0, "cacheWrite": 0})
+
+    async def test_settings_and_preferences_pin_every_role_to_selected_model(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            agent = RecordingGsdKimchi(logs_dir=Path(tmp), model_name="kimchi-dev/minimax-m2.7")
+            model = agent._model_metadata_for("test-key", "kimchi-dev/minimax-m2.7")
+
+            settings = agent._settings_config(model)
+            prefs = agent._preferences(model)
+
+        self.assertEqual(settings["defaultProvider"], "kimchi-dev")
+        self.assertEqual(settings["defaultModel"], "minimax-m2.7")
+        self.assertIn("execution: kimchi-dev/minimax-m2.7", prefs)
+        self.assertIn("validation: kimchi-dev/minimax-m2.7", prefs)
+        self.assertIn("auto_supervisor:\n  model: kimchi-dev/minimax-m2.7", prefs)
+        self.assertIn("dynamic_routing:\n  enabled: false", prefs)
+        self.assertIn("light: kimchi-dev/minimax-m2.7", prefs)
+        self.assertIn("standard: kimchi-dev/minimax-m2.7", prefs)
+        self.assertIn("- kimchi-dev/minimax-m2.7", prefs)
+
+    async def test_rejects_non_kimchi_provider(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            agent = RecordingGsdKimchi(logs_dir=Path(tmp), model_name="openai/gpt-4.1")
+
+            with self.assertRaisesRegex(ValueError, "only supports kimchi-dev"):
+                await agent.run("solve it", object(), AgentContext())
+
+    async def test_missing_kimchi_api_key_fails_before_commands(self) -> None:
+        os.environ.pop("KIMCHI_API_KEY", None)
+        with tempfile.TemporaryDirectory() as tmp:
+            agent = RecordingGsdKimchi(logs_dir=Path(tmp), model_name="kimchi-dev/kimi-k2.5")
+
+            with self.assertRaisesRegex(ValueError, "KIMCHI_API_KEY is required"):
+                await agent.run("solve it", object(), AgentContext())
+
+        self.assertEqual(agent.agent_commands, [])
+
+    async def test_rejects_model_missing_from_metadata_endpoint(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            agent = RecordingGsdKimchi(logs_dir=Path(tmp), model_name="kimchi-dev/not-returned")
+
+            with self.assertRaisesRegex(ValueError, "was not returned"):
+                await agent.run("solve it", object(), AgentContext())
+
+    def test_populate_context_records_exit_status_without_parsing_output(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            logs_dir = Path(tmp) / "jobs" / "run-1" / "task__trial" / "agent"
+            logs_dir.mkdir(parents=True)
+            (logs_dir / GSD_OUTPUT_FILENAME).write_text("large human-readable transcript\n")
+            (logs_dir / GSD_EXIT_CODE_FILENAME).write_text(f"{GSD_BLOCKED_EXIT_CODE}\n")
+            agent = RecordingGsdKimchi(logs_dir=logs_dir, model_name="kimchi-dev/kimi-k2.5")
+            context = AgentContext()
+
+            agent.populate_context_post_run(context)
+
+            self.assertIsNone(context.n_input_tokens)
+            self.assertIsNone(context.n_output_tokens)
+            self.assertIsNone(context.n_cache_tokens)
+            self.assertIsNone(context.cost_usd)
+            self.assertEqual(
+                context.metadata,
+                {"gsd_exit_code": GSD_BLOCKED_EXIT_CODE, "gsd_status": "blocked"},
+            )
+            self.assertFalse((logs_dir / "trajectory.json").exists())
+
+    def test_populate_context_aggregates_pi_session_tokens(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            logs_dir = Path(tmp) / "jobs" / "run-1" / "task__trial" / "agent"
+            session_dir = logs_dir / "gsd-home" / "agent" / "sessions" / "--work--"
+            session_dir.mkdir(parents=True)
+            entries = [
+                {"type": "session", "id": "session-1"},
+                {"type": "message", "message": {"role": "user", "usage": {"input": 99, "output": 99}}},
+                {
+                    "type": "message",
+                    "message": {
+                        "role": "assistant",
+                        "usage": {
+                            "input": 10,
+                            "output": 4,
+                            "cacheRead": 3,
+                            "cacheWrite": 2,
+                            "cost": {"total": 0.12},
+                        },
+                    },
+                },
+                {
+                    "type": "message",
+                    "message": {
+                        "role": "assistant",
+                        "usage": {"input": 5, "output": 1},
+                    },
+                },
+            ]
+            (session_dir / "main.jsonl").write_text(
+                "\n".join(["not json", *(json.dumps(entry) for entry in entries), ""])
+            )
+            (logs_dir / GSD_EXIT_CODE_FILENAME).write_text("0\n")
+            agent = RecordingGsdKimchi(logs_dir=logs_dir, model_name="kimchi-dev/kimi-k2.5")
+            context = AgentContext()
+
+            agent.populate_context_post_run(context)
+
+            self.assertEqual(context.n_input_tokens, 20)
+            self.assertEqual(context.n_output_tokens, 5)
+            self.assertEqual(context.n_cache_tokens, 3)
+            self.assertEqual(context.cost_usd, 0.12)
+            self.assertEqual(context.metadata, {"gsd_exit_code": 0, "gsd_status": "success"})
+            self.assertFalse((logs_dir / "trajectory.json").exists())

--- a/benchmark/terminal-bench-2/src/kimchi_agent/opencode_kimchi.py
+++ b/benchmark/terminal-bench-2/src/kimchi_agent/opencode_kimchi.py
@@ -1,48 +1,28 @@
 import copy
 import json
-import os
 import shlex
 from typing import Any
 
-import httpx
 from harbor.agents.installed.base import with_prompt_template
 from harbor.agents.installed.opencode import OpenCode
 from harbor.environments.base import BaseEnvironment
 from harbor.models.agent.context import AgentContext
-from pydantic import BaseModel, ConfigDict, Field, StrictBool, StrictInt, ValidationError
 
-KIMCHI_API = "https://llm.kimchi.dev"
-KIMCHI_PROVIDER = "kimchi-dev"
-KIMCHI_BASE_URL = f"{KIMCHI_API}/openai/v1"
-KIMCHI_MODELS_METADATA_URL = f"{KIMCHI_API}/v1/models/metadata?include_in_cli=true"
-KIMCHI_API_KEY_ENV = "KIMCHI_API_KEY"
+from kimchi_agent.gateway import (
+    KIMCHI_API_KEY_ENV,
+    KIMCHI_OPENAI_BASE_URL,
+    KIMCHI_PROVIDER,
+    KimchiGatewayMixin,
+)
 
-FETCH_TIMEOUT_SEC = 5
 SMALL_MODEL_ENV = "OPENCODE_SMALL_MODEL"
+OPENCODE_RUNTIME_ENV_KEYS = {
+    "OPENCODE_CLIENT",
+    "OPENCODE_FAKE_VCS",
+}
 
 
-class KimchiModelLimits(BaseModel):
-    model_config = ConfigDict(extra="ignore")
-
-    context_window: StrictInt = Field(gt=0)
-    max_output_tokens: StrictInt = Field(gt=0)
-
-
-class KimchiModelMetadata(BaseModel):
-    model_config = ConfigDict(extra="ignore")
-
-    slug: str = Field(min_length=1)
-    reasoning: StrictBool = False
-    limits: KimchiModelLimits
-
-
-class KimchiModelsMetadataResponse(BaseModel):
-    model_config = ConfigDict(extra="ignore")
-
-    models: list[KimchiModelMetadata] = Field(min_length=1)
-
-
-class OpenCodeKimchi(OpenCode):
+class OpenCodeKimchi(KimchiGatewayMixin, OpenCode):
     """Harbor OpenCode agent wired to the Kimchi OpenAI-compatible gateway.
 
     The model remains Harbor-configurable: pass ``--model kimchi-dev/<id>`` or
@@ -54,59 +34,6 @@ class OpenCodeKimchi(OpenCode):
     @staticmethod
     def name() -> str:
         return "opencode-kimchi"
-
-    def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs)
-        self._model_metadata_cache: tuple[str, list[KimchiModelMetadata]] | None = None
-
-    @staticmethod
-    def _split_model(model_name: str | None) -> tuple[str, str]:
-        if not model_name or "/" not in model_name:
-            raise ValueError("--model is required and must use provider/model format, e.g. kimchi-dev/kimi-k2.5")
-        provider, model_id = model_name.split("/", 1)
-        if provider != KIMCHI_PROVIDER:
-            raise ValueError(
-                f"OpenCodeKimchi only supports {KIMCHI_PROVIDER}/<model-id> models; got {model_name!r}"
-            )
-        if not model_id:
-            raise ValueError("--model must include a model id after kimchi-dev/")
-        return provider, model_id
-
-    def _fetch_model_metadata(self, api_key: str) -> list[KimchiModelMetadata]:
-        try:
-            response = httpx.get(
-                KIMCHI_MODELS_METADATA_URL,
-                headers={"Authorization": f"Bearer {api_key}"},
-                timeout=FETCH_TIMEOUT_SEC,
-            )
-            response.raise_for_status()
-            body = response.json()
-        except httpx.HTTPStatusError as exc:
-            raise RuntimeError(f"Failed to fetch Kimchi model metadata: HTTP {exc.response.status_code}") from exc
-        except (httpx.HTTPError, json.JSONDecodeError) as exc:
-            raise RuntimeError(f"Failed to fetch Kimchi model metadata: {exc}") from exc
-
-        try:
-            metadata = KimchiModelsMetadataResponse.model_validate(body)
-        except ValidationError as exc:
-            raise RuntimeError(f"Failed to parse Kimchi model metadata: {exc}") from exc
-
-        return metadata.models
-
-    def _model_metadata(self, api_key: str) -> list[KimchiModelMetadata]:
-        if self._model_metadata_cache is None or self._model_metadata_cache[0] != api_key:
-            self._model_metadata_cache = (api_key, self._fetch_model_metadata(api_key))
-        return self._model_metadata_cache[1]
-
-    def _model_metadata_for(self, api_key: str, model_name: str | None) -> KimchiModelMetadata:
-        _, model_id = self._split_model(model_name)
-        for model in self._model_metadata(api_key):
-            if model.slug == model_id:
-                return model
-        raise ValueError(f"Model {model_name!r} was not returned by {KIMCHI_MODELS_METADATA_URL}")
-
-    def _selected_model_metadata(self, api_key: str) -> KimchiModelMetadata:
-        return self._model_metadata_for(api_key, self.model_name)
 
     def _model_config(self, api_key: str, model_name: str | None) -> dict[str, Any]:
         model = self._model_metadata_for(api_key, model_name)
@@ -128,9 +55,9 @@ class OpenCodeKimchi(OpenCode):
     def _small_model_name(self) -> str | None:
         return self._get_env(SMALL_MODEL_ENV) or self.model_name
 
-    def _build_register_config_command(self, api_key: str) -> str:
+    def _build_register_config_command(self, api_key: str, small_model_name: str | None = None) -> str:
         _, model_id = self._split_model(self.model_name)
-        small_model_name = self._small_model_name()
+        small_model_name = small_model_name or self._small_model_name()
         _, small_model_id = self._split_model(small_model_name)
         models = {model_id: self._selected_model_config(api_key)}
         if small_model_id != model_id:
@@ -151,7 +78,7 @@ class OpenCodeKimchi(OpenCode):
                     "npm": "@ai-sdk/openai-compatible",
                     "name": "Kimchi",
                     "options": {
-                        "baseURL": KIMCHI_BASE_URL,
+                        "baseURL": KIMCHI_OPENAI_BASE_URL,
                         # kimchi: the gateway is served through LiteLLM, matching
                         # the first-party Kimchi OpenCode provider integration.
                         "litellmProxy": True,
@@ -175,22 +102,13 @@ class OpenCodeKimchi(OpenCode):
         return f"mkdir -p ~/.config/opencode && echo {shlex.quote(config_json)} > ~/.config/opencode/opencode.json"
 
     def _build_env(self) -> dict[str, str]:
-        api_key = self._get_env(KIMCHI_API_KEY_ENV)
-        if not api_key:
-            raise ValueError(
-                f"{KIMCHI_API_KEY_ENV} is required. Export it on the host and forward it with "
-                f"`--ae {KIMCHI_API_KEY_ENV}=${KIMCHI_API_KEY_ENV}`."
-            )
-        env = self._passthrough_env(("OPENCODE_",))
+        api_key = self._required_kimchi_api_key()
+        env = self._passthrough_env(keys=OPENCODE_RUNTIME_ENV_KEYS)
         env.update({
             KIMCHI_API_KEY_ENV: api_key,
         })
         env.setdefault("OPENCODE_FAKE_VCS", "git")
-        return env
-
-    def _passthrough_env(self, prefixes: tuple[str, ...]) -> dict[str, str]:
-        env = {key: value for key, value in os.environ.items() if key.startswith(prefixes)}
-        env.update({key: value for key, value in self._extra_env.items() if key.startswith(prefixes)})
+        self._scrub_extra_env(prefixes=("OPENCODE_",), allow_keys=OPENCODE_RUNTIME_ENV_KEYS)
         return env
 
     def _thinking_flag(self, api_key: str) -> str:
@@ -203,16 +121,17 @@ class OpenCodeKimchi(OpenCode):
         environment: BaseEnvironment,
         context: AgentContext,
     ) -> None:
-        self._split_model(self.model_name)
         escaped_instruction = shlex.quote(instruction)
+        small_model_name = self._small_model_name()
         env = self._build_env()
         api_key = env[KIMCHI_API_KEY_ENV]
+        config_command = self._build_register_config_command(api_key, small_model_name)
 
         skills_command = self._build_register_skills_command()
         if skills_command:
             await self.exec_as_agent(environment, command=skills_command, env=env)
 
-        await self.exec_as_agent(environment, command=self._build_register_config_command(api_key), env=env)
+        await self.exec_as_agent(environment, command=config_command, env=env)
 
         await self.exec_as_agent(
             environment,

--- a/benchmark/terminal-bench-2/src/kimchi_agent/opencode_kimchi_test.py
+++ b/benchmark/terminal-bench-2/src/kimchi_agent/opencode_kimchi_test.py
@@ -10,14 +10,13 @@ from unittest.mock import patch
 from harbor.models.agent.context import AgentContext
 from harbor.models.task.config import MCPServerConfig
 
-from kimchi_agent.opencode_kimchi import (
-    KIMCHI_BASE_URL,
+from kimchi_agent.gateway import (
     KIMCHI_MODELS_METADATA_URL,
-    KIMCHI_PROVIDER,
+    KIMCHI_OPENAI_BASE_URL,
     KimchiModelMetadata,
     KimchiModelsMetadataResponse,
-    OpenCodeKimchi,
 )
+from kimchi_agent.opencode_kimchi import KIMCHI_PROVIDER, OpenCodeKimchi
 
 
 class FakeMetadataResponse:
@@ -57,11 +56,15 @@ class RecordingOpenCodeKimchi(OpenCodeKimchi):
         super().__init__(*args, **kwargs)
         self.agent_commands: list[str] = []
         self.agent_envs: list[dict[str, str] | None] = []
+        self.effective_agent_envs: list[dict[str, str]] = []
         self.metadata_fetch_count = 0
 
     async def exec_as_agent(self, _environment, command: str, env=None, cwd=None, timeout_sec=None):
         self.agent_commands.append(command)
         self.agent_envs.append(env)
+        merged_env = dict(env) if env else {}
+        merged_env.update(self._extra_env)
+        self.effective_agent_envs.append(merged_env)
 
     def _fetch_model_metadata(self, api_key: str) -> list[KimchiModelMetadata]:
         self.metadata_fetch_count += 1
@@ -101,7 +104,7 @@ class OpenCodeKimchiTest(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(config["small_model"], "kimchi-dev/minimax-m2.7")
         self.assertIn("minimax-m2.7", config["provider"][KIMCHI_PROVIDER]["models"])
         self.assertNotIn("kimi-k2.5", config["provider"][KIMCHI_PROVIDER]["models"])
-        self.assertEqual(config["provider"][KIMCHI_PROVIDER]["options"]["baseURL"], KIMCHI_BASE_URL)
+        self.assertEqual(config["provider"][KIMCHI_PROVIDER]["options"]["baseURL"], KIMCHI_OPENAI_BASE_URL)
         self.assertEqual(config["provider"][KIMCHI_PROVIDER]["options"]["apiKey"], "{env:KIMCHI_API_KEY}")
 
         run_command = agent.agent_commands[1]
@@ -210,7 +213,7 @@ class OpenCodeKimchiTest(unittest.IsolatedAsyncioTestCase):
         config = extract_echo_json(agent.agent_commands[0])
         provider = config["provider"][KIMCHI_PROVIDER]
         self.assertEqual(config["share"], "disabled")
-        self.assertEqual(provider["options"]["baseURL"], KIMCHI_BASE_URL)
+        self.assertEqual(provider["options"]["baseURL"], KIMCHI_OPENAI_BASE_URL)
         self.assertEqual(provider["options"]["timeout"], 600000)
         self.assertFalse(provider["models"]["kimi-k2.5"]["reasoning"])
 
@@ -230,17 +233,30 @@ class OpenCodeKimchiTest(unittest.IsolatedAsyncioTestCase):
         self.assertIn("opencode --model=kimchi-dev/kimi-k2.5", agent.agent_commands[2])
 
     async def test_opencode_extra_env_overrides_default_fake_vcs(self) -> None:
-        with tempfile.TemporaryDirectory() as tmp:
+        opencode_env = {
+            "OPENCODE_API_KEY": "wrong-key",
+            "OPENCODE_CLIENT": "host-client",
+            "OPENCODE_CONFIG": "/tmp/evil-config.json",
+        }
+        with patch.dict(os.environ, opencode_env), tempfile.TemporaryDirectory() as tmp:
             agent = RecordingOpenCodeKimchi(
                 logs_dir=Path(tmp) / "jobs" / "run-1" / "task__trial" / "agent",
                 model_name="kimchi-dev/kimi-k2.5",
-                extra_env={"OPENCODE_FAKE_VCS": "none", "OPENCODE_CLIENT": "terminal-bench"},
+                extra_env={
+                    "OPENCODE_API_KEY": "wrong-extra-key",
+                    "OPENCODE_CLIENT": "terminal-bench",
+                    "OPENCODE_CONFIG": "/tmp/evil-extra-config.json",
+                    "OPENCODE_FAKE_VCS": "none",
+                },
             )
 
             await agent.run("solve it", object(), AgentContext())
 
         self.assertEqual(agent.agent_envs[0]["OPENCODE_FAKE_VCS"], "none")
         self.assertEqual(agent.agent_envs[0]["OPENCODE_CLIENT"], "terminal-bench")
+        effective_env = agent.effective_agent_envs[0]
+        self.assertNotIn("OPENCODE_API_KEY", effective_env)
+        self.assertNotIn("OPENCODE_CONFIG", effective_env)
 
     async def test_registers_distinct_small_model_from_metadata(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:
@@ -257,6 +273,7 @@ class OpenCodeKimchiTest(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(config["small_model"], "kimchi-dev/minimax-m2.7")
         self.assertIn("kimi-k2.5", models)
         self.assertIn("minimax-m2.7", models)
+        self.assertNotIn("OPENCODE_SMALL_MODEL", agent.effective_agent_envs[0])
 
     async def test_rejects_invalid_metadata_response(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:
@@ -275,7 +292,7 @@ class OpenCodeKimchiTest(unittest.IsolatedAsyncioTestCase):
             })
 
             with (
-                patch("kimchi_agent.opencode_kimchi.httpx.get", return_value=response) as http_get,
+                patch("kimchi_agent.gateway.httpx.get", return_value=response) as http_get,
                 self.assertRaisesRegex(RuntimeError, "Failed to parse Kimchi model metadata"),
             ):
                 await agent.run("solve it", object(), AgentContext())


### PR DESCRIPTION
  ## Summary

  - Add Terminal Bench adapters for Claude Code and GSD, routed through the Kimchi gateway
  - Add multi-model orchestration mode to the base `Kimchi` agent (omits `--model`, writes `{"multiModel":true}` to `~/.config/kimchi/harness/settings.json`)
  - Extract shared `KimchiGatewayMixin` (model metadata fetch, API key validation, env scrubbing) from the OpenCode adapter

  ## Adapters

  - **Claude Code** (`claude_code_kimchi.py`): installs Claude Code, points it at `llm.kimchi.dev/anthropic`, pins all model aliases to the selected `kimchi-dev/<model-id>`, reclassifies transient API errors as `RetryableApiError`
  - **GSD** (`gsd_kimchi.py`): installs `gsd-pi`, writes single-model `models.json` + `preferences.md`, runs non-interactive text mode, aggregates token usage from pi session JSONL
  - **OpenCode**: refactored onto `KimchiGatewayMixin`, scrubs `OPENCODE_*` env that could override gateway rou

---
### Kimchi Summary
### What changed
Adds Harbor benchmark adapters for Claude Code and GSD, both routing through the Kimchi gateway. Updates the base `Kimchi` agent to support multi-model orchestration mode in addition to the existing single-model mode.

### Why
Expands `terminal-bench-2` coverage to include Claude Code and GSD scaffolds. Enables benchmarking of Kimchi's multi-model orchestrator by allowing adapters to run without an explicit `--model` flag.

### Key changes
- `benchmark/terminal-bench-2/src/kimchi_agent/claude_code_kimchi.py` — New agent that installs Claude Code, configures it to use Kimchi's Anthropic-compatible endpoint (`llm.kimchi.dev/anthropic`), pins all model aliases to the selected `kimchi-dev/<model-id>`, and reclassifies transient API errors as `RetryableApiError` for Harbor retries.
- `benchmark/terminal-bench-2/src/kimchi_agent/gsd_kimchi.py` — New agent that installs `gsd-pi`, writes a single-model `models.json` and `preferences.md` config, runs GSD in non-interactive text mode, and aggregates token usage from pi session JSONL files.
- `benchmark/terminal-bench-2/src/kimchi_agent/gateway.py` — Extracts shared `KimchiGatewayMixin` from the existing OpenCode adapter, providing model metadata fetching, API key validation, and env passthrough/scrubbing for all Kimchi-gateway adapters.
- `benchmark/terminal-bench-2/src/kimchi_agent/agent.py` — Adds `multi-model` agent kwarg to the base `Kimchi` agent. When enabled, writes `{"multiModel":true}` to `~/.config/kimchi/harness/settings.json` and omits the `--model` CLI flag so kimchi runs in orchestrator mode. Adds `_coerce_bool_kwarg` and `_validate_model_name` helpers.
- `benchmark/terminal-bench-2/scripts/run-claude-code-kimchi.sh` and `run-gsd-kimchi.sh` — New helper scripts for running the respective scaffolds via Harbor.
- `benchmark/terminal-bench-2/scripts/run-local.sh` and `run-release.sh` — Updated usage examples show `--agent-kwarg multi-model=true`.
- `benchmark/terminal-bench-2/src/kimchi_agent/opencode_kimchi.py` — Refactored to use `KimchiGatewayMixin`; scrubs `OPENCODE_` extra env keys that could override gateway routing.
- `benchmark/terminal-bench-2/README.md` — Documents Claude Code and GSD runners, clarifies single-model vs multi-model semantics, and documents `CLAUDE_CODE_VERSION` and `GSD_VERSION` env vars.

### Impact
- **Behavior change**: Single-model runs still require `--model`, but multi-model runs intentionally omit it. Passing `--agent-kwarg multi-model=true` enables orchestration; passing both `multi-model=true` and `disable-multi-model=true` raises a `ValueError`.
- **Legacy compatibility**: The removed `--multi-model=false` CLI flag is no longer emitted; `disable-multi-model=true` is accepted as a no-op kwarg for backward compatibility.
- **Env isolation**: All gateway adapters (`opencode`, `claude-code`, `gsd`) now scrub conflicting extra env to prevent host credentials from overriding Kimchi routing.

---
### Kimchi Summary
### What changed
Adds Harbor benchmark adapters for Claude Code and GSD, refactors shared Kimchi gateway utilities into a reusable mixin, and fixes multi-model orchestration mode in the base Kimchi agent.

### Why
Expands Terminal Bench coverage to additional agent scaffolds and prevents the benchmark adapter from inadvertently disabling Kimchi's multi-model orchestrator by always injecting `--model`.

### Key changes
- `gateway.py`: Introduces `KimchiGatewayMixin` with model metadata fetching via `/v1/models/metadata?include_in_cli=true`, API key validation, and secure env passthrough/scrubbing.
- `claude_code_kimchi.py` + `run-claude-code-kimchi.sh`: New adapter that installs Claude Code, routes to Kimchi's Anthropic-compatible endpoint (`https://llm.kimchi.dev/anthropic`), aliases Sonnet/Opus/Haiku/subagent roles to the selected model, and reclassifies transient API errors as `RetryableApiError`.
- `gsd_kimchi.py` + `run-gsd-kimchi.sh`: New adapter that installs `gsd-pi`, writes a temporary GSD home with single-model preferences routing every role to one Kimchi model, runs in non-interactive text mode, and post-processes pi session JSONL for token accounting.
- `opencode_kimchi.py`: Refactored to inherit from `KimchiGatewayMixin`; now scrubs blocked env keys from `_extra_env` so host credentials cannot override gateway routing.
- `agent.py`: Replaces the obsolete `--multi-model=false` CLI flag with `multi-model=true` adapter-kwarg support. Multi-model runs omit `--model`, persist `{"multiModel":true}` to `~/.config/kimchi/harness/settings.json`, and report `multi-model` in `AgentInfo`. Single-model runs continue to require a qualified `--model`.
- `README.md`: Documents Claude Code and GSD usage, distinguishes single-model from multi-model invocation, and adds `OPENCODE_VERSION`, `CLAUDE_CODE_VERSION`, and `GSD_VERSION` env vars.

### Impact
- **Behavior change**: The legacy `disable-multi-model` kwarg is accepted for compatibility but no longer emits a CLI flag. Use `--agent-kwarg multi-model=true` to enable orchestration.
- Host env variables for conflicting provider credentials (e.g., `ANTHROPIC_API_KEY`, `ANTHROPIC_BASE_URL`, `OPENCODE_API_KEY`, `OPENCODE_CONFIG`) are now forcibly overridden or cleared by adapters to prevent off-gateway routing.
- `MODEL` defaults to single-model mode in helper scripts; multi-model mode intentionally omits `--model` because an explicit model flag disables orchestration in the kimchi CLI.