### PR TITLE
fix(.github/release.yml): use labels array instead of singular label

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,12 +1,17 @@
 changelog:
   categories:
-    - label: "breaking change"
-      title: "Breaking Changes"
-    - label: "new feature"
-      title: "New Features"
-    - label: "bug"
-      title: "Bug Fixes"
-    - label: "documentation"
-      title: "Documentation"
-    - label: "*"
-      title: "Other Changes"
+    - title: "Breaking Changes"
+      labels:
+        - "breaking change"
+    - title: "New Features"
+      labels:
+        - "new feature"
+    - title: "Bug Fixes"
+      labels:
+        - "bug"
+    - title: "Documentation"
+      labels:
+        - "documentation"
+    - title: "Other Changes"
+      labels:
+        - "*"


### PR DESCRIPTION
## Description

Previous format was incorrect.


## Type of Change

<!-- Select all that apply. -->

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
