### PR TITLE
fix: static system prompt sections at start for prefix caching

### DIFF
--- a/src/extensions/behaviours/wiring.smoke.test.ts
+++ b/src/extensions/behaviours/wiring.smoke.test.ts
@@ -332,8 +332,8 @@ describe("wireBehaviours — before_agent_start", () => {
 
 		expect(sp).toContain("## Rules")
 		expect(sp).toContain("Always do X.")
-		expect(sp.indexOf("Project rule.")).toBeLessThan(sp.indexOf("## Rules"))
 		expect(sp.indexOf("## Rules")).toBeLessThan(sp.indexOf("## Available Tools"))
+		expect(sp.indexOf("## Rules")).toBeLessThan(sp.indexOf("Project rule."))
 	})
 
 	it("delivers the body of a loaded triggered behaviour as a hidden message, exactly once", async () => {

--- a/src/extensions/prompt-construction/system-prompt-blocks.test.ts
+++ b/src/extensions/prompt-construction/system-prompt-blocks.test.ts
@@ -238,8 +238,8 @@ describe("system prompt blocks", () => {
 		expect(project).toBeGreaterThan(-1)
 		expect(frame).toBeGreaterThan(-1)
 		expect(tools).toBeGreaterThan(-1)
-		expect(project).toBeLessThan(frame)
 		expect(frame).toBeLessThan(tools)
+		expect(tools).toBeLessThan(project)
 	})
 
 	it("joins rendered blocks with blank lines and prepends a blank line before the first block", () => {
@@ -249,7 +249,7 @@ describe("system prompt blocks", () => {
 		blocks.register({ id: "b", render: () => "## Second\n\nBeta" })
 
 		const result = prompt(pi)
-		expect(result).toContain("Project rule.\n\n## First")
+		expect(result).toContain("acting on it.\n\n## First")
 		expect(result).toContain("Alpha\n\n## Second")
 		expect(result).toContain("Beta\n\n## Available Tools")
 	})

--- a/src/extensions/prompt-construction/system-prompt.ts
+++ b/src/extensions/prompt-construction/system-prompt.ts
@@ -138,23 +138,11 @@ function buildPrompt(parts: PromptParts): string {
 	const sections: string[] = []
 
 	const intro = parts.mode === "orchestrator" ? ORCHESTRATOR_INTRO : SINGLE_INTRO
-	sections.push(`${intro}\n\n${parts.environmentSection}`)
+	sections.push(intro)
 
 	sections.push(`## Documents\n\n${DOCUMENTS_SECTION}`)
 	sections.push(`## Guidelines\n\n${CORE_GUIDELINES}`)
 	sections.push(`## Factual Accuracy\n\n${FACTUAL_ACCURACY}`)
-
-	if (!parts.suppressed.has("orchestration") && parts.orchestrationSection) {
-		sections.push(parts.orchestrationSection)
-	}
-
-	if (!parts.suppressed.has("phase-guidelines") && parts.phaseSection) {
-		sections.push(parts.phaseSection)
-	}
-
-	if (!parts.suppressed.has("project-context") && parts.projectContext) {
-		sections.push(parts.projectContext)
-	}
 
 	if (parts.systemPromptBlocks) {
 		sections.push(parts.systemPromptBlocks)
@@ -164,6 +152,20 @@ function buildPrompt(parts: PromptParts): string {
 
 	if (!parts.suppressed.has("skills") && parts.skillsSection) {
 		sections.push(parts.skillsSection)
+	}
+
+	if (!parts.suppressed.has("orchestration") && parts.orchestrationSection) {
+		sections.push(parts.orchestrationSection)
+	}
+
+	if (!parts.suppressed.has("phase-guidelines") && parts.phaseSection) {
+		sections.push(parts.phaseSection)
+	}
+
+	sections.push(parts.environmentSection)
+
+	if (!parts.suppressed.has("project-context") && parts.projectContext) {
+		sections.push(parts.projectContext)
 	}
 
 	return sections.filter((s) => s.length > 0).join("\n\n")


### PR DESCRIPTION
## Description

Reorders the system prompt sections so that static content (intro, guidelines, prompt blocks, tools, skills) comes before dynamic per-session content (orchestration mode, phase guidelines, environment, project context). This maximizes the shared token prefix across users and sessions for prefix caching.

## Type of Change

- [X] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
