### PR TITLE
feat: bash max timeout (default 1 min)

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -29,6 +29,7 @@ import { isBunBinary } from "./env.js"
 import activityExtension from "./extensions/activity.js"
 import agentsExtension from "./extensions/agents/index.js"
 import assistantPrefixExtension from "./extensions/assistant-prefix.js"
+import bashMaxTimeoutExtension from "./extensions/bash-max-timeout/index.js"
 import behavioursExtension from "./extensions/behaviours/index.js"
 import claudeCodeHooksAdapter from "./extensions/claude-code-hook-adapter/index.js"
 import claudeCodeSkillsExtension from "./extensions/claude-code-skills/index.js"
@@ -440,6 +441,7 @@ try {
 			// SessionStart steering blocks into the system prompt. Gated per-package
 			// by each package's own resource toggle (see pluginPackageHookSources).
 			pluginPackageHooksAdapter,
+			bashMaxTimeoutExtension,
 			permissionsExtension,
 			resourcesExtension,
 			resourceToolBlockerExtension,

--- a/src/config.test.ts
+++ b/src/config.test.ts
@@ -49,6 +49,63 @@ describe("loadConfig", () => {
 		expect(config.apiKey).toBe("new-key")
 	})
 
+	describe("bashMaxTimeoutMs", () => {
+		it("defaults to 60000 when not set", () => {
+			const config = loadConfig({ configPath })
+			expect(config.bashMaxTimeoutMs).toBe(60_000)
+		})
+
+		it("reads bashMaxTimeoutMs from config file", () => {
+			writeFileSync(configPath, JSON.stringify({ bashMaxTimeoutMs: 12_345 }))
+			const config = loadConfig({ configPath })
+			expect(config.bashMaxTimeoutMs).toBe(12_345)
+		})
+
+		it("rejects non-positive values and falls back to the default", () => {
+			writeFileSync(configPath, JSON.stringify({ bashMaxTimeoutMs: -1 }))
+			const config = loadConfig({ configPath })
+			expect(config.bashMaxTimeoutMs).toBe(60_000)
+		})
+
+		it("rejects zero values and falls back to the default", () => {
+			writeFileSync(configPath, JSON.stringify({ bashMaxTimeoutMs: 0 }))
+			const config = loadConfig({ configPath })
+			expect(config.bashMaxTimeoutMs).toBe(60_000)
+		})
+
+		it("rejects non-numeric values and falls back to the default", () => {
+			writeFileSync(configPath, JSON.stringify({ bashMaxTimeoutMs: "30000" }))
+			const config = loadConfig({ configPath })
+			expect(config.bashMaxTimeoutMs).toBe(60_000)
+		})
+
+		it("project config wins over global", () => {
+			const projectDir = mkdtempSync(join(tmpdir(), "kimchi-proj-"))
+			mkdirSync(join(projectDir, ".kimchi"))
+			writeFileSync(configPath, JSON.stringify({ bashMaxTimeoutMs: 1000 }))
+			writeFileSync(join(projectDir, ".kimchi", "config.json"), JSON.stringify({ bashMaxTimeoutMs: 5000 }))
+			try {
+				const config = loadConfig({ configPath, cwd: projectDir })
+				expect(config.bashMaxTimeoutMs).toBe(5000)
+			} finally {
+				rmSync(projectDir, { recursive: true, force: true })
+			}
+		})
+
+		it("falls back to global when project omits the field", () => {
+			const projectDir = mkdtempSync(join(tmpdir(), "kimchi-proj-"))
+			mkdirSync(join(projectDir, ".kimchi"))
+			writeFileSync(configPath, JSON.stringify({ bashMaxTimeoutMs: 7777 }))
+			writeFileSync(join(projectDir, ".kimchi", "config.json"), JSON.stringify({ apiKey: "x" }))
+			try {
+				const config = loadConfig({ configPath, cwd: projectDir })
+				expect(config.bashMaxTimeoutMs).toBe(7777)
+			} finally {
+				rmSync(projectDir, { recursive: true, force: true })
+			}
+		})
+	})
+
 	it("reads deviceId from config file", () => {
 		writeFileSync(configPath, JSON.stringify({ deviceId: "550e8400-e29b-41d4-a716-446655440000" }))
 		const config = loadConfig({ configPath })

--- a/src/config.ts
+++ b/src/config.ts
@@ -141,6 +141,8 @@ export interface KimchiConfig {
 	migrationState?: MigrationState
 	onboarding: OnboardingConfig
 	deviceId: string
+	/** Default bash execution timeout in milliseconds. The bash tool's existing per-call `timeout` argument (seconds) overrides this. */
+	bashMaxTimeoutMs: number
 }
 
 /**
@@ -174,6 +176,7 @@ function readConfigExtras(configPath: string): {
 	onboarding?: OnboardingConfig
 	preferences?: PreferencesConfig
 	deviceId?: string
+	bashMaxTimeoutMs?: number
 } {
 	try {
 		const raw = readFileSync(configPath, "utf-8")
@@ -239,6 +242,10 @@ function readConfigExtras(configPath: string): {
 			(typeof parsed.device_id === "string" && parsed.device_id.length > 0 && parsed.device_id) ||
 			undefined
 
+		// Read bashMaxTimeoutMs (positive integer; anything else falls back to default)
+		const bashMaxTimeoutMs =
+			typeof parsed.bashMaxTimeoutMs === "number" && parsed.bashMaxTimeoutMs > 0 ? parsed.bashMaxTimeoutMs : undefined
+
 		return {
 			apiKey,
 			llmEndpoint,
@@ -250,6 +257,7 @@ function readConfigExtras(configPath: string): {
 			onboarding,
 			deviceId,
 			preferences,
+			bashMaxTimeoutMs,
 		}
 	} catch {
 		return {}
@@ -399,6 +407,7 @@ export function loadConfig(options?: { configPath?: string; cwd?: string }): Kim
 		migrationState: projectExtras.migrationState ?? globalExtras.migrationState,
 		onboarding: globalExtras.onboarding,
 		deviceId: projectExtras.deviceId ?? globalExtras.deviceId,
+		bashMaxTimeoutMs: projectExtras.bashMaxTimeoutMs ?? globalExtras.bashMaxTimeoutMs,
 	}
 
 	return {
@@ -413,6 +422,7 @@ export function loadConfig(options?: { configPath?: string; cwd?: string }): Kim
 		migrationState: extras.migrationState,
 		onboarding: extras.onboarding ?? {},
 		deviceId: extras.deviceId ?? "",
+		bashMaxTimeoutMs: extras.bashMaxTimeoutMs ?? 60_000,
 	}
 }
 

--- a/src/config.ts
+++ b/src/config.ts
@@ -10,6 +10,9 @@ const CAST_AI_LLM_ENDPOINT = "https://llm.cast.ai/openai/v1"
 const DEFAULT_TELEMETRY_LOGS_ENDPOINT = "https://api.cast.ai/ai-optimizer/v1beta/logs:ingest"
 const DEFAULT_TELEMETRY_METRICS_ENDPOINT = "https://api.cast.ai/ai-optimizer/v1beta/metrics:ingest"
 
+/** Default `bashMaxTimeoutMs` when the value is missing or invalid in config.json. */
+export const DEFAULT_BASH_MAX_TIMEOUT_MS = 60_000
+
 export const ALWAYS_SHOWN_SKILL_PATHS = [join(".config", "kimchi", "harness", "skills")]
 
 export const OPTIONAL_SKILL_PATHS = [join(".pi", "agent", "skills"), join(".claude", "skills")]
@@ -422,7 +425,7 @@ export function loadConfig(options?: { configPath?: string; cwd?: string }): Kim
 		migrationState: extras.migrationState,
 		onboarding: extras.onboarding ?? {},
 		deviceId: extras.deviceId ?? "",
-		bashMaxTimeoutMs: extras.bashMaxTimeoutMs ?? 60_000,
+		bashMaxTimeoutMs: extras.bashMaxTimeoutMs ?? DEFAULT_BASH_MAX_TIMEOUT_MS,
 	}
 }
 

--- a/src/extensions/bash-max-timeout/index.test.ts
+++ b/src/extensions/bash-max-timeout/index.test.ts
@@ -1,5 +1,6 @@
-import { describe, expect, it } from "vitest"
-import { bashMaxTimeoutSecondsFor } from "./index.js"
+import { describe, expect, it, vi } from "vitest"
+import * as config from "../../config.js"
+import bashMaxTimeoutExtension, { bashMaxTimeoutSecondsFor } from "./index.js"
 
 describe("bashMaxTimeoutSecondsFor", () => {
 	it("returns the default in seconds when the call has no timeout", () => {
@@ -30,5 +31,82 @@ describe("bashMaxTimeoutSecondsFor", () => {
 
 	it("never returns less than 1 second", () => {
 		expect(bashMaxTimeoutSecondsFor({}, 100)).toBe(1)
+	})
+})
+
+describe("bashMaxTimeoutExtension handler", () => {
+	function makePi(): {
+		pi: Parameters<typeof bashMaxTimeoutExtension>[0]
+		emit: (event: { toolName: string; input: Record<string, unknown> }) => void
+	} {
+		let handler: ((event: { toolName: string; input: Record<string, unknown> }) => unknown) | undefined
+		const pi = {
+			on: (event: string, fn: (e: { toolName: string; input: Record<string, unknown> }) => unknown) => {
+				if (event === "tool_call") handler = fn
+			},
+		}
+		return {
+			pi: pi as unknown as Parameters<typeof bashMaxTimeoutExtension>[0],
+			emit: (event) => {
+				if (!handler) throw new Error("tool_call handler was not registered")
+				handler(event)
+			},
+		}
+	}
+
+	function mockConfig(bashMaxTimeoutMs: number) {
+		return vi.spyOn(config, "loadConfig").mockReturnValue({ bashMaxTimeoutMs } as ReturnType<typeof config.loadConfig>)
+	}
+
+	it("injects default timeout for bash when no override is set", () => {
+		const spy = mockConfig(2_000)
+		const { pi, emit } = makePi()
+		bashMaxTimeoutExtension(pi)
+		const input: Record<string, unknown> = { command: "sleep 10" }
+		emit({ toolName: "bash", input })
+		expect(input.timeout).toBe(2)
+		spy.mockRestore()
+	})
+
+	it("preserves per-call bash timeout when set", () => {
+		const spy = mockConfig(2_000)
+		const { pi, emit } = makePi()
+		bashMaxTimeoutExtension(pi)
+		const input: Record<string, unknown> = { command: "sleep 10", timeout: 5 }
+		emit({ toolName: "bash", input })
+		expect(input.timeout).toBe(5)
+		spy.mockRestore()
+	})
+
+	it("clamps oversized per-call bash timeout to the cap", () => {
+		const spy = mockConfig(1_000) // cap = 10s
+		const { pi, emit } = makePi()
+		bashMaxTimeoutExtension(pi)
+		const input: Record<string, unknown> = { command: "sleep 5", timeout: 999 }
+		emit({ toolName: "bash", input })
+		expect(input.timeout).toBe(10)
+		spy.mockRestore()
+	})
+
+	it("matches bash regardless of case", () => {
+		const spy = mockConfig(4_000)
+		const { pi, emit } = makePi()
+		bashMaxTimeoutExtension(pi)
+		const input: Record<string, unknown> = { command: "echo hi" }
+		emit({ toolName: "BASH", input })
+		expect(input.timeout).toBe(4)
+		spy.mockRestore()
+	})
+
+	it("does not touch non-bash tools", () => {
+		const spy = mockConfig(60_000)
+		const { pi, emit } = makePi()
+		bashMaxTimeoutExtension(pi)
+		const input: Record<string, unknown> = { path: "/etc/hosts" }
+		emit({ toolName: "read", input })
+		expect(input.timeout).toBeUndefined()
+		expect(input.timeoutMs).toBeUndefined()
+		expect(input.path).toBe("/etc/hosts")
+		spy.mockRestore()
 	})
 })

--- a/src/extensions/bash-max-timeout/index.test.ts
+++ b/src/extensions/bash-max-timeout/index.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from "vitest"
+import { bashMaxTimeoutSecondsFor } from "./index.js"
+
+describe("bashMaxTimeoutSecondsFor", () => {
+	it("returns the default in seconds when the call has no timeout", () => {
+		expect(bashMaxTimeoutSecondsFor({}, 60_000)).toBe(60)
+	})
+
+	it("returns the per-call override in seconds when set", () => {
+		expect(bashMaxTimeoutSecondsFor({ timeout: 5 }, 60_000)).toBe(5)
+	})
+
+	it("rounds the default up to the next whole second", () => {
+		expect(bashMaxTimeoutSecondsFor({}, 2_500)).toBe(3)
+	})
+
+	it("treats non-positive overrides as missing", () => {
+		expect(bashMaxTimeoutSecondsFor({ timeout: 0 }, 60_000)).toBe(60)
+		expect(bashMaxTimeoutSecondsFor({ timeout: -3 }, 60_000)).toBe(60)
+	})
+
+	it("treats non-numeric overrides as missing", () => {
+		expect(bashMaxTimeoutSecondsFor({ timeout: "10" }, 60_000)).toBe(60)
+	})
+
+	it("clamps the per-call override to defaultMs * 10", () => {
+		// defaultMs = 1000 → cap = 10000ms = 10s
+		expect(bashMaxTimeoutSecondsFor({ timeout: 999 }, 1_000)).toBe(10)
+	})
+
+	it("never returns less than 1 second", () => {
+		expect(bashMaxTimeoutSecondsFor({}, 100)).toBe(1)
+	})
+})

--- a/src/extensions/bash-max-timeout/index.ts
+++ b/src/extensions/bash-max-timeout/index.ts
@@ -1,0 +1,44 @@
+import type { ExtensionAPI } from "@earendil-works/pi-coding-agent"
+import { loadConfig } from "../../config.js"
+
+/**
+ * Compute the `timeout` (seconds) value to inject into a `bash` tool call.
+ *
+ * Behaviour:
+ *   - Per-call `timeout` (seconds, positive number) wins.
+ *   - Otherwise fall back to `defaultMs` from settings, rounded up to whole
+ *     seconds, minimum 1.
+ *   - Per-call overrides greater than `defaultMs * 10` are clamped so a
+ *     misbehaving caller cannot disable the safety net.
+ *
+ * Exported for testing; the extension handler calls it on every bash call.
+ */
+export function bashMaxTimeoutSecondsFor(input: Record<string, unknown>, defaultMs: number): number {
+	const raw = input.timeout
+	const override = typeof raw === "number" && raw > 0 ? raw : undefined
+	const cap = Math.ceil((defaultMs * 10) / 1000)
+
+	if (override !== undefined) {
+		return Math.max(1, Math.min(override, cap))
+	}
+
+	return Math.max(1, Math.ceil(defaultMs / 1000))
+}
+
+/**
+ * Bash max timeout extension.
+ *
+ * For each `bash` tool call, fills in `event.input.timeout` (seconds) from
+ * the configured maximum when the caller did not already provide one.
+ * Upstream `createLocalBashOperations` enforces the timeout and races it
+ * against the session AbortController — no other wiring is needed here.
+ */
+export default function bashMaxTimeoutExtension(pi: ExtensionAPI): void {
+	const { bashMaxTimeoutMs } = loadConfig()
+
+	pi.on("tool_call", (event) => {
+		if (event.toolName.toLowerCase() !== "bash") return
+		const input = event.input as Record<string, unknown>
+		input.timeout = bashMaxTimeoutSecondsFor(input, bashMaxTimeoutMs)
+	})
+}

--- a/src/extensions/prompt-construction/prompt-enrichment.test.ts
+++ b/src/extensions/prompt-construction/prompt-enrichment.test.ts
@@ -839,6 +839,7 @@ describe("continuation nudge turn_end handler", () => {
 			},
 			onboarding: {},
 			deviceId: "test",
+			bashMaxTimeoutMs: 60_000,
 		})
 
 		const pi = {

--- a/src/extensions/prompt-construction/prompt-enrichment.test.ts
+++ b/src/extensions/prompt-construction/prompt-enrichment.test.ts
@@ -3,6 +3,8 @@ import { tmpdir } from "node:os"
 import { join } from "node:path"
 import type { AssistantMessage, ToolResultMessage } from "@earendil-works/pi-ai"
 import type { ExtensionAPI, ToolInfo } from "@earendil-works/pi-coding-agent"
+import { DEFAULT_BASH_MAX_TIMEOUT_MS } from "../../config.js"
+
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
 import * as config from "../../config.js"
 import type { ModelMetadata } from "../../models.js"
@@ -839,7 +841,7 @@ describe("continuation nudge turn_end handler", () => {
 			},
 			onboarding: {},
 			deviceId: "test",
-			bashMaxTimeoutMs: 60_000,
+			bashMaxTimeoutMs: DEFAULT_BASH_MAX_TIMEOUT_MS,
 		})
 
 		const pi = {


### PR DESCRIPTION
## Summary

- Add `bashMaxTimeoutMs` setting to `~/.config/kimchi/config.json` (default 60 000 ms).
- New `src/extensions/bash-max-timeout/` extension injects the timeout into every `bash` tool call that doesn't already specify one.
- Per-call `timeout` (seconds) wins; oversized per-call values are clamped to `defaultMs × 10`.
- Race-with-session-abort is handled by upstream `createLocalBashOperations`.

## Scope

Bash only. Other built-ins (`read`/`write`/`edit`/`grep`/`find`/`ls`) don't currently honour a per-call timeout upstream; extending to them is a separate effort.