### PR TITLE
feat(terminal-bench): Forward harbor skills_dir to kimchi

### DIFF
--- a/benchmark/terminal-bench-2/src/kimchi_agent/agent.py
+++ b/benchmark/terminal-bench-2/src/kimchi_agent/agent.py
@@ -36,6 +36,7 @@ CONTAINER_MAIN_SESSION = f"{CONTAINER_SESSIONS_DIR}/main.jsonl"
 CONTAINER_AGENT_PGID_FILE = f"{CONTAINER_LOGS_DIR}/kimchi-agent.pgid"
 CONTAINER_HARNESS_SETTINGS_DIR = "~/.config/kimchi/harness"
 CONTAINER_HARNESS_SETTINGS = f"{CONTAINER_HARNESS_SETTINGS_DIR}/settings.json"
+CONTAINER_HARNESS_SKILLS_DIR = f"{CONTAINER_HARNESS_SETTINGS_DIR}/skills"
 KIMCHI_API_KEY_ENV = "KIMCHI_API_KEY"
 
 
@@ -263,6 +264,9 @@ class Kimchi(BaseInstalledAgent):
         multi_model_settings = self._multi_model_settings_command()
         if multi_model_settings:
             parts.append(multi_model_settings)
+        skills_registration = self._skills_registration_command()
+        if skills_registration:
+            parts.append(skills_registration)
 
         parts.append(
             # Enable job control so the backgrounded kimchi pipeline gets a
@@ -300,6 +304,15 @@ class Kimchi(BaseInstalledAgent):
         return (
             f"mkdir -p {CONTAINER_HARNESS_SETTINGS_DIR} && "
             f"printf '%s\\n' {shlex.quote(settings_json)} > {CONTAINER_HARNESS_SETTINGS}"
+        )
+
+    def _skills_registration_command(self) -> str:
+        if not self.skills_dir:
+            return ""
+
+        return (
+            f"mkdir -p {CONTAINER_HARNESS_SKILLS_DIR} && "
+            f"{{ cp -a {shlex.quote(self.skills_dir)}/. {CONTAINER_HARNESS_SKILLS_DIR}/ || true; }}"
         )
 
     def _kimchi_command(self, cli_flags: str) -> str:

--- a/benchmark/terminal-bench-2/src/kimchi_agent/agent_test.py
+++ b/benchmark/terminal-bench-2/src/kimchi_agent/agent_test.py
@@ -7,7 +7,7 @@ from unittest.mock import patch
 
 from harbor.models.agent.context import AgentContext
 
-from kimchi_agent.agent import CONTAINER_AGENT_PGID_FILE, Kimchi
+from kimchi_agent.agent import CONTAINER_AGENT_PGID_FILE, CONTAINER_HARNESS_SKILLS_DIR, Kimchi
 
 
 class RecordingKimchi(Kimchi):
@@ -113,6 +113,38 @@ class KimchiHarnessTest(unittest.IsolatedAsyncioTestCase):
                 await agent.run("hello", object(), AgentContext())
 
             self.assertNotIn("--model", agent.agent_commands[0])
+
+    async def test_run_copies_harbor_skills_dir_into_kimchi_harness_skills_dir(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            agent = RecordingKimchi(
+                logs_dir=Path(tmp) / "jobs" / "run-1" / "task__trial" / "agent",
+                model_name="kimchi-dev/kimi-k2.6",
+                skills_dir="/task skills",
+            )
+
+            with self.assertRaises(asyncio.CancelledError):
+                await agent.run("hello", object(), AgentContext())
+
+            command = agent.agent_commands[0]
+            self.assertIn(f"mkdir -p {CONTAINER_HARNESS_SKILLS_DIR}", command)
+            self.assertIn(f"cp -a '/task skills'/. {CONTAINER_HARNESS_SKILLS_DIR}/", command)
+            self.assertNotIn("2>/dev/null", agent._skills_registration_command())
+            self.assertIn(f"{agent._skills_registration_command()} && set -m", command)
+            self.assertIn("--model kimchi-dev/kimi-k2.6", command)
+
+    async def test_run_omits_skills_copy_when_no_harbor_skills_dir(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            agent = RecordingKimchi(
+                logs_dir=Path(tmp) / "jobs" / "run-1" / "task__trial" / "agent",
+                model_name="kimchi-dev/kimi-k2.6",
+            )
+
+            with self.assertRaises(asyncio.CancelledError):
+                await agent.run("hello", object(), AgentContext())
+
+            command = agent.agent_commands[0]
+            self.assertNotIn(CONTAINER_HARNESS_SKILLS_DIR, command)
+            self.assertEqual(agent._skills_registration_command(), "")
 
     async def test_api_key_can_come_from_agent_extra_env(self) -> None:
         os.environ.pop("KIMCHI_API_KEY", None)


### PR DESCRIPTION
## Description

Teach the Kimchi Terminal Bench adapter to install Harbor-provided task skills before launching the agent.

When Harbor passes `skills_dir`, the adapter now copies its contents into Kimchi’s harness skill directory:

`~/.config/kimchi/harness/skills`

This matches the behavior expected from other Terminal Bench agents that translate Harbor task skills into their native skill locations.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
