### PR TITLE
feat(ferment): auto-compact session at end of each step and phase

### DIFF
--- a/src/extensions/ferment/auto-compaction.test.ts
+++ b/src/extensions/ferment/auto-compaction.test.ts
@@ -478,16 +478,22 @@ describe("maybeTriggerFermentCompaction", () => {
 		const fakeResult = { tokensBefore: 5000 } as unknown as CompactionResult
 		compactCall.onComplete(fakeResult)
 
-		expect(pi.sendMessage).toHaveBeenCalledTimes(1)
-		const sendMsgCall = (pi.sendMessage as ReturnType<typeof vi.fn>).mock.calls[0]
-		expect(sendMsgCall[0]).toMatchObject({
+		// onComplete should fire two sendMessage calls: handoff entry, then
+		// continuation nudge so the agent keeps moving.
+		expect(pi.sendMessage).toHaveBeenCalledTimes(2)
+		const sendMsgCalls = (pi.sendMessage as ReturnType<typeof vi.fn>).mock.calls
+		expect(sendMsgCalls[0][0]).toMatchObject({
 			customType: "ferment_stage_handoff",
 			display: false,
 		})
-		expect(sendMsgCall[0].details).toMatchObject({
+		expect(sendMsgCalls[0][0].details).toMatchObject({
 			fermentName: "My Ferment",
 			compactionTokensBefore: 5000,
 		})
+		expect(sendMsgCalls[1][0]).toMatchObject({
+			customType: "ferment_continuation_nudge",
+		})
+		expect(sendMsgCalls[1][1]).toMatchObject({ triggerTurn: true })
 	})
 
 	it("onError calls ctx.ui.notify with a warning and does not throw", () => {

--- a/src/extensions/ferment/auto-compaction.test.ts
+++ b/src/extensions/ferment/auto-compaction.test.ts
@@ -11,12 +11,7 @@ import type { ExtensionAPI, ExtensionContext } from "@earendil-works/pi-coding-a
 import type { CompactionResult } from "@earendil-works/pi-coding-agent"
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
 import type { Ferment, Phase, Step } from "../../ferment/types.js"
-import {
-	buildCustomInstructions,
-	buildHandoffDetails,
-	compactionInProgress,
-	maybeTriggerFermentCompaction,
-} from "./auto-compaction.js"
+import { buildCustomInstructions, buildHandoffDetails, maybeTriggerFermentCompaction } from "./auto-compaction.js"
 import type { FermentRuntime } from "./runtime.js"
 import { createDefaultFermentRuntime } from "./runtime.js"
 import { type PendingCompaction, clearPendingCompaction, setPendingCompaction } from "./state.js"
@@ -31,9 +26,7 @@ const NOW = "2026-01-01T00:00:00.000Z"
 
 function makeStep(overrides: Partial<Step> & { id: string; description: string }): Step {
 	return {
-		id: "step-1",
 		index: 1,
-		description: "Do the thing",
 		status: "done",
 		...overrides,
 	}
@@ -41,10 +34,7 @@ function makeStep(overrides: Partial<Step> & { id: string; description: string }
 
 function makePhase(overrides: Partial<Phase> & { id: string; name: string; goal: string }): Phase {
 	return {
-		id: "phase-1",
 		index: 1,
-		name: "Phase One",
-		goal: "Build stuff",
 		status: "active",
 		steps: [],
 		...overrides,
@@ -409,8 +399,8 @@ describe("maybeTriggerFermentCompaction", () => {
 	})
 
 	afterEach(() => {
-		compactionInProgress.delete("ferment-1")
-		compactionInProgress.delete("ferment-2")
+		runtime.clearCompactionInFlight("ferment-1")
+		runtime.clearCompactionInFlight("ferment-2")
 		clearPendingCompaction("ferment-1")
 		clearPendingCompaction("ferment-2")
 		vi.restoreAllMocks()
@@ -523,7 +513,7 @@ describe("maybeTriggerFermentCompaction", () => {
 		expect(notifyCall[1]).toBe("warning")
 	})
 
-	it("in-flight guard: second call while compaction is running does not issue a second compact", () => {
+	it("in-flight guard: a new pending while compaction is running is left for the next tick", () => {
 		const ferment = makeFermentWithPhase(
 			{ id: "phase-1", name: "Phase", goal: "Goal" },
 			{ id: "step-1", description: "Step" },
@@ -532,15 +522,28 @@ describe("maybeTriggerFermentCompaction", () => {
 		runtime.setActive(ferment)
 		setPendingCompaction(ferment.id, makePendingStep(ferment.id, "phase-1", "step-1"))
 
-		// First call
+		// First call — starts compaction, marks ferment in-flight.
 		maybeTriggerFermentCompaction(pi, ctx, runtime)
-
-		// Second call before onComplete fires — clearPendingCompaction was already
-		// called by the first call, so this returns early.
-		maybeTriggerFermentCompaction(pi, ctx, runtime)
-
-		// Only one compact call should have been made
 		expect(ctx.compact).toHaveBeenCalledTimes(1)
+
+		// A new pending arrives while the first compaction is still running
+		// (onComplete has NOT been called yet, so in-flight flag is still set).
+		setPendingCompaction(ferment.id, makePendingStep(ferment.id, "phase-1", "step-2"))
+
+		// Second call — ferment is in-flight so drainPendingCompactions skips it;
+		// no additional compact() call is made.
+		maybeTriggerFermentCompaction(pi, ctx, runtime)
+		expect(ctx.compact).toHaveBeenCalledTimes(1)
+
+		// After onComplete fires, the in-flight flag is cleared.
+		const compactCall = (ctx.compact as ReturnType<typeof vi.fn>).mock.calls[0][0] as {
+			onComplete: (result: CompactionResult) => void
+		}
+		compactCall.onComplete({ tokensBefore: 1000 } as unknown as CompactionResult)
+
+		// Now step-2 pending is still in the map and will fire on the next tick.
+		maybeTriggerFermentCompaction(pi, ctx, runtime)
+		expect(ctx.compact).toHaveBeenCalledTimes(2)
 	})
 
 	it("returns early when ferment is not found in storage after reload", () => {

--- a/src/extensions/ferment/auto-compaction.test.ts
+++ b/src/extensions/ferment/auto-compaction.test.ts
@@ -1,0 +1,557 @@
+/**
+ * Unit tests for auto-compaction logic.
+ *
+ * Tests:
+ * 1. buildCustomInstructions  — custom instruction string building
+ * 2. buildHandoffDetails       — FermentHandoffDetails payload shape
+ * 3. maybeTriggerFermentCompaction — integration: no-op, trigger, onComplete, onError, in-flight guard
+ */
+
+import type { ExtensionAPI, ExtensionContext } from "@earendil-works/pi-coding-agent"
+import type { CompactionResult } from "@earendil-works/pi-coding-agent"
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
+import type { Ferment, Phase, Step } from "../../ferment/types.js"
+import {
+	buildCustomInstructions,
+	buildHandoffDetails,
+	compactionInProgress,
+	maybeTriggerFermentCompaction,
+} from "./auto-compaction.js"
+import type { FermentRuntime } from "./runtime.js"
+import { createDefaultFermentRuntime } from "./runtime.js"
+import { type PendingCompaction, clearPendingCompaction, setPendingCompaction } from "./state.js"
+
+// ─── Mock the dynamic require of engine.js in auto-compaction.ts ───────────────
+// auto-compaction.ts uses require() inside buildNextActionDescription to avoid
+// a circular dependency. Mock it here so tests run without the real engine.
+
+// ─── Helpers ──────────────────────────────────────────────────────────────────
+
+const NOW = "2026-01-01T00:00:00.000Z"
+
+function makeStep(overrides: Partial<Step> & { id: string; description: string }): Step {
+	return {
+		id: "step-1",
+		index: 1,
+		description: "Do the thing",
+		status: "done",
+		...overrides,
+	}
+}
+
+function makePhase(overrides: Partial<Phase> & { id: string; name: string; goal: string }): Phase {
+	return {
+		id: "phase-1",
+		index: 1,
+		name: "Phase One",
+		goal: "Build stuff",
+		status: "active",
+		steps: [],
+		...overrides,
+	}
+}
+
+function makeFerment(overrides: Partial<Ferment> = {}): Ferment {
+	return {
+		id: "ferment-1",
+		name: "My Ferment",
+		status: "running",
+		worktree: { path: "/repo" },
+		scoping: {},
+		phases: [],
+		decisions: [],
+		memories: [],
+		createdAt: NOW,
+		updatedAt: NOW,
+		goal: "Ship the feature",
+		successCriteria: ["Tests pass", "Lint clean"],
+		...overrides,
+	}
+}
+
+function makePi(): ExtensionAPI {
+	return {
+		on: vi.fn(),
+		registerCommand: vi.fn(),
+		registerShortcut: vi.fn(),
+		registerTool: vi.fn(),
+		registerMessageRenderer: vi.fn(),
+		registerFlag: vi.fn(),
+		getFlag: vi.fn(),
+		getActiveTools: vi.fn(() => []),
+		getAllTools: vi.fn(() => []),
+		setActiveTools: vi.fn(),
+		appendEntry: vi.fn(),
+		sendMessage: vi.fn(),
+		sendUserMessage: vi.fn(),
+		events: { emit: vi.fn(), on: vi.fn(() => () => {}) },
+	} as unknown as ExtensionAPI
+}
+
+function makeCtx(): ExtensionContext {
+	return {
+		compact: vi.fn(),
+		ui: {
+			notify: vi.fn(),
+		},
+	} as unknown as ExtensionContext
+}
+
+// Simple in-memory storage for maybeTriggerFermentCompaction tests.
+// Simulates FermentEventStore for get() / list() / save() / delete() / resolve().
+function makeMockStorage(ferments: Map<string, Ferment> = new Map()) {
+	const map = ferments
+	return {
+		get: vi.fn((id: string) => map.get(id)),
+		list: vi.fn(() => [...map.values()]),
+		save: vi.fn(),
+		write: vi.fn(),
+		addDecision: vi.fn(),
+		addMemory: vi.fn(),
+		updateWorktree: vi.fn(),
+		isFullyTerminal: vi.fn(),
+		delete: vi.fn(),
+		resolve: vi.fn(),
+		apply: vi.fn(),
+	}
+}
+
+function makeRuntime(overrides: Partial<FermentRuntime> = {}): FermentRuntime {
+	const base = createDefaultFermentRuntime()
+	return {
+		...base,
+		...overrides,
+	} as FermentRuntime
+}
+
+// ─── Test data factory helpers ────────────────────────────────────────────────
+
+function makeFermentWithPhase(
+	phaseOverrides: Partial<Phase> & { id: string; name: string; goal: string } = {
+		id: "phase-1",
+		name: "Phase One",
+		goal: "Build stuff",
+	},
+	stepOverrides: Partial<Step> & { id: string; description: string } = {
+		id: "step-1",
+		description: "Do the thing",
+	},
+): Ferment {
+	return makeFerment({
+		phases: [
+			{
+				...makePhase({ ...phaseOverrides, steps: [makeStep(stepOverrides)] }),
+			},
+		],
+	})
+}
+
+function makePendingStep(fermentId = "ferment-1", phaseId = "phase-1", stepId = "step-1"): PendingCompaction {
+	return { kind: "step", fermentId, phaseId, stepId, completedAt: NOW }
+}
+
+function makePendingPhase(fermentId = "ferment-1", phaseId = "phase-1"): PendingCompaction {
+	return { kind: "phase", fermentId, phaseId, completedAt: NOW }
+}
+
+// ─── Test suite ───────────────────────────────────────────────────────────────
+
+describe("buildCustomInstructions", () => {
+	it("includes ferment name and goal", () => {
+		const ferment = makeFerment({ name: "Test Ferment", goal: "Test the thing" })
+		const pending = makePendingPhase()
+
+		const instructions = buildCustomInstructions(ferment, pending)
+
+		expect(instructions).toContain("Test Ferment")
+		expect(instructions).toContain("Test the thing")
+	})
+
+	it("includes success criteria", () => {
+		const ferment = makeFerment({
+			successCriteria: ["Criterion A", "Criterion B"],
+		})
+		const pending = makePendingPhase()
+
+		const instructions = buildCustomInstructions(ferment, pending)
+
+		expect(instructions).toContain("Success criteria: Criterion A; Criterion B")
+	})
+
+	it("includes active phase name and goal", () => {
+		const ferment = makeFermentWithPhase(
+			{ id: "phase-1", name: "Implementation", goal: "Write code" },
+			{ id: "step-1", description: "Write tests" },
+		)
+		ferment.phases[0].status = "active"
+		const pending = makePendingPhase("ferment-1", "phase-1")
+
+		const instructions = buildCustomInstructions(ferment, pending)
+
+		expect(instructions).toContain("Implementation")
+		expect(instructions).toContain("Write code")
+	})
+
+	it("includes completed step description and summary for step-kind pending", () => {
+		const ferment = makeFermentWithPhase(
+			{ id: "phase-1", name: "Phase", goal: "Goal" },
+			{ id: "step-1", description: "Write the feature", summary: "Done" },
+		)
+		ferment.phases[0].status = "active"
+		const pending = makePendingStep("ferment-1", "phase-1", "step-1")
+
+		const instructions = buildCustomInstructions(ferment, pending)
+
+		expect(instructions).toContain("Write the feature")
+		expect(instructions).toContain("Done")
+	})
+
+	it("includes completed phase summary for phase-kind pending", () => {
+		const ferment = makeFermentWithPhase(
+			{
+				id: "phase-1",
+				name: "Phase One",
+				goal: "Goal",
+				summary: "Phase completed successfully",
+			},
+			{ id: "step-1", description: "Do it" },
+		)
+		const pending = makePendingPhase("ferment-1", "phase-1")
+
+		const instructions = buildCustomInstructions(ferment, pending)
+
+		expect(instructions).toContain("Phase One")
+		expect(instructions).toContain("Phase completed successfully")
+	})
+
+	it("includes next step description when a next step is available", () => {
+		const ferment = makeFerment({
+			phases: [
+				makePhase({
+					id: "phase-1",
+					name: "Phase One",
+					goal: "First goal",
+					status: "completed",
+					steps: [
+						makeStep({
+							id: "step-1",
+							description: "Done step",
+							status: "done",
+						}),
+					],
+				}),
+				makePhase({
+					id: "phase-2",
+					name: "Phase Two",
+					goal: "Second goal",
+					status: "active",
+					steps: [
+						makeStep({
+							id: "step-2",
+							description: "Next step",
+							index: 2,
+							status: "pending",
+						}),
+					],
+				}),
+			],
+		})
+		const pending = makePendingPhase("ferment-1", "phase-1")
+
+		const instructions = buildCustomInstructions(ferment, pending)
+
+		expect(instructions).toContain("Step 2:")
+		expect(instructions).toContain("Next step")
+	})
+
+	it("marks ferment as terminal when no next action exists", () => {
+		const ferment = makeFerment({
+			status: "running",
+			phases: [
+				makePhase({
+					id: "phase-1",
+					name: "Phase One",
+					goal: "Goal",
+					status: "completed",
+					steps: [makeStep({ id: "step-1", description: "Done", status: "done" })],
+				}),
+			],
+		})
+		const pending = makePendingPhase("ferment-1", "phase-1")
+
+		const instructions = buildCustomInstructions(ferment, pending)
+
+		expect(instructions).toContain("No further lifecycle action")
+	})
+})
+
+describe("buildHandoffDetails", () => {
+	it("populates ferment name, goal, and success criteria", () => {
+		const ferment = makeFerment({
+			name: "Handoff Ferment",
+			goal: "Achieve X",
+			successCriteria: ["A", "B"],
+		})
+		const result = { tokensBefore: 5000 } as unknown as CompactionResult
+		const pending = makePendingPhase()
+
+		const details = buildHandoffDetails(result, ferment, pending)
+
+		expect(details.fermentName).toBe("Handoff Ferment")
+		expect(details.fermentGoal).toBe("Achieve X")
+		expect(details.successCriteria).toEqual(["A", "B"])
+	})
+
+	it("populates active phase name and goal", () => {
+		const ferment = makeFermentWithPhase(
+			{ id: "phase-1", name: "Active Phase", goal: "Active goal" },
+			{ id: "step-1", description: "Step" },
+		)
+		ferment.phases[0].status = "active"
+		const result = {} as CompactionResult
+		const pending = makePendingPhase("ferment-1", "phase-1")
+
+		const details = buildHandoffDetails(result, ferment, pending)
+
+		expect(details.activePhaseName).toBe("Active Phase")
+		expect(details.activePhaseGoal).toBe("Active goal")
+	})
+
+	it("populates completedStepSummary when step kind", () => {
+		const ferment = makeFermentWithPhase(
+			{ id: "phase-1", name: "Phase", goal: "Goal" },
+			{ id: "step-1", description: "The step", summary: "Step summary" },
+		)
+		ferment.phases[0].status = "active"
+		const result = {} as CompactionResult
+		const pending = makePendingStep("ferment-1", "phase-1", "step-1")
+
+		const details = buildHandoffDetails(result, ferment, pending)
+
+		expect(details.completedStepSummary).toBe("Step summary")
+		expect(details.completedPhaseSummary).toBeUndefined()
+	})
+
+	it("populates completedPhaseSummary when phase kind", () => {
+		const ferment = makeFermentWithPhase(
+			{
+				id: "phase-1",
+				name: "Phase",
+				goal: "Goal",
+				summary: "Phase summary",
+			},
+			{ id: "step-1", description: "Step" },
+		)
+		const result = {} as CompactionResult
+		const pending = makePendingPhase("ferment-1", "phase-1")
+
+		const details = buildHandoffDetails(result, ferment, pending)
+
+		expect(details.completedPhaseSummary).toBe("Phase summary")
+		expect(details.completedStepSummary).toBeUndefined()
+	})
+
+	it("sets compactionTokensBefore from CompactionResult.tokensBefore", () => {
+		const ferment = makeFerment()
+		const result = { tokensBefore: 12345 } as unknown as CompactionResult
+		const pending = makePendingPhase()
+
+		const details = buildHandoffDetails(result, ferment, pending)
+
+		expect(details.compactionTokensBefore).toBe(12345)
+	})
+
+	it("populates next step/phase details", () => {
+		const ferment = makeFerment({
+			phases: [
+				makePhase({
+					id: "phase-1",
+					name: "Phase One",
+					goal: "First",
+					status: "completed",
+					steps: [makeStep({ id: "step-1", description: "Done", status: "done" })],
+				}),
+				makePhase({
+					id: "phase-2",
+					name: "Phase Two",
+					goal: "Second",
+					status: "active",
+					steps: [makeStep({ id: "step-2", description: "Next", status: "pending", index: 2 })],
+				}),
+			],
+		})
+		const result = {} as CompactionResult
+		const pending = makePendingPhase("ferment-1", "phase-1")
+
+		const details = buildHandoffDetails(result, ferment, pending)
+
+		expect(details.nextPhaseName).toBe("Phase Two")
+		expect(details.nextPhaseGoal).toBe("Second")
+		expect(details.nextStepDescription).toContain("Step 2")
+	})
+})
+
+describe("maybeTriggerFermentCompaction", () => {
+	let storageMap: Map<string, Ferment>
+	let mockStorage: ReturnType<typeof makeMockStorage>
+	let runtime: FermentRuntime
+	let pi: ExtensionAPI
+	let ctx: ExtensionContext
+
+	beforeEach(() => {
+		storageMap = new Map()
+		mockStorage = makeMockStorage(storageMap)
+		runtime = makeRuntime({
+			getStorage: () => mockStorage as unknown as import("../../ferment/event-store.js").FermentEventStore,
+		})
+		pi = makePi()
+		ctx = makeCtx()
+	})
+
+	afterEach(() => {
+		compactionInProgress.delete("ferment-1")
+		compactionInProgress.delete("ferment-2")
+		clearPendingCompaction("ferment-1")
+		clearPendingCompaction("ferment-2")
+		vi.restoreAllMocks()
+	})
+
+	it("returns immediately when no ferment is active", () => {
+		runtime = makeRuntime({
+			getStorage: () => mockStorage as unknown as import("../../ferment/event-store.js").FermentEventStore,
+			getActiveId: () => undefined,
+		})
+
+		maybeTriggerFermentCompaction(pi, ctx, runtime)
+
+		expect(ctx.compact).not.toHaveBeenCalled()
+	})
+
+	it("returns immediately when no pending compaction exists", () => {
+		runtime.setActive(makeFerment({ id: "ferment-1", name: "No Pending" }))
+
+		maybeTriggerFermentCompaction(pi, ctx, runtime)
+
+		expect(ctx.compact).not.toHaveBeenCalled()
+	})
+
+	it("calls ctx.compact() with customInstructions when pending compaction exists", () => {
+		const ferment = makeFermentWithPhase(
+			{ id: "phase-1", name: "Phase", goal: "Goal" },
+			{ id: "step-1", description: "Do it" },
+		)
+		storageMap.set(ferment.id, ferment)
+		runtime.setActive(ferment)
+		setPendingCompaction(ferment.id, makePendingStep(ferment.id, "phase-1", "step-1"))
+
+		maybeTriggerFermentCompaction(pi, ctx, runtime)
+
+		expect(ctx.compact).toHaveBeenCalledTimes(1)
+		const call = (ctx.compact as ReturnType<typeof vi.fn>).mock.calls[0][0] as {
+			customInstructions: string
+		}
+		expect(call.customInstructions).toContain("Ferment: My Ferment")
+		expect(call.customInstructions).toContain("Phase")
+		expect(call.customInstructions).toContain("Do it")
+	})
+
+	it("clears pending compaction after triggering", () => {
+		const ferment = makeFermentWithPhase(
+			{ id: "phase-1", name: "Phase", goal: "Goal" },
+			{ id: "step-1", description: "Step" },
+		)
+		storageMap.set(ferment.id, ferment)
+		runtime.setActive(ferment)
+		setPendingCompaction(ferment.id, makePendingStep(ferment.id, "phase-1", "step-1"))
+
+		maybeTriggerFermentCompaction(pi, ctx, runtime)
+
+		expect(runtime.getPendingCompaction(ferment.id)).toBeUndefined()
+	})
+
+	it("onComplete calls pi.sendMessage with ferment_stage_handoff and display: false", () => {
+		const ferment = makeFermentWithPhase(
+			{ id: "phase-1", name: "Phase", goal: "Goal" },
+			{ id: "step-1", description: "Step" },
+		)
+		storageMap.set(ferment.id, ferment)
+		runtime.setActive(ferment)
+		setPendingCompaction(ferment.id, makePendingStep(ferment.id, "phase-1", "step-1"))
+
+		maybeTriggerFermentCompaction(pi, ctx, runtime)
+
+		const compactCall = (ctx.compact as ReturnType<typeof vi.fn>).mock.calls[0][0] as {
+			onComplete: (result: CompactionResult) => void
+			onError: (error: Error) => void
+		}
+
+		const fakeResult = { tokensBefore: 5000 } as unknown as CompactionResult
+		compactCall.onComplete(fakeResult)
+
+		expect(pi.sendMessage).toHaveBeenCalledTimes(1)
+		const sendMsgCall = (pi.sendMessage as ReturnType<typeof vi.fn>).mock.calls[0]
+		expect(sendMsgCall[0]).toMatchObject({
+			customType: "ferment_stage_handoff",
+			display: false,
+		})
+		expect(sendMsgCall[0].details).toMatchObject({
+			fermentName: "My Ferment",
+			compactionTokensBefore: 5000,
+		})
+	})
+
+	it("onError calls ctx.ui.notify with a warning and does not throw", () => {
+		const ferment = makeFermentWithPhase(
+			{ id: "phase-1", name: "Phase", goal: "Goal" },
+			{ id: "step-1", description: "Step" },
+		)
+		storageMap.set(ferment.id, ferment)
+		runtime.setActive(ferment)
+		setPendingCompaction(ferment.id, makePendingStep(ferment.id, "phase-1", "step-1"))
+
+		maybeTriggerFermentCompaction(pi, ctx, runtime)
+
+		const compactCall = (ctx.compact as ReturnType<typeof vi.fn>).mock.calls[0][0] as {
+			onComplete: (result: CompactionResult) => void
+			onError: (error: Error) => void
+		}
+
+		expect(() => compactCall.onError(new Error("compaction failed"))).not.toThrow()
+		expect(ctx.ui.notify).toHaveBeenCalledTimes(1)
+		const notifyCall = (ctx.ui.notify as ReturnType<typeof vi.fn>).mock.calls[0]
+		expect(notifyCall[0]).toContain("compaction failed")
+		expect(notifyCall[1]).toBe("warning")
+	})
+
+	it("in-flight guard: second call while compaction is running does not issue a second compact", () => {
+		const ferment = makeFermentWithPhase(
+			{ id: "phase-1", name: "Phase", goal: "Goal" },
+			{ id: "step-1", description: "Step" },
+		)
+		storageMap.set(ferment.id, ferment)
+		runtime.setActive(ferment)
+		setPendingCompaction(ferment.id, makePendingStep(ferment.id, "phase-1", "step-1"))
+
+		// First call
+		maybeTriggerFermentCompaction(pi, ctx, runtime)
+
+		// Second call before onComplete fires — clearPendingCompaction was already
+		// called by the first call, so this returns early.
+		maybeTriggerFermentCompaction(pi, ctx, runtime)
+
+		// Only one compact call should have been made
+		expect(ctx.compact).toHaveBeenCalledTimes(1)
+	})
+
+	it("returns early when ferment is not found in storage after reload", () => {
+		runtime = makeRuntime({
+			getStorage: () => mockStorage as unknown as import("../../ferment/event-store.js").FermentEventStore,
+			getActiveId: () => "missing-ferment-id",
+		})
+		// Inject a pending compaction for a non-existent ferment
+		setPendingCompaction("missing-ferment-id", makePendingStep("missing-ferment-id", "phase-1", "step-1"))
+
+		expect(() => maybeTriggerFermentCompaction(pi, ctx, runtime)).not.toThrow()
+		expect(ctx.compact).not.toHaveBeenCalled()
+	})
+})

--- a/src/extensions/ferment/auto-compaction.ts
+++ b/src/extensions/ferment/auto-compaction.ts
@@ -22,6 +22,7 @@ import type { CompactionResult } from "@earendil-works/pi-coding-agent"
 import { determineNextAction } from "../../ferment/engine.js"
 import type { Ferment, Phase, Step } from "../../ferment/types.js"
 import type { FermentRuntime } from "./runtime.js"
+import { scheduleNextFermentAction } from "./scheduler.js"
 import type { PendingCompaction } from "./state.js"
 
 // ─── Public types ─────────────────────────────────────────────────────────────
@@ -253,6 +254,23 @@ function triggerCompactionForPending(
 		onComplete: (result: CompactionResult) => {
 			runtime.clearCompactionInFlight(fermentId)
 			appendHandoffEntry(result)
+
+			// After compaction the session is idle. The LLM's previous
+			// next-action reasoning was discarded with the old history, so
+			// schedule the next ferment action as a follow-up turn to keep
+			// automated ferments moving forward without user intervention.
+			try {
+				const freshFerment = runtime.getStorage().get(fermentId)
+				if (freshFerment && (freshFerment.status === "running" || freshFerment.status === "planned")) {
+					runtime.setActive(freshFerment)
+					scheduleNextFermentAction(pi, freshFerment, runtime, {
+						tag: "Auto-compaction continuation",
+						deliverAsFollowUp: true,
+					})
+				}
+			} catch {
+				// Best-effort: scheduler errors must not propagate from a compaction callback.
+			}
 		},
 		onError: (error: Error) => {
 			try {

--- a/src/extensions/ferment/auto-compaction.ts
+++ b/src/extensions/ferment/auto-compaction.ts
@@ -1,0 +1,271 @@
+/**
+ * Ferment auto-compaction.
+ *
+ * After every successful `complete_ferment_step` or `complete_ferment_phase`,
+ * the tool handler records a pending compaction request in `state.ts`.
+ * The `agent_end` hook calls `maybeTriggerFermentCompaction` to:
+ *   1. Guard against double-trigger with an in-flight set.
+ *   2. Resolve the next step/phase from the current ferment state.
+ *   3. Build custom instructions highlighting the ferment plan.
+ *   4. Fire `ctx.compact()` which summarises the session.
+ *   5. On completion, append a hidden `ferment_stage_handoff` session entry
+ *      so the next stage has all context it needs to resume cleanly.
+ *
+ * Failures warn via `ctx.ui.notify` and never block the pipeline.
+ */
+
+import type { ExtensionAPI, ExtensionContext } from "@earendil-works/pi-coding-agent"
+import type { CompactionResult } from "@earendil-works/pi-coding-agent"
+import { determineNextAction } from "../../ferment/engine.js"
+import type { Ferment, Phase, Step } from "../../ferment/types.js"
+import type { FermentRuntime } from "./runtime.js"
+import type { PendingCompaction } from "./state.js"
+
+// ─── Public types ─────────────────────────────────────────────────────────────
+
+export interface FermentHandoffDetails {
+	fermentName: string
+	fermentGoal?: string
+	successCriteria?: string[]
+	activePhaseName: string
+	activePhaseGoal: string
+	nextStepDescription?: string
+	nextPhaseName?: string
+	nextPhaseGoal?: string
+	completedStepSummary?: string
+	completedPhaseSummary?: string
+	/** Number of tokens in the session before compaction was triggered (from CompactionResult.tokensBefore) */
+	compactionTokensBefore?: number
+}
+
+// ─── In-flight guard ──────────────────────────────────────────────────────────
+
+/** Prevents double-trigger when agent_end fires multiple times while compaction
+ *  is already in progress for the same ferment. */
+export const compactionInProgress = new Set<string>()
+
+// ─── Helpers ──────────────────────────────────────────────────────────────────
+
+/**
+ * Build a human-readable description of the next action from `determineNextAction`.
+ * Returns undefined when no next action is found (ferment complete/abandoned).
+ */
+function buildNextActionDescription(
+	ferment: Ferment,
+): { nextStepDescription?: string; nextPhaseName?: string; nextPhaseGoal?: string } | undefined {
+	const action = determineNextAction(ferment)
+	if (!action) return undefined
+
+	switch (action.kind) {
+		case "start_step":
+		case "complete_step":
+		case "verify_step": {
+			const phase = ferment.phases.find((p) => p.id === action.phaseId)
+			const step = phase?.steps.find((s) => s.id === action.stepId)
+			return {
+				nextStepDescription: step ? `Step ${step.index}: ${step.description}` : action.stepId,
+				nextPhaseName: phase?.name,
+				nextPhaseGoal: phase?.goal,
+			}
+		}
+		case "activate_phase": {
+			const phase = ferment.phases.find((p) => p.id === action.phaseId)
+			return {
+				nextPhaseName: phase?.name ?? action.phaseId,
+				nextPhaseGoal: phase?.goal,
+			}
+		}
+		case "complete_phase": {
+			const phase = ferment.phases.find((p) => p.id === action.phaseId)
+			return {
+				nextPhaseName: phase?.name,
+				nextPhaseGoal: phase?.goal,
+			}
+		}
+		default:
+			return undefined
+	}
+}
+
+/** Find the step that just completed (from the pending compaction's stepId). */
+function findCompletedStep(ferment: Ferment, pending: PendingCompaction): Step | undefined {
+	if (!pending.stepId) return undefined
+	return findStepById(ferment, pending.phaseId, pending.stepId)
+}
+
+/** Find the phase that just completed (from the pending compaction's phaseId). */
+function findCompletedPhase(ferment: Ferment, pending: PendingCompaction): Phase | undefined {
+	return findPhaseById(ferment, pending.phaseId)
+}
+
+function findPhaseById(ferment: Ferment, phaseId: string): Phase | undefined {
+	return ferment.phases.find((p) => p.id === phaseId)
+}
+
+function findStepById(ferment: Ferment, phaseId: string, stepId: string): Step | undefined {
+	return findPhaseById(ferment, phaseId)?.steps.find((s) => s.id === stepId)
+}
+
+/** Build the custom instructions string passed to ctx.compact(). */
+export function buildCustomInstructions(ferment: Ferment, pending: PendingCompaction): string {
+	const completedPhase = findCompletedPhase(ferment, pending)
+	const completedStep = findCompletedStep(ferment, pending)
+
+	const nextAction = buildNextActionDescription(ferment)
+
+	const lines: string[] = ["Preserve ferment plan details in the summary:"]
+
+	lines.push(`- Ferment: ${ferment.name}${ferment.goal ? ` — ${ferment.goal}` : ""}`)
+
+	if (ferment.successCriteria && ferment.successCriteria.length > 0) {
+		lines.push(`- Success criteria: ${ferment.successCriteria.join("; ")}`)
+	}
+
+	if (completedPhase) {
+		lines.push(`- Active phase: ${completedPhase.name} — ${completedPhase.goal}`)
+	} else {
+		const activePhase = ferment.phases.find((p) => p.status === "active")
+		if (activePhase) {
+			lines.push(`- Active phase: ${activePhase.name} — ${activePhase.goal}`)
+		}
+	}
+
+	if (pending.kind === "step" && completedStep) {
+		lines.push(
+			`- Completed step: ${completedStep.description}${completedStep.summary ? ` (${completedStep.summary})` : ""}`,
+		)
+	} else if (pending.kind === "phase" && completedPhase) {
+		lines.push(
+			`- Completed phase: ${completedPhase.name}${completedPhase.summary ? ` (${completedPhase.summary})` : ""}`,
+		)
+	}
+
+	if (nextAction?.nextStepDescription) {
+		lines.push(`- Next up: ${nextAction.nextStepDescription}`)
+	} else if (nextAction?.nextPhaseName) {
+		lines.push(`- Next up: Phase "${nextAction.nextPhaseName}" — ${nextAction.nextPhaseGoal ?? "goal TBD"}`)
+	} else {
+		lines.push("- Next up: No further lifecycle action — ferment is terminal")
+	}
+
+	return lines.join("\n")
+}
+
+/** Build the FermentHandoffDetails payload written to the hidden session entry. */
+export function buildHandoffDetails(
+	result: CompactionResult,
+	ferment: Ferment,
+	pending: PendingCompaction,
+): FermentHandoffDetails {
+	const completedPhase = findCompletedPhase(ferment, pending)
+	const completedStep = findCompletedStep(ferment, pending)
+	const nextAction = buildNextActionDescription(ferment)
+	const activePhase = ferment.phases.find((p) => p.status === "active") ?? completedPhase
+
+	return {
+		fermentName: ferment.name,
+		fermentGoal: ferment.goal,
+		successCriteria: ferment.successCriteria,
+		activePhaseName: activePhase?.name ?? "unknown",
+		activePhaseGoal: activePhase?.goal ?? "",
+		nextStepDescription: nextAction?.nextStepDescription,
+		nextPhaseName: nextAction?.nextPhaseName,
+		nextPhaseGoal: nextAction?.nextPhaseGoal,
+		completedStepSummary: completedStep?.summary,
+		completedPhaseSummary: completedPhase?.summary,
+		compactionTokensBefore: result.tokensBefore,
+	}
+}
+
+// ─── Main entry point ─────────────────────────────────────────────────────────
+
+/**
+ * Check for a pending compaction request and fire `ctx.compact()` if one exists.
+ *
+ * Called from the `agent_end` event handler so the compaction does not interrupt
+ * the agent loop that just finished. The in-flight guard prevents double-fire
+ * when `agent_end` is dispatched multiple times while compaction is running.
+ *
+ * @param pi      - ExtensionAPI (for sendMessage and events)
+ * @param ctx     - ExtensionContext (for compact, ui.notify)
+ * @param runtime - FermentRuntime (for storage, active-id, pending-compaction state)
+ */
+export function maybeTriggerFermentCompaction(pi: ExtensionAPI, ctx: ExtensionContext, runtime: FermentRuntime): void {
+	// Drain ALL pending compactions — not just the active ferment's. In automated
+	// continuation mode the entire ferment runs in one long agent turn: agent_end
+	// fires once at the end, after complete_ferment has already cleared
+	// getActiveId(). Using drainPendingCompactions() ensures we catch every
+	// step/phase that completed during the run, regardless of active-ferment state.
+	const allPending = runtime.drainPendingCompactions()
+	if (allPending.length === 0) return
+
+	for (const pending of allPending) {
+		triggerCompactionForPending(pi, ctx, runtime, pending)
+	}
+}
+
+function triggerCompactionForPending(
+	pi: ExtensionAPI,
+	ctx: ExtensionContext,
+	runtime: FermentRuntime,
+	pending: PendingCompaction,
+): void {
+	const { fermentId } = pending
+
+	// Guard: don't re-enter if compaction is already running for this ferment.
+	if (compactionInProgress.has(fermentId)) return
+	compactionInProgress.add(fermentId)
+
+	// Reload the ferment from disk — the in-memory copy may be stale.
+	const fermentMaybe = runtime.getStorage().get(fermentId)
+	if (!fermentMaybe) {
+		compactionInProgress.delete(fermentId)
+		return
+	}
+	// Captured after the guard so the non-null type is visible inside closures.
+	const ferment: Ferment = fermentMaybe
+
+	const customInstructions = buildCustomInstructions(ferment, pending)
+
+	/** Append the hidden handoff entry so the next stage always receives
+	 *  plan + stage context, even when compaction is skipped (session too
+	 *  small, already compacted, no model, etc.). */
+	function appendHandoffEntry(result?: CompactionResult): void {
+		const handoff = buildHandoffDetails(
+			result ?? { summary: "", firstKeptEntryId: "", tokensBefore: 0 },
+			ferment,
+			pending,
+		)
+		pi.sendMessage(
+			{
+				customType: "ferment_stage_handoff",
+				content: [{ type: "text", text: JSON.stringify(handoff) }],
+				display: false,
+				details: handoff,
+			},
+			{ triggerTurn: false },
+		)
+	}
+
+	ctx.compact({
+		customInstructions,
+		onComplete: (result: CompactionResult) => {
+			compactionInProgress.delete(fermentId)
+			appendHandoffEntry(result)
+		},
+		onError: (error: Error) => {
+			compactionInProgress.delete(fermentId)
+			// Silently skip expected non-errors: session too small, already
+			// compacted, cancelled. These are routine when steps are short.
+			const isExpected =
+				error.message.includes("too small") ||
+				error.message.includes("Already compacted") ||
+				error.message.includes("Compaction cancelled")
+			if (!isExpected) {
+				ctx.ui?.notify?.(`Stage compaction failed: ${error.message}`, "warning")
+			}
+			// Always append the handoff entry even when compaction fails/is skipped.
+			appendHandoffEntry()
+		},
+	})
+}

--- a/src/extensions/ferment/auto-compaction.ts
+++ b/src/extensions/ferment/auto-compaction.ts
@@ -3,13 +3,16 @@
  *
  * After every successful `complete_ferment_step` or `complete_ferment_phase`,
  * the tool handler records a pending compaction request in `state.ts`.
- * The `agent_end` hook calls `maybeTriggerFermentCompaction` to:
- *   1. Guard against double-trigger with an in-flight set.
- *   2. Resolve the next step/phase from the current ferment state.
- *   3. Build custom instructions highlighting the ferment plan.
- *   4. Fire `ctx.compact()` which summarises the session.
- *   5. On completion, append a hidden `ferment_stage_handoff` session entry
+ * The `turn_end` and `agent_end` hooks call `maybeTriggerFermentCompaction` to:
+ *   1. Drain ready (non-in-flight) pending entries from the map.
+ *   2. Build custom instructions highlighting the ferment plan and stage.
+ *   3. Fire `ctx.compact()` which summarises the session.
+ *   4. On completion, append a hidden `ferment_stage_handoff` session entry
  *      so the next stage has all context it needs to resume cleanly.
+ *
+ * In-flight tracking lives in `state.ts` (via `FermentRuntime`) so it is
+ * scoped to the runtime instance and resets on session_start, not leaked across
+ * test runs.
  *
  * Failures warn via `ctx.ui.notify` and never block the pipeline.
  */
@@ -37,12 +40,6 @@ export interface FermentHandoffDetails {
 	/** Number of tokens in the session before compaction was triggered (from CompactionResult.tokensBefore) */
 	compactionTokensBefore?: number
 }
-
-// ─── In-flight guard ──────────────────────────────────────────────────────────
-
-/** Prevents double-trigger when agent_end fires multiple times while compaction
- *  is already in progress for the same ferment. */
-export const compactionInProgress = new Set<string>()
 
 // ─── Helpers ──────────────────────────────────────────────────────────────────
 
@@ -110,7 +107,6 @@ function findStepById(ferment: Ferment, phaseId: string, stepId: string): Step |
 export function buildCustomInstructions(ferment: Ferment, pending: PendingCompaction): string {
 	const completedPhase = findCompletedPhase(ferment, pending)
 	const completedStep = findCompletedStep(ferment, pending)
-
 	const nextAction = buildNextActionDescription(ferment)
 
 	const lines: string[] = ["Preserve ferment plan details in the summary:"]
@@ -121,23 +117,30 @@ export function buildCustomInstructions(ferment: Ferment, pending: PendingCompac
 		lines.push(`- Success criteria: ${ferment.successCriteria.join("; ")}`)
 	}
 
-	if (completedPhase) {
-		lines.push(`- Active phase: ${completedPhase.name} — ${completedPhase.goal}`)
-	} else {
-		const activePhase = ferment.phases.find((p) => p.status === "active")
+	// For step completions: show the phase that is still active.
+	// For phase completions: show the just-completed phase as "completed", then
+	// show the next active phase (if any) as the current context.
+	if (pending.kind === "step") {
+		const activePhase = ferment.phases.find((p) => p.status === "active") ?? completedPhase
 		if (activePhase) {
 			lines.push(`- Active phase: ${activePhase.name} — ${activePhase.goal}`)
 		}
-	}
-
-	if (pending.kind === "step" && completedStep) {
-		lines.push(
-			`- Completed step: ${completedStep.description}${completedStep.summary ? ` (${completedStep.summary})` : ""}`,
-		)
-	} else if (pending.kind === "phase" && completedPhase) {
-		lines.push(
-			`- Completed phase: ${completedPhase.name}${completedPhase.summary ? ` (${completedPhase.summary})` : ""}`,
-		)
+		if (completedStep) {
+			lines.push(
+				`- Completed step: ${completedStep.description}${completedStep.summary ? ` (${completedStep.summary})` : ""}`,
+			)
+		}
+	} else {
+		// kind === "phase"
+		if (completedPhase) {
+			lines.push(
+				`- Completed phase: ${completedPhase.name}${completedPhase.summary ? ` (${completedPhase.summary})` : ""}`,
+			)
+		}
+		const nextActivePhase = ferment.phases.find((p) => p.status === "active")
+		if (nextActivePhase) {
+			lines.push(`- Next active phase: ${nextActivePhase.name} — ${nextActivePhase.goal}`)
+		}
 	}
 
 	if (nextAction?.nextStepDescription) {
@@ -180,26 +183,24 @@ export function buildHandoffDetails(
 // ─── Main entry point ─────────────────────────────────────────────────────────
 
 /**
- * Check for a pending compaction request and fire `ctx.compact()` if one exists.
+ * Check for pending compaction requests and fire `ctx.compact()` for each ready one.
  *
- * Called from the `agent_end` event handler so the compaction does not interrupt
- * the agent loop that just finished. The in-flight guard prevents double-fire
- * when `agent_end` is dispatched multiple times while compaction is running.
+ * Called from both `turn_end` (between phases in automated-continuation runs)
+ * and `agent_end` (catch-all after the run finishes). The in-flight guard in
+ * `runtime` prevents double-fire for ferments whose previous compaction is still
+ * running — their pending entry is left in the map and retried on the next tick.
  *
  * @param pi      - ExtensionAPI (for sendMessage and events)
  * @param ctx     - ExtensionContext (for compact, ui.notify)
  * @param runtime - FermentRuntime (for storage, active-id, pending-compaction state)
  */
 export function maybeTriggerFermentCompaction(pi: ExtensionAPI, ctx: ExtensionContext, runtime: FermentRuntime): void {
-	// Drain ALL pending compactions — not just the active ferment's. In automated
-	// continuation mode the entire ferment runs in one long agent turn: agent_end
-	// fires once at the end, after complete_ferment has already cleared
-	// getActiveId(). Using drainPendingCompactions() ensures we catch every
-	// step/phase that completed during the run, regardless of active-ferment state.
-	const allPending = runtime.drainPendingCompactions()
-	if (allPending.length === 0) return
+	// drainPendingCompactions() skips in-flight ferments — their entries stay in
+	// the map for the next turn_end / agent_end to pick up.
+	const ready = runtime.drainPendingCompactions()
+	if (ready.length === 0) return
 
-	for (const pending of allPending) {
+	for (const pending of ready) {
 		triggerCompactionForPending(pi, ctx, runtime, pending)
 	}
 }
@@ -212,14 +213,14 @@ function triggerCompactionForPending(
 ): void {
 	const { fermentId } = pending
 
-	// Guard: don't re-enter if compaction is already running for this ferment.
-	if (compactionInProgress.has(fermentId)) return
-	compactionInProgress.add(fermentId)
+	// Mark in-flight via runtime so the guard is scoped to this runtime instance
+	// (resets at session_start, not leaked across test runs).
+	runtime.markCompactionInFlight(fermentId)
 
 	// Reload the ferment from disk — the in-memory copy may be stale.
 	const fermentMaybe = runtime.getStorage().get(fermentId)
 	if (!fermentMaybe) {
-		compactionInProgress.delete(fermentId)
+		runtime.clearCompactionInFlight(fermentId)
 		return
 	}
 	// Captured after the guard so the non-null type is visible inside closures.
@@ -250,22 +251,26 @@ function triggerCompactionForPending(
 	ctx.compact({
 		customInstructions,
 		onComplete: (result: CompactionResult) => {
-			compactionInProgress.delete(fermentId)
+			runtime.clearCompactionInFlight(fermentId)
 			appendHandoffEntry(result)
 		},
 		onError: (error: Error) => {
-			compactionInProgress.delete(fermentId)
-			// Silently skip expected non-errors: session too small, already
-			// compacted, cancelled. These are routine when steps are short.
-			const isExpected =
-				error.message.includes("too small") ||
-				error.message.includes("Already compacted") ||
-				error.message.includes("Compaction cancelled")
-			if (!isExpected) {
-				ctx.ui?.notify?.(`Stage compaction failed: ${error.message}`, "warning")
+			try {
+				runtime.clearCompactionInFlight(fermentId)
+				// Silently skip expected non-errors: session too small, already
+				// compacted, cancelled. These are routine when steps are short.
+				const isExpected =
+					error.message.includes("too small") ||
+					error.message.includes("Already compacted") ||
+					error.message.includes("Compaction cancelled")
+				if (!isExpected) {
+					ctx.ui?.notify?.(`Stage compaction failed: ${error.message}`, "warning")
+				}
+				// Always append the handoff entry even when compaction fails/is skipped.
+				appendHandoffEntry()
+			} catch {
+				// Best-effort: never let onError propagate and crash the extension.
 			}
-			// Always append the handoff entry even when compaction fails/is skipped.
-			appendHandoffEntry()
 		},
 	})
 }

--- a/src/extensions/ferment/events.ts
+++ b/src/extensions/ferment/events.ts
@@ -3,6 +3,7 @@ import { clearFermentCache } from "../../ferment/store.js"
 import { deriveDraftFermentTitle } from "../../ferment/title.js"
 import { isAgentWorker } from "../agent-worker-context.js"
 import { deferExtensionAction } from "../deferred-action.js"
+import { maybeTriggerFermentCompaction } from "./auto-compaction.js"
 import { formatDuration } from "./colors.js"
 import { extractContextualOptions, extractTrailingQuestion } from "./contextual-options.js"
 import { decideContinuation } from "./continuation.js"
@@ -419,5 +420,10 @@ export function registerFermentEvents(pi: ExtensionAPI, runtime: FermentRuntime 
 		const userInputHandled = await maybeRunUserInputDropdown(pi, ctx, content, f, runtime)
 		if (userInputHandled) return
 		if (!toolCallSeen) maybeInjectReactiveContinuationNudge(pi, runtime)
+
+		// Trigger compaction after any turn that completed a step or phase.
+		// Fires between turns in automated-continuation mode, so the next
+		// phase starts with a fresh compacted session.
+		maybeTriggerFermentCompaction(pi, ctx, runtime)
 	})
 }

--- a/src/extensions/ferment/events.ts
+++ b/src/extensions/ferment/events.ts
@@ -249,6 +249,7 @@ export function registerFermentEvents(pi: ExtensionAPI, runtime: FermentRuntime 
 		runtime.clearAllScopingGates()
 		runtime.clearAllPendingScopes()
 		runtime.clearAllPendingPlanReviews()
+		runtime.clearAllPendingCompactions()
 		clearFermentCache()
 
 		const envId = getActiveFermentId()

--- a/src/extensions/ferment/index.test.ts
+++ b/src/extensions/ferment/index.test.ts
@@ -14,11 +14,13 @@ import { clearAllPendingPlanReviews, getPendingPlanReview, setPendingPlanReview 
 import { type FermentRuntime, createDefaultFermentRuntime } from "./runtime.js"
 import {
 	clearActiveFermentId,
+	clearPendingCompaction,
 	getActive,
 	getActiveFermentId,
 	isAutomatedContinuationEnabled,
 	setActive,
 	setContinuationPolicy,
+	setPendingCompaction,
 } from "./state.js"
 import { createApplyAndPersist } from "./tool-helpers.js"
 import { completeFerment, scopeFerment } from "./tools/lifecycle.js"
@@ -1237,5 +1239,78 @@ Does this plan look right?`,
 
 		expect(ctx.ui.select).not.toHaveBeenCalled()
 		expect(pi.sendUserMessage).not.toHaveBeenCalled()
+	})
+
+	describe("auto-compaction on agent_end", () => {
+		const NOW = "2026-01-01T00:00:00.000Z"
+
+		afterEach(() => {
+			vi.restoreAllMocks()
+		})
+
+		it("calls ctx.compact() when a pending compaction exists for the active ferment", async () => {
+			const storage = new FermentEventStore(mkdtempSync(join(tmpdir(), "ferment-compaction-trigger-test-")))
+			const runtime: FermentRuntime = {
+				...createDefaultFermentRuntime(),
+				getStorage: () => storage,
+			}
+			const draft = storage.create("Compaction Trigger Test")
+			runtime.setActive(draft)
+			setPendingCompaction(draft.id, {
+				kind: "step",
+				fermentId: draft.id,
+				phaseId: "phase-1",
+				stepId: "step-1",
+				completedAt: NOW,
+			})
+
+			const { handlers } = registerFermentExtension(runtime)
+			const agentEnd = handlers.get("agent_end")
+			if (!agentEnd) throw new Error("agent_end handler was not registered")
+
+			const compact = vi.fn()
+			const notify = vi.fn()
+			const ctx = {
+				compact,
+				ui: { notify },
+			}
+
+			await agentEnd({ type: "agent_end" }, ctx)
+
+			expect(compact).toHaveBeenCalledTimes(1)
+			expect(compact).toHaveBeenCalledWith(
+				expect.objectContaining({
+					customInstructions: expect.stringContaining("Compaction Trigger Test"),
+				}),
+			)
+
+			clearPendingCompaction(draft.id)
+		})
+
+		it("does not call ctx.compact() when no pending compaction exists", async () => {
+			const storage = new FermentEventStore(mkdtempSync(join(tmpdir(), "ferment-no-compaction-test-")))
+			const runtime: FermentRuntime = {
+				...createDefaultFermentRuntime(),
+				getStorage: () => storage,
+			}
+			const draft = storage.create("No Compaction Test")
+			runtime.setActive(draft)
+			// Intentionally do NOT set a pending compaction
+
+			const { handlers } = registerFermentExtension(runtime)
+			const agentEnd = handlers.get("agent_end")
+			if (!agentEnd) throw new Error("agent_end handler was not registered")
+
+			const compact = vi.fn()
+			const notify = vi.fn()
+			const ctx = {
+				compact,
+				ui: { notify },
+			}
+
+			await agentEnd({ type: "agent_end" }, ctx)
+
+			expect(compact).not.toHaveBeenCalled()
+		})
 	})
 })

--- a/src/extensions/ferment/index.ts
+++ b/src/extensions/ferment/index.ts
@@ -16,6 +16,7 @@ import type { Step } from "../../ferment/types.js"
 import { createSystemPromptBlocks } from "../prompt-construction/index.js"
 import { requestSharedFooterRender } from "../shared-footer.js"
 import { registerTipProvider } from "../tips/registry.js"
+import { maybeTriggerFermentCompaction } from "./auto-compaction.js"
 import { fermentBreadcrumbRenderer } from "./breadcrumb-renderer.js"
 import { registerFermentCommands } from "./commands.js"
 import { registerFermentEvents } from "./events.js"
@@ -187,12 +188,18 @@ export default function fermentExtension(pi: ExtensionAPI, runtime: FermentRunti
 
 	pi.on("agent_end", (_event, ctx) => {
 		const review = runtime.getCurrentPendingPlanReview()
-		if (planReviewRunning || !review) return
-		clearPlanReviewTimer()
-		planReviewTimer = setTimeout(() => {
-			planReviewTimer = undefined
-			void runPendingPlanReview(ctx, review)
-		}, 0)
+		if (!planReviewRunning && review) {
+			clearPlanReviewTimer()
+			planReviewTimer = setTimeout(() => {
+				planReviewTimer = undefined
+				void runPendingPlanReview(ctx, review)
+			}, 0)
+		}
+
+		// Drain any remaining pending compactions at agent_end (catches the case
+		// where the ferment completes within a single agent run and the turn_end
+		// handler already cleared most pending entries).
+		maybeTriggerFermentCompaction(pi, ctx, runtime)
 	})
 
 	pi.registerMessageRenderer(FERMENT_REQUEST_MESSAGE_TYPE, fermentRequestRenderer)

--- a/src/extensions/ferment/runtime.ts
+++ b/src/extensions/ferment/runtime.ts
@@ -26,15 +26,18 @@ import {
 	clearAllScopingGates,
 	clearAllStepStarts,
 	clearBlockRetry,
+	clearPendingCompaction,
 	clearFermentState as clearStateForFerment,
 	clearStepCompleteAttempt,
 	clearStepStart,
 	consumeScopingGate,
+	drainPendingCompactions,
 	getActive,
 	getActiveId,
 	getBlockRetry,
 	getContinuationPolicy,
 	getLastHumanInputAt,
+	getPendingCompaction,
 	getPhaseStartRef,
 	getStepStartRef,
 	getStorage,
@@ -48,10 +51,12 @@ import {
 	setActive,
 	setAutomatedContinuationEnabled,
 	setContinuationPolicy,
+	setPendingCompaction,
 	setPhaseStartRef,
 	setStepStartRef,
 } from "./state.js"
 import type { ContinuationPolicy } from "./state.js"
+import type { PendingCompaction } from "./state.js"
 
 export interface FermentRuntime {
 	/** pi.events bus — set by the ferment extension factory so all mutations
@@ -101,6 +106,12 @@ export interface FermentRuntime {
 	bumpStepCompleteAttempt(fermentId: string, phaseId: string, stepId: string): number
 	clearStepCompleteAttempt(fermentId: string, phaseId: string, stepId: string): void
 	clearFermentState(fermentId: string): void
+	setPendingCompaction(fermentId: string, pending: PendingCompaction): void
+	getPendingCompaction(fermentId: string): PendingCompaction | undefined
+	clearPendingCompaction(fermentId: string): void
+	/** Drain and return all pending compactions, clearing the map. Used by
+	 *  agent_end so compaction fires even after getActiveId() is cleared. */
+	drainPendingCompactions(): PendingCompaction[]
 }
 
 function getCurrentPendingPlanReview(): PendingPlanReview | undefined {
@@ -166,6 +177,10 @@ export function createDefaultFermentRuntime(): FermentRuntime {
 		bumpStepCompleteAttempt,
 		clearStepCompleteAttempt,
 		clearFermentState,
+		getPendingCompaction,
+		setPendingCompaction,
+		clearPendingCompaction,
+		drainPendingCompactions,
 	}
 	return runtime
 }

--- a/src/extensions/ferment/runtime.ts
+++ b/src/extensions/ferment/runtime.ts
@@ -23,9 +23,11 @@ import {
 	bumpStepCompleteAttempt,
 	bumpStepStart,
 	captureJudgeContext,
+	clearAllPendingCompactions,
 	clearAllScopingGates,
 	clearAllStepStarts,
 	clearBlockRetry,
+	clearCompactionInFlight,
 	clearPendingCompaction,
 	clearFermentState as clearStateForFerment,
 	clearStepCompleteAttempt,
@@ -42,8 +44,10 @@ import {
 	getStepStartRef,
 	getStorage,
 	isAutomatedContinuationEnabled,
+	isCompactionInFlight,
 	isScopingConfirmed,
 	isScopingInteractive,
+	markCompactionInFlight,
 	markHumanInput,
 	markScopingConfirmed,
 	markScopingInteractive,
@@ -109,9 +113,12 @@ export interface FermentRuntime {
 	setPendingCompaction(fermentId: string, pending: PendingCompaction): void
 	getPendingCompaction(fermentId: string): PendingCompaction | undefined
 	clearPendingCompaction(fermentId: string): void
-	/** Drain and return all pending compactions, clearing the map. Used by
-	 *  agent_end so compaction fires even after getActiveId() is cleared. */
+	/** Drain ready (non-in-flight) pending compactions, leaving in-flight ones for the next tick. */
 	drainPendingCompactions(): PendingCompaction[]
+	markCompactionInFlight(fermentId: string): void
+	clearCompactionInFlight(fermentId: string): void
+	isCompactionInFlight(fermentId: string): boolean
+	clearAllPendingCompactions(): void
 }
 
 function getCurrentPendingPlanReview(): PendingPlanReview | undefined {
@@ -181,6 +188,10 @@ export function createDefaultFermentRuntime(): FermentRuntime {
 		setPendingCompaction,
 		clearPendingCompaction,
 		drainPendingCompactions,
+		markCompactionInFlight,
+		clearCompactionInFlight,
+		isCompactionInFlight,
+		clearAllPendingCompactions,
 	}
 	return runtime
 }

--- a/src/extensions/ferment/state.test.ts
+++ b/src/extensions/ferment/state.test.ts
@@ -2,10 +2,17 @@ import { afterEach, describe, expect, it, vi } from "vitest"
 import type { Ferment, FermentStatus } from "../../ferment/types.js"
 import {
 	clearActiveFermentId,
+	clearCompactionInFlight,
+	clearFermentState,
+	clearPendingCompaction,
 	getActiveFermentId,
+	getPendingCompaction,
 	hasActiveFerment,
+	isCompactionInFlight,
+	markCompactionInFlight,
 	onActiveFermentChange,
 	setActive,
+	setPendingCompaction,
 } from "./state.js"
 
 const NOW = "2026-01-01T00:00:00.000Z"
@@ -68,5 +75,41 @@ describe("active ferment env helpers", () => {
 	it("treats missing or blank env values as inactive", () => {
 		expect(getActiveFermentId({})).toBeUndefined()
 		expect(hasActiveFerment({ KIMCHI_ACTIVE_FERMENT: " " })).toBe(false)
+	})
+})
+
+describe("clearFermentState", () => {
+	afterEach(() => {
+		clearPendingCompaction("ferment-A")
+		clearPendingCompaction("ferment-B")
+		clearCompactionInFlight("ferment-A")
+		clearCompactionInFlight("ferment-B")
+	})
+
+	it("clears pending compactions and in-flight markers scoped to the ferment", () => {
+		setPendingCompaction("ferment-A", {
+			kind: "step",
+			fermentId: "ferment-A",
+			phaseId: "phase-1",
+			stepId: "step-1",
+			completedAt: NOW,
+		})
+		setPendingCompaction("ferment-B", {
+			kind: "phase",
+			fermentId: "ferment-B",
+			phaseId: "phase-1",
+			completedAt: NOW,
+		})
+		markCompactionInFlight("ferment-A")
+
+		expect(getPendingCompaction("ferment-A")).toBeDefined()
+		expect(isCompactionInFlight("ferment-A")).toBe(true)
+
+		clearFermentState("ferment-A")
+
+		expect(getPendingCompaction("ferment-A")).toBeUndefined()
+		expect(isCompactionInFlight("ferment-A")).toBe(false)
+		// Other ferments are unaffected.
+		expect(getPendingCompaction("ferment-B")).toBeDefined()
 	})
 })

--- a/src/extensions/ferment/state.ts
+++ b/src/extensions/ferment/state.ts
@@ -255,6 +255,9 @@ export interface PendingCompaction {
 }
 
 const pendingCompactions = new Map<string, PendingCompaction>()
+/** Ferment IDs whose compaction is currently in-flight. Kept in state so it
+ *  resets with clearFermentState and doesn't leak across test runtimes. */
+const compactionInFlight = new Set<string>()
 
 export function setPendingCompaction(fermentId: string, pending: PendingCompaction): void {
 	pendingCompactions.set(fermentId, pending)
@@ -268,13 +271,35 @@ export function clearPendingCompaction(fermentId: string): void {
 	pendingCompactions.delete(fermentId)
 }
 
-/** Drain and return all pending compactions. Clears the map. Used by the
- *  agent_end handler so it fires even when getActiveId() is already cleared
- *  (e.g. after complete_ferment sets active to undefined). */
+/** Drain pending compactions that are NOT currently in-flight.
+ *  Items for in-flight ferments are left in the map so the next
+ *  turn_end / agent_end can retry them once the current compaction finishes. */
 export function drainPendingCompactions(): PendingCompaction[] {
-	const all = Array.from(pendingCompactions.values())
+	const ready: PendingCompaction[] = []
+	for (const [fermentId, pending] of pendingCompactions) {
+		if (!compactionInFlight.has(fermentId)) {
+			ready.push(pending)
+			pendingCompactions.delete(fermentId)
+		}
+	}
+	return ready
+}
+
+export function markCompactionInFlight(fermentId: string): void {
+	compactionInFlight.add(fermentId)
+}
+
+export function clearCompactionInFlight(fermentId: string): void {
+	compactionInFlight.delete(fermentId)
+}
+
+export function isCompactionInFlight(fermentId: string): boolean {
+	return compactionInFlight.has(fermentId)
+}
+
+export function clearAllPendingCompactions(): void {
 	pendingCompactions.clear()
-	return all
+	compactionInFlight.clear()
 }
 
 // ─── Block-retry counter (per phase) ─────────────────────────────────────────

--- a/src/extensions/ferment/state.ts
+++ b/src/extensions/ferment/state.ts
@@ -511,6 +511,12 @@ export function clearFermentState(fermentId: string): void {
 		if (key.startsWith(prefix)) stepStartRefs.delete(key)
 	}
 	hydratedFerments.delete(fermentId)
+	// Per-ferment compaction state: a pending request left in the map for a
+	// completed/abandoned/deleted ferment will never be drained, and an
+	// in-flight marker that outlives the ferment blocks future compactions
+	// for the same id (key collisions are vanishingly unlikely but cheap to avoid).
+	pendingCompactions.delete(fermentId)
+	compactionInFlight.delete(fermentId)
 	deleteRuntimeState(fermentId, runtimeStatePersistRoot)
 }
 

--- a/src/extensions/ferment/state.ts
+++ b/src/extensions/ferment/state.ts
@@ -241,6 +241,42 @@ export function clearAllScopingGates(): void {
 	scopingConfirmed.clear()
 }
 
+// ─── Pending compaction requests (transient) ─────────────────────────────────
+// Recorded on successful complete_ferment_step / complete_ferment_phase so the
+// agent_end hook can auto-compact the session context. Cleared when the
+// compaction fires. Not persisted — single-session handoff only.
+
+export interface PendingCompaction {
+	kind: "step" | "phase"
+	fermentId: string
+	phaseId: string
+	stepId?: string
+	completedAt: string
+}
+
+const pendingCompactions = new Map<string, PendingCompaction>()
+
+export function setPendingCompaction(fermentId: string, pending: PendingCompaction): void {
+	pendingCompactions.set(fermentId, pending)
+}
+
+export function getPendingCompaction(fermentId: string): PendingCompaction | undefined {
+	return pendingCompactions.get(fermentId)
+}
+
+export function clearPendingCompaction(fermentId: string): void {
+	pendingCompactions.delete(fermentId)
+}
+
+/** Drain and return all pending compactions. Clears the map. Used by the
+ *  agent_end handler so it fires even when getActiveId() is already cleared
+ *  (e.g. after complete_ferment sets active to undefined). */
+export function drainPendingCompactions(): PendingCompaction[] {
+	const all = Array.from(pendingCompactions.values())
+	pendingCompactions.clear()
+	return all
+}
+
 // ─── Block-retry counter (per phase) ─────────────────────────────────────────
 // Key: `${fermentId}:${phaseId}`. Incremented every time complete_ferment_phase is
 // called and the reviewer emits at least one `block` flag. After

--- a/src/extensions/ferment/tools/phases.ts
+++ b/src/extensions/ferment/tools/phases.ts
@@ -438,6 +438,14 @@ export async function completePhase(
 	services.onPhaseCompleted(runtime)
 	const fresh = completeOutcome.ferment
 
+	// Record pending phase-compaction request for agent_end to drain.
+	runtime.setPendingCompaction(params.ferment_id, {
+		kind: "phase",
+		fermentId: params.ferment_id,
+		phaseId: phase.id,
+		completedAt: runtime.nowIso(),
+	})
+
 	// Visual ack mirrors the step ✓ breadcrumb in steps.ts. The grade letter is
 	// the deterministic derivedGrade (A/B/F) from gate verdicts + project
 	// checks (post-#230 no LLM judge per phase), colorized via gradeColor for

--- a/src/extensions/ferment/tools/steps.ts
+++ b/src/extensions/ferment/tools/steps.ts
@@ -309,6 +309,13 @@ export async function completeStep(
 		if (!completeOutcome.ok) return failedToolResult(completeOutcome.error, f)
 		runtime.clearStepStart(f.id, phase.id, step.id)
 		runtime.bumpStepCompleteAttempt(f.id, phase.id, step.id)
+		runtime.setPendingCompaction(f.id, {
+			kind: "step",
+			fermentId: f.id,
+			phaseId: phase.id,
+			stepId: step.id,
+			completedAt: runtime.nowIso(),
+		})
 		services.onStepCompleted(runtime)
 		sendStepBreadcrumb(pi, `Step ${step.index} ✓ ${step.description}`)
 		return toolOk(
@@ -346,6 +353,13 @@ export async function completeStep(
 	if (exitCode === 0) {
 		// Verification passed + all gates pass → silent advance. No LLM call.
 		runtime.bumpStepCompleteAttempt(f.id, phase.id, step.id)
+		runtime.setPendingCompaction(f.id, {
+			kind: "step",
+			fermentId: f.id,
+			phaseId: phase.id,
+			stepId: step.id,
+			completedAt: runtime.nowIso(),
+		})
 		services.onStepCompleted(runtime)
 		sendStepBreadcrumb(pi, `Step ${step.index} ✓ verified — ${step.description}`)
 		return toolOk(
@@ -368,6 +382,13 @@ export async function completeStep(
 		// is acceptable (e.g. linter noise on an unrelated file). Gate
 		// verdicts already passed above, so advance.
 		runtime.bumpStepCompleteAttempt(f.id, phase.id, step.id)
+		runtime.setPendingCompaction(f.id, {
+			kind: "step",
+			fermentId: f.id,
+			phaseId: phase.id,
+			stepId: step.id,
+			completedAt: runtime.nowIso(),
+		})
 		services.onStepCompleted(runtime)
 		sendStepBreadcrumb(pi, `Step ${step.index} ✓  Judge passed: ${judgeVerdict.reason}`)
 		return toolOk(


### PR DESCRIPTION
## Summary

After every successful `complete_ferment_step` or `complete_ferment_phase`, the ferment pipeline now automatically:

1. **Triggers session compaction** with custom instructions telling the LLM to preserve the ferment plan, active phase, completed step/phase summary, and next step/phase details.
2. **Appends a hidden `ferment_stage_handoff` session entry** (whether or not compaction succeeded) containing the full context handoff — ferment name, goal, success criteria, phase details, and next action.

## Motivation

Long-running ferments accumulate a large session context across many phases and steps. Without compaction, the agent carries the full history of every previous phase into each new one, burning tokens and diluting focus. This feature ensures each phase starts with a fresh, compact summary focused on what matters for the next stage.

## Changes

| File | Change |
|---|---|
| `state.ts` | `PendingCompaction` type + transient `pendingCompactions` map with `set`/`get`/`clear`/`drain` |
| `runtime.ts` | Wires all four state functions into `FermentRuntime` |
| `tools/steps.ts` | Records pending compaction on all three `completeStep` success paths |
| `tools/phases.ts` | Records pending compaction on `completePhase` success |
| `auto-compaction.ts` _(new)_ | `maybeTriggerFermentCompaction`: drains pending entries, calls `ctx.compact()`, appends handoff entry in `onComplete` and `onError` |
| `index.ts` | Calls `maybeTriggerFermentCompaction` in `agent_end` (catch-all) |
| `events.ts` | Calls `maybeTriggerFermentCompaction` in `turn_end` for between-phase compaction in automated continuation mode |
| `auto-compaction.test.ts` _(new)_ | 21 unit tests |
| `index.test.ts` | 2 new `agent_end` compaction trigger tests |

## Design notes

### Why `turn_end` + `agent_end`

In automated continuation mode the whole ferment executes in a single agent run — `agent_end` fires only once at the very end. Triggering in `turn_end` (which fires after each LLM turn) ensures compaction happens between phases during a continuous run. The `agent_end` call remains as a catch-all.

### Why `drainPendingCompactions()`

`complete_ferment` calls `setActive(undefined)` before `agent_end` fires, so `getActiveId()` returns `undefined` at that point. Storing the `fermentId` inside `PendingCompaction` and draining the full map sidesteps this race.

### Handoff entry always appended

`ferment_stage_handoff` is written in both `onComplete` and `onError`. Expected non-errors (session too small, already compacted, cancelled) are silently skipped. Unexpected errors surface via `ctx.ui.notify`. The handoff entry is the primary deliverable; compaction itself is a best-effort optimization.

## Testing

```
pnpm run test  # 23 new tests pass; 10 pre-existing unrelated failures
```