### PR TITLE
fix: re-append --append-system-prompt content after prompt rebuild

### DIFF
--- a/src/extensions/prompt-construction/prompt-enrichment.test.ts
+++ b/src/extensions/prompt-construction/prompt-enrichment.test.ts
@@ -389,6 +389,89 @@ describe("prompt enrichment Claude Code skills", () => {
 	})
 })
 
+describe("append system prompt", () => {
+	beforeEach(() => {
+		vi.restoreAllMocks()
+		vi.spyOn(config, "loadConfig").mockReturnValue({ apiKey: "" } as ReturnType<typeof config.loadConfig>)
+		vi.spyOn(startupContext, "getAvailableModels").mockReturnValue([])
+	})
+
+	it("appends systemPromptOptions.appendSystemPrompt to the built system prompt", async () => {
+		const { beforeAgentStart } = buildPromptExtensionWithHandlers()
+		if (!beforeAgentStart) throw new Error("before_agent_start handler was not registered")
+
+		const result = (await beforeAgentStart(
+			{ systemPromptOptions: { appendSystemPrompt: "Custom appended instructions" } },
+			{
+				cwd: "/tmp",
+				model: undefined,
+				hasUI: false,
+				sessionManager: { getSessionId: () => "session-1" },
+			},
+		)) as { systemPrompt: string }
+
+		expect(result.systemPrompt).toContain("Custom appended instructions")
+		// It should be at the end of the prompt
+		expect(result.systemPrompt.endsWith("Custom appended instructions")).toBe(true)
+	})
+
+	it("does not append when appendSystemPrompt is undefined", async () => {
+		const { beforeAgentStart } = buildPromptExtensionWithHandlers()
+		if (!beforeAgentStart) throw new Error("before_agent_start handler was not registered")
+
+		const resultWithout = (await beforeAgentStart(
+			{ systemPromptOptions: {} },
+			{
+				cwd: "/tmp",
+				model: undefined,
+				hasUI: false,
+				sessionManager: { getSessionId: () => "session-1" },
+			},
+		)) as { systemPrompt: string }
+
+		const resultWithEmpty = (await beforeAgentStart(
+			{ systemPromptOptions: { appendSystemPrompt: undefined } },
+			{
+				cwd: "/tmp",
+				model: undefined,
+				hasUI: false,
+				sessionManager: { getSessionId: () => "session-2" },
+			},
+		)) as { systemPrompt: string }
+
+		// Both should produce the same prompt (no trailing append)
+		expect(resultWithout.systemPrompt).toBe(resultWithEmpty.systemPrompt)
+	})
+
+	it("does not append when appendSystemPrompt is whitespace-only", async () => {
+		const { beforeAgentStart } = buildPromptExtensionWithHandlers()
+		if (!beforeAgentStart) throw new Error("before_agent_start handler was not registered")
+
+		const resultBaseline = (await beforeAgentStart(
+			{ systemPromptOptions: {} },
+			{
+				cwd: "/tmp",
+				model: undefined,
+				hasUI: false,
+				sessionManager: { getSessionId: () => "session-1" },
+			},
+		)) as { systemPrompt: string }
+
+		const resultWhitespace = (await beforeAgentStart(
+			{ systemPromptOptions: { appendSystemPrompt: "   \n  " } },
+			{
+				cwd: "/tmp",
+				model: undefined,
+				hasUI: false,
+				sessionManager: { getSessionId: () => "session-2" },
+			},
+		)) as { systemPrompt: string }
+
+		// Whitespace-only should be skipped — prompt unchanged
+		expect(resultBaseline.systemPrompt).toBe(resultWhitespace.systemPrompt)
+	})
+})
+
 describe("model role startup warnings", () => {
 	beforeEach(() => {
 		vi.restoreAllMocks()

--- a/src/extensions/prompt-construction/prompt-enrichment.ts
+++ b/src/extensions/prompt-construction/prompt-enrichment.ts
@@ -458,7 +458,7 @@ export default function (skillPaths: string[]) {
 		let cachedSkills: Skill[] | undefined
 		let cachedGitRemote: string | undefined | null = null
 
-		pi.on("before_agent_start", async (_event, ctx) => {
+		pi.on("before_agent_start", async (event, ctx) => {
 			const activeToolNames = new Set(pi.getActiveTools())
 			const tools = pi.getAllTools().filter((tool) => activeToolNames.has(tool.name))
 			cachedContextFiles ??= loadProjectContextFiles(ctx.cwd)
@@ -500,7 +500,7 @@ export default function (skillPaths: string[]) {
 			const mode: PromptMode = subagentMode ? "subagent" : multiModelEnabled ? "orchestrator" : "single"
 			const roles = mode === "orchestrator" ? getModelRoles() : undefined
 
-			const systemPrompt = buildSystemPrompt({
+			let systemPrompt = buildSystemPrompt({
 				tools: tools as readonly ToolInfo[],
 				env,
 				contextFiles: cachedContextFiles,
@@ -512,6 +512,16 @@ export default function (skillPaths: string[]) {
 				roles,
 				sessionId: ctx.sessionManager?.getSessionId(),
 			})
+
+			// The rebuilt prompt replaces pi's base prompt entirely, which would
+			// silently drop --append-system-prompt flag values (and SYSTEM/
+			// APPEND_SYSTEM.md content) collected by pi's resource loader.
+			// Re-append them so per-session prompt extensions keep working,
+			// e.g. orchestrators embedding kimchi as a managed agent.
+			const appendSystemPrompt = event.systemPromptOptions?.appendSystemPrompt?.trim()
+			if (appendSystemPrompt) {
+				systemPrompt = `${systemPrompt}\n\n${appendSystemPrompt}`
+			}
 
 			const debugSession = process.env.KIMCHI_DEBUG_SESSION
 			const debugFlag = pi.getFlag("debug-prompts") === true


### PR DESCRIPTION
Kimchi's before_agent_start handler replaces pi-mono's base system prompt entirely, which silently drops --append-system-prompt flag values and APPEND_SYSTEM.md content collected by pi's resource loader.

Re-read event.systemPromptOptions.appendSystemPrompt and append it to the rebuilt prompt so per-session prompt extensions keep working (e.g. orchestrators embedding kimchi as a managed agent).

Also add optional chaining on systemPromptOptions access to prevent crashes when callers omit it, and add tests for the append, undefined, and whitespace-only cases.

## Description

We need to be able to append to kimchi system prompt and there's already flag available (`--append-system-prompt`) but it doesn't work as expected.
