### PR TITLE
feat: add indicator for pasting images

### DIFF
--- a/src/extensions/clipboard-image.test.ts
+++ b/src/extensions/clipboard-image.test.ts
@@ -10,7 +10,7 @@ const {
 	mockAddImage,
 	mockClearAllImages,
 	mockSetImageCacheDir,
-	mockExecFileSync,
+	mockExecFile,
 } = vi.hoisted(() => ({
 	mockSetPendingImageIndicator: vi.fn(),
 	mockGetNativeClipboard: vi.fn(),
@@ -18,11 +18,11 @@ const {
 	mockAddImage: vi.fn(),
 	mockClearAllImages: vi.fn(),
 	mockSetImageCacheDir: vi.fn(),
-	mockExecFileSync: vi.fn(),
+	mockExecFile: vi.fn(),
 }))
 
 vi.mock("node:child_process", () => ({
-	execFileSync: mockExecFileSync,
+	execFile: mockExecFile,
 }))
 
 vi.mock("./ui.js", () => ({
@@ -226,12 +226,12 @@ describe("clipboard-image extension", () => {
 			clipboardImageExtension(pi)
 			;(pi._handlers.session_start as (e: unknown, ctx: ExtensionContext) => void)(void 0, makeMockCtx())
 
-			// Immediate check fires once.
-			expect(mockSetPendingImageIndicator).toHaveBeenCalledTimes(1)
+			// session_start fires updateIndicator() (null reset) then checkClipboard() (hint) — 2 calls total.
+			expect(mockSetPendingImageIndicator).toHaveBeenCalledTimes(2)
 
 			// Two timer ticks pass with image still present — no additional calls.
 			vi.advanceTimersByTime(1000)
-			expect(mockSetPendingImageIndicator).toHaveBeenCalledTimes(1)
+			expect(mockSetPendingImageIndicator).toHaveBeenCalledTimes(2)
 		})
 
 		it("detects images via availableFormats fallback when hasImage returns false", () => {
@@ -294,7 +294,7 @@ describe("clipboard-image extension", () => {
 			expect(mockSetPendingImageIndicator).toHaveBeenLastCalledWith(null)
 		})
 
-		it("shows hint when an image file is copied in Finder", () => {
+		it("shows hint when an image file is copied in Finder", async () => {
 			mockGetAvailableModels.mockReturnValue([{ slug: "glm-4", input_modalities: ["text", "image"] }])
 			mockGetNativeClipboard.mockReturnValue({
 				clipboard: {
@@ -303,16 +303,23 @@ describe("clipboard-image extension", () => {
 				},
 				error: null,
 			})
-			mockExecFileSync.mockReturnValue("/Users/user/photo.jpg\n")
+			mockExecFile.mockImplementation(
+				(_cmd: string, _args: string[], _opts: unknown, cb: (err: null, stdout: string) => void) => {
+					cb(null, "/Users/user/photo.jpg\n")
+				},
+			)
 
 			const pi = makeMockPi()
 			clipboardImageExtension(pi)
 			;(pi._handlers.session_start as (e: unknown, ctx: ExtensionContext) => void)(void 0, makeMockCtx())
 
+			// isFinderImageFileCopy is async — flush microtasks so the .then() runs.
+			await Promise.resolve()
+
 			expect(mockSetPendingImageIndicator).toHaveBeenCalledWith("Image in clipboard · ctrl+v to paste")
 		})
 
-		it("does not show hint when a non-image file is copied in Finder", () => {
+		it("does not show hint when a non-image file is copied in Finder", async () => {
 			mockGetAvailableModels.mockReturnValue([{ slug: "glm-4", input_modalities: ["text", "image"] }])
 			mockGetNativeClipboard.mockReturnValue({
 				clipboard: {
@@ -322,11 +329,17 @@ describe("clipboard-image extension", () => {
 				},
 				error: null,
 			})
-			mockExecFileSync.mockReturnValue("/Users/user/document.pdf\n")
+			mockExecFile.mockImplementation(
+				(_cmd: string, _args: string[], _opts: unknown, cb: (err: null, stdout: string) => void) => {
+					cb(null, "/Users/user/document.pdf\n")
+				},
+			)
 
 			const pi = makeMockPi()
 			clipboardImageExtension(pi)
 			;(pi._handlers.session_start as (e: unknown, ctx: ExtensionContext) => void)(void 0, makeMockCtx())
+
+			await Promise.resolve()
 
 			expect(mockSetPendingImageIndicator).not.toHaveBeenCalledWith("Image in clipboard · ctrl+v to paste")
 		})

--- a/src/extensions/clipboard-image.test.ts
+++ b/src/extensions/clipboard-image.test.ts
@@ -197,6 +197,7 @@ describe("clipboard-image extension", () => {
 		beforeEach(() => {
 			vi.clearAllMocks()
 			mockGetAvailableModels.mockReturnValue([{ slug: "glm-4", input_modalities: ["text", "image"] }])
+			Object.defineProperty(process, "platform", { value: "darwin" })
 		})
 
 		afterEach(() => {

--- a/src/extensions/clipboard-image.test.ts
+++ b/src/extensions/clipboard-image.test.ts
@@ -78,6 +78,18 @@ function callInputHandler(pi: ExtensionAPI & { _handlers: Handlers }, event: { t
 
 describe("clipboard-image extension", () => {
 	beforeEach(() => {
+		// Reset module-level state (clipboardHasImage) before each test.
+		// session_shutdown no longer clears it, so we drive a session_start with an
+		// empty-clipboard mock which causes checkClipboard to set clipboardHasImage=false.
+		mockGetAvailableModels.mockReturnValue([{ slug: "glm-4", input_modalities: ["text", "image"] }])
+		mockGetNativeClipboard.mockReturnValue({
+			clipboard: { hasImage: () => false, availableFormats: () => [] },
+			error: null,
+		})
+		const resetPi = makeMockPi()
+		clipboardImageExtension(resetPi)
+		;(resetPi._handlers.session_start as (e: unknown, ctx: ExtensionContext) => void)(void 0, makeMockCtx())
+		;(resetPi._handlers.session_shutdown as () => void)()
 		vi.clearAllMocks()
 		vi.useFakeTimers()
 	})
@@ -119,34 +131,42 @@ describe("clipboard-image extension", () => {
 			expect(result).toBeUndefined()
 		})
 
-		it("second input increments the counter and labels the next image correctly", () => {
-			// imageCounter persists across calls in the same module session.
-			// Previous test already incremented it to 1. The next image should be #2.
+		it("counter accumulates across submissions within a session", () => {
 			const pi = makeMockPi()
 			clipboardImageExtension(pi)
 
+			// First submission: image #1
+			callInputHandler(pi, { text: "first", images: [{ type: "image", mimeType: "image/png", data: "aaa" }] })
+
+			// Second submission on the same pi — counter is 1, so next image is #2
 			const result = callInputHandler(pi, {
 				text: "second",
 				images: [{ type: "image", mimeType: "image/png", data: "bbb" }],
 			})
-			const text = (result as { text: string }).text
-			// Counter was at 1 from previous test, so startIndex = 2 → #2
-			expect(text).toContain("[Image #2]")
-			expect(text).not.toContain("[Image #1]") // not the first image anymore
+			expect((result as { text: string }).text).toContain("[Image #2]")
 		})
 
-		it("multiple images in the same turn get sequential markers from the current counter position", () => {
-			// Counter is already at 2 from previous tests. With 2 new images:
-			// startIndex = 3, so markers should be #3 and #4
+		it("multiple images in the same turn get sequential markers", () => {
 			const pi = makeMockPi()
 			clipboardImageExtension(pi)
 
-			const images: ImageContent[] = [
-				{ type: "image", mimeType: "image/png", data: "aaa" },
-				{ type: "image", mimeType: "image/jpeg", data: "bbb" },
-			]
-			const result = callInputHandler(pi, { text: "check both", images })
+			// First submission advances counter by 2
+			callInputHandler(pi, {
+				text: "setup",
+				images: [
+					{ type: "image", mimeType: "image/png", data: "aaa" },
+					{ type: "image", mimeType: "image/jpeg", data: "bbb" },
+				],
+			})
 
+			// Second submission: counter is 2, so next pair is #3 and #4
+			const result = callInputHandler(pi, {
+				text: "check both",
+				images: [
+					{ type: "image", mimeType: "image/png", data: "ccc" },
+					{ type: "image", mimeType: "image/jpeg", data: "ddd" },
+				],
+			})
 			const text = (result as { text: string }).text
 			expect(text).toContain("[Image #3]")
 			expect(text).toContain("[Image #4]")
@@ -286,13 +306,12 @@ describe("clipboard-image extension", () => {
 			vi.advanceTimersByTime(1000)
 			const countBeforeShutdown = mockSetPendingImageIndicator.mock.calls.length
 
-			// Trigger session_shutdown.
+			// Trigger session_shutdown — only stops the interval, no indicator change.
 			;(pi._handlers.session_shutdown as () => void)()
 			vi.advanceTimersByTime(2000)
 
-			// Only one additional call from the shutdown handler.
-			expect(mockSetPendingImageIndicator.mock.calls.length).toBe(countBeforeShutdown + 1)
-			expect(mockSetPendingImageIndicator).toHaveBeenLastCalledWith(null)
+			// No new indicator calls after shutdown — polling stopped, state preserved.
+			expect(mockSetPendingImageIndicator.mock.calls.length).toBe(countBeforeShutdown)
 		})
 
 		it("shows hint when an image file is copied in Finder", async () => {

--- a/src/extensions/clipboard-image.test.ts
+++ b/src/extensions/clipboard-image.test.ts
@@ -1,39 +1,37 @@
-import { beforeEach, describe, expect, it, vi } from "vitest"
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
 
 // All mock functions must be vi.hoisted — vi.mock is hoisted and its factory
 // runs before any imports, so it cannot reference module-level consts below it.
 // vi.hoisted runs first so the mocks exist when the factory executes.
 const {
-	mockSetPasteImageHandler,
 	mockSetPendingImageIndicator,
 	mockGetNativeClipboard,
-	mockReadClipboardImage,
 	mockGetAvailableModels,
 	mockAddImage,
 	mockClearAllImages,
 	mockSetImageCacheDir,
+	mockExecFileSync,
 } = vi.hoisted(() => ({
-	mockSetPasteImageHandler: vi.fn(),
 	mockSetPendingImageIndicator: vi.fn(),
 	mockGetNativeClipboard: vi.fn(),
-	mockReadClipboardImage: vi.fn(),
 	mockGetAvailableModels: vi.fn(),
 	mockAddImage: vi.fn(),
 	mockClearAllImages: vi.fn(),
 	mockSetImageCacheDir: vi.fn(),
+	mockExecFileSync: vi.fn(),
+}))
+
+vi.mock("node:child_process", () => ({
+	execFileSync: mockExecFileSync,
 }))
 
 vi.mock("./ui.js", () => ({
-	setPasteImageHandler: mockSetPasteImageHandler,
+	setPasteImageHandler: vi.fn(),
 	setPendingImageIndicator: mockSetPendingImageIndicator,
 }))
 
 vi.mock("../utils/clipboard-native-harness.js", () => ({
 	getNativeClipboard: mockGetNativeClipboard,
-}))
-
-vi.mock("../utils/clipboard-read.js", () => ({
-	readClipboardImage: mockReadClipboardImage,
 }))
 
 vi.mock("../startup-context.js", () => ({
@@ -81,6 +79,11 @@ function callInputHandler(pi: ExtensionAPI & { _handlers: Handlers }, event: { t
 describe("clipboard-image extension", () => {
 	beforeEach(() => {
 		vi.clearAllMocks()
+		vi.useFakeTimers()
+	})
+
+	afterEach(() => {
+		vi.useRealTimers()
 	})
 
 	describe("input transform", () => {
@@ -147,6 +150,201 @@ describe("clipboard-image extension", () => {
 			const text = (result as { text: string }).text
 			expect(text).toContain("[Image #3]")
 			expect(text).toContain("[Image #4]")
+		})
+
+		it("indicator shows clipboard hint (not 📎) immediately after images are submitted", () => {
+			mockGetAvailableModels.mockReturnValue([{ slug: "glm-4", input_modalities: ["text", "image"] }])
+			mockGetNativeClipboard.mockReturnValue({
+				clipboard: { hasImage: () => true, availableFormats: () => [] },
+				error: null,
+			})
+
+			const pi = makeMockPi()
+			clipboardImageExtension(pi)
+			;(pi._handlers.session_start as (e: unknown, ctx: ExtensionContext) => void)(void 0, makeMockCtx())
+
+			const images: ImageContent[] = [{ type: "image", mimeType: "image/png", data: "abc123" }]
+			callInputHandler(pi, { text: "look at this", images })
+
+			// After submit, pendingImages is empty. clipboardHasImage is true, so the
+			// clipboard hint takes over immediately — no 📎 lingering on screen.
+			const calls = mockSetPendingImageIndicator.mock.calls
+			const lastCall = calls[calls.length - 1][0]
+			expect(lastCall).toBe("Image in clipboard · ctrl+v to paste")
+		})
+
+		it("indicator clears to null after images are submitted when clipboard is empty", () => {
+			mockGetAvailableModels.mockReturnValue([{ slug: "glm-4", input_modalities: ["text", "image"] }])
+			mockGetNativeClipboard.mockReturnValue({
+				clipboard: { hasImage: () => false, availableFormats: () => [] },
+				error: null,
+			})
+			const pi = makeMockPi()
+			clipboardImageExtension(pi)
+			;(pi._handlers.session_start as (e: unknown, ctx: ExtensionContext) => void)(void 0, makeMockCtx())
+
+			const images: ImageContent[] = [{ type: "image", mimeType: "image/png", data: "abc123" }]
+			callInputHandler(pi, { text: "message", images })
+
+			const calls = mockSetPendingImageIndicator.mock.calls
+			expect(calls[calls.length - 1][0]).toBeNull()
+		})
+	})
+
+	describe("proactive clipboard polling", () => {
+		const realPlatform = process.platform
+
+		beforeEach(() => {
+			vi.clearAllMocks()
+			mockGetAvailableModels.mockReturnValue([{ slug: "glm-4", input_modalities: ["text", "image"] }])
+		})
+
+		afterEach(() => {
+			Object.defineProperty(process, "platform", { value: realPlatform })
+		})
+
+		it("shows hint when clipboard contains an image", () => {
+			mockGetNativeClipboard.mockReturnValue({
+				clipboard: { hasImage: () => true, availableFormats: () => [] },
+				error: null,
+			})
+
+			const pi = makeMockPi()
+			clipboardImageExtension(pi)
+			;(pi._handlers.session_start as (e: unknown, ctx: ExtensionContext) => void)(void 0, makeMockCtx())
+
+			expect(mockSetPendingImageIndicator).toHaveBeenCalledWith("Image in clipboard · ctrl+v to paste")
+		})
+
+		it("does not duplicate indicator on repeated polls", () => {
+			mockGetNativeClipboard.mockReturnValue({
+				clipboard: { hasImage: () => true, availableFormats: () => [] },
+				error: null,
+			})
+
+			const pi = makeMockPi()
+			clipboardImageExtension(pi)
+			;(pi._handlers.session_start as (e: unknown, ctx: ExtensionContext) => void)(void 0, makeMockCtx())
+
+			// Immediate check fires once.
+			expect(mockSetPendingImageIndicator).toHaveBeenCalledTimes(1)
+
+			// Two timer ticks pass with image still present — no additional calls.
+			vi.advanceTimersByTime(1000)
+			expect(mockSetPendingImageIndicator).toHaveBeenCalledTimes(1)
+		})
+
+		it("detects images via availableFormats fallback when hasImage returns false", () => {
+			mockGetNativeClipboard.mockReturnValue({
+				clipboard: {
+					hasImage: () => false,
+					availableFormats: () => ["public.jpeg"],
+				},
+				error: null,
+			})
+
+			const pi = makeMockPi()
+			clipboardImageExtension(pi)
+			;(pi._handlers.session_start as (e: unknown, ctx: ExtensionContext) => void)(void 0, makeMockCtx())
+
+			// session_start fires checkClipboard → hasImage is false, but fallback detects JPEG.
+			expect(mockSetPendingImageIndicator).toHaveBeenCalledWith("Image in clipboard · ctrl+v to paste")
+		})
+
+		it("survives when availableFormats throws", () => {
+			mockGetNativeClipboard.mockReturnValue({
+				clipboard: {
+					hasImage: () => false,
+					availableFormats: () => {
+						throw new Error("pasteboard unavailable")
+					},
+				},
+				error: null,
+			})
+
+			const pi = makeMockPi()
+			clipboardImageExtension(pi)
+			;(pi._handlers.session_start as (e: unknown, ctx: ExtensionContext) => void)(void 0, makeMockCtx())
+
+			// Should not throw — timer keeps running.
+			expect(() => vi.advanceTimersByTime(2000)).not.toThrow()
+			// No hint shown since both hasImage and fallback failed.
+			expect(mockSetPendingImageIndicator).not.toHaveBeenCalledWith("Image in clipboard · ctrl+v to paste")
+		})
+
+		it("stops polling on session_shutdown", () => {
+			mockGetNativeClipboard.mockReturnValue({
+				clipboard: { hasImage: () => true, availableFormats: () => [] },
+				error: null,
+			})
+
+			const pi = makeMockPi()
+			clipboardImageExtension(pi)
+			;(pi._handlers.session_start as (e: unknown, ctx: ExtensionContext) => void)(void 0, makeMockCtx())
+
+			vi.advanceTimersByTime(1000)
+			const countBeforeShutdown = mockSetPendingImageIndicator.mock.calls.length
+
+			// Trigger session_shutdown.
+			;(pi._handlers.session_shutdown as () => void)()
+			vi.advanceTimersByTime(2000)
+
+			// Only one additional call from the shutdown handler.
+			expect(mockSetPendingImageIndicator.mock.calls.length).toBe(countBeforeShutdown + 1)
+			expect(mockSetPendingImageIndicator).toHaveBeenLastCalledWith(null)
+		})
+
+		it("shows hint when an image file is copied in Finder", () => {
+			mockGetAvailableModels.mockReturnValue([{ slug: "glm-4", input_modalities: ["text", "image"] }])
+			mockGetNativeClipboard.mockReturnValue({
+				clipboard: {
+					hasImage: () => true,
+					availableFormats: () => ["public.file-url", "public.jpeg"],
+				},
+				error: null,
+			})
+			mockExecFileSync.mockReturnValue("/Users/user/photo.jpg\n")
+
+			const pi = makeMockPi()
+			clipboardImageExtension(pi)
+			;(pi._handlers.session_start as (e: unknown, ctx: ExtensionContext) => void)(void 0, makeMockCtx())
+
+			expect(mockSetPendingImageIndicator).toHaveBeenCalledWith("Image in clipboard · ctrl+v to paste")
+		})
+
+		it("does not show hint when a non-image file is copied in Finder", () => {
+			mockGetAvailableModels.mockReturnValue([{ slug: "glm-4", input_modalities: ["text", "image"] }])
+			mockGetNativeClipboard.mockReturnValue({
+				clipboard: {
+					// macOS puts a thumbnail alongside the file URL; hasImage() returns true for it.
+					hasImage: () => true,
+					availableFormats: () => ["public.file-url", "public.png"],
+				},
+				error: null,
+			})
+			mockExecFileSync.mockReturnValue("/Users/user/document.pdf\n")
+
+			const pi = makeMockPi()
+			clipboardImageExtension(pi)
+			;(pi._handlers.session_start as (e: unknown, ctx: ExtensionContext) => void)(void 0, makeMockCtx())
+
+			expect(mockSetPendingImageIndicator).not.toHaveBeenCalledWith("Image in clipboard · ctrl+v to paste")
+		})
+
+		it("does not show hint when model does not support images", () => {
+			mockGetAvailableModels.mockReturnValue([{ slug: "text-only", input_modalities: ["text"] }])
+			mockGetNativeClipboard.mockReturnValue({
+				clipboard: { hasImage: () => true, availableFormats: () => [] },
+				error: null,
+			})
+
+			const pi = makeMockPi()
+			clipboardImageExtension(pi)
+			;(pi._handlers.session_start as (e: unknown, ctx: ExtensionContext) => void)(void 0, makeMockCtx())
+
+			vi.advanceTimersByTime(2000)
+
+			expect(mockSetPendingImageIndicator).not.toHaveBeenCalledWith("Image in clipboard · ctrl+v to paste")
 		})
 	})
 })

--- a/src/extensions/clipboard-image.ts
+++ b/src/extensions/clipboard-image.ts
@@ -1,10 +1,12 @@
-import { join } from "node:path"
+import { execFileSync } from "node:child_process"
+import { extname, join } from "node:path"
 import type { ImageContent } from "@earendil-works/pi-ai"
 import type { ExtensionAPI, ExtensionContext } from "@earendil-works/pi-coding-agent"
 import { getAvailableModels } from "../startup-context.js"
 import { getNativeClipboard } from "../utils/clipboard-native-harness.js"
 import { readClipboardImage } from "../utils/clipboard-read.js"
 import { addImage, clearAllImages, setImageCacheDir } from "../utils/image-registry.js"
+import { IMAGE_EXT_TO_MIME } from "../utils/image-utils.js"
 import { setPasteImageHandler, setPendingImageIndicator } from "./ui.js"
 
 let pendingImages: ImageContent[] = []
@@ -13,11 +15,95 @@ let currentCtx: ExtensionContext | null = null
 // session_start so that a new conversation always begins at #1.
 let imageCounter = 0
 
+const CLIPBOARD_POLL_INTERVAL_MS = 2000
+let clipboardPollId: ReturnType<typeof setInterval> | null = null
+let clipboardHasImage = false
+
 function modelSupportsImages(modelId: string | undefined): boolean {
 	if (!modelId) return false
 	const models = getAvailableModels()
 	const meta = models.find((m) => m.slug === modelId)
 	return meta?.input_modalities.includes("image") ?? false
+}
+
+function isImageFormat(format: string): boolean {
+	// Match common image MIME types and macOS UTI identifiers
+	return /^(public\.(png|tiff|jpeg|jpg|heic|webp|bmp|gif|image)|com\.apple\.png|com\.compuserve\.gif|image\/)/i.test(
+		format,
+	)
+}
+
+function isFinderImageFileCopy(): boolean {
+	if (process.platform !== "darwin") return false
+	try {
+		const raw = execFileSync("/usr/bin/osascript", ["-e", "POSIX path of (the clipboard as «class furl»)"], {
+			encoding: "utf8",
+			timeout: 1000,
+			stdio: ["ignore", "pipe", "ignore"],
+		})
+		const path = raw.trim()
+		return path !== "" && IMAGE_EXT_TO_MIME[extname(path).toLowerCase()] !== undefined
+	} catch {
+		return false
+	}
+}
+
+function checkClipboard(): void {
+	if (!currentCtx) return
+
+	try {
+		if (!modelSupportsImages(currentCtx.model?.id)) {
+			if (clipboardHasImage) {
+				clipboardHasImage = false
+				updateIndicator()
+			}
+			return
+		}
+
+		const { clipboard: native } = getNativeClipboard()
+		if (!native) {
+			if (clipboardHasImage) {
+				clipboardHasImage = false
+				updateIndicator()
+			}
+			return
+		}
+
+		let hasImage = false
+		let formats: string[] | null = null
+		if (native.availableFormats) {
+			try {
+				formats = native.availableFormats()
+			} catch {
+				formats = null
+			}
+		}
+
+		if (formats?.includes("public.file-url")) {
+			// Finder file copy: macOS puts public.file-url + a thumbnail on the pasteboard.
+			// hasImage() returns true for any file's thumbnail, so we can't use it here.
+			// Resolve the actual file path and check its extension — same logic as the paste handler.
+			hasImage = isFinderImageFileCopy()
+		} else {
+			try {
+				hasImage = native.hasImage()
+			} catch {
+				hasImage = false
+			}
+			// Fallback: clipboard-rs hasImage() only checks PNG/TIFF.
+			// Probe availableFormats for other image types (JPEG, HEIC, WebP, BMP, GIF).
+			if (!hasImage && formats) {
+				hasImage = formats.some(isImageFormat)
+			}
+		}
+
+		if (hasImage !== clipboardHasImage) {
+			clipboardHasImage = hasImage
+			updateIndicator()
+		}
+	} catch (err) {
+		console.error("[clipboard-image] Proactive clipboard check failed:", err)
+	}
 }
 
 function buildImageMarkerPrefix(startIndex: number, count: number): string {
@@ -70,18 +156,26 @@ async function handlePaste(): Promise<void> {
 }
 
 function updateIndicator(): void {
-	if (pendingImages.length === 0) {
+	const count = pendingImages.length
+	if (count > 0) {
+		const totalRawBytes = pendingImages.reduce((sum, img) => sum + Math.floor((img.data.length * 3) / 4), 0)
+		const kb = Math.max(1, Math.round(totalRawBytes / 1024))
+		const label = count === 1 ? "image" : "images"
+		setPendingImageIndicator(`📎 ${count} ${label} (${kb} KB)`)
+	} else if (clipboardHasImage) {
+		setPendingImageIndicator("Image in clipboard · ctrl+v to paste")
+	} else {
 		setPendingImageIndicator(null)
-		return
 	}
-	const totalRawBytes = pendingImages.reduce((sum, img) => sum + Math.floor((img.data.length * 3) / 4), 0)
-	const kb = Math.max(1, Math.round(totalRawBytes / 1024))
-	const label = pendingImages.length === 1 ? "image" : "images"
-	setPendingImageIndicator(`📎 ${pendingImages.length} ${label} (${kb} KB)`)
 }
 
 export default function clipboardImageExtension(pi: ExtensionAPI): void {
 	pi.on("session_start", (_event, ctx) => {
+		if (clipboardPollId !== null) {
+			clearInterval(clipboardPollId)
+			clipboardPollId = null
+		}
+		clipboardHasImage = false
 		currentCtx = ctx
 		pendingImages = []
 		imageCounter = 0
@@ -89,7 +183,17 @@ export default function clipboardImageExtension(pi: ExtensionAPI): void {
 		const dir = sessionDir ? join(sessionDir, "image-cache") : null
 		setImageCacheDir(dir)
 		clearAllImages()
-		updateIndicator()
+		checkClipboard()
+		clipboardPollId = setInterval(checkClipboard, CLIPBOARD_POLL_INTERVAL_MS)
+	})
+
+	pi.on("session_shutdown", () => {
+		if (clipboardPollId !== null) {
+			clearInterval(clipboardPollId)
+			clipboardPollId = null
+		}
+		clipboardHasImage = false
+		setPendingImageIndicator(null)
 	})
 
 	pi.on("input", (event) => {

--- a/src/extensions/clipboard-image.ts
+++ b/src/extensions/clipboard-image.ts
@@ -1,4 +1,4 @@
-import { execFileSync } from "node:child_process"
+import { execFile } from "node:child_process"
 import { extname, join } from "node:path"
 import type { ImageContent } from "@earendil-works/pi-ai"
 import type { ExtensionAPI, ExtensionContext } from "@earendil-works/pi-coding-agent"
@@ -18,6 +18,7 @@ let imageCounter = 0
 const CLIPBOARD_POLL_INTERVAL_MS = 2000
 let clipboardPollId: ReturnType<typeof setInterval> | null = null
 let clipboardHasImage = false
+let isCheckingFinder = false
 
 function modelSupportsImages(modelId: string | undefined): boolean {
 	if (!modelId) return false
@@ -33,23 +34,31 @@ function isImageFormat(format: string): boolean {
 	)
 }
 
-function isFinderImageFileCopy(): boolean {
-	if (process.platform !== "darwin") return false
-	try {
-		const raw = execFileSync("/usr/bin/osascript", ["-e", "POSIX path of (the clipboard as «class furl»)"], {
-			encoding: "utf8",
-			timeout: 1000,
-			stdio: ["ignore", "pipe", "ignore"],
-		})
-		const path = raw.trim()
-		return path !== "" && IMAGE_EXT_TO_MIME[extname(path).toLowerCase()] !== undefined
-	} catch {
-		return false
-	}
+function isFinderImageFileCopy(): Promise<boolean> {
+	return new Promise<boolean>((resolve) => {
+		if (process.platform !== "darwin") {
+			resolve(false)
+			return
+		}
+		execFile(
+			"/usr/bin/osascript",
+			["-e", "POSIX path of (the clipboard as «class furl»)"],
+			{ encoding: "utf8", timeout: 300 },
+			(err, stdout) => {
+				if (err) {
+					resolve(false)
+					return
+				}
+				const path = stdout.trim()
+				resolve(path !== "" && IMAGE_EXT_TO_MIME[extname(path).toLowerCase()] !== undefined)
+			},
+		)
+	})
 }
 
 function checkClipboard(): void {
 	if (!currentCtx) return
+	if (isCheckingFinder) return
 
 	try {
 		if (!modelSupportsImages(currentCtx.model?.id)) {
@@ -69,7 +78,6 @@ function checkClipboard(): void {
 			return
 		}
 
-		let hasImage = false
 		let formats: string[] | null = null
 		if (native.availableFormats) {
 			try {
@@ -82,9 +90,22 @@ function checkClipboard(): void {
 		if (formats?.includes("public.file-url")) {
 			// Finder file copy: macOS puts public.file-url + a thumbnail on the pasteboard.
 			// hasImage() returns true for any file's thumbnail, so we can't use it here.
-			// Resolve the actual file path and check its extension — same logic as the paste handler.
-			hasImage = isFinderImageFileCopy()
+			// Resolve the actual file path asynchronously to avoid blocking the event loop.
+			isCheckingFinder = true
+			isFinderImageFileCopy()
+				.then((hasImage) => {
+					if (clipboardPollId === null) return // session shut down while checking
+					if (hasImage !== clipboardHasImage) {
+						clipboardHasImage = hasImage
+						updateIndicator()
+					}
+				})
+				.catch(() => {})
+				.finally(() => {
+					isCheckingFinder = false
+				})
 		} else {
+			let hasImage = false
 			try {
 				hasImage = native.hasImage()
 			} catch {
@@ -95,11 +116,10 @@ function checkClipboard(): void {
 			if (!hasImage && formats) {
 				hasImage = formats.some(isImageFormat)
 			}
-		}
-
-		if (hasImage !== clipboardHasImage) {
-			clipboardHasImage = hasImage
-			updateIndicator()
+			if (hasImage !== clipboardHasImage) {
+				clipboardHasImage = hasImage
+				updateIndicator()
+			}
 		}
 	} catch (err) {
 		console.error("[clipboard-image] Proactive clipboard check failed:", err)
@@ -175,6 +195,7 @@ export default function clipboardImageExtension(pi: ExtensionAPI): void {
 			clearInterval(clipboardPollId)
 			clipboardPollId = null
 		}
+		isCheckingFinder = false
 		clipboardHasImage = false
 		currentCtx = ctx
 		pendingImages = []
@@ -183,6 +204,7 @@ export default function clipboardImageExtension(pi: ExtensionAPI): void {
 		const dir = sessionDir ? join(sessionDir, "image-cache") : null
 		setImageCacheDir(dir)
 		clearAllImages()
+		updateIndicator()
 		checkClipboard()
 		clipboardPollId = setInterval(checkClipboard, CLIPBOARD_POLL_INTERVAL_MS)
 	})

--- a/src/extensions/clipboard-image.ts
+++ b/src/extensions/clipboard-image.ts
@@ -234,6 +234,10 @@ export default function clipboardImageExtension(pi: ExtensionAPI): void {
 			clearInterval(clipboardPollId)
 			clipboardPollId = null
 		}
+		// Increment the generation so any in-flight Finder file-type probe
+		// from the dying session is treated as stale when its callback lands.
+		sessionGeneration++
+		currentCtx = null
 	})
 
 	pi.on("input", (event) => {

--- a/src/extensions/clipboard-image.ts
+++ b/src/extensions/clipboard-image.ts
@@ -15,10 +15,14 @@ let currentCtx: ExtensionContext | null = null
 // session_start so that a new conversation always begins at #1.
 let imageCounter = 0
 
-const CLIPBOARD_POLL_INTERVAL_MS = 2000
+const CLIPBOARD_POLL_INTERVAL_MS = 1000
 let clipboardPollId: ReturnType<typeof setInterval> | null = null
 let clipboardHasImage = false
 let isCheckingFinder = false
+// Monotonic counter incremented on every session_start. Async callbacks
+// capture the generation at launch and bail out if it no longer matches,
+// preventing stale Finder checks from corrupting a newer session's state.
+let sessionGeneration = 0
 
 function modelSupportsImages(modelId: string | undefined): boolean {
 	if (!modelId) return false
@@ -34,23 +38,30 @@ function isImageFormat(format: string): boolean {
 	)
 }
 
-function isFinderImageFileCopy(): Promise<boolean> {
-	return new Promise<boolean>((resolve) => {
+type FinderFileResult = "image" | "non-image" | null
+
+function checkFinderImageFileCopy(): Promise<FinderFileResult> {
+	return new Promise<FinderFileResult>((resolve) => {
 		if (process.platform !== "darwin") {
-			resolve(false)
+			resolve(null)
 			return
 		}
 		execFile(
 			"/usr/bin/osascript",
 			["-e", "POSIX path of (the clipboard as «class furl»)"],
-			{ encoding: "utf8", timeout: 300 },
+			{ encoding: "utf8", timeout: 1000 },
 			(err, stdout) => {
 				if (err) {
-					resolve(false)
+					resolve(null)
 					return
 				}
 				const path = stdout.trim()
-				resolve(path !== "" && IMAGE_EXT_TO_MIME[extname(path).toLowerCase()] !== undefined)
+				if (!path) {
+					resolve(null)
+					return
+				}
+				const isImage = IMAGE_EXT_TO_MIME[extname(path).toLowerCase()] !== undefined
+				resolve(isImage ? "image" : "non-image")
 			},
 		)
 	})
@@ -87,37 +98,46 @@ function checkClipboard(): void {
 			}
 		}
 
-		if (formats?.includes("public.file-url")) {
+		let baselineHasImage = false
+		try {
+			baselineHasImage = native.hasImage()
+		} catch {
+			baselineHasImage = false
+		}
+		// Fallback: clipboard-rs hasImage() only checks PNG/TIFF.
+		// Probe availableFormats for other image types (JPEG, HEIC, WebP, BMP, GIF).
+		if (!baselineHasImage && formats) {
+			baselineHasImage = formats.some(isImageFormat)
+		}
+
+		if (baselineHasImage && formats?.includes("public.file-url")) {
 			// Finder file copy: macOS puts public.file-url + a thumbnail on the pasteboard.
-			// hasImage() returns true for any file's thumbnail, so we can't use it here.
+			// hasImage() returns true for any file's thumbnail. We must verify the file
+			// is actually an image (not PDF etc.) before showing the hint.
 			// Resolve the actual file path asynchronously to avoid blocking the event loop.
 			isCheckingFinder = true
-			isFinderImageFileCopy()
-				.then((hasImage) => {
-					if (clipboardPollId === null) return // session shut down while checking
-					if (hasImage !== clipboardHasImage) {
-						clipboardHasImage = hasImage
+			const myGeneration = sessionGeneration
+			checkFinderImageFileCopy()
+				.then((result) => {
+					if (myGeneration !== sessionGeneration) return // stale callback
+					// Only suppress the indicator when we CONFIRM the file is not an image.
+					// If there is no file path (null) we keep the baseline — this handles
+					// spurious public.file-url reports from macOS and AppleScript timeouts.
+					const final = result === "non-image" ? false : baselineHasImage
+					if (final !== clipboardHasImage) {
+						clipboardHasImage = final
 						updateIndicator()
 					}
 				})
 				.catch(() => {})
 				.finally(() => {
-					isCheckingFinder = false
+					if (myGeneration === sessionGeneration) {
+						isCheckingFinder = false
+					}
 				})
 		} else {
-			let hasImage = false
-			try {
-				hasImage = native.hasImage()
-			} catch {
-				hasImage = false
-			}
-			// Fallback: clipboard-rs hasImage() only checks PNG/TIFF.
-			// Probe availableFormats for other image types (JPEG, HEIC, WebP, BMP, GIF).
-			if (!hasImage && formats) {
-				hasImage = formats.some(isImageFormat)
-			}
-			if (hasImage !== clipboardHasImage) {
-				clipboardHasImage = hasImage
+			if (baselineHasImage !== clipboardHasImage) {
+				clipboardHasImage = baselineHasImage
 				updateIndicator()
 			}
 		}
@@ -195,8 +215,8 @@ export default function clipboardImageExtension(pi: ExtensionAPI): void {
 			clearInterval(clipboardPollId)
 			clipboardPollId = null
 		}
+		sessionGeneration++
 		isCheckingFinder = false
-		clipboardHasImage = false
 		currentCtx = ctx
 		pendingImages = []
 		imageCounter = 0
@@ -214,8 +234,6 @@ export default function clipboardImageExtension(pi: ExtensionAPI): void {
 			clearInterval(clipboardPollId)
 			clipboardPollId = null
 		}
-		clipboardHasImage = false
-		setPendingImageIndicator(null)
 	})
 
 	pi.on("input", (event) => {


### PR DESCRIPTION
## Description
 Add indicator for clipboard images that appears in the TUI when an image is detected, supporting both direct image    
 copies and macOS file references resolved via AppleScript.

<!-- What problem does this PR solve? What changes were made and why? -->

<img width="722" height="141" alt="image" src="https://github.com/user-attachments/assets/26b95097-28a6-40a1-9ac3-a00b4b135b7c" />


https://github.com/user-attachments/assets/5c1d29f6-dd68-4901-8bd4-cfcbfa5366b6


## Type of Change

<!-- Select all that apply. -->

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Documentation update
