### PR TITLE
fix(update): repoint repo constant and URLs to getkimchi/kimchi after rename

### DIFF
--- a/src/commands/update.ts
+++ b/src/commands/update.ts
@@ -29,7 +29,7 @@ function parseFlags(args: string[]): UpdateFlags | string {
 
 /**
  * `kimchi update` — explicit self-update entry point. Always skips the
- * 24h cache so users get fresh results when they ask.
+ * cached state so users get fresh results when they ask.
  *
  * On Linux/macOS the swap is atomic via POSIX rename(2); on Windows we
  * rotate kimchi.exe → kimchi.exe.old and the user is told to restart
@@ -58,7 +58,7 @@ export async function runUpdate(args: string[]): Promise<number> {
 			console.log("To use canary, uninstall the Homebrew package and reinstall directly:")
 			console.log("")
 			console.log("  brew uninstall kimchi")
-			console.log("  curl -fsSL https://github.com/castai/kimchi-dev/releases/latest/download/install.sh | bash")
+			console.log("  curl -fsSL https://github.com/getkimchi/kimchi/releases/latest/download/install.sh | bash")
 			console.log("")
 			console.log("Then re-run: kimchi update --canary")
 			return 0
@@ -109,7 +109,7 @@ export async function runUpdate(args: string[]): Promise<number> {
 		console.error(`kimchi update: update failed — ${(err as Error).message}`)
 		console.error("")
 		console.error(
-			"Please copy the error message above and create a bug report at https://github.com/castai/kimchi/issues",
+			"Please copy the error message above and create a bug report at https://github.com/getkimchi/kimchi/issues",
 		)
 		return 1
 	}

--- a/src/update/github.ts
+++ b/src/update/github.ts
@@ -32,7 +32,7 @@ export interface GitHubClientOptions {
 	fetch?: typeof globalThis.fetch
 }
 
-export const KIMCHI_REPO: Repo = { owner: "castai", name: "kimchi-dev", binary: "kimchi" }
+export const KIMCHI_REPO: Repo = { owner: "getkimchi", name: "kimchi", binary: "kimchi" }
 
 /** Map node `process.platform` → the goreleaser-style OS slug used in asset names. */
 function osSlug(): string {

--- a/src/update/workflow.ts
+++ b/src/update/workflow.ts
@@ -57,7 +57,7 @@ export function parseCanarySha7(version: string): string | null {
 }
 
 /**
- * Resolve the latest release for `repo`, hitting the 24h-cached state file
+ * Resolve the latest release for `repo`, hitting the 1h-cached state file
  * when fresh and falling back to the GitHub API otherwise. Honors
  * $KIMCHI_NO_UPDATE_CHECK by short-circuiting to a "no update" result.
  *


### PR DESCRIPTION
Part 1 of #435.

`KIMCHI_REPO` in `src/update/github.ts` still pointed at the deprecated `castai/kimchi-dev`. The check worked only because `api.github.com` 301-redirects the old org to `getkimchi/kimchi`:

```
$ curl -sI https://api.github.com/repos/castai/kimchi-dev/releases/latest | head -2
HTTP/2 301
location: https://api.github.com/repositories/1204057895/releases/latest
```

Relying on GitHub's permanent-redirect is brittle. If it's ever lifted (or rate-limited), every kimchi install on the planet stops getting update notifications. The stale constant also leaked into two user-visible URLs in `src/commands/update.ts`. The canary install script (404 on `castai/kimchi-dev`) and the bug-report URL.

Also fixes JSDoc drift: `src/update/state.ts` has used `TTL_MS = 60 * 60 * 1_000` (1h) for a while but the comments in `workflow.ts` and `commands/update.ts` still said "24h".

## Diff

- `src/update/github.ts` - `KIMCHI_REPO` owner/name → `getkimchi/kimchi`.
- `src/commands/update.ts`. Canary install URL + bug-report URL → `getkimchi/kimchi`.
- `src/update/workflow.ts`, `src/commands/update.ts`. JSDoc says 1h, not 24h.

## What's not in this PR

Doesn't fix #435 by itself. That needs the tap-aware logic (consult the installed Homebrew formula's tap + version before nagging, and offer a tap-migration command when the user is on the deprecated `castai/tap`). Splitting that out keeps this PR a no-risk drop-in.

Test fixtures in `src/update/state.test.ts` intentionally keep the `castai/*` keys. They exercise backward-compat parsing of cache state files written by older builds, not the production constant.

## Tests

```
$ pnpm exec vitest run src/update src/commands/update.test.ts
Test Files  6 passed (6)
     Tests  64 passed (64)
```

Lint + typecheck clean.
