### PR TITLE
fix: add GIT_EDITOR and dynamic branch detection to git-hygiene skill

### DIFF
--- a/src/extensions/behaviours/bodies/git-hygiene.md
+++ b/src/extensions/behaviours/bodies/git-hygiene.md
@@ -9,3 +9,5 @@ When using git:
 - Never run destructive commands (`git reset --hard`, `git push --force`, `git branch -D`, `git clean -f`) on `main`, `master`, `release/*`, or other protected branches without explicit user approval.
 - Prefer creating new commits over amending published commits. Only amend when the user explicitly asks.
 - Never skip hooks (`--no-verify`) or bypass signing unless the user explicitly asks. If a hook fails, fix the underlying issue.
+- When running automated git commands that may invoke an editor (e.g. `git rebase`, `git commit`, `git merge --squash`), set `GIT_EDITOR=true` — an interactive shell must not block execution or cause the command to hang.
+- Do not hardcode branch names like `main` or `master`. Detect the default branch dynamically (e.g. `git symbolic-ref refs/remotes/origin/HEAD --short | sed 's/origin\///'`). Use the detected name in scripts and commands.


### PR DESCRIPTION
## Problem

The git-hygiene skill file lacked guidance on two common pitfalls that cause AI-assisted coding sessions to hang or make incorrect assumptions:

1. **Interactive shells blocking automated git operations** — When agents run commands like `git rebase`, `git commit`, or `git merge --squash`, git may open an interactive editor (e.g. vim, nano). In a headless/automated context, this causes the command to hang indefinitely, waiting for input that will never come. This is a frequent source of stalled sessions.

2. **Hardcoded default branch names** — Many repositories use `main`, but others use `master`, `trunk`, or custom default branch names. Scripts and instructions that hardcode `main` fail on repositories with different conventions, leading to errors like `fatal: invalid reference: main`.

## Solution

Extend `git-hygiene.md` with two new bullet points:

- **GIT_EDITOR=true** — When running automated git commands that may invoke an editor, set `GIT_EDITOR=true` so the command either succeeds or fails fast. An interactive shell must not block execution.

- **Dynamic default-branch detection** — Detect the repository's default branch dynamically (e.g. `git symbolic-ref refs/remotes/origin/HEAD --short | sed 's/origin\///'`) rather than hardcoding `main` or `master`. Use the detected name in scripts and commands so guidance works across all repositories.

## Changes

- `src/extensions/behaviours/bodies/git-hygiene.md`: added 2 bullet points (2 lines)

## Verification

- [x] New content matches existing tone and structure of the skill file
- [x] File renders as valid markdown
- [x] Both `GIT_EDITOR` and `default branch` guidance are present in the file