### PR TITLE
fix(web-fetch): honour abort signal on Ctrl+C

### DIFF
--- a/src/extensions/web-fetch/execute-handler.ts
+++ b/src/extensions/web-fetch/execute-handler.ts
@@ -41,7 +41,7 @@ function buildOutput(metadataLines: string[], content: string, truncationNotice:
 	return `${metadataLines.join("\n")}\n\n${content}${truncationNotice}`
 }
 
-export async function executeWebFetch(params: WebFetchParams): Promise<WebFetchResult> {
+export async function executeWebFetch(params: WebFetchParams, signal?: AbortSignal): Promise<WebFetchResult> {
 	const format: OutputFormat = params.format ?? "markdown"
 	const timeoutSeconds = params.timeout != null ? Math.max(0, Math.min(params.timeout, MAX_TIMEOUT_SECONDS)) : undefined
 	const startedAt = Date.now()
@@ -69,7 +69,7 @@ export async function executeWebFetch(params: WebFetchParams): Promise<WebFetchR
 	// Fetch
 	let result: FetchResult
 	try {
-		result = await fetchPage(params.url, { timeoutSeconds, format })
+		result = await fetchPage(params.url, { timeoutSeconds, format, signal })
 	} catch (err: unknown) {
 		const message = err instanceof FetchError ? err.message : err instanceof Error ? err.message : String(err)
 		return errorResult(`Error: ${message}`)

--- a/src/extensions/web-fetch/index.ts
+++ b/src/extensions/web-fetch/index.ts
@@ -57,8 +57,8 @@ export default function webFetchExtension(pi: ExtensionAPI): void {
 			),
 		}),
 
-		async execute(_toolCallId, params) {
-			return executeWebFetch(params)
+		async execute(_toolCallId, params, signal) {
+			return executeWebFetch(params, signal)
 		},
 
 		renderCall(args, theme, context) {

--- a/src/extensions/web-fetch/page-fetcher.ts
+++ b/src/extensions/web-fetch/page-fetcher.ts
@@ -52,7 +52,7 @@ export interface FetchResult {
 export class FetchError extends Error {
 	constructor(
 		message: string,
-		public readonly category: "timeout" | "http" | "network" | "binary" | "too_large" | "unknown",
+		public readonly category: "timeout" | "cancelled" | "http" | "network" | "binary" | "too_large" | "unknown",
 	) {
 		super(message)
 		this.name = "FetchError"
@@ -106,6 +106,10 @@ async function fetchWithPlaywright(
 	const page = await browser.newPage()
 
 	if (options?.signal) {
+		if (options.signal.aborted) {
+			void page.close().catch(() => {})
+			throw new FetchError(`Fetch of "${url}" was cancelled`, "cancelled")
+		}
 		options.signal.addEventListener(
 			"abort",
 			() => {
@@ -218,6 +222,9 @@ async function fetchWithPlaywright(
 		}
 	} catch (err: unknown) {
 		if (err instanceof FetchError) throw err
+		if (options?.signal?.aborted) {
+			throw new FetchError(`Fetch of "${url}" was cancelled`, "cancelled")
+		}
 		const name = err instanceof Error ? err.name : ""
 		const message = err instanceof Error ? err.message : String(err)
 		if (name === "TimeoutError" || message.includes("Timeout") || message.includes("timeout")) {
@@ -268,6 +275,9 @@ async function fetchWithNative(url: string, options?: FetchOptions): Promise<Fet
 	} catch (err: unknown) {
 		clearTimeout(timer)
 		if (err instanceof DOMException && err.name === "AbortError") {
+			if (options?.signal?.aborted) {
+				throw new FetchError(`Fetch of "${url}" was cancelled`, "cancelled")
+			}
 			throw new FetchError(
 				`Timeout: request to "${url}" timed out after ${options?.timeoutSeconds ?? DEFAULT_TIMEOUT_SECONDS} seconds`,
 				"timeout",

--- a/src/extensions/web-fetch/page-fetcher.ts
+++ b/src/extensions/web-fetch/page-fetcher.ts
@@ -63,6 +63,7 @@ export interface FetchOptions {
 	timeoutSeconds?: number
 	/** Requested output format — when "text" and Playwright is active, uses page.textContent(). */
 	format?: "markdown" | "text" | "html"
+	signal?: AbortSignal
 }
 
 function isBinaryContentType(ct: string): boolean {
@@ -103,6 +104,16 @@ async function fetchWithPlaywright(
 ): Promise<FetchResult> {
 	const timeoutMs = (options?.timeoutSeconds ?? DEFAULT_TIMEOUT_SECONDS) * 1000
 	const page = await browser.newPage()
+
+	if (options?.signal) {
+		options.signal.addEventListener(
+			"abort",
+			() => {
+				void page.close().catch(() => {})
+			},
+			{ once: true },
+		)
+	}
 
 	try {
 		const response = await page.goto(url, {
@@ -243,11 +254,12 @@ async function fetchWithNative(url: string, options?: FetchOptions): Promise<Fet
 	const timeoutMs = (options?.timeoutSeconds ?? DEFAULT_TIMEOUT_SECONDS) * 1000
 	const controller = new AbortController()
 	const timer = setTimeout(() => controller.abort(), timeoutMs)
+	const signal = options?.signal ? AbortSignal.any([controller.signal, options.signal]) : controller.signal
 
 	let response: Response
 	try {
 		response = await fetch(url, {
-			signal: controller.signal,
+			signal,
 			redirect: "follow",
 			headers: {
 				Accept: "text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8",


### PR DESCRIPTION
## Description


  - `web_fetch` ignored the framework's `AbortSignal`, so Ctrl+C had no effect during an in-flight fetch
  - Wire the signal through `execute → executeWebFetch → fetchPage`
  - Playwright path: close the page on abort; native fetch path: combine timeout and abort signals via `AbortSignal.any()`

  Follows the same pattern already used by `web_search`.


## Type of Change

<!-- Select all that apply. -->

- [ x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
