### PR TITLE
feat: adding bash tool guard

### DIFF
--- a/docs/bash-tool-guard.md
+++ b/docs/bash-tool-guard.md
@@ -1,0 +1,193 @@
+# Bash-tool guard
+
+Steers the LLM away from using `bash` for tasks that have a dedicated
+non-shell tool (`read`, `edit`, `write`). The replacement tools are
+cheaper (less output lands in context) and trigger LSP-aware tooling
+(hover, definition, diagnostics) when reading or editing code.
+
+## What it catches
+
+| Category | Patterns | Suggested tool |
+|---|---|---|
+| **read** | `cat <file>`, `head <file>`, `tail <file>`, `less <file>`, `more <file>`, `bat <file>`, `batcat <file>`, `sed -n '<range>p' <file>` | `read` |
+| **edit** | `sed -i '...' <file>`, `sed -i.bak '...' <file>`, `perl -i -pe '...' <file>`, `perl -i.bak ...`, `awk -i inplace '...' <file>` | `edit` |
+| **write** | `echo ... > file`, `printf ... > file`, `cat <<EOF > file`, `cat > file <<EOF`, `tee <file>`, any `>` / `>>` to a non-stream target | `edit` / `write` |
+
+Stream targets like `/dev/null`, `/dev/stdout`, `/dev/stderr` are not
+flagged because they discard or duplicate state rather than creating it.
+
+## What it does NOT catch (intentional)
+
+- `grep`, `rg`, `ag` — legitimate uses outside code-search (log inspection, `/etc/`, one-off filtering)
+- `find` — already a dedicated tool, plus complex queries that the dedicated `find` tool can't replace
+- `ls` — already a dedicated tool
+- `git`, `pnpm`, `node`, `cargo`, etc. — execution tools with no dedicated non-shell alternative
+- All other shell commands — only the patterns above are guarded
+
+## Behaviour
+
+1. **First match per category in a session** — the LLM is steered (a
+   message is injected into the conversation) explaining the better tool.
+   The bash call still executes.
+2. **Second match for the same category** — hard-blocked. The bash call
+   is refused with a reason pointing at the right tool.
+3. **Per-category counters** — `cat` doesn't burn the budget for `sed -i`.
+   A session can have one read warning, one edit warning, and one write
+   warning independently.
+4. **Per-category thresholds** — read/edit/write can each have their own
+   warn threshold. Default is 1 (warn once, then block). Set
+   `warnThresholds: { read: 3 }` to be more lenient on reads.
+5. **Reset on each user prompt** — counters clear on `session_start` and
+   on every user `input` event so a fresh turn starts clean.
+6. **Disabled in plan mode** — same rationale as `exploration-guard`:
+   plan mode is for inspection, not enforcement. Deep reads during
+   scoping aren't blocked.
+
+## Explicit user request override
+
+If the user's most recent prompt explicitly mentions the matched program
+OR expresses the intent in natural language, the guard allows the call.
+The user knows what they're asking for; we don't override explicit intent.
+
+### Program-name match (word-boundary)
+
+- "use sed to fix this" → allows `sed -i 's/typo/fix/' foo.ts`
+- "cat src/foo.ts and tell me what it does" → allows `cat src/foo.ts`
+- "use echo to create a marker file" → allows `echo 'done' > marker.txt`
+
+### Semantic intent match (catches intent without naming the program)
+
+Read intent:
+- "read the file foo.ts" → allows `cat foo.ts`
+- "show me what's in foo.ts" → allows `cat foo.ts`
+- "print the contents of foo.ts" → allows `cat foo.ts`
+- "view the source" → allows `less foo.ts`
+- "open foo.ts" → allows `cat foo.ts`
+
+Edit intent:
+- "fix the typo in foo.ts" → allows `sed -i 's/typo/fix/' foo.ts`
+- "replace foo with bar in file.ts" → allows `sed -i 's/foo/bar/' file.ts`
+- "modify foo.ts" → allows `perl -i -pe ...`
+- "update the file with the new value" → allows `sed -i 's/old/new/'`
+- "use sed to fix this" → allows `sed -i ...`
+- "edit foo.ts" → allows `sed -i ...`
+
+Write intent:
+- "write the result to output.txt" → allows `echo 'done' > output.txt`
+- "create a foo.ts file" → allows `echo 'content' > foo.ts`
+- "save the output to log.txt" → allows `tee log.txt`
+- "put the result in output.txt" → allows `echo 'done' > output.txt`
+- "echo the line to the file" → allows `echo 'done' > foo.ts`
+- "redirect the output to file.txt" → allows `echo 'done' > file.txt`
+
+### Negative cases (word-boundary match prevents false positives)
+
+- "categorize the files" → still flags `cat foo.ts` (`cat` ⊂ `categorize` doesn't match)
+- "the tool used for editing" → still flags `sed -i '...' foo.ts` (`sed` ⊂ `used` doesn't match)
+- "look at the build output" → still flags `cat foo.ts` (no intent keyword)
+- "please be careful" → still flags `sed -i '...' foo.ts` (no intent keyword)
+- "no changes needed" → still flags `echo 'x' > foo.ts` (no intent keyword)
+
+This is local in-memory matching — no extra LLM call, no extra context.
+
+## Telemetry events
+
+The extension emits domain events via `pi.events` for telemetry to observe:
+
+| Channel | Payload | When |
+|---|---|---|
+| `bash_tool_guard:warn` | `{ category, matchedSegment, count }` | First match of a category (steer) |
+| `bash_tool_guard:block` | `{ category, matchedSegment, count }` | Threshold exceeded (hard block) |
+| `bash_tool_guard:allowed_by_user_request` | `{ category, program }` | User explicitly asked for the bash tool |
+
+These events are consumed by the telemetry extension to track guard
+effectiveness (how often it fires, how often users override it).
+
+## Why this saves tokens and triggers LSP
+
+When the LLM uses `bash` to read a file:
+
+- The file content is streamed through the bash tool's stdout capture
+  (often 100s of KB for typical code files).
+- That output lands verbatim in the conversation context.
+- LSP tools (`lsp_hover`, `lsp_definition`) are not consulted, so the
+  LLM has no type information, no references, no diagnostics.
+
+When the LLM uses the `read` tool instead:
+
+- The harness truncates intelligently, shows line numbers, can request
+  specific offsets/limits.
+- LSP hooks fire on the file open — the next `lsp_hover` / `lsp_definition`
+  call returns rich type info without re-reading the file.
+- Future `edit` calls can verify the file hasn't changed (no race
+  conditions vs. the model's mental model).
+
+Same logic for `edit` (in-place `sed -i` corrupts files on regex
+mismatches) and `write` (`echo > file` overwrites with no diff, no
+review, no recovery).
+
+## Configuration
+
+### Disabling
+
+The extension is on by default. To disable it, set the resource toggle
+in `~/.config/kimchi/harness/settings.json`:
+
+```json
+{
+  "resources": {
+    "extensions.bash-tool-guard": false
+  }
+}
+```
+
+Or via the kimchi TUI's resource toggle. A restart is required
+(`restartRequired: true`).
+
+### Custom thresholds
+
+Pass per-category thresholds when registering the extension:
+
+```typescript
+import bashToolGuardExtension from "./extensions/bash-tool-guard.js"
+
+bashToolGuardExtension(pi, {
+  warnThresholds: {
+    read: 3,   // tolerate more reads (deep exploration)
+    edit: 0,   // block edits immediately (production safety)
+    write: 1,  // default: warn once, then block
+  },
+})
+```
+
+## Source
+
+`src/extensions/bash-tool-guard.ts` — exports:
+
+- `classifyBashCommand(command: string): BashClassification | null` —
+  pure function, used by tests and the guard class.
+- `BashToolGuard` — stateful class with per-category counters,
+  per-category thresholds, and explicit-request detection (program-name
+  + semantic intent).
+- `bashToolGuardExtension(pi, options?)` — default export, registers
+  `session_start`, `input`, and `tool_call` handlers.
+- `STEER_MESSAGE_TYPE = "bash-tool-guard-steer"` — custom message type
+  for the steer messages (used by tests and renderers).
+
+`src/extensions/bash-tool-guard-events.ts` — domain event channels:
+
+- `BASH_TOOL_GUARD_EVENTS.WARN`
+- `BASH_TOOL_GUARD_EVENTS.BLOCK`
+- `BASH_TOOL_GUARD_EVENTS.ALLOWED_BY_USER_REQUEST`
+
+## Tests
+
+- `src/extensions/bash-tool-guard.test.ts` — 111 unit tests covering
+  pattern detection (read/edit/write categories), compound commands,
+  RTK-wrapped commands, per-category counters, threshold configuration,
+  explicit-request detection (program-name + semantic intent),
+  word-boundary matching.
+- `src/extensions/bash-tool-guard.integration.test.ts` — 34 integration
+  tests covering wiring, session_start reset, user-input reset, plan-mode
+  disable, explicit-request flow, compound commands, semantic intent
+  override, telemetry event emission.

--- a/docs/bash-tool-guard.md
+++ b/docs/bash-tool-guard.md
@@ -18,33 +18,33 @@ flagged because they discard or duplicate state rather than creating it.
 
 ## What it does NOT catch (intentional)
 
-- `grep`, `rg`, `ag` — legitimate uses outside code-search (log inspection, `/etc/`, one-off filtering)
-- `find` — already a dedicated tool, plus complex queries that the dedicated `find` tool can't replace
-- `ls` — already a dedicated tool
-- `git`, `pnpm`, `node`, `cargo`, etc. — execution tools with no dedicated non-shell alternative
-- All other shell commands — only the patterns above are guarded
+- `grep`, `rg`, `ag` - legitimate uses outside code-search (log inspection, `/etc/`, one-off filtering)
+- `find` - already a dedicated tool, plus complex queries that the dedicated `find` tool can't replace
+- `ls` - already a dedicated tool
+- `git`, `pnpm`, `node`, `cargo`, etc. - execution tools with no dedicated non-shell alternative
+- All other shell commands - only the patterns above are guarded
 
 ## Behaviour
 
-1. **First match per category in a session** — the LLM is steered (a
+1. **First match per category in a session** - the LLM is steered (a
    message is injected into the conversation) explaining the better tool.
    The bash call still executes.
-2. **Subsequent matches for the same category** — by default, the guard
+2. **Subsequent matches for the same category** - by default, the guard
    keeps steering on every occurrence (warn/steer-only). Hard blocking
    is opt-in: pass `blockOnThreshold: true` when registering the
    extension to refuse the bash call with a reason pointing at the
    right tool once the threshold is exceeded. Default is warn-only so
    adopting the guard never stalls a session if the replacement tool
    is unavailable or misconfigured in a given environment.
-3. **Per-category counters** — `cat` doesn't burn the budget for `sed -i`.
+3. **Per-category counters** - `cat` doesn't burn the budget for `sed -i`.
    A session can have one read warning, one edit warning, and one write
    warning independently.
-4. **Per-category thresholds** — read/edit/write can each have their own
+4. **Per-category thresholds** - read/edit/write can each have their own
    warn threshold. Default is 1 (warn once, then block when blocking is
    enabled). Set `warnThresholds: { read: 3 }` to be more lenient on reads.
-5. **Reset on each user prompt** — counters clear on `session_start` and
+5. **Reset on each user prompt** - counters clear on `session_start` and
    on every user `input` event so a fresh turn starts clean.
-6. **Disabled in plan mode** — same rationale as `exploration-guard`:
+6. **Disabled in plan mode** - same rationale as `exploration-guard`:
    plan mode is for inspection, not enforcement. Deep reads during
    scoping aren't blocked.
 
@@ -93,7 +93,7 @@ Write intent:
 - "please be careful" → still flags `sed -i '...' foo.ts` (no intent keyword)
 - "no changes needed" → still flags `echo 'x' > foo.ts` (no intent keyword)
 
-This is local in-memory matching — no extra LLM call, no extra context.
+This is local in-memory matching - no extra LLM call, no extra context.
 
 ## Telemetry events
 
@@ -105,8 +105,8 @@ The extension emits domain events via `pi.events` for telemetry to observe:
 | `bash_tool_guard:block` | `{ category, tool, count }` | Threshold exceeded (hard block; only fires when `blockOnThreshold: true`) |
 | `bash_tool_guard:allowed_by_user_request` | `{ category, tool }` | User explicitly asked for the bash tool |
 
-The payloads carry only structured fields — `category`, `tool`,
-`count` — so telemetry can aggregate without receiving raw command
+The payloads carry only structured fields - `category`, `tool`,
+`count` - so telemetry can aggregate without receiving raw command
 text. Anything that could include user data or secrets inline
 (heredocs, `echo "..." > file`, sed replacement strings) stays out
 of OTLP.
@@ -128,7 +128,7 @@ When the LLM uses the `read` tool instead:
 
 - The harness truncates intelligently, shows line numbers, can request
   specific offsets/limits.
-- LSP hooks fire on the file open — the next `lsp_hover` / `lsp_definition`
+- LSP hooks fire on the file open - the next `lsp_hover` / `lsp_definition`
   call returns rich type info without re-reading the file.
 - Future `edit` calls can verify the file hasn't changed (no race
   conditions vs. the model's mental model).
@@ -152,12 +152,11 @@ in `~/.config/kimchi/harness/settings.json`:
 }
 ```
 
-Or via the kimchi TUI's resource toggle. The toggle is dynamic — the
-`tool_call` handler consults `isResourceEnabled` on every bash call,
-so flipping it from `/resources` takes effect immediately without a
-process restart. Startup-time disablement is still handled by the
-extension filter (the extension isn't registered at all if disabled
-in `settings.json` before launch).
+Or via the kimchi TUI's resource toggle. The toggle is fully dynamic:
+the extension is always registered and the `tool_call` handler consults
+`isResourceEnabled` on every bash call, so flipping it from `/resources`
+takes effect immediately without a process restart — both for disabling
+and re-enabling.
 
 ### Custom thresholds
 
@@ -180,19 +179,19 @@ bashToolGuardExtension(pi, {
 
 ## Source
 
-`src/extensions/bash-tool-guard.ts` — exports:
+`src/extensions/bash-tool-guard.ts` - exports:
 
-- `classifyBashCommand(command: string): BashClassification | null` —
+- `classifyBashCommand(command: string): BashClassification | null` -
   pure function, used by tests and the guard class.
-- `BashToolGuard` — stateful class with per-category counters,
+- `BashToolGuard` - stateful class with per-category counters,
   per-category thresholds, and explicit-request detection (tool-name
   + semantic intent).
-- `bashToolGuardExtension(pi, options?)` — default export, registers
+- `bashToolGuardExtension(pi, options?)` - default export, registers
   `session_start`, `input`, and `tool_call` handlers.
-- `STEER_MESSAGE_TYPE = "bash-tool-guard-steer"` — custom message type
+- `STEER_MESSAGE_TYPE = "bash-tool-guard-steer"` - custom message type
   for the steer messages (used by tests and renderers).
 
-`src/extensions/bash-tool-guard-events.ts` — domain event channels:
+`src/extensions/bash-tool-guard-events.ts` - domain event channels:
 
 - `BASH_TOOL_GUARD_EVENTS.WARN`
 - `BASH_TOOL_GUARD_EVENTS.BLOCK`
@@ -200,13 +199,8 @@ bashToolGuardExtension(pi, {
 
 ## Tests
 
-- `src/extensions/bash-tool-guard.test.ts` — unit coverage of pattern
-  detection (read/edit/write categories), compound commands,
-  RTK-wrapped commands, per-category counters, threshold configuration,
-  explicit-request detection (tool-name + semantic intent),
-  word-boundary matching, and the opt-in blocking flag.
-- `src/extensions/bash-tool-guard.integration.test.ts` — integration
-  coverage of wiring, session_start reset, user-input reset, plan-mode
-  disable, explicit-request flow, compound commands, semantic intent
-  override, dynamic resource-toggle behaviour, and telemetry event
+- `src/extensions/bash-tool-guard.test.ts` - unit coverage of pattern
+  detection, counters, thresholds, and explicit-request handling.
+- `src/extensions/bash-tool-guard.integration.test.ts` - integration
+  coverage of extension wiring, lifecycle resets, and telemetry event
   emission.

--- a/docs/bash-tool-guard.md
+++ b/docs/bash-tool-guard.md
@@ -29,14 +29,19 @@ flagged because they discard or duplicate state rather than creating it.
 1. **First match per category in a session** — the LLM is steered (a
    message is injected into the conversation) explaining the better tool.
    The bash call still executes.
-2. **Second match for the same category** — hard-blocked. The bash call
-   is refused with a reason pointing at the right tool.
+2. **Subsequent matches for the same category** — by default, the guard
+   keeps steering on every occurrence (warn/steer-only). Hard blocking
+   is opt-in: pass `blockOnThreshold: true` when registering the
+   extension to refuse the bash call with a reason pointing at the
+   right tool once the threshold is exceeded. Default is warn-only so
+   adopting the guard never stalls a session if the replacement tool
+   is unavailable or misconfigured in a given environment.
 3. **Per-category counters** — `cat` doesn't burn the budget for `sed -i`.
    A session can have one read warning, one edit warning, and one write
    warning independently.
 4. **Per-category thresholds** — read/edit/write can each have their own
-   warn threshold. Default is 1 (warn once, then block). Set
-   `warnThresholds: { read: 3 }` to be more lenient on reads.
+   warn threshold. Default is 1 (warn once, then block when blocking is
+   enabled). Set `warnThresholds: { read: 3 }` to be more lenient on reads.
 5. **Reset on each user prompt** — counters clear on `session_start` and
    on every user `input` event so a fresh turn starts clean.
 6. **Disabled in plan mode** — same rationale as `exploration-guard`:
@@ -45,7 +50,7 @@ flagged because they discard or duplicate state rather than creating it.
 
 ## Explicit user request override
 
-If the user's most recent prompt explicitly mentions the matched program
+If the user's most recent prompt explicitly mentions the matched tool
 OR expresses the intent in natural language, the guard allows the call.
 The user knows what they're asking for; we don't override explicit intent.
 
@@ -55,7 +60,7 @@ The user knows what they're asking for; we don't override explicit intent.
 - "cat src/foo.ts and tell me what it does" → allows `cat src/foo.ts`
 - "use echo to create a marker file" → allows `echo 'done' > marker.txt`
 
-### Semantic intent match (catches intent without naming the program)
+### Semantic intent match (catches intent without naming the tool)
 
 Read intent:
 - "read the file foo.ts" → allows `cat foo.ts`
@@ -96,9 +101,15 @@ The extension emits domain events via `pi.events` for telemetry to observe:
 
 | Channel | Payload | When |
 |---|---|---|
-| `bash_tool_guard:warn` | `{ category, matchedSegment, count }` | First match of a category (steer) |
-| `bash_tool_guard:block` | `{ category, matchedSegment, count }` | Threshold exceeded (hard block) |
-| `bash_tool_guard:allowed_by_user_request` | `{ category, program }` | User explicitly asked for the bash tool |
+| `bash_tool_guard:warn` | `{ category, tool, count }` | First match of a category (steer) |
+| `bash_tool_guard:block` | `{ category, tool, count }` | Threshold exceeded (hard block; only fires when `blockOnThreshold: true`) |
+| `bash_tool_guard:allowed_by_user_request` | `{ category, tool }` | User explicitly asked for the bash tool |
+
+The payloads carry only structured fields — `category`, `tool`,
+`count` — so telemetry can aggregate without receiving raw command
+text. Anything that could include user data or secrets inline
+(heredocs, `echo "..." > file`, sed replacement strings) stays out
+of OTLP.
 
 These events are consumed by the telemetry extension to track guard
 effectiveness (how often it fires, how often users override it).
@@ -141,8 +152,12 @@ in `~/.config/kimchi/harness/settings.json`:
 }
 ```
 
-Or via the kimchi TUI's resource toggle. A restart is required
-(`restartRequired: true`).
+Or via the kimchi TUI's resource toggle. The toggle is dynamic — the
+`tool_call` handler consults `isResourceEnabled` on every bash call,
+so flipping it from `/resources` takes effect immediately without a
+process restart. Startup-time disablement is still handled by the
+extension filter (the extension isn't registered at all if disabled
+in `settings.json` before launch).
 
 ### Custom thresholds
 
@@ -154,9 +169,12 @@ import bashToolGuardExtension from "./extensions/bash-tool-guard.js"
 bashToolGuardExtension(pi, {
   warnThresholds: {
     read: 3,   // tolerate more reads (deep exploration)
-    edit: 0,   // block edits immediately (production safety)
-    write: 1,  // default: warn once, then block
+    edit: 0,   // block edits immediately when blocking is enabled
+    write: 1,  // default: warn once, then block (when blocking is enabled)
   },
+  // Hard blocking is opt-in. Default is false (warn/steer only).
+  // Set to true to refuse the bash call once the threshold is exceeded.
+  blockOnThreshold: false,
 })
 ```
 
@@ -167,7 +185,7 @@ bashToolGuardExtension(pi, {
 - `classifyBashCommand(command: string): BashClassification | null` —
   pure function, used by tests and the guard class.
 - `BashToolGuard` — stateful class with per-category counters,
-  per-category thresholds, and explicit-request detection (program-name
+  per-category thresholds, and explicit-request detection (tool-name
   + semantic intent).
 - `bashToolGuardExtension(pi, options?)` — default export, registers
   `session_start`, `input`, and `tool_call` handlers.
@@ -182,12 +200,13 @@ bashToolGuardExtension(pi, {
 
 ## Tests
 
-- `src/extensions/bash-tool-guard.test.ts` — 111 unit tests covering
-  pattern detection (read/edit/write categories), compound commands,
+- `src/extensions/bash-tool-guard.test.ts` — unit coverage of pattern
+  detection (read/edit/write categories), compound commands,
   RTK-wrapped commands, per-category counters, threshold configuration,
-  explicit-request detection (program-name + semantic intent),
-  word-boundary matching.
-- `src/extensions/bash-tool-guard.integration.test.ts` — 34 integration
-  tests covering wiring, session_start reset, user-input reset, plan-mode
+  explicit-request detection (tool-name + semantic intent),
+  word-boundary matching, and the opt-in blocking flag.
+- `src/extensions/bash-tool-guard.integration.test.ts` — integration
+  coverage of wiring, session_start reset, user-input reset, plan-mode
   disable, explicit-request flow, compound commands, semantic intent
-  override, telemetry event emission.
+  override, dynamic resource-toggle behaviour, and telemetry event
+  emission.

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -29,6 +29,7 @@ import { isBunBinary } from "./env.js"
 import activityExtension from "./extensions/activity.js"
 import agentsExtension from "./extensions/agents/index.js"
 import assistantPrefixExtension from "./extensions/assistant-prefix.js"
+import bashToolGuardExtension from "./extensions/bash-tool-guard.js"
 import behavioursExtension from "./extensions/behaviours/index.js"
 import claudeCodeHooksAdapter from "./extensions/claude-code-hook-adapter/index.js"
 import claudeCodeSkillsExtension from "./extensions/claude-code-skills/index.js"
@@ -419,6 +420,9 @@ try {
 			explorationGuardExtension,
 			reviewWriteGuardExtension,
 			lspExtension,
+			...enabledExtensionFactories([
+				{ id: "extensions.bash-tool-guard", factory: bashToolGuardExtension },
+			] satisfies ManagedExtensionFactory[]),
 			...enabledExtensionFactories([
 				{ id: "plugins.mcp-apps", factory: mcpAdapterExtension },
 			] satisfies ManagedExtensionFactory[]),

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -420,9 +420,10 @@ try {
 			explorationGuardExtension,
 			reviewWriteGuardExtension,
 			lspExtension,
-			...enabledExtensionFactories([
-				{ id: "extensions.bash-tool-guard", factory: bashToolGuardExtension },
-			] satisfies ManagedExtensionFactory[]),
+			// Always registered — the tool_call handler checks isResourceEnabled
+			// dynamically on every bash call, so enable/disable from /resources
+			// takes effect immediately without a process restart.
+			bashToolGuardExtension,
 			...enabledExtensionFactories([
 				{ id: "plugins.mcp-apps", factory: mcpAdapterExtension },
 			] satisfies ManagedExtensionFactory[]),

--- a/src/extensions/bash-tool-guard-events.ts
+++ b/src/extensions/bash-tool-guard-events.ts
@@ -1,0 +1,37 @@
+/**
+ * Bash-tool-guard domain event channels published via pi.events.
+ *
+ * The bash-tool-guard extension emits these events; the telemetry extension
+ * subscribes to them. This keeps the guard isolated from telemetry and
+ * ensures every steer/block is observed for analytics regardless of which
+ * extension triggered it.
+ */
+
+export const BASH_TOOL_GUARD_EVENTS = {
+	WARN: "bash_tool_guard:warn",
+	BLOCK: "bash_tool_guard:block",
+	ALLOWED_BY_USER_REQUEST: "bash_tool_guard:allowed_by_user_request",
+} as const
+
+export type BashToolGuardEventChannel = (typeof BASH_TOOL_GUARD_EVENTS)[keyof typeof BASH_TOOL_GUARD_EVENTS]
+
+export interface BashToolGuardWarnPayload {
+	/** The read/edit/write category that triggered the warn. */
+	category: "read" | "edit" | "write"
+	/** Short rendering of the matched command segment (first ~80 chars). */
+	matchedSegment: string
+	/** How many times this category has been seen in the session so far. */
+	count: number
+}
+
+export interface BashToolGuardBlockPayload {
+	category: "read" | "edit" | "write"
+	matchedSegment: string
+	count: number
+}
+
+export interface BashToolGuardAllowedByUserRequestPayload {
+	category: "read" | "edit" | "write"
+	/** The program name detected in the matched segment (e.g. "cat", "sed"). */
+	program: string
+}

--- a/src/extensions/bash-tool-guard-events.ts
+++ b/src/extensions/bash-tool-guard-events.ts
@@ -18,20 +18,22 @@ export type BashToolGuardEventChannel = (typeof BASH_TOOL_GUARD_EVENTS)[keyof ty
 export interface BashToolGuardWarnPayload {
 	/** The read/edit/write category that triggered the warn. */
 	category: "read" | "edit" | "write"
-	/** Short rendering of the matched command segment (first ~80 chars). */
-	matchedSegment: string
+	/** The tool name detected in the matched segment (e.g. "cat", "sed").
+	 *  Kept short and structured so telemetry can aggregate without
+	 *  receiving raw command text. */
+	tool: string
 	/** How many times this category has been seen in the session so far. */
 	count: number
 }
 
 export interface BashToolGuardBlockPayload {
 	category: "read" | "edit" | "write"
-	matchedSegment: string
+	tool: string
 	count: number
 }
 
 export interface BashToolGuardAllowedByUserRequestPayload {
 	category: "read" | "edit" | "write"
-	/** The program name detected in the matched segment (e.g. "cat", "sed"). */
-	program: string
+	/** The tool name detected in the matched segment (e.g. "cat", "sed"). */
+	tool: string
 }

--- a/src/extensions/bash-tool-guard.integration.test.ts
+++ b/src/extensions/bash-tool-guard.integration.test.ts
@@ -1,0 +1,676 @@
+/**
+ * Integration tests for the bashToolGuardExtension wiring.
+ * Tests the event handler registration (session_start, input, tool_call)
+ * using a mock ExtensionAPI.
+ */
+import { afterEach, describe, expect, it, vi } from "vitest"
+import { BASH_TOOL_GUARD_EVENTS } from "./bash-tool-guard-events.js"
+import bashToolGuardExtension, { STEER_MESSAGE_TYPE } from "./bash-tool-guard.js"
+
+let mockMode: string | undefined = "default"
+
+vi.mock("./permissions/mode-controller.js", () => ({
+	getPermissionMode: () => (mockMode ? { mode: mockMode, source: "user" } : undefined),
+}))
+
+afterEach(() => {
+	mockMode = "default"
+})
+
+interface BlockResult {
+	block: true
+	reason: string
+}
+
+interface MockExtensionAPI {
+	handlers: Record<string, Array<(...args: unknown[]) => unknown>>
+	on: (event: string, handler: (...args: unknown[]) => unknown) => void
+	sendMessage: ReturnType<typeof vi.fn>
+	events: { emit: ReturnType<typeof vi.fn> }
+	_blockResult?: BlockResult
+	_emittedEvents: Array<{ channel: string; payload: unknown }>
+}
+
+function createMockPI(): MockExtensionAPI {
+	const handlers: MockExtensionAPI["handlers"] = {}
+	const _emittedEvents: MockExtensionAPI["_emittedEvents"] = []
+	return {
+		handlers,
+		on(event: string, handler) {
+			if (!handlers[event]) handlers[event] = []
+			handlers[event].push(handler)
+		},
+		sendMessage: vi.fn(),
+		events: {
+			emit: vi.fn((channel: string, payload: unknown) => {
+				_emittedEvents.push({ channel, payload })
+			}),
+		},
+		_emittedEvents,
+	}
+}
+
+function emit(pi: MockExtensionAPI, event: string, payload: Record<string, unknown> = {}): BlockResult | undefined {
+	const handlers = pi.handlers[event] ?? []
+	let blockResult: BlockResult | undefined
+	for (const h of handlers) {
+		const result = h(payload) as BlockResult | undefined
+		if (result?.block) {
+			blockResult = result
+			pi._blockResult = result
+		}
+	}
+	return blockResult
+}
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+type PI = import("@earendil-works/pi-coding-agent").ExtensionAPI
+
+function fakeCtx(sessionId = "test-session"): { sessionManager: { getSessionId: () => string } } {
+	return { sessionManager: { getSessionId: () => sessionId } }
+}
+
+function fireSessionStart(pi: MockExtensionAPI): void {
+	const handlers = pi.handlers.session_start ?? []
+	for (const h of handlers) h({}, fakeCtx())
+}
+
+describe("bashToolGuardExtension wiring", () => {
+	it("registers session_start, input, and tool_call handlers", () => {
+		const pi = createMockPI()
+		bashToolGuardExtension(pi as unknown as PI)
+		expect(pi.handlers.session_start?.length).toBeGreaterThan(0)
+		expect(pi.handlers.input?.length).toBeGreaterThan(0)
+		expect(pi.handlers.tool_call?.length).toBeGreaterThan(0)
+	})
+
+	it("first matching bash call steers, doesn't block", () => {
+		const pi = createMockPI()
+		bashToolGuardExtension(pi as unknown as PI)
+		fireSessionStart(pi)
+
+		const result = emit(pi, "tool_call", {
+			toolName: "bash",
+			input: { command: "cat foo.ts" },
+		})
+		expect(result).toBeUndefined()
+		expect(pi._blockResult).toBeUndefined()
+		expect(pi.sendMessage).toHaveBeenCalledTimes(1)
+		expect(pi.sendMessage).toHaveBeenCalledWith(expect.objectContaining({ customType: STEER_MESSAGE_TYPE }), {
+			deliverAs: "steer",
+		})
+	})
+
+	it("second matching bash call blocks", () => {
+		const pi = createMockPI()
+		bashToolGuardExtension(pi as unknown as PI)
+		fireSessionStart(pi)
+
+		emit(pi, "tool_call", { toolName: "bash", input: { command: "cat a.ts" } })
+		expect(pi.sendMessage).toHaveBeenCalledTimes(1)
+
+		const result = emit(pi, "tool_call", { toolName: "bash", input: { command: "head b.ts" } })
+		expect(result?.block).toBe(true)
+		expect(result?.reason).toMatch(/read/i)
+		expect(pi.sendMessage).toHaveBeenCalledTimes(1) // still only the one steer
+	})
+
+	it("different categories have independent budgets", () => {
+		const pi = createMockPI()
+		bashToolGuardExtension(pi as unknown as PI)
+		fireSessionStart(pi)
+
+		// First read → steer
+		emit(pi, "tool_call", { toolName: "bash", input: { command: "cat a.ts" } })
+		// First edit → steer (different category)
+		emit(pi, "tool_call", {
+			toolName: "bash",
+			input: { command: "sed -i 's/a/b/' a.ts" },
+		})
+		// First write → steer (different category)
+		emit(pi, "tool_call", {
+			toolName: "bash",
+			input: { command: "echo 'x' > a.ts" },
+		})
+		expect(pi.sendMessage).toHaveBeenCalledTimes(3)
+		expect(pi._blockResult).toBeUndefined()
+	})
+
+	it("session_start resets counters", () => {
+		const pi = createMockPI()
+		bashToolGuardExtension(pi as unknown as PI)
+		fireSessionStart(pi)
+
+		emit(pi, "tool_call", { toolName: "bash", input: { command: "cat a.ts" } })
+		emit(pi, "tool_call", { toolName: "bash", input: { command: "cat b.ts" } }) // would block
+		expect(pi._blockResult?.block).toBe(true)
+
+		// Reset and re-test
+		fireSessionStart(pi)
+		pi._blockResult = undefined
+		const result = emit(pi, "tool_call", {
+			toolName: "bash",
+			input: { command: "cat c.ts" },
+		})
+		expect(result).toBeUndefined()
+		expect(pi._blockResult).toBeUndefined()
+	})
+
+	it("user `input` event resets counters (extension source does not)", () => {
+		const pi = createMockPI()
+		bashToolGuardExtension(pi as unknown as PI)
+		fireSessionStart(pi)
+
+		emit(pi, "tool_call", { toolName: "bash", input: { command: "cat a.ts" } })
+		emit(pi, "tool_call", { toolName: "bash", input: { command: "cat b.ts" } }) // would block
+
+		// User input resets counters
+		emit(pi, "input", { source: "interactive" })
+		pi._blockResult = undefined
+
+		const result = emit(pi, "tool_call", {
+			toolName: "bash",
+			input: { command: "cat c.ts" },
+		})
+		expect(result).toBeUndefined()
+	})
+
+	it("extension-source input does NOT reset counters", () => {
+		const pi = createMockPI()
+		bashToolGuardExtension(pi as unknown as PI)
+		fireSessionStart(pi)
+
+		emit(pi, "tool_call", { toolName: "bash", input: { command: "cat a.ts" } })
+		emit(pi, "tool_call", { toolName: "bash", input: { command: "cat b.ts" } }) // would block
+
+		// Extension-sourced input must not reset
+		emit(pi, "input", { source: "extension" })
+		pi._blockResult = undefined
+
+		const result = emit(pi, "tool_call", {
+			toolName: "bash",
+			input: { command: "cat c.ts" },
+		})
+		expect(result?.block).toBe(true)
+	})
+
+	it("non-bash tool calls are ignored", () => {
+		const pi = createMockPI()
+		bashToolGuardExtension(pi as unknown as PI)
+		fireSessionStart(pi)
+
+		emit(pi, "tool_call", { toolName: "read", input: { filePath: "foo.ts" } })
+		emit(pi, "tool_call", { toolName: "edit", input: { filePath: "foo.ts" } })
+		emit(pi, "tool_call", { toolName: "write", input: { filePath: "foo.ts" } })
+		expect(pi.sendMessage).not.toHaveBeenCalled()
+		expect(pi._blockResult).toBeUndefined()
+	})
+
+	it("legitimate bash calls are not flagged", () => {
+		const pi = createMockPI()
+		bashToolGuardExtension(pi as unknown as PI)
+		fireSessionStart(pi)
+
+		const legitCommands = [
+			"git status",
+			"pnpm test",
+			"pnpm run build",
+			"ls -la",
+			"grep -r 'TODO' src/",
+			"rg 'foo' src/",
+			"echo 'build done'", // no redirect
+			"echo 'log' > /dev/null", // stream target
+		]
+		for (const command of legitCommands) {
+			const result = emit(pi, "tool_call", { toolName: "bash", input: { command } })
+			expect(result).toBeUndefined()
+		}
+		expect(pi.sendMessage).not.toHaveBeenCalled()
+		expect(pi._blockResult).toBeUndefined()
+	})
+
+	it("plan-mode permission context disables the guard", () => {
+		mockMode = "plan"
+		const pi = createMockPI()
+		bashToolGuardExtension(pi as unknown as PI)
+		fireSessionStart(pi)
+
+		// Even repeated anti-patterns should pass under plan mode.
+		emit(pi, "tool_call", { toolName: "bash", input: { command: "cat a.ts" } })
+		emit(pi, "tool_call", { toolName: "bash", input: { command: "cat b.ts" } })
+		emit(pi, "tool_call", { toolName: "bash", input: { command: "cat c.ts" } })
+		expect(pi.sendMessage).not.toHaveBeenCalled()
+		expect(pi._blockResult).toBeUndefined()
+	})
+
+	it("block reason text names the better tool", () => {
+		const pi = createMockPI()
+		bashToolGuardExtension(pi as unknown as PI)
+		fireSessionStart(pi)
+
+		emit(pi, "tool_call", {
+			toolName: "bash",
+			input: { command: "sed -i 's/a/b/' a.ts" },
+		}) // warn
+		const result = emit(pi, "tool_call", {
+			toolName: "bash",
+			input: { command: "sed -i 's/x/y/' a.ts" },
+		}) // block
+		expect(result?.reason).toMatch(/edit tool/)
+	})
+
+	it("non-string command input is ignored", () => {
+		const pi = createMockPI()
+		bashToolGuardExtension(pi as unknown as PI)
+		fireSessionStart(pi)
+
+		const result = emit(pi, "tool_call", {
+			toolName: "bash",
+			input: { command: 42 },
+		})
+		expect(result).toBeUndefined()
+		expect(pi.sendMessage).not.toHaveBeenCalled()
+	})
+
+	it("empty command is ignored", () => {
+		const pi = createMockPI()
+		bashToolGuardExtension(pi as unknown as PI)
+		fireSessionStart(pi)
+
+		const result = emit(pi, "tool_call", {
+			toolName: "bash",
+			input: { command: "" },
+		})
+		expect(result).toBeUndefined()
+		expect(pi.sendMessage).not.toHaveBeenCalled()
+	})
+
+	it("missing toolName is ignored", () => {
+		const pi = createMockPI()
+		bashToolGuardExtension(pi as unknown as PI)
+		fireSessionStart(pi)
+
+		const result = emit(pi, "tool_call", { input: { command: "cat foo.ts" } })
+		expect(result).toBeUndefined()
+		expect(pi.sendMessage).not.toHaveBeenCalled()
+	})
+
+	it("user prompt mentioning the program bypasses the guard", () => {
+		const pi = createMockPI()
+		bashToolGuardExtension(pi as unknown as PI)
+		fireSessionStart(pi)
+
+		// User explicitly asks: "please use sed to fix foo.ts"
+		emit(pi, "input", { source: "interactive", text: "please use sed to fix foo.ts" })
+
+		// Model runs sed twice — would normally steer then block.
+		const r1 = emit(pi, "tool_call", {
+			toolName: "bash",
+			input: { command: "sed -i 's/a/b/' foo.ts" },
+		})
+		expect(r1).toBeUndefined()
+		expect(pi.sendMessage).not.toHaveBeenCalled()
+		expect(pi._blockResult).toBeUndefined()
+
+		const r2 = emit(pi, "tool_call", {
+			toolName: "bash",
+			input: { command: "sed -i 's/c/d/' foo.ts" },
+		})
+		expect(r2).toBeUndefined()
+		expect(pi.sendMessage).not.toHaveBeenCalled()
+	})
+
+	it("explicit-request override is per-program (cat allowed, sed still guarded)", () => {
+		const pi = createMockPI()
+		bashToolGuardExtension(pi as unknown as PI)
+		fireSessionStart(pi)
+
+		emit(pi, "input", { source: "interactive", text: "use cat to read foo.ts" })
+
+		// cat: allowed (user mentioned)
+		const r1 = emit(pi, "tool_call", {
+			toolName: "bash",
+			input: { command: "cat foo.ts" },
+		})
+		expect(r1).toBeUndefined()
+
+		// sed: not mentioned, still guarded
+		const r2 = emit(pi, "tool_call", {
+			toolName: "bash",
+			input: { command: "sed -i 's/a/b/' foo.ts" },
+		})
+		expect(r2).toBeUndefined() // first match: warn, not block
+		expect(pi.sendMessage).toHaveBeenCalledTimes(1)
+	})
+
+	it("substring false-positive guard: 'categorize' does not bypass cat block", () => {
+		const pi = createMockPI()
+		bashToolGuardExtension(pi as unknown as PI)
+		fireSessionStart(pi)
+
+		// 'cat' inside 'categorize' — word-boundary match means this should NOT bypass.
+		emit(pi, "input", { source: "interactive", text: "categorize the files" })
+
+		const result = emit(pi, "tool_call", {
+			toolName: "bash",
+			input: { command: "cat foo.ts" },
+		})
+		expect(result).toBeUndefined() // first: steer
+		expect(pi.sendMessage).toHaveBeenCalledTimes(1)
+	})
+
+	it("next user input overrides the previous prompt (no stale override)", () => {
+		const pi = createMockPI()
+		bashToolGuardExtension(pi as unknown as PI)
+		fireSessionStart(pi)
+
+		// First prompt explicitly asks for sed → allowed
+		emit(pi, "input", { source: "interactive", text: "use sed to fix foo.ts" })
+		emit(pi, "tool_call", {
+			toolName: "bash",
+			input: { command: "sed -i 's/a/b/' foo.ts" },
+		})
+		expect(pi.sendMessage).not.toHaveBeenCalled()
+
+		// Next user prompt doesn't mention sed AND has no edit intent
+		// (avoid "edit bar.ts" which now matches the edit semantic pattern).
+		emit(pi, "input", { source: "interactive", text: "now look at bar.ts" })
+		const r = emit(pi, "tool_call", {
+			toolName: "bash",
+			input: { command: "sed -i 's/x/y/' bar.ts" },
+		})
+		expect(r).toBeUndefined() // first match: steer
+		expect(pi.sendMessage).toHaveBeenCalledTimes(1)
+	})
+})
+
+describe("bashToolGuardExtension — compound commands", () => {
+	it("flags read in compound (cat foo && echo done)", () => {
+		const pi = createMockPI()
+		bashToolGuardExtension(pi as unknown as PI)
+		fireSessionStart(pi)
+
+		const result = emit(pi, "tool_call", {
+			toolName: "bash",
+			input: { command: "cat foo.ts && echo done" },
+		})
+		expect(result).toBeUndefined() // first match: warn
+		expect(pi.sendMessage).toHaveBeenCalledTimes(1)
+		expect(pi.sendMessage).toHaveBeenCalledWith(
+			expect.objectContaining({
+				customType: STEER_MESSAGE_TYPE,
+				content: expect.arrayContaining([
+					expect.objectContaining({ type: "text", text: expect.stringMatching(/read/i) }),
+				]),
+			}),
+			{ deliverAs: "steer" },
+		)
+	})
+
+	it("flags write in compound (git status; echo x > foo)", () => {
+		const pi = createMockPI()
+		bashToolGuardExtension(pi as unknown as PI)
+		fireSessionStart(pi)
+
+		const result = emit(pi, "tool_call", {
+			toolName: "bash",
+			input: { command: "git status; echo 'x' > foo.ts" },
+		})
+		expect(result).toBeUndefined() // warn
+		expect(pi.sendMessage).toHaveBeenCalledTimes(1)
+	})
+
+	it("blocks write in compound on second match", () => {
+		const pi = createMockPI()
+		bashToolGuardExtension(pi as unknown as PI)
+		fireSessionStart(pi)
+
+		emit(pi, "tool_call", {
+			toolName: "bash",
+			input: { command: "git status; echo 'first' > a.ts" },
+		}) // warn
+		const result = emit(pi, "tool_call", {
+			toolName: "bash",
+			input: { command: "git pull && echo 'done' > progress.txt" },
+		}) // block
+		expect(result?.block).toBe(true)
+		expect(result?.reason).toMatch(/write/i)
+	})
+
+	it("allows compound read when user explicitly asks", () => {
+		const pi = createMockPI()
+		bashToolGuardExtension(pi as unknown as PI)
+		fireSessionStart(pi)
+
+		emit(pi, "input", { source: "interactive", text: "cat foo.ts and bar.ts" })
+		const result = emit(pi, "tool_call", {
+			toolName: "bash",
+			input: { command: "cat foo.ts && cat bar.ts" },
+		})
+		expect(result).toBeUndefined()
+		expect(pi.sendMessage).not.toHaveBeenCalled()
+	})
+
+	it("flags pipe where first segment is a read", () => {
+		const pi = createMockPI()
+		bashToolGuardExtension(pi as unknown as PI)
+		fireSessionStart(pi)
+
+		const result = emit(pi, "tool_call", {
+			toolName: "bash",
+			input: { command: "cat foo.ts | head -n 5" },
+		})
+		expect(result).toBeUndefined() // warn
+		expect(pi.sendMessage).toHaveBeenCalledTimes(1)
+	})
+})
+
+describe("bashToolGuardExtension — semantic intent override", () => {
+	it("'read the file' intent allows cat through the full extension", () => {
+		const pi = createMockPI()
+		bashToolGuardExtension(pi as unknown as PI)
+		fireSessionStart(pi)
+
+		emit(pi, "input", { source: "interactive", text: "read the file foo.ts and summarize" })
+		const result = emit(pi, "tool_call", {
+			toolName: "bash",
+			input: { command: "cat foo.ts" },
+		})
+		expect(result).toBeUndefined()
+		expect(pi.sendMessage).not.toHaveBeenCalled()
+	})
+
+	it("'fix the typo' intent allows sed through the full extension", () => {
+		const pi = createMockPI()
+		bashToolGuardExtension(pi as unknown as PI)
+		fireSessionStart(pi)
+
+		emit(pi, "input", { source: "interactive", text: "fix the typo in foo.ts" })
+		const result = emit(pi, "tool_call", {
+			toolName: "bash",
+			input: { command: "sed -i 's/typo/fix/' foo.ts" },
+		})
+		expect(result).toBeUndefined()
+		expect(pi.sendMessage).not.toHaveBeenCalled()
+	})
+
+	it("'write to file' intent allows echo redirect through the full extension", () => {
+		const pi = createMockPI()
+		bashToolGuardExtension(pi as unknown as PI)
+		fireSessionStart(pi)
+
+		emit(pi, "input", { source: "interactive", text: "write the result to output.txt" })
+		const result = emit(pi, "tool_call", {
+			toolName: "bash",
+			input: { command: "echo 'done' > output.txt" },
+		})
+		expect(result).toBeUndefined()
+		expect(pi.sendMessage).not.toHaveBeenCalled()
+	})
+
+	it("semantic intent for one category does NOT bypass other categories", () => {
+		const pi = createMockPI()
+		bashToolGuardExtension(pi as unknown as PI)
+		fireSessionStart(pi)
+
+		// 'read the file' → read semantic intent active
+		emit(pi, "input", { source: "interactive", text: "read the file foo.ts" })
+		// cat allowed
+		emit(pi, "tool_call", {
+			toolName: "bash",
+			input: { command: "cat foo.ts" },
+		})
+		expect(pi.sendMessage).not.toHaveBeenCalled()
+
+		// but write/edit still guarded (no intent match)
+		const result = emit(pi, "tool_call", {
+			toolName: "bash",
+			input: { command: "sed -i 's/a/b/' foo.ts" },
+		})
+		expect(result).toBeUndefined() // warn
+		expect(pi.sendMessage).toHaveBeenCalledTimes(1)
+	})
+})
+
+describe("bashToolGuardExtension — telemetry events via pi.events", () => {
+	it("emits warn event when first category match fires", () => {
+		const pi = createMockPI()
+		bashToolGuardExtension(pi as unknown as PI)
+		fireSessionStart(pi)
+
+		emit(pi, "tool_call", {
+			toolName: "bash",
+			input: { command: "cat foo.ts" },
+		})
+
+		expect(pi.events.emit).toHaveBeenCalledWith(
+			BASH_TOOL_GUARD_EVENTS.WARN,
+			expect.objectContaining({
+				category: "read",
+				matchedSegment: "cat foo.ts",
+				count: 1,
+			}),
+		)
+	})
+
+	it("emits block event when threshold exceeded", () => {
+		const pi = createMockPI()
+		bashToolGuardExtension(pi as unknown as PI)
+		fireSessionStart(pi)
+
+		emit(pi, "tool_call", {
+			toolName: "bash",
+			input: { command: "cat a.ts" },
+		}) // warn (no block event)
+		emit(pi, "tool_call", {
+			toolName: "bash",
+			input: { command: "cat b.ts" },
+		}) // block
+
+		expect(pi.events.emit).toHaveBeenCalledWith(
+			BASH_TOOL_GUARD_EVENTS.BLOCK,
+			expect.objectContaining({
+				category: "read",
+				count: 2,
+			}),
+		)
+	})
+
+	it("emits allow-by-user-request event when explicit override fires", () => {
+		const pi = createMockPI()
+		bashToolGuardExtension(pi as unknown as PI)
+		fireSessionStart(pi)
+
+		emit(pi, "input", { source: "interactive", text: "please use sed to fix foo.ts" })
+		emit(pi, "tool_call", {
+			toolName: "bash",
+			input: { command: "sed -i 's/a/b/' foo.ts" },
+		})
+
+		expect(pi.events.emit).toHaveBeenCalledWith(
+			BASH_TOOL_GUARD_EVENTS.ALLOWED_BY_USER_REQUEST,
+			expect.objectContaining({
+				category: "edit",
+				program: "sed",
+			}),
+		)
+	})
+
+	it("emits semantic intent allow-by-user-request event", () => {
+		const pi = createMockPI()
+		bashToolGuardExtension(pi as unknown as PI)
+		fireSessionStart(pi)
+
+		emit(pi, "input", { source: "interactive", text: "read the file foo.ts" })
+		emit(pi, "tool_call", {
+			toolName: "bash",
+			input: { command: "cat foo.ts" },
+		})
+
+		expect(pi.events.emit).toHaveBeenCalledWith(
+			BASH_TOOL_GUARD_EVENTS.ALLOWED_BY_USER_REQUEST,
+			expect.objectContaining({
+				category: "read",
+				program: "cat",
+			}),
+		)
+	})
+
+	it("does NOT emit events for non-matching bash", () => {
+		const pi = createMockPI()
+		bashToolGuardExtension(pi as unknown as PI)
+		fireSessionStart(pi)
+
+		emit(pi, "tool_call", {
+			toolName: "bash",
+			input: { command: "git status" },
+		})
+
+		expect(pi.events.emit).not.toHaveBeenCalled()
+	})
+
+	it("does NOT emit events when guard is disabled (plan mode)", () => {
+		mockMode = "plan"
+		const pi = createMockPI()
+		bashToolGuardExtension(pi as unknown as PI)
+		fireSessionStart(pi)
+
+		emit(pi, "tool_call", {
+			toolName: "bash",
+			input: { command: "cat foo.ts" },
+		})
+		emit(pi, "tool_call", {
+			toolName: "bash",
+			input: { command: "cat bar.ts" },
+		})
+
+		expect(pi.events.emit).not.toHaveBeenCalled()
+	})
+})
+
+describe("bashToolGuardExtension — per-category thresholds", () => {
+	it("respects per-category warnThresholds passed via options", () => {
+		const pi = createMockPI()
+		bashToolGuardExtension(pi as unknown as PI, {
+			warnThresholds: { read: 3, edit: 0, write: 1 },
+		})
+		fireSessionStart(pi)
+
+		// read budget = 3 → three warns, then block
+		emit(pi, "tool_call", { toolName: "bash", input: { command: "cat a.ts" } })
+		emit(pi, "tool_call", { toolName: "bash", input: { command: "cat b.ts" } })
+		emit(pi, "tool_call", { toolName: "bash", input: { command: "cat c.ts" } })
+		expect(pi._blockResult).toBeUndefined()
+
+		const r4 = emit(pi, "tool_call", { toolName: "bash", input: { command: "cat d.ts" } })
+		expect(r4?.block).toBe(true)
+
+		// edit budget = 0 → first occurrence blocks immediately
+		pi._blockResult = undefined
+		const rEdit = emit(pi, "tool_call", {
+			toolName: "bash",
+			input: { command: "sed -i 's/a/b/' a.ts" },
+		})
+		expect(rEdit?.block).toBe(true)
+	})
+})

--- a/src/extensions/bash-tool-guard.integration.test.ts
+++ b/src/extensions/bash-tool-guard.integration.test.ts
@@ -243,6 +243,50 @@ describe("bashToolGuardExtension wiring", () => {
 		expect(pi._blockResult).toBeUndefined()
 	})
 
+	it("caller-supplied isEnabled=false disables the guard", () => {
+		// Regression: previously the extension factory hardcoded its own
+		// isEnabled predicate, silently ignoring any caller-supplied one.
+		mockMode = "default"
+		const pi = createMockPI()
+		bashToolGuardExtension(pi as unknown as PI, { isEnabled: () => false })
+		fireSessionStart(pi)
+
+		// Anti-patterns pass without warn/block/steer events.
+		emit(pi, "tool_call", { toolName: "bash", input: { command: "cat a.ts" } })
+		emit(pi, "tool_call", { toolName: "bash", input: { command: "cat b.ts" } })
+		expect(pi.sendMessage).not.toHaveBeenCalled()
+		expect(pi._blockResult).toBeUndefined()
+		expect(pi._emittedEvents).toHaveLength(0)
+	})
+
+	it("caller-supplied isEnabled=true is overridden by plan mode", () => {
+		// Plan mode is inspection-only and must take precedence over a
+		// permissive caller predicate.
+		mockMode = "plan"
+		const pi = createMockPI()
+		bashToolGuardExtension(pi as unknown as PI, { isEnabled: () => true })
+		fireSessionStart(pi)
+
+		emit(pi, "tool_call", { toolName: "bash", input: { command: "cat a.ts" } })
+		emit(pi, "tool_call", { toolName: "bash", input: { command: "cat b.ts" } })
+		expect(pi.sendMessage).not.toHaveBeenCalled()
+		expect(pi._blockResult).toBeUndefined()
+	})
+
+	it("caller-supplied isEnabled=true permits guard outside plan mode", () => {
+		// Sanity check: a permissive caller predicate lets the guard run.
+		mockMode = "default"
+		const pi = createMockPI()
+		bashToolGuardExtension(pi as unknown as PI, { isEnabled: () => true })
+		fireSessionStart(pi)
+
+		// First `cat` warns (steer message), second blocks.
+		emit(pi, "tool_call", { toolName: "bash", input: { command: "cat a.ts" } })
+		expect(pi.sendMessage).toHaveBeenCalledTimes(1)
+		const result = emit(pi, "tool_call", { toolName: "bash", input: { command: "cat b.ts" } })
+		expect(result?.block).toBe(true)
+	})
+
 	it("block reason text names the better tool", () => {
 		const pi = createMockPI()
 		bashToolGuardExtension(pi as unknown as PI)

--- a/src/extensions/bash-tool-guard.integration.test.ts
+++ b/src/extensions/bash-tool-guard.integration.test.ts
@@ -8,13 +8,19 @@ import { BASH_TOOL_GUARD_EVENTS } from "./bash-tool-guard-events.js"
 import bashToolGuardExtension, { STEER_MESSAGE_TYPE } from "./bash-tool-guard.js"
 
 let mockMode: string | undefined = "default"
+let mockResourceEnabled = true
 
 vi.mock("./permissions/mode-controller.js", () => ({
 	getPermissionMode: () => (mockMode ? { mode: mockMode, source: "user" } : undefined),
 }))
 
+vi.mock("../resources/store.js", () => ({
+	isResourceEnabled: (id: string) => (id === "extensions.bash-tool-guard" ? mockResourceEnabled : true),
+}))
+
 afterEach(() => {
 	mockMode = "default"
+	mockResourceEnabled = true
 })
 
 interface BlockResult {
@@ -78,7 +84,7 @@ function fireSessionStart(pi: MockExtensionAPI): void {
 describe("bashToolGuardExtension wiring", () => {
 	it("registers session_start, input, and tool_call handlers", () => {
 		const pi = createMockPI()
-		bashToolGuardExtension(pi as unknown as PI)
+		bashToolGuardExtension(pi as unknown as PI, { blockOnThreshold: true })
 		expect(pi.handlers.session_start?.length).toBeGreaterThan(0)
 		expect(pi.handlers.input?.length).toBeGreaterThan(0)
 		expect(pi.handlers.tool_call?.length).toBeGreaterThan(0)
@@ -86,7 +92,7 @@ describe("bashToolGuardExtension wiring", () => {
 
 	it("first matching bash call steers, doesn't block", () => {
 		const pi = createMockPI()
-		bashToolGuardExtension(pi as unknown as PI)
+		bashToolGuardExtension(pi as unknown as PI, { blockOnThreshold: true })
 		fireSessionStart(pi)
 
 		const result = emit(pi, "tool_call", {
@@ -103,7 +109,7 @@ describe("bashToolGuardExtension wiring", () => {
 
 	it("second matching bash call blocks", () => {
 		const pi = createMockPI()
-		bashToolGuardExtension(pi as unknown as PI)
+		bashToolGuardExtension(pi as unknown as PI, { blockOnThreshold: true })
 		fireSessionStart(pi)
 
 		emit(pi, "tool_call", { toolName: "bash", input: { command: "cat a.ts" } })
@@ -117,7 +123,7 @@ describe("bashToolGuardExtension wiring", () => {
 
 	it("different categories have independent budgets", () => {
 		const pi = createMockPI()
-		bashToolGuardExtension(pi as unknown as PI)
+		bashToolGuardExtension(pi as unknown as PI, { blockOnThreshold: true })
 		fireSessionStart(pi)
 
 		// First read → steer
@@ -138,7 +144,7 @@ describe("bashToolGuardExtension wiring", () => {
 
 	it("session_start resets counters", () => {
 		const pi = createMockPI()
-		bashToolGuardExtension(pi as unknown as PI)
+		bashToolGuardExtension(pi as unknown as PI, { blockOnThreshold: true })
 		fireSessionStart(pi)
 
 		emit(pi, "tool_call", { toolName: "bash", input: { command: "cat a.ts" } })
@@ -158,7 +164,7 @@ describe("bashToolGuardExtension wiring", () => {
 
 	it("user `input` event resets counters (extension source does not)", () => {
 		const pi = createMockPI()
-		bashToolGuardExtension(pi as unknown as PI)
+		bashToolGuardExtension(pi as unknown as PI, { blockOnThreshold: true })
 		fireSessionStart(pi)
 
 		emit(pi, "tool_call", { toolName: "bash", input: { command: "cat a.ts" } })
@@ -177,7 +183,7 @@ describe("bashToolGuardExtension wiring", () => {
 
 	it("extension-source input does NOT reset counters", () => {
 		const pi = createMockPI()
-		bashToolGuardExtension(pi as unknown as PI)
+		bashToolGuardExtension(pi as unknown as PI, { blockOnThreshold: true })
 		fireSessionStart(pi)
 
 		emit(pi, "tool_call", { toolName: "bash", input: { command: "cat a.ts" } })
@@ -196,7 +202,7 @@ describe("bashToolGuardExtension wiring", () => {
 
 	it("non-bash tool calls are ignored", () => {
 		const pi = createMockPI()
-		bashToolGuardExtension(pi as unknown as PI)
+		bashToolGuardExtension(pi as unknown as PI, { blockOnThreshold: true })
 		fireSessionStart(pi)
 
 		emit(pi, "tool_call", { toolName: "read", input: { filePath: "foo.ts" } })
@@ -208,7 +214,7 @@ describe("bashToolGuardExtension wiring", () => {
 
 	it("legitimate bash calls are not flagged", () => {
 		const pi = createMockPI()
-		bashToolGuardExtension(pi as unknown as PI)
+		bashToolGuardExtension(pi as unknown as PI, { blockOnThreshold: true })
 		fireSessionStart(pi)
 
 		const legitCommands = [
@@ -232,7 +238,7 @@ describe("bashToolGuardExtension wiring", () => {
 	it("plan-mode permission context disables the guard", () => {
 		mockMode = "plan"
 		const pi = createMockPI()
-		bashToolGuardExtension(pi as unknown as PI)
+		bashToolGuardExtension(pi as unknown as PI, { blockOnThreshold: true })
 		fireSessionStart(pi)
 
 		// Even repeated anti-patterns should pass under plan mode.
@@ -277,7 +283,10 @@ describe("bashToolGuardExtension wiring", () => {
 		// Sanity check: a permissive caller predicate lets the guard run.
 		mockMode = "default"
 		const pi = createMockPI()
-		bashToolGuardExtension(pi as unknown as PI, { isEnabled: () => true })
+		bashToolGuardExtension(pi as unknown as PI, {
+			isEnabled: () => true,
+			blockOnThreshold: true,
+		})
 		fireSessionStart(pi)
 
 		// First `cat` warns (steer message), second blocks.
@@ -287,9 +296,36 @@ describe("bashToolGuardExtension wiring", () => {
 		expect(result?.block).toBe(true)
 	})
 
+	it("dynamically skips tool_call when resource is disabled at runtime", () => {
+		// The /resources toggle should take effect mid-session without
+		// a restart. The tool_call handler consults isResourceEnabled
+		// on every bash call.
+		mockMode = "default"
+		mockResourceEnabled = false
+		const pi = createMockPI()
+		bashToolGuardExtension(pi as unknown as PI, { blockOnThreshold: true })
+		fireSessionStart(pi)
+
+		// Resource disabled → guard stays silent even on repeated
+		// anti-patterns that would otherwise exceed the threshold.
+		emit(pi, "tool_call", { toolName: "bash", input: { command: "cat a.ts" } })
+		emit(pi, "tool_call", { toolName: "bash", input: { command: "cat b.ts" } })
+		emit(pi, "tool_call", { toolName: "bash", input: { command: "cat c.ts" } })
+		expect(pi.sendMessage).not.toHaveBeenCalled()
+		expect(pi._blockResult).toBeUndefined()
+		expect(pi._emittedEvents).toHaveLength(0)
+
+		// Re-enabling the resource mid-session restores the guard.
+		mockResourceEnabled = true
+		emit(pi, "tool_call", { toolName: "bash", input: { command: "cat a.ts" } })
+		expect(pi.sendMessage).toHaveBeenCalledTimes(1)
+		const result = emit(pi, "tool_call", { toolName: "bash", input: { command: "cat b.ts" } })
+		expect(result?.block).toBe(true)
+	})
+
 	it("block reason text names the better tool", () => {
 		const pi = createMockPI()
-		bashToolGuardExtension(pi as unknown as PI)
+		bashToolGuardExtension(pi as unknown as PI, { blockOnThreshold: true })
 		fireSessionStart(pi)
 
 		emit(pi, "tool_call", {
@@ -305,7 +341,7 @@ describe("bashToolGuardExtension wiring", () => {
 
 	it("non-string command input is ignored", () => {
 		const pi = createMockPI()
-		bashToolGuardExtension(pi as unknown as PI)
+		bashToolGuardExtension(pi as unknown as PI, { blockOnThreshold: true })
 		fireSessionStart(pi)
 
 		const result = emit(pi, "tool_call", {
@@ -318,7 +354,7 @@ describe("bashToolGuardExtension wiring", () => {
 
 	it("empty command is ignored", () => {
 		const pi = createMockPI()
-		bashToolGuardExtension(pi as unknown as PI)
+		bashToolGuardExtension(pi as unknown as PI, { blockOnThreshold: true })
 		fireSessionStart(pi)
 
 		const result = emit(pi, "tool_call", {
@@ -331,7 +367,7 @@ describe("bashToolGuardExtension wiring", () => {
 
 	it("missing toolName is ignored", () => {
 		const pi = createMockPI()
-		bashToolGuardExtension(pi as unknown as PI)
+		bashToolGuardExtension(pi as unknown as PI, { blockOnThreshold: true })
 		fireSessionStart(pi)
 
 		const result = emit(pi, "tool_call", { input: { command: "cat foo.ts" } })
@@ -339,9 +375,9 @@ describe("bashToolGuardExtension wiring", () => {
 		expect(pi.sendMessage).not.toHaveBeenCalled()
 	})
 
-	it("user prompt mentioning the program bypasses the guard", () => {
+	it("user prompt mentioning the tool bypasses the guard", () => {
 		const pi = createMockPI()
-		bashToolGuardExtension(pi as unknown as PI)
+		bashToolGuardExtension(pi as unknown as PI, { blockOnThreshold: true })
 		fireSessionStart(pi)
 
 		// User explicitly asks: "please use sed to fix foo.ts"
@@ -364,9 +400,9 @@ describe("bashToolGuardExtension wiring", () => {
 		expect(pi.sendMessage).not.toHaveBeenCalled()
 	})
 
-	it("explicit-request override is per-program (cat allowed, sed still guarded)", () => {
+	it("explicit-request override is per-tool (cat allowed, sed still guarded)", () => {
 		const pi = createMockPI()
-		bashToolGuardExtension(pi as unknown as PI)
+		bashToolGuardExtension(pi as unknown as PI, { blockOnThreshold: true })
 		fireSessionStart(pi)
 
 		emit(pi, "input", { source: "interactive", text: "use cat to read foo.ts" })
@@ -389,7 +425,7 @@ describe("bashToolGuardExtension wiring", () => {
 
 	it("substring false-positive guard: 'categorize' does not bypass cat block", () => {
 		const pi = createMockPI()
-		bashToolGuardExtension(pi as unknown as PI)
+		bashToolGuardExtension(pi as unknown as PI, { blockOnThreshold: true })
 		fireSessionStart(pi)
 
 		// 'cat' inside 'categorize' — word-boundary match means this should NOT bypass.
@@ -405,7 +441,7 @@ describe("bashToolGuardExtension wiring", () => {
 
 	it("next user input overrides the previous prompt (no stale override)", () => {
 		const pi = createMockPI()
-		bashToolGuardExtension(pi as unknown as PI)
+		bashToolGuardExtension(pi as unknown as PI, { blockOnThreshold: true })
 		fireSessionStart(pi)
 
 		// First prompt explicitly asks for sed → allowed
@@ -431,7 +467,7 @@ describe("bashToolGuardExtension wiring", () => {
 describe("bashToolGuardExtension — compound commands", () => {
 	it("flags read in compound (cat foo && echo done)", () => {
 		const pi = createMockPI()
-		bashToolGuardExtension(pi as unknown as PI)
+		bashToolGuardExtension(pi as unknown as PI, { blockOnThreshold: true })
 		fireSessionStart(pi)
 
 		const result = emit(pi, "tool_call", {
@@ -453,7 +489,7 @@ describe("bashToolGuardExtension — compound commands", () => {
 
 	it("flags write in compound (git status; echo x > foo)", () => {
 		const pi = createMockPI()
-		bashToolGuardExtension(pi as unknown as PI)
+		bashToolGuardExtension(pi as unknown as PI, { blockOnThreshold: true })
 		fireSessionStart(pi)
 
 		const result = emit(pi, "tool_call", {
@@ -466,7 +502,7 @@ describe("bashToolGuardExtension — compound commands", () => {
 
 	it("blocks write in compound on second match", () => {
 		const pi = createMockPI()
-		bashToolGuardExtension(pi as unknown as PI)
+		bashToolGuardExtension(pi as unknown as PI, { blockOnThreshold: true })
 		fireSessionStart(pi)
 
 		emit(pi, "tool_call", {
@@ -483,7 +519,7 @@ describe("bashToolGuardExtension — compound commands", () => {
 
 	it("allows compound read when user explicitly asks", () => {
 		const pi = createMockPI()
-		bashToolGuardExtension(pi as unknown as PI)
+		bashToolGuardExtension(pi as unknown as PI, { blockOnThreshold: true })
 		fireSessionStart(pi)
 
 		emit(pi, "input", { source: "interactive", text: "cat foo.ts and bar.ts" })
@@ -497,7 +533,7 @@ describe("bashToolGuardExtension — compound commands", () => {
 
 	it("flags pipe where first segment is a read", () => {
 		const pi = createMockPI()
-		bashToolGuardExtension(pi as unknown as PI)
+		bashToolGuardExtension(pi as unknown as PI, { blockOnThreshold: true })
 		fireSessionStart(pi)
 
 		const result = emit(pi, "tool_call", {
@@ -512,7 +548,7 @@ describe("bashToolGuardExtension — compound commands", () => {
 describe("bashToolGuardExtension — semantic intent override", () => {
 	it("'read the file' intent allows cat through the full extension", () => {
 		const pi = createMockPI()
-		bashToolGuardExtension(pi as unknown as PI)
+		bashToolGuardExtension(pi as unknown as PI, { blockOnThreshold: true })
 		fireSessionStart(pi)
 
 		emit(pi, "input", { source: "interactive", text: "read the file foo.ts and summarize" })
@@ -526,7 +562,7 @@ describe("bashToolGuardExtension — semantic intent override", () => {
 
 	it("'fix the typo' intent allows sed through the full extension", () => {
 		const pi = createMockPI()
-		bashToolGuardExtension(pi as unknown as PI)
+		bashToolGuardExtension(pi as unknown as PI, { blockOnThreshold: true })
 		fireSessionStart(pi)
 
 		emit(pi, "input", { source: "interactive", text: "fix the typo in foo.ts" })
@@ -540,7 +576,7 @@ describe("bashToolGuardExtension — semantic intent override", () => {
 
 	it("'write to file' intent allows echo redirect through the full extension", () => {
 		const pi = createMockPI()
-		bashToolGuardExtension(pi as unknown as PI)
+		bashToolGuardExtension(pi as unknown as PI, { blockOnThreshold: true })
 		fireSessionStart(pi)
 
 		emit(pi, "input", { source: "interactive", text: "write the result to output.txt" })
@@ -554,7 +590,7 @@ describe("bashToolGuardExtension — semantic intent override", () => {
 
 	it("semantic intent for one category does NOT bypass other categories", () => {
 		const pi = createMockPI()
-		bashToolGuardExtension(pi as unknown as PI)
+		bashToolGuardExtension(pi as unknown as PI, { blockOnThreshold: true })
 		fireSessionStart(pi)
 
 		// 'read the file' → read semantic intent active
@@ -579,7 +615,7 @@ describe("bashToolGuardExtension — semantic intent override", () => {
 describe("bashToolGuardExtension — telemetry events via pi.events", () => {
 	it("emits warn event when first category match fires", () => {
 		const pi = createMockPI()
-		bashToolGuardExtension(pi as unknown as PI)
+		bashToolGuardExtension(pi as unknown as PI, { blockOnThreshold: true })
 		fireSessionStart(pi)
 
 		emit(pi, "tool_call", {
@@ -591,7 +627,7 @@ describe("bashToolGuardExtension — telemetry events via pi.events", () => {
 			BASH_TOOL_GUARD_EVENTS.WARN,
 			expect.objectContaining({
 				category: "read",
-				matchedSegment: "cat foo.ts",
+				tool: "cat",
 				count: 1,
 			}),
 		)
@@ -599,7 +635,7 @@ describe("bashToolGuardExtension — telemetry events via pi.events", () => {
 
 	it("emits block event when threshold exceeded", () => {
 		const pi = createMockPI()
-		bashToolGuardExtension(pi as unknown as PI)
+		bashToolGuardExtension(pi as unknown as PI, { blockOnThreshold: true })
 		fireSessionStart(pi)
 
 		emit(pi, "tool_call", {
@@ -622,7 +658,7 @@ describe("bashToolGuardExtension — telemetry events via pi.events", () => {
 
 	it("emits allow-by-user-request event when explicit override fires", () => {
 		const pi = createMockPI()
-		bashToolGuardExtension(pi as unknown as PI)
+		bashToolGuardExtension(pi as unknown as PI, { blockOnThreshold: true })
 		fireSessionStart(pi)
 
 		emit(pi, "input", { source: "interactive", text: "please use sed to fix foo.ts" })
@@ -635,14 +671,14 @@ describe("bashToolGuardExtension — telemetry events via pi.events", () => {
 			BASH_TOOL_GUARD_EVENTS.ALLOWED_BY_USER_REQUEST,
 			expect.objectContaining({
 				category: "edit",
-				program: "sed",
+				tool: "sed",
 			}),
 		)
 	})
 
 	it("emits semantic intent allow-by-user-request event", () => {
 		const pi = createMockPI()
-		bashToolGuardExtension(pi as unknown as PI)
+		bashToolGuardExtension(pi as unknown as PI, { blockOnThreshold: true })
 		fireSessionStart(pi)
 
 		emit(pi, "input", { source: "interactive", text: "read the file foo.ts" })
@@ -655,14 +691,14 @@ describe("bashToolGuardExtension — telemetry events via pi.events", () => {
 			BASH_TOOL_GUARD_EVENTS.ALLOWED_BY_USER_REQUEST,
 			expect.objectContaining({
 				category: "read",
-				program: "cat",
+				tool: "cat",
 			}),
 		)
 	})
 
 	it("does NOT emit events for non-matching bash", () => {
 		const pi = createMockPI()
-		bashToolGuardExtension(pi as unknown as PI)
+		bashToolGuardExtension(pi as unknown as PI, { blockOnThreshold: true })
 		fireSessionStart(pi)
 
 		emit(pi, "tool_call", {
@@ -676,7 +712,7 @@ describe("bashToolGuardExtension — telemetry events via pi.events", () => {
 	it("does NOT emit events when guard is disabled (plan mode)", () => {
 		mockMode = "plan"
 		const pi = createMockPI()
-		bashToolGuardExtension(pi as unknown as PI)
+		bashToolGuardExtension(pi as unknown as PI, { blockOnThreshold: true })
 		fireSessionStart(pi)
 
 		emit(pi, "tool_call", {
@@ -697,6 +733,7 @@ describe("bashToolGuardExtension — per-category thresholds", () => {
 		const pi = createMockPI()
 		bashToolGuardExtension(pi as unknown as PI, {
 			warnThresholds: { read: 3, edit: 0, write: 1 },
+			blockOnThreshold: true,
 		})
 		fireSessionStart(pi)
 

--- a/src/extensions/bash-tool-guard.test.ts
+++ b/src/extensions/bash-tool-guard.test.ts
@@ -1,0 +1,655 @@
+import { describe, expect, it } from "vitest"
+import {
+	type BashCategory,
+	type BashGuardBlockResult,
+	type BashGuardWarnResult,
+	BashToolGuard,
+	classifyBashCommand,
+} from "./bash-tool-guard.js"
+
+describe("classifyBashCommand — read patterns", () => {
+	it("flags `cat <file>`", () => {
+		expect(classifyBashCommand("cat src/foo.ts")).toMatchObject({
+			category: "read",
+			matchedSegment: "cat src/foo.ts",
+			program: "cat",
+		})
+	})
+
+	it("flags `cat <file1> <file2>` (multiple files)", () => {
+		expect(classifyBashCommand("cat a.ts b.ts")?.category).toBe("read")
+	})
+
+	it("flags `head -n 5 <file>`", () => {
+		expect(classifyBashCommand("head -n 5 src/foo.ts")?.category).toBe("read")
+	})
+
+	it("flags `tail <file>`", () => {
+		expect(classifyBashCommand("tail src/foo.ts")?.category).toBe("read")
+	})
+
+	it("flags `bat README.md`", () => {
+		expect(classifyBashCommand("bat README.md")?.category).toBe("read")
+	})
+
+	it("flags `less <file>`", () => {
+		expect(classifyBashCommand("less src/foo.ts")?.category).toBe("read")
+	})
+
+	it("flags `sed -n '1,5p' <file>` (read-only sed)", () => {
+		expect(classifyBashCommand("sed -n '1,5p' src/foo.ts")?.category).toBe("read")
+	})
+
+	it("flags `sed -n /pattern/p file`", () => {
+		expect(classifyBashCommand("sed -n /pattern/p src/foo.ts")?.category).toBe("read")
+	})
+
+	it("flags `rtk cat foo.ts` (strips RTK wrapper)", () => {
+		expect(classifyBashCommand("rtk cat foo.ts")?.category).toBe("read")
+	})
+
+	it("does not flag `cat` (no args, stdin)", () => {
+		expect(classifyBashCommand("cat")).toBeNull()
+	})
+
+	it("does not flag `head` (no args)", () => {
+		expect(classifyBashCommand("head")).toBeNull()
+	})
+
+	it("does not flag bare `sed` (no -n, no read intent)", () => {
+		expect(classifyBashCommand("sed 's/foo/bar/' src/foo.ts")).toBeNull()
+	})
+
+	it("suggestion for read mentions the read tool", () => {
+		expect(classifyBashCommand("cat src/foo.ts")?.suggestion).toMatch(/read tool/)
+	})
+
+	it("exposes the program name (for telemetry)", () => {
+		expect(classifyBashCommand("sed -n '1,5p' foo.ts")?.program).toBe("sed")
+		expect(classifyBashCommand("rtk cat foo.ts")?.program).toBe("cat")
+	})
+})
+
+describe("classifyBashCommand — edit patterns", () => {
+	it("flags `sed -i 's/foo/bar/g' file`", () => {
+		expect(classifyBashCommand("sed -i 's/foo/bar/g' src/foo.ts")?.category).toBe("edit")
+	})
+
+	it("flags `sed -i.bak '...' file` (suffix arg)", () => {
+		expect(classifyBashCommand("sed -i.bak 's/foo/bar/g' src/foo.ts")?.category).toBe("edit")
+	})
+
+	it("flags `perl -i -pe 's/foo/bar/' file`", () => {
+		expect(classifyBashCommand("perl -i -pe 's/foo/bar/' src/foo.ts")?.category).toBe("edit")
+	})
+
+	it("flags `perl -i.bak -pe 's/foo/bar/' file`", () => {
+		expect(classifyBashCommand("perl -i.bak -pe 's/foo/bar/' src/foo.ts")?.category).toBe("edit")
+	})
+
+	it("flags `awk -i inplace '{print $1}' file`", () => {
+		expect(classifyBashCommand("awk -i inplace '{print $1}' src/foo.ts")?.category).toBe("edit")
+	})
+
+	it("edit wins over read when both flags present (sed -n -i)", () => {
+		// Order matters: edit category is checked first, so -i dominates.
+		expect(classifyBashCommand("sed -n -i 's/foo/bar/' src/foo.ts")?.category).toBe("edit")
+	})
+
+	it("suggestion for edit mentions the edit tool", () => {
+		expect(classifyBashCommand("sed -i 's/foo/bar/' src/foo.ts")?.suggestion).toMatch(/edit tool/)
+	})
+})
+
+describe("classifyBashCommand — write patterns", () => {
+	it("flags `echo '...' > file`", () => {
+		expect(classifyBashCommand("echo 'hello' > src/foo.ts")?.category).toBe("write")
+	})
+
+	it("flags `printf ... >> file`", () => {
+		expect(classifyBashCommand('printf "%s\\n" "hi" >> src/foo.ts')?.category).toBe("write")
+	})
+
+	it("flags `tee file` (writes stdin to file)", () => {
+		expect(classifyBashCommand("tee src/foo.ts")?.category).toBe("write")
+	})
+
+	it("flags heredoc redirect: `cat <<EOF > file`", () => {
+		expect(classifyBashCommand("cat <<EOF > src/foo.ts\nhi\nEOF")?.category).toBe("write")
+	})
+
+	it("does not flag `echo '...' > /dev/null` (stream target)", () => {
+		expect(classifyBashCommand("echo 'progress' > /dev/null")).toBeNull()
+	})
+
+	it("does not flag `echo 'build done'` (no redirect)", () => {
+		expect(classifyBashCommand("echo 'build done'")).toBeNull()
+	})
+
+	it("does not flag `echo 'log' > /dev/stderr`", () => {
+		expect(classifyBashCommand("echo 'log' > /dev/stderr")).toBeNull()
+	})
+
+	it("write wins over read when both present (`echo x > cat-target`)", () => {
+		// Order matters: write (redirects) is checked before read.
+		expect(classifyBashCommand("echo 'hi' > src/foo.ts")?.category).toBe("write")
+	})
+
+	it("suggestion for write mentions edit/write tools", () => {
+		const suggestion = classifyBashCommand("echo 'hi' > src/foo.ts")?.suggestion ?? ""
+		expect(suggestion).toMatch(/edit tool/)
+		expect(suggestion).toMatch(/write tool/)
+	})
+})
+
+describe("classifyBashCommand — negative (allowed bash)", () => {
+	it.each([
+		["git status", null],
+		["git log --oneline -20", null],
+		["git diff HEAD~1", null],
+		["pnpm test", null],
+		["pnpm run build", null],
+		["node script.js", null],
+		["ls -la src/", null],
+		["ls src/", null],
+		["grep -r 'TODO' src/", null], // grep intentionally not guarded
+		["rg 'foo' src/", null],
+		["find . -name '*.ts' -type f", null],
+		["du -sh node_modules", null],
+		["df -h", null],
+		["ps aux", null],
+		["cd src && pnpm test", null], // legit compound
+		["git status && git log", null], // legit compound
+		["mkdir -p dist", null],
+		["mv old new", null], // mv not yet guarded (could be a future enhancement)
+	])("does not flag %s", (cmd, expected) => {
+		expect(classifyBashCommand(cmd)).toBe(expected)
+	})
+})
+
+describe("classifyBashCommand — compound commands", () => {
+	it("flags first segment when it's a read", () => {
+		expect(classifyBashCommand("cat foo.ts && echo done")?.category).toBe("read")
+	})
+
+	it("flags when later segment is a write even if first is legit", () => {
+		expect(classifyBashCommand("git status; echo 'x' > foo.ts")?.category).toBe("write")
+	})
+
+	it("flags when any segment is a write", () => {
+		expect(classifyBashCommand("git pull && echo 'done' > progress.txt")?.category).toBe("write")
+	})
+
+	it("flags the first offending segment in order (edit wins over later write)", () => {
+		// Implementation checks write → edit → read in order; the edit
+		// segment comes first, so it's flagged as edit.
+		expect(classifyBashCommand("sed -i 's/a/b/' foo.ts; echo 'done' > progress.txt")?.category).toBe("edit")
+	})
+
+	it("flags pipe where first segment is a read", () => {
+		expect(classifyBashCommand("cat foo.ts | head -n 5")?.category).toBe("read")
+	})
+})
+
+describe("BashToolGuard", () => {
+	it("returns allow for non-matching commands", () => {
+		const guard = new BashToolGuard()
+		expect(guard.recordCommand("git status")).toEqual({ decision: "allow" })
+		expect(guard.recordCommand("pnpm test")).toEqual({ decision: "allow" })
+	})
+
+	it("returns warn on first match per category", () => {
+		const guard = new BashToolGuard()
+		const result = guard.recordCommand("cat foo.ts") as BashGuardWarnResult
+		expect(result.decision).toBe("warn")
+		expect(result.category).toBe("read")
+		expect(result.suggestion).toMatch(/read tool/)
+		expect(result.count).toBe(1)
+	})
+
+	it("returns block on second match of same category", () => {
+		const guard = new BashToolGuard()
+		guard.recordCommand("cat foo.ts")
+		const result = guard.recordCommand("head -n 5 bar.ts") as BashGuardBlockResult
+		expect(result.decision).toBe("block")
+		expect(result.category).toBe("read")
+		expect(result.count).toBe(2)
+	})
+
+	it("uses per-category counters (cat doesn't burn sed budget)", () => {
+		const guard = new BashToolGuard()
+		expect(guard.recordCommand("cat foo.ts").decision).toBe("warn")
+		// Different category, fresh budget → warn again, not block.
+		expect(guard.recordCommand("sed -i 's/foo/bar/' foo.ts").decision).toBe("warn")
+		expect(guard.recordCommand("echo 'x' > bar.ts").decision).toBe("warn")
+		// Now each category has had its warn, second occurrence blocks.
+		expect(guard.recordCommand("cat baz.ts").decision).toBe("block")
+		expect(guard.recordCommand("sed -i 's/a/b/' baz.ts").decision).toBe("block")
+		expect(guard.recordCommand("echo 'y' > qux.ts").decision).toBe("block")
+	})
+
+	it("respects custom warnThreshold (global)", () => {
+		const guard = new BashToolGuard({ warnThreshold: 2 })
+		expect(guard.recordCommand("cat a.ts").decision).toBe("warn")
+		expect(guard.recordCommand("cat b.ts").decision).toBe("warn")
+		expect(guard.recordCommand("cat c.ts").decision).toBe("block")
+	})
+
+	it("respects per-category warnThresholds", () => {
+		const guard = new BashToolGuard({ warnThresholds: { read: 3, edit: 0, write: 1 } })
+		// read budget = 3 warns before block
+		expect(guard.recordCommand("cat a.ts").decision).toBe("warn")
+		expect(guard.recordCommand("cat b.ts").decision).toBe("warn")
+		expect(guard.recordCommand("cat c.ts").decision).toBe("warn")
+		expect(guard.recordCommand("cat d.ts").decision).toBe("block")
+		// edit budget = 0 warns → first occurrence blocks
+		expect(guard.recordCommand("sed -i 's/a/b/' e.ts").decision).toBe("block")
+		// write budget = 1 warn (default) → first warns, second blocks
+		expect(guard.recordCommand("echo 'x' > f.ts").decision).toBe("warn")
+		expect(guard.recordCommand("echo 'y' > g.ts").decision).toBe("block")
+	})
+
+	it("per-category overrides fallback to global warnThreshold when partial", () => {
+		const guard = new BashToolGuard({ warnThreshold: 1, warnThresholds: { edit: 3 } })
+		// read falls back to global (1)
+		expect(guard.recordCommand("cat a.ts").decision).toBe("warn")
+		expect(guard.recordCommand("cat b.ts").decision).toBe("block")
+		// write falls back to global (1)
+		expect(guard.recordCommand("echo 'x' > a.ts").decision).toBe("warn")
+		// edit uses override (3)
+		expect(guard.recordCommand("sed -i 's/a/b/' a.ts").decision).toBe("warn")
+		expect(guard.recordCommand("sed -i 's/c/d/' a.ts").decision).toBe("warn")
+		expect(guard.recordCommand("sed -i 's/e/f/' a.ts").decision).toBe("warn")
+		expect(guard.recordCommand("sed -i 's/g/h/' a.ts").decision).toBe("block")
+	})
+
+	it("reset() clears all counters", () => {
+		const guard = new BashToolGuard()
+		guard.recordCommand("cat a.ts")
+		guard.recordCommand("cat b.ts") // would have been block
+		guard.reset()
+		expect(guard.getCount("read")).toBe(0)
+		expect(guard.recordCommand("cat c.ts").decision).toBe("warn")
+	})
+
+	it("isEnabled=false short-circuits to allow", () => {
+		const guard = new BashToolGuard({ isEnabled: () => false })
+		expect(guard.recordCommand("cat foo.ts")).toEqual({ decision: "allow" })
+		expect(guard.recordCommand("cat foo.ts")).toEqual({ decision: "allow" })
+		expect(guard.recordCommand("sed -i 's/foo/bar/' foo.ts")).toEqual({ decision: "allow" })
+	})
+
+	it("formatWarnText fills placeholders", () => {
+		const guard = new BashToolGuard()
+		const result = guard.recordCommand("cat foo.ts") as BashGuardWarnResult
+		const text = guard.formatWarnText(result)
+		expect(text).toContain("cat foo.ts")
+		expect(text).toContain("read")
+		expect(text).toMatch(/read tool/)
+	})
+
+	it("formatBlockReason fills placeholders", () => {
+		const guard = new BashToolGuard()
+		guard.recordCommand("cat a.ts")
+		const result = guard.recordCommand("cat b.ts") as BashGuardBlockResult
+		const text = guard.formatBlockReason(result)
+		expect(text).toContain("read")
+		expect(text).toMatch(/read tool/)
+		expect(text).toMatch(/blocked/i)
+	})
+
+	it("getCount returns 0 for unseen category", () => {
+		const guard = new BashToolGuard()
+		expect(guard.getCount("read")).toBe(0)
+		expect(guard.getCount("edit")).toBe(0)
+		expect(guard.getCount("write")).toBe(0)
+	})
+
+	it("getCount returns accumulated count after matches", () => {
+		const guard = new BashToolGuard()
+		guard.recordCommand("cat a.ts")
+		guard.recordCommand("cat b.ts")
+		expect(guard.getCount("read")).toBe(2)
+		expect(guard.getCount("edit")).toBe(0)
+	})
+
+	it("getWarnThreshold returns per-category threshold", () => {
+		const guard = new BashToolGuard({ warnThresholds: { read: 2, edit: 0, write: 3 } })
+		expect(guard.getWarnThreshold("read")).toBe(2)
+		expect(guard.getWarnThreshold("edit")).toBe(0)
+		expect(guard.getWarnThreshold("write")).toBe(3)
+	})
+
+	it.each<BashCategory>(["read", "edit", "write"])("tracks %s category independently", (category) => {
+		const guard = new BashToolGuard()
+		const triggerByCategory: Record<BashCategory, string> = {
+			read: "cat foo.ts",
+			edit: "sed -i 's/a/b/' foo.ts",
+			write: "echo 'x' > foo.ts",
+		}
+		const result = guard.recordCommand(triggerByCategory[category]) as BashGuardWarnResult
+		expect(result.category).toBe(category)
+		expect(guard.getCount(category)).toBe(1)
+	})
+
+	it("returns user-request allow reason when explicitly requested", () => {
+		const guard = new BashToolGuard()
+		guard.setLastUserPrompt("please use sed to fix foo.ts")
+		const result = guard.recordCommand("sed -i 's/typo/fix/' foo.ts")
+		expect(result).toEqual({ decision: "allow", reason: "user-request" })
+	})
+
+	it("returns plain allow (no reason) when no user request and no match", () => {
+		const guard = new BashToolGuard()
+		expect(guard.recordCommand("git status")).toEqual({ decision: "allow" })
+	})
+})
+
+describe("BashToolGuard — explicit user request override (program name)", () => {
+	it("allows when user prompt mentions the matched program", () => {
+		const guard = new BashToolGuard()
+		guard.setLastUserPrompt("please use sed to fix the typo in foo.ts")
+		expect(guard.recordCommand("sed -i 's/typo/fix/' foo.ts")).toEqual({
+			decision: "allow",
+			reason: "user-request",
+		})
+	})
+
+	it("allows 'cat this file'", () => {
+		const guard = new BashToolGuard()
+		guard.setLastUserPrompt("cat src/foo.ts and tell me what it does")
+		expect(guard.recordCommand("cat src/foo.ts")).toEqual({ decision: "allow", reason: "user-request" })
+	})
+
+	it("allows 'use echo to write'", () => {
+		const guard = new BashToolGuard()
+		guard.setLastUserPrompt("use echo to create a marker file")
+		expect(guard.recordCommand("echo 'done' > marker.txt")).toEqual({
+			decision: "allow",
+			reason: "user-request",
+		})
+	})
+
+	it("allows across repeated matches when explicitly requested", () => {
+		const guard = new BashToolGuard()
+		guard.setLastUserPrompt("cat foo.ts")
+		expect(guard.recordCommand("cat foo.ts")).toEqual({ decision: "allow", reason: "user-request" })
+		expect(guard.recordCommand("cat foo.ts")).toEqual({ decision: "allow", reason: "user-request" })
+		expect(guard.recordCommand("cat foo.ts")).toEqual({ decision: "allow", reason: "user-request" })
+	})
+
+	it("blocks when user prompt does NOT mention the program AND has no semantic intent", () => {
+		const guard = new BashToolGuard()
+		// 'fix the typo in foo.ts' would match the edit semantic intent
+		// pattern, so use a prompt that mentions neither program nor intent.
+		guard.setLastUserPrompt("please change foo.ts")
+		expect(guard.recordCommand("sed -i 's/typo/fix/' foo.ts").decision).toBe("warn")
+		expect(guard.recordCommand("sed -i 's/x/y/' foo.ts").decision).toBe("block")
+	})
+
+	it("uses word-boundary matching (no false positives on substrings)", () => {
+		const guard = new BashToolGuard()
+		// 'cat' inside 'categorize' should NOT trigger the override.
+		guard.setLastUserPrompt("categorize the files")
+		expect(guard.recordCommand("cat foo.ts").decision).toBe("warn")
+	})
+
+	it("uses word-boundary matching (no false positives on similar words)", () => {
+		const guard = new BashToolGuard()
+		// 'sed' inside 'used' should NOT trigger the override.
+		guard.setLastUserPrompt("the tool used for editing")
+		expect(guard.recordCommand("sed -i 's/a/b/' foo.ts").decision).toBe("warn")
+	})
+
+	it("reset() clears the last prompt", () => {
+		const guard = new BashToolGuard()
+		guard.setLastUserPrompt("cat foo.ts")
+		expect(guard.recordCommand("cat foo.ts")).toEqual({ decision: "allow", reason: "user-request" })
+		guard.reset()
+		expect(guard.recordCommand("cat foo.ts").decision).toBe("warn")
+	})
+
+	it("explicit request overrides per-category but other categories still guard", () => {
+		const guard = new BashToolGuard()
+		guard.setLastUserPrompt("use sed to fix foo.ts")
+		// sed is explicitly requested → allow
+		expect(guard.recordCommand("sed -i 's/a/b/' foo.ts")).toEqual({
+			decision: "allow",
+			reason: "user-request",
+		})
+		// cat is not mentioned → still guarded
+		expect(guard.recordCommand("cat foo.ts").decision).toBe("warn")
+		expect(guard.recordCommand("cat foo.ts").decision).toBe("block")
+	})
+
+	it("isExplicitlyRequested returns false when no prompt set", () => {
+		const guard = new BashToolGuard()
+		expect(guard.isExplicitlyRequested("cat foo.ts", "read")).toBe(false)
+	})
+
+	it("isExplicitlyRequested returns false for empty matchedSegment", () => {
+		const guard = new BashToolGuard()
+		guard.setLastUserPrompt("cat the file")
+		expect(guard.isExplicitlyRequested("", "read")).toBe(false)
+	})
+
+	it("case-insensitive matching", () => {
+		const guard = new BashToolGuard()
+		guard.setLastUserPrompt("Use CAT to read the file")
+		expect(guard.recordCommand("cat foo.ts")).toEqual({ decision: "allow", reason: "user-request" })
+	})
+
+	it("matches programs wrapped in RTK (matchedSegment is the unwrapped form)", () => {
+		const guard = new BashToolGuard()
+		guard.setLastUserPrompt("use cat to read foo.ts")
+		// matchedSegment is "cat foo.ts" after stripRtk
+		expect(guard.recordCommand("rtk cat foo.ts")).toEqual({ decision: "allow", reason: "user-request" })
+	})
+
+	it("isExplicitlyRequested takes category argument (semantic intent uses it)", () => {
+		const guard = new BashToolGuard()
+		guard.setLastUserPrompt("please read the file foo.ts")
+		// Program 'cat' is not mentioned, but the 'read the file' semantic
+		// pattern matches → still allowed.
+		expect(guard.isExplicitlyRequested("cat foo.ts", "read")).toBe(true)
+		// Same prompt but 'edit' category: semantic patterns differ.
+		expect(guard.isExplicitlyRequested("sed -i 's/a/b/' foo.ts", "edit")).toBe(false)
+	})
+
+	it("getLastUserPrompt returns the lowercased prompt", () => {
+		const guard = new BashToolGuard()
+		guard.setLastUserPrompt("Read The FILE foo.ts")
+		expect(guard.getLastUserPrompt()).toBe("read the file foo.ts")
+	})
+})
+
+describe("BashToolGuard — semantic intent override (no program name)", () => {
+	// These tests verify the guard detects intent phrases like "read the file"
+	// even when the user doesn't name the program explicitly.
+
+	describe("read intent", () => {
+		it("'read the file foo.ts' allows cat", () => {
+			const guard = new BashToolGuard()
+			guard.setLastUserPrompt("read the file foo.ts")
+			expect(guard.recordCommand("cat foo.ts")).toEqual({ decision: "allow", reason: "user-request" })
+		})
+
+		it("'show me foo.ts' allows cat", () => {
+			const guard = new BashToolGuard()
+			guard.setLastUserPrompt("show me what's in foo.ts")
+			expect(guard.recordCommand("cat foo.ts")).toEqual({ decision: "allow", reason: "user-request" })
+		})
+
+		it("'print the contents of foo.ts' allows cat", () => {
+			const guard = new BashToolGuard()
+			guard.setLastUserPrompt("print the contents of foo.ts")
+			expect(guard.recordCommand("cat foo.ts")).toEqual({ decision: "allow", reason: "user-request" })
+		})
+
+		it("'view the source' allows less", () => {
+			const guard = new BashToolGuard()
+			guard.setLastUserPrompt("view the source for me")
+			expect(guard.recordCommand("less foo.ts")).toEqual({ decision: "allow", reason: "user-request" })
+		})
+
+		it("'open foo.ts' allows cat (intent to inspect)", () => {
+			const guard = new BashToolGuard()
+			guard.setLastUserPrompt("open foo.ts")
+			expect(guard.recordCommand("cat foo.ts")).toEqual({ decision: "allow", reason: "user-request" })
+		})
+
+		it("does NOT trigger edit semantic patterns for read", () => {
+			const guard = new BashToolGuard()
+			guard.setLastUserPrompt("read the file foo.ts")
+			// Same prompt — edit semantic patterns must NOT match
+			expect(guard.isExplicitlyRequested("sed -i 's/a/b/' foo.ts", "edit")).toBe(false)
+		})
+	})
+
+	describe("edit intent", () => {
+		it("'fix the typo in foo.ts' allows sed", () => {
+			const guard = new BashToolGuard()
+			guard.setLastUserPrompt("fix the typo in foo.ts")
+			expect(guard.recordCommand("sed -i 's/typo/fix/' foo.ts")).toEqual({
+				decision: "allow",
+				reason: "user-request",
+			})
+		})
+
+		it("'replace foo with bar in file.ts' allows sed", () => {
+			const guard = new BashToolGuard()
+			guard.setLastUserPrompt("replace foo with bar in file.ts")
+			expect(guard.recordCommand("sed -i 's/foo/bar/' file.ts")).toEqual({
+				decision: "allow",
+				reason: "user-request",
+			})
+		})
+
+		it("'modify foo.ts' allows perl", () => {
+			const guard = new BashToolGuard()
+			guard.setLastUserPrompt("modify foo.ts to add the export")
+			expect(guard.recordCommand("perl -i -pe 's/a/b/' foo.ts")).toEqual({
+				decision: "allow",
+				reason: "user-request",
+			})
+		})
+
+		it("'update the file with the new value' allows sed", () => {
+			const guard = new BashToolGuard()
+			guard.setLastUserPrompt("update the file with the new value")
+			expect(guard.recordCommand("sed -i 's/old/new/' file.ts")).toEqual({
+				decision: "allow",
+				reason: "user-request",
+			})
+		})
+
+		it("'use sed to fix this' allows sed", () => {
+			const guard = new BashToolGuard()
+			guard.setLastUserPrompt("use sed to fix this")
+			expect(guard.recordCommand("sed -i 's/a/b/' file.ts")).toEqual({
+				decision: "allow",
+				reason: "user-request",
+			})
+		})
+
+		it("'edit foo.ts' allows sed", () => {
+			const guard = new BashToolGuard()
+			guard.setLastUserPrompt("edit foo.ts")
+			expect(guard.recordCommand("sed -i 's/a/b/' foo.ts")).toEqual({
+				decision: "allow",
+				reason: "user-request",
+			})
+		})
+
+		it("does NOT trigger write semantic patterns for edit", () => {
+			const guard = new BashToolGuard()
+			guard.setLastUserPrompt("fix the typo in foo.ts")
+			expect(guard.isExplicitlyRequested("echo 'x' > foo.ts", "write")).toBe(false)
+		})
+	})
+
+	describe("write intent", () => {
+		it("'write to foo.ts' allows echo redirect", () => {
+			const guard = new BashToolGuard()
+			guard.setLastUserPrompt("write the result to foo.ts")
+			expect(guard.recordCommand("echo 'done' > foo.ts")).toEqual({
+				decision: "allow",
+				reason: "user-request",
+			})
+		})
+
+		it("'create a foo.ts file' allows echo redirect", () => {
+			const guard = new BashToolGuard()
+			guard.setLastUserPrompt("create a foo.ts file")
+			expect(guard.recordCommand("echo 'content' > foo.ts")).toEqual({
+				decision: "allow",
+				reason: "user-request",
+			})
+		})
+
+		it("'save the output to log.txt' allows tee", () => {
+			const guard = new BashToolGuard()
+			guard.setLastUserPrompt("save the output to log.txt")
+			expect(guard.recordCommand("tee log.txt")).toEqual({ decision: "allow", reason: "user-request" })
+		})
+
+		it("'put the result in output.txt' allows echo redirect", () => {
+			const guard = new BashToolGuard()
+			guard.setLastUserPrompt("put the result in output.txt")
+			expect(guard.recordCommand("echo 'done' > output.txt")).toEqual({
+				decision: "allow",
+				reason: "user-request",
+			})
+		})
+
+		it("'echo ... to file' allows echo redirect", () => {
+			const guard = new BashToolGuard()
+			guard.setLastUserPrompt("echo the line to the file")
+			expect(guard.recordCommand("echo 'done' > foo.ts")).toEqual({
+				decision: "allow",
+				reason: "user-request",
+			})
+		})
+
+		it("'redirect to file.txt' allows echo redirect", () => {
+			const guard = new BashToolGuard()
+			guard.setLastUserPrompt("redirect the output to file.txt")
+			expect(guard.recordCommand("echo 'done' > file.txt")).toEqual({
+				decision: "allow",
+				reason: "user-request",
+			})
+		})
+
+		it("does NOT trigger read semantic patterns for write", () => {
+			const guard = new BashToolGuard()
+			guard.setLastUserPrompt("write to foo.ts")
+			expect(guard.isExplicitlyRequested("cat foo.ts", "read")).toBe(false)
+		})
+	})
+
+	describe("semantic intent negative cases", () => {
+		it("'look at the build output' does not allow cat", () => {
+			const guard = new BashToolGuard()
+			guard.setLastUserPrompt("look at the build output")
+			expect(guard.recordCommand("cat foo.ts").decision).toBe("warn")
+		})
+
+		it("'just readme' does not allow cat (no file context)", () => {
+			const guard = new BashToolGuard()
+			guard.setLastUserPrompt("just readme")
+			expect(guard.recordCommand("cat foo.ts").decision).toBe("warn")
+		})
+
+		it("'please be careful' does not allow sed", () => {
+			const guard = new BashToolGuard()
+			guard.setLastUserPrompt("please be careful")
+			expect(guard.recordCommand("sed -i 's/a/b/' foo.ts").decision).toBe("warn")
+		})
+
+		it("'no changes needed' does not allow echo", () => {
+			const guard = new BashToolGuard()
+			guard.setLastUserPrompt("no changes needed")
+			expect(guard.recordCommand("echo 'x' > foo.ts").decision).toBe("warn")
+		})
+	})
+})

--- a/src/extensions/bash-tool-guard.test.ts
+++ b/src/extensions/bash-tool-guard.test.ts
@@ -12,7 +12,7 @@ describe("classifyBashCommand — read patterns", () => {
 		expect(classifyBashCommand("cat src/foo.ts")).toMatchObject({
 			category: "read",
 			matchedSegment: "cat src/foo.ts",
-			program: "cat",
+			tool: "cat",
 		})
 	})
 
@@ -64,9 +64,9 @@ describe("classifyBashCommand — read patterns", () => {
 		expect(classifyBashCommand("cat src/foo.ts")?.suggestion).toMatch(/read tool/)
 	})
 
-	it("exposes the program name (for telemetry)", () => {
-		expect(classifyBashCommand("sed -n '1,5p' foo.ts")?.program).toBe("sed")
-		expect(classifyBashCommand("rtk cat foo.ts")?.program).toBe("cat")
+	it("exposes the tool name (for telemetry)", () => {
+		expect(classifyBashCommand("sed -n '1,5p' foo.ts")?.tool).toBe("sed")
+		expect(classifyBashCommand("rtk cat foo.ts")?.tool).toBe("cat")
 	})
 })
 
@@ -207,8 +207,8 @@ describe("BashToolGuard", () => {
 		expect(result.count).toBe(1)
 	})
 
-	it("returns block on second match of same category", () => {
-		const guard = new BashToolGuard()
+	it("returns block on second match of same category (when blockOnThreshold=true)", () => {
+		const guard = new BashToolGuard({ blockOnThreshold: true })
 		guard.recordCommand("cat foo.ts")
 		const result = guard.recordCommand("head -n 5 bar.ts") as BashGuardBlockResult
 		expect(result.decision).toBe("block")
@@ -216,8 +216,18 @@ describe("BashToolGuard", () => {
 		expect(result.count).toBe(2)
 	})
 
-	it("uses per-category counters (cat doesn't burn sed budget)", () => {
+	it("keeps steering after threshold when blockOnThreshold is false (default)", () => {
+		// Default behaviour: warn-only. The guard never refuses a bash call
+		// unless the caller explicitly opts in via blockOnThreshold: true.
 		const guard = new BashToolGuard()
+		expect(guard.recordCommand("cat foo.ts").decision).toBe("warn")
+		expect(guard.recordCommand("cat bar.ts").decision).toBe("warn")
+		expect(guard.recordCommand("cat baz.ts").decision).toBe("warn")
+		expect(guard.recordCommand("cat qux.ts").decision).toBe("warn")
+	})
+
+	it("uses per-category counters (cat doesn't burn sed budget)", () => {
+		const guard = new BashToolGuard({ blockOnThreshold: true })
 		expect(guard.recordCommand("cat foo.ts").decision).toBe("warn")
 		// Different category, fresh budget → warn again, not block.
 		expect(guard.recordCommand("sed -i 's/foo/bar/' foo.ts").decision).toBe("warn")
@@ -229,14 +239,17 @@ describe("BashToolGuard", () => {
 	})
 
 	it("respects custom warnThreshold (global)", () => {
-		const guard = new BashToolGuard({ warnThreshold: 2 })
+		const guard = new BashToolGuard({ warnThreshold: 2, blockOnThreshold: true })
 		expect(guard.recordCommand("cat a.ts").decision).toBe("warn")
 		expect(guard.recordCommand("cat b.ts").decision).toBe("warn")
 		expect(guard.recordCommand("cat c.ts").decision).toBe("block")
 	})
 
 	it("respects per-category warnThresholds", () => {
-		const guard = new BashToolGuard({ warnThresholds: { read: 3, edit: 0, write: 1 } })
+		const guard = new BashToolGuard({
+			warnThresholds: { read: 3, edit: 0, write: 1 },
+			blockOnThreshold: true,
+		})
 		// read budget = 3 warns before block
 		expect(guard.recordCommand("cat a.ts").decision).toBe("warn")
 		expect(guard.recordCommand("cat b.ts").decision).toBe("warn")
@@ -250,7 +263,11 @@ describe("BashToolGuard", () => {
 	})
 
 	it("per-category overrides fallback to global warnThreshold when partial", () => {
-		const guard = new BashToolGuard({ warnThreshold: 1, warnThresholds: { edit: 3 } })
+		const guard = new BashToolGuard({
+			warnThreshold: 1,
+			warnThresholds: { edit: 3 },
+			blockOnThreshold: true,
+		})
 		// read falls back to global (1)
 		expect(guard.recordCommand("cat a.ts").decision).toBe("warn")
 		expect(guard.recordCommand("cat b.ts").decision).toBe("block")
@@ -345,8 +362,8 @@ describe("BashToolGuard", () => {
 	})
 })
 
-describe("BashToolGuard — explicit user request override (program name)", () => {
-	it("allows when user prompt mentions the matched program", () => {
+describe("BashToolGuard — explicit user request override (tool name)", () => {
+	it("allows when user prompt mentions the matched tool", () => {
 		const guard = new BashToolGuard()
 		guard.setLastUserPrompt("please use sed to fix the typo in foo.ts")
 		expect(guard.recordCommand("sed -i 's/typo/fix/' foo.ts")).toEqual({
@@ -378,13 +395,21 @@ describe("BashToolGuard — explicit user request override (program name)", () =
 		expect(guard.recordCommand("cat foo.ts")).toEqual({ decision: "allow", reason: "user-request" })
 	})
 
-	it("blocks when user prompt does NOT mention the program AND has no semantic intent", () => {
-		const guard = new BashToolGuard()
+	it("blocks when user prompt does NOT mention the tool AND has no semantic intent (opt-in)", () => {
+		const guard = new BashToolGuard({ blockOnThreshold: true })
 		// 'fix the typo in foo.ts' would match the edit semantic intent
-		// pattern, so use a prompt that mentions neither program nor intent.
+		// pattern, so use a prompt that mentions neither tool nor intent.
 		guard.setLastUserPrompt("please change foo.ts")
 		expect(guard.recordCommand("sed -i 's/typo/fix/' foo.ts").decision).toBe("warn")
 		expect(guard.recordCommand("sed -i 's/x/y/' foo.ts").decision).toBe("block")
+	})
+
+	it("warns repeatedly when user prompt lacks explicit intent (default opt-in)", () => {
+		const guard = new BashToolGuard()
+		guard.setLastUserPrompt("please change foo.ts")
+		expect(guard.recordCommand("sed -i 's/typo/fix/' foo.ts").decision).toBe("warn")
+		expect(guard.recordCommand("sed -i 's/x/y/' foo.ts").decision).toBe("warn")
+		expect(guard.recordCommand("sed -i 's/a/b/' foo.ts").decision).toBe("warn")
 	})
 
 	it("uses word-boundary matching (no false positives on substrings)", () => {
@@ -410,7 +435,7 @@ describe("BashToolGuard — explicit user request override (program name)", () =
 	})
 
 	it("explicit request overrides per-category but other categories still guard", () => {
-		const guard = new BashToolGuard()
+		const guard = new BashToolGuard({ blockOnThreshold: true })
 		guard.setLastUserPrompt("use sed to fix foo.ts")
 		// sed is explicitly requested → allow
 		expect(guard.recordCommand("sed -i 's/a/b/' foo.ts")).toEqual({
@@ -439,7 +464,7 @@ describe("BashToolGuard — explicit user request override (program name)", () =
 		expect(guard.recordCommand("cat foo.ts")).toEqual({ decision: "allow", reason: "user-request" })
 	})
 
-	it("matches programs wrapped in RTK (matchedSegment is the unwrapped form)", () => {
+	it("matches tools wrapped in RTK (matchedSegment is the unwrapped form)", () => {
 		const guard = new BashToolGuard()
 		guard.setLastUserPrompt("use cat to read foo.ts")
 		// matchedSegment is "cat foo.ts" after stripRtk
@@ -463,9 +488,9 @@ describe("BashToolGuard — explicit user request override (program name)", () =
 	})
 })
 
-describe("BashToolGuard — semantic intent override (no program name)", () => {
+describe("BashToolGuard — semantic intent override (no tool name)", () => {
 	// These tests verify the guard detects intent phrases like "read the file"
-	// even when the user doesn't name the program explicitly.
+	// even when the user doesn't name the tool explicitly.
 
 	describe("read intent", () => {
 		it("'read the file foo.ts' allows cat", () => {

--- a/src/extensions/bash-tool-guard.ts
+++ b/src/extensions/bash-tool-guard.ts
@@ -1,0 +1,526 @@
+/**
+ * Bash-tool guard
+ *
+ * Steers the LLM away from using `bash` for tasks that have a dedicated
+ * non-shell tool (`read`, `edit`, `write`). The replacement tools are
+ * cheaper (less output to land in context) and trigger LSP-aware tooling
+ * (hover/definition) when reading or editing code.
+ *
+ * Three categories are detected:
+ *   - read  — `cat <file>`, `head <file>`, `tail <file>`, `less <file>`,
+ *             `bat <file>`, `sed -n '<range>p' <file>` (read-only sed).
+ *   - edit  — `sed -i ... <file>`, `perl -i -pe ... <file>`,
+ *             `awk -i inplace ... <file>` (in-place mutation).
+ *   - write — `>` / `>>` redirect to a regular file, `tee <file>`, heredoc
+ *             redirect (`<<EOF > file`), `printf ... > file`,
+ *             `echo ... > file`.
+ *
+ * Behaviour:
+ *   - First match for a category within a session: steer (don't block).
+ *   - Second match for the same category: hard-block with a reason pointing
+ *     at the right tool.
+ *   - Per-category counters: a `cat` doesn't burn the budget for `sed -i`.
+ *   - Per-category thresholds: read/edit/write can have different budgets.
+ *   - Reset on `session_start` and on each user `input` event so a fresh
+ *     turn starts with a clean slate.
+ *   - Disabled in plan-mode permission context (inspection, not
+ *     enforcement — same rationale as `exploration-guard`).
+ *   - Phase-aware: stricter in build/review, lenient in explore.
+ *   - Explicit user request override: detects both program names ("cat",
+ *     "sed") and semantic intents ("read the file", "fix with sed",
+ *     "write a marker"). Uses word-boundary matching to avoid false
+ *     positives (e.g. "cat" inside "categorize").
+ *   - Emits domain events via pi.events for telemetry to observe.
+ *   - `grep` / `rg` / `ag` and `find` are intentionally NOT guarded: they
+ *     have legitimate uses outside code-search and the false-positive cost
+ *     outweighs the savings.
+ */
+
+import type { ExtensionAPI, ExtensionContext, InputEvent } from "@earendil-works/pi-coding-agent"
+import {
+	BASH_TOOL_GUARD_EVENTS,
+	type BashToolGuardAllowedByUserRequestPayload,
+	type BashToolGuardBlockPayload,
+	type BashToolGuardWarnPayload,
+} from "./bash-tool-guard-events.js"
+import { getPermissionMode } from "./permissions/mode-controller.js"
+import { parseCommandSegments } from "./permissions/taxonomy.js"
+import { getCurrentPhase } from "./tags.js"
+
+export const STEER_MESSAGE_TYPE = "bash-tool-guard-steer"
+
+export type BashCategory = "read" | "edit" | "write"
+
+export interface BashClassification {
+	category: BashCategory
+	suggestion: string
+	/** A short, human-readable rendering of the matched segment (for steer text). */
+	matchedSegment: string
+	/** The program name detected (first token after stripping rtk wrapper). */
+	program: string
+}
+
+export interface PerCategoryThresholds {
+	read?: number
+	edit?: number
+	write?: number
+}
+
+export interface BashGuardOptions {
+	/** Number of warnings per category before hard-blocking. Default: 1.
+	 *  Overridden by per-category values when set. */
+	warnThreshold?: number
+	/** Per-category overrides for the warn threshold. */
+	warnThresholds?: PerCategoryThresholds
+	/** Predicate to temporarily disable the guard (e.g., during plan mode). */
+	isEnabled?: () => boolean
+}
+
+export interface BashGuardResult {
+	decision: "allow"
+	/** When the allow was due to an explicit user request, this is set. */
+	reason?: "user-request"
+}
+
+export interface BashGuardWarnResult {
+	decision: "warn"
+	category: BashCategory
+	suggestion: string
+	matchedSegment: string
+	count: number
+}
+
+export interface BashGuardBlockResult {
+	decision: "block"
+	category: BashCategory
+	suggestion: string
+	matchedSegment: string
+	count: number
+}
+
+export type BashGuardDecision = BashGuardResult | BashGuardWarnResult | BashGuardBlockResult
+
+const WARN_STEER_BASE =
+	"Bash-tool guard: this command reads/updates files via a shell command (%matchedSegment%, category: %category%). " +
+	"The dedicated tool is faster and unlocks LSP context (hover/definition/diagnostics): %suggestion% " +
+	"Next occurrence of the same category will be blocked."
+
+const BLOCK_REASON_BASE =
+	"Bash-tool guard: blocked %category% via shell after a warning in this session. " +
+	"%suggestion% " +
+	"To override, disable the bash-tool-guard extension in resource settings."
+
+const READ_SUGGESTION = "Use the read tool with the file path (and offset/limit for head/tail)."
+const EDIT_SUGGESTION = "Use the edit tool with old_string/new_string."
+const WRITE_SUGGESTION = "Use the edit tool for targeted changes or the write tool for full-file replacements."
+
+/**
+ * Pure classification of a bash command. Returns null when the command is
+ * not one of the guarded anti-patterns. Used by both the guard class and
+ * the unit tests.
+ *
+ * Shell parsing is delegated to `parseCommandSegments` from the permissions
+ * taxonomy so the parser stays in one place. Detection is best-effort:
+ * exotic shell syntax (process substitution, eval'd strings, complex
+ * nested subshells) may slip through; we treat the steer-first design as
+ * the safety net.
+ */
+export function classifyBashCommand(command: string): BashClassification | null {
+	const segments = parseCommandSegments(command)
+
+	for (const segment of segments) {
+		// Drop the leading program name and any RTK wrapper to inspect args.
+		const tokens = stripRtk(segment.tokens)
+		const program = tokens[0]
+		if (!program) continue
+
+		const matchedSegment = tokens.join(" ")
+
+		// Category 1: write — `> file` / `>> file` redirect to a non-stream
+		// target, OR `tee <file>`. We treat any non-stream `>` / `>>` op in
+		// any segment as a write signal because the redirect target is the
+		// file the model wants to produce.
+		for (const op of segment.ops) {
+			if ((op.op === ">" || op.op === ">>") && op.target && !isStreamRedirectTarget(op.target)) {
+				return { category: "write", suggestion: WRITE_SUGGESTION, matchedSegment, program }
+			}
+		}
+		if (program === "tee" && tokens.length >= 2) {
+			return { category: "write", suggestion: WRITE_SUGGESTION, matchedSegment, program }
+		}
+
+		// Category 2: edit — in-place mutation flags.
+		if (isInPlaceEditProgram(program, tokens)) {
+			return { category: "edit", suggestion: EDIT_SUGGESTION, matchedSegment, program }
+		}
+
+		// Category 3: read — programs whose only purpose is to print a file's
+		// contents, plus `sed -n` read mode. Each requires at least one
+		// positional file argument; bare `cat` / `head` reading stdin is
+		// harmless and not flagged.
+		if (isFileReader(program, tokens)) {
+			return { category: "read", suggestion: READ_SUGGESTION, matchedSegment, program }
+		}
+	}
+
+	return null
+}
+
+const STREAM_REDIRECT_TARGETS = new Set(["/dev/null", "/dev/stdout", "/dev/stderr"])
+
+function isStreamRedirectTarget(target: string): boolean {
+	return STREAM_REDIRECT_TARGETS.has(target)
+}
+
+/**
+ * `sed -i`, `sed -i<suffix>`, `perl -i`, `perl -i<suffix>`, and
+ * `awk -i inplace`. These mutate the file in place; the LLM should use
+ * `edit` instead so the diff is reviewable and reversible.
+ */
+function isInPlaceEditProgram(program: string, tokens: string[]): boolean {
+	if (program === "sed") {
+		return tokens.slice(1).some((t) => t === "-i" || t.startsWith("-i"))
+	}
+	if (program === "perl") {
+		return tokens.slice(1).some((t) => t === "-i" || t.startsWith("-i"))
+	}
+	if (program === "awk") {
+		// awk uses `-i file` (separate arg), not a fused flag.
+		for (let i = 1; i < tokens.length - 1; i++) {
+			if (tokens[i] === "-i" && tokens[i + 1] === "inplace") return true
+		}
+	}
+	return false
+}
+
+const READER_PROGRAMS = new Set(["cat", "head", "tail", "less", "more", "bat", "batcat"])
+
+function isFileReader(program: string, tokens: string[]): boolean {
+	if (!READER_PROGRAMS.has(program)) {
+		// `sed -n '<range>p' <files...>` is read-only sed usage.
+		if (program === "sed") {
+			const args = tokens.slice(1)
+			const hasQuiet = args.includes("-n") || args.includes("--quiet") || args.includes("--silent")
+			// Heuristic: read mode usually has `-n` together with a `p` print
+			// command. Without `-n` and `p` it's an editing sed that we
+			// don't catch here (and which the edit category catches via -i).
+			if (!hasQuiet) return false
+			const printCmd = args.find((a) => /p\b/.test(a) && !/^[-]/.test(a))
+			if (!printCmd) return false
+		} else {
+			return false
+		}
+	}
+	// Every guarded reader takes a file path. Bare `cat` / `head` reading
+	// stdin has no positional file arg and is harmless — don't flag it.
+	const positional = tokens.slice(1).filter((t) => !t.startsWith("-"))
+	return positional.length > 0
+}
+
+function stripRtk(tokens: string[]): string[] {
+	return tokens[0] === "rtk" ? tokens.slice(1) : tokens
+}
+
+function escapeRegex(s: string): string {
+	return s.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")
+}
+
+/**
+ * Semantic intent phrases that imply an explicit user request for a given
+ * category. Each entry maps a category to a list of regex patterns matched
+ * against the (lowercased) user prompt.
+ *
+ * Why regex instead of plain word lists: natural-language prompts use
+ * varied phrasings ("read the file", "show me what's in foo.ts", "print
+ * the contents of foo.ts"). Word lists catch only the literal form;
+ * regexes cover the common variants while staying readable.
+ *
+ * Each pattern must be a complete regex (anchored with \b where needed).
+ * Test new patterns in `bash-tool-guard.test.ts` before adding.
+ */
+const SEMANTIC_INTENT_PATTERNS: Record<BashCategory, RegExp[]> = {
+	read: [
+		// "read the file", "read foo.ts", "read the contents of foo.ts"
+		/\bread\b.*\b(file|contents?|source|code)\b/,
+		// "show me foo.ts", "show what's in foo.ts"
+		/\bshow\b.*\b(me|what'?s? in|contents? of)\b/,
+		// "print the contents of foo.ts"
+		/\bprint\b.*\b(contents?|file|source)\b/,
+		// "view foo.ts", "view the file"
+		/\bview\b.*\b(file|contents?|source)\b/,
+		// "open foo.ts" / "open the file" — agents often say this
+		/\bopen\b.*\b(file|\.[a-z]{1,4})\b/,
+	],
+	edit: [
+		// "fix the typo", "fix this with sed", "fix the file"
+		/\bfix\b.*\b(typo|bug|error|file|this|line)\b/,
+		// "replace foo with bar", "replace text in foo.ts"
+		/\breplace\b.*\b(with|in|inside)\b/,
+		// "modify foo.ts", "modify the file"
+		/\bmodify\b.*\b(file|\.[a-z]{1,4})\b/,
+		// "update foo.ts", "update the file"
+		/\bupdate\b.*\b(file|\.[a-z]{1,4})\b/,
+		// "use sed/awk/perl to ..."
+		/\buse\b.*\b(sed|awk|perl)\b/,
+		// "edit foo.ts"
+		/\bedit\b.*\b(file|\.[a-z]{1,4})\b/,
+	],
+	write: [
+		// "write a file", "write to foo.ts", "write the contents to foo.ts"
+		/\bwrite\b.*\b(to|file|contents? to)\b/,
+		// "create a file", "create foo.ts"
+		/\bcreate\b.*\b(file|\.[a-z]{1,4})\b/,
+		// "save to foo.ts", "save the output to foo.ts"
+		/\bsave\b.*\b(to|into)\b/,
+		// "put it in foo.ts", "put the result in foo.ts"
+		/\bput\b.*\b(in|into|to)\b/,
+		// "echo ... to file"
+		/\becho\b.*\bto\b/,
+		// "redirect to foo.ts", "redirect output to foo.ts"
+		/\bredirect\b.*\bto\b/,
+	],
+}
+
+export class BashToolGuard {
+	private readonly warnThresholds: Record<BashCategory, number>
+	private readonly isEnabled: () => boolean
+	private readonly categoryCounts: Map<BashCategory, number> = new Map()
+	/** Most recent user prompt text, lowercased. Used to detect explicit
+	 *  requests like "use sed" or "cat this file" so the guard doesn't
+	 *  override an explicit user instruction. */
+	private lastUserPrompt = ""
+
+	constructor(options: BashGuardOptions = {}) {
+		const defaultThreshold = options.warnThreshold ?? 1
+		this.warnThresholds = {
+			read: options.warnThresholds?.read ?? defaultThreshold,
+			edit: options.warnThresholds?.edit ?? defaultThreshold,
+			write: options.warnThresholds?.write ?? defaultThreshold,
+		}
+		this.isEnabled = options.isEnabled ?? (() => true)
+	}
+
+	reset(): void {
+		this.categoryCounts.clear()
+		this.lastUserPrompt = ""
+	}
+
+	/** Record the most recent user prompt so the guard can detect explicit
+	 *  requests. Call this from the `input` event handler. */
+	setLastUserPrompt(text: string): void {
+		this.lastUserPrompt = text.toLowerCase()
+	}
+
+	/** Returns the lowercased user prompt (for testing and debugging). */
+	getLastUserPrompt(): string {
+		return this.lastUserPrompt
+	}
+
+	/** True when the user's most recent prompt explicitly requests the
+	 *  matched program or category. Detection is two-tiered:
+	 *    1. Program-name match (word-boundary): "use sed to fix this",
+	 *       "cat the file", "echo to marker".
+	 *    2. Semantic intent match: "read the file", "fix with sed",
+	 *       "write to foo.ts", etc. — catches prompts that don't mention
+	 *       the program by name but clearly intend the operation.
+	 *  Both use word-boundary matching to avoid false positives (e.g.
+	 *  "cat" inside "categorize", "sed" inside "used"). */
+	isExplicitlyRequested(matchedSegment: string, category: BashCategory): boolean {
+		if (!this.lastUserPrompt) return false
+		// First token of the matched segment is the program name.
+		const program = matchedSegment.split(/\s+/)[0]?.toLowerCase()
+		if (program) {
+			const programPattern = new RegExp(`\\b${escapeRegex(program)}\\b`)
+			if (programPattern.test(this.lastUserPrompt)) return true
+		}
+		// Semantic intent fallback — catches intent without naming the program.
+		const intentPatterns = SEMANTIC_INTENT_PATTERNS[category]
+		return intentPatterns.some((pattern) => pattern.test(this.lastUserPrompt))
+	}
+
+	getCount(category: BashCategory): number {
+		return this.categoryCounts.get(category) ?? 0
+	}
+
+	/** Threshold for a given category (read/edit/write). */
+	getWarnThreshold(category: BashCategory): number {
+		return this.warnThresholds[category]
+	}
+
+	/**
+	 * Inspect a bash command. Returns:
+	 *   - `{ decision: "allow" }` when the command is fine.
+	 *   - `{ decision: "warn", ... }` for the first match of a category.
+	 *   - `{ decision: "block", ... }` once the per-category warnThreshold
+	 *     is exceeded.
+	 */
+	recordCommand(command: string): BashGuardDecision {
+		if (!this.isEnabled()) return { decision: "allow" }
+		const classification = classifyBashCommand(command)
+		if (!classification) return { decision: "allow" }
+
+		// Explicit user request: "use sed to fix this", "cat the file", etc.
+		// The user knows what they're asking for; don't override.
+		if (this.isExplicitlyRequested(classification.matchedSegment, classification.category)) {
+			return { decision: "allow", reason: "user-request" }
+		}
+
+		const threshold = this.warnThresholds[classification.category]
+		const count = (this.categoryCounts.get(classification.category) ?? 0) + 1
+		this.categoryCounts.set(classification.category, count)
+
+		if (count > threshold) {
+			return {
+				decision: "block",
+				category: classification.category,
+				suggestion: classification.suggestion,
+				matchedSegment: classification.matchedSegment,
+				count,
+			}
+		}
+
+		return {
+			decision: "warn",
+			category: classification.category,
+			suggestion: classification.suggestion,
+			matchedSegment: classification.matchedSegment,
+			count,
+		}
+	}
+
+	/** Build the steer message text for a `warn` decision. */
+	formatWarnText(result: BashGuardWarnResult): string {
+		return WARN_STEER_BASE.replace("%matchedSegment%", result.matchedSegment)
+			.replace("%category%", result.category)
+			.replace("%suggestion%", result.suggestion)
+	}
+
+	/** Build the block reason text for a `block` decision. */
+	formatBlockReason(result: BashGuardBlockResult): string {
+		return BLOCK_REASON_BASE.replace("%category%", result.category).replace("%suggestion%", result.suggestion)
+	}
+}
+
+/**
+ * Phase-aware enable predicate. Returns true when the guard should be active.
+ *
+ * Plan mode is always disabled (existing exploration-guard precedent). Build
+ * and review phases get stricter enforcement (warn threshold 1, not blocked
+ * by default — same as the global default). Research phase follows the
+ * default. Explore phase is slightly more lenient (warn threshold 2) so
+ * deep code-diving during initial exploration isn't aggressively steered.
+ *
+ * Note: `phaseOverride` is exposed as a parameter for unit tests so we can
+ * inject a fake phase without monkey-patching the tags module.
+ */
+export function phaseAwareIsEnabled(phaseOverride?: () => string | undefined): () => boolean {
+	return () => {
+		// plan mode (permission) is always disabled — deep inspection
+		// during scoping shouldn't be blocked
+		// (caller passes `getPermissionMode` check separately)
+		const phase = phaseOverride ? phaseOverride() : getCurrentPhase()
+		// All phases active by default; per-phase threshold tuning lives in
+		// the extension's `warnThresholds` option, not in this predicate.
+		// Review phase stays active: orchestrators in review should still
+		// use `read` over `cat` for LSP context.
+		return phase !== undefined // active in all defined phases
+	}
+}
+
+export default function bashToolGuardExtension(pi: ExtensionAPI, options?: BashGuardOptions): void {
+	let ctx: ExtensionContext | undefined
+
+	const guard = new BashToolGuard({
+		...options,
+		isEnabled: () => {
+			const sessionId = ctx?.sessionManager.getSessionId()
+			if (!sessionId) return true
+			// Plan mode is for inspection; the existing exploration-guard
+			// precedent disables itself there. We follow suit so deep
+			// reads during scoping aren't blocked.
+			if (getPermissionMode(sessionId)?.mode === "plan") return false
+			return true
+		},
+	})
+
+	// Domain event helper: emit a `warn` / `block` / `user-request-allow`
+	// event. No-ops silently when `pi.events` is unavailable on the host.
+	function emitGuardEvent(channel: string, payload: unknown): void {
+		try {
+			pi.events.emit(channel, payload)
+		} catch {
+			// Older pi-coding-agent versions may not expose `events`. The
+			// guard still functions correctly without telemetry.
+		}
+	}
+
+	pi.on("session_start", (_event, _ctx) => {
+		ctx = _ctx
+		guard.reset()
+	})
+
+	pi.on("input", (event: InputEvent) => {
+		if (event.source === "extension") return
+		// Capture the prompt text BEFORE reset so isExplicitlyRequested can
+		// still see it after the counters clear.
+		const prompt = typeof event.text === "string" ? event.text : ""
+		guard.reset()
+		guard.setLastUserPrompt(prompt)
+	})
+
+	pi.on("tool_call", (event) => {
+		if (!event.toolName) return { block: false }
+		if (event.toolName !== "bash") return { block: false }
+
+		const input = event.input as { command?: unknown }
+		const command = typeof input.command === "string" ? input.command : ""
+		if (!command) return { block: false }
+
+		const result = guard.recordCommand(command)
+		if (result.decision === "allow") {
+			// Surface user-request overrides so we can measure how often
+			// users explicitly ask for bash usage.
+			if (result.reason === "user-request") {
+				const classification = classifyBashCommand(command)
+				if (classification) {
+					const payload: BashToolGuardAllowedByUserRequestPayload = {
+						category: classification.category,
+						program: classification.program,
+					}
+					emitGuardEvent(BASH_TOOL_GUARD_EVENTS.ALLOWED_BY_USER_REQUEST, payload)
+				}
+			}
+			return { block: false }
+		}
+
+		if (result.decision === "block") {
+			const payload: BashToolGuardBlockPayload = {
+				category: result.category,
+				matchedSegment: result.matchedSegment,
+				count: result.count,
+			}
+			emitGuardEvent(BASH_TOOL_GUARD_EVENTS.BLOCK, payload)
+			return {
+				block: true,
+				reason: guard.formatBlockReason(result),
+			}
+		}
+
+		// decision === "warn"
+		const payload: BashToolGuardWarnPayload = {
+			category: result.category,
+			matchedSegment: result.matchedSegment,
+			count: result.count,
+		}
+		emitGuardEvent(BASH_TOOL_GUARD_EVENTS.WARN, payload)
+		pi.sendMessage(
+			{
+				customType: STEER_MESSAGE_TYPE,
+				content: [{ type: "text", text: guard.formatWarnText(result) }],
+				display: false,
+			},
+			{ deliverAs: "steer" },
+		)
+		return { block: false }
+	})
+}

--- a/src/extensions/bash-tool-guard.ts
+++ b/src/extensions/bash-tool-guard.ts
@@ -18,14 +18,16 @@
  * Behaviour:
  *   - First match for a category within a session: steer (don't block).
  *   - Second match for the same category: hard-block with a reason pointing
- *     at the right tool.
+ *     at the right tool — but only when `blockOnThreshold: true` is passed
+ *     to the extension. The default is warn-only so adopting the guard
+ *     never stalls a session if the replacement tool is unavailable.
  *   - Per-category counters: a `cat` doesn't burn the budget for `sed -i`.
  *   - Per-category thresholds: read/edit/write can have different budgets.
  *   - Reset on `session_start` and on each user `input` event so a fresh
  *     turn starts with a clean slate.
  *   - Disabled in plan-mode permission context (inspection, not
  *     enforcement — same rationale as `exploration-guard`).
- *   - Explicit user request override: detects both program names ("cat",
+ *   - Explicit user request override: detects both tool names ("cat",
  *     "sed") and semantic intents ("read the file", "fix with sed",
  *     "write a marker"). Uses word-boundary matching to avoid false
  *     positives (e.g. "cat" inside "categorize").
@@ -36,6 +38,7 @@
  */
 
 import type { ExtensionAPI, ExtensionContext, InputEvent } from "@earendil-works/pi-coding-agent"
+import { isResourceEnabled } from "../resources/store.js"
 import {
 	BASH_TOOL_GUARD_EVENTS,
 	type BashToolGuardAllowedByUserRequestPayload,
@@ -44,6 +47,8 @@ import {
 } from "./bash-tool-guard-events.js"
 import { getPermissionMode } from "./permissions/mode-controller.js"
 import { parseCommandSegments } from "./permissions/taxonomy.js"
+
+const RESOURCE_ID = "extensions.bash-tool-guard"
 
 export const STEER_MESSAGE_TYPE = "bash-tool-guard-steer"
 
@@ -54,8 +59,8 @@ export interface BashClassification {
 	suggestion: string
 	/** A short, human-readable rendering of the matched segment (for steer text). */
 	matchedSegment: string
-	/** The program name detected (first token after stripping rtk wrapper). */
-	program: string
+	/** The tool name detected (first token after stripping rtk wrapper). */
+	tool: string
 }
 
 export interface PerCategoryThresholds {
@@ -72,6 +77,12 @@ export interface BashGuardOptions {
 	warnThresholds?: PerCategoryThresholds
 	/** Predicate to temporarily disable the guard (e.g., during plan mode). */
 	isEnabled?: () => boolean
+	/** When true, the guard hard-blocks bash calls once the per-category
+	 *  warn threshold is exceeded. Default: false (warn/steer only).
+	 *  Hard blocking is opt-in so users can adopt the guard without
+	 *  risking session stalls if the replacement tool is unavailable
+	 *  or misconfigured in a given environment. */
+	blockOnThreshold?: boolean
 }
 
 export interface BashGuardResult {
@@ -85,6 +96,7 @@ export interface BashGuardWarnResult {
 	category: BashCategory
 	suggestion: string
 	matchedSegment: string
+	tool: string
 	count: number
 }
 
@@ -93,6 +105,7 @@ export interface BashGuardBlockResult {
 	category: BashCategory
 	suggestion: string
 	matchedSegment: string
+	tool: string
 	count: number
 }
 
@@ -101,7 +114,7 @@ export type BashGuardDecision = BashGuardResult | BashGuardWarnResult | BashGuar
 const WARN_STEER_BASE =
 	"Bash-tool guard: this command reads/updates files via a shell command (%matchedSegment%, category: %category%). " +
 	"The dedicated tool is faster and unlocks LSP context (hover/definition/diagnostics): %suggestion% " +
-	"Next occurrence of the same category will be blocked."
+	"Hard blocking is opt-in; pass `blockOnThreshold: true` to enable."
 
 const BLOCK_REASON_BASE =
 	"Bash-tool guard: blocked %category% via shell after a warning in this session. " +
@@ -127,10 +140,10 @@ export function classifyBashCommand(command: string): BashClassification | null 
 	const segments = parseCommandSegments(command)
 
 	for (const segment of segments) {
-		// Drop the leading program name and any RTK wrapper to inspect args.
+		// Drop the leading tool name and any RTK wrapper to inspect args.
 		const tokens = stripRtk(segment.tokens)
-		const program = tokens[0]
-		if (!program) continue
+		const tool = tokens[0]
+		if (!tool) continue
 
 		const matchedSegment = tokens.join(" ")
 
@@ -140,24 +153,24 @@ export function classifyBashCommand(command: string): BashClassification | null 
 		// file the model wants to produce.
 		for (const op of segment.ops) {
 			if ((op.op === ">" || op.op === ">>") && op.target && !isStreamRedirectTarget(op.target)) {
-				return { category: "write", suggestion: WRITE_SUGGESTION, matchedSegment, program }
+				return { category: "write", suggestion: WRITE_SUGGESTION, matchedSegment, tool }
 			}
 		}
-		if (program === "tee" && tokens.length >= 2) {
-			return { category: "write", suggestion: WRITE_SUGGESTION, matchedSegment, program }
+		if (tool === "tee" && tokens.length >= 2) {
+			return { category: "write", suggestion: WRITE_SUGGESTION, matchedSegment, tool }
 		}
 
 		// Category 2: edit — in-place mutation flags.
-		if (isInPlaceEditProgram(program, tokens)) {
-			return { category: "edit", suggestion: EDIT_SUGGESTION, matchedSegment, program }
+		if (isInPlaceEditTool(tool, tokens)) {
+			return { category: "edit", suggestion: EDIT_SUGGESTION, matchedSegment, tool }
 		}
 
-		// Category 3: read — programs whose only purpose is to print a file's
+		// Category 3: read — tools whose only purpose is to print a file's
 		// contents, plus `sed -n` read mode. Each requires at least one
 		// positional file argument; bare `cat` / `head` reading stdin is
 		// harmless and not flagged.
-		if (isFileReader(program, tokens)) {
-			return { category: "read", suggestion: READ_SUGGESTION, matchedSegment, program }
+		if (isFileReader(tool, tokens)) {
+			return { category: "read", suggestion: READ_SUGGESTION, matchedSegment, tool }
 		}
 	}
 
@@ -175,14 +188,14 @@ function isStreamRedirectTarget(target: string): boolean {
  * `awk -i inplace`. These mutate the file in place; the LLM should use
  * `edit` instead so the diff is reviewable and reversible.
  */
-function isInPlaceEditProgram(program: string, tokens: string[]): boolean {
-	if (program === "sed") {
+function isInPlaceEditTool(tool: string, tokens: string[]): boolean {
+	if (tool === "sed") {
 		return tokens.slice(1).some((t) => t === "-i" || t.startsWith("-i"))
 	}
-	if (program === "perl") {
+	if (tool === "perl") {
 		return tokens.slice(1).some((t) => t === "-i" || t.startsWith("-i"))
 	}
-	if (program === "awk") {
+	if (tool === "awk") {
 		// awk uses `-i file` (separate arg), not a fused flag.
 		for (let i = 1; i < tokens.length - 1; i++) {
 			if (tokens[i] === "-i" && tokens[i + 1] === "inplace") return true
@@ -191,12 +204,12 @@ function isInPlaceEditProgram(program: string, tokens: string[]): boolean {
 	return false
 }
 
-const READER_PROGRAMS = new Set(["cat", "head", "tail", "less", "more", "bat", "batcat"])
+const READER_TOOLS = new Set(["cat", "head", "tail", "less", "more", "bat", "batcat"])
 
-function isFileReader(program: string, tokens: string[]): boolean {
-	if (!READER_PROGRAMS.has(program)) {
+function isFileReader(tool: string, tokens: string[]): boolean {
+	if (!READER_TOOLS.has(tool)) {
 		// `sed -n '<range>p' <files...>` is read-only sed usage.
-		if (program === "sed") {
+		if (tool === "sed") {
 			const args = tokens.slice(1)
 			const hasQuiet = args.includes("-n") || args.includes("--quiet") || args.includes("--silent")
 			// Heuristic: read mode usually has `-n` together with a `p` print
@@ -282,6 +295,7 @@ const SEMANTIC_INTENT_PATTERNS: Record<BashCategory, RegExp[]> = {
 export class BashToolGuard {
 	private readonly warnThresholds: Record<BashCategory, number>
 	private readonly isEnabled: () => boolean
+	private readonly blockOnThreshold: boolean
 	private readonly categoryCounts: Map<BashCategory, number> = new Map()
 	/** Most recent user prompt text, lowercased. Used to detect explicit
 	 *  requests like "use sed" or "cat this file" so the guard doesn't
@@ -296,6 +310,7 @@ export class BashToolGuard {
 			write: options.warnThresholds?.write ?? defaultThreshold,
 		}
 		this.isEnabled = options.isEnabled ?? (() => true)
+		this.blockOnThreshold = options.blockOnThreshold ?? false
 	}
 
 	reset(): void {
@@ -315,23 +330,23 @@ export class BashToolGuard {
 	}
 
 	/** True when the user's most recent prompt explicitly requests the
-	 *  matched program or category. Detection is two-tiered:
+	 *  matched tool or category. Detection is two-tiered:
 	 *    1. Program-name match (word-boundary): "use sed to fix this",
 	 *       "cat the file", "echo to marker".
 	 *    2. Semantic intent match: "read the file", "fix with sed",
 	 *       "write to foo.ts", etc. — catches prompts that don't mention
-	 *       the program by name but clearly intend the operation.
+	 *       the tool by name but clearly intend the operation.
 	 *  Both use word-boundary matching to avoid false positives (e.g.
 	 *  "cat" inside "categorize", "sed" inside "used"). */
 	isExplicitlyRequested(matchedSegment: string, category: BashCategory): boolean {
 		if (!this.lastUserPrompt) return false
-		// First token of the matched segment is the program name.
-		const program = matchedSegment.split(/\s+/)[0]?.toLowerCase()
-		if (program) {
-			const programPattern = new RegExp(`\\b${escapeRegex(program)}\\b`)
-			if (programPattern.test(this.lastUserPrompt)) return true
+		// First token of the matched segment is the tool name.
+		const tool = matchedSegment.split(/\s+/)[0]?.toLowerCase()
+		if (tool) {
+			const toolPattern = new RegExp(`\\b${escapeRegex(tool)}\\b`)
+			if (toolPattern.test(this.lastUserPrompt)) return true
 		}
-		// Semantic intent fallback — catches intent without naming the program.
+		// Semantic intent fallback — catches intent without naming the tool.
 		const intentPatterns = SEMANTIC_INTENT_PATTERNS[category]
 		return intentPatterns.some((pattern) => pattern.test(this.lastUserPrompt))
 	}
@@ -348,9 +363,11 @@ export class BashToolGuard {
 	/**
 	 * Inspect a bash command. Returns:
 	 *   - `{ decision: "allow" }` when the command is fine.
-	 *   - `{ decision: "warn", ... }` for the first match of a category.
+	 *   - `{ decision: "warn", ... }` for the first match of a category,
+	 *     AND for every subsequent match when `blockOnThreshold` is false
+	 *     (default). The LLM keeps getting nudged on each occurrence.
 	 *   - `{ decision: "block", ... }` once the per-category warnThreshold
-	 *     is exceeded.
+	 *     is exceeded, but only when `blockOnThreshold` is true (opt-in).
 	 */
 	recordCommand(command: string): BashGuardDecision {
 		if (!this.isEnabled()) return { decision: "allow" }
@@ -368,11 +385,27 @@ export class BashToolGuard {
 		this.categoryCounts.set(classification.category, count)
 
 		if (count > threshold) {
+			// Hard blocking is opt-in. When disabled, the guard keeps
+			// steering on every occurrence instead of refusing the call.
+			// The downstream `tool_call` handler falls back to a warn in
+			// that case so the LLM keeps getting nudged without losing
+			// the ability to proceed.
+			if (!this.blockOnThreshold) {
+				return {
+					decision: "warn",
+					category: classification.category,
+					suggestion: classification.suggestion,
+					matchedSegment: classification.matchedSegment,
+					tool: classification.tool,
+					count,
+				}
+			}
 			return {
 				decision: "block",
 				category: classification.category,
 				suggestion: classification.suggestion,
 				matchedSegment: classification.matchedSegment,
+				tool: classification.tool,
 				count,
 			}
 		}
@@ -382,6 +415,7 @@ export class BashToolGuard {
 			category: classification.category,
 			suggestion: classification.suggestion,
 			matchedSegment: classification.matchedSegment,
+			tool: classification.tool,
 			count,
 		}
 	}
@@ -448,6 +482,12 @@ export default function bashToolGuardExtension(pi: ExtensionAPI, options?: BashG
 		if (!event.toolName) return { block: false }
 		if (event.toolName !== "bash") return { block: false }
 
+		// Dynamic resource toggle: consult the resource store on every
+		// bash call so users can disable the guard mid-session from the
+		// /resources UI without a restart. Startup-time disablement is
+		// still handled by the extension filter; this is a no-op there.
+		if (!isResourceEnabled(RESOURCE_ID)) return { block: false }
+
 		const input = event.input as { command?: unknown }
 		const command = typeof input.command === "string" ? input.command : ""
 		if (!command) return { block: false }
@@ -461,7 +501,7 @@ export default function bashToolGuardExtension(pi: ExtensionAPI, options?: BashG
 				if (classification) {
 					const payload: BashToolGuardAllowedByUserRequestPayload = {
 						category: classification.category,
-						program: classification.program,
+						tool: classification.tool,
 					}
 					emitGuardEvent(BASH_TOOL_GUARD_EVENTS.ALLOWED_BY_USER_REQUEST, payload)
 				}
@@ -472,7 +512,7 @@ export default function bashToolGuardExtension(pi: ExtensionAPI, options?: BashG
 		if (result.decision === "block") {
 			const payload: BashToolGuardBlockPayload = {
 				category: result.category,
-				matchedSegment: result.matchedSegment,
+				tool: result.tool ?? "",
 				count: result.count,
 			}
 			emitGuardEvent(BASH_TOOL_GUARD_EVENTS.BLOCK, payload)
@@ -485,7 +525,7 @@ export default function bashToolGuardExtension(pi: ExtensionAPI, options?: BashG
 		// decision === "warn"
 		const payload: BashToolGuardWarnPayload = {
 			category: result.category,
-			matchedSegment: result.matchedSegment,
+			tool: result.tool ?? "",
 			count: result.count,
 		}
 		emitGuardEvent(BASH_TOOL_GUARD_EVENTS.WARN, payload)

--- a/src/extensions/bash-tool-guard.ts
+++ b/src/extensions/bash-tool-guard.ts
@@ -25,7 +25,6 @@
  *     turn starts with a clean slate.
  *   - Disabled in plan-mode permission context (inspection, not
  *     enforcement — same rationale as `exploration-guard`).
- *   - Phase-aware: stricter in build/review, lenient in explore.
  *   - Explicit user request override: detects both program names ("cat",
  *     "sed") and semantic intents ("read the file", "fix with sed",
  *     "write a marker"). Uses word-boundary matching to avoid false
@@ -45,7 +44,6 @@ import {
 } from "./bash-tool-guard-events.js"
 import { getPermissionMode } from "./permissions/mode-controller.js"
 import { parseCommandSegments } from "./permissions/taxonomy.js"
-import { getCurrentPhase } from "./tags.js"
 
 export const STEER_MESSAGE_TYPE = "bash-tool-guard-steer"
 
@@ -401,45 +399,23 @@ export class BashToolGuard {
 	}
 }
 
-/**
- * Phase-aware enable predicate. Returns true when the guard should be active.
- *
- * Plan mode is always disabled (existing exploration-guard precedent). Build
- * and review phases get stricter enforcement (warn threshold 1, not blocked
- * by default — same as the global default). Research phase follows the
- * default. Explore phase is slightly more lenient (warn threshold 2) so
- * deep code-diving during initial exploration isn't aggressively steered.
- *
- * Note: `phaseOverride` is exposed as a parameter for unit tests so we can
- * inject a fake phase without monkey-patching the tags module.
- */
-export function phaseAwareIsEnabled(phaseOverride?: () => string | undefined): () => boolean {
-	return () => {
-		// plan mode (permission) is always disabled — deep inspection
-		// during scoping shouldn't be blocked
-		// (caller passes `getPermissionMode` check separately)
-		const phase = phaseOverride ? phaseOverride() : getCurrentPhase()
-		// All phases active by default; per-phase threshold tuning lives in
-		// the extension's `warnThresholds` option, not in this predicate.
-		// Review phase stays active: orchestrators in review should still
-		// use `read` over `cat` for LSP context.
-		return phase !== undefined // active in all defined phases
-	}
-}
-
 export default function bashToolGuardExtension(pi: ExtensionAPI, options?: BashGuardOptions): void {
 	let ctx: ExtensionContext | undefined
 
 	const guard = new BashToolGuard({
 		...options,
 		isEnabled: () => {
+			// Caller predicate (if any) is consulted first so users can
+			// disable the guard from their own config. Plan mode then
+			// short-circuits because inspection should never be enforced,
+			// regardless of what the caller asked for.
+			if (options?.isEnabled && !options.isEnabled()) return false
 			const sessionId = ctx?.sessionManager.getSessionId()
 			if (!sessionId) return true
 			// Plan mode is for inspection; the existing exploration-guard
 			// precedent disables itself there. We follow suit so deep
 			// reads during scoping aren't blocked.
-			if (getPermissionMode(sessionId)?.mode === "plan") return false
-			return true
+			return getPermissionMode(sessionId)?.mode !== "plan"
 		},
 	})
 

--- a/src/extensions/permissions/taxonomy.ts
+++ b/src/extensions/permissions/taxonomy.ts
@@ -383,7 +383,7 @@ interface Segment {
 // `||`. Each segment carries its word tokens plus the operators (`>`, `>>`,
 // etc.) that appear within it. Backticks are pre-rejected because
 // shell-quote leaves them as opaque strings.
-function parseCommandSegments(command: string): Segment[] {
+export function parseCommandSegments(command: string): Segment[] {
 	// shell-quote does not recognize legacy backtick substitution; treat any
 	// backtick as a poison pill to avoid silently accepting embedded commands.
 	if (command.includes("`")) return [{ tokens: [], ops: [{ op: "(" }] }]

--- a/src/extensions/telemetry/index.test.ts
+++ b/src/extensions/telemetry/index.test.ts
@@ -1025,13 +1025,13 @@ describe("bash-tool-guard telemetry via pi.events", () => {
 		return Object.fromEntries(rec.attributes.map((a) => [a.key, a.value.stringValue]))
 	}
 
-	it("bash_tool_guard:warn → bash_tool_guard.warn OTLP record with category, count, preview", async () => {
+	it("bash_tool_guard:warn → bash_tool_guard.warn OTLP record with category, tool, count", async () => {
 		const { handlers, events } = await setup()
 		const { BASH_TOOL_GUARD_EVENTS } = await import("../bash-tool-guard-events.js")
 
 		events.emit(BASH_TOOL_GUARD_EVENTS.WARN, {
 			category: "read",
-			matchedSegment: "cat src/foo.ts",
+			tool: "cat",
 			count: 1,
 		})
 		await getHandler(handlers, "session_shutdown")({ reason: "test" })
@@ -1040,18 +1040,21 @@ describe("bash-tool-guard telemetry via pi.events", () => {
 		expect(rec).toBeDefined()
 		const attrs = attrsOf(rec as NonNullable<typeof rec>)
 		expect(attrs.category).toBe("read")
+		expect(attrs.tool).toBe("cat")
 		expect(attrs.count).toBe("1")
-		expect(attrs.segment_preview).toBe("cat src/foo.ts")
+		// Raw command text must not leak into OTLP — only structured fields.
+		expect(attrs.segment_preview).toBeUndefined()
+		expect(attrs.matchedSegment).toBeUndefined()
 		expect(attrs.model).toBe("claude-sonnet-4-6")
 	})
 
-	it("bash_tool_guard:block → bash_tool_guard.block OTLP record", async () => {
+	it("bash_tool_guard:block → bash_tool_guard.block OTLP record with tool", async () => {
 		const { handlers, events } = await setup()
 		const { BASH_TOOL_GUARD_EVENTS } = await import("../bash-tool-guard-events.js")
 
 		events.emit(BASH_TOOL_GUARD_EVENTS.BLOCK, {
 			category: "edit",
-			matchedSegment: "sed -i 's/a/b/' foo.ts",
+			tool: "sed",
 			count: 2,
 		})
 		await getHandler(handlers, "session_shutdown")({ reason: "test" })
@@ -1060,17 +1063,20 @@ describe("bash-tool-guard telemetry via pi.events", () => {
 		expect(rec).toBeDefined()
 		const attrs = attrsOf(rec as NonNullable<typeof rec>)
 		expect(attrs.category).toBe("edit")
+		expect(attrs.tool).toBe("sed")
 		expect(attrs.count).toBe("2")
-		expect(attrs.segment_preview).toBe("sed -i 's/a/b/' foo.ts")
+		// Raw command text must not leak into OTLP — only structured fields.
+		expect(attrs.segment_preview).toBeUndefined()
+		expect(attrs.matchedSegment).toBeUndefined()
 	})
 
-	it("bash_tool_guard:allowed_by_user_request → OTLP record with program", async () => {
+	it("bash_tool_guard:allowed_by_user_request → OTLP record with tool", async () => {
 		const { handlers, events } = await setup()
 		const { BASH_TOOL_GUARD_EVENTS } = await import("../bash-tool-guard-events.js")
 
 		events.emit(BASH_TOOL_GUARD_EVENTS.ALLOWED_BY_USER_REQUEST, {
 			category: "read",
-			program: "cat",
+			tool: "cat",
 		})
 		await getHandler(handlers, "session_shutdown")({ reason: "test" })
 
@@ -1078,25 +1084,7 @@ describe("bash-tool-guard telemetry via pi.events", () => {
 		expect(rec).toBeDefined()
 		const attrs = attrsOf(rec as NonNullable<typeof rec>)
 		expect(attrs.category).toBe("read")
-		expect(attrs.program).toBe("cat")
-	})
-
-	it("truncates long matched segments in segment_preview", async () => {
-		const { handlers, events } = await setup()
-		const { BASH_TOOL_GUARD_EVENTS } = await import("../bash-tool-guard-events.js")
-
-		const longSegment = `echo '${"x".repeat(200)}' > foo.ts`
-		events.emit(BASH_TOOL_GUARD_EVENTS.WARN, {
-			category: "write",
-			matchedSegment: longSegment,
-			count: 1,
-		})
-		await getHandler(handlers, "session_shutdown")({ reason: "test" })
-
-		const rec = extractRecords().find((r) => r.eventName === "bash_tool_guard.warn")
-		expect(rec).toBeDefined()
-		const attrs = attrsOf(rec as NonNullable<typeof rec>)
-		expect(attrs.segment_preview?.length).toBeLessThanOrEqual(80)
+		expect(attrs.tool).toBe("cat")
 	})
 
 	it("does NOT emit OTLP records when telemetry is disabled", async () => {
@@ -1109,7 +1097,7 @@ describe("bash-tool-guard telemetry via pi.events", () => {
 		// emit() simply has no listeners and nothing reaches the network.
 		events.emit(BASH_TOOL_GUARD_EVENTS.WARN, {
 			category: "read",
-			matchedSegment: "cat foo.ts",
+			tool: "cat",
 			count: 1,
 		})
 		expect(fetchMock).not.toHaveBeenCalled()

--- a/src/extensions/telemetry/index.test.ts
+++ b/src/extensions/telemetry/index.test.ts
@@ -860,3 +860,145 @@ describe("token accounting regression tests", () => {
 		expect(attrs.session_type).toBe("ferment")
 	})
 })
+
+// ---------------------------------------------------------------------------
+// Bash-tool-guard domain event → OTLP log record tests
+// ---------------------------------------------------------------------------
+
+describe("bash-tool-guard telemetry via pi.events", () => {
+	let fetchMock: ReturnType<typeof vi.fn>
+	let originalFetch: typeof globalThis.fetch
+
+	beforeEach(() => {
+		fetchMock = vi.fn().mockResolvedValue({ ok: true, text: async () => "" })
+		originalFetch = globalThis.fetch
+		// biome-ignore lint/suspicious/noExplicitAny: test mock
+		globalThis.fetch = fetchMock as any
+	})
+
+	afterEach(async () => {
+		globalThis.fetch = originalFetch
+		_resetSharedAccumulators()
+		const { _resetFermentTrackingState, _getBashGuardCounts } = await import("./index.js")
+		_resetFermentTrackingState()
+		// Reset bash-guard counters by emitting zeros via the reset hook
+		// (the counters reset on session_start; calling it clears state).
+		vi.restoreAllMocks()
+		// Force fresh state for next test by clearing module-level accumulators.
+		// Direct access is not exposed; reset via the public reset path.
+		expect(_getBashGuardCounts()).toBeDefined()
+	})
+
+	async function setup() {
+		const { handlers, events, api } = createMockApi()
+		const { default: ext } = await import("./index.js")
+		ext(makeConfig())(api)
+		await getHandler(handlers, "session_start")({}, { model: { id: "claude-sonnet-4-6" } })
+		return { handlers, events }
+	}
+
+	function extractRecords() {
+		const logCalls = fetchMock.mock.calls.filter(([url]: unknown[]) => String(url).includes("/logs"))
+		return logCalls.flatMap(([, opts]: unknown[]) => {
+			const body = JSON.parse((opts as { body: string }).body)
+			return body.resourceLogs[0].scopeLogs[0].logRecords as Array<{
+				eventName: string
+				attributes: Array<{ key: string; value: { stringValue: string } }>
+			}>
+		})
+	}
+
+	function attrsOf(rec: { attributes: Array<{ key: string; value: { stringValue: string } }> }) {
+		return Object.fromEntries(rec.attributes.map((a) => [a.key, a.value.stringValue]))
+	}
+
+	it("bash_tool_guard:warn → bash_tool_guard.warn OTLP record with category, count, preview", async () => {
+		const { handlers, events } = await setup()
+		const { BASH_TOOL_GUARD_EVENTS } = await import("../bash-tool-guard-events.js")
+
+		events.emit(BASH_TOOL_GUARD_EVENTS.WARN, {
+			category: "read",
+			matchedSegment: "cat src/foo.ts",
+			count: 1,
+		})
+		await getHandler(handlers, "session_shutdown")({ reason: "test" })
+
+		const rec = extractRecords().find((r) => r.eventName === "bash_tool_guard.warn")
+		expect(rec).toBeDefined()
+		const attrs = attrsOf(rec as NonNullable<typeof rec>)
+		expect(attrs.category).toBe("read")
+		expect(attrs.count).toBe("1")
+		expect(attrs.segment_preview).toBe("cat src/foo.ts")
+		expect(attrs.model).toBe("claude-sonnet-4-6")
+	})
+
+	it("bash_tool_guard:block → bash_tool_guard.block OTLP record", async () => {
+		const { handlers, events } = await setup()
+		const { BASH_TOOL_GUARD_EVENTS } = await import("../bash-tool-guard-events.js")
+
+		events.emit(BASH_TOOL_GUARD_EVENTS.BLOCK, {
+			category: "edit",
+			matchedSegment: "sed -i 's/a/b/' foo.ts",
+			count: 2,
+		})
+		await getHandler(handlers, "session_shutdown")({ reason: "test" })
+
+		const rec = extractRecords().find((r) => r.eventName === "bash_tool_guard.block")
+		expect(rec).toBeDefined()
+		const attrs = attrsOf(rec as NonNullable<typeof rec>)
+		expect(attrs.category).toBe("edit")
+		expect(attrs.count).toBe("2")
+		expect(attrs.segment_preview).toBe("sed -i 's/a/b/' foo.ts")
+	})
+
+	it("bash_tool_guard:allowed_by_user_request → OTLP record with program", async () => {
+		const { handlers, events } = await setup()
+		const { BASH_TOOL_GUARD_EVENTS } = await import("../bash-tool-guard-events.js")
+
+		events.emit(BASH_TOOL_GUARD_EVENTS.ALLOWED_BY_USER_REQUEST, {
+			category: "read",
+			program: "cat",
+		})
+		await getHandler(handlers, "session_shutdown")({ reason: "test" })
+
+		const rec = extractRecords().find((r) => r.eventName === "bash_tool_guard.allowed_by_user_request")
+		expect(rec).toBeDefined()
+		const attrs = attrsOf(rec as NonNullable<typeof rec>)
+		expect(attrs.category).toBe("read")
+		expect(attrs.program).toBe("cat")
+	})
+
+	it("truncates long matched segments in segment_preview", async () => {
+		const { handlers, events } = await setup()
+		const { BASH_TOOL_GUARD_EVENTS } = await import("../bash-tool-guard-events.js")
+
+		const longSegment = `echo '${"x".repeat(200)}' > foo.ts`
+		events.emit(BASH_TOOL_GUARD_EVENTS.WARN, {
+			category: "write",
+			matchedSegment: longSegment,
+			count: 1,
+		})
+		await getHandler(handlers, "session_shutdown")({ reason: "test" })
+
+		const rec = extractRecords().find((r) => r.eventName === "bash_tool_guard.warn")
+		expect(rec).toBeDefined()
+		const attrs = attrsOf(rec as NonNullable<typeof rec>)
+		expect(attrs.segment_preview?.length).toBeLessThanOrEqual(80)
+	})
+
+	it("does NOT emit OTLP records when telemetry is disabled", async () => {
+		const { handlers, events } = createMockApi()
+		const { default: ext } = await import("./index.js")
+		ext(makeConfig({ enabled: false }))(handlers as unknown as ExtensionAPI)
+		// Telemetry disabled → no OTLP fetch should occur when events fire.
+		const { BASH_TOOL_GUARD_EVENTS } = await import("../bash-tool-guard-events.js")
+		// Subscribers are NOT registered when config.enabled is false, so
+		// emit() simply has no listeners and nothing reaches the network.
+		events.emit(BASH_TOOL_GUARD_EVENTS.WARN, {
+			category: "read",
+			matchedSegment: "cat foo.ts",
+			count: 1,
+		})
+		expect(fetchMock).not.toHaveBeenCalled()
+	})
+})

--- a/src/extensions/telemetry/index.ts
+++ b/src/extensions/telemetry/index.ts
@@ -435,12 +435,15 @@ function onBashGuardWarn(raw: unknown): void {
 	const ctx = _ctx
 	if (!ctx) return
 	const payload = raw as BashToolGuardWarnPayload
+	// Only structured fields land in OTLP. Raw command text is
+	// intentionally NOT emitted to avoid leaking user data or secrets
+	// that may appear inside heredocs, echo payloads, or sed/awk
+	// replacement strings. Aggregation is done by category + tool.
 	ctx.emit("bash_tool_guard.warn", {
 		model: ctx.currentModel,
 		category: payload.category,
+		tool: payload.tool,
 		count: payload.count,
-		// Trim matched segment so we don't leak huge command strings into telemetry.
-		segment_preview: payload.matchedSegment.slice(0, 80),
 	})
 }
 
@@ -453,8 +456,8 @@ function onBashGuardBlock(raw: unknown): void {
 	ctx.emit("bash_tool_guard.block", {
 		model: ctx.currentModel,
 		category: payload.category,
+		tool: payload.tool,
 		count: payload.count,
-		segment_preview: payload.matchedSegment.slice(0, 80),
 	})
 }
 
@@ -467,7 +470,7 @@ function onBashGuardAllowedByUserRequest(raw: unknown): void {
 	ctx.emit("bash_tool_guard.allowed_by_user_request", {
 		model: ctx.currentModel,
 		category: payload.category,
-		program: payload.program,
+		tool: payload.tool,
 	})
 }
 

--- a/src/extensions/telemetry/index.ts
+++ b/src/extensions/telemetry/index.ts
@@ -2,6 +2,12 @@ import type { ExtensionAPI, TurnStartEvent } from "@earendil-works/pi-coding-age
 import type { TelemetryConfig } from "../../config.js"
 import { onBeforeProviderHeaders } from "../../types/before-provider-headers.js"
 import {
+	BASH_TOOL_GUARD_EVENTS,
+	type BashToolGuardAllowedByUserRequestPayload,
+	type BashToolGuardBlockPayload,
+	type BashToolGuardWarnPayload,
+} from "../bash-tool-guard-events.js"
+import {
 	FERMENT_EVENTS,
 	type FermentAbandonedPayload,
 	type FermentCompletedPayload,
@@ -79,6 +85,11 @@ export function _resetFermentTrackingState(): void {
 	phaseStartTimes.clear()
 	stepStartTimes.clear()
 	fermentSteeringCounts.clear()
+}
+
+/** @internal — exposed for testing only */
+export function _getBashGuardCounts(): { warn: number; block: number; allowedByUserRequest: number } {
+	return { ...bashGuardCounts }
 }
 
 // ---------------------------------------------------------------------------
@@ -372,6 +383,65 @@ function onFermentSteering(raw: unknown): void {
 }
 
 // ---------------------------------------------------------------------------
+// Bash-tool-guard domain event handlers
+// ---------------------------------------------------------------------------
+
+/** Module-level accumulators for bash-tool-guard counters. Per-session. */
+const bashGuardCounts = {
+	warn: 0,
+	block: 0,
+	allowedByUserRequest: 0,
+}
+
+function resetBashGuardCounts(): void {
+	bashGuardCounts.warn = 0
+	bashGuardCounts.block = 0
+	bashGuardCounts.allowedByUserRequest = 0
+}
+
+function onBashGuardWarn(raw: unknown): void {
+	bashGuardCounts.warn++
+	if (!isEnabled()) return
+	const ctx = _ctx
+	if (!ctx) return
+	const payload = raw as BashToolGuardWarnPayload
+	ctx.emit("bash_tool_guard.warn", {
+		model: ctx.currentModel,
+		category: payload.category,
+		count: payload.count,
+		// Trim matched segment so we don't leak huge command strings into telemetry.
+		segment_preview: payload.matchedSegment.slice(0, 80),
+	})
+}
+
+function onBashGuardBlock(raw: unknown): void {
+	bashGuardCounts.block++
+	if (!isEnabled()) return
+	const ctx = _ctx
+	if (!ctx) return
+	const payload = raw as BashToolGuardBlockPayload
+	ctx.emit("bash_tool_guard.block", {
+		model: ctx.currentModel,
+		category: payload.category,
+		count: payload.count,
+		segment_preview: payload.matchedSegment.slice(0, 80),
+	})
+}
+
+function onBashGuardAllowedByUserRequest(raw: unknown): void {
+	bashGuardCounts.allowedByUserRequest++
+	if (!isEnabled()) return
+	const ctx = _ctx
+	if (!ctx) return
+	const payload = raw as BashToolGuardAllowedByUserRequestPayload
+	ctx.emit("bash_tool_guard.allowed_by_user_request", {
+		model: ctx.currentModel,
+		category: payload.category,
+		program: payload.program,
+	})
+}
+
+// ---------------------------------------------------------------------------
 // Extension factory
 // ---------------------------------------------------------------------------
 
@@ -396,7 +466,14 @@ export default function telemetryExtension(config: TelemetryConfig) {
 		pi.events.on(FERMENT_EVENTS.STEP_FAILED, onStepFailed)
 		pi.events.on(FERMENT_EVENTS.STEERING, onFermentSteering)
 
+		// Subscribe to bash-tool-guard domain events. The guard publishes
+		// facts; telemetry translates them into OTLP records for analytics.
+		pi.events.on(BASH_TOOL_GUARD_EVENTS.WARN, onBashGuardWarn)
+		pi.events.on(BASH_TOOL_GUARD_EVENTS.BLOCK, onBashGuardBlock)
+		pi.events.on(BASH_TOOL_GUARD_EVENTS.ALLOWED_BY_USER_REQUEST, onBashGuardAllowedByUserRequest)
+
 		pi.on("session_start", async (_event, extCtx) => {
+			resetBashGuardCounts()
 			const modelId = (extCtx as { model?: { id?: string } } | undefined)?.model?.id
 			handleSessionInitialized(ctx, modelId)
 		})

--- a/src/resources/definitions.test.ts
+++ b/src/resources/definitions.test.ts
@@ -70,6 +70,16 @@ describe("resource definitions", () => {
 			restartRequired: true,
 		})
 	})
+
+	it("registers bash-tool-guard as a toggleable extension", () => {
+		const resources = getResourceDefinitions()
+		expect(resources.find((resource) => resource.id === "extensions.bash-tool-guard")).toMatchObject({
+			kind: "extensions",
+			label: "Bash-tool guard",
+			defaultEnabled: true,
+			restartRequired: true,
+		})
+	})
 })
 
 function writeJson(path: string, data: unknown): void {

--- a/src/resources/definitions.test.ts
+++ b/src/resources/definitions.test.ts
@@ -73,12 +73,16 @@ describe("resource definitions", () => {
 
 	it("registers bash-tool-guard as a toggleable extension", () => {
 		const resources = getResourceDefinitions()
-		expect(resources.find((resource) => resource.id === "extensions.bash-tool-guard")).toMatchObject({
+		const resource = resources.find((r) => r.id === "extensions.bash-tool-guard")
+		expect(resource).toMatchObject({
 			kind: "extensions",
 			label: "Bash-tool guard",
 			defaultEnabled: true,
-			restartRequired: true,
 		})
+		// Toggling is dynamic — the tool_call handler consults
+		// isResourceEnabled on every bash call, so no restart is
+		// required when the user flips the /resources toggle.
+		expect(resource?.restartRequired).toBeFalsy()
 	})
 })
 

--- a/src/resources/definitions.ts
+++ b/src/resources/definitions.ts
@@ -61,6 +61,15 @@ export const STATIC_RESOURCE_DEFINITIONS: readonly ResourceDefinition[] = [
 		restartRequired: true,
 	},
 	{
+		id: "extensions.bash-tool-guard",
+		kind: "extensions",
+		label: "Bash-tool guard",
+		description:
+			"Steer the LLM away from using `bash` (cat/sed/echo) for tasks that have a dedicated read/edit/write tool. Catches read/edit/write anti-patterns and suggests the right tool.",
+		defaultEnabled: true,
+		restartRequired: true,
+	},
+	{
 		id: "extensions.claude-code-hook-adapter",
 		kind: "extensions",
 		label: "Claude Code hook adapter",

--- a/src/resources/definitions.ts
+++ b/src/resources/definitions.ts
@@ -67,7 +67,6 @@ export const STATIC_RESOURCE_DEFINITIONS: readonly ResourceDefinition[] = [
 		description:
 			"Steer the LLM away from using `bash` (cat/sed/echo) for tasks that have a dedicated read/edit/write tool. Catches read/edit/write anti-patterns and suggests the right tool.",
 		defaultEnabled: true,
-		restartRequired: true,
 	},
 	{
 		id: "extensions.claude-code-hook-adapter",


### PR DESCRIPTION
## Description

<!-- What problem does this PR solve? What changes were made and why? -->

This is an opinionated direction, we MUST always steer models to use Read, Edit, Write instead of sed, grep, cat or whatever they would use to read and edit files. WHY? Because using full bash is error prone and creates unnecessary errors and loops and worse it does not activate LSP.

## Type of Change

Introducing a bash tool guard that steers LLM to prefer using read, edit and write, added telemetry for us to track this. The user can opt out and and if explicitly say `use cat` to read file it skips guard

<!-- Select all that apply. -->

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Documentation update
