### PR TITLE
fix(permissions): auto-match bare deny rules against bash programs

### DIFF
--- a/src/extensions/permissions/rules.test.ts
+++ b/src/extensions/permissions/rules.test.ts
@@ -131,6 +131,23 @@ describe("evaluateRules precedence", () => {
 		expect(match.decision).toBe("no-match")
 	})
 
+	it("auto-rewrites bare rules to match bash invocations of that program", () => {
+		const r: Rule[] = [{ toolName: "rm", content: undefined, behavior: "deny", source: "project" }]
+		expect(evaluateRules(r, "bash", { command: "rm file.txt" }).decision).toBe("deny")
+		expect(evaluateRules(r, "bash", { command: "rtk rm file.txt" }).decision).toBe("deny")
+		expect(evaluateRules(r, "bash", { command: "mv file.txt" }).decision).toBe("no-match")
+		// When rtk wraps "bash", the underlying program is "bash", not "rm".
+		expect(evaluateRules(r, "bash", { command: "rtk bash rm file.txt" }).decision).toBe("no-match")
+	})
+
+	it("auto-rewrite affects bash builtins that share tool names", () => {
+		const r: Rule[] = [{ toolName: "read", content: undefined, behavior: "deny", source: "project" }]
+		expect(evaluateRules(r, "read", { path: "foo" }).decision).toBe("deny")
+		// read is also a bash builtin, so bare "read" rule matches bash(read ...)
+		expect(evaluateRules(r, "bash", { command: "read var" }).decision).toBe("deny")
+		expect(evaluateRules(r, "bash", { command: "echo hello" }).decision).toBe("no-match")
+	})
+
 	it("first match in source order wins across sources", () => {
 		const r: Rule[] = [
 			{ toolName: "bash", content: undefined, behavior: "allow", source: "project" },

--- a/src/extensions/permissions/rules.ts
+++ b/src/extensions/permissions/rules.ts
@@ -1,5 +1,5 @@
 import micromatch from "micromatch"
-import { FILE_TOOLS } from "./taxonomy.js"
+import { FILE_TOOLS, extractBashProgram } from "./taxonomy.js"
 import type { Rule, RuleBehavior, RuleSource } from "./types.js"
 
 // Rule syntax: `toolname` or `toolname(content)`. Tool names are case-
@@ -26,7 +26,18 @@ export function stringifyRule(rule: Rule): string {
 const BASH_TOOL = "bash"
 
 export function matchRule(rule: Rule, toolName: string, input: Record<string, unknown>): boolean {
-	if (rule.toolName !== toolName.toLowerCase()) return false
+	const lowerToolName = toolName.toLowerCase()
+	if (rule.toolName !== lowerToolName) {
+		// Auto-rewrite: bare rules like "rm" or "mv" should match bash invocations
+		// of that program (including through rtk wrapper). Users naturally write
+		// deny: ["rm"] expecting it to block bash(rm ...) commands.
+		if (rule.content === undefined && lowerToolName === BASH_TOOL) {
+			const command = typeof input.command === "string" ? input.command : ""
+			const { program } = extractBashProgram(command)
+			if (rule.toolName === program) return true
+		}
+		return false
+	}
 	if (rule.content === undefined) return true
 
 	if (toolName === BASH_TOOL) {


### PR DESCRIPTION
## Description

Users naturally write deny rules like `["rm", "mv"]` in permissions.json, expecting them to block bash invocations of those programs. Previously these were parsed as rules for non-existent tools named "rm"/"mv", so they never matched actual `bash()` tool calls. Enforcement fell through to the LLM classifier, producing inconsistent prompting in auto mode.

This change makes `matchRule()` fall back to extracting the underlying program from the bash command (including through the `rtk` wrapper) and matching bare rules against that program. This makes e.g. `deny: ["rm"]` correctly block `bash(rm file.txt)` and `bash(rtk rm file.txt)`.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

Closes LLM-1641