### PR TITLE
fix: trust OS certificate store in compiled binary

### DIFF
--- a/scripts/build-binary.js
+++ b/scripts/build-binary.js
@@ -44,9 +44,12 @@ run("typecheck", "pnpm run typecheck")
 // If a new dependency causes a build failure, check whether it also needs --external here.
 const targetFlag = crossTarget ? ` --target=${crossTarget}` : ""
 
+// Trust the OS certificate store in addition to Bun's bundled roots so users behind
+// TLS-intercepting corporate proxies (Netskope, Zscaler, etc.) can reach the API without
+// extra env vars. Bun ignores the system store by default; --use-system-ca is additive.
 run(
 	"compile",
-	`bun build src/entry.ts --compile${targetFlag} --outfile dist/bin/kimchi --external chromium-bidi --external electron`.trim(),
+	`bun build src/entry.ts --compile${targetFlag} --compile-exec-argv="--use-system-ca" --outfile dist/bin/kimchi --external chromium-bidi --external electron`.trim(),
 )
 
 // Bun --compile produces binaries with an invalid code signature on macOS.

--- a/src/setup-wizard/steps/done.test.ts
+++ b/src/setup-wizard/steps/done.test.ts
@@ -129,6 +129,28 @@ describe("runDoneStep", () => {
 		writeSpy.mockRestore()
 	})
 
+	it("aborts before configuring tools when model fetch fails without a cache", async () => {
+		vi.mocked(modelsModule.updateModelsConfig).mockRejectedValueOnce(
+			new Error("self signed certificate in certificate chain"),
+		)
+		const tool = getClaudeCodeTool()
+		const writeSpy = vi.spyOn(tool, "write").mockResolvedValue()
+
+		const outcome = await runDoneStep(baseState())
+
+		expect(writeSpy).not.toHaveBeenCalled()
+		expect(outcome.successes).toEqual([])
+		expect(outcome.failures).toEqual([
+			{ id: "*", error: "model fetch failed: self signed certificate in certificate chain" },
+		])
+		expect(clackMock.spinnerInstance.stop).toHaveBeenCalledWith(
+			"Could not fetch available models: self signed certificate in certificate chain",
+		)
+		expect(clackMock.outro).toHaveBeenCalledWith("Aborted.")
+
+		writeSpy.mockRestore()
+	})
+
 	it("inject mode skips the writer entirely", async () => {
 		const tool = getClaudeCodeTool()
 		const writeSpy = vi.spyOn(tool, "write").mockResolvedValue()


### PR DESCRIPTION
## Description

Bun ignores the system trust store by default and validates TLS only against its bundled Mozilla roots. Users behind TLS-intercepting corporate proxies (Netskope, Zscaler, etc.) therefore hit "self signed certificate in certificate chain" during `kimchi setup`, even though the proxy root is installed in their OS keychain (their browser works fine).

Bake --use-system-ca into the compiled binary via --compile-exec-argv so the OS-installed corporate root is honored with no env var. The flag is additive: Bun's bundled roots stay trusted, so non-corporate users are unaffected.

Also add a regression test for the graceful-abort path when the model fetch fails, which is the failure mode this proxy issue triggers.

## Type of Change

<!-- Select all that apply. -->

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
