### PR TITLE
fix: inject appVersion into JSONL session header line

### DIFF
--- a/src/utils/export-post-process.test.ts
+++ b/src/utils/export-post-process.test.ts
@@ -20,9 +20,9 @@ describe("postProcessJsonlExport", () => {
 		}
 	})
 
-	it("injects appVersion into the header line", () => {
+	it("injects appVersion into the session header line", () => {
 		const lines = [
-			JSON.stringify({ type: "header", version: 3, id: "s1" }),
+			JSON.stringify({ type: "session", version: 3, id: "s1" }),
 			JSON.stringify({ type: "message", id: "e1", parentId: null, message: { role: "user", content: "hello" } }),
 		]
 		const filePath = join(tmpDir, "export.jsonl")
@@ -34,13 +34,13 @@ describe("postProcessJsonlExport", () => {
 			.split("\n")
 			.filter((l) => l.trim().length > 0)
 		const header = JSON.parse(result[0])
-		expect(header.type).toBe("header")
+		expect(header.type).toBe("session")
 		expect(header.appVersion).toBeDefined()
 	})
 
 	it("preserves trace ID injection", () => {
 		const lines = [
-			JSON.stringify({ type: "header", version: 3, id: "s1" }),
+			JSON.stringify({ type: "session", version: 3, id: "s1" }),
 			JSON.stringify({ type: "message", id: "e1", parentId: null, message: { role: "user", content: "hello" } }),
 			JSON.stringify({ type: "message", id: "e2", parentId: "e1", message: { role: "assistant", content: "hi" } }),
 			JSON.stringify({
@@ -64,7 +64,7 @@ describe("postProcessJsonlExport", () => {
 	})
 
 	it("is idempotent when run twice", () => {
-		const lines = [JSON.stringify({ type: "header", version: 3, id: "s1" })]
+		const lines = [JSON.stringify({ type: "session", version: 3, id: "s1" })]
 		const filePath = join(tmpDir, "export-idempotent.jsonl")
 		writeFileSync(filePath, `${lines.join("\n")}\n`, "utf-8")
 
@@ -79,7 +79,7 @@ describe("postProcessJsonlExport", () => {
 		expect(header.appVersion).toBeDefined()
 	})
 
-	it("does not inject appVersion when the first line is not a header", () => {
+	it("does not inject appVersion when the first line is not a session header", () => {
 		const lines = [
 			JSON.stringify({ type: "message", id: "e1", parentId: null, message: { role: "user", content: "hello" } }),
 		]

--- a/src/utils/export-post-process.ts
+++ b/src/utils/export-post-process.ts
@@ -15,10 +15,10 @@ export function postProcessJsonlExport(filePath: string): void {
 	const lines = raw.split(/\r?\n/).filter((l) => l.trim().length > 0)
 	const processed = injectTraceIdsIntoExport(lines)
 
-	// Inject version into header line if present.
+	// Inject version into session header line if present.
 	if (processed.length > 0) {
 		const first = JSON.parse(processed[0]) as Record<string, unknown>
-		if (first.type === "header") {
+		if (first.type === "session") {
 			first.appVersion = getVersion()
 			processed[0] = JSON.stringify(first)
 		}


### PR DESCRIPTION
## Problem

PR #494 added version number to exports, but `appVersion` was only injected into HTML exports, not JSONL ones.

## Root Cause

`postProcessJsonlExport` checked for `first.type === 'header'`, but the actual JSONL export format uses `type: 'session'` for the first line (the session info entry). Because the type never matched, `appVersion` was never added to JSONL exports.

## Fix

- Update the type check from `'header'` to `'session'`.
- Update tests to use the correct `'session'` type.

## How to verify

1. Export a session as JSONL
2. Check the first line — it should now include `appVersion`