### PR TITLE
fix(benchmark): unique session filenames and JSONL-based audit detection

### DIFF
--- a/benchmark/audit-session/audit-session.sh
+++ b/benchmark/audit-session/audit-session.sh
@@ -4,6 +4,7 @@ set -euo pipefail
 SESSIONS_BASE="${HOME}/.config/kimchi/harness/sessions"
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 PROMPT_FILE="${SCRIPT_DIR}/audit-session-prompt.md"
+SESSION_OUT=""
 
 usage() {
     cat <<EOF
@@ -21,6 +22,7 @@ Options:
   -d, --dir DIR       Use DIR to find sessions (default: current directory)
   -r, --runner CMD    Harness to use: kimchi or claude (default: kimchi)
   -m, --model MODEL   Model to use (default: kimchi-dev/claude-opus-4-6)
+  -s, --session PATH  Write session JSONL to PATH (kimchi only)
   -h, --help          Show this help
 
 Examples:
@@ -154,6 +156,7 @@ while [[ $# -gt 0 ]]; do
         -d|--dir) TARGET_DIR="$2"; shift 2 ;;
         -r|--runner) RUNNER="$2"; shift 2 ;;
         -m|--model) MODEL="$2"; shift 2 ;;
+        -s|--session) SESSION_OUT="$2"; shift 2 ;;
         *)
             if [[ -f "$1" ]]; then
                 SESSION_FILE="$1"
@@ -247,7 +250,12 @@ run_audit_agent() {
 
     case "$runner" in
         kimchi)
-            kimchi --model "$model" --yolo "@${prompt_file}"
+            local -a kimchi_args=(--model "$model" --yolo)
+            if [[ -n "$SESSION_OUT" ]]; then
+                kimchi_args+=(--session "$SESSION_OUT")
+            fi
+            kimchi_args+=("@${prompt_file}")
+            kimchi "${kimchi_args[@]}"
             ;;
         claude)
             claude --model "$model" --dangerously-skip-permissions "$(cat "$prompt_file")"

--- a/benchmark/manual/check-session.py
+++ b/benchmark/manual/check-session.py
@@ -91,10 +91,62 @@ def resolve_session(arg: str) -> Path:
     return SESSIONS_DIR / arg
 
 
+def check_jsonl_main(jsonl_paths: list[str]) -> bool:
+    """Handle --jsonl mode: report status for each file and exit accordingly."""
+    all_done = True
+    for path_str in jsonl_paths:
+        path = Path(path_str)
+        if not path.exists():
+            print(f"  {path.name}: NO LOG")
+            all_done = False
+            continue
+
+        info = check_jsonl(path)
+        if info["has_agent_end"]:
+            status = "DONE"
+        elif info["has_terminated"]:
+            status = "TERMINATED"
+        elif info["lines"] == 0:
+            status = "NO LOG"
+            all_done = False
+        else:
+            status = f"IN PROGRESS (last write {info['file_age_s']:.0f}s ago)"
+            all_done = False
+        print(f"  {path.name}: {status}")
+
+    return all_done
+
+
 def main():
     args = sys.argv[1:]
 
-    # Determine session and task filters
+    # --- Check for --jsonl / -j flag (must be recognised before session-arg logic) ---
+    jsonl_paths: list[str] = []
+    remaining_args: list[str] = []
+    jsonl_mode = False
+
+    i = 0
+    while i < len(args):
+        arg = args[i]
+        if arg in ("--jsonl", "-j") and not jsonl_mode:
+            jsonl_mode = True
+            i += 1
+            continue
+        if jsonl_mode:
+            jsonl_paths.append(arg)
+        else:
+            remaining_args.append(arg)
+        i += 1
+
+    if jsonl_mode:
+        if not jsonl_paths:
+            print("ERROR: --jsonl requires at least one file path", file=sys.stderr)
+            sys.exit(2)
+        all_done = check_jsonl_main(jsonl_paths)
+        sys.exit(0 if all_done else 1)
+
+    # --- Original session-directory logic ---
+    args = remaining_args
     session_dir = None
     task_filters: list[str] = []
 

--- a/benchmark/manual/new-session.sh
+++ b/benchmark/manual/new-session.sh
@@ -91,7 +91,7 @@ for task, task_prompt, extra_flags, in_run_all, setup_cmd in multi_model_tasks:
     setup_block = (setup_cmd + "\n") if setup_cmd else ""
     content = f"""#!/bin/zsh
 TS=$(date +%Y%m%d-%H%M%S)
-SESSION_FILE="{session_dir}/runs/{run_dir}/session-${{TS}}.jsonl"
+SESSION_FILE="{session_dir}/runs/{run_dir}/session-${{TS}}-{slug}.jsonl"
 DIR=$(mktemp -d /private/tmp/kimchi-{slug}-XXXXXX)
 echo "Working directory: $DIR"
 echo "Session file: $SESSION_FILE"
@@ -116,7 +116,7 @@ for model in models:
     script_path = os.path.join(session_dir, f"run-complex-single-{model}.sh")
     content = f"""#!/bin/zsh
 TS=$(date +%Y%m%d-%H%M%S)
-SESSION_FILE="{session_dir}/runs/{run_dir}/session-${{TS}}.jsonl"
+SESSION_FILE="{session_dir}/runs/{run_dir}/session-${{TS}}-{slug}.jsonl"
 DIR=$(mktemp -d /private/tmp/kimchi-{slug}-XXXXXX)
 echo "Working directory: $DIR"
 echo "Session file: $SESSION_FILE"

--- a/benchmark/manual/run-evaluation.sh
+++ b/benchmark/manual/run-evaluation.sh
@@ -144,24 +144,17 @@ done
 # --- Step 5: Run audits with Claude Opus 4.6 in separate iTerm2 tabs ---
 echo "=== Spawning iTerm2 tabs for audits ==="
 
-# Build expected output paths that match audit-session.sh naming.
-# audit-session.sh writes: <sessionId>-<task>-<runner>-<model_slug>-AUDIT.md
-# and its JSON sidecar:   <sessionId>-<task>-<runner>-<model_slug>-AUDIT.json
-declare -A AUDIT_MD_FILES
-declare -A AUDIT_JSON_FILES
+# Create audits directory and declare known audit session file paths.
+mkdir -p "${SESSION_DIR}/audits"
+declare -A AUDIT_SESSION_FILES
 for task in "${TASKS[@]}"; do
   jsonl_basename=$(basename "${JSONL_FILES["$task"]}")
   session_id="${jsonl_basename%.jsonl}"
-  audit_runner="kimchi"
-  audit_model="kimchi-dev/claude-opus-4-6"
-  model_slug="$(echo "$audit_model" | sed 's|.*/||' | tr '[:upper:]' '[:lower:]')"
-  audit_name="${session_id}-${task}-${audit_runner}-${model_slug}-AUDIT"
-  AUDIT_MD_FILES["$task"]="${REPO_ROOT}/.kimchi/audits/${audit_name}.md"
-  AUDIT_JSON_FILES["$task"]="${REPO_ROOT}/.kimchi/audits/${audit_name}.json"
+  AUDIT_SESSION_FILES["$task"]="${SESSION_DIR}/audits/audit-${session_id}.jsonl"
 done
 
 for task in "${TASKS[@]}"; do
-  audit_cmd="cd \"$REPO_ROOT\" && \"$AUDIT_SCRIPT\" -m kimchi-dev/claude-opus-4-6 \"${JSONL_FILES[\"$task\"]}\""
+  audit_cmd="cd \"$REPO_ROOT\" && \"$AUDIT_SCRIPT\" -m kimchi-dev/claude-opus-4-6 -s \"${AUDIT_SESSION_FILES["$task"]}\" \"${JSONL_FILES["$task"]}\""
   audit_cmd_escaped=${audit_cmd//\"/\\\"}
   osascript <<EOF
 tell application "iTerm2"
@@ -185,28 +178,18 @@ echo ""
 
 for ((i = 1; i <= 120; i++)); do
   echo "--- Audit poll $i/120 ---"
-  all_done=true
+  audit_jsonl_paths=()
   for task in "${TASKS[@]}"; do
-    md_file="${AUDIT_MD_FILES["$task"]}"
-    json_file="${AUDIT_JSON_FILES["$task"]}"
-    if [[ -f "$md_file" && -f "$json_file" ]]; then
-      echo "  ${task}: done (md + json sidecar)"
-    elif [[ -f "$md_file" ]]; then
-      echo "  ${task}: md done, json pending..."
-      all_done=false
-    else
-      echo "  ${task}: still running..."
-      all_done=false
-    fi
+    audit_jsonl_paths+=("${AUDIT_SESSION_FILES["$task"]}")
   done
-  if $all_done; then
+  if python3 "${SCRIPT_DIR}/check-session.py" --jsonl "${audit_jsonl_paths[@]}" 2>&1; then
     echo "=== All audits finished ==="
     break
   fi
   sleep 30
 done
 
-if ! $all_done; then
+if ! python3 "${SCRIPT_DIR}/check-session.py" --jsonl "${audit_jsonl_paths[@]}" 2>&1; then
   echo "WARNING: Timed out waiting for audits. Check iTerm2 tabs for status." >&2
 fi
 


### PR DESCRIPTION
Fixes two issues in the benchmark evaluation scripts:

1. **Session filename collisions**: When multiple tasks run simultaneously, they used the same timestamp-based session filename (`session-${TS}.jsonl`). Since `TS` only has second-level granularity, concurrent tasks collide. Now the task slug is appended to ensure uniqueness.

2. **Fragile audit completion detection**: `run-evaluation.sh` polled for audit completion by checking if `.md` and `.json` files exist. This is fragile — files may be partially written. Task sessions already use `check-session.py` which inspects the session JSONL for terminal events (`agent_end`/`agent_terminated`). Audit sessions now use the same mechanism.

### Changes

- `benchmark/manual/new-session.sh`: append task slug to session filenames
- `benchmark/audit-session/audit-session.sh`: add `-s/--session` flag forwarded to kimchi harness
- `benchmark/manual/check-session.py`: add `--jsonl` mode for inspecting individual JSONL files
- `benchmark/manual/run-evaluation.sh`: pass known audit session paths and poll with `check-session.py --jsonl`
