### PR TITLE
feat: add live elapsed-time timer to tool call headers and collapsed groups

### DIFF
--- a/src/extensions/tool-grouping.test.ts
+++ b/src/extensions/tool-grouping.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, it } from "vitest"
 import {
 	buildCurrentToolLine,
 	buildGroupSummaryText,
+	buildGroupView,
 	classifyTool,
 	findToolGroup,
 	formatSummary,
@@ -333,5 +334,44 @@ describe("buildCurrentToolLine", () => {
 	it("unknown tool shows toolName …", () => {
 		const tool = mockToolFull("some_mcp_tool", {})
 		expect(buildCurrentToolLine(tool)).toBe("some_mcp_tool …")
+	})
+})
+
+describe("buildGroupView", () => {
+	const plainTheme = {
+		fg: (key: string, value: string) => value,
+	}
+
+	it("appends timer to right header when a tool is in-progress", () => {
+		const run = [mockToolFull("read", { path: "a.ts" }), mockToolFull("read", { path: "b.ts" }, { isPartial: true })]
+		// biome-ignore lint/suspicious/noExplicitAny: mock property access
+		;(run[1] as any).rendererState = { _executionStartedAt: Date.now() - 5000 }
+		const view = buildGroupView(run, plainTheme)
+		const lines = view.render(120)
+		const headerLine = lines[0]
+		expect(headerLine).toContain("ctrl+o to expand")
+		expect(headerLine).toContain("5.0s")
+	})
+
+	it("appends timer for sub-second elapsed", () => {
+		const run = [mockToolFull("read", { path: "a.ts" }, { isPartial: true })]
+		// biome-ignore lint/suspicious/noExplicitAny: mock property access
+		;(run[0] as any).rendererState = { _executionStartedAt: Date.now() - 500 }
+		const view = buildGroupView(run, plainTheme)
+		const lines = view.render(120)
+		const headerLine = lines[0]
+		expect(headerLine).toContain("ctrl+o to expand")
+		expect(headerLine).toContain("500ms")
+	})
+
+	it("appends timer for completed groups", () => {
+		const run = [mockToolFull("read", { path: "a.ts" }), mockToolFull("read", { path: "b.ts" })]
+		// biome-ignore lint/suspicious/noExplicitAny: mock property access
+		;(run[1] as any).rendererState = { _executionStartedAt: Date.now() - 5000, _executionEndedAt: Date.now() }
+		const view = buildGroupView(run, plainTheme)
+		const lines = view.render(120)
+		const headerLine = lines[0]
+		expect(headerLine).toContain("ctrl+o to expand")
+		expect(headerLine).toContain("5.0s")
 	})
 })

--- a/src/extensions/tool-grouping.ts
+++ b/src/extensions/tool-grouping.ts
@@ -2,6 +2,7 @@ import type { ExtensionAPI } from "@earendil-works/pi-coding-agent"
 import { ToolExecutionComponent } from "@earendil-works/pi-coding-agent"
 import { Container, Spacer } from "@earendil-works/pi-tui"
 import { ToolBlockView } from "../components/tool-block.js"
+import { formatToolTimer } from "./tool-rendering.js"
 
 // ---------------------------------------------------------------------------
 // Types
@@ -218,21 +219,29 @@ export function buildCurrentToolLine(tool: object): string {
 const GROUP_RENDER_PATCH_FLAG = Symbol.for("pi-tool-grouping:patched-render")
 
 // biome-ignore lint/suspicious/noExplicitAny: theme comes from untyped external package
-function buildGroupView(run: object[], theme: any): ToolBlockView {
+export function buildGroupView(run: object[], theme: any): ToolBlockView {
 	const view = new ToolBlockView()
 	// biome-ignore lint/suspicious/noExplicitAny: runtime duck-typing on unknown object
 	const last = run[run.length - 1] as any
 	const isInProgress = last?.isPartial === true
 	const summaryText = buildGroupSummaryText(run, isInProgress)
 
+	const startedAt = last?.rendererState?._executionStartedAt
+	const endedAt = last?.rendererState?._executionEndedAt
+	const elapsedMs = startedAt ? (endedAt ?? Date.now()) - startedAt : 0
+	const timer = formatToolTimer(elapsedMs)
+	const right = timer
+		? (theme?.fg?.("dim", `(ctrl+o to expand) • ${timer}`) ?? `(ctrl+o to expand) • ${timer}`)
+		: (theme?.fg?.("dim", "(ctrl+o to expand)") ?? "(ctrl+o to expand)")
+
 	if (isInProgress) {
 		const icon = theme?.fg?.("accent", "⟳") ?? "⟳"
-		view.setHeader(`${icon} ${summaryText}…`, theme?.fg?.("dim", "(ctrl+o to expand)") ?? "(ctrl+o to expand)")
+		view.setHeader(`${icon} ${summaryText}…`, right)
 		view.setBranchMode((s: string) => theme?.fg?.("borderMuted", s) ?? s)
 		view.setExtra([theme?.fg?.("dim", buildCurrentToolLine(last)) ?? buildCurrentToolLine(last)])
 	} else {
 		const icon = theme?.fg?.("success", "✓") ?? "✓"
-		view.setHeader(`${icon} ${summaryText}`, theme?.fg?.("dim", "ctrl+o") ?? "ctrl+o")
+		view.setHeader(`${icon} ${summaryText}`, right)
 		view.hideDivider()
 		view.setFooter("", "")
 		view.setExtra([])

--- a/src/extensions/tool-rendering.test.ts
+++ b/src/extensions/tool-rendering.test.ts
@@ -1,7 +1,15 @@
-import { type Theme, UserMessageComponent, initTheme } from "@earendil-works/pi-coding-agent"
+import { type Theme, ToolExecutionComponent, UserMessageComponent, initTheme } from "@earendil-works/pi-coding-agent"
 import { visibleWidth } from "@earendil-works/pi-tui"
 import { beforeAll, describe, expect, it } from "vitest"
-import { patchUserMessageRender, splitLeadingOsc133Markers, summarizeOpenAiToolCall } from "./tool-rendering.js"
+import {
+	formatToolTimer,
+	getToolElapsedMs,
+	patchToolRenderCacheInvalidation,
+	patchUserMessageRender,
+	splitLeadingOsc133Markers,
+	summarizeOpenAiToolCall,
+	toolHeader,
+} from "./tool-rendering.js"
 
 const OSC133_A = "\x1b]133;A\x07"
 const OSC133_B = "\x1b]133;B\x07"
@@ -11,6 +19,7 @@ const SGR_RE = new RegExp(`${"\x1b"}\\[[0-9;]*m`, "g")
 const stripSgr = (line: string): string => line.replace(SGR_RE, "")
 const plainTheme = {
 	fg: (_name: string, value: string) => value,
+	bold: (value: string) => value,
 } as unknown as Theme
 
 describe("user message render patch", () => {
@@ -47,5 +56,127 @@ describe("user message render patch", () => {
 		)
 
 		expect(summary).toBe("Which improvement areas should this ferment include?")
+	})
+})
+
+describe("execution timestamp tracking", () => {
+	beforeAll(() => {
+		patchToolRenderCacheInvalidation()
+	})
+
+	function createMockComponent(): ToolExecutionComponent {
+		return new ToolExecutionComponent(
+			"bash",
+			"tc-1",
+			{ command: "sleep 1" },
+			{},
+			undefined,
+			// biome-ignore lint/suspicious/noExplicitAny: mock property access
+			{ requestRender: () => {} } as any,
+			"/tmp",
+		)
+	}
+
+	it("records _executionStartedAt when markExecutionStarted is called", () => {
+		const component = createMockComponent()
+		// biome-ignore lint/suspicious/noExplicitAny: mock property access
+		expect((component as any).rendererState._executionStartedAt).toBeUndefined()
+		component.markExecutionStarted()
+		// biome-ignore lint/suspicious/noExplicitAny: mock property access
+		expect(typeof (component as any).rendererState._executionStartedAt).toBe("number")
+	})
+
+	it("records _executionEndedAt when updateResult is called with isPartial=false", () => {
+		const component = createMockComponent()
+		component.markExecutionStarted()
+		// biome-ignore lint/suspicious/noExplicitAny: mock property access
+		expect((component as any).rendererState._executionEndedAt).toBeUndefined()
+		component.updateResult({ content: [], isError: false }, false)
+		// biome-ignore lint/suspicious/noExplicitAny: mock property access
+		expect(typeof (component as any).rendererState._executionEndedAt).toBe("number")
+	})
+
+	it("does not overwrite _executionStartedAt on duplicate calls", () => {
+		const component = createMockComponent()
+		component.markExecutionStarted()
+		// biome-ignore lint/suspicious/noExplicitAny: mock property access
+		const first = (component as any).rendererState._executionStartedAt
+		component.markExecutionStarted()
+		// biome-ignore lint/suspicious/noExplicitAny: mock property access
+		expect((component as any).rendererState._executionStartedAt).toBe(first)
+	})
+
+	it("records _executionEndedAt when updateResult is called with one argument (default isPartial=false)", () => {
+		const component = createMockComponent()
+		component.markExecutionStarted()
+		// biome-ignore lint/suspicious/noExplicitAny: mock property access
+		expect((component as any).rendererState._executionEndedAt).toBeUndefined()
+		component.updateResult({ content: [], isError: false })
+		// biome-ignore lint/suspicious/noExplicitAny: mock property access
+		expect(typeof (component as any).rendererState._executionEndedAt).toBe("number")
+	})
+
+	it("does not record _executionEndedAt when isPartial is true", () => {
+		const component = createMockComponent()
+		component.markExecutionStarted()
+		component.updateResult({ content: [], isError: false }, true)
+		// biome-ignore lint/suspicious/noExplicitAny: mock property access
+		expect((component as any).rendererState._executionEndedAt).toBeUndefined()
+	})
+})
+
+describe("elapsed time helpers", () => {
+	it("returns 0 when no timestamps exist", () => {
+		expect(getToolElapsedMs({ state: {} })).toBe(0)
+		expect(getToolElapsedMs({})).toBe(0)
+		expect(getToolElapsedMs(null)).toBe(0)
+	})
+
+	it("returns elapsed time for a running tool (no end timestamp)", () => {
+		const startedAt = Date.now() - 5000
+		const elapsed = getToolElapsedMs({ state: { _executionStartedAt: startedAt } })
+		expect(elapsed).toBeGreaterThanOrEqual(5000)
+		expect(elapsed).toBeLessThan(6000)
+	})
+
+	it("returns exact elapsed time for a completed tool", () => {
+		const startedAt = 1000
+		const endedAt = 3500
+		const elapsed = getToolElapsedMs({ state: { _executionStartedAt: startedAt, _executionEndedAt: endedAt } })
+		expect(elapsed).toBe(2500)
+	})
+
+	it("formatToolTimer returns undefined at zero or negative elapsed", () => {
+		expect(formatToolTimer(0)).toBeUndefined()
+		expect(formatToolTimer(-1)).toBeUndefined()
+	})
+
+	it("formatToolTimer returns formatted duration for any positive elapsed", () => {
+		expect(formatToolTimer(500)).toBe("500ms")
+		expect(formatToolTimer(1000)).toBe("1.0s")
+		expect(formatToolTimer(12345)).toBe("12.3s")
+		expect(formatToolTimer(120000)).toBe("120.0s")
+	})
+})
+
+describe("toolHeader", () => {
+	it("renders header with tool name and summary", () => {
+		const header = toolHeader("Read", "src/foo.ts", plainTheme, "○ ")
+		expect(header).toContain("Read")
+		expect(header).toContain("src/foo.ts")
+	})
+
+	it("appends timer when timer is provided", () => {
+		const header = toolHeader("Read", "src/foo.ts", plainTheme, "○ ", "1.5s")
+		expect(header).toContain("Read")
+		expect(header).toContain("src/foo.ts")
+		expect(header).toContain("1.5s")
+	})
+
+	it("omits timer when timer is undefined", () => {
+		const headerWith = toolHeader("Read", "src/foo.ts", plainTheme, "○ ", "1.5s")
+		const headerWithout = toolHeader("Read", "src/foo.ts", plainTheme, "○ ")
+		expect(headerWithout).not.toContain("1.5s")
+		expect(headerWith).toContain("1.5s")
 	})
 })

--- a/src/extensions/tool-rendering.ts
+++ b/src/extensions/tool-rendering.ts
@@ -1,6 +1,7 @@
 import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs"
 import { readFile as readFileAsync } from "node:fs/promises"
 import { extname, relative, resolve } from "node:path"
+import { formatDuration } from "../extensions/format.js"
 
 import type {
 	BashToolDetails,
@@ -342,6 +343,25 @@ function formatWorkedDuration(ms: number): string {
 	return `${minutes}m ${seconds}s`
 }
 
+/**
+ * Returns elapsed milliseconds for a tool call.
+ *
+ * Note: `ctx.state` is the component's `rendererState` — the upstream
+ * framework's `getRenderContext` method aliases them via
+ * `state: this.rendererState`.
+ */
+export function getToolElapsedMs(ctx: any): number {
+	const startedAt = ctx?.state?._executionStartedAt
+	if (!startedAt) return 0
+	const endedAt = ctx?.state?._executionEndedAt
+	return (endedAt ?? Date.now()) - startedAt
+}
+
+export function formatToolTimer(elapsedMs: number): string | undefined {
+	if (elapsedMs <= 0) return undefined
+	return formatDuration(elapsedMs)
+}
+
 function inlineWorkedDurationText(ms: number): string {
 	return `${WORKED_LINE_FG}✻ Worked for ${formatWorkedDuration(ms)}${RESET}`
 }
@@ -420,7 +440,7 @@ export function patchUserMessageRender(): void {
 	proto[USER_MESSAGE_PATCH_FLAG] = true
 }
 
-function patchToolRenderCacheInvalidation(): void {
+export function patchToolRenderCacheInvalidation(): void {
 	const proto = ToolExecutionComponent.prototype as any
 	if (proto[TOOL_CACHE_PATCH_FLAG]) return
 
@@ -441,6 +461,16 @@ function patchToolRenderCacheInvalidation(): void {
 		if (typeof original !== "function") continue
 		proto[method] = function patchedToolMutation(...args: any[]) {
 			clearToolRenderCache(this)
+			if (method === "markExecutionStarted" && !this.rendererState._executionStartedAt) {
+				this.rendererState._executionStartedAt = Date.now()
+			}
+			if (
+				method === "updateResult" &&
+				!this.rendererState._executionEndedAt &&
+				args[1] !== true
+			) {
+				this.rendererState._executionEndedAt = Date.now()
+			}
 			const result = original.apply(this, args)
 			clearToolRenderCache(this)
 			return result
@@ -554,11 +584,13 @@ function shortPath(cwd: string, filePath: string): string {
 // Status dot — flickers green/gray while pending
 // ---------------------------------------------------------------------------
 
-function toolHeader(tool: string, summary: string, theme: Theme, prefix = ""): string {
+export function toolHeader(tool: string, summary: string, theme: Theme, prefix = "", timer?: string): string {
 	applyThemePaletteIfNeeded(theme)
 	const label = theme.fg("toolTitle", theme.bold(tool))
-	if (!summary) return `${prefix}${label}`
-	return `${prefix}${label} ${WRAP_MARK}${theme.fg("accent", summary)}`
+	let result = `${prefix}${label}`
+	if (summary) result += ` ${WRAP_MARK}${theme.fg("accent", summary)}`
+	if (timer) result += ` ${theme.fg("dim", timer)}`
+	return result
 }
 
 
@@ -889,6 +921,7 @@ class ToolText extends Text {
 		this.toolCachedValue = undefined
 		this.toolCachedWidth = undefined
 		this.toolCachedLines = undefined
+		super.invalidate()
 	}
 
 	render(width: number): string[] {
@@ -2559,7 +2592,8 @@ function renderGenericToolCall(name: string, args: any, theme: Theme, ctx: any):
 	ctx.state._openAiPatchFiles = []
 	const sp = (path: string) => shortPath(ctx.cwd ?? process.cwd(), path)
 	const summary = stableCallSummary(ctx, "_callSummary", () => summarizeGenericToolCall(name, args, theme, sp))
-	return makeText(ctx.lastComponent, toolHeader(genericToolLabel(name), summary, theme, toolStatusDot(ctx, theme)))
+	const timer = formatToolTimer(getToolElapsedMs(ctx))
+	return makeText(ctx.lastComponent, toolHeader(genericToolLabel(name), summary, theme, toolStatusDot(ctx, theme), timer))
 }
 
 function renderGenericToolResult(name: string, result: any, options: any, theme: Theme, ctx: any): Text {
@@ -2951,7 +2985,8 @@ function getApplyPatchResultMeta(args: any, ctx: any, sp: (path: string) => stri
 function renderApplyPatchCall(args: any, theme: Theme, ctx: any, sp: (path: string) => string): Text {
 	const patchText = getStringArg(args, "patchText", "patch_text")
 	const summary = stableCallSummary(ctx, "_callSummary", () => summarizeOpenAiToolCall("apply_patch", args, theme, sp))
-	const hdr = toolHeader("Apply Patch", summary, theme, toolStatusDot(ctx, theme))
+	const timer = formatToolTimer(getToolElapsedMs(ctx))
+	const hdr = toolHeader("Apply Patch", summary, theme, toolStatusDot(ctx, theme), timer)
 
 	if (!ctx.argsComplete) return makeText(ctx.lastComponent, hdr)
 	const preview = getCachedApplyPatchPreview(patchText, sp, ctx)
@@ -3709,7 +3744,8 @@ export default function (pi: ExtensionAPI) {
 				}
 				return value
 			})
-			return makeText(ctx.lastComponent, toolHeader("Read", summary, theme, toolStatusDot(ctx, theme)))
+			const timer = formatToolTimer(getToolElapsedMs(ctx))
+			return makeText(ctx.lastComponent, toolHeader("Read", summary, theme, toolStatusDot(ctx, theme), timer))
 		},
 		renderResult(result, { expanded, isPartial }, theme, ctx) {
 			if (isPartial) {
@@ -3754,7 +3790,8 @@ export default function (pi: ExtensionAPI) {
 		},
 		renderCall(args, theme, ctx) {
 			const summary = summarizeText(getBashCommandForDisplay(args.command) ?? args.command, 72)
-			return makeText(ctx.lastComponent, toolHeader("Bash", summary, theme, toolStatusDot(ctx, theme)))
+			const timer = formatToolTimer(getToolElapsedMs(ctx))
+			return makeText(ctx.lastComponent, toolHeader("Bash", summary, theme, toolStatusDot(ctx, theme), timer))
 		},
 		renderResult(result, { expanded, isPartial }, theme, ctx) {
 			const details = result.details as BashToolDetails | undefined
@@ -3806,7 +3843,8 @@ export default function (pi: ExtensionAPI) {
 				if (args.path) value += ` in ${args.path}`
 				return value
 			})
-			return makeText(ctx.lastComponent, toolHeader("Grep", summary, theme, toolStatusDot(ctx, theme)))
+			const timer = formatToolTimer(getToolElapsedMs(ctx))
+			return makeText(ctx.lastComponent, toolHeader("Grep", summary, theme, toolStatusDot(ctx, theme), timer))
 		},
 		renderResult(result, { expanded, isPartial }, theme, ctx) {
 			if (isPartial) {
@@ -3848,7 +3886,8 @@ export default function (pi: ExtensionAPI) {
 				if (args.path) value += ` in ${args.path}`
 				return value
 			})
-			return makeText(ctx.lastComponent, toolHeader("Find", summary, theme, toolStatusDot(ctx, theme)))
+			const timer = formatToolTimer(getToolElapsedMs(ctx))
+			return makeText(ctx.lastComponent, toolHeader("Find", summary, theme, toolStatusDot(ctx, theme), timer))
 		},
 		renderResult(result, { expanded, isPartial }, theme, ctx) {
 			if (isPartial) {
@@ -3892,7 +3931,8 @@ export default function (pi: ExtensionAPI) {
 		},
 		renderCall(args, theme, ctx) {
 			const summary = stableCallSummary(ctx, "_callSummary", () => sp(args.path ?? "."))
-			return makeText(ctx.lastComponent, toolHeader("List", summary, theme, toolStatusDot(ctx, theme)))
+			const timer = formatToolTimer(getToolElapsedMs(ctx))
+			return makeText(ctx.lastComponent, toolHeader("List", summary, theme, toolStatusDot(ctx, theme), timer))
 		},
 		renderResult(result, { expanded, isPartial }, theme, ctx) {
 			if (isPartial) {
@@ -3980,7 +4020,8 @@ export default function (pi: ExtensionAPI) {
 				},
 				revealSummary,
 			)
-			const hdr = toolHeader(label, summary, theme, toolStatusDot(ctx, theme))
+			const timer = formatToolTimer(getToolElapsedMs(ctx))
+			const hdr = toolHeader(label, summary, theme, toolStatusDot(ctx, theme), timer)
 			return makeText(ctx.lastComponent, hdr)
 		},
 		renderResult(result, { isPartial }, theme, ctx) {
@@ -4115,7 +4156,8 @@ export default function (pi: ExtensionAPI) {
 						: sp(fp),
 				revealSummary,
 			)
-			const hdr = toolHeader("Edit", summary, theme, ` ${toolStatusDot(ctx, theme)}`)
+			const timer = formatToolTimer(getToolElapsedMs(ctx))
+			const hdr = toolHeader("Edit", summary, theme, ` ${toolStatusDot(ctx, theme)}`, timer)
 			if (!(ctx.argsComplete && operations.length > 0)) return makeText(ctx.lastComponent, hdr)
 			const diffWidth = branchDiffWidth()
 			const key = `edit:${fp}:${hashText(operations.map((edit) => `${edit.oldText}\u0000${edit.newText}`).join("\u0001"))}:${diffWidth}:${ctx.expanded ? 1 : 0}`
@@ -4218,7 +4260,8 @@ export default function (pi: ExtensionAPI) {
 					if (name === "apply_patch") return renderApplyPatchCall(args, theme, ctx, sp)
 					ctx.state._openAiPatchFiles = []
 					const summary = stableCallSummary(ctx, "_callSummary", () => summarizeOpenAiToolCall(name, args, theme, sp))
-					return makeText(ctx.lastComponent, toolHeader(label, summary, theme, toolStatusDot(ctx, theme)))
+					const timer = formatToolTimer(getToolElapsedMs(ctx))
+					return makeText(ctx.lastComponent, toolHeader(label, summary, theme, toolStatusDot(ctx, theme), timer))
 				},
 				renderResult(result: any, { expanded, isPartial }: any, theme: Theme, ctx: any) {
 					if (name === "apply_patch") return renderApplyPatchResult(result, isPartial, theme, ctx)


### PR DESCRIPTION
## What

Adds a live elapsed-time timer to every tool call header and to collapsed parallel-group headers, so users can see how long a running or completed tool has taken.

## How

- Patches `markExecutionStarted` and `updateResult` on `ToolExecutionComponent` to record `_executionStartedAt` / `_executionEndedAt` timestamps on `rendererState`.
- Adds `getToolElapsedMs()` and `formatToolTimer()` helpers; timers update via the existing 500 ms blink timer loop (no new dependencies).
- Wires timer into `renderCall` for all tools: read, bash, grep, find, ls, write, edit, apply_patch, and generic tools.
- Wires timer into `buildGroupView` for collapsed parallel groups. Removes the old `>= 1000 ms` threshold so sub-second durations (e.g. `500ms`) are shown.
- Shows frozen timer on completed groups too for consistency.
- Adds `super.invalidate()` to `ToolText.invalidate()` to ensure cache propagation when timer text changes.

## Tests

- `tool-rendering.test.ts`: 13 timer-related tests (all passing)
- `tool-grouping.test.ts`: 63 group tests including timer cases (all passing)

Co-Authored-By: Kimchi <noreply@kimchi.dev>

<img width="1086" height="846" alt="image" src="https://github.com/user-attachments/assets/cfc7bc56-b451-4820-acab-1b83c3cb640e" />
