### PR TITLE
feat(acp): expose ferment via available_commands_update

### DIFF
--- a/docs/acp-commands.md
+++ b/docs/acp-commands.md
@@ -1,0 +1,318 @@
+# ACP Available Commands — VS Code Extension Integration Guide
+
+This document explains how VS Code extensions can use the `available_commands_update` notification to discover and trigger ferment workflows via the Agent Connection Protocol (ACP).
+
+## Overview
+
+The `available_commands_update` is a session notification that the ACP server sends to advertise available commands. This allows ACP clients (such as VS Code extensions) to:
+
+- Discover what commands the agent supports
+- Display commands in a UI (command palette, buttons, menu items)
+- Invoke commands when the user selects them
+
+## When Commands Are Sent
+
+The server sends `available_commands_update` at two points:
+
+1. **Session initialization** — When a new session is created or loaded, the server sends the current available commands
+2. **Ferment state changes** — When the ferment state changes (e.g., new ferment available, ferment completed), the server sends an updated command list
+
+## Notification Structure
+
+```typescript
+{
+    sessionId: string,           // The session this notification belongs to
+    update: {
+        sessionUpdate: "available_commands_update",
+        availableCommands: [
+            {
+                name: string,           // Command identifier (e.g., "create_ferment")
+                description: string,    // Human-readable description
+                input?: {
+                    hint: string        // Placeholder text for input field
+                }
+            }
+        ]
+    }
+}
+```
+
+## The `create_ferment` Command
+
+The primary command exposed for VS Code integration is `create_ferment`:
+
+```typescript
+{
+    name: "create_ferment",
+    description: "Create a new ferment workflow",
+    input: {
+        hint: "Describe the task or paste ferment ID"
+    }
+}
+```
+
+This command allows users to start a new ferment workflow from within your VS Code extension.
+
+## How the Server Handles the Command
+
+When a user sends a prompt containing `/create_ferment`, the ACP server:
+
+1. **Parses the command**: Extracts the title from text following the command
+2. **Transforms the request**: Converts the command into a tool invocation hint that triggers `request_ferment_workflow`
+3. **Passes to agent**: The transformed prompt instructs the agent to call the ferment workflow tool
+
+Example command handling:
+
+```typescript
+// User sends: "/create_ferment Rewrite login flow"
+// Server transforms to:
+// "Create a ferment workflow using request_ferment_workflow tool 
+//  with title "Rewrite login flow" and intent: User initiated : Rewrite login flow"
+```
+
+The `request_ferment_workflow` tool then:
+- Validates no other ferment is active
+- Prompts for user confirmation (if UI available)
+- Creates the ferment draft
+- Activates the ferment workflow
+
+## How VS Code Extensions Should Handle It
+
+### Step 1: Subscribe to Session Notifications
+
+Listen for `session/notify` messages from the ACP server:
+
+```typescript
+// In your ACP client connection handler
+connection.onNotification('session/notify', (params: SessionNotification) => {
+    if (params.update.sessionUpdate === 'available_commands_update') {
+        handleAvailableCommandsUpdate(params.update.availableCommands);
+    }
+});
+```
+
+### Step 2: Store and Display Commands
+
+Maintain a list of available commands and update your UI:
+
+```typescript
+let availableCommands: AvailableCommand[] = [];
+
+function handleAvailableCommandsUpdate(commands: AvailableCommand[]) {
+    availableCommands = commands;
+    
+    // Update VS Code command palette
+    availableCommands.forEach(cmd => {
+        vscode.commands.registerCommand(
+            `ferment.${cmd.name}`,
+            async () => {
+                await invokeFermentCommand(cmd.name, cmd.input?.hint);
+            }
+        );
+    });
+}
+```
+
+### Step 3: Display in Command Palette
+
+Register commands so they appear in VS Code's command palette:
+
+```typescript
+// Register all available commands
+availableCommands.forEach(cmd => {
+    const commandId = `ferment.${cmd.name}`;
+    
+    vscode.commands.registerCommand(commandId, async () => {
+        // Get user input if command requires it
+        const userInput = cmd.input
+            ? await vscode.window.showInputBox({
+                  prompt: cmd.description,
+                  placeHolder: cmd.input.hint
+              })
+            : undefined;
+        
+        // Invoke the command via ACP
+        await invokeFermentCommand(cmd.name, userInput);
+    });
+    
+    // Optionally add to command palette with a specific label
+    vscode.commands.registerCommand(commandId, () => {}, {
+        id: commandId,
+        label: cmd.name,
+        description: cmd.description
+    });
+});
+```
+
+### Step 4: Handle Command Invocation
+
+When the user invokes a command, send it to the agent:
+
+```typescript
+async function invokeFermentCommand(commandName: string, userInput?: string) {
+    // Build the command string (similar to slash command format)
+    const commandText = userInput
+        ? `/${commandName} ${userInput}`
+        : `/${commandName}`;
+    
+    // Send as a prompt to the ACP session
+    await connection.sendRequest('session/prompt', {
+        sessionId: currentSessionId,
+        prompt: [{ type: 'text', text: commandText }]
+    });
+}
+```
+
+## How to Add More Commands
+
+To extend the available commands, update the server implementation:
+
+### 1. Define the command in the available commands list
+
+In `src/modes/acp/server.ts`, modify the `getAvailableCommands()` function:
+
+```typescript
+function getAvailableCommands(fermentState: FermentState): AvailableCommand[] {
+    const commands: AvailableCommand[] = [
+        {
+            name: 'create_ferment',
+            description: 'Create a new ferment workflow for structured multi-step project work',
+            input: {
+                hint: 'Provide a concise title (3-5 words) and full intent description'
+            }
+        }
+    ];
+    
+    // Add new commands here
+    if (fermentState?.status === 'running') {
+        commands.push({
+            name: 'pause_ferment',
+            description: 'Pause the current ferment',
+            // No input required
+        });
+        
+        commands.push({
+            name: 'complete_ferment',
+            description: 'Mark the current ferment as complete',
+            input: {
+                hint: 'Add completion notes (optional)'
+            }
+        });
+    }
+    
+    return commands;
+}
+```
+
+### 2. Register a handler for the new command
+
+In your ACP prompt handler, recognize the new command:
+
+```typescript
+async prompt(params: PromptRequest): Promise<PromptResponse> {
+    const text = params.prompt
+        .map((b: ContentBlock) => (b.type === 'text' ? b.text : ''))
+        .join('')
+        .trim();
+    
+    // Handle commands
+    if (text.startsWith('/create_ferment')) {
+        // Parse command arguments
+        const commandArg = text.slice('/create_ferment'.length).trim();
+        const title = commandArg || 'New Ferment';
+        const intent = commandArg
+            ? `User initiated : ${commandArg}`
+            : 'User initiated a new ferment workflow ';
+        
+        // Transform into a prompt that triggers the request_ferment_workflow tool
+        text = `Create a ferment workflow using the request_ferment_workflow tool with title "${title}" and intent: ${intent}`;
+    } else if (text.startsWith('/pause_ferment')) {
+        // Handle pause_ferment command
+    } else if (text.startsWith('/complete_ferment')) {
+        // Handle complete_ferment command
+    }
+    
+    // ... rest of prompt handling
+}
+```
+
+### 3. Send updated commands when state changes
+
+Emit `available_commands_update` after any state change that affects available commands:
+
+```typescript
+// After ferment state changes
+this.send({
+    sessionId,
+    update: {
+        sessionUpdate: 'available_commands_update',
+        availableCommands: getAvailableCommands(newFermentState)
+    }
+});
+```
+
+## Example: Complete VS Code Extension Handler
+
+```typescript
+import * as vscode from 'vscode';
+import type { SessionNotification, AvailableCommand } from '@agentclientprotocol/sdk';
+
+interface FermentCommandsExtension {
+    activate(context: vscode.ExtensionContext): void;
+}
+
+export function activate(context: vscode.ExtensionContext): void {
+    let availableCommands: AvailableCommand[] = [];
+    let currentSessionId: string | null = null;
+    
+    // Subscribe to session notifications
+    acpConnection.onNotification('session/notify', (params: SessionNotification) => {
+        if (params.update.sessionUpdate === 'available_commands_update') {
+            availableCommands = params.update.availableCommands;
+            registerFermentCommands(availableCommands);
+        }
+    });
+    
+    function registerFermentCommands(commands: AvailableCommand[]): void {
+        commands.forEach(cmd => {
+            const commandId = `ferment.${cmd.name}`;
+            
+            // Dispose existing command if present
+            const existing = vscode.commands.getCommands(true)
+                .then(cmds => {
+                    if (cmds.includes(commandId)) {
+                        vscode.commands.registerCommand(commandId, () => {});
+                    }
+                });
+            
+            const disposable = vscode.commands.registerCommand(commandId, async () => {
+                const userInput = cmd.input
+                    ? await vscode.window.showInputBox({
+                          prompt: cmd.description,
+                          placeHolder: cmd.input.hint
+                      })
+                    : undefined;
+                
+                // Send command to ACP
+                await acpConnection.sendRequest('session/prompt', {
+                    sessionId: currentSessionId!,
+                    prompt: [{
+                        type: 'text',
+                        text: userInput
+                            ? `/${cmd.name} ${userInput}`
+                            : `/${cmd.name}`
+                    }]
+                });
+            });
+            
+            context.subscriptions.push(disposable);
+        });
+    }
+}
+```
+
+## Related Documentation
+
+- [Ferment Overview](./ferment.md) — Complete guide to ferment workflows
+- [ACP SDK Types](./ferment/acp-sdk-types.md) — Detailed type definitions
+- [ACP Notification Pattern](./ferment/acp-notification-pattern.md) — How notifications work

--- a/src/extensions/ferment/state.test.ts
+++ b/src/extensions/ferment/state.test.ts
@@ -57,6 +57,32 @@ describe("setActive", () => {
 	})
 })
 
+describe("onActiveFermentChange", () => {
+	it("supports multiple listeners", () => {
+		const listener1 = vi.fn()
+		const listener2 = vi.fn()
+		const listener3 = vi.fn()
+
+		const unsubscribe1 = onActiveFermentChange(listener1)
+		onActiveFermentChange(listener2)
+		onActiveFermentChange(listener3)
+
+		setActive(makeFerment("running"))
+
+		expect(listener1).toHaveBeenCalledWith(true)
+		expect(listener2).toHaveBeenCalledWith(true)
+		expect(listener3).toHaveBeenCalledWith(true)
+
+		// Unsubscribe listener1 and verify others still work
+		unsubscribe1()
+		setActive(makeFerment("complete"))
+
+		expect(listener1).toHaveBeenCalledTimes(1) // Not called again
+		expect(listener2).toHaveBeenCalledTimes(2)
+		expect(listener3).toHaveBeenCalledTimes(2)
+	})
+})
+
 describe("active ferment env helpers", () => {
 	it("treats a non-empty env value as active", () => {
 		vi.stubEnv("KIMCHI_ACTIVE_FERMENT", "ferment-123")

--- a/src/extensions/ferment/state.ts
+++ b/src/extensions/ferment/state.ts
@@ -46,17 +46,26 @@ export function clearActiveFermentId(env: Record<string, string | undefined> = p
 	Reflect.deleteProperty(env, "KIMCHI_ACTIVE_FERMENT")
 }
 
-let activeFermentChangeListener: ((hasActive: boolean) => void) | undefined
+const activeFermentChangeListeners = new Set<(hasActive: boolean) => void>()
 
 export function onActiveFermentChange(listener: (hasActive: boolean) => void): () => void {
-	activeFermentChangeListener = listener
+	activeFermentChangeListeners.add(listener)
 	return () => {
-		if (activeFermentChangeListener === listener) activeFermentChangeListener = undefined
+		activeFermentChangeListeners.delete(listener)
 	}
 }
 
 export function notifyFermentActive(hasActive: boolean): void {
-	activeFermentChangeListener?.(hasActive)
+	// Snapshot to avoid concurrent-modification issues if a listener
+	// synchronously registers or unregisters another listener.
+	for (const listener of [...activeFermentChangeListeners]) {
+		try {
+			listener(hasActive)
+		} catch (err) {
+			// Log but don't let one failing listener prevent others from receiving updates
+			process.stderr.write(`[ferment] active ferment change listener failed: ${String(err)}\n`)
+		}
+	}
 }
 
 function shouldElevatePermissions(f: Ferment | undefined): boolean {

--- a/src/modes/acp/command-processor.test.ts
+++ b/src/modes/acp/command-processor.test.ts
@@ -1,0 +1,132 @@
+import { describe, expect, it } from "vitest"
+import {
+	type CommandResult,
+	type CreateFermentResult,
+	type UnknownCommandResult,
+	processCommand,
+} from "./command-processor.js"
+
+/** Type guard to narrow CommandResult to CreateFermentResult in tests. */
+function isCreateFermentResult(result: CommandResult): result is CreateFermentResult {
+	return result.isCommand === true && result.command === "create_ferment"
+}
+
+/** Type guard to narrow CommandResult to UnknownCommandResult in tests. */
+function isUnknownCommandResult(result: CommandResult): result is UnknownCommandResult {
+	return result.isCommand === true && result.command !== "create_ferment"
+}
+
+describe("processCommand", () => {
+	describe("non-command input", () => {
+		it("returns unchanged text for input without slash prefix", () => {
+			const result = processCommand("Hello world")
+			expect(result.isCommand).toBe(false)
+			expect(result.promptText).toBe("Hello world")
+			expect(result.originalText).toBe("Hello world")
+		})
+
+		it("returns unchanged text for empty input", () => {
+			const result = processCommand("")
+			expect(result.isCommand).toBe(false)
+			expect(result.promptText).toBe("")
+		})
+
+		it("returns unchanged text for whitespace-only input", () => {
+			const result = processCommand("   ")
+			expect(result.isCommand).toBe(false)
+			expect(result.promptText).toBe("   ")
+		})
+	})
+
+	describe("create_ferment command", () => {
+		it("processes /create_ferment with title argument", () => {
+			const result = processCommand("/create_ferment Rewrite authentication")
+			expect(isCreateFermentResult(result)).toBe(true)
+			if (!isCreateFermentResult(result)) return // TS narrowing
+			expect(result.argument).toBe("Rewrite authentication")
+			expect(result.title).toBe("Rewrite authentication")
+			expect(result.intent).toBe("User wants to create a ferment: Rewrite authentication")
+			expect(result.promptText).toContain("request_ferment_workflow")
+			expect(result.promptText).toContain('"Rewrite authentication"')
+		})
+
+		it("is case-insensitive", () => {
+			const lower = processCommand("/create_ferment Title")
+			const upper = processCommand("/CREATE_FERMENT Title")
+			const mixed = processCommand("/Create_Ferment Title")
+			const partial = processCommand("/CREATE_ferment Title")
+
+			for (const r of [lower, upper, mixed, partial]) {
+				expect(isCreateFermentResult(r)).toBe(true)
+				if (!isCreateFermentResult(r)) continue // TS narrowing
+				expect(r.title).toBe("Title")
+			}
+		})
+
+		it("processes /create_ferment without argument", () => {
+			const result = processCommand("/create_ferment")
+			expect(isCreateFermentResult(result)).toBe(true)
+			if (!isCreateFermentResult(result)) return // TS narrowing
+			expect(result.argument).toBe("")
+			expect(result.title).toBe("New Ferment")
+			expect(result.intent).toBe("User wants to create a new ferment workflow")
+			expect(result.promptText).toContain("request_ferment_workflow")
+			expect(result.promptText).toContain('"New Ferment"')
+		})
+
+		it("processes /create_ferment with multiple word title", () => {
+			const result = processCommand("/create_ferment Implement OAuth2 login with Google")
+			expect(isCreateFermentResult(result)).toBe(true)
+			if (!isCreateFermentResult(result)) return // TS narrowing
+			expect(result.title).toBe("Implement OAuth2 login with Google")
+			expect(result.argument).toBe("Implement OAuth2 login with Google")
+		})
+
+		it("trims leading/trailing whitespace from argument", () => {
+			const result = processCommand("/create_ferment   My Ferment   ")
+			expect(isCreateFermentResult(result)).toBe(true)
+			if (!isCreateFermentResult(result)) return // TS narrowing
+			expect(result.title).toBe("My Ferment")
+		})
+
+		it("preserves original text unchanged", () => {
+			const original = "/create_ferment My Title"
+			const result = processCommand(original)
+			expect(result.originalText).toBe(original)
+		})
+	})
+
+	describe("edge cases", () => {
+		it("treats bare / as non-command", () => {
+			const result = processCommand("/")
+			expect(result.isCommand).toBe(false)
+			expect(result.promptText).toBe("/")
+		})
+	})
+
+	describe("unknown commands", () => {
+		it("returns unchanged for unknown commands", () => {
+			const result = processCommand("/unknown_command something")
+			expect(isUnknownCommandResult(result)).toBe(true)
+			if (!isUnknownCommandResult(result)) return // TS narrowing
+			expect(result.command).toBe("unknown_command")
+			expect(result.promptText).toBe("/unknown_command something")
+		})
+
+		it("returns unchanged for /pause_ferment (not yet implemented)", () => {
+			const result = processCommand("/pause_ferment")
+			expect(isUnknownCommandResult(result)).toBe(true)
+			if (!isUnknownCommandResult(result)) return // TS narrowing
+			expect(result.command).toBe("pause_ferment")
+			expect(result.promptText).toBe("/pause_ferment")
+		})
+
+		it("returns unchanged for /resume_ferment (not yet implemented)", () => {
+			const result = processCommand("/resume_ferment")
+			expect(isUnknownCommandResult(result)).toBe(true)
+			if (!isUnknownCommandResult(result)) return // TS narrowing
+			expect(result.command).toBe("resume_ferment")
+			expect(result.promptText).toBe("/resume_ferment")
+		})
+	})
+})

--- a/src/modes/acp/command-processor.ts
+++ b/src/modes/acp/command-processor.ts
@@ -1,0 +1,112 @@
+/**
+ * Command processor — transforms slash commands into structured prompt data.
+ *
+ * This module is transport-agnostic: it knows nothing about ACP, JSON-RPC,
+ * or any specific protocol. It simply parses command syntax and returns
+ * structured data that can be used to build prompts.
+ */
+
+/** Common fields shared by all command results. */
+interface CommandResultBase {
+	/** The original input text, unmodified. */
+	readonly originalText: string
+	/** The processed text to send to the agent. */
+	readonly promptText: string
+}
+
+/** Input was not a slash command — pass through unchanged. */
+export interface PassthroughResult extends CommandResultBase {
+	readonly isCommand: false
+}
+
+/** A recognised slash command with command-specific payload. */
+export interface CreateFermentResult extends CommandResultBase {
+	readonly isCommand: true
+	readonly command: "create_ferment"
+	readonly argument: string
+	readonly title: string
+	readonly intent: string
+}
+
+/** A slash command that was parsed but is not (yet) handled. */
+export interface UnknownCommandResult extends CommandResultBase {
+	readonly isCommand: true
+	readonly command: string
+	readonly argument: string
+}
+
+/**
+ * Discriminated union of all possible command processing outcomes.
+ *
+ * Discriminate on `isCommand` first, then narrow on `command` to access
+ * command-specific fields like `title` and `intent`.
+ */
+export type CommandResult = PassthroughResult | CreateFermentResult | UnknownCommandResult
+
+/**
+ * Parse and process slash commands from user input.
+ *
+ * Supported commands:
+ * - /create_ferment [title] — Creates a new ferment workflow
+ *
+ * Commands are case-insensitive.
+ *
+ * @param text - The raw input text
+ * @returns A discriminated {@link CommandResult}
+ */
+export function processCommand(text: string): CommandResult {
+	const trimmed = text.trim()
+
+	// Check for command prefix
+	if (!trimmed.startsWith("/")) {
+		return { originalText: text, isCommand: false, promptText: text }
+	}
+
+	// Extract command name (case-insensitive) and argument
+	const spaceIndex = trimmed.indexOf(" ")
+	const command = (spaceIndex === -1 ? trimmed.slice(1) : trimmed.slice(1, spaceIndex)).toLowerCase()
+	const argument = spaceIndex === -1 ? "" : trimmed.slice(spaceIndex + 1).trim()
+
+	if (!command) {
+		// Bare "/" with no command name — not a command
+		return { originalText: text, isCommand: false, promptText: text }
+	}
+
+	switch (command) {
+		case "create_ferment":
+			return buildCreateFerment(text, argument)
+
+		// Future commands:
+		// case "pause_ferment":
+		// case "resume_ferment":
+		// case "complete_ferment":
+
+		default:
+			return {
+				originalText: text,
+				isCommand: true,
+				command,
+				argument,
+				promptText: text,
+			}
+	}
+}
+
+function buildCreateFerment(originalText: string, argument: string): CreateFermentResult {
+	const title = argument || "New Ferment"
+	const intent = argument
+		? `User wants to create a ferment: ${argument}`
+		: "User wants to create a new ferment workflow"
+
+	const promptText = `Create a ferment workflow using the request_ferment_workflow tool with title "${title}" and intent: ${intent}`
+
+	return {
+		originalText,
+		isCommand: true,
+		command: "create_ferment",
+		argument,
+		promptText,
+		title,
+		intent,
+	}
+}

--- a/src/modes/acp/server.test.ts
+++ b/src/modes/acp/server.test.ts
@@ -60,6 +60,7 @@ class FakeAgentSession {
 	abortImpl: () => Promise<void> = async () => {}
 	bindExtensionsImpl: (_bindings: unknown) => Promise<void> = async () => {}
 	lastPromptImages?: unknown[]
+	promptCalls: Array<{ prompt: string; opts?: { images?: unknown[] } }> = []
 	// Branch entries returned to the replay walker. Tests fill this with the
 	// shape buildSessionContext consumers expect (type:"message" + role).
 	branch: unknown[] = []
@@ -84,6 +85,7 @@ class FakeAgentSession {
 
 	async prompt(text: string, opts?: { images?: unknown[] }): Promise<void> {
 		this.lastPromptImages = opts?.images
+		this.promptCalls.push({ prompt: text, opts })
 		await this.promptImpl(text, opts)
 	}
 
@@ -1290,6 +1292,134 @@ describe("newSession model state", () => {
 	})
 })
 
+describe("newSession available commands", () => {
+	it("sends available_commands_update with create_ferment command on session init", async () => {
+		const fake = new FakeAgentSession("session-commands")
+		const factory: AcpSessionFactory = async () => asSession(fake)
+		const { conn, updates } = makeRecordingConn()
+		const agent = new KimchiAcpAgent(conn, {
+			extensionFactories: [],
+			agentDir: "/tmp/fake-agent-dir",
+			sessionFactory: factory,
+		})
+		await agent.newSession({ cwd: "/tmp", mcpServers: [] })
+
+		// Find the available_commands_update notification
+		const update = updates.find((u) => u.update.sessionUpdate === "available_commands_update")
+		expect(update).toBeDefined()
+		expect(update?.sessionId).toBe("session-commands")
+
+		const updatePayload = update?.update as { availableCommands: Array<Record<string, unknown>> }
+		expect(updatePayload.availableCommands).toHaveLength(1)
+
+		const cmd = updatePayload.availableCommands[0]
+		expect(cmd).toMatchObject({
+			name: "create_ferment",
+			description: "Create a new ferment workflow for structured multi-step project work",
+			input: { hint: "Provide a concise title (3-5 words) and full intent description" },
+		})
+	})
+
+	it("omits create_ferment command when hasActive is true", async () => {
+		const fake = new FakeAgentSession("session-no-commands")
+		const factory: AcpSessionFactory = async () => asSession(fake)
+		const { conn, updates } = makeRecordingConn()
+		const agent = new KimchiAcpAgent(conn, {
+			extensionFactories: [],
+			agentDir: "/tmp/fake-agent-dir",
+			sessionFactory: factory,
+		})
+
+		// @ts-expect-error Accessing private method for testing
+		agent.sendAvailableCommandsUpdate("session-no-commands", true)
+
+		// Find the available_commands_update notification
+		const update = updates.find((u) => u.update.sessionUpdate === "available_commands_update")
+		expect(update).toBeDefined()
+
+		const updatePayload = update?.update as { availableCommands: Array<Record<string, unknown>> }
+		// When hasActive is true, available commands should be empty
+		expect(updatePayload.availableCommands).toHaveLength(0)
+	})
+})
+
+describe("create_ferment command handling", () => {
+	it("transforms /create_ferment command into tool invocation prompt", async () => {
+		const fake = new FakeAgentSession("session-cmd-test")
+		const factory: AcpSessionFactory = async () => asSession(fake)
+		const { conn } = makeRecordingConn()
+		const agent = new KimchiAcpAgent(conn, {
+			extensionFactories: [],
+			agentDir: "/tmp/fake-agent-dir",
+			sessionFactory: factory,
+		})
+		await agent.newSession({ cwd: "/tmp", mcpServers: [] })
+
+		// Send the create_ferment command with a title
+		await agent.prompt({
+			sessionId: "session-cmd-test",
+			prompt: [{ type: "text", text: "/create_ferment Rewrite authentication" }],
+		})
+
+		// Verify the session received the transformed prompt
+		expect(fake.promptCalls).toHaveLength(1)
+		const transformedPrompt = fake.promptCalls[0]?.prompt ?? ""
+		expect(transformedPrompt).toContain("request_ferment_workflow")
+		expect(transformedPrompt).toContain("Rewrite authentication")
+	})
+
+	it("uses default title when /create_ferment has no arguments", async () => {
+		const fake = new FakeAgentSession("session-cmd-default")
+		const factory: AcpSessionFactory = async () => asSession(fake)
+		const { conn } = makeRecordingConn()
+		const agent = new KimchiAcpAgent(conn, {
+			extensionFactories: [],
+			agentDir: "/tmp/fake-agent-dir",
+			sessionFactory: factory,
+		})
+		await agent.newSession({ cwd: "/tmp", mcpServers: [] })
+
+		// Send the command without arguments
+		await agent.prompt({
+			sessionId: "session-cmd-default",
+			prompt: [{ type: "text", text: "/create_ferment" }],
+		})
+
+		expect(fake.promptCalls).toHaveLength(1)
+		const transformedPrompt = fake.promptCalls[0]?.prompt ?? ""
+		expect(transformedPrompt).toContain("New Ferment")
+	})
+})
+
+describe("loadSession available commands", () => {
+	it("does not send available_commands_update on session load", async () => {
+		const fake = new FakeAgentSession("session-load-test")
+		fake.branch = [userTextEntry("previous message", "u1", null)]
+		const loader: AcpSessionLoader = async () => asSession(fake)
+		const { conn, updates } = makeRecordingConn()
+		const agent = new KimchiAcpAgent(conn, {
+			extensionFactories: [],
+			agentDir: "/tmp/fake-agent-dir",
+			sessionFactory: async () => asSession(new FakeAgentSession("unused")),
+			sessionLoader: loader,
+		})
+
+		await agent.loadSession({ sessionId: "session-load-test", cwd: "/tmp", mcpServers: [] })
+
+		// loadSession should NOT send available_commands_update
+		// It only replays transcript entries
+		const cmdUpdate = updates.find((u) => u.update.sessionUpdate === "available_commands_update")
+		expect(cmdUpdate).toBeUndefined()
+
+		// Should have only the transcript replay notification
+		expect(updates.length).toBeGreaterThanOrEqual(1)
+		expect(updates[0].update).toMatchObject({
+			sessionUpdate: "user_message_chunk",
+			content: { type: "text", text: "previous message" },
+		})
+	})
+})
+
 describe("unstable_setSessionModel", () => {
 	it("switches to a valid model", async () => {
 		const fake = new FakeAgentSession("switch-session")
@@ -1788,8 +1918,12 @@ describe("KimchiAcpAgent loadSession", () => {
 			currentModelId: "test/test-model",
 		})
 		expect(loaderCalls.count).toBe(0)
-		expect(updates).toHaveLength(1)
+		// newSession sends available_commands_update, then loadSession replay sends user_message_chunk
+		expect(updates).toHaveLength(2)
 		expect(updates[0].update).toMatchObject({
+			sessionUpdate: "available_commands_update",
+		})
+		expect(updates[1].update).toMatchObject({
 			sessionUpdate: "user_message_chunk",
 			content: { type: "text", text: "already here" },
 		})

--- a/src/modes/acp/server.ts
+++ b/src/modes/acp/server.ts
@@ -51,8 +51,10 @@ import {
 	createAgentSession,
 	initTheme,
 } from "@earendil-works/pi-coding-agent"
+import { hasActiveFerment, onActiveFermentChange } from "../../extensions/ferment/state.js"
 import { isHideThinkingEnabled } from "../../extensions/hide-thinking.js"
 import { createAcpPermissionPrompter } from "./acp-prompter.js"
+import { processCommand } from "./command-processor.js"
 import { registerAcpPrompter, unregisterAcpPrompter } from "./permission-prompter-registry.js"
 
 /**
@@ -124,6 +126,9 @@ export class KimchiAcpAgent implements Agent {
 	// earlier session record.
 	private loadingSessions = new Map<string, Promise<LoadSessionResponse>>()
 	private shutdownPromise: Promise<void> | undefined
+	// Unsubscribe function for the active ferment change listener; stored for
+	// cleanup during shutdown to prevent leaks and stale references.
+	private unsubscribeFromFermentChanges?: () => void
 
 	constructor(
 		private readonly conn: AgentSideConnection,
@@ -133,6 +138,19 @@ export class KimchiAcpAgent implements Agent {
 		this.agentDir = options.agentDir
 		this.sessionLister = options.sessionLister ?? defaultSessionLister(options)
 		this.sessionLoader = options.sessionLoader ?? defaultSessionLoader(options)
+
+		// Subscribe to ferment state changes to update available commands
+		this.unsubscribeFromFermentChanges = onActiveFermentChange((hasActive) => {
+			// When ferment state changes, re-send available commands to all active sessions
+			for (const [sessionId, _record] of this.sessions) {
+				try {
+					this.sendAvailableCommandsUpdate(sessionId, hasActive)
+				} catch (err) {
+					// Log but don't let one failing session prevent updates to others
+					process.stderr.write(`acp sendAvailableCommandsUpdate failed for ${sessionId}: ${String(err)}\n`)
+				}
+			}
+		})
 	}
 
 	async initialize(_: InitializeRequest): Promise<InitializeResponse> {
@@ -206,6 +224,10 @@ export class KimchiAcpAgent implements Agent {
 			await bindAcpExtensions(session)
 			const unsubscribe = session.subscribe((event) => this.onSessionEvent(sessionId, event))
 			this.sessions.set(sessionId, { session, unsubscribe })
+			// Send after sessions.set so that a throw from this.send (e.g., closed
+			// connection) doesn't abort session creation and leak the prompter
+			// registered above — disposeSessionRecord / doShutdown will clean it up.
+			this.sendAvailableCommandsUpdate(sessionId, hasActiveFerment())
 			const models = buildSessionModelState(session)
 			return { sessionId, models }
 		} catch (err) {
@@ -348,10 +370,16 @@ export class KimchiAcpAgent implements Agent {
 				process.stderr.write(`acp prompt: dropping ${b.type} block (${reason})\n`)
 			}
 		}
-		const text = params.prompt
+		let text = params.prompt
 			.map((b: ContentBlock) => (b.type === "text" ? b.text : ""))
 			.join("")
 			.trim()
+
+		// Process slash commands (e.g., /create_ferment)
+		const commandResult = processCommand(text)
+		if (commandResult.isCommand) {
+			text = commandResult.promptText
+		}
 		// Extract image blocks from the prompt only if model supports vision.
 		const images: ImageContent[] = supportsImages
 			? params.prompt
@@ -445,6 +473,8 @@ export class KimchiAcpAgent implements Agent {
 			await this.disposeSessionRecord(entry)
 		}
 		this.sessions.clear()
+		// Unsubscribe from ferment state changes to prevent leaks and stale references
+		this.unsubscribeFromFermentChanges?.()
 	}
 
 	private async closeSessionRecord(sessionId: string): Promise<void> {
@@ -748,6 +778,27 @@ export class KimchiAcpAgent implements Agent {
 		// _processAgentEvent does not expect.
 		this.conn.sessionUpdate(params).catch((err: unknown) => {
 			process.stderr.write(`acp sessionUpdate failed: ${String(err)}\n`)
+		})
+	}
+
+	private sendAvailableCommandsUpdate(sessionId: string, hasActive = false): void {
+		// When a ferment is active, omit the create_ferment command to prevent
+		// creating multiple ferments. The description is only sent when available.
+		const availableCommands = hasActive
+			? []
+			: [
+					{
+						name: "create_ferment",
+						description: "Create a new ferment workflow for structured multi-step project work",
+						input: { hint: "Provide a concise title (3-5 words) and full intent description" },
+					},
+				]
+		this.send({
+			sessionId,
+			update: {
+				sessionUpdate: "available_commands_update",
+				availableCommands,
+			},
 		})
 	}
 


### PR DESCRIPTION
Add ACP available_commands_update notification to enable VS Code discovery and triggering of ferment workflows.

## Description

Changes:
- Add sendAvailableCommandsUpdate() method to KimchiAcpAgent
- Emit available_commands_update on newSession with start_ferment cmd
- Subscribe to onActiveFermentChange, re-send updated commands on state change
- When ferment active, commands array is empty (suppress start_ferment)
- Convert onActiveFermentChange from single to multi-listener (Set)

Tests:
- Test available_commands_update sent on newSession
- Test commands empty when hasActive=true
- Test loadSession does NOT send available_commands_update
- Test onActiveFermentChange supports multiple listeners

Docs:
- Add docs/acp-commands.md integration guide for VS Code

## Type of Change

<!-- Select all that apply. -->

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [x] Documentation update
