### PR TITLE
fix: prevent clipboard native addon crash on WSL/headless Linux

### DIFF
--- a/src/utils/clipboard-native-harness-wsl.test.ts
+++ b/src/utils/clipboard-native-harness-wsl.test.ts
@@ -1,0 +1,109 @@
+/**
+ * Tests for the WSL / headless Linux guard inside clipboard-native-harness.ts.
+ *
+ * We test the exported `hasDisplayServer` helper directly so the tests work
+ * on all platforms (macOS CI, Linux, WSL) without trying to load the native
+ * .node binding.
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
+
+beforeEach(() => {
+	vi.resetModules()
+})
+
+afterEach(() => {
+	vi.unstubAllEnvs()
+})
+
+async function freshHasDisplayServer(): Promise<() => boolean> {
+	const mod = await import("./clipboard-native-harness.js")
+	return mod.hasDisplayServer
+}
+
+describe("hasDisplayServer — WSL / headless Linux guard", () => {
+	it("returns false on WSL when WSL_DISTRO_NAME is set", async () => {
+		vi.stubEnv("WSL_DISTRO_NAME", "Ubuntu")
+		vi.stubEnv("WSL_INTEROP", "")
+		vi.stubEnv("DISPLAY", "")
+		vi.stubEnv("WAYLAND_DISPLAY", "")
+		vi.stubEnv("KIMCHI_CLIPBOARD_FORCE", "")
+
+		const hasDisplayServer = await freshHasDisplayServer()
+		// Simulate linux platform logic inline (function reads process.platform)
+		// On non-linux hosts the guard returns true immediately; test the logic
+		// via the exported helper which only applies the guard on linux.
+		// We call it and accept that on macOS/win32 it returns true (correct).
+		if (process.platform === "linux") {
+			expect(hasDisplayServer()).toBe(false)
+		} else {
+			// On macOS/Windows the function correctly returns true; WSL cannot
+			// run there so the check is a no-op.
+			expect(hasDisplayServer()).toBe(true)
+		}
+	})
+
+	it("returns false on WSL when WSL_INTEROP is set (even if WSLg sets DISPLAY)", async () => {
+		vi.stubEnv("WSL_DISTRO_NAME", "")
+		vi.stubEnv("WSL_INTEROP", "/run/WSL/1_interop")
+		vi.stubEnv("DISPLAY", ":0") // WSLg sets this even without a real X server
+		vi.stubEnv("WAYLAND_DISPLAY", "")
+		vi.stubEnv("KIMCHI_CLIPBOARD_FORCE", "")
+
+		const hasDisplayServer = await freshHasDisplayServer()
+		if (process.platform === "linux") {
+			expect(hasDisplayServer()).toBe(false)
+		} else {
+			expect(hasDisplayServer()).toBe(true)
+		}
+	})
+
+	it("returns true when KIMCHI_CLIPBOARD_FORCE=1 even on WSL", async () => {
+		vi.stubEnv("WSL_DISTRO_NAME", "Ubuntu")
+		vi.stubEnv("WSL_INTEROP", "/run/WSL/1_interop")
+		vi.stubEnv("DISPLAY", ":0")
+		vi.stubEnv("KIMCHI_CLIPBOARD_FORCE", "1")
+
+		const hasDisplayServer = await freshHasDisplayServer()
+		// Force flag overrides WSL check on all platforms
+		expect(hasDisplayServer()).toBe(true)
+	})
+
+	it("returns false on headless Linux (no DISPLAY, no WAYLAND, no WSL)", async () => {
+		vi.stubEnv("WSL_DISTRO_NAME", "")
+		vi.stubEnv("WSL_INTEROP", "")
+		vi.stubEnv("DISPLAY", "")
+		vi.stubEnv("WAYLAND_DISPLAY", "")
+		vi.stubEnv("KIMCHI_CLIPBOARD_FORCE", "")
+
+		const hasDisplayServer = await freshHasDisplayServer()
+		if (process.platform === "linux") {
+			expect(hasDisplayServer()).toBe(false)
+		} else {
+			expect(hasDisplayServer()).toBe(true)
+		}
+	})
+
+	it("returns true on Linux with DISPLAY set and no WSL", async () => {
+		vi.stubEnv("WSL_DISTRO_NAME", "")
+		vi.stubEnv("WSL_INTEROP", "")
+		vi.stubEnv("DISPLAY", ":1")
+		vi.stubEnv("WAYLAND_DISPLAY", "")
+		vi.stubEnv("KIMCHI_CLIPBOARD_FORCE", "")
+
+		const hasDisplayServer = await freshHasDisplayServer()
+		// On linux: DISPLAY is set and no WSL → should return true
+		// On macOS/win32: always returns true
+		expect(hasDisplayServer()).toBe(true)
+	})
+
+	it("returns true on Linux with WAYLAND_DISPLAY set and no WSL", async () => {
+		vi.stubEnv("WSL_DISTRO_NAME", "")
+		vi.stubEnv("WSL_INTEROP", "")
+		vi.stubEnv("DISPLAY", "")
+		vi.stubEnv("WAYLAND_DISPLAY", "wayland-0")
+		vi.stubEnv("KIMCHI_CLIPBOARD_FORCE", "")
+
+		const hasDisplayServer = await freshHasDisplayServer()
+		expect(hasDisplayServer()).toBe(true)
+	})
+})

--- a/src/utils/clipboard-native-harness.ts
+++ b/src/utils/clipboard-native-harness.ts
@@ -19,6 +19,18 @@
 //
 // See oven-sh/bun#25635 and oven-sh/bun#1843 for the underlying bundler
 // limitation.
+//
+// WSL / headless Linux note:
+// The clipboard-rs Rust library calls XOpenDisplay() during ClipboardContext
+// initialisation. On Linux without a real X11/Wayland server this call
+// panics (Rust unwrap on Err) rather than returning a JS exception, killing
+// the entire process. We therefore probe the binding immediately after
+// loading it by calling availableFormats() inside the same try/catch block.
+// A Rust panic propagates as a process abort that cannot be caught in JS, so
+// the only safe strategy is to never load the binding when there is no
+// display server. We also detect WSL explicitly (via WSL_DISTRO_NAME /
+// WSL_INTEROP) because WSLg may set $DISPLAY to ":0" even when no graphical
+// session is running, giving a false positive to the simple display check.
 
 export type NativeClipboard = {
 	hasImage(): boolean
@@ -69,6 +81,23 @@ function loadPlatformBinding(): NativeClipboard {
 }
 
 /**
+ * Return true when the environment has (or may have) a working display server.
+ *
+ * On WSL the kernel sets WSL_DISTRO_NAME / WSL_INTEROP unconditionally, and
+ * WSLg sets $DISPLAY even when no graphical session is active. We therefore
+ * treat WSL as "no display" unless the user has explicitly opted in by
+ * setting KIMCHI_CLIPBOARD_FORCE=1. All other Linux systems require at least
+ * one of DISPLAY / WAYLAND_DISPLAY to be set.
+ */
+export function hasDisplayServer(): boolean {
+	if (process.platform !== "linux") return true
+	if (process.env.KIMCHI_CLIPBOARD_FORCE === "1") return true
+	const isWsl = Boolean(process.env.WSL_DISTRO_NAME || process.env.WSL_INTEROP)
+	if (isWsl) return false
+	return Boolean(process.env.DISPLAY || process.env.WAYLAND_DISPLAY)
+}
+
+/**
  * Load the native clipboard addon, or return `null` if the platform is
  * unsupported, has no display server, or the addon is not available.
  * The result is cached for the lifetime of the process.
@@ -78,17 +107,27 @@ export function getNativeClipboard(): { clipboard: NativeClipboard | null; error
 		return { clipboard: cached, error: loadError }
 	}
 
-	const hasDisplay = process.platform !== "linux" || Boolean(process.env.DISPLAY || process.env.WAYLAND_DISPLAY)
-	if (process.env.TERMUX_VERSION || !hasDisplay) {
+	if (process.env.TERMUX_VERSION || !hasDisplayServer()) {
 		loadError = process.env.TERMUX_VERSION
 			? "Clipboard image support is not available: Termux is not supported"
-			: "Clipboard image support is not available: no display server detected"
+			: "Clipboard image support is not available: no display server detected (WSL/headless Linux — set KIMCHI_CLIPBOARD_FORCE=1 to override)"
 		cached = null
 		return { clipboard: null, error: loadError }
 	}
 
 	try {
-		cached = loadPlatformBinding()
+		const binding = loadPlatformBinding()
+		// Eagerly probe the binding so that a Rust panic from a broken display
+		// server (e.g. $DISPLAY set but X server not running) surfaces here
+		// inside this try/catch rather than later in a polling callback where
+		// it would abort the process. availableFormats() calls
+		// ClipboardContext::new() internally which is the call that panics.
+		// NOTE: a genuine Rust panic is a process abort and cannot be caught
+		// in JS. The probe only helps for recoverable JS-level errors. The
+		// real protection is hasDisplayServer() above refusing to load at all
+		// in environments known to lack a working display server.
+		binding.availableFormats()
+		cached = binding
 	} catch (err) {
 		cached = null
 		loadError = err instanceof Error ? err.message : String(err)


### PR DESCRIPTION
## Summary

Fixes a process abort when running Kimchi in WSL (Windows Subsystem for Linux).

### Root Cause

The `@mariozechner/clipboard` Rust addon calls `XOpenDisplay()` during `ClipboardContext::new()`. On WSL or headless Linux this **panics** (Rust `unwrap` on `Err`) and aborts the entire process — it cannot be caught by JS error handling.

The previous guard checked `$DISPLAY || $WAYLAND_DISPLAY`, but WSLg (Windows 11 built-in) unconditionally sets `$DISPLAY=:0` even when no real X/Wayland session is running. This gave a false positive, causing the binding to load and immediately crash.

### Fix

- **`src/utils/clipboard-native-harness.ts`**: Replaced the display check with `hasDisplayServer()` which explicitly detects WSL via `WSL_DISTRO_NAME` / `WSL_INTEROP` env vars and returns `false` regardless of `$DISPLAY`
- Non-WSL headless Linux still requires `DISPLAY` or `WAYLAND_DISPLAY` as before
- Added `KIMCHI_CLIPBOARD_FORCE=1` opt-in escape hatch for WSL users who do have a real X server (e.g. VcXsrv, X410)
- Added eagerness probe: calls `availableFormats()` immediately after loading the binding so JS-level errors surface in the existing `try/catch` rather than later in polling callbacks

### Tests

New `src/utils/clipboard-native-harness-wsl.test.ts` with 6 cases covering all `hasDisplayServer()` branches:
- WSL detected via `WSL_DISTRO_NAME`
- WSL detected via `WSL_INTEROP` (even with `$DISPLAY` set by WSLg)
- `KIMCHI_CLIPBOARD_FORCE=1` override
- Headless Linux (no display vars)
- Linux with `$DISPLAY` set
- Linux with `$WAYLAND_DISPLAY` set

### Workaround for users on WSL with a real X server

```bash
export KIMCHI_CLIPBOARD_FORCE=1
kimchi
```

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)