### PR TITLE
LLM-1468: highlight user messages with background color

### DIFF
--- a/src/extensions/tool-rendering.ts
+++ b/src/extensions/tool-rendering.ts
@@ -402,7 +402,20 @@ function patchUserMessageRender(): void {
 		const content = first.slice(osc.length)
 		const available = Math.max(0, width - prefixW)
 		const truncated = visibleWidth(content) > available ? truncateToWidth(content, available) : content
-		lines[0] = osc + prefix + truncated
+		const line0Content = prefix + truncated
+		// Pad to full width so background colour fills the whole line.
+		const pad = Math.max(0, width - prefixW - visibleWidth(truncated))
+		const paddedLine0 = typeof theme?.bg === "function"
+			? theme.bg("userMessageBg", line0Content + " ".repeat(pad))
+			: line0Content
+		lines[0] = osc + paddedLine0
+		// Apply background to continuation lines too.
+		for (let i = 1; i < lines.length; i++) {
+			if (typeof theme?.bg !== "function") break
+			const lw = visibleWidth(lines[i])
+			const lpad = Math.max(0, width - lw)
+			lines[i] = theme.bg("userMessageBg", lines[i] + " ".repeat(lpad))
+		}
 		return lines
 	}
 	proto[USER_MESSAGE_PATCH_FLAG] = true

--- a/src/extensions/tool-rendering.ts
+++ b/src/extensions/tool-rendering.ts
@@ -409,12 +409,14 @@ function patchUserMessageRender(): void {
 			? theme.bg("userMessageBg", line0Content + " ".repeat(pad))
 			: line0Content
 		lines[0] = osc + paddedLine0
-		// Apply background to continuation lines too.
+		// Indent continuation lines to align with text after ❯, apply background.
+		const indent = " ".repeat(prefixW)
 		for (let i = 1; i < lines.length; i++) {
-			if (typeof theme?.bg !== "function") break
-			const lw = visibleWidth(lines[i])
-			const lpad = Math.max(0, width - lw)
-			lines[i] = theme.bg("userMessageBg", lines[i] + " ".repeat(lpad))
+			const indented = indent + truncateToWidth(lines[i], width - prefixW)
+			const ipad = Math.max(0, width - visibleWidth(indented))
+			lines[i] = typeof theme?.bg === "function"
+				? theme.bg("userMessageBg", indented + " ".repeat(ipad))
+				: indented
 		}
 		return lines
 	}

--- a/src/extensions/tool-rendering.ts
+++ b/src/extensions/tool-rendering.ts
@@ -388,35 +388,25 @@ function patchUserMessageRender(): void {
 			box.paddingX = 0
 			box.invalidateCache?.()
 		}
-		const lines: string[] = originalRender.call(this, width)
-		if (!Array.isArray(lines) || lines.length === 0) return lines
-		// Prepend "❯ " in accent color to line 0 (after OSC133).
-		// Measure the prefix width and truncate content so the total never exceeds
-		// the terminal width — guards against ❯ being rendered as 2 cells wide.
 		const theme = _themePaletteCacheTheme as any
 		const glyph = typeof theme?.fg === "function" ? theme.fg("accent", "❯") : "❯"
 		const prefix = ` ${glyph} `
 		const prefixW = visibleWidth(prefix)
+		// Render content narrower so all lines fit when we prepend the indent.
+		const innerWidth = Math.max(1, width - prefixW)
+		const lines: string[] = originalRender.call(this, innerWidth)
+		if (!Array.isArray(lines) || lines.length === 0) return lines
 		const first = lines[0]
 		const osc = first.startsWith(OSC133_ZONE_START) ? OSC133_ZONE_START : ""
-		const content = first.slice(osc.length)
-		const available = Math.max(0, width - prefixW)
-		const truncated = visibleWidth(content) > available ? truncateToWidth(content, available) : content
-		const line0Content = prefix + truncated
-		// Pad to full width so background colour fills the whole line.
-		const pad = Math.max(0, width - prefixW - visibleWidth(truncated))
-		const paddedLine0 = typeof theme?.bg === "function"
-			? theme.bg("userMessageBg", line0Content + " ".repeat(pad))
-			: line0Content
-		lines[0] = osc + paddedLine0
-		// Indent continuation lines to align with text after ❯, apply background.
 		const indent = " ".repeat(prefixW)
-		for (let i = 1; i < lines.length; i++) {
-			const indented = indent + truncateToWidth(lines[i], width - prefixW)
-			const ipad = Math.max(0, width - visibleWidth(indented))
-			lines[i] = typeof theme?.bg === "function"
-				? theme.bg("userMessageBg", indented + " ".repeat(ipad))
-				: indented
+		const hasBg = typeof theme?.bg === "function"
+		for (let i = 0; i < lines.length; i++) {
+			const linePrefix = i === 0 ? prefix : indent
+			const rawLine = i === 0 ? lines[0].slice(osc.length) : lines[i]
+			const composed = linePrefix + rawLine
+			const pad = Math.max(0, width - visibleWidth(composed))
+			const styled = hasBg ? theme.bg("userMessageBg", composed + " ".repeat(pad)) : composed
+			lines[i] = (i === 0 ? osc : "") + styled
 		}
 		return lines
 	}


### PR DESCRIPTION

<img width="848" height="201" alt="image" src="https://github.com/user-attachments/assets/2b639cb2-2000-4379-a8fa-b13559e8cd79" />


## Summary

- Applies `userMessageBg` theme color as a full-width background band on user messages, making them easier to spot while scrolling
- Continuation lines in multiline messages are indented to align with the text after `❯`
- Renders content at `width - prefixW` so all lines wrap correctly without truncation ellipsis

## Test plan
- [ ] Single-line user message has background highlight
- [ ] Multiline user message has background on all lines, continuation lines aligned under `❯`
- [ ] No `...` appearing at line ends
- [ ] Background respects theme (`kimchi-minimal` has no background — verify no visual regression)