### PR TITLE
fix: Add retry and timeout to all first-party fetch calls

### DIFF
--- a/src/api/me.test.ts
+++ b/src/api/me.test.ts
@@ -1,6 +1,18 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
 import { getMe } from "./me.js"
 
+vi.mock("../utils/http.js", () => ({
+	fetchWithRetry: (
+		url: string,
+		init?: RequestInit,
+		options?: { fetchImpl?: typeof fetch; timeoutMs?: number; signal?: AbortSignal },
+	) => {
+		const fetchFn = options?.fetchImpl ?? globalThis.fetch
+		const signal = options?.signal ?? init?.signal
+		return fetchFn(url, signal ? { ...init, signal } : (init as RequestInit))
+	},
+}))
+
 describe("getMe", () => {
 	let originalFetch: typeof globalThis.fetch
 

--- a/src/api/me.ts
+++ b/src/api/me.ts
@@ -1,3 +1,5 @@
+import { fetchWithRetry } from "../utils/http.js"
+
 export interface MeResponse {
 	id: string
 	username?: string
@@ -29,14 +31,17 @@ export async function getMe(apiKey: string, options?: GetMeOptions): Promise<MeR
 	const fetchImpl = options?.fetch ?? globalThis.fetch
 
 	const url = `${endpoint}/v1/me`
-	const resp = await fetchImpl(url, {
-		method: "GET",
-		headers: {
-			Authorization: `Bearer ${apiKey}`,
-			Accept: "application/json",
+	const resp = await fetchWithRetry(
+		url,
+		{
+			method: "GET",
+			headers: {
+				Authorization: `Bearer ${apiKey}`,
+				Accept: "application/json",
+			},
 		},
-		signal: options?.signal,
-	})
+		{ signal: options?.signal, fetchImpl },
+	)
 
 	if (!resp.ok) {
 		throw new Error(`GET ${url} failed with HTTP ${resp.status}`)

--- a/src/auth/validator.test.ts
+++ b/src/auth/validator.test.ts
@@ -1,20 +1,27 @@
 import { describe, expect, it, vi } from "vitest"
 import { validateApiKey } from "./validator.js"
 
+type FetchWithRetryOptions = {
+	fetchImpl?: typeof fetch
+	timeoutMs?: number
+	signal?: AbortSignal
+	retry?: { maxRetries?: number }
+}
+
+const fetchWithRetrySpy = vi.fn((url: string, init?: RequestInit, options?: FetchWithRetryOptions) => {
+	const fetchFn = options?.fetchImpl ?? globalThis.fetch
+	const ctrl = new AbortController()
+	if (options?.timeoutMs) {
+		setTimeout(() => ctrl.abort(), options.timeoutMs)
+	}
+	const signals = [ctrl.signal, options?.signal, init?.signal].filter(Boolean) as AbortSignal[]
+	const signal = signals.length > 1 ? AbortSignal.any(signals) : signals[0]
+	return fetchFn(url, { ...init, signal })
+})
+
 vi.mock("../utils/http.js", () => ({
-	fetchWithRetry: (
-		url: string,
-		init?: RequestInit,
-		options?: { fetchImpl?: typeof fetch; timeoutMs?: number; signal?: AbortSignal },
-	) => {
-		const fetchFn = options?.fetchImpl ?? globalThis.fetch
-		const ctrl = new AbortController()
-		if (options?.timeoutMs) {
-			setTimeout(() => ctrl.abort(), options.timeoutMs)
-		}
-		const signals = [ctrl.signal, options?.signal, init?.signal].filter(Boolean) as AbortSignal[]
-		const signal = signals.length > 1 ? AbortSignal.any(signals) : signals[0]
-		return fetchFn(url, { ...init, signal })
+	get fetchWithRetry() {
+		return fetchWithRetrySpy
 	},
 }))
 
@@ -83,6 +90,17 @@ describe("validateApiKey", () => {
 			expect.objectContaining({
 				headers: expect.objectContaining({ Authorization: "Bearer my-key" }),
 			}),
+		)
+	})
+
+	it("passes retry maxRetries: 1 to limit retries in interactive flows", async () => {
+		fetchWithRetrySpy.mockClear()
+		const fetchSpy = vi.fn(async () => new Response(null, { status: 200 }))
+		await validateApiKey("k", { fetch: fetchSpy as unknown as typeof globalThis.fetch })
+		expect(fetchWithRetrySpy).toHaveBeenCalledWith(
+			expect.any(String),
+			expect.any(Object),
+			expect.objectContaining({ retry: { maxRetries: 1 } }),
 		)
 	})
 })

--- a/src/auth/validator.test.ts
+++ b/src/auth/validator.test.ts
@@ -1,6 +1,23 @@
 import { describe, expect, it, vi } from "vitest"
 import { validateApiKey } from "./validator.js"
 
+vi.mock("../utils/http.js", () => ({
+	fetchWithRetry: (
+		url: string,
+		init?: RequestInit,
+		options?: { fetchImpl?: typeof fetch; timeoutMs?: number; signal?: AbortSignal },
+	) => {
+		const fetchFn = options?.fetchImpl ?? globalThis.fetch
+		const ctrl = new AbortController()
+		if (options?.timeoutMs) {
+			setTimeout(() => ctrl.abort(), options.timeoutMs)
+		}
+		const signals = [ctrl.signal, options?.signal, init?.signal].filter(Boolean) as AbortSignal[]
+		const signal = signals.length > 1 ? AbortSignal.any(signals) : signals[0]
+		return fetchFn(url, { ...init, signal })
+	},
+}))
+
 function fakeFetch(response: { status: number } | Error): typeof globalThis.fetch {
 	return vi.fn(async () => {
 		if (response instanceof Error) throw response

--- a/src/auth/validator.ts
+++ b/src/auth/validator.ts
@@ -53,7 +53,7 @@ export async function validateApiKey(apiKey: string, options: ValidatorOptions =
 					Accept: "application/json",
 				},
 			},
-			{ timeoutMs, fetchImpl },
+			{ timeoutMs, fetchImpl, retry: { maxRetries: 1 } },
 		)
 	} catch {
 		return {

--- a/src/auth/validator.ts
+++ b/src/auth/validator.ts
@@ -1,3 +1,5 @@
+import { fetchWithRetry } from "../utils/http.js"
+
 export interface ValidateResult {
 	valid: boolean
 	error?: string
@@ -40,18 +42,19 @@ export async function validateApiKey(apiKey: string, options: ValidatorOptions =
 	const timeoutMs = options.timeoutMs ?? REQUEST_TIMEOUT_MS
 	const fetchImpl = options.fetch ?? globalThis.fetch
 
-	const controller = new AbortController()
-	const timer = setTimeout(() => controller.abort(), timeoutMs)
 	let resp: Response
 	try {
-		resp = await fetchImpl(endpoint, {
-			method: "GET",
-			headers: {
-				Authorization: `Bearer ${apiKey}`,
-				Accept: "application/json",
+		resp = await fetchWithRetry(
+			endpoint,
+			{
+				method: "GET",
+				headers: {
+					Authorization: `Bearer ${apiKey}`,
+					Accept: "application/json",
+				},
 			},
-			signal: controller.signal,
-		})
+			{ timeoutMs, fetchImpl },
+		)
 	} catch {
 		return {
 			valid: false,
@@ -62,8 +65,6 @@ export async function validateApiKey(apiKey: string, options: ValidatorOptions =
 				"Try again in a few moments",
 			],
 		}
-	} finally {
-		clearTimeout(timer)
 	}
 
 	if (resp.status === 200) {

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -290,6 +290,18 @@ try {
 			}
 		}
 
+		// Sync retry config to SDK settings so both systems use the same value
+		try {
+			const existing = JSON.parse(readFileSync(settingsPath, "utf-8"))
+			const sdkRetry = existing.retry
+			if (!sdkRetry || sdkRetry.maxRetries !== config.retry.maxRetries) {
+				existing.retry = { ...sdkRetry, maxRetries: config.retry.maxRetries }
+				writeFileSync(settingsPath, `${JSON.stringify(existing, null, 2)}\n`)
+			}
+		} catch {
+			/* retry sync is best-effort */
+		}
+
 		// Bundled themes are write-through cache — owned by the package, not the user.
 		// Source edits propagate so packaged upgrades pick up new defaults. Users
 		// wanting custom colors should clone+rename (e.g. `my-kimchi.json`), which

--- a/src/config.ts
+++ b/src/config.ts
@@ -119,6 +119,16 @@ export interface PreferencesConfig {
 	hideTips?: boolean
 }
 
+export interface RetryConfig {
+	maxRetries: number
+}
+
+export const RETRY_DEFAULTS: RetryConfig = {
+	maxRetries: 10,
+}
+
+export const THIRD_PARTY_MAX_RETRIES = 4
+
 export const SEARCH_STRATEGY_DEFAULTS: SearchStrategyConfig = {
 	strategy: "bm25",
 	bm25K1: 1.2,
@@ -137,6 +147,7 @@ export interface KimchiConfig {
 	maxToolResultChars: number
 	mcpSearchLimit: number
 	mcpSearch: SearchStrategyConfig
+	retry: RetryConfig
 	skillPaths?: string[]
 	migrationState?: MigrationState
 	onboarding: OnboardingConfig
@@ -169,6 +180,7 @@ function readConfigExtras(configPath: string): {
 	maxToolResultChars?: number
 	mcpSearchLimit?: number
 	mcpSearch?: Partial<SearchStrategyConfig>
+	retry?: Partial<RetryConfig>
 	skillPaths?: string[]
 	migrationState?: MigrationState
 	onboarding?: OnboardingConfig
@@ -211,6 +223,13 @@ function readConfigExtras(configPath: string): {
 					: {}),
 			}
 		}
+		let retry: Partial<RetryConfig> | undefined
+		const r = parsed.retry
+		if (r && typeof r === "object") {
+			retry = {
+				...(typeof r.maxRetries === "number" && r.maxRetries > 0 ? { maxRetries: r.maxRetries } : {}),
+			}
+		}
 		const skillPaths =
 			Array.isArray(parsed.skillPaths) && parsed.skillPaths.every((p: unknown) => typeof p === "string")
 				? (parsed.skillPaths as string[])
@@ -245,6 +264,7 @@ function readConfigExtras(configPath: string): {
 			maxToolResultChars,
 			mcpSearchLimit,
 			mcpSearch,
+			retry,
 			skillPaths,
 			migrationState,
 			onboarding,
@@ -388,13 +408,14 @@ export function loadConfig(options?: { configPath?: string; cwd?: string }): Kim
 	const projectPath = resolve(options?.cwd ?? process.cwd(), ".kimchi", "config.json")
 	const projectExtras = readConfigExtras(projectPath)
 
-	// Merge: project wins for scalars; shallow merge for mcpSearch
+	// Merge: project wins for scalars; shallow merge for mcpSearch and retry
 	const extras = {
 		apiKey: projectExtras.apiKey ?? globalExtras.apiKey,
 		llmEndpoint: projectExtras.llmEndpoint ?? globalExtras.llmEndpoint,
 		maxToolResultChars: projectExtras.maxToolResultChars ?? globalExtras.maxToolResultChars,
 		mcpSearchLimit: projectExtras.mcpSearchLimit ?? globalExtras.mcpSearchLimit,
 		mcpSearch: { ...globalExtras.mcpSearch, ...projectExtras.mcpSearch },
+		retry: { ...globalExtras.retry, ...projectExtras.retry },
 		skillPaths: projectExtras.skillPaths ?? globalExtras.skillPaths,
 		migrationState: projectExtras.migrationState ?? globalExtras.migrationState,
 		onboarding: globalExtras.onboarding,
@@ -409,6 +430,7 @@ export function loadConfig(options?: { configPath?: string; cwd?: string }): Kim
 		maxToolResultChars: extras.maxToolResultChars ?? 10_000,
 		mcpSearchLimit: extras.mcpSearchLimit ?? 5,
 		mcpSearch: { ...SEARCH_STRATEGY_DEFAULTS, ...extras.mcpSearch },
+		retry: { ...RETRY_DEFAULTS, ...extras.retry },
 		skillPaths: extras.skillPaths,
 		migrationState: extras.migrationState,
 		onboarding: extras.onboarding ?? {},

--- a/src/extensions/agents/manager/agent-runner.test.ts
+++ b/src/extensions/agents/manager/agent-runner.test.ts
@@ -10,7 +10,7 @@ vi.mock("@earendil-works/pi-coding-agent", async () => {
 			open: vi.fn().mockReturnValue({}),
 		},
 		SettingsManager: {
-			create: vi.fn().mockReturnValue({}),
+			create: vi.fn().mockReturnValue({ applyOverrides: vi.fn() }),
 		},
 		createAgentSession: vi.fn(),
 		getAgentDir: vi.fn().mockReturnValue("/fake-agent-dir"),
@@ -92,6 +92,7 @@ vi.mock("../../telemetry/index.js", () => ({
 }))
 
 vi.mock("../../../config.js", () => ({
+	loadConfig: vi.fn().mockReturnValue({ retry: { maxRetries: 10 } }),
 	readTelemetryConfig: vi.fn().mockReturnValue({
 		enabled: true,
 		endpoint: "https://test/logs",

--- a/src/extensions/agents/manager/agent-runner.ts
+++ b/src/extensions/agents/manager/agent-runner.ts
@@ -12,7 +12,7 @@ import {
 	createAgentSession,
 	getAgentDir,
 } from "@earendil-works/pi-coding-agent"
-import { readTelemetryConfig } from "../../../config.js"
+import { loadConfig, readTelemetryConfig } from "../../../config.js"
 import { getAvailableModels } from "../../../startup-context.js"
 import { runAsAgentWorker } from "../../agent-worker-context.js"
 import { buildPhaseGuidelinesSection } from "../../orchestration/model-registry/guidelines/guidelines-resolver.js"
@@ -54,6 +54,9 @@ const ORCHESTRATOR_PREFIX = "[Orchestrator — automated system instruction, not
 function steerAsOrchestrator(session: AgentSession, message: string): Promise<void> {
 	return session.steer(ORCHESTRATOR_PREFIX + message)
 }
+
+/** Cached kimchi config — loaded once per process to avoid repeated disk reads per agent spawn. */
+const kimchiConfig = loadConfig()
 
 /** Default max turns. undefined = unlimited (no turn limit). */
 let defaultMaxTurns: number | undefined = 30
@@ -367,13 +370,16 @@ async function runAgentInner(
 
 	const thinkingLevel = options.thinkingLevel ?? agentConfig?.thinking
 
+	const settingsManager = SettingsManager.create(effectiveCwd, agentDir)
+	settingsManager.applyOverrides({ retry: { maxRetries: kimchiConfig.retry.maxRetries } })
+
 	const sessionOpts: Parameters<typeof createAgentSession>[0] = {
 		cwd: effectiveCwd,
 		agentDir,
 		sessionManager: options.sessionFile
 			? SessionManager.open(options.sessionFile, options.sessionDir, effectiveCwd)
 			: SessionManager.inMemory(effectiveCwd),
-		settingsManager: SettingsManager.create(effectiveCwd, agentDir),
+		settingsManager,
 		modelRegistry: ctx.modelRegistry,
 		model,
 		resourceLoader: loader,

--- a/src/extensions/prompt-construction/prompt-enrichment.test.ts
+++ b/src/extensions/prompt-construction/prompt-enrichment.test.ts
@@ -837,6 +837,7 @@ describe("continuation nudge turn_end handler", () => {
 				bm25B: 0.75,
 				fieldWeights: { name: 6, description: 2, schemaKey: 1 },
 			},
+			retry: { maxRetries: 10 },
 			onboarding: {},
 			deviceId: "test",
 		})

--- a/src/extensions/session-name.test.ts
+++ b/src/extensions/session-name.test.ts
@@ -6,6 +6,10 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
 import { loadConfig } from "../config.js"
 import { deterministicFallback, extractFirstUserMessage, suggestSessionName } from "./session-name.js"
 
+vi.mock("../utils/http.js", () => ({
+	fetchWithRetry: (url: string, init?: RequestInit) => globalThis.fetch(url, init),
+}))
+
 vi.mock("../config.js")
 vi.mock("node:path", async () => {
 	const actual = await vi.importActual<typeof import("node:path")>("node:path")

--- a/src/extensions/session-name.ts
+++ b/src/extensions/session-name.ts
@@ -9,6 +9,7 @@
 import { basename } from "node:path"
 import type { ExtensionAPI, ExtensionContext, TurnEndEvent } from "@earendil-works/pi-coding-agent"
 import { loadConfig } from "../config.js"
+import { fetchWithRetry } from "../utils/http.js"
 
 // System prompt for session name generation - keep it simple; cheap models choke
 // on negative constraints, formatting demands, and multi-step instructions.
@@ -143,15 +144,18 @@ export async function suggestSessionName(ctx: ExtensionContext, hint?: string, q
 		}
 		const body = JSON.stringify(payload)
 
-		const response = await fetch(`${config.llmEndpoint}/chat/completions`, {
-			method: "POST",
-			headers: {
-				"Content-Type": "application/json",
-				Authorization: `Bearer ${apiKey}`,
+		const response = await fetchWithRetry(
+			`${config.llmEndpoint}/chat/completions`,
+			{
+				method: "POST",
+				headers: {
+					"Content-Type": "application/json",
+					Authorization: `Bearer ${apiKey}`,
+				},
+				body,
 			},
-			body,
-			signal: AbortSignal.timeout(10000),
-		})
+			{ timeoutMs: 10_000, retry: { maxRetries: 3 } },
+		)
 
 		if (!response.ok) {
 			const errorBody = await response.text().catch(() => "")

--- a/src/extensions/stats/api.ts
+++ b/src/extensions/stats/api.ts
@@ -4,6 +4,7 @@
  * Fetches analytics, productivity metrics, and timeseries data from Cast AI.
  */
 
+import { fetchWithRetry } from "../../utils/http.js"
 import type {
 	GenerateAnalyticsResponse,
 	GenerateProductivityMetricsTimeseriesResponse,
@@ -36,10 +37,7 @@ export class CastAiStatsApi {
 		headers.set("Content-Type", "application/json")
 		headers.set("Accept", "application/json")
 
-		const response = await fetch(url, {
-			...options,
-			headers,
-		})
+		const response = await fetchWithRetry(url, { ...options, headers }, { timeoutMs: 10_000, retry: { maxRetries: 3 } })
 
 		if (!response.ok) {
 			const errorText = await response.text().catch(() => "Unknown error")

--- a/src/extensions/superpowers/installer.ts
+++ b/src/extensions/superpowers/installer.ts
@@ -2,6 +2,8 @@ import { createWriteStream, existsSync, mkdirSync, readFileSync, rmSync, writeFi
 import { unlink } from "node:fs/promises"
 import { join } from "node:path"
 import { extract } from "tar"
+import { THIRD_PARTY_MAX_RETRIES } from "../../config.js"
+import { fetchWithRetry } from "../../utils/http.js"
 import { SUPERPOWERS_VERSION, getSuperpowersTarballUrl, getSuperpowersVendorDir } from "./config.js"
 
 export async function ensureSuperpowersInstalled(): Promise<boolean> {
@@ -21,7 +23,10 @@ export async function ensureSuperpowersInstalled(): Promise<boolean> {
 	const tarballPath = `${vendorDir}.download.tar.gz`
 	mkdirSync(vendorDir, { recursive: true })
 
-	const response = await fetch(getSuperpowersTarballUrl())
+	const response = await fetchWithRetry(getSuperpowersTarballUrl(), undefined, {
+		timeoutMs: 60_000,
+		retry: { maxRetries: THIRD_PARTY_MAX_RETRIES },
+	})
 	if (!response.ok) {
 		throw new Error(`Failed to download superpowers: ${response.status} ${response.statusText}`)
 	}

--- a/src/extensions/telemetry/transport.test.ts
+++ b/src/extensions/telemetry/transport.test.ts
@@ -3,6 +3,10 @@ import type { TelemetryConfig } from "../../config.js"
 import { buildLogRecord, sendLog, sendLogBatch, sendMetrics } from "./transport.js"
 import type { MetricData } from "./transport.js"
 
+vi.mock("../../utils/http.js", () => ({
+	fetchWithRetry: (url: string, init?: RequestInit) => globalThis.fetch(url, init),
+}))
+
 const BASE_NS = String(new Date("2026-06-02T10:00:00.000Z").getTime() * 1_000_000)
 
 function makeConfig(overrides: Partial<TelemetryConfig> = {}): TelemetryConfig {

--- a/src/extensions/telemetry/transport.ts
+++ b/src/extensions/telemetry/transport.ts
@@ -2,6 +2,7 @@ import * as fs from "node:fs"
 import * as path from "node:path"
 import type { TelemetryConfig } from "../../config.js"
 import { getVersion } from "../../utils.js"
+import { fetchWithRetry } from "../../utils/http.js"
 import { nowNano, strAttr } from "./helpers.js"
 
 // ---------------------------------------------------------------------------
@@ -119,11 +120,15 @@ export async function sendLogBatch(config: TelemetryConfig, records: LogRecord[]
 		logEventToFile(record.eventName, props)
 	}
 	try {
-		const response = await fetch(config.endpoint, {
-			method: "POST",
-			headers: { "Content-Type": "application/json", ...config.headers },
-			body: JSON.stringify(payload),
-		})
+		const response = await fetchWithRetry(
+			config.endpoint,
+			{
+				method: "POST",
+				headers: { "Content-Type": "application/json", ...config.headers },
+				body: JSON.stringify(payload),
+			},
+			{ timeoutMs: 10_000, retry: { maxRetries: 3 } },
+		)
 		if (!response.ok) {
 			logEventToFile("telemetry.response.error", {
 				endpoint: config.endpoint,
@@ -185,11 +190,15 @@ export async function sendMetrics(
 		logEventToFile(metric.name, { value: metric.value, ...metric.attrs })
 	}
 	try {
-		const response = await fetch(config.metricsEndpoint, {
-			method: "POST",
-			headers: { "Content-Type": "application/json", ...config.headers },
-			body: JSON.stringify(payload),
-		})
+		const response = await fetchWithRetry(
+			config.metricsEndpoint,
+			{
+				method: "POST",
+				headers: { "Content-Type": "application/json", ...config.headers },
+				body: JSON.stringify(payload),
+			},
+			{ timeoutMs: 10_000, retry: { maxRetries: 3 } },
+		)
 		if (!response.ok) {
 			logEventToFile("telemetry.response.error", {
 				endpoint: config.metricsEndpoint,

--- a/src/extensions/web-fetch/execute-handler.ts
+++ b/src/extensions/web-fetch/execute-handler.ts
@@ -96,10 +96,10 @@ export async function executeWebFetch(params: WebFetchParams, signal?: AbortSign
 		...(result.finalURL !== params.url ? [`Final URL: ${result.finalURL}`] : []),
 		`Content-Type: ${result.contentType}`,
 		`Format: ${format}`,
-		`Characters: ${totalChars.toLocaleString()}`,
+		`Characters: ${totalChars.toLocaleString("en-US")}`,
 		...(truncated
 			? [
-					`Truncated: content truncated to ${MAX_OUTPUT_CHARS.toLocaleString()} of ${totalChars.toLocaleString()} characters`,
+					`Truncated: content truncated to ${MAX_OUTPUT_CHARS.toLocaleString("en-US")} of ${totalChars.toLocaleString("en-US")} characters`,
 				]
 			: []),
 		"Cache: miss",
@@ -107,7 +107,7 @@ export async function executeWebFetch(params: WebFetchParams, signal?: AbortSign
 	]
 
 	const truncationNotice = truncated
-		? `\n\n[Content truncated: showing ${MAX_OUTPUT_CHARS.toLocaleString()} of ${totalChars.toLocaleString()} characters]`
+		? `\n\n[Content truncated: showing ${MAX_OUTPUT_CHARS.toLocaleString("en-US")} of ${totalChars.toLocaleString("en-US")} characters]`
 		: ""
 	const output = buildOutput(lines, content, truncationNotice)
 

--- a/src/extensions/web-fetch/integration.test.ts
+++ b/src/extensions/web-fetch/integration.test.ts
@@ -16,6 +16,20 @@ vi.mock("./url-validator.js", () => ({
 	},
 }))
 
+// Remove retry behaviour so 500s throw immediately and timeout tests aren't
+// affected by retry delays. Timeout behaviour is preserved via AbortController.
+vi.mock("../../utils/http.js", () => ({
+	fetchWithRetry: (url: string, init?: RequestInit, options?: Record<string, unknown>) => {
+		const fetchFn = (options?.fetchImpl as typeof fetch) ?? globalThis.fetch
+		const signal = options?.signal as AbortSignal | undefined
+		const timeoutMs = (options?.timeoutMs as number) ?? 30_000
+		const ctrl = new AbortController()
+		const timer = setTimeout(() => ctrl.abort(), timeoutMs)
+		const composedSignal = signal ? AbortSignal.any([ctrl.signal, signal]) : ctrl.signal
+		return fetchFn(url, { ...init, signal: composedSignal }).finally(() => clearTimeout(timer))
+	},
+}))
+
 import type { ExtensionAPI } from "@earendil-works/pi-coding-agent"
 import webFetchExtension from "./index.js"
 

--- a/src/extensions/web-fetch/page-fetcher.test.ts
+++ b/src/extensions/web-fetch/page-fetcher.test.ts
@@ -1,5 +1,21 @@
 import { type MockInstance, afterEach, beforeEach, describe, expect, it, vi } from "vitest"
 
+vi.mock("../../utils/http.js", () => ({
+	fetchWithRetry: (
+		url: string,
+		init?: RequestInit,
+		options?: { timeoutMs?: number; signal?: AbortSignal; fetchImpl?: typeof fetch },
+	) => {
+		const ctrl = new AbortController()
+		if (options?.timeoutMs) {
+			setTimeout(() => ctrl.abort(), options.timeoutMs)
+		}
+		const signals = [ctrl.signal, options?.signal, init?.signal].filter(Boolean) as AbortSignal[]
+		const signal = signals.length > 1 ? AbortSignal.any(signals) : signals[0]
+		return globalThis.fetch(url, { ...init, signal })
+	},
+}))
+
 // Mock browser-pool to control Playwright availability.
 vi.mock("./browser-pool.js", () => ({
 	getBrowser: vi.fn(),

--- a/src/extensions/web-fetch/page-fetcher.ts
+++ b/src/extensions/web-fetch/page-fetcher.ts
@@ -5,6 +5,8 @@
  * not installed, falls back to native fetch() with a warning.
  */
 
+import { THIRD_PARTY_MAX_RETRIES } from "../../config.js"
+import { fetchWithRetry } from "../../utils/http.js"
 import { getBrowser } from "./browser-pool.js"
 
 /** Maximum raw response size in bytes (5 MB). */
@@ -259,21 +261,20 @@ const FALLBACK_WARNING =
 
 async function fetchWithNative(url: string, options?: FetchOptions): Promise<FetchResult> {
 	const timeoutMs = (options?.timeoutSeconds ?? DEFAULT_TIMEOUT_SECONDS) * 1000
-	const controller = new AbortController()
-	const timer = setTimeout(() => controller.abort(), timeoutMs)
-	const signal = options?.signal ? AbortSignal.any([controller.signal, options.signal]) : controller.signal
 
 	let response: Response
 	try {
-		response = await fetch(url, {
-			signal,
-			redirect: "follow",
-			headers: {
-				Accept: "text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8",
+		response = await fetchWithRetry(
+			url,
+			{
+				redirect: "follow",
+				headers: {
+					Accept: "text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8",
+				},
 			},
-		})
+			{ timeoutMs, signal: options?.signal, retry: { maxRetries: THIRD_PARTY_MAX_RETRIES } },
+		)
 	} catch (err: unknown) {
-		clearTimeout(timer)
 		if (err instanceof DOMException && err.name === "AbortError") {
 			if (options?.signal?.aborted) {
 				throw new FetchError(`Fetch of "${url}" was cancelled`, "cancelled")
@@ -294,8 +295,6 @@ async function fetchWithNative(url: string, options?: FetchOptions): Promise<Fet
 			throw new FetchError(`Connection reset while fetching "${url}"`, "network")
 		}
 		throw new FetchError(`Network error fetching "${url}": ${message}`, "network")
-	} finally {
-		clearTimeout(timer)
 	}
 
 	// HTTP errors

--- a/src/extensions/web-search/execute-handler.test.ts
+++ b/src/extensions/web-search/execute-handler.test.ts
@@ -3,6 +3,9 @@ import * as config from "../../config.js"
 import { DEFAULT_LIMIT, SEARCH_ENDPOINT, type SearchResponse, executeWebSearch } from "./execute-handler.js"
 
 vi.mock("../../config.js", () => ({ readApiKeyFromConfigFile: vi.fn() }))
+vi.mock("../../utils/http.js", () => ({
+	fetchWithRetry: (url: string, init?: RequestInit) => globalThis.fetch(url, init),
+}))
 
 function mockFetch(status: number, body: unknown, headers: Record<string, string> = {}): void {
 	vi.stubGlobal(
@@ -132,27 +135,11 @@ describe("executeWebSearch", () => {
 			await expect(executeWebSearch({ query: "test" })).rejects.toThrow("Web search failed with status 500")
 		})
 
-		it("throws rate limit error for 429 without Retry-After", async () => {
+		it("throws rate limit error for 429 after retries exhausted", async () => {
 			mockFetch(429, {})
 
 			await expect(executeWebSearch({ query: "test" })).rejects.toThrow(
-				"Web search rate limited. Try again in a moment.",
-			)
-		})
-
-		it("includes Retry-After seconds in 429 error when header is a number", async () => {
-			mockFetch(429, {}, { "Retry-After": "30" })
-
-			await expect(executeWebSearch({ query: "test" })).rejects.toThrow(
-				"Web search rate limited. Retry after 30 seconds.",
-			)
-		})
-
-		it("includes Retry-After date in 429 error when header is an HTTP date", async () => {
-			mockFetch(429, {}, { "Retry-After": "Wed, 21 Oct 2025 07:28:00 GMT" })
-
-			await expect(executeWebSearch({ query: "test" })).rejects.toThrow(
-				"Web search rate limited. Retry after Wed, 21 Oct 2025 07:28:00 GMT.",
+				"Web search rate limited. Retries exhausted, please try again later.",
 			)
 		})
 	})

--- a/src/extensions/web-search/execute-handler.ts
+++ b/src/extensions/web-search/execute-handler.ts
@@ -7,6 +7,7 @@
 
 import { truncateHead, truncateLine } from "@earendil-works/pi-coding-agent"
 import { readApiKeyFromConfigFile } from "../../config.js"
+import { fetchWithRetry } from "../../utils/http.js"
 
 export const SEARCH_ENDPOINT = "https://llm.kimchi.dev/v1/search"
 export const SEARCH_TIMEOUT_MS = 25_000
@@ -57,18 +58,21 @@ export function formatForLLM(response: SearchResponse, maxContentChars = DEFAULT
 	return parts.join("\n")
 }
 
-async function fetchSearchResponse(body: object, apiKey: string, signal: AbortSignal): Promise<SearchResponse> {
+async function fetchSearchResponse(body: object, apiKey: string, signal?: AbortSignal): Promise<SearchResponse> {
 	let response: Response
 	try {
-		response = await fetch(SEARCH_ENDPOINT, {
-			method: "POST",
-			headers: {
-				"Content-Type": "application/json",
-				Authorization: `Bearer ${apiKey}`,
+		response = await fetchWithRetry(
+			SEARCH_ENDPOINT,
+			{
+				method: "POST",
+				headers: {
+					"Content-Type": "application/json",
+					Authorization: `Bearer ${apiKey}`,
+				},
+				body: JSON.stringify(body),
 			},
-			body: JSON.stringify(body),
-			signal,
-		})
+			{ timeoutMs: SEARCH_TIMEOUT_MS, signal },
+		)
 	} catch (err) {
 		if (err instanceof Error && err.name === "AbortError") {
 			throw new Error("Web search timed out")
@@ -81,13 +85,7 @@ async function fetchSearchResponse(body: object, apiKey: string, signal: AbortSi
 			throw new Error(`Authentication failed (${response.status}). Check your API key.`)
 		}
 		if (response.status === 429) {
-			const retryAfter = response.headers.get("Retry-After")
-			let retryHint = " Try again in a moment."
-			if (retryAfter !== null) {
-				const seconds = Number(retryAfter)
-				retryHint = Number.isNaN(seconds) ? ` Retry after ${retryAfter}.` : ` Retry after ${seconds} seconds.`
-			}
-			throw new Error(`Web search rate limited.${retryHint}`)
+			throw new Error("Web search rate limited. Retries exhausted, please try again later.")
 		}
 		throw new Error(`Web search failed with status ${response.status}`)
 	}
@@ -117,31 +115,24 @@ export async function executeWebSearch(params: WebSearchParams, signal?: AbortSi
 		...(params.search_depth !== undefined ? { search_depth: params.search_depth } : {}),
 	}
 
-	const controller = new AbortController()
-	const timeout = setTimeout(() => controller.abort(), SEARCH_TIMEOUT_MS)
-	const combinedSignal = signal ? AbortSignal.any([signal, controller.signal]) : controller.signal
 	const startedAt = Date.now()
 
-	try {
-		const data = await fetchSearchResponse(body, apiKey, combinedSignal)
-		const raw = formatForLLM(data, maxContentChars)
-		const truncation = truncateHead(raw, { maxLines: MAX_LINES })
+	const data = await fetchSearchResponse(body, apiKey, signal)
+	const raw = formatForLLM(data, maxContentChars)
+	const truncation = truncateHead(raw, { maxLines: MAX_LINES })
 
-		let text = truncation.content || "No results found."
-		if (truncation.truncated) {
-			text += `\n\n[Output truncated: showing ${truncation.outputLines} of ${truncation.totalLines} lines]`
-		}
+	let text = truncation.content || "No results found."
+	if (truncation.truncated) {
+		text += `\n\n[Output truncated: showing ${truncation.outputLines} of ${truncation.totalLines} lines]`
+	}
 
-		return {
-			content: [{ type: "text" as const, text }],
-			details: {
-				sources: data.sources,
-				durationMs: Date.now() - startedAt,
-				chars: text.length,
-				words: countWords(text),
-			},
-		}
-	} finally {
-		clearTimeout(timeout)
+	return {
+		content: [{ type: "text" as const, text }],
+		details: {
+			sources: data.sources,
+			durationMs: Date.now() - startedAt,
+			chars: text.length,
+			words: countWords(text),
+		},
 	}
 }

--- a/src/integrations/opencode.ts
+++ b/src/integrations/opencode.ts
@@ -1,9 +1,10 @@
 import { execFileSync } from "node:child_process"
-import { readTelemetryConfig } from "../config.js"
+import { THIRD_PARTY_MAX_RETRIES, readTelemetryConfig } from "../config.js"
 import { readJson, writeJson } from "../config/json.js"
 import type { ConfigScope } from "../config/scope.js"
 import { resolveScopePath } from "../config/scope.js"
 import type { ModelMetadata } from "../models.js"
+import { fetchWithRetry } from "../utils/http.js"
 import {
 	NPM_REGISTRY_BASE_URL,
 	OPENCODE_PLUGIN_ARRAY_MIN_VERSION,
@@ -82,7 +83,10 @@ export function compareSemverGte(a: string | null, b: string): boolean {
 export async function getLatestNpmVersion(packageName: string): Promise<string | null> {
 	const url = `${NPM_REGISTRY_BASE_URL}/${packageName}/latest`
 	try {
-		const res = await fetch(url, { signal: AbortSignal.timeout(NPM_REQUEST_TIMEOUT_MS) })
+		const res = await fetchWithRetry(url, undefined, {
+			timeoutMs: NPM_REQUEST_TIMEOUT_MS,
+			retry: { maxRetries: THIRD_PARTY_MAX_RETRIES },
+		})
 		if (!res.ok) return null
 		const body = (await res.json()) as { version?: unknown }
 		return typeof body.version === "string" && body.version.length > 0 ? body.version : null

--- a/src/resources/rtk-install.ts
+++ b/src/resources/rtk-install.ts
@@ -15,6 +15,8 @@ import {
 import { chmod, writeFile } from "node:fs/promises"
 import { homedir, tmpdir } from "node:os"
 import { basename, delimiter, dirname, join } from "node:path"
+import { THIRD_PARTY_MAX_RETRIES } from "../config.js"
+import { fetchWithRetry } from "../utils/http.js"
 import { settingsPath } from "./store.js"
 
 const LATEST_RELEASE_URL = "https://api.github.com/repos/rtk-ai/rtk/releases/latest"
@@ -212,13 +214,21 @@ function assetName(): string {
 }
 
 async function fetchJson<T>(url: string): Promise<T> {
-	const res = await fetch(url, { headers: requestHeaders() })
+	const res = await fetchWithRetry(
+		url,
+		{ headers: requestHeaders() },
+		{ retry: { maxRetries: THIRD_PARTY_MAX_RETRIES } },
+	)
 	if (!res.ok) throw new Error(`Failed to fetch ${url}: ${res.status}`)
 	return (await res.json()) as T
 }
 
 async function download(url: string): Promise<Buffer> {
-	const res = await fetch(url, { headers: requestHeaders() })
+	const res = await fetchWithRetry(
+		url,
+		{ headers: requestHeaders() },
+		{ timeoutMs: 60_000, retry: { maxRetries: THIRD_PARTY_MAX_RETRIES } },
+	)
 	if (!res.ok) throw new Error(`Failed to download ${basename(url)}: ${res.status}`)
 	return Buffer.from(await res.arrayBuffer())
 }

--- a/src/update/github.ts
+++ b/src/update/github.ts
@@ -2,6 +2,8 @@ import { createWriteStream } from "node:fs"
 import { Readable } from "node:stream"
 import { pipeline } from "node:stream/promises"
 import type { ReadableStream as WebReadable } from "node:stream/web"
+import { THIRD_PARTY_MAX_RETRIES } from "../config.js"
+import { fetchWithRetry } from "../utils/http.js"
 
 const DEFAULT_API_BASE = "https://api.github.com"
 const DEFAULT_DOWNLOAD_BASE = "https://github.com"
@@ -79,9 +81,11 @@ export class GitHubClient {
 	/** GET /repos/{owner}/{name}/releases/latest. Returns tag + URL. */
 	async latestRelease(repo: Repo): Promise<ReleaseInfo> {
 		const url = `${this.apiBase}/repos/${repo.owner}/${repo.name}/releases/latest`
-		const res = await this.fetchImpl(url, {
-			headers: { Accept: "application/vnd.github+json" },
-		})
+		const res = await fetchWithRetry(
+			url,
+			{ headers: { Accept: "application/vnd.github+json" } },
+			{ fetchImpl: this.fetchImpl, retry: { maxRetries: THIRD_PARTY_MAX_RETRIES } },
+		)
 		if (!res.ok) {
 			throw new Error(`github API returned ${res.status}`)
 		}
@@ -98,9 +102,11 @@ export class GitHubClient {
 	/** GET /repos/{owner}/{name}/releases/tags/canary. */
 	async canaryRelease(repo: Repo): Promise<CanaryReleaseInfo> {
 		const url = `${this.apiBase}/repos/${repo.owner}/${repo.name}/releases/tags/canary`
-		const res = await this.fetchImpl(url, {
-			headers: { Accept: "application/vnd.github+json" },
-		})
+		const res = await fetchWithRetry(
+			url,
+			{ headers: { Accept: "application/vnd.github+json" } },
+			{ fetchImpl: this.fetchImpl, retry: { maxRetries: THIRD_PARTY_MAX_RETRIES } },
+		)
 		if (!res.ok) {
 			throw new Error(`github API returned ${res.status}`)
 		}
@@ -131,7 +137,10 @@ export class GitHubClient {
 	 */
 	async fetchChecksum(repo: Repo, tag: string): Promise<Uint8Array> {
 		const url = `${this.downloadBase}/${repo.owner}/${repo.name}/releases/download/${tag}/checksums.txt`
-		const res = await this.fetchImpl(url)
+		const res = await fetchWithRetry(url, undefined, {
+			fetchImpl: this.fetchImpl,
+			retry: { maxRetries: THIRD_PARTY_MAX_RETRIES },
+		})
 		if (!res.ok) {
 			throw new Error(`checksums.txt download returned ${res.status}`)
 		}
@@ -149,7 +158,11 @@ export class GitHubClient {
 	/** Download the platform asset to `dest`. Streams body to disk. */
 	async downloadArchive(repo: Repo, tag: string, dest: string): Promise<void> {
 		const url = `${this.downloadBase}/${repo.owner}/${repo.name}/releases/download/${tag}/${assetName(repo)}`
-		const res = await this.fetchImpl(url)
+		const res = await fetchWithRetry(url, undefined, {
+			fetchImpl: this.fetchImpl,
+			timeoutMs: 60_000,
+			retry: { maxRetries: THIRD_PARTY_MAX_RETRIES },
+		})
 		if (!res.ok || !res.body) {
 			throw new Error(`release download returned ${res.status}`)
 		}

--- a/src/upstream-retry-patch.test.ts
+++ b/src/upstream-retry-patch.test.ts
@@ -1,11 +1,11 @@
 import { describe, expect, it, vi } from "vitest"
-import { installCloudflare524RetryPatch, isCloudflare524Retryable } from "./upstream-retry-patch.js"
+import { installCloudflare524RetryPatch, isNetworkErrorRetryable } from "./upstream-retry-patch.js"
 
 describe("upstream retry patch", () => {
 	it("classifies Cloudflare 524 provider errors as retryable", () => {
-		expect(isCloudflare524Retryable({ stopReason: "error", errorMessage: "524 status code (no body)" })).toBe(true)
-		expect(isCloudflare524Retryable({ stopReason: "stop", errorMessage: "524 status code (no body)" })).toBe(false)
-		expect(isCloudflare524Retryable({ stopReason: "error", errorMessage: "bad request" })).toBe(false)
+		expect(isNetworkErrorRetryable({ stopReason: "error", errorMessage: "524 status code (no body)" })).toBe(true)
+		expect(isNetworkErrorRetryable({ stopReason: "stop", errorMessage: "524 status code (no body)" })).toBe(false)
+		expect(isNetworkErrorRetryable({ stopReason: "error", errorMessage: "bad request" })).toBe(false)
 	})
 
 	it("wraps the upstream retry classifier once and preserves original retryable errors", () => {
@@ -26,5 +26,52 @@ describe("upstream retry patch", () => {
 		expect(wrapped?.({ stopReason: "error", errorMessage: "524 status code (no body)" })).toBe(true)
 		expect(wrapped?.({ stopReason: "error", errorMessage: "429 rate limit" })).toBe(true)
 		expect(wrapped?.({ stopReason: "error", errorMessage: "invalid request" })).toBe(false)
+	})
+})
+
+describe("isNetworkErrorRetryable", () => {
+	it("returns false when stopReason is not error", () => {
+		expect(isNetworkErrorRetryable({ stopReason: "end_turn", errorMessage: "524" })).toBe(false)
+	})
+
+	it("returns false when errorMessage is absent", () => {
+		expect(isNetworkErrorRetryable({ stopReason: "error" })).toBe(false)
+	})
+
+	it("returns false for unrelated error messages", () => {
+		expect(isNetworkErrorRetryable({ stopReason: "error", errorMessage: "rate limit exceeded" })).toBe(false)
+	})
+
+	it("matches 'socket connection was closed'", () => {
+		expect(isNetworkErrorRetryable({ stopReason: "error", errorMessage: "socket connection was closed" })).toBe(true)
+	})
+
+	it("matches 'unexpectedly'", () => {
+		expect(isNetworkErrorRetryable({ stopReason: "error", errorMessage: "connection closed unexpectedly" })).toBe(true)
+	})
+
+	it("matches EPIPE", () => {
+		expect(isNetworkErrorRetryable({ stopReason: "error", errorMessage: "write EPIPE" })).toBe(true)
+	})
+
+	it("matches ERR_SOCKET_CLOSED", () => {
+		expect(isNetworkErrorRetryable({ stopReason: "error", errorMessage: "ERR_SOCKET_CLOSED" })).toBe(true)
+	})
+
+	it("matches ERR_STREAM_PREMATURE_CLOSE", () => {
+		expect(isNetworkErrorRetryable({ stopReason: "error", errorMessage: "ERR_STREAM_PREMATURE_CLOSE" })).toBe(true)
+	})
+
+	it("matches ECONNRESET", () => {
+		expect(isNetworkErrorRetryable({ stopReason: "error", errorMessage: "read ECONNRESET" })).toBe(true)
+	})
+
+	it("matches 'connection reset'", () => {
+		expect(isNetworkErrorRetryable({ stopReason: "error", errorMessage: "connection reset by peer" })).toBe(true)
+	})
+
+	it("is case-insensitive for mixed-case variants", () => {
+		expect(isNetworkErrorRetryable({ stopReason: "error", errorMessage: "Socket Connection Was Closed" })).toBe(true)
+		expect(isNetworkErrorRetryable({ stopReason: "error", errorMessage: "Connection Reset" })).toBe(true)
 	})
 })

--- a/src/upstream-retry-patch.ts
+++ b/src/upstream-retry-patch.ts
@@ -9,16 +9,22 @@ type PatchableAgentSession = {
 	}
 }
 
-const CLOUDFLARE_524_RE = /\b524\b|cloudflare.*timeout|timeout.*cloudflare/i
+// Covers Cloudflare 524 timeouts and Node fetch connection-level failures that
+// warrant a retry (socket closed mid-stream, pipe broken, connection reset, etc.)
+const RETRYABLE_NETWORK_ERROR_RE =
+	/\b524\b|cloudflare.*timeout|timeout.*cloudflare|socket connection was closed|unexpectedly|EPIPE|ERR_SOCKET_CLOSED|ERR_STREAM_PREMATURE_CLOSE|ECONNRESET|connection reset/i
 
-export function isCloudflare524Retryable(message: RetryableMessage): boolean {
-	return message.stopReason === "error" && !!message.errorMessage && CLOUDFLARE_524_RE.test(message.errorMessage)
+export function isNetworkErrorRetryable(message: RetryableMessage): boolean {
+	return (
+		message.stopReason === "error" && !!message.errorMessage && RETRYABLE_NETWORK_ERROR_RE.test(message.errorMessage)
+	)
 }
 
 /**
  * Temporary adapter for pi-coding-agent@0.74.0. Upstream retries 429/500/502/503/504
  * but not Cloudflare's 524 timeout, which kimchi-dev's gateway can return for a
- * long planner call. Remove once upstream's retry classifier covers 524.
+ * long planner call, nor Node fetch connection errors (ECONNRESET, EPIPE, etc.).
+ * Remove once upstream's retry classifier covers these cases.
  */
 export function installCloudflare524RetryPatch(
 	sessionClass: PatchableAgentSession = AgentSession as unknown as PatchableAgentSession,
@@ -29,7 +35,7 @@ export function installCloudflare524RetryPatch(
 	if (!original) return
 
 	proto._isRetryableError = function patchedIsRetryableError(message: RetryableMessage): boolean {
-		return original.call(this, message) || isCloudflare524Retryable(message)
+		return original.call(this, message) || isNetworkErrorRetryable(message)
 	}
 	proto._kimchiCloudflare524RetryPatch = true
 }

--- a/src/utils/http.test.ts
+++ b/src/utils/http.test.ts
@@ -1,0 +1,282 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
+import { computeRetryDelayMs, fetchWithRetry } from "./http.js"
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function makeResponse(status: number, headers?: Record<string, string>): Response {
+	return {
+		status,
+		ok: status >= 200 && status < 300,
+		headers: {
+			get: (name: string) => headers?.[name.toLowerCase()] ?? null,
+		},
+	} as unknown as Response
+}
+
+// ---------------------------------------------------------------------------
+// computeRetryDelayMs
+// ---------------------------------------------------------------------------
+
+describe("computeRetryDelayMs", () => {
+	it("returns expected delays for attempts 1-5 with random=()=>1", () => {
+		const random = () => 1
+
+		// planned = min(1000 * 2^(attempt-1), 60000), floor 100
+		// attempt 1: min(1000, 60000) * 1 = 1000
+		expect(computeRetryDelayMs(1, random)).toBe(1_000)
+		// attempt 2: min(2000, 60000) * 1 = 2000
+		expect(computeRetryDelayMs(2, random)).toBe(2_000)
+		// attempt 3: min(4000, 60000) * 1 = 4000
+		expect(computeRetryDelayMs(3, random)).toBe(4_000)
+		// attempt 4: min(8000, 60000) * 1 = 8000
+		expect(computeRetryDelayMs(4, random)).toBe(8_000)
+		// attempt 5: min(16000, 60000) * 1 = 16000
+		expect(computeRetryDelayMs(5, random)).toBe(16_000)
+	})
+
+	it("caps at MAX_DELAY_MS (60s) for high attempt numbers", () => {
+		const random = () => 1
+
+		// attempt 7: 1000 * 2^6 = 64000, capped to 60000
+		expect(computeRetryDelayMs(7, random)).toBe(60_000)
+		// attempt 20: well beyond cap
+		expect(computeRetryDelayMs(20, random)).toBe(60_000)
+	})
+
+	it("returns floor of 100ms when random=()=>0", () => {
+		const random = () => 0
+
+		// planned * 0 = 0, max(0, 100) = 100
+		expect(computeRetryDelayMs(1, random)).toBe(100)
+		expect(computeRetryDelayMs(5, random)).toBe(100)
+	})
+
+	it("returns half the planned delay when random=()=>0.5", () => {
+		const random = () => 0.5
+
+		// attempt 1: 1000 * 0.5 = 500
+		expect(computeRetryDelayMs(1, random)).toBe(500)
+		// attempt 2: 2000 * 0.5 = 1000
+		expect(computeRetryDelayMs(2, random)).toBe(1_000)
+		// attempt 3: 4000 * 0.5 = 2000
+		expect(computeRetryDelayMs(3, random)).toBe(2_000)
+	})
+})
+
+// ---------------------------------------------------------------------------
+// fetchWithRetry
+// ---------------------------------------------------------------------------
+
+describe("fetchWithRetry", () => {
+	beforeEach(() => {
+		vi.useFakeTimers()
+	})
+
+	afterEach(() => {
+		vi.useRealTimers()
+		vi.restoreAllMocks()
+	})
+
+	// Advance all pending timers so delays in fetchWithRetry resolve quickly.
+	// We wrap each test that needs retries with a helper that races the
+	// promise against timer advancement.
+	async function runWithTimers<T>(fn: () => Promise<T>): Promise<T> {
+		const promise = fn()
+		// Keep advancing until the promise settles.
+		await vi.runAllTimersAsync()
+		return promise
+	}
+
+	// -------------------------------------------------------------------------
+	// Happy path
+	// -------------------------------------------------------------------------
+
+	it("returns a successful response without retrying", async () => {
+		const fetchImpl = vi.fn().mockResolvedValue(makeResponse(200))
+
+		const response = await fetchWithRetry("https://example.com", undefined, { fetchImpl })
+
+		expect(response.status).toBe(200)
+		expect(fetchImpl).toHaveBeenCalledTimes(1)
+	})
+
+	// -------------------------------------------------------------------------
+	// Retry on transient HTTP status codes
+	// -------------------------------------------------------------------------
+
+	it.each([429, 500, 502, 503, 504, 524])("retries on %i and returns the successful response", async (status) => {
+		const fetchImpl = vi.fn().mockResolvedValueOnce(makeResponse(status)).mockResolvedValueOnce(makeResponse(200))
+
+		const response = await runWithTimers(() =>
+			fetchWithRetry("https://example.com", undefined, {
+				fetchImpl,
+				retry: { maxRetries: 3 },
+			}),
+		)
+
+		expect(response.status).toBe(200)
+		expect(fetchImpl).toHaveBeenCalledTimes(2)
+	})
+
+	// -------------------------------------------------------------------------
+	// Retry on network error
+	// -------------------------------------------------------------------------
+
+	it("retries after a network TypeError and returns the successful response", async () => {
+		const fetchImpl = vi
+			.fn()
+			.mockRejectedValueOnce(new TypeError("fetch failed"))
+			.mockResolvedValueOnce(makeResponse(200))
+
+		const response = await runWithTimers(() =>
+			fetchWithRetry("https://example.com", undefined, {
+				fetchImpl,
+				retry: { maxRetries: 3 },
+			}),
+		)
+
+		expect(response.status).toBe(200)
+		expect(fetchImpl).toHaveBeenCalledTimes(2)
+	})
+
+	// -------------------------------------------------------------------------
+	// Respects maxRetries - returns final bad response
+	// -------------------------------------------------------------------------
+
+	it("calls fetch exactly maxRetries times and returns the final bad response", async () => {
+		const fetchImpl = vi.fn().mockResolvedValue(makeResponse(500))
+
+		const response = await runWithTimers(() =>
+			fetchWithRetry("https://example.com", undefined, {
+				fetchImpl,
+				retry: { maxRetries: 3 },
+			}),
+		)
+
+		// Last attempt is returned, not thrown
+		expect(response.status).toBe(500)
+		expect(fetchImpl).toHaveBeenCalledTimes(3)
+	})
+
+	// -------------------------------------------------------------------------
+	// Throws after all retries exhausted on network error
+	// -------------------------------------------------------------------------
+
+	it("throws after exhausting retries when fetch always throws", async () => {
+		const networkError = new TypeError("fetch failed")
+		const fetchImpl = vi.fn().mockRejectedValue(networkError)
+
+		// Attach a no-op rejection handler immediately so the promise is never
+		// "unhandled" while timers are being flushed.
+		const promise = fetchWithRetry("https://example.com", undefined, {
+			fetchImpl,
+			retry: { maxRetries: 2 },
+		})
+		promise.catch(() => {})
+
+		await vi.runAllTimersAsync()
+
+		await expect(promise).rejects.toThrow("fetch failed")
+		expect(fetchImpl).toHaveBeenCalledTimes(2)
+	})
+
+	// -------------------------------------------------------------------------
+	// Respects caller abort signal
+	// -------------------------------------------------------------------------
+
+	it("throws immediately without retrying when caller signal is already aborted", async () => {
+		const controller = new AbortController()
+		controller.abort()
+
+		const fetchImpl = vi.fn().mockRejectedValue(new DOMException("Aborted", "AbortError"))
+
+		await expect(
+			fetchWithRetry("https://example.com", undefined, {
+				fetchImpl,
+				signal: controller.signal,
+				retry: { maxRetries: 5 },
+			}),
+		).rejects.toThrow()
+
+		// Should not retry after caller aborts
+		expect(fetchImpl).toHaveBeenCalledTimes(1)
+	})
+
+	// -------------------------------------------------------------------------
+	// Timeout via AbortController
+	// -------------------------------------------------------------------------
+
+	it("aborts and throws when fetch hangs past timeoutMs", async () => {
+		const fetchImpl = vi.fn().mockImplementation((_url: string, init?: RequestInit) => {
+			// Simulate a hanging fetch that respects the abort signal
+			return new Promise<Response>((_resolve, reject) => {
+				init?.signal?.addEventListener("abort", () => {
+					reject(new DOMException("The operation was aborted.", "AbortError"))
+				})
+			})
+		})
+
+		const promise = fetchWithRetry("https://example.com", undefined, {
+			fetchImpl,
+			timeoutMs: 100,
+			retry: { maxRetries: 1 },
+		})
+		// Suppress unhandled rejection during timer flush
+		promise.catch(() => {})
+
+		// Advance past the timeout
+		await vi.advanceTimersByTimeAsync(200)
+
+		await expect(promise).rejects.toThrow()
+		expect(fetchImpl).toHaveBeenCalledTimes(1)
+	})
+
+	// -------------------------------------------------------------------------
+	// Retry-After header
+	// -------------------------------------------------------------------------
+
+	it("waits at least Retry-After seconds before retrying on 429", async () => {
+		const fetchImpl = vi
+			.fn()
+			.mockResolvedValueOnce(makeResponse(429, { "retry-after": "2" }))
+			.mockResolvedValueOnce(makeResponse(200))
+
+		let settled = false
+		const promise = fetchWithRetry("https://example.com", undefined, {
+			fetchImpl,
+			retry: { maxRetries: 3 },
+		}).then((r) => {
+			settled = true
+			return r
+		})
+
+		// Advance less than 2s — should not have settled yet (still waiting for Retry-After)
+		await vi.advanceTimersByTimeAsync(1_500)
+		expect(settled).toBe(false)
+
+		// Advance past the 2s Retry-After window
+		await vi.advanceTimersByTimeAsync(1_000)
+		const response = await promise
+
+		expect(response.status).toBe(200)
+		expect(fetchImpl).toHaveBeenCalledTimes(2)
+	})
+
+	// -------------------------------------------------------------------------
+	// Does not retry non-retriable 4xx
+	// -------------------------------------------------------------------------
+
+	it.each([400, 401, 403, 404])("does not retry %i and returns the response after a single call", async (status) => {
+		const fetchImpl = vi.fn().mockResolvedValue(makeResponse(status))
+
+		const response = await fetchWithRetry("https://example.com", undefined, {
+			fetchImpl,
+			retry: { maxRetries: 5 },
+		})
+
+		expect(response.status).toBe(status)
+		expect(fetchImpl).toHaveBeenCalledTimes(1)
+	})
+})

--- a/src/utils/http.test.ts
+++ b/src/utils/http.test.ts
@@ -204,6 +204,26 @@ describe("fetchWithRetry", () => {
 		expect(fetchImpl).toHaveBeenCalledTimes(1)
 	})
 
+	it("aborts during retry delay when signal is triggered", async () => {
+		const fetchImpl = vi.fn().mockResolvedValueOnce(makeResponse(500)).mockResolvedValueOnce(makeResponse(200))
+		const controller = new AbortController()
+
+		const promise = fetchWithRetry("https://example.com", undefined, {
+			fetchImpl,
+			signal: controller.signal,
+			retry: { maxRetries: 3 },
+		})
+
+		// Let the first attempt complete and enter retry delay
+		await vi.advanceTimersByTimeAsync(0)
+		// Abort during the delay
+		controller.abort()
+
+		await expect(promise).rejects.toThrow()
+		// Should NOT have made a second attempt
+		expect(fetchImpl).toHaveBeenCalledTimes(1)
+	})
+
 	// -------------------------------------------------------------------------
 	// Timeout via AbortController
 	// -------------------------------------------------------------------------

--- a/src/utils/http.ts
+++ b/src/utils/http.ts
@@ -36,6 +36,24 @@ function parseRetryAfterMs(response: Response): number | null {
 	return null
 }
 
+function abortableDelay(ms: number, signal?: AbortSignal): Promise<void> {
+	return new Promise((resolve, reject) => {
+		if (signal?.aborted) {
+			reject(signal.reason)
+			return
+		}
+		const timer = setTimeout(resolve, ms)
+		signal?.addEventListener(
+			"abort",
+			() => {
+				clearTimeout(timer)
+				reject(signal.reason)
+			},
+			{ once: true },
+		)
+	})
+}
+
 export async function fetchWithRetry(
 	url: string,
 	init?: RequestInit,
@@ -68,7 +86,7 @@ export async function fetchWithRetry(
 			const retryAfterMs = parseRetryAfterMs(response)
 			const computedDelay = computeRetryDelayMs(attempt)
 			const delay = retryAfterMs !== null ? Math.max(computedDelay, retryAfterMs) : computedDelay
-			await new Promise((resolve) => setTimeout(resolve, delay))
+			await abortableDelay(delay, options?.signal)
 		} catch (error) {
 			clearTimeout(timer)
 
@@ -80,7 +98,7 @@ export async function fetchWithRetry(
 			lastError = error
 
 			const delay = computeRetryDelayMs(attempt)
-			await new Promise((resolve) => setTimeout(resolve, delay))
+			await abortableDelay(delay, options?.signal)
 		}
 	}
 

--- a/src/utils/http.ts
+++ b/src/utils/http.ts
@@ -1,0 +1,88 @@
+import { RETRY_DEFAULTS, type RetryConfig } from "../config.js"
+
+const RETRYABLE_STATUSES = new Set([429, 500, 502, 503, 504, 524])
+const BASE_DELAY_MS = 1_000
+const MAX_DELAY_MS = 60_000
+const BACKOFF_FACTOR = 2
+
+export interface FetchWithRetryOptions {
+	timeoutMs?: number
+	retry?: Partial<RetryConfig>
+	signal?: AbortSignal
+	fetchImpl?: typeof globalThis.fetch
+}
+
+/**
+ * Exponential backoff with full jitter.
+ * delay = min(BASE * FACTOR^(attempt-1), MAX) * random()
+ * Floor of 100ms to avoid busy-loops.
+ */
+export function computeRetryDelayMs(attempt: number, random: () => number = Math.random): number {
+	const planned = Math.min(BASE_DELAY_MS * BACKOFF_FACTOR ** (attempt - 1), MAX_DELAY_MS)
+	return Math.max(planned * random(), 100)
+}
+
+function isRetryableResponse(response: Response): boolean {
+	return RETRYABLE_STATUSES.has(response.status)
+}
+
+function parseRetryAfterMs(response: Response): number | null {
+	const header = response.headers.get("retry-after")
+	if (!header) return null
+	const seconds = Number(header)
+	if (Number.isFinite(seconds) && seconds >= 0) return seconds * 1000
+	const dateMs = Date.parse(header)
+	if (!Number.isNaN(dateMs)) return Math.max(dateMs - Date.now(), 0)
+	return null
+}
+
+export async function fetchWithRetry(
+	url: string,
+	init?: RequestInit,
+	options?: FetchWithRetryOptions,
+): Promise<Response> {
+	const fetchFn = options?.fetchImpl ?? globalThis.fetch
+	const timeoutMs = options?.timeoutMs ?? 30_000
+	const maxRetries = options?.retry?.maxRetries ?? RETRY_DEFAULTS.maxRetries
+
+	let lastError: unknown
+
+	for (let attempt = 1; attempt <= maxRetries; attempt++) {
+		const ctrl = new AbortController()
+		const timer = setTimeout(() => ctrl.abort(), timeoutMs)
+		const signal = options?.signal ? AbortSignal.any([ctrl.signal, options.signal]) : ctrl.signal
+
+		try {
+			const response = await fetchFn(url, { ...init, signal })
+			clearTimeout(timer)
+
+			if (!isRetryableResponse(response) || attempt === maxRetries) {
+				return response
+			}
+
+			// Drain body so the connection can be reused
+			await response.body?.cancel().catch(() => {})
+
+			lastError = new Error(`HTTP ${response.status}`)
+
+			const retryAfterMs = parseRetryAfterMs(response)
+			const computedDelay = computeRetryDelayMs(attempt)
+			const delay = retryAfterMs !== null ? Math.max(computedDelay, retryAfterMs) : computedDelay
+			await new Promise((resolve) => setTimeout(resolve, delay))
+		} catch (error) {
+			clearTimeout(timer)
+
+			// If caller aborted, don't retry
+			if (options?.signal?.aborted) throw error
+
+			if (attempt === maxRetries) throw error
+
+			lastError = error
+
+			const delay = computeRetryDelayMs(attempt)
+			await new Promise((resolve) => setTimeout(resolve, delay))
+		}
+	}
+
+	throw lastError
+}

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -13,6 +13,9 @@ export default defineConfig({
 			PI_PACKAGE_DIR: fileURLToPath(
 				new URL("./node_modules/@earendil-works/pi-coding-agent", import.meta.url),
 			),
+			// Pin locale so toLocaleString() produces consistent comma-separated
+			// numbers across developer machines and CI regardless of system locale.
+			LANG: "en_US.UTF-8",
 		},
 		alias: {
 			// The deep-import path used in clipboard-read.ts is not in the package's


### PR DESCRIPTION
## TL;DR

Add configurable retry with exponential backoff and timeout to all 16 first-party fetch calls via a shared `fetchWithRetry` utility. Sync retry config to the SDK so one setting controls everything.

## Requirements

- All non-SDK fetch calls must retry on transient failures (network errors, 429, 5xx)
- Exponential backoff with jitter to prevent thundering herd
- Per-request timeout (default 30s, configurable per site)
- Retry-After header support
- User-configurable maxRetries via config.json
- SDK LLM retries use the same config value
- Third-party services use a lower retry count (4) than Kimchi APIs (10)

## Changes

- New `fetchWithRetry` utility with backoff, jitter, timeout, and Retry-After support
- All 16 fetch sites migrated with appropriate retry counts per tier
- Retry config synced to SDK settings.json at startup and sub-agent SettingsManager
- Extended upstream retry regex for additional Node fetch error patterns

Closes #0