### PR TITLE
feat(compactor): replace tombstone pruning with coherent pair-drop and action log

### DIFF
--- a/src/extensions/context-compactor.test.ts
+++ b/src/extensions/context-compactor.test.ts
@@ -1,9 +1,8 @@
-import type { TextContent, ToolCall, ToolResultMessage } from "@earendil-works/pi-ai"
+import type { ToolCall, ToolResultMessage, UserMessage } from "@earendil-works/pi-ai"
 import type { ContextEvent, ExtensionAPI } from "@earendil-works/pi-coding-agent"
 import { describe, expect, it } from "vitest"
 import contextCompactorExtension, {
 	computeCutoff,
-	pruneToolResult,
 	groupTurnsBeforeCutoff,
 	partitionDropZone,
 	buildActionLog,
@@ -85,6 +84,51 @@ function makeToolResultFor(callId: string, toolName: string, text: string, isErr
 	}
 }
 
+function makeMessageEndEvent(inputTokens: number) {
+	return {
+		message: {
+			role: "assistant" as const,
+			content: [{ type: "text" as const, text: "ok" }],
+			usage: {
+				input: inputTokens,
+				output: 0,
+				cacheRead: 0,
+				cacheWrite: 0,
+				totalTokens: inputTokens,
+				cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+			},
+			// biome-ignore lint/suspicious/noExplicitAny: test stub
+			api: "openai-completions" as any,
+			// biome-ignore lint/suspicious/noExplicitAny: test stub
+			provider: "test" as any,
+			// biome-ignore lint/suspicious/noExplicitAny: test stub
+			stopReason: "endTurn" as any,
+			model: "test",
+			timestamp: 0,
+		},
+	}
+}
+
+function makeMockPI(contextWindow = 131_072) {
+	const handlers: Record<string, (event: unknown, ctx: unknown) => Promise<unknown>> = {}
+	const entries: Array<{ customType: string; data: unknown }> = []
+	const ctx = { model: { contextWindow } }
+	return {
+		pi: {
+			on(event: string, handler: (e: unknown, c: unknown) => Promise<unknown>) {
+				handlers[event] = handler
+			},
+			appendEntry(customType: string, data: unknown) {
+				entries.push({ customType, data })
+			},
+		} as unknown as ExtensionAPI,
+		async trigger(event: string, payload: unknown) {
+			return handlers[event]?.(payload, ctx)
+		},
+		entries,
+	}
+}
+
 // ── computeCutoff ────────────────────────────────────────────────────────────
 
 describe("computeCutoff", () => {
@@ -140,205 +184,216 @@ describe("computeCutoff", () => {
 	})
 })
 
-// ── pruneToolResult ──────────────────────────────────────────────────────────
+// ── contextCompactorExtension (pair-drop) ────────────────────────────────────
 
-describe("pruneToolResult", () => {
-	const MIN_PRUNE_CHARS = 10
-
-	it("returns a new object (no mutation)", () => {
-		const msg = makeToolResult("bash", "x".repeat(20))
-		const result = pruneToolResult(msg, MIN_PRUNE_CHARS)
-		expect(result).not.toBe(msg)
-		expect(msg.content[0]).toHaveProperty("text", "x".repeat(20)) // original unchanged
-	})
-
-	it("replaces large text content with placeholder", () => {
-		const msg = makeToolResult("bash", "x".repeat(20))
-		const result = pruneToolResult(msg, MIN_PRUNE_CHARS)
-		expect(result.content[0]).toHaveProperty("type", "text")
-		expect((result.content[0] as TextContent).text).toContain("[compacted: bash output")
-	})
-
-	it("leaves small text content untouched", () => {
-		const msg = makeToolResult("bash", "tiny")
-		const result = pruneToolResult(msg, MIN_PRUNE_CHARS)
-		expect((result.content[0] as TextContent).text).toBe("tiny")
-	})
-
-	it("preserves non-text content blocks unchanged", () => {
-		const msg: ToolResultMessage = {
-			role: "toolResult",
-			toolCallId: "id-1",
-			toolName: "bash",
-			content: [
-				// biome-ignore lint/suspicious/noExplicitAny: image block not in TextContent union
-				{ type: "image", source: { type: "base64", mediaType: "image/png", data: "abc" } } as any,
-				{ type: "text", text: "x".repeat(20) },
-			],
-			details: undefined,
-			isError: false,
-			timestamp: 0,
-		}
-		const result = pruneToolResult(msg, MIN_PRUNE_CHARS)
-		expect(result.content[0]).toHaveProperty("type", "image") // untouched
-		expect((result.content[1] as TextContent).text).toContain("[compacted")
-	})
-
-	it("truncates error output to last 2000 chars with header", () => {
-		const longError = "e".repeat(5000)
-		const msg = makeToolResult("bash", longError, true)
-		const result = pruneToolResult(msg, MIN_PRUNE_CHARS)
-		const text = (result.content[0] as TextContent).text
-		expect(text).toContain("[compacted: bash error")
-		expect(text).toContain("e".repeat(2000))
-		expect(text.length).toBeLessThan(longError.length)
-	})
-
-	it("preserves all ToolResultMessage fields", () => {
-		const msg = makeToolResult("read", "x".repeat(20))
-		const result = pruneToolResult(msg, MIN_PRUNE_CHARS)
-		expect(result.toolCallId).toBe(msg.toolCallId)
-		expect(result.toolName).toBe(msg.toolName)
-		expect(result.isError).toBe(msg.isError)
-		expect(result.timestamp).toBe(msg.timestamp)
-	})
-})
-
-// ── contextCompactorExtension (event wiring) ─────────────────────────────────
-
-function makeMockPI() {
-	const handlers: Record<string, (event: unknown) => Promise<unknown>> = {}
-	const entries: Array<{ customType: string; data: unknown }> = []
-	return {
-		pi: {
-			on(event: string, handler: (e: unknown) => Promise<unknown>) {
-				handlers[event] = handler
-			},
-			appendEntry(customType: string, data: unknown) {
-				entries.push({ customType, data })
-			},
-		} as unknown as ExtensionAPI,
-		async trigger(event: string, payload: unknown) {
-			return handlers[event]?.(payload)
-		},
-		entries,
+describe("contextCompactorExtension (pair-drop)", () => {
+	function makeFullTurn(callId: string, toolName: string, resultText: string) {
+		const call = makeToolCall(callId, toolName, { pattern: "x" })
+		const assistant = makeAssistantWithCalls([call])
+		const result = makeToolResultFor(callId, toolName, resultText)
+		return [assistant, result] as ContextEvent["messages"]
 	}
-}
 
-function makeMessageEndEvent(inputTokens: number) {
-	return {
-		message: {
-			role: "assistant" as const,
-			usage: {
-				input: inputTokens,
-				output: 0,
-				cacheRead: 0,
-				cacheWrite: 0,
-				totalTokens: inputTokens,
-				cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
-			},
-			content: [],
-			model: "test",
-			timestamp: 0,
-		},
-	}
-}
-
-describe("contextCompactorExtension", () => {
-	it("returns undefined when below token threshold", async () => {
-		const { pi, trigger } = makeMockPI()
+	it("does not fire when below 65% of context window", async () => {
+		const { pi, trigger } = makeMockPI(131_072)
 		contextCompactorExtension(pi)
-		await trigger("message_end", makeMessageEndEvent(1_000))
+		// 65% of 131072 ≈ 85196; use 50k — below threshold
+		await trigger("message_end", makeMessageEndEvent(50_000))
+		const oldTurn = makeFullTurn("c1", "grep", "x".repeat(600))
+		const recent = Array.from({ length: 50 }, makeUser)
 		const result = await trigger("context", {
-			messages: [makeToolResult("bash", "x".repeat(600))] as ContextEvent["messages"],
+			messages: [...oldTurn, ...recent] as ContextEvent["messages"],
 		})
 		expect(result).toBeUndefined()
 	})
 
-	it("returns undefined when above threshold but nothing to prune (cutoff = 0)", async () => {
-		const { pi, trigger } = makeMockPI()
+	it("fires when above 65% of context window", async () => {
+		const { pi, trigger } = makeMockPI(131_072)
 		contextCompactorExtension(pi)
-		await trigger("message_end", makeMessageEndEvent(40_000))
-		// 3 messages — fits within PROTECT_WINDOW=30, chars well under MAX_PROTECTED_CHARS
-		const messages = [makeUser(), makeAssistant(), makeToolResult("bash", "small")]
-		const result = await trigger("context", { messages: messages as ContextEvent["messages"] })
-		expect(result).toBeUndefined()
-	})
-
-	it("prunes tool results before the cutoff when above threshold", async () => {
-		const { pi, trigger } = makeMockPI()
-		contextCompactorExtension(pi)
-		await trigger("message_end", makeMessageEndEvent(40_000))
-		// 1 old tool result + 30 recent messages → cutoff = 1, index 0 is pruned
-		const oldOutput = makeToolResult("bash", "x".repeat(600)) // > MIN_PRUNE_CHARS=500
-		const recent = Array.from({ length: 30 }, makeUser)
-		const messages = [oldOutput, ...recent] as ContextEvent["messages"]
-		const result = (await trigger("context", { messages })) as { messages: ContextEvent["messages"] }
+		// 65% of 131072 ≈ 85196; use 90k
+		await trigger("message_end", makeMessageEndEvent(90_000))
+		const oldTurn = makeFullTurn("c1", "grep", "x".repeat(600))
+		const recent = Array.from({ length: 50 }, makeUser)
+		const result = (await trigger("context", {
+			messages: [...oldTurn, ...recent] as ContextEvent["messages"],
+		})) as { messages: ContextEvent["messages"] } | undefined
 		expect(result).toBeDefined()
-		const pruned = result.messages[0] as ToolResultMessage
-		expect((pruned.content[0] as TextContent).text).toContain("[compacted: bash output")
 	})
 
-	it("passes non-tool-result messages through unchanged before cutoff", async () => {
-		const { pi, trigger } = makeMockPI()
+	it("drops full assistant+result pair — no tombstones remain", async () => {
+		const { pi, trigger } = makeMockPI(131_072)
 		contextCompactorExtension(pi)
-		await trigger("message_end", makeMessageEndEvent(40_000))
-		const oldUser = makeUser()
-		const recent = Array.from({ length: 30 }, makeUser)
-		const messages = [oldUser, ...recent] as ContextEvent["messages"]
+		await trigger("message_end", makeMessageEndEvent(90_000))
+		const call = makeToolCall("c1", "grep", { pattern: "foo" })
+		const oldAssistant = makeAssistantWithCalls([call])
+		const oldResult = makeToolResultFor("c1", "grep", "5 matches found\nline2\nline3\nline4\nline5")
+		const recent = Array.from({ length: 50 }, makeUser)
+		const messages = [oldAssistant, oldResult, ...recent] as ContextEvent["messages"]
 		const result = (await trigger("context", { messages })) as { messages: ContextEvent["messages"] }
-		expect(result).toBeDefined()
-		// user message before cutoff is returned by reference (not cloned)
-		expect(result.messages[0]).toBe(oldUser)
+		expect(result.messages).not.toContain(oldAssistant)
+		expect(result.messages).not.toContain(oldResult)
+		const allText = result.messages
+			.flatMap((m) => {
+				const msg = m as ToolResultMessage
+				return msg.role === "toolResult" ? msg.content.map((c) => (c as { text?: string }).text ?? "") : []
+			})
+			.join("")
+		expect(allText).not.toContain("[compacted")
 	})
 
-	it("emits tool_result_pruning entry with correct counts when pruning fires", async () => {
-		const { pi, trigger, entries } = makeMockPI()
+	it("injects action log user message at cutoff boundary", async () => {
+		const { pi, trigger } = makeMockPI(131_072)
 		contextCompactorExtension(pi)
-		await trigger("message_end", makeMessageEndEvent(40_000))
-		const oldOutput = makeToolResult("bash", "x".repeat(600)) // 600 chars, pruned to placeholder
-		const recent = Array.from({ length: 30 }, makeUser)
-		const messages = [oldOutput, ...recent] as ContextEvent["messages"]
+		await trigger("message_end", makeMessageEndEvent(90_000))
+		const call = makeToolCall("c1", "grep", { pattern: "registerCommand" })
+		const oldAssistant = makeAssistantWithCalls([call])
+		const oldResult = makeToolResultFor("c1", "grep", "a.ts:1: x\nb.ts:2: x\nc.ts:3: x")
+		const recent = Array.from({ length: 50 }, makeUser)
+		const messages = [oldAssistant, oldResult, ...recent] as ContextEvent["messages"]
+		const result = (await trigger("context", { messages })) as { messages: ContextEvent["messages"] }
+		const first = result.messages[0] as UserMessage
+		expect(first.role).toBe("user")
+		const text = (first.content as Array<{ type: string; text: string }>)[0].text
+		expect(text).toContain(ACTION_LOG_MARKER)
+		expect(text).toContain("grep")
+		expect(text).toContain("3 match")
+	})
+
+	it("merges previous action log when it falls into the drop zone", async () => {
+		const { pi, trigger } = makeMockPI(131_072)
+		contextCompactorExtension(pi)
+		await trigger("message_end", makeMessageEndEvent(90_000))
+		const previousLogText = `${ACTION_LOG_MARKER}\n- grep("old") → 2 matches`
+		const previousLog = {
+			role: "user" as const,
+			content: [{ type: "text" as const, text: previousLogText }],
+			timestamp: 0,
+		}
+		const call = makeToolCall("c1", "read", { path: "new.ts" })
+		const newAssistant = makeAssistantWithCalls([call])
+		const newResult = makeToolResultFor("c1", "read", "x".repeat(500))
+		const recent = Array.from({ length: 50 }, makeUser)
+		const messages = [previousLog, newAssistant, newResult, ...recent] as ContextEvent["messages"]
+		const result = (await trigger("context", { messages })) as { messages: ContextEvent["messages"] }
+		const first = result.messages[0] as UserMessage
+		const text = (first.content as Array<{ type: string; text: string }>)[0].text
+		expect(text).toContain('grep("old")')
+		expect(text).toContain("read")
+	})
+
+	it("preserves user messages below the cutoff via passthrough (not clamping)", async () => {
+		const { pi, trigger } = makeMockPI(131_072)
+		contextCompactorExtension(pi)
+		await trigger("message_end", makeMessageEndEvent(90_000))
+		const userMsg = makeUser()
+		const oldTurn = makeFullTurn("c1", "grep", "x".repeat(600))
+		const recent = Array.from({ length: 50 }, makeUser)
+		const messages = [userMsg, ...oldTurn, ...recent] as ContextEvent["messages"]
+		const result = (await trigger("context", { messages })) as { messages: ContextEvent["messages"] }
+		// userMsg text "hi" must survive (merged into action log or in passthrough)
+		const allText = result.messages
+			.flatMap((m) => {
+				const u = m as UserMessage
+				if (u.role !== "user" || !Array.isArray(u.content)) return []
+				return u.content.map((c) => (c as { text?: string }).text ?? "")
+			})
+			.join("")
+		expect(allText).toContain("hi")
+	})
+
+	it("emits tool_result_pruning entry with droppedTurns and droppedMessages", async () => {
+		const { pi, trigger, entries } = makeMockPI(131_072)
+		contextCompactorExtension(pi)
+		await trigger("message_end", makeMessageEndEvent(90_000))
+		const oldTurn = makeFullTurn("c1", "grep", "x".repeat(600))
+		const recent = Array.from({ length: 50 }, makeUser)
+		const messages = [...oldTurn, ...recent] as ContextEvent["messages"]
 		await trigger("context", { messages })
 		expect(entries).toHaveLength(1)
 		expect(entries[0].customType).toBe("tool_result_pruning")
-		const data = entries[0].data as { prunedCount: number; totalCharsRemoved: number; cutoff: number }
-		expect(data.prunedCount).toBe(1)
-		expect(data.totalCharsRemoved).toBeGreaterThan(0)
-		expect(data.cutoff).toBe(1)
+		const data = entries[0].data as { droppedTurns: number; droppedMessages: number; cutoff: number }
+		expect(data.droppedTurns).toBe(1)
+		expect(data.droppedMessages).toBe(2) // 1 assistant + 1 result
+		expect(data.cutoff).toBeGreaterThan(0)
 	})
 
-	it("extends the protected window to include the most recent user message", async () => {
-		const { pi, trigger, entries } = makeMockPI()
+	it("adapts threshold to model context window (small 32k model)", async () => {
+		// 65% of 32768 ≈ 21299; use 25k input — above threshold
+		const { pi, trigger } = makeMockPI(32_768)
 		contextCompactorExtension(pi)
-		await trigger("message_end", makeMessageEndEvent(40_000))
-
-		// oldTool (index 0) is prunable, userMsg (index 1) must be preserved,
-		// and 30 tool results (indices 2-31) fill the protected window.
-		// baseCutoff = 2 would drop userMsg; floor brings it down to 1.
-		const oldTool = makeToolResult("bash", "x".repeat(600))
-		const userMsg = makeUser()
-		const recent = Array.from({ length: 30 }, () => makeToolResult("bash", "x".repeat(600)))
-		const messages = [oldTool, userMsg, ...recent] as ContextEvent["messages"]
-
-		const result = (await trigger("context", { messages })) as { messages: ContextEvent["messages"] }
+		await trigger("message_end", makeMessageEndEvent(25_000))
+		const oldTurn = makeFullTurn("c1", "grep", "x".repeat(600))
+		const recent = Array.from({ length: 50 }, makeUser)
+		const result = await trigger("context", {
+			messages: [...oldTurn, ...recent] as ContextEvent["messages"],
+		})
 		expect(result).toBeDefined()
-		expect(result.messages[1]).toBe(userMsg) // user message preserved
-		expect(entries).toHaveLength(1)
-		const data = entries[0].data as { cutoff: number }
-		expect(data.cutoff).toBe(1)
 	})
 
-	it("does not emit entry when no messages are actually pruned", async () => {
-		const { pi, trigger, entries } = makeMockPI()
+	it("preserves user messages in the drop zone — only tool-call pairs are dropped", async () => {
+		const { pi, trigger } = makeMockPI(131_072)
 		contextCompactorExtension(pi)
-		await trigger("message_end", makeMessageEndEvent(40_000))
-		// old tool result is below MIN_PRUNE_CHARS — won't be pruned
-		const oldOutput = makeToolResult("bash", "tiny")
-		const recent = Array.from({ length: 30 }, makeUser)
-		const messages = [oldOutput, ...recent] as ContextEvent["messages"]
-		await trigger("context", { messages })
-		expect(entries).toHaveLength(0)
+		await trigger("message_end", makeMessageEndEvent(90_000))
+		const oldUserMsg = makeUser()
+		const oldTurn = makeFullTurn("c1", "grep", "x".repeat(600))
+		const recent = Array.from({ length: 50 }, makeUser)
+		const messages = [oldUserMsg, ...oldTurn, ...recent] as ContextEvent["messages"]
+		const result = (await trigger("context", { messages })) as { messages: ContextEvent["messages"] }
+		// oldUserMsg text must survive (merged into action log or in passthrough)
+		const allUserText = result.messages
+			.flatMap((m) => {
+				const u = m as UserMessage
+				if (u.role !== "user" || !Array.isArray(u.content)) return []
+				return u.content.map((c) => (c as { text?: string }).text ?? "")
+			})
+			.join("")
+		expect(allUserText).toContain("hi")
+		// the tool pair must be gone
+		expect(result.messages).not.toContain(oldTurn[0]) // assistant
+		expect(result.messages).not.toContain(oldTurn[1]) // toolResult
+	})
+
+	it("preserves reasoning-only assistant messages in the drop zone", async () => {
+		const { pi, trigger } = makeMockPI(131_072)
+		contextCompactorExtension(pi)
+		await trigger("message_end", makeMessageEndEvent(90_000))
+		const reasoningAssistant = makeAssistant()
+		const oldTurn = makeFullTurn("c1", "grep", "x".repeat(600))
+		const recent = Array.from({ length: 50 }, makeUser)
+		const messages = [reasoningAssistant, ...oldTurn, ...recent] as ContextEvent["messages"]
+		const result = (await trigger("context", { messages })) as { messages: ContextEvent["messages"] }
+		expect(result.messages).toContain(reasoningAssistant)
+	})
+
+	it("merges action log into first passthrough user message to avoid consecutive user messages", async () => {
+		const { pi, trigger } = makeMockPI(131_072)
+		contextCompactorExtension(pi)
+		await trigger("message_end", makeMessageEndEvent(90_000))
+		const oldUser = makeUser()
+		const oldTurn = makeFullTurn("c1", "grep", "x".repeat(600))
+		const recent = Array.from({ length: 50 }, makeUser)
+		const messages = [oldUser, ...oldTurn, ...recent] as ContextEvent["messages"]
+		const result = (await trigger("context", { messages })) as { messages: ContextEvent["messages"] }
+		const first = result.messages[0] as UserMessage
+		expect(first.role).toBe("user")
+		const content = first.content as Array<{ type: string; text: string }>
+		const fullText = content.map((c) => c.text).join("")
+		expect(fullText).toContain(ACTION_LOG_MARKER)
+		expect(fullText).toContain("hi")
+		// Verify oldUser was merged into the action log, not left as a separate message
+		expect(result.messages).not.toContain(oldUser)
+	})
+
+	it("compacts even when only user message is at index 0", async () => {
+		const { pi, trigger } = makeMockPI(131_072)
+		contextCompactorExtension(pi)
+		await trigger("message_end", makeMessageEndEvent(90_000))
+		const userMsg = makeUser()
+		const turns = Array.from({ length: 5 }, (_, i) => makeFullTurn(`c${i}`, "grep", "x".repeat(600)))
+		const recent = Array.from({ length: 50 }, makeUser)
+		const messages = [userMsg, ...turns.flat(), ...recent] as ContextEvent["messages"]
+		const result = await trigger("context", { messages })
+		expect(result).toBeDefined()
 	})
 })
 

--- a/src/extensions/context-compactor.test.ts
+++ b/src/extensions/context-compactor.test.ts
@@ -1,7 +1,14 @@
-import type { TextContent, ToolResultMessage } from "@earendil-works/pi-ai"
+import type { TextContent, ToolCall, ToolResultMessage } from "@earendil-works/pi-ai"
 import type { ContextEvent, ExtensionAPI } from "@earendil-works/pi-coding-agent"
 import { describe, expect, it } from "vitest"
-import contextCompactorExtension, { computeCutoff, pruneToolResult } from "./context-compactor.js"
+import contextCompactorExtension, {
+	computeCutoff,
+	pruneToolResult,
+	groupTurnsBeforeCutoff,
+	partitionDropZone,
+	buildActionLog,
+	ACTION_LOG_MARKER,
+} from "./context-compactor.js"
 
 // helpers
 function makeToolResult(toolName: string, text: string, isError = false): ToolResultMessage {
@@ -33,6 +40,47 @@ function makeAssistant() {
 			cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
 		},
 		model: "test",
+		timestamp: 0,
+	}
+}
+
+function makeToolCall(id: string, name: string, args: Record<string, unknown> = {}): ToolCall {
+	return { type: "toolCall", id, name, arguments: args }
+}
+
+// No explicit return type — avoids TS errors from missing optional fields.
+// Required fields (api, provider, stopReason) are stubbed with `as any`.
+function makeAssistantWithCalls(calls: ToolCall[]) {
+	return {
+		role: "assistant" as const,
+		content: calls,
+		// biome-ignore lint/suspicious/noExplicitAny: test stub
+		api: "openai-completions" as any,
+		// biome-ignore lint/suspicious/noExplicitAny: test stub
+		provider: "test" as any,
+		// biome-ignore lint/suspicious/noExplicitAny: test stub
+		stopReason: "toolUse" as any,
+		usage: {
+			input: 0,
+			output: 0,
+			cacheRead: 0,
+			cacheWrite: 0,
+			totalTokens: 0,
+			cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+		},
+		model: "test",
+		timestamp: 0,
+	}
+}
+
+function makeToolResultFor(callId: string, toolName: string, text: string, isError = false) {
+	return {
+		role: "toolResult" as const,
+		toolCallId: callId,
+		toolName,
+		content: [{ type: "text" as const, text }],
+		details: undefined,
+		isError,
 		timestamp: 0,
 	}
 }
@@ -291,5 +339,210 @@ describe("contextCompactorExtension", () => {
 		const messages = [oldOutput, ...recent] as ContextEvent["messages"]
 		await trigger("context", { messages })
 		expect(entries).toHaveLength(0)
+	})
+})
+
+describe("groupTurnsBeforeCutoff", () => {
+	it("groups a single assistant+result pair into one turn", () => {
+		const call = makeToolCall("c1", "grep", { pattern: "foo" })
+		const assistant = makeAssistantWithCalls([call])
+		const result = makeToolResultFor("c1", "grep", "3 matches")
+		const messages = [assistant, result]
+		const turns = groupTurnsBeforeCutoff(messages as ContextEvent["messages"], 2)
+		expect(turns).toHaveLength(1)
+		expect(turns[0].assistant).toBe(assistant)
+		expect(turns[0].results).toHaveLength(1)
+		expect(turns[0].results[0]).toBe(result)
+	})
+
+	it("groups multi-tool-call turn: one assistant + 3 results", () => {
+		const calls = [
+			makeToolCall("c1", "grep", { pattern: "foo" }),
+			makeToolCall("c2", "read", { path: "a.ts" }),
+			makeToolCall("c3", "find", { pattern: "*.ts" }),
+		]
+		const assistant = makeAssistantWithCalls(calls)
+		const results = [
+			makeToolResultFor("c1", "grep", "5 matches"),
+			makeToolResultFor("c2", "read", "x".repeat(100)),
+			makeToolResultFor("c3", "find", "No files found matching pattern"),
+		]
+		const messages = [assistant, ...results]
+		const turns = groupTurnsBeforeCutoff(messages as ContextEvent["messages"], 4)
+		expect(turns).toHaveLength(1)
+		expect(turns[0].results).toHaveLength(3)
+	})
+
+	it("handles orphaned toolResult (no matching assistant) as standalone turn", () => {
+		const orphan = makeToolResultFor("missing", "bash", "output")
+		const messages = [orphan]
+		const turns = groupTurnsBeforeCutoff(messages as ContextEvent["messages"], 1)
+		expect(turns).toHaveLength(1)
+		expect(turns[0].assistant).toBeNull()
+		expect(turns[0].results[0]).toBe(orphan)
+	})
+
+	it("handles assistant with calls but missing results (aborted turn)", () => {
+		const call = makeToolCall("c1", "bash", { command: "pnpm test" })
+		const assistant = makeAssistantWithCalls([call])
+		const messages = [assistant] // no toolResult
+		const turns = groupTurnsBeforeCutoff(messages as ContextEvent["messages"], 1)
+		expect(turns).toHaveLength(1)
+		expect(turns[0].assistant).toBe(assistant)
+		expect(turns[0].results).toHaveLength(0)
+	})
+
+	it("only groups messages below the cutoff index", () => {
+		const call = makeToolCall("c1", "grep", { pattern: "foo" })
+		const assistant = makeAssistantWithCalls([call])
+		const result = makeToolResultFor("c1", "grep", "3 matches")
+		const user = makeUser()
+		const messages = [assistant, result, user]
+		const turns = groupTurnsBeforeCutoff(messages as ContextEvent["messages"], 2)
+		expect(turns).toHaveLength(1) // user at index 2 not included
+	})
+})
+
+describe("partitionDropZone", () => {
+	it("puts user messages into passthrough, not turns", () => {
+		const user = makeUser()
+		const call = makeToolCall("c1", "grep", { pattern: "foo" })
+		const assistant = makeAssistantWithCalls([call])
+		const result = makeToolResultFor("c1", "grep", "3 matches")
+		const messages = [user, assistant, result]
+		const { turns, passthrough } = partitionDropZone(messages as ContextEvent["messages"], 3)
+		expect(turns).toHaveLength(1)
+		expect(passthrough).toHaveLength(1)
+		expect(passthrough[0]).toBe(user)
+	})
+
+	it("puts reasoning-only assistant messages into passthrough", () => {
+		const reasoning = makeAssistant() // text-only, no tool calls
+		const call = makeToolCall("c1", "grep", { pattern: "foo" })
+		const assistant = makeAssistantWithCalls([call])
+		const result = makeToolResultFor("c1", "grep", "3 matches")
+		const messages = [reasoning, assistant, result]
+		const { turns, passthrough } = partitionDropZone(messages as ContextEvent["messages"], 3)
+		expect(turns).toHaveLength(1)
+		expect(passthrough).toHaveLength(1)
+		expect(passthrough[0]).toBe(reasoning)
+	})
+
+	it("returns empty passthrough when drop zone has only tool-call pairs", () => {
+		const call = makeToolCall("c1", "grep", { pattern: "foo" })
+		const assistant = makeAssistantWithCalls([call])
+		const result = makeToolResultFor("c1", "grep", "3 matches")
+		const messages = [assistant, result]
+		const { turns, passthrough } = partitionDropZone(messages as ContextEvent["messages"], 2)
+		expect(turns).toHaveLength(1)
+		expect(passthrough).toHaveLength(0)
+	})
+})
+
+describe("buildActionLog", () => {
+	it("returns a user-role message with ACTION_LOG_MARKER", () => {
+		const call = makeToolCall("c1", "grep", { pattern: "registerCommand" })
+		const assistant = makeAssistantWithCalls([call])
+		const result = makeToolResultFor("c1", "grep", "line1\nline2\nline3\nline4\nline5")
+		const turns = [{ assistant, results: [result] }]
+		const msg = buildActionLog(turns)
+		expect(msg.role).toBe("user")
+		const text = (msg.content as Array<{ type: string; text: string }>)[0].text
+		expect(text).toContain(ACTION_LOG_MARKER)
+		expect(text).toContain("grep")
+	})
+
+	it("formats grep result with match count", () => {
+		const call = makeToolCall("c1", "grep", { pattern: "foo" })
+		const assistant = makeAssistantWithCalls([call])
+		const result = makeToolResultFor("c1", "grep", "a.ts:1: foo\nb.ts:2: foo\nc.ts:3: foo")
+		const turns = [{ assistant, results: [result] }]
+		const msg = buildActionLog(turns)
+		const text = (msg.content as Array<{ type: string; text: string }>)[0].text
+		expect(text).toContain("3 match")
+	})
+
+	it("formats 'No matches found' for empty grep", () => {
+		const call = makeToolCall("c1", "grep", { pattern: "notfound" })
+		const assistant = makeAssistantWithCalls([call])
+		const result = makeToolResultFor("c1", "grep", "No matches found")
+		const turns = [{ assistant, results: [result] }]
+		const msg = buildActionLog(turns)
+		const text = (msg.content as Array<{ type: string; text: string }>)[0].text
+		expect(text).toContain("No matches found")
+	})
+
+	it("formats read result with char count", () => {
+		const call = makeToolCall("c1", "read", { path: "src/foo.ts" })
+		const assistant = makeAssistantWithCalls([call])
+		const result = makeToolResultFor("c1", "read", "x".repeat(2847))
+		const turns = [{ assistant, results: [result] }]
+		const msg = buildActionLog(turns)
+		const text = (msg.content as Array<{ type: string; text: string }>)[0].text
+		expect(text).toContain("2847 chars")
+	})
+
+	it("formats 'No files found' for empty find", () => {
+		const call = makeToolCall("c1", "find", { pattern: "*.test.ts" })
+		const assistant = makeAssistantWithCalls([call])
+		const result = makeToolResultFor("c1", "find", "No files found matching pattern")
+		const turns = [{ assistant, results: [result] }]
+		const msg = buildActionLog(turns)
+		const text = (msg.content as Array<{ type: string; text: string }>)[0].text
+		expect(text).toContain("No files found")
+	})
+
+	it("formats bash result with line count", () => {
+		const call = makeToolCall("c1", "bash", { command: "pnpm test" })
+		const assistant = makeAssistantWithCalls([call])
+		const result = makeToolResultFor("c1", "bash", "line1\nline2\nline3")
+		const turns = [{ assistant, results: [result] }]
+		const msg = buildActionLog(turns)
+		const text = (msg.content as Array<{ type: string; text: string }>)[0].text
+		expect(text).toContain("bash")
+		expect(text).toContain("3 lines")
+	})
+
+	it("formats aborted turn (no results) with [no result]", () => {
+		const call = makeToolCall("c1", "bash", { command: "pnpm test" })
+		const assistant = makeAssistantWithCalls([call])
+		const turns = [{ assistant, results: [] }]
+		const msg = buildActionLog(turns)
+		const text = (msg.content as Array<{ type: string; text: string }>)[0].text
+		expect(text).toContain("[no result]")
+	})
+
+	it("merges existing action log lines when previous log is in drop zone", () => {
+		const previousLogText = `${ACTION_LOG_MARKER}\n- grep("old") → 2 matches`
+		const existingLog = {
+			role: "user" as const,
+			content: [{ type: "text" as const, text: previousLogText }],
+			timestamp: 0,
+		}
+		const call = makeToolCall("c1", "read", { path: "new.ts" })
+		const assistant = makeAssistantWithCalls([call])
+		const result = makeToolResultFor("c1", "read", "x".repeat(100))
+		const turns = [{ assistant, results: [result] }]
+		const msg = buildActionLog(turns, existingLog as ContextEvent["messages"][number])
+		const text = (msg.content as Array<{ type: string; text: string }>)[0].text
+		expect(text).toContain('grep("old")')
+		expect(text).toContain("read")
+	})
+
+	it("ignores existing log when content is a plain string (not an array)", () => {
+		const existingLog = {
+			role: "user" as const,
+			content: `${ACTION_LOG_MARKER}\n- grep("old") → 2 matches`,
+			timestamp: 0,
+		}
+		const call = makeToolCall("c1", "read", { path: "new.ts" })
+		const assistant = makeAssistantWithCalls([call])
+		const result = makeToolResultFor("c1", "read", "x".repeat(100))
+		const turns = [{ assistant, results: [result] }]
+		// Should not throw, should not include old lines
+		const msg = buildActionLog(turns, existingLog as unknown as ContextEvent["messages"][number])
+		const text = (msg.content as Array<{ type: string; text: string }>)[0].text
+		expect(text).not.toContain('grep("old")')
+		expect(text).toContain("read")
 	})
 })

--- a/src/extensions/context-compactor.ts
+++ b/src/extensions/context-compactor.ts
@@ -1,11 +1,11 @@
 import type { AssistantMessage, ToolCall, ToolResultMessage, UserMessage } from "@earendil-works/pi-ai"
-import type { ContextEvent, ExtensionAPI } from "@earendil-works/pi-coding-agent"
+import type { ContextEvent, ExtensionAPI, ExtensionContext } from "@earendil-works/pi-coding-agent"
 import { isSubagent } from "./prompt-construction/prompt-enrichment.js"
 
-const PRUNE_THRESHOLD = 35_000
-const PROTECT_WINDOW = 30
+const PRUNE_THRESHOLD_RATIO = 0.65 // fire at 65% of model context window
+const FALLBACK_THRESHOLD = 85_000 // used when ctx.model is unavailable
+const PROTECT_WINDOW = 50
 const MAX_PROTECTED_CHARS = 100_000
-const MIN_PRUNE_CHARS = 500
 
 /**
  * Walk backwards through messages to find the cutoff index.
@@ -45,48 +45,6 @@ export function computeCutoff(
 	// Clamp to last message: if recent outputs blew the char budget, still prune everything
 	// older than the final message rather than silently skipping compaction entirely.
 	return Math.min(cutoff, Math.max(0, messages.length - 1))
-}
-
-/**
- * Find the index of the most recent message with role "user".
- * This ensures the LLM always retains the user's language, tone,
- * and task framing even during long tool-call chains.
- */
-function findLastUserMessageIndex(messages: ContextEvent["messages"]): number {
-	for (let i = messages.length - 1; i >= 0; i--) {
-		const m = messages[i] as { role?: string }
-		if (m.role === "user") {
-			return i
-		}
-	}
-	return -1
-}
-
-/**
- * Return a pruned copy of a ToolResultMessage.
- * - Large text blocks are replaced with a placeholder (preserves all other fields).
- * - Error outputs keep the last 2000 chars so the agent can still read the crash reason.
- * - Non-text content blocks (images, etc.) are left untouched.
- */
-export function pruneToolResult(msg: ToolResultMessage, minPruneChars: number): ToolResultMessage {
-	return {
-		...msg,
-		content: msg.content.map((block) => {
-			if (block.type !== "text") return block
-			if (block.text.length < minPruneChars) return block
-			if (msg.isError) {
-				const tail = block.text.slice(-2000)
-				return {
-					...block,
-					text: `[compacted: ${msg.toolName} error, ${block.text.length} chars]\n...\n${tail}`,
-				}
-			}
-			return {
-				...block,
-				text: `[compacted: ${msg.toolName} output, ${block.text.length} chars]`,
-			}
-		}),
-	}
 }
 
 export const ACTION_LOG_MARKER = "[Context: earlier steps compacted]"
@@ -260,51 +218,84 @@ export function buildActionLog(turns: DroppedTurn[], existingLog?: ContextEvent[
 export default function contextCompactorExtension(pi: ExtensionAPI) {
 	if (isSubagent()) return
 
-	// Closure-scoped: independent per agent instance, safe if multiple are constructed.
 	let lastInputTokens = 0
 
 	pi.on("message_end", async (event) => {
-		const msg = event.message as AssistantMessage
+		const msg = (event as { message: AssistantMessage }).message
 		if (msg.role !== "assistant") return
 		lastInputTokens = msg.usage?.input ?? 0
 	})
 
-	pi.on("context", async (event) => {
-		if (lastInputTokens < PRUNE_THRESHOLD) return
+	pi.on("context", async (event, ctx: ExtensionContext) => {
+		const contextWindow = ctx?.model?.contextWindow
+		const threshold = contextWindow ? Math.floor(contextWindow * PRUNE_THRESHOLD_RATIO) : FALLBACK_THRESHOLD
 
-		const { messages } = event
-		const baseCutoff = computeCutoff(messages, PROTECT_WINDOW, MAX_PROTECTED_CHARS)
-		if (baseCutoff === 0) return
+		if (lastInputTokens < threshold) return
 
-		// If the most recent user message falls outside the protected window
-		// (i.e. it's before `baseCutoff`), extend the window backward so that
-		// the user message is still visible. This prevents the model from losing
-		// the user's language, tone, or task framing during long tool-call chains.
-		const lastUserIndex = findLastUserMessageIndex(messages)
-		const cutoff = lastUserIndex >= 0 ? Math.min(baseCutoff, lastUserIndex) : baseCutoff
+		const { messages } = event as ContextEvent
+		const cutoff = computeCutoff(messages, PROTECT_WINDOW, MAX_PROTECTED_CHARS)
+		if (cutoff === 0) return
 
-		let prunedCount = 0
-		let totalCharsRemoved = 0
+		// Partition the drop zone: tool-call pairs get dropped, everything else passes through.
+		// No lastUserIndex clamping — partitionDropZone preserves user messages via passthrough
+		// unconditionally. The old Math.min(baseCutoff, lastUserIndex) guard made cutoff=0
+		// when the only user message was at index 0, preventing compaction entirely.
+		const { turns, passthrough } = partitionDropZone(messages, cutoff)
+		if (turns.length === 0) return
 
-		const pruned = messages.map((msg, i) => {
-			if (i >= cutoff) return msg
-			// Explicit cast required: AgentMessage = Message | CustomAgentMessages union;
-			// role check alone does not narrow to ToolResultMessage in TypeScript.
-			const m = msg as ToolResultMessage
-			if (m.role !== "toolResult") return msg
-			const originalLen = m.content.reduce((sum, b) => sum + (b.type === "text" ? b.text.length : 0), 0)
-			const result = pruneToolResult(m, MIN_PRUNE_CHARS)
-			const newLen = result.content.reduce((sum, b) => sum + (b.type === "text" ? b.text.length : 0), 0)
-			if (newLen < originalLen) {
-				prunedCount++
-				totalCharsRemoved += originalLen - newLen
-			}
-			return result
+		// Detect existing action log in passthrough for merging across cycles
+		const existingLog = passthrough.find((m) => {
+			if (m.role !== "user") return false
+			const u = m as UserMessage
+			if (!Array.isArray(u.content)) return false
+			return u.content.some(
+				(c): c is { type: "text"; text: string } => c.type === "text" && c.text.includes(ACTION_LOG_MARKER),
+			)
 		})
 
-		if (prunedCount > 0) {
-			pi.appendEntry("tool_result_pruning", { prunedCount, totalCharsRemoved, cutoff })
+		const actionLog = buildActionLog(turns, existingLog)
+
+		// Remove the old action log from passthrough (its lines were merged into the new one).
+		// Use marker-string check (not reference equality) to be robust against message cloning.
+		const filteredPassthrough = existingLog
+			? passthrough.filter((m) => {
+					if (m.role !== "user") return true
+					const u = m as UserMessage
+					if (!Array.isArray(u.content)) return true
+					return !u.content.some(
+						(c): c is { type: "text"; text: string } => c.type === "text" && c.text.includes(ACTION_LOG_MARKER),
+					)
+				})
+			: passthrough
+
+		const kept = messages.slice(cutoff)
+
+		// Guard against consecutive user messages: some providers (e.g. Anthropic) require
+		// strictly alternating roles and will reject back-to-back user messages.
+		// If filteredPassthrough starts with a user message, merge the action log text
+		// into it instead of prepending a separate user message.
+		let pruned: ContextEvent["messages"]
+		const firstPassthrough = filteredPassthrough[0] as { role?: string } | undefined
+		if (firstPassthrough?.role === "user") {
+			const firstUser = firstPassthrough as UserMessage
+			const logText = (actionLog.content as Array<{ type: string; text: string }>)[0].text
+			const mergedContent = Array.isArray(firstUser.content)
+				? [{ type: "text" as const, text: logText }, ...firstUser.content]
+				: [{ type: "text" as const, text: logText }]
+			const mergedUser = { ...firstUser, content: mergedContent }
+			pruned = [mergedUser as unknown as ContextEvent["messages"][number], ...filteredPassthrough.slice(1), ...kept]
+		} else {
+			pruned = [actionLog as unknown as ContextEvent["messages"][number], ...filteredPassthrough, ...kept]
 		}
+
+		const droppedTurnCount = turns.filter((t) => t.assistant !== null || t.results.length > 0).length
+		const droppedMsgCount = turns.reduce((sum, t) => sum + (t.assistant ? 1 : 0) + t.results.length, 0)
+
+		pi.appendEntry("tool_result_pruning", {
+			droppedTurns: droppedTurnCount,
+			droppedMessages: droppedMsgCount,
+			cutoff,
+		})
 
 		return { messages: pruned }
 	})

--- a/src/extensions/context-compactor.ts
+++ b/src/extensions/context-compactor.ts
@@ -1,4 +1,4 @@
-import type { AssistantMessage, ToolResultMessage } from "@earendil-works/pi-ai"
+import type { AssistantMessage, ToolCall, ToolResultMessage, UserMessage } from "@earendil-works/pi-ai"
 import type { ContextEvent, ExtensionAPI } from "@earendil-works/pi-coding-agent"
 import { isSubagent } from "./prompt-construction/prompt-enrichment.js"
 
@@ -86,6 +86,174 @@ export function pruneToolResult(msg: ToolResultMessage, minPruneChars: number): 
 				text: `[compacted: ${msg.toolName} output, ${block.text.length} chars]`,
 			}
 		}),
+	}
+}
+
+export const ACTION_LOG_MARKER = "[Context: earlier steps compacted]"
+
+export interface DroppedTurn {
+	assistant: AssistantMessage | null
+	results: ToolResultMessage[]
+}
+
+export interface DropZonePartition {
+	turns: DroppedTurn[]
+	passthrough: ContextEvent["messages"]
+}
+
+/**
+ * Partition messages below `cutoff` into:
+ * - `turns`: tool-call assistant messages + their matched toolResult messages (to be dropped)
+ * - `passthrough`: everything else (user messages, reasoning-only assistants — never dropped)
+ *
+ * Key invariant: user messages are NEVER included in `turns`.
+ */
+export function partitionDropZone(messages: ContextEvent["messages"], cutoff: number): DropZonePartition {
+	const zone = messages.slice(0, cutoff)
+
+	const resultsByCallId = new Map<string, ToolResultMessage>()
+	for (const msg of zone) {
+		const m = msg as ToolResultMessage
+		if (m.role === "toolResult") {
+			resultsByCallId.set(m.toolCallId, m)
+		}
+	}
+
+	const turns: DroppedTurn[] = []
+	const claimedIds = new Set<string>()
+	const droppedAssistants = new Set<ContextEvent["messages"][number]>()
+
+	for (const msg of zone) {
+		const m = msg as AssistantMessage
+		if (m.role !== "assistant") continue
+		const toolCalls = m.content.filter((c): c is ToolCall => c.type === "toolCall")
+		if (toolCalls.length === 0) continue // reasoning-only — goes to passthrough
+		const results: ToolResultMessage[] = []
+		for (const tc of toolCalls) {
+			const r = resultsByCallId.get(tc.id)
+			if (r) {
+				results.push(r)
+				claimedIds.add(tc.id)
+			}
+		}
+		turns.push({ assistant: m, results })
+		droppedAssistants.add(msg)
+	}
+
+	const orphanResults: ToolResultMessage[] = []
+	for (const msg of zone) {
+		const m = msg as ToolResultMessage
+		if (m.role === "toolResult" && !claimedIds.has(m.toolCallId)) {
+			orphanResults.push(m)
+			claimedIds.add(m.toolCallId)
+		}
+	}
+	if (orphanResults.length > 0) {
+		turns.push({ assistant: null, results: orphanResults })
+	}
+
+	const droppedResults = new Set(turns.flatMap((t) => t.results))
+	const passthrough = zone.filter((msg) => {
+		if (droppedAssistants.has(msg)) return false
+		if (droppedResults.has(msg as ToolResultMessage)) return false
+		return true
+	})
+
+	return { turns, passthrough }
+}
+
+/**
+ * Convenience wrapper — returns only the turns.
+ */
+export function groupTurnsBeforeCutoff(messages: ContextEvent["messages"], cutoff: number): DroppedTurn[] {
+	return partitionDropZone(messages, cutoff).turns
+}
+
+function summariseResult(toolName: string, text: string, isError: boolean): string {
+	if (isError) return "error"
+	const trimmed = text.trim()
+	if (!trimmed) {
+		if (toolName === "grep") return "No matches found"
+		if (toolName === "find") return "No files found"
+		return "ok"
+	}
+	if (trimmed === "No matches found") return "No matches found"
+	if (trimmed.startsWith("No files found")) return "No files found"
+	if (toolName === "read" || toolName === "write" || toolName === "edit") {
+		return `${trimmed.length} chars`
+	}
+	if (toolName === "grep") {
+		const lines = trimmed.split("\n").filter(Boolean)
+		return `${lines.length} match${lines.length === 1 ? "" : "es"}`
+	}
+	if (toolName === "find") {
+		if (trimmed.startsWith("No files")) return "No files found"
+		const lines = trimmed.split("\n").filter(Boolean)
+		return `${lines.length} file${lines.length === 1 ? "" : "s"}`
+	}
+	const lines = trimmed.split("\n")
+	return `${lines.length} line${lines.length === 1 ? "" : "s"}`
+}
+
+function summariseArgs(args: Record<string, unknown>): string {
+	const vals = Object.values(args)
+	if (vals.length === 0) return ""
+	const first = String(vals[0])
+	return first.length > 40 ? `${first.slice(0, 37)}…` : first
+}
+
+/**
+ * Build a single synthetic user message summarising all dropped turns.
+ * If `existingLog` is a previous action log message (detected by ACTION_LOG_MARKER),
+ * its lines are prepended so history accumulates across multiple prune cycles.
+ */
+export function buildActionLog(turns: DroppedTurn[], existingLog?: ContextEvent["messages"][number]): UserMessage {
+	const previousLines: string[] = []
+
+	if (existingLog) {
+		const m = existingLog as UserMessage
+		if (m.role === "user" && Array.isArray(m.content)) {
+			const textBlock = m.content.find((c): c is { type: "text"; text: string } => c.type === "text")
+			if (textBlock?.text.includes(ACTION_LOG_MARKER)) {
+				const lines = textBlock.text.split("\n").filter((l) => l.startsWith("- "))
+				previousLines.push(...lines)
+			}
+		}
+	}
+
+	const newLines: string[] = []
+	for (const turn of turns) {
+		if (!turn.assistant && turn.results.length === 0) continue
+		if (!turn.assistant) {
+			for (const r of turn.results) {
+				const text = (r.content.find((c) => c.type === "text") as { text: string } | undefined)?.text ?? ""
+				newLines.push(`- ${r.toolName}(orphaned) → ${summariseResult(r.toolName, text, r.isError)}`)
+			}
+			continue
+		}
+		const toolCalls = turn.assistant.content.filter((c): c is ToolCall => c.type === "toolCall")
+		if (toolCalls.length === 0) continue
+		for (const tc of toolCalls) {
+			const result = turn.results.find((r) => r.toolCallId === tc.id)
+			const argStr = summariseArgs(tc.arguments)
+			const outcomeStr = result
+				? summariseResult(
+						tc.name,
+						(result.content.find((c) => c.type === "text") as { text: string } | undefined)?.text ?? "",
+						result.isError,
+					)
+				: "[no result]"
+			newLines.push(`- ${tc.name}(${argStr ? `"${argStr}"` : ""}) → ${outcomeStr}`)
+		}
+	}
+
+	const allLines = [...previousLines, ...newLines]
+	const text = `${ACTION_LOG_MARKER}\n${allLines.join("\n")}`
+
+	return {
+		role: "user",
+		content: [{ type: "text", text }],
+		timestamp: Date.now(),
 	}
 }
 


### PR DESCRIPTION
## What

Rewrites the tool-result pruning extension to eliminate tombstone placeholders in favour of dropping full assistant+toolResult pairs and injecting a compact action log summary.

## Why the old approach was broken

The old compactor replaced large tool results with `[compacted: grep output, N chars]` but left the assistant message (with its tool calls) intact. This created orphaned tool-call/result pairs with opaque responses — the model could see it had called `grep` but not what it found. After enough tombstones, models would loop, re-reading and re-grepping the same files. In the Kimi K2.6 case this also caused complete silent stops at high tool-call depths.

## What changed

**Threshold:** Model-relative (65% of `ctx.model.contextWindow`) instead of fixed 35k tokens. For Kimi K2.6 (131k window) this is ~85k — the old 35k threshold fired far too early.

**Pruning strategy:** Full assistant+toolResult pairs are dropped below the cutoff instead of tombstoning. User messages and reasoning-only assistant messages always survive via `partitionDropZone`.

**Action log:** A single synthetic `user` message is injected at the cutoff boundary summarising what was dropped:
```
[Context: earlier steps compacted]
- grep("registerCommand") → 3 matches
- read("src/extensions/context-compactor.ts") → 4821 chars
- bash("pnpm test") → 12 lines
```
The log accumulates across multiple prune cycles so early history is never silently lost.

**Provider compatibility:** When a user message is already at the cutoff boundary, the action log text is merged into it rather than prepending a separate user message — prevents consecutive `user` role messages that Anthropic's API rejects.

**Protected window:** Raised from 30 → 50 messages.

## New exports (pure, testable)

- `partitionDropZone(messages, cutoff)` — splits drop zone into `turns` (to drop) and `passthrough` (user msgs, reasoning-only assistants — never dropped)
- `groupTurnsBeforeCutoff` — convenience wrapper
- `buildActionLog(turns, existingLog?)` — builds the summary user message, merging previous log lines
- `ACTION_LOG_MARKER` — sentinel string for detecting existing logs

## Test coverage

34 tests: unit tests for all pure helpers + 12 integration tests covering threshold gating, pair dropping, action log injection, log merging, passthrough preservation, consecutive-user-message prevention, and the index-0 user message edge case.