### PR TITLE
fix(models): emit explicit Kimchi API key env reference

### DIFF
--- a/src/extensions/login/flow.ts
+++ b/src/extensions/login/flow.ts
@@ -20,6 +20,16 @@ export const SUBSCRIPTION_LABEL = "Use a subscription"
 
 let browserLoginLinkSeq = 0
 
+export function getKimchiAuthPath(): string {
+	const agentDir = process.env.KIMCHI_CODING_AGENT_DIR
+	return agentDir ? resolve(agentDir, "auth.json") : "auth.json"
+}
+
+export function formatKimchiLoginSuccessMessage(modelId?: string): string {
+	const selectedModel = modelId ? ` Selected ${modelId}.` : ""
+	return `Logged in to Kimchi.${selectedModel} Credentials saved to ${getKimchiAuthPath()}`
+}
+
 /**
  * Format the browser-login URL as a feedback message the user can act on when
  * the auto-opened browser landed in the wrong app/profile.
@@ -187,7 +197,7 @@ async function configureKimchiToken(host: KimchiBrowserLoginHost, token: string)
 	if (providerModels.length > 0) {
 		const selectedModel = providerModels.find((m) => m.id === KIMCHI_DEFAULT_MODEL_ID) ?? providerModels[0]
 		await host.setModel?.(selectedModel)
-		host.addFeedback?.(`✓ Logged in. Model: ${selectedModel.id}`)
+		host.addFeedback?.(formatKimchiLoginSuccessMessage(selectedModel.id))
 		return true
 	}
 

--- a/src/login-command-patch.test.ts
+++ b/src/login-command-patch.test.ts
@@ -123,6 +123,7 @@ async function selectSubscriptionLoginOption(fakeIm: FakeIm): Promise<void> {
 }
 
 it("intercepts showOAuthSelector('login') and runs Kimchi browser auth", async () => {
+	process.env.KIMCHI_CODING_AGENT_DIR = "/tmp/kimchi-login-test"
 	const cliAuthModule = await import("./cli-auth/index.js")
 	const authSpy = vi.spyOn(cliAuthModule, "authenticateViaBrowser").mockResolvedValue({ token: "test-token-123" })
 
@@ -147,7 +148,9 @@ it("intercepts showOAuthSelector('login') and runs Kimchi browser auth", async (
 		id: "kimi-k2.6",
 		provider: "kimchi-dev",
 	})
-	expect(getFeedbackMessages(fakeIm)).toContain("✓ Logged in. Model: kimi-k2.6")
+	expect(getFeedbackMessages(fakeIm)).toContain(
+		"Logged in to Kimchi. Selected kimi-k2.6. Credentials saved to /tmp/kimchi-login-test/auth.json",
+	)
 })
 
 it("does not reuse a saved Kimchi key for explicit /login", async () => {
@@ -225,7 +228,9 @@ it("falls back to the first available model when the default is not present", as
 		id: "other-model",
 		provider: "kimchi-dev",
 	})
-	expect(getFeedbackMessages(fakeIm)).toContain("✓ Logged in. Model: other-model")
+	expect(getFeedbackMessages(fakeIm)).toContainEqual(
+		expect.stringContaining("Logged in to Kimchi. Selected other-model. Credentials saved to "),
+	)
 })
 
 it("reports failure when no models are available for the provider", async () => {

--- a/src/models.test.ts
+++ b/src/models.test.ts
@@ -68,6 +68,7 @@ describe("updateModelsConfig", () => {
 		await updateModelsConfig(modelsJsonPath, "test-key")
 
 		const config = JSON.parse(readFileSync(modelsJsonPath, "utf-8"))
+		expect(config.providers["kimchi-dev"].apiKey).toBe("$KIMCHI_API_KEY")
 		expect(config.providers["kimchi-dev"].models).toEqual([
 			{
 				id: "kimi-k2.5",
@@ -220,7 +221,7 @@ describe("updateModelsConfig", () => {
 				providers: {
 					"kimchi-dev": {
 						baseUrl: "https://llm.kimchi.dev",
-						apiKey: "KIMCHI_API_KEY",
+						apiKey: "$KIMCHI_API_KEY",
 						api: "openai-completions",
 						models: [OPENAI_MODEL],
 					},

--- a/src/models.ts
+++ b/src/models.ts
@@ -165,7 +165,7 @@ function buildModelsConfig(models: ModelMetadata[]) {
 		providers: {
 			"kimchi-dev": {
 				baseUrl: CHAT_COMPLETIONS_API,
-				apiKey: "KIMCHI_API_KEY",
+				apiKey: "$KIMCHI_API_KEY",
 				api: "openai-completions",
 				authHeader: true,
 				headers: { "User-Agent": `kimchi/${getVersion()}` },

--- a/tests/smoke/harness.ts
+++ b/tests/smoke/harness.ts
@@ -43,7 +43,7 @@ beforeAll(() => {
 				providers: {
 					"kimchi-dev": {
 						baseUrl: "https://llm.kimchi.dev/openai/v1",
-						apiKey: "KIMCHI_API_KEY",
+						apiKey: "$KIMCHI_API_KEY",
 						api: "openai-completions",
 						authHeader: true,
 						models: [


### PR DESCRIPTION

<img width="1095" height="992" alt="Screenshot 2026-06-02 at 09 51 28" src="https://github.com/user-attachments/assets/b30f0297-e6e2-414e-ae90-f954a76c926a" />


## Description

pi 0.78.0 migrates legacy env-var-shaped strings in models.json to the explicit  syntax and prints a warning.

Generate the Kimchi provider apiKey as  so new configs are already in the expected format and do not trigger that migration warning.

## Type of Change

<!-- Select all that apply. -->

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
