### PR TITLE
feat(setup): show Kimchi as mandatory, locked default in tool list

### DIFF
--- a/scripts/patch-clack-for-locked-options.mjs
+++ b/scripts/patch-clack-for-locked-options.mjs
@@ -13,41 +13,70 @@ const PROMPTS = "node_modules/.pnpm/@clack+prompts@1.3.0/node_modules/@clack/pro
 let core = readFileSync(CORE, "utf-8")
 let prompts = readFileSync(PROMPTS, "utf-8")
 
+function verify(name, before, after) {
+	if (before === after) {
+		throw new Error(`Patch failed: "${name}" did not match. The minified clack output may have changed — review the patch script.`)
+	}
+}
+
 /* ── @clack/core: allow cursor navigation to disabled options ── */
 
 // findCursor — remove disabled-skip logic
-// Before: function d(r,t,s){if(!s.some(o=>!o.disabled))return r;const e=r+t,i=Math.max(s.length-1,0),n=e<0?i:e>i?0:e;return s[n].disabled?d(n,t<0?-1:1,s):n}
-// After:   function d(r,t,s){const e=r+t,i=Math.max(s.length-1,0),n=e<0?i:e>i?0:e;return n}
+const beforeFindCursor = core
 core = core.replace(
-  "function d(r,t,s){if(!s.some(o=>!o.disabled))return r;const e=r+t,i=Math.max(s.length-1,0),n=e<0?i:e>i?0:e;return s[n].disabled?d(n,t<0?-1:1,s):n}",
-  "function d(r,t,s){const e=r+t,i=Math.max(s.length-1,0),n=e<0?i:e>i?0:e;return n}"
+	"function d(r,t,s){if(!s.some(o=>!o.disabled))return r;const e=r+t,i=Math.max(s.length-1,0),n=e<0?i:e>i?0:e;return s[n].disabled?d(n,t<0?-1:1,s):n}",
+	"function d(r,t,s){const e=r+t,i=Math.max(s.length-1,0),n=e<0?i:e>i?0:e;return n}"
 )
+verify("findCursor", beforeFindCursor, core)
 
 // MultiSelectPrompt initial cursor — don't skip disabled on init
-// Before: this.cursor=this.options[s].disabled?d(s,1,this.options):s
-// After:   this.cursor=s
+const beforeInitCursor = core
 core = core.replace(
-  "this.cursor=this.options[s].disabled?d(s,1,this.options):s",
-  "this.cursor=s"
+	"this.cursor=this.options[s].disabled?d(s,1,this.options):s",
+	"this.cursor=s"
 )
+verify("initCursor", beforeInitCursor, core)
 
 // MultiSelectPrompt cursor events — simple wrap without disabled skip
-// Before: case"left":case"up":this.cursor=d(this.cursor,-1,this.options);break;case"down":case"right":this.cursor=d(this.cursor,1,this.options);break;
-// After:   inline wrap logic
+const beforeNavCursor = core
 core = core.replace(
-  'case"left":case"up":this.cursor=d(this.cursor,-1,this.options);break;case"down":case"right":this.cursor=d(this.cursor,1,this.options);break;',
-  'case"left":case"up":{const n=this.cursor-1,o=this.options.length-1;this.cursor=n<0?o:n>o?0:n;break;}case"down":case"right":{const n=this.cursor+1,o=this.options.length-1;this.cursor=n<0?o:n>o?0:n;break;}'
+	'case"left":case"up":this.cursor=d(this.cursor,-1,this.options);break;case"down":case"right":this.cursor=d(this.cursor,1,this.options);break;',
+	'case"left":case"up":{const n=this.cursor-1,o=this.options.length-1;this.cursor=n<0?o:n>o?0:n;break;}case"down":case"right":{const n=this.cursor+1,o=this.options.length-1;this.cursor=n<0?o:n>o?0:n;break;}'
 )
+verify("navCursor", beforeNavCursor, core)
+
+// toggleValue — skip disabled options
+const beforeToggleValue = core
+core = core.replace(
+	'toggleValue(){this.value===void 0&&(this.value=[]);const t=this.value.includes(this._value);this.value=t?this.value.filter(s=>s!==this._value):[...this.value,this._value]}',
+	'toggleValue(){if(this.options[this.cursor]?.disabled)return;this.value===void 0&&(this.value=[]);const t=this.value.includes(this._value);this.value=t?this.value.filter(s=>s!==this._value):[...this.value,this._value]}'
+)
+verify("toggleValue", beforeToggleValue, core)
+
+// toggleAll — preserve locked (disabled+selected) values
+const beforeToggleAll = core
+core = core.replace(
+	'toggleAll(){const t=this._enabledOptions,s=this.value!==void 0&&this.value.length===t.length;this.value=s?[]:t.map(e=>e.value)}',
+	'toggleAll(){const t=this._enabledOptions,s=this.value!==void 0&&this.value.length===t.length;const l=this.options.filter(o=>o.disabled&&this.value?.includes(o.value)).map(o=>o.value);this.value=s?[...l]:[...t.map(e=>e.value),...l]}'
+)
+verify("toggleAll", beforeToggleAll, core)
+
+// toggleInvert — preserve locked (disabled+selected) values
+const beforeToggleInvert = core
+core = core.replace(
+	'toggleInvert(){const t=this.value;if(!t)return;const s=this._enabledOptions.filter(e=>!t.includes(e.value));this.value=s.map(e=>e.value)}',
+	'toggleInvert(){const t=this.value;if(!t)return;const s=this._enabledOptions.filter(e=>!t.includes(e.value)),l=this.options.filter(o=>o.disabled&&this.value?.includes(o.value)).map(o=>o.value);this.value=[...s.map(e=>e.value),...l]}'
+)
+verify("toggleInvert", beforeToggleInvert, core)
 
 /* ── @clack/prompts: render disabled+selected with green checkmark ── */
 
-// styleOption — when disabled AND selected, render green checkbox + gray label
-// Before: const c=(a,l)=>{if(a.disabled)return r(a,"disabled");const d=o.includes(a.value);return l&&d?r(a,"active-selected"):d?r(a,"selected"):r(a,l?"active":"inactive")};
-// After:   same but checks selected state for disabled options
+const beforePrompts = prompts
 prompts = prompts.replace(
-  'const c=(a,l)=>{if(a.disabled)return r(a,"disabled");const d=o.includes(a.value);return l&&d?r(a,"active-selected"):d?r(a,"selected"):r(a,l?"active":"inactive")};',
-  'const c=(a,l)=>{if(a.disabled){const d=o.includes(a.value);return d?`${e("green",U)} ${Q(a.label??String(a.value),o=>e("gray",o))}${a.hint?` ${e("dim",`(${a.hint})`)}`:""}`:r(a,"disabled")}const d=o.includes(a.value);return l&&d?r(a,"active-selected"):d?r(a,"selected"):r(a,l?"active":"inactive")};'
+	'c=(a,l)=>{if(a.disabled)return r(a,"disabled");const d=o.includes(a.value);return l&&d?r(a,"active-selected"):d?r(a,"selected"):r(a,l?"active":"inactive")};',
+	'c=(a,l)=>{if(a.disabled){const d=o.includes(a.value);return d?`${e("green",U)} ${Q(a.label??String(a.value),o=>e("gray",o))}${a.hint?` ${e("dim",`(${a.hint})`)}`:""}`:r(a,"disabled")}const d=o.includes(a.value);return l&&d?r(a,"active-selected"):d?r(a,"selected"):r(a,l?"active":"inactive")};'
 )
+verify("styleOption", beforePrompts, prompts)
 
 writeFileSync(CORE, core)
 writeFileSync(PROMPTS, prompts)

--- a/scripts/patch-clack-for-locked-options.mjs
+++ b/scripts/patch-clack-for-locked-options.mjs
@@ -1,0 +1,55 @@
+/**
+ * Patches @clack/core and @clack/prompts to support "locked" options:
+ * disabled options that are checked by default and cannot be toggled,
+ * rendered with a green checkmark and gray text (no strikethrough).
+ *
+ * Run this script before `pnpm run build:binary` after `pnpm install`.
+ */
+import { readFileSync, writeFileSync } from "node:fs"
+
+const CORE = "node_modules/.pnpm/@clack+core@1.3.0/node_modules/@clack/core/dist/index.mjs"
+const PROMPTS = "node_modules/.pnpm/@clack+prompts@1.3.0/node_modules/@clack/prompts/dist/index.mjs"
+
+let core = readFileSync(CORE, "utf-8")
+let prompts = readFileSync(PROMPTS, "utf-8")
+
+/* ── @clack/core: allow cursor navigation to disabled options ── */
+
+// findCursor — remove disabled-skip logic
+// Before: function d(r,t,s){if(!s.some(o=>!o.disabled))return r;const e=r+t,i=Math.max(s.length-1,0),n=e<0?i:e>i?0:e;return s[n].disabled?d(n,t<0?-1:1,s):n}
+// After:   function d(r,t,s){const e=r+t,i=Math.max(s.length-1,0),n=e<0?i:e>i?0:e;return n}
+core = core.replace(
+  "function d(r,t,s){if(!s.some(o=>!o.disabled))return r;const e=r+t,i=Math.max(s.length-1,0),n=e<0?i:e>i?0:e;return s[n].disabled?d(n,t<0?-1:1,s):n}",
+  "function d(r,t,s){const e=r+t,i=Math.max(s.length-1,0),n=e<0?i:e>i?0:e;return n}"
+)
+
+// MultiSelectPrompt initial cursor — don't skip disabled on init
+// Before: this.cursor=this.options[s].disabled?d(s,1,this.options):s
+// After:   this.cursor=s
+core = core.replace(
+  "this.cursor=this.options[s].disabled?d(s,1,this.options):s",
+  "this.cursor=s"
+)
+
+// MultiSelectPrompt cursor events — simple wrap without disabled skip
+// Before: case"left":case"up":this.cursor=d(this.cursor,-1,this.options);break;case"down":case"right":this.cursor=d(this.cursor,1,this.options);break;
+// After:   inline wrap logic
+core = core.replace(
+  'case"left":case"up":this.cursor=d(this.cursor,-1,this.options);break;case"down":case"right":this.cursor=d(this.cursor,1,this.options);break;',
+  'case"left":case"up":{const n=this.cursor-1,o=this.options.length-1;this.cursor=n<0?o:n>o?0:n;break;}case"down":case"right":{const n=this.cursor+1,o=this.options.length-1;this.cursor=n<0?o:n>o?0:n;break;}'
+)
+
+/* ── @clack/prompts: render disabled+selected with green checkmark ── */
+
+// styleOption — when disabled AND selected, render green checkbox + gray label
+// Before: const c=(a,l)=>{if(a.disabled)return r(a,"disabled");const d=o.includes(a.value);return l&&d?r(a,"active-selected"):d?r(a,"selected"):r(a,l?"active":"inactive")};
+// After:   same but checks selected state for disabled options
+prompts = prompts.replace(
+  'const c=(a,l)=>{if(a.disabled)return r(a,"disabled");const d=o.includes(a.value);return l&&d?r(a,"active-selected"):d?r(a,"selected"):r(a,l?"active":"inactive")};',
+  'const c=(a,l)=>{if(a.disabled){const d=o.includes(a.value);return d?`${e("green",U)} ${Q(a.label??String(a.value),o=>e("gray",o))}${a.hint?` ${e("dim",`(${a.hint})`)}`:""}`:r(a,"disabled")}const d=o.includes(a.value);return l&&d?r(a,"active-selected"):d?r(a,"selected"):r(a,l?"active":"inactive")};'
+)
+
+writeFileSync(CORE, core)
+writeFileSync(PROMPTS, prompts)
+
+console.log("✅ Patched @clack/core and @clack/prompts for locked options")

--- a/src/integrations/kimchi.ts
+++ b/src/integrations/kimchi.ts
@@ -1,0 +1,10 @@
+import { register } from "./registry.js"
+register({
+	id: "kimchi",
+	name: "Kimchi",
+	description: "AI coding agent harness",
+	configPath: "",
+	binaryName: "kimchi",
+	isInstalled: () => true,
+	write: async () => {},
+})

--- a/src/integrations/types.ts
+++ b/src/integrations/types.ts
@@ -1,7 +1,7 @@
 import type { ConfigScope } from "../config/scope.js"
 import type { ModelMetadata } from "../models.js"
 
-export type ToolId = "opencode" | "claudecode" | "cursor" | "openclaw" | "gsd2"
+export type ToolId = "opencode" | "claudecode" | "cursor" | "openclaw" | "gsd2" | "kimchi"
 
 /**
  * A configurable third-party tool that kimchi can point at the kimchi LLM

--- a/src/setup-wizard/index.ts
+++ b/src/setup-wizard/index.ts
@@ -1,6 +1,7 @@
 // Side-effect imports register each integration. Import order doesn't matter
 // — the registry is a Map keyed by ToolId — but the imports themselves do,
 // otherwise byId() returns undefined for an unimported tool.
+import "../integrations/kimchi.js"
 import "../integrations/claude-code.js"
 import "../integrations/cursor.js"
 import "../integrations/gsd2.js"

--- a/src/setup-wizard/prompt.ts
+++ b/src/setup-wizard/prompt.ts
@@ -91,6 +91,7 @@ export async function multiselect<T>(opts: {
 	initialValues?: T[]
 	required?: boolean
 	backable: boolean
+	cursorAt?: T
 }): Promise<Outcome<T[]>> {
 	return awaitWithCancelDetection(opts.backable, () =>
 		clackMultiselect<T>({
@@ -98,6 +99,7 @@ export async function multiselect<T>(opts: {
 			options: opts.options as Parameters<typeof clackMultiselect<T>>[0]["options"],
 			initialValues: opts.initialValues,
 			required: opts.required,
+			cursorAt: opts.cursorAt,
 		}),
 	)
 }

--- a/src/setup-wizard/steps/done.ts
+++ b/src/setup-wizard/steps/done.ts
@@ -69,9 +69,13 @@ export async function runDoneStep(state: WizardState): Promise<ApplyOutcome> {
 		if (state.mode === "inject") {
 			// No disk writes in inject mode — the launcher sets env per-process.
 			outcome.successes.push(tool.name)
-			// 'claudecode' is the tool ID but the CLI command is 'claude'
-			const launchCmd = id === "claudecode" ? "claude" : id
-			log.info(`${tool.name}: ready (launch via 'kimchi ${launchCmd}')`)
+			if (id === "kimchi") {
+				log.info(`${tool.name}: ready`)
+			} else {
+				// 'claudecode' is the tool ID but the CLI command is 'claude'
+				const launchCmd = id === "claudecode" ? "claude" : id
+				log.info(`${tool.name}: ready (launch via 'kimchi ${launchCmd}')`)
+			}
 			continue
 		}
 		const s = spinner()

--- a/src/setup-wizard/steps/done.ts
+++ b/src/setup-wizard/steps/done.ts
@@ -133,6 +133,7 @@ export async function runDoneStep(state: WizardState): Promise<ApplyOutcome> {
 	].filter((l) => l.length > 0)
 
 	note(summaryLines.join("\n"), "Summary")
+	log.step("Run `kimchi` to get started.")
 	outro(outcome.failures.length === 0 ? "Done." : "Done with errors. Check above for details.")
 	return outcome
 }

--- a/src/setup-wizard/steps/tools.ts
+++ b/src/setup-wizard/steps/tools.ts
@@ -10,6 +10,10 @@ import type { WizardState } from "../state.js"
  * detection state (installed / not detected). Pre-selects the tools we
  * detect as installed; users can flip individual toggles.
  *
+ * Kimchi itself is always at the top, always selected, and always locked
+ * (labelled with a 🔒 and hint). If the user somehow unchecks it, the
+ * selection is restored after the prompt closes.
+ *
  * Tools whose `isInstalled()` returns false are still selectable — useful
  * when the user is about to install the binary alongside.
  */
@@ -41,8 +45,8 @@ export async function runToolsStep(state: WizardState, opts: { backable: boolean
 		message: "Which tools should be configured?",
 		options: tools.map((t) => ({
 			value: t.id,
-			label: t.name,
-			hint: t.id === "kimchi" ? "\x1b[36minstalled\x1b[39m" : installed.has(t.id) ? "installed" : "not detected",
+			label: t.id === "kimchi" ? "Kimchi 🔒" : t.name,
+			hint: t.id === "kimchi" ? "\x1b[36mrequired\x1b[39m" : installed.has(t.id) ? "installed" : "not detected",
 		})),
 		initialValues: initial,
 		required: false,

--- a/src/setup-wizard/steps/tools.ts
+++ b/src/setup-wizard/steps/tools.ts
@@ -1,4 +1,4 @@
-import { log, note } from "@clack/prompts"
+import { note } from "@clack/prompts"
 import { all as allTools } from "../../integrations/registry.js"
 import type { ToolId } from "../../integrations/types.js"
 import { multiselect } from "../prompt.js"
@@ -6,8 +6,9 @@ import type { WizardState } from "../state.js"
 
 /**
  * Tools step — multi-select which tools to configure. Kimchi itself is
- * shown as a locked header above the list (always included, never
- * toggleable). The multiselect only contains third-party tools.
+ * shown as the first, locked option in the list (disabled in clack,
+ * rendered with a green checkmark and gray text). The user cannot
+ * navigate away from it or toggle it off — the checkbox is purely visual.
  *
  * Each option's hint reflects detection state (installed / not detected).
  * Pre-selects the tools we detect as installed; users can flip individual
@@ -19,11 +20,14 @@ import type { WizardState } from "../state.js"
 export async function runToolsStep(state: WizardState, opts: { backable: boolean }): Promise<void> {
 	const tools = allTools()
 
-	// Kimchi is always included and shown above the list as a locked item.
-	const kimchi = tools.find((t) => t.id === "kimchi")
-	const otherTools = tools.filter((t) => t.id !== "kimchi")
+	// Move Kimchi to the top of the list
+	const kimchiIndex = tools.findIndex((t) => t.id === "kimchi")
+	if (kimchiIndex > 0) {
+		const [kimchi] = tools.splice(kimchiIndex, 1)
+		tools.unshift(kimchi)
+	}
 
-	if (otherTools.length === 0) {
+	if (tools.length === 0) {
 		// Defensive: only reachable if no integration modules were imported,
 		// which means the wizard was wired wrong. Bail with a clear message
 		// rather than a silent empty selection.
@@ -32,20 +36,20 @@ export async function runToolsStep(state: WizardState, opts: { backable: boolean
 		return
 	}
 
-	// Show Kimchi as a locked header — always included, not in the list.
-	if (kimchi) {
-		log.step("Kimchi 🔒  already installed — will be configured")
+	const installed = new Set(tools.filter((t) => t.isInstalled()).map((t) => t.id))
+	const initial = tools.filter((t) => installed.has(t.id)).map((t) => t.id)
+	// Kimchi is always selected
+	if (!initial.includes("kimchi")) {
+		initial.unshift("kimchi")
 	}
 
-	const installed = new Set(otherTools.filter((t) => t.isInstalled()).map((t) => t.id))
-	const initial = otherTools.filter((t) => installed.has(t.id)).map((t) => t.id)
-
 	const r = await multiselect<ToolId>({
-		message: "Which additional tools should be configured?",
-		options: otherTools.map((t) => ({
+		message: "Which tools should be configured?",
+		options: tools.map((t) => ({
 			value: t.id,
-			label: t.name,
-			hint: installed.has(t.id) ? "installed" : "not detected",
+			label: t.id === "kimchi" ? "Kimchi 🔒" : t.name,
+			hint: t.id === "kimchi" ? "required" : installed.has(t.id) ? "installed" : "not detected",
+			disabled: t.id === "kimchi",
 		})),
 		initialValues: initial,
 		required: false,
@@ -60,6 +64,5 @@ export async function runToolsStep(state: WizardState, opts: { backable: boolean
 		state.cancelled = true
 		return
 	}
-	// Kimchi is always selected and cannot be unselected
-	state.selectedTools = ["kimchi", ...r.value]
+	state.selectedTools = r.value
 }

--- a/src/setup-wizard/steps/tools.ts
+++ b/src/setup-wizard/steps/tools.ts
@@ -54,6 +54,7 @@ export async function runToolsStep(state: WizardState, opts: { backable: boolean
 		initialValues: initial,
 		required: false,
 		backable: opts.backable,
+		cursorAt: "claudecode",
 	})
 
 	if (r.kind === "back") {

--- a/src/setup-wizard/steps/tools.ts
+++ b/src/setup-wizard/steps/tools.ts
@@ -47,7 +47,7 @@ export async function runToolsStep(state: WizardState, opts: { backable: boolean
 		message: "Which tools should be configured?",
 		options: tools.map((t) => ({
 			value: t.id,
-			label: t.id === "kimchi" ? "Kimchi 🔒" : t.name,
+			label: t.name,
 			hint: t.id === "kimchi" ? "required" : installed.has(t.id) ? "installed" : "not detected",
 			disabled: t.id === "kimchi",
 		})),

--- a/src/setup-wizard/steps/tools.ts
+++ b/src/setup-wizard/steps/tools.ts
@@ -15,6 +15,12 @@ import type { WizardState } from "../state.js"
  */
 export async function runToolsStep(state: WizardState, opts: { backable: boolean }): Promise<void> {
 	const tools = allTools()
+	// Move Kimchi to the top of the list
+	const kimchiIndex = tools.findIndex((t) => t.id === "kimchi")
+	if (kimchiIndex > 0) {
+		const kimchi = tools.splice(kimchiIndex, 1)[0]
+		tools.unshift(kimchi)
+	}
 	if (tools.length === 0) {
 		// Defensive: only reachable if no integration modules were imported,
 		// which means the wizard was wired wrong. Bail with a clear message
@@ -26,13 +32,17 @@ export async function runToolsStep(state: WizardState, opts: { backable: boolean
 
 	const installed = new Set(tools.filter((t) => t.isInstalled()).map((t) => t.id))
 	const initial = tools.filter((t) => installed.has(t.id)).map((t) => t.id)
+	// Kimchi is always selected and cannot be unselected
+	if (!initial.includes("kimchi")) {
+		initial.unshift("kimchi")
+	}
 
 	const r = await multiselect<ToolId>({
 		message: "Which tools should be configured?",
 		options: tools.map((t) => ({
 			value: t.id,
 			label: t.name,
-			hint: installed.has(t.id) ? "installed" : "not detected",
+			hint: t.id === "kimchi" ? "\x1b[36minstalled\x1b[39m" : installed.has(t.id) ? "installed" : "not detected",
 		})),
 		initialValues: initial,
 		required: false,
@@ -48,4 +58,8 @@ export async function runToolsStep(state: WizardState, opts: { backable: boolean
 		return
 	}
 	state.selectedTools = r.value
+	// Kimchi is always selected and cannot be unselected
+	if (!state.selectedTools.includes("kimchi")) {
+		state.selectedTools.unshift("kimchi")
+	}
 }

--- a/src/setup-wizard/steps/tools.ts
+++ b/src/setup-wizard/steps/tools.ts
@@ -1,31 +1,29 @@
-import { note } from "@clack/prompts"
+import { log, note } from "@clack/prompts"
 import { all as allTools } from "../../integrations/registry.js"
 import type { ToolId } from "../../integrations/types.js"
 import { multiselect } from "../prompt.js"
 import type { WizardState } from "../state.js"
 
 /**
- * Tools step — multi-select which tools to configure. The list is built
- * from the integrations registry, with each option's hint reflecting
- * detection state (installed / not detected). Pre-selects the tools we
- * detect as installed; users can flip individual toggles.
+ * Tools step — multi-select which tools to configure. Kimchi itself is
+ * shown as a locked header above the list (always included, never
+ * toggleable). The multiselect only contains third-party tools.
  *
- * Kimchi itself is always at the top, always selected, and always locked
- * (labelled with a 🔒 and hint). If the user somehow unchecks it, the
- * selection is restored after the prompt closes.
+ * Each option's hint reflects detection state (installed / not detected).
+ * Pre-selects the tools we detect as installed; users can flip individual
+ * toggles.
  *
  * Tools whose `isInstalled()` returns false are still selectable — useful
  * when the user is about to install the binary alongside.
  */
 export async function runToolsStep(state: WizardState, opts: { backable: boolean }): Promise<void> {
 	const tools = allTools()
-	// Move Kimchi to the top of the list
-	const kimchiIndex = tools.findIndex((t) => t.id === "kimchi")
-	if (kimchiIndex > 0) {
-		const kimchi = tools.splice(kimchiIndex, 1)[0]
-		tools.unshift(kimchi)
-	}
-	if (tools.length === 0) {
+
+	// Kimchi is always included and shown above the list as a locked item.
+	const kimchi = tools.find((t) => t.id === "kimchi")
+	const otherTools = tools.filter((t) => t.id !== "kimchi")
+
+	if (otherTools.length === 0) {
 		// Defensive: only reachable if no integration modules were imported,
 		// which means the wizard was wired wrong. Bail with a clear message
 		// rather than a silent empty selection.
@@ -34,19 +32,20 @@ export async function runToolsStep(state: WizardState, opts: { backable: boolean
 		return
 	}
 
-	const installed = new Set(tools.filter((t) => t.isInstalled()).map((t) => t.id))
-	const initial = tools.filter((t) => installed.has(t.id)).map((t) => t.id)
-	// Kimchi is always selected and cannot be unselected
-	if (!initial.includes("kimchi")) {
-		initial.unshift("kimchi")
+	// Show Kimchi as a locked header — always included, not in the list.
+	if (kimchi) {
+		log.step("Kimchi 🔒  already installed — will be configured")
 	}
 
+	const installed = new Set(otherTools.filter((t) => t.isInstalled()).map((t) => t.id))
+	const initial = otherTools.filter((t) => installed.has(t.id)).map((t) => t.id)
+
 	const r = await multiselect<ToolId>({
-		message: "Which tools should be configured?",
-		options: tools.map((t) => ({
+		message: "Which additional tools should be configured?",
+		options: otherTools.map((t) => ({
 			value: t.id,
-			label: t.id === "kimchi" ? "Kimchi 🔒" : t.name,
-			hint: t.id === "kimchi" ? "\x1b[36mrequired\x1b[39m" : installed.has(t.id) ? "installed" : "not detected",
+			label: t.name,
+			hint: installed.has(t.id) ? "installed" : "not detected",
 		})),
 		initialValues: initial,
 		required: false,
@@ -61,9 +60,6 @@ export async function runToolsStep(state: WizardState, opts: { backable: boolean
 		state.cancelled = true
 		return
 	}
-	state.selectedTools = r.value
 	// Kimchi is always selected and cannot be unselected
-	if (!state.selectedTools.includes("kimchi")) {
-		state.selectedTools.unshift("kimchi")
-	}
+	state.selectedTools = ["kimchi", ...r.value]
 }


### PR DESCRIPTION
## Summary

Makes Kimchi appear as the first, always-selected, un-unselectable option in the setup wizard's tool list.

## Changes

- **New integration**  — registers Kimchi as a tool (always installed, no-op write)
- **Tool selection**  — Kimchi is at the top, disabled (locked), pre-selected; cursor starts on Claude Code
- **Done step**  — added "Run `kimchi` to get started." message after summary
- **Prompt wrapper**  — added  support for multiselect
- **Clack patches**  — patches `@clack/core` and `@clack/prompts` to support disabled+selected options (green checkmark, navigable, non-toggleable)

## Why patches?

`@clack/prompts` does not natively support disabled options that are checked by default and cannot be toggled. The patches:
1. Allow cursor navigation to disabled options
2. Skip toggling on disabled options (space does nothing)
3. Render disabled+selected with a green checkmark + gray label instead of an empty gray box with strikethrough

## How to test

```bash
kimchi setup
```

After the welcome + API key steps, the Tools step shows Kimchi at the top (locked, checked) with the cursor starting on Claude Code. Pressing space on Kimchi has no effect.

---
### Kimchi Summary
### What changed
Adds Kimchi itself as a locked, pre-selected option in the setup wizard's tools multi-select, rendered first in the list with a green checkmark and disabled so it cannot be toggled off. Introduces a post-install patch for `@clack/core` and `@clack/prompts` to support this "locked" UI state, and updates the done step to prompt users to run `kimchi` to get started.

### Why
Kimchi is the host harness and must always be configured; surfacing it as an explicit, locked option clarifies this requirement and guides users through setup.

### Key changes
- `scripts/patch-clack-for-locked-options.mjs`: New post-install script that patches `@clack/core` to allow cursor navigation to disabled options, prevent toggling disabled items, and preserve disabled+selected values during `toggleAll` and `toggleInvert`; patches `@clack/prompts` to render disabled+selected options with a green checkmark and gray text instead of strikethrough.
- `src/integrations/kimchi.ts`: Registers the Kimchi harness as a self-integration (`id: "kimchi"`, `isInstalled: () => true`).
- `src/integrations/types.ts`: Added `"kimchi"` to the `ToolId` union.
- `src/setup-wizard/index.ts`: Imports the Kimchi integration so it appears in the registry.
- `src/setup-wizard/prompt.ts`: Added `cursorAt` option to the `multiselect` wrapper forwarded to `clackMultiselect`.
- `src/setup-wizard/steps/tools.ts`: Moves Kimchi to the top of the list, forces it into `initialValues`, marks it `disabled` with hint `"required"`, and sets `cursorAt: "claudecode"` so the cursor starts on the first configurable tool.
- `src/setup-wizard/steps/done.ts`: Skips the `kimchi <cmd>` launch hint for the Kimchi self-integration; adds `log.step("Run \`kimchi\` to get started.")` before the outro.

### Impact
The post-install patch depends on exact minified code strings from `@clack/core@1.3.0` and `@clack/prompts@1.3.0`. Upgrading either package will likely break the patches and require updating the replacement strings in the script.