### PR TITLE
feat(behaviours): add re-read-before-edit baseline behaviour

### DIFF
--- a/src/extensions/behaviours/bodies/re-read-before-edit.md
+++ b/src/extensions/behaviours/bodies/re-read-before-edit.md
@@ -1,0 +1,10 @@
+---
+name: re-read-before-edit
+description: Re-read a file before editing if a bash command ran since the last read.
+---
+
+Before every Edit/Write:
+
+- Check whether a bash command has executed since you last read that file. If it has, re-read the file first — formatters, linters, generators, and git operations may have changed it since your last read.
+- This applies to any bash execution: explicit user commands, tool-triggered scripts, pre/post hooks, and build steps. If in doubt, re-read.
+- Never edit from a stale snapshot. A single `read` call is cheap; a broken edit from outdated content wastes a turn and risks silent data loss.

--- a/src/extensions/behaviours/registry.ts
+++ b/src/extensions/behaviours/registry.ts
@@ -16,6 +16,7 @@ import ghCliBody from "./bodies/gh-cli.md" with { type: "text" }
 import gitHygieneBody from "./bodies/git-hygiene.md" with { type: "text" }
 import glabCliBody from "./bodies/glab-cli.md" with { type: "text" }
 import pythonEditBody from "./bodies/python-edit.md" with { type: "text" }
+import reReadBeforeEditBody from "./bodies/re-read-before-edit.md" with { type: "text" }
 import { type BehaviourSource, buildBehaviours } from "./build.js"
 import { bashInvokes, fetchesHost } from "./matchers.js"
 import { any, cli, gitRemote, gitRepo, tool } from "./triggers.js"
@@ -42,6 +43,7 @@ const sources: BehaviourSource[] = [
 		kind: "triggered",
 		triggers: { tool: pythonFileEdit },
 	},
+	{ raw: reReadBeforeEditBody, kind: "baseline" },
 	{
 		raw: ghCliBody,
 		kind: "triggered",


### PR DESCRIPTION
## What

Adds a new **baseline behaviour** (`re-read-before-edit`) that instructs agents to re-read a file before editing it whenever a bash command has executed since the file was last read.

### Files changed

- `src/extensions/behaviours/bodies/re-read-before-edit.md` — new behaviour body
- `src/extensions/behaviours/registry.ts` — import + baseline registration

## Why

The `edit` tool uses exact text matching (`oldText`) to locate the region to replace. When an agent reads a file, runs a bash command that modifies it (formatter, linter, code generator, git checkout, sed, etc.), and then attempts an edit against its stale cached content, the `oldText` no longer matches the actual file — causing either:

1. **Silent wrong-location edits** — the text happens to match elsewhere, producing corrupted output
2. **Edit failures** — the tool rejects the match, wasting a turn and forcing a retry cycle

This is one of the most common failure modes in multi-step coding workflows. A single `read` call costs ~50ms and a few hundred tokens. A failed edit costs a full retry turn (tool call + LLM round-trip + user confusion).

### Concrete scenarios this prevents

| Scenario | What goes wrong without re-read |
|---|---|
| Agent reads `foo.ts`, runs `pnpm run lint:fix` (Biome reformats the file), then edits | `oldText` has pre-format whitespace/ordering — edit fails or patches wrong location |
| Agent reads a file, runs `git checkout -- .` or `git stash pop`, then edits | File content reverted/changed — edit applies against phantom content |
| Agent reads a config, runs a code generator that updates it, then edits | Generator output differs from cached read — silent corruption |
| Agent reads a file, runs tests that have side effects (snapshot updates, coverage files), then edits | Snapshot/generated content changed — stale oldText |

### Design choice: baseline, not triggered

This behaviour is registered as `baseline` (always loaded into the system prompt) rather than `triggered` (activated per file type), because:

- The failure mode is **language-agnostic** — bash commands can modify any file type
- The cost of the reminder is negligible (3 bullet points, ~80 tokens in the system prompt)
- The benefit is universal — every edit after every bash command carries this risk
- Making it triggered would require enumerating every file extension, which is fragile and incomplete

## Testing

- All 128 behaviour tests pass ✓
- Typecheck passes ✓
- Verified in-session: spawned a subagent that read a file, ran `sed` via bash to modify it, then correctly re-read before editing — confirming the behaviour is active and followed