### PR TITLE
hotfix: Fix deformed logo when branch name or dir is too long

### DIFF
--- a/src/components/logo-art.test.ts
+++ b/src/components/logo-art.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from "vitest"
+import { truncatePath } from "./logo-art.js"
+
+describe("truncatePath", () => {
+	it("returns short paths unchanged", () => {
+		expect(truncatePath("~/project", 20)).toBe("~/project")
+		expect(truncatePath("/home/user/foo", 20)).toBe("/home/user/foo")
+	})
+
+	it("truncates from the right when there is no slash", () => {
+		expect(truncatePath("someverylongname", 10)).toBe("somever...")
+		expect(truncatePath("someverylongname", 5)).toBe("so...")
+	})
+
+	it("preserves the basename with ellipsis in the directory part", () => {
+		expect(truncatePath("/home/user/cast/kimchi", 14)).toBe("/hom.../kimchi")
+	})
+
+	it("preserves the tilde prefix and basename", () => {
+		expect(truncatePath("~/very/long/path/kimchi", 16)).toBe("~/very.../kimchi")
+	})
+
+	it("preserves an absolute root path prefix", () => {
+		expect(truncatePath("/very/long/path/to/kimchi", 16)).toBe("/very/.../kimchi")
+	})
+
+	it("falls back to right truncation when even the minimal prefix does not fit", () => {
+		expect(truncatePath("/home/user/cast/kimchi", 5)).toBe("/h...")
+	})
+})

--- a/src/components/logo-art.ts
+++ b/src/components/logo-art.ts
@@ -4,6 +4,35 @@ import { getFolder, getGitBranch, getVersion } from "../utils.js"
 
 let cachedVersion: string | undefined
 
+/** Truncate a file-system path to fit `maxWidth` while preserving the basename. */
+export function truncatePath(path: string, maxWidth: number): string {
+	if (path.length <= maxWidth) return path
+
+	const lastSlash = path.lastIndexOf("/")
+	if (lastSlash <= 0 || lastSlash >= path.length - 1) {
+		return `${path.slice(0, Math.max(0, maxWidth - 3))}...`
+	}
+
+	const dir = path.slice(0, lastSlash)
+	const basename = path.slice(lastSlash + 1)
+	const ellipsis = "..."
+	const sep = "/"
+	const minPrefixLen = 1
+
+	// Try: dirPrefix + ".../" + basename
+	for (
+		let prefixLen = Math.min(dir.length, maxWidth - ellipsis.length - sep.length - basename.length);
+		prefixLen >= minPrefixLen;
+		prefixLen--
+	) {
+		const candidate = dir.slice(0, prefixLen) + ellipsis + sep + basename
+		if (candidate.length <= maxWidth) return candidate
+	}
+
+	// Fall back to simple right truncation
+	return `${path.slice(0, Math.max(0, maxWidth - 3))}...`
+}
+
 export function buildLogoLines(theme: Theme): string[] {
 	const L = theme.getFgAnsi("accent")
 	const G = theme.getFgAnsi("bashMode")
@@ -15,13 +44,19 @@ export function buildLogoLines(theme: Theme): string[] {
 	]
 }
 
-export function buildInfoLine(theme: Theme): string {
+export function buildInfoLines(theme: Theme, { folderMaxWidth }: { folderMaxWidth?: number } = {}): string[] {
 	if (!cachedVersion) cachedVersion = getVersion()
 	const dim = theme.getFgAnsi("dim")
 	const branchColor = theme.getFgAnsi("mdLink")
-	const folder = getFolder()
+	let folder = getFolder()
+	if (folderMaxWidth !== undefined && folder.length > folderMaxWidth) {
+		folder = truncatePath(folder, folderMaxWidth)
+	}
 	const branch = getGitBranch()
 	const vdot = ` ${dim}·${RST_FG} `
-	const branchPart = branch ? `${vdot}${branchColor}${branch}${RST_FG}` : ""
-	return `${dim}v${cachedVersion}${RST_FG}${vdot}${dim}${folder}${RST_FG}${branchPart}`
+	const lines: string[] = [`${dim}v${cachedVersion}${RST_FG}${vdot}${dim}${folder}${RST_FG}`]
+	if (branch) {
+		lines.push(`${branchColor}${branch}${RST_FG}`)
+	}
+	return lines
 }

--- a/src/components/logo.test.ts
+++ b/src/components/logo.test.ts
@@ -68,16 +68,15 @@ describe("LogoHeader", () => {
 		const logoRows = lines.slice(1, -1).filter((l) => stripAnsi(l).includes("█"))
 		expect(logoRows.length).toBeGreaterThanOrEqual(3)
 
-		// Contains a single combined info line with version, folder, and branch
-		const infoRow = lines
+		// Version and folder appear on one info line, branch on a separate line
+		const infoLineWithVersion = lines
 			.slice(1, -1)
-			.find(
-				(l) =>
-					stripAnsi(l).includes("v1.0.0-test") && stripAnsi(l).includes("/project") && stripAnsi(l).includes("main"),
-			)
-		expect(infoRow).toBeDefined()
+			.find((l) => stripAnsi(l).includes("v1.0.0-test") && stripAnsi(l).includes("/project"))
+		expect(infoLineWithVersion).toBeDefined()
+		const infoLineWithBranch = lines.slice(1, -1).find((l) => stripAnsi(l).includes("main"))
+		expect(infoLineWithBranch).toBeDefined()
 
-		// Box should be taller due to generous vertical padding
+		// Box should be taller due to generous vertical padding and two info lines
 		expect(lines.length).toBeGreaterThan(11)
 
 		// Contains right column content
@@ -165,7 +164,7 @@ describe("LogoHeader", () => {
 		expect(rightSection).toContain("\x1b[36m/ferment exit\x1b[0m")
 	})
 
-	it("centers the logo and info line vertically as a unit", () => {
+	it("centers the logo and info lines vertically as a unit", () => {
 		const theme = createMockTheme()
 		const header = new LogoHeader(theme)
 		const lines = header.render(120)
@@ -181,34 +180,32 @@ describe("LogoHeader", () => {
 		}
 		expect(logoIndices.length).toBeGreaterThanOrEqual(3)
 
-		// Find combined info row
-		const infoIndex = lines.findIndex(
-			(l) => stripAnsi(l).includes("v1.0.0-test") && stripAnsi(l).includes("/project") && stripAnsi(l).includes("main"),
-		)
-		expect(infoIndex).toBeGreaterThan(0)
+		// Find info rows (version/folder line and branch line)
+		const infoIndex1 = lines.findIndex((l) => stripAnsi(l).includes("v1.0.0-test") && stripAnsi(l).includes("/project"))
+		const infoIndex2 = lines.findIndex((l) => stripAnsi(l).includes("main"))
+		expect(infoIndex1).toBeGreaterThan(0)
+		expect(infoIndex2).toBeGreaterThan(0)
 
 		const logoTop = logoIndices[0] - 1
-		const infoRow = infoIndex - 1
+		const lastInfoRow = infoIndex2 - 1
 
-		// There should be a gap between logo bottom and info row
+		// There should be a gap between logo bottom and first info row
 		const logoBottom = logoIndices[logoIndices.length - 1] - 1
-		expect(infoRow).toBeGreaterThan(logoBottom)
+		expect(infoIndex1 - 1).toBeGreaterThan(logoBottom)
 
-		// The unit (logo through info row) should be vertically centered
-		const unitCenter = (logoTop + infoRow) / 2
+		// The unit (logo through last info row) should be vertically centered
+		const unitCenter = (logoTop + lastInfoRow) / 2
 		const contentCenter = (contentHeight - 1) / 2
 		expect(Math.abs(unitCenter - contentCenter)).toBeLessThanOrEqual(1)
 	})
 
-	it("centers the logo and info line horizontally within the left column", () => {
+	it("centers the logo and info lines horizontally within the left column", () => {
 		const theme = createMockTheme()
 		const header = new LogoHeader(theme)
 		const lines = header.render(120)
 
-		// Find the info row
-		const infoIndex = lines.findIndex(
-			(l) => stripAnsi(l).includes("v1.0.0-test") && stripAnsi(l).includes("/project") && stripAnsi(l).includes("main"),
-		)
+		// Find the version/folder info row
+		const infoIndex = lines.findIndex((l) => stripAnsi(l).includes("v1.0.0-test") && stripAnsi(l).includes("/project"))
 		expect(infoIndex).toBeGreaterThan(0)
 
 		// Strip ANSI and split by the vertical divider character
@@ -225,7 +222,7 @@ describe("LogoHeader", () => {
 
 		// The info text should also not end at the very last position
 		// (it should have trailing padding for centering)
-		const infoEnd = leftCol.lastIndexOf("main") + "main".length
+		const infoEnd = leftCol.lastIndexOf("/project") + "/project".length
 		expect(infoEnd).toBeLessThan(leftCol.length - 1)
 
 		// A logo row should have the same total left column width as the info row
@@ -233,5 +230,80 @@ describe("LogoHeader", () => {
 		const strippedLogo = stripAnsi(lines[logoRow])
 		const logoParts = strippedLogo.split("│")
 		expect(logoParts[1].length).toBe(leftCol.length)
+	})
+
+	it("does not exceed width with a very long branch name", () => {
+		getGitBranchMock.mockReturnValue("fix-logo-aaaaaaaaaa-adasda-very-long-branch-name-goes-on-and-on")
+		const theme = createMockTheme()
+		const header = new LogoHeader(theme)
+		const lines = header.render(120)
+
+		for (const line of lines) {
+			expect(visibleWidth(line)).toBeLessThanOrEqual(120)
+		}
+	})
+
+	it("keeps left column width stable regardless of info line length", () => {
+		const themeShort = createMockTheme()
+		const headerShort = new LogoHeader(themeShort)
+		const linesShort = headerShort.render(120)
+
+		getGitBranchMock.mockReturnValue("fix-logo-aaaaaaaaaa-adasda-very-long-branch-name-goes-on-and-on")
+		const themeLong = createMockTheme()
+		const headerLong = new LogoHeader(themeLong)
+		const linesLong = headerLong.render(120)
+
+		// Extract left column width from a logo row in both renders
+		const getLeftColWidth = (lines: string[]): number => {
+			const logoRow = lines.find((l) => stripAnsi(l).includes("█"))
+			expect(logoRow).toBeDefined()
+			if (!logoRow) return 0
+			const parts = stripAnsi(logoRow).split("│")
+			return parts[1]?.length ?? 0
+		}
+
+		expect(getLeftColWidth(linesShort)).toBe(getLeftColWidth(linesLong))
+	})
+
+	it("truncates the branch line with ellipsis when branch name is too long", () => {
+		getGitBranchMock.mockReturnValue("fix-logo-aaaaaaaaaa-adasda-very-long-branch-name-goes-on-and-on")
+		const theme = createMockTheme()
+		const header = new LogoHeader(theme)
+		const lines = header.render(120)
+
+		// Find the branch line
+		const branchLine = lines.slice(1, -1).find((l) => stripAnsi(l).includes("fix-logo"))
+		expect(branchLine).toBeDefined()
+		if (branchLine) {
+			expect(stripAnsi(branchLine)).toContain("...")
+		}
+	})
+
+	it("truncates the version/folder line with ellipsis when folder path is too long", () => {
+		getFolderMock.mockReturnValue("/very/long/path/to/the/project/directory/that/keeps/going")
+		const theme = createMockTheme()
+		const header = new LogoHeader(theme)
+		const lines = header.render(120)
+
+		// Find the version/folder line
+		const folderLine = lines
+			.slice(1, -1)
+			.find((l) => stripAnsi(l).includes("v1.0.0-test") && stripAnsi(l).includes("/very"))
+		expect(folderLine).toBeDefined()
+		if (folderLine) {
+			expect(stripAnsi(folderLine)).toContain("...")
+		}
+	})
+
+	it("shows branch on its own line below version and folder", () => {
+		const theme = createMockTheme()
+		const header = new LogoHeader(theme)
+		const lines = header.render(120)
+
+		const versionIdx = lines.findIndex((l) => stripAnsi(l).includes("v1.0.0-test") && stripAnsi(l).includes("/project"))
+		const branchIdx = lines.findIndex((l) => stripAnsi(l).includes("main"))
+		expect(versionIdx).toBeGreaterThan(0)
+		expect(branchIdx).toBeGreaterThan(0)
+		expect(branchIdx).toBeGreaterThan(versionIdx)
 	})
 })

--- a/src/components/logo.ts
+++ b/src/components/logo.ts
@@ -1,8 +1,9 @@
 import type { Theme } from "@earendil-works/pi-coding-agent"
 import type { Component } from "@earendil-works/pi-tui"
-import { visibleWidth, wrapTextWithAnsi } from "@earendil-works/pi-tui"
+import { truncateToWidth, visibleWidth, wrapTextWithAnsi } from "@earendil-works/pi-tui"
 import { RST_FG } from "../ansi.js"
-import { buildInfoLine, buildLogoLines } from "./logo-art.js"
+import { getVersion } from "../utils.js"
+import { buildInfoLines, buildLogoLines } from "./logo-art.js"
 
 export class LogoHeader implements Component {
 	private readonly theme: Theme
@@ -20,16 +21,30 @@ export class LogoHeader implements Component {
 	render(width: number): string[] {
 		const { theme } = this
 		const accentOpen = theme.getFgAnsi("accent")
-		const infoLine = buildInfoLine(theme)
-		const infoWidth = visibleWidth(infoLine)
 
 		// Logo dimensions
 		const logoWidth = Math.max(...this.logoLines.map((l) => visibleWidth(l)))
 		const logoHeight = this.logoLines.length
 		const midGap = 2
 
-		// Left column content width (widest of logo or info line)
-		const leftContentWidth = Math.max(logoWidth, infoWidth)
+		// Compute how much room the version prefix takes so we can tell
+		// buildInfoLines how much space remains for the folder before the
+		// whole line would exceed the fixed logo width.
+		const versionStr = getVersion()
+		const versionPrefixWidth = 1 + versionStr.length + 3 // "v" + version + " · "
+		const folderMaxWidth = Math.max(4, logoWidth - versionPrefixWidth)
+
+		const infoLines = buildInfoLines(theme, { folderMaxWidth })
+
+		// Left column content width is fixed to logo width so the logo never
+		// shifts or deforms when the info line (branch name, folder) is long.
+		const leftContentWidth = logoWidth
+
+		// Truncate each info line so it never exceeds the fixed left column width.
+		const infoLinesFitted = infoLines.map((line) => {
+			const w = visibleWidth(line)
+			return w > leftContentWidth ? truncateToWidth(line, leftContentWidth) : line
+		})
 
 		// Compute right column width with progressive padding reduction for narrow terminals
 		let leftPad = 10
@@ -65,14 +80,15 @@ export class LogoHeader implements Component {
 
 		const rightLines: string[] = [...labelWrap, ...wrap1, hrLine, ...wrap2]
 
-		// Left column: generous vertical padding plus centered logo + info line
-		const unitHeight = logoHeight + midGap + 1
+		// Left column: generous vertical padding plus centered logo + info lines
+		const infoLineCount = infoLinesFitted.length
+		const unitHeight = logoHeight + midGap + infoLineCount
 		const minVerticalPad = 2
 		const leftContentHeight = unitHeight + 2 * minVerticalPad
 		const totalHeight = Math.max(rightLines.length, leftContentHeight)
 
 		const logoTop = Math.floor((totalHeight - unitHeight) / 2)
-		const infoRow = logoTop + logoHeight + midGap
+		const infoRowStart = logoTop + logoHeight + midGap
 
 		const accentBorder = (char: string) => accentOpen + char + RST_FG
 		const result: string[] = []
@@ -86,8 +102,8 @@ export class LogoHeader implements Component {
 			if (row >= logoTop && row < logoTop + logoHeight) {
 				leftContent = this.logoLines[row - logoTop]
 			}
-			if (row === infoRow) {
-				leftContent = infoLine
+			if (row >= infoRowStart && row < infoRowStart + infoLineCount) {
+				leftContent = infoLinesFitted[row - infoRowStart]
 			}
 
 			// Horizontally center content within leftContentWidth


### PR DESCRIPTION
## Description

Handle long paths and branch names better.

<img width="547" height="250" alt="Screenshot 2026-05-28 at 18 04 52" src="https://github.com/user-attachments/assets/8475d470-88ac-4b19-b0c9-0c11cc64c923" />


## Type of Change

<!-- Select all that apply. -->

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
