### PR TITLE
LLM-1890: Handle string int64 in analytics

### DIFF
--- a/src/extensions/stats/display.ts
+++ b/src/extensions/stats/display.ts
@@ -45,8 +45,8 @@ export function formatAnalyticsSummary(data: GenerateAnalyticsResponse, theme: T
 		for (const item of data.tokens.items) {
 			if (item.models) {
 				for (const model of item.models) {
-					totalInput += model.inputTokens || 0
-					totalOutput += model.outputTokens || 0
+					totalInput += Number(model.inputTokens) || 0
+					totalOutput += Number(model.outputTokens) || 0
 				}
 			}
 		}

--- a/src/extensions/stats/display.ts
+++ b/src/extensions/stats/display.ts
@@ -5,6 +5,7 @@
 import type { Theme } from "@earendil-works/pi-coding-agent"
 import { formatCount } from "../format.js"
 import type { GenerateAnalyticsResponse, GetProductivityMetricsResponse } from "./types.js"
+import { aggregateTokens } from "./visual.js"
 
 function formatCurrency(amount: string | number): string {
 	const num = typeof amount === "string" ? Number.parseFloat(amount) : amount
@@ -38,20 +39,9 @@ export function formatAnalyticsSummary(data: GenerateAnalyticsResponse, theme: T
 	lines.push(theme.bold(theme.fg("accent", "📊 Analytics (Last 30 Days)")))
 
 	// Token usage section
-	let totalInput = 0
-	let totalOutput = 0
-
-	if (data.tokens?.items) {
-		for (const item of data.tokens.items) {
-			if (item.models) {
-				for (const model of item.models) {
-					totalInput += Number(model.inputTokens) || 0
-					totalOutput += Number(model.outputTokens) || 0
-				}
-			}
-		}
-	}
-
+	const { totals } = aggregateTokens(data)
+	const totalInput = totals.totalInput
+	const totalOutput = totals.totalOutput
 	const total = totalInput + totalOutput
 
 	// Cost section

--- a/src/extensions/stats/stats.test.ts
+++ b/src/extensions/stats/stats.test.ts
@@ -402,6 +402,44 @@ describe("formatAnalyticsVisual", () => {
 
 		expect(joined).toContain("500")
 	})
+
+	it("coerces string int64 token values from protobuf JSON encoding", () => {
+		// Protobuf JSON encodes int64 as strings (e.g. "9007199254740993") because
+		// JavaScript Number can't safely represent integers > 2^53. The formatter
+		// must parse these strings before aggregating.
+		const data: GenerateAnalyticsResponse = {
+			stepDuration: "0s",
+			tokens: {
+				items: [
+					{
+						executionTime: "2026-06-09T09:00:00Z",
+						models: [
+							makeModelTokenStat({
+								model: "gpt-4",
+								providerName: "pi-otel",
+								inputTokens: "1000",
+								outputTokens: "500",
+							}),
+							makeModelTokenStat({
+								model: "claude-3",
+								providerName: "pi-otel",
+								inputTokens: "2000",
+								outputTokens: "1000",
+							}),
+						],
+					},
+				],
+			},
+		}
+
+		const lines = formatAnalyticsVisual(data, mockTheme)
+		const joined = lines.join("\n")
+
+		// Total input across all models: 3000, output: 1500
+		expect(joined).toContain("4.5k")
+		expect(joined).toContain("3.0k")
+		expect(joined).toContain("1.5k")
+	})
 })
 
 describe("formatAnalyticsSummary", () => {
@@ -439,6 +477,37 @@ describe("formatAnalyticsSummary", () => {
 								providerName: "pi-otel",
 								inputTokens: 3000,
 								outputTokens: 1500,
+							}),
+						],
+					},
+				],
+			},
+		}
+
+		const lines = formatAnalyticsSummary(data, mockTheme)
+		const joined = lines.join("\n")
+
+		expect(joined).toContain("4.5k")
+		expect(joined).toContain("3.0k")
+		expect(joined).toContain("1.5k")
+	})
+
+	it("coerces string int64 token values from protobuf JSON encoding", () => {
+		// Protobuf JSON encodes int64 as strings (e.g. "9007199254740993") because
+		// JavaScript Number can't safely represent integers > 2^53. The formatter
+		// must parse these strings before aggregating.
+		const data: GenerateAnalyticsResponse = {
+			stepDuration: "0s",
+			tokens: {
+				items: [
+					{
+						executionTime: "2026-06-09T09:00:00Z",
+						models: [
+							makeModelTokenStat({
+								model: "gpt-4",
+								providerName: "pi-otel",
+								inputTokens: "3000",
+								outputTokens: "1500",
 							}),
 						],
 					},

--- a/src/extensions/stats/stats.test.ts
+++ b/src/extensions/stats/stats.test.ts
@@ -7,6 +7,7 @@ import { parseStatsArgs } from "./index.js"
 import type { GenerateAnalyticsResponse } from "./types.js"
 import {
 	type SortBy,
+	aggregateTokens,
 	formatAnalyticsVisual,
 	formatCurrency,
 	getProviderDisplayName,
@@ -404,9 +405,10 @@ describe("formatAnalyticsVisual", () => {
 	})
 
 	it("coerces string int64 token values from protobuf JSON encoding", () => {
-		// Protobuf JSON encodes int64 as strings (e.g. "9007199254740993") because
-		// JavaScript Number can't safely represent integers > 2^53. The formatter
-		// must parse these strings before aggregating.
+		// Protobuf JSON encodes int64 as strings (e.g. "9007199254740991",
+		// i.e. Number.MAX_SAFE_INTEGER) because JavaScript Number can't safely
+		// represent integers > 2^53. The formatter must parse these strings
+		// before aggregating.
 		const data: GenerateAnalyticsResponse = {
 			stepDuration: "0s",
 			tokens: {
@@ -439,6 +441,17 @@ describe("formatAnalyticsVisual", () => {
 		expect(joined).toContain("4.5k")
 		expect(joined).toContain("3.0k")
 		expect(joined).toContain("1.5k")
+
+		// Pin down the numeric aggregation directly so a regression that
+		// breaks per-row totals (but still renders valid k/M suffixes) is
+		// caught here too, not just the totals row.
+		const aggregated = aggregateTokens(data)
+		expect(aggregated.totals.totalInput).toBe(3000)
+		expect(aggregated.totals.totalOutput).toBe(1500)
+		expect(aggregated.perModel.get("gpt-4\tKimchi")?.inputTokens).toBe(1000)
+		expect(aggregated.perModel.get("gpt-4\tKimchi")?.outputTokens).toBe(500)
+		expect(aggregated.perModel.get("claude-3\tKimchi")?.inputTokens).toBe(2000)
+		expect(aggregated.perModel.get("claude-3\tKimchi")?.outputTokens).toBe(1000)
 	})
 })
 
@@ -493,9 +506,10 @@ describe("formatAnalyticsSummary", () => {
 	})
 
 	it("coerces string int64 token values from protobuf JSON encoding", () => {
-		// Protobuf JSON encodes int64 as strings (e.g. "9007199254740993") because
-		// JavaScript Number can't safely represent integers > 2^53. The formatter
-		// must parse these strings before aggregating.
+		// Protobuf JSON encodes int64 as strings (e.g. "9007199254740991",
+		// i.e. Number.MAX_SAFE_INTEGER) because JavaScript Number can't safely
+		// represent integers > 2^53. The formatter must parse these strings
+		// before aggregating.
 		const data: GenerateAnalyticsResponse = {
 			stepDuration: "0s",
 			tokens: {
@@ -521,5 +535,13 @@ describe("formatAnalyticsSummary", () => {
 		expect(joined).toContain("4.5k")
 		expect(joined).toContain("3.0k")
 		expect(joined).toContain("1.5k")
+
+		// Pin down the numeric aggregation directly so a regression in the
+		// aggregation loop is caught by the helper, not just the rendered row.
+		const aggregated = aggregateTokens(data)
+		expect(aggregated.totals.totalInput).toBe(3000)
+		expect(aggregated.totals.totalOutput).toBe(1500)
+		expect(aggregated.perModel.get("gpt-4\tKimchi")?.inputTokens).toBe(3000)
+		expect(aggregated.perModel.get("gpt-4\tKimchi")?.outputTokens).toBe(1500)
 	})
 })

--- a/src/extensions/stats/types.ts
+++ b/src/extensions/stats/types.ts
@@ -65,11 +65,11 @@ export interface ModelTokenStat {
 	provider: string
 	castaiApiKey: string
 	providerName: string
-	inputTokens: number
-	outputTokens: number
-	totalTokens: number
-	cacheReadTokens: number
-	cacheWriteTokens: number
+	inputTokens: number | string
+	outputTokens: number | string
+	totalTokens: number | string
+	cacheReadTokens: number | string
+	cacheWriteTokens: number | string
 	castaiApiKeyMetadata: CastAiApiKeyMetadata
 }
 
@@ -130,7 +130,7 @@ export interface ModelStatItem {
 	provider: string
 	castaiApiKey: string
 	providerName: string
-	totalCount: number
+	totalCount: number | string
 	castaiApiKeyMetadata: CastAiApiKeyMetadata
 }
 

--- a/src/extensions/stats/visual.ts
+++ b/src/extensions/stats/visual.ts
@@ -155,8 +155,8 @@ export function formatAnalyticsVisual(
 						inputCost: 0,
 						outputCost: 0,
 					}
-					stats.inputTokens += model.inputTokens || 0
-					stats.outputTokens += model.outputTokens || 0
+					stats.inputTokens += Number(model.inputTokens) || 0
+					stats.outputTokens += Number(model.outputTokens) || 0
 					modelStats.set(key, stats)
 				}
 			}

--- a/src/extensions/stats/visual.ts
+++ b/src/extensions/stats/visual.ts
@@ -53,6 +53,59 @@ export function getSourceName(providerName: string): string {
 	return mapping[providerName] || "Proxy"
 }
 
+export interface TokenTotals {
+	totalInput: number
+	totalOutput: number
+}
+
+export interface PerModelTokenStats {
+	model: string
+	source: string
+	inputTokens: number
+	outputTokens: number
+}
+
+/**
+ * Aggregates token counts from `data.tokens.items[].models[]`, coercing
+ * string-encoded int64 values (protobuf JSON) to numbers. Returns both
+ * the grand totals and a per-model+source breakdown so callers can do
+ * numeric aggregation without re-parsing the raw API payload. Exposed
+ * for direct testing of the aggregation in isolation from formatting.
+ */
+export function aggregateTokens(data: GenerateAnalyticsResponse): {
+	totals: TokenTotals
+	perModel: Map<string, PerModelTokenStats>
+} {
+	const totals: TokenTotals = { totalInput: 0, totalOutput: 0 }
+	const perModel = new Map<string, PerModelTokenStats>()
+
+	if (!data.tokens?.items) return { totals, perModel }
+
+	for (const item of data.tokens.items) {
+		if (!item.models) continue
+		for (const model of item.models) {
+			const input = Number(model.inputTokens) || 0
+			const output = Number(model.outputTokens) || 0
+			totals.totalInput += input
+			totals.totalOutput += output
+
+			const source = getSourceName(model.providerName)
+			const key = `${model.model}\t${source}`
+			const existing = perModel.get(key) || {
+				model: model.model,
+				source,
+				inputTokens: 0,
+				outputTokens: 0,
+			}
+			existing.inputTokens += input
+			existing.outputTokens += output
+			perModel.set(key, existing)
+		}
+	}
+
+	return { totals, perModel }
+}
+
 export type SortBy = "cost" | "tokens" | "model" | "source"
 
 type SortStats = {
@@ -141,25 +194,20 @@ export function formatAnalyticsVisual(
 	}
 
 	if (data.tokens?.items) {
-		for (const item of data.tokens.items) {
-			if (item.models) {
-				for (const model of item.models) {
-					const source = getSourceName(model.providerName)
-					const key = `${model.model}\t${source}`
-					const stats = modelStats.get(key) || {
-						modelName: model.model,
-						source,
-						cost: 0,
-						inputTokens: 0,
-						outputTokens: 0,
-						inputCost: 0,
-						outputCost: 0,
-					}
-					stats.inputTokens += Number(model.inputTokens) || 0
-					stats.outputTokens += Number(model.outputTokens) || 0
-					modelStats.set(key, stats)
-				}
+		const { perModel } = aggregateTokens(data)
+		for (const [key, tokens] of perModel) {
+			const stats = modelStats.get(key) || {
+				modelName: tokens.model,
+				source: tokens.source,
+				cost: 0,
+				inputTokens: 0,
+				outputTokens: 0,
+				inputCost: 0,
+				outputCost: 0,
 			}
+			stats.inputTokens += tokens.inputTokens
+			stats.outputTokens += tokens.outputTokens
+			modelStats.set(key, stats)
 		}
 	}
 


### PR DESCRIPTION
## Description

Handle `int64` returned by analytics endpoints encoded as `string`. This should be backward compatible.

## Type of Change

<!-- Select all that apply. -->

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
