### PR TITLE
feat: New header

### DIFF
--- a/src/components/logo-art.ts
+++ b/src/components/logo-art.ts
@@ -15,17 +15,13 @@ export function buildLogoLines(theme: Theme): string[] {
 	]
 }
 
-export function buildVersionLine(theme: Theme): string {
+export function buildInfoLine(theme: Theme): string {
 	if (!cachedVersion) cachedVersion = getVersion()
 	const dim = theme.getFgAnsi("dim")
-	return `${dim}v${cachedVersion}${RST_FG}`
-}
-
-export function buildPathLine(theme: Theme): string {
-	const dim = theme.getFgAnsi("dim")
 	const branchColor = theme.getFgAnsi("mdLink")
-	const branch = getGitBranch()
 	const folder = getFolder()
-	const branchPart = branch ? ` ${dim}·${RST_FG} ${branchColor}${branch}${RST_FG}` : ""
-	return `${dim}${folder}${RST_FG}${branchPart}`
+	const branch = getGitBranch()
+	const vdot = ` ${dim}·${RST_FG} `
+	const branchPart = branch ? `${vdot}${branchColor}${branch}${RST_FG}` : ""
+	return `${dim}v${cachedVersion}${RST_FG}${vdot}${dim}${folder}${RST_FG}${branchPart}`
 }

--- a/src/components/logo.test.ts
+++ b/src/components/logo.test.ts
@@ -68,13 +68,14 @@ describe("LogoHeader", () => {
 		const logoRows = lines.slice(1, -1).filter((l) => stripAnsi(l).includes("█"))
 		expect(logoRows.length).toBeGreaterThanOrEqual(3)
 
-		// Contains version info
-		const versionRow = lines.slice(1, -1).find((l) => stripAnsi(l).includes("v1.0.0-test"))
-		expect(versionRow).toBeDefined()
-
-		// Contains folder + branch
-		const pathRow = lines.slice(1, -1).find((l) => stripAnsi(l).includes("/project") && stripAnsi(l).includes("main"))
-		expect(pathRow).toBeDefined()
+		// Contains a single combined info line with version, folder, and branch
+		const infoRow = lines
+			.slice(1, -1)
+			.find(
+				(l) =>
+					stripAnsi(l).includes("v1.0.0-test") && stripAnsi(l).includes("/project") && stripAnsi(l).includes("main"),
+			)
+		expect(infoRow).toBeDefined()
 
 		// Contains right column content
 		const rightText = lines.slice(1, -1).map(stripAnsi).join(" ")
@@ -129,19 +130,15 @@ describe("LogoHeader", () => {
 		expect(stripAnsi(lines[lines.length - 1])).toMatch(/^└─+┘$/)
 
 		// Right column content wraps aggressively but remains present.
-		// At width 45 the right column is ~6 chars wide, so words may split;
-		// we verify the keywords appear across the wrapped output.
 		const rightChars = stripAnsi(lines.slice(1, -1).join(""))
 		expect(rightChars).toMatch(/K/i)
 		expect(rightChars).toMatch(/s\s*p\s*e\s*c/i)
 		expect(rightChars).toMatch(/f\s*e\s*r\s*m/i)
 		expect(rightChars).toMatch(/p\s*a\s*u\s*s/i)
 		expect(rightChars).toMatch(/q\s*u\s*i\s*t/i)
-		// Verify the right column actually has content (non-space chars after the left column)
 		const contentRows = lines.slice(1, -1)
 		const rowsWithRightContent = contentRows.filter((l) => {
 			const stripped = stripAnsi(l)
-			// After the logo area (~36 chars) there should be a divider and then content
 			return /│[^│]+│/.test(stripped)
 		})
 		expect(rowsWithRightContent.length).toBeGreaterThan(5)
@@ -168,12 +165,14 @@ describe("LogoHeader", () => {
 		expect(rightSection).toContain("\x1b[36m/quit\x1b[0m")
 	})
 
-	it("centers the logo vertically when the right column is taller", () => {
+	it("centers the logo and info line vertically as a unit", () => {
 		const theme = createMockTheme()
 		const header = new LogoHeader(theme)
 		const lines = header.render(120)
 
-		// Find rows containing logo art (█ character)
+		const contentHeight = lines.length - 2 // excluding borders
+
+		// Find logo rows
 		const logoIndices: number[] = []
 		for (let i = 1; i < lines.length - 1; i++) {
 			if (stripAnsi(lines[i]).includes("█")) {
@@ -182,23 +181,57 @@ describe("LogoHeader", () => {
 		}
 		expect(logoIndices.length).toBeGreaterThanOrEqual(3)
 
-		// Logo should be vertically centered within content lines when possible.
-		// When the left column (logo + version + path) determines the total height,
-		// there may be no slack to center the logo (it must stay at the top to fit
-		// version and path below it). We verify the logo is within the content area
-		// and version/path appear below it.
-		const contentHeight = lines.length - 2 // excluding borders
-		const logoTop = logoIndices[0] - 1 // 0-based within content
+		// Find combined info row
+		const infoIndex = lines.findIndex(
+			(l) => stripAnsi(l).includes("v1.0.0-test") && stripAnsi(l).includes("/project") && stripAnsi(l).includes("main"),
+		)
+		expect(infoIndex).toBeGreaterThan(0)
+
+		const logoTop = logoIndices[0] - 1
+		const infoRow = infoIndex - 1
+
+		// There should be a gap between logo bottom and info row
 		const logoBottom = logoIndices[logoIndices.length - 1] - 1
-		const versionTop = logoBottom + 2 // gap + version line
+		expect(infoRow).toBeGreaterThan(logoBottom)
 
-		expect(logoTop).toBeGreaterThanOrEqual(0)
-		expect(logoBottom).toBeLessThan(contentHeight)
-		expect(versionTop).toBeGreaterThan(logoBottom)
-
-		// Logo center should be reasonably close to content center (±2 rows)
-		const logoCenter = (logoTop + logoBottom) / 2
+		// The unit (logo through info row) should be vertically centered
+		const unitCenter = (logoTop + infoRow) / 2
 		const contentCenter = (contentHeight - 1) / 2
-		expect(Math.abs(logoCenter - contentCenter)).toBeLessThanOrEqual(2)
+		expect(Math.abs(unitCenter - contentCenter)).toBeLessThanOrEqual(1)
+	})
+
+	it("centers the logo and info line horizontally within the left column", () => {
+		const theme = createMockTheme()
+		const header = new LogoHeader(theme)
+		const lines = header.render(120)
+
+		// Find the info row
+		const infoIndex = lines.findIndex(
+			(l) => stripAnsi(l).includes("v1.0.0-test") && stripAnsi(l).includes("/project") && stripAnsi(l).includes("main"),
+		)
+		expect(infoIndex).toBeGreaterThan(0)
+
+		// Strip ANSI and split by the vertical divider character
+		const strippedInfo = stripAnsi(lines[infoIndex])
+		const parts = strippedInfo.split("│")
+		// parts[1] is the left column content area
+		const leftCol = parts[1]
+		expect(leftCol).toBeDefined()
+
+		// The info text should not start at the very first position of the left column
+		// (it should be centered with some leading padding)
+		const infoStart = leftCol.indexOf("v1.0.0-test")
+		expect(infoStart).toBeGreaterThan(1)
+
+		// The info text should also not end at the very last position
+		// (it should have trailing padding for centering)
+		const infoEnd = leftCol.lastIndexOf("main") + "main".length
+		expect(infoEnd).toBeLessThan(leftCol.length - 1)
+
+		// A logo row should have the same total left column width as the info row
+		const logoRow = lines.findIndex((l) => stripAnsi(l).includes("█"))
+		const strippedLogo = stripAnsi(lines[logoRow])
+		const logoParts = strippedLogo.split("│")
+		expect(logoParts[1].length).toBe(leftCol.length)
 	})
 })

--- a/src/components/logo.test.ts
+++ b/src/components/logo.test.ts
@@ -77,6 +77,9 @@ describe("LogoHeader", () => {
 			)
 		expect(infoRow).toBeDefined()
 
+		// Box should be taller due to generous vertical padding
+		expect(lines.length).toBeGreaterThan(35)
+
 		// Contains right column content
 		const rightText = lines.slice(1, -1).map(stripAnsi).join(" ")
 		expect(rightText).toContain("Kimchi's special:")

--- a/src/components/logo.test.ts
+++ b/src/components/logo.test.ts
@@ -1,0 +1,204 @@
+import type { Theme } from "@earendil-works/pi-coding-agent"
+import { visibleWidth } from "@earendil-works/pi-tui"
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
+
+const getVersionMock = vi.fn(() => "1.0.0-test")
+const getFolderMock = vi.fn(() => "/project")
+const getGitBranchMock = vi.fn(() => "main")
+
+vi.mock("../utils.js", () => ({
+	getVersion: () => getVersionMock(),
+	getFolder: () => getFolderMock(),
+	getGitBranch: () => getGitBranchMock(),
+}))
+
+const { LogoHeader } = await import("./logo.js")
+
+// biome-ignore lint/suspicious/noControlCharactersInRegex: ANSI escape stripping in test assertions
+const ANSI_ESCAPE = /\x1b\[[\d;]*m/g
+const stripAnsi = (s: string): string => s.replace(ANSI_ESCAPE, "")
+
+function createMockTheme(): Theme {
+	const COLOR_CODE: Record<string, string> = {
+		accent: "\x1b[36m",
+		dim: "\x1b[2m",
+		mdLink: "\x1b[35m",
+	}
+	const RESET = "\x1b[0m"
+	const fg = vi.fn((color: string, s: string) => `${COLOR_CODE[color] ?? "\x1b[39m"}${s}${RESET}`)
+	return {
+		fg,
+		bg: vi.fn(),
+		getFgAnsi: vi.fn((color: string) => COLOR_CODE[color] ?? "\x1b[39m"),
+		getBgAnsi: vi.fn(),
+		fgColors: {},
+		bgColors: {},
+		mode: "light",
+		preproc: vi.fn(),
+		extensions: {},
+	} as unknown as Theme
+}
+
+describe("LogoHeader", () => {
+	beforeEach(() => {
+		getVersionMock.mockReturnValue("1.0.0-test")
+		getFolderMock.mockReturnValue("/project")
+		getGitBranchMock.mockReturnValue("main")
+	})
+
+	afterEach(() => {
+		vi.clearAllMocks()
+	})
+
+	it("renders a bordered two-column layout at width 120", () => {
+		const theme = createMockTheme()
+		const header = new LogoHeader(theme)
+		const lines = header.render(120)
+
+		// First and last lines are borders
+		expect(stripAnsi(lines[0])).toMatch(/^┌─+┐$/)
+		expect(stripAnsi(lines[lines.length - 1])).toMatch(/^└─+┘$/)
+
+		// Every content line contains the vertical divider
+		for (let i = 1; i < lines.length - 1; i++) {
+			expect(stripAnsi(lines[i])).toContain("│")
+		}
+
+		// Contains logo lines in the left column
+		const logoRows = lines.slice(1, -1).filter((l) => stripAnsi(l).includes("█"))
+		expect(logoRows.length).toBeGreaterThanOrEqual(3)
+
+		// Contains version info
+		const versionRow = lines.slice(1, -1).find((l) => stripAnsi(l).includes("v1.0.0-test"))
+		expect(versionRow).toBeDefined()
+
+		// Contains folder + branch
+		const pathRow = lines.slice(1, -1).find((l) => stripAnsi(l).includes("/project") && stripAnsi(l).includes("main"))
+		expect(pathRow).toBeDefined()
+
+		// Contains right column content
+		const rightText = lines.slice(1, -1).map(stripAnsi).join(" ")
+		expect(rightText).toContain("Kimchi's special:")
+		expect(rightText).toContain("/ferment")
+		expect(rightText).toContain("/pause")
+		expect(rightText).toContain("/quit")
+
+		// Contains a horizontal rule in the right column
+		const hrRow = lines.slice(1, -1).find((l) => {
+			const stripped = stripAnsi(l)
+			return stripped.includes("──")
+		})
+		expect(hrRow).toBeDefined()
+
+		// No content line exceeds the requested width
+		for (const line of lines) {
+			expect(visibleWidth(line)).toBeLessThanOrEqual(120)
+		}
+	})
+
+	it("wraps right column text at width 60", () => {
+		const theme = createMockTheme()
+		const header = new LogoHeader(theme)
+		const lines = header.render(60)
+
+		// Should still be a bordered box
+		expect(stripAnsi(lines[0])).toMatch(/^┌─+┐$/)
+		expect(stripAnsi(lines[lines.length - 1])).toMatch(/^└─+┘$/)
+
+		// Right column text wraps, so total height should be taller than logo + version
+		expect(lines.length).toBeGreaterThan(8)
+
+		const rightText = lines.slice(1, -1).map(stripAnsi).join(" ")
+		expect(rightText).toContain("Kimchi's special:")
+		expect(rightText).toContain("/ferment")
+		expect(rightText).toContain("/pause")
+		expect(rightText).toContain("/quit")
+
+		for (const line of lines) {
+			expect(visibleWidth(line)).toBeLessThanOrEqual(60)
+		}
+	})
+
+	it("degrades gracefully at narrow width 45", () => {
+		const theme = createMockTheme()
+		const header = new LogoHeader(theme)
+		const lines = header.render(45)
+
+		// Still has borders and dividers
+		expect(stripAnsi(lines[0])).toMatch(/^┌─+┐$/)
+		expect(stripAnsi(lines[lines.length - 1])).toMatch(/^└─+┘$/)
+
+		// Right column content wraps aggressively but remains present.
+		// At width 45 the right column is ~6 chars wide, so words may split;
+		// we verify the keywords appear across the wrapped output.
+		const rightChars = stripAnsi(lines.slice(1, -1).join(""))
+		expect(rightChars).toMatch(/K/i)
+		expect(rightChars).toMatch(/s\s*p\s*e\s*c/i)
+		expect(rightChars).toMatch(/f\s*e\s*r\s*m/i)
+		expect(rightChars).toMatch(/p\s*a\s*u\s*s/i)
+		expect(rightChars).toMatch(/q\s*u\s*i\s*t/i)
+		// Verify the right column actually has content (non-space chars after the left column)
+		const contentRows = lines.slice(1, -1)
+		const rowsWithRightContent = contentRows.filter((l) => {
+			const stripped = stripAnsi(l)
+			// After the logo area (~36 chars) there should be a divider and then content
+			return /│[^│]+│/.test(stripped)
+		})
+		expect(rowsWithRightContent.length).toBeGreaterThan(5)
+
+		for (const line of lines) {
+			expect(visibleWidth(line)).toBeLessThanOrEqual(45)
+		}
+	})
+
+	it("uses accent color for borders, divider, and highlighted commands", () => {
+		const theme = createMockTheme()
+		const header = new LogoHeader(theme)
+		const lines = header.render(120)
+
+		// Borders use accent ANSI
+		for (const line of lines) {
+			expect(line).toContain("\x1b[36m")
+		}
+
+		// Highlighted commands use theme.fg("accent", ...) which wraps with accent + reset
+		const rightSection = lines.slice(1, -1).join("\n")
+		expect(rightSection).toContain("\x1b[36m/ferment\x1b[0m")
+		expect(rightSection).toContain("\x1b[36m/pause\x1b[0m")
+		expect(rightSection).toContain("\x1b[36m/quit\x1b[0m")
+	})
+
+	it("centers the logo vertically when the right column is taller", () => {
+		const theme = createMockTheme()
+		const header = new LogoHeader(theme)
+		const lines = header.render(120)
+
+		// Find rows containing logo art (█ character)
+		const logoIndices: number[] = []
+		for (let i = 1; i < lines.length - 1; i++) {
+			if (stripAnsi(lines[i]).includes("█")) {
+				logoIndices.push(i)
+			}
+		}
+		expect(logoIndices.length).toBeGreaterThanOrEqual(3)
+
+		// Logo should be vertically centered within content lines when possible.
+		// When the left column (logo + version + path) determines the total height,
+		// there may be no slack to center the logo (it must stay at the top to fit
+		// version and path below it). We verify the logo is within the content area
+		// and version/path appear below it.
+		const contentHeight = lines.length - 2 // excluding borders
+		const logoTop = logoIndices[0] - 1 // 0-based within content
+		const logoBottom = logoIndices[logoIndices.length - 1] - 1
+		const versionTop = logoBottom + 2 // gap + version line
+
+		expect(logoTop).toBeGreaterThanOrEqual(0)
+		expect(logoBottom).toBeLessThan(contentHeight)
+		expect(versionTop).toBeGreaterThan(logoBottom)
+
+		// Logo center should be reasonably close to content center (±2 rows)
+		const logoCenter = (logoTop + logoBottom) / 2
+		const contentCenter = (contentHeight - 1) / 2
+		expect(Math.abs(logoCenter - contentCenter)).toBeLessThanOrEqual(2)
+	})
+})

--- a/src/components/logo.test.ts
+++ b/src/components/logo.test.ts
@@ -78,7 +78,7 @@ describe("LogoHeader", () => {
 		expect(infoRow).toBeDefined()
 
 		// Box should be taller due to generous vertical padding
-		expect(lines.length).toBeGreaterThan(35)
+		expect(lines.length).toBeGreaterThan(13)
 
 		// Contains right column content
 		const rightText = lines.slice(1, -1).map(stripAnsi).join(" ")

--- a/src/components/logo.test.ts
+++ b/src/components/logo.test.ts
@@ -78,7 +78,7 @@ describe("LogoHeader", () => {
 		expect(infoRow).toBeDefined()
 
 		// Box should be taller due to generous vertical padding
-		expect(lines.length).toBeGreaterThan(13)
+		expect(lines.length).toBeGreaterThan(11)
 
 		// Contains right column content
 		const rightText = lines.slice(1, -1).map(stripAnsi).join(" ")
@@ -113,10 +113,11 @@ describe("LogoHeader", () => {
 		expect(lines.length).toBeGreaterThan(8)
 
 		const rightText = lines.slice(1, -1).map(stripAnsi).join(" ")
-		expect(rightText).toContain("Kimchi's special:")
-		expect(rightText).toContain("/ferment")
-		expect(rightText).toContain("/pause")
-		expect(rightText).toContain("/quit")
+		expect(rightText).toContain("Kimchi")
+		expect(rightText).toContain("special")
+		expect(rightText).toContain("ferment")
+		expect(rightText).toContain("pause")
+		expect(rightText).toContain("quit")
 
 		for (const line of lines) {
 			expect(visibleWidth(line)).toBeLessThanOrEqual(60)

--- a/src/components/logo.test.ts
+++ b/src/components/logo.test.ts
@@ -84,8 +84,7 @@ describe("LogoHeader", () => {
 		const rightText = lines.slice(1, -1).map(stripAnsi).join(" ")
 		expect(rightText).toContain("Kimchi's special:")
 		expect(rightText).toContain("/ferment")
-		expect(rightText).toContain("/pause")
-		expect(rightText).toContain("/quit")
+		expect(rightText).toContain("exit")
 
 		// Contains a horizontal rule in the right column
 		const hrRow = lines.slice(1, -1).find((l) => {
@@ -116,8 +115,7 @@ describe("LogoHeader", () => {
 		expect(rightText).toContain("Kimchi")
 		expect(rightText).toContain("special")
 		expect(rightText).toContain("ferment")
-		expect(rightText).toContain("pause")
-		expect(rightText).toContain("quit")
+		expect(rightText).toContain("exit")
 
 		for (const line of lines) {
 			expect(visibleWidth(line)).toBeLessThanOrEqual(60)
@@ -138,8 +136,7 @@ describe("LogoHeader", () => {
 		expect(rightChars).toMatch(/K/i)
 		expect(rightChars).toMatch(/s\s*p\s*e\s*c/i)
 		expect(rightChars).toMatch(/f\s*e\s*r\s*m/i)
-		expect(rightChars).toMatch(/p\s*a\s*u\s*s/i)
-		expect(rightChars).toMatch(/q\s*u\s*i\s*t/i)
+		expect(rightChars).toMatch(/e\s*x\s*i\s*t/i)
 		const contentRows = lines.slice(1, -1)
 		const rowsWithRightContent = contentRows.filter((l) => {
 			const stripped = stripAnsi(l)
@@ -165,8 +162,7 @@ describe("LogoHeader", () => {
 		// Highlighted commands use theme.fg("accent", ...) which wraps with accent + reset
 		const rightSection = lines.slice(1, -1).join("\n")
 		expect(rightSection).toContain("\x1b[36m/ferment\x1b[0m")
-		expect(rightSection).toContain("\x1b[36m/pause\x1b[0m")
-		expect(rightSection).toContain("\x1b[36m/quit\x1b[0m")
+		expect(rightSection).toContain("\x1b[36m/ferment exit\x1b[0m")
 	})
 
 	it("centers the logo and info line vertically as a unit", () => {

--- a/src/components/logo.ts
+++ b/src/components/logo.ts
@@ -1,6 +1,7 @@
 import type { Theme } from "@earendil-works/pi-coding-agent"
 import type { Component } from "@earendil-works/pi-tui"
-import { truncateToWidth, visibleWidth } from "@earendil-works/pi-tui"
+import { visibleWidth, wrapTextWithAnsi } from "@earendil-works/pi-tui"
+import { RST_FG } from "../ansi.js"
 import { buildLogoLines, buildPathLine, buildVersionLine } from "./logo-art.js"
 
 export class LogoHeader implements Component {
@@ -18,40 +19,100 @@ export class LogoHeader implements Component {
 
 	render(width: number): string[] {
 		const { theme } = this
+		const accentOpen = theme.getFgAnsi("accent")
 		const versionLine = buildVersionLine(theme)
 		const pathLine = buildPathLine(theme)
-
 		const versionWidth = visibleWidth(versionLine)
 		const pathWidth = visibleWidth(pathLine)
-		const leftPad = "    " // 4 spaces to shift logo right
-		const gap = 3
 
-		// Find the widest logo line (without leftPad)
-		let maxLogoWidth = 0
-		for (const line of this.logoLines) {
-			maxLogoWidth = Math.max(maxLogoWidth, visibleWidth(line))
+		// Logo dimensions
+		const logoWidth = Math.max(...this.logoLines.map((l) => visibleWidth(l)))
+		const logoHeight = this.logoLines.length
+		const gapBelowLogo = 1
+
+		// Compute right column width with progressive padding reduction for narrow terminals
+		let leftPad = 1
+		let midPad = 1
+		let rightPad = 1
+		let endPad = 1
+		let rightColWidth = width - (2 + leftPad + logoWidth + midPad + 1 + rightPad + endPad)
+
+		if (rightColWidth < 8) {
+			midPad = 0
+			rightPad = 0
+			rightColWidth = width - (2 + leftPad + logoWidth + 1 + endPad)
+		}
+		if (rightColWidth < 8) {
+			leftPad = 0
+			endPad = 0
+			rightColWidth = width - (2 + logoWidth + 1)
+		}
+		if (rightColWidth < 1) {
+			rightColWidth = 1
 		}
 
-		const result: string[] = [""]
+		// Right column content (static text — no dynamic tip mechanism exists yet)
+		const accentText = (text: string) => theme.fg("accent", text)
+		const labelLine = "Kimchi's special:"
+		const tip1Text = `Use ${accentText("/ferment")} to hand off a large task with minimal interruption.`
+		const tip2Text = `${accentText("/pause")} and ${accentText("/quit")} your ferment workflow anytime.`
 
-		// Logo lines - position right content to the right of the logo
-		// Version on line 2, path on line 3 (0-indexed 1 and 2) for vertical centering
-		for (let i = 0; i < this.logoLines.length; i++) {
-			const logoLine = leftPad + this.logoLines[i]
-			const lineWidth = visibleWidth(this.logoLines[i])
-			const padding = " ".repeat(maxLogoWidth - lineWidth + gap)
+		const labelWrap = wrapTextWithAnsi(labelLine, rightColWidth)
+		const wrap1 = wrapTextWithAnsi(tip1Text, rightColWidth)
+		const wrap2 = wrapTextWithAnsi(tip2Text, rightColWidth)
+		const hrLine = accentOpen + "─".repeat(Math.max(0, rightColWidth)) + RST_FG
 
-			let rightContent = ""
-			if (i === 1 && versionWidth > 0) {
-				rightContent = padding + versionLine
-			} else if (i === 2 && pathWidth > 0) {
-				rightContent = padding + pathLine
+		const rightLines: string[] = [...labelWrap, ...wrap1, hrLine, ...wrap2]
+
+		// Left column: logo centered vertically, version/path below
+		const leftContentHeight = logoHeight + gapBelowLogo + (versionWidth > 0 ? 1 : 0) + (pathWidth > 0 ? 1 : 0)
+		const totalHeight = Math.max(rightLines.length, leftContentHeight)
+
+		const logoTop = Math.min(Math.floor((totalHeight - logoHeight) / 2), totalHeight - leftContentHeight)
+
+		const accentBorder = (char: string) => accentOpen + char + RST_FG
+		const result: string[] = []
+
+		// Top border
+		const borderInner = Math.max(0, width - 2)
+		result.push(accentBorder(`┌${"─".repeat(borderInner)}┐`))
+
+		for (let row = 0; row < totalHeight; row++) {
+			let leftContent = ""
+			if (row >= logoTop && row < logoTop + logoHeight) {
+				leftContent = this.logoLines[row - logoTop]
+			}
+			if (versionWidth > 0 && row === logoTop + logoHeight + gapBelowLogo) {
+				leftContent = versionLine
+			}
+			if (pathWidth > 0 && row === logoTop + logoHeight + gapBelowLogo + 1) {
+				leftContent = pathLine
 			}
 
-			result.push(truncateToWidth(logoLine + rightContent, width))
+			const leftVisible = visibleWidth(leftContent)
+			const leftPadded = leftContent + " ".repeat(Math.max(0, logoWidth - leftVisible))
+
+			const rightContent = rightLines[row] || ""
+			const rightVisible = visibleWidth(rightContent)
+			const rightPadded = rightContent + " ".repeat(Math.max(0, rightColWidth - rightVisible))
+
+			const line =
+				accentBorder("│") +
+				" ".repeat(leftPad) +
+				leftPadded +
+				" ".repeat(midPad) +
+				accentBorder("│") +
+				" ".repeat(rightPad) +
+				rightPadded +
+				" ".repeat(endPad) +
+				accentBorder("│")
+
+			result.push(line)
 		}
 
-		result.push("")
+		// Bottom border
+		result.push(accentBorder(`└${"─".repeat(borderInner)}┘`))
+
 		return result
 	}
 }

--- a/src/components/logo.ts
+++ b/src/components/logo.ts
@@ -2,7 +2,7 @@ import type { Theme } from "@earendil-works/pi-coding-agent"
 import type { Component } from "@earendil-works/pi-tui"
 import { visibleWidth, wrapTextWithAnsi } from "@earendil-works/pi-tui"
 import { RST_FG } from "../ansi.js"
-import { buildLogoLines, buildPathLine, buildVersionLine } from "./logo-art.js"
+import { buildInfoLine, buildLogoLines } from "./logo-art.js"
 
 export class LogoHeader implements Component {
 	private readonly theme: Theme
@@ -20,32 +20,33 @@ export class LogoHeader implements Component {
 	render(width: number): string[] {
 		const { theme } = this
 		const accentOpen = theme.getFgAnsi("accent")
-		const versionLine = buildVersionLine(theme)
-		const pathLine = buildPathLine(theme)
-		const versionWidth = visibleWidth(versionLine)
-		const pathWidth = visibleWidth(pathLine)
+		const infoLine = buildInfoLine(theme)
+		const infoWidth = visibleWidth(infoLine)
 
 		// Logo dimensions
 		const logoWidth = Math.max(...this.logoLines.map((l) => visibleWidth(l)))
 		const logoHeight = this.logoLines.length
-		const gapBelowLogo = 1
+		const midGap = 2
+
+		// Left column content width (widest of logo or info line)
+		const leftContentWidth = Math.max(logoWidth, infoWidth)
 
 		// Compute right column width with progressive padding reduction for narrow terminals
 		let leftPad = 1
 		let midPad = 1
 		let rightPad = 1
 		let endPad = 1
-		let rightColWidth = width - (2 + leftPad + logoWidth + midPad + 1 + rightPad + endPad)
+		let rightColWidth = width - (2 + leftPad + leftContentWidth + midPad + 1 + rightPad + endPad)
 
 		if (rightColWidth < 8) {
 			midPad = 0
 			rightPad = 0
-			rightColWidth = width - (2 + leftPad + logoWidth + 1 + endPad)
+			rightColWidth = width - (2 + leftPad + leftContentWidth + 1 + endPad)
 		}
 		if (rightColWidth < 8) {
 			leftPad = 0
 			endPad = 0
-			rightColWidth = width - (2 + logoWidth + 1)
+			rightColWidth = width - (2 + leftContentWidth + 1)
 		}
 		if (rightColWidth < 1) {
 			rightColWidth = 1
@@ -64,11 +65,13 @@ export class LogoHeader implements Component {
 
 		const rightLines: string[] = [...labelWrap, ...wrap1, hrLine, ...wrap2]
 
-		// Left column: logo centered vertically, version/path below
-		const leftContentHeight = logoHeight + gapBelowLogo + (versionWidth > 0 ? 1 : 0) + (pathWidth > 0 ? 1 : 0)
+		// Left column: center logo + info line as a unit vertically
+		const unitHeight = logoHeight + midGap + 1
+		const leftContentHeight = unitHeight
 		const totalHeight = Math.max(rightLines.length, leftContentHeight)
 
-		const logoTop = Math.min(Math.floor((totalHeight - logoHeight) / 2), totalHeight - leftContentHeight)
+		const logoTop = Math.floor((totalHeight - unitHeight) / 2)
+		const infoRow = logoTop + logoHeight + midGap
 
 		const accentBorder = (char: string) => accentOpen + char + RST_FG
 		const result: string[] = []
@@ -82,15 +85,14 @@ export class LogoHeader implements Component {
 			if (row >= logoTop && row < logoTop + logoHeight) {
 				leftContent = this.logoLines[row - logoTop]
 			}
-			if (versionWidth > 0 && row === logoTop + logoHeight + gapBelowLogo) {
-				leftContent = versionLine
-			}
-			if (pathWidth > 0 && row === logoTop + logoHeight + gapBelowLogo + 1) {
-				leftContent = pathLine
+			if (row === infoRow) {
+				leftContent = infoLine
 			}
 
-			const leftVisible = visibleWidth(leftContent)
-			const leftPadded = leftContent + " ".repeat(Math.max(0, logoWidth - leftVisible))
+			// Horizontally center content within leftContentWidth
+			const contentWidth = visibleWidth(leftContent)
+			const hPad = Math.floor((leftContentWidth - contentWidth) / 2)
+			const leftPadded = " ".repeat(hPad) + leftContent + " ".repeat(leftContentWidth - contentWidth - hPad)
 
 			const rightContent = rightLines[row] || ""
 			const rightVisible = visibleWidth(rightContent)

--- a/src/components/logo.ts
+++ b/src/components/logo.ts
@@ -34,8 +34,8 @@ export class LogoHeader implements Component {
 		// Compute right column width with progressive padding reduction for narrow terminals
 		let leftPad = 10
 		let midPad = 10
-		let rightPad = 10
-		let endPad = 10
+		let rightPad = 1
+		let endPad = 1
 		let rightColWidth = width - (2 + leftPad + leftContentWidth + midPad + 1 + rightPad + endPad)
 
 		if (rightColWidth < 8) {
@@ -67,7 +67,7 @@ export class LogoHeader implements Component {
 
 		// Left column: generous vertical padding plus centered logo + info line
 		const unitHeight = logoHeight + midGap + 1
-		const minVerticalPad = 3
+		const minVerticalPad = 2
 		const leftContentHeight = unitHeight + 2 * minVerticalPad
 		const totalHeight = Math.max(rightLines.length, leftContentHeight)
 

--- a/src/components/logo.ts
+++ b/src/components/logo.ts
@@ -32,10 +32,10 @@ export class LogoHeader implements Component {
 		const leftContentWidth = Math.max(logoWidth, infoWidth)
 
 		// Compute right column width with progressive padding reduction for narrow terminals
-		let leftPad = 15
-		let midPad = 15
-		let rightPad = 15
-		let endPad = 15
+		let leftPad = 10
+		let midPad = 10
+		let rightPad = 10
+		let endPad = 10
 		let rightColWidth = width - (2 + leftPad + leftContentWidth + midPad + 1 + rightPad + endPad)
 
 		if (rightColWidth < 8) {
@@ -67,7 +67,7 @@ export class LogoHeader implements Component {
 
 		// Left column: generous vertical padding plus centered logo + info line
 		const unitHeight = logoHeight + midGap + 1
-		const minVerticalPad = 15
+		const minVerticalPad = 3
 		const leftContentHeight = unitHeight + 2 * minVerticalPad
 		const totalHeight = Math.max(rightLines.length, leftContentHeight)
 

--- a/src/components/logo.ts
+++ b/src/components/logo.ts
@@ -56,7 +56,7 @@ export class LogoHeader implements Component {
 		const accentText = (text: string) => theme.fg("accent", text)
 		const labelLine = "Kimchi's special:"
 		const tip1Text = `Use ${accentText("/ferment")} to hand off a large task with minimal interruption.`
-		const tip2Text = `${accentText("/pause")} and ${accentText("/quit")} your ferment workflow anytime.`
+		const tip2Text = `To leave the Ferment mode and return to a regular coding session, use ${accentText("/ferment exit")}.`
 
 		const labelWrap = wrapTextWithAnsi(labelLine, rightColWidth)
 		const wrap1 = wrapTextWithAnsi(tip1Text, rightColWidth)

--- a/src/components/logo.ts
+++ b/src/components/logo.ts
@@ -32,10 +32,10 @@ export class LogoHeader implements Component {
 		const leftContentWidth = Math.max(logoWidth, infoWidth)
 
 		// Compute right column width with progressive padding reduction for narrow terminals
-		let leftPad = 1
-		let midPad = 1
-		let rightPad = 1
-		let endPad = 1
+		let leftPad = 15
+		let midPad = 15
+		let rightPad = 15
+		let endPad = 15
 		let rightColWidth = width - (2 + leftPad + leftContentWidth + midPad + 1 + rightPad + endPad)
 
 		if (rightColWidth < 8) {
@@ -65,9 +65,10 @@ export class LogoHeader implements Component {
 
 		const rightLines: string[] = [...labelWrap, ...wrap1, hrLine, ...wrap2]
 
-		// Left column: center logo + info line as a unit vertically
+		// Left column: generous vertical padding plus centered logo + info line
 		const unitHeight = logoHeight + midGap + 1
-		const leftContentHeight = unitHeight
+		const minVerticalPad = 15
+		const leftContentHeight = unitHeight + 2 * minVerticalPad
 		const totalHeight = Math.max(rightLines.length, leftContentHeight)
 
 		const logoTop = Math.floor((totalHeight - unitHeight) / 2)


### PR DESCRIPTION
## Description

New header with the logo/motd split. I'll integrate with the tip provider and breaking changes separately.

<img width="1259" height="829" alt="Screenshot 2026-05-25 at 20 54 43" src="https://github.com/user-attachments/assets/0d5b2764-c457-4920-b3a3-02e70275380a" />


## Type of Change

<!-- Select all that apply. -->

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Documentation update
