### PR TITLE
fix(model-guard): prevent context loss via threshold fix and mid-turn compaction guard

### DIFF
--- a/src/extensions/model-guard.test.ts
+++ b/src/extensions/model-guard.test.ts
@@ -463,21 +463,34 @@ describe("modelGuardExtension handler", () => {
 		expect(result).toBeUndefined()
 	})
 
-	it("truncates when usage.tokens exceeds safety margin of context window", async () => {
+	it("does not truncate when usage.tokens is below the hard context window limit", async () => {
 		const { pi, trigger } = makeMockPI()
 		modelGuardExtension(pi)
 		const ctx = makeMockCtx({
 			model: { id: "claude", input: ["text"], contextWindow: 10_000 } as ExtensionContext["model"],
+			// 96% of context window — old threshold fired here, new one should not
 			getContextUsage: () => ({ tokens: 9_600, contextWindow: 10_000, percent: 96 }),
 		})
-		// 30 user messages at ~500 tokens each (2000 chars) = 15,000 tokens — will be truncated
-		const msgs: ContextEvent["messages"] = Array.from({ length: 30 }, (_, i) => makeUser("x".repeat(2000)))
+		const msgs: ContextEvent["messages"] = Array.from({ length: 30 }, () => makeUser("x".repeat(2000)))
+		const result = await trigger("context", { messages: msgs }, ctx)
+		expect(result).toBeUndefined()
+	})
+
+	it("truncates when usage.tokens exceeds the hard context window limit", async () => {
+		const { pi, trigger } = makeMockPI()
+		modelGuardExtension(pi)
+		const ctx = makeMockCtx({
+			model: { id: "claude", input: ["text"], contextWindow: 10_000 } as ExtensionContext["model"],
+			// Exceeds the hard limit — context built against a larger window (e.g. model switch)
+			getContextUsage: () => ({ tokens: 10_001, contextWindow: 10_000, percent: 100.01 }),
+		})
+		const msgs: ContextEvent["messages"] = Array.from({ length: 30 }, () => makeUser("x".repeat(2000)))
 		const result = (await trigger("context", { messages: msgs }, ctx)) as { messages: ContextEvent["messages"] }
 		expect(result).toBeDefined()
 		expect(result.messages.length).toBeLessThan(30)
 	})
 
-	it("returns undefined when within safety margin", async () => {
+	it("returns undefined when within context window", async () => {
 		const { pi, trigger } = makeMockPI()
 		modelGuardExtension(pi)
 		const ctx = makeMockCtx({
@@ -494,7 +507,8 @@ describe("modelGuardExtension handler", () => {
 		modelGuardExtension(pi)
 		const ctx = makeMockCtx({
 			model: { id: "gpt-4", input: ["text"], contextWindow: 5_000 } as ExtensionContext["model"],
-			getContextUsage: () => ({ tokens: 5_100, contextWindow: 5_000, percent: 100 }),
+			// Over the hard limit
+			getContextUsage: () => ({ tokens: 5_100, contextWindow: 5_000, percent: 102 }),
 		})
 		// "msg N " (6-7 chars) + 1900 x's = ~1906 chars → ceil(1906/4)=477 + image 1000 = ~1477 tokens each; 20 msgs ~ 29,540 tokens
 		const msgs: ContextEvent["messages"] = Array.from({ length: 20 }, (_, i) =>
@@ -506,7 +520,7 @@ describe("modelGuardExtension handler", () => {
 		expect(result.messages.length).toBeLessThan(20)
 	})
 
-	it("returns undefined when usage.tokens is null", async () => {
+	it("returns undefined when usage.tokens is null and local estimate is within window", async () => {
 		const { pi, trigger } = makeMockPI()
 		modelGuardExtension(pi)
 		const ctx = makeMockCtx({
@@ -525,12 +539,119 @@ describe("modelGuardExtension handler", () => {
 			model: { id: "kimi-k2.6", input: ["text"], contextWindow: 10_000 } as ExtensionContext["model"],
 			getContextUsage: () => ({ tokens: null, contextWindow: 10_000, percent: null }),
 		})
-		// 30 messages × 2000 chars each → ceil(2000/4)=500 tokens each = 15,000 tokens
-		// This exceeds 10_000 * 0.95 = 9,500, so truncation should fire
+		// 30 messages × 2000 chars each → ceil(2000/4)=500 tokens each = 15,000 tokens > 10,000
 		const msgs: ContextEvent["messages"] = Array.from({ length: 30 }, () => makeUser("x".repeat(2000)))
 		const result = (await trigger("context", { messages: msgs }, ctx)) as { messages: ContextEvent["messages"] }
 		expect(result).toBeDefined()
 		expect(result.messages.length).toBeLessThan(30)
+	})
+})
+
+// ── turn_end compaction guard ─────────────────────────────────────────────────
+
+function makeTurnEndEvent(totalTokens: number, stopReason: string) {
+	return {
+		type: "turn_end" as const,
+		turnIndex: 1,
+		message: {
+			role: "assistant" as const,
+			content: [{ type: "toolCall" as const, name: "read", arguments: {}, id: "tc1" }],
+			usage: {
+				input: totalTokens - 100,
+				output: 100,
+				cacheRead: 0,
+				cacheWrite: 0,
+				totalTokens,
+				cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+			},
+			api: "openai-completions" as const,
+			provider: "kimchi-dev" as const,
+			stopReason,
+			model: "kimi-k2.6",
+			timestamp: Date.now(),
+		},
+		toolResults: [],
+	}
+}
+
+describe("turn_end compaction guard", () => {
+	const CONTEXT_WINDOW = 262_144
+	const RESERVE = 16_384
+	const THRESHOLD = CONTEXT_WINDOW - RESERVE // 245,760
+
+	it("does not compact when totalTokens is below the compaction threshold", async () => {
+		const { pi, trigger } = makeMockPI()
+		modelGuardExtension(pi)
+		const compact = vi.fn()
+		const ctx = makeMockCtx({
+			model: { id: "kimi-k2.6", input: ["text"], contextWindow: CONTEXT_WINDOW } as ExtensionContext["model"],
+			compact,
+		})
+		await trigger("turn_end", makeTurnEndEvent(THRESHOLD - 1, "toolUse"), ctx)
+		expect(compact).not.toHaveBeenCalled()
+	})
+
+	it("calls compact with notification callbacks when totalTokens exceeds the compaction threshold mid-turn", async () => {
+		const { pi, trigger } = makeMockPI()
+		modelGuardExtension(pi)
+		const compact = vi.fn()
+		const notify = vi.fn()
+		const ctx = makeMockCtx({
+			model: { id: "kimi-k2.6", input: ["text"], contextWindow: CONTEXT_WINDOW } as ExtensionContext["model"],
+			compact,
+			ui: { notify } as unknown as ExtensionContext["ui"],
+		})
+		await trigger("turn_end", makeTurnEndEvent(THRESHOLD + 1, "toolUse"), ctx)
+		expect(compact).toHaveBeenCalledOnce()
+
+		// Verify the options shape includes onComplete/onError callbacks
+		const options = compact.mock.calls[0][0]
+		expect(typeof options.onComplete).toBe("function")
+		expect(typeof options.onError).toBe("function")
+
+		// Simulate a successful compaction callback
+		options.onComplete({ tokensBefore: THRESHOLD + 1 })
+		expect(notify).toHaveBeenCalledWith(expect.stringContaining("Context compacted"), "info")
+
+		// Simulate a failed compaction callback
+		notify.mockClear()
+		options.onError(new Error("summariser failed"))
+		expect(notify).toHaveBeenCalledWith(expect.stringContaining("summariser failed"), "error")
+	})
+
+	it("does not compact when stopReason is not toolUse (turn already ending)", async () => {
+		const { pi, trigger } = makeMockPI()
+		modelGuardExtension(pi)
+		const compact = vi.fn()
+		const ctx = makeMockCtx({
+			model: { id: "kimi-k2.6", input: ["text"], contextWindow: CONTEXT_WINDOW } as ExtensionContext["model"],
+			compact,
+		})
+		for (const stopReason of ["stop", "length", "error", "aborted"]) {
+			await trigger("turn_end", makeTurnEndEvent(THRESHOLD + 1, stopReason), ctx)
+		}
+		expect(compact).not.toHaveBeenCalled()
+	})
+
+	it("does not compact when no model is set", async () => {
+		const { pi, trigger } = makeMockPI()
+		modelGuardExtension(pi)
+		const compact = vi.fn()
+		const ctx = makeMockCtx({ model: undefined, compact })
+		await trigger("turn_end", makeTurnEndEvent(THRESHOLD + 1, "toolUse"), ctx)
+		expect(compact).not.toHaveBeenCalled()
+	})
+
+	it("does not compact at exactly the threshold boundary", async () => {
+		const { pi, trigger } = makeMockPI()
+		modelGuardExtension(pi)
+		const compact = vi.fn()
+		const ctx = makeMockCtx({
+			model: { id: "kimi-k2.6", input: ["text"], contextWindow: CONTEXT_WINDOW } as ExtensionContext["model"],
+			compact,
+		})
+		await trigger("turn_end", makeTurnEndEvent(THRESHOLD, "toolUse"), ctx)
+		expect(compact).not.toHaveBeenCalled()
 	})
 })
 

--- a/src/extensions/model-guard.ts
+++ b/src/extensions/model-guard.ts
@@ -305,12 +305,17 @@ export default function createModelGuardExtension(_pi: ExtensionAPI) {
 			}
 		}
 
-		// Truncate when context usage exceeds the target model's context window.
-		// Falls back to local estimate when upstream tokens are null (post-compaction).
+		// Emergency truncation: only fires when the context was built against a larger
+		// window than the current model accepts (e.g. session restored onto a smaller
+		// model). In the normal same-model case usage.input is always < contextWindow
+		// by API contract, so this never triggers and compaction handles growth instead.
+		// Using the 95% safety-margin threshold here was wrong: it fired inside the
+		// compaction zone, silently dropped history without a summary, and reset the
+		// token estimate to ~20k — preventing compaction from triggering on the very
+		// next turn.
 		if (model) {
 			const tokens = resolveContextTokens(usage, result)
-			const threshold = Math.floor(model.contextWindow * SAFETY_MARGIN)
-			if (tokens != null && tokens > threshold) {
+			if (tokens != null && tokens > model.contextWindow) {
 				const truncated = truncateMessages(result, model.contextWindow)
 				if (truncated !== result) {
 					result = truncated
@@ -320,6 +325,54 @@ export default function createModelGuardExtension(_pi: ExtensionAPI) {
 		}
 
 		if (modified) return { messages: result }
+	})
+
+	// Compaction mid-turn guard: upstream auto-compaction only checks the threshold
+	// once per user turn (after agent.prompt() returns). In a long tool-call chain
+	// the context can exceed the compaction threshold many times over before the
+	// turn ends. turn_end fires after every individual LLM response inside the
+	// loop, giving us a chance to compact before the hard limit is hit.
+	_pi.on("turn_end", async (event, ctx: ExtensionContext) => {
+		const model = ctx.model
+		if (!model) return
+
+		const msg = event.message
+		if (msg.role !== "assistant") return
+		// Only act on tool-use responses — the turn is still in progress.
+		// stop/error/aborted responses are already handled by _handlePostAgentRun.
+		if (msg.stopReason !== "toolUse") return
+
+		const usage = "usage" in msg ? msg.usage : undefined
+		if (!usage?.totalTokens) return
+
+		// Use the same threshold as upstream auto-compaction: contextWindow - reserveTokens.
+		// reserveTokens defaults to 16,384 in DEFAULT_COMPACTION_SETTINGS.
+		const RESERVE_TOKENS = 16_384
+		if (usage.totalTokens <= model.contextWindow - RESERVE_TOKENS) return
+
+		// Threshold exceeded mid-turn. Compact now.
+		//
+		// NOTE: ctx.compact() is the manual compaction path which calls abort() on the
+		// current agent run. This means the in-progress tool-call chain stops here and
+		// the user must send another message to resume. This is worse UX than upstream
+		// auto-compaction (which transparently retries via agent.continue()), but it is
+		// the only option available from an extension — _runAutoCompaction and the
+		// agent.continue() path are not exposed on ExtensionContext.
+		//
+		// The proper upstream fix is to wire _checkCompaction into the agent loop via
+		// shouldStopAfterTurn or after_provider_response so compaction fires inside
+		// the loop with transparent retry. This handler is a pragmatic stopgap.
+		ctx.compact({
+			onComplete: (result) => {
+				ctx.ui?.notify(
+					`Context compacted (${(result.tokensBefore ?? 0).toLocaleString()} tokens → summary). Continue to resume.`,
+					"info",
+				)
+			},
+			onError: (error) => {
+				ctx.ui?.notify(`Context compaction failed: ${error.message}`, "error")
+			},
+		})
 	})
 
 	_pi.on("model_select", async () => {


### PR DESCRIPTION
# Context Loss Root Cause Report

**Session:** `019e8870-e63e-7fef-b098-720db32ac087`  
**Date:** 2026-06-02 → 2026-06-03 (resumed after ~17-hour gap)  
**Model:** `kimchi-dev/kimi-k2.6` (context window: 262,144 tokens)  
**Project:** `kubecast` (autoscaler bin-packing investigation)  
**Auto-compaction:** enabled  

---

## What the user saw

At the end of a long exploration session the model responded:

> *"It looks like the conversation context was truncated, and I don't have any remaining information about the task we were working on. Could you please restate what you'd like me to do?"*

The model had been actively making progress — its final `<thinking>` block (cut off by the hard context limit) showed it had reached the correct answer and was about to write it up.

---

## Session timeline

| Time | Event | Cumulative input tokens |
|---|---|---|
| Jun 2 13:06 | Session start | — |
| Jun 2 13:15 | Turn 1 ends | 457,648 |
| Jun 2 13:40 | Turn 2 ends | 1,109,262 |
| Jun 2 13:51 | Turn 3 ends | 873,335 |
| Jun 2 13:54 | Turn 4 ends | 147,682 |
| Jun 2 14:09 | Turn 5 ends | 1,211,188 |
| Jun 2 14:22 | Turn 6 ends | 1,140,038 |
| *(17-hour gap)* | | |
| Jun 3 07:46 | Turn 7 ends (Continue) | — |
| Jun 3 08:15 | Turn 8 ends (Continue) | 7,876,716 |
| Jun 3 09:53 | **Turn 9 ends — context lost** | 3,253,693 |

Turn 9 was triggered by the user asking *"Nice finding. Why does the removal of instance criteria change the Node Template scoring?"* The model made 14 consecutive tool calls over 12 minutes without the turn ending, running the context into the hard limit.

---

## Detailed flow of the fatal turn

All entries below are **within a single user turn** — `agent.prompt()` was called once and did not return until entry [402]. `_handlePostAgentRun` (which runs `_checkCompaction`) fires **once**, only when `agent.prompt()` returns.

| Entry | Type | Input tokens | Stop reason | What happened |
|---|---|---|---|---|
| [332] | **User message** | — | — | Turn starts — `agent.prompt()` called |
| [333] | Tool call (read) | 234,767 | toolUse | Growing normally |
| [337] | Tool call (read) | 235,842 | toolUse | |
| [341] | Tool call (grep) | 236,603 | toolUse | |
| [345] | Tool call (grep) | 237,086 | toolUse | |
| [349] | Tool call (grep) | 238,188 | toolUse | |
| — | *exploration guard injected* | — | — | |
| [354] | Tool call (read) | 242,185 | toolUse | |
| [358] | Tool call (grep) | 244,674 | toolUse | |
| [362] | Tool call (read) | 245,384 | toolUse | |
| — | *exploration guard injected* | — | — | |
| [367] | Tool call (grep) | **246,108** | toolUse | Above compaction threshold (245,760) — `_checkCompaction` does not run here |
| [371] | Tool call (grep) | **248,481** | toolUse | Above threshold — same |
| [375] | Tool call (read) | **20,239** | toolUse | model-guard truncated before this call |
| [379] | Tool call (grep) | **255,406** | toolUse | Estimate reset to ~20k → no truncation → full history sent. Above both thresholds |
| [383] | Tool call (grep) | **17,527** | toolUse | model-guard truncated again |
| [387] | Tool call (read) | **258,308** | toolUse | Full history again. Above both thresholds |
| [391] | Tool call (read) | **16,539** | toolUse | model-guard truncated again |
| [395] | Tool call (—) | **260,602** | **length** | Hard limit hit (260,602 + 1,542 output = **262,144**) — output cut mid-generation |
| — | *nudge injected* | — | — | Fires because model produced no tool call |
| [399] | LLM call (—) | **15,754** | stop | Model says "context truncated, I don't know what we were doing" |
| [402] | **Turn ends** | — | — | `_handlePostAgentRun` fires — `_checkCompaction` sees **15,754 tokens → shouldCompact = false** |

---

## Two bugs caused this

### Bug 1 — `_checkCompaction` only runs once per user turn (upstream: pi-agent-core)

`_checkCompaction` is called in `_handlePostAgentRun`, which fires when `agent.prompt()` or `agent.continue()` returns. The agent loop runs all tool calls for a turn internally without returning between them. This means every intermediate LLM response — including the ones at 246k, 248k, 255k, 258k, 260k that all exceeded the compaction threshold — is **invisible to compaction**.

The only response `_checkCompaction` ever sees is the **last** one of the entire turn. In this case that was the nudge-triggered 15k response, which correctly evaluated to `shouldCompact = false`.

Concretely: `pi-agent-core` has a `shouldStopAfterTurn` callback that the agent loop calls between each tool-use round-trip, and an `after_provider_response` extension event that fires inside the loop. Neither is wired up to trigger compaction. If either were, compaction would have fired at entry [367] (246k, the first call to cross the threshold).

### Bug 2 — model-guard truncation interferes with compaction and corrupts the token estimate

`model-guard` has a `context` event handler that fires before **every** individual LLM call (inside the loop). When its estimate of context size exceeds `floor(262,144 × 0.95) = 249,036` tokens, it calls `truncateMessages` — silently dropping old message history and replacing it with a bare `⚠️ Context truncated` notice.

This creates a second problem: `transformContext` (the hook that invokes model-guard) only modifies what is sent to the API for that call. It does not update `agent.state.messages`. So after model-guard truncates to ~20k:

- The LLM reports `usage.input ≈ 20k` for that call
- `agent.state.messages` still holds the full history
- The **next** call's token estimate is anchored to the last assistant's usage (20k) → estimate looks cheap → model-guard does not truncate → full history goes to the API → LLM reports ~255k actual

This is the oscillation visible in the table above: every odd call is truncated to ~17–20k, every even call sends the full history at 255–260k.

Each time the full history is sent (entries 379, 387, 395), `shouldCompact` would return `true` — but `_checkCompaction` is never called for those responses because they are inside the agent loop (Bug 1).

#### Why the model-guard threshold is wrong for this use case

The original purpose of `truncateMessages` was to handle **session restore with a different model**: if a session saved against a 1M-token model is reopened on a 262k-token model, the context physically cannot fit and something must give before the API call fails. That is a legitimate crash-prevention measure.

But the threshold of 95% (`249,036`) fires inside the compaction zone (compaction threshold: `245,760`). In the normal same-model growing-context case, model-guard fires before compaction gets a chance — even if compaction is enabled. The correct threshold for the model-switch scenario is `> contextWindow` (i.e., the context was measured against a *different, larger* window and genuinely cannot fit). For same-model growth, `usage.input` is always `< contextWindow` by API contract, so this trigger would never fire, leaving compaction to do its job.

#### Why the `stop=length` response did not trigger the overflow recovery path

`isContextOverflow` has a Case 3 for length-stop overflow (the Xiaomi MiMo pattern): it fires when `stopReason == "length"` **and** `output == 0`. Entry [395] had `output = 1,542` — the model did produce some output (its `<thinking>` block) before being cut off. So `isContextOverflow` returned `false`, the overflow recovery path did not run, and the session fell through to the nudge.

---

## Why compaction never ran

Combining both bugs:

1. The only calls that exceeded the compaction threshold (entries 367, 371, 379, 387, 395) all happened **inside** the agent loop — Bug 1 means `_checkCompaction` never observed them.
2. The calls that `_checkCompaction` *did* observe (only entry 399, the final response) showed 15,754 tokens because model-guard had just truncated the context — Bug 2 means the token count `_checkCompaction` sees is artificially low.
3. `stop=length` at entry 395 did not trigger the overflow recovery path because the model produced non-zero output tokens before being cut off.

All three conditions had to coincide for this failure to occur, and they did.

---

## Implemented fixes

### Fix 1 — Compaction mid-turn via `turn_end` extension event (this repo)

`_checkCompaction` only runs once per user turn at `agent_end` time, so it never sees intermediate LLM responses. The `turn_end` extension event fires **after every individual LLM response** inside the agent loop, including mid-turn tool calls. A `turn_end` handler in `model-guard` now:

1. Checks only `toolUse` responses (turns ending with `stop`, `length`, `error`, or `aborted` are already handled by `_handlePostAgentRun`)
2. Checks whether `usage.totalTokens` exceeds the same threshold as upstream auto-compaction: `contextWindow − 16,384`
3. Calls `ctx.compact()` to abort the current run and compact **before** the hard limit is hit

**Limitation:** `ctx.compact()` is the manual compaction path which calls `this.abort()` on the agent. The current tool-call chain stops and the user must send another message to resume. This is worse UX than upstream auto-compaction (which transparently retries via `agent.continue()` after compaction), but `_runAutoCompaction` and `agent.continue()` are not exposed on `ExtensionContext`. The proper upstream fix is to wire `_checkCompaction` into the agent loop via `shouldStopAfterTurn` or `after_provider_response`.

### Fix 2 — Raise model-guard's truncation threshold to the hard limit (this repo)

Changed the context-event truncation trigger from `tokens > floor(contextWindow × 0.95)` to `tokens > contextWindow`.

- With compaction enabled, compaction fires at `contextWindow − 16,384` (≈246k) and model-guard at the hard limit (262k) never triggers for normal same-model growth
- With compaction disabled, model-guard only fires when the context genuinely cannot fit the model's window — the session-restore scenario it was designed for

This eliminates the oscillation and stops model-guard from corrupting the token estimate that both itself and compaction rely on.

```ts
// Before
const threshold = Math.floor(model.contextWindow * SAFETY_MARGIN)  // 249,036
if (tokens != null && tokens > threshold) {

// After
if (tokens != null && tokens > model.contextWindow) {
```

Both fixes were implemented in `src/extensions/model-guard.ts` with 5 new tests covering the `turn_end` compaction guard.

---

## Supporting evidence from the session file

- **Zero compaction events** in the entire 403-entry session JSONL (no `compaction_start`, no `compaction_end`), confirming compaction never ran despite auto-compaction being enabled.
- **Entry [395]:** `stopReason=length`, `input=260,602`, `output=1,542`, `totalTokens=262,144` — exactly the model's hard limit.
- **Entry [396]:** Assistant message contains only a `<thinking>` block, no text output — the generation was cut off before producing any visible response.
- **Entry [402]:** `_handlePostAgentRun` receives the assistant from entry [399] with `totalTokens=15,971`. `shouldCompact(15971, 262144, {reserveTokens: 16384})` = `15,971 > 245,760` = **false**.
- **Alternating input pattern** in the final segment: 248k → 20k → 255k → 17k → 258k → 16k → 260k → 15k — the model-guard oscillation is directly visible in the API-reported token counts.
