### PR TITLE
feat: number key (1-9) selection in TUI selectors

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "@kimchi-dev/cli",
 	"version": "0.0.0",
-	"description": "kimchi — a coding agent CLI powered by Cast AI",
+	"description": "kimchi \u2014 a coding agent CLI powered by Cast AI",
 	"type": "module",
 	"license": "Apache-2.0",
 	"bin": {
@@ -108,9 +108,9 @@
 			"nan"
 		],
 		"patchedDependencies": {
-			"@earendil-works/pi-coding-agent": "patches/@earendil-works__pi-coding-agent.patch",
 			"@earendil-works/pi-tui": "patches/@earendil-works__pi-tui.patch",
-			"playwright-core@1.59.1": "patches/playwright-core@1.59.1.patch"
+			"playwright-core@1.59.1": "patches/playwright-core@1.59.1.patch",
+			"@earendil-works/pi-coding-agent": "patches/@earendil-works__pi-coding-agent.patch"
 		}
 	}
 }

--- a/patches/@earendil-works__pi-coding-agent.patch
+++ b/patches/@earendil-works__pi-coding-agent.patch
@@ -107,6 +107,35 @@ index 2d54902da1800044206eb1f00ca07501a7310145..44daf4982a5ab6f671f5bce373a94a31
          this.rebuild();
      }
      setExpanded(expanded) {
+diff --git a/dist/modes/interactive/components/extension-selector.js b/dist/modes/interactive/components/extension-selector.js
+--- a/dist/modes/interactive/components/extension-selector.js
++++ b/dist/modes/interactive/components/extension-selector.js
+@@ -2,7 +2,7 @@
+  * Generic selector component for extensions.
+  * Displays a list of string options with keyboard navigation.
+  */
+-import { Container, getKeybindings, Spacer, Text } from "@earendil-works/pi-tui";
++import { Container, getKeybindings, matchesKey, Spacer, Text } from "@earendil-works/pi-tui";
+ import { theme } from "../theme/theme.js";
+ import { CountdownTimer } from "./countdown-timer.js";
+ import { DynamicBorder } from "./dynamic-border.js";
+@@ -75,6 +75,16 @@
+         else if (kb.matches(keyData, "tui.select.cancel")) {
+             this.onCancelCallback();
+         }
++        else {
++            for (let n = 1; n <= 9; n++) {
++                if (matchesKey(keyData, String(n))) {
++                    const selected = this.options[n - 1];
++                    if (selected)
++                        this.onSelectCallback(selected);
++                    break;
++                }
++            }
++        }
+     }
+     dispose() {
+         this.countdown?.dispose();
 diff --git a/dist/modes/interactive/components/model-selector.js b/dist/modes/interactive/components/model-selector.js
 index 879b90f6c1f150a30d05af9f09455b93b5dd15f0..ee23106b19e169807cbd001372180573f43bfb1e 100644
 --- a/dist/modes/interactive/components/model-selector.js

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6,7 +6,7 @@ settings:
 
 patchedDependencies:
   '@earendil-works/pi-coding-agent':
-    hash: 11e94ac7718318a3f17430de437722938537567a1e5590875018c1d3aa9cd9ed
+    hash: c36101b181c447311e7de8e72b2b72907459f1d2ae5344c72d57c3007087a2b4
     path: patches/@earendil-works__pi-coding-agent.patch
   '@earendil-works/pi-tui':
     hash: e432fee0f54b7321d104a08ff5a38561d9c2cd3b002f34e6b8cbc2377889c9d2
@@ -27,7 +27,7 @@ importers:
         version: 1.3.0
       '@earendil-works/pi-coding-agent':
         specifier: ^0.78.0
-        version: 0.78.0(patch_hash=11e94ac7718318a3f17430de437722938537567a1e5590875018c1d3aa9cd9ed)(@modelcontextprotocol/sdk@1.29.0(supports-color@10.2.2)(zod@4.4.3))(supports-color@10.2.2)(ws@8.20.1)(zod@4.4.3)
+        version: 0.78.0(patch_hash=c36101b181c447311e7de8e72b2b72907459f1d2ae5344c72d57c3007087a2b4)(@modelcontextprotocol/sdk@1.29.0(supports-color@10.2.2)(zod@4.4.3))(supports-color@10.2.2)(ws@8.20.1)(zod@4.4.3)
       '@earendil-works/pi-tui':
         specifier: ^0.78.0
         version: 0.78.0(patch_hash=e432fee0f54b7321d104a08ff5a38561d9c2cd3b002f34e6b8cbc2377889c9d2)
@@ -2440,7 +2440,7 @@ snapshots:
       - ws
       - zod
 
-  '@earendil-works/pi-coding-agent@0.78.0(patch_hash=11e94ac7718318a3f17430de437722938537567a1e5590875018c1d3aa9cd9ed)(@modelcontextprotocol/sdk@1.29.0(supports-color@10.2.2)(zod@4.4.3))(supports-color@10.2.2)(ws@8.20.1)(zod@4.4.3)':
+  '@earendil-works/pi-coding-agent@0.78.0(patch_hash=c36101b181c447311e7de8e72b2b72907459f1d2ae5344c72d57c3007087a2b4)(@modelcontextprotocol/sdk@1.29.0(supports-color@10.2.2)(zod@4.4.3))(supports-color@10.2.2)(ws@8.20.1)(zod@4.4.3)':
     dependencies:
       '@earendil-works/pi-agent-core': 0.78.0(@modelcontextprotocol/sdk@1.29.0(supports-color@10.2.2)(zod@4.4.3))(supports-color@10.2.2)(ws@8.20.1)(zod@4.4.3)
       '@earendil-works/pi-ai': 0.78.0(@modelcontextprotocol/sdk@1.29.0(supports-color@10.2.2)(zod@4.4.3))(supports-color@10.2.2)(ws@8.20.1)(zod@4.4.3)

--- a/src/extensions/questionnaire-form.ts
+++ b/src/extensions/questionnaire-form.ts
@@ -12,7 +12,7 @@
  */
 
 import { type Theme, getSelectListTheme } from "@earendil-works/pi-coding-agent"
-import { Editor, Key, type TUI, matchesKey, wrapTextWithAnsi } from "@earendil-works/pi-tui"
+import { Editor, Key, type KeyId, type TUI, matchesKey, wrapTextWithAnsi } from "@earendil-works/pi-tui"
 import type { Component } from "@earendil-works/pi-tui"
 import {
 	type Answer,
@@ -129,6 +129,18 @@ export function createQuestionForm(
 		if (data === " ") {
 			dispatch({ kind: "key-space" })
 			return
+		}
+		// Number keys 1-9: jump directly to that option (1-based index).
+		// Only active for questions that have options (not text questions,
+		// which are handled above, and not the submit tab).
+		const q = currentQuestion(state)
+		if (data.length === 1 && data >= "1" && data <= "9" && q && q.type !== "text") {
+			for (let n = 1; n <= 9; n++) {
+				if (matchesKey(data, String(n) as KeyId)) {
+					dispatch({ kind: "select-option", index: n - 1 })
+					return
+				}
+			}
 		}
 		if (data.length === 1 && data >= " ") {
 			dispatch({ kind: "char-typed", char: data })
@@ -271,16 +283,16 @@ export function createQuestionForm(
 				help = isMulti ? " Tab/←→ navigate • Enter submit • Esc cancel" : " Enter submit • Esc cancel"
 			} else if (q?.type === "multi") {
 				help = isMulti
-					? " Tab/←→ navigate • ↑↓ select • Space toggle • Enter submit • Esc cancel"
-					: " ↑↓ navigate • Space toggle • Enter submit • Esc cancel"
+					? " Tab/←→ navigate • ↑↓/1-9 select • Space toggle • Enter submit • Esc cancel"
+					: " ↑↓/1-9 navigate • Space toggle • Enter submit • Esc cancel"
 			} else if (q?.type === "text") {
 				help = isMulti
 					? " Tab/←→ navigate • Type answer • Enter edit • Esc cancel"
 					: " Type answer • Enter edit • Esc cancel"
 			} else {
 				help = isMulti
-					? " Tab/←→ navigate • ↑↓ select • Enter confirm • Esc cancel"
-					: " ↑↓ navigate • Enter select • Esc cancel"
+					? " Tab/←→ navigate • ↑↓ select • 1-9 pick • Enter confirm • Esc cancel"
+					: " ↑↓ navigate • 1-9 pick • Enter select • Esc cancel"
 			}
 			add(theme.fg("dim", help))
 		}

--- a/src/extensions/questionnaire-reducer.test.ts
+++ b/src/extensions/questionnaire-reducer.test.ts
@@ -403,7 +403,76 @@ describe("submit gating", () => {
 	})
 })
 
-// ─── Group 10: Helpers ────────────────────────────────────────────────────────
+// ─── Group 10: select-option (number-key direct selection) ──────────────────
+
+describe("select-option event", () => {
+	it("single question: select-option confirms the option immediately", () => {
+		const { state, effects } = reduce(initialState([singleQ()]), { kind: "select-option", index: 1 })
+		expect(effects).toContainEqual({ kind: "done", cancelled: false })
+		const answer = state.answers.get("q1")
+		expect(answer).toMatchObject({ value: "opt2", label: "Option 2", index: 2 })
+	})
+
+	it("single question: select-option sets optionIndex to the target", () => {
+		const { state } = reduce(initialState([singleQ()]), { kind: "select-option", index: 1 })
+		expect(state.optionIndex).toBe(1)
+	})
+
+	it("single question: select-option with out-of-range index is a no-op", () => {
+		const initial = initialState([singleQ()])
+		const { state, effects } = reduce(initial, { kind: "select-option", index: 99 })
+		expect(effects).toHaveLength(0)
+		expect(state.answers.size).toBe(0)
+	})
+
+	it("single question: select-option on Other row is a no-op (no text typed)", () => {
+		// singleQ has 2 options + Other at index 2
+		const { effects } = reduce(initialState([singleQ()]), { kind: "select-option", index: 2 })
+		expect(effects).not.toContainEqual({ kind: "done", cancelled: false })
+	})
+
+	it("confirm question: select-option 0 (Yes) confirms immediately", () => {
+		const { effects } = reduce(initialState([confirmQ()]), { kind: "select-option", index: 0 })
+		expect(effects).toContainEqual({ kind: "done", cancelled: false })
+	})
+
+	it("multi question: select-option toggles the option on", () => {
+		const { state, effects } = reduce(initialState([multiQ()]), { kind: "select-option", index: 0 })
+		expect(effects).toContainEqual({ kind: "render" })
+		expect(effects).not.toContainEqual({ kind: "done", cancelled: false })
+		const toggled = state.multiToggles.get("q1")
+		expect(toggled?.has(0)).toBe(true)
+	})
+
+	it("multi question: select-option toggles the option off when already on", () => {
+		let { state } = reduce(initialState([multiQ()]), { kind: "select-option", index: 1 })
+		;({ state } = reduce(state, { kind: "select-option", index: 1 }))
+		const toggled = state.multiToggles.get("q1")
+		expect(toggled?.has(1)).toBe(false)
+	})
+
+	it("multi question: select-option on Other row is a no-op", () => {
+		// multiQ has 3 options + Other at index 3
+		const initial = initialState([multiQ()])
+		const { state } = reduce(initial, { kind: "select-option", index: 3 })
+		const toggled = state.multiToggles.get("q1")
+		expect(toggled?.has(3)).toBeFalsy()
+	})
+
+	it("multi-question flow: select-option advances to next tab after single answer", () => {
+		const sq = { ...singleQ(), id: "sq" }
+		const mq = { ...multiQ(), id: "mq" }
+		const { state } = reduce(initialState([sq, mq]), { kind: "select-option", index: 0 })
+		expect(state.currentTab).toBe(1)
+	})
+
+	it("text question: select-option is ignored (no options)", () => {
+		const { effects } = reduce(initialState([textQ()]), { kind: "select-option", index: 0 })
+		expect(effects).toHaveLength(0)
+	})
+})
+
+// ─── Group 11: Helpers ────────────────────────────────────────────────────────
 
 describe("helpers", () => {
 	it("currentOptions returns options + synthesised Other row when allowOther=true", () => {

--- a/src/extensions/questionnaire-reducer.ts
+++ b/src/extensions/questionnaire-reducer.ts
@@ -76,6 +76,7 @@ export type QuestionnaireEvent =
 	| { kind: "key-space" }
 	| { kind: "char-typed"; char: string }
 	| { kind: "editor-submit"; value: string }
+	| { kind: "select-option"; index: number }
 
 export type QuestionnaireEffect =
 	| { kind: "render" }
@@ -448,6 +449,40 @@ export function reduce(state: QuestionnaireState, event: QuestionnaireEvent): Re
 		if (opt) {
 			saveAnswer(s, q.id, opt.id, opt.label, false, s.optionIndex + 1)
 			advanceAfterAnswer(s, effects)
+		}
+		return { state: freeze(s), effects }
+	}
+
+	// ── Number-key direct selection ───────────────────────────────────────
+	// Pressing 1-9 jumps directly to that option (1-based).
+	// For single/confirm: immediately confirms the selection.
+	// For multi: moves focus to that option and toggles it.
+	if (event.kind === "select-option" && q) {
+		const idx = event.index
+		if (idx >= 0 && idx < opts.length) {
+			s.optionIndex = idx
+			const opt = opts[idx]
+			if (q.type === "multi") {
+				// Toggle like Space, but skip Other (requires typed text first)
+				if (opt && !opt.isOther) {
+					if (!s.multiToggles.has(q.id)) s.multiToggles.set(q.id, new Set())
+					const toggled = s.multiToggles.get(q.id) ?? new Set<number>()
+					if (toggled.has(idx)) {
+						toggled.delete(idx)
+					} else {
+						toggled.add(idx)
+					}
+					saveMultiAnswer(s, q)
+				}
+			} else {
+				// single / confirm: confirm immediately (skip Other)
+				if (opt && !opt.isOther) {
+					saveAnswer(s, q.id, opt.id, opt.label, false, idx + 1)
+					advanceAfterAnswer(s, effects)
+					return { state: freeze(s), effects }
+				}
+			}
+			effects.push({ kind: "render" })
 		}
 		return { state: freeze(s), effects }
 	}


### PR DESCRIPTION
## Summary

Adds support for pressing **1–9** (and numpad 1–9) to immediately select and confirm the corresponding option in any `ExtensionSelectorComponent` — no arrow keys + Enter needed.

This was a customer request, specifically for the permission prompts shown in default mode when the agent asks to run a command.

## What's affected

Every selector that uses `ExtensionSelectorComponent`, including:
- **Permission prompts** — approve/deny tool calls
- **Plan completion menu** — Execute / Convert to ferment / Rework
- **Ferment menus** — continue, abandon, retry/skip/edit step, etc.
- **Agent creation wizard** — type, location, model, tools, thinking level
- **Permissions command menu** and mode picker
- Auth method selector, missing-CWD prompt, questionnaire options

`ModelSelectorComponent` (the model picker) is unaffected — it has its own input handling with search/filter.

## Implementation

Patches `@earendil-works/pi-coding-agent@0.78.0` via `patchedDependencies`:

1. Import `matchesKey` from `@earendil-works/pi-tui` in `extension-selector.js`
2. Add a catch-all `else` block at the end of `handleInput()` that loops `n = 1..9` and calls `matchesKey(keyData, String(n))`

Using `matchesKey` directly (rather than `kb.matches`) is important — `kb.matches` looks up named keybinding IDs from the registry and would always return false for raw digit strings. `matchesKey` is the pi-tui primitive that handles both plain digit characters (`"1"`) and Kitty protocol numpad sequences (`KP_1` = `\x1b[57400u` through `KP_9` = `\x1b[57408u`).

## Testing

- Trigger any permission prompt in default mode → press **1**, **2**, etc. to confirm instantly
- Numpad digits work equally
- Arrow key navigation and Enter/Esc are unaffected
- `pnpm run typecheck` and `pnpm run test` pass (2 pre-existing failures unrelated to this change)