### PR TITLE
fix(install): simplify post-install message

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -157,5 +157,4 @@ if [ "$NEEDS_PATH_SETUP" = "yes" ] || { [ "$NEEDS_PATH_SETUP" = "maybe" ] && ! c
 fi
 
 echo ""
-echo -e "${BLUE}Next:${NC} run ${GREEN}kimchi setup${NC} to configure your API key and migrate your skills and MCPs,"
-echo -e "      or just ${GREEN}kimchi${NC} to launch the coding harness."
+echo -e "${BLUE}Next:${NC} run ${GREEN}kimchi${NC} and follow the first-time wizard to configure your API key and migrate your skills and MCPs"


### PR DESCRIPTION
## Summary
- Replaces the two-line post-install next-steps message with a single line directing users to the first-time wizard (`kimchi`), which now handles API key setup and migration automatically.

## Test plan
- [x] Run `scripts/install.sh` and verify the final output shows the updated single-line message