### PR TITLE
feat: graduated context compaction (first/last N lines)

### DIFF
--- a/src/extensions/context-compactor.test.ts
+++ b/src/extensions/context-compactor.test.ts
@@ -1,9 +1,20 @@
 import type { TextContent, ToolResultMessage } from "@earendil-works/pi-ai"
 import type { ContextEvent, ExtensionAPI } from "@earendil-works/pi-coding-agent"
 import { describe, expect, it } from "vitest"
-import contextCompactorExtension, { computeCutoff, pruneToolResult } from "./context-compactor.js"
+import contextCompactorExtension, {
+	compactText,
+	computeCutoff,
+	pruneToolResult,
+	RETAIN_HEAD_LINES,
+	RETAIN_TAIL_LINES,
+} from "./context-compactor.js"
 
 // helpers
+/** Create multi-line text that will be compacted (>60 lines, >minChars chars) */
+function makeBigText(lines = 100): string {
+	return Array.from({ length: lines }, (_, i) => `line ${String(i + 1).padStart(4, "0")}: ${"x".repeat(20)}`).join("\n")
+}
+
 function makeToolResult(toolName: string, text: string, isError = false): ToolResultMessage {
 	return {
 		role: "toolResult",
@@ -92,6 +103,64 @@ describe("computeCutoff", () => {
 	})
 })
 
+// ── compactText ──────────────────────────────────────────────────────────────
+
+describe("compactText", () => {
+	it("returns text unchanged when total lines <= headLines + tailLines", () => {
+		const text = Array.from({ length: 60 }, (_, i) => `line ${i + 1}`).join("\n")
+		const result = compactText(text, 30, 30)
+		expect(result.compacted).toBe(false)
+		expect(result.text).toBe(text)
+	})
+
+	it("returns text unchanged for fewer lines than head + tail", () => {
+		const text = "one\ntwo\nthree"
+		const result = compactText(text, 30, 30)
+		expect(result.compacted).toBe(false)
+		expect(result.text).toBe(text)
+	})
+
+	it("compacts text with more lines than head + tail", () => {
+		const lines = Array.from({ length: 100 }, (_, i) => `line ${i + 1}`)
+		const text = lines.join("\n")
+		const result = compactText(text, 5, 5)
+		expect(result.compacted).toBe(true)
+		// Should have first 5 lines
+		expect(result.text).toContain("line 1")
+		expect(result.text).toContain("line 5")
+		// Should have last 5 lines
+		expect(result.text).toContain("line 96")
+		expect(result.text).toContain("line 100")
+		// Should NOT have middle lines
+		expect(result.text).not.toContain("line 50")
+	})
+
+	it("shows correct omitted line count in separator", () => {
+		const lines = Array.from({ length: 100 }, (_, i) => `line ${i + 1}`)
+		const text = lines.join("\n")
+		const result = compactText(text, 5, 5)
+		expect(result.text).toContain("... [90 lines omitted] ...")
+	})
+
+	it("handles 61 lines (just over head + tail of 30+30) correctly", () => {
+		const lines = Array.from({ length: 61 }, (_, i) => `line ${i + 1}`)
+		const text = lines.join("\n")
+		const result = compactText(text, 30, 30)
+		expect(result.compacted).toBe(true)
+		expect(result.text).toContain("... [1 lines omitted] ...")
+		expect(result.text).toContain("line 1")
+		expect(result.text).toContain("line 30")
+		expect(result.text).toContain("line 32")
+		expect(result.text).toContain("line 61")
+		expect(result.text).not.toContain("\nline 31\n")
+	})
+
+	it("uses default RETAIN_HEAD_LINES and RETAIN_TAIL_LINES values of 30", () => {
+		expect(RETAIN_HEAD_LINES).toBe(30)
+		expect(RETAIN_TAIL_LINES).toBe(30)
+	})
+})
+
 // ── pruneToolResult ──────────────────────────────────────────────────────────
 
 describe("pruneToolResult", () => {
@@ -104,11 +173,29 @@ describe("pruneToolResult", () => {
 		expect(msg.content[0]).toHaveProperty("text", "x".repeat(20)) // original unchanged
 	})
 
-	it("replaces large text content with placeholder", () => {
-		const msg = makeToolResult("bash", "x".repeat(20))
-		const result = pruneToolResult(msg, MIN_PRUNE_CHARS)
-		expect(result.content[0]).toHaveProperty("type", "text")
-		expect((result.content[0] as TextContent).text).toContain("[compacted: bash output")
+	it("compacts large text content with head + tail retention", () => {
+		// 100 lines, each ~10 chars → well over MIN_PRUNE_CHARS
+		const lines = Array.from({ length: 100 }, (_, i) => `line ${String(i + 1).padStart(3, "0")}`)
+		const text = lines.join("\n")
+		const msg = makeToolResult("read", text)
+		const result = pruneToolResult(msg, MIN_PRUNE_CHARS, 5, 5)
+		const output = (result.content[0] as TextContent).text
+		expect(output).toContain("[compacted: read output")
+		expect(output).toContain("line 001")
+		expect(output).toContain("line 005")
+		expect(output).toContain("line 096")
+		expect(output).toContain("line 100")
+		expect(output).toContain("... [90 lines omitted] ...")
+		expect(output).not.toContain("line 050")
+	})
+
+	it("leaves text intact when lines fit within head + tail", () => {
+		// 8 lines, headLines=5 tailLines=5 → total 8 <= 10, no compaction
+		const lines = Array.from({ length: 8 }, (_, i) => `line ${i + 1}`)
+		const longLine = `${lines.join("\n")}\n${"x".repeat(200)}` // enough chars to exceed MIN_PRUNE_CHARS
+		const msg = makeToolResult("bash", longLine)
+		const result = pruneToolResult(msg, MIN_PRUNE_CHARS, 5, 5)
+		expect((result.content[0] as TextContent).text).toBe(longLine)
 	})
 
 	it("leaves small text content untouched", () => {
@@ -118,6 +205,7 @@ describe("pruneToolResult", () => {
 	})
 
 	it("preserves non-text content blocks unchanged", () => {
+		const bigText = Array.from({ length: 100 }, (_, i) => `line ${i + 1}`).join("\n")
 		const msg: ToolResultMessage = {
 			role: "toolResult",
 			toolCallId: "id-1",
@@ -125,13 +213,13 @@ describe("pruneToolResult", () => {
 			content: [
 				// biome-ignore lint/suspicious/noExplicitAny: image block not in TextContent union
 				{ type: "image", source: { type: "base64", mediaType: "image/png", data: "abc" } } as any,
-				{ type: "text", text: "x".repeat(20) },
+				{ type: "text", text: bigText },
 			],
 			details: undefined,
 			isError: false,
 			timestamp: 0,
 		}
-		const result = pruneToolResult(msg, MIN_PRUNE_CHARS)
+		const result = pruneToolResult(msg, MIN_PRUNE_CHARS, 5, 5)
 		expect(result.content[0]).toHaveProperty("type", "image") // untouched
 		expect((result.content[1] as TextContent).text).toContain("[compacted")
 	})
@@ -153,6 +241,20 @@ describe("pruneToolResult", () => {
 		expect(result.toolName).toBe(msg.toolName)
 		expect(result.isError).toBe(msg.isError)
 		expect(result.timestamp).toBe(msg.timestamp)
+	})
+
+	it("uses default head/tail line counts when not specified", () => {
+		// 100 lines → with defaults (30+30), 40 lines omitted
+		const lines = Array.from({ length: 100 }, (_, i) => `line ${String(i + 1).padStart(3, "0")}`)
+		const text = lines.join("\n")
+		const msg = makeToolResult("read", text)
+		const result = pruneToolResult(msg, MIN_PRUNE_CHARS)
+		const output = (result.content[0] as TextContent).text
+		expect(output).toContain("... [40 lines omitted] ...")
+		expect(output).toContain("line 001")
+		expect(output).toContain("line 030")
+		expect(output).toContain("line 071")
+		expect(output).toContain("line 100")
 	})
 })
 
@@ -222,7 +324,7 @@ describe("contextCompactorExtension", () => {
 		contextCompactorExtension(pi)
 		await trigger("message_end", makeMessageEndEvent(40_000))
 		// 1 old tool result + 30 recent messages → cutoff = 1, index 0 is pruned
-		const oldOutput = makeToolResult("bash", "x".repeat(600)) // > MIN_PRUNE_CHARS=500
+		const oldOutput = makeToolResult("bash", makeBigText()) // multi-line, > MIN_PRUNE_CHARS=500
 		const recent = Array.from({ length: 30 }, makeUser)
 		const messages = [oldOutput, ...recent] as ContextEvent["messages"]
 		const result = (await trigger("context", { messages })) as { messages: ContextEvent["messages"] }
@@ -248,7 +350,7 @@ describe("contextCompactorExtension", () => {
 		const { pi, trigger, entries } = makeMockPI()
 		contextCompactorExtension(pi)
 		await trigger("message_end", makeMessageEndEvent(40_000))
-		const oldOutput = makeToolResult("bash", "x".repeat(600)) // 600 chars, pruned to placeholder
+		const oldOutput = makeToolResult("bash", makeBigText()) // multi-line, pruned via graduated compaction
 		const recent = Array.from({ length: 30 }, makeUser)
 		const messages = [oldOutput, ...recent] as ContextEvent["messages"]
 		await trigger("context", { messages })
@@ -268,9 +370,9 @@ describe("contextCompactorExtension", () => {
 		// oldTool (index 0) is prunable, userMsg (index 1) must be preserved,
 		// and 30 tool results (indices 2-31) fill the protected window.
 		// baseCutoff = 2 would drop userMsg; floor brings it down to 1.
-		const oldTool = makeToolResult("bash", "x".repeat(600))
+		const oldTool = makeToolResult("bash", makeBigText())
 		const userMsg = makeUser()
-		const recent = Array.from({ length: 30 }, () => makeToolResult("bash", "x".repeat(600)))
+		const recent = Array.from({ length: 30 }, () => makeToolResult("bash", makeBigText()))
 		const messages = [oldTool, userMsg, ...recent] as ContextEvent["messages"]
 
 		const result = (await trigger("context", { messages })) as { messages: ContextEvent["messages"] }

--- a/src/extensions/context-compactor.ts
+++ b/src/extensions/context-compactor.ts
@@ -7,6 +7,11 @@ const PROTECT_WINDOW = 30
 const MAX_PROTECTED_CHARS = 100_000
 const MIN_PRUNE_CHARS = 500
 
+/** Number of lines to retain from the start of a compacted text block. */
+export const RETAIN_HEAD_LINES = 30
+/** Number of lines to retain from the end of a compacted text block. */
+export const RETAIN_TAIL_LINES = 30
+
 /**
  * Walk backwards through messages to find the cutoff index.
  * Messages at index >= cutoff are kept; messages before cutoff are candidates for pruning.
@@ -63,12 +68,42 @@ function findLastUserMessageIndex(messages: ContextEvent["messages"]): number {
 }
 
 /**
+ * Compact a text block using graduated head+tail retention.
+ *
+ * If the text has more lines than headLines + tailLines, keeps the first
+ * headLines and the last tailLines with an informative separator showing
+ * how many lines were omitted. Otherwise returns the text unchanged.
+ */
+export function compactText(text: string, headLines: number, tailLines: number): { text: string; compacted: boolean } {
+	const lines = text.split("\n")
+	const totalLines = lines.length
+
+	if (totalLines <= headLines + tailLines) {
+		return { text, compacted: false }
+	}
+
+	const head = lines.slice(0, headLines).join("\n")
+	const tail = lines.slice(totalLines - tailLines).join("\n")
+	const omitted = totalLines - headLines - tailLines
+
+	return {
+		text: `${head}\n\n... [${omitted} lines omitted] ...\n\n${tail}`,
+		compacted: true,
+	}
+}
+
+/**
  * Return a pruned copy of a ToolResultMessage.
- * - Large text blocks are replaced with a placeholder (preserves all other fields).
+ * - Large text blocks are compacted to first N + last N lines with an omission separator.
  * - Error outputs keep the last 2000 chars so the agent can still read the crash reason.
  * - Non-text content blocks (images, etc.) are left untouched.
  */
-export function pruneToolResult(msg: ToolResultMessage, minPruneChars: number): ToolResultMessage {
+export function pruneToolResult(
+	msg: ToolResultMessage,
+	minPruneChars: number,
+	headLines = RETAIN_HEAD_LINES,
+	tailLines = RETAIN_TAIL_LINES,
+): ToolResultMessage {
 	return {
 		...msg,
 		content: msg.content.map((block) => {
@@ -81,9 +116,12 @@ export function pruneToolResult(msg: ToolResultMessage, minPruneChars: number): 
 					text: `[compacted: ${msg.toolName} error, ${block.text.length} chars]\n...\n${tail}`,
 				}
 			}
+			const result = compactText(block.text, headLines, tailLines)
 			return {
 				...block,
-				text: `[compacted: ${msg.toolName} output, ${block.text.length} chars]`,
+				text: result.compacted
+					? `[compacted: ${msg.toolName} output, ${block.text.length} chars]\n${result.text}`
+					: block.text,
 			}
 		}),
 	}


### PR DESCRIPTION
## Problem

When the context compactor fires on long conversations, it replaces entire tool results with a single-line placeholder:

```
[compacted: read output, 8432 chars]
```

This is **binary all-or-nothing pruning** — the model loses all structural information about the file it previously read. In practice this means:

- **Lost imports/types** — the model forgets what was imported at the top of a file, leading to hallucinated import paths or duplicated imports on subsequent edits.
- **Lost exports/signatures** — the model forgets function signatures and exported symbols from the bottom of files, causing type errors in later tool calls.
- **Blind re-reads** — the model frequently re-reads the same file because the compacted placeholder gives it zero usable context, wasting tokens and turns.

## Solution

Replace binary pruning with **graduated "first N + last N lines" retention**. When a tool result is compacted, instead of discarding everything, we keep:

- **First 30 lines** — captures imports, type declarations, constants, and file-level documentation
- **Last 30 lines** — captures exports, function signatures, closing logic, and the most recently relevant code
- **Informative separator** — `... [N lines omitted] ...` so the model knows content was removed and how much

### Before
```
[compacted: read output, 8432 chars]
```

### After
```
[compacted: read output, 8432 chars]
import type { AssistantMessage, ToolResultMessage } from "@earendil-works/pi-ai"
import type { ContextEvent, ExtensionAPI } from "@earendil-works/pi-coding-agent"
import { isSubagent } from "./prompt-construction/prompt-enrichment.js"

const PRUNE_THRESHOLD = 35_000
... (lines 1-30 of original)

... [126 lines omitted] ...

... (lines 157-186 of original)
        return { messages: pruned }
    })
}
```

The model retains enough structural context to make informed decisions without re-reading, while still achieving significant token savings on large tool results.

## Changes

### `src/extensions/context-compactor.ts`
- Added `RETAIN_HEAD_LINES` (30) and `RETAIN_TAIL_LINES` (30) exported constants
- New `compactText()` function — splits text into lines, retains head + tail with separator, returns unchanged if lines fit within threshold
- Refactored `pruneToolResult()` to accept optional `headLines`/`tailLines` parameters and use `compactText()` for non-error blocks
- Error output behavior preserved unchanged (last 2000 chars)

### `src/extensions/context-compactor.test.ts`
- New `compactText` test suite (6 tests): unchanged passthrough, graduated compaction, separator accuracy, boundary at 61 lines, constant defaults
- Updated `pruneToolResult` tests (9 tests): head+tail retention, line-count passthrough, error preservation, field preservation, default parameters
- Updated integration tests to use multi-line content (`makeBigText()` helper) so graduated compaction actually triggers

## Design decisions

- **30/30 default** — imports and type declarations cluster in the first ~20-30 lines of most files; exports and closing logic in the last ~20-30. This captures the structural bookends without retaining too much.
- **Configurable via constants** — `RETAIN_HEAD_LINES` and `RETAIN_TAIL_LINES` are exported, making it easy to tune or override per-context in future.
- **Preserves `[compacted:]` prefix** — downstream logic or extensions that key on this marker continue to work.
- **No change to error handling** — error outputs still retain the last 2000 chars since crash context is typically at the end.
- **Edge case: short files** — files with ≤60 lines (head + tail) are returned unchanged since there is nothing to omit.