### PR TITLE
fix(tool-rendering): show full bash command when expanded

### DIFF
--- a/src/extensions/tool-rendering.ts
+++ b/src/extensions/tool-rendering.ts
@@ -53,7 +53,6 @@ const TOOL_RENDER_CACHE = Symbol.for("pi-claude-style-tools:tool-render-cache")
 const TOOL_CACHE_PATCH_FLAG = Symbol.for("pi-claude-style-tools:patched-tool-cache-invalidation")
 const TOOL_IMAGE_EXPAND_PATCH_FLAG = Symbol.for("pi-claude-style-tools:patched-read-image-expansion")
 const USER_MESSAGE_PATCH_FLAG = Symbol.for("pi-claude-style-tools:patched-user-message-render")
-const HIDDEN_TOOL_BLOCK_NAMES = new Set(["write_todos"])
 const WRAP_MARK = "\uE000"
 const KITTY_IMAGE_PREFIX = "\x1b_G"
 const ITERM2_IMAGE_PREFIX = "\x1b]1337;File="
@@ -243,7 +242,6 @@ function patchGlobalToolBorders(): void {
 	const originalRender = proto.render
 	proto.render = function patchedContainerRender(width: number): string[] {
 		if (isToolExecutionLike(this)) {
-			if (HIDDEN_TOOL_BLOCK_NAMES.has(this.toolName.toLowerCase())) return []
 			const cached = (this as any)[TOOL_RENDER_CACHE]
 			if (cached?.width === width && cached?.mode === toolBackgroundMode) {
 				return cached.lines
@@ -3943,7 +3941,10 @@ export default function (pi: ExtensionAPI) {
 			return bashTool.execute(toolCallId, params, signal, onUpdate)
 		},
 		renderCall(args, theme, ctx) {
-			const summary = summarizeText(getBashCommandForDisplay(args.command) ?? args.command, 72)
+			const command = getBashCommandForDisplay(args.command) ?? args.command
+			const summary = ctx.expanded
+				? (command ?? "").replace(/\n+/g, " \u23ce ")
+				: summarizeText(command, 72)
 			const timer = formatToolTimer(getToolElapsedMs(ctx))
 			return makeText(ctx.lastComponent, toolHeader("Bash", summary, theme, toolStatusDot(ctx, theme), timer))
 		},

--- a/src/extensions/tool-rendering.ts
+++ b/src/extensions/tool-rendering.ts
@@ -3947,7 +3947,7 @@ export default function (pi: ExtensionAPI) {
 				// Expanded: show the tool name + timer on line 1, then the full
 				// command (with real newlines) as a continued branch block below.
 				const hdr = toolHeader("Bash", "", theme, toolStatusDot(ctx, theme), timer)
-				const cmdBlock = withBranch(theme.fg("accent", command), theme, false, true)
+				const cmdBlock = withBranch(command.split("\n").map((l) => theme.fg("accent", l)).join("\n"), theme, false, true)
 				return makeText(ctx.lastComponent, `${hdr}\n${cmdBlock}`)
 			}
 			const summary = summarizeText(command, 72)
@@ -3980,7 +3980,7 @@ export default function (pi: ExtensionAPI) {
 			const collapsed = bashCollapsedLimit()
 			text += `\n${buildPreviewText(
 				nonEmpty.map((line) => theme.fg("dim", line)),
-				false,
+				expanded,
 				theme,
 				collapsed,
 			)}`

--- a/src/extensions/tool-rendering.ts
+++ b/src/extensions/tool-rendering.ts
@@ -3942,10 +3942,15 @@ export default function (pi: ExtensionAPI) {
 		},
 		renderCall(args, theme, ctx) {
 			const command = getBashCommandForDisplay(args.command) ?? args.command
-			const summary = ctx.expanded
-				? (command ?? "").replace(/\n+/g, " \u23ce ")
-				: summarizeText(command, 72)
 			const timer = formatToolTimer(getToolElapsedMs(ctx))
+			if (ctx.expanded && command) {
+				// Expanded: show the tool name + timer on line 1, then the full
+				// command (with real newlines) as a continued branch block below.
+				const hdr = toolHeader("Bash", "", theme, toolStatusDot(ctx, theme), timer)
+				const cmdBlock = withBranch(theme.fg("accent", command), theme, false, true)
+				return makeText(ctx.lastComponent, `${hdr}\n${cmdBlock}`)
+			}
+			const summary = summarizeText(command, 72)
 			return makeText(ctx.lastComponent, toolHeader("Bash", summary, theme, toolStatusDot(ctx, theme), timer))
 		},
 		renderResult(result, { expanded, isPartial }, theme, ctx) {

--- a/src/extensions/tool-rendering.ts
+++ b/src/extensions/tool-rendering.ts
@@ -53,6 +53,7 @@ const TOOL_RENDER_CACHE = Symbol.for("pi-claude-style-tools:tool-render-cache")
 const TOOL_CACHE_PATCH_FLAG = Symbol.for("pi-claude-style-tools:patched-tool-cache-invalidation")
 const TOOL_IMAGE_EXPAND_PATCH_FLAG = Symbol.for("pi-claude-style-tools:patched-read-image-expansion")
 const USER_MESSAGE_PATCH_FLAG = Symbol.for("pi-claude-style-tools:patched-user-message-render")
+const HIDDEN_TOOL_BLOCK_NAMES = new Set(["write_todos"])
 const WRAP_MARK = "\uE000"
 const KITTY_IMAGE_PREFIX = "\x1b_G"
 const ITERM2_IMAGE_PREFIX = "\x1b]1337;File="
@@ -241,6 +242,7 @@ function patchGlobalToolBorders(): void {
 
 	const originalRender = proto.render
 	proto.render = function patchedContainerRender(width: number): string[] {
+		if (isToolExecutionLike(this) && HIDDEN_TOOL_BLOCK_NAMES.has(this.toolName.toLowerCase())) return []
 		if (isToolExecutionLike(this)) {
 			const cached = (this as any)[TOOL_RENDER_CACHE]
 			if (cached?.width === width && cached?.mode === toolBackgroundMode) {


### PR DESCRIPTION
## Problem

When a `Bash` tool block is expanded (ctrl+o), the command in the header was always truncated to 72 chars. You could see the full output but never the full command that produced it.

## Solution

In expanded mode, the header now shows:
- **Line 1:** tool name + elapsed timer
- **Below:** full command with real newlines, rendered as a continued branch block (`├─` / `│` connectors), each line accent-colored individually

Collapsed mode is unchanged — command still summarized to 72 chars with `...`.

Also fixed `buildPreviewText` being called with hardcoded `false` for its `expanded` argument, which caused `• ctrl+o to expand` to appear even after the block was already expanded.

## Before / After

**Expanded** (old):
<img width="635" height="257" alt="image" src="https://github.com/user-attachments/assets/d2838e74-571e-4226-8e42-e3fa76d2443e" />


**Expanded** (new):
<img width="711" height="534" alt="image" src="https://github.com/user-attachments/assets/b85ab0c6-72aa-417f-a8c0-09a84282de9a" />