### PR TITLE
feat: add exploration guard extension

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -27,6 +27,7 @@ import bashCollapseExtension from "./extensions/bash-collapse.js"
 import behavioursExtension from "./extensions/behaviours/index.js"
 import clipboardImageExtension from "./extensions/clipboard-image.js"
 import contextCompactorExtension from "./extensions/context-compactor.js"
+import explorationGuardExtension from "./extensions/exploration-guard.js"
 import fermentExtension from "./extensions/ferment/index.js"
 import helpExtension from "./extensions/help.js"
 import hideThinkingExtension from "./extensions/hide-thinking.js"
@@ -461,6 +462,7 @@ try {
 			terminalColorsExtension,
 			kimchiMinimalTintsExtension,
 			loopGuardExtension,
+			explorationGuardExtension,
 			lspExtension,
 			...enabledExtensionFactories([
 				{ id: "plugins.mcp-apps", factory: mcpAdapterExtension },

--- a/src/extensions/exploration-guard.test.ts
+++ b/src/extensions/exploration-guard.test.ts
@@ -1,0 +1,191 @@
+import { describe, expect, it, vi } from "vitest"
+import { ExplorationGuard, type ExplorationGuardOptions, STEER_MESSAGE_TYPE } from "./exploration-guard.js"
+
+function createGuard(options?: ExplorationGuardOptions): ExplorationGuard {
+	return new ExplorationGuard(options)
+}
+
+function simulateReadTurn(guard: ExplorationGuard): string[] {
+	const steers: string[] = []
+	guard.turnStart()
+	guard.recordToolCall("read")
+	guard.turnEnd((text) => steers.push(text))
+	return steers
+}
+
+function simulateWriteTurn(guard: ExplorationGuard): string[] {
+	const steers: string[] = []
+	guard.turnStart()
+	guard.recordToolCall("edit")
+	guard.turnEnd((text) => steers.push(text))
+	return steers
+}
+
+function simulateNoToolTurn(guard: ExplorationGuard): string[] {
+	const steers: string[] = []
+	guard.turnStart()
+	guard.turnEnd((text) => steers.push(text))
+	return steers
+}
+
+function simulateMixedTurn(guard: ExplorationGuard): string[] {
+	const steers: string[] = []
+	guard.turnStart()
+	guard.recordToolCall("read")
+	guard.recordToolCall("edit")
+	guard.turnEnd((text) => steers.push(text))
+	return steers
+}
+
+describe("ExplorationGuard.reset", () => {
+	it("clears the streak", () => {
+		const guard = createGuard()
+		for (let i = 0; i < 4; i++) simulateReadTurn(guard)
+		expect(guard.getConsecutiveReadOnlyTurns()).toBe(4)
+		guard.reset()
+		expect(guard.getConsecutiveReadOnlyTurns()).toBe(0)
+	})
+})
+
+describe("Read-only turn counting", () => {
+	it("increments streak on consecutive read-only turns", () => {
+		const guard = createGuard()
+		for (let i = 0; i < 3; i++) simulateReadTurn(guard)
+		expect(guard.getConsecutiveReadOnlyTurns()).toBe(3)
+	})
+
+	it("resets streak on a write turn", () => {
+		const guard = createGuard()
+		for (let i = 0; i < 3; i++) simulateReadTurn(guard)
+		simulateWriteTurn(guard)
+		expect(guard.getConsecutiveReadOnlyTurns()).toBe(0)
+	})
+
+	it("resets streak on a no-tool turn", () => {
+		const guard = createGuard()
+		for (let i = 0; i < 3; i++) simulateReadTurn(guard)
+		simulateNoToolTurn(guard)
+		expect(guard.getConsecutiveReadOnlyTurns()).toBe(0)
+	})
+
+	it("resets streak on a mixed read+write turn", () => {
+		const guard = createGuard()
+		for (let i = 0; i < 3; i++) simulateReadTurn(guard)
+		simulateMixedTurn(guard)
+		expect(guard.getConsecutiveReadOnlyTurns()).toBe(0)
+	})
+
+	it("does not increment on the first tool-less turn", () => {
+		const guard = createGuard()
+		simulateNoToolTurn(guard)
+		expect(guard.getConsecutiveReadOnlyTurns()).toBe(0)
+	})
+})
+
+describe("Threshold triggers", () => {
+	it("emits a reminder at the default hypothesis threshold (5)", () => {
+		const guard = createGuard()
+		const steers: string[] = []
+		for (let i = 0; i < 4; i++) simulateReadTurn(guard)
+		expect(steers).toHaveLength(0)
+
+		// 5th read-only turn triggers reminder
+		guard.turnStart()
+		guard.recordToolCall("read")
+		guard.turnEnd((text) => steers.push(text))
+		expect(steers).toHaveLength(1)
+		expect(steers[0]).toContain("Exploration guard")
+		expect(steers[0]).toContain("5 consecutive turns")
+		expect(steers[0]).toContain("hypothesis")
+	})
+
+	it("emits a mandatory steer at the default steer threshold (8)", () => {
+		const guard = createGuard()
+		const steers: string[] = []
+		for (let i = 0; i < 7; i++) {
+			guard.turnStart()
+			guard.recordToolCall("grep")
+			guard.turnEnd((text) => steers.push(text))
+		}
+		expect(steers).toHaveLength(1) // only the reminder at 5
+
+		// 8th read-only turn triggers mandatory steer
+		guard.turnStart()
+		guard.recordToolCall("find")
+		guard.turnEnd((text) => steers.push(text))
+		expect(steers).toHaveLength(2)
+		expect(steers[1]).toContain("8 consecutive turns")
+		expect(steers[1]).toContain("MUST")
+	})
+
+	it("uses custom thresholds", () => {
+		const guard = createGuard({ hypothesisThreshold: 2, steerThreshold: 4 })
+		const steers: string[] = []
+
+		guard.turnStart()
+		guard.recordToolCall("ls")
+		guard.turnEnd((text) => steers.push(text))
+		expect(steers).toHaveLength(0)
+
+		guard.turnStart()
+		guard.recordToolCall("ls")
+		guard.turnEnd((text) => steers.push(text))
+		expect(steers).toHaveLength(1)
+		expect(steers[0]).toContain("2 consecutive turns")
+
+		guard.turnStart()
+		guard.recordToolCall("ls")
+		guard.turnEnd((text) => steers.push(text))
+		expect(steers).toHaveLength(1)
+
+		guard.turnStart()
+		guard.recordToolCall("ls")
+		guard.turnEnd((text) => steers.push(text))
+		expect(steers).toHaveLength(2)
+		expect(steers[1]).toContain("4 consecutive turns")
+	})
+
+	it("does not trigger twice on the same threshold", () => {
+		const guard = createGuard()
+		const steers: string[] = []
+		for (let i = 0; i < 10; i++) {
+			guard.turnStart()
+			guard.recordToolCall("read")
+			guard.turnEnd((text) => steers.push(text))
+		}
+		expect(steers.filter((s) => s.includes("5 consecutive turns"))).toHaveLength(1)
+		expect(steers.filter((s) => s.includes("8 consecutive turns"))).toHaveLength(1)
+	})
+})
+
+describe("Custom tool classification", () => {
+	it("treats custom read tools as read-only", () => {
+		const guard = createGuard({ readTools: new Set(["custom_read"]), writeTools: new Set(["custom_write"]) })
+		const steers: string[] = []
+		for (let i = 0; i < 5; i++) {
+			guard.turnStart()
+			guard.recordToolCall("custom_read")
+			guard.turnEnd((text) => steers.push(text))
+		}
+		expect(steers).toHaveLength(1)
+	})
+
+	it("treats custom write tools as write operations", () => {
+		const guard = createGuard({ readTools: new Set(["custom_read"]), writeTools: new Set(["custom_write"]) })
+		for (let i = 0; i < 4; i++) {
+			guard.turnStart()
+			guard.recordToolCall("custom_read")
+			guard.turnEnd(() => {})
+		}
+		guard.turnStart()
+		guard.recordToolCall("custom_write")
+		guard.turnEnd(() => {})
+		expect(guard.getConsecutiveReadOnlyTurns()).toBe(0)
+	})
+})
+
+describe("STEER_MESSAGE_TYPE", () => {
+	it("has a stable custom type string", () => {
+		expect(STEER_MESSAGE_TYPE).toBe("exploration-guard-steer")
+	})
+})

--- a/src/extensions/exploration-guard.ts
+++ b/src/extensions/exploration-guard.ts
@@ -1,0 +1,133 @@
+import type { ExtensionAPI, InputEvent } from "@earendil-works/pi-coding-agent"
+
+export const DEFAULT_READ_TOOLS = new Set([
+	"read",
+	"grep",
+	"find",
+	"ls",
+	"web_search",
+	"web_fetch",
+	"lsp_hover",
+	"lsp_definition",
+	"lsp_references",
+	"lsp_diagnostics",
+	"bash",
+	"mcp",
+])
+
+export const DEFAULT_WRITE_TOOLS = new Set(["edit", "write", "lsp_rename", "ask_user", "steer_subagent", "Agent"])
+
+export interface ExplorationGuardOptions {
+	/** Tools that count as read-only (default: common inspection tools). */
+	readTools?: Set<string>
+	/** Tools that count as write operations (default: common mutating tools). */
+	writeTools?: Set<string>
+	/** Number of consecutive read-only turns before a reminder is injected. Default: 5 */
+	hypothesisThreshold?: number
+	/** Number of consecutive read-only turns before a mandatory steer is injected. Default: 8 */
+	steerThreshold?: number
+}
+
+const HYPOTHESIS_REMINDER_BASE =
+	"Exploration guard: you have spent %d consecutive turns reading without formulating a concrete hypothesis. State your hypothesis and run ONE targeted command to test it. Reading without a hypothesis wastes tokens."
+
+const MANDATORY_STEER_BASE =
+	"Exploration guard: you have spent %d consecutive turns in read-only exploration. You MUST either (1) state a concrete hypothesis and test it with a single targeted command, or (2) transition to the plan phase. Do not continue reading without a hypothesis."
+
+export const STEER_MESSAGE_TYPE = "exploration-guard-steer"
+
+export class ExplorationGuard {
+	private readonly readTools: Set<string>
+	private readonly writeTools: Set<string>
+	private readonly hypothesisThreshold: number
+	private readonly steerThreshold: number
+
+	private consecutiveReadOnlyTurns = 0
+	private currentTurnHasWriteTool = false
+	private currentTurnHasAnyTool = false
+
+	constructor(options: ExplorationGuardOptions = {}) {
+		this.readTools = options.readTools ?? new Set(DEFAULT_READ_TOOLS)
+		this.writeTools = options.writeTools ?? new Set(DEFAULT_WRITE_TOOLS)
+		this.hypothesisThreshold = options.hypothesisThreshold ?? 5
+		this.steerThreshold = options.steerThreshold ?? 8
+	}
+
+	reset(): void {
+		this.consecutiveReadOnlyTurns = 0
+		this.currentTurnHasWriteTool = false
+		this.currentTurnHasAnyTool = false
+	}
+
+	turnStart(): void {
+		this.currentTurnHasWriteTool = false
+		this.currentTurnHasAnyTool = false
+	}
+
+	recordToolCall(toolName: string): void {
+		this.currentTurnHasAnyTool = true
+		if (this.writeTools.has(toolName)) {
+			this.currentTurnHasWriteTool = true
+		}
+	}
+
+	turnEnd(sendSteer: (text: string) => void): void {
+		// A turn is read-only only if it contains at least one tool and none
+		// of them are write tools. Turns with no tools or with write tools
+		// reset the streak.
+		if (!this.currentTurnHasAnyTool || this.currentTurnHasWriteTool) {
+			this.consecutiveReadOnlyTurns = 0
+			return
+		}
+
+		this.consecutiveReadOnlyTurns++
+
+		if (this.consecutiveReadOnlyTurns === this.hypothesisThreshold) {
+			sendSteer(HYPOTHESIS_REMINDER_BASE.replace("%d", String(this.hypothesisThreshold)))
+		}
+		if (this.consecutiveReadOnlyTurns === this.steerThreshold) {
+			sendSteer(MANDATORY_STEER_BASE.replace("%d", String(this.steerThreshold)))
+		}
+	}
+
+	getConsecutiveReadOnlyTurns(): number {
+		return this.consecutiveReadOnlyTurns
+	}
+}
+
+export default function explorationGuardExtension(pi: ExtensionAPI, options?: ExplorationGuardOptions): void {
+	const guard = new ExplorationGuard(options)
+
+	pi.on("session_start", () => {
+		guard.reset()
+	})
+
+	pi.on("input", (event: InputEvent) => {
+		// User input breaks the exploration streak.
+		if (event.source === "extension") return
+		guard.reset()
+	})
+
+	pi.on("turn_start", () => {
+		guard.turnStart()
+	})
+
+	pi.on("tool_call", (event) => {
+		if (!event.toolName) return
+		guard.recordToolCall(event.toolName)
+		return { block: false }
+	})
+
+	pi.on("turn_end", () => {
+		guard.turnEnd((text) => {
+			pi.sendMessage(
+				{
+					customType: STEER_MESSAGE_TYPE,
+					content: [{ type: "text", text }],
+					display: false,
+				},
+				{ deliverAs: "steer" },
+			)
+		})
+	})
+}

--- a/src/extensions/orchestration/model-registry/guidelines/default-phase-guidelines.ts
+++ b/src/extensions/orchestration/model-registry/guidelines/default-phase-guidelines.ts
@@ -6,6 +6,7 @@ export const DEFAULT_EXPLORE_GUIDELINES = `During **explore** phase:
 - Start broad with \`grep\`/\`find\`/\`ls\`; then \`read\` the 3–5 most relevant files in full.
 - Trace imports and call chains across module boundaries — note the actual entry points and seams, not every file you saw.
 - Batch independent reads in a single turn to minimise round-trips.
+- **Hypothesis testing**: After 5 consecutive read-only turns without a concrete hypothesis, state your hypothesis and run ONE targeted command to test it. Exploration without a hypothesis wastes tokens.
 - Stop as soon as you have enough context to plan. Over-exploring wastes tokens.
 - Output: a tight summary (paths, key types, integration points) — what matters, not everything you saw.`
 


### PR DESCRIPTION
## Problem

Agents frequently get stuck in read-only loops during the **explore** phase — repeatedly calling `read`, `grep`, `find`, and `ls` without ever forming a concrete hypothesis. This wastes tokens and extends exploration far beyond what is useful.

## Solution

This PR adds an **ExplorationGuard** extension that tracks consecutive read-only turns and injects corrective steers when the agent is drifting:

- **Configurable thresholds** (default: 5 for a reminder, 8 for a mandatory steer).
- **Read-only classification** via configurable tool sets (defaults cover the common inspection/mutation split).
- **Reset on user input** or session start — a fresh user prompt or a write tool breaks the streak naturally.

### How it works

1. On each turn the extension checks whether every tool call in that turn is read-only.
2. If so, it increments an internal streak counter.
3. When the streak hits the first threshold, a reminder steer is injected:
   > "Exploration guard: you have spent N consecutive turns reading without formulating a concrete hypothesis. State your hypothesis and run ONE targeted command to test it."
4. When the streak hits the second threshold, a firmer steer is injected:
   > "Exploration guard: you have spent N consecutive turns in read-only exploration. You MUST either state a concrete hypothesis and test it, or transition to the plan phase."

### Changes

- `src/extensions/exploration-guard.ts` — new extension with configurable thresholds and steer injection.
- `src/extensions/exploration-guard.test.ts` — unit tests for counting, threshold triggers, and steer content.
- `src/cli.ts` — registers the extension in the harness.
- `src/extensions/orchestration/model-registry/guidelines/default-phase-guidelines.ts` — adds the hypothesis-testing instruction to the explore-phase guidelines.

### Co-Authored By

Kimchi <noreply@kimchi.dev>
