### PR TITLE
fix(acp): forward image tool-result blocks to ACP clients

### DIFF
--- a/src/modes/acp/server.test.ts
+++ b/src/modes/acp/server.test.ts
@@ -1032,6 +1032,103 @@ describe("KimchiAcpAgent tool execution stream", () => {
 		expect(terminal).toBeDefined()
 	})
 
+	// web_fetch (and MCP image tools whose blocks survive transformMcpContent)
+	// can return image blocks in a tool result. toolResultContent must forward
+	// them as ACP image content; before this they were dropped and the client
+	// saw a completed tool call with empty content.
+	it("forwards an image block on tool_execution_end as ACP image content", async () => {
+		fake.promptImpl = async () => {
+			fake.emit({ type: "agent_start" })
+			fake.emit({ type: "tool_execution_start", toolCallId: "tc-img", toolName: "web_fetch", args: { url: "x" } })
+			fake.emit({
+				type: "tool_execution_end",
+				toolCallId: "tc-img",
+				toolName: "web_fetch",
+				result: { content: [{ type: "image", data: "aGVsbG8=", mimeType: "image/png" }] },
+				isError: false,
+			})
+			fake.emit(agentEnd())
+		}
+
+		const res = await agent.prompt({ sessionId, prompt: [{ type: "text", text: "run" }] })
+		expect(res.stopReason).toBe("end_turn")
+
+		const completed = updates.find(
+			(u) => u.update.sessionUpdate === "tool_call_update" && (u.update as { status?: string }).status === "completed",
+		)
+		expect(completed).toBeDefined()
+		const content = (completed?.update as { content: unknown[] }).content
+		expect(content).toEqual([{ type: "content", content: { type: "image", data: "aGVsbG8=", mimeType: "image/png" } }])
+	})
+
+	// The image path also runs on the streaming branch: an image-only partial
+	// must produce an in_progress update rather than being swallowed as empty.
+	it("forwards image blocks from a streaming partialResult", async () => {
+		fake.promptImpl = async () => {
+			fake.emit({ type: "agent_start" })
+			fake.emit({ type: "tool_execution_start", toolCallId: "tc-img2", toolName: "web_fetch", args: { url: "x" } })
+			fake.emit({
+				type: "tool_execution_update",
+				toolCallId: "tc-img2",
+				toolName: "web_fetch",
+				args: { url: "x" },
+				partialResult: { content: [{ type: "image", data: "Zm9v", mimeType: "image/jpeg" }] },
+			})
+			fake.emit({
+				type: "tool_execution_end",
+				toolCallId: "tc-img2",
+				toolName: "web_fetch",
+				result: { content: [{ type: "image", data: "Zm9v", mimeType: "image/jpeg" }] },
+				isError: false,
+			})
+			fake.emit(agentEnd())
+		}
+
+		const res = await agent.prompt({ sessionId, prompt: [{ type: "text", text: "run" }] })
+		expect(res.stopReason).toBe("end_turn")
+
+		const partial = updates.find(
+			(u) =>
+				u.update.sessionUpdate === "tool_call_update" && (u.update as { status?: string }).status === "in_progress",
+		)
+		expect(partial).toBeDefined()
+		const content = (partial?.update as { content: unknown[] }).content
+		expect(content).toEqual([{ type: "content", content: { type: "image", data: "Zm9v", mimeType: "image/jpeg" } }])
+	})
+
+	// A result mixing text and image blocks forwards every block, in order.
+	it("forwards text and image blocks together, preserving order", async () => {
+		fake.promptImpl = async () => {
+			fake.emit({ type: "agent_start" })
+			fake.emit({ type: "tool_execution_start", toolCallId: "tc-mix", toolName: "web_fetch", args: { url: "x" } })
+			fake.emit({
+				type: "tool_execution_end",
+				toolCallId: "tc-mix",
+				toolName: "web_fetch",
+				result: {
+					content: [
+						{ type: "text", text: "before" },
+						{ type: "image", data: "YmFy", mimeType: "image/png" },
+					],
+				},
+				isError: false,
+			})
+			fake.emit(agentEnd())
+		}
+
+		const res = await agent.prompt({ sessionId, prompt: [{ type: "text", text: "run" }] })
+		expect(res.stopReason).toBe("end_turn")
+
+		const completed = updates.find(
+			(u) => u.update.sessionUpdate === "tool_call_update" && (u.update as { status?: string }).status === "completed",
+		)
+		const content = (completed?.update as { content: unknown[] }).content
+		expect(content).toEqual([
+			{ type: "content", content: { type: "text", text: "before" } },
+			{ type: "content", content: { type: "image", data: "YmFy", mimeType: "image/png" } },
+		])
+	})
+
 	// Guard on server.ts:213-214: an empty partialResult must NOT produce a
 	// tool_call_update — an in_progress update with empty content is noise for
 	// clients that render the stream as it arrives.

--- a/src/modes/acp/server.ts
+++ b/src/modes/acp/server.ts
@@ -1230,20 +1230,27 @@ export function shouldEmitThinking(_thinking: string): boolean {
 }
 
 function toolResultContent(result: unknown): ToolCallContent[] {
-	// TODO: non-text blocks are silently dropped here. web_fetch can in principle
-	// return image blocks, and MCP tools may return resource blocks — clients
-	// would see a completed tool call with empty content. Safe today because no
-	// registered tool emits non-text blocks in practice, but revisit when
-	// web_fetch or an MCP tool starts returning them.
+	// Tool results carry pi-ai content blocks, typed as (TextContent |
+	// ImageContent)[] on pi-ai's ToolResultMessage. Forward both, so a tool that
+	// emits an image (e.g. web_fetch, or an MCP image tool whose block survives
+	// transformMcpContent) doesn't surface to the client as a completed call with
+	// empty content.
+	//
+	// resource / resource_link / audio blocks never reach here: the MCP bridge
+	// (transformMcpContent) already flattens them to text, because pi-ai tool
+	// results only model text and image. Forwarding them as native ACP resource
+	// blocks would require widening pi-ai's tool-result content type upstream.
 	const r = result as { content?: unknown } | null | undefined
 	const content = r?.content
 	if (!Array.isArray(content)) return []
 	const out: ToolCallContent[] = []
 	for (const block of content) {
 		if (!block || typeof block !== "object") continue
-		const b = block as { type?: string; text?: string }
+		const b = block as { type?: string; text?: string; data?: string; mimeType?: string }
 		if (b.type === "text" && typeof b.text === "string") {
 			out.push({ type: "content", content: { type: "text", text: b.text } })
+		} else if (b.type === "image" && typeof b.data === "string" && typeof b.mimeType === "string") {
+			out.push({ type: "content", content: { type: "image", data: b.data, mimeType: b.mimeType } })
 		}
 	}
 	return out


### PR DESCRIPTION
## Description

`toolResultContent()` in `src/modes/acp/server.ts` forwarded only `text` blocks to ACP clients, so **image blocks in a tool result were silently dropped** — a client like Zed saw a completed tool call with empty content. This resolves the maintainer `TODO` on that function.

Resolves the maintainer `TODO` in `toolResultContent` (`src/modes/acp/server.ts`).

### What actually reaches this code (AGENTS.md "Before Adding Features" check)

The ACP tool-result translation is **local to this repo**: `node_modules/@earendil-works/pi-coding-agent/dist` has no `@agentclientprotocol` / `toolResultContent` references, so this is the correct layer to fix (not upstream).

Tool-result content is typed by pi-ai as `(TextContent | ImageContent)[]` (`ToolResultMessage`). Therefore:

- **`image`** blocks genuinely occur (web_fetch, or an MCP image tool whose block survives the bridge) and were the ones being dropped → fixed here.
- **`resource` / `resource_link` / `audio`** blocks never reach `toolResultContent`: the MCP bridge `transformMcpContent()` (`src/extensions/mcp-adapter/tool-registrar.ts`) already flattens them to text. A `resource` branch here would be unreachable dead code, so the stale TODO comment is corrected instead. True resource passthrough would require an upstream pi-ai change (worth a separate follow-up issue).

## Changes

- Forward `image` tool-result blocks as ACP `{ type: "content", content: { type: "image", data, mimeType } }`, mirroring the existing inbound prompt → pi-ai image mapping in `server.ts`. Guarded on `data`/`mimeType` being strings, consistent with the `text` branch.
- Replace the stale TODO with a comment describing the real data flow.
- Tests (extending the existing `tool execution stream` suite): image on `tool_execution_end`, image on a streaming `partialResult`, and mixed text+image ordering.

## Verification

- `pnpm run check` (biome lint + `tsc --noEmit`) — passes.
- `pnpm run test` — full unit suite green (299 files, 4589 passed / 3 skipped); the ACP server test file is 124/124 (3 new).

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
