### PR TITLE
feat(agent-discovery): widen migration skill scan to converged agent dirs

### DIFF
--- a/src/agent-discovery/agents/skills-only.test.ts
+++ b/src/agent-discovery/agents/skills-only.test.ts
@@ -1,0 +1,78 @@
+import { mkdirSync, mkdtempSync, rmSync } from "node:fs"
+import { homedir, tmpdir } from "node:os"
+import { join } from "node:path"
+import { afterEach, beforeEach, describe, expect, it } from "vitest"
+import { AGENT_DEFINITIONS, discoverAgent } from "../index.js"
+import { SKILLS_ONLY_AGENTS, makeSkillsOnlyAgent } from "./skills-only.js"
+
+describe("skills-only agents", () => {
+	let tempDir: string
+
+	beforeEach(() => {
+		tempDir = mkdtempSync(join(tmpdir(), "kimchi-skills-only-"))
+	})
+
+	afterEach(() => {
+		rmSync(tempDir, { recursive: true, force: true })
+	})
+
+	it("discovers a skills directory and counts subdirectories as skills", () => {
+		const skillsDir = join(tempDir, "skills")
+		mkdirSync(join(skillsDir, "alpha"), { recursive: true })
+		mkdirSync(join(skillsDir, "beta"), { recursive: true })
+
+		const def = makeSkillsOnlyAgent("cursor", "Cursor", ".cursor", { skillsDirs: [skillsDir] })
+		const discovery = discoverAgent(def)
+
+		expect(discovery.skillsDir).toBe(skillsDir)
+		expect(discovery.skillCount).toBe(2)
+		expect(discovery.mcpServers).toEqual({})
+		expect(discovery.commandsCount).toBe(0)
+	})
+
+	it("falls through to the next candidate when the first does not exist", () => {
+		const present = join(tempDir, "present", "skills")
+		mkdirSync(join(present, "only"), { recursive: true })
+
+		const def = makeSkillsOnlyAgent("warp", "Warp", ".warp", {
+			skillsDirs: [join(tempDir, "missing", "skills"), present],
+		})
+		const discovery = discoverAgent(def)
+
+		expect(discovery.skillsDir).toBe(present)
+		expect(discovery.skillCount).toBe(1)
+	})
+
+	it("reports no skills directory when none of the candidates exist", () => {
+		const def = makeSkillsOnlyAgent("gemini", "Gemini", ".gemini", {
+			skillsDirs: [join(tempDir, "nope", "skills")],
+		})
+		const discovery = discoverAgent(def)
+
+		expect(discovery.skillsDir).toBeUndefined()
+		expect(discovery.skillCount).toBe(0)
+	})
+
+	it("defaults to the project-local skills dir first, then the global fallback", () => {
+		const def = makeSkillsOnlyAgent("cursor", "Cursor", ".cursor")
+		expect(def.skillsDirs[0]).toBe(join(process.cwd(), ".cursor", "skills"))
+		expect(def.skillsDirs[1]).toBe(join(homedir(), ".cursor", "skills"))
+	})
+
+	it("registers the converged skills directories in AGENT_DEFINITIONS", () => {
+		const ids = new Set(AGENT_DEFINITIONS.map((a) => a.id))
+		for (const def of SKILLS_ONLY_AGENTS) {
+			expect(ids.has(def.id)).toBe(true)
+		}
+		expect(SKILLS_ONLY_AGENTS.map((a) => a.id)).toEqual([
+			"codex",
+			"cursor",
+			"warp",
+			"factory",
+			"gemini",
+			"copilot",
+			"github",
+			"agents",
+		])
+	})
+})

--- a/src/agent-discovery/agents/skills-only.ts
+++ b/src/agent-discovery/agents/skills-only.ts
@@ -1,0 +1,48 @@
+import { homedir } from "node:os"
+import { join } from "node:path"
+import type { AgentDefinition } from "../index.js"
+
+/**
+ * Agents whose configs kimchi doesn't migrate (no MCP server schema we
+ * read), but which ship skills under the converged `<dir>/skills/<name>/SKILL.md`
+ * layout. The migration wizard scans these so a user running several agents
+ * sees every skills directory called out, not just Claude Code and OpenCode.
+ *
+ * Each entry scans the project-local dir first (these conventions are mostly
+ * repo-relative, e.g. `.github/skills`, `.agents/skills`) then the global
+ * `~/<dir>/skills` fallback. First existing directory wins, matching the
+ * Claude Code / OpenCode discoverers.
+ */
+export function makeSkillsOnlyAgent(
+	id: string,
+	displayName: string,
+	dir: string,
+	overrides?: { skillsDirs?: string[] },
+): AgentDefinition {
+	const skillsDirs = overrides?.skillsDirs ?? [join(process.cwd(), dir, "skills"), join(homedir(), dir, "skills")]
+	return {
+		id,
+		displayName,
+		configPaths: [],
+		skillsDirs,
+		commandsDirs: [],
+		extractServerSources: () => [],
+		transformServer: () => undefined,
+	}
+}
+
+/** Converged skills directories beyond the agents that have full migrators. */
+const SKILLS_ONLY_DIRS: ReadonlyArray<{ id: string; displayName: string; dir: string }> = [
+	{ id: "codex", displayName: "Codex", dir: ".codex" },
+	{ id: "cursor", displayName: "Cursor", dir: ".cursor" },
+	{ id: "warp", displayName: "Warp", dir: ".warp" },
+	{ id: "factory", displayName: "Factory (Droid)", dir: ".factory" },
+	{ id: "gemini", displayName: "Gemini", dir: ".gemini" },
+	{ id: "copilot", displayName: "Copilot", dir: ".copilot" },
+	{ id: "github", displayName: "GitHub", dir: ".github" },
+	{ id: "agents", displayName: "Agents", dir: ".agents" },
+]
+
+export const SKILLS_ONLY_AGENTS: readonly AgentDefinition[] = SKILLS_ONLY_DIRS.map((a) =>
+	makeSkillsOnlyAgent(a.id, a.displayName, a.dir),
+)

--- a/src/agent-discovery/index.ts
+++ b/src/agent-discovery/index.ts
@@ -1,6 +1,7 @@
 import type { ServerEntry } from "../extensions/mcp-adapter/types.js"
 import { claudeCode } from "./agents/claude-code.js"
 import { openCode } from "./agents/opencode.js"
+import { SKILLS_ONLY_AGENTS } from "./agents/skills-only.js"
 import { discoverAgent } from "./engine.js"
 
 export interface AgentDefinition {
@@ -70,4 +71,4 @@ export interface AgentDiscovery {
 
 export { discoverAgent }
 
-export const AGENT_DEFINITIONS: readonly AgentDefinition[] = [claudeCode, openCode]
+export const AGENT_DEFINITIONS: readonly AgentDefinition[] = [claudeCode, openCode, ...SKILLS_ONLY_AGENTS]

--- a/src/config.test.ts
+++ b/src/config.test.ts
@@ -4,6 +4,7 @@ import { dirname, join } from "node:path"
 import { afterEach, beforeEach, describe, expect, it } from "vitest"
 import {
 	VENDOR_SKILL_PATHS,
+	buildSkillPathOptions,
 	clearApiKey,
 	getActiveVendorSkillPaths,
 	loadConfig,
@@ -689,5 +690,33 @@ describe("getActiveVendorSkillPaths", () => {
 
 	it("returns empty array when vendor dir does not exist", () => {
 		expect(getActiveVendorSkillPaths()).toEqual([])
+	})
+})
+
+describe("buildSkillPathOptions", () => {
+	let tempDir: string
+	let originalCwd: string
+
+	beforeEach(() => {
+		originalCwd = process.cwd()
+		tempDir = mkdtempSync(join(tmpdir(), "kimchi-skillpaths-"))
+	})
+
+	afterEach(() => {
+		process.chdir(originalCwd)
+		rmSync(tempDir, { recursive: true, force: true })
+	})
+
+	it("relativizes a cwd-rooted discovered dir so it is not pinned to the wizard's cwd", () => {
+		process.chdir(tempDir)
+		// Resolve through process.cwd() so the test matches macOS symlink-resolved
+		// /private/var paths, exactly as the discoverer (which builds dirs from cwd) does.
+		const skillsDir = join(process.cwd(), ".cursor", "skills")
+		mkdirSync(skillsDir, { recursive: true })
+
+		const options = buildSkillPathOptions([skillsDir])
+
+		expect(options).toContain(join(".cursor", "skills"))
+		expect(options).not.toContain(skillsDir)
 	})
 })

--- a/src/config.ts
+++ b/src/config.ts
@@ -46,7 +46,16 @@ export const DEFAULT_SKILL_PATHS = [...ALWAYS_SHOWN_SKILL_PATHS, ...OPTIONAL_SKI
 
 export function buildSkillPathOptions(discoveredDirs: string[]): string[] {
 	const home = homedir()
-	const toRelative = (abs: string): string => (abs === home || abs.startsWith(`${home}/`) ? relative(home, abs) : abs)
+	const cwd = process.cwd()
+	// Relativize home- and cwd-rooted dirs so the persisted skill path is
+	// location-independent: a relative path is re-scanned under both ~ and the
+	// current project at runtime (see expandUserPath/resolveUserPath), whereas
+	// an absolute path is pinned to the directory the wizard happened to run in.
+	const toRelative = (abs: string): string => {
+		if (abs === home || abs.startsWith(`${home}/`)) return relative(home, abs)
+		if (abs === cwd || abs.startsWith(`${cwd}/`)) return relative(cwd, abs)
+		return abs
+	}
 
 	const seen = new Set<string>()
 	const result: string[] = []


### PR DESCRIPTION
Implements #448. Widens the migration wizard's skill discovery from the two current agents (Claude Code, OpenCode) to the converged directory set used across the ecosystem.

## What
- New `skills-only` agent family scanning `<dir>/skills` for Codex, Cursor, Warp, Factory (Droid), Gemini, Copilot, `.github`, and `.agents`. Project-local dir first, then the global `~/<dir>/skills` fallback (first existing wins, same as the Claude Code / OpenCode discoverers).
- These agents carry no MCP or commands schema, so server extraction is a no-op; only their skills directories are surfaced.
- Relativize cwd-rooted discovered dirs in `buildSkillPathOptions` so a persisted skill path is re-scanned per project at runtime instead of being pinned to the directory the wizard happened to run in.

## Tests
- `skills-only.test.ts`: discovery, candidate fall-through, default candidate order, registration.
- `config.test.ts`: a cwd-rooted discovered dir is persisted relative, not absolute.
- Full agent-discovery and config suites green (127 tests). tsc and biome clean.
