### PR TITLE
fix: suppress empty-turn nudge after completed tool sequences

### DIFF
--- a/src/extensions/orchestration/continuation-nudge.ts
+++ b/src/extensions/orchestration/continuation-nudge.ts
@@ -59,6 +59,13 @@ export class ContinuationNudge {
 	private static readonly MAX_NUDGES = 2
 
 	private toolsCalledSinceLastUserInput = false
+	/** Tracks whether any tool has been called during the current agent run
+	 *  (between `resetForNewAgentRun` and the next `resetForNewAgentRun`).
+	 *  Unlike `toolsCalledSinceLastUserInput`, this is NOT reset by
+	 *  `resetForNewUserInput`, so a follow-up question after a tool sequence
+	 *  does not re-arm the nudge and cause spurious "you didn't call a tool"
+	 *  prompts that the model mistakes for user input. */
+	private toolsCalledThisAgentRun = false
 	private nudgeCountThisCycle = 0
 	private nudgeResponsePending = false
 	private accumulatedResponseText = ""
@@ -66,6 +73,13 @@ export class ContinuationNudge {
 	 *  Incremented by `markDelegationCall()`, decremented by `clearDelegationPending()`.
 	 *  The continuation nudge is suppressed while this is > 0. */
 	private pendingDelegationCount = 0
+
+	/** Called at the start of each agent run (agent_start event).
+	 *  Resets the run-level tool tracking so the nudge can fire if the model
+	 *  gets stuck in a new run. */
+	resetForNewAgentRun(): void {
+		this.toolsCalledThisAgentRun = false
+	}
 
 	resetForNewUserInput(): void {
 		this.toolsCalledSinceLastUserInput = false
@@ -80,6 +94,7 @@ export class ContinuationNudge {
 
 	recordToolCall(): void {
 		this.toolsCalledSinceLastUserInput = true
+		this.toolsCalledThisAgentRun = true
 		this.nudgeResponsePending = false
 		this.accumulatedResponseText = ""
 	}
@@ -137,6 +152,10 @@ export class ContinuationNudge {
 
 	hasToolBeenCalledThisCycle(): boolean {
 		return this.toolsCalledSinceLastUserInput
+	}
+
+	hasToolBeenCalledThisRun(): boolean {
+		return this.toolsCalledThisAgentRun
 	}
 
 	getNudgeText(): string {

--- a/src/extensions/prompt-construction/prompt-enrichment.test.ts
+++ b/src/extensions/prompt-construction/prompt-enrichment.test.ts
@@ -826,4 +826,46 @@ describe("continuation nudge turn_end handler", () => {
 		})
 		expect(sendMessageCalls.length).toBe(2)
 	})
+
+	it("does not send an empty-turn nudge after tools were called this agent run", async () => {
+		const { fire, sendMessageCalls } = buildNudgeHandlers()
+
+		// Start a fresh agent run.
+		await fire("agent_start", {})
+
+		// Simulate user input.
+		await fire("input", { source: "user" })
+
+		// Model calls a tool — marks the run as having used tools.
+		await fire("tool_execution_start", {})
+
+		// Model then produces an empty response (thinking-only or truly empty).
+		await fire("turn_end", {
+			message: makeAssistantWithStop([{ type: "thinking", thinking: "I am done." }]),
+		})
+
+		// No nudge should fire — tools were called this run, so the empty
+		// response is the model finishing, not a glitch.
+		expect(sendMessageCalls.length).toBe(0)
+	})
+
+	it("sends an empty-turn nudge when no tools have been called this run", async () => {
+		const { fire, sendMessageCalls } = buildNudgeHandlers()
+
+		// Start a fresh agent run.
+		await fire("agent_start", {})
+
+		// Simulate user input.
+		await fire("input", { source: "user" })
+
+		// Model returns an empty response with no prior tool calls.
+		await fire("turn_end", {
+			message: makeAssistantWithStop([]),
+		})
+
+		// Empty-turn nudge should fire — no tools have been called, the model
+		// might be stuck.
+		expect(sendMessageCalls.length).toBe(1)
+		expect((sendMessageCalls[0].message as { content?: string }).content).toContain("If you have finished")
+	})
 })

--- a/src/extensions/prompt-construction/prompt-enrichment.ts
+++ b/src/extensions/prompt-construction/prompt-enrichment.ts
@@ -359,6 +359,9 @@ export default function (skillPaths: string[]) {
 			// circuits the input-handler chain.
 			const continuationNudge = new ContinuationNudge()
 			const emptyTurnNudge = new EmptyTurnNudge()
+			pi.on("agent_start", async () => {
+				continuationNudge.resetForNewAgentRun()
+			})
 			pi.on("input", async (event) => {
 				if (event.source === "extension") {
 					// Agent result arriving. Clear the delegation-pending flag so the
@@ -413,7 +416,15 @@ export default function (skillPaths: string[]) {
 					// in a recovery cycle. Skip empty-turn nudge here to avoid sending
 					// mixed instructions ("call a tool" vs "summarize or continue").
 					// Fall through to continuationNudge.evaluateTurn below.
-				} else if (emptyTurnNudge.evaluateTurn(assistantMsg)) {
+				} else if (
+					// Suppress the empty-turn nudge when any tool was called during this
+					// agent run. After a completed tool sequence, an empty response is
+					// almost certainly the model finishing, not a model glitch. Without
+					// this check the model treats the nudge as user input and continues
+					// working after it was already done.
+					!continuationNudge.hasToolBeenCalledThisRun() &&
+					emptyTurnNudge.evaluateTurn(assistantMsg)
+				) {
 					pi.sendMessage(
 						{ customType: NUDGE_CUSTOM_TYPE, content: EMPTY_TURN_NUDGE_TEXT, display: false },
 						{ deliverAs: "followUp" },


### PR DESCRIPTION
## Description

After an agent run that called tools, the EmptyTurnNudge could fire on the model's final response (e.g. a summary or thinking-only turn). The model would interpret the nudge as user input and keep working — producing redundant summaries and wasting compute.

Add a run-level tool tracking flag (toolsCalledThisAgentRun) that persists across user-input cycles within the same agent run and resets only on agent_start. The empty-turn nudge path in the turn_end handler now checks this flag and suppresses the nudge when any tool was called during the current run.

<!-- What problem does this PR solve? What changes were made and why? -->


## Type of Change

<!-- Select all that apply. -->

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
