### PR TITLE
fix: bump clipboard addon to v0.3.6 to fix Rust panic on startup

### DIFF
--- a/package.json
+++ b/package.json
@@ -61,15 +61,15 @@
 		"typebox": "*"
 	},
 	"optionalDependencies": {
-		"@mariozechner/clipboard-darwin-arm64": "0.3.2",
-		"@mariozechner/clipboard-darwin-universal": "0.3.2",
-		"@mariozechner/clipboard-darwin-x64": "0.3.2",
-		"@mariozechner/clipboard-linux-arm64-gnu": "0.3.2",
-		"@mariozechner/clipboard-linux-arm64-musl": "0.3.2",
-		"@mariozechner/clipboard-linux-x64-gnu": "0.3.2",
-		"@mariozechner/clipboard-linux-x64-musl": "0.3.2",
-		"@mariozechner/clipboard-win32-arm64-msvc": "0.3.2",
-		"@mariozechner/clipboard-win32-x64-msvc": "0.3.2"
+		"@mariozechner/clipboard-darwin-arm64": "0.3.6",
+		"@mariozechner/clipboard-darwin-universal": "0.3.6",
+		"@mariozechner/clipboard-darwin-x64": "0.3.6",
+		"@mariozechner/clipboard-linux-arm64-gnu": "0.3.6",
+		"@mariozechner/clipboard-linux-arm64-musl": "0.3.6",
+		"@mariozechner/clipboard-linux-x64-gnu": "0.3.6",
+		"@mariozechner/clipboard-linux-x64-musl": "0.3.6",
+		"@mariozechner/clipboard-win32-arm64-msvc": "0.3.6",
+		"@mariozechner/clipboard-win32-x64-msvc": "0.3.6"
 	},
 	"devDependencies": {
 		"@biomejs/biome": "^1.9.4",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -151,32 +151,32 @@ importers:
         version: 8.20.1
     optionalDependencies:
       '@mariozechner/clipboard-darwin-arm64':
-        specifier: 0.3.2
-        version: 0.3.2
+        specifier: 0.3.6
+        version: 0.3.6
       '@mariozechner/clipboard-darwin-universal':
-        specifier: 0.3.2
-        version: 0.3.2
+        specifier: 0.3.6
+        version: 0.3.6
       '@mariozechner/clipboard-darwin-x64':
-        specifier: 0.3.2
-        version: 0.3.2
+        specifier: 0.3.6
+        version: 0.3.6
       '@mariozechner/clipboard-linux-arm64-gnu':
-        specifier: 0.3.2
-        version: 0.3.2
+        specifier: 0.3.6
+        version: 0.3.6
       '@mariozechner/clipboard-linux-arm64-musl':
-        specifier: 0.3.2
-        version: 0.3.2
+        specifier: 0.3.6
+        version: 0.3.6
       '@mariozechner/clipboard-linux-x64-gnu':
-        specifier: 0.3.2
-        version: 0.3.2
+        specifier: 0.3.6
+        version: 0.3.6
       '@mariozechner/clipboard-linux-x64-musl':
-        specifier: 0.3.2
-        version: 0.3.2
+        specifier: 0.3.6
+        version: 0.3.6
       '@mariozechner/clipboard-win32-arm64-msvc':
-        specifier: 0.3.2
-        version: 0.3.2
+        specifier: 0.3.6
+        version: 0.3.6
       '@mariozechner/clipboard-win32-x64-msvc':
-        specifier: 0.3.2
-        version: 0.3.2
+        specifier: 0.3.6
+        version: 0.3.6
 
 packages:
 
@@ -553,8 +553,8 @@ packages:
   '@jridgewell/sourcemap-codec@1.5.5':
     resolution: {integrity: sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==}
 
-  '@mariozechner/clipboard-darwin-arm64@0.3.2':
-    resolution: {integrity: sha512-uBf6K7Je1ihsgvmWxA8UCGCeI+nbRVRXoarZdLjl6slz94Zs1tNKFZqx7aCI5O1i3e0B6ja82zZ06BWrl0MCVw==}
+  '@mariozechner/clipboard-darwin-arm64@0.3.6':
+    resolution: {integrity: sha512-HjaisYCAbHi/1+N1yDAQHc8ZXGffufIUT5NSOSVR3f3AuMDusxTtnbK8tZ7JFDkShua1oNGZoNwQHsc8MPtE0Q==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [darwin]
@@ -565,8 +565,8 @@ packages:
     cpu: [arm64]
     os: [darwin]
 
-  '@mariozechner/clipboard-darwin-universal@0.3.2':
-    resolution: {integrity: sha512-mxSheKTW2U9LsBdXy0SdmdCAE5HqNS9QUmpNHLnfJ+SsbFKALjEZc5oRrVMXxGQSirDvYf5bjmRyT0QYYonnlg==}
+  '@mariozechner/clipboard-darwin-universal@0.3.6':
+    resolution: {integrity: sha512-8BWtPjOtJOJoykml3w0fx0zRrfWP31mXrJwfoA7xzNprkZw1uolCNfgmjDiVBseoKjp16EGITz7bN+61qn8dWA==}
     engines: {node: '>= 10'}
     os: [darwin]
 
@@ -575,8 +575,8 @@ packages:
     engines: {node: '>= 10'}
     os: [darwin]
 
-  '@mariozechner/clipboard-darwin-x64@0.3.2':
-    resolution: {integrity: sha512-U1BcVEoidvwIp95+HJswSW+xr28EQiHR7rZjH6pn8Sja5yO4Yoe3yCN0Zm8Lo72BbSOK/fTSq0je7CJpaPCspg==}
+  '@mariozechner/clipboard-darwin-x64@0.3.6':
+    resolution: {integrity: sha512-p9syiZD1kU4I+1ya7f7g+zD1GiUvR8fdlRlNmgsZNWlyjtc8rlV2EjTLd/35x1LsdBq020GVvtzp0ZmPgBI09Q==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [darwin]
@@ -587,8 +587,8 @@ packages:
     cpu: [x64]
     os: [darwin]
 
-  '@mariozechner/clipboard-linux-arm64-gnu@0.3.2':
-    resolution: {integrity: sha512-BsinwG3yWTIjdgNCxsFlip7LkfwPk+ruw/aFCXHUg/fb5XC/Ksp+YMQ7u0LUtiKzIv/7LMXgZInJQH6gxbAaqQ==}
+  '@mariozechner/clipboard-linux-arm64-gnu@0.3.6':
+    resolution: {integrity: sha512-5JFf5rGofrm+V29HNF+wLthXphHdQpMbKDUYJ5tML6/Z5DLlLOV/9Ak4kDPtYyZ+Dzf+kAusE0VsFg4+tfP1IA==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
@@ -599,8 +599,8 @@ packages:
     cpu: [arm64]
     os: [linux]
 
-  '@mariozechner/clipboard-linux-arm64-musl@0.3.2':
-    resolution: {integrity: sha512-0/Gi5Xq2V6goXBop19ePoHvXsmJD9SzFlO3S+d6+T2b+BlPcpOu3Oa0wTjl+cZrLAAEzA86aPNBI+VVAFDFPKw==}
+  '@mariozechner/clipboard-linux-arm64-musl@0.3.6':
+    resolution: {integrity: sha512-JlVjxxw0GbGC0djXYWRIqyteO3J1KZ/QG3udlEFaOD5TLOM1FnmXXAPDQBqr+aBVr720ef9K00dirYnJ0LDCtw==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
@@ -617,8 +617,8 @@ packages:
     cpu: [riscv64]
     os: [linux]
 
-  '@mariozechner/clipboard-linux-x64-gnu@0.3.2':
-    resolution: {integrity: sha512-v6fVnsn7WMGg73Dab8QMwyFce7tzGfgEixKgzLP8f1GJqkJZi5zO4k4FOHzSgUufgLil63gnxvMpjWkgfeQN7A==}
+  '@mariozechner/clipboard-linux-x64-gnu@0.3.6':
+    resolution: {integrity: sha512-trtPwcNLW37irwQCJLtCxLw757jjJZk3TSnY/MU9bhtWtA3K9b/eLW0e4RGhUXDoFRds9opNWWaUDuFLa8dm0w==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
@@ -629,8 +629,8 @@ packages:
     cpu: [x64]
     os: [linux]
 
-  '@mariozechner/clipboard-linux-x64-musl@0.3.2':
-    resolution: {integrity: sha512-xVUtnoMQ8v2JVyfJLKKXACA6avdnchdbBkTsZs8BgJQo29qwCp5NIHAUO8gbJ40iaEGToW5RlmVk2M9V0HsHEw==}
+  '@mariozechner/clipboard-linux-x64-musl@0.3.6':
+    resolution: {integrity: sha512-WfnzIvOCCWQiN0MmltCEo6cLceUDbYe+I7xyFZjaps5A+2Op/M2CY7Rey+C4ucQhrvmpoHmTSFgY9ODWk7snoA==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
@@ -641,8 +641,8 @@ packages:
     cpu: [x64]
     os: [linux]
 
-  '@mariozechner/clipboard-win32-arm64-msvc@0.3.2':
-    resolution: {integrity: sha512-AEgg95TNi8TGgak2wSXZkXKCvAUTjWoU1Pqb0ON7JHrX78p616XUFNTJohtIon3e0w6k0pYPZeCuqRCza/Tqeg==}
+  '@mariozechner/clipboard-win32-arm64-msvc@0.3.6':
+    resolution: {integrity: sha512-+8+1aHYsBPUjmW3otmWlg+Hijt0iJvoBBs5e0mxFeUd4gDaKMB8Bn6x7c6KVtscg7E5j5NFXnwQqNSIAO4p8zQ==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [win32]
@@ -653,8 +653,8 @@ packages:
     cpu: [arm64]
     os: [win32]
 
-  '@mariozechner/clipboard-win32-x64-msvc@0.3.2':
-    resolution: {integrity: sha512-tGRuYpZwDOD7HBrCpyRuhGnHHSCknELvqwKKUG4JSfSB7JIU7LKRh6zx6fMUOQd8uISK35TjFg5UcNih+vJhFA==}
+  '@mariozechner/clipboard-win32-x64-msvc@0.3.6':
+    resolution: {integrity: sha512-S4xfPmERC8ZkiLHe3vekZCjdDwNEETCuvCgQK2kP6/TnvmUkq1y2Pk+DjM4t8uh9KMX9bH4zs5ePcKa8GTXmfg==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [win32]
@@ -2575,31 +2575,31 @@ snapshots:
 
   '@jridgewell/sourcemap-codec@1.5.5': {}
 
-  '@mariozechner/clipboard-darwin-arm64@0.3.2':
+  '@mariozechner/clipboard-darwin-arm64@0.3.6':
     optional: true
 
   '@mariozechner/clipboard-darwin-arm64@0.3.9':
     optional: true
 
-  '@mariozechner/clipboard-darwin-universal@0.3.2':
+  '@mariozechner/clipboard-darwin-universal@0.3.6':
     optional: true
 
   '@mariozechner/clipboard-darwin-universal@0.3.9':
     optional: true
 
-  '@mariozechner/clipboard-darwin-x64@0.3.2':
+  '@mariozechner/clipboard-darwin-x64@0.3.6':
     optional: true
 
   '@mariozechner/clipboard-darwin-x64@0.3.9':
     optional: true
 
-  '@mariozechner/clipboard-linux-arm64-gnu@0.3.2':
+  '@mariozechner/clipboard-linux-arm64-gnu@0.3.6':
     optional: true
 
   '@mariozechner/clipboard-linux-arm64-gnu@0.3.9':
     optional: true
 
-  '@mariozechner/clipboard-linux-arm64-musl@0.3.2':
+  '@mariozechner/clipboard-linux-arm64-musl@0.3.6':
     optional: true
 
   '@mariozechner/clipboard-linux-arm64-musl@0.3.9':
@@ -2608,25 +2608,25 @@ snapshots:
   '@mariozechner/clipboard-linux-riscv64-gnu@0.3.9':
     optional: true
 
-  '@mariozechner/clipboard-linux-x64-gnu@0.3.2':
+  '@mariozechner/clipboard-linux-x64-gnu@0.3.6':
     optional: true
 
   '@mariozechner/clipboard-linux-x64-gnu@0.3.9':
     optional: true
 
-  '@mariozechner/clipboard-linux-x64-musl@0.3.2':
+  '@mariozechner/clipboard-linux-x64-musl@0.3.6':
     optional: true
 
   '@mariozechner/clipboard-linux-x64-musl@0.3.9':
     optional: true
 
-  '@mariozechner/clipboard-win32-arm64-msvc@0.3.2':
+  '@mariozechner/clipboard-win32-arm64-msvc@0.3.6':
     optional: true
 
   '@mariozechner/clipboard-win32-arm64-msvc@0.3.9':
     optional: true
 
-  '@mariozechner/clipboard-win32-x64-msvc@0.3.2':
+  '@mariozechner/clipboard-win32-x64-msvc@0.3.6':
     optional: true
 
   '@mariozechner/clipboard-win32-x64-msvc@0.3.9':

--- a/src/utils/clipboard-native-harness.ts
+++ b/src/utils/clipboard-native-harness.ts
@@ -21,14 +21,12 @@
 // limitation.
 //
 // WSL / headless Linux note:
-// The clipboard-rs Rust library calls XOpenDisplay() during ClipboardContext
-// initialisation. On Linux without a real X11/Wayland server this call
-// panics (Rust unwrap on Err) rather than returning a JS exception, killing
-// the entire process. We therefore probe the binding immediately after
-// loading it by calling availableFormats() inside the same try/catch block.
-// A Rust panic propagates as a process abort that cannot be caught in JS, so
-// the only safe strategy is to never load the binding when there is no
-// display server. We also detect WSL explicitly (via WSL_DISTRO_NAME /
+// Loading the native clipboard addon when no display server is available
+// causes clipboard-initialization failures. Older versions of the library
+// (≤ 0.3.2, bundled clipboard-rs 0.2.4) would panic via Rust unwrap, turning
+// the error into an uncatchable process abort. Version 0.3.6+ handles errors
+// gracefully (returning JS exceptions), but we still avoid unnecessary addon
+// loads on headless systems. We detect WSL explicitly (via WSL_DISTRO_NAME /
 // WSL_INTEROP) because WSLg may set $DISPLAY to ":0" even when no graphical
 // session is running, giving a false positive to the simple display check.
 


### PR DESCRIPTION
## Problem

Customer on Arch Linux + Hyprland (XWayland active, `DISPLAY=:0`) gets a process abort on every kimchi command:

```
thread '<unnamed>' panicked at src/lib.rs:19:37:
called Result::unwrap() on an Err value: SetupFailed(SetupFailed { .. })
panic in a function that cannot unwind. aborting.
Aborted (core dumped)
```

The crash appeared in v0.1.15 (worked fine in v0.1.9).

## Root Cause

`@mariozechner/clipboard` v0.3.2 (the version currently pinned in kimchi) bundles `clipboard-rs` 0.2.4 and **every NAPI function calls `.unwrap()` on `ClipboardContext::new()`**:

```rust
// v0.3.2 lib.rs
pub fn available_formats() -> Vec<String> {
  let ctx = ClipboardContext::new().unwrap();  // ← PANIC
  ...
}
```

When `clipboard-rs` 0.2.4 fails to initialize (even with a valid `DISPLAY`), the `.unwrap()` turns the `SetupFailed` error into a Rust panic. Because the panic crosses a Node FFI boundary, the entire process aborts — no JS exception is thrown.

## Fix

Bump `@mariozechner/clipboard-*` from **0.3.2 → 0.3.6**.

v0.3.6 completely replaces the buggy `clipboard-rs` 0.2.4 crate with direct `wl-clipboard-rs` + `x11rb` and switches NAPI bindings from `.unwrap()` to `Result` types:

```rust
// v0.3.6 lib.rs
pub fn available_formats() -> Result<Vec<String>> {
  let ctx = ClipboardContext::new().map_err(napi_error)?;  // Safe
  ...
}
```

Errors now surface as **catchable JS exceptions** instead of uncatchable process aborts.
