### PR TITLE
fix(acp): initialize theme for headless sessions

### DIFF
--- a/src/cli-args.test.ts
+++ b/src/cli-args.test.ts
@@ -4,6 +4,8 @@ import {
 	isExperimentalFeaturesArg,
 	isHelpOrVersionArgs,
 	isPreDispatchValueFlag,
+	isProtocolOrPrintMode,
+	isTerminalUiMode,
 	stripExperimentalFeaturesArg,
 } from "./cli-args.js"
 
@@ -33,6 +35,44 @@ describe("isHelpOrVersionArgs", () => {
 
 	it("returns false without help or version flags", () => {
 		expect(isHelpOrVersionArgs(["--mode", "json"])).toBe(false)
+	})
+})
+
+describe("isProtocolOrPrintMode", () => {
+	it.each([
+		["pi rpc mode", ["--mode", "rpc"]],
+		["pi json mode", ["--mode", "json"]],
+		["pi print mode", ["--print", "hello"]],
+		["pi short print mode", ["-p", "hello"]],
+		["raw equals mode fallback", ["--mode=rpc"]],
+		["kimchi acp mode", ["--mode", "acp"]],
+	])("returns true for %s", (_name, args) => {
+		expect(isProtocolOrPrintMode(args)).toBe(true)
+	})
+
+	it("returns false for interactive invocations", () => {
+		expect(isProtocolOrPrintMode([])).toBe(false)
+		expect(isProtocolOrPrintMode(["fix tests"])).toBe(false)
+	})
+})
+
+describe("isTerminalUiMode", () => {
+	const tty = { stdinIsTTY: true, stdoutIsTTY: true }
+
+	it("returns true for an interactive terminal invocation", () => {
+		expect(isTerminalUiMode([], tty)).toBe(true)
+	})
+
+	it.each([["--mode", "acp"], ["--mode", "rpc"], ["--mode=json"], ["--print"], ["-p"]])(
+		"returns false for protocol or print args %j",
+		(...args) => {
+			expect(isTerminalUiMode(args, tty)).toBe(false)
+		},
+	)
+
+	it("returns false when stdin or stdout is not a TTY", () => {
+		expect(isTerminalUiMode([], { stdinIsTTY: false, stdoutIsTTY: true })).toBe(false)
+		expect(isTerminalUiMode([], { stdinIsTTY: true, stdoutIsTTY: false })).toBe(false)
 	})
 })
 

--- a/src/cli-args.ts
+++ b/src/cli-args.ts
@@ -1,6 +1,7 @@
-// Pre-dispatch scanners need to skip values for known CLI flags before the
-// upstream pi-coding-agent parser runs. Keep this mirrored with the upstream
-// parser because that parser is not exported through the package API.
+import { parseArgs as parsePiArgs } from "@earendil-works/pi-coding-agent"
+
+// Pre-dispatch scanners still need to skip values for Kimchi-local raw scans
+// such as `--mode acp`, which upstream pi does not parse.
 const PRE_DISPATCH_VALUE_FLAGS = new Set([
 	"--provider",
 	"--model",
@@ -43,8 +44,13 @@ export function isHelpOrVersionArgs(args: string[]): boolean {
 // print output). Terminal OSC writes and compat warnings must be suppressed
 // because they corrupt that stream.
 export function isProtocolOrPrintMode(args: string[]): boolean {
-	const mode = getCliModeArg(args)
-	return mode === "json" || mode === "rpc" || mode === "acp" || args.includes("--print") || args.includes("-p")
+	const parsed = parsePiArgs(args)
+	const mode = parsed.mode ?? getCliModeArg(args)
+	return mode === "json" || mode === "rpc" || mode === "acp" || parsed.print === true
+}
+
+export function isTerminalUiMode(args: string[], io: { stdinIsTTY: boolean; stdoutIsTTY: boolean }): boolean {
+	return io.stdinIsTTY && io.stdoutIsTTY && !isProtocolOrPrintMode(args)
 }
 
 export function isExperimentalFeaturesArg(args: string[]): boolean {

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -10,7 +10,7 @@ import {
 	getCliModeArg,
 	isExperimentalFeaturesArg,
 	isHelpOrVersionArgs,
-	isProtocolOrPrintMode,
+	isTerminalUiMode,
 	stripExperimentalFeaturesArg,
 } from "./cli-args.js"
 import { dispatchSubcommand } from "./commands/dispatch.js"
@@ -398,9 +398,13 @@ try {
 		mkdirSync(themesDir, { recursive: true })
 
 		// Probe runs here (before pi-mono takes stdin) so the result is cached for
-		// the kimchi-minimal-tints and terminal-colors extensions. Skip protocol
-		// and print modes: stdout belongs to the caller, and OSC escapes corrupt it.
-		const terminalStartupOutputAllowed = !isProtocolOrPrintMode(process.argv.slice(2))
+		// the kimchi-minimal-tints and terminal-colors extensions. Skip non-TUI
+		// modes: stdout belongs to the caller, and OSC escapes corrupt it.
+		const terminalIo = {
+			stdinIsTTY: process.stdin.isTTY === true,
+			stdoutIsTTY: process.stdout.isTTY === true,
+		}
+		const terminalStartupOutputAllowed = isTerminalUiMode(process.argv.slice(2), terminalIo)
 		if (terminalStartupOutputAllowed) {
 			await probeTerminalBackground()
 			await probeKittyKeyboardSupport()
@@ -438,7 +442,7 @@ try {
 		}
 
 		// Clear the visible viewport and home the cursor so kimchi renders at the top.
-		if (!acpMode && process.stdout.isTTY) {
+		if (terminalStartupOutputAllowed) {
 			process.stdout.write("\x1b[2J\x1b[H")
 		}
 
@@ -463,8 +467,7 @@ try {
 		const rawArgs = stripExperimentalFeaturesArg(process.argv.slice(2))
 		const interactiveStartupContext = {
 			nonInteractiveMode: acpMode,
-			stdinIsTTY: process.stdin.isTTY === true,
-			stdoutIsTTY: process.stdout.isTTY === true,
+			...terminalIo,
 		}
 		const startupAuthState = createStartupAuthGateState()
 		const startupAuthGate = createStartupAuthGate({
@@ -476,15 +479,17 @@ try {
 			...interactiveStartupContext,
 			shouldSkip: () => startupAuthState.cancelled,
 		})
+		// Terminal chrome extensions need an actual TUI, not just an extension UI protocol.
+		const terminalUiExtensionFactories = isTerminalUiMode(rawArgs, terminalIo)
+			? [terminalColorsExtension, kimchiMinimalTintsExtension, uiExtension]
+			: []
 		const extensionFactories = [
 			startupUpdateExtension,
 			sessionIdCaptureExtension,
 			shutdownMarkerExtension,
 			statsExtension,
-			terminalColorsExtension,
-			kimchiMinimalTintsExtension,
+			...terminalUiExtensionFactories,
 			loginExtension,
-			uiExtension,
 			startupAuthGate,
 			loopGuardExtension,
 			explorationGuardExtension,

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -400,11 +400,12 @@ try {
 		// Probe runs here (before pi-mono takes stdin) so the result is cached for
 		// the kimchi-minimal-tints and terminal-colors extensions. Skip non-TUI
 		// modes: stdout belongs to the caller, and OSC escapes corrupt it.
+		const rawArgs = stripExperimentalFeaturesArg(process.argv.slice(2))
 		const terminalIo = {
 			stdinIsTTY: process.stdin.isTTY === true,
 			stdoutIsTTY: process.stdout.isTTY === true,
 		}
-		const terminalStartupOutputAllowed = isTerminalUiMode(process.argv.slice(2), terminalIo)
+		const terminalStartupOutputAllowed = isTerminalUiMode(rawArgs, terminalIo)
 		if (terminalStartupOutputAllowed) {
 			await probeTerminalBackground()
 			await probeKittyKeyboardSupport()
@@ -464,7 +465,6 @@ try {
 			globalThis.fetch = patchedFetch
 		}
 
-		const rawArgs = stripExperimentalFeaturesArg(process.argv.slice(2))
 		const interactiveStartupContext = {
 			nonInteractiveMode: acpMode,
 			...terminalIo,

--- a/src/modes/acp/server.test.ts
+++ b/src/modes/acp/server.test.ts
@@ -24,6 +24,7 @@ import {
 	assertSessionHasModel,
 	buildSessionModelState,
 	describeToolCall,
+	initializeHeadlessTheme,
 	isHiddenToolCall,
 	shouldEmitThinking,
 	stripAnsi,
@@ -1179,6 +1180,27 @@ describe("assertSessionHasModel", () => {
 		expect(() =>
 			assertSessionHasModel({ model: {} as NonNullable<Parameters<typeof assertSessionHasModel>[0]["model"]> }),
 		).not.toThrow()
+	})
+})
+
+describe("initializeHeadlessTheme", () => {
+	const THEME_KEY = Symbol.for("@earendil-works/pi-coding-agent:theme")
+	const THEME_KEY_OLD = Symbol.for("@mariozechner/pi-coding-agent:theme")
+
+	it("initializes pi's global theme proxy for headless sessions", () => {
+		const globals = globalThis as Record<symbol, unknown>
+		delete globals[THEME_KEY]
+		delete globals[THEME_KEY_OLD]
+
+		expect(globals[THEME_KEY]).toBeUndefined()
+		expect(globals[THEME_KEY_OLD]).toBeUndefined()
+
+		initializeHeadlessTheme({ getTheme: () => "default" })
+
+		expect(globals[THEME_KEY]).toBeDefined()
+		expect(globals[THEME_KEY_OLD]).toBeDefined()
+		const initializedTheme = globals[THEME_KEY] as { getFgAnsi(color: string): string }
+		expect(() => initializedTheme.getFgAnsi("accent")).not.toThrow()
 	})
 })
 

--- a/src/modes/acp/server.test.ts
+++ b/src/modes/acp/server.test.ts
@@ -13,7 +13,11 @@ import type {
 	AgentSessionEventListener,
 	SessionInfo as PiSessionInfo,
 } from "@earendil-works/pi-coding-agent"
-import { afterEach, beforeEach, describe, expect, it } from "vitest"
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
+
+const THEME_KEY = Symbol.for("@earendil-works/pi-coding-agent:theme")
+const THEME_KEY_OLD = Symbol.for("@mariozechner/pi-coding-agent:theme")
+
 import { _resetState as _resetHideThinking, _setHideThinking } from "../../extensions/hide-thinking.js"
 import { getAcpPrompter } from "./permission-prompter-registry.js"
 import {
@@ -1184,13 +1188,17 @@ describe("assertSessionHasModel", () => {
 })
 
 describe("initializeHeadlessTheme", () => {
-	const THEME_KEY = Symbol.for("@earendil-works/pi-coding-agent:theme")
-	const THEME_KEY_OLD = Symbol.for("@mariozechner/pi-coding-agent:theme")
+	beforeEach(() => {
+		vi.stubGlobal(THEME_KEY, undefined)
+		vi.stubGlobal(THEME_KEY_OLD, undefined)
+	})
+
+	afterEach(() => {
+		vi.unstubAllGlobals()
+	})
 
 	it("initializes pi's global theme proxy for headless sessions", () => {
 		const globals = globalThis as Record<symbol, unknown>
-		delete globals[THEME_KEY]
-		delete globals[THEME_KEY_OLD]
 
 		expect(globals[THEME_KEY]).toBeUndefined()
 		expect(globals[THEME_KEY_OLD]).toBeUndefined()

--- a/src/modes/acp/server.ts
+++ b/src/modes/acp/server.ts
@@ -49,6 +49,7 @@ import {
 	SessionManager,
 	SettingsManager,
 	createAgentSession,
+	initTheme,
 } from "@earendil-works/pi-coding-agent"
 import { isHideThinkingEnabled } from "../../extensions/hide-thinking.js"
 import { createAcpPermissionPrompter } from "./acp-prompter.js"
@@ -800,6 +801,10 @@ export function assertSessionHasModel(session: Pick<AgentSession, "model">): voi
 	}
 }
 
+export function initializeHeadlessTheme(settingsManager: Pick<SettingsManager, "getTheme">): void {
+	initTheme(settingsManager.getTheme(), false)
+}
+
 async function bindAcpExtensions(session: AgentSession): Promise<void> {
 	await session.bindExtensions({
 		onError: (err) => {
@@ -1001,6 +1006,7 @@ function defaultSessionLoader(options: RunAcpOptions): AcpSessionLoader {
 			throw RequestError.invalidParams(undefined, `failed to open session: ${msg}`)
 		}
 		const settingsManager = SettingsManager.create(cwd, options.agentDir)
+		initializeHeadlessTheme(settingsManager)
 		const resourceLoader = new DefaultResourceLoader({
 			cwd,
 			agentDir: options.agentDir,
@@ -1023,6 +1029,7 @@ function defaultSessionFactory(options: RunAcpOptions): AcpSessionFactory {
 	return async (params: NewSessionRequest): Promise<AgentSession> => {
 		const cwd = params.cwd ?? process.cwd()
 		const settingsManager = SettingsManager.create(cwd, options.agentDir)
+		initializeHeadlessTheme(settingsManager)
 		const resourceLoader = new DefaultResourceLoader({
 			cwd,
 			agentDir: options.agentDir,


### PR DESCRIPTION
## Description

ACP creates AgentSession instances directly through the SDK, bypassing pi's main() bootstrap. Upstream initializes the global theme for every app mode and only enables watcher/interactive behavior for the terminal TUI, so ACP needs the same non-interactive initialization before extensions or renderers can touch ctx.ui.theme.

The fix keeps terminal chrome out of non-TUI modes instead of adding scattered guards. terminal-colors, kimchi-minimal-tints, and uiExtension are only registered when stdin/stdout are real TTYs and the invocation is not protocol or print mode. This avoids corrupting protocol streams while preserving the shared theme contract expected by pi's no-op UI context and tool/message renderers.

parseArgs from pi is used for pi-owned flags, while Kimchi keeps a raw scanner for --mode acp and --mode=... forms that the upstream parser does not currently represent. This keeps the dispatch predicate aligned with upstream without losing local ACP support.

## Type of Change

<!-- Select all that apply. -->

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
