### PR TITLE
fix: strip UI-only custom messages from LLM context

### DIFF
--- a/src/extensions/curator/index.ts
+++ b/src/extensions/curator/index.ts
@@ -115,14 +115,17 @@ export default function curatorExtension(pi: ExtensionAPI, options?: CuratorExte
 							baseline.add(s)
 							knownAgentSkills.add(s)
 						}
-						pi.sendMessage({
-							customType: CURATOR_NOTIFICATION_TYPE,
-							content: [
-								{ type: "text", text: "<system-annotation>Skill review created new skills</system-annotation>" },
-							],
-							display: true,
-							details: { names: newSkills } satisfies CuratorNotificationData,
-						})
+						pi.sendMessage(
+							{
+								customType: CURATOR_NOTIFICATION_TYPE,
+								content: [
+									{ type: "text", text: "<system-annotation>Skill review created new skills</system-annotation>" },
+								],
+								display: true,
+								details: { names: newSkills } satisfies CuratorNotificationData,
+							},
+							{ triggerTurn: false },
+						)
 					} catch {
 						// best-effort
 					}
@@ -155,11 +158,14 @@ export default function curatorExtension(pi: ExtensionAPI, options?: CuratorExte
 			const known = new Set(state.known_agent_skills ?? [])
 			const newSkills = currentAgentSkills.filter((n) => !known.has(n))
 			if (newSkills.length > 0) {
-				pi.sendMessage({
-					customType: CURATOR_NOTIFICATION_TYPE,
-					content: [{ type: "text", text: `skill review created: ${newSkills.join(", ")}` }],
-					display: true,
-				})
+				pi.sendMessage(
+					{
+						customType: CURATOR_NOTIFICATION_TYPE,
+						content: [{ type: "text", text: `skill review created: ${newSkills.join(", ")}` }],
+						display: true,
+					},
+					{ triggerTurn: false },
+				)
 				await saveState(statePath, { ...state, known_agent_skills: currentAgentSkills })
 			} else if (state.known_agent_skills === undefined) {
 				// First run — seed without notifying

--- a/src/extensions/ferment/commands.test.ts
+++ b/src/extensions/ferment/commands.test.ts
@@ -238,6 +238,7 @@ describe("FermentCommandController", () => {
 				display: true,
 				details: { intent: "make reports better\ninclude tests" },
 			}),
+			{ triggerTurn: false },
 		)
 		expect(h.pi.sendMessage).toHaveBeenCalledWith(
 			expect.objectContaining({
@@ -277,6 +278,7 @@ describe("FermentCommandController", () => {
 				display: true,
 				details: { intent: "make the todo app glassy\nwith tests" },
 			}),
+			{ triggerTurn: false },
 		)
 		expect(h.pi.sendMessage).toHaveBeenCalledWith(
 			expect.objectContaining({
@@ -310,6 +312,7 @@ describe("FermentCommandController", () => {
 				display: true,
 				details: { intent: "make settings searchable" },
 			}),
+			{ triggerTurn: false },
 		)
 		expect(h.runtime.setActive).toHaveBeenCalledWith(
 			expect.objectContaining({ description: "make settings searchable" }),

--- a/src/extensions/ferment/scoping.test.ts
+++ b/src/extensions/ferment/scoping.test.ts
@@ -160,6 +160,7 @@ describe("runScopingFlow", () => {
 				customType: "ferment_request",
 				details: { intent: "I want to build reports\nwith export tests" },
 			}),
+			{ triggerTurn: false },
 		)
 	})
 

--- a/src/extensions/ferment/scoping.ts
+++ b/src/extensions/ferment/scoping.ts
@@ -112,12 +112,15 @@ export interface FermentRequestMessageDetails {
 }
 
 export function sendFermentRequestMessage(pi: ExtensionAPI, intent: string): void {
-	void pi.sendMessage<FermentRequestMessageDetails>({
-		customType: FERMENT_REQUEST_MESSAGE_TYPE,
-		content: [{ type: "text", text: `User entered ferment request: ${intent}` }],
-		display: true,
-		details: { intent },
-	})
+	void pi.sendMessage<FermentRequestMessageDetails>(
+		{
+			customType: FERMENT_REQUEST_MESSAGE_TYPE,
+			content: [{ type: "text", text: `User entered ferment request: ${intent}` }],
+			display: true,
+			details: { intent },
+		},
+		{ triggerTurn: false },
+	)
 }
 
 // ─── Scoping flow ─────────────────────────────────────────────────────────────

--- a/src/extensions/orchestration/continuation-nudge.test.ts
+++ b/src/extensions/orchestration/continuation-nudge.test.ts
@@ -6,6 +6,7 @@ import {
 	EmptyTurnNudge,
 	type OrchestratorMessages,
 	stripStaleNudges,
+	stripUiOnlyMessages,
 } from "./continuation-nudge.js"
 
 function makeAssistant(content: AssistantMessage["content"]): AssistantMessage {
@@ -374,5 +375,67 @@ describe("EmptyTurnNudge", () => {
 		// Reset re-arms the nudge for the next user-input cycle
 		guard.resetForNewUserInput()
 		expect(guard.evaluateTurn(emptyMessage)).toBe(true)
+	})
+})
+
+describe("stripUiOnlyMessages", () => {
+	function makeUiOnly(customType: string): OrchestratorMessages[number] {
+		return {
+			role: "custom",
+			customType,
+			content: [{ type: "text", text: "ui-only" }],
+			display: true,
+			timestamp: Date.now(),
+		}
+	}
+
+	it("returns the same array when there are no UI-only messages", () => {
+		const messages: OrchestratorMessages = [makeUser("q"), textOnlyMessage]
+		expect(stripUiOnlyMessages(messages)).toBe(messages)
+	})
+
+	it("strips a UI-only message from the tail", () => {
+		const ui = makeUiOnly("prompt-summary")
+		const messages: OrchestratorMessages = [makeUser("q"), textOnlyMessage, ui]
+		const result = stripUiOnlyMessages(messages)
+		expect(result).not.toBe(messages)
+		expect(result).toHaveLength(2)
+		expect(result).not.toContainEqual(ui)
+	})
+
+	it("strips a UI-only message from the middle", () => {
+		const ui = makeUiOnly("ferment_breadcrumb")
+		const messages: OrchestratorMessages = [makeUser("q"), ui, textOnlyMessage]
+		const result = stripUiOnlyMessages(messages)
+		expect(result).not.toBe(messages)
+		expect(result).toHaveLength(2)
+		expect(result).not.toContainEqual(ui)
+	})
+
+	it("strips multiple distinct UI-only types", () => {
+		const messages: OrchestratorMessages = [
+			makeUser("q"),
+			makeUiOnly("prompt-summary"),
+			makeUser("q2"),
+			makeUiOnly("curator-notification"),
+			makeUiOnly("ferment_ack"),
+			textOnlyMessage,
+		]
+		const result = stripUiOnlyMessages(messages)
+		expect(result.filter((m) => m.role === "custom")).toHaveLength(0)
+		expect(result).toHaveLength(3)
+	})
+
+	it("does not strip non-UI custom messages", () => {
+		const other = {
+			role: "custom" as const,
+			customType: "subagent-notification",
+			content: [{ type: "text" as const, text: "agent done" }],
+			display: true,
+			timestamp: Date.now(),
+		}
+		const messages: OrchestratorMessages = [makeUser("q"), other, textOnlyMessage]
+		const result = stripUiOnlyMessages(messages)
+		expect(result).toBe(messages)
 	})
 })

--- a/src/extensions/orchestration/continuation-nudge.ts
+++ b/src/extensions/orchestration/continuation-nudge.ts
@@ -201,3 +201,35 @@ export function stripStaleNudges(messages: OrchestratorMessages): OrchestratorMe
 	const stripped = messages.filter((m, i) => i > lastAssistantIdx || !isNudgeMessage(m))
 	return stripped.length === messages.length ? messages : stripped
 }
+
+/** Custom types that are display-only UI markers and must never reach the LLM. */
+export const UI_ONLY_CUSTOM_TYPES: ReadonlySet<string> = Object.freeze(
+	new Set([
+		"prompt-summary",
+		"curator-notification",
+		"ferment_breadcrumb",
+		"ferment_worktree_warning",
+		"ferment_ack",
+		"ferment_request",
+		"ferment_oneshot_failed",
+	]),
+)
+
+function isCustomMessage(
+	m: OrchestratorMessages[number],
+): m is Extract<OrchestratorMessages[number], { role: "custom" }> {
+	return m.role === "custom"
+}
+
+/**
+ * Strip UI-only custom messages that are meant for display but should never
+ * reach the LLM. These are emitted via `sendMessage` with `display: true` and
+ * no `triggerTurn` / `deliverAs` options, which causes pi-mono to push them
+ * into `agent.state.messages` as user-role messages.
+ */
+export function stripUiOnlyMessages(messages: OrchestratorMessages): OrchestratorMessages {
+	const filtered = messages.filter(
+		(m) => !(isCustomMessage(m) && UI_ONLY_CUSTOM_TYPES.has((m as { customType?: string }).customType ?? "")),
+	)
+	return filtered.length === messages.length ? messages : filtered
+}

--- a/src/extensions/prompt-construction/prompt-enrichment.ts
+++ b/src/extensions/prompt-construction/prompt-enrichment.ts
@@ -45,6 +45,7 @@ import {
 	NUDGE_CUSTOM_TYPE,
 	type OrchestratorMessages,
 	stripStaleNudges,
+	stripUiOnlyMessages,
 } from "../orchestration/continuation-nudge.js"
 import { ModelRegistry } from "../orchestration/model-registry/index.js"
 import { registerModelRolesCommand } from "../orchestration/model-roles-command.js"
@@ -426,6 +427,7 @@ export default function (skillPaths: string[]) {
 			pi.on("context", async (event) => {
 				let messages = stripStaleNudges(event.messages)
 				messages = stripEmptyToolCalls(messages)
+				messages = stripUiOnlyMessages(messages)
 				if (messages !== event.messages) return { messages }
 			})
 		}

--- a/src/extensions/prompt-summary.ts
+++ b/src/extensions/prompt-summary.ts
@@ -232,14 +232,17 @@ export default function promptSummaryExtension(pi: ExtensionAPI) {
 		// and only appears after the next user prompt.
 		await new Promise((resolve) => setTimeout(resolve, 0))
 
-		pi.sendMessage({
-			customType: "prompt-summary",
-			// Wrap in a tag so the LLM treats this as a system annotation, not user input.
-			// All custom messages are transformed to role:"user" by pi-mono, so without
-			// this the model interprets "Prompt summary (Xs)" as something the user typed.
-			content: [{ type: "text", text: `<system-annotation>Prompt summary (${data.elapsed})</system-annotation>` }],
-			display: true,
-			details: data,
-		})
+		pi.sendMessage(
+			{
+				customType: "prompt-summary",
+				// Wrap in a tag so the LLM treats this as a system annotation, not user input.
+				// All custom messages are transformed to role:"user" by pi-mono, so without
+				// this the model interprets "Prompt summary (Xs)" as something the user typed.
+				content: [{ type: "text", text: `<system-annotation>Prompt summary (${data.elapsed})</system-annotation>` }],
+				display: true,
+				details: data,
+			},
+			{ triggerTurn: false },
+		)
 	})
 }


### PR DESCRIPTION
## Problem

Display-only custom messages emitted via `pi.sendMessage()` with `display: true` but no delivery options were leaking into the LLM prompt context. Pi-mono treats all `role: "custom"` messages as user-role messages, so these UI markers (prompt summary, curator notifications, ferment breadcrumbs, etc.) were being sent to the model.

The `<system-annotation>` wrapper in prompt-summary and curator-notification was a mitigation attempt, not a proper fix.

## Changes

- **Add `stripUiOnlyMessages()`** in `continuation-nudge.ts` alongside the existing `stripStaleNudges`. Filters out 7 known UI-only custom types before each LLM call.
- **Wire into `prompt-enrichment.ts`\** — applies the filter in the main `context` handler.
- **Explicit `{ triggerTurn: false }`** on 4 UI-only `sendMessage` calls that lacked it (prompt-summary, curator-notification ×2, ferment-request).
- **5 new tests** covering removal from tail, middle, multiple types, and preservation of non-UI custom messages.

## Verification

- 45 tests pass, 0 fail (continuation-nudge.test.ts)
- `pnpm run lint:fix` clean

## Affected custom types (now stripped)

| Type | Origin |
|---|---|
| `prompt-summary` | `extensions/prompt-summary.ts` |
| `curator-notification` | `extensions/curator/index.ts` |
| `ferment_breadcrumb` | `extensions/ferment/*.ts` |
| `ferment_worktree_warning` | `extensions/ferment/resume.ts` |
| `ferment_ack` | `extensions/ferment/*.ts` |
| `ferment_request` | `extensions/ferment/scoping.ts` |
| `ferment_oneshot_failed` | `extensions/ferment/events.ts` |