### PR TITLE
fix(ui): multiline questionaire answer

### DIFF
--- a/src/extensions/questionnaire-form.ts
+++ b/src/extensions/questionnaire-form.ts
@@ -11,7 +11,7 @@
  * a single `title`; ferment's `promptForm` passes `title` + `description`.
  */
 
-import type { Theme } from "@earendil-works/pi-coding-agent"
+import { type Theme, getSelectListTheme } from "@earendil-works/pi-coding-agent"
 import { Editor, Key, type TUI, matchesKey, wrapTextWithAnsi } from "@earendil-works/pi-tui"
 import type { Component } from "@earendil-works/pi-tui"
 import {
@@ -57,13 +57,7 @@ export function createQuestionForm(
 	const isMulti = questions.length > 1
 	const editorTheme = {
 		borderColor: (s: string) => theme.fg("muted", s),
-		selectList: {
-			selectedPrefix: (s: string) => theme.fg("accent", s),
-			selectedText: (s: string) => theme.fg("accent", s),
-			description: (s: string) => theme.fg("muted", s),
-			scrollInfo: (s: string) => theme.fg("dim", s),
-			noMatch: (s: string) => theme.fg("dim", s),
-		},
+		selectList: getSelectListTheme(),
 	}
 	const editor = new Editor(tui, editorTheme)
 	editor.focused = true

--- a/src/extensions/questionnaire-form.ts
+++ b/src/extensions/questionnaire-form.ts
@@ -12,7 +12,7 @@
  */
 
 import type { Theme } from "@earendil-works/pi-coding-agent"
-import { Input, Key, type TUI, matchesKey, wrapTextWithAnsi } from "@earendil-works/pi-tui"
+import { Editor, Key, type TUI, matchesKey, wrapTextWithAnsi } from "@earendil-works/pi-tui"
 import type { Component } from "@earendil-works/pi-tui"
 import {
 	type Answer,
@@ -55,7 +55,17 @@ export function createQuestionForm(
 	let cachedLines: string[] | undefined
 	let cachedWidth = 0
 	const isMulti = questions.length > 1
-	const editor = new Input()
+	const editorTheme = {
+		borderColor: (s: string) => theme.fg("muted", s),
+		selectList: {
+			selectedPrefix: (s: string) => theme.fg("accent", s),
+			selectedText: (s: string) => theme.fg("accent", s),
+			description: (s: string) => theme.fg("muted", s),
+			scrollInfo: (s: string) => theme.fg("dim", s),
+			noMatch: (s: string) => theme.fg("dim", s),
+		},
+	}
+	const editor = new Editor(tui, editorTheme)
 	editor.focused = true
 
 	function applyEffects(effects: QuestionnaireEffect[]): void {
@@ -66,7 +76,7 @@ export function createQuestionForm(
 					tui.requestRender()
 					break
 				case "editor-set-text":
-					editor.setValue(eff.text)
+					editor.setText(eff.text)
 					break
 				case "editor-handle-input":
 					editor.handleInput(eff.data)
@@ -221,7 +231,7 @@ export function createQuestionForm(
 			add(theme.fg("muted", " Your answer:"))
 			for (const line of editor.render(width - 2)) add(` ${line}`)
 			lines.push("")
-			add(theme.fg("dim", " Enter to submit • Esc to cancel"))
+			add(theme.fg("dim", " Enter to submit • Shift+Enter for newline • Esc to cancel"))
 		} else if (isSubmitTab(state)) {
 			add(theme.fg("accent", theme.bold(" Ready to submit")))
 			lines.push("")


### PR DESCRIPTION
## Description

Replace questionnaire free-text answer from `Input` to `Editor` to make it multi-line.

Before:
<img width="859" height="531" alt="Screenshot 2026-06-04 at 16 14 06" src="https://github.com/user-attachments/assets/14dcad94-33e0-4990-97c7-8c9308f21e8b" />

After:
<img width="859" height="531" alt="Screenshot 2026-06-04 at 16 14 55" src="https://github.com/user-attachments/assets/c87564a0-3ee2-4820-a8dd-d336d6878a90" />



## Type of Change

<!-- Select all that apply. -->

- [X] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
