### PR TITLE
fix(mcp): restore mcp({}) empty-call status behavior

### DIFF
--- a/src/extensions/mcp-adapter/index.ts
+++ b/src/extensions/mcp-adapter/index.ts
@@ -24,6 +24,7 @@ import {
 	executeConnect,
 	executeDescribe,
 	executeSearch,
+	executeStatus,
 	executeUiMessages,
 } from "./proxy-modes.js"
 import type { McpExtensionState } from "./state.js"
@@ -486,10 +487,7 @@ export default function mcpAdapter(pi: ExtensionAPI) {
 					registerAndActivate(specs, undefined, ctx)
 				)
 				}
-				return {
-					content: [{ type: "text" as const, text: `Workflow Error: Missing action parameter.\nTo use MCP tools, you must first discover them and their schemas.\nUse mcp({ search: "..." }) to find tools, or mcp({ describe: "tool_name" }) to get a schema. Matched tools will then be injected for you to call directly.` }],
-					details: { error: "missing_action" },
-				}
+				return executeStatus(state)
 			},
 			renderCall(args: { tool?: string; args?: string; connect?: string; describe?: string; search?: string; limit?: number; server?: string; action?: string }, theme: Theme, context: { lastComponent: Component | undefined }) {
 				const text = (context.lastComponent as Text | undefined) ?? new Text("", 0, 0)


### PR DESCRIPTION
Fixes a frustrating UX loop where the MCP tool error messages tell users to call `mcp({})` to see available servers, but that call was returning "Missing action parameter."

## Root cause

- `executeStatus()` existed in `proxy-modes.ts` but was never imported or wired into the tool handler in `index.ts`
- The fallback code returned a hard-coded error instead of calling `executeStatus()`
- Three error messages in `proxy-modes.ts` still referenced the documented `mcp({})` behavior

## Fix

- Import `executeStatus` in `index.ts`
- Replace the "Missing action parameter" fallback with `executeStatus(state)`

## Verification

- `pnpm run typecheck` — clean
- MCP adapter tests (63) — all pass
- Full suite — 2 pre-existing unrelated failures

## Also discovered (not addressed in this PR)

- README documents `.pi/mcp.json` for project configs, but `loadMcpConfig()` looks for `.kimchi/mcp.json` — docs/code mismatch
- `.mcp.json` at repo root is not loaded by `loadMcpConfig()"