### PR TITLE
chore: Add a secondary nudge when the first one fails

### DIFF
--- a/src/extensions/orchestration/continuation-nudge.test.ts
+++ b/src/extensions/orchestration/continuation-nudge.test.ts
@@ -89,9 +89,10 @@ describe("ContinuationNudge.evaluateTurn", () => {
 		expect(guard.evaluateTurn(whitespaceTextMessage)).toBe(false)
 	})
 
-	it("nudges at most once per user-input cycle", () => {
+	it("nudges at most twice per user-input cycle", () => {
 		const guard = new ContinuationNudge()
 		guard.resetForNewUserInput()
+		expect(guard.evaluateTurn(textOnlyMessage)).toBe(true)
 		expect(guard.evaluateTurn(textOnlyMessage)).toBe(true)
 		expect(guard.evaluateTurn(textOnlyMessage)).toBe(false)
 	})
@@ -356,9 +357,10 @@ describe("EmptyTurnNudge", () => {
 		expect(guard.evaluateTurn(textOnlyMessage)).toBe(false)
 	})
 
-	it("resets tracking after firing", () => {
+	it("resets tracking after two nudges", () => {
 		const guard = new EmptyTurnNudge()
 		guard.evaluateTurn(toolCallMessage)
+		expect(guard.evaluateTurn(emptyMessage)).toBe(true)
 		expect(guard.evaluateTurn(emptyMessage)).toBe(true)
 		expect(guard.evaluateTurn(emptyMessage)).toBe(false)
 	})
@@ -366,7 +368,8 @@ describe("EmptyTurnNudge", () => {
 	it("re-arms after resetForNewUserInput", () => {
 		const guard = new EmptyTurnNudge()
 		expect(guard.evaluateTurn(emptyMessage)).toBe(true)
-		// Already nudged this cycle — second empty should not nudge
+		// Already nudged twice this cycle — third empty should not nudge
+		expect(guard.evaluateTurn(emptyMessage)).toBe(true)
 		expect(guard.evaluateTurn(emptyMessage)).toBe(false)
 		// Reset re-arms the nudge for the next user-input cycle
 		guard.resetForNewUserInput()

--- a/src/extensions/orchestration/continuation-nudge.ts
+++ b/src/extensions/orchestration/continuation-nudge.ts
@@ -44,13 +44,7 @@ export const SECOND_NUDGE_TEXT =
 export const EMPTY_TURN_NUDGE_TEXT =
 	"If you have finished, please summarize the result for the user. Otherwise, continue with the next tool call."
 
-/** Select nudge text based on how many continuation nudges have already fired. */
-function getNudgeText(count: number): string {
-	return count <= 1 ? CONTINUATION_NUDGE_TEXT : SECOND_NUDGE_TEXT
-}
-
-/**
- * Post-turn state machine for the "text-only drift" nudge.
+/** Post-turn state machine for the "text-only drift" nudge.
  *
  * Fires at most twice per user-input cycle, and only when no tool has been
  * called during that cycle — so legitimate end-of-task summaries after a

--- a/src/extensions/orchestration/continuation-nudge.ts
+++ b/src/extensions/orchestration/continuation-nudge.ts
@@ -38,13 +38,21 @@ export const DONE_SIGNAL = "<done>"
 
 export const CONTINUATION_NUDGE_TEXT = `You ended your turn without calling a tool. If this task is complete, respond with ${DONE_SIGNAL}. If a tool call is still needed, call it now.`
 
+export const SECOND_NUDGE_TEXT =
+	"You MUST call a tool immediately. Stop writing text and execute the required tool call now — or respond with <done> if you are finished."
+
 export const EMPTY_TURN_NUDGE_TEXT =
 	"If you have finished, please summarize the result for the user. Otherwise, continue with the next tool call."
+
+/** Select nudge text based on how many continuation nudges have already fired. */
+function getNudgeText(count: number): string {
+	return count <= 1 ? CONTINUATION_NUDGE_TEXT : SECOND_NUDGE_TEXT
+}
 
 /**
  * Post-turn state machine for the "text-only drift" nudge.
  *
- * Fires at most once per user-input cycle, and only when no tool has been
+ * Fires at most twice per user-input cycle, and only when no tool has been
  * called during that cycle — so legitimate end-of-task summaries after a
  * completed tool sequence are not nudged.
  *
@@ -53,8 +61,11 @@ export const EMPTY_TURN_NUDGE_TEXT =
  * and processed.
  */
 export class ContinuationNudge {
+	/** Maximum text-only nudges allowed per user-input cycle. */
+	private static readonly MAX_NUDGES = 2
+
 	private toolsCalledSinceLastUserInput = false
-	private nudgedSinceLastUserInput = false
+	private nudgeCountThisCycle = 0
 	private nudgeResponsePending = false
 	private accumulatedResponseText = ""
 	/** Number of Agent calls still awaiting results.
@@ -64,7 +75,7 @@ export class ContinuationNudge {
 
 	resetForNewUserInput(): void {
 		this.toolsCalledSinceLastUserInput = false
-		this.nudgedSinceLastUserInput = false
+		this.nudgeCountThisCycle = 0
 		this.nudgeResponsePending = false
 		this.accumulatedResponseText = ""
 		// pendingDelegationCount is intentionally NOT reset here — it is
@@ -101,7 +112,7 @@ export class ContinuationNudge {
 	}
 
 	evaluateTurn(message: AssistantMessage): boolean {
-		if (this.nudgedSinceLastUserInput) return false
+		if (this.nudgeCountThisCycle >= ContinuationNudge.MAX_NUDGES) return false
 		if (this.toolsCalledSinceLastUserInput) return false
 		// Do not nudge while any Agent result is pending — the model must
 		// wait for all Agent outputs before it can continue or signal done.
@@ -109,7 +120,7 @@ export class ContinuationNudge {
 		const hasToolCalls = message.content.some((c) => c.type === "toolCall")
 		const hasText = message.content.some((c) => c.type === "text" && c.text.trim().length > 0)
 		if (hasToolCalls || !hasText) return false
-		this.nudgedSinceLastUserInput = true
+		this.nudgeCountThisCycle++
 		this.nudgeResponsePending = true
 		return true
 	}
@@ -125,6 +136,18 @@ export class ContinuationNudge {
 			this.pendingDelegationCount--
 		}
 	}
+
+	isBudgetExhausted(): boolean {
+		return this.nudgeCountThisCycle >= ContinuationNudge.MAX_NUDGES
+	}
+
+	hasToolBeenCalledThisCycle(): boolean {
+		return this.toolsCalledSinceLastUserInput
+	}
+
+	getNudgeText(): string {
+		return this.nudgeCountThisCycle <= 1 ? CONTINUATION_NUDGE_TEXT : SECOND_NUDGE_TEXT
+	}
 }
 
 /**
@@ -135,28 +158,35 @@ export class ContinuationNudge {
  * nudge the agent loop stalls because there is nothing to execute or
  * display.
  *
- * Fires at most once per user-input cycle to avoid infinite nudge loops
+ * Fires at most twice per user-input cycle to avoid infinite nudge loops
  * when a model persistently returns empty responses.
  */
 export class EmptyTurnNudge {
-	private nudgedSinceLastUserInput = false
+	/** Maximum empty-turn nudges allowed per user-input cycle. */
+	private static readonly MAX_NUDGES = 2
+
+	private nudgeCountThisCycle = 0
 
 	evaluateTurn(message: AssistantMessage): boolean {
-		if (this.nudgedSinceLastUserInput) return false
+		if (this.nudgeCountThisCycle >= EmptyTurnNudge.MAX_NUDGES) return false
 
 		const hasText = message.content.some((c) => c.type === "text" && c.text.trim().length > 0)
 		const hasToolCalls = message.content.some((c) => c.type === "toolCall")
 
 		if (!hasText && !hasToolCalls) {
-			this.nudgedSinceLastUserInput = true
+			this.nudgeCountThisCycle++
 			return true
 		}
 
 		return false
 	}
 
+	isBudgetExhausted(): boolean {
+		return this.nudgeCountThisCycle >= EmptyTurnNudge.MAX_NUDGES
+	}
+
 	resetForNewUserInput(): void {
-		this.nudgedSinceLastUserInput = false
+		this.nudgeCountThisCycle = 0
 	}
 }
 

--- a/src/extensions/prompt-construction/prompt-enrichment.ts
+++ b/src/extensions/prompt-construction/prompt-enrichment.ts
@@ -410,7 +410,7 @@ export default function (skillPaths: string[]) {
 				pi.sendMessage(
 					{
 						customType: NUDGE_CUSTOM_TYPE,
-						content: [{ type: "text", text: continuationNudge.getNudgeText() }],
+						content: continuationNudge.getNudgeText(),
 						display: false,
 					},
 					{ deliverAs: "followUp" },

--- a/src/extensions/prompt-construction/prompt-enrichment.ts
+++ b/src/extensions/prompt-construction/prompt-enrichment.ts
@@ -394,9 +394,11 @@ export default function (skillPaths: string[]) {
 					if (continuationNudge.isDoneSignalReceived()) {
 						return
 					}
-				}
-
-				if (emptyTurnNudge.evaluateTurn(event.message)) {
+					// While a continuation nudge response is pending, the model is already
+					// in a recovery cycle. Skip empty-turn nudge here to avoid sending
+					// mixed instructions ("call a tool" vs "summarize or continue").
+					// Fall through to continuationNudge.evaluateTurn below.
+				} else if (emptyTurnNudge.evaluateTurn(event.message)) {
 					pi.sendMessage(
 						{ customType: NUDGE_CUSTOM_TYPE, content: EMPTY_TURN_NUDGE_TEXT, display: false },
 						{ deliverAs: "followUp" },
@@ -406,7 +408,11 @@ export default function (skillPaths: string[]) {
 
 				if (!continuationNudge.evaluateTurn(event.message)) return
 				pi.sendMessage(
-					{ customType: NUDGE_CUSTOM_TYPE, content: CONTINUATION_NUDGE_TEXT, display: false },
+					{
+						customType: NUDGE_CUSTOM_TYPE,
+						content: [{ type: "text", text: continuationNudge.getNudgeText() }],
+						display: false,
+					},
 					{ deliverAs: "followUp" },
 				)
 			})


### PR DESCRIPTION
## Description

 When the model said it would act ("let me do X") but emitted no tool calls, the harness sent exactly one hidden
 follow-up nudge and then silently gave up. This change lets it retry once with a stronger message, and prevents it from
 sending a confusing different nudge mid-recovery.

 ### Changes
 - ContinuationNudge.MAX_NUDGES: 1 → 2
 - EmptyTurnNudge.MAX_NUDGES: 1 → 2
 - Added SECOND_NUDGE_TEXT - shorter, imperative: "You MUST call a tool immediately. Stop writing text and execute the
   required tool call now - or respond with <done>."
 - turn_end handler now suppresses EmptyTurnNudge while a continuation nudge response is pending. Previously, text
   cleared by message_update could make the turn look empty and trigger the "summarize or continue" nudge, giving the
   model two conflicting instructions in the same cycle.
 - Updated unit tests to cover two-nudge behavior.


## Type of Change

- [ ] Bug fix
- [ ] New feature
- [x] Enhancement
- [ ] Breaking change
- [ ] Documentation update
