### PR TITLE
LLM-1836: Emit telemetry error event for socket disconnects

### DIFF
--- a/src/extensions/telemetry/README.md
+++ b/src/extensions/telemetry/README.md
@@ -66,7 +66,7 @@ Fired from `session-context.ts` via `ctx.emit()`. Batched (max 20) and flushed e
 | `file_written` | `write` tool succeeds | `model`, `language`, `file_hash`, `lines_added`, `duration_ms` |
 | `file_edited` | `edit` / `multiedit` / `patch` succeed | `model`, `language`, `file_hash`, `lines_added`, `lines_deleted`, `duration_ms` |
 | `command_executed` | `bash` tool runs | `model`, `command_type`, `exit_code`, `duration_ms` |
-| `error` | Agent or tool error | `model`, `error_type` (`agent_error` / `tool_failure`), `error_message` *(truncated to 300 chars)* |
+| `error` | Agent, tool, or transport error | `model`, `error_type` (`agent_error` / `tool_failure` / `transport_error`), `error_message` *(truncated to 300 chars)* |
 | `subagent.spawned` | Sub-agent created | `model`, `agent_type`, `reason` |
 
 ## Cumulative Metrics (OTLP Sum)

--- a/src/extensions/telemetry/handlers/messages.test.ts
+++ b/src/extensions/telemetry/handlers/messages.test.ts
@@ -268,6 +268,34 @@ describe("handleMessageEnd", () => {
 
 		expect(emitSpy).not.toHaveBeenCalled()
 	})
+
+	it("emits transport_error when stopReason is error and message matches a transport pattern", async () => {
+		const ctx = makeCtx()
+		const emitSpy = vi.spyOn(ctx, "emit")
+
+		await handleMessageEnd(ctx, {
+			message: {
+				role: "assistant",
+				model: "kimi-k2.6",
+				provider: "kimchi-dev",
+				stopReason: "error",
+				errorMessage:
+					"The socket connection was closed unexpectedly. For more information, pass `verbose: true` in the second argument to fetch()",
+				usage: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, cost: { total: 0 } },
+				timestamp: BASE_TS,
+				responseId: "chatcmpl-transport-test",
+			},
+		})
+
+		expect(emitSpy).toHaveBeenCalledWith(
+			"error",
+			expect.objectContaining({
+				model: "kimi-k2.6",
+				error_type: "transport_error",
+				error_message: expect.stringContaining("socket connection was closed unexpectedly"),
+			}),
+		)
+	})
 })
 
 describe("handleBeforeAgentStart", () => {

--- a/src/extensions/telemetry/handlers/messages.ts
+++ b/src/extensions/telemetry/handlers/messages.ts
@@ -1,6 +1,7 @@
 import type { AssistantMessage } from "@earendil-works/pi-ai"
 import { getAvailableModels } from "../../../startup-context.js"
 import type { SessionContext } from "../session-context.js"
+import { handleTransportError } from "./transport-errors.js"
 
 /** Maps OAuth provider IDs to canonical names accepted by the telemetry backend. */
 const PROVIDER_TELEMETRY_MAP: Record<string, string> = {
@@ -64,6 +65,9 @@ export async function handleMessageEnd(
 			cost_usd: costTotal,
 			duration_ms: durationMs,
 		})
+
+		// Detect and emit transport errors (socket closed, connection reset, etc.)
+		handleTransportError(ctx, { message: assistant })
 
 		// Accumulate tokens/cost for cumulative metrics
 		if (!ctx.cumulative.tokensByModel[model]) {

--- a/src/extensions/telemetry/handlers/transport-errors.test.ts
+++ b/src/extensions/telemetry/handlers/transport-errors.test.ts
@@ -1,0 +1,178 @@
+import { describe, expect, it, vi } from "vitest"
+import type { SessionContext } from "../session-context.js"
+import { handleTransportError } from "./transport-errors.js"
+
+function mockCtx(): Pick<SessionContext, "emit"> {
+	return {
+		emit: vi.fn(),
+	}
+}
+
+describe("handleTransportError", () => {
+	it("does not emit when role is not assistant", () => {
+		const ctx = mockCtx()
+		handleTransportError(ctx as SessionContext, {
+			message: { role: "user", stopReason: "error", errorMessage: "socket connection was closed unexpectedly" },
+		})
+		expect(ctx.emit).not.toHaveBeenCalled()
+	})
+
+	it("does not emit when stopReason is not error", () => {
+		const ctx = mockCtx()
+		handleTransportError(ctx as SessionContext, {
+			message: { role: "assistant", stopReason: "stop", errorMessage: "socket connection was closed unexpectedly" },
+		})
+		expect(ctx.emit).not.toHaveBeenCalled()
+	})
+
+	it("does not emit when stopReason is aborted (user cancelled)", () => {
+		const ctx = mockCtx()
+		handleTransportError(ctx as SessionContext, {
+			message: { role: "assistant", stopReason: "aborted", errorMessage: "socket connection was closed unexpectedly" },
+		})
+		expect(ctx.emit).not.toHaveBeenCalled()
+	})
+
+	it("does not emit when errorMessage is not a transport error", () => {
+		const ctx = mockCtx()
+		handleTransportError(ctx as SessionContext, {
+			message: { role: "assistant", stopReason: "error", errorMessage: "something went wrong" },
+		})
+		expect(ctx.emit).not.toHaveBeenCalled()
+	})
+
+	it("emits error with error_type transport_error for socket connection was closed unexpectedly", () => {
+		const ctx = mockCtx()
+		handleTransportError(ctx as SessionContext, {
+			message: {
+				role: "assistant",
+				model: "kimi-k2.6",
+				provider: "kimchi-dev",
+				api: "openai-completions",
+				stopReason: "error",
+				errorMessage:
+					"The socket connection was closed unexpectedly. For more information, pass `verbose: true` in the second argument to fetch()",
+			},
+		})
+		expect(ctx.emit).toHaveBeenCalledTimes(1)
+		expect(ctx.emit).toHaveBeenCalledWith("error", {
+			model: "kimi-k2.6",
+			error_type: "transport_error",
+			error_message:
+				"The socket connection was closed unexpectedly. For more information, pass `verbose: true` in the second argument to fetch()",
+		})
+	})
+
+	it("emits error case-insensitively", () => {
+		const ctx = mockCtx()
+		handleTransportError(ctx as SessionContext, {
+			message: {
+				role: "assistant",
+				model: "claude-sonnet-4-20250514",
+				stopReason: "error",
+				errorMessage: "THE SOCKET CONNECTION WAS CLOSED UNEXPECTEDLY",
+			},
+		})
+		expect(ctx.emit).toHaveBeenCalledWith(
+			"error",
+			expect.objectContaining({ error_type: "transport_error", error_message: expect.any(String) }),
+		)
+	})
+
+	it("emits error for connection reset", () => {
+		const ctx = mockCtx()
+		handleTransportError(ctx as SessionContext, {
+			message: {
+				role: "assistant",
+				model: "claude-sonnet-4-20250514",
+				stopReason: "error",
+				errorMessage: "Connection reset by peer",
+			},
+		})
+		expect(ctx.emit).toHaveBeenCalledWith(
+			"error",
+			expect.objectContaining({ error_type: "transport_error", error_message: "Connection reset by peer" }),
+		)
+	})
+
+	it("emits error for socket closed", () => {
+		const ctx = mockCtx()
+		handleTransportError(ctx as SessionContext, {
+			message: { role: "assistant", stopReason: "error", errorMessage: "socket closed" },
+		})
+		expect(ctx.emit).toHaveBeenCalledWith(
+			"error",
+			expect.objectContaining({ error_type: "transport_error", error_message: "socket closed" }),
+		)
+	})
+
+	it("emits error for connection closed", () => {
+		const ctx = mockCtx()
+		handleTransportError(ctx as SessionContext, {
+			message: { role: "assistant", stopReason: "error", errorMessage: "connection closed" },
+		})
+		expect(ctx.emit).toHaveBeenCalledWith(
+			"error",
+			expect.objectContaining({ error_type: "transport_error", error_message: "connection closed" }),
+		)
+	})
+
+	it("emits error for econnreset", () => {
+		const ctx = mockCtx()
+		handleTransportError(ctx as SessionContext, {
+			message: { role: "assistant", stopReason: "error", errorMessage: "read ECONNRESET" },
+		})
+		expect(ctx.emit).toHaveBeenCalledWith(
+			"error",
+			expect.objectContaining({ error_type: "transport_error", error_message: "read ECONNRESET" }),
+		)
+	})
+
+	it("emits error for econnrefused", () => {
+		const ctx = mockCtx()
+		handleTransportError(ctx as SessionContext, {
+			message: { role: "assistant", stopReason: "error", errorMessage: "connect ECONNREFUSED 127.0.0.1:443" },
+		})
+		expect(ctx.emit).toHaveBeenCalledWith(
+			"error",
+			expect.objectContaining({
+				error_type: "transport_error",
+				error_message: "connect ECONNREFUSED 127.0.0.1:443",
+			}),
+		)
+	})
+
+	it("emits error for broken pipe", () => {
+		const ctx = mockCtx()
+		handleTransportError(ctx as SessionContext, {
+			message: { role: "assistant", stopReason: "error", errorMessage: "Broken pipe" },
+		})
+		expect(ctx.emit).toHaveBeenCalledWith(
+			"error",
+			expect.objectContaining({ error_type: "transport_error", error_message: "Broken pipe" }),
+		)
+	})
+
+	it("handles missing optional fields gracefully", () => {
+		const ctx = mockCtx()
+		handleTransportError(ctx as SessionContext, {
+			message: { role: "assistant", stopReason: "error", errorMessage: "socket connection was closed unexpectedly" },
+		})
+		expect(ctx.emit).toHaveBeenCalledWith("error", {
+			model: "unknown",
+			error_type: "transport_error",
+			error_message: "socket connection was closed unexpectedly",
+		})
+	})
+
+	it("truncates error_message to 300 chars", () => {
+		const ctx = mockCtx()
+		const longMessage = `socket connection was closed unexpectedly ${"x".repeat(400)}`
+		handleTransportError(ctx as SessionContext, {
+			message: { role: "assistant", stopReason: "error", errorMessage: longMessage },
+		})
+		const emitted = (ctx.emit as ReturnType<typeof vi.fn>).mock.calls[0][1] as { error_message: string }
+		expect(emitted.error_message.length).toBe(300)
+		expect(emitted.error_message.endsWith("xxx")).toBe(true)
+	})
+})

--- a/src/extensions/telemetry/handlers/transport-errors.ts
+++ b/src/extensions/telemetry/handlers/transport-errors.ts
@@ -1,0 +1,42 @@
+import type { SessionContext } from "../session-context.js"
+
+const TRANSPORT_ERROR_PATTERNS = [
+	"socket connection was closed unexpectedly",
+	"socket closed",
+	"connection closed",
+	"connection reset",
+	"broken pipe",
+	"econnreset",
+	"econnrefused",
+]
+
+function isTransportError(errorMessage: string | undefined): boolean {
+	if (!errorMessage) return false
+	const lower = errorMessage.toLowerCase()
+	return TRANSPORT_ERROR_PATTERNS.some((p) => lower.includes(p))
+}
+
+export function handleTransportError(
+	ctx: SessionContext,
+	event: {
+		message: {
+			role?: string
+			model?: string
+			provider?: string
+			api?: string
+			stopReason?: string
+			errorMessage?: string
+		}
+	},
+): void {
+	const msg = event.message
+	if (msg.role !== "assistant") return
+	if (msg.stopReason !== "error") return
+	if (!isTransportError(msg.errorMessage)) return
+
+	ctx.emit("error", {
+		model: msg.model ?? "unknown",
+		error_type: "transport_error",
+		error_message: (msg.errorMessage ?? "").slice(0, 300),
+	})
+}


### PR DESCRIPTION
## What

Adds `transport_error` as a new `error_type` value on the existing `error` telemetry event, emitted when the LLM API layer encounters socket, connection reset, or similar transport-level errors during streaming responses.

## Why

Transport errors are currently recorded only as unstructured `llm_response_debug` entries with `stopReason: "error"` and an `errorMessage` string. This makes them hard to query, alert on, or group by error pattern in the telemetry backend. Adding `error_type: "transport_error"` to the existing `error` event keeps the event taxonomy clean while making these errors properly queryable.

## Changes

- **`handlers/transport-errors.ts`** — new handler that pattern-matches known transport error strings in `AssistantMessage.errorMessage` when `stopReason === "error"`, then emits `error` with `error_type: "transport_error"`
- **`handlers/transport-errors.test.ts`** — 10 tests covering all guard conditions, all patterns, case-insensitivity, truncation at 300 chars, and missing-field fallbacks
- **`handlers/messages.ts`** — wires `handleTransportError` into `handleMessageEnd` after the `api_request` emission
- **`README.md`** — updates the `error` event row to include `transport_error` in the `error_type` enum

## Event schema

```json
{
  "eventName": "error",
  "attributes": {
    "model": "kimi-k2.6",
    "error_type": "transport_error",
    "error_message": "... (truncated to 300 chars)"
  }
}
```

This is a subtype of the existing `error` event, consistent with `agent_error` and `tool_failure`.

## Patterns detected

- `socket connection was closed unexpectedly`
- `socket closed`
- `connection closed`
- `connection reset`
- `broken pipe`
- `econnreset`
- `econnrefused`

## Notes

- `etimedout` and `enotfound` can be added as a follow-up if needed
- `AssistantMessage.diagnostics` with `provider_transport_failure` type was identified as a potential longer-term alternative to string matching — worth investigating separately
- The `provider` and `api` fields from the session artifact were removed as they are not present on `AssistantMessage`; the handler emits only the fields that are actually available
