### PR TITLE
feat: model catalog sunset & lifecycle management

### DIFF
--- a/src/extensions/orchestration/model-registry/model-registry.test.ts
+++ b/src/extensions/orchestration/model-registry/model-registry.test.ts
@@ -50,7 +50,10 @@ describe("MODEL_CAPABILITIES completeness invariants", () => {
 const KNOWN_IDS = [...MODEL_CAPABILITIES.keys()]
 const ACTIVE_IDS = KNOWN_IDS.filter((id) => MODEL_CAPABILITIES.get(id) !== "ignored")
 
-function metadata(slug: string, overrides: Partial<ModelMetadata> = {}): ModelMetadata {
+function metadata(
+	slug: string,
+	overrides: Partial<ModelMetadata> & { status?: ModelMetadata["status"]; replacement?: string } = {},
+): ModelMetadata {
 	return {
 		slug,
 		display_name: "",
@@ -156,6 +159,71 @@ describe("ModelRegistry — ignored models", () => {
 		const ignoredIds = KNOWN_IDS.filter((id) => MODEL_CAPABILITIES.get(id) === "ignored")
 		const registry = new ModelRegistry(ignoredIds.map((id) => metadata(id)))
 		expect(registry.warnings).toHaveLength(0)
+	})
+})
+
+describe("ModelRegistry — sunset models", () => {
+	it("excludes sunset models from getAll() and getModelsWithCapabilities()", () => {
+		const registry = new ModelRegistry([metadata("some-model", { status: "sunset" })])
+		expect(registry.getAll()).toHaveLength(0)
+		expect(registry.getModelsWithCapabilities()).toHaveLength(0)
+	})
+
+	it("does not emit warnings for sunset models", () => {
+		const registry = new ModelRegistry([metadata("some-model", { status: "sunset" })])
+		expect(registry.warnings).toHaveLength(0)
+	})
+
+	it("sunset model is excluded even when it has a capabilities entry", () => {
+		const registry = new ModelRegistry([metadata(ACTIVE_IDS[0], { status: "sunset" })])
+		expect(registry.getAll().map((m) => m.id)).not.toContain(ACTIVE_IDS[0])
+		expect(registry.getModelsWithCapabilities().map((m) => m.id)).not.toContain(ACTIVE_IDS[0])
+		expect(registry.warnings).toHaveLength(0)
+	})
+})
+
+describe("ModelRegistry — deprecated models", () => {
+	it("includes deprecated models in getAll()", () => {
+		const registry = new ModelRegistry([metadata("some-model", { status: "deprecated" })])
+		expect(registry.getAll().map((m) => m.id)).toContain("some-model")
+	})
+
+	it("emits a deprecated_model warning with modelId", () => {
+		const registry = new ModelRegistry([metadata("some-model", { status: "deprecated" })])
+		const warning = registry.warnings.find((w) => w.modelId === "some-model")
+		expect(warning).toBeDefined()
+		expect(warning?.kind).toBe("deprecated_model")
+	})
+
+	it("emits deprecated_model warning with replacement when provided", () => {
+		const registry = new ModelRegistry([metadata("old-model", { status: "deprecated", replacement: "new-model" })])
+		const warning = registry.warnings.find((w) => w.modelId === "old-model")
+		expect(warning?.kind).toBe("deprecated_model")
+		expect(warning?.replacement).toBe("new-model")
+	})
+
+	it("deprecated model without replacement emits warning with undefined replacement", () => {
+		const registry = new ModelRegistry([metadata("old-model", { status: "deprecated" })])
+		const warning = registry.warnings.find((w) => w.modelId === "old-model")
+		expect(warning?.kind).toBe("deprecated_model")
+		expect(warning?.replacement).toBeUndefined()
+	})
+
+	it("deprecated model with capabilities uses those capabilities", () => {
+		const id = ACTIVE_IDS[0]
+		const registry = new ModelRegistry([metadata(id, { status: "deprecated" })])
+		const model = registry.getAll().find((m) => m.id === id)
+		const entry = MODEL_CAPABILITIES.get(id)
+		if (!entry || entry === "ignored") return
+		expect(model?.capabilities.description).toBe(entry.description)
+		expect(registry.getModelsWithCapabilities().map((m) => m.id)).toContain(id)
+	})
+
+	it("deprecated model without capabilities uses generic capabilities", () => {
+		const registry = new ModelRegistry([metadata("unknown-deprecated", { status: "deprecated" })])
+		const model = registry.getAll().find((m) => m.id === "unknown-deprecated")
+		expect(model?.capabilities.description).toContain("No capability information")
+		expect(registry.getModelsWithCapabilities().map((m) => m.id)).not.toContain("unknown-deprecated")
 	})
 })
 

--- a/src/extensions/orchestration/model-registry/model-registry.ts
+++ b/src/extensions/orchestration/model-registry/model-registry.ts
@@ -45,8 +45,9 @@ function deriveName(m: ModelMetadata): string {
 }
 
 export interface ModelRegistryWarning {
-	kind: "unknown_model"
+	kind: "unknown_model" | "deprecated_model"
 	modelId: string
+	replacement?: string // only for deprecated_model
 }
 
 export class ModelRegistry {
@@ -60,10 +61,22 @@ export class ModelRegistry {
 		const allModels: OrchestrationModelDescriptor[] = []
 
 		for (const m of availableModels) {
+			// Sunset models are excluded entirely, like "ignored"
+			if (m.status === "sunset") continue
+
+			// Deprecated warning is emitted even for ignored models so the
+			// user gets notified even if the model isn't routed to subagents.
+			if (m.status === "deprecated") {
+				warnings.push({ kind: "deprecated_model", modelId: m.slug, replacement: m.replacement })
+			}
+
 			const entry = MODEL_CAPABILITIES.get(m.slug)
 			if (entry === "ignored") continue
+
 			if (entry === undefined) {
-				warnings.push({ kind: "unknown_model", modelId: m.slug })
+				if (m.status !== "deprecated") {
+					warnings.push({ kind: "unknown_model", modelId: m.slug })
+				}
 				allModels.push({
 					id: m.slug,
 					provider: KIMCHI_DEV_PROVIDER,

--- a/src/extensions/prompt-construction/prompt-enrichment.test.ts
+++ b/src/extensions/prompt-construction/prompt-enrichment.test.ts
@@ -1,8 +1,14 @@
 import type { AssistantMessage, ToolResultMessage } from "@earendil-works/pi-ai"
 import type { ExtensionAPI, ToolInfo } from "@earendil-works/pi-coding-agent"
-import { describe, expect, it } from "vitest"
+import { beforeEach, describe, expect, it, vi } from "vitest"
+import type { ModelMetadata } from "../../models.js"
+import * as startupContext from "../../startup-context.js"
+import * as agentWorkerContext from "../agent-worker-context.js"
 import type { OrchestratorMessages } from "../orchestration/continuation-nudge.js"
-import promptEnrichmentExtension, { stripEmptyToolCalls } from "./prompt-enrichment.js"
+import promptEnrichmentExtension, {
+	stripEmptyToolCalls,
+	_resetDeprecatedNotificationTracking,
+} from "./prompt-enrichment.js"
 import { createToolVisibility } from "./tool-visibility.js"
 
 function makeUser(text: string): OrchestratorMessages[number] {
@@ -243,5 +249,246 @@ describe("prompt enrichment tool visibility", () => {
 
 		expect(result.systemPrompt).toContain('<tool name="read">')
 		expect(result.systemPrompt).not.toContain('<tool name="bash">')
+	})
+})
+
+describe("deprecated model notification", () => {
+	beforeEach(() => {
+		vi.restoreAllMocks()
+		_resetDeprecatedNotificationTracking()
+	})
+
+	const deprecatedModelId = "kimi-k2.6-old"
+	const replacementModelId = "kimi-k2.7"
+
+	function makeMockContext(modelId: string | undefined, sessionId = "test-session-1") {
+		return {
+			cwd: "/tmp",
+			model: modelId ? { id: modelId, provider: "kimchi-dev" } : undefined,
+			hasUI: true,
+			sessionManager: {
+				getSessionId: () => sessionId,
+			},
+			ui: {
+				notify: vi.fn(),
+			},
+		}
+	}
+
+	function setupAvailableModels(models: readonly ModelMetadata[]) {
+		vi.spyOn(startupContext, "getAvailableModels").mockReturnValue(models)
+	}
+
+	function buildExtensionWithHandlers() {
+		const handlers = new Map<string, (event: unknown, ctx: unknown) => Promise<unknown> | unknown>()
+		const pi = {
+			registerFlag: () => {},
+			registerCommand: () => {},
+			on: (event: string, handler: (event: unknown, ctx: unknown) => Promise<unknown> | unknown) => {
+				handlers.set(event, handler)
+			},
+			getAllTools: () => [],
+			getActiveTools: () => [],
+			getFlag: () => false,
+		} as unknown as ExtensionAPI
+		promptEnrichmentExtension([])(pi)
+		return {
+			handlers,
+			sessionStart: handlers.get("session_start"),
+			sessionShutdown: handlers.get("session_shutdown"),
+			modelSelect: handlers.get("model_select"),
+		}
+	}
+
+	it("notifies when session starts with a deprecated model that has a replacement", async () => {
+		const modelProps: Omit<ModelMetadata, "slug" | "display_name" | "status" | "replacement"> = {
+			provider: "kimchi-dev",
+			reasoning: false,
+			input_modalities: ["text"],
+			is_serverless: true,
+			limits: { context_window: 128000, max_output_tokens: 8192 },
+		}
+		const models: ModelMetadata[] = [
+			{
+				slug: deprecatedModelId,
+				display_name: "Kimi K2.6 Old",
+				status: "deprecated",
+				replacement: replacementModelId,
+				...modelProps,
+			},
+			{ slug: "active-model", display_name: "Active Model", status: "active", ...modelProps },
+			{ slug: replacementModelId, display_name: "Kimi K2.7", status: "active", ...modelProps },
+		]
+		setupAvailableModels(models)
+
+		const { sessionStart } = buildExtensionWithHandlers()
+		if (!sessionStart) throw new Error("session_start handler not registered")
+
+		const ctx = makeMockContext(deprecatedModelId)
+		await sessionStart({}, ctx)
+
+		const notifyMock = (ctx as { ui: { notify: ReturnType<typeof vi.fn> } }).ui.notify
+		expect(notifyMock.mock.calls.length).toBe(1)
+		expect(notifyMock).toHaveBeenCalledWith(
+			`Model "${deprecatedModelId}" is deprecated. Switch to "${replacementModelId}" for better performance.`,
+			"warning",
+		)
+	})
+
+	it("notifies with fallback message when deprecated model has no replacement", async () => {
+		const modelProps: Omit<ModelMetadata, "slug" | "display_name" | "status" | "replacement"> = {
+			provider: "kimchi-dev",
+			reasoning: false,
+			input_modalities: ["text"],
+			is_serverless: true,
+			limits: { context_window: 128000, max_output_tokens: 8192 },
+		}
+		const models: ModelMetadata[] = [
+			{ slug: deprecatedModelId, display_name: "Kimi K2.6 Old", status: "deprecated", ...modelProps },
+			{ slug: "active-model", display_name: "Active Model", status: "active", ...modelProps },
+		]
+		setupAvailableModels(models)
+
+		const { sessionStart } = buildExtensionWithHandlers()
+		if (!sessionStart) throw new Error("session_start handler not registered")
+
+		const ctx = makeMockContext(deprecatedModelId)
+		await sessionStart({}, ctx)
+
+		const notifyMock = (ctx as { ui: { notify: ReturnType<typeof vi.fn> } }).ui.notify
+		expect(notifyMock.mock.calls.length).toBe(1)
+		expect(notifyMock).toHaveBeenCalledWith(
+			`Model "${deprecatedModelId}" is deprecated. It may be removed in a future update.`,
+			"warning",
+		)
+	})
+
+	it("does not notify when session starts with an active model", async () => {
+		const modelProps: Omit<ModelMetadata, "slug" | "display_name" | "status" | "replacement"> = {
+			provider: "kimchi-dev",
+			reasoning: false,
+			input_modalities: ["text"],
+			is_serverless: true,
+			limits: { context_window: 128000, max_output_tokens: 8192 },
+		}
+		const models: ModelMetadata[] = [
+			{ slug: "active-model", display_name: "Active Model", status: "active", ...modelProps },
+		]
+		setupAvailableModels(models)
+
+		const { sessionStart } = buildExtensionWithHandlers()
+		if (!sessionStart) throw new Error("session_start handler not registered")
+
+		const ctx = makeMockContext("active-model")
+		await sessionStart({}, ctx)
+
+		const notifyMock = (ctx as { ui: { notify: ReturnType<typeof vi.fn> } }).ui.notify
+		expect(notifyMock.mock.calls.length).toBe(0)
+	})
+
+	it("only fires notification once per session", async () => {
+		const modelProps: Omit<ModelMetadata, "slug" | "display_name" | "status" | "replacement"> = {
+			provider: "kimchi-dev",
+			reasoning: false,
+			input_modalities: ["text"],
+			is_serverless: true,
+			limits: { context_window: 128000, max_output_tokens: 8192 },
+		}
+		const models: ModelMetadata[] = [
+			{
+				slug: deprecatedModelId,
+				display_name: "Kimi K2.6 Old",
+				status: "deprecated",
+				replacement: replacementModelId,
+				...modelProps,
+			},
+			{ slug: "active-model", display_name: "Active Model", status: "active", ...modelProps },
+		]
+		setupAvailableModels(models)
+
+		const { sessionStart } = buildExtensionWithHandlers()
+		if (!sessionStart) throw new Error("session_start handler not registered")
+
+		// First session
+		const ctx1 = makeMockContext(deprecatedModelId, "session-1")
+		await sessionStart({}, ctx1)
+
+		// Second session_start for same session should not fire again
+		await sessionStart({}, ctx1)
+
+		const notifyMock = (ctx1 as { ui: { notify: ReturnType<typeof vi.fn> } }).ui.notify
+		expect(notifyMock.mock.calls.length).toBe(1)
+	})
+
+	it("cleans up notification tracking on session_shutdown", async () => {
+		const modelProps: Omit<ModelMetadata, "slug" | "display_name" | "status" | "replacement"> = {
+			provider: "kimchi-dev",
+			reasoning: false,
+			input_modalities: ["text"],
+			is_serverless: true,
+			limits: { context_window: 128000, max_output_tokens: 8192 },
+		}
+		const models: ModelMetadata[] = [
+			{
+				slug: deprecatedModelId,
+				display_name: "Kimi K2.6 Old",
+				status: "deprecated",
+				replacement: replacementModelId,
+				...modelProps,
+			},
+			{ slug: "active-model", display_name: "Active Model", status: "active", ...modelProps },
+		]
+		setupAvailableModels(models)
+
+		const { sessionStart, sessionShutdown } = buildExtensionWithHandlers()
+		if (!sessionStart) throw new Error("session_start handler not registered")
+		if (!sessionShutdown) throw new Error("session_shutdown handler not registered")
+
+		const ctx = makeMockContext(deprecatedModelId, "session-1")
+
+		// Fire session_start
+		await sessionStart({}, ctx)
+		// Fire session_shutdown (cleans up the tracking for this session)
+		await sessionShutdown({}, ctx)
+		// Fire session_start again with same session ID — should notify again
+		await sessionStart({}, ctx)
+
+		const notifyMock = (ctx as { ui: { notify: ReturnType<typeof vi.fn> } }).ui.notify
+		// Should have fired twice — once at each session_start
+		expect(notifyMock.mock.calls.length).toBe(2)
+	})
+
+	it("shows fallback message when replacement model is not available", async () => {
+		const modelProps: Omit<ModelMetadata, "slug" | "display_name" | "status" | "replacement"> = {
+			provider: "kimchi-dev",
+			reasoning: false,
+			input_modalities: ["text"],
+			is_serverless: true,
+			limits: { context_window: 128000, max_output_tokens: 8192 },
+		}
+		const models: ModelMetadata[] = [
+			{
+				slug: deprecatedModelId,
+				display_name: "Kimi K2.6 Old",
+				status: "deprecated",
+				replacement: "nonexistent-model",
+				...modelProps,
+			},
+			{ slug: "active-model", display_name: "Active Model", status: "active", ...modelProps },
+		]
+		setupAvailableModels(models)
+
+		const { sessionStart } = buildExtensionWithHandlers()
+		if (!sessionStart) throw new Error("session_start handler not registered")
+
+		const ctx = makeMockContext(deprecatedModelId)
+		await sessionStart({}, ctx)
+
+		const notifyMock = (ctx as { ui: { notify: ReturnType<typeof vi.fn> } }).ui.notify
+		expect(notifyMock.mock.calls.length).toBe(1)
+		expect(notifyMock).toHaveBeenCalledWith(
+			`Model "${deprecatedModelId}" is deprecated. It may be removed in a future update.`,
+			"warning",
+		)
 	})
 })

--- a/src/extensions/prompt-construction/prompt-enrichment.ts
+++ b/src/extensions/prompt-construction/prompt-enrichment.ts
@@ -143,6 +143,13 @@ export function getOrchestratorModelRef(): string {
 }
 const DELEGATION_TOOL_NAMES = new Set(["Agent", "subagent"])
 
+// Tracks sessions that have already received a deprecation notification to avoid duplicate alerts.
+const deprecatedNotificationFired = new Set<string>()
+
+export function _resetDeprecatedNotificationTracking(): void {
+	deprecatedNotificationFired.clear()
+}
+
 function isDelegationToolCallName(name: string | undefined): boolean {
 	return name != null && DELEGATION_TOOL_NAMES.has(name)
 }
@@ -262,6 +269,14 @@ export default function (skillPaths: string[]) {
 		// For sub agents we don't want to transform the prompt sent from parent with model capabilities
 		const registry = new ModelRegistry(getAvailableModels())
 
+		// Build a map of deprecated model IDs for quick lookup during session_start.
+		const deprecatedWarnings = new Map<string, string | undefined>()
+		for (const w of registry.warnings) {
+			if (w.kind === "deprecated_model") {
+				deprecatedWarnings.set(w.modelId, w.replacement)
+			}
+		}
+
 		if (!subagentMode) {
 			// Validate model roles against available API models at startup
 			const availableIds = new Set(getAvailableModels().map((m) => m.slug))
@@ -271,7 +286,32 @@ export default function (skillPaths: string[]) {
 					`[model-roles] Warning: ${role} model "${configuredModel}" is not available. Subagents for this role will fall back to the parent model.`,
 				)
 			}
+			function notifyIfDeprecated(ctx: {
+				sessionManager?: { getSessionId: () => string | undefined }
+				model?: { id: string }
+				ui?: { notify: (msg: string, kind?: "warning" | "error" | "info") => void }
+			}) {
+				const sessionId = ctx.sessionManager?.getSessionId() ?? "unknown"
+				if (ctx.model && deprecatedWarnings.has(ctx.model.id) && !deprecatedNotificationFired.has(sessionId)) {
+					deprecatedNotificationFired.add(sessionId)
+					const replacement = deprecatedWarnings.get(ctx.model.id)
+					const replacementAvailable = replacement && registry.getAll().some((m) => m.id === replacement)
+					const message =
+						replacement && replacementAvailable
+							? `Model "${ctx.model.id}" is deprecated. Switch to "${replacement}" for better performance.`
+							: `Model "${ctx.model.id}" is deprecated. It may be removed in a future update.`
+					ctx.ui?.notify(message, "warning")
+				}
+			}
+
+			pi.on("session_shutdown", async (_event, ctx) => {
+				const sessionId = ctx.sessionManager?.getSessionId()
+				if (sessionId) deprecatedNotificationFired.delete(sessionId)
+			})
+
 			pi.on("session_start", async (_event, ctx) => {
+				notifyIfDeprecated(ctx)
+
 				// In multi-model mode the orchestrator must always be the configured
 				// orchestrator model. Force-switch if the user has a different model
 				// selected via /models.
@@ -286,6 +326,10 @@ export default function (skillPaths: string[]) {
 						}
 					}
 				}
+			})
+
+			pi.on("model_select", async (_event, ctx) => {
+				notifyIfDeprecated(ctx)
 			})
 
 			// Detect the inverse of the context-event nudge below: the orchestrator reasons

--- a/src/models.test.ts
+++ b/src/models.test.ts
@@ -376,4 +376,115 @@ describe("updateModelsConfig", () => {
 		expect(fetch).not.toHaveBeenCalled()
 		expect(existsSync(modelsJsonPath)).toBe(false)
 	})
+
+	it("filters out sunset models from models.json and returned list", async () => {
+		const sunsetModel = {
+			slug: "old-model",
+			display_name: "Old Model",
+			provider: "ai-enabler",
+			reasoning: false,
+			input_modalities: ["text"],
+			is_serverless: true,
+			limits: { context_window: 100_000, max_output_tokens: 4096 },
+			status: "sunset",
+		}
+		vi.mocked(fetch).mockResolvedValueOnce({
+			ok: true,
+			json: async () => ({ models: [KIMI, sunsetModel] }),
+		} as Response)
+
+		const result = await updateModelsConfig(modelsJsonPath, "test-key")
+
+		const config = JSON.parse(readFileSync(modelsJsonPath, "utf-8"))
+		const writtenIds = config.providers["kimchi-dev"].models.map((m: { id: string }) => m.id)
+		expect(writtenIds).toEqual(["kimi-k2.5"])
+		expect(result.models.map((m) => m.slug)).toEqual(["kimi-k2.5"])
+	})
+
+	it("warns when all API models are sunset", async () => {
+		const consoleWarnSpy = vi.spyOn(console, "warn").mockImplementation(() => {})
+		const sunsetModel = {
+			slug: "old-model",
+			display_name: "Old Model",
+			provider: "ai-enabler",
+			reasoning: false,
+			input_modalities: ["text"],
+			is_serverless: true,
+			limits: { context_window: 100_000, max_output_tokens: 4096 },
+			status: "sunset",
+		}
+		vi.mocked(fetch).mockResolvedValueOnce({
+			ok: true,
+			json: async () => ({ models: [sunsetModel] }),
+		} as Response)
+
+		const result = await updateModelsConfig(modelsJsonPath, "test-key")
+
+		expect(consoleWarnSpy).toHaveBeenCalledWith(expect.stringContaining("All models from the API are sunset"))
+		expect(result.models).toHaveLength(0)
+		const config = JSON.parse(readFileSync(modelsJsonPath, "utf-8"))
+		expect(config.providers["kimchi-dev"].models).toHaveLength(0)
+		consoleWarnSpy.mockRestore()
+	})
+
+	it("treats models without status field as active (backward compatibility)", async () => {
+		vi.mocked(fetch).mockResolvedValueOnce({
+			ok: true,
+			json: async () => ({ models: [KIMI] }),
+		} as Response)
+
+		const result = await updateModelsConfig(modelsJsonPath, "test-key")
+
+		const config = JSON.parse(readFileSync(modelsJsonPath, "utf-8"))
+		expect(config.providers["kimchi-dev"].models).toHaveLength(1)
+		expect(result.models.map((m) => m.slug)).toEqual(["kimi-k2.5"])
+	})
+
+	it("preserves deprecated models in models.json and returned list", async () => {
+		const deprecatedModel = {
+			slug: "deprecated-model",
+			display_name: "Deprecated Model",
+			provider: "ai-enabler",
+			reasoning: false,
+			input_modalities: ["text"],
+			is_serverless: true,
+			limits: { context_window: 100_000, max_output_tokens: 4096 },
+			status: "deprecated",
+		}
+		vi.mocked(fetch).mockResolvedValueOnce({
+			ok: true,
+			json: async () => ({ models: [KIMI, deprecatedModel] }),
+		} as Response)
+
+		const result = await updateModelsConfig(modelsJsonPath, "test-key")
+
+		const config = JSON.parse(readFileSync(modelsJsonPath, "utf-8"))
+		const writtenIds = config.providers["kimchi-dev"].models.map((m: { id: string }) => m.id)
+		expect(writtenIds).toContain("deprecated-model")
+		expect(result.models.map((m) => m.slug)).toContain("deprecated-model")
+	})
+
+	it("preserves replacement field on deprecated/sunset models in returned metadata", async () => {
+		const deprecatedWithReplacement = {
+			slug: "old-model",
+			display_name: "Old Model",
+			provider: "ai-enabler",
+			reasoning: false,
+			input_modalities: ["text"],
+			is_serverless: true,
+			limits: { context_window: 100_000, max_output_tokens: 4096 },
+			status: "deprecated",
+			replacement: "new-model",
+		}
+		vi.mocked(fetch).mockResolvedValueOnce({
+			ok: true,
+			json: async () => ({ models: [deprecatedWithReplacement] }),
+		} as Response)
+
+		const result = await updateModelsConfig(modelsJsonPath, "test-key")
+
+		const model = result.models.find((m) => m.slug === "old-model")
+		expect(model?.status).toBe("deprecated")
+		expect(model?.replacement).toBe("new-model")
+	})
 })

--- a/src/models.ts
+++ b/src/models.ts
@@ -18,6 +18,8 @@ export interface ModelMetadata {
 		context_window: number
 		max_output_tokens: number
 	}
+	status?: "active" | "sunset" | "deprecated"
+	replacement?: string
 }
 
 interface ModelsMetadataResponse {
@@ -210,8 +212,12 @@ export async function updateModelsConfig(modelsJsonPath: string, apiKey: string)
 		return { models: sortModels([...cached, ...otherModels]) }
 	}
 
-	const models = sortModels(fetched)
+	const activeModels = fetched.filter((m) => m.status !== "sunset")
+	if (activeModels.length === 0 && fetched.length > 0) {
+		console.warn("All models from the API are sunset. No active models available.")
+	}
+	const models = sortModels(activeModels)
 	const merged = { providers: { ...otherProviders, ...buildModelsConfig(models).providers } }
 	writeFileSync(modelsJsonPath, JSON.stringify(merged, null, "\t"), "utf-8")
-	return { models: sortModels([...fetched, ...otherModels]) }
+	return { models: sortModels([...activeModels, ...otherModels]) }
 }


### PR DESCRIPTION
Implements model lifecycle management: sunset models are excluded from the catalog, deprecated models trigger user notification with replacement suggestions.

## Changes
- Add `status` (active | sunset | deprecated) and optional `replacement` fields to ModelMetadata
- Filter sunset models from models.json and returned catalog
- Emit deprecation warnings via ModelRegistry (even for ignored models)
- TUI notification on session_start and model_select when active model is deprecated
- session_shutdown cleanup prevents memory leaks in long-running ACP server
- Warn when API returns only sunset models
- Refactor ModelRegistry constructor to remove duplicated capabilities lookup

## Tests
- 25 new tests across models.test.ts (5), model-registry.test.ts (9), prompt-enrichment.test.ts (11)
- Manual testing verified with live API

## Example

<img width="1465" height="603" alt="image" src="https://github.com/user-attachments/assets/2eae106d-9213-43c5-8bfb-348a4765381c" />


Co-Authored-By: Kimchi <noreply@kimchi.dev>