### PR TITLE
fix(tips): Tips are being replaced too quickly

### DIFF
--- a/src/extensions/tips/presenter.test.ts
+++ b/src/extensions/tips/presenter.test.ts
@@ -15,6 +15,10 @@ function provider(
 }
 
 describe("TipPresenter", () => {
+	function immediateRotationPresenter(registry: TipRegistry): TipPresenter {
+		return new TipPresenter(registry, { minCompletedTurnsVisible: 1, minVisibleMs: 0 })
+	}
+
 	it("prefers contextual tips and resumes general tips when contextual tips disappear", () => {
 		const registry = new TipRegistry()
 		let contextualActive = false
@@ -34,16 +38,36 @@ describe("TipPresenter", () => {
 		expect(presenter.getCurrentTip()?.id).toBe("general")
 	})
 
-	it("keeps the current tip stable until a turn_end rotation", () => {
+	it("keeps the current tip stable until three turns and one minute have elapsed", () => {
 		const registry = new TipRegistry()
 		registry.registerProvider(provider("general", [{ id: "first" }, { id: "second" }]))
-		const presenter = new TipPresenter(registry)
+		let now = 0
+		const presenter = new TipPresenter(registry, { now: () => now })
 
 		expect(presenter.getCurrentTip()?.id).toBe("first")
 		expect(presenter.getCurrentTip()?.id).toBe("first")
 
+		expect(presenter.onTurnEnd()?.id).toBe("first")
+		expect(presenter.onTurnEnd()?.id).toBe("first")
+		expect(presenter.onTurnEnd()?.id).toBe("first")
+
+		now = 60_000
 		expect(presenter.onTurnEnd()?.id).toBe("second")
 		expect(presenter.getCurrentTip()?.id).toBe("second")
+	})
+
+	it("does not rotate after one minute until the tip has been visible for three completed turns", () => {
+		const registry = new TipRegistry()
+		registry.registerProvider(provider("general", [{ id: "first" }, { id: "second" }]))
+		let now = 0
+		const presenter = new TipPresenter(registry, { now: () => now })
+
+		expect(presenter.getCurrentTip()?.id).toBe("first")
+
+		now = 60_000
+		expect(presenter.onTurnEnd()?.id).toBe("first")
+		expect(presenter.onTurnEnd()?.id).toBe("first")
+		expect(presenter.onTurnEnd()?.id).toBe("second")
 	})
 
 	it("refreshes current tip content from provider state without rotating", () => {
@@ -69,7 +93,7 @@ describe("TipPresenter", () => {
 		const registry = new TipRegistry()
 		registry.registerProvider(provider("alpha", [{ id: "a1" }, { id: "a2" }]))
 		registry.registerProvider(provider("beta", [{ id: "b1" }]))
-		const presenter = new TipPresenter(registry)
+		const presenter = immediateRotationPresenter(registry)
 
 		expect(presenter.getCurrentTip()?.id).toBe("a1")
 		expect(presenter.onTurnEnd()?.id).toBe("b1")

--- a/src/extensions/tips/presenter.ts
+++ b/src/extensions/tips/presenter.ts
@@ -11,13 +11,33 @@ interface ActiveTipGroup {
 	providers: ProviderTips[]
 }
 
+export interface TipPresenterOptions {
+	minCompletedTurnsVisible?: number
+	minVisibleMs?: number
+	now?: () => number
+}
+
+const DEFAULT_MIN_COMPLETED_TURNS_VISIBLE = 3
+const DEFAULT_MIN_VISIBLE_MS = 60_000
+
 export class TipPresenter {
 	private current: TipCandidate | undefined
 	private completedTurnsVisible = 0
+	private visibleSinceMs: number | undefined
 	private activeGroupKey: string | undefined
 	private readonly nextTipIndexBySource = new Map<string, number>()
+	private readonly minCompletedTurnsVisible: number
+	private readonly minVisibleMs: number
+	private readonly now: () => number
 
-	constructor(private readonly registry: TipRegistry) {}
+	constructor(
+		private readonly registry: TipRegistry,
+		options: TipPresenterOptions = {},
+	) {
+		this.minCompletedTurnsVisible = Math.max(0, options.minCompletedTurnsVisible ?? DEFAULT_MIN_COMPLETED_TURNS_VISIBLE)
+		this.minVisibleMs = Math.max(0, options.minVisibleMs ?? DEFAULT_MIN_VISIBLE_MS)
+		this.now = options.now ?? Date.now
+	}
 
 	getCurrentTip(): TipCandidate | undefined {
 		return this.refresh(false)
@@ -25,12 +45,13 @@ export class TipPresenter {
 
 	onTurnEnd(): TipCandidate | undefined {
 		if (this.current) this.completedTurnsVisible += 1
-		return this.refresh(this.completedTurnsVisible >= 1)
+		return this.refresh(this.canRotateCurrentTip())
 	}
 
 	clear(): void {
 		this.current = undefined
 		this.completedTurnsVisible = 0
+		this.visibleSinceMs = undefined
 		this.activeGroupKey = undefined
 		this.nextTipIndexBySource.clear()
 	}
@@ -40,6 +61,7 @@ export class TipPresenter {
 		if (!group) {
 			this.current = undefined
 			this.completedTurnsVisible = 0
+			this.visibleSinceMs = undefined
 			this.activeGroupKey = undefined
 			return undefined
 		}
@@ -72,6 +94,7 @@ export class TipPresenter {
 		if (!nextProvider) {
 			this.current = undefined
 			this.completedTurnsVisible = 0
+			this.visibleSinceMs = undefined
 			return undefined
 		}
 
@@ -82,7 +105,14 @@ export class TipPresenter {
 
 		this.current = nextTip
 		this.completedTurnsVisible = 0
+		this.visibleSinceMs = this.now()
 		return nextTip
+	}
+
+	private canRotateCurrentTip(): boolean {
+		if (!this.current || this.visibleSinceMs === undefined) return false
+		if (this.completedTurnsVisible < this.minCompletedTurnsVisible) return false
+		return this.now() - this.visibleSinceMs >= this.minVisibleMs
 	}
 
 	private getActiveGroup(): ActiveTipGroup | undefined {


### PR DESCRIPTION
## Description

<!-- What problem does this PR solve? What changes were made and why? -->

Slows down tip rotation so tips remain readable instead of changing after every assistant turn.

Tips now rotate only after both dwell thresholds are met:
- the current tip has been visible for at least 3 completed turns
- the current tip has been visible for at least 60 seconds

Context changes still take effect immediately: when the active tip group changes, such as a Ferment state change, the presenter selects the first relevant tip right away and resets the dwell counters.

## Type of Change

<!-- Select all that apply. -->

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
