### PR TITLE
feat(acp): expose multi-model in models list

### DIFF
--- a/src/extensions/model-switch.ts
+++ b/src/extensions/model-switch.ts
@@ -12,11 +12,11 @@ import {
 } from "./model-guard.js"
 import { MODEL_CAPABILITIES } from "./orchestration/model-registry/builtin-models.js"
 import type { ModelTier } from "./orchestration/model-registry/types.js"
-import { splitModelRef } from "./orchestration/model-roles.js"
 import {
 	getMultiModelEnabled,
 	getOrchestratorModelId,
 	getOrchestratorModelRef,
+	resolveOrchestratorModel,
 	setMultiModelEnabled,
 } from "./prompt-construction/prompt-enrichment.js"
 
@@ -64,8 +64,7 @@ export default function modelSwitchExtension(pi: ExtensionAPI) {
 			if (model === "multi-model") {
 				const orchRef = getOrchestratorModelRef()
 				const orchId = getOrchestratorModelId()
-				const parsed = splitModelRef(orchRef)
-				const orchestrator = parsed ? ctx.modelRegistry?.find(parsed.provider, parsed.modelId) : undefined
+				const orchestrator = ctx.modelRegistry ? resolveOrchestratorModel(ctx.modelRegistry) : undefined
 				if (!orchestrator) {
 					return {
 						content: [{ type: "text" as const, text: `Multi-model orchestrator (${orchRef}) is not available.` }],

--- a/src/extensions/prompt-construction/prompt-enrichment.test.ts
+++ b/src/extensions/prompt-construction/prompt-enrichment.test.ts
@@ -7,6 +7,8 @@ import * as startupContext from "../../startup-context.js"
 import * as agentWorkerContext from "../agent-worker-context.js"
 import type { OrchestratorMessages } from "../orchestration/continuation-nudge.js"
 import promptEnrichmentExtension, {
+	getMultiModelEnabled,
+	setMultiModelEnabled,
 	stripEmptyToolCalls,
 	_resetDeprecatedNotificationTracking,
 } from "./prompt-enrichment.js"
@@ -681,5 +683,18 @@ describe("continuation nudge turn_end handler", () => {
 			message: makeAssistantWithStop([{ type: "text", text: "I was going to say..." }], "length"),
 		})
 		expect(sendMessageCalls.length).toBe(2)
+	})
+})
+
+describe("global multi-model state (CLI mode)", () => {
+	it("returns false by default", () => {
+		expect(getMultiModelEnabled()).toBe(false)
+	})
+
+	it("get/set round-trips", () => {
+		setMultiModelEnabled(true)
+		expect(getMultiModelEnabled()).toBe(true)
+		setMultiModelEnabled(false)
+		expect(getMultiModelEnabled()).toBe(false)
 	})
 })

--- a/src/extensions/prompt-construction/prompt-enrichment.ts
+++ b/src/extensions/prompt-construction/prompt-enrichment.ts
@@ -25,8 +25,14 @@ import { randomUUID } from "node:crypto"
 import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs"
 import { homedir, platform, userInfo } from "node:os"
 import { isAbsolute, join, normalize, resolve } from "node:path"
-import type { AssistantMessage } from "@earendil-works/pi-ai"
-import { type ExtensionAPI, type Skill, getAgentDir, loadSkills } from "@earendil-works/pi-coding-agent"
+import type { Api, AssistantMessage, Model } from "@earendil-works/pi-ai"
+import {
+	type ExtensionAPI,
+	type ModelRegistry as PiModelRegistry,
+	type Skill,
+	getAgentDir,
+	loadSkills,
+} from "@earendil-works/pi-coding-agent"
 import { loadConfig } from "../../config.js"
 import { getAvailableModels } from "../../startup-context.js"
 import { getGitBranch } from "../../utils.js"
@@ -38,7 +44,6 @@ import {
 	setProcessOrchestratorRef,
 } from "../kimchi-process.js"
 import {
-	CONTINUATION_NUDGE_TEXT,
 	ContinuationNudge,
 	EMPTY_TURN_NUDGE_TEXT,
 	EmptyTurnNudge,
@@ -149,6 +154,18 @@ export function getOrchestratorModelId(): string {
 export function getOrchestratorModelRef(): string {
 	return getModelRoles().orchestrator
 }
+
+/**
+ * Resolve the orchestrator model from a registry. Returns the model object
+ * if found, or undefined if the orchestrator ref is invalid or unavailable.
+ */
+export function resolveOrchestratorModel(registry: PiModelRegistry): Model<Api> | undefined {
+	const ref = getOrchestratorModelRef()
+	const parsed = splitModelRef(ref)
+	if (!parsed) return undefined
+	return registry.find(parsed.provider, parsed.modelId)
+}
+
 const DELEGATION_TOOL_NAMES = new Set(["Agent", "subagent"])
 
 // Tracks sessions that have already received a deprecation notification to avoid duplicate alerts.

--- a/src/extensions/prompt-construction/prompt-enrichment.ts
+++ b/src/extensions/prompt-construction/prompt-enrichment.ts
@@ -34,6 +34,7 @@ import {
 	loadSkills,
 } from "@earendil-works/pi-coding-agent"
 import { loadConfig } from "../../config.js"
+import { getCurrentSessionId, getSessionMultiModelEnabled } from "../../modes/acp/session-state.js"
 import { getAvailableModels } from "../../startup-context.js"
 import { getGitBranch } from "../../utils.js"
 import { isAgentWorker } from "../agent-worker-context.js"
@@ -88,8 +89,11 @@ function safeUsername(): string {
 function readGitRemote(cwd: string): string | undefined {
 	try {
 		return (
-			execSync("git remote get-url origin", { cwd, encoding: "utf8", stdio: ["ignore", "pipe", "ignore"] }).trim() ||
-			undefined
+			execSync("git remote get-url origin", {
+				cwd,
+				encoding: "utf8",
+				stdio: ["ignore", "pipe", "ignore"],
+			}).trim() || undefined
 		)
 	} catch {
 		return undefined
@@ -237,7 +241,10 @@ export function stripEmptyToolCalls(messages: OrchestratorMessages): Orchestrato
 			if (cleaned.length !== msg.content.length) {
 				changed = true
 				if (cleaned.length > 0) {
-					filtered.push({ ...msg, content: cleaned } as OrchestratorMessages[number])
+					filtered.push({
+						...msg,
+						content: cleaned,
+					} as OrchestratorMessages[number])
 				}
 				continue
 			}
@@ -256,7 +263,18 @@ export function stripEmptyToolCalls(messages: OrchestratorMessages): Orchestrato
 	return changed ? filtered : messages
 }
 
+/**
+ * Get the effective multi-model enabled state.
+ * In ACP mode (inside a runWithSession context), returns per-session state.
+ * In CLI mode, returns the global flag (synced with cross-process state).
+ */
 export function getMultiModelEnabled(): boolean {
+	// Check per-session state first (ACP mode)
+	const sessionId = getCurrentSessionId()
+	if (sessionId) {
+		return getSessionMultiModelEnabled(sessionId)
+	}
+	// CLI mode: cross-process sync — a subagent may have toggled the flag
 	const processFlag = getProcessMultiModelEnabled()
 	if (processFlag !== undefined && processFlag !== multiModelEnabled) {
 		multiModelEnabled = processFlag
@@ -265,10 +283,12 @@ export function getMultiModelEnabled(): boolean {
 	return multiModelEnabled
 }
 
+/**
+ * Set the global multi-model enabled state (CLI mode).
+ * ACP mode should use setSessionMultiModelEnabled from session-state.ts.
+ */
 export function setMultiModelEnabled(enabled: boolean): void {
 	multiModelEnabled = enabled
-	// Only update the enabled flag — the orchestrator ref is managed separately
-	// via setProcessOrchestratorRef() when roles actually change, not here.
 	setProcessMultiModelEnabled(enabled)
 	writeMultiModelSetting(enabled)
 }
@@ -319,7 +339,9 @@ export default function (skillPaths: string[]) {
 			function notifyIfDeprecated(ctx: {
 				sessionManager?: { getSessionId: () => string | undefined }
 				model?: { id: string }
-				ui?: { notify: (msg: string, kind?: "warning" | "error" | "info") => void }
+				ui?: {
+					notify: (msg: string, kind?: "warning" | "error" | "info") => void
+				}
 			}) {
 				const sessionId = ctx.sessionManager?.getSessionId() ?? "unknown"
 				if (ctx.model && deprecatedWarnings.has(ctx.model.id) && !deprecatedNotificationFired.has(sessionId)) {
@@ -345,7 +367,7 @@ export default function (skillPaths: string[]) {
 				// In multi-model mode the orchestrator must always be the configured
 				// orchestrator model. Force-switch if the user has a different model
 				// selected via /models.
-				if (multiModelEnabled && ctx.model?.id !== getOrchestratorModelId()) {
+				if (getMultiModelEnabled() && ctx.model?.id !== getOrchestratorModelId()) {
 					const ref = splitModelRef(getOrchestratorModelRef())
 					const orchestratorModel = ref ? ctx.modelRegistry?.find(ref.provider, ref.modelId) : undefined
 					if (orchestratorModel) {
@@ -430,7 +452,11 @@ export default function (skillPaths: string[]) {
 					// Fall through to continuationNudge.evaluateTurn below.
 				} else if (emptyTurnNudge.evaluateTurn(assistantMsg)) {
 					pi.sendMessage(
-						{ customType: NUDGE_CUSTOM_TYPE, content: EMPTY_TURN_NUDGE_TEXT, display: false },
+						{
+							customType: NUDGE_CUSTOM_TYPE,
+							content: EMPTY_TURN_NUDGE_TEXT,
+							display: false,
+						},
 						{ deliverAs: "followUp" },
 					)
 					return
@@ -467,7 +493,10 @@ export default function (skillPaths: string[]) {
 			})
 		}
 
-		const platformNames: Record<string, string> = { darwin: "macOS", win32: "Windows" }
+		const platformNames: Record<string, string> = {
+			darwin: "macOS",
+			win32: "Windows",
+		}
 		const cachedOs = platformNames[platform()] ?? platform()
 		const cachedUsername = safeUsername()
 		const cachedHomeDir = homedir()
@@ -510,7 +539,7 @@ export default function (skillPaths: string[]) {
 				gitRemote: isGitRepo ? (cachedGitRemote ?? undefined) : undefined,
 			}
 
-			const mode: PromptMode = subagentMode ? "subagent" : multiModelEnabled ? "orchestrator" : "single"
+			const mode: PromptMode = subagentMode ? "subagent" : getMultiModelEnabled() ? "orchestrator" : "single"
 			const roles = mode === "orchestrator" ? getModelRoles() : undefined
 
 			const systemPrompt = buildSystemPrompt({

--- a/src/modes/acp/server.test.ts
+++ b/src/modes/acp/server.test.ts
@@ -19,8 +19,20 @@ const THEME_KEY = Symbol.for("@earendil-works/pi-coding-agent:theme")
 const THEME_KEY_OLD = Symbol.for("@mariozechner/pi-coding-agent:theme")
 
 import { _resetState as _resetHideThinking, _setHideThinking } from "../../extensions/hide-thinking.js"
-import { resolveModelRoles } from "../../extensions/orchestration/model-roles.js"
 import { getAcpPrompter } from "./permission-prompter-registry.js"
+
+// Mock resolveModelRoles to ensure hermetic tests that don't depend on external settings
+vi.mock("../../extensions/orchestration/model-roles.js", async (importOriginal) => {
+	const actual = await importOriginal<typeof import("../../extensions/orchestration/model-roles.js")>()
+	return {
+		...actual,
+		resolveModelRoles: () => ({
+			roles: { orchestrator: "test-provider/test-orchestrator" },
+			warnings: [],
+		}),
+		getModelRoles: () => ({ orchestrator: "test-provider/test-orchestrator" }),
+	}
+})
 import {
 	type AcpSessionFactory,
 	type AcpSessionLister,
@@ -1258,18 +1270,18 @@ describe("buildSessionModelState", () => {
 	it("returns multi-model currentModelId when multi-model mode is active", () => {
 		const fake = new FakeAgentSession("s1")
 		fake.model = { provider: "openai", id: "gpt-4" }
+		// Fixed test fixture for orchestrator to ensure hermetic tests
+		const TEST_ORCHESTRATOR_PROVIDER = "test-provider"
+		const TEST_ORCHESTRATOR_MODEL = "test-model"
 		fake.modelRegistry = {
 			getAvailable: () => [
 				{ provider: "openai", id: "gpt-4", name: "GPT-4" },
 				{ provider: "anthropic", id: "claude-3", name: "Claude 3" },
 			],
 			find: (provider: string, modelId: string) => {
-				// Return a model matching the orchestrator from settings
-				const { roles } = resolveModelRoles()
-				const orchRef = roles.orchestrator
-				const orchParts = orchRef.split("/")
-				if (orchParts.length === 2 && provider === orchParts[0] && modelId === orchParts[1]) {
-					return { provider: orchParts[0], id: orchParts[1], name: "Orchestrator Model" }
+				// Use fixed test fixture instead of calling resolveModelRoles()
+				if (provider === TEST_ORCHESTRATOR_PROVIDER && modelId === TEST_ORCHESTRATOR_MODEL) {
+					return { provider: TEST_ORCHESTRATOR_PROVIDER, id: TEST_ORCHESTRATOR_MODEL, name: "Orchestrator Model" }
 				}
 				return undefined
 			},
@@ -1395,10 +1407,9 @@ describe("unstable_setSessionModel", () => {
 	it("switches to multi-model mode", async () => {
 		const fake = new FakeAgentSession("switch-session")
 		fake.model = { provider: "provider-a", id: "model-a" }
-		// Use the actual orchestrator from settings to match what resolveModelRoles returns
-		const { roles } = resolveModelRoles()
-		const orchRef = roles.orchestrator
-		const [orchProvider, orchModelId] = orchRef.split("/")
+		// Use fixed test fixture for orchestrator to ensure deterministic, hermetic tests
+		const orchProvider = "test-provider"
+		const orchModelId = "test-orchestrator"
 		fake.modelRegistry = {
 			getAvailable: () => [
 				{ provider: orchProvider, id: orchModelId, name: "Orchestrator Model" },

--- a/src/modes/acp/server.test.ts
+++ b/src/modes/acp/server.test.ts
@@ -1247,7 +1247,7 @@ describe("buildSessionModelState", () => {
 			expect(result).toEqual({
 				currentModelId: "openai/gpt-4",
 				availableModels: [
-					{ modelId: "multi-model", name: "Multi-Model" },
+					{ modelId: "multi-model", name: expect.stringContaining("Multi-Model") },
 					{ modelId: "openai/gpt-4", name: "GPT-4" },
 					{ modelId: "anthropic/claude-3", name: "Claude 3" },
 				],
@@ -1267,7 +1267,7 @@ describe("buildSessionModelState", () => {
 			const result = buildSessionModelState(fake as unknown as Parameters<typeof buildSessionModelState>[0])
 			expect(result).toEqual({
 				currentModelId: "openai/gpt-4",
-				availableModels: [{ modelId: "multi-model", name: "Multi-Model" }],
+				availableModels: [{ modelId: "multi-model", name: expect.stringContaining("Multi-Model") }],
 			})
 		} finally {
 			setMultiModelEnabled(wasEnabled)
@@ -1284,11 +1284,24 @@ describe("buildSessionModelState", () => {
 					{ provider: "openai", id: "gpt-4", name: "GPT-4" },
 					{ provider: "anthropic", id: "claude-3", name: "Claude 3" },
 				],
+				find: (provider: string, modelId: string) => {
+					// Return a model matching the orchestrator from settings
+					const { roles } = resolveModelRoles()
+					const orchRef = roles.orchestrator
+					const orchParts = orchRef.split("/")
+					if (orchParts.length === 2 && provider === orchParts[0] && modelId === orchParts[1]) {
+						return { provider: orchParts[0], id: orchParts[1], name: "Orchestrator Model" }
+					}
+					return undefined
+				},
 			}
 			setMultiModelEnabled(true)
 			const result = buildSessionModelState(fake as unknown as Parameters<typeof buildSessionModelState>[0])
-			expect(result?.currentModelId).toBe(`multi-model/${resolveModelRoles().roles.orchestrator}`)
-			expect(result?.availableModels[0]).toEqual({ modelId: "multi-model", name: "Multi-Model" })
+			expect(result?.currentModelId).toBe("multi-model")
+			expect(result?.availableModels[0]).toEqual({
+				modelId: "multi-model",
+				name: expect.stringContaining("Multi-Model"),
+			})
 		} finally {
 			setMultiModelEnabled(wasEnabled)
 		}
@@ -1316,7 +1329,10 @@ describe("newSession model state", () => {
 		expect(res.models).toBeDefined()
 		expect(res.models?.currentModelId).toBe("openai/gpt-4")
 		expect(res.models?.availableModels).toHaveLength(3)
-		expect(res.models?.availableModels[0]).toEqual({ modelId: "multi-model", name: "Multi-Model" })
+		expect(res.models?.availableModels[0]).toEqual({
+			modelId: "multi-model",
+			name: expect.stringContaining("Multi-Model"),
+		})
 		expect(res.models?.availableModels[1]).toEqual({ modelId: "openai/gpt-4", name: "GPT-4" })
 		expect(res.models?.availableModels[2]).toEqual({ modelId: "anthropic/claude-3", name: "Claude 3" })
 	})
@@ -2031,7 +2047,7 @@ describe("KimchiAcpAgent loadSession", () => {
 		expect(res.models).toMatchObject({
 			currentModelId: "test/test-model",
 			availableModels: [
-				{ modelId: "multi-model", name: "Multi-Model" },
+				{ modelId: "multi-model", name: expect.stringContaining("Multi-Model") },
 				{ modelId: "test/test-model", name: "Test Model" },
 			],
 		})

--- a/src/modes/acp/server.test.ts
+++ b/src/modes/acp/server.test.ts
@@ -1249,7 +1249,7 @@ describe("buildSessionModelState", () => {
 		expect(result).toEqual({
 			currentModelId: "openai/gpt-4",
 			availableModels: [
-				{ modelId: "multi-model", name: expect.stringContaining("Multi-Model") },
+				{ modelId: "multi-model", name: expect.stringContaining("Multi-model") },
 				{ modelId: "openai/gpt-4", name: "GPT-4" },
 				{ modelId: "anthropic/claude-3", name: "Claude 3" },
 			],
@@ -1263,7 +1263,7 @@ describe("buildSessionModelState", () => {
 		const result = buildSessionModelState(fake as unknown as Parameters<typeof buildSessionModelState>[0])
 		expect(result).toEqual({
 			currentModelId: "openai/gpt-4",
-			availableModels: [{ modelId: "multi-model", name: expect.stringContaining("Multi-Model") }],
+			availableModels: [{ modelId: "multi-model", name: expect.stringContaining("Multi-model") }],
 		})
 	})
 
@@ -1291,7 +1291,7 @@ describe("buildSessionModelState", () => {
 		expect(result?.currentModelId).toBe("multi-model")
 		expect(result?.availableModels[0]).toEqual({
 			modelId: "multi-model",
-			name: expect.stringContaining("Multi-Model"),
+			name: expect.stringContaining("Multi-model"),
 		})
 	})
 })
@@ -1319,7 +1319,7 @@ describe("newSession model state", () => {
 		expect(res.models?.availableModels).toHaveLength(3)
 		expect(res.models?.availableModels[0]).toEqual({
 			modelId: "multi-model",
-			name: expect.stringContaining("Multi-Model"),
+			name: expect.stringContaining("Multi-model"),
 		})
 		expect(res.models?.availableModels[1]).toEqual({ modelId: "openai/gpt-4", name: "GPT-4" })
 		expect(res.models?.availableModels[2]).toEqual({ modelId: "anthropic/claude-3", name: "Claude 3" })
@@ -2028,7 +2028,7 @@ describe("KimchiAcpAgent loadSession", () => {
 		expect(res.models).toMatchObject({
 			currentModelId: "test/test-model",
 			availableModels: [
-				{ modelId: "multi-model", name: expect.stringContaining("Multi-Model") },
+				{ modelId: "multi-model", name: expect.stringContaining("Multi-model") },
 				{ modelId: "test/test-model", name: "Test Model" },
 			],
 		})

--- a/src/modes/acp/server.test.ts
+++ b/src/modes/acp/server.test.ts
@@ -20,7 +20,6 @@ const THEME_KEY_OLD = Symbol.for("@mariozechner/pi-coding-agent:theme")
 
 import { _resetState as _resetHideThinking, _setHideThinking } from "../../extensions/hide-thinking.js"
 import { resolveModelRoles } from "../../extensions/orchestration/model-roles.js"
-import { getMultiModelEnabled, setMultiModelEnabled } from "../../extensions/prompt-construction/prompt-enrichment.js"
 import { getAcpPrompter } from "./permission-prompter-registry.js"
 import {
 	type AcpSessionFactory,
@@ -1219,92 +1218,69 @@ describe("initializeHeadlessTheme", () => {
 
 describe("buildSessionModelState", () => {
 	it("returns null when model is missing", () => {
-		const wasEnabled = getMultiModelEnabled()
-		try {
-			setMultiModelEnabled(false)
-			const fake = new FakeAgentSession("s1")
-			fake.model = undefined
-			const result = buildSessionModelState(fake as unknown as Parameters<typeof buildSessionModelState>[0])
-			expect(result).toBeNull()
-		} finally {
-			setMultiModelEnabled(wasEnabled)
-		}
+		const fake = new FakeAgentSession("s1")
+		fake.model = undefined
+		const result = buildSessionModelState(fake as unknown as Parameters<typeof buildSessionModelState>[0])
+		expect(result).toBeNull()
 	})
 
 	it("returns currentModelId and availableModels when model is present", () => {
-		const wasEnabled = getMultiModelEnabled()
-		try {
-			setMultiModelEnabled(false)
-			const fake = new FakeAgentSession("s1")
-			fake.model = { provider: "openai", id: "gpt-4" }
-			fake.modelRegistry = {
-				getAvailable: () => [
-					{ provider: "openai", id: "gpt-4", name: "GPT-4" },
-					{ provider: "anthropic", id: "claude-3", name: "Claude 3" },
-				],
-			}
-			const result = buildSessionModelState(fake as unknown as Parameters<typeof buildSessionModelState>[0])
-			expect(result).toEqual({
-				currentModelId: "openai/gpt-4",
-				availableModels: [
-					{ modelId: "multi-model", name: expect.stringContaining("Multi-Model") },
-					{ modelId: "openai/gpt-4", name: "GPT-4" },
-					{ modelId: "anthropic/claude-3", name: "Claude 3" },
-				],
-			})
-		} finally {
-			setMultiModelEnabled(wasEnabled)
+		const fake = new FakeAgentSession("s1")
+		fake.model = { provider: "openai", id: "gpt-4" }
+		fake.modelRegistry = {
+			getAvailable: () => [
+				{ provider: "openai", id: "gpt-4", name: "GPT-4" },
+				{ provider: "anthropic", id: "claude-3", name: "Claude 3" },
+			],
 		}
+		const result = buildSessionModelState(fake as unknown as Parameters<typeof buildSessionModelState>[0])
+		expect(result).toEqual({
+			currentModelId: "openai/gpt-4",
+			availableModels: [
+				{ modelId: "multi-model", name: expect.stringContaining("Multi-Model") },
+				{ modelId: "openai/gpt-4", name: "GPT-4" },
+				{ modelId: "anthropic/claude-3", name: "Claude 3" },
+			],
+		})
 	})
 
 	it("returns empty availableModels when registry has no models", () => {
-		const wasEnabled = getMultiModelEnabled()
-		try {
-			setMultiModelEnabled(false)
-			const fake = new FakeAgentSession("s1")
-			fake.model = { provider: "openai", id: "gpt-4" }
-			fake.modelRegistry = { getAvailable: () => [] }
-			const result = buildSessionModelState(fake as unknown as Parameters<typeof buildSessionModelState>[0])
-			expect(result).toEqual({
-				currentModelId: "openai/gpt-4",
-				availableModels: [{ modelId: "multi-model", name: expect.stringContaining("Multi-Model") }],
-			})
-		} finally {
-			setMultiModelEnabled(wasEnabled)
-		}
+		const fake = new FakeAgentSession("s1")
+		fake.model = { provider: "openai", id: "gpt-4" }
+		fake.modelRegistry = { getAvailable: () => [] }
+		const result = buildSessionModelState(fake as unknown as Parameters<typeof buildSessionModelState>[0])
+		expect(result).toEqual({
+			currentModelId: "openai/gpt-4",
+			availableModels: [{ modelId: "multi-model", name: expect.stringContaining("Multi-Model") }],
+		})
 	})
 
 	it("returns multi-model currentModelId when multi-model mode is active", () => {
-		const wasEnabled = getMultiModelEnabled()
-		try {
-			const fake = new FakeAgentSession("s1")
-			fake.model = { provider: "openai", id: "gpt-4" }
-			fake.modelRegistry = {
-				getAvailable: () => [
-					{ provider: "openai", id: "gpt-4", name: "GPT-4" },
-					{ provider: "anthropic", id: "claude-3", name: "Claude 3" },
-				],
-				find: (provider: string, modelId: string) => {
-					// Return a model matching the orchestrator from settings
-					const { roles } = resolveModelRoles()
-					const orchRef = roles.orchestrator
-					const orchParts = orchRef.split("/")
-					if (orchParts.length === 2 && provider === orchParts[0] && modelId === orchParts[1]) {
-						return { provider: orchParts[0], id: orchParts[1], name: "Orchestrator Model" }
-					}
-					return undefined
-				},
-			}
-			setMultiModelEnabled(true)
-			const result = buildSessionModelState(fake as unknown as Parameters<typeof buildSessionModelState>[0])
-			expect(result?.currentModelId).toBe("multi-model")
-			expect(result?.availableModels[0]).toEqual({
-				modelId: "multi-model",
-				name: expect.stringContaining("Multi-Model"),
-			})
-		} finally {
-			setMultiModelEnabled(wasEnabled)
+		const fake = new FakeAgentSession("s1")
+		fake.model = { provider: "openai", id: "gpt-4" }
+		fake.modelRegistry = {
+			getAvailable: () => [
+				{ provider: "openai", id: "gpt-4", name: "GPT-4" },
+				{ provider: "anthropic", id: "claude-3", name: "Claude 3" },
+			],
+			find: (provider: string, modelId: string) => {
+				// Return a model matching the orchestrator from settings
+				const { roles } = resolveModelRoles()
+				const orchRef = roles.orchestrator
+				const orchParts = orchRef.split("/")
+				if (orchParts.length === 2 && provider === orchParts[0] && modelId === orchParts[1]) {
+					return { provider: orchParts[0], id: orchParts[1], name: "Orchestrator Model" }
+				}
+				return undefined
+			},
 		}
+		// Pass true as second argument to enable multi-model state
+		const result = buildSessionModelState(fake as unknown as Parameters<typeof buildSessionModelState>[0], true)
+		expect(result?.currentModelId).toBe("multi-model")
+		expect(result?.availableModels[0]).toEqual({
+			modelId: "multi-model",
+			name: expect.stringContaining("Multi-Model"),
+		})
 	})
 })
 
@@ -1417,41 +1393,35 @@ describe("unstable_setSessionModel", () => {
 	})
 
 	it("switches to multi-model mode", async () => {
-		// Save and restore multi-model state to avoid polluting other tests
-		const wasEnabled = getMultiModelEnabled()
-		try {
-			const fake = new FakeAgentSession("switch-session")
-			fake.model = { provider: "provider-a", id: "model-a" }
-			// Use the actual orchestrator from settings to match what resolveModelRoles returns
-			const { roles } = resolveModelRoles()
-			const orchRef = roles.orchestrator
-			const [orchProvider, orchModelId] = orchRef.split("/")
-			fake.modelRegistry = {
-				getAvailable: () => [
-					{ provider: orchProvider, id: orchModelId, name: "Orchestrator Model" },
-					{ provider: "provider-a", id: "model-a", name: "Model A" },
-				],
-				find: (provider: string, modelId: string) => {
-					if (provider === orchProvider && modelId === orchModelId) {
-						return { provider: orchProvider, id: orchModelId, name: "Orchestrator Model" }
-					}
-					return undefined
-				},
-			}
-			const factory: AcpSessionFactory = async () => asSession(fake)
-			const agent = new KimchiAcpAgent(makeConn(), {
-				extensionFactories: [],
-				agentDir: "/tmp/fake-agent-dir",
-				sessionFactory: factory,
-			})
-			await agent.newSession({ cwd: "/tmp", mcpServers: [] })
-			const res = await agent.unstable_setSessionModel({ sessionId: "switch-session", modelId: "multi-model" })
-			expect(res).toEqual({})
-			expect(fake.model?.provider).toBe(orchProvider)
-			expect(fake.model?.id).toBe(orchModelId)
-		} finally {
-			setMultiModelEnabled(wasEnabled)
+		const fake = new FakeAgentSession("switch-session")
+		fake.model = { provider: "provider-a", id: "model-a" }
+		// Use the actual orchestrator from settings to match what resolveModelRoles returns
+		const { roles } = resolveModelRoles()
+		const orchRef = roles.orchestrator
+		const [orchProvider, orchModelId] = orchRef.split("/")
+		fake.modelRegistry = {
+			getAvailable: () => [
+				{ provider: orchProvider, id: orchModelId, name: "Orchestrator Model" },
+				{ provider: "provider-a", id: "model-a", name: "Model A" },
+			],
+			find: (provider: string, modelId: string) => {
+				if (provider === orchProvider && modelId === orchModelId) {
+					return { provider: orchProvider, id: orchModelId, name: "Orchestrator Model" }
+				}
+				return undefined
+			},
 		}
+		const factory: AcpSessionFactory = async () => asSession(fake)
+		const agent = new KimchiAcpAgent(makeConn(), {
+			extensionFactories: [],
+			agentDir: "/tmp/fake-agent-dir",
+			sessionFactory: factory,
+		})
+		await agent.newSession({ cwd: "/tmp", mcpServers: [] })
+		const res = await agent.unstable_setSessionModel({ sessionId: "switch-session", modelId: "multi-model" })
+		expect(res).toEqual({})
+		expect(fake.model?.provider).toBe(orchProvider)
+		expect(fake.model?.id).toBe(orchModelId)
 	})
 
 	it("throws invalidParams for unknown sessionId", async () => {

--- a/src/modes/acp/server.test.ts
+++ b/src/modes/acp/server.test.ts
@@ -19,6 +19,8 @@ const THEME_KEY = Symbol.for("@earendil-works/pi-coding-agent:theme")
 const THEME_KEY_OLD = Symbol.for("@mariozechner/pi-coding-agent:theme")
 
 import { _resetState as _resetHideThinking, _setHideThinking } from "../../extensions/hide-thinking.js"
+import { resolveModelRoles } from "../../extensions/orchestration/model-roles.js"
+import { getMultiModelEnabled, setMultiModelEnabled } from "../../extensions/prompt-construction/prompt-enrichment.js"
 import { getAcpPrompter } from "./permission-prompter-registry.js"
 import {
 	type AcpSessionFactory,
@@ -52,7 +54,10 @@ class FakeAgentSession {
 		name: "Test Model",
 		input: ["text"],
 	}
-	modelRegistry = {
+	modelRegistry: {
+		getAvailable: () => { provider: string; id: string; name: string }[]
+		find?: (provider: string, modelId: string) => { provider: string; id: string; name: string } | undefined
+	} = {
 		getAvailable: () =>
 			this.model ? [{ provider: this.model.provider, id: this.model.id, name: this.model.name ?? this.model.id }] : [],
 	}
@@ -1214,40 +1219,79 @@ describe("initializeHeadlessTheme", () => {
 
 describe("buildSessionModelState", () => {
 	it("returns null when model is missing", () => {
-		const fake = new FakeAgentSession("s1")
-		fake.model = undefined
-		const result = buildSessionModelState(fake as unknown as Parameters<typeof buildSessionModelState>[0])
-		expect(result).toBeNull()
+		const wasEnabled = getMultiModelEnabled()
+		try {
+			setMultiModelEnabled(false)
+			const fake = new FakeAgentSession("s1")
+			fake.model = undefined
+			const result = buildSessionModelState(fake as unknown as Parameters<typeof buildSessionModelState>[0])
+			expect(result).toBeNull()
+		} finally {
+			setMultiModelEnabled(wasEnabled)
+		}
 	})
 
 	it("returns currentModelId and availableModels when model is present", () => {
-		const fake = new FakeAgentSession("s1")
-		fake.model = { provider: "openai", id: "gpt-4" }
-		fake.modelRegistry = {
-			getAvailable: () => [
-				{ provider: "openai", id: "gpt-4", name: "GPT-4" },
-				{ provider: "anthropic", id: "claude-3", name: "Claude 3" },
-			],
+		const wasEnabled = getMultiModelEnabled()
+		try {
+			setMultiModelEnabled(false)
+			const fake = new FakeAgentSession("s1")
+			fake.model = { provider: "openai", id: "gpt-4" }
+			fake.modelRegistry = {
+				getAvailable: () => [
+					{ provider: "openai", id: "gpt-4", name: "GPT-4" },
+					{ provider: "anthropic", id: "claude-3", name: "Claude 3" },
+				],
+			}
+			const result = buildSessionModelState(fake as unknown as Parameters<typeof buildSessionModelState>[0])
+			expect(result).toEqual({
+				currentModelId: "openai/gpt-4",
+				availableModels: [
+					{ modelId: "multi-model", name: "Multi-Model" },
+					{ modelId: "openai/gpt-4", name: "GPT-4" },
+					{ modelId: "anthropic/claude-3", name: "Claude 3" },
+				],
+			})
+		} finally {
+			setMultiModelEnabled(wasEnabled)
 		}
-		const result = buildSessionModelState(fake as unknown as Parameters<typeof buildSessionModelState>[0])
-		expect(result).toEqual({
-			currentModelId: "openai/gpt-4",
-			availableModels: [
-				{ modelId: "openai/gpt-4", name: "GPT-4" },
-				{ modelId: "anthropic/claude-3", name: "Claude 3" },
-			],
-		})
 	})
 
 	it("returns empty availableModels when registry has no models", () => {
-		const fake = new FakeAgentSession("s1")
-		fake.model = { provider: "openai", id: "gpt-4" }
-		fake.modelRegistry = { getAvailable: () => [] }
-		const result = buildSessionModelState(fake as unknown as Parameters<typeof buildSessionModelState>[0])
-		expect(result).toEqual({
-			currentModelId: "openai/gpt-4",
-			availableModels: [],
-		})
+		const wasEnabled = getMultiModelEnabled()
+		try {
+			setMultiModelEnabled(false)
+			const fake = new FakeAgentSession("s1")
+			fake.model = { provider: "openai", id: "gpt-4" }
+			fake.modelRegistry = { getAvailable: () => [] }
+			const result = buildSessionModelState(fake as unknown as Parameters<typeof buildSessionModelState>[0])
+			expect(result).toEqual({
+				currentModelId: "openai/gpt-4",
+				availableModels: [{ modelId: "multi-model", name: "Multi-Model" }],
+			})
+		} finally {
+			setMultiModelEnabled(wasEnabled)
+		}
+	})
+
+	it("returns multi-model currentModelId when multi-model mode is active", () => {
+		const wasEnabled = getMultiModelEnabled()
+		try {
+			const fake = new FakeAgentSession("s1")
+			fake.model = { provider: "openai", id: "gpt-4" }
+			fake.modelRegistry = {
+				getAvailable: () => [
+					{ provider: "openai", id: "gpt-4", name: "GPT-4" },
+					{ provider: "anthropic", id: "claude-3", name: "Claude 3" },
+				],
+			}
+			setMultiModelEnabled(true)
+			const result = buildSessionModelState(fake as unknown as Parameters<typeof buildSessionModelState>[0])
+			expect(result?.currentModelId).toBe(`multi-model/${resolveModelRoles().roles.orchestrator}`)
+			expect(result?.availableModels[0]).toEqual({ modelId: "multi-model", name: "Multi-Model" })
+		} finally {
+			setMultiModelEnabled(wasEnabled)
+		}
 	})
 })
 
@@ -1271,9 +1315,10 @@ describe("newSession model state", () => {
 		expect(res.sessionId).toBe("session-model")
 		expect(res.models).toBeDefined()
 		expect(res.models?.currentModelId).toBe("openai/gpt-4")
-		expect(res.models?.availableModels).toHaveLength(2)
-		expect(res.models?.availableModels[0]).toEqual({ modelId: "openai/gpt-4", name: "GPT-4" })
-		expect(res.models?.availableModels[1]).toEqual({ modelId: "anthropic/claude-3", name: "Claude 3" })
+		expect(res.models?.availableModels).toHaveLength(3)
+		expect(res.models?.availableModels[0]).toEqual({ modelId: "multi-model", name: "Multi-Model" })
+		expect(res.models?.availableModels[1]).toEqual({ modelId: "openai/gpt-4", name: "GPT-4" })
+		expect(res.models?.availableModels[2]).toEqual({ modelId: "anthropic/claude-3", name: "Claude 3" })
 	})
 
 	it("rejects with authRequired when no model is active", async () => {
@@ -1353,6 +1398,44 @@ describe("unstable_setSessionModel", () => {
 		expect(result).toBeDefined()
 		expect(fake.model?.provider).toBe("provider-b")
 		expect(fake.model?.id).toBe("model-b")
+	})
+
+	it("switches to multi-model mode", async () => {
+		// Save and restore multi-model state to avoid polluting other tests
+		const wasEnabled = getMultiModelEnabled()
+		try {
+			const fake = new FakeAgentSession("switch-session")
+			fake.model = { provider: "provider-a", id: "model-a" }
+			// Use the actual orchestrator from settings to match what resolveModelRoles returns
+			const { roles } = resolveModelRoles()
+			const orchRef = roles.orchestrator
+			const [orchProvider, orchModelId] = orchRef.split("/")
+			fake.modelRegistry = {
+				getAvailable: () => [
+					{ provider: orchProvider, id: orchModelId, name: "Orchestrator Model" },
+					{ provider: "provider-a", id: "model-a", name: "Model A" },
+				],
+				find: (provider: string, modelId: string) => {
+					if (provider === orchProvider && modelId === orchModelId) {
+						return { provider: orchProvider, id: orchModelId, name: "Orchestrator Model" }
+					}
+					return undefined
+				},
+			}
+			const factory: AcpSessionFactory = async () => asSession(fake)
+			const agent = new KimchiAcpAgent(makeConn(), {
+				extensionFactories: [],
+				agentDir: "/tmp/fake-agent-dir",
+				sessionFactory: factory,
+			})
+			await agent.newSession({ cwd: "/tmp", mcpServers: [] })
+			const res = await agent.unstable_setSessionModel({ sessionId: "switch-session", modelId: "multi-model" })
+			expect(res).toEqual({})
+			expect(fake.model?.provider).toBe(orchProvider)
+			expect(fake.model?.id).toBe(orchModelId)
+		} finally {
+			setMultiModelEnabled(wasEnabled)
+		}
 	})
 
 	it("throws invalidParams for unknown sessionId", async () => {
@@ -1947,7 +2030,10 @@ describe("KimchiAcpAgent loadSession", () => {
 		})
 		expect(res.models).toMatchObject({
 			currentModelId: "test/test-model",
-			availableModels: [{ modelId: "test/test-model", name: "Test Model" }],
+			availableModels: [
+				{ modelId: "multi-model", name: "Multi-Model" },
+				{ modelId: "test/test-model", name: "Test Model" },
+			],
 		})
 	})
 

--- a/src/modes/acp/server.test.ts
+++ b/src/modes/acp/server.test.ts
@@ -1435,12 +1435,324 @@ describe("unstable_setSessionModel", () => {
 		expect(fake.model?.id).toBe(orchModelId)
 	})
 
+	it("isolates multi-model state between sessions", async () => {
+		// Use fixed test fixtures for orchestrator to ensure deterministic tests
+		const orchProvider = "test-provider"
+		const orchModelId = "test-orchestrator"
+
+		// Create session A
+		const fakeA = new FakeAgentSession("session-a")
+		fakeA.model = { provider: "provider-a", id: "model-a" }
+		fakeA.modelRegistry = {
+			getAvailable: () => [
+				{ provider: orchProvider, id: orchModelId, name: "Orchestrator Model" },
+				{ provider: "provider-a", id: "model-a", name: "Model A" },
+			],
+			find: (provider: string, modelId: string) => {
+				if (provider === orchProvider && modelId === orchModelId) {
+					return { provider: orchProvider, id: orchModelId, name: "Orchestrator Model" }
+				}
+				return undefined
+			},
+		}
+
+		// Create session B
+		const fakeB = new FakeAgentSession("session-b")
+		fakeB.model = { provider: "provider-b", id: "model-b" }
+		fakeB.modelRegistry = {
+			getAvailable: () => [
+				{ provider: orchProvider, id: orchModelId, name: "Orchestrator Model" },
+				{ provider: "provider-b", id: "model-b", name: "Model B" },
+			],
+			find: (provider: string, modelId: string) => {
+				if (provider === orchProvider && modelId === orchModelId) {
+					return { provider: orchProvider, id: orchModelId, name: "Orchestrator Model" }
+				}
+				return undefined
+			},
+		}
+
+		// Rotating factory returns different sessions in order
+		const fakes = [fakeA, fakeB]
+		let i = 0
+		const factory: AcpSessionFactory = async () => asSession(fakes[i++] ?? fakes[fakes.length - 1])
+
+		const agent = new KimchiAcpAgent(makeConn(), {
+			extensionFactories: [],
+			agentDir: "/tmp/fake-agent-dir",
+			sessionFactory: factory,
+		})
+
+		// Create both sessions
+		const a = await agent.newSession({ cwd: "/tmp/a", mcpServers: [] })
+		const b = await agent.newSession({ cwd: "/tmp/b", mcpServers: [] })
+
+		// Switch session A to multi-model
+		await agent.unstable_setSessionModel({ sessionId: a.sessionId, modelId: "multi-model" })
+
+		// Keep session B on single model (explicitly switch to a specific model)
+		await agent.unstable_setSessionModel({ sessionId: b.sessionId, modelId: "provider-b/model-b" })
+
+		// Verify session A is in multi-model mode (model switched to orchestrator)
+		expect(fakeA.model?.provider).toBe(orchProvider)
+		expect(fakeA.model?.id).toBe(orchModelId)
+
+		// Verify session B is in single-model mode (model switched to provider-b/model-b)
+		expect(fakeB.model?.provider).toBe("provider-b")
+		expect(fakeB.model?.id).toBe("model-b")
+	})
+
 	it("throws invalidParams for unknown sessionId", async () => {
 		const agent = new KimchiAcpAgent(makeConn(), {
 			extensionFactories: [],
 			agentDir: "/tmp/fake-agent-dir",
 		})
 		await expect(agent.unstable_setSessionModel({ sessionId: "no-such-session", modelId: "model-a" })).rejects.toThrow()
+	})
+
+	// Concurrent model switches on different sessions must not interfere with each other.
+	// Each session must end up with the model mode it requested, regardless of timing.
+	it("handles concurrent model switches on different sessions independently", async () => {
+		const orchProvider = "test-provider"
+		const orchModelId = "test-orchestrator"
+
+		const fakeA = new FakeAgentSession("concurrent-a")
+		fakeA.model = { provider: "provider-a", id: "model-a" }
+		fakeA.modelRegistry = {
+			getAvailable: () => [
+				{ provider: orchProvider, id: orchModelId, name: "Orchestrator Model" },
+				{ provider: "provider-a", id: "model-a", name: "Model A" },
+			],
+			find: (provider: string, modelId: string) => {
+				if (provider === orchProvider && modelId === orchModelId) {
+					return { provider: orchProvider, id: orchModelId, name: "Orchestrator Model" }
+				}
+				return undefined
+			},
+		}
+
+		const fakeB = new FakeAgentSession("concurrent-b")
+		fakeB.model = { provider: "provider-b", id: "model-b" }
+		fakeB.modelRegistry = {
+			getAvailable: () => [
+				{ provider: orchProvider, id: orchModelId, name: "Orchestrator Model" },
+				{ provider: "provider-b", id: "model-b", name: "Model B" },
+			],
+			find: (provider: string, modelId: string) => {
+				if (provider === orchProvider && modelId === orchModelId) {
+					return { provider: orchProvider, id: orchModelId, name: "Orchestrator Model" }
+				}
+				return undefined
+			},
+		}
+
+		const fakes = [fakeA, fakeB]
+		let i = 0
+		const rotating: AcpSessionFactory = async () => asSession(fakes[i++] ?? fakes[fakes.length - 1])
+		const agent = new KimchiAcpAgent(makeConn(), {
+			extensionFactories: [],
+			agentDir: "/tmp/fake-agent-dir",
+			sessionFactory: rotating,
+		})
+
+		// Create both sessions
+		const [a, b] = await Promise.all([
+			agent.newSession({ cwd: "/tmp/a", mcpServers: [] }),
+			agent.newSession({ cwd: "/tmp/b", mcpServers: [] }),
+		])
+		expect(a.sessionId).toBe("concurrent-a")
+		expect(b.sessionId).toBe("concurrent-b")
+
+		// Concurrently switch both sessions - A to multi-model, B to single-model
+		const [resA, resB] = await Promise.all([
+			agent.unstable_setSessionModel({ sessionId: a.sessionId, modelId: "multi-model" }),
+			agent.unstable_setSessionModel({ sessionId: b.sessionId, modelId: "provider-b/model-b" }),
+		])
+		expect(resA).toEqual({})
+		expect(resB).toEqual({})
+
+		// Verify session A got the orchestrator (multi-model)
+		expect(fakeA.model?.provider).toBe(orchProvider)
+		expect(fakeA.model?.id).toBe(orchModelId)
+
+		// Verify session B got the single model
+		expect(fakeB.model?.provider).toBe("provider-b")
+		expect(fakeB.model?.id).toBe("model-b")
+	})
+})
+
+// ---------------------------------------------------------------------------
+// runSerializedModelSwitch lock tests
+// ---------------------------------------------------------------------------
+// These tests verify that the per-session model-switch lock serializes
+// concurrent switches on the SAME session and does NOT block switches on
+// DIFFERENT sessions.
+
+describe("runSerializedModelSwitch (lock behaviour)", () => {
+	const orchProvider = "test-provider"
+	const orchModelId = "test-orchestrator"
+	const delay = (ms: number) => new Promise<void>((r) => setTimeout(r, ms))
+
+	function makeFakeWithDelay(id: string) {
+		const fake = new FakeAgentSession(id)
+		const log: string[] = []
+		fake.model = { provider: orchProvider, id: orchModelId }
+		fake.modelRegistry = {
+			getAvailable: () => [
+				{ provider: orchProvider, id: orchModelId, name: "Orchestrator" },
+				{ provider: "p-a", id: "model-a", name: "Model A" },
+				{ provider: "p-b", id: "model-b", name: "Model B" },
+				{ provider: "p-c", id: "model-c", name: "Model C" },
+			],
+			find: (provider: string, modelId: string) => {
+				for (const m of fake.modelRegistry.getAvailable()) {
+					if (m.provider === provider && m.id === modelId) return m
+				}
+				return undefined
+			},
+		}
+		return { fake, log }
+	}
+
+	async function makeAgentWithFakes(...fakeEntries: { fake: FakeAgentSession }[]) {
+		const fakes = fakeEntries.map((e) => e.fake)
+		let i = 0
+		const rotating: AcpSessionFactory = async () => asSession(fakes[i++] ?? fakes[fakes.length - 1])
+		const agent = new KimchiAcpAgent(makeConn(), {
+			extensionFactories: [],
+			agentDir: "/tmp/fake-agent-dir",
+			sessionFactory: rotating,
+		})
+		const sessions = []
+		for (const f of fakes) {
+			sessions.push(await agent.newSession({ cwd: `/tmp/${f.sessionId}`, mcpServers: [] }))
+		}
+		return { agent, sessions }
+	}
+
+	// Rapid-fire switches on the SAME session must serialize: each setModel
+	// must complete before the next one starts, and the final model must be
+	// the one from the last switch.
+	it("serializes rapid-fire switches on the same session", async () => {
+		const entry = makeFakeWithDelay("serial")
+		const { fake, log } = entry
+
+		// Override setModel to record order and introduce a delay
+		fake.setModel = async (model: { provider: string; id: string }) => {
+			log.push(`start:${model.provider}/${model.id}`)
+			await delay(20)
+			fake.model = model
+			log.push(`end:${model.provider}/${model.id}`)
+		}
+
+		const { agent, sessions } = await makeAgentWithFakes(entry)
+		const sid = sessions[0].sessionId
+
+		// Fire three switches concurrently on the same session
+		const [r1, r2, r3] = await Promise.all([
+			agent.unstable_setSessionModel({ sessionId: sid, modelId: "p-a/model-a" }),
+			agent.unstable_setSessionModel({ sessionId: sid, modelId: "p-b/model-b" }),
+			agent.unstable_setSessionModel({ sessionId: sid, modelId: "p-c/model-c" }),
+		])
+		expect(r1).toEqual({})
+		expect(r2).toEqual({})
+		expect(r3).toEqual({})
+
+		// Each switch must complete (end) before the next starts — serialized.
+		expect(log).toEqual([
+			"start:p-a/model-a",
+			"end:p-a/model-a",
+			"start:p-b/model-b",
+			"end:p-b/model-b",
+			"start:p-c/model-c",
+			"end:p-c/model-c",
+		])
+
+		// Final model is the last one switched to
+		expect(fake.model?.provider).toBe("p-c")
+		expect(fake.model?.id).toBe("model-c")
+	})
+
+	// If a switch fails, the next queued switch must still execute.
+	it("does not break the chain when a switch fails", async () => {
+		const entry = makeFakeWithDelay("fail-chain")
+		const { fake, log } = entry
+		let callCount = 0
+
+		fake.setModel = async (model: { provider: string; id: string }) => {
+			callCount++
+			log.push(`start:${model.provider}/${model.id}`)
+			await delay(10)
+			if (callCount === 1) {
+				log.push(`fail:${model.provider}/${model.id}`)
+				throw new Error("simulated setModel failure")
+			}
+			fake.model = model
+			log.push(`end:${model.provider}/${model.id}`)
+		}
+
+		const { agent, sessions } = await makeAgentWithFakes(entry)
+		const sid = sessions[0].sessionId
+
+		// Fire two switches: first will fail, second must still run
+		const results = await Promise.allSettled([
+			agent.unstable_setSessionModel({ sessionId: sid, modelId: "p-a/model-a" }),
+			agent.unstable_setSessionModel({ sessionId: sid, modelId: "p-b/model-b" }),
+		])
+
+		// First rejected, second fulfilled
+		expect(results[0].status).toBe("rejected")
+		expect(results[1].status).toBe("fulfilled")
+
+		// Second switch ran after the first completed (even though first failed)
+		expect(log).toEqual(["start:p-a/model-a", "fail:p-a/model-a", "start:p-b/model-b", "end:p-b/model-b"])
+
+		// Model ends up as the second switch's target
+		expect(fake.model?.provider).toBe("p-b")
+		expect(fake.model?.id).toBe("model-b")
+	})
+
+	// Switches on DIFFERENT sessions must NOT block each other — they should
+	// overlap in time (parallel execution).
+	it("does not block switches across different sessions", async () => {
+		const entryA = makeFakeWithDelay("cross-a")
+		const entryB = makeFakeWithDelay("cross-b")
+		const timeline: string[] = []
+
+		entryA.fake.setModel = async (model: { provider: string; id: string }) => {
+			timeline.push("a:start")
+			await delay(40)
+			entryA.fake.model = model
+			timeline.push("a:end")
+		}
+		entryB.fake.setModel = async (model: { provider: string; id: string }) => {
+			timeline.push("b:start")
+			await delay(40)
+			entryB.fake.model = model
+			timeline.push("b:end")
+		}
+
+		const { agent, sessions } = await makeAgentWithFakes(entryA, entryB)
+
+		await Promise.all([
+			agent.unstable_setSessionModel({ sessionId: sessions[0].sessionId, modelId: "p-a/model-a" }),
+			agent.unstable_setSessionModel({ sessionId: sessions[1].sessionId, modelId: "p-b/model-b" }),
+		])
+
+		// Both should start before either ends (parallel, not serialized)
+		const aStart = timeline.indexOf("a:start")
+		const bStart = timeline.indexOf("b:start")
+		const aEnd = timeline.indexOf("a:end")
+		const bEnd = timeline.indexOf("b:end")
+
+		// Both started before either finished
+		expect(aStart).toBeLessThan(aEnd)
+		expect(bStart).toBeLessThan(bEnd)
+		expect(aStart).toBeLessThan(bEnd)
+		expect(bStart).toBeLessThan(aEnd)
+
+		expect(entryA.fake.model?.id).toBe("model-a")
+		expect(entryB.fake.model?.id).toBe("model-b")
 	})
 })
 

--- a/src/modes/acp/server.ts
+++ b/src/modes/acp/server.ts
@@ -128,6 +128,11 @@ export class KimchiAcpAgent implements Agent {
 	// the JSONL twice, and the later registration overwrites (and leaks) the
 	// earlier session record.
 	private loadingSessions = new Map<string, Promise<LoadSessionResponse>>()
+	// Per-session lock for model switching. Prevents race conditions where
+	// concurrent unstable_setSessionModel calls could corrupt the multiModelEnabled
+	// flag (e.g., call A sets it to true, yields, call B sets it to false, then
+	// call A resumes and overwrites it to true with the session now on single-model).
+	private modelSwitchLocks = new Map<string, Promise<void>>()
 	private shutdownPromise: Promise<void> | undefined
 
 	constructor(
@@ -228,6 +233,35 @@ export class KimchiAcpAgent implements Agent {
 		if (entry.turn) {
 			throw RequestError.invalidRequest(undefined, "a prompt is already in progress for this session")
 		}
+
+		// Serialize concurrent model switches for the same session to prevent
+		// race conditions on entry.multiModelEnabled. The turn gate above only
+		// blocks prompts, not model switches.
+		const existingLock = this.modelSwitchLocks.get(params.sessionId)
+		if (existingLock) {
+			await existingLock
+		}
+
+		const switchPromise = this.executeModelSwitch(entry, params)
+		this.modelSwitchLocks.set(
+			params.sessionId,
+			switchPromise.then(() => undefined),
+		)
+		try {
+			return await switchPromise
+		} finally {
+			// Only clean up if this call's promise is still the current lock
+			// (handles the case where a new switch started during our await)
+			if (this.modelSwitchLocks.get(params.sessionId) === switchPromise.then(() => undefined)) {
+				this.modelSwitchLocks.delete(params.sessionId)
+			}
+		}
+	}
+
+	private async executeModelSwitch(
+		entry: SessionRecord,
+		params: SetSessionModelRequest,
+	): Promise<SetSessionModelResponse> {
 		const { session } = entry
 
 		// Handle multi-model mode
@@ -243,10 +277,14 @@ export class KimchiAcpAgent implements Agent {
 				throw RequestError.invalidParams(undefined, `Multi-model orchestrator (${orchestratorRef}) is not available.`)
 			}
 			try {
-				// Only set the flag after successfully switching models
-				await session.setModel(orchestrator)
+				// Set the flag BEFORE the await to ensure atomicity with respect
+				// to other serialized model switches. If setModel fails, we rely
+				// on the catch block to reset the flag.
 				entry.multiModelEnabled = true
+				await session.setModel(orchestrator)
 			} catch (err) {
+				// Reset the flag on failure since we didn't actually switch models
+				entry.multiModelEnabled = false
 				if (err instanceof RequestError) {
 					throw err
 				}
@@ -263,9 +301,9 @@ export class KimchiAcpAgent implements Agent {
 			throw RequestError.invalidParams(undefined, `Unknown or unavailable model: ${params.modelId}`)
 		}
 		try {
-			await session.setModel(selectedModel)
-			// Clear multi-model flag when switching to a single model
+			// Set the flag BEFORE the await for atomicity
 			entry.multiModelEnabled = false
+			await session.setModel(selectedModel)
 		} catch (err) {
 			if (err instanceof RequestError) {
 				throw err

--- a/src/modes/acp/server.ts
+++ b/src/modes/acp/server.ts
@@ -225,6 +225,39 @@ export class KimchiAcpAgent implements Agent {
 		}
 	}
 
+	/**
+	 * Serializes model switches per session using a simple lock pattern:
+	 * - Wait for any in-flight switch to complete
+	 * - Execute the switch function
+	 * - Track the completion promise so subsequent calls queue behind it
+	 * - Clean up the lock after completion (success or failure)
+	 *
+	 * Uses async/await with try/catch to ensure synchronous throws from
+	 * session.setModel() are also caught and normalized to RequestError.
+	 */
+	private async runSerializedModelSwitch(sessionId: string, switchFn: () => Promise<void>): Promise<void> {
+		const pending = this.modelSwitchLocks.get(sessionId)
+		if (pending) {
+			await pending
+		}
+
+		const switchCompletion = (async () => {
+			try {
+				await switchFn()
+			} catch (err) {
+				if (err instanceof RequestError) throw err
+				throw RequestError.internalError(`Failed to switch model: ${err instanceof Error ? err.message : String(err)}`)
+			}
+		})()
+
+		this.modelSwitchLocks.set(sessionId, switchCompletion)
+		try {
+			await switchCompletion
+		} finally {
+			this.modelSwitchLocks.delete(sessionId)
+		}
+	}
+
 	async unstable_setSessionModel(params: SetSessionModelRequest): Promise<SetSessionModelResponse> {
 		const entry = this.sessions.get(params.sessionId)
 		if (!entry) {
@@ -232,14 +265,6 @@ export class KimchiAcpAgent implements Agent {
 		}
 		if (entry.turn) {
 			throw RequestError.invalidRequest(undefined, "a prompt is already in progress for this session")
-		}
-
-		// Serialize concurrent model switches per session. The turn gate above
-		// only blocks prompts, not model switches. We use a simple lock pattern:
-		// await any pending switch, then execute ours and store its completion promise.
-		const pending = this.modelSwitchLocks.get(params.sessionId)
-		if (pending) {
-			await pending
 		}
 
 		const { session } = entry
@@ -257,47 +282,24 @@ export class KimchiAcpAgent implements Agent {
 				throw RequestError.invalidParams(undefined, `Multi-model orchestrator (${orchestratorRef}) is not available.`)
 			}
 
-			const switchCompletion = session.setModel(orchestrator).then(
-				() => {
-					entry.multiModelEnabled = true
-				},
-				(err) => {
-					if (err instanceof RequestError) throw err
-					throw RequestError.internalError(
-						`Failed to switch to multi-model mode: ${err instanceof Error ? err.message : String(err)}`,
-					)
-				},
-			)
-			this.modelSwitchLocks.set(params.sessionId, switchCompletion)
-			try {
-				await switchCompletion
-			} finally {
-				this.modelSwitchLocks.delete(params.sessionId)
-			}
+			await this.runSerializedModelSwitch(params.sessionId, async () => {
+				await session.setModel(orchestrator)
+				entry.multiModelEnabled = true
+			})
 			return {}
 		}
 
+		// Single-model mode
 		const availableModels = session.modelRegistry.getAvailable()
 		const selectedModel = availableModels.find((m) => getAcpModelId(m) === params.modelId)
 		if (!selectedModel) {
 			throw RequestError.invalidParams(undefined, `Unknown or unavailable model: ${params.modelId}`)
 		}
 
-		const switchCompletion = session.setModel(selectedModel).then(
-			() => {
-				entry.multiModelEnabled = false
-			},
-			(err) => {
-				if (err instanceof RequestError) throw err
-				throw RequestError.internalError(`Failed to switch model: ${err instanceof Error ? err.message : String(err)}`)
-			},
-		)
-		this.modelSwitchLocks.set(params.sessionId, switchCompletion)
-		try {
-			await switchCompletion
-		} finally {
-			this.modelSwitchLocks.delete(params.sessionId)
-		}
+		await this.runSerializedModelSwitch(params.sessionId, async () => {
+			await session.setModel(selectedModel)
+			entry.multiModelEnabled = false
+		})
 		return {}
 	}
 

--- a/src/modes/acp/server.ts
+++ b/src/modes/acp/server.ts
@@ -52,6 +52,9 @@ import {
 	initTheme,
 } from "@earendil-works/pi-coding-agent"
 import { isHideThinkingEnabled } from "../../extensions/hide-thinking.js"
+import { splitModelRef } from "../../extensions/orchestration/model-roles.js"
+import { resolveModelRoles } from "../../extensions/orchestration/model-roles.js"
+import { getMultiModelEnabled, setMultiModelEnabled } from "../../extensions/prompt-construction/prompt-enrichment.js"
 import { createAcpPermissionPrompter } from "./acp-prompter.js"
 import { registerAcpPrompter, unregisterAcpPrompter } from "./permission-prompter-registry.js"
 
@@ -224,6 +227,34 @@ export class KimchiAcpAgent implements Agent {
 			throw RequestError.invalidRequest(undefined, "a prompt is already in progress for this session")
 		}
 		const { session } = entry
+
+		// Handle multi-model mode
+		if (params.modelId === "multi-model") {
+			const { roles } = resolveModelRoles()
+			const orchestratorRef = roles.orchestrator
+			const parsed = splitModelRef(orchestratorRef)
+			if (!parsed) {
+				throw RequestError.invalidParams(undefined, `Invalid orchestrator model ref: ${orchestratorRef}`)
+			}
+			const orchestrator = session.modelRegistry.find(parsed.provider, parsed.modelId)
+			if (!orchestrator) {
+				throw RequestError.invalidParams(undefined, `Multi-model orchestrator (${orchestratorRef}) is not available.`)
+			}
+			try {
+				setMultiModelEnabled(true)
+				await session.setModel(orchestrator)
+			} catch (err) {
+				if (err instanceof RequestError) {
+					throw err
+				}
+				throw RequestError.invalidParams(
+					undefined,
+					`Failed to switch to multi-model mode: ${err instanceof Error ? err.message : String(err)}`,
+				)
+			}
+			return {}
+		}
+
 		const availableModels = session.modelRegistry.getAvailable()
 		const selectedModel = availableModels.find((m) => getAcpModelId(m) === params.modelId)
 		if (!selectedModel) {
@@ -779,12 +810,19 @@ export function buildSessionModelState(
 		return null
 	}
 	const availableModels = session.modelRegistry.getAvailable()
+	const multiModelActive = getMultiModelEnabled()
+	const currentModelId = multiModelActive
+		? `multi-model/${resolveModelRoles().roles.orchestrator}`
+		: getAcpModelId(currentModel)
 	return {
-		currentModelId: getAcpModelId(currentModel),
-		availableModels: availableModels.map((m) => ({
-			modelId: getAcpModelId(m),
-			name: m.name,
-		})),
+		currentModelId,
+		availableModels: [
+			{ modelId: "multi-model", name: "Multi-Model" },
+			...availableModels.map((m) => ({
+				modelId: getAcpModelId(m),
+				name: m.name,
+			})),
+		],
 	}
 }
 

--- a/src/modes/acp/server.ts
+++ b/src/modes/acp/server.ts
@@ -53,11 +53,15 @@ import {
 } from "@earendil-works/pi-coding-agent"
 import { isHideThinkingEnabled } from "../../extensions/hide-thinking.js"
 import {
-	getMultiModelEnabled,
 	getOrchestratorModelRef,
 	resolveOrchestratorModel,
-	setMultiModelEnabled,
 } from "../../extensions/prompt-construction/prompt-enrichment.js"
+import {
+	clearSessionMultiModelState,
+	getSessionMultiModelEnabled,
+	runWithSession,
+	setSessionMultiModelEnabled,
+} from "./session-state.js"
 
 import { createAcpPermissionPrompter } from "./acp-prompter.js"
 import { registerAcpPrompter, unregisterAcpPrompter } from "./permission-prompter-registry.js"
@@ -158,7 +162,11 @@ export class KimchiAcpAgent implements Agent {
 				// "supported"). loadSession remains the top-level flag because
 				// the spec hasn't unified it under sessionCapabilities yet.
 				sessionCapabilities: { list: {}, close: {} },
-				promptCapabilities: { image: supportsImages, audio: false, embeddedContext: false },
+				promptCapabilities: {
+					image: supportsImages,
+					audio: false,
+					embeddedContext: false,
+				},
 			},
 			authMethods: [],
 		}
@@ -286,7 +294,7 @@ export class KimchiAcpAgent implements Agent {
 
 			await this.runSerializedModelSwitch(params.sessionId, async () => {
 				await session.setModel(orchestrator)
-				setMultiModelEnabled(true)
+				setSessionMultiModelEnabled(session.sessionId, true)
 			})
 			return {}
 		}
@@ -300,7 +308,7 @@ export class KimchiAcpAgent implements Agent {
 
 		await this.runSerializedModelSwitch(params.sessionId, async () => {
 			await session.setModel(selectedModel)
-			setMultiModelEnabled(false)
+			setSessionMultiModelEnabled(session.sessionId, false)
 		})
 		return {}
 	}
@@ -380,6 +388,7 @@ export class KimchiAcpAgent implements Agent {
 			const existing = this.sessions.get(sid)
 			if (existing) {
 				this.sessions.delete(sid)
+				clearSessionMultiModelState(sid)
 				existing.unsubscribe()
 			}
 			session.dispose()
@@ -447,7 +456,10 @@ export class KimchiAcpAgent implements Agent {
 		// paused on `await session.prompt()`. Instead, attach handlers that drive
 		// finalizeTurn/failTurn and return `result` directly; settling `result`
 		// propagates to the caller regardless of whether session.prompt ever resolves.
-		entry.session.prompt(text, { source: "rpc", images }).then(
+		// Run the prompt inside an AsyncLocalStorage context so extensions
+		// (prompt-enrichment) can read per-session state like multiModelEnabled
+		// without a module-level global that breaks under concurrent sessions.
+		runWithSession(entry.session, () => entry.session.prompt(text, { source: "rpc", images })).then(
 			() => {
 				// pi-coding-agent's session.prompt() short-circuits for extension commands,
 				// input-handler intercepts, and no-op paths — in those cases agent.prompt()
@@ -514,6 +526,7 @@ export class KimchiAcpAgent implements Agent {
 		const entry = this.sessions.get(sessionId)
 		if (!entry) return
 		this.sessions.delete(sessionId)
+		clearSessionMultiModelState(sessionId)
 		unregisterAcpPrompter(sessionId)
 		entry.unsubscribe()
 		if (entry.turn) {
@@ -538,7 +551,10 @@ export class KimchiAcpAgent implements Agent {
 		// calling dispose(). dispose() is synchronous and returns void, so async
 		// extension handlers (e.g. telemetry drain, shutdown marker) would be
 		// fire-and-forgotten if we relied on dispose() alone.
-		await entry.session.extensionRunner?.emit({ type: "session_shutdown", reason: "quit" })
+		await entry.session.extensionRunner?.emit({
+			type: "session_shutdown",
+			reason: "quit",
+		})
 		entry.session.dispose()
 	}
 
@@ -796,7 +812,7 @@ export class KimchiAcpAgent implements Agent {
 	}
 
 	private modelStateForSession(session: AgentSession): SessionModelState | null {
-		return buildSessionModelState(session, getMultiModelEnabled())
+		return buildSessionModelState(session, getSessionMultiModelEnabled(session.sessionId))
 	}
 
 	private send(params: SessionNotification): void {
@@ -963,7 +979,10 @@ function parseSessionHeader(raw: string): Pick<SessionHeader, "id" | "cwd"> | nu
 	return null
 }
 
-function readSessionHeaderPeek(sessionPath: string): { raw: string; complete: boolean } {
+function readSessionHeaderPeek(sessionPath: string): {
+	raw: string
+	complete: boolean
+} {
 	const fd = openSync(sessionPath, "r")
 	try {
 		const buffer = Buffer.allocUnsafe(SESSION_HEADER_PEEK_BYTES)

--- a/src/modes/acp/server.ts
+++ b/src/modes/acp/server.ts
@@ -811,13 +811,25 @@ export function buildSessionModelState(
 	}
 	const availableModels = session.modelRegistry.getAvailable()
 	const multiModelActive = getMultiModelEnabled()
-	const currentModelId = multiModelActive
-		? `multi-model/${resolveModelRoles().roles.orchestrator}`
-		: getAcpModelId(currentModel)
+	// When multi-model is active, return "multi-model" as currentModelId to match
+	// what clients send in setSessionModel. Include orchestrator name in the name
+	// so the UI can display "Multi-Model (Kimi K2.6)".
+	let multiModelName = "Multi-Model"
+	if (multiModelActive) {
+		const { roles } = resolveModelRoles()
+		const parsed = splitModelRef(roles.orchestrator)
+		if (parsed) {
+			const orchModel = session.modelRegistry.find(parsed.provider, parsed.modelId)
+			if (orchModel) {
+				multiModelName = `Multi-Model (${orchModel.name})`
+			}
+		}
+	}
+	const currentModelId = multiModelActive ? "multi-model" : getAcpModelId(currentModel)
 	return {
 		currentModelId,
 		availableModels: [
-			{ modelId: "multi-model", name: "Multi-Model" },
+			{ modelId: "multi-model", name: multiModelName },
 			...availableModels.map((m) => ({
 				modelId: getAcpModelId(m),
 				name: m.name,

--- a/src/modes/acp/server.ts
+++ b/src/modes/acp/server.ts
@@ -234,34 +234,14 @@ export class KimchiAcpAgent implements Agent {
 			throw RequestError.invalidRequest(undefined, "a prompt is already in progress for this session")
 		}
 
-		// Serialize concurrent model switches for the same session to prevent
-		// race conditions on entry.multiModelEnabled. The turn gate above only
-		// blocks prompts, not model switches.
-		const existingLock = this.modelSwitchLocks.get(params.sessionId)
-		if (existingLock) {
-			await existingLock
+		// Serialize concurrent model switches per session. The turn gate above
+		// only blocks prompts, not model switches. We use a simple lock pattern:
+		// await any pending switch, then execute ours and store its completion promise.
+		const pending = this.modelSwitchLocks.get(params.sessionId)
+		if (pending) {
+			await pending
 		}
 
-		const switchPromise = this.executeModelSwitch(entry, params)
-		this.modelSwitchLocks.set(
-			params.sessionId,
-			switchPromise.then(() => undefined),
-		)
-		try {
-			return await switchPromise
-		} finally {
-			// Only clean up if this call's promise is still the current lock
-			// (handles the case where a new switch started during our await)
-			if (this.modelSwitchLocks.get(params.sessionId) === switchPromise.then(() => undefined)) {
-				this.modelSwitchLocks.delete(params.sessionId)
-			}
-		}
-	}
-
-	private async executeModelSwitch(
-		entry: SessionRecord,
-		params: SetSessionModelRequest,
-	): Promise<SetSessionModelResponse> {
 		const { session } = entry
 
 		// Handle multi-model mode
@@ -276,21 +256,23 @@ export class KimchiAcpAgent implements Agent {
 			if (!orchestrator) {
 				throw RequestError.invalidParams(undefined, `Multi-model orchestrator (${orchestratorRef}) is not available.`)
 			}
+
+			const switchCompletion = session.setModel(orchestrator).then(
+				() => {
+					entry.multiModelEnabled = true
+				},
+				(err) => {
+					if (err instanceof RequestError) throw err
+					throw RequestError.internalError(
+						`Failed to switch to multi-model mode: ${err instanceof Error ? err.message : String(err)}`,
+					)
+				},
+			)
+			this.modelSwitchLocks.set(params.sessionId, switchCompletion)
 			try {
-				// Set the flag BEFORE the await to ensure atomicity with respect
-				// to other serialized model switches. If setModel fails, we rely
-				// on the catch block to reset the flag.
-				entry.multiModelEnabled = true
-				await session.setModel(orchestrator)
-			} catch (err) {
-				// Reset the flag on failure since we didn't actually switch models
-				entry.multiModelEnabled = false
-				if (err instanceof RequestError) {
-					throw err
-				}
-				throw RequestError.internalError(
-					`Failed to switch to multi-model mode: ${err instanceof Error ? err.message : String(err)}`,
-				)
+				await switchCompletion
+			} finally {
+				this.modelSwitchLocks.delete(params.sessionId)
 			}
 			return {}
 		}
@@ -300,15 +282,21 @@ export class KimchiAcpAgent implements Agent {
 		if (!selectedModel) {
 			throw RequestError.invalidParams(undefined, `Unknown or unavailable model: ${params.modelId}`)
 		}
+
+		const switchCompletion = session.setModel(selectedModel).then(
+			() => {
+				entry.multiModelEnabled = false
+			},
+			(err) => {
+				if (err instanceof RequestError) throw err
+				throw RequestError.internalError(`Failed to switch model: ${err instanceof Error ? err.message : String(err)}`)
+			},
+		)
+		this.modelSwitchLocks.set(params.sessionId, switchCompletion)
 		try {
-			// Set the flag BEFORE the await for atomicity
-			entry.multiModelEnabled = false
-			await session.setModel(selectedModel)
-		} catch (err) {
-			if (err instanceof RequestError) {
-				throw err
-			}
-			throw RequestError.internalError(`Failed to switch model: ${err instanceof Error ? err.message : String(err)}`)
+			await switchCompletion
+		} finally {
+			this.modelSwitchLocks.delete(params.sessionId)
 		}
 		return {}
 	}

--- a/src/modes/acp/server.ts
+++ b/src/modes/acp/server.ts
@@ -52,8 +52,12 @@ import {
 	initTheme,
 } from "@earendil-works/pi-coding-agent"
 import { isHideThinkingEnabled } from "../../extensions/hide-thinking.js"
-import { splitModelRef } from "../../extensions/orchestration/model-roles.js"
-import { resolveModelRoles } from "../../extensions/orchestration/model-roles.js"
+import {
+	getMultiModelEnabled,
+	getOrchestratorModelRef,
+	resolveOrchestratorModel,
+	setMultiModelEnabled,
+} from "../../extensions/prompt-construction/prompt-enrichment.js"
 
 import { createAcpPermissionPrompter } from "./acp-prompter.js"
 import { registerAcpPrompter, unregisterAcpPrompter } from "./permission-prompter-registry.js"
@@ -110,8 +114,6 @@ type SessionRecord = {
 	session: AgentSession
 	unsubscribe: () => void
 	turn?: TurnContext
-	/** Track whether this session is in multi-model mode (session-scoped, not global). */
-	multiModelEnabled?: boolean
 }
 
 export class KimchiAcpAgent implements Agent {
@@ -128,10 +130,8 @@ export class KimchiAcpAgent implements Agent {
 	// the JSONL twice, and the later registration overwrites (and leaks) the
 	// earlier session record.
 	private loadingSessions = new Map<string, Promise<LoadSessionResponse>>()
-	// Per-session lock for model switching. Prevents race conditions where
-	// concurrent unstable_setSessionModel calls could corrupt the multiModelEnabled
-	// flag (e.g., call A sets it to true, yields, call B sets it to false, then
-	// call A resumes and overwrites it to true with the session now on single-model).
+	// Per-session lock for model switching. Each call chains onto the tail of
+	// the current promise so that concurrent switches serialize correctly.
 	private modelSwitchLocks = new Map<string, Promise<void>>()
 	private shutdownPromise: Promise<void> | undefined
 
@@ -226,36 +226,41 @@ export class KimchiAcpAgent implements Agent {
 	}
 
 	/**
-	 * Serializes model switches per session using a simple lock pattern:
-	 * - Wait for any in-flight switch to complete
-	 * - Execute the switch function
-	 * - Track the completion promise so subsequent calls queue behind it
-	 * - Clean up the lock after completion (success or failure)
+	 * Serializes model switches per session by chaining onto the current lock
+	 * promise. Each call appends itself to the chain so that concurrent calls
+	 * (A → B → C) execute strictly in order rather than racing after A
+	 * completes.
 	 *
 	 * Uses async/await with try/catch to ensure synchronous throws from
 	 * session.setModel() are also caught and normalized to RequestError.
 	 */
 	private async runSerializedModelSwitch(sessionId: string, switchFn: () => Promise<void>): Promise<void> {
-		const pending = this.modelSwitchLocks.get(sessionId)
-		if (pending) {
-			await pending
-		}
+		const pending = this.modelSwitchLocks.get(sessionId) ?? Promise.resolve()
 
-		const switchCompletion = (async () => {
-			try {
-				await switchFn()
-			} catch (err) {
-				if (err instanceof RequestError) throw err
-				throw RequestError.internalError(`Failed to switch model: ${err instanceof Error ? err.message : String(err)}`)
+		// Chain onto whatever is currently pending. The .catch(() => {}) on
+		// `pending` ensures a rejected predecessor doesn't skip our switchFn.
+		const next = pending
+			.catch(() => {})
+			.then(async () => {
+				try {
+					await switchFn()
+				} catch (err) {
+					if (err instanceof RequestError) throw err
+					throw RequestError.internalError(
+						`Failed to switch model: ${err instanceof Error ? err.message : String(err)}`,
+					)
+				}
+			})
+
+		this.modelSwitchLocks.set(sessionId, next)
+
+		// Clean up the lock only if we're still the tail of the chain.
+		// A newer call may have already appended itself.
+		return next.finally(() => {
+			if (this.modelSwitchLocks.get(sessionId) === next) {
+				this.modelSwitchLocks.delete(sessionId)
 			}
-		})()
-
-		this.modelSwitchLocks.set(sessionId, switchCompletion)
-		try {
-			await switchCompletion
-		} finally {
-			this.modelSwitchLocks.delete(sessionId)
-		}
+		})
 	}
 
 	async unstable_setSessionModel(params: SetSessionModelRequest): Promise<SetSessionModelResponse> {
@@ -271,20 +276,17 @@ export class KimchiAcpAgent implements Agent {
 
 		// Handle multi-model mode
 		if (params.modelId === "multi-model") {
-			const { roles } = resolveModelRoles()
-			const orchestratorRef = roles.orchestrator
-			const parsed = splitModelRef(orchestratorRef)
-			if (!parsed) {
-				throw RequestError.invalidParams(undefined, `Invalid orchestrator model ref: ${orchestratorRef}`)
-			}
-			const orchestrator = session.modelRegistry.find(parsed.provider, parsed.modelId)
+			const orchestrator = resolveOrchestratorModel(session.modelRegistry)
 			if (!orchestrator) {
-				throw RequestError.invalidParams(undefined, `Multi-model orchestrator (${orchestratorRef}) is not available.`)
+				throw RequestError.invalidParams(
+					undefined,
+					`Multi-model orchestrator (${getOrchestratorModelRef()}) is not available.`,
+				)
 			}
 
 			await this.runSerializedModelSwitch(params.sessionId, async () => {
 				await session.setModel(orchestrator)
-				entry.multiModelEnabled = true
+				setMultiModelEnabled(true)
 			})
 			return {}
 		}
@@ -298,7 +300,7 @@ export class KimchiAcpAgent implements Agent {
 
 		await this.runSerializedModelSwitch(params.sessionId, async () => {
 			await session.setModel(selectedModel)
-			entry.multiModelEnabled = false
+			setMultiModelEnabled(false)
 		})
 		return {}
 	}
@@ -321,7 +323,7 @@ export class KimchiAcpAgent implements Agent {
 				)
 			}
 			this.replayTranscript(existing.session)
-			return { models: this.modelStateForSession(existing.session, existing) }
+			return { models: this.modelStateForSession(existing.session) }
 		}
 		const loading = this.loadingSessions.get(params.sessionId)
 		if (loading) return loading
@@ -372,7 +374,7 @@ export class KimchiAcpAgent implements Agent {
 			// concurrent session/cancel during replay is a no-op — a turn must not
 			// be considered active during replay.
 			this.replayTranscript(session)
-			return { models: this.modelStateForSession(session, entry) }
+			return { models: this.modelStateForSession(session) }
 		} catch (err) {
 			unregisterAcpPrompter(sid)
 			const existing = this.sessions.get(sid)
@@ -793,9 +795,8 @@ export class KimchiAcpAgent implements Agent {
 		flushText()
 	}
 
-	private modelStateForSession(session: AgentSession, entry?: SessionRecord): SessionModelState | null {
-		const isMultiModel = entry?.multiModelEnabled ?? false
-		return buildSessionModelState(session, isMultiModel)
+	private modelStateForSession(session: AgentSession): SessionModelState | null {
+		return buildSessionModelState(session, getMultiModelEnabled())
 	}
 
 	private send(params: SessionNotification): void {
@@ -847,13 +848,9 @@ export function buildSessionModelState(
 	// so the UI can display "Multi-model (Kimi K2.6)".
 	let multiModelName = "Multi-model"
 	if (isMultiModel) {
-		const { roles } = resolveModelRoles()
-		const parsed = splitModelRef(roles.orchestrator)
-		if (parsed) {
-			const orchModel = session.modelRegistry.find(parsed.provider, parsed.modelId)
-			if (orchModel) {
-				multiModelName = `Multi-model (${orchModel.name})`
-			}
+		const orchModel = resolveOrchestratorModel(session.modelRegistry)
+		if (orchModel) {
+			multiModelName = `Multi-model (${orchModel.name})`
 		}
 	}
 	const currentModelId = isMultiModel ? "multi-model" : getAcpModelId(currentModel)

--- a/src/modes/acp/server.ts
+++ b/src/modes/acp/server.ts
@@ -54,7 +54,7 @@ import {
 import { isHideThinkingEnabled } from "../../extensions/hide-thinking.js"
 import { splitModelRef } from "../../extensions/orchestration/model-roles.js"
 import { resolveModelRoles } from "../../extensions/orchestration/model-roles.js"
-import { getMultiModelEnabled, setMultiModelEnabled } from "../../extensions/prompt-construction/prompt-enrichment.js"
+
 import { createAcpPermissionPrompter } from "./acp-prompter.js"
 import { registerAcpPrompter, unregisterAcpPrompter } from "./permission-prompter-registry.js"
 
@@ -110,6 +110,8 @@ type SessionRecord = {
 	session: AgentSession
 	unsubscribe: () => void
 	turn?: TurnContext
+	/** Track whether this session is in multi-model mode (session-scoped, not global). */
+	multiModelEnabled?: boolean
 }
 
 export class KimchiAcpAgent implements Agent {
@@ -209,7 +211,7 @@ export class KimchiAcpAgent implements Agent {
 			await bindAcpExtensions(session)
 			const unsubscribe = session.subscribe((event) => this.onSessionEvent(sessionId, event))
 			this.sessions.set(sessionId, { session, unsubscribe })
-			const models = buildSessionModelState(session)
+			const models = buildSessionModelState(session, false)
 			return { sessionId, models }
 		} catch (err) {
 			unregisterAcpPrompter(session.sessionId)
@@ -241,14 +243,14 @@ export class KimchiAcpAgent implements Agent {
 				throw RequestError.invalidParams(undefined, `Multi-model orchestrator (${orchestratorRef}) is not available.`)
 			}
 			try {
-				setMultiModelEnabled(true)
+				// Only set the flag after successfully switching models
 				await session.setModel(orchestrator)
+				entry.multiModelEnabled = true
 			} catch (err) {
 				if (err instanceof RequestError) {
 					throw err
 				}
-				throw RequestError.invalidParams(
-					undefined,
+				throw RequestError.internalError(
 					`Failed to switch to multi-model mode: ${err instanceof Error ? err.message : String(err)}`,
 				)
 			}
@@ -262,14 +264,13 @@ export class KimchiAcpAgent implements Agent {
 		}
 		try {
 			await session.setModel(selectedModel)
+			// Clear multi-model flag when switching to a single model
+			entry.multiModelEnabled = false
 		} catch (err) {
 			if (err instanceof RequestError) {
 				throw err
 			}
-			throw RequestError.invalidParams(
-				undefined,
-				`Failed to switch model: ${err instanceof Error ? err.message : String(err)}`,
-			)
+			throw RequestError.internalError(`Failed to switch model: ${err instanceof Error ? err.message : String(err)}`)
 		}
 		return {}
 	}
@@ -292,7 +293,7 @@ export class KimchiAcpAgent implements Agent {
 				)
 			}
 			this.replayTranscript(existing.session)
-			return { models: this.modelStateForSession(existing.session) }
+			return { models: this.modelStateForSession(existing.session, existing) }
 		}
 		const loading = this.loadingSessions.get(params.sessionId)
 		if (loading) return loading
@@ -336,13 +337,14 @@ export class KimchiAcpAgent implements Agent {
 			registerAcpPrompter(sid, createAcpPermissionPrompter(this.conn, sid, buildToolCallUpdate))
 			await bindAcpExtensions(session)
 			const unsubscribe = session.subscribe((event) => this.onSessionEvent(sid, event))
-			this.sessions.set(sid, { session, unsubscribe })
+			const entry: SessionRecord = { session, unsubscribe }
+			this.sessions.set(sid, entry)
 			// Replay BEFORE the response resolves so Zed sees a coherent transcript
 			// when the loadSession promise settles. No turn context is created, so a
 			// concurrent session/cancel during replay is a no-op — a turn must not
 			// be considered active during replay.
 			this.replayTranscript(session)
-			return { models: this.modelStateForSession(session) }
+			return { models: this.modelStateForSession(session, entry) }
 		} catch (err) {
 			unregisterAcpPrompter(sid)
 			const existing = this.sessions.get(sid)
@@ -763,8 +765,9 @@ export class KimchiAcpAgent implements Agent {
 		flushText()
 	}
 
-	private modelStateForSession(session: AgentSession): SessionModelState | null {
-		return buildSessionModelState(session)
+	private modelStateForSession(session: AgentSession, entry?: SessionRecord): SessionModelState | null {
+		const isMultiModel = entry?.multiModelEnabled ?? false
+		return buildSessionModelState(session, isMultiModel)
 	}
 
 	private send(params: SessionNotification): void {
@@ -804,18 +807,18 @@ export class KimchiAcpAgent implements Agent {
 // Zed toward an auth prompt instead of showing a generic "internal error".
 export function buildSessionModelState(
 	session: Pick<AgentSession, "model" | "modelRegistry">,
+	isMultiModel = false,
 ): SessionModelState | null {
 	const currentModel = session.model
 	if (!currentModel) {
 		return null
 	}
 	const availableModels = session.modelRegistry.getAvailable()
-	const multiModelActive = getMultiModelEnabled()
 	// When multi-model is active, return "multi-model" as currentModelId to match
 	// what clients send in setSessionModel. Include orchestrator name in the name
 	// so the UI can display "Multi-Model (Kimi K2.6)".
 	let multiModelName = "Multi-Model"
-	if (multiModelActive) {
+	if (isMultiModel) {
 		const { roles } = resolveModelRoles()
 		const parsed = splitModelRef(roles.orchestrator)
 		if (parsed) {
@@ -825,7 +828,7 @@ export function buildSessionModelState(
 			}
 		}
 	}
-	const currentModelId = multiModelActive ? "multi-model" : getAcpModelId(currentModel)
+	const currentModelId = isMultiModel ? "multi-model" : getAcpModelId(currentModel)
 	return {
 		currentModelId,
 		availableModels: [

--- a/src/modes/acp/server.ts
+++ b/src/modes/acp/server.ts
@@ -844,15 +844,15 @@ export function buildSessionModelState(
 	const availableModels = session.modelRegistry.getAvailable()
 	// When multi-model is active, return "multi-model" as currentModelId to match
 	// what clients send in setSessionModel. Include orchestrator name in the name
-	// so the UI can display "Multi-Model (Kimi K2.6)".
-	let multiModelName = "Multi-Model"
+	// so the UI can display "Multi-model (Kimi K2.6)".
+	let multiModelName = "Multi-model"
 	if (isMultiModel) {
 		const { roles } = resolveModelRoles()
 		const parsed = splitModelRef(roles.orchestrator)
 		if (parsed) {
 			const orchModel = session.modelRegistry.find(parsed.provider, parsed.modelId)
 			if (orchModel) {
-				multiModelName = `Multi-Model (${orchModel.name})`
+				multiModelName = `Multi-model (${orchModel.name})`
 			}
 		}
 	}

--- a/src/modes/acp/session-state.test.ts
+++ b/src/modes/acp/session-state.test.ts
@@ -1,0 +1,127 @@
+import type { AgentSession } from "@earendil-works/pi-coding-agent"
+import { afterEach, describe, expect, it } from "vitest"
+import { getMultiModelEnabled, setMultiModelEnabled } from "../../extensions/prompt-construction/prompt-enrichment.js"
+import {
+	clearSessionMultiModelState,
+	getCurrentSessionId,
+	getSessionMultiModelEnabled,
+	runWithSession,
+	setSessionMultiModelEnabled,
+} from "./session-state.js"
+
+describe("session-state", () => {
+	afterEach(() => {
+		// Clean up any session state between tests
+		clearSessionMultiModelState("s-a")
+		clearSessionMultiModelState("s-b")
+		clearSessionMultiModelState("s-ctx")
+		setMultiModelEnabled(false)
+	})
+
+	describe("getSessionMultiModelEnabled / setSessionMultiModelEnabled", () => {
+		it("returns false for unknown sessionId", () => {
+			expect(getSessionMultiModelEnabled("nonexistent")).toBe(false)
+		})
+
+		it("isolates state between sessions", () => {
+			setSessionMultiModelEnabled("s-a", true)
+			setSessionMultiModelEnabled("s-b", false)
+
+			expect(getSessionMultiModelEnabled("s-a")).toBe(true)
+			expect(getSessionMultiModelEnabled("s-b")).toBe(false)
+		})
+	})
+
+	describe("clearSessionMultiModelState", () => {
+		it("removes per-session state", () => {
+			setSessionMultiModelEnabled("s-a", true)
+			expect(getSessionMultiModelEnabled("s-a")).toBe(true)
+
+			clearSessionMultiModelState("s-a")
+			expect(getSessionMultiModelEnabled("s-a")).toBe(false)
+		})
+
+		it("is a no-op for unknown sessionId", () => {
+			// Should not throw
+			clearSessionMultiModelState("nonexistent")
+		})
+	})
+
+	describe("runWithSession / getCurrentSessionId", () => {
+		it("returns null outside a runWithSession context", () => {
+			expect(getCurrentSessionId()).toBeNull()
+		})
+
+		it("provides sessionId inside a runWithSession context", () => {
+			const fake = { sessionId: "s-ctx" } as AgentSession
+			runWithSession(fake, () => {
+				expect(getCurrentSessionId()).toBe("s-ctx")
+			})
+			// Back to null after
+			expect(getCurrentSessionId()).toBeNull()
+		})
+
+		it("nests correctly — inner context wins", () => {
+			const outer = { sessionId: "s-a" } as AgentSession
+			const inner = { sessionId: "s-b" } as AgentSession
+			runWithSession(outer, () => {
+				expect(getCurrentSessionId()).toBe("s-a")
+				runWithSession(inner, () => {
+					expect(getCurrentSessionId()).toBe("s-b")
+				})
+				expect(getCurrentSessionId()).toBe("s-a")
+			})
+		})
+	})
+
+	describe("getMultiModelEnabled integration with session context", () => {
+		it("reads per-session state inside runWithSession", () => {
+			const fake = { sessionId: "s-a" } as AgentSession
+			setSessionMultiModelEnabled("s-a", true)
+
+			// Outside context → global (false)
+			expect(getMultiModelEnabled()).toBe(false)
+
+			// Inside context → per-session (true)
+			runWithSession(fake, () => {
+				expect(getMultiModelEnabled()).toBe(true)
+			})
+
+			// Back to global
+			expect(getMultiModelEnabled()).toBe(false)
+		})
+
+		it("falls back to global when session has no state", () => {
+			const fake = { sessionId: "s-a" } as AgentSession
+			setMultiModelEnabled(true)
+
+			// Inside context but no per-session state → session returns false
+			// (session state takes precedence, defaults to false)
+			runWithSession(fake, () => {
+				expect(getMultiModelEnabled()).toBe(false)
+			})
+		})
+
+		it("concurrent sessions see independent state", async () => {
+			const fakeA = { sessionId: "s-a" } as AgentSession
+			const fakeB = { sessionId: "s-b" } as AgentSession
+			setSessionMultiModelEnabled("s-a", true)
+			setSessionMultiModelEnabled("s-b", false)
+
+			const results = await Promise.all([
+				new Promise<boolean>((resolve) => {
+					runWithSession(fakeA, () => {
+						resolve(getMultiModelEnabled())
+					})
+				}),
+				new Promise<boolean>((resolve) => {
+					runWithSession(fakeB, () => {
+						resolve(getMultiModelEnabled())
+					})
+				}),
+			])
+
+			expect(results).toEqual([true, false])
+		})
+	})
+})

--- a/src/modes/acp/session-state.ts
+++ b/src/modes/acp/session-state.ts
@@ -1,0 +1,59 @@
+/**
+ * Per-session multi-model state for ACP mode.
+ *
+ * ACP supports multiple concurrent sessions, each with its own model mode
+ * (single-model vs multi-model). This module owns the session-scoped storage
+ * and the AsyncLocalStorage context that lets extensions read the correct
+ * per-session flag without an explicit session parameter.
+ *
+ * CLI mode does not use this module — it relies on the global flag in
+ * prompt-enrichment.ts.
+ */
+
+import { AsyncLocalStorage } from "node:async_hooks"
+import type { AgentSession } from "@earendil-works/pi-coding-agent"
+
+// ---------------------------------------------------------------------------
+// AsyncLocalStorage context — concurrency-safe session pointer
+// ---------------------------------------------------------------------------
+
+const sessionStorage = new AsyncLocalStorage<AgentSession | null>()
+
+/**
+ * Run `fn` with `session` as the active session context.
+ * Extensions called during `fn` can read per-session state via
+ * {@link getCurrentSessionId}.
+ */
+export function runWithSession<T>(session: AgentSession | null, fn: () => T): T {
+	return sessionStorage.run(session, fn)
+}
+
+/**
+ * Return the sessionId of the current ACP session, or `null` when running
+ * outside an ACP prompt context (e.g. CLI mode).
+ */
+export function getCurrentSessionId(): string | null {
+	return sessionStorage.getStore()?.sessionId ?? null
+}
+
+// ---------------------------------------------------------------------------
+// Per-session multi-model flag — keyed by sessionId
+// ---------------------------------------------------------------------------
+
+const sessionMultiModelState = new Map<string, boolean>()
+
+export function getSessionMultiModelEnabled(sessionId: string): boolean {
+	return sessionMultiModelState.get(sessionId) ?? false
+}
+
+export function setSessionMultiModelEnabled(sessionId: string, enabled: boolean): void {
+	sessionMultiModelState.set(sessionId, enabled)
+}
+
+/**
+ * Remove per-session state when a session is destroyed.
+ * Call during ACP session cleanup to prevent Map growth.
+ */
+export function clearSessionMultiModelState(sessionId: string): void {
+	sessionMultiModelState.delete(sessionId)
+}


### PR DESCRIPTION
## Description

Previously, ACP didn't list multi-model as an option for model selector. This adds that support, consumers can run multi-model workflows in ACP mode.

## Type of Change

<!-- Select all that apply. -->

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Documentation update
