### PR TITLE
fix: display skill name when loading skills via Skill tool

### DIFF
--- a/src/extensions/tool-rendering.test.ts
+++ b/src/extensions/tool-rendering.test.ts
@@ -60,6 +60,21 @@ describe("user message render patch", () => {
 
 		expect(summary).toBe("Which improvement areas should this ferment include?")
 	})
+
+	it("renders Skill tool with skill name when skill arg is provided", () => {
+		const summary = summarizeOpenAiToolCall("Skill", { skill: "writing-plans" }, plainTheme, (path) => path)
+		expect(summary).toBe("writing-plans")
+	})
+
+	it("renders Skill tool with name arg as primary", () => {
+		const summary = summarizeOpenAiToolCall("Skill", { name: "test-skill" }, plainTheme, (path) => path)
+		expect(summary).toBe("test-skill")
+	})
+
+	it("renders Skill tool with fallback when no name or skill arg", () => {
+		const summary = summarizeOpenAiToolCall("Skill", {}, plainTheme, (path) => path)
+		expect(summary).toBe("run skill")
+	})
 })
 
 describe("execution timestamp tracking", () => {

--- a/src/extensions/tool-rendering.ts
+++ b/src/extensions/tool-rendering.ts
@@ -3371,7 +3371,9 @@ export function summarizeOpenAiToolCall(name: string, args: any, theme: Theme, s
 		case "alpha_read_code":
 			return getStringArg(args, "githubUrl", "github_url") || theme.fg("muted", "repository")
 		case "Skill":
-			return getStringArg(args, "name") || theme.fg("muted", "run skill")
+			// SkillToolSchema accepts both 'skill' (primary) and 'name' (alias for Claude Code compat).
+			// The adapter passes 'skill'; direct tool calls may pass either. Check both before falling back.
+			return getStringArg(args, "skill") || getStringArg(args, "name") || theme.fg("muted", "run skill")
 		case "EnterPlanMode":
 			return theme.fg("muted", "enable read-only planning")
 		case "ExitPlanMode":


### PR DESCRIPTION
## Description

 When Kimchi CLI loads a skill, the tool renderer now shows the skill name (e.g., "Loading writing-plans skill") instead of the generic "(Skill run skill)" message.

### Before
<img width="411" height="346" alt="Screenshot 2026-06-12 at 16 54 10" src="https://github.com/user-attachments/assets/7cbd78ea-43e5-4c95-a711-c4ec12e6104b" />

### After
<img width="346" height="57" alt="Screenshot 2026-06-12 at 16 53 08" src="https://github.com/user-attachments/assets/17e3436c-86da-421c-b68a-168895e48036" />


