### PR TITLE
fix(mcp): fix tool name mismatch in search/describe injection

### DIFF
--- a/src/extensions/mcp-adapter/index.test.ts
+++ b/src/extensions/mcp-adapter/index.test.ts
@@ -1,6 +1,9 @@
 import type { ExtensionAPI, ToolInfo } from "@earendil-works/pi-coding-agent"
 import { afterEach, describe, expect, it, vi } from "vitest"
 import { type EnvironmentInfo, buildSystemPrompt } from "../prompt-construction/system-prompt.js"
+import { executeDescribe, executeSearch } from "./proxy-modes.js"
+import type { McpExtensionState } from "./state.js"
+import type { DirectToolSpec, ToolMetadata } from "./types.js"
 import mcpAdapter from "./index.js"
 
 const testEnv: EnvironmentInfo = {
@@ -50,6 +53,47 @@ afterEach(() => {
 	vi.unstubAllEnvs()
 })
 
+// ---------------------------------------------------------------------------
+// Helpers for inject-path tests
+// ---------------------------------------------------------------------------
+
+function makeMetadata(
+	rawName: string,
+	serverName: string,
+	prefix: "server" | "none" | "short",
+): ToolMetadata {
+	// Mirrors what buildToolMetadata in tool-metadata.ts produces
+	const p =
+		prefix === "none"
+			? ""
+			: prefix === "short"
+				? serverName.replace(/-?mcp$/i, "").replace(/-/g, "_") || "mcp"
+				: serverName.replace(/-/g, "_")
+	const prefixedName = p ? `${p}_${rawName}` : rawName
+	return {
+		name: prefixedName,
+		originalName: rawName,
+		description: "test tool",
+		inputSchema: { type: "object", properties: { prompt: { type: "string" } }, required: ["prompt"] },
+	}
+}
+
+function makeState(meta: ToolMetadata, serverName: string): McpExtensionState {
+	return {
+		manager: {} as McpExtensionState["manager"],
+		lifecycle: {} as McpExtensionState["lifecycle"],
+		toolMetadata: new Map([[serverName, [meta]]]),
+		config: { mcpServers: { [serverName]: {} as McpExtensionState["config"]["mcpServers"][string] } },
+		failureTracker: new Map(),
+		uiResourceHandler: {} as McpExtensionState["uiResourceHandler"],
+		consentManager: {} as McpExtensionState["consentManager"],
+		uiServer: null,
+		completedUiSessions: [],
+		openBrowser: async () => {},
+		dynamicToolNames: new Set(),
+	} as unknown as McpExtensionState
+}
+
 describe("mcp adapter system prompt block", () => {
 	it("registers tool and MCP discovery instructions with the extension that owns mcp", async () => {
 		vi.stubEnv("MCP_DIRECT_TOOLS", "__none__")
@@ -71,5 +115,105 @@ describe("mcp adapter system prompt block", () => {
 		} finally {
 			await pi.fireShutdown()
 		}
+	})
+})
+
+// ---------------------------------------------------------------------------
+// inject-path: spec correctness for executeSearch / executeDescribe
+// ---------------------------------------------------------------------------
+
+describe.each(["none", "server", "short"] as const)("inject-path (toolPrefix=%s)", (prefix) => {
+	const SERVER = "pal"
+	const RAW_NAME = "pal_chat"
+
+	it("executeSearch: spec.originalName is raw, spec.prefixedName matches metadata.name", () => {
+		const meta = makeMetadata(RAW_NAME, SERVER, prefix)
+		const state = makeState(meta, SERVER)
+		const capturedSpecs: DirectToolSpec[] = []
+
+		executeSearch(
+			state,
+			"chat",
+			undefined,
+			undefined,
+			undefined,
+			undefined,
+			5,
+			undefined,
+			(specs) => {
+				capturedSpecs.push(...specs)
+				return specs.map((s) => s.prefixedName)
+			},
+		)
+
+		expect(capturedSpecs).toHaveLength(1)
+		expect(capturedSpecs[0].originalName).toBe(RAW_NAME)
+		expect(capturedSpecs[0].prefixedName).toBe(meta.name)
+	})
+
+	it("executeSearch: display name and injected name are the same string", () => {
+		const meta = makeMetadata(RAW_NAME, SERVER, prefix)
+		const state = makeState(meta, SERVER)
+		let injectedNames: string[] = []
+
+		const result = executeSearch(
+			state,
+			"chat",
+			undefined,
+			undefined,
+			undefined,
+			undefined,
+			5,
+			undefined,
+			(specs) => {
+				injectedNames = specs.map((s) => s.prefixedName)
+				return injectedNames
+			},
+		)
+
+		const block = result.content[0]
+		const text = block.type === "text" ? block.text : ""
+		expect(injectedNames).toHaveLength(1)
+		// The displayed name (metadata.name) appears in the output body
+		expect(text).toContain(meta.name)
+		// The injected name footer references the exact same name
+		expect(text).toContain(injectedNames[0])
+		expect(injectedNames[0]).toBe(meta.name)
+	})
+
+	it("executeDescribe: spec.originalName is raw, spec.prefixedName matches metadata.name", () => {
+		const meta = makeMetadata(RAW_NAME, SERVER, prefix)
+		const state = makeState(meta, SERVER)
+		const capturedSpecs: DirectToolSpec[] = []
+
+		// describe accepts either the prefixed or raw name via findToolByName
+		executeDescribe(state, meta.name, (specs) => {
+			capturedSpecs.push(...specs)
+			return specs.map((s) => s.prefixedName)
+		})
+
+		expect(capturedSpecs).toHaveLength(1)
+		expect(capturedSpecs[0].originalName).toBe(RAW_NAME)
+		expect(capturedSpecs[0].prefixedName).toBe(meta.name)
+	})
+
+	it("executeDescribe: display name and injected name are the same string", () => {
+		const meta = makeMetadata(RAW_NAME, SERVER, prefix)
+		const state = makeState(meta, SERVER)
+		let injectedNames: string[] = []
+
+		const result = executeDescribe(state, meta.name, (specs) => {
+			injectedNames = specs.map((s) => s.prefixedName)
+			return injectedNames
+		})
+
+		const block = result.content[0]
+		const text = block.type === "text" ? block.text : ""
+		expect(injectedNames).toHaveLength(1)
+		// Header shows metadata.name
+		expect(text).toContain(meta.name)
+		// Footer references the same name
+		expect(text).toContain(injectedNames[0])
+		expect(injectedNames[0]).toBe(meta.name)
 	})
 })

--- a/src/extensions/mcp-adapter/index.ts
+++ b/src/extensions/mcp-adapter/index.ts
@@ -2,7 +2,6 @@ import type { ExtensionAPI, ExtensionContext, ToolInfo, ToolRenderResultOptions 
 import { Theme, keyHint } from "@earendil-works/pi-coding-agent"
 import { Type } from "typebox"
 import type { DirectToolSpec, ToolMetadata } from "./types.js"
-import { formatToolName } from "./types.js"
 import { type Component, Text } from "@earendil-works/pi-tui"
 import { registerToolCall, isToolExpanded } from "../../expand-state.js"
 import { createSystemPromptBlocks } from "../prompt-construction/index.js"
@@ -464,7 +463,7 @@ export default function mcpAdapter(pi: ExtensionAPI) {
 				}
 				if (params.describe) {
 					return executeDescribe(state, params.describe, (specs) =>
-						registerAndActivate(specs.map((s) => ({ ...s, prefixedName: formatToolName(s.originalName, s.serverName, prefix) })), undefined, ctx)
+						registerAndActivate(specs, undefined, ctx)
 					)
 				}
 				if (params.search) {
@@ -476,7 +475,7 @@ export default function mcpAdapter(pi: ExtensionAPI) {
 					// no API key configured; default is fine
 				}
 				return executeSearch(state, params.search, params.regex, params.server, params.includeSchemas, getPiTools, params.limit ?? mcpSearchLimit, state.searchStrategy, (specs) =>
-					registerAndActivate(specs.map((s) => ({ ...s, prefixedName: formatToolName(s.originalName, s.serverName, prefix) })), undefined, ctx)
+					registerAndActivate(specs, undefined, ctx)
 				)
 				}
 				return {

--- a/src/extensions/mcp-adapter/proxy-modes.ts
+++ b/src/extensions/mcp-adapter/proxy-modes.ts
@@ -289,8 +289,8 @@ export function executeDescribe(
 		injectedNames = onInject([
 			{
 				serverName,
-				originalName: toolMeta.name,
-				prefixedName: toolName,
+				originalName: toolMeta.originalName,
+				prefixedName: toolMeta.name,
 				description: toolMeta.description ?? "",
 				inputSchema: toolMeta.inputSchema,
 				uiResourceUri: toolMeta.uiResourceUri,
@@ -315,7 +315,8 @@ export function executeDescribe(
 	}
 
 	if (injectedNames.length > 0) {
-		text += `\n\nInjected into context. Call it using the exact name shown above (do NOT add any prefix): ${injectedNames[0]}`
+		text += `\n\nInjected into context. Call using the exact name shown above: ${injectedNames[0]}`
+		text += `\n(Available from the next turn. To call now: mcp({ tool: "${toolMeta.originalName}", args: "..." }).)`
 	}
 
 	return {
@@ -439,7 +440,7 @@ export function executeSearch(
 			.filter((m) => !m.tool.resourceUri)
 			.map((m) => ({
 				serverName: m.server,
-				originalName: m.tool.name,
+				originalName: m.tool.originalName,
 				prefixedName: m.tool.name,
 				description: m.tool.description ?? "",
 				inputSchema: m.tool.inputSchema,
@@ -488,7 +489,8 @@ export function executeSearch(
 	}
 
 	if (injectedNames.length > 0) {
-		text += `\nInjected into context. Call using the exact names shown above (do NOT add any prefix): ${injectedNames.join(", ")}`
+		text += `\nInjected into context. Call using the exact name${injectedNames.length > 1 ? "s" : ""} shown above: ${injectedNames.join(", ")}`
+		text += `\n(Available from the next turn. To call now: mcp({ tool: "<name>", args: "..." }).)`
 	}
 
 	return {


### PR DESCRIPTION
## Problem

When the model discovers MCP tools via `mcp({ search: "..." })` or `mcp({ describe: "..." })`, the displayed tool name and the injected tool name were inconsistent. The model failed 2+ times before falling back to the proxy path.

**Observed sequence (before fix):**
1. `mcp({ search: "chat", server: "pal" })` → shows `pal_chat` in result text
2. Footer says: *"Call using the exact names shown above: `pal_pal_chat`"* ← contradiction
3. Model tries `pal_pal_chat` → Tool not found
4. Model tries `pal_chat` → Tool not found
5. Model tries `mcp({ tool: "pal_chat" })` → success (3 wasted turns)

## Root Causes

**1. Double-prefixing:** `executeSearch`/`executeDescribe` set `originalName: m.tool.name` (already prefixed metadata name). The `index.ts` callback then re-applied `formatToolName(s.originalName, s.serverName, prefix)` on top, producing double-prefixed names like `pal_pal_chat`.

**2. Wrong `originalName` for MCP server calls:** `createDirectToolExecutor` calls the MCP server using `spec.originalName`. With the old code, it would send the prefixed name to the server, which the server doesn't recognise.

**3. Misleading injection message:** The footer claimed the tool was callable immediately when injected tools are only available from the next turn (tool registry is rebuilt on new user input).

## Fix

- **`proxy-modes.ts`:** Use `m.tool.originalName` (raw MCP name) for `originalName` and `m.tool.name` (already-prefixed metadata name) for `prefixedName` in both `executeSearch` and `executeDescribe`. Display and injection name are now the same string.
- **`index.ts`:** Remove the `formatToolName` re-mapping in both `onInject` callbacks. Drop the now-unused import.
- **Messages:** Update footer to reflect correct name and clarify same-turn limitation with a proxy fallback hint.

## Tests

Added 12 new tests covering the inject path for all three `toolPrefix` modes (`none` / `server` / `short`), asserting `originalName == rawMcpName` and `prefixedName == metadata.name` in both `executeSearch` and `executeDescribe`.