### PR TITLE
fix: remove fermenting option from spinner

### DIFF
--- a/src/extensions/spinner.ts
+++ b/src/extensions/spinner.ts
@@ -49,6 +49,7 @@ const COOKING_FRAMES: readonly {
 	},
 	{ frames: ["✦", "✧", "✦", "✧"], message: "Prepping aromatics", intervalMs: 140 },
 	{ frames: ["·", "+", "·", "×", "·", "+"], message: "Simmering", intervalMs: 93 },
+	{ frames: ["❄", "·", "❄", "·"], message: "Chilling", intervalMs: 200 },
 	{ frames: ["·", "+", "·", "×", "·", "+"], message: "Seasoning", intervalMs: 93 },
 	{ frames: ["ˊ", "`", "ˊ", "`"], message: "Tasting", intervalMs: 100 },
 	{ frames: ["z", "Z", "z", "Z"], message: "Letting it rest", intervalMs: 140 },

--- a/src/extensions/spinner.ts
+++ b/src/extensions/spinner.ts
@@ -49,7 +49,6 @@ const COOKING_FRAMES: readonly {
 	},
 	{ frames: ["✦", "✧", "✦", "✧"], message: "Prepping aromatics", intervalMs: 140 },
 	{ frames: ["·", "+", "·", "×", "·", "+"], message: "Simmering", intervalMs: 93 },
-	{ frames: ["░", "▒", "▓", "█", "▓", "▒", "░"], message: "Fermenting", intervalMs: 80 },
 	{ frames: ["·", "+", "·", "×", "·", "+"], message: "Seasoning", intervalMs: 93 },
 	{ frames: ["ˊ", "`", "ˊ", "`"], message: "Tasting", intervalMs: 100 },
 	{ frames: ["z", "Z", "z", "Z"], message: "Letting it rest", intervalMs: 140 },


### PR DESCRIPTION
Having the fermenting message in the spinner causes some confusing when not using /ferment.