### PR TITLE
fix(oauth): harden callback page rendering and add coverage

### DIFF
--- a/resources/oauth/error.html
+++ b/resources/oauth/error.html
@@ -4,8 +4,6 @@
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <title>{{TITLE}}</title>
-  <link rel="preconnect" href="https://api.fontshare.com" />
-  <link href="https://api.fontshare.com/v2/css?f[]=satoshi@400,500,600,700&display=swap" rel="stylesheet" />
   <style>
     *, *::before, *::after {
       box-sizing: border-box;
@@ -13,20 +11,15 @@
       padding: 0;
     }
 
-    html, body {
-      height: 100%;
-      width: 100%;
-    }
-
     body {
       background-color: #0b0b0e;
       color: #fafafa;
-      font-family: 'Satoshi', system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, sans-serif;
+      font-family: system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, sans-serif;
       display: flex;
       align-items: center;
       justify-content: center;
       min-height: 100vh;
-      overflow: hidden;
+      padding: 24px;
       position: relative;
     }
 
@@ -71,7 +64,8 @@
       border: 1px solid rgba(234, 231, 226, 0.09);
       border-radius: 20px;
       padding: 44px 52px;
-      width: 360px;
+      width: 100%;
+      max-width: 360px;
       text-align: center;
       backdrop-filter: blur(24px);
       -webkit-backdrop-filter: blur(24px);

--- a/resources/oauth/success.html
+++ b/resources/oauth/success.html
@@ -4,8 +4,6 @@
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <title>{{TITLE}}</title>
-  <link rel="preconnect" href="https://api.fontshare.com" />
-  <link href="https://api.fontshare.com/v2/css?f[]=satoshi@400,500,600,700&display=swap" rel="stylesheet" />
   <style>
     *, *::before, *::after {
       box-sizing: border-box;
@@ -13,20 +11,15 @@
       padding: 0;
     }
 
-    html, body {
-      height: 100%;
-      width: 100%;
-    }
-
     body {
       background-color: #0b0b0e;
       color: #fafafa;
-      font-family: 'Satoshi', system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, sans-serif;
+      font-family: system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, sans-serif;
       display: flex;
       align-items: center;
       justify-content: center;
       min-height: 100vh;
-      overflow: hidden;
+      padding: 24px;
       position: relative;
     }
 
@@ -71,7 +64,8 @@
       border: 1px solid rgba(234, 231, 226, 0.09);
       border-radius: 20px;
       padding: 44px 52px;
-      width: 360px;
+      width: 100%;
+      max-width: 360px;
       text-align: center;
       backdrop-filter: blur(24px);
       -webkit-backdrop-filter: blur(24px);

--- a/scripts/patch-pi-ai-oauth.js
+++ b/scripts/patch-pi-ai-oauth.js
@@ -2,12 +2,19 @@
 /**
  * Post-install patch for @earendil-works/pi-ai OAuth pages.
  *
- * Replaces the hardcoded Pi logo and HTML templates in pi-ai's oauth-page.js
- * with a version that reads custom templates from KIMCHI_OAUTH_TEMPLATE_DIR.
+ * Replaces the hardcoded Pi-branded HTML in pi-ai's oauth-page.js with a
+ * renderer that reads Kimchi templates from KIMCHI_OAUTH_TEMPLATE_DIR.
+ * The templates themselves live in resources/oauth/ — designers iterate
+ * on them without touching node_modules or refreshing this patch.
  *
- * This avoids pnpm patch fragility for multi-line template changes.
+ * If the env var is missing or the template can't be read, the renderer
+ * falls through to a minimal unbranded HTML fallback. We deliberately avoid
+ * upstream's Pi-branded fallback (kimchi shipping competitor branding is the
+ * exact failure mode this patch exists to eliminate), and we avoid throwing
+ * (the token is already saved by the time the renderer is called — blank-
+ * paging the user mid-flow is worse UX than a degraded-looking page).
+ *
  * Remove when upstream supports configurable OAuth page templates.
- *
  * Tracking: TODO - open upstream issue against pi-mono for OAuth page customization.
  */
 import { writeFileSync } from "node:fs"
@@ -25,7 +32,6 @@ const target = join(
 )
 
 const patched = `import { readFileSync } from "node:fs";
-const LOGO_SVG = \`<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 800 800" aria-hidden="true"><path fill="#fff" fill-rule="evenodd" d="M165.29 165.29 H517.36 V400 H400 V517.36 H282.65 V634.72 H165.29 Z M282.65 282.65 V400 H400 V282.65 Z"/><path fill="#fff" d="M517.36 400 H634.72 V634.72 H517.36 Z"/></svg>\`;
 function escapeHtml(value) {
     return value
         .replaceAll("&", "&amp;")
@@ -47,12 +53,12 @@ function renderPage(options) {
             return html;
         }
         catch {
-            // fall through to default template
+            // fall through to minimal unbranded fallback
         }
     }
-    const title = escapeHtml(options.title);
-    const heading = escapeHtml(options.heading);
-    const message = escapeHtml(options.message);
+    const title = escapeHtml(options.title || "");
+    const heading = escapeHtml(options.heading || "");
+    const message = escapeHtml(options.message || "");
     const details = options.details ? escapeHtml(options.details) : undefined;
     return \`<!doctype html>
 <html lang="en">
@@ -61,71 +67,16 @@ function renderPage(options) {
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <title>\${title}</title>
   <style>
-    :root {
-      --text: #fafafa;
-      --text-dim: #a1a1aa;
-      --page-bg: #09090b;
-      --font-sans: ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol", "Noto Color Emoji";
-      --font-mono: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace;
-    }
-    * { box-sizing: border-box; }
-    html { color-scheme: dark; }
-    body {
-      margin: 0;
-      min-height: 100vh;
-      display: flex;
-      align-items: center;
-      justify-content: center;
-      padding: 24px;
-      background: var(--page-bg);
-      color: var(--text);
-      font-family: var(--font-sans);
-      text-align: center;
-    }
-    main {
-      width: 100%;
-      max-width: 560px;
-      display: flex;
-      flex-direction: column;
-      align-items: center;
-      justify-content: center;
-    }
-    .logo {
-      width: 72px;
-      height: 72px;
-      display: block;
-      margin-bottom: 24px;
-    }
-    h1 {
-      margin: 0 0 10px;
-      font-size: 28px;
-      line-height: 1.15;
-      font-weight: 650;
-      color: var(--text);
-    }
-    p {
-      margin: 0;
-      line-height: 1.7;
-      color: var(--text-dim);
-      font-size: 15px;
-    }
-    .details {
-      margin-top: 16px;
-      font-family: var(--font-mono);
-      font-size: 13px;
-      color: var(--text-dim);
-      white-space: pre-wrap;
-      word-break: break-word;
-    }
+    body { font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif; max-width: 480px; margin: 48px auto; padding: 24px; line-height: 1.5; color: #111; }
+    h1 { font-size: 20px; margin: 0 0 12px; }
+    p { margin: 0 0 12px; color: #555; }
+    .details { font-family: ui-monospace, SFMono-Regular, Menlo, monospace; font-size: 13px; background: #f5f5f5; padding: 12px; border-radius: 6px; white-space: pre-wrap; word-break: break-word; }
   </style>
 </head>
 <body>
-  <main>
-    <div class="logo">\${LOGO_SVG}</div>
-    <h1>\${heading}</h1>
-    <p>\${message}</p>
-    \${details ? \`<div class="details">\${details}</div>\` : ""}
-  </main>
+  <h1>\${heading}</h1>
+  <p>\${message}</p>
+  \${details ? \`<div class="details">\${details}</div>\` : ""}
 </body>
 </html>\`;
 }
@@ -153,5 +104,6 @@ try {
 	writeFileSync(target, patched)
 	console.log("[patch-pi-ai-oauth] Patched pi-ai OAuth page templates.")
 } catch (err) {
-	console.warn("[patch-pi-ai-oauth] Could not patch file:", err instanceof Error ? err.message : String(err))
+	console.error("[patch-pi-ai-oauth] Could not patch file:", err instanceof Error ? err.message : String(err))
+	process.exit(1)
 }

--- a/src/oauth-page-patch.test.ts
+++ b/src/oauth-page-patch.test.ts
@@ -1,0 +1,84 @@
+import { readFileSync } from "node:fs"
+import { dirname, resolve } from "node:path"
+import { fileURLToPath, pathToFileURL } from "node:url"
+import { afterEach, beforeEach, expect, it } from "vitest"
+
+const projectRoot = resolve(dirname(fileURLToPath(import.meta.url)), "..")
+const patchedFile = resolve(projectRoot, "node_modules/@earendil-works/pi-ai/dist/utils/oauth/oauth-page.js")
+const patchedFileUrl = pathToFileURL(patchedFile).href
+const templateDir = resolve(projectRoot, "resources/oauth")
+
+// The Kimchi logo SVG in both templates uses this exact orange — distinct from
+// upstream's Pi-branded white-on-transparent logo. Asserting the rendered HTML
+// contains it catches both "patch didn't run" (still upstream's renderer) and
+// "templates can't be read" (any silent fallback we might reintroduce).
+const KIMCHI_LOGO_ORANGE = "#FF521D"
+
+it("scripts/patch-pi-ai-oauth.js has been applied to node_modules", () => {
+	const source = readFileSync(patchedFile, "utf-8")
+	expect(source, "Run `pnpm install` (or `node scripts/patch-pi-ai-oauth.js`) first").toContain(
+		"KIMCHI_OAUTH_TEMPLATE_DIR",
+	)
+})
+
+let originalTemplateDir: string | undefined
+
+beforeEach(() => {
+	originalTemplateDir = process.env.KIMCHI_OAUTH_TEMPLATE_DIR
+	process.env.KIMCHI_OAUTH_TEMPLATE_DIR = templateDir
+})
+
+afterEach(() => {
+	if (originalTemplateDir === undefined) {
+		// biome-ignore lint/performance/noDelete: process.env requires delete operator to truly unset
+		delete process.env.KIMCHI_OAUTH_TEMPLATE_DIR
+	} else {
+		process.env.KIMCHI_OAUTH_TEMPLATE_DIR = originalTemplateDir
+	}
+})
+
+it("renders the Kimchi-branded success page with substitutions", async () => {
+	const { oauthSuccessHtml } = await import(/* @vite-ignore */ patchedFileUrl)
+
+	const html = oauthSuccessHtml("You can close this window.")
+
+	expect(html).toContain(KIMCHI_LOGO_ORANGE)
+	expect(html).toContain("You can close this window.")
+	expect(html).not.toMatch(/\{\{[A-Z_]+\}\}/)
+	expect(html).not.toContain('class="details"')
+})
+
+it("renders the Kimchi-branded error page with escaped details", async () => {
+	const { oauthErrorHtml } = await import(/* @vite-ignore */ patchedFileUrl)
+
+	const html = oauthErrorHtml("Token exchange failed.", "<script>alert(1)</script>")
+
+	expect(html).toContain(KIMCHI_LOGO_ORANGE)
+	expect(html).toContain("Token exchange failed.")
+	expect(html).toContain("&lt;script&gt;alert(1)&lt;/script&gt;")
+	expect(html).not.toContain("<script>alert(1)</script>")
+	expect(html).toContain('class="details"')
+	expect(html).not.toMatch(/\{\{[A-Z_]+\}\}/)
+})
+
+it("omits the details block when no details are provided", async () => {
+	const { oauthErrorHtml } = await import(/* @vite-ignore */ patchedFileUrl)
+
+	const html = oauthErrorHtml("Missing authorization code.")
+
+	expect(html).not.toContain('class="details"')
+})
+
+it("falls back to a minimal unbranded page when the template dir is unreadable", async () => {
+	process.env.KIMCHI_OAUTH_TEMPLATE_DIR = resolve(projectRoot, "this/path/does/not/exist")
+	const { oauthSuccessHtml } = await import(/* @vite-ignore */ patchedFileUrl)
+
+	const html = oauthSuccessHtml("You can close this window.")
+
+	expect(html).toContain("You can close this window.")
+	expect(html).toContain("Authentication successful")
+	// Fallback must not silently misbrand as Kimchi (orange marker) or Pi
+	// (the upstream LOGO_SVG path that the original fallback shipped).
+	expect(html).not.toContain(KIMCHI_LOGO_ORANGE)
+	expect(html).not.toContain("M165.29 165.29")
+})


### PR DESCRIPTION
## Description

Hardening for Kimchi-branded OAuth callback pages.

* scripts/patch-pi-ai-oauth.js: fail loud on postinstall write errors. Previously a write failure logged a warning and exited 0, letting `pnpm install` succeed silently - `build:binary` then packaged a release binary with the upstream Pi-branded page. Now exits 1 so install fails and CI catches it before the binary is built.

* scripts/patch-pi-ai-oauth.js: replace the Pi-branded inline fallback with a minimal unbranded one (system font, no logo). The original fallback rendered upstream's Pi logo whenever templates couldn't be read. Throwing was rejected too: the token is already saved by the time the renderer is called, so blank-paging the user after successful auth would be worse UX than a degraded but functional page.

* resources/oauth/{error,success}.html: drop `overflow: hidden` and the fixed `width: 360px` card in favour of `max-width: 360px` with body padding. On narrow viewports the card was clipped horizontally; on the error page, long `{{DETAILS}}` traces ran below the fold with no scroll fallback - users couldn't read why auth failed.

* resources/oauth/{error,success}.html: remove Fontshare `<link>` tags and 'Satoshi' from the font cascade. A localhost auth-completion page shouldn't make third-party requests; the system-ui fallback already in the cascade renders cleanly. Satoshi isn't used anywhere else in the repo, so removing it doesn't break visual consistency.

* src/oauth-page-patch.test.ts (new): tests covering patch-applied assertion (greps node_modules for the marker), Kimchi-branded rendering, escape-on-details, details omission when absent, and the minimal-unbranded fallback path. Would have caught the postinstall-skipped bug surfaced during manual testing, plus future regressions on substitution, escaping, or silent re-misbranding.


## Type of Change

<!-- Select all that apply. -->

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
