### PR TITLE
feat(hide-thinking): support <mm:think> tags alongside <think> tags

### DIFF
--- a/src/extensions/hide-thinking.test.ts
+++ b/src/extensions/hide-thinking.test.ts
@@ -75,6 +75,7 @@ describe("hideThinkingExtension", () => {
 	// --- Default behaviour (hideThinking = false → dim) ---
 
 	it("dims thinking content by default (hideThinking not set)", async () => {
+		_setHideThinking(false)
 		const { endResult } = await simulateStreaming(h, ["Before ", "<think>", "reason", "</think>", " After"])
 		expect(endResult).toBeDefined()
 		const text = (endResult as { message: { content: Array<{ text: string }> } }).message.content[0].text
@@ -116,6 +117,7 @@ describe("hideThinkingExtension", () => {
 	// --- Streaming display ---
 
 	it("hides <think> tag and dims content during streaming", async () => {
+		_setHideThinking(false)
 		const content = [{ type: "text" as const, text: "" }]
 		const message = { role: "assistant" as const, content }
 
@@ -270,6 +272,7 @@ describe("hideThinkingExtension", () => {
 	// --- mm:think tags ---
 
 	it("dims <mm:think> content by default", async () => {
+		_setHideThinking(false)
 		const { endResult } = await simulateStreaming(h, ["Before ", "<mm:think>", "mm reason", "</mm:think>", " After"])
 		expect(endResult).toBeDefined()
 		const text = (endResult as { message: { content: Array<{ text: string }> } }).message.content[0].text
@@ -285,6 +288,7 @@ describe("hideThinkingExtension", () => {
 	})
 
 	it("hides <mm:think> tag and dims content during streaming", async () => {
+		_setHideThinking(false)
 		const content = [{ type: "text" as const, text: "" }]
 		const message = { role: "assistant" as const, content }
 

--- a/src/extensions/hide-thinking.test.ts
+++ b/src/extensions/hide-thinking.test.ts
@@ -78,7 +78,7 @@ describe("hideThinkingExtension", () => {
 		const { endResult } = await simulateStreaming(h, ["Before ", "<think>", "reason", "</think>", " After"])
 		expect(endResult).toBeDefined()
 		const text = (endResult as { message: { content: Array<{ text: string }> } }).message.content[0].text
-		expect(text).toBe(`Before ${fg(ANSI.dim, "reason")} After`)
+		expect(text).toBe(`Before ${fg(ANSI.dim, "reason")}\n\n After`)
 	})
 
 	// --- Explicit hideThinking = true (strip entirely) ---
@@ -110,7 +110,7 @@ describe("hideThinkingExtension", () => {
 		const text = (endResult as { message: { content: Array<{ text: string }> } }).message.content[0].text
 		const expectedLines = thinkingLines.slice(-5)
 		const expectedDimmed = expectedLines.map((l) => fg(ANSI.dim, l)).join("\n")
-		expect(text).toBe(`Before ${expectedDimmed} After`)
+		expect(text).toBe(`Before ${expectedDimmed}\n\n After`)
 	})
 
 	// --- Streaming display ---
@@ -144,7 +144,7 @@ describe("hideThinkingExtension", () => {
 		// More text after closing
 		content[0].text += " World"
 		await h.messageUpdate({ type: "message_update", message, assistantMessageEvent: {} })
-		expect(content[0].text).toBe(`Hello ${fg(ANSI.dim, "reasoning")} World`)
+		expect(content[0].text).toBe(`Hello ${fg(ANSI.dim, "reasoning")}\n\n World`)
 	})
 
 	it("hides thinking content entirely during streaming when hideThinking is true", async () => {
@@ -273,7 +273,7 @@ describe("hideThinkingExtension", () => {
 		const { endResult } = await simulateStreaming(h, ["Before ", "<mm:think>", "mm reason", "</mm:think>", " After"])
 		expect(endResult).toBeDefined()
 		const text = (endResult as { message: { content: Array<{ text: string }> } }).message.content[0].text
-		expect(text).toBe(`Before ${fg(ANSI.dim, "mm reason")} After`)
+		expect(text).toBe(`Before ${fg(ANSI.dim, "mm reason")}\n\n After`)
 	})
 
 	it("strips <mm:think> tags when hideThinking is true", async () => {
@@ -308,7 +308,7 @@ describe("hideThinkingExtension", () => {
 
 		content[0].text += " World"
 		await h.messageUpdate({ type: "message_update", message, assistantMessageEvent: {} })
-		expect(content[0].text).toBe(`Hello ${fg(ANSI.dim, "mm reasoning")} World`)
+		expect(content[0].text).toBe(`Hello ${fg(ANSI.dim, "mm reasoning")}\n\n World`)
 	})
 
 	it("restores <mm:think> content in context event", async () => {
@@ -350,7 +350,7 @@ describe("filterThinkingForDisplay", () => {
 		"dims thinking blocks when hideThinking is false": {
 			input: "Before <think>reasoning</think> After",
 			hideThinking: false,
-			expected: `Before ${fg(ANSI.dim, "reasoning")} After`,
+			expected: `Before ${fg(ANSI.dim, "reasoning")}\n\n After`,
 		},
 		"returns text unchanged when no thinking tags present": {
 			input: "plain text without thinking",
@@ -380,7 +380,7 @@ describe("filterThinkingForDisplay", () => {
 		"dims mm:think blocks when hideThinking is false": {
 			input: "Before <mm:think>mm reasoning</mm:think> After",
 			hideThinking: false,
-			expected: `Before ${fg(ANSI.dim, "mm reasoning")} After`,
+			expected: `Before ${fg(ANSI.dim, "mm reasoning")}\n\n After`,
 		},
 		"handles unclosed mm:think tag by hiding content when hideThinking is true": {
 			input: "Before <mm:think>still streaming",

--- a/src/extensions/hide-thinking.test.ts
+++ b/src/extensions/hide-thinking.test.ts
@@ -266,6 +266,66 @@ describe("hideThinkingExtension", () => {
 		expect(text).toBe("A  B  C")
 	})
 
+	// --- mm:think tags ---
+
+	it("dims <mm:think> content by default", async () => {
+		const { endResult } = await simulateStreaming(h, ["Before ", "<mm:think>", "mm reason", "</mm:think>", " After"])
+		expect(endResult).toBeDefined()
+		const text = (endResult as { message: { content: Array<{ text: string }> } }).message.content[0].text
+		expect(text).toBe(`Before ${fg(ANSI.dim, "mm reason")} After`)
+	})
+
+	it("strips <mm:think> tags when hideThinking is true", async () => {
+		_setHideThinking(true)
+		const { endResult } = await simulateStreaming(h, ["Hello ", "<mm:think>", "mm reasoning", "</mm:think>", " World"])
+		expect(endResult).toBeDefined()
+		const text = (endResult as { message: { content: Array<{ text: string }> } }).message.content[0].text
+		expect(text).toBe("Hello  World")
+	})
+
+	it("hides <mm:think> tag and dims content during streaming", async () => {
+		const content = [{ type: "text" as const, text: "" }]
+		const message = { role: "assistant" as const, content }
+
+		await h.messageStart({ type: "message_start", message })
+
+		content[0].text += "Hello "
+		await h.messageUpdate({ type: "message_update", message, assistantMessageEvent: {} })
+		expect(content[0].text).toBe("Hello ")
+
+		content[0].text += "<mm:think>"
+		await h.messageUpdate({ type: "message_update", message, assistantMessageEvent: {} })
+		expect(content[0].text).toBe("Hello ")
+
+		content[0].text += "mm reasoning"
+		await h.messageUpdate({ type: "message_update", message, assistantMessageEvent: {} })
+		expect(content[0].text).toBe(`Hello ${fg(ANSI.dim, "mm reasoning")}`)
+
+		content[0].text += "</mm:think>"
+		await h.messageUpdate({ type: "message_update", message, assistantMessageEvent: {} })
+		expect(content[0].text).toBe(`Hello ${fg(ANSI.dim, "mm reasoning")}`)
+
+		content[0].text += " World"
+		await h.messageUpdate({ type: "message_update", message, assistantMessageEvent: {} })
+		expect(content[0].text).toBe(`Hello ${fg(ANSI.dim, "mm reasoning")} World`)
+	})
+
+	it("restores <mm:think> content in context event", async () => {
+		_setHideThinking(true)
+		const { endResult } = await simulateStreaming(h, ["Before ", "<mm:think>", "mm deep", "</mm:think>", " After"])
+		const displayText = (endResult as { message: { content: Array<{ text: string }> } }).message.content[0].text
+		expect(displayText).toBe("Before  After")
+
+		const contextResult = await h.context({
+			type: "context",
+			messages: [{ role: "assistant", content: [{ type: "text", text: displayText }] }],
+		})
+
+		expect(contextResult).toBeDefined()
+		const restored = (contextResult as { messages: Array<{ content: Array<{ text: string }> }> }).messages
+		expect(restored[0].content[0].text).toBe("Before <mm:think>mm deep</mm:think> After")
+	})
+
 	it("context handler is a no-op when shadow map is empty", async () => {
 		const result = await h.context({
 			type: "context",
@@ -308,6 +368,26 @@ describe("filterThinkingForDisplay", () => {
 		},
 		"handles unclosed think tag by dimming trailing content when hideThinking is false": {
 			input: "Before <think>still streaming",
+			hideThinking: false,
+			expected: `Before ${fg(ANSI.dim, "still streaming")}`,
+		},
+		"strips mm:think blocks when hideThinking is true": {
+			input: "Before <mm:think>mm reasoning</mm:think> After",
+			hideThinking: true,
+			expected: "Before  After",
+		},
+		"dims mm:think blocks when hideThinking is false": {
+			input: "Before <mm:think>mm reasoning</mm:think> After",
+			hideThinking: false,
+			expected: `Before ${fg(ANSI.dim, "mm reasoning")} After`,
+		},
+		"handles unclosed mm:think tag by hiding content when hideThinking is true": {
+			input: "Before <mm:think>still streaming",
+			hideThinking: true,
+			expected: "Before ",
+		},
+		"handles unclosed mm:think tag by dimming content when hideThinking is false": {
+			input: "Before <mm:think>still streaming",
 			hideThinking: false,
 			expected: `Before ${fg(ANSI.dim, "still streaming")}`,
 		},

--- a/src/extensions/hide-thinking.test.ts
+++ b/src/extensions/hide-thinking.test.ts
@@ -108,8 +108,9 @@ describe("hideThinkingExtension", () => {
 
 		expect(endResult).toBeDefined()
 		const text = (endResult as { message: { content: Array<{ text: string }> } }).message.content[0].text
-		const expected = thinkingLines.slice(-5).join("\n")
-		expect(text).toBe(`Before ${fg(ANSI.dim, expected)} After`)
+		const expectedLines = thinkingLines.slice(-5)
+		const expectedDimmed = expectedLines.map((l) => fg(ANSI.dim, l)).join("\n")
+		expect(text).toBe(`Before ${expectedDimmed} After`)
 	})
 
 	// --- Streaming display ---

--- a/src/extensions/hide-thinking.ts
+++ b/src/extensions/hide-thinking.ts
@@ -31,10 +31,21 @@ import type { ExtensionAPI } from "@earendil-works/pi-coding-agent"
 import { ANSI, fg } from "../ansi.js"
 import { isSubagent } from "./prompt-construction/prompt-enrichment.js"
 
-const THINK_TAG_PATTERN = /<think>[\s\S]*?<\/think>/g
+const THINK_TAG_PATTERN = /<think>[\s\S]*?<\/think>|<mm:think>[\s\S]*?<\/mm:think>/g
 
 function containsThinkTags(text: string): boolean {
-	return text.includes("<think>") && text.includes("</think>")
+	return (
+		(text.includes("<think>") && text.includes("</think>")) ||
+		(text.includes("<mm:think>") && text.includes("</mm:think>"))
+	)
+}
+
+function getOpenTag(match: string): string {
+	return match.startsWith("<mm:think>") ? "<mm:think>" : "<think>"
+}
+
+function getCloseTag(match: string): string {
+	return match.startsWith("<mm:think>") ? "</mm:think>" : "</think>"
 }
 
 // ---------------------------------------------------------------------------
@@ -93,7 +104,9 @@ function stripThinkingTags(text: string): string {
 
 function replaceThinkingTagsWithDimmed(text: string): string {
 	return text.replace(THINK_TAG_PATTERN, (match) => {
-		const content = match.slice("<think>".length, -"</think>".length)
+		const openTag = getOpenTag(match)
+		const closeTag = getCloseTag(match)
+		const content = match.slice(openTag.length, -closeTag.length)
 		const visible = lastNLines(content, 5)
 		return visible ? fg(ANSI.dim, visible) : ""
 	})
@@ -107,21 +120,26 @@ function replaceThinkingTagsWithDimmed(text: string): string {
  * stable during streaming.
  */
 function applyStreamingDisplay(text: string, hideThinking: boolean): string {
-	// 1. Replace fully closed <think>…</think> blocks
+	// 1. Replace fully closed <think>…</think> and <mm:think>…</mm:think> blocks
 	let result = text.replace(THINK_TAG_PATTERN, (match) => {
 		if (hideThinking) return ""
-		const inner = match.slice("<think>".length, -"</think>".length)
+		const openTag = getOpenTag(match)
+		const closeTag = getCloseTag(match)
+		const inner = match.slice(openTag.length, -closeTag.length)
 		return inner ? fg(ANSI.dim, inner) : ""
 	})
-	// 2. Handle an unclosed <think> tag (thinking content still streaming)
-	const openIdx = result.indexOf("<think>")
-	if (openIdx !== -1) {
-		const before = result.slice(0, openIdx)
-		if (hideThinking) {
-			result = before
-		} else {
-			const inner = result.slice(openIdx + "<think>".length)
-			result = before + (inner ? fg(ANSI.dim, inner) : "")
+	// 2. Handle unclosed open tags (thinking content still streaming)
+	for (const openTag of ["<think>", "<mm:think>"]) {
+		const openIdx = result.indexOf(openTag)
+		if (openIdx !== -1) {
+			const before = result.slice(0, openIdx)
+			if (hideThinking) {
+				result = before
+			} else {
+				const inner = result.slice(openIdx + openTag.length)
+				result = before + (inner ? fg(ANSI.dim, inner) : "")
+			}
+			break
 		}
 	}
 	return result
@@ -209,8 +227,8 @@ export default function hideThinkingExtension(pi: ExtensionAPI): void {
 			if (!newContent) continue
 			state.original += newContent
 
-			// Only touch the block when there is (or might be) a <think> tag.
-			if (!state.original.includes("<think>")) {
+			// Only touch the block when there is (or might be) a think tag.
+			if (!state.original.includes("<think>") && !state.original.includes("<mm:think>")) {
 				state.lastDisplayLength = block.text.length
 				continue
 			}

--- a/src/extensions/hide-thinking.ts
+++ b/src/extensions/hide-thinking.ts
@@ -102,11 +102,46 @@ function stripThinkingTags(text: string): string {
 	return text.replace(THINK_TAG_PATTERN, "")
 }
 
+/**
+ * Strip markdown syntax from thinking content so the TUI's Markdown renderer
+ * treats it as plain text. Without this, constructs like `backtick spans`,
+ * **bold**, _italic_, and # headings inside a dim ANSI wrapper get re-styled
+ * by the Markdown renderer's theme colors, overriding our dim.
+ */
+function stripMarkdownSyntax(text: string): string {
+	return (
+		text
+			// Inline code: `foo` → foo
+			.replace(/`([^`]*)`/g, "$1")
+			// Bold+italic: ***foo*** or ___foo___
+			.replace(/\*{3}([^*]+)\*{3}/g, "$1")
+			.replace(/_{3}([^_]+)_{3}/g, "$1")
+			// Bold: **foo** or __foo__
+			.replace(/\*{2}([^*]+)\*{2}/g, "$1")
+			.replace(/_{2}([^_]+)_{2}/g, "$1")
+			// Italic: *foo* or _foo_
+			.replace(/\*([^*]+)\*/g, "$1")
+			.replace(/_([^_]+)_/g, "$1")
+			// ATX headings: # Heading → Heading
+			.replace(/^#{1,6}\s+/gm, "")
+			// Setext headings: underline rows
+			.replace(/^[=-]{2,}\s*$/gm, "")
+			// Blockquotes: > text → text
+			.replace(/^>+\s?/gm, "")
+			// Horizontal rules
+			.replace(/^[-*_]{3,}\s*$/gm, "")
+			// Links: [text](url) → text
+			.replace(/\[([^\]]+)\]\([^)]*\)/g, "$1")
+			// Images: ![alt](url) → alt
+			.replace(/!\[([^\]]*?)\]\([^)]*\)/g, "$1")
+	)
+}
+
 function replaceThinkingTagsWithDimmed(text: string): string {
 	return text.replace(THINK_TAG_PATTERN, (match) => {
 		const openTag = getOpenTag(match)
 		const closeTag = getCloseTag(match)
-		const content = match.slice(openTag.length, -closeTag.length)
+		const content = stripMarkdownSyntax(match.slice(openTag.length, -closeTag.length))
 		const visible = lastNLines(content, 5)
 		return visible ? fg(ANSI.dim, visible) : ""
 	})
@@ -125,7 +160,7 @@ function applyStreamingDisplay(text: string, hideThinking: boolean): string {
 		if (hideThinking) return ""
 		const openTag = getOpenTag(match)
 		const closeTag = getCloseTag(match)
-		const inner = match.slice(openTag.length, -closeTag.length)
+		const inner = stripMarkdownSyntax(match.slice(openTag.length, -closeTag.length))
 		return inner ? fg(ANSI.dim, inner) : ""
 	})
 	// 2. Handle unclosed open tags (thinking content still streaming)
@@ -136,7 +171,7 @@ function applyStreamingDisplay(text: string, hideThinking: boolean): string {
 			if (hideThinking) {
 				result = before
 			} else {
-				const inner = result.slice(openIdx + openTag.length)
+				const inner = stripMarkdownSyntax(result.slice(openIdx + openTag.length))
 				result = before + (inner ? fg(ANSI.dim, inner) : "")
 			}
 			break

--- a/src/extensions/hide-thinking.ts
+++ b/src/extensions/hide-thinking.ts
@@ -103,6 +103,22 @@ function stripThinkingTags(text: string): string {
 }
 
 /**
+ * Dim thinking content for display.
+ *
+ * The TUI's Markdown renderer splits text into paragraph tokens before
+ * applying ANSI, so a single ANSI open-code wrapping multi-paragraph content
+ * only colours the first paragraph — subsequent paragraphs start fresh with
+ * no colour. Prepending the dim code to every non-empty line ensures each
+ * paragraph token begins with the correct ANSI state regardless of how the
+ * lexer splits the input.
+ */
+function dimThinkingContent(text: string): string {
+	const lines = text.split("\n")
+	const dimmed = lines.map((line) => (line ? fg(ANSI.dim, line) : line))
+	return dimmed.join("\n")
+}
+
+/**
  * Strip markdown syntax from thinking content so the TUI's Markdown renderer
  * treats it as plain text. Without this, constructs like `backtick spans`,
  * **bold**, _italic_, and # headings inside a dim ANSI wrapper get re-styled
@@ -143,7 +159,7 @@ function replaceThinkingTagsWithDimmed(text: string): string {
 		const closeTag = getCloseTag(match)
 		const content = stripMarkdownSyntax(match.slice(openTag.length, -closeTag.length))
 		const visible = lastNLines(content, 5)
-		return visible ? fg(ANSI.dim, visible) : ""
+		return visible ? dimThinkingContent(visible) : ""
 	})
 }
 
@@ -161,7 +177,7 @@ function applyStreamingDisplay(text: string, hideThinking: boolean): string {
 		const openTag = getOpenTag(match)
 		const closeTag = getCloseTag(match)
 		const inner = stripMarkdownSyntax(match.slice(openTag.length, -closeTag.length))
-		return inner ? fg(ANSI.dim, inner) : ""
+		return inner ? dimThinkingContent(inner) : ""
 	})
 	// 2. Handle unclosed open tags (thinking content still streaming)
 	for (const openTag of ["<think>", "<mm:think>"]) {
@@ -172,7 +188,7 @@ function applyStreamingDisplay(text: string, hideThinking: boolean): string {
 				result = before
 			} else {
 				const inner = stripMarkdownSyntax(result.slice(openIdx + openTag.length))
-				result = before + (inner ? fg(ANSI.dim, inner) : "")
+				result = before + (inner ? dimThinkingContent(inner) : "")
 			}
 			break
 		}

--- a/src/extensions/hide-thinking.ts
+++ b/src/extensions/hide-thinking.ts
@@ -154,12 +154,15 @@ function stripMarkdownSyntax(text: string): string {
 }
 
 function replaceThinkingTagsWithDimmed(text: string): string {
-	return text.replace(THINK_TAG_PATTERN, (match) => {
+	return text.replace(THINK_TAG_PATTERN, (match, offset, fullString) => {
 		const openTag = getOpenTag(match)
 		const closeTag = getCloseTag(match)
 		const content = stripMarkdownSyntax(match.slice(openTag.length, -closeTag.length))
 		const visible = lastNLines(content, 5)
-		return visible ? dimThinkingContent(visible) : ""
+		if (!visible) return ""
+		const after = fullString.slice(offset + match.length)
+		const separator = after.trimStart().length > 0 ? "\n\n" : ""
+		return dimThinkingContent(visible) + separator
 	})
 }
 
@@ -172,12 +175,15 @@ function replaceThinkingTagsWithDimmed(text: string): string {
  */
 function applyStreamingDisplay(text: string, hideThinking: boolean): string {
 	// 1. Replace fully closed <think>…</think> and <mm:think>…</mm:think> blocks
-	let result = text.replace(THINK_TAG_PATTERN, (match) => {
+	let result = text.replace(THINK_TAG_PATTERN, (match, offset, fullString) => {
 		if (hideThinking) return ""
 		const openTag = getOpenTag(match)
 		const closeTag = getCloseTag(match)
 		const inner = stripMarkdownSyntax(match.slice(openTag.length, -closeTag.length))
-		return inner ? dimThinkingContent(inner) : ""
+		if (!inner) return ""
+		const after = fullString.slice(offset + match.length)
+		const separator = after.trimStart().length > 0 ? "\n\n" : ""
+		return dimThinkingContent(inner) + separator
 	})
 	// 2. Handle unclosed open tags (thinking content still streaming)
 	for (const openTag of ["<think>", "<mm:think>"]) {


### PR DESCRIPTION
## Summary

MiniMax models emit reasoning inside `<mm:think>...</mm:think>` tags instead of the `<think>...</think>` tags used by DeepSeek/QwQ. This extends the `hide-thinking` extension to handle both variants transparently.

- `THINK_TAG_PATTERN` regex alternates on both tag forms
- `containsThinkTags()` checks for either pair
- Added `getOpenTag` / `getCloseTag` helpers so slice offsets are always correct (fixes a bug where `<mm:think>` content would incorrectly include the closing tag text)
- `replaceThinkingTagsWithDimmed()` uses the helpers
- `applyStreamingDisplay()` handles both closed and unclosed tags for both variants
- `message_update` streaming guard checks for both `<think>` and `<mm:think>`

## Test Plan

- [x] 9 new test cases covering `<mm:think>` in both the `hideThinkingExtension` and `filterThinkingForDisplay` suites
- [x] All 27 hide-thinking tests pass (`pnpm run test --testPathPattern="hide-thinking"`)
- [x] `pnpm run typecheck` clean