### PR TITLE
feat: log LLM response metadata as custom session entries

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -36,6 +36,7 @@ import fermentExtension from "./extensions/ferment/index.js"
 import helpExtension from "./extensions/help.js"
 import hideThinkingExtension from "./extensions/hide-thinking.js"
 import kimchiMinimalTintsExtension from "./extensions/kimchi-minimal-tints.js"
+import llmResponseLogExtension from "./extensions/llm-response-log.js"
 import loginExtension from "./extensions/login/index.js"
 import { createStartupAuthGate, createStartupAuthGateState } from "./extensions/login/startup-auth.js"
 import loopGuardExtension from "./extensions/loop-guard.js"
@@ -532,6 +533,7 @@ try {
 			modelGuardExtension,
 			stripImagesExtension,
 			traceIdExtension,
+			llmResponseLogExtension,
 			activityExtension,
 		]
 

--- a/src/extensions/llm-response-log.test.ts
+++ b/src/extensions/llm-response-log.test.ts
@@ -176,7 +176,7 @@ describe("llmResponseLogExtension", () => {
 		expect(appendEntryMock).not.toHaveBeenCalled()
 	})
 
-	it("error handling: appendEntry throws does not propagate", async () => {
+	it("error handling: appendEntry throws does not propagate and logs error", async () => {
 		const { pi, trigger } = makeMockPI()
 		llmResponseLogExtension(pi)
 
@@ -185,11 +185,16 @@ describe("llmResponseLogExtension", () => {
 			throw new Error("appendEntry failed")
 		}
 
+		const consoleErrorSpy = vi.spyOn(console, "error").mockImplementation(() => {})
+
 		// Should not throw
 		await expect(
 			trigger("message_end", {
 				message: makeAssistantMessage(),
 			}),
 		).resolves.not.toThrow()
+
+		expect(consoleErrorSpy).toHaveBeenCalledWith("[llm-response-log] failed to append debug entry:", expect.any(Error))
+		consoleErrorSpy.mockRestore()
 	})
 })

--- a/src/extensions/llm-response-log.test.ts
+++ b/src/extensions/llm-response-log.test.ts
@@ -1,0 +1,195 @@
+import type { ExtensionAPI } from "@earendil-works/pi-coding-agent"
+import { describe, expect, it, vi } from "vitest"
+import llmResponseLogExtension from "./llm-response-log.js"
+
+// ── helpers ──────────────────────────────────────────────────────────────────
+
+type MessageEndEvent = {
+	message: {
+		role: string
+		model: string
+		provider: string
+		api: string
+		stopReason: string
+		errorMessage?: string
+		content: Array<{ type: string; [key: string]: unknown }>
+		usage: {
+			input: number
+			output: number
+			cacheRead: number
+			cacheWrite: number
+			totalTokens: number
+			cost: {
+				input: number
+				output: number
+				cacheRead: number
+				cacheWrite: number
+				total: number
+			}
+		}
+		timestamp: number
+	}
+}
+
+function makeMockPI() {
+	const handlers: Array<(event: MessageEndEvent) => unknown> = []
+	const appendEntryMock = vi.fn()
+
+	const pi = {
+		on(event: string, handler: (event: MessageEndEvent) => unknown) {
+			if (event === "message_end") {
+				handlers.push(handler)
+			}
+		},
+		appendEntry: appendEntryMock,
+	} as unknown as ExtensionAPI & { appendEntry: typeof appendEntryMock }
+
+	async function trigger(event: string, payload: MessageEndEvent) {
+		for (const handler of handlers) {
+			await handler(payload)
+		}
+	}
+
+	return { pi, trigger, appendEntryMock, getAppendEntryMock: () => appendEntryMock }
+}
+
+function makeAssistantMessage(overrides: Partial<MessageEndEvent["message"]> = {}): MessageEndEvent["message"] {
+	return {
+		role: "assistant",
+		model: "claude-sonnet-4-20250514",
+		provider: "anthropic",
+		api: "messages",
+		stopReason: "end_turn",
+		content: [{ type: "text", text: "Hello!" }],
+		usage: {
+			input: 100,
+			output: 50,
+			cacheRead: 10,
+			cacheWrite: 5,
+			totalTokens: 155,
+			cost: { input: 0.001, output: 0.002, cacheRead: 0.0001, cacheWrite: 0.0002, total: 0.0033 },
+		},
+		timestamp: 0,
+		...overrides,
+	}
+}
+
+// ── tests ────────────────────────────────────────────────────────────────────
+
+describe("llmResponseLogExtension", () => {
+	it("happy path: logs assistant message with text and tool calls", async () => {
+		const { pi, trigger, appendEntryMock } = makeMockPI()
+		llmResponseLogExtension(pi)
+
+		const before = Date.now()
+		await trigger("message_end", {
+			message: makeAssistantMessage({
+				model: "claude-sonnet-4-20250514",
+				provider: "anthropic",
+				api: "messages",
+				stopReason: "end_turn",
+				content: [
+					{ type: "text", text: "I'll read the file for you." },
+					{ type: "toolCall", name: "read", id: "tool-1", arguments: { path: "src/index.ts" } },
+					{ type: "toolCall", name: "bash", id: "tool-2", arguments: { command: "ls" } },
+				],
+				usage: {
+					input: 100,
+					output: 50,
+					cacheRead: 10,
+					cacheWrite: 5,
+					totalTokens: 155,
+					cost: { input: 0.001, output: 0.002, cacheRead: 0.0001, cacheWrite: 0.0002, total: 0.0033 },
+				},
+			}),
+		})
+		const after = Date.now()
+
+		expect(appendEntryMock).toHaveBeenCalledTimes(1)
+		const [customType, data] = appendEntryMock.mock.calls[0]
+
+		expect(customType).toBe("llm_response_debug")
+		expect(data).toMatchObject({
+			model: "claude-sonnet-4-20250514",
+			provider: "anthropic",
+			api: "messages",
+			stopReason: "end_turn",
+		})
+		expect(data.toolCalls).toEqual([
+			{ name: "read", id: "tool-1", arguments: { path: "src/index.ts" } },
+			{ name: "bash", id: "tool-2", arguments: { command: "ls" } },
+		])
+		expect(data.contentSummary).toEqual(["text", "toolCall", "toolCall"])
+		expect(data.usage).toEqual({
+			input: 100,
+			output: 50,
+			cacheRead: 10,
+			cacheWrite: 5,
+			totalTokens: 155,
+			cost: { input: 0.001, output: 0.002, cacheRead: 0.0001, cacheWrite: 0.0002, total: 0.0033 },
+		})
+		expect(data.timestamp).toBeGreaterThanOrEqual(before)
+		expect(data.timestamp).toBeLessThanOrEqual(after)
+	})
+
+	it("assistant message without tool calls logs empty toolCalls array", async () => {
+		const { pi, trigger, appendEntryMock } = makeMockPI()
+		llmResponseLogExtension(pi)
+
+		await trigger("message_end", {
+			message: makeAssistantMessage({
+				content: [{ type: "text", text: "Hello, how can I help?" }],
+			}),
+		})
+
+		expect(appendEntryMock).toHaveBeenCalledTimes(1)
+		const [, data] = appendEntryMock.mock.calls[0]
+
+		expect(data.toolCalls).toEqual([])
+		expect(data.contentSummary).toEqual(["text"])
+	})
+
+	it("non-assistant messages are ignored", async () => {
+		const { pi, trigger, appendEntryMock } = makeMockPI()
+		llmResponseLogExtension(pi)
+
+		await trigger("message_end", {
+			message: {
+				role: "user",
+				model: "claude-sonnet-4-20250514",
+				provider: "anthropic",
+				api: "messages",
+				stopReason: "end_turn",
+				content: [{ type: "text", text: "Hello!" }],
+				usage: {
+					input: 100,
+					output: 0,
+					cacheRead: 0,
+					cacheWrite: 0,
+					totalTokens: 100,
+					cost: { input: 0.001, output: 0, cacheRead: 0, cacheWrite: 0, total: 0.001 },
+				},
+				timestamp: 0,
+			},
+		})
+
+		expect(appendEntryMock).not.toHaveBeenCalled()
+	})
+
+	it("error handling: appendEntry throws does not propagate", async () => {
+		const { pi, trigger } = makeMockPI()
+		llmResponseLogExtension(pi)
+
+		// Replace appendEntry with a throwing mock after extension is registered
+		;(pi as unknown as { appendEntry: () => void }).appendEntry = () => {
+			throw new Error("appendEntry failed")
+		}
+
+		// Should not throw
+		await expect(
+			trigger("message_end", {
+				message: makeAssistantMessage(),
+			}),
+		).resolves.not.toThrow()
+	})
+})

--- a/src/extensions/llm-response-log.ts
+++ b/src/extensions/llm-response-log.ts
@@ -1,0 +1,87 @@
+/**
+ * LLM Response Log Extension
+ *
+ * Logs detailed LLM response metadata (model, usage, tool calls, stop reason)
+ * as custom session entries for debugging and analytics.
+ */
+
+import type { AssistantMessage, ToolCall } from "@earendil-works/pi-ai"
+import type { ExtensionAPI } from "@earendil-works/pi-coding-agent"
+
+interface LLMResponseDebugEntry {
+	model: string
+	provider: string
+	api: string
+	stopReason: string
+	errorMessage?: string
+	usage: {
+		input: number
+		output: number
+		cacheRead: number
+		cacheWrite: number
+		totalTokens: number
+		cost: {
+			input: number
+			output: number
+			cacheRead: number
+			cacheWrite: number
+			total: number
+		}
+	}
+	toolCalls: Array<{
+		name: string
+		id: string
+		arguments: unknown
+	}>
+	contentSummary: string[]
+	timestamp: number
+}
+
+export default function llmResponseLogExtension(pi: ExtensionAPI): void {
+	pi.on("message_end", async (event) => {
+		const message = event.message
+		if (message.role !== "assistant") {
+			return
+		}
+
+		try {
+			// Extract tool calls from content blocks
+			const toolCalls: Array<{ name: string; id: string; arguments: unknown }> = []
+			const contentSummary: string[] = []
+
+			for (const block of message.content) {
+				if (block.type === "toolCall") {
+					toolCalls.push({
+						name: block.name,
+						id: block.id,
+						arguments: block.arguments,
+					})
+				}
+				contentSummary.push(block.type)
+			}
+
+			const entry: LLMResponseDebugEntry = {
+				model: message.model,
+				provider: message.provider,
+				api: message.api,
+				stopReason: message.stopReason,
+				errorMessage: message.errorMessage,
+				usage: {
+					input: message.usage.input,
+					output: message.usage.output,
+					cacheRead: message.usage.cacheRead,
+					cacheWrite: message.usage.cacheWrite,
+					totalTokens: message.usage.totalTokens,
+					cost: message.usage.cost,
+				},
+				toolCalls,
+				contentSummary,
+				timestamp: Date.now(),
+			}
+
+			pi.appendEntry("llm_response_debug", entry)
+		} catch {
+			// Silent fail - don't break the session if logging fails
+		}
+	})
+}

--- a/src/extensions/llm-response-log.ts
+++ b/src/extensions/llm-response-log.ts
@@ -79,9 +79,9 @@ export default function llmResponseLogExtension(pi: ExtensionAPI): void {
 				timestamp: Date.now(),
 			}
 
-			pi.appendEntry("llm_response_debug", entry)
-		} catch {
-			// Silent fail - don't break the session if logging fails
+			await pi.appendEntry("llm_response_debug", entry)
+		} catch (err) {
+			console.error("[llm-response-log] failed to append debug entry:", err)
 		}
 	})
 }


### PR DESCRIPTION
## What

Adds a new `llm-response-log` extension that hooks `message_end` and appends a `llm_response_debug` custom entry to the session JSONL for each assistant message.

## Data captured per message

- `model`, `provider`, `api`
- `stopReason`, `errorMessage`
- `usage`: input/output/cacheRead/cacheWrite tokens + cost breakdown
- `toolCalls`: name, id, arguments for each tool call
- `contentSummary`: list of content block types (e.g. `["text", "toolCall"]`)
- `timestamp`

## Changes

- `src/extensions/llm-response-log.ts` — extension implementation
- `src/extensions/llm-response-log.test.ts` — 4 unit tests
- `src/cli.ts` — register `llmResponseLogExtension` in `extensionFactories`

## Notes

- Entries are `CustomEntry` nodes — ignored by `buildSessionContext` so they don't bloat LLM context
- Handler wrapped in try/catch so failures never break a session
- Visible in HTML export when filter is set to "all"