### PR TITLE
updating prompts to fix inefficiencies

### DIFF
--- a/src/extensions/exploration-guard.test.ts
+++ b/src/extensions/exploration-guard.test.ts
@@ -135,14 +135,14 @@ describe("Threshold triggers", () => {
 		const steers: string[] = []
 		for (let i = 0; i < 7; i++) {
 			guard.turnStart()
-			guard.recordToolCall("grep")
+			guard.recordToolCall("read")
 			guard.turnEnd((text) => steers.push(text))
 		}
 		expect(steers).toHaveLength(1) // only the reminder at 5
 
 		// 8th read-only turn triggers mandatory steer
 		guard.turnStart()
-		guard.recordToolCall("find")
+		guard.recordToolCall("web_search")
 		guard.turnEnd((text) => steers.push(text))
 		expect(steers).toHaveLength(2)
 		expect(steers[1]).toContain("8 consecutive read-only turns")
@@ -154,32 +154,32 @@ describe("Threshold triggers", () => {
 		const steers: string[] = []
 
 		guard.turnStart()
-		guard.recordToolCall("ls")
+		guard.recordToolCall("read")
 		guard.turnEnd((text) => steers.push(text))
 		expect(steers).toHaveLength(0)
 
 		guard.turnStart()
-		guard.recordToolCall("ls")
+		guard.recordToolCall("read")
 		guard.turnEnd((text) => steers.push(text))
 		expect(steers).toHaveLength(1)
 		expect(steers[0]).toContain("2 consecutive read-only turns")
 
 		guard.turnStart()
-		guard.recordToolCall("ls")
+		guard.recordToolCall("read")
 		guard.turnEnd((text) => steers.push(text))
 		expect(steers).toHaveLength(1)
 
 		guard.turnStart()
-		guard.recordToolCall("ls")
+		guard.recordToolCall("read")
 		guard.turnEnd((text) => steers.push(text))
 		expect(steers).toHaveLength(2)
 		expect(steers[1]).toContain("4 consecutive read-only turns")
 	})
 
-	it("each threshold fires once per streak; mandatory steer resets the counter", () => {
+	it("each threshold fires once per streak; mandatory steer resets the counter to hypothesisThreshold", () => {
 		// 5 turns → hypothesis steer (no reset, counter stays at 5)
-		// 8 turns → mandatory steer + reset (counter back to 0)
-		// 5 more turns → hypothesis steer again in the new streak
+		// 8 turns → mandatory steer + reset (counter back to hypothesisThreshold=5)
+		// 3 more turns → mandatory steer again (counter hits steerThreshold=8 again)
 		const guard = createGuard()
 		const steers: string[] = []
 		const readTurn = () => {
@@ -192,34 +192,42 @@ describe("Threshold triggers", () => {
 		expect(steers).toHaveLength(2)
 		expect(steers[0]).toContain("5 consecutive read-only turns")
 		expect(steers[1]).toContain("8 consecutive read-only turns")
-		expect(guard.getConsecutiveReadOnlyTurns()).toBe(0)
+		// Counter resets to hypothesisThreshold (5), not 0
+		expect(guard.getConsecutiveReadOnlyTurns()).toBe(5)
 
-		for (let i = 0; i < 5; i++) readTurn() // new streak after reset
+		// Only 3 more read-only turns needed to reach steerThreshold (8) again
+		for (let i = 0; i < 3; i++) readTurn()
 		expect(steers).toHaveLength(3)
-		expect(steers[2]).toContain("5 consecutive read-only turns")
+		expect(steers[2]).toContain("8 consecutive read-only turns")
 	})
 
-	it("resets counter after mandatory steer fires", () => {
-		const guard = createGuard({ hypothesisThreshold: 99 }) // skip hypothesis steer
+	it("resets counter to hypothesisThreshold after mandatory steer fires", () => {
+		// Custom thresholds: hypothesis at 2, mandatory steer at 4.
+		// After the mandatory steer at turn 4, counter resets to 2 (hypothesisThreshold).
+		// The next 2 read-only turns (turns 5 and 6) increment it to 4 again,
+		// firing the mandatory steer a second time.
+		const guard = createGuard({ hypothesisThreshold: 2, steerThreshold: 4 })
 		const steers: string[] = []
-
-		for (let i = 0; i < 8; i++) {
+		const readTurn = () => {
 			guard.turnStart()
 			guard.recordToolCall("read")
 			guard.turnEnd((text) => steers.push(text))
 		}
-		expect(steers).toHaveLength(1)
-		expect(steers[0]).toContain("concrete action")
-		expect(guard.getConsecutiveReadOnlyTurns()).toBe(0)
 
-		// Subsequent read turns start a fresh streak
-		for (let i = 0; i < 4; i++) {
-			guard.turnStart()
-			guard.recordToolCall("read")
-			guard.turnEnd(() => {})
-		}
-		expect(guard.getConsecutiveReadOnlyTurns()).toBe(4)
-		expect(steers).toHaveLength(1)
+		// Turns 1-4: hypothesis at 2, mandatory at 4
+		for (let i = 0; i < 4; i++) readTurn()
+		expect(steers).toHaveLength(2)
+		expect(steers[0]).toContain("2 consecutive read-only turns")
+		expect(steers[1]).toContain("4 consecutive read-only turns")
+		// Counter resets to hypothesisThreshold (2), not 0
+		expect(guard.getConsecutiveReadOnlyTurns()).toBe(2)
+
+		// Only 2 more turns needed to reach steerThreshold (4) again
+		readTurn() // counter = 3, no steer
+		expect(steers).toHaveLength(2)
+		readTurn() // counter = 4, mandatory steer fires again
+		expect(steers).toHaveLength(3)
+		expect(steers[2]).toContain("4 consecutive read-only turns")
 	})
 
 	it("does not trigger when isEnabled returns false", () => {

--- a/src/extensions/exploration-guard.ts
+++ b/src/extensions/exploration-guard.ts
@@ -3,9 +3,6 @@ import { getPermissionMode } from "./permissions/mode-controller.js"
 
 export const DEFAULT_READ_TOOLS = new Set([
 	"read",
-	"grep",
-	"find",
-	"ls",
 	"web_search",
 	"web_fetch",
 	"lsp_hover",
@@ -17,12 +14,21 @@ export const DEFAULT_READ_TOOLS = new Set([
 	// git log, grep). The false positives it caused on work turns outweigh the
 	// missed detections. Callers who want bash to count can pass a custom
 	// readTools set that includes it.
+	// grep, find, ls are NOT included: they are not first-class registered tools
+	// in every session — agents reach them via bash. Listing them here would
+	// make the guard track tool names that never fire, and encouraged models to
+	// call them by name (producing "tool not found" errors).
 	"mcp",
 ])
 
 export const DEFAULT_WRITE_TOOLS = new Set(["edit", "write", "lsp_rename", "ask_user", "steer_subagent", "Agent"])
 
-export const DEFAULT_NEUTRAL_TOOLS = new Set(["set_phase", "set_model"])
+export const DEFAULT_NEUTRAL_TOOLS = new Set([
+	// set_model is a first-class registered tool. set_phase is a ferment
+	// extension tool and is NOT registered in all session types — removing it
+	// here prevents "tool not found" errors in non-ferment subagent sessions.
+	"set_model",
+])
 
 export interface ExplorationGuardOptions {
 	/** Tools that count as read-only (default: common inspection tools). */
@@ -113,9 +119,12 @@ export class ExplorationGuard {
 		}
 		if (this.consecutiveReadOnlyTurns === this.steerThreshold) {
 			sendSteer(MANDATORY_STEER_BASE.replace("%d", String(this.steerThreshold)))
-			// Reset after the mandatory steer so the model gets a fresh budget
-			// rather than immediately re-triggering on the next read turn.
-			this.consecutiveReadOnlyTurns = 0
+			// Reset to hypothesisThreshold (not 0) so the model gets a short
+			// grace window rather than a full fresh budget. This means the next
+			// mandatory steer fires after (steerThreshold - hypothesisThreshold)
+			// additional read-only turns — 3 turns with the defaults — instead of
+			// the full 8, catching persistent exploration loops much sooner.
+			this.consecutiveReadOnlyTurns = this.hypothesisThreshold
 		}
 	}
 

--- a/src/extensions/orchestration/orchestration-instructions.ts
+++ b/src/extensions/orchestration/orchestration-instructions.ts
@@ -164,7 +164,11 @@ The review agent runs tests, checks lint, and verifies the implementation matche
 
 **Review verdicts are final**: Never edit a review report to change its verdict. If a flag is genuinely wrong, add a separate rationale note alongside the original review — do not alter the reviewer's output.
 
-**Orchestrator discipline**: Between delegation calls, you may do at most 5 tool calls (e.g. reading the spec file, setting the phase, checking a subagent result). If you find yourself doing reads, edits, bash calls, or writes on implementation files, STOP — you are doing a subagent's job. Delegate it instead. **Post-abort anti-pattern**: When a subagent aborts (budget or turns), do NOT manually complete its remaining work — this is the most common violation. Spawn a follow-up Agent scoped to the unfinished portion. List what the aborted agent completed and what remains. The orchestrator orchestrates; it does not build.
+**Orchestrator discipline**: Between delegation calls, you may do at most 5 tool calls (e.g. reading the spec file, setting the phase, checking a subagent result). If you find yourself doing reads, edits, bash calls, or writes on implementation files, STOP — you are doing a subagent's job. Delegate it instead.
+
+**Post-abort rule (mandatory)**: When a subagent aborts due to token budget or turn limit, your ONLY permitted action in that turn is to spawn a follow-up Agent scoped to the unfinished portion. Zero other tool calls are allowed in that turn — no reading source files, no running tests, no grepping, no editing. List in the follow-up prompt what the aborted agent completed and what remains. If you call any tool other than Agent after receiving an abort, you are violating orchestrator discipline.
+
+**Write-tool guard**: If you catch yourself calling \`edit\` or \`write\` on implementation files (anything outside \`.kimchi/docs\`), STOP immediately. You are doing build work that belongs to a Builder subagent. Spawn a Builder Agent for the remaining work instead. Writing spec or findings files to \`.kimchi/docs\` is the only exception — those are orchestrator responsibilities.
 
 ### Sharing context between agents
 


### PR DESCRIPTION
Issue 1 - Ghost tool names (find, ls, grep, set_phase):

Removed grep, find, ls from DEFAULT_READ_TOOLS in exploration-guard.ts. These aren't first-class registered tools — they're bash subcommands. The guard was tracking names that
never fire, and the system prompt's tool list encouraged models to call them directly, producing "tool not found" errors.
Removed set_phase from DEFAULT_NEUTRAL_TOOLS. It's a ferment extension tool, not registered in all session types (particularly subagents). Subagents that don't have ferment
wired were getting errors every time the guard was tracked against it.
Updated the 4 tests that used grep, find, ls as tool names to use read and web_search instead.
Issue 2 - Guard resets too generously (fires 5-7× per session):

Changed the mandatory steer reset from consecutiveReadOnlyTurns = 0 to consecutiveReadOnlyTurns = this.hypothesisThreshold in exploration-guard.ts. With defaults (hypothesis=5,
steer=8), the next mandatory steer fires 3 turns later instead of 8. Persistent exploration loops now get a hard steer every 3 turns rather than every 8.
Updated tests to reflect the new reset value and added a test verifying the tighter re-firing cadence.
Issue 5 - Orchestrator doing build work instead of delegating:

Strengthened the "Orchestrator discipline" paragraph in orchestration-instructions.ts with two explicit rules:
Post-abort rule: after a subagent abort, the orchestrator's only permitted action is spawning a follow-up Agent — zero other tool calls allowed in that turn.
Write-tool guard: calling edit/write on implementation files (anything outside .kimchi/docs) is an immediate stop signal — spawn a Builder instead.