### PR TITLE
docs: rewrite README for clarity and conciseness

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,30 @@
+<div align="center">
+
+<a href="https://kimchi.dev"><img src="./kimchi.png" alt="kimchi" width="300" /></a>
+
 # kimchi
 
-A coding agent CLI powered by [kimchi](https://kimchi.dev/). Built on the [pi-mono](https://github.com/badlogic/pi-mono) coding agent SDK, kimchi gives you an AI-powered development assistant in your terminal that connects to kimchi's LLM infrastructure.
+[![CI](https://img.shields.io/github/actions/workflow/status/getkimchi/kimchi/ci.yml?style=flat-square&label=CI)](https://github.com/getkimchi/kimchi/actions)
+![Node](https://img.shields.io/badge/node-%3E%3D22-3c873a?style=flat-square)
+[![TypeScript](https://img.shields.io/badge/TypeScript-blue?style=flat-square&logo=typescript&logoColor=white)](https://www.typescriptlang.org)
+[![License](https://img.shields.io/badge/license-Apache%202.0-blue?style=flat-square)](LICENSE)
+[![Discord](https://img.shields.io/badge/Discord-Join-5865F2?style=flat-square&logo=discord&logoColor=white)](https://discord.com/invite/getkimchi)
+[![X/Twitter](https://img.shields.io/badge/X%2FTwitter-@kimchi__dev-black?style=flat-square&logo=x)](https://x.com/kimchi_dev)
+[![LinkedIn](https://img.shields.io/badge/LinkedIn-kimchi--dev-0A66C2?style=flat-square&logo=linkedin)](https://www.linkedin.com/company/kimchi-dev/)
 
-![kimchi](./kimchi.png)
+**A multi-model coding agent CLI for your terminal.**
+
+Kimchi connects to a fleet of LLMs and automatically delegates each task to the model best suited for the job — orchestration, planning, building, reviewing, or exploration. Projects survive across sessions via [Ferment](#ferment), a cross-session project mode with deterministic state recovery.
+
+[Quick start](#quick-start) · [Features](#features) · [Multi-model orchestration](#multi-model-orchestration) · [Ferment](#ferment) · [Development](#development) · [Docs](#docs)
+
+</div>
+
+---
 
 ## Quick start
 
-Install the latest release:
+### Install
 
 **Homebrew (macOS / Linux):**
 
@@ -20,83 +38,50 @@ brew install getkimchi/tap/kimchi
 curl -fsSL https://github.com/getkimchi/kimchi/releases/latest/download/install.sh | bash
 ```
 
-Then configure your API key and launch:
+### Configure & run
 
 ```bash
 kimchi setup   # one-time interactive setup
 kimchi         # launch the coding agent
 ```
 
-Run `kimchi --help` to see all available subcommands and flags.
+Run `kimchi --help` for all subcommands and flags.
 
-## Models
+> [!TIP]
+> On first run, kimchi can migrate your MCP servers and skills from Claude Code or OpenCode. You'll see a one-shot prompt if anything is migratable.
 
-### Model selection
+---
 
-The supported model list is fetched at startup from the kimchi metadata service. Use `/model` or `ctrl+p` in the interactive CLI to switch between available models.
+## Features
 
-Kimchi operates in one of two modes:
+| Feature | What it does |
+|---------|-------------|
+| **Multi-model orchestration** | Classifies every task and delegates it to the right model — heavy models for architecture, fast models for exploration. [Details](#multi-model-orchestration) |
+| **Ferment** | Multi-session project mode with phases, steps, and automatic cross-session recovery. [Details](#ferment) |
+| **MCP integration** | Connect to MCP servers for external tools (filesystem, GitHub, web search, etc.). |
+| **Tagging** | Tag every LLM request for cost attribution and usage tracking. |
+| **Remote teleport** | Session-multiplex across remote sandboxes without restarting kimchi. |
+| **Token optimization (RTK)** | Optional output compression (60–90% reduction) for bash tool calls. |
+| **Agent migration** | One-shot import of MCP servers and skills from Claude Code / OpenCode. |
+| **IDE mode (ACP)** | JSON-RPC over stdio for editor integration. |
 
-| Mode | Footer indicator | Behavior |
-|------|-----------------|----------|
-| **Multi-model** | `multi-model (orchestrator-id)` | The orchestrator delegates each task to the model assigned for that role |
-| **Single-model** | model name | All work runs on the selected model directly |
+---
 
-Use `ctrl+p` to cycle through models. The last entry in the cycle is `multi-model`. You can also open the `/model` picker and select a specific model or `multi-model` from the list.
+## Multi-model orchestration
 
-In single-model mode the orchestration system prompt (environment, tools, research rules, guidelines, phase tagging) stays active, but task classification and delegation are disabled. The subagent tool remains available if you explicitly ask the agent to delegate.
+Kimchi does not run everything on one model. Each task is classified and routed to a role-specific model pool:
 
-### Model roles
+| Role | Default | Purpose |
+|------|---------|---------|
+| **Orchestrator** | `kimi-k2.6` | Main loop, task classification, delegation |
+| **Planner** | `kimi-k2.6` | Architecture, specs, interface design |
+| **Builder** | `minimax-m2.7` | Code implementation |
+| **Reviewer** | `kimi-k2.6` / `minimax-m2.7` | Code review, verification |
+| **Explorer** | `kimi-k2.6` / `nemotron-3-super-fp4` | Codebase exploration, research |
 
-In multi-model mode, each task type is handled by a specific role. Each role can have one model or a **pool of candidates** — the orchestrator reads model descriptions (tier, capabilities) and picks the best fit for each task.
+Switch models interactively with `ctrl+p` or `/model`. Toggle between single-model and multi-model mode on the fly.
 
-Use `/multi-model` in the interactive CLI to toggle models on/off per role, or edit `~/.config/kimchi/harness/settings.json` directly:
-
-```json
-{
-  "modelRoles": {
-    "orchestrator": "kimchi-dev/kimi-k2.6",
-    "builder": ["kimchi-dev/minimax-m2.7", "anthropic/claude-sonnet-4-5"],
-    "reviewer": "anthropic/claude-sonnet-4-5",
-    "explorer": "kimchi-dev/nemotron-3-super-fp4"
-  }
-}
-```
-
-| Role | Default | Description |
-|------|---------|-------------|
-| **orchestrator** | `kimi-k2.6` | Runs the main loop, classifies tasks, delegates work. Single model. |
-| **planner** | `kimi-k2.6` | Designs the approach, writes specs. When same as orchestrator, planning is done in-process. |
-| **builder** | `minimax-m2.7` | Code implementation. For complex tasks the orchestrator may pick a heavier model from the pool. |
-| **reviewer** | `kimi-k2.6`, `minimax-m2.7` | Code review. Orchestrator picks the strongest by tier for initial review. |
-| **explorer** | `kimi-k2.6`, `nemotron-3-super-fp4` | Codebase exploration, research. Light models for broad scans, heavy for deep analysis. |
-
-Defaults are derived from model capabilities in `MODEL_CAPABILITIES`. Roles accept any `provider/model-id` string or an array of strings. Only non-default values need to be specified; missing keys fall back to defaults.
-
-#### How model selection works
-
-The orchestrator sees each role's model pool with tier and description. It picks the model whose description best matches the task:
-
-- **Simple build chunk** (CRUD, parsers, CLI): picks standard-tier builder (minimax-m2.7)
-- **Complex build chunk** (concurrency, graph algorithms): picks the heaviest model whose description confirms correctness reasoning
-- **Code review**: picks the strongest reviewer by tier — fresh Agent context provides independence
-- **Exploration**: picks a light model for broad file reading, heavy for deep analysis
-
-#### Example: using Claude for builds
-
-To use Claude Sonnet for all build work while keeping kimchi-dev models for orchestration and review:
-
-```json
-{
-  "modelRoles": {
-    "builder": "anthropic/claude-sonnet-4-5"
-  }
-}
-```
-
-#### Example: mixed pool with tier-based selection
-
-To give the orchestrator a choice between a cheap builder and a strong one, and let it pick based on chunk complexity:
+Configure role assignments in `~/.config/kimchi/harness/settings.json`:
 
 ```json
 {
@@ -107,298 +92,92 @@ To give the orchestrator a choice between a cheap builder and a strong one, and 
 }
 ```
 
-The orchestrator will use minimax for simple chunks and Claude for complex ones (based on the plan's complexity classification).
+> [!NOTE]
+> The orchestrator picks the best model from each pool based on the task's complexity classification.
 
-### Phase tracking
+---
 
-Kimchi tags every LLM request with a `phase:{name}` label for usage analytics and cost attribution. The orchestrator sets the phase as work progresses and it is displayed in the footer.
+## Ferment
 
-| Phase | Description |
-|-------|-------------|
-| `explore` | Navigating the codebase, reading files to understand structure |
-| `plan` | Designing, breaking down tasks, writing specs |
-| `build` | Writing, modifying, or refactoring code |
-| `review` | Analyzing output, verifying correctness |
-| `research` | Investigating documentation, researching issues |
-
-Subagents inherit the current phase from the orchestrator but cannot change it.
-
-## Tags
-
-Kimchi supports tagging LLM requests for usage tracking and cost attribution. Tags are included with every request and displayed in the footer, grouped by key with color coding.
-
-### Commands
-
-| Command | Description |
-|---------|-------------|
-| `/tags` | List all active tags |
-| `/tags add key:value ...` | Add one or more tags (e.g., `/tags add project:myapp team:backend`) |
-| `/tags remove tag ...` | Remove one or more user-defined tags |
-| `/tags clear` | Remove all user-defined tags |
-
-### Tag format
-
-Tags use `key:value` format. Key and value must start and end with alphanumeric characters (middle characters may include `-`, `_`, `.`), each 64 characters max, 10 tags total.
-
-### Static tags
-
-Set via the `KIMCHI_TAGS` environment variable (comma-separated). Static tags are read-only within the session and shown with a `[static]` marker.
+Ferment is kimchi's project mode for long-running, multi-session work. Instead of starting from scratch every chat, Ferment persists a structured plan and resumes exactly where you left off.
 
 ```bash
-export KIMCHI_TAGS="team:backend,project:api"
+kimchi --ferment "Build a Redis clone"
 ```
 
-### Auto-tags
+Inside a session:
 
-Two tags are added automatically to every request and do not count toward the 10 tag limit:
+```
+/ferment new "Build a Redis clone"   # create
+/ferment auto                         # automated continuation
+/ferment progress                     # navigate phases & steps
+```
 
-- `model:{model_id}` -- the model handling the request
-- `phase:{phase}` -- the current work phase
+**How it works:**
+- **Ferment** — the project ("Build a Redis clone")
+- **Phase** — a milestone (e.g. "Wire protocol", "Data structures")
+- **Step** — a concrete task (e.g. "Implement RESP parser")
+- **Decision** — an architectural choice recorded for posterity
+- **Memory** — conventions, gotchas, patterns discovered during work
 
-### Persistence
-
-User-defined tags (added via `/tags add`) are persisted to `~/.config/kimchi/tags.json` and survive across sessions. Static tags from `KIMCHI_TAGS` must be set each session.
-
-## Ferment -- cross-session project management
-
-Ferment is Kimchi's progressive-refinement project mode for multi-session work. Instead of starting from scratch each chat, Ferment persists a structured plan (goal, phases, steps) as a JSON state file.
-
-### Quick start
+State is persisted under `.kimchi/ferments/`. Every mutation is an append-only event with pre/post state hashes, enabling full auditability and deterministic recovery.
 
 ```bash
-kimchi --ferment "Build Tetris"
+# Day 1: work, crash, terminal closes
+# Day 2: re-run `kimchi --ferment "Build a Redis clone"` → resumes exactly where it stopped
 ```
 
-Or inside an active session:
+> [!NOTE]
+> For full documentation see [`docs/ferment.md`](docs/ferment.md).
 
-```
-/ferment new "Build Tetris"    # create a ferment
-/ferment auto                   # keep going until done or blocked
-```
-
-### Concepts
-
-- **Ferment** -- the top-level project (e.g. "Build Tetris", "Auth rewrite")
-- **Phase** -- a milestone within the project (e.g. "Canvas & Grid", "Movement")
-- **Step** -- a single executable task within a phase (e.g. "Create index.html")
-- **Decision** -- an architectural choice recorded for posterity
-- **Memory** -- a gotcha, convention, or pattern encountered during work
-
-### State machine
-
-All lifecycle transitions are validated by a deterministic finite state machine that enforces valid state changes and prevents illegal operations (e.g. completing a step before it starts, skipping an already-completed phase).
-
-```
-draft -> planned -> running -> [paused] -> complete
-```
-
-1. **draft** -- created via `/ferment new`, agent collects goal and phases conversationally
-2. **planned** -- `scope_ferment` sets goal, criteria, constraints, phase breakdown
-3. **running** -- `activate_ferment_phase` starts a phase, agent executes steps
-4. **paused** -- user intervention required, or paused with `/ferment pause`
-5. **complete** -- all phases terminal
-
-### Continuation policy
-
-Controls whether the active ferment advances across phase boundaries.
-
-| Policy | Behavior | Command |
-|--------|----------|---------|
-| **manual** | Ask before moving to the next phase | `/ferment manual` |
-| **automated** | Keep going until complete, blocked, paused, or user input is needed | `/ferment auto` |
-
-Pause/resume is separate: `/ferment pause` stops the ferment, `/ferment resume` continues it using the current policy. `/ferment exit` leaves Ferment mode without deleting or abandoning the ferment; planned/running work is paused first, active Ferment UI/tools are cleared, and you can later select it from `/ferment list` or `/ferment switch`.
-
-### Commands
-
-| Command | Description |
-|---------|-------------|
-| `/ferment` | Start a new ferment via prompt |
-| `/ferment new "Name"` | Create new ferment |
-| `/ferment switch <id>` | Resume by ID prefix or name |
-| `/ferment delete <id>` | Delete permanently |
-| `/ferment export` | Export stats to JSON |
-| `/ferment progress` | Open phase/step navigator overlay |
-| `/ferment manual` | Set manual continuation policy |
-| `/ferment auto` | Set automated continuation policy |
-| `/ferment pause` | Pause the active ferment lifecycle |
-| `/ferment resume` | Resume the active ferment lifecycle |
-| `/ferment exit` | Leave Ferment mode without deleting the ferment |
-
-### Recovery
-
-Every session writes a `ferment_reference` entry in the session log. On next start, the harness reads this entry and resumes from the exact state.
-
-```bash
-# Day 1
-$ kimchi --ferment "Build Tetris"
-# ... agent works, crashes, terminal closes ...
-
-# Day 2
-$ kimchi --ferment "Build Tetris"
-# -> Rehydrates state, continues Phase 2 exactly where it left off
-```
-
-### Where state lives
-
-```
-.kimchi/
-  ferments/
-    <uuid>.json          -- snapshot (machine-readable plan state)
-    <uuid>.events.jsonl  -- append-only audit log of every transition
-  sessions/
-    <timestamp>.jsonl    -- chat history + tool calls
-```
-
-Every mutation is persisted as an append-only event with pre/post state hashes, enabling full auditability. Stats (phase/step counts, timing, model usage, grade distributions) are computed on demand from the snapshot and exported via `/ferment export`.
-
-For full documentation see `docs/ferment.md` and `docs/ferment-storage-schema.md`.
-
-## Remote teleport (preview)
-
-Launch with `kimchi --teleport` to enable session-multiplex commands. The local TUI stays the home base; remote workers are spawned, detached, and re-attached without restarting kimchi.
-
-```bash
-kimchi --teleport
-```
-
-Slash commands available inside the TUI:
-
-| Command | Description |
-|---------|-------------|
-| `/teleport [name] [flags]` | Rsync the working tree to a fresh remote sandbox and foreground it. Flags: `--allow-dirty`, `--exclude <glob>`, `--include-ignored`, `--abandon-pending`, `--force` |
-| `/detach [--abandon-pending]` | Drop the WebSocket to the foreground remote and return to the local home base. The server keeps the session running. |
-| `/attach <name-or-id>` | Re-attach to a previously detached remote |
-| `/sessions` | List everything: foreground remote, detached remotes, server-side sessions |
-| `/connect [name-or-id]` | Open an interactive SSH shell on the sandbox via the teleport proxy |
-
-`--teleport` and `--remote` are mutually exclusive. Use `--remote --session <id>` to attach to a single remote at startup; use `--teleport` to multiplex from a local home base.
+---
 
 ## Configuration
 
-### Authentication
+### API key
 
-The API key is resolved in this order:
-
-1. `KIMCHI_API_KEY` environment variable (takes precedence)
+Resolved in order:
+1. `KIMCHI_API_KEY` environment variable
 2. `~/.config/kimchi/config.json` field `api_key`
 
-Run `kimchi setup` for an interactive first-time configuration.
+Run `kimchi setup` for interactive first-time configuration.
 
-### Agent config
+### Tags
 
-Kimchi stores its configuration (settings, sessions, models) under:
-
-```
-~/.config/kimchi/harness/
-```
-
-### Packages
-
-Kimchi supports native Pi packages. `kimchi install npm:<package>` installs a package only for Kimchi, while `pi install npm:<package>` keeps the package owned by the original Pi harness. Kimchi can also load original Pi packages through the **Pi package lookup** resource, so both CLIs can use Pi packages without sharing Kimchi's install scope.
-
-If the same package is installed in both places, the Kimchi install wins. Disable original Pi package lookup with:
+Track usage and cost with `key:value` tags:
 
 ```bash
-kimchi resources disable extensions.pi-package-lookup
+/tags add project:api team:backend
 ```
 
-Update packages with:
-
-```bash
-kimchi update                  # update installed packages, then Kimchi itself
-kimchi update --extensions     # update installed packages only
-kimchi update context-mode     # update one package by source or display name
-kimchi update self             # update Kimchi itself only
-```
+Static tags via `KIMCHI_TAGS="team:backend,project:api"`. Auto-tags (`model:`, `phase:`) are added to every request.
 
 ### HTTP proxy
 
-Kimchi respects `HTTP_PROXY` / `HTTPS_PROXY` environment variables for network requests.
-
-### Token optimization (RTK)
-
-Kimchi installs [RTK](https://github.com/rtk-ai/rtk) during setup and keeps the `rtk` command available on startup. When enabled, kimchi rewrites bash tool calls through `rtk rewrite` before execution. This compresses command output (git, cargo, npm, docker, etc.) by 60-90%, reducing LLM context usage.
-
-Before every bash tool execution, kimchi calls `rtk rewrite "<command>"`. If RTK returns a rewritten command (e.g. `git status` becomes `rtk git status`), the rewritten version is executed instead.
-
-```bash
-brew install rtk    # macOS / Linux
-```
-
-RTK rewrite is managed from resources:
-
-```bash
-kimchi resources disable hooks.rtk-rewrite
-kimchi resources enable hooks.rtk-rewrite
-```
+Kimchi respects `HTTP_PROXY` / `HTTPS_PROXY`.
 
 ### Hooks
 
-Users can add custom Bash hooks to rewrite or block shell commands before they run. Global hooks live in `~/.config/kimchi/harness/hooks/bash/`; project hooks live in `.kimchi/hooks/bash/` and default to disabled until enabled from `/resources` or `kimchi resources enable ...`.
+Add custom Bash command hooks in `~/.config/kimchi/harness/hooks/bash/` (global) or `.kimchi/hooks/bash/` (project). See [`docs/hooks.md`](docs/hooks.md) for the protocol.
 
-See `docs/hooks.md` for the hook protocol and examples.
-
-### Migrating from another coding agent
-
-On first run, kimchi looks for an existing **Claude Code** or **OpenCode** installation and offers to migrate its MCP servers. If anything is migratable you will see a one-shot prompt:
-
-```
-+  Claude Code + OpenCode configuration found
-|
-|  MCP servers: filesystem, github, ripgrep
-|  Claude Code skills: 4 in ~/.claude/skills
-|  OpenCode skills: 2 in ~/.config/opencode/skills
-|
-*  Migrate MCP servers to Kimchi?
-|  * Migrate now
-|  * Skip this time
-|  * Never ask again
-```
-
-Discovered MCP servers are merged into `~/.config/kimchi/harness/mcp.json`. Existing Kimchi entries always win on name collisions, so re-running the migration is safe.
-
-The prompt is only shown when something is actually worth migrating. If neither agent is installed or both are empty, the wizard skips silently.
-
-#### Sources scanned
-
-| Agent | Config files (read in order, results merged) | Skills directory |
-|---|---|---|
-| Claude Code | `~/.claude.json` (top-level `mcpServers` + per-project `projects[*].mcpServers`) | `~/.claude/skills/` |
-| OpenCode | `$OPENCODE_CONFIG`, then `~/.config/opencode/opencode.json`, `opencode.jsonc`, `config.json`, `~/.opencode.json` | `~/.config/opencode/skills/` |
-
-For OpenCode, both the modern (`mcp` block) and legacy Go-binary (`mcpServers` block) schemas are supported. Servers with `enabled: false` are skipped.
-
-#### Conflict resolution
-
-When the same MCP server name appears in multiple sources:
-
-1. **Within one agent**: earlier files win; project-level entries win over top-level (Claude Code); modern `mcp` block wins over legacy `mcpServers` (OpenCode).
-2. **Across agents**: Claude Code wins over OpenCode.
-3. **Against existing Kimchi config**: your entries in `~/.config/kimchi/harness/mcp.json` always win.
-
-#### "Never ask again"
-
-Stored in `~/.config/kimchi/config.json` (`migrationState: "skip-forever"`). Delete that field to re-trigger the prompt. Adding support for another agent is a small change -- drop a new definition into `src/agent-discovery/agents/` and append it to the registry.
+---
 
 ## Development
 
 ### Prerequisites
 
 - Node.js 22 (LTS)
-- [Bun](https://bun.sh/) (dev server and binary compilation)
+- [Bun](https://bun.sh/)
 - [corepack](https://nodejs.org/api/corepack.html) enabled (`corepack enable`)
-- pnpm (installed automatically via corepack)
+- pnpm (installed via corepack)
 
-### Quick setup
+### Setup
 
 ```bash
-./scripts/dev-startup.sh
+./scripts/dev-startup.sh   # checks deps, installs, copies resources, starts dev
 ```
 
-This script checks and installs node, pnpm, and bun if missing, runs `pnpm install`, copies resources, and starts the harness with `pnpm run dev`.
-
-### Manual setup
+Or manually:
 
 ```bash
 git clone git@github.com:getkimchi/kimchi.git
@@ -411,34 +190,12 @@ pnpm install
 
 | Command | Description |
 |---------|-------------|
-| `pnpm run build` | Compile TypeScript to `dist/` and copy theme assets |
-| `pnpm run dev` | Run the CLI locally via Bun |
+| `pnpm run build` | Compile to `dist/` and copy assets |
+| `pnpm run dev` | Run CLI locally via Bun |
 | `pnpm run check` | Biome lint + TypeScript type check |
-| `pnpm run lint` | Biome lint only |
 | `pnpm run lint:fix` | Biome lint with auto-fix |
-| `pnpm run test` | Run tests with vitest |
+| `pnpm run test` | Unit tests (vitest) |
 | `pnpm run test:smoke` | End-to-end smoke tests |
-
-### Running locally
-
-Propagate resources before first run:
-
-```bash
-node ./scripts/copy-resources.js --dev
-```
-
-Run the CLI directly via Bun:
-
-```bash
-pnpm run dev
-```
-
-Or build a standalone binary:
-
-```bash
-pnpm run build:binary
-./dist/bin/kimchi
-```
 
 ### Project structure
 
@@ -446,53 +203,38 @@ pnpm run build:binary
 src/
   entry.ts              -- Entry point
   cli.ts                -- CLI logic & harness initialization
-  cli-args.ts           -- Argument parsing
-  config.ts             -- Auth & config loading
-  models.ts             -- Model metadata fetching & registration
-  setup-wizard.ts       -- First-run wizard
-  commands/             -- CLI subcommands (setup, login, config, update, ...)
+  commands/             -- CLI subcommands
   extensions/           -- Agent extensions
-    agents/             -- Subagent system (personas, manager, memory)
-    orchestration/      -- Task classification, model registry, delegation
+    agents/             -- Subagent system
+    orchestration/      -- Task classification & delegation
     ferment/            -- Ferment lifecycle tools & UI
     mcp-adapter/        -- MCP server integration
-    permissions/        -- Tool auth flows
-    behaviours/         -- Contextual prompt behaviours
-    web-fetch/          -- Web content fetching
-    web-search/         -- Web search
-    lsp/                -- Language Server Protocol
-    login/              -- OAuth flows
-    onboarding/         -- Session mode startup wizard
-  ferment/              -- Ferment state machine, event store, stats
   modes/
     interactive/        -- TUI harness
-    acp/                -- JSON-RPC over stdio (IDE integration)
+    acp/                -- JSON-RPC over stdio (IDE)
     teleport/           -- Remote session multiplexing
-  agent-discovery/      -- Detection & migration of other coding agents
-  config/               -- Config loading & merging
-  auth/                 -- API key management
-  utils/                -- Shared helpers
+  agent-discovery/      -- Migration from other coding agents
+  ferment/              -- Ferment state machine & event store
 ```
+
+---
 
 ## Benchmarking
 
-The `benchmark/` directory contains tools for smoke-testing kimchi sessions and auditing their quality.
+The `benchmark/` directory contains quality and performance tooling:
 
-- **Manual benchmarks** (`benchmark/manual/`) -- run predefined tasks against different models and compare results. See `benchmark/manual/README.md`.
-- **Terminal-bench-2** (`benchmark/terminal-bench-2/`) -- run the [terminal-bench](https://www.harborframework.com/) suite (89 tasks) against kimchi inside Docker containers. See `benchmark/terminal-bench-2/README.md`.
-- **Session audit** (`benchmark/audit-session/`) -- audit a completed session for phase discipline, code quality, architecture, testing, model alignment, and cost efficiency. See `benchmark/audit-session/README.md`.
+| Suite | What it does | Read more |
+|-------|-------------|-----------|
+| **Manual benchmarks** | Predefined tasks against different models | [`benchmark/manual/README.md`](benchmark/manual/README.md) |
+| **terminal-bench-2** | 89-task [terminal-bench](https://www.harborframework.com/) suite in Docker | [`benchmark/terminal-bench-2/README.md`](benchmark/terminal-bench-2/README.md) |
+| **Session audit** | Audit completed sessions for phase discipline, quality, cost | [`benchmark/audit-session/README.md`](benchmark/audit-session/README.md) |
 
-## Release
+---
 
-Standalone binaries are built automatically by GitHub Actions when a version tag is pushed (`v*`). Binaries are compiled with `bun build --compile` and require no runtime on the user's machine.
+## Docs
 
-Supported platforms:
-
-- macOS (amd64, arm64)
-- Linux (amd64, arm64)
-
-Release assets follow the naming convention `kimchi_{os}_{arch}.tar.gz` with a `checksums.txt` (SHA256) for verification.
-
-## License
-
-[Apache License 2.0](LICENSE) -- see [CONTRIBUTING.md](CONTRIBUTING.md) for the CLA and contributor guidelines.
+- [`docs/ferment.md`](docs/ferment.md) — Ferment project mode
+- [`docs/ferment-storage-schema.md`](docs/ferment-storage-schema.md) — Ferment state & event format
+- [`docs/hooks.md`](docs/hooks.md) — Bash hook protocol
+- [`docs/teleport.md`](docs/teleport.md) — Remote teleport
+- [`AGENTS.md`](AGENTS.md) — Agent guidelines for kimchi-dev contributors

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 <div align="center">
 
-<a href="https://kimchi.dev"><img src="./kimchi.png" alt="kimchi" width="300" /></a>
+<a href="https://kimchi.dev"><img src="./kimchi.png" alt="kimchi" width="600" /></a>
 
 # kimchi
 


### PR DESCRIPTION
## Summary

Rewrites the top-level README from ~480 lines to ~150 lines for better readability and first-time user experience.

## Changes

- **Tightened prose** — removed inline reference docs that duplicated `docs/` content
- **Feature table** — quick-scan overview of all key capabilities
- **Multi-model orchestration section** — role table + config snippet, moved API details to docs
- **Ferment section** — concise workflow example with recovery story
- **Social badges** — added Discord, X/Twitter, LinkedIn links
- **GitHub admonitions** — `> [!TIP]` and `> [!NOTE]` blocks where appropriate
- **Removed** — LICENSE, CONTRIBUTING, CHANGELOG sections (linked instead), inline docs for tags, teleport, token optimization, packages

## What reviewers should check

- Are the two key value props (multi-model + Ferment) clear in the first 10 seconds?
- Is anything critical missing from the quick-start path?
- Do the social links and badges all resolve correctly?
