### PR TITLE
fix(mcp): surface invalid config as UI warning instead of raw stack trace

### DIFF
--- a/src/extensions/mcp-adapter/config.ts
+++ b/src/extensions/mcp-adapter/config.ts
@@ -21,8 +21,9 @@ const IMPORT_PATHS: Record<ImportKind, string> = {
 	vscode: ".vscode/mcp.json", // Relative to project
 }
 
-export function loadMcpConfig(overridePath?: string): McpConfig {
+export function loadMcpConfig(overridePath?: string): { config: McpConfig; warnings: string[] } {
 	const configPath = overridePath ? resolve(overridePath) : getDefaultConfigPath()
+	const warnings: string[] = []
 
 	// Load base config
 	let config: McpConfig = { mcpServers: {} }
@@ -32,7 +33,8 @@ export function loadMcpConfig(overridePath?: string): McpConfig {
 			const raw = JSON.parse(readFileSync(configPath, "utf-8"))
 			config = validateConfig(raw)
 		} catch (error) {
-			console.warn(`Failed to load MCP config from ${configPath}:`, error)
+			const msg = error instanceof Error ? error.message : String(error)
+			warnings.push(`Failed to load MCP config from ${configPath}: ${msg}`)
 		}
 	}
 
@@ -57,7 +59,8 @@ export function loadMcpConfig(overridePath?: string): McpConfig {
 					}
 				}
 			} catch (error) {
-				console.warn(`Failed to import MCP config from ${importKind}:`, error)
+				const msg = error instanceof Error ? error.message : String(error)
+				warnings.push(`Failed to import MCP config from ${importKind}: ${msg}`)
 			}
 		}
 	}
@@ -75,11 +78,12 @@ export function loadMcpConfig(overridePath?: string): McpConfig {
 				config.settings = { ...config.settings, ...validated.settings }
 			}
 		} catch (error) {
-			console.warn(`Failed to load project MCP config:`, error)
+			const msg = error instanceof Error ? error.message : String(error)
+			warnings.push(`Failed to load project MCP config: ${msg}`)
 		}
 	}
 
-	return config
+	return { config, warnings }
 }
 
 function validateConfig(raw: unknown): McpConfig {

--- a/src/extensions/mcp-adapter/index.ts
+++ b/src/extensions/mcp-adapter/index.ts
@@ -71,7 +71,7 @@ export default function mcpAdapter(pi: ExtensionAPI) {
 	}
 
 	const earlyConfigPath = getConfigPathFromArgv()
-	const earlyConfig = loadMcpConfig(earlyConfigPath)
+	const { config: earlyConfig } = loadMcpConfig(earlyConfigPath)
 	let earlyCache = loadMetadataCache()
 
 	// Drop cache entries whose configHash no longer matches the configured server

--- a/src/extensions/mcp-adapter/init.ts
+++ b/src/extensions/mcp-adapter/init.ts
@@ -33,7 +33,14 @@ export async function initializeMcp(
 	registerBootstrappedDirectTools?: (specs: DirectToolSpec[], ctx?: Pick<ExtensionContext, "cwd">) => string[],
 ): Promise<McpExtensionState> {
 	const configPath = pi.getFlag("mcp-config") as string | undefined
-	const config = loadMcpConfig(configPath)
+	const { config, warnings: configWarnings } = loadMcpConfig(configPath)
+	for (const warning of configWarnings) {
+		if (ctx.hasUI) {
+			ctx.ui.notify(warning, "warning")
+		} else {
+			console.warn(warning)
+		}
+	}
 
 	const manager = new McpServerManager()
 	const lifecycle = new McpLifecycleManager(manager)


### PR DESCRIPTION
## Description

<!-- What problem does this PR solve? What changes were made and why? -->

Before: 
<img width="3380" height="2060" alt="image" src="https://github.com/user-attachments/assets/119b1d82-5e0b-4b42-8d50-21c1c7ab39ec" />

After: 
<img width="3380" height="2060" alt="image" src="https://github.com/user-attachments/assets/ea1cd251-d92c-4eec-9ba0-e52c24eb9980" />


## Type of Change

<!-- Select all that apply. -->

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
