### PR TITLE
fix: theme-aware shiki syntax highlighting in Write/Edit diffs

### DIFF
--- a/src/extensions/tool-rendering.ts
+++ b/src/extensions/tool-rendering.ts
@@ -1151,7 +1151,18 @@ function themeAdaptiveEnabled(): boolean {
 }
 
 let DIFF_THEME: BundledTheme = (process.env.DIFF_THEME as BundledTheme | undefined) ?? "github-dark"
+let hasExplicitShikiTheme = false
 let codeToAnsiLoader: Promise<any> | null = null
+
+function isHarnessThemeLight(themeName: string | undefined): boolean {
+	if (!themeName) return false
+	const n = themeName.toLowerCase()
+	return n === "light" || n.endsWith("-light") || n.startsWith("light-")
+}
+
+function shikiThemeForHarnessTheme(themeName: string | undefined): BundledTheme {
+	return isHarnessThemeLight(themeName) ? "github-light" : "github-dark"
+}
 
 const SPLIT_MIN_WIDTH = 150
 const SPLIT_MIN_CODE_WIDTH = 60
@@ -1327,6 +1338,16 @@ function applyThemePaletteIfNeeded(theme: any): void {
 		autoDeriveBgFromTheme(theme)
 		autoDerivePending = false
 	}
+
+	// Auto-select shiki theme to match harness theme light/dark mode, unless
+	// the user pinned an explicit shikiTheme in their diffTheme/diffColors config.
+	if (!hasExplicitShikiTheme && !process.env.DIFF_THEME) {
+		const derived = shikiThemeForHarnessTheme(theme?.name)
+		if (derived !== DIFF_THEME) {
+			DIFF_THEME = derived
+			clearHighlightCache()
+		}
+	}
 }
 
 function applyDiffPalette(): void {
@@ -1401,7 +1422,12 @@ function applyDiffPalette(): void {
 	})
 
 	const shiki = overrides.shikiTheme ?? preset?.shikiTheme
-	if (shiki) DIFF_THEME = shiki as BundledTheme
+	if (shiki) {
+		DIFF_THEME = shiki as BundledTheme
+		hasExplicitShikiTheme = true
+	} else {
+		hasExplicitShikiTheme = false
+	}
 
 	DIVIDER = `${FG_RULE}│${D_RST}`
 	DEFAULT_DIFF_COLORS = { fgAdd: FG_ADD, fgDel: FG_DEL, fgCtx: FG_DIM }
@@ -1505,6 +1531,10 @@ function ansiState(text: string): string {
 
 function normalizeShikiContrast(ansi: string): string {
 	return ansi.replace(/\x1b\[([0-9;]*)m/g, (seq, params: string) => {
+		// Strip background colors emitted by shiki — the diff renderer manages
+		// its own per-line backgrounds (BG_ADD, BG_DEL, BG_BASE, etc.) and shiki
+		// bg codes would override them regardless of the active harness theme.
+		if (params.startsWith("48;")) return ""
 		if (params === "30" || params === "90" || params === "38;5;0" || params === "38;5;8") return FG_SAFE_MUTED
 		if (!params.startsWith("38;2;")) return seq
 		const parts = params.split(";").map(Number)


### PR DESCRIPTION
## Problem

The Write/Edit tool diff view always rendered with a dark background, even when the user was on a light harness theme (e.g. `github-light`, `light`, `kimchi-light`).

Two compounding bugs:

**Bug 1 — shiki emits background ANSI codes that override diff colors**
`codeToANSI` with the `github-dark` shiki theme emits `\x1b[48;2;13;17;23m` (near-black) on every token. These codes appear _after_ `BG_ADD`/`BG_BASE` in each composed diff line, so shiki's bg always wins. `normalizeShikiContrast` only adjusted low-luminance fg codes and never touched bg codes.

**Bug 2 — shiki theme was hardcoded to `github-dark`**
`DIFF_THEME` was initialized to `"github-dark"` and never updated based on the active harness theme, so light-theme users always got dark syntax highlighting.

## Fix

- **`normalizeShikiContrast`**: strip all `48;*` background escape codes from shiki output. The diff renderer owns its own backgrounds (`BG_ADD`, `BG_DEL`, `BG_BASE`, etc.) — shiki has no business setting them.

- **`shikiThemeForHarnessTheme` / `isHarnessThemeLight`**: new helpers that map harness theme name → shiki theme. Themes named `light`, `*-light`, or `light-*` get `github-light`; everything else gets `github-dark`.

- **`applyThemePaletteIfNeeded`**: auto-selects and applies the mapped shiki theme on every theme change. Invalidates `hlCache` when it switches. User-pinned `shikiTheme` (via `diffTheme`/`diffColors` config) and the `DIFF_THEME` env var bypass auto-selection.

## Test plan

- [ ] Open a session with a light theme (`github-light`, `light`, `kimchi-light`, `solarized-light`) — Write tool diff should render with light syntax colors and no dark background
- [ ] Open a session with a dark theme — diff should look unchanged (still `github-dark` shiki)
- [ ] Set `diffColors.shikiTheme` in settings — verify user's explicit choice is not overridden
- [ ] Switch themes mid-session — verify diff re-renders with the new theme's shiki colors
- [ ] `pnpm test` passes (same pre-existing failures as before, no regressions)