### PR TITLE
fix(classifier): retry on timeout

### DIFF
--- a/src/extensions/permissions/classifier.test.ts
+++ b/src/extensions/permissions/classifier.test.ts
@@ -118,6 +118,38 @@ describe("classifyToolCall", () => {
 		expect(completeMock).toHaveBeenCalledTimes(3)
 	})
 
+	it("returns 'classifier aborted' when signal aborts during final attempt", async () => {
+		const controller = new AbortController()
+
+		// First two attempts: timeout (retryable). Third attempt: also timeout,
+		// but the outer signal is aborted during this attempt.
+		let callCount = 0
+		completeMock.mockImplementation(() => {
+			callCount++
+			if (callCount === 3) {
+				// Simulate the outer signal aborting during the final classifier call
+				controller.abort()
+			}
+			return fakeResponse({ stopReason: "aborted" })
+		})
+
+		const promise = classifyToolCall(
+			fakeModel(),
+			fakeRegistry(),
+			{ toolName: "bash", input: { command: "ls" }, cwd: "/tmp" },
+			{ timeoutMs: 5000 },
+			controller.signal,
+		)
+
+		await vi.runAllTimersAsync()
+		const result = await promise
+
+		expect(completeMock).toHaveBeenCalledTimes(3)
+		expect(result.verdict).toBe("requires-confirmation")
+		expect(result.ok).toBe(false)
+		expect(result.reason).toBe("classifier aborted")
+	})
+
 	it("does not retry when signal is aborted before first attempt", async () => {
 		const controller = new AbortController()
 		controller.abort()

--- a/src/extensions/permissions/classifier.test.ts
+++ b/src/extensions/permissions/classifier.test.ts
@@ -1,5 +1,170 @@
-import { describe, expect, it } from "vitest"
-import { parseClassifierOutput } from "./classifier.js"
+import type { Api, Model } from "@earendil-works/pi-ai"
+import type { ModelRegistry } from "@earendil-works/pi-coding-agent"
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
+import { classifyToolCall, parseClassifierOutput } from "./classifier.js"
+
+const completeMock = vi.fn()
+
+vi.mock("@earendil-works/pi-ai", async () => {
+	const actual = await vi.importActual<typeof import("@earendil-works/pi-ai")>("@earendil-works/pi-ai")
+	return {
+		...actual,
+		complete: (...args: unknown[]) => completeMock(...args),
+	}
+})
+
+function fakeModel(id = "test-model"): Model<Api> {
+	return { provider: "openai", id, api: "openai-completions" } as Model<Api>
+}
+
+function fakeRegistry(apiKey = "fake-key"): ModelRegistry {
+	return {
+		getApiKeyAndHeaders: vi.fn().mockResolvedValue({ ok: true, apiKey, headers: {} }),
+	} as unknown as ModelRegistry
+}
+
+function fakeResponse(opts: { stopReason: string; content?: string; errorMessage?: string }) {
+	return {
+		content: opts.content ? [{ type: "text", text: opts.content }] : [],
+		stopReason: opts.stopReason,
+		errorMessage: opts.errorMessage,
+	}
+}
+
+describe("classifyToolCall", () => {
+	beforeEach(() => {
+		completeMock.mockReset()
+		vi.useFakeTimers()
+	})
+
+	afterEach(() => {
+		vi.restoreAllMocks()
+		vi.useRealTimers()
+	})
+
+	it("returns safe verdict on first attempt", async () => {
+		completeMock.mockResolvedValue(fakeResponse({ stopReason: "stop", content: '{"verdict":"safe","reason":"fine"}' }))
+
+		const result = await classifyToolCall(
+			fakeModel(),
+			fakeRegistry(),
+			{ toolName: "bash", input: { command: "ls" }, cwd: "/tmp" },
+			{ timeoutMs: 5000 },
+		)
+
+		expect(result.verdict).toBe("safe")
+		expect(result.ok).toBe(true)
+		expect(completeMock).toHaveBeenCalledTimes(1)
+	})
+
+	it("retries up to 3 times on abort before giving up", async () => {
+		completeMock.mockResolvedValue(fakeResponse({ stopReason: "aborted" }))
+
+		const promise = classifyToolCall(
+			fakeModel("nemotron-test"),
+			fakeRegistry(),
+			{ toolName: "edit", input: { path: "foo.ts" }, cwd: "/tmp" },
+			{ timeoutMs: 5000 },
+		)
+
+		await vi.runAllTimersAsync()
+		const result = await promise
+
+		expect(result.verdict).toBe("requires-confirmation")
+		expect(result.ok).toBe(false)
+		expect(result.reason).toContain("classifier timeout")
+		expect(result.reason).toContain("nemotron-test")
+		expect(completeMock).toHaveBeenCalledTimes(3)
+	})
+
+	it("succeeds on 2nd attempt after first abort", async () => {
+		completeMock
+			.mockResolvedValueOnce(fakeResponse({ stopReason: "aborted" }))
+			.mockResolvedValueOnce(fakeResponse({ stopReason: "stop", content: '{"verdict":"safe","reason":"fine"}' }))
+
+		const promise = classifyToolCall(
+			fakeModel(),
+			fakeRegistry(),
+			{ toolName: "bash", input: { command: "ls" }, cwd: "/tmp" },
+			{ timeoutMs: 5000 },
+		)
+
+		await vi.runAllTimersAsync()
+		const result = await promise
+
+		expect(result.verdict).toBe("safe")
+		expect(result.ok).toBe(true)
+		expect(completeMock).toHaveBeenCalledTimes(2)
+	})
+
+	it("succeeds on 3rd attempt after two aborts", async () => {
+		completeMock
+			.mockResolvedValueOnce(fakeResponse({ stopReason: "aborted" }))
+			.mockResolvedValueOnce(fakeResponse({ stopReason: "aborted" }))
+			.mockResolvedValueOnce(fakeResponse({ stopReason: "stop", content: '{"verdict":"safe","reason":"fine"}' }))
+
+		const promise = classifyToolCall(
+			fakeModel(),
+			fakeRegistry(),
+			{ toolName: "bash", input: { command: "ls" }, cwd: "/tmp" },
+			{ timeoutMs: 5000 },
+		)
+
+		await vi.runAllTimersAsync()
+		const result = await promise
+
+		expect(result.verdict).toBe("safe")
+		expect(result.ok).toBe(true)
+		expect(completeMock).toHaveBeenCalledTimes(3)
+	})
+
+	it("does not retry when signal is aborted before first attempt", async () => {
+		const controller = new AbortController()
+		controller.abort()
+
+		const result = await classifyToolCall(
+			fakeModel(),
+			fakeRegistry(),
+			{ toolName: "bash", input: { command: "ls" }, cwd: "/tmp" },
+			{ timeoutMs: 5000 },
+			controller.signal,
+		)
+
+		expect(completeMock).not.toHaveBeenCalled()
+		expect(result.reason).toBe("classifier aborted")
+	})
+
+	it("does not retry on error and returns requires-confirmation", async () => {
+		completeMock.mockResolvedValue(fakeResponse({ stopReason: "error", errorMessage: "rate limit exceeded" }))
+
+		const result = await classifyToolCall(
+			fakeModel(),
+			fakeRegistry(),
+			{ toolName: "bash", input: { command: "ls" }, cwd: "/tmp" },
+			{ timeoutMs: 5000 },
+		)
+
+		expect(completeMock).toHaveBeenCalledTimes(1)
+		expect(result.verdict).toBe("requires-confirmation")
+		expect(result.ok).toBe(false)
+		expect(result.reason).toContain("classifier error: rate limit exceeded")
+	})
+
+	it("still falls back to unparseable when text is garbage", async () => {
+		completeMock.mockResolvedValue(fakeResponse({ stopReason: "stop", content: "not json at all" }))
+
+		const result = await classifyToolCall(
+			fakeModel(),
+			fakeRegistry(),
+			{ toolName: "bash", input: { command: "ls" }, cwd: "/tmp" },
+			{ timeoutMs: 5000 },
+		)
+
+		expect(result.verdict).toBe("requires-confirmation")
+		expect(result.ok).toBe(false)
+		expect(result.reason).toContain("unparseable")
+	})
+})
 
 describe("parseClassifierOutput", () => {
 	it("parses a valid safe verdict", () => {

--- a/src/extensions/permissions/classifier.ts
+++ b/src/extensions/permissions/classifier.ts
@@ -17,6 +17,9 @@ export interface ClassifierOptions {
 	timeoutMs: number
 }
 
+/** Internal result type that carries a retry hint without touching the public ClassifierResult. */
+type InternalResult = ClassifierResult & { retryable: boolean }
+
 export async function classifyToolCall(
 	model: Model<Api>,
 	modelRegistry: ModelRegistry,
@@ -25,6 +28,38 @@ export async function classifyToolCall(
 	signal?: AbortSignal,
 ): Promise<ClassifierResult> {
 	const auth = await modelRegistry.getApiKeyAndHeaders(model)
+	if (!auth.ok || !auth.apiKey) return unavailable("no API key for classifier")
+
+	if (signal?.aborted) return unavailable("classifier aborted")
+
+	const maxAttempts = 3
+	let lastResult: InternalResult = unavailable("classifier unavailable")
+
+	for (let attempt = 0; attempt < maxAttempts; attempt++) {
+		if (attempt > 0) {
+			const backoff = 500 * 2 ** (attempt - 1)
+			await sleep(backoff)
+			if (signal?.aborted) return unavailable("classifier aborted")
+		}
+
+		const result = await runClassifier(model, auth, call, options, signal)
+		if (result.ok) return result
+
+		if (!result.retryable) return result
+
+		lastResult = result
+	}
+
+	return lastResult
+}
+
+async function runClassifier(
+	model: Model<Api>,
+	auth: Awaited<ReturnType<ModelRegistry["getApiKeyAndHeaders"]>>,
+	call: ClassifyInput,
+	options: ClassifierOptions,
+	signal?: AbortSignal,
+): Promise<InternalResult> {
 	if (!auth.ok || !auth.apiKey) return unavailable("no API key for classifier")
 
 	if (signal?.aborted) return unavailable("classifier aborted")
@@ -62,6 +97,16 @@ export async function classifyToolCall(
 			},
 		)
 
+		if (response.stopReason === "aborted") {
+			return retryable(`classifier timeout (model=${model.id} tool=${call.toolName})`)
+		}
+
+		if (response.stopReason === "error") {
+			return unavailable(
+				`classifier error: ${response.errorMessage || "unknown"} (model=${model.id} tool=${call.toolName})`,
+			)
+		}
+
 		const text = response.content
 			.filter((c): c is { type: "text"; text: string } => c.type === "text")
 			.map((c) => c.text)
@@ -78,11 +123,12 @@ export async function classifyToolCall(
 			return unavailable(`${result.reason} (${diag})`)
 		}
 
-		return result
+		return { ...result, retryable: false }
 	} catch (err) {
 		const aborted = (err as Error)?.name === "AbortError" || controller.signal.aborted
 		const reason = aborted ? "classifier timeout" : `classifier error: ${(err as Error).message}`
-		return unavailable(`${reason} (model=${model.id} tool=${call.toolName})`)
+		const message = `${reason} (model=${model.id} tool=${call.toolName})`
+		return aborted ? retryable(message) : unavailable(message)
 	} finally {
 		clearTimeout(timeoutHandle)
 		signal?.removeEventListener("abort", onOuterAbort)
@@ -105,8 +151,12 @@ export function parseClassifierOutput(raw: string): ClassifierResult {
 	return { verdict, reason, ok: true }
 }
 
-function unavailable(reason: string): ClassifierResult {
-	return { verdict: "requires-confirmation", reason, ok: false }
+function unavailable(reason: string): InternalResult {
+	return { verdict: "requires-confirmation", reason, ok: false, retryable: false }
+}
+
+function retryable(reason: string): InternalResult {
+	return { verdict: "requires-confirmation", reason, ok: false, retryable: true }
 }
 
 function normalizeVerdict(v: unknown): ClassifierVerdict | undefined {
@@ -138,4 +188,8 @@ function safeStringify(value: unknown): string {
 function truncate(s: string, max: number): string {
 	if (s.length <= max) return s
 	return `${s.slice(0, max - 1)}…`
+}
+
+function sleep(ms: number): Promise<void> {
+	return new Promise((resolve) => setTimeout(resolve, ms))
 }

--- a/src/extensions/permissions/classifier.ts
+++ b/src/extensions/permissions/classifier.ts
@@ -50,6 +50,8 @@ export async function classifyToolCall(
 		lastResult = result
 	}
 
+	if (signal?.aborted) return unavailable("classifier aborted")
+
 	return lastResult
 }
 


### PR DESCRIPTION
- Add retry loop (up to 3 attempts, 500ms/1000ms backoff) for classifier timeouts and AbortErrors; non-retryable failures (parse errors, API errors, no key) return immediately
- Introduce internal InternalResult type with a boolean retryable field so retry logic doesn't sniff human-readable error message strings
- Handle stopReason=aborted and stopReason=error explicitly before attempting to parse response text, with model/tool context in the message
- Restore auth.ok narrowing guard inside runClassifier (needed for TS to narrow ResolvedRequestAuth union) while keeping the early-exit in classifyToolCall for the common path
- Replace lastResult! non-null assertion with a safe default initialiser
- Merge duplicate error-path tests into one assertion covering both call-count and verdict/reason
- Rename misleading test title: retries up to 3 times on abort before giving up (no model-switching involved)

## Description

<!-- What problem does this PR solve? What changes were made and why? -->
This change is suppose to fix an issue where classifier occasionally returned `unparseable output`:
<img width="696" height="121" alt="Screenshot 2026-05-05 at 00 06 15" src="https://github.com/user-attachments/assets/b8ed2b88-a625-451b-8581-b0ee8eb2c0ee" />

These errors were caused by timeouts in calls to nemotron.


## Type of Change

<!-- Select all that apply. -->

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
