### PR TITLE
feat: SubagentStart/Stop and StopFail hook support

### DIFF
--- a/docs/hooks.md
+++ b/docs/hooks.md
@@ -146,6 +146,8 @@ Supported events:
 - `Stop` — fires once when the agent finishes responding (pi `agent_end`); a `{"decision":"block","reason":"..."}` result continues the run, with `stop_hook_active` set on re-entry
 - `TaskCompleted` — fires at the end of each turn (pi `turn_end`); observer-only, block decisions are ignored
 - `TurnStart`, `MessageStart`, `MessageEnd`, `ModelSelect`, `UserBash` — kimchi-specific observer hooks for pi events with no Claude Code equivalent
+- `SubagentStart` — fires when an `Agent` tool subagent spawns (kimchi `subagents:started` bus event); observer-only. Payload adds `subagent_id`, `subagent_type`, `description`, `visibility`
+- `SubagentStop` — fires when a subagent completes or fails (`subagents:completed` / `subagents:failed`); observer-only. Payload adds the `SubagentStart` fields plus `status`, `result`, `error`, `abort_reason`, `duration_ms`, `tool_uses`, `tokens`, and `is_error` (`true` on the failed path: status `error`, `stopped`, or `aborted`). Both hooks also fire for `visibility: "system"` agents, which are hidden from the subagent widget for UI reasons only — filter on the `visibility` field if you want user-visible agents only
 - `SessionEnd`
 
 Plugin packages installed via `kimchi install` may ship a `hooks/hooks.json` (or `.claude-plugin/hooks/hooks.json`). Those hooks honor the same full event set as the adapter above; `SessionStart` context from packages is injected into the system prompt.

--- a/docs/hooks.md
+++ b/docs/hooks.md
@@ -143,8 +143,9 @@ Supported events:
 - `PreCompact`
 - `PostCompact`
 - `UserPromptSubmit`
-- `Stop` — fires once when the agent finishes responding (pi `agent_end`); a `{"decision":"block","reason":"..."}` result continues the run, with `stop_hook_active` set on re-entry
-- `TaskCompleted` — fires at the end of each turn (pi `turn_end`); observer-only, block decisions are ignored
+- `Stop` — fires once when the agent finishes responding (pi `agent_end`); a `{"decision":"block","reason":"..."}` result continues the run, with `stop_hook_active` set on re-entry. Payload includes `stop_reason` and `error_message` from the final assistant message
+- `StopFail` — fires in addition to `Stop` only when the run ends with `stop_reason` `error` or `aborted` (`Stop` still fires for all runs). Same payload and block/continuation semantics as `Stop`, plus `is_error: true`; use `stop_reason` to distinguish provider errors from user aborts
+- `TaskCompleted` — fires at the end of each turn (pi `turn_end`); observer-only, block decisions are ignored. ⚠️ Note: this diverges from Claude Code, where `TaskCompleted` fires when a task-list item is marked completed (via the `TaskUpdate` tool) and can block; kimchi has no task-list tool, so this name is bound to per-turn semantics instead
 - `TurnStart`, `MessageStart`, `MessageEnd`, `ModelSelect`, `UserBash` — kimchi-specific observer hooks for pi events with no Claude Code equivalent
 - `SubagentStart` — fires when an `Agent` tool subagent spawns (kimchi `subagents:started` bus event); observer-only. Payload adds `subagent_id`, `subagent_type`, `description`, `visibility`
 - `SubagentStop` — fires when a subagent completes or fails (`subagents:completed` / `subagents:failed`); observer-only. Payload adds the `SubagentStart` fields plus `status`, `result`, `error`, `abort_reason`, `duration_ms`, `tool_uses`, `tokens`, and `is_error` (`true` on the failed path: status `error`, `stopped`, or `aborted`). Both hooks also fire for `visibility: "system"` agents, which are hidden from the subagent widget for UI reasons only — filter on the `visibility` field if you want user-visible agents only

--- a/src/extensions/hook-adapters/adapter.integration.test.ts
+++ b/src/extensions/hook-adapters/adapter.integration.test.ts
@@ -116,6 +116,10 @@ function fakePi() {
 			handlers[event] ??= []
 			handlers[event].push(handler)
 		}),
+		events: {
+			emit: vi.fn(),
+			on: vi.fn(() => () => {}),
+		},
 		sendMessage: vi.fn(),
 		sendUserMessage: vi.fn(),
 	}

--- a/src/extensions/hook-adapters/adapter.test.ts
+++ b/src/extensions/hook-adapters/adapter.test.ts
@@ -501,6 +501,131 @@ describe("hook adapter command execution", () => {
 		expect(mockSpawn).not.toHaveBeenCalled()
 	})
 
+	it("runs SubagentStart and SubagentStop hooks from subagent bus events", async () => {
+		writeJson(join(dir, "home", ".claude", "settings.json"), {
+			hooks: {
+				SubagentStart: [{ hooks: [{ type: "command", command: "subagent-start" }] }],
+				SubagentStop: [{ hooks: [{ type: "command", command: "subagent-stop" }] }],
+			},
+		})
+		const startHook = mockBlockingHook()
+		const stopHook = mockBlockingHook()
+		const pi = fakePi()
+		claudeCodeHooksAdapter(pi as never)
+
+		await pi.handlers.turn_start[0]({ type: "turn_start", turnIndex: 1 }, fakeCtx())
+		await pi.eventHandlers["subagents:started"][0]({
+			id: "agent-1",
+			type: "explore",
+			description: "scan the repo",
+			visibility: "user",
+		})
+		await pi.eventHandlers["subagents:completed"][0]({
+			id: "agent-1",
+			type: "explore",
+			description: "scan the repo",
+			visibility: "user",
+			status: "completed",
+			result: "all good",
+			toolUses: 4,
+			durationMs: 1234,
+			tokens: { input: 10, output: 5, total: 15 },
+		})
+
+		expect(mockSpawn).toHaveBeenCalledTimes(2)
+		expect(hookPayload(startHook)).toMatchObject({
+			hook_event_name: "SubagentStart",
+			subagent_id: "agent-1",
+			subagent_type: "explore",
+			description: "scan the repo",
+			visibility: "user",
+		})
+		expect(hookPayload(stopHook)).toMatchObject({
+			hook_event_name: "SubagentStop",
+			subagent_id: "agent-1",
+			subagent_type: "explore",
+			status: "completed",
+			result: "all good",
+			is_error: false,
+			duration_ms: 1234,
+			tool_uses: 4,
+			tokens: { input: 10, output: 5, total: 15 },
+		})
+	})
+
+	it("marks SubagentStop is_error for failed subagents", async () => {
+		writeJson(join(dir, "home", ".claude", "settings.json"), {
+			hooks: {
+				SubagentStop: [{ hooks: [{ type: "command", command: "subagent-stop" }] }],
+			},
+		})
+		const stopHook = mockBlockingHook()
+		const pi = fakePi()
+		claudeCodeHooksAdapter(pi as never)
+
+		await pi.handlers.turn_start[0]({ type: "turn_start", turnIndex: 1 }, fakeCtx())
+		await pi.eventHandlers["subagents:failed"][0]({
+			id: "agent-2",
+			type: "claude",
+			description: "doomed task",
+			visibility: "user",
+			status: "aborted",
+			abortReason: "user_abort",
+			error: "aborted by user",
+			toolUses: 0,
+			durationMs: 50,
+		})
+
+		expect(hookPayload(stopHook)).toMatchObject({
+			hook_event_name: "SubagentStop",
+			subagent_id: "agent-2",
+			status: "aborted",
+			abort_reason: "user_abort",
+			error: "aborted by user",
+			is_error: true,
+		})
+	})
+
+	it("fires subagent hooks for system-visibility agents", async () => {
+		writeJson(join(dir, "home", ".claude", "settings.json"), {
+			hooks: {
+				SubagentStart: [{ hooks: [{ type: "command", command: "subagent-start" }] }],
+			},
+		})
+		const startHook = mockBlockingHook()
+		const pi = fakePi()
+		claudeCodeHooksAdapter(pi as never)
+
+		await pi.handlers.turn_start[0]({ type: "turn_start", turnIndex: 1 }, fakeCtx())
+		await pi.eventHandlers["subagents:started"][0]({
+			id: "agent-3",
+			type: "summarizer",
+			description: "background summarization",
+			visibility: "system",
+		})
+
+		expect(mockSpawn).toHaveBeenCalledTimes(1)
+		expect(hookPayload(startHook)).toMatchObject({
+			hook_event_name: "SubagentStart",
+			subagent_id: "agent-3",
+			visibility: "system",
+		})
+	})
+
+	it("skips subagent hooks before any extension context is captured", async () => {
+		writeJson(join(dir, "home", ".claude", "settings.json"), {
+			hooks: {
+				SubagentStart: [{ hooks: [{ type: "command", command: "subagent-start" }] }],
+			},
+		})
+		const pi = fakePi()
+		claudeCodeHooksAdapter(pi as never)
+
+		await pi.eventHandlers["subagents:started"][0]({ id: "agent-4", type: "explore" })
+
+		expect(mockSpawn).not.toHaveBeenCalled()
+	})
+
 	it("runs observer hooks for TurnStart, MessageEnd, ModelSelect, and UserBash", async () => {
 		writeJson(join(dir, "home", ".claude", "settings.json"), {
 			hooks: {
@@ -727,12 +852,22 @@ type FakeHandler = (event: unknown, ctx: unknown) => unknown
 
 function fakePi() {
 	const handlers: Record<string, FakeHandler[]> = {}
+	const eventHandlers: Record<string, Array<(data: unknown) => unknown>> = {}
 	return {
 		handlers,
+		eventHandlers,
 		on: vi.fn((event: string, handler: FakeHandler) => {
 			handlers[event] ??= []
 			handlers[event].push(handler)
 		}),
+		events: {
+			emit: vi.fn(),
+			on: vi.fn((channel: string, handler: (data: unknown) => unknown) => {
+				eventHandlers[channel] ??= []
+				eventHandlers[channel].push(handler)
+				return () => {}
+			}),
+		},
 		sendMessage: vi.fn(),
 		sendUserMessage: vi.fn(),
 	}

--- a/src/extensions/hook-adapters/adapter.test.ts
+++ b/src/extensions/hook-adapters/adapter.test.ts
@@ -378,6 +378,84 @@ describe("hook adapter command execution", () => {
 		expect(pi.sendUserMessage).toHaveBeenCalledTimes(1)
 	})
 
+	it("runs StopFail hooks in addition to Stop when the run ends with an error", async () => {
+		writeJson(join(dir, "home", ".claude", "settings.json"), {
+			hooks: {
+				Stop: [{ hooks: [{ type: "command", command: "stop" }] }],
+				StopFail: [{ hooks: [{ type: "command", command: "stop-fail" }] }],
+			},
+		})
+		const stopHook = mockBlockingHook()
+		const failHook = mockBlockingHook()
+		const pi = fakePi()
+		claudeCodeHooksAdapter(pi as never)
+
+		await pi.handlers.agent_end[0](agentEndEvent({ stopReason: "error", errorMessage: "provider exploded" }), fakeCtx())
+
+		expect(mockSpawn).toHaveBeenCalledTimes(2)
+		expect(hookPayload(stopHook)).toMatchObject({
+			hook_event_name: "Stop",
+			stop_reason: "error",
+			error_message: "provider exploded",
+		})
+		expect(hookPayload(failHook)).toMatchObject({
+			hook_event_name: "StopFail",
+			stop_reason: "error",
+			error_message: "provider exploded",
+			is_error: true,
+			last_assistant_message: "done",
+		})
+	})
+
+	it("runs StopFail hooks for aborted runs", async () => {
+		writeJson(join(dir, "home", ".claude", "settings.json"), {
+			hooks: {
+				StopFail: [{ hooks: [{ type: "command", command: "stop-fail" }] }],
+			},
+		})
+		const failHook = mockBlockingHook()
+		const pi = fakePi()
+		claudeCodeHooksAdapter(pi as never)
+
+		await pi.handlers.agent_end[0](agentEndEvent({ stopReason: "aborted" }), fakeCtx())
+
+		expect(hookPayload(failHook)).toMatchObject({
+			hook_event_name: "StopFail",
+			stop_reason: "aborted",
+			error_message: null,
+			is_error: true,
+		})
+	})
+
+	it("skips StopFail hooks when the run ends normally", async () => {
+		writeJson(join(dir, "home", ".claude", "settings.json"), {
+			hooks: {
+				StopFail: [{ hooks: [{ type: "command", command: "stop-fail" }] }],
+			},
+		})
+		const pi = fakePi()
+		claudeCodeHooksAdapter(pi as never)
+
+		await pi.handlers.agent_end[0](agentEndEvent(), fakeCtx())
+
+		expect(mockSpawn).not.toHaveBeenCalled()
+	})
+
+	it("honors a StopFail continuation request like Stop", async () => {
+		writeJson(join(dir, "home", ".claude", "settings.json"), {
+			hooks: {
+				StopFail: [{ hooks: [{ type: "command", command: "stop-fail" }] }],
+			},
+		})
+		mockBlockingHook({ stdout: JSON.stringify({ decision: "block", reason: "Retry the failed run." }) })
+		const pi = fakePi()
+		claudeCodeHooksAdapter(pi as never)
+
+		await pi.handlers.agent_end[0](agentEndEvent({ stopReason: "error" }), fakeCtx())
+
+		expect(pi.sendUserMessage).toHaveBeenCalledWith("Retry the failed run.", { deliverAs: "followUp" })
+	})
+
 	it("runs TaskCompleted hooks per turn without follow-up continuation", async () => {
 		writeJson(join(dir, "home", ".claude", "settings.json"), {
 			hooks: {
@@ -890,12 +968,17 @@ function turnEndEvent(turnIndex: number) {
 	}
 }
 
-function agentEndEvent() {
+function agentEndEvent(stop: { stopReason?: string; errorMessage?: string } = {}) {
 	return {
 		type: "agent_end",
 		messages: [
 			{ role: "user", content: [{ type: "text", text: "do the thing" }] },
-			{ role: "assistant", content: [{ type: "text", text: "done" }] },
+			{
+				role: "assistant",
+				content: [{ type: "text", text: "done" }],
+				stopReason: stop.stopReason ?? "stop",
+				errorMessage: stop.errorMessage,
+			},
 		],
 	}
 }

--- a/src/extensions/hook-adapters/adapter.ts
+++ b/src/extensions/hook-adapters/adapter.ts
@@ -59,6 +59,9 @@ export function createCommandHookAdapter(definition: CommandHookAdapterDefinitio
 		let stopHookFollowUpPending = false
 		let batchedToolResults: Array<{ tool_name: string; tool_use_id: string; is_error: boolean }> = []
 		const pendingSystemPrompt: { context?: string } = {}
+		// Custom bus events (pi.events.on) carry no ExtensionContext, so keep the
+		// most recent one from core events for the subagent lifecycle hooks.
+		let latestCtx: ExtensionContext | undefined
 
 		if (definition.sessionStartDelivery === "systemPrompt") {
 			pi.on("before_agent_start", (event: BeforeAgentStartEvent): BeforeAgentStartEventResult | undefined => {
@@ -72,6 +75,7 @@ export function createCommandHookAdapter(definition: CommandHookAdapterDefinitio
 		pi.on("tool_call", (event, ctx) => runPreToolUse(definition, pi, event, ctx))
 		pi.on("tool_result", (event, ctx) => runPostToolUse(definition, pi, event, ctx))
 		pi.on("session_start", async (event, ctx) => {
+			latestCtx = ctx
 			await runSessionStart(definition, pi, event, ctx, pendingSystemPrompt)
 		})
 		pi.on("session_compact", async (event, ctx) => {
@@ -83,6 +87,7 @@ export function createCommandHookAdapter(definition: CommandHookAdapterDefinitio
 			return runUserPromptSubmit(definition, pi, event, ctx)
 		})
 		pi.on("turn_start", async (event, ctx) => {
+			latestCtx = ctx
 			batchedToolResults = []
 			await runObserver(definition, "TurnStart", ctx, { turn_id: String(event.turnIndex) })
 		})
@@ -134,6 +139,18 @@ export function createCommandHookAdapter(definition: CommandHookAdapterDefinitio
 		})
 		pi.on("session_shutdown", async (event, ctx) => {
 			await runObserver(definition, "SessionEnd", ctx, event as unknown as Record<string, unknown>)
+		})
+		pi.events.on("subagents:started", async (data) => {
+			if (!latestCtx) return
+			await runObserver(definition, "SubagentStart", latestCtx, subagentBasePayload(data))
+		})
+		pi.events.on("subagents:completed", async (data) => {
+			if (!latestCtx) return
+			await runObserver(definition, "SubagentStop", latestCtx, subagentStopPayload(data, false))
+		})
+		pi.events.on("subagents:failed", async (data) => {
+			if (!latestCtx) return
+			await runObserver(definition, "SubagentStop", latestCtx, subagentStopPayload(data, true))
 		})
 	}
 }
@@ -610,6 +627,31 @@ function lastAssistantTextFromMessages(messages: AgentEndEvent["messages"]): str
 		if (isRecord(message) && message.role === "assistant") return lastAssistantText(message)
 	}
 	return null
+}
+
+function subagentBasePayload(data: unknown): Record<string, unknown> {
+	const event = asRecord(data) ?? {}
+	return {
+		subagent_id: stringValue(event.id) ?? null,
+		subagent_type: stringValue(event.type) ?? null,
+		description: stringValue(event.description) ?? null,
+		visibility: stringValue(event.visibility) ?? null,
+	}
+}
+
+function subagentStopPayload(data: unknown, isError: boolean): Record<string, unknown> {
+	const event = asRecord(data) ?? {}
+	return {
+		...subagentBasePayload(data),
+		status: stringValue(event.status) ?? null,
+		result: stringValue(event.result) ?? null,
+		error: stringValue(event.error) ?? null,
+		abort_reason: stringValue(event.abortReason) ?? null,
+		duration_ms: typeof event.durationMs === "number" ? event.durationMs : null,
+		tool_uses: typeof event.toolUses === "number" ? event.toolUses : null,
+		tokens: asRecord(event.tokens) ?? null,
+		is_error: isError,
+	}
 }
 
 function messagePayload(message: TurnEndEvent["message"]): Record<string, unknown> {

--- a/src/extensions/hook-adapters/adapter.ts
+++ b/src/extensions/hook-adapters/adapter.ts
@@ -111,7 +111,11 @@ export function createCommandHookAdapter(definition: CommandHookAdapterDefinitio
 		})
 		pi.on("agent_end", async (event, ctx) => {
 			const stopHookActive = stopHookFollowUpPending
-			const result = await runStop(definition, event, ctx, stopHookActive)
+			let result = await runStop(definition, event, ctx, stopHookActive)
+			const stop = lastAssistantStop(event.messages)
+			if (stop.stopReason === "error" || stop.stopReason === "aborted") {
+				result = mergeOptionalResults(result, await runStopFail(definition, event, ctx, stopHookActive))
+			}
 			if (stopHookActive) stopHookFollowUpPending = false
 			if (result?.block && result.reason && !stopHookActive) {
 				stopHookFollowUpPending = true
@@ -431,10 +435,29 @@ async function runStop(
 	ctx: ExtensionContext,
 	stopHookActive: boolean,
 ): Promise<HookCommandResult | undefined> {
-	return runMatchingHooks(definition, "Stop", ctx, [], {
+	return runMatchingHooks(definition, "Stop", ctx, [], stopPayload(event, stopHookActive))
+}
+
+async function runStopFail(
+	definition: CommandHookAdapterDefinition,
+	event: AgentEndEvent,
+	ctx: ExtensionContext,
+	stopHookActive: boolean,
+): Promise<HookCommandResult | undefined> {
+	return runMatchingHooks(definition, "StopFail", ctx, [], {
+		...stopPayload(event, stopHookActive),
+		is_error: true,
+	})
+}
+
+function stopPayload(event: AgentEndEvent, stopHookActive: boolean): Record<string, unknown> {
+	const stop = lastAssistantStop(event.messages)
+	return {
 		stop_hook_active: stopHookActive,
 		last_assistant_message: lastAssistantTextFromMessages(event.messages),
-	})
+		stop_reason: stop.stopReason ?? null,
+		error_message: stop.errorMessage ?? null,
+	}
 }
 
 async function runTaskCompleted(
@@ -627,6 +650,16 @@ function lastAssistantTextFromMessages(messages: AgentEndEvent["messages"]): str
 		if (isRecord(message) && message.role === "assistant") return lastAssistantText(message)
 	}
 	return null
+}
+
+function lastAssistantStop(messages: AgentEndEvent["messages"]): { stopReason?: string; errorMessage?: string } {
+	for (let i = messages.length - 1; i >= 0; i--) {
+		const message = messages[i]
+		if (isRecord(message) && message.role === "assistant") {
+			return { stopReason: stringValue(message.stopReason), errorMessage: stringValue(message.errorMessage) }
+		}
+	}
+	return {}
 }
 
 function subagentBasePayload(data: unknown): Record<string, unknown> {

--- a/src/extensions/hook-adapters/discovery.ts
+++ b/src/extensions/hook-adapters/discovery.ts
@@ -13,6 +13,7 @@ export type CommandHookEventName =
 	| "PostCompact"
 	| "UserPromptSubmit"
 	| "Stop"
+	| "StopFail"
 	| "TaskCompleted"
 	| "TurnStart"
 	| "MessageStart"
@@ -34,6 +35,7 @@ export const FULL_COMMAND_HOOK_EVENTS: readonly CommandHookEventName[] = [
 	"PostCompact",
 	"UserPromptSubmit",
 	"Stop",
+	"StopFail",
 	"TaskCompleted",
 	"TurnStart",
 	"MessageStart",

--- a/src/extensions/hook-adapters/discovery.ts
+++ b/src/extensions/hook-adapters/discovery.ts
@@ -19,6 +19,8 @@ export type CommandHookEventName =
 	| "MessageEnd"
 	| "ModelSelect"
 	| "UserBash"
+	| "SubagentStart"
+	| "SubagentStop"
 	| "SessionEnd"
 
 /** Every hook event the command-hook adapter machinery can drive. */
@@ -38,6 +40,8 @@ export const FULL_COMMAND_HOOK_EVENTS: readonly CommandHookEventName[] = [
 	"MessageEnd",
 	"ModelSelect",
 	"UserBash",
+	"SubagentStart",
+	"SubagentStop",
 	"SessionEnd",
 ]
 


### PR DESCRIPTION
## Summary

Follow-up to #563: adds the three remaining hooks that were previously blocked on missing pi events, using signals that turn out to be available kimchi-side.

### `SubagentStart` / `SubagentStop`

Wired to kimchi's `subagents:started` / `subagents:completed` / `subagents:failed` bus events (`pi.events.on`). Both are observer-only.

- `SubagentStart` payload: `subagent_id`, `subagent_type`, `description`, `visibility`
- `SubagentStop` payload adds `status`, `result`, `error`, `abort_reason`, `duration_ms`, `tool_uses`, `tokens`, and `is_error` (`true` on the failed path)
- Custom bus events carry no `ExtensionContext`, so the adapter captures the latest context from core events (`session_start` / `turn_start`) for payload base fields; subagent hooks are skipped if none has been seen yet
- Hooks also fire for `visibility: "system"` agents (hidden from the widget for UI reasons only) — documented so hook authors can filter on the `visibility` field

### `StopFail`

Fires in addition to `Stop` when the run ends with `stop_reason` `error` or `aborted`, derived from the final assistant message's `stopReason` (`AgentEndEvent` itself has no error field). Same block→followUp continuation semantics as `Stop`, plus `is_error: true`. The `Stop` payload also gains `stop_reason` and `error_message` so existing Stop hooks can branch without subscribing to the new event.

### Docs

`docs/hooks.md` documents the new events, including the divergence note on `TaskCompleted` semantics vs Claude Code.

## Test plan

- [x] `pnpm check` (biome + tsc) clean
- [x] `pnpm vitest run src/extensions/hook-adapters` — 43 tests pass, including new coverage for: SubagentStart/Stop payloads on started/completed/failed events, missing-context skip, StopFail firing only on `error`/`aborted` stop reasons, Stop+StopFail result merging, and `stop_reason`/`error_message` in the Stop payload
