### PR TITLE
Add Windows x64 and release support

### DIFF
--- a/.github/workflows/canary.yml
+++ b/.github/workflows/canary.yml
@@ -89,22 +89,30 @@ jobs:
     strategy:
       matrix:
         include:
-          - target: bun-darwin-x64
+          - target: darwin-x64
             os: darwin
             arch: amd64
             runner: macos-15-intel
-          - target: bun-darwin-arm64
+
+          - target: darwin-arm64
             os: darwin
             arch: arm64
             runner: macos-15
-          - target: bun-linux-x64
+
+          - target: linux-x64
             os: linux
             arch: amd64
             runner: ubuntu-latest
-          - target: bun-linux-arm64
+
+          - target: linux-arm64
             os: linux
             arch: arm64
             runner: ubuntu-24.04-arm
+
+          - target: windows-x64
+            os: windows
+            arch: amd64
+            runner: windows-latest
 
     runs-on: ${{ matrix.runner }}
     timeout-minutes: 20
@@ -121,18 +129,27 @@ jobs:
           cache-dependency-path: tools/proxy-helper/go.sum
 
       - name: Build proxy-helper
+        if: matrix.os != 'windows'
         run: make -C tools/proxy-helper build
         env:
           GOOS: ${{ matrix.os }}
           GOARCH: ${{ matrix.arch }}
 
+      - name: Build proxy-helper (Windows)
+        if: matrix.os == 'windows'
+        shell: pwsh
+        working-directory: tools/proxy-helper
+        run: |
+          go build -o bin/proxy-helper.exe
+
       - name: Set version
         run: node scripts/set-version.js "${{ needs.preflight.outputs.version }}"
 
       - name: Build binary
-        run: pnpm run build:binary
+        run: node scripts/build-binary.js --target ${{ matrix.target }}
 
       - name: Verify binary architecture
+        if: matrix.os != 'windows'
         run: |
           file dist/bin/kimchi
           case "${{ matrix.arch }}" in
@@ -142,13 +159,22 @@ jobs:
           esac
 
       - name: Package binary
+        if: matrix.os != 'windows'
         run: tar -czf kimchi_${{ matrix.os }}_${{ matrix.arch }}.tar.gz -C dist bin share
+
+      - name: Package Windows binary
+        if: matrix.os == 'windows'
+        shell: pwsh
+        run: |
+          Compress-Archive `
+            -Path dist\bin,dist\share `
+            -DestinationPath kimchi_${{ matrix.os }}_${{ matrix.arch }}.zip
 
       - name: Upload artifact
         uses: actions/upload-artifact@v4
         with:
           name: kimchi_${{ matrix.os }}_${{ matrix.arch }}
-          path: kimchi_${{ matrix.os }}_${{ matrix.arch }}.tar.gz
+          path: kimchi_${{ matrix.os }}_${{ matrix.arch }}.*
 
   smoke-test:
     needs: [preflight, build]
@@ -197,7 +223,7 @@ jobs:
       - name: Generate checksums
         run: |
           cd artifacts
-          sha256sum kimchi_*.tar.gz > checksums.txt
+          sha256sum kimchi_* > checksums.txt
 
       - name: Build release notes
         env:
@@ -232,5 +258,6 @@ jobs:
             --notes-file release-notes.md \
             --prerelease \
             --target "$GITHUB_SHA" \
-            artifacts/kimchi_*.tar.gz \
-            artifacts/checksums.txt
+              artifacts/kimchi_*.tar.gz \
+              artifacts/kimchi_*.zip \
+              artifacts/checksums.txt

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -34,22 +34,26 @@ jobs:
     strategy:
       matrix:
         include:
-          - target: bun-darwin-x64
+          - target: darwin-x64
             os: darwin
             arch: amd64
             runner: macos-15-intel
-          - target: bun-darwin-arm64
+          - target: darwin-arm64
             os: darwin
             arch: arm64
             runner: macos-15
-          - target: bun-linux-x64
+          - target: linux-x64
             os: linux
             arch: amd64
             runner: ubuntu-latest
-          - target: bun-linux-arm64
+          - target: linux-arm64
             os: linux
             arch: arm64
             runner: ubuntu-24.04-arm
+          - target: windows-x64
+            os: windows
+            arch: amd64
+            runner: windows-latest
 
     runs-on: ${{ matrix.runner }}
 
@@ -60,6 +64,7 @@ jobs:
           bun: "true"
 
       - name: Set version from tag
+        shell: bash
         run: node scripts/set-version.js "$GITHUB_REF_NAME"
 
       - uses: actions/setup-go@v5
@@ -67,13 +72,22 @@ jobs:
           go-version-file: tools/proxy-helper/go.mod
 
       - name: Build proxy-helper
+        if: matrix.os != 'windows'
         run: make build
         working-directory: tools/proxy-helper
 
+      - name: Build proxy-helper (Windows)
+        if: matrix.os == 'windows'
+        shell: pwsh
+        working-directory: tools/proxy-helper
+        run: |
+          go build -o bin/proxy-helper.exe
+
       - name: Build binary
-        run: pnpm run build:binary
+        run: node scripts/build-binary.js --target ${{ matrix.target }}
 
       - name: Verify binary architecture
+        if: matrix.os != 'windows'
         run: |
           file dist/bin/kimchi
           case "${{ matrix.arch }}" in
@@ -90,13 +104,22 @@ jobs:
           esac
 
       - name: Package binary
+        if: matrix.os != 'windows'
         run: tar -czf kimchi_${{ matrix.os }}_${{ matrix.arch }}.tar.gz -C dist bin share
+
+      - name: Package Windows binary
+        if: matrix.os == 'windows'
+        shell: pwsh
+        run: |
+          Compress-Archive `
+            -Path dist\bin,dist\share `
+            -DestinationPath kimchi_${{ matrix.os }}_${{ matrix.arch }}.zip
 
       - name: Upload artifact
         uses: actions/upload-artifact@v4
         with:
           name: kimchi_${{ matrix.os }}_${{ matrix.arch }}
-          path: kimchi_${{ matrix.os }}_${{ matrix.arch }}.tar.gz
+          path: kimchi_${{ matrix.os }}_${{ matrix.arch }}.*
 
   smoke-test:
     needs: [build]
@@ -138,15 +161,17 @@ jobs:
       - name: Generate checksums
         run: |
           cd artifacts
-          sha256sum kimchi_*.tar.gz > checksums.txt
+          sha256sum kimchi_* > checksums.txt
 
       - name: Create GitHub release
         uses: softprops/action-gh-release@153bb8e04406b158c6c84fc1615b65b24149a1fe # v2
         with:
           files: |
             artifacts/kimchi_*.tar.gz
+            artifacts/kimchi_*.zip
             artifacts/checksums.txt
             scripts/install.sh
+            scripts/install.ps1
           generate_release_notes: true
 
   homebrew:

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ brew install getkimchi/tap/kimchi
 curl -fsSL https://github.com/getkimchi/kimchi/releases/latest/download/install.sh | bash
 ```
 
-### PowerShell installer (Windows)
+### PowerShell installer (Windows x64)
 
 ```powershell
 irm https://github.com/getkimchi/kimchi/releases/latest/download/install.ps1 | iex

--- a/README.md
+++ b/README.md
@@ -8,17 +8,35 @@ A coding agent CLI powered by [kimchi](https://kimchi.dev/). Built on the [pi-mo
 
 Install the latest release:
 
-**Homebrew (macOS / Linux):**
+### Homebrew (macOS / Linux)
 
 ```bash
 brew install getkimchi/tap/kimchi
 ```
 
-**Install script:**
+### Install script (macOS / Linux)
 
 ```bash
 curl -fsSL https://github.com/getkimchi/kimchi/releases/latest/download/install.sh | bash
 ```
+
+### PowerShell installer (Windows)
+
+```powershell
+irm https://github.com/getkimchi/kimchi/releases/latest/download/install.ps1 | iex
+```
+
+### Manual download
+
+Download the appropriate release package from:
+
+https://github.com/getkimchi/kimchi/releases/latest
+
+- macOS Intel → `kimchi_darwin_amd64.tar.gz`
+- macOS Apple Silicon → `kimchi_darwin_arm64.tar.gz`
+- Linux x64 → `kimchi_linux_amd64.tar.gz`
+- Linux ARM64 → `kimchi_linux_arm64.tar.gz`
+- Windows x64 → `kimchi_windows_amd64.zip`
 
 Then configure your API key and launch:
 

--- a/package.json
+++ b/package.json
@@ -15,7 +15,6 @@
 		"build:binary-linux-arm64": "node scripts/build-binary.js --target linux-arm64",
 		"build:binary-linux-x64": "node scripts/build-binary.js --target linux-x64",
 		"build:binary-windows-x64": "node scripts/build-binary.js --target windows-x64",
-		"build:binary-windows-arm64": "node scripts/build-binary.js --target windows-arm64",
 		"dev": "make -C tools/proxy-helper/ copy-for-dev && bun run --preload ./src/set-package-dir.ts src/entry.ts",
 		"dev:overlay": "scripts/dev-overlay.sh",
 		"dev:setup": "bun run --preload ./src/set-package-dir.ts src/entry.ts setup",

--- a/package.json
+++ b/package.json
@@ -8,12 +8,14 @@
 		"kimchi": "src/entry.ts"
 	},
 	"scripts": {
-		"clean": "rm -rf dist",
+		"clean": "node -e \"import('node:fs').then(fs=>fs.rmSync('dist',{recursive:true,force:true}))\"",
 		"build": "tsc --noEmit && node scripts/copy-resources.js --dev",
 		"build:binary": "node scripts/build-binary.js",
 		"install:local": "node scripts/install-local.js",
 		"build:binary-linux-arm64": "node scripts/build-binary.js --target linux-arm64",
 		"build:binary-linux-x64": "node scripts/build-binary.js --target linux-x64",
+		"build:binary-windows-x64": "node scripts/build-binary.js --target windows-x64",
+		"build:binary-windows-arm64": "node scripts/build-binary.js --target windows-arm64",
 		"dev": "make -C tools/proxy-helper/ copy-for-dev && bun run --preload ./src/set-package-dir.ts src/entry.ts",
 		"dev:overlay": "scripts/dev-overlay.sh",
 		"dev:setup": "bun run --preload ./src/set-package-dir.ts src/entry.ts setup",

--- a/scripts/build-binary.js
+++ b/scripts/build-binary.js
@@ -60,9 +60,15 @@ run(
 // Bun --compile produces binaries with an invalid code signature on macOS.
 // The kernel kills badly-signed arm64 binaries immediately (SIGKILL, exit 137).
 // Strip the corrupt signature and re-sign ad-hoc. See: https://github.com/oven-sh/bun/issues/7208
-if (platform() === "darwin") {
+const isDarwinTarget =
+	!crossTarget || crossTarget.includes("darwin")
+
+if (platform() === "darwin" && isDarwinTarget) {
 	run("codesign (strip)", `codesign --remove-signature dist/bin/${exeName}`)
 	run("codesign (ad-hoc)", `codesign -s - dist/bin/${exeName}`)
 }
 
-run("copy resources", "node scripts/copy-resources.js")
+run(
+	"copy resources",
+	`BUILD_TARGET=${targetArg ?? ""} node scripts/copy-resources.js`,
+)

--- a/scripts/build-binary.js
+++ b/scripts/build-binary.js
@@ -10,8 +10,11 @@ import { execSync } from "node:child_process"
 import { platform } from "node:os"
 
 const TARGET_MAP = {
+	"darwin-x64": "bun-darwin-x64",
+	"darwin-arm64": "bun-darwin-arm64",
 	"linux-arm64": "bun-linux-arm64",
 	"linux-x64": "bun-linux-x64",
+	"windows-x64": "bun-windows-x64",
 }
 
 const targetArg =
@@ -20,6 +23,8 @@ const targetArg =
 
 const crossTarget = targetArg ? (TARGET_MAP[targetArg] ?? targetArg) : undefined
 const isCrossCompile = !!crossTarget
+
+const exeName = platform() === "win32" || crossTarget?.includes("windows") ? "kimchi.exe" : "kimchi"
 
 function run(label, cmd) {
 	console.log(`\n→ ${label}`)
@@ -49,15 +54,15 @@ const targetFlag = crossTarget ? ` --target=${crossTarget}` : ""
 // extra env vars. Bun ignores the system store by default; --use-system-ca is additive.
 run(
 	"compile",
-	`bun build src/entry.ts --compile${targetFlag} --compile-exec-argv="--use-system-ca" --outfile dist/bin/kimchi --external chromium-bidi --external electron`.trim(),
+	`bun build src/entry.ts --compile${targetFlag} --compile-exec-argv="--use-system-ca" --outfile dist/bin/${exeName} --external chromium-bidi --external electron`.trim(),
 )
 
 // Bun --compile produces binaries with an invalid code signature on macOS.
 // The kernel kills badly-signed arm64 binaries immediately (SIGKILL, exit 137).
 // Strip the corrupt signature and re-sign ad-hoc. See: https://github.com/oven-sh/bun/issues/7208
-if (!isCrossCompile && platform() === "darwin") {
-	run("codesign (strip)", "codesign --remove-signature dist/bin/kimchi")
-	run("codesign (ad-hoc)", "codesign -s - dist/bin/kimchi")
+if (platform() === "darwin") {
+	run("codesign (strip)", `codesign --remove-signature dist/bin/${exeName}`)
+	run("codesign (ad-hoc)", `codesign -s - dist/bin/${exeName}`)
 }
 
 run("copy resources", "node scripts/copy-resources.js")

--- a/scripts/build-binary.js
+++ b/scripts/build-binary.js
@@ -60,15 +60,11 @@ run(
 // Bun --compile produces binaries with an invalid code signature on macOS.
 // The kernel kills badly-signed arm64 binaries immediately (SIGKILL, exit 137).
 // Strip the corrupt signature and re-sign ad-hoc. See: https://github.com/oven-sh/bun/issues/7208
-const isDarwinTarget =
-	!crossTarget || crossTarget.includes("darwin")
+const isDarwinTarget = !crossTarget || crossTarget.includes("darwin")
 
 if (platform() === "darwin" && isDarwinTarget) {
 	run("codesign (strip)", `codesign --remove-signature dist/bin/${exeName}`)
 	run("codesign (ad-hoc)", `codesign -s - dist/bin/${exeName}`)
 }
 
-run(
-	"copy resources",
-	`BUILD_TARGET=${targetArg ?? ""} node scripts/copy-resources.js`,
-)
+run("copy resources", `BUILD_TARGET=${targetArg ?? ""} node scripts/copy-resources.js`)

--- a/scripts/build-binary.js
+++ b/scripts/build-binary.js
@@ -67,4 +67,4 @@ if (platform() === "darwin" && isDarwinTarget) {
 	run("codesign (ad-hoc)", `codesign -s - dist/bin/${exeName}`)
 }
 
-run("copy resources", `BUILD_TARGET=${targetArg ?? ""} node scripts/copy-resources.js`)
+run("copy resources", `node scripts/copy-resources.js ${targetArg ?? ""}`)

--- a/scripts/copy-resources.js
+++ b/scripts/copy-resources.js
@@ -87,7 +87,12 @@ if (!isDev) {
 	cpSync(oauthSrc, oauthDest, { recursive: true })
 
 	// Copy proxy-helper binary built by tools/proxy-helper/Makefile
-	const proxyHelperName = platform() === "win32" ? "proxy-helper.exe" : "proxy-helper"
+	const buildTarget = process.env.BUILD_TARGET
+
+	const proxyHelperName =
+		buildTarget?.startsWith("windows") || platform() === "win32"
+			? "proxy-helper.exe"
+			: "proxy-helper"
 
 	const proxyHelperSrc = join(projectRoot, "tools", "proxy-helper", "bin", proxyHelperName)
 	const proxyHelperBinDest = join(projectRoot, "dist", "share", "kimchi", "bin")

--- a/scripts/copy-resources.js
+++ b/scripts/copy-resources.js
@@ -87,7 +87,7 @@ if (!isDev) {
 	cpSync(oauthSrc, oauthDest, { recursive: true })
 
 	// Copy proxy-helper binary built by tools/proxy-helper/Makefile
-	const buildTarget = process.env.BUILD_TARGET
+	const buildTarget = process.argv[2]
 
 	const proxyHelperName =
 		buildTarget?.startsWith("windows") || platform() === "win32" ? "proxy-helper.exe" : "proxy-helper"

--- a/scripts/copy-resources.js
+++ b/scripts/copy-resources.js
@@ -90,9 +90,7 @@ if (!isDev) {
 	const buildTarget = process.env.BUILD_TARGET
 
 	const proxyHelperName =
-		buildTarget?.startsWith("windows") || platform() === "win32"
-			? "proxy-helper.exe"
-			: "proxy-helper"
+		buildTarget?.startsWith("windows") || platform() === "win32" ? "proxy-helper.exe" : "proxy-helper"
 
 	const proxyHelperSrc = join(projectRoot, "tools", "proxy-helper", "bin", proxyHelperName)
 	const proxyHelperBinDest = join(projectRoot, "dist", "share", "kimchi", "bin")

--- a/scripts/copy-resources.js
+++ b/scripts/copy-resources.js
@@ -11,6 +11,7 @@
 //                                   so the compiled binary resolves assets from the shared data directory
 
 import { cpSync, mkdirSync, readFileSync, readdirSync, writeFileSync } from "node:fs"
+import { platform } from "node:os"
 import { dirname, join } from "node:path"
 import { fileURLToPath } from "node:url"
 
@@ -86,10 +87,12 @@ if (!isDev) {
 	cpSync(oauthSrc, oauthDest, { recursive: true })
 
 	// Copy proxy-helper binary built by tools/proxy-helper/Makefile
-	const proxyHelperSrc = join(projectRoot, "tools", "proxy-helper", "bin", "proxy-helper")
+	const proxyHelperName = platform() === "win32" ? "proxy-helper.exe" : "proxy-helper"
+
+	const proxyHelperSrc = join(projectRoot, "tools", "proxy-helper", "bin", proxyHelperName)
 	const proxyHelperBinDest = join(projectRoot, "dist", "share", "kimchi", "bin")
 	mkdirSync(proxyHelperBinDest, { recursive: true })
-	cpSync(proxyHelperSrc, join(proxyHelperBinDest, "proxy-helper"))
+	cpSync(proxyHelperSrc, join(proxyHelperBinDest, proxyHelperName))
 
 	// teleport-proxy.js is invoked by `node` (spawned via ssh ProxyCommand), so it
 	// has to live on the real filesystem next to the binary's share assets — it

--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -1,0 +1,82 @@
+$ErrorActionPreference = "Stop"
+
+$Repo = if ($env:KIMCHI_REPO_OVERRIDE) {
+    $env:KIMCHI_REPO_OVERRIDE
+} else {
+    "getkimchi/kimchi"
+}
+
+$Version = if ($env:KIMCHI_VERSION) { $env:KIMCHI_VERSION } else { "latest" }
+
+Write-Host "Installing Kimchi from $Repo ($Version)..."
+
+switch ($env:PROCESSOR_ARCHITECTURE) {
+    "AMD64" {
+        $Arch = "amd64"
+    }
+
+    "ARM64" {
+        Write-Error "Windows ARM64 is not currently supported."
+        exit 1
+    }
+
+    default {
+        Write-Error "Unsupported architecture: $env:PROCESSOR_ARCHITECTURE"
+        exit 1
+    }
+}
+
+if ($Version -eq "latest") {
+    $ZipUrl = "https://github.com/$Repo/releases/latest/download/kimchi_windows_$Arch.zip"
+}
+else {
+    $ZipUrl = "https://github.com/$Repo/releases/download/$Version/kimchi_windows_$Arch.zip"
+}
+
+$TempDir = Join-Path $env:TEMP ("kimchi-" + [guid]::NewGuid())
+$ZipPath = Join-Path $TempDir "kimchi.zip"
+
+New-Item -ItemType Directory -Force -Path $TempDir | Out-Null
+
+Write-Host "Downloading Kimchi for windows/$Arch..."
+Invoke-WebRequest -Uri $ZipUrl -OutFile $ZipPath
+
+Write-Host "Extracting..."
+Expand-Archive -Path $ZipPath -DestinationPath $TempDir -Force
+
+$InstallDir = if ($env:KIMCHI_INSTALL_DIR) {
+    $env:KIMCHI_INSTALL_DIR
+} else {
+    Join-Path $env:LOCALAPPDATA "Kimchi"
+}
+
+New-Item -ItemType Directory -Force -Path $InstallDir | Out-Null
+
+Copy-Item "$TempDir\bin" -Destination $InstallDir -Recurse -Force
+Copy-Item "$TempDir\share" -Destination $InstallDir -Recurse -Force
+
+$BinDir = Join-Path $InstallDir "bin"
+
+$UserPath = [Environment]::GetEnvironmentVariable("Path", "User")
+
+if ($UserPath -notlike "*$BinDir*") {
+    [Environment]::SetEnvironmentVariable(
+        "Path",
+        "$UserPath;$BinDir",
+        "User"
+    )
+
+    Write-Host ""
+    Write-Host "Added $BinDir to your user PATH."
+    Write-Host "Open a new PowerShell window to use kimchi."
+}
+
+Write-Host ""
+Write-Host "Installed Kimchi to:"
+Write-Host "$BinDir\kimchi.exe"
+
+Write-Host ""
+Write-Host "Next: run"
+Write-Host "  kimchi setup"
+Write-Host "or"
+Write-Host "  kimchi"


### PR DESCRIPTION
## Description

<!-- What problem does this PR solve? What changes were made and why? -->


## Type of Change

<!-- Select all that apply. -->

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Documentation update
- [x] Windows x64 Support

## Summary

Adds Windows release and installation support.

### Changes

- Add install.ps1 for Windows installation
- Publish install.ps1 in GitHub releases
- Build proxy-helper.exe on Windows
- Copy proxy-helper.exe into release artifacts
- Add Windows binary packaging (.zip)
- Fix macOS codesign for Bun-compiled binaries
- Add darwin target mapping for cross-compilation
- Remove unsupported Windows ARM64 release references

### Testing

- Release workflow successfully produced:
  - kimchi_darwin_amd64
  - kimchi_darwin_arm64
  - kimchi_linux_amd64
  - kimchi_linux_arm64
  - kimchi_windows_amd64

- Verified release artifacts and installer scripts.
- Get new binaries from: https://github.com/TacticsPro/kimchi/releases