### PR TITLE
feat(telemetry): track tool result size, compaction count, and turn index

### DIFF
--- a/src/extensions/telemetry/handlers/messages.ts
+++ b/src/extensions/telemetry/handlers/messages.ts
@@ -36,7 +36,9 @@ export async function handleMessageEnd(
 		const model = assistant.model ?? "unknown"
 		if (model !== "unknown") ctx.currentModel = model
 		const availableModels = getAvailableModels()
-		const meta = availableModels.find((m: { slug: string; provider?: string }) => m.slug === model)
+		const meta = availableModels.find(
+			(m: { slug: string; provider?: string; limits?: { context_window?: number } }) => m.slug === model,
+		)
 		const rawProvider = String(assistant.provider ?? "unknown")
 		const resolvedProvider = meta?.provider ? meta.provider : rawProvider === "kimchi-dev" ? "ai-enabler" : rawProvider
 		const provider = PROVIDER_TELEMETRY_MAP[resolvedProvider] ?? resolvedProvider
@@ -79,7 +81,11 @@ export async function handleMessageEnd(
 }
 
 export function handleBeforeAgentStart(ctx: SessionContext, event: { prompt: string }): void {
-	ctx.emit("user_message", { model: ctx.currentModel, message_length: event.prompt.length })
+	ctx.emit("user_message", {
+		model: ctx.currentModel,
+		message_length: event.prompt.length,
+		turn_index: ctx.turnIndex,
+	})
 }
 
 export function handleAgentEnd(
@@ -93,6 +99,11 @@ export function handleAgentEnd(
 		const text = Array.isArray(last.content)
 			? ((last.content[0] as { text?: string } | undefined)?.text ?? "unknown error")
 			: "unknown error"
-		ctx.emit("error", { model: ctx.currentModel, error_type: "agent_error", error_message: text.slice(0, 300) })
+		ctx.emit("error", {
+			model: ctx.currentModel,
+			error_type: "agent_error",
+			error_message: text.slice(0, 300),
+			turn_index: ctx.turnIndex,
+		})
 	}
 }

--- a/src/extensions/telemetry/handlers/session.ts
+++ b/src/extensions/telemetry/handlers/session.ts
@@ -16,6 +16,8 @@ export async function handleSessionShutdown(ctx: SessionContext, event: { reason
 		model: ctx.currentModel,
 		duration_ms: Date.now() - ctx.sessionStartMs,
 		ended_by: endedBy,
+		compaction_count: ctx.compactionCount,
+		turn_index: ctx.turnIndex,
 	})
 	ctx.flushLogBuffer()
 	await ctx.drain()

--- a/src/extensions/telemetry/handlers/tools.test.ts
+++ b/src/extensions/telemetry/handlers/tools.test.ts
@@ -1,7 +1,7 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
 import type { TelemetryConfig } from "../../../config.js"
 import { SessionContext, _resetSharedAccumulators } from "../session-context.js"
-import { handleToolExecutionEnd, handleToolExecutionStart } from "./tools.js"
+import { handleToolExecutionEnd, handleToolExecutionStart, resultSizeChars } from "./tools.js"
 
 vi.mock("../../../api/me.js", () => ({
 	getMe: vi.fn().mockResolvedValue({ id: "test-user", email: "test@example.com" }),
@@ -287,6 +287,115 @@ describe("handlers/tools", () => {
 
 			handleToolExecutionEnd(ctx, { toolCallId: "b1", isError: false })
 			expect(ctx.toolStartTimes.has("b1")).toBe(false)
+		})
+	})
+
+	// -----------------------------------------------------------------------
+	// resultSizeChars
+	// -----------------------------------------------------------------------
+
+	describe("resultSizeChars", () => {
+		it("returns 0 for null result", () => {
+			expect(resultSizeChars(null)).toBe(0)
+		})
+
+		it("returns 0 for result with empty content array", () => {
+			expect(resultSizeChars({ content: [] })).toBe(0)
+		})
+
+		it("sums text lengths from all content blocks", () => {
+			expect(resultSizeChars({ content: [{ text: "hello" }, { text: " world" }] })).toBe(11)
+		})
+
+		it("ignores content blocks without text property", () => {
+			expect(resultSizeChars({ content: [{ text: "hi" }, { other: "field" }] })).toBe(2)
+		})
+	})
+
+	// -----------------------------------------------------------------------
+	// tool result size attrs
+	// -----------------------------------------------------------------------
+
+	describe("tool result size attrs", () => {
+		it("emits file_size_chars and read_is_truncated=false when no limit is set", async () => {
+			const ctx = new SessionContext(makeConfig(), "cli")
+			ctx.currentModel = "claude-3-5-sonnet"
+			const toolCallId = "tc-read-size"
+
+			// No limit arg — full file returned, not truncated
+			handleToolExecutionStart(ctx, { toolCallId, toolName: "read", args: { path: "/src/app.ts" } })
+			handleToolExecutionEnd(ctx, {
+				toolCallId,
+				isError: false,
+				result: { content: [{ text: "file contents here" }] },
+			})
+
+			ctx.flushLogBuffer()
+			await Promise.allSettled([...ctx.inFlight])
+			const events = parseLogEvents(fetchMock)
+
+			const fileRead = events.find((e) => e.eventName === "file_read")
+			expect(fileRead?.attrs.file_size_chars).toBe(String("file contents here".length))
+			expect(fileRead?.attrs.read_is_truncated).toBe("false")
+		})
+
+		it("emits read_is_truncated=true when a limit arg is set", async () => {
+			const ctx = new SessionContext(makeConfig(), "cli")
+			ctx.currentModel = "claude-3-5-sonnet"
+			const toolCallId = "tc-read-limited"
+
+			// limit arg present — caller capped the lines, result may be truncated
+			handleToolExecutionStart(ctx, { toolCallId, toolName: "read", args: { path: "/src/app.ts", limit: 50 } })
+			handleToolExecutionEnd(ctx, {
+				toolCallId,
+				isError: false,
+				result: { content: [{ text: "file contents here" }] },
+			})
+
+			ctx.flushLogBuffer()
+			await Promise.allSettled([...ctx.inFlight])
+			const events = parseLogEvents(fetchMock)
+
+			const fileRead = events.find((e) => e.eventName === "file_read")
+			expect(fileRead?.attrs.read_is_truncated).toBe("true")
+		})
+
+		it("emits bash_output_size_chars on command_executed", async () => {
+			const ctx = new SessionContext(makeConfig(), "cli")
+			const toolCallId = "tc-bash-size"
+
+			handleToolExecutionStart(ctx, { toolCallId, toolName: "bash", args: { command: "ls" } })
+			handleToolExecutionEnd(ctx, {
+				toolCallId,
+				isError: false,
+				result: { content: [{ text: "file1.txt\nfile2.txt\n" }] },
+			})
+
+			ctx.flushLogBuffer()
+			await Promise.allSettled([...ctx.inFlight])
+			const events = parseLogEvents(fetchMock)
+
+			const cmdExec = events.find((e) => e.eventName === "command_executed")
+			expect(cmdExec?.attrs.bash_output_size_chars).toBe(String("file1.txt\nfile2.txt\n".length))
+		})
+
+		it("emits tool_result_size_chars on tool_result", async () => {
+			const ctx = new SessionContext(makeConfig(), "cli")
+			const toolCallId = "tc-read-size-tr"
+
+			handleToolExecutionStart(ctx, { toolCallId, toolName: "read", args: { path: "/src/app.ts" } })
+			handleToolExecutionEnd(ctx, {
+				toolCallId,
+				isError: false,
+				result: { content: [{ text: "hello world" }] },
+			})
+
+			ctx.flushLogBuffer()
+			await Promise.allSettled([...ctx.inFlight])
+			const events = parseLogEvents(fetchMock)
+
+			const toolResult = events.find((e) => e.eventName === "tool_result")
+			expect(toolResult?.attrs.tool_result_size_chars).toBe(String("hello world".length))
 		})
 	})
 

--- a/src/extensions/telemetry/handlers/tools.ts
+++ b/src/extensions/telemetry/handlers/tools.ts
@@ -10,6 +10,15 @@ import {
 import type { SessionContext } from "../session-context.js"
 
 // ---------------------------------------------------------------------------
+// Helper
+// ---------------------------------------------------------------------------
+
+export function resultSizeChars(result: unknown): number {
+	const r = result as { content?: Array<{ text?: string }> } | null
+	return (r?.content ?? []).reduce((sum, c) => sum + (c.text?.length ?? 0), 0)
+}
+
+// ---------------------------------------------------------------------------
 // Tool execution handlers
 // ---------------------------------------------------------------------------
 
@@ -48,21 +57,43 @@ export function handleToolExecutionEnd(
 	// --- Per-tool events ------------------------------------------------------
 
 	const model = ctx.currentModel
+	const sizeChars = resultSizeChars(event.result)
 
 	if (toolName === "read" && !event.isError) {
 		const filePath = extractFilePath(args)
 		if (filePath) {
-			ctx.emit("tool_result", { tool_name: "read", model, success: true, duration_ms: toolDurationMs })
+			ctx.emit("tool_result", {
+				tool_name: "read",
+				model,
+				success: true,
+				duration_ms: toolDurationMs,
+				tool_result_size_chars: sizeChars,
+				turn_index: ctx.turnIndex,
+			})
 			ctx.emit("file_read", {
 				model,
 				language: inferLanguage(filePath),
 				file_hash: hashFilePath(filePath),
 				duration_ms: toolDurationMs,
+				file_size_chars: sizeChars,
+				// read_is_truncated signals that the caller passed a `limit` arg, capping
+				// the number of lines returned. A limited read may have omitted content
+				// that would otherwise have been returned. Reads without a limit return
+				// the full file (up to the built-in size cap), so they are not truncated.
+				read_is_truncated: !!args?.limit,
+				turn_index: ctx.turnIndex,
 			})
 		}
 	} else if (toolName === "write" && !event.isError) {
 		const filePath = extractFilePath(args)
-		ctx.emit("tool_result", { tool_name: "write", model, success: true, duration_ms: toolDurationMs })
+		ctx.emit("tool_result", {
+			tool_name: "write",
+			model,
+			success: true,
+			duration_ms: toolDurationMs,
+			tool_result_size_chars: sizeChars,
+			turn_index: ctx.turnIndex,
+		})
 		if (filePath) {
 			ctx.emit("file_written", {
 				model,
@@ -70,10 +101,18 @@ export function handleToolExecutionEnd(
 				file_hash: hashFilePath(filePath),
 				lines_added: computeWriteLines(args),
 				duration_ms: toolDurationMs,
+				turn_index: ctx.turnIndex,
 			})
 		}
 	} else if (["edit", "multiedit", "patch"].includes(toolName) && !event.isError) {
-		ctx.emit("tool_result", { tool_name: toolName, model, success: true, duration_ms: toolDurationMs })
+		ctx.emit("tool_result", {
+			tool_name: toolName,
+			model,
+			success: true,
+			duration_ms: toolDurationMs,
+			tool_result_size_chars: sizeChars,
+			turn_index: ctx.turnIndex,
+		})
 		const filePath = extractFilePath(args)
 		const changes = computeLineChanges(toolName, args)
 		if (filePath) {
@@ -84,15 +123,25 @@ export function handleToolExecutionEnd(
 				lines_added: changes.added,
 				lines_deleted: changes.removed,
 				duration_ms: toolDurationMs,
+				turn_index: ctx.turnIndex,
 			})
 		}
 	} else if (toolName === "bash") {
-		ctx.emit("tool_result", { tool_name: "bash", model, success: !event.isError, duration_ms: toolDurationMs })
+		ctx.emit("tool_result", {
+			tool_name: "bash",
+			model,
+			success: !event.isError,
+			duration_ms: toolDurationMs,
+			tool_result_size_chars: sizeChars,
+			turn_index: ctx.turnIndex,
+		})
 		ctx.emit("command_executed", {
 			model,
 			command_type: "bash",
 			exit_code: event.isError ? 1 : 0,
 			duration_ms: toolDurationMs,
+			bash_output_size_chars: sizeChars,
+			turn_index: ctx.turnIndex,
 		})
 	}
 
@@ -111,6 +160,12 @@ export function handleToolExecutionEnd(
 				.join("\n")
 				.slice(0, 300)
 		}
-		ctx.emit("error", { model, error_type: "tool_failure", tool_name: toolName, error_message: errorMsg })
+		ctx.emit("error", {
+			model,
+			error_type: "tool_failure",
+			tool_name: toolName,
+			error_message: errorMsg,
+			turn_index: ctx.turnIndex,
+		})
 	}
 }

--- a/src/extensions/telemetry/index.ts
+++ b/src/extensions/telemetry/index.ts
@@ -411,6 +411,14 @@ export default function telemetryExtension(config: TelemetryConfig) {
 			const e = event as { model?: { id?: string } }
 			ctx.currentModel = e.model?.id ?? "unknown"
 		})
+		pi.on("session_compact", async () => {
+			ctx.compactionCount++
+			ctx.emit("session.compacted", {
+				model: ctx.currentModel,
+				compaction_count: ctx.compactionCount,
+				turn_index: ctx.turnIndex,
+			})
+		})
 		pi.on("tool_execution_start", async (event) =>
 			handleToolExecutionStart(ctx, event as { toolCallId: string; toolName: string; args: unknown }),
 		)

--- a/src/extensions/telemetry/session-context.test.ts
+++ b/src/extensions/telemetry/session-context.test.ts
@@ -370,4 +370,36 @@ describe("SessionContext", () => {
 		await ctx.userEmailReady
 		expect(ctx.userEmail).toBeUndefined()
 	})
+
+	it("emit includes user.account_uuid from userId after getMe resolves", async () => {
+		const { getMe } = await import("../../api/me.js")
+		vi.mocked(getMe).mockResolvedValue({ id: "user-uuid-123" })
+
+		const ctx = new SessionContext(makeConfig({ apiKey: "key" }), "cli")
+		await ctx.userEmailReady
+
+		ctx.emit("test.event", { foo: "bar" })
+		ctx.flushLogBuffer()
+		await Promise.allSettled([...ctx.inFlight])
+
+		const call = (globalThis.fetch as ReturnType<typeof vi.fn>).mock.calls.find(([url]: unknown[]) =>
+			String(url).includes("/logs"),
+		)
+		const body = JSON.parse((call?.[1] as { body: string }).body)
+		const attrMap = Object.fromEntries(
+			body.resourceLogs[0].scopeLogs[0].logRecords[0].attributes.map(
+				(a: { key: string; value: { stringValue: string } }) => [a.key, a.value.stringValue],
+			),
+		)
+		expect(attrMap["user.account_uuid"]).toBe("user-uuid-123")
+	})
+
+	it("compactionCount resets to 0 on ctx.reset()", () => {
+		const ctx = new SessionContext(makeConfig(), "cli")
+		ctx.compactionCount = 3
+
+		ctx.reset("cli")
+
+		expect(ctx.compactionCount).toBe(0)
+	})
 })

--- a/src/extensions/telemetry/session-context.ts
+++ b/src/extensions/telemetry/session-context.ts
@@ -74,9 +74,13 @@ export class SessionContext {
 	logBuffer: LogRecord[] = []
 	private logFlushTimer: NodeJS.Timeout | undefined
 	lastSessionType: string | undefined
+	/** Number of context compactions in the current session. */
+	compactionCount = 0
 
 	/** Cached user email from /v1/me — populated once in the background. */
 	userEmail: string | undefined
+	/** Cached user ID (uuid) from /v1/me — populated once in the background. */
+	userId: string | undefined
 	/** Resolves when the userEmail has been fetched (or the fetch failed). */
 	userEmailReady: Promise<void>
 	private resolveUserEmailReady!: () => void
@@ -110,6 +114,7 @@ export class SessionContext {
 		this.messageStartTimes.clear()
 		this.toolStartTimes.clear()
 		this.lastSessionType = undefined
+		this.compactionCount = 0
 		this.cumulative = getOrCreateAccumulator(this.sessionId)
 		this.inFlight.clear()
 		this.shuttingDown = false
@@ -145,6 +150,7 @@ export class SessionContext {
 			session_type: sessionType,
 			...ids,
 			...attrs,
+			"user.account_uuid": this.userId ?? "",
 		}
 		this.enqueueLogRecord(buildLogRecord(this.sessionId, eventName, toAttrs(merged)))
 	}
@@ -165,7 +171,13 @@ export class SessionContext {
 		}
 		this.lastSessionType = sessionType
 
-		const merged = { ...attrs, source: this.source, session_type: sessionType, ferment_id: ferment?.id ?? "" }
+		const merged = {
+			...attrs,
+			source: this.source,
+			session_type: sessionType,
+			ferment_id: ferment?.id ?? "",
+			"user.account_uuid": this.userId ?? "",
+		}
 		this.enqueueLogRecord(buildLogRecord(this.sessionId, eventName, toAttrs(merged)))
 	}
 
@@ -198,7 +210,18 @@ export class SessionContext {
 		if (metrics.length > 0) {
 			this.track(
 				this.userEmailReady.then(() =>
-					sendMetrics(this.config, this.sessionId, metrics, this.sessionStartNano, this.userEmail),
+					sendMetrics(
+						this.config,
+						this.sessionId,
+						metrics.map((m) => ({
+							...m,
+							attrs: {
+								...m.attrs,
+								"user.account_uuid": this.userId ?? "",
+							},
+						})),
+						this.sessionStartNano,
+					),
 				),
 			)
 		}
@@ -224,6 +247,7 @@ export class SessionContext {
 		}
 		getMe(apiKey)
 			.then((me) => {
+				this.userId = me.id
 				this.userEmail = me.email
 			})
 			.catch(() => {


### PR DESCRIPTION
Tool result sizes:
  - tool_result: tool_result_size_chars on all tool types
  - file_read: file_size_chars, read_is_truncated
  - command_executed: bash_output_size_chars

Compaction signals:
  - session.compacted event emitted on each context compaction,
    carrying compaction_count and turn_index
  - session.end: compaction_count, turn_index

Turn index:
  - turn_index added to tool_result, command_executed, user_message,
    session.compacted, session.end, error, file_read, file_written,
    and file_edited events
  - sourced from ctx.turnIndex, updated on each turn_start event
  - enables turn-level queries on all event metric_names including
    child tool events and error correlation

Session-level attribution:
  - user.account_uuid injected into all in-session OTLP log events
    and metric data points
