### PR TITLE
fix(ferment): Remove meta system prompt parts for ferment

### DIFF
--- a/src/extensions/agents/personas/default-agents.ts
+++ b/src/extensions/agents/personas/default-agents.ts
@@ -119,7 +119,7 @@ You are STRICTLY PROHIBITED from:
 # Planning Process
 
 1. **Decide whether to explore first.** Only read files if the task is about code or software. If the task is NOT about code (writing, strategy, general planning), skip exploration entirely and go straight to clarifying questions.
-2. **Draft the plan directly.** Do NOT start Ferment, use ferment tools, or use any workflow-starting mechanism.
+2. **Draft the plan directly.** Do NOT use any workflow-starting mechanism.
 3. Understand requirements — ask clarifying questions via \`questionnaire\` before committing to an approach.
 4. If code-related: explore relevant files, understand architecture, identify patterns.
 5. Identify ambiguities and resolve them with the user before proceeding.

--- a/src/extensions/agents/personas/default-agents.ts
+++ b/src/extensions/agents/personas/default-agents.ts
@@ -119,7 +119,7 @@ You are STRICTLY PROHIBITED from:
 # Planning Process
 
 1. **Decide whether to explore first.** Only read files if the task is about code or software. If the task is NOT about code (writing, strategy, general planning), skip exploration entirely and go straight to clarifying questions.
-2. **Draft the plan directly.** Do NOT use ferment tools, or any workflow-starting mechanism.
+2. **Draft the plan directly.** Do NOT start Ferment, use ferment tools, or use any workflow-starting mechanism.
 3. Understand requirements — ask clarifying questions via \`questionnaire\` before committing to an approach.
 4. If code-related: explore relevant files, understand architecture, identify patterns.
 5. Identify ambiguities and resolve them with the user before proceeding.

--- a/src/extensions/agents/personas/default-agents.ts
+++ b/src/extensions/agents/personas/default-agents.ts
@@ -119,7 +119,7 @@ You are STRICTLY PROHIBITED from:
 # Planning Process
 
 1. **Decide whether to explore first.** Only read files if the task is about code or software. If the task is NOT about code (writing, strategy, general planning), skip exploration entirely and go straight to clarifying questions.
-2. **Draft the plan directly.** Do NOT use \`request_ferment_workflow\`, ferment tools, or any workflow-starting mechanism.
+2. **Draft the plan directly.** Do NOT use ferment tools, or any workflow-starting mechanism.
 3. Understand requirements — ask clarifying questions via \`questionnaire\` before committing to an approach.
 4. If code-related: explore relevant files, understand architecture, identify patterns.
 5. Identify ambiguities and resolve them with the user before proceeding.

--- a/src/extensions/agents/prompt/prompts.test.ts
+++ b/src/extensions/agents/prompt/prompts.test.ts
@@ -133,7 +133,7 @@ describe("default agents — subagent system prompt snapshot", () => {
 			# Planning Process
 
 			1. **Decide whether to explore first.** Only read files if the task is about code or software. If the task is NOT about code (writing, strategy, general planning), skip exploration entirely and go straight to clarifying questions.
-			2. **Draft the plan directly.** Do NOT start Ferment, use ferment tools, or use any workflow-starting mechanism.
+			2. **Draft the plan directly.** Do NOT use any workflow-starting mechanism.
 			3. Understand requirements — ask clarifying questions via \`questionnaire\` before committing to an approach.
 			4. If code-related: explore relevant files, understand architecture, identify patterns.
 			5. Identify ambiguities and resolve them with the user before proceeding.

--- a/src/extensions/agents/prompt/prompts.test.ts
+++ b/src/extensions/agents/prompt/prompts.test.ts
@@ -133,7 +133,7 @@ describe("default agents — subagent system prompt snapshot", () => {
 			# Planning Process
 
 			1. **Decide whether to explore first.** Only read files if the task is about code or software. If the task is NOT about code (writing, strategy, general planning), skip exploration entirely and go straight to clarifying questions.
-			2. **Draft the plan directly.** Do NOT use \`request_ferment_workflow\`, ferment tools, or any workflow-starting mechanism.
+			2. **Draft the plan directly.** Do NOT start Ferment, use ferment tools, or use any workflow-starting mechanism.
 			3. Understand requirements — ask clarifying questions via \`questionnaire\` before committing to an approach.
 			4. If code-related: explore relevant files, understand architecture, identify patterns.
 			5. Identify ambiguities and resolve them with the user before proceeding.

--- a/src/extensions/ferment/commands.test.ts
+++ b/src/extensions/ferment/commands.test.ts
@@ -381,7 +381,7 @@ describe("FermentCommandController", () => {
 		expect(h.storage.get(ferment.id)?.status).toBe("draft")
 		expect(h.runtime.getActive()).toBeUndefined()
 		expect(h.runtime.setActive).toHaveBeenLastCalledWith(undefined)
-		expect(h.pi.setActiveTools).toHaveBeenLastCalledWith(["read", "bash", "propose_ferment_scoping"])
+		expect(h.pi.setActiveTools).toHaveBeenLastCalledWith(["read", "bash"])
 		expect(h.runtime.getContinuationPolicy()).toBe("manual")
 		expect(h.ctx.ui.notify).toHaveBeenCalledWith(expect.stringContaining('Exited Ferment mode for "Draft Exit"'))
 		expect(h.pi.sendMessage).toHaveBeenCalledWith(
@@ -411,7 +411,7 @@ describe("FermentCommandController", () => {
 		expect(h.runtime.getActive()).toBeUndefined()
 		expect(h.runtime.setActive).toHaveBeenCalledWith(expect.objectContaining({ status: "paused" }))
 		expect(h.runtime.setActive).toHaveBeenLastCalledWith(undefined)
-		expect(h.pi.setActiveTools).toHaveBeenLastCalledWith(["read", "bash", "propose_ferment_scoping"])
+		expect(h.pi.setActiveTools).toHaveBeenLastCalledWith(["read", "bash"])
 		expect(h.runtime.getContinuationPolicy()).toBe("automated")
 	})
 
@@ -429,7 +429,7 @@ describe("FermentCommandController", () => {
 		expect(h.runtime.getActive()).toBeUndefined()
 		expect(h.runtime.setActive).toHaveBeenCalledWith(expect.objectContaining({ status: "paused" }))
 		expect(h.runtime.setActive).toHaveBeenLastCalledWith(undefined)
-		expect(h.pi.setActiveTools).toHaveBeenLastCalledWith(["read", "bash", "propose_ferment_scoping"])
+		expect(h.pi.setActiveTools).toHaveBeenLastCalledWith(["read", "bash"])
 	})
 
 	it("/ferment exit leaves paused ferments paused while clearing active mode", async () => {
@@ -446,7 +446,7 @@ describe("FermentCommandController", () => {
 		expect(h.runtime.getActive()).toBeUndefined()
 		expect(h.runtime.setActive).toHaveBeenCalledTimes(1)
 		expect(h.runtime.setActive).toHaveBeenLastCalledWith(undefined)
-		expect(h.pi.setActiveTools).toHaveBeenLastCalledWith(["read", "bash", "propose_ferment_scoping"])
+		expect(h.pi.setActiveTools).toHaveBeenLastCalledWith(["read", "bash"])
 	})
 
 	it("/ferment exit detaches terminal ferments without mutating lifecycle", async () => {
@@ -463,7 +463,7 @@ describe("FermentCommandController", () => {
 		expect(h.runtime.getActive()).toBeUndefined()
 		expect(h.runtime.setActive).toHaveBeenCalledTimes(1)
 		expect(h.runtime.setActive).toHaveBeenLastCalledWith(undefined)
-		expect(h.pi.setActiveTools).toHaveBeenLastCalledWith(["read", "bash", "propose_ferment_scoping"])
+		expect(h.pi.setActiveTools).toHaveBeenLastCalledWith(["read", "bash"])
 		expect(h.ctx.ui.notify).toHaveBeenCalledWith(
 			'Exited Ferment mode for "Complete Exit". It remains complete and is still available from /ferment list.',
 		)

--- a/src/extensions/ferment/commands.ts
+++ b/src/extensions/ferment/commands.ts
@@ -195,17 +195,14 @@ export async function startInteractiveFerment({
 
 	// Echo the typed intent into the transcript before the host starts working.
 	// /ferment new "X" with an inline title skips this; the title was visible in
-	// the slash command itself. The tool path (request_ferment_workflow) also skips
-	// because its tool call serves the same purpose.
+	// the slash command itself.
 	sendFermentRequestMessage(pi, rawIntent)
 	await startFermentForIntent({ pi, ctx, runtime, rawIntent })
 }
 
 /**
  * Create a draft ferment and run the interactive scoping flow with a
- * pre-supplied intent. Shared between the slash command (after editor prompt)
- * and the `request_ferment_workflow` tool (after the agent confirms with the
- * user via questionnaire). Returns `undefined` when another ferment is already
+ * pre-supplied intent. Returns `undefined` when another ferment is already
  * running and the call is refused.
  */
 export async function startFermentForIntent({

--- a/src/extensions/ferment/events.test.ts
+++ b/src/extensions/ferment/events.test.ts
@@ -183,7 +183,7 @@ describe("registerFermentEvents", () => {
 		expect(result?.systemPrompt).toBeUndefined()
 	})
 
-	it("applies the idle static profile on before_agent_start when flag is unset and no ferment is active", async () => {
+	it("applies the idle static profile without ferment tools when no ferment is active", async () => {
 		const runtime: FermentRuntime = { ...createDefaultFermentRuntime() }
 		const { handlers, pi } = createPi()
 		;(pi.getFlag as ReturnType<typeof vi.fn>).mockReturnValue(undefined)
@@ -203,7 +203,7 @@ describe("registerFermentEvents", () => {
 		await beforeAgentStart({ systemPrompt: "base" }, {})
 
 		const lastCall = (pi.setActiveTools as ReturnType<typeof vi.fn>).mock.lastCall?.[0] as string[]
-		expect(lastCall).toContain("list_ferments")
+		expect(lastCall).not.toContain("list_ferments")
 		expect(lastCall).not.toContain("scope_ferment")
 	})
 

--- a/src/extensions/ferment/prompt-block.test.ts
+++ b/src/extensions/ferment/prompt-block.test.ts
@@ -16,14 +16,19 @@ function makeMockCtx(): ExtensionContext {
 	return { sessionManager: { getSessionId: () => TEST_SESSION_ID } } as unknown as ExtensionContext
 }
 
-function makePi(oneshot: boolean): ExtensionAPI {
+function makePi(oneshot: boolean, idleNudge = false): ExtensionAPI {
 	return {
-		getFlag: (name: string) => (name === "ferment-oneshot" ? oneshot : undefined),
+		getFlag: (name: string) => {
+			if (name === "ferment-oneshot") return oneshot
+			if (name === "ferment-idle-nudge") return idleNudge
+			return undefined
+		},
 	} as unknown as ExtensionAPI
 }
 
 const PI_NORMAL = makePi(false)
 const PI_ONESHOT = makePi(true)
+const PI_IDLE_NUDGE = makePi(false, true)
 
 const NOW = "2026-01-01T00:00:00.000Z"
 
@@ -115,8 +120,13 @@ describe("buildFermentPromptBlock", () => {
 			})
 		}
 
-		it("returns idle hint when no ferment is active", () => {
+		it("does not inject the idle hint when no ferment is active", () => {
 			const out = buildFermentPromptBlock(makeMockCtx(), PI_NORMAL, makeNoActiveFermentRuntime())
+			expect(out).toBeUndefined()
+		})
+
+		it("returns idle hint when the ferment-idle-nudge flag is enabled", () => {
+			const out = buildFermentPromptBlock(makeMockCtx(), PI_IDLE_NUDGE, makeNoActiveFermentRuntime())
 			expect(out).toContain("Ferment Workflow")
 			expect(out).toContain("The tool asks the user for explicit host confirmation")
 			expect(out).toContain("In yolo permissions mode, the host auto-approves")
@@ -321,8 +331,8 @@ describe("buildFermentPromptBlock", () => {
 			expect(out).not.toContain("worker_model")
 		})
 
-		it("keeps phase tagging out of the pre-ferment classification path", () => {
-			const out = buildFermentPromptBlock(makeMockCtx(), PI_NORMAL, makeNoActiveFermentRuntime()) ?? ""
+		it("keeps phase tagging out of the flagged idle-nudge classification path", () => {
+			const out = buildFermentPromptBlock(makeMockCtx(), PI_IDLE_NUDGE, makeNoActiveFermentRuntime()) ?? ""
 			expect(out).toContain("Do not call `set_phase`")
 			expect(out).toContain("*until* you have classified the request")
 			expect(out).toContain("called `request_ferment_workflow`")

--- a/src/extensions/ferment/prompt-block.test.ts
+++ b/src/extensions/ferment/prompt-block.test.ts
@@ -16,19 +16,14 @@ function makeMockCtx(): ExtensionContext {
 	return { sessionManager: { getSessionId: () => TEST_SESSION_ID } } as unknown as ExtensionContext
 }
 
-function makePi(oneshot: boolean, idleNudge = false): ExtensionAPI {
+function makePi(oneshot: boolean): ExtensionAPI {
 	return {
-		getFlag: (name: string) => {
-			if (name === "ferment-oneshot") return oneshot
-			if (name === "ferment-idle-nudge") return idleNudge
-			return undefined
-		},
+		getFlag: (name: string) => (name === "ferment-oneshot" ? oneshot : undefined),
 	} as unknown as ExtensionAPI
 }
 
 const PI_NORMAL = makePi(false)
 const PI_ONESHOT = makePi(true)
-const PI_IDLE_NUDGE = makePi(false, true)
 
 const NOW = "2026-01-01T00:00:00.000Z"
 
@@ -123,17 +118,6 @@ describe("buildFermentPromptBlock", () => {
 		it("does not inject the idle hint when no ferment is active", () => {
 			const out = buildFermentPromptBlock(makeMockCtx(), PI_NORMAL, makeNoActiveFermentRuntime())
 			expect(out).toBeUndefined()
-		})
-
-		it("returns idle hint when the ferment-idle-nudge flag is enabled", () => {
-			const out = buildFermentPromptBlock(makeMockCtx(), PI_IDLE_NUDGE, makeNoActiveFermentRuntime())
-			expect(out).toContain("Ferment Workflow")
-			expect(out).toContain("The tool asks the user for explicit host confirmation")
-			expect(out).toContain("In yolo permissions mode, the host auto-approves")
-			expect(out).not.toContain("questionnaire")
-			expect(out).not.toContain("ferment_start_approval")
-			expect(out).toContain("`intent` containing the full original user request")
-			expect(out).toContain("Never block")
 		})
 	})
 
@@ -329,16 +313,6 @@ describe("buildFermentPromptBlock", () => {
 			expect(out).not.toContain("minimax-m2.7")
 			expect(out).not.toContain("kimi-k2.5")
 			expect(out).not.toContain("worker_model")
-		})
-
-		it("keeps phase tagging out of the flagged idle-nudge classification path", () => {
-			const out = buildFermentPromptBlock(makeMockCtx(), PI_IDLE_NUDGE, makeNoActiveFermentRuntime()) ?? ""
-			expect(out).toContain("Do not call `set_phase`")
-			expect(out).toContain("*until* you have classified the request")
-			expect(out).toContain("called `request_ferment_workflow`")
-			expect(out).toContain("open-ended analysis of an existing app")
-			expect(out).toContain("request the ferment workflow before analysis, file reads, or phase tagging")
-			expect(out).toContain("the host handles confirmation and queues scoping")
 		})
 	})
 

--- a/src/extensions/ferment/prompt-block.ts
+++ b/src/extensions/ferment/prompt-block.ts
@@ -93,19 +93,6 @@ function buildPausedWarning(f: Ferment): string {
 	return `\n\n## Ferment Paused\n\nFerment "${f.name}" is paused by the user. Do NOT call any ferment tools (activate_ferment_phase, start_ferment_step, complete_ferment_step, etc.) — they will be rejected. Acknowledge any pending question briefly and wait for the user to resume with /ferment resume.`
 }
 
-const IDLE_FERMENT_HINT = `## Ferment Workflow (optional)
-
-Ferment is a host-owned plan → build → review workflow. Start it only with \`request_ferment_workflow\`; never create or edit \`.kimchi/\` files yourself. The tool asks the user for explicit host confirmation before creating the workflow. In yolo permissions mode, the host auto-approves.
-
-Before exploration, classify the user's text only:
-- Clear small task: handle inline.
-- Substantive, multi-step, broad discovery, or explicit ferment/planning request: call \`request_ferment_workflow\` first.
-- Vague non-ferment request: ask only decision-blocking clarification, then act inline.
-Do not call \`set_phase\` or discovery tools *until* you have classified the request and either called \`request_ferment_workflow\`, chosen inline work, or asked necessary non-ferment clarification.
-Treat open-ended analysis of an existing app as substantive: request the ferment workflow before analysis, file reads, or phase tagging.
-
-Call \`request_ferment_workflow\` with a concise \`title\` and an \`intent\` containing the full original user request, then stop; the host handles confirmation and queues scoping. If the user declines, continue inline. Never block on this.`
-
 /**
  * Renders the ferment-specific system-prompt block. Registered as a
  * `SystemPromptBlock` from index.ts and assembled into the system prompt by
@@ -119,8 +106,7 @@ Call \`request_ferment_workflow\` with a concise \`title\` and an \`intent\` con
  *   ferment-oneshot planner must scope autonomously from the bootstrap turn.
  *
  * Returns `undefined` for terminal/draft states that already have their own
- * flow. Idle sessions stay Ferment-free by default; `ferment-idle-nudge`
- * keeps the old optional hint available for controlled experiments.
+ * flow. Idle sessions stay Ferment-free.
  */
 export function buildFermentPromptBlock(
 	ctx: ExtensionContext,
@@ -136,9 +122,7 @@ export function buildFermentPromptBlock(
 	if (getPermissionMode(sessionId)?.mode === "plan") return undefined
 
 	const f = runtime.getActive()
-	if (!f) {
-		return pi.getFlag("ferment-idle-nudge") === true ? IDLE_FERMENT_HINT : undefined
-	}
+	if (!f) return undefined
 
 	const oneshot = pi.getFlag("ferment-oneshot") === true
 

--- a/src/extensions/ferment/prompt-block.ts
+++ b/src/extensions/ferment/prompt-block.ts
@@ -118,9 +118,9 @@ Call \`request_ferment_workflow\` with a concise \`title\` and an \`intent\` con
  * - flag set: draft state still gets the planner supplement because the
  *   ferment-oneshot planner must scope autonomously from the bootstrap turn.
  *
- * Returns `undefined` only for terminal/draft states that already have their
- * own flow; idle (no ferment) renders a soft, optional hint that nudges the
- * agent to ask the user before starting substantial work, never to block.
+ * Returns `undefined` for terminal/draft states that already have their own
+ * flow. Idle sessions stay Ferment-free by default; `ferment-idle-nudge`
+ * keeps the old optional hint available for controlled experiments.
  */
 export function buildFermentPromptBlock(
 	ctx: ExtensionContext,
@@ -136,7 +136,9 @@ export function buildFermentPromptBlock(
 	if (getPermissionMode(sessionId)?.mode === "plan") return undefined
 
 	const f = runtime.getActive()
-	if (!f) return IDLE_FERMENT_HINT
+	if (!f) {
+		return pi.getFlag("ferment-idle-nudge") === true ? IDLE_FERMENT_HINT : undefined
+	}
 
 	const oneshot = pi.getFlag("ferment-oneshot") === true
 

--- a/src/extensions/ferment/tool-names.ts
+++ b/src/extensions/ferment/tool-names.ts
@@ -1,5 +1,4 @@
 export const FERMENT_TOOLS = {
-	REQUEST_WORKFLOW: "request_ferment_workflow",
 	PROPOSE_SCOPING: "propose_ferment_scoping",
 	LIST: "list_ferments",
 	SCOPE: "scope_ferment",
@@ -24,7 +23,7 @@ export const FERMENT_TOOLS = {
 export const FERMENT_TOOL_NAMES = Object.freeze(Object.values(FERMENT_TOOLS))
 
 const FERMENT_TOOL_NAME_SET = new Set<string>(FERMENT_TOOL_NAMES)
-const NON_PLANNER_FERMENT_TOOL_NAMES = new Set<string>([FERMENT_TOOLS.LIST, FERMENT_TOOLS.REQUEST_WORKFLOW])
+const NON_PLANNER_FERMENT_TOOL_NAMES = new Set<string>([FERMENT_TOOLS.LIST])
 const PLANNER_ONLY_FERMENT_TOOL_NAMES = new Set<string>([
 	FERMENT_TOOLS.PROPOSE_SCOPING,
 	FERMENT_TOOLS.SCOPE,

--- a/src/extensions/ferment/tool-scope.test.ts
+++ b/src/extensions/ferment/tool-scope.test.ts
@@ -38,7 +38,6 @@ describe("ferment tool scope", () => {
 			[
 				"read",
 				"bash",
-				"request_ferment_workflow",
 				"propose_ferment_scoping",
 				"scope_ferment",
 				"activate_ferment_phase",
@@ -49,7 +48,6 @@ describe("ferment tool scope", () => {
 			[
 				"read",
 				"bash",
-				"request_ferment_workflow",
 				"propose_ferment_scoping",
 				"scope_ferment",
 				"activate_ferment_phase",

--- a/src/extensions/ferment/tool-scope.test.ts
+++ b/src/extensions/ferment/tool-scope.test.ts
@@ -33,11 +33,13 @@ describe("ferment tool scope", () => {
 		expect(pi.setActiveTools).toHaveBeenLastCalledWith(["read", "bash", "start_ferment_step"])
 	})
 
-	it("applies the idle profile as discovery-only ferment tools", () => {
+	it("applies the idle profile without ferment tools", () => {
 		const pi = createPi(
 			[
 				"read",
 				"bash",
+				"request_ferment_workflow",
+				"propose_ferment_scoping",
 				"scope_ferment",
 				"activate_ferment_phase",
 				"list_ferments",
@@ -47,6 +49,8 @@ describe("ferment tool scope", () => {
 			[
 				"read",
 				"bash",
+				"request_ferment_workflow",
+				"propose_ferment_scoping",
 				"scope_ferment",
 				"activate_ferment_phase",
 				"list_ferments",
@@ -57,12 +61,7 @@ describe("ferment tool scope", () => {
 
 		applyFermentToolProfile(pi, "idle")
 
-		expect(pi.setActiveTools).toHaveBeenLastCalledWith([
-			"read",
-			"bash",
-			FERMENT_TOOLS.LIST,
-			FERMENT_TOOLS.CONFIRM_COMPLETION_CRITERIA,
-		])
+		expect(pi.setActiveTools).toHaveBeenLastCalledWith(["read", "bash"])
 	})
 
 	it("keeps the existing-ferment lifecycle surface for an active planner profile", () => {

--- a/src/extensions/ferment/tool-scope.ts
+++ b/src/extensions/ferment/tool-scope.ts
@@ -7,17 +7,6 @@ import { FERMENT_TOOLS, FERMENT_TOOL_NAMES, isFermentToolName } from "./tool-nam
 
 export type FermentToolProfile = "idle" | "planner-active" | "paused-terminal" | "worker" | "oneshot-planner"
 
-// Idle includes `propose_ferment_scoping` so it lives in the LLM's tool snapshot from
-// the very first turn. When `request_ferment_workflow` creates a draft mid-turn, the
-// LLM can immediately call `propose_ferment_scoping` without waiting for a new turn
-// snapshot (pi-mono snapshots active tools at turn start; mid-turn profile changes
-// don't reach the running turn).
-const IDLE_FERMENT_TOOL_NAMES = [
-	FERMENT_TOOLS.LIST,
-	FERMENT_TOOLS.REQUEST_WORKFLOW,
-	FERMENT_TOOLS.CONFIRM_COMPLETION_CRITERIA,
-	FERMENT_TOOLS.PROPOSE_SCOPING,
-] as const
 const PAUSED_TERMINAL_FERMENT_TOOL_NAMES = [FERMENT_TOOLS.LIST, FERMENT_TOOLS.REQUEST_WORKFLOW] as const
 
 /**
@@ -58,7 +47,7 @@ function registeredFermentToolNames(pi: ExtensionAPI): string[] {
 function allowedFermentToolNamesForProfile(profile: FermentToolProfile): readonly string[] {
 	switch (profile) {
 		case "idle":
-			return IDLE_FERMENT_TOOL_NAMES
+			return []
 		case "planner-active":
 			return FERMENT_TOOL_NAMES
 		case "oneshot-planner":

--- a/src/extensions/ferment/tool-scope.ts
+++ b/src/extensions/ferment/tool-scope.ts
@@ -7,7 +7,7 @@ import { FERMENT_TOOLS, FERMENT_TOOL_NAMES, isFermentToolName } from "./tool-nam
 
 export type FermentToolProfile = "idle" | "planner-active" | "paused-terminal" | "worker" | "oneshot-planner"
 
-const PAUSED_TERMINAL_FERMENT_TOOL_NAMES = [FERMENT_TOOLS.LIST, FERMENT_TOOLS.REQUEST_WORKFLOW] as const
+const PAUSED_TERMINAL_FERMENT_TOOL_NAMES = [FERMENT_TOOLS.LIST] as const
 
 /**
  * Tools the planner is allowed to call directly in `ferment-oneshot` mode.

--- a/src/extensions/ferment/tools.integration.test.ts
+++ b/src/extensions/ferment/tools.integration.test.ts
@@ -18,7 +18,6 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
 import { FermentEventStore } from "../../ferment/event-store.js"
 import { FermentStorage, clearFermentCache } from "../../ferment/store.js"
 import type { Ferment } from "../../ferment/types.js"
-import { PERMISSIONS_ENV_KEY } from "../permissions/constants.js"
 import { type FermentRuntime, createDefaultFermentRuntime } from "./runtime.js"
 import { clearAllPendingScopes, getPendingScope, setPendingScope } from "./scoping.js"
 import {
@@ -113,17 +112,6 @@ function createHarness(): Harness {
 	}
 
 	return { storage, runtime, tempDir, tools, pi, call }
-}
-
-function createWorkflowCtx(options: { confirm?: boolean } = {}) {
-	return {
-		hasUI: true,
-		ui: {
-			notify: vi.fn(),
-			setStatus: vi.fn(),
-			confirm: vi.fn(async () => options.confirm ?? false),
-		},
-	}
 }
 
 // Helpers for asserting on tool results.
@@ -240,84 +228,6 @@ function loadFerment(id: string): Ferment {
 	if (!f) throw new Error(`Ferment ${id} not found`)
 	return f
 }
-
-// ─── request_ferment_workflow ────────────────────────────────────────────────
-
-describe("request_ferment_workflow approval gate", () => {
-	const approvedIntent = "Find improvements to this extension, but do not implement anything until I approve the plan."
-	const requestWorkflow = (params: { title?: string; intent?: string }, ctx = createWorkflowCtx()) =>
-		h.call("request_ferment_workflow", { title: "Approved Ferment", intent: approvedIntent, ...params }, ctx)
-
-	it("asks the host for approval and refuses when the user declines", async () => {
-		const ctx = createWorkflowCtx({ confirm: false })
-		const text = err(
-			await requestWorkflow({ title: "No Consent", intent: "Find improvements to this extension." }, ctx),
-		)
-
-		expect(ctx.ui.confirm).toHaveBeenCalledWith(
-			"Start Ferment Workflow",
-			expect.stringContaining('Start a Ferment workflow for "No Consent"?'),
-		)
-		expect(text).toContain("request_ferment_workflow cancelled")
-		expect(text).toContain("user declined")
-		expect(getActive()).toBeUndefined()
-	})
-
-	it("starts after host approval", async () => {
-		const ctx = createWorkflowCtx({ confirm: true })
-
-		const text = ok(await requestWorkflow({}, ctx))
-
-		expect(text).toContain('Ferment "Approved Ferment" created')
-		expect(getActive()?.status).toBe("draft")
-		expect(getActive()?.description).toBe(
-			"Find improvements to this extension, but do not implement anything until I approve the plan.",
-		)
-		expect(getActiveFermentId()).toBe(getActive()?.id)
-	})
-
-	it("validates intent before asking for host approval", async () => {
-		const ctx = createWorkflowCtx({ confirm: true })
-
-		const first = err(await requestWorkflow({ intent: "  " }, ctx))
-		expect(first).toContain('Field "intent" must be the full non-empty user request')
-		expect(ctx.ui.confirm).not.toHaveBeenCalled()
-
-		const retry = ok(await requestWorkflow({ intent: "Find improvements to this extension." }, ctx))
-		expect(retry).toContain('Ferment "Approved Ferment" created')
-	})
-
-	it("bypasses the approval gate in yolo mode", async () => {
-		vi.stubEnv(PERMISSIONS_ENV_KEY, "yolo")
-		const ctx = createWorkflowCtx({ confirm: false })
-		const text = ok(
-			await requestWorkflow(
-				{
-					title: "Yolo Ferment",
-					intent: "Create a Go app with Gin and integrate Kimchi plugin logic.",
-				},
-				ctx,
-			),
-		)
-
-		expect(ctx.ui.confirm).not.toHaveBeenCalled()
-		expect(text).toContain('Ferment "Yolo Ferment" created')
-		expect(getActive()?.status).toBe("draft")
-		expect(getActive()?.description).toBe("Create a Go app with Gin and integrate Kimchi plugin logic.")
-	})
-
-	it("does not bypass approval when yolo came from an active ferment env", async () => {
-		vi.stubEnv(PERMISSIONS_ENV_KEY, "yolo")
-		vi.stubEnv("KIMCHI_ACTIVE_FERMENT", "existing-ferment")
-		const text = err(
-			await requestWorkflow({ title: "Blocked Ferment", intent: "Find improvements to this extension." }),
-		)
-
-		expect(text).toContain("request_ferment_workflow refused")
-		expect(text).toContain("another ferment appears to be active")
-		expect(getActive()).toBeUndefined()
-	})
-})
 
 // ─── list_ferments ────────────────────────────────────────────────────────────
 

--- a/src/extensions/ferment/tools/lifecycle.ts
+++ b/src/extensions/ferment/tools/lifecycle.ts
@@ -25,7 +25,6 @@ import {
 	type ScopingQuestion,
 	type ScopingQuestionType,
 } from "../../../ferment/types.js"
-import { isLaunchedWithYolo } from "../../permissions/index.js"
 import { YES_NO_OPTIONS } from "../../questionnaire-reducer.js"
 import {
 	type AskUserQuestion,
@@ -35,7 +34,6 @@ import {
 	toScopingQuestionType,
 } from "../ask-user.js"
 import { pr_bold, pr_dim } from "../colors.js"
-import { startFermentForIntent } from "../commands.js"
 import { validateFsmTransitionWithFerment } from "../fsm-adapter.js"
 import { renderGateGuidance } from "../gate-registry.js"
 import { assertGateFieldsPresent, validateGatesOrErr } from "../gate-validation.js"
@@ -47,7 +45,6 @@ import { readLatestPhaseReviews } from "../review-evidence.js"
 import { type FermentRuntime, defaultFermentRuntime } from "../runtime.js"
 import { confirmPendingScope } from "../scoping-confirmation.js"
 import type { PendingScope } from "../scoping.js"
-import { hasActiveFerment } from "../state.js"
 import {
 	createApplyAndPersist,
 	failedToolResult,
@@ -66,7 +63,6 @@ import {
 	ScopeParams,
 	UpdateScopeFieldParams,
 } from "../tool-schemas.js"
-import type { FermentUiContext } from "../ui.js"
 
 type ScopeArgs = Static<typeof ScopeParams>
 type ProposeScopingArgs = Static<typeof ProposeScopingParams>
@@ -755,78 +751,8 @@ export async function completeFerment(runtime: FermentRuntime, params: CompleteF
 	)
 }
 
-function canAutoApproveFermentStart(): boolean {
-	return isLaunchedWithYolo() && !hasActiveFerment()
-}
-
-async function confirmFermentStart(ctx: unknown, title: string, intent: string): Promise<boolean | undefined> {
-	const hostCtx = ctx as
-		| {
-				hasUI?: boolean
-				ui?: { confirm?: (title: string, message?: string) => Promise<boolean> }
-		  }
-		| undefined
-	if (!hostCtx?.hasUI || !hostCtx.ui?.confirm) return undefined
-	return hostCtx.ui.confirm("Start Ferment Workflow", `Start a Ferment workflow for "${title}"?\n\n${intent}`)
-}
-
 export function registerLifecycleTools(pi: ExtensionAPI, runtime: FermentRuntime = defaultFermentRuntime): void {
 	const applyAndPersist = createApplyAndPersist(runtime)
-
-	pi.registerTool({
-		name: FERMENT_TOOLS.REQUEST_WORKFLOW,
-		label: "Start Ferment Workflow",
-		description:
-			"Request the ferment workflow (interactive scoping -> planner) for substantive multi-step work. Provide a concise 3-5 word title and the full original user intent. The host asks the user for explicit confirmation before creating the draft; in yolo permissions mode, the host auto-approves. Refuses if another ferment is already running.",
-		parameters: Type.Object({
-			title: Type.String({
-				description: "Concise 3-5 word title for the new ferment (e.g. 'Rewrite login flow').",
-			}),
-			intent: Type.String({
-				description:
-					"Full original user request, preserving all constraints, scope details, and wording that the scoping turn needs.",
-			}),
-		}),
-		async execute(_id, params, _signal, _onUpdate, ctx) {
-			const title = typeof params.title === "string" ? params.title.trim() : ""
-			if (!title) return toolErr('Field "title" must be a non-empty string.')
-			const intent = typeof params.intent === "string" ? params.intent.trim() : ""
-			if (!intent) return toolErr('Field "intent" must be the full non-empty user request.')
-			if (hasActiveFerment()) {
-				return toolErr(
-					"request_ferment_workflow refused — another ferment appears to be active. Continue that ferment or ask the user before starting a separate workflow.",
-				)
-			}
-			if (!canAutoApproveFermentStart()) {
-				const approved = await confirmFermentStart(ctx, title, intent)
-				if (approved === undefined) {
-					return toolErr(
-						"request_ferment_workflow refused — interactive host approval is required before starting a ferment, but no confirmation UI is available. Ask the user directly whether they want a ferment workflow, then retry when interactive UI is available.",
-					)
-				}
-				if (!approved) {
-					return toolErr(
-						"request_ferment_workflow cancelled — the user declined starting a ferment. Continue inline or ask only decision-blocking clarification.",
-					)
-				}
-			}
-			const result = await startFermentForIntent({
-				pi,
-				ctx: ctx as unknown as FermentUiContext,
-				runtime,
-				rawIntent: intent,
-				title,
-			})
-			if (!result) {
-				return toolErr(
-					"Could not start ferment workflow. Another ferment may already be running, or the host UI refused. Tell the user to check /ferment list and try again.",
-				)
-			}
-			return toolOk(
-				`Ferment "${result.name}" created. Follow the scoping nudge instructions the host injects on this turn.`,
-			)
-		},
-	})
 
 	pi.registerTool({
 		name: FERMENT_TOOLS.PROPOSE_SCOPING,

--- a/src/extensions/permissions/index.test.ts
+++ b/src/extensions/permissions/index.test.ts
@@ -303,22 +303,6 @@ describe("permissions plan-mode tool visibility", () => {
 		expect(harness.activeTools().sort()).toEqual(["bash", "grep", "read"])
 	})
 
-	it("hides and blocks request_ferment_workflow under explicit --plan", async () => {
-		const harness = createPermissionsHarness(["read", "bash", FERMENT_TOOLS.REQUEST_WORKFLOW], { plan: true })
-
-		await harness.fire("session_start", {}, createMockContext([]))
-
-		expect(harness.activeTools().sort()).toEqual(["bash", "read"])
-		const result = await harness.fire(
-			"tool_call",
-			{ toolName: FERMENT_TOOLS.REQUEST_WORKFLOW, input: { title: "Audit", intent: "Find improvements" } },
-			createMockContext([]),
-		)
-
-		expect(result).toEqual(expect.objectContaining({ block: true }))
-		expect(JSON.stringify(result)).toContain("Plan mode")
-	})
-
 	it("keeps write_todos visible and allowed under explicit --plan", async () => {
 		const harness = createPermissionsHarness(["read", "bash", TODO_TOOL_NAME], { plan: true })
 
@@ -332,23 +316,6 @@ describe("permissions plan-mode tool visibility", () => {
 				createMockContext([]),
 			),
 		).resolves.toBeUndefined()
-	})
-
-	it("allows request_ferment_workflow after runtime plan-mode questionnaire", async () => {
-		const harness = createPermissionsHarness(["read", "questionnaire", "bash", FERMENT_TOOLS.REQUEST_WORKFLOW])
-		await harness.fire("session_start", {}, createMockContext([]))
-
-		expect(
-			await harness.fire("tool_call", { toolName: "questionnaire", input: { questions: [] } }, createMockContext([])),
-		).toBeUndefined()
-		expect(getPermissionMode(TEST_SESSION_ID)).toEqual({ mode: "plan", source: "user" })
-
-		const result = await harness.fire(
-			"tool_call",
-			{ toolName: FERMENT_TOOLS.REQUEST_WORKFLOW, input: { title: "Audit", intent: "Find improvements" } },
-			createMockContext([]),
-		)
-		expect(result).toBeUndefined()
 	})
 
 	it("leaving plan mode does not restore tools hidden by another extension", async () => {
@@ -553,27 +520,21 @@ describe("plan mode assumption detection", () => {
 		expect(ctx.ui.select).toHaveBeenCalled()
 	})
 
-	it("converts plan to ferment when user chooses ferment menu", async () => {
-		const harness = createPermissionsHarness(["read", "bash", FERMENT_TOOLS.REQUEST_WORKFLOW], { plan: true })
+	it("review menu does not offer ferment conversion", async () => {
+		const harness = createPermissionsHarness(["read", "bash"], { plan: true })
 		await harness.fire("session_start", {}, createMockContext([]))
 
 		const planText =
 			"# Plan\n\n## Goal\nAdd caching layer.\n\n## Chunks\n- Chunk 1\nImplement cache.\n\n## Verification\nRun tests.\n\n<!-- PLAN_COMPLETE -->"
-		const ctx = createMockContext(["Convert to ferment workflow"])
+		const ctx = createMockContext(["Rework the plan"])
 		await fireTurnEnd(harness, planText, ctx)
 
-		expect(ctx.ui.select).toHaveBeenCalled()
-		expect(harness.pi.sendMessage).toHaveBeenCalledWith(
-			expect.objectContaining({
-				customType: "plan-execute",
-				content: expect.stringContaining("request_ferment_workflow"),
-				display: false,
-			}),
-			{ triggerTurn: true },
-		)
-
-		// Mode should have switched from plan to default (ferment tools unlocked)
-		expect(getPermissionMode(TEST_SESSION_ID)).toEqual({ mode: "default", source: "user" })
+		expect(ctx.ui.select).toHaveBeenCalledWith("Plan complete. How would you like to proceed?", [
+			"Execute the plan",
+			"Rework the plan",
+		])
+		expect(harness.pi.sendMessage).not.toHaveBeenCalled()
+		expect(getPermissionMode(TEST_SESSION_ID)).toEqual({ mode: "plan", source: "user" })
 	})
 })
 

--- a/src/extensions/permissions/index.ts
+++ b/src/extensions/permissions/index.ts
@@ -6,7 +6,7 @@ import { getAcpPrompter } from "../../modes/acp/permission-prompter-registry.js"
 import { isAgentWorker } from "../agent-worker-context.js"
 import { PARENT_SESSION_ID_ENV_KEY } from "../agents/manager/constants.js"
 import { hasActiveFerment, notifyFermentActive, onActiveFermentChange } from "../ferment/state.js"
-import { FERMENT_TOOLS, isFermentToolName, isUserFacingFermentToolName } from "../ferment/tool-names.js"
+import { isFermentToolName, isUserFacingFermentToolName } from "../ferment/tool-names.js"
 import { createSystemPromptBlocks } from "../prompt-construction/index.js"
 import { type ToolVisibilityAPI, createToolVisibility } from "../prompt-construction/tool-visibility.js"
 import { isRawInputCaptureActive } from "../shared-input.js"
@@ -261,7 +261,6 @@ export default function permissionsExtension(pi: ExtensionAPI): void {
 	}
 
 	function isPlanModeTool(name: string): boolean {
-		if (name === FERMENT_TOOLS.REQUEST_WORKFLOW) return cliMode !== "plan"
 		return PLAN_MODE_TOOL_SET.has(name) || isReadOnlyTool(name)
 	}
 
@@ -386,47 +385,6 @@ export default function permissionsExtension(pi: ExtensionAPI): void {
 		)
 	}
 
-	function executeFermentPlan(planText: string): void {
-		// Extract a title from the plan text: first non-empty line after a Goal heading,
-		// or failing that the first heading text.
-		const lines = planText.split(/\r?\n/)
-		const goalIdx = lines.findIndex((l) => /^#+\s*Goal\b/i.test(l))
-		let title = ""
-		if (goalIdx >= 0) {
-			for (let i = goalIdx + 1; i < lines.length; i++) {
-				const trimmed = lines[i].trim()
-				if (trimmed.length > 0 && !/^#/.test(trimmed)) {
-					title = trimmed.slice(0, 80).trim()
-					break
-				}
-			}
-		}
-		if (!title) {
-			title =
-				lines[0]
-					?.replace(/^#+\s*/, "")
-					.trim()
-					.slice(0, 80) ?? "Plan"
-		}
-		pi.sendMessage(
-			{
-				customType: "plan-execute",
-				content: `The user approved the plan and wants to run it as a ferment workflow. You MUST call \`request_ferment_workflow\` now — do not describe it, do not ask for confirmation, just call it immediately.
-
-Use these exact values:
-- title: "${title}"
-- intent: the full plan text below (copy it verbatim as the intent)
-
-The plan text:
-\`\`\`
-${planText}
-\`\`\``,
-				display: false,
-			},
-			{ triggerTurn: true },
-		)
-	}
-
 	pi.on("session_start", async (_event, ctx) => {
 		currentCtx = ctx
 		const { errors } = doLoadConfig(ctx)
@@ -522,11 +480,10 @@ ${planText}
 		if (!text.includes("<!-- PLAN_COMPLETE -->") && !text.includes("<done>")) return
 
 		const EXECUTE = "Execute the plan"
-		const FERMENT = "Convert to ferment workflow"
 		const DECLINE = "Rework the plan"
 
 		const choice = await withWorkingHidden(ctx, () =>
-			ctx.ui.select("Plan complete. How would you like to proceed?", [EXECUTE, FERMENT, DECLINE]),
+			ctx.ui.select("Plan complete. How would you like to proceed?", [EXECUTE, DECLINE]),
 		)
 
 		if (choice === EXECUTE) {
@@ -538,11 +495,6 @@ ${planText}
 			}
 			changeMode(ctx, "plan", "auto", "user")
 			executePlan(planPath, text)
-		} else if (choice === FERMENT) {
-			// Switch to default mode so ferment tools become available, then ask
-			// the agent to call request_ferment_workflow with the plan as intent.
-			changeMode(ctx, "plan", "default", "user")
-			executeFermentPlan(text)
 		}
 		// Decline or escape: stay in plan mode.
 	})

--- a/src/extensions/permissions/prompts/plan-mode-supplement.ts
+++ b/src/extensions/permissions/prompts/plan-mode-supplement.ts
@@ -10,7 +10,7 @@ When you need to ask the user questions — to clarify requirements, choose betw
 
 # Structured Planning
 
-Use this template to draft plans directly **within this conversation**. Do NOT use \`request_ferment_workflow\`, ferment tools, or any workflow-starting mechanism. Plan mode is where YOU create the plan by investigating and writing it. The user will review it here before execution begins.
+Use this template to draft plans directly **within this conversation**. Do NOT start Ferment, use ferment tools, or use any workflow-starting mechanism. Plan mode is where YOU create the plan by investigating and writing it. The user will review it here before execution begins.
 
 When your plan is complete, finished, and all assumptions resolved, end your response with one of these markers on its own line:
 

--- a/src/extensions/permissions/prompts/plan-mode-supplement.ts
+++ b/src/extensions/permissions/prompts/plan-mode-supplement.ts
@@ -10,7 +10,7 @@ When you need to ask the user questions — to clarify requirements, choose betw
 
 # Structured Planning
 
-Use this template to draft plans directly **within this conversation**. Do NOT start Ferment, use ferment tools, or use any workflow-starting mechanism. Plan mode is where YOU create the plan by investigating and writing it. The user will review it here before execution begins.
+Use this template to draft plans directly **within this conversation**. Do NOT use any workflow-starting mechanism. Plan mode is where YOU create the plan by investigating and writing it. The user will review it here before execution begins.
 
 When your plan is complete, finished, and all assumptions resolved, end your response with one of these markers on its own line:
 


### PR DESCRIPTION
## Linked issue

Closes #630

## What does this PR do?

Removes model-visible Ferment suggestion/autostart paths from default sessions while keeping explicit `/ferment` entry points.

This is a removal of previously added things for dynamic changes

## Checklist

- [ ] I have read [CONTRIBUTING.md](../CONTRIBUTING.md) and agree to the CLA
- [x] This PR links to an open issue above
- [x] Tests pass locally (`pnpm run test`)
- [x] Lint passes (`pnpm run check`)
- [ ] Documentation updated if behavior changed
