### PR TITLE
fix(mcp): restore mcp({}) empty-call status behavior

### DIFF
--- a/src/extensions/mcp-adapter/index.ts
+++ b/src/extensions/mcp-adapter/index.ts
@@ -24,6 +24,7 @@ import {
 	executeConnect,
 	executeDescribe,
 	executeSearch,
+	executeStatus,
 	executeUiMessages,
 } from "./proxy-modes.js"
 import type { McpExtensionState } from "./state.js"
@@ -486,10 +487,7 @@ export default function mcpAdapter(pi: ExtensionAPI) {
 					registerAndActivate(specs, undefined, ctx)
 				)
 				}
-				return {
-					content: [{ type: "text" as const, text: `Workflow Error: Missing action parameter.\nTo use MCP tools, you must first discover them and their schemas.\nUse mcp({ search: "..." }) to find tools, or mcp({ describe: "tool_name" }) to get a schema. Matched tools will then be injected for you to call directly.` }],
-					details: { error: "missing_action" },
-				}
+				return executeStatus(state)
 			},
 			renderCall(args: { tool?: string; args?: string; connect?: string; describe?: string; search?: string; limit?: number; server?: string; action?: string }, theme: Theme, context: { lastComponent: Component | undefined }) {
 				const text = (context.lastComponent as Text | undefined) ?? new Text("", 0, 0)


### PR DESCRIPTION
The mcp() tool handler was returning"Missing action parameter"when called with no arguments (mcp({})), but the CHANGELOG and README still document this as a valid "Status" call. Three error messages in proxy-modes.ts also tell users to use mcp({}) to see available servers, creating a frustrating loop.

Fix: wire up the existing executeStatus() function (which was defined but never imported/called) as the fallback when no action parameter is provided.

## Description

<!-- What problem does this PR solve? What changes were made and why? -->


## Type of Change

<!-- Select all that apply. -->

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
