### PR TITLE
feat(acp): Request permission

### DIFF
--- a/src/extensions/permissions/index.test.ts
+++ b/src/extensions/permissions/index.test.ts
@@ -1,5 +1,7 @@
 import type { ExtensionAPI, ExtensionContext, ToolCallEvent, ToolInfo } from "@earendil-works/pi-coding-agent"
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
+import { registerAcpPrompter, unregisterAcpPrompter } from "../../modes/acp/permission-prompter-registry.js"
+import { runAsAgentWorker } from "../agent-worker-context.js"
 import { FERMENT_TOOLS } from "../ferment/tool-names.js"
 import { type EnvironmentInfo, buildSystemPrompt } from "../prompt-construction/system-prompt.js"
 import { createToolVisibility } from "../prompt-construction/tool-visibility.js"
@@ -81,6 +83,8 @@ function createClassifierContext(): ExtensionContext {
 // Helper to create a mock tool call event
 function createMockEvent(): ToolCallEvent {
 	return {
+		type: "tool_call",
+		toolCallId: "tool-call-1",
 		toolName: "bash",
 		input: { command: "echo a && echo b" },
 		cwd: "/test",
@@ -371,6 +375,129 @@ describe("permissions ferment tool classification", () => {
 		expect(readResult).toBeUndefined()
 		expect(bashResult).toBeUndefined()
 		expect(classifyToolCall).not.toHaveBeenCalled()
+	})
+})
+
+describe("permissions ACP prompter", () => {
+	beforeEach(() => {
+		Reflect.deleteProperty(process.env, "KIMCHI_PERMISSIONS")
+		vi.mocked(classifyToolCall).mockClear()
+	})
+
+	afterEach(() => {
+		unregisterAcpPrompter(TEST_SESSION_ID)
+		vi.unstubAllEnvs()
+	})
+
+	it("uses a registered ACP prompter in headless default mode", async () => {
+		const requests: Array<{ toolCallId: string; choices: string[] }> = []
+		registerAcpPrompter(TEST_SESSION_ID, {
+			request: async (req) => {
+				requests.push({
+					toolCallId: req.toolCallId,
+					choices: req.choices.map((choice) => choice.kind),
+				})
+				return { kind: "allow-once" }
+			},
+		})
+		const harness = createPermissionsHarness(["bash"])
+		const ctx = createClassifierContext()
+		await harness.fire("session_start", {}, ctx)
+
+		const result = await harness.fire(
+			"tool_call",
+			{ type: "tool_call", toolCallId: "tc-acp", toolName: "bash", input: { command: "touch file.txt" } },
+			ctx,
+		)
+
+		expect(result).toBeUndefined()
+		expect(classifyToolCall).not.toHaveBeenCalled()
+		expect(requests).toEqual([
+			{
+				toolCallId: "tc-acp",
+				choices: ["allow-once", "allow-remember", "allow-remember-wildcard", "deny"],
+			},
+		])
+	})
+
+	it("does not remember allow_once approvals", async () => {
+		const requests: string[] = []
+		registerAcpPrompter(TEST_SESSION_ID, {
+			request: async (req) => {
+				requests.push(req.toolCallId)
+				return { kind: "allow-once" }
+			},
+		})
+		const harness = createPermissionsHarness(["bash"])
+		const ctx = createClassifierContext()
+		await harness.fire("session_start", {}, ctx)
+
+		for (const toolCallId of ["tc-once-1", "tc-once-2"]) {
+			const result = await harness.fire(
+				"tool_call",
+				{ type: "tool_call", toolCallId, toolName: "bash", input: { command: "touch once.txt" } },
+				ctx,
+			)
+			expect(result).toBeUndefined()
+		}
+
+		expect(requests).toEqual(["tc-once-1", "tc-once-2"])
+	})
+
+	it("stores allow_always as a session rule", async () => {
+		const requests: string[] = []
+		registerAcpPrompter(TEST_SESSION_ID, {
+			request: async (req) => {
+				requests.push(req.toolCallId)
+				const remember = req.choices.find((choice) => choice.kind === "allow-remember")
+				if (!remember || remember.kind !== "allow-remember") throw new Error("missing remember choice")
+				return { kind: "allow-remember", rule: remember.rule }
+			},
+		})
+		const harness = createPermissionsHarness(["bash"])
+		const ctx = createClassifierContext()
+		await harness.fire("session_start", {}, ctx)
+
+		for (const toolCallId of ["tc-remember-1", "tc-remember-2"]) {
+			const result = await harness.fire(
+				"tool_call",
+				{ type: "tool_call", toolCallId, toolName: "bash", input: { command: "touch remembered.txt" } },
+				ctx,
+			)
+			expect(result).toBeUndefined()
+		}
+
+		expect(requests).toEqual(["tc-remember-1"])
+	})
+
+	it("keeps subagent workers classifier-only even when an ACP prompter is registered", async () => {
+		const requests: string[] = []
+		vi.mocked(classifyToolCall).mockResolvedValueOnce({
+			verdict: "requires-confirmation",
+			reason: "needs a human",
+			ok: true,
+		})
+		registerAcpPrompter(TEST_SESSION_ID, {
+			request: async (req) => {
+				requests.push(req.toolCallId)
+				return { kind: "allow-once" }
+			},
+		})
+		const harness = createPermissionsHarness(["bash"])
+		const ctx = createClassifierContext()
+		await harness.fire("session_start", {}, ctx)
+
+		const result = await runAsAgentWorker(() =>
+			harness.fire(
+				"tool_call",
+				{ type: "tool_call", toolCallId: "tc-worker", toolName: "bash", input: { command: "touch worker.txt" } },
+				ctx,
+			),
+		)
+
+		expect(result).toEqual({ block: true, reason: "Classifier: needs a human (no UI to confirm)" })
+		expect(requests).toEqual([])
+		expect(classifyToolCall).toHaveBeenCalledTimes(1)
 	})
 })
 

--- a/src/extensions/permissions/index.ts
+++ b/src/extensions/permissions/index.ts
@@ -3,6 +3,8 @@ import type { Api, AssistantMessage, Model } from "@earendil-works/pi-ai"
 import type { ExtensionAPI, ExtensionContext, ToolCallEvent } from "@earendil-works/pi-coding-agent"
 import { isKeyRelease, matchesKey } from "@earendil-works/pi-tui"
 import { RST_FG, resolvedSemanticFg } from "../../ansi.js"
+import { getAcpPrompter } from "../../modes/acp/permission-prompter-registry.js"
+import { isAgentWorker } from "../agent-worker-context.js"
 import { hasActiveFerment, notifyFermentActive, onActiveFermentChange } from "../ferment/state.js"
 import { FERMENT_TOOLS, isFermentToolName, isUserFacingFermentToolName } from "../ferment/tool-names.js"
 import { createSystemPromptBlocks } from "../prompt-construction/index.js"
@@ -12,7 +14,14 @@ import { classifyToolCall } from "./classifier.js"
 import { registerCommands } from "./commands.js"
 import { type LoadedConfig, loadConfig } from "./config.js"
 import { resolveMode } from "./mode.js"
-import { type CompoundSubcommand, promptForApproval, promptForCompoundApproval, withWorkingHidden } from "./prompts.js"
+import type { ToolPermissionPrompter } from "./prompter.js"
+import {
+	type CompoundSubcommand,
+	buildPermissionChoices,
+	promptForCompoundApproval,
+	terminalPrompter,
+	withWorkingHidden,
+} from "./prompts.js"
 import planModeSupplement from "./prompts/plan-mode-supplement.js"
 import { evaluateRules, parseRules, stringifyRule } from "./rules.js"
 import { SessionMemory } from "./session-memory.js"
@@ -89,6 +98,18 @@ export function isUserChosenYolo(): boolean {
 }
 
 export { notifyFermentActive }
+
+function canPrompt(ctx: ExtensionContext): boolean {
+	if (isAgentWorker()) return false
+	if (ctx.hasUI) return true
+	return getAcpPrompter(ctx.sessionManager.getSessionId()) !== undefined
+}
+
+function resolvePrompter(ctx: ExtensionContext): ToolPermissionPrompter | undefined {
+	if (isAgentWorker()) return undefined
+	if (ctx.hasUI) return terminalPrompter(ctx)
+	return getAcpPrompter(ctx.sessionManager.getSessionId())
+}
 
 let _modeChangeListener: ((mode: PermissionMode) => void) | undefined
 
@@ -532,9 +553,10 @@ export default function permissionsExtension(pi: ExtensionAPI): void {
 				if (isReadOnlyBashCommand(command)) return undefined
 			}
 
-			// Auto mode + headless default mode (subagents) both go through the
-			// classifier; prompts without a UI fail closed.
-			if (mode === "auto" || !ctx.hasUI) {
+			// Auto mode + non-promptable default mode (headless/subagents) both go
+			// through the classifier; prompts without a frontend fail closed.
+			const promptAvailable = canPrompt(ctx)
+			if (mode === "auto" || !promptAvailable) {
 				const classifierModel = resolveClassifierModel(ctx.model, ctx.modelRegistry)
 				if (!classifierModel) return { block: true, reason: "no model available for classifier" }
 
@@ -550,7 +572,7 @@ export default function permissionsExtension(pi: ExtensionAPI): void {
 				if (verdict.verdict === "blocked") {
 					return { block: true, reason: `Classifier blocked: ${verdict.reason}` }
 				}
-				if (!ctx.hasUI) {
+				if (!promptAvailable) {
 					return { block: true, reason: `Classifier: ${verdict.reason} (no UI to confirm)` }
 				}
 				const result = await handleConfirm(event, {
@@ -631,31 +653,25 @@ async function handleConfirm(
 	opts: ConfirmOptions,
 ): Promise<{ block: true; reason: string } | "aborted" | undefined> {
 	const abort = new AbortController()
+	const unlinkAbort = linkAbortSignal(opts.ctx.signal, abort)
 	opts.activeAborts.add(abort)
 	try {
-		const outcome = await promptForApproval({
+		const prompter = resolvePrompter(opts.ctx)
+		if (!prompter) return { block: true, reason: "No UI to confirm permission" }
+
+		const input = event.input as Record<string, unknown>
+		const outcome = await prompter.request({
+			toolCallId: event.toolCallId ?? `${event.toolName}-permission`,
 			toolName: event.toolName,
-			input: event.input as Record<string, unknown>,
-			ctx: opts.ctx,
+			input,
 			subtitle: opts.subtitle,
+			choices: buildPermissionChoices(event.toolName, input),
 			signal: abort.signal,
 		})
 
-		if (outcome.kind === "aborted") return "aborted"
-		if (outcome.kind === "allow-once") return undefined
-		if (outcome.kind === "allow-remember") {
-			opts.session.add(outcome.rule)
-			return undefined
-		}
-		if (outcome.kind === "allow-remember-wildcard") {
-			opts.session.add(outcome.rule)
-			return undefined
-		}
-		if (outcome.kind === "deny-with-feedback") {
-			return { block: true, reason: outcome.feedback }
-		}
-		return { block: true, reason: "Declined by user" }
+		return applyApprovalOutcome(outcome, opts.session)
 	} finally {
+		unlinkAbort()
 		opts.activeAborts.delete(abort)
 	}
 }
@@ -665,8 +681,28 @@ export async function handleCompoundConfirm(
 	opts: ConfirmOptions & { subcommands: string[] },
 ): Promise<{ block: true; reason: string } | "aborted" | undefined> {
 	const abort = new AbortController()
+	const unlinkAbort = linkAbortSignal(opts.ctx.signal, abort)
 	opts.activeAborts.add(abort)
 	try {
+		const prompter = resolvePrompter(opts.ctx)
+		if (!prompter) return { block: true, reason: "No UI to confirm permission" }
+
+		if (!opts.ctx.hasUI) {
+			// ACP v1 presents compound commands as one permission card. It does
+			// not offer TUI's per-subcommand picker, so remembered rules are scoped
+			// to the compound call's suggested scope rather than each segment.
+			const input = event.input as Record<string, unknown>
+			const outcome = await prompter.request({
+				toolCallId: event.toolCallId ?? `${event.toolName}-permission`,
+				toolName: event.toolName,
+				input,
+				subtitle: opts.subtitle,
+				choices: buildPermissionChoices(event.toolName, input),
+				signal: abort.signal,
+			})
+			return applyApprovalOutcome(outcome, opts.session)
+		}
+
 		const compoundSubs: CompoundSubcommand[] = opts.subcommands.map((cmd) => ({
 			command: cmd,
 			description: `bash(${truncate(cmd, 100)})`,
@@ -724,8 +760,40 @@ export async function handleCompoundConfirm(
 
 		return { block: true, reason: "Declined by user" }
 	} finally {
+		unlinkAbort()
 		opts.activeAborts.delete(abort)
 	}
+}
+
+function applyApprovalOutcome(
+	outcome: Awaited<ReturnType<ToolPermissionPrompter["request"]>>,
+	session: SessionMemory,
+): { block: true; reason: string } | "aborted" | undefined {
+	if (outcome.kind === "aborted") return "aborted"
+	if (outcome.kind === "allow-once") return undefined
+	if (outcome.kind === "allow-remember") {
+		session.add(outcome.rule)
+		return undefined
+	}
+	if (outcome.kind === "allow-remember-wildcard") {
+		session.add(outcome.rule)
+		return undefined
+	}
+	if (outcome.kind === "deny-with-feedback") {
+		return { block: true, reason: outcome.feedback }
+	}
+	return { block: true, reason: "Declined by user" }
+}
+
+function linkAbortSignal(signal: AbortSignal | undefined, controller: AbortController): () => void {
+	if (!signal) return () => {}
+	if (signal.aborted) {
+		controller.abort()
+		return () => {}
+	}
+	const abort = () => controller.abort()
+	signal.addEventListener("abort", abort, { once: true })
+	return () => signal.removeEventListener("abort", abort)
 }
 
 function splitFlag(raw: boolean | string | undefined): string[] {

--- a/src/extensions/permissions/prompter.ts
+++ b/src/extensions/permissions/prompter.ts
@@ -1,0 +1,21 @@
+import type { ApprovalOutcome } from "./prompts.js"
+import type { Rule } from "./types.js"
+
+export type PermissionChoice =
+	| { kind: "allow-once"; label: string }
+	| { kind: "allow-remember"; label: string; rule: Rule }
+	| { kind: "allow-remember-wildcard"; label: string; rule: Rule }
+	| { kind: "deny"; label: string }
+
+export interface PermissionRequest {
+	toolCallId: string
+	toolName: string
+	input: Record<string, unknown>
+	subtitle?: string
+	choices: PermissionChoice[]
+	signal?: AbortSignal
+}
+
+export interface ToolPermissionPrompter {
+	request(req: PermissionRequest): Promise<ApprovalOutcome>
+}

--- a/src/extensions/permissions/prompts.ts
+++ b/src/extensions/permissions/prompts.ts
@@ -1,4 +1,5 @@
 import type { ExtensionContext } from "@earendil-works/pi-coding-agent"
+import type { PermissionChoice, ToolPermissionPrompter } from "./prompter.js"
 import { numberedChoices, stripChoiceNumber } from "./select-utils.js"
 import { suggestScope } from "./session-memory.js"
 import type { Rule } from "./types.js"
@@ -39,62 +40,90 @@ interface PromptOptions {
 	ctx: ExtensionContext
 	/** Extra context line shown above the choices (e.g. classifier reason). */
 	subtitle?: string
+	/** Structured choices to present. Defaults to the standard per-tool choices. */
+	choices?: PermissionChoice[]
 	/** Signal to programmatically dismiss the prompt (e.g. when permission mode changes). */
 	signal?: AbortSignal
+}
+
+export function terminalPrompter(ctx: ExtensionContext): ToolPermissionPrompter {
+	return {
+		request: (req) =>
+			promptForApproval({
+				toolName: req.toolName,
+				input: req.input,
+				ctx,
+				subtitle: req.subtitle,
+				choices: req.choices,
+				signal: req.signal,
+			}),
+	}
+}
+
+export function buildPermissionChoices(toolName: string, input: Record<string, unknown>): PermissionChoice[] {
+	const scope = suggestScope(toolName, input)
+
+	const choices: PermissionChoice[] = [
+		{ kind: "allow-once", label: "Yes — just this call" },
+		{
+			kind: "allow-remember",
+			label: `Yes — don't ask again for ${scope.label} this session`,
+			rule: {
+				toolName: scope.toolName,
+				content: scope.content,
+				behavior: "allow",
+				source: "session",
+			},
+		},
+	]
+
+	if (scope.wildcardContent) {
+		choices.push({
+			kind: "allow-remember-wildcard",
+			label: `Yes — don't ask again for ${scope.wildcardContent} this session`,
+			rule: {
+				toolName: scope.toolName,
+				content: `${scope.wildcardContent}`,
+				behavior: "allow",
+				source: "session",
+			},
+		})
+	}
+
+	choices.push({ kind: "deny", label: "No — tell the assistant what to do differently" })
+	return choices
 }
 
 export async function promptForApproval(opts: PromptOptions): Promise<ApprovalOutcome> {
 	const { ctx, toolName, input, subtitle } = opts
 	if (!ctx.hasUI) return { kind: "deny" }
 
-	const scope = suggestScope(toolName, input)
 	const callDescription = describeCall(toolName, input)
 
 	const lines = [`The assistant wants to run: ${callDescription}`]
 	if (subtitle) lines.push(subtitle)
 
-	const yesOnce = "Yes — just this call"
-	const yesRemember = `Yes — don't ask again for ${scope.label} this session`
-	const noWithFeedback = "No — tell the assistant what to do differently"
-	const yesWildcard = scope.wildcardContent
-		? `Yes — don't ask again for ${scope.wildcardContent} this session`
-		: undefined
-
-	// Add wildcard option for bash commands
-	const choices = numberedChoices(
-		yesWildcard ? [yesOnce, yesRemember, yesWildcard, noWithFeedback] : [yesOnce, yesRemember, noWithFeedback],
-	)
+	const permissionChoices = opts.choices ?? buildPermissionChoices(toolName, input)
+	const choices = numberedChoices(permissionChoices.map((choice) => choice.label))
 
 	const choice = await withWorkingHidden(ctx, () => ctx.ui.select(lines.join("\n"), choices, { signal: opts.signal }))
 
 	if (choice === undefined && opts.signal?.aborted) return { kind: "aborted" }
 
 	const selected = choice ? stripChoiceNumber(choice) : undefined
+	const selectedChoice = permissionChoices.find((candidate) => candidate.label === selected)
 
-	if (selected === yesOnce) return { kind: "allow-once" }
+	if (selectedChoice?.kind === "allow-once") return { kind: "allow-once" }
 
-	if (selected === yesRemember) {
-		const rule: Rule = {
-			toolName: scope.toolName,
-			content: scope.content,
-			behavior: "allow",
-			source: "session",
-		}
-		return { kind: "allow-remember", rule }
+	if (selectedChoice?.kind === "allow-remember") {
+		return { kind: "allow-remember", rule: selectedChoice.rule }
 	}
 
-	// Check if wildcard was selected (only applicable for bash)
-	if (yesWildcard && selected === yesWildcard) {
-		const rule: Rule = {
-			toolName: scope.toolName,
-			content: `${scope.wildcardContent}`,
-			behavior: "allow",
-			source: "session",
-		}
-		return { kind: "allow-remember-wildcard", rule }
+	if (selectedChoice?.kind === "allow-remember-wildcard") {
+		return { kind: "allow-remember-wildcard", rule: selectedChoice.rule }
 	}
 
-	if (selected === noWithFeedback) {
+	if (selectedChoice?.kind === "deny") {
 		const feedback = await withWorkingHidden(ctx, () => ctx.ui.input("Tell the assistant what to do differently:"))
 		const text = feedback?.trim()
 		if (text) return { kind: "deny-with-feedback", feedback: text }

--- a/src/modes/acp/acp-prompter.ts
+++ b/src/modes/acp/acp-prompter.ts
@@ -1,0 +1,76 @@
+import type {
+	AgentSideConnection,
+	PermissionOption,
+	RequestPermissionResponse,
+	ToolCallUpdate,
+} from "@agentclientprotocol/sdk"
+import type { PermissionChoice, ToolPermissionPrompter } from "../../extensions/permissions/prompter.js"
+import type { ApprovalOutcome } from "../../extensions/permissions/prompts.js"
+
+export type ToolCallUpdateBuilder = (
+	toolCallId: string,
+	toolName: string,
+	input: Record<string, unknown>,
+) => ToolCallUpdate
+
+export function createAcpPermissionPrompter(
+	conn: AgentSideConnection,
+	sessionId: string,
+	buildToolCallUpdate: ToolCallUpdateBuilder,
+): ToolPermissionPrompter {
+	return {
+		async request(req): Promise<ApprovalOutcome> {
+			if (req.signal?.aborted) return { kind: "aborted" }
+
+			const optionById = new Map<string, PermissionChoice>()
+			const options: PermissionOption[] = req.choices.map((choice, index) => {
+				const optionId = `choice-${index}`
+				optionById.set(optionId, choice)
+				return {
+					optionId,
+					name: choice.label,
+					kind: choice.kind === "deny" ? "reject_once" : choice.kind === "allow-once" ? "allow_once" : "allow_always",
+				}
+			})
+
+			const response = await requestWithAbort(
+				conn.requestPermission({
+					sessionId,
+					toolCall: buildToolCallUpdate(req.toolCallId, req.toolName, req.input),
+					options,
+				}),
+				req.signal,
+			)
+
+			if (response === "aborted" || response.outcome.outcome === "cancelled") return { kind: "aborted" }
+
+			const selected = optionById.get(response.outcome.optionId)
+			if (!selected) return { kind: "deny" }
+
+			switch (selected.kind) {
+				case "allow-once":
+					return { kind: "allow-once" }
+				case "allow-remember":
+					return { kind: "allow-remember", rule: selected.rule }
+				case "allow-remember-wildcard":
+					return { kind: "allow-remember-wildcard", rule: selected.rule }
+				case "deny":
+					return { kind: "deny" }
+			}
+		},
+	}
+}
+
+function requestWithAbort(
+	request: Promise<RequestPermissionResponse>,
+	signal: AbortSignal | undefined,
+): Promise<RequestPermissionResponse | "aborted"> {
+	if (!signal) return request
+	if (signal.aborted) return Promise.resolve("aborted")
+
+	return new Promise((resolve, reject) => {
+		const onAbort = () => resolve("aborted")
+		signal.addEventListener("abort", onAbort, { once: true })
+		request.then(resolve, reject).finally(() => signal.removeEventListener("abort", onAbort))
+	})
+}

--- a/src/modes/acp/permission-prompter-registry.ts
+++ b/src/modes/acp/permission-prompter-registry.ts
@@ -2,9 +2,8 @@ import type { ToolPermissionPrompter } from "../../extensions/permissions/prompt
 
 const bySessionId = new Map<string, ToolPermissionPrompter>()
 
-// Keep this paired with every ACP session ownership path. Any future
-// closeSession/releaseSession RPC that removes from KimchiAcpAgent.sessions
-// must call unregisterAcpPrompter for the same sessionId.
+// Keep this paired with every ACP session ownership path: load/new register,
+// bind failures, session/close, and process shutdown all need symmetric cleanup.
 export function registerAcpPrompter(sessionId: string, prompter: ToolPermissionPrompter): void {
 	bySessionId.set(sessionId, prompter)
 }

--- a/src/modes/acp/permission-prompter-registry.ts
+++ b/src/modes/acp/permission-prompter-registry.ts
@@ -1,0 +1,18 @@
+import type { ToolPermissionPrompter } from "../../extensions/permissions/prompter.js"
+
+const bySessionId = new Map<string, ToolPermissionPrompter>()
+
+// Keep this paired with every ACP session ownership path. Any future
+// closeSession/releaseSession RPC that removes from KimchiAcpAgent.sessions
+// must call unregisterAcpPrompter for the same sessionId.
+export function registerAcpPrompter(sessionId: string, prompter: ToolPermissionPrompter): void {
+	bySessionId.set(sessionId, prompter)
+}
+
+export function unregisterAcpPrompter(sessionId: string): void {
+	bySessionId.delete(sessionId)
+}
+
+export function getAcpPrompter(sessionId: string): ToolPermissionPrompter | undefined {
+	return bySessionId.get(sessionId)
+}

--- a/src/modes/acp/server.test.ts
+++ b/src/modes/acp/server.test.ts
@@ -1,7 +1,12 @@
 import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs"
 import { tmpdir } from "node:os"
 import { join, resolve } from "node:path"
-import type { AgentSideConnection, ListSessionsRequest, SessionNotification } from "@agentclientprotocol/sdk"
+import type {
+	AgentSideConnection,
+	ListSessionsRequest,
+	RequestPermissionRequest,
+	SessionNotification,
+} from "@agentclientprotocol/sdk"
 import type {
 	AgentSession,
 	AgentSessionEvent,
@@ -10,6 +15,7 @@ import type {
 } from "@earendil-works/pi-coding-agent"
 import { afterEach, beforeEach, describe, expect, it } from "vitest"
 import { _resetState as _resetHideThinking, _setHideThinking } from "../../extensions/hide-thinking.js"
+import { getAcpPrompter } from "./permission-prompter-registry.js"
 import {
 	type AcpSessionFactory,
 	type AcpSessionLister,
@@ -35,10 +41,19 @@ class FakeAgentSession {
 	private listeners = new Set<AgentSessionEventListener>()
 	disposed = false
 	aborted = false
-	model?: { provider: string; id: string; name?: string; input?: string[] }
-	modelRegistry = { getAvailable: () => [] as Array<{ provider: string; id: string; name: string }> }
+	model: { provider: string; id: string; name?: string; input?: string[] } | undefined = {
+		provider: "test",
+		id: "test-model",
+		name: "Test Model",
+		input: ["text"],
+	}
+	modelRegistry = {
+		getAvailable: () =>
+			this.model ? [{ provider: this.model.provider, id: this.model.id, name: this.model.name ?? this.model.id }] : [],
+	}
 	promptImpl: (text: string, opts?: { images?: unknown[] }) => Promise<void> = async () => {}
 	abortImpl: () => Promise<void> = async () => {}
+	bindExtensionsImpl: (_bindings: unknown) => Promise<void> = async () => {}
 	lastPromptImages?: unknown[]
 	// Branch entries returned to the replay walker. Tests fill this with the
 	// shape buildSessionContext consumers expect (type:"message" + role).
@@ -74,6 +89,10 @@ class FakeAgentSession {
 	async abort(): Promise<void> {
 		this.aborted = true
 		await this.abortImpl()
+	}
+
+	async bindExtensions(bindings: unknown): Promise<void> {
+		await this.bindExtensionsImpl(bindings)
 	}
 
 	dispose(): void {
@@ -605,6 +624,118 @@ describe("KimchiAcpAgent turn lifecycle", () => {
 		expect(leaky.disposed).toBe(true)
 	})
 
+	it("unregisters the ACP permission prompter if bindExtensions throws during newSession", async () => {
+		const leaky = new FakeAgentSession("session-bind-leak")
+		leaky.bindExtensionsImpl = async () => {
+			throw new Error("bind boom")
+		}
+		const factory: AcpSessionFactory = async () => asSession(leaky)
+		const localAgent = new KimchiAcpAgent(makeConn(), {
+			extensionFactories: [],
+			agentDir: "/tmp/fake-agent-dir",
+			sessionFactory: factory,
+		})
+
+		await expect(localAgent.newSession({ cwd: "/tmp", mcpServers: [] })).rejects.toThrow(/bind boom/)
+		expect(leaky.disposed).toBe(true)
+		expect(getAcpPrompter("session-bind-leak")).toBeUndefined()
+	})
+
+	it("registers an ACP permission prompter that maps allow_once through requestPermission", async () => {
+		const requests: RequestPermissionRequest[] = []
+		const conn = {
+			sessionUpdate: async (_p: SessionNotification) => {},
+			requestPermission: async (params: RequestPermissionRequest) => {
+				requests.push(params)
+				return { outcome: { outcome: "selected", optionId: "choice-0" } }
+			},
+		} as unknown as AgentSideConnection
+		const localFake = new FakeAgentSession("session-permission")
+		const localAgent = new KimchiAcpAgent(conn, {
+			extensionFactories: [],
+			agentDir: "/tmp/fake-agent-dir",
+			sessionFactory: async () => asSession(localFake),
+		})
+		await localAgent.newSession({ cwd: "/tmp", mcpServers: [] })
+
+		const prompter = getAcpPrompter("session-permission")
+		expect(prompter).toBeDefined()
+		const result = await prompter?.request({
+			toolCallId: "tc-permission",
+			toolName: "bash",
+			input: { command: "touch allowed.txt" },
+			choices: [
+				{ kind: "allow-once", label: "Allow once" },
+				{ kind: "deny", label: "Deny" },
+			],
+		})
+
+		expect(result).toEqual({ kind: "allow-once" })
+		expect(requests).toHaveLength(1)
+		expect(requests[0]).toMatchObject({
+			sessionId: "session-permission",
+			toolCall: {
+				toolCallId: "tc-permission",
+				title: "touch allowed.txt",
+				kind: "execute",
+				status: "pending",
+				rawInput: { command: "touch allowed.txt" },
+			},
+			options: [
+				{ optionId: "choice-0", name: "Allow once", kind: "allow_once" },
+				{ optionId: "choice-1", name: "Deny", kind: "reject_once" },
+			],
+		})
+
+		await localAgent.shutdown()
+		expect(getAcpPrompter("session-permission")).toBeUndefined()
+	})
+
+	it("maps ACP permission cancellation to an aborted prompt result", async () => {
+		const requests: RequestPermissionRequest[] = []
+		const conn = {
+			sessionUpdate: async (_p: SessionNotification) => {},
+			requestPermission: async (params: RequestPermissionRequest) => {
+				requests.push(params)
+				return {
+					outcome: { outcome: "cancelled" },
+				}
+			},
+		} as unknown as AgentSideConnection
+		const localFake = new FakeAgentSession("session-permission-cancel")
+		const localAgent = new KimchiAcpAgent(conn, {
+			extensionFactories: [],
+			agentDir: "/tmp/fake-agent-dir",
+			sessionFactory: async () => asSession(localFake),
+		})
+		await localAgent.newSession({ cwd: "/tmp", mcpServers: [] })
+
+		const prompter = getAcpPrompter("session-permission-cancel")
+		const result = await prompter?.request({
+			toolCallId: "tc-cancel",
+			toolName: "write",
+			input: { path: "/tmp/out.txt", content: "x" },
+			choices: [{ kind: "allow-once", label: "Allow once" }],
+		})
+
+		expect(result).toEqual({ kind: "aborted" })
+		expect(requests).toHaveLength(1)
+
+		const abort = new AbortController()
+		abort.abort()
+		const skippedResult = await prompter?.request({
+			toolCallId: "tc-cancel-retry",
+			toolName: "write",
+			input: { path: "/tmp/out.txt", content: "x" },
+			choices: [{ kind: "allow-once", label: "Allow once" }],
+			signal: abort.signal,
+		})
+
+		expect(skippedResult).toEqual({ kind: "aborted" })
+		expect(requests).toHaveLength(1)
+		await localAgent.shutdown()
+	})
+
 	// mcpServers is declared in the ACP request shape but kimchi has no hook to
 	// wire them into a live session — pi-coding-agent loads MCP servers from its
 	// own config. Silently dropping them would leave the client believing those
@@ -934,6 +1065,7 @@ describe("assertSessionHasModel", () => {
 describe("buildSessionModelState", () => {
 	it("returns null when model is missing", () => {
 		const fake = new FakeAgentSession("s1")
+		fake.model = undefined
 		const result = buildSessionModelState(fake as unknown as Parameters<typeof buildSessionModelState>[0])
 		expect(result).toBeNull()
 	})
@@ -994,18 +1126,17 @@ describe("newSession model state", () => {
 		expect(res.models?.availableModels[1]).toEqual({ modelId: "anthropic/claude-3", name: "Claude 3" })
 	})
 
-	it("returns models: null when no model is active", async () => {
+	it("rejects with authRequired when no model is active", async () => {
 		const fake = new FakeAgentSession("session-empty")
-		// model defaults to undefined
+		fake.model = undefined
 		const factory: AcpSessionFactory = async () => asSession(fake)
 		const agent = new KimchiAcpAgent(makeConn(), {
 			extensionFactories: [],
 			agentDir: "/tmp/fake-agent-dir",
 			sessionFactory: factory,
 		})
-		const res = await agent.newSession({ cwd: "/tmp", mcpServers: [] })
-		expect(res.sessionId).toBe("session-empty")
-		expect(res.models).toBeNull()
+		await expect(agent.newSession({ cwd: "/tmp", mcpServers: [] })).rejects.toMatchObject({ code: -32000 })
+		expect(fake.disposed).toBe(true)
 	})
 })
 
@@ -1749,20 +1880,19 @@ describe("KimchiAcpAgent loadSession", () => {
 		await expect(agent.cancel({ sessionId: "loaded-cancel" })).resolves.toBeUndefined()
 	})
 
-	it("returns null models when the loaded session has no model", async () => {
+	it("rejects loaded sessions with no model", async () => {
 		const fake = new FakeAgentSession("loaded-no-model")
 		fake.model = undefined
 		fake.branch = []
 		const agent = makeAgent(async () => asSession(fake))
-		const res = await agent.loadSession({
-			sessionId: "loaded-no-model",
-			cwd: "/tmp",
-			mcpServers: [],
-		})
-		// modelStateForSession returns undefined when model is missing; the
-		// loadSession response normalizes that to null so clients see a
-		// consistent shape regardless.
-		expect(res.models).toBeNull()
+		await expect(
+			agent.loadSession({
+				sessionId: "loaded-no-model",
+				cwd: "/tmp",
+				mcpServers: [],
+			}),
+		).rejects.toMatchObject({ code: -32000 })
+		expect(fake.disposed).toBe(true)
 	})
 
 	it("registers the loaded session so a follow-up prompt is accepted", async () => {

--- a/src/modes/acp/server.test.ts
+++ b/src/modes/acp/server.test.ts
@@ -774,6 +774,84 @@ describe("KimchiAcpAgent turn lifecycle", () => {
 		expect(fake.disposed).toBe(true)
 	})
 
+	it("keeps a same-id reload isolated while close awaits abort", async () => {
+		const sid = "session-close-reload"
+		const oldFake = new FakeAgentSession(sid)
+		const newFake = new FakeAgentSession(sid)
+		const { conn, updates } = makeRecordingConn()
+		let loaderCalls = 0
+		let releaseOldPrompt!: () => void
+		const oldPromptReleased = new Promise<void>((resolve) => {
+			releaseOldPrompt = resolve
+		})
+		let releaseNewPrompt!: () => void
+		const newPromptReleased = new Promise<void>((resolve) => {
+			releaseNewPrompt = resolve
+		})
+		let markNewPromptStarted!: () => void
+		const newPromptStarted = new Promise<void>((resolve) => {
+			markNewPromptStarted = resolve
+		})
+		let newPrompt: Promise<unknown> | undefined
+		const localAgent = new KimchiAcpAgent(conn, {
+			extensionFactories: [],
+			agentDir: "/tmp/fake-agent-dir",
+			sessionFactory: async () => asSession(oldFake),
+			sessionLoader: async () => {
+				loaderCalls++
+				return asSession(newFake)
+			},
+		})
+
+		oldFake.promptImpl = async () => {
+			oldFake.emit({ type: "agent_start" })
+			await oldPromptReleased
+		}
+		newFake.promptImpl = async () => {
+			newFake.emit({ type: "agent_start" })
+			markNewPromptStarted()
+			await newPromptReleased
+			newFake.emit({ type: "agent_end", messages: [] })
+		}
+		oldFake.abortImpl = async () => {
+			await localAgent.loadSession({ sessionId: sid, cwd: "/tmp", mcpServers: [] })
+			newPrompt = localAgent.prompt({
+				sessionId: sid,
+				prompt: [{ type: "text", text: "new turn" }],
+			})
+			await newPromptStarted
+			oldFake.emit({
+				type: "message_update",
+				assistantMessageEvent: { type: "text_delta", delta: "stale old event" },
+			} as unknown as AgentSessionEvent)
+			releaseNewPrompt()
+		}
+
+		await localAgent.newSession({ cwd: "/tmp", mcpServers: [] })
+		const oldPrompt = localAgent.prompt({
+			sessionId: sid,
+			prompt: [{ type: "text", text: "old turn" }],
+		})
+		await delay(0)
+
+		await localAgent.unstable_closeSession({ sessionId: sid })
+		releaseOldPrompt()
+
+		await expect(oldPrompt).resolves.toEqual({ stopReason: "cancelled" })
+		await expect(newPrompt).resolves.toEqual({ stopReason: "end_turn" })
+		expect(loaderCalls).toBe(1)
+		expect(getAcpPrompter(sid)).toBeDefined()
+		expect(
+			updates.some(
+				(u) =>
+					u.update.sessionUpdate === "agent_message_chunk" &&
+					(u.update as { content: { text: string } }).content.text === "stale old event",
+			),
+		).toBe(false)
+
+		await localAgent.shutdown()
+	})
+
 	// mcpServers is declared in the ACP request shape but kimchi has no hook to
 	// wire them into a live session — pi-coding-agent loads MCP servers from its
 	// own config. Silently dropping them would leave the client believing those

--- a/src/modes/acp/server.test.ts
+++ b/src/modes/acp/server.test.ts
@@ -736,6 +736,44 @@ describe("KimchiAcpAgent turn lifecycle", () => {
 		await localAgent.shutdown()
 	})
 
+	it("closes a live session and unregisters its ACP permission prompter", async () => {
+		expect(getAcpPrompter(sessionId)).toBeDefined()
+
+		await agent.unstable_closeSession({ sessionId })
+
+		expect(fake.disposed).toBe(true)
+		expect(getAcpPrompter(sessionId)).toBeUndefined()
+		await expect(
+			agent.prompt({
+				sessionId,
+				prompt: [{ type: "text", text: "hello" }],
+			}),
+		).rejects.toMatchObject({ code: -32602 })
+	})
+
+	it("cancels an in-flight turn when closing a session", async () => {
+		let releasePrompt!: () => void
+		const promptReleased = new Promise<void>((resolve) => {
+			releasePrompt = resolve
+		})
+		fake.promptImpl = async () => {
+			fake.emit({ type: "agent_start" })
+			await promptReleased
+		}
+
+		const result = agent.prompt({
+			sessionId,
+			prompt: [{ type: "text", text: "hello" }],
+		})
+		await delay(0)
+		await agent.unstable_closeSession({ sessionId })
+		releasePrompt()
+
+		await expect(result).resolves.toEqual({ stopReason: "cancelled" })
+		expect(fake.aborted).toBe(true)
+		expect(fake.disposed).toBe(true)
+	})
+
 	// mcpServers is declared in the ACP request shape but kimchi has no hook to
 	// wire them into a live session — pi-coding-agent loads MCP servers from its
 	// own config. Silently dropping them would leave the client believing those
@@ -1593,6 +1631,7 @@ describe("KimchiAcpAgent loadSession", () => {
 			clientCapabilities: {} as never,
 		} as never)
 		expect(init.agentCapabilities?.loadSession).toBe(true)
+		expect(init.agentCapabilities?.sessionCapabilities?.close).toEqual({})
 	})
 
 	it("rejects loadSession when mcpServers is non-empty (does not invoke loader)", async () => {
@@ -1613,28 +1652,62 @@ describe("KimchiAcpAgent loadSession", () => {
 		expect(loaderCalls.count).toBe(0)
 	})
 
-	it("rejects loadSession with invalidRequest when sessionId is already loaded", async () => {
+	it("replays and returns an already loaded session without reopening it", async () => {
 		const loaderCalls = { count: 0 }
 		const live = new FakeAgentSession("live-1")
+		live.branch = [userTextEntry("already here", "u1", null)]
 		const factory: AcpSessionFactory = async () => asSession(live)
 		const loader: AcpSessionLoader = async () => {
 			loaderCalls.count++
 			return asSession(new FakeAgentSession("unused"))
 		}
-		const agent = new KimchiAcpAgent(makeConn(), {
+		const { conn, updates } = makeRecordingConn()
+		const agent = new KimchiAcpAgent(conn, {
 			extensionFactories: [],
 			agentDir: "/tmp/fake-agent-dir",
 			sessionFactory: factory,
 			sessionLoader: loader,
 		})
 		await agent.newSession({ cwd: "/tmp", mcpServers: [] })
-		await expect(agent.loadSession({ sessionId: "live-1", cwd: "/tmp", mcpServers: [] })).rejects.toMatchObject({
-			code: -32600,
+
+		const res = await agent.loadSession({ sessionId: "live-1", cwd: "/tmp", mcpServers: [] })
+
+		expect(res.models).toMatchObject({
+			currentModelId: "test/test-model",
 		})
-		// invalidRequest must short-circuit BEFORE the loader runs — otherwise
-		// we'd open the same JSONL twice (and pi's append-only writers would
-		// interleave entries on the next prompt).
 		expect(loaderCalls.count).toBe(0)
+		expect(updates).toHaveLength(1)
+		expect(updates[0].update).toMatchObject({
+			sessionUpdate: "user_message_chunk",
+			content: { type: "text", text: "already here" },
+		})
+	})
+
+	it("coalesces concurrent loadSession requests for the same sessionId", async () => {
+		const fake = new FakeAgentSession("coalesce-1")
+		let loaderCalls = 0
+		let markLoaderStarted!: () => void
+		let releaseLoader!: () => void
+		const loaderStarted = new Promise<void>((resolve) => {
+			markLoaderStarted = resolve
+		})
+		const release = new Promise<void>((resolve) => {
+			releaseLoader = resolve
+		})
+		const loader: AcpSessionLoader = async () => {
+			loaderCalls++
+			markLoaderStarted()
+			await release
+			return asSession(fake)
+		}
+		const agent = makeAgent(loader)
+		const first = agent.loadSession({ sessionId: "coalesce-1", cwd: "/tmp", mcpServers: [] })
+		await loaderStarted
+		const second = agent.loadSession({ sessionId: "coalesce-1", cwd: "/tmp", mcpServers: [] })
+		releaseLoader()
+
+		await expect(Promise.all([first, second])).resolves.toHaveLength(2)
+		expect(loaderCalls).toBe(1)
 	})
 
 	it("propagates loader errors (e.g. missing file → invalidParams)", async () => {

--- a/src/modes/acp/server.ts
+++ b/src/modes/acp/server.ts
@@ -30,6 +30,7 @@ import {
 	type SetSessionModelResponse,
 	type ToolCallContent,
 	type ToolCallLocation,
+	type ToolCallUpdate,
 	type ToolKind,
 	ndJsonStream,
 } from "@agentclientprotocol/sdk"
@@ -48,11 +49,14 @@ import {
 	createAgentSession,
 } from "@earendil-works/pi-coding-agent"
 import { isHideThinkingEnabled } from "../../extensions/hide-thinking.js"
+import { createAcpPermissionPrompter } from "./acp-prompter.js"
+import { registerAcpPrompter, unregisterAcpPrompter } from "./permission-prompter-registry.js"
 
 /**
- * Produces a ready-to-use AgentSession for a newSession request. The returned
- * session must already have its model verified and extensions bound. Exposed
- * so tests can inject fakes; production uses {@link defaultSessionFactory}.
+ * Produces an unbound AgentSession for a newSession request. The ACP agent owns
+ * model verification, extension binding, ACP prompter registration, and final
+ * lifecycle registration. Exposed so tests can inject fakes; production uses
+ * {@link defaultSessionFactory}.
  */
 export type AcpSessionFactory = (params: NewSessionRequest) => Promise<AgentSession>
 
@@ -63,10 +67,10 @@ export type AcpSessionFactory = (params: NewSessionRequest) => Promise<AgentSess
 export type AcpSessionLister = (params: ListSessionsRequest) => Promise<PiSessionInfo[]>
 
 /**
- * Opens a persisted session for a loadSession request. The returned AgentSession
- * must already be fully wired (model verified, extensions bound) and seeded
- * with the on-disk transcript; the agent only handles registration, replay,
- * and response shaping. Exposed so tests can stub disk access.
+ * Opens a persisted, unbound session for a loadSession request. The returned
+ * AgentSession is seeded with the on-disk transcript; the ACP agent owns model
+ * verification, extension binding, replay, and response shaping. Exposed so
+ * tests can stub disk access.
  */
 export type AcpSessionLoader = (params: LoadSessionRequest) => Promise<AgentSession>
 
@@ -188,16 +192,21 @@ export class KimchiAcpAgent implements Agent {
 			)
 		}
 		const session = await this.sessionFactory(params)
-		// Once the factory hands us a live session we own its lifecycle. If subscribe or
-		// the registering Map.set throws before we hand it back to the caller, nothing
-		// else will ever dispose it — so make ownership transfer atomic.
+		// Once the factory hands us a live session we own its lifecycle. If model
+		// verification, extension binding, subscribe, or the registering Map.set
+		// throws before we hand it back to the caller, nothing else will ever
+		// dispose it — so make ownership transfer atomic.
 		try {
+			assertSessionHasModel(session)
 			const sessionId = session.sessionId
+			registerAcpPrompter(sessionId, createAcpPermissionPrompter(this.conn, sessionId, buildToolCallUpdate))
+			await bindAcpExtensions(session)
 			const unsubscribe = session.subscribe((event) => this.onSessionEvent(sessionId, event))
 			this.sessions.set(sessionId, { session, unsubscribe })
 			const models = buildSessionModelState(session)
 			return { sessionId, models }
 		} catch (err) {
+			unregisterAcpPrompter(session.sessionId)
 			session.dispose()
 			throw err
 		}
@@ -275,6 +284,9 @@ export class KimchiAcpAgent implements Agent {
 			)
 		}
 		try {
+			assertSessionHasModel(session)
+			registerAcpPrompter(sid, createAcpPermissionPrompter(this.conn, sid, buildToolCallUpdate))
+			await bindAcpExtensions(session)
 			const unsubscribe = session.subscribe((event) => this.onSessionEvent(sid, event))
 			this.sessions.set(sid, { session, unsubscribe })
 			// Replay BEFORE the response resolves so Zed sees a coherent transcript
@@ -284,6 +296,7 @@ export class KimchiAcpAgent implements Agent {
 			this.replayTranscript(session)
 			return { models: this.modelStateForSession(session) }
 		} catch (err) {
+			unregisterAcpPrompter(sid)
 			const existing = this.sessions.get(sid)
 			if (existing) {
 				this.sessions.delete(sid)
@@ -407,6 +420,7 @@ export class KimchiAcpAgent implements Agent {
 		for (const entry of this.sessions.values()) {
 			if (entry.turn) this.failTurn(entry, new Error("acp agent shutting down"))
 			entry.unsubscribe()
+			unregisterAcpPrompter(entry.session.sessionId)
 			// Emit session_shutdown to extensions and await all handlers before
 			// calling dispose(). dispose() is synchronous and returns void, so
 			// async extension handlers (e.g. telemetry drain, shutdown marker)
@@ -739,6 +753,14 @@ export function assertSessionHasModel(session: Pick<AgentSession, "model">): voi
 	}
 }
 
+async function bindAcpExtensions(session: AgentSession): Promise<void> {
+	await session.bindExtensions({
+		onError: (err) => {
+			process.stderr.write(`acp ext error [${err.extensionPath}] ${err.event}: ${err.error}\n`)
+		},
+	})
+}
+
 // Title falls back to the truncated first user message when the session has no
 // user-defined name. ACP clients render this in the thread-picker UI; we do
 // NOT trigger a fresh prompt-summary on listSessions because that would mean
@@ -946,18 +968,7 @@ function defaultSessionLoader(options: RunAcpOptions): AcpSessionLoader {
 			resourceLoader,
 			sessionManager,
 		})
-		try {
-			assertSessionHasModel(session)
-			await session.bindExtensions({
-				onError: (err) => {
-					process.stderr.write(`acp ext error [${err.extensionPath}] ${err.event}: ${err.error}\n`)
-				},
-			})
-			return session
-		} catch (err) {
-			session.dispose()
-			throw err
-		}
+		return session
 	}
 }
 
@@ -978,22 +989,7 @@ function defaultSessionFactory(options: RunAcpOptions): AcpSessionFactory {
 			settingsManager,
 			resourceLoader,
 		})
-		// From this point the session holds resources (extension loaders, model
-		// clients). Any failure on the setup path — model check or bindExtensions —
-		// must dispose before rethrowing, otherwise we leak on the newSession error
-		// path where the caller never sees a sessionId to clean up.
-		try {
-			assertSessionHasModel(session)
-			await session.bindExtensions({
-				onError: (err) => {
-					process.stderr.write(`acp ext error [${err.extensionPath}] ${err.event}: ${err.error}\n`)
-				},
-			})
-			return session
-		} catch (err) {
-			session.dispose()
-			throw err
-		}
+		return session
 	}
 }
 
@@ -1087,6 +1083,22 @@ export function describeToolCall(
 		title: truncate(rawTitle),
 		kind: TOOL_KINDS[toolName] ?? "other",
 		locations: path ? [{ path }] : [],
+	}
+}
+
+export function buildToolCallUpdate(
+	toolCallId: string,
+	toolName: string,
+	args: Record<string, unknown>,
+): ToolCallUpdate {
+	const { title, kind, locations } = describeToolCall(toolName, args)
+	return {
+		toolCallId,
+		title,
+		kind,
+		status: "pending",
+		locations,
+		rawInput: args,
 	}
 }
 

--- a/src/modes/acp/server.ts
+++ b/src/modes/acp/server.ts
@@ -11,6 +11,8 @@ import {
 	type AuthenticateRequest,
 	type AuthenticateResponse,
 	type CancelNotification,
+	type CloseSessionRequest,
+	type CloseSessionResponse,
 	type ContentBlock,
 	type InitializeRequest,
 	type InitializeResponse,
@@ -115,11 +117,11 @@ export class KimchiAcpAgent implements Agent {
 	// Track non-text prompt block types we've already warned about so a
 	// misbehaving client that sends 1000 image blocks doesn't flood stderr.
 	private warnedBlockTypes = new Set<string>()
-	// Ids currently inside loadSession's `await sessionLoader(...)` window.
-	// Without this, two concurrent loads of the same id both pass the
-	// `sessions.has()` guard, open the JSONL twice, and the later registration
-	// overwrites (and leaks) the earlier session record.
-	private loadingSessions = new Set<string>()
+	// In-flight loadSession calls, keyed by session id. Without this, two
+	// concurrent loads of the same id both pass the `sessions.has()` guard, open
+	// the JSONL twice, and the later registration overwrites (and leaks) the
+	// earlier session record.
+	private loadingSessions = new Map<string, Promise<LoadSessionResponse>>()
 	private shutdownPromise: Promise<void> | undefined
 
 	constructor(
@@ -144,7 +146,7 @@ export class KimchiAcpAgent implements Agent {
 				// (SessionListCapabilities is `{ _meta? }` — empty object means
 				// "supported"). loadSession remains the top-level flag because
 				// the spec hasn't unified it under sessionCapabilities yet.
-				sessionCapabilities: { list: {} },
+				sessionCapabilities: { list: {}, close: {} },
 				promptCapabilities: { image: supportsImages, audio: false, embeddedContext: false },
 			},
 			authMethods: [],
@@ -249,20 +251,34 @@ export class KimchiAcpAgent implements Agent {
 				"mcpServers is not supported; configure MCP servers via kimchi config",
 			)
 		}
-		// Reject re-load of an already-live session: pi's JSONL is append-only and
-		// two writers on the same file would interleave entries unpredictably. Zed
-		// should close the live session before reloading. invalidRequest (-32600)
-		// signals "method valid but state forbids it now".
-		if (this.sessions.has(params.sessionId) || this.loadingSessions.has(params.sessionId)) {
-			throw RequestError.invalidRequest(undefined, `session ${params.sessionId} is already loaded; close it first`)
+		const existing = this.sessions.get(params.sessionId)
+		if (existing) {
+			if (existing.turn) {
+				throw RequestError.invalidRequest(
+					undefined,
+					`session ${params.sessionId} has a turn in progress; cancel it first`,
+				)
+			}
+			this.replayTranscript(existing.session)
+			return { models: this.modelStateForSession(existing.session) }
 		}
-		this.loadingSessions.add(params.sessionId)
-		let session: AgentSession
+		const loading = this.loadingSessions.get(params.sessionId)
+		if (loading) return loading
+
+		const loadingPromise = this.loadSessionFresh(params)
+		this.loadingSessions.set(params.sessionId, loadingPromise)
 		try {
-			session = await this.sessionLoader(params)
+			return await loadingPromise
 		} finally {
-			this.loadingSessions.delete(params.sessionId)
+			if (this.loadingSessions.get(params.sessionId) === loadingPromise) {
+				this.loadingSessions.delete(params.sessionId)
+			}
 		}
+	}
+
+	private async loadSessionFresh(params: LoadSessionRequest): Promise<LoadSessionResponse> {
+		let session: AgentSession
+		session = await this.sessionLoader(params)
 		// Atomic ownership transfer mirrors newSession but covers the full
 		// register → replay → respond path: a throw at any point after the
 		// loader hands back a live session must unwind registration AND dispose,
@@ -305,6 +321,11 @@ export class KimchiAcpAgent implements Agent {
 			session.dispose()
 			throw err
 		}
+	}
+
+	async unstable_closeSession(params: CloseSessionRequest): Promise<CloseSessionResponse> {
+		await this.closeSessionRecord(params.sessionId)
+		return {}
 	}
 
 	async prompt(params: PromptRequest): Promise<PromptResponse> {
@@ -419,16 +440,37 @@ export class KimchiAcpAgent implements Agent {
 		// until process exit. Reject symmetrically so the caller's await settles.
 		for (const entry of this.sessions.values()) {
 			if (entry.turn) this.failTurn(entry, new Error("acp agent shutting down"))
-			entry.unsubscribe()
-			unregisterAcpPrompter(entry.session.sessionId)
-			// Emit session_shutdown to extensions and await all handlers before
-			// calling dispose(). dispose() is synchronous and returns void, so
-			// async extension handlers (e.g. telemetry drain, shutdown marker)
-			// would be fire-and-forgotten if we relied on dispose() alone.
-			await entry.session.extensionRunner?.emit({ type: "session_shutdown", reason: "quit" })
-			entry.session.dispose()
+			await this.disposeSessionRecord(entry)
 		}
 		this.sessions.clear()
+	}
+
+	private async closeSessionRecord(sessionId: string): Promise<void> {
+		const entry = this.sessions.get(sessionId)
+		if (!entry) return
+		this.sessions.delete(sessionId)
+		if (entry.turn) {
+			entry.turn.cancelled = true
+			try {
+				await entry.session.abort()
+			} catch {
+				// Closing is best-effort cleanup; still resolve the pending prompt
+				// as cancelled and release the session resources below.
+			}
+			this.finalizeTurn(entry, "cancelled")
+		}
+		await this.disposeSessionRecord(entry)
+	}
+
+	private async disposeSessionRecord(entry: SessionRecord): Promise<void> {
+		entry.unsubscribe()
+		unregisterAcpPrompter(entry.session.sessionId)
+		// Emit session_shutdown to extensions and await all handlers before
+		// calling dispose(). dispose() is synchronous and returns void, so async
+		// extension handlers (e.g. telemetry drain, shutdown marker) would be
+		// fire-and-forgotten if we relied on dispose() alone.
+		await entry.session.extensionRunner?.emit({ type: "session_shutdown", reason: "quit" })
+		entry.session.dispose()
 	}
 
 	private onSessionEvent(sessionId: string, event: AgentSessionEvent): void {

--- a/src/modes/acp/server.ts
+++ b/src/modes/acp/server.ts
@@ -440,6 +440,7 @@ export class KimchiAcpAgent implements Agent {
 		// until process exit. Reject symmetrically so the caller's await settles.
 		for (const entry of this.sessions.values()) {
 			if (entry.turn) this.failTurn(entry, new Error("acp agent shutting down"))
+			unregisterAcpPrompter(entry.session.sessionId)
 			await this.disposeSessionRecord(entry)
 		}
 		this.sessions.clear()
@@ -449,6 +450,8 @@ export class KimchiAcpAgent implements Agent {
 		const entry = this.sessions.get(sessionId)
 		if (!entry) return
 		this.sessions.delete(sessionId)
+		unregisterAcpPrompter(sessionId)
+		entry.unsubscribe()
 		if (entry.turn) {
 			entry.turn.cancelled = true
 			try {
@@ -459,12 +462,14 @@ export class KimchiAcpAgent implements Agent {
 			}
 			this.finalizeTurn(entry, "cancelled")
 		}
-		await this.disposeSessionRecord(entry)
+		await this.disposeSessionRecord(entry, { alreadyUnsubscribed: true })
 	}
 
-	private async disposeSessionRecord(entry: SessionRecord): Promise<void> {
-		entry.unsubscribe()
-		unregisterAcpPrompter(entry.session.sessionId)
+	private async disposeSessionRecord(
+		entry: SessionRecord,
+		opts: { alreadyUnsubscribed?: boolean } = {},
+	): Promise<void> {
+		if (!opts.alreadyUnsubscribed) entry.unsubscribe()
 		// Emit session_shutdown to extensions and await all handlers before
 		// calling dispose(). dispose() is synchronous and returns void, so async
 		// extension handlers (e.g. telemetry drain, shutdown marker) would be


### PR DESCRIPTION
## Description

  - Adds ACP-backed permission prompts so headless ACP sessions can ask the client for tool approval instead of falling back to classifier-only handling.
  - Refactors permission prompting behind a shared ToolPermissionPrompter interface, reusing the same allow-once, allow-for-session, wildcard, and deny choice logic
    for terminal and ACP flows.
  - Registers per-session ACP permission prompters during newSession and loadSession, unregistering them on close, shutdown, and setup failures.
  - Adds ACP session/close support and improves session cleanup, including cancelling in-flight turns before disposal.
  - Changes ACP loadSession handling to replay already-loaded sessions and coalesce duplicate concurrent loads instead of rejecting/reopening the same session.
  - Adds tests for ACP permission approval mapping, remembered permissions, subagent classifier fallback, prompter lifecycle cleanup, session close, and duplicate load
    handling.


## Type of Change

<!-- Select all that apply. -->

- [x] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Documentation update
