### PR TITLE
fix: remove tier-downgrade notification

### DIFF
--- a/src/extensions/model-guard.test.ts
+++ b/src/extensions/model-guard.test.ts
@@ -1,7 +1,5 @@
-import type { Api, ImageContent, Model, TextContent, ToolResultMessage, UserMessage } from "@earendil-works/pi-ai"
+import type { ImageContent, TextContent, ToolResultMessage, UserMessage } from "@earendil-works/pi-ai"
 import type { ContextEvent, ExtensionAPI, ExtensionContext } from "@earendil-works/pi-coding-agent"
-
-type ModelSelectEvent = { type: string; source: string; model: Model<Api>; previousModel?: Model<Api> }
 
 import { beforeEach, describe, expect, it, vi } from "vitest"
 import modelGuardExtension, {
@@ -533,64 +531,6 @@ describe("modelGuardExtension handler", () => {
 		const result = (await trigger("context", { messages: msgs }, ctx)) as { messages: ContextEvent["messages"] }
 		expect(result).toBeDefined()
 		expect(result.messages.length).toBeLessThan(30)
-	})
-})
-
-describe("model_select handler", () => {
-	let notifyMock: ReturnType<typeof vi.fn>
-	let ctx: ExtensionContext
-
-	beforeEach(() => {
-		__resetImagesDetectedForTest()
-		notifyMock = vi.fn()
-		ctx = makeMockCtx({
-			model: { id: "test-model", input: ["text"], contextWindow: 100_000 } as ExtensionContext["model"],
-			getContextUsage: () => ({ tokens: 1000, contextWindow: 100_000, percent: 1 }),
-			ui: { notify: notifyMock, setStatus: vi.fn() } as unknown as ExtensionContext["ui"],
-		})
-	})
-
-	it("skips source=restore events", async () => {
-		const { pi, trigger } = makeMockPI()
-		modelGuardExtension(pi)
-		const event: ModelSelectEvent = {
-			type: "model_select",
-			model: { id: "new-model", input: ["text"], contextWindow: 100_000 } as never,
-			previousModel: { id: "old-model", input: ["text"], contextWindow: 100_000 } as never,
-			source: "restore",
-		}
-		await trigger("model_select", event, ctx)
-		expect(notifyMock).not.toHaveBeenCalled()
-	})
-
-	it("warns on tier downgrade (heavy → standard)", async () => {
-		const { pi, trigger } = makeMockPI()
-		modelGuardExtension(pi)
-		const event: ModelSelectEvent = {
-			type: "model_select",
-			model: { id: "claude-sonnet-4-20250514", input: ["text"], contextWindow: 200_000 } as never,
-			previousModel: { id: "claude-sonnet-4-20250514", input: ["text", "image"], contextWindow: 200_000 } as never,
-			source: "set",
-		}
-		await trigger("model_select", event, ctx)
-		// The builtin-models.ts maps these, but we just verify the tier downgrade logic fires
-		// Note: actual tier depends on builtin-models.ts getModelTier implementation
-		// For this test we just verify the notify was called (info level for tier downgrade)
-		// The actual tier levels are determined by getModelTier from builtin-models.ts
-	})
-
-	it("does not warn on tier upgrade", async () => {
-		const { pi, trigger } = makeMockPI()
-		modelGuardExtension(pi)
-		// Use a model known to be heavy (claude-opus) upgrading from standard
-		const event: ModelSelectEvent = {
-			type: "model_select",
-			model: { id: "claude-opus-4-20250514", input: ["text", "image"], contextWindow: 200_000 } as never,
-			previousModel: { id: "claude-sonnet-4-20250514", input: ["text", "image"], contextWindow: 200_000 } as never,
-			source: "set",
-		}
-		await trigger("model_select", event, ctx)
-		expect(notifyMock).not.toHaveBeenCalled()
 	})
 })
 

--- a/src/extensions/model-guard.ts
+++ b/src/extensions/model-guard.ts
@@ -1,15 +1,5 @@
-import type {
-	Api,
-	AssistantMessage,
-	ImageContent,
-	Model,
-	TextContent,
-	ToolResultMessage,
-	UserMessage,
-} from "@earendil-works/pi-ai"
+import type { AssistantMessage, ImageContent, TextContent, ToolResultMessage, UserMessage } from "@earendil-works/pi-ai"
 import type { ContextEvent, ExtensionAPI, ExtensionContext } from "@earendil-works/pi-coding-agent"
-import { getModelTier } from "./model-switch.js"
-import { MODEL_CAPABILITIES } from "./orchestration/model-registry/builtin-models.js"
 
 /** Messages that have a content array we can inspect for images. */
 type ContentMessage = UserMessage | AssistantMessage | ToolResultMessage
@@ -332,33 +322,9 @@ export default function createModelGuardExtension(_pi: ExtensionAPI) {
 		if (modified) return { messages: result }
 	})
 
-	_pi.on("model_select", async (event: { source: string; previousModel?: Model<Api> }, ctx: ExtensionContext) => {
-		if (event.source === "restore") return
-
-		const model = ctx.model
-
-		// Context and vision guards are handled by the originating switch path:
-		// - "cycle" (ctrl+p): findNextCompatibleModel pre-filters incompatible models
-		// - "set" (set_model tool): blocks and reports to user before switching
-		// - "restore": skipped above (automatic reversion)
-		// Only tier-downgrade notifications remain here as they are informational
-		// and not checked by any pre-switch path.
-
-		if (event.previousModel) {
-			const prevTier = getModelTier(event.previousModel, MODEL_CAPABILITIES)
-			const nextTier = getModelTier(ctx.model, MODEL_CAPABILITIES)
-			if (prevTier && nextTier) {
-				const TIER_ORDER = ["heavy", "standard", "light"]
-				const prevIdx = TIER_ORDER.indexOf(prevTier)
-				const nextIdx = TIER_ORDER.indexOf(nextTier)
-				if (prevIdx < nextIdx) {
-					ctx.ui.notify(
-						`Switching from ${prevTier} → ${nextTier} tier. Reasoning and planning quality may be reduced.`,
-						"info",
-					)
-				}
-			}
-		}
+	_pi.on("model_select", async () => {
+		// model_select is handled entirely by model-switch.ts; model-guard only
+		// registers vision and context guards on the context event.
 	})
 }
 

--- a/src/extensions/model-switch.test.ts
+++ b/src/extensions/model-switch.test.ts
@@ -373,12 +373,6 @@ describe("modelSwitchExtension", () => {
 				expect((caps as { tier: unknown }).tier).toBe("heavy")
 			}
 		})
-	})
-
-	describe("tier-downgrade warning", () => {
-		beforeEach(() => {
-			__resetImagesDetectedForTest()
-		})
 
 		it("getModelTier returns heavy for kimi-k2.6 and light for nemotron (fresh import)", async () => {
 			const { MODEL_CAPABILITIES } = await import("./orchestration/model-registry/builtin-models.js")
@@ -390,8 +384,13 @@ describe("modelSwitchExtension", () => {
 			expect(currentTier).toBe("heavy")
 			expect(targetTier).toBe("light")
 		})
+	})
 
-		it("does not include tier warning in tool result (handled by model-guard notification)", async () => {
+	describe("set_model tool result", () => {
+		beforeEach(() => {
+			__resetImagesDetectedForTest()
+		})
+		it("does not include tier warning in tool result", async () => {
 			const h = createHarness()
 			const result = await h.exec("kimchi-dev/nemotron-3-super-fp4", {
 				currentModel: { id: "kimi-k2.6", provider: "kimchi-dev", name: "Kimi K2.6" },
@@ -730,57 +729,6 @@ describe("modelSwitchExtension", () => {
 			)
 			expect(setModel).not.toHaveBeenCalled()
 			expect(notify).not.toHaveBeenCalledWith(expect.stringContaining("vision"), "error")
-		})
-
-		it("shows info notification on tier downgrade (heavy → light)", async () => {
-			const { pi, trigger } = createHarnessWithTrigger()
-			modelSwitchExtension(pi)
-			const notify = vi.fn()
-			await trigger(
-				"model_select",
-				{
-					type: "model_select",
-					model: { id: "nemotron-3-super-fp4", provider: "kimchi-dev", input: ["text"], contextWindow: 1_000_000 },
-					previousModel: { id: "kimi-k2.6", provider: "kimchi-dev", input: ["text", "image"] },
-					source: "set",
-				},
-				mockCtx({ tokens: 10_000, ui: { notify }, modelId: "nemotron-3-super-fp4" }),
-			)
-			expect(notify).toHaveBeenCalledWith(expect.stringContaining("heavy"), "info")
-		})
-
-		it("does NOT notify on tier upgrade", async () => {
-			const { pi, trigger } = createHarnessWithTrigger()
-			modelSwitchExtension(pi)
-			const notify = vi.fn()
-			await trigger(
-				"model_select",
-				{
-					type: "model_select",
-					model: { id: "kimi-k2.6", provider: "kimchi-dev", input: ["text", "image"], contextWindow: 200_000 },
-					previousModel: { id: "nemotron-3-super-fp4", provider: "kimchi-dev", input: ["text"] },
-					source: "set",
-				},
-				mockCtx({ tokens: 10_000, ui: { notify } }),
-			)
-			expect(notify).not.toHaveBeenCalled()
-		})
-
-		it("does NOT notify when tier is unknown", async () => {
-			const { pi, trigger } = createHarnessWithTrigger()
-			modelSwitchExtension(pi)
-			const notify = vi.fn()
-			await trigger(
-				"model_select",
-				{
-					type: "model_select",
-					model: { id: "unknown-model", provider: "kimchi-dev", input: ["text"], contextWindow: 100_000 },
-					previousModel: { id: "kimi-k2.6", provider: "kimchi-dev", input: ["text", "image"] },
-					source: "set",
-				},
-				mockCtx({ tokens: 10_000, ui: { notify } }),
-			)
-			expect(notify).not.toHaveBeenCalled()
 		})
 
 		it("syncs multi-model process flag to extension state on model_select from /models UI", async () => {

--- a/src/extensions/model-switch.ts
+++ b/src/extensions/model-switch.ts
@@ -20,9 +20,6 @@ import {
 	setMultiModelEnabled,
 } from "./prompt-construction/prompt-enrichment.js"
 
-/** Tier ordering for downgrade detection: higher index = lower tier. */
-const TIER_ORDER: ModelTier[] = ["heavy", "standard", "light"]
-
 /** Prevents model_select handler from re-checking what set_model tool already validated. */
 let suppressModelSelectGuard = false
 
@@ -246,17 +243,6 @@ export default function modelSwitchExtension(pi: ExtensionAPI) {
 				"error",
 			)
 			return
-		}
-
-		// Tier-downgrade info — non-blocking
-		const prevTier = getModelTier(event.previousModel as never, MODEL_CAPABILITIES)
-		const nextTier = getModelTier(event.model as never, MODEL_CAPABILITIES)
-		// Explicit model selection (e.g. /model) disables multi-model unless the orchestrator itself was picked
-		if (prevTier && nextTier && TIER_ORDER.indexOf(prevTier) < TIER_ORDER.indexOf(nextTier)) {
-			ctx.ui?.notify(
-				`Switching from ${prevTier}-tier to ${nextTier}-tier model. Reasoning quality may be reduced for complex tasks.`,
-				"info",
-			)
 		}
 
 		if (event.source === "set") {


### PR DESCRIPTION
Removes the UI notification shown when switching from a heavier to a lighter model tier.

The notification (`Switching from heavy → light tier...`) was displayed in two places:
- `src/extensions/model-switch.ts` on `model_select` events
- `src/extensions/model-guard.ts` on `model_select` events

This PR removes both notification blocks, cleans up now-unused imports and constants, and updates the corresponding test files.