### PR TITLE
feat(agent-runner): add 50% soft steer nudge

### DIFF
--- a/src/extensions/agents/manager/agent-runner.test.ts
+++ b/src/extensions/agents/manager/agent-runner.test.ts
@@ -698,22 +698,33 @@ describe("runAgent — budget awareness steers", () => {
 
 	const steerCases: Record<string, { maxTurns: number; turns: number; expectedSteerCount: number; pattern?: RegExp }> =
 		{
+			"does not steer before 50% of turn budget": {
+				maxTurns: 10,
+				turns: 4,
+				expectedSteerCount: 0,
+			},
+			"steers at 50% of turn budget": {
+				maxTurns: 10,
+				turns: 5,
+				expectedSteerCount: 1,
+				pattern: /50% of your turn budget./,
+			},
+			"does not steer between 50% and 75%": {
+				maxTurns: 10,
+				turns: 7,
+				expectedSteerCount: 1,
+			},
 			"steers at 75% of turn budget": {
 				maxTurns: 10,
 				turns: 8,
-				expectedSteerCount: 1,
+				expectedSteerCount: 2,
 				pattern: /75% of your turn budget./,
 			},
 			"steers at 90% of turn budget": {
 				maxTurns: 10,
 				turns: 9,
-				expectedSteerCount: 2,
+				expectedSteerCount: 3,
 				pattern: /90% of your turn budget./,
-			},
-			"does not steer before 75% of turn budget": {
-				maxTurns: 10,
-				turns: 7,
-				expectedSteerCount: 0,
 			},
 		}
 

--- a/src/extensions/agents/manager/agent-runner.ts
+++ b/src/extensions/agents/manager/agent-runner.ts
@@ -405,6 +405,11 @@ async function runAgentInner(
 
 	const PROGRESS_STEER_POINTS: { threshold: number; message: string }[] = [
 		{
+			threshold: 0.5,
+			message:
+				"You're at 50% of your turn budget. Pause briefly to evaluate your progress and confirm you're still on the right path. Adjust course if needed.",
+		},
+		{
 			threshold: 0.75,
 			message:
 				"You're at 75% of your turn budget. Continue your current approach; avoid starting new exploratory work.",


### PR DESCRIPTION
Adds a 50% turn-budget checkpoint to `PROGRESS_STEER_POINTS` that prompts the agent to pause and evaluate its progress and path, without demanding immediate wrap-up. This sits alongside the existing 75% and 90% steers.

Commit f6824a4 raised the steer thresholds to `[0.75, 0.9]` to avoid too-early intervention. Benchmarks have shown that without an intermediate checkpoint agents can drift off course for longer. The 50% nudge is a gentler, earlier guardrail that invites self-correction while still tolerating exploratory work.

### Changes
- Add `threshold: 0.5` entry to `PROGRESS_STEER_POINTS` in `agent-runner.ts`
- Update `steerCases` tests to cover 50% firing behavior and adjust expected steer counts for 75%/90%