### PR TITLE
fix(install): correct repo refs and handle Windows shells

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -3,7 +3,7 @@
 # Install the kimchi coding-harness CLI from the latest GitHub release.
 #
 # Usage:
-#   curl -fsSL https://github.com/castai/kimchi/releases/latest/download/install.sh | bash
+#   curl -fsSL https://github.com/getkimchi/kimchi/releases/latest/download/install.sh | bash
 #
 # Optional env:
 #   KIMCHI_INSTALL_DIR  Override install dir. Defaults to /usr/local/bin if
@@ -20,7 +20,7 @@ BLUE='\033[0;34m'
 YELLOW='\033[0;33m'
 NC='\033[0m'
 
-REPO="${KIMCHI_REPO_OVERRIDE:-castai/kimchi}"
+REPO="${KIMCHI_REPO_OVERRIDE:-getkimchi/kimchi}"
 VERSION="${KIMCHI_VERSION:-latest}"
 
 echo -e "${BLUE}Installing Kimchi from ${REPO}${VERSION:+ (${VERSION})}…${NC}"
@@ -30,9 +30,17 @@ OS_RAW="$(uname -s | tr '[:upper:]' '[:lower:]')"
 case "$OS_RAW" in
 darwin*) OS="darwin" ;;
 linux*) OS="linux" ;;
+mingw* | msys* | cygwin*)
+	echo -e "${RED}Windows is not supported natively.${NC}" >&2
+	echo "There is no native Windows build yet. Run this installer from inside the" >&2
+	echo "Windows Subsystem for Linux (WSL), where the Linux build works." >&2
+	echo "Set up WSL: https://learn.microsoft.com/windows/wsl/install" >&2
+	exit 1
+	;;
 *)
 	echo -e "${RED}Unsupported OS: $OS_RAW${NC}" >&2
-	echo "Windows: download the .zip from https://github.com/${REPO}/releases" >&2
+	echo "Kimchi ships builds for macOS (darwin) and Linux only." >&2
+	echo "See https://github.com/${REPO}/releases for available downloads." >&2
 	exit 1
 	;;
 esac


### PR DESCRIPTION
## Description

`scripts/install.sh` had three related problems:

1. **Stale default repo.** `REPO` defaulted to `castai/kimchi`, and the usage
   comment (`curl … | bash`) used the same URL. The project moved to
   `getkimchi/kimchi`; the old path only resolves today via GitHub's
   transfer redirect, which silently breaks (or could be hijacked) if
   `castai/kimchi` is ever recreated.
2. **#546 — Git Bash gets a misleading error.** Git Bash, MSYS2 and Cygwin
   report `mingw*` / `msys*` / `cygwin*` from `uname -s`. These fell through
   to the catch-all `*)` arm and printed `Windows: download the .zip from …`.
3. **…pointing at a `.zip` that doesn't exist.** The latest release
   (`v0.1.17`) ships only `kimchi_{darwin,linux}_{amd64,arm64}.tar.gz` — there
   is no Windows artifact at all.

## Changes

- Point the `REPO` default and the usage-comment URL at `getkimchi/kimchi`.
- Recognize `mingw*|msys*|cygwin*` explicitly and tell users there is no
  native Windows build yet, directing them to run the installer inside WSL
  (where the Linux build works).
- Replace the dead `.zip` hint in the catch-all with honest text that points
  at the releases page and states the supported platforms (macOS + Linux).

## Verification

- `bash -n scripts/install.sh` passes.
- Simulated `uname -s` via a shim:
  - `MINGW64_NT-10.0`, `MSYS_NT-10.0`, `CYGWIN_NT-10.0` → WSL guidance, exit 1.
  - an unknown OS (`Plan9`) → "macOS and Linux only" catch-all, exit 1.
  - The banner now reads `Installing Kimchi from getkimchi/kimchi`.

Closes #546

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
