### PR TITLE
feat(telemetry): inject X-Session-Id and X-Turn-Index as headers in LLM calls

### DIFF
--- a/patches/@earendil-works__pi-coding-agent.patch
+++ b/patches/@earendil-works__pi-coding-agent.patch
@@ -1,3 +1,25 @@
+# Patch: kimchi-dev runtime extensions for pi-coding-agent
+#
+# Changes included:
+#   1. dist/cli/args.js         — expose KIMCHI_API_KEY in --help env-var block
+#   2. dist/core/extensions/runner.js — add emitBeforeProviderHeaders(headers) method,
+#                                       mirroring emitBeforeProviderRequest pattern
+#   3. dist/core/sdk.js         — call emitBeforeProviderHeaders in streamFn after
+#                                 static header assembly, so extensions can inject
+#                                 per-request dynamic headers (X-Session-Id, X-Turn-Index)
+#   4. dist/core/model-registry.js, dist/core/tools/edit.js,
+#      dist/modes/interactive/  — miscellaneous upstream fixes bundled in this patch
+#
+# Tracking: open an upstream PR against pi-mono to ship before_provider_headers as
+# a first-class extension hook in ExtensionRunner and ExtensionAPI.
+# Issue: TODO — file against https://github.com/earendil-works/pi-mono once the
+# API design is confirmed stable.
+#
+# Removal criteria: Remove this patch (and the companion type augmentation in
+# src/types/pi-coding-agent-utils.d.ts) once upstream pi-coding-agent ships
+# BeforeProviderHeadersEvent + ExtensionAPI.on("before_provider_headers", ...) and
+# the fixed version is pinned in package.json.
+#
 diff --git a/dist/cli/args.js b/dist/cli/args.js
 index a15ca52038d6ad71737fca0a3a99d5a62eaa8a0b..f4ed40d3ae21f4b296cc95ecdb7ffdbd7be3bc76 100644
 --- a/dist/cli/args.js
@@ -10,6 +32,41 @@ index a15ca52038d6ad71737fca0a3a99d5a62eaa8a0b..f4ed40d3ae21f4b296cc95ecdb7ffdbd
    ANTHROPIC_API_KEY                - Anthropic Claude API key
    ANTHROPIC_OAUTH_TOKEN            - Anthropic OAuth token (alternative to API key)
    OPENAI_API_KEY                   - OpenAI GPT API key
+diff --git a/dist/core/extensions/runner.js b/dist/core/extensions/runner.js
+index 60dbdae6192943bbc085c596aa6af563014a1eb4..ebbe8fce28074b5dec61fd63544eeb71cfcb84e6 100644
+--- a/dist/core/extensions/runner.js
++++ b/dist/core/extensions/runner.js
+@@ -697,6 +697,30 @@ export class ExtensionRunner {
+         }
+         return currentPayload;
+     }
++    async emitBeforeProviderHeaders(headers) {
++        const ctx = this.createContext();
++        let current = headers;
++        for (const ext of this.extensions) {
++            const handlers = ext.handlers.get("before_provider_headers");
++            if (!handlers || handlers.length === 0)
++                continue;
++            for (const handler of handlers) {
++                try {
++                    const result = await handler({ type: "before_provider_headers", headers: current }, ctx);
++                    if (result !== undefined)
++                        current = result;
++                } catch (err) {
++                    this.emitError({
++                        extensionPath: ext.path,
++                        event: "before_provider_headers",
++                        error: err instanceof Error ? err.message : String(err),
++                        stack: err instanceof Error ? err.stack : undefined,
++                    });
++                }
++            }
++        }
++        return current;
++    }
+     async emitBeforeAgentStart(prompt, images, systemPrompt, systemPromptOptions) {
+         let currentSystemPrompt = systemPrompt;
+         const ctx = Object.defineProperties({}, Object.getOwnPropertyDescriptors(this.createContext()));
 diff --git a/dist/core/model-registry.js b/dist/core/model-registry.js
 index 41ffa679c862f6d0862f1ed07be45836046b97e4..dc6468f0627a2b85dac9abb08b5b424085c02217 100644
 --- a/dist/core/model-registry.js
@@ -36,6 +93,36 @@ index 21f0270f903b0461a2fa1ef8cb53ffdad4f5894d..041ead7eeddc216065864ac0725c3eb8
      "cloudflare-workers-ai": "@cf/moonshotai/kimi-k2.6",
      "cloudflare-ai-gateway": "workers-ai/@cf/moonshotai/kimi-k2.6",
      xiaomi: "mimo-v2.5-pro",
+diff --git a/dist/core/sdk.js b/dist/core/sdk.js
+index 6f56e8568e7be821a8a17c71a5e1a9fbf4665a8a..fa9e4869016b1aecba1880ee9b455be26999e4ba 100644
+--- a/dist/core/sdk.js
++++ b/dist/core/sdk.js
+@@ -209,6 +209,14 @@ export async function createAgentSession(options = {}) {
+                 (model.api === "openai-codex-responses" ? settingsManager.getHttpIdleTimeoutMs() : undefined);
+             const websocketConnectTimeoutMs = options?.websocketConnectTimeoutMs ?? settingsManager.getWebSocketConnectTimeoutMs();
+             const attributionHeaders = getAttributionHeaders(model, settingsManager, options?.sessionId);
++            let headers = attributionHeaders || auth.headers || options?.headers
++                ? { ...attributionHeaders, ...auth.headers, ...options?.headers }
++                : undefined;
++            // Let extensions inject per-request dynamic headers (e.g. X-Session-Id, X-Turn-Index)
++            const runner = extensionRunnerRef.current;
++            if (runner?.hasHandlers("before_provider_headers")) {
++                headers = await runner.emitBeforeProviderHeaders(headers ?? {});
++            }
+             return streamSimple(model, context, {
+                 ...options,
+                 apiKey: auth.apiKey,
+@@ -216,9 +224,7 @@ export async function createAgentSession(options = {}) {
+                 websocketConnectTimeoutMs,
+                 maxRetries: options?.maxRetries ?? providerRetrySettings.maxRetries,
+                 maxRetryDelayMs: options?.maxRetryDelayMs ?? providerRetrySettings.maxRetryDelayMs,
+-                headers: attributionHeaders || auth.headers || options?.headers
+-                    ? { ...attributionHeaders, ...auth.headers, ...options?.headers }
+-                    : undefined,
++                headers,
+             });
+         },
+         onPayload: async (payload, _model) => {
 diff --git a/dist/core/tools/edit.js b/dist/core/tools/edit.js
 index bf8a79ebfdbe23415cd1effdd3db0b9ebfd804bc..f69116ceafe8ee7f1e2dbfeaa37f60c5d97aa84c 100644
 --- a/dist/core/tools/edit.js
@@ -108,6 +195,7 @@ index 2d54902da1800044206eb1f00ca07501a7310145..44daf4982a5ab6f671f5bce373a94a31
      }
      setExpanded(expanded) {
 diff --git a/dist/modes/interactive/components/extension-selector.js b/dist/modes/interactive/components/extension-selector.js
+index 8220e06bc1e2b136c4b84c4af3cd29fd21b98a9f..b213a26c7ac002776850a59d7cafce4ce1379683 100644
 --- a/dist/modes/interactive/components/extension-selector.js
 +++ b/dist/modes/interactive/components/extension-selector.js
 @@ -2,7 +2,7 @@
@@ -119,7 +207,7 @@ diff --git a/dist/modes/interactive/components/extension-selector.js b/dist/mode
  import { theme } from "../theme/theme.js";
  import { CountdownTimer } from "./countdown-timer.js";
  import { DynamicBorder } from "./dynamic-border.js";
-@@ -75,6 +75,16 @@
+@@ -75,6 +75,16 @@ export class ExtensionSelectorComponent extends Container {
          else if (kb.matches(keyData, "tui.select.cancel")) {
              this.onCancelCallback();
          }
@@ -258,7 +346,7 @@ index 0e85e9006835b754e38a7af725b4f1ca18eb3a61..94ea3d983a2abe039a7729d452f60c32
              color: (content) => theme.fg("userMessageText", content),
          }, { preserveOrderedListMarkers: true }));
 diff --git a/dist/modes/interactive/interactive-mode.js b/dist/modes/interactive/interactive-mode.js
-index 3f7bfee32e1aad19be55097c2b8577d6380779ab..70fc577b6476bd81deaa27de272f02eb83628fb5 100644
+index 3f7bfee32e1aad19be55097c2b8577d6380779ab..4e264c42a2407fbf618760612a1d65a7e1ce0781 100644
 --- a/dist/modes/interactive/interactive-mode.js
 +++ b/dist/modes/interactive/interactive-mode.js
 @@ -1575,7 +1575,7 @@ export class InteractiveMode {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9,7 +9,7 @@ patchedDependencies:
     hash: 4f83b8a1e0fc692950712178d9dfc3ad08c7e72369cd27ee54df63bf2710bcf5
     path: patches/@earendil-works__pi-ai@0.78.0.patch
   '@earendil-works/pi-coding-agent':
-    hash: 2bb2445481fcd3f79cbf5be9f9f00cdde574e474d99abb99f8efe177889235b9
+    hash: 2c31f02c90c970feb90460df6aaf904f689b9a6323c078a6b3f63f1ea90ee3ec
     path: patches/@earendil-works__pi-coding-agent.patch
   '@earendil-works/pi-tui':
     hash: e432fee0f54b7321d104a08ff5a38561d9c2cd3b002f34e6b8cbc2377889c9d2
@@ -30,7 +30,7 @@ importers:
         version: 1.3.0
       '@earendil-works/pi-coding-agent':
         specifier: ^0.78.0
-        version: 0.78.0(patch_hash=2bb2445481fcd3f79cbf5be9f9f00cdde574e474d99abb99f8efe177889235b9)(@modelcontextprotocol/sdk@1.29.0(supports-color@10.2.2)(zod@4.4.3))(supports-color@10.2.2)(ws@8.20.1)(zod@4.4.3)
+        version: 0.78.0(patch_hash=2c31f02c90c970feb90460df6aaf904f689b9a6323c078a6b3f63f1ea90ee3ec)(@modelcontextprotocol/sdk@1.29.0(supports-color@10.2.2)(zod@4.4.3))(supports-color@10.2.2)(ws@8.20.1)(zod@4.4.3)
       '@earendil-works/pi-tui':
         specifier: ^0.78.0
         version: 0.78.0(patch_hash=e432fee0f54b7321d104a08ff5a38561d9c2cd3b002f34e6b8cbc2377889c9d2)
@@ -2443,7 +2443,7 @@ snapshots:
       - ws
       - zod
 
-  '@earendil-works/pi-coding-agent@0.78.0(patch_hash=2bb2445481fcd3f79cbf5be9f9f00cdde574e474d99abb99f8efe177889235b9)(@modelcontextprotocol/sdk@1.29.0(supports-color@10.2.2)(zod@4.4.3))(supports-color@10.2.2)(ws@8.20.1)(zod@4.4.3)':
+  '@earendil-works/pi-coding-agent@0.78.0(patch_hash=2c31f02c90c970feb90460df6aaf904f689b9a6323c078a6b3f63f1ea90ee3ec)(@modelcontextprotocol/sdk@1.29.0(supports-color@10.2.2)(zod@4.4.3))(supports-color@10.2.2)(ws@8.20.1)(zod@4.4.3)':
     dependencies:
       '@earendil-works/pi-agent-core': 0.78.0(@modelcontextprotocol/sdk@1.29.0(supports-color@10.2.2)(zod@4.4.3))(supports-color@10.2.2)(ws@8.20.1)(zod@4.4.3)
       '@earendil-works/pi-ai': 0.78.0(patch_hash=4f83b8a1e0fc692950712178d9dfc3ad08c7e72369cd27ee54df63bf2710bcf5)(@modelcontextprotocol/sdk@1.29.0(supports-color@10.2.2)(zod@4.4.3))(supports-color@10.2.2)(ws@8.20.1)(zod@4.4.3)

--- a/src/extensions/telemetry/index.test.ts
+++ b/src/extensions/telemetry/index.test.ts
@@ -241,6 +241,36 @@ describe("telemetryExtension integration", () => {
 
 		expect(dismissedAttrs.survey_id).toBe("019e87cc-5033-0000-d9bd-5e6501640b6e")
 	})
+
+	it("turn_start event updates ctx.turnIndex", async () => {
+		const { handlers, api } = createMockApi()
+		telemetryExtension(makeConfig())(api)
+		await getHandler(handlers, "session_start")({}, { model: { id: "claude-opus-4-6" } })
+
+		await getHandler(handlers, "turn_start")({ turnIndex: 3 })
+
+		const { default: _ext, ...rest } = await import("./index.js")
+		// Verify via before_provider_headers which exposes ctx.turnIndex
+		const result = getHandler(handlers, "before_provider_headers")({ headers: {} })
+		expect((result as unknown as Record<string, string>)["X-Turn-Index"]).toBe("3")
+	})
+
+	it("before_provider_headers injects X-Session-Id and X-Turn-Index", async () => {
+		const { handlers, api } = createMockApi()
+		telemetryExtension(makeConfig())(api)
+		await getHandler(handlers, "session_start")({}, { model: { id: "claude-opus-4-6" } })
+
+		// Set a known turn index via the turn_start handler
+		await getHandler(handlers, "turn_start")({ turnIndex: 4 })
+
+		const result = getHandler(handlers, "before_provider_headers")({ headers: { "User-Agent": "kimchi/1.0" } })
+		const headers = result as unknown as Record<string, string>
+
+		expect(headers["User-Agent"]).toBe("kimchi/1.0")
+		expect(typeof headers["X-Session-Id"]).toBe("string")
+		expect(headers["X-Session-Id"]).toMatch(/^[0-9a-f-]{36}$/)
+		expect(headers["X-Turn-Index"]).toBe("4")
+	})
 })
 
 // ---------------------------------------------------------------------------

--- a/src/extensions/telemetry/index.ts
+++ b/src/extensions/telemetry/index.ts
@@ -1,5 +1,6 @@
-import type { ExtensionAPI } from "@earendil-works/pi-coding-agent"
+import type { ExtensionAPI, TurnStartEvent } from "@earendil-works/pi-coding-agent"
 import type { TelemetryConfig } from "../../config.js"
+import { onBeforeProviderHeaders } from "../../types/before-provider-headers.js"
 import {
 	FERMENT_EVENTS,
 	type FermentAbandonedPayload,
@@ -431,5 +432,19 @@ export default function telemetryExtension(config: TelemetryConfig) {
 		pi.on("agent_end", async (event) => {
 			handleAgentEnd(ctx, event as { messages?: { role?: string; content?: unknown[] }[] })
 		})
+		pi.on("turn_start", async (event) => {
+			const incoming = (event as TurnStartEvent).turnIndex
+			if (incoming !== undefined) {
+				ctx.turnIndex = incoming
+			} else {
+				console.warn("[telemetry] turn_start received without turnIndex field — ctx.turnIndex unchanged")
+			}
+		})
+		onBeforeProviderHeaders(pi, (event) => ({
+			...event.headers,
+			"X-Session-Id": ctx.sessionId,
+			// 0 means "before first turn" (sentinel); backend should treat it accordingly.
+			"X-Turn-Index": String(ctx.turnIndex),
+		}))
 	}
 }

--- a/src/extensions/telemetry/session-context.test.ts
+++ b/src/extensions/telemetry/session-context.test.ts
@@ -207,6 +207,13 @@ describe("SessionContext", () => {
 		expect(ctx.logBuffer).toHaveLength(0)
 	})
 
+	it("turnIndex resets to 0 on ctx.reset()", () => {
+		const ctx = new SessionContext(makeConfig(), "cli")
+		ctx.turnIndex = 5
+		ctx.reset("cli")
+		expect(ctx.turnIndex).toBe(0)
+	})
+
 	it("reset preserves rootSessionId and clears per-instance state", () => {
 		const ctx = new SessionContext(makeConfig(), "cli")
 		const originalId = ctx.sessionId

--- a/src/extensions/telemetry/session-context.ts
+++ b/src/extensions/telemetry/session-context.ts
@@ -56,6 +56,13 @@ export class SessionContext {
 	sessionStartMs: number
 	source: string
 	currentModel = "unknown"
+	/**
+	 * Current turn index, updated on each turn_start event.
+	 * `0` is a sentinel meaning "before the first turn" (e.g. a provider call
+	 * made during session warmup before any user message). Backends should treat
+	 * `0` as "unknown / pre-turn" rather than a valid 1-based turn number.
+	 */
+	turnIndex = 0
 	sentMessages = new Set<string>()
 	pendingArgs = new Map<string, { toolName: string; args: unknown }>()
 	messageStartTimes = new Map<string, number>()
@@ -97,6 +104,7 @@ export class SessionContext {
 		this.sessionId = rootSessionId
 		this.sessionStartMs = Date.now()
 		this.currentModel = "unknown"
+		this.turnIndex = 0
 		this.sentMessages.clear()
 		this.pendingArgs.clear()
 		this.messageStartTimes.clear()

--- a/src/types/before-provider-headers.ts
+++ b/src/types/before-provider-headers.ts
@@ -1,0 +1,48 @@
+/**
+ * Typed registration helper for the `before_provider_headers` extension hook.
+ *
+ * The patched pi-coding-agent runtime adds `emitBeforeProviderHeaders` to
+ * ExtensionRunner and calls it in `streamFn` (sdk.js) after static header
+ * assembly, allowing extensions to inject per-request dynamic headers
+ * (e.g. X-Session-Id, X-Turn-Index) before every LLM HTTP call.
+ *
+ * The upstream TypeScript types do not yet include this event. TypeScript
+ * module augmentation cannot safely add overloads to an existing interface
+ * (augmented overloads shadow originals rather than composing with them), so
+ * we provide this helper instead of patching ExtensionAPI directly.
+ *
+ * Tracking: open an upstream PR against pi-mono to add BeforeProviderHeadersEvent
+ * and the ExtensionAPI.on() overload to core/extensions/types.ts.
+ * Remove this file (and the cast inside `onBeforeProviderHeaders`) once the
+ * fixed version is pinned in package.json.
+ */
+
+import type { ExtensionAPI } from "@earendil-works/pi-coding-agent"
+
+/** Fired in streamFn after static header assembly, before every LLM HTTP call. */
+export interface BeforeProviderHeadersEvent {
+	type: "before_provider_headers"
+	/** The assembled headers so far (attribution + auth + session options). */
+	headers: Record<string, string>
+}
+
+/** Handler signature for the before_provider_headers hook. */
+export type BeforeProviderHeadersHandler = (
+	event: BeforeProviderHeadersEvent,
+) => Record<string, string> | Promise<Record<string, string>>
+
+/**
+ * Register a `before_provider_headers` handler on the given ExtensionAPI.
+ *
+ * Use this instead of `pi.on("before_provider_headers", ...)` directly — the
+ * upstream `ExtensionAPI` type has no overload for this event yet, so calling
+ * `.on()` directly requires an `as unknown` cast. This wrapper isolates the
+ * cast and provides full type safety for the handler.
+ */
+export function onBeforeProviderHeaders(pi: ExtensionAPI, handler: BeforeProviderHeadersHandler): void {
+	;(
+		pi as unknown as {
+			on(event: "before_provider_headers", handler: BeforeProviderHeadersHandler): void
+		}
+	).on("before_provider_headers", handler)
+}

--- a/src/types/pi-coding-agent-utils.d.ts
+++ b/src/types/pi-coding-agent-utils.d.ts
@@ -2,6 +2,24 @@
 // are on disk in node_modules after install. We use them via deep-module
 // paths to avoid duplicating upstream logic.
 
+// ---------------------------------------------------------------------------
+// Typed helper: before_provider_headers hook
+//
+// The patched pi-coding-agent runtime (patches/@earendil-works__pi-coding-agent.patch)
+// adds a `before_provider_headers` event to ExtensionRunner and wires it into
+// sdk.js, but the published TypeScript types do not include this event.
+//
+// TypeScript module augmentation cannot safely add overloads to an existing
+// interface (augmented overloads shadow originals instead of composing with
+// them). The typed registration helper lives in
+// src/types/before-provider-headers.ts; import from there instead of using
+// an `as unknown` cast.
+//
+// Tracking: open an upstream PR against pi-mono to add BeforeProviderHeadersEvent
+// and the ExtensionAPI.on() overload to core/extensions/types.ts.
+// Remove the helper file once the fixed version is pinned.
+// ---------------------------------------------------------------------------
+
 declare module "@earendil-works/pi-coding-agent/dist/utils/clipboard-image.js" {
 	export type ClipboardImage = {
 		bytes: Uint8Array


### PR DESCRIPTION
Adds a new `before_provider_headers` extension hook to pi-coding-agent (via
patch) and wires it into the kimchi telemetry extension to inject X-Session-Id
and X-Turn-Index headers on every LLM HTTP request.

Patch changes (patches/@earendil-works__pi-coding-agent.patch):
- runner.js: add emitBeforeProviderHeaders(headers), mirroring the existing
  emitBeforeProviderRequest pattern with per-extension error isolation
- sdk.js: call emitBeforeProviderHeaders in streamFn after static header
  assembly, so extensions can return a merged headers object before each call

Telemetry extension changes:
- session-context.ts: add turnIndex field (reset to 0 on ctx.reset()); 0 is a
  sentinel meaning "before first turn" — backends should treat it as pre-turn
- index.ts: register turn_start handler to update ctx.turnIndex; warn via
  console.warn if turn_start fires without a turnIndex field (makes SDK
  regressions observable); register before_provider_headers handler via typed
  onBeforeProviderHeaders() helper to inject X-Session-Id and X-Turn-Index
- src/types/before-provider-headers.ts: typed helper that isolates the single
  as-unknown cast needed to register the hook (module augmentation cannot add
  overloads to ExtensionAPI.on() without shadowing existing ones)
- patch header comment documents each hunk, upstream tracking TODO, and
  removal criteria

Patch generated with pnpm patch / pnpm patch-commit workflow.