### PR TITLE
Fix model metadata retry calls

### DIFF
--- a/src/models.test.ts
+++ b/src/models.test.ts
@@ -311,30 +311,6 @@ describe("updateModelsConfig", () => {
 		expect(result.models.map((m) => m.slug)).toEqual(["kimi-k2.5"])
 	})
 
-	it("classifies a persistent timeout as transient after exhausting retries", async () => {
-		vi.mocked(fetch).mockRejectedValue(new Error("The operation timed out."))
-
-		const error = await updateModelsConfig(modelsJsonPath, "test-key", { sleep: async () => {} }).catch((e) => e)
-
-		expect(error).toBeInstanceOf(ModelsFetchError)
-		expect(isTransientModelsError(error)).toBe(true)
-		expect((error as Error).message).toContain("timed out")
-		expect(fetch).toHaveBeenCalledTimes(3)
-	})
-
-	it("uses a 20s timeout to tolerate slow ingress", async () => {
-		const timeoutSpy = vi.spyOn(AbortSignal, "timeout")
-		vi.mocked(fetch).mockResolvedValueOnce({
-			ok: true,
-			json: async () => ({ models: [KIMI] }),
-		} as Response)
-
-		await updateModelsConfig(modelsJsonPath, "test-key")
-
-		expect(timeoutSpy).toHaveBeenCalledWith(20000)
-		timeoutSpy.mockRestore()
-	})
-
 	it("throws on non-ok response when no cached config exists", async () => {
 		vi.mocked(fetch).mockResolvedValueOnce({
 			ok: false,

--- a/src/models.test.ts
+++ b/src/models.test.ts
@@ -273,9 +273,66 @@ describe("updateModelsConfig", () => {
 		expect(written.providers.openai.models).toHaveLength(1)
 	})
 
-	it("throws on fetch failure when no cached config exists", async () => {
-		vi.mocked(fetch).mockRejectedValueOnce(new Error("network error"))
-		await expect(updateModelsConfig(modelsJsonPath, "test-key")).rejects.toThrow("network error")
+	it("throws after exhausting retries on network errors when no cache exists", async () => {
+		vi.mocked(fetch).mockRejectedValue(new Error("network error"))
+		const error = await updateModelsConfig(modelsJsonPath, "test-key", { sleep: async () => {} }).catch((e) => e)
+
+		expect(error).toBeInstanceOf(ModelsFetchError)
+		expect(isTransientModelsError(error)).toBe(true)
+		expect((error as Error).message).toContain("network error")
+		expect(fetch).toHaveBeenCalledTimes(3)
+	})
+
+	it("retries a network error and succeeds on a later attempt", async () => {
+		vi.mocked(fetch)
+			.mockRejectedValueOnce(new Error("ECONNREFUSED"))
+			.mockResolvedValueOnce({
+				ok: true,
+				json: async () => ({ models: [KIMI] }),
+			} as Response)
+
+		const result = await updateModelsConfig(modelsJsonPath, "test-key", { sleep: async () => {} })
+
+		expect(fetch).toHaveBeenCalledTimes(2)
+		expect(result.models.map((m) => m.slug)).toEqual(["kimi-k2.5"])
+	})
+
+	it("retries a timeout error and succeeds on a later attempt", async () => {
+		vi.mocked(fetch)
+			.mockRejectedValueOnce(new Error("The operation timed out."))
+			.mockResolvedValueOnce({
+				ok: true,
+				json: async () => ({ models: [KIMI] }),
+			} as Response)
+
+		const result = await updateModelsConfig(modelsJsonPath, "test-key", { sleep: async () => {} })
+
+		expect(fetch).toHaveBeenCalledTimes(2)
+		expect(result.models.map((m) => m.slug)).toEqual(["kimi-k2.5"])
+	})
+
+	it("classifies a persistent timeout as transient after exhausting retries", async () => {
+		vi.mocked(fetch).mockRejectedValue(new Error("The operation timed out."))
+
+		const error = await updateModelsConfig(modelsJsonPath, "test-key", { sleep: async () => {} }).catch((e) => e)
+
+		expect(error).toBeInstanceOf(ModelsFetchError)
+		expect(isTransientModelsError(error)).toBe(true)
+		expect((error as Error).message).toContain("timed out")
+		expect(fetch).toHaveBeenCalledTimes(3)
+	})
+
+	it("uses a 20s timeout to tolerate slow ingress", async () => {
+		const timeoutSpy = vi.spyOn(AbortSignal, "timeout")
+		vi.mocked(fetch).mockResolvedValueOnce({
+			ok: true,
+			json: async () => ({ models: [KIMI] }),
+		} as Response)
+
+		await updateModelsConfig(modelsJsonPath, "test-key")
+
+		expect(timeoutSpy).toHaveBeenCalledWith(20000)
+		timeoutSpy.mockRestore()
 	})
 
 	it("throws on non-ok response when no cached config exists", async () => {
@@ -380,6 +437,40 @@ describe("updateModelsConfig", () => {
 		const result = await updateModelsConfig(modelsJsonPath, "test-key")
 
 		expect(result.models.map((m) => m.slug)).toEqual(["kimi-k2.5", "claude-sonnet-4-6", "gpt-4"])
+	})
+
+	it("falls back to cached metadata after exhausting network retries", async () => {
+		const OPENAI_MODEL = {
+			id: "gpt-4",
+			name: "GPT-4",
+			reasoning: false,
+			input: ["text"],
+			contextWindow: 8192,
+			maxTokens: 4096,
+			cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+			provider: "openai",
+		}
+
+		// Seed cache with a successful fetch
+		vi.mocked(fetch).mockResolvedValueOnce({
+			ok: true,
+			json: async () => ({ models: [KIMI, SONNET_46] }),
+		} as Response)
+		await updateModelsConfig(modelsJsonPath, "test-key")
+		const config = JSON.parse(readFileSync(modelsJsonPath, "utf-8"))
+		config.providers.openai = { models: [OPENAI_MODEL] }
+		writeFileSync(modelsJsonPath, JSON.stringify(config))
+		vi.mocked(fetch).mockClear()
+
+		// All retry attempts fail — proves fallback works after retry exhaustion
+		vi.mocked(fetch).mockRejectedValue(new Error("network down"))
+
+		const result = await updateModelsConfig(modelsJsonPath, "test-key", { sleep: async () => {} })
+
+		// Cache + custom provider are returned
+		expect(result.models.map((m) => m.slug)).toEqual(["kimi-k2.5", "claude-sonnet-4-6", "gpt-4"])
+		// Confirms retry exhaustion actually happened (3 attempts, no success)
+		expect(fetch).toHaveBeenCalledTimes(3)
 	})
 
 	it("falls back to cached metadata when API returns empty list", async () => {

--- a/src/models.ts
+++ b/src/models.ts
@@ -59,21 +59,15 @@ export interface FetchModelsOptions {
 
 const defaultSleep = (ms: number): Promise<void> => new Promise((resolve) => setTimeout(resolve, ms))
 
-/** Plain exponential backoff (ms), capped at MAX_RETRY_DELAY_MS. */
-function exponentialBackoffMs(attempt: number): number {
-	return Math.min(BASE_RETRY_DELAY_MS * 2 ** (attempt - 1), MAX_RETRY_DELAY_MS)
-}
-
-/** Delay before the next retry, honoring a `Retry-After` header when present. */
-function retryDelayMs(response: Response, attempt: number): number {
-	const header = response.headers?.get?.("retry-after")
-	if (header) {
-		const seconds = Number(header)
+// Delay before the next retry, honoring a `Retry-After` header when present.
+function retryDelayMs(retryAfterHeader: string | null, attempt: number): number {
+	if (retryAfterHeader) {
+		const seconds = Number(retryAfterHeader)
 		if (Number.isFinite(seconds) && seconds >= 0) return Math.min(seconds * 1000, MAX_RETRY_DELAY_MS)
-		const dateMs = Date.parse(header)
+		const dateMs = Date.parse(retryAfterHeader)
 		if (!Number.isNaN(dateMs)) return Math.min(Math.max(dateMs - Date.now(), 0), MAX_RETRY_DELAY_MS)
 	}
-	return exponentialBackoffMs(attempt)
+	return Math.min(BASE_RETRY_DELAY_MS * 2 ** (attempt - 1), MAX_RETRY_DELAY_MS)
 }
 
 export interface ModelMetadata {
@@ -119,7 +113,7 @@ async function fetchAvailableModels(apiKey: string, options: FetchModelsOptions 
 					transient: true,
 				})
 			}
-			await sleep(exponentialBackoffMs(attempt))
+			await sleep(retryDelayMs(null, attempt))
 			continue
 		}
 
@@ -140,7 +134,7 @@ async function fetchAvailableModels(apiKey: string, options: FetchModelsOptions 
 			transient,
 		})
 		if (!transient || attempt === MAX_FETCH_ATTEMPTS) throw lastError
-		await sleep(retryDelayMs(response, attempt))
+		await sleep(retryDelayMs(response.headers?.get?.("retry-after"), attempt))
 	}
 
 	// Unreachable: the loop returns on success or throws on the final attempt.

--- a/src/models.ts
+++ b/src/models.ts
@@ -3,7 +3,7 @@ import { dirname } from "node:path"
 import { getVersion } from "./utils.js"
 
 const KIMCHI_API = "https://llm.kimchi.dev"
-const FETCH_TIMEOUT_MS = 5000
+const FETCH_TIMEOUT_MS = 20000
 
 function normalizeKimchiEndpoint(endpoint?: string): string {
 	const trimmed = endpoint?.trim()
@@ -59,6 +59,11 @@ export interface FetchModelsOptions {
 
 const defaultSleep = (ms: number): Promise<void> => new Promise((resolve) => setTimeout(resolve, ms))
 
+/** Plain exponential backoff (ms), capped at MAX_RETRY_DELAY_MS. */
+function exponentialBackoffMs(attempt: number): number {
+	return Math.min(BASE_RETRY_DELAY_MS * 2 ** (attempt - 1), MAX_RETRY_DELAY_MS)
+}
+
 /** Delay before the next retry, honoring a `Retry-After` header when present. */
 function retryDelayMs(response: Response, attempt: number): number {
 	const header = response.headers?.get?.("retry-after")
@@ -68,7 +73,7 @@ function retryDelayMs(response: Response, attempt: number): number {
 		const dateMs = Date.parse(header)
 		if (!Number.isNaN(dateMs)) return Math.min(Math.max(dateMs - Date.now(), 0), MAX_RETRY_DELAY_MS)
 	}
-	return Math.min(BASE_RETRY_DELAY_MS * 2 ** (attempt - 1), MAX_RETRY_DELAY_MS)
+	return exponentialBackoffMs(attempt)
 }
 
 export interface ModelMetadata {
@@ -109,11 +114,13 @@ async function fetchAvailableModels(apiKey: string, options: FetchModelsOptions 
 				signal: AbortSignal.timeout(FETCH_TIMEOUT_MS),
 			})
 		} catch (err) {
-			// Network/timeout failures are transient; surface them so the caller can
-			// offer a retry rather than discarding the user's saved API key.
-			throw new ModelsFetchError(`Failed to fetch models: ${err instanceof Error ? err.message : String(err)}`, {
-				transient: true,
-			})
+			if (attempt === MAX_FETCH_ATTEMPTS) {
+				throw new ModelsFetchError(`Failed to fetch models: ${err instanceof Error ? err.message : String(err)}`, {
+					transient: true,
+				})
+			}
+			await sleep(exponentialBackoffMs(attempt))
+			continue
 		}
 
 		if (response.ok) {


### PR DESCRIPTION
## Description

Adresses slow model metadata loading: 
- increase the timeout to 20s
- add retries

## Type of Change

<!-- Select all that apply. -->

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
