### PR TITLE
fix(auto-mode): add classifier fallback model

### DIFF
--- a/src/extensions/permissions/classifier-model.test.ts
+++ b/src/extensions/permissions/classifier-model.test.ts
@@ -2,9 +2,9 @@ import type { Api, Model } from "@earendil-works/pi-ai"
 import type { ModelRegistry } from "@earendil-works/pi-coding-agent"
 import { describe, expect, it } from "vitest"
 import { KIMCHI_DEV_PROVIDER, MODEL_CAPABILITIES } from "../orchestration/model-registry/index.js"
-import { resolveClassifierModel } from "./classifier-model.js"
+import { resolveClassifierModels } from "./classifier-model.js"
 
-/** Minimal Model stub — only the fields resolveClassifierModel inspects. */
+/** Minimal Model stub. */
 function fakeModel(
 	provider: string,
 	id = "test-model",
@@ -13,225 +13,115 @@ function fakeModel(
 	return { provider, id, cost } as Model<Api>
 }
 
-/** Minimal ModelRegistry stub with controllable find() and getAvailable(). */
-function fakeRegistry(findResult: Model<Api> | undefined = undefined, available: Model<Api>[] = []): ModelRegistry {
-	return { find: () => findResult, getAvailable: () => available } as unknown as ModelRegistry
+function kimchi(id: string, cost = { input: 10, output: 30, cacheRead: 0, cacheWrite: 0 }): Model<Api> {
+	return fakeModel(KIMCHI_DEV_PROVIDER, id, cost)
 }
 
-/** The first light-tier model ID in MODEL_CAPABILITIES. */
-const LIGHT_MODEL_ID = [...MODEL_CAPABILITIES.entries()].find(
-	([, caps]) => caps !== "ignored" && caps.tier === "light",
-)?.[0]
+/** Registry that resolves kimchi-dev models by ID from a map, and returns a fixed available list. */
+function fakeRegistry(kimchiModels: Map<string, Model<Api>> = new Map(), available: Model<Api>[] = []): ModelRegistry {
+	return {
+		find: (provider: string, id: string) => (provider === KIMCHI_DEV_PROVIDER ? kimchiModels.get(id) : undefined),
+		getAvailable: () => available,
+	} as unknown as ModelRegistry
+}
 
-describe("resolveClassifierModel", () => {
-	it("returns undefined when currentModel is undefined", () => {
-		expect(resolveClassifierModel(undefined, fakeRegistry())).toBeUndefined()
+const LIGHT_ID = [...MODEL_CAPABILITIES.entries()].find(([, c]) => c !== "ignored" && c.tier === "light")?.[0] ?? ""
+const STANDARD_ID =
+	[...MODEL_CAPABILITIES.entries()].find(([, c]) => c !== "ignored" && c.tier === "standard")?.[0] ?? ""
+const HEAVY_ID = [...MODEL_CAPABILITIES.entries()].find(([, c]) => c !== "ignored" && c.tier === "heavy")?.[0] ?? ""
+
+describe("resolveClassifierModels", () => {
+	it("returns undefined when no models are available", () => {
+		expect(resolveClassifierModels(fakeRegistry())).toBeUndefined()
 	})
 
-	describe("non-kimchi-dev provider", () => {
-		it("steps down two cost tiers when three cheaper models exist", () => {
-			const opus = fakeModel("anthropic", "claude-opus", { input: 15, output: 75, cacheRead: 0, cacheWrite: 0 })
-			const sonnet = fakeModel("anthropic", "claude-sonnet", { input: 3, output: 15, cacheRead: 0, cacheWrite: 0 })
-			const haiku = fakeModel("anthropic", "claude-haiku", { input: 0.25, output: 1.25, cacheRead: 0, cacheWrite: 0 })
-			const nano = fakeModel("anthropic", "claude-nano", { input: 0.1, output: 0.4, cacheRead: 0, cacheWrite: 0 })
+	describe("primary", () => {
+		it("picks the kimchi light model regardless of current provider", () => {
+			const light = kimchi(LIGHT_ID)
+			const current = fakeModel("anthropic", "claude-opus")
+			const registry = fakeRegistry(new Map([[LIGHT_ID, light]]), [current])
 
-			const registry = fakeRegistry(undefined, [opus, sonnet, haiku, nano])
-			const result = resolveClassifierModel(opus, registry)
-			// Two steps down from opus: sonnet → haiku.
-			expect(result).toBe(haiku)
+			expect(resolveClassifierModels(registry)?.primary).toBe(light)
 		})
 
-		it("steps down one tier when only one cheaper model exists", () => {
-			const current = fakeModel("openai", "gpt-4o", { input: 5, output: 15, cacheRead: 0, cacheWrite: 0 })
-			const mini = fakeModel("openai", "gpt-4o-mini", { input: 0.15, output: 0.6, cacheRead: 0, cacheWrite: 0 })
+		it("falls back to standard when no light model resolves", () => {
+			const standard = kimchi(STANDARD_ID)
+			const current = fakeModel("anthropic", "claude-opus")
+			const registry = fakeRegistry(new Map([[STANDARD_ID, standard]]), [current])
 
-			const registry = fakeRegistry(undefined, [current, mini])
-			const result = resolveClassifierModel(current, registry)
-			expect(result).toBe(mini)
+			expect(resolveClassifierModels(registry)?.primary).toBe(standard)
 		})
 
-		it("steps down exactly two when only two cheaper models exist", () => {
-			const opus = fakeModel("anthropic", "claude-opus", { input: 15, output: 75, cacheRead: 0, cacheWrite: 0 })
-			const sonnet = fakeModel("anthropic", "claude-sonnet", { input: 3, output: 15, cacheRead: 0, cacheWrite: 0 })
-			const haiku = fakeModel("anthropic", "claude-haiku", { input: 0.25, output: 1.25, cacheRead: 0, cacheWrite: 0 })
+		it("falls back to cheapest available when no kimchi models resolve", () => {
+			const cheap = fakeModel("anthropic", "haiku", { input: 0.25, output: 1.25, cacheRead: 0, cacheWrite: 0 })
+			const expensive = fakeModel("anthropic", "opus", { input: 15, output: 75, cacheRead: 0, cacheWrite: 0 })
+			const registry = fakeRegistry(new Map(), [cheap, expensive])
 
-			const registry = fakeRegistry(undefined, [opus, sonnet, haiku])
-			const result = resolveClassifierModel(opus, registry)
-			expect(result).toBe(haiku)
-		})
-
-		it("ignores models from other providers", () => {
-			const current = fakeModel("openai", "gpt-4o", { input: 5, output: 15, cacheRead: 0, cacheWrite: 0 })
-			const cheapOther = fakeModel("anthropic", "claude-haiku", {
-				input: 0.25,
-				output: 1.25,
-				cacheRead: 0,
-				cacheWrite: 0,
-			})
-			const sameProvider = fakeModel("openai", "gpt-4o-mini", { input: 0.15, output: 0.6, cacheRead: 0, cacheWrite: 0 })
-
-			const registry = fakeRegistry(undefined, [current, cheapOther, sameProvider])
-			const result = resolveClassifierModel(current, registry)
-			expect(result).toBe(sameProvider)
-		})
-
-		it("picks the least expensive more-expensive model when current is already the cheapest", () => {
-			const current = fakeModel("openai", "gpt-4o-mini", { input: 0.15, output: 0.6, cacheRead: 0, cacheWrite: 0 })
-			const mid = fakeModel("openai", "gpt-4o", { input: 5, output: 15, cacheRead: 0, cacheWrite: 0 })
-			const expensive = fakeModel("openai", "o3", { input: 10, output: 40, cacheRead: 0, cacheWrite: 0 })
-
-			const registry = fakeRegistry(undefined, [current, mid, expensive])
-			const result = resolveClassifierModel(current, registry)
-			// Should pick gpt-4o (least expensive among more-expensive), not o3.
-			expect(result).toBe(mid)
-		})
-
-		it("picks a different model even when all same-provider models cost the same", () => {
-			const current = fakeModel("openai", "gpt-4o", { input: 5, output: 15, cacheRead: 0, cacheWrite: 0 })
-			const twin = fakeModel("openai", "gpt-4o-copy", { input: 5, output: 15, cacheRead: 0, cacheWrite: 0 })
-
-			const registry = fakeRegistry(undefined, [current, twin])
-			const result = resolveClassifierModel(current, registry)
-			expect(result).toBe(twin)
-		})
-
-		it("falls back to current model only when it is the sole model in the provider", () => {
-			const current = fakeModel("openai", "gpt-4o")
-			const registry = fakeRegistry(undefined, [current])
-
-			const result = resolveClassifierModel(current, registry)
-			expect(result).toBe(current)
-		})
-
-		it("falls back to current model when no models from the same provider are available", () => {
-			const current = fakeModel("openai", "gpt-4o")
-			const registry = fakeRegistry(undefined, [])
-
-			const result = resolveClassifierModel(current, registry)
-			expect(result).toBe(current)
-		})
-
-		it("does not call registry.find for a non-kimchi-dev provider", () => {
-			const calls: string[] = []
-			const model = fakeModel("openai", "gpt-4o")
-			const registry = {
-				find: (_provider: string, id: string) => {
-					calls.push(id)
-					return undefined
-				},
-				getAvailable: () => [model],
-			} as unknown as ModelRegistry
-
-			resolveClassifierModel(model, registry)
-			expect(calls).toHaveLength(0)
+			expect(resolveClassifierModels(registry)?.primary).toBe(cheap)
 		})
 	})
 
-	describe("kimchi-dev provider", () => {
-		it("returns a light-tier model from the registry when current is not light", () => {
-			const lightModel = fakeModel(KIMCHI_DEV_PROVIDER, LIGHT_MODEL_ID)
-			const current = fakeModel(KIMCHI_DEV_PROVIDER, "kimi-k2.6")
-			const registry = fakeRegistry(lightModel)
+	describe("fallback", () => {
+		it("steps up to standard when light is the primary", () => {
+			const light = kimchi(LIGHT_ID)
+			const standard = kimchi(STANDARD_ID)
+			const registry = fakeRegistry(
+				new Map([
+					[LIGHT_ID, light],
+					[STANDARD_ID, standard],
+				]),
+				[light],
+			)
 
-			const result = resolveClassifierModel(current, registry)
-			expect(result).toBe(lightModel)
-			expect(result?.id).toBe(LIGHT_MODEL_ID)
+			const result = resolveClassifierModels(registry)
+			expect(result?.primary).toBe(light)
+			expect(result?.fallback).toBe(standard)
 		})
 
-		it("returns a different light-tier model when current is already light-tier", () => {
-			const current = fakeModel(KIMCHI_DEV_PROVIDER, LIGHT_MODEL_ID)
-			const otherLight = fakeModel(KIMCHI_DEV_PROVIDER, "other-light")
+		it("skips to heavy when standard is unavailable", () => {
+			const light = kimchi(LIGHT_ID)
+			const heavy = kimchi(HEAVY_ID)
+			const registry = fakeRegistry(
+				new Map([
+					[LIGHT_ID, light],
+					[HEAVY_ID, heavy],
+				]),
+				[light],
+			)
 
-			// Registry returns otherLight for the light-tier ID lookup
-			// We need a registry that returns different models for different IDs.
-			const lightIds = [...MODEL_CAPABILITIES.entries()]
-				.filter(([, caps]) => caps !== "ignored" && caps.tier === "light")
-				.map(([id]) => id)
-
-			// If there's only one light-tier in capabilities, we need to test
-			// the "step up to next tier" path instead.
-			if (lightIds.length <= 1) {
-				// Current is the sole light-tier model. Registry should find a
-				// standard-tier model as fallback.
-				const standardId = [...MODEL_CAPABILITIES.entries()].find(
-					([, caps]) => caps !== "ignored" && caps.tier === "standard",
-				)?.[0]
-
-				const standardModel = fakeModel(KIMCHI_DEV_PROVIDER, standardId ?? "standard-fallback")
-				const registry = {
-					find: (_p: string, id: string) => {
-						if (id === LIGHT_MODEL_ID) return current
-						if (standardId && id === standardId) return standardModel
-						return undefined
-					},
-					getAvailable: () => [],
-				} as unknown as ModelRegistry
-
-				const result = resolveClassifierModel(current, registry)
-				expect(result).not.toBe(current)
-				expect(result?.id).toBe(standardModel.id)
-			} else {
-				// Multiple light-tier models exist — should pick the other one.
-				const otherId = lightIds.find((id) => id !== LIGHT_MODEL_ID)
-				const registry = {
-					find: (_p: string, id: string) => {
-						if (id === LIGHT_MODEL_ID) return current
-						if (otherId && id === otherId) return otherLight
-						return undefined
-					},
-					getAvailable: () => [],
-				} as unknown as ModelRegistry
-
-				const result = resolveClassifierModel(current, registry)
-				expect(result).not.toBe(current)
+			const result = resolveClassifierModels(registry)
+			expect(result?.primary).toBe(light)
+			// If light and heavy have different IDs the fallback should be heavy.
+			if (LIGHT_ID !== HEAVY_ID && STANDARD_ID !== HEAVY_ID) {
+				expect(result?.fallback).toBe(heavy)
 			}
 		})
 
-		it("steps up to next tier when current is the sole light-tier model", () => {
-			const current = fakeModel(KIMCHI_DEV_PROVIDER, LIGHT_MODEL_ID)
-			const standardId = [...MODEL_CAPABILITIES.entries()].find(
-				([, caps]) => caps !== "ignored" && caps.tier === "standard",
-			)?.[0]
+		it("falls back to cheapest available when no kimchi model available for fallback", () => {
+			const light = kimchi(LIGHT_ID)
+			const other = fakeModel("anthropic", "haiku", { input: 0.25, output: 1.25, cacheRead: 0, cacheWrite: 0 })
+			const registry = fakeRegistry(new Map([[LIGHT_ID, light]]), [light, other])
 
-			const standardModel = fakeModel(KIMCHI_DEV_PROVIDER, standardId ?? "standard-fallback")
-			const registry = {
-				find: (_p: string, id: string) => {
-					if (id === LIGHT_MODEL_ID) return current
-					if (standardId && id === standardId) return standardModel
-					return undefined
-				},
-				getAvailable: () => [],
-			} as unknown as ModelRegistry
-
-			const result = resolveClassifierModel(current, registry)
-			expect(result).not.toBe(current)
+			const result = resolveClassifierModels(registry)
+			expect(result?.primary).toBe(light)
+			expect(result?.fallback).toBe(other)
 		})
 
-		it("falls back to current model only when no other models are available", () => {
-			const current = fakeModel(KIMCHI_DEV_PROVIDER, "kimi-k2.6")
-			const registry = fakeRegistry(undefined)
+		it("returns undefined fallback when no alternative exists", () => {
+			const light = kimchi(LIGHT_ID)
+			const registry = fakeRegistry(new Map([[LIGHT_ID, light]]), [light])
 
-			const result = resolveClassifierModel(current, registry)
-			expect(result).toBe(current)
+			const result = resolveClassifierModels(registry)
+			expect(result?.primary).toBe(light)
+			expect(result?.fallback).toBeUndefined()
 		})
 
-		it("calls registry.find with kimchi-dev provider and a light-tier model ID", () => {
-			const calls: Array<{ provider: string; id: string }> = []
-			const registry = {
-				find: (provider: string, id: string) => {
-					calls.push({ provider, id })
-					return undefined
-				},
-				getAvailable: () => [],
-			} as unknown as ModelRegistry
+		it("fallback excludes primary — does not return same model twice", () => {
+			const light = kimchi(LIGHT_ID)
+			const registry = fakeRegistry(new Map([[LIGHT_ID, light]]), [light])
 
-			const current = fakeModel(KIMCHI_DEV_PROVIDER, "kimi-k2.6")
-			resolveClassifierModel(current, registry)
-
-			// Should have searched for at least one light-tier model.
-			expect(calls.length).toBeGreaterThan(0)
-			expect(calls.every((c) => c.provider === KIMCHI_DEV_PROVIDER)).toBe(true)
-			expect(calls.some((c) => c.id === LIGHT_MODEL_ID)).toBe(true)
+			const result = resolveClassifierModels(registry)
+			expect(result?.fallback?.id).not.toBe(result?.primary?.id)
 		})
 	})
 })

--- a/src/extensions/permissions/classifier-model.ts
+++ b/src/extensions/permissions/classifier-model.ts
@@ -4,147 +4,62 @@ import { KIMCHI_DEV_PROVIDER, MODEL_CAPABILITIES } from "../orchestration/model-
 import type { ModelTier } from "../orchestration/model-registry/types.js"
 
 /** Tier ordering from cheapest to most expensive. */
-const TIER_RANK: Record<ModelTier, number> = { light: 0, standard: 1, heavy: 2 }
+const TIERS_ASCENDING: ModelTier[] = ["light", "standard", "heavy"]
 
-/**
- * Compute a single scalar cost for a model so we can compare cheapness.
- * Uses the sum of input and output per-token costs.
- */
-function modelCost(model: Model<Api>): number {
-	return (model.cost?.input ?? 0) + (model.cost?.output ?? 0)
+export interface ClassifierModels {
+	/** Primary model to use for classification. */
+	primary: Model<Api>
+	/**
+	 * Fallback model used after the primary exhausts its retries.
+	 * Undefined when no suitable alternative exists.
+	 */
+	fallback: Model<Api> | undefined
 }
 
 /**
- * Pick the model to use for the classifier.
+ * Resolve the primary and fallback models for classification.
  *
- * The goal is to always use a *different* model than the current one to
- * avoid wasting expensive tokens on a simple classification task. The
- * current model is only returned as a last resort when no other model
- * from the same provider is available.
+ * Both prefer kimchi-dev models, walking tiers light → standard → heavy.
+ * Only when no kimchi-dev model is available do they fall back to the
+ * cheapest model across all providers.
  *
- * Strategy:
- *   - kimchi-dev provider: select the lightest-tier model from the
- *     orchestration model registry (MODEL_CAPABILITIES). If the current
- *     model is already light-tier, try another light-tier model first,
- *     then step up to the next tier. Falls back to the current model
- *     only when it is the sole available model.
- *   - Any other provider: step down up to two cost tiers within the same
- *     provider. If the current model is already the cheapest, pick the
- *     least expensive model that costs more. Falls back to the current
- *     model only when it is the sole available model.
+ * Returns undefined when no model is available at all.
  */
-export function resolveClassifierModel(
-	currentModel: Model<Api> | undefined,
-	modelRegistry: ModelRegistry,
-): Model<Api> | undefined {
-	if (!currentModel) return undefined
+export function resolveClassifierModels(modelRegistry: ModelRegistry): ClassifierModels | undefined {
+	const primary = resolveKimchiModel(modelRegistry) ?? cheapestAvailable(modelRegistry)
+	if (!primary) return undefined
 
-	if (currentModel.provider !== KIMCHI_DEV_PROVIDER) {
-		return cheaperFromSameProvider(currentModel, modelRegistry)
-	}
+	const fallback = resolveKimchiModel(modelRegistry, primary.id) ?? cheapestAvailable(modelRegistry, primary.id)
 
-	return resolveKimchiDevClassifier(currentModel, modelRegistry)
+	return { primary, fallback }
 }
 
 /**
- * Resolve a classifier model for the kimchi-dev provider.
- *
- * Preference order:
- *   1. A light-tier model that is NOT the current model.
- *   2. Any other light-tier model (even the current one — covered by step 1 only
- *      when there are multiple lights).
- *   3. The next tier up (standard, then heavy) — any model other than current.
- *   4. The current model as an absolute fallback.
+ * Find the best available kimchi-dev model, excluding `excludeId`.
+ * Walks tiers light → standard → heavy and returns the first non-empty tier's
+ * cheapest model.
  */
-function resolveKimchiDevClassifier(currentModel: Model<Api>, modelRegistry: ModelRegistry): Model<Api> {
-	const currentCaps = MODEL_CAPABILITIES.get(currentModel.id)
-	const currentTier = currentCaps !== undefined && currentCaps !== "ignored" ? currentCaps.tier : undefined
-
-	// 1. Try light-tier models, preferring one that is NOT the current model.
-	const lightModels: Model<Api>[] = []
-	for (const [id, caps] of MODEL_CAPABILITIES) {
-		if (caps === "ignored") continue
-		if (caps.tier === "light") {
-			const resolved = modelRegistry.find(KIMCHI_DEV_PROVIDER, id)
-			if (resolved) lightModels.push(resolved)
-		}
-	}
-
-	const differentLight = lightModels.find((m) => m.id !== currentModel.id)
-	if (differentLight) return differentLight
-
-	// Current model is the only light-tier model — if current is already
-	// light-tier, try the next tier up instead.
-	if (currentTier === "light") {
-		const nextUp = findNextTierUp(currentModel, modelRegistry, "light")
-		if (nextUp) return nextUp
-	}
-
-	// Return the single light-tier model if one exists (even if it is current).
-	if (lightModels.length > 0) return lightModels[0]
-
-	// No light-tier available at all — fall back to current.
-	return currentModel
-}
-
-/**
- * Find the lowest-cost model at the next tier above `belowTier` that is
- * not the current model.
- *
- * Tier ordering: light < standard < heavy.
- */
-function findNextTierUp(
-	currentModel: Model<Api>,
-	modelRegistry: ModelRegistry,
-	belowTier: ModelTier,
-): Model<Api> | undefined {
-	const tiersAscending: ModelTier[] = ["light", "standard", "heavy"]
-	const startRank = TIER_RANK[belowTier] + 1
-
-	for (const tier of tiersAscending) {
-		if (TIER_RANK[tier] < startRank) continue
+function resolveKimchiModel(modelRegistry: ModelRegistry, excludeId?: string): Model<Api> | undefined {
+	for (const tier of TIERS_ASCENDING) {
 		for (const [id, caps] of MODEL_CAPABILITIES) {
 			if (caps === "ignored") continue
-			if (caps.tier === tier && id !== currentModel.id) {
-				const resolved = modelRegistry.find(KIMCHI_DEV_PROVIDER, id)
-				if (resolved) return resolved
-			}
+			if (excludeId && id === excludeId) continue
+			if (caps.tier !== tier) continue
+			const resolved = modelRegistry.find(KIMCHI_DEV_PROVIDER, id)
+			if (resolved) return resolved
 		}
 	}
-
 	return undefined
 }
 
 /**
- * Among all available models from the same provider, step down up to two
- * cost tiers from `currentModel`.
- *
- * If no cheaper model exists, pick the least more expensive model to
- * still avoid reusing the current model. Falls back to the current model
- * only when it is the sole available model from that provider.
+ * Return the cheapest model across all available providers, excluding `excludeId`.
  */
-function cheaperFromSameProvider(currentModel: Model<Api>, modelRegistry: ModelRegistry): Model<Api> {
-	const currentCost = modelCost(currentModel)
-
-	const sameProvider = modelRegistry.getAvailable().filter((m) => m.provider === currentModel.provider)
-
-	// Collect models that are strictly cheaper, sorted descending by cost.
-	const cheaper = sameProvider.filter((m) => modelCost(m) < currentCost).sort((a, b) => modelCost(b) - modelCost(a))
-
-	if (cheaper.length > 0) {
-		// Step down up to 2 tiers: index 0 = one step, index 1 = two steps.
-		const stepsDown = Math.min(1, cheaper.length - 1)
-		return cheaper[stepsDown]
-	}
-
-	// No cheaper model — pick the least more expensive alternative to avoid
-	// reusing the current model.
-	const moreExpensive = sameProvider
-		.filter((m) => m.id !== currentModel.id && modelCost(m) >= currentCost)
-		.sort((a, b) => modelCost(a) - modelCost(b))
-
-	if (moreExpensive.length > 0) return moreExpensive[0]
-
-	// Sole model in the provider — no choice.
-	return currentModel
+function cheapestAvailable(modelRegistry: ModelRegistry, excludeId?: string): Model<Api> | undefined {
+	const candidates = modelRegistry.getAvailable().filter((m) => !excludeId || m.id !== excludeId)
+	if (candidates.length === 0) return undefined
+	candidates.sort(
+		(a, b) => (a.cost?.input ?? 0) + (a.cost?.output ?? 0) - ((b.cost?.input ?? 0) + (b.cost?.output ?? 0)),
+	)
+	return candidates[0]
 }

--- a/src/extensions/permissions/classifier.test.ts
+++ b/src/extensions/permissions/classifier.test.ts
@@ -47,6 +47,7 @@ describe("classifyToolCall", () => {
 
 		const result = await classifyToolCall(
 			fakeModel(),
+			undefined,
 			fakeRegistry(),
 			{ toolName: "bash", input: { command: "ls" }, cwd: "/tmp" },
 			{ timeoutMs: 5000 },
@@ -62,6 +63,7 @@ describe("classifyToolCall", () => {
 
 		const promise = classifyToolCall(
 			fakeModel("nemotron-test"),
+			undefined,
 			fakeRegistry(),
 			{ toolName: "edit", input: { path: "foo.ts" }, cwd: "/tmp" },
 			{ timeoutMs: 5000 },
@@ -84,6 +86,7 @@ describe("classifyToolCall", () => {
 
 		const promise = classifyToolCall(
 			fakeModel(),
+			undefined,
 			fakeRegistry(),
 			{ toolName: "bash", input: { command: "ls" }, cwd: "/tmp" },
 			{ timeoutMs: 5000 },
@@ -105,6 +108,7 @@ describe("classifyToolCall", () => {
 
 		const promise = classifyToolCall(
 			fakeModel(),
+			undefined,
 			fakeRegistry(),
 			{ toolName: "bash", input: { command: "ls" }, cwd: "/tmp" },
 			{ timeoutMs: 5000 },
@@ -115,6 +119,48 @@ describe("classifyToolCall", () => {
 
 		expect(result.verdict).toBe("safe")
 		expect(result.ok).toBe(true)
+		expect(completeMock).toHaveBeenCalledTimes(3)
+	})
+
+	it("calls fallback model after 3 retryable failures and returns its result", async () => {
+		completeMock
+			.mockResolvedValueOnce(fakeResponse({ stopReason: "aborted" }))
+			.mockResolvedValueOnce(fakeResponse({ stopReason: "aborted" }))
+			.mockResolvedValueOnce(fakeResponse({ stopReason: "aborted" }))
+			.mockResolvedValueOnce(fakeResponse({ stopReason: "stop", content: '{"verdict":"safe","reason":"fine"}' }))
+
+		const promise = classifyToolCall(
+			fakeModel("primary-model"),
+			fakeModel("backoff-model"),
+			fakeRegistry(),
+			{ toolName: "bash", input: { command: "ls" }, cwd: "/tmp" },
+			{ timeoutMs: 5000 },
+		)
+
+		await vi.runAllTimersAsync()
+		const result = await promise
+
+		expect(result.verdict).toBe("safe")
+		expect(result.ok).toBe(true)
+		expect(completeMock).toHaveBeenCalledTimes(4)
+	})
+
+	it("returns last result when no fallback model is provided", async () => {
+		completeMock.mockResolvedValue(fakeResponse({ stopReason: "aborted" }))
+
+		const promise = classifyToolCall(
+			fakeModel("primary-model"),
+			undefined,
+			fakeRegistry(),
+			{ toolName: "bash", input: { command: "ls" }, cwd: "/tmp" },
+			{ timeoutMs: 5000 },
+		)
+
+		await vi.runAllTimersAsync()
+		const result = await promise
+
+		expect(result.verdict).toBe("requires-confirmation")
+		expect(result.ok).toBe(false)
 		expect(completeMock).toHaveBeenCalledTimes(3)
 	})
 
@@ -135,6 +181,7 @@ describe("classifyToolCall", () => {
 
 		const promise = classifyToolCall(
 			fakeModel(),
+			undefined,
 			fakeRegistry(),
 			{ toolName: "bash", input: { command: "ls" }, cwd: "/tmp" },
 			{ timeoutMs: 5000 },
@@ -156,6 +203,7 @@ describe("classifyToolCall", () => {
 
 		const result = await classifyToolCall(
 			fakeModel(),
+			undefined,
 			fakeRegistry(),
 			{ toolName: "bash", input: { command: "ls" }, cwd: "/tmp" },
 			{ timeoutMs: 5000 },
@@ -171,6 +219,7 @@ describe("classifyToolCall", () => {
 
 		const result = await classifyToolCall(
 			fakeModel(),
+			undefined,
 			fakeRegistry(),
 			{ toolName: "bash", input: { command: "ls" }, cwd: "/tmp" },
 			{ timeoutMs: 5000 },
@@ -187,6 +236,7 @@ describe("classifyToolCall", () => {
 
 		const result = await classifyToolCall(
 			fakeModel(),
+			undefined,
 			fakeRegistry(),
 			{ toolName: "bash", input: { command: "ls" }, cwd: "/tmp" },
 			{ timeoutMs: 5000 },

--- a/src/extensions/permissions/classifier.ts
+++ b/src/extensions/permissions/classifier.ts
@@ -21,13 +21,14 @@ export interface ClassifierOptions {
 type InternalResult = ClassifierResult & { retryable: boolean }
 
 export async function classifyToolCall(
-	model: Model<Api>,
+	primaryModel: Model<Api>,
+	fallbackModel: Model<Api> | undefined,
 	modelRegistry: ModelRegistry,
 	call: ClassifyInput,
 	options: ClassifierOptions,
 	signal?: AbortSignal,
 ): Promise<ClassifierResult> {
-	const auth = await modelRegistry.getApiKeyAndHeaders(model)
+	const auth = await modelRegistry.getApiKeyAndHeaders(primaryModel)
 	if (!auth.ok || !auth.apiKey) return unavailable("no API key for classifier")
 
 	if (signal?.aborted) return unavailable("classifier aborted")
@@ -37,12 +38,11 @@ export async function classifyToolCall(
 
 	for (let attempt = 0; attempt < maxAttempts; attempt++) {
 		if (attempt > 0) {
-			const backoff = 500 * 2 ** (attempt - 1)
-			await sleep(backoff)
+			await sleep(attempt * 500)
 			if (signal?.aborted) return unavailable("classifier aborted")
 		}
 
-		const result = await runClassifier(model, auth, call, options, signal)
+		const result = await runClassifier(primaryModel, auth, call, options, signal)
 		if (result.ok) return result
 
 		if (!result.retryable) return result
@@ -51,6 +51,13 @@ export async function classifyToolCall(
 	}
 
 	if (signal?.aborted) return unavailable("classifier aborted")
+
+	if (fallbackModel) {
+		const fallbackAuth = await modelRegistry.getApiKeyAndHeaders(fallbackModel)
+		if (fallbackAuth.ok && fallbackAuth.apiKey) {
+			return runClassifier(fallbackModel, fallbackAuth, call, options, signal)
+		}
+	}
 
 	return lastResult
 }

--- a/src/extensions/permissions/index.test.ts
+++ b/src/extensions/permissions/index.test.ts
@@ -545,7 +545,7 @@ describe("permissions ferment tool classification", () => {
 
 		expect(result).toBeUndefined()
 		expect(classifyToolCall).toHaveBeenCalledTimes(1)
-		expect(vi.mocked(classifyToolCall).mock.calls[0]?.[2]).toMatchObject({
+		expect(vi.mocked(classifyToolCall).mock.calls[0]?.[3]).toMatchObject({
 			toolName: "unknown_tool",
 			input: { value: 1 },
 			cwd: "/test",

--- a/src/extensions/permissions/index.ts
+++ b/src/extensions/permissions/index.ts
@@ -1,5 +1,5 @@
 import { resolve } from "node:path"
-import type { Api, AssistantMessage, Model } from "@earendil-works/pi-ai"
+import type { AssistantMessage } from "@earendil-works/pi-ai"
 import type { ExtensionAPI, ExtensionContext, ToolCallEvent } from "@earendil-works/pi-coding-agent"
 import { isKeyRelease, matchesKey } from "@earendil-works/pi-tui"
 import { RST_FG, resolvedSemanticFg } from "../../ansi.js"
@@ -10,7 +10,7 @@ import { FERMENT_TOOLS, isFermentToolName, isUserFacingFermentToolName } from ".
 import { createSystemPromptBlocks } from "../prompt-construction/index.js"
 import { type ToolVisibilityAPI, createToolVisibility } from "../prompt-construction/tool-visibility.js"
 import { isRawInputCaptureActive } from "../shared-input.js"
-import { resolveClassifierModel } from "./classifier-model.js"
+import { resolveClassifierModels } from "./classifier-model.js"
 import { classifyToolCall } from "./classifier.js"
 import { registerCommands } from "./commands.js"
 import { type LoadedConfig, loadConfig } from "./config.js"
@@ -599,11 +599,12 @@ ${text}
 			// through the classifier; prompts without a frontend fail closed.
 			const promptAvailable = canPrompt(ctx)
 			if (mode === "auto" || !promptAvailable) {
-				const classifierModel = resolveClassifierModel(ctx.model, ctx.modelRegistry)
-				if (!classifierModel) return { block: true, reason: "no model available for classifier" }
+				const classifierModels = resolveClassifierModels(ctx.modelRegistry)
+				if (!classifierModels) return { block: true, reason: "no model available for classifier" }
 
 				const verdict = await classifyToolCall(
-					classifierModel,
+					classifierModels.primary,
+					classifierModels.fallback,
 					ctx.modelRegistry,
 					{ toolName, input, cwd: ctx.cwd },
 					{ timeoutMs: loaded.config.classifierTimeoutMs },


### PR DESCRIPTION
## Description

<!-- What problem does this PR solve? What changes were made and why? -->


## Type of Change

Currently, even after adding backoff retries in the auto mode api call, the nemotron model is still unavailable oftentimes. The user sees timeout errors. 

To remediate this add a fallback model.

**What changed**                                                                                                                                                                                               
                                                                                                                                                                                                            
 - resolveClassifierModel replaced with resolveClassifierModels(modelRegistry) returning { primary, fallback } — fallback is now a first-class output instead of a second call with an excludeId hack       
 - Primary: kimchi-dev light → standard → heavy, then cheapest across all providers                                                                                                                         
 - Fallback: same walk excluding primary, then cheapest available excluding primary — tried once after primary exhausts 3 retries                                                                           
 - Retry delays changed from 500 * 2^n to attempt * 500ms (500ms, 1000ms, 1500ms)                                                                                                                           
 - currentModel removed from the resolution API — it has no bearing on classifier model selection                                                                                                           
                                                                                                                                                                                                            
 **Why**                                                                                                                                                                                                        
                                                                                                                                                                                                            
 The old code had two separate provider paths where the kimchi path used tier metadata (kimchi models don't expose cost) but completely ignored kimchi models when the current model was on another         
 provider. It could also pick a more expensive model just to avoid reusing the current one — the classifier makes an independent API call with a fresh context, so there's no reason to avoid it.           


- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
