### PR TITLE
fix: prevent Rust panic on pure Wayland sessions

### DIFF
--- a/src/utils/clipboard-native-harness-wsl.test.ts
+++ b/src/utils/clipboard-native-harness-wsl.test.ts
@@ -96,7 +96,7 @@ describe("hasDisplayServer — WSL / headless Linux guard", () => {
 		expect(hasDisplayServer()).toBe(true)
 	})
 
-	it("returns true on Linux with WAYLAND_DISPLAY set and no WSL", async () => {
+	it("returns false on Linux with only WAYLAND_DISPLAY set (pure Wayland, no X11)", async () => {
 		vi.stubEnv("WSL_DISTRO_NAME", "")
 		vi.stubEnv("WSL_INTEROP", "")
 		vi.stubEnv("DISPLAY", "")
@@ -104,6 +104,25 @@ describe("hasDisplayServer — WSL / headless Linux guard", () => {
 		vi.stubEnv("KIMCHI_CLIPBOARD_FORCE", "")
 
 		const hasDisplayServer = await freshHasDisplayServer()
-		expect(hasDisplayServer()).toBe(true)
+		if (process.platform === "linux") {
+			expect(hasDisplayServer()).toBe(false)
+		} else {
+			expect(hasDisplayServer()).toBe(true)
+		}
+	})
+
+	it("returns true on Linux with both DISPLAY and WAYLAND_DISPLAY set (XWayland)", async () => {
+		vi.stubEnv("WSL_DISTRO_NAME", "")
+		vi.stubEnv("WSL_INTEROP", "")
+		vi.stubEnv("DISPLAY", ":0")
+		vi.stubEnv("WAYLAND_DISPLAY", "wayland-0")
+		vi.stubEnv("KIMCHI_CLIPBOARD_FORCE", "")
+
+		const hasDisplayServer = await freshHasDisplayServer()
+		if (process.platform === "linux") {
+			expect(hasDisplayServer()).toBe(true)
+		} else {
+			expect(hasDisplayServer()).toBe(true)
+		}
 	})
 })

--- a/src/utils/clipboard-native-harness.ts
+++ b/src/utils/clipboard-native-harness.ts
@@ -86,15 +86,16 @@ function loadPlatformBinding(): NativeClipboard {
  * On WSL the kernel sets WSL_DISTRO_NAME / WSL_INTEROP unconditionally, and
  * WSLg sets $DISPLAY even when no graphical session is active. We therefore
  * treat WSL as "no display" unless the user has explicitly opted in by
- * setting KIMCHI_CLIPBOARD_FORCE=1. All other Linux systems require at least
- * one of DISPLAY / WAYLAND_DISPLAY to be set.
+ * setting KIMCHI_CLIPBOARD_FORCE=1. Requires DISPLAY to be set because the
+ * underlying clipboard-rs library only supports X11. WAYLAND_DISPLAY alone
+ * is not sufficient.
  */
 export function hasDisplayServer(): boolean {
 	if (process.platform !== "linux") return true
 	if (process.env.KIMCHI_CLIPBOARD_FORCE === "1") return true
 	const isWsl = Boolean(process.env.WSL_DISTRO_NAME || process.env.WSL_INTEROP)
 	if (isWsl) return false
-	return Boolean(process.env.DISPLAY || process.env.WAYLAND_DISPLAY)
+	return Boolean(process.env.DISPLAY)
 }
 
 /**


### PR DESCRIPTION
## Problem

On pure Wayland Linux sessions (e.g. Arch Linux + Hyprland where `WAYLAND_DISPLAY` is set but `DISPLAY` is not), running any kimchi command causes a process abort:

```
thread '<unnamed>' panicked at src/lib.rs:19:37:
called Result::unwrap() on an Err value: SetupFailed(SetupFailed { .. })
thread caused non-unwinding panic. aborting.
Aborted (core dumped)
```

## Root Cause

The native clipboard NAPI addon (`@mariozechner/clipboard-*`) is built on the Rust `clipboard-rs` library, which internally calls `XOpenDisplay()` during `ClipboardContext::new()`. On pure Wayland (no X11), this fails and the Rust code panics via `.unwrap()` on the error.

Because this panic crosses a Node FFI boundary, it becomes "panic in a function that cannot unwind" and the entire Bun/Node process aborts — no JS exception is thrown.

`hasDisplayServer()` was returning `true` when `WAYLAND_DISPLAY` was set (even without `DISPLAY`), causing the X11-only addon to be loaded.

## Fix

- `hasDisplayServer()` on Linux now requires `DISPLAY` to be set specifically.
- `WAYLAND_DISPLAY` alone no longer passes the guard.
- On pure Wayland, the native addon is skipped safely and clipboard image reading falls back to the existing `wl-copy` / `wl-paste` path in `clipboard-image.ts`.
- XWayland environments (both `DISPLAY` and `WAYLAND_DISPLAY` set) continue to work unchanged.

## Files Changed

- `src/utils/clipboard-native-harness.ts` — narrowed display guard to `DISPLAY` only
- `src/utils/clipboard-native-harness-wsl.test.ts` — updated existing test, added XWayland test

## Test Plan

```bash
pnpm exec vitest run src/utils/clipboard-native-harness-wsl.test.ts
```

All 7 tests pass.

## Workaround (current version)

Until this fix is released, users on pure Wayland can work around the crash by ensuring XWayland is running and `DISPLAY` is exported:
```bash
export DISPLAY=:0  # or whatever XWayland display is active
kimchi ...
```