### PR TITLE
fix(models): make kimchi-experimental auth work by writing resolved API key

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -72,7 +72,12 @@ import traceIdExtension from "./extensions/trace-id.js"
 import uiExtension from "./extensions/ui.js"
 import webFetchExtension from "./extensions/web-fetch/index.js"
 import webSearchExtension from "./extensions/web-search/index.js"
-import { injectExperimentalProvider, isTransientModelsError, updateModelsConfig } from "./models.js"
+import {
+	injectExperimentalProvider,
+	isTransientModelsError,
+	readExperimentalModels,
+	updateModelsConfig,
+} from "./models.js"
 import resourcesExtension from "./resources/extension.js"
 import { type ManagedExtensionFactory, enabledExtensionFactories } from "./resources/filter.js"
 import resourceToolBlockerExtension from "./resources/tool-blocker.js"
@@ -316,7 +321,10 @@ try {
 		let models: Awaited<ReturnType<typeof updateModelsConfig>>["models"]
 		try {
 			;({ models } = await updateModelsConfig(modelsJsonPath, currentApiKey))
-			if (experimentalFeatures) injectExperimentalProvider(modelsJsonPath)
+			if (experimentalFeatures) {
+				injectExperimentalProvider(modelsJsonPath, currentApiKey ?? "")
+				models = [...models, ...readExperimentalModels(modelsJsonPath)]
+			}
 		} catch (err) {
 			const is401 = err instanceof Error && err.message.includes("401")
 			if (is401 && process.stdin.isTTY) {
@@ -333,7 +341,10 @@ try {
 				writeApiKey(currentApiKey)
 				config = loadConfig()
 				;({ models } = await updateModelsConfig(modelsJsonPath, currentApiKey))
-				if (experimentalFeatures) injectExperimentalProvider(modelsJsonPath)
+				if (experimentalFeatures) {
+					injectExperimentalProvider(modelsJsonPath, currentApiKey)
+					models = [...models, ...readExperimentalModels(modelsJsonPath)]
+				}
 			} else if (isTransientModelsError(err)) {
 				// Rate limit / gateway error with no cached models to fall back on.
 				// Don't crash startup over a transient condition — continue with an

--- a/src/models.test.ts
+++ b/src/models.test.ts
@@ -2,7 +2,13 @@ import { existsSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "no
 import { tmpdir } from "node:os"
 import { join } from "node:path"
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
-import { ModelsFetchError, injectExperimentalProvider, isTransientModelsError, updateModelsConfig } from "./models.js"
+import {
+	ModelsFetchError,
+	injectExperimentalProvider,
+	isTransientModelsError,
+	readExperimentalModels,
+	updateModelsConfig,
+} from "./models.js"
 
 const KIMI: unknown = {
 	slug: "kimi-k2.5",
@@ -560,7 +566,7 @@ describe("readExistingProviders strips kimchi-experimental", () => {
 				providers: {
 					"kimchi-experimental": {
 						baseUrl: "https://llm.kimchi.dev/experimental/openai/v1",
-						apiKey: "KIMCHI_API_KEY",
+						apiKey: "some-key",
 						api: "openai-completions",
 						authHeader: true,
 						headers: {},
@@ -599,19 +605,19 @@ describe("injectExperimentalProvider", () => {
 
 	it("is a no-op when kimchi-dev is absent", () => {
 		writeFileSync(modelsJsonPath, JSON.stringify({ providers: {} }))
-		injectExperimentalProvider(modelsJsonPath)
+		injectExperimentalProvider(modelsJsonPath, "test-api-key")
 		const config = JSON.parse(readFileSync(modelsJsonPath, "utf-8"))
 		expect(config.providers["kimchi-experimental"]).toBeUndefined()
 	})
 
-	it("copies the kimchi-dev block with experimental baseUrl", async () => {
+	it("copies the kimchi-dev block with kimchi-experimental baseUrl", async () => {
 		vi.mocked(fetch).mockResolvedValueOnce({
 			ok: true,
 			json: async () => ({ models: [KIMI] }),
 		} as Response)
 		await updateModelsConfig(modelsJsonPath, "test-key")
 
-		injectExperimentalProvider(modelsJsonPath)
+		injectExperimentalProvider(modelsJsonPath, "test-api-key")
 
 		const config = JSON.parse(readFileSync(modelsJsonPath, "utf-8"))
 		const dev = config.providers["kimchi-dev"]
@@ -619,8 +625,7 @@ describe("injectExperimentalProvider", () => {
 
 		expect(exp).toBeDefined()
 		expect(exp.baseUrl).toBe("https://llm.kimchi.dev/experimental/openai/v1")
-		// Everything else is identical to kimchi-dev
-		expect(exp.apiKey).toBe(dev.apiKey)
+		expect(exp.apiKey).toBe("test-api-key")
 		expect(exp.api).toBe(dev.api)
 		expect(exp.authHeader).toBe(dev.authHeader)
 		expect(exp.models).toEqual(dev.models)
@@ -644,7 +649,7 @@ describe("injectExperimentalProvider", () => {
 			}),
 		)
 
-		injectExperimentalProvider(modelsJsonPath)
+		injectExperimentalProvider(modelsJsonPath, "test-api-key")
 
 		const config = JSON.parse(readFileSync(modelsJsonPath, "utf-8"))
 		expect(config.providers["my-custom"]).toBeDefined()
@@ -652,7 +657,45 @@ describe("injectExperimentalProvider", () => {
 	})
 
 	it("is a no-op when models.json does not exist", () => {
-		injectExperimentalProvider(modelsJsonPath)
+		injectExperimentalProvider(modelsJsonPath, "test-api-key")
 		expect(existsSync(modelsJsonPath)).toBe(false)
+	})
+})
+
+describe("readExperimentalModels", () => {
+	let tempDir: string
+	let modelsJsonPath: string
+
+	beforeEach(() => {
+		tempDir = mkdtempSync(join(tmpdir(), "kimchi-read-exp-test-"))
+		modelsJsonPath = join(tempDir, "models.json")
+		vi.stubGlobal("fetch", vi.fn())
+	})
+
+	afterEach(() => {
+		rmSync(tempDir, { recursive: true, force: true })
+		vi.restoreAllMocks()
+	})
+
+	it("returns empty array when models.json does not exist", () => {
+		expect(readExperimentalModels(modelsJsonPath)).toEqual([])
+	})
+
+	it("returns empty array when kimchi-experimental is absent", () => {
+		writeFileSync(modelsJsonPath, JSON.stringify({ providers: { "kimchi-dev": { models: [] } } }))
+		expect(readExperimentalModels(modelsJsonPath)).toEqual([])
+	})
+
+	it("returns ModelMetadata for each model in kimchi-experimental", async () => {
+		vi.mocked(fetch).mockResolvedValueOnce({
+			ok: true,
+			json: async () => ({ models: [KIMI] }),
+		} as Response)
+		await updateModelsConfig(modelsJsonPath, "test-key")
+		injectExperimentalProvider(modelsJsonPath, "test-api-key")
+
+		const result = readExperimentalModels(modelsJsonPath)
+		expect(result).toHaveLength(1)
+		expect(result[0].slug).toBe("kimi-k2.5")
 	})
 })

--- a/src/models.ts
+++ b/src/models.ts
@@ -251,7 +251,7 @@ export function syncProviderModels(
 	writeFileSync(modelsJsonPath, JSON.stringify(config, null, "\t"), "utf-8")
 }
 
-export function injectExperimentalProvider(modelsJsonPath: string): void {
+export function injectExperimentalProvider(modelsJsonPath: string, apiKey: string): void {
 	if (!existsSync(modelsJsonPath)) return
 	let config: { providers?: Record<string, unknown> }
 	try {
@@ -264,9 +264,22 @@ export function injectExperimentalProvider(modelsJsonPath: string): void {
 	const experimental = {
 		...(kimchiDev as Record<string, unknown>),
 		baseUrl: "https://llm.kimchi.dev/experimental/openai/v1",
+		apiKey,
 	}
 	config.providers = { ...config.providers, "kimchi-experimental": experimental }
 	writeFileSync(modelsJsonPath, JSON.stringify(config, null, "\t"), "utf-8")
+}
+
+export function readExperimentalModels(modelsJsonPath: string): ModelMetadata[] {
+	try {
+		const raw = readFileSync(modelsJsonPath, "utf-8")
+		const parsed = JSON.parse(raw)
+		const models = parsed?.providers?.["kimchi-experimental"]?.models
+		if (!Array.isArray(models) || models.length === 0) return []
+		return (models as PiModelConfig[]).map(modelToMetadata)
+	} catch {
+		return []
+	}
 }
 
 /**


### PR DESCRIPTION
## Summary

- The `kimchi-experimental` provider couldn't authenticate because `KIMCHI_API_KEY` is deleted from `process.env` before pi-mono runs, and the provider is not a registered OAuth provider so auth.json entries are ignored
- Fix: write the literal resolved API key value into the provider config in `models.json` instead of the `"$KIMCHI_API_KEY"` env var reference
- Also surfaces experimental models via `readExperimentalModels` so they appear in the in-memory model list passed to `setAvailableModels`

## Test Plan

- [ ] `pnpm test` passes (pre-existing teleport/startup-warning failures unrelated)
- [ ] Run `kimchi --enable-experimental-features` and confirm `/model` picker shows `kimchi-experimental` models without "Only showing models from configured providers" warning