### PR TITLE
fix(first-time-experience): require authentication before startup onboarding

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
 		"build:binary-linux-arm64": "node scripts/build-binary.js --target linux-arm64",
 		"build:binary-linux-x64": "node scripts/build-binary.js --target linux-x64",
 		"dev": "make -C tools/proxy-helper/ copy-for-dev && bun run --preload ./src/set-package-dir.ts src/entry.ts",
+		"dev:overlay": "scripts/dev-overlay.sh",
 		"dev:setup": "bun run --preload ./src/set-package-dir.ts src/entry.ts setup",
 		"lint": "biome check src/ scripts/",
 		"lint:fix": "biome check --write src/ scripts/",

--- a/scripts/dev-overlay.sh
+++ b/scripts/dev-overlay.sh
@@ -1,0 +1,52 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(dirname "$SCRIPT_DIR")"
+
+SANDBOX_HOME="${KIMCHI_OVERLAY_HOME:-$(mktemp -d "${TMPDIR:-/tmp}/kimchi-overlay.XXXXXX")}"
+SANDBOX_WORKDIR="$SANDBOX_HOME/workdir"
+CONFIG_DIR="$SANDBOX_HOME/.config/kimchi"
+
+cleanup() {
+	if [[ -z "${KIMCHI_OVERLAY_HOME:-}" && "${KEEP_KIMCHI_OVERLAY_HOME:-0}" != "1" ]]; then
+		rm -rf "$SANDBOX_HOME"
+	fi
+}
+trap cleanup EXIT
+
+mkdir -p "$CONFIG_DIR" "$SANDBOX_WORKDIR"
+cat > "$CONFIG_DIR/config.json" <<'JSON'
+{
+  "skillPaths": [],
+  "migrationState": "done",
+  "onboarding": {
+    "hideSessionModeDialog": true
+  },
+  "telemetry": {
+    "enabled": false
+  }
+}
+JSON
+
+echo "Starting Kimchi overlay check with isolated HOME:"
+echo "  $SANDBOX_HOME"
+echo
+echo "Expected manual check:"
+echo "  1. The existing Shift+Enter / Ctrl+J terminal overlay appears."
+echo "  2. Press any key to dismiss it."
+echo "  3. Kimchi continues startup normally."
+echo
+echo "Set KEEP_KIMCHI_OVERLAY_HOME=1 to preserve this HOME after exit."
+echo
+
+make -C "$PROJECT_ROOT/tools/proxy-helper" copy-for-dev
+
+cd "$SANDBOX_WORKDIR"
+env \
+	HOME="$SANDBOX_HOME" \
+	TMUX="/tmp/kimchi-overlay-test,1,0" \
+	TERMINAL_EMULATOR="" \
+	KIMCHI_TELEMETRY_ENABLED=0 \
+	PI_SKIP_VERSION_CHECK=1 \
+	bun run --preload "$PROJECT_ROOT/src/set-package-dir.ts" "$PROJECT_ROOT/src/entry.ts" "$@"

--- a/src/cli-auth/callback-server.test.ts
+++ b/src/cli-auth/callback-server.test.ts
@@ -1,5 +1,9 @@
+import { dirname, resolve } from "node:path"
+import { fileURLToPath } from "node:url"
 import { describe, expect, it, vi } from "vitest"
 import { generateState, startCallbackServer } from "./callback-server.js"
+
+const repoRoot = resolve(dirname(fileURLToPath(import.meta.url)), "../..")
 
 describe("generateState", () => {
 	it("produces a 64-character hex string", () => {
@@ -37,12 +41,38 @@ describe("startCallbackServer", () => {
 		const res = await request(server.port, `/callback?token=my-secret-token&state=${state}`)
 		expect(res.status).toBe(200)
 		const body = await res.text()
-		expect(body).toContain("Authentication Successful")
+		expect(body).toContain("Authentication successful")
 
 		const result = await server.result
 		expect(result.token).toBe("my-secret-token")
 		expect(result.error).toBeUndefined()
 		server.close()
+	})
+
+	it("serves the branded success template when KIMCHI_OAUTH_TEMPLATE_DIR is set", async () => {
+		const previous = process.env.KIMCHI_OAUTH_TEMPLATE_DIR
+		process.env.KIMCHI_OAUTH_TEMPLATE_DIR = resolve(repoRoot, "resources", "oauth")
+		try {
+			const state = generateState()
+			const server = await startCallbackServer(state)
+			const res = await request(server.port, `/callback?token=t&state=${state}`)
+			const body = await res.text()
+			// `bg-svg` / `class="dark"` exist only in resources/oauth/success.html, never
+			// in the minimal unbranded fallback, so this proves the Kimchi-account
+			// callback now shares the same branded pages as pi's subscription logins,
+			// with {{MESSAGE}} substituted.
+			expect(body).toContain("bg-svg")
+			expect(body).toContain("Your CLI is now connected")
+			await server.result
+			server.close()
+		} finally {
+			if (previous === undefined) {
+				// biome-ignore lint/performance/noDelete: must truly unset, not stringify to "undefined"
+				delete process.env.KIMCHI_OAUTH_TEMPLATE_DIR
+			} else {
+				process.env.KIMCHI_OAUTH_TEMPLATE_DIR = previous
+			}
+		}
 	})
 
 	it("rejects an invalid state parameter", async () => {

--- a/src/cli-auth/callback-server.ts
+++ b/src/cli-auth/callback-server.ts
@@ -1,8 +1,10 @@
 import { randomBytes } from "node:crypto"
 import { type IncomingMessage, type Server, type ServerResponse, createServer } from "node:http"
+import { oauthErrorHtml, oauthSuccessHtml } from "./oauth-page.js"
 
 const CALLBACK_PATH = "/callback"
 const CALLBACK_TIMEOUT_MS = 300_000 // 5 minutes
+const SUCCESS_MESSAGE = "Your CLI is now connected. You can close this window and start using Kimchi."
 
 export interface CallbackResult {
 	token?: string
@@ -14,135 +16,6 @@ export interface CallbackServer {
 	url: string
 	result: Promise<CallbackResult>
 	close: () => void
-}
-
-const HTML_SUCCESS = `<!DOCTYPE html>
-<html>
-<head>
-  <meta charset="utf-8">
-  <title>Authentication Successful</title>
-  <style>
-    body {
-      font-family: system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
-      display: flex;
-      justify-content: center;
-      align-items: center;
-      height: 100vh;
-      margin: 0;
-      background: #0f172a;
-      color: #e2e8f0;
-    }
-    .container {
-      text-align: center;
-      padding: 2rem;
-      max-width: 420px;
-    }
-    .icon {
-      width: 64px;
-      height: 64px;
-      margin: 0 auto 1.5rem;
-      background: #10b981;
-      border-radius: 50%;
-      display: flex;
-      align-items: center;
-      justify-content: center;
-      font-size: 32px;
-    }
-    h1 {
-      font-size: 1.5rem;
-      font-weight: 600;
-      margin-bottom: 0.5rem;
-      color: #fff;
-    }
-    p {
-      color: #94a3b8;
-      line-height: 1.6;
-      margin: 0;
-    }
-  </style>
-</head>
-<body>
-  <div class="container">
-    <div class="icon">&#10003;</div>
-    <h1>Authentication Successful</h1>
-    <p>Your CLI is now connected. You can close this window and start using Kimchi.</p>
-  </div>
-</body>
-</html>`
-
-function escapeHtml(unsafe: string): string {
-	return unsafe
-		.replace(/&/g, "&amp;")
-		.replace(/</g, "&lt;")
-		.replace(/>/g, "&gt;")
-		.replace(/"/g, "&quot;")
-		.replace(/'/g, "&#039;")
-}
-
-function htmlError(message: string, details?: string): string {
-	const detailBlock = details
-		? `<div style="margin-top: 1rem; padding: 1rem; background: rgba(248,113,113,0.1); border-radius: 0.5rem; font-family: monospace; font-size: 0.875rem; color: #fca5a5; word-break: break-word;">${escapeHtml(details)}</div>`
-		: ""
-	return `<!DOCTYPE html>
-<html>
-<head>
-  <meta charset="utf-8">
-  <meta http-equiv="refresh" content="5;url=about:blank" />
-  <title>Authentication Failed</title>
-  <style>
-    body {
-      font-family: system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
-      display: flex;
-      justify-content: center;
-      align-items: center;
-      height: 100vh;
-      margin: 0;
-      background: #0f172a;
-      color: #e2e8f0;
-    }
-    .container {
-      text-align: center;
-      padding: 2rem;
-      max-width: 420px;
-    }
-    .icon {
-      width: 64px;
-      height: 64px;
-      margin: 0 auto 1.5rem;
-      background: #ef4444;
-      border-radius: 50%;
-      display: flex;
-      align-items: center;
-      justify-content: center;
-      font-size: 32px;
-    }
-    h1 {
-      font-size: 1.5rem;
-      font-weight: 600;
-      margin-bottom: 0.5rem;
-      color: #fff;
-    }
-    p {
-      color: #94a3b8;
-      line-height: 1.6;
-      margin: 0 0 1.5rem;
-    }
-    .timer {
-      color: #64748b;
-      font-size: 0.875rem;
-    }
-  </style>
-</head>
-<body>
-  <div class="container">
-    <div class="icon">&#10007;</div>
-    <h1>Authentication Failed</h1>
-    <p>${escapeHtml(message)}</p>
-    ${detailBlock}
-  </div>
-  <script>setTimeout(() => window.close(), 5000);</script>
-</body>
-</html>`
 }
 
 /**
@@ -192,7 +65,7 @@ export function startCallbackServer(expectedState: string): Promise<CallbackServ
 				// Only accept connections from the loopback interface
 				if (!(remote.startsWith("127.") || remote === "::1" || remote === "::ffff:127.0.0.1")) {
 					res.writeHead(403, { "Content-Type": "text/html", Connection: "close" })
-					res.end(htmlError("Forbidden", "Only localhost connections are allowed."))
+					res.end(oauthErrorHtml("Forbidden", "Only localhost connections are allowed."))
 					return
 				}
 
@@ -208,7 +81,7 @@ export function startCallbackServer(expectedState: string): Promise<CallbackServ
 				if (!state || state !== expectedState) {
 					const errorMsg = "This request isn't valid. Please try logging in again from your terminal."
 					res.writeHead(400, { "Content-Type": "text/html", Connection: "close" })
-					res.end(htmlError("Login error", errorMsg))
+					res.end(oauthErrorHtml("Login error", errorMsg))
 					finish({ error: errorMsg })
 					return
 				}
@@ -219,7 +92,7 @@ export function startCallbackServer(expectedState: string): Promise<CallbackServ
 				if (error) {
 					const errorMsg = errorDescription || error
 					res.writeHead(200, { "Content-Type": "text/html", Connection: "close" })
-					res.end(htmlError("Authentication failed", errorMsg))
+					res.end(oauthErrorHtml("Authentication failed", errorMsg))
 					finish({ error: errorMsg })
 					return
 				}
@@ -229,14 +102,14 @@ export function startCallbackServer(expectedState: string): Promise<CallbackServ
 				if (!token) {
 					const errorMsg = "No token was returned by the authentication server"
 					res.writeHead(400, { "Content-Type": "text/html", Connection: "close" })
-					res.end(htmlError("Missing token", errorMsg))
+					res.end(oauthErrorHtml("Missing token", errorMsg))
 					finish({ error: errorMsg })
 					return
 				}
 
 				// Success
 				res.writeHead(200, { "Content-Type": "text/html", Connection: "close" })
-				res.end(HTML_SUCCESS)
+				res.end(oauthSuccessHtml(SUCCESS_MESSAGE))
 				finish({ token })
 			} catch (err) {
 				const message = err instanceof Error ? err.message : String(err)

--- a/src/cli-auth/index.test.ts
+++ b/src/cli-auth/index.test.ts
@@ -39,6 +39,40 @@ describe("authenticateViaBrowser", () => {
 		expect(result.token).toBe("castai_v1_test_token_123")
 	})
 
+	it("aborts the callback wait when the signal fires (e.g. login dialog cancelled)", async () => {
+		openMock.mockResolvedValue(undefined)
+		const controller = new AbortController()
+
+		const promise = authenticateViaBrowser({ webAppUrl: "https://app.kimchi.dev", signal: controller.signal })
+		let rejection: Error | undefined
+		promise.catch((err) => {
+			rejection = err instanceof Error ? err : new Error(String(err))
+		})
+		await vi.waitFor(() => {
+			expect(openMock).toHaveBeenCalledTimes(1)
+		})
+
+		// Abort instead of completing the browser callback; the server must tear down
+		// and the wait must reject rather than hang until the 5-minute timeout.
+		controller.abort()
+
+		await vi.waitFor(() => {
+			expect(rejection).toBeInstanceOf(Error)
+		})
+		expect((rejection as Error).message).toMatch(/cancelled/i)
+	})
+
+	it("does not open the browser when the signal is already aborted", async () => {
+		openMock.mockResolvedValue(undefined)
+		const controller = new AbortController()
+		controller.abort()
+
+		await expect(
+			authenticateViaBrowser({ webAppUrl: "https://app.kimchi.dev", signal: controller.signal }),
+		).rejects.toThrow(/cancelled/i)
+		expect(openMock).not.toHaveBeenCalled()
+	})
+
 	it("throws when the browser callback returns an error", async () => {
 		openMock.mockResolvedValue(undefined)
 

--- a/src/cli-auth/index.ts
+++ b/src/cli-auth/index.ts
@@ -22,6 +22,8 @@ export interface BrowserAuthOptions {
 	onMessage?: (message: string) => void
 	/** Optional callback invoked with the browser URL before the browser opens */
 	onBrowserUrl?: (url: string) => void
+	/** Abort the flow (e.g. user pressed Esc): tears down the callback server early. */
+	signal?: AbortSignal
 }
 
 /**
@@ -43,7 +45,18 @@ export async function authenticateViaBrowser(options: BrowserAuthOptions = {}): 
 
 	const callbackServer = await startCallbackServer(state)
 
+	// Let callers cancel the wait (e.g. the login dialog's Esc) instead of leaving
+	// the callback server running until its 5-minute timeout. close() resolves the
+	// pending result with a "Login cancelled" error, which surfaces as a throw below.
+	const onAbort = () => callbackServer.close()
+
 	try {
+		if (options.signal?.aborted) {
+			callbackServer.close()
+			throw new Error("Browser login failed: Login cancelled")
+		}
+		options.signal?.addEventListener("abort", onAbort, { once: true })
+
 		const callbackUrl = encodeURIComponent(callbackServer.url)
 		const browserUrl = `${webAppUrl}/cli-auth?callback=${callbackUrl}&state=${encodeURIComponent(state)}`
 
@@ -78,5 +91,7 @@ export async function authenticateViaBrowser(options: BrowserAuthOptions = {}): 
 		// Ensure the callback server is torn down on any error path
 		callbackServer.close()
 		throw err
+	} finally {
+		options.signal?.removeEventListener("abort", onAbort)
 	}
 }

--- a/src/cli-auth/oauth-page.ts
+++ b/src/cli-auth/oauth-page.ts
@@ -1,0 +1,94 @@
+// Branded OAuth callback pages for the Kimchi-account browser login.
+//
+// This mirrors the renderer that `scripts/patch-pi-ai-oauth.js` injects into
+// pi-ai's `oauth-page.js`: both read the SAME templates from
+// `KIMCHI_OAUTH_TEMPLATE_DIR` (resources/oauth/{success,error}.html, set in
+// entry.ts) and substitute the same `{{TITLE}}/{{HEADING}}/{{MESSAGE}}/{{DETAILS}}`
+// placeholders. We re-implement the ~20 lines here because pi-ai does not export
+// `oauth-page.js` (its package `exports` map blocks the deep import), but by
+// sharing the template files the Kimchi-account login and pi's subscription
+// providers serve identical branded pages, and designer edits propagate to both.
+//
+// If the env var is missing or the template can't be read we fall through to a
+// minimal *unbranded* page, deliberately not a Kimchi- or Pi-branded fallback,
+// matching the patch's behavior (the token is already saved by the time this
+// renders, so a degraded page beats blanking the user mid-flow).
+
+import { readFileSync } from "node:fs"
+import { resolve } from "node:path"
+
+function escapeHtml(value: string): string {
+	return value
+		.replaceAll("&", "&amp;")
+		.replaceAll("<", "&lt;")
+		.replaceAll(">", "&gt;")
+		.replaceAll('"', "&quot;")
+		.replaceAll("'", "&#39;")
+}
+
+interface PageOptions {
+	title: string
+	heading: string
+	message: string
+	details?: string
+	template: "success" | "error"
+}
+
+function renderPage(options: PageOptions): string {
+	const templateDir = process.env.KIMCHI_OAUTH_TEMPLATE_DIR
+	if (templateDir) {
+		try {
+			const html = readFileSync(resolve(templateDir, `${options.template}.html`), "utf-8")
+			return html
+				.replaceAll("{{TITLE}}", escapeHtml(options.title))
+				.replaceAll("{{HEADING}}", escapeHtml(options.heading))
+				.replaceAll("{{MESSAGE}}", escapeHtml(options.message))
+				.replaceAll("{{DETAILS}}", options.details ? `<div class="details">${escapeHtml(options.details)}</div>` : "")
+		} catch {
+			// fall through to minimal unbranded fallback
+		}
+	}
+
+	const title = escapeHtml(options.title)
+	const heading = escapeHtml(options.heading)
+	const message = escapeHtml(options.message)
+	const details = options.details ? escapeHtml(options.details) : undefined
+	return `<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>${title}</title>
+  <style>
+    body { font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif; max-width: 480px; margin: 48px auto; padding: 24px; line-height: 1.5; color: #111; }
+    h1 { font-size: 20px; margin: 0 0 12px; }
+    p { margin: 0 0 12px; color: #555; }
+    .details { font-family: ui-monospace, SFMono-Regular, Menlo, monospace; font-size: 13px; background: #f5f5f5; padding: 12px; border-radius: 6px; white-space: pre-wrap; word-break: break-word; }
+  </style>
+</head>
+<body>
+  <h1>${heading}</h1>
+  <p>${message}</p>
+  ${details ? `<div class="details">${details}</div>` : ""}
+</body>
+</html>`
+}
+
+export function oauthSuccessHtml(message: string): string {
+	return renderPage({
+		title: "Authentication successful",
+		heading: "Authentication successful",
+		message,
+		template: "success",
+	})
+}
+
+export function oauthErrorHtml(message: string, details?: string): string {
+	return renderPage({
+		title: "Authentication failed",
+		heading: "Authentication failed",
+		message,
+		details,
+		template: "error",
+	})
+}

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -480,6 +480,7 @@ try {
 			terminalColorsExtension,
 			kimchiMinimalTintsExtension,
 			loginExtension,
+			uiExtension,
 			startupAuthGate,
 			loopGuardExtension,
 			explorationGuardExtension,
@@ -503,7 +504,6 @@ try {
 			thinkingStepsExtension,
 			assistantPrefixExtension,
 			clipboardImageExtension,
-			uiExtension,
 			sessionModeOnboarding,
 			tipsExtension(),
 			...enabledExtensionFactories([

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -31,6 +31,7 @@ import helpExtension from "./extensions/help.js"
 import hideThinkingExtension from "./extensions/hide-thinking.js"
 import kimchiMinimalTintsExtension from "./extensions/kimchi-minimal-tints.js"
 import loginExtension from "./extensions/login/index.js"
+import { createStartupAuthGate, createStartupAuthGateState } from "./extensions/login/startup-auth.js"
 import loopGuardExtension from "./extensions/loop-guard.js"
 import lspExtension from "./extensions/lsp.js"
 import mcpAdapterExtension from "./extensions/mcp-adapter/index.js"
@@ -448,11 +449,20 @@ try {
 		}
 
 		const rawArgs = process.argv.slice(2)
-		const sessionModeOnboarding = createSessionModeOnboardingForStartup({
-			rawArgs,
+		const interactiveStartupContext = {
 			nonInteractiveMode: acpMode,
 			stdinIsTTY: process.stdin.isTTY === true,
 			stdoutIsTTY: process.stdout.isTTY === true,
+		}
+		const startupAuthState = createStartupAuthGateState()
+		const startupAuthGate = createStartupAuthGate({
+			...interactiveStartupContext,
+			state: startupAuthState,
+		})
+		const sessionModeOnboarding = createSessionModeOnboardingForStartup({
+			rawArgs,
+			...interactiveStartupContext,
+			shouldSkip: () => startupAuthState.cancelled,
 		})
 		const extensionFactories = [
 			startupUpdateExtension,
@@ -461,6 +471,8 @@ try {
 			statsExtension,
 			terminalColorsExtension,
 			kimchiMinimalTintsExtension,
+			loginExtension,
+			startupAuthGate,
 			loopGuardExtension,
 			explorationGuardExtension,
 			lspExtension,
@@ -499,7 +511,6 @@ try {
 				{ id: "tools.web_fetch", factory: webFetchExtension },
 				{ id: "tools.web_search", factory: webSearchExtension },
 			] satisfies ManagedExtensionFactory[]),
-			loginExtension,
 			modelSwitchExtension,
 			modelGuardExtension,
 			stripImagesExtension,

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -63,7 +63,7 @@ import traceIdExtension from "./extensions/trace-id.js"
 import uiExtension from "./extensions/ui.js"
 import webFetchExtension from "./extensions/web-fetch/index.js"
 import webSearchExtension from "./extensions/web-search/index.js"
-import { updateModelsConfig } from "./models.js"
+import { isTransientModelsError, updateModelsConfig } from "./models.js"
 import { injectTraceIdsIntoEntries, injectTraceIdsIntoExport } from "./modes/teleport/sync/session-export.js"
 import resourcesExtension from "./resources/extension.js"
 import { type ManagedExtensionFactory, enabledExtensionFactories } from "./resources/filter.js"
@@ -330,6 +330,14 @@ try {
 				writeApiKey(currentApiKey)
 				config = loadConfig()
 				;({ models } = await updateModelsConfig(modelsJsonPath, currentApiKey))
+			} else if (isTransientModelsError(err)) {
+				// Rate limit / gateway error with no cached models to fall back on.
+				// Don't crash startup over a transient condition — continue with an
+				// empty list; the login gate and later refreshes will repopulate it.
+				console.warn(
+					`Could not load the model list right now (${err instanceof Error ? err.message : String(err)}). Continuing; models will refresh once the service is reachable.`,
+				)
+				models = []
 			} else {
 				throw err
 			}

--- a/src/extensions/login/flow.ts
+++ b/src/extensions/login/flow.ts
@@ -1,0 +1,397 @@
+import { resolve } from "node:path"
+import type { Api, Model } from "@earendil-works/pi-ai"
+import { getModels } from "@earendil-works/pi-ai"
+import {
+	type AuthStatus,
+	type ExtensionContext,
+	ExtensionSelectorComponent,
+	LoginDialogComponent,
+	OAuthSelectorComponent,
+} from "@earendil-works/pi-coding-agent"
+import { type Component, Container, type TUI } from "@earendil-works/pi-tui"
+import { authenticateViaBrowser } from "../../cli-auth/index.js"
+import { loadConfig, writeApiKey } from "../../config.js"
+import { type PiModelConfig, syncProviderModels, updateModelsConfig } from "../../models.js"
+
+export const KIMCHI_PROVIDER_ID = "kimchi-dev"
+export const KIMCHI_DEFAULT_MODEL_ID = "kimi-k2.6"
+export const KIMCHI_ACCOUNT_LABEL = "Use a Kimchi account"
+export const SUBSCRIPTION_LABEL = "Use a subscription"
+
+type AuthSelectorProvider = ConstructorParameters<typeof OAuthSelectorComponent>[2][number]
+interface AuthStorageLike {
+	set(provider: string, credential: unknown): void
+	get(provider: string): unknown
+}
+
+interface ProviderModelLike {
+	id: string
+	provider: string
+}
+
+interface ModelRegistryLike<TModel extends ProviderModelLike = ProviderModelLike> {
+	authStorage: AuthStorageLike
+	refresh(): void
+	getAvailable(): TModel[]
+	getProviderAuthStatus(providerId: string): AuthStatus
+}
+
+export function createLoginChoiceSelector(options: {
+	onKimchiAccount: () => void
+	onSubscription: () => void
+	onCancel: () => void
+}): ExtensionSelectorComponent {
+	return new ExtensionSelectorComponent(
+		"Select authentication method:",
+		[KIMCHI_ACCOUNT_LABEL, SUBSCRIPTION_LABEL],
+		(option) => {
+			if (option === SUBSCRIPTION_LABEL) {
+				options.onSubscription()
+				return
+			}
+			options.onKimchiAccount()
+		},
+		options.onCancel,
+	)
+}
+
+function upstreamModelToPiConfig(m: Model<Api>, providerId: string): PiModelConfig {
+	return {
+		id: m.id,
+		name: m.name,
+		api: m.api,
+		baseUrl: m.baseUrl,
+		reasoning: m.reasoning,
+		input: m.input,
+		contextWindow: m.contextWindow,
+		maxTokens: m.maxTokens,
+		cost: m.cost,
+		provider: providerId,
+		compat: m.compat as PiModelConfig["compat"],
+	}
+}
+
+export async function prePopulateSubscriptionModels(providerId: string): Promise<void> {
+	const piModels = getModels?.(providerId as Parameters<typeof getModels>[0]) ?? []
+	if (piModels.length === 0) return
+
+	const agentDir = process.env.KIMCHI_CODING_AGENT_DIR
+	if (!agentDir) {
+		console.warn("KIMCHI_CODING_AGENT_DIR environment variable is missing. Models cannot be cached.")
+		return
+	}
+
+	const modelsJsonPath = resolve(agentDir, "models.json")
+	const configs = piModels.map((m) => upstreamModelToPiConfig(m, providerId))
+	const firstModel = piModels[0]
+	syncProviderModels(modelsJsonPath, providerId, configs, {
+		api: firstModel.api,
+		baseUrl: firstModel.baseUrl,
+	})
+}
+
+async function refreshKimchiModels(token: string): Promise<void> {
+	const agentDir = process.env.KIMCHI_CODING_AGENT_DIR
+	if (!agentDir) return
+	await updateModelsConfig(resolve(agentDir, "models.json"), token)
+}
+
+export function setKimchiAuthToken(
+	modelRegistry: ModelRegistryLike,
+	token: string,
+	credentialType: "api_key" | "oauth" = "api_key",
+): void {
+	if (credentialType === "oauth") {
+		modelRegistry.authStorage.set(KIMCHI_PROVIDER_ID, {
+			type: "oauth",
+			access: token,
+			refresh: "",
+			expires: Number.MAX_SAFE_INTEGER,
+		})
+		return
+	}
+
+	modelRegistry.authStorage.set(KIMCHI_PROVIDER_ID, {
+		type: "api_key",
+		key: token,
+	})
+}
+
+export interface KimchiBrowserLoginHost {
+	modelRegistry: ModelRegistryLike
+	setModel?: (model: ProviderModelLike) => Promise<unknown> | unknown
+	showStatus?: (message: string) => void
+	showError?: (message: string) => void
+	addFeedback?: (message: string) => void
+	onBrowserUrl?: (url: string) => void
+}
+
+async function configureKimchiToken(host: KimchiBrowserLoginHost, token: string): Promise<boolean> {
+	let refreshError: unknown
+	try {
+		await refreshKimchiModels(token)
+	} catch (error) {
+		refreshError = error
+	}
+
+	setKimchiAuthToken(host.modelRegistry, token)
+	try {
+		host.modelRegistry.refresh()
+	} catch (error) {
+		refreshError ??= error
+	}
+
+	let providerModels: ProviderModelLike[] = []
+	try {
+		providerModels = host.modelRegistry.getAvailable().filter((m) => m.provider === KIMCHI_PROVIDER_ID)
+	} catch (error) {
+		refreshError ??= error
+	}
+	if (providerModels.length > 0) {
+		const selectedModel = providerModels.find((m) => m.id === KIMCHI_DEFAULT_MODEL_ID) ?? providerModels[0]
+		await host.setModel?.(selectedModel)
+		host.addFeedback?.(`✓ Logged in. Model: ${selectedModel.id}`)
+		return true
+	}
+
+	if (refreshError) {
+		host.showError?.(
+			`Kimchi model refresh failed: ${refreshError instanceof Error ? refreshError.message : String(refreshError)}`,
+		)
+	} else {
+		host.showError?.("Kimchi login did not configure any available models. Your API key was saved; try again.")
+	}
+	return false
+}
+
+export async function performKimchiBrowserLogin(host: KimchiBrowserLoginHost): Promise<boolean> {
+	const existingToken = loadConfig().apiKey
+	if (existingToken) {
+		host.showStatus?.("Refreshing Kimchi models with existing login...")
+		return configureKimchiToken(host, existingToken)
+	}
+
+	let browserUrl: string | undefined
+	try {
+		host.showStatus?.("Opening browser for Kimchi login...")
+
+		const { token } = await authenticateViaBrowser({
+			onBrowserUrl: (url) => {
+				browserUrl = url
+				host.onBrowserUrl?.(url)
+			},
+		})
+
+		writeApiKey(token)
+		return configureKimchiToken(host, token)
+	} catch (error) {
+		if (browserUrl) {
+			host.addFeedback?.(`Couldn't open browser automatically. Visit: ${browserUrl}`)
+		}
+		host.showError?.(`Kimchi login failed: ${error instanceof Error ? error.message : String(error)}`)
+		return false
+	}
+}
+
+export function getSubscriptionProviderOptions(
+	modelRegistry: ExtensionContext["modelRegistry"],
+): AuthSelectorProvider[] {
+	const providers = modelRegistry.authStorage.getOAuthProviders()
+	return providers
+		.filter((provider) => provider.id !== KIMCHI_PROVIDER_ID)
+		.map((provider) => ({
+			id: provider.id,
+			name: provider.name,
+			authType: "oauth" as const,
+		}))
+		.sort((a, b) => a.name.localeCompare(b.name))
+}
+
+class SwappableAuthComponent extends Container {
+	private current: unknown
+	private _focused = false
+
+	constructor(private readonly tui: TUI) {
+		super()
+	}
+
+	get focused(): boolean {
+		return this._focused
+	}
+
+	set focused(value: boolean) {
+		this._focused = value
+		this.setChildFocused(value)
+	}
+
+	set(component: unknown): void {
+		this.current = component
+		this.clear()
+		this.addChild(component as Component)
+		this.setChildFocused(this._focused)
+		this.tui.requestRender()
+	}
+
+	handleInput(data: string): void {
+		const inputHandler = (this.current as { handleInput?: (data: string) => void } | undefined)?.handleInput
+		inputHandler?.(data)
+	}
+
+	private setChildFocused(focused: boolean): void {
+		const maybeFocusable = this.current as { focused?: boolean } | undefined
+		if (maybeFocusable && "focused" in maybeFocusable) {
+			maybeFocusable.focused = focused
+		}
+	}
+}
+
+function showOAuthLoginSelectInHost(
+	host: SwappableAuthComponent,
+	dialog: LoginDialogComponent,
+	prompt: Parameters<
+		NonNullable<Parameters<ExtensionContext["modelRegistry"]["authStorage"]["login"]>[1]["onSelect"]>
+	>[0],
+): Promise<string | undefined> {
+	return new Promise((resolve) => {
+		const labels = prompt.options.map((option) => option.label)
+		const selector = new ExtensionSelectorComponent(
+			prompt.message,
+			labels,
+			(optionLabel) => {
+				host.set(dialog)
+				resolve(prompt.options.find((option) => option.label === optionLabel)?.id)
+			},
+			() => {
+				host.set(dialog)
+				resolve(undefined)
+			},
+		)
+		host.set(selector)
+	})
+}
+
+async function showOAuthLoginDialogWithExtensionUI(
+	ctx: ExtensionContext,
+	providerId: string,
+	providerName: string,
+): Promise<boolean> {
+	const providerInfo = ctx.modelRegistry.authStorage.getOAuthProviders().find((provider) => provider.id === providerId)
+	const usesCallbackServer = providerInfo?.usesCallbackServer ?? false
+
+	return ctx.ui.custom<boolean>((tui, _theme, _keybindings, done) => {
+		const host = new SwappableAuthComponent(tui)
+		let finished = false
+		const finish = (result: boolean) => {
+			if (finished) return
+			finished = true
+			done(result)
+		}
+		const dialog = new LoginDialogComponent(
+			tui,
+			providerId,
+			(success) => {
+				if (!success) finish(false)
+			},
+			providerName,
+		)
+		host.set(dialog)
+
+		void (async () => {
+			let manualCodeResolve: ((value: string) => void) | undefined
+			let manualCodeReject: ((error: Error) => void) | undefined
+			const manualCodePromise = new Promise<string>((resolve, reject) => {
+				manualCodeResolve = resolve
+				manualCodeReject = reject
+			})
+
+			try {
+				await ctx.modelRegistry.authStorage.login(providerId, {
+					onAuth: (info) => {
+						dialog.showAuth(info.url, info.instructions)
+						if (usesCallbackServer) {
+							dialog
+								.showManualInput("Paste redirect URL below, or complete login in browser:")
+								.then((value) => {
+									if (value && manualCodeResolve) {
+										manualCodeResolve(value)
+										manualCodeResolve = undefined
+									}
+								})
+								.catch(() => {
+									if (manualCodeReject) {
+										manualCodeReject(new Error("Login cancelled"))
+										manualCodeReject = undefined
+									}
+								})
+						} else if (providerId === "github-copilot") {
+							dialog.showWaiting("Waiting for browser authentication...")
+						}
+					},
+					onPrompt: async (prompt) => dialog.showPrompt(prompt.message, prompt.placeholder),
+					onProgress: (message) => {
+						dialog.showProgress(message)
+					},
+					onSelect: (prompt) => showOAuthLoginSelectInHost(host, dialog, prompt),
+					onManualCodeInput: () => manualCodePromise,
+					signal: dialog.signal,
+				})
+				finish(true)
+			} catch (error) {
+				const errorMsg = error instanceof Error ? error.message : String(error)
+				if (errorMsg !== "Login cancelled") {
+					ctx.ui.notify(`Failed to login to ${providerName}: ${errorMsg}`, "error")
+				}
+				finish(false)
+			}
+		})()
+
+		return host
+	})
+}
+
+export async function showSubscriptionLoginWithExtensionUI(
+	ctx: ExtensionContext,
+	setModel?: (model: Model<Api>) => Promise<unknown> | unknown,
+): Promise<boolean> {
+	const providerOptions = getSubscriptionProviderOptions(ctx.modelRegistry)
+	if (providerOptions.length === 0) {
+		ctx.ui.notify("No subscription providers available.", "warning")
+		return false
+	}
+
+	const providerId = await ctx.ui.custom<string | undefined>((_tui, _theme, _keybindings, done) => {
+		const selector = new OAuthSelectorComponent(
+			"login",
+			ctx.modelRegistry.authStorage,
+			providerOptions,
+			(selectedProviderId) => done(selectedProviderId),
+			() => done(undefined),
+			(id) => ctx.modelRegistry.getProviderAuthStatus(id),
+		)
+		return selector
+	})
+	if (!providerId) return false
+
+	const providerOption = providerOptions.find((provider) => provider.id === providerId)
+	if (!providerOption) return false
+
+	try {
+		await prePopulateSubscriptionModels(providerOption.id)
+		const success = await showOAuthLoginDialogWithExtensionUI(ctx, providerOption.id, providerOption.name)
+		if (!success) return false
+
+		ctx.modelRegistry.refresh()
+		const providerModels = ctx.modelRegistry.getAvailable().filter((model) => model.provider === providerOption.id)
+		const selectedModel = providerModels[0]
+		if (selectedModel) {
+			await setModel?.(selectedModel)
+			ctx.ui.notify(`Logged in to ${providerOption.name}. Model: ${selectedModel.id}`, "info")
+		} else {
+			ctx.ui.notify(`Logged in to ${providerOption.name}. Use /model to select a model.`, "info")
+		}
+		return true
+	} catch (error) {
+		ctx.ui.notify(`Subscription login failed: ${error instanceof Error ? error.message : String(error)}`, "error")
+		return false
+	}
+}

--- a/src/extensions/login/flow.ts
+++ b/src/extensions/login/flow.ts
@@ -11,7 +11,7 @@ import {
 import { type Component, Container, type TUI } from "@earendil-works/pi-tui"
 import { authenticateViaBrowser } from "../../cli-auth/index.js"
 import { loadConfig, writeApiKey } from "../../config.js"
-import { type PiModelConfig, syncProviderModels, updateModelsConfig } from "../../models.js"
+import { type PiModelConfig, isTransientModelsError, syncProviderModels, updateModelsConfig } from "../../models.js"
 
 export const KIMCHI_PROVIDER_ID = "kimchi-dev"
 export const KIMCHI_DEFAULT_MODEL_ID = "kimi-k2.6"
@@ -155,9 +155,17 @@ async function configureKimchiToken(host: KimchiBrowserLoginHost, token: string)
 	}
 
 	if (refreshError) {
-		host.showError?.(
-			`Kimchi model refresh failed: ${refreshError instanceof Error ? refreshError.message : String(refreshError)}`,
-		)
+		const detail = refreshError instanceof Error ? refreshError.message : String(refreshError)
+		if (isTransientModelsError(refreshError)) {
+			// Key is valid; the model list is just temporarily unreachable (rate limit,
+			// gateway error). Tell the user to wait and retry rather than implying the
+			// login failed — and the saved key means a retry won't mint a new one.
+			host.showError?.(
+				`Kimchi is temporarily unavailable (${detail}). Your API key was saved — wait a moment and try again.`,
+			)
+		} else {
+			host.showError?.(`Kimchi model refresh failed: ${detail}`)
+		}
 	} else {
 		host.showError?.("Kimchi login did not configure any available models. Your API key was saved; try again.")
 	}

--- a/src/extensions/login/flow.ts
+++ b/src/extensions/login/flow.ts
@@ -18,6 +18,34 @@ export const KIMCHI_DEFAULT_MODEL_ID = "kimi-k2.6"
 export const KIMCHI_ACCOUNT_LABEL = "Use a Kimchi account"
 export const SUBSCRIPTION_LABEL = "Use a subscription"
 
+let browserLoginLinkSeq = 0
+
+/**
+ * Format the browser-login URL as a feedback message the user can act on when
+ * the auto-opened browser landed in the wrong app/profile.
+ *
+ * The URL is wrapped as an OSC 8 terminal hyperlink so the user can right-click
+ * "Copy Link" (or Cmd/Ctrl-click) and get the *complete* URL; selecting the
+ * raw wrapped text injects a newline at the wrap point that corrupts the `state`
+ * query param on paste.
+ *
+ * Two details make the wrapped link behave as a single link:
+ *  - BEL terminator (`\x07`), mirroring upstream `LoginDialogComponent.showAuth`,
+ *    rather than pi-tui's exported `hyperlink()` which uses the ST terminator
+ *    (`\x1b\\`); pi-tui's own line-wrapper documents that ST leaves only the
+ *    first wrapped physical line clickable in some terminals.
+ *  - a unique `id=` param so the terminal treats the wrapped rows as ONE link
+ *    and highlights the whole URL on hover (without it, each wrapped segment is a
+ *    separate link and only the row under the cursor lights up). pi-tui's wrapper
+ *    preserves the param when it re-opens the link on continuation rows.
+ */
+export function formatBrowserLoginMessage(url: string): string {
+	browserLoginLinkSeq += 1
+	const id = `kimchi-login-${browserLoginLinkSeq}`
+	const linkedUrl = `\x1b]8;id=${id};${url}\x07${url}\x1b]8;;\x07`
+	return `If the wrong browser or profile opened, right-click this link, choose "Copy Link", and open it in the correct one:\n${linkedUrl}`
+}
+
 type AuthSelectorProvider = ConstructorParameters<typeof OAuthSelectorComponent>[2][number]
 interface AuthStorageLike {
 	set(provider: string, credential: unknown): void

--- a/src/extensions/login/flow.ts
+++ b/src/extensions/login/flow.ts
@@ -159,6 +159,10 @@ export interface KimchiBrowserLoginHost {
 	signal?: AbortSignal
 }
 
+export interface KimchiBrowserLoginOptions {
+	reuseExistingToken?: boolean
+}
+
 async function configureKimchiToken(host: KimchiBrowserLoginHost, token: string): Promise<boolean> {
 	let refreshError: unknown
 	try {
@@ -205,8 +209,11 @@ async function configureKimchiToken(host: KimchiBrowserLoginHost, token: string)
 	return false
 }
 
-export async function performKimchiBrowserLogin(host: KimchiBrowserLoginHost): Promise<boolean> {
-	const existingToken = loadConfig().apiKey
+export async function performKimchiBrowserLogin(
+	host: KimchiBrowserLoginHost,
+	options: KimchiBrowserLoginOptions = {},
+): Promise<boolean> {
+	const existingToken = options.reuseExistingToken ? loadConfig().apiKey : ""
 	if (existingToken) {
 		host.showStatus?.("Refreshing Kimchi models with existing login...")
 		return configureKimchiToken(host, existingToken)
@@ -280,20 +287,23 @@ export async function performKimchiBrowserLoginWithDialog(
 		)
 
 		void (async () => {
-			const ok = await performKimchiBrowserLogin({
-				modelRegistry: ctx.modelRegistry,
-				setModel,
-				showStatus: (message) => dialog.showProgress(message),
-				showError: (message) => ctx.ui.notify(message, "error"),
-				addFeedback: (message) => dialog.showProgress(message),
-				onBrowserUrl: (url) =>
-					dialog.showInfo([
-						'If the wrong browser or profile opened, right-click this link, choose "Copy Link", and open it in the correct one:',
-						"",
-						formatKimchiLoginLink(url),
-					]),
-				signal: dialog.signal,
-			})
+			const ok = await performKimchiBrowserLogin(
+				{
+					modelRegistry: ctx.modelRegistry,
+					setModel,
+					showStatus: (message) => dialog.showProgress(message),
+					showError: (message) => ctx.ui.notify(message, "error"),
+					addFeedback: (message) => dialog.showProgress(message),
+					onBrowserUrl: (url) =>
+						dialog.showInfo([
+							'If the wrong browser or profile opened, right-click this link, choose "Copy Link", and open it in the correct one:',
+							"",
+							formatKimchiLoginLink(url),
+						]),
+					signal: dialog.signal,
+				},
+				{ reuseExistingToken: true },
+			)
 			if (cancelled || dialog.signal.aborted) finish("cancelled")
 			else finish(ok ? "success" : "failed")
 		})()

--- a/src/extensions/login/flow.ts
+++ b/src/extensions/login/flow.ts
@@ -39,11 +39,14 @@ let browserLoginLinkSeq = 0
  *    separate link and only the row under the cursor lights up). pi-tui's wrapper
  *    preserves the param when it re-opens the link on continuation rows.
  */
-export function formatBrowserLoginMessage(url: string): string {
+export function formatKimchiLoginLink(url: string): string {
 	browserLoginLinkSeq += 1
 	const id = `kimchi-login-${browserLoginLinkSeq}`
-	const linkedUrl = `\x1b]8;id=${id};${url}\x07${url}\x1b]8;;\x07`
-	return `If the wrong browser or profile opened, right-click this link, choose "Copy Link", and open it in the correct one:\n${linkedUrl}`
+	return `\x1b]8;id=${id};${url}\x07${url}\x1b]8;;\x07`
+}
+
+export function formatBrowserLoginMessage(url: string): string {
+	return `If the wrong browser or profile opened, right-click this link, choose "Copy Link", and open it in the correct one:\n${formatKimchiLoginLink(url)}`
 }
 
 type AuthSelectorProvider = ConstructorParameters<typeof OAuthSelectorComponent>[2][number]
@@ -152,6 +155,8 @@ export interface KimchiBrowserLoginHost {
 	showError?: (message: string) => void
 	addFeedback?: (message: string) => void
 	onBrowserUrl?: (url: string) => void
+	/** Abort the in-flight browser login (e.g. the login dialog was cancelled). */
+	signal?: AbortSignal
 }
 
 async function configureKimchiToken(host: KimchiBrowserLoginHost, token: string): Promise<boolean> {
@@ -216,17 +221,85 @@ export async function performKimchiBrowserLogin(host: KimchiBrowserLoginHost): P
 				browserUrl = url
 				host.onBrowserUrl?.(url)
 			},
+			signal: host.signal,
 		})
 
 		writeApiKey(token)
 		return configureKimchiToken(host, token)
 	} catch (error) {
+		// User cancelled (Esc in the login dialog aborts host.signal); that's not a
+		// failure, so stay silent instead of flashing an error toast and a misleading
+		// "Couldn't open browser" hint. Mirrors the subscription path, which ignores
+		// the "Login cancelled" error from authStorage.login.
+		if (host.signal?.aborted) return false
 		if (browserUrl) {
 			host.addFeedback?.(`Couldn't open browser automatically. Visit: ${browserUrl}`)
 		}
 		host.showError?.(`Kimchi login failed: ${error instanceof Error ? error.message : String(error)}`)
 		return false
 	}
+}
+
+export type KimchiBrowserLoginDialogResult = "success" | "failed" | "cancelled"
+
+/**
+ * Run the Kimchi browser login inside pi's `LoginDialogComponent`, mirroring how
+ * subscription login is presented (`showOAuthLoginDialogWithExtensionUI`). We reuse
+ * the dialog for its chrome and lifecycle: bordered "Log in to Kimchi" box, focus,
+ * and Esc-to-cancel (wired to abort the callback server). We feed it our own
+ * `formatKimchiLoginLink` via `showInfo` rather than the dialog's `showAuth`, which
+ * renders the URL without the `id=` grouping that keeps the wrapped link clickable
+ * and fully highlighted.
+ */
+export async function performKimchiBrowserLoginWithDialog(
+	ctx: ExtensionContext,
+	setModel?: (model: ProviderModelLike) => Promise<unknown> | unknown,
+): Promise<KimchiBrowserLoginDialogResult> {
+	return ctx.ui.custom<KimchiBrowserLoginDialogResult>((tui, _theme, _keybindings, done) => {
+		let finished = false
+		let cancelled = false
+		const finish = (result: KimchiBrowserLoginDialogResult) => {
+			if (finished) return
+			finished = true
+			done(result)
+		}
+
+		const dialog = new LoginDialogComponent(
+			tui,
+			KIMCHI_PROVIDER_ID,
+			// Fires when the dialog is cancelled (Esc). The abort below tears down the
+			// callback server; closing the dialog here resolves the surrounding custom.
+			(success) => {
+				if (!success) {
+					cancelled = true
+					finish("cancelled")
+				}
+			},
+			"Kimchi",
+			"Log in to Kimchi",
+		)
+
+		void (async () => {
+			const ok = await performKimchiBrowserLogin({
+				modelRegistry: ctx.modelRegistry,
+				setModel,
+				showStatus: (message) => dialog.showProgress(message),
+				showError: (message) => ctx.ui.notify(message, "error"),
+				addFeedback: (message) => dialog.showProgress(message),
+				onBrowserUrl: (url) =>
+					dialog.showInfo([
+						'If the wrong browser or profile opened, right-click this link, choose "Copy Link", and open it in the correct one:',
+						"",
+						formatKimchiLoginLink(url),
+					]),
+				signal: dialog.signal,
+			})
+			if (cancelled || dialog.signal.aborted) finish("cancelled")
+			else finish(ok ? "success" : "failed")
+		})()
+
+		return dialog
+	})
 }
 
 export function getSubscriptionProviderOptions(

--- a/src/extensions/login/index.ts
+++ b/src/extensions/login/index.ts
@@ -2,6 +2,9 @@ import { resolve } from "node:path"
 import type { ExtensionAPI } from "@earendil-works/pi-coding-agent"
 import { clearApiKey, loadConfig, writeApiKey } from "../../config.js"
 import { updateModelsConfig, validateApiKey } from "../../models.js"
+import { KIMCHI_PROVIDER_ID, setKimchiAuthToken } from "./flow.js"
+
+const KIMCHI_LOGOUT_PATCHED = Symbol("kimchi.logoutPatched")
 
 export default function loginExtension(pi: ExtensionAPI): void {
 	const agentDir = process.env.KIMCHI_CODING_AGENT_DIR
@@ -13,19 +16,23 @@ export default function loginExtension(pi: ExtensionAPI): void {
 
 		const configKey = loadConfig().apiKey
 		if (configKey) {
-			authStorage.set("kimchi-dev", { type: "oauth", access: configKey, refresh: "", expires: Number.MAX_SAFE_INTEGER })
+			setKimchiAuthToken(ctx.modelRegistry, configKey, "oauth")
 		}
 
-		const originalLogout = authStorage.logout.bind(authStorage)
-		authStorage.logout = (provider: string) => {
+		const patchedAuthStorage = authStorage as typeof authStorage & { [KIMCHI_LOGOUT_PATCHED]?: boolean }
+		if (patchedAuthStorage[KIMCHI_LOGOUT_PATCHED]) return
+
+		const originalLogout = patchedAuthStorage.logout.bind(patchedAuthStorage)
+		patchedAuthStorage.logout = (provider: string) => {
 			originalLogout(provider)
-			if (provider === "kimchi-dev") {
+			if (provider === KIMCHI_PROVIDER_ID) {
 				clearApiKey()
 			}
 		}
+		patchedAuthStorage[KIMCHI_LOGOUT_PATCHED] = true
 	})
 
-	pi.registerProvider("kimchi-dev", {
+	pi.registerProvider(KIMCHI_PROVIDER_ID, {
 		oauth: {
 			name: "Kimchi",
 			login: async (callbacks) => {

--- a/src/extensions/login/startup-auth.test.ts
+++ b/src/extensions/login/startup-auth.test.ts
@@ -1,4 +1,4 @@
-import { type Theme, initTheme } from "@earendil-works/pi-coding-agent"
+import { LoginDialogComponent, type Theme, initTheme } from "@earendil-works/pi-coding-agent"
 import type { TUI } from "@earendil-works/pi-tui"
 import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest"
 
@@ -216,27 +216,69 @@ describe("startup auth gate", () => {
 		expect(harness.state.authenticated).toBe(true)
 	})
 
-	it("surfaces the login URL so it can be copied into the right browser/profile", async () => {
+	it("surfaces the login URL in pi's login dialog so it can be copied into the right browser/profile", async () => {
 		const loginUrl = "https://app.kimchi.dev/cli-auth?callback=http%3A%2F%2Flocalhost%3A51234&state=abc123"
 		authMock.authenticateViaBrowser.mockImplementation(async (options: { onBrowserUrl?: (url: string) => void }) => {
 			options?.onBrowserUrl?.(loginUrl)
 			return { token: "kimchi-token" }
 		})
+		// The URL is shown via the reused LoginDialogComponent's showInfo, not notify.
+		const showInfoSpy = vi.spyOn(LoginDialogComponent.prototype, "showInfo")
 
-		const harness = createHarness()
+		try {
+			const harness = createHarness()
+			const started = harness.start()
+
+			await harness.settle()
+			harness.input("\n")
+			await started
+
+			expect(authMock.authenticateViaBrowser).toHaveBeenCalledOnce()
+			const lines = showInfoSpy.mock.calls.flatMap((call) => call[0] as string[])
+			// Intact BEL-terminated OSC 8 hyperlink target so "Copy Link" yields the full
+			// URL even when the visible text wraps (a raw wrapped URL would get a newline
+			// injected at the wrap point, corrupting the state param on paste). The `id=`
+			// param groups the wrapped rows so the whole URL highlights as one link.
+			expect(lines.some((line) => line.includes(`;${loginUrl}\x07`))).toBe(true)
+			expect(lines.some((line) => line.includes("\x1b]8;id=kimchi-login-"))).toBe(true)
+		} finally {
+			showInfoSpy.mockRestore()
+		}
+	})
+
+	it("cancels the Kimchi login dialog without showing a login failure", async () => {
+		authMock.authenticateViaBrowser.mockImplementation(
+			(options: { signal?: AbortSignal }) =>
+				new Promise((_resolve, reject) => {
+					options.signal?.addEventListener("abort", () => reject(new Error("Browser login failed: Login cancelled")), {
+						once: true,
+					})
+				}),
+		)
+
+		const onCancel = vi.fn()
+		const harness = createHarness({ onCancel })
 		const started = harness.start()
 
 		await harness.settle()
 		harness.input("\n")
-		await started
+		await harness.waitForCustomPrompts(2)
+
+		harness.input("\x1b")
+		await harness.waitForCustomPrompts(3)
 
 		expect(authMock.authenticateViaBrowser).toHaveBeenCalledOnce()
-		// Intact BEL-terminated OSC 8 hyperlink target so "Copy Link" yields the full
-		// URL even when the visible text wraps (a raw wrapped URL would get a newline
-		// injected at the wrap point, corrupting the state param on paste). The `id=`
-		// param groups the wrapped rows so the whole URL highlights as one link.
-		expect(harness.ctx.ui.notify).toHaveBeenCalledWith(expect.stringContaining(`;${loginUrl}\x07`), "info")
-		expect(harness.ctx.ui.notify).toHaveBeenCalledWith(expect.stringContaining("\x1b]8;id=kimchi-login-"), "info")
+		expect(harness.ctx.ui.notify).not.toHaveBeenCalledWith(expect.stringContaining("Kimchi login failed"), "error")
+		expect(harness.ctx.ui.notify).not.toHaveBeenCalledWith(
+			"Login did not configure an available model. Try again or cancel.",
+			"warning",
+		)
+
+		harness.input("\x1b")
+		await started
+
+		expect(harness.state.cancelled).toBe(true)
+		expect(onCancel).toHaveBeenCalledOnce()
 	})
 
 	it("does not mint another browser key when a retry still has no available models", async () => {
@@ -253,11 +295,13 @@ describe("startup auth gate", () => {
 		try {
 			const started = harness.start()
 
+			// Each Kimchi attempt opens two customs: the auth-method selector, then the
+			// login dialog. So selectors land on prompts #1, #3, #5 (dialogs are #2, #4).
 			await harness.settle()
 			harness.input("\n")
-			await harness.waitForCustomPrompts(2)
-			harness.input("\n")
 			await harness.waitForCustomPrompts(3)
+			harness.input("\n")
+			await harness.waitForCustomPrompts(5)
 			harness.input("\x1b")
 			await started
 

--- a/src/extensions/login/startup-auth.test.ts
+++ b/src/extensions/login/startup-auth.test.ts
@@ -29,6 +29,7 @@ import {
 } from "./startup-auth.js"
 
 type SessionStartHandler = (event: { reason: string }, ctx: unknown) => unknown
+type TerminalInputHandler = (data: string) => unknown
 type CustomComponent = { handleInput?(data: string): void }
 
 function theme(): Theme {
@@ -51,6 +52,7 @@ function createHarness(
 		state?: StartupAuthGateState
 		availableInitially?: boolean
 		addModelOnAuthSet?: boolean
+		overlayActiveInitially?: boolean
 		onCancel?: ReturnType<typeof vi.fn>
 		afterSessionStart?: SessionStartHandler
 	} = {},
@@ -84,12 +86,19 @@ function createHarness(
 		getProviderAuthStatus: vi.fn(() => ({ configured: false })),
 	}
 	let activeComponent: CustomComponent | undefined
-	const tui = { requestRender: vi.fn(), hasOverlay: vi.fn(() => false) } as unknown as TUI
+	let overlayActive = options.overlayActiveInitially === true
+	let terminalInputHandler: TerminalInputHandler | undefined
+	const tui = { requestRender: vi.fn(), hasOverlay: vi.fn(() => overlayActive) } as unknown as TUI
 	const ui = {
 		setWidget: vi.fn((_key: string, content: unknown) => {
 			if (typeof content === "function") content(tui, theme())
 		}),
-		onTerminalInput: vi.fn(() => vi.fn()),
+		onTerminalInput: vi.fn((handler: TerminalInputHandler) => {
+			terminalInputHandler = handler
+			return () => {
+				if (terminalInputHandler === handler) terminalInputHandler = undefined
+			}
+		}),
 		custom: vi.fn((factory: (...args: unknown[]) => CustomComponent) => {
 			return new Promise((resolve) => {
 				const done = (result: unknown) => {
@@ -118,12 +127,16 @@ function createHarness(
 		ctx,
 		modelRegistry,
 		state,
+		setOverlay: (active: boolean) => {
+			overlayActive = active
+		},
 		start: async () => {
 			for (const handler of handlers.get("session_start") ?? []) {
 				await handler({ reason: "startup" }, ctx)
 			}
 		},
 		input: (data: string) => activeComponent?.handleInput?.(data),
+		terminalInput: (data: string) => terminalInputHandler?.(data),
 		settle: async () => {
 			for (let i = 0; i < 4; i += 1) await Promise.resolve()
 		},
@@ -294,6 +307,28 @@ describe("startup auth gate", () => {
 		await started
 
 		expect(laterOnboarding).toHaveBeenCalledOnce()
+	})
+
+	it("waits for an active overlay before showing the login selector", async () => {
+		const harness = createHarness({ overlayActiveInitially: true })
+		const started = harness.start()
+
+		await harness.settle()
+
+		expect(harness.ctx.ui.custom).not.toHaveBeenCalled()
+		expect(harness.modelRegistry.authStorage.set).not.toHaveBeenCalled()
+
+		harness.setOverlay(false)
+		harness.terminalInput("x")
+		await harness.waitForCustomPrompts(1)
+
+		expect(harness.ctx.ui.custom).toHaveBeenCalledOnce()
+
+		harness.input("\n")
+		await started
+
+		expect(authMock.authenticateViaBrowser).toHaveBeenCalledOnce()
+		expect(harness.state.authenticated).toBe(true)
 	})
 
 	it("does not show the selector when auth is already usable", async () => {

--- a/src/extensions/login/startup-auth.test.ts
+++ b/src/extensions/login/startup-auth.test.ts
@@ -14,6 +14,7 @@ const configMock = vi.hoisted(() => ({
 const modelsMock = vi.hoisted(() => ({
 	updateModelsConfig: vi.fn(),
 	syncProviderModels: vi.fn(),
+	isTransientModelsError: vi.fn((error: unknown) => (error as { transient?: boolean })?.transient === true),
 }))
 
 vi.mock("../../cli-auth/index.js", () => authMock)
@@ -143,9 +144,13 @@ beforeAll(() => {
 beforeEach(() => {
 	authMock.authenticateViaBrowser.mockReset()
 	authMock.authenticateViaBrowser.mockResolvedValue({ token: "kimchi-token" })
+	let savedConfigKey = ""
 	configMock.loadConfig.mockReset()
-	configMock.loadConfig.mockReturnValue({ apiKey: "" })
+	configMock.loadConfig.mockImplementation(() => ({ apiKey: savedConfigKey }))
 	configMock.writeApiKey.mockReset()
+	configMock.writeApiKey.mockImplementation((key: string) => {
+		savedConfigKey = key
+	})
 	modelsMock.updateModelsConfig.mockReset()
 	modelsMock.updateModelsConfig.mockResolvedValue({ models: [] })
 	modelsMock.syncProviderModels.mockReset()
@@ -235,6 +240,46 @@ describe("startup auth gate", () => {
 		}
 	})
 
+	it("reports a transient rate-limit failure as retryable without discarding the saved key", async () => {
+		const previousAgentDir = process.env.KIMCHI_CODING_AGENT_DIR
+		process.env.KIMCHI_CODING_AGENT_DIR = "/tmp/kimchi-startup-auth-test"
+		let savedConfigKey = ""
+		configMock.loadConfig.mockImplementation(() => ({ apiKey: savedConfigKey }))
+		configMock.writeApiKey.mockImplementation((key: string) => {
+			savedConfigKey = key
+		})
+		const transientError = Object.assign(new Error("Failed to fetch models: 429 Too Many Requests"), {
+			transient: true,
+		})
+		modelsMock.updateModelsConfig.mockRejectedValue(transientError)
+		const onCancel = vi.fn()
+		const harness = createHarness({ addModelOnAuthSet: false, onCancel })
+
+		try {
+			const started = harness.start()
+
+			await harness.settle()
+			harness.input("\n")
+			await harness.waitForCustomPrompts(2)
+			harness.input("\x1b")
+			await started
+
+			// The browser flow ran once; the retry reused the saved key (no new mint).
+			expect(authMock.authenticateViaBrowser).toHaveBeenCalledOnce()
+			const messages = (harness.ctx.ui.notify as ReturnType<typeof vi.fn>).mock.calls.map((call) => call[0])
+			expect(messages.some((message: string) => /temporarily unavailable/i.test(message))).toBe(true)
+			expect(harness.state.authenticated).toBe(false)
+			expect(harness.state.cancelled).toBe(true)
+		} finally {
+			if (previousAgentDir === undefined) {
+				// biome-ignore lint/performance/noDelete: process.env requires delete operator to be truly unset rather than stringified to "undefined"
+				delete process.env.KIMCHI_CODING_AGENT_DIR
+			} else {
+				process.env.KIMCHI_CODING_AGENT_DIR = previousAgentDir
+			}
+		}
+	})
+
 	it("keeps later startup onboarding parked while authentication is pending", async () => {
 		const laterOnboarding = vi.fn()
 		const onCancel = vi.fn()
@@ -252,12 +297,27 @@ describe("startup auth gate", () => {
 	})
 
 	it("does not show the selector when auth is already usable", async () => {
+		configMock.loadConfig.mockReturnValue({ apiKey: "saved-config-token" })
 		const harness = createHarness({ availableInitially: true })
 
 		await harness.start()
 
 		expect(harness.ctx.ui.custom).not.toHaveBeenCalled()
 		expect(harness.state.attempted).toBe(false)
+	})
+
+	it("does not treat cached Kimchi models as usable without a saved key", async () => {
+		const onCancel = vi.fn()
+		const harness = createHarness({ availableInitially: true, onCancel })
+		const started = harness.start()
+
+		await harness.waitForCustomPrompts(1)
+		harness.input("\x1b")
+		await started
+
+		expect(harness.ctx.ui.custom).toHaveBeenCalledOnce()
+		expect(harness.state.cancelled).toBe(true)
+		expect(onCancel).toHaveBeenCalledWith(harness.ctx)
 	})
 
 	it("preserves master behavior by seeding saved config keys as oauth credentials", async () => {

--- a/src/extensions/login/startup-auth.test.ts
+++ b/src/extensions/login/startup-auth.test.ts
@@ -1,0 +1,290 @@
+import { type Theme, initTheme } from "@earendil-works/pi-coding-agent"
+import type { TUI } from "@earendil-works/pi-tui"
+import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest"
+
+const authMock = vi.hoisted(() => ({
+	authenticateViaBrowser: vi.fn(),
+}))
+
+const configMock = vi.hoisted(() => ({
+	loadConfig: vi.fn(),
+	writeApiKey: vi.fn(),
+}))
+
+const modelsMock = vi.hoisted(() => ({
+	updateModelsConfig: vi.fn(),
+	syncProviderModels: vi.fn(),
+}))
+
+vi.mock("../../cli-auth/index.js", () => authMock)
+vi.mock("../../config.js", () => configMock)
+vi.mock("../../models.js", () => modelsMock)
+
+import {
+	type StartupAuthGateState,
+	createStartupAuthGate,
+	createStartupAuthGateState,
+	shouldShowStartupAuthGate,
+} from "./startup-auth.js"
+
+type SessionStartHandler = (event: { reason: string }, ctx: unknown) => unknown
+type CustomComponent = { handleInput?(data: string): void }
+
+function theme(): Theme {
+	return {
+		fg: vi.fn((_color: string, text: string) => text),
+		bg: vi.fn((_color: string, text: string) => text),
+		bold: vi.fn((text: string) => text),
+		getFgAnsi: vi.fn(),
+		getBgAnsi: vi.fn(),
+		fgColors: {},
+		bgColors: {},
+		mode: "dark",
+		preproc: vi.fn(),
+		extensions: {},
+	} as unknown as Theme
+}
+
+function createHarness(
+	options: {
+		state?: StartupAuthGateState
+		availableInitially?: boolean
+		addModelOnAuthSet?: boolean
+		onCancel?: ReturnType<typeof vi.fn>
+		afterSessionStart?: SessionStartHandler
+	} = {},
+) {
+	const handlers = new Map<string, SessionStartHandler[]>()
+	const api = {
+		on: vi.fn((event: string, handler: SessionStartHandler) => {
+			const list = handlers.get(event) ?? []
+			list.push(handler)
+			handlers.set(event, list)
+		}),
+		setModel: vi.fn().mockResolvedValue(true),
+	}
+	const availableModels: Array<{ id: string; provider: string }> = options.availableInitially
+		? [{ id: "kimi-k2.6", provider: "kimchi-dev" }]
+		: []
+	const authStorage = {
+		set: vi.fn((provider: string) => {
+			if (provider === "kimchi-dev" && options.addModelOnAuthSet !== false && availableModels.length === 0) {
+				availableModels.push({ id: "kimi-k2.6", provider: "kimchi-dev" })
+			}
+		}),
+		get: vi.fn(),
+		getOAuthProviders: vi.fn(() => []),
+		login: vi.fn(),
+	}
+	const modelRegistry = {
+		authStorage,
+		refresh: vi.fn(),
+		getAvailable: vi.fn(() => availableModels),
+		getProviderAuthStatus: vi.fn(() => ({ configured: false })),
+	}
+	let activeComponent: CustomComponent | undefined
+	const tui = { requestRender: vi.fn(), hasOverlay: vi.fn(() => false) } as unknown as TUI
+	const ui = {
+		setWidget: vi.fn((_key: string, content: unknown) => {
+			if (typeof content === "function") content(tui, theme())
+		}),
+		onTerminalInput: vi.fn(() => vi.fn()),
+		custom: vi.fn((factory: (...args: unknown[]) => CustomComponent) => {
+			return new Promise((resolve) => {
+				const done = (result: unknown) => {
+					activeComponent = undefined
+					resolve(result)
+				}
+				activeComponent = factory(tui, theme(), {}, done)
+			})
+		}),
+		notify: vi.fn(),
+	}
+	const ctx = { hasUI: true, ui, modelRegistry }
+	const state = options.state ?? createStartupAuthGateState()
+
+	createStartupAuthGate({
+		nonInteractiveMode: false,
+		stdinIsTTY: true,
+		stdoutIsTTY: true,
+		state,
+		onCancel: options.onCancel,
+	})(api as never)
+	if (options.afterSessionStart) api.on("session_start", options.afterSessionStart)
+
+	return {
+		api,
+		ctx,
+		modelRegistry,
+		state,
+		start: async () => {
+			for (const handler of handlers.get("session_start") ?? []) {
+				await handler({ reason: "startup" }, ctx)
+			}
+		},
+		input: (data: string) => activeComponent?.handleInput?.(data),
+		settle: async () => {
+			for (let i = 0; i < 4; i += 1) await Promise.resolve()
+		},
+		waitForCustomPrompts: async (count: number) => {
+			for (let i = 0; i < 50; i += 1) {
+				if (ui.custom.mock.calls.length >= count) return
+				await new Promise((resolve) => setTimeout(resolve, 0))
+			}
+			throw new Error(`Timed out waiting for ${count} auth prompts`)
+		},
+	}
+}
+
+beforeAll(() => {
+	initTheme("default")
+})
+
+beforeEach(() => {
+	authMock.authenticateViaBrowser.mockReset()
+	authMock.authenticateViaBrowser.mockResolvedValue({ token: "kimchi-token" })
+	configMock.loadConfig.mockReset()
+	configMock.loadConfig.mockReturnValue({ apiKey: "" })
+	configMock.writeApiKey.mockReset()
+	modelsMock.updateModelsConfig.mockReset()
+	modelsMock.updateModelsConfig.mockResolvedValue({ models: [] })
+	modelsMock.syncProviderModels.mockReset()
+})
+
+describe("shouldShowStartupAuthGate", () => {
+	it("shows for an unauthenticated interactive startup", () => {
+		expect(
+			shouldShowStartupAuthGate({
+				hasUI: true,
+				stdinIsTTY: true,
+				stdoutIsTTY: true,
+				nonInteractiveMode: false,
+				sessionStartReason: "startup",
+				hasUsableAuth: false,
+			}),
+		).toBe(true)
+	})
+
+	it("skips once usable auth is available", () => {
+		expect(
+			shouldShowStartupAuthGate({
+				hasUI: true,
+				stdinIsTTY: true,
+				stdoutIsTTY: true,
+				nonInteractiveMode: false,
+				sessionStartReason: "startup",
+				hasUsableAuth: true,
+			}),
+		).toBe(false)
+	})
+})
+
+describe("startup auth gate", () => {
+	it("runs the shared Kimchi login option and selects the configured model", async () => {
+		const harness = createHarness()
+		const started = harness.start()
+
+		await harness.settle()
+		harness.input("\n")
+		await started
+
+		expect(authMock.authenticateViaBrowser).toHaveBeenCalledOnce()
+		expect(configMock.writeApiKey).toHaveBeenCalledWith("kimchi-token")
+		expect(harness.modelRegistry.authStorage.set).toHaveBeenCalledWith("kimchi-dev", {
+			type: "api_key",
+			key: "kimchi-token",
+		})
+		expect(harness.api.setModel).toHaveBeenCalledWith({ id: "kimi-k2.6", provider: "kimchi-dev" })
+		expect(harness.state.authenticated).toBe(true)
+	})
+
+	it("does not mint another browser key when a retry still has no available models", async () => {
+		const previousAgentDir = process.env.KIMCHI_CODING_AGENT_DIR
+		process.env.KIMCHI_CODING_AGENT_DIR = "/tmp/kimchi-startup-auth-test"
+		let savedConfigKey = ""
+		configMock.loadConfig.mockImplementation(() => ({ apiKey: savedConfigKey }))
+		configMock.writeApiKey.mockImplementation((key: string) => {
+			savedConfigKey = key
+		})
+		const onCancel = vi.fn()
+		const harness = createHarness({ addModelOnAuthSet: false, onCancel })
+
+		try {
+			const started = harness.start()
+
+			await harness.settle()
+			harness.input("\n")
+			await harness.waitForCustomPrompts(2)
+			harness.input("\n")
+			await harness.waitForCustomPrompts(3)
+			harness.input("\x1b")
+			await started
+
+			expect(authMock.authenticateViaBrowser).toHaveBeenCalledOnce()
+			expect(modelsMock.updateModelsConfig).toHaveBeenCalledTimes(2)
+			expect(modelsMock.updateModelsConfig.mock.calls.map((call) => call[1])).toEqual(["kimchi-token", "kimchi-token"])
+			expect(harness.state.authenticated).toBe(false)
+			expect(harness.state.cancelled).toBe(true)
+		} finally {
+			if (previousAgentDir === undefined) {
+				// biome-ignore lint/performance/noDelete: process.env requires delete operator to be truly unset rather than stringified to "undefined"
+				delete process.env.KIMCHI_CODING_AGENT_DIR
+			} else {
+				process.env.KIMCHI_CODING_AGENT_DIR = previousAgentDir
+			}
+		}
+	})
+
+	it("keeps later startup onboarding parked while authentication is pending", async () => {
+		const laterOnboarding = vi.fn()
+		const onCancel = vi.fn()
+		const harness = createHarness({ afterSessionStart: laterOnboarding, onCancel })
+
+		const started = harness.start()
+
+		await harness.settle()
+		expect(laterOnboarding).not.toHaveBeenCalled()
+
+		harness.input("\x1b")
+		await started
+
+		expect(laterOnboarding).toHaveBeenCalledOnce()
+	})
+
+	it("does not show the selector when auth is already usable", async () => {
+		const harness = createHarness({ availableInitially: true })
+
+		await harness.start()
+
+		expect(harness.ctx.ui.custom).not.toHaveBeenCalled()
+		expect(harness.state.attempted).toBe(false)
+	})
+
+	it("preserves master behavior by seeding saved config keys as oauth credentials", async () => {
+		configMock.loadConfig.mockReturnValue({ apiKey: "saved-config-token" })
+		const harness = createHarness()
+
+		await harness.start()
+
+		expect(harness.modelRegistry.authStorage.set).toHaveBeenCalledWith("kimchi-dev", {
+			type: "oauth",
+			access: "saved-config-token",
+			refresh: "",
+			expires: Number.MAX_SAFE_INTEGER,
+		})
+		expect(harness.ctx.ui.custom).not.toHaveBeenCalled()
+	})
+
+	it("marks cancellation and delegates shutdown behavior to the caller", async () => {
+		const onCancel = vi.fn()
+		const harness = createHarness({ onCancel })
+		const started = harness.start()
+
+		await harness.settle()
+		harness.input("\x1b")
+		await started
+
+		expect(harness.state.cancelled).toBe(true)
+		expect(onCancel).toHaveBeenCalledWith(harness.ctx)
+	})
+})

--- a/src/extensions/login/startup-auth.test.ts
+++ b/src/extensions/login/startup-auth.test.ts
@@ -216,6 +216,29 @@ describe("startup auth gate", () => {
 		expect(harness.state.authenticated).toBe(true)
 	})
 
+	it("surfaces the login URL so it can be copied into the right browser/profile", async () => {
+		const loginUrl = "https://app.kimchi.dev/cli-auth?callback=http%3A%2F%2Flocalhost%3A51234&state=abc123"
+		authMock.authenticateViaBrowser.mockImplementation(async (options: { onBrowserUrl?: (url: string) => void }) => {
+			options?.onBrowserUrl?.(loginUrl)
+			return { token: "kimchi-token" }
+		})
+
+		const harness = createHarness()
+		const started = harness.start()
+
+		await harness.settle()
+		harness.input("\n")
+		await started
+
+		expect(authMock.authenticateViaBrowser).toHaveBeenCalledOnce()
+		// Intact BEL-terminated OSC 8 hyperlink target so "Copy Link" yields the full
+		// URL even when the visible text wraps (a raw wrapped URL would get a newline
+		// injected at the wrap point, corrupting the state param on paste). The `id=`
+		// param groups the wrapped rows so the whole URL highlights as one link.
+		expect(harness.ctx.ui.notify).toHaveBeenCalledWith(expect.stringContaining(`;${loginUrl}\x07`), "info")
+		expect(harness.ctx.ui.notify).toHaveBeenCalledWith(expect.stringContaining("\x1b]8;id=kimchi-login-"), "info")
+	})
+
 	it("does not mint another browser key when a retry still has no available models", async () => {
 		const previousAgentDir = process.env.KIMCHI_CODING_AGENT_DIR
 		process.env.KIMCHI_CODING_AGENT_DIR = "/tmp/kimchi-startup-auth-test"

--- a/src/extensions/login/startup-auth.ts
+++ b/src/extensions/login/startup-auth.ts
@@ -1,0 +1,189 @@
+import type {
+	ExtensionAPI,
+	ExtensionContext,
+	ExtensionFactory,
+	SessionStartEvent,
+} from "@earendil-works/pi-coding-agent"
+import { loadConfig } from "../../config.js"
+import {
+	createLoginChoiceSelector,
+	performKimchiBrowserLogin,
+	setKimchiAuthToken,
+	showSubscriptionLoginWithExtensionUI,
+} from "./flow.js"
+
+const STARTUP_AUTH_OVERLAY_WAIT_KEY = "kimchi-startup-auth-overlay-wait"
+const OVERLAY_WAIT_WIDGET_OPTIONS = { placement: "aboveEditor" } as const
+const SHIM_COMPONENT = { render: () => [], invalidate: () => {} } as const
+
+export interface StartupAuthGateState {
+	attempted: boolean
+	authenticated: boolean
+	cancelled: boolean
+}
+
+export interface StartupAuthGateOptions {
+	nonInteractiveMode: boolean
+	stdinIsTTY: boolean
+	stdoutIsTTY: boolean
+	state?: StartupAuthGateState
+	onCancel?: (ctx: ExtensionContext) => void | Promise<void>
+}
+
+export function createStartupAuthGateState(): StartupAuthGateState {
+	return { attempted: false, authenticated: false, cancelled: false }
+}
+
+export function shouldShowStartupAuthGate(input: {
+	hasUI: boolean
+	stdinIsTTY: boolean
+	stdoutIsTTY: boolean
+	nonInteractiveMode: boolean
+	sessionStartReason?: SessionStartEvent["reason"]
+	hasUsableAuth: boolean
+}): boolean {
+	if (input.sessionStartReason !== undefined && input.sessionStartReason !== "startup") {
+		return false
+	}
+	if (!input.hasUI || !input.stdinIsTTY || !input.stdoutIsTTY) {
+		return false
+	}
+	if (input.nonInteractiveMode) return false
+	if (input.hasUsableAuth) return false
+	return true
+}
+
+export function seedKimchiAuthFromConfig(ctx: ExtensionContext): void {
+	const configKey = loadConfig().apiKey
+	if (!configKey) return
+	setKimchiAuthToken(ctx.modelRegistry, configKey, "oauth")
+}
+
+export function hasUsableAuth(ctx: ExtensionContext): boolean {
+	seedKimchiAuthFromConfig(ctx)
+	try {
+		ctx.modelRegistry.refresh()
+	} catch {
+		// Broken models.json is reported by upstream startup warnings. Treat it
+		// as unauthenticated here so the user gets a login path instead of Ferment.
+	}
+	try {
+		return ctx.modelRegistry.getAvailable().length > 0
+	} catch {
+		return false
+	}
+}
+
+async function waitForOverlayClear(ctx: ExtensionContext): Promise<void> {
+	let tuiRef: { hasOverlay?: () => boolean } | undefined
+	let unsubscribeInput: (() => void) | undefined
+
+	return new Promise((resolve) => {
+		let done = false
+		const cleanup = () => {
+			ctx.ui.setWidget(STARTUP_AUTH_OVERLAY_WAIT_KEY, undefined, OVERLAY_WAIT_WIDGET_OPTIONS)
+			unsubscribeInput?.()
+			unsubscribeInput = undefined
+		}
+		const tryResolve = () => {
+			if (done || !tuiRef) return
+			if (typeof tuiRef.hasOverlay === "function" && tuiRef.hasOverlay()) return
+			done = true
+			cleanup()
+			resolve()
+		}
+
+		ctx.ui.setWidget(
+			STARTUP_AUTH_OVERLAY_WAIT_KEY,
+			(tui) => {
+				tuiRef = tui as unknown as { hasOverlay?: () => boolean }
+				queueMicrotask(tryResolve)
+				return SHIM_COMPONENT
+			},
+			OVERLAY_WAIT_WIDGET_OPTIONS,
+		)
+		unsubscribeInput = ctx.ui.onTerminalInput(() => {
+			setTimeout(tryResolve, 0)
+			return undefined
+		})
+	})
+}
+
+async function promptAuthChoice(ctx: ExtensionContext): Promise<"kimchi" | "subscription" | undefined> {
+	await waitForOverlayClear(ctx)
+	return ctx.ui.custom<"kimchi" | "subscription" | undefined>((_tui, _theme, _keybindings, done) => {
+		const selector = createLoginChoiceSelector({
+			onKimchiAccount: () => done("kimchi"),
+			onSubscription: () => done("subscription"),
+			onCancel: () => done(undefined),
+		})
+		return selector
+	})
+}
+
+function defaultCancel(ctx: ExtensionContext): Promise<never> {
+	ctx.ui.notify("Login cancelled. Run `kimchi login` or `kimchi setup` to authenticate.", "warning")
+	ctx.shutdown()
+	// Keep session_start from falling through to the unauthenticated editor while
+	// interactive shutdown drains input, stops the TUI, and exits the process.
+	return new Promise<never>(() => {})
+}
+
+async function runStartupAuthGate(
+	pi: ExtensionAPI,
+	ctx: ExtensionContext,
+	state: StartupAuthGateState,
+	options: StartupAuthGateOptions,
+): Promise<void> {
+	state.attempted = true
+
+	for (;;) {
+		const choice = await promptAuthChoice(ctx)
+		if (!choice) {
+			state.cancelled = true
+			await (options.onCancel ?? defaultCancel)(ctx)
+			return
+		}
+
+		const success =
+			choice === "kimchi"
+				? await performKimchiBrowserLogin({
+						modelRegistry: ctx.modelRegistry,
+						setModel: (model) => pi.setModel(model as Parameters<typeof pi.setModel>[0]),
+						showStatus: (message) => ctx.ui.notify(message, "info"),
+						showError: (message) => ctx.ui.notify(message, "error"),
+						addFeedback: (message) => ctx.ui.notify(message, "info"),
+					})
+				: await showSubscriptionLoginWithExtensionUI(ctx, (model) => pi.setModel(model))
+
+		if (success && hasUsableAuth(ctx)) {
+			state.authenticated = true
+			return
+		}
+
+		ctx.ui.notify("Login did not configure an available model. Try again or cancel.", "warning")
+	}
+}
+
+export function createStartupAuthGate(options: StartupAuthGateOptions): ExtensionFactory {
+	const state = options.state ?? createStartupAuthGateState()
+
+	return (pi: ExtensionAPI) => {
+		pi.on("session_start", async (event, ctx) => {
+			if (
+				!shouldShowStartupAuthGate({
+					hasUI: ctx.hasUI,
+					stdinIsTTY: options.stdinIsTTY,
+					stdoutIsTTY: options.stdoutIsTTY,
+					nonInteractiveMode: options.nonInteractiveMode,
+					sessionStartReason: event.reason,
+					hasUsableAuth: hasUsableAuth(ctx),
+				})
+			) {
+				return
+			}
+
+			await runStartupAuthGate(pi, ctx, state, options)
+		})
+	}
+}

--- a/src/extensions/login/startup-auth.ts
+++ b/src/extensions/login/startup-auth.ts
@@ -6,6 +6,7 @@ import type {
 } from "@earendil-works/pi-coding-agent"
 import { loadConfig } from "../../config.js"
 import {
+	KIMCHI_PROVIDER_ID,
 	createLoginChoiceSelector,
 	performKimchiBrowserLogin,
 	setKimchiAuthToken,
@@ -54,13 +55,19 @@ export function shouldShowStartupAuthGate(input: {
 }
 
 export function seedKimchiAuthFromConfig(ctx: ExtensionContext): void {
+	seedKimchiAuthFromConfigAndReturnKey(ctx)
+}
+
+function seedKimchiAuthFromConfigAndReturnKey(ctx: ExtensionContext): string {
 	const configKey = loadConfig().apiKey
-	if (!configKey) return
-	setKimchiAuthToken(ctx.modelRegistry, configKey, "oauth")
+	if (configKey) {
+		setKimchiAuthToken(ctx.modelRegistry, configKey, "oauth")
+	}
+	return configKey
 }
 
 export function hasUsableAuth(ctx: ExtensionContext): boolean {
-	seedKimchiAuthFromConfig(ctx)
+	const configKey = seedKimchiAuthFromConfigAndReturnKey(ctx)
 	try {
 		ctx.modelRegistry.refresh()
 	} catch {
@@ -68,7 +75,10 @@ export function hasUsableAuth(ctx: ExtensionContext): boolean {
 		// as unauthenticated here so the user gets a login path instead of Ferment.
 	}
 	try {
-		return ctx.modelRegistry.getAvailable().length > 0
+		const availableModels = ctx.modelRegistry.getAvailable()
+		if (availableModels.length === 0) return false
+		if (availableModels.some((model) => model.provider !== KIMCHI_PROVIDER_ID)) return true
+		return configKey.length > 0
 	} catch {
 		return false
 	}

--- a/src/extensions/login/startup-auth.ts
+++ b/src/extensions/login/startup-auth.ts
@@ -8,8 +8,7 @@ import { loadConfig } from "../../config.js"
 import {
 	KIMCHI_PROVIDER_ID,
 	createLoginChoiceSelector,
-	formatBrowserLoginMessage,
-	performKimchiBrowserLogin,
+	performKimchiBrowserLoginWithDialog,
 	setKimchiAuthToken,
 	showSubscriptionLoginWithExtensionUI,
 } from "./flow.js"
@@ -156,21 +155,18 @@ async function runStartupAuthGate(
 			return
 		}
 
-		const success =
+		const result =
 			choice === "kimchi"
-				? await performKimchiBrowserLogin({
-						modelRegistry: ctx.modelRegistry,
-						setModel: (model) => pi.setModel(model as Parameters<typeof pi.setModel>[0]),
-						showStatus: (message) => ctx.ui.notify(message, "info"),
-						showError: (message) => ctx.ui.notify(message, "error"),
-						addFeedback: (message) => ctx.ui.notify(message, "info"),
-						// Surface the generated browser-login URL so the user can copy it into the
-						// right browser/profile when auto-open picks the wrong one but still succeeds.
-						onBrowserUrl: (url) => ctx.ui.notify(formatBrowserLoginMessage(url), "info"),
-					})
-				: await showSubscriptionLoginWithExtensionUI(ctx, (model) => pi.setModel(model))
+				? await performKimchiBrowserLoginWithDialog(ctx, (model) =>
+						pi.setModel(model as Parameters<typeof pi.setModel>[0]),
+					)
+				: (await showSubscriptionLoginWithExtensionUI(ctx, (model) => pi.setModel(model)))
+					? "success"
+					: "failed"
 
-		if (success && hasUsableAuth(ctx)) {
+		if (result === "cancelled") continue
+
+		if (result === "success" && hasUsableAuth(ctx)) {
 			state.authenticated = true
 			return
 		}

--- a/src/extensions/login/startup-auth.ts
+++ b/src/extensions/login/startup-auth.ts
@@ -8,6 +8,7 @@ import { loadConfig } from "../../config.js"
 import {
 	KIMCHI_PROVIDER_ID,
 	createLoginChoiceSelector,
+	formatBrowserLoginMessage,
 	performKimchiBrowserLogin,
 	setKimchiAuthToken,
 	showSubscriptionLoginWithExtensionUI,
@@ -163,6 +164,9 @@ async function runStartupAuthGate(
 						showStatus: (message) => ctx.ui.notify(message, "info"),
 						showError: (message) => ctx.ui.notify(message, "error"),
 						addFeedback: (message) => ctx.ui.notify(message, "info"),
+						// Surface the generated browser-login URL so the user can copy it into the
+						// right browser/profile when auto-open picks the wrong one but still succeeds.
+						onBrowserUrl: (url) => ctx.ui.notify(formatBrowserLoginMessage(url), "info"),
 					})
 				: await showSubscriptionLoginWithExtensionUI(ctx, (model) => pi.setModel(model))
 

--- a/src/extensions/onboarding/session-mode-startup.ts
+++ b/src/extensions/onboarding/session-mode-startup.ts
@@ -9,6 +9,7 @@ export interface SessionModeStartupOptions {
 	stdoutIsTTY: boolean
 	configPath?: string
 	now?: () => Date
+	shouldSkip?: () => boolean
 	startFerment?: (params: { pi: ExtensionAPI; ctx: ExtensionContext }) => void | Promise<void>
 }
 
@@ -27,6 +28,7 @@ export function createSessionModeOnboardingForStartup(options: SessionModeStartu
 		}),
 		configPath: options.configPath,
 		now: options.now,
+		shouldSkip: options.shouldSkip,
 		onOutcome: (outcome, ctx, pi) => {
 			if (outcome === "ferment") return startFerment({ pi, ctx })
 		},

--- a/src/extensions/onboarding/session-mode.test.ts
+++ b/src/extensions/onboarding/session-mode.test.ts
@@ -273,6 +273,18 @@ describe("session-mode onboarding persistence", () => {
 		expect(raw.onboarding.sessionModeWizardSeenAt).toBe("2026-05-19T09:30:00.000Z")
 	})
 
+	it("does not mount or mark seen while a startup prerequisite suppresses onboarding", async () => {
+		const harness = createExtensionHarness()
+		sessionModeOnboardingExtension({ launchContext: launch([]), configPath, now, shouldSkip: () => true })(
+			harness.api as unknown as Parameters<ReturnType<typeof sessionModeOnboardingExtension>>[0],
+		)
+
+		await harness.start()
+
+		expect(harness.ui.setWidget).not.toHaveBeenCalled()
+		expect(existsSync(configPath)).toBe(false)
+	})
+
 	it("extension mounts the picker and records Default selection", async () => {
 		const harness = createExtensionHarness()
 

--- a/src/extensions/onboarding/session-mode.ts
+++ b/src/extensions/onboarding/session-mode.ts
@@ -67,6 +67,7 @@ export interface SessionModeOnboardingExtensionOptions {
 	launchContext: SessionModeLaunchContext
 	configPath?: string
 	now?: () => Date
+	shouldSkip?: () => boolean
 	onOutcome?: (
 		outcome: Extract<SessionModeWizardOutcome, "default" | "ferment">,
 		ctx: ExtensionContext,
@@ -81,6 +82,7 @@ export default function sessionModeOnboardingExtension(options: SessionModeOnboa
 		pi.on("session_start", (event, ctx) => {
 			cleanupActiveWizard?.()
 			cleanupActiveWizard = undefined
+			if (options.shouldSkip?.()) return
 			const seenAt = readSessionModeWizardSeenAt(options.configPath)
 			const decision = decideSessionModeOnboarding({
 				launchContext: options.launchContext,

--- a/src/extensions/prompt-construction/prompt-enrichment.test.ts
+++ b/src/extensions/prompt-construction/prompt-enrichment.test.ts
@@ -1,6 +1,7 @@
 import type { AssistantMessage, ToolResultMessage } from "@earendil-works/pi-ai"
 import type { ExtensionAPI, ToolInfo } from "@earendil-works/pi-coding-agent"
 import { beforeEach, describe, expect, it, vi } from "vitest"
+import * as config from "../../config.js"
 import type { ModelMetadata } from "../../models.js"
 import * as startupContext from "../../startup-context.js"
 import * as agentWorkerContext from "../agent-worker-context.js"
@@ -249,6 +250,77 @@ describe("prompt enrichment tool visibility", () => {
 
 		expect(result.systemPrompt).toContain('<tool name="read">')
 		expect(result.systemPrompt).not.toContain('<tool name="bash">')
+	})
+})
+
+describe("model role startup warnings", () => {
+	beforeEach(() => {
+		vi.restoreAllMocks()
+	})
+
+	function modelMetadata(slug: string): ModelMetadata {
+		return {
+			slug,
+			display_name: slug,
+			provider: "kimchi-dev",
+			reasoning: false,
+			input_modalities: ["text"],
+			is_serverless: true,
+			limits: { context_window: 128000, max_output_tokens: 8192 },
+		}
+	}
+
+	it("does not print unavailable role warnings when no models are available yet", () => {
+		vi.spyOn(startupContext, "getAvailableModels").mockReturnValue([])
+		const warn = vi.spyOn(console, "warn").mockImplementation(() => {})
+		const pi = {
+			registerFlag: () => {},
+			registerCommand: () => {},
+			on: () => {},
+			getAllTools: () => [],
+			getActiveTools: () => [],
+			getFlag: () => false,
+		} as unknown as ExtensionAPI
+
+		promptEnrichmentExtension([])(pi)
+
+		expect(warn).not.toHaveBeenCalledWith(expect.stringContaining("[model-roles] Warning:"))
+	})
+
+	it("does not print unavailable role warnings from cached metadata before auth is configured", () => {
+		vi.spyOn(config, "loadConfig").mockReturnValue({ apiKey: "" } as ReturnType<typeof config.loadConfig>)
+		vi.spyOn(startupContext, "getAvailableModels").mockReturnValue([modelMetadata("cached-model")])
+		const warn = vi.spyOn(console, "warn").mockImplementation(() => {})
+		const pi = {
+			registerFlag: () => {},
+			registerCommand: () => {},
+			on: () => {},
+			getAllTools: () => [],
+			getActiveTools: () => [],
+			getFlag: () => false,
+		} as unknown as ExtensionAPI
+
+		promptEnrichmentExtension([])(pi)
+
+		expect(warn).not.toHaveBeenCalledWith(expect.stringContaining("[model-roles] Warning:"))
+	})
+
+	it("keeps unavailable role warnings when Kimchi auth is already configured", () => {
+		vi.spyOn(config, "loadConfig").mockReturnValue({ apiKey: "test-key" } as ReturnType<typeof config.loadConfig>)
+		vi.spyOn(startupContext, "getAvailableModels").mockReturnValue([modelMetadata("different-model")])
+		const warn = vi.spyOn(console, "warn").mockImplementation(() => {})
+		const pi = {
+			registerFlag: () => {},
+			registerCommand: () => {},
+			on: () => {},
+			getAllTools: () => [],
+			getActiveTools: () => [],
+			getFlag: () => false,
+		} as unknown as ExtensionAPI
+
+		promptEnrichmentExtension([])(pi)
+
+		expect(warn).toHaveBeenCalledWith(expect.stringContaining("[model-roles] Warning: orchestrator"))
 	})
 })
 

--- a/src/extensions/prompt-construction/prompt-enrichment.ts
+++ b/src/extensions/prompt-construction/prompt-enrichment.ts
@@ -27,6 +27,7 @@ import { homedir, platform, userInfo } from "node:os"
 import { isAbsolute, join, normalize, resolve } from "node:path"
 import type { AssistantMessage } from "@earendil-works/pi-ai"
 import { type ExtensionAPI, type Skill, getAgentDir, loadSkills } from "@earendil-works/pi-coding-agent"
+import { loadConfig } from "../../config.js"
 import { getAvailableModels } from "../../startup-context.js"
 import { getGitBranch } from "../../utils.js"
 import { isAgentWorker } from "../agent-worker-context.js"
@@ -278,13 +279,18 @@ export default function (skillPaths: string[]) {
 		}
 
 		if (!subagentMode) {
-			// Validate model roles against available API models at startup
+			// Validate model roles against available API models at startup.
+			// Cached model metadata can exist before auth is configured; in that
+			// state startup auth owns the first-run login path, so role warnings
+			// would be misleading noise before the user has a usable model.
 			const availableIds = new Set(getAvailableModels().map((m) => m.slug))
-			const validation = validateModelRoles(getModelRoles(), availableIds)
-			for (const { role, configuredModel } of validation.unavailable) {
-				console.warn(
-					`[model-roles] Warning: ${role} model "${configuredModel}" is not available. Subagents for this role will fall back to the parent model.`,
-				)
+			if (loadConfig().apiKey && availableIds.size > 0) {
+				const validation = validateModelRoles(getModelRoles(), availableIds)
+				for (const { role, configuredModel } of validation.unavailable) {
+					console.warn(
+						`[model-roles] Warning: ${role} model "${configuredModel}" is not available. Subagents for this role will fall back to the parent model.`,
+					)
+				}
 			}
 			function notifyIfDeprecated(ctx: {
 				sessionManager?: { getSessionId: () => string | undefined }

--- a/src/extensions/ui.ts
+++ b/src/extensions/ui.ts
@@ -39,6 +39,19 @@ function modelsAreEqual(a: Model<Api>, b: Model<Api>): boolean {
 	return a.provider === b.provider && a.id === b.id
 }
 
+// True when `data` is a terminal *response* to a query rather than a user
+// keypress: OSC color reports (ESC ] … BEL/ST), DCS replies (ESC P … ST),
+// primary device-attributes / kitty-keyboard replies (ESC [ ? … c|u), and
+// cursor-position reports (ESC [ row;col R). Terminals such as iTerm2 and
+// Ghostty emit these unbidden right after startup (answering our OSC 10/11
+// background/foreground probes), so any "dismiss on any key" handler must skip
+// them or it fires before the user ever sees the prompt.
+// biome-ignore lint/suspicious/noControlCharactersInRegex: matching raw terminal escape sequences
+const TERMINAL_RESPONSE_RE = /^\x1b(?:[\]P]|\[\?[0-9;]*[cu]|\[[0-9;]*R)/
+function isTerminalResponse(data: string): boolean {
+	return TERMINAL_RESPONSE_RE.test(data)
+}
+
 /** Reason a model was skipped during ctrl+p cycle. */
 export interface SkippedModel {
 	model: Model<Api>
@@ -350,6 +363,12 @@ export default function uiExtension(pi: ExtensionAPI) {
 										},
 										invalidate() {},
 										handleInput(data: string): void {
+											// Ignore terminal query responses (OSC color reports, DCS, primary
+											// device-attributes, kitty-keyboard and cursor-position replies). These
+											// arrive on stdin moments after the overlay opens — e.g. iTerm/Ghostty
+											// answering kimchi's OSC 10/11 color probe — and must NOT count as the
+											// "any key" dismissal, or the hint is torn down before it ever renders.
+											if (isTerminalResponse(data)) return
 											if (data === "d") {
 												try {
 													const s: Record<string, unknown> = {}

--- a/src/login-command-patch.test.ts
+++ b/src/login-command-patch.test.ts
@@ -6,7 +6,7 @@ import * as configModule from "./config.js"
 import * as loginPatch from "./login-command-patch.js"
 import * as modelsModule from "./models.js"
 
-const { applyLoginCommandPatch, oauthDelegate } = loginPatch
+const { applyLoginCommandPatch, oauthDelegate, warningDelegate } = loginPatch
 
 vi.mock("@earendil-works/pi-ai", async () => {
 	const actual = await vi.importActual("@earendil-works/pi-ai")
@@ -362,5 +362,42 @@ it("passes through to original showOAuthSelector for 'logout' mode", async () =>
 		expect(stub).toHaveBeenCalledWith("logout")
 	} finally {
 		oauthDelegate.original = saved
+	}
+})
+
+it("suppresses stale startup no-model warning after startup auth selected a model", () => {
+	const stub = vi.fn()
+	const saved = warningDelegate.original
+	warningDelegate.original = stub
+
+	try {
+		const fakeIm = makeFakeInteractiveMode(makeFakeModelRegistry())
+		fakeIm.session.model = { id: "kimi-k2.6", provider: "kimchi-dev" }
+
+		// biome-ignore lint/suspicious/noExplicitAny: not present in public type
+		const patched = (InteractiveMode.prototype as any).showWarning
+		patched.call(fakeIm, "No models available. Use /login to log into a provider via OAuth or API key.")
+
+		expect(stub).not.toHaveBeenCalled()
+	} finally {
+		warningDelegate.original = saved
+	}
+})
+
+it("keeps real no-model warnings when no model became available", () => {
+	const stub = vi.fn()
+	const saved = warningDelegate.original
+	warningDelegate.original = stub
+
+	try {
+		const fakeIm = makeFakeInteractiveMode(makeFakeModelRegistry())
+
+		// biome-ignore lint/suspicious/noExplicitAny: not present in public type
+		const patched = (InteractiveMode.prototype as any).showWarning
+		patched.call(fakeIm, "No models available. Use /login to log into a provider via OAuth or API key.")
+
+		expect(stub).toHaveBeenCalledOnce()
+	} finally {
+		warningDelegate.original = saved
 	}
 })

--- a/src/login-command-patch.test.ts
+++ b/src/login-command-patch.test.ts
@@ -2,7 +2,9 @@ import { getModels } from "@earendil-works/pi-ai"
 import { InteractiveMode, initTheme } from "@earendil-works/pi-coding-agent"
 import { Text } from "@earendil-works/pi-tui"
 import { afterEach, beforeAll, beforeEach, expect, it, vi } from "vitest"
+import * as configModule from "./config.js"
 import * as loginPatch from "./login-command-patch.js"
+import * as modelsModule from "./models.js"
 
 const { applyLoginCommandPatch, oauthDelegate } = loginPatch
 
@@ -22,6 +24,10 @@ let originalCodingAgentDir: string | undefined
 
 beforeEach(() => {
 	originalCodingAgentDir = process.env.KIMCHI_CODING_AGENT_DIR
+	// Auth tests should be independent of the developer machine's real config.
+	vi.spyOn(configModule, "loadConfig").mockReturnValue({ apiKey: "" } as ReturnType<typeof configModule.loadConfig>)
+	vi.spyOn(configModule, "writeApiKey").mockImplementation(() => {})
+	vi.spyOn(modelsModule, "updateModelsConfig").mockResolvedValue({ models: [] })
 })
 
 afterEach(() => {
@@ -119,8 +125,6 @@ async function selectSubscriptionLoginOption(fakeIm: FakeIm): Promise<void> {
 it("intercepts showOAuthSelector('login') and runs Kimchi browser auth", async () => {
 	const cliAuthModule = await import("./cli-auth/index.js")
 	const authSpy = vi.spyOn(cliAuthModule, "authenticateViaBrowser").mockResolvedValue({ token: "test-token-123" })
-	const configModule = await import("./config.js")
-	vi.spyOn(configModule, "writeApiKey").mockImplementation(() => {})
 
 	const registry = makeFakeModelRegistry()
 	registry.getAvailable.mockReturnValue([{ id: "kimi-k2.6", provider: "kimchi-dev" }])
@@ -151,8 +155,6 @@ it("falls back to the first available model when the default is not present", as
 	vi.spyOn(cliAuthModule, "authenticateViaBrowser").mockResolvedValue({
 		token: "test-token-456",
 	})
-	const configModule = await import("./config.js")
-	vi.spyOn(configModule, "writeApiKey").mockImplementation(() => {})
 
 	const registry = makeFakeModelRegistry()
 	registry.getAvailable.mockReturnValue([{ id: "other-model", provider: "kimchi-dev" }])
@@ -170,13 +172,11 @@ it("falls back to the first available model when the default is not present", as
 	expect(getFeedbackMessages(fakeIm)).toContain("✓ Logged in. Model: other-model")
 })
 
-it("shows generic success when no models are available for the provider", async () => {
+it("reports failure when no models are available for the provider", async () => {
 	const cliAuthModule = await import("./cli-auth/index.js")
 	vi.spyOn(cliAuthModule, "authenticateViaBrowser").mockResolvedValue({
 		token: "test-token-789",
 	})
-	const configModule = await import("./config.js")
-	vi.spyOn(configModule, "writeApiKey").mockImplementation(() => {})
 
 	const registry = makeFakeModelRegistry()
 	registry.getAvailable.mockReturnValue([])
@@ -187,7 +187,10 @@ it("shows generic success when no models are available for the provider", async 
 	await patched.call(fakeIm, "login")
 	await selectCurrentLoginOption(fakeIm)
 
-	expect(getFeedbackMessages(fakeIm)).toContain("✓ Login successful. API key saved.")
+	expect(fakeIm.showError).toHaveBeenCalledWith(
+		"Kimchi login did not configure any available models. Your API key was saved; try again.",
+	)
+	expect(getFeedbackMessages(fakeIm)).not.toContain("✓ Login successful. API key saved.")
 	expect(fakeIm.session.setModel).not.toHaveBeenCalled()
 })
 

--- a/src/login-command-patch.test.ts
+++ b/src/login-command-patch.test.ts
@@ -150,6 +150,32 @@ it("intercepts showOAuthSelector('login') and runs Kimchi browser auth", async (
 	expect(getFeedbackMessages(fakeIm)).toContain("✓ Logged in. Model: kimi-k2.6")
 })
 
+it("surfaces the login URL in the TUI so it can be copied into the right browser/profile", async () => {
+	const loginUrl = "https://app.kimchi.dev/cli-auth?callback=http%3A%2F%2Flocalhost%3A51234&state=abc123"
+	const cliAuthModule = await import("./cli-auth/index.js")
+	vi.spyOn(cliAuthModule, "authenticateViaBrowser").mockImplementation(async (options) => {
+		options?.onBrowserUrl?.(loginUrl)
+		return { token: "test-token-url" }
+	})
+
+	const registry = makeFakeModelRegistry()
+	registry.getAvailable.mockReturnValue([{ id: "kimi-k2.6", provider: "kimchi-dev" }])
+
+	const fakeIm = makeFakeInteractiveMode(registry)
+	// biome-ignore lint/suspicious/noExplicitAny: not present in public type
+	const patched = (InteractiveMode.prototype as any).showOAuthSelector
+	await patched.call(fakeIm, "login")
+	await selectCurrentLoginOption(fakeIm)
+
+	// Must be an intact OSC 8 hyperlink target (BEL-terminated, like upstream
+	// showAuth) so "Copy Link" yields the full URL even when the visible text
+	// wraps; a raw wrapped URL injects a newline that corrupts the state param.
+	// The `id=` param groups the wrapped rows so the whole URL highlights as one link.
+	const msg = getFeedbackMessages(fakeIm).find((m) => m.includes(`;${loginUrl}\x07`))
+	expect(msg).toBeDefined()
+	expect(msg).toContain("\x1b]8;id=kimchi-login-")
+})
+
 it("falls back to the first available model when the default is not present", async () => {
 	const cliAuthModule = await import("./cli-auth/index.js")
 	vi.spyOn(cliAuthModule, "authenticateViaBrowser").mockResolvedValue({

--- a/src/login-command-patch.test.ts
+++ b/src/login-command-patch.test.ts
@@ -150,6 +150,36 @@ it("intercepts showOAuthSelector('login') and runs Kimchi browser auth", async (
 	expect(getFeedbackMessages(fakeIm)).toContain("✓ Logged in. Model: kimi-k2.6")
 })
 
+it("does not reuse a saved Kimchi key for explicit /login", async () => {
+	vi.mocked(configModule.loadConfig).mockReturnValue({
+		apiKey: "stale-saved-token",
+	} as ReturnType<typeof configModule.loadConfig>)
+	const cliAuthModule = await import("./cli-auth/index.js")
+	const authSpy = vi.spyOn(cliAuthModule, "authenticateViaBrowser").mockResolvedValue({ token: "fresh-token" })
+
+	const registry = makeFakeModelRegistry()
+	registry.getAvailable.mockReturnValue([{ id: "kimi-k2.6", provider: "kimchi-dev" }])
+
+	const fakeIm = makeFakeInteractiveMode(registry)
+	// biome-ignore lint/suspicious/noExplicitAny: not present in public type
+	const patched = (InteractiveMode.prototype as any).showOAuthSelector
+	await patched.call(fakeIm, "login")
+	await selectCurrentLoginOption(fakeIm)
+
+	expect(authSpy).toHaveBeenCalledOnce()
+	expect(fakeIm.showStatus).toHaveBeenCalledWith("Opening browser for Kimchi login...")
+	expect(fakeIm.showStatus).not.toHaveBeenCalledWith("Refreshing Kimchi models with existing login...")
+	expect(configModule.writeApiKey).toHaveBeenCalledWith("fresh-token")
+	expect(registry.authStorage.set).toHaveBeenCalledWith("kimchi-dev", {
+		type: "api_key",
+		key: "fresh-token",
+	})
+	expect(fakeIm.session.setModel).toHaveBeenCalledWith({
+		id: "kimi-k2.6",
+		provider: "kimchi-dev",
+	})
+})
+
 it("surfaces the login URL in the TUI so it can be copied into the right browser/profile", async () => {
 	const loginUrl = "https://app.kimchi.dev/cli-auth?callback=http%3A%2F%2Flocalhost%3A51234&state=abc123"
 	const cliAuthModule = await import("./cli-auth/index.js")

--- a/src/login-command-patch.ts
+++ b/src/login-command-patch.ts
@@ -98,9 +98,15 @@ export const oauthDelegate = {
 	original: imProto.showOAuthSelector as (this: any, mode: "login" | "logout") => Promise<void>,
 }
 
+export const warningDelegate = {
+	// biome-ignore lint/suspicious/noExplicitAny: `this` context type for upstream prototype method is unknown
+	original: imProto.showWarning as (this: any, warningMessage: string) => void,
+}
+
 /** Exported for testing: applies the prototype patch (idempotent re-apply is safe). */
 export function applyLoginCommandPatch(): void {
 	imProto.showOAuthSelector = patchedShowOAuthSelector
+	imProto.showWarning = patchedShowWarning
 }
 
 async function handleKimchiLogin(im: InteractiveMode): Promise<void> {
@@ -218,6 +224,25 @@ async function patchedShowOAuthSelector(this: InteractiveMode, mode: "login" | "
 		return
 	}
 	return oauthDelegate.original.call(this, mode)
+}
+
+function patchedShowWarning(this: InteractiveMode, warningMessage: string): void {
+	if (warningMessage.startsWith("No models available.") && hasModelsAfterStartupAuth(this)) {
+		return
+	}
+	warningDelegate.original.call(this, warningMessage)
+}
+
+function hasModelsAfterStartupAuth(im: InteractiveMode): boolean {
+	const modeLike = im as unknown as {
+		session?: { model?: unknown; modelRegistry?: { getAvailable?: () => unknown[] } }
+	}
+	if (modeLike.session?.model) return true
+	try {
+		return (modeLike.session?.modelRegistry?.getAvailable?.().length ?? 0) > 0
+	} catch {
+		return false
+	}
 }
 
 // Apply patch on module load

--- a/src/login-command-patch.ts
+++ b/src/login-command-patch.ts
@@ -6,78 +6,14 @@
  * `InteractiveMode` instance is constructed so the prototype patch takes effect.
  */
 
-import { existsSync, readFileSync, writeFileSync } from "node:fs"
-import { resolve } from "node:path"
-import type { Api, Model } from "@earendil-works/pi-ai"
-import {
-	type AuthStatus,
-	ExtensionSelectorComponent,
-	InteractiveMode,
-	OAuthSelectorComponent,
-} from "@earendil-works/pi-coding-agent"
+import { type AuthStatus, InteractiveMode, OAuthSelectorComponent } from "@earendil-works/pi-coding-agent"
 import { Spacer, Text } from "@earendil-works/pi-tui"
-import { authenticateViaBrowser } from "./cli-auth/index.js"
-import { writeApiKey } from "./config.js"
-import type { PiModelConfig } from "./models.js"
-import { syncProviderModels } from "./models.js"
-
-const getPiModels = async () => {
-	const piAi = await import("@earendil-works/pi-ai")
-	return piAi.getModels
-}
-
-const KIMCHI_PROVIDER_ID = "kimchi-dev"
-const KIMCHI_DEFAULT_MODEL_ID = "kimi-k2.6"
-/**
- * Convert upstream Model to Kimchi PiModelConfig so we can persist subscription
- * provider models in Kimchi's models.json.
- */
-function upstreamModelToPiConfig(m: Model<Api>, providerId: string) {
-	return {
-		id: m.id,
-		name: m.name,
-		api: m.api,
-		baseUrl: m.baseUrl,
-		reasoning: m.reasoning,
-		input: m.input,
-		contextWindow: m.contextWindow,
-		maxTokens: m.maxTokens,
-		cost: m.cost,
-		provider: providerId,
-		compat: m.compat,
-	}
-}
-
-/**
- * Pre-populate models.json with the subscription provider's built-in models.
- * This is necessary because `KIMCHI_DISABLE_BUILTIN_PROVIDERS` filters them
- * out of loadBuiltInModels(), so the only way upstream discovers them is
- * through models.json. Writing them before showLoginDialog ensures
- * completeProviderAuthentication() → refresh() sees them while auth is
- * already configured.
- */
-async function prePopulateSubscriptionModels(providerId: string): Promise<void> {
-	const getModels = await getPiModels()
-	const piModels = getModels?.(providerId as unknown as Parameters<typeof getModels>[0]) ?? []
-	if (piModels.length === 0) return
-
-	const agentDir = process.env.KIMCHI_CODING_AGENT_DIR
-	if (!agentDir) {
-		console.warn("KIMCHI_CODING_AGENT_DIR environment variable is missing. Models cannot be cached.")
-		return
-	}
-
-	const modelsJsonPath = resolve(agentDir, "models.json")
-	const configs = piModels.map((m) => upstreamModelToPiConfig(m, providerId))
-	const firstModel = piModels[0]
-	syncProviderModels(modelsJsonPath, providerId, configs as PiModelConfig[], {
-		api: firstModel.api,
-		baseUrl: firstModel.baseUrl,
-	})
-}
-
-const KIMCHI_ACCOUNT_LABEL = "Use a Kimchi account"
-const SUBSCRIPTION_LABEL = "Use a subscription"
+import {
+	KIMCHI_PROVIDER_ID,
+	createLoginChoiceSelector,
+	performKimchiBrowserLogin,
+	prePopulateSubscriptionModels,
+} from "./extensions/login/flow.js"
 
 // ---------------------------------------------------------------------------
 // Intercept the upstream login flow to add the Kimchi browser auth choice
@@ -171,48 +107,20 @@ async function handleKimchiLogin(im: InteractiveMode): Promise<void> {
 	const modeLike = im as unknown as { showStatus?: (msg: string) => void; session: SessionLike }
 	const showStatus = modeLike.showStatus?.bind(modeLike)
 	const showError = im.showError.bind(im)
-
-	let browserUrl: string | undefined
-	try {
-		showStatus?.("Opening browser for Kimchi login...")
-
-		const { token } = await authenticateViaBrowser({
-			onBrowserUrl: (url) => {
-				browserUrl = url
-			},
-		})
-
-		// Persist to Kimchi config
-		writeApiKey(token)
-
-		// Update the running session's auth storage
-		const session = modeLike.session
-		const registry = session?.modelRegistry
-		if (registry) {
-			registry.authStorage.set(KIMCHI_PROVIDER_ID, {
-				type: "api_key",
-				key: token,
-			})
-			registry.refresh()
-
-			const availableModels = registry.getAvailable()
-			const providerModels = availableModels.filter((m) => m.provider === KIMCHI_PROVIDER_ID)
-			if (providerModels.length > 0) {
-				const selectedModel = providerModels.find((m) => m.id === KIMCHI_DEFAULT_MODEL_ID) ?? providerModels[0]
-				await session.setModel(selectedModel)
-				addLoginFeedback(im, `✓ Logged in. Model: ${selectedModel.id}`)
-			} else {
-				addLoginFeedback(im, "✓ Login successful. API key saved.")
-			}
-		} else {
-			addLoginFeedback(im, "✓ Login successful. API key saved.")
-		}
-	} catch (error) {
-		if (browserUrl) {
-			addLoginFeedback(im, `Couldn't open browser automatically. Visit: ${browserUrl}`)
-		}
-		showError(`Kimchi login failed: ${error instanceof Error ? error.message : String(error)}`)
+	const session = modeLike.session
+	const registry = session?.modelRegistry
+	if (!registry) {
+		showError("Kimchi login failed: model registry is unavailable")
+		return
 	}
+
+	await performKimchiBrowserLogin({
+		modelRegistry: registry,
+		setModel: (model) => session.setModel(model),
+		showStatus,
+		showError,
+		addFeedback: (message) => addLoginFeedback(im, message),
+	})
 }
 
 function showSubscriptionLogin(im: InteractiveMode): void {
@@ -286,22 +194,20 @@ function showLoginChoiceSelector(im: InteractiveMode): void {
 	}
 
 	modeLike.showSelector((done) => {
-		const selector = new ExtensionSelectorComponent(
-			"Select authentication method:",
-			[KIMCHI_ACCOUNT_LABEL, SUBSCRIPTION_LABEL],
-			(option) => {
+		const selector = createLoginChoiceSelector({
+			onKimchiAccount: () => {
 				done()
-				if (option === SUBSCRIPTION_LABEL) {
-					showSubscriptionLogin(im)
-					return
-				}
 				void handleKimchiLogin(im)
 			},
-			() => {
+			onSubscription: () => {
+				done()
+				showSubscriptionLogin(im)
+			},
+			onCancel: () => {
 				done()
 				modeLike.ui?.requestRender()
 			},
-		)
+		})
 		return { component: selector, focus: selector }
 	})
 }

--- a/src/login-command-patch.ts
+++ b/src/login-command-patch.ts
@@ -11,6 +11,7 @@ import { Spacer, Text } from "@earendil-works/pi-tui"
 import {
 	KIMCHI_PROVIDER_ID,
 	createLoginChoiceSelector,
+	formatBrowserLoginMessage,
 	performKimchiBrowserLogin,
 	prePopulateSubscriptionModels,
 } from "./extensions/login/flow.js"
@@ -126,6 +127,10 @@ async function handleKimchiLogin(im: InteractiveMode): Promise<void> {
 		showStatus,
 		showError,
 		addFeedback: (message) => addLoginFeedback(im, message),
+		// Surface the generated browser-login URL in the TUI. The auto-open can land
+		// in the wrong browser or Chrome profile (and still "succeed"), so the user
+		// needs the URL to copy into the right one. console.log is swallowed under the TUI.
+		onBrowserUrl: (url) => addLoginFeedback(im, formatBrowserLoginMessage(url)),
 	})
 }
 

--- a/src/models.test.ts
+++ b/src/models.test.ts
@@ -2,7 +2,7 @@ import { existsSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "no
 import { tmpdir } from "node:os"
 import { join } from "node:path"
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
-import { updateModelsConfig } from "./models.js"
+import { ModelsFetchError, isTransientModelsError, updateModelsConfig } from "./models.js"
 
 const KIMI: unknown = {
 	slug: "kimi-k2.5",
@@ -261,6 +261,53 @@ describe("updateModelsConfig", () => {
 		await expect(updateModelsConfig(modelsJsonPath, "bad-key")).rejects.toThrow(
 			"Failed to fetch models: 401 Unauthorized",
 		)
+	})
+
+	it("retries a transient 429 and succeeds on a later attempt", async () => {
+		vi.mocked(fetch)
+			.mockResolvedValueOnce({
+				ok: false,
+				status: 429,
+				statusText: "Too Many Requests",
+				headers: { get: () => null },
+			} as unknown as Response)
+			.mockResolvedValueOnce({
+				ok: true,
+				json: async () => ({ models: [KIMI] }),
+			} as Response)
+
+		const result = await updateModelsConfig(modelsJsonPath, "test-key", { sleep: async () => {} })
+
+		expect(fetch).toHaveBeenCalledTimes(2)
+		expect(result.models.map((m) => m.slug)).toEqual(["kimi-k2.5"])
+	})
+
+	it("classifies a persistent 429 as transient after exhausting retries", async () => {
+		vi.mocked(fetch).mockResolvedValue({
+			ok: false,
+			status: 429,
+			statusText: "Too Many Requests",
+			headers: { get: () => null },
+		} as unknown as Response)
+
+		const error = await updateModelsConfig(modelsJsonPath, "test-key", { sleep: async () => {} }).catch((e) => e)
+
+		expect(isTransientModelsError(error)).toBe(true)
+		expect(fetch).toHaveBeenCalledTimes(3)
+	})
+
+	it("classifies a 401 as a non-transient error and does not retry", async () => {
+		vi.mocked(fetch).mockResolvedValueOnce({
+			ok: false,
+			status: 401,
+			statusText: "Unauthorized",
+		} as Response)
+
+		const error = await updateModelsConfig(modelsJsonPath, "bad-key").catch((e) => e)
+
+		expect(error).toBeInstanceOf(ModelsFetchError)
+		expect(isTransientModelsError(error)).toBe(false)
+		expect(fetch).toHaveBeenCalledTimes(1)
 	})
 
 	it("throws on unexpected response shape when no cached config exists", async () => {

--- a/src/models.ts
+++ b/src/models.ts
@@ -7,6 +7,53 @@ const MODELS_METADATA_API = `${KIMCHI_API}/v1/models/metadata?include_in_cli=tru
 const CHAT_COMPLETIONS_API = `${KIMCHI_API}/openai/v1`
 const FETCH_TIMEOUT_MS = 5000
 
+// HTTP statuses worth retrying: rate limiting and transient gateway/server errors.
+const RETRYABLE_STATUSES = new Set([429, 500, 502, 503, 504])
+const MAX_FETCH_ATTEMPTS = 3
+const BASE_RETRY_DELAY_MS = 500
+const MAX_RETRY_DELAY_MS = 4000
+
+/**
+ * Error raised when the model metadata API cannot be reached. `transient` marks
+ * failures that are expected to clear on their own (rate limiting, gateway/server
+ * errors, network blips) so callers can offer "try again" instead of treating the
+ * user's saved API key as invalid.
+ */
+export class ModelsFetchError extends Error {
+	readonly status?: number
+	readonly transient: boolean
+	constructor(message: string, options: { status?: number; transient: boolean }) {
+		super(message)
+		this.name = "ModelsFetchError"
+		this.status = options.status
+		this.transient = options.transient
+	}
+}
+
+/** True when `error` is a transient (retryable) model-refresh failure. */
+export function isTransientModelsError(error: unknown): boolean {
+	return error instanceof ModelsFetchError && error.transient
+}
+
+export interface FetchModelsOptions {
+	/** Injected sleep for deterministic tests; defaults to a setTimeout-based delay. */
+	sleep?: (ms: number) => Promise<void>
+}
+
+const defaultSleep = (ms: number): Promise<void> => new Promise((resolve) => setTimeout(resolve, ms))
+
+/** Delay before the next retry, honoring a `Retry-After` header when present. */
+function retryDelayMs(response: Response, attempt: number): number {
+	const header = response.headers?.get?.("retry-after")
+	if (header) {
+		const seconds = Number(header)
+		if (Number.isFinite(seconds) && seconds >= 0) return Math.min(seconds * 1000, MAX_RETRY_DELAY_MS)
+		const dateMs = Date.parse(header)
+		if (!Number.isNaN(dateMs)) return Math.min(Math.max(dateMs - Date.now(), 0), MAX_RETRY_DELAY_MS)
+	}
+	return Math.min(BASE_RETRY_DELAY_MS * 2 ** (attempt - 1), MAX_RETRY_DELAY_MS)
+}
+
 export interface ModelMetadata {
 	slug: string
 	display_name: string
@@ -32,22 +79,47 @@ function sortModels(models: ModelMetadata[]): ModelMetadata[] {
 	return [...serverless, ...rest]
 }
 
-async function fetchAvailableModels(apiKey: string): Promise<ModelMetadata[]> {
-	const response = await fetch(MODELS_METADATA_API, {
-		headers: { Authorization: `Bearer ${apiKey}` },
-		signal: AbortSignal.timeout(FETCH_TIMEOUT_MS),
-	})
-	if (!response.ok) {
-		throw new Error(`Failed to fetch models: ${response.status} ${response.statusText}`)
+async function fetchAvailableModels(apiKey: string, options: FetchModelsOptions = {}): Promise<ModelMetadata[]> {
+	const sleep = options.sleep ?? defaultSleep
+	let lastError: ModelsFetchError | undefined
+
+	for (let attempt = 1; attempt <= MAX_FETCH_ATTEMPTS; attempt += 1) {
+		let response: Response
+		try {
+			response = await fetch(MODELS_METADATA_API, {
+				headers: { Authorization: `Bearer ${apiKey}` },
+				signal: AbortSignal.timeout(FETCH_TIMEOUT_MS),
+			})
+		} catch (err) {
+			// Network/timeout failures are transient; surface them so the caller can
+			// offer a retry rather than discarding the user's saved API key.
+			throw new ModelsFetchError(`Failed to fetch models: ${err instanceof Error ? err.message : String(err)}`, {
+				transient: true,
+			})
+		}
+
+		if (response.ok) {
+			const body = (await response.json()) as ModelsMetadataResponse
+			if (!Array.isArray(body?.models)) {
+				throw new ModelsFetchError("Unexpected response shape from models API", { transient: false })
+			}
+			if (body.models.length === 0) {
+				throw new ModelsFetchError("API returned empty model list", { transient: false })
+			}
+			return body.models
+		}
+
+		const transient = RETRYABLE_STATUSES.has(response.status)
+		lastError = new ModelsFetchError(`Failed to fetch models: ${response.status} ${response.statusText}`, {
+			status: response.status,
+			transient,
+		})
+		if (!transient || attempt === MAX_FETCH_ATTEMPTS) throw lastError
+		await sleep(retryDelayMs(response, attempt))
 	}
-	const body = (await response.json()) as ModelsMetadataResponse
-	if (!Array.isArray(body?.models)) {
-		throw new Error("Unexpected response shape from models API")
-	}
-	if (body.models.length === 0) {
-		throw new Error("API returned empty model list")
-	}
-	return body.models
+
+	// Unreachable: the loop returns on success or throws on the final attempt.
+	throw lastError ?? new ModelsFetchError("Failed to fetch models", { transient: true })
 }
 
 export interface PiModelConfig {
@@ -190,7 +262,11 @@ export function syncProviderModels(
  * User-added providers (anything other than "kimchi-dev") are preserved across
  * updates so custom model configurations are not lost on startup.
  */
-export async function updateModelsConfig(modelsJsonPath: string, apiKey: string): Promise<ModelsConfigResult> {
+export async function updateModelsConfig(
+	modelsJsonPath: string,
+	apiKey: string,
+	options: FetchModelsOptions = {},
+): Promise<ModelsConfigResult> {
 	const dir = dirname(modelsJsonPath)
 	mkdirSync(dir, { recursive: true })
 
@@ -203,7 +279,7 @@ export async function updateModelsConfig(modelsJsonPath: string, apiKey: string)
 
 	let fetched: ModelMetadata[]
 	try {
-		fetched = await fetchAvailableModels(apiKey)
+		fetched = await fetchAvailableModels(apiKey, options)
 	} catch (err) {
 		const cached = readCachedMetadata(modelsJsonPath) ?? []
 		if (cached.length === 0 && otherModels.length === 0) throw err


### PR DESCRIPTION
## Description

Show the existing login method selector during interactive startup when no usable auth/model is available.

Gate Ferment/session onboarding until login succeeds, so first-time users cannot enter Ferment or live coding while unauthenticated.

Reuse the shared /login choices for Kimchi account and subscription auth instead of introducing a separate first-run dialog.

Reuse saved Kimchi config keys on retry and refresh models with that key before opening browser auth again, preventing repeated server-side key creation when model refresh fails or returns no usable models.

Shut down cleanly when startup login is cancelled instead of falling through to an unauthenticated session.

This fixes the broken first-run path where fresh installs could reach product workflows without login and could mint multiple Kimchi API keys while retrying failed startup auth.



## Type of Change

<!-- Select all that apply. -->

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
