### PR TITLE
chore(github): add contributor infrastructure (issue templates, PR template, labels, workflows, CODEOWNERS)

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,16 @@
+# Global fallback — all PRs require at least one maintainer review
+* @getkimchi/core
+
+# Ferment subsystem
+src/extensions/ferment/ @getkimchi/core
+src/ferment/ @getkimchi/core
+
+# Teleport subsystem
+src/modes/teleport/ @getkimchi/core
+
+# CI and repo config
+.github/ @getkimchi/core
+
+# Docs
+docs/ @getkimchi/core
+*.md @getkimchi/core

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -6,6 +6,8 @@ body:
     attributes:
       value: |
         Before filing, please check existing issues to avoid duplicates.
+
+        **Tip:** Before submitting, check that your report doesn't include any sensitive information (API keys, credentials, proprietary code).
   - type: input
     id: version
     attributes:
@@ -43,6 +45,39 @@ body:
       label: Expected behavior
     validations:
       required: true
+  - type: textarea
+    id: reproduction-command
+    attributes:
+      label: Reproduction command
+      description: |
+        A one-liner that reproduces the issue. Pin the model with `--provider` and `--model` for consistency.
+      placeholder: |
+        kimchi -p "your prompt here" --provider kimchi-dev --model kimi-k2.5
+      render: shell
+    validations:
+      required: true
+  - type: textarea
+    id: session-file
+    attributes:
+      label: Session file
+      description: |
+        If the bug occurred during an interactive session, paste the session file path. You can also export it to HTML for easier sharing: `kimchi --export <path-to-session.jsonl>`
+      placeholder: ~/.config/kimchi/harness/sessions/--path--/session.jsonl
+    validations:
+      required: false
+  - type: textarea
+    id: json-event-stream
+    attributes:
+      label: JSON event stream
+      description: |
+        Optional. Re-run your reproduction command with `--mode json --no-session` to capture a machine-readable event trace:
+        ```
+        kimchi --mode json -p "your prompt" --no-session --provider kimchi-dev --model kimi-k2.5 > events.jsonl
+        ```
+        Paste the contents or attach the file.
+      render: json
+    validations:
+      required: false
   - type: textarea
     id: logs
     attributes:

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,66 +1,50 @@
-name: Bug Report
-description: Report an issue with the kimchi coding harness
-labels: ["bug"]
+name: Bug report
+description: Something isn't working as expected
+labels: ["bug", "needs-triage"]
 body:
   - type: markdown
     attributes:
       value: |
-        See [Troubleshooting Guide](../../docs/troubleshooting.md) for useful debugging commands.
-
-        **Tip:** Before submitting, check that your report doesn't include any sensitive information (API keys, credentials, proprietary code).
-
+        Before filing, please check existing issues to avoid duplicates.
+  - type: input
+    id: version
+    attributes:
+      label: Kimchi version
+      description: Output of `kimchi --version`
+      placeholder: "e.g. v0.0.84"
+    validations:
+      required: true
+  - type: input
+    id: os
+    attributes:
+      label: OS and architecture
+      placeholder: "e.g. macOS 14, arm64"
+    validations:
+      required: true
   - type: textarea
     id: description
     attributes:
       label: What happened?
-      description: Describe what you observed and what you expected instead.
-      placeholder: |
-        **Actual:** The agent failed to edit the file and returned an empty response.
-        **Expected:** The agent should have replaced "foo" with "bar" in config.ts.
+      description: A clear description of the bug.
     validations:
       required: true
-
   - type: textarea
-    id: reproduction
+    id: repro
     attributes:
-      label: Reproduction command
-      description: |
-        A one-liner that reproduces the issue. Pin the model with `--provider` and `--model` for consistency.
+      label: Steps to reproduce
       placeholder: |
-        kimchi -p "your prompt here" --provider kimchi-dev --model kimi-k2.5
+        1. Run `kimchi ...`
+        2. ...
+    validations:
+      required: true
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected behavior
+    validations:
+      required: true
+  - type: textarea
+    id: logs
+    attributes:
+      label: Relevant logs or output
       render: shell
-    validations:
-      required: true
-
-  - type: input
-    id: version
-    attributes:
-      label: Harness version
-      description: Output of `kimchi --version`
-      placeholder: "0.5.0"
-    validations:
-      required: true
-
-  - type: textarea
-    id: session-file
-    attributes:
-      label: Session file
-      description: |
-        If the bug occurred during an interactive session, paste the session file path. You can also export it to HTML for easier sharing: `kimchi --export <path-to-session.jsonl>`
-      placeholder: ~/.config/kimchi/harness/sessions/--path--/session.jsonl
-    validations:
-      required: false
-
-  - type: textarea
-    id: json-event-stream
-    attributes:
-      label: JSON event stream
-      description: |
-        Optional. Re-run your reproduction command with `--mode json --no-session` to capture a machine-readable event trace:
-        ```
-        kimchi --mode json -p "your prompt" --no-session --provider kimchi-dev --model kimi-k2.5 > events.jsonl
-        ```
-        Paste the contents or attach the file.
-      render: json
-    validations:
-      required: false

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Question or discussion
+    url: https://github.com/getkimchi/kimchi/issues/new?template=question.yml
+    about: Ask a question or start a discussion

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,24 @@
+name: Feature request
+description: Propose a new feature or enhancement
+labels: ["enhancement", "needs-triage"]
+body:
+  - type: textarea
+    id: motivation
+    attributes:
+      label: Motivation
+      description: What problem does this solve? Who is affected?
+    validations:
+      required: true
+  - type: textarea
+    id: proposal
+    attributes:
+      label: Proposed solution
+      description: Describe what you'd like to happen. Include API changes or CLI flags if relevant.
+    validations:
+      required: true
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives considered
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/question.yml
+++ b/.github/ISSUE_TEMPLATE/question.yml
@@ -1,0 +1,16 @@
+name: Question
+description: Ask a question about usage or behavior
+labels: ["question", "needs-triage"]
+body:
+  - type: textarea
+    id: question
+    attributes:
+      label: Your question
+    validations:
+      required: true
+  - type: textarea
+    id: context
+    attributes:
+      label: What have you already tried?
+    validations:
+      required: false

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,13 +1,18 @@
-## Description
+## Linked issue
 
-<!-- What problem does this PR solve? What changes were made and why? -->
+Closes #
 
+<!-- Every PR must link to an existing issue. PRs without a linked issue will not be reviewed.
+     Use one of: Closes #N / Fixes #N / Resolves #N -->
 
-## Type of Change
+## What does this PR do?
 
-<!-- Select all that apply. -->
+<!-- Brief description of the change and why it's needed. -->
 
-- [ ] Bug fix
-- [ ] New feature
-- [ ] Breaking change
-- [ ] Documentation update
+## Checklist
+
+- [ ] I have read [CONTRIBUTING.md](../CONTRIBUTING.md) and agree to the CLA
+- [ ] This PR links to an open issue above
+- [ ] Tests pass locally (`pnpm run test`)
+- [ ] Lint passes (`pnpm run check`)
+- [ ] Documentation updated if behavior changed

--- a/.github/workflows/require-linked-issue.yml
+++ b/.github/workflows/require-linked-issue.yml
@@ -1,0 +1,21 @@
+name: Require linked issue
+
+on:
+  pull_request:
+    types: [opened, edited, synchronize, reopened]
+
+jobs:
+  check:
+    name: Linked issue present
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check PR body for linked issue
+        env:
+          PR_BODY: ${{ github.event.pull_request.body }}
+        run: |
+          if ! echo "$PR_BODY" | grep -iE "(closes|fixes|resolves) #[0-9]+" > /dev/null; then
+            echo "❌ No linked issue found in PR description."
+            echo "Add one of: 'Closes #N', 'Fixes #N', or 'Resolves #N'"
+            exit 1
+          fi
+          echo "✅ Linked issue found."

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,0 +1,32 @@
+name: Stale issues and PRs
+
+on:
+  schedule:
+    - cron: '0 8 * * 1'  # Every Monday at 08:00 UTC
+  workflow_dispatch:
+
+jobs:
+  stale:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/stale@v9
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          days-before-issue-stale: 30
+          days-before-issue-close: 14
+          days-before-pr-stale: 21
+          days-before-pr-close: 14
+          stale-issue-label: stale
+          stale-pr-label: stale
+          stale-issue-message: >
+            This issue has had no activity for 30 days. It will be closed in 14 days
+            unless there is new activity or a maintainer removes the `stale` label.
+          stale-pr-message: >
+            This PR has had no activity for 21 days. It will be closed in 14 days
+            unless there is new activity or a maintainer removes the `stale` label.
+          close-issue-message: >
+            Closing due to inactivity. Feel free to reopen if this is still relevant.
+          close-pr-message: >
+            Closing due to inactivity. Feel free to reopen if this is still relevant.
+          exempt-issue-labels: 'pinned,help wanted,good first issue'
+          exempt-pr-labels: 'pinned'

--- a/.github/workflows/welcome.yml
+++ b/.github/workflows/welcome.yml
@@ -1,0 +1,21 @@
+name: Welcome new contributors
+
+on:
+  pull_request_target:
+    types: [opened]
+  issues:
+    types: [opened]
+
+jobs:
+  welcome:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/first-interaction@v1
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          issue-message: |
+            👋 Thanks for opening your first issue on kimchi! A maintainer will triage this shortly.
+            While you wait, make sure you've checked the [existing issues](https://github.com/getkimchi/kimchi/issues) for duplicates.
+          pr-message: |
+            👋 Thanks for your first PR on kimchi! A maintainer will review it soon.
+            Please make sure your PR links to an open issue and your checklist is complete.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -28,6 +28,30 @@ Kimchi is licensed under the **Apache License 2.0**. By contributing, you agree 
 3. Ensure tests pass and code follows the existing style.
 4. Open a pull request and complete the CLA check.
 
+## Contribution workflow
+
+1. **Open an issue first.** For anything beyond a typo fix, open an issue and get maintainer acknowledgement before starting work. This avoids duplicated effort and ensures the change aligns with the project direction.
+2. **Fork and branch.** Fork the repo and create a feature branch (`feat/your-feature` or `fix/your-fix`).
+3. **Keep PRs focused.** One issue per PR. Large PRs are hard to review and slow to merge.
+4. **Pass CI.** Run `pnpm run check` and `pnpm run test` locally before opening a PR. PRs that fail CI will not be reviewed.
+5. **Fill in the PR template.** Every field in the template exists for a reason. PRs with blank or placeholder descriptions will be closed.
+
+## What we will and won't accept
+
+**Likely to be accepted:**
+- Bug fixes with a clear reproduction case
+- Performance improvements with benchmark data
+- Features that were discussed and approved in an issue first
+
+**Unlikely to be accepted without prior discussion:**
+- Large refactors or architectural changes
+- New dependencies
+- Features that duplicate existing functionality
+
+## Review SLA
+
+We aim to triage new issues within **3 business days** and provide a first review on PRs within **5 business days**. If you haven't heard back, a polite ping on the issue is welcome.
+
 ## Code of Conduct
 
 Be respectful, constructive, and assume good intent. We enforce the [Contributor Covenant Code of Conduct](https://www.contributor-covenant.org/version/2/1/code_of_conduct/).


### PR DESCRIPTION
## What does this PR do?

Adds the full contributor infrastructure layer to the repo — structured to handle the growing volume of external PRs and issues without manual triage overhead.

## Changes

| Task | Files |
|------|-------|
| Issue templates | `.github/ISSUE_TEMPLATE/config.yml`, `bug_report.yml`, `feature_request.yml`, `question.yml` |
| PR template | `.github/pull_request_template.md` |
| Labels | Created via API: `needs-triage`, `help wanted`, `pinned`, `stale`, `docs` |
| Linked-issue check | `.github/workflows/require-linked-issue.yml` |
| Stale bot | `.github/workflows/stale.yml` |
| Welcome workflow | `.github/workflows/welcome.yml` |
| CODEOWNERS | `.github/CODEOWNERS` |
| CONTRIBUTING.md | Appended contribution workflow, acceptance criteria, review SLA |

## Manual steps after merge

- [ ] ~~Enable "Linked issue present" as a required status check on `master`~~ — intentionally **not** required; maintainers track issues in Jira. The workflow runs as advisory-only for external contributors.
- [ ] Enable "Require review from code owners" on the same branch protection rule (Settings → Branches → master → Edit)
- [ ] Create the `@getkimchi/core` GitHub Team in org settings and assign maintainers; or replace the placeholder with individual usernames in `CODEOWNERS`

## No source files modified

All changes are confined to `.github/` and `CONTRIBUTING.md`.