### PR TITLE
fix(exploration-guard): reduce false positives and improve messaging

### DIFF
--- a/src/extensions/exploration-guard.test.ts
+++ b/src/extensions/exploration-guard.test.ts
@@ -37,6 +37,23 @@ function simulateMixedTurn(guard: ExplorationGuard): string[] {
 	return steers
 }
 
+function simulateNeutralTurn(guard: ExplorationGuard): string[] {
+	const steers: string[] = []
+	guard.turnStart()
+	guard.recordToolCall("set_phase")
+	guard.turnEnd((text) => steers.push(text))
+	return steers
+}
+
+function simulateNeutralPlusReadTurn(guard: ExplorationGuard): string[] {
+	const steers: string[] = []
+	guard.turnStart()
+	guard.recordToolCall("set_phase")
+	guard.recordToolCall("read")
+	guard.turnEnd((text) => steers.push(text))
+	return steers
+}
+
 describe("ExplorationGuard.reset", () => {
 	it("clears the streak", () => {
 		const guard = createGuard()
@@ -80,6 +97,20 @@ describe("Read-only turn counting", () => {
 		simulateNoToolTurn(guard)
 		expect(guard.getConsecutiveReadOnlyTurns()).toBe(0)
 	})
+
+	it("resets streak on a neutral tool turn", () => {
+		const guard = createGuard()
+		for (let i = 0; i < 3; i++) simulateReadTurn(guard)
+		simulateNeutralTurn(guard)
+		expect(guard.getConsecutiveReadOnlyTurns()).toBe(0)
+	})
+
+	it("counts a mixed neutral+read turn as read-only", () => {
+		const guard = createGuard()
+		for (let i = 0; i < 3; i++) simulateReadTurn(guard)
+		simulateNeutralPlusReadTurn(guard)
+		expect(guard.getConsecutiveReadOnlyTurns()).toBe(4)
+	})
 })
 
 describe("Threshold triggers", () => {
@@ -95,8 +126,8 @@ describe("Threshold triggers", () => {
 		guard.turnEnd((text) => steers.push(text))
 		expect(steers).toHaveLength(1)
 		expect(steers[0]).toContain("Exploration guard")
-		expect(steers[0]).toContain("5 consecutive turns")
-		expect(steers[0]).toContain("hypothesis")
+		expect(steers[0]).toContain("5 consecutive read-only turns")
+		expect(steers[0]).toContain("concrete action")
 	})
 
 	it("emits a mandatory steer at the default steer threshold (8)", () => {
@@ -114,8 +145,8 @@ describe("Threshold triggers", () => {
 		guard.recordToolCall("find")
 		guard.turnEnd((text) => steers.push(text))
 		expect(steers).toHaveLength(2)
-		expect(steers[1]).toContain("8 consecutive turns")
-		expect(steers[1]).toContain("MUST")
+		expect(steers[1]).toContain("8 consecutive read-only turns")
+		expect(steers[1]).toContain("concrete action")
 	})
 
 	it("uses custom thresholds", () => {
@@ -131,7 +162,7 @@ describe("Threshold triggers", () => {
 		guard.recordToolCall("ls")
 		guard.turnEnd((text) => steers.push(text))
 		expect(steers).toHaveLength(1)
-		expect(steers[0]).toContain("2 consecutive turns")
+		expect(steers[0]).toContain("2 consecutive read-only turns")
 
 		guard.turnStart()
 		guard.recordToolCall("ls")
@@ -142,19 +173,53 @@ describe("Threshold triggers", () => {
 		guard.recordToolCall("ls")
 		guard.turnEnd((text) => steers.push(text))
 		expect(steers).toHaveLength(2)
-		expect(steers[1]).toContain("4 consecutive turns")
+		expect(steers[1]).toContain("4 consecutive read-only turns")
 	})
 
-	it("does not trigger twice on the same threshold", () => {
+	it("each threshold fires once per streak; mandatory steer resets the counter", () => {
+		// 5 turns → hypothesis steer (no reset, counter stays at 5)
+		// 8 turns → mandatory steer + reset (counter back to 0)
+		// 5 more turns → hypothesis steer again in the new streak
 		const guard = createGuard()
 		const steers: string[] = []
-		for (let i = 0; i < 10; i++) {
+		const readTurn = () => {
 			guard.turnStart()
 			guard.recordToolCall("read")
 			guard.turnEnd((text) => steers.push(text))
 		}
-		expect(steers.filter((s) => s.includes("5 consecutive turns"))).toHaveLength(1)
-		expect(steers.filter((s) => s.includes("8 consecutive turns"))).toHaveLength(1)
+
+		for (let i = 0; i < 8; i++) readTurn()
+		expect(steers).toHaveLength(2)
+		expect(steers[0]).toContain("5 consecutive read-only turns")
+		expect(steers[1]).toContain("8 consecutive read-only turns")
+		expect(guard.getConsecutiveReadOnlyTurns()).toBe(0)
+
+		for (let i = 0; i < 5; i++) readTurn() // new streak after reset
+		expect(steers).toHaveLength(3)
+		expect(steers[2]).toContain("5 consecutive read-only turns")
+	})
+
+	it("resets counter after mandatory steer fires", () => {
+		const guard = createGuard({ hypothesisThreshold: 99 }) // skip hypothesis steer
+		const steers: string[] = []
+
+		for (let i = 0; i < 8; i++) {
+			guard.turnStart()
+			guard.recordToolCall("read")
+			guard.turnEnd((text) => steers.push(text))
+		}
+		expect(steers).toHaveLength(1)
+		expect(steers[0]).toContain("concrete action")
+		expect(guard.getConsecutiveReadOnlyTurns()).toBe(0)
+
+		// Subsequent read turns start a fresh streak
+		for (let i = 0; i < 4; i++) {
+			guard.turnStart()
+			guard.recordToolCall("read")
+			guard.turnEnd(() => {})
+		}
+		expect(guard.getConsecutiveReadOnlyTurns()).toBe(4)
+		expect(steers).toHaveLength(1)
 	})
 
 	it("does not trigger when isEnabled returns false", () => {
@@ -179,7 +244,7 @@ describe("Threshold triggers", () => {
 			const steers = simulateReadTurn(guard)
 			if (i === 4) {
 				expect(steers).toHaveLength(1)
-				expect(steers[0]).toContain("5 consecutive turns")
+				expect(steers[0]).toContain("5 consecutive read-only turns")
 			}
 		}
 	})
@@ -208,6 +273,41 @@ describe("Custom tool classification", () => {
 		guard.recordToolCall("custom_write")
 		guard.turnEnd(() => {})
 		expect(guard.getConsecutiveReadOnlyTurns()).toBe(0)
+	})
+})
+
+describe("bash tool classification", () => {
+	it("bash alone does not count as a read-only turn", () => {
+		const guard = createGuard()
+		for (let i = 0; i < 3; i++) {
+			guard.turnStart()
+			guard.recordToolCall("bash")
+			guard.turnEnd(() => {})
+		}
+		expect(guard.getConsecutiveReadOnlyTurns()).toBe(0)
+	})
+
+	it("bash resets a read-only streak", () => {
+		const guard = createGuard()
+		for (let i = 0; i < 3; i++) {
+			guard.turnStart()
+			guard.recordToolCall("read")
+			guard.turnEnd(() => {})
+		}
+		expect(guard.getConsecutiveReadOnlyTurns()).toBe(3)
+		guard.turnStart()
+		guard.recordToolCall("bash")
+		guard.turnEnd(() => {})
+		expect(guard.getConsecutiveReadOnlyTurns()).toBe(0)
+	})
+
+	it("bash combined with a read tool still counts as read-only", () => {
+		const guard = createGuard()
+		guard.turnStart()
+		guard.recordToolCall("bash")
+		guard.recordToolCall("read")
+		guard.turnEnd(() => {})
+		expect(guard.getConsecutiveReadOnlyTurns()).toBe(1)
 	})
 })
 

--- a/src/extensions/exploration-guard.test.ts
+++ b/src/extensions/exploration-guard.test.ts
@@ -248,6 +248,31 @@ describe("Threshold triggers", () => {
 			}
 		}
 	})
+
+	it("resets streak while disabled so it does not fire immediately on re-enable", () => {
+		// Simulates: 4 read turns → guard disabled (e.g. scoping starts) →
+		// 3 more read turns while disabled → guard re-enabled → should need
+		// a full 5 turns before firing, not just 1.
+		let enabled = true
+		const guard = createGuard({ isEnabled: () => enabled })
+
+		for (let i = 0; i < 4; i++) simulateReadTurn(guard)
+		expect(guard.getConsecutiveReadOnlyTurns()).toBe(4)
+
+		enabled = false
+		for (let i = 0; i < 3; i++) simulateReadTurn(guard)
+		expect(guard.getConsecutiveReadOnlyTurns()).toBe(0)
+
+		enabled = true
+		const steers: string[] = []
+		for (let i = 0; i < 4; i++) {
+			guard.turnStart()
+			guard.recordToolCall("read")
+			guard.turnEnd((text) => steers.push(text))
+		}
+		expect(steers).toHaveLength(0) // streak only at 4, not yet at 5
+		expect(guard.getConsecutiveReadOnlyTurns()).toBe(4)
+	})
 })
 
 describe("Custom tool classification", () => {

--- a/src/extensions/exploration-guard.ts
+++ b/src/extensions/exploration-guard.ts
@@ -126,9 +126,8 @@ export default function explorationGuardExtension(pi: ExtensionAPI, options?: Ex
 			try {
 				// Avoid a hard import cycle: ferment state is optional.
 				// eslint-disable-next-line @typescript-eslint/no-require-imports
-				const { isScopingInteractive, getActiveFermentId } = require("./ferment/state.js") as typeof import(
-					"./ferment/state.js",
-				)
+				const s: typeof import("./ferment/state.js") = require("./ferment/state.js")
+				const { isScopingInteractive, getActiveFermentId } = s
 				const fermentId = getActiveFermentId()
 				if (fermentId && isScopingInteractive(fermentId)) return false
 				// Keep guard active during ferment execution phases — scoping is done.

--- a/src/extensions/exploration-guard.ts
+++ b/src/extensions/exploration-guard.ts
@@ -126,7 +126,9 @@ export default function explorationGuardExtension(pi: ExtensionAPI, options?: Ex
 			try {
 				// Avoid a hard import cycle: ferment state is optional.
 				// eslint-disable-next-line @typescript-eslint/no-require-imports
-				const { hasActiveFerment, isScopingInteractive, getActiveFermentId } = require("./ferment/state.js") as typeof import("./ferment/state.js")
+				const { isScopingInteractive, getActiveFermentId } = require("./ferment/state.js") as typeof import(
+					"./ferment/state.js",
+				)
 				const fermentId = getActiveFermentId()
 				if (fermentId && isScopingInteractive(fermentId)) return false
 				// Keep guard active during ferment execution phases — scoping is done.

--- a/src/extensions/exploration-guard.ts
+++ b/src/extensions/exploration-guard.ts
@@ -11,11 +11,15 @@ export const DEFAULT_READ_TOOLS = new Set([
 	"lsp_definition",
 	"lsp_references",
 	"lsp_diagnostics",
-	"bash",
+	// bash is intentionally excluded: it is used for execution (tests, git ops,
+	// builds) as often as for inspection, so classifying it as read-only causes
+	// too many false positives on legitimate work turns.
 	"mcp",
 ])
 
 export const DEFAULT_WRITE_TOOLS = new Set(["edit", "write", "lsp_rename", "ask_user", "steer_subagent", "Agent"])
+
+export const DEFAULT_NEUTRAL_TOOLS = new Set(["set_phase", "set_model"])
 
 export interface ExplorationGuardOptions {
 	/** Tools that count as read-only (default: common inspection tools). */
@@ -31,10 +35,10 @@ export interface ExplorationGuardOptions {
 }
 
 const HYPOTHESIS_REMINDER_BASE =
-	"Exploration guard: you have spent %d consecutive turns reading without formulating a concrete hypothesis. State your hypothesis and run ONE targeted command to test it. Reading without a hypothesis wastes tokens."
+	"Exploration guard: %d consecutive read-only turns. If you have a clear hypothesis, test it with one targeted command. If you are building context before writing or planning, consider whether you have enough — and if so, take the next concrete action."
 
 const MANDATORY_STEER_BASE =
-	"Exploration guard: you have spent %d consecutive turns in read-only exploration. You MUST either (1) state a concrete hypothesis and test it with a single targeted command, or (2) transition to the plan phase. Do not continue reading without a hypothesis."
+	"Exploration guard: %d consecutive read-only turns. You must take a concrete action this turn: run a targeted test, make an edit, write a plan, or ask the user a question. Do not read further without a clear reason."
 
 export const STEER_MESSAGE_TYPE = "exploration-guard-steer"
 
@@ -48,6 +52,7 @@ export class ExplorationGuard {
 	private consecutiveReadOnlyTurns = 0
 	private currentTurnHasWriteTool = false
 	private currentTurnHasAnyTool = false
+	private currentTurnHasReadTool = false
 
 	constructor(options: ExplorationGuardOptions = {}) {
 		this.readTools = options.readTools ?? new Set(DEFAULT_READ_TOOLS)
@@ -61,11 +66,13 @@ export class ExplorationGuard {
 		this.consecutiveReadOnlyTurns = 0
 		this.currentTurnHasWriteTool = false
 		this.currentTurnHasAnyTool = false
+		this.currentTurnHasReadTool = false
 	}
 
 	turnStart(): void {
 		this.currentTurnHasWriteTool = false
 		this.currentTurnHasAnyTool = false
+		this.currentTurnHasReadTool = false
 	}
 
 	recordToolCall(toolName: string): void {
@@ -73,15 +80,18 @@ export class ExplorationGuard {
 		if (this.writeTools.has(toolName)) {
 			this.currentTurnHasWriteTool = true
 		}
+		if (this.readTools.has(toolName)) {
+			this.currentTurnHasReadTool = true
+		}
 	}
 
 	turnEnd(sendSteer: (text: string) => void): void {
 		if (!this.isEnabled()) return
 
-		// A turn is read-only only if it contains at least one tool and none
-		// of them are write tools. Turns with no tools or with write tools
-		// reset the streak.
-		if (!this.currentTurnHasAnyTool || this.currentTurnHasWriteTool) {
+		// A turn is read-only only if it contains at least one read tool and none
+		// of them are write tools. Turns with no tools, with write tools, or with
+		// only neutral tools reset the streak.
+		if (!this.currentTurnHasAnyTool || this.currentTurnHasWriteTool || !this.currentTurnHasReadTool) {
 			this.consecutiveReadOnlyTurns = 0
 			return
 		}
@@ -90,9 +100,14 @@ export class ExplorationGuard {
 
 		if (this.consecutiveReadOnlyTurns === this.hypothesisThreshold) {
 			sendSteer(HYPOTHESIS_REMINDER_BASE.replace("%d", String(this.hypothesisThreshold)))
+			// Don't reset yet — the model gets a chance to course-correct before
+			// the mandatory steer fires at steerThreshold.
 		}
 		if (this.consecutiveReadOnlyTurns === this.steerThreshold) {
 			sendSteer(MANDATORY_STEER_BASE.replace("%d", String(this.steerThreshold)))
+			// Reset after the mandatory steer so the model gets a fresh budget
+			// rather than immediately re-triggering on the next read turn.
+			this.consecutiveReadOnlyTurns = 0
 		}
 	}
 
@@ -104,7 +119,22 @@ export class ExplorationGuard {
 export default function explorationGuardExtension(pi: ExtensionAPI, options?: ExplorationGuardOptions): void {
 	const guard = new ExplorationGuard({
 		...options,
-		isEnabled: () => process.env.KIMCHI_PERMISSIONS !== "plan",
+		// Disabled during plan-permission mode (e.g. ferment build phase) and
+		// during active ferment scoping — both contexts mandate deep exploration.
+		isEnabled: () => {
+			if (process.env.KIMCHI_PERMISSIONS === "plan") return false
+			try {
+				// Avoid a hard import cycle: ferment state is optional.
+				// eslint-disable-next-line @typescript-eslint/no-require-imports
+				const { hasActiveFerment, isScopingInteractive, getActiveFermentId } = require("./ferment/state.js") as typeof import("./ferment/state.js")
+				const fermentId = getActiveFermentId()
+				if (fermentId && isScopingInteractive(fermentId)) return false
+				// Keep guard active during ferment execution phases — scoping is done.
+			} catch {
+				// ferment state module unavailable — ignore
+			}
+			return true
+		},
 	})
 
 	pi.on("session_start", () => {

--- a/src/extensions/exploration-guard.ts
+++ b/src/extensions/exploration-guard.ts
@@ -11,9 +11,11 @@ export const DEFAULT_READ_TOOLS = new Set([
 	"lsp_definition",
 	"lsp_references",
 	"lsp_diagnostics",
-	// bash is intentionally excluded: it is used for execution (tests, git ops,
-	// builds) as often as for inspection, so classifying it as read-only causes
-	// too many false positives on legitimate work turns.
+	// bash is intentionally excluded from the default read set. It is used for
+	// execution (tests, git ops, builds) as often as for inspection (git diff,
+	// git log, grep). The false positives it caused on work turns outweigh the
+	// missed detections. Callers who want bash to count can pass a custom
+	// readTools set that includes it.
 	"mcp",
 ])
 
@@ -86,7 +88,12 @@ export class ExplorationGuard {
 	}
 
 	turnEnd(sendSteer: (text: string) => void): void {
-		if (!this.isEnabled()) return
+		if (!this.isEnabled()) {
+			// Reset the streak while the guard is suppressed so it doesn't
+			// fire immediately when it becomes re-enabled (e.g. after scoping).
+			this.consecutiveReadOnlyTurns = 0
+			return
+		}
 
 		// A turn is read-only only if it contains at least one read tool and none
 		// of them are write tools. Turns with no tools, with write tools, or with


### PR DESCRIPTION
## Problem

Investigated a real session ([issue.jsonl](https://github.com/getkimchi/kimchi/)) where the exploration guard fired **three times** — including once during active step execution (creating a git worktree with `bash`). The guard also fired on me twice while investigating this issue, which is a perfect reproduction.

## Root causes

### 1. Neutral tools counted as read-only
Any tool not in `writeTools` incremented the streak, even tools that are neither read nor write: `set_phase`, `propose_ferment_scoping`, `activate_ferment_phase`, `start_ferment_step`. The very first turn of a scoping session called `set_phase` and was immediately counted as turn 1 of an exploration streak.

### 2. `bash` in `DEFAULT_READ_TOOLS`
`bash` is used for execution (git ops, test runs, builds) as much as inspection. In the session, `git worktree add` and `git branch` counted as exploration turns, causing the guard to fire mid-execution.

### 3. No reset after mandatory steer
After the hard steer fired at turn 8, the counter kept climbing silently, causing immediate re-triggers on the next streak.

### 4. Guard active during ferment scoping
The scoping nudge explicitly instructs the model to do deep exploration. The guard firing during scoping is always a false positive.

### 5. Steer messages used wrong framing
"Hypothesis" is a scientific framing that doesn't fit planning/build work. "YOU MUST (1) or (2)" forced binary choices that didn't apply, causing agents to take the nearest exit (premature `propose_ferment_scoping`) rather than finishing their thought.

## Changes

**`exploration-guard.ts`**
- Remove `bash` from `DEFAULT_READ_TOOLS` — bash-only turns reset the streak; bash mixed with a read tool still counts
- Track `currentTurnHasReadTool`: a turn only counts as read-only if it uses at least one tool from `readTools`. Neutral-only turns reset the streak.
- Suppress guard when `isScopingInteractive(fermentId)` is true
- Reset counter to 0 after the mandatory steer fires
- Reword both messages: drop "hypothesis"/"wastes tokens"/"YOU MUST", replace with phase-neutral "take a concrete action" framing
- Export `DEFAULT_NEUTRAL_TOOLS` as documentation

**`exploration-guard.test.ts`**
- 21 tests (up from 14)
- New: bash classification (alone resets, resets a streak, mixed with read still counts)
- New: neutral tool streak behaviour
- New: per-threshold reset semantics
- Updated: all threshold/wording assertions to match new behaviour