### PR TITLE
fix: Correctly detect existing Git repo in the ferment mode

### DIFF
--- a/src/extensions/ferment/git-init.test.ts
+++ b/src/extensions/ferment/git-init.test.ts
@@ -1,0 +1,146 @@
+import { execSync } from "node:child_process"
+import { mkdtempSync, rmdirSync } from "node:fs"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
+import { afterEach, beforeEach, describe, expect, it } from "vitest"
+import { autoInitFromEnv, ensureGitRepo } from "./git-init.js"
+import type { FermentUi } from "./ui.js"
+
+function makeGitRepo(): string {
+	const dir = mkdtempSync(join(tmpdir(), "git-init-test-"))
+	execSync("git init", { cwd: dir, stdio: "ignore" })
+	execSync('git config user.email "test@example.com"', { cwd: dir, stdio: "ignore" })
+	execSync('git config user.name "Test"', { cwd: dir, stdio: "ignore" })
+	execSync("git config commit.gpgsign false", { cwd: dir, stdio: "ignore" })
+	return dir
+}
+
+function makeEmptyDir(): string {
+	return mkdtempSync(join(tmpdir(), "git-init-test-empty-"))
+}
+
+function cleanup(dir: string): void {
+	try {
+		rmdirSync(dir, { recursive: true })
+	} catch {
+		// ignore cleanup errors
+	}
+}
+
+function makeMockUi(confirmResult = false): FermentUi {
+	return {
+		notify: (_message: string) => {},
+		confirm: async () => confirmResult,
+	}
+}
+
+describe("ensureGitRepo", () => {
+	let repos: string[]
+
+	beforeEach(() => {
+		repos = []
+	})
+
+	afterEach(() => {
+		for (const dir of repos) {
+			cleanup(dir)
+		}
+	})
+
+	it("returns already-repo when cwd is the git root", async () => {
+		const dir = makeGitRepo()
+		repos.push(dir)
+		const result = await ensureGitRepo({ cwd: dir })
+		expect(result).toBe("already-repo")
+	})
+
+	it("returns already-repo when cwd is a subdirectory of a git repo", async () => {
+		const dir = makeGitRepo()
+		repos.push(dir)
+		const subdir = join(dir, "subdir")
+		execSync("mkdir subdir", { cwd: dir, stdio: "ignore" })
+
+		const result = await ensureGitRepo({ cwd: subdir })
+		expect(result).toBe("already-repo")
+	})
+
+	it("returns skipped when not in a git repo and no UI is provided", async () => {
+		const dir = makeEmptyDir()
+		repos.push(dir)
+		const result = await ensureGitRepo({ cwd: dir })
+		expect(result).toBe("skipped")
+	})
+
+	it("initializes a new repo when autoInit is true and not in a git repo", async () => {
+		const dir = makeEmptyDir()
+		repos.push(dir)
+		const result = await ensureGitRepo({ cwd: dir, autoInit: true })
+		expect(result).toBe("initialized")
+	})
+
+	it("returns already-repo when autoInit is true and inside a git repo", async () => {
+		const dir = makeGitRepo()
+		repos.push(dir)
+		const result = await ensureGitRepo({ cwd: dir, autoInit: true })
+		expect(result).toBe("already-repo")
+	})
+
+	it("returns declined when user declines the prompt", async () => {
+		const dir = makeEmptyDir()
+		repos.push(dir)
+		const mockUi = makeMockUi()
+		mockUi.confirm = async () => false
+
+		const result = await ensureGitRepo({ cwd: dir, ui: mockUi })
+		expect(result).toBe("declined")
+	})
+
+	it("returns initialized when user confirms the prompt", async () => {
+		const dir = makeEmptyDir()
+		repos.push(dir)
+		const mockUi = makeMockUi(true)
+
+		const result = await ensureGitRepo({ cwd: dir, ui: mockUi })
+		expect(result).toBe("initialized")
+	})
+
+	it("returns init-failed when git init fails on a read-only directory", async () => {
+		// Use a path to a non-existent directory so git init fails
+		const dir = mkdtempSync(join(tmpdir(), "git-init-fail-"))
+		repos.push(dir)
+		const nonexistent = join(dir, "nonexistent", "path")
+		const mockUi = makeMockUi(true) // confirm to trigger git init
+
+		// git init on a path that doesn't exist should fail
+		const result = await ensureGitRepo({ cwd: nonexistent, ui: mockUi })
+
+		expect(result).toBe("init-failed")
+	})
+})
+
+describe("autoInitFromEnv", () => {
+	const originalVal = process.env.KIMCHI_AUTO_GIT_INIT
+
+	afterEach(() => {
+		if (originalVal === undefined) {
+			process.env.KIMCHI_AUTO_GIT_INIT = undefined
+		} else {
+			process.env.KIMCHI_AUTO_GIT_INIT = originalVal
+		}
+	})
+
+	it("returns false when KIMCHI_AUTO_GIT_INIT is not set", () => {
+		process.env.KIMCHI_AUTO_GIT_INIT = undefined
+		expect(autoInitFromEnv()).toBe(false)
+	})
+
+	it("returns true when KIMCHI_AUTO_GIT_INIT is '1'", () => {
+		process.env.KIMCHI_AUTO_GIT_INIT = "1"
+		expect(autoInitFromEnv()).toBe(true)
+	})
+
+	it("returns false when KIMCHI_AUTO_GIT_INIT is not '1'", () => {
+		process.env.KIMCHI_AUTO_GIT_INIT = "yes"
+		expect(autoInitFromEnv()).toBe(false)
+	})
+})

--- a/src/extensions/ferment/git-init.test.ts
+++ b/src/extensions/ferment/git-init.test.ts
@@ -104,7 +104,7 @@ describe("ensureGitRepo", () => {
 		expect(result).toBe("initialized")
 	})
 
-	it("returns init-failed when git init fails on a read-only directory", async () => {
+	it("returns init-failed when git init fails on a non-existent path", async () => {
 		// Use a path to a non-existent directory so git init fails
 		const dir = mkdtempSync(join(tmpdir(), "git-init-fail-"))
 		repos.push(dir)

--- a/src/extensions/ferment/git-init.ts
+++ b/src/extensions/ferment/git-init.ts
@@ -1,7 +1,18 @@
 import { execSync } from "node:child_process"
-import { existsSync } from "node:fs"
-import { join } from "node:path"
 import type { FermentUi } from "./ui.js"
+
+/**
+ * Check if `cwd` is inside a git repository (including subdirectories).
+ * Uses `git rev-parse --is-inside-work-tree` which correctly handles subdirectories.
+ */
+function isInsideGitRepo(cwd: string): boolean {
+	try {
+		execSync("git rev-parse --is-inside-work-tree", { cwd, stdio: ["ignore", "ignore", "ignore"] })
+		return true
+	} catch {
+		return false
+	}
+}
 
 export type EnsureGitRepoOutcome = "already-repo" | "initialized" | "declined" | "skipped" | "init-failed"
 
@@ -28,7 +39,7 @@ export interface EnsureGitRepoOptions {
  */
 export async function ensureGitRepo(opts: EnsureGitRepoOptions = {}): Promise<EnsureGitRepoOutcome> {
 	const cwd = opts.cwd ?? process.cwd()
-	if (existsSync(join(cwd, ".git"))) return "already-repo"
+	if (isInsideGitRepo(cwd)) return "already-repo"
 
 	if (!opts.autoInit) {
 		if (typeof opts.ui?.confirm !== "function") return "skipped"


### PR DESCRIPTION
## Description

<!-- What problem does this PR solve? What changes were made and why? -->


## Type of Change

<!-- Select all that apply. -->

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

---
### Kimchi Summary
### What changed
Fixes git repository detection in the `ferment` extension so it correctly recognizes when the working directory is inside a git repository (including subdirectories), instead of only checking for a `.git` folder at the exact path. Also adds unit tests for the initialization logic.

### Why
Previously, running in a subdirectory of an existing git repo would incorrectly trigger a re-initialization prompt or be skipped, because the check only looked for `.git` at the current directory level.

### Key changes
- `src/extensions/ferment/git-init.ts`: Added `isInsideGitRepo()` helper using `git rev-parse --is-inside-work-tree` to detect git worktrees recursively; replaced the `existsSync(join(cwd, ".git"))` check in `ensureGitRepo()` with this helper.
- `src/extensions/ferment/git-init.test.ts`: Added test coverage for `ensureGitRepo` outcomes (`already-repo`, `initialized`, `declined`, `skipped`, `init-failed`) and `autoInitFromEnv()` env-var parsing.