### PR TITLE
chore: Use the new tokens api response field in /stats

### DIFF
--- a/src/extensions/stats/display.ts
+++ b/src/extensions/stats/display.ts
@@ -41,21 +41,12 @@ export function formatAnalyticsSummary(data: GenerateAnalyticsResponse, theme: T
 	let totalInput = 0
 	let totalOutput = 0
 
-	if (data.inputTokens?.items) {
-		for (const item of data.inputTokens.items) {
+	if (data.tokens?.items) {
+		for (const item of data.tokens.items) {
 			if (item.models) {
 				for (const model of item.models) {
-					totalInput += model.totalCount || 0
-				}
-			}
-		}
-	}
-
-	if (data.outputTokens?.items) {
-		for (const item of data.outputTokens.items) {
-			if (item.models) {
-				for (const model of item.models) {
-					totalOutput += model.totalCount || 0
+					totalInput += model.inputTokens || 0
+					totalOutput += model.outputTokens || 0
 				}
 			}
 		}
@@ -100,11 +91,8 @@ export function formatAnalyticsSummary(data: GenerateAnalyticsResponse, theme: T
 
 	// Change indicators line
 	const changeParts: string[] = []
-	if (data.comparison?.inputTokens?.changePercentage !== undefined) {
-		changeParts.push(`in: ${formatChangeIndicator(data.comparison.inputTokens.changePercentage, theme)}`)
-	}
-	if (data.comparison?.outputTokens?.changePercentage !== undefined) {
-		changeParts.push(`out: ${formatChangeIndicator(data.comparison.outputTokens.changePercentage, theme)}`)
+	if (data.comparison?.tokens?.changePercentage !== undefined) {
+		changeParts.push(`tokens: ${formatChangeIndicator(data.comparison.tokens.changePercentage, theme)}`)
 	}
 	if (data.comparison?.cost?.changePercentage !== undefined) {
 		changeParts.push(`cost: ${formatChangeIndicator(data.comparison.cost.changePercentage, theme)}`)

--- a/src/extensions/stats/index.ts
+++ b/src/extensions/stats/index.ts
@@ -77,7 +77,7 @@ async function handleStatsCommand(args: string, ctx: ExtensionCommandContext): P
 		// Fetch analytics data
 		try {
 			const analytics = await api.generateAnalytics(startTime, endTime)
-			const hasTokenData = analytics.inputTokens?.items?.length || analytics.outputTokens?.items?.length
+			const hasTokenData = analytics.tokens?.items?.length
 			const hasCostData = analytics.cost?.items?.length
 			const hasApiCalls = analytics.apiCalls?.items?.length
 

--- a/src/extensions/stats/stats.test.ts
+++ b/src/extensions/stats/stats.test.ts
@@ -1,8 +1,24 @@
+import type { Theme } from "@earendil-works/pi-coding-agent"
 import { describe, expect, it } from "vitest"
 import { formatCount } from "../format.js"
 import { getTimeRange } from "./api.js"
+import { formatAnalyticsSummary } from "./display.js"
 import { parseStatsArgs } from "./index.js"
-import { type SortBy, formatCurrency, getProviderDisplayName, getSourceName, sortFn } from "./visual.js"
+import type { GenerateAnalyticsResponse } from "./types.js"
+import {
+	type SortBy,
+	formatAnalyticsVisual,
+	formatCurrency,
+	getProviderDisplayName,
+	getSourceName,
+	sortFn,
+} from "./visual.js"
+
+// Simple pass-through mock for testing output shape without ANSI codes
+const mockTheme = {
+	bold: (text: string) => text,
+	fg: (_color: string, text: string) => text,
+} as unknown as Theme
 
 describe("getTimeRange", () => {
 	it("returns correct time range for 30 days", () => {
@@ -241,5 +257,200 @@ describe("sortFn", () => {
 			expect(sorted[0].modelName).toBe("claude-3")
 			expect(sorted[1].modelName).toBe("gpt-4")
 		})
+	})
+})
+
+function makeModelTokenStat(
+	overrides: Partial<import("./types.js").ModelTokenStat> = {},
+): import("./types.js").ModelTokenStat {
+	return {
+		model: "gpt-4",
+		provider: "openai",
+		castaiApiKey: "key-1",
+		providerName: "pi-otel",
+		inputTokens: 0,
+		outputTokens: 0,
+		totalTokens: 0,
+		cacheReadTokens: 0,
+		cacheWriteTokens: 0,
+		castaiApiKeyMetadata: { id: "1", name: "", ownerType: "", ownerId: "", ownerEmail: "" },
+		...overrides,
+	}
+}
+
+function makeModelCost(overrides: Partial<import("./types.js").ModelCost> = {}): import("./types.js").ModelCost {
+	return {
+		model: "gpt-4",
+		provider: "openai",
+		castaiApiKey: "key-1",
+		providerName: "pi-otel",
+		totalCost: "0",
+		totalCostPerMillionTokens: "0",
+		castaiApiKeyMetadata: { id: "1", name: "", ownerType: "", ownerId: "", ownerEmail: "" },
+		inputTokenCost: "0",
+		outputTokenCost: "0",
+		...overrides,
+	}
+}
+
+describe("formatAnalyticsVisual", () => {
+	it("uses new tokens field when present", () => {
+		const data: GenerateAnalyticsResponse = {
+			stepDuration: "0s",
+			tokens: {
+				items: [
+					{
+						executionTime: "2026-06-09T09:00:00Z",
+						models: [
+							makeModelTokenStat({
+								model: "gpt-4",
+								providerName: "pi-otel",
+								inputTokens: 1000,
+								outputTokens: 500,
+							}),
+							makeModelTokenStat({
+								model: "gpt-4",
+								providerName: "cloud-code-otel",
+								inputTokens: 2000,
+								outputTokens: 1000,
+							}),
+						],
+					},
+				],
+			},
+		}
+
+		const lines = formatAnalyticsVisual(data, mockTheme)
+		const joined = lines.join("\n")
+
+		// Should show gpt-4 aggregated by source
+		expect(joined).toContain("gpt-4")
+		expect(joined).toContain("Kimchi")
+		expect(joined).toContain("Claude Code")
+		// Total input = 3000, output = 1500
+		expect(joined).toContain("3.0k")
+		expect(joined).toContain("1.5k")
+	})
+
+	it("sums token counts across multiple execution times for same model+source", () => {
+		const data: GenerateAnalyticsResponse = {
+			stepDuration: "0s",
+			tokens: {
+				items: [
+					{
+						executionTime: "2026-06-09T09:00:00Z",
+						models: [
+							makeModelTokenStat({
+								model: "gpt-4",
+								providerName: "pi-otel",
+								inputTokens: 1000,
+								outputTokens: 500,
+							}),
+						],
+					},
+					{
+						executionTime: "2026-06-09T10:00:00Z",
+						models: [
+							makeModelTokenStat({
+								model: "gpt-4",
+								providerName: "pi-otel",
+								inputTokens: 2000,
+								outputTokens: 1000,
+							}),
+						],
+					},
+				],
+			},
+		}
+
+		const lines = formatAnalyticsVisual(data, mockTheme)
+		const joined = lines.join("\n")
+
+		// Input = 1000 + 2000 = 3000, Output = 500 + 1000 = 1500
+		expect(joined).toContain("3.0k")
+		expect(joined).toContain("1.5k")
+	})
+
+	it("coalesces undefined token values to 0", () => {
+		const data: GenerateAnalyticsResponse = {
+			stepDuration: "0s",
+			tokens: {
+				items: [
+					{
+						executionTime: "2026-06-09T09:00:00Z",
+						models: [
+							{
+								model: "gpt-4",
+								provider: "openai",
+								castaiApiKey: "key-1",
+								providerName: "pi-otel",
+								inputTokens: undefined as unknown as number,
+								outputTokens: 500,
+								totalTokens: 500,
+								cacheReadTokens: 0,
+								cacheWriteTokens: 0,
+								castaiApiKeyMetadata: { id: "1", name: "", ownerType: "", ownerId: "", ownerEmail: "" },
+							},
+						],
+					},
+				],
+			},
+		}
+
+		const lines = formatAnalyticsVisual(data, mockTheme)
+		const joined = lines.join("\n")
+
+		expect(joined).toContain("500")
+	})
+})
+
+describe("formatAnalyticsSummary", () => {
+	it("uses new tokens field when present", () => {
+		const data: GenerateAnalyticsResponse = {
+			stepDuration: "0s",
+			tokens: {
+				items: [
+					{
+						executionTime: "2026-06-09T09:00:00Z",
+						models: [makeModelTokenStat({ inputTokens: 3000, outputTokens: 1500 })],
+					},
+				],
+			},
+		}
+
+		const lines = formatAnalyticsSummary(data, mockTheme)
+		const joined = lines.join("\n")
+
+		expect(joined).toContain("4.5k")
+		expect(joined).toContain("3.0k")
+		expect(joined).toContain("1.5k")
+	})
+
+	it("aggregates model and source correctly", () => {
+		const data: GenerateAnalyticsResponse = {
+			stepDuration: "0s",
+			tokens: {
+				items: [
+					{
+						executionTime: "2026-06-09T09:00:00Z",
+						models: [
+							makeModelTokenStat({
+								model: "gpt-4",
+								providerName: "pi-otel",
+								inputTokens: 3000,
+								outputTokens: 1500,
+							}),
+						],
+					},
+				],
+			},
+		}
+
+		const lines = formatAnalyticsSummary(data, mockTheme)
+		const joined = lines.join("\n")
+
+		expect(joined).toContain("4.5k")
+		expect(joined).toContain("3.0k")
+		expect(joined).toContain("1.5k")
 	})
 })

--- a/src/extensions/stats/types.ts
+++ b/src/extensions/stats/types.ts
@@ -38,22 +38,46 @@ export interface GenerateAnalyticsResponse {
 	comparison?: Comparison
 	cost?: Cost
 	apiCalls?: ApiCalls
-	inputTokens?: Tokens
-	outputTokens?: Tokens
 	errors?: Errors
 	ttft?: Ttft
 	requestDuration?: RequestDuration
 	hostedModels?: HostedModels
+	tokens?: TokensDetail
 	stepDuration: string
 	mostRecentTime?: string
 }
 
+/**
+ * Detailed token metrics with per-model breakdowns including cache tokens.
+ * Used when the API returns the new unified tokens structure.
+ */
+export interface TokensDetail {
+	items: TokenDetailItem[]
+}
+
+export interface TokenDetailItem {
+	executionTime: string
+	models: ModelTokenStat[]
+}
+
+export interface ModelTokenStat {
+	model: string
+	provider: string
+	castaiApiKey: string
+	providerName: string
+	inputTokens: number
+	outputTokens: number
+	totalTokens: number
+	cacheReadTokens: number
+	cacheWriteTokens: number
+	castaiApiKeyMetadata: CastAiApiKeyMetadata
+}
+
 export interface Comparison {
-	inputTokens?: ComparisonValue
-	outputTokens?: ComparisonValue
 	apiCalls?: ComparisonValue
 	errors?: ComparisonValue
 	cost?: ComparisonValue
+	tokens?: ComparisonValue
 }
 
 export interface ComparisonValue {
@@ -100,17 +124,7 @@ export interface ApiCallItem {
 	models: ModelStatItem[]
 }
 
-export interface Tokens {
-	items: TokenItem[]
-}
-
-// Token items have models array like cost
-export interface TokenItem {
-	executionTime: string
-	models: ModelStatItem[]
-}
-
-// Model stats used in apiCalls and tokens
+// Model stats used in apiCalls
 export interface ModelStatItem {
 	model: string
 	provider: string

--- a/src/extensions/stats/visual.ts
+++ b/src/extensions/stats/visual.ts
@@ -140,8 +140,8 @@ export function formatAnalyticsVisual(
 		}
 	}
 
-	if (data.inputTokens?.items) {
-		for (const item of data.inputTokens.items) {
+	if (data.tokens?.items) {
+		for (const item of data.tokens.items) {
 			if (item.models) {
 				for (const model of item.models) {
 					const source = getSourceName(model.providerName)
@@ -155,29 +155,8 @@ export function formatAnalyticsVisual(
 						inputCost: 0,
 						outputCost: 0,
 					}
-					stats.inputTokens += model.totalCount || 0
-					modelStats.set(key, stats)
-				}
-			}
-		}
-	}
-
-	if (data.outputTokens?.items) {
-		for (const item of data.outputTokens.items) {
-			if (item.models) {
-				for (const model of item.models) {
-					const source = getSourceName(model.providerName)
-					const key = `${model.model}\t${source}`
-					const stats = modelStats.get(key) || {
-						modelName: model.model,
-						source,
-						cost: 0,
-						inputTokens: 0,
-						outputTokens: 0,
-						inputCost: 0,
-						outputCost: 0,
-					}
-					stats.outputTokens += model.totalCount || 0
+					stats.inputTokens += model.inputTokens || 0
+					stats.outputTokens += model.outputTokens || 0
 					modelStats.set(key, stats)
 				}
 			}


### PR DESCRIPTION
Use new unified `tokens` field in analytics API response: the analytics endpoint now returns a single `tokens` field containing per-model inputTokens, outputTokens, cacheReadTokens, and cacheWriteTokens instead of separate top-level inputTokens and outputTokens arrays.
