### PR TITLE
fix(ferment-model-locking): respect model switches during active ferments

### DIFF
--- a/src/extensions/ferment/events.test.ts
+++ b/src/extensions/ferment/events.test.ts
@@ -1,7 +1,8 @@
 import { mkdtempSync } from "node:fs"
 import { tmpdir } from "node:os"
 import { join } from "node:path"
-import type { ExtensionAPI } from "@earendil-works/pi-coding-agent"
+import type { Api, Model } from "@earendil-works/pi-ai"
+import type { ExtensionAPI, ModelRegistry } from "@earendil-works/pi-coding-agent"
 import { afterEach, describe, expect, it, vi } from "vitest"
 import { FermentEventStore } from "../../ferment/event-store.js"
 import { registerFermentEvents } from "./events.js"
@@ -316,5 +317,27 @@ describe("registerFermentEvents", () => {
 			{ triggerTurn: false },
 		)
 		expect(ctx.ui.notify).toHaveBeenCalledWith('Plan saved for "Google OAuth Login". 1 phase(s) ready.')
+	})
+
+	it("model_select captures the newly-selected model in the judge context", () => {
+		const captureJudgeContext = vi.fn()
+		const runtime: FermentRuntime = {
+			...createDefaultFermentRuntime(),
+			captureJudgeContext,
+		}
+		const { handlers, pi } = createPi()
+		registerFermentEvents(pi, runtime)
+
+		const handler = handlers.get("model_select")
+		if (!handler) throw new Error("model_select handler was not registered")
+
+		const newModel = { id: "new-model" } as unknown as Model<Api>
+		const previousModel = { id: "previous-model" } as unknown as Model<Api>
+		const modelRegistry = {} as ModelRegistry
+		const ctx = { modelRegistry }
+
+		handler({ model: newModel, previousModel }, ctx)
+
+		expect(captureJudgeContext).toHaveBeenCalledWith(newModel, modelRegistry)
 	})
 })

--- a/src/extensions/ferment/events.ts
+++ b/src/extensions/ferment/events.ts
@@ -394,7 +394,7 @@ export function registerFermentEvents(pi: ExtensionAPI, runtime: FermentRuntime 
 		return {}
 	})
 
-	pi.on("model_select", async (event, ctx) => {
+	pi.on("model_select", (event, ctx) => {
 		runtime.captureJudgeContext(event.model, ctx?.modelRegistry)
 	})
 

--- a/src/extensions/ferment/events.ts
+++ b/src/extensions/ferment/events.ts
@@ -21,7 +21,7 @@ import { loadFermentSilently, resumeFerment } from "./resume.js"
 import { type FermentRuntime, defaultFermentRuntime } from "./runtime.js"
 import { scheduleFermentWakeUp } from "./scheduler.js"
 import { confirmPendingScope } from "./scoping-confirmation.js"
-import { clearActiveFermentId, getActiveFermentId, isRestoringModel, setRestoringModel } from "./state.js"
+import { clearActiveFermentId, getActiveFermentId } from "./state.js"
 import { createApplyAndPersist } from "./tool-helpers.js"
 import {
 	applyFermentRuntimeToolProfile,
@@ -395,23 +395,7 @@ export function registerFermentEvents(pi: ExtensionAPI, runtime: FermentRuntime 
 	})
 
 	pi.on("model_select", async (event, ctx) => {
-		runtime.captureJudgeContext(ctx?.model, ctx?.modelRegistry)
-		const f = runtime.getActive()
-		if (!f || f.status !== "running") return
-		if (isRestoringModel()) return
-
-		if (event.previousModel) {
-			setRestoringModel(true)
-			pi.setModel(event.previousModel)
-				.catch(() => {})
-				.finally(() => {
-					setRestoringModel(false)
-				})
-		}
-		ctx.ui.notify(
-			`Model switching is locked while ferment "${f.name}" is running. Finish or abandon the ferment first.`,
-			"warning",
-		)
+		runtime.captureJudgeContext(event.model, ctx?.modelRegistry)
 	})
 
 	pi.on("turn_end", async (event, ctx) => {

--- a/src/extensions/ferment/state.ts
+++ b/src/extensions/ferment/state.ts
@@ -108,19 +108,6 @@ export function markHumanInput(): void {
 	lastHumanInputAt = new Date()
 }
 
-// ─── Model-switch suppression ─────────────────────────────────────────────────
-// Used by model_select handler to prevent infinite recursion when reverting.
-
-let restoringModel = false
-
-export function isRestoringModel(): boolean {
-	return restoringModel
-}
-
-export function setRestoringModel(v: boolean): void {
-	restoringModel = v
-}
-
 // ─── Judge model handles (captured opportunistically from ctx) ────────────────
 
 let judgeModel: Model<Api> | undefined

--- a/src/extensions/model-switch.ts
+++ b/src/extensions/model-switch.ts
@@ -1,7 +1,6 @@
 import type { Api, Model } from "@earendil-works/pi-ai"
 import type { ExtensionAPI } from "@earendil-works/pi-coding-agent"
 import { Type } from "typebox"
-import { isRestoringModel } from "./ferment/state.js"
 import {
 	contextFitsModel,
 	getLatestMessages,
@@ -203,8 +202,6 @@ export default function modelSwitchExtension(pi: ExtensionAPI) {
 		if (suppressModelSelectGuard) return
 		// cycle and restore are handled by ctrl+p / session recovery already
 		if (event.source === "cycle" || event.source === "restore") return
-		// Skip if ferment is reverting (its own rollback path)
-		if (isRestoringModel()) return
 
 		// Flush the multi-model flag that the harness /models UI sets via
 		// process.__kimchiMultiModelEnabled.  getMultiModelEnabled() detects a


### PR DESCRIPTION
## Description

Remove the Ferment-owned model_select rollback that restored the previous model while a ferment was running. That lock was originally added to preserve planner consistency when Ferment prescribed a stable planner/worker model policy, but that policy is now obsolete: worker selection is handled by the orchestrator and Ferment no longer stores worker model intent.

Ferment still captures the active model/registry for judge fallback, and the normal model-switch guards continue to reject unsafe switches such as context window overflow or image-incompatible targets.


## Type of Change

<!-- Select all that apply. -->

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
