### PR TITLE
feat(clipboard-image): replace chip UI with inline 📎 marker approach

### DIFF
--- a/src/extensions/clipboard-image.test.ts
+++ b/src/extensions/clipboard-image.test.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, it, vi } from "vitest"
+import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest"
 
 // All mock functions must be vi.hoisted — vi.mock is hoisted and its factory
 // runs before any imports, so it cannot reference module-level consts below it.
@@ -6,6 +6,7 @@ import { beforeEach, describe, expect, it, vi } from "vitest"
 const {
 	mockSetPasteImageHandler,
 	mockSetPendingImageIndicator,
+	mockInsertAtCursor,
 	mockGetNativeClipboard,
 	mockReadClipboardImage,
 	mockGetAvailableModels,
@@ -15,6 +16,7 @@ const {
 } = vi.hoisted(() => ({
 	mockSetPasteImageHandler: vi.fn(),
 	mockSetPendingImageIndicator: vi.fn(),
+	mockInsertAtCursor: vi.fn(),
 	mockGetNativeClipboard: vi.fn(),
 	mockReadClipboardImage: vi.fn(),
 	mockGetAvailableModels: vi.fn(),
@@ -26,6 +28,7 @@ const {
 vi.mock("./ui.js", () => ({
 	setPasteImageHandler: mockSetPasteImageHandler,
 	setPendingImageIndicator: mockSetPendingImageIndicator,
+	insertAtCursor: mockInsertAtCursor,
 }))
 
 vi.mock("../utils/clipboard-native-harness.js", () => ({
@@ -56,6 +59,7 @@ function makeMockCtx(overrides: Partial<ExtensionContext> = {}): ExtensionContex
 	return {
 		model: { id: "glm-4", slug: "glm-4", input_modalities: ["text", "image"] as string[] },
 		ui: { notify: vi.fn(), setStatus: vi.fn() },
+		sessionManager: { getSessionDir: vi.fn().mockReturnValue(null) },
 		...overrides,
 	} as unknown as ExtensionContext
 }
@@ -74,79 +78,238 @@ function makeMockPi(): ExtensionAPI & { _handlers: Handlers } {
 	} as unknown as ExtensionAPI & { _handlers: Handlers }
 }
 
-function callInputHandler(pi: ExtensionAPI & { _handlers: Handlers }, event: { text: string; images: ImageContent[] }) {
-	return (pi._handlers.input as (e: { text: string; images: ImageContent[] }) => unknown)(event)
+function callInputHandler(
+	pi: ExtensionAPI & { _handlers: Handlers },
+	event: { text: string; images?: ImageContent[] },
+) {
+	return (pi._handlers.input as (e: { text: string; images: ImageContent[] }) => unknown)({
+		images: [],
+		...event,
+	})
 }
 
+function triggerSessionStart(pi: ExtensionAPI & { _handlers: Handlers }, ctx: ExtensionContext) {
+	;(pi._handlers.session_start as (e: unknown, ctx: ExtensionContext) => void)({}, ctx)
+}
+
+/** Returns the paste handler registered at module load time. */
+function getPasteHandler(): () => void {
+	if (!savedPasteHandler) throw new Error("paste handler not registered")
+	return savedPasteHandler
+}
+
+// The paste handler is registered once at module load; save it before
+// beforeEach can clear mock history.
+let savedPasteHandler: (() => void) | undefined
+
 describe("clipboard-image extension", () => {
+	beforeAll(() => {
+		savedPasteHandler = mockSetPasteImageHandler.mock.calls[0]?.[0] as (() => void) | undefined
+	})
 	beforeEach(() => {
 		vi.clearAllMocks()
 	})
 
-	describe("input transform", () => {
-		it("returns transform with [Image #N] prefix when images are attached", () => {
+	describe("input transform — incoming images (PI-provided path)", () => {
+		it("passes incoming images through and returns a transform", () => {
 			const pi = makeMockPi()
 			clipboardImageExtension(pi)
+			triggerSessionStart(pi, makeMockCtx())
 
 			const images: ImageContent[] = [{ type: "image", mimeType: "image/png", data: "abc123" }]
 			const result = callInputHandler(pi, { text: "hello", images })
 
 			expect(result).toMatchObject({
 				action: "transform",
-				text: expect.stringContaining("[Image #1]"),
 				images: expect.arrayContaining(images),
 			})
 		})
 
-		it("does not call addImage when no images are present", () => {
+		it("registers each incoming image with addImage", () => {
+			const pi = makeMockPi()
+			clipboardImageExtension(pi)
+			triggerSessionStart(pi, makeMockCtx())
+
+			const images: ImageContent[] = [{ type: "image", mimeType: "image/png", data: "abc123" }]
+			callInputHandler(pi, { text: "hello", images })
+
+			expect(mockAddImage).toHaveBeenCalledOnce()
+		})
+
+		it("does not call addImage when no images and no markers are present", () => {
 			const pi = makeMockPi()
 			clipboardImageExtension(pi)
 
-			callInputHandler(pi, { text: "hello", images: [] })
+			callInputHandler(pi, { text: "hello" })
 
-			// Early return when no images — addImage must not be called.
 			expect(mockAddImage).not.toHaveBeenCalled()
 		})
 
-		it("returns undefined (no transform) when no text and no images", () => {
+		it("returns undefined when text is empty and no images", () => {
 			const pi = makeMockPi()
 			clipboardImageExtension(pi)
 
-			const result = callInputHandler(pi, { text: "", images: [] })
+			const result = callInputHandler(pi, { text: "" })
 			expect(result).toBeUndefined()
 		})
+	})
 
-		it("second input increments the counter and labels the next image correctly", () => {
-			// imageCounter persists across calls in the same module session.
-			// Previous test already incremented it to 1. The next image should be #2.
+	describe("input transform — 📎 marker path (paste handler)", () => {
+		it("replaces a single 📎 marker with [Image #N] when its slot is filled", async () => {
 			const pi = makeMockPi()
 			clipboardImageExtension(pi)
+			triggerSessionStart(pi, makeMockCtx())
 
-			const result = callInputHandler(pi, {
-				text: "second",
-				images: [{ type: "image", mimeType: "image/png", data: "bbb" }],
+			// Set up clipboard
+			mockGetNativeClipboard.mockReturnValue({ clipboard: {}, error: null })
+			mockGetAvailableModels.mockReturnValue([{ slug: "glm-4", input_modalities: ["text", "image"] }])
+			mockReadClipboardImage.mockResolvedValue({ bytes: new Uint8Array([1, 2, 3]), mimeType: "image/png" })
+
+			// Trigger paste — inserts 📎 synchronously and fills slot async
+			getPasteHandler()()
+			expect(mockInsertAtCursor).toHaveBeenCalledWith("📎")
+
+			// Wait for async slot fill
+			await Promise.resolve()
+
+			const result = callInputHandler(pi, { text: "📎 describe this" })
+			expect(result).toMatchObject({
+				action: "transform",
+				text: expect.stringContaining("[Image #1]"),
 			})
-			const text = (result as { text: string }).text
-			// Counter was at 1 from previous test, so startIndex = 2 → #2
-			expect(text).toContain("[Image #2]")
-			expect(text).not.toContain("[Image #1]") // not the first image anymore
+			expect((result as { text: string }).text).not.toContain("📎")
 		})
 
-		it("multiple images in the same turn get sequential markers from the current counter position", () => {
-			// Counter is already at 2 from previous tests. With 2 new images:
-			// startIndex = 3, so markers should be #3 and #4
+		it("replaces multiple 📎 markers in text order", async () => {
+			const pi = makeMockPi()
+			clipboardImageExtension(pi)
+			triggerSessionStart(pi, makeMockCtx())
+
+			mockGetNativeClipboard.mockReturnValue({ clipboard: {}, error: null })
+			mockGetAvailableModels.mockReturnValue([{ slug: "glm-4", input_modalities: ["text", "image"] }])
+			mockReadClipboardImage.mockResolvedValue({ bytes: new Uint8Array([1]), mimeType: "image/png" })
+
+			getPasteHandler()()
+			getPasteHandler()()
+			await Promise.resolve()
+			await Promise.resolve()
+
+			const result = callInputHandler(pi, { text: "📎 hi 📎 there" })
+			const text = (result as { text: string }).text
+			expect(text).toBe("[Image #1] hi [Image #2] there")
+		})
+
+		it("strips orphaned 📎 markers whose async read failed", async () => {
+			const pi = makeMockPi()
+			clipboardImageExtension(pi)
+			triggerSessionStart(pi, makeMockCtx())
+
+			mockGetNativeClipboard.mockReturnValue({ clipboard: {}, error: null })
+			mockGetAvailableModels.mockReturnValue([{ slug: "glm-4", input_modalities: ["text", "image"] }])
+			mockReadClipboardImage.mockResolvedValue(null) // no image found
+
+			getPasteHandler()()
+			await Promise.resolve()
+
+			// The null slot is still in pendingImages — marker is stripped from text
+			const result = callInputHandler(pi, { text: "📎 hello" })
+			expect(result).toMatchObject({
+				action: "transform",
+				text: " hello",
+				images: [],
+			})
+		})
+
+		it("inserts 📎 synchronously before async read completes", () => {
+			const pi = makeMockPi()
+			clipboardImageExtension(pi)
+			triggerSessionStart(pi, makeMockCtx())
+
+			mockGetNativeClipboard.mockReturnValue({ clipboard: {}, error: null })
+			mockGetAvailableModels.mockReturnValue([{ slug: "glm-4", input_modalities: ["text", "image"] }])
+			// Never resolves in this test — verifying sync part only
+			mockReadClipboardImage.mockReturnValue(new Promise(() => {}))
+
+			getPasteHandler()()
+
+			// Must be called synchronously before any awaits
+			expect(mockInsertAtCursor).toHaveBeenCalledWith("📎")
+		})
+
+		it("does not insert 📎 when model does not support images", () => {
+			const pi = makeMockPi()
+			clipboardImageExtension(pi)
+			triggerSessionStart(
+				pi,
+				makeMockCtx({
+					model: { id: "text-only", slug: "text-only", input_modalities: ["text"] } as never,
+				}),
+			)
+
+			mockGetAvailableModels.mockReturnValue([{ slug: "text-only", input_modalities: ["text"] }])
+
+			getPasteHandler()()
+
+			expect(mockInsertAtCursor).not.toHaveBeenCalled()
+		})
+
+		it("does not insert 📎 when native clipboard is unavailable", () => {
+			const pi = makeMockPi()
+			clipboardImageExtension(pi)
+			triggerSessionStart(pi, makeMockCtx())
+
+			mockGetAvailableModels.mockReturnValue([{ slug: "glm-4", input_modalities: ["text", "image"] }])
+			mockGetNativeClipboard.mockReturnValue({ clipboard: null, error: "unsupported" })
+
+			getPasteHandler()()
+
+			expect(mockInsertAtCursor).not.toHaveBeenCalled()
+		})
+	})
+
+	describe("session_start", () => {
+		it("resets imageCounter so the first image in a new session is #1", async () => {
 			const pi = makeMockPi()
 			clipboardImageExtension(pi)
 
-			const images: ImageContent[] = [
-				{ type: "image", mimeType: "image/png", data: "aaa" },
-				{ type: "image", mimeType: "image/jpeg", data: "bbb" },
-			]
-			const result = callInputHandler(pi, { text: "check both", images })
+			mockGetNativeClipboard.mockReturnValue({ clipboard: {}, error: null })
+			mockGetAvailableModels.mockReturnValue([{ slug: "glm-4", input_modalities: ["text", "image"] }])
+			mockReadClipboardImage.mockResolvedValue({ bytes: new Uint8Array([1]), mimeType: "image/png" })
 
+			// First session: paste and submit to advance counter
+			triggerSessionStart(pi, makeMockCtx())
+			getPasteHandler()()
+			await Promise.resolve()
+			callInputHandler(pi, { text: "📎" })
+
+			// New session: counter should reset
+			triggerSessionStart(pi, makeMockCtx())
+			getPasteHandler()()
+			await Promise.resolve()
+
+			const result = callInputHandler(pi, { text: "📎" })
 			const text = (result as { text: string }).text
-			expect(text).toContain("[Image #3]")
-			expect(text).toContain("[Image #4]")
+			expect(text).toContain("[Image #1]")
+		})
+
+		it("clears pending images on session start", async () => {
+			const pi = makeMockPi()
+			clipboardImageExtension(pi)
+
+			mockGetNativeClipboard.mockReturnValue({ clipboard: {}, error: null })
+			mockGetAvailableModels.mockReturnValue([{ slug: "glm-4", input_modalities: ["text", "image"] }])
+			mockReadClipboardImage.mockResolvedValue({ bytes: new Uint8Array([1]), mimeType: "image/png" })
+
+			triggerSessionStart(pi, makeMockCtx())
+			getPasteHandler()() // pending slot reserved in old session's bucket
+			await Promise.resolve()
+
+			// New session creates a fresh pendingImages array; old bucket is abandoned
+			triggerSessionStart(pi, makeMockCtx())
+
+			// Submit with a 📎 — no pending slots in new session, marker stripped
+			const result = callInputHandler(pi, { text: "📎" })
+			expect(result).toMatchObject({ action: "transform", text: "", images: [] })
 		})
 	})
 })

--- a/src/extensions/clipboard-image.ts
+++ b/src/extensions/clipboard-image.ts
@@ -5,9 +5,10 @@ import { getAvailableModels } from "../startup-context.js"
 import { getNativeClipboard } from "../utils/clipboard-native-harness.js"
 import { readClipboardImage } from "../utils/clipboard-read.js"
 import { addImage, clearAllImages, setImageCacheDir } from "../utils/image-registry.js"
-import { setPasteImageHandler, setPendingImageIndicator } from "./ui.js"
+import { insertAtCursor, setPasteImageHandler, setPendingImageIndicator } from "./ui.js"
 
-let pendingImages: ImageContent[] = []
+// Slots filled async after paste; null means image read is still in-flight or failed.
+let pendingImages: (ImageContent | null)[] = []
 let currentCtx: ExtensionContext | null = null
 // Per-session running counter of images attached to user turns. Resets on
 // session_start so that a new conversation always begins at #1.
@@ -20,19 +21,8 @@ function modelSupportsImages(modelId: string | undefined): boolean {
 	return meta?.input_modalities.includes("image") ?? false
 }
 
-function buildImageMarkerPrefix(startIndex: number, count: number): string {
-	if (count <= 0) return ""
-	const markers = Array.from({ length: count }, (_, i) => `[Image #${startIndex + i}]`)
-	return markers.join(" ")
-}
-
 setPasteImageHandler(() => {
-	handlePaste().catch((err) => {
-		console.error("Clipboard paste handler error:", err)
-	})
-})
-
-async function handlePaste(): Promise<void> {
+	// Synchronous checks first — bail early without reserving a slot.
 	const model = currentCtx?.model
 	if (!modelSupportsImages(model?.id)) {
 		currentCtx?.ui?.notify(`${model?.id ?? "Current model"} does not support images`, "warning")
@@ -46,39 +36,31 @@ async function handlePaste(): Promise<void> {
 		return
 	}
 
-	let image: { bytes: Uint8Array; mimeType: string } | null
-	try {
-		image = await readClipboardImage()
-	} catch {
-		currentCtx?.ui?.notify("Clipboard image support is not available", "warning")
-		return
-	}
+	// Reserve the slot and insert the marker synchronously so it lands at the
+	// cursor position before any async work can shift state.
+	// Capture the array reference so in-flight callbacks stay bound to this
+	// session's bucket even if session_start replaces pendingImages later.
+	const bucket = pendingImages
+	const slot = bucket.length
+	bucket.push(null)
+	insertAtCursor("📎")
 
-	if (!image) {
-		currentCtx?.ui?.notify("No image found on clipboard", "info")
-		return
-	}
-
-	const base64 = Buffer.from(image.bytes).toString("base64")
-	const imageContent: ImageContent = {
-		type: "image",
-		data: base64,
-		mimeType: image.mimeType,
-	}
-	pendingImages.push(imageContent)
-	updateIndicator()
-}
-
-function updateIndicator(): void {
-	if (pendingImages.length === 0) {
-		setPendingImageIndicator(null)
-		return
-	}
-	const totalRawBytes = pendingImages.reduce((sum, img) => sum + Math.floor((img.data.length * 3) / 4), 0)
-	const kb = Math.max(1, Math.round(totalRawBytes / 1024))
-	const label = pendingImages.length === 1 ? "image" : "images"
-	setPendingImageIndicator(`📎 ${pendingImages.length} ${label} (${kb} KB)`)
-}
+	// Fill in the actual image data asynchronously.
+	readClipboardImage()
+		.then((image) => {
+			if (!image) {
+				// Leave bucket[slot] as null — the 📎 marker will be stripped on submit.
+				currentCtx?.ui?.notify("No image found on clipboard", "info")
+				return
+			}
+			const base64 = Buffer.from(image.bytes).toString("base64")
+			bucket[slot] = { type: "image", data: base64, mimeType: image.mimeType }
+		})
+		.catch(() => {
+			// Leave bucket[slot] as null — the 📎 marker will be stripped on submit.
+			currentCtx?.ui?.notify("Clipboard image support is not available", "warning")
+		})
+})
 
 export default function clipboardImageExtension(pi: ExtensionAPI): void {
 	pi.on("session_start", (_event, ctx) => {
@@ -89,29 +71,41 @@ export default function clipboardImageExtension(pi: ExtensionAPI): void {
 		const dir = sessionDir ? join(sessionDir, "image-cache") : null
 		setImageCacheDir(dir)
 		clearAllImages()
-		updateIndicator()
+		setPendingImageIndicator(null)
 	})
 
 	pi.on("input", (event) => {
 		const incoming = event.images ?? []
-		const totalImages = incoming.length + pendingImages.length
+		// Count 📎 markers in text — each maps to a pending slot in push order.
+		const markerCount = (event.text.match(/📎/gu) ?? []).length
 
-		if (totalImages === 0) return
+		if (incoming.length === 0 && markerCount === 0) return
 
-		const images = [...incoming, ...pendingImages]
-		pendingImages = []
-		updateIndicator()
+		// Only consume pending slots when there are markers to resolve.
+		// Skipping this when markerCount === 0 prevents programmatic follow-up
+		// messages (e.g. from ferment) from clearing slots before the user submits.
+		let pendingSlots: (ImageContent | null)[] = []
+		if (markerCount > 0) {
+			const captured = pendingImages
+			pendingImages = []
+			pendingSlots = captured.slice(0, markerCount)
+		}
+
+		const validPending = pendingSlots.filter((img): img is ImageContent => img !== null)
+		const images = [...incoming, ...validPending]
 
 		const startIndex = imageCounter + 1
-		imageCounter += totalImages
-		// Persist each image to disk and register under its [Image #N] id.
-		images.forEach((image, i) => {
-			const id = startIndex + i
-			addImage(id, image)
+		imageCounter += images.length
+		images.forEach((image, i) => addImage(startIndex + i, image))
+
+		// Replace 📎 markers left-to-right with [Image #N].
+		// Orphaned markers (failed load or no backing slot) are stripped from the text.
+		let slotIdx = 0
+		let sessionIdx = startIndex + incoming.length
+		const text = event.text.replace(/📎/gu, () => {
+			const slot = pendingSlots[slotIdx++]
+			return slot != null ? `[Image #${sessionIdx++}]` : ""
 		})
-		const prefix = buildImageMarkerPrefix(startIndex, totalImages)
-		const trimmed = event.text.trimStart()
-		const text = trimmed ? `${prefix} ${trimmed}` : prefix
 
 		return { action: "transform" as const, text, images }
 	})

--- a/src/extensions/ui.ts
+++ b/src/extensions/ui.ts
@@ -148,6 +148,10 @@ export function setPasteImageHandler(handler: () => void): void {
 	pasteImageHandler = handler
 }
 
+export function insertAtCursor(text: string): void {
+	currentEditor?.insertTextAtCursor?.(text)
+}
+
 /**
  * Show or clear a short status string right-aligned on the prompt's first row,
  * next to the placeholder. Used by the clipboard-image extension to surface


### PR DESCRIPTION
## Description
Clipboard image paste: inline 📎 marker replaces chip approach

  Replaces the pending-image chip row with an inline marker: pasting inserts 📎 at the cursor position, which is replaced with [Image #N] when the message is submitted. Deleting a pasted image is now just deleting the 📎 character - no separate backspace handler or chip UI needed.

## Type of Change

### Before

https://github.com/user-attachments/assets/92f3948e-46b8-4789-8541-5eae918f9b82



### After

https://github.com/user-attachments/assets/3640432c-8258-44c7-989c-2d167b18a481



<!-- Select all that apply. -->

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Documentation update
