### PR TITLE
fix(rtk-rewrite): passthrough all pnpm commands to avoid subcommand collisions

### DIFF
--- a/src/extensions/rtk-rewrite.test.ts
+++ b/src/extensions/rtk-rewrite.test.ts
@@ -18,16 +18,30 @@ import {
 
 describe("isRtkPassthrough", () => {
 	it.each([
+		// explicit `run` forms
 		"pnpm run lint",
 		"npm run lint",
 		"yarn run build",
 		"bun run test",
 		"pnpm run lint --fix",
 		"npm run lint:fix",
-		"npx eslint .",
-		"pnpm exec eslint .",
-		"bunx tsx script.ts",
 		"  pnpm run lint", // leading whitespace
+		// npx / bunx
+		"npx eslint .",
+		"bunx tsx script.ts",
+		// all pnpm commands — scripts AND built-ins — are passed through
+		"pnpm lint",
+		"pnpm build",
+		"pnpm typecheck",
+		"pnpm lint:fix",
+		"pnpm dev",
+		"pnpm check",
+		"pnpm install",
+		"pnpm add react",
+		"pnpm i",
+		"pnpm update",
+		"pnpm remove lodash",
+		"pnpm exec eslint .",
 	])("returns true for %s", (cmd) => {
 		expect(isRtkPassthrough(cmd)).toBe(true)
 	})
@@ -35,10 +49,8 @@ describe("isRtkPassthrough", () => {
 	it.each([
 		"git status",
 		"cargo test",
-		"pnpm install",
-		"npm install",
-		"pnpm add react",
-		"echo pnpm run lint", // pnpm run not at start
+		"npm install", // npm without `run` is not passed through
+		"echo pnpm run lint", // pnpm not at start
 	])("returns false for %s", (cmd) => {
 		expect(isRtkPassthrough(cmd)).toBe(false)
 	})

--- a/src/extensions/rtk-rewrite.ts
+++ b/src/extensions/rtk-rewrite.ts
@@ -66,11 +66,17 @@ export function detectRtk(): Promise<boolean> {
 /**
  * Package-manager script invocations that RTK must not rewrite.
  *
- * RTK maps `pnpm run lint` → `rtk lint` (its own lint subcommand) and
- * similarly mangles other `<pm> run <script>` forms.  These commands must
- * reach the package manager unchanged.
+ * RTK hijacks subcommand names that collide with its own — the most painful
+ * example is `pnpm lint` / `pnpm run lint` → `rtk lint` (its own ESLint
+ * wrapper), which breaks projects that use Biome or other linters.
+ *
+ * Rather than maintaining an allowlist of pnpm built-ins, we passthrough
+ * ALL `pnpm …` commands.  RTK's token-compression benefit on pnpm subcommands
+ * is negligible compared to the risk of future subcommand name collisions.
+ * Other package managers (`npm run`, `yarn run`, `bun run`) are also
+ * passed through because they may invoke arbitrary user-defined scripts.
  */
-const RTK_PASSTHROUGH_RE = /^\s*(pnpm|npm|yarn|bun)\s+run\b|^\s*(npx|bunx)\s|^\s*pnpm\s+exec\s/
+const RTK_PASSTHROUGH_RE = /^\s*(pnpm|npm\s+run|yarn\s+run|bun\s+run)\b|^\s*(npx|bunx)\s/
 
 /**
  * Returns true for commands that must bypass RTK rewriting entirely.


### PR DESCRIPTION
## Problem

RTK rewrites `pnpm lint` → `rtk lint` (its own ESLint wrapper), breaking projects that use Biome or other linters. Tracked upstream at [rtk-ai/rtk#665](https://github.com/rtk-ai/rtk/issues/665).

The previous passthrough regex only guarded `pnpm run <script>` forms, leaving the bare pnpm shorthand (`pnpm lint`, `pnpm build`, `pnpm typecheck`, etc.) unprotected.

## Fix

Pass through **all** `pnpm *` commands instead of maintaining a `PNPM_BUILTINS` allowlist. The token-compression benefit RTK provides on pnpm subcommands is negligible compared to the maintenance burden and risk of future name collisions.

The regex simplifies from three alternation branches to one clean anchor:

```diff
- /^\s*(pnpm|npm|yarn|bun)\s+run\b|^\s*(npx|bunx)\s|^\s*pnpm\s+exec\s/
+ /^\s*(pnpm|npm\s+run|yarn\s+run|bun\s+run)\b|^\s*(npx|bunx)\s/
```

## Tests

- Added `pnpm install`, `pnpm add react`, `pnpm i`, `pnpm update`, `pnpm remove lodash`, `pnpm exec eslint .` to the passthrough-true cases
- 43/43 tests passing