### PR TITLE
fix: retry socket-connection-closed errors during SSE streams

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -70,10 +70,10 @@ import resourceToolBlockerExtension from "./resources/tool-blocker.js"
 import { runSetupWizard } from "./setup-wizard.js"
 import { setAvailableModels } from "./startup-context.js"
 import { probeTerminalBackground } from "./terminal-bg-probe.js"
-import { installCloudflare524RetryPatch } from "./upstream-retry-patch.js"
+import { installRetryPatch } from "./upstream-retry-patch.js"
 import { getVersion } from "./utils.js"
 
-installCloudflare524RetryPatch()
+installRetryPatch()
 
 // --- PostHog device ID & analytics ---
 // Read or generate device ID (persisted; reused across invocations for

--- a/src/upstream-retry-patch.test.ts
+++ b/src/upstream-retry-patch.test.ts
@@ -1,11 +1,53 @@
 import { describe, expect, it, vi } from "vitest"
-import { installCloudflare524RetryPatch, isCloudflare524Retryable } from "./upstream-retry-patch.js"
+import { installRetryPatch, isCloudflare524Retryable, isSocketClosedRetryable } from "./upstream-retry-patch.js"
 
 describe("upstream retry patch", () => {
 	it("classifies Cloudflare 524 provider errors as retryable", () => {
 		expect(isCloudflare524Retryable({ stopReason: "error", errorMessage: "524 status code (no body)" })).toBe(true)
 		expect(isCloudflare524Retryable({ stopReason: "stop", errorMessage: "524 status code (no body)" })).toBe(false)
 		expect(isCloudflare524Retryable({ stopReason: "error", errorMessage: "bad request" })).toBe(false)
+	})
+
+	it("classifies socket-connection-closed errors as retryable", () => {
+		// The Node 24 wrapped message (undici SocketError wrapped by Node)
+		expect(
+			isSocketClosedRetryable({
+				stopReason: "error",
+				errorMessage:
+					"The socket connection was closed unexpectedly. For more information, pass `verbose: true` in the second argument to fetch()",
+			}),
+		).toBe(true)
+		// Raw undici SocketError message ("other side closed")
+		expect(
+			isSocketClosedRetryable({
+				stopReason: "error",
+				errorMessage: "SocketError: other side closed",
+			}),
+		).toBe(true)
+		// Other socket closed variants
+		expect(
+			isSocketClosedRetryable({
+				stopReason: "error",
+				errorMessage: "socket unexpectedly closed by server",
+			}),
+		).toBe(true)
+		expect(
+			isSocketClosedRetryable({
+				stopReason: "error",
+				errorMessage: "socket closed",
+			}),
+		).toBe(true)
+		// Non-socket errors should not match
+		expect(isSocketClosedRetryable({ stopReason: "error", errorMessage: "connection reset" })).toBe(false)
+		expect(isSocketClosedRetryable({ stopReason: "error", errorMessage: "fetch failed" })).toBe(false)
+		expect(isSocketClosedRetryable({ stopReason: "error", errorMessage: "request failed" })).toBe(false)
+		// Non-error stopReason should not match
+		expect(
+			isSocketClosedRetryable({
+				stopReason: "stop",
+				errorMessage: "The socket connection was closed unexpectedly",
+			}),
+		).toBe(false)
 	})
 
 	it("wraps the upstream retry classifier once and preserves original retryable errors", () => {
@@ -18,13 +60,23 @@ describe("upstream retry patch", () => {
 			},
 		}
 
-		installCloudflare524RetryPatch(sessionClass)
+		installRetryPatch(sessionClass)
 		const wrapped = sessionClass.prototype._isRetryableError
-		installCloudflare524RetryPatch(sessionClass)
+		installRetryPatch(sessionClass)
 
 		expect(sessionClass.prototype._isRetryableError).toBe(wrapped)
 		expect(wrapped?.({ stopReason: "error", errorMessage: "524 status code (no body)" })).toBe(true)
 		expect(wrapped?.({ stopReason: "error", errorMessage: "429 rate limit" })).toBe(true)
 		expect(wrapped?.({ stopReason: "error", errorMessage: "invalid request" })).toBe(false)
+		// Non-matching errors fall through to the original classifier (returns false)
+		expect(wrapped?.({ stopReason: "error", errorMessage: "context overflow" })).toBe(false)
+		// Socket closed errors are also retried
+		expect(
+			wrapped?.({
+				stopReason: "error",
+				errorMessage:
+					"The socket connection was closed unexpectedly. For more information, pass `verbose: true` in the second argument to fetch()",
+			}),
+		).toBe(true)
 	})
 })

--- a/src/upstream-retry-patch.ts
+++ b/src/upstream-retry-patch.ts
@@ -5,31 +5,50 @@ type RetryableClassifier = (message: RetryableMessage) => boolean
 type PatchableAgentSession = {
 	prototype: {
 		_isRetryableError?: RetryableClassifier
-		_kimchiCloudflare524RetryPatch?: boolean
+		_kimchiRetryPatchApplied?: boolean
 	}
 }
 
 const CLOUDFLARE_524_RE = /\b524\b|cloudflare.*timeout|timeout.*cloudflare/i
 
+/**
+ * Matches socket-connection-closed errors from undici/Node.js native fetch.
+ * These are transient — the next request on a fresh connection succeeds.
+ * Covers:
+ * - "The socket connection was closed unexpectedly. For more information, pass `verbose: true`..."
+ *   (Node 24 wraps undici SocketError with this message)
+ * - "other side closed" (raw undici SocketError message)
+ * - "socket closed" and "socket unexpectedly closed"
+ */
+const SOCKET_CLOSED_RE = /socket.*closed|other side closed/i
+
 export function isCloudflare524Retryable(message: RetryableMessage): boolean {
 	return message.stopReason === "error" && !!message.errorMessage && CLOUDFLARE_524_RE.test(message.errorMessage)
 }
 
+export function isSocketClosedRetryable(message: RetryableMessage): boolean {
+	return message.stopReason === "error" && !!message.errorMessage && SOCKET_CLOSED_RE.test(message.errorMessage)
+}
+
 /**
- * Temporary adapter for pi-coding-agent@0.74.0. Upstream retries 429/500/502/503/504
- * but not Cloudflare's 524 timeout, which kimchi-dev's gateway can return for a
- * long planner call. Remove once upstream's retry classifier covers 524.
+ * Temporary adapter for pi-coding-agent@0.74.0. Augments the upstream retry classifier
+ * to also handle:
+ * - Cloudflare 524 timeouts (gateway can return them for long calls)
+ * - Socket-connection-closed errors (Node 24 wraps undici SocketError with
+ *   "The socket connection was closed unexpectedly..."; upstream regex has "other side closed"
+ *   but not "socket.*closed", so misses the Node 24 wrapped form)
+ * Remove once upstream's retry classifier covers both cases.
  */
-export function installCloudflare524RetryPatch(
+export function installRetryPatch(
 	sessionClass: PatchableAgentSession = AgentSession as unknown as PatchableAgentSession,
 ): void {
 	const proto = sessionClass.prototype
-	if (proto._kimchiCloudflare524RetryPatch) return
+	if (proto._kimchiRetryPatchApplied) return
 	const original = proto._isRetryableError
 	if (!original) return
 
 	proto._isRetryableError = function patchedIsRetryableError(message: RetryableMessage): boolean {
-		return original.call(this, message) || isCloudflare524Retryable(message)
+		return original.call(this, message) || isCloudflare524Retryable(message) || isSocketClosedRetryable(message)
 	}
-	proto._kimchiCloudflare524RetryPatch = true
+	proto._kimchiRetryPatchApplied = true
 }


### PR DESCRIPTION
## Description

 Upstream's retry classifier has "other side closed" but not the Node 24 wrapped form "socket connection was closed unexpectedly". These errors are transient (server closing the connection mid-stream), so retrying on a fresh connection resolves the issue.

## Type of Change

<!-- Select all that apply. -->

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
