### PR TITLE
fix: tip positioning to be always directly above editor

### DIFF
--- a/src/extensions/agents/ui/agent-widget.ts
+++ b/src/extensions/agents/ui/agent-widget.ts
@@ -3,6 +3,7 @@
  */
 
 import { truncateToWidth } from "@earendil-works/pi-tui"
+import { remountTipWidget } from "../../tips/index.js"
 import type { AgentManager } from "../manager/agent-manager.js"
 import { type LifetimeUsage, type SessionLike, getLifetimeTotal, getSessionContextPercent } from "../manager/usage.js"
 import { getConfig } from "../personas/agent-types.js"
@@ -432,6 +433,9 @@ export class AgentWidget {
 				{ placement: "aboveEditor" },
 			)
 			this.widgetRegistered = true
+			// Re-insert tip widget after agents so it renders directly above the editor
+			// (framework renders aboveEditor widgets in Map insertion order).
+			remountTipWidget()
 		} else {
 			;(this.tui as { requestRender?(): void } | undefined)?.requestRender?.()
 		}

--- a/src/extensions/tips/index.ts
+++ b/src/extensions/tips/index.ts
@@ -12,6 +12,7 @@ export type TipWidgetLocation = VisibleTipWidgetLocation | "hidden"
 const DEFAULT_TIP_WIDGET_LOCATION: TipWidgetLocation = "aboveEditor"
 let tipWidgetLocation: TipWidgetLocation = DEFAULT_TIP_WIDGET_LOCATION
 let onLocationChange: (() => void) | undefined
+let onRemountRequest: (() => void) | undefined
 
 export function setTipWidgetLocation(location: TipWidgetLocation): () => void {
 	const previous = tipWidgetLocation
@@ -40,6 +41,10 @@ function onTipWidgetLocationChange(listener: () => void): () => void {
 	return () => {
 		if (onLocationChange === listener) onLocationChange = undefined
 	}
+}
+
+export function remountTipWidget(): void {
+	onRemountRequest?.()
 }
 
 export interface TipsExtensionOptions {
@@ -115,6 +120,12 @@ export default function tipsExtension(options: TipsExtensionOptions = {}): Exten
 			unregisterLocationChange = onTipWidgetLocationChange(() => {
 				if (activeCtx) updateWidget(activeCtx)
 			})
+			onRemountRequest = () => {
+				if (activeCtx && widgetMounted) {
+					unmountWidget()
+					mountWidget(activeCtx)
+				}
+			}
 			activeCtx = ctx
 
 			updateWidget(ctx)
@@ -132,6 +143,7 @@ export default function tipsExtension(options: TipsExtensionOptions = {}): Exten
 			unregisterGeneral = undefined
 			unregisterLocationChange?.()
 			unregisterLocationChange = undefined
+			onRemountRequest = undefined
 		})
 	}
 }

--- a/src/extensions/tips/tip-row.test.ts
+++ b/src/extensions/tips/tip-row.test.ts
@@ -58,10 +58,10 @@ describe("TipRow", () => {
 		expect(wideLine).toBe(narrowerLine)
 	})
 
-	it("renders the Tip label with success styling", () => {
+	it("renders the Tip label with muted styling", () => {
 		const [line] = renderTipRow(tip, theme(), 120)
 
-		expect(line).toContain("\x1b[32mTip:\x1b[39m")
+		expect(line).toContain("\x1b[90mTip:\x1b[39m")
 	})
 
 	it("renders nothing when no tip is selected", () => {
@@ -90,7 +90,7 @@ describe("TipRow", () => {
 	it("renders a standalone tip message with the shared styling", () => {
 		const [line] = renderTipText("Use `/ferment` anytime.", theme(), 120)
 
-		expect(line).toContain("\x1b[32mTip:\x1b[39m")
+		expect(line).toContain("\x1b[90mTip:\x1b[39m")
 		expect(line).toContain("\x1b[36m/ferment\x1b[39m")
 		expect(line).not.toContain("`")
 	})

--- a/src/extensions/tips/tip-row.ts
+++ b/src/extensions/tips/tip-row.ts
@@ -35,7 +35,7 @@ export function renderTipText(message: string, theme: Theme, width: number): str
 }
 
 function formatTipContent(message: string, theme: Theme): string {
-	return `${theme.fg("success", "Tip:")} ${formatTipMessage(message, theme)}`
+	return `${theme.fg("muted", "Tip:")} ${formatTipMessage(message, theme)}`
 }
 
 function formatTipMessage(message: string, theme: Theme): string {


### PR DESCRIPTION
## Description

1. Ensure that agents are always above tips, and tips stay always directly above the editor - regardless of registration timing.

2. Make tip less stand out visually by graying out the "Tip:" prefix.

<img width="1096" height="221" alt="Screenshot 2026-05-25 at 23 11 39" src="https://github.com/user-attachments/assets/045babed-3423-4785-bda3-ec9579b3f996" />


## Type of Change

<!-- Select all that apply. -->

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
