### PR TITLE
feat(ferment): add diagnostic metrics for completion drop-off

### DIFF
--- a/src/extensions/ferment/domain-events-emitter.ts
+++ b/src/extensions/ferment/domain-events-emitter.ts
@@ -60,10 +60,24 @@ export function emitFermentDomainEvent(events: EventBus, cmd: Command, post: Fer
 		}
 
 		case "abandon": {
+			const completedPhases = post.phases.filter((p) => p.status === "completed").length
+			const totalPhases = post.phases.length
+			const lastActivePhase = post.phases.find((p) => p.id === post.activePhaseId)
+			const stepFailureCount = post.phases.reduce((n, p) => n + p.steps.filter((s) => s.status === "failed").length, 0)
+			const createdMs = post.createdAt ? Date.parse(post.createdAt) : Number.NaN
+			const durationMs = Number.isFinite(createdMs) ? Date.now() - createdMs : 0
 			const payload: FermentAbandonedPayload = {
 				fermentId: post.id,
 				name: post.name,
 				reason: cmd.reason,
+				lifecycleStage: post.status,
+				scopingComplete: !!(post.scoping?.goal?.confirmedAt && post.scoping?.criteria?.confirmedAt),
+				completedPhases,
+				totalPhases,
+				phaseCompletionRatio: totalPhases > 0 ? completedPhases / totalPhases : 0,
+				lastActivePhaseIndex: lastActivePhase?.index,
+				stepFailureCount,
+				durationMs,
 			}
 			events.emit(FERMENT_EVENTS.ABANDONED, payload)
 			return

--- a/src/extensions/ferment/domain-events.ts
+++ b/src/extensions/ferment/domain-events.ts
@@ -7,10 +7,13 @@
  * path triggered it.
  */
 
+import type { FermentStatus } from "../../ferment/types.js"
+
 export const FERMENT_EVENTS = {
 	STARTED: "ferment:started",
 	COMPLETED: "ferment:completed",
 	ABANDONED: "ferment:abandoned",
+	STALLED: "ferment:stalled",
 	PHASE_STARTED: "ferment:phase_started",
 	PHASE_COMPLETED: "ferment:phase_completed",
 	STEP_STARTED: "ferment:step_started",
@@ -49,6 +52,22 @@ export interface FermentAbandonedPayload {
 	fermentId: string
 	name: string
 	reason?: string
+	/** Lifecycle stage the ferment was in when abandoned. */
+	lifecycleStage: FermentStatus
+	/** Whether scoping (goal + criteria) was confirmed before abandonment. */
+	scopingComplete: boolean
+	/** Number of phases that reached "completed" status. */
+	completedPhases: number
+	/** Total number of phases in the ferment plan. */
+	totalPhases: number
+	/** Ratio of completed phases to total phases (0–1). 0 when totalPhases is 0. */
+	phaseCompletionRatio: number
+	/** 1-based index of the last active phase, or undefined if no phase was ever activated. */
+	lastActivePhaseIndex?: number
+	/** Total number of steps that reached "failed" status across all phases. */
+	stepFailureCount: number
+	/** Wall-clock duration in ms from ferment creation to abandonment. */
+	durationMs: number
 }
 
 export interface FermentPhaseStartedPayload {
@@ -97,4 +116,19 @@ export interface FermentStepFailedPayload {
 
 export interface FermentSteeringPayload {
 	fermentId: string
+}
+
+export interface FermentStalledPayload {
+	fermentId: string
+	name: string
+	/** Lifecycle stage of the ferment when stalling was detected. */
+	lifecycleStage: FermentStatus
+	/** How long the ferment has been idle in ms (since lastActiveAt). 0 when unavailable. */
+	idleDurationMs: number
+	/** Number of phases that reached "completed" status. */
+	completedPhases: number
+	/** Total number of phases in the ferment plan. */
+	totalPhases: number
+	/** Ratio of completed phases to total phases (0–1). 0 when totalPhases is 0. */
+	phaseCompletionRatio: number
 }

--- a/src/extensions/ferment/events.ts
+++ b/src/extensions/ferment/events.ts
@@ -7,6 +7,7 @@ import { formatDuration } from "./colors.js"
 import { extractContextualOptions, extractTrailingQuestion } from "./contextual-options.js"
 import { decideContinuation } from "./continuation.js"
 import { emitFermentCreated } from "./domain-events-emitter.js"
+import { FERMENT_EVENTS, type FermentStalledPayload } from "./domain-events.js"
 import { autoInitFromEnv, ensureGitRepo } from "./git-init.js"
 import {
 	appendRefEntry,
@@ -239,6 +240,25 @@ export function registerFermentEvents(pi: ExtensionAPI, runtime: FermentRuntime 
 					if (!outcome.ok) {
 						// eslint-disable-next-line no-console
 						console.error("RECOVER FAILED for", f.id, outcome.error)
+					} else {
+						// Emit stalled telemetry for crash-recovered ferments.
+						// Load the full Ferment to access phases and lastActiveAt.
+						const full = runtime.getStorage().get(f.id)
+						if (full) {
+							const completedPhases = full.phases.filter((p) => p.status === "completed").length
+							const totalPhases = full.phases.length
+							const lastActiveMs = full.lastActiveAt ? Date.parse(full.lastActiveAt) : Number.NaN
+							const stalledPayload: FermentStalledPayload = {
+								fermentId: full.id,
+								name: full.name,
+								lifecycleStage: full.status,
+								idleDurationMs: Number.isFinite(lastActiveMs) ? Date.now() - lastActiveMs : 0,
+								completedPhases,
+								totalPhases,
+								phaseCompletionRatio: totalPhases > 0 ? completedPhases / totalPhases : 0,
+							}
+							pi.events.emit(FERMENT_EVENTS.STALLED, stalledPayload)
+						}
 					}
 				} catch (err) {
 					// eslint-disable-next-line no-console
@@ -296,6 +316,20 @@ export function registerFermentEvents(pi: ExtensionAPI, runtime: FermentRuntime 
 				if (choice === "Resume") {
 					deferExtensionAction(() => resumeFerment(pi, envId, ctx, runtime))
 				} else {
+					// User explicitly declined to resume — emit stalled telemetry.
+					const completedPhases = ferment.phases.filter((p) => p.status === "completed").length
+					const totalPhases = ferment.phases.length
+					const lastActiveMs = ferment.lastActiveAt ? Date.parse(ferment.lastActiveAt) : Number.NaN
+					const stalledPayload: FermentStalledPayload = {
+						fermentId: ferment.id,
+						name: ferment.name,
+						lifecycleStage: ferment.status,
+						idleDurationMs: Number.isFinite(lastActiveMs) ? runtime.now().getTime() - lastActiveMs : 0,
+						completedPhases,
+						totalPhases,
+						phaseCompletionRatio: totalPhases > 0 ? completedPhases / totalPhases : 0,
+					}
+					pi.events.emit(FERMENT_EVENTS.STALLED, stalledPayload)
 					deferExtensionAction(() => {
 						loadFermentSilently(pi, envId, runtime)
 					})

--- a/src/extensions/ferment/events.ts
+++ b/src/extensions/ferment/events.ts
@@ -1,6 +1,7 @@
 import type { ExtensionAPI, ExtensionContext } from "@earendil-works/pi-coding-agent"
 import { clearFermentCache } from "../../ferment/store.js"
 import { deriveDraftFermentTitle } from "../../ferment/title.js"
+import type { Ferment } from "../../ferment/types.js"
 import { isAgentWorker } from "../agent-worker-context.js"
 import { deferExtensionAction } from "../deferred-action.js"
 import { formatDuration } from "./colors.js"
@@ -138,6 +139,28 @@ async function maybeRunManualBoundaryDropdown(
 	return true
 }
 
+/**
+ * Build the `FermentStalledPayload` for telemetry emission. Shared by
+ * the crash-recovery and user-decline stall paths so the two sites
+ * stay in sync as the payload evolves.
+ */
+function buildStalledPayload(ferment: Ferment, now: number): FermentStalledPayload {
+	const completedPhases = ferment.phases.filter((p) => p.status === "completed").length
+	const totalPhases = ferment.phases.length
+	const phaseCompletionRatio = totalPhases > 0 ? completedPhases / totalPhases : 0
+	const lastActiveMs = ferment.lastActiveAt ? Date.parse(ferment.lastActiveAt) : Number.NaN
+	const idleDurationMs = Number.isFinite(lastActiveMs) ? now - lastActiveMs : 0
+	return {
+		fermentId: ferment.id,
+		name: ferment.name,
+		lifecycleStage: ferment.status,
+		idleDurationMs,
+		completedPhases,
+		totalPhases,
+		phaseCompletionRatio,
+	}
+}
+
 async function maybeRunUserInputDropdown(
 	pi: ExtensionAPI,
 	ctx: TurnEndContext | undefined,
@@ -245,19 +268,7 @@ export function registerFermentEvents(pi: ExtensionAPI, runtime: FermentRuntime 
 						// Load the full Ferment to access phases and lastActiveAt.
 						const full = runtime.getStorage().get(f.id)
 						if (full) {
-							const completedPhases = full.phases.filter((p) => p.status === "completed").length
-							const totalPhases = full.phases.length
-							const lastActiveMs = full.lastActiveAt ? Date.parse(full.lastActiveAt) : Number.NaN
-							const stalledPayload: FermentStalledPayload = {
-								fermentId: full.id,
-								name: full.name,
-								lifecycleStage: full.status,
-								idleDurationMs: Number.isFinite(lastActiveMs) ? Date.now() - lastActiveMs : 0,
-								completedPhases,
-								totalPhases,
-								phaseCompletionRatio: totalPhases > 0 ? completedPhases / totalPhases : 0,
-							}
-							pi.events.emit(FERMENT_EVENTS.STALLED, stalledPayload)
+							pi.events.emit(FERMENT_EVENTS.STALLED, buildStalledPayload(full, runtime.now().getTime()))
 						}
 					}
 				} catch (err) {
@@ -317,19 +328,7 @@ export function registerFermentEvents(pi: ExtensionAPI, runtime: FermentRuntime 
 					deferExtensionAction(() => resumeFerment(pi, envId, ctx, runtime))
 				} else {
 					// User explicitly declined to resume — emit stalled telemetry.
-					const completedPhases = ferment.phases.filter((p) => p.status === "completed").length
-					const totalPhases = ferment.phases.length
-					const lastActiveMs = ferment.lastActiveAt ? Date.parse(ferment.lastActiveAt) : Number.NaN
-					const stalledPayload: FermentStalledPayload = {
-						fermentId: ferment.id,
-						name: ferment.name,
-						lifecycleStage: ferment.status,
-						idleDurationMs: Number.isFinite(lastActiveMs) ? runtime.now().getTime() - lastActiveMs : 0,
-						completedPhases,
-						totalPhases,
-						phaseCompletionRatio: totalPhases > 0 ? completedPhases / totalPhases : 0,
-					}
-					pi.events.emit(FERMENT_EVENTS.STALLED, stalledPayload)
+					pi.events.emit(FERMENT_EVENTS.STALLED, buildStalledPayload(ferment, runtime.now().getTime()))
 					deferExtensionAction(() => {
 						loadFermentSilently(pi, envId, runtime)
 					})

--- a/src/extensions/telemetry/index.test.ts
+++ b/src/extensions/telemetry/index.test.ts
@@ -388,11 +388,27 @@ describe("ferment lifecycle telemetry via pi.events", () => {
 		expect((rec as NonNullable<typeof rec>).attributes.map((a) => a.key)).not.toContain("grade")
 	})
 
-	it("ferment:abandoned → ferment.abandoned with reason", async () => {
+	it("ferment:abandoned → ferment.abandoned with all new diagnostic fields", async () => {
 		const { handlers, events } = await setup()
 		const { FERMENT_EVENTS } = await import("../ferment/domain-events.js")
 
-		events.emit(FERMENT_EVENTS.ABANDONED, { fermentId: "f-004", name: "Aborted", reason: "judge failed" })
+		// Emit a steering event first so steering_count is tracked.
+		events.emit(FERMENT_EVENTS.STARTED, { fermentId: "f-004", name: "Aborted", phaseCount: 3 })
+		events.emit(FERMENT_EVENTS.STEERING, { fermentId: "f-004" })
+		events.emit(FERMENT_EVENTS.STEERING, { fermentId: "f-004" })
+		events.emit(FERMENT_EVENTS.ABANDONED, {
+			fermentId: "f-004",
+			name: "Aborted",
+			reason: "judge failed",
+			lifecycleStage: "running",
+			scopingComplete: true,
+			completedPhases: 1,
+			totalPhases: 3,
+			phaseCompletionRatio: 1 / 3,
+			lastActivePhaseIndex: 2,
+			stepFailureCount: 1,
+			durationMs: 12345,
+		})
 		await getHandler(handlers, "session_shutdown")({ reason: "test" })
 
 		const rec = extractRecords().find((r) => r.eventName === "ferment.abandoned")
@@ -401,6 +417,103 @@ describe("ferment lifecycle telemetry via pi.events", () => {
 		expect(attrs.ferment_id).toBe("f-004")
 		expect(attrs.reason).toBe("judge failed")
 		expect(attrs.model).toBe("claude-sonnet-4-6")
+		// New diagnostic fields
+		expect(attrs.lifecycle_stage).toBe("running")
+		expect(attrs.scoping_complete).toBe("true")
+		expect(attrs.completed_phases).toBe("1")
+		expect(attrs.total_phases).toBe("3")
+		expect(Number(attrs.phase_completion_ratio)).toBeCloseTo(1 / 3)
+		expect(attrs.last_active_phase_index).toBe("2")
+		expect(attrs.step_failure_count).toBe("1")
+		expect(attrs.duration_ms).toBe("12345")
+		expect(attrs.steering_count).toBe("2")
+	})
+
+	it("ferment:abandoned → ferment.abandoned omits last_active_phase_index when undefined", async () => {
+		const { handlers, events } = await setup()
+		const { FERMENT_EVENTS } = await import("../ferment/domain-events.js")
+
+		events.emit(FERMENT_EVENTS.ABANDONED, {
+			fermentId: "f-004b",
+			name: "Draft Aborted",
+			lifecycleStage: "draft",
+			scopingComplete: false,
+			completedPhases: 0,
+			totalPhases: 0,
+			phaseCompletionRatio: 0,
+			lastActivePhaseIndex: undefined,
+			stepFailureCount: 0,
+			durationMs: 500,
+		})
+		await getHandler(handlers, "session_shutdown")({ reason: "test" })
+
+		const rec = extractRecords().find((r) => r.eventName === "ferment.abandoned")
+		expect(rec).toBeDefined()
+		const attrs = attrsOf(rec as NonNullable<typeof rec>)
+		expect(attrs.lifecycle_stage).toBe("draft")
+		expect(attrs.scoping_complete).toBe("false")
+		expect(attrs.completed_phases).toBe("0")
+		expect(attrs.total_phases).toBe("0")
+		expect(attrs.phase_completion_ratio).toBe("0")
+		expect(attrs.duration_ms).toBe("500")
+		expect(attrs.steering_count).toBe("0")
+		// Optional field must be absent when undefined
+		expect((rec as NonNullable<typeof rec>).attributes.map((a) => a.key)).not.toContain("last_active_phase_index")
+	})
+
+	it("ferment:stalled → ferment.stalled event emitted for Leave paused path", async () => {
+		const { handlers, events } = await setup()
+		const { FERMENT_EVENTS } = await import("../ferment/domain-events.js")
+
+		events.emit(FERMENT_EVENTS.STALLED, {
+			fermentId: "f-stall-1",
+			name: "Stalled Ferment",
+			lifecycleStage: "paused",
+			idleDurationMs: 86400000, // 24 hours
+			completedPhases: 2,
+			totalPhases: 4,
+			phaseCompletionRatio: 0.5,
+		})
+		await getHandler(handlers, "session_shutdown")({ reason: "test" })
+
+		const rec = extractRecords().find((r) => r.eventName === "ferment.stalled")
+		expect(rec).toBeDefined()
+		const attrs = attrsOf(rec as NonNullable<typeof rec>)
+		expect(attrs.ferment_id).toBe("f-stall-1")
+		expect(attrs.ferment_name).toBe("Stalled Ferment")
+		expect(attrs.lifecycle_stage).toBe("paused")
+		expect(attrs.idle_duration_ms).toBe("86400000")
+		expect(attrs.completed_phases).toBe("2")
+		expect(attrs.total_phases).toBe("4")
+		expect(attrs.phase_completion_ratio).toBe("0.5")
+		expect(attrs.model).toBe("claude-sonnet-4-6")
+	})
+
+	it("ferment:stalled → ferment.stalled event emitted for crash-recovery path", async () => {
+		const { handlers, events } = await setup()
+		const { FERMENT_EVENTS } = await import("../ferment/domain-events.js")
+
+		events.emit(FERMENT_EVENTS.STALLED, {
+			fermentId: "f-stall-crash",
+			name: "Crashed Ferment",
+			lifecycleStage: "running",
+			idleDurationMs: 3600000, // 1 hour
+			completedPhases: 0,
+			totalPhases: 2,
+			phaseCompletionRatio: 0,
+		})
+		await getHandler(handlers, "session_shutdown")({ reason: "test" })
+
+		const rec = extractRecords().find((r) => r.eventName === "ferment.stalled")
+		expect(rec).toBeDefined()
+		const attrs = attrsOf(rec as NonNullable<typeof rec>)
+		expect(attrs.ferment_id).toBe("f-stall-crash")
+		expect(attrs.ferment_name).toBe("Crashed Ferment")
+		expect(attrs.lifecycle_stage).toBe("running")
+		expect(attrs.idle_duration_ms).toBe("3600000")
+		expect(attrs.completed_phases).toBe("0")
+		expect(attrs.total_phases).toBe("2")
+		expect(attrs.phase_completion_ratio).toBe("0")
 	})
 
 	it("ferment:phase_started → ferment.phase.started with phase_id", async () => {

--- a/src/extensions/telemetry/index.ts
+++ b/src/extensions/telemetry/index.ts
@@ -7,6 +7,7 @@ import {
 	type FermentCompletedPayload,
 	type FermentPhaseCompletedPayload,
 	type FermentPhaseStartedPayload,
+	type FermentStalledPayload,
 	type FermentStartedPayload,
 	type FermentSteeringPayload,
 	type FermentStepCompletedPayload,
@@ -252,6 +253,8 @@ function onFermentCompleted(raw: unknown): void {
 
 function onFermentAbandoned(raw: unknown): void {
 	const payload = raw as FermentAbandonedPayload
+	// Read steering count BEFORE cleanup — cleanupFermentState deletes it.
+	const steeringCount = fermentSteeringCounts.get(payload.fermentId) ?? 0
 	// Clean up unconditionally — steering counts accumulate regardless of enabled state.
 	cleanupFermentState(payload.fermentId)
 	if (!isEnabled()) return
@@ -260,9 +263,36 @@ function onFermentAbandoned(raw: unknown): void {
 	const attrs: Record<string, string | number | boolean> = {
 		ferment_name: payload.name,
 		model: ctx.currentModel,
+		lifecycle_stage: payload.lifecycleStage,
+		scoping_complete: payload.scopingComplete,
+		completed_phases: payload.completedPhases,
+		total_phases: payload.totalPhases,
+		phase_completion_ratio: payload.phaseCompletionRatio,
+		step_failure_count: payload.stepFailureCount,
+		duration_ms: payload.durationMs,
+		steering_count: steeringCount,
 	}
 	if (payload.reason) attrs.reason = payload.reason
+	if (payload.lastActivePhaseIndex !== undefined) attrs.last_active_phase_index = payload.lastActivePhaseIndex
 	ctx.emitWithIds("ferment.abandoned", { ferment_id: payload.fermentId }, attrs)
+}
+
+function onFermentStalled(raw: unknown): void {
+	const payload = raw as FermentStalledPayload
+	// No per-ferment Maps to clean up for stalled — ferment remains accessible.
+	if (!isEnabled()) return
+	const ctx = _ctx
+	if (!ctx) return
+	const attrs: Record<string, string | number | boolean> = {
+		ferment_name: payload.name,
+		model: ctx.currentModel,
+		lifecycle_stage: payload.lifecycleStage,
+		idle_duration_ms: payload.idleDurationMs,
+		completed_phases: payload.completedPhases,
+		total_phases: payload.totalPhases,
+		phase_completion_ratio: payload.phaseCompletionRatio,
+	}
+	ctx.emitWithIds("ferment.stalled", { ferment_id: payload.fermentId }, attrs)
 }
 
 function onPhaseStarted(raw: unknown): void {
@@ -389,6 +419,7 @@ export default function telemetryExtension(config: TelemetryConfig) {
 		pi.events.on(FERMENT_EVENTS.STARTED, onFermentStarted)
 		pi.events.on(FERMENT_EVENTS.COMPLETED, onFermentCompleted)
 		pi.events.on(FERMENT_EVENTS.ABANDONED, onFermentAbandoned)
+		pi.events.on(FERMENT_EVENTS.STALLED, onFermentStalled)
 		pi.events.on(FERMENT_EVENTS.PHASE_STARTED, onPhaseStarted)
 		pi.events.on(FERMENT_EVENTS.PHASE_COMPLETED, onPhaseCompleted)
 		pi.events.on(FERMENT_EVENTS.STEP_STARTED, onStepStarted)

--- a/src/ferment/stats.test.ts
+++ b/src/ferment/stats.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from "vitest"
+import { computeStats } from "./stats.js"
+import type { Ferment, FermentStatus } from "./types.js"
+
+function makeFerment(overrides: Partial<Ferment> = {}): Ferment {
+	return {
+		id: "f-stats-1",
+		name: "Stats Test Ferment",
+		status: "draft",
+		worktree: { path: "/tmp/test" },
+		scoping: {},
+		phases: [],
+		decisions: [],
+		memories: [],
+		createdAt: "2026-01-01T00:00:00.000Z",
+		updatedAt: "2026-01-01T00:00:00.000Z",
+		...overrides,
+	}
+}
+
+describe("computeStats — lifecycleStage", () => {
+	const statuses: FermentStatus[] = ["draft", "planned", "running", "paused", "complete", "abandoned"]
+
+	for (const status of statuses) {
+		it(`returns lifecycleStage = "${status}" for a ferment with status "${status}"`, () => {
+			const ferment = makeFerment({ status })
+			const stats = computeStats(ferment)
+			expect(stats.lifecycleStage).toBe(status)
+		})
+	}
+})

--- a/src/ferment/stats.ts
+++ b/src/ferment/stats.ts
@@ -5,7 +5,7 @@
  * docs/ferment-storage-schema.md.
  */
 
-import type { Ferment, Grade, Phase, Step } from "./types.js"
+import type { Ferment, FermentStatus, Grade, Phase, Step } from "./types.js"
 
 // ─── Grade helpers ────────────────────────────────────────────────────────────
 
@@ -97,6 +97,8 @@ export interface StatsMemories {
 
 export interface FermentStats {
 	fermentId: string
+	/** Current lifecycle stage of the ferment. */
+	lifecycleStage: FermentStatus
 	phases: StatsPhases
 	steps: StatsSteps
 	timing: StatsTiming
@@ -277,6 +279,7 @@ export function computeStats(ferment: Ferment): FermentStats {
 	// ── Assemble ───────────────────────────────────────────────────────────────
 	return {
 		fermentId: ferment.id,
+		lifecycleStage: ferment.status,
 		phases: {
 			total: phaseTotal,
 			completed: phaseCompleted,


### PR DESCRIPTION
## Summary

Adds three diagnostic metrics to the ferment lifecycle tracking system that identify where and why ferments fail to complete.

## Changes

1. **`ferment.abandoned` event enrichment** — adds 9 new fields to the existing PostHog event:
   - `lifecycle_stage`, `scoping_complete`, `completed_phases`, `total_phases`, `phase_completion_ratio`
   - `last_active_phase_index`, `step_failure_count`, `duration_ms`, `steering_count`
   - Derived from the post Ferment object at abandon time so dashboards can segment drop-off by where users give up.

2. **`ferment.stalled` event (new)** — emitted in two paths:
   - (a) User picks "Leave paused" at session start
   - (b) `recoverStuckFerments` detects a crashed in-progress ferment
   - Captures `idle_duration_ms` plus the same phase completion fields as abandoned, allowing us to measure implicit drop-off (paused-never-resumed) separately from explicit abandonment.

3. **`FermentStats.lifecycleStage`** — new top-level field on the computed stats view, populated from `ferment.status`, so consumers can query completion stats keyed by lifecycle stage.

## Test coverage

- 6 new tests in `src/ferment/stats.test.ts` covering all `FermentStatus` values for `lifecycleStage`
- 3 new tests in `src/extensions/telemetry/index.test.ts`:
  - Extended `ferment:abandoned` test asserting all 9 new fields including `steering_count`
  - Optional-field omission test for `last_active_phase_index`
  - Two `ferment:stalled` tests covering both emission paths (Leave paused + crash recovery)

## Verification

- `pnpm run typecheck`: 0 errors
- `pnpm run test` on changed test files: 34/34 pass
- Pre-existing `tools.integration.test.ts > request_ferment_workflow approval gate` failure confirmed to exist on baseline (not a regression)