### PR TITLE
fix: filter out embedding models that break model registry

### DIFF
--- a/src/models.test.ts
+++ b/src/models.test.ts
@@ -712,6 +712,88 @@ describe("injectExperimentalProvider", () => {
 	})
 })
 
+describe("embedding model filtering", () => {
+	let tempDir: string
+	let modelsJsonPath: string
+
+	const EMBEDDING_MODEL: unknown = {
+		slug: "text-embedding-3-small",
+		display_name: "",
+		provider: "openai",
+		tool_call: false,
+		reasoning: false,
+		supports_images: false,
+		input_modalities: ["text"],
+		is_serverless: false,
+		is_routable: false,
+		limits: { context_window: 8191, max_output_tokens: 0 },
+	}
+
+	const GPT5: unknown = {
+		slug: "gpt-5",
+		display_name: "",
+		provider: "openai",
+		tool_call: true,
+		reasoning: true,
+		supports_images: true,
+		input_modalities: ["text", "image"],
+		is_serverless: false,
+		is_routable: false,
+		limits: { context_window: 272000, max_output_tokens: 128000 },
+	}
+
+	beforeEach(() => {
+		tempDir = mkdtempSync(join(tmpdir(), "kimchi-embedding-test-"))
+		modelsJsonPath = join(tempDir, "models.json")
+		vi.stubGlobal("fetch", vi.fn())
+	})
+
+	afterEach(() => {
+		rmSync(tempDir, { recursive: true, force: true })
+		vi.restoreAllMocks()
+	})
+
+	it("filters out embedding models with max_output_tokens: 0", async () => {
+		vi.mocked(fetch).mockResolvedValueOnce({
+			ok: true,
+			json: async () => ({ models: [KIMI, EMBEDDING_MODEL] }),
+		} as Response)
+
+		await updateModelsConfig(modelsJsonPath, "test-key")
+
+		const config = JSON.parse(readFileSync(modelsJsonPath, "utf-8"))
+		const writtenIds = config.providers["kimchi-dev"].models.map((m: { id: string }) => m.id)
+		expect(writtenIds).not.toContain("text-embedding-3-small")
+	})
+
+	it("preserves valid chat models alongside filtered embedding models", async () => {
+		vi.mocked(fetch).mockResolvedValueOnce({
+			ok: true,
+			json: async () => ({ models: [KIMI, GPT5, EMBEDDING_MODEL] }),
+		} as Response)
+
+		const result = await updateModelsConfig(modelsJsonPath, "test-key")
+
+		const slugs = result.models.map((m) => m.slug)
+		expect(slugs).toContain("kimi-k2.5")
+		expect(slugs).toContain("gpt-5")
+		expect(slugs).not.toContain("text-embedding-3-small")
+	})
+
+	it("handles response where all models are embeddings", async () => {
+		vi.mocked(fetch).mockResolvedValueOnce({
+			ok: true,
+			json: async () => ({ models: [EMBEDDING_MODEL] }),
+		} as Response)
+
+		const result = await updateModelsConfig(modelsJsonPath, "test-key")
+
+		expect(result.models).toHaveLength(0)
+		const config = JSON.parse(readFileSync(modelsJsonPath, "utf-8"))
+		expect(config.providers["kimchi-dev"].models).toHaveLength(0)
+	})
+})
+
 describe("readExperimentalModels", () => {
 	let tempDir: string
 	let modelsJsonPath: string

--- a/src/models.ts
+++ b/src/models.ts
@@ -337,7 +337,7 @@ export async function updateModelsConfig(
 		return { models: sortModels([...cached, ...otherModels]) }
 	}
 
-	const activeModels = fetched.filter((m) => m.status !== "sunset")
+	const activeModels = fetched.filter((m) => m.status !== "sunset" && m.limits.max_output_tokens > 0)
 	if (activeModels.length === 0 && fetched.length > 0) {
 		if (options.requireActiveModels) {
 			throw new ModelsFetchError("No active Kimchi models are available for this API key", { transient: false })


### PR DESCRIPTION
## TL;DR

Embedding models with `max_output_tokens: 0` poison the entire model registry, causing login to fail for users whose API keys return these models.

## Requirements

- Models with `max_output_tokens <= 0` (embeddings, moderation) must not be written to `models.json`
- Valid chat models must be preserved unchanged
- Users with mixed model sets (chat + embedding) can log in successfully

## Changes

- Filter out non-generative models (max_output_tokens <= 0) before writing to models.json
- Add tests covering embedding model filtering with real customer data

## Root cause

The metadata API (`/v1/models/metadata?include_in_cli=true`) returns embedding models like `text-embedding-3-small` with `max_output_tokens: 0`. `updateModelsConfig()` writes these to `models.json` with `maxTokens: 0`. Pi SDK's `validateConfig()` rejects any model where `maxTokens <= 0` and discards the **entire** provider block (not just the invalid model). Since `KIMCHI_DISABLE_BUILTIN_PROVIDERS=1`, there are no fallback models, resulting in an empty registry and login failure.

The bug only affects users whose API keys return embedding models. Our internal accounts only return Anthropic + ai-enabler serverless models (no embeddings), which is why we never hit this.

**Bug chain:**
1. API returns embedding models with `max_output_tokens: 0`
2. `metadataToModel()` writes `maxTokens: 0` to models.json
3. Pi SDK `validateConfig()` throws on `maxTokens <= 0`
4. `loadCustomModels()` catch block returns zero models
5. `KIMCHI_DISABLE_BUILTIN_PROVIDERS=1` means no built-in fallback
6. `getAvailable()` returns empty, login fails with "no available Kimchi models"

## Customer reports

- https://discord.com/channels/1491078938649432124/1514760121786433679
- https://discord.com/channels/1491078938649432124/1514286708034633850