### PR TITLE
fix(ferment): stop blocking ferment creation on a synchronous LLM title call

### DIFF
--- a/src/extensions/ferment/command-parser.ts
+++ b/src/extensions/ferment/command-parser.ts
@@ -1,3 +1,5 @@
+import { stripOuterQuotes } from "../../ferment/text.js"
+
 export type FermentCommand =
 	| { type: "interactive" }
 	| { type: "list" }
@@ -15,18 +17,6 @@ export type FermentCommand =
 	| { type: "one-shot"; intent: string }
 	| { type: "new"; title: string }
 	| { type: "unknown"; input: string }
-
-export function stripOuterQuotes(value: string): string {
-	const trimmed = value.trim()
-	if (trimmed.length >= 2) {
-		const first = trimmed[0]
-		const last = trimmed[trimmed.length - 1]
-		if ((first === `"` && last === `"`) || (first === `'` && last === `'`)) {
-			return trimmed.slice(1, -1).trim()
-		}
-	}
-	return trimmed
-}
 
 function parseSwitch(raw: string): FermentCommand {
 	const verb = "switch"

--- a/src/extensions/ferment/commands.test.ts
+++ b/src/extensions/ferment/commands.test.ts
@@ -24,10 +24,6 @@ vi.mock("node:fs", async (importOriginal) => {
 	}
 })
 
-vi.mock("../../ferment/shorten-title.js", () => ({
-	shortenTitle: vi.fn(async (input: string) => input),
-}))
-
 const tipWidgetLocationMock = vi.hoisted(() => ({
 	restore: vi.fn(),
 	set: vi.fn(),

--- a/src/extensions/ferment/commands.test.ts
+++ b/src/extensions/ferment/commands.test.ts
@@ -462,12 +462,10 @@ describe("FermentCommandController", () => {
 		h.runtime.setActive(active)
 		setPendingPlanReview({
 			fermentId: active.id,
-			fermentName: active.name,
 			planMarkdown: "# Plan: Exit Pending State",
 		})
 		setPendingPlanReview({
 			fermentId: other.id,
-			fermentName: other.name,
 			planMarkdown: "# Plan: Other Pending State",
 		})
 		h.runtime.setPendingScope(active.id, { goal: "Goal", successCriteria: "Works", constraints: [] })
@@ -708,12 +706,10 @@ describe("registerFermentCommands", () => {
 		h.runtime.setActive(previous)
 		setPendingPlanReview({
 			fermentId: previous.id,
-			fermentName: previous.name,
 			planMarkdown: "# Plan: Previous Review",
 		})
 		setPendingPlanReview({
 			fermentId: target.id,
-			fermentName: target.name,
 			planMarkdown: "# Plan: Target Review",
 		})
 

--- a/src/extensions/ferment/commands.ts
+++ b/src/extensions/ferment/commands.ts
@@ -187,7 +187,7 @@ export async function startInteractiveFerment({
 	if (!rawIntent) return
 
 	const storage = runtime.getStorage()
-	ctx.ui.setStatus?.("ferment-scoping", "Fermenting · naming…")
+	ctx.ui.setStatus?.("ferment-scoping", "Fermenting · creating…")
 	sendFermentRequestMessage(pi, rawIntent)
 	try {
 		const shortName = await shortenTitle(rawIntent)
@@ -820,7 +820,7 @@ export class FermentCommandController {
 				if (!typed) return { handled: true }
 				resolvedIntent = typed
 			}
-			ctx.ui.setStatus?.("ferment-scoping", "🫧  Fermenting · naming…")
+			ctx.ui.setStatus?.("ferment-scoping", "🫧  Fermenting · creating…")
 			try {
 				// One-shot is non-interactive by definition — only auto-init when the
 				// user opted in via flag or env var. Otherwise skip silently.
@@ -885,7 +885,7 @@ export class FermentCommandController {
 			scopingIntent = typed
 			sendFermentRequestMessage(pi, typed)
 		}
-		ctx.ui.setStatus?.("ferment-scoping", "🫧  Fermenting · naming…")
+		ctx.ui.setStatus?.("ferment-scoping", "🫧  Fermenting · creating…")
 		try {
 			// Interactive path: ui.confirm is available, so ensureGitRepo will ask.
 			// User can decline; ferment still proceeds with no branch/commit info.

--- a/src/extensions/ferment/commands.ts
+++ b/src/extensions/ferment/commands.ts
@@ -1,8 +1,8 @@
 import { writeFileSync } from "node:fs"
 import type { ExtensionAPI, ExtensionCommandContext } from "@earendil-works/pi-coding-agent"
-import { shortenTitle } from "../../ferment/shorten-title.js"
 import { computeStats, serializeStats } from "../../ferment/stats.js"
 import { FermentError } from "../../ferment/store.js"
+import { deriveDraftFermentTitle } from "../../ferment/title.js"
 import { requestSharedFooterRender } from "../shared-footer.js"
 import { pr_bold, pr_dim, pr_orange, pr_success, pr_teal } from "./colors.js"
 import { type FermentCommand, parseFermentCommand } from "./command-parser.js"
@@ -190,7 +190,7 @@ export async function startInteractiveFerment({
 	ctx.ui.setStatus?.("ferment-scoping", "Fermenting · creating…")
 	sendFermentRequestMessage(pi, rawIntent)
 	try {
-		const shortName = await shortenTitle(rawIntent)
+		const shortName = deriveDraftFermentTitle(rawIntent)
 		const f = storage.create(shortName, rawIntent)
 		setActiveFermentAndApplyProfile(pi, runtime, f)
 		appendRefEntry(pi, f.id)
@@ -829,7 +829,7 @@ export class FermentCommandController {
 					autoInit: pi.getFlag?.("init-git") === true || autoInitFromEnv(),
 				})
 				runtime.setContinuationPolicy("automated")
-				const shortName = await shortenTitle(resolvedIntent)
+				const shortName = deriveDraftFermentTitle(resolvedIntent)
 				const f = storage.create(shortName, resolvedIntent)
 				const updated = f
 				setActiveFermentAndApplyProfile(pi, runtime, updated)
@@ -890,7 +890,7 @@ export class FermentCommandController {
 			// Interactive path: ui.confirm is available, so ensureGitRepo will ask.
 			// User can decline; ferment still proceeds with no branch/commit info.
 			await ensureGitRepo({ ui: ctx.ui })
-			const shortName = await shortenTitle(rawName)
+			const shortName = deriveDraftFermentTitle(rawName)
 			const f = storage.create(shortName, rawName)
 			setActiveFermentAndApplyProfile(pi, runtime, f)
 			appendRefEntry(pi, f.id)

--- a/src/extensions/ferment/events.test.ts
+++ b/src/extensions/ferment/events.test.ts
@@ -1,6 +1,9 @@
+import { mkdtempSync } from "node:fs"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
 import type { ExtensionAPI } from "@earendil-works/pi-coding-agent"
 import { afterEach, describe, expect, it, vi } from "vitest"
-import type { FermentEventStore } from "../../ferment/event-store.js"
+import { FermentEventStore } from "../../ferment/event-store.js"
 import { registerFermentEvents } from "./events.js"
 import type { FermentRuntime } from "./runtime.js"
 import { createDefaultFermentRuntime } from "./runtime.js"
@@ -251,5 +254,57 @@ describe("registerFermentEvents", () => {
 		} finally {
 			Reflect.deleteProperty(process.env, "KIMCHI_SUBAGENT")
 		}
+	})
+
+	it("uses the buffered proposal title when draft confirmation happens at turn end", async () => {
+		const storage = new FermentEventStore(mkdtempSync(join(tmpdir(), "ferment-events-title-test-")))
+		const draft = storage.create("Draft Raw Intent")
+		const runtime: FermentRuntime = {
+			...createDefaultFermentRuntime(),
+			getStorage: () => storage,
+		}
+		runtime.setActive(draft)
+		runtime.setPendingScope(draft.id, {
+			title: "Google OAuth Login",
+			goal: "Users can sign in with Google OAuth",
+			successCriteria: "OAuth login works",
+			constraints: [],
+			phases: [{ name: "Build", goal: "Implement OAuth", steps: [{ description: "Add login flow" }] }],
+		})
+		const { handlers, pi } = createPi()
+		registerFermentEvents(pi, runtime)
+		const turnEnd = handlers.get("turn_end")
+		if (!turnEnd) throw new Error("turn_end handler was not registered")
+		const select = vi.fn().mockResolvedValueOnce("Yes, this looks right").mockResolvedValueOnce("✓ Confirm and start")
+		const ctx = {
+			ui: {
+				select,
+				input: vi.fn(),
+				notify: vi.fn(),
+			},
+		}
+
+		await turnEnd(
+			{
+				message: {
+					role: "assistant",
+					content: [{ type: "text", text: "Does this look right?" }],
+				},
+			},
+			ctx,
+		)
+
+		expect(storage.get(draft.id)?.name).toBe("Google OAuth Login")
+		expect(storage.get(draft.id)?.status).toBe("planned")
+		expect(pi.sendMessage).toHaveBeenCalledWith(
+			expect.objectContaining({
+				customType: "ferment_ack",
+				details: expect.objectContaining({
+					text: 'Named ferment "Google OAuth Login" (was "Draft Raw Intent").',
+				}),
+			}),
+			{ triggerTurn: false },
+		)
+		expect(ctx.ui.notify).toHaveBeenCalledWith('Plan saved for "Google OAuth Login". 1 phase(s) ready.')
 	})
 })

--- a/src/extensions/ferment/events.ts
+++ b/src/extensions/ferment/events.ts
@@ -181,7 +181,7 @@ async function maybeRunUserInputDropdown(
 			}
 			edited = result
 		}
-		const outcome = confirmPendingScope(runtime, f.id, edited, "turn_end", f.name, pi)
+		const outcome = confirmPendingScope(runtime, f.id, edited, "turn_end", pending?.title ?? f.name, pi)
 		if (outcome.ok) {
 			ctx.ui.notify?.(
 				`Plan saved for "${outcome.outcome.ferment.name}". ${outcome.outcome.ferment.phases.length} phase(s) ready.`,
@@ -334,12 +334,7 @@ export function registerFermentEvents(pi: ExtensionAPI, runtime: FermentRuntime 
 				autoInit: pi.getFlag?.("init-git") === true || autoInitFromEnv(),
 			})
 			const storage = runtime.getStorage()
-			let shortName: string
-			try {
-				shortName = await shortenTitle(intent)
-			} catch {
-				shortName = intent.length > 60 ? `${intent.slice(0, 57).trimEnd()}...` : intent
-			}
+			const shortName = await shortenTitle(intent)
 			const f = storage.create(shortName, intent)
 			const updated = f
 			runtime.setActive(updated)

--- a/src/extensions/ferment/events.ts
+++ b/src/extensions/ferment/events.ts
@@ -1,6 +1,6 @@
 import type { ExtensionAPI, ExtensionContext } from "@earendil-works/pi-coding-agent"
-import { shortenTitle } from "../../ferment/shorten-title.js"
 import { clearFermentCache } from "../../ferment/store.js"
+import { deriveDraftFermentTitle } from "../../ferment/title.js"
 import { isAgentWorker } from "../agent-worker-context.js"
 import { formatDuration } from "./colors.js"
 import { extractContextualOptions, extractTrailingQuestion } from "./contextual-options.js"
@@ -181,7 +181,7 @@ async function maybeRunUserInputDropdown(
 			}
 			edited = result
 		}
-		const outcome = confirmPendingScope(runtime, f.id, edited, "turn_end", pending?.title ?? f.name, pi)
+		const outcome = confirmPendingScope(runtime, f.id, edited, "turn_end", pi)
 		if (outcome.ok) {
 			ctx.ui.notify?.(
 				`Plan saved for "${outcome.outcome.ferment.name}". ${outcome.outcome.ferment.phases.length} phase(s) ready.`,
@@ -334,7 +334,7 @@ export function registerFermentEvents(pi: ExtensionAPI, runtime: FermentRuntime 
 				autoInit: pi.getFlag?.("init-git") === true || autoInitFromEnv(),
 			})
 			const storage = runtime.getStorage()
-			const shortName = await shortenTitle(intent)
+			const shortName = deriveDraftFermentTitle(intent)
 			const f = storage.create(shortName, intent)
 			const updated = f
 			runtime.setActive(updated)

--- a/src/extensions/ferment/index.test.ts
+++ b/src/extensions/ferment/index.test.ts
@@ -16,10 +16,6 @@ import { getActive, isAutomatedContinuationEnabled, setActive, setContinuationPo
 import { createApplyAndPersist } from "./tool-helpers.js"
 import { completeFerment, scopeFerment } from "./tools/lifecycle.js"
 
-vi.mock("../../ferment/shorten-title.js", () => ({
-	shortenTitle: vi.fn(async (input: string) => input),
-}))
-
 const requestSharedFooterRenderMock = vi.hoisted(() => vi.fn())
 
 vi.mock("../shared-footer.js", () => ({
@@ -783,6 +779,7 @@ describe("fermentExtension question dropdown", () => {
 			runtime,
 			{
 				ferment_id: draft.id,
+				title: "Plan Handoff",
 				goal: "Goal",
 				success_criteria: "Works",
 				constraints: [],

--- a/src/extensions/ferment/index.test.ts
+++ b/src/extensions/ferment/index.test.ts
@@ -859,7 +859,6 @@ describe("fermentExtension question dropdown", () => {
 			})
 			setPendingPlanReview({
 				fermentId: draft.id,
-				fermentName: draft.name,
 				planMarkdown: "# Plan: Deferred Review",
 			})
 
@@ -929,12 +928,10 @@ describe("fermentExtension question dropdown", () => {
 			})
 			setPendingPlanReview({
 				fermentId: firstDraft.id,
-				fermentName: firstDraft.name,
 				planMarkdown: "# Plan: First Deferred Review",
 			})
 			setPendingPlanReview({
 				fermentId: secondDraft.id,
-				fermentName: secondDraft.name,
 				planMarkdown: "# Plan: Second Deferred Review",
 			})
 
@@ -980,7 +977,6 @@ describe("fermentExtension question dropdown", () => {
 			})
 			setPendingPlanReview({
 				fermentId: draft.id,
-				fermentName: draft.name,
 				planMarkdown: "# Plan: Deferred Feedback",
 			})
 
@@ -1042,7 +1038,6 @@ describe("fermentExtension question dropdown", () => {
 			})
 			setPendingPlanReview({
 				fermentId: draft.id,
-				fermentName: draft.name,
 				planMarkdown: "# Plan: Cancelled Review",
 			})
 
@@ -1084,7 +1079,6 @@ describe("fermentExtension question dropdown", () => {
 			})
 			setPendingPlanReview({
 				fermentId: draft.id,
-				fermentName: draft.name,
 				planMarkdown: "# Plan: Failed Confirmation",
 			})
 

--- a/src/extensions/ferment/index.ts
+++ b/src/extensions/ferment/index.ts
@@ -143,7 +143,7 @@ export default function fermentExtension(pi: ExtensionAPI, runtime: FermentRunti
 			if (!isCurrentPendingReview(review)) return
 
 			if (outcome.kind === "start") {
-				const scopeOutcome = confirmPendingScope(runtime, review.fermentId, undefined, "turn_end", review.title, pi)
+				const scopeOutcome = confirmPendingScope(runtime, review.fermentId, undefined, "turn_end", pi)
 				if (!scopeOutcome.ok) {
 					ctx?.ui?.notify?.(`Failed to save plan: ${scopeOutcome.error.message}`, "error")
 					return

--- a/src/extensions/ferment/oneshot.ts
+++ b/src/extensions/ferment/oneshot.ts
@@ -13,6 +13,7 @@ User intent: "${intent}"
 Your task — execute ALL of the following steps WITHOUT pausing to ask the user:
 1. Call scope_ferment with:
    - ferment_id: "${ferment.id}"
+   - title: concise 3-5 word Ferment name derived from the task
    - goal: derived from the user intent
    - success_criteria: what observable outcome proves the goal
    - constraints: any technical constraints implied by the intent

--- a/src/extensions/ferment/plan-review.test.ts
+++ b/src/extensions/ferment/plan-review.test.ts
@@ -83,8 +83,8 @@ describe("plan review pending state", () => {
 	})
 
 	it("returns only the active ferment pending review", () => {
-		setPendingPlanReview({ fermentId: "active", fermentName: "Active", planMarkdown: "# Active" })
-		setPendingPlanReview({ fermentId: "other", fermentName: "Other", planMarkdown: "# Other" })
+		setPendingPlanReview({ fermentId: "active", planMarkdown: "# Active" })
+		setPendingPlanReview({ fermentId: "other", planMarkdown: "# Other" })
 
 		expect(getCurrentPendingPlanReview({ getActiveId: () => "active" } as never)?.fermentId).toBe("active")
 		expect(getCurrentPendingPlanReview({ getActiveId: () => "missing" } as never)).toBeUndefined()

--- a/src/extensions/ferment/plan-review.ts
+++ b/src/extensions/ferment/plan-review.ts
@@ -10,8 +10,6 @@ import { getPromptUi, withWorkingHidden } from "./prompt-ui.js"
 
 export interface PendingPlanReview {
 	fermentId: string
-	fermentName: string
-	title?: string
 	planMarkdown: string
 }
 

--- a/src/extensions/ferment/prompt-block.ts
+++ b/src/extensions/ferment/prompt-block.ts
@@ -40,7 +40,7 @@ function buildPlannerSupplement(f: Ferment, continuationPolicy: ContinuationPoli
 
 ${SCOPING_DISCOVERY_GUIDANCE}
 
-On the first scoping turn after \`/ferment\`, draft \`goal\`/\`success_criteria\`/\`constraints\`/\`assumptions\`/\`phases\` from the user's free-form intent and call \`propose_ferment_scoping\` with all of them in ONE call.
+On the first scoping turn after \`/ferment\`, draft \`title\`/\`goal\`/\`success_criteria\`/\`constraints\`/\`assumptions\`/\`phases\` from the user's free-form intent and call \`propose_ferment_scoping\` with all of them in ONE call. The title is required and should be a concise 3-5 word Ferment name.
 
 Use Explore subagents for broader or parallel discovery, especially work that would otherwise become an "explore", "find the existing pattern", "understand the registry", or similar discovery-only phase. Keep each Explore prompt narrowly scoped to one independent area or question. If an Explore subagent aborts on the ${SCOPING_EXPLORE_TOKEN_BUDGET} token budget, do not retry the same broad task; use any partial result, spawn a narrower replacement only if that missing fact is plan-blocking, otherwise continue with direct targeted reads or record the uncertainty in \`assumptions\`. Do not make discovery-only work a user-approved phase when that discovery is needed to decide what the approved phases should be. The plan you propose should reflect the discovered files, patterns, constraints, and implementation layer.
 

--- a/src/extensions/ferment/scoping-confirmation.test.ts
+++ b/src/extensions/ferment/scoping-confirmation.test.ts
@@ -62,6 +62,49 @@ describe("confirmPendingScope", () => {
 		)
 	})
 
+	it("emits a visible rename acknowledgement when the confirmed title changes", () => {
+		const { runtime, storage } = createRuntime()
+		const pi = { appendEntry: vi.fn(), sendMessage: vi.fn() }
+		const ferment = storage.create("Draft OAuth Task")
+		runtime.setPendingScope(ferment.id, {
+			goal: "Goal",
+			successCriteria: "Works",
+			constraints: [],
+			phases: [{ name: "P1", goal: "Build", steps: [{ description: "Do it" }] }],
+		})
+
+		const result = confirmPendingScope(runtime, ferment.id, undefined, "turn_end", "Google OAuth Login", pi as never)
+
+		expect(result.ok).toBe(true)
+		expect(pi.sendMessage).toHaveBeenCalledWith(
+			expect.objectContaining({
+				customType: "ferment_ack",
+				display: true,
+				details: expect.objectContaining({
+					text: 'Named ferment "Google OAuth Login" (was "Draft OAuth Task").',
+					variant: "ack",
+				}),
+			}),
+			{ triggerTurn: false },
+		)
+	})
+
+	it("preserves the draft name when the confirmed title is blank", () => {
+		const { runtime, storage } = createRuntime()
+		const ferment = storage.create("Draft Name")
+		runtime.setPendingScope(ferment.id, {
+			goal: "Goal",
+			successCriteria: "Works",
+			constraints: [],
+			phases: [{ name: "P1", goal: "Build", steps: [{ description: "Do it" }] }],
+		})
+
+		const result = confirmPendingScope(runtime, ferment.id, undefined, "turn_end", '  ""  ')
+
+		expect(result.ok).toBe(true)
+		if (result.ok) expect(result.outcome.ferment.name).toBe("Draft Name")
+	})
+
 	it("uses explicit phases from propose_ferment_scoping and preserves pending user answers", () => {
 		const { runtime, storage } = createRuntime()
 		const ferment = storage.create("Explicit")

--- a/src/extensions/ferment/scoping-confirmation.test.ts
+++ b/src/extensions/ferment/scoping-confirmation.test.ts
@@ -21,14 +21,15 @@ describe("confirmPendingScope", () => {
 		const { runtime, storage } = createRuntime()
 		const ferment = storage.create("Confirm")
 		runtime.setPendingScope(ferment.id, {
+			title: "Confirmed Title",
 			goal: "Goal",
 			successCriteria: "Works",
 			constraints: ["no regressions"],
 			phases: [{ name: "P1", goal: "Build", steps: [{ description: "Do it" }] }],
 		})
 
-		const first = confirmPendingScope(runtime, ferment.id, undefined, "turn_end", "Confirmed Title")
-		const second = confirmPendingScope(runtime, ferment.id, undefined, "turn_end", "Confirmed Title")
+		const first = confirmPendingScope(runtime, ferment.id, undefined, "turn_end")
+		const second = confirmPendingScope(runtime, ferment.id, undefined, "turn_end")
 
 		expect(first.ok).toBe(true)
 		if (first.ok) {
@@ -47,13 +48,14 @@ describe("confirmPendingScope", () => {
 		const pi = { appendEntry: vi.fn(), sendMessage: vi.fn() }
 		const ferment = storage.create("Confirm And Continue")
 		runtime.setPendingScope(ferment.id, {
+			title: "Confirmed Title",
 			goal: "Goal",
 			successCriteria: "Works",
 			constraints: [],
 			phases: [{ name: "P1", goal: "Build", steps: [{ description: "Do it" }] }],
 		})
 
-		const result = confirmPendingScope(runtime, ferment.id, undefined, "turn_end", "Confirmed Title", pi as never)
+		const result = confirmPendingScope(runtime, ferment.id, undefined, "turn_end", pi as never)
 
 		expect(result.ok).toBe(true)
 		expect(pi.sendMessage).not.toHaveBeenCalledWith(
@@ -67,13 +69,14 @@ describe("confirmPendingScope", () => {
 		const pi = { appendEntry: vi.fn(), sendMessage: vi.fn() }
 		const ferment = storage.create("Draft OAuth Task")
 		runtime.setPendingScope(ferment.id, {
+			title: "Google OAuth Login",
 			goal: "Goal",
 			successCriteria: "Works",
 			constraints: [],
 			phases: [{ name: "P1", goal: "Build", steps: [{ description: "Do it" }] }],
 		})
 
-		const result = confirmPendingScope(runtime, ferment.id, undefined, "turn_end", "Google OAuth Login", pi as never)
+		const result = confirmPendingScope(runtime, ferment.id, undefined, "turn_end", pi as never)
 
 		expect(result.ok).toBe(true)
 		expect(pi.sendMessage).toHaveBeenCalledWith(
@@ -93,13 +96,14 @@ describe("confirmPendingScope", () => {
 		const { runtime, storage } = createRuntime()
 		const ferment = storage.create("Draft Name")
 		runtime.setPendingScope(ferment.id, {
+			title: '  ""  ',
 			goal: "Goal",
 			successCriteria: "Works",
 			constraints: [],
 			phases: [{ name: "P1", goal: "Build", steps: [{ description: "Do it" }] }],
 		})
 
-		const result = confirmPendingScope(runtime, ferment.id, undefined, "turn_end", '  ""  ')
+		const result = confirmPendingScope(runtime, ferment.id, undefined, "turn_end")
 
 		expect(result.ok).toBe(true)
 		if (result.ok) expect(result.outcome.ferment.name).toBe("Draft Name")

--- a/src/extensions/ferment/scoping-confirmation.ts
+++ b/src/extensions/ferment/scoping-confirmation.ts
@@ -1,4 +1,5 @@
 import type { ExtensionAPI } from "@earendil-works/pi-coding-agent"
+import { normalizeFermentTitle } from "../../ferment/shorten-title.js"
 import type { ScopePhaseInput } from "../../ferment/state-machine.js"
 import type { FermentRuntime } from "./runtime.js"
 import { type ApplyOutcome, createApplyAndPersist } from "./tool-helpers.js"
@@ -50,9 +51,10 @@ export function confirmPendingScope(
 
 	runtime.consumeScopingGate(fermentId)
 	const applyAndPersist = createApplyAndPersist(runtime)
+	const previous = runtime.getStorage().get(fermentId)
 	const outcome = applyAndPersist(fermentId, {
 		type: "scope",
-		title,
+		title: normalizeFermentTitle(title),
 		goal: pending.goal,
 		successCriteria: pending.successCriteria,
 		constraints: pending.constraints,
@@ -64,6 +66,18 @@ export function confirmPendingScope(
 
 	if (pi) {
 		runtime.setActive(outcome.ferment)
+		if (previous && previous.name !== outcome.ferment.name) {
+			const text = `Named ferment "${outcome.ferment.name}" (was "${previous.name}").`
+			void pi.sendMessage(
+				{
+					customType: "ferment_ack",
+					content: [{ type: "text", text }],
+					display: true,
+					details: { text, variant: "ack" },
+				},
+				{ triggerTurn: false },
+			)
+		}
 	}
 
 	return { ok: true, outcome }

--- a/src/extensions/ferment/scoping-confirmation.ts
+++ b/src/extensions/ferment/scoping-confirmation.ts
@@ -1,6 +1,6 @@
 import type { ExtensionAPI } from "@earendil-works/pi-coding-agent"
-import { normalizeFermentTitle } from "../../ferment/shorten-title.js"
 import type { ScopePhaseInput } from "../../ferment/state-machine.js"
+import { normalizeFermentTitle } from "../../ferment/title.js"
 import type { FermentRuntime } from "./runtime.js"
 import { type ApplyOutcome, createApplyAndPersist } from "./tool-helpers.js"
 
@@ -21,7 +21,6 @@ export function confirmPendingScope(
 	fermentId: string,
 	phases: ScopePhaseInput[] | undefined,
 	source: ConfirmPendingScopeSource,
-	title?: string,
 	pi?: ExtensionAPI,
 ): ConfirmPendingScopeResult {
 	const pending = runtime.getPendingScope(fermentId)
@@ -54,7 +53,7 @@ export function confirmPendingScope(
 	const previous = runtime.getStorage().get(fermentId)
 	const outcome = applyAndPersist(fermentId, {
 		type: "scope",
-		title: normalizeFermentTitle(title),
+		title: normalizeFermentTitle(pending.title),
 		goal: pending.goal,
 		successCriteria: pending.successCriteria,
 		constraints: pending.constraints,

--- a/src/extensions/ferment/scoping-flow.integration.test.ts
+++ b/src/extensions/ferment/scoping-flow.integration.test.ts
@@ -160,6 +160,7 @@ describe("runScopingFlow → propose_ferment_scoping end-to-end", () => {
 		// Step 2: simulate agent calling propose_ferment_scoping with full payload
 		const proposeScopingPayload = {
 			ferment_id: ferment.id,
+			title: "Google OAuth Login",
 			goal: "Users can sign in with Google OAuth",
 			success_criteria: "E2E test passes for OAuth login flow",
 			constraints: ["No external auth libraries beyond Google SDK"],
@@ -192,6 +193,7 @@ describe("runScopingFlow → propose_ferment_scoping end-to-end", () => {
 		if (!planned) throw new Error("Ferment not found after propose_ferment_scoping")
 
 		expect(planned.status).toBe("planned")
+		expect(planned.name).toBe("Google OAuth Login")
 		expect(planned.phases).toHaveLength(1)
 		expect(planned.scoping.assumptions?.answer).toBe("Google API credentials are already provisioned")
 

--- a/src/extensions/ferment/scoping.test.ts
+++ b/src/extensions/ferment/scoping.test.ts
@@ -56,12 +56,14 @@ describe("attachPendingProposal", () => {
 
 		// Replace with only goal+phases; other fields should be cleared
 		const replaced = runtime.attachPendingProposal(ferment.id, {
+			title: "New Title",
 			goal: "new goal",
 			phases: [{ name: "P2", goal: "Ship", steps: [{ description: "Deploy" }] }],
 		})
 
 		expect(replaced).toBe(true)
 		const pending = runtime.getPendingScope(ferment.id)
+		expect(pending?.title).toBe("New Title")
 		expect(pending?.goal).toBe("new goal")
 		expect(pending?.successCriteria).toBe("")
 		expect(pending?.constraints).toEqual([])
@@ -126,6 +128,7 @@ describe("runScopingFlow", () => {
 		expect(text).toContain("Question policy:")
 		expect(text).toContain("Planning policy:")
 		expect(text).toContain("Output contract:")
+		expect(text).toContain("title is required")
 		expect(text).toContain("ask those questions through the propose_ferment_scoping questions array")
 		expect(text).toContain("questions must be in propose_ferment_scoping.questions")
 		expect(text).toContain("gates array is required")

--- a/src/extensions/ferment/scoping.ts
+++ b/src/extensions/ferment/scoping.ts
@@ -6,7 +6,7 @@
  *   1. `runScopingFlow` shows ONE free-form editor prompt ("What do you want
  *      to do?"). On non-empty input it seeds the pending-scope buffer and fires a
  *      single LLM turn asking the model to call `propose_ferment_scoping` with the
- *      full draft (goal, criteria, constraints, assumptions, phases, and
+ *      full draft (title, goal, criteria, constraints, assumptions, phases, and
  *      optional clarifying questions).
  *
  *   2. `propose_ferment_scoping` (the tool) validates P-gates, replaces the buffer
@@ -49,6 +49,7 @@ function sendScopingBreadcrumb(pi: ExtensionAPI, text: string): void {
 // propose_ferment_scoping on each call. Held until the user confirms via dropdown.
 
 export interface PendingScope {
+	title?: string
 	goal: string
 	successCriteria: string
 	constraints: string[]
@@ -74,6 +75,7 @@ const pendingScopes = new Map<string, PendingScope>()
 export function attachPendingProposal(fermentId: string, partial: AttachPendingProposalPartial): boolean {
 	if (!pendingScopes.has(fermentId)) return false
 	pendingScopes.set(fermentId, {
+		title: partial.title,
 		goal: partial.goal ?? "",
 		successCriteria: partial.successCriteria ?? "",
 		constraints: partial.constraints ?? [],
@@ -198,7 +200,7 @@ Planning policy:
 - Do not split phases just for setup, directory creation, CRUD vs polish, or to make the plan look organized.
 
 Output contract:
-Call propose_ferment_scoping with ferment_id "${f.id}" and a complete payload: goal, success_criteria, constraints, assumptions, 1-7 phases, questions, and gates. Do not ask scoping questions in chat; questions must be in propose_ferment_scoping.questions, or questions: [] when no decision-blocking question remains.
+Call propose_ferment_scoping with ferment_id "${f.id}" and a complete payload: title, goal, success_criteria, constraints, assumptions, 1-7 phases, questions, and gates. title is required; set it to a concise 3-5 word Ferment name derived from the user intent and plan. Do not ask scoping questions in chat; questions must be in propose_ferment_scoping.questions, or questions: [] when no decision-blocking question remains.
 The gates array is required and must contain exactly P1, P2, and P3. Every gate object must include id, verdict, rationale, and evidence. Never emit a partial gates array, never omit rationale or evidence, and never include only P1. If a validation error happens, retry with the full payload again, including questions and all three gates.`,
 				},
 			],

--- a/src/extensions/ferment/tool-schemas.test.ts
+++ b/src/extensions/ferment/tool-schemas.test.ts
@@ -45,6 +45,7 @@ describe("ProposeScopingParams schema", () => {
 	it("accepts radio, checkbox, and text scoping question styles", () => {
 		const payload = {
 			ferment_id: "f-123",
+			title: "Test Ferment",
 			goal: "Do something",
 			phases: minimalPhases(),
 			questions: [
@@ -81,6 +82,7 @@ describe("ProposeScopingParams schema", () => {
 	it("accepts payload without questions (questions is optional)", () => {
 		const payload = {
 			ferment_id: "f-123",
+			title: "Test Ferment",
 			goal: "Do something",
 			phases: minimalPhases(),
 			gates: passingGates(),
@@ -89,9 +91,21 @@ describe("ProposeScopingParams schema", () => {
 		expect(Value.Check(ProposeScopingParams, payload)).toBe(true)
 	})
 
+	it("rejects payload without title", () => {
+		const payload = {
+			ferment_id: "f-123",
+			goal: "Do something",
+			phases: minimalPhases(),
+			gates: passingGates(),
+		}
+
+		expect(Value.Check(ProposeScopingParams, payload)).toBe(false)
+	})
+
 	it("accepts stringified phases/questions as a defensive fallback", () => {
 		const payload = {
 			ferment_id: "f-123",
+			title: "Test Ferment",
 			goal: "Do something",
 			phases: JSON.stringify(minimalPhases()),
 			questions: JSON.stringify([
@@ -113,6 +127,7 @@ describe("ProposeScopingParams schema", () => {
 	it("accepts assumptions as a real string array compatibility fallback", () => {
 		const payload = {
 			ferment_id: "f-123",
+			title: "Test Ferment",
 			goal: "Do something",
 			assumptions: ["Go toolchain is installed", "The current directory is writable"],
 			phases: minimalPhases(),
@@ -125,6 +140,7 @@ describe("ProposeScopingParams schema", () => {
 	it("allows too-few options through schema so runtime can return a focused validation error", () => {
 		const payload = {
 			ferment_id: "f-123",
+			title: "Test Ferment",
 			goal: "Do something",
 			phases: minimalPhases(),
 			questions: [
@@ -143,6 +159,7 @@ describe("ProposeScopingParams schema", () => {
 	it("allows empty options through schema so runtime can return a focused validation error", () => {
 		const payload = {
 			ferment_id: "f-123",
+			title: "Test Ferment",
 			goal: "Do something",
 			phases: minimalPhases(),
 			questions: [
@@ -161,6 +178,7 @@ describe("ProposeScopingParams schema", () => {
 	it("accepts question as the canonical schema field", () => {
 		const payload = {
 			ferment_id: "f-123",
+			title: "Test Ferment",
 			goal: "Do something",
 			phases: minimalPhases(),
 			questions: [
@@ -182,6 +200,7 @@ describe("ProposeScopingParams schema", () => {
 	it("rejects prompt at the schema boundary", () => {
 		const payload = {
 			ferment_id: "f-123",
+			title: "Test Ferment",
 			goal: "Do something",
 			phases: minimalPhases(),
 			questions: [
@@ -212,6 +231,7 @@ describe("ProposeScopingParams schema", () => {
 
 		const payload = {
 			ferment_id: "f-123",
+			title: "Test Ferment",
 			goal: "Do something",
 			phases: minimalPhases(),
 			questions: [question("q1"), question("q2"), question("q3"), question("q4")],
@@ -224,6 +244,7 @@ describe("ProposeScopingParams schema", () => {
 	it("accepts a single phase for simple tasks (minItems: 1)", () => {
 		const payload = {
 			ferment_id: "f-123",
+			title: "Test Ferment",
 			goal: "Do something",
 			phases: minimalPhases(),
 			gates: passingGates(),
@@ -241,6 +262,7 @@ describe("ProposeScopingParams schema", () => {
 
 		const payload = {
 			ferment_id: "f-123",
+			title: "Test Ferment",
 			goal: "Do something",
 			phases,
 			gates: passingGates(),
@@ -252,6 +274,7 @@ describe("ProposeScopingParams schema", () => {
 	it("allows more than 5 options through schema so runtime can return a focused validation error", () => {
 		const payload = {
 			ferment_id: "f-123",
+			title: "Test Ferment",
 			goal: "Do something",
 			phases: minimalPhases(),
 			questions: [
@@ -276,9 +299,21 @@ describe("ProposeScopingParams schema", () => {
 })
 
 describe("ScopeParams schema", () => {
+	it("rejects payload without title", () => {
+		const payload = {
+			ferment_id: "f-123",
+			goal: "Do something",
+			phases: [{ name: "Build", goal: "Implement" }],
+			gates: passingGates(),
+		}
+
+		expect(Value.Check(ScopeParams, payload)).toBe(false)
+	})
+
 	it("accepts assumptions as either text or a string array", () => {
 		const basePayload = {
 			ferment_id: "f-123",
+			title: "Test Ferment",
 			goal: "Do something",
 			phases: [{ name: "Build", goal: "Implement" }],
 			gates: passingGates(),

--- a/src/extensions/ferment/tool-schemas.ts
+++ b/src/extensions/ferment/tool-schemas.ts
@@ -81,7 +81,9 @@ export const PhaseProposalSchema = Type.Object({
 
 export const ScopeParams = Type.Object({
 	ferment_id: Type.String(),
-	title: Type.Optional(Type.String({ description: "A short 3-5 word title for this ferment" })),
+	title: Type.String({
+		description: "Required concise 3-5 word title for this ferment. The host applies it when scoping is saved.",
+	}),
 	goal: Type.String(),
 	success_criteria: Type.Optional(Type.String()),
 	constraints: Type.Optional(Type.Array(Type.String())),
@@ -142,7 +144,10 @@ export const ProposeScopingParams = Type.Object({
 	ferment_id: Type.String({
 		description: "The ferment whose scoping you're proposing.",
 	}),
-	title: Type.Optional(Type.String({ description: "A short 3-5 word title for this ferment." })),
+	title: Type.String({
+		description:
+			"Required concise 3-5 word title for this ferment. The host applies it only after the user confirms/saves this proposal.",
+	}),
 	goal: Type.String({ description: "The ferment goal." }),
 	success_criteria: Type.Optional(Type.String()),
 	constraints: Type.Optional(

--- a/src/extensions/ferment/tools.integration.test.ts
+++ b/src/extensions/ferment/tools.integration.test.ts
@@ -1108,7 +1108,6 @@ describe("propose_ferment_scoping", () => {
 		expect(ctx.ui.custom).not.toHaveBeenCalled()
 		expect(getPendingPlanReview(id)).toMatchObject({
 			fermentId: id,
-			fermentName: "ZeroQ Review",
 			planMarkdown: expect.stringContaining("# Plan: Proposed Ferment"),
 		})
 		expect(getPendingPlanReview(id)?.planMarkdown.includes(`${String.fromCharCode(27)}[`)).toBe(false)

--- a/src/extensions/ferment/tools.integration.test.ts
+++ b/src/extensions/ferment/tools.integration.test.ts
@@ -183,13 +183,20 @@ async function createFerment(name: string, description?: string): Promise<string
 
 async function scopeFerment(
 	id: string,
-	overrides: Partial<{ goal: string; success_criteria: string; constraints: string[]; phases: unknown[] }> = {},
+	overrides: Partial<{
+		title: string
+		goal: string
+		success_criteria: string
+		constraints: string[]
+		phases: unknown[]
+	}> = {},
 ): Promise<void> {
 	// Bypass scoping gate — we test the gate explicitly below.
 	markScopingInteractive(id)
 	markScopingConfirmed(id)
 	const params = {
 		ferment_id: id,
+		title: overrides.title ?? h.runtime.getStorage().get(id)?.name ?? "Scoped Ferment",
 		goal: overrides.goal ?? "Make a thing",
 		success_criteria: overrides.success_criteria ?? "It works",
 		constraints: overrides.constraints ?? [],
@@ -278,6 +285,7 @@ describe("scope_ferment", () => {
 		markScopingConfirmed(id)
 		const result = await h.call("scope_ferment", {
 			ferment_id: id,
+			title: "Scoped Ferment",
 			goal: "Different goal",
 			phases: [],
 			gates: passingPlanGates(),
@@ -291,6 +299,7 @@ describe("scope_ferment", () => {
 		markScopingInteractive(id)
 		const result = await h.call("scope_ferment", {
 			ferment_id: id,
+			title: "Scoped Ferment",
 			goal: "X",
 			phases: [],
 			gates: passingPlanGates(),
@@ -307,6 +316,7 @@ describe("scope_ferment", () => {
 		// Don't confirm — legacy mode is inert and cannot bypass this gate.
 		const result = await h.call("scope_ferment", {
 			ferment_id: id,
+			title: "Scoped Ferment",
 			goal: "X",
 			phases: [{ name: "P1", goal: "G", steps: [{ description: "S" }] }],
 			gates: passingPlanGates(),
@@ -319,6 +329,7 @@ describe("scope_ferment", () => {
 		markScopingConfirmed("nonexistent")
 		const result = await h.call("scope_ferment", {
 			ferment_id: "nonexistent",
+			title: "Missing Ferment",
 			goal: "X",
 			phases: [],
 			gates: passingPlanGates(),
@@ -1043,6 +1054,7 @@ describe("propose_ferment_scoping", () => {
 
 	const basePayload = (ferment_id: string, overrides: Record<string, unknown> = {}) => ({
 		ferment_id,
+		title: "Proposed Ferment",
 		goal: "Build a thing",
 		success_criteria: "Tests pass",
 		constraints: ["no breaking changes"],
@@ -1097,7 +1109,7 @@ describe("propose_ferment_scoping", () => {
 		expect(getPendingPlanReview(id)).toMatchObject({
 			fermentId: id,
 			fermentName: "ZeroQ Review",
-			planMarkdown: expect.stringContaining("# Plan: ZeroQ Review"),
+			planMarkdown: expect.stringContaining("# Plan: Proposed Ferment"),
 		})
 		expect(getPendingPlanReview(id)?.planMarkdown.includes(`${String.fromCharCode(27)}[`)).toBe(false)
 	})

--- a/src/extensions/ferment/tools/lifecycle.test.ts
+++ b/src/extensions/ferment/tools/lifecycle.test.ts
@@ -140,7 +140,6 @@ describe("FermentRuntime pending plan review cleanup", () => {
 		h.runtime.setPendingScope(h.fermentId, { goal: "Goal", successCriteria: "Done", constraints: [] })
 		h.runtime.setPendingPlanReview({
 			fermentId: h.fermentId,
-			fermentName: "Lifecycle Test",
 			planMarkdown: "# Plan",
 		})
 

--- a/src/extensions/ferment/tools/lifecycle.test.ts
+++ b/src/extensions/ferment/tools/lifecycle.test.ts
@@ -159,6 +159,7 @@ describe("scopeFerment", () => {
 			h.runtime,
 			{
 				ferment_id: h.fermentId,
+				title: "Lifecycle Test",
 				goal: "Ship the feature",
 				success_criteria: "Tests pass",
 				constraints: ["Keep it small"],
@@ -183,6 +184,7 @@ describe("scopeFerment", () => {
 			h.runtime,
 			{
 				ferment_id: h.fermentId,
+				title: "Lifecycle Test",
 				goal: "Ship the feature",
 				phases: [{ name: "Build", goal: "Implement", steps: [{ description: "Code it" }] }],
 				gates: passingPlanGates(),
@@ -192,6 +194,25 @@ describe("scopeFerment", () => {
 
 		expect(okText(result)).toContain("scoped and ready")
 		expect(h.storage.get(h.fermentId)?.status).toBe("planned")
+	})
+
+	it("rejects scope_ferment when title is blank", async () => {
+		const h = createHarness()
+
+		const result = await scopeFerment(
+			h.runtime,
+			{
+				ferment_id: h.fermentId,
+				title: "   ",
+				goal: "Ship the feature",
+				phases: [{ name: "Build", goal: "Implement", steps: [{ description: "Code it" }] }],
+				gates: passingPlanGates(),
+			},
+			{ pi: h.pi },
+		)
+
+		expect(errText(result)).toContain('Field "title" must be a non-empty')
+		expect(h.storage.get(h.fermentId)?.status).toBe("draft")
 	})
 
 	it("refuses scoping when agent self-flags a plan gate", async () => {
@@ -211,6 +232,7 @@ describe("scopeFerment", () => {
 			h.runtime,
 			{
 				ferment_id: h.fermentId,
+				title: "Lifecycle Test",
 				goal: "Ship the feature",
 				phases: [{ name: "Build", goal: "Implement" }],
 				gates: flaggedGates,
@@ -231,6 +253,7 @@ describe("scopeFerment", () => {
 			h.runtime,
 			{
 				ferment_id: h.fermentId,
+				title: "Lifecycle Test",
 				goal: "Ship the feature",
 				phases: [{ name: "Build", goal: "Implement" }],
 				gates: incomplete,
@@ -252,6 +275,7 @@ describe("scopeFerment", () => {
 			h.runtime,
 			{
 				ferment_id: h.fermentId,
+				title: "Lifecycle Test",
 				goal: "Ship the feature",
 				phases: [{ name: "Build", goal: "Implement" }],
 				gates: passingPlanGates(),
@@ -272,6 +296,7 @@ describe("scopeFerment", () => {
 			h.runtime,
 			{
 				ferment_id: h.fermentId,
+				title: "Lifecycle Test",
 				goal: "Ship the feature",
 				success_criteria: "Tests pass",
 				assumptions: "k8s cluster exists and is reachable",
@@ -292,6 +317,7 @@ describe("scopeFerment", () => {
 			h.runtime,
 			{
 				ferment_id: h.fermentId,
+				title: "Lifecycle Test",
 				goal: "Ship the feature",
 				phases: [{ name: "Build", goal: "Implement", steps: [{ description: "Code it" }] }],
 				gates: passingPlanGates(),
@@ -334,6 +360,7 @@ describe("propose_ferment_scoping via registerLifecycleTools", () => {
 			"tool-call-1",
 			{
 				ferment_id: h.fermentId,
+				title: "Lifecycle Test",
 				goal: "Ship the feature",
 				phases: [{ name: "Build", goal: "Implement", steps: [{ description: "Code it" }] }],
 				questions: [
@@ -357,6 +384,27 @@ describe("propose_ferment_scoping via registerLifecycleTools", () => {
 		expect(errText(result)).not.toContain("questions.0.question")
 	})
 
+	it("rejects propose_ferment_scoping when title is blank", async () => {
+		const { h, execute } = createProposeHarness()
+
+		const result = await execute(
+			"tool-call-1",
+			{
+				ferment_id: h.fermentId,
+				title: '  ""  ',
+				goal: "Ship the feature",
+				phases: [{ name: "Build", goal: "Implement", steps: [{ description: "Code it" }] }],
+				questions: [],
+				gates: passingPlanGates(),
+			},
+			undefined,
+			undefined,
+			{ ui: {} },
+		)
+
+		expect(errText(result)).toContain('Field "title" must be a non-empty')
+	})
+
 	it("rejects prompt because question is the only public question text field", async () => {
 		const { h, execute } = createProposeHarness()
 
@@ -364,6 +412,7 @@ describe("propose_ferment_scoping via registerLifecycleTools", () => {
 			"tool-call-1",
 			{
 				ferment_id: h.fermentId,
+				title: "Lifecycle Test",
 				goal: "Ship the feature",
 				phases: [{ name: "Build", goal: "Implement", steps: [{ description: "Code it" }] }],
 				questions: [
@@ -393,6 +442,7 @@ describe("propose_ferment_scoping via registerLifecycleTools", () => {
 			"tool-call-1",
 			{
 				ferment_id: h.fermentId,
+				title: "Lifecycle Test",
 				goal: "Ship the feature",
 				phases: [{ name: "Build", goal: "Implement", steps: [{ description: "Code it" }] }],
 				questions: [
@@ -423,6 +473,7 @@ describe("propose_ferment_scoping via registerLifecycleTools", () => {
 			"tool-call-1",
 			{
 				ferment_id: h.fermentId,
+				title: "Lifecycle Test",
 				goal: "Ship the feature",
 				phases: [{ name: "Build", goal: "Implement", steps: [{ description: "Code it" }] }],
 				questions: [

--- a/src/extensions/ferment/tools/lifecycle.ts
+++ b/src/extensions/ferment/tools/lifecycle.ts
@@ -10,8 +10,8 @@
 
 import type { ExtensionAPI } from "@earendil-works/pi-coding-agent"
 import type { Static } from "typebox"
-import { normalizeFermentTitle } from "../../../ferment/shorten-title.js"
 import type { Command, ScopePhaseInput } from "../../../ferment/state-machine.js"
+import { normalizeFermentTitle } from "../../../ferment/title.js"
 import {
 	DEFAULT_SCOPING_QUESTION_TYPE,
 	type Grade,
@@ -362,8 +362,7 @@ function validateScopingQuestions(questions: ScopingQuestion[]): string | null {
 	return null
 }
 
-export function buildPlanMarkdown(fermentName: string, params: NormalizedProposeScopingArgs): string {
-	const planTitle = params.title ?? fermentName
+export function buildPlanMarkdown(params: NormalizedProposeScopingArgs): string {
 	const phaseBlocks = params.phases.map((p, i) => {
 		const goalLines = wrapText(p.goal, 86)
 		const stepLines = (p.steps ?? []).map((s, j) => renderStep(j + 1, s.description)).join("\n")
@@ -376,7 +375,7 @@ export function buildPlanMarkdown(fermentName: string, params: NormalizedPropose
 			.join("\n")
 	})
 	return [
-		`# Plan: ${planTitle}`,
+		`# Plan: ${params.title}`,
 		"",
 		renderWrapped("## Goal", params.goal),
 		"",
@@ -739,7 +738,7 @@ ${renderGateGuidance("scope_ferment")}`,
 			})
 
 			// 4. Build clean markdown for final/headless tool output and local review UI.
-			const planEntry = buildPlanMarkdown(ferment.name, params)
+			const planEntry = buildPlanMarkdown(params)
 			const formatPlanEntry = (suffix?: string): string => (suffix ? `${planEntry}\n\n${suffix}` : planEntry)
 			const planToolOk = (message: string, options: { includePlan?: boolean; suffix?: string } = {}) =>
 				toolOk(options.includePlan ? `${formatPlanEntry(options.suffix)}\n\n${message}` : message)
@@ -753,7 +752,6 @@ ${renderGateGuidance("scope_ferment")}`,
 						params.ferment_id,
 						params.phases,
 						"propose_ferment_scoping",
-						params.title,
 						pi,
 					)
 					if (!scopeOutcome.ok) return failedToolResult(scopeOutcome.error, ferment)
@@ -782,7 +780,6 @@ ${renderGateGuidance("scope_ferment")}`,
 						params.ferment_id,
 						params.phases,
 						"propose_ferment_scoping",
-						params.title,
 						pi,
 					)
 					if (!scopeOutcome.ok) return failedToolResult(scopeOutcome.error, ferment)
@@ -797,8 +794,6 @@ ${renderGateGuidance("scope_ferment")}`,
 
 				runtime.setPendingPlanReview({
 					fermentId: params.ferment_id,
-					fermentName: ferment.name,
-					title: params.title,
 					planMarkdown: planEntry,
 				})
 				return planToolOk("Plan ready for review. The review dialog will open when this turn finishes.")

--- a/src/extensions/ferment/tools/lifecycle.ts
+++ b/src/extensions/ferment/tools/lifecycle.ts
@@ -10,6 +10,7 @@
 
 import type { ExtensionAPI } from "@earendil-works/pi-coding-agent"
 import type { Static } from "typebox"
+import { normalizeFermentTitle } from "../../../ferment/shorten-title.js"
 import type { Command, ScopePhaseInput } from "../../../ferment/state-machine.js"
 import {
 	DEFAULT_SCOPING_QUESTION_TYPE,
@@ -68,6 +69,8 @@ type ScopingAnswer = {
 }
 
 const SCOPING_STATUS_KEY = "ferment-scoping"
+const TITLE_REQUIRED_ERROR =
+	'Field "title" must be a non-empty concise 3-5 word title. Retry with the full payload including title.'
 
 export interface LifecycleExecutionContext {
 	pi: ExtensionAPI
@@ -312,6 +315,8 @@ function normalizeScopingQuestionType(
 }
 
 function normalizeProposeScopingParams(params: ProposeScopingArgs): NormalizeProposeScopingResult {
+	const title = normalizeFermentTitle(params.title)
+	if (!title) return { ok: false, error: toolErr(TITLE_REQUIRED_ERROR) }
 	const constraints = normalizeStringArray(params.constraints, "constraints")
 	if (typeof constraints === "string") return { ok: false, error: toolErr(constraints) }
 	const phases = normalizePhases(params.phases)
@@ -320,7 +325,14 @@ function normalizeProposeScopingParams(params: ProposeScopingArgs): NormalizePro
 	if (typeof questions === "string") return { ok: false, error: toolErr(questions) }
 	return {
 		ok: true,
-		params: { ...params, constraints, assumptions: normalizeAssumptions(params.assumptions), phases, questions },
+		params: {
+			...params,
+			title,
+			constraints,
+			assumptions: normalizeAssumptions(params.assumptions),
+			phases,
+			questions,
+		},
 	}
 }
 
@@ -351,6 +363,7 @@ function validateScopingQuestions(questions: ScopingQuestion[]): string | null {
 }
 
 export function buildPlanMarkdown(fermentName: string, params: NormalizedProposeScopingArgs): string {
+	const planTitle = params.title ?? fermentName
 	const phaseBlocks = params.phases.map((p, i) => {
 		const goalLines = wrapText(p.goal, 86)
 		const stepLines = (p.steps ?? []).map((s, j) => renderStep(j + 1, s.description)).join("\n")
@@ -363,7 +376,7 @@ export function buildPlanMarkdown(fermentName: string, params: NormalizedPropose
 			.join("\n")
 	})
 	return [
-		`# Plan: ${fermentName}`,
+		`# Plan: ${planTitle}`,
 		"",
 		renderWrapped("## Goal", params.goal),
 		"",
@@ -417,6 +430,8 @@ export async function scopeFerment(
 	{ pi }: LifecycleExecutionContext,
 ): Promise<ToolResult> {
 	const applyAndPersist = createApplyAndPersist(runtime)
+	const title = normalizeFermentTitle(params.title)
+	if (!title) return toolErr(TITLE_REQUIRED_ERROR)
 
 	// Plan-scope gate validation runs BEFORE any state mutation. The agent
 	// must declare verifiable success signals (P1), composition (P2), and
@@ -443,7 +458,7 @@ export async function scopeFerment(
 			[
 				`Cannot call scope_ferment for interactive ferment "${params.ferment_id}" before host confirmation.`,
 				pendingHint,
-				"Retry by calling propose_ferment_scoping with the full valid payload: goal, success_criteria, constraints, assumptions, phases, questions, and gates.",
+				"Retry by calling propose_ferment_scoping with the full valid payload: title, goal, success_criteria, constraints, assumptions, phases, questions, and gates.",
 				"If a previous propose_ferment_scoping call failed validation, fix that schema error and re-emit the same plan.",
 				"Do not summarize the plan in chat. Do not call scope_ferment directly.",
 			].join("\n"),
@@ -457,7 +472,7 @@ export async function scopeFerment(
 
 	const cmd: Command = {
 		type: "scope",
-		title: params.title,
+		title,
 		goal: params.goal,
 		successCriteria: params.success_criteria,
 		constraints: params.constraints,
@@ -660,7 +675,7 @@ export function registerLifecycleTools(pi: ExtensionAPI, runtime: FermentRuntime
 	pi.registerTool({
 		name: "propose_ferment_scoping",
 		label: "Propose Scoping",
-		description: `Emit the full scoping draft: goal, criteria, constraints, assumptions, 1-7 phases, questions, and gates. If the agent has decision-blocking scoping questions, they must be included in the questions array in this tool call; each question should use the canonical field name question for the user-visible question sentence; do not ask scoping questions in chat after calling this tool. Use questions: [] when no decision-blocking question remains. Questions pause planning; after answers, re-emit the updated proposal with questions: []. If questions is non-empty, keep phases provisional and answer-agnostic. Every call must include the full gates array: exactly P1, P2, and P3, each with id, verdict, rationale, and evidence. Partial gates are rejected. Prefer one phase for simple tasks and assumptions over default-choice questions.
+		description: `Emit the full scoping draft: title, goal, criteria, constraints, assumptions, 1-7 phases, questions, and gates. title is required and must be a concise 3-5 word Ferment name. If the agent has decision-blocking scoping questions, they must be included in the questions array in this tool call; each question should use the canonical field name question for the user-visible question sentence; do not ask scoping questions in chat after calling this tool. Use questions: [] when no decision-blocking question remains. Questions pause planning; after answers, re-emit the updated proposal with questions: []. If questions is non-empty, keep phases provisional and answer-agnostic. Every call must include the full gates array: exactly P1, P2, and P3, each with id, verdict, rationale, and evidence. Partial gates are rejected. Prefer one phase for simple tasks and assumptions over default-choice questions.
 
 ${renderGateGuidance("scope_ferment")}`,
 		parameters: ProposeScopingParams,
@@ -962,7 +977,7 @@ ${renderGateGuidance("scope_ferment")}`,
 	pi.registerTool({
 		name: "scope_ferment",
 		label: "Scope Ferment",
-		description: `Save scoping answers and transition ferment from draft to planned. In interactive scoping, the harness gates this call until the user has confirmed the proposed plan via TUI dropdown. You must produce verdicts for the three plan-scope gates below. A "flag" verdict refuses scoping.
+		description: `Save scoping answers and transition ferment from draft to planned. title is required and must be a concise 3-5 word Ferment name. In interactive scoping, the harness gates this call until the user has confirmed the proposed plan via TUI dropdown. You must produce verdicts for the three plan-scope gates below. A "flag" verdict refuses scoping.
 
 ${renderGateGuidance("scope_ferment")}`,
 		parameters: ScopeParams,

--- a/src/ferment/event-mapper.ts
+++ b/src/ferment/event-mapper.ts
@@ -111,6 +111,9 @@ export function commandToEvents(cmd: Command, pre: Ferment, post: Ferment, ctx: 
 			) {
 				b.push("scoping_assumptions_set", { assumptions: post.scoping.assumptions })
 			}
+			if (pre.name !== post.name) {
+				b.push("ferment_renamed", { name: post.name })
+			}
 			if (pre.status !== post.status && post.status === "planned") {
 				b.push("ferment_planned", {})
 			}

--- a/src/ferment/shorten-title.test.ts
+++ b/src/ferment/shorten-title.test.ts
@@ -1,0 +1,35 @@
+import { afterEach, describe, expect, it, vi } from "vitest"
+import { normalizeFermentTitle, shortenTitle } from "./shorten-title.js"
+
+afterEach(() => {
+	vi.restoreAllMocks()
+})
+
+describe("shortenTitle", () => {
+	it("derives a deterministic local title without calling fetch", async () => {
+		const fetchSpy = vi.spyOn(globalThis, "fetch")
+
+		await expect(shortenTitle("  Build   OAuth Login  ")).resolves.toBe("Build OAuth Login")
+
+		expect(fetchSpy).not.toHaveBeenCalled()
+	})
+
+	it("normalizes model-proposed titles", () => {
+		expect(normalizeFermentTitle('  "Build   OAuth Login"  ')).toBe("Build OAuth Login")
+		expect(normalizeFermentTitle("   ")).toBeUndefined()
+		expect(normalizeFermentTitle('""')).toBeUndefined()
+	})
+
+	it("truncates long titles at a word boundary", () => {
+		const title = normalizeFermentTitle(
+			"Build a complete OAuth login and account linking migration with rollout safeguards",
+		)
+
+		expect(title).toBe("Build a complete OAuth login and account linking migration")
+		expect(title?.length).toBeLessThanOrEqual(60)
+	})
+
+	it("falls back for empty draft intents", async () => {
+		await expect(shortenTitle("   ")).resolves.toBe("Untitled Ferment")
+	})
+})

--- a/src/ferment/shorten-title.ts
+++ b/src/ferment/shorten-title.ts
@@ -1,59 +1,38 @@
-import { loadConfig } from "../config.js"
+const MAX_TITLE_LENGTH = 60
 
-const SYSTEM_PROMPT =
-	"You are a title generator. Respond with ONLY a short title. 1-5 words, no quotes, no explanation, no markdown."
+function stripOuterTitleQuotes(value: string): string {
+	const trimmed = value.trim()
+	if (trimmed.length >= 2) {
+		const first = trimmed[0]
+		const last = trimmed[trimmed.length - 1]
+		if ((first === `"` && last === `"`) || (first === `'` && last === `'`) || (first === "`" && last === "`")) {
+			return trimmed.slice(1, -1).trim()
+		}
+	}
+	return trimmed
+}
 
-/** Deterministic fallback when LLM is unavailable. */
-function autoShortTitle(name: string): string {
-	const max = 35
-	const normalized = name.replace(/\s+/g, " ").trim()
-	if (normalized.length <= max) return normalized
-	const truncated = normalized.slice(0, max)
+function truncateTitle(value: string): string {
+	if (value.length <= MAX_TITLE_LENGTH) return value
+	const truncated = value.slice(0, MAX_TITLE_LENGTH)
 	const lastSpace = truncated.lastIndexOf(" ")
 	return (lastSpace > 0 ? truncated.slice(0, lastSpace) : truncated).trim()
 }
 
+export function normalizeFermentTitle(value: string | undefined): string | undefined {
+	const stripped = stripOuterTitleQuotes(value ?? "")
+	const normalized = stripped.replace(/\s+/g, " ").trim()
+	if (!normalized) return undefined
+	return truncateTitle(normalized)
+}
+
 /**
- * Ask a cheap LLM to generate a short title for the raw user intent.
- * Falls back to deterministic truncation on any error.
+ * Derive a stable draft title without calling a model.
+ *
+ * LLM naming happens later through `propose_ferment_scoping.title`, using the
+ * active Pi turn and normal tool contract. Draft creation must stay local so a
+ * cosmetic title can never block Ferment startup.
  */
 export async function shortenTitle(rawIntent: string): Promise<string> {
-	const config = loadConfig()
-	const apiKey = config.apiKey || process.env.KIMCHI_API_KEY || ""
-
-	if (!apiKey) {
-		return autoShortTitle(rawIntent)
-	}
-
-	try {
-		const response = await fetch(`${config.llmEndpoint}/chat/completions`, {
-			method: "POST",
-			headers: {
-				"Content-Type": "application/json",
-				Authorization: `Bearer ${apiKey}`,
-			},
-			body: JSON.stringify({
-				model: "nemotron-3-super-fp4",
-				messages: [
-					{ role: "system", content: SYSTEM_PROMPT },
-					{ role: "user", content: `Short title for: "${rawIntent}"` },
-				],
-				max_tokens: 20,
-				temperature: 0,
-			}),
-		})
-
-		if (!response.ok) {
-			return autoShortTitle(rawIntent)
-		}
-
-		const data = (await response.json()) as {
-			choices?: Array<{ message?: { content?: string } }>
-		}
-		const title = data.choices?.[0]?.message?.content?.trim() ?? ""
-		if (title.length > 0) return title
-		return autoShortTitle(rawIntent)
-	} catch {
-		return autoShortTitle(rawIntent)
-	}
+	return normalizeFermentTitle(rawIntent) ?? "Untitled Ferment"
 }

--- a/src/ferment/text.ts
+++ b/src/ferment/text.ts
@@ -1,0 +1,11 @@
+export function stripOuterQuotes(value: string): string {
+	const trimmed = value.trim()
+	if (trimmed.length >= 2) {
+		const first = trimmed[0]
+		const last = trimmed[trimmed.length - 1]
+		if ((first === `"` && last === `"`) || (first === `'` && last === `'`) || (first === "`" && last === "`")) {
+			return trimmed.slice(1, -1).trim()
+		}
+	}
+	return trimmed
+}

--- a/src/ferment/title.test.ts
+++ b/src/ferment/title.test.ts
@@ -1,15 +1,15 @@
 import { afterEach, describe, expect, it, vi } from "vitest"
-import { normalizeFermentTitle, shortenTitle } from "./shorten-title.js"
+import { deriveDraftFermentTitle, normalizeFermentTitle } from "./title.js"
 
 afterEach(() => {
 	vi.restoreAllMocks()
 })
 
-describe("shortenTitle", () => {
-	it("derives a deterministic local title without calling fetch", async () => {
+describe("deriveDraftFermentTitle", () => {
+	it("derives a deterministic local title without calling fetch", () => {
 		const fetchSpy = vi.spyOn(globalThis, "fetch")
 
-		await expect(shortenTitle("  Build   OAuth Login  ")).resolves.toBe("Build OAuth Login")
+		expect(deriveDraftFermentTitle("  Build   OAuth Login  ")).toBe("Build OAuth Login")
 
 		expect(fetchSpy).not.toHaveBeenCalled()
 	})
@@ -29,7 +29,7 @@ describe("shortenTitle", () => {
 		expect(title?.length).toBeLessThanOrEqual(60)
 	})
 
-	it("falls back for empty draft intents", async () => {
-		await expect(shortenTitle("   ")).resolves.toBe("Untitled Ferment")
+	it("falls back for empty draft intents", () => {
+		expect(deriveDraftFermentTitle("   ")).toBe("Untitled Ferment")
 	})
 })

--- a/src/ferment/title.ts
+++ b/src/ferment/title.ts
@@ -1,16 +1,6 @@
-const MAX_TITLE_LENGTH = 60
+import { stripOuterQuotes } from "./text.js"
 
-function stripOuterTitleQuotes(value: string): string {
-	const trimmed = value.trim()
-	if (trimmed.length >= 2) {
-		const first = trimmed[0]
-		const last = trimmed[trimmed.length - 1]
-		if ((first === `"` && last === `"`) || (first === `'` && last === `'`) || (first === "`" && last === "`")) {
-			return trimmed.slice(1, -1).trim()
-		}
-	}
-	return trimmed
-}
+const MAX_TITLE_LENGTH = 60
 
 function truncateTitle(value: string): string {
 	if (value.length <= MAX_TITLE_LENGTH) return value
@@ -20,7 +10,7 @@ function truncateTitle(value: string): string {
 }
 
 export function normalizeFermentTitle(value: string | undefined): string | undefined {
-	const stripped = stripOuterTitleQuotes(value ?? "")
+	const stripped = stripOuterQuotes(value ?? "")
 	const normalized = stripped.replace(/\s+/g, " ").trim()
 	if (!normalized) return undefined
 	return truncateTitle(normalized)
@@ -33,6 +23,6 @@ export function normalizeFermentTitle(value: string | undefined): string | undef
  * active Pi turn and normal tool contract. Draft creation must stay local so a
  * cosmetic title can never block Ferment startup.
  */
-export async function shortenTitle(rawIntent: string): Promise<string> {
+export function deriveDraftFermentTitle(rawIntent: string): string {
 	return normalizeFermentTitle(rawIntent) ?? "Untitled Ferment"
 }


### PR DESCRIPTION
## Description

shortenTitle called the LLM chat-completions endpoint directly with no timeout, so a slow or unreachable endpoint could hang ferment creation — a critical path that must never stall on a cosmetic title.

Replace it with deterministic local shortening for the draft name, and move LLM-quality naming to propose_ferment_scoping/scope_ferment via a now-required `title` field applied only after the plan is confirmed. The proposed title is threaded through the pending-scope buffer and every confirmation path, and a ferment_renamed event plus a visible rename ack are emitted when the name changes.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
