### PR TITLE
fix(permissions): mode picker always switched to default

### DIFF
--- a/src/extensions/permissions/commands.ts
+++ b/src/extensions/permissions/commands.ts
@@ -139,7 +139,7 @@ async function openModePicker(ctx: ExtensionContext, deps: CommandDeps): Promise
 	if (selected === CANCEL) return
 
 	let picked: PermissionMode
-	switch (choice) {
+	switch (selected) {
 		case OPT_PLAN:
 			picked = "plan"
 			break
@@ -206,7 +206,7 @@ function showStatus(ctx: ExtensionCommandContext, deps: CommandDeps): void {
 function handleMode(ctx: ExtensionContext, deps: CommandDeps, arg: string): void {
 	const mode = parseModeString(arg)
 	if (!mode) {
-		ctx.ui.notify(`unknown mode "${arg}". Valid: default, plan, auto`, "warning")
+		ctx.ui.notify(`unknown mode "${arg}". Valid: default, plan, auto, yolo`, "warning")
 		return
 	}
 	const prev = deps.getMode()


### PR DESCRIPTION
## Description

The switch statement in openModePicker() evaluated `choice` instead of`selected`.


## Type of Change

<!-- Select all that apply. -->

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
