### PR TITLE
chore: Bump pi to 0.78.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,8 +34,8 @@
 	"dependencies": {
 		"@agentclientprotocol/sdk": "^0.19.2",
 		"@clack/prompts": "^1.3.0",
-		"@earendil-works/pi-coding-agent": "^0.75.1",
-		"@earendil-works/pi-tui": "^0.75.1",
+		"@earendil-works/pi-coding-agent": "^0.78.0",
+		"@earendil-works/pi-tui": "^0.78.0",
 		"@modelcontextprotocol/ext-apps": "^1.7.1",
 		"@modelcontextprotocol/sdk": "^1.29.0",
 		"@shikijs/cli": "^4.0.2",
@@ -69,7 +69,7 @@
 	},
 	"devDependencies": {
 		"@biomejs/biome": "^1.9.4",
-		"@earendil-works/pi-ai": "^0.75.1",
+		"@earendil-works/pi-ai": "^0.78.0",
 		"@mixmark-io/domino": "^2.2.0",
 		"@types/micromatch": "^4.0.10",
 		"@types/node": "^22.19.18",

--- a/package.json
+++ b/package.json
@@ -57,15 +57,15 @@
 		"typebox": "*"
 	},
 	"optionalDependencies": {
-		"@mariozechner/clipboard-darwin-arm64": "0.3.9",
-		"@mariozechner/clipboard-darwin-universal": "0.3.9",
-		"@mariozechner/clipboard-darwin-x64": "0.3.9",
-		"@mariozechner/clipboard-linux-arm64-gnu": "0.3.9",
-		"@mariozechner/clipboard-linux-arm64-musl": "0.3.9",
-		"@mariozechner/clipboard-linux-x64-gnu": "0.3.9",
-		"@mariozechner/clipboard-linux-x64-musl": "0.3.9",
-		"@mariozechner/clipboard-win32-arm64-msvc": "0.3.9",
-		"@mariozechner/clipboard-win32-x64-msvc": "0.3.9"
+		"@mariozechner/clipboard-darwin-arm64": "0.3.2",
+		"@mariozechner/clipboard-darwin-universal": "0.3.2",
+		"@mariozechner/clipboard-darwin-x64": "0.3.2",
+		"@mariozechner/clipboard-linux-arm64-gnu": "0.3.2",
+		"@mariozechner/clipboard-linux-arm64-musl": "0.3.2",
+		"@mariozechner/clipboard-linux-x64-gnu": "0.3.2",
+		"@mariozechner/clipboard-linux-x64-musl": "0.3.2",
+		"@mariozechner/clipboard-win32-arm64-msvc": "0.3.2",
+		"@mariozechner/clipboard-win32-x64-msvc": "0.3.2"
 	},
 	"devDependencies": {
 		"@biomejs/biome": "^1.9.4",

--- a/package.json
+++ b/package.json
@@ -57,15 +57,15 @@
 		"typebox": "*"
 	},
 	"optionalDependencies": {
-		"@mariozechner/clipboard-darwin-arm64": "0.3.2",
-		"@mariozechner/clipboard-darwin-universal": "0.3.2",
-		"@mariozechner/clipboard-darwin-x64": "0.3.2",
-		"@mariozechner/clipboard-linux-arm64-gnu": "0.3.2",
-		"@mariozechner/clipboard-linux-arm64-musl": "0.3.2",
-		"@mariozechner/clipboard-linux-x64-gnu": "0.3.2",
-		"@mariozechner/clipboard-linux-x64-musl": "0.3.2",
-		"@mariozechner/clipboard-win32-arm64-msvc": "0.3.2",
-		"@mariozechner/clipboard-win32-x64-msvc": "0.3.2"
+		"@mariozechner/clipboard-darwin-arm64": "0.3.9",
+		"@mariozechner/clipboard-darwin-universal": "0.3.9",
+		"@mariozechner/clipboard-darwin-x64": "0.3.9",
+		"@mariozechner/clipboard-linux-arm64-gnu": "0.3.9",
+		"@mariozechner/clipboard-linux-arm64-musl": "0.3.9",
+		"@mariozechner/clipboard-linux-x64-gnu": "0.3.9",
+		"@mariozechner/clipboard-linux-x64-musl": "0.3.9",
+		"@mariozechner/clipboard-win32-arm64-msvc": "0.3.9",
+		"@mariozechner/clipboard-win32-x64-msvc": "0.3.9"
 	},
 	"devDependencies": {
 		"@biomejs/biome": "^1.9.4",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -26,11 +26,11 @@ importers:
         specifier: ^1.3.0
         version: 1.3.0
       '@earendil-works/pi-coding-agent':
-        specifier: ^0.75.1
-        version: 0.75.1(patch_hash=5f611222f23d465ba6b392ac0eb0c5ed1b0745525ad106d827967b62cc724d3c)(@modelcontextprotocol/sdk@1.29.0(supports-color@10.2.2)(zod@4.4.3))(supports-color@10.2.2)(ws@8.20.1)(zod@4.4.3)
+        specifier: ^0.78.0
+        version: 0.78.0(patch_hash=5f611222f23d465ba6b392ac0eb0c5ed1b0745525ad106d827967b62cc724d3c)(@modelcontextprotocol/sdk@1.29.0(supports-color@10.2.2)(zod@4.4.3))(supports-color@10.2.2)(ws@8.20.1)(zod@4.4.3)
       '@earendil-works/pi-tui':
-        specifier: ^0.75.1
-        version: 0.75.1(patch_hash=e432fee0f54b7321d104a08ff5a38561d9c2cd3b002f34e6b8cbc2377889c9d2)
+        specifier: ^0.78.0
+        version: 0.78.0(patch_hash=e432fee0f54b7321d104a08ff5a38561d9c2cd3b002f34e6b8cbc2377889c9d2)
       '@modelcontextprotocol/ext-apps':
         specifier: ^1.7.1
         version: 1.7.1(@modelcontextprotocol/sdk@1.29.0(supports-color@10.2.2)(zod@4.4.3))(zod@4.4.3)
@@ -87,8 +87,8 @@ importers:
         specifier: ^1.9.4
         version: 1.9.4
       '@earendil-works/pi-ai':
-        specifier: ^0.75.1
-        version: 0.75.1(@modelcontextprotocol/sdk@1.29.0(supports-color@10.2.2)(zod@4.4.3))(supports-color@10.2.2)(ws@8.20.1)(zod@4.4.3)
+        specifier: ^0.78.0
+        version: 0.78.0(@modelcontextprotocol/sdk@1.29.0(supports-color@10.2.2)(zod@4.4.3))(supports-color@10.2.2)(ws@8.20.1)(zod@4.4.3)
       '@mixmark-io/domino':
         specifier: ^2.2.0
         version: 2.2.0
@@ -345,22 +345,22 @@ packages:
     resolution: {integrity: sha512-GgcWwRCs/xPtaqlMy8qRhPnZf9vlWcWZNHAitnVQ3yk7JmSralSiq5q07yaffYE8SogtDm7zFeKccx1QNVARpw==}
     engines: {node: '>= 20.12.0'}
 
-  '@earendil-works/pi-agent-core@0.75.1':
-    resolution: {integrity: sha512-JVpX/Zle/enBzEM6he9sE0ASMo8Yhm8q7nOuPQjR/BXhkTBUevrNz7wtTV8VFvgjyhsXzbAsNCP5A4LiCcDx/A==}
+  '@earendil-works/pi-agent-core@0.78.0':
+    resolution: {integrity: sha512-xhWd59Qzd8yO88gYQw2S4dEQstJJEiUtxRP01//YzVJ61jCtUASMfcyAmYhgGYR4Onp7GmwEAbBBGOiV6Iwk9g==}
     engines: {node: '>=22.19.0'}
 
-  '@earendil-works/pi-ai@0.75.1':
-    resolution: {integrity: sha512-/bhCWS2R+qHLBDnN+d1t1QRUxtZk7sZpMcrlexPq3W++3bJ0Df0GjhM2FToTubhoCsjOBdBOuRYcV8FNPfRUVQ==}
-    engines: {node: '>=22.19.0'}
-    hasBin: true
-
-  '@earendil-works/pi-coding-agent@0.75.1':
-    resolution: {integrity: sha512-QMbmv8lFQ8P98kpuMc/z1ATTq7t0lQ+Bo3GLiOKQ/HonO34n4E1+395FCqlmG8zJEhiMp4yqVTzlj7BALQMlqw==}
+  '@earendil-works/pi-ai@0.78.0':
+    resolution: {integrity: sha512-q0hUrvT6ngT6cgBX0oIbzfQfmzztgdkZobP8OTL+sCOOBlnG6+1YRt8g7zO9CC/4NdeYEqa7uGqWdQhH0fjCLA==}
     engines: {node: '>=22.19.0'}
     hasBin: true
 
-  '@earendil-works/pi-tui@0.75.1':
-    resolution: {integrity: sha512-IFDSvCXcXMoIxFKxdhqc7ybX8p86KpdxoTUTYEq3FHilMFkBqlXqZD0jZBitqxStBjjMkAlhjS1bKS0IOXSpsg==}
+  '@earendil-works/pi-coding-agent@0.78.0':
+    resolution: {integrity: sha512-gXt6pD3BoSG0yLwfLqb6844vz6qAO87PvNrv+YSDYKP3QliTjcwIld9v4ihmDcmBjO13QwKswubq/lYCvn4bkg==}
+    engines: {node: '>=22.19.0'}
+    hasBin: true
+
+  '@earendil-works/pi-tui@0.78.0':
+    resolution: {integrity: sha512-3a705FnsVVUhAyceShNB3kS2rpxcxLcx+hqB0u6MMMpHwQGbW+m++MqA6r7eOzq/8FLx5e3vDh38h/SVTk2qzw==}
     engines: {node: '>=22.19.0'}
 
   '@esbuild/aix-ppc64@0.27.7':
@@ -547,8 +547,8 @@ packages:
     cpu: [arm64]
     os: [darwin]
 
-  '@mariozechner/clipboard-darwin-arm64@0.3.6':
-    resolution: {integrity: sha512-HjaisYCAbHi/1+N1yDAQHc8ZXGffufIUT5NSOSVR3f3AuMDusxTtnbK8tZ7JFDkShua1oNGZoNwQHsc8MPtE0Q==}
+  '@mariozechner/clipboard-darwin-arm64@0.3.9':
+    resolution: {integrity: sha512-BfgV7vCEWZwJwZJw03r6bP5+tf0iI/ANuQYCxi9RNn7FrWB3yzGuMKCrNLRl6V761vXRdL8+OqZ0wd4TqlsNOQ==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [darwin]
@@ -558,8 +558,8 @@ packages:
     engines: {node: '>= 10'}
     os: [darwin]
 
-  '@mariozechner/clipboard-darwin-universal@0.3.6':
-    resolution: {integrity: sha512-8BWtPjOtJOJoykml3w0fx0zRrfWP31mXrJwfoA7xzNprkZw1uolCNfgmjDiVBseoKjp16EGITz7bN+61qn8dWA==}
+  '@mariozechner/clipboard-darwin-universal@0.3.9':
+    resolution: {integrity: sha512-BGGR4iA9Z2shAjI65eI5xtyb3LYNlDW9X3gxKxDbqtbnREohsrqznov6zpKoIrsRWpzlYVEdKphS7ksJ0/ndSQ==}
     engines: {node: '>= 10'}
     os: [darwin]
 
@@ -569,8 +569,8 @@ packages:
     cpu: [x64]
     os: [darwin]
 
-  '@mariozechner/clipboard-darwin-x64@0.3.6':
-    resolution: {integrity: sha512-p9syiZD1kU4I+1ya7f7g+zD1GiUvR8fdlRlNmgsZNWlyjtc8rlV2EjTLd/35x1LsdBq020GVvtzp0ZmPgBI09Q==}
+  '@mariozechner/clipboard-darwin-x64@0.3.9':
+    resolution: {integrity: sha512-4kURmCbS6nt8uYhtmWpUcJWyPHfmAr5dTpXD1nO3pIfa+TSQ9DbrGOYCKH+aEFW47XhQ4Vp8ZTszie+wfFvDKg==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [darwin]
@@ -581,8 +581,8 @@ packages:
     cpu: [arm64]
     os: [linux]
 
-  '@mariozechner/clipboard-linux-arm64-gnu@0.3.6':
-    resolution: {integrity: sha512-5JFf5rGofrm+V29HNF+wLthXphHdQpMbKDUYJ5tML6/Z5DLlLOV/9Ak4kDPtYyZ+Dzf+kAusE0VsFg4+tfP1IA==}
+  '@mariozechner/clipboard-linux-arm64-gnu@0.3.9':
+    resolution: {integrity: sha512-g59OkUGP2DDfCOIKypHeYgv2M55u/cKvXa5dSxFbEJ34XvIQMdcVmpKCkGUro3ZgefXiGVdwguvTMQGpHWzIXw==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
@@ -593,14 +593,14 @@ packages:
     cpu: [arm64]
     os: [linux]
 
-  '@mariozechner/clipboard-linux-arm64-musl@0.3.6':
-    resolution: {integrity: sha512-JlVjxxw0GbGC0djXYWRIqyteO3J1KZ/QG3udlEFaOD5TLOM1FnmXXAPDQBqr+aBVr720ef9K00dirYnJ0LDCtw==}
+  '@mariozechner/clipboard-linux-arm64-musl@0.3.9':
+    resolution: {integrity: sha512-AGuJdgKsmJdm4Pych7kv3sqe591ERRaAHW3xjLooiFzn8J+PxUyof++7YZrB5Y5tpnTO+K18Og3taj2NpluCRQ==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
 
-  '@mariozechner/clipboard-linux-riscv64-gnu@0.3.6':
-    resolution: {integrity: sha512-4t8BUi5zZ+L77otFQVnVSlaTyAX4TVk9EqQm4syMrEQp96trFEHEwwNHcNEBGzYv5+K7mxay50TthYkz47OWzQ==}
+  '@mariozechner/clipboard-linux-riscv64-gnu@0.3.9':
+    resolution: {integrity: sha512-DXBEAiuMpk7dhS1a9NzNxVAFi1vaKoPu7rQNgY8LIDLGrK3lnIp3nT10DUum+PKVJoJppIP+NAA8IZe4DMNDPw==}
     engines: {node: '>= 10'}
     cpu: [riscv64]
     os: [linux]
@@ -611,8 +611,8 @@ packages:
     cpu: [x64]
     os: [linux]
 
-  '@mariozechner/clipboard-linux-x64-gnu@0.3.6':
-    resolution: {integrity: sha512-trtPwcNLW37irwQCJLtCxLw757jjJZk3TSnY/MU9bhtWtA3K9b/eLW0e4RGhUXDoFRds9opNWWaUDuFLa8dm0w==}
+  '@mariozechner/clipboard-linux-x64-gnu@0.3.9':
+    resolution: {integrity: sha512-WORrMLd6EpElEME7JRKfSaY34nW1P5LbdgK5YNCS1ncG2LqmITsSMEJ8nh2mpvxb3TxqbOOKgY7k9eMJYlW9Mw==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
@@ -623,8 +623,8 @@ packages:
     cpu: [x64]
     os: [linux]
 
-  '@mariozechner/clipboard-linux-x64-musl@0.3.6':
-    resolution: {integrity: sha512-WfnzIvOCCWQiN0MmltCEo6cLceUDbYe+I7xyFZjaps5A+2Op/M2CY7Rey+C4ucQhrvmpoHmTSFgY9ODWk7snoA==}
+  '@mariozechner/clipboard-linux-x64-musl@0.3.9':
+    resolution: {integrity: sha512-/DHn+1DrfL6oRaPPWXaOKvonFFrni666fxd+zFqiQEfvBH0tsHVWjq9iqBk0oDp0qaPA72lIMy5BptxISBEhZQ==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
@@ -635,8 +635,8 @@ packages:
     cpu: [arm64]
     os: [win32]
 
-  '@mariozechner/clipboard-win32-arm64-msvc@0.3.6':
-    resolution: {integrity: sha512-+8+1aHYsBPUjmW3otmWlg+Hijt0iJvoBBs5e0mxFeUd4gDaKMB8Bn6x7c6KVtscg7E5j5NFXnwQqNSIAO4p8zQ==}
+  '@mariozechner/clipboard-win32-arm64-msvc@0.3.9':
+    resolution: {integrity: sha512-O5FHD3ErkMwMhNzAfu3ggy0ug4z7btZuoQgwwxlzPrwV2bxlD6WDpqBY4NCgICAgZdDKdp+loUEKVAVt8aYnhQ==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [win32]
@@ -647,14 +647,14 @@ packages:
     cpu: [x64]
     os: [win32]
 
-  '@mariozechner/clipboard-win32-x64-msvc@0.3.6':
-    resolution: {integrity: sha512-S4xfPmERC8ZkiLHe3vekZCjdDwNEETCuvCgQK2kP6/TnvmUkq1y2Pk+DjM4t8uh9KMX9bH4zs5ePcKa8GTXmfg==}
+  '@mariozechner/clipboard-win32-x64-msvc@0.3.9':
+    resolution: {integrity: sha512-ihQC3EufqEY81vhXBgVBtK4prL+wc62zJsSvxrgz7K1hsdt6OObz6v9p3Rn1OG3GJksTTKMJF0u/guMISHPhSA==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [win32]
 
-  '@mariozechner/clipboard@0.3.6':
-    resolution: {integrity: sha512-MXdtr+6+ntlIVHdrZYuZNQydu6o8yZswFJ2Ln81j2O/Y9B/LDHvEaIm95xWNPkjGTWriSOeLnQJRFs6dYb60bg==}
+  '@mariozechner/clipboard@0.3.9':
+    resolution: {integrity: sha512-ABnA53mdfkGZwOFUdZNv2S0CWGO/EIuPj8Vv9xmBFmSYg/qFc7ihO6q5FcQjvoE67kZpWkEc4AhD6B/os04yuA==}
     engines: {node: '>= 10'}
 
   '@mistralai/mistralai@2.2.1':
@@ -1486,9 +1486,6 @@ packages:
   jws@4.0.1:
     resolution: {integrity: sha512-EKI/M/yqPncGUUh44xz0PxSidXFr/+r0pA70+gIYhjv+et7yxM+s29Y+VGDkovRofQem0fs7Uvf4+YmAdyRduA==}
 
-  koffi@2.16.2:
-    resolution: {integrity: sha512-owU0MRwv6xkrVqCd+33uw6BaYppkTRXbO/rVdJNI2dvZG0gzyRhYwW25eWtc5pauwK8TGh3AbkFONSezdykfSA==}
-
   long@5.3.2:
     resolution: {integrity: sha512-mNAgZ1GmyNhD7AuqnTG3/VQ26o760+ZYBPKjPvugO8+nLbYfX6TVpJPseBvopbdY+qpZ/lKUnmEc1LeZYS3QAA==}
 
@@ -2065,6 +2062,11 @@ packages:
     engines: {node: '>= 14.6'}
     hasBin: true
 
+  yaml@2.9.0:
+    resolution: {integrity: sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==}
+    engines: {node: '>= 14.6'}
+    hasBin: true
+
   zod-to-json-schema@3.25.2:
     resolution: {integrity: sha512-O/PgfnpT1xKSDeQYSCfRI5Gy3hPf91mKVDuYLUHZJMiDFptvP41MSnWofm8dnCm0256ZNfZIM7DSzuSMAFnjHA==}
     peerDependencies:
@@ -2353,12 +2355,12 @@ snapshots:
       fast-wrap-ansi: 0.2.0
       sisteransi: 1.0.5
 
-  '@earendil-works/pi-agent-core@0.75.1(@modelcontextprotocol/sdk@1.29.0(supports-color@10.2.2)(zod@4.4.3))(supports-color@10.2.2)(ws@8.20.1)(zod@4.4.3)':
+  '@earendil-works/pi-agent-core@0.78.0(@modelcontextprotocol/sdk@1.29.0(supports-color@10.2.2)(zod@4.4.3))(supports-color@10.2.2)(ws@8.20.1)(zod@4.4.3)':
     dependencies:
-      '@earendil-works/pi-ai': 0.75.1(@modelcontextprotocol/sdk@1.29.0(supports-color@10.2.2)(zod@4.4.3))(supports-color@10.2.2)(ws@8.20.1)(zod@4.4.3)
+      '@earendil-works/pi-ai': 0.78.0(@modelcontextprotocol/sdk@1.29.0(supports-color@10.2.2)(zod@4.4.3))(supports-color@10.2.2)(ws@8.20.1)(zod@4.4.3)
       ignore: 7.0.5
       typebox: 1.1.38
-      yaml: 2.8.4
+      yaml: 2.9.0
     transitivePeerDependencies:
       - '@modelcontextprotocol/sdk'
       - bufferutil
@@ -2367,12 +2369,13 @@ snapshots:
       - ws
       - zod
 
-  '@earendil-works/pi-ai@0.75.1(@modelcontextprotocol/sdk@1.29.0(supports-color@10.2.2)(zod@4.4.3))(supports-color@10.2.2)(ws@8.20.1)(zod@4.4.3)':
+  '@earendil-works/pi-ai@0.78.0(@modelcontextprotocol/sdk@1.29.0(supports-color@10.2.2)(zod@4.4.3))(supports-color@10.2.2)(ws@8.20.1)(zod@4.4.3)':
     dependencies:
       '@anthropic-ai/sdk': 0.91.1(zod@4.4.3)
       '@aws-sdk/client-bedrock-runtime': 3.1048.0
       '@google/genai': 1.52.0(@modelcontextprotocol/sdk@1.29.0(supports-color@10.2.2)(zod@4.4.3))(supports-color@10.2.2)
       '@mistralai/mistralai': 2.2.1
+      '@smithy/node-http-handler': 4.7.3
       http-proxy-agent: 7.0.2(supports-color@10.2.2)
       https-proxy-agent: 7.0.6(supports-color@10.2.2)
       openai: 6.26.0(ws@8.20.1)(zod@4.4.3)
@@ -2386,13 +2389,14 @@ snapshots:
       - ws
       - zod
 
-  '@earendil-works/pi-coding-agent@0.75.1(patch_hash=5f611222f23d465ba6b392ac0eb0c5ed1b0745525ad106d827967b62cc724d3c)(@modelcontextprotocol/sdk@1.29.0(supports-color@10.2.2)(zod@4.4.3))(supports-color@10.2.2)(ws@8.20.1)(zod@4.4.3)':
+  '@earendil-works/pi-coding-agent@0.78.0(patch_hash=5f611222f23d465ba6b392ac0eb0c5ed1b0745525ad106d827967b62cc724d3c)(@modelcontextprotocol/sdk@1.29.0(supports-color@10.2.2)(zod@4.4.3))(supports-color@10.2.2)(ws@8.20.1)(zod@4.4.3)':
     dependencies:
-      '@earendil-works/pi-agent-core': 0.75.1(@modelcontextprotocol/sdk@1.29.0(supports-color@10.2.2)(zod@4.4.3))(supports-color@10.2.2)(ws@8.20.1)(zod@4.4.3)
-      '@earendil-works/pi-ai': 0.75.1(@modelcontextprotocol/sdk@1.29.0(supports-color@10.2.2)(zod@4.4.3))(supports-color@10.2.2)(ws@8.20.1)(zod@4.4.3)
-      '@earendil-works/pi-tui': 0.75.1(patch_hash=e432fee0f54b7321d104a08ff5a38561d9c2cd3b002f34e6b8cbc2377889c9d2)
+      '@earendil-works/pi-agent-core': 0.78.0(@modelcontextprotocol/sdk@1.29.0(supports-color@10.2.2)(zod@4.4.3))(supports-color@10.2.2)(ws@8.20.1)(zod@4.4.3)
+      '@earendil-works/pi-ai': 0.78.0(@modelcontextprotocol/sdk@1.29.0(supports-color@10.2.2)(zod@4.4.3))(supports-color@10.2.2)(ws@8.20.1)(zod@4.4.3)
+      '@earendil-works/pi-tui': 0.78.0(patch_hash=e432fee0f54b7321d104a08ff5a38561d9c2cd3b002f34e6b8cbc2377889c9d2)
       '@silvia-odwyer/photon-node': 0.3.4
       chalk: 5.6.2
+      cross-spawn: 7.0.6
       diff: 8.0.4
       glob: 13.0.6
       highlight.js: 10.7.3
@@ -2403,9 +2407,9 @@ snapshots:
       proper-lockfile: 4.1.2
       typebox: 1.1.38
       undici: 8.3.0
-      yaml: 2.8.4
+      yaml: 2.9.0
     optionalDependencies:
-      '@mariozechner/clipboard': 0.3.6
+      '@mariozechner/clipboard': 0.3.9
     transitivePeerDependencies:
       - '@modelcontextprotocol/sdk'
       - bufferutil
@@ -2414,12 +2418,10 @@ snapshots:
       - ws
       - zod
 
-  '@earendil-works/pi-tui@0.75.1(patch_hash=e432fee0f54b7321d104a08ff5a38561d9c2cd3b002f34e6b8cbc2377889c9d2)':
+  '@earendil-works/pi-tui@0.78.0(patch_hash=e432fee0f54b7321d104a08ff5a38561d9c2cd3b002f34e6b8cbc2377889c9d2)':
     dependencies:
       get-east-asian-width: 1.6.0
       marked: 15.0.12
-    optionalDependencies:
-      koffi: 2.16.2
 
   '@esbuild/aix-ppc64@0.27.7':
     optional: true
@@ -2525,72 +2527,72 @@ snapshots:
   '@mariozechner/clipboard-darwin-arm64@0.3.2':
     optional: true
 
-  '@mariozechner/clipboard-darwin-arm64@0.3.6':
+  '@mariozechner/clipboard-darwin-arm64@0.3.9':
     optional: true
 
   '@mariozechner/clipboard-darwin-universal@0.3.2':
     optional: true
 
-  '@mariozechner/clipboard-darwin-universal@0.3.6':
+  '@mariozechner/clipboard-darwin-universal@0.3.9':
     optional: true
 
   '@mariozechner/clipboard-darwin-x64@0.3.2':
     optional: true
 
-  '@mariozechner/clipboard-darwin-x64@0.3.6':
+  '@mariozechner/clipboard-darwin-x64@0.3.9':
     optional: true
 
   '@mariozechner/clipboard-linux-arm64-gnu@0.3.2':
     optional: true
 
-  '@mariozechner/clipboard-linux-arm64-gnu@0.3.6':
+  '@mariozechner/clipboard-linux-arm64-gnu@0.3.9':
     optional: true
 
   '@mariozechner/clipboard-linux-arm64-musl@0.3.2':
     optional: true
 
-  '@mariozechner/clipboard-linux-arm64-musl@0.3.6':
+  '@mariozechner/clipboard-linux-arm64-musl@0.3.9':
     optional: true
 
-  '@mariozechner/clipboard-linux-riscv64-gnu@0.3.6':
+  '@mariozechner/clipboard-linux-riscv64-gnu@0.3.9':
     optional: true
 
   '@mariozechner/clipboard-linux-x64-gnu@0.3.2':
     optional: true
 
-  '@mariozechner/clipboard-linux-x64-gnu@0.3.6':
+  '@mariozechner/clipboard-linux-x64-gnu@0.3.9':
     optional: true
 
   '@mariozechner/clipboard-linux-x64-musl@0.3.2':
     optional: true
 
-  '@mariozechner/clipboard-linux-x64-musl@0.3.6':
+  '@mariozechner/clipboard-linux-x64-musl@0.3.9':
     optional: true
 
   '@mariozechner/clipboard-win32-arm64-msvc@0.3.2':
     optional: true
 
-  '@mariozechner/clipboard-win32-arm64-msvc@0.3.6':
+  '@mariozechner/clipboard-win32-arm64-msvc@0.3.9':
     optional: true
 
   '@mariozechner/clipboard-win32-x64-msvc@0.3.2':
     optional: true
 
-  '@mariozechner/clipboard-win32-x64-msvc@0.3.6':
+  '@mariozechner/clipboard-win32-x64-msvc@0.3.9':
     optional: true
 
-  '@mariozechner/clipboard@0.3.6':
+  '@mariozechner/clipboard@0.3.9':
     optionalDependencies:
-      '@mariozechner/clipboard-darwin-arm64': 0.3.6
-      '@mariozechner/clipboard-darwin-universal': 0.3.6
-      '@mariozechner/clipboard-darwin-x64': 0.3.6
-      '@mariozechner/clipboard-linux-arm64-gnu': 0.3.6
-      '@mariozechner/clipboard-linux-arm64-musl': 0.3.6
-      '@mariozechner/clipboard-linux-riscv64-gnu': 0.3.6
-      '@mariozechner/clipboard-linux-x64-gnu': 0.3.6
-      '@mariozechner/clipboard-linux-x64-musl': 0.3.6
-      '@mariozechner/clipboard-win32-arm64-msvc': 0.3.6
-      '@mariozechner/clipboard-win32-x64-msvc': 0.3.6
+      '@mariozechner/clipboard-darwin-arm64': 0.3.9
+      '@mariozechner/clipboard-darwin-universal': 0.3.9
+      '@mariozechner/clipboard-darwin-x64': 0.3.9
+      '@mariozechner/clipboard-linux-arm64-gnu': 0.3.9
+      '@mariozechner/clipboard-linux-arm64-musl': 0.3.9
+      '@mariozechner/clipboard-linux-riscv64-gnu': 0.3.9
+      '@mariozechner/clipboard-linux-x64-gnu': 0.3.9
+      '@mariozechner/clipboard-linux-x64-musl': 0.3.9
+      '@mariozechner/clipboard-win32-arm64-msvc': 0.3.9
+      '@mariozechner/clipboard-win32-x64-msvc': 0.3.9
     optional: true
 
   '@mistralai/mistralai@2.2.1':
@@ -3429,9 +3431,6 @@ snapshots:
       jwa: 2.0.1
       safe-buffer: 5.2.1
 
-  koffi@2.16.2:
-    optional: true
-
   long@5.3.2: {}
 
   loupe@3.2.1: {}
@@ -4009,6 +4008,8 @@ snapshots:
   yallist@5.0.0: {}
 
   yaml@2.8.4: {}
+
+  yaml@2.9.0: {}
 
   zod-to-json-schema@3.25.2(zod@4.4.3):
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -139,32 +139,32 @@ importers:
         version: 8.20.1
     optionalDependencies:
       '@mariozechner/clipboard-darwin-arm64':
-        specifier: 0.3.9
-        version: 0.3.9
+        specifier: 0.3.2
+        version: 0.3.2
       '@mariozechner/clipboard-darwin-universal':
-        specifier: 0.3.9
-        version: 0.3.9
+        specifier: 0.3.2
+        version: 0.3.2
       '@mariozechner/clipboard-darwin-x64':
-        specifier: 0.3.9
-        version: 0.3.9
+        specifier: 0.3.2
+        version: 0.3.2
       '@mariozechner/clipboard-linux-arm64-gnu':
-        specifier: 0.3.9
-        version: 0.3.9
+        specifier: 0.3.2
+        version: 0.3.2
       '@mariozechner/clipboard-linux-arm64-musl':
-        specifier: 0.3.9
-        version: 0.3.9
+        specifier: 0.3.2
+        version: 0.3.2
       '@mariozechner/clipboard-linux-x64-gnu':
-        specifier: 0.3.9
-        version: 0.3.9
+        specifier: 0.3.2
+        version: 0.3.2
       '@mariozechner/clipboard-linux-x64-musl':
-        specifier: 0.3.9
-        version: 0.3.9
+        specifier: 0.3.2
+        version: 0.3.2
       '@mariozechner/clipboard-win32-arm64-msvc':
-        specifier: 0.3.9
-        version: 0.3.9
+        specifier: 0.3.2
+        version: 0.3.2
       '@mariozechner/clipboard-win32-x64-msvc':
-        specifier: 0.3.9
-        version: 0.3.9
+        specifier: 0.3.2
+        version: 0.3.2
 
 packages:
 
@@ -541,15 +541,32 @@ packages:
   '@jridgewell/sourcemap-codec@1.5.5':
     resolution: {integrity: sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==}
 
+  '@mariozechner/clipboard-darwin-arm64@0.3.2':
+    resolution: {integrity: sha512-uBf6K7Je1ihsgvmWxA8UCGCeI+nbRVRXoarZdLjl6slz94Zs1tNKFZqx7aCI5O1i3e0B6ja82zZ06BWrl0MCVw==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [darwin]
+
   '@mariozechner/clipboard-darwin-arm64@0.3.9':
     resolution: {integrity: sha512-BfgV7vCEWZwJwZJw03r6bP5+tf0iI/ANuQYCxi9RNn7FrWB3yzGuMKCrNLRl6V761vXRdL8+OqZ0wd4TqlsNOQ==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [darwin]
 
+  '@mariozechner/clipboard-darwin-universal@0.3.2':
+    resolution: {integrity: sha512-mxSheKTW2U9LsBdXy0SdmdCAE5HqNS9QUmpNHLnfJ+SsbFKALjEZc5oRrVMXxGQSirDvYf5bjmRyT0QYYonnlg==}
+    engines: {node: '>= 10'}
+    os: [darwin]
+
   '@mariozechner/clipboard-darwin-universal@0.3.9':
     resolution: {integrity: sha512-BGGR4iA9Z2shAjI65eI5xtyb3LYNlDW9X3gxKxDbqtbnREohsrqznov6zpKoIrsRWpzlYVEdKphS7ksJ0/ndSQ==}
     engines: {node: '>= 10'}
+    os: [darwin]
+
+  '@mariozechner/clipboard-darwin-x64@0.3.2':
+    resolution: {integrity: sha512-U1BcVEoidvwIp95+HJswSW+xr28EQiHR7rZjH6pn8Sja5yO4Yoe3yCN0Zm8Lo72BbSOK/fTSq0je7CJpaPCspg==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
     os: [darwin]
 
   '@mariozechner/clipboard-darwin-x64@0.3.9':
@@ -558,8 +575,20 @@ packages:
     cpu: [x64]
     os: [darwin]
 
+  '@mariozechner/clipboard-linux-arm64-gnu@0.3.2':
+    resolution: {integrity: sha512-BsinwG3yWTIjdgNCxsFlip7LkfwPk+ruw/aFCXHUg/fb5XC/Ksp+YMQ7u0LUtiKzIv/7LMXgZInJQH6gxbAaqQ==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [linux]
+
   '@mariozechner/clipboard-linux-arm64-gnu@0.3.9':
     resolution: {integrity: sha512-g59OkUGP2DDfCOIKypHeYgv2M55u/cKvXa5dSxFbEJ34XvIQMdcVmpKCkGUro3ZgefXiGVdwguvTMQGpHWzIXw==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [linux]
+
+  '@mariozechner/clipboard-linux-arm64-musl@0.3.2':
+    resolution: {integrity: sha512-0/Gi5Xq2V6goXBop19ePoHvXsmJD9SzFlO3S+d6+T2b+BlPcpOu3Oa0wTjl+cZrLAAEzA86aPNBI+VVAFDFPKw==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
@@ -576,8 +605,20 @@ packages:
     cpu: [riscv64]
     os: [linux]
 
+  '@mariozechner/clipboard-linux-x64-gnu@0.3.2':
+    resolution: {integrity: sha512-v6fVnsn7WMGg73Dab8QMwyFce7tzGfgEixKgzLP8f1GJqkJZi5zO4k4FOHzSgUufgLil63gnxvMpjWkgfeQN7A==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [linux]
+
   '@mariozechner/clipboard-linux-x64-gnu@0.3.9':
     resolution: {integrity: sha512-WORrMLd6EpElEME7JRKfSaY34nW1P5LbdgK5YNCS1ncG2LqmITsSMEJ8nh2mpvxb3TxqbOOKgY7k9eMJYlW9Mw==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [linux]
+
+  '@mariozechner/clipboard-linux-x64-musl@0.3.2':
+    resolution: {integrity: sha512-xVUtnoMQ8v2JVyfJLKKXACA6avdnchdbBkTsZs8BgJQo29qwCp5NIHAUO8gbJ40iaEGToW5RlmVk2M9V0HsHEw==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
@@ -588,10 +629,22 @@ packages:
     cpu: [x64]
     os: [linux]
 
+  '@mariozechner/clipboard-win32-arm64-msvc@0.3.2':
+    resolution: {integrity: sha512-AEgg95TNi8TGgak2wSXZkXKCvAUTjWoU1Pqb0ON7JHrX78p616XUFNTJohtIon3e0w6k0pYPZeCuqRCza/Tqeg==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [win32]
+
   '@mariozechner/clipboard-win32-arm64-msvc@0.3.9':
     resolution: {integrity: sha512-O5FHD3ErkMwMhNzAfu3ggy0ug4z7btZuoQgwwxlzPrwV2bxlD6WDpqBY4NCgICAgZdDKdp+loUEKVAVt8aYnhQ==}
     engines: {node: '>= 10'}
     cpu: [arm64]
+    os: [win32]
+
+  '@mariozechner/clipboard-win32-x64-msvc@0.3.2':
+    resolution: {integrity: sha512-tGRuYpZwDOD7HBrCpyRuhGnHHSCknELvqwKKUG4JSfSB7JIU7LKRh6zx6fMUOQd8uISK35TjFg5UcNih+vJhFA==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
     os: [win32]
 
   '@mariozechner/clipboard-win32-x64-msvc@0.3.9':
@@ -2471,16 +2524,31 @@ snapshots:
 
   '@jridgewell/sourcemap-codec@1.5.5': {}
 
+  '@mariozechner/clipboard-darwin-arm64@0.3.2':
+    optional: true
+
   '@mariozechner/clipboard-darwin-arm64@0.3.9':
+    optional: true
+
+  '@mariozechner/clipboard-darwin-universal@0.3.2':
     optional: true
 
   '@mariozechner/clipboard-darwin-universal@0.3.9':
     optional: true
 
+  '@mariozechner/clipboard-darwin-x64@0.3.2':
+    optional: true
+
   '@mariozechner/clipboard-darwin-x64@0.3.9':
     optional: true
 
+  '@mariozechner/clipboard-linux-arm64-gnu@0.3.2':
+    optional: true
+
   '@mariozechner/clipboard-linux-arm64-gnu@0.3.9':
+    optional: true
+
+  '@mariozechner/clipboard-linux-arm64-musl@0.3.2':
     optional: true
 
   '@mariozechner/clipboard-linux-arm64-musl@0.3.9':
@@ -2489,13 +2557,25 @@ snapshots:
   '@mariozechner/clipboard-linux-riscv64-gnu@0.3.9':
     optional: true
 
+  '@mariozechner/clipboard-linux-x64-gnu@0.3.2':
+    optional: true
+
   '@mariozechner/clipboard-linux-x64-gnu@0.3.9':
+    optional: true
+
+  '@mariozechner/clipboard-linux-x64-musl@0.3.2':
     optional: true
 
   '@mariozechner/clipboard-linux-x64-musl@0.3.9':
     optional: true
 
+  '@mariozechner/clipboard-win32-arm64-msvc@0.3.2':
+    optional: true
+
   '@mariozechner/clipboard-win32-arm64-msvc@0.3.9':
+    optional: true
+
+  '@mariozechner/clipboard-win32-x64-msvc@0.3.2':
     optional: true
 
   '@mariozechner/clipboard-win32-x64-msvc@0.3.9':

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -139,32 +139,32 @@ importers:
         version: 8.20.1
     optionalDependencies:
       '@mariozechner/clipboard-darwin-arm64':
-        specifier: 0.3.2
-        version: 0.3.2
+        specifier: 0.3.9
+        version: 0.3.9
       '@mariozechner/clipboard-darwin-universal':
-        specifier: 0.3.2
-        version: 0.3.2
+        specifier: 0.3.9
+        version: 0.3.9
       '@mariozechner/clipboard-darwin-x64':
-        specifier: 0.3.2
-        version: 0.3.2
+        specifier: 0.3.9
+        version: 0.3.9
       '@mariozechner/clipboard-linux-arm64-gnu':
-        specifier: 0.3.2
-        version: 0.3.2
+        specifier: 0.3.9
+        version: 0.3.9
       '@mariozechner/clipboard-linux-arm64-musl':
-        specifier: 0.3.2
-        version: 0.3.2
+        specifier: 0.3.9
+        version: 0.3.9
       '@mariozechner/clipboard-linux-x64-gnu':
-        specifier: 0.3.2
-        version: 0.3.2
+        specifier: 0.3.9
+        version: 0.3.9
       '@mariozechner/clipboard-linux-x64-musl':
-        specifier: 0.3.2
-        version: 0.3.2
+        specifier: 0.3.9
+        version: 0.3.9
       '@mariozechner/clipboard-win32-arm64-msvc':
-        specifier: 0.3.2
-        version: 0.3.2
+        specifier: 0.3.9
+        version: 0.3.9
       '@mariozechner/clipboard-win32-x64-msvc':
-        specifier: 0.3.2
-        version: 0.3.2
+        specifier: 0.3.9
+        version: 0.3.9
 
 packages:
 
@@ -541,32 +541,15 @@ packages:
   '@jridgewell/sourcemap-codec@1.5.5':
     resolution: {integrity: sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==}
 
-  '@mariozechner/clipboard-darwin-arm64@0.3.2':
-    resolution: {integrity: sha512-uBf6K7Je1ihsgvmWxA8UCGCeI+nbRVRXoarZdLjl6slz94Zs1tNKFZqx7aCI5O1i3e0B6ja82zZ06BWrl0MCVw==}
-    engines: {node: '>= 10'}
-    cpu: [arm64]
-    os: [darwin]
-
   '@mariozechner/clipboard-darwin-arm64@0.3.9':
     resolution: {integrity: sha512-BfgV7vCEWZwJwZJw03r6bP5+tf0iI/ANuQYCxi9RNn7FrWB3yzGuMKCrNLRl6V761vXRdL8+OqZ0wd4TqlsNOQ==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [darwin]
 
-  '@mariozechner/clipboard-darwin-universal@0.3.2':
-    resolution: {integrity: sha512-mxSheKTW2U9LsBdXy0SdmdCAE5HqNS9QUmpNHLnfJ+SsbFKALjEZc5oRrVMXxGQSirDvYf5bjmRyT0QYYonnlg==}
-    engines: {node: '>= 10'}
-    os: [darwin]
-
   '@mariozechner/clipboard-darwin-universal@0.3.9':
     resolution: {integrity: sha512-BGGR4iA9Z2shAjI65eI5xtyb3LYNlDW9X3gxKxDbqtbnREohsrqznov6zpKoIrsRWpzlYVEdKphS7ksJ0/ndSQ==}
     engines: {node: '>= 10'}
-    os: [darwin]
-
-  '@mariozechner/clipboard-darwin-x64@0.3.2':
-    resolution: {integrity: sha512-U1BcVEoidvwIp95+HJswSW+xr28EQiHR7rZjH6pn8Sja5yO4Yoe3yCN0Zm8Lo72BbSOK/fTSq0je7CJpaPCspg==}
-    engines: {node: '>= 10'}
-    cpu: [x64]
     os: [darwin]
 
   '@mariozechner/clipboard-darwin-x64@0.3.9':
@@ -575,20 +558,8 @@ packages:
     cpu: [x64]
     os: [darwin]
 
-  '@mariozechner/clipboard-linux-arm64-gnu@0.3.2':
-    resolution: {integrity: sha512-BsinwG3yWTIjdgNCxsFlip7LkfwPk+ruw/aFCXHUg/fb5XC/Ksp+YMQ7u0LUtiKzIv/7LMXgZInJQH6gxbAaqQ==}
-    engines: {node: '>= 10'}
-    cpu: [arm64]
-    os: [linux]
-
   '@mariozechner/clipboard-linux-arm64-gnu@0.3.9':
     resolution: {integrity: sha512-g59OkUGP2DDfCOIKypHeYgv2M55u/cKvXa5dSxFbEJ34XvIQMdcVmpKCkGUro3ZgefXiGVdwguvTMQGpHWzIXw==}
-    engines: {node: '>= 10'}
-    cpu: [arm64]
-    os: [linux]
-
-  '@mariozechner/clipboard-linux-arm64-musl@0.3.2':
-    resolution: {integrity: sha512-0/Gi5Xq2V6goXBop19ePoHvXsmJD9SzFlO3S+d6+T2b+BlPcpOu3Oa0wTjl+cZrLAAEzA86aPNBI+VVAFDFPKw==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
@@ -605,20 +576,8 @@ packages:
     cpu: [riscv64]
     os: [linux]
 
-  '@mariozechner/clipboard-linux-x64-gnu@0.3.2':
-    resolution: {integrity: sha512-v6fVnsn7WMGg73Dab8QMwyFce7tzGfgEixKgzLP8f1GJqkJZi5zO4k4FOHzSgUufgLil63gnxvMpjWkgfeQN7A==}
-    engines: {node: '>= 10'}
-    cpu: [x64]
-    os: [linux]
-
   '@mariozechner/clipboard-linux-x64-gnu@0.3.9':
     resolution: {integrity: sha512-WORrMLd6EpElEME7JRKfSaY34nW1P5LbdgK5YNCS1ncG2LqmITsSMEJ8nh2mpvxb3TxqbOOKgY7k9eMJYlW9Mw==}
-    engines: {node: '>= 10'}
-    cpu: [x64]
-    os: [linux]
-
-  '@mariozechner/clipboard-linux-x64-musl@0.3.2':
-    resolution: {integrity: sha512-xVUtnoMQ8v2JVyfJLKKXACA6avdnchdbBkTsZs8BgJQo29qwCp5NIHAUO8gbJ40iaEGToW5RlmVk2M9V0HsHEw==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
@@ -629,22 +588,10 @@ packages:
     cpu: [x64]
     os: [linux]
 
-  '@mariozechner/clipboard-win32-arm64-msvc@0.3.2':
-    resolution: {integrity: sha512-AEgg95TNi8TGgak2wSXZkXKCvAUTjWoU1Pqb0ON7JHrX78p616XUFNTJohtIon3e0w6k0pYPZeCuqRCza/Tqeg==}
-    engines: {node: '>= 10'}
-    cpu: [arm64]
-    os: [win32]
-
   '@mariozechner/clipboard-win32-arm64-msvc@0.3.9':
     resolution: {integrity: sha512-O5FHD3ErkMwMhNzAfu3ggy0ug4z7btZuoQgwwxlzPrwV2bxlD6WDpqBY4NCgICAgZdDKdp+loUEKVAVt8aYnhQ==}
     engines: {node: '>= 10'}
     cpu: [arm64]
-    os: [win32]
-
-  '@mariozechner/clipboard-win32-x64-msvc@0.3.2':
-    resolution: {integrity: sha512-tGRuYpZwDOD7HBrCpyRuhGnHHSCknELvqwKKUG4JSfSB7JIU7LKRh6zx6fMUOQd8uISK35TjFg5UcNih+vJhFA==}
-    engines: {node: '>= 10'}
-    cpu: [x64]
     os: [win32]
 
   '@mariozechner/clipboard-win32-x64-msvc@0.3.9':
@@ -2524,31 +2471,16 @@ snapshots:
 
   '@jridgewell/sourcemap-codec@1.5.5': {}
 
-  '@mariozechner/clipboard-darwin-arm64@0.3.2':
-    optional: true
-
   '@mariozechner/clipboard-darwin-arm64@0.3.9':
-    optional: true
-
-  '@mariozechner/clipboard-darwin-universal@0.3.2':
     optional: true
 
   '@mariozechner/clipboard-darwin-universal@0.3.9':
     optional: true
 
-  '@mariozechner/clipboard-darwin-x64@0.3.2':
-    optional: true
-
   '@mariozechner/clipboard-darwin-x64@0.3.9':
     optional: true
 
-  '@mariozechner/clipboard-linux-arm64-gnu@0.3.2':
-    optional: true
-
   '@mariozechner/clipboard-linux-arm64-gnu@0.3.9':
-    optional: true
-
-  '@mariozechner/clipboard-linux-arm64-musl@0.3.2':
     optional: true
 
   '@mariozechner/clipboard-linux-arm64-musl@0.3.9':
@@ -2557,25 +2489,13 @@ snapshots:
   '@mariozechner/clipboard-linux-riscv64-gnu@0.3.9':
     optional: true
 
-  '@mariozechner/clipboard-linux-x64-gnu@0.3.2':
-    optional: true
-
   '@mariozechner/clipboard-linux-x64-gnu@0.3.9':
-    optional: true
-
-  '@mariozechner/clipboard-linux-x64-musl@0.3.2':
     optional: true
 
   '@mariozechner/clipboard-linux-x64-musl@0.3.9':
     optional: true
 
-  '@mariozechner/clipboard-win32-arm64-msvc@0.3.2':
-    optional: true
-
   '@mariozechner/clipboard-win32-arm64-msvc@0.3.9':
-    optional: true
-
-  '@mariozechner/clipboard-win32-x64-msvc@0.3.2':
     optional: true
 
   '@mariozechner/clipboard-win32-x64-msvc@0.3.9':

--- a/src/extensions/login/flow.ts
+++ b/src/extensions/login/flow.ts
@@ -446,6 +446,10 @@ async function showOAuthLoginDialogWithExtensionUI(
 							dialog.showWaiting("Waiting for browser authentication...")
 						}
 					},
+					onDeviceCode: (info) => {
+						dialog.showDeviceCode(info)
+						dialog.showWaiting("Waiting for authentication...")
+					},
 					onPrompt: async (prompt) => dialog.showPrompt(prompt.message, prompt.placeholder),
 					onProgress: (message) => {
 						dialog.showProgress(message)

--- a/src/modes/acp/server.test.ts
+++ b/src/modes/acp/server.test.ts
@@ -127,6 +127,10 @@ function makeRecordingConn(): { conn: AgentSideConnection; updates: SessionNotif
 
 const delay = (ms: number) => new Promise<void>((r) => setTimeout(r, ms))
 
+function agentEnd(): AgentSessionEvent {
+	return { type: "agent_end", messages: [], willRetry: false }
+}
+
 describe("KimchiAcpAgent turn lifecycle", () => {
 	let fake: FakeAgentSession
 	let agent: KimchiAcpAgent
@@ -236,7 +240,7 @@ describe("KimchiAcpAgent turn lifecycle", () => {
 			// simulating a slow downstream handler on the agent_end path.
 			setTimeout(() => {
 				agentEndDeliveredAt = Date.now()
-				fake.emit({ type: "agent_end", messages: [] })
+				fake.emit(agentEnd())
 			}, 40)
 			// Return now — agent_end has NOT reached our subscriber yet.
 		}
@@ -272,7 +276,7 @@ describe("KimchiAcpAgent turn lifecycle", () => {
 			// Schedule agent_start + agent_end AFTER session.prompt resolves.
 			setTimeout(() => {
 				fake.emit({ type: "agent_start" })
-				fake.emit({ type: "agent_end", messages: [] })
+				fake.emit(agentEnd())
 				lateEventsFired = true
 			}, 30)
 		}
@@ -307,7 +311,7 @@ describe("KimchiAcpAgent turn lifecycle", () => {
 				args: { command: "noop" },
 			})
 			await delay(5)
-			setTimeout(() => fake.emit({ type: "agent_end", messages: [] }), 30)
+			setTimeout(() => fake.emit(agentEnd()), 30)
 		}
 		const result = await agent.prompt({
 			sessionId,
@@ -344,7 +348,7 @@ describe("KimchiAcpAgent turn lifecycle", () => {
 			// Wait until cancel() runs.
 			while (!cancelSeen) await delay(5)
 			// pi-mono's abort path still emits agent_end on teardown.
-			fake.emit({ type: "agent_end", messages: [] })
+			fake.emit(agentEnd())
 		}
 		fake.abortImpl = async () => {
 			cancelSeen = true
@@ -487,7 +491,7 @@ describe("KimchiAcpAgent turn lifecycle", () => {
 		fake.promptImpl = async () => {
 			fake.emit({ type: "agent_start" })
 			await delay(5)
-			fake.emit({ type: "agent_end", messages: [] })
+			fake.emit(agentEnd())
 		}
 
 		const result = await agent.prompt({
@@ -514,7 +518,7 @@ describe("KimchiAcpAgent turn lifecycle", () => {
 		fake.promptImpl = async () => {
 			fake.emit({ type: "agent_start" })
 			await delay(5)
-			fake.emit({ type: "agent_end", messages: [] })
+			fake.emit(agentEnd())
 		}
 
 		const writes: string[] = []
@@ -602,7 +606,7 @@ describe("KimchiAcpAgent turn lifecycle", () => {
 
 		// Stray agent_end arrives later (shouldn't happen in production, but
 		// the guard in onSessionEvent must keep us safe either way).
-		expect(() => fake.emit({ type: "agent_end", messages: [] })).not.toThrow()
+		expect(() => fake.emit(agentEnd())).not.toThrow()
 	})
 
 	// Resource safety on the newSession error path: if subscribe (or any step
@@ -811,7 +815,7 @@ describe("KimchiAcpAgent turn lifecycle", () => {
 			newFake.emit({ type: "agent_start" })
 			markNewPromptStarted()
 			await newPromptReleased
-			newFake.emit({ type: "agent_end", messages: [] })
+			newFake.emit(agentEnd())
 		}
 		oldFake.abortImpl = async () => {
 			await localAgent.loadSession({ sessionId: sid, cwd: "/tmp", mcpServers: [] })
@@ -926,12 +930,12 @@ describe("KimchiAcpAgent turn lifecycle", () => {
 		fakeA.promptImpl = async () => {
 			fakeA.emit({ type: "agent_start" })
 			await delay(5)
-			setTimeout(() => fakeA.emit({ type: "agent_end", messages: [] }), 60)
+			setTimeout(() => fakeA.emit(agentEnd()), 60)
 		}
 		fakeB.promptImpl = async () => {
 			fakeB.emit({ type: "agent_start" })
 			await delay(5)
-			setTimeout(() => fakeB.emit({ type: "agent_end", messages: [] }), 10)
+			setTimeout(() => fakeB.emit(agentEnd()), 10)
 		}
 
 		const [resA, resB] = await Promise.all([
@@ -998,7 +1002,7 @@ describe("KimchiAcpAgent tool execution stream", () => {
 				result: { content: [{ type: "text", text: "ab" }] },
 				isError: false,
 			})
-			fake.emit({ type: "agent_end", messages: [] })
+			fake.emit(agentEnd())
 		}
 
 		const res = await agent.prompt({ sessionId, prompt: [{ type: "text", text: "run" }] })
@@ -1057,7 +1061,7 @@ describe("KimchiAcpAgent tool execution stream", () => {
 				result: { content: [{ type: "text", text: "" }] },
 				isError: false,
 			})
-			fake.emit({ type: "agent_end", messages: [] })
+			fake.emit(agentEnd())
 		}
 
 		const res = await agent.prompt({ sessionId, prompt: [{ type: "text", text: "run" }] })
@@ -1094,7 +1098,7 @@ describe("KimchiAcpAgent tool execution stream", () => {
 				result: { content: [{ type: "text", text: "System agent started." }] },
 				isError: false,
 			})
-			fake.emit({ type: "agent_end", messages: [] })
+			fake.emit(agentEnd())
 		}
 
 		const res = await agent.prompt({ sessionId, prompt: [{ type: "text", text: "run" }] })
@@ -1120,7 +1124,7 @@ describe("KimchiAcpAgent tool execution stream", () => {
 				result: { content: [{ type: "text", text: "System agent started." }] },
 				isError: false,
 			})
-			fake.emit({ type: "agent_end", messages: [] })
+			fake.emit(agentEnd())
 		}
 
 		const res = await agent.prompt({ sessionId, prompt: [{ type: "text", text: "run" }] })


### PR DESCRIPTION
  ## Description

  Upgrades the Pi SDK packages from `0.75.1` to `0.78.0`:

  - `@earendil-works/pi-coding-agent`
  - `@earendil-works/pi-tui`
  - `@earendil-works/pi-ai`

  Also adapts Kimchi to the Pi `0.78.0` API changes:
  - Adds the required OAuth `onDeviceCode` callback for subscription login flows.
  - Updates ACP `agent_end` test fixtures for the new `willRetry` field.
  - Aligns Kimchi’s direct native clipboard sidecar deps with Pi’s `@mariozechner/clipboard@0.3.9` sidecars.

  ## Why Upgrade

  This is worth taking because the releases between `0.75.1` and `0.78.0` include fixes that map directly to Kimchi’s runtime surface:

  - **Ctrl+V image paste reliability:** Pi fixed native clipboard sidecar packaging for Bun release binaries and updated clipboard native packages. Kimchi has its own Bun-friendly clipboard loader, so
  matching the sidecar version avoids resolving older `0.3.2` native modules while Pi uses `0.3.9`.
  - **Kimi K2.6 provider fixes:** Upstream fixed several Kimi K2.6 request/metadata issues, including OpenRouter Moonshot Kimi using `system` instead of unsupported `developer` messages, and OpenCode
  Kimi K2.6 thinking metadata/request formatting.
  - **Better agent lifecycle behavior:** Pi now exposes retry awareness via `agent_end.willRetry`, improves retry/compaction settlement, and fixes queued follow-up handling from `agent_end` extension
  handlers.
  - **More reliable shutdown/disposal:** Fixes around `session_shutdown`, SIGTERM/SIGHUP cleanup, and session disposal are relevant to Kimchi telemetry, MCP cleanup, ACP, and Teleport sessions.
  - **Automation/RPC improvements:** `--session-id`, RPC `bash.excludeFromContext`, bounded Codex waits, and provider retry settings improve headless and protocol-driven usage.

  ## Compatibility Notes

  The upgrade introduced two compile-time API changes, both handled here:

  - `OAuthLoginCallbacks` now requires `onDeviceCode`.
  - `AgentSessionEvent` `agent_end` now includes `willRetry`.

  Kimchi’s existing Pi patches still apply on `0.78.0`.

## Type of Change

<!-- Select all that apply. -->

- [x] Dependency upgrade
