### PR TITLE
feat: support .local.md variants for CLAUDE.md and AGENTS.md

### DIFF
--- a/src/extensions/prompt-construction/context-files.test.ts
+++ b/src/extensions/prompt-construction/context-files.test.ts
@@ -68,4 +68,43 @@ describe("loadProjectContextFiles", () => {
 		const paths = inTmp.map((f) => f.path)
 		expect(new Set(paths).size).toBe(paths.length)
 	})
+
+	it("appends CLAUDE.local.md content to CLAUDE.md when both exist", () => {
+		writeFileSync(join(nested, "CLAUDE.md"), "shared rules")
+		writeFileSync(join(nested, "CLAUDE.local.md"), "my local rules")
+		const result = loadProjectContextFiles(nested)
+		const inTmp = result.filter((f) => f.path.startsWith(tmpBase))
+		expect(inTmp).toHaveLength(1)
+		expect(inTmp[0].path).toBe(join(nested, "CLAUDE.md"))
+		expect(inTmp[0].content).toBe("shared rules\n\nmy local rules")
+	})
+
+	it("appends AGENTS.local.md content to AGENTS.md when both exist", () => {
+		writeFileSync(join(nested, "AGENTS.md"), "shared agents")
+		writeFileSync(join(nested, "AGENTS.local.md"), "my local agents")
+		const result = loadProjectContextFiles(nested)
+		const inTmp = result.filter((f) => f.path.startsWith(tmpBase))
+		expect(inTmp).toHaveLength(1)
+		expect(inTmp[0].path).toBe(join(nested, "AGENTS.md"))
+		expect(inTmp[0].content).toBe("shared agents\n\nmy local agents")
+	})
+
+	it("loads CLAUDE.local.md standalone when CLAUDE.md is absent", () => {
+		writeFileSync(join(nested, "CLAUDE.local.md"), "only local")
+		const result = loadProjectContextFiles(nested)
+		const inTmp = result.filter((f) => f.path.startsWith(tmpBase))
+		expect(inTmp).toHaveLength(1)
+		expect(inTmp[0].path).toBe(join(nested, "CLAUDE.local.md"))
+		expect(inTmp[0].content).toBe("only local")
+	})
+
+	it("ignores CLAUDE.local.md when AGENTS.md wins priority in same dir", () => {
+		writeFileSync(join(nested, "AGENTS.md"), "agents wins")
+		writeFileSync(join(nested, "CLAUDE.local.md"), "claude local ignored")
+		const result = loadProjectContextFiles(nested)
+		const inTmp = result.filter((f) => f.path.startsWith(tmpBase))
+		expect(inTmp).toHaveLength(1)
+		expect(inTmp[0].path).toBe(join(nested, "AGENTS.md"))
+		expect(inTmp[0].content).toBe("agents wins")
+	})
 })

--- a/src/extensions/prompt-construction/context-files.ts
+++ b/src/extensions/prompt-construction/context-files.ts
@@ -8,6 +8,11 @@
  * guidelines into our custom system prompts.
  *
  * Per directory, the first match wins: AGENTS.md is checked before CLAUDE.md.
+ * When a primary file is found, its `.local.md` variant (e.g. CLAUDE.local.md)
+ * is appended if present. A `.local.md` file without a primary file is also
+ * loaded standalone. `.local.md` files are intended for user-specific,
+ * gitignored overrides.
+ *
  * Files are returned in root → cwd order (ancestors first).
  */
 
@@ -21,15 +26,33 @@ export interface ContextFile {
 
 const CONTEXT_FILE_NAMES = ["AGENTS.md", "CLAUDE.md"]
 
+function tryReadFile(filePath: string): string | null {
+	if (!existsSync(filePath)) return null
+	try {
+		return readFileSync(filePath, "utf-8")
+	} catch {
+		return null
+	}
+}
+
+/** Derive the `.local.md` variant for a context filename, e.g. "CLAUDE.md" → "CLAUDE.local.md". */
+function localVariant(filename: string): string {
+	return filename.replace(/\.md$/, ".local.md")
+}
+
 function loadContextFileFromDir(dir: string): ContextFile | null {
 	for (const filename of CONTEXT_FILE_NAMES) {
 		const filePath = join(dir, filename)
-		if (existsSync(filePath)) {
-			try {
-				return { path: filePath, content: readFileSync(filePath, "utf-8") }
-			} catch {
-				// Unreadable file — skip silently
-			}
+		const localPath = join(dir, localVariant(filename))
+		const primary = tryReadFile(filePath)
+		const local = tryReadFile(localPath)
+
+		if (primary !== null) {
+			const content = local !== null ? `${primary}\n\n${local}` : primary
+			return { path: filePath, content }
+		}
+		if (local !== null) {
+			return { path: localPath, content: local }
 		}
 	}
 	return null


### PR DESCRIPTION

When a primary context file (AGENTS.md or CLAUDE.md) is found in a directory, the loader now also checks for a .local.md variant (AGENTS.local.md or CLAUDE.local.md) and appends its content.

If only a .local.md file exists without its primary counterpart, it is loaded standalone.

These files are intended for user-specific, gitignored overrides — matching the convention used by Claude Code.

## Description

<!-- What problem does this PR solve? What changes were made and why? -->


## Type of Change

<!-- Select all that apply. -->

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
