### PR TITLE
feat: support global AGENTS.md / CLAUDE.md in ~/.config/kimchi/harness/

### DIFF
--- a/docs/agents.md
+++ b/docs/agents.md
@@ -292,3 +292,26 @@ inside the agent's tool calls. Conventional layout:
 Memory is read-only for agents whose `tools` set lacks `write`/`edit` — the
 runtime detects this and skips memory injection rather than confusing the agent
 with directives it cannot act on.
+
+## Global context file
+
+In addition to project-discovered context files, the harness looks up a single
+user-level context file in the harness config directory, applied to every agent
+invocation:
+
+| File | Priority |
+|---|---|
+| `~/.config/kimchi/harness/AGENTS.md` | Preferred |
+| `~/.config/kimchi/harness/CLAUDE.md` | Fallback |
+
+The file is injected **after** any project-level `AGENTS.md` / `CLAUDE.md` files,
+so personal rules win on conflict (recency in the final prompt block). The
+lookup is gated on the persona flag `includeContextFiles` and is skipped when an
+agent runs in `isolated` mode (the Explore/Plan-equivalent fast path).
+
+The location respects `KIMCHI_CODING_AGENT_DIR` (set automatically by the
+harness entrypoint from your `~/.config/kimchi/harness` directory) — set that
+env var to redirect the whole harness directory.
+
+`.local.md` variants are **not** honoured at the global level — the global file
+is already your file, so there is no shared/local distinction to make.

--- a/src/extensions/agents/manager/agent-runner.test.ts
+++ b/src/extensions/agents/manager/agent-runner.test.ts
@@ -85,6 +85,7 @@ vi.mock("../../memory/memory.js", () => ({
 
 vi.mock("../../prompt-construction/context-files.js", () => ({
 	loadProjectContextFiles: vi.fn().mockReturnValue([]),
+	loadGlobalContextFile: vi.fn().mockReturnValue(null),
 }))
 
 vi.mock("../../telemetry/index.js", () => ({
@@ -108,7 +109,7 @@ vi.mock("../../orchestration/model-registry/guidelines/guidelines-resolver.js", 
 import { type AgentSession, DefaultResourceLoader, createAgentSession } from "@earendil-works/pi-coding-agent"
 import { readTelemetryConfig } from "../../../config.js"
 import { buildPhaseGuidelinesSection } from "../../orchestration/model-registry/guidelines/guidelines-resolver.js"
-import { loadProjectContextFiles } from "../../prompt-construction/context-files.js"
+import { loadGlobalContextFile, loadProjectContextFiles } from "../../prompt-construction/context-files.js"
 import telemetryExtension from "../../telemetry/index.js"
 import { getAgentConfig, getConfig, getToolNamesForType } from "../personas/agent-types.js"
 import { buildAgentPrompt } from "../prompt/prompts.js"
@@ -119,6 +120,7 @@ const mockGetConfig = vi.mocked(getConfig)
 const mockGetAgentConfig = vi.mocked(getAgentConfig)
 const mockGetToolNamesForType = vi.mocked(getToolNamesForType)
 const mockLoadProjectContextFiles = vi.mocked(loadProjectContextFiles)
+const mockLoadGlobalContextFile = vi.mocked(loadGlobalContextFile)
 const mockBuildAgentPrompt = vi.mocked(buildAgentPrompt)
 const mockBuildPhaseGuidelinesSection = vi.mocked(buildPhaseGuidelinesSection)
 const mockDefaultResourceLoader = vi.mocked(DefaultResourceLoader)
@@ -972,6 +974,8 @@ describe("runAgent — includeContextFiles", () => {
 		pi = makeFakePi()
 		mockCreateAgentSession.mockReset()
 		mockLoadProjectContextFiles.mockReset()
+		mockLoadGlobalContextFile.mockReset()
+		mockLoadGlobalContextFile.mockReturnValue(null)
 		mockBuildAgentPrompt.mockReset()
 		mockBuildAgentPrompt.mockReturnValue("System prompt text")
 		mockGetConfig.mockReturnValue(makeTypeConfig({ extensions: false, skills: false }))
@@ -1083,6 +1087,91 @@ describe("runAgent — includeContextFiles", () => {
 		})
 
 		expect(mockBuildPhaseGuidelinesSection).toHaveBeenCalledWith(undefined, undefined, expect.anything())
+	})
+
+	it("appends global file LAST after project files when both exist", async () => {
+		const projectFiles = [
+			{ path: "/repo/AGENTS.md", content: "project rule 1" },
+			{ path: "/repo/sub/CLAUDE.md", content: "project rule 2" },
+		]
+		const globalFile = {
+			path: "/home/user/.config/kimchi/harness/AGENTS.md",
+			content: "global rule",
+		}
+		mockLoadProjectContextFiles.mockReturnValue(projectFiles)
+		mockLoadGlobalContextFile.mockReturnValue(globalFile)
+		mockGetAgentConfig.mockReturnValue(
+			makeAgentConfig({ name: "Plan", description: "Plan agent", includeContextFiles: true }),
+		)
+
+		mockCreateAgentSession.mockResolvedValue({
+			session: makeFakeSession() as unknown as Awaited<ReturnType<typeof createAgentSession>>["session"],
+			extensionsResult: { extensions: [], tools: [] } as unknown as Awaited<
+				ReturnType<typeof createAgentSession>
+			>["extensionsResult"],
+		})
+
+		await runAgent(ctx as unknown as Parameters<typeof runAgent>[0], "Plan", "write a plan", {
+			pi: pi as unknown as RunOptions["pi"],
+		})
+
+		expect(mockLoadGlobalContextFile).toHaveBeenCalledWith("/fake-agent-dir")
+		const extras = mockBuildAgentPrompt.mock.calls[0]?.[4]
+		expect(extras?.contextFiles).toEqual([...projectFiles, globalFile])
+	})
+
+	it("uses only global file when project files are empty", async () => {
+		const globalFile = {
+			path: "/home/user/.config/kimchi/harness/AGENTS.md",
+			content: "global rule",
+		}
+		mockLoadProjectContextFiles.mockReturnValue([])
+		mockLoadGlobalContextFile.mockReturnValue(globalFile)
+		mockGetAgentConfig.mockReturnValue(
+			makeAgentConfig({ name: "Plan", description: "Plan agent", includeContextFiles: true }),
+		)
+
+		mockCreateAgentSession.mockResolvedValue({
+			session: makeFakeSession() as unknown as Awaited<ReturnType<typeof createAgentSession>>["session"],
+			extensionsResult: { extensions: [], tools: [] } as unknown as Awaited<
+				ReturnType<typeof createAgentSession>
+			>["extensionsResult"],
+		})
+
+		await runAgent(ctx as unknown as Parameters<typeof runAgent>[0], "Plan", "write a plan", {
+			pi: pi as unknown as RunOptions["pi"],
+		})
+
+		const extras = mockBuildAgentPrompt.mock.calls[0]?.[4]
+		expect(extras?.contextFiles).toEqual([globalFile])
+	})
+
+	it("does not load global file when isolated is true", async () => {
+		mockLoadProjectContextFiles.mockReturnValue([])
+		mockLoadGlobalContextFile.mockReturnValue({
+			path: "/home/user/.config/kimchi/harness/AGENTS.md",
+			content: "should not load",
+		})
+		mockGetAgentConfig.mockReturnValue(
+			makeAgentConfig({ name: "Plan", description: "Plan agent", includeContextFiles: true }),
+		)
+
+		mockCreateAgentSession.mockResolvedValue({
+			session: makeFakeSession() as unknown as Awaited<ReturnType<typeof createAgentSession>>["session"],
+			extensionsResult: { extensions: [], tools: [] } as unknown as Awaited<
+				ReturnType<typeof createAgentSession>
+			>["extensionsResult"],
+		})
+
+		await runAgent(ctx as unknown as Parameters<typeof runAgent>[0], "Plan", "write a plan", {
+			pi: pi as unknown as RunOptions["pi"],
+			isolated: true,
+		})
+
+		expect(mockLoadGlobalContextFile).not.toHaveBeenCalled()
+		expect(mockLoadProjectContextFiles).not.toHaveBeenCalled()
+		const extras = mockBuildAgentPrompt.mock.calls[0]?.[4]
+		expect(extras?.contextFiles).toBeUndefined()
 	})
 })
 

--- a/src/extensions/agents/manager/agent-runner.ts
+++ b/src/extensions/agents/manager/agent-runner.ts
@@ -18,7 +18,11 @@ import { runAsAgentWorker } from "../../agent-worker-context.js"
 import { buildPhaseGuidelinesSection } from "../../orchestration/model-registry/guidelines/guidelines-resolver.js"
 import { ModelRegistry } from "../../orchestration/model-registry/index.js"
 import type { Phase } from "../../orchestration/model-registry/types.js"
-import { loadProjectContextFiles } from "../../prompt-construction/context-files.js"
+import {
+	type ContextFile,
+	loadGlobalContextFile,
+	loadProjectContextFiles,
+} from "../../prompt-construction/context-files.js"
 import { getCurrentPhase, setCurrentPhase } from "../../tags.js"
 import telemetryExtension from "../../telemetry/index.js"
 import { detectEnv } from "../env.js"
@@ -255,10 +259,14 @@ async function runAgentInner(
 	const extensions = options.isolated ? false : config.extensions
 	const skills = options.isolated ? false : config.skills
 
-	const extras: PromptExtras = {
-		contextFiles:
-			agentConfig?.includeContextFiles && !options.isolated ? loadProjectContextFiles(effectiveCwd) : undefined,
+	const includeContext = agentConfig?.includeContextFiles && !options.isolated
+	let contextFiles: ContextFile[] | undefined
+	if (includeContext) {
+		const projectFiles = loadProjectContextFiles(effectiveCwd)
+		const globalFile = loadGlobalContextFile(getAgentDir())
+		contextFiles = globalFile ? [...projectFiles, globalFile] : projectFiles
 	}
+	const extras: PromptExtras = { contextFiles }
 
 	if (Array.isArray(skills)) {
 		const loaded = preloadSkills(skills, effectiveCwd)

--- a/src/extensions/prompt-construction/context-files.test.ts
+++ b/src/extensions/prompt-construction/context-files.test.ts
@@ -1,7 +1,7 @@
 import { mkdirSync, rmSync, writeFileSync } from "node:fs"
 import { join } from "node:path"
 import { afterEach, beforeEach, describe, expect, it } from "vitest"
-import { loadProjectContextFiles } from "./context-files.js"
+import { loadGlobalContextFile, loadProjectContextFiles } from "./context-files.js"
 
 describe("loadProjectContextFiles", () => {
 	const tmpBase = join(import.meta.dirname, "__test_tmp_context__")
@@ -106,5 +106,54 @@ describe("loadProjectContextFiles", () => {
 		expect(inTmp).toHaveLength(1)
 		expect(inTmp[0].path).toBe(join(nested, "AGENTS.md"))
 		expect(inTmp[0].content).toBe("agents wins")
+	})
+})
+
+describe("loadGlobalContextFile", () => {
+	const tmpDir = join(import.meta.dirname, "__test_tmp_global_context__")
+
+	beforeEach(() => {
+		mkdirSync(tmpDir, { recursive: true })
+	})
+
+	afterEach(() => {
+		rmSync(tmpDir, { recursive: true, force: true })
+	})
+
+	it("returns null when neither AGENTS.md nor CLAUDE.md exists", () => {
+		expect(loadGlobalContextFile(tmpDir)).toBeNull()
+	})
+
+	it("returns AGENTS.md content when AGENTS.md exists", () => {
+		writeFileSync(join(tmpDir, "AGENTS.md"), "# My personal rules")
+		const result = loadGlobalContextFile(tmpDir)
+		expect(result).toEqual({
+			path: join(tmpDir, "AGENTS.md"),
+			content: "# My personal rules",
+		})
+	})
+
+	it("returns CLAUDE.md content when only CLAUDE.md exists", () => {
+		writeFileSync(join(tmpDir, "CLAUDE.md"), "# Claude-style rules")
+		const result = loadGlobalContextFile(tmpDir)
+		expect(result).toEqual({
+			path: join(tmpDir, "CLAUDE.md"),
+			content: "# Claude-style rules",
+		})
+	})
+
+	it("prefers AGENTS.md over CLAUDE.md when both exist", () => {
+		writeFileSync(join(tmpDir, "AGENTS.md"), "agents wins")
+		writeFileSync(join(tmpDir, "CLAUDE.md"), "claude loses")
+		const result = loadGlobalContextFile(tmpDir)
+		expect(result?.path).toBe(join(tmpDir, "AGENTS.md"))
+		expect(result?.content).toBe("agents wins")
+	})
+
+	it("does NOT pick up .local.md variants", () => {
+		writeFileSync(join(tmpDir, "AGENTS.md"), "primary content")
+		writeFileSync(join(tmpDir, "AGENTS.local.md"), "local content must be ignored")
+		const result = loadGlobalContextFile(tmpDir)
+		expect(result?.content).toBe("primary content")
 	})
 })

--- a/src/extensions/prompt-construction/context-files.ts
+++ b/src/extensions/prompt-construction/context-files.ts
@@ -59,6 +59,25 @@ function loadContextFileFromDir(dir: string): ContextFile | null {
 }
 
 /**
+ * Look up the user's personal context file in the harness directory.
+ * Returns at most one ContextFile: AGENTS.md if present, else CLAUDE.md,
+ * else null. Does NOT honour .local.md — the global file IS the user's
+ * file, so there is no shared-vs-local distinction to make.
+ *
+ * Exported separately from the project walk so callers can place the
+ * result wherever they want in the final ordering (typically LAST, so
+ * the user's rules override project rules).
+ */
+export function loadGlobalContextFile(harnessDir: string): ContextFile | null {
+	for (const filename of ["AGENTS.md", "CLAUDE.md"]) {
+		const filePath = join(harnessDir, filename)
+		const content = tryReadFile(filePath)
+		if (content !== null) return { path: filePath, content }
+	}
+	return null
+}
+
+/**
  * Walk from `cwd` up to the filesystem root, collecting one context file
  * per directory. Returns them in ancestor-first order (root → cwd).
  */


### PR DESCRIPTION
## Summary

Adds support for a user-level context file at `~/.config/kimchi/harness/AGENTS.md` (fallback `CLAUDE.md`) that gets injected into every agent's system prompt after project-level context files. Personal rules win on conflict via recency in the final prompt block.

## Motivation

Today the harness only discovers `AGENTS.md` / `CLAUDE.md` by walking `cwd → /`. Users have no way to place personal conventions in a single location and have them apply across every project. This mirrors Claude Code's `~/.claude/CLAUDE.md` pattern.

## Behaviour

- **Location**: `~/.config/kimchi/harness/AGENTS.md` (preferred) or `CLAUDE.md` (fallback).
- **Order**: global file appended LAST after project files → personal rules win.
- **Gating**: reuses the existing `includeContextFiles` persona flag. Skipped when `options.isolated` is true (mirrors Claude Code's Explore/Plan skip).
- **Env var**: respects `KIMCHI_CODING_AGENT_DIR` automatically (via `getAgentDir()`).
- **No `.local.md` support at the global level** (YAGNI — the global file IS the user's file).

## Changes

- **`src/extensions/prompt-construction/context-files.ts`**: new exported `loadGlobalContextFile(harnessDir)` helper.
- **`src/extensions/agents/manager/agent-runner.ts`**: call site wires the global file into `extras.contextFiles` after project files.
- **`docs/agents.md`**: new "Global context file" section.
- **Tests**: 5 new unit tests for `loadGlobalContextFile`, 3 new tests for `agent-runner` wiring (covers: both files, project empty + global only, isolated skips both).

## Test plan

- `pnpm run test` — full unit suite passes (4642 tests, +8 new). The 3 pre-existing failures in `terminal-compat/startup-warning.test.ts` are unrelated environmental issues.
- `pnpm run typecheck` — clean.
- `pnpm run lint` — clean on modified files.

## Spec / design

See `docs/superpowers/specs/2026-06-15-global-context-files-design.md` and `docs/superpowers/plans/2026-06-15-global-context-files.md` in the working tree (ephemeral docs, not in this PR).

🤖 Generated with [Claude Code](https://claude.com/claude-code)