### PR TITLE
feat: add Global user prompt file

### DIFF
--- a/README.md
+++ b/README.md
@@ -256,6 +256,29 @@ Kimchi stores its configuration (settings, sessions, models) under:
 ~/.config/kimchi/harness/
 ```
 
+### Context files
+
+You can provide custom instructions that are injected into the system prompt on every session. Kimchi discovers two kinds of context files:
+
+**Global** — applied to every session, regardless of project:
+
+```
+~/.config/kimchi/harness/AGENTS.md
+```
+
+Place rules that apply everywhere (e.g., your name, code style preferences, or global tool defaults) in this file. It is loaded before any project-level files.
+
+**Project-level** — applied when working in a specific directory tree. Kimchi walks from the working directory up to the filesystem root and collects one context file per directory:
+
+```
+AGENTS.md
+CLAUDE.md
+```
+
+Per directory, `AGENTS.md` takes priority over `CLAUDE.md`. A `.local.md` variant (e.g. `AGENTS.local.md`) is appended to its primary file for user-specific, gitignored overrides.
+
+When both global and project files exist, global instructions appear first in the prompt, followed by ancestor directories, and finally the working directory. This means project-level rules can refine or override global ones.
+
 ### Packages
 
 Kimchi supports native Pi packages. `kimchi install npm:<package>` installs a package only for Kimchi, while `pi install npm:<package>` keeps the package owned by the original Pi harness. Kimchi can also load original Pi packages through the **Pi package lookup** resource, so both CLIs can use Pi packages without sharing Kimchi's install scope.

--- a/src/extensions/agents/index.ts
+++ b/src/extensions/agents/index.ts
@@ -774,6 +774,7 @@ export default function (pi: ExtensionAPI) {
 			...(customDescs.length > 0 ? ["", "Custom agents:", ...customDescs] : []),
 			"",
 			`Custom agents can be defined in .kimchi/agents/<name>.md (project) or ${getAgentDir()}/agents/<name>.md (global) — they are picked up automatically. Project-level agents override global ones. Creating a .md file with the same name as a default agent overrides it.`,
+			`Global user instructions (applied to every session) can be placed in the global ${getAgentDir()}/AGENTS.md. Project-level AGENTS.md or CLAUDE.md files in the working directory tree are combined with it.`,
 		].join("\n")
 	}
 

--- a/src/extensions/prompt-construction/context-files.test.ts
+++ b/src/extensions/prompt-construction/context-files.test.ts
@@ -1,13 +1,22 @@
 import { mkdirSync, rmSync, writeFileSync } from "node:fs"
+import { tmpdir } from "node:os"
 import { join } from "node:path"
-import { afterEach, beforeEach, describe, expect, it } from "vitest"
-import { loadProjectContextFiles } from "./context-files.js"
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
+
+const FAKE_AGENT_DIR = join(tmpdir(), `kimchi-global-context-${Date.now()}`)
+const tmpBase = join(tmpdir(), `kimchi-project-context-${Date.now()}`)
+const nested = join(tmpBase, "a", "b", "c")
+
+vi.mock("@earendil-works/pi-coding-agent", async (importOriginal) => {
+	const actual = (await importOriginal()) as Record<string, unknown>
+	return { ...actual, getAgentDir: () => FAKE_AGENT_DIR }
+})
+
+import { loadGlobalContextFiles, loadProjectContextFiles } from "./context-files.js"
 
 describe("loadProjectContextFiles", () => {
-	const tmpBase = join(import.meta.dirname, "__test_tmp_context__")
-	const nested = join(tmpBase, "a", "b", "c")
-
 	beforeEach(() => {
+		rmSync(tmpBase, { recursive: true, force: true })
 		mkdirSync(nested, { recursive: true })
 	})
 
@@ -106,5 +115,53 @@ describe("loadProjectContextFiles", () => {
 		expect(inTmp).toHaveLength(1)
 		expect(inTmp[0].path).toBe(join(nested, "AGENTS.md"))
 		expect(inTmp[0].content).toBe("agents wins")
+	})
+})
+
+describe("loadGlobalContextFiles", () => {
+	beforeEach(() => {
+		rmSync(FAKE_AGENT_DIR, { recursive: true, force: true })
+		rmSync(tmpBase, { recursive: true, force: true })
+		mkdirSync(FAKE_AGENT_DIR, { recursive: true })
+	})
+
+	afterEach(() => {
+		rmSync(FAKE_AGENT_DIR, { recursive: true, force: true })
+		rmSync(tmpBase, { recursive: true, force: true })
+	})
+
+	it("returns empty array when no global context files exist", () => {
+		const result = loadGlobalContextFiles()
+		expect(result).toEqual([])
+	})
+
+	it("discovers AGENTS.md in agent dir", () => {
+		writeFileSync(join(FAKE_AGENT_DIR, "AGENTS.md"), "# Global rules")
+		const result = loadGlobalContextFiles()
+		expect(result).toHaveLength(1)
+		expect(result[0].path).toBe(join(FAKE_AGENT_DIR, "AGENTS.md"))
+		expect(result[0].content).toBe("# Global rules")
+	})
+
+	it("appends AGENTS.local.md content to AGENTS.md when both exist", () => {
+		writeFileSync(join(FAKE_AGENT_DIR, "AGENTS.md"), "global shared agents")
+		writeFileSync(join(FAKE_AGENT_DIR, "AGENTS.local.md"), "global local agents")
+		const result = loadGlobalContextFiles()
+		expect(result).toHaveLength(1)
+		expect(result[0].path).toBe(join(FAKE_AGENT_DIR, "AGENTS.md"))
+		expect(result[0].content).toBe("global shared agents\n\nglobal local agents")
+	})
+
+	it("returns global files before project files when combined", () => {
+		mkdirSync(nested, { recursive: true })
+		writeFileSync(join(FAKE_AGENT_DIR, "AGENTS.md"), "global first")
+		writeFileSync(join(nested, "AGENTS.md"), "project second")
+		const globalResult = loadGlobalContextFiles()
+		const projectResult = loadProjectContextFiles(nested)
+		const combined = [...globalResult, ...projectResult]
+		const inTmp = combined.filter((f) => f.path.startsWith(FAKE_AGENT_DIR) || f.path.startsWith(tmpBase))
+		expect(inTmp).toHaveLength(2)
+		expect(inTmp[0].content).toBe("global first")
+		expect(inTmp[1].content).toBe("project second")
 	})
 })

--- a/src/extensions/prompt-construction/context-files.ts
+++ b/src/extensions/prompt-construction/context-files.ts
@@ -18,6 +18,7 @@
 
 import { existsSync, readFileSync } from "node:fs"
 import { join, resolve } from "node:path"
+import { getAgentDir } from "@earendil-works/pi-coding-agent"
 
 export interface ContextFile {
 	path: string
@@ -81,4 +82,30 @@ export function loadProjectContextFiles(cwd: string): ContextFile[] {
 	}
 
 	return files
+}
+
+/**
+ * Discover the global context file (AGENTS.md) from the agent
+ * configuration directory (~/.config/kimchi/harness/).
+ *
+ * Only AGENTS.md is checked globally. If a `.local.md` variant
+ * (AGENTS.local.md) exists, it is appended.
+ *
+ * Returns an array of at most one ContextFile, or empty if none found.
+ */
+export function loadGlobalContextFiles(): ContextFile[] {
+	const dir = getAgentDir()
+	if (!dir) return []
+	const filePath = join(dir, "AGENTS.md")
+	const localPath = join(dir, localVariant("AGENTS.md"))
+	const primary = tryReadFile(filePath)
+	const local = tryReadFile(localPath)
+	if (primary !== null) {
+		const content = local !== null ? `${primary}\n\n${local}` : primary
+		return [{ path: filePath, content }]
+	}
+	if (local !== null) {
+		return [{ path: localPath, content: local }]
+	}
+	return []
 }

--- a/src/extensions/prompt-construction/prompt-enrichment.ts
+++ b/src/extensions/prompt-construction/prompt-enrichment.ts
@@ -51,7 +51,7 @@ import { ModelRegistry } from "../orchestration/model-registry/index.js"
 import { registerModelRolesCommand } from "../orchestration/model-roles-command.js"
 import { getModelRoles, modelIdFromRef, splitModelRef, validateModelRoles } from "../orchestration/model-roles.js"
 import { getCurrentPhase } from "../tags.js"
-import { type ContextFile, loadProjectContextFiles } from "./context-files.js"
+import { type ContextFile, loadGlobalContextFiles, loadProjectContextFiles } from "./context-files.js"
 import { type EnvironmentInfo, type PromptMode, type ToolInfo, buildSystemPrompt } from "./system-prompt.js"
 
 function expandSkillPaths(configuredPaths: string[], cwd: string): string[] {
@@ -456,7 +456,7 @@ export default function (skillPaths: string[]) {
 		pi.on("before_agent_start", async (_event, ctx) => {
 			const activeToolNames = new Set(pi.getActiveTools())
 			const tools = pi.getAllTools().filter((tool) => activeToolNames.has(tool.name))
-			cachedContextFiles ??= loadProjectContextFiles(ctx.cwd)
+			cachedContextFiles ??= [...loadGlobalContextFiles(), ...loadProjectContextFiles(ctx.cwd)]
 			if (cachedSkills === undefined) {
 				const allSkillPaths = [
 					...expandSkillPaths(skillPaths, ctx.cwd),

--- a/src/extensions/prompt-construction/system-prompt.test.ts
+++ b/src/extensions/prompt-construction/system-prompt.test.ts
@@ -112,6 +112,24 @@ describe("buildSystemPrompt", () => {
 			expect(result).toContain("Always run tests before committing.")
 		})
 
+		it("places global context files before project context files", () => {
+			const contextFiles = [
+				{ path: "/home/testuser/.config/kimchi/harness/AGENTS.md", content: "Global rule" },
+				{ path: "/repo/AGENTS.md", content: "Project rule" },
+			]
+			const result = buildSystemPrompt({
+				tools,
+				env: testEnv,
+				contextFiles,
+				mode: "orchestrator",
+			})
+			const globalPos = result.indexOf("Global rule")
+			const projectPos = result.indexOf("Project rule")
+			expect(globalPos).toBeGreaterThan(-1)
+			expect(projectPos).toBeGreaterThan(-1)
+			expect(globalPos).toBeLessThan(projectPos)
+		})
+
 		it("injects skills", () => {
 			const skills = [createSkill({ name: "deploy", description: "Deploy the app to production" })]
 			const result = buildSystemPrompt({


### PR DESCRIPTION
## Description

Adds support for global user instruction files that apply to all Kimchi sessions.

Users can now place an `AGENTS.md` in `~/.config/kimchi/harness/` and it will be automatically discovered and prepended to the system prompt on every session. Global files are combined with existing project-level `AGENTS.md`/`CLAUDE.md` files discovered from the working directory tree, with global instructions appearing first so project-level rules can refine or override them.

**Changes:**
- Added `loadGlobalContextFiles()` in `src/extensions/prompt-construction/context-files.ts` that reads the global `AGENTS.md` from `getAgentDir()`.
- Wired global files into `src/extensions/prompt-construction/prompt-enrichment.ts` so they are prepended before project context files before `buildSystemPrompt()`.
- Added test coverage for global file discovery (present, absent, priority, `.local.md` variants, and combined ordering).
- Added system-prompt ordering test verifying global files appear before project files in the rendered prompt.
- Updated README with a "Context files" section documenting global and project-level conventions.
- Updated agents inline help to reference the global `AGENTS.md` location.

**Why:** Previously, context files only worked at the project level (walking up from `cwd`). Users who wanted session-wide instructions (e.g., personal coding style, global tool preferences) had to duplicate them in every project. Global context files solve this while preserving the existing project-level override behavior.

## Type of Change

<!-- Select all that apply. -->

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [x] Documentation update