### PR TITLE
feat: add --enable-experimental-features flag

### DIFF
--- a/src/cli-args.test.ts
+++ b/src/cli-args.test.ts
@@ -1,5 +1,11 @@
 import { describe, expect, it } from "vitest"
-import { getCliModeArg, isHelpOrVersionArgs, isPreDispatchValueFlag } from "./cli-args.js"
+import {
+	getCliModeArg,
+	isExperimentalFeaturesArg,
+	isHelpOrVersionArgs,
+	isPreDispatchValueFlag,
+	stripExperimentalFeaturesArg,
+} from "./cli-args.js"
 
 describe("getCliModeArg", () => {
 	it("reads --mode value", () => {
@@ -60,4 +66,45 @@ describe("isPreDispatchValueFlag", () => {
 			expect(isPreDispatchValueFlag(arg)).toBe(false)
 		},
 	)
+})
+
+describe("isExperimentalFeaturesArg", () => {
+	it("returns true when flag is present", () => {
+		expect(isExperimentalFeaturesArg(["--enable-experimental-features"])).toBe(true)
+	})
+
+	it("returns true when mixed with other args", () => {
+		expect(isExperimentalFeaturesArg(["--model", "foo", "--enable-experimental-features"])).toBe(true)
+	})
+
+	it("returns false when flag is absent", () => {
+		expect(isExperimentalFeaturesArg(["--model", "foo"])).toBe(false)
+	})
+
+	it("returns false for empty args", () => {
+		expect(isExperimentalFeaturesArg([])).toBe(false)
+	})
+})
+
+describe("stripExperimentalFeaturesArg", () => {
+	it("removes the flag from the array", () => {
+		expect(stripExperimentalFeaturesArg(["--enable-experimental-features", "--model", "foo"])).toEqual([
+			"--model",
+			"foo",
+		])
+	})
+
+	it("removes all occurrences", () => {
+		expect(stripExperimentalFeaturesArg(["--enable-experimental-features", "--enable-experimental-features"])).toEqual(
+			[],
+		)
+	})
+
+	it("returns the array unchanged when flag is absent", () => {
+		expect(stripExperimentalFeaturesArg(["--model", "foo"])).toEqual(["--model", "foo"])
+	})
+
+	it("returns empty array for empty input", () => {
+		expect(stripExperimentalFeaturesArg([])).toEqual([])
+	})
 })

--- a/src/cli-args.ts
+++ b/src/cli-args.ts
@@ -46,3 +46,11 @@ export function isProtocolOrPrintMode(args: string[]): boolean {
 	const mode = getCliModeArg(args)
 	return mode === "json" || mode === "rpc" || mode === "acp" || args.includes("--print") || args.includes("-p")
 }
+
+export function isExperimentalFeaturesArg(args: string[]): boolean {
+	return args.includes("--enable-experimental-features")
+}
+
+export function stripExperimentalFeaturesArg(args: string[]): string[] {
+	return args.filter((a) => a !== "--enable-experimental-features")
+}

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -6,7 +6,13 @@ import { basename, dirname, resolve } from "node:path"
 import { fileURLToPath } from "node:url"
 import type { ExtensionAPI, ExtensionContext } from "@earendil-works/pi-coding-agent"
 import { AgentSession } from "@earendil-works/pi-coding-agent"
-import { getCliModeArg, isHelpOrVersionArgs, isProtocolOrPrintMode } from "./cli-args.js"
+import {
+	getCliModeArg,
+	isExperimentalFeaturesArg,
+	isHelpOrVersionArgs,
+	isProtocolOrPrintMode,
+	stripExperimentalFeaturesArg,
+} from "./cli-args.js"
 import { dispatchSubcommand } from "./commands/dispatch.js"
 // IMPORTANT: must be first local import — patches InteractiveMode.prototype
 // before any module can construct an InteractiveMode instance.
@@ -63,7 +69,7 @@ import traceIdExtension from "./extensions/trace-id.js"
 import uiExtension from "./extensions/ui.js"
 import webFetchExtension from "./extensions/web-fetch/index.js"
 import webSearchExtension from "./extensions/web-search/index.js"
-import { isTransientModelsError, updateModelsConfig } from "./models.js"
+import { injectExperimentalProvider, isTransientModelsError, updateModelsConfig } from "./models.js"
 import { injectTraceIdsIntoEntries, injectTraceIdsIntoExport } from "./modes/teleport/sync/session-export.js"
 import resourcesExtension from "./resources/extension.js"
 import { type ManagedExtensionFactory, enabledExtensionFactories } from "./resources/filter.js"
@@ -263,6 +269,7 @@ try {
 			sendPreSessionEvent(telemetryConfig, "harness_launched", { version: getVersion() })
 		}
 
+		const experimentalFeatures = isExperimentalFeaturesArg(process.argv.slice(2))
 		let config = loadConfig()
 
 		const envKey = process.env.KIMCHI_API_KEY || undefined
@@ -314,6 +321,7 @@ try {
 		let models: Awaited<ReturnType<typeof updateModelsConfig>>["models"]
 		try {
 			;({ models } = await updateModelsConfig(modelsJsonPath, currentApiKey))
+			if (experimentalFeatures) injectExperimentalProvider(modelsJsonPath)
 		} catch (err) {
 			const is401 = err instanceof Error && err.message.includes("401")
 			if (is401 && process.stdin.isTTY) {
@@ -330,6 +338,7 @@ try {
 				writeApiKey(currentApiKey)
 				config = loadConfig()
 				;({ models } = await updateModelsConfig(modelsJsonPath, currentApiKey))
+				if (experimentalFeatures) injectExperimentalProvider(modelsJsonPath)
 			} else if (isTransientModelsError(err)) {
 				// Rate limit / gateway error with no cached models to fall back on.
 				// Don't crash startup over a transient condition — continue with an
@@ -456,7 +465,7 @@ try {
 			globalThis.fetch = patchedFetch
 		}
 
-		const rawArgs = process.argv.slice(2)
+		const rawArgs = stripExperimentalFeaturesArg(process.argv.slice(2))
 		const interactiveStartupContext = {
 			nonInteractiveMode: acpMode,
 			stdinIsTTY: process.stdin.isTTY === true,

--- a/src/models.test.ts
+++ b/src/models.test.ts
@@ -2,7 +2,7 @@ import { existsSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "no
 import { tmpdir } from "node:os"
 import { join } from "node:path"
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
-import { ModelsFetchError, isTransientModelsError, updateModelsConfig } from "./models.js"
+import { ModelsFetchError, injectExperimentalProvider, isTransientModelsError, updateModelsConfig } from "./models.js"
 
 const KIMI: unknown = {
 	slug: "kimi-k2.5",
@@ -579,5 +579,80 @@ describe("readExistingProviders strips kimchi-experimental", () => {
 
 		const config = JSON.parse(readFileSync(modelsJsonPath, "utf-8"))
 		expect(config.providers["kimchi-experimental"]).toBeUndefined()
+	})
+})
+
+describe("injectExperimentalProvider", () => {
+	let tempDir: string
+	let modelsJsonPath: string
+
+	beforeEach(() => {
+		tempDir = mkdtempSync(join(tmpdir(), "kimchi-inject-exp-test-"))
+		modelsJsonPath = join(tempDir, "models.json")
+		vi.stubGlobal("fetch", vi.fn())
+	})
+
+	afterEach(() => {
+		rmSync(tempDir, { recursive: true, force: true })
+		vi.restoreAllMocks()
+	})
+
+	it("is a no-op when kimchi-dev is absent", () => {
+		writeFileSync(modelsJsonPath, JSON.stringify({ providers: {} }))
+		injectExperimentalProvider(modelsJsonPath)
+		const config = JSON.parse(readFileSync(modelsJsonPath, "utf-8"))
+		expect(config.providers["kimchi-experimental"]).toBeUndefined()
+	})
+
+	it("copies the kimchi-dev block with experimental baseUrl", async () => {
+		vi.mocked(fetch).mockResolvedValueOnce({
+			ok: true,
+			json: async () => ({ models: [KIMI] }),
+		} as Response)
+		await updateModelsConfig(modelsJsonPath, "test-key")
+
+		injectExperimentalProvider(modelsJsonPath)
+
+		const config = JSON.parse(readFileSync(modelsJsonPath, "utf-8"))
+		const dev = config.providers["kimchi-dev"]
+		const exp = config.providers["kimchi-experimental"]
+
+		expect(exp).toBeDefined()
+		expect(exp.baseUrl).toBe("https://llm.kimchi.dev/experimental/openai/v1")
+		// Everything else is identical to kimchi-dev
+		expect(exp.apiKey).toBe(dev.apiKey)
+		expect(exp.api).toBe(dev.api)
+		expect(exp.authHeader).toBe(dev.authHeader)
+		expect(exp.models).toEqual(dev.models)
+	})
+
+	it("preserves other providers when injecting", async () => {
+		writeFileSync(
+			modelsJsonPath,
+			JSON.stringify({
+				providers: {
+					"kimchi-dev": {
+						baseUrl: "https://llm.kimchi.dev/openai/v1",
+						apiKey: "KIMCHI_API_KEY",
+						api: "openai-completions",
+						authHeader: true,
+						headers: {},
+						models: [],
+					},
+					"my-custom": { baseUrl: "https://custom.example.com", models: [] },
+				},
+			}),
+		)
+
+		injectExperimentalProvider(modelsJsonPath)
+
+		const config = JSON.parse(readFileSync(modelsJsonPath, "utf-8"))
+		expect(config.providers["my-custom"]).toBeDefined()
+		expect(config.providers["kimchi-experimental"]).toBeDefined()
+	})
+
+	it("is a no-op when models.json does not exist", () => {
+		injectExperimentalProvider(modelsJsonPath)
+		expect(existsSync(modelsJsonPath)).toBe(false)
 	})
 })

--- a/src/models.test.ts
+++ b/src/models.test.ts
@@ -536,3 +536,48 @@ describe("updateModelsConfig", () => {
 		expect(model?.replacement).toBe("new-model")
 	})
 })
+
+describe("readExistingProviders strips kimchi-experimental", () => {
+	let tempDir: string
+	let modelsJsonPath: string
+
+	beforeEach(() => {
+		tempDir = mkdtempSync(join(tmpdir(), "kimchi-models-exp-test-"))
+		modelsJsonPath = join(tempDir, "models.json")
+		vi.stubGlobal("fetch", vi.fn())
+	})
+
+	afterEach(() => {
+		rmSync(tempDir, { recursive: true, force: true })
+		vi.restoreAllMocks()
+	})
+
+	it("clobbers kimchi-experimental on the next updateModelsConfig call", async () => {
+		// Simulate a previous run that left kimchi-experimental in models.json
+		writeFileSync(
+			modelsJsonPath,
+			JSON.stringify({
+				providers: {
+					"kimchi-experimental": {
+						baseUrl: "https://llm.kimchi.dev/experimental/openai/v1",
+						apiKey: "KIMCHI_API_KEY",
+						api: "openai-completions",
+						authHeader: true,
+						headers: {},
+						models: [],
+					},
+				},
+			}),
+		)
+
+		vi.mocked(fetch).mockResolvedValueOnce({
+			ok: true,
+			json: async () => ({ models: [KIMI] }),
+		} as Response)
+
+		await updateModelsConfig(modelsJsonPath, "test-key")
+
+		const config = JSON.parse(readFileSync(modelsJsonPath, "utf-8"))
+		expect(config.providers["kimchi-experimental"]).toBeUndefined()
+	})
+})

--- a/src/models.ts
+++ b/src/models.ts
@@ -251,6 +251,24 @@ export function syncProviderModels(
 	writeFileSync(modelsJsonPath, JSON.stringify(config, null, "\t"), "utf-8")
 }
 
+export function injectExperimentalProvider(modelsJsonPath: string): void {
+	if (!existsSync(modelsJsonPath)) return
+	let config: { providers?: Record<string, unknown> }
+	try {
+		config = JSON.parse(readFileSync(modelsJsonPath, "utf-8"))
+	} catch {
+		return
+	}
+	const kimchiDev = config.providers?.["kimchi-dev"]
+	if (!kimchiDev) return
+	const experimental = {
+		...(kimchiDev as Record<string, unknown>),
+		baseUrl: "https://llm.kimchi.dev/experimental/openai/v1",
+	}
+	config.providers = { ...config.providers, "kimchi-experimental": experimental }
+	writeFileSync(modelsJsonPath, JSON.stringify(config, null, "\t"), "utf-8")
+}
+
 /**
  * Fetch available models from the kimchi metadata API and write the
  * configuration to modelsJsonPath. If no API key is configured, returns

--- a/src/models.ts
+++ b/src/models.ts
@@ -221,7 +221,7 @@ function readExistingProviders(modelsJsonPath: string): Record<string, unknown> 
 		const raw = readFileSync(modelsJsonPath, "utf-8")
 		const config = JSON.parse(raw)
 		const providers = config?.providers ?? {}
-		const { "kimchi-dev": _kimchi, ...rest } = providers as Record<string, unknown>
+		const { "kimchi-dev": _kimchi, "kimchi-experimental": _exp, ...rest } = providers as Record<string, unknown>
 		return rest
 	} catch {
 		return {}


### PR DESCRIPTION
## Summary

- Adds `--enable-experimental-features` CLI flag that injects a `kimchi-experimental` provider into `models.json` pointing at `https://llm.kimchi.dev/experimental/openai/v1`
- Provider is ephemeral — derived from `kimchi-dev` on each startup, stripped on the next run without the flag
- Flag is stripped before forwarding args to pi-mono so it doesn't reject unknown flags

## Test Plan

- [ ] `pnpm test` passes (excluding pre-existing `startup-warning.test.ts` failure)
- [ ] Run `kimchi --enable-experimental-features` and verify `kimchi-experimental` appears in models.json with the experimental baseUrl
- [ ] Run `kimchi` without the flag and verify `kimchi-experimental` is absent from models.json