### PR TITLE
fix: patch to fix cache-write that was ALWAYS zeroed

### DIFF
--- a/package.json
+++ b/package.json
@@ -110,7 +110,8 @@
 		"patchedDependencies": {
 			"@earendil-works/pi-tui": "patches/@earendil-works__pi-tui.patch",
 			"playwright-core@1.59.1": "patches/playwright-core@1.59.1.patch",
-			"@earendil-works/pi-coding-agent": "patches/@earendil-works__pi-coding-agent.patch"
+			"@earendil-works/pi-coding-agent": "patches/@earendil-works__pi-coding-agent.patch",
+			"@earendil-works/pi-ai@0.78.0": "patches/@earendil-works__pi-ai@0.78.0.patch"
 		}
 	}
 }

--- a/patches/@earendil-works__pi-ai@0.78.0.patch
+++ b/patches/@earendil-works__pi-ai@0.78.0.patch
@@ -1,0 +1,31 @@
+# Patch: Add cache_creation_tokens fallback for LiteLLM prompt-caching write counts
+#
+# Upstream issue: pi-ai OpenAI completions provider only reads
+# `prompt_tokens_details.cache_write_tokens`, but LiteLLM (Kimchi's gateway)
+# returns cache writes as `cache_creation_tokens`. This causes cache-write to
+# always be reported as 0.
+#
+# Tracking: TODO - open upstream issue/PR against pi-mono to add
+# `cache_creation_tokens` fallback in parseChunkUsage.
+#
+# Removal criteria: Remove this patch once upstream pi-ai accepts a PR that
+# adds `cache_creation_tokens` as a fallback for `cache_write_tokens` in the
+# OpenAI completions provider, and the fixed version is released and pinned.
+#
+diff --git a/dist/providers/openai-completions.js b/dist/providers/openai-completions.js
+index 47acfa838f10d0e14ab6368dc0c2f242ffeb73a0..c21a0284192085ea5564a25568f7d6829b9e814d 100644
+--- a/dist/providers/openai-completions.js
++++ b/dist/providers/openai-completions.js
+@@ -819,10 +819,11 @@ function convertTools(tools, compat) {
+ function parseChunkUsage(rawUsage, model) {
+     const promptTokens = rawUsage.prompt_tokens || 0;
+     const cacheReadTokens = rawUsage.prompt_tokens_details?.cached_tokens ?? rawUsage.prompt_cache_hit_tokens ?? 0;
+-    const cacheWriteTokens = rawUsage.prompt_tokens_details?.cache_write_tokens || 0;
++    const cacheWriteTokens = rawUsage.prompt_tokens_details?.cache_write_tokens ?? rawUsage.prompt_tokens_details?.cache_creation_tokens ?? 0;
+     // Follow documented OpenAI/OpenRouter semantics: cached_tokens is cache-read
+     // tokens (hits). OpenAI does not document or emit cache_write_tokens, but
+     // OpenRouter-compatible providers can include it as a separate write count.
++    // LiteLLM returns cache writes as cache_creation_tokens, so we fall back to that.
+     // OpenRouter's own provider/tests affirm the separate mapping:
+     // https://github.com/OpenRouterTeam/ai-sdk-provider/pull/409
+     // Do not subtract writes from cached_tokens, otherwise spec-compliant

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5,6 +5,9 @@ settings:
   excludeLinksFromLockfile: false
 
 patchedDependencies:
+  '@earendil-works/pi-ai@0.78.0':
+    hash: 4f83b8a1e0fc692950712178d9dfc3ad08c7e72369cd27ee54df63bf2710bcf5
+    path: patches/@earendil-works__pi-ai@0.78.0.patch
   '@earendil-works/pi-coding-agent':
     hash: 2bb2445481fcd3f79cbf5be9f9f00cdde574e474d99abb99f8efe177889235b9
     path: patches/@earendil-works__pi-coding-agent.patch
@@ -100,7 +103,7 @@ importers:
         version: 1.9.4
       '@earendil-works/pi-ai':
         specifier: ^0.78.0
-        version: 0.78.0(@modelcontextprotocol/sdk@1.29.0(supports-color@10.2.2)(zod@4.4.3))(supports-color@10.2.2)(ws@8.20.1)(zod@4.4.3)
+        version: 0.78.0(patch_hash=4f83b8a1e0fc692950712178d9dfc3ad08c7e72369cd27ee54df63bf2710bcf5)(@modelcontextprotocol/sdk@1.29.0(supports-color@10.2.2)(zod@4.4.3))(supports-color@10.2.2)(ws@8.20.1)(zod@4.4.3)
       '@mixmark-io/domino':
         specifier: ^2.2.0
         version: 2.2.0
@@ -2408,7 +2411,7 @@ snapshots:
 
   '@earendil-works/pi-agent-core@0.78.0(@modelcontextprotocol/sdk@1.29.0(supports-color@10.2.2)(zod@4.4.3))(supports-color@10.2.2)(ws@8.20.1)(zod@4.4.3)':
     dependencies:
-      '@earendil-works/pi-ai': 0.78.0(@modelcontextprotocol/sdk@1.29.0(supports-color@10.2.2)(zod@4.4.3))(supports-color@10.2.2)(ws@8.20.1)(zod@4.4.3)
+      '@earendil-works/pi-ai': 0.78.0(patch_hash=4f83b8a1e0fc692950712178d9dfc3ad08c7e72369cd27ee54df63bf2710bcf5)(@modelcontextprotocol/sdk@1.29.0(supports-color@10.2.2)(zod@4.4.3))(supports-color@10.2.2)(ws@8.20.1)(zod@4.4.3)
       ignore: 7.0.5
       typebox: 1.1.38
       yaml: 2.9.0
@@ -2420,7 +2423,7 @@ snapshots:
       - ws
       - zod
 
-  '@earendil-works/pi-ai@0.78.0(@modelcontextprotocol/sdk@1.29.0(supports-color@10.2.2)(zod@4.4.3))(supports-color@10.2.2)(ws@8.20.1)(zod@4.4.3)':
+  '@earendil-works/pi-ai@0.78.0(patch_hash=4f83b8a1e0fc692950712178d9dfc3ad08c7e72369cd27ee54df63bf2710bcf5)(@modelcontextprotocol/sdk@1.29.0(supports-color@10.2.2)(zod@4.4.3))(supports-color@10.2.2)(ws@8.20.1)(zod@4.4.3)':
     dependencies:
       '@anthropic-ai/sdk': 0.91.1(zod@4.4.3)
       '@aws-sdk/client-bedrock-runtime': 3.1048.0
@@ -2443,7 +2446,7 @@ snapshots:
   '@earendil-works/pi-coding-agent@0.78.0(patch_hash=2bb2445481fcd3f79cbf5be9f9f00cdde574e474d99abb99f8efe177889235b9)(@modelcontextprotocol/sdk@1.29.0(supports-color@10.2.2)(zod@4.4.3))(supports-color@10.2.2)(ws@8.20.1)(zod@4.4.3)':
     dependencies:
       '@earendil-works/pi-agent-core': 0.78.0(@modelcontextprotocol/sdk@1.29.0(supports-color@10.2.2)(zod@4.4.3))(supports-color@10.2.2)(ws@8.20.1)(zod@4.4.3)
-      '@earendil-works/pi-ai': 0.78.0(@modelcontextprotocol/sdk@1.29.0(supports-color@10.2.2)(zod@4.4.3))(supports-color@10.2.2)(ws@8.20.1)(zod@4.4.3)
+      '@earendil-works/pi-ai': 0.78.0(patch_hash=4f83b8a1e0fc692950712178d9dfc3ad08c7e72369cd27ee54df63bf2710bcf5)(@modelcontextprotocol/sdk@1.29.0(supports-color@10.2.2)(zod@4.4.3))(supports-color@10.2.2)(ws@8.20.1)(zod@4.4.3)
       '@earendil-works/pi-tui': 0.78.0(patch_hash=e432fee0f54b7321d104a08ff5a38561d9c2cd3b002f34e6b8cbc2377889c9d2)
       '@silvia-odwyer/photon-node': 0.3.4
       chalk: 5.6.2


### PR DESCRIPTION


## Description
I found odd that the cache-write was always zeroed, so I found a way to patch it now it shows real data

### Before
<img width="533" height="106" alt="image" src="https://github.com/user-attachments/assets/7ab9bc1e-48fd-4b20-bf01-8013bf4dbe5e" />

### After with my patch
<img width="580" height="94" alt="image" src="https://github.com/user-attachments/assets/f9a255d6-65ba-425a-b333-340aee61decc" />

## Type of Change

- [ X] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
