### PR TITLE
chore: disable tool-result pruning extension until redesign lands

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -26,7 +26,6 @@ import assistantPrefixExtension from "./extensions/assistant-prefix.js"
 import bashCollapseExtension from "./extensions/bash-collapse.js"
 import behavioursExtension from "./extensions/behaviours/index.js"
 import clipboardImageExtension from "./extensions/clipboard-image.js"
-import contextCompactorExtension from "./extensions/context-compactor.js"
 import explorationGuardExtension from "./extensions/exploration-guard.js"
 import fermentExtension from "./extensions/ferment/index.js"
 import helpExtension from "./extensions/help.js"
@@ -479,7 +478,6 @@ try {
 			resourceToolBlockerExtension,
 			behavioursExtension,
 			promptSummaryExtension,
-			contextCompactorExtension,
 			hideThinkingExtension,
 			thinkingStepsExtension,
 			assistantPrefixExtension,

--- a/src/extensions/disabled/tool-result-pruning.test.ts
+++ b/src/extensions/disabled/tool-result-pruning.test.ts
@@ -7,7 +7,7 @@ import contextCompactorExtension, {
 	pruneToolResult,
 	RETAIN_HEAD_LINES,
 	RETAIN_TAIL_LINES,
-} from "./context-compactor.js"
+} from "./tool-result-pruning.js"
 
 // helpers
 /** Create multi-line text that will be compacted (>60 lines, >minChars chars) */

--- a/src/extensions/disabled/tool-result-pruning.ts
+++ b/src/extensions/disabled/tool-result-pruning.ts
@@ -1,6 +1,6 @@
 import type { AssistantMessage, ToolResultMessage } from "@earendil-works/pi-ai"
 import type { ContextEvent, ExtensionAPI } from "@earendil-works/pi-coding-agent"
-import { isSubagent } from "./prompt-construction/prompt-enrichment.js"
+import { isSubagent } from "../prompt-construction/prompt-enrichment.js"
 
 const PRUNE_THRESHOLD = 35_000
 const PROTECT_WINDOW = 30


### PR DESCRIPTION
## What

Moves the tool-result pruning extension to `src/extensions/disabled/` (renamed from `context-compactor.ts` to `tool-result-pruning.ts`) and removes its import and registration from `cli.ts`.

**This does NOT affect the `/compact` command** — that is handled entirely by upstream pi-coding-agent core and is unrelated to this extension.

## Why

The current tombstone-based pruning causes model amnesia. When tool results are replaced with `[compacted: bash output, N chars]` placeholders, the assistant can see it made tool calls but not what they returned. In practice this causes the model to re-read and re-grep the same files repeatedly in the same session.

Concrete example from a real session: the same file was read **12 times** and the same grep run **8 times** — all because the 35k token threshold fired at turn 4 and tombstoned the read results the model had just fetched.

## Follow-up

`ilie/context-compactor-redesign` replaces the tombstone approach with coherent full-turn dropping + an action log summary. That branch is ready for review. This PR is a temporary safety measure until it lands.