### PR TITLE
fix(permissions): strip thinking blocks before parsing classifier output

### DIFF
--- a/src/extensions/permissions/classifier.test.ts
+++ b/src/extensions/permissions/classifier.test.ts
@@ -288,4 +288,47 @@ describe("parseClassifierOutput", () => {
 		const r = parseClassifierOutput(`{"verdict":"safe"}`)
 		expect(r.reason).toBe("no reason provided")
 	})
+
+	it("strips <think>…</think> and parses JSON after", () => {
+		const raw = `<think>The user is editing a test file, this is safe.</think>\n{"verdict":"safe","reason":"test file edit"}`
+		const r = parseClassifierOutput(raw)
+		expect(r.ok).toBe(true)
+		expect(r.verdict).toBe("safe")
+		expect(r.reason).toBe("test file edit")
+	})
+
+	it("strips <thinking>…</thinking> (alternate delimiter)", () => {
+		const raw = `<thinking>checking blast radius</thinking>\n{"verdict":"requires-confirmation","reason":"writes outside cwd"}`
+		const r = parseClassifierOutput(raw)
+		expect(r.ok).toBe(true)
+		expect(r.verdict).toBe("requires-confirmation")
+	})
+
+	it("ignores braces inside thinking block (the minimax-m2.7 bug)", () => {
+		// Model thinks aloud about the JSON shape, including example braces,
+		// then emits the real JSON after the closing tag. The naive
+		// indexOf('{') / lastIndexOf('}') approach latches onto braces
+		// inside the thinking text and returns null.
+		const raw = `<think>The answer should look like {verdict: safe, reason: ...} so I'll output it now.</think>\n{"verdict":"safe","reason":"file edit"}`
+		const r = parseClassifierOutput(raw)
+		expect(r.ok).toBe(true)
+		expect(r.verdict).toBe("safe")
+		expect(r.reason).toBe("file edit")
+	})
+
+	it("returns unparseable when <think> is unclosed and no JSON follows", () => {
+		const raw = "<think>The model burned its tokens reasoning and never produced a verdict."
+		const r = parseClassifierOutput(raw)
+		expect(r.ok).toBe(false)
+		expect(r.verdict).toBe("requires-confirmation")
+		expect(r.reason).toContain("unparseable")
+	})
+
+	it("strips <mm:think>…</mm:think> (minimax-m3 delimiter)", () => {
+		const raw = `<mm:think>The answer should look like {verdict: safe} so I'll respond now.</mm:think>
+{"verdict":"safe","reason":"file edit"}`
+		const r = parseClassifierOutput(raw)
+		expect(r.ok).toBe(true)
+		expect(r.verdict).toBe("safe")
+	})
 })

--- a/src/extensions/permissions/classifier.ts
+++ b/src/extensions/permissions/classifier.ts
@@ -150,7 +150,7 @@ function buildUserPrompt(call: ClassifyInput): string {
 }
 
 export function parseClassifierOutput(raw: string): ClassifierResult {
-	const json = extractJsonObject(raw)
+	const json = extractJsonObject(stripThinking(raw))
 	if (!json) return unavailable("classifier returned unparseable output")
 
 	const verdict = normalizeVerdict(json.verdict)
@@ -158,6 +158,30 @@ export function parseClassifierOutput(raw: string): ClassifierResult {
 
 	const reason = typeof json.reason === "string" && json.reason.trim() ? json.reason.trim() : "no reason provided"
 	return { verdict, reason, ok: true }
+}
+
+/**
+ * Strip `<think>…</think>` / `<thinking>…</thinking>` / `<mm:think>…</mm:think>`
+ * blocks from the raw model output. Reasoning models inline their thinking
+ * prose into the text content using these tags, and that prose routinely
+ * contains brace characters when the model reasons about the JSON shape
+ * it's about to emit. The naive `indexOf('{')` / `lastIndexOf('}')`
+ * extractor then latches onto braces inside the thinking text and returns
+ * null.
+ *
+ * If a thinking tag is opened but never closed (truncated by stopReason =
+ * length), the model burned its tokens reasoning and produced no verdict;
+ * return empty string so the existing unparseable → requires-confirmation
+ * fallback still fires.
+ */
+export function stripThinking(raw: string): string {
+	const closed = raw
+		.replace(/<mm:think>[\s\S]*?<\/mm:think>/gi, "")
+		.replace(/<think(?:ing)?>[\s\S]*?<\/think(?:ing)?>/gi, "")
+	if (/<(?:mm_?)?think(?:ing)?>/i.test(closed) && !/<\/(?:mm_?)?think(?:ing)?>/i.test(closed)) {
+		return ""
+	}
+	return closed
 }
 
 function unavailable(reason: string): InternalResult {


### PR DESCRIPTION
Fixes `parseClassifierOutput` to strip inline reasoning blocks from raw model output before extracting the JSON verdict, preventing parsing failures when reasoning models emit `<thinking>` ,`<think>` or <mm:think>` tags.

### Why
Reasoning models such as minimax-m2.7 (via the anthropic-messages adapter) inline their thinking prose using `<think>` / `<thinking>` delimiters. This prose often contains `{` and `}` characters when the model reasons about the JSON shape it will emit, which causes the naive `indexOf('{')` / `lastIndexOf('}')` extractor to capture the wrong braces and return null.

### Key changes
- `src/extensions/permissions/classifier.ts`: Added `stripThinking()` to remove `<think>` / `<thinking>` / `<mm:think>` blocks and their contents before passing the raw string to `extractJsonObject`.
- `src/extensions/permissions/classifier.ts`: `stripThinking()` returns an empty string when a thinking tag is opened but not closed, ensuring the existing unparseable-output fallback (`requires-confirmation`) still fires for truncated reasoning.
- `src/extensions/permissions/classifier.test.ts`: Added tests for closed thinking blocks, the alternate `<thinking>` delimiter, braces inside thinking text, and unclosed thinking tags.

### Impact
- Eliminates false `unparseable` results caused by brace characters inside model reasoning text.
- No breaking changes; truncated or missing reasoning continues to safely fall back to `requires-confirmation`.