### PR TITLE
refactor(agent-runner): replace [0.5, 0.75] with [0.75, 0.9] progress steers

### DIFF
--- a/src/extensions/agents/manager/agent-runner.test.ts
+++ b/src/extensions/agents/manager/agent-runner.test.ts
@@ -698,21 +698,21 @@ describe("runAgent — budget awareness steers", () => {
 
 	const steerCases: Record<string, { maxTurns: number; turns: number; expectedSteerCount: number; pattern?: RegExp }> =
 		{
-			"steers at 50% of turn budget": {
-				maxTurns: 10,
-				turns: 5,
-				expectedSteerCount: 1,
-				pattern: /Budget check.*Turn 5\/10/,
-			},
 			"steers at 75% of turn budget": {
 				maxTurns: 10,
 				turns: 8,
-				expectedSteerCount: 2,
-				pattern: /Budget check.*Turn 8\/10/,
+				expectedSteerCount: 1,
+				pattern: /75% of your turn budget./,
 			},
-			"does not steer before 50% of turn budget": {
+			"steers at 90% of turn budget": {
 				maxTurns: 10,
-				turns: 4,
+				turns: 9,
+				expectedSteerCount: 2,
+				pattern: /90% of your turn budget./,
+			},
+			"does not steer before 75% of turn budget": {
+				maxTurns: 10,
+				turns: 7,
 				expectedSteerCount: 0,
 			},
 		}

--- a/src/extensions/agents/manager/agent-runner.ts
+++ b/src/extensions/agents/manager/agent-runner.ts
@@ -403,7 +403,18 @@ async function runAgentInner(
 	const inactivity = { lastActivityAt: Date.now(), steered: false }
 	const inactivityTimeout = options.inactivityTimeout ?? DEFAULT_INACTIVITY_TIMEOUT
 
-	const progressSteerThresholds = [0.5, 0.75]
+	const PROGRESS_STEER_POINTS: { threshold: number; message: string }[] = [
+		{
+			threshold: 0.75,
+			message:
+				"You're at 75% of your turn budget. Continue your current approach; avoid starting new exploratory work.",
+		},
+		{
+			threshold: 0.9,
+			message:
+				"You're at 90% of your turn budget. Finish your current edit, run verification, and summarize any remaining work.",
+		},
+	]
 	let nextProgressIdx = 0
 	let tokenSoftLimitSteered = false
 
@@ -436,13 +447,11 @@ async function runAgentInner(
 					aborted = true
 					abortReason = "max_turns"
 					session.abort()
-				} else if (!softLimitReached && nextProgressIdx < progressSteerThresholds.length) {
-					const threshold = progressSteerThresholds[nextProgressIdx] ?? 1
-					if (turnCount >= effectiveMaxTurns * threshold) {
+				} else if (!softLimitReached && nextProgressIdx < PROGRESS_STEER_POINTS.length) {
+					const point = PROGRESS_STEER_POINTS[nextProgressIdx]
+					if (point && turnCount >= effectiveMaxTurns * point.threshold) {
 						nextProgressIdx++
-						session.steer(
-							`Budget check: ${buildProgressSummary()}. Prioritize completing the most important remaining work.`,
-						)
+						session.steer(point.message)
 					}
 				}
 			}


### PR DESCRIPTION
## Problem

The turn-progress budget steering was using `[0.5, 0.75]` thresholds:

- **50%** — *"Prioritize completing the most important remaining work"*
- **75%** — same message, just re-fired

The 50% threshold was **demonstrably harmful**. Agents still had half their turn budget remaining when they received a panic-inducing message, causing them to prematurely wind down and abandon work that still had room to run. The message created anxiety rather than actionable guidance.

The old implementation also used a flat array of scalars (`[0.5, 0.75]`) with a single hard-coded message, making it impossible to vary tone by threshold.

## Solution

Replace the flat scalar array with a **structured threshold+message table** (`PROGRESS_STEER_POINTS`) and use a two-point ladder:

| Threshold | Tone | Message |
|---|---|---|
| **75%** | Calm heads-up | "You're at 75% of your turn budget. Continue your current approach; avoid starting new exploratory work." |
| **90%** | Firm wind-down | "You're at 90% of your turn budget. Finish your current edit, run verification, and summarize any remaining work." |

**Why this is better:**

1. **No more premature panic** — The 50% steer is gone. Agents get calm guidance at 75%, not anxiety at the halfway mark.
2. **Graduated urgency** — 75% is purely advisory ("keep going, just don't start new threads"). 90% is the concrete "land the plane now" signal, fired only 1–2 turns before the hard limit. The agent has just enough runway to commit, verify, and summarize.
3. **Threshold-specific messaging** — Each row carries its own message, so tone and content match the actual urgency of the moment.
4. **Extensible structure** — Adding a future threshold (e.g. 95%) is now a one-line change in the table, not a refactor of array indexing + hard-coded templates.

## What changed

| File | Change |
|---|---|
| `agent-runner.ts` | `progressSteerThresholds: number[]` → `PROGRESS_STEER_POINTS: {threshold, message}[]`; removed 50% entry; added 90% entry with stronger message |
| `agent-runner.test.ts` | Removed 50% test case; updated 75% case; added 90% case asserting 2 steers at 9/10 turns |

## Verification

- `pnpm run test` — 3,649 tests passed (232 files)
- `pnpm run typecheck` — clean
- `pnpm run lint` — clean (no non-null assertions)
