### PR TITLE
feat(integrations): add Droid (Factory.ai) integration

### DIFF
--- a/src/commands/droid.ts
+++ b/src/commands/droid.ts
@@ -1,0 +1,23 @@
+import "../integrations/droid.js" // side-effect: register integration
+import { byId } from "../integrations/registry.js"
+import { popScope, prepareTool } from "./_helpers.js"
+
+export async function runDroid(args: string[]): Promise<number> {
+	const scope = popScope(args)
+	const prepped = await prepareTool("droid", "override")
+	if (!prepped) return 1
+
+	try {
+		const tool = byId("droid")
+		if (!tool) {
+			console.error("kimchi droid: integration not registered")
+			return 1
+		}
+		await tool.write(scope, prepped.apiKey, prepped.models)
+		console.log("kimchi droid: configuration written. Run `droid` and pick a kimchi model with /model.")
+		return 0
+	} catch (err) {
+		console.error(`kimchi droid: ${(err as Error).message}`)
+		return 1
+	}
+}

--- a/src/commands/registry.ts
+++ b/src/commands/registry.ts
@@ -8,6 +8,7 @@ export interface CommandDefinition {
 import { runClaude } from "./claude.js"
 import { runConfig } from "./config.js"
 import { runCursor } from "./cursor.js"
+import { runDroid } from "./droid.js"
 import { runGsd2 } from "./gsd2.js"
 import { runLogin } from "./login.js"
 import { runOpenClaw } from "./openclaw.js"
@@ -27,6 +28,7 @@ export const COMMANDS: CommandDefinition[] = [
 	{ name: "cursor", summary: "Configure Cursor to use Kimchi", run: runCursor },
 	{ name: "openclaw", summary: "Configure OpenClaw to use Kimchi", run: runOpenClaw },
 	{ name: "gsd2", summary: "Install / configure GSD2 with Kimchi", run: runGsd2 },
+	{ name: "droid", summary: "Configure Droid (Factory.ai) to use Kimchi", run: runDroid },
 	{ name: "update", summary: "Check for and install Kimchi/package updates", run: runUpdate },
 	{ name: "config", summary: "Inspect or change kimchi config (e.g. telemetry)", run: runConfig },
 	{ name: "resources", summary: "Enable or disable Kimchi hooks, tools, extensions, and plugins", run: runResources },

--- a/src/commands/setup-tools.ts
+++ b/src/commands/setup-tools.ts
@@ -2,6 +2,7 @@
 // and byId() in the integrations registry return nothing.
 import "../integrations/claude-code.js"
 import "../integrations/cursor.js"
+import "../integrations/droid.js"
 import "../integrations/gsd2.js"
 import "../integrations/openclaw.js"
 import "../integrations/opencode.js"

--- a/src/integrations/droid.test.ts
+++ b/src/integrations/droid.test.ts
@@ -1,0 +1,103 @@
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
+import { afterEach, beforeEach, describe, expect, it } from "vitest"
+import { resolveScopePath } from "../config/scope.js"
+import { TEST_MODELS } from "./__fixtures__/models.js"
+import { buildDroidCustomModels, writeDroidConfig } from "./droid.js"
+import { byId } from "./registry.js"
+
+const BASE_URL = "https://llm.kimchi.dev/openai/v1"
+const ANTHROPIC_BASE_URL = "https://llm.kimchi.dev/anthropic"
+
+describe("buildDroidCustomModels", () => {
+	it("emits one customModels entry per model with the BYOK field shape", () => {
+		const entries = buildDroidCustomModels(undefined, "test-key", TEST_MODELS)
+		expect(entries.length).toBe(TEST_MODELS.length)
+		const kimi = entries.find((e) => e.model === "kimi-k2.6")
+		expect(kimi).toEqual({
+			model: "kimi-k2.6",
+			displayName: "Kimi K2.6",
+			baseUrl: BASE_URL,
+			apiKey: "test-key",
+			provider: "generic-chat-completion-api",
+			maxOutputTokens: 32_768,
+		})
+	})
+
+	it("routes anthropic models to the anthropic provider and base URL", () => {
+		const entries = buildDroidCustomModels(undefined, "k", TEST_MODELS)
+		const opus = entries.find((e) => e.model === "claude-opus-4-6")
+		expect(opus?.provider).toBe("anthropic")
+		expect(opus?.baseUrl).toBe(ANTHROPIC_BASE_URL)
+	})
+
+	it("preserves user models and replaces prior kimchi entries (idempotent)", () => {
+		const existing = [
+			{ model: "my-local", displayName: "Local", baseUrl: "http://localhost:11434/v1", provider: "ollama" },
+			{ model: "kimi-k2.6", displayName: "stale", baseUrl: BASE_URL, provider: "generic-chat-completion-api" },
+		]
+		const first = buildDroidCustomModels(existing, "k", TEST_MODELS)
+		expect(first.filter((e) => e.model === "my-local").length).toBe(1)
+		expect(first.filter((e) => e.model === "kimi-k2.6").length).toBe(1)
+
+		const second = buildDroidCustomModels(first, "k", TEST_MODELS)
+		expect(second.length).toBe(first.length)
+	})
+})
+
+describe("writeDroidConfig", () => {
+	let tempDir: string
+
+	beforeEach(() => {
+		tempDir = mkdtempSync(join(tmpdir(), "kimchi-droid-test-"))
+	})
+
+	afterEach(() => {
+		rmSync(tempDir, { recursive: true, force: true })
+	})
+
+	it("merges customModels into an existing settings.json and is idempotent", () => {
+		const path = join(tempDir, "settings.json")
+		writeFileSync(path, JSON.stringify({ theme: "dark" }), "utf-8")
+
+		writeDroidConfig(path, "k", TEST_MODELS)
+		const first = JSON.parse(readFileSync(path, "utf-8")) as { theme: string; customModels: unknown[] }
+		expect(first.theme).toBe("dark")
+		expect(first.customModels.length).toBe(TEST_MODELS.length)
+
+		writeDroidConfig(path, "k", TEST_MODELS)
+		const second = JSON.parse(readFileSync(path, "utf-8")) as { customModels: unknown[] }
+		expect(second.customModels.length).toBe(TEST_MODELS.length)
+	})
+})
+
+describe("droid integration", () => {
+	it("is registered under the kimchi config path", () => {
+		const tool = byId("droid")
+		expect(tool?.name).toBe("Droid")
+		expect(tool?.configPath).toBe("~/.factory/settings.json")
+	})
+
+	it("writes at global scope only so it never collides with Claude Code's project settings.json", () => {
+		// Droid and Claude Code share the basename settings.json, so in project
+		// scope both resolve to <cwd>/.claude/settings.json — the reason the
+		// writer ignores scope and always targets the global factory path.
+		expect(resolveScopePath("project", "~/.factory/settings.json")).toBe(
+			resolveScopePath("project", "~/.claude/settings.json"),
+		)
+		expect(resolveScopePath("global", "~/.factory/settings.json")).not.toBe(
+			resolveScopePath("global", "~/.claude/settings.json"),
+		)
+	})
+
+	it("rejects an empty API key before touching the filesystem", async () => {
+		const tool = byId("droid")
+		await expect(tool?.write("global", "", TEST_MODELS)).rejects.toThrow("API key not configured")
+	})
+
+	it("rejects an empty model list before touching the filesystem", async () => {
+		const tool = byId("droid")
+		await expect(tool?.write("global", "k", [])).rejects.toThrow("No models available")
+	})
+})

--- a/src/integrations/droid.ts
+++ b/src/integrations/droid.ts
@@ -1,0 +1,105 @@
+import { readJson, writeJson } from "../config/json.js"
+import type { ConfigScope } from "../config/scope.js"
+import { resolveScopePath } from "../config/scope.js"
+import type { ModelMetadata } from "../models.js"
+import { ANTHROPIC_BASE_URL, BASE_URL } from "./constants.js"
+import { dirExists, findBinary } from "./detect.js"
+import { register } from "./registry.js"
+
+const DROID_CONFIG_PATH = "~/.factory/settings.json"
+const KIMCHI_BASE_URLS = new Set([BASE_URL, ANTHROPIC_BASE_URL])
+
+/**
+ * One entry in Droid's `customModels` array. Field names follow Factory's
+ * settings.json (camelCase) BYOK schema; kimchi only emits the `anthropic`
+ * and `generic-chat-completion-api` providers.
+ */
+interface DroidCustomModel {
+	model: string
+	displayName: string
+	baseUrl: string
+	apiKey: string
+	provider: "anthropic" | "generic-chat-completion-api"
+	maxOutputTokens: number
+}
+
+function toCustomModel(model: ModelMetadata, apiKey: string): DroidCustomModel {
+	const isAnthropic = model.provider === "anthropic"
+	return {
+		model: model.slug,
+		displayName: model.display_name || model.slug,
+		baseUrl: isAnthropic ? ANTHROPIC_BASE_URL : BASE_URL,
+		apiKey,
+		provider: isAnthropic ? "anthropic" : "generic-chat-completion-api",
+		maxOutputTokens: model.limits.max_output_tokens,
+	}
+}
+
+/**
+ * Replace any previously kimchi-written entries (identified by their base URL)
+ * with a fresh set for the current model list, preserving the user's own
+ * custom models. Pure so the merge is testable without touching the filesystem.
+ */
+export function buildDroidCustomModels(
+	existing: unknown,
+	apiKey: string,
+	models: readonly ModelMetadata[],
+): Array<DroidCustomModel | Record<string, unknown>> {
+	const kept = (Array.isArray(existing) ? existing : []).filter(
+		(entry): entry is Record<string, unknown> =>
+			typeof entry === "object" &&
+			entry !== null &&
+			!KIMCHI_BASE_URLS.has((entry as { baseUrl?: string }).baseUrl ?? ""),
+	)
+	const fresh = models.map((m) => toCustomModel(m, apiKey))
+	return [...kept, ...fresh]
+}
+
+/**
+ * Merge the kimchi customModels block into Droid's settings.json at `path`.
+ * Split out from writeDroid so the read/merge/write round-trip is testable
+ * against a temp file.
+ */
+export function writeDroidConfig(path: string, apiKey: string, models: readonly ModelMetadata[]): void {
+	const existing = readJson(path)
+	existing.customModels = buildDroidCustomModels(existing.customModels, apiKey, models)
+	writeJson(path, existing)
+}
+
+/**
+ * Factory keeps BYOK models in a single user-level settings.json; it has no
+ * Factory-native project config, and kimchi's `<cwd>/.claude/<basename>`
+ * project path would collide with Claude Code's own settings.json (same
+ * basename) and leak the API key into it. So Droid is configured at global
+ * scope only — `scope` is accepted for the ToolDefinition contract but
+ * ignored, mirroring the Cursor writer.
+ */
+async function writeDroid(
+	_scope: ConfigScope,
+	apiKey: string,
+	models: readonly ModelMetadata[],
+	_options?: { telemetryEnabled?: boolean },
+): Promise<void> {
+	if (!apiKey) {
+		throw new Error("API key not configured")
+	}
+	if (!models || models.length === 0) {
+		throw new Error("No models available — is the API key valid?")
+	}
+
+	writeDroidConfig(resolveScopePath("global", DROID_CONFIG_PATH), apiKey, models)
+}
+
+function detectDroid(): boolean {
+	return findBinary("droid") !== undefined || dirExists(resolveScopePath("global", "~/.factory"))
+}
+
+register({
+	id: "droid",
+	name: "Droid",
+	description: "Factory.ai agentic coding CLI",
+	configPath: DROID_CONFIG_PATH,
+	binaryName: "droid",
+	isInstalled: detectDroid,
+	write: writeDroid,
+})

--- a/src/integrations/types.ts
+++ b/src/integrations/types.ts
@@ -1,7 +1,7 @@
 import type { ConfigScope } from "../config/scope.js"
 import type { ModelMetadata } from "../models.js"
 
-export type ToolId = "opencode" | "claudecode" | "cursor" | "openclaw" | "gsd2"
+export type ToolId = "opencode" | "claudecode" | "cursor" | "openclaw" | "gsd2" | "droid"
 
 /**
  * A configurable third-party tool that kimchi can point at the kimchi LLM

--- a/src/setup-wizard/index.ts
+++ b/src/setup-wizard/index.ts
@@ -3,6 +3,7 @@
 // otherwise byId() returns undefined for an unimported tool.
 import "../integrations/claude-code.js"
 import "../integrations/cursor.js"
+import "../integrations/droid.js"
 import "../integrations/gsd2.js"
 import "../integrations/openclaw.js"
 import "../integrations/opencode.js"


### PR DESCRIPTION
First of the integrations proposed in #446: Droid (Factory.ai), the lowest-cost candidate (plain JSON writer, no new dependencies).

## What
- Writes the kimchi BYOK `customModels` block into `~/.factory/settings.json`. Anthropic models route through the `anthropic` provider and Anthropic base URL; everything else through `generic-chat-completion-api` against the kimchi OpenAI-compatible gateway (the same choice as the OpenCode and GSD2 writers, which also target chat-completions).
- Prior kimchi entries (matched by gateway base URL) are replaced on each run; the user's own custom models are preserved.
- Adds the `kimchi droid` command and registers the tool in the setup wizard and `setup-tools`.
- Global scope only: Droid has no native project config and shares the `settings.json` basename with Claude Code, so project scope would resolve both to `<cwd>/.claude/settings.json` and leak the API key into Claude Code's file. The writer ignores scope and always targets the global factory path, mirroring the Cursor integration.

## Tests
- `droid.test.ts`: provider and base-URL mapping, idempotent merge, settings.json round-trip, global-only path rationale, input guards.
- Integration and setup-tools suites green (120 tests). tsc and biome clean.

The remaining four candidates (Continue, Codex, Goose, Cline) can follow in separate PRs since each needs its own config format (YAML/TOML/SQLite); keeping this one focused on the JSON writer.
