### PR TITLE
feat: add single-model prompt instructions for subagent delegation

### DIFF
--- a/src/extensions/orchestration/orchestration-instructions.test.ts
+++ b/src/extensions/orchestration/orchestration-instructions.test.ts
@@ -134,13 +134,17 @@ describe("resolveOrchestrationInstructions", () => {
 		expect(result).not.toContain("## Your Team")
 	})
 
-	it("returns empty string in single-model mode", () => {
+	it("returns single-model instructions in single-model mode", () => {
 		const result = resolveOrchestrationInstructions({
 			currentModelId: "kimi-k2.6",
 			registry,
 			mode: "single",
 		})
-		expect(result).toBe("")
+		expect(result).toContain("single-model mode")
+		expect(result).toContain("same model")
+		expect(result).toContain("different model")
+		expect(result).toContain("asking the user for approval")
+		expect(result).toContain("Agent")
 	})
 
 	it("returns subagent instructions in subagent mode", () => {
@@ -172,7 +176,8 @@ describe("resolveOrchestrationInstructions", () => {
 			mode: "single",
 			roles: DEFAULT_MODEL_ROLES,
 		})
-		expect(result).toBe("")
+		expect(result).toContain("single-model mode")
+		expect(result).not.toContain("Your Team")
 	})
 
 	it("includes model-specific orchestration guidelines when provided", () => {

--- a/src/extensions/orchestration/orchestration-instructions.test.ts
+++ b/src/extensions/orchestration/orchestration-instructions.test.ts
@@ -134,17 +134,16 @@ describe("resolveOrchestrationInstructions", () => {
 		expect(result).not.toContain("## Your Team")
 	})
 
-	it("returns single-model instructions in single-model mode", () => {
+	it("returns single-model instructions with model ID in single-model mode", () => {
 		const result = resolveOrchestrationInstructions({
 			currentModelId: "kimi-k2.6",
 			registry,
 			mode: "single",
 		})
-		expect(result).toContain("single-model mode")
-		expect(result).toContain("same model")
-		expect(result).toContain("different model")
-		expect(result).toContain("asking the user for approval")
-		expect(result).toContain("Agent")
+		expect(result).toContain("Single-Model Mode")
+		expect(result).toContain("kimi-k2.6")
+		expect(result).toContain("MUST always pass your own model ID")
+		expect(result).toContain("never delegate to a different model")
 	})
 
 	it("returns subagent instructions in subagent mode", () => {
@@ -176,7 +175,7 @@ describe("resolveOrchestrationInstructions", () => {
 			mode: "single",
 			roles: DEFAULT_MODEL_ROLES,
 		})
-		expect(result).toContain("single-model mode")
+		expect(result).toContain("Single-Model Mode")
 		expect(result).not.toContain("Your Team")
 	})
 

--- a/src/extensions/orchestration/orchestration-instructions.ts
+++ b/src/extensions/orchestration/orchestration-instructions.ts
@@ -27,6 +27,9 @@ export function resolveOrchestrationInstructions(ctx: OrchestrationInstructionsC
 	if (ctx.mode === "orchestrator") {
 		return resolveOrchestratorInstructions(ctx)
 	}
+	if (ctx.mode === "single") {
+		return resolveSingleModelInstructions()
+	}
 	return ""
 }
 
@@ -248,6 +251,24 @@ function buildRoleAssignmentsSection(roles: ModelRoles, registry?: ModelRegistry
 		),
 	)
 	return `## Your Team\n\n${lines.join("\n")}`
+}
+
+// ---------------------------------------------------------------------------
+// Subagent Mode Instructions
+// ---------------------------------------------------------------------------
+
+const SINGLE_MODEL_INSTRUCTIONS = `## Single-Model Mode
+
+You are running in single-model mode. The promise to the user is that all work in this session runs on the currently selected model. Handle tasks directly yourself unless delegation is clearly beneficial.
+
+You may spawn a subagent with the \`Agent\` tool under these rules:
+
+- You may delegate to the **same** model you are running on without asking the user for permission. Only do this when the user explicitly requests delegation, or when parallel execution would genuinely save time.
+- You may **not** delegate to a different model without first asking the user for approval. If you think a different model would help, briefly explain why and wait for the user to agree.
+- When delegating to the same model, pass your own model ID in the \`model\` parameter.`
+
+function resolveSingleModelInstructions(): string {
+	return SINGLE_MODEL_INSTRUCTIONS
 }
 
 // ---------------------------------------------------------------------------

--- a/src/extensions/orchestration/orchestration-instructions.ts
+++ b/src/extensions/orchestration/orchestration-instructions.ts
@@ -28,7 +28,7 @@ export function resolveOrchestrationInstructions(ctx: OrchestrationInstructionsC
 		return resolveOrchestratorInstructions(ctx)
 	}
 	if (ctx.mode === "single") {
-		return resolveSingleModelInstructions()
+		return resolveSingleModelInstructions(ctx.currentModelId)
 	}
 	return ""
 }
@@ -254,21 +254,16 @@ function buildRoleAssignmentsSection(roles: ModelRoles, registry?: ModelRegistry
 }
 
 // ---------------------------------------------------------------------------
-// Subagent Mode Instructions
+// Single-Model Mode Instructions
 // ---------------------------------------------------------------------------
 
-const SINGLE_MODEL_INSTRUCTIONS = `## Single-Model Mode
+function resolveSingleModelInstructions(currentModelId?: string): string {
+	const modelClause = currentModelId ? ` Your model ID is \`${currentModelId}\`.` : ""
+	return `## Single-Model Mode
 
-You are running in single-model mode. The promise to the user is that all work in this session runs on the currently selected model. Handle tasks directly yourself unless delegation is clearly beneficial.
+You are running in single-model mode.${modelClause} All work in this session runs on the currently selected model. Handle tasks directly yourself unless delegation is clearly beneficial.
 
-You may spawn a subagent with the \`Agent\` tool under these rules:
-
-- You may delegate to the **same** model you are running on without asking the user for permission. Only do this when the user explicitly requests delegation, or when parallel execution would genuinely save time.
-- You may **not** delegate to a different model without first asking the user for approval. If you think a different model would help, briefly explain why and wait for the user to agree.
-- When delegating to the same model, pass your own model ID in the \`model\` parameter.`
-
-function resolveSingleModelInstructions(): string {
-	return SINGLE_MODEL_INSTRUCTIONS
+You may spawn subagents with the \`Agent\` tool for parallel work or to isolate long-running tasks. When you do, you MUST always pass your own model ID in the \`model\` parameter — never delegate to a different model.`
 }
 
 // ---------------------------------------------------------------------------

--- a/src/extensions/prompt-construction/system-prompt.test.ts
+++ b/src/extensions/prompt-construction/system-prompt.test.ts
@@ -360,9 +360,9 @@ describe("buildSystemPrompt", () => {
 			expect(result).not.toContain("Orchestrate the work")
 			expect(result).not.toContain("Model selection for delegation")
 			expect(result).not.toContain("Token budgets")
-			expect(result).not.toContain("Orchestrate the work")
 			expect(result).not.toContain("Sharing context between agents")
 			expect(result).not.toContain("Subagent response protocol")
+			expect(result).toContain("Single-Model Mode")
 		})
 
 		it("includes core sections", () => {


### PR DESCRIPTION
In single-model mode, instruct the agent that:
- All work runs on the currently selected model (the promise to the user)
- Delegation to the same model is allowed without asking
- Delegation to a different model requires explicit user approval
- When delegating to the same model, pass its own model ID