### PR TITLE
fix(clipboard): replace Linux native addon with xclip/wl-paste subprocess to fix X11 connection leak

### DIFF
--- a/src/utils/clipboard-linux-routing.test.ts
+++ b/src/utils/clipboard-linux-routing.test.ts
@@ -1,0 +1,100 @@
+/**
+ * Red-green regression tests for the Linux clipboard subprocess routing.
+ *
+ * These tests run only on Linux (CI workers are Linux-based). They verify
+ * that getNativeClipboard() routes through the xclip/wl-paste subprocess
+ * shim rather than the native .node addon. If the routing is removed or
+ * reverted, these tests fail.
+ *
+ * Strategy: mock node:child_process (so spawnSync is interceptable) but do
+ * NOT mock clipboard-native-harness — load the real module to exercise the
+ * actual routing logic.
+ */
+import { spawnSync } from "node:child_process"
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
+
+vi.mock("node:child_process", () => ({ spawnSync: vi.fn() }))
+
+const mockSpawn = vi.mocked(spawnSync)
+
+function stubSpawn(stdout: string, status = 0) {
+	// biome-ignore lint/suspicious/noExplicitAny: test mock
+	mockSpawn.mockReturnValue({ stdout, stderr: "", status, pid: 1, signal: null, output: [] } as any)
+}
+
+beforeEach(() => {
+	vi.resetModules()
+	vi.clearAllMocks()
+	stubSpawn("image/png\ntext/plain\n")
+})
+
+afterEach(() => {
+	vi.unstubAllEnvs()
+})
+
+describe("Linux clipboard subprocess routing", () => {
+	it("returns subprocess-backed clipboard on X11 Linux", async () => {
+		if (process.platform !== "linux") return
+
+		vi.stubEnv("DISPLAY", ":0")
+		vi.stubEnv("WAYLAND_DISPLAY", "")
+		vi.stubEnv("WSL_DISTRO_NAME", "")
+		vi.stubEnv("WSL_INTEROP", "")
+		vi.stubEnv("TERMUX_VERSION", "")
+		vi.stubEnv("KIMCHI_CLIPBOARD_FORCE", "")
+
+		const { getNativeClipboard } = await import("./clipboard-native-harness.js")
+		const { clipboard } = getNativeClipboard()
+
+		expect(clipboard).not.toBeNull()
+		expect(typeof clipboard?.availableFormats).toBe("function")
+		expect(typeof clipboard?.hasImage).toBe("function")
+		expect(typeof clipboard?.getImageBinary).toBe("function")
+	})
+
+	it("invokes xclip for availableFormats on X11", async () => {
+		if (process.platform !== "linux") return
+
+		vi.stubEnv("DISPLAY", ":0")
+		vi.stubEnv("WAYLAND_DISPLAY", "")
+		vi.stubEnv("WSL_DISTRO_NAME", "")
+		vi.stubEnv("WSL_INTEROP", "")
+		vi.stubEnv("TERMUX_VERSION", "")
+
+		const { getNativeClipboard } = await import("./clipboard-native-harness.js")
+		const { clipboard } = getNativeClipboard()
+		clipboard?.availableFormats()
+
+		expect(mockSpawn).toHaveBeenCalledWith(
+			"xclip",
+			["-selection", "clipboard", "-t", "TARGETS", "-o"],
+			expect.objectContaining({ encoding: "utf8" }),
+		)
+	})
+
+	it("invokes wl-paste for availableFormats on Wayland", async () => {
+		if (process.platform !== "linux") return
+
+		vi.stubEnv("WAYLAND_DISPLAY", "wayland-0")
+		vi.stubEnv("DISPLAY", "")
+		vi.stubEnv("WSL_DISTRO_NAME", "")
+		vi.stubEnv("WSL_INTEROP", "")
+		vi.stubEnv("TERMUX_VERSION", "")
+
+		const { getNativeClipboard } = await import("./clipboard-native-harness.js")
+		const { clipboard } = getNativeClipboard()
+		clipboard?.availableFormats()
+
+		expect(mockSpawn).toHaveBeenCalledWith("wl-paste", ["--list-types"], expect.objectContaining({ encoding: "utf8" }))
+	})
+
+	it("does not call spawnSync on non-Linux platforms", async () => {
+		if (process.platform === "linux") return
+
+		const { getNativeClipboard } = await import("./clipboard-native-harness.js")
+		getNativeClipboard()
+
+		// Non-Linux should not touch xclip/wl-paste at all
+		expect(mockSpawn).not.toHaveBeenCalled()
+	})
+})

--- a/src/utils/clipboard-linux-subprocess.test.ts
+++ b/src/utils/clipboard-linux-subprocess.test.ts
@@ -1,0 +1,80 @@
+import { spawnSync } from "node:child_process"
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
+
+vi.mock("node:child_process", () => ({ spawnSync: vi.fn() }))
+
+const mockSpawn = vi.mocked(spawnSync)
+
+function mockSpawnResult(stdout: string, status = 0) {
+	// biome-ignore lint/suspicious/noExplicitAny: test mock
+	mockSpawn.mockReturnValue({ stdout, stderr: "", status, pid: 1, signal: null, output: [] } as any)
+}
+
+beforeEach(() => {
+	vi.resetModules()
+	vi.clearAllMocks()
+})
+
+afterEach(() => {
+	vi.unstubAllEnvs()
+})
+
+async function freshShim() {
+	const mod = await import("./clipboard-linux-subprocess.js")
+	return mod.createLinuxClipboard()
+}
+
+describe("availableFormats — X11", () => {
+	beforeEach(() => {
+		vi.stubEnv("WAYLAND_DISPLAY", "")
+		vi.stubEnv("DISPLAY", ":0")
+	})
+
+	it("returns MIME types from xclip TARGETS output", async () => {
+		mockSpawnResult("TARGETS\nimage/png\ntext/plain\n")
+		const cb = await freshShim()
+		const formats = cb.availableFormats()
+		expect(formats).toContain("image/png")
+		expect(formats).toContain("text/plain")
+		expect(formats).not.toContain("TARGETS")
+	})
+
+	it("returns empty array when xclip fails", async () => {
+		// biome-ignore lint/suspicious/noExplicitAny: test mock
+		mockSpawn.mockReturnValue({ stdout: "", stderr: "error", status: 1, pid: 1, signal: null, output: [] } as any)
+		const cb = await freshShim()
+		expect(cb.availableFormats()).toEqual([])
+	})
+
+	it("calls xclip with correct args", async () => {
+		mockSpawnResult("image/png\n")
+		const cb = await freshShim()
+		cb.availableFormats()
+		expect(mockSpawn).toHaveBeenCalledWith(
+			"xclip",
+			["-selection", "clipboard", "-t", "TARGETS", "-o"],
+			expect.objectContaining({ encoding: "utf8" }),
+		)
+	})
+})
+
+describe("availableFormats — Wayland", () => {
+	beforeEach(() => {
+		vi.stubEnv("WAYLAND_DISPLAY", "wayland-0")
+		vi.stubEnv("DISPLAY", "")
+	})
+
+	it("returns MIME types from wl-paste output", async () => {
+		mockSpawnResult("image/png\ntext/plain\n")
+		const cb = await freshShim()
+		const formats = cb.availableFormats()
+		expect(formats).toContain("image/png")
+	})
+
+	it("calls wl-paste with correct args", async () => {
+		mockSpawnResult("image/png\n")
+		const cb = await freshShim()
+		cb.availableFormats()
+		expect(mockSpawn).toHaveBeenCalledWith("wl-paste", ["--list-types"], expect.objectContaining({ encoding: "utf8" }))
+	})
+})

--- a/src/utils/clipboard-linux-subprocess.test.ts
+++ b/src/utils/clipboard-linux-subprocess.test.ts
@@ -78,3 +78,99 @@ describe("availableFormats — Wayland", () => {
 		expect(mockSpawn).toHaveBeenCalledWith("wl-paste", ["--list-types"], expect.objectContaining({ encoding: "utf8" }))
 	})
 })
+
+describe("hasImage", () => {
+	beforeEach(() => {
+		vi.stubEnv("WAYLAND_DISPLAY", "")
+		vi.stubEnv("DISPLAY", ":0")
+	})
+
+	it("returns true when image/png is in formats", async () => {
+		mockSpawnResult("image/png\ntext/plain\n")
+		const cb = await freshShim()
+		expect(cb.hasImage()).toBe(true)
+	})
+
+	it("returns true when image/jpeg is in formats", async () => {
+		mockSpawnResult("image/jpeg\ntext/plain\n")
+		const cb = await freshShim()
+		expect(cb.hasImage()).toBe(true)
+	})
+
+	it("returns false when no image format present", async () => {
+		mockSpawnResult("text/plain\napplication/json\n")
+		const cb = await freshShim()
+		expect(cb.hasImage()).toBe(false)
+	})
+
+	it("returns false when xclip fails", async () => {
+		// biome-ignore lint/suspicious/noExplicitAny: test mock
+		mockSpawn.mockReturnValue({ stdout: "", stderr: "", status: 1, pid: 1, signal: null, output: [] } as any)
+		const cb = await freshShim()
+		expect(cb.hasImage()).toBe(false)
+	})
+})
+
+describe("getImageBinary", () => {
+	beforeEach(() => {
+		vi.stubEnv("WAYLAND_DISPLAY", "")
+		vi.stubEnv("DISPLAY", ":0")
+	})
+
+	it("returns image bytes from xclip", async () => {
+		// First call: TARGETS (availableFormats), second call: image bytes
+		mockSpawn
+			// biome-ignore lint/suspicious/noExplicitAny: test mock
+			.mockReturnValueOnce({ stdout: "image/png\n", stderr: "", status: 0, pid: 1, signal: null, output: [] } as any)
+			.mockReturnValueOnce({
+				stdout: Buffer.from([0x89, 0x50, 0x4e, 0x47]),
+				stderr: "",
+				status: 0,
+				pid: 1,
+				signal: null,
+				output: [],
+				// biome-ignore lint/suspicious/noExplicitAny: test mock
+			} as any)
+		const cb = await freshShim()
+		const bytes = await cb.getImageBinary()
+		expect(bytes).toEqual([0x89, 0x50, 0x4e, 0x47])
+	})
+
+	it("returns empty array when xclip fails", async () => {
+		mockSpawn.mockReturnValue({
+			stdout: Buffer.alloc(0),
+			stderr: "",
+			status: 1,
+			pid: 1,
+			signal: null,
+			output: [],
+			// biome-ignore lint/suspicious/noExplicitAny: test mock
+		} as any)
+		const cb = await freshShim()
+		const bytes = await cb.getImageBinary()
+		expect(bytes).toEqual([])
+	})
+
+	it("picks correct MIME type from available formats", async () => {
+		mockSpawn
+			// biome-ignore lint/suspicious/noExplicitAny: test mock
+			.mockReturnValueOnce({ stdout: "image/jpeg\n", stderr: "", status: 0, pid: 1, signal: null, output: [] } as any)
+			.mockReturnValueOnce({
+				stdout: Buffer.from([0xff, 0xd8]),
+				stderr: "",
+				status: 0,
+				pid: 1,
+				signal: null,
+				output: [],
+				// biome-ignore lint/suspicious/noExplicitAny: test mock
+			} as any)
+		const cb = await freshShim()
+		await cb.getImageBinary()
+		expect(mockSpawn).toHaveBeenNthCalledWith(
+			2,
+			"xclip",
+			["-selection", "clipboard", "-t", "image/jpeg", "-o"],
+			expect.anything(),
+		)
+	})
+})

--- a/src/utils/clipboard-linux-subprocess.ts
+++ b/src/utils/clipboard-linux-subprocess.ts
@@ -1,0 +1,53 @@
+import { spawnSync } from "node:child_process"
+import type { NativeClipboard } from "./clipboard-native-harness.js"
+
+function isWayland(): boolean {
+	return Boolean(process.env.WAYLAND_DISPLAY)
+}
+
+function runAvailableFormats(): string[] {
+	try {
+		const result = isWayland()
+			? spawnSync("wl-paste", ["--list-types"], { encoding: "utf8", timeout: 2000 })
+			: spawnSync("xclip", ["-selection", "clipboard", "-t", "TARGETS", "-o"], {
+					encoding: "utf8",
+					timeout: 2000,
+				})
+		if (result.status !== 0 || !result.stdout) return []
+		return result.stdout
+			.split("\n")
+			.map((s) => s.trim())
+			.filter((s) => s.length > 0 && s !== "TARGETS")
+	} catch {
+		return []
+	}
+}
+
+export function createLinuxClipboard(): NativeClipboard {
+	return {
+		availableFormats(): string[] {
+			return runAvailableFormats()
+		},
+
+		hasImage(): boolean {
+			return runAvailableFormats().some((f) => /^image\//i.test(f))
+		},
+
+		async getImageBinary(): Promise<number[]> {
+			const formats = runAvailableFormats()
+			const imageType = formats.find((f) => /^image\/(png|jpeg|jpg|gif|webp|bmp)/i.test(f)) ?? "image/png"
+			try {
+				const result = isWayland()
+					? spawnSync("wl-paste", ["--type", imageType], { timeout: 5000, encoding: "buffer" })
+					: spawnSync("xclip", ["-selection", "clipboard", "-t", imageType, "-o"], {
+							timeout: 5000,
+							encoding: "buffer",
+						})
+				if (result.status !== 0 || !result.stdout) return []
+				return Array.from(result.stdout)
+			} catch {
+				return []
+			}
+		},
+	}
+}

--- a/src/utils/clipboard-linux-subprocess.ts
+++ b/src/utils/clipboard-linux-subprocess.ts
@@ -38,10 +38,15 @@ export function createLinuxClipboard(): NativeClipboard {
 			const imageType = formats.find((f) => /^image\/(png|jpeg|jpg|gif|webp|bmp)/i.test(f)) ?? "image/png"
 			try {
 				const result = isWayland()
-					? spawnSync("wl-paste", ["--type", imageType], { timeout: 5000, encoding: "buffer" })
+					? spawnSync("wl-paste", ["--type", imageType], {
+							timeout: 5000,
+							encoding: "buffer",
+							maxBuffer: 50 * 1024 * 1024,
+						})
 					: spawnSync("xclip", ["-selection", "clipboard", "-t", imageType, "-o"], {
 							timeout: 5000,
 							encoding: "buffer",
+							maxBuffer: 50 * 1024 * 1024,
 						})
 				if (result.status !== 0 || !result.stdout) return []
 				return Array.from(result.stdout)

--- a/src/utils/clipboard-native-harness.test.ts
+++ b/src/utils/clipboard-native-harness.test.ts
@@ -52,22 +52,3 @@ describe("getNativeClipboard (mocked)", () => {
 		expect(vi.mocked(getNativeClipboard)).toHaveBeenCalled()
 	})
 })
-
-describe("getNativeClipboard — Linux subprocess routing", () => {
-	it("returns non-null clipboard on Linux when display is available", async () => {
-		if (process.platform !== "linux") return
-		vi.stubEnv("DISPLAY", ":0")
-		vi.stubEnv("WAYLAND_DISPLAY", "")
-		vi.stubEnv("WSL_DISTRO_NAME", "")
-		vi.stubEnv("WSL_INTEROP", "")
-		vi.stubEnv("KIMCHI_CLIPBOARD_FORCE", "")
-		vi.resetModules()
-		const { getNativeClipboard: fresh } = await import("./clipboard-native-harness.js")
-		const result = fresh()
-		expect(() => fresh()).not.toThrow()
-		if (result.clipboard) {
-			expect(typeof result.clipboard.availableFormats).toBe("function")
-			expect(typeof result.clipboard.hasImage).toBe("function")
-		}
-	})
-})

--- a/src/utils/clipboard-native-harness.test.ts
+++ b/src/utils/clipboard-native-harness.test.ts
@@ -52,3 +52,22 @@ describe("getNativeClipboard (mocked)", () => {
 		expect(vi.mocked(getNativeClipboard)).toHaveBeenCalled()
 	})
 })
+
+describe("getNativeClipboard — Linux subprocess routing", () => {
+	it("returns non-null clipboard on Linux when display is available", async () => {
+		if (process.platform !== "linux") return
+		vi.stubEnv("DISPLAY", ":0")
+		vi.stubEnv("WAYLAND_DISPLAY", "")
+		vi.stubEnv("WSL_DISTRO_NAME", "")
+		vi.stubEnv("WSL_INTEROP", "")
+		vi.stubEnv("KIMCHI_CLIPBOARD_FORCE", "")
+		vi.resetModules()
+		const { getNativeClipboard: fresh } = await import("./clipboard-native-harness.js")
+		const result = fresh()
+		expect(() => fresh()).not.toThrow()
+		if (result.clipboard) {
+			expect(typeof result.clipboard.availableFormats).toBe("function")
+			expect(typeof result.clipboard.hasImage).toBe("function")
+		}
+	})
+})

--- a/src/utils/clipboard-native-harness.ts
+++ b/src/utils/clipboard-native-harness.ts
@@ -30,6 +30,8 @@
 // WSL_INTEROP) because WSLg may set $DISPLAY to ":0" even when no graphical
 // session is running, giving a false positive to the simple display check.
 
+import { createLinuxClipboard } from "./clipboard-linux-subprocess.js"
+
 export type NativeClipboard = {
 	hasImage(): boolean
 	getImageBinary(): Promise<number[]>
@@ -118,15 +120,7 @@ export function getNativeClipboard(): { clipboard: NativeClipboard | null; error
 	// method call which opens a new X11 connection; background threads in the Rust
 	// library keep those connections alive and exhaust X11's 255-client limit.
 	if (process.platform === "linux") {
-		try {
-			// eslint-disable-next-line @typescript-eslint/no-require-imports
-			const mod = require("./clipboard-linux-subprocess.js") as typeof import("./clipboard-linux-subprocess.js")
-			const { createLinuxClipboard } = mod
-			cached = createLinuxClipboard()
-		} catch (err) {
-			cached = null
-			loadError = err instanceof Error ? err.message : String(err)
-		}
+		cached = createLinuxClipboard()
 		return { clipboard: cached, error: loadError }
 	}
 

--- a/src/utils/clipboard-native-harness.ts
+++ b/src/utils/clipboard-native-harness.ts
@@ -113,6 +113,23 @@ export function getNativeClipboard(): { clipboard: NativeClipboard | null; error
 		return { clipboard: null, error: loadError }
 	}
 
+	// On Linux use subprocess-based clipboard access (xclip/wl-paste) instead of
+	// the native .node addon. The addon calls ClipboardContext::new() on every
+	// method call which opens a new X11 connection; background threads in the Rust
+	// library keep those connections alive and exhaust X11's 255-client limit.
+	if (process.platform === "linux") {
+		try {
+			// eslint-disable-next-line @typescript-eslint/no-require-imports
+			const mod = require("./clipboard-linux-subprocess.js") as typeof import("./clipboard-linux-subprocess.js")
+			const { createLinuxClipboard } = mod
+			cached = createLinuxClipboard()
+		} catch (err) {
+			cached = null
+			loadError = err instanceof Error ? err.message : String(err)
+		}
+		return { clipboard: cached, error: loadError }
+	}
+
 	try {
 		const binding = loadPlatformBinding()
 		// Eagerly probe the binding so that a Rust panic from a broken display


### PR DESCRIPTION
## Summary

- Replaces the `@mariozechner/clipboard` native addon on Linux with subprocess calls to `xclip` (X11) or `wl-paste` (Wayland)
- Fixes X11 client slot exhaustion: the addon calls `ClipboardContext::new()` on every `availableFormats()`/`hasImage()` call, opening a new X11 connection each time; background threads in the Rust library keep those connections alive and exhaust X11's 255-client limit (~3 min at 1 Hz polling)
- Matches the approach used by Claude Code, which also shells out to `xclip`/`wl-paste` on Linux

## Root Cause

`@mariozechner/clipboard`'s Rust source (`lib.rs:25-28`, `lib.rs:79-82`) creates a fresh `ClipboardContext::new()` on every free function call — there is no persistent connection. With clipboard polling at 1 Hz, a running session accumulates ~60 connections/min, saturating the X server's 255-client limit in minutes.

Reported by a user: kimchi holding 206 of 255 X11 slots, starving other apps.

## Changes

- **`src/utils/clipboard-linux-subprocess.ts`** (new): implements `NativeClipboard` interface via `spawnSync` to `xclip`/`wl-paste`. Detects Wayland vs X11 from `WAYLAND_DISPLAY`. Gracefully returns empty results if tools are absent.
- **`src/utils/clipboard-linux-subprocess.test.ts`** (new): 12 unit tests covering `availableFormats`, `hasImage`, `getImageBinary` for both X11 and Wayland paths, with mocked `spawnSync`.
- **`src/utils/clipboard-native-harness.ts`**: on `process.platform === "linux"`, returns the subprocess shim instead of loading the `.node` addon. The existing `hasDisplayServer()` / WSL / headless guards remain unchanged.

## Verification

Tested on Hetzner Ubuntu arm64 VM under `xvfb-run`:

```
availableFormats(): [ "image/png" ]
hasImage(): true
X11 connections held by this process: 0
X11 connections after 30 polls: 0 (was 0)
No leak — X11 connection count stayed bounded.
```

## Notes

- `xclip` must be installed (`apt install xclip`). If absent, `availableFormats()` returns `[]` and clipboard image support silently degrades — same behaviour as today on headless Linux.
- Wayland users need `wl-clipboard` (`apt install wl-clipboard`) for `wl-paste`.
- The native `.node` Linux addon packages remain in `package.json` as optional dependencies (other potential uses), but are no longer loaded at runtime on Linux.