### PR TITLE
fix: stop continuation nudge cycle when LLM responds with stopReason 'stop'

### DIFF
--- a/src/extensions/orchestration/continuation-nudge.test.ts
+++ b/src/extensions/orchestration/continuation-nudge.test.ts
@@ -197,6 +197,42 @@ describe("ContinuationNudge.isDoneSignalReceived", () => {
 	})
 })
 
+describe("ContinuationNudge nudge-response-pending state", () => {
+	it("marks nudge response pending after evaluateTurn fires", () => {
+		const guard = new ContinuationNudge()
+		guard.resetForNewUserInput()
+		expect(guard.isNudgeResponsePending()).toBe(false)
+		guard.evaluateTurn(textOnlyMessage)
+		expect(guard.isNudgeResponsePending()).toBe(true)
+	})
+
+	it("remains pending when model responds without tool calls (handler must check stopReason)", () => {
+		// After a nudge fires and the model responds with text-only (no <done>),
+		// isNudgeResponsePending() stays true because recordToolCall() is never
+		// called. The turn_end handler in prompt-enrichment.ts checks stopReason
+		// to decide whether to honour the stop or send another nudge.
+		const guard = new ContinuationNudge()
+		guard.resetForNewUserInput()
+		guard.evaluateTurn(textOnlyMessage) // first nudge fires
+		expect(guard.isNudgeResponsePending()).toBe(true)
+		// Model responds with text but not <done>; no tool calls recorded.
+		guard.accumulateResponse("I am done with the task.")
+		expect(guard.isNudgeResponsePending()).toBe(true)
+		expect(guard.isDoneSignalReceived()).toBe(false)
+		// At this point the handler checks stopReason === "stop" to break
+		// the nudge cycle instead of falling through to evaluateTurn again.
+	})
+
+	it("clears pending state when model calls a tool after nudge", () => {
+		const guard = new ContinuationNudge()
+		guard.resetForNewUserInput()
+		guard.evaluateTurn(textOnlyMessage) // nudge fires
+		expect(guard.isNudgeResponsePending()).toBe(true)
+		guard.recordToolCall() // model obeyed the nudge
+		expect(guard.isNudgeResponsePending()).toBe(false)
+	})
+})
+
 describe("ContinuationNudge Agent-pending suppression", () => {
 	it("suppresses the nudge when an Agent call is pending", () => {
 		const guard = new ContinuationNudge()

--- a/src/extensions/prompt-construction/prompt-enrichment.test.ts
+++ b/src/extensions/prompt-construction/prompt-enrichment.test.ts
@@ -564,3 +564,122 @@ describe("deprecated model notification", () => {
 		)
 	})
 })
+
+describe("continuation nudge turn_end handler", () => {
+	beforeEach(() => {
+		vi.restoreAllMocks()
+	})
+
+	function buildNudgeHandlers() {
+		const handlerMap = new Map<string, Array<(event: unknown, ctx?: unknown) => Promise<unknown> | unknown>>()
+		const sendMessageCalls: Array<{ message: unknown; options: unknown }> = []
+
+		vi.spyOn(agentWorkerContext, "isAgentWorker").mockReturnValue(false)
+		vi.spyOn(startupContext, "getAvailableModels").mockReturnValue([])
+		vi.spyOn(config, "loadConfig").mockReturnValue({
+			apiKey: "",
+			agentConfigDir: "",
+			llmEndpoint: "",
+			customLlmEndpoint: undefined,
+			maxToolResultChars: 0,
+			mcpSearchLimit: 5,
+			mcpSearch: {
+				strategy: "bm25" as const,
+				bm25K1: 1.2,
+				bm25B: 0.75,
+				fieldWeights: { name: 6, description: 2, schemaKey: 1 },
+			},
+			onboarding: {},
+			deviceId: "test",
+		})
+
+		const pi = {
+			registerFlag: () => {},
+			registerCommand: () => {},
+			on: (event: string, handler: (event: unknown, ctx?: unknown) => Promise<unknown> | unknown) => {
+				const list = handlerMap.get(event) ?? []
+				list.push(handler)
+				handlerMap.set(event, list)
+			},
+			getAllTools: () => [],
+			getActiveTools: () => [],
+			getFlag: () => false,
+			sendMessage: (message: unknown, options: unknown) => {
+				sendMessageCalls.push({ message, options })
+			},
+			events: { on: () => {}, emit: () => {} },
+		} as unknown as ExtensionAPI
+
+		promptEnrichmentExtension([])(pi)
+
+		const fire = async (event: string, payload: unknown) => {
+			const handlers = handlerMap.get(event) ?? []
+			for (const h of handlers) await h(payload)
+		}
+
+		return { fire, sendMessageCalls }
+	}
+
+	function makeAssistantWithStop(
+		content: AssistantMessage["content"],
+		stopReason: AssistantMessage["stopReason"] = "stop",
+	): AssistantMessage {
+		return { ...makeAssistant(content), stopReason }
+	}
+
+	it("sends a continuation nudge on a text-only turn with no tools called", async () => {
+		const { fire, sendMessageCalls } = buildNudgeHandlers()
+
+		// Simulate user input to reset the nudge state.
+		await fire("input", { source: "user" })
+
+		// Model responds with text-only, stopReason "stop".
+		await fire("turn_end", {
+			message: makeAssistantWithStop([{ type: "text", text: "I will delegate this." }]),
+		})
+
+		// A continuation nudge should have been sent.
+		expect(sendMessageCalls.length).toBe(1)
+		expect((sendMessageCalls[0].message as { customType?: string }).customType).toBe("nudge")
+	})
+
+	it("does not send a second nudge when model responds to nudge with stopReason 'stop'", async () => {
+		const { fire, sendMessageCalls } = buildNudgeHandlers()
+
+		// Simulate user input.
+		await fire("input", { source: "user" })
+
+		// First text-only turn triggers the continuation nudge.
+		await fire("turn_end", {
+			message: makeAssistantWithStop([{ type: "text", text: "I will delegate this." }]),
+		})
+		expect(sendMessageCalls.length).toBe(1)
+
+		// Model responds to the nudge with text and stopReason "stop".
+		// The handler should NOT send a second nudge.
+		await fire("turn_end", {
+			message: makeAssistantWithStop([{ type: "text", text: "OK, I am done." }]),
+		})
+		expect(sendMessageCalls.length).toBe(1) // no new nudge
+	})
+
+	it("falls through to second nudge when model responds with non-stop stopReason", async () => {
+		const { fire, sendMessageCalls } = buildNudgeHandlers()
+
+		await fire("input", { source: "user" })
+
+		// First text-only turn triggers the continuation nudge.
+		await fire("turn_end", {
+			message: makeAssistantWithStop([{ type: "text", text: "I will delegate this." }]),
+		})
+		expect(sendMessageCalls.length).toBe(1)
+
+		// Model responds with stopReason "length" (e.g. output truncated).
+		// The handler should allow a second nudge since the model did not
+		// intentionally stop.
+		await fire("turn_end", {
+			message: makeAssistantWithStop([{ type: "text", text: "I was going to say..." }], "length"),
+		})
+		expect(sendMessageCalls.length).toBe(2)
+	})
+})

--- a/src/extensions/prompt-construction/prompt-enrichment.ts
+++ b/src/extensions/prompt-construction/prompt-enrichment.ts
@@ -387,25 +387,31 @@ export default function (skillPaths: string[]) {
 
 			pi.on("turn_end", async (event) => {
 				if (event.message.role !== "assistant") return
+				// Safe after the role guard: AgentMessage with role "assistant" is AssistantMessage.
+				const assistantMsg = event.message as AssistantMessage
 
 				// Mark each delegation tool call so the continuation nudge stays
 				// suppressed until all delegated-agent results have been received.
 				// A single turn may contain multiple parallel agent calls.
-				for (const c of event.message.content) {
+				for (const c of assistantMsg.content) {
 					if (c.type === "toolCall" && isDelegationToolCallName((c as { name?: string }).name)) {
 						continuationNudge.markDelegationCall()
 					}
 				}
 
 				if (continuationNudge.isNudgeResponsePending()) {
-					if (continuationNudge.isDoneSignalReceived()) {
+					if (continuationNudge.isDoneSignalReceived() || assistantMsg.stopReason === "stop") {
+						// The model either explicitly sent the <done> signal or ended its
+						// turn with stopReason "stop" (intentional end-of-turn). Either
+						// way, respect the stop — do not send another nudge that would
+						// trigger a new turn and make the model think it received user input.
 						return
 					}
 					// While a continuation nudge response is pending, the model is already
 					// in a recovery cycle. Skip empty-turn nudge here to avoid sending
 					// mixed instructions ("call a tool" vs "summarize or continue").
 					// Fall through to continuationNudge.evaluateTurn below.
-				} else if (emptyTurnNudge.evaluateTurn(event.message)) {
+				} else if (emptyTurnNudge.evaluateTurn(assistantMsg)) {
 					pi.sendMessage(
 						{ customType: NUDGE_CUSTOM_TYPE, content: EMPTY_TURN_NUDGE_TEXT, display: false },
 						{ deliverAs: "followUp" },
@@ -413,7 +419,7 @@ export default function (skillPaths: string[]) {
 					return
 				}
 
-				if (!continuationNudge.evaluateTurn(event.message)) return
+				if (!continuationNudge.evaluateTurn(assistantMsg)) return
 				pi.sendMessage(
 					{
 						customType: NUDGE_CUSTOM_TYPE,


### PR DESCRIPTION
## Problem

When a continuation nudge was sent (to recover from Kimi K2.x text-only drift) and the model responded with text (not the `<done>` signal) but with `stopReason: "stop"` (intentional end-of-turn), the `turn_end` handler would fall through to `evaluateTurn` again, potentially firing a second nudge. Each nudge triggers a new turn via `deliverAs: "followUp"`, making the model think it received user input and continue working unnecessarily.

## Root Cause

In `prompt-enrichment.ts`, the `isNudgeResponsePending()` branch only checked for the literal `<done>` signal via `isDoneSignalReceived()`. When the model responded to the nudge with normal text and `stopReason: "stop"`, this wasn't recognized as "done" and the handler fell through, allowing another nudge to fire.

## Fix

Added `assistantMsg.stopReason === "stop"` as an alternative exit condition alongside `isDoneSignalReceived()` in the `isNudgeResponsePending()` branch of the `turn_end` handler. When the model explicitly signals stop after receiving a nudge, we respect it and don't send another nudge.

### Preserved behavior
- The **first** continuation nudge still fires normally on text-only turns with no tool calls (preserving Kimi K2.x drift recovery)
- Only the **response cycle** is changed: if the model responds to the nudge with an intentional stop, we don't send another nudge

## Changes

- `src/extensions/prompt-construction/prompt-enrichment.ts`: Check `stopReason === "stop"` in the nudge-response-pending path
- `src/extensions/orchestration/continuation-nudge.test.ts`: 3 new tests documenting the nudge-response-pending state machine

## Testing

- `pnpm run typecheck` — clean
- All existing continuation-nudge tests pass (48 total, 3 new)
- All prompt-enrichment tests pass (20 total)