### PR TITLE
fix: persist prompt history across sessions

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -41,6 +41,7 @@ import { createSessionModeOnboardingForStartup } from "./extensions/onboarding/s
 import permissionsExtension from "./extensions/permissions/index.js"
 import { writeKimchiKeybindingDefaults } from "./extensions/permissions/keybindings.js"
 import promptEnrichmentExtension from "./extensions/prompt-construction/prompt-enrichment.js"
+import promptHistoryExtension from "./extensions/prompt-history.js"
 import promptSummaryExtension from "./extensions/prompt-summary.js"
 import questionnaireExtension from "./extensions/questionnaire.js"
 import reportBugExtension from "./extensions/report-bug.js"
@@ -481,6 +482,7 @@ try {
 			kimchiMinimalTintsExtension,
 			loginExtension,
 			uiExtension,
+			promptHistoryExtension,
 			startupAuthGate,
 			loopGuardExtension,
 			explorationGuardExtension,

--- a/src/extensions/prompt-history.ts
+++ b/src/extensions/prompt-history.ts
@@ -16,7 +16,7 @@ import { mkdirSync, readFileSync, renameSync, writeFileSync } from "node:fs"
 import { homedir } from "node:os"
 import { join } from "node:path"
 import type { ExtensionAPI, InputEvent } from "@earendil-works/pi-coding-agent"
-import { currentEditor } from "./ui.js"
+import { getCurrentEditor } from "./ui.js"
 
 const HISTORY_FILE = join(homedir(), ".config", "kimchi", "prompt-history.json")
 const MAX_HISTORY = 500
@@ -57,7 +57,7 @@ export default function promptHistoryExtension(pi: ExtensionAPI) {
 			// Reverse order so oldest is added first — addToHistory prepends,
 			// making the final in-memory array index 0 = most recent.
 			for (let i = history.length - 1; i >= 0; i--) {
-				(currentEditor as any)?.addToHistory?.(history[i])
+				getCurrentEditor()?.addToHistory?.(history[i])
 			}
 		})
 	})

--- a/src/extensions/prompt-history.ts
+++ b/src/extensions/prompt-history.ts
@@ -1,0 +1,83 @@
+/**
+ * prompt-history — Cross-session prompt history persistence.
+ *
+ * Reads/writes ~/.config/kimchi/prompt-history.json so the up/down arrow
+ * history in the editor survives restarts.
+ *
+ * - session_start: loads saved entries and feeds them into the editor's
+ *   addToHistory() via setImmediate (after ui.ts has installed the editor).
+ * - input: prepends each non-empty, non-duplicate submission, caps at 500
+ *   entries, writes atomically (.tmp + renameSync).
+ *
+ * All disk I/O is wrapped in try/catch — never throws.
+ */
+
+import { mkdirSync, readFileSync, renameSync, writeFileSync } from "node:fs"
+import { homedir } from "node:os"
+import { join } from "node:path"
+import type { ExtensionAPI, InputEvent } from "@earendil-works/pi-coding-agent"
+import { currentEditor } from "./ui.js"
+
+const HISTORY_FILE = join(homedir(), ".config", "kimchi", "prompt-history.json")
+const MAX_HISTORY = 500
+
+interface PromptHistory {
+	history: string[]
+}
+
+function loadHistory(): string[] {
+	try {
+		const raw = readFileSync(HISTORY_FILE, "utf-8")
+		const parsed = JSON.parse(raw) as PromptHistory
+		if (Array.isArray(parsed.history)) return parsed.history
+	} catch {
+		// file missing or corrupt — start fresh
+	}
+	return []
+}
+
+function saveHistory(history: string[]): void {
+	try {
+		const dir = join(homedir(), ".config", "kimchi")
+		mkdirSync(dir, { recursive: true })
+		const tmp = `${HISTORY_FILE}.tmp`
+		writeFileSync(tmp, JSON.stringify({ history }, null, 2), "utf-8")
+		renameSync(tmp, HISTORY_FILE)
+	} catch {
+		// best-effort; never throw
+	}
+}
+
+export default function promptHistoryExtension(pi: ExtensionAPI) {
+	pi.on("session_start", () => {
+		const history = loadHistory()
+		if (history.length === 0) return
+
+		setImmediate(() => {
+			// Reverse order so oldest is added first — addToHistory prepends,
+			// making the final in-memory array index 0 = most recent.
+			for (let i = history.length - 1; i >= 0; i--) {
+				(currentEditor as any)?.addToHistory?.(history[i])
+			}
+		})
+	})
+
+	pi.on("input", (event: InputEvent) => {
+		const text = event.text.trim()
+		if (!text) return
+
+		const history = loadHistory()
+
+		// Skip consecutive duplicate of the last entry
+		if (history.length > 0 && history[0] === text) return
+
+		history.unshift(text)
+
+		// Cap at MAX_HISTORY
+		if (history.length > MAX_HISTORY) {
+			history.length = MAX_HISTORY
+		}
+
+		saveHistory(history)
+	})
+}

--- a/src/extensions/ui.ts
+++ b/src/extensions/ui.ts
@@ -125,7 +125,12 @@ function getEnabledModelIds(): Set<string> | null {
 }
 
 // Track current editor for indicator updates
-export let currentEditor: PromptEditor | undefined
+let currentEditor: PromptEditor | undefined
+
+export function getCurrentEditor(): PromptEditor | undefined {
+	return currentEditor
+}
+
 let pasteImageHandler: (() => void) | undefined
 let currentSessionIndicatorText: string | null = null
 

--- a/src/extensions/ui.ts
+++ b/src/extensions/ui.ts
@@ -125,7 +125,7 @@ function getEnabledModelIds(): Set<string> | null {
 }
 
 // Track current editor for indicator updates
-let currentEditor: PromptEditor | undefined
+export let currentEditor: PromptEditor | undefined
 let pasteImageHandler: (() => void) | undefined
 let currentSessionIndicatorText: string | null = null
 


### PR DESCRIPTION
CONTEXT: The editor supported in-session up/down arrow history via addToHistory() and navigateHistory(), but history was lost on restart.
CHANGE: Creates prompt-history extension that reads/writes ~/.config/kimchi/prompt-history.json. On session_start, loads saved entries into the editor via setImmediate. On input, persists each non-duplicate submission atomically (.tmp + renameSync), capped at 500 entries. Also exports currentEditor from ui.ts so prompt-history can access addToHistory.
WHY: The in-memory navigation already worked; this adds the missing persistence layer without patching pi-tui or pi-coding-agent internals.
IMPACT: Users get cross-session prompt history, making the CLI feel more polished and reducing friction for repeated commands.

## Description

<!-- What problem does this PR solve? What changes were made and why? -->


## Type of Change

<!-- Select all that apply. -->

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
