### PR TITLE
fix: Wrap the JSON parse and classify parse failures as transient

### DIFF
--- a/src/models.test.ts
+++ b/src/models.test.ts
@@ -367,6 +367,43 @@ describe("updateModelsConfig", () => {
 		expect(result.models.map((m) => m.slug)).toEqual(["kimi-k2.5"])
 	})
 
+	it("retries a 200 response with an unparseable body and succeeds on a later attempt", async () => {
+		vi.mocked(fetch)
+			.mockResolvedValueOnce({
+				ok: true,
+				headers: { get: () => null },
+				json: async () => {
+					throw new SyntaxError("Unexpected token < in JSON at position 0")
+				},
+			} as unknown as Response)
+			.mockResolvedValueOnce({
+				ok: true,
+				json: async () => ({ models: [KIMI] }),
+			} as Response)
+
+		const result = await updateModelsConfig(modelsJsonPath, "test-key", { sleep: async () => {} })
+
+		expect(fetch).toHaveBeenCalledTimes(2)
+		expect(result.models.map((m) => m.slug)).toEqual(["kimi-k2.5"])
+	})
+
+	it("classifies a persistent unparseable body as transient after exhausting retries", async () => {
+		vi.mocked(fetch).mockResolvedValue({
+			ok: true,
+			headers: { get: () => null },
+			json: async () => {
+				throw new SyntaxError("Unexpected end of JSON input")
+			},
+		} as unknown as Response)
+
+		const error = await updateModelsConfig(modelsJsonPath, "test-key", { sleep: async () => {} }).catch((e) => e)
+
+		expect(error).toBeInstanceOf(ModelsFetchError)
+		expect(isTransientModelsError(error)).toBe(true)
+		expect((error as Error).message).toContain("Failed to parse models response")
+		expect(fetch).toHaveBeenCalledTimes(3)
+	})
+
 	it("throws on non-ok response when no cached config exists", async () => {
 		vi.mocked(fetch).mockResolvedValueOnce({
 			ok: false,

--- a/src/models.ts
+++ b/src/models.ts
@@ -122,7 +122,22 @@ async function fetchAvailableModels(apiKey: string, options: FetchModelsOptions 
 		}
 
 		if (response.ok) {
-			const body = (await response.json()) as ModelsMetadataResponse
+			let body: ModelsMetadataResponse
+			try {
+				body = (await response.json()) as ModelsMetadataResponse
+			} catch (err) {
+				// A 200 with a body that fails to parse (truncated/interrupted response, an
+				// HTML error page from an intermediary, etc.) is treated as a transient
+				// failure so it flows through the retry/cache logic instead of escaping
+				// as an uncaught rejection.
+				lastError = new ModelsFetchError(
+					`Failed to parse models response: ${err instanceof Error ? err.message : String(err)}`,
+					{ transient: true },
+				)
+				if (attempt === MAX_FETCH_ATTEMPTS) throw lastError
+				await sleep(retryDelayMs(response.headers?.get?.("retry-after"), attempt))
+				continue
+			}
 			if (!Array.isArray(body?.models)) {
 				throw new ModelsFetchError("Unexpected response shape from models API", { transient: false })
 			}


### PR DESCRIPTION
## Linked issue

Closes #634 

<!-- Every PR must link to an existing issue. PRs without a linked issue will not be reviewed.
     Use one of: Closes #N / Fixes #N / Resolves #N -->

## What does this PR do?

`fetchAvailableModels` in `src/models.ts` only wrapped `fetch()` in a try/catch,
  so the following `response.json()` ran unguarded. A 200 response with a body  that fails to parse (a truncated/interrupted response, or an HTML error page from an intermediary) threw a `SyntaxError` that bypassed the retry loop and cache fallback, escaping as an uncaught rejection instead of being handled like other transient failures (network errors, 5xx, 429).

This wraps the JSON parse and classifies parse failures as transient: they are
  retried up to `MAX_FETCH_ATTEMPTS`, then surfaced as `ModelsFetchError{ transient: true}` so the cache fallback applies. The intentional non-transient shape and empty-list validation throws are left unchanged. Adds two regression tests covering retry then succeed and persistent failure classified as transient.


<!-- Brief description of the change and why it's needed. -->

## Checklist

- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md) and agree to the CLA
- [x] This PR links to an open issue above
- [x] Tests pass locally (`pnpm run test`)
- [x] Lint passes (`pnpm run check`)
- [x] Documentation updated if behavior changed
