### PR TITLE
fix(utils): always report kimchi own version, don't fallback to upsteam

### DIFF
--- a/src/utils.test.ts
+++ b/src/utils.test.ts
@@ -20,13 +20,16 @@ describe("getVersion", () => {
 		expect(v).toBe("dev")
 	})
 
-	it("returns the real version from PI_PACKAGE_DIR package.json", async () => {
+	it("ignores PI_PACKAGE_DIR and always reads the kimchi workspace package.json", async () => {
+		// Point PI_PACKAGE_DIR at a foreign package.json with a real semver.
+		// Even with that set, getVersion() must report the kimchi workspace
+		// version ("0.0.0" → "dev"), not the foreign one.
 		const tmpDir = mkdtempSync(resolve(tmpdir(), "kimchi-test-"))
-		writeFileSync(resolve(tmpDir, "package.json"), JSON.stringify({ name: "kimchi-test", version: "1.2.3" }))
+		writeFileSync(resolve(tmpDir, "package.json"), JSON.stringify({ name: "foreign-pkg", version: "9.9.9" }))
 		vi.stubEnv("PI_PACKAGE_DIR", tmpDir)
 		const { getVersion } = await import("./utils.js")
 		const v = getVersion()
-		expect(v).toBe("1.2.3")
+		expect(v).toBe("dev")
 	})
 
 	it("memoizes the result (returns the same value on repeated calls)", async () => {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -45,10 +45,11 @@ let cachedVersion: string | undefined
 export function getVersion(): string {
 	if (cachedVersion !== undefined) return cachedVersion
 	try {
-		const pkgDir = process.env.PI_PACKAGE_DIR
-		const pkgPath = pkgDir
-			? resolve(pkgDir, "package.json")
-			: resolve(dirname(fileURLToPath(import.meta.url)), "../package.json")
+		// Always read kimchi's own package.json — `PI_PACKAGE_DIR` is set in
+		// dev to point at `@earendil-works/pi-coding-agent` so pi-coding-agent's
+		// getPackageDir() can locate its bundled assets, but it must not
+		// influence the version we report for the kimchi CLI itself.
+		const pkgPath = resolve(dirname(fileURLToPath(import.meta.url)), "../package.json")
 		const pkg = JSON.parse(readFileSync(pkgPath, "utf-8"))
 		let version = pkg.version ?? "unknown"
 		// When the version field is the development placeholder (0.0.0)


### PR DESCRIPTION
Always read kimchi's own package.json. In dev reports `dev` instead of upstream `pi-coding-agent` version.