### PR TITLE
fix(one-shot ferment): disable autocompaction for single shot ferments

### DIFF
--- a/src/extensions/ferment/auto-compaction.ts
+++ b/src/extensions/ferment/auto-compaction.ts
@@ -196,6 +196,8 @@ export function buildHandoffDetails(
  * @param runtime - FermentRuntime (for storage, active-id, pending-compaction state)
  */
 export function maybeTriggerFermentCompaction(pi: ExtensionAPI, ctx: ExtensionContext, runtime: FermentRuntime): void {
+	if (pi.getFlag?.("ferment-oneshot") === true) return
+
 	// drainPendingCompactions() skips in-flight ferments — their entries stay in
 	// the map for the next turn_end / agent_end to pick up.
 	const ready = runtime.drainPendingCompactions()


### PR DESCRIPTION
## What does this PR do?

Disable autocompaction in one shot ferment to prevent the session being aborted and terminating prematurely

```
kimchi --print --session /logs/agent/sessions/main.jsonl \
  --model ... \
  --dangerously-skip-permissions \
  --ferment-oneshot
```

The failure sequence was:

1. one-shot Ferment starts normally,
1. agent scopes/activates/starts work,
1. first lifecycle step completes, usually complete_ferment_step,
1. Ferment schedules auto-compaction,
1. turn_end calls maybeTriggerFermentCompaction(),
1. maybeTriggerFermentCompaction() calls ctx.compact(),
1. upstream compact() calls session.abort(),
1. print mode treats that as the active request being aborted,
1. process exits non-zero with stdout: Request was aborted.

## Checklist

- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md) and agree to the CLA
- [x] Tests pass locally (`pnpm run test`)
- [x] Lint passes (`pnpm run check`)
- [x] Documentation updated if behavior changed
