### PR TITLE
fix(setup-wizard): show manual export hint when shell profile write fails

### DIFF
--- a/src/setup-wizard/shell-profile.test.ts
+++ b/src/setup-wizard/shell-profile.test.ts
@@ -1,4 +1,5 @@
 import {
+	chmodSync,
 	mkdirSync,
 	mkdtempSync,
 	readFileSync,
@@ -136,5 +137,18 @@ describe("exportEnvToShellProfile", () => {
 		const result = exportEnvToShellProfile("KIMCHI_API_KEY", "key")
 		expect(result.path).toBeNull()
 		expect(result.error).toMatch(/non-UTF-8/)
+	})
+
+	it("surfaces permission error when parent directory is read-only", () => {
+		process.env.SHELL = "/bin/zsh"
+		const profile = join(tmpHome, ".zshrc")
+		writeFileSync(profile, "# existing\n")
+		chmodSync(tmpHome, 0o555)
+
+		const result = exportEnvToShellProfile("KIMCHI_API_KEY", "key")
+		expect(result.path).toBeNull()
+		expect(result.error).toMatch(/read-only/)
+
+		chmodSync(tmpHome, 0o755)
 	})
 })

--- a/src/setup-wizard/shell-profile.ts
+++ b/src/setup-wizard/shell-profile.ts
@@ -7,6 +7,8 @@ export interface ExportResult {
 	path: string | null
 	/** Non-fatal warning (e.g. profile file contains non-UTF-8 bytes); the export was skipped. */
 	error?: string
+	/** The line the user should add manually when the automated write fails. */
+	manualLine?: string
 }
 
 /**
@@ -64,7 +66,18 @@ export function exportEnvToShellProfile(key: string, value: string): ExportResul
 	}
 
 	const newContent = upsertExportLine(existing, exportLine, matchPrefix)
-	atomicWriteFile(profilePath, newContent)
+	try {
+		atomicWriteFile(profilePath, newContent)
+	} catch (err) {
+		const code = (err as NodeJS.ErrnoException).code
+		const reason =
+			code === "EACCES" || code === "EPERM"
+				? `${profilePath} is read-only`
+				: err instanceof Error
+					? err.message
+					: String(err)
+		return { path: null, error: reason, manualLine: `Update ${profilePath} with:\n${exportLine}` }
+	}
 	return { path: profilePath }
 }
 

--- a/src/setup-wizard/steps/done.ts
+++ b/src/setup-wizard/steps/done.ts
@@ -96,6 +96,9 @@ export async function runDoneStep(state: WizardState): Promise<ApplyOutcome> {
 		log.info(`${KIMCHI_API_KEY_ENV} exported to ${shellExport.path}`)
 	} else if (shellExport.error) {
 		log.warn(`Could not export ${KIMCHI_API_KEY_ENV} to shell profile: ${shellExport.error}`)
+		if (shellExport.manualLine) {
+			log.info(shellExport.manualLine)
+		}
 	}
 
 	const summaryLines = [


### PR DESCRIPTION
## Description

When writing to the shell profile fails (e.g. read-only file), the wizard previously only printed the error. Now it also shows the exact line the user should add manually, including the profile path and the export command.

After:
<img width="1702" height="644" alt="image" src="https://github.com/user-attachments/assets/d36d77db-d3cd-4f7e-a4b6-c45e27eaaa47" />


## Type of Change

<!-- Select all that apply. -->

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
