### PR TITLE
fix: align Claude Code hook adapters with the full hook lifecycle

### DIFF
--- a/docs/hooks.md
+++ b/docs/hooks.md
@@ -137,12 +137,18 @@ Supported events:
 
 - `PreToolUse`
 - `PostToolUse`
+- `PostToolUseFail` — runs only when a tool result is an error (`PostToolUse` still runs for all results)
+- `PostToolBatch` — synthesized once per turn after all tool executions in that turn finish
 - `SessionStart`
 - `PreCompact`
 - `PostCompact`
 - `UserPromptSubmit`
-- `Stop`
+- `Stop` — fires once when the agent finishes responding (pi `agent_end`); a `{"decision":"block","reason":"..."}` result continues the run, with `stop_hook_active` set on re-entry
+- `TaskCompleted` — fires at the end of each turn (pi `turn_end`); observer-only, block decisions are ignored
+- `TurnStart`, `MessageStart`, `MessageEnd`, `ModelSelect`, `UserBash` — kimchi-specific observer hooks for pi events with no Claude Code equivalent
 - `SessionEnd`
+
+Plugin packages installed via `kimchi install` may ship a `hooks/hooks.json` (or `.claude-plugin/hooks/hooks.json`). Those hooks honor the same full event set as the adapter above; `SessionStart` context from packages is injected into the system prompt.
 
 Example:
 

--- a/src/extensions/claude-code-hook-adapter/definition.ts
+++ b/src/extensions/claude-code-hook-adapter/definition.ts
@@ -4,6 +4,7 @@ import { join, resolve } from "node:path"
 import {
 	type CommandHookAdapterDefinition,
 	type CommandHookSource,
+	FULL_COMMAND_HOOK_EVENTS,
 	discoverCommandHookResources,
 } from "../hook-adapters/discovery.js"
 
@@ -11,16 +12,7 @@ export const CLAUDE_CODE_HOOK_ADAPTER_DEFINITION: CommandHookAdapterDefinition =
 	id: "claude-code",
 	label: "Claude Code",
 	customType: "kimchi-claude-code-hook-context",
-	supportedEvents: [
-		"PreToolUse",
-		"PostToolUse",
-		"SessionStart",
-		"PreCompact",
-		"PostCompact",
-		"UserPromptSubmit",
-		"Stop",
-		"SessionEnd",
-	],
+	supportedEvents: FULL_COMMAND_HOOK_EVENTS,
 	sources: claudeCodeHookSources,
 	defaultTimeoutMs: 60_000,
 }

--- a/src/extensions/hook-adapters/adapter.test.ts
+++ b/src/extensions/hook-adapters/adapter.test.ts
@@ -325,21 +325,16 @@ describe("hook adapter command execution", () => {
 				Stop: [{ hooks: [{ type: "command", command: "continue" }] }],
 			},
 		})
-		mockBlockingHook({ stdout: JSON.stringify({ decision: "block", reason: "Run tests before stopping." }) })
+		const child = mockBlockingHook({
+			stdout: JSON.stringify({ decision: "block", reason: "Run tests before stopping." }),
+		})
 		const pi = fakePi()
 		claudeCodeHooksAdapter(pi as never)
 
-		await pi.handlers.turn_end[0](
-			{
-				type: "turn_end",
-				turnIndex: 1,
-				message: { role: "assistant", content: [{ type: "text", text: "done" }] },
-				toolResults: [],
-			},
-			fakeCtx(),
-		)
+		await pi.handlers.agent_end[0](agentEndEvent(), fakeCtx())
 
 		expect(pi.sendUserMessage).toHaveBeenCalledWith("Run tests before stopping.", { deliverAs: "followUp" })
+		expect(hookPayload(child).last_assistant_message).toBe("done")
 	})
 
 	it("keeps Stop hook active across an intervening input event", async () => {
@@ -348,19 +343,208 @@ describe("hook adapter command execution", () => {
 				Stop: [{ hooks: [{ type: "command", command: "continue" }] }],
 			},
 		})
-		const firstStop = mockBlockingHook({ stdout: JSON.stringify({ decision: "block", reason: "Continue once." }) })
-		const secondStop = mockBlockingHook({ stdout: JSON.stringify({ decision: "block", reason: "Continue once." }) })
+		const firstHook = mockBlockingHook({ stdout: JSON.stringify({ decision: "block", reason: "Continue once." }) })
+		const secondHook = mockBlockingHook({ stdout: JSON.stringify({ decision: "block", reason: "Continue once." }) })
 		const pi = fakePi()
 		claudeCodeHooksAdapter(pi as never)
 
-		await pi.handlers.turn_end[0](turnEndEvent(1), fakeCtx())
+		await pi.handlers.agent_end[0](agentEndEvent(), fakeCtx())
 		await pi.handlers.input[0]({ type: "input", text: "follow-up", source: "user" }, fakeCtx())
-		await pi.handlers.turn_end[0](turnEndEvent(2), fakeCtx())
+		await pi.handlers.agent_end[0](agentEndEvent(), fakeCtx())
 
 		expect(pi.sendUserMessage).toHaveBeenCalledTimes(1)
-		expect(hookPayload(firstStop).stop_hook_active).toBe(false)
-		const secondStopPayload = hookPayload(secondStop)
-		expect(secondStopPayload.stop_hook_active).toBe(true)
+		expect(hookPayload(firstHook).stop_hook_active).toBe(false)
+		const secondPayload = hookPayload(secondHook)
+		expect(secondPayload.stop_hook_active).toBe(true)
+	})
+
+	it("runs every Stop hook even when an earlier one blocks", async () => {
+		writeJson(join(dir, "home", ".claude", "settings.json"), {
+			hooks: {
+				Stop: [
+					{ hooks: [{ type: "command", command: "stop-one" }] },
+					{ hooks: [{ type: "command", command: "stop-two" }] },
+				],
+			},
+		})
+		mockBlockingHook({ stdout: JSON.stringify({ decision: "block", reason: "Keep going." }) })
+		mockBlockingHook()
+		const pi = fakePi()
+		claudeCodeHooksAdapter(pi as never)
+
+		await pi.handlers.agent_end[0](agentEndEvent(), fakeCtx())
+
+		expect(mockSpawn).toHaveBeenCalledTimes(2)
+		expect(pi.sendUserMessage).toHaveBeenCalledTimes(1)
+	})
+
+	it("runs TaskCompleted hooks per turn without follow-up continuation", async () => {
+		writeJson(join(dir, "home", ".claude", "settings.json"), {
+			hooks: {
+				TaskCompleted: [{ hooks: [{ type: "command", command: "task-observer" }] }],
+			},
+		})
+		const child = mockBlockingHook({ stdout: JSON.stringify({ decision: "block", reason: "ignored" }) })
+		const pi = fakePi()
+		claudeCodeHooksAdapter(pi as never)
+
+		await pi.handlers.turn_end[0](
+			{
+				type: "turn_end",
+				turnIndex: 3,
+				message: { role: "assistant", content: [{ type: "text", text: "turn done" }] },
+				toolResults: [{ toolCallId: "call-1", isError: false }],
+			},
+			fakeCtx(),
+		)
+
+		const payload = hookPayload(child)
+		expect(payload.turn_id).toBe("3")
+		expect(payload.last_assistant_message).toBe("turn done")
+		expect(payload.tool_results).toEqual([{ tool_use_id: "call-1", is_error: false }])
+		expect(pi.sendUserMessage).not.toHaveBeenCalled()
+	})
+
+	it("runs PostToolUseFail hooks only for failed tool results", async () => {
+		writeJson(join(dir, "home", ".claude", "settings.json"), {
+			hooks: {
+				PostToolUse: [{ hooks: [{ type: "command", command: "post-tool" }] }],
+				PostToolUseFail: [{ hooks: [{ type: "command", command: "post-tool-fail" }] }],
+			},
+		})
+		const postHook = mockBlockingHook()
+		const failHook = mockBlockingHook()
+		const pi = fakePi()
+		claudeCodeHooksAdapter(pi as never)
+
+		await pi.handlers.tool_result[0](
+			{
+				type: "tool_result",
+				toolCallId: "1",
+				toolName: "bash",
+				input: { command: "false" },
+				content: [{ type: "text", text: "exit 1" }],
+				isError: true,
+			},
+			fakeCtx(),
+		)
+
+		expect(mockSpawn).toHaveBeenCalledTimes(2)
+		expect(hookPayload(postHook).hook_event_name).toBe("PostToolUse")
+		const failPayload = hookPayload(failHook)
+		expect(failPayload.hook_event_name).toBe("PostToolUseFail")
+		expect(failPayload.is_error).toBe(true)
+
+		mockSpawn.mockClear()
+		mockBlockingHook()
+		await pi.handlers.tool_result[0](
+			{
+				type: "tool_result",
+				toolCallId: "2",
+				toolName: "bash",
+				input: { command: "true" },
+				content: [{ type: "text", text: "" }],
+				isError: false,
+			},
+			fakeCtx(),
+		)
+
+		expect(mockSpawn).toHaveBeenCalledTimes(1)
+	})
+
+	it("synthesizes PostToolBatch from tool executions within a turn", async () => {
+		writeJson(join(dir, "home", ".claude", "settings.json"), {
+			hooks: {
+				PostToolBatch: [{ hooks: [{ type: "command", command: "batch-observer" }] }],
+			},
+		})
+		const child = mockBlockingHook()
+		const pi = fakePi()
+		claudeCodeHooksAdapter(pi as never)
+
+		await pi.handlers.turn_start[0]({ type: "turn_start", turnIndex: 1 }, fakeCtx())
+		pi.handlers.tool_execution_end[0](
+			{ type: "tool_execution_end", toolCallId: "a", toolName: "bash", result: "ok", isError: false },
+			fakeCtx(),
+		)
+		pi.handlers.tool_execution_end[0](
+			{ type: "tool_execution_end", toolCallId: "b", toolName: "read", result: "boom", isError: true },
+			fakeCtx(),
+		)
+		await pi.handlers.turn_end[0](turnEndEvent(1), fakeCtx())
+
+		expect(mockSpawn).toHaveBeenCalledTimes(1)
+		const payload = hookPayload(child)
+		expect(payload.turn_id).toBe("1")
+		expect(payload.tool_results).toEqual([
+			{ tool_name: "Bash", tool_use_id: "a", is_error: false },
+			{ tool_name: "Read", tool_use_id: "b", is_error: true },
+		])
+
+		mockSpawn.mockClear()
+		await pi.handlers.turn_end[0](turnEndEvent(2), fakeCtx())
+		expect(mockSpawn).not.toHaveBeenCalled()
+	})
+
+	it("skips PostToolBatch when a turn ran no tools", async () => {
+		writeJson(join(dir, "home", ".claude", "settings.json"), {
+			hooks: {
+				PostToolBatch: [{ hooks: [{ type: "command", command: "batch-observer" }] }],
+			},
+		})
+		const pi = fakePi()
+		claudeCodeHooksAdapter(pi as never)
+
+		await pi.handlers.turn_start[0]({ type: "turn_start", turnIndex: 1 }, fakeCtx())
+		await pi.handlers.turn_end[0](turnEndEvent(1), fakeCtx())
+
+		expect(mockSpawn).not.toHaveBeenCalled()
+	})
+
+	it("runs observer hooks for TurnStart, MessageEnd, ModelSelect, and UserBash", async () => {
+		writeJson(join(dir, "home", ".claude", "settings.json"), {
+			hooks: {
+				TurnStart: [{ hooks: [{ type: "command", command: "turn-start" }] }],
+				MessageEnd: [{ hooks: [{ type: "command", command: "message-end" }] }],
+				ModelSelect: [{ hooks: [{ type: "command", command: "model-select" }] }],
+				UserBash: [{ hooks: [{ type: "command", command: "user-bash" }] }],
+			},
+		})
+		const turnStart = mockBlockingHook()
+		const messageEnd = mockBlockingHook()
+		const modelSelect = mockBlockingHook()
+		const userBash = mockBlockingHook()
+		const pi = fakePi()
+		claudeCodeHooksAdapter(pi as never)
+
+		await pi.handlers.turn_start[0]({ type: "turn_start", turnIndex: 5 }, fakeCtx())
+		await pi.handlers.message_end[0](
+			{ type: "message_end", message: { role: "assistant", content: [{ type: "text", text: "hello" }] } },
+			fakeCtx(),
+		)
+		await pi.handlers.model_select[0](
+			{ type: "model_select", model: { id: "new-model" }, previousModel: { id: "old-model" }, source: "user" },
+			fakeCtx(),
+		)
+		await pi.handlers.user_bash[0]({ type: "user_bash", command: "ls", excludeFromContext: true, cwd: dir }, fakeCtx())
+
+		expect(hookPayload(turnStart)).toMatchObject({ hook_event_name: "TurnStart", turn_id: "5" })
+		expect(hookPayload(messageEnd)).toMatchObject({
+			hook_event_name: "MessageEnd",
+			message_role: "assistant",
+			message_text: "hello",
+		})
+		expect(hookPayload(modelSelect)).toMatchObject({
+			hook_event_name: "ModelSelect",
+			model: "new-model",
+			previous_model: "old-model",
+			source: "user",
+		})
+		expect(hookPayload(userBash)).toMatchObject({
+			hook_event_name: "UserBash",
+			command: "ls",
+			exclude_from_context: true,
+		})
 	})
 
 	it("surfaces a Claude Code UserPromptSubmit denial reason without starting another turn", async () => {
@@ -568,6 +752,16 @@ function turnEndEvent(turnIndex: number) {
 		turnIndex,
 		message: { role: "assistant", content: [{ type: "text", text: "done" }] },
 		toolResults: [],
+	}
+}
+
+function agentEndEvent() {
+	return {
+		type: "agent_end",
+		messages: [
+			{ role: "user", content: [{ type: "text", text: "do the thing" }] },
+			{ role: "assistant", content: [{ type: "text", text: "done" }] },
+		],
 	}
 }
 

--- a/src/extensions/hook-adapters/adapter.ts
+++ b/src/extensions/hook-adapters/adapter.ts
@@ -1,5 +1,6 @@
 import { spawn } from "node:child_process"
 import type {
+	AgentEndEvent,
 	BeforeAgentStartEvent,
 	BeforeAgentStartEventResult,
 	ExtensionAPI,
@@ -8,7 +9,6 @@ import type {
 	InputEventResult,
 	SessionBeforeCompactEvent,
 	SessionCompactEvent,
-	SessionShutdownEvent,
 	SessionStartEvent,
 	ToolCallEvent,
 	ToolCallEventResult,
@@ -57,6 +57,7 @@ type HookToolResultEventResult = {
 export function createCommandHookAdapter(definition: CommandHookAdapterDefinition): (pi: ExtensionAPI) => void {
 	return (pi) => {
 		let stopHookFollowUpPending = false
+		let batchedToolResults: Array<{ tool_name: string; tool_use_id: string; is_error: boolean }> = []
 		const pendingSystemPrompt: { context?: string } = {}
 
 		if (definition.sessionStartDelivery === "systemPrompt") {
@@ -81,7 +82,29 @@ export function createCommandHookAdapter(definition: CommandHookAdapterDefinitio
 		pi.on("input", (event, ctx) => {
 			return runUserPromptSubmit(definition, pi, event, ctx)
 		})
+		pi.on("turn_start", async (event, ctx) => {
+			batchedToolResults = []
+			await runObserver(definition, "TurnStart", ctx, { turn_id: String(event.turnIndex) })
+		})
+		pi.on("tool_execution_end", (event) => {
+			batchedToolResults.push({
+				tool_name: externalToolName(event.toolName),
+				tool_use_id: event.toolCallId,
+				is_error: event.isError,
+			})
+		})
 		pi.on("turn_end", async (event, ctx) => {
+			if (batchedToolResults.length > 0) {
+				const toolResults = batchedToolResults
+				batchedToolResults = []
+				await runObserver(definition, "PostToolBatch", ctx, {
+					turn_id: String(event.turnIndex),
+					tool_results: toolResults,
+				})
+			}
+			await runTaskCompleted(definition, pi, event, ctx)
+		})
+		pi.on("agent_end", async (event, ctx) => {
 			const stopHookActive = stopHookFollowUpPending
 			const result = await runStop(definition, event, ctx, stopHookActive)
 			if (stopHookActive) stopHookFollowUpPending = false
@@ -90,8 +113,27 @@ export function createCommandHookAdapter(definition: CommandHookAdapterDefinitio
 				pi.sendUserMessage(result.reason, { deliverAs: "followUp" })
 			}
 		})
+		pi.on("message_start", async (event, ctx) => {
+			await runObserver(definition, "MessageStart", ctx, messagePayload(event.message))
+		})
+		pi.on("message_end", async (event, ctx) => {
+			await runObserver(definition, "MessageEnd", ctx, messagePayload(event.message))
+		})
+		pi.on("model_select", async (event, ctx) => {
+			await runObserver(definition, "ModelSelect", ctx, {
+				model: modelIdValue(event.model),
+				previous_model: modelIdValue(event.previousModel),
+				source: event.source,
+			})
+		})
+		pi.on("user_bash", async (event, ctx) => {
+			await runObserver(definition, "UserBash", ctx, {
+				command: event.command,
+				exclude_from_context: event.excludeFromContext,
+			})
+		})
 		pi.on("session_shutdown", async (event, ctx) => {
-			await runObserver(definition, "SessionEnd", event, ctx)
+			await runObserver(definition, "SessionEnd", ctx, event as unknown as Record<string, unknown>)
 		})
 	}
 }
@@ -262,6 +304,12 @@ async function runPostToolUse(
 		is_error: event.isError,
 	}
 	let result = await runMatchingHooks(definition, "PostToolUse", ctx, matcherCandidates(event.toolName), basePayload)
+	if (event.isError) {
+		result = mergeOptionalResults(
+			result,
+			await runMatchingHooks(definition, "PostToolUseFail", ctx, matcherCandidates(event.toolName), basePayload),
+		)
+	}
 	const skillName = skillNameFromReadPath(event)
 	if (skillName) {
 		result = mergeOptionalResults(
@@ -362,24 +410,40 @@ async function runUserPromptSubmit(
 
 async function runStop(
 	definition: CommandHookAdapterDefinition,
-	event: TurnEndEvent,
+	event: AgentEndEvent,
 	ctx: ExtensionContext,
 	stopHookActive: boolean,
 ): Promise<HookCommandResult | undefined> {
 	return runMatchingHooks(definition, "Stop", ctx, [], {
-		turn_id: String(event.turnIndex),
 		stop_hook_active: stopHookActive,
-		last_assistant_message: lastAssistantText(event.message),
+		last_assistant_message: lastAssistantTextFromMessages(event.messages),
 	})
+}
+
+async function runTaskCompleted(
+	definition: CommandHookAdapterDefinition,
+	pi: ExtensionAPI,
+	event: TurnEndEvent,
+	ctx: ExtensionContext,
+): Promise<void> {
+	const result = await runMatchingHooks(definition, "TaskCompleted", ctx, [], {
+		turn_id: String(event.turnIndex),
+		last_assistant_message: lastAssistantText(event.message),
+		tool_results: event.toolResults.map((toolResult) => ({
+			tool_use_id: stringValue((toolResult as unknown as Record<string, unknown>).toolCallId) ?? null,
+			is_error: (toolResult as unknown as Record<string, unknown>).isError === true,
+		})),
+	})
+	if (result?.additionalContext) sendAdditionalContext(definition, pi, result.additionalContext, "steer")
 }
 
 async function runObserver(
 	definition: CommandHookAdapterDefinition,
-	eventName: "SessionEnd",
-	event: SessionShutdownEvent,
+	eventName: CommandHookEventName,
 	ctx: ExtensionContext,
+	payload: Record<string, unknown>,
 ): Promise<void> {
-	await runMatchingHooks(definition, eventName, ctx, [], event as unknown as Record<string, unknown>)
+	await runMatchingHooks(definition, eventName, ctx, [], payload)
 }
 
 async function runMatchingHooks(
@@ -538,6 +602,26 @@ function skillNameFromReadPath(event: ToolResultEvent): string | undefined {
 function lastAssistantText(message: TurnEndEvent["message"]): string | null {
 	if (!isRecord(message) || !Array.isArray(message.content)) return null
 	return message.content.map((part) => (isRecord(part) && part.type === "text" ? part.text : "")).join("") || null
+}
+
+function lastAssistantTextFromMessages(messages: AgentEndEvent["messages"]): string | null {
+	for (let i = messages.length - 1; i >= 0; i--) {
+		const message = messages[i]
+		if (isRecord(message) && message.role === "assistant") return lastAssistantText(message)
+	}
+	return null
+}
+
+function messagePayload(message: TurnEndEvent["message"]): Record<string, unknown> {
+	return {
+		message_role: isRecord(message) ? (stringValue(message.role) ?? null) : null,
+		message_text: lastAssistantText(message),
+	}
+}
+
+function modelIdValue(model: unknown): string | null {
+	if (!isRecord(model)) return null
+	return stringValue(model.id) ?? stringValue(model.name) ?? null
 }
 
 function sessionStartSource(reason: SessionStartEvent["reason"]): string {

--- a/src/extensions/hook-adapters/discovery.ts
+++ b/src/extensions/hook-adapters/discovery.ts
@@ -6,12 +6,40 @@ export type HookAdapterScope = "user" | "project" | "local"
 export type CommandHookEventName =
 	| "PreToolUse"
 	| "PostToolUse"
+	| "PostToolUseFail"
+	| "PostToolBatch"
 	| "SessionStart"
 	| "PreCompact"
 	| "PostCompact"
 	| "UserPromptSubmit"
 	| "Stop"
+	| "TaskCompleted"
+	| "TurnStart"
+	| "MessageStart"
+	| "MessageEnd"
+	| "ModelSelect"
+	| "UserBash"
 	| "SessionEnd"
+
+/** Every hook event the command-hook adapter machinery can drive. */
+export const FULL_COMMAND_HOOK_EVENTS: readonly CommandHookEventName[] = [
+	"PreToolUse",
+	"PostToolUse",
+	"PostToolUseFail",
+	"PostToolBatch",
+	"SessionStart",
+	"PreCompact",
+	"PostCompact",
+	"UserPromptSubmit",
+	"Stop",
+	"TaskCompleted",
+	"TurnStart",
+	"MessageStart",
+	"MessageEnd",
+	"ModelSelect",
+	"UserBash",
+	"SessionEnd",
+]
 
 export interface CommandHookAdapterDefinition {
 	id: string

--- a/src/extensions/plugin-package-hook-adapter/definition.test.ts
+++ b/src/extensions/plugin-package-hook-adapter/definition.test.ts
@@ -1,13 +1,14 @@
 import { mkdirSync, rmSync, writeFileSync } from "node:fs"
 import { tmpdir } from "node:os"
 import { join } from "node:path"
-import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
+import { afterEach, beforeEach, describe, expect, it } from "vitest"
 import {
 	getResourceDefinition,
 	getResourceDefinitions,
 	invalidateResourceDefinitionsCache,
 } from "../../resources/definitions.js"
-import { discoverCommandHookResources } from "../hook-adapters/discovery.js"
+import { FULL_COMMAND_HOOK_EVENTS, discoverCommandHookResources } from "../hook-adapters/discovery.js"
+import { PLUGIN_PACKAGE_HOOK_ADAPTER_DEFINITION } from "./definition.js"
 
 // Isolate filesystem env
 let dir: string
@@ -186,6 +187,20 @@ describe("discoverCommandHookResources with pluginRoot", () => {
 		expect(resources).toHaveLength(2)
 		const ids = resources.map((r) => r.id)
 		expect(new Set(ids).size).toBe(2)
+	})
+
+	it("supports the full Claude Code hook lifecycle", () => {
+		expect(PLUGIN_PACKAGE_HOOK_ADAPTER_DEFINITION.supportedEvents).toEqual(FULL_COMMAND_HOOK_EVENTS)
+
+		const pkgRoot = join(dir, "pkg-full")
+		const hooksFile = makeHooksFile(join(pkgRoot, "hooks"))
+		const definition = {
+			...PLUGIN_PACKAGE_HOOK_ADAPTER_DEFINITION,
+			sources: () => [{ scope: "user" as const, path: hooksFile, pluginRoot: pkgRoot }],
+		}
+
+		const resources = discoverCommandHookResources(definition)
+		expect(resources.map((r) => r.eventName).sort()).toEqual(["PostToolUse", "PreToolUse", "SessionStart"])
 	})
 })
 

--- a/src/extensions/plugin-package-hook-adapter/definition.ts
+++ b/src/extensions/plugin-package-hook-adapter/definition.ts
@@ -1,14 +1,16 @@
 /**
- * Plugin-package SessionStart hook adapter.
+ * Plugin-package hook adapter.
  *
- * Loads ONLY the SessionStart hooks from each enabled pi plugin package's
- * `hooks/hooks.json` (or `.claude-plugin/hooks/hooks.json`) and injects their
- * `additionalContext` into the system prompt on the first `before_agent_start`
- * event, giving a strong steering delivery.
+ * Loads the `hooks/hooks.json` (or `.claude-plugin/hooks/hooks.json`) from
+ * each enabled pi plugin package and honors the full Claude Code hook
+ * lifecycle — the same event set as the standalone claude-code-hook-adapter.
+ * SessionStart `additionalContext` is injected into the system prompt on the
+ * first `before_agent_start` event, giving a strong steering delivery.
  *
- * Tool capture and routing is intentionally left to each package's own pi
- * extension to avoid double-capturing PreToolUse/PostToolUse/etc.  This
- * adapter handles nothing except the SessionStart steering block.
+ * Hooks run unconditionally alongside any pi extension the package ships:
+ * extension event subscriptions are opaque, so no precedence check is
+ * possible. Avoiding duplicate behavior across a package's hooks.json and
+ * its pi extension is the package author's contract.
  */
 import { existsSync } from "node:fs"
 import { join } from "node:path"
@@ -17,6 +19,7 @@ import { getResourceOverride } from "../../resources/store.js"
 import {
 	type CommandHookAdapterDefinition,
 	type CommandHookSource,
+	FULL_COMMAND_HOOK_EVENTS,
 	discoverCommandHookResources,
 } from "../hook-adapters/discovery.js"
 
@@ -24,7 +27,7 @@ export const PLUGIN_PACKAGE_HOOK_ADAPTER_DEFINITION: CommandHookAdapterDefinitio
 	id: "plugin-package",
 	label: "Plugin package",
 	customType: "kimchi-plugin-package-hook-context",
-	supportedEvents: ["SessionStart"],
+	supportedEvents: FULL_COMMAND_HOOK_EVENTS,
 	sources: pluginPackageHookSources,
 	defaultTimeoutMs: 60_000,
 	sessionStartDelivery: "systemPrompt",


### PR DESCRIPTION
## Summary

Implements all kimchi-side fixes from the pi ↔ Claude Code hooks alignment analysis, bringing both hook adapters (`claude-code-hook-adapter` and `plugin-package-hook-adapter`) to full parity with the Claude Code hook lifecycle where pi SDK events allow.

### Stop / TaskCompleted rebind (Fix 10)

On master, `Stop` was wired to pi's `turn_end`, so it over-fired once per turn instead of once per agent run.

- `Stop` now binds to `agent_end`: fires once when the run ends, keeps `stop_hook_active` re-entrancy across the block→followUp continuation, and derives `last_assistant_message` from `AgentEndEvent.messages`. All Stop hooks run even when an earlier one blocks.
- `TaskCompleted` binds to `turn_end` as a per-turn observer (`turn_id`, `last_assistant_message`, `tool_results`); `additionalContext` is honored, block decisions are ignored — continuation semantics belong to Stop.

### New hook coverage

- **`PostToolUseFail`** (Fix 1): runs additionally when `tool_result.isError` is true; `PostToolUse` still fires on all results for backward compatibility.
- **`PostToolBatch`** (Fix 6, kimchi-side synthesis): collects `tool_execution_end` events per turn and fires once at `turn_end`; skipped on tool-less turns.
- **Observer hooks** (Fix 8): `TurnStart`, `MessageStart`, `MessageEnd`, `ModelSelect`, `UserBash` for pi events with no Claude Code equivalent.

### Plugin-package adapter parity (Fix 9)

`plugin-package-hook-adapter` previously honored only `SessionStart` from a package's `hooks.json` and silently dropped every other declared event. It now supports the same full event set as the standalone adapter via a shared `FULL_COMMAND_HOOK_EVENTS` constant. Hooks run unconditionally alongside any pi extension the package ships (extension event subscriptions are opaque, so no precedence check is possible — documented as the package author's contract).

`StopFail`, `PermissionRequest`, `SubagentStart/Stop` remain unsupported: they need upstream pi events (`AgentEndEvent` has no error field as of 0.78).

## Test plan

- [x] `pnpm check` (biome + tsc) clean
- [x] `pnpm test` — full suite passes, including new coverage for: Stop continuation + `stop_hook_active` re-entrancy on `agent_end`, no short-circuit across blocking Stop hooks, TaskCompleted payload without followUp, PostToolUseFail routing on `isError`, PostToolBatch collection/reset across turns, observer hook payloads, and plugin-package full-lifecycle discovery