### PR TITLE
fix: mcp panel improvements

### DIFF
--- a/src/extensions/mcp-adapter/commands.ts
+++ b/src/extensions/mcp-adapter/commands.ts
@@ -206,6 +206,10 @@ export async function openMcpPanel(
 			const freshCache = loadMetadataCache()
 			return freshCache?.servers?.[serverName] ?? null
 		},
+		onSave: (changes) => {
+			writeDirectToolsConfig(changes, provenanceMap, config)
+			ctx.ui.notify("Direct tools updated. Restart pi to apply.", "info")
+		},
 	}
 
 	const { createMcpPanel } = await import("./mcp-panel.js")

--- a/src/extensions/mcp-adapter/config.test.ts
+++ b/src/extensions/mcp-adapter/config.test.ts
@@ -1,0 +1,189 @@
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
+import { afterEach, beforeEach, describe, expect, it } from "vitest"
+import { writeDirectToolsConfig } from "./config.js"
+import type { McpConfig, ServerProvenance } from "./types.js"
+
+// ─── Helpers ──────────────────────────────────────────────────────────────────
+
+let tempDir: string
+
+beforeEach(() => {
+	tempDir = mkdtempSync(join(tmpdir(), "mcp-config-test-"))
+})
+
+afterEach(() => {
+	rmSync(tempDir, { recursive: true, force: true })
+})
+
+/** Write a minimal mcp.json to tempDir and return its path. */
+function writeMcpFile(servers: Record<string, unknown>): string {
+	const filePath = join(tempDir, "mcp.json")
+	writeFileSync(filePath, JSON.stringify({ mcpServers: servers }, null, 2), "utf-8")
+	return filePath
+}
+
+/** Read the mcpServers object back from a file written by writeDirectToolsConfig. */
+function readServers(filePath: string): Record<string, unknown> {
+	const raw = JSON.parse(readFileSync(filePath, "utf-8")) as Record<string, unknown>
+	return (raw.mcpServers ?? {}) as Record<string, unknown>
+}
+
+// ─── writeDirectToolsConfig ───────────────────────────────────────────────────
+
+describe("writeDirectToolsConfig", () => {
+	describe("in-memory sync (fullConfig.mcpServers)", () => {
+		it("updates fullConfig.mcpServers[name].directTools after writing to disk", () => {
+			const filePath = writeMcpFile({
+				"my-server": { command: "npx", args: ["my-server"] },
+			})
+
+			const fullConfig: McpConfig = {
+				mcpServers: {
+					"my-server": { command: "npx", args: ["my-server"] },
+				},
+			}
+			const provenance = new Map<string, ServerProvenance>([
+				["my-server", { path: filePath, kind: "user" }],
+			])
+			const changes = new Map<string, true | string[] | false>([["my-server", true]])
+
+			writeDirectToolsConfig(changes, provenance, fullConfig)
+
+			expect(fullConfig.mcpServers["my-server"].directTools).toBe(true)
+		})
+
+		it("syncs a tool list (string[]) into fullConfig", () => {
+			const filePath = writeMcpFile({
+				"my-server": { command: "npx", args: ["my-server"] },
+			})
+
+			const fullConfig: McpConfig = {
+				mcpServers: { "my-server": { command: "npx", args: ["my-server"] } },
+			}
+			const provenance = new Map<string, ServerProvenance>([
+				["my-server", { path: filePath, kind: "user" }],
+			])
+			const changes = new Map<string, true | string[] | false>([
+				["my-server", ["tool_a", "tool_b"]],
+			])
+
+			writeDirectToolsConfig(changes, provenance, fullConfig)
+
+			expect(fullConfig.mcpServers["my-server"].directTools).toEqual(["tool_a", "tool_b"])
+		})
+
+		it("syncs false (disable all direct tools) into fullConfig", () => {
+			const filePath = writeMcpFile({
+				"my-server": { command: "npx", args: ["my-server"], directTools: true },
+			})
+
+			const fullConfig: McpConfig = {
+				mcpServers: { "my-server": { command: "npx", args: ["my-server"], directTools: true } },
+			}
+			const provenance = new Map<string, ServerProvenance>([
+				["my-server", { path: filePath, kind: "user" }],
+			])
+			const changes = new Map<string, true | string[] | false>([["my-server", false]])
+
+			writeDirectToolsConfig(changes, provenance, fullConfig)
+
+			expect(fullConfig.mcpServers["my-server"].directTools).toBe(false)
+		})
+
+		it("syncs multiple servers independently", () => {
+			const filePath = writeMcpFile({
+				server_a: { command: "npx", args: ["a"] },
+				server_b: { command: "npx", args: ["b"] },
+			})
+
+			const fullConfig: McpConfig = {
+				mcpServers: {
+					server_a: { command: "npx", args: ["a"] },
+					server_b: { command: "npx", args: ["b"] },
+				},
+			}
+			const provenance = new Map<string, ServerProvenance>([
+				["server_a", { path: filePath, kind: "user" }],
+				["server_b", { path: filePath, kind: "user" }],
+			])
+			const changes = new Map<string, true | string[] | false>([
+				["server_a", true],
+				["server_b", ["tool_x"]],
+			])
+
+			writeDirectToolsConfig(changes, provenance, fullConfig)
+
+			expect(fullConfig.mcpServers["server_a"].directTools).toBe(true)
+			expect(fullConfig.mcpServers["server_b"].directTools).toEqual(["tool_x"])
+		})
+
+		it("does not sync a server that has no provenance entry", () => {
+			const filePath = writeMcpFile({
+				"my-server": { command: "npx", args: ["my-server"] },
+			})
+
+			const fullConfig: McpConfig = {
+				mcpServers: { "my-server": { command: "npx", args: ["my-server"] } },
+			}
+			// Provenance map is empty — writeDirectToolsConfig should skip silently
+			const provenance = new Map<string, ServerProvenance>()
+			const changes = new Map<string, true | string[] | false>([["my-server", true]])
+
+			writeDirectToolsConfig(changes, provenance, fullConfig)
+
+			// fullConfig unchanged because prov lookup failed
+			expect(fullConfig.mcpServers["my-server"].directTools).toBeUndefined()
+			// File also unchanged
+			const onDisk = readServers(filePath)
+			expect((onDisk["my-server"] as Record<string, unknown>).directTools).toBeUndefined()
+		})
+	})
+
+	describe("disk writes", () => {
+		it("persists directTools to the target config file", () => {
+			const filePath = writeMcpFile({
+				"my-server": { command: "npx", args: ["my-server"] },
+			})
+
+			const fullConfig: McpConfig = {
+				mcpServers: { "my-server": { command: "npx", args: ["my-server"] } },
+			}
+			const provenance = new Map<string, ServerProvenance>([
+				["my-server", { path: filePath, kind: "user" }],
+			])
+			const changes = new Map<string, true | string[] | false>([["my-server", true]])
+
+			writeDirectToolsConfig(changes, provenance, fullConfig)
+
+			const onDisk = readServers(filePath)
+			expect((onDisk["my-server"] as Record<string, unknown>).directTools).toBe(true)
+		})
+
+		it("preserves other server fields when updating directTools", () => {
+			const filePath = writeMcpFile({
+				"my-server": { command: "npx", args: ["my-server", "--flag"], env: { FOO: "bar" } },
+			})
+
+			const fullConfig: McpConfig = {
+				mcpServers: {
+					"my-server": { command: "npx", args: ["my-server", "--flag"], env: { FOO: "bar" } },
+				},
+			}
+			const provenance = new Map<string, ServerProvenance>([
+				["my-server", { path: filePath, kind: "user" }],
+			])
+			const changes = new Map<string, true | string[] | false>([["my-server", true]])
+
+			writeDirectToolsConfig(changes, provenance, fullConfig)
+
+			const onDisk = readServers(filePath)
+			const srv = onDisk["my-server"] as Record<string, unknown>
+			expect(srv.command).toBe("npx")
+			expect(srv.args).toEqual(["my-server", "--flag"])
+			expect(srv.env).toEqual({ FOO: "bar" })
+			expect(srv.directTools).toBe(true)
+		})
+	})
+})

--- a/src/extensions/mcp-adapter/config.ts
+++ b/src/extensions/mcp-adapter/config.ts
@@ -217,6 +217,9 @@ export function writeDirectToolsConfig(
 			} else if (servers[name]) {
 				servers[name] = { ...servers[name], directTools: value }
 			}
+
+			// Sync in-memory state so /mcp panel reflects changes on reopen without kimchi restart.
+			fullConfig.mcpServers[name] = servers[name]
 		}
 
 		const key = raw["mcp-servers"] && !raw.mcpServers ? "mcp-servers" : "mcpServers"

--- a/src/extensions/mcp-adapter/config.ts
+++ b/src/extensions/mcp-adapter/config.ts
@@ -218,7 +218,7 @@ export function writeDirectToolsConfig(
 				servers[name] = { ...servers[name], directTools: value }
 			}
 
-			// Sync in-memory state so /mcp panel reflects changes on reopen without kimchi restart.
+			// Sync in-memory config so /mcp panel shows current state on reopen. Tool availability still requires restart.
 			fullConfig.mcpServers[name] = servers[name]
 		}
 

--- a/src/extensions/mcp-adapter/mcp-panel.test.ts
+++ b/src/extensions/mcp-adapter/mcp-panel.test.ts
@@ -1,5 +1,90 @@
-import { describe, expect, it } from "vitest"
-import { computeVisibleWindow } from "./mcp-panel.js"
+import { describe, expect, it, vi } from "vitest"
+import { createMcpPanel, computeVisibleWindow } from "./mcp-panel.js"
+import type { McpConfig, McpPanelCallbacks, McpPanelResult, ServerProvenance } from "./types.js"
+import type { MetadataCache } from "./metadata-cache.js"
+
+// ─── Panel test helpers ───────────────────────────────────────────────────────
+
+/** Minimal McpConfig with one server and one cached tool. */
+function makeConfig(serverName = "my-server"): McpConfig {
+	return {
+		mcpServers: {
+			[serverName]: { command: "npx", args: ["my-server"] },
+		},
+	}
+}
+
+/** MetadataCache with one tool cached for the given server. */
+function makeCache(serverName = "my-server", toolName = "my_tool", description = "Does a thing"): MetadataCache {
+	return {
+		version: 1,
+		servers: {
+			[serverName]: {
+				configHash: "abc",
+				tools: [{ name: toolName, description }],
+				resources: [],
+				cachedAt: Date.now(),
+			},
+		},
+	}
+}
+
+/** Stub callbacks — all no-ops except onSave which uses a vi.fn(). */
+function makeCallbacks(): { callbacks: McpPanelCallbacks; onSave: ReturnType<typeof vi.fn> } {
+	const onSave = vi.fn<(changes: Map<string, true | string[] | false>) => void>()
+	const callbacks: McpPanelCallbacks = {
+		reconnect: () => Promise.resolve(true),
+		getConnectionStatus: () => "connected",
+		refreshCacheAfterReconnect: () => null,
+		onSave,
+	}
+	return { callbacks, onSave }
+}
+
+/** Stub TUI — captures requestRender calls. */
+function makeTui(rows = 40): { requestRender: ReturnType<typeof vi.fn>; terminal: { rows: number } } {
+	return { requestRender: vi.fn(), terminal: { rows } }
+}
+
+/** Empty provenance map (all servers treated as user-config). */
+function makeProvenance(serverName = "my-server", path = "/tmp/mcp-test.json"): Map<string, ServerProvenance> {
+	return new Map([[serverName, { path, kind: "user" }]])
+}
+
+/**
+ * Create a panel and return it together with its callbacks and a done spy.
+ * The panel starts with the server row focused (cursorIndex = 0).
+ */
+function makePanel(opts?: {
+	config?: McpConfig
+	cache?: MetadataCache | null
+	provenance?: Map<string, ServerProvenance>
+	serverName?: string
+}) {
+	const serverName = opts?.serverName ?? "my-server"
+	const config = opts?.config ?? makeConfig(serverName)
+	const cache = opts?.cache !== undefined ? opts.cache : makeCache(serverName)
+	const provenance = opts?.provenance ?? makeProvenance(serverName)
+	const { callbacks, onSave } = makeCallbacks()
+	const tui = makeTui()
+	const done = vi.fn<(result: McpPanelResult) => void>()
+	const panel = createMcpPanel(config, cache, provenance, callbacks, tui, done)
+	return { panel, callbacks, onSave, tui, done }
+}
+
+/**
+ * Strip ANSI escape sequences from a string so assertions on rendered text
+ * work without depending on exact color codes.
+ */
+function stripAnsi(s: string): string {
+	// biome-ignore lint/suspicious/noControlCharactersInRegex: needed to strip ANSI
+	return s.replace(/\x1b\[[\d;]*[A-Za-z]/g, "")
+}
+
+/** Collect all rendered lines as plain text (ANSI stripped). */
+function renderText(panel: ReturnType<typeof createMcpPanel>, width = 80): string[] {
+	return panel.render(width).map(stripAnsi)
+}
 
 const LIMITS = { maxVisible: 12, minVisible: 3, fixedOverheadRows: 16 }
 
@@ -83,5 +168,154 @@ describe("computeVisibleWindow", () => {
 			expect(startIdx).toBe(74)
 			expect(endIdx).toBe(78)
 		})
+	})
+})
+
+// ─── ctrl+s save behaviour ───────────────────────────────────────────────────────────────
+
+describe("McpPanel ctrl+s", () => {
+	const CTRL_S = "\x13"
+
+	it("does nothing when there are no changes", () => {
+		const { panel, onSave, tui } = makePanel()
+		panel.handleInput(CTRL_S)
+		expect(onSave).not.toHaveBeenCalled()
+		// render is still requested so the panel redraws (clears any stale notice)
+		expect(tui.requestRender).toHaveBeenCalled()
+	})
+
+	it("calls onSave with the correct changes map after toggling a tool", () => {
+		const { panel, onSave } = makePanel()
+
+		// Expand the server (cursor is on server row, press return)
+		panel.handleInput("\r")
+		// Move down to the tool row
+		panel.handleInput("\x1b[B")
+		// Toggle the tool direct (space bar)
+		panel.handleInput(" ")
+		// Save
+		panel.handleInput(CTRL_S)
+
+		expect(onSave).toHaveBeenCalledOnce()
+		const [changesArg] = onSave.mock.calls[0] as [Map<string, true | string[] | false>]
+		// Tool was off (false) by default; toggled to on. With 1 out of 1 tools
+		// direct, buildResult emits `true` for the server.
+		expect(changesArg.get("my-server")).toBe(true)
+	})
+
+	it("commits the new baseline so a second ctrl+s does not call onSave again", () => {
+		const { panel, onSave } = makePanel()
+
+		panel.handleInput("\r") // expand
+		panel.handleInput("\x1b[B") // move to tool
+		panel.handleInput(" ") // toggle
+		panel.handleInput(CTRL_S) // save — should fire onSave
+		panel.handleInput(CTRL_S) // save again — no new changes, should NOT fire again
+
+		expect(onSave).toHaveBeenCalledOnce()
+	})
+
+	it("shows the save notice in the rendered output after saving", () => {
+		const { panel } = makePanel()
+
+		panel.handleInput("\r")
+		panel.handleInput("\x1b[B")
+		panel.handleInput(" ")
+		panel.handleInput(CTRL_S)
+
+		const lines = renderText(panel)
+		const hasSaveNotice = lines.some((l) => l.includes("Saved"))
+		expect(hasSaveNotice).toBe(true)
+	})
+
+	it("clears the save notice on the next keypress", () => {
+		const { panel } = makePanel()
+
+		panel.handleInput("\r")
+		panel.handleInput("\x1b[B")
+		panel.handleInput(" ")
+		panel.handleInput(CTRL_S)
+		// Any subsequent key clears notices (handleInput resets them)
+		panel.handleInput("\x1b[A") // up arrow
+
+		const lines = renderText(panel)
+		const hasSaveNotice = lines.some((l) => l.includes("Saved"))
+		expect(hasSaveNotice).toBe(false)
+	})
+})
+
+// ─── return key toggles focusDescription on tool rows ─────────────────────────────────
+
+describe("McpPanel return on tool row", () => {
+	it("shows the description block in the render output after pressing return on a tool", () => {
+		const { panel } = makePanel()
+
+		// Expand the server
+		panel.handleInput("\r")
+		// Move cursor to the tool row
+		panel.handleInput("\x1b[B")
+		// Press return on the tool
+		panel.handleInput("\r")
+
+		const lines = renderText(panel)
+		// The description header contains “▼ server — toolname”
+		const hasDescHeader = lines.some((l) => l.includes("▼") && l.includes("my-server") && l.includes("my_tool"))
+		expect(hasDescHeader).toBe(true)
+	})
+
+	it("hides the description block on the second return press (toggle off)", () => {
+		const { panel } = makePanel()
+
+		panel.handleInput("\r") // expand server
+		panel.handleInput("\x1b[B") // move to tool
+		panel.handleInput("\r") // open description
+		panel.handleInput("\r") // close description
+
+		const lines = renderText(panel)
+		const hasDescHeader = lines.some((l) => l.includes("▼") && l.includes("my-server") && l.includes("my_tool"))
+		expect(hasDescHeader).toBe(false)
+	})
+
+	it("clears the description when the cursor moves to a different tool", () => {
+		// Two tools in the same server so we can navigate between them.
+		const config: McpConfig = { mcpServers: { "my-server": { command: "npx", args: [] } } }
+		const cache: MetadataCache = {
+			version: 1,
+			servers: {
+				"my-server": {
+					configHash: "abc",
+					tools: [
+						{ name: "tool_a", description: "Alpha" },
+						{ name: "tool_b", description: "Beta" },
+					],
+					resources: [],
+					cachedAt: Date.now(),
+				},
+			},
+		}
+		const { panel } = makePanel({ config, cache })
+
+		panel.handleInput("\r") // expand server
+		panel.handleInput("\x1b[B") // move to tool_a
+		panel.handleInput("\r") // open description for tool_a
+		// Navigate down to tool_b — moving the cursor clears focusDescription
+		panel.handleInput("\x1b[B")
+
+		const lines = renderText(panel)
+		// Neither description header should be visible
+		const hasAnyDescHeader = lines.some((l) => l.includes("▼"))
+		expect(hasAnyDescHeader).toBe(false)
+	})
+
+	it("does not toggle isDirect when return is pressed on a tool (space still does)", () => {
+		const { panel, onSave } = makePanel()
+
+		panel.handleInput("\r") // expand server
+		panel.handleInput("\x1b[B") // move to tool
+		panel.handleInput("\r") // open description (was: toggle isDirect in old code)
+		panel.handleInput("\x13") // ctrl+s
+
+		// No changes because return did not toggle isDirect
+		expect(onSave).not.toHaveBeenCalled()
 	})
 })

--- a/src/extensions/mcp-adapter/mcp-panel.ts
+++ b/src/extensions/mcp-adapter/mcp-panel.ts
@@ -1,4 +1,4 @@
-import { matchesKey, truncateToWidth, visibleWidth } from "@earendil-works/pi-tui"
+import { matchesKey, truncateToWidth, visibleWidth, wrapTextWithAnsi } from "@earendil-works/pi-tui"
 import { fg } from "../../ansi.js"
 import type { CachedTool, MetadataCache, ServerCacheEntry } from "./metadata-cache.js"
 import { resourceNameToToolName } from "./resource-tools.js"
@@ -145,6 +145,8 @@ class McpPanel {
 	private discardSelected = 1
 	private importNotice: string | null = null
 	private authNotice: string | null = null
+	private saveNotice: string | null = null
+	private focusDescription: { serverName: string; toolName: string; text: string } | null = null
 	private inactivityTimeout: ReturnType<typeof setTimeout> | null = null
 	private visibleItems: VisibleItem[] = []
 	private tui: { requestRender(force?: boolean): void; terminal: { rows: number } }
@@ -311,6 +313,7 @@ class McpPanel {
 		this.resetInactivityTimeout()
 		this.importNotice = null
 		this.authNotice = null
+		this.saveNotice = null
 
 		if (this.confirmingDiscard) {
 			this.handleDiscardInput(data)
@@ -325,14 +328,22 @@ class McpPanel {
 		}
 
 		if (matchesKey(data, "ctrl+s")) {
-			this.cleanup()
-			this.done(this.buildResult())
+			const result = this.buildResult()
+			if (result.changes.size > 0) {
+				this.callbacks.onSave(result.changes)
+				// Commit saved values as the new baseline so dirty/unsaved clears.
+				this.servers.forEach((s) => s.tools.forEach((t) => { t.wasDirect = t.isDirect }))
+				this.updateDirty()
+				this.saveNotice = "Saved ✓"
+			}
+			this.tui.requestRender()
 			return
 		}
 
 		// Modal description search mode
 		if (this.descSearchActive) {
 			if (matchesKey(data, "escape") || matchesKey(data, "return")) {
+				this.focusDescription = null
 				this.descSearchActive = false
 				this.descQuery = ""
 				this.rebuildVisibleItems()
@@ -340,6 +351,7 @@ class McpPanel {
 				return
 			}
 			if (matchesKey(data, "backspace")) {
+				this.focusDescription = null
 				if (this.descQuery.length > 0) {
 					this.descQuery = this.descQuery.slice(0, -1)
 					this.rebuildVisibleItems()
@@ -348,20 +360,24 @@ class McpPanel {
 				return
 			}
 			if (matchesKey(data, "up")) {
+				this.focusDescription = null
 				this.moveCursor(-1)
 				return
 			}
 			if (matchesKey(data, "down")) {
+				this.focusDescription = null
 				this.moveCursor(1)
 				return
 			}
 			if (matchesKey(data, "space")) {
+				this.focusDescription = null
 				// Toggle even while in desc search
 				const item = this.visibleItems[this.cursorIndex]
 				if (item) this.toggleItem(item)
 				return
 			}
 			if (data.length === 1 && data.charCodeAt(0) >= 32) {
+				this.focusDescription = null
 				this.descQuery += data
 				this.rebuildVisibleItems()
 				this.cursorIndex = Math.min(this.cursorIndex, Math.max(0, this.visibleItems.length - 1))
@@ -371,6 +387,11 @@ class McpPanel {
 		}
 
 		if (matchesKey(data, "escape")) {
+			if (this.focusDescription) {
+				this.focusDescription = null
+				this.tui.requestRender()
+				return
+			}
 			if (this.nameQuery) {
 				this.nameQuery = ""
 				this.rebuildVisibleItems()
@@ -388,10 +409,12 @@ class McpPanel {
 		}
 
 		if (matchesKey(data, "up")) {
+			this.focusDescription = null
 			this.moveCursor(-1)
 			return
 		}
 		if (matchesKey(data, "down")) {
+			this.focusDescription = null
 			this.moveCursor(1)
 			return
 		}
@@ -399,6 +422,7 @@ class McpPanel {
 		if (matchesKey(data, "space")) {
 			const item = this.visibleItems[this.cursorIndex]
 			if (item) this.toggleItem(item)
+			this.focusDescription = null
 			return
 		}
 
@@ -416,16 +440,19 @@ class McpPanel {
 				this.cursorIndex = Math.min(this.cursorIndex, Math.max(0, this.visibleItems.length - 1))
 			} else if (item.toolIndex !== undefined) {
 				const tool = server.tools[item.toolIndex]
-				tool.isDirect = !tool.isDirect
-				if (tool.isDirect && server.source === "import") {
-					this.importNotice = `Imported from ${server.importKind ?? "external"} — will copy to user config on save`
+				const fd = this.focusDescription
+				if (fd && fd.serverName === server.name && fd.toolName === tool.name) {
+					this.focusDescription = null
+				} else {
+					this.focusDescription = { serverName: server.name, toolName: tool.name, text: tool.description }
 				}
-				this.updateDirty()
 			}
+			this.tui.requestRender()
 			return
 		}
 
 		if (matchesKey(data, "ctrl+r")) {
+			this.focusDescription = null
 			const item = this.visibleItems[this.cursorIndex]
 			if (!item) return
 			const server = this.servers[item.serverIndex]
@@ -454,6 +481,7 @@ class McpPanel {
 		}
 
 		if (data === "?") {
+			this.focusDescription = null
 			this.descSearchActive = true
 			this.descQuery = ""
 			this.rebuildVisibleItems()
@@ -463,6 +491,7 @@ class McpPanel {
 
 		// Backspace removes from name query
 		if (matchesKey(data, "backspace")) {
+			this.focusDescription = null
 			if (this.nameQuery.length > 0) {
 				this.nameQuery = this.nameQuery.slice(0, -1)
 				this.rebuildVisibleItems()
@@ -473,6 +502,7 @@ class McpPanel {
 
 		// All other printable chars → always-on name search
 		if (data.length === 1 && data.charCodeAt(0) >= 32) {
+			this.focusDescription = null
 			this.nameQuery += data
 			this.rebuildVisibleItems()
 			this.cursorIndex = Math.min(this.cursorIndex, Math.max(0, this.visibleItems.length - 1))
@@ -657,6 +687,19 @@ class McpPanel {
 			}
 			if (this.authNotice) {
 				lines.push(row(fg(t.needsAuth, italic(this.authNotice))))
+				lines.push(emptyRow())
+			}
+			if (this.saveNotice) {
+				lines.push(row(fg(t.direct, italic(this.saveNotice))))
+				lines.push(emptyRow())
+			}
+			if (this.focusDescription) {
+				const label = fg(t.description, `▼ ${this.focusDescription.serverName} — ${this.focusDescription.toolName}`)
+				lines.push(row(label))
+				const wrapped = wrapTextWithAnsi(this.focusDescription.text, innerW - 6)
+				for (const wl of wrapped) {
+					lines.push(row(fg(t.description, `     ${wl}`)))
+				}
 				lines.push(emptyRow())
 			}
 		}

--- a/src/extensions/mcp-adapter/mcp-panel.ts
+++ b/src/extensions/mcp-adapter/mcp-panel.ts
@@ -334,7 +334,7 @@ class McpPanel {
 				// Commit saved values as the new baseline so dirty/unsaved clears.
 				this.servers.forEach((s) => s.tools.forEach((t) => { t.wasDirect = t.isDirect }))
 				this.updateDirty()
-				this.saveNotice = "Saved ✓"
+				this.saveNotice = "Saved ✓ — restart pi to apply"
 			}
 			this.tui.requestRender()
 			return

--- a/src/extensions/mcp-adapter/mcp-panel.ts
+++ b/src/extensions/mcp-adapter/mcp-panel.ts
@@ -444,7 +444,7 @@ class McpPanel {
 				if (fd && fd.serverName === server.name && fd.toolName === tool.name) {
 					this.focusDescription = null
 				} else {
-					this.focusDescription = { serverName: server.name, toolName: tool.name, text: tool.description }
+					this.focusDescription = { serverName: server.name, toolName: tool.name, text: tool.description ?? "" }
 				}
 			}
 			this.tui.requestRender()

--- a/src/extensions/mcp-adapter/types.ts
+++ b/src/extensions/mcp-adapter/types.ts
@@ -356,6 +356,11 @@ export interface McpPanelCallbacks {
 	reconnect: (serverName: string) => Promise<boolean>
 	getConnectionStatus: (serverName: string) => "connected" | "idle" | "failed" | "needs-auth"
 	refreshCacheAfterReconnect: (serverName: string) => import("./metadata-cache.js").ServerCacheEntry | null
+	/**
+	 * Persists the given changes to disk and shows a notification.
+	 * The panel stays open after this is called.
+	 */
+	onSave: (changes: Map<string, true | string[] | false>) => void
 }
 
 export interface McpPanelResult {


### PR DESCRIPTION
Closes #1590

## Description

<!-- What problem does this PR solve? What changes were made and why? -->
 - Save direct-tools toggles in-place with Ctrl+S without closing the panel, with a "Saved ✓" confirmation and cleared dirty state.                                           
 - Sync written direct-tools config back to in-memory fullConfig.mcpServers so reopening the panel reflects changes immediately without restarting.                           
 - Press Return on a tool to open its full inline description; press Return again or Esc to dismiss it (previously it toggled the tool and there was no possibility of viewing full description).                                      



<img width="572" height="521" alt="image" src="https://github.com/user-attachments/assets/42ff48bf-2174-4204-893c-968b13473c2f" />
<img width="570" height="343" alt="image" src="https://github.com/user-attachments/assets/f71f063d-3a3b-43d0-b18b-0a9f64284062" />


## Type of Change

<!-- Select all that apply. -->

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
