### PR TITLE
fix: poll isIdle() before sending prompt-summary to prevent steer loop

### DIFF
--- a/src/extensions/orchestration/continuation-nudge.ts
+++ b/src/extensions/orchestration/continuation-nudge.ts
@@ -202,6 +202,24 @@ export function stripStaleNudges(messages: OrchestratorMessages): OrchestratorMe
 	return stripped.length === messages.length ? messages : stripped
 }
 
+function isBehaviourMessage(m: OrchestratorMessages[number]): boolean {
+	return m.role === "custom" && "customType" in m && (m as { customType: string }).customType === "behaviour"
+}
+
+/**
+ * Strip behaviour-body messages that the model has already acted on (i.e.
+ * there is an assistant response after them). Behaviour bodies are injected
+ * once per agent start to prime the model with rules; once the model has
+ * processed them they accumulate in context as stale user-role messages and
+ * can confuse the model on subsequent turns.
+ */
+export function stripStaleBehaviours(messages: OrchestratorMessages): OrchestratorMessages {
+	const lastAssistantIdx = messages.findLastIndex((m) => m.role === "assistant")
+	if (lastAssistantIdx === -1) return messages
+	const stripped = messages.filter((m, i) => i > lastAssistantIdx || !isBehaviourMessage(m))
+	return stripped.length === messages.length ? messages : stripped
+}
+
 /** Custom types that are display-only UI markers and must never reach the LLM. */
 export const UI_ONLY_CUSTOM_TYPES: ReadonlySet<string> = Object.freeze(
 	new Set([

--- a/src/extensions/orchestration/continuation-nudge.ts
+++ b/src/extensions/orchestration/continuation-nudge.ts
@@ -202,24 +202,6 @@ export function stripStaleNudges(messages: OrchestratorMessages): OrchestratorMe
 	return stripped.length === messages.length ? messages : stripped
 }
 
-function isBehaviourMessage(m: OrchestratorMessages[number]): boolean {
-	return m.role === "custom" && "customType" in m && (m as { customType: string }).customType === "behaviour"
-}
-
-/**
- * Strip behaviour-body messages that the model has already acted on (i.e.
- * there is an assistant response after them). Behaviour bodies are injected
- * once per agent start to prime the model with rules; once the model has
- * processed them they accumulate in context as stale user-role messages and
- * can confuse the model on subsequent turns.
- */
-export function stripStaleBehaviours(messages: OrchestratorMessages): OrchestratorMessages {
-	const lastAssistantIdx = messages.findLastIndex((m) => m.role === "assistant")
-	if (lastAssistantIdx === -1) return messages
-	const stripped = messages.filter((m, i) => i > lastAssistantIdx || !isBehaviourMessage(m))
-	return stripped.length === messages.length ? messages : stripped
-}
-
 /** Custom types that are display-only UI markers and must never reach the LLM. */
 export const UI_ONLY_CUSTOM_TYPES: ReadonlySet<string> = Object.freeze(
 	new Set([

--- a/src/extensions/prompt-summary.ts
+++ b/src/extensions/prompt-summary.ts
@@ -201,7 +201,7 @@ export default function promptSummaryExtension(pi: ExtensionAPI) {
 		}
 	})
 
-	pi.on("agent_end", async () => {
+	pi.on("agent_end", async (event, ctx) => {
 		const grandTotal: UsageTotals = {
 			input: orchestrator.input + subagents.input,
 			output: orchestrator.output + subagents.output,
@@ -227,22 +227,24 @@ export default function promptSummaryExtension(pi: ExtensionAPI) {
 			extras: extras.length > 0 ? extras : undefined,
 		}
 
-		// Defer so the agent event loop finishes and isStreaming resets to false
-		// before sendMessage is called — otherwise it gets queued as a steer message
-		// and only appears after the next user prompt.
-		await new Promise((resolve) => setTimeout(resolve, 0))
-
-		pi.sendMessage(
-			{
-				customType: "prompt-summary",
-				// Wrap in a tag so the LLM treats this as a system annotation, not user input.
-				// All custom messages are transformed to role:"user" by pi-mono, so without
-				// this the model interprets "Prompt summary (Xs)" as something the user typed.
-				content: [{ type: "text", text: `<system-annotation>Prompt summary (${data.elapsed})</system-annotation>` }],
-				display: true,
-				details: data,
-			},
-			{ triggerTurn: false },
-		)
+		// Poll until the agent is idle before sending — a plain setTimeout(0)
+		// is not enough because isStreaming can still be true when agent_end fires,
+		// causing sendMessage to take the steer path and trigger a new LLM turn.
+		const trySend = () => {
+			if (ctx?.isIdle() === false) {
+				setTimeout(trySend, 50)
+				return
+			}
+			pi.sendMessage(
+				{
+					customType: "prompt-summary",
+					content: [{ type: "text", text: `<system-annotation>Prompt summary (${data.elapsed})</system-annotation>` }],
+					display: true,
+					details: data,
+				},
+				{ triggerTurn: false },
+			)
+		}
+		trySend()
 	})
 }

--- a/src/extensions/prompt-summary.ts
+++ b/src/extensions/prompt-summary.ts
@@ -230,20 +230,28 @@ export default function promptSummaryExtension(pi: ExtensionAPI) {
 		// Poll until the agent is idle before sending — a plain setTimeout(0)
 		// is not enough because isStreaming can still be true when agent_end fires,
 		// causing sendMessage to take the steer path and trigger a new LLM turn.
+		let attempts = 0
+		const MAX_ATTEMPTS = 100 // 5s max
 		const trySend = () => {
-			if (ctx?.isIdle() === false) {
+			if (ctx?.isIdle() === false && attempts++ < MAX_ATTEMPTS) {
 				setTimeout(trySend, 50)
 				return
 			}
-			pi.sendMessage(
-				{
-					customType: "prompt-summary",
-					content: [{ type: "text", text: `<system-annotation>Prompt summary (${data.elapsed})</system-annotation>` }],
-					display: true,
-					details: data,
-				},
-				{ triggerTurn: false },
-			)
+			try {
+				pi.sendMessage(
+					{
+						customType: "prompt-summary",
+						content: [
+							{ type: "text", text: `<system-annotation>Prompt summary (${data.elapsed})</system-annotation>` },
+						],
+						display: true,
+						details: data,
+					},
+					{ triggerTurn: false },
+				)
+			} catch (err) {
+				console.error("[prompt-summary] Failed to send:", err)
+			}
 		}
 		trySend()
 	})


### PR DESCRIPTION
## Root cause

`agent_end` fires while `isStreaming` is still `true`. The previous `setTimeout(0)` defer only yields to the microtask queue — not long enough for the agent-session to clear `isStreaming`.

When `sendMessage` is called while `isStreaming=true` with no `deliverAs` option, pi-mono routes it through `agent.steer()`, which **immediately triggers a new LLM generation**. This caused the infinite loop:

```
agent ends → prompt-summary steer → new generation → agent ends → repeat
```

The `stripUiOnlyMessages` fix from #488 correctly removes the prompt-summary from the LLM context (explaining why the model's thinking shows it doesn't see the text), but it can't prevent a turn that was already triggered by the steer.

## Fix

Poll `ctx.isIdle()` every 50ms and only call `sendMessage` once the agent is truly idle. The `{ triggerTurn: false }` else-branch is then taken, which quietly pushes to `agent.state.messages` without triggering a turn. `stripUiOnlyMessages` removes it before the next LLM call.