### PR TITLE
Auto-enable telemetry with informational notice

### DIFF
--- a/src/commands/setup-tools.test.ts
+++ b/src/commands/setup-tools.test.ts
@@ -135,7 +135,7 @@ describe("runSetupTools", () => {
 		expect(applyToolConfigs).toHaveBeenCalledWith(expect.objectContaining({ telemetryEnabled: false }))
 	})
 
-	it("prompts for telemetry when preference is not yet configured", async () => {
+	it("shows telemetry notice and auto-enables when preference is not yet configured", async () => {
 		vi.mocked(resolveApiKey).mockReturnValue("test-key")
 		vi.mocked(promptToolSelection).mockResolvedValue({ kind: "next", value: ["cursor"] })
 		vi.mocked(isTelemetryExplicitlyConfigured).mockReturnValue(false)
@@ -150,17 +150,6 @@ describe("runSetupTools", () => {
 
 		expect(promptTelemetry).toHaveBeenCalledWith({ backable: false })
 		expect(applyToolConfigs).toHaveBeenCalledWith(expect.objectContaining({ telemetryEnabled: true }))
-	})
-
-	it("exits with code 1 when telemetry prompt is cancelled", async () => {
-		vi.mocked(resolveApiKey).mockReturnValue("test-key")
-		vi.mocked(promptToolSelection).mockResolvedValue({ kind: "next", value: ["cursor"] })
-		vi.mocked(isTelemetryExplicitlyConfigured).mockReturnValue(false)
-		vi.mocked(promptTelemetry).mockResolvedValue({ kind: "cancel" })
-
-		const result = await runSetupTools([])
-		expect(result).toBe(1)
-		expect(applyToolConfigs).not.toHaveBeenCalled()
 	})
 
 	it("does not send telemetry when telemetry is disabled", async () => {
@@ -193,19 +182,6 @@ describe("runSetupTools", () => {
 		expect(result).toBe(1)
 		expect(sendPreSessionEvent).toHaveBeenCalledWith(mockTelemetryConfig, "tools_setup_aborted", {
 			step: "tools",
-		})
-	})
-
-	it("sends tools_setup_aborted with step telemetry when user cancels at telemetry prompt", async () => {
-		vi.mocked(resolveApiKey).mockReturnValue("test-key")
-		vi.mocked(promptToolSelection).mockResolvedValue({ kind: "next", value: ["cursor"] })
-		vi.mocked(isTelemetryExplicitlyConfigured).mockReturnValue(false)
-		vi.mocked(promptTelemetry).mockResolvedValue({ kind: "cancel" })
-
-		const result = await runSetupTools([])
-		expect(result).toBe(1)
-		expect(sendPreSessionEvent).toHaveBeenCalledWith(mockTelemetryConfig, "tools_setup_aborted", {
-			step: "telemetry",
 		})
 	})
 

--- a/src/commands/setup-tools.ts
+++ b/src/commands/setup-tools.ts
@@ -72,22 +72,13 @@ export async function runSetupTools(args: string[]): Promise<number> {
 
 	// Resolve telemetry preference. If the user has already chosen (via
 	// `kimchi setup`, `kimchi config telemetry`, or $KIMCHI_TELEMETRY_ENABLED)
-	// we respect that. Otherwise prompt — some tools (Claude Code) write
-	// telemetry settings into their config files.
+	// we respect that. Otherwise we auto-enable and show a notice.
 	let telemetryEnabled: boolean
 	if (isTelemetryExplicitlyConfigured()) {
 		telemetryEnabled = readTelemetryConfig().enabled
 	} else {
-		const telemetryResult = await promptTelemetry({ backable: false })
-		if (telemetryResult.kind === "cancel" || telemetryResult.kind === "back") {
-			if (telemetryConfig.enabled) {
-				sendPreSessionEvent(telemetryConfig, "tools_setup_aborted", { step: "telemetry" })
-				await drainPreSessionTelemetry()
-			}
-			outro("Cancelled.")
-			return 1
-		}
-		telemetryEnabled = telemetryResult.value
+		await promptTelemetry({ backable: false })
+		telemetryEnabled = true
 	}
 
 	// Fetch live models.

--- a/src/extensions/telemetry/README.md
+++ b/src/extensions/telemetry/README.md
@@ -110,4 +110,4 @@ Example: `write|accept|TypeScript|auto`
 
 - **File paths are hashed** (SHA-256, first 12 chars) before being sent as `file_hash`.
 - **No prompt content or file contents** are transmitted.
-- Telemetry is opt-in and controlled by `telemetry.enabled` in `~/.config/kimchi/config.json` (overridable via `$KIMCHI_TELEMETRY_ENABLED`).
+- Telemetry is on by default and controlled by `telemetry.enabled` in `~/.config/kimchi/config.json` (overridable via `$KIMCHI_TELEMETRY_ENABLED`).

--- a/src/setup-wizard/steps/telemetry.test.ts
+++ b/src/setup-wizard/steps/telemetry.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it, vi } from "vitest"
+
+vi.mock("@clack/prompts", () => ({
+	note: vi.fn(),
+}))
+
+vi.mock("../../config.js", () => ({
+	writeTelemetryEnabled: vi.fn(),
+}))
+
+import { note } from "@clack/prompts"
+import { writeTelemetryEnabled } from "../../config.js"
+import { promptTelemetry, runTelemetryStep } from "./telemetry.js"
+
+describe("promptTelemetry", () => {
+	it("shows the telemetry notice and auto-enables telemetry", async () => {
+		const result = await promptTelemetry({ backable: false })
+
+		expect(note).toHaveBeenCalledWith(
+			"Kimchi collects usage data (commands run, models used, error rates) to improve the product. This data is associated with your account. No prompt content or code is collected.",
+			"Usage telemetry",
+		)
+		expect(writeTelemetryEnabled).toHaveBeenCalledWith(true)
+		expect(result).toEqual({ kind: "next", value: true })
+	})
+})
+
+describe("runTelemetryStep", () => {
+	it("sets telemetryEnabled to true on state", async () => {
+		const state = {
+			apiKey: "",
+			mode: "override" as const,
+			scope: "global" as const,
+			selectedTools: [],
+			telemetryEnabled: false,
+			cancelled: false,
+			back: false,
+		}
+
+		await runTelemetryStep(state, { backable: false })
+
+		expect(state.telemetryEnabled).toBe(true)
+		expect(state.cancelled).toBe(false)
+		expect(state.back).toBe(false)
+	})
+})

--- a/src/setup-wizard/steps/telemetry.ts
+++ b/src/setup-wizard/steps/telemetry.ts
@@ -1,55 +1,26 @@
 import { note } from "@clack/prompts"
 import { writeTelemetryEnabled } from "../../config.js"
 import type { Outcome } from "../prompt.js"
-import { select } from "../prompt.js"
 import type { WizardState } from "../state.js"
 
 /**
- * Standalone telemetry prompt. Can be used both inside the setup wizard
- * and by standalone commands that need to ask for telemetry preference.
+ * Standalone telemetry notice. Can be used both inside the setup wizard
+ * and by standalone commands that need to inform users about telemetry.
  *
- * Returns the raw outcome so callers decide what to do with back/cancel.
- * Persists the choice to config.json on success.
+ * Automatically enables telemetry and persists the choice to config.json.
  */
-export async function promptTelemetry(opts: { backable: boolean }): Promise<Outcome<boolean>> {
+export async function promptTelemetry(_opts: { backable: boolean }): Promise<Outcome<boolean>> {
 	note(
-		[
-			"Help us improve your experience by sharing anonymous usage metrics.",
-			"This data enhances your Coding Report in the Kimchi console.",
-			"",
-			"What we collect:",
-			"  • Number of requests and sessions",
-			"  • Token usage and model selection",
-			"  • Error rates and performance metrics",
-			"",
-			"What we don't collect:",
-			"  • Your actual prompts or code",
-			"  • File contents or sensitive data",
-			"  • Personal information",
-		].join("\n"),
+		"Kimchi collects usage data (commands run, models used, error rates) to improve the product. This data is associated with your account. No prompt content or code is collected.",
 		"Usage telemetry",
 	)
 
-	const r = await select<"on" | "off">({
-		message: "Share anonymous usage data?",
-		options: [
-			{ value: "on", label: "Yes, share anonymous usage data" },
-			{ value: "off", label: "No, keep my usage private" },
-		],
-		initialValue: "on",
-		backable: opts.backable,
-	})
-	if (r.kind === "back") return { kind: "back" }
-	if (r.kind === "cancel") return { kind: "cancel" }
-
-	const enabled = r.value === "on"
-	writeTelemetryEnabled(enabled)
-	return { kind: "next", value: enabled }
+	writeTelemetryEnabled(true)
+	return { kind: "next", value: true }
 }
 
 /**
- * Telemetry step — explain exactly what we collect and offer opt-in /
- * opt-out. The disclosure copy is load-bearing — be careful when editing.
+ * Telemetry step — inform the user that telemetry is enabled by default.
  *
  * The choice is persisted to ~/.config/kimchi/config.json's
  * telemetry.enabled. $KIMCHI_TELEMETRY_ENABLED still wins over the


### PR DESCRIPTION
## Summary
Replace the telemetry opt-in prompt during setup with automatic opt-in. Instead of asking users to share usage data, we now show an informational notice and persist `telemetry.enabled = true` to `config.json`.

## Changes
- `promptTelemetry()` now shows a note and auto-enables instead of prompting
- `runTelemetryStep()` preserved; back/cancel handling kept defensively
- `setup-tools` removes dead cancel/back branches for the telemetry prompt
- New tests cover the auto-enable behavior in `telemetry.test.ts`
- Updated README to reflect telemetry is on by default (opt-out)

## Opt-out
The opt-out mechanism is unchanged:
- `KIMCHI_TELEMETRY_ENABLED=0` disables telemetry for the current process
- `kimchi config telemetry off` persists the choice to `config.json`

## Verification
- `pnpm run typecheck` ✅
- `pnpm run lint` ✅
- `pnpm run test` — all telemetry-related tests pass ✅