### PR TITLE
fix(agents): prefix automated sub-agent steering to avoid user impersonation

### DIFF
--- a/src/extensions/agents/manager/agent-runner.test.ts
+++ b/src/extensions/agents/manager/agent-runner.test.ts
@@ -101,7 +101,7 @@ vi.mock("../../../config.js", () => ({
 	}),
 }))
 
-import { DefaultResourceLoader, createAgentSession } from "@earendil-works/pi-coding-agent"
+import { type AgentSession, DefaultResourceLoader, createAgentSession } from "@earendil-works/pi-coding-agent"
 import { readTelemetryConfig } from "../../../config.js"
 import { loadProjectContextFiles } from "../../prompt-construction/context-files.js"
 import telemetryExtension from "../../telemetry/index.js"
@@ -707,7 +707,7 @@ describe("runAgent — budget awareness steers", () => {
 				maxTurns: 10,
 				turns: 5,
 				expectedSteerCount: 1,
-				pattern: /50% of your turn budget./,
+				pattern: /\[Orchestrator — automated system instruction, not a user message\][\s\S]*50% of your turn budget./,
 			},
 			"does not steer between 50% and 75%": {
 				maxTurns: 10,
@@ -718,13 +718,13 @@ describe("runAgent — budget awareness steers", () => {
 				maxTurns: 10,
 				turns: 8,
 				expectedSteerCount: 2,
-				pattern: /75% of your turn budget./,
+				pattern: /\[Orchestrator — automated system instruction, not a user message\][\s\S]*75% of your turn budget./,
 			},
 			"steers at 90% of turn budget": {
 				maxTurns: 10,
 				turns: 9,
 				expectedSteerCount: 3,
-				pattern: /90% of your turn budget./,
+				pattern: /\[Orchestrator — automated system instruction, not a user message\][\s\S]*90% of your turn budget./,
 			},
 		}
 
@@ -1037,5 +1037,54 @@ describe("runAgent — includeContextFiles", () => {
 		expect(mockLoadProjectContextFiles).not.toHaveBeenCalled()
 		const extras = mockBuildAgentPrompt.mock.calls[0]?.[4]
 		expect(extras?.contextFiles).toBeUndefined()
+	})
+})
+
+describe("steerAgent — explicit steering", () => {
+	it("does NOT add orchestrator prefix to explicit steer messages", async () => {
+		const { steerAgent } = await import("./agent-runner.js")
+		const session = makeFakeSession()
+		await steerAgent(session as unknown as AgentSession, "custom user steer")
+		expect(session.steer).toHaveBeenCalledWith("custom user steer")
+		expect(session.steer).not.toHaveBeenCalledWith(expect.stringContaining("[Orchestrator"))
+	})
+})
+
+describe("resumeAgent — inactivity steering", () => {
+	it("adds orchestrator prefix to automated inactivity steer", async () => {
+		const { resumeAgent } = await import("./agent-runner.js")
+		vi.useFakeTimers()
+
+		const subscribers: Subscriber[] = []
+		const session = {
+			subscribe: vi.fn((cb: Subscriber) => {
+				subscribers.push(cb)
+				return () => {
+					const idx = subscribers.indexOf(cb)
+					if (idx !== -1) subscribers.splice(idx, 1)
+				}
+			}),
+			abort: vi.fn(),
+			steer: vi.fn(),
+			messages: [],
+			prompt: vi.fn().mockImplementation(async () => {
+				// Advance time past inactivity timeout during prompt
+				await vi.advanceTimersByTimeAsync(130_000)
+			}),
+			extensionRunner: { emit: vi.fn().mockResolvedValue(true) },
+		}
+
+		const promise = resumeAgent(session as unknown as AgentSession, "resume prompt", {
+			inactivityTimeout: 120_000,
+		})
+
+		await promise
+
+		expect(session.steer).toHaveBeenCalledWith(
+			expect.stringMatching(/\[Orchestrator — automated system instruction, not a user message\]/),
+		)
+		expect(session.steer).toHaveBeenCalledWith(expect.stringContaining("You appear to be stalled"))
+
+		vi.useRealTimers()
 	})
 })

--- a/src/extensions/agents/manager/agent-runner.ts
+++ b/src/extensions/agents/manager/agent-runner.ts
@@ -45,6 +45,14 @@ import { type LifetimeUsage, addUsage, getLifetimeTotal, getOutputTotal, getSess
 /** Names of tools registered by this extension that subagents must NOT inherit. */
 const EXCLUDED_TOOL_NAMES = ["Agent", "get_subagent_result", "steer_subagent"]
 
+/** Prefix applied to automated steering messages so the LLM does not attribute them to the user. */
+const ORCHESTRATOR_PREFIX = "[Orchestrator — automated system instruction, not a user message]\n\n"
+
+/** Send a steering message that is clearly marked as coming from the orchestrator, not the user. */
+function steerAsOrchestrator(session: AgentSession, message: string): Promise<void> {
+	return session.steer(ORCHESTRATOR_PREFIX + message)
+}
+
 /** Default max turns. undefined = unlimited (no turn limit). */
 let defaultMaxTurns: number | undefined = 30
 
@@ -445,7 +453,8 @@ async function runAgentInner(
 			if (effectiveMaxTurns != null) {
 				if (!softLimitReached && turnCount >= effectiveMaxTurns) {
 					softLimitReached = true
-					session.steer(
+					steerAsOrchestrator(
+						session,
 						"You have reached your turn limit. Stop exploring. Complete your current edit, ensure file syntax is valid, undo any git state mutations so your work is visible on the filesystem, and summarize progress for the orchestrator. Do not start new edits.",
 					)
 				} else if (softLimitReached && turnCount >= effectiveMaxTurns + graceTurns) {
@@ -456,7 +465,7 @@ async function runAgentInner(
 					const point = PROGRESS_STEER_POINTS[nextProgressIdx]
 					if (point && turnCount >= effectiveMaxTurns * point.threshold) {
 						nextProgressIdx++
-						session.steer(point.message)
+						steerAsOrchestrator(session, point.message)
 					}
 				}
 			}
@@ -501,7 +510,8 @@ async function runAgentInner(
 						session.abort()
 					} else if (!tokenSoftLimitSteered && cumulativeTokens >= effectiveTokenBudget * 0.8) {
 						tokenSoftLimitSteered = true
-						session.steer(
+						steerAsOrchestrator(
+							session,
 							`Budget check: ${buildProgressSummary()}. You are approaching your output token limit. Wrap up your current work and summarize any remaining tasks.`,
 						)
 					}
@@ -522,7 +532,7 @@ async function runAgentInner(
 			session.abort()
 		} else if (!inactivity.steered && elapsed >= inactivityTimeout) {
 			inactivity.steered = true
-			session.steer("You appear to be stalled. Resume work immediately or summarize your progress.")
+			steerAsOrchestrator(session, "You appear to be stalled. Resume work immediately or summarize your progress.")
 		}
 	}, INACTIVITY_CHECK_INTERVAL)
 
@@ -652,7 +662,7 @@ export async function resumeAgent(
 			session.abort()
 		} else if (!resumeInactivity.steered && elapsed >= resumeInactivityTimeout) {
 			resumeInactivity.steered = true
-			session.steer("You appear to be stalled. Resume work immediately or summarize your progress.")
+			steerAsOrchestrator(session, "You appear to be stalled. Resume work immediately or summarize your progress.")
 		}
 	}, INACTIVITY_CHECK_INTERVAL)
 

--- a/src/extensions/agents/prompt/prompts.test.ts
+++ b/src/extensions/agents/prompt/prompts.test.ts
@@ -46,6 +46,7 @@ describe("default agents — subagent system prompt snapshot", () => {
 			- Use absolute file paths
 			- Do not use emojis
 			- Be concise but complete
+			- Messages prefixed with "[Orchestrator]" are system instructions from the agent loop, not user input. Do not attribute them to the user.
 			</sub_agent_context>"
 		`)
 	})

--- a/src/extensions/agents/prompt/prompts.ts
+++ b/src/extensions/agents/prompt/prompts.ts
@@ -77,6 +77,7 @@ You are operating as a sub-agent invoked to handle a specific task.
 - Use absolute file paths
 - Do not use emojis
 - Be concise but complete
+- Messages prefixed with "[Orchestrator]" are system instructions from the agent loop, not user input. Do not attribute them to the user.
 </sub_agent_context>`
 
 		const customSection = config.systemPrompt?.trim()


### PR DESCRIPTION
## Problem

Sub-agent automated steering messages (turn limit, budget warnings, inactivity prompts) are incorrectly perceived as user prompts. The LLM responds with attributions like "the user wants me to..." even though the user provided no input while the agent is working.

## Root Cause

The upstream \ hardcodes \ for every queued steering message in [AgentSession._queueSteer](https://github.com/earendil-works/pi-mono/blob/main/packages/coding-agent/src/core/agent-session.ts). There is no extension hook or API to override this role.

We **cannot** simply change the role to "system" or "developer" because:
1. The upstream Agent class filters non-User/Assistant/ToolResult roles via \ — a "system" role message in the middle of a conversation would be silently dropped.
2. Anthropic and OpenAI APIs do not support mid-conversation system/developer messages anyway.
3. Monkey-patching the upstream Agent would be fragile and would affect interactive mode too, where genuine user steering messages legitimately are from the user.

## Solution

Content-level adapter — prefix automated steering messages and teach the sub-agent system prompt to recognize them.

### What changed

- **\**
  - Added \ helper that prefixes with:
    > \
  - All automated steers (turn limit, 50%/75%/90% progress, token budget, inactivity in both \ and \) now use this helper.
  - \ — used for explicit user/orchestrator-initiated steering — remains unprefixed.

- **\**
  - Added to the \ block: a bullet instructing the model that \-prefixed messages are system instructions, not user input.

- **\**
  - Updated budget-awareness steer patterns to match across the new prefix.
  - Added tests verifying explicit \ does **not** add the prefix.
  - Added test verifying \ inactivity steering **does** add the prefix.

- **\**
  - Updated inline snapshot to include the new instruction.

## Verification

- \
> @kimchi-dev/cli@0.0.0 typecheck /Users/mike/Source/github.com/castai/kimchi-dev
> tsc --noEmit ✅
- \
> @kimchi-dev/cli@0.0.0 lint /Users/mike/Source/github.com/castai/kimchi-dev
> biome check src/ scripts/

Checked 671 files in 268ms. No fixes applied. ✅
- \ (27 tests) ✅
- \ (19 tests) ✅
- Full suite: only 2 pre-existing unrelated failures (ferment integration, permissions yolo)

closes LLM-1884