### PR TITLE
fix: treat rtk as transparent wrapper in bash permissions taxonomy

### DIFF
--- a/src/extensions/permissions/taxonomy.test.ts
+++ b/src/extensions/permissions/taxonomy.test.ts
@@ -83,6 +83,11 @@ describe("extractBashProgram", () => {
 	it("strips leading env-var assignments", () => {
 		expect(extractBashProgram("FOO=bar BAZ=1 git status")).toEqual({ program: "git", subcommand: "status" })
 	})
+
+	it("sees through rtk wrapper to extract the real program", () => {
+		expect(extractBashProgram("rtk git status")).toEqual({ program: "git", subcommand: "status" })
+		expect(extractBashProgram("rtk ls -la")).toEqual({ program: "ls", subcommand: "-la" })
+	})
 })
 
 describe("isReadOnlyBashCommand", () => {
@@ -199,6 +204,43 @@ describe("isReadOnlyBashCommand", () => {
 		expect(isReadOnlyBashCommand("FOO=bar cat foo")).toBe(true)
 		expect(isReadOnlyBashCommand("FOO=bar git status")).toBe(true)
 	})
+
+	it("sees through rtk wrapper for read-only programs", () => {
+		expect(isReadOnlyBashCommand("rtk ls -la")).toBe(true)
+		expect(isReadOnlyBashCommand("rtk cat foo.txt")).toBe(true)
+		expect(isReadOnlyBashCommand("rtk tree -L 2")).toBe(true)
+	})
+
+	it("sees through rtk wrapper for read-only git subcommands", () => {
+		expect(isReadOnlyBashCommand("rtk git status")).toBe(true)
+		expect(isReadOnlyBashCommand("rtk git log --oneline")).toBe(true)
+		expect(isReadOnlyBashCommand("rtk git diff HEAD")).toBe(true)
+		expect(isReadOnlyBashCommand("rtk git branch")).toBe(true)
+	})
+
+	it("blocks rtk-wrapped git subcommands outside allowlist", () => {
+		expect(isReadOnlyBashCommand("rtk git push")).toBe(false)
+		expect(isReadOnlyBashCommand("rtk git commit -am x")).toBe(false)
+		expect(isReadOnlyBashCommand("rtk git reset --hard")).toBe(false)
+	})
+
+	it("blocks rtk-wrapped unknown programs", () => {
+		expect(isReadOnlyBashCommand("rtk rm -rf foo")).toBe(false)
+		expect(isReadOnlyBashCommand("rtk curl https://x.com")).toBe(false)
+	})
+
+	it("rejects bare rtk with no wrapped command", () => {
+		expect(isReadOnlyBashCommand("rtk")).toBe(false)
+	})
+
+	it("allows rtk in compound commands when all segments are read-only", () => {
+		expect(isReadOnlyBashCommand("rtk git status && rtk ls -la")).toBe(true)
+		expect(isReadOnlyBashCommand("rtk git status | head -5")).toBe(true)
+	})
+
+	it("blocks rtk in compound commands when any segment is not read-only", () => {
+		expect(isReadOnlyBashCommand("rtk git status && rtk git push")).toBe(false)
+	})
 })
 
 describe("isHardBlockedBash", () => {
@@ -227,6 +269,12 @@ describe("isHardBlockedBash", () => {
 		expect(isHardBlockedBash("rm -rf ./build")).toBe(false)
 		expect(isHardBlockedBash("rm foo.txt")).toBe(false)
 		expect(isHardBlockedBash("rm -f node_modules/.cache")).toBe(false)
+	})
+
+	it("sees through rtk wrapper for hard-blocked commands", () => {
+		expect(isHardBlockedBash("rtk sudo ls")).toBe(true)
+		expect(isHardBlockedBash("rtk rm -rf /")).toBe(true)
+		expect(isHardBlockedBash("rtk rm -rf /etc")).toBe(true)
 	})
 })
 

--- a/src/extensions/permissions/taxonomy.ts
+++ b/src/extensions/permissions/taxonomy.ts
@@ -216,11 +216,13 @@ export function isHardBlockedBash(command: string): boolean {
 	if (/:\(\)\s*\{/.test(command)) return true
 
 	for (const segment of parseCommandSegments(command)) {
-		const program = segment.tokens[0]
+		// See through RTK wrapper so `rtk rm -rf /` is still caught.
+		const tokens = segment.tokens[0] === "rtk" ? segment.tokens.slice(1) : segment.tokens
+		const program = tokens[0]
 		if (!program) continue
 		if (HARD_BLOCK_PROGRAMS.has(program)) return true
-		if (program === "rm" && isDangerousRmSegment(segment.tokens)) return true
-		if (program === "dd" && segment.tokens.some((t) => t.startsWith("of=/dev/"))) return true
+		if (program === "rm" && isDangerousRmSegment(tokens)) return true
+		if (program === "dd" && tokens.some((t) => t.startsWith("of=/dev/"))) return true
 	}
 	return false
 }
@@ -304,7 +306,9 @@ export function splitCompoundCommand(command: string): string[] | null {
 }
 
 export function extractBashProgram(command: string): { program: string; subcommand: string | undefined } {
-	const tokens = firstSegmentTokens(command)
+	// See through the RTK wrapper so callers get the real program/subcommand.
+	const raw = firstSegmentTokens(command)
+	const tokens = raw[0] === "rtk" ? raw.slice(1) : raw
 	return { program: tokens[0] ?? "", subcommand: tokens[1] }
 }
 
@@ -328,6 +332,14 @@ export function isReadOnlyBashCommand(command: string): boolean {
 function isSegmentReadOnly(tokens: string[]): boolean {
 	const program = tokens[0]
 	if (!program) return false
+
+	// RTK is a transparent wrapper (`rtk git status` → classify `git status`).
+	// Delegate to the wrapped command so read-only checks apply as if RTK
+	// were not present.  If there is no wrapped command, reject — bare `rtk`
+	// is not read-only.
+	if (program === "rtk") {
+		return tokens.length > 1 ? isSegmentReadOnly(tokens.slice(1)) : false
+	}
 
 	const allowedSubs = READ_ONLY_SUBCOMMANDS[program]
 	if (allowedSubs) {


### PR DESCRIPTION
RTK rewrites commands like `ls -la` → `rtk ls -la` and `git status` → `rtk git status`. The permissions system saw `rtk` as the program and rejected it because it wasn't in any allowlist.

Changes:
- isSegmentReadOnly: when program is `rtk`, recursively classify the wrapped command (tokens[1:]) using the same read-only logic
- isHardBlockedBash: see through `rtk` wrapper so `rtk sudo`, `rtk rm -rf /` etc. are still caught
- extractBashProgram: unwrap `rtk` so callers get the real program and subcommand

Bare `rtk` (no wrapped command) is rejected as not read-only.

## Description

<!-- What problem does this PR solve? What changes were made and why? -->


## Type of Change

<!-- Select all that apply. -->

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
