### PR TITLE
fix: prevent crash when typing in the GitHub Copilot login dialog (#616)

### DIFF
--- a/src/extensions/login/flow.test.ts
+++ b/src/extensions/login/flow.test.ts
@@ -1,0 +1,47 @@
+import { LoginDialogComponent, initTheme } from "@earendil-works/pi-coding-agent"
+import type { TUI } from "@earendil-works/pi-tui"
+import { beforeAll, describe, expect, it, vi } from "vitest"
+
+import { SwappableAuthComponent } from "./flow.js"
+
+beforeAll(() => {
+	initTheme("default")
+})
+
+function createTui(): TUI {
+	return { requestRender: vi.fn() } as unknown as TUI
+}
+
+describe("SwappableAuthComponent", () => {
+	// Regression for https://github.com/getkimchi/kimchi/issues/616: the subscription
+	// (GitHub Copilot) login path hosts a LoginDialogComponent inside SwappableAuthComponent.
+	// Typing any non-Escape character forwards the byte to the hosted LoginDialogComponent,
+	// whose handleInput dereferences `this.input`. If the forward drops the `this` binding,
+	// that runs with `this === undefined` and crashes.
+	it("forwards a typed character to the real login dialog without crashing", () => {
+		const tui = createTui()
+		const host = new SwappableAuthComponent(tui)
+		const dialog = new LoginDialogComponent(tui, "github-copilot", () => {}, "GitHub Copilot")
+		host.set(dialog)
+
+		expect(() => host.handleInput("a")).not.toThrow()
+	})
+
+	// Pinpoints the root cause directly: the hosted component must be invoked as a method so
+	// `this` stays bound to it. Fails loudly if the forward ever regresses to a detached bare call.
+	it("invokes the hosted component with `this` bound to that component", () => {
+		const tui = createTui()
+		const host = new SwappableAuthComponent(tui)
+		let receivedThis: unknown
+		const child = {
+			handleInput(this: unknown): void {
+				receivedThis = this
+			},
+		}
+		host.set(child)
+
+		host.handleInput("a")
+
+		expect(receivedThis).toBe(child)
+	})
+})

--- a/src/extensions/login/flow.ts
+++ b/src/extensions/login/flow.ts
@@ -443,7 +443,7 @@ export function getSubscriptionProviderOptions(
 		.sort((a, b) => a.name.localeCompare(b.name))
 }
 
-class SwappableAuthComponent extends Container {
+export class SwappableAuthComponent extends Container {
 	private current: unknown
 	private _focused = false
 
@@ -469,8 +469,8 @@ class SwappableAuthComponent extends Container {
 	}
 
 	handleInput(data: string): void {
-		const inputHandler = (this.current as { handleInput?: (data: string) => void } | undefined)?.handleInput
-		inputHandler?.(data)
+		const child = this.current as { handleInput?: (data: string) => void } | undefined
+		child?.handleInput?.(data)
 	}
 
 	private setChildFocused(focused: boolean): void {


### PR DESCRIPTION
## Summary

Fixes #616 — Kimchi crashed on the **first character typed** while logging in with a GitHub Copilot subscription:

```
TypeError: undefined is not an object (evaluating 'this.input')
    at handleInput (.../kimchi:252734:11)   ← LoginDialogComponent.handleInput
    at handleInput (.../kimchi:280513:21)   ← SwappableAuthComponent.handleInput
    ...
```

The root cause is a lost `this` binding when forwarding keystrokes from `SwappableAuthComponent` to the hosted login dialog. One line fixes it.

## Why it crashed

The subscription (GitHub Copilot) login flow hosts a `LoginDialogComponent` inside `SwappableAuthComponent` and forwards terminal input to it. The forward extracted the child's method into a local variable and called it **detached**:

```ts
// before
handleInput(data: string): void {
  const inputHandler = (this.current as { handleInput?: (data: string) => void } | undefined)?.handleInput
  inputHandler?.(data)   // ⚠️ called detached — `this` is lost
}
```

In JavaScript, reading a method off an object and then calling the stored reference does **not** preserve the receiver. Inside the call, `this` is `undefined` (strict mode / ESM):

```ts
const child = {
  value: 1,
  handleInput(data) { console.log(this.value) },
}

const inputHandler = child.handleInput
inputHandler("x")   // 💥 `this` is undefined — not `child`
```

That's exactly what bites us here. `LoginDialogComponent.handleInput` passes any non-cancel key to its text input:

```ts
handleInput(data) {
  const kb = getKeybindings()
  if (kb.matches(data, "tui.select.cancel")) { this.cancel(); return }
  this.input.handleInput(data)   // 💥 `this` is undefined → reading `.input` throws
}
```

So pressing Escape happened to work (it returns before touching `this.input`), but typing **any** character fell through to `this.input.handleInput(data)` and threw — matching the repro in the issue exactly. The uncaught exception then propagated to pi's process-level `uncaughtException` handler, which tore down the TUI and printed the raw stack trace.

This only affected the **subscription / GitHub Copilot** path because that's the one that wraps the dialog in `SwappableAuthComponent`. The "Use a Kimchi account" path returns the `LoginDialogComponent` directly, so `this` was never lost there.

## The fix

Call the method **on the object** so JavaScript binds the receiver:

```ts
// after
handleInput(data: string): void {
  const child = this.current as { handleInput?: (data: string) => void } | undefined
  child?.handleInput?.(data)   // ✅ `this` === child inside the call
}
```

`child?.handleInput?.(data)` keeps the call attached to `child`, so inside `handleInput`, `this === child` and `this.input` resolves correctly. The `?.` chaining preserves the original behavior of silently no-op'ing when `current` is unset or has no `handleInput`.

| | Detached (before) | Attached (after) |
|---|---|---|
| Call form | `const fn = obj.handleInput; fn(data)` | `obj?.handleInput?.(data)` |
| `this` inside | `undefined` | the component |
| Result for Copilot login | 💥 crash on first keystroke | works |

## Tests

Added `src/extensions/login/flow.test.ts`:

- **`forwards a typed character to the real login dialog without crashing`** — drives a real `LoginDialogComponent` (the exact #616 scenario) and asserts typing a character does not throw.
- **`invokes the hosted component with \`this\` bound to that component`** — pins the root cause directly, so it fails loudly if the forward ever regresses to a detached bare call.

Verified red→green: reintroducing the detached call makes **both** tests fail; restoring the fix makes them pass.

## Verification

- `tsc --noEmit` — clean
- `biome check` — clean
- `vitest run --dir src` — full suite green (login suite + the new tests)