### PR TITLE
Add Kimchi API key login flow

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -315,7 +315,7 @@ try {
 		let currentApiKey = apiKey
 		let models: Awaited<ReturnType<typeof updateModelsConfig>>["models"]
 		try {
-			;({ models } = await updateModelsConfig(modelsJsonPath, currentApiKey))
+			;({ models } = await updateModelsConfig(modelsJsonPath, currentApiKey, { endpoint: config.llmEndpoint }))
 			if (experimentalFeatures) injectExperimentalProvider(modelsJsonPath)
 		} catch (err) {
 			const is401 = err instanceof Error && err.message.includes("401")

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -265,7 +265,7 @@ try {
 		let currentApiKey = apiKey
 		let models: Awaited<ReturnType<typeof updateModelsConfig>>["models"]
 		try {
-			;({ models } = await updateModelsConfig(modelsJsonPath, currentApiKey, { endpoint: config.llmEndpoint }))
+			;({ models } = await updateModelsConfig(modelsJsonPath, currentApiKey, { endpoint: config.customLlmEndpoint }))
 			if (experimentalFeatures) {
 				injectExperimentalProvider(modelsJsonPath, currentApiKey ?? "")
 				models = [...models, ...readExperimentalModels(modelsJsonPath)]
@@ -285,7 +285,7 @@ try {
 				currentApiKey = wizardResult.apiKey ?? ""
 				writeApiKey(currentApiKey)
 				config = loadConfig()
-				;({ models } = await updateModelsConfig(modelsJsonPath, currentApiKey, { endpoint: config.llmEndpoint }))
+				;({ models } = await updateModelsConfig(modelsJsonPath, currentApiKey, { endpoint: config.customLlmEndpoint }))
 				if (experimentalFeatures) {
 					injectExperimentalProvider(modelsJsonPath, currentApiKey)
 					models = [...models, ...readExperimentalModels(modelsJsonPath)]

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -332,7 +332,7 @@ try {
 				currentApiKey = wizardResult.apiKey ?? ""
 				writeApiKey(currentApiKey)
 				config = loadConfig()
-				;({ models } = await updateModelsConfig(modelsJsonPath, currentApiKey))
+				;({ models } = await updateModelsConfig(modelsJsonPath, currentApiKey, { endpoint: config.llmEndpoint }))
 				if (experimentalFeatures) injectExperimentalProvider(modelsJsonPath)
 			} else if (isTransientModelsError(err)) {
 				// Rate limit / gateway error with no cached models to fall back on.

--- a/src/config.test.ts
+++ b/src/config.test.ts
@@ -127,6 +127,19 @@ describe("loadConfig", () => {
 		rmSync(projectDir, { recursive: true, force: true })
 	})
 
+	it("customLlmEndpoint is undefined when no endpoint is saved", () => {
+		writeFileSync(configPath, JSON.stringify({ apiKey: "my-key" }))
+		const config = loadConfig({ configPath })
+		expect(config.customLlmEndpoint).toBeUndefined()
+	})
+
+	it("customLlmEndpoint returns the saved value when explicitly configured", () => {
+		writeFileSync(configPath, JSON.stringify({ apiKey: "my-key", llmEndpoint: "https://custom.example" }))
+		const config = loadConfig({ configPath })
+		expect(config.customLlmEndpoint).toBe("https://custom.example")
+		expect(config.llmEndpoint).toBe("https://custom.example")
+	})
+
 	it("project llmEndpoint overrides global", () => {
 		const globalDir = mkdtempSync(join(tmpdir(), "kimchi-test-"))
 		const projectDir = mkdtempSync(join(tmpdir(), "kimchi-test-"))

--- a/src/config.test.ts
+++ b/src/config.test.ts
@@ -278,6 +278,13 @@ describe("writeApiKey", () => {
 		const raw = readFileSync(configPath, "utf-8")
 		expect(JSON.parse(raw).apiKey).toBe("second")
 	})
+
+	it("can persist the Kimchi API endpoint with the API key", () => {
+		writeApiKey("sekrit-42", configPath, { llmEndpoint: " https://custom.kimchi.example " })
+		const raw = JSON.parse(readFileSync(configPath, "utf-8"))
+		expect(raw.apiKey).toBe("sekrit-42")
+		expect(raw.llmEndpoint).toBe("https://custom.kimchi.example")
+	})
 })
 
 describe("clearApiKey", () => {

--- a/src/config.test.ts
+++ b/src/config.test.ts
@@ -285,6 +285,14 @@ describe("writeApiKey", () => {
 		expect(raw.apiKey).toBe("sekrit-42")
 		expect(raw.llmEndpoint).toBe("https://custom.kimchi.example")
 	})
+
+	it("clears llmEndpoint when no endpoint is provided (prevents stale endpoint after browser login)", () => {
+		writeFileSync(configPath, JSON.stringify({ apiKey: "old-key", llmEndpoint: "https://custom.example" }))
+		writeApiKey("new-browser-token", configPath)
+		const raw = JSON.parse(readFileSync(configPath, "utf-8"))
+		expect(raw.apiKey).toBe("new-browser-token")
+		expect(raw.llmEndpoint).toBeUndefined()
+	})
 })
 
 describe("clearApiKey", () => {

--- a/src/config.ts
+++ b/src/config.ts
@@ -87,6 +87,8 @@ export interface KimchiConfig {
 	apiKey: string
 	agentConfigDir: string
 	llmEndpoint: string
+	/** The user-configured endpoint, undefined if not explicitly set. Use this when passing to updateModelsConfig. */
+	customLlmEndpoint: string | undefined
 	maxToolResultChars: number
 	mcpSearchLimit: number
 	mcpSearch: SearchStrategyConfig
@@ -345,6 +347,7 @@ export function loadConfig(options?: { configPath?: string; cwd?: string }): Kim
 		apiKey: extras.apiKey ?? "",
 		agentConfigDir: AGENT_CONFIG_DIR,
 		llmEndpoint: extras.llmEndpoint ?? CAST_AI_LLM_ENDPOINT,
+		customLlmEndpoint: extras.llmEndpoint,
 		maxToolResultChars: extras.maxToolResultChars ?? 10_000,
 		mcpSearchLimit: extras.mcpSearchLimit ?? 5,
 		mcpSearch: { ...SEARCH_STRATEGY_DEFAULTS, ...extras.mcpSearch },

--- a/src/config.ts
+++ b/src/config.ts
@@ -467,7 +467,12 @@ export function writeApiKey(key: string, configPath?: string, options: WriteApiK
 	updateConfigFile(path, (raw) => {
 		raw.apiKey = key
 		const llmEndpoint = options.llmEndpoint?.trim()
-		if (llmEndpoint) raw.llmEndpoint = llmEndpoint
+		if (llmEndpoint) {
+			raw.llmEndpoint = llmEndpoint
+		} else {
+			// biome-ignore lint/performance/noDelete: explicit removal is clearer than relying on JSON.stringify to silently drop undefined values
+			delete raw.llmEndpoint
+		}
 		// Clear legacy snake_case key so we don't keep stale data
 		// biome-ignore lint/performance/noDelete: explicit removal is clearer than relying on JSON.stringify to silently drop undefined values
 		delete raw.api_key

--- a/src/config.ts
+++ b/src/config.ts
@@ -458,10 +458,16 @@ export function writeSkillPaths(paths: string[], configPath?: string): void {
 	writeConfigField("skillPaths", paths, configPath ?? KIMCHI_CONFIG_PATH)
 }
 
-export function writeApiKey(key: string, configPath?: string): void {
+export interface WriteApiKeyOptions {
+	llmEndpoint?: string
+}
+
+export function writeApiKey(key: string, configPath?: string, options: WriteApiKeyOptions = {}): void {
 	const path = configPath ?? KIMCHI_CONFIG_PATH
 	updateConfigFile(path, (raw) => {
 		raw.apiKey = key
+		const llmEndpoint = options.llmEndpoint?.trim()
+		if (llmEndpoint) raw.llmEndpoint = llmEndpoint
 		// Clear legacy snake_case key so we don't keep stale data
 		// biome-ignore lint/performance/noDelete: explicit removal is clearer than relying on JSON.stringify to silently drop undefined values
 		delete raw.api_key

--- a/src/entry.ts
+++ b/src/entry.ts
@@ -44,6 +44,7 @@ if (existsSync(oauthTemplateDir)) {
 
 const agentDir = resolve(homedir(), ".config", "kimchi", "harness")
 process.env.KIMCHI_CODING_AGENT_DIR = agentDir
+process.env.PI_CODING_AGENT_DIR = agentDir
 
 process.title = "kimchi"
 process.env.PI_SKIP_VERSION_CHECK = "1"

--- a/src/extensions/login/flow.ts
+++ b/src/extensions/login/flow.ts
@@ -222,7 +222,6 @@ async function configureKimchiToken(
 	try {
 		await refreshKimchiModels(token, endpoint, {
 			allowCachedFallback: !options.strictFreshDiscovery,
-			requireActiveModels: options.strictFreshDiscovery,
 		})
 	} catch (error) {
 		refreshError = error

--- a/src/extensions/login/flow.ts
+++ b/src/extensions/login/flow.ts
@@ -16,7 +16,9 @@ import { type PiModelConfig, isTransientModelsError, syncProviderModels, updateM
 export const KIMCHI_PROVIDER_ID = "kimchi-dev"
 export const KIMCHI_DEFAULT_MODEL_ID = "kimi-k2.6"
 export const KIMCHI_ACCOUNT_LABEL = "Use a Kimchi account"
+export const KIMCHI_API_KEY_LABEL = "Use a Kimchi API key"
 export const SUBSCRIPTION_LABEL = "Use a subscription"
+export const KIMCHI_DEFAULT_ENDPOINT = "https://llm.kimchi.dev"
 
 let browserLoginLinkSeq = 0
 
@@ -63,6 +65,7 @@ type AuthSelectorProvider = ConstructorParameters<typeof OAuthSelectorComponent>
 interface AuthStorageLike {
 	set(provider: string, credential: unknown): void
 	get(provider: string): unknown
+	remove?(provider: string): void
 }
 
 interface ProviderModelLike {
@@ -79,15 +82,23 @@ interface ModelRegistryLike<TModel extends ProviderModelLike = ProviderModelLike
 
 export function createLoginChoiceSelector(options: {
 	onKimchiAccount: () => void
+	onKimchiApiKey?: () => void
 	onSubscription: () => void
 	onCancel: () => void
 }): ExtensionSelectorComponent {
+	const labels = options.onKimchiApiKey
+		? [KIMCHI_ACCOUNT_LABEL, KIMCHI_API_KEY_LABEL, SUBSCRIPTION_LABEL]
+		: [KIMCHI_ACCOUNT_LABEL, SUBSCRIPTION_LABEL]
 	return new ExtensionSelectorComponent(
 		"Select authentication method:",
-		[KIMCHI_ACCOUNT_LABEL, SUBSCRIPTION_LABEL],
+		labels,
 		(option) => {
 			if (option === SUBSCRIPTION_LABEL) {
 				options.onSubscription()
+				return
+			}
+			if (option === KIMCHI_API_KEY_LABEL && options.onKimchiApiKey) {
+				options.onKimchiApiKey()
 				return
 			}
 			options.onKimchiAccount()
@@ -131,10 +142,14 @@ export async function prePopulateSubscriptionModels(providerId: string): Promise
 	})
 }
 
-async function refreshKimchiModels(token: string): Promise<void> {
+async function refreshKimchiModels(
+	token: string,
+	endpoint?: string,
+	options: { allowCachedFallback?: boolean; requireActiveModels?: boolean } = {},
+): Promise<void> {
 	const agentDir = process.env.KIMCHI_CODING_AGENT_DIR
 	if (!agentDir) return
-	await updateModelsConfig(resolve(agentDir, "models.json"), token)
+	await updateModelsConfig(resolve(agentDir, "models.json"), token, { endpoint, ...options })
 }
 
 export function setKimchiAuthToken(
@@ -173,14 +188,52 @@ export interface KimchiBrowserLoginOptions {
 	reuseExistingToken?: boolean
 }
 
-async function configureKimchiToken(host: KimchiBrowserLoginHost, token: string): Promise<boolean> {
+export interface KimchiApiKeyLoginOptions {
+	apiKey: string
+	endpoint: string
+}
+
+function restoreKimchiAuth(modelRegistry: ModelRegistryLike, previousCredential: unknown): void {
+	if (previousCredential !== undefined) {
+		modelRegistry.authStorage.set(KIMCHI_PROVIDER_ID, previousCredential)
+		return
+	}
+	modelRegistry.authStorage.remove?.(KIMCHI_PROVIDER_ID)
+}
+
+function formatKimchiTokenError(error: unknown, options: { saved: boolean }): string {
+	const detail = error instanceof Error ? error.message : String(error)
+	const savedSuffix = options.saved
+		? " Your API key was saved; wait a moment and try again."
+		: " No changes were saved."
+	if (isTransientModelsError(error)) {
+		return `Kimchi endpoint is unreachable or temporarily unavailable (${detail}). Check the endpoint and try again.${savedSuffix}`
+	}
+	return `Kimchi model refresh failed: ${detail}.${savedSuffix}`
+}
+
+async function configureKimchiToken(
+	host: KimchiBrowserLoginHost,
+	token: string,
+	endpoint?: string,
+	options: { strictFreshDiscovery?: boolean; persistConfig?: () => void } = {},
+): Promise<boolean> {
 	let refreshError: unknown
 	try {
-		await refreshKimchiModels(token)
+		await refreshKimchiModels(token, endpoint, {
+			allowCachedFallback: !options.strictFreshDiscovery,
+			requireActiveModels: options.strictFreshDiscovery,
+		})
 	} catch (error) {
 		refreshError = error
 	}
 
+	if (refreshError && options.strictFreshDiscovery) {
+		host.showError?.(formatKimchiTokenError(refreshError, { saved: false }))
+		return false
+	}
+
+	const previousCredential = host.modelRegistry.authStorage.get(KIMCHI_PROVIDER_ID)
 	setKimchiAuthToken(host.modelRegistry, token)
 	try {
 		host.modelRegistry.refresh()
@@ -195,28 +248,48 @@ async function configureKimchiToken(host: KimchiBrowserLoginHost, token: string)
 		refreshError ??= error
 	}
 	if (providerModels.length > 0) {
+		options.persistConfig?.()
 		const selectedModel = providerModels.find((m) => m.id === KIMCHI_DEFAULT_MODEL_ID) ?? providerModels[0]
 		await host.setModel?.(selectedModel)
 		host.addFeedback?.(formatKimchiLoginSuccessMessage(selectedModel.id))
 		return true
 	}
 
+	if (options.strictFreshDiscovery) {
+		restoreKimchiAuth(host.modelRegistry, previousCredential)
+		host.showError?.("Kimchi API-key login found no available Kimchi models. No changes were saved.")
+		return false
+	}
+
 	if (refreshError) {
-		const detail = refreshError instanceof Error ? refreshError.message : String(refreshError)
-		if (isTransientModelsError(refreshError)) {
-			// Key is valid; the model list is just temporarily unreachable (rate limit,
-			// gateway error). Tell the user to wait and retry rather than implying the
-			// login failed — and the saved key means a retry won't mint a new one.
-			host.showError?.(
-				`Kimchi is temporarily unavailable (${detail}). Your API key was saved — wait a moment and try again.`,
-			)
-		} else {
-			host.showError?.(`Kimchi model refresh failed: ${detail}`)
-		}
+		host.showError?.(formatKimchiTokenError(refreshError, { saved: true }))
 	} else {
 		host.showError?.("Kimchi login did not configure any available models. Your API key was saved; try again.")
 	}
 	return false
+}
+
+export async function performKimchiApiKeyLogin(
+	host: KimchiBrowserLoginHost,
+	options: KimchiApiKeyLoginOptions,
+): Promise<boolean> {
+	const token = options.apiKey.trim()
+	const endpoint = options.endpoint.trim() || KIMCHI_DEFAULT_ENDPOINT
+	if (!token) {
+		host.showError?.("Kimchi API key is required.")
+		return false
+	}
+
+	try {
+		host.showStatus?.(`Refreshing Kimchi models from ${endpoint}...`)
+		return configureKimchiToken(host, token, endpoint, {
+			strictFreshDiscovery: true,
+			persistConfig: () => writeApiKey(token, undefined, { llmEndpoint: endpoint }),
+		})
+	} catch (error) {
+		host.showError?.(`Kimchi API-key login failed: ${error instanceof Error ? error.message : String(error)}`)
+		return false
+	}
 }
 
 export async function performKimchiBrowserLogin(

--- a/src/extensions/login/flow.ts
+++ b/src/extensions/login/flow.ts
@@ -239,6 +239,11 @@ async function configureKimchiToken(
 		host.modelRegistry.refresh()
 	} catch (error) {
 		refreshError ??= error
+		if (options.strictFreshDiscovery) {
+			restoreKimchiAuth(host.modelRegistry, previousCredential)
+			host.showError?.(formatKimchiTokenError(error, { saved: false }))
+			return false
+		}
 	}
 
 	let providerModels: ProviderModelLike[] = []
@@ -282,7 +287,7 @@ export async function performKimchiApiKeyLogin(
 
 	try {
 		host.showStatus?.(`Refreshing Kimchi models from ${endpoint}...`)
-		return configureKimchiToken(host, token, endpoint, {
+		return await configureKimchiToken(host, token, endpoint, {
 			strictFreshDiscovery: true,
 			persistConfig: () => writeApiKey(token, undefined, { llmEndpoint: endpoint }),
 		})

--- a/src/extensions/login/flow.ts
+++ b/src/extensions/login/flow.ts
@@ -11,7 +11,13 @@ import {
 import { type Component, Container, type TUI } from "@earendil-works/pi-tui"
 import { authenticateViaBrowser } from "../../cli-auth/index.js"
 import { loadConfig, writeApiKey } from "../../config.js"
-import { type PiModelConfig, isTransientModelsError, syncProviderModels, updateModelsConfig } from "../../models.js"
+import {
+	ModelsFetchError,
+	type PiModelConfig,
+	isTransientModelsError,
+	syncProviderModels,
+	updateModelsConfig,
+} from "../../models.js"
 
 export const KIMCHI_PROVIDER_ID = "kimchi-dev"
 export const KIMCHI_DEFAULT_MODEL_ID = "kimi-k2.6"
@@ -208,6 +214,9 @@ function formatKimchiTokenError(error: unknown, options: { saved: boolean }): st
 		: " No changes were saved."
 	if (isTransientModelsError(error)) {
 		return `Kimchi endpoint is unreachable or temporarily unavailable (${detail}). Check the endpoint and try again.${savedSuffix}`
+	}
+	if (error instanceof ModelsFetchError && error.status === 401) {
+		return `Invalid API key. Please check your key and try again.${savedSuffix}`
 	}
 	return `Kimchi model refresh failed: ${detail}.${savedSuffix}`
 }

--- a/src/extensions/login/flow.ts
+++ b/src/extensions/login/flow.ts
@@ -400,6 +400,27 @@ export async function performKimchiBrowserLoginWithDialog(
 	})
 }
 
+export async function performKimchiApiKeyLoginViaExtensionUI(
+	ctx: ExtensionContext,
+	setModel?: (model: ProviderModelLike) => Promise<unknown> | unknown,
+): Promise<"success" | "failed" | "cancelled"> {
+	const apiKey = await ctx.ui.input("Kimchi API Key:")
+	if (!apiKey?.trim()) return "cancelled"
+	const endpoint = await ctx.ui.input(`Kimchi endpoint (press Enter to use ${KIMCHI_DEFAULT_ENDPOINT}):`)
+	const trimmedEndpoint = endpoint?.trim() || KIMCHI_DEFAULT_ENDPOINT
+	const ok = await performKimchiApiKeyLogin(
+		{
+			modelRegistry: ctx.modelRegistry,
+			setModel,
+			showStatus: (message) => ctx.ui.notify(message, "info"),
+			showError: (message) => ctx.ui.notify(message, "error"),
+			addFeedback: (message) => ctx.ui.notify(message, "info"),
+		},
+		{ apiKey: apiKey.trim(), endpoint: trimmedEndpoint },
+	)
+	return ok ? "success" : "failed"
+}
+
 export function getSubscriptionProviderOptions(
 	modelRegistry: ExtensionContext["modelRegistry"],
 ): AuthSelectorProvider[] {

--- a/src/extensions/login/startup-auth.test.ts
+++ b/src/extensions/login/startup-auth.test.ts
@@ -484,7 +484,7 @@ describe("startup auth gate", () => {
 		expect(modelsMock.updateModelsConfig).toHaveBeenCalledWith(
 			expect.stringContaining("models.json"),
 			"my-api-key",
-			expect.objectContaining({ endpoint: "https://custom.kimchi.example", requireActiveModels: true }),
+			expect.objectContaining({ endpoint: "https://custom.kimchi.example" }),
 		)
 		expect(harness.state.authenticated).toBe(true)
 	})

--- a/src/extensions/login/startup-auth.test.ts
+++ b/src/extensions/login/startup-auth.test.ts
@@ -109,6 +109,7 @@ function createHarness(
 			})
 		}),
 		notify: vi.fn(),
+		input: vi.fn(),
 	}
 	const ctx = { hasUI: true, ui, modelRegistry }
 	const state = options.state ?? createStartupAuthGateState()
@@ -448,5 +449,59 @@ describe("startup auth gate", () => {
 
 		expect(harness.state.cancelled).toBe(true)
 		expect(onCancel).toHaveBeenCalledWith(harness.ctx)
+	})
+
+	it("runs the API key login option and authenticates with a custom endpoint", async () => {
+		const harness = createHarness()
+
+		// Simulate user providing API key and custom endpoint via ctx.ui.input
+		harness.ctx.ui.input
+			// biome-ignore lint/suspicious/noExplicitAny: mock chaining
+			.mockResolvedValueOnce("my-api-key")
+			.mockResolvedValueOnce("https://custom.kimchi.example")
+
+		modelsMock.updateModelsConfig.mockResolvedValue({ models: [{ slug: "kimi-k2.6", provider: "ai-enabler" }] })
+
+		const started = harness.start()
+		await harness.settle()
+
+		// Select the API key option (second item: j then Enter)
+		harness.input("j")
+		harness.input("\n")
+
+		await started
+
+		expect(harness.ctx.ui.input).toHaveBeenNthCalledWith(1, "Kimchi API Key:")
+		expect(harness.ctx.ui.input).toHaveBeenNthCalledWith(
+			2,
+			"Kimchi endpoint (press Enter to use https://llm.kimchi.dev):",
+		)
+		expect(modelsMock.updateModelsConfig).toHaveBeenCalledWith(
+			expect.stringContaining("models.json"),
+			"my-api-key",
+			expect.objectContaining({ endpoint: "https://custom.kimchi.example", requireActiveModels: true }),
+		)
+		expect(harness.state.authenticated).toBe(true)
+	})
+
+	it("cancels API key login when the user dismisses the API key input", async () => {
+		const onCancel = vi.fn().mockResolvedValue(undefined)
+		const harness = createHarness({ onCancel })
+		harness.ctx.ui.input.mockResolvedValueOnce(undefined) // user pressed Escape
+
+		const started = harness.start()
+		await harness.settle()
+
+		// Select API key option
+		harness.input("j")
+		harness.input("\n")
+
+		// After cancellation the gate loops back to the selector — cancel it
+		await harness.waitForCustomPrompts(2)
+		harness.input("\x1b")
+		await started
+
+		expect(harness.state.cancelled).toBe(true)
+		expect(modelsMock.updateModelsConfig).not.toHaveBeenCalled()
 	})
 })

--- a/src/extensions/login/startup-auth.test.ts
+++ b/src/extensions/login/startup-auth.test.ts
@@ -1,6 +1,6 @@
 import { LoginDialogComponent, type Theme, initTheme } from "@earendil-works/pi-coding-agent"
 import type { TUI } from "@earendil-works/pi-tui"
-import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest"
+import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest"
 
 const authMock = vi.hoisted(() => ({
 	authenticateViaBrowser: vi.fn(),
@@ -168,6 +168,10 @@ beforeEach(() => {
 	modelsMock.updateModelsConfig.mockReset()
 	modelsMock.updateModelsConfig.mockResolvedValue({ models: [] })
 	modelsMock.syncProviderModels.mockReset()
+})
+
+afterEach(() => {
+	vi.unstubAllEnvs()
 })
 
 describe("shouldShowStartupAuthGate", () => {
@@ -452,6 +456,7 @@ describe("startup auth gate", () => {
 	})
 
 	it("runs the API key login option and authenticates with a custom endpoint", async () => {
+		vi.stubEnv("KIMCHI_CODING_AGENT_DIR", "/tmp/kimchi-startup-auth-test")
 		const harness = createHarness()
 
 		// Simulate user providing API key and custom endpoint via ctx.ui.input

--- a/src/extensions/login/startup-auth.test.ts
+++ b/src/extensions/login/startup-auth.test.ts
@@ -460,10 +460,7 @@ describe("startup auth gate", () => {
 		const harness = createHarness()
 
 		// Simulate user providing API key and custom endpoint via ctx.ui.input
-		harness.ctx.ui.input
-			// biome-ignore lint/suspicious/noExplicitAny: mock chaining
-			.mockResolvedValueOnce("my-api-key")
-			.mockResolvedValueOnce("https://custom.kimchi.example")
+		harness.ctx.ui.input.mockResolvedValueOnce("my-api-key").mockResolvedValueOnce("https://custom.kimchi.example")
 
 		modelsMock.updateModelsConfig.mockResolvedValue({ models: [{ slug: "kimi-k2.6", provider: "ai-enabler" }] })
 

--- a/src/extensions/login/startup-auth.ts
+++ b/src/extensions/login/startup-auth.ts
@@ -8,6 +8,7 @@ import { loadConfig } from "../../config.js"
 import {
 	KIMCHI_PROVIDER_ID,
 	createLoginChoiceSelector,
+	performKimchiApiKeyLoginViaExtensionUI,
 	performKimchiBrowserLoginWithDialog,
 	setKimchiAuthToken,
 	showSubscriptionLoginWithExtensionUI,
@@ -119,11 +120,12 @@ async function waitForOverlayClear(ctx: ExtensionContext): Promise<void> {
 	})
 }
 
-async function promptAuthChoice(ctx: ExtensionContext): Promise<"kimchi" | "subscription" | undefined> {
+async function promptAuthChoice(ctx: ExtensionContext): Promise<"kimchi" | "api-key" | "subscription" | undefined> {
 	await waitForOverlayClear(ctx)
-	return ctx.ui.custom<"kimchi" | "subscription" | undefined>((_tui, _theme, _keybindings, done) => {
+	return ctx.ui.custom<"kimchi" | "api-key" | "subscription" | undefined>((_tui, _theme, _keybindings, done) => {
 		const selector = createLoginChoiceSelector({
 			onKimchiAccount: () => done("kimchi"),
+			onKimchiApiKey: () => done("api-key"),
 			onSubscription: () => done("subscription"),
 			onCancel: () => done(undefined),
 		})
@@ -160,9 +162,13 @@ async function runStartupAuthGate(
 				? await performKimchiBrowserLoginWithDialog(ctx, (model) =>
 						pi.setModel(model as Parameters<typeof pi.setModel>[0]),
 					)
-				: (await showSubscriptionLoginWithExtensionUI(ctx, (model) => pi.setModel(model)))
-					? "success"
-					: "failed"
+				: choice === "api-key"
+					? await performKimchiApiKeyLoginViaExtensionUI(ctx, (model) =>
+							pi.setModel(model as Parameters<typeof pi.setModel>[0]),
+						)
+					: (await showSubscriptionLoginWithExtensionUI(ctx, (model) => pi.setModel(model)))
+						? "success"
+						: "failed"
 
 		if (result === "cancelled") continue
 

--- a/src/login-command-patch.test.ts
+++ b/src/login-command-patch.test.ts
@@ -46,6 +46,7 @@ function makeFakeModelRegistry() {
 		authStorage: {
 			set: vi.fn(),
 			get: vi.fn(),
+			remove: vi.fn(),
 		},
 		refresh: vi.fn(),
 		getAvailable: vi.fn().mockReturnValue([]),
@@ -62,6 +63,7 @@ function makeFakeInteractiveMode(registry: ReturnType<typeof makeFakeModelRegist
 		showError: vi.fn(),
 		showStatus: vi.fn(),
 		showLoginDialog: vi.fn().mockResolvedValue(undefined),
+		showExtensionInput: vi.fn(),
 		getLoginProviderOptions: vi.fn().mockReturnValue([]),
 		chatContainer: {
 			addChild: vi.fn((child: unknown) => children.push(child)),
@@ -116,7 +118,14 @@ async function selectCurrentLoginOption(fakeIm: FakeIm): Promise<void> {
 	await flushAsyncLogin()
 }
 
+async function selectApiKeyLoginOption(fakeIm: FakeIm): Promise<void> {
+	fakeIm.selectorComponent.handleInput("j")
+	fakeIm.selectorComponent.handleInput("\n")
+	await flushAsyncLogin()
+}
+
 async function selectSubscriptionLoginOption(fakeIm: FakeIm): Promise<void> {
+	fakeIm.selectorComponent.handleInput("j")
 	fakeIm.selectorComponent.handleInput("j")
 	fakeIm.selectorComponent.handleInput("\n")
 	await Promise.resolve()
@@ -268,6 +277,165 @@ it("shows error when browser auth fails", async () => {
 
 	expect(fakeIm.showError).toHaveBeenCalledWith("Kimchi login failed: Browser closed")
 	expect(registry.authStorage.set).not.toHaveBeenCalled()
+})
+
+it("prompts for Kimchi API key and endpoint with the default endpoint", async () => {
+	process.env.KIMCHI_CODING_AGENT_DIR = "/tmp/kimchi-api-login-test"
+
+	const registry = makeFakeModelRegistry()
+	registry.getAvailable.mockReturnValue([{ id: "kimi-k2.6", provider: "kimchi-dev" }])
+
+	const fakeIm = makeFakeInteractiveMode(registry)
+	fakeIm.showExtensionInput.mockResolvedValueOnce("api-key-123").mockResolvedValueOnce("")
+
+	// biome-ignore lint/suspicious/noExplicitAny: not present in public type
+	const patched = (InteractiveMode.prototype as any).showOAuthSelector
+	await patched.call(fakeIm, "login")
+	await selectApiKeyLoginOption(fakeIm)
+	await waitForMockCall(fakeIm.session.setModel)
+
+	expect(fakeIm.showExtensionInput).toHaveBeenNthCalledWith(1, "Kimchi API Key:", "Enter your Kimchi API key")
+	expect(fakeIm.showExtensionInput).toHaveBeenNthCalledWith(2, "Kimchi endpoint:", "https://llm.kimchi.dev")
+	expect(fakeIm.showStatus).toHaveBeenCalledWith("Refreshing Kimchi models from https://llm.kimchi.dev...")
+	expect(configModule.writeApiKey).toHaveBeenCalledWith("api-key-123", undefined, {
+		llmEndpoint: "https://llm.kimchi.dev",
+	})
+	expect(modelsModule.updateModelsConfig).toHaveBeenCalledWith(
+		"/tmp/kimchi-api-login-test/models.json",
+		"api-key-123",
+		{
+			allowCachedFallback: false,
+			endpoint: "https://llm.kimchi.dev",
+			requireActiveModels: true,
+		},
+	)
+	expect(registry.authStorage.set).toHaveBeenCalledWith("kimchi-dev", {
+		type: "api_key",
+		key: "api-key-123",
+	})
+	expect(fakeIm.session.setModel).toHaveBeenCalledWith({
+		id: "kimi-k2.6",
+		provider: "kimchi-dev",
+	})
+})
+
+it("uses a custom Kimchi endpoint for API-key model discovery and config persistence", async () => {
+	process.env.KIMCHI_CODING_AGENT_DIR = "/tmp/kimchi-api-login-test"
+
+	const registry = makeFakeModelRegistry()
+	registry.getAvailable.mockReturnValue([{ id: "custom-model", provider: "kimchi-dev" }])
+
+	const fakeIm = makeFakeInteractiveMode(registry)
+	fakeIm.showExtensionInput.mockResolvedValueOnce(" api-key-456 ").mockResolvedValueOnce(" https://custom.example/ ")
+
+	// biome-ignore lint/suspicious/noExplicitAny: not present in public type
+	const patched = (InteractiveMode.prototype as any).showOAuthSelector
+	await patched.call(fakeIm, "login")
+	await selectApiKeyLoginOption(fakeIm)
+	await waitForMockCall(fakeIm.session.setModel)
+
+	expect(fakeIm.showStatus).toHaveBeenCalledWith("Refreshing Kimchi models from https://custom.example/...")
+	expect(modelsModule.updateModelsConfig).toHaveBeenCalledWith(
+		"/tmp/kimchi-api-login-test/models.json",
+		"api-key-456",
+		{
+			allowCachedFallback: false,
+			endpoint: "https://custom.example/",
+			requireActiveModels: true,
+		},
+	)
+	expect(configModule.writeApiKey).toHaveBeenCalledWith("api-key-456", undefined, {
+		llmEndpoint: "https://custom.example/",
+	})
+	expect(registry.authStorage.set).toHaveBeenCalledWith("kimchi-dev", {
+		type: "api_key",
+		key: "api-key-456",
+	})
+	expect(fakeIm.session.setModel).toHaveBeenCalledWith({ id: "custom-model", provider: "kimchi-dev" })
+})
+
+it("does not persist API-key login when model discovery rejects an invalid key", async () => {
+	process.env.KIMCHI_CODING_AGENT_DIR = "/tmp/kimchi-api-login-test"
+	vi.mocked(modelsModule.updateModelsConfig).mockRejectedValueOnce(
+		new modelsModule.ModelsFetchError("Failed to fetch models: 401 Unauthorized", {
+			status: 401,
+			transient: false,
+		}),
+	)
+
+	const registry = makeFakeModelRegistry()
+	const fakeIm = makeFakeInteractiveMode(registry)
+	fakeIm.showExtensionInput.mockResolvedValueOnce("bad-key").mockResolvedValueOnce("https://llm.kimchi.dev")
+
+	// biome-ignore lint/suspicious/noExplicitAny: not present in public type
+	const patched = (InteractiveMode.prototype as any).showOAuthSelector
+	await patched.call(fakeIm, "login")
+	await selectApiKeyLoginOption(fakeIm)
+	await waitForMockCall(fakeIm.showError)
+
+	expect(fakeIm.showError).toHaveBeenCalledWith(
+		"Kimchi model refresh failed: Failed to fetch models: 401 Unauthorized. No changes were saved.",
+	)
+	expect(configModule.writeApiKey).not.toHaveBeenCalled()
+	expect(registry.authStorage.set).not.toHaveBeenCalled()
+	expect(registry.authStorage.remove).not.toHaveBeenCalled()
+	expect(registry.refresh).not.toHaveBeenCalled()
+	expect(fakeIm.session.setModel).not.toHaveBeenCalled()
+})
+
+it("does not persist API-key login when the endpoint is unreachable", async () => {
+	process.env.KIMCHI_CODING_AGENT_DIR = "/tmp/kimchi-api-login-test"
+	vi.mocked(modelsModule.updateModelsConfig).mockRejectedValueOnce(
+		new modelsModule.ModelsFetchError("Failed to fetch models: network down", { transient: true }),
+	)
+
+	const registry = makeFakeModelRegistry()
+	const fakeIm = makeFakeInteractiveMode(registry)
+	fakeIm.showExtensionInput.mockResolvedValueOnce("api-key-123").mockResolvedValueOnce("https://offline.example")
+
+	// biome-ignore lint/suspicious/noExplicitAny: not present in public type
+	const patched = (InteractiveMode.prototype as any).showOAuthSelector
+	await patched.call(fakeIm, "login")
+	await selectApiKeyLoginOption(fakeIm)
+	await waitForMockCall(fakeIm.showError)
+
+	expect(fakeIm.showError).toHaveBeenCalledWith(
+		"Kimchi endpoint is unreachable or temporarily unavailable (Failed to fetch models: network down). Check the endpoint and try again. No changes were saved.",
+	)
+	expect(configModule.writeApiKey).not.toHaveBeenCalled()
+	expect(registry.authStorage.set).not.toHaveBeenCalled()
+	expect(registry.authStorage.remove).not.toHaveBeenCalled()
+	expect(registry.refresh).not.toHaveBeenCalled()
+	expect(fakeIm.session.setModel).not.toHaveBeenCalled()
+})
+
+it("rolls back API-key auth when fresh discovery succeeds but no Kimchi models become available", async () => {
+	process.env.KIMCHI_CODING_AGENT_DIR = "/tmp/kimchi-api-login-test"
+
+	const previousCredential = { type: "api_key", key: "previous-key" }
+	const registry = makeFakeModelRegistry()
+	registry.authStorage.get.mockReturnValue(previousCredential)
+	registry.getAvailable.mockReturnValue([{ id: "gpt-4", provider: "openai" }])
+
+	const fakeIm = makeFakeInteractiveMode(registry)
+	fakeIm.showExtensionInput.mockResolvedValueOnce("api-key-123").mockResolvedValueOnce("https://llm.kimchi.dev")
+
+	// biome-ignore lint/suspicious/noExplicitAny: not present in public type
+	const patched = (InteractiveMode.prototype as any).showOAuthSelector
+	await patched.call(fakeIm, "login")
+	await selectApiKeyLoginOption(fakeIm)
+	await waitForMockCall(fakeIm.showError)
+
+	expect(fakeIm.showError).toHaveBeenCalledWith(
+		"Kimchi API-key login found no available Kimchi models. No changes were saved.",
+	)
+	expect(registry.authStorage.set).toHaveBeenNthCalledWith(1, "kimchi-dev", {
+		type: "api_key",
+		key: "api-key-123",
+	})
+	expect(registry.authStorage.set).toHaveBeenNthCalledWith(2, "kimchi-dev", previousCredential)
+	expect(configModule.writeApiKey).not.toHaveBeenCalled()
+	expect(fakeIm.session.setModel).not.toHaveBeenCalled()
 })
 
 it("routes the subscription option to upstream OAuth providers without showing Kimchi as a duplicate", async () => {

--- a/src/login-command-patch.test.ts
+++ b/src/login-command-patch.test.ts
@@ -303,7 +303,6 @@ it("prompts for Kimchi API key and endpoint with the default endpoint", async ()
 		{
 			allowCachedFallback: false,
 			endpoint: "https://llm.kimchi.dev",
-			requireActiveModels: true,
 		},
 	)
 	expect(registry.authStorage.set).toHaveBeenCalledWith("kimchi-dev", {
@@ -338,7 +337,6 @@ it("uses a custom Kimchi endpoint for API-key model discovery and config persist
 		{
 			allowCachedFallback: false,
 			endpoint: "https://custom.example/",
-			requireActiveModels: true,
 		},
 	)
 	expect(configModule.writeApiKey).toHaveBeenCalledWith("api-key-456", undefined, {

--- a/src/login-command-patch.test.ts
+++ b/src/login-command-patch.test.ts
@@ -20,10 +20,8 @@ beforeAll(() => {
 	initTheme("default")
 })
 
-let originalCodingAgentDir: string | undefined
-
 beforeEach(() => {
-	originalCodingAgentDir = process.env.KIMCHI_CODING_AGENT_DIR
+	vi.stubEnv("KIMCHI_CODING_AGENT_DIR", "/tmp/kimchi-api-login-test")
 	// Auth tests should be independent of the developer machine's real config.
 	vi.spyOn(configModule, "loadConfig").mockReturnValue({ apiKey: "" } as ReturnType<typeof configModule.loadConfig>)
 	vi.spyOn(configModule, "writeApiKey").mockImplementation(() => {})
@@ -31,12 +29,7 @@ beforeEach(() => {
 })
 
 afterEach(() => {
-	if (originalCodingAgentDir === undefined) {
-		// biome-ignore lint/performance/noDelete: process.env requires delete operator to be truly unset rather than stringified to "undefined"
-		delete process.env.KIMCHI_CODING_AGENT_DIR
-	} else {
-		process.env.KIMCHI_CODING_AGENT_DIR = originalCodingAgentDir
-	}
+	vi.unstubAllEnvs()
 	vi.restoreAllMocks()
 	vi.mocked(getModels).mockReturnValue([])
 })
@@ -132,7 +125,7 @@ async function selectSubscriptionLoginOption(fakeIm: FakeIm): Promise<void> {
 }
 
 it("intercepts showOAuthSelector('login') and runs Kimchi browser auth", async () => {
-	process.env.KIMCHI_CODING_AGENT_DIR = "/tmp/kimchi-login-test"
+	vi.stubEnv("KIMCHI_CODING_AGENT_DIR", "/tmp/kimchi-login-test")
 	const cliAuthModule = await import("./cli-auth/index.js")
 	const authSpy = vi.spyOn(cliAuthModule, "authenticateViaBrowser").mockResolvedValue({ token: "test-token-123" })
 
@@ -280,7 +273,7 @@ it("shows error when browser auth fails", async () => {
 })
 
 it("prompts for Kimchi API key and endpoint with the default endpoint", async () => {
-	process.env.KIMCHI_CODING_AGENT_DIR = "/tmp/kimchi-api-login-test"
+	vi.stubEnv("KIMCHI_CODING_AGENT_DIR", "/tmp/kimchi-api-login-test")
 
 	const registry = makeFakeModelRegistry()
 	registry.getAvailable.mockReturnValue([{ id: "kimi-k2.6", provider: "kimchi-dev" }])
@@ -295,7 +288,11 @@ it("prompts for Kimchi API key and endpoint with the default endpoint", async ()
 	await waitForMockCall(fakeIm.session.setModel)
 
 	expect(fakeIm.showExtensionInput).toHaveBeenNthCalledWith(1, "Kimchi API Key:", "Enter your Kimchi API key")
-	expect(fakeIm.showExtensionInput).toHaveBeenNthCalledWith(2, "Kimchi endpoint:", "https://llm.kimchi.dev")
+	expect(fakeIm.showExtensionInput).toHaveBeenNthCalledWith(
+		2,
+		"Kimchi endpoint (press Enter to use https://llm.kimchi.dev):",
+		"",
+	)
 	expect(fakeIm.showStatus).toHaveBeenCalledWith("Refreshing Kimchi models from https://llm.kimchi.dev...")
 	expect(configModule.writeApiKey).toHaveBeenCalledWith("api-key-123", undefined, {
 		llmEndpoint: "https://llm.kimchi.dev",
@@ -320,7 +317,7 @@ it("prompts for Kimchi API key and endpoint with the default endpoint", async ()
 })
 
 it("uses a custom Kimchi endpoint for API-key model discovery and config persistence", async () => {
-	process.env.KIMCHI_CODING_AGENT_DIR = "/tmp/kimchi-api-login-test"
+	vi.stubEnv("KIMCHI_CODING_AGENT_DIR", "/tmp/kimchi-api-login-test")
 
 	const registry = makeFakeModelRegistry()
 	registry.getAvailable.mockReturnValue([{ id: "custom-model", provider: "kimchi-dev" }])
@@ -355,7 +352,7 @@ it("uses a custom Kimchi endpoint for API-key model discovery and config persist
 })
 
 it("does not persist API-key login when model discovery rejects an invalid key", async () => {
-	process.env.KIMCHI_CODING_AGENT_DIR = "/tmp/kimchi-api-login-test"
+	vi.stubEnv("KIMCHI_CODING_AGENT_DIR", "/tmp/kimchi-api-login-test")
 	vi.mocked(modelsModule.updateModelsConfig).mockRejectedValueOnce(
 		new modelsModule.ModelsFetchError("Failed to fetch models: 401 Unauthorized", {
 			status: 401,
@@ -384,7 +381,7 @@ it("does not persist API-key login when model discovery rejects an invalid key",
 })
 
 it("does not persist API-key login when the endpoint is unreachable", async () => {
-	process.env.KIMCHI_CODING_AGENT_DIR = "/tmp/kimchi-api-login-test"
+	vi.stubEnv("KIMCHI_CODING_AGENT_DIR", "/tmp/kimchi-api-login-test")
 	vi.mocked(modelsModule.updateModelsConfig).mockRejectedValueOnce(
 		new modelsModule.ModelsFetchError("Failed to fetch models: network down", { transient: true }),
 	)
@@ -410,7 +407,7 @@ it("does not persist API-key login when the endpoint is unreachable", async () =
 })
 
 it("rolls back API-key auth when fresh discovery succeeds but no Kimchi models become available", async () => {
-	process.env.KIMCHI_CODING_AGENT_DIR = "/tmp/kimchi-api-login-test"
+	vi.stubEnv("KIMCHI_CODING_AGENT_DIR", "/tmp/kimchi-api-login-test")
 
 	const previousCredential = { type: "api_key", key: "previous-key" }
 	const registry = makeFakeModelRegistry()
@@ -482,50 +479,40 @@ it("pre-populates subscription provider models in models.json before upstream lo
 	const fakeIm = makeFakeInteractiveMode(registry)
 	fakeIm.getLoginProviderOptions.mockReturnValue([{ id: "openai", name: "OpenAI", authType: "oauth" }])
 
-	const previousDir = process.env.KIMCHI_CODING_AGENT_DIR
-	process.env.KIMCHI_CODING_AGENT_DIR = "/tmp/kimchi-test-models"
+	vi.stubEnv("KIMCHI_CODING_AGENT_DIR", "/tmp/kimchi-test-models")
 
-	try {
-		// biome-ignore lint/suspicious/noExplicitAny: not present in public type
-		const patched = (InteractiveMode.prototype as any).showOAuthSelector
-		await patched.call(fakeIm, "login")
-		await selectSubscriptionLoginOption(fakeIm)
-		fakeIm.selectorComponent.handleInput("\n")
-		await waitForMockCall(fakeIm.showLoginDialog)
+	// biome-ignore lint/suspicious/noExplicitAny: not present in public type
+	const patched = (InteractiveMode.prototype as any).showOAuthSelector
+	await patched.call(fakeIm, "login")
+	await selectSubscriptionLoginOption(fakeIm)
+	fakeIm.selectorComponent.handleInput("\n")
+	await waitForMockCall(fakeIm.showLoginDialog)
 
-		expect(fakeIm.showLoginDialog).toHaveBeenCalledWith("openai", "OpenAI")
-		expect(syncSpy).toHaveBeenCalledOnce()
-		const [_path, providerId, configs, providerConfig] = syncSpy.mock.calls[0] as unknown as [
-			string,
-			string,
-			unknown[],
-			unknown,
-		]
-		expect(providerId).toBe("openai")
-		expect(providerConfig).toMatchObject({
-			api: "openai-chat",
-			baseUrl: "https://api.openai.com/v1/chat/completions",
-		})
-		expect(configs).toHaveLength(1)
-		expect(configs[0]).toMatchObject({
-			id: "codex",
-			name: "Codex",
-			provider: "openai",
-			input: ["text"],
-			contextWindow: 200000,
-			maxTokens: 8192,
-			reasoning: false,
-		})
-	} finally {
-		if (previousDir === undefined) {
-			// biome-ignore lint/performance/noDelete: process.env requires delete operator to be truly unset rather than stringified to "undefined"
-			delete process.env.KIMCHI_CODING_AGENT_DIR
-		} else {
-			process.env.KIMCHI_CODING_AGENT_DIR = previousDir
-		}
-		syncSpy.mockRestore()
-		getModelsMock.mockReturnValue([])
-	}
+	expect(fakeIm.showLoginDialog).toHaveBeenCalledWith("openai", "OpenAI")
+	expect(syncSpy).toHaveBeenCalledOnce()
+	const [_path, providerId, configs, providerConfig] = syncSpy.mock.calls[0] as unknown as [
+		string,
+		string,
+		unknown[],
+		unknown,
+	]
+	expect(providerId).toBe("openai")
+	expect(providerConfig).toMatchObject({
+		api: "openai-chat",
+		baseUrl: "https://api.openai.com/v1/chat/completions",
+	})
+	expect(configs).toHaveLength(1)
+	expect(configs[0]).toMatchObject({
+		id: "codex",
+		name: "Codex",
+		provider: "openai",
+		input: ["text"],
+		contextWindow: 200000,
+		maxTokens: 8192,
+		reasoning: false,
+	})
+	syncSpy.mockRestore()
+	getModelsMock.mockReturnValue([])
 })
 
 it("does not crash when registry.getAvailable returns empty after subscription login", async () => {

--- a/src/login-command-patch.test.ts
+++ b/src/login-command-patch.test.ts
@@ -369,7 +369,7 @@ it("does not persist API-key login when model discovery rejects an invalid key",
 	await waitForMockCall(fakeIm.showError)
 
 	expect(fakeIm.showError).toHaveBeenCalledWith(
-		"Kimchi model refresh failed: Failed to fetch models: 401 Unauthorized. No changes were saved.",
+		"Invalid API key. Please check your key and try again. No changes were saved.",
 	)
 	expect(configModule.writeApiKey).not.toHaveBeenCalled()
 	expect(registry.authStorage.set).not.toHaveBeenCalled()

--- a/src/login-command-patch.ts
+++ b/src/login-command-patch.ts
@@ -9,9 +9,11 @@
 import { type AuthStatus, InteractiveMode, OAuthSelectorComponent } from "@earendil-works/pi-coding-agent"
 import { Spacer, Text } from "@earendil-works/pi-tui"
 import {
+	KIMCHI_DEFAULT_ENDPOINT,
 	KIMCHI_PROVIDER_ID,
 	createLoginChoiceSelector,
 	formatBrowserLoginMessage,
+	performKimchiApiKeyLogin,
 	performKimchiBrowserLogin,
 	prePopulateSubscriptionModels,
 } from "./extensions/login/flow.js"
@@ -60,6 +62,7 @@ type LoginModeLike = {
 	showSelector?: ShowSelector
 	showStatus?: (msg: string) => void
 	showLoginDialog?: (providerId: string, providerName: string) => Promise<void>
+	showExtensionInput?: (title: string, placeholder?: string) => Promise<string | undefined>
 	getLoginProviderOptions?: (authType: "oauth" | "api_key") => AuthSelectorProvider[]
 	session: SessionLike
 	ui?: UiLike
@@ -132,6 +135,41 @@ async function handleKimchiLogin(im: InteractiveMode): Promise<void> {
 		// needs the URL to copy into the right one. console.log is swallowed under the TUI.
 		onBrowserUrl: (url) => addLoginFeedback(im, formatBrowserLoginMessage(url)),
 	})
+}
+
+async function handleKimchiApiKeyLogin(im: InteractiveMode): Promise<void> {
+	const modeLike = im as unknown as LoginModeLike
+	const showStatus = modeLike.showStatus?.bind(modeLike)
+	const showError = im.showError.bind(im)
+	const session = modeLike.session
+	const registry = session?.modelRegistry
+	if (!registry) {
+		showError("Kimchi API-key login failed: model registry is unavailable")
+		return
+	}
+	if (!modeLike.showExtensionInput) {
+		showError("Kimchi API-key login failed: text input is unavailable")
+		return
+	}
+
+	const apiKey = await modeLike.showExtensionInput("Kimchi API Key:", "Enter your Kimchi API key")
+	if (apiKey === undefined) return
+	const endpointInput = await modeLike.showExtensionInput("Kimchi endpoint:", KIMCHI_DEFAULT_ENDPOINT)
+	if (endpointInput === undefined) return
+
+	await performKimchiApiKeyLogin(
+		{
+			modelRegistry: registry,
+			setModel: (model) => session.setModel(model),
+			showStatus,
+			showError,
+			addFeedback: (message) => addLoginFeedback(im, message),
+		},
+		{
+			apiKey,
+			endpoint: endpointInput.trim() || KIMCHI_DEFAULT_ENDPOINT,
+		},
+	)
 }
 
 function showSubscriptionLogin(im: InteractiveMode): void {
@@ -209,6 +247,10 @@ function showLoginChoiceSelector(im: InteractiveMode): void {
 			onKimchiAccount: () => {
 				done()
 				void handleKimchiLogin(im)
+			},
+			onKimchiApiKey: () => {
+				done()
+				void handleKimchiApiKeyLogin(im)
 			},
 			onSubscription: () => {
 				done()

--- a/src/login-command-patch.ts
+++ b/src/login-command-patch.ts
@@ -154,7 +154,10 @@ async function handleKimchiApiKeyLogin(im: InteractiveMode): Promise<void> {
 
 	const apiKey = await modeLike.showExtensionInput("Kimchi API Key:", "Enter your Kimchi API key")
 	if (apiKey === undefined) return
-	const endpointInput = await modeLike.showExtensionInput("Kimchi endpoint:", KIMCHI_DEFAULT_ENDPOINT)
+	const endpointInput = await modeLike.showExtensionInput(
+		`Kimchi endpoint (press Enter to use ${KIMCHI_DEFAULT_ENDPOINT}):`,
+		"",
+	)
 	if (endpointInput === undefined) return
 
 	await performKimchiApiKeyLogin(

--- a/src/models.test.ts
+++ b/src/models.test.ts
@@ -153,6 +153,24 @@ describe("updateModelsConfig", () => {
 		)
 	})
 
+	it("uses a provided Kimchi endpoint for metadata fetch and kimchi-dev baseUrl", async () => {
+		vi.mocked(fetch).mockResolvedValueOnce({
+			ok: true,
+			json: async () => ({ models: [KIMI] }),
+		} as Response)
+
+		await updateModelsConfig(modelsJsonPath, "my-api-key", { endpoint: "https://custom.kimchi.example/" })
+
+		expect(fetch).toHaveBeenCalledWith(
+			"https://custom.kimchi.example/v1/models/metadata?include_in_cli=true",
+			expect.objectContaining({
+				headers: { Authorization: "Bearer my-api-key" },
+			}),
+		)
+		const config = JSON.parse(readFileSync(modelsJsonPath, "utf-8"))
+		expect(config.providers["kimchi-dev"].baseUrl).toBe("https://custom.kimchi.example/openai/v1")
+	})
+
 	it("returns discovered metadata when fetch succeeds", async () => {
 		vi.mocked(fetch).mockResolvedValueOnce({
 			ok: true,
@@ -171,10 +189,11 @@ describe("updateModelsConfig", () => {
 			json: async () => ({ models: [KIMI] }),
 		} as Response)
 
-		await updateModelsConfig(modelsJsonPath, "test-key")
+		await updateModelsConfig(modelsJsonPath, "test-key", { endpoint: "https://custom.kimchi.example" })
 
 		const config = JSON.parse(readFileSync(modelsJsonPath, "utf-8"))
 		expect(config.providers["kimchi-dev"].models.map((m: { id: string }) => m.id)).toEqual(["kimi-k2.5"])
+		expect(config.providers["kimchi-dev"].baseUrl).toBe("https://custom.kimchi.example/openai/v1")
 		expect(config.providers.custom).toEqual({ models: [] })
 	})
 
@@ -473,6 +492,37 @@ describe("updateModelsConfig", () => {
 		const config = JSON.parse(readFileSync(modelsJsonPath, "utf-8"))
 		expect(config.providers["kimchi-dev"].models).toHaveLength(0)
 		consoleWarnSpy.mockRestore()
+	})
+
+	it("throws without changing models.json when strict fresh discovery finds no active Kimchi models", async () => {
+		const existingConfig = {
+			providers: {
+				openai: { models: [{ id: "gpt-4o", name: "GPT-4o", provider: "openai" }] },
+				"kimchi-dev": { models: [{ id: "old-kimchi", name: "Old Kimchi", provider: "ai-enabler" }] },
+			},
+		}
+		writeFileSync(modelsJsonPath, JSON.stringify(existingConfig, null, "\t"), "utf-8")
+		const before = readFileSync(modelsJsonPath, "utf-8")
+		const sunsetModel = {
+			slug: "old-model",
+			display_name: "Old Model",
+			provider: "ai-enabler",
+			reasoning: false,
+			input_modalities: ["text"],
+			is_serverless: true,
+			limits: { context_window: 100_000, max_output_tokens: 4096 },
+			status: "sunset",
+		}
+		vi.mocked(fetch).mockResolvedValueOnce({
+			ok: true,
+			json: async () => ({ models: [sunsetModel] }),
+		} as Response)
+
+		await expect(updateModelsConfig(modelsJsonPath, "test-key", { requireActiveModels: true })).rejects.toThrow(
+			"No active Kimchi models are available for this API key",
+		)
+
+		expect(readFileSync(modelsJsonPath, "utf-8")).toBe(before)
 	})
 
 	it("treats models without status field as active (backward compatibility)", async () => {

--- a/src/models.ts
+++ b/src/models.ts
@@ -3,9 +3,20 @@ import { dirname } from "node:path"
 import { getVersion } from "./utils.js"
 
 const KIMCHI_API = "https://llm.kimchi.dev"
-const MODELS_METADATA_API = `${KIMCHI_API}/v1/models/metadata?include_in_cli=true`
-const CHAT_COMPLETIONS_API = `${KIMCHI_API}/openai/v1`
 const FETCH_TIMEOUT_MS = 5000
+
+function normalizeKimchiEndpoint(endpoint?: string): string {
+	const trimmed = endpoint?.trim()
+	return (trimmed && trimmed.length > 0 ? trimmed : KIMCHI_API).replace(/\/+$/, "")
+}
+
+function modelsMetadataApi(endpoint?: string): string {
+	return `${normalizeKimchiEndpoint(endpoint)}/v1/models/metadata?include_in_cli=true`
+}
+
+function chatCompletionsApi(endpoint?: string): string {
+	return `${normalizeKimchiEndpoint(endpoint)}/openai/v1`
+}
 
 // HTTP statuses worth retrying: rate limiting and transient gateway/server errors.
 const RETRYABLE_STATUSES = new Set([429, 500, 502, 503, 504])
@@ -38,6 +49,12 @@ export function isTransientModelsError(error: unknown): boolean {
 export interface FetchModelsOptions {
 	/** Injected sleep for deterministic tests; defaults to a setTimeout-based delay. */
 	sleep?: (ms: number) => Promise<void>
+	/** Base Kimchi service endpoint; defaults to https://llm.kimchi.dev. */
+	endpoint?: string
+	/** When false, fetch failures throw even if models.json contains cached models. */
+	allowCachedFallback?: boolean
+	/** When true, an API response with no active models throws instead of writing an empty kimchi-dev block. */
+	requireActiveModels?: boolean
 }
 
 const defaultSleep = (ms: number): Promise<void> => new Promise((resolve) => setTimeout(resolve, ms))
@@ -81,12 +98,13 @@ function sortModels(models: ModelMetadata[]): ModelMetadata[] {
 
 async function fetchAvailableModels(apiKey: string, options: FetchModelsOptions = {}): Promise<ModelMetadata[]> {
 	const sleep = options.sleep ?? defaultSleep
+	const metadataUrl = modelsMetadataApi(options.endpoint)
 	let lastError: ModelsFetchError | undefined
 
 	for (let attempt = 1; attempt <= MAX_FETCH_ATTEMPTS; attempt += 1) {
 		let response: Response
 		try {
-			response = await fetch(MODELS_METADATA_API, {
+			response = await fetch(metadataUrl, {
 				headers: { Authorization: `Bearer ${apiKey}` },
 				signal: AbortSignal.timeout(FETCH_TIMEOUT_MS),
 			})
@@ -160,11 +178,11 @@ function metadataToModel(m: ModelMetadata): PiModelConfig {
 	}
 }
 
-function buildModelsConfig(models: ModelMetadata[]) {
+function buildModelsConfig(models: ModelMetadata[], endpoint?: string) {
 	return {
 		providers: {
 			"kimchi-dev": {
-				baseUrl: CHAT_COMPLETIONS_API,
+				baseUrl: chatCompletionsApi(endpoint),
 				apiKey: "$KIMCHI_API_KEY",
 				api: "openai-completions",
 				authHeader: true,
@@ -228,8 +246,8 @@ function readExistingProviders(modelsJsonPath: string): Record<string, unknown> 
 	}
 }
 
-export async function validateApiKey(apiKey: string): Promise<void> {
-	await fetchAvailableModels(apiKey)
+export async function validateApiKey(apiKey: string, options: FetchModelsOptions = {}): Promise<void> {
+	await fetchAvailableModels(apiKey, options)
 }
 
 /**
@@ -300,7 +318,7 @@ export async function updateModelsConfig(
 		fetched = await fetchAvailableModels(apiKey, options)
 	} catch (err) {
 		const cached = readCachedMetadata(modelsJsonPath) ?? []
-		if (cached.length === 0 && otherModels.length === 0) throw err
+		if (options.allowCachedFallback === false || (cached.length === 0 && otherModels.length === 0)) throw err
 		const message = err instanceof Error ? err.message : String(err)
 		console.warn(`Failed to refresh models from API, using cached list: ${message}`)
 		return { models: sortModels([...cached, ...otherModels]) }
@@ -308,10 +326,13 @@ export async function updateModelsConfig(
 
 	const activeModels = fetched.filter((m) => m.status !== "sunset")
 	if (activeModels.length === 0 && fetched.length > 0) {
+		if (options.requireActiveModels) {
+			throw new ModelsFetchError("No active Kimchi models are available for this API key", { transient: false })
+		}
 		console.warn("All models from the API are sunset. No active models available.")
 	}
 	const models = sortModels(activeModels)
-	const merged = { providers: { ...otherProviders, ...buildModelsConfig(models).providers } }
+	const merged = { providers: { ...otherProviders, ...buildModelsConfig(models, options.endpoint).providers } }
 	writeFileSync(modelsJsonPath, JSON.stringify(merged, null, "\t"), "utf-8")
 	return { models: sortModels([...activeModels, ...otherModels]) }
 }

--- a/src/set-package-dir.ts
+++ b/src/set-package-dir.ts
@@ -2,4 +2,4 @@ import { dirname, resolve } from "node:path"
 import { fileURLToPath } from "node:url"
 
 const __dirname = dirname(fileURLToPath(import.meta.url))
-process.env.PI_PACKAGE_DIR = resolve(__dirname, "..")
+process.env.PI_PACKAGE_DIR = resolve(__dirname, "../node_modules/@earendil-works/pi-coding-agent")

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -5,6 +5,15 @@ const stubPath = fileURLToPath(new URL("./src/__mocks__/earendil-clipboard-image
 
 export default defineConfig({
 	test: {
+		env: {
+			// initTheme() reads theme JSON files from the package dir. In test
+			// environments the app is never installed, so we point PI_PACKAGE_DIR
+			// at the pi-coding-agent package inside node_modules so theme files
+			// are always found.
+			PI_PACKAGE_DIR: fileURLToPath(
+				new URL("./node_modules/@earendil-works/pi-coding-agent", import.meta.url),
+			),
+		},
 		alias: {
 			// The deep-import path used in clipboard-read.ts is not in the package's
 			// exports map, so Vite cannot resolve it normally. Map it to a stub file


### PR DESCRIPTION
## Summary

Adds a Kimchi API key login flow, allowing users to authenticate using a Kimchi API key in addition to existing login methods.

## Changes

- **`src/extensions/login/flow.ts`** — Extended login flow to support API key authentication
- **`src/login-command-patch.ts`** — New patch wiring the API key login command
- **`src/models.ts`** — Model updates to support API key auth
- **`src/config.ts`** — Config updates for API key storage
- **Tests** — Full test coverage added for new login flow, config, and model changes

## Testing

- `src/config.test.ts` — Config tests
- `src/login-command-patch.test.ts` — Login command patch tests  
- `src/models.test.ts` — Model tests