### PR TITLE
fix(terminal-bench): harden kimchi agents

### DIFF
--- a/benchmark/terminal-bench-2/pyproject.toml
+++ b/benchmark/terminal-bench-2/pyproject.toml
@@ -4,10 +4,11 @@ version = "0.1.0"
 description = "Harbor terminal-bench agent that runs the kimchi binary inside the task container."
 requires-python = ">=3.14"
 dependencies = [
-    "harbor>=0.4.0",
+    "harbor>=0.13.2",
     "pydantic>=2.11",
     "pydantic-settings>=2.5",
     "httpx>=0.27",
+    "tenacity>=9.1",
 ]
 
 [dependency-groups]

--- a/benchmark/terminal-bench-2/src/kimchi_agent/claude_code_kimchi.py
+++ b/benchmark/terminal-bench-2/src/kimchi_agent/claude_code_kimchi.py
@@ -1,3 +1,4 @@
+import asyncio
 import json
 import shlex
 from typing import Any
@@ -7,6 +8,7 @@ from harbor.agents.installed.claude_code import ClaudeCode
 from harbor.environments.base import BaseEnvironment
 from harbor.models.agent.context import AgentContext
 from harbor.models.trial.paths import EnvironmentPaths
+from tenacity import AsyncRetrying, RetryCallState, retry_if_exception, stop_after_attempt, wait_chain, wait_fixed
 
 from kimchi_agent.gateway import (
     KIMCHI_ANTHROPIC_BASE_URL,
@@ -18,6 +20,7 @@ CLAUDE_CODE_AUTO_COMPACT_PERCENT = 85
 CLAUDE_CODE_OUTPUT_RESERVE_TOKENS = 32_768
 CLAUDE_CODE_CONTEXT_SAFETY_MARGIN_TOKENS = 8_192
 CLAUDE_CODE_OUTPUT_PATH = "/logs/agent/claude-code.txt"
+CLAUDE_CODE_INSTALL_RETRY_DELAYS_SEC = (5, 15)
 RETRYABLE_API_STATUSES = frozenset({408, 409, 425, 429, 500, 502, 503, 504, 524, 529})
 RETRYABLE_API_ERROR_MESSAGE_LIMIT = 2_000
 CLAUDE_PASSTHROUGH_ENV_PREFIXES = ("CLAUDE_CODE_", "OTEL_")
@@ -92,6 +95,50 @@ class ClaudeCodeKimchi(KimchiGatewayMixin, ClaudeCode):
         percent_window = context_window * CLAUDE_CODE_AUTO_COMPACT_PERCENT // 100
         reserved_window = context_window - output_reserve - safety_margin
         return str(max(1, min(percent_window, reserved_window)))
+
+    @staticmethod
+    def _is_retryable_claude_install_error(exc: NonZeroAgentExitCodeError) -> bool:
+        message = str(exc)
+        if "Command failed (exit 137):" not in message or "claude --version" not in message:
+            return False
+
+        return any(
+            marker in message
+            for marker in (
+                "@anthropic-ai/claude-code",
+                "claude.ai/install.sh",
+                "claude-code-releases/bootstrap.sh",
+            )
+        )
+
+    @classmethod
+    def _is_retryable_install_exception(cls, exc: BaseException) -> bool:
+        return isinstance(exc, NonZeroAgentExitCodeError) and cls._is_retryable_claude_install_error(exc)
+
+    def _log_install_retry(self, retry_state: RetryCallState) -> None:
+        delay_sec = retry_state.next_action.sleep if retry_state.next_action else None
+        self.logger.warning(
+            "Claude Code installer was killed; retrying install",
+            extra={
+                "attempt": retry_state.attempt_number,
+                "max_attempts": len(CLAUDE_CODE_INSTALL_RETRY_DELAYS_SEC) + 1,
+                "delay_sec": delay_sec,
+            },
+        )
+
+    async def install(self, environment: BaseEnvironment) -> None:
+        retrying = AsyncRetrying(
+            retry=retry_if_exception(self._is_retryable_install_exception),
+            wait=wait_chain(*(wait_fixed(delay) for delay in CLAUDE_CODE_INSTALL_RETRY_DELAYS_SEC)),
+            stop=stop_after_attempt(len(CLAUDE_CODE_INSTALL_RETRY_DELAYS_SEC) + 1),
+            before_sleep=self._log_install_retry,
+            sleep=asyncio.sleep,
+            reraise=True,
+        )
+
+        async for attempt in retrying:
+            with attempt:
+                await super().install(environment)
 
     def _build_env(self) -> dict[str, str]:
         api_key = self._required_kimchi_api_key()

--- a/benchmark/terminal-bench-2/src/kimchi_agent/claude_code_kimchi_test.py
+++ b/benchmark/terminal-bench-2/src/kimchi_agent/claude_code_kimchi_test.py
@@ -4,7 +4,7 @@ import tempfile
 import unittest
 from pathlib import Path
 from typing import ClassVar
-from unittest.mock import patch
+from unittest.mock import AsyncMock, patch
 
 from harbor.agents.installed.base import NonZeroAgentExitCodeError
 from harbor.environments.base import ExecResult
@@ -12,12 +12,14 @@ from harbor.models.agent.context import AgentContext
 
 from kimchi_agent.claude_code_kimchi import (
     CLAUDE_CODE_CONTEXT_SAFETY_MARGIN_TOKENS,
+    CLAUDE_CODE_INSTALL_RETRY_DELAYS_SEC,
     CLAUDE_CODE_OUTPUT_RESERVE_TOKENS,
     KIMCHI_ANTHROPIC_BASE_URL,
     ClaudeCodeKimchi,
     RetryableApiError,
 )
 from kimchi_agent.gateway import (
+    FETCH_TIMEOUT_SEC,
     KIMCHI_MODELS_METADATA_URL,
     KimchiModelMetadata,
     KimchiModelsMetadataResponse,
@@ -82,6 +84,22 @@ class FailingClaudeCodeKimchi(RecordingClaudeCodeKimchi):
             raise self.failure
 
 
+class InstallRecordingClaudeCodeKimchi(ClaudeCodeKimchi):
+    def __init__(self, *args, failures: list[Exception] | None = None, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.failures = list(failures or [])
+        self.root_commands: list[str] = []
+        self.agent_commands: list[str] = []
+
+    async def exec_as_root(self, _environment, command: str, env=None, cwd=None, timeout_sec=None):
+        self.root_commands.append(command)
+
+    async def exec_as_agent(self, _environment, command: str, env=None, cwd=None, timeout_sec=None):
+        self.agent_commands.append(command)
+        if self.failures:
+            raise self.failures.pop(0)
+
+
 class FakeEnvironment:
     def __init__(self, stdout: str, return_code: int = 0) -> None:
         self.stdout = stdout
@@ -103,6 +121,59 @@ class ClaudeCodeKimchiTest(unittest.IsolatedAsyncioTestCase):
             os.environ.pop("KIMCHI_API_KEY", None)
         else:
             os.environ["KIMCHI_API_KEY"] = self._old_api_key
+
+    @staticmethod
+    def _killed_claude_install_error() -> NonZeroAgentExitCodeError:
+        return NonZeroAgentExitCodeError(
+            "Command failed (exit 137): set -euo pipefail; "
+            "curl -fsSL https://downloads.claude.ai/claude-code-releases/bootstrap.sh | bash -s -- && "
+            "export PATH=\"$HOME/.local/bin:$PATH\" && claude --version\n"
+            "stdout: Installing Claude Code native build latest..."
+            "bash: line 158: 235 Killed \"$binary_path\" install\n"
+            "stderr: None"
+        )
+
+    async def test_retries_killed_claude_code_installer(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            agent = InstallRecordingClaudeCodeKimchi(
+                logs_dir=Path(tmp) / "jobs" / "run-1" / "task__trial" / "agent",
+                model_name="kimchi-dev/kimi-k2.5",
+                failures=[self._killed_claude_install_error()],
+            )
+
+            with (
+                patch("kimchi_agent.claude_code_kimchi.asyncio.sleep", new_callable=AsyncMock) as sleep,
+                patch.object(agent.logger, "warning") as warning,
+            ):
+                await agent.install(object())
+
+        self.assertEqual(len(agent.root_commands), 2)
+        self.assertEqual(len(agent.agent_commands), 2)
+        sleep.assert_awaited_once_with(CLAUDE_CODE_INSTALL_RETRY_DELAYS_SEC[0])
+        warning.assert_called_once()
+
+    async def test_non_installer_exit_137_is_not_retried(self) -> None:
+        original_error = NonZeroAgentExitCodeError(
+            "Command failed (exit 137): export PATH=\"$HOME/.local/bin:$PATH\"; "
+            "claude --verbose --output-format=stream-json --print -- 'solve it'"
+        )
+        with tempfile.TemporaryDirectory() as tmp:
+            agent = InstallRecordingClaudeCodeKimchi(
+                logs_dir=Path(tmp) / "jobs" / "run-1" / "task__trial" / "agent",
+                model_name="kimchi-dev/kimi-k2.5",
+                failures=[original_error],
+            )
+
+            with (
+                patch("kimchi_agent.claude_code_kimchi.asyncio.sleep", new_callable=AsyncMock) as sleep,
+                self.assertRaises(NonZeroAgentExitCodeError) as raised,
+            ):
+                await agent.install(object())
+
+        self.assertIs(raised.exception, original_error)
+        self.assertEqual(len(agent.root_commands), 1)
+        self.assertEqual(len(agent.agent_commands), 1)
+        sleep.assert_not_awaited()
 
     async def test_runs_claude_code_against_selected_kimchi_model(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:
@@ -395,7 +466,7 @@ class ClaudeCodeKimchiTest(unittest.IsolatedAsyncioTestCase):
 
         http_get.assert_called_once()
         self.assertEqual(http_get.call_args.kwargs["headers"], {"Authorization": "Bearer test-key"})
-        self.assertEqual(http_get.call_args.kwargs["timeout"], 5)
+        self.assertEqual(http_get.call_args.kwargs["timeout"], FETCH_TIMEOUT_SEC)
         self.assertEqual(http_get.call_args.args, (KIMCHI_MODELS_METADATA_URL,))
 
 

--- a/benchmark/terminal-bench-2/src/kimchi_agent/gateway.py
+++ b/benchmark/terminal-bench-2/src/kimchi_agent/gateway.py
@@ -4,6 +4,7 @@ from collections.abc import Iterable
 
 import httpx
 from pydantic import BaseModel, ConfigDict, Field, StrictBool, StrictInt, ValidationError
+from tenacity import retry, retry_if_exception, stop_after_attempt, wait_exponential
 
 KIMCHI_API = "https://llm.kimchi.dev"
 KIMCHI_PROVIDER = "kimchi-dev"
@@ -12,7 +13,10 @@ KIMCHI_ANTHROPIC_BASE_URL = f"{KIMCHI_API}/anthropic"
 KIMCHI_MODELS_METADATA_URL = f"{KIMCHI_API}/v1/models/metadata?include_in_cli=true"
 KIMCHI_API_KEY_ENV = "KIMCHI_API_KEY"
 
-FETCH_TIMEOUT_SEC = 5
+FETCH_TIMEOUT_SEC = 20
+FETCH_MAX_ATTEMPTS = 3
+FETCH_RETRY_BACKOFF_SEC = 1
+RETRYABLE_FETCH_STATUSES = frozenset({408, 425, 429, 500, 502, 503, 504, 524, 529})
 
 
 class KimchiModelLimits(BaseModel):
@@ -36,6 +40,14 @@ class KimchiModelsMetadataResponse(BaseModel):
     model_config = ConfigDict(extra="ignore")
 
     models: list[KimchiModelMetadata] = Field(min_length=1)
+
+
+def _is_retryable_metadata_fetch_error(exc: BaseException) -> bool:
+    if isinstance(exc, (httpx.TimeoutException, httpx.NetworkError)):
+        return True
+    if isinstance(exc, httpx.HTTPStatusError):
+        return exc.response.status_code in RETRYABLE_FETCH_STATUSES
+    return False
 
 
 class KimchiGatewayMixin:
@@ -95,17 +107,34 @@ class KimchiGatewayMixin:
             )
         return api_key
 
+    @retry(
+        retry=retry_if_exception(_is_retryable_metadata_fetch_error),
+        stop=stop_after_attempt(FETCH_MAX_ATTEMPTS),
+        wait=wait_exponential(
+            multiplier=FETCH_RETRY_BACKOFF_SEC,
+            min=FETCH_RETRY_BACKOFF_SEC,
+            max=FETCH_RETRY_BACKOFF_SEC * (FETCH_MAX_ATTEMPTS - 1),
+        ),
+        reraise=True,
+    )
+    def _fetch_model_metadata_body(self, api_key: str) -> object:
+        response = httpx.get(
+            KIMCHI_MODELS_METADATA_URL,
+            headers={"Authorization": f"Bearer {api_key}"},
+            timeout=FETCH_TIMEOUT_SEC,
+        )
+        response.raise_for_status()
+        return response.json()
+
     def _fetch_model_metadata(self, api_key: str) -> list[KimchiModelMetadata]:
         try:
-            response = httpx.get(
-                KIMCHI_MODELS_METADATA_URL,
-                headers={"Authorization": f"Bearer {api_key}"},
-                timeout=FETCH_TIMEOUT_SEC,
-            )
-            response.raise_for_status()
-            body = response.json()
+            body = self._fetch_model_metadata_body(api_key)
         except httpx.HTTPStatusError as exc:
             raise RuntimeError(f"Failed to fetch Kimchi model metadata: HTTP {exc.response.status_code}") from exc
+        except (httpx.TimeoutException, httpx.NetworkError) as exc:
+            raise RuntimeError(
+                f"Failed to fetch Kimchi model metadata after {FETCH_MAX_ATTEMPTS} attempts: {exc}"
+            ) from exc
         except (httpx.HTTPError, json.JSONDecodeError) as exc:
             raise RuntimeError(f"Failed to fetch Kimchi model metadata: {exc}") from exc
 

--- a/benchmark/terminal-bench-2/src/kimchi_agent/opencode_kimchi_test.py
+++ b/benchmark/terminal-bench-2/src/kimchi_agent/opencode_kimchi_test.py
@@ -11,6 +11,7 @@ from harbor.models.agent.context import AgentContext
 from harbor.models.task.config import MCPServerConfig
 
 from kimchi_agent.gateway import (
+    FETCH_TIMEOUT_SEC,
     KIMCHI_MODELS_METADATA_URL,
     KIMCHI_OPENAI_BASE_URL,
     KimchiModelMetadata,
@@ -299,7 +300,7 @@ class OpenCodeKimchiTest(unittest.IsolatedAsyncioTestCase):
 
         http_get.assert_called_once()
         self.assertEqual(http_get.call_args.kwargs["headers"], {"Authorization": "Bearer test-key"})
-        self.assertEqual(http_get.call_args.kwargs["timeout"], 5)
+        self.assertEqual(http_get.call_args.kwargs["timeout"], FETCH_TIMEOUT_SEC)
         self.assertEqual(http_get.call_args.args, (KIMCHI_MODELS_METADATA_URL,))
 
 

--- a/benchmark/terminal-bench-2/uv.lock
+++ b/benchmark/terminal-bench-2/uv.lock
@@ -491,7 +491,7 @@ wheels = [
 
 [[package]]
 name = "harbor"
-version = "0.4.0"
+version = "0.13.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "claude-agent-sdk" },
@@ -516,9 +516,9 @@ dependencies = [
     { name = "typer" },
     { name = "uvicorn" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/e8/a4/4f1add77047bae43e0b172d7801dcab2b9a9a6d5903e154b7186ebc4acd7/harbor-0.4.0.tar.gz", hash = "sha256:bc0260b7db3e810399401f37456f4aabbc6b82f659e159acf896d72762527c1c", size = 882052, upload-time = "2026-04-16T04:19:33.28Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/09/d2/8ea1fa703ebc8acd15fffc020555259dd1bb4f4188e830b5467ca0fd1950/harbor-0.13.2.tar.gz", hash = "sha256:e5cf94f9dac9bb465d61f37a689679b69ecd1987bae1ad48714dc641bea2f699", size = 1154370, upload-time = "2026-06-11T00:15:35.44Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/7b/2d/a731ae57852a97547fc6d913ecc9894c1b395fe60c125d2e0fcfe8adf662/harbor-0.4.0-py3-none-any.whl", hash = "sha256:133c0a45114f40b9214c6aadde6c108c98f890e95656aba08681ba554d69378c", size = 1006416, upload-time = "2026-04-16T04:19:31.507Z" },
+    { url = "https://files.pythonhosted.org/packages/e6/ae/fc41d4d2bf830a878cf778877aafe90c05ef45651dab05dee3df7e463e1d/harbor-0.13.2-py3-none-any.whl", hash = "sha256:7a60207965755268fb0a4748a553ce92ed91ce7b32805e7f0c8fea1ed61567b6", size = 1313409, upload-time = "2026-06-11T00:15:36.98Z" },
 ]
 
 [[package]]
@@ -636,14 +636,14 @@ wheels = [
 
 [[package]]
 name = "importlib-metadata"
-version = "9.0.0"
+version = "8.9.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "zipp" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/a9/01/15bb152d77b21318514a96f43af312635eb2500c96b55398d020c93d86ea/importlib_metadata-9.0.0.tar.gz", hash = "sha256:a4f57ab599e6a2e3016d7595cfd72eb4661a5106e787a95bcc90c7105b831efc", size = 56405, upload-time = "2026-03-20T06:42:56.999Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/e7/72/c600ae4f68c28fc19f9c31b9403053e5dbb8cace2e6842c7b7c3e4d42fe9/importlib_metadata-8.9.0.tar.gz", hash = "sha256:58850626cef4bd2df100378b0f2aea9724a7b92f10770d547725b047078f99ee", size = 56140, upload-time = "2026-03-20T16:56:26.362Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/38/3d/2d244233ac4f76e38533cfcb2991c9eb4c7bf688ae0a036d30725b8faafe/importlib_metadata-9.0.0-py3-none-any.whl", hash = "sha256:2d21d1cc5a017bd0559e36150c21c830ab1dc304dedd1b7ea85d20f45ef3edd7", size = 27789, upload-time = "2026-03-20T06:42:55.665Z" },
+    { url = "https://files.pythonhosted.org/packages/7d/f9/97f2ca8bb3ec6e4b1d64f983ebe98b9a192faddff67fac3d6303a537e670/importlib_metadata-8.9.0-py3-none-any.whl", hash = "sha256:e0f761b6ea91ced3b0844c14c9d955224d538105921f8e6754c00f6ca79fba7f", size = 27220, upload-time = "2026-03-20T16:56:25.07Z" },
 ]
 
 [[package]]
@@ -729,6 +729,7 @@ dependencies = [
     { name = "httpx" },
     { name = "pydantic" },
     { name = "pydantic-settings" },
+    { name = "tenacity" },
 ]
 
 [package.dev-dependencies]
@@ -738,10 +739,11 @@ dev = [
 
 [package.metadata]
 requires-dist = [
-    { name = "harbor", specifier = ">=0.4.0" },
+    { name = "harbor", specifier = ">=0.13.2" },
     { name = "httpx", specifier = ">=0.27" },
     { name = "pydantic", specifier = ">=2.11" },
     { name = "pydantic-settings", specifier = ">=2.5" },
+    { name = "tenacity", specifier = ">=9.1" },
 ]
 
 [package.metadata.requires-dev]
@@ -749,7 +751,7 @@ dev = [{ name = "ruff", specifier = ">=0.7" }]
 
 [[package]]
 name = "litellm"
-version = "1.83.0"
+version = "1.88.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "aiohttp" },
@@ -765,9 +767,9 @@ dependencies = [
     { name = "tiktoken" },
     { name = "tokenizers" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/22/92/6ce9737554994ca8e536e5f4f6a87cc7c4774b656c9eb9add071caf7d54b/litellm-1.83.0.tar.gz", hash = "sha256:860bebc76c4bb27b4cf90b4a77acd66dba25aced37e3db98750de8a1766bfb7a", size = 17333062, upload-time = "2026-03-31T05:08:25.331Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/16/ea/f99ececb7f22703fe120f1d8be9ffb749ec9453fbbbbbebc0d6a6b4d7864/litellm-1.88.1.tar.gz", hash = "sha256:89c6b74cc7912d6365793006ff951c0450fe847625008dfe49de8a7dc4529aa5", size = 13885969, upload-time = "2026-06-09T01:06:25.192Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/19/2c/a670cc050fcd6f45c6199eb99e259c73aea92edba8d5c2fc1b3686d36217/litellm-1.83.0-py3-none-any.whl", hash = "sha256:88c536d339248f3987571493015784671ba3f193a328e1ea6780dbebaa2094a8", size = 15610306, upload-time = "2026-03-31T05:08:21.987Z" },
+    { url = "https://files.pythonhosted.org/packages/42/9a/8f8909201b4bebaf96498c09226f6baa8540086a4c4188ad57d7dfbd97c1/litellm-1.88.1-py3-none-any.whl", hash = "sha256:369b84e57d9426582ddc35e731956ddb6618cda97cc44e4e4d2dfa75982a6e3a", size = 15276206, upload-time = "2026-06-09T01:06:16.72Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Retry transient Kimchi model metadata fetches and killed Claude Code installer runs. Keep the change scoped to Terminal Bench agent code and tests, with no GitLab pipeline scripts included.

## Description

This hardens the Terminal Bench Kimchi agents against transient setup failures.

 Changes:
  - Retry transient Kimchi model metadata fetch failures with tenacity.
  - Retry Claude Code installer runs when the installer process is killed.
  - Add focused tests for metadata retry behavior and Claude Code install retry handling.
  - Update Terminal Bench dependency lockfile for the added retry dependency.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
