### PR TITLE
feat(tool-rendering): distinguish MCP tool invocations from discovery calls

### DIFF
--- a/src/extensions/tool-rendering.test.ts
+++ b/src/extensions/tool-rendering.test.ts
@@ -214,6 +214,14 @@ describe("isMcpToolName", () => {
 	it("returns false for empty string", () => {
 		expect(isMcpToolName("")).toBe(false)
 	})
+
+	it("returns false for mcp as substring without separator (mcptool)", () => {
+		expect(isMcpToolName("mcptool")).toBe(false)
+	})
+
+	it("returns true for MCP_ prefix (case-insensitive)", () => {
+		expect(isMcpToolName("MCP_tool")).toBe(true)
+	})
 })
 
 describe("summarizeMcpToolInvocationArgs", () => {
@@ -250,6 +258,10 @@ describe("summarizeMcpToolInvocationArgs", () => {
 
 	it("skips null and undefined values", () => {
 		expect(summarizeMcpToolInvocationArgs({ args: '{"a":null,"b":"hello"}' })).toBe("(b=hello)")
+	})
+
+	it("skips empty arrays", () => {
+		expect(summarizeMcpToolInvocationArgs({ args: '{"tags":[],"name":"foo"}' })).toBe("(name=foo)")
 	})
 
 	it("skips nested objects", () => {

--- a/src/extensions/tool-rendering.test.ts
+++ b/src/extensions/tool-rendering.test.ts
@@ -4,9 +4,12 @@ import { beforeAll, describe, expect, it } from "vitest"
 import {
 	formatToolTimer,
 	getToolElapsedMs,
+	isMcpToolName,
+	mcpCallLabelAndSummary,
 	patchToolRenderCacheInvalidation,
 	patchUserMessageRender,
 	splitLeadingOsc133Markers,
+	summarizeMcpToolInvocationArgs,
 	summarizeOpenAiToolCall,
 	toolHeader,
 } from "./tool-rendering.js"
@@ -178,5 +181,157 @@ describe("toolHeader", () => {
 		const headerWithout = toolHeader("Read", "src/foo.ts", plainTheme, "○ ")
 		expect(headerWithout).not.toContain("1.5s")
 		expect(headerWith).toContain("1.5s")
+	})
+})
+
+describe("isMcpToolName", () => {
+	it('returns true for bare "mcp"', () => {
+		expect(isMcpToolName("mcp")).toBe(true)
+	})
+
+	it("returns true for mcp_ prefixed names", () => {
+		expect(isMcpToolName("mcp_pal_chat")).toBe(true)
+	})
+
+	it("returns true for mcp- prefixed names", () => {
+		expect(isMcpToolName("mcp-search")).toBe(true)
+	})
+
+	it("returns true for mcp: prefixed names", () => {
+		expect(isMcpToolName("mcp:tool")).toBe(true)
+	})
+
+	it("returns true for names containing _mcp_", () => {
+		expect(isMcpToolName("foo_mcp_bar")).toBe(true)
+	})
+
+	it("returns false for non-mcp tool names", () => {
+		expect(isMcpToolName("read")).toBe(false)
+		expect(isMcpToolName("bash")).toBe(false)
+		expect(isMcpToolName("write")).toBe(false)
+	})
+
+	it("returns false for empty string", () => {
+		expect(isMcpToolName("")).toBe(false)
+	})
+})
+
+describe("summarizeMcpToolInvocationArgs", () => {
+	it("returns empty string when args field is missing", () => {
+		expect(summarizeMcpToolInvocationArgs({})).toBe("")
+	})
+
+	it("returns empty string when args field is not valid JSON", () => {
+		expect(summarizeMcpToolInvocationArgs({ args: "not json" })).toBe("")
+	})
+
+	it("returns empty string when parsed args is an array", () => {
+		expect(summarizeMcpToolInvocationArgs({ args: '["a","b"]' })).toBe("")
+	})
+
+	it("formats simple key=value pairs", () => {
+		expect(summarizeMcpToolInvocationArgs({ args: '{"model":"gpt-4","temperature":0.7}' })).toBe(
+			"(model=gpt-4, temperature=0.7)",
+		)
+	})
+
+	it("truncates long values in collapsed mode", () => {
+		const longVal = "a".repeat(100)
+		const result = summarizeMcpToolInvocationArgs({ args: JSON.stringify({ prompt: longVal }) })
+		expect(result.length).toBeLessThan(longVal.length + 20)
+		expect(result.startsWith("(prompt=")).toBe(true)
+	})
+
+	it("shows full values in expanded mode", () => {
+		const longVal = "a".repeat(100)
+		const result = summarizeMcpToolInvocationArgs({ args: JSON.stringify({ prompt: longVal }) }, true)
+		expect(result).toBe(`(prompt=${longVal})`)
+	})
+
+	it("skips null and undefined values", () => {
+		expect(summarizeMcpToolInvocationArgs({ args: '{"a":null,"b":"hello"}' })).toBe("(b=hello)")
+	})
+
+	it("skips nested objects", () => {
+		expect(summarizeMcpToolInvocationArgs({ args: '{"a":{"nested":1},"b":"hi"}' })).toBe("(b=hi)")
+	})
+
+	it("formats arrays as first-elem +N in collapsed mode", () => {
+		expect(summarizeMcpToolInvocationArgs({ args: '{"tags":["foo","bar","baz"]}' })).toBe("(tags=foo +2)")
+	})
+
+	it("formats arrays as comma-joined in expanded mode", () => {
+		expect(summarizeMcpToolInvocationArgs({ args: '{"tags":["foo","bar","baz"]}' }, true)).toBe("(tags=foo, bar, baz)")
+	})
+
+	it("caps total suffix at 120 chars in collapsed mode", () => {
+		const manyKeys: Record<string, string> = {}
+		for (let i = 0; i < 20; i++) manyKeys[`key${i}`] = "val".repeat(5)
+		const result = summarizeMcpToolInvocationArgs({ args: JSON.stringify(manyKeys) })
+		const inner = result.slice(1, -1)
+		expect(inner.length).toBeLessThanOrEqual(120)
+	})
+})
+
+describe("mcpCallLabelAndSummary", () => {
+	it("returns humanized tool label for tool invocations", () => {
+		const result = mcpCallLabelAndSummary({ tool: "pal_chat" }, plainTheme)
+		expect(result.label).toBe("pal chat")
+	})
+
+	it("prefixes label with server name when server is present", () => {
+		const result = mcpCallLabelAndSummary({ tool: "pal_chat", server: "pal" }, plainTheme)
+		expect(result.label).toBe("pal - pal chat")
+	})
+
+	it("includes args summary in summary for tool invocations", () => {
+		const result = mcpCallLabelAndSummary({ tool: "pal_chat", args: '{"model":"gpt-4"}' }, plainTheme)
+		expect(result.summary).toBe("(model=gpt-4)")
+	})
+
+	it('returns "Tool search" label for search calls', () => {
+		const result = mcpCallLabelAndSummary({ search: "pal chat" }, plainTheme)
+		expect(result.label).toBe("Tool search")
+		expect(result.summary).toBe("(query=pal chat)")
+	})
+
+	it('returns "Tool search" label for server calls', () => {
+		const result = mcpCallLabelAndSummary({ server: "pal" }, plainTheme)
+		expect(result.label).toBe("Tool search")
+		expect(result.summary).toBe("(server=pal)")
+	})
+
+	it('returns "Tool describe" label for describe calls', () => {
+		const result = mcpCallLabelAndSummary({ describe: "pal_chat" }, plainTheme)
+		expect(result.label).toBe("Tool describe")
+		expect(result.summary).toBe("(tool=pal_chat)")
+	})
+
+	it('returns "Tool connect" label for connect calls', () => {
+		const result = mcpCallLabelAndSummary({ connect: "my-server" }, plainTheme)
+		expect(result.label).toBe("Tool connect")
+		expect(result.summary).toBe("(server=my-server)")
+	})
+
+	it('returns "Tool action" label for action calls', () => {
+		const result = mcpCallLabelAndSummary({ action: "restart" }, plainTheme)
+		expect(result.label).toBe("Tool action")
+		expect(result.summary).toBe("(action=restart)")
+	})
+
+	it('falls back to "MCP" label for empty args', () => {
+		const result = mcpCallLabelAndSummary({}, plainTheme)
+		expect(result.label).toBe("MCP")
+		expect(result.summary).toBe("(status)")
+	})
+
+	it("shows full arg values in expanded mode", () => {
+		const longVal = "x".repeat(100)
+		const result = mcpCallLabelAndSummary(
+			{ tool: "pal_chat", args: JSON.stringify({ prompt: longVal }) },
+			plainTheme,
+			true,
+		)
+		expect(result.summary).toContain(longVal)
 	})
 })

--- a/src/extensions/tool-rendering.ts
+++ b/src/extensions/tool-rendering.ts
@@ -2583,6 +2583,16 @@ function genericToolLabel(name: string): string {
 function renderGenericToolCall(name: string, args: any, theme: Theme, ctx: any): Text {
 	ctx.state._openAiPatchFiles = []
 	const sp = (path: string) => shortPath(ctx.cwd ?? process.cwd(), path)
+	if (isMcpToolName(name)) {
+		const packed = stableCallSummary(ctx, "_mcpLabelSummary", () => {
+			const ls = mcpCallLabelAndSummary(args, theme)
+			return `${ls.label}\x00${ls.summary}`
+		})
+		const sepIdx = packed.indexOf("\x00")
+		const mcpLabel = sepIdx >= 0 ? packed.slice(0, sepIdx) : "MCP"
+		const mcpSummary = sepIdx >= 0 ? packed.slice(sepIdx + 1) : ""
+		return makeText(ctx.lastComponent, toolHeader(mcpLabel, mcpSummary, theme, toolStatusDot(ctx, theme)))
+	}
 	const summary = stableCallSummary(ctx, "_callSummary", () => summarizeGenericToolCall(name, args, theme, sp))
 	return makeText(ctx.lastComponent, toolHeader(genericToolLabel(name), summary, theme, toolStatusDot(ctx, theme)))
 }
@@ -3096,14 +3106,84 @@ function renderApplyPatchResult(result: any, isPartial: boolean, theme: Theme, c
 	)
 }
 
+/**
+ * For an MCP gateway call whose args contain `tool`, parse the nested args
+ * JSON and return a short summary of notable parameters (prompt, model, …).
+ */
+function summarizeMcpToolInvocationArgs(args: any, theme: Theme): string {
+	const rawArgs = getStringArg(args, "args")
+	if (!rawArgs) return ""
+	try {
+		const parsed = JSON.parse(rawArgs)
+		if (parsed && typeof parsed === "object") {
+			// Show model if present
+			const model = typeof parsed.model === "string" ? parsed.model : ""
+			// Show a truncated prompt snippet
+			const prompt =
+				typeof parsed.prompt === "string"
+					? parsed.prompt
+					: typeof parsed.message === "string"
+						? parsed.message
+						: typeof parsed.query === "string"
+							? parsed.query
+							: ""
+			if (model && prompt) {
+				return `${theme.fg("muted", model)} ${summarizeText(prompt, 48)}`
+			}
+			if (model) return theme.fg("muted", model)
+			if (prompt) return summarizeText(prompt, 60)
+		}
+	} catch {
+		// not valid JSON — ignore
+	}
+	return ""
+}
+
 function summarizeMcpToolCall(args: any, theme: Theme): string {
 	const tool = getStringArg(args, "tool")
-	if (tool) return args?.server ? `${args.server}:${tool}` : tool
+	if (tool) {
+		const argsSummary = summarizeMcpToolInvocationArgs(args, theme)
+		return argsSummary ? argsSummary : theme.fg("muted", "")
+	}
 	const connect = getStringArg(args, "connect")
-	if (connect) return `connect ${connect}`
+	if (connect) return connect
 	const search = getStringArg(args, "search", "describe", "server", "action")
 	if (search) return summarizeText(search, 72)
 	return theme.fg("muted", "status")
+}
+
+/**
+ * Returns the display label and summary for an MCP gateway call.
+ * - Tool invocation (`args.tool` present): label = humanized tool name, summary = args preview
+ * - Discovery (`args.search` / `args.describe` / …): label = "Tool search" / "Tool describe" / …
+ * - Connect: label = "Tool connect"
+ */
+function mcpCallLabelAndSummary(
+	args: any,
+	theme: Theme,
+): { label: string; summary: string } {
+	const tool = getStringArg(args, "tool")
+	if (tool) {
+		const label = humanizeToolName(tool)
+		const summary = summarizeMcpToolInvocationArgs(args, theme)
+		return { label, summary }
+	}
+	if (getStringArg(args, "connect")) {
+		return { label: "Tool connect", summary: getStringArg(args, "connect") }
+	}
+	if (getStringArg(args, "describe")) {
+		return { label: "Tool describe", summary: summarizeText(getStringArg(args, "describe"), 72) }
+	}
+	if (getStringArg(args, "search")) {
+		return { label: "Tool search", summary: summarizeText(getStringArg(args, "search"), 72) }
+	}
+	if (getStringArg(args, "server")) {
+		return { label: "Tool search", summary: summarizeText(getStringArg(args, "server"), 72) }
+	}
+	if (getStringArg(args, "action")) {
+		return { label: "Tool action", summary: summarizeText(getStringArg(args, "action"), 72) }
+	}
+	return { label: "MCP", summary: theme.fg("muted", "status") }
 }
 
 function summarizeGenericToolCall(name: string, args: any, theme: Theme, sp: (path: string) => string): string {

--- a/src/extensions/tool-rendering.ts
+++ b/src/extensions/tool-rendering.ts
@@ -348,8 +348,11 @@ function formatWorkedDuration(ms: number): string {
 	return `${minutes}m ${seconds}s`
 }
 
+// One space of indent — aligns the ✻ glyph with the assistant message body.
+const WORKED_DURATION_INDENT = " "
+
 function inlineWorkedDurationText(ms: number): string {
-	return `${WORKED_LINE_FG}✻ Worked for ${formatWorkedDuration(ms)}${RESET}`
+	return `${WORKED_DURATION_INDENT}${WORKED_LINE_FG}✻ Worked for ${formatWorkedDuration(ms)}${RESET}`
 }
 
 function patchAssistantMessageRender(): void {
@@ -367,12 +370,13 @@ function patchAssistantMessageRender(): void {
 		// (B = command end, C = command output). Strip them off, push the widget
 		// line, then reattach so the zone still brackets the full message.
 		const lastIdx = lines.length - 1
+		const widgetLine = inlineWorkedDurationText(durationMs)
 		if (lines[lastIdx].includes(OSC133_ZONE_END)) {
 			lines[lastIdx] = lines[lastIdx].replace(OSC133_ZONE_SUFFIX, "")
-			lines.push(inlineWorkedDurationText(durationMs))
+			lines.push("", widgetLine)
 			lines[lines.length - 1] += OSC133_ZONE_SUFFIX
 		} else {
-			lines.push(inlineWorkedDurationText(durationMs))
+			lines.push("", widgetLine)
 		}
 		return lines
 	}

--- a/src/extensions/tool-rendering.ts
+++ b/src/extensions/tool-rendering.ts
@@ -10,6 +10,7 @@ import type {
 	Theme,
 } from "@earendil-works/pi-coding-agent"
 import {
+	AssistantMessageComponent,
 	ToolExecutionComponent,
 	UserMessageComponent,
 	createBashTool,
@@ -310,7 +311,12 @@ function unrefTimer(timer: ReturnType<typeof setTimeout> | null | undefined): vo
 const TOOL_EXECUTION_PATCH_FLAG = Symbol.for("pi-claude-style-tools:patched-tool-execution")
 const WORKED_DURATION_KEY = "_piClaudeStyleWorkedDurationMs"
 const WORKED_START_KEY = "_piClaudeStyleWorkedStartMs"
-const WORKED_DURATION_MARKER = "Worked for"
+const ASSISTANT_MESSAGE_PATCH_FLAG = Symbol.for("pi-claude-style-tools:patched-assistant-message-render")
+// OSC 133 zone markers applied by AssistantMessageComponent.render() — must be
+// reattached to the last line after we append the duration widget.
+const OSC133_ZONE_END = "\x1b]133;B\x07"
+const OSC133_ZONE_FINAL = "\x1b]133;C\x07"
+const OSC133_ZONE_SUFFIX = OSC133_ZONE_END + OSC133_ZONE_FINAL
 // WORKED_LINE_FG is theme-derived (from "muted") when themeAdaptive is on.
 let WORKED_LINE_FG = "\x1b[38;2;140;140;140m"
 let currentAgentWorkStartMs: number | undefined
@@ -346,28 +352,31 @@ function inlineWorkedDurationText(ms: number): string {
 	return `${WORKED_LINE_FG}✻ Worked for ${formatWorkedDuration(ms)}${RESET}`
 }
 
-function isWorkedDurationLine(line: string): boolean {
-	return line.includes(WORKED_DURATION_MARKER) && /^✻ Worked for [^\r\n]+$/.test(stripAnsi(line).trim())
-}
-
-function stripWorkedDurationLine(text: string): string {
-	if (!text.includes(WORKED_DURATION_MARKER)) return text
-	return text
-		.split(/\r?\n/)
-		.filter((line) => !isWorkedDurationLine(line))
-		.join("\n")
-		.replace(/\n{3,}/g, "\n\n")
-}
-
-function appendWorkedDurationLine(message: any, durationMs: number): void {
-	if (!message || message.role !== "assistant" || !Array.isArray(message.content)) return
-	const textBlocks = message.content.filter(
-		(block: any) => block?.type === "text" && typeof block.text === "string" && block.text.trim(),
-	)
-	const lastText = textBlocks[textBlocks.length - 1]
-	if (!lastText) return
-	const text = lastText.text.includes(WORKED_DURATION_MARKER) ? stripWorkedDurationLine(lastText.text) : lastText.text
-	lastText.text = `${text.trimEnd()}\n\n${inlineWorkedDurationText(durationMs)}`
+function patchAssistantMessageRender(): void {
+	const proto = AssistantMessageComponent.prototype as any
+	if (proto[ASSISTANT_MESSAGE_PATCH_FLAG]) return
+	const originalRender = proto.render
+	if (typeof originalRender !== "function") return
+	proto.render = function patchedAssistantMessageRender(width: number) {
+		const lines: string[] = originalRender.call(this, width)
+		if (!Array.isArray(lines) || lines.length === 0) return lines
+		const message = (this as any).lastMessage
+		const durationMs = message?.[WORKED_DURATION_KEY]
+		if (typeof durationMs !== "number" || durationMs <= 0) return lines
+		// The original render() appends OSC 133 zone markers to the last line
+		// (B = command end, C = command output). Strip them off, push the widget
+		// line, then reattach so the zone still brackets the full message.
+		const lastIdx = lines.length - 1
+		if (lines[lastIdx].includes(OSC133_ZONE_END)) {
+			lines[lastIdx] = lines[lastIdx].replace(OSC133_ZONE_SUFFIX, "")
+			lines.push(inlineWorkedDurationText(durationMs))
+			lines[lines.length - 1] += OSC133_ZONE_SUFFIX
+		} else {
+			lines.push(inlineWorkedDurationText(durationMs))
+		}
+		return lines
+	}
+	proto[ASSISTANT_MESSAGE_PATCH_FLAG] = true
 }
 
 // OSC 133 zone markers that UserMessageComponent prepends/appends for shell integration.
@@ -2451,12 +2460,14 @@ function registerThinkingLabels(pi: ExtensionAPI): void {
 			const isFinalAssistantMessage = message.stopReason !== "toolUse"
 			if (started !== undefined && isFinalAssistantMessage) {
 				const durationMs = Date.now() - started
+				// Store duration as metadata on the message object. The patched
+				// AssistantMessageComponent.render() reads it and appends the widget
+				// line outside of the message content blocks — never injected into
+				// the text that gets sent to the model.
 				;(message as any)[WORKED_DURATION_KEY] = durationMs
-				// Mutate the message itself before pi renders/persists it. This is more
-				// reliable than the spinner because pi removes the loader on agent_end,
-				// and more reliable than component monkey-patching when extensions are
-				// loaded from a different package instance than the running TUI.
-				appendWorkedDurationLine(message, durationMs)
+				// Persist the duration as a sidecar entry in the JSONL session file
+				// (type: "custom", does not participate in LLM context).
+				pi.appendEntry("turn_duration", { durationMs })
 			}
 			currentAssistantMessageStartMs = undefined
 		}
@@ -2474,8 +2485,18 @@ function registerThinkingLabels(pi: ExtensionAPI): void {
 				if (block && block.type === "thinking" && typeof block.thinking === "string") {
 					block.thinking = stripThinkingPresentationArtifacts(block.thinking)
 				}
+					// Legacy sessions written before this change may have the duration
+				// text injected directly into content blocks. Strip it so it doesn't
+				// appear twice alongside the widget.
 				if (block && block.type === "text" && typeof block.text === "string") {
-					block.text = stripWorkedDurationLine(block.text)
+					const marker = "Worked for"
+					if (block.text.includes(marker)) {
+						block.text = block.text
+							.split(/\r?\n/)
+							.filter((l: string) => !(l.includes(marker) && /^✻ Worked for [^\r\n]+$/.test(l.replace(/\x1b\[[0-9;]*m/g, "").trim())))
+							.join("\n")
+							.replace(/\n{3,}/g, "\n\n")
+					}
 				}
 			}
 		}
@@ -3434,6 +3455,7 @@ export default function (pi: ExtensionAPI) {
 	patchGlobalToolBorders()
 	patchToolExecutionRenderers()
 	patchUserMessageRender()
+	patchAssistantMessageRender()
 	applyDiffPalette()
 	registerThinkingLabels(pi)
 

--- a/src/extensions/tool-rendering.ts
+++ b/src/extensions/tool-rendering.ts
@@ -2577,6 +2577,9 @@ function renderGenericToolCall(name: string, args: any, theme: Theme, ctx: any):
 	ctx.state._openAiPatchFiles = []
 	const sp = (path: string) => shortPath(ctx.cwd ?? process.cwd(), path)
 	if (isMcpToolName(name)) {
+		// For MCP calls the summary may already contain ANSI color codes (muted
+		// for the args suffix) so we build the header line directly instead of
+		// passing it through toolHeader() which would re-wrap everything in accent.
 		const packed = stableCallSummary(ctx, "_mcpLabelSummary", () => {
 			const ls = mcpCallLabelAndSummary(args, theme)
 			return `${ls.label}\x00${ls.summary}`
@@ -2584,7 +2587,10 @@ function renderGenericToolCall(name: string, args: any, theme: Theme, ctx: any):
 		const sepIdx = packed.indexOf("\x00")
 		const mcpLabel = sepIdx >= 0 ? packed.slice(0, sepIdx) : "MCP"
 		const mcpSummary = sepIdx >= 0 ? packed.slice(sepIdx + 1) : ""
-		return makeText(ctx.lastComponent, toolHeader(mcpLabel, mcpSummary, theme, toolStatusDot(ctx, theme)))
+		const dot = toolStatusDot(ctx, theme)
+		const labelPart = theme.fg("toolTitle", theme.bold(mcpLabel))
+		const header = mcpSummary ? `${dot}${labelPart} ${WRAP_MARK}${mcpSummary}` : `${dot}${labelPart}`
+		return makeText(ctx.lastComponent, header)
 	}
 	const summary = stableCallSummary(ctx, "_callSummary", () => summarizeGenericToolCall(name, args, theme, sp))
 	return makeText(ctx.lastComponent, toolHeader(genericToolLabel(name), summary, theme, toolStatusDot(ctx, theme)))
@@ -3099,33 +3105,74 @@ function renderApplyPatchResult(result: any, isPartial: boolean, theme: Theme, c
 	)
 }
 
+/** Max chars shown for a single arg value before truncation. */
+const MCP_ARG_VALUE_MAX = 60
+/** Max total chars for the entire (key=val, …) suffix. */
+const MCP_ARGS_SUFFIX_MAX = 120
+
+/**
+ * Keys whose values are typically long blobs (file paths list, prompt text,
+ * raw content). These get truncated more aggressively or skipped when many
+ * other keys are present.
+ */
+const MCP_LONG_VALUE_KEYS = new Set([
+	"prompt",
+	"message",
+	"query",
+	"content",
+	"text",
+	"body",
+	"absolute_file_paths",
+	"file_paths",
+	"files",
+])
+
 /**
  * For an MCP gateway call whose args contain `tool`, parse the nested args
- * JSON and return a short summary of notable parameters (prompt, model, …).
+ * JSON and return a compact `(key=val, key=val)` style plain string (no ANSI),
+ * matching the style used by the `read` tool for offset/limit.
+ * Long values (prompts, file lists) are truncated. The whole suffix is capped
+ * so the call header stays on one line.
  */
-function summarizeMcpToolInvocationArgs(args: any, theme: Theme): string {
+function summarizeMcpToolInvocationArgs(args: any): string {
 	const rawArgs = getStringArg(args, "args")
 	if (!rawArgs) return ""
 	try {
 		const parsed = JSON.parse(rawArgs)
-		if (parsed && typeof parsed === "object") {
-			// Show model if present
-			const model = typeof parsed.model === "string" ? parsed.model : ""
-			// Show a truncated prompt snippet
-			const prompt =
-				typeof parsed.prompt === "string"
-					? parsed.prompt
-					: typeof parsed.message === "string"
-						? parsed.message
-						: typeof parsed.query === "string"
-							? parsed.query
-							: ""
-			if (model && prompt) {
-				return `${theme.fg("muted", model)} ${summarizeText(prompt, 48)}`
+		if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) return ""
+
+		const parts: string[] = []
+		// Prioritise short scalar keys first so they always appear.
+		const entries = Object.entries(parsed as Record<string, unknown>)
+		const shortFirst = [
+			...entries.filter(([k]) => !MCP_LONG_VALUE_KEYS.has(k)),
+			...entries.filter(([k]) => MCP_LONG_VALUE_KEYS.has(k)),
+		]
+		for (const [key, val] of shortFirst) {
+			if (val === undefined || val === null) continue
+			let display: string
+			if (Array.isArray(val)) {
+				if (val.length === 0) continue
+				const first = String(val[0])
+				display =
+					val.length === 1
+						? summarizeText(first, MCP_ARG_VALUE_MAX)
+						: `${summarizeText(first, 30)} +${val.length - 1}`
+			} else if (typeof val === "object") {
+				continue // skip nested objects
+			} else {
+				const maxLen = MCP_LONG_VALUE_KEYS.has(key) ? 40 : MCP_ARG_VALUE_MAX
+				display = summarizeText(String(val), maxLen)
 			}
-			if (model) return theme.fg("muted", model)
-			if (prompt) return summarizeText(prompt, 60)
+			const part = `${key}=${display}`
+			// Stop adding parts if we'd exceed the suffix cap.
+			const currentLen = parts.reduce((n, p) => n + p.length + 2, 0)
+			if (currentLen + part.length > MCP_ARGS_SUFFIX_MAX) break
+			parts.push(part)
 		}
+
+		if (parts.length === 0) return ""
+		return `(${parts.join(", ")})`
 	} catch {
 		// not valid JSON — ignore
 	}
@@ -3135,8 +3182,8 @@ function summarizeMcpToolInvocationArgs(args: any, theme: Theme): string {
 function summarizeMcpToolCall(args: any, theme: Theme): string {
 	const tool = getStringArg(args, "tool")
 	if (tool) {
-		const argsSummary = summarizeMcpToolInvocationArgs(args, theme)
-		return argsSummary ? argsSummary : theme.fg("muted", "")
+		const argsSummary = summarizeMcpToolInvocationArgs(args)
+		return argsSummary ? theme.fg("muted", argsSummary) : ""
 	}
 	const connect = getStringArg(args, "connect")
 	if (connect) return connect
@@ -3160,7 +3207,8 @@ function mcpCallLabelAndSummary(
 		const server = getStringArg(args, "server")
 		const toolDisplay = tool.replace(/_/g, " ")
 		const label = server ? `${server} - ${toolDisplay}` : toolDisplay
-		const summary = summarizeMcpToolInvocationArgs(args, theme)
+		const rawSuffix = summarizeMcpToolInvocationArgs(args)
+		const summary = rawSuffix ? theme.fg("muted", rawSuffix) : ""
 		return { label, summary }
 	}
 	if (getStringArg(args, "connect")) {

--- a/src/extensions/tool-rendering.ts
+++ b/src/extensions/tool-rendering.ts
@@ -2584,6 +2584,9 @@ function renderGenericToolCall(name: string, args: any, theme: Theme, ctx: any):
 	ctx.state._openAiPatchFiles = []
 	const sp = (path: string) => shortPath(ctx.cwd ?? process.cwd(), path)
 	if (isMcpToolName(name)) {
+		// For MCP calls the summary may already contain ANSI color codes (muted
+		// for the args suffix) so we build the header line directly instead of
+		// passing it through toolHeader() which would re-wrap everything in accent.
 		const packed = stableCallSummary(ctx, "_mcpLabelSummary", () => {
 			const ls = mcpCallLabelAndSummary(args, theme)
 			return `${ls.label}\x00${ls.summary}`
@@ -2591,7 +2594,10 @@ function renderGenericToolCall(name: string, args: any, theme: Theme, ctx: any):
 		const sepIdx = packed.indexOf("\x00")
 		const mcpLabel = sepIdx >= 0 ? packed.slice(0, sepIdx) : "MCP"
 		const mcpSummary = sepIdx >= 0 ? packed.slice(sepIdx + 1) : ""
-		return makeText(ctx.lastComponent, toolHeader(mcpLabel, mcpSummary, theme, toolStatusDot(ctx, theme)))
+		const dot = toolStatusDot(ctx, theme)
+		const labelPart = theme.fg("toolTitle", theme.bold(mcpLabel))
+		const header = mcpSummary ? `${dot}${labelPart} ${WRAP_MARK}${mcpSummary}` : `${dot}${labelPart}`
+		return makeText(ctx.lastComponent, header)
 	}
 	const summary = stableCallSummary(ctx, "_callSummary", () => summarizeGenericToolCall(name, args, theme, sp))
 	return makeText(ctx.lastComponent, toolHeader(genericToolLabel(name), summary, theme, toolStatusDot(ctx, theme)))
@@ -3106,33 +3112,74 @@ function renderApplyPatchResult(result: any, isPartial: boolean, theme: Theme, c
 	)
 }
 
+/** Max chars shown for a single arg value before truncation. */
+const MCP_ARG_VALUE_MAX = 60
+/** Max total chars for the entire (key=val, …) suffix. */
+const MCP_ARGS_SUFFIX_MAX = 120
+
+/**
+ * Keys whose values are typically long blobs (file paths list, prompt text,
+ * raw content). These get truncated more aggressively or skipped when many
+ * other keys are present.
+ */
+const MCP_LONG_VALUE_KEYS = new Set([
+	"prompt",
+	"message",
+	"query",
+	"content",
+	"text",
+	"body",
+	"absolute_file_paths",
+	"file_paths",
+	"files",
+])
+
 /**
  * For an MCP gateway call whose args contain `tool`, parse the nested args
- * JSON and return a short summary of notable parameters (prompt, model, …).
+ * JSON and return a compact `(key=val, key=val)` style plain string (no ANSI),
+ * matching the style used by the `read` tool for offset/limit.
+ * Long values (prompts, file lists) are truncated. The whole suffix is capped
+ * so the call header stays on one line.
  */
-function summarizeMcpToolInvocationArgs(args: any, theme: Theme): string {
+function summarizeMcpToolInvocationArgs(args: any): string {
 	const rawArgs = getStringArg(args, "args")
 	if (!rawArgs) return ""
 	try {
 		const parsed = JSON.parse(rawArgs)
-		if (parsed && typeof parsed === "object") {
-			// Show model if present
-			const model = typeof parsed.model === "string" ? parsed.model : ""
-			// Show a truncated prompt snippet
-			const prompt =
-				typeof parsed.prompt === "string"
-					? parsed.prompt
-					: typeof parsed.message === "string"
-						? parsed.message
-						: typeof parsed.query === "string"
-							? parsed.query
-							: ""
-			if (model && prompt) {
-				return `${theme.fg("muted", model)} ${summarizeText(prompt, 48)}`
+		if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) return ""
+
+		const parts: string[] = []
+		// Prioritise short scalar keys first so they always appear.
+		const entries = Object.entries(parsed as Record<string, unknown>)
+		const shortFirst = [
+			...entries.filter(([k]) => !MCP_LONG_VALUE_KEYS.has(k)),
+			...entries.filter(([k]) => MCP_LONG_VALUE_KEYS.has(k)),
+		]
+		for (const [key, val] of shortFirst) {
+			if (val === undefined || val === null) continue
+			let display: string
+			if (Array.isArray(val)) {
+				if (val.length === 0) continue
+				const first = String(val[0])
+				display =
+					val.length === 1
+						? summarizeText(first, MCP_ARG_VALUE_MAX)
+						: `${summarizeText(first, 30)} +${val.length - 1}`
+			} else if (typeof val === "object") {
+				continue // skip nested objects
+			} else {
+				const maxLen = MCP_LONG_VALUE_KEYS.has(key) ? 40 : MCP_ARG_VALUE_MAX
+				display = summarizeText(String(val), maxLen)
 			}
-			if (model) return theme.fg("muted", model)
-			if (prompt) return summarizeText(prompt, 60)
+			const part = `${key}=${display}`
+			// Stop adding parts if we'd exceed the suffix cap.
+			const currentLen = parts.reduce((n, p) => n + p.length + 2, 0)
+			if (currentLen + part.length > MCP_ARGS_SUFFIX_MAX) break
+			parts.push(part)
 		}
+
+		if (parts.length === 0) return ""
+		return `(${parts.join(", ")})`
 	} catch {
 		// not valid JSON — ignore
 	}
@@ -3142,8 +3189,8 @@ function summarizeMcpToolInvocationArgs(args: any, theme: Theme): string {
 function summarizeMcpToolCall(args: any, theme: Theme): string {
 	const tool = getStringArg(args, "tool")
 	if (tool) {
-		const argsSummary = summarizeMcpToolInvocationArgs(args, theme)
-		return argsSummary ? argsSummary : theme.fg("muted", "")
+		const argsSummary = summarizeMcpToolInvocationArgs(args)
+		return argsSummary ? theme.fg("muted", argsSummary) : ""
 	}
 	const connect = getStringArg(args, "connect")
 	if (connect) return connect
@@ -3167,7 +3214,8 @@ function mcpCallLabelAndSummary(
 		const server = getStringArg(args, "server")
 		const toolDisplay = tool.replace(/_/g, " ")
 		const label = server ? `${server} - ${toolDisplay}` : toolDisplay
-		const summary = summarizeMcpToolInvocationArgs(args, theme)
+		const rawSuffix = summarizeMcpToolInvocationArgs(args)
+		const summary = rawSuffix ? theme.fg("muted", rawSuffix) : ""
 		return { label, summary }
 	}
 	if (getStringArg(args, "connect")) {

--- a/src/extensions/tool-rendering.ts
+++ b/src/extensions/tool-rendering.ts
@@ -10,6 +10,7 @@ import type {
 	Theme,
 } from "@earendil-works/pi-coding-agent"
 import {
+	AssistantMessageComponent,
 	ToolExecutionComponent,
 	UserMessageComponent,
 	createBashTool,
@@ -310,7 +311,12 @@ function unrefTimer(timer: ReturnType<typeof setTimeout> | null | undefined): vo
 const TOOL_EXECUTION_PATCH_FLAG = Symbol.for("pi-claude-style-tools:patched-tool-execution")
 const WORKED_DURATION_KEY = "_piClaudeStyleWorkedDurationMs"
 const WORKED_START_KEY = "_piClaudeStyleWorkedStartMs"
-const WORKED_DURATION_MARKER = "Worked for"
+const ASSISTANT_MESSAGE_PATCH_FLAG = Symbol.for("pi-claude-style-tools:patched-assistant-message-render")
+// OSC 133 zone markers applied by AssistantMessageComponent.render() — must be
+// reattached to the last line after we append the duration widget.
+const OSC133_ZONE_END = "\x1b]133;B\x07"
+const OSC133_ZONE_FINAL = "\x1b]133;C\x07"
+const OSC133_ZONE_SUFFIX = OSC133_ZONE_END + OSC133_ZONE_FINAL
 // WORKED_LINE_FG is theme-derived (from "muted") when themeAdaptive is on.
 let WORKED_LINE_FG = "\x1b[38;2;140;140;140m"
 let currentAgentWorkStartMs: number | undefined
@@ -346,28 +352,31 @@ function inlineWorkedDurationText(ms: number): string {
 	return `${WORKED_LINE_FG}✻ Worked for ${formatWorkedDuration(ms)}${RESET}`
 }
 
-function isWorkedDurationLine(line: string): boolean {
-	return line.includes(WORKED_DURATION_MARKER) && /^✻ Worked for [^\r\n]+$/.test(stripAnsi(line).trim())
-}
-
-function stripWorkedDurationLine(text: string): string {
-	if (!text.includes(WORKED_DURATION_MARKER)) return text
-	return text
-		.split(/\r?\n/)
-		.filter((line) => !isWorkedDurationLine(line))
-		.join("\n")
-		.replace(/\n{3,}/g, "\n\n")
-}
-
-function appendWorkedDurationLine(message: any, durationMs: number): void {
-	if (!message || message.role !== "assistant" || !Array.isArray(message.content)) return
-	const textBlocks = message.content.filter(
-		(block: any) => block?.type === "text" && typeof block.text === "string" && block.text.trim(),
-	)
-	const lastText = textBlocks[textBlocks.length - 1]
-	if (!lastText) return
-	const text = lastText.text.includes(WORKED_DURATION_MARKER) ? stripWorkedDurationLine(lastText.text) : lastText.text
-	lastText.text = `${text.trimEnd()}\n\n${inlineWorkedDurationText(durationMs)}`
+function patchAssistantMessageRender(): void {
+	const proto = AssistantMessageComponent.prototype as any
+	if (proto[ASSISTANT_MESSAGE_PATCH_FLAG]) return
+	const originalRender = proto.render
+	if (typeof originalRender !== "function") return
+	proto.render = function patchedAssistantMessageRender(width: number) {
+		const lines: string[] = originalRender.call(this, width)
+		if (!Array.isArray(lines) || lines.length === 0) return lines
+		const message = (this as any).lastMessage
+		const durationMs = message?.[WORKED_DURATION_KEY]
+		if (typeof durationMs !== "number" || durationMs <= 0) return lines
+		// The original render() appends OSC 133 zone markers to the last line
+		// (B = command end, C = command output). Strip them off, push the widget
+		// line, then reattach so the zone still brackets the full message.
+		const lastIdx = lines.length - 1
+		if (lines[lastIdx].includes(OSC133_ZONE_END)) {
+			lines[lastIdx] = lines[lastIdx].replace(OSC133_ZONE_SUFFIX, "")
+			lines.push(inlineWorkedDurationText(durationMs))
+			lines[lines.length - 1] += OSC133_ZONE_SUFFIX
+		} else {
+			lines.push(inlineWorkedDurationText(durationMs))
+		}
+		return lines
+	}
+	proto[ASSISTANT_MESSAGE_PATCH_FLAG] = true
 }
 
 // OSC 133 zone marker that UserMessageComponent prepends to lines[0].
@@ -2444,12 +2453,14 @@ function registerThinkingLabels(pi: ExtensionAPI): void {
 			const isFinalAssistantMessage = message.stopReason !== "toolUse"
 			if (started !== undefined && isFinalAssistantMessage) {
 				const durationMs = Date.now() - started
+				// Store duration as metadata on the message object. The patched
+				// AssistantMessageComponent.render() reads it and appends the widget
+				// line outside of the message content blocks — never injected into
+				// the text that gets sent to the model.
 				;(message as any)[WORKED_DURATION_KEY] = durationMs
-				// Mutate the message itself before pi renders/persists it. This is more
-				// reliable than the spinner because pi removes the loader on agent_end,
-				// and more reliable than component monkey-patching when extensions are
-				// loaded from a different package instance than the running TUI.
-				appendWorkedDurationLine(message, durationMs)
+				// Persist the duration as a sidecar entry in the JSONL session file
+				// (type: "custom", does not participate in LLM context).
+				pi.appendEntry("turn_duration", { durationMs })
 			}
 			currentAssistantMessageStartMs = undefined
 		}
@@ -2467,8 +2478,18 @@ function registerThinkingLabels(pi: ExtensionAPI): void {
 				if (block && block.type === "thinking" && typeof block.thinking === "string") {
 					block.thinking = stripThinkingPresentationArtifacts(block.thinking)
 				}
+					// Legacy sessions written before this change may have the duration
+				// text injected directly into content blocks. Strip it so it doesn't
+				// appear twice alongside the widget.
 				if (block && block.type === "text" && typeof block.text === "string") {
-					block.text = stripWorkedDurationLine(block.text)
+					const marker = "Worked for"
+					if (block.text.includes(marker)) {
+						block.text = block.text
+							.split(/\r?\n/)
+							.filter((l: string) => !(l.includes(marker) && /^✻ Worked for [^\r\n]+$/.test(l.replace(/\x1b\[[0-9;]*m/g, "").trim())))
+							.join("\n")
+							.replace(/\n{3,}/g, "\n\n")
+					}
 				}
 			}
 		}
@@ -3416,6 +3437,7 @@ export default function (pi: ExtensionAPI) {
 	patchGlobalToolBorders()
 	patchToolExecutionRenderers()
 	patchUserMessageRender()
+	patchAssistantMessageRender()
 	applyDiffPalette()
 	registerThinkingLabels(pi)
 

--- a/src/extensions/tool-rendering.ts
+++ b/src/extensions/tool-rendering.ts
@@ -3164,7 +3164,9 @@ function mcpCallLabelAndSummary(
 ): { label: string; summary: string } {
 	const tool = getStringArg(args, "tool")
 	if (tool) {
-		const label = humanizeToolName(tool)
+		const server = getStringArg(args, "server")
+		const toolDisplay = tool.replace(/_/g, " ")
+		const label = server ? `${server} - ${toolDisplay}` : toolDisplay
 		const summary = summarizeMcpToolInvocationArgs(args, theme)
 		return { label, summary }
 	}

--- a/src/extensions/tool-rendering.ts
+++ b/src/extensions/tool-rendering.ts
@@ -2601,7 +2601,7 @@ function humanizeToolName(name: string): string {
 		.replace(/\b\w/g, (char) => char.toUpperCase())
 }
 
-function isMcpToolName(name: string): boolean {
+export function isMcpToolName(name: string): boolean {
 	return name === "mcp" || /^mcp[_:-]/i.test(name) || /[_:-]mcp[_:-]/i.test(name)
 }
 
@@ -3170,7 +3170,7 @@ const MCP_ARGS_SUFFIX_MAX = 120
  * whole suffix is capped at MCP_ARGS_SUFFIX_MAX chars so the header stays on
  * one line. When `expanded` is true all values are shown in full.
  */
-function summarizeMcpToolInvocationArgs(args: any, expanded = false): string {
+export function summarizeMcpToolInvocationArgs(args: any, expanded = false): string {
 	const rawArgs = getStringArg(args, "args")
 	if (!rawArgs) return ""
 	try {
@@ -3235,7 +3235,7 @@ function summarizeMcpToolCall(args: any, theme: Theme, expanded = false): string
  * - Discovery (`args.search` / `args.describe` / …): label = "Tool search" / "Tool describe" / …
  * - Connect: label = "Tool connect"
  */
-function mcpCallLabelAndSummary(
+export function mcpCallLabelAndSummary(
 	args: any,
 	theme: Theme,
 	expanded = false,

--- a/src/extensions/tool-rendering.ts
+++ b/src/extensions/tool-rendering.ts
@@ -3219,21 +3219,21 @@ function mcpCallLabelAndSummary(
 		return { label, summary }
 	}
 	if (getStringArg(args, "connect")) {
-		return { label: "Tool connect", summary: getStringArg(args, "connect") }
+		return { label: "Tool connect", summary: theme.fg("muted", `(server=${getStringArg(args, "connect")})`) }
 	}
 	if (getStringArg(args, "describe")) {
-		return { label: "Tool describe", summary: summarizeText(getStringArg(args, "describe"), 72) }
+		return { label: "Tool describe", summary: theme.fg("muted", `(tool=${summarizeText(getStringArg(args, "describe"), 60)})`) }
 	}
 	if (getStringArg(args, "search")) {
-		return { label: "Tool search", summary: summarizeText(getStringArg(args, "search"), 72) }
+		return { label: "Tool search", summary: theme.fg("muted", `(query=${summarizeText(getStringArg(args, "search"), 60)})`) }
 	}
 	if (getStringArg(args, "server")) {
-		return { label: "Tool search", summary: summarizeText(getStringArg(args, "server"), 72) }
+		return { label: "Tool search", summary: theme.fg("muted", `(server=${summarizeText(getStringArg(args, "server"), 60)})`) }
 	}
 	if (getStringArg(args, "action")) {
-		return { label: "Tool action", summary: summarizeText(getStringArg(args, "action"), 72) }
+		return { label: "Tool action", summary: theme.fg("muted", `(action=${summarizeText(getStringArg(args, "action"), 60)})`) }
 	}
-	return { label: "MCP", summary: theme.fg("muted", "status") }
+	return { label: "MCP", summary: theme.fg("muted", "(status)") }
 }
 
 function summarizeGenericToolCall(name: string, args: any, theme: Theme, sp: (path: string) => string): string {

--- a/src/extensions/tool-rendering.ts
+++ b/src/extensions/tool-rendering.ts
@@ -3212,21 +3212,21 @@ function mcpCallLabelAndSummary(
 		return { label, summary }
 	}
 	if (getStringArg(args, "connect")) {
-		return { label: "Tool connect", summary: getStringArg(args, "connect") }
+		return { label: "Tool connect", summary: theme.fg("muted", `(server=${getStringArg(args, "connect")})`) }
 	}
 	if (getStringArg(args, "describe")) {
-		return { label: "Tool describe", summary: summarizeText(getStringArg(args, "describe"), 72) }
+		return { label: "Tool describe", summary: theme.fg("muted", `(tool=${summarizeText(getStringArg(args, "describe"), 60)})`) }
 	}
 	if (getStringArg(args, "search")) {
-		return { label: "Tool search", summary: summarizeText(getStringArg(args, "search"), 72) }
+		return { label: "Tool search", summary: theme.fg("muted", `(query=${summarizeText(getStringArg(args, "search"), 60)})`) }
 	}
 	if (getStringArg(args, "server")) {
-		return { label: "Tool search", summary: summarizeText(getStringArg(args, "server"), 72) }
+		return { label: "Tool search", summary: theme.fg("muted", `(server=${summarizeText(getStringArg(args, "server"), 60)})`) }
 	}
 	if (getStringArg(args, "action")) {
-		return { label: "Tool action", summary: summarizeText(getStringArg(args, "action"), 72) }
+		return { label: "Tool action", summary: theme.fg("muted", `(action=${summarizeText(getStringArg(args, "action"), 60)})`) }
 	}
-	return { label: "MCP", summary: theme.fg("muted", "status") }
+	return { label: "MCP", summary: theme.fg("muted", "(status)") }
 }
 
 function summarizeGenericToolCall(name: string, args: any, theme: Theme, sp: (path: string) => string): string {

--- a/src/extensions/tool-rendering.ts
+++ b/src/extensions/tool-rendering.ts
@@ -3125,17 +3125,6 @@ const MCP_ARGS_SUFFIX_MAX = 120
  * raw content). These get truncated more aggressively or skipped when many
  * other keys are present.
  */
-const MCP_LONG_VALUE_KEYS = new Set([
-	"prompt",
-	"message",
-	"query",
-	"content",
-	"text",
-	"body",
-	"absolute_file_paths",
-	"file_paths",
-	"files",
-])
 
 /**
  * For an MCP gateway call whose args contain `tool`, parse the nested args
@@ -3154,15 +3143,8 @@ function summarizeMcpToolInvocationArgs(args: any, expanded = false): string {
 		if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) return ""
 
 		const parts: string[] = []
-		// Collapsed: short scalar keys first so they always appear within cap.
-		// Expanded: preserve original key order.
-		const entries = Object.entries(parsed as Record<string, unknown>)
-		const ordered = expanded
-			? entries
-			: [
-					...entries.filter(([k]) => !MCP_LONG_VALUE_KEYS.has(k)),
-					...entries.filter(([k]) => MCP_LONG_VALUE_KEYS.has(k)),
-				]
+		// Always use original key order — collapsed mode just stops at the cap.
+		const ordered = Object.entries(parsed as Record<string, unknown>)
 		for (const [key, val] of ordered) {
 			if (val === undefined || val === null) continue
 			let display: string
@@ -3180,8 +3162,7 @@ function summarizeMcpToolInvocationArgs(args: any, expanded = false): string {
 			} else if (typeof val === "object") {
 				continue // skip nested objects
 			} else {
-				const maxLen = expanded ? Number.POSITIVE_INFINITY : MCP_LONG_VALUE_KEYS.has(key) ? 40 : MCP_ARG_VALUE_MAX
-				display = expanded ? String(val) : summarizeText(String(val), maxLen)
+				display = expanded ? String(val) : summarizeText(String(val), MCP_ARG_VALUE_MAX)
 			}
 			const part = `${key}=${display}`
 			// In collapsed mode stop adding parts if we'd exceed the suffix cap.

--- a/src/extensions/tool-rendering.ts
+++ b/src/extensions/tool-rendering.ts
@@ -2576,6 +2576,16 @@ function genericToolLabel(name: string): string {
 function renderGenericToolCall(name: string, args: any, theme: Theme, ctx: any): Text {
 	ctx.state._openAiPatchFiles = []
 	const sp = (path: string) => shortPath(ctx.cwd ?? process.cwd(), path)
+	if (isMcpToolName(name)) {
+		const packed = stableCallSummary(ctx, "_mcpLabelSummary", () => {
+			const ls = mcpCallLabelAndSummary(args, theme)
+			return `${ls.label}\x00${ls.summary}`
+		})
+		const sepIdx = packed.indexOf("\x00")
+		const mcpLabel = sepIdx >= 0 ? packed.slice(0, sepIdx) : "MCP"
+		const mcpSummary = sepIdx >= 0 ? packed.slice(sepIdx + 1) : ""
+		return makeText(ctx.lastComponent, toolHeader(mcpLabel, mcpSummary, theme, toolStatusDot(ctx, theme)))
+	}
 	const summary = stableCallSummary(ctx, "_callSummary", () => summarizeGenericToolCall(name, args, theme, sp))
 	return makeText(ctx.lastComponent, toolHeader(genericToolLabel(name), summary, theme, toolStatusDot(ctx, theme)))
 }
@@ -3089,14 +3099,84 @@ function renderApplyPatchResult(result: any, isPartial: boolean, theme: Theme, c
 	)
 }
 
+/**
+ * For an MCP gateway call whose args contain `tool`, parse the nested args
+ * JSON and return a short summary of notable parameters (prompt, model, …).
+ */
+function summarizeMcpToolInvocationArgs(args: any, theme: Theme): string {
+	const rawArgs = getStringArg(args, "args")
+	if (!rawArgs) return ""
+	try {
+		const parsed = JSON.parse(rawArgs)
+		if (parsed && typeof parsed === "object") {
+			// Show model if present
+			const model = typeof parsed.model === "string" ? parsed.model : ""
+			// Show a truncated prompt snippet
+			const prompt =
+				typeof parsed.prompt === "string"
+					? parsed.prompt
+					: typeof parsed.message === "string"
+						? parsed.message
+						: typeof parsed.query === "string"
+							? parsed.query
+							: ""
+			if (model && prompt) {
+				return `${theme.fg("muted", model)} ${summarizeText(prompt, 48)}`
+			}
+			if (model) return theme.fg("muted", model)
+			if (prompt) return summarizeText(prompt, 60)
+		}
+	} catch {
+		// not valid JSON — ignore
+	}
+	return ""
+}
+
 function summarizeMcpToolCall(args: any, theme: Theme): string {
 	const tool = getStringArg(args, "tool")
-	if (tool) return args?.server ? `${args.server}:${tool}` : tool
+	if (tool) {
+		const argsSummary = summarizeMcpToolInvocationArgs(args, theme)
+		return argsSummary ? argsSummary : theme.fg("muted", "")
+	}
 	const connect = getStringArg(args, "connect")
-	if (connect) return `connect ${connect}`
+	if (connect) return connect
 	const search = getStringArg(args, "search", "describe", "server", "action")
 	if (search) return summarizeText(search, 72)
 	return theme.fg("muted", "status")
+}
+
+/**
+ * Returns the display label and summary for an MCP gateway call.
+ * - Tool invocation (`args.tool` present): label = humanized tool name, summary = args preview
+ * - Discovery (`args.search` / `args.describe` / …): label = "Tool search" / "Tool describe" / …
+ * - Connect: label = "Tool connect"
+ */
+function mcpCallLabelAndSummary(
+	args: any,
+	theme: Theme,
+): { label: string; summary: string } {
+	const tool = getStringArg(args, "tool")
+	if (tool) {
+		const label = humanizeToolName(tool)
+		const summary = summarizeMcpToolInvocationArgs(args, theme)
+		return { label, summary }
+	}
+	if (getStringArg(args, "connect")) {
+		return { label: "Tool connect", summary: getStringArg(args, "connect") }
+	}
+	if (getStringArg(args, "describe")) {
+		return { label: "Tool describe", summary: summarizeText(getStringArg(args, "describe"), 72) }
+	}
+	if (getStringArg(args, "search")) {
+		return { label: "Tool search", summary: summarizeText(getStringArg(args, "search"), 72) }
+	}
+	if (getStringArg(args, "server")) {
+		return { label: "Tool search", summary: summarizeText(getStringArg(args, "server"), 72) }
+	}
+	if (getStringArg(args, "action")) {
+		return { label: "Tool action", summary: summarizeText(getStringArg(args, "action"), 72) }
+	}
+	return { label: "MCP", summary: theme.fg("muted", "status") }
 }
 
 function summarizeGenericToolCall(name: string, args: any, theme: Theme, sp: (path: string) => string): string {

--- a/src/extensions/tool-rendering.ts
+++ b/src/extensions/tool-rendering.ts
@@ -3118,17 +3118,6 @@ const MCP_ARGS_SUFFIX_MAX = 120
  * raw content). These get truncated more aggressively or skipped when many
  * other keys are present.
  */
-const MCP_LONG_VALUE_KEYS = new Set([
-	"prompt",
-	"message",
-	"query",
-	"content",
-	"text",
-	"body",
-	"absolute_file_paths",
-	"file_paths",
-	"files",
-])
 
 /**
  * For an MCP gateway call whose args contain `tool`, parse the nested args
@@ -3147,15 +3136,8 @@ function summarizeMcpToolInvocationArgs(args: any, expanded = false): string {
 		if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) return ""
 
 		const parts: string[] = []
-		// Collapsed: short scalar keys first so they always appear within cap.
-		// Expanded: preserve original key order.
-		const entries = Object.entries(parsed as Record<string, unknown>)
-		const ordered = expanded
-			? entries
-			: [
-					...entries.filter(([k]) => !MCP_LONG_VALUE_KEYS.has(k)),
-					...entries.filter(([k]) => MCP_LONG_VALUE_KEYS.has(k)),
-				]
+		// Always use original key order — collapsed mode just stops at the cap.
+		const ordered = Object.entries(parsed as Record<string, unknown>)
 		for (const [key, val] of ordered) {
 			if (val === undefined || val === null) continue
 			let display: string
@@ -3173,8 +3155,7 @@ function summarizeMcpToolInvocationArgs(args: any, expanded = false): string {
 			} else if (typeof val === "object") {
 				continue // skip nested objects
 			} else {
-				const maxLen = expanded ? Number.POSITIVE_INFINITY : MCP_LONG_VALUE_KEYS.has(key) ? 40 : MCP_ARG_VALUE_MAX
-				display = expanded ? String(val) : summarizeText(String(val), maxLen)
+				display = expanded ? String(val) : summarizeText(String(val), MCP_ARG_VALUE_MAX)
 			}
 			const part = `${key}=${display}`
 			// In collapsed mode stop adding parts if we'd exceed the suffix cap.

--- a/src/extensions/tool-rendering.ts
+++ b/src/extensions/tool-rendering.ts
@@ -2587,8 +2587,11 @@ function renderGenericToolCall(name: string, args: any, theme: Theme, ctx: any):
 		// For MCP calls the summary may already contain ANSI color codes (muted
 		// for the args suffix) so we build the header line directly instead of
 		// passing it through toolHeader() which would re-wrap everything in accent.
-		const packed = stableCallSummary(ctx, "_mcpLabelSummary", () => {
-			const ls = mcpCallLabelAndSummary(args, theme)
+		// The cache key includes expanded state so ctrl+o triggers a full re-render.
+		const expanded = !!ctx.expanded
+		const cacheKey = `_mcpLabelSummary:${expanded ? 1 : 0}`
+		const packed = stableCallSummary(ctx, cacheKey, () => {
+			const ls = mcpCallLabelAndSummary(args, theme, expanded)
 			return `${ls.label}\x00${ls.summary}`
 		})
 		const sepIdx = packed.indexOf("\x00")
@@ -3138,10 +3141,12 @@ const MCP_LONG_VALUE_KEYS = new Set([
  * For an MCP gateway call whose args contain `tool`, parse the nested args
  * JSON and return a compact `(key=val, key=val)` style plain string (no ANSI),
  * matching the style used by the `read` tool for offset/limit.
- * Long values (prompts, file lists) are truncated. The whole suffix is capped
- * so the call header stays on one line.
+ *
+ * When `expanded` is false (collapsed view) long values are truncated and the
+ * whole suffix is capped at MCP_ARGS_SUFFIX_MAX chars so the header stays on
+ * one line. When `expanded` is true all values are shown in full.
  */
-function summarizeMcpToolInvocationArgs(args: any): string {
+function summarizeMcpToolInvocationArgs(args: any, expanded = false): string {
 	const rawArgs = getStringArg(args, "args")
 	if (!rawArgs) return ""
 	try {
@@ -3149,32 +3154,41 @@ function summarizeMcpToolInvocationArgs(args: any): string {
 		if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) return ""
 
 		const parts: string[] = []
-		// Prioritise short scalar keys first so they always appear.
+		// Collapsed: short scalar keys first so they always appear within cap.
+		// Expanded: preserve original key order.
 		const entries = Object.entries(parsed as Record<string, unknown>)
-		const shortFirst = [
-			...entries.filter(([k]) => !MCP_LONG_VALUE_KEYS.has(k)),
-			...entries.filter(([k]) => MCP_LONG_VALUE_KEYS.has(k)),
-		]
-		for (const [key, val] of shortFirst) {
+		const ordered = expanded
+			? entries
+			: [
+					...entries.filter(([k]) => !MCP_LONG_VALUE_KEYS.has(k)),
+					...entries.filter(([k]) => MCP_LONG_VALUE_KEYS.has(k)),
+				]
+		for (const [key, val] of ordered) {
 			if (val === undefined || val === null) continue
 			let display: string
 			if (Array.isArray(val)) {
 				if (val.length === 0) continue
-				const first = String(val[0])
-				display =
-					val.length === 1
-						? summarizeText(first, MCP_ARG_VALUE_MAX)
-						: `${summarizeText(first, 30)} +${val.length - 1}`
+				if (expanded) {
+					display = val.map((v) => String(v)).join(", ")
+				} else {
+					const first = String(val[0])
+					display =
+						val.length === 1
+							? summarizeText(first, MCP_ARG_VALUE_MAX)
+							: `${summarizeText(first, 30)} +${val.length - 1}`
+				}
 			} else if (typeof val === "object") {
 				continue // skip nested objects
 			} else {
-				const maxLen = MCP_LONG_VALUE_KEYS.has(key) ? 40 : MCP_ARG_VALUE_MAX
-				display = summarizeText(String(val), maxLen)
+				const maxLen = expanded ? Number.POSITIVE_INFINITY : MCP_LONG_VALUE_KEYS.has(key) ? 40 : MCP_ARG_VALUE_MAX
+				display = expanded ? String(val) : summarizeText(String(val), maxLen)
 			}
 			const part = `${key}=${display}`
-			// Stop adding parts if we'd exceed the suffix cap.
-			const currentLen = parts.reduce((n, p) => n + p.length + 2, 0)
-			if (currentLen + part.length > MCP_ARGS_SUFFIX_MAX) break
+			// In collapsed mode stop adding parts if we'd exceed the suffix cap.
+			if (!expanded) {
+				const currentLen = parts.reduce((n, p) => n + p.length + 2, 0)
+				if (currentLen + part.length > MCP_ARGS_SUFFIX_MAX) break
+			}
 			parts.push(part)
 		}
 
@@ -3186,10 +3200,10 @@ function summarizeMcpToolInvocationArgs(args: any): string {
 	return ""
 }
 
-function summarizeMcpToolCall(args: any, theme: Theme): string {
+function summarizeMcpToolCall(args: any, theme: Theme, expanded = false): string {
 	const tool = getStringArg(args, "tool")
 	if (tool) {
-		const argsSummary = summarizeMcpToolInvocationArgs(args)
+		const argsSummary = summarizeMcpToolInvocationArgs(args, expanded)
 		return argsSummary ? theme.fg("muted", argsSummary) : ""
 	}
 	const connect = getStringArg(args, "connect")
@@ -3208,13 +3222,14 @@ function summarizeMcpToolCall(args: any, theme: Theme): string {
 function mcpCallLabelAndSummary(
 	args: any,
 	theme: Theme,
+	expanded = false,
 ): { label: string; summary: string } {
 	const tool = getStringArg(args, "tool")
 	if (tool) {
 		const server = getStringArg(args, "server")
 		const toolDisplay = tool.replace(/_/g, " ")
 		const label = server ? `${server} - ${toolDisplay}` : toolDisplay
-		const rawSuffix = summarizeMcpToolInvocationArgs(args)
+		const rawSuffix = summarizeMcpToolInvocationArgs(args, expanded)
 		const summary = rawSuffix ? theme.fg("muted", rawSuffix) : ""
 		return { label, summary }
 	}

--- a/src/extensions/tool-rendering.ts
+++ b/src/extensions/tool-rendering.ts
@@ -3157,7 +3157,9 @@ function mcpCallLabelAndSummary(
 ): { label: string; summary: string } {
 	const tool = getStringArg(args, "tool")
 	if (tool) {
-		const label = humanizeToolName(tool)
+		const server = getStringArg(args, "server")
+		const toolDisplay = tool.replace(/_/g, " ")
+		const label = server ? `${server} - ${toolDisplay}` : toolDisplay
 		const summary = summarizeMcpToolInvocationArgs(args, theme)
 		return { label, summary }
 	}

--- a/src/extensions/tool-rendering.ts
+++ b/src/extensions/tool-rendering.ts
@@ -2580,8 +2580,11 @@ function renderGenericToolCall(name: string, args: any, theme: Theme, ctx: any):
 		// For MCP calls the summary may already contain ANSI color codes (muted
 		// for the args suffix) so we build the header line directly instead of
 		// passing it through toolHeader() which would re-wrap everything in accent.
-		const packed = stableCallSummary(ctx, "_mcpLabelSummary", () => {
-			const ls = mcpCallLabelAndSummary(args, theme)
+		// The cache key includes expanded state so ctrl+o triggers a full re-render.
+		const expanded = !!ctx.expanded
+		const cacheKey = `_mcpLabelSummary:${expanded ? 1 : 0}`
+		const packed = stableCallSummary(ctx, cacheKey, () => {
+			const ls = mcpCallLabelAndSummary(args, theme, expanded)
 			return `${ls.label}\x00${ls.summary}`
 		})
 		const sepIdx = packed.indexOf("\x00")
@@ -3131,10 +3134,12 @@ const MCP_LONG_VALUE_KEYS = new Set([
  * For an MCP gateway call whose args contain `tool`, parse the nested args
  * JSON and return a compact `(key=val, key=val)` style plain string (no ANSI),
  * matching the style used by the `read` tool for offset/limit.
- * Long values (prompts, file lists) are truncated. The whole suffix is capped
- * so the call header stays on one line.
+ *
+ * When `expanded` is false (collapsed view) long values are truncated and the
+ * whole suffix is capped at MCP_ARGS_SUFFIX_MAX chars so the header stays on
+ * one line. When `expanded` is true all values are shown in full.
  */
-function summarizeMcpToolInvocationArgs(args: any): string {
+function summarizeMcpToolInvocationArgs(args: any, expanded = false): string {
 	const rawArgs = getStringArg(args, "args")
 	if (!rawArgs) return ""
 	try {
@@ -3142,32 +3147,41 @@ function summarizeMcpToolInvocationArgs(args: any): string {
 		if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) return ""
 
 		const parts: string[] = []
-		// Prioritise short scalar keys first so they always appear.
+		// Collapsed: short scalar keys first so they always appear within cap.
+		// Expanded: preserve original key order.
 		const entries = Object.entries(parsed as Record<string, unknown>)
-		const shortFirst = [
-			...entries.filter(([k]) => !MCP_LONG_VALUE_KEYS.has(k)),
-			...entries.filter(([k]) => MCP_LONG_VALUE_KEYS.has(k)),
-		]
-		for (const [key, val] of shortFirst) {
+		const ordered = expanded
+			? entries
+			: [
+					...entries.filter(([k]) => !MCP_LONG_VALUE_KEYS.has(k)),
+					...entries.filter(([k]) => MCP_LONG_VALUE_KEYS.has(k)),
+				]
+		for (const [key, val] of ordered) {
 			if (val === undefined || val === null) continue
 			let display: string
 			if (Array.isArray(val)) {
 				if (val.length === 0) continue
-				const first = String(val[0])
-				display =
-					val.length === 1
-						? summarizeText(first, MCP_ARG_VALUE_MAX)
-						: `${summarizeText(first, 30)} +${val.length - 1}`
+				if (expanded) {
+					display = val.map((v) => String(v)).join(", ")
+				} else {
+					const first = String(val[0])
+					display =
+						val.length === 1
+							? summarizeText(first, MCP_ARG_VALUE_MAX)
+							: `${summarizeText(first, 30)} +${val.length - 1}`
+				}
 			} else if (typeof val === "object") {
 				continue // skip nested objects
 			} else {
-				const maxLen = MCP_LONG_VALUE_KEYS.has(key) ? 40 : MCP_ARG_VALUE_MAX
-				display = summarizeText(String(val), maxLen)
+				const maxLen = expanded ? Number.POSITIVE_INFINITY : MCP_LONG_VALUE_KEYS.has(key) ? 40 : MCP_ARG_VALUE_MAX
+				display = expanded ? String(val) : summarizeText(String(val), maxLen)
 			}
 			const part = `${key}=${display}`
-			// Stop adding parts if we'd exceed the suffix cap.
-			const currentLen = parts.reduce((n, p) => n + p.length + 2, 0)
-			if (currentLen + part.length > MCP_ARGS_SUFFIX_MAX) break
+			// In collapsed mode stop adding parts if we'd exceed the suffix cap.
+			if (!expanded) {
+				const currentLen = parts.reduce((n, p) => n + p.length + 2, 0)
+				if (currentLen + part.length > MCP_ARGS_SUFFIX_MAX) break
+			}
 			parts.push(part)
 		}
 
@@ -3179,10 +3193,10 @@ function summarizeMcpToolInvocationArgs(args: any): string {
 	return ""
 }
 
-function summarizeMcpToolCall(args: any, theme: Theme): string {
+function summarizeMcpToolCall(args: any, theme: Theme, expanded = false): string {
 	const tool = getStringArg(args, "tool")
 	if (tool) {
-		const argsSummary = summarizeMcpToolInvocationArgs(args)
+		const argsSummary = summarizeMcpToolInvocationArgs(args, expanded)
 		return argsSummary ? theme.fg("muted", argsSummary) : ""
 	}
 	const connect = getStringArg(args, "connect")
@@ -3201,13 +3215,14 @@ function summarizeMcpToolCall(args: any, theme: Theme): string {
 function mcpCallLabelAndSummary(
 	args: any,
 	theme: Theme,
+	expanded = false,
 ): { label: string; summary: string } {
 	const tool = getStringArg(args, "tool")
 	if (tool) {
 		const server = getStringArg(args, "server")
 		const toolDisplay = tool.replace(/_/g, " ")
 		const label = server ? `${server} - ${toolDisplay}` : toolDisplay
-		const rawSuffix = summarizeMcpToolInvocationArgs(args)
+		const rawSuffix = summarizeMcpToolInvocationArgs(args, expanded)
 		const summary = rawSuffix ? theme.fg("muted", rawSuffix) : ""
 		return { label, summary }
 	}


### PR DESCRIPTION
## Problem

The MCP gateway proxy tool renders all calls identically as `● MCP <text>`, making it impossible to distinguish:
- **Discovery calls** (`mcp({ search: "pal chat" })`) — bookkeeping lookups
- **Tool invocations** (`mcp({ tool: "pal_chat", args: "..." })`) — actual work

## Solution

### Call header labels
- **Tool invocations**: label = tool name with underscores replaced by spaces (`pal_chat` → `pal chat`), prefixed with server if present (`pal - pal chat`)
- **Discovery calls**: label = `Tool search` / `Tool describe` / `Tool connect` / `Tool action`

### Argument rendering
All MCP calls now show a compact muted `(key=val, ...)` suffix matching the style used by the `read` tool for `(offset=46, limit=100)`:

```
● pal chat  (model=gemini-3-pro-preview, thinking_mode=high, prompt=We're debugging...)
● Tool search  (query=pal chat)
● Tool describe  (tool=pal_chat)
```

- Original JSON key order preserved in both collapsed and expanded views
- Collapsed: values truncated at 60 chars, suffix capped at 120 chars total
- Expanded (`ctrl+o`): all values shown in full, no truncation
- Arrays show all elements when expanded, `first-elem +N` when collapsed
- Nested objects skipped

### Implementation notes
- MCP call header bypasses `toolHeader()`'s accent re-wrapping to preserve the inner muted ANSI codes
- Expanded state included in `stableCallSummary` cache key so `ctrl+o` triggers a re-render
- Discovery call summaries also switched to muted `(key=val)` format for visual consistency