### PR TITLE
feat: Add version number to exported session HTML

### DIFF
--- a/scripts/copy-resources.js
+++ b/scripts/copy-resources.js
@@ -10,7 +10,7 @@
 //                                   plus package.json → dist/share/kimchi/
 //                                   so the compiled binary resolves assets from the shared data directory
 
-import { cpSync, mkdirSync, readdirSync } from "node:fs"
+import { cpSync, mkdirSync, readFileSync, readdirSync, writeFileSync } from "node:fs"
 import { dirname, join } from "node:path"
 import { fileURLToPath } from "node:url"
 
@@ -42,6 +42,32 @@ cpSync(exportHtmlSrc, exportHtmlDest, {
 	recursive: true,
 	filter: (src) => !exportHtmlSkipSuffixes.some((suffix) => src.endsWith(suffix)),
 })
+
+// Post-process export HTML template to inject the kimchi version number.
+const pkg = JSON.parse(readFileSync(join(projectRoot, "package.json"), "utf-8"))
+// Match src/utils.ts getVersion() mapping (0.0.0 → "dev").
+const appVersion = pkg.version && pkg.version !== "0.0.0" ? pkg.version : "dev"
+// Inject a single inline script just before </body> that sets the version
+// and dynamically patches the DOM after renderHeader() has already run.
+// renderHeader() stays upstream code, so this survives template.js refactors.
+const templateHtmlPath = join(exportHtmlDest, "template.html")
+let templateHtml = readFileSync(templateHtmlPath, "utf-8")
+templateHtml = templateHtml.replace(
+	"</body>",
+	`<script>
+(function() {
+  window.__KIMCHI_VERSION = ${JSON.stringify(appVersion)};
+  const container = document.querySelector('.header-info');
+  if (!container) return;
+  const el = document.createElement('div');
+  el.className = 'info-item';
+  el.innerHTML = '<span class="info-label">Version:</span><span class="info-value">' + window.__KIMCHI_VERSION + '</span>';
+  container.appendChild(el);
+})();
+</script>
+</body>`,
+)
+writeFileSync(templateHtmlPath, templateHtml, "utf-8")
 
 // kimchi's own themes live outside node_modules — copy them alongside the upstream themes
 const kimchiThemesSrc = join(projectRoot, "themes")

--- a/tests/smoke/binary.test.ts
+++ b/tests/smoke/binary.test.ts
@@ -1,4 +1,4 @@
-import { constants, accessSync, copyFileSync, mkdtempSync, rmSync, statSync } from "node:fs"
+import { constants, accessSync, copyFileSync, mkdtempSync, readFileSync, rmSync, statSync } from "node:fs"
 import { tmpdir } from "node:os"
 import { join, resolve } from "node:path"
 import { afterEach, beforeEach, describe, expect, it } from "vitest"
@@ -111,6 +111,9 @@ describe("binary smoke tests", () => {
 			expect(result.stdout).toContain(outPath)
 			// Output must load the template + vendor bundle (marked + highlight ≈ 200KB), so 10KB is a safe regression floor.
 			expect(statSync(outPath).size).toBeGreaterThan(10_000)
+			const html = readFileSync(outPath, "utf-8")
+			expect(html).toContain('window.__KIMCHI_VERSION')
+			expect(html).toContain('class="info-label">Version:')
 		})
 	})
 


### PR DESCRIPTION
Inject the current kimchi version into exported session HTML template during the build step.

**Changes:**
- `scripts/copy-resources.js` — after copying upstream export templates, post-processes `template.html` to inject `window.__KIMCHI_VERSION` and a tiny script that dynamically patches the header to add the version row
- `tests/smoke/binary.test.ts` — asserts the exported HTML contains the version

The version is read from `package.json` and uses the same `0.0.0 → dev` mapping as the TUI header, so exported sessions display a consistent version string.

**Export sample:**

<img width="812" height="248" alt="Screenshot 2026-06-03 at 09 37 51" src="https://github.com/user-attachments/assets/0ecfb21c-cd45-40b4-9d3f-fcaee472e0ad" />
