### PR TITLE
feat: add /rewind slash command

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -42,6 +42,7 @@ import { writeKimchiKeybindingDefaults } from "./extensions/permissions/keybindi
 import promptEnrichmentExtension from "./extensions/prompt-construction/prompt-enrichment.js"
 import promptSummaryExtension from "./extensions/prompt-summary.js"
 import questionnaireExtension from "./extensions/questionnaire.js"
+import rewindExtension from "./extensions/rewind/index.js"
 import shutdownMarkerExtension from "./extensions/shutdown-marker.js"
 import startupUpdateExtension from "./extensions/startup-update.js"
 import statsExtension from "./extensions/stats/index.js"
@@ -508,6 +509,7 @@ try {
 			stripImagesExtension,
 			traceIdExtension,
 			activityExtension,
+			rewindExtension,
 		]
 
 		if (acpMode) {

--- a/src/extensions/rewind/index.test.ts
+++ b/src/extensions/rewind/index.test.ts
@@ -143,7 +143,7 @@ describe("offset resolution: /rewind -1 on session with 3 messages", () => {
 		let capturedTarget: string | undefined
 		;(ctx.sessionManager as ReturnType<typeof makeMockSessionManager>).getBranch = vi.fn((targetId: string) => {
 			capturedTarget = targetId
-			const entries = (ctx.sessionManager as any).getEntries()
+			const entries = (ctx.sessionManager as ReturnType<typeof makeMockSessionManager>).getEntries()
 			const branch: SessionEntry[] = []
 			let currentId: string | null = targetId
 			while (currentId) {

--- a/src/extensions/rewind/index.test.ts
+++ b/src/extensions/rewind/index.test.ts
@@ -1,0 +1,399 @@
+import type {
+	ExtensionAPI,
+	ExtensionCommandContext,
+	ExtensionUIContext,
+	SessionEntry,
+} from "@earendil-works/pi-coding-agent"
+import { beforeEach, describe, expect, it, vi } from "vitest"
+import type { MockInstance } from "vitest"
+
+// vi.mock is hoisted — factory must be self-contained (no refs to vars below).
+vi.mock("node:fs", () => ({
+	writeFileSync: vi.fn(),
+	renameSync: vi.fn(),
+}))
+
+// Import mocked references so we can control them per-test.
+import { renameSync, writeFileSync } from "node:fs"
+
+const mockWriteFileSync = writeFileSync as unknown as MockInstance
+const mockRenameSync = renameSync as unknown as MockInstance
+
+// Import extension AFTER vi.mock so it sees the mocked fs module.
+import rewindExtension from "./index.js"
+
+// ─── Mock factories ───────────────────────────────────────────────────────────
+
+function makeMessageEntry(id: string, parentId: string | null, role: string, text: string) {
+	return {
+		type: "message",
+		id,
+		parentId,
+		timestamp: new Date().toISOString(),
+		message: {
+			role: role as "user" | "assistant" | "developer" | "system" | "tool",
+			content: [{ type: "text", text }],
+		},
+	}
+}
+
+function makeHeaderEntry() {
+	return {
+		type: "session",
+		id: "session-header",
+		parentId: null,
+		timestamp: new Date().toISOString(),
+	}
+}
+
+type AnyEntry = { id: string; parentId: string | null; [key: string]: unknown }
+
+function makeMockSessionManager(entries: AnyEntry[], leafId: string, sessionFile: string) {
+	return {
+		getEntries: vi.fn(() => entries),
+		getLeafId: vi.fn(() => leafId),
+		getSessionFile: vi.fn(() => sessionFile),
+		getEntry: vi.fn((id: string) => entries.find((e) => e.id === id)),
+		getHeader: vi.fn(() => entries.find((e) => e.type === "session") ?? null),
+		getBranch: vi.fn((targetId: string) => {
+			const branch: AnyEntry[] = []
+			let currentId: string | null = targetId
+			while (currentId) {
+				const entry = entries.find((e) => e.id === currentId)
+				if (!entry) break
+				branch.unshift(entry)
+				currentId = entry.parentId
+			}
+			return branch
+		}),
+	} as unknown as ExtensionCommandContext["sessionManager"]
+}
+
+function makeMockCtx(overrides: Partial<ExtensionCommandContext> = {}): ExtensionCommandContext {
+	const entries = [
+		makeHeaderEntry(),
+		makeMessageEntry("msg-1", "session-header", "user", "Hello"),
+		makeMessageEntry("msg-2", "msg-1", "assistant", "Hi there!"),
+		makeMessageEntry("msg-3", "msg-2", "user", "How are you?"),
+	]
+	const sm = makeMockSessionManager(entries, "msg-3", "/tmp/test-session.jsonl")
+
+	const ui = {
+		select: vi.fn<() => Promise<string | undefined>>(),
+		notify: vi.fn<(_msg: string, _type?: string) => void>(),
+		theme: { fg: (_color: string, text: string) => text } as unknown as ExtensionUIContext["theme"],
+		setStatus: vi.fn(),
+		hasUI: true,
+	}
+
+	return {
+		sessionManager: sm,
+		ui,
+		hasUI: true,
+		switchSession: vi.fn<() => Promise<{ cancelled: boolean }>>(),
+		...overrides,
+	} as unknown as ExtensionCommandContext
+}
+
+function makePi(): ExtensionAPI {
+	return {
+		registerCommand: vi.fn(),
+		registerTool: vi.fn(),
+		on: vi.fn(),
+	} as unknown as ExtensionAPI
+}
+
+function getHandler(pi: ExtensionAPI) {
+	const calls = (
+		pi.registerCommand as unknown as {
+			mock: { calls: Array<[string, { handler: (args: string, ctx: ExtensionCommandContext) => Promise<void> }]> }
+		}
+	).mock.calls
+	const rewindCall = calls.find(([name]) => name === "rewind")
+	if (!rewindCall) throw new Error("rewind command not registered")
+	return rewindCall[1].handler
+}
+
+// ─── Tests ────────────────────────────────────────────────────────────────────
+
+describe("rewindExtension", () => {
+	it("registers the /rewind command", () => {
+		const pi = makePi()
+		rewindExtension(pi)
+		expect(pi.registerCommand).toHaveBeenCalledOnce()
+		expect(pi.registerCommand).toHaveBeenCalledWith(
+			"rewind",
+			expect.objectContaining({
+				description: "Rewind conversation to a previous point",
+				handler: expect.any(Function),
+			}),
+		)
+	})
+})
+
+describe("offset resolution: /rewind -1 on session with 3 messages", () => {
+	beforeEach(() => {
+		mockWriteFileSync.mockReset()
+		mockRenameSync.mockReset()
+	})
+
+	it("target is the parentId of the last message (rewind BEFORE last user message)", async () => {
+		const pi = makePi()
+		const ctx = makeMockCtx()
+		let capturedTarget: string | undefined
+		;(ctx.sessionManager as ReturnType<typeof makeMockSessionManager>).getBranch = vi.fn((targetId: string) => {
+			capturedTarget = targetId
+			const entries = (ctx.sessionManager as any).getEntries()
+			const branch: SessionEntry[] = []
+			let currentId: string | null = targetId
+			while (currentId) {
+				const entry = entries.find((e: SessionEntry) => e.id === currentId)
+				if (!entry) break
+				branch.unshift(entry)
+				currentId = entry.parentId
+			}
+			return branch
+		})
+		ctx.switchSession = vi.fn(async () => ({ cancelled: false }))
+
+		rewindExtension(pi)
+		const handler = getHandler(pi)
+		await handler("-1", ctx)
+
+		// -1 on session: last is msg-3 (user), its parentId is msg-2
+		expect(capturedTarget).toBe("msg-2")
+	})
+})
+
+describe("offset resolution: /rewind -5 on session with 2 messages", () => {
+	it("notifies warning and returns gracefully", async () => {
+		const entries = [
+			makeHeaderEntry(),
+			makeMessageEntry("msg-a", "session-header", "user", "Hello"),
+			makeMessageEntry("msg-b", "msg-a", "assistant", "Hi"),
+		]
+		const sm = makeMockSessionManager(entries, "msg-b", "/tmp/test.jsonl")
+		const ctx = makeMockCtx({ sessionManager: sm })
+
+		const pi = makePi()
+		rewindExtension(pi)
+		const handler = getHandler(pi)
+
+		await handler("-5", ctx)
+
+		expect(ctx.ui.notify).toHaveBeenCalledWith(expect.stringContaining("Cannot rewind 5 messages"), "warning")
+	})
+})
+
+describe("offset resolution: /rewind with invalid offset", () => {
+	it("notifies usage error for positive integer", async () => {
+		const ctx = makeMockCtx()
+		const pi = makePi()
+		rewindExtension(pi)
+		const handler = getHandler(pi)
+
+		await handler("3", ctx)
+
+		expect(ctx.ui.notify).toHaveBeenCalledWith("Usage: /rewind or /rewind -N", "warning")
+	})
+
+	it("notifies usage error for non-numeric args", async () => {
+		const ctx = makeMockCtx()
+		const pi = makePi()
+		rewindExtension(pi)
+		const handler = getHandler(pi)
+
+		await handler("foo", ctx)
+
+		expect(ctx.ui.notify).toHaveBeenCalledWith("Usage: /rewind or /rewind -N", "warning")
+	})
+})
+
+describe("picker: /rewind with no args", () => {
+	beforeEach(() => {
+		mockWriteFileSync.mockReset()
+		mockRenameSync.mockReset()
+	})
+
+	it("calls ui.select with formatted message choices", async () => {
+		const ctx = makeMockCtx()
+		ctx.ui.select = vi.fn(async () => undefined)
+
+		const pi = makePi()
+		rewindExtension(pi)
+		const handler = getHandler(pi)
+
+		await handler("", ctx)
+
+		expect(ctx.ui.select).toHaveBeenCalledWith(
+			"Rewind to before which message?",
+			expect.arrayContaining([expect.stringContaining("Hello"), expect.stringContaining("How are you?")]),
+		)
+	})
+
+	it("picker cancelled → switchSession not called, no notify", async () => {
+		const ctx = makeMockCtx()
+		ctx.ui.select = vi.fn(async () => undefined)
+		ctx.switchSession = vi.fn(async () => ({ cancelled: false }))
+
+		const pi = makePi()
+		rewindExtension(pi)
+		const handler = getHandler(pi)
+
+		await handler("", ctx)
+
+		expect(ctx.switchSession).not.toHaveBeenCalled()
+		expect(ctx.ui.notify).not.toHaveBeenCalled()
+	})
+
+	it("picker resolved → switchSession called with original file path", async () => {
+		const ctx = makeMockCtx()
+		ctx.ui.select = vi.fn(async () => "2. How are you?")
+		ctx.switchSession = vi.fn(async () => ({ cancelled: false }))
+
+		const pi = makePi()
+		rewindExtension(pi)
+		const handler = getHandler(pi)
+
+		await handler("", ctx)
+
+		// msg-3's parentId is msg-2 → rewind target = msg-2
+		expect(ctx.ui.select).toHaveBeenCalled()
+		expect(ctx.switchSession).toHaveBeenCalledWith("/tmp/test-session.jsonl")
+	})
+})
+
+describe("performRewind file rewrite", () => {
+	beforeEach(() => {
+		mockWriteFileSync.mockReset()
+		mockRenameSync.mockReset()
+	})
+
+	it("writes temp file then renames with correct content", async () => {
+		const ctx = makeMockCtx()
+		let writtenContent: string | undefined
+
+		mockWriteFileSync.mockImplementation((path: string, content: string) => {
+			if (typeof path === "string" && path.endsWith(".rewind.tmp")) {
+				writtenContent = content
+			}
+		})
+		ctx.switchSession = vi.fn(async () => ({ cancelled: false }))
+
+		const pi = makePi()
+		rewindExtension(pi)
+		const handler = getHandler(pi)
+
+		await handler("-1", ctx)
+
+		expect(mockWriteFileSync).toHaveBeenCalledWith("/tmp/test-session.jsonl.rewind.tmp", expect.any(String))
+		expect(mockRenameSync).toHaveBeenCalledWith("/tmp/test-session.jsonl.rewind.tmp", "/tmp/test-session.jsonl")
+
+		// Verify content is valid JSON lines (header + branch entries)
+		expect(writtenContent).toBeDefined()
+		const lines = writtenContent?.split("\n").filter((l) => l.trim()) ?? []
+		expect(lines.length).toBeGreaterThan(1)
+		for (const line of lines) {
+			expect(() => JSON.parse(line)).not.toThrow()
+		}
+	})
+})
+
+describe("performRewind switchSession", () => {
+	beforeEach(() => {
+		mockWriteFileSync.mockReset()
+		mockRenameSync.mockReset()
+	})
+
+	it("switchSession called with original file path", async () => {
+		const ctx = makeMockCtx()
+		ctx.switchSession = vi.fn(async () => ({ cancelled: false }))
+
+		const pi = makePi()
+		rewindExtension(pi)
+		const handler = getHandler(pi)
+
+		await handler("-1", ctx)
+
+		expect(ctx.switchSession).toHaveBeenCalledWith("/tmp/test-session.jsonl")
+	})
+
+	it("switchSession cancelled → warning notify", async () => {
+		const ctx = makeMockCtx()
+		ctx.switchSession = vi.fn(async () => ({ cancelled: true }))
+
+		const pi = makePi()
+		rewindExtension(pi)
+		const handler = getHandler(pi)
+
+		await handler("-1", ctx)
+
+		expect(ctx.ui.notify).toHaveBeenCalledWith("Rewind was cancelled.", "warning")
+	})
+})
+
+describe("no user messages", () => {
+	it("warning notify when session has only assistant messages", async () => {
+		const entries = [
+			makeHeaderEntry(),
+			makeMessageEntry("a-1", "session-header", "assistant", "Hello!"),
+			makeMessageEntry("a-2", "a-1", "assistant", "How can I help?"),
+		]
+		const sm = makeMockSessionManager(entries, "a-2", "/tmp/test.jsonl")
+		const ctx = makeMockCtx({ sessionManager: sm })
+
+		const pi = makePi()
+		rewindExtension(pi)
+		const handler = getHandler(pi)
+
+		await handler("", ctx)
+
+		expect(ctx.ui.notify).toHaveBeenCalledWith("No messages to rewind.", "warning")
+	})
+})
+
+describe("negative offset with multiple user messages", () => {
+	beforeEach(() => {
+		mockWriteFileSync.mockReset()
+		mockRenameSync.mockReset()
+	})
+
+	it("/rewind -2 when 2 user messages → target is the assistant before second user", async () => {
+		// Session: header → u1 (user) → a1 (assistant) → u2 (user) → a2 (assistant)
+		const entries = [
+			makeHeaderEntry(),
+			makeMessageEntry("u1", "session-header", "user", "First"),
+			makeMessageEntry("a1", "u1", "assistant", "Response 1"),
+			makeMessageEntry("u2", "a1", "user", "Second"),
+			makeMessageEntry("a2", "u2", "assistant", "Response 2"),
+		]
+		const sm = makeMockSessionManager(entries, "a2", "/tmp/test.jsonl")
+		let targetSeen: string | undefined
+		;(sm as ReturnType<typeof makeMockSessionManager>).getBranch = vi.fn((targetId: string) => {
+			targetSeen = targetId
+			const branch: AnyEntry[] = []
+			let currentId: string | null = targetId
+			while (currentId) {
+				const entry = entries.find((e) => e.id === currentId)
+				if (!entry) break
+				branch.unshift(entry)
+				currentId = entry.parentId
+			}
+			return branch as unknown as SessionEntry[]
+		})
+
+		const ctx = makeMockCtx({ sessionManager: sm })
+		ctx.switchSession = vi.fn(async () => ({ cancelled: false }))
+
+		const pi = makePi()
+		rewindExtension(pi)
+		const handler = getHandler(pi)
+
+		await handler("-2", ctx)
+
+		// -2 means rewind 2 message-type entries back from leaf (a2).
+		// Walk counting only user/developer messages: a2(skip)→u2(1)→a1(skip)→u1(2, stop).
+		// currentId = u1, return u1.parentId = session-header
+		expect(targetSeen).toBe("session-header")
+	})
+})

--- a/src/extensions/rewind/index.ts
+++ b/src/extensions/rewind/index.ts
@@ -1,0 +1,164 @@
+import { renameSync, writeFileSync } from "node:fs"
+import type { ExtensionAPI, ExtensionCommandContext, SessionEntry } from "@earendil-works/pi-coding-agent"
+
+export default function rewindExtension(pi: ExtensionAPI): void {
+	pi.registerCommand("rewind", {
+		description: "Rewind conversation to a previous point",
+		handler: async (args: string, ctx: ExtensionCommandContext) => {
+			const targetId = await resolveRewindTarget(args, ctx)
+			if (!targetId) return
+			await performRewind(targetId, ctx)
+		},
+	})
+}
+
+// ─── Target resolution ────────────────────────────────────────────────────────
+
+async function resolveRewindTarget(args: string, ctx: ExtensionCommandContext): Promise<string | undefined> {
+	const trimmed = args.trim()
+
+	// Offset mode: /rewind -N
+	if (/^-\d+$/.test(trimmed)) {
+		return resolveByOffset(Number.parseInt(trimmed, 10), ctx)
+	}
+
+	// Empty → interactive picker
+	if (trimmed === "") {
+		return resolveByPicker(ctx)
+	}
+
+	// Invalid format
+	ctx.ui.notify("Usage: /rewind or /rewind -N", "warning")
+	return undefined
+}
+
+function resolveByOffset(offset: number, ctx: ExtensionCommandContext): string | undefined {
+	const sm = ctx.sessionManager
+	const leafId = sm.getLeafId()
+	if (!leafId) {
+		ctx.ui.notify("No active session.", "warning")
+		return undefined
+	}
+
+	// Walk backward counting "message" type entries
+	let currentId: string | null = leafId
+	let count = 0
+
+	while (currentId && count < Math.abs(offset)) {
+		const entry = sm.getEntry(currentId)
+		if (!entry) break
+		if (entry.type === "message") {
+			const role = (entry as { message?: { role?: string } }).message?.role
+			if (role === "user" || role === "developer") {
+				count++
+			}
+		}
+		if (count === Math.abs(offset)) break
+		currentId = entry.parentId
+	}
+
+	if (count < Math.abs(offset)) {
+		const available = count
+		ctx.ui.notify(`Cannot rewind ${Math.abs(offset)} messages: only ${available} available.`, "warning")
+		return undefined
+	}
+
+	// currentId is now the Nth message from the end; return its parentId (rewind BEFORE it)
+	if (!currentId) {
+		ctx.ui.notify("Could not resolve rewind target.", "error")
+		return undefined
+	}
+	const targetEntry = sm.getEntry(currentId)
+	if (!targetEntry) {
+		ctx.ui.notify("Could not resolve rewind target.", "error")
+		return undefined
+	}
+	return targetEntry.parentId ?? undefined
+}
+
+async function resolveByPicker(ctx: ExtensionCommandContext): Promise<string | undefined> {
+	const entries = ctx.sessionManager.getEntries()
+	const userMessages: SessionEntry[] = []
+
+	for (const entry of entries) {
+		if (entry.type !== "message") continue
+		const role = (entry as { message?: { role?: string } }).message?.role
+		if (role === "user" || role === "developer") {
+			userMessages.push(entry)
+		}
+	}
+
+	if (userMessages.length === 0) {
+		ctx.ui.notify("No messages to rewind.", "warning")
+		return undefined
+	}
+
+	// Format as "N. preview" — the index maps directly to userMessages array
+	const choiceLabels = userMessages.map((entry, index) => {
+		const text = extractPreview(entry)
+		return `${index + 1}. ${text}`
+	})
+
+	const selected = await ctx.ui.select("Rewind to before which message?", choiceLabels)
+	if (!selected) return undefined
+
+	// Parse the selected index and look up the corresponding entry
+	const match = selected.match(/^(\d+)\./)
+	if (!match) return undefined
+	const chosenIndex = Number.parseInt(match[1], 10) - 1
+	const chosen = userMessages[chosenIndex]
+	if (!chosen) return undefined
+	return chosen.parentId ?? undefined
+}
+
+// ─── File rewrite ─────────────────────────────────────────────────────────────
+
+async function performRewind(targetId: string, ctx: ExtensionCommandContext): Promise<void> {
+	const sm = ctx.sessionManager
+	const originalFile = sm.getSessionFile()
+	if (!originalFile) {
+		ctx.ui.notify("Session file not found.", "error")
+		return
+	}
+
+	const branchPath = sm.getBranch(targetId)
+	if (branchPath.length === 0) {
+		ctx.ui.notify("Could not resolve branch for rewind target.", "error")
+		return
+	}
+
+	const header = sm.getHeader()
+	if (!header) {
+		ctx.ui.notify("Session header not found.", "error")
+		return
+	}
+
+	const content = `${[header, ...branchPath].map((e) => JSON.stringify(e)).join("\n")}\n`
+	const tempFile = `${originalFile}.rewind.tmp`
+
+	try {
+		writeFileSync(tempFile, content)
+		renameSync(tempFile, originalFile)
+	} catch (err) {
+		ctx.ui.notify(`Failed to rewind: ${err instanceof Error ? err.message : String(err)}`, "error")
+		return
+	}
+
+	const result = await ctx.switchSession(originalFile)
+	if (result.cancelled) {
+		ctx.ui.notify("Rewind was cancelled.", "warning")
+	}
+}
+
+// ─── Helpers ──────────────────────────────────────────────────────────────────
+
+function extractPreview(entry: SessionEntry): string {
+	if (entry.type !== "message") return "(non-message)"
+	const text =
+		(entry as { message?: { content?: Array<{ type: string; text?: string }> } }).message?.content
+			?.filter((c) => c.type === "text")
+			.map((c) => c.text ?? "")
+			.join(" ") ?? ""
+	const trimmed = text.trim().replace(/\s+/g, " ")
+	return trimmed.length > 60 ? `${trimmed.slice(0, 60)}…` : trimmed || "(empty message)"
+}


### PR DESCRIPTION
## Summary

Adds a `/rewind` slash command that destructively truncates the current session to any previous user message.

## Usage

- `/rewind` — opens an interactive picker showing all user messages
- `/rewind -N` — rewinds N user messages back (e.g. `/rewind -2`)

## How it works

1. Resolves the target entry (picker or offset)
2. Calls `sessionManager.getBranch(targetId)` to get the path from root to target
3. Atomically rewrites the session file: `writeFileSync(tmp)` → `renameSync(tmp, original)`
4. Calls `ctx.switchSession(originalFile)` — same teardown/apply/rebind cycle as `/fork`, but on the same (now-truncated) file, preserving session identity

## Notes

- Destructive: entries after the rewind point are permanently deleted
- Session identity is preserved (same file path, same session `id` in header)
- No upstream patches needed — implemented entirely as a kimchi-dev extension
- **Conversation only**: `/rewind` truncates the session history but does not undo file edits made during the rewound turns — those remain on disk