### PR TITLE
fix(ferment): wait for headless turns before returning

### DIFF
--- a/src/cli-args.ts
+++ b/src/cli-args.ts
@@ -38,3 +38,11 @@ export function getCliModeArg(args: string[]): string | undefined {
 export function isHelpOrVersionArgs(args: string[]): boolean {
 	return args.some((a) => a === "--help" || a === "-h" || a === "--version" || a === "-v")
 }
+
+// Modes where stdout belongs to the caller (protocol channel or user-facing
+// print output). Terminal OSC writes and compat warnings must be suppressed
+// because they corrupt that stream.
+export function isProtocolOrPrintMode(args: string[]): boolean {
+	const mode = getCliModeArg(args)
+	return mode === "json" || mode === "rpc" || mode === "acp" || args.includes("--print") || args.includes("-p")
+}

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -383,18 +383,21 @@ try {
 			: resolve(dirname(fileURLToPath(import.meta.url)), "../themes")
 		mkdirSync(themesDir, { recursive: true })
 
+		const startupArgs = process.argv.slice(2)
+		const printMode = startupArgs.includes("--print") || startupArgs.includes("-p")
+		const protocolOutputMode = cliMode === "json" || cliMode === "rpc" || cliMode === "acp"
 		// Probe runs here (before pi-mono takes stdin) so the result is cached for
-		// the kimchi-minimal-tints and terminal-colors extensions. Skip in ACP mode —
-		// stdout is the JSON-RPC channel and OSC escapes would corrupt the IDE's
-		// input stream.
-		if (!acpMode) {
+		// the kimchi-minimal-tints and terminal-colors extensions. Skip protocol
+		// and print modes: stdout belongs to the caller, and OSC escapes corrupt it.
+		const terminalStartupOutputAllowed = !protocolOutputMode && !printMode
+		if (terminalStartupOutputAllowed) {
 			await probeTerminalBackground()
 			await probeKittyKeyboardSupport()
 		}
 
 		// Emit warnings for terminals that don't support modifier-aware Enter.
 		// Runs after the keyboard-capability probe so the result is available.
-		emitTerminalCompatWarning(agentDir)
+		if (terminalStartupOutputAllowed) emitTerminalCompatWarning(agentDir)
 
 		// Compare contents and only write when they differ. Restarts in a second
 		// terminal must be byte-identical no-ops because pi runs `fs.watch` on the

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -6,7 +6,7 @@ import { basename, dirname, resolve } from "node:path"
 import { fileURLToPath } from "node:url"
 import type { ExtensionAPI, ExtensionContext } from "@earendil-works/pi-coding-agent"
 import { AgentSession } from "@earendil-works/pi-coding-agent"
-import { getCliModeArg, isHelpOrVersionArgs } from "./cli-args.js"
+import { getCliModeArg, isHelpOrVersionArgs, isProtocolOrPrintMode } from "./cli-args.js"
 import { dispatchSubcommand } from "./commands/dispatch.js"
 // IMPORTANT: must be first local import — patches InteractiveMode.prototype
 // before any module can construct an InteractiveMode instance.
@@ -383,13 +383,10 @@ try {
 			: resolve(dirname(fileURLToPath(import.meta.url)), "../themes")
 		mkdirSync(themesDir, { recursive: true })
 
-		const startupArgs = process.argv.slice(2)
-		const printMode = startupArgs.includes("--print") || startupArgs.includes("-p")
-		const protocolOutputMode = cliMode === "json" || cliMode === "rpc" || cliMode === "acp"
 		// Probe runs here (before pi-mono takes stdin) so the result is cached for
 		// the kimchi-minimal-tints and terminal-colors extensions. Skip protocol
 		// and print modes: stdout belongs to the caller, and OSC escapes corrupt it.
-		const terminalStartupOutputAllowed = !protocolOutputMode && !printMode
+		const terminalStartupOutputAllowed = !isProtocolOrPrintMode(process.argv.slice(2))
 		if (terminalStartupOutputAllowed) {
 			await probeTerminalBackground()
 			await probeKittyKeyboardSupport()

--- a/src/extensions/ferment/commands.test.ts
+++ b/src/extensions/ferment/commands.test.ts
@@ -101,6 +101,7 @@ function createHarness() {
 		hasUI: false,
 		ui: { notify: vi.fn() },
 		abort: vi.fn(),
+		waitForIdle: vi.fn().mockResolvedValue(undefined),
 	} as unknown as ExtensionCommandContext
 	return { storage, runtime, pi, ctx }
 }
@@ -169,6 +170,7 @@ describe("FermentCommandController", () => {
 			}),
 			{ triggerTurn: true },
 		)
+		expect(h.ctx.waitForIdle).toHaveBeenCalledTimes(1)
 	})
 
 	it("accepts an inline new title without opening an editor in UI mode", async () => {
@@ -562,6 +564,26 @@ describe("FermentCommandController", () => {
 		expect(ctx.ui.notify).toHaveBeenCalledWith('Usage: /ferment one-shot "description of what to build"')
 		expect(h.storage.list()).toHaveLength(0)
 		expect(h.pi.sendMessage).not.toHaveBeenCalled()
+	})
+
+	it("waits for headless one-shot turns before returning", async () => {
+		const h = createHarness()
+		const controller = new FermentCommandController()
+
+		const result = await controller.execute(
+			{ type: "one-shot", intent: "fix the failing smoke test" },
+			{ raw: 'one-shot "fix the failing smoke test"', pi: h.pi, ctx: h.ctx, runtime: h.runtime },
+		)
+
+		expect(result).toEqual({ handled: true })
+		expect(h.pi.sendMessage).toHaveBeenCalledWith(
+			expect.objectContaining({
+				customType: "ferment_oneshot_nudge",
+				content: [expect.objectContaining({ text: expect.stringContaining("fix the failing smoke test") })],
+			}),
+			{ triggerTurn: true },
+		)
+		expect(h.ctx.waitForIdle).toHaveBeenCalledTimes(1)
 	})
 
 	it("uses the multi-line editor for free-form goal revisions", async () => {

--- a/src/extensions/ferment/commands.ts
+++ b/src/extensions/ferment/commands.ts
@@ -164,6 +164,11 @@ export interface StartInteractiveFermentDeps {
 	runtime?: FermentRuntime
 }
 
+async function waitForHeadlessCommandTurn(ctx: FermentUiContext & ExtensionCommandContext): Promise<void> {
+	if (ctx.hasUI) return
+	await ctx.waitForIdle()
+}
+
 export async function startInteractiveFerment({
 	pi,
 	ctx,
@@ -851,6 +856,7 @@ export class FermentCommandController {
 					},
 					{ triggerTurn: true },
 				)
+				await waitForHeadlessCommandTurn(ctx)
 			} catch (err) {
 				ctx.ui.notify(err instanceof FermentError ? err.message : "One-shot create failed.")
 			} finally {
@@ -903,6 +909,7 @@ export class FermentCommandController {
 			)
 
 			await runScopingFlow(f, pi, ctx, runtime, scopingIntent)
+			await waitForHeadlessCommandTurn(ctx)
 		} catch (err) {
 			ctx.ui.notify(err instanceof FermentError ? err.message : "Create failed.")
 		} finally {

--- a/src/extensions/terminal-colors.ts
+++ b/src/extensions/terminal-colors.ts
@@ -1,6 +1,7 @@
 import { readFileSync } from "node:fs"
 import { basename, resolve } from "node:path"
 import type { ExtensionAPI, ExtensionContext } from "@earendil-works/pi-coding-agent"
+import { getCliModeArg } from "../cli-args.js"
 import { getActiveThemeName, onThemeChange } from "../settings-watcher.js"
 import { QUERY_BG, getRawBgPayload } from "../terminal-bg-probe.js"
 
@@ -30,6 +31,15 @@ function hexToItermFormat(hex: string): string | null {
 	const match = hex.match(/^#?([0-9a-fA-F]{6})$/i)
 	if (!match) return null
 	return match[1].toUpperCase()
+}
+
+function isProtocolOrPrintMode(args: string[]): boolean {
+	const mode = getCliModeArg(args)
+	return mode === "json" || mode === "rpc" || mode === "acp" || args.includes("--print") || args.includes("-p")
+}
+
+function canUseTerminalOsc(args: string[]): boolean {
+	return process.stdin.isTTY === true && process.stdout.isTTY === true && !isProtocolOrPrintMode(args)
 }
 
 // OSC 10/11 enforce theme-specified fg/bg over the terminal's own colors.
@@ -72,6 +82,7 @@ function getThemeColors(themeName: string): { fgHex: string; bgHex: string } | n
 }
 
 export default function terminalColorsExtension(pi: ExtensionAPI) {
+	const startupArgs = process.argv.slice(2)
 	let savedFg: string | null = null
 	let savedBg: string | null = null
 	let active = false
@@ -81,9 +92,10 @@ export default function terminalColorsExtension(pi: ExtensionAPI) {
 	// Shared by the onThemeChange callback and the sensor widget so neither
 	// re-runs the OSC writes for a theme the other just handled.
 	let lastSensorTheme: string | undefined
+	const canUseOsc = () => canUseTerminalOsc(startupArgs)
 
 	const restore = () => {
-		if (!process.stdout.isTTY) return
+		if (!canUseOsc()) return
 
 		if (isIterm2()) {
 			// iTerm2: reset via named preset first, then fall back to saved OSC values
@@ -99,7 +111,7 @@ export default function terminalColorsExtension(pi: ExtensionAPI) {
 	}
 
 	const apply = (fgHex: string, bgHex: string) => {
-		if (!process.stdout.isTTY) return
+		if (!canUseOsc()) return
 
 		// OSC sequences change what "default background" means in the terminal emulator,
 		// affecting future blank cells from scroll/resize. Pi-mono's own repaint covers
@@ -205,7 +217,7 @@ export default function terminalColorsExtension(pi: ExtensionAPI) {
 	}
 
 	pi.on("session_start", (_event, ctx) => {
-		if (!process.stdin.isTTY) return
+		if (!canUseOsc()) return
 		lastCtx = ctx
 		installExitHandlers()
 

--- a/src/extensions/terminal-colors.ts
+++ b/src/extensions/terminal-colors.ts
@@ -1,7 +1,7 @@
 import { readFileSync } from "node:fs"
 import { basename, resolve } from "node:path"
 import type { ExtensionAPI, ExtensionContext } from "@earendil-works/pi-coding-agent"
-import { getCliModeArg } from "../cli-args.js"
+import { isProtocolOrPrintMode } from "../cli-args.js"
 import { getActiveThemeName, onThemeChange } from "../settings-watcher.js"
 import { QUERY_BG, getRawBgPayload } from "../terminal-bg-probe.js"
 
@@ -31,11 +31,6 @@ function hexToItermFormat(hex: string): string | null {
 	const match = hex.match(/^#?([0-9a-fA-F]{6})$/i)
 	if (!match) return null
 	return match[1].toUpperCase()
-}
-
-function isProtocolOrPrintMode(args: string[]): boolean {
-	const mode = getCliModeArg(args)
-	return mode === "json" || mode === "rpc" || mode === "acp" || args.includes("--print") || args.includes("-p")
 }
 
 function canUseTerminalOsc(args: string[]): boolean {


### PR DESCRIPTION
## Description

Wait for Ferment-triggered agent turns in headless command flows so print/json sessions do not dispose while a hidden turn is still emitting events.

Also skip terminal OSC probes and terminal compatibility warnings in protocol and print modes to keep stdout clean.


## Type of Change

<!-- Select all that apply. -->

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
