### PR TITLE
feat(orchestration): refined and simplified model delegation rules

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,9 +69,10 @@ Use `/multi-model` in the interactive CLI to toggle models on/off per role, or e
 | **planner** | `kimi-k2.6` | Designs the approach, writes specs. When same as orchestrator, planning is done in-process. |
 | **builder** | `kimi-k2.6`, `minimax-m2.7` | Code implementation. For complex tasks the orchestrator may pick a heavier model from the pool. |
 | **reviewer** | `kimi-k2.6`, `minimax-m2.7` | Code review. Orchestrator picks the strongest by tier for initial review. |
-| **explorer** | `kimi-k2.6`, `nemotron-3-ultra-fp4` | Codebase exploration, research. Light models for broad scans, heavy for deep analysis. |
+| **explorer** | `nemotron-3-ultra-fp4` | Codebase exploration — navigating files, reading code, tracing architecture. |
+| **researcher** | `kimi-k2.6` | Research beyond the codebase — web search, documentation lookup, external sources. |
 
-Defaults are derived from model capabilities in `MODEL_CAPABILITIES`. Roles accept any `provider/model-id` string or an array of strings. Only non-default values need to be specified; missing keys fall back to defaults.
+Defaults are hardcoded in `DEFAULT_MODEL_ROLES`. Roles accept any `provider/model-id` string or an array of strings. Only non-default values need to be specified; missing keys fall back to defaults.
 
 #### How model selection works
 

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ In single-model mode the orchestration system prompt (environment, tools, resear
 
 ### Model roles
 
-In multi-model mode, each task type is handled by a specific role. Each role can have one model or a **pool of candidates** — the orchestrator reads model descriptions (tier, capabilities) and picks the best fit for each task.
+In multi-model mode, each task type is handled by a specific role. Each role can have one model or a **pool of candidates** — the orchestrator reads model tier and description and picks the best fit for each task.
 
 Use `/multi-model` in the interactive CLI to toggle models on/off per role, or edit `~/.config/kimchi/harness/settings.json` directly:
 
@@ -77,57 +77,27 @@ Defaults are derived from model capabilities in `MODEL_CAPABILITIES`. Roles acce
 
 The orchestrator sees each role's model pool with tier and description. It picks the model whose description best matches the task:
 
-- **Simple build chunk** (CRUD, parsers, CLI): picks standard-tier builder (minimax-m2.7)
+- **Simple build chunk** (CRUD, parsers, CLI): picks standard-tier builder
 - **Complex build chunk** (concurrency, graph algorithms): picks the heaviest model whose description confirms correctness reasoning
 - **Code review**: picks the strongest reviewer by tier — fresh Agent context provides independence
 - **Exploration**: picks a light model for broad file reading, heavy for deep analysis
 
-#### Example: using Claude for builds
+Built-in models (kimchi-dev) have tier and description baked in. External models need metadata — see below.
 
-To use Claude Sonnet for all build work while keeping kimchi-dev models for orchestration and review:
+#### Model metadata
 
-```json
-{
-  "modelRoles": {
-    "builder": "anthropic/claude-sonnet-4-5"
-  }
-}
-```
-
-#### Example: mixed pool with tier-based selection
-
-To give the orchestrator a choice between a cheap builder and a strong one, and let it pick based on chunk complexity:
+External models (Anthropic, OpenAI, or any non-builtin provider) have no built-in tier or description. Without metadata, they default to `standard` tier, `vision: false`, and an auto-generated description based on their assigned roles. To give the orchestrator better routing information, add a `modelMetadata` section to `settings.json`:
 
 ```json
 {
   "modelRoles": {
     "builder": ["kimchi-dev/minimax-m2.7", "anthropic/claude-sonnet-4-5"],
     "reviewer": "anthropic/claude-sonnet-4-5"
-  }
-}
-```
-
-The orchestrator will use minimax for simple chunks and Claude for complex ones (based on the plan's complexity classification).
-
-#### Custom metadata for external models
-
-Models without a built-in capability entry (e.g., Anthropic or OpenAI models) can be annotated with custom metadata so the orchestrator sees their tier, description, and vision support when making routing decisions. Add a `modelMetadata` section to `settings.json`:
-
-```json
-{
-  "modelRoles": {
-    "planner": ["kimchi-dev/kimi-k2.6", "anthropic/claude-opus-4-6"],
-    "builder": "openai/gpt-4o"
   },
   "modelMetadata": {
-    "anthropic/claude-opus-4-6": {
+    "anthropic/claude-sonnet-4-5": {
       "tier": "heavy",
-      "description": "Anthropic flagship — best for complex architectural planning and deep reasoning.",
-      "vision": false
-    },
-    "openai/gpt-4o": {
-      "tier": "standard",
-      "description": "Fast and capable general-purpose model."
+      "description": "Strong general-purpose model — use for complex builds and thorough reviews."
     }
   }
 }
@@ -136,12 +106,12 @@ Models without a built-in capability entry (e.g., Anthropic or OpenAI models) ca
 | Field | Default | Description |
 |-------|---------|-------------|
 | `tier` | `standard` | `light`, `standard`, or `heavy`. Used for complexity-based routing. |
-| `description` | Auto-generated | Shown to the orchestrator in the **Your Team** and **Your Capabilities** sections. When omitted, a description is generated based on the model's assigned roles. |
+| `description` | Auto-generated | Shown to the orchestrator so it can match model strengths to task requirements. |
 | `vision` | `false` | Whether the model supports image input. |
 
-External models assigned without custom metadata still work — they default to `standard` tier with `vision: false`, and the orchestrator receives an auto-generated description based on their assigned roles.
+With the metadata above, the orchestrator will use minimax for simple build chunks and Claude for complex ones. Without it, both models look like standard-tier to the orchestrator and selection is arbitrary.
 
-Metadata can also be managed interactively via `/multi-model` → "Edit model metadata". Custom overrides can be reset to defaults from the same menu. When switching to an unknown model, a wizard prompts for metadata configuration.
+Metadata can also be managed interactively via `/multi-model` → "Edit model metadata". Custom overrides can be reset to defaults from the same menu. When switching to an unknown model, a wizard prompts for metadata configuration. Metadata for builtin models can be overridden the same way.
 
 ### Phase tracking
 

--- a/README.md
+++ b/README.md
@@ -111,48 +111,37 @@ The orchestrator will use minimax for simple chunks and Claude for complex ones 
 
 #### Custom metadata for external models
 
-Models without a built-in capability entry (e.g., Anthropic or OpenAI models) can be annotated with custom metadata so the orchestrator sees their tier, description, and vision support when making routing decisions. Provide an object instead of a plain string:
+Models without a built-in capability entry (e.g., Anthropic or OpenAI models) can be annotated with custom metadata so the orchestrator sees their tier, description, and vision support when making routing decisions. Add a `modelMetadata` section to `settings.json`:
 
 ```json
 {
   "modelRoles": {
-    "planner": [
-      "kimchi-dev/kimi-k2.6",
-      {
-        "model": "anthropic/claude-opus-4-6",
-        "tier": "heavy",
-        "description": "Anthropic flagship — best for complex architectural planning and deep reasoning.",
-        "vision": false
-      }
-    ]
-  }
-}
-```
-
-| Field | Required | Default | Description |
-|-------|----------|---------|-------------|
-| `model` | **Yes** | — | Full model reference (`provider/model-id`). |
-| `tier` | No | `standard` | `light`, `standard`, or `heavy`. Used for complexity-based routing. |
-| `description` | No | Auto-generated | Shown to the orchestrator in the **Your Team** and **Your Capabilities** sections. When omitted, a description is generated indicating the model was configured by the user and listing its assigned roles. |
-| `vision` | No | `false` | Whether the model supports image input. |
-
-External models assigned without custom metadata still work — they default to `standard` tier with `vision: false`, and the orchestrator receives an auto-generated description noting the model was chosen by the user for its assigned roles.
-
-Metadata can also be managed interactively via `/multi-model` → "Edit model metadata". Custom overrides can be reset to defaults from the same menu. When switching to an unknown model, a wizard prompts for metadata configuration.
-
-Under the hood, metadata from inline objects is extracted and stored in the `modelMetadata` key of `settings.json`, separate from role assignments. The `modelMetadata` key can also be edited directly:
-
-```json
-{
+    "planner": ["kimchi-dev/kimi-k2.6", "anthropic/claude-opus-4-6"],
+    "builder": "openai/gpt-4o"
+  },
   "modelMetadata": {
     "anthropic/claude-opus-4-6": {
       "tier": "heavy",
-      "description": "Anthropic flagship — best for complex architectural planning.",
+      "description": "Anthropic flagship — best for complex architectural planning and deep reasoning.",
       "vision": false
+    },
+    "openai/gpt-4o": {
+      "tier": "standard",
+      "description": "Fast and capable general-purpose model."
     }
   }
 }
 ```
+
+| Field | Default | Description |
+|-------|---------|-------------|
+| `tier` | `standard` | `light`, `standard`, or `heavy`. Used for complexity-based routing. |
+| `description` | Auto-generated | Shown to the orchestrator in the **Your Team** and **Your Capabilities** sections. When omitted, a description is generated based on the model's assigned roles. |
+| `vision` | `false` | Whether the model supports image input. |
+
+External models assigned without custom metadata still work — they default to `standard` tier with `vision: false`, and the orchestrator receives an auto-generated description based on their assigned roles.
+
+Metadata can also be managed interactively via `/multi-model` → "Edit model metadata". Custom overrides can be reset to defaults from the same menu. When switching to an unknown model, a wizard prompts for metadata configuration.
 
 ### Phase tracking
 

--- a/README.md
+++ b/README.md
@@ -109,6 +109,35 @@ To give the orchestrator a choice between a cheap builder and a strong one, and 
 
 The orchestrator will use minimax for simple chunks and Claude for complex ones (based on the plan's complexity classification).
 
+#### Custom metadata for external models
+
+Models without a built-in capability entry (e.g., Anthropic or OpenAI models) can be annotated with custom metadata so the orchestrator sees their tier, roles, and description when making routing decisions. Provide an object instead of a plain string:
+
+```json
+{
+  "modelRoles": {
+    "planner": [
+      "kimchi-dev/kimi-k2.6",
+      {
+        "model": "anthropic/claude-opus-4-6",
+        "tier": "heavy",
+        "description": "Anthropic flagship — best for complex architectural planning and deep reasoning.",
+        "vision": false
+      }
+    ]
+  }
+}
+```
+
+| Field | Required | Description |
+|-------|----------|-------------|
+| `model` | **Yes** | Full model reference (`provider/model-id`). |
+| `tier` | No | `light`, `standard`, or `heavy`. Used for complexity-based routing. |
+| `description` | No | Shown to the orchestrator in the **Your Team** section. |
+| `vision` | No | `true` if the model supports image input. Shown in **Your Capabilities**. |
+
+If an external model is assigned without custom metadata, it still works — it simply appears in the prompt with no tier or description, and the orchestrator must infer its strengths from the model name alone.
+
 ### Phase tracking
 
 Kimchi tags every LLM request with a `phase:{name}` label for usage analytics and cost attribution. The orchestrator sets the phase as work progresses and it is displayed in the footer.

--- a/README.md
+++ b/README.md
@@ -129,14 +129,14 @@ Models without a built-in capability entry (e.g., Anthropic or OpenAI models) ca
 }
 ```
 
-| Field | Required | Description |
-|-------|----------|-------------|
-| `model` | **Yes** | Full model reference (`provider/model-id`). |
-| `tier` | No | `light`, `standard`, or `heavy`. Used for complexity-based routing. |
-| `description` | No | Shown to the orchestrator in the **Your Team** section. |
-| `vision` | No | `true` if the model supports image input. Shown in **Your Capabilities**. |
+| Field | Required | Default | Description |
+|-------|----------|---------|-------------|
+| `model` | **Yes** | — | Full model reference (`provider/model-id`). |
+| `tier` | No | `standard` | `light`, `standard`, or `heavy`. Used for complexity-based routing. |
+| `description` | No | Auto-generated | Shown to the orchestrator in the **Your Team** and **Your Capabilities** sections. When omitted, a description is generated indicating the model was configured by the user and listing its assigned roles. |
+| `vision` | No | `false` | Whether the model supports image input. |
 
-If an external model is assigned without custom metadata, it still works — it simply appears in the prompt with no tier or description, and the orchestrator must infer its strengths from the model name alone.
+External models assigned without custom metadata still work — they default to `standard` tier with `vision: false`, and the orchestrator receives an auto-generated description noting the model was chosen by the user for its assigned roles.
 
 ### Phase tracking
 

--- a/README.md
+++ b/README.md
@@ -74,14 +74,15 @@ Use `/multi-model` in the interactive CLI to toggle models on/off per role, or e
 
 Defaults are hardcoded in `DEFAULT_MODEL_ROLES`. Roles accept any `provider/model-id` string or an array of strings. Only non-default values need to be specified; missing keys fall back to defaults.
 
-#### How model selection works
+#### How delegation works
 
-The orchestrator sees each role's model pool with tier and description. It picks the model whose description best matches the task:
+The orchestrator receives explicit per-phase directives generated from the role configuration. For each pipeline phase (plan, build, review, explore, research), the system prompt tells the orchestrator exactly what to do:
 
-- **Simple build chunk** (CRUD, parsers, CLI): picks standard-tier builder
-- **Complex build chunk** (concurrency, graph algorithms): picks the heaviest model whose description confirms correctness reasoning
-- **Code review**: picks the strongest reviewer by tier — fresh Agent context provides independence
-- **Exploration**: picks a light model for broad file reading, heavy for deep analysis
+- **Roles it owns** (its model ID appears in the role pool): "DO perform this work yourself."
+- **Roles it does not own**: "DO NOT perform this work yourself. Delegate to Agent(type: X, model: Y)." — with the concrete model IDs from the pool.
+- **Review is always delegated**, even when the orchestrator has the reviewer role, to ensure independence via a fresh context.
+
+When a role pool has multiple models, the orchestrator picks the lightest-tier model that fits the task and escalates to heavy-tier only for complex work (concurrency, algorithms) or as a retry after a standard-tier model has failed.
 
 Built-in models (kimchi-dev) have tier and description baked in. External models need metadata — see below.
 

--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ Use `/multi-model` in the interactive CLI to toggle models on/off per role, or e
 |------|---------|-------------|
 | **orchestrator** | `kimi-k2.6` | Runs the main loop, classifies tasks, delegates work. Single model. |
 | **planner** | `kimi-k2.6` | Designs the approach, writes specs. When same as orchestrator, planning is done in-process. |
-| **builder** | `minimax-m2.7` | Code implementation. For complex tasks the orchestrator may pick a heavier model from the pool. |
+| **builder** | `kimi-k2.6`, `minimax-m2.7` | Code implementation. For complex tasks the orchestrator may pick a heavier model from the pool. |
 | **reviewer** | `kimi-k2.6`, `minimax-m2.7` | Code review. Orchestrator picks the strongest by tier for initial review. |
 | **explorer** | `kimi-k2.6`, `nemotron-3-ultra-fp4` | Codebase exploration, research. Light models for broad scans, heavy for deep analysis. |
 

--- a/README.md
+++ b/README.md
@@ -138,6 +138,22 @@ Models without a built-in capability entry (e.g., Anthropic or OpenAI models) ca
 
 External models assigned without custom metadata still work — they default to `standard` tier with `vision: false`, and the orchestrator receives an auto-generated description noting the model was chosen by the user for its assigned roles.
 
+Metadata can also be managed interactively via `/multi-model` → "Edit model metadata". Custom overrides can be reset to defaults from the same menu. When switching to an unknown model, a wizard prompts for metadata configuration.
+
+Under the hood, metadata from inline objects is extracted and stored in the `modelMetadata` key of `settings.json`, separate from role assignments. The `modelMetadata` key can also be edited directly:
+
+```json
+{
+  "modelMetadata": {
+    "anthropic/claude-opus-4-6": {
+      "tier": "heavy",
+      "description": "Anthropic flagship — best for complex architectural planning.",
+      "vision": false
+    }
+  }
+}
+```
+
 ### Phase tracking
 
 Kimchi tags every LLM request with a `phase:{name}` label for usage analytics and cost attribution. The orchestrator sets the phase as work progresses and it is displayed in the footer.

--- a/README.md
+++ b/README.md
@@ -111,7 +111,7 @@ The orchestrator will use minimax for simple chunks and Claude for complex ones 
 
 #### Custom metadata for external models
 
-Models without a built-in capability entry (e.g., Anthropic or OpenAI models) can be annotated with custom metadata so the orchestrator sees their tier, roles, and description when making routing decisions. Provide an object instead of a plain string:
+Models without a built-in capability entry (e.g., Anthropic or OpenAI models) can be annotated with custom metadata so the orchestrator sees their tier, description, and vision support when making routing decisions. Provide an object instead of a plain string:
 
 ```json
 {

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -16,6 +16,7 @@ import { dispatchSubcommand } from "./commands/dispatch.js"
 // IMPORTANT: must be first local import — patches InteractiveMode.prototype
 // before any module can construct an InteractiveMode instance.
 import "./login-command-patch.js"
+import "./paste-to-editor-patch.js"
 import {
 	DEFAULT_SKILL_PATHS,
 	getActiveVendorSkillPaths,

--- a/src/extensions/agents/personas/types.ts
+++ b/src/extensions/agents/personas/types.ts
@@ -3,7 +3,8 @@
  */
 
 import type { AgentSession } from "@earendil-works/pi-coding-agent"
-import type { ModelRole, ModelTier } from "../../orchestration/model-registry/types.js"
+import type { ModelTier } from "../../orchestration/model-registry/types.js"
+import type { ModelRole } from "../../orchestration/model-roles.js"
 import type { LifetimeUsage } from "../manager/usage.js"
 
 /** Thinking/reasoning level for models that support it. */

--- a/src/extensions/ferment/judge.ts
+++ b/src/extensions/ferment/judge.ts
@@ -45,15 +45,7 @@ export async function judgeApiCall(systemPrompt: string, userMsg: string, maxTok
 	if (!registry) return { ok: false, reason: "no_registry" }
 
 	const judgeAssignment = getModelRoles().judge
-	let judgeModelStr: string | undefined
-	if (Array.isArray(judgeAssignment)) {
-		const first = judgeAssignment[0]
-		judgeModelStr = typeof first === "string" ? first : first?.model
-	} else if (typeof judgeAssignment === "string") {
-		judgeModelStr = judgeAssignment
-	} else {
-		judgeModelStr = judgeAssignment.model
-	}
+	const judgeModelStr = Array.isArray(judgeAssignment) ? judgeAssignment[0] : judgeAssignment
 	const judgeRef = judgeModelStr ? splitModelRef(judgeModelStr) : undefined
 	const model = (judgeRef ? registry.find(judgeRef.provider, judgeRef.modelId) : undefined) ?? getJudgeModel()
 	if (!model) return { ok: false, reason: "no_model" }

--- a/src/extensions/ferment/judge.ts
+++ b/src/extensions/ferment/judge.ts
@@ -45,7 +45,15 @@ export async function judgeApiCall(systemPrompt: string, userMsg: string, maxTok
 	if (!registry) return { ok: false, reason: "no_registry" }
 
 	const judgeAssignment = getModelRoles().judge
-	const judgeModelStr = Array.isArray(judgeAssignment) ? judgeAssignment[0] : judgeAssignment
+	let judgeModelStr: string | undefined
+	if (Array.isArray(judgeAssignment)) {
+		const first = judgeAssignment[0]
+		judgeModelStr = typeof first === "string" ? first : first?.model
+	} else if (typeof judgeAssignment === "string") {
+		judgeModelStr = judgeAssignment
+	} else {
+		judgeModelStr = judgeAssignment.model
+	}
 	const judgeRef = judgeModelStr ? splitModelRef(judgeModelStr) : undefined
 	const model = (judgeRef ? registry.find(judgeRef.provider, judgeRef.modelId) : undefined) ?? getJudgeModel()
 	if (!model) return { ok: false, reason: "no_model" }

--- a/src/extensions/model-switch.test.ts
+++ b/src/extensions/model-switch.test.ts
@@ -477,15 +477,22 @@ describe("modelSwitchExtension", () => {
 				getContextUsage: () => { tokens: number }
 				modelId: string
 				modelProvider: string
-				ui: { notify: (...args: unknown[]) => unknown }
+				hasUI: boolean
+				ui: {
+					notify: (...args: unknown[]) => unknown
+					select?: (...args: unknown[]) => unknown
+					input?: (...args: unknown[]) => unknown
+				}
 			}> = {},
 		) => {
 			const tokens = overrides.tokens ?? 10_000
+			const hasUI = overrides.hasUI ?? false
 			return {
 				model: { id: "kimi-k2.6", provider: "kimchi-dev", input: ["text", "image"] },
 				modelRegistry: { getAvailable: () => MODELS },
 				getContextUsage: () => ({ tokens }),
-				ui: { notify: vi.fn() },
+				hasUI,
+				ui: { notify: vi.fn(), select: vi.fn(), input: vi.fn(), ...overrides.ui },
 				...overrides,
 			} as unknown as never
 		}

--- a/src/extensions/model-switch.ts
+++ b/src/extensions/model-switch.ts
@@ -44,18 +44,18 @@ let isRevertingModel = false
 let sessionSkippedModels = new Set<string>()
 
 /** Models the user has permanently skipped the metadata wizard for. */
-let permanentlySkippedModels: Set<string> | undefined
+let sessionWideSkippedModels: Set<string> | undefined
 
-function getPermanentlySkippedModels(): Set<string> {
-	if (permanentlySkippedModels) return permanentlySkippedModels
+function getSessionWideSkippedModels(): Set<string> {
+	if (sessionWideSkippedModels) return sessionWideSkippedModels
 	// No persistent skip list yet — could be added to settings.json later
-	permanentlySkippedModels = new Set<string>()
-	return permanentlySkippedModels
+	sessionWideSkippedModels = new Set<string>()
+	return sessionWideSkippedModels
 }
 
 function shouldShowMetadataWizard(ref: string): boolean {
 	if (sessionSkippedModels.has(ref)) return false
-	if (getPermanentlySkippedModels().has(ref)) return false
+	if (getSessionWideSkippedModels().has(ref)) return false
 	return isModelMetadataMissing(ref)
 }
 
@@ -80,32 +80,39 @@ export function getModelTier(
 	return (caps as { tier: ModelTier }).tier
 }
 
-interface WizardUI {
-	ui: {
-		select(label: string, options: string[]): Promise<string | undefined>
-		input(label: string, defaultValue?: string): Promise<string | undefined>
-		notify(message: string, type: "info" | "warning" | "error"): void
-	}
+interface MetadataWizardUI {
+	select(label: string, options: string[]): Promise<string | undefined>
+	input(label: string, defaultValue?: string): Promise<string | undefined>
+	notify(message: string, type: "info" | "warning" | "error"): void
 }
 
-async function promptAndSaveMetadata(ref: string, ctx: WizardUI): Promise<void> {
-	const wizardChoice = await ctx.ui.select(
+function asWizardUI(ctx: { ui?: Partial<MetadataWizardUI> }): MetadataWizardUI | undefined {
+	const ui = ctx.ui
+	if (!ui) return undefined
+	if (typeof ui.select !== "function" || typeof ui.input !== "function" || typeof ui.notify !== "function") {
+		return undefined
+	}
+	return ui as MetadataWizardUI
+}
+
+async function promptAndSaveMetadata(ref: string, ui: MetadataWizardUI): Promise<void> {
+	const wizardChoice = await ui.select(
 		`${ref}\nThis model has no metadata (tier, description, vision).\nSpecifying metadata will improve orchestration.`,
-		["Configure now", "Skip this time", "Skip permanently"],
+		["Configure now", "Skip this time", "Skip for this session"],
 	)
 
 	if (wizardChoice === "Skip this time") {
 		sessionSkippedModels.add(ref)
 		return
 	}
-	if (wizardChoice === "Skip permanently") {
+	if (wizardChoice === "Skip for this session") {
 		sessionSkippedModels.add(ref)
-		getPermanentlySkippedModels().add(ref)
+		getSessionWideSkippedModels().add(ref)
 		return
 	}
 	if (wizardChoice !== "Configure now") return
 
-	const existing = resolveModelMetadata(ref) ?? undefined
+	const existing = resolveModelMetadata(ref)
 	const existingMeta: ModelCustomMetadata | undefined = existing
 		? { tier: existing.tier, description: existing.description, vision: existing.vision }
 		: undefined
@@ -116,7 +123,7 @@ async function promptAndSaveMetadata(ref: string, ctx: WizardUI): Promise<void> 
 	} else {
 		tierOptions.push("skip")
 	}
-	const tierChoice = await ctx.ui.select(
+	const tierChoice = await ui.select(
 		`${ref}\nSpecifying metadata will improve orchestration.\nTier - what capability level is this model?`,
 		tierOptions,
 	)
@@ -133,7 +140,7 @@ async function promptAndSaveMetadata(ref: string, ctx: WizardUI): Promise<void> 
 	} else {
 		visionOptions.push("skip")
 	}
-	const visionChoice = await ctx.ui.select(`${ref}\nVision support - can this model process images?`, visionOptions)
+	const visionChoice = await ui.select(`${ref}\nVision support - can this model process images?`, visionOptions)
 	if (!visionChoice) return
 	const vision = visionChoice.startsWith("keep current")
 		? existingMeta?.vision
@@ -142,7 +149,7 @@ async function promptAndSaveMetadata(ref: string, ctx: WizardUI): Promise<void> 
 			: visionChoice === "yes"
 
 	const descDefault = existingMeta?.description ?? ""
-	const descInput = await ctx.ui.input(`${ref}\nDescription - when should this model be used? (optional):`, descDefault)
+	const descInput = await ui.input(`${ref}\nDescription - when should this model be used? (optional):`, descDefault)
 	if (descInput === undefined) return
 	const description = descInput.trim() || existingMeta?.description || undefined
 
@@ -155,7 +162,7 @@ async function promptAndSaveMetadata(ref: string, ctx: WizardUI): Promise<void> 
 		const map = new Map<string, ModelCustomMetadata>()
 		map.set(ref, config)
 		saveModelMetadata(map)
-		ctx.ui.notify(`Metadata saved for ${ref}.`, "info")
+		ui.notify(`Metadata saved for ${ref}.`, "info")
 	}
 }
 
@@ -366,9 +373,12 @@ export default function modelSwitchExtension(pi: ExtensionAPI) {
 
 		// Metadata wizard for models without tier/description/vision
 		if (event.source === "set" && event.model && ctx.hasUI) {
-			const selectedRef = `${event.model.provider}/${event.model.id}`
-			if (shouldShowMetadataWizard(selectedRef)) {
-				await promptAndSaveMetadata(selectedRef, ctx as unknown as WizardUI)
+			const wizardUI = asWizardUI(ctx)
+			if (wizardUI) {
+				const selectedRef = `${event.model.provider}/${event.model.id}`
+				if (shouldShowMetadataWizard(selectedRef)) {
+					await promptAndSaveMetadata(selectedRef, wizardUI)
+				}
 			}
 		}
 	})

--- a/src/extensions/model-switch.ts
+++ b/src/extensions/model-switch.ts
@@ -9,6 +9,12 @@ import {
 	resolveContextTokens,
 	sessionHasImages,
 } from "./model-guard.js"
+import {
+	type ModelCustomMetadata,
+	isModelMetadataMissing,
+	resolveModelMetadata,
+	saveModelMetadata,
+} from "./orchestration/model-metadata.js"
 import { MODEL_CAPABILITIES } from "./orchestration/model-registry/builtin-models.js"
 import type { ModelTier } from "./orchestration/model-registry/types.js"
 import { splitModelRef } from "./orchestration/model-roles.js"
@@ -22,13 +28,42 @@ import {
 /** Prevents model_select handler from re-checking what set_model tool already validated. */
 let suppressModelSelectGuard = false
 
+/** Suppress the model_select guard and metadata wizard temporarily.
+ *  Used by /multi-model which handles its own metadata prompts. */
+export function withSuppressedModelSelectGuard<T>(fn: () => Promise<T>): Promise<T> {
+	suppressModelSelectGuard = true
+	return fn().finally(() => {
+		suppressModelSelectGuard = false
+	})
+}
+
 /** Recursion guard — true while our own revert is in progress. */
 let isRevertingModel = false
+
+/** Models the user has skipped the metadata wizard for this session. */
+let sessionSkippedModels = new Set<string>()
+
+/** Models the user has permanently skipped the metadata wizard for. */
+let permanentlySkippedModels: Set<string> | undefined
+
+function getPermanentlySkippedModels(): Set<string> {
+	if (permanentlySkippedModels) return permanentlySkippedModels
+	// No persistent skip list yet — could be added to settings.json later
+	permanentlySkippedModels = new Set<string>()
+	return permanentlySkippedModels
+}
+
+function shouldShowMetadataWizard(ref: string): boolean {
+	if (sessionSkippedModels.has(ref)) return false
+	if (getPermanentlySkippedModels().has(ref)) return false
+	return isModelMetadataMissing(ref)
+}
 
 /** Resets module state between tests. */
 export function __resetModelSwitchStateForTest(): void {
 	suppressModelSelectGuard = false
 	isRevertingModel = false
+	sessionSkippedModels = new Set<string>()
 }
 
 /**
@@ -43,6 +78,85 @@ export function getModelTier(
 	const caps = capsMap.get(model.id)
 	if (!caps || caps === "ignored") return undefined
 	return (caps as { tier: ModelTier }).tier
+}
+
+interface WizardUI {
+	ui: {
+		select(label: string, options: string[]): Promise<string | undefined>
+		input(label: string, defaultValue?: string): Promise<string | undefined>
+		notify(message: string, type: "info" | "warning" | "error"): void
+	}
+}
+
+async function promptAndSaveMetadata(ref: string, ctx: WizardUI): Promise<void> {
+	const wizardChoice = await ctx.ui.select(
+		`${ref}\nThis model has no metadata (tier, description, vision).\nSpecifying metadata will improve orchestration.`,
+		["Configure now", "Skip this time", "Skip permanently"],
+	)
+
+	if (wizardChoice === "Skip this time") {
+		sessionSkippedModels.add(ref)
+		return
+	}
+	if (wizardChoice === "Skip permanently") {
+		sessionSkippedModels.add(ref)
+		getPermanentlySkippedModels().add(ref)
+		return
+	}
+	if (wizardChoice !== "Configure now") return
+
+	const existing = resolveModelMetadata(ref) ?? undefined
+	const existingMeta: ModelCustomMetadata | undefined = existing
+		? { tier: existing.tier, description: existing.description, vision: existing.vision }
+		: undefined
+
+	const tierOptions = ["heavy", "standard", "light"]
+	if (existingMeta?.tier) {
+		tierOptions.push(`keep current (${existingMeta.tier})`)
+	} else {
+		tierOptions.push("skip")
+	}
+	const tierChoice = await ctx.ui.select(
+		`${ref}\nSpecifying metadata will improve orchestration.\nTier - what capability level is this model?`,
+		tierOptions,
+	)
+	if (!tierChoice) return
+	const tier = tierChoice.startsWith("keep current")
+		? existingMeta?.tier
+		: tierChoice === "skip"
+			? undefined
+			: (tierChoice as ModelTier)
+
+	const visionOptions = ["yes", "no"]
+	if (existingMeta?.vision !== undefined) {
+		visionOptions.push(`keep current (${existingMeta.vision ? "yes" : "no"})`)
+	} else {
+		visionOptions.push("skip")
+	}
+	const visionChoice = await ctx.ui.select(`${ref}\nVision support - can this model process images?`, visionOptions)
+	if (!visionChoice) return
+	const vision = visionChoice.startsWith("keep current")
+		? existingMeta?.vision
+		: visionChoice === "skip"
+			? undefined
+			: visionChoice === "yes"
+
+	const descDefault = existingMeta?.description ?? ""
+	const descInput = await ctx.ui.input(`${ref}\nDescription - when should this model be used? (optional):`, descDefault)
+	if (descInput === undefined) return
+	const description = descInput.trim() || existingMeta?.description || undefined
+
+	const config: ModelCustomMetadata = {}
+	if (tier !== undefined) config.tier = tier
+	if (vision !== undefined) config.vision = vision
+	if (description !== undefined) config.description = description
+
+	if (Object.keys(config).length > 0) {
+		const map = new Map<string, ModelCustomMetadata>()
+		map.set(ref, config)
+		saveModelMetadata(map)
+		ctx.ui.notify(`Metadata saved for ${ref}.`, "info")
+	}
 }
 
 export default function modelSwitchExtension(pi: ExtensionAPI) {
@@ -247,6 +361,14 @@ export default function modelSwitchExtension(pi: ExtensionAPI) {
 			const selectedRef = `${event.model.provider}/${event.model.id}`
 			if (selectedRef !== orchRef) {
 				setMultiModelEnabled(false)
+			}
+		}
+
+		// Metadata wizard for models without tier/description/vision
+		if (event.source === "set" && event.model && ctx.hasUI) {
+			const selectedRef = `${event.model.provider}/${event.model.id}`
+			if (shouldShowMetadataWizard(selectedRef)) {
+				await promptAndSaveMetadata(selectedRef, ctx as unknown as WizardUI)
 			}
 		}
 	})

--- a/src/extensions/orchestration/model-metadata.test.ts
+++ b/src/extensions/orchestration/model-metadata.test.ts
@@ -430,8 +430,8 @@ describe("resolveModelMetadata", () => {
 		expect(result).toEqual(expect.objectContaining({ source: "builtin", tier: "standard", vision: false }))
 	})
 
-	it("returns builtin for nemotron-3-super-fp4", () => {
-		const result = resolveModelMetadata("kimchi-dev/nemotron-3-super-fp4", testPath)
+	it("returns builtin for nemotron-3-ultra-fp4", () => {
+		const result = resolveModelMetadata("kimchi-dev/nemotron-3-ultra-fp4", testPath)
 		expect(result).toEqual(expect.objectContaining({ source: "builtin", tier: "light" }))
 	})
 })

--- a/src/extensions/orchestration/model-metadata.test.ts
+++ b/src/extensions/orchestration/model-metadata.test.ts
@@ -254,20 +254,26 @@ describe("saveModelMetadata", () => {
 })
 
 describe("resolveModelMetadata", () => {
+	const testDir = join(tmpdir(), `kimchi-model-metadata-test-${process.pid}`)
+	const testPath = join(testDir, "settings.json")
+
+	afterEach(() => {
+		try {
+			rmSync(testDir, { recursive: true, force: true })
+		} catch {}
+	})
+
 	it("returns builtin for known model (e.g. kimchi-dev/kimi-k2.6)", () => {
-		const result = resolveModelMetadata("kimchi-dev/kimi-k2.6")
+		const result = resolveModelMetadata("kimchi-dev/kimi-k2.6", testPath)
 		expect(result).toEqual(expect.objectContaining({ source: "builtin", tier: "heavy", vision: true }))
 	})
 
 	it("returns builtin for known model without provider prefix", () => {
-		const result = resolveModelMetadata("kimi-k2.6")
+		const result = resolveModelMetadata("kimi-k2.6", testPath)
 		expect(result).toEqual(expect.objectContaining({ source: "builtin", tier: "heavy" }))
 	})
 
 	it("returns custom for model in settings", () => {
-		const testDir = join(tmpdir(), `kimchi-model-metadata-test-${process.pid}`)
-		const testPath = join(testDir, "settings.json")
-
 		mkdirSync(testDir, { recursive: true })
 		writeFileSync(
 			testPath,
@@ -296,21 +302,14 @@ describe("resolveModelMetadata", () => {
 			description: "My custom model",
 			vision: false,
 		})
-
-		try {
-			rmSync(testDir, { recursive: true, force: true })
-		} catch {}
 	})
 
 	it("returns undefined for unknown model with no custom metadata", () => {
-		const result = resolveModelMetadata("unknown/provider-model")
+		const result = resolveModelMetadata("unknown/provider-model", testPath)
 		expect(result).toBeUndefined()
 	})
 
 	it("prefers custom over builtin when both exist", () => {
-		const testDir = join(tmpdir(), `kimchi-model-metadata-test-${process.pid}`)
-		const testPath = join(testDir, "settings.json")
-
 		mkdirSync(testDir, { recursive: true })
 		writeFileSync(
 			testPath,
@@ -327,37 +326,39 @@ describe("resolveModelMetadata", () => {
 
 		const result = resolveModelMetadata("kimchi-dev/kimi-k2.6", testPath)
 		expect(result).toEqual(expect.objectContaining({ source: "custom", tier: "light", description: "Custom override" }))
-
-		try {
-			rmSync(testDir, { recursive: true, force: true })
-		} catch {}
 	})
 
 	it("returns builtin for minimax-m2.7", () => {
-		const result = resolveModelMetadata("kimchi-dev/minimax-m2.7")
+		const result = resolveModelMetadata("kimchi-dev/minimax-m2.7", testPath)
 		expect(result).toEqual(expect.objectContaining({ source: "builtin", tier: "standard", vision: false }))
 	})
 
 	it("returns builtin for nemotron-3-super-fp4", () => {
-		const result = resolveModelMetadata("kimchi-dev/nemotron-3-super-fp4")
+		const result = resolveModelMetadata("kimchi-dev/nemotron-3-super-fp4", testPath)
 		expect(result).toEqual(expect.objectContaining({ source: "builtin", tier: "light" }))
 	})
 })
 
 describe("isModelMetadataMissing", () => {
+	const testDir = join(tmpdir(), `kimchi-model-metadata-test-${process.pid}`)
+	const testPath = join(testDir, "settings.json")
+
+	afterEach(() => {
+		try {
+			rmSync(testDir, { recursive: true, force: true })
+		} catch {}
+	})
+
 	it("returns false for known builtin model", () => {
-		expect(isModelMetadataMissing("kimchi-dev/kimi-k2.6")).toBe(false)
-		expect(isModelMetadataMissing("kimchi-dev/minimax-m2.7")).toBe(false)
+		expect(isModelMetadataMissing("kimchi-dev/kimi-k2.6", testPath)).toBe(false)
+		expect(isModelMetadataMissing("kimchi-dev/minimax-m2.7", testPath)).toBe(false)
 	})
 
 	it("returns true for completely unknown model with no custom metadata", () => {
-		expect(isModelMetadataMissing("completely/unknown-model-xyz")).toBe(true)
+		expect(isModelMetadataMissing("completely/unknown-model-xyz", testPath)).toBe(true)
 	})
 
 	it("returns false when custom metadata exists for a model", () => {
-		const testDir = join(tmpdir(), `kimchi-model-metadata-test-${process.pid}`)
-		const testPath = join(testDir, "settings.json")
-
 		mkdirSync(testDir, { recursive: true })
 		writeFileSync(
 			testPath,
@@ -372,13 +373,8 @@ describe("isModelMetadataMissing", () => {
 			),
 		)
 
-		// Populate cache from the test path
 		getModelMetadata(testPath)
 		expect(isModelMetadataMissing("custom/my-model", testPath)).toBe(false)
-
-		try {
-			rmSync(testDir, { recursive: true, force: true })
-		} catch {}
 	})
 })
 

--- a/src/extensions/orchestration/model-metadata.test.ts
+++ b/src/extensions/orchestration/model-metadata.test.ts
@@ -4,6 +4,7 @@ import { join } from "node:path"
 import { afterEach, describe, expect, it } from "vitest"
 import {
 	type ModelCustomMetadata,
+	deleteModelMetadata,
 	getModelMetadata,
 	getModelMetadataWarnings,
 	isModelMetadataMissing,
@@ -250,6 +251,102 @@ describe("saveModelMetadata", () => {
 		const saved = JSON.parse(readFileSync(testPath, "utf-8"))
 		expect(saved.modelMetadata["model/a"]).toEqual({ tier: "heavy", description: "Updated" })
 		expect(saved.modelMetadata["model/b"]).toEqual({ tier: "standard" })
+	})
+})
+
+describe("deleteModelMetadata", () => {
+	const testDir = join(tmpdir(), `kimchi-model-metadata-test-${process.pid}`)
+	const testPath = join(testDir, "settings.json")
+
+	afterEach(() => {
+		try {
+			rmSync(testDir, { recursive: true, force: true })
+		} catch {}
+	})
+
+	it("removes a single model entry", () => {
+		mkdirSync(testDir, { recursive: true })
+		writeFileSync(
+			testPath,
+			JSON.stringify({
+				modelMetadata: {
+					"custom/model-a": { tier: "heavy" },
+					"custom/model-b": { tier: "light" },
+				},
+			}),
+		)
+
+		deleteModelMetadata("custom/model-a", testPath)
+
+		const saved = JSON.parse(readFileSync(testPath, "utf-8"))
+		expect(saved.modelMetadata["custom/model-a"]).toBeUndefined()
+		expect(saved.modelMetadata["custom/model-b"]).toEqual({ tier: "light" })
+	})
+
+	it("removes modelMetadata key when last entry is deleted", () => {
+		mkdirSync(testDir, { recursive: true })
+		writeFileSync(
+			testPath,
+			JSON.stringify({
+				otherSetting: true,
+				modelMetadata: { "custom/only-model": { tier: "standard" } },
+			}),
+		)
+
+		deleteModelMetadata("custom/only-model", testPath)
+
+		const saved = JSON.parse(readFileSync(testPath, "utf-8"))
+		expect(saved.modelMetadata).toBeUndefined()
+		expect(saved.otherSetting).toBe(true)
+	})
+
+	it("is a no-op when model ref does not exist", () => {
+		mkdirSync(testDir, { recursive: true })
+		writeFileSync(
+			testPath,
+			JSON.stringify({
+				modelMetadata: { "custom/model": { tier: "heavy" } },
+			}),
+		)
+
+		deleteModelMetadata("custom/nonexistent", testPath)
+
+		const saved = JSON.parse(readFileSync(testPath, "utf-8"))
+		expect(saved.modelMetadata["custom/model"]).toEqual({ tier: "heavy" })
+	})
+
+	it("is a no-op when settings file does not exist", () => {
+		deleteModelMetadata("custom/model", testPath)
+		expect(existsSync(testPath)).toBe(false)
+	})
+
+	it("is a no-op when modelMetadata key is absent", () => {
+		mkdirSync(testDir, { recursive: true })
+		writeFileSync(testPath, JSON.stringify({ otherSetting: true }))
+
+		deleteModelMetadata("custom/model", testPath)
+
+		const saved = JSON.parse(readFileSync(testPath, "utf-8"))
+		expect(saved.modelMetadata).toBeUndefined()
+		expect(saved.otherSetting).toBe(true)
+	})
+
+	it("invalidates the metadata cache", () => {
+		mkdirSync(testDir, { recursive: true })
+		writeFileSync(
+			testPath,
+			JSON.stringify({
+				modelMetadata: { "custom/model": { tier: "heavy" } },
+			}),
+		)
+
+		const before = getModelMetadata(testPath)
+		expect(before.get("custom/model")).toEqual({ tier: "heavy" })
+
+		deleteModelMetadata("custom/model", testPath)
+
+		const after = getModelMetadata(testPath)
+		expect(after.has("custom/model")).toBe(false)
 	})
 })
 

--- a/src/extensions/orchestration/model-metadata.test.ts
+++ b/src/extensions/orchestration/model-metadata.test.ts
@@ -30,7 +30,8 @@ describe("loadModelMetadata", () => {
 
 	it("returns empty map when settings file absent", () => {
 		const result = loadModelMetadata(testPath)
-		expect(result.size).toBe(0)
+		expect(result.metadata.size).toBe(0)
+		expect(result.warnings).toEqual([])
 	})
 
 	it("reads metadata from settings.json", () => {
@@ -50,13 +51,14 @@ describe("loadModelMetadata", () => {
 		)
 
 		const result = loadModelMetadata(testPath)
-		expect(result.size).toBe(2)
-		expect(result.get("custom/model-1")).toEqual({
+		expect(result.metadata.size).toBe(2)
+		expect(result.metadata.get("custom/model-1")).toEqual({
 			tier: "heavy",
 			description: "A heavy model",
 			vision: true,
 		})
-		expect(result.get("custom/model-2")).toEqual({ tier: "light" })
+		expect(result.metadata.get("custom/model-2")).toEqual({ tier: "light" })
+		expect(result.warnings).toEqual([])
 	})
 
 	it("ignores entries with no valid fields", () => {
@@ -78,11 +80,11 @@ describe("loadModelMetadata", () => {
 		)
 
 		const result = loadModelMetadata(testPath)
-		expect(result.size).toBe(1)
-		expect(result.has("valid/model")).toBe(true)
-		expect(result.has("empty/model")).toBe(false)
-		expect(result.has("invalid/model")).toBe(false)
-		expect(result.has("null/model")).toBe(false)
+		expect(result.metadata.size).toBe(1)
+		expect(result.metadata.has("valid/model")).toBe(true)
+		expect(result.metadata.has("empty/model")).toBe(false)
+		expect(result.metadata.has("invalid/model")).toBe(false)
+		expect(result.metadata.has("null/model")).toBe(false)
 	})
 
 	it("ignores non-object modelMetadata value", () => {
@@ -90,7 +92,7 @@ describe("loadModelMetadata", () => {
 		writeFileSync(testPath, JSON.stringify({ modelMetadata: "not an object" }, null, 2))
 
 		const result = loadModelMetadata(testPath)
-		expect(result.size).toBe(0)
+		expect(result.metadata.size).toBe(0)
 	})
 
 	it("ignores array modelMetadata value", () => {
@@ -98,7 +100,7 @@ describe("loadModelMetadata", () => {
 		writeFileSync(testPath, JSON.stringify({ modelMetadata: [] }, null, 2))
 
 		const result = loadModelMetadata(testPath)
-		expect(result.size).toBe(0)
+		expect(result.metadata.size).toBe(0)
 	})
 
 	it("trims whitespace from ref keys", () => {
@@ -118,10 +120,10 @@ describe("loadModelMetadata", () => {
 		)
 
 		const result = loadModelMetadata(testPath)
-		expect(result.get("custom/model-1")).toEqual({ tier: "heavy" })
+		expect(result.metadata.get("custom/model-1")).toEqual({ tier: "heavy" })
 		// Note: whitespace trimming happens on the key itself, not the value
 		// So "  custom/model-1  " becomes "custom/model-1" (trims leading/trailing)
-		expect(result.has("  custom/model-1  ")).toBe(false)
+		expect(result.metadata.has("  custom/model-1  ")).toBe(false)
 	})
 
 	it("validates tier values strictly", () => {
@@ -141,8 +143,54 @@ describe("loadModelMetadata", () => {
 		)
 
 		const result = loadModelMetadata(testPath)
-		expect(result.get("valid/model")?.tier).toBe("standard")
-		expect(result.get("invalid/tier")?.tier).toBeUndefined()
+		expect(result.metadata.get("valid/model")?.tier).toBe("standard")
+		// Invalid tier now drops the entire entry (and surfaces a warning),
+		// rather than silently dropping just the tier field. Either way the
+		// resolved tier is undefined — the contract tests assert.
+		expect(result.metadata.get("invalid/tier")?.tier).toBeUndefined()
+	})
+
+	it("emits warnings for entries that fail TypeBox validation", () => {
+		mkdirSync(testDir, { recursive: true })
+		writeFileSync(
+			testPath,
+			JSON.stringify(
+				{
+					modelMetadata: {
+						"bad/tier": { tier: "not-a-tier" },
+						"bad/description": { description: 123 },
+						"bad/vision": { vision: "yes" },
+					},
+				},
+				null,
+				2,
+			),
+		)
+
+		const result = loadModelMetadata(testPath)
+		expect(result.metadata.size).toBe(0)
+		const refs = result.warnings.map((w) => w.ref).sort()
+		expect(refs).toEqual(["bad/description", "bad/tier", "bad/vision"])
+		for (const w of result.warnings) {
+			expect(w.message).toMatch(/entry failed validation/)
+		}
+	})
+
+	it("does not warn for null/non-object entries (cannot arise from well-behaved callers)", () => {
+		mkdirSync(testDir, { recursive: true })
+		writeFileSync(
+			testPath,
+			JSON.stringify({
+				modelMetadata: {
+					"null/model": null,
+					"string/model": "not-an-object",
+					"array/model": [],
+				},
+			}),
+		)
+
+		const result = loadModelMetadata(testPath)
+		expect(result.warnings).toEqual([])
 	})
 })
 
@@ -386,7 +434,7 @@ describe("resolveModelMetadata", () => {
 		)
 
 		const loaded = loadModelMetadata(testPath)
-		expect(loaded.get("custom/my-model")).toEqual({
+		expect(loaded.metadata.get("custom/my-model")).toEqual({
 			tier: "standard",
 			description: "My custom model",
 			vision: false,
@@ -597,11 +645,11 @@ describe("Integration: saveModelMetadata and loadModelMetadata round-trip", () =
 		saveModelMetadata(original, testPath)
 		const loaded = loadModelMetadata(testPath)
 
-		expect(loaded.size).toBe(4)
-		expect(loaded.get("custom/model-1")).toEqual({ tier: "heavy", description: "Heavy model", vision: true })
-		expect(loaded.get("custom/model-2")).toEqual({ tier: "light" })
-		expect(loaded.get("custom/model-3")).toEqual({ description: "Description only" })
-		expect(loaded.get("custom/model-4")).toEqual({ vision: false })
+		expect(loaded.metadata.size).toBe(4)
+		expect(loaded.metadata.get("custom/model-1")).toEqual({ tier: "heavy", description: "Heavy model", vision: true })
+		expect(loaded.metadata.get("custom/model-2")).toEqual({ tier: "light" })
+		expect(loaded.metadata.get("custom/model-3")).toEqual({ description: "Description only" })
+		expect(loaded.metadata.get("custom/model-4")).toEqual({ vision: false })
 	})
 
 	it("empty map removes modelMetadata from settings", () => {

--- a/src/extensions/orchestration/model-metadata.test.ts
+++ b/src/extensions/orchestration/model-metadata.test.ts
@@ -1,0 +1,524 @@
+import { existsSync, mkdirSync, readFileSync, rmSync, writeFileSync } from "node:fs"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
+import { afterEach, describe, expect, it } from "vitest"
+import {
+	type ModelCustomMetadata,
+	getModelMetadata,
+	getModelMetadataWarnings,
+	isModelMetadataMissing,
+	loadModelMetadata,
+	resetModelMetadataCache,
+	resolveModelMetadata,
+	saveModelMetadata,
+} from "./model-metadata.js"
+
+afterEach(() => {
+	resetModelMetadataCache()
+})
+
+describe("loadModelMetadata", () => {
+	const testDir = join(tmpdir(), `kimchi-model-metadata-test-${process.pid}`)
+	const testPath = join(testDir, "settings.json")
+
+	afterEach(() => {
+		try {
+			rmSync(testDir, { recursive: true, force: true })
+		} catch {}
+	})
+
+	it("returns empty map when settings file absent", () => {
+		const result = loadModelMetadata(testPath)
+		expect(result.size).toBe(0)
+	})
+
+	it("reads metadata from settings.json", () => {
+		mkdirSync(testDir, { recursive: true })
+		writeFileSync(
+			testPath,
+			JSON.stringify(
+				{
+					modelMetadata: {
+						"custom/model-1": { tier: "heavy", description: "A heavy model", vision: true },
+						"custom/model-2": { tier: "light" },
+					},
+				},
+				null,
+				2,
+			),
+		)
+
+		const result = loadModelMetadata(testPath)
+		expect(result.size).toBe(2)
+		expect(result.get("custom/model-1")).toEqual({
+			tier: "heavy",
+			description: "A heavy model",
+			vision: true,
+		})
+		expect(result.get("custom/model-2")).toEqual({ tier: "light" })
+	})
+
+	it("ignores entries with no valid fields", () => {
+		mkdirSync(testDir, { recursive: true })
+		writeFileSync(
+			testPath,
+			JSON.stringify(
+				{
+					modelMetadata: {
+						"valid/model": { tier: "standard" },
+						"empty/model": {},
+						"invalid/model": { unknownField: "test" },
+						"null/model": null,
+					},
+				},
+				null,
+				2,
+			),
+		)
+
+		const result = loadModelMetadata(testPath)
+		expect(result.size).toBe(1)
+		expect(result.has("valid/model")).toBe(true)
+		expect(result.has("empty/model")).toBe(false)
+		expect(result.has("invalid/model")).toBe(false)
+		expect(result.has("null/model")).toBe(false)
+	})
+
+	it("ignores non-object modelMetadata value", () => {
+		mkdirSync(testDir, { recursive: true })
+		writeFileSync(testPath, JSON.stringify({ modelMetadata: "not an object" }, null, 2))
+
+		const result = loadModelMetadata(testPath)
+		expect(result.size).toBe(0)
+	})
+
+	it("ignores array modelMetadata value", () => {
+		mkdirSync(testDir, { recursive: true })
+		writeFileSync(testPath, JSON.stringify({ modelMetadata: [] }, null, 2))
+
+		const result = loadModelMetadata(testPath)
+		expect(result.size).toBe(0)
+	})
+
+	it("trims whitespace from ref keys", () => {
+		mkdirSync(testDir, { recursive: true })
+		writeFileSync(
+			testPath,
+			JSON.stringify(
+				{
+					modelMetadata: {
+						"  custom/model-1  ": { tier: "heavy" },
+						"custom/model-2": { tier: "light" },
+					},
+				},
+				null,
+				2,
+			),
+		)
+
+		const result = loadModelMetadata(testPath)
+		expect(result.get("custom/model-1")).toEqual({ tier: "heavy" })
+		// Note: whitespace trimming happens on the key itself, not the value
+		// So "  custom/model-1  " becomes "custom/model-1" (trims leading/trailing)
+		expect(result.has("  custom/model-1  ")).toBe(false)
+	})
+
+	it("validates tier values strictly", () => {
+		mkdirSync(testDir, { recursive: true })
+		writeFileSync(
+			testPath,
+			JSON.stringify(
+				{
+					modelMetadata: {
+						"valid/model": { tier: "standard" },
+						"invalid/tier": { tier: "not-a-tier" },
+					},
+				},
+				null,
+				2,
+			),
+		)
+
+		const result = loadModelMetadata(testPath)
+		expect(result.get("valid/model")?.tier).toBe("standard")
+		expect(result.get("invalid/tier")?.tier).toBeUndefined()
+	})
+})
+
+describe("saveModelMetadata", () => {
+	const testDir = join(tmpdir(), `kimchi-model-metadata-test-${process.pid}`)
+	const testPath = join(testDir, "settings.json")
+
+	afterEach(() => {
+		try {
+			rmSync(testDir, { recursive: true, force: true })
+		} catch {}
+	})
+
+	it("creates file and directory if absent", () => {
+		const metadata = new Map<string, ModelCustomMetadata>([["custom/model", { tier: "heavy" }]])
+		saveModelMetadata(metadata, testPath)
+		expect(existsSync(testPath)).toBe(true)
+	})
+
+	it("writes to modelMetadata key", () => {
+		const metadata = new Map<string, ModelCustomMetadata>([
+			["custom/model", { tier: "heavy", description: "Test model", vision: true }],
+		])
+		saveModelMetadata(metadata, testPath)
+
+		const saved = JSON.parse(readFileSync(testPath, "utf-8"))
+		expect(saved.modelMetadata).toBeDefined()
+		expect(saved.modelMetadata["custom/model"]).toEqual({
+			tier: "heavy",
+			description: "Test model",
+			vision: true,
+		})
+	})
+
+	it("removes modelMetadata key when map is empty", () => {
+		// First save some data
+		const metadata = new Map<string, ModelCustomMetadata>([["custom/model", { tier: "heavy" }]])
+		saveModelMetadata(metadata, testPath)
+		expect(existsSync(testPath)).toBe(true)
+
+		// Then save empty map
+		saveModelMetadata(new Map(), testPath)
+
+		const saved = JSON.parse(readFileSync(testPath, "utf-8"))
+		expect(saved.modelMetadata).toBeUndefined()
+	})
+
+	it("preserves other settings in the file", () => {
+		mkdirSync(testDir, { recursive: true })
+		writeFileSync(testPath, JSON.stringify({ multiModel: true, theme: "dark", otherSetting: 42 }, null, 2))
+
+		const metadata = new Map<string, ModelCustomMetadata>([["custom/model", { tier: "heavy", description: "Test" }]])
+		saveModelMetadata(metadata, testPath)
+
+		const saved = JSON.parse(readFileSync(testPath, "utf-8"))
+		expect(saved.multiModel).toBe(true)
+		expect(saved.theme).toBe("dark")
+		expect(saved.otherSetting).toBe(42)
+		expect(saved.modelMetadata["custom/model"]).toEqual({ tier: "heavy", description: "Test" })
+	})
+
+	it("merges new metadata with existing modelMetadata", () => {
+		mkdirSync(testDir, { recursive: true })
+		writeFileSync(
+			testPath,
+			JSON.stringify(
+				{
+					modelMetadata: {
+						"old/model": { tier: "light" },
+						"another/old": { description: "Old description" },
+					},
+				},
+				null,
+				2,
+			),
+		)
+
+		const metadata = new Map<string, ModelCustomMetadata>([["new/model", { tier: "heavy" }]])
+		saveModelMetadata(metadata, testPath)
+
+		const saved = JSON.parse(readFileSync(testPath, "utf-8"))
+		expect(saved.modelMetadata["old/model"]).toEqual({ tier: "light" })
+		expect(saved.modelMetadata["another/old"]).toEqual({ description: "Old description" })
+		expect(saved.modelMetadata["new/model"]).toEqual({ tier: "heavy" })
+	})
+
+	it("overwriting a model updates it while keeping others", () => {
+		mkdirSync(testDir, { recursive: true })
+		writeFileSync(
+			testPath,
+			JSON.stringify(
+				{
+					modelMetadata: {
+						"model/a": { tier: "light" },
+						"model/b": { tier: "standard" },
+					},
+				},
+				null,
+				2,
+			),
+		)
+
+		const metadata = new Map<string, ModelCustomMetadata>([["model/a", { tier: "heavy", description: "Updated" }]])
+		saveModelMetadata(metadata, testPath)
+
+		const saved = JSON.parse(readFileSync(testPath, "utf-8"))
+		expect(saved.modelMetadata["model/a"]).toEqual({ tier: "heavy", description: "Updated" })
+		expect(saved.modelMetadata["model/b"]).toEqual({ tier: "standard" })
+	})
+})
+
+describe("resolveModelMetadata", () => {
+	it("returns builtin for known model (e.g. kimchi-dev/kimi-k2.6)", () => {
+		const result = resolveModelMetadata("kimchi-dev/kimi-k2.6")
+		expect(result).toEqual(expect.objectContaining({ source: "builtin", tier: "heavy", vision: true }))
+	})
+
+	it("returns builtin for known model without provider prefix", () => {
+		const result = resolveModelMetadata("kimi-k2.6")
+		expect(result).toEqual(expect.objectContaining({ source: "builtin", tier: "heavy" }))
+	})
+
+	it("returns custom for model in settings", () => {
+		const testDir = join(tmpdir(), `kimchi-model-metadata-test-${process.pid}`)
+		const testPath = join(testDir, "settings.json")
+
+		mkdirSync(testDir, { recursive: true })
+		writeFileSync(
+			testPath,
+			JSON.stringify(
+				{
+					modelMetadata: {
+						"custom/my-model": { tier: "standard", description: "My custom model", vision: false },
+					},
+				},
+				null,
+				2,
+			),
+		)
+
+		const loaded = loadModelMetadata(testPath)
+		expect(loaded.get("custom/my-model")).toEqual({
+			tier: "standard",
+			description: "My custom model",
+			vision: false,
+		})
+
+		const result = resolveModelMetadata("custom/my-model", testPath)
+		expect(result).toEqual({
+			source: "custom",
+			tier: "standard",
+			description: "My custom model",
+			vision: false,
+		})
+
+		try {
+			rmSync(testDir, { recursive: true, force: true })
+		} catch {}
+	})
+
+	it("returns undefined for unknown model with no custom metadata", () => {
+		const result = resolveModelMetadata("unknown/provider-model")
+		expect(result).toBeUndefined()
+	})
+
+	it("prefers custom over builtin when both exist", () => {
+		const testDir = join(tmpdir(), `kimchi-model-metadata-test-${process.pid}`)
+		const testPath = join(testDir, "settings.json")
+
+		mkdirSync(testDir, { recursive: true })
+		writeFileSync(
+			testPath,
+			JSON.stringify(
+				{
+					modelMetadata: {
+						"kimchi-dev/kimi-k2.6": { tier: "light", description: "Custom override" },
+					},
+				},
+				null,
+				2,
+			),
+		)
+
+		const result = resolveModelMetadata("kimchi-dev/kimi-k2.6", testPath)
+		expect(result).toEqual(expect.objectContaining({ source: "custom", tier: "light", description: "Custom override" }))
+
+		try {
+			rmSync(testDir, { recursive: true, force: true })
+		} catch {}
+	})
+
+	it("returns builtin for minimax-m2.7", () => {
+		const result = resolveModelMetadata("kimchi-dev/minimax-m2.7")
+		expect(result).toEqual(expect.objectContaining({ source: "builtin", tier: "standard", vision: false }))
+	})
+
+	it("returns builtin for nemotron-3-super-fp4", () => {
+		const result = resolveModelMetadata("kimchi-dev/nemotron-3-super-fp4")
+		expect(result).toEqual(expect.objectContaining({ source: "builtin", tier: "light" }))
+	})
+})
+
+describe("isModelMetadataMissing", () => {
+	it("returns false for known builtin model", () => {
+		expect(isModelMetadataMissing("kimchi-dev/kimi-k2.6")).toBe(false)
+		expect(isModelMetadataMissing("kimchi-dev/minimax-m2.7")).toBe(false)
+	})
+
+	it("returns true for completely unknown model with no custom metadata", () => {
+		expect(isModelMetadataMissing("completely/unknown-model-xyz")).toBe(true)
+	})
+
+	it("returns false when custom metadata exists for a model", () => {
+		const testDir = join(tmpdir(), `kimchi-model-metadata-test-${process.pid}`)
+		const testPath = join(testDir, "settings.json")
+
+		mkdirSync(testDir, { recursive: true })
+		writeFileSync(
+			testPath,
+			JSON.stringify(
+				{
+					modelMetadata: {
+						"custom/my-model": { tier: "standard" },
+					},
+				},
+				null,
+				2,
+			),
+		)
+
+		// Populate cache from the test path
+		getModelMetadata(testPath)
+		expect(isModelMetadataMissing("custom/my-model", testPath)).toBe(false)
+
+		try {
+			rmSync(testDir, { recursive: true, force: true })
+		} catch {}
+	})
+})
+
+describe("Cache functions", () => {
+	const testDir = join(tmpdir(), `kimchi-model-metadata-test-${process.pid}`)
+	const testPath = join(testDir, "settings.json")
+
+	afterEach(() => {
+		resetModelMetadataCache()
+		try {
+			rmSync(testDir, { recursive: true, force: true })
+		} catch {}
+	})
+
+	it("getModelMetadata returns cached data", () => {
+		mkdirSync(testDir, { recursive: true })
+		writeFileSync(
+			testPath,
+			JSON.stringify(
+				{
+					modelMetadata: {
+						"cached/model": { tier: "heavy" },
+					},
+				},
+				null,
+				2,
+			),
+		)
+
+		// First call loads from disk at the test path
+		const first = getModelMetadata(testPath)
+		expect(first.get("cached/model")).toEqual({ tier: "heavy" })
+
+		// Modify the file on disk
+		writeFileSync(
+			testPath,
+			JSON.stringify(
+				{
+					modelMetadata: {
+						"cached/model": { tier: "light" },
+						"new/model": { tier: "standard" },
+					},
+				},
+				null,
+				2,
+			),
+		)
+
+		// Second call with same path should return cached data, not the new file content
+		const second = getModelMetadata(testPath)
+		expect(second.get("cached/model")).toEqual({ tier: "heavy" })
+		expect(second.has("new/model")).toBe(false)
+	})
+
+	it("resetModelMetadataCache clears the cache", () => {
+		mkdirSync(testDir, { recursive: true })
+		writeFileSync(
+			testPath,
+			JSON.stringify(
+				{
+					modelMetadata: {
+						"test/model": { tier: "heavy" },
+					},
+				},
+				null,
+				2,
+			),
+		)
+
+		// Load and cache
+		const first = getModelMetadata(testPath)
+		expect(first.get("test/model")).toEqual({ tier: "heavy" })
+
+		// Modify file
+		writeFileSync(
+			testPath,
+			JSON.stringify(
+				{
+					modelMetadata: {
+						"test/model": { tier: "light" },
+						"new/model": { tier: "standard" },
+					},
+				},
+				null,
+				2,
+			),
+		)
+
+		// Reset cache
+		resetModelMetadataCache()
+
+		// Next call should re-read from disk
+		const afterReset = getModelMetadata(testPath)
+		expect(afterReset.get("test/model")).toEqual({ tier: "light" })
+		expect(afterReset.get("new/model")).toEqual({ tier: "standard" })
+	})
+
+	it("getModelMetadataWarnings returns empty array initially", () => {
+		const warnings = getModelMetadataWarnings()
+		expect(warnings).toEqual([])
+	})
+})
+
+describe("Integration: saveModelMetadata and loadModelMetadata round-trip", () => {
+	const testDir = join(tmpdir(), `kimchi-model-metadata-test-${process.pid}`)
+	const testPath = join(testDir, "settings.json")
+
+	afterEach(() => {
+		resetModelMetadataCache()
+		try {
+			rmSync(testDir, { recursive: true, force: true })
+		} catch {}
+	})
+
+	it("round-trips a complex metadata map correctly", () => {
+		const original = new Map<string, ModelCustomMetadata>([
+			["custom/model-1", { tier: "heavy", description: "Heavy model", vision: true }],
+			["custom/model-2", { tier: "light" }],
+			["custom/model-3", { description: "Description only" }],
+			["custom/model-4", { vision: false }],
+		])
+
+		saveModelMetadata(original, testPath)
+		const loaded = loadModelMetadata(testPath)
+
+		expect(loaded.size).toBe(4)
+		expect(loaded.get("custom/model-1")).toEqual({ tier: "heavy", description: "Heavy model", vision: true })
+		expect(loaded.get("custom/model-2")).toEqual({ tier: "light" })
+		expect(loaded.get("custom/model-3")).toEqual({ description: "Description only" })
+		expect(loaded.get("custom/model-4")).toEqual({ vision: false })
+	})
+
+	it("empty map removes modelMetadata from settings", () => {
+		const metadata = new Map<string, ModelCustomMetadata>([["temp/model", { tier: "standard" }]])
+		saveModelMetadata(metadata, testPath)
+		expect(existsSync(testPath)).toBe(true)
+
+		saveModelMetadata(new Map(), testPath)
+
+		const saved = JSON.parse(readFileSync(testPath, "utf-8"))
+		expect(saved.modelMetadata).toBeUndefined()
+	})
+})

--- a/src/extensions/orchestration/model-metadata.ts
+++ b/src/extensions/orchestration/model-metadata.ts
@@ -111,6 +111,39 @@ export function saveModelMetadata(metadata: Map<string, ModelCustomMetadata>, se
 }
 
 /**
+ * Remove a single model's custom metadata from settings.json.
+ * If the modelMetadata object becomes empty, the key is removed entirely.
+ */
+export function deleteModelMetadata(ref: string, settingsPath?: string): void {
+	const path = settingsPath ?? HARNESS_SETTINGS_PATH
+	let existing: Record<string, unknown> = {}
+	try {
+		existing = JSON.parse(readFileSync(path, "utf-8"))
+	} catch {
+		return
+	}
+
+	if (!existing.modelMetadata || typeof existing.modelMetadata !== "object" || Array.isArray(existing.modelMetadata)) {
+		return
+	}
+
+	const metaObj = { ...(existing.modelMetadata as Record<string, ModelCustomMetadata>) }
+	if (!(ref in metaObj)) return
+
+	delete metaObj[ref]
+
+	if (Object.keys(metaObj).length === 0) {
+		const { modelMetadata: _, ...rest } = existing
+		existing = rest
+	} else {
+		existing.modelMetadata = metaObj
+	}
+
+	writeFileSync(path, `${JSON.stringify(existing, null, 2)}\n`)
+	resetModelMetadataCache()
+}
+
+/**
  * Unified lookup: settings metadata → builtin MODEL_CAPABILITIES → undefined
  * ref format: "provider/model-id". For builtin lookup, strip provider and use model ID.
  */

--- a/src/extensions/orchestration/model-metadata.ts
+++ b/src/extensions/orchestration/model-metadata.ts
@@ -12,64 +12,94 @@ import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs"
 import { homedir } from "node:os"
 import { dirname, join } from "node:path"
 
+import { type Static, Type } from "typebox"
+import { Value } from "typebox/value"
+
 import { modelIdFromRef } from "./model-ref-utils.js"
 import { MODEL_CAPABILITIES } from "./model-registry/builtin-models.js"
 import type { ModelTier } from "./model-registry/types.js"
 
-export interface ModelCustomMetadata {
-	tier?: ModelTier
-	description?: string
-	vision?: boolean
-}
+/**
+ * TypeBox schema for the on-disk shape of a `modelMetadata` entry.
+ *
+ * All three fields are optional; an entry with none of them set is still
+ * "shape-valid" but is dropped by {@link loadModelMetadata} (the whole entry
+ * would carry no signal). `Value.Check` rejects entries whose fields have the
+ * wrong runtime type — e.g. `tier: "mega"` — and the rejection is recorded as
+ * a warning via {@link getModelMetadataWarnings}.
+ */
+const ModelTierSchema = Type.Union([Type.Literal("light"), Type.Literal("standard"), Type.Literal("heavy")])
+
+const ModelCustomMetadataSchema = Type.Object({
+	tier: Type.Optional(ModelTierSchema),
+	description: Type.Optional(Type.String()),
+	vision: Type.Optional(Type.Boolean()),
+})
+
+export type ModelCustomMetadata = Static<typeof ModelCustomMetadataSchema>
 
 const HARNESS_SETTINGS_PATH = join(homedir(), ".config", "kimchi", "harness", "settings.json")
 
 /**
  * Load metadata from settings.json "modelMetadata" key.
- * Returns an empty map if the file is absent or the key is missing.
- * Entries with no valid fields are ignored.
+ *
+ * Returns the loaded map plus a list of warnings for entries that failed
+ * TypeBox validation (wrong field types, unrecognised tier, etc.). The caller
+ * decides what to do with the warnings — the public API exposes them via
+ * {@link getModelMetadataWarnings}. Returns an empty map + empty warnings when
+ * the file is absent or the key is missing. Entries with no defined fields
+ * after validation are silently dropped.
  */
-export function loadModelMetadata(settingsPath?: string): Map<string, ModelCustomMetadata> {
+export function loadModelMetadata(settingsPath?: string): {
+	metadata: Map<string, ModelCustomMetadata>
+	warnings: Array<{ ref: string; message: string }>
+} {
 	const path = settingsPath ?? HARNESS_SETTINGS_PATH
-	const result = new Map<string, ModelCustomMetadata>()
+	const metadata = new Map<string, ModelCustomMetadata>()
+	const warnings: Array<{ ref: string; message: string }> = []
 
 	try {
 		const raw = readFileSync(path, "utf-8")
 		const parsed = JSON.parse(raw)
-		if (!parsed || typeof parsed !== "object") return result
+		if (!parsed || typeof parsed !== "object") return { metadata, warnings }
 		const meta = parsed.modelMetadata
-		if (!meta || typeof meta !== "object" || Array.isArray(meta)) return result
+		if (!meta || typeof meta !== "object" || Array.isArray(meta)) return { metadata, warnings }
 
 		for (const [ref, value] of Object.entries(meta)) {
 			if (typeof ref !== "string" || !ref.trim()) continue
+			const trimmed = ref.trim()
 			const entry = validateMetadataEntry(value)
-			if (entry) result.set(ref.trim(), entry)
+			if (entry) {
+				metadata.set(trimmed, entry)
+				continue
+			}
+			// Only record a warning if the entry looked like an object but failed
+			// validation — nulls and primitives are silently ignored (they cannot
+			// arise from well-behaved callers and would just be noise).
+			if (value && typeof value === "object" && !Array.isArray(value)) {
+				const errors = Value.Errors(ModelCustomMetadataSchema, value)
+				const detail = errors.length > 0 ? `: ${errors[0].message}` : ""
+				warnings.push({ ref: trimmed, message: `entry failed validation${detail}` })
+			}
 		}
 	} catch {
-		// settings.json absent or unreadable — return empty map
+		// settings.json absent or unreadable — return empty result
 	}
 
-	return result
-}
-
-function isModelTier(value: unknown): value is ModelTier {
-	return value === "light" || value === "standard" || value === "heavy"
+	return { metadata, warnings }
 }
 
 function validateMetadataEntry(value: unknown): ModelCustomMetadata | undefined {
 	if (!value || typeof value !== "object") return undefined
-	const obj = value as Record<string, unknown>
-
-	const tier = obj.tier !== undefined && isModelTier(obj.tier) ? obj.tier : undefined
-	const description = typeof obj.description === "string" ? obj.description : undefined
-	const vision = typeof obj.vision === "boolean" ? obj.vision : undefined
-
-	// Entry must have at least one valid field
-	if (tier === undefined && description === undefined && vision === undefined) {
+	if (!Value.Check(ModelCustomMetadataSchema, value)) return undefined
+	const entry = value as ModelCustomMetadata
+	// Entry must carry at least one defined field; otherwise it has no signal
+	// and would clutter settings.json with empty rows that resolveModelMetadata
+	// would ignore anyway.
+	if (entry.tier === undefined && entry.description === undefined && entry.vision === undefined) {
 		return undefined
 	}
-
-	return { tier, description, vision }
+	return entry
 }
 
 /**
@@ -195,7 +225,9 @@ let _cachedPath: string | undefined
 export function getModelMetadata(settingsPath?: string): ReadonlyMap<string, ModelCustomMetadata> {
 	const path = settingsPath ?? HARNESS_SETTINGS_PATH
 	if (_cachedPath !== path) {
-		_cached = loadModelMetadata(path)
+		const loaded = loadModelMetadata(path)
+		_cached = loaded.metadata
+		_warnings = loaded.warnings
 		_cachedPath = path
 	}
 	// _cached is always set after the branch above (either previously or just now)
@@ -203,8 +235,6 @@ export function getModelMetadata(settingsPath?: string): ReadonlyMap<string, Mod
 }
 
 export function getModelMetadataWarnings(): ReadonlyArray<{ ref: string; message: string }> {
-	// Currently no warnings are generated during load, but the API exists
-	// for future validation (e.g., unknown fields, type mismatches)
 	_warnings ??= []
 	return _warnings
 }

--- a/src/extensions/orchestration/model-metadata.ts
+++ b/src/extensions/orchestration/model-metadata.ts
@@ -1,0 +1,191 @@
+/**
+ * Standalone model metadata storage module.
+ *
+ * Stores custom metadata (tier, description, vision) keyed by model ref in
+ * ~/.config/kimchi/harness/settings.json under the "modelMetadata" key.
+ * This separates metadata from role assignments in modelRoles.
+ *
+ * Unified lookup: custom settings → builtin MODEL_CAPABILITIES → undefined
+ */
+
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs"
+import { homedir } from "node:os"
+import { dirname, join } from "node:path"
+
+import { MODEL_CAPABILITIES } from "./model-registry/builtin-models.js"
+import type { ModelTier } from "./model-registry/types.js"
+
+export interface ModelCustomMetadata {
+	tier?: ModelTier
+	description?: string
+	vision?: boolean
+}
+
+const HARNESS_SETTINGS_PATH = join(homedir(), ".config", "kimchi", "harness", "settings.json")
+
+/**
+ * Strip provider prefix from a "provider/model-id" ref to get the model ID.
+ * Returns the full string if no slash is present.
+ */
+function modelIdFromRef(ref: string): string {
+	const slashIdx = ref.indexOf("/")
+	return slashIdx >= 0 ? ref.slice(slashIdx + 1) : ref
+}
+
+/**
+ * Load metadata from settings.json "modelMetadata" key.
+ * Returns an empty map if the file is absent or the key is missing.
+ * Entries with no valid fields are ignored.
+ */
+export function loadModelMetadata(settingsPath?: string): Map<string, ModelCustomMetadata> {
+	const path = settingsPath ?? HARNESS_SETTINGS_PATH
+	const result = new Map<string, ModelCustomMetadata>()
+
+	try {
+		const raw = readFileSync(path, "utf-8")
+		const parsed = JSON.parse(raw)
+		if (!parsed || typeof parsed !== "object") return result
+		const meta = parsed.modelMetadata
+		if (!meta || typeof meta !== "object" || Array.isArray(meta)) return result
+
+		for (const [ref, value] of Object.entries(meta)) {
+			if (typeof ref !== "string" || !ref.trim()) continue
+			const entry = validateMetadataEntry(value)
+			if (entry) result.set(ref.trim(), entry)
+		}
+	} catch {
+		// settings.json absent or unreadable — return empty map
+	}
+
+	return result
+}
+
+function isModelTier(value: unknown): value is ModelTier {
+	return value === "light" || value === "standard" || value === "heavy"
+}
+
+function validateMetadataEntry(value: unknown): ModelCustomMetadata | undefined {
+	if (!value || typeof value !== "object") return undefined
+	const obj = value as Record<string, unknown>
+
+	const tier = obj.tier !== undefined && isModelTier(obj.tier) ? obj.tier : undefined
+	const description = typeof obj.description === "string" ? obj.description : undefined
+	const vision = typeof obj.vision === "boolean" ? obj.vision : undefined
+
+	// Entry must have at least one valid field
+	if (tier === undefined && description === undefined && vision === undefined) {
+		return undefined
+	}
+
+	return { tier, description, vision }
+}
+
+/**
+ * Save metadata to settings.json "modelMetadata" key, preserving other settings.
+ * If the map is empty, the "modelMetadata" key is deleted.
+ */
+export function saveModelMetadata(metadata: Map<string, ModelCustomMetadata>, settingsPath?: string): void {
+	const path = settingsPath ?? HARNESS_SETTINGS_PATH
+	let existing: Record<string, unknown> = {}
+	try {
+		existing = JSON.parse(readFileSync(path, "utf-8"))
+	} catch {
+		// absent or unreadable — start fresh
+	}
+
+	// Merge with existing modelMetadata so we don't wipe out other models
+	const metaObj: Record<string, ModelCustomMetadata> =
+		existing.modelMetadata && typeof existing.modelMetadata === "object" && !Array.isArray(existing.modelMetadata)
+			? { ...(existing.modelMetadata as Record<string, ModelCustomMetadata>) }
+			: {}
+
+	if (metadata.size === 0) {
+		// Delete the key if map is empty
+		const { modelMetadata: _, ...rest } = existing
+		existing = rest
+	} else {
+		for (const [ref, entry] of metadata.entries()) {
+			const prev = metaObj[ref]
+			metaObj[ref] = prev ? { ...prev, ...entry } : entry
+		}
+		existing.modelMetadata = metaObj
+	}
+
+	const dir = dirname(path)
+	if (!existsSync(dir)) mkdirSync(dir, { recursive: true })
+	writeFileSync(path, `${JSON.stringify(existing, null, 2)}\n`)
+
+	resetModelMetadataCache()
+}
+
+/**
+ * Unified lookup: settings metadata → builtin MODEL_CAPABILITIES → undefined
+ * ref format: "provider/model-id". For builtin lookup, strip provider and use model ID.
+ */
+export function resolveModelMetadata(
+	ref: string,
+	settingsPath?: string,
+): { source: "builtin" | "custom"; tier?: ModelTier; description?: string; vision?: boolean } | undefined {
+	// 1. Check cached custom metadata for the exact ref
+	const custom = getModelMetadata(settingsPath).get(ref)
+	if (custom) {
+		return { source: "custom", tier: custom.tier, description: custom.description, vision: custom.vision }
+	}
+
+	// 2. Check MODEL_CAPABILITIES — strip provider prefix to get model ID
+	const modelId = modelIdFromRef(ref)
+	const entry = MODEL_CAPABILITIES.get(modelId)
+	if (entry && entry !== "ignored") {
+		return {
+			source: "builtin",
+			tier: entry.tier,
+			description: entry.description,
+			vision: entry.vision,
+		}
+	}
+
+	// 3. Return undefined if neither
+	return undefined
+}
+
+/**
+ * True if model has neither builtin nor custom metadata.
+ */
+export function isModelMetadataMissing(ref: string, settingsPath?: string): boolean {
+	return resolveModelMetadata(ref, settingsPath) === undefined
+}
+
+// ---------------------------------------------------------------------------
+// Singleton — resolved once at module load, reusable across the process
+// ---------------------------------------------------------------------------
+
+let _cached: ReadonlyMap<string, ModelCustomMetadata> | undefined
+let _warnings: ReadonlyArray<{ ref: string; message: string }> | undefined
+let _cachedPath: string | undefined
+
+/**
+ * Get cached model metadata, loading from the default settings path on first call.
+ * If a settingsPath is provided and differs from the cached path, reloads.
+ */
+export function getModelMetadata(settingsPath?: string): ReadonlyMap<string, ModelCustomMetadata> {
+	const path = settingsPath ?? HARNESS_SETTINGS_PATH
+	if (_cachedPath !== path) {
+		_cached = loadModelMetadata(path)
+		_cachedPath = path
+	}
+	// _cached is always set after the branch above (either previously or just now)
+	return _cached ?? new Map()
+}
+
+export function getModelMetadataWarnings(): ReadonlyArray<{ ref: string; message: string }> {
+	// Currently no warnings are generated during load, but the API exists
+	// for future validation (e.g., unknown fields, type mismatches)
+	_warnings ??= []
+	return _warnings
+}
+
+export function resetModelMetadataCache(): void {
+	_cached = undefined
+	_warnings = undefined
+	_cachedPath = undefined
+}

--- a/src/extensions/orchestration/model-metadata.ts
+++ b/src/extensions/orchestration/model-metadata.ts
@@ -12,6 +12,7 @@ import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs"
 import { homedir } from "node:os"
 import { dirname, join } from "node:path"
 
+import { modelIdFromRef } from "./model-ref-utils.js"
 import { MODEL_CAPABILITIES } from "./model-registry/builtin-models.js"
 import type { ModelTier } from "./model-registry/types.js"
 
@@ -22,15 +23,6 @@ export interface ModelCustomMetadata {
 }
 
 const HARNESS_SETTINGS_PATH = join(homedir(), ".config", "kimchi", "harness", "settings.json")
-
-/**
- * Strip provider prefix from a "provider/model-id" ref to get the model ID.
- * Returns the full string if no slash is present.
- */
-function modelIdFromRef(ref: string): string {
-	const slashIdx = ref.indexOf("/")
-	return slashIdx >= 0 ? ref.slice(slashIdx + 1) : ref
-}
 
 /**
  * Load metadata from settings.json "modelMetadata" key.

--- a/src/extensions/orchestration/model-ref-utils.ts
+++ b/src/extensions/orchestration/model-ref-utils.ts
@@ -9,13 +9,14 @@ export function modelIdFromRef(ref: string): string {
 
 /**
  * Extract provider and model ID from a "provider/model-id" string.
- * Returns undefined if the string doesn't contain a slash.
+ * Returns undefined if the string doesn't contain a slash, or if either
+ * the provider or the model ID is empty / whitespace-only.
  */
 export function splitModelRef(ref: string): { provider: string; modelId: string } | undefined {
 	const slashIdx = ref.indexOf("/")
 	if (slashIdx <= 0) return undefined
-	return {
-		provider: ref.slice(0, slashIdx),
-		modelId: ref.slice(slashIdx + 1),
-	}
+	const provider = ref.slice(0, slashIdx)
+	const modelId = ref.slice(slashIdx + 1)
+	if (provider.trim().length === 0 || modelId.trim().length === 0) return undefined
+	return { provider, modelId }
 }

--- a/src/extensions/orchestration/model-ref-utils.ts
+++ b/src/extensions/orchestration/model-ref-utils.ts
@@ -1,0 +1,21 @@
+/**
+ * Extract just the model ID from a "provider/model-id" string.
+ * Returns the full string if no slash is present.
+ */
+export function modelIdFromRef(ref: string): string {
+	const slashIdx = ref.indexOf("/")
+	return slashIdx >= 0 ? ref.slice(slashIdx + 1) : ref
+}
+
+/**
+ * Extract provider and model ID from a "provider/model-id" string.
+ * Returns undefined if the string doesn't contain a slash.
+ */
+export function splitModelRef(ref: string): { provider: string; modelId: string } | undefined {
+	const slashIdx = ref.indexOf("/")
+	if (slashIdx <= 0) return undefined
+	return {
+		provider: ref.slice(0, slashIdx),
+		modelId: ref.slice(slashIdx + 1),
+	}
+}

--- a/src/extensions/orchestration/model-registry/builtin-models.ts
+++ b/src/extensions/orchestration/model-registry/builtin-models.ts
@@ -116,7 +116,6 @@ export const MODEL_CAPABILITIES: ReadonlyMap<string, ModelCapabilities | "ignore
 		"kimi-k2.6",
 		{
 			vision: true,
-			roles: ["research", "plan", "build", "review"],
 			tier: "heavy",
 			description: KIMI_K26_DESCRIPTION,
 			guidelines: guidelinesMap({
@@ -137,7 +136,6 @@ export const MODEL_CAPABILITIES: ReadonlyMap<string, ModelCapabilities | "ignore
 		"minimax-m2.7",
 		{
 			vision: false,
-			roles: ["build", "review"],
 			tier: "standard",
 			description: MINIMAX_M27_DESCRIPTION,
 			guidelines: guidelinesMap({
@@ -155,7 +153,6 @@ export const MODEL_CAPABILITIES: ReadonlyMap<string, ModelCapabilities | "ignore
 		"nemotron-3-ultra-fp4",
 		{
 			vision: false,
-			roles: ["explore", "research"],
 			tier: "light",
 			description: NEMOTRON_3_ULTRA_DESCRIPTION,
 			guidelines: guidelinesMap({

--- a/src/extensions/orchestration/model-registry/index.ts
+++ b/src/extensions/orchestration/model-registry/index.ts
@@ -1,4 +1,4 @@
 export { KIMCHI_DEV_PROVIDER, ModelRegistry } from "./model-registry.js"
 export { MODEL_CAPABILITIES } from "./builtin-models.js"
 export type { ModelRegistryWarning } from "./model-registry.js"
-export type { ModelRole, ModelTier, ModelCapabilities, OrchestrationModelDescriptor } from "./types.js"
+export type { ModelTier, ModelCapabilities, OrchestrationModelDescriptor } from "./types.js"

--- a/src/extensions/orchestration/model-registry/model-registry.test.ts
+++ b/src/extensions/orchestration/model-registry/model-registry.test.ts
@@ -2,10 +2,9 @@ import { describe, expect, it } from "vitest"
 import type { ModelMetadata } from "../../../models.js"
 import { MODEL_CAPABILITIES } from "./builtin-models.js"
 import { ModelRegistry } from "./model-registry.js"
-import type { ModelRole, ModelTier } from "./types.js"
+import type { ModelTier } from "./types.js"
 
 const ALLOWED_TIERS: ModelTier[] = ["light", "standard", "heavy"]
-const ALLOWED_ROLES: ModelRole[] = ["build", "explore", "plan", "review", "research"]
 
 const LIVE_ENTRIES = Object.entries(Object.fromEntries(MODEL_CAPABILITIES)).filter(
 	([, value]) => value !== "ignored",
@@ -19,14 +18,6 @@ describe("MODEL_CAPABILITIES completeness invariants", () => {
 
 	it.each(LIVE_ENTRIES)("%s — tier is one of light | standard | heavy", (_id, cap) => {
 		expect(ALLOWED_TIERS).toContain(cap.tier)
-	})
-
-	it.each(LIVE_ENTRIES)("%s — roles is a non-empty array of valid ModelRole values", (_id, cap) => {
-		expect(Array.isArray(cap.roles)).toBe(true)
-		expect(cap.roles.length).toBeGreaterThanOrEqual(1)
-		for (const s of cap.roles) {
-			expect(ALLOWED_ROLES).toContain(s)
-		}
 	})
 
 	it.each(LIVE_ENTRIES)("%s — orchestrationGuidelines is a non-empty string", (_id, cap) => {

--- a/src/extensions/orchestration/model-registry/model-registry.ts
+++ b/src/extensions/orchestration/model-registry/model-registry.ts
@@ -28,7 +28,6 @@ export const KIMCHI_DEV_PROVIDER = "kimchi-dev"
 
 const GENERIC_CAPABILITIES: ModelCapabilities = {
 	vision: false,
-	roles: ["build"],
 	tier: "standard",
 	description: "No capability information available for this model.",
 }

--- a/src/extensions/orchestration/model-registry/types.ts
+++ b/src/extensions/orchestration/model-registry/types.ts
@@ -1,18 +1,4 @@
 /**
- * Task-type affinity used by the Orchestrator to match a model to a role.
- *
- *  - "build"    — writing, modifying, and refactoring code.
- *  - "explore"  — navigating codebases, searching for information,
- *                  answering questions about code.
- *  - "review"   — code review, finding bugs, and suggesting improvements.
- *  - "plan"     — architectural planning, breaking down complex tasks,
- *                  writing specs.
- *  - "research" — researching and investigating code, tracing dependencies,
- *                  understanding large codebases.
- */
-export type ModelRole = "review" | "build" | "plan" | "explore" | "research"
-
-/**
  * Relative cost/capability tier used by the Orchestrator to match task
  * difficulty to model weight class.
  *
@@ -31,7 +17,6 @@ export type Phase = "explore" | "research" | "plan" | "build" | "review"
 /** Injected into the Orchestrator LLM's context to steer model selection. */
 export interface ModelCapabilities {
 	vision: boolean
-	roles: ModelRole[]
 	tier: ModelTier
 	description: string
 	/** Phase-specific guideline annexes. If a phase key is present, its value

--- a/src/extensions/orchestration/model-roles-command.test.ts
+++ b/src/extensions/orchestration/model-roles-command.test.ts
@@ -10,6 +10,7 @@ import {
 	formatRoleAssignment,
 	formatRoleDisplay,
 	formatRoleSummaryBlock,
+	hasMetadataContent,
 	isEqualAssignment,
 } from "./model-roles-command.js"
 import type { RoleModelAssignment } from "./model-roles.js"
@@ -165,9 +166,9 @@ describe("splitModelRef (from model-roles.ts)", () => {
 			input: "/",
 			expected: undefined,
 		},
-		"returns provider with empty modelId for trailing slash": {
+		"returns undefined for trailing slash with empty modelId": {
 			input: "provider/",
-			expected: { provider: "provider", modelId: "" },
+			expected: undefined,
 		},
 	}
 
@@ -253,5 +254,25 @@ describe("collectModelMetadata", () => {
 		expect(selectCalls[1][0]).toContain("custom/my-model")
 		const inputCalls = (ctx.ui.input as ReturnType<typeof vi.fn>).mock.calls
 		expect(inputCalls[0][0]).toContain("custom/my-model")
+	})
+})
+
+describe("hasMetadataContent", () => {
+	it("returns false for undefined (user cancelled)", () => {
+		expect(hasMetadataContent(undefined)).toBe(false)
+	})
+
+	it("returns false for empty object (user skipped all fields)", () => {
+		// Regression: collectModelMetadata() returns {} when the user completes the
+		// form while skipping every optional field. Saving this clutters settings.json
+		// with empty entries that resolveModelMetadata ignores anyway.
+		expect(hasMetadataContent({})).toBe(false)
+	})
+
+	it("returns true when at least one field is present", () => {
+		expect(hasMetadataContent({ tier: "heavy" })).toBe(true)
+		expect(hasMetadataContent({ vision: true })).toBe(true)
+		expect(hasMetadataContent({ description: "x" })).toBe(true)
+		expect(hasMetadataContent({ tier: "light", vision: false })).toBe(true)
 	})
 })

--- a/src/extensions/orchestration/model-roles-command.test.ts
+++ b/src/extensions/orchestration/model-roles-command.test.ts
@@ -12,6 +12,7 @@ import {
 	formatRoleSummaryBlock,
 	isEqualAssignment,
 } from "./model-roles-command.js"
+import type { RoleModelAssignment } from "./model-roles.js"
 import { splitModelRef } from "./model-roles.js"
 
 // Mock model-metadata module
@@ -87,7 +88,6 @@ describe("isEqualAssignment", () => {
 		},
 	}
 
-	type RoleModelAssignment = string | string[]
 	for (const [name, { a, b, expected }] of Object.entries(cases)) {
 		it(name, () => {
 			expect(isEqualAssignment(a, b)).toBe(expected)

--- a/src/extensions/orchestration/model-roles-command.test.ts
+++ b/src/extensions/orchestration/model-roles-command.test.ts
@@ -1,9 +1,11 @@
-import type { ExtensionCommandContext } from "@earendil-works/pi-coding-agent"
+import type { ExtensionCommandContext, Theme } from "@earendil-works/pi-coding-agent"
 /**
  * Tests for the pure helper functions in model-roles-command.ts.
- * Interactive CLI flows (select/input UI) are not tested here —
- * they require a full mock UI harness and are covered by manual smoke tests.
+ * Interactive CLI flows are tested via a mock ui.custom that returns a
+ * canned QuestionFormResult, so the user-completion contract of
+ * `collectModelMetadata` is exercised without booting the real TUI.
  */
+import type { Component, TUI } from "@earendil-works/pi-tui"
 import { describe, expect, it, vi } from "vitest"
 import {
 	collectModelMetadata,
@@ -25,16 +27,63 @@ vi.mock("./model-metadata.js", () => ({
 	getModelMetadata: vi.fn(() => new Map()),
 }))
 
-const createMockCtx = (responses: { selects?: (string | undefined)[]; inputs?: (string | undefined)[] } = {}) => {
-	let selectIdx = 0
-	let inputIdx = 0
+// Spy on the shared form factory so we can assert what questions / header
+// were rendered without booting the real TUI. The factory itself is loaded
+// for real so its reducer wiring is exercised end-to-end.
+import * as questionnaireForm from "../questionnaire-form.js"
+import type { QuestionFormResult } from "../questionnaire-form.js"
+import type { Answer, Question } from "../questionnaire-reducer.js"
+
+vi.mock("../questionnaire-form.js", async () => {
+	const actual = await vi.importActual<typeof questionnaireForm>("../questionnaire-form.js")
 	return {
+		...actual,
+		createQuestionForm: vi.fn(actual.createQuestionForm),
+	}
+})
+
+function singleAnswer(id: string, value: string): Answer {
+	return { id, value, label: value, wasCustom: false, index: 1 }
+}
+
+function textAnswer(id: string, value: string): Answer {
+	return { id, value, label: value, wasCustom: true }
+}
+
+const createMockCtx = (
+	answers: Answer[] = [],
+	cancelled = false,
+): {
+	ctx: ExtensionCommandContext
+	factoryArgs: { questions: Question[]; header: { title?: string; description?: string } }
+} => {
+	const factoryArgs = { questions: [] as Question[], header: {} as { title?: string; description?: string } }
+	const ctx = {
 		ui: {
-			select: vi.fn(async () => responses.selects?.[selectIdx++]),
-			input: vi.fn(async () => responses.inputs?.[inputIdx++]),
+			custom: vi.fn(async <T>(factory: (...args: unknown[]) => Component | Promise<Component>) => {
+				const fakeTui = {} as TUI
+				const fakeTheme = { fg: (s: string) => s, bold: (s: string) => s } as unknown as Theme
+				const fakeDone = (_r: T) => {}
+				// Wire a wrapper around createQuestionForm so we can capture the
+				// questions + header that the caller passed to it.
+				const original = vi.mocked(questionnaireForm.createQuestionForm)
+				original.mockImplementationOnce((_tui, _theme, questions, header, done) => {
+					factoryArgs.questions = questions
+					factoryArgs.header = header
+					return {
+						render: () => [],
+						handleInput: () => {},
+						invalidate: () => {},
+					} as Component
+				})
+				factory(fakeTui, fakeTheme, {} as never, fakeDone as never)
+				const result: QuestionFormResult = { questions: factoryArgs.questions, answers, cancelled }
+				return result as T
+			}),
 			notify: vi.fn(),
 		},
 	} as unknown as ExtensionCommandContext
+	return { ctx, factoryArgs }
 }
 
 describe("formatRoleAssignment", () => {
@@ -184,17 +233,18 @@ describe("splitModelRef (from model-roles.ts)", () => {
 })
 
 describe("collectModelMetadata", () => {
-	it("returns undefined when user cancels tier selection (select returns undefined)", async () => {
-		const ctx = createMockCtx({ selects: [undefined] })
+	it("returns undefined when the user cancels the form", async () => {
+		const { ctx } = createMockCtx([], true)
 		const result = await collectModelMetadata("custom/model", undefined, ctx)
 		expect(result).toBeUndefined()
 	})
 
-	it("returns config with all fields when user provides tier, vision=yes, description", async () => {
-		const ctx = createMockCtx({
-			selects: ["heavy", "yes"],
-			inputs: ["A powerful model good at reasoning"],
-		})
+	it("returns config with all fields when user picks tier, vision=yes, and a description", async () => {
+		const { ctx } = createMockCtx([
+			singleAnswer("tier", "heavy"),
+			singleAnswer("vision", "yes"),
+			textAnswer("description", "A powerful model good at reasoning"),
+		])
 		const result = await collectModelMetadata("custom/model", undefined, ctx)
 		expect(result).toEqual({
 			tier: "heavy",
@@ -203,24 +253,24 @@ describe("collectModelMetadata", () => {
 		})
 	})
 
-	it("returns config with only provided fields, skips undefined ones (user selects skip for vision, empty description)", async () => {
-		const ctx = createMockCtx({
-			selects: ["standard", "skip"],
-			inputs: [""],
-		})
+	it("drops unselected fields when user picks skip / leaves them blank", async () => {
+		const { ctx } = createMockCtx([
+			singleAnswer("tier", "standard"),
+			singleAnswer("vision", "__keep__"), // "skip" since no existing vision
+			textAnswer("description", "(no response)"), // empty editor submit
+		])
 		const result = await collectModelMetadata("custom/model", undefined, ctx)
-		expect(result).toEqual({
-			tier: "standard",
-		})
+		expect(result).toEqual({ tier: "standard" })
 		expect(result).not.toHaveProperty("vision")
 		expect(result).not.toHaveProperty("description")
 	})
 
-	it("preserves existing fields when user selects keep current", async () => {
-		const ctx = createMockCtx({
-			selects: ["keep current (standard)", "keep current (yes)"],
-			inputs: ["Existing description"],
-		})
+	it("preserves existing fields when user picks keep current for each", async () => {
+		const { ctx } = createMockCtx([
+			singleAnswer("tier", "__keep__"),
+			singleAnswer("vision", "__keep__"),
+			textAnswer("description", "Existing description"),
+		])
 		const existing = { tier: "standard" as const, description: "Old desc", vision: true as const }
 		const result = await collectModelMetadata("custom/model", existing, ctx)
 		expect(result).toEqual({
@@ -230,30 +280,70 @@ describe("collectModelMetadata", () => {
 		})
 	})
 
-	it("does not include vision when user selects skip and no existing vision", async () => {
-		const ctx = createMockCtx({
-			selects: ["light", "skip"],
-			inputs: ["A light model"],
-		})
-		const result = await collectModelMetadata("custom/model", undefined, ctx)
+	it("keeps existing description when user submits empty text", async () => {
+		const { ctx } = createMockCtx([
+			singleAnswer("tier", "heavy"),
+			singleAnswer("vision", "no"),
+			textAnswer("description", "(no response)"),
+		])
+		const existing = { description: "Pre-existing description" }
+		const result = await collectModelMetadata("custom/model", existing, ctx)
 		expect(result).toEqual({
-			tier: "light",
-			description: "A light model",
+			tier: "heavy",
+			vision: false,
+			description: "Pre-existing description",
 		})
-		expect(result).not.toHaveProperty("vision")
 	})
 
-	it("includes model ref in select prompts", async () => {
-		const ctx = createMockCtx({
-			selects: ["heavy", "yes"],
-			inputs: ["test"],
-		})
+	it("keeps existing description when user navigates past the description question", async () => {
+		// No description answer recorded at all — form treats it as "skip".
+		const { ctx } = createMockCtx([singleAnswer("tier", "light"), singleAnswer("vision", "no")])
+		const existing = { description: "Pre-existing description" }
+		const result = await collectModelMetadata("custom/model", existing, ctx)
+		expect(result).toEqual({ tier: "light", vision: false, description: "Pre-existing description" })
+	})
+
+	it("labels the skip option as 'keep current (X)' when an existing value is present", async () => {
+		const { ctx, factoryArgs } = createMockCtx([singleAnswer("tier", "__keep__")])
+		await collectModelMetadata("custom/model", { tier: "heavy" }, ctx)
+		const tierQuestion = factoryArgs.questions.find((q) => q.id === "tier")
+		expect(tierQuestion).toBeDefined()
+		const keepOption = tierQuestion?.options.find((o) => o.id === "__keep__")
+		expect(keepOption?.label).toBe("keep current (heavy)")
+	})
+
+	it("labels the skip option as 'skip' when no existing value is present", async () => {
+		const { ctx, factoryArgs } = createMockCtx([singleAnswer("tier", "__keep__")])
+		await collectModelMetadata("custom/model", undefined, ctx)
+		const tierQuestion = factoryArgs.questions.find((q) => q.id === "tier")
+		const keepOption = tierQuestion?.options.find((o) => o.id === "__keep__")
+		expect(keepOption?.label).toBe("skip")
+	})
+
+	it("includes model ref in question prompts and form title", async () => {
+		const { ctx, factoryArgs } = createMockCtx([singleAnswer("tier", "heavy")])
 		await collectModelMetadata("custom/my-model", undefined, ctx)
-		const selectCalls = (ctx.ui.select as ReturnType<typeof vi.fn>).mock.calls
-		expect(selectCalls[0][0]).toContain("custom/my-model")
-		expect(selectCalls[1][0]).toContain("custom/my-model")
-		const inputCalls = (ctx.ui.input as ReturnType<typeof vi.fn>).mock.calls
-		expect(inputCalls[0][0]).toContain("custom/my-model")
+		expect(factoryArgs.header.title).toBe("custom/my-model")
+		for (const q of factoryArgs.questions) {
+			expect(q.prompt).toContain("custom/my-model")
+		}
+	})
+
+	it("uses three questions (tier, vision, description)", async () => {
+		const { ctx, factoryArgs } = createMockCtx([singleAnswer("tier", "heavy")])
+		await collectModelMetadata("custom/model", undefined, ctx)
+		expect(factoryArgs.questions.map((q) => q.id)).toEqual(["tier", "vision", "description"])
+	})
+
+	it("uses YES_NO_OPTIONS plus a keep-current option for vision", async () => {
+		const { ctx, factoryArgs } = createMockCtx([singleAnswer("tier", "heavy")])
+		await collectModelMetadata("custom/model", undefined, ctx)
+		const visionQuestion = factoryArgs.questions.find((q) => q.id === "vision")
+		expect(visionQuestion).toBeDefined()
+		const optionIds = visionQuestion?.options.map((o) => o.id)
+		expect(optionIds).toContain("yes")
+		expect(optionIds).toContain("no")
+		expect(optionIds).toContain("__keep__")
 	})
 })
 

--- a/src/extensions/orchestration/model-roles-command.test.ts
+++ b/src/extensions/orchestration/model-roles-command.test.ts
@@ -1,11 +1,39 @@
+import type { ExtensionCommandContext } from "@earendil-works/pi-coding-agent"
 /**
  * Tests for the pure helper functions in model-roles-command.ts.
  * Interactive CLI flows (select/input UI) are not tested here —
  * they require a full mock UI harness and are covered by manual smoke tests.
  */
-import { describe, expect, it } from "vitest"
-import { formatRoleAssignment, formatRoleDisplay, isEqualAssignment } from "./model-roles-command.js"
+import { describe, expect, it, vi } from "vitest"
+import {
+	collectModelMetadata,
+	formatRoleAssignment,
+	formatRoleDisplay,
+	formatRoleSummaryBlock,
+	isEqualAssignment,
+} from "./model-roles-command.js"
 import { splitModelRef } from "./model-roles.js"
+
+// Mock model-metadata module
+vi.mock("./model-metadata.js", () => ({
+	isModelMetadataMissing: vi.fn(),
+	loadModelMetadata: vi.fn(),
+	resolveModelMetadata: vi.fn(),
+	saveModelMetadata: vi.fn(),
+	getModelMetadata: vi.fn(() => new Map()),
+}))
+
+const createMockCtx = (responses: { selects?: (string | undefined)[]; inputs?: (string | undefined)[] } = {}) => {
+	let selectIdx = 0
+	let inputIdx = 0
+	return {
+		ui: {
+			select: vi.fn(async () => responses.selects?.[selectIdx++]),
+			input: vi.fn(async () => responses.inputs?.[inputIdx++]),
+			notify: vi.fn(),
+		},
+	} as unknown as ExtensionCommandContext
+}
 
 describe("formatRoleAssignment", () => {
 	it("formats a single model as-is", () => {
@@ -19,8 +47,6 @@ describe("formatRoleAssignment", () => {
 	})
 
 	it("formats empty array as empty string", () => {
-		// normalizeRoleModels([]) would not be valid input per isValidRoleValue guard,
-		// but formatRoleAssignment handles it gracefully
 		const models: string[] = []
 		const result = models.join(", ")
 		expect(result).toBe("")
@@ -28,45 +54,49 @@ describe("formatRoleAssignment", () => {
 })
 
 describe("isEqualAssignment", () => {
-	it("returns true for identical single-model assignments", () => {
-		expect(isEqualAssignment("kimchi-dev/kimi-k2.6", "kimchi-dev/kimi-k2.6")).toBe(true)
-	})
+	const cases: Record<string, { a: RoleModelAssignment; b: RoleModelAssignment; expected: boolean }> = {
+		"identical single-model assignments": {
+			a: "kimchi-dev/kimi-k2.6",
+			b: "kimchi-dev/kimi-k2.6",
+			expected: true,
+		},
+		"different single-model assignments": {
+			a: "kimchi-dev/kimi-k2.6",
+			b: "kimchi-dev/minimax-m2.7",
+			expected: false,
+		},
+		"identical multi-model assignments (same order)": {
+			a: ["kimchi-dev/kimi-k2.6", "kimchi-dev/minimax-m2.7"],
+			b: ["kimchi-dev/kimi-k2.6", "kimchi-dev/minimax-m2.7"],
+			expected: true,
+		},
+		"same models in different order": {
+			a: ["kimchi-dev/kimi-k2.6", "kimchi-dev/minimax-m2.7"],
+			b: ["kimchi-dev/minimax-m2.7", "kimchi-dev/kimi-k2.6"],
+			expected: false,
+		},
+		"different lengths": {
+			a: "kimchi-dev/kimi-k2.6",
+			b: ["kimchi-dev/kimi-k2.6", "kimchi-dev/minimax-m2.7"],
+			expected: false,
+		},
+		"mixed types (string vs array of one)": {
+			a: "kimchi-dev/kimi-k2.6",
+			b: ["kimchi-dev/kimi-k2.6"],
+			expected: true,
+		},
+	}
 
-	it("returns false for different single-model assignments", () => {
-		expect(isEqualAssignment("kimchi-dev/kimi-k2.6", "kimchi-dev/minimax-m2.7")).toBe(false)
-	})
-
-	it("returns true for identical multi-model assignments (same order)", () => {
-		expect(
-			isEqualAssignment(
-				["kimchi-dev/kimi-k2.6", "kimchi-dev/minimax-m2.7"],
-				["kimchi-dev/kimi-k2.6", "kimchi-dev/minimax-m2.7"],
-			),
-		).toBe(true)
-	})
-
-	it("returns false for same models in different order", () => {
-		// Order matters — this is intentional
-		expect(
-			isEqualAssignment(
-				["kimchi-dev/kimi-k2.6", "kimchi-dev/minimax-m2.7"],
-				["kimchi-dev/minimax-m2.7", "kimchi-dev/kimi-k2.6"],
-			),
-		).toBe(false)
-	})
-
-	it("returns false for different lengths", () => {
-		expect(isEqualAssignment("kimchi-dev/kimi-k2.6", ["kimchi-dev/kimi-k2.6", "kimchi-dev/minimax-m2.7"])).toBe(false)
-	})
-
-	it("handles mixed types (string vs array of one)", () => {
-		expect(isEqualAssignment("kimchi-dev/kimi-k2.6", ["kimchi-dev/kimi-k2.6"])).toBe(true)
-	})
+	type RoleModelAssignment = string | string[]
+	for (const [name, { a, b, expected }] of Object.entries(cases)) {
+		it(name, () => {
+			expect(isEqualAssignment(a, b)).toBe(expected)
+		})
+	}
 })
 
 describe("formatRoleDisplay", () => {
 	it("appends (default) suffix when value matches DEFAULT_MODEL_ROLES", () => {
-		// orchestrator default is kimchi-dev/kimi-k2.6 (or heaviest plan-capable model)
 		const display = formatRoleDisplay("orchestrator", "kimchi-dev/kimi-k2.6")
 		expect(display).toMatch(/\(default\)$/)
 	})
@@ -90,27 +120,138 @@ describe("formatRoleDisplay", () => {
 	})
 })
 
+describe("formatRoleSummaryBlock", () => {
+	it("shows role label with indented model on next line", () => {
+		const display = formatRoleSummaryBlock("orchestrator", "kimchi-dev/kimi-k2.6")
+		expect(display).toMatch(/^Orchestrator:/)
+		expect(display).toContain("\n    kimchi-dev/kimi-k2.6")
+	})
+
+	it("shows multiple models on separate indented lines", () => {
+		const display = formatRoleSummaryBlock("builder", ["custom/model-a", "custom/model-b"])
+		const lines = display.split("\n")
+		expect(lines).toHaveLength(3)
+		expect(lines[0]).toBe("Builder:")
+		expect(lines[1]).toBe("    custom/model-a")
+		expect(lines[2]).toBe("    custom/model-b")
+	})
+
+	it("appends (default) suffix to each model line when assignment matches default", () => {
+		const display = formatRoleSummaryBlock("orchestrator", "kimchi-dev/kimi-k2.6")
+		expect(display).toContain("(default)")
+	})
+
+	it("omits (default) suffix when assignment differs from default", () => {
+		const display = formatRoleSummaryBlock("orchestrator", "kimchi-dev/minimax-m2.7")
+		expect(display).not.toContain("(default)")
+	})
+})
+
 describe("splitModelRef (from model-roles.ts)", () => {
-	it("parses valid provider/model-id", () => {
-		expect(splitModelRef("kimchi-dev/kimi-k2.6")).toEqual({
-			provider: "kimchi-dev",
-			modelId: "kimi-k2.6",
+	const cases: Record<string, { input: string; expected: { provider: string; modelId: string } | undefined }> = {
+		"parses valid provider/model-id": {
+			input: "kimchi-dev/kimi-k2.6",
+			expected: { provider: "kimchi-dev", modelId: "kimi-k2.6" },
+		},
+		"returns undefined for model-id without slash": {
+			input: "kimi-k2.6",
+			expected: undefined,
+		},
+		"returns undefined for empty string": {
+			input: "",
+			expected: undefined,
+		},
+		"returns undefined for slash-only string": {
+			input: "/",
+			expected: undefined,
+		},
+		"returns provider with empty modelId for trailing slash": {
+			input: "provider/",
+			expected: { provider: "provider", modelId: "" },
+		},
+	}
+
+	for (const [name, { input, expected }] of Object.entries(cases)) {
+		it(name, () => {
+			if (expected === undefined) {
+				expect(splitModelRef(input)).toBeUndefined()
+			} else {
+				expect(splitModelRef(input)).toEqual(expected)
+			}
+		})
+	}
+})
+
+describe("collectModelMetadata", () => {
+	it("returns undefined when user cancels tier selection (select returns undefined)", async () => {
+		const ctx = createMockCtx({ selects: [undefined] })
+		const result = await collectModelMetadata("custom/model", undefined, ctx)
+		expect(result).toBeUndefined()
+	})
+
+	it("returns config with all fields when user provides tier, vision=yes, description", async () => {
+		const ctx = createMockCtx({
+			selects: ["heavy", "yes"],
+			inputs: ["A powerful model good at reasoning"],
+		})
+		const result = await collectModelMetadata("custom/model", undefined, ctx)
+		expect(result).toEqual({
+			tier: "heavy",
+			vision: true,
+			description: "A powerful model good at reasoning",
 		})
 	})
 
-	it("returns undefined for model-id without slash", () => {
-		expect(splitModelRef("kimi-k2.6")).toBeUndefined()
+	it("returns config with only provided fields, skips undefined ones (user selects skip for vision, empty description)", async () => {
+		const ctx = createMockCtx({
+			selects: ["standard", "skip"],
+			inputs: [""],
+		})
+		const result = await collectModelMetadata("custom/model", undefined, ctx)
+		expect(result).toEqual({
+			tier: "standard",
+		})
+		expect(result).not.toHaveProperty("vision")
+		expect(result).not.toHaveProperty("description")
 	})
 
-	it("returns undefined for empty string", () => {
-		expect(splitModelRef("")).toBeUndefined()
+	it("preserves existing fields when user selects keep current", async () => {
+		const ctx = createMockCtx({
+			selects: ["keep current (standard)", "keep current (yes)"],
+			inputs: ["Existing description"],
+		})
+		const existing = { tier: "standard" as const, description: "Old desc", vision: true as const }
+		const result = await collectModelMetadata("custom/model", existing, ctx)
+		expect(result).toEqual({
+			tier: "standard",
+			vision: true,
+			description: "Existing description",
+		})
 	})
 
-	it("returns undefined for slash-only string", () => {
-		expect(splitModelRef("/")).toBeUndefined()
+	it("does not include vision when user selects skip and no existing vision", async () => {
+		const ctx = createMockCtx({
+			selects: ["light", "skip"],
+			inputs: ["A light model"],
+		})
+		const result = await collectModelMetadata("custom/model", undefined, ctx)
+		expect(result).toEqual({
+			tier: "light",
+			description: "A light model",
+		})
+		expect(result).not.toHaveProperty("vision")
 	})
 
-	it("returns provider with empty modelId for trailing slash", () => {
-		expect(splitModelRef("provider/")).toEqual({ provider: "provider", modelId: "" })
+	it("includes model ref in select prompts", async () => {
+		const ctx = createMockCtx({
+			selects: ["heavy", "yes"],
+			inputs: ["test"],
+		})
+		await collectModelMetadata("custom/my-model", undefined, ctx)
+		const selectCalls = (ctx.ui.select as ReturnType<typeof vi.fn>).mock.calls
+		expect(selectCalls[0][0]).toContain("custom/my-model")
+		expect(selectCalls[1][0]).toContain("custom/my-model")
+		const inputCalls = (ctx.ui.input as ReturnType<typeof vi.fn>).mock.calls
+		expect(inputCalls[0][0]).toContain("custom/my-model")
 	})
 })

--- a/src/extensions/orchestration/model-roles-command.ts
+++ b/src/extensions/orchestration/model-roles-command.ts
@@ -6,17 +6,25 @@
  * ~/.config/kimchi/harness/settings.json.
  */
 
-import type { ExtensionAPI } from "@earendil-works/pi-coding-agent"
+import type { ExtensionAPI, ExtensionCommandContext, Theme } from "@earendil-works/pi-coding-agent"
+import { Key, type TUI, matchesKey, wrapTextWithAnsi } from "@earendil-works/pi-tui"
+import type { Component } from "@earendil-works/pi-tui"
 import { getAvailableModels } from "../../startup-context.js"
 import { setProcessOrchestratorRef } from "../kimchi-process.js"
+import { withSuppressedModelSelectGuard } from "../model-switch.js"
 import { getMultiModelEnabled } from "../prompt-construction/prompt-enrichment.js"
+import {
+	type ModelCustomMetadata,
+	getModelMetadata,
+	isModelMetadataMissing,
+	resolveModelMetadata,
+	saveModelMetadata,
+} from "./model-metadata.js"
 import { MODEL_CAPABILITIES } from "./model-registry/builtin-models.js"
 import {
-	type CustomModelConfig,
 	DEFAULT_MODEL_ROLES,
 	type ModelRoles,
 	type RoleModelAssignment,
-	extractCustomConfigs,
 	getModelRoles,
 	modelIdFromRef,
 	normalizeRoleModels,
@@ -52,6 +60,20 @@ export function isEqualAssignment(a: RoleModelAssignment, b: RoleModelAssignment
 	return arrA.length === arrB.length && arrA.every((v, i) => v === arrB[i])
 }
 
+export function formatRoleSummaryBlock(role: keyof ModelRoles, value: RoleModelAssignment): string {
+	const info = ROLE_LABELS[role]
+	const models = normalizeRoleModels(value)
+	const isDefault = isEqualAssignment(value, DEFAULT_MODEL_ROLES[role])
+
+	const indent = "    "
+	const modelLines = models.map((ref) => {
+		const suffix = isDefault ? " (default)" : ""
+		return `${indent}${ref}${suffix}`
+	})
+
+	return `${info.label}:\n${modelLines.join("\n")}`
+}
+
 export function formatRoleDisplay(role: keyof ModelRoles, value: RoleModelAssignment): string {
 	const info = ROLE_LABELS[role]
 	const isDefault = isEqualAssignment(value, DEFAULT_MODEL_ROLES[role])
@@ -65,21 +87,199 @@ function hasBuiltinCapability(ref: string): boolean {
 	return entry !== undefined && entry !== "ignored"
 }
 
-function formatMetadataSnippet(ref: string): string {
-	return `\n"modelRoles": {\n  "builder": [\n    "kimchi-dev/minimax-m2.7",\n    {\n      "model": "${ref}",\n      "tier": "heavy",\n      "description": "Describe this model's strengths...",\n      "vision": false\n    }\n  ]\n}\n`
+function shouldPromptForMetadata(ref: string): boolean {
+	if (hasBuiltinCapability(ref)) return false
+	return isModelMetadataMissing(ref)
 }
 
-function findModelRoleEntry(roles: ModelRoles, ref: string): { key: keyof ModelRoles; index: number } | undefined {
-	for (const key of ROLE_KEYS) {
-		const value = roles[key]
-		if (Array.isArray(value)) {
-			const idx = value.findIndex((item) => (typeof item === "string" ? item : item.model) === ref)
-			if (idx !== -1) return { key, index: idx }
-		} else if (typeof value === "string" && value === ref) {
-			return { key, index: 0 }
+export async function collectModelMetadata(
+	ref: string,
+	existing: ModelCustomMetadata | undefined,
+	ctx: ExtensionCommandContext,
+): Promise<ModelCustomMetadata | undefined> {
+	const tierOptions = ["heavy", "standard", "light"]
+	if (existing?.tier) {
+		tierOptions.push(`keep current (${existing.tier})`)
+	} else {
+		tierOptions.push("skip")
+	}
+	const tierChoice = await ctx.ui.select(
+		`${ref}\nSpecifying metadata will improve orchestration.\nTier - what capability level is this model?`,
+		tierOptions,
+	)
+	if (!tierChoice) return undefined
+	const tier = tierChoice.startsWith("keep current")
+		? existing?.tier
+		: tierChoice === "skip"
+			? undefined
+			: (tierChoice as "heavy" | "standard" | "light")
+
+	const visionOptions = ["yes", "no"]
+	if (existing?.vision !== undefined) {
+		visionOptions.push(`keep current (${existing.vision ? "yes" : "no"})`)
+	} else {
+		visionOptions.push("skip")
+	}
+	const visionChoice = await ctx.ui.select(`${ref}\nVision support - can this model process images?`, visionOptions)
+	if (!visionChoice) return undefined
+	const vision = visionChoice.startsWith("keep current")
+		? existing?.vision
+		: visionChoice === "skip"
+			? undefined
+			: visionChoice === "yes"
+
+	const descDefault = existing?.description ?? ""
+	const descInput = await ctx.ui.input(`${ref}\nDescription - when should this model be used? (optional):`, descDefault)
+	if (descInput === undefined) return undefined
+	const description = descInput.trim() || existing?.description || undefined
+
+	const config: ModelCustomMetadata = {}
+	if (tier !== undefined) config.tier = tier
+	if (vision !== undefined) config.vision = vision
+	if (description !== undefined) config.description = description
+	return config
+}
+
+async function promptMetadataWizard(
+	ref: string,
+	ctx: ExtensionCommandContext,
+	configuredThisSession: Set<string>,
+): Promise<void> {
+	if (configuredThisSession.has(ref)) return
+
+	const wizardChoice = await ctx.ui.select(
+		`${ref}\nThis model has no metadata (tier, description, vision).\nSpecifying metadata will improve orchestration.`,
+		["Configure now", "Skip"],
+	)
+	if (wizardChoice !== "Configure now") {
+		configuredThisSession.add(ref)
+		return
+	}
+
+	const metadata = await collectModelMetadata(ref, resolveModelMetadata(ref) ?? undefined, ctx)
+	if (metadata && Object.keys(metadata).length > 0) {
+		const map = new Map<string, ModelCustomMetadata>()
+		map.set(ref, metadata)
+		saveModelMetadata(map)
+		ctx.ui.notify(`Metadata saved for ${ref}.`, "info")
+	}
+	configuredThisSession.add(ref)
+}
+
+// ---------------------------------------------------------------------------
+// Custom toggle-select component (space to toggle, cursor preserved)
+// ---------------------------------------------------------------------------
+
+interface ToggleSelectResult {
+	selected: Set<string>
+	cancelled: boolean
+	addCustom: boolean
+}
+
+function createToggleSelect(
+	tui: TUI,
+	theme: Theme,
+	title: string,
+	refs: string[],
+	selected: Set<string>,
+	done: (result: ToggleSelectResult) => void,
+): Component {
+	let cursorIndex = 0
+	let cachedLines: string[] | undefined
+
+	const ADD_CUSTOM = "Add custom model..."
+	const doneLabel = () => `Done (${selected.size} selected)`
+	const allItems = (): string[] => [...refs, ADD_CUSTOM, doneLabel()]
+
+	function handleInput(data: string): void {
+		const items = allItems()
+
+		if (matchesKey(data, Key.up)) {
+			cursorIndex = (cursorIndex - 1 + items.length) % items.length
+			cachedLines = undefined
+			tui.requestRender()
+			return
+		}
+		if (matchesKey(data, Key.down)) {
+			cursorIndex = (cursorIndex + 1) % items.length
+			cachedLines = undefined
+			tui.requestRender()
+			return
+		}
+		if (data === " ") {
+			if (cursorIndex < refs.length) {
+				const ref = refs[cursorIndex]
+				if (selected.has(ref)) {
+					selected.delete(ref)
+				} else {
+					selected.add(ref)
+				}
+				cachedLines = undefined
+				tui.requestRender()
+			}
+			return
+		}
+		if (matchesKey(data, Key.enter)) {
+			const item = items[cursorIndex]
+			if (item === ADD_CUSTOM) {
+				done({ selected, cancelled: false, addCustom: true })
+				return
+			}
+			done({ selected, cancelled: false, addCustom: false })
+			return
+		}
+		if (matchesKey(data, Key.escape)) {
+			done({ selected, cancelled: true, addCustom: false })
+			return
 		}
 	}
-	return undefined
+
+	function render(width: number): string[] {
+		if (cachedLines) return cachedLines
+
+		const lines: string[] = []
+		const add = (s: string) => {
+			for (const line of wrapTextWithAnsi(s, width)) {
+				lines.push(line)
+			}
+		}
+
+		add(theme.fg("accent", "\u2500".repeat(width)))
+		add(` ${theme.fg("text", theme.bold(title))}`)
+		lines.push("")
+
+		const items = allItems()
+		for (let i = 0; i < items.length; i++) {
+			const isCursor = i === cursorIndex
+			const prefix = isCursor ? theme.fg("accent", "> ") : "  "
+
+			if (i < refs.length) {
+				const ref = refs[i]
+				const checked = selected.has(ref)
+				const box = checked ? "[x]" : "[ ]"
+				const color = isCursor ? "accent" : "text"
+				add(`${prefix}${theme.fg(color, `${box} ${ref}`)}`)
+			} else {
+				const color = isCursor ? "accent" : "text"
+				add(`${prefix}${theme.fg(color, items[i])}`)
+			}
+		}
+
+		lines.push("")
+		add(theme.fg("dim", " \u2191\u2193 navigate  space toggle  enter confirm  esc cancel"))
+		add(theme.fg("accent", "\u2500".repeat(width)))
+
+		cachedLines = lines
+		return lines
+	}
+
+	return {
+		render,
+		invalidate: () => {
+			cachedLines = undefined
+		},
+		handleInput,
+	}
 }
 
 export function registerModelRolesCommand(pi: ExtensionAPI): void {
@@ -92,7 +292,7 @@ export function registerModelRolesCommand(pi: ExtensionAPI): void {
 			}
 
 			const roles = { ...getModelRoles() }
-			const customConfigs = extractCustomConfigs(roles)
+			const configuredThisSession = new Set<string>()
 
 			const apiModels = getAvailableModels()
 			const availableModelRefs = apiModels.map((m) => `kimchi-dev/${m.slug}`)
@@ -106,11 +306,8 @@ export function registerModelRolesCommand(pi: ExtensionAPI): void {
 			}
 
 			const showMainMenu = async (): Promise<void> => {
-				const options = [
-					...ROLE_KEYS.map((key) => formatRoleDisplay(key, roles[key])),
-					"Add metadata to a model...",
-					"Reset all to defaults",
-				]
+				const roleOptions = ROLE_KEYS.map((key) => formatRoleSummaryBlock(key, roles[key]))
+				const options = [...roleOptions, "Edit model metadata...", "Reset all to defaults"]
 
 				const choice = await ctx.ui.select("Model Roles", options)
 				if (!choice) return
@@ -126,14 +323,13 @@ export function registerModelRolesCommand(pi: ExtensionAPI): void {
 					}
 					ctx.ui.notify("Model roles reset to defaults.", "info")
 
-					// Switch the active model only if currently in multi-model mode
 					if (getMultiModelEnabled()) {
 						const parsed = splitModelRef(DEFAULT_MODEL_ROLES.orchestrator)
 						if (parsed) {
 							const target = ctx.modelRegistry?.find(parsed.provider, parsed.modelId)
 							if (target) {
 								try {
-									await pi.setModel(target)
+									await withSuppressedModelSelectGuard(() => pi.setModel(target))
 								} catch {
 									ctx.ui.notify(
 										`Could not switch to ${DEFAULT_MODEL_ROLES.orchestrator}. The model will be used next session.`,
@@ -146,13 +342,13 @@ export function registerModelRolesCommand(pi: ExtensionAPI): void {
 					return
 				}
 
-				if (choice === "Add metadata to a model...") {
+				if (choice === "Edit model metadata...") {
 					await showMetadataEditor()
 					await showMainMenu()
 					return
 				}
 
-				const roleIndex = ROLE_KEYS.findIndex((key) => choice === formatRoleDisplay(key, roles[key]))
+				const roleIndex = ROLE_KEYS.findIndex((key) => choice === formatRoleSummaryBlock(key, roles[key]))
 				if (roleIndex === -1) return
 
 				const roleKey = ROLE_KEYS[roleIndex]
@@ -221,51 +417,46 @@ export function registerModelRolesCommand(pi: ExtensionAPI): void {
 				}
 				ctx.ui.notify(`${info.label} set to ${newRef}`, "info")
 
-				// When the orchestrator role changes and multi-model is active,
-				// switch the active model to the new orchestrator.
 				if (roleKey === "orchestrator" && getMultiModelEnabled()) {
 					const parsed = splitModelRef(newRef)
 					if (parsed) {
 						const target = ctx.modelRegistry?.find(parsed.provider, parsed.modelId)
 						if (target) {
 							try {
-								await pi.setModel(target)
+								await withSuppressedModelSelectGuard(() => pi.setModel(target))
 							} catch {
 								ctx.ui.notify(`Could not switch to ${newRef}. The model will be used next session.`, "warning")
 							}
 						}
 					}
 				}
+
+				if (shouldPromptForMetadata(newRef)) {
+					await promptMetadataWizard(newRef, ctx, configuredThisSession)
+				}
 			}
 
 			const showMultiModelEditor = async (roleKey: keyof ModelRoles): Promise<void> => {
 				const info = ROLE_LABELS[roleKey]
-				const selected = new Set(normalizeRoleModels(roles[roleKey]))
-
-				const buildToggleOptions = (): string[] => {
-					const options = availableModelRefs.map((ref) => {
-						const isSelected = selected.has(ref)
-						const marker = isSelected ? "[x]" : "[ ]"
-						return `${marker} ${ref}`
-					})
-					options.push("Add custom model...")
-					options.push(`Done (${selected.size} selected)`)
-					return options
-				}
+				const previousModels = new Set(normalizeRoleModels(roles[roleKey]))
+				const selected = new Set(previousModels)
 
 				// eslint-disable-next-line no-constant-condition
 				while (true) {
-					const choice = await ctx.ui.select(
-						`${info.label} — toggle models (${selected.size} selected)`,
-						buildToggleOptions(),
+					const result = await ctx.ui.custom<ToggleSelectResult>((tui, theme, _kb, done) =>
+						createToggleSelect(
+							tui,
+							theme,
+							`${info.label} — toggle models (${selected.size} selected)`,
+							availableModelRefs,
+							selected,
+							done,
+						),
 					)
-					if (!choice) return
 
-					if (choice.startsWith("Done")) {
-						break
-					}
+					if (result.cancelled) return
 
-					if (choice === "Add custom model...") {
+					if (result.addCustom) {
 						const input = await ctx.ui.input("Model (provider/model-id):")
 						if (!input?.trim()) continue
 						const ref = input.trim()
@@ -294,12 +485,7 @@ export function registerModelRolesCommand(pi: ExtensionAPI): void {
 						continue
 					}
 
-					const ref = choice.replace(/^\[.\]\s*/, "").replace(/\s*\(.*\)$/, "")
-					if (selected.has(ref)) {
-						selected.delete(ref)
-					} else {
-						selected.add(ref)
-					}
+					break
 				}
 
 				if (selected.size === 0) {
@@ -317,110 +503,65 @@ export function registerModelRolesCommand(pi: ExtensionAPI): void {
 					return
 				}
 				ctx.ui.notify(`${info.label} set to ${models.join(", ")}`, "info")
-				encourageMetadataIfNeeded(models)
-			}
 
-			const encourageMetadataIfNeeded = (models: string[]) => {
-				for (const ref of models) {
-					if (!hasBuiltinCapability(ref) && !customConfigs.has(ref)) {
-						ctx.ui.notify(
-							`Tip: ${ref} has no built-in metadata. Add tier/description in settings.json to help the orchestrator route tasks. ${formatMetadataSnippet(ref)}`,
-							"info",
-						)
+				const newlyAdded = models.filter((ref) => !previousModels.has(ref))
+				for (const ref of newlyAdded) {
+					if (shouldPromptForMetadata(ref)) {
+						await promptMetadataWizard(ref, ctx, configuredThisSession)
 					}
 				}
 			}
 
 			const showMetadataEditor = async (): Promise<void> => {
-				// Collect all unique model refs across all roles
+				const globalMeta = getModelMetadata()
+
 				const seen = new Set<string>()
 				const modelOptions: string[] = []
+
+				for (const ref of globalMeta.keys()) {
+					if (!seen.has(ref)) {
+						seen.add(ref)
+						modelOptions.push(ref)
+					}
+				}
+
 				for (const key of ROLE_KEYS) {
 					for (const ref of normalizeRoleModels(roles[key])) {
 						if (!seen.has(ref)) {
 							seen.add(ref)
-							const config = customConfigs.get(ref)
-							const annotation = config ? " (metadata ✓)" : ""
+							const resolved = resolveModelMetadata(ref)
+							const annotation =
+								resolved?.source === "custom"
+									? ""
+									: resolved?.source === "builtin"
+										? " (default)"
+										: " (missing metadata)"
 							modelOptions.push(`${ref}${annotation}`)
 						}
 					}
 				}
+
 				if (modelOptions.length === 0) {
 					ctx.ui.notify("No models are currently configured.", "warning")
 					return
 				}
 				modelOptions.push("Back")
 
-				const choice = await ctx.ui.select("Choose a model to annotate", modelOptions)
+				const choice = await ctx.ui.select("Choose a model to edit metadata", modelOptions)
 				if (!choice || choice === "Back") return
 
-				const ref = choice.replace(/\s*\(metadata.*\)$/, "")
-				const existing = customConfigs.get(ref)
+				const ref = choice.replace(/\s*\(default\)$/, "").replace(/\s*\(missing metadata\)$/, "")
+				const existing = resolveModelMetadata(ref)
+				const existingMeta: ModelCustomMetadata | undefined = existing
+					? { tier: existing.tier, description: existing.description, vision: existing.vision }
+					: undefined
 
-				// Tier
-				const tierChoice = await ctx.ui.select("Tier", [
-					"heavy",
-					"standard",
-					"light",
-					existing?.tier ? `keep current (${existing.tier})` : "skip",
-				])
-				if (!tierChoice) return
-				const tier = tierChoice.startsWith("keep current")
-					? existing?.tier
-					: tierChoice === "skip"
-						? undefined
-						: (tierChoice as "heavy" | "standard" | "light")
+				const metadata = await collectModelMetadata(ref, existingMeta, ctx)
+				if (!metadata) return
 
-				// Vision
-				const visionChoice = await ctx.ui.select("Vision support", [
-					"yes",
-					"no",
-					existing?.vision !== undefined ? `keep current (${existing.vision ? "yes" : "no"})` : "skip",
-				])
-				if (!visionChoice) return
-				const vision = visionChoice.startsWith("keep current")
-					? existing?.vision
-					: visionChoice === "skip"
-						? undefined
-						: visionChoice === "yes"
-
-				// Description
-				const descDefault = existing?.description ?? ""
-				const descInput = await ctx.ui.input("Description (optional):", descDefault)
-				const description = descInput?.trim() || existing?.description || undefined
-
-				// Build config object, omitting undefined fields
-				const config: CustomModelConfig = { model: ref }
-				if (tier !== undefined) config.tier = tier
-				if (vision !== undefined) config.vision = vision
-				if (description !== undefined) config.description = description
-
-				// Find the first role containing this model and convert to object
-				const location = findModelRoleEntry(roles, ref)
-				if (!location) {
-					ctx.ui.notify(`Could not find ${ref} in any role.`, "error")
-					return
-				}
-
-				const { key, index } = location
-				const value = roles[key]
-				if (Array.isArray(value)) {
-					const item = value[index]
-					if (typeof item === "string") {
-						value[index] = config
-					} else {
-						Object.assign(item, config)
-					}
-				} else if (typeof value === "string") {
-					;(roles as Record<string, RoleModelAssignment>)[key] = config
-				}
-
-				try {
-					saveModelRoles(roles)
-				} catch (err) {
-					ctx.ui.notify(`Failed to save model roles: ${err instanceof Error ? err.message : err}`, "error")
-					return
-				}
+				const map = new Map<string, ModelCustomMetadata>()
+				map.set(ref, metadata)
+				saveModelMetadata(map)
 				ctx.ui.notify(`Metadata saved for ${ref}.`, "info")
 			}
 

--- a/src/extensions/orchestration/model-roles-command.ts
+++ b/src/extensions/orchestration/model-roles-command.ts
@@ -10,10 +10,13 @@ import type { ExtensionAPI } from "@earendil-works/pi-coding-agent"
 import { getAvailableModels } from "../../startup-context.js"
 import { setProcessOrchestratorRef } from "../kimchi-process.js"
 import { getMultiModelEnabled } from "../prompt-construction/prompt-enrichment.js"
+import { MODEL_CAPABILITIES } from "./model-registry/builtin-models.js"
 import {
+	type CustomModelConfig,
 	DEFAULT_MODEL_ROLES,
 	type ModelRoles,
 	type RoleModelAssignment,
+	extractCustomConfigs,
 	getModelRoles,
 	modelIdFromRef,
 	normalizeRoleModels,
@@ -56,6 +59,29 @@ export function formatRoleDisplay(role: keyof ModelRoles, value: RoleModelAssign
 	return `${info.label}: ${formatRoleAssignment(value)}${suffix}`
 }
 
+function hasBuiltinCapability(ref: string): boolean {
+	const id = modelIdFromRef(ref)
+	const entry = MODEL_CAPABILITIES.get(id)
+	return entry !== undefined && entry !== "ignored"
+}
+
+function formatMetadataSnippet(ref: string): string {
+	return `\n"modelRoles": {\n  "builder": [\n    "kimchi-dev/minimax-m2.7",\n    {\n      "model": "${ref}",\n      "tier": "heavy",\n      "description": "Describe this model's strengths...",\n      "vision": false\n    }\n  ]\n}\n`
+}
+
+function findModelRoleEntry(roles: ModelRoles, ref: string): { key: keyof ModelRoles; index: number } | undefined {
+	for (const key of ROLE_KEYS) {
+		const value = roles[key]
+		if (Array.isArray(value)) {
+			const idx = value.findIndex((item) => (typeof item === "string" ? item : item.model) === ref)
+			if (idx !== -1) return { key, index: idx }
+		} else if (typeof value === "string" && value === ref) {
+			return { key, index: 0 }
+		}
+	}
+	return undefined
+}
+
 export function registerModelRolesCommand(pi: ExtensionAPI): void {
 	pi.registerCommand("multi-model", {
 		description: "Configure model roles (orchestrator, planner, builder, reviewer, explorer, judge)",
@@ -66,6 +92,7 @@ export function registerModelRolesCommand(pi: ExtensionAPI): void {
 			}
 
 			const roles = { ...getModelRoles() }
+			const customConfigs = extractCustomConfigs(roles)
 
 			const apiModels = getAvailableModels()
 			const availableModelRefs = apiModels.map((m) => `kimchi-dev/${m.slug}`)
@@ -79,7 +106,11 @@ export function registerModelRolesCommand(pi: ExtensionAPI): void {
 			}
 
 			const showMainMenu = async (): Promise<void> => {
-				const options = [...ROLE_KEYS.map((key) => formatRoleDisplay(key, roles[key])), "Reset all to defaults"]
+				const options = [
+					...ROLE_KEYS.map((key) => formatRoleDisplay(key, roles[key])),
+					"Add metadata to a model...",
+					"Reset all to defaults",
+				]
 
 				const choice = await ctx.ui.select("Model Roles", options)
 				if (!choice) return
@@ -112,6 +143,12 @@ export function registerModelRolesCommand(pi: ExtensionAPI): void {
 							}
 						}
 					}
+					return
+				}
+
+				if (choice === "Add metadata to a model...") {
+					await showMetadataEditor()
+					await showMainMenu()
 					return
 				}
 
@@ -280,6 +317,111 @@ export function registerModelRolesCommand(pi: ExtensionAPI): void {
 					return
 				}
 				ctx.ui.notify(`${info.label} set to ${models.join(", ")}`, "info")
+				encourageMetadataIfNeeded(models)
+			}
+
+			const encourageMetadataIfNeeded = (models: string[]) => {
+				for (const ref of models) {
+					if (!hasBuiltinCapability(ref) && !customConfigs.has(ref)) {
+						ctx.ui.notify(
+							`Tip: ${ref} has no built-in metadata. Add tier/description in settings.json to help the orchestrator route tasks. ${formatMetadataSnippet(ref)}`,
+							"info",
+						)
+					}
+				}
+			}
+
+			const showMetadataEditor = async (): Promise<void> => {
+				// Collect all unique model refs across all roles
+				const seen = new Set<string>()
+				const modelOptions: string[] = []
+				for (const key of ROLE_KEYS) {
+					for (const ref of normalizeRoleModels(roles[key])) {
+						if (!seen.has(ref)) {
+							seen.add(ref)
+							const config = customConfigs.get(ref)
+							const annotation = config ? " (metadata ✓)" : ""
+							modelOptions.push(`${ref}${annotation}`)
+						}
+					}
+				}
+				if (modelOptions.length === 0) {
+					ctx.ui.notify("No models are currently configured.", "warning")
+					return
+				}
+				modelOptions.push("Back")
+
+				const choice = await ctx.ui.select("Choose a model to annotate", modelOptions)
+				if (!choice || choice === "Back") return
+
+				const ref = choice.replace(/\s*\(metadata.*\)$/, "")
+				const existing = customConfigs.get(ref)
+
+				// Tier
+				const tierChoice = await ctx.ui.select("Tier", [
+					"heavy",
+					"standard",
+					"light",
+					existing?.tier ? `keep current (${existing.tier})` : "skip",
+				])
+				if (!tierChoice) return
+				const tier = tierChoice.startsWith("keep current")
+					? existing?.tier
+					: tierChoice === "skip"
+						? undefined
+						: (tierChoice as "heavy" | "standard" | "light")
+
+				// Vision
+				const visionChoice = await ctx.ui.select("Vision support", [
+					"yes",
+					"no",
+					existing?.vision !== undefined ? `keep current (${existing.vision ? "yes" : "no"})` : "skip",
+				])
+				if (!visionChoice) return
+				const vision = visionChoice.startsWith("keep current")
+					? existing?.vision
+					: visionChoice === "skip"
+						? undefined
+						: visionChoice === "yes"
+
+				// Description
+				const descDefault = existing?.description ?? ""
+				const descInput = await ctx.ui.input("Description (optional):", descDefault)
+				const description = descInput?.trim() || existing?.description || undefined
+
+				// Build config object, omitting undefined fields
+				const config: CustomModelConfig = { model: ref }
+				if (tier !== undefined) config.tier = tier
+				if (vision !== undefined) config.vision = vision
+				if (description !== undefined) config.description = description
+
+				// Find the first role containing this model and convert to object
+				const location = findModelRoleEntry(roles, ref)
+				if (!location) {
+					ctx.ui.notify(`Could not find ${ref} in any role.`, "error")
+					return
+				}
+
+				const { key, index } = location
+				const value = roles[key]
+				if (Array.isArray(value)) {
+					const item = value[index]
+					if (typeof item === "string") {
+						value[index] = config
+					} else {
+						Object.assign(item, config)
+					}
+				} else if (typeof value === "string") {
+					;(roles as Record<string, RoleModelAssignment>)[key] = config
+				}
+
+				try {
+					saveModelRoles(roles)
+				} catch (err) {
+					ctx.ui.notify(`Failed to save model roles: ${err instanceof Error ? err.message : err}`, "error")
+					return
+				}
+				ctx.ui.notify(`Metadata saved for ${ref}.`, "info")
 			}
 
 			await showMainMenu()

--- a/src/extensions/orchestration/model-roles-command.ts
+++ b/src/extensions/orchestration/model-roles-command.ts
@@ -15,6 +15,7 @@ import { withSuppressedModelSelectGuard } from "../model-switch.js"
 import { getMultiModelEnabled } from "../prompt-construction/prompt-enrichment.js"
 import {
 	type ModelCustomMetadata,
+	deleteModelMetadata,
 	getModelMetadata,
 	isModelMetadataMissing,
 	resolveModelMetadata,
@@ -555,6 +556,17 @@ export function registerModelRolesCommand(pi: ExtensionAPI): void {
 				const existingMeta: ModelCustomMetadata | undefined = existing
 					? { tier: existing.tier, description: existing.description, vision: existing.vision }
 					: undefined
+
+				const hasCustomOverride = existing?.source === "custom"
+				const actionOptions = hasCustomOverride ? ["Edit", "Reset to defaults", "Cancel"] : ["Edit", "Cancel"]
+				const action = await ctx.ui.select(`${ref} — metadata`, actionOptions)
+				if (!action || action === "Cancel") return
+
+				if (action === "Reset to defaults") {
+					deleteModelMetadata(ref)
+					ctx.ui.notify(`Custom metadata removed for ${ref}.`, "info")
+					return
+				}
 
 				const metadata = await collectModelMetadata(ref, existingMeta, ctx)
 				if (!metadata) return

--- a/src/extensions/orchestration/model-roles-command.ts
+++ b/src/extensions/orchestration/model-roles-command.ts
@@ -42,11 +42,12 @@ const ROLE_LABELS: Record<keyof ModelRoles, { label: string; description: string
 	planner: { label: "Planner", description: "designs the approach, writes specs" },
 	builder: { label: "Builder", description: "code implementation" },
 	reviewer: { label: "Reviewer", description: "code review" },
-	explorer: { label: "Explorer", description: "codebase exploration, research" },
+	explorer: { label: "Explorer", description: "codebase exploration" },
+	researcher: { label: "Researcher", description: "research beyond codebase, web search" },
 	judge: { label: "Judge", description: "ferment verification and grading" },
 }
 
-const DELEGABLE_KEYS: (keyof ModelRoles)[] = ["planner", "builder", "reviewer", "explorer", "judge"]
+const DELEGABLE_KEYS: (keyof ModelRoles)[] = ["planner", "builder", "reviewer", "explorer", "researcher", "judge"]
 
 const ROLE_KEYS: (keyof ModelRoles)[] = ["orchestrator", ...DELEGABLE_KEYS]
 
@@ -285,7 +286,7 @@ function createToggleSelect(
 
 export function registerModelRolesCommand(pi: ExtensionAPI): void {
 	pi.registerCommand("multi-model", {
-		description: "Configure model roles (orchestrator, planner, builder, reviewer, explorer, judge)",
+		description: "Configure model roles (orchestrator, planner, builder, reviewer, explorer, researcher, judge)",
 		async handler(_args, ctx) {
 			if (!ctx.hasUI) {
 				ctx.ui.notify("Model roles configuration requires an interactive session.", "warning")

--- a/src/extensions/orchestration/model-roles-command.ts
+++ b/src/extensions/orchestration/model-roles-command.ts
@@ -13,6 +13,8 @@ import { getAvailableModels } from "../../startup-context.js"
 import { setProcessOrchestratorRef } from "../kimchi-process.js"
 import { withSuppressedModelSelectGuard } from "../model-switch.js"
 import { getMultiModelEnabled } from "../prompt-construction/prompt-enrichment.js"
+import { type QuestionFormResult, createQuestionForm } from "../questionnaire-form.js"
+import { type Question, YES_NO_OPTIONS } from "../questionnaire-reducer.js"
 import {
 	type ModelCustomMetadata,
 	deleteModelMetadata,
@@ -110,46 +112,91 @@ export async function collectModelMetadata(
 	existing: ModelCustomMetadata | undefined,
 	ctx: ExtensionCommandContext,
 ): Promise<ModelCustomMetadata | undefined> {
-	const tierOptions = ["heavy", "standard", "light"]
-	if (existing?.tier) {
-		tierOptions.push(`keep current (${existing.tier})`)
-	} else {
-		tierOptions.push("skip")
-	}
-	const tierChoice = await ctx.ui.select(
-		`${ref}\nSpecifying metadata will improve orchestration.\nTier - what capability level is this model?`,
-		tierOptions,
+	// Sentinel option id for "leave this field as it currently is". When no
+	// `existing` value is present the label collapses to plain "skip" so the
+	// option reads naturally in both edit and create flows. A user picking
+	// this option preserves whatever value is already in settings.json (or
+	// leaves the field unset for create flows).
+	const keepTierLabel = existing?.tier ? `keep current (${existing.tier})` : "skip"
+	const keepVisionLabel = existing?.vision !== undefined ? `keep current (${existing.vision ? "yes" : "no"})` : "skip"
+
+	const questions: Question[] = [
+		{
+			id: "tier",
+			label: "Tier",
+			prompt: `${ref}\nTier — what capability level is this model?`,
+			type: "single",
+			options: [
+				{ id: "heavy", label: "heavy" },
+				{ id: "standard", label: "standard" },
+				{ id: "light", label: "light" },
+				{ id: "__keep__", label: keepTierLabel },
+			],
+			allowOther: false,
+			required: false,
+		},
+		{
+			id: "vision",
+			label: "Vision",
+			prompt: `${ref}\nVision support — can this model process images?`,
+			type: "single",
+			options: [
+				...YES_NO_OPTIONS.map((o) => ({ id: o.id, label: o.label })),
+				{ id: "__keep__", label: keepVisionLabel },
+			],
+			allowOther: false,
+			required: false,
+		},
+		{
+			id: "description",
+			label: "Description",
+			prompt: `${ref}\nDescription — when should this model be used? (optional, leave blank to keep current)`,
+			type: "text",
+			options: [],
+			allowOther: false,
+			required: false,
+		},
+	]
+
+	const result = await ctx.ui.custom<QuestionFormResult>((tui, theme, _kb, done) =>
+		createQuestionForm(tui, theme, questions, { title: ref }, done),
 	)
-	if (!tierChoice) return undefined
-	const tier = tierChoice.startsWith("keep current")
-		? existing?.tier
-		: tierChoice === "skip"
-			? undefined
-			: (tierChoice as "heavy" | "standard" | "light")
+	if (result.cancelled) return undefined
 
-	const visionOptions = ["yes", "no"]
-	if (existing?.vision !== undefined) {
-		visionOptions.push(`keep current (${existing.vision ? "yes" : "no"})`)
-	} else {
-		visionOptions.push("skip")
-	}
-	const visionChoice = await ctx.ui.select(`${ref}\nVision support - can this model process images?`, visionOptions)
-	if (!visionChoice) return undefined
-	const vision = visionChoice.startsWith("keep current")
-		? existing?.vision
-		: visionChoice === "skip"
-			? undefined
-			: visionChoice === "yes"
-
-	const descDefault = existing?.description ?? ""
-	const descInput = await ctx.ui.input(`${ref}\nDescription - when should this model be used? (optional):`, descDefault)
-	if (descInput === undefined) return undefined
-	const description = descInput.trim() || existing?.description || undefined
-
+	const byId = new Map(result.answers.map((a) => [a.id, a]))
 	const config: ModelCustomMetadata = {}
-	if (tier !== undefined) config.tier = tier
-	if (vision !== undefined) config.vision = vision
-	if (description !== undefined) config.description = description
+
+	const tierAnswer = byId.get("tier")
+	if (tierAnswer) {
+		if (tierAnswer.value === "__keep__") {
+			// User picked "keep current" / "skip" — only carry the existing tier
+			// forward if there is one to carry.
+			if (existing?.tier !== undefined) config.tier = existing.tier
+		} else {
+			config.tier = tierAnswer.value as "heavy" | "standard" | "light"
+		}
+	}
+
+	const visionAnswer = byId.get("vision")
+	if (visionAnswer) {
+		if (visionAnswer.value === "__keep__") {
+			if (existing?.vision !== undefined) config.vision = existing.vision
+		} else {
+			config.vision = visionAnswer.value === "yes"
+		}
+	}
+
+	const descAnswer = byId.get("description")
+	// The text-question reducer records "(no response)" when the user submits
+	// an empty editor; treat that the same as "no answer recorded" so an
+	// existing description is preserved unless the user types a replacement.
+	const explicitDescription = descAnswer?.value && descAnswer.value !== "(no response)" ? descAnswer.value : undefined
+	if (explicitDescription !== undefined) {
+		config.description = explicitDescription
+	} else if (existing?.description) {
+		config.description = existing.description
+	}
+
 	return config
 }
 

--- a/src/extensions/orchestration/model-roles-command.ts
+++ b/src/extensions/orchestration/model-roles-command.ts
@@ -51,6 +51,17 @@ const DELEGABLE_KEYS: (keyof ModelRoles)[] = ["planner", "builder", "reviewer", 
 
 const ROLE_KEYS: (keyof ModelRoles)[] = ["orchestrator", ...DELEGABLE_KEYS]
 
+/**
+ * Whether `collectModelMetadata()` produced something worth persisting.
+ *
+ * Returns false for both `undefined` (user cancelled) and `{}` (user completed
+ * the form but skipped every optional field). Saving an empty entry would
+ * clutter settings.json with rows that `resolveModelMetadata()` ignores.
+ */
+export function hasMetadataContent(metadata: ModelCustomMetadata | undefined): metadata is ModelCustomMetadata {
+	return metadata !== undefined && Object.keys(metadata).length > 0
+}
+
 export function formatRoleAssignment(value: RoleModelAssignment): string {
 	const models = normalizeRoleModels(value)
 	return models.join(", ")
@@ -159,7 +170,7 @@ async function promptMetadataWizard(
 	}
 
 	const metadata = await collectModelMetadata(ref, resolveModelMetadata(ref) ?? undefined, ctx)
-	if (metadata && Object.keys(metadata).length > 0) {
+	if (hasMetadataContent(metadata)) {
 		const map = new Map<string, ModelCustomMetadata>()
 		map.set(ref, metadata)
 		saveModelMetadata(map)
@@ -570,7 +581,10 @@ export function registerModelRolesCommand(pi: ExtensionAPI): void {
 				}
 
 				const metadata = await collectModelMetadata(ref, existingMeta, ctx)
-				if (!metadata) return
+				if (!hasMetadataContent(metadata)) {
+					ctx.ui.notify(`No metadata saved for ${ref}.`, "info")
+					return
+				}
 
 				const map = new Map<string, ModelCustomMetadata>()
 				map.set(ref, metadata)

--- a/src/extensions/orchestration/model-roles.test.ts
+++ b/src/extensions/orchestration/model-roles.test.ts
@@ -67,6 +67,7 @@ describe("parseModelRoles", () => {
 			builder: "anthropic/claude-sonnet-4-5",
 			reviewer: "openai/gpt-4o",
 			explorer: "kimchi-dev/nemotron-3-ultra-fp4",
+			researcher: "kimchi-dev/nemotron-3-ultra-fp4",
 			judge: "kimchi-dev/claude-opus-4-6",
 		}
 		const { roles } = parseModelRoles(custom)
@@ -321,6 +322,7 @@ describe("validateModelRoles", () => {
 			builder: "anthropic/claude-sonnet-4-5",
 			reviewer: "kimchi-dev/minimax-m2.7",
 			explorer: "google/gemini-pro",
+			researcher: "kimchi-dev/nemotron-3-ultra-fp4",
 			judge: "kimchi-dev/kimi-k2.6",
 		}
 		const result = validateModelRoles(roles, available)
@@ -346,7 +348,9 @@ describe("validateModelRoles", () => {
 		const result = validateModelRoles(DEFAULT_MODEL_ROLES, new Set())
 		expect(result.unavailable.length).toBeGreaterThanOrEqual(5)
 		const flaggedRoles = new Set(result.unavailable.map((u) => u.role))
-		expect(flaggedRoles).toEqual(new Set(["orchestrator", "planner", "builder", "reviewer", "explorer", "judge"]))
+		expect(flaggedRoles).toEqual(
+			new Set(["orchestrator", "planner", "builder", "reviewer", "explorer", "researcher", "judge"]),
+		)
 	})
 })
 

--- a/src/extensions/orchestration/model-roles.test.ts
+++ b/src/extensions/orchestration/model-roles.test.ts
@@ -2,6 +2,7 @@ import { existsSync, mkdirSync, readFileSync, rmSync, writeFileSync } from "node
 import { tmpdir } from "node:os"
 import { join } from "node:path"
 import { afterEach, describe, expect, it } from "vitest"
+import { loadModelMetadata, resetModelMetadataCache } from "./model-metadata.js"
 import {
 	type CustomModelConfig,
 	DEFAULT_MODEL_ROLES,
@@ -18,6 +19,7 @@ import {
 
 afterEach(() => {
 	resetModelRolesCache()
+	resetModelMetadataCache()
 })
 
 describe("parseModelRoles", () => {
@@ -444,22 +446,23 @@ describe("normalizeRoleModels with CustomModelConfig", () => {
 })
 
 describe("extractCustomConfigs", () => {
-	it("returns empty map when no custom configs present", () => {
+	it("returns empty map when no custom configs present and no overrides", () => {
 		const roles: ModelRoles = {
 			...DEFAULT_MODEL_ROLES,
 			builder: "kimchi-dev/minimax-m2.7",
 			planner: "kimchi-dev/kimi-k2.6",
 		}
-		const result = extractCustomConfigs(roles)
+		// Pass empty overrides to avoid relying on global cache state
+		const result = extractCustomConfigs(roles, new Map())
 		expect(result.size).toBe(0)
 	})
 
-	it("extracts single custom config from a role", () => {
+	it("extracts single custom config from a role (embedded only, no overrides)", () => {
 		const roles: ModelRoles = {
 			...DEFAULT_MODEL_ROLES,
 			planner: { model: "anthropic/claude-opus-4-6", tier: "heavy" },
 		}
-		const result = extractCustomConfigs(roles)
+		const result = extractCustomConfigs(roles, new Map())
 		expect(result.size).toBe(1)
 		expect(result.get("anthropic/claude-opus-4-6")).toEqual({
 			model: "anthropic/claude-opus-4-6",
@@ -467,7 +470,7 @@ describe("extractCustomConfigs", () => {
 		})
 	})
 
-	it("extracts multiple custom configs from a role array", () => {
+	it("extracts multiple custom configs from a role array (embedded only)", () => {
 		const roles: ModelRoles = {
 			...DEFAULT_MODEL_ROLES,
 			planner: [
@@ -476,7 +479,7 @@ describe("extractCustomConfigs", () => {
 				{ model: "openai/gpt-4o", tier: "standard" },
 			],
 		}
-		const result = extractCustomConfigs(roles)
+		const result = extractCustomConfigs(roles, new Map())
 		expect(result.size).toBe(2)
 		expect(result.get("anthropic/claude-opus-4-6")).toEqual({
 			model: "anthropic/claude-opus-4-6",
@@ -486,28 +489,82 @@ describe("extractCustomConfigs", () => {
 		expect(result.get("openai/gpt-4o")).toEqual({ model: "openai/gpt-4o", tier: "standard" })
 	})
 
-	it("extracts configs from multiple roles", () => {
+	it("extracts configs from multiple roles (embedded only)", () => {
 		const roles: ModelRoles = {
 			...DEFAULT_MODEL_ROLES,
 			planner: { model: "anthropic/claude-opus-4-6", tier: "heavy" },
 			builder: { model: "openai/gpt-4o", tier: "standard" },
 		}
-		const result = extractCustomConfigs(roles)
+		const result = extractCustomConfigs(roles, new Map())
 		expect(result.size).toBe(2)
 	})
 
-	it("last-wins when same model ref appears in multiple roles", () => {
+	it("last-wins when same model ref appears in multiple roles (embedded only)", () => {
 		const roles: ModelRoles = {
 			...DEFAULT_MODEL_ROLES,
 			planner: { model: "anthropic/claude-opus-4-6", tier: "heavy", description: "Planner description" },
 			builder: { model: "anthropic/claude-opus-4-6", tier: "standard", description: "Builder description" },
 		}
-		const result = extractCustomConfigs(roles)
+		const result = extractCustomConfigs(roles, new Map())
 		expect(result.size).toBe(1)
 		expect(result.get("anthropic/claude-opus-4-6")).toEqual({
 			model: "anthropic/claude-opus-4-6",
 			tier: "standard",
 			description: "Builder description",
+		})
+	})
+
+	it("returns global metadata when no embedded objects present", () => {
+		const roles: ModelRoles = {
+			...DEFAULT_MODEL_ROLES,
+			builder: "anthropic/claude-sonnet-4-5",
+		}
+		const globalOverrides = new Map<string, { tier?: "heavy"; description?: string }>([
+			["anthropic/claude-sonnet-4-5", { tier: "heavy", description: "From global store" }],
+		])
+		const result = extractCustomConfigs(roles, globalOverrides)
+		expect(result.size).toBe(1)
+		expect(result.get("anthropic/claude-sonnet-4-5")).toEqual({
+			model: "anthropic/claude-sonnet-4-5",
+			tier: "heavy",
+			description: "From global store",
+		})
+	})
+
+	it("global metadata wins over embedded objects for same model ref", () => {
+		const roles: ModelRoles = {
+			...DEFAULT_MODEL_ROLES,
+			planner: { model: "anthropic/claude-opus-4-6", tier: "heavy", description: "Embedded" },
+		}
+		const globalOverrides = new Map<string, { tier?: "standard"; description?: string }>([
+			["anthropic/claude-opus-4-6", { tier: "standard", description: "From global" }],
+		])
+		const result = extractCustomConfigs(roles, globalOverrides)
+		expect(result.size).toBe(1)
+		expect(result.get("anthropic/claude-opus-4-6")).toEqual({
+			model: "anthropic/claude-opus-4-6",
+			tier: "standard",
+			description: "From global",
+		})
+	})
+
+	it("embedded objects included when model ref is not in global metadata", () => {
+		const roles: ModelRoles = {
+			...DEFAULT_MODEL_ROLES,
+			planner: { model: "anthropic/claude-opus-4-6", tier: "heavy", description: "Embedded only" },
+			builder: "openai/gpt-4o",
+		}
+		const globalOverrides = new Map<string, { tier?: "standard" }>([["openai/gpt-4o", { tier: "standard" }]])
+		const result = extractCustomConfigs(roles, globalOverrides)
+		expect(result.size).toBe(2)
+		expect(result.get("anthropic/claude-opus-4-6")).toEqual({
+			model: "anthropic/claude-opus-4-6",
+			tier: "heavy",
+			description: "Embedded only",
+		})
+		expect(result.get("openai/gpt-4o")).toEqual({
+			model: "openai/gpt-4o",
+			tier: "standard",
 		})
 	})
 })
@@ -558,7 +615,7 @@ describe("saveModelRoles with CustomModelConfig", () => {
 		} catch {}
 	})
 
-	it("saves CustomModelConfig object and reads it back", () => {
+	it("extracts metadata and saves to modelMetadata, saves strings to modelRoles", () => {
 		const custom: CustomModelConfig = {
 			model: "anthropic/claude-opus-4-6",
 			tier: "heavy",
@@ -571,17 +628,82 @@ describe("saveModelRoles with CustomModelConfig", () => {
 		}
 		saveModelRoles(roles, testPath)
 		const saved = JSON.parse(readFileSync(testPath, "utf-8"))
-		expect(saved.modelRoles.planner).toEqual(custom)
+		// modelRoles should have the string ref, not the object
+		expect(saved.modelRoles.planner).toBe("anthropic/claude-opus-4-6")
+		// metadata should be in modelMetadata
+		expect(saved.modelMetadata).toBeDefined()
+		expect(saved.modelMetadata["anthropic/claude-opus-4-6"]).toEqual({
+			tier: "heavy",
+			description: "Anthropic's flagship.",
+			vision: false,
+		})
 	})
 
-	it("saves mixed string/object array and reads it back", () => {
+	it("extracts metadata from mixed string/object array", () => {
 		const roles: ModelRoles = {
 			...DEFAULT_MODEL_ROLES,
 			planner: ["kimchi-dev/kimi-k2.6", { model: "anthropic/claude-opus-4-6", tier: "heavy" }],
 		}
 		saveModelRoles(roles, testPath)
 		const saved = JSON.parse(readFileSync(testPath, "utf-8"))
+		// First element stays as string
 		expect(saved.modelRoles.planner[0]).toBe("kimchi-dev/kimi-k2.6")
-		expect(saved.modelRoles.planner[1]).toEqual({ model: "anthropic/claude-opus-4-6", tier: "heavy" })
+		// Second element is converted to string ref
+		expect(saved.modelRoles.planner[1]).toBe("anthropic/claude-opus-4-6")
+		// metadata extracted for the object
+		expect(saved.modelMetadata["anthropic/claude-opus-4-6"]).toEqual({ tier: "heavy" })
+	})
+
+	it("round-trip: save with objects, read back with parseModelRoles and loadModelMetadata", () => {
+		const roles: ModelRoles = {
+			...DEFAULT_MODEL_ROLES,
+			planner: ["kimchi-dev/kimi-k2.6", { model: "anthropic/claude-opus-4-6", tier: "heavy", description: "Test" }],
+			builder: { model: "openai/gpt-4o", tier: "standard" },
+		}
+		saveModelRoles(roles, testPath)
+
+		// Read back modelRoles (should be strings now)
+		const saved = JSON.parse(readFileSync(testPath, "utf-8"))
+		const { roles: parsedRoles } = parseModelRoles(saved.modelRoles)
+		// Verify planner has string refs
+		expect(parsedRoles.planner).toEqual(["kimchi-dev/kimi-k2.6", "anthropic/claude-opus-4-6"])
+		// Verify builder is just string
+		expect(parsedRoles.builder).toBe("openai/gpt-4o")
+
+		// Read back modelMetadata
+		const metadata = loadModelMetadata(testPath)
+		expect(metadata.get("anthropic/claude-opus-4-6")).toEqual({ tier: "heavy", description: "Test" })
+		expect(metadata.get("openai/gpt-4o")).toEqual({ tier: "standard" })
+	})
+
+	it("saves string-only roles as before (backwards compat)", () => {
+		const roles: ModelRoles = {
+			...DEFAULT_MODEL_ROLES,
+			builder: "anthropic/claude-sonnet-4-5",
+		}
+		saveModelRoles(roles, testPath)
+		const saved = JSON.parse(readFileSync(testPath, "utf-8"))
+		expect(saved.modelRoles.builder).toBe("anthropic/claude-sonnet-4-5")
+		expect(saved.modelMetadata).toBeUndefined()
+	})
+
+	it("preserves existing modelMetadata when saving string-only roles", () => {
+		const rolesWithMeta: ModelRoles = {
+			...DEFAULT_MODEL_ROLES,
+			planner: { model: "anthropic/claude-opus-4-6", tier: "heavy" },
+		}
+		saveModelRoles(rolesWithMeta, testPath)
+
+		let saved = JSON.parse(readFileSync(testPath, "utf-8"))
+		expect(saved.modelMetadata).toBeDefined()
+
+		const rolesNoMeta: ModelRoles = {
+			...DEFAULT_MODEL_ROLES,
+			builder: "openai/gpt-4o",
+		}
+		saveModelRoles(rolesNoMeta, testPath)
+
+		saved = JSON.parse(readFileSync(testPath, "utf-8"))
+		expect(saved.modelMetadata["anthropic/claude-opus-4-6"]).toEqual({ tier: "heavy" })
 	})
 })

--- a/src/extensions/orchestration/model-roles.test.ts
+++ b/src/extensions/orchestration/model-roles.test.ts
@@ -2,9 +2,13 @@ import { existsSync, mkdirSync, readFileSync, rmSync, writeFileSync } from "node
 import { tmpdir } from "node:os"
 import { join } from "node:path"
 import { afterEach, describe, expect, it } from "vitest"
-import { loadModelMetadata, resetModelMetadataCache } from "./model-metadata.js"
 import {
-	type CustomModelConfig,
+	type ModelCustomMetadata,
+	loadModelMetadata,
+	resetModelMetadataCache,
+	saveModelMetadata,
+} from "./model-metadata.js"
+import {
 	DEFAULT_MODEL_ROLES,
 	type ModelRoles,
 	extractCustomConfigs,
@@ -346,266 +350,51 @@ describe("validateModelRoles", () => {
 	})
 })
 
-describe("parseModelRoles with CustomModelConfig objects", () => {
-	it("accepts a single CustomModelConfig object for a delegable role", () => {
-		const custom: CustomModelConfig = {
-			model: "anthropic/claude-opus-4-6",
-			tier: "heavy",
-			description: "Anthropic's flagship model.",
-			vision: false,
-		}
-		const { roles, warnings } = parseModelRoles({ planner: custom })
-		expect(roles.planner).toEqual(custom)
-		expect(warnings).toHaveLength(0)
-	})
-
-	it("accepts a mixed array of strings and CustomModelConfig objects", () => {
+describe("parseModelRoles rejects objects", () => {
+	it("warns on object value for a delegable role", () => {
 		const { roles, warnings } = parseModelRoles({
-			planner: [
-				"kimchi-dev/kimi-k2.6",
-				{
-					model: "anthropic/claude-opus-4-6",
-					tier: "heavy",
-					description: "Anthropic's flagship model.",
-				},
-			],
-		})
-		expect(Array.isArray(roles.planner)).toBe(true)
-		expect((roles.planner as (string | CustomModelConfig)[])[0]).toBe("kimchi-dev/kimi-k2.6")
-		expect(((roles.planner as (string | CustomModelConfig)[])[1] as CustomModelConfig).model).toBe(
-			"anthropic/claude-opus-4-6",
-		)
-		expect(warnings).toHaveLength(0)
-	})
-
-	it("accepts CustomModelConfig with only model field", () => {
-		const { roles, warnings } = parseModelRoles({
-			builder: { model: "anthropic/claude-sonnet-4-5" },
-		})
-		expect((roles.builder as CustomModelConfig).model).toBe("anthropic/claude-sonnet-4-5")
-		expect(warnings).toHaveLength(0)
-	})
-
-	it("warns on object with missing model field", () => {
-		const { roles, warnings } = parseModelRoles({
-			builder: { tier: "heavy" } as unknown as CustomModelConfig,
+			builder: { model: "anthropic/claude-sonnet-4-5", tier: "heavy" },
 		})
 		expect(roles.builder).toBe(DEFAULT_MODEL_ROLES.builder)
 		expect(warnings).toHaveLength(1)
 		expect(warnings[0].role).toBe("builder")
 	})
 
-	it("warns on object with empty model string", () => {
+	it("warns on array containing objects", () => {
 		const { roles, warnings } = parseModelRoles({
-			builder: { model: "   " },
-		})
-		expect(roles.builder).toBe(DEFAULT_MODEL_ROLES.builder)
-		expect(warnings).toHaveLength(1)
-		expect(warnings[0].role).toBe("builder")
-	})
-
-	it("warns on array with invalid object entry", () => {
-		const { roles, warnings } = parseModelRoles({
-			planner: ["kimchi-dev/kimi-k2.6", { tier: "heavy" }],
+			planner: ["kimchi-dev/kimi-k2.6", { model: "anthropic/claude-opus-4-6" }],
 		})
 		expect(roles.planner).toBe(DEFAULT_MODEL_ROLES.planner)
 		expect(warnings).toHaveLength(1)
 		expect(warnings[0].role).toBe("planner")
 	})
-
-	it("trims whitespace from model field in custom config", () => {
-		const { roles } = parseModelRoles({
-			builder: { model: "  anthropic/claude-sonnet-4-5  " },
-		})
-		expect((roles.builder as CustomModelConfig).model).toBe("anthropic/claude-sonnet-4-5")
-	})
-})
-
-describe("normalizeRoleModels with CustomModelConfig", () => {
-	it("extracts model ref from a single CustomModelConfig object", () => {
-		const config: CustomModelConfig = { model: "anthropic/claude-opus-4-6", tier: "heavy" }
-		expect(normalizeRoleModels(config)).toEqual(["anthropic/claude-opus-4-6"])
-	})
-
-	it("extracts model refs from mixed string/object array", () => {
-		const mixed: (string | CustomModelConfig)[] = [
-			"kimchi-dev/kimi-k2.6",
-			{ model: "anthropic/claude-opus-4-6", tier: "heavy" },
-			"openai/gpt-4o",
-		]
-		expect(normalizeRoleModels(mixed)).toEqual(["kimchi-dev/kimi-k2.6", "anthropic/claude-opus-4-6", "openai/gpt-4o"])
-	})
-
-	it("still works with plain string", () => {
-		expect(normalizeRoleModels("kimchi-dev/kimi-k2.6")).toEqual(["kimchi-dev/kimi-k2.6"])
-	})
-
-	it("still works with string array", () => {
-		expect(normalizeRoleModels(["a", "b"])).toEqual(["a", "b"])
-	})
 })
 
 describe("extractCustomConfigs", () => {
-	it("returns empty map when no custom configs present and no overrides", () => {
+	it("returns empty map when no overrides provided", () => {
 		const roles: ModelRoles = {
 			...DEFAULT_MODEL_ROLES,
 			builder: "kimchi-dev/minimax-m2.7",
-			planner: "kimchi-dev/kimi-k2.6",
 		}
-		// Pass empty overrides to avoid relying on global cache state
 		const result = extractCustomConfigs(roles, new Map())
 		expect(result.size).toBe(0)
 	})
 
-	it("extracts single custom config from a role (embedded only, no overrides)", () => {
-		const roles: ModelRoles = {
-			...DEFAULT_MODEL_ROLES,
-			planner: { model: "anthropic/claude-opus-4-6", tier: "heavy" },
-		}
-		const result = extractCustomConfigs(roles, new Map())
-		expect(result.size).toBe(1)
-		expect(result.get("anthropic/claude-opus-4-6")).toEqual({
-			model: "anthropic/claude-opus-4-6",
-			tier: "heavy",
-		})
-	})
-
-	it("extracts multiple custom configs from a role array (embedded only)", () => {
-		const roles: ModelRoles = {
-			...DEFAULT_MODEL_ROLES,
-			planner: [
-				"kimchi-dev/kimi-k2.6",
-				{ model: "anthropic/claude-opus-4-6", tier: "heavy", description: "Test" },
-				{ model: "openai/gpt-4o", tier: "standard" },
-			],
-		}
-		const result = extractCustomConfigs(roles, new Map())
-		expect(result.size).toBe(2)
-		expect(result.get("anthropic/claude-opus-4-6")).toEqual({
-			model: "anthropic/claude-opus-4-6",
-			tier: "heavy",
-			description: "Test",
-		})
-		expect(result.get("openai/gpt-4o")).toEqual({ model: "openai/gpt-4o", tier: "standard" })
-	})
-
-	it("extracts configs from multiple roles (embedded only)", () => {
-		const roles: ModelRoles = {
-			...DEFAULT_MODEL_ROLES,
-			planner: { model: "anthropic/claude-opus-4-6", tier: "heavy" },
-			builder: { model: "openai/gpt-4o", tier: "standard" },
-		}
-		const result = extractCustomConfigs(roles, new Map())
-		expect(result.size).toBe(2)
-	})
-
-	it("last-wins when same model ref appears in multiple roles (embedded only)", () => {
-		const roles: ModelRoles = {
-			...DEFAULT_MODEL_ROLES,
-			planner: { model: "anthropic/claude-opus-4-6", tier: "heavy", description: "Planner description" },
-			builder: { model: "anthropic/claude-opus-4-6", tier: "standard", description: "Builder description" },
-		}
-		const result = extractCustomConfigs(roles, new Map())
-		expect(result.size).toBe(1)
-		expect(result.get("anthropic/claude-opus-4-6")).toEqual({
-			model: "anthropic/claude-opus-4-6",
-			tier: "standard",
-			description: "Builder description",
-		})
-	})
-
-	it("returns global metadata when no embedded objects present", () => {
-		const roles: ModelRoles = {
-			...DEFAULT_MODEL_ROLES,
-			builder: "anthropic/claude-sonnet-4-5",
-		}
-		const globalOverrides = new Map<string, { tier?: "heavy"; description?: string }>([
+	it("returns overrides directly", () => {
+		const roles: ModelRoles = { ...DEFAULT_MODEL_ROLES }
+		const overrides = new Map<string, ModelCustomMetadata>([
 			["anthropic/claude-sonnet-4-5", { tier: "heavy", description: "From global store" }],
 		])
-		const result = extractCustomConfigs(roles, globalOverrides)
+		const result = extractCustomConfigs(roles, overrides)
 		expect(result.size).toBe(1)
 		expect(result.get("anthropic/claude-sonnet-4-5")).toEqual({
-			model: "anthropic/claude-sonnet-4-5",
 			tier: "heavy",
 			description: "From global store",
 		})
 	})
-
-	it("global metadata wins over embedded objects for same model ref", () => {
-		const roles: ModelRoles = {
-			...DEFAULT_MODEL_ROLES,
-			planner: { model: "anthropic/claude-opus-4-6", tier: "heavy", description: "Embedded" },
-		}
-		const globalOverrides = new Map<string, { tier?: "standard"; description?: string }>([
-			["anthropic/claude-opus-4-6", { tier: "standard", description: "From global" }],
-		])
-		const result = extractCustomConfigs(roles, globalOverrides)
-		expect(result.size).toBe(1)
-		expect(result.get("anthropic/claude-opus-4-6")).toEqual({
-			model: "anthropic/claude-opus-4-6",
-			tier: "standard",
-			description: "From global",
-		})
-	})
-
-	it("embedded objects included when model ref is not in global metadata", () => {
-		const roles: ModelRoles = {
-			...DEFAULT_MODEL_ROLES,
-			planner: { model: "anthropic/claude-opus-4-6", tier: "heavy", description: "Embedded only" },
-			builder: "openai/gpt-4o",
-		}
-		const globalOverrides = new Map<string, { tier?: "standard" }>([["openai/gpt-4o", { tier: "standard" }]])
-		const result = extractCustomConfigs(roles, globalOverrides)
-		expect(result.size).toBe(2)
-		expect(result.get("anthropic/claude-opus-4-6")).toEqual({
-			model: "anthropic/claude-opus-4-6",
-			tier: "heavy",
-			description: "Embedded only",
-		})
-		expect(result.get("openai/gpt-4o")).toEqual({
-			model: "openai/gpt-4o",
-			tier: "standard",
-		})
-	})
 })
 
-describe("validateModelRoles with CustomModelConfig", () => {
-	it("validates model ID extracted from CustomModelConfig object", () => {
-		const roles: ModelRoles = {
-			...DEFAULT_MODEL_ROLES,
-			builder: { model: "anthropic/claude-sonnet-4-5", tier: "standard" },
-		}
-		const available = new Set(["kimi-k2.6", "minimax-m2.7", "nemotron-3-super-fp4"])
-		const result = validateModelRoles(roles, available)
-		expect(result.unavailable).toHaveLength(1)
-		expect(result.unavailable[0].role).toBe("builder")
-		expect(result.unavailable[0].configuredModel).toBe("anthropic/claude-sonnet-4-5")
-	})
-
-	it("validates model IDs from mixed string/object arrays", () => {
-		const roles: ModelRoles = {
-			...DEFAULT_MODEL_ROLES,
-			planner: ["kimchi-dev/kimi-k2.6", { model: "anthropic/claude-opus-4-6", tier: "heavy" }],
-		}
-		const available = new Set(["kimi-k2.6", "minimax-m2.7", "nemotron-3-super-fp4"])
-		const result = validateModelRoles(roles, available)
-		expect(result.unavailable).toHaveLength(1)
-		expect(result.unavailable[0].configuredModel).toBe("anthropic/claude-opus-4-6")
-	})
-
-	it("strips provider prefix from model ref in CustomModelConfig when validating", () => {
-		const roles: ModelRoles = {
-			...DEFAULT_MODEL_ROLES,
-			builder: { model: "custom-provider/minimax-m2.7", tier: "standard" },
-		}
-		const available = new Set(["minimax-m2.7", "kimi-k2.6", "nemotron-3-super-fp4"])
-		const result = validateModelRoles(roles, available)
-		// Should strip provider and find minimax-m2.7 in available set
-		expect(result.unavailable).toHaveLength(0)
-	})
-})
-
-describe("saveModelRoles with CustomModelConfig", () => {
+describe("saveModelRoles", () => {
 	const testDir = join(tmpdir(), `kimchi-model-roles-test-${process.pid}`)
 	const testPath = join(testDir, "settings.json")
 
@@ -615,68 +404,7 @@ describe("saveModelRoles with CustomModelConfig", () => {
 		} catch {}
 	})
 
-	it("extracts metadata and saves to modelMetadata, saves strings to modelRoles", () => {
-		const custom: CustomModelConfig = {
-			model: "anthropic/claude-opus-4-6",
-			tier: "heavy",
-			description: "Anthropic's flagship.",
-			vision: false,
-		}
-		const roles: ModelRoles = {
-			...DEFAULT_MODEL_ROLES,
-			planner: custom,
-		}
-		saveModelRoles(roles, testPath)
-		const saved = JSON.parse(readFileSync(testPath, "utf-8"))
-		// modelRoles should have the string ref, not the object
-		expect(saved.modelRoles.planner).toBe("anthropic/claude-opus-4-6")
-		// metadata should be in modelMetadata
-		expect(saved.modelMetadata).toBeDefined()
-		expect(saved.modelMetadata["anthropic/claude-opus-4-6"]).toEqual({
-			tier: "heavy",
-			description: "Anthropic's flagship.",
-			vision: false,
-		})
-	})
-
-	it("extracts metadata from mixed string/object array", () => {
-		const roles: ModelRoles = {
-			...DEFAULT_MODEL_ROLES,
-			planner: ["kimchi-dev/kimi-k2.6", { model: "anthropic/claude-opus-4-6", tier: "heavy" }],
-		}
-		saveModelRoles(roles, testPath)
-		const saved = JSON.parse(readFileSync(testPath, "utf-8"))
-		// First element stays as string
-		expect(saved.modelRoles.planner[0]).toBe("kimchi-dev/kimi-k2.6")
-		// Second element is converted to string ref
-		expect(saved.modelRoles.planner[1]).toBe("anthropic/claude-opus-4-6")
-		// metadata extracted for the object
-		expect(saved.modelMetadata["anthropic/claude-opus-4-6"]).toEqual({ tier: "heavy" })
-	})
-
-	it("round-trip: save with objects, read back with parseModelRoles and loadModelMetadata", () => {
-		const roles: ModelRoles = {
-			...DEFAULT_MODEL_ROLES,
-			planner: ["kimchi-dev/kimi-k2.6", { model: "anthropic/claude-opus-4-6", tier: "heavy", description: "Test" }],
-			builder: { model: "openai/gpt-4o", tier: "standard" },
-		}
-		saveModelRoles(roles, testPath)
-
-		// Read back modelRoles (should be strings now)
-		const saved = JSON.parse(readFileSync(testPath, "utf-8"))
-		const { roles: parsedRoles } = parseModelRoles(saved.modelRoles)
-		// Verify planner has string refs
-		expect(parsedRoles.planner).toEqual(["kimchi-dev/kimi-k2.6", "anthropic/claude-opus-4-6"])
-		// Verify builder is just string
-		expect(parsedRoles.builder).toBe("openai/gpt-4o")
-
-		// Read back modelMetadata
-		const metadata = loadModelMetadata(testPath)
-		expect(metadata.get("anthropic/claude-opus-4-6")).toEqual({ tier: "heavy", description: "Test" })
-		expect(metadata.get("openai/gpt-4o")).toEqual({ tier: "standard" })
-	})
-
-	it("saves string-only roles as before (backwards compat)", () => {
+	it("saves string roles to modelRoles key", () => {
 		const roles: ModelRoles = {
 			...DEFAULT_MODEL_ROLES,
 			builder: "anthropic/claude-sonnet-4-5",
@@ -684,26 +412,31 @@ describe("saveModelRoles with CustomModelConfig", () => {
 		saveModelRoles(roles, testPath)
 		const saved = JSON.parse(readFileSync(testPath, "utf-8"))
 		expect(saved.modelRoles.builder).toBe("anthropic/claude-sonnet-4-5")
+	})
+
+	it("does not write modelMetadata", () => {
+		const roles: ModelRoles = {
+			...DEFAULT_MODEL_ROLES,
+			builder: "anthropic/claude-sonnet-4-5",
+		}
+		saveModelRoles(roles, testPath)
+		const saved = JSON.parse(readFileSync(testPath, "utf-8"))
 		expect(saved.modelMetadata).toBeUndefined()
 	})
 
-	it("preserves existing modelMetadata when saving string-only roles", () => {
-		const rolesWithMeta: ModelRoles = {
-			...DEFAULT_MODEL_ROLES,
-			planner: { model: "anthropic/claude-opus-4-6", tier: "heavy" },
-		}
-		saveModelRoles(rolesWithMeta, testPath)
+	it("preserves existing modelMetadata when saving roles", () => {
+		mkdirSync(testDir, { recursive: true })
+		const metadata = new Map<string, ModelCustomMetadata>([["anthropic/claude-opus-4-6", { tier: "heavy" }]])
+		saveModelMetadata(metadata, testPath)
 
-		let saved = JSON.parse(readFileSync(testPath, "utf-8"))
-		expect(saved.modelMetadata).toBeDefined()
-
-		const rolesNoMeta: ModelRoles = {
+		const roles: ModelRoles = {
 			...DEFAULT_MODEL_ROLES,
 			builder: "openai/gpt-4o",
 		}
-		saveModelRoles(rolesNoMeta, testPath)
+		saveModelRoles(roles, testPath)
 
-		saved = JSON.parse(readFileSync(testPath, "utf-8"))
+		const saved = JSON.parse(readFileSync(testPath, "utf-8"))
 		expect(saved.modelMetadata["anthropic/claude-opus-4-6"]).toEqual({ tier: "heavy" })
+		expect(saved.modelRoles.builder).toBe("openai/gpt-4o")
 	})
 })

--- a/src/extensions/orchestration/model-roles.test.ts
+++ b/src/extensions/orchestration/model-roles.test.ts
@@ -3,8 +3,10 @@ import { tmpdir } from "node:os"
 import { join } from "node:path"
 import { afterEach, describe, expect, it } from "vitest"
 import {
+	type CustomModelConfig,
 	DEFAULT_MODEL_ROLES,
 	type ModelRoles,
+	extractCustomConfigs,
 	modelIdFromRef,
 	normalizeRoleModels,
 	parseModelRoles,
@@ -339,5 +341,247 @@ describe("validateModelRoles", () => {
 		expect(result.unavailable.length).toBeGreaterThanOrEqual(5)
 		const flaggedRoles = new Set(result.unavailable.map((u) => u.role))
 		expect(flaggedRoles).toEqual(new Set(["orchestrator", "planner", "builder", "reviewer", "explorer", "judge"]))
+	})
+})
+
+describe("parseModelRoles with CustomModelConfig objects", () => {
+	it("accepts a single CustomModelConfig object for a delegable role", () => {
+		const custom: CustomModelConfig = {
+			model: "anthropic/claude-opus-4-6",
+			tier: "heavy",
+			description: "Anthropic's flagship model.",
+			vision: false,
+		}
+		const { roles, warnings } = parseModelRoles({ planner: custom })
+		expect(roles.planner).toEqual(custom)
+		expect(warnings).toHaveLength(0)
+	})
+
+	it("accepts a mixed array of strings and CustomModelConfig objects", () => {
+		const { roles, warnings } = parseModelRoles({
+			planner: [
+				"kimchi-dev/kimi-k2.6",
+				{
+					model: "anthropic/claude-opus-4-6",
+					tier: "heavy",
+					description: "Anthropic's flagship model.",
+				},
+			],
+		})
+		expect(Array.isArray(roles.planner)).toBe(true)
+		expect((roles.planner as (string | CustomModelConfig)[])[0]).toBe("kimchi-dev/kimi-k2.6")
+		expect(((roles.planner as (string | CustomModelConfig)[])[1] as CustomModelConfig).model).toBe(
+			"anthropic/claude-opus-4-6",
+		)
+		expect(warnings).toHaveLength(0)
+	})
+
+	it("accepts CustomModelConfig with only model field", () => {
+		const { roles, warnings } = parseModelRoles({
+			builder: { model: "anthropic/claude-sonnet-4-5" },
+		})
+		expect((roles.builder as CustomModelConfig).model).toBe("anthropic/claude-sonnet-4-5")
+		expect(warnings).toHaveLength(0)
+	})
+
+	it("warns on object with missing model field", () => {
+		const { roles, warnings } = parseModelRoles({
+			builder: { tier: "heavy" } as unknown as CustomModelConfig,
+		})
+		expect(roles.builder).toBe(DEFAULT_MODEL_ROLES.builder)
+		expect(warnings).toHaveLength(1)
+		expect(warnings[0].role).toBe("builder")
+	})
+
+	it("warns on object with empty model string", () => {
+		const { roles, warnings } = parseModelRoles({
+			builder: { model: "   " },
+		})
+		expect(roles.builder).toBe(DEFAULT_MODEL_ROLES.builder)
+		expect(warnings).toHaveLength(1)
+		expect(warnings[0].role).toBe("builder")
+	})
+
+	it("warns on array with invalid object entry", () => {
+		const { roles, warnings } = parseModelRoles({
+			planner: ["kimchi-dev/kimi-k2.6", { tier: "heavy" }],
+		})
+		expect(roles.planner).toBe(DEFAULT_MODEL_ROLES.planner)
+		expect(warnings).toHaveLength(1)
+		expect(warnings[0].role).toBe("planner")
+	})
+
+	it("trims whitespace from model field in custom config", () => {
+		const { roles } = parseModelRoles({
+			builder: { model: "  anthropic/claude-sonnet-4-5  " },
+		})
+		expect((roles.builder as CustomModelConfig).model).toBe("anthropic/claude-sonnet-4-5")
+	})
+})
+
+describe("normalizeRoleModels with CustomModelConfig", () => {
+	it("extracts model ref from a single CustomModelConfig object", () => {
+		const config: CustomModelConfig = { model: "anthropic/claude-opus-4-6", tier: "heavy" }
+		expect(normalizeRoleModels(config)).toEqual(["anthropic/claude-opus-4-6"])
+	})
+
+	it("extracts model refs from mixed string/object array", () => {
+		const mixed: (string | CustomModelConfig)[] = [
+			"kimchi-dev/kimi-k2.6",
+			{ model: "anthropic/claude-opus-4-6", tier: "heavy" },
+			"openai/gpt-4o",
+		]
+		expect(normalizeRoleModels(mixed)).toEqual(["kimchi-dev/kimi-k2.6", "anthropic/claude-opus-4-6", "openai/gpt-4o"])
+	})
+
+	it("still works with plain string", () => {
+		expect(normalizeRoleModels("kimchi-dev/kimi-k2.6")).toEqual(["kimchi-dev/kimi-k2.6"])
+	})
+
+	it("still works with string array", () => {
+		expect(normalizeRoleModels(["a", "b"])).toEqual(["a", "b"])
+	})
+})
+
+describe("extractCustomConfigs", () => {
+	it("returns empty map when no custom configs present", () => {
+		const roles: ModelRoles = {
+			...DEFAULT_MODEL_ROLES,
+			builder: "kimchi-dev/minimax-m2.7",
+			planner: "kimchi-dev/kimi-k2.6",
+		}
+		const result = extractCustomConfigs(roles)
+		expect(result.size).toBe(0)
+	})
+
+	it("extracts single custom config from a role", () => {
+		const roles: ModelRoles = {
+			...DEFAULT_MODEL_ROLES,
+			planner: { model: "anthropic/claude-opus-4-6", tier: "heavy" },
+		}
+		const result = extractCustomConfigs(roles)
+		expect(result.size).toBe(1)
+		expect(result.get("anthropic/claude-opus-4-6")).toEqual({
+			model: "anthropic/claude-opus-4-6",
+			tier: "heavy",
+		})
+	})
+
+	it("extracts multiple custom configs from a role array", () => {
+		const roles: ModelRoles = {
+			...DEFAULT_MODEL_ROLES,
+			planner: [
+				"kimchi-dev/kimi-k2.6",
+				{ model: "anthropic/claude-opus-4-6", tier: "heavy", description: "Test" },
+				{ model: "openai/gpt-4o", tier: "standard" },
+			],
+		}
+		const result = extractCustomConfigs(roles)
+		expect(result.size).toBe(2)
+		expect(result.get("anthropic/claude-opus-4-6")).toEqual({
+			model: "anthropic/claude-opus-4-6",
+			tier: "heavy",
+			description: "Test",
+		})
+		expect(result.get("openai/gpt-4o")).toEqual({ model: "openai/gpt-4o", tier: "standard" })
+	})
+
+	it("extracts configs from multiple roles", () => {
+		const roles: ModelRoles = {
+			...DEFAULT_MODEL_ROLES,
+			planner: { model: "anthropic/claude-opus-4-6", tier: "heavy" },
+			builder: { model: "openai/gpt-4o", tier: "standard" },
+		}
+		const result = extractCustomConfigs(roles)
+		expect(result.size).toBe(2)
+	})
+
+	it("last-wins when same model ref appears in multiple roles", () => {
+		const roles: ModelRoles = {
+			...DEFAULT_MODEL_ROLES,
+			planner: { model: "anthropic/claude-opus-4-6", tier: "heavy", description: "Planner description" },
+			builder: { model: "anthropic/claude-opus-4-6", tier: "standard", description: "Builder description" },
+		}
+		const result = extractCustomConfigs(roles)
+		expect(result.size).toBe(1)
+		expect(result.get("anthropic/claude-opus-4-6")).toEqual({
+			model: "anthropic/claude-opus-4-6",
+			tier: "standard",
+			description: "Builder description",
+		})
+	})
+})
+
+describe("validateModelRoles with CustomModelConfig", () => {
+	it("validates model ID extracted from CustomModelConfig object", () => {
+		const roles: ModelRoles = {
+			...DEFAULT_MODEL_ROLES,
+			builder: { model: "anthropic/claude-sonnet-4-5", tier: "standard" },
+		}
+		const available = new Set(["kimi-k2.6", "minimax-m2.7", "nemotron-3-super-fp4"])
+		const result = validateModelRoles(roles, available)
+		expect(result.unavailable).toHaveLength(1)
+		expect(result.unavailable[0].role).toBe("builder")
+		expect(result.unavailable[0].configuredModel).toBe("anthropic/claude-sonnet-4-5")
+	})
+
+	it("validates model IDs from mixed string/object arrays", () => {
+		const roles: ModelRoles = {
+			...DEFAULT_MODEL_ROLES,
+			planner: ["kimchi-dev/kimi-k2.6", { model: "anthropic/claude-opus-4-6", tier: "heavy" }],
+		}
+		const available = new Set(["kimi-k2.6", "minimax-m2.7", "nemotron-3-super-fp4"])
+		const result = validateModelRoles(roles, available)
+		expect(result.unavailable).toHaveLength(1)
+		expect(result.unavailable[0].configuredModel).toBe("anthropic/claude-opus-4-6")
+	})
+
+	it("strips provider prefix from model ref in CustomModelConfig when validating", () => {
+		const roles: ModelRoles = {
+			...DEFAULT_MODEL_ROLES,
+			builder: { model: "custom-provider/minimax-m2.7", tier: "standard" },
+		}
+		const available = new Set(["minimax-m2.7", "kimi-k2.6", "nemotron-3-super-fp4"])
+		const result = validateModelRoles(roles, available)
+		// Should strip provider and find minimax-m2.7 in available set
+		expect(result.unavailable).toHaveLength(0)
+	})
+})
+
+describe("saveModelRoles with CustomModelConfig", () => {
+	const testDir = join(tmpdir(), `kimchi-model-roles-test-${process.pid}`)
+	const testPath = join(testDir, "settings.json")
+
+	afterEach(() => {
+		try {
+			rmSync(testDir, { recursive: true, force: true })
+		} catch {}
+	})
+
+	it("saves CustomModelConfig object and reads it back", () => {
+		const custom: CustomModelConfig = {
+			model: "anthropic/claude-opus-4-6",
+			tier: "heavy",
+			description: "Anthropic's flagship.",
+			vision: false,
+		}
+		const roles: ModelRoles = {
+			...DEFAULT_MODEL_ROLES,
+			planner: custom,
+		}
+		saveModelRoles(roles, testPath)
+		const saved = JSON.parse(readFileSync(testPath, "utf-8"))
+		expect(saved.modelRoles.planner).toEqual(custom)
+	})
+
+	it("saves mixed string/object array and reads it back", () => {
+		const roles: ModelRoles = {
+			...DEFAULT_MODEL_ROLES,
+			planner: ["kimchi-dev/kimi-k2.6", { model: "anthropic/claude-opus-4-6", tier: "heavy" }],
+		}
+		saveModelRoles(roles, testPath)
+		const saved = JSON.parse(readFileSync(testPath, "utf-8"))
+		expect(saved.modelRoles.planner[0]).toBe("kimchi-dev/kimi-k2.6")
+		expect(saved.modelRoles.planner[1]).toEqual({ model: "anthropic/claude-opus-4-6", tier: "heavy" })
 	})
 })

--- a/src/extensions/orchestration/model-roles.test.ts
+++ b/src/extensions/orchestration/model-roles.test.ts
@@ -191,6 +191,14 @@ describe("splitModelRef", () => {
 	it("returns undefined for empty string", () => {
 		expect(splitModelRef("")).toBeUndefined()
 	})
+
+	it("returns undefined for empty model id after slash", () => {
+		expect(splitModelRef("provider/")).toBeUndefined()
+	})
+
+	it("returns undefined for whitespace-only model id after slash", () => {
+		expect(splitModelRef("provider/   ")).toBeUndefined()
+	})
 })
 
 describe("modelIdFromRef", () => {

--- a/src/extensions/orchestration/model-roles.ts
+++ b/src/extensions/orchestration/model-roles.ts
@@ -39,6 +39,11 @@ import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs"
 import { homedir } from "node:os"
 import { dirname, join } from "node:path"
 
+import {
+	type ModelCustomMetadata,
+	getModelMetadata,
+	resetModelMetadataCache as resetMetadataCache,
+} from "./model-metadata.js"
 import { MODEL_CAPABILITIES } from "./model-registry/builtin-models.js"
 import { KIMCHI_DEV_PROVIDER } from "./model-registry/model-registry.js"
 import type { ModelTier } from "./model-registry/types.js"
@@ -245,6 +250,10 @@ function isEqualRoleValue(a: RoleModelAssignment, b: RoleModelAssignment): boole
 /**
  * Save model roles to settings.json. Merges with existing settings,
  * only writing non-default values (omits keys that match DEFAULT_MODEL_ROLES).
+ *
+ * Embedded CustomModelConfig objects in role assignments are extracted and
+ * saved to the global modelMetadata store. Role assignments are saved as
+ * strings only (model ref), preserving backwards compat for unmigrated readers.
  */
 export function saveModelRoles(roles: ModelRoles, settingsPath?: string): void {
 	const path = settingsPath ?? HARNESS_SETTINGS_PATH
@@ -255,10 +264,46 @@ export function saveModelRoles(roles: ModelRoles, settingsPath?: string): void {
 		// absent or unreadable — start fresh
 	}
 
+	// 1. Extract embedded CustomModelConfig objects and convert to strings
+	const metadataToSave = new Map<string, ModelCustomMetadata>()
+	const stringifiedRoles: ModelRoles = { ...roles }
+
+	for (const key of ROLE_KEYS) {
+		const value = roles[key]
+		if (key === "orchestrator") {
+			// orchestrator is always a string
+			stringifiedRoles.orchestrator = value as string
+			continue
+		}
+
+		const items = Array.isArray(value) ? value : [value]
+		const stringifiedItems: (string | CustomModelConfig)[] = []
+
+		for (const item of items) {
+			if (typeof item === "object" && item !== null) {
+				// Extract metadata and save just the string ref
+				const { model, tier, description, vision } = item
+				const meta: ModelCustomMetadata = {}
+				if (tier !== undefined) meta.tier = tier
+				if (description !== undefined) meta.description = description
+				if (vision !== undefined) meta.vision = vision
+				if (Object.keys(meta).length > 0) {
+					metadataToSave.set(model, meta)
+				}
+				stringifiedItems.push(model)
+			} else {
+				stringifiedItems.push(item)
+			}
+		}
+
+		stringifiedRoles[key] = items.length === 1 ? stringifiedItems[0] : stringifiedItems
+	}
+
+	// 2. Save stringified roles (only non-default values)
 	const rolesObj: Record<string, RoleModelAssignment> = {}
 	for (const key of ROLE_KEYS) {
-		if (!isEqualRoleValue(roles[key], DEFAULT_MODEL_ROLES[key])) {
-			rolesObj[key] = roles[key]
+		if (!isEqualRoleValue(stringifiedRoles[key], DEFAULT_MODEL_ROLES[key])) {
+			rolesObj[key] = stringifiedRoles[key]
 		}
 	}
 
@@ -269,11 +314,25 @@ export function saveModelRoles(roles: ModelRoles, settingsPath?: string): void {
 		existing.modelRoles = rolesObj
 	}
 
+	// 3. Merge embedded metadata into existing modelMetadata (preserves other models)
+	if (metadataToSave.size > 0) {
+		const existingMeta =
+			existing.modelMetadata && typeof existing.modelMetadata === "object" && !Array.isArray(existing.modelMetadata)
+				? { ...(existing.modelMetadata as Record<string, ModelCustomMetadata>) }
+				: {}
+		for (const [ref, entry] of metadataToSave.entries()) {
+			const prev = existingMeta[ref]
+			existingMeta[ref] = prev ? { ...prev, ...entry } : entry
+		}
+		existing.modelMetadata = existingMeta
+	}
+
 	const dir = dirname(path)
 	if (!existsSync(dir)) mkdirSync(dir, { recursive: true })
 	writeFileSync(path, `${JSON.stringify(existing, null, 2)}\n`)
 
 	resetModelRolesCache()
+	resetMetadataCache()
 }
 
 /**
@@ -302,17 +361,34 @@ export function modelIdFromRef(ref: string): string {
 // Validation against available models
 // ---------------------------------------------------------------------------
 
-export function extractCustomConfigs(roles: ModelRoles): ReadonlyMap<string, CustomModelConfig> {
+export function extractCustomConfigs(
+	roles: ModelRoles,
+	overrides?: ReadonlyMap<string, ModelCustomMetadata>,
+): ReadonlyMap<string, CustomModelConfig> {
 	const map = new Map<string, CustomModelConfig>()
+
+	// 1. Read from global metadata store (new format)
+	const globalRefs = new Set<string>()
+	const globalMetadata = overrides ?? getModelMetadata()
+	for (const [ref, meta] of globalMetadata) {
+		globalRefs.add(ref)
+		map.set(ref, { model: ref, ...meta })
+	}
+
+	// 2. Backwards compat: scan role assignments for embedded objects
+	// Global metadata wins, but embedded objects among themselves keep last-wins semantics
 	for (const key of ROLE_KEYS) {
 		const value = roles[key]
 		const items = Array.isArray(value) ? value : [value]
 		for (const item of items) {
 			if (typeof item === "object" && item !== null) {
-				map.set(item.model, item)
+				if (!globalRefs.has(item.model)) {
+					map.set(item.model, item)
+				}
 			}
 		}
 	}
+
 	return map
 }
 

--- a/src/extensions/orchestration/model-roles.ts
+++ b/src/extensions/orchestration/model-roles.ts
@@ -161,7 +161,7 @@ function isValidCustomModelConfig(value: unknown): value is CustomModelConfig {
 	)
 }
 
-function isValidRoleValue(value: unknown): value is string | string[] {
+function isValidRoleValue(value: unknown): value is RoleModelAssignment {
 	if (typeof value === "string" && value.trim().length > 0) return true
 	if (Array.isArray(value) && value.length > 0 && value.every((v) => typeof v === "string" && v.trim().length > 0))
 		return true

--- a/src/extensions/orchestration/model-roles.ts
+++ b/src/extensions/orchestration/model-roles.ts
@@ -1,12 +1,13 @@
 /**
  * Role-based model configuration for multi-model orchestration.
  *
- * Six roles:
+ * Seven roles:
  *   - orchestrator: runs the main loop, delegates work (single model)
  *   - planner: designs the approach, writes specs
  *   - builder: code implementation
  *   - reviewer: code review
  *   - explorer: codebase exploration, reading files, tracing architecture
+ *   - researcher: research beyond codebase — web search, documentation lookup
  *   - judge: ferment verification and final grading calls
  *
  * Delegable roles (planner, builder, reviewer, explorer) accept either a
@@ -17,8 +18,7 @@
  * Model metadata (tier, description, vision) is stored separately in the
  * "modelMetadata" key of settings.json — see model-metadata.ts.
  *
- * Defaults are derived from MODEL_CAPABILITIES — each model's `roles` field
- * determines which role pools it belongs to.
+ * Defaults are hardcoded in DEFAULT_MODEL_ROLES.
  *
  * Users can override in ~/.config/kimchi/harness/settings.json under the
  * "modelRoles" key. Supports any provider/model-id string.
@@ -48,8 +48,9 @@ import {
 } from "./model-metadata.js"
 export { modelIdFromRef, splitModelRef } from "./model-ref-utils.js"
 import { modelIdFromRef } from "./model-ref-utils.js"
-import { MODEL_CAPABILITIES } from "./model-registry/builtin-models.js"
-import { KIMCHI_DEV_PROVIDER } from "./model-registry/model-registry.js"
+
+/** Task-type affinity tag used to match an agent persona to a model role. */
+export type ModelRole = "review" | "build" | "plan" | "explore" | "research"
 
 /** Model assignment for a role: single model ref or ordered list of candidates. */
 export type RoleModelAssignment = string | string[]
@@ -65,6 +66,8 @@ export interface ModelRoles {
 	reviewer: RoleModelAssignment
 	/** Codebase exploration model(s). */
 	explorer: RoleModelAssignment
+	/** Research model(s): research beyond codebase — web search, documentation lookup, external sources. */
+	researcher: RoleModelAssignment
 	/** Ferment judge model(s): verification triage and final grading calls. */
 	judge: RoleModelAssignment
 }
@@ -74,60 +77,23 @@ const DELEGABLE_ROLE_KEYS: readonly (keyof Omit<ModelRoles, "orchestrator">)[] =
 	"builder",
 	"reviewer",
 	"explorer",
+	"researcher",
 	"judge",
 ]
 const ROLE_KEYS: readonly (keyof ModelRoles)[] = ["orchestrator", ...DELEGABLE_ROLE_KEYS]
 
 const HARNESS_SETTINGS_PATH = join(homedir(), ".config", "kimchi", "harness", "settings.json")
 
-/**
- * Build default model roles by scanning MODEL_CAPABILITIES.
- *
- * Each non-ignored model is placed into role pools matching its `roles` field.
- * The orchestrator is the heaviest model with the "plan" role.
- */
-export function buildDefaultModelRoles(): ModelRoles {
-	const planners: string[] = []
-	const builders: string[] = []
-	const reviewers: string[] = []
-	const explorers: string[] = []
-
-	let orchestrator: string | undefined
-
-	for (const [id, entry] of MODEL_CAPABILITIES.entries()) {
-		if (entry === "ignored") continue
-		const ref = `${KIMCHI_DEV_PROVIDER}/${id}`
-
-		if (entry.roles.includes("plan")) {
-			planners.push(ref)
-			if (entry.tier === "heavy" && !orchestrator) {
-				orchestrator = ref
-			}
-		}
-		if (entry.roles.includes("build")) builders.push(ref)
-		if (entry.roles.includes("review")) reviewers.push(ref)
-		if (entry.roles.includes("explore") || entry.roles.includes("research")) {
-			if (!explorers.includes(ref)) explorers.push(ref)
-		}
-	}
-
-	const orch = orchestrator ?? `${KIMCHI_DEV_PROVIDER}/kimi-k2.6`
-
-	const toAssignment = (arr: string[], fallback: string): RoleModelAssignment =>
-		arr.length === 1 ? arr[0] : arr.length > 0 ? arr : fallback
-
-	return {
-		orchestrator: orch,
-		planner: toAssignment(planners, orch),
-		builder: toAssignment(builders, orch),
-		reviewer: toAssignment(reviewers, orch),
-		explorer: toAssignment(explorers, orch),
-		judge: orch,
-	}
+/** Hardcoded default model-to-role assignment. Users override via /multi-model. */
+export const DEFAULT_MODEL_ROLES: Readonly<ModelRoles> = {
+	orchestrator: "kimchi-dev/kimi-k2.6",
+	planner: "kimchi-dev/kimi-k2.6",
+	builder: ["kimchi-dev/kimi-k2.6", "kimchi-dev/minimax-m2.7"],
+	reviewer: ["kimchi-dev/kimi-k2.6", "kimchi-dev/minimax-m2.7"],
+	explorer: "kimchi-dev/nemotron-3-ultra-fp4",
+	researcher: "kimchi-dev/kimi-k2.6",
+	judge: "kimchi-dev/kimi-k2.6",
 }
-
-/** Default roles derived from MODEL_CAPABILITIES. */
-export const DEFAULT_MODEL_ROLES: Readonly<ModelRoles> = buildDefaultModelRoles()
 
 export interface ModelRolesWarning {
 	role: keyof ModelRoles

--- a/src/extensions/orchestration/model-roles.ts
+++ b/src/extensions/orchestration/model-roles.ts
@@ -43,7 +43,10 @@ import {
 	type ModelCustomMetadata,
 	getModelMetadata,
 	resetModelMetadataCache as resetMetadataCache,
+	saveModelMetadata,
 } from "./model-metadata.js"
+export { modelIdFromRef, splitModelRef } from "./model-ref-utils.js"
+import { modelIdFromRef } from "./model-ref-utils.js"
 import { MODEL_CAPABILITIES } from "./model-registry/builtin-models.js"
 import { KIMCHI_DEV_PROVIDER } from "./model-registry/model-registry.js"
 import type { ModelTier } from "./model-registry/types.js"
@@ -299,7 +302,21 @@ export function saveModelRoles(roles: ModelRoles, settingsPath?: string): void {
 		stringifiedRoles[key] = items.length === 1 ? stringifiedItems[0] : stringifiedItems
 	}
 
-	// 2. Save stringified roles (only non-default values)
+	// 2. Save extracted metadata via the canonical saveModelMetadata path
+	if (metadataToSave.size > 0) {
+		saveModelMetadata(metadataToSave, path)
+	}
+
+	// 3. Save stringified roles (only non-default values)
+	// Re-read the file since saveModelMetadata may have written to it
+	if (metadataToSave.size > 0) {
+		try {
+			existing = JSON.parse(readFileSync(path, "utf-8"))
+		} catch {
+			// should not happen since saveModelMetadata just wrote it
+		}
+	}
+
 	const rolesObj: Record<string, RoleModelAssignment> = {}
 	for (const key of ROLE_KEYS) {
 		if (!isEqualRoleValue(stringifiedRoles[key], DEFAULT_MODEL_ROLES[key])) {
@@ -314,47 +331,12 @@ export function saveModelRoles(roles: ModelRoles, settingsPath?: string): void {
 		existing.modelRoles = rolesObj
 	}
 
-	// 3. Merge embedded metadata into existing modelMetadata (preserves other models)
-	if (metadataToSave.size > 0) {
-		const existingMeta =
-			existing.modelMetadata && typeof existing.modelMetadata === "object" && !Array.isArray(existing.modelMetadata)
-				? { ...(existing.modelMetadata as Record<string, ModelCustomMetadata>) }
-				: {}
-		for (const [ref, entry] of metadataToSave.entries()) {
-			const prev = existingMeta[ref]
-			existingMeta[ref] = prev ? { ...prev, ...entry } : entry
-		}
-		existing.modelMetadata = existingMeta
-	}
-
 	const dir = dirname(path)
 	if (!existsSync(dir)) mkdirSync(dir, { recursive: true })
 	writeFileSync(path, `${JSON.stringify(existing, null, 2)}\n`)
 
 	resetModelRolesCache()
 	resetMetadataCache()
-}
-
-/**
- * Extract provider and model ID from a "provider/model-id" string.
- * Returns undefined if the string doesn't contain a slash.
- */
-export function splitModelRef(ref: string): { provider: string; modelId: string } | undefined {
-	const slashIdx = ref.indexOf("/")
-	if (slashIdx <= 0) return undefined
-	return {
-		provider: ref.slice(0, slashIdx),
-		modelId: ref.slice(slashIdx + 1),
-	}
-}
-
-/**
- * Extract just the model ID from a "provider/model-id" string.
- * Returns the full string if no slash is present.
- */
-export function modelIdFromRef(ref: string): string {
-	const slashIdx = ref.indexOf("/")
-	return slashIdx >= 0 ? ref.slice(slashIdx + 1) : ref
 }
 
 // ---------------------------------------------------------------------------

--- a/src/extensions/orchestration/model-roles.ts
+++ b/src/extensions/orchestration/model-roles.ts
@@ -10,7 +10,8 @@
  *   - judge: ferment verification and final grading calls
  *
  * Delegable roles (planner, builder, reviewer, explorer) accept either a
- * single model string or an array of candidates. When multiple models are
+ * single model string, an array of candidates, a CustomModelConfig object,
+ * or an array mixing strings and objects. When multiple models are
  * assigned, the orchestrator selects the best fit based on tier and task
  * complexity.
  *
@@ -40,9 +41,18 @@ import { dirname, join } from "node:path"
 
 import { MODEL_CAPABILITIES } from "./model-registry/builtin-models.js"
 import { KIMCHI_DEV_PROVIDER } from "./model-registry/model-registry.js"
+import type { ModelTier } from "./model-registry/types.js"
 
-/** Model assignment for a role: single model or ordered list of candidates. */
-export type RoleModelAssignment = string | string[]
+/** Custom metadata for a non-registry model assigned to a role. */
+export interface CustomModelConfig {
+	model: string
+	tier?: ModelTier
+	description?: string
+	vision?: boolean
+}
+
+/** Model assignment for a role: single model, ordered list of candidates, custom config, or mixed array. */
+export type RoleModelAssignment = string | CustomModelConfig | (string | CustomModelConfig)[]
 
 export interface ModelRoles {
 	/** Main model: runs the orchestrator loop, delegates work to other roles. */
@@ -103,7 +113,7 @@ export function buildDefaultModelRoles(): ModelRoles {
 
 	const orch = orchestrator ?? `${KIMCHI_DEV_PROVIDER}/kimi-k2.6`
 
-	const toAssignment = (arr: string[], fallback: string): string | string[] =>
+	const toAssignment = (arr: string[], fallback: string): RoleModelAssignment =>
 		arr.length === 1 ? arr[0] : arr.length > 0 ? arr : fallback
 
 	return {
@@ -126,24 +136,43 @@ export interface ModelRolesWarning {
 }
 
 /** Normalize a role value to an array of model refs. */
-export function normalizeRoleModels(value: RoleModelAssignment): string[] {
-	return Array.isArray(value) ? value : [value]
+export function normalizeRoleModels(value: RoleModelAssignment | (string | CustomModelConfig)[]): string[] {
+	if (Array.isArray(value)) {
+		return value.map((v) => (typeof v === "string" ? v : v.model))
+	}
+	if (typeof value === "string") return [value]
+	return [value.model]
+}
+
+function isValidCustomModelConfig(value: unknown): value is CustomModelConfig {
+	return (
+		typeof value === "object" &&
+		value !== null &&
+		typeof (value as { model?: string }).model === "string" &&
+		(value as { model: string }).model.trim().length > 0
+	)
 }
 
 function isValidRoleValue(value: unknown): value is string | string[] {
 	if (typeof value === "string" && value.trim().length > 0) return true
+	if (Array.isArray(value) && value.length > 0 && value.every((v) => typeof v === "string" && v.trim().length > 0))
+		return true
+	if (isValidCustomModelConfig(value)) return true
 	if (
 		Array.isArray(value) &&
 		value.length > 0 &&
-		value.every((v) => typeof v === "string" && (v as string).trim().length > 0)
+		value.every((v) => isValidCustomModelConfig(v) || (typeof v === "string" && v.trim().length > 0))
 	)
 		return true
 	return false
 }
 
-function trimRoleValue(value: string | string[]): string | string[] {
+function trimRoleValue(value: string | string[] | CustomModelConfig | CustomModelConfig[]): RoleModelAssignment {
 	if (typeof value === "string") return value.trim()
-	return value.map((v) => v.trim())
+	if (Array.isArray(value)) {
+		return value.map((v) => (typeof v === "string" ? v.trim() : { ...v, model: v.model.trim() }))
+	}
+	return { ...value, model: value.model.trim() }
 }
 
 /**
@@ -183,7 +212,7 @@ export function parseModelRoles(raw: unknown): { roles: ModelRoles; warnings: Mo
 				})
 				continue
 			}
-			roles[key] = trimRoleValue(value as string | string[])
+			roles[key] = trimRoleValue(value as string | string[] | CustomModelConfig | CustomModelConfig[])
 		}
 	}
 
@@ -210,9 +239,7 @@ export function resolveModelRoles(settingsPath?: string): { roles: ModelRoles; w
 
 function isEqualRoleValue(a: RoleModelAssignment, b: RoleModelAssignment): boolean {
 	if (typeof a === "string" && typeof b === "string") return a === b
-	const arrA = normalizeRoleModels(a)
-	const arrB = normalizeRoleModels(b)
-	return arrA.length === arrB.length && arrA.every((v, i) => v === arrB[i])
+	return JSON.stringify(a) === JSON.stringify(b)
 }
 
 /**
@@ -228,7 +255,7 @@ export function saveModelRoles(roles: ModelRoles, settingsPath?: string): void {
 		// absent or unreadable — start fresh
 	}
 
-	const rolesObj: Record<string, string | string[]> = {}
+	const rolesObj: Record<string, RoleModelAssignment> = {}
 	for (const key of ROLE_KEYS) {
 		if (!isEqualRoleValue(roles[key], DEFAULT_MODEL_ROLES[key])) {
 			rolesObj[key] = roles[key]
@@ -274,6 +301,20 @@ export function modelIdFromRef(ref: string): string {
 // ---------------------------------------------------------------------------
 // Validation against available models
 // ---------------------------------------------------------------------------
+
+export function extractCustomConfigs(roles: ModelRoles): ReadonlyMap<string, CustomModelConfig> {
+	const map = new Map<string, CustomModelConfig>()
+	for (const key of ROLE_KEYS) {
+		const value = roles[key]
+		const items = Array.isArray(value) ? value : [value]
+		for (const item of items) {
+			if (typeof item === "object" && item !== null) {
+				map.set(item.model, item)
+			}
+		}
+	}
+	return map
+}
 
 export interface ModelRoleValidationResult {
 	/** Roles whose configured model is not available in the API. */

--- a/src/extensions/orchestration/model-roles.ts
+++ b/src/extensions/orchestration/model-roles.ts
@@ -10,10 +10,12 @@
  *   - judge: ferment verification and final grading calls
  *
  * Delegable roles (planner, builder, reviewer, explorer) accept either a
- * single model string, an array of candidates, a CustomModelConfig object,
- * or an array mixing strings and objects. When multiple models are
+ * single model string or an array of candidates. When multiple models are
  * assigned, the orchestrator selects the best fit based on tier and task
  * complexity.
+ *
+ * Model metadata (tier, description, vision) is stored separately in the
+ * "modelMetadata" key of settings.json — see model-metadata.ts.
  *
  * Defaults are derived from MODEL_CAPABILITIES — each model's `roles` field
  * determines which role pools it belongs to.
@@ -43,24 +45,14 @@ import {
 	type ModelCustomMetadata,
 	getModelMetadata,
 	resetModelMetadataCache as resetMetadataCache,
-	saveModelMetadata,
 } from "./model-metadata.js"
 export { modelIdFromRef, splitModelRef } from "./model-ref-utils.js"
 import { modelIdFromRef } from "./model-ref-utils.js"
 import { MODEL_CAPABILITIES } from "./model-registry/builtin-models.js"
 import { KIMCHI_DEV_PROVIDER } from "./model-registry/model-registry.js"
-import type { ModelTier } from "./model-registry/types.js"
 
-/** Custom metadata for a non-registry model assigned to a role. */
-export interface CustomModelConfig {
-	model: string
-	tier?: ModelTier
-	description?: string
-	vision?: boolean
-}
-
-/** Model assignment for a role: single model, ordered list of candidates, custom config, or mixed array. */
-export type RoleModelAssignment = string | CustomModelConfig | (string | CustomModelConfig)[]
+/** Model assignment for a role: single model ref or ordered list of candidates. */
+export type RoleModelAssignment = string | string[]
 
 export interface ModelRoles {
 	/** Main model: runs the orchestrator loop, delegates work to other roles. */
@@ -144,43 +136,21 @@ export interface ModelRolesWarning {
 }
 
 /** Normalize a role value to an array of model refs. */
-export function normalizeRoleModels(value: RoleModelAssignment | (string | CustomModelConfig)[]): string[] {
-	if (Array.isArray(value)) {
-		return value.map((v) => (typeof v === "string" ? v : v.model))
-	}
-	if (typeof value === "string") return [value]
-	return [value.model]
-}
-
-function isValidCustomModelConfig(value: unknown): value is CustomModelConfig {
-	return (
-		typeof value === "object" &&
-		value !== null &&
-		typeof (value as { model?: string }).model === "string" &&
-		(value as { model: string }).model.trim().length > 0
-	)
+export function normalizeRoleModels(value: RoleModelAssignment): string[] {
+	if (Array.isArray(value)) return value
+	return [value]
 }
 
 function isValidRoleValue(value: unknown): value is RoleModelAssignment {
 	if (typeof value === "string" && value.trim().length > 0) return true
 	if (Array.isArray(value) && value.length > 0 && value.every((v) => typeof v === "string" && v.trim().length > 0))
 		return true
-	if (isValidCustomModelConfig(value)) return true
-	if (
-		Array.isArray(value) &&
-		value.length > 0 &&
-		value.every((v) => isValidCustomModelConfig(v) || (typeof v === "string" && v.trim().length > 0))
-	)
-		return true
 	return false
 }
 
-function trimRoleValue(value: string | string[] | CustomModelConfig | CustomModelConfig[]): RoleModelAssignment {
+function trimRoleValue(value: string | string[]): RoleModelAssignment {
 	if (typeof value === "string") return value.trim()
-	if (Array.isArray(value)) {
-		return value.map((v) => (typeof v === "string" ? v.trim() : { ...v, model: v.model.trim() }))
-	}
-	return { ...value, model: value.model.trim() }
+	return value.map((v) => v.trim())
 }
 
 /**
@@ -220,7 +190,7 @@ export function parseModelRoles(raw: unknown): { roles: ModelRoles; warnings: Mo
 				})
 				continue
 			}
-			roles[key] = trimRoleValue(value as string | string[] | CustomModelConfig | CustomModelConfig[])
+			roles[key] = trimRoleValue(value as string | string[])
 		}
 	}
 
@@ -253,10 +223,6 @@ function isEqualRoleValue(a: RoleModelAssignment, b: RoleModelAssignment): boole
 /**
  * Save model roles to settings.json. Merges with existing settings,
  * only writing non-default values (omits keys that match DEFAULT_MODEL_ROLES).
- *
- * Embedded CustomModelConfig objects in role assignments are extracted and
- * saved to the global modelMetadata store. Role assignments are saved as
- * strings only (model ref), preserving backwards compat for unmigrated readers.
  */
 export function saveModelRoles(roles: ModelRoles, settingsPath?: string): void {
 	const path = settingsPath ?? HARNESS_SETTINGS_PATH
@@ -267,60 +233,10 @@ export function saveModelRoles(roles: ModelRoles, settingsPath?: string): void {
 		// absent or unreadable — start fresh
 	}
 
-	// 1. Extract embedded CustomModelConfig objects and convert to strings
-	const metadataToSave = new Map<string, ModelCustomMetadata>()
-	const stringifiedRoles: ModelRoles = { ...roles }
-
-	for (const key of ROLE_KEYS) {
-		const value = roles[key]
-		if (key === "orchestrator") {
-			// orchestrator is always a string
-			stringifiedRoles.orchestrator = value as string
-			continue
-		}
-
-		const items = Array.isArray(value) ? value : [value]
-		const stringifiedItems: (string | CustomModelConfig)[] = []
-
-		for (const item of items) {
-			if (typeof item === "object" && item !== null) {
-				// Extract metadata and save just the string ref
-				const { model, tier, description, vision } = item
-				const meta: ModelCustomMetadata = {}
-				if (tier !== undefined) meta.tier = tier
-				if (description !== undefined) meta.description = description
-				if (vision !== undefined) meta.vision = vision
-				if (Object.keys(meta).length > 0) {
-					metadataToSave.set(model, meta)
-				}
-				stringifiedItems.push(model)
-			} else {
-				stringifiedItems.push(item)
-			}
-		}
-
-		stringifiedRoles[key] = items.length === 1 ? stringifiedItems[0] : stringifiedItems
-	}
-
-	// 2. Save extracted metadata via the canonical saveModelMetadata path
-	if (metadataToSave.size > 0) {
-		saveModelMetadata(metadataToSave, path)
-	}
-
-	// 3. Save stringified roles (only non-default values)
-	// Re-read the file since saveModelMetadata may have written to it
-	if (metadataToSave.size > 0) {
-		try {
-			existing = JSON.parse(readFileSync(path, "utf-8"))
-		} catch {
-			// should not happen since saveModelMetadata just wrote it
-		}
-	}
-
 	const rolesObj: Record<string, RoleModelAssignment> = {}
 	for (const key of ROLE_KEYS) {
-		if (!isEqualRoleValue(stringifiedRoles[key], DEFAULT_MODEL_ROLES[key])) {
-			rolesObj[key] = stringifiedRoles[key]
+		if (!isEqualRoleValue(roles[key], DEFAULT_MODEL_ROLES[key])) {
+			rolesObj[key] = roles[key]
 		}
 	}
 
@@ -344,34 +260,10 @@ export function saveModelRoles(roles: ModelRoles, settingsPath?: string): void {
 // ---------------------------------------------------------------------------
 
 export function extractCustomConfigs(
-	roles: ModelRoles,
+	_roles: ModelRoles,
 	overrides?: ReadonlyMap<string, ModelCustomMetadata>,
-): ReadonlyMap<string, CustomModelConfig> {
-	const map = new Map<string, CustomModelConfig>()
-
-	// 1. Read from global metadata store (new format)
-	const globalRefs = new Set<string>()
-	const globalMetadata = overrides ?? getModelMetadata()
-	for (const [ref, meta] of globalMetadata) {
-		globalRefs.add(ref)
-		map.set(ref, { model: ref, ...meta })
-	}
-
-	// 2. Backwards compat: scan role assignments for embedded objects
-	// Global metadata wins, but embedded objects among themselves keep last-wins semantics
-	for (const key of ROLE_KEYS) {
-		const value = roles[key]
-		const items = Array.isArray(value) ? value : [value]
-		for (const item of items) {
-			if (typeof item === "object" && item !== null) {
-				if (!globalRefs.has(item.model)) {
-					map.set(item.model, item)
-				}
-			}
-		}
-	}
-
-	return map
+): ReadonlyMap<string, ModelCustomMetadata> {
+	return overrides ?? getModelMetadata()
 }
 
 export interface ModelRoleValidationResult {

--- a/src/extensions/orchestration/orchestration-instructions.test.ts
+++ b/src/extensions/orchestration/orchestration-instructions.test.ts
@@ -433,6 +433,39 @@ describe("resolveOrchestrationInstructions with custom configs", () => {
 		expect(result).toContain("Vision: no")
 	})
 
+	it("orchestrator custom metadata is not dropped when currentModelId is a bare model id (no provider)", () => {
+		// Regression: prompt-enrichment.ts passes `getOrchestratorModelId()` (bare
+		// model id) as `currentModelId`, but `modelMetadata` in settings.json is
+		// keyed by full ref (`anthropic/claude-opus-4-6`). `resolveModelMeta` did
+		// `customConfigs?.get(ref)` directly, so the orchestrator's own custom
+		// tier/description/vision was silently dropped from "Your Capabilities".
+		const customConfigs = new Map<string, ModelCustomMetadata>([
+			[
+				"anthropic/claude-opus-4-6",
+				{ tier: "heavy", description: "Anthropic's flagship reasoning model.", vision: true },
+			],
+		])
+		const roles = {
+			orchestrator: "anthropic/claude-opus-4-6",
+			planner: "anthropic/claude-opus-4-6",
+			builder: "kimchi-dev/minimax-m2.7",
+			reviewer: "kimchi-dev/minimax-m2.7",
+			explorer: "kimchi-dev/nemotron-3-super-fp4",
+			researcher: "kimchi-dev/nemotron-3-super-fp4",
+			judge: "kimchi-dev/kimi-k2.6",
+		}
+		const result = resolveAsString({
+			currentModelId: "claude-opus-4-6",
+			registry,
+			mode: "orchestrator",
+			roles,
+			customConfigs,
+		})
+		expect(result).toContain("Tier: heavy")
+		expect(result).toContain("Vision: yes")
+		expect(result).toContain("Anthropic's flagship reasoning model.")
+	})
+
 	it("model assigned to multiple roles lists all roles in default description", () => {
 		const customConfigs = new Map<string, ModelCustomMetadata>([["multi-role/model", {}]])
 		const roles = {
@@ -452,5 +485,29 @@ describe("resolveOrchestrationInstructions with custom configs", () => {
 			customConfigs,
 		})
 		expect(result).toContain("This model was configured by the user to handle builder, reviewer work.")
+	})
+})
+
+describe("Build phase directive (complex-chunk tier routing)", () => {
+	const registry = new ModelRegistry(ALL_KNOWN_METADATA)
+
+	it("routes complex chunks to a heavy-tier Builder on first attempt, not as a retry", () => {
+		// Regression: the previous directive said "Use a standard-tier Builder by default.
+		// Use a heavy-tier Builder only as a retry when a standard-tier Builder has
+		// already failed." That contradicts the tier model elsewhere in the prompt,
+		// which says complex chunks (concurrency, state machines, algorithms) require
+		// a heavy-tier Builder. The new tier metadata would never actually route
+		// complex chunks to the heavy model on the first attempt.
+		const result = resolveAsString({
+			currentModelId: "kimi-k2.6",
+			registry,
+			mode: "orchestrator",
+			roles: DEFAULT_MODEL_ROLES,
+		})
+		expect(result).toContain("#### Build phase")
+		// The directive must explicitly call out heavy-tier for complex chunks on the first attempt.
+		expect(result).toMatch(/complex chunk.*heavy-tier Builder/s)
+		// And it must NOT tell the orchestrator to start with standard-tier and only escalate on retry.
+		expect(result).not.toMatch(/standard-tier Builder by default.*retry/s)
 	})
 })

--- a/src/extensions/orchestration/orchestration-instructions.test.ts
+++ b/src/extensions/orchestration/orchestration-instructions.test.ts
@@ -322,7 +322,7 @@ describe("resolveOrchestrationInstructions with custom configs", () => {
 		expect(result).toContain("Anthropic's flagship external model.")
 	})
 
-	it("shows external orchestrator model with custom config in Your Capabilities", () => {
+	it("shows external orchestrator model with custom config in Your Capabilities using assigned roles", () => {
 		const customConfig: CustomModelConfig = {
 			model: "external-orchestrator",
 			tier: "heavy",
@@ -345,50 +345,98 @@ describe("resolveOrchestrationInstructions with custom configs", () => {
 			customConfigs,
 		})
 		expect(result).toContain("Tier: heavy")
-		expect(result).toContain("Roles: plan, research, build, review")
+		expect(result).toContain("Roles: orchestrator, planner")
 		expect(result).toContain("Vision: yes")
 		expect(result).toContain("External orchestrator model.")
 	})
 
-	it("external model without custom config falls back to generic text", () => {
+	it("external model without custom config defaults to standard tier and vision no", () => {
+		const roles = {
+			orchestrator: "kimchi-dev/kimi-k2.6",
+			planner: "kimchi-dev/kimi-k2.6",
+			builder: "unknown-model",
+			reviewer: "kimchi-dev/minimax-m2.7",
+			explorer: "kimchi-dev/nemotron-3-super-fp4",
+			judge: "kimchi-dev/kimi-k2.6",
+		}
 		const result = resolveOrchestrationInstructions({
 			currentModelId: "unknown-model",
 			registry,
 			mode: "orchestrator",
-			roles: {
-				orchestrator: "kimchi-dev/kimi-k2.6",
-				planner: "kimchi-dev/kimi-k2.6",
-				builder: "unknown-model",
-				reviewer: "kimchi-dev/minimax-m2.7",
-				explorer: "kimchi-dev/nemotron-3-super-fp4",
-				judge: "kimchi-dev/kimi-k2.6",
-			},
+			roles,
 		})
 		expect(result).toContain("unknown-model")
+		expect(result).toContain("Tier: standard")
+		expect(result).toContain("Vision: no")
+		expect(result).toContain("This model was configured by the user to handle builder work.")
 		expect(result).not.toContain("Tier: undefined")
-		expect(result).not.toContain("description: undefined")
 	})
 
-	it("custom config with only model field renders without undefined tier/description", () => {
+	it("custom config with only model field defaults tier to standard and vision to no", () => {
 		const customConfig: CustomModelConfig = { model: "bare-external/model" }
 		const customConfigs = new Map<string, CustomModelConfig>([["bare-external/model", customConfig]])
+		const roles = {
+			orchestrator: "kimchi-dev/kimi-k2.6",
+			planner: "kimchi-dev/kimi-k2.6",
+			builder: "bare-external/model",
+			reviewer: "kimchi-dev/minimax-m2.7",
+			explorer: "kimchi-dev/nemotron-3-super-fp4",
+			judge: "kimchi-dev/kimi-k2.6",
+		}
 		const result = resolveOrchestrationInstructions({
 			currentModelId: "kimi-k2.6",
 			registry,
 			mode: "orchestrator",
-			roles: {
-				orchestrator: "kimchi-dev/kimi-k2.6",
-				planner: "kimchi-dev/kimi-k2.6",
-				builder: "bare-external/model",
-				reviewer: "kimchi-dev/minimax-m2.7",
-				explorer: "kimchi-dev/nemotron-3-super-fp4",
-				judge: "kimchi-dev/kimi-k2.6",
-			},
+			roles,
 			customConfigs,
 		})
 		expect(result).toContain("bare-external/model")
+		expect(result).toContain("Tier: standard")
+		expect(result).toContain("Vision: no")
+		expect(result).toContain("This model was configured by the user to handle builder work.")
 		expect(result).not.toContain("Tier: undefined")
 		expect(result).not.toContain("Vision: undefined")
-		expect(result).not.toContain("  undefined")
+	})
+
+	it("external orchestrator without custom config shows roles from config", () => {
+		const roles = {
+			orchestrator: "external-orchestrator",
+			planner: "external-orchestrator",
+			builder: "kimchi-dev/minimax-m2.7",
+			reviewer: "kimchi-dev/minimax-m2.7",
+			explorer: "kimchi-dev/nemotron-3-super-fp4",
+			judge: "external-orchestrator",
+		}
+		const result = resolveOrchestrationInstructions({
+			currentModelId: "external-orchestrator",
+			registry,
+			mode: "orchestrator",
+			roles,
+		})
+		expect(result).toContain("Tier: standard")
+		expect(result).toContain("Roles: orchestrator, planner")
+		expect(result).toContain("Vision: no")
+		expect(result).toContain("This model was configured by the user to handle orchestrator, planner work.")
+	})
+
+	it("model assigned to multiple roles lists all roles in default description", () => {
+		const customConfig: CustomModelConfig = { model: "multi-role/model" }
+		const customConfigs = new Map<string, CustomModelConfig>([["multi-role/model", customConfig]])
+		const roles = {
+			orchestrator: "kimchi-dev/kimi-k2.6",
+			planner: "kimchi-dev/kimi-k2.6",
+			builder: "multi-role/model",
+			reviewer: "multi-role/model",
+			explorer: "kimchi-dev/nemotron-3-super-fp4",
+			judge: "kimchi-dev/kimi-k2.6",
+		}
+		const result = resolveOrchestrationInstructions({
+			currentModelId: "kimi-k2.6",
+			registry,
+			mode: "orchestrator",
+			roles,
+			customConfigs,
+		})
+		expect(result).toContain("This model was configured by the user to handle builder, reviewer work.")
 	})
 })

--- a/src/extensions/orchestration/orchestration-instructions.test.ts
+++ b/src/extensions/orchestration/orchestration-instructions.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest"
 import type { ModelMetadata } from "../../models.js"
 import { MODEL_CAPABILITIES, ModelRegistry } from "./model-registry/index.js"
+import type { CustomModelConfig } from "./model-roles.js"
 import { DEFAULT_MODEL_ROLES } from "./model-roles.js"
 import { resolveOrchestrationInstructions } from "./orchestration-instructions.js"
 
@@ -288,5 +289,106 @@ describe("resolveOrchestrationInstructions", () => {
 		expect(result).toContain("### Builder")
 		expect(result).toContain("minimax-m2.7")
 		expect(result).toContain("### Reviewer")
+	})
+})
+
+describe("resolveOrchestrationInstructions with custom configs", () => {
+	const registry = new ModelRegistry(ALL_KNOWN_METADATA)
+
+	it("shows external model with custom config in Your Team with tier and description", () => {
+		const customConfig: CustomModelConfig = {
+			model: "anthropic/external-model",
+			tier: "heavy",
+			description: "Anthropic's flagship external model.",
+			vision: false,
+		}
+		const customConfigs = new Map<string, CustomModelConfig>([["anthropic/external-model", customConfig]])
+		const result = resolveOrchestrationInstructions({
+			currentModelId: "kimi-k2.6",
+			registry,
+			mode: "orchestrator",
+			roles: {
+				orchestrator: "kimchi-dev/kimi-k2.6",
+				planner: "kimchi-dev/kimi-k2.6",
+				builder: "anthropic/external-model",
+				reviewer: "kimchi-dev/minimax-m2.7",
+				explorer: "kimchi-dev/nemotron-3-super-fp4",
+				judge: "kimchi-dev/kimi-k2.6",
+			},
+			customConfigs,
+		})
+		expect(result).toContain("anthropic/external-model")
+		expect(result).toContain("Tier: heavy")
+		expect(result).toContain("Anthropic's flagship external model.")
+	})
+
+	it("shows external orchestrator model with custom config in Your Capabilities", () => {
+		const customConfig: CustomModelConfig = {
+			model: "external-orchestrator",
+			tier: "heavy",
+			description: "External orchestrator model.",
+			vision: true,
+		}
+		const customConfigs = new Map<string, CustomModelConfig>([["external-orchestrator", customConfig]])
+		const result = resolveOrchestrationInstructions({
+			currentModelId: "external-orchestrator",
+			registry,
+			mode: "orchestrator",
+			roles: {
+				orchestrator: "external-orchestrator",
+				planner: "external-orchestrator",
+				builder: "kimchi-dev/minimax-m2.7",
+				reviewer: "kimchi-dev/minimax-m2.7",
+				explorer: "kimchi-dev/nemotron-3-super-fp4",
+				judge: "external-orchestrator",
+			},
+			customConfigs,
+		})
+		expect(result).toContain("Tier: heavy")
+		expect(result).toContain("Roles: plan, research, build, review")
+		expect(result).toContain("Vision: yes")
+		expect(result).toContain("External orchestrator model.")
+	})
+
+	it("external model without custom config falls back to generic text", () => {
+		const result = resolveOrchestrationInstructions({
+			currentModelId: "unknown-model",
+			registry,
+			mode: "orchestrator",
+			roles: {
+				orchestrator: "kimchi-dev/kimi-k2.6",
+				planner: "kimchi-dev/kimi-k2.6",
+				builder: "unknown-model",
+				reviewer: "kimchi-dev/minimax-m2.7",
+				explorer: "kimchi-dev/nemotron-3-super-fp4",
+				judge: "kimchi-dev/kimi-k2.6",
+			},
+		})
+		expect(result).toContain("unknown-model")
+		expect(result).not.toContain("Tier: undefined")
+		expect(result).not.toContain("description: undefined")
+	})
+
+	it("custom config with only model field renders without undefined tier/description", () => {
+		const customConfig: CustomModelConfig = { model: "bare-external/model" }
+		const customConfigs = new Map<string, CustomModelConfig>([["bare-external/model", customConfig]])
+		const result = resolveOrchestrationInstructions({
+			currentModelId: "kimi-k2.6",
+			registry,
+			mode: "orchestrator",
+			roles: {
+				orchestrator: "kimchi-dev/kimi-k2.6",
+				planner: "kimchi-dev/kimi-k2.6",
+				builder: "bare-external/model",
+				reviewer: "kimchi-dev/minimax-m2.7",
+				explorer: "kimchi-dev/nemotron-3-super-fp4",
+				judge: "kimchi-dev/kimi-k2.6",
+			},
+			customConfigs,
+		})
+		expect(result).toContain("bare-external/model")
+		expect(result).not.toContain("Tier: undefined")
+		expect(result).not.toContain("Vision: undefined")
+		expect(result).not.toContain("  undefined")
 	})
 })

--- a/src/extensions/orchestration/orchestration-instructions.test.ts
+++ b/src/extensions/orchestration/orchestration-instructions.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from "vitest"
 import type { ModelMetadata } from "../../models.js"
+import type { ModelCustomMetadata } from "./model-metadata.js"
 import { MODEL_CAPABILITIES, ModelRegistry } from "./model-registry/index.js"
-import type { CustomModelConfig } from "./model-roles.js"
 import { DEFAULT_MODEL_ROLES } from "./model-roles.js"
 import { resolveOrchestrationInstructions } from "./orchestration-instructions.js"
 
@@ -296,13 +296,12 @@ describe("resolveOrchestrationInstructions with custom configs", () => {
 	const registry = new ModelRegistry(ALL_KNOWN_METADATA)
 
 	it("shows external model with custom config in Your Team with tier and description", () => {
-		const customConfig: CustomModelConfig = {
-			model: "anthropic/external-model",
-			tier: "heavy",
-			description: "Anthropic's flagship external model.",
-			vision: false,
-		}
-		const customConfigs = new Map<string, CustomModelConfig>([["anthropic/external-model", customConfig]])
+		const customConfigs = new Map<string, ModelCustomMetadata>([
+			[
+				"anthropic/external-model",
+				{ tier: "heavy", description: "Anthropic's flagship external model.", vision: false },
+			],
+		])
 		const result = resolveOrchestrationInstructions({
 			currentModelId: "kimi-k2.6",
 			registry,
@@ -323,13 +322,9 @@ describe("resolveOrchestrationInstructions with custom configs", () => {
 	})
 
 	it("shows external orchestrator model with custom config in Your Capabilities using assigned roles", () => {
-		const customConfig: CustomModelConfig = {
-			model: "external-orchestrator",
-			tier: "heavy",
-			description: "External orchestrator model.",
-			vision: true,
-		}
-		const customConfigs = new Map<string, CustomModelConfig>([["external-orchestrator", customConfig]])
+		const customConfigs = new Map<string, ModelCustomMetadata>([
+			["external-orchestrator", { tier: "heavy", description: "External orchestrator model.", vision: true }],
+		])
 		const result = resolveOrchestrationInstructions({
 			currentModelId: "external-orchestrator",
 			registry,
@@ -372,9 +367,8 @@ describe("resolveOrchestrationInstructions with custom configs", () => {
 		expect(result).not.toContain("Tier: undefined")
 	})
 
-	it("custom config with only model field defaults tier to standard and vision to no", () => {
-		const customConfig: CustomModelConfig = { model: "bare-external/model" }
-		const customConfigs = new Map<string, CustomModelConfig>([["bare-external/model", customConfig]])
+	it("empty custom metadata defaults tier to standard and vision to no", () => {
+		const customConfigs = new Map<string, ModelCustomMetadata>([["bare-external/model", {}]])
 		const roles = {
 			orchestrator: "kimchi-dev/kimi-k2.6",
 			planner: "kimchi-dev/kimi-k2.6",
@@ -420,8 +414,7 @@ describe("resolveOrchestrationInstructions with custom configs", () => {
 	})
 
 	it("model assigned to multiple roles lists all roles in default description", () => {
-		const customConfig: CustomModelConfig = { model: "multi-role/model" }
-		const customConfigs = new Map<string, CustomModelConfig>([["multi-role/model", customConfig]])
+		const customConfigs = new Map<string, ModelCustomMetadata>([["multi-role/model", {}]])
 		const roles = {
 			orchestrator: "kimchi-dev/kimi-k2.6",
 			planner: "kimchi-dev/kimi-k2.6",

--- a/src/extensions/orchestration/orchestration-instructions.test.ts
+++ b/src/extensions/orchestration/orchestration-instructions.test.ts
@@ -3,7 +3,15 @@ import type { ModelMetadata } from "../../models.js"
 import type { ModelCustomMetadata } from "./model-metadata.js"
 import { MODEL_CAPABILITIES, ModelRegistry } from "./model-registry/index.js"
 import { DEFAULT_MODEL_ROLES } from "./model-roles.js"
-import { resolveOrchestrationInstructions } from "./orchestration-instructions.js"
+import {
+	type OrchestrationInstructionsContext,
+	resolveOrchestrationInstructions,
+} from "./orchestration-instructions.js"
+
+function resolveAsString(ctx: OrchestrationInstructionsContext): string {
+	const { teamSection, instructionsSection } = resolveOrchestrationInstructions(ctx)
+	return [teamSection, instructionsSection].filter(Boolean).join("\n\n")
+}
 
 const ALL_KNOWN_IDS = [...MODEL_CAPABILITIES.keys()]
 
@@ -25,7 +33,7 @@ describe("resolveOrchestrationInstructions", () => {
 	const registry = new ModelRegistry(ALL_KNOWN_METADATA)
 
 	it("returns orchestration instructions in orchestrator mode", () => {
-		const result = resolveOrchestrationInstructions({
+		const result = resolveAsString({
 			currentModelId: "kimi-k2.6",
 			registry,
 			mode: "orchestrator",
@@ -35,7 +43,7 @@ describe("resolveOrchestrationInstructions", () => {
 	})
 
 	it("shows role assignments with Your Team section", () => {
-		const result = resolveOrchestrationInstructions({
+		const result = resolveAsString({
 			currentModelId: "kimi-k2.6",
 			registry,
 			mode: "orchestrator",
@@ -48,44 +56,47 @@ describe("resolveOrchestrationInstructions", () => {
 	})
 
 	it("shows Your Capabilities section with orchestrator roles", () => {
-		const result = resolveOrchestrationInstructions({
+		const result = resolveAsString({
 			currentModelId: "kimi-k2.6",
 			registry,
 			mode: "orchestrator",
 			roles: DEFAULT_MODEL_ROLES,
 		})
 		expect(result).toContain("## Your Capabilities")
-		expect(result).toContain("Roles: orchestrator, planner, builder, reviewer, researcher")
+		expect(result).toContain("You have these roles: **planner, builder, reviewer, researcher**")
 	})
 
-	it("uses role-based delegation rules in Step 3", () => {
-		const result = resolveOrchestrationInstructions({
+	it("uses DO/DONT directives in Step 3", () => {
+		const result = resolveAsString({
 			currentModelId: "kimi-k2.6",
 			registry,
 			mode: "orchestrator",
 			roles: DEFAULT_MODEL_ROLES,
 		})
-		expect(result).toContain("Your roles are the authoritative signal")
-		expect(result).toContain("If a step matches your roles")
-		expect(result).toContain("delegate it to a model from the matching role pool")
+		expect(result).toContain("Your responsibilities per phase")
+		expect(result).toContain("#### Plan phase")
+		expect(result).toContain("#### Build phase")
+		expect(result).toContain("#### Review phase")
+		expect(result).toContain("#### Explore phase")
+		expect(result).toContain("#### Research phase")
 	})
 
 	it("instructs to use matching persona for each step", () => {
-		const result = resolveOrchestrationInstructions({
+		const result = resolveAsString({
 			currentModelId: "kimi-k2.6",
 			registry,
 			mode: "orchestrator",
-			roles: DEFAULT_MODEL_ROLES,
+			roles: {
+				...DEFAULT_MODEL_ROLES,
+				planner: "some-other/model",
+			},
 		})
-		expect(result).toContain('Agent(type: "Builder"')
-		expect(result).toContain('Agent(type: "Reviewer"')
-		expect(result).toContain('Agent(type: "Fixer"')
-		expect(result).toContain('Agent(type: "Explore"')
 		expect(result).toContain('Agent(type: "Plan"')
+		expect(result).toContain("some-other/model")
 	})
 
 	it("shows model IDs from the roles config", () => {
-		const result = resolveOrchestrationInstructions({
+		const result = resolveAsString({
 			currentModelId: "kimi-k2.6",
 			registry,
 			mode: "orchestrator",
@@ -104,19 +115,20 @@ describe("resolveOrchestrationInstructions", () => {
 		expect(result).toContain("kimchi-dev/nemotron-3-ultra-fp4")
 	})
 
-	it("omits Planner section when planner equals orchestrator", () => {
-		const result = resolveOrchestrationInstructions({
+	it("generates DO directive for plan when orchestrator is planner", () => {
+		const result = resolveAsString({
 			currentModelId: "kimi-k2.6",
 			registry,
 			mode: "orchestrator",
 			roles: DEFAULT_MODEL_ROLES,
 		})
 		expect(result).not.toContain("### Planner")
-		expect(result).toContain("you write the plan yourself in-process")
+		expect(result).toContain("DO write the plan yourself")
+		expect(result).not.toContain("DO NOT write the plan yourself")
 	})
 
-	it("shows Planner section when planner has multiple models or differs from orchestrator", () => {
-		const result = resolveOrchestrationInstructions({
+	it("generates DO NOT directive for plan when orchestrator is not planner", () => {
+		const result = resolveAsString({
 			currentModelId: "kimi-k2.6",
 			registry,
 			mode: "orchestrator",
@@ -127,10 +139,13 @@ describe("resolveOrchestrationInstructions", () => {
 		})
 		expect(result).toContain("### Planner")
 		expect(result).toContain("anthropic/claude-opus-4-7")
+		expect(result).toContain("DO NOT write the plan yourself")
+		expect(result).toContain('delegate planning to Agent(type: "Plan"')
+		expect(result).not.toContain("DO write the plan yourself")
 	})
 
 	it("renders tier and description for models in Your Team", () => {
-		const result = resolveOrchestrationInstructions({
+		const result = resolveAsString({
 			currentModelId: "kimi-k2.6",
 			registry,
 			mode: "orchestrator",
@@ -142,12 +157,11 @@ describe("resolveOrchestrationInstructions", () => {
 	})
 
 	it("still works without roles (no team section, instructions only)", () => {
-		const result = resolveOrchestrationInstructions({
+		const result = resolveAsString({
 			currentModelId: "kimi-k2.6",
 			registry,
 			mode: "orchestrator",
 		})
-		expect(result).toContain("Sharing context between agents")
 		expect(result).toContain("Orchestrate the work")
 		expect(result).toContain("Token budgets")
 		expect(result).toContain("token_budget")
@@ -160,7 +174,7 @@ describe("resolveOrchestrationInstructions", () => {
 	})
 
 	it("includes concurrency test mandate in plan checklist", () => {
-		const result = resolveOrchestrationInstructions({
+		const result = resolveAsString({
 			currentModelId: "kimi-k2.6",
 			registry,
 			mode: "orchestrator",
@@ -171,7 +185,7 @@ describe("resolveOrchestrationInstructions", () => {
 	})
 
 	it("includes chunk complexity classification in plan and build phases", () => {
-		const result = resolveOrchestrationInstructions({
+		const result = resolveAsString({
 			currentModelId: "kimi-k2.6",
 			registry,
 			mode: "orchestrator",
@@ -184,7 +198,7 @@ describe("resolveOrchestrationInstructions", () => {
 	})
 
 	it("includes complex chunk spec detail requirements", () => {
-		const result = resolveOrchestrationInstructions({
+		const result = resolveAsString({
 			currentModelId: "kimi-k2.6",
 			registry,
 			mode: "orchestrator",
@@ -197,7 +211,7 @@ describe("resolveOrchestrationInstructions", () => {
 	})
 
 	it("includes review row in budget table", () => {
-		const result = resolveOrchestrationInstructions({
+		const result = resolveAsString({
 			currentModelId: "kimi-k2.6",
 			registry,
 			mode: "orchestrator",
@@ -208,7 +222,7 @@ describe("resolveOrchestrationInstructions", () => {
 	})
 
 	it("does not include lightweight re-verification guidance", () => {
-		const result = resolveOrchestrationInstructions({
+		const result = resolveAsString({
 			currentModelId: "kimi-k2.6",
 			registry,
 			mode: "orchestrator",
@@ -218,7 +232,7 @@ describe("resolveOrchestrationInstructions", () => {
 	})
 
 	it("returns single-model instructions with model ID in single-model mode", () => {
-		const result = resolveOrchestrationInstructions({
+		const result = resolveAsString({
 			currentModelId: "kimi-k2.6",
 			registry,
 			mode: "single",
@@ -230,7 +244,7 @@ describe("resolveOrchestrationInstructions", () => {
 	})
 
 	it("returns subagent instructions in subagent mode", () => {
-		const result = resolveOrchestrationInstructions({
+		const result = resolveAsString({
 			currentModelId: "kimi-k2.6",
 			registry,
 			mode: "subagent",
@@ -241,7 +255,7 @@ describe("resolveOrchestrationInstructions", () => {
 	})
 
 	it("does not affect subagent mode even with roles", () => {
-		const result = resolveOrchestrationInstructions({
+		const result = resolveAsString({
 			currentModelId: "kimi-k2.6",
 			registry,
 			mode: "subagent",
@@ -252,7 +266,7 @@ describe("resolveOrchestrationInstructions", () => {
 	})
 
 	it("does not affect single-model mode even with roles", () => {
-		const result = resolveOrchestrationInstructions({
+		const result = resolveAsString({
 			currentModelId: "kimi-k2.6",
 			registry,
 			mode: "single",
@@ -263,7 +277,7 @@ describe("resolveOrchestrationInstructions", () => {
 	})
 
 	it("includes model-specific orchestration guidelines when provided", () => {
-		const result = resolveOrchestrationInstructions({
+		const result = resolveAsString({
 			currentModelId: "minimax-m2.7",
 			registry,
 			mode: "orchestrator",
@@ -274,7 +288,7 @@ describe("resolveOrchestrationInstructions", () => {
 	})
 
 	it("renders multiple models per role when configured as array", () => {
-		const result = resolveOrchestrationInstructions({
+		const result = resolveAsString({
 			currentModelId: "kimi-k2.6",
 			registry,
 			mode: "orchestrator",
@@ -304,7 +318,7 @@ describe("resolveOrchestrationInstructions with custom configs", () => {
 				{ tier: "heavy", description: "Anthropic's flagship external model.", vision: false },
 			],
 		])
-		const result = resolveOrchestrationInstructions({
+		const result = resolveAsString({
 			currentModelId: "kimi-k2.6",
 			registry,
 			mode: "orchestrator",
@@ -328,7 +342,7 @@ describe("resolveOrchestrationInstructions with custom configs", () => {
 		const customConfigs = new Map<string, ModelCustomMetadata>([
 			["external-orchestrator", { tier: "heavy", description: "External orchestrator model.", vision: true }],
 		])
-		const result = resolveOrchestrationInstructions({
+		const result = resolveAsString({
 			currentModelId: "external-orchestrator",
 			registry,
 			mode: "orchestrator",
@@ -344,7 +358,7 @@ describe("resolveOrchestrationInstructions with custom configs", () => {
 			customConfigs,
 		})
 		expect(result).toContain("Tier: heavy")
-		expect(result).toContain("Roles: orchestrator, planner")
+		expect(result).toContain("You have these roles: **planner**")
 		expect(result).toContain("Vision: yes")
 		expect(result).toContain("External orchestrator model.")
 	})
@@ -359,7 +373,7 @@ describe("resolveOrchestrationInstructions with custom configs", () => {
 			researcher: "kimchi-dev/nemotron-3-super-fp4",
 			judge: "kimchi-dev/kimi-k2.6",
 		}
-		const result = resolveOrchestrationInstructions({
+		const result = resolveAsString({
 			currentModelId: "unknown-model",
 			registry,
 			mode: "orchestrator",
@@ -383,7 +397,7 @@ describe("resolveOrchestrationInstructions with custom configs", () => {
 			researcher: "kimchi-dev/nemotron-3-super-fp4",
 			judge: "kimchi-dev/kimi-k2.6",
 		}
-		const result = resolveOrchestrationInstructions({
+		const result = resolveAsString({
 			currentModelId: "kimi-k2.6",
 			registry,
 			mode: "orchestrator",
@@ -408,16 +422,15 @@ describe("resolveOrchestrationInstructions with custom configs", () => {
 			researcher: "kimchi-dev/nemotron-3-super-fp4",
 			judge: "external-orchestrator",
 		}
-		const result = resolveOrchestrationInstructions({
+		const result = resolveAsString({
 			currentModelId: "external-orchestrator",
 			registry,
 			mode: "orchestrator",
 			roles,
 		})
 		expect(result).toContain("Tier: standard")
-		expect(result).toContain("Roles: orchestrator, planner")
+		expect(result).toContain("You have these roles: **planner**")
 		expect(result).toContain("Vision: no")
-		expect(result).toContain("This model was configured by the user to handle orchestrator, planner work.")
 	})
 
 	it("model assigned to multiple roles lists all roles in default description", () => {
@@ -431,7 +444,7 @@ describe("resolveOrchestrationInstructions with custom configs", () => {
 			researcher: "kimchi-dev/nemotron-3-super-fp4",
 			judge: "kimchi-dev/kimi-k2.6",
 		}
-		const result = resolveOrchestrationInstructions({
+		const result = resolveAsString({
 			currentModelId: "kimi-k2.6",
 			registry,
 			mode: "orchestrator",

--- a/src/extensions/orchestration/orchestration-instructions.test.ts
+++ b/src/extensions/orchestration/orchestration-instructions.test.ts
@@ -55,7 +55,7 @@ describe("resolveOrchestrationInstructions", () => {
 			roles: DEFAULT_MODEL_ROLES,
 		})
 		expect(result).toContain("## Your Capabilities")
-		expect(result).toContain("Roles: research, plan, build, review")
+		expect(result).toContain("Roles: orchestrator, planner, builder, reviewer, researcher")
 	})
 
 	it("uses role-based delegation rules in Step 3", () => {
@@ -95,6 +95,7 @@ describe("resolveOrchestrationInstructions", () => {
 				builder: "anthropic/claude-sonnet-4-5",
 				reviewer: "openai/gpt-4o",
 				explorer: "kimchi-dev/nemotron-3-ultra-fp4",
+				researcher: "kimchi-dev/nemotron-3-ultra-fp4",
 				judge: "kimchi-dev/claude-opus-4-6",
 			},
 		})
@@ -283,6 +284,7 @@ describe("resolveOrchestrationInstructions", () => {
 				builder: ["kimchi-dev/minimax-m2.7", "kimchi-dev/kimi-k2.6"],
 				reviewer: ["kimchi-dev/kimi-k2.6", "kimchi-dev/minimax-m2.7"],
 				explorer: "kimchi-dev/nemotron-3-ultra-fp4",
+				researcher: "kimchi-dev/nemotron-3-ultra-fp4",
 				judge: "kimchi-dev/kimi-k2.6",
 			},
 		})
@@ -312,6 +314,7 @@ describe("resolveOrchestrationInstructions with custom configs", () => {
 				builder: "anthropic/external-model",
 				reviewer: "kimchi-dev/minimax-m2.7",
 				explorer: "kimchi-dev/nemotron-3-super-fp4",
+				researcher: "kimchi-dev/nemotron-3-super-fp4",
 				judge: "kimchi-dev/kimi-k2.6",
 			},
 			customConfigs,
@@ -335,6 +338,7 @@ describe("resolveOrchestrationInstructions with custom configs", () => {
 				builder: "kimchi-dev/minimax-m2.7",
 				reviewer: "kimchi-dev/minimax-m2.7",
 				explorer: "kimchi-dev/nemotron-3-super-fp4",
+				researcher: "kimchi-dev/nemotron-3-super-fp4",
 				judge: "external-orchestrator",
 			},
 			customConfigs,
@@ -352,6 +356,7 @@ describe("resolveOrchestrationInstructions with custom configs", () => {
 			builder: "unknown-model",
 			reviewer: "kimchi-dev/minimax-m2.7",
 			explorer: "kimchi-dev/nemotron-3-super-fp4",
+			researcher: "kimchi-dev/nemotron-3-super-fp4",
 			judge: "kimchi-dev/kimi-k2.6",
 		}
 		const result = resolveOrchestrationInstructions({
@@ -375,6 +380,7 @@ describe("resolveOrchestrationInstructions with custom configs", () => {
 			builder: "bare-external/model",
 			reviewer: "kimchi-dev/minimax-m2.7",
 			explorer: "kimchi-dev/nemotron-3-super-fp4",
+			researcher: "kimchi-dev/nemotron-3-super-fp4",
 			judge: "kimchi-dev/kimi-k2.6",
 		}
 		const result = resolveOrchestrationInstructions({
@@ -399,6 +405,7 @@ describe("resolveOrchestrationInstructions with custom configs", () => {
 			builder: "kimchi-dev/minimax-m2.7",
 			reviewer: "kimchi-dev/minimax-m2.7",
 			explorer: "kimchi-dev/nemotron-3-super-fp4",
+			researcher: "kimchi-dev/nemotron-3-super-fp4",
 			judge: "external-orchestrator",
 		}
 		const result = resolveOrchestrationInstructions({
@@ -421,6 +428,7 @@ describe("resolveOrchestrationInstructions with custom configs", () => {
 			builder: "multi-role/model",
 			reviewer: "multi-role/model",
 			explorer: "kimchi-dev/nemotron-3-super-fp4",
+			researcher: "kimchi-dev/nemotron-3-super-fp4",
 			judge: "kimchi-dev/kimi-k2.6",
 		}
 		const result = resolveOrchestrationInstructions({

--- a/src/extensions/orchestration/orchestration-instructions.ts
+++ b/src/extensions/orchestration/orchestration-instructions.ts
@@ -24,35 +24,42 @@ export interface OrchestrationInstructionsContext {
 	customConfigs?: ReadonlyMap<string, ModelCustomMetadata>
 }
 
-export function resolveOrchestrationInstructions(ctx: OrchestrationInstructionsContext): string {
-	if (ctx.mode === "subagent") {
-		return resolveSubagentInstructions()
-	}
+export interface OrchestrationInstructionsResult {
+	teamSection: string
+	instructionsSection: string
+}
+
+export function resolveOrchestrationInstructions(
+	ctx: OrchestrationInstructionsContext,
+): OrchestrationInstructionsResult {
 	if (ctx.mode === "orchestrator") {
 		return resolveOrchestratorInstructions(ctx)
 	}
-	if (ctx.mode === "single") {
-		return resolveSingleModelInstructions(ctx.currentModelId)
+	if (ctx.mode === "subagent") {
+		return { teamSection: "", instructionsSection: resolveSubagentInstructions() }
 	}
-	return ""
+	if (ctx.mode === "single") {
+		return { teamSection: "", instructionsSection: resolveSingleModelInstructions(ctx.currentModelId) }
+	}
+	return { teamSection: "", instructionsSection: "" }
 }
 
 // ---------------------------------------------------------------------------
 // Orchestrator Mode Instructions
 // ---------------------------------------------------------------------------
 
-const ORCHESTRATOR_INSTRUCTIONS = `## Orchestrate the work
+// ---------------------------------------------------------------------------
+// Orchestrator instruction building blocks (static parts)
+// ---------------------------------------------------------------------------
 
-Before taking any action, silently reason through the steps below. Keep this reasoning internal — do not write it into your response. Proceed directly to the action.
-
-### Step 1 — Classify the task
+const STEP_1_CLASSIFY = `### Step 1 — Classify the task
 
 Decide whether the task is **simple** or **complex**:
 
 - **Simple**: single-file change, no design decisions required, unambiguous what to write.
-- **Complex**: anything involving multiple files, a layered architecture, modifying existing code you haven't read, or any decision about structure or interfaces.
+- **Complex**: anything involving multiple files, a layered architecture, modifying existing code you haven't read, or any decision about structure or interfaces.`
 
-### Step 2 — Identify required pipeline steps
+const STEP_2_PIPELINE = `### Step 2 — Identify required pipeline steps
 
 From the following steps, select only the ones the task actually needs:
 
@@ -62,7 +69,7 @@ From the following steps, select only the ones the task actually needs:
 - build — writing, modifying, or refactoring code.
 - review — verifying correctness, checking for bugs, confirming the implementation matches intent.
 
-Omit steps that add no value. A simple fix may need only build. A complex feature may need all phases. **Match the pipeline to the request**: if the user asks to review code, run explore + review — not plan + build + review. If the user asks to plan an approach, run explore + plan — not the full pipeline. If the user asks to explore or research, do only that. The mandatory plan→build→review pipeline applies only when the task involves writing or modifying code. **Greenfield projects** (empty directory, no existing code to read): skip explore entirely — there is nothing to explore. Merge any discovery work into the plan phase instead.
+Omit steps that add no value. A simple fix may need only build. A complex feature may need all phases. **Match the pipeline to the request**: if the user asks to review code, run explore + review — not plan + build + review. If the user asks to plan an approach, run explore + plan — not the full pipeline. If the user asks to explore or research, do only that. The mandatory plan->build->review pipeline applies only when the task involves writing or modifying code. **Greenfield projects** (empty directory, no existing code to read): skip explore entirely — there is nothing to explore. Merge any discovery work into the plan phase instead.
 
 **Intent boundary — never exceed what was asked.** The selected pipeline is the scope ceiling. No agent — orchestrator or subagent — may perform actions that belong to a pipeline step not selected above. Concrete rules:
 - If the pipeline does not include **build**, no source files may be created, modified, or deleted. No commits may be made. Findings and suggestions are reported, never applied.
@@ -70,44 +77,21 @@ Omit steps that add no value. A simple fix may need only build. A complex featur
 - If the pipeline is **review-only** (explore + review), the output is a findings report. Do not fix, refactor, or apply any of the reported issues. Do not offer to apply fixes inline. Report what you found and stop.
 - If the pipeline is **explore-only** or **research-only**, produce a summary. Do not plan, build, or review.
 
-When delegating to subagents, include the intent boundary explicitly in the agent prompt so the subagent knows what it must not do.
+When delegating to subagents, include the intent boundary explicitly in the agent prompt so the subagent knows what it must not do.`
 
-### Step 3 — Decide what to do yourself vs. delegate
+const STEP_4_EXECUTE = `### Step 4 — Execute
 
-Look at **Your Capabilities** above. Your roles are the authoritative signal — not your confidence, not your general intelligence:
+Run the steps in order. For steps you own, use your tools directly. For steps you delegate, call the Agent tool and wait for it to complete before proceeding unless you explicitly run it in the background. Never perform a step yourself while an Agent for that step is running or after you have delegated it.`
 
-- If a step matches your roles, **do it yourself** — unless the workload is large enough that a cheaper model from the matching pool would be more efficient. In particular: if plan is in your roles, you write the plan yourself. For explore, you may delegate to a lighter model from the Explorer pool when the exploration involves many files; for a few files, do it yourself.
-- **Exception — review must always be delegated**: You MUST delegate review to an Agent from the Reviewer pool. The review agent runs in a separate, fresh context — it has no memory of earlier planning or build decisions, which provides independence. When selecting the reviewer, **prefer a standard-tier Reviewer** that can reliably complete within the timeout — heavy-tier models are slower and more prone to timing out as subagents. Only use a heavy-tier Reviewer when the code involves complex concurrency, security-critical logic, or novel architectural patterns. The same model family in a fresh context is far better than a weaker model with a different name.
-- If a step does not match your roles, delegate it to a model from the matching role pool in **Your Team** — regardless of whether you think you could attempt it.
-- When a role pool has multiple models, match the model's **tier** to the task complexity: use the heaviest model for complex or ambiguous work, the lightest for mechanical work.
-- If your tier is heavy: for each step the task needs, apply the previous rules. In practice this means **you write the plan yourself in-process** (heavy-tier orchestrators always list plan among their roles), save the spec file (interfaces, file paths, method signatures) to the Documents directory, then delegate only the steps you do not own — typically build — to a cheaper Agent call, passing the spec file path.
-- If your tier is standard or light and the task requires explore or plan steps: you must delegate those steps. Your roles list is the gate — if a step type is not listed there, you are not qualified to perform it regardless of task scope or apparent simplicity.
-- **Exception — simple research (overrides every rule above)**: If a task only needs a quick factual lookup (e.g. library comparisons, version numbers, API references, a single fact), call web_search directly and answer from the results — do NOT delegate to an Agent. For simple lookups this is strictly cheaper, faster, and more reliable than spawning an Agent. The roles-based delegation rules apply only when research requires deep analysis, reading multiple long documents, or synthesising information across many sources.
-
-The goal is to use the model best suited for each step, not the one already running. Pick the persona and model for each step from **Your Team**. You MUST always pass a concrete \`model\` — never omit it:
-- Build chunks -> Agent(type: "Builder", model: <standard-tier model for simple chunks, heavy-tier for complex>)
-- Code review -> Agent(type: "Reviewer", model: <standard-tier model>)
-- Fix review issues -> Agent(type: "Fixer", model: <standard-tier model>)
-- Explore codebase -> Agent(type: "Explore", model: <light-tier or standard-tier model>)
-- Verify plan -> Agent(type: "Plan", model: <heavy-tier model>)
-
-### Step 4 — Execute
-
-Run the steps in order. For steps you own, use your tools directly. For steps you delegate, call the Agent tool and wait for it to complete before proceeding unless you explicitly run it in the background. Never perform a step yourself while an Agent for that step is running or after you have delegated it.
-
-#### Mandatory pipeline for complex tasks
-
-When Step 1 classified the task as **complex**, you MUST execute it as a phased pipeline — never lump everything into a single Agent call or do it all yourself. The phases below are sequential; each one produces an artefact the next one consumes.
-
-1. **Plan phase** — Produce a Markdown spec file in the Documents directory. The spec MUST break the work into **small, independently-buildable chunks** — each chunk is a single cohesive unit (typically 1–3 files) that can be verified independently. Keep implementation and its tests in the same chunk — the agent that writes the code has the best context to test it. Include for each chunk: the file paths, method signatures / interfaces, expected behaviour, acceptance criteria, and a **complexity** classification:
+const PLAN_SPEC_REQUIREMENTS = `The spec MUST break the work into **small, independently-buildable chunks** — each chunk is a single cohesive unit (typically 1–3 files) that can be verified independently. Keep implementation and its tests in the same chunk — the agent that writes the code has the best context to test it. Include for each chunk: the file paths, method signatures / interfaces, expected behaviour, acceptance criteria, and a **complexity** classification:
    - **simple** — straightforward CRUD, data structures, boilerplate, CLI wiring, simple input parsing. A standard-tier Builder can implement this from the spec alone.
    - **complex** — concurrency (goroutines, threads, channels, mutexes, worker pools), state machines, graph algorithms (topological sort, cycle detection, BFS/DFS), dynamic programming, signal handling, tricky synchronization, or any logic where correctness depends on subtle ordering or edge cases. Requires a heavy-tier Builder.
 
 **What makes a good complex chunk spec:** For each chunk classified as \`complex\`, the spec MUST include: (1) the specific concurrency/algorithm primitives to use (e.g. "sync.WaitGroup + buffered channel of size N", not just "use concurrency"), (2) the lifecycle of goroutines/threads (who spawns, who waits, what triggers shutdown), (3) the error propagation path (which errors cancel other work, which are collected and returned). A complex chunk without these details is not ready for delegation — the builder will invent the design and likely get it wrong, causing repeated aborts.
 
-Chunks must be ordered so each one can build on the previous. If plan is in your roles, write it yourself; otherwise delegate to a Planner agent.
+Chunks must be ordered so each one can build on the previous.`
 
-**Plan self-validation (mandatory, lightweight):** After writing the spec, re-read it in a separate turn and cross-check every requirement from the original task against the plan. Flag any gap — missing features, ambiguous API choices (e.g. which stdlib function to use), unhandled edge cases (signals, timeouts, concurrency). Fix gaps before proceeding to build. This is a SELF check — it does not replace external verification for complex tasks.
+const PLAN_VERIFICATION = `**Plan self-validation (mandatory, lightweight):** After the spec is written, re-read it in a separate turn and cross-check every requirement from the original task against the plan. Flag any gap — missing features, ambiguous API choices (e.g. which stdlib function to use), unhandled edge cases (signals, timeouts, concurrency). Fix gaps before proceeding to build.
 
 **Plan verification (required for complex tasks, optional for simple):** After self-validation, decide whether the plan needs external verification.
 
@@ -116,16 +100,12 @@ Chunks must be ordered so each one can build on the previous. If plan is in your
 - Well-understood pattern (e.g. adding a field, fixing a nil check, updating a constant)
 - No new architecture, interfaces, or data flow
 - No ambiguous requirements or multiple valid approaches
-- Orchestrator is confident the plan is complete and correct
 
 **Require verification when ANY of these apply:**
 - 3+ files or 2+ chunks in the plan
 - New architecture, abstraction layer, or unfamiliar pattern
 - Requirements are unclear, incomplete, or have multiple interpretations
 - The task involves concurrency, state machines, or distributed logic
-- The orchestrator is uncertain about completeness or correctness
-
-**Who verifies:** A model with \`plan\` or \`review\` in its roles. Read the model descriptions to pick the right verifier — checklist-style verification can use a standard-tier model, but plans involving concurrency or algorithmic design need a model whose description confirms it can reason about correctness.
 
 **Verification prompt:** The verifier receives: (1) the original task description, (2) the plan spec file path. Verifier reads both, then outputs a brief markdown verdict:
 - APPROVED — the plan is complete, buildable, and aligned with requirements.
@@ -135,14 +115,9 @@ The verifier MUST check **build feasibility** and **complexity classification** 
 - **Build feasibility**: is the spec detailed enough that a standard-tier Builder model can implement it without inventing design decisions? Are concurrency primitives named (e.g. "use sync.WaitGroup + channels", not just "use concurrency")? Are state transitions explicit? Are synchronization points specified?
 - **Complexity accuracy**: is the chunk classified correctly? A chunk using concurrency primitives, worker pools, channels, mutexes, signal handling, graph algorithms (topological sort, cycle detection, BFS/DFS), or any logic where correctness depends on subtle ordering MUST be marked \`complex\`. A chunk marked \`simple\` that contains any of these is a classification error.
 - **Chunk scope**: does any single chunk combine multiple independent concurrency concerns (e.g. worker pool scheduling AND signal handling AND fail-fast cancellation)? A chunk that stacks 3+ concurrency mechanisms must be split — models spend excessive generation time reasoning about all interactions at once, frequently hitting duration limits. Split along natural seams: e.g. one chunk for the core execution loop with worker pool, a separate chunk for signal handling and graceful shutdown wired on top.
-If any chunk fails either check, the verdict MUST be NEEDS_REVISION with the specific gaps listed.
+If any chunk fails either check, the verdict MUST be NEEDS_REVISION with the specific gaps listed.`
 
-**Handling the verdict:** If APPROVED: proceed to build phase. If NEEDS_REVISION: fix the gaps (yourself if plan is in your roles; otherwise delegate to a Planner agent). After revision, send ONLY the changed sections back to the verifier — not the full plan. Maximum one re-verification round; if still not approved, proceed with documented reservations.
-2. **Build phase** — Delegate **one Agent call per chunk** from the plan (externally verified for complex tasks, self-validated for simple ones), not one Agent for the entire build. Each agent gets the spec file path and is told which chunk to implement. Instruct every build agent to: (1) write the implementation, (2) write tests, (3) verify the code compiles and passes lint, (4) run tests exactly once. If compilation fails or tests fail, report the failures and stop — do not iterate on fix-retry cycles. The orchestrator will spawn a targeted fix agent if needed. If chunks are independent (no data dependency), run up to 3 build agents in parallel with run_in_background. If chunks are sequential, run them one at a time, passing the previous chunk's output as context to the next. **Model selection for builders**: use a standard-tier Builder for all chunks. Standard-tier models are faster and more reliable within subagent time/token budgets. Reserve heavy-tier Builders only as a fallback when a standard-tier Builder has already failed on the same chunk.
-**Build-to-review transition**: When the last build chunk's subagent completes, transition to review phase immediately. Do NOT read the subagent's output files yourself, do NOT run tests yourself, do NOT verify the code. Trust the subagent's completion report. The Reviewer subagent will independently verify everything in a fresh context — that is the whole point of the review phase.
-3. **Review phase** — After all build chunks complete, delegate a single review agent. Prefer a **standard-tier Reviewer** that reliably completes within the timeout. Only use a heavy-tier Reviewer for complex concurrency, security-critical logic, or novel architectural patterns — and if you do, apply heavy-tier duration scaling (1.5x max_duration). The review agent runs in a fresh context with no memory of earlier work. Pass the spec file path and the full list of created files. **Review delegation is mandatory** — you MUST spawn a Reviewer Agent even if you already ran tests during build. Your in-process verification is not a substitute: you have context bias from planning and building; the reviewer does not.
-
-**Review output contract:** Instruct the review agent to write its findings to a Markdown file in the Documents directory (e.g. \`.kimchi/docs/review.md\`). The file MUST contain:
+const REVIEW_PHASE = `**Review output contract:** Instruct the review agent to write its findings to a Markdown file in the Documents directory (e.g. \`.kimchi/docs/review.md\`). The file MUST contain:
 - **Verdict**: APPROVED or NEEDS_FIXES
 - **Issues** (if NEEDS_FIXES): numbered list, each with the file path, line reference, description of the problem, and suggested fix
 
@@ -158,49 +133,34 @@ The review agent runs tests, checks lint, and verifies the implementation matche
 - **Verdict**: ALL_PASS or HAS_FAILURES
 
 **After the fix agent completes:** Read ONLY the verification file — this is the ONLY action you take. Do NOT re-read source files, do NOT run tests yourself, do NOT grep, do NOT smoke-test, do NOT write any file, do NOT build the binary, do NOT create test scripts. Then:
-- If the verdict is ALL_PASS → review phase is complete. Produce ONE final summary message and stop. Do not repeat the summary.
-- If the verdict is HAS_FAILURES → this is fix round 1. Spawn ONE more fix agent with the remaining failures. When it returns its verification file, read it. That is fix round 2.
+- If the verdict is ALL_PASS -> review phase is complete. Produce ONE final summary message and stop. Do not repeat the summary.
+- If the verdict is HAS_FAILURES -> this is fix round 1. Spawn ONE more fix agent with the remaining failures. When it returns its verification file, read it. That is fix round 2.
 - After round 2, STOP regardless of outcome. If failures remain, report them to the user as unresolved. Do NOT attempt a third round. Do NOT debug manually. Do NOT write smoke tests. Do NOT run the binary.
 - If remaining failures are tests that assert specific ordering of concurrently-executed operations (e.g. checking which goroutine/thread finishes first), these are non-deterministic test design flaws, not implementation bugs. Report them as known flaky tests and stop — do not attempt to fix non-deterministic ordering assertions.
 
-**Review phase turn budget:** The entire review phase (from \`set_phase(review)\` to final summary) should complete in at most 10 orchestrator turns: 1 turn to dispatch the reviewer, 1 turn to read the review file, 1 turn to dispatch the fixer (if needed), 1 turn to read the verification file, 1 turn for a possible second fix round, 1 turn for the final summary. If you are approaching 10 turns in the review phase, stop immediately and produce the summary with whatever state you have.
+**Review phase turn budget:** The entire review phase (from \`set_phase(review)\` to final summary) should complete in at most 10 orchestrator turns. If you are approaching 10 turns in the review phase, stop immediately and produce the summary with whatever state you have.
 
-**Review verdicts are final**: Never edit a review report to change its verdict. If a flag is genuinely wrong, add a separate rationale note alongside the original review — do not alter the reviewer's output.
+**Review verdicts are final**: Never edit a review report to change its verdict. If a flag is genuinely wrong, add a separate rationale note alongside the original review — do not alter the reviewer's output.`
 
-**Orchestrator discipline**: Between delegation calls, you may do at most 5 tool calls (e.g. reading the spec file, setting the phase, checking a subagent result). If you find yourself doing reads, edits, bash calls, or writes on implementation files, STOP — you are doing a subagent's job. Delegate it instead. **Post-abort anti-pattern**: When a subagent aborts (budget or turns), do NOT manually complete its remaining work — this is the most common violation. Spawn a follow-up Agent scoped to the unfinished portion. List what the aborted agent completed and what remains. The orchestrator orchestrates; it does not build.
+const ORCHESTRATOR_DISCIPLINE = `**Orchestrator discipline**: Between delegation calls, you may do at most 5 tool calls (e.g. reading the spec file, setting the phase, checking a subagent result). If you find yourself doing reads, edits, bash calls, or writes on implementation files, STOP — you are doing a subagent's job. Delegate it instead. **Post-abort anti-pattern**: When a subagent aborts (budget or turns), do NOT manually complete its remaining work — this is the most common violation. Spawn a follow-up Agent scoped to the unfinished portion. List what the aborted agent completed and what remains. The orchestrator orchestrates; it does not build.`
 
-### Sharing context between agents
-
-Pass plans and structured findings as Markdown files in the Documents directory, not as inline blobs in prompts.
-
-### Agent management
+const AGENT_MANAGEMENT = `### Agent management
 
 - Write Agent prompts that are fully self-contained. Agents start with fresh context by default — include necessary instructions directly, or point them to a Markdown file containing larger context.
 - When delegating \`plan\` before \`build\`, have the Plan agent write a Markdown spec file (full method signatures, file paths, interfaces) to the Documents directory. Pass that file path to the build Agent — it must not rediscover what was already decided.
 - Spawn independent subtasks in parallel with \`run_in_background: true\`: do NOT run more than 3 concurrent Agents.
 - After an Agent returns, TRUST its output unless the subagent itself reported errors or produced obviously incomplete work. Do NOT re-read source files just to verify a successful subagent's findings — this is the most common source of wasted orchestrator turns. Instead, have the subagent write its substantive output to a Markdown file in the Documents directory and return the file path. Read ONLY that file (or pass it to the next subagent). For build agents specifically: if the agent reports tests pass and compilation succeeds, move on to the next chunk or to review. Do NOT re-read the code it wrote. For correction tasks, call Agent again with the correction task rather than fixing inline.
 - If an Agent call returns an error of any kind (including protocol violation, timeout, or exit error): do NOT attempt to implement or debug the work yourself. First assess whether the failure is retryable (e.g. transient timeouts or protocol violations) or not (e.g. missing files, permission errors, or invalid inputs). For retryable failures, call a replacement Agent with a corrected or simplified prompt — allow at most one retry per delegated step. For non-retryable failures, report the failure clearly and stop immediately without retrying.
-- **When a subagent aborts due to token budget or duration limit**: the work is likely partially done. Do NOT pick up the remaining work yourself — that defeats the purpose of delegation and wastes orchestrator tokens. A heavy-tier orchestrator doing mechanical edit/bash/read cycles after a subagent abort is the single most expensive anti-pattern. Instead, spawn a NEW follow-up Agent scoped to ONLY the unfinished portion. List what the first agent completed (files created, tests passing) and what remains in the follow-up prompt. Use the same or higher budget tier if the original was undersized (see multi-file package tier in budget table). **Include dependency context**: paste the public type signatures and function signatures of packages the follow-up agent will import (e.g. structs, interfaces, exported functions from earlier chunks) directly in the prompt so it does not waste turns re-reading files.
+- **When a subagent aborts due to token budget or duration limit**: the work is likely partially done. Do NOT pick up the remaining work yourself — that defeats the purpose of delegation and wastes orchestrator tokens. Instead, spawn a NEW follow-up Agent scoped to ONLY the unfinished portion. List what the first agent completed (files created, tests passing) and what remains in the follow-up prompt. Use the same or higher budget tier if the original was undersized (see multi-file package tier in budget table). **Include dependency context**: paste the public type signatures and function signatures of packages the follow-up agent will import (e.g. structs, interfaces, exported functions from earlier chunks) directly in the prompt so it does not waste turns re-reading files.
 - Do NOT call Agent for work you can do in a single tool call.
 - Use \`inherit_context: true\` only when the Agent needs the parent conversation history. Otherwise keep the default fresh context.
 - Inline images in your conversation are forwarded automatically to vision-capable Agents when needed. If no vision-capable model is available, the harness will automatically switch to one.
 
-### Model selection for delegation
+### Model selection
 
-You MUST always pass a \`model\` parameter on every Agent call — never omit it. Use the **Your Team** section above to pick the right model. Read each model's **description** and **tier** to match it to the task.
+Always pass a \`model\` parameter on every Agent call — never omit it. Default to the lightest-tier model from the relevant pool. Escalate to heavy-tier only for concurrency, algorithms, architectural reasoning, or when a standard-tier model has already failed on the same chunk. Read the model's **description** before selecting — it may reveal limitations. If the subtask involves images or visual content, select a model with Vision: yes.`
 
-- **Standard-tier models** for well-scoped tasks: CRUD, straightforward tests, mechanical fixes, code review, applying review findings.
-- **Heavy-tier models** for complex work: concurrency, graph algorithms, architectural reasoning, plan verification. Also use heavy-tier as a retry when a standard-tier model has failed on the same chunk.
-- **Light-tier models** for trivial work: codebase exploration, simple verification.
-- Read the model's **description** before selecting — a model in a role pool is a candidate, not a guarantee. Its description may reveal limitations.
-- If the subtask involves images or visual content, select a model with \`Vision: yes\`.
-- **Default to the lightest model that can handle the work.** Only escalate tier when the task genuinely requires it.
-
-### Review delegation
-
-The full review/fix/verification contract is described in the **Review phase** of the mandatory pipeline above. In summary: delegate to a standard-tier Reviewer (reliable completion outweighs thoroughness — use heavy-tier only for complex concurrency or security-critical code), require a findings file, pass it to a fix agent if needed, read only the verification report, and stop after at most 2 fix rounds. The entire review phase must complete in at most 10 orchestrator turns.
-
-### Token budgets and turn caps
+const TOKEN_BUDGETS = `### Token budgets and turn caps
 
 Include a \`token_budget\` and \`max_turns\` for every Agent call. The token budget caps **cumulative output tokens** (tokens generated by the agent across all turns). It does not count input tokens, which grow as a side-effect of conversation length and are not controllable by the agent.
 
@@ -217,13 +177,13 @@ If the user explicitly asks for the Agent tool with a specific \`token_budget\`,
 
 **Always set \`max_duration\`** on every Agent call. Subagents can hang on blocking operations (deadlocked tests, infinite loops, stuck network calls) where token budget and turn limits do not trigger. The duration cap is the last line of defence against runaway agents.
 
-**Heavy-tier model duration scaling:** When delegating to a heavy-tier model (high per-token cost, slower generation), multiply \`max_duration\` by 1.5x. A task that needs 600s with a standard-tier model needs 900s with a heavy-tier model. **However, prefer standard-tier models for build subagents** — heavy-tier models frequently time out as subagents because they spend too long reasoning before acting. Use heavy-tier builders only as a retry after a standard-tier builder has already failed on the same chunk.
+**Heavy-tier model duration scaling:** When delegating to a heavy-tier model, multiply \`max_duration\` by 1.5x.
 
 Use the **multi-file package** tier when a build chunk involves concurrency primitives, worker pools, channels, or complex state machines — these require more iterative test-fix cycles than simple CRUD code. When in doubt between single-file and multi-file, prefer the larger budget — an abort followed by a follow-up agent costs more total tokens than a generous initial budget.
 
-The turn cap prevents debug-loop budget exhaustion — an agent that hasn't converged in 12 turns is unlikely to converge in 20. If an Agent hits its budget or turn cap, spawn a follow-up with the remaining work rather than raising the budget. The follow-up prompt must list what the first agent completed and what remains.
+The turn cap prevents debug-loop budget exhaustion — an agent that hasn't converged in 12 turns is unlikely to converge in 20. If an Agent hits its budget or turn cap, spawn a follow-up with the remaining work rather than raising the budget. The follow-up prompt must list what the first agent completed and what remains.`
 
-### What makes a good plan
+const PLAN_QUALITY_CHECKLIST = `### What makes a good plan
 
 A plan is "good" when an independent model can build from it without asking questions. Verify against this checklist before calling a plan complete:
 
@@ -238,19 +198,208 @@ A plan is "good" when an independent model can build from it without asking ques
 9. **No ambiguity** — API choices, library versions, and design decisions are explicit. Alternatives rejected are noted in one line each.
 10. **Feasibility** — The plan fits within the token budgets allocated for each chunk. No chunk requires >150k tokens to build.`
 
-function resolveOrchestratorInstructions(ctx: OrchestrationInstructionsContext): string {
-	const parts: string[] = []
+// ---------------------------------------------------------------------------
+// Orchestrator instruction builder (generates role-specific DOs/DONTs)
+// ---------------------------------------------------------------------------
 
-	if (ctx.roles && ctx.registry) {
-		parts.push(buildRoleAssignmentsSection(ctx.roles, ctx.registry, ctx.currentModelId, ctx.customConfigs))
+interface PhaseDirectiveContext {
+	ownRoles: string[]
+	roles?: ModelRoles
+	registry?: ModelRegistry
+	customConfigs?: ReadonlyMap<string, ModelCustomMetadata>
+}
+
+function modelListForRole(assignment: RoleModelAssignment): string {
+	return normalizeRoleModels(assignment)
+		.map((r) => `\`${r}\``)
+		.join(", ")
+}
+
+function buildPlanPhaseDirectives(ctx: PhaseDirectiveContext): string {
+	const owns = ctx.ownRoles.includes("planner")
+	const lines: string[] = []
+
+	lines.push("#### Plan phase")
+	lines.push("")
+
+	if (owns) {
+		lines.push("- DO write the plan yourself. Produce a Markdown spec file in the Documents directory.")
+		lines.push("- DO self-validate: re-read the spec and cross-check every requirement from the original task.")
+	} else {
+		const models = ctx.roles ? modelListForRole(ctx.roles.planner) : "a Planner model"
+		lines.push("- DO NOT write the plan yourself. You do not have the planner role.")
+		lines.push(`- DO delegate planning to Agent(type: "Plan", model: ${models}).`)
+		lines.push(
+			"- DO self-validate after the Plan agent returns: re-read the spec and cross-check every requirement from the original task.",
+		)
 	}
 
-	parts.push(ORCHESTRATOR_INSTRUCTIONS)
+	lines.push("")
+	lines.push(PLAN_SPEC_REQUIREMENTS)
+	lines.push("")
+	lines.push(PLAN_VERIFICATION)
+	lines.push("")
 
-	const orchGuidelines = buildOrchestrationGuidelinesSection(ctx.currentModelId, ctx.registry)
-	if (orchGuidelines) parts.push(orchGuidelines)
+	if (owns) {
+		lines.push(
+			"**Handling the verdict:** If APPROVED: proceed to build phase. If NEEDS_REVISION: fix the gaps yourself. After revision, send ONLY the changed sections back to the verifier — not the full plan. Maximum one re-verification round; if still not approved, proceed with documented reservations.",
+		)
+	} else {
+		const models = ctx.roles ? modelListForRole(ctx.roles.planner) : "a Planner model"
+		lines.push(
+			`**Handling the verdict:** If APPROVED: proceed to build phase. If NEEDS_REVISION: delegate revisions to Agent(type: "Plan", model: ${models}). After revision, send ONLY the changed sections back to the verifier — not the full plan. Maximum one re-verification round; if still not approved, proceed with documented reservations.`,
+		)
+	}
+
+	return lines.join("\n")
+}
+
+function buildBuildPhaseDirectives(ctx: PhaseDirectiveContext): string {
+	const lines: string[] = []
+	const models = ctx.roles ? modelListForRole(ctx.roles.builder) : "a Builder model"
+
+	lines.push("#### Build phase")
+	lines.push("")
+	lines.push("- DO NOT build code yourself. Delegate one Agent call per chunk from the plan.")
+	lines.push(
+		`- DO delegate each chunk to Agent(type: "Builder", model: ${models}). Use a standard-tier Builder by default. Use a heavy-tier Builder only as a retry when a standard-tier Builder has already failed on the same chunk.`,
+	)
+	lines.push("- DO pass the spec file path and tell each agent which chunk to implement.")
+	lines.push(
+		"- DO instruct every build agent to: (1) write the implementation, (2) write tests, (3) verify compilation and lint, (4) run tests exactly once. If compilation or tests fail, the agent reports failures and stops — no fix-retry cycles.",
+	)
+	lines.push(
+		"- DO run up to 3 independent chunks in parallel with run_in_background. Run sequential chunks one at a time.",
+	)
+	lines.push(
+		"- DO NOT read the subagent's output files yourself, run tests yourself, or verify the code after the last build chunk completes. Transition to review immediately.",
+	)
+
+	return lines.join("\n")
+}
+
+function buildReviewPhaseDirectives(ctx: PhaseDirectiveContext): string {
+	const lines: string[] = []
+	const models = ctx.roles ? modelListForRole(ctx.roles.reviewer) : "a Reviewer model"
+
+	lines.push("#### Review phase")
+	lines.push("")
+	lines.push(
+		"- DO NOT review code yourself. Always delegate to a Reviewer agent in a fresh context — even when reviewer is in your roles. The fresh context provides independence from planning and building.",
+	)
+	lines.push(
+		`- DO delegate to Agent(type: "Reviewer", model: ${models}). Prefer a standard-tier Reviewer — heavy-tier models are slower and more prone to timing out. Only use a heavy-tier Reviewer for complex concurrency, security-critical logic, or novel architectural patterns.`,
+	)
+	lines.push("- DO pass the spec file path and the full list of created files.")
+	lines.push("")
+	lines.push(REVIEW_PHASE)
+
+	return lines.join("\n")
+}
+
+function buildExplorePhaseDirectives(ctx: PhaseDirectiveContext): string {
+	const owns = ctx.ownRoles.includes("explorer")
+	const lines: string[] = []
+
+	lines.push("#### Explore phase")
+	lines.push("")
+
+	if (owns) {
+		const models = ctx.roles ? modelListForRole(ctx.roles.explorer) : "an Explorer model"
+		lines.push("- DO explore the codebase yourself for small explorations (a few files).")
+		lines.push(`- DO delegate large explorations (many files) to Agent(type: "Explore", model: ${models}).`)
+	} else {
+		const models = ctx.roles ? modelListForRole(ctx.roles.explorer) : "an Explorer model"
+		lines.push("- DO NOT explore the codebase yourself. You do not have the explorer role.")
+		lines.push(`- DO delegate to Agent(type: "Explore", model: ${models}).`)
+	}
+
+	return lines.join("\n")
+}
+
+function buildResearchPhaseDirectives(ctx: PhaseDirectiveContext): string {
+	const owns = ctx.ownRoles.includes("researcher")
+	const lines: string[] = []
+
+	lines.push("#### Research phase")
+	lines.push("")
+	lines.push(
+		"- For quick factual lookups (library comparisons, version numbers, API references), call web_search directly — do not spawn an Agent.",
+	)
+
+	if (owns) {
+		lines.push("- DO perform deep research yourself when it requires analysis across multiple sources.")
+		lines.push(
+			`- DO delegate large research tasks to Agent(type: "Researcher") when the scope is too broad for a single web_search call.`,
+		)
+	} else {
+		const models = ctx.roles ? modelListForRole(ctx.roles.researcher) : "a Researcher model"
+		lines.push("- DO NOT perform deep research yourself. You do not have the researcher role.")
+		lines.push(`- DO delegate deep research to Agent(type: "Researcher", model: ${models}).`)
+	}
+
+	return lines.join("\n")
+}
+
+function buildOrchestratorInstructions(
+	roles?: ModelRoles,
+	currentModelId?: string,
+	registry?: ModelRegistry,
+	customConfigs?: ReadonlyMap<string, ModelCustomMetadata>,
+): string {
+	const ownRoles = currentModelId && roles ? resolveModelRoleNames(currentModelId, roles) : []
+
+	const ctx: PhaseDirectiveContext = { ownRoles, roles, registry, customConfigs }
+
+	const parts: string[] = []
+
+	parts.push(`## Orchestrate the work
+
+Before taking any action, silently reason through the steps below. Keep this reasoning internal — do not write it into your response. Proceed directly to the action.`)
+
+	parts.push(STEP_1_CLASSIFY)
+	parts.push(STEP_2_PIPELINE)
+
+	// Step 3 — per-phase DOs/DONTs (generated from roles)
+	parts.push(`### Step 3 — Your responsibilities per phase
+
+Read **Your Capabilities** above. The sections below tell you exactly what to DO and what NOT to do for each pipeline phase. Follow them literally.
+
+Pass plans and structured findings as Markdown files in the Documents directory, not as inline blobs in prompts.`)
+
+	parts.push(buildPlanPhaseDirectives(ctx))
+	parts.push(buildBuildPhaseDirectives(ctx))
+	parts.push(buildReviewPhaseDirectives(ctx))
+	parts.push(buildExplorePhaseDirectives(ctx))
+	parts.push(buildResearchPhaseDirectives(ctx))
+
+	parts.push(STEP_4_EXECUTE)
+
+	parts.push(`#### Mandatory pipeline for complex tasks
+
+When Step 1 classified the task as **complex**, you MUST execute it as a phased pipeline — never lump everything into a single Agent call or do it all yourself. The phases are sequential: plan -> build -> review. Each one produces an artefact the next one consumes. Follow the phase directives above for each step.`)
+
+	parts.push(ORCHESTRATOR_DISCIPLINE)
+	parts.push(AGENT_MANAGEMENT)
+	parts.push(TOKEN_BUDGETS)
+	parts.push(PLAN_QUALITY_CHECKLIST)
 
 	return parts.join("\n\n")
+}
+
+function resolveOrchestratorInstructions(ctx: OrchestrationInstructionsContext): OrchestrationInstructionsResult {
+	const teamSection =
+		ctx.roles && ctx.registry
+			? buildRoleAssignmentsSection(ctx.roles, ctx.registry, ctx.currentModelId, ctx.customConfigs)
+			: ""
+
+	const instructionParts: string[] = []
+	instructionParts.push(buildOrchestratorInstructions(ctx.roles, ctx.currentModelId, ctx.registry, ctx.customConfigs))
+
+	const orchGuidelines = buildOrchestrationGuidelinesSection(ctx.currentModelId, ctx.registry)
+	if (orchGuidelines) instructionParts.push(orchGuidelines)
+
+	return { teamSection, instructionsSection: instructionParts.join("\n\n") }
 }
 
 // ---------------------------------------------------------------------------
@@ -367,10 +516,58 @@ function formatCurrentModelCapabilities(
 	roles?: ModelRoles,
 ): string {
 	const meta = resolveModelMeta(currentModelId, registry, customConfigs, roles)
-	const roleNames = resolveModelRoleNames(currentModelId, roles)
-	const capRoles = roleNames.length > 0 ? roleNames.join(", ") : "none"
+	const ownRoles = resolveModelRoleNames(currentModelId, roles)
 
-	return `Tier: ${meta.tier} | Roles: ${capRoles} | Vision: ${meta.vision ? "yes" : "no"}\n${meta.description}`
+	const lines: string[] = []
+	lines.push(`Tier: ${meta.tier} | Vision: ${meta.vision ? "yes" : "no"}`)
+	lines.push(meta.description)
+	lines.push("")
+
+	if (!roles) return lines.join("\n")
+
+	const delegableRoles: Array<{ role: string; assignment: RoleModelAssignment }> = [
+		{ role: "planner", assignment: roles.planner },
+		{ role: "builder", assignment: roles.builder },
+		{ role: "reviewer", assignment: roles.reviewer },
+		{ role: "explorer", assignment: roles.explorer },
+		{ role: "researcher", assignment: roles.researcher },
+	]
+
+	const owned: string[] = []
+	const delegated: string[] = []
+
+	const agentTypeForRole: Record<string, string> = {
+		planner: "Plan",
+		builder: "Builder",
+		reviewer: "Reviewer",
+		explorer: "Explore",
+		researcher: "Researcher",
+	}
+
+	for (const { role, assignment } of delegableRoles) {
+		if (ownRoles.includes(role)) {
+			owned.push(role)
+		} else {
+			const models = normalizeRoleModels(assignment)
+			const modelList = models.map((r) => `\`${r}\``).join(", ")
+			const agentType = agentTypeForRole[role] ?? role
+			delegated.push(
+				`- You do not have the **${role}** role. Do not perform ${role} work yourself. Delegate to Agent(type: "${agentType}") using one of: ${modelList}.`,
+			)
+		}
+	}
+
+	if (owned.length > 0) {
+		lines.push(
+			`You have these roles: **${owned.join(", ")}**. You are allowed to perform this work yourself, but delegate to a team member when one is better suited for the task.`,
+		)
+	}
+	if (delegated.length > 0) {
+		lines.push("")
+		lines.push(...delegated)
+	}
+
+	return lines.join("\n")
 }
 
 function buildRoleAssignmentsSection(

--- a/src/extensions/orchestration/orchestration-instructions.ts
+++ b/src/extensions/orchestration/orchestration-instructions.ts
@@ -272,6 +272,10 @@ function resolveDescriptor(ref: string, registry?: ModelRegistry): Orchestration
 	return registry?.getModelById(modelId)
 }
 
+function matchesRef(candidate: string, refs: string[]): boolean {
+	return refs.some((r) => r === candidate || modelIdFromRef(r) === candidate)
+}
+
 function resolveModelRoleNames(ref: string, roles?: ModelRoles): string[] {
 	if (!roles) return []
 	const assigned: string[] = []
@@ -280,13 +284,14 @@ function resolveModelRoleNames(ref: string, roles?: ModelRoles): string[] {
 		builder: roles.builder,
 		reviewer: roles.reviewer,
 		explorer: roles.explorer,
+		researcher: roles.researcher,
 	}
 	for (const [roleName, assignment] of Object.entries(roleMap)) {
-		if (normalizeRoleModels(assignment).includes(ref)) {
+		if (matchesRef(ref, normalizeRoleModels(assignment))) {
 			assigned.push(roleName)
 		}
 	}
-	if (roles.orchestrator === ref) {
+	if (roles.orchestrator === ref || modelIdFromRef(roles.orchestrator) === ref) {
 		assigned.unshift("orchestrator")
 	}
 	return assigned
@@ -355,19 +360,6 @@ function formatRoleSection(
 	return `### ${roleName}\n${entries.join("\n\n")}`
 }
 
-function deriveRolesFromTier(tier: ModelTier | undefined): string {
-	switch (tier) {
-		case "heavy":
-			return "plan, build, review"
-		case "standard":
-			return "build, review"
-		case "light":
-			return "explore"
-		default:
-			return "build"
-	}
-}
-
 function formatCurrentModelCapabilities(
 	currentModelId: string,
 	registry?: ModelRegistry,
@@ -375,16 +367,8 @@ function formatCurrentModelCapabilities(
 	roles?: ModelRoles,
 ): string {
 	const meta = resolveModelMeta(currentModelId, registry, customConfigs, roles)
-	const descriptor = resolveDescriptor(currentModelId, registry)
-	const custom = customConfigs?.get(currentModelId)
-
 	const roleNames = resolveModelRoleNames(currentModelId, roles)
-	const capRoles =
-		custom || !descriptor
-			? roleNames.length > 0
-				? roleNames.join(", ")
-				: deriveRolesFromTier(meta.tier)
-			: descriptor.capabilities.roles.join(", ")
+	const capRoles = roleNames.length > 0 ? roleNames.join(", ") : "none"
 
 	return `Tier: ${meta.tier} | Roles: ${capRoles} | Vision: ${meta.vision ? "yes" : "no"}\n${meta.description}`
 }
@@ -406,6 +390,7 @@ function buildRoleAssignmentsSection(
 	sections.push(formatRoleSection("Builder", roles.builder, registry, customConfigs, roles))
 	sections.push(formatRoleSection("Reviewer", roles.reviewer, registry, customConfigs, roles))
 	sections.push(formatRoleSection("Explorer", roles.explorer, registry, customConfigs, roles))
+	sections.push(formatRoleSection("Researcher", roles.researcher, registry, customConfigs, roles))
 
 	const capabilitiesSection = currentModelId
 		? formatCurrentModelCapabilities(currentModelId, registry, customConfigs, roles)

--- a/src/extensions/orchestration/orchestration-instructions.ts
+++ b/src/extensions/orchestration/orchestration-instructions.ts
@@ -272,50 +272,74 @@ function resolveDescriptor(ref: string, registry?: ModelRegistry): Orchestration
 	return registry?.getModelById(modelId)
 }
 
+function resolveModelRoleNames(ref: string, roles?: ModelRoles): string[] {
+	if (!roles) return []
+	const assigned: string[] = []
+	const roleMap: Record<string, RoleModelAssignment> = {
+		planner: roles.planner,
+		builder: roles.builder,
+		reviewer: roles.reviewer,
+		explorer: roles.explorer,
+	}
+	for (const [roleName, assignment] of Object.entries(roleMap)) {
+		if (normalizeRoleModels(assignment).includes(ref)) {
+			assigned.push(roleName)
+		}
+	}
+	if (roles.orchestrator === ref) {
+		assigned.unshift("orchestrator")
+	}
+	return assigned
+}
+
+function defaultDescription(ref: string, roleNames: string[]): string {
+	if (roleNames.length > 0) {
+		const roles = roleNames.join(", ")
+		return `This model was configured by the user to handle ${roles} work.`
+	}
+	return "This model was configured by the user."
+}
+
+interface ResolvedModelMeta {
+	tier: ModelTier
+	vision: boolean
+	description: string
+}
+
+function resolveModelMeta(
+	ref: string,
+	registry?: ModelRegistry,
+	customConfigs?: ReadonlyMap<string, CustomModelConfig>,
+	roles?: ModelRoles,
+): ResolvedModelMeta {
+	const descriptor = resolveDescriptor(ref, registry)
+	const custom = customConfigs?.get(ref)
+	const roleNames = resolveModelRoleNames(ref, roles)
+
+	const tier = custom?.tier ?? descriptor?.capabilities.tier ?? "standard"
+	const vision = custom?.vision ?? descriptor?.capabilities.vision ?? false
+	const description = custom?.description ?? descriptor?.capabilities.description ?? defaultDescription(ref, roleNames)
+
+	return { tier, vision, description }
+}
+
 function formatModelEntry(
 	ref: string,
 	registry?: ModelRegistry,
 	customConfigs?: ReadonlyMap<string, CustomModelConfig>,
+	roles?: ModelRoles,
 ): string {
 	const displayName = resolveModelDisplayName(ref, registry)
-	const descriptor = resolveDescriptor(ref, registry)
 	const parsed = splitModelRef(ref)
 	const providerInfo = parsed ? `, provider: \`${parsed.provider}\`` : ""
 
-	// If descriptor is available, use it
-	if (descriptor) {
-		const tierInfo = `Tier: ${descriptor.capabilities.tier}`
-		const vision = descriptor.capabilities.vision ? " | Vision: yes" : ""
-		const description = descriptor.capabilities.description ?? ""
+	const meta = resolveModelMeta(ref, registry, customConfigs, roles)
+	const tierInfo = `Tier: ${meta.tier}`
+	const visionInfo = ` | Vision: ${meta.vision ? "yes" : "no"}`
+	const metaSuffix = ` — ${tierInfo}${visionInfo}`
 
-		const meta = [tierInfo, vision].filter(Boolean).join("")
-		const metaSuffix = meta ? ` — ${meta}` : ""
-
-		const lines = [`- **${displayName}** (id: \`${ref}\`${providerInfo})${metaSuffix}`]
-		if (description) {
-			lines.push(`  ${description}`)
-		}
-		return lines.join("\n")
-	}
-
-	// Check custom config as fallback
-	const custom = customConfigs?.get(ref)
-	if (custom) {
-		const tierInfo = custom.tier ? `Tier: ${custom.tier}` : ""
-		const vision = custom.vision ? " | Vision: yes" : ""
-
-		const meta = [tierInfo, vision].filter(Boolean).join("")
-		const metaSuffix = meta ? ` — ${meta}` : ""
-
-		const lines = [`- **${displayName}** (id: \`${ref}\`${providerInfo})${metaSuffix}`]
-		if (custom.description) {
-			lines.push(`  ${custom.description}`)
-		}
-		return lines.join("\n")
-	}
-
-	// Generic fallback
-	const lines = [`- **${displayName}** (id: \`${ref}\`${providerInfo})`]
+	const lines = [`- **${displayName}** (id: \`${ref}\`${providerInfo})${metaSuffix}`]
+	lines.push(`  ${meta.description}`)
 	return lines.join("\n")
 }
 
@@ -324,20 +348,21 @@ function formatRoleSection(
 	assignment: RoleModelAssignment,
 	registry?: ModelRegistry,
 	customConfigs?: ReadonlyMap<string, CustomModelConfig>,
+	roles?: ModelRoles,
 ): string {
 	const models = normalizeRoleModels(assignment)
-	const entries = models.map((ref) => formatModelEntry(ref, registry, customConfigs))
+	const entries = models.map((ref) => formatModelEntry(ref, registry, customConfigs, roles))
 	return `### ${roleName}\n${entries.join("\n\n")}`
 }
 
 function deriveRolesFromTier(tier: ModelTier | undefined): string {
 	switch (tier) {
 		case "heavy":
-			return "plan, research, build, review"
+			return "plan, build, review"
 		case "standard":
 			return "build, review"
 		case "light":
-			return "explore, research"
+			return "explore"
 		default:
 			return "build"
 	}
@@ -347,28 +372,21 @@ function formatCurrentModelCapabilities(
 	currentModelId: string,
 	registry?: ModelRegistry,
 	customConfigs?: ReadonlyMap<string, CustomModelConfig>,
+	roles?: ModelRoles,
 ): string {
+	const meta = resolveModelMeta(currentModelId, registry, customConfigs, roles)
 	const descriptor = resolveDescriptor(currentModelId, registry)
-	if (descriptor) {
-		const roles = descriptor.capabilities.roles.join(", ")
-		const vision = descriptor.capabilities.vision ? "yes" : "no"
-		return `Tier: ${descriptor.capabilities.tier} | Roles: ${roles} | Vision: ${vision}\n${descriptor.capabilities.description}`
-	}
-
 	const custom = customConfigs?.get(currentModelId)
-	if (custom) {
-		const derivedRoles = deriveRolesFromTier(custom.tier)
-		const vision = custom.vision ? "yes" : "no"
-		const tier = custom.tier ?? "unknown"
-		const description = custom.description ?? ""
-		const lines = [`Tier: ${tier} | Roles: ${derivedRoles} | Vision: ${vision}`]
-		if (description) {
-			lines.push(description)
-		}
-		return lines.join("\n")
-	}
 
-	return "No capability information available for this model."
+	const roleNames = resolveModelRoleNames(currentModelId, roles)
+	const capRoles =
+		custom || !descriptor
+			? roleNames.length > 0
+				? roleNames.join(", ")
+				: deriveRolesFromTier(meta.tier)
+			: descriptor.capabilities.roles.join(", ")
+
+	return `Tier: ${meta.tier} | Roles: ${capRoles} | Vision: ${meta.vision ? "yes" : "no"}\n${meta.description}`
 }
 
 function buildRoleAssignmentsSection(
@@ -382,15 +400,15 @@ function buildRoleAssignmentsSection(
 	const plannerModels = normalizeRoleModels(roles.planner)
 	const orchestratorIsPlanner = plannerModels.length === 1 && plannerModels[0] === roles.orchestrator
 	if (!orchestratorIsPlanner) {
-		sections.push(formatRoleSection("Planner", roles.planner, registry, customConfigs))
+		sections.push(formatRoleSection("Planner", roles.planner, registry, customConfigs, roles))
 	}
 
-	sections.push(formatRoleSection("Builder", roles.builder, registry, customConfigs))
-	sections.push(formatRoleSection("Reviewer", roles.reviewer, registry, customConfigs))
-	sections.push(formatRoleSection("Explorer", roles.explorer, registry, customConfigs))
+	sections.push(formatRoleSection("Builder", roles.builder, registry, customConfigs, roles))
+	sections.push(formatRoleSection("Reviewer", roles.reviewer, registry, customConfigs, roles))
+	sections.push(formatRoleSection("Explorer", roles.explorer, registry, customConfigs, roles))
 
 	const capabilitiesSection = currentModelId
-		? formatCurrentModelCapabilities(currentModelId, registry, customConfigs)
+		? formatCurrentModelCapabilities(currentModelId, registry, customConfigs, roles)
 		: "No capability information available for this model."
 
 	return `## Your Team\n\n${sections.join("\n\n")}\n\n## Your Capabilities\n\n${capabilitiesSection}`

--- a/src/extensions/orchestration/orchestration-instructions.ts
+++ b/src/extensions/orchestration/orchestration-instructions.ts
@@ -9,8 +9,9 @@
 import type { PromptMode } from "../prompt-construction/system-prompt.js"
 import { buildOrchestrationGuidelinesSection } from "./model-registry/guidelines/guidelines-resolver.js"
 import type { ModelRegistry } from "./model-registry/index.js"
-import type { OrchestrationModelDescriptor } from "./model-registry/types.js"
+import type { ModelTier, OrchestrationModelDescriptor } from "./model-registry/types.js"
 import type { ModelRoles, RoleModelAssignment } from "./model-roles.js"
+import type { CustomModelConfig } from "./model-roles.js"
 import { modelIdFromRef, normalizeRoleModels, splitModelRef } from "./model-roles.js"
 
 export interface OrchestrationInstructionsContext {
@@ -19,6 +20,8 @@ export interface OrchestrationInstructionsContext {
 	mode: PromptMode
 	/** Role-based model assignments for orchestrator mode. */
 	roles?: ModelRoles
+	/** Custom model configs for non-registry models. */
+	customConfigs?: ReadonlyMap<string, CustomModelConfig>
 }
 
 export function resolveOrchestrationInstructions(ctx: OrchestrationInstructionsContext): string {
@@ -239,7 +242,7 @@ function resolveOrchestratorInstructions(ctx: OrchestrationInstructionsContext):
 	const parts: string[] = []
 
 	if (ctx.roles && ctx.registry) {
-		parts.push(buildRoleAssignmentsSection(ctx.roles, ctx.registry, ctx.currentModelId))
+		parts.push(buildRoleAssignmentsSection(ctx.roles, ctx.registry, ctx.currentModelId, ctx.customConfigs))
 	}
 
 	parts.push(ORCHESTRATOR_INSTRUCTIONS)
@@ -269,55 +272,125 @@ function resolveDescriptor(ref: string, registry?: ModelRegistry): Orchestration
 	return registry?.getModelById(modelId)
 }
 
-function formatModelEntry(ref: string, registry?: ModelRegistry): string {
+function formatModelEntry(
+	ref: string,
+	registry?: ModelRegistry,
+	customConfigs?: ReadonlyMap<string, CustomModelConfig>,
+): string {
 	const displayName = resolveModelDisplayName(ref, registry)
 	const descriptor = resolveDescriptor(ref, registry)
 	const parsed = splitModelRef(ref)
 	const providerInfo = parsed ? `, provider: \`${parsed.provider}\`` : ""
 
-	const tierInfo = descriptor ? `Tier: ${descriptor.capabilities.tier}` : ""
-	const vision = descriptor?.capabilities.vision ? " | Vision: yes" : ""
-	const description = descriptor?.capabilities.description ?? ""
+	// If descriptor is available, use it
+	if (descriptor) {
+		const tierInfo = `Tier: ${descriptor.capabilities.tier}`
+		const vision = descriptor.capabilities.vision ? " | Vision: yes" : ""
+		const description = descriptor.capabilities.description ?? ""
 
-	const meta = [tierInfo, vision].filter(Boolean).join("")
-	const metaSuffix = meta ? ` — ${meta}` : ""
+		const meta = [tierInfo, vision].filter(Boolean).join("")
+		const metaSuffix = meta ? ` — ${meta}` : ""
 
-	const lines = [`- **${displayName}** (id: \`${ref}\`${providerInfo})${metaSuffix}`]
-	if (description) {
-		lines.push(`  ${description}`)
+		const lines = [`- **${displayName}** (id: \`${ref}\`${providerInfo})${metaSuffix}`]
+		if (description) {
+			lines.push(`  ${description}`)
+		}
+		return lines.join("\n")
 	}
+
+	// Check custom config as fallback
+	const custom = customConfigs?.get(ref)
+	if (custom) {
+		const tierInfo = custom.tier ? `Tier: ${custom.tier}` : ""
+		const vision = custom.vision ? " | Vision: yes" : ""
+
+		const meta = [tierInfo, vision].filter(Boolean).join("")
+		const metaSuffix = meta ? ` — ${meta}` : ""
+
+		const lines = [`- **${displayName}** (id: \`${ref}\`${providerInfo})${metaSuffix}`]
+		if (custom.description) {
+			lines.push(`  ${custom.description}`)
+		}
+		return lines.join("\n")
+	}
+
+	// Generic fallback
+	const lines = [`- **${displayName}** (id: \`${ref}\`${providerInfo})`]
 	return lines.join("\n")
 }
 
-function formatRoleSection(roleName: string, assignment: RoleModelAssignment, registry?: ModelRegistry): string {
+function formatRoleSection(
+	roleName: string,
+	assignment: RoleModelAssignment,
+	registry?: ModelRegistry,
+	customConfigs?: ReadonlyMap<string, CustomModelConfig>,
+): string {
 	const models = normalizeRoleModels(assignment)
-	const entries = models.map((ref) => formatModelEntry(ref, registry))
+	const entries = models.map((ref) => formatModelEntry(ref, registry, customConfigs))
 	return `### ${roleName}\n${entries.join("\n\n")}`
 }
 
-function formatCurrentModelCapabilities(currentModelId: string, registry?: ModelRegistry): string {
-	const descriptor = resolveDescriptor(currentModelId, registry)
-	if (!descriptor) return "No capability information available for this model."
-	const roles = descriptor.capabilities.roles.join(", ")
-	const vision = descriptor.capabilities.vision ? "yes" : "no"
-	return `Tier: ${descriptor.capabilities.tier} | Roles: ${roles} | Vision: ${vision}\n${descriptor.capabilities.description}`
+function deriveRolesFromTier(tier: ModelTier | undefined): string {
+	switch (tier) {
+		case "heavy":
+			return "plan, research, build, review"
+		case "standard":
+			return "build, review"
+		case "light":
+			return "explore, research"
+		default:
+			return "build"
+	}
 }
 
-function buildRoleAssignmentsSection(roles: ModelRoles, registry?: ModelRegistry, currentModelId?: string): string {
+function formatCurrentModelCapabilities(
+	currentModelId: string,
+	registry?: ModelRegistry,
+	customConfigs?: ReadonlyMap<string, CustomModelConfig>,
+): string {
+	const descriptor = resolveDescriptor(currentModelId, registry)
+	if (descriptor) {
+		const roles = descriptor.capabilities.roles.join(", ")
+		const vision = descriptor.capabilities.vision ? "yes" : "no"
+		return `Tier: ${descriptor.capabilities.tier} | Roles: ${roles} | Vision: ${vision}\n${descriptor.capabilities.description}`
+	}
+
+	const custom = customConfigs?.get(currentModelId)
+	if (custom) {
+		const derivedRoles = deriveRolesFromTier(custom.tier)
+		const vision = custom.vision ? "yes" : "no"
+		const tier = custom.tier ?? "unknown"
+		const description = custom.description ?? ""
+		const lines = [`Tier: ${tier} | Roles: ${derivedRoles} | Vision: ${vision}`]
+		if (description) {
+			lines.push(description)
+		}
+		return lines.join("\n")
+	}
+
+	return "No capability information available for this model."
+}
+
+function buildRoleAssignmentsSection(
+	roles: ModelRoles,
+	registry?: ModelRegistry,
+	currentModelId?: string,
+	customConfigs?: ReadonlyMap<string, CustomModelConfig>,
+): string {
 	const sections: string[] = []
 
 	const plannerModels = normalizeRoleModels(roles.planner)
 	const orchestratorIsPlanner = plannerModels.length === 1 && plannerModels[0] === roles.orchestrator
 	if (!orchestratorIsPlanner) {
-		sections.push(formatRoleSection("Planner", roles.planner, registry))
+		sections.push(formatRoleSection("Planner", roles.planner, registry, customConfigs))
 	}
 
-	sections.push(formatRoleSection("Builder", roles.builder, registry))
-	sections.push(formatRoleSection("Reviewer", roles.reviewer, registry))
-	sections.push(formatRoleSection("Explorer", roles.explorer, registry))
+	sections.push(formatRoleSection("Builder", roles.builder, registry, customConfigs))
+	sections.push(formatRoleSection("Reviewer", roles.reviewer, registry, customConfigs))
+	sections.push(formatRoleSection("Explorer", roles.explorer, registry, customConfigs))
 
 	const capabilitiesSection = currentModelId
-		? formatCurrentModelCapabilities(currentModelId, registry)
+		? formatCurrentModelCapabilities(currentModelId, registry, customConfigs)
 		: "No capability information available for this model."
 
 	return `## Your Team\n\n${sections.join("\n\n")}\n\n## Your Capabilities\n\n${capabilitiesSection}`

--- a/src/extensions/orchestration/orchestration-instructions.ts
+++ b/src/extensions/orchestration/orchestration-instructions.ts
@@ -262,7 +262,7 @@ function buildBuildPhaseDirectives(ctx: PhaseDirectiveContext): string {
 	lines.push("")
 	lines.push("- DO NOT build code yourself. Delegate one Agent call per chunk from the plan.")
 	lines.push(
-		`- DO delegate each chunk to Agent(type: "Builder", model: ${models}). Use a standard-tier Builder by default. Use a heavy-tier Builder only as a retry when a standard-tier Builder has already failed on the same chunk.`,
+		`- DO delegate each chunk to Agent(type: "Builder", model: ${models}). Simple chunks use a standard-tier Builder; complex chunks (concurrency, state machines, algorithms) require a heavy-tier Builder. Retries may escalate to a heavier tier when the first choice fails.`,
 	)
 	lines.push("- DO pass the spec file path and tell each agent which chunk to implement.")
 	lines.push(
@@ -460,6 +460,25 @@ interface ResolvedModelMeta {
 	description: string
 }
 
+/**
+ * Look up custom metadata by ref. Accepts either a full ref (`provider/model-id`)
+ * or a bare model id (`model-id`) — settings metadata is keyed by full ref, but
+ * the orchestrator current-model lookup sometimes has only the bare id.
+ */
+export function lookupCustomConfig(
+	ref: string,
+	customConfigs?: ReadonlyMap<string, ModelCustomMetadata>,
+): ModelCustomMetadata | undefined {
+	if (!customConfigs) return undefined
+	const direct = customConfigs.get(ref)
+	if (direct) return direct
+	// Fallback: ref might be the bare model id. Find the matching full-ref key.
+	for (const [key, value] of customConfigs) {
+		if (key !== ref && modelIdFromRef(key) === ref) return value
+	}
+	return undefined
+}
+
 function resolveModelMeta(
 	ref: string,
 	registry?: ModelRegistry,
@@ -467,7 +486,7 @@ function resolveModelMeta(
 	roles?: ModelRoles,
 ): ResolvedModelMeta {
 	const descriptor = resolveDescriptor(ref, registry)
-	const custom = customConfigs?.get(ref)
+	const custom = lookupCustomConfig(ref, customConfigs)
 	const roleNames = resolveModelRoleNames(ref, roles)
 
 	const tier = custom?.tier ?? descriptor?.capabilities.tier ?? "standard"

--- a/src/extensions/orchestration/orchestration-instructions.ts
+++ b/src/extensions/orchestration/orchestration-instructions.ts
@@ -7,11 +7,11 @@
  */
 
 import type { PromptMode } from "../prompt-construction/system-prompt.js"
+import type { ModelCustomMetadata } from "./model-metadata.js"
 import { buildOrchestrationGuidelinesSection } from "./model-registry/guidelines/guidelines-resolver.js"
 import type { ModelRegistry } from "./model-registry/index.js"
 import type { ModelTier, OrchestrationModelDescriptor } from "./model-registry/types.js"
 import type { ModelRoles, RoleModelAssignment } from "./model-roles.js"
-import type { CustomModelConfig } from "./model-roles.js"
 import { modelIdFromRef, normalizeRoleModels, splitModelRef } from "./model-roles.js"
 
 export interface OrchestrationInstructionsContext {
@@ -20,8 +20,8 @@ export interface OrchestrationInstructionsContext {
 	mode: PromptMode
 	/** Role-based model assignments for orchestrator mode. */
 	roles?: ModelRoles
-	/** Custom model configs for non-registry models. */
-	customConfigs?: ReadonlyMap<string, CustomModelConfig>
+	/** Custom model metadata for non-registry models. */
+	customConfigs?: ReadonlyMap<string, ModelCustomMetadata>
 }
 
 export function resolveOrchestrationInstructions(ctx: OrchestrationInstructionsContext): string {
@@ -309,7 +309,7 @@ interface ResolvedModelMeta {
 function resolveModelMeta(
 	ref: string,
 	registry?: ModelRegistry,
-	customConfigs?: ReadonlyMap<string, CustomModelConfig>,
+	customConfigs?: ReadonlyMap<string, ModelCustomMetadata>,
 	roles?: ModelRoles,
 ): ResolvedModelMeta {
 	const descriptor = resolveDescriptor(ref, registry)
@@ -326,7 +326,7 @@ function resolveModelMeta(
 function formatModelEntry(
 	ref: string,
 	registry?: ModelRegistry,
-	customConfigs?: ReadonlyMap<string, CustomModelConfig>,
+	customConfigs?: ReadonlyMap<string, ModelCustomMetadata>,
 	roles?: ModelRoles,
 ): string {
 	const displayName = resolveModelDisplayName(ref, registry)
@@ -347,7 +347,7 @@ function formatRoleSection(
 	roleName: string,
 	assignment: RoleModelAssignment,
 	registry?: ModelRegistry,
-	customConfigs?: ReadonlyMap<string, CustomModelConfig>,
+	customConfigs?: ReadonlyMap<string, ModelCustomMetadata>,
 	roles?: ModelRoles,
 ): string {
 	const models = normalizeRoleModels(assignment)
@@ -371,7 +371,7 @@ function deriveRolesFromTier(tier: ModelTier | undefined): string {
 function formatCurrentModelCapabilities(
 	currentModelId: string,
 	registry?: ModelRegistry,
-	customConfigs?: ReadonlyMap<string, CustomModelConfig>,
+	customConfigs?: ReadonlyMap<string, ModelCustomMetadata>,
 	roles?: ModelRoles,
 ): string {
 	const meta = resolveModelMeta(currentModelId, registry, customConfigs, roles)
@@ -393,7 +393,7 @@ function buildRoleAssignmentsSection(
 	roles: ModelRoles,
 	registry?: ModelRegistry,
 	currentModelId?: string,
-	customConfigs?: ReadonlyMap<string, CustomModelConfig>,
+	customConfigs?: ReadonlyMap<string, ModelCustomMetadata>,
 ): string {
 	const sections: string[] = []
 

--- a/src/extensions/prompt-construction/prompt-enrichment.ts
+++ b/src/extensions/prompt-construction/prompt-enrichment.ts
@@ -57,7 +57,13 @@ import {
 } from "../orchestration/continuation-nudge.js"
 import { ModelRegistry } from "../orchestration/model-registry/index.js"
 import { registerModelRolesCommand } from "../orchestration/model-roles-command.js"
-import { getModelRoles, modelIdFromRef, splitModelRef, validateModelRoles } from "../orchestration/model-roles.js"
+import {
+	extractCustomConfigs,
+	getModelRoles,
+	modelIdFromRef,
+	splitModelRef,
+	validateModelRoles,
+} from "../orchestration/model-roles.js"
 import { getCurrentPhase } from "../tags.js"
 import { type ContextFile, loadGlobalContextFiles, loadProjectContextFiles } from "./context-files.js"
 import { type EnvironmentInfo, type PromptMode, type ToolInfo, buildSystemPrompt } from "./system-prompt.js"
@@ -509,6 +515,7 @@ export default function (skillPaths: string[]) {
 
 			const mode: PromptMode = subagentMode ? "subagent" : multiModelEnabled ? "orchestrator" : "single"
 			const roles = mode === "orchestrator" ? getModelRoles() : undefined
+			const customConfigs = mode === "orchestrator" && roles ? extractCustomConfigs(roles) : undefined
 
 			let systemPrompt = buildSystemPrompt({
 				tools: tools as readonly ToolInfo[],
@@ -520,6 +527,7 @@ export default function (skillPaths: string[]) {
 				registry: registry,
 				mode,
 				roles,
+				customConfigs,
 				sessionId: ctx.sessionManager?.getSessionId(),
 			})
 

--- a/src/extensions/prompt-construction/system-prompt-blocks.test.ts
+++ b/src/extensions/prompt-construction/system-prompt-blocks.test.ts
@@ -249,7 +249,6 @@ describe("system prompt blocks", () => {
 		blocks.register({ id: "b", render: () => "## Second\n\nBeta" })
 
 		const result = prompt(pi)
-		expect(result).toContain("acting on it.\n\n## First")
 		expect(result).toContain("Alpha\n\n## Second")
 		expect(result).toContain("Beta\n\n## Available Tools")
 	})

--- a/src/extensions/prompt-construction/system-prompt.test.ts
+++ b/src/extensions/prompt-construction/system-prompt.test.ts
@@ -64,8 +64,6 @@ describe("buildSystemPrompt", () => {
 			expect(result).toContain("## Documents")
 			expect(result).toContain("## Guidelines")
 			expect(result).toContain("Orchestrate the work")
-			expect(result).toContain("Sharing context between agents")
-			expect(result).toContain("Orchestrate the work")
 			expect(result).toContain("Token budgets")
 			expect(result).toContain("token_budget")
 		})

--- a/src/extensions/prompt-construction/system-prompt.ts
+++ b/src/extensions/prompt-construction/system-prompt.ts
@@ -12,7 +12,7 @@ import { type Skill, formatSkillsForPrompt } from "@earendil-works/pi-coding-age
 import { buildPhaseGuidelinesSection } from "../orchestration/model-registry/guidelines/guidelines-resolver.js"
 import type { ModelRegistry } from "../orchestration/model-registry/index.js"
 import type { Phase } from "../orchestration/model-registry/types.js"
-import type { ModelRoles } from "../orchestration/model-roles.js"
+import type { CustomModelConfig, ModelRoles } from "../orchestration/model-roles.js"
 import { resolveOrchestrationInstructions } from "../orchestration/orchestration-instructions.js"
 import type { ContextFile } from "./context-files.js"
 import { type SuppressibleSection, renderSystemPromptBlocks } from "./system-prompt-blocks.js"
@@ -47,6 +47,8 @@ export interface SystemPromptBuildOptions {
 	mode: PromptMode
 	/** Role-based model assignments for orchestrator mode. */
 	roles?: ModelRoles
+	/** Custom model configs for non-registry models. */
+	customConfigs?: ReadonlyMap<string, CustomModelConfig>
 	/** Session ID for the active pi-mono session. Used to scope extension prompt blocks
 	 *  to this session so an in-process subagent's blocks don't leak into the parent's
 	 *  prompt and vice versa. Omit only in unit tests or before any session has started. */
@@ -70,6 +72,7 @@ export function buildSystemPrompt(options: SystemPromptBuildOptions): string {
 		registry,
 		mode,
 		roles,
+		customConfigs: options.customConfigs,
 	})
 
 	const phaseSection = buildPhaseGuidelinesSection(currentModelId, currentPhase, registry)

--- a/src/extensions/prompt-construction/system-prompt.ts
+++ b/src/extensions/prompt-construction/system-prompt.ts
@@ -68,7 +68,7 @@ export function buildSystemPrompt(options: SystemPromptBuildOptions): string {
 	const projectContext = formatProjectContext(contextFiles)
 	const skillsSection = formatSkills(skills)
 
-	const orchestrationSection = resolveOrchestrationInstructions({
+	const { teamSection, instructionsSection: orchestrationSection } = resolveOrchestrationInstructions({
 		currentModelId,
 		registry,
 		mode,
@@ -85,6 +85,7 @@ export function buildSystemPrompt(options: SystemPromptBuildOptions): string {
 
 	return buildPrompt({
 		mode,
+		teamSection,
 		toolsSection,
 		environmentSection,
 		projectContext,
@@ -102,6 +103,7 @@ export function buildSystemPrompt(options: SystemPromptBuildOptions): string {
 
 interface PromptParts {
 	mode: PromptMode
+	teamSection: string
 	toolsSection: string
 	environmentSection: string
 	projectContext: string
@@ -141,13 +143,33 @@ const FACTUAL_ACCURACY = `
 function buildPrompt(parts: PromptParts): string {
 	const sections: string[] = []
 
+	// 1. Intro
 	const intro = parts.mode === "orchestrator" ? ORCHESTRATOR_INTRO : SINGLE_INTRO
 	sections.push(intro)
 
-	sections.push(`## Documents\n\n${DOCUMENTS_SECTION}`)
+	// 2. Your Team + Your Capabilities
+	if (parts.teamSection) {
+		sections.push(parts.teamSection)
+	}
+
+	// 3. Orchestration instructions (DOs/DONTs, budgets, agent management)
+	if (!parts.suppressed.has("orchestration") && parts.orchestrationSection) {
+		sections.push(parts.orchestrationSection)
+	}
+
+	// 4. Guidelines
 	sections.push(`## Guidelines\n\n${CORE_GUIDELINES}`)
 	sections.push(`## Factual Accuracy\n\n${FACTUAL_ACCURACY}`)
 
+	// 5. Phase guidelines
+	if (!parts.suppressed.has("phase-guidelines") && parts.phaseSection) {
+		sections.push(parts.phaseSection)
+	}
+
+	// 6. Documents
+	sections.push(`## Documents\n\n${DOCUMENTS_SECTION}`)
+
+	// 7. Rest: system prompt blocks, tools, skills, environment, project context
 	if (parts.systemPromptBlocks) {
 		sections.push(parts.systemPromptBlocks)
 	}
@@ -156,14 +178,6 @@ function buildPrompt(parts: PromptParts): string {
 
 	if (!parts.suppressed.has("skills") && parts.skillsSection) {
 		sections.push(parts.skillsSection)
-	}
-
-	if (!parts.suppressed.has("orchestration") && parts.orchestrationSection) {
-		sections.push(parts.orchestrationSection)
-	}
-
-	if (!parts.suppressed.has("phase-guidelines") && parts.phaseSection) {
-		sections.push(parts.phaseSection)
 	}
 
 	sections.push(parts.environmentSection)

--- a/src/extensions/prompt-construction/system-prompt.ts
+++ b/src/extensions/prompt-construction/system-prompt.ts
@@ -9,10 +9,11 @@
  */
 
 import { type Skill, formatSkillsForPrompt } from "@earendil-works/pi-coding-agent"
+import type { ModelCustomMetadata } from "../orchestration/model-metadata.js"
 import { buildPhaseGuidelinesSection } from "../orchestration/model-registry/guidelines/guidelines-resolver.js"
 import type { ModelRegistry } from "../orchestration/model-registry/index.js"
 import type { Phase } from "../orchestration/model-registry/types.js"
-import type { CustomModelConfig, ModelRoles } from "../orchestration/model-roles.js"
+import type { ModelRoles } from "../orchestration/model-roles.js"
 import { resolveOrchestrationInstructions } from "../orchestration/orchestration-instructions.js"
 import type { ContextFile } from "./context-files.js"
 import { type SuppressibleSection, renderSystemPromptBlocks } from "./system-prompt-blocks.js"
@@ -47,8 +48,8 @@ export interface SystemPromptBuildOptions {
 	mode: PromptMode
 	/** Role-based model assignments for orchestrator mode. */
 	roles?: ModelRoles
-	/** Custom model configs for non-registry models. */
-	customConfigs?: ReadonlyMap<string, CustomModelConfig>
+	/** Custom model metadata for non-registry models. */
+	customConfigs?: ReadonlyMap<string, ModelCustomMetadata>
 	/** Session ID for the active pi-mono session. Used to scope extension prompt blocks
 	 *  to this session so an in-process subagent's blocks don't leak into the parent's
 	 *  prompt and vice versa. Omit only in unit tests or before any session has started. */

--- a/src/paste-to-editor-patch.test.ts
+++ b/src/paste-to-editor-patch.test.ts
@@ -1,5 +1,6 @@
 import { InteractiveMode } from "@earendil-works/pi-coding-agent"
 import { describe, expect, it, vi } from "vitest"
+import "./paste-to-editor-patch.js"
 
 describe("pasteToEditor patch", () => {
 	it("routes pasteToEditor through ui.handleInput instead of editor.handleInput", () => {

--- a/src/paste-to-editor-patch.ts
+++ b/src/paste-to-editor-patch.ts
@@ -1,0 +1,27 @@
+/**
+ * Patches the upstream pi SDK's `createExtensionUIContext` so that
+ * `pasteToEditor` routes through `ui.handleInput` instead of `editor.handleInput`.
+ *
+ * This ensures pasted text goes through the UI's input handling layer,
+ * which properly processes bracketed-paste sequences.
+ */
+
+import { InteractiveMode } from "@earendil-works/pi-coding-agent"
+
+// biome-ignore lint/suspicious/noExplicitAny: private upstream prototype mutation
+const imProto = InteractiveMode.prototype as any
+
+const originalCreateExtensionUIContext = imProto.createExtensionUIContext
+
+export function applyPasteToEditorPatch(): void {
+	imProto.createExtensionUIContext = function patchedCreateExtensionUIContext() {
+		const ctx = originalCreateExtensionUIContext.call(this)
+		ctx.pasteToEditor = (text: string) => {
+			this.ui.handleInput(`\x1b[200~${text}\x1b[201~`)
+		}
+		return ctx
+	}
+}
+
+// Apply patch on module load
+applyPasteToEditorPatch()


### PR DESCRIPTION
## Problem

When a proprietary model (e.g. Claude Sonnet) is configured as orchestrator in multi-model mode, it performs all work inline and never spawns sub-agents.

The orchestrator system prompt shows "No capability information available for this model" in the Your Capabilities section. Without role information, the model has no signal for what to delegate vs do itself, so it defaults to doing everything.

Root cause: proprietary models are marked as "ignored" in MODEL_CAPABILITIES to exclude them from OSS subagent routing. But the same registry is used to resolve orchestrator capabilities. An "ignored" model used as orchestrator gets zero role/tier metadata in the prompt.

A secondary issue compounds the problem: even when role metadata IS present, the orchestration prompt uses conditional rules ("if plan is in your roles, write it yourself; otherwise delegate") that require the LLM to evaluate its own state. Benchmark sessions show models (including kimi-k2.6) hallucinating roles they don't have and writing plans in-process instead of delegating.

## Solution

### 1. Custom model metadata for external models

Models can now carry custom metadata (tier, description, vision) stored in the `modelMetadata` key of settings.json, separate from role assignments. This gives the orchestrator the routing information it needs regardless of whether the model exists in the builtin registry:

```json
{
  "modelRoles": {
    "planner": "kimchi-dev/claude-opus-4-6",
    "builder": ["kimchi-dev/minimax-m2.7", "kimchi-dev/claude-sonnet-4-6"]
  },
  "modelMetadata": {
    "kimchi-dev/claude-opus-4-6": {
      "tier": "heavy",
      "description": "Use for complex tasks and planning"
    }
  }
}
```

Without custom metadata, external models default to `standard` tier, `vision: false`, and an auto-generated description based on assigned roles. Metadata can also be managed interactively via `/multi-model` -> "Edit model metadata".

#### Demo

<img width="2484" height="1544" alt="2026-06-18 16 33 41" src="https://github.com/user-attachments/assets/1106a907-e268-4c52-958f-698ce60f7034" />

### 2. Model roles decoupled from capabilities

Default model-to-role assignment is now a hardcoded mapping (`DEFAULT_MODEL_ROLES`) instead of being dynamically derived from per-model capability metadata. This removes the dependency on the builtin registry for role resolution. A new **researcher** role is added for tasks beyond the codebase (web search, documentation lookup).

### 3. Replace conditional orchestration rules with direct DO/DONT directives

Instead of generic rules the model must interpret ("if a step matches your roles, do it yourself"), the system prompt now generates **per-phase directives** computed from the resolved role configuration:

- When the orchestrator does NOT have the planner role: "DO NOT write the plan yourself. Delegate to Agent(type: Plan, model: kimchi-dev/claude-opus-4-6)."
- When it DOES have the planner role: "DO write the plan yourself."

Applied to all pipeline phases (plan, build, review, explore, research). The model reads facts and follows instructions -- it does not evaluate conditions.

### 4. Your Capabilities section generates direct statements

Instead of a terse `Roles: orchestrator, reviewer` line that the model must cross-reference against rules, the capabilities section now generates explicit statements per role:

```
You have these roles: reviewer, researcher. You are allowed to perform
this work yourself, but delegate to a team member when one is better
suited for the task.

- You do not have the planner role. Do not perform planner work yourself.
  Delegate to Agent(type: "Plan") using: kimchi-dev/claude-opus-4-6.
- You do not have the builder role. Do not perform builder work yourself.
  Delegate to Agent(type: "Builder") using: kimchi-dev/minimax-m2.7, ...
```

### 5. System prompt reordering

Moved "Your Team" and "Your Capabilities" to the top of the system prompt (right after intro), followed by orchestration instructions. The model sees who it is and what it can/cannot do before reading any rules.

## Benchmark validation

All three configurations tested on the same task (greenfield Go REST API, layered architecture, 5 CRUD endpoints, service tests):

| | S29: kimi orch, opus planner | S30: kimi orch + planner (default) | S31: opus orch + planner + reviewer |
|---|---|---|---|
| **Plan** | Delegated to opus | Written by kimi in-process | Written by opus in-process |
| **Correct?** | Yes — kimi lacks planner role, delegated | Yes — kimi has planner role, wrote itself | Yes — opus has planner role, wrote itself |
| **Build** | 4x minimax | 3x minimax (1 retry) | 3x minimax (1 abort, recovered) |
| **Review** | Delegated to minimax | Delegated to minimax | Delegated to opus (fresh context) |
| **Review correct?** | Yes | Yes | Yes — delegated despite having reviewer role |
| **Duration** | 15m 30s | 13m 34s | 12m 33s |
| **Cost** | $2.24 | $0.89 | n/a (test pricing) |
| **Tests passing** | 21 | 35 | 46 |

Key findings:
- **Planning delegation fixed.** S29 proves the core bug is resolved — kimi-k2.6 delegates planning to opus on Turn 1 instead of hallucinating "I have planner role." Before the fix, all benchmark runs had kimi writing plans itself.
- **Directives work both ways.** S30 and S31 confirm that when the orchestrator HAS the planner role, it writes the plan in-process without unnecessary delegation.
- **Review always delegated.** All three sessions delegated review to a fresh-context agent — including S31 where opus has the reviewer role.

## Test plan

- [x] Metadata storage: load, save, delete, cache invalidation, round-trip (34 tests)
- [x] Role parsing and validation with string-only assignments (47 tests)
- [x] Metadata editor UI: formatting, equality, wizard flow (28 tests)
- [x] Prompt rendering: DO/DONT directives, capabilities section, team section (27 tests)
- [x] Model switching with metadata wizard integration (37 tests)
- [x] Model registry invariants without roles field (36 tests)
- [x] System prompt section ordering (5 tests)

Closes #0