### PR TITLE
refactor: replace WebSocket readiness probe with HTTP GET /startupcompletedz

### DIFF
--- a/src/sandbox/cloud/readiness.test.ts
+++ b/src/sandbox/cloud/readiness.test.ts
@@ -1,93 +1,72 @@
-import { describe, expect, it } from "vitest"
+import { afterEach, describe, expect, it, vi } from "vitest"
 import { waitForWorkspaceReady } from "./readiness.js"
 
 describe("waitForWorkspaceReady", () => {
-	type WSEvent = "open" | "close" | "error"
-	class FakeWS {
-		readonly url: string
-		readonly opts: { headers?: Record<string, string> } | undefined
-		readonly listeners = new Map<WSEvent, Array<(e: unknown) => void>>()
-		closed = false
-		constructor(url: string, opts?: { headers?: Record<string, string> }) {
-			this.url = url
-			this.opts = opts
-		}
-		addEventListener(type: WSEvent, cb: (e: unknown) => void) {
-			const list = this.listeners.get(type) ?? []
-			list.push(cb)
-			this.listeners.set(type, list)
-		}
-		removeEventListener() {
-			/* unused */
-		}
-		close() {
-			this.closed = true
-		}
-		fire(type: WSEvent, payload: unknown = {}) {
-			for (const cb of this.listeners.get(type) ?? []) cb(payload)
-		}
+	function mockFetch(responses: Array<{ ok: boolean; status: number } | Error>) {
+		let i = 0
+		const mockFn = vi.fn()
+		mockFn.mockImplementation(() => {
+			const resp = responses[Math.min(i++, responses.length - 1)]
+			if (resp instanceof Error) {
+				return Promise.reject(resp)
+			}
+			return Promise.resolve({
+				ok: resp.ok,
+				status: resp.status,
+				statusText: resp.ok ? "OK" : "Error",
+			} as Response)
+		})
+		vi.stubGlobal("fetch", mockFn)
+		return mockFn
 	}
 
-	function wsFactory() {
-		const created: FakeWS[] = []
-		const ctor = function (this: unknown, url: string, opts?: { headers?: Record<string, string> }) {
-			const ws = new FakeWS(url, opts)
-			created.push(ws)
-			return ws
-		} as unknown as new (
-			url: string,
-			opts?: { headers?: Record<string, string> },
-		) => FakeWS
-		return { created, ctor }
-	}
+	afterEach(() => {
+		vi.unstubAllGlobals()
+	})
 
-	it("resolves on the first probe that opens", async () => {
-		const { created, ctor } = wsFactory()
+	it("resolves on the first probe that returns 200", async () => {
+		const fetchMock = mockFetch([{ ok: true, status: 200 }])
 
 		const promise = waitForWorkspaceReady({
 			wsUrl: "wss://h.example.com/",
 			connectToken: "tok-1",
 			pollIntervalMs: 1,
 			probeTimeoutMs: 1000,
-			_WebSocket: ctor,
 		})
 
-		await Promise.resolve()
-		await Promise.resolve()
-		expect(created).toHaveLength(1)
-		expect(created[0].url).toBe("wss://h.example.com//connect")
-		expect(created[0].opts?.headers).toEqual({ Authorization: "Bearer tok-1" })
-
-		created[0].fire("open")
 		await expect(promise).resolves.toBeUndefined()
-		expect(created[0].closed).toBe(true)
+
+		expect(fetchMock).toHaveBeenCalledTimes(1)
+		expect(fetchMock).toHaveBeenCalledWith("https://h.example.com/readyz", {
+			method: "GET",
+			headers: { Authorization: "Bearer tok-1" },
+			signal: expect.any(AbortSignal),
+		})
 	})
 
-	it("retries when the first probe closes with a non-101", async () => {
-		const { created, ctor } = wsFactory()
+	it("retries when the first probe gets a non-200", async () => {
+		const fetchMock = mockFetch([
+			{ ok: false, status: 503 },
+			{ ok: true, status: 200 },
+		])
 
 		const promise = waitForWorkspaceReady({
 			wsUrl: "wss://h.example.com/",
 			connectToken: "tok",
 			pollIntervalMs: 1,
 			probeTimeoutMs: 1000,
-			_WebSocket: ctor,
 		})
 
-		await Promise.resolve()
-		await Promise.resolve()
-		created[0].fire("close", { code: 1002, reason: "not yet" })
-
-		await new Promise((r) => setTimeout(r, 10))
-		expect(created.length).toBeGreaterThanOrEqual(2)
-		created[1].fire("open")
-
 		await expect(promise).resolves.toBeUndefined()
+		expect(fetchMock).toHaveBeenCalledTimes(2)
 	})
 
 	it("fires onTick for each probe with lastError on failure", async () => {
-		const { created, ctor } = wsFactory()
 		const ticks: Array<{ elapsedMs: number; lastError?: string }> = []
+		const fetchMock = mockFetch([
+			{ ok: false, status: 503 },
+			{ ok: true, status: 200 },
+		])
 
 		const promise = waitForWorkspaceReady({
 			wsUrl: "wss://h.example.com/",
@@ -95,23 +74,18 @@ describe("waitForWorkspaceReady", () => {
 			pollIntervalMs: 1,
 			probeTimeoutMs: 1000,
 			onTick: (t) => ticks.push(t),
-			_WebSocket: ctor,
 		})
 
-		await Promise.resolve()
-		await Promise.resolve()
-		created[0].fire("close", { code: 1002 })
-		await new Promise((r) => setTimeout(r, 10))
-		created[1].fire("open")
 		await promise
 
 		expect(ticks).toHaveLength(2)
-		expect(ticks[0].lastError).toMatch(/code=1002/)
+		expect(ticks[0].lastError).toMatch(/HTTP 503/)
 		expect(ticks[1].lastError).toBeUndefined()
+		expect(fetchMock).toHaveBeenCalledTimes(2)
 	})
 
 	it("rejects on overall timeout with the last probe error in the message", async () => {
-		const { created, ctor } = wsFactory()
+		mockFetch([{ ok: false, status: 503 }])
 
 		const promise = waitForWorkspaceReady({
 			wsUrl: "wss://h.example.com/",
@@ -119,20 +93,12 @@ describe("waitForWorkspaceReady", () => {
 			pollIntervalMs: 5,
 			probeTimeoutMs: 2,
 			timeoutMs: 30,
-			_WebSocket: ctor,
 		})
 
-		const loop = setInterval(() => {
-			const latest = created[created.length - 1]
-			if (latest && !latest.closed) latest.fire("close", { code: 1002 })
-		}, 1)
-
-		await expect(promise).rejects.toThrow(/code=1002/)
-		clearInterval(loop)
+		await expect(promise).rejects.toThrow(/HTTP 503/)
 	})
 
 	it("rejects when the abort signal fires", async () => {
-		const { ctor } = wsFactory()
 		const ctrl = new AbortController()
 
 		const promise = waitForWorkspaceReady({
@@ -141,21 +107,9 @@ describe("waitForWorkspaceReady", () => {
 			pollIntervalMs: 60_000,
 			probeTimeoutMs: 60_000,
 			signal: ctrl.signal,
-			_WebSocket: ctor,
 		})
 
 		setTimeout(() => ctrl.abort(), 5)
 		await expect(promise).rejects.toThrow(/[Aa]borted/)
-	})
-
-	it("throws when no WebSocket implementation is available", async () => {
-		await expect(
-			waitForWorkspaceReady({
-				wsUrl: "wss://h.example.com/",
-				connectToken: "tok",
-				// biome-ignore lint/suspicious/noExplicitAny: simulate missing WebSocket
-				_WebSocket: undefined as any,
-			}),
-		).rejects.toThrow(/WebSocket is not available/)
 	})
 })

--- a/src/sandbox/cloud/readiness.test.ts
+++ b/src/sandbox/cloud/readiness.test.ts
@@ -37,7 +37,7 @@ describe("waitForWorkspaceReady", () => {
 		await expect(promise).resolves.toBeUndefined()
 
 		expect(fetchMock).toHaveBeenCalledTimes(1)
-		expect(fetchMock).toHaveBeenCalledWith("https://h.example.com/readyz", {
+		expect(fetchMock).toHaveBeenCalledWith("https://h.example.com/startupcompletedz", {
 			method: "GET",
 			headers: { Authorization: "Bearer tok-1" },
 			signal: expect.any(AbortSignal),

--- a/src/sandbox/cloud/readiness.ts
+++ b/src/sandbox/cloud/readiness.ts
@@ -40,13 +40,26 @@ async function probeReadyOnce(opts: {
 	probeTimeoutMs: number
 	signal?: AbortSignal
 }): Promise<{ ready: boolean; error?: string }> {
+	let timer: ReturnType<typeof setTimeout> | undefined
 	try {
 		const baseUrl = deriveBaseUrl(opts.wsUrl)
 		const url = `${baseUrl}/readyz`
 
 		const ctrl = new AbortController()
-		const timer = setTimeout(() => ctrl.abort(), opts.probeTimeoutMs)
-		const signal = opts.signal ? AbortSignal.any([ctrl.signal, opts.signal]) : ctrl.signal
+		timer = setTimeout(() => ctrl.abort(), opts.probeTimeoutMs)
+
+		let signal: AbortSignal
+		if (opts.signal) {
+			if (typeof AbortSignal.any === "function") {
+				signal = AbortSignal.any([ctrl.signal, opts.signal])
+			} else {
+				opts.signal.addEventListener("abort", () => ctrl.abort(), { once: true })
+				if (opts.signal.aborted) ctrl.abort()
+				signal = ctrl.signal
+			}
+		} else {
+			signal = ctrl.signal
+		}
 
 		const resp = await fetch(url, {
 			method: "GET",
@@ -56,8 +69,6 @@ async function probeReadyOnce(opts: {
 			signal,
 		})
 
-		clearTimeout(timer)
-
 		if (resp.ok) {
 			return { ready: true }
 		}
@@ -65,6 +76,8 @@ async function probeReadyOnce(opts: {
 	} catch (err) {
 		const msg = err instanceof Error ? err.message : String(err)
 		return { ready: false, error: msg }
+	} finally {
+		if (timer) clearTimeout(timer)
 	}
 }
 

--- a/src/sandbox/cloud/readiness.ts
+++ b/src/sandbox/cloud/readiness.ts
@@ -1,11 +1,10 @@
-import { WebSocket } from "ws"
+import { deriveBaseUrl } from "../worker/client.js"
 import type { WaitForWorkspaceReadyOptions } from "./types.js"
 import { RemoteNetworkError } from "./types.js"
 
 const DEFAULT_READY_TIMEOUT_MS = 90_000
 const DEFAULT_POLL_INTERVAL_MS = 1_500
 const DEFAULT_PROBE_TIMEOUT_MS = 5_000
-const DEFAULT_WS_PATH = "/connect"
 
 function sleep(ms: number, signal?: AbortSignal): Promise<void> {
 	return new Promise((resolve, reject) => {
@@ -32,83 +31,52 @@ function sleep(ms: number, signal?: AbortSignal): Promise<void> {
 }
 
 /**
- * Probe the WS endpoint once. Resolves with `{ ready: true }` if the upgrade
- * completes, `{ ready: false, error }` otherwise. Never throws.
+ * Poll the /readyz endpoint once via HTTP. Resolves with `{ ready: true }` if
+ * the response is 2xx, `{ ready: false, error }` otherwise. Never throws.
  */
-function probeWorkspaceWsOnce(opts: {
+async function probeReadyOnce(opts: {
 	connectToken: string
-	wsURL: string
-	wsPath: string
+	wsUrl: string
 	probeTimeoutMs: number
 	signal?: AbortSignal
-	// biome-ignore lint/suspicious/noExplicitAny: injectable WebSocket constructor
-	WS: any
 }): Promise<{ ready: boolean; error?: string }> {
-	return new Promise((resolve) => {
-		let settled = false
-		const settle = (result: { ready: boolean; error?: string }) => {
-			if (settled) return
-			settled = true
-			cleanup()
-			try {
-				ws.close()
-			} catch {
-				// ignore
-			}
-			resolve(result)
-		}
+	try {
+		const baseUrl = deriveBaseUrl(opts.wsUrl)
+		const url = `${baseUrl}/readyz`
 
-		const url = `${opts.wsURL}${opts.wsPath}`
-		const headers = { Authorization: `Bearer ${opts.connectToken}` }
-		let ws: { close(): void; addEventListener: (t: string, cb: (e: unknown) => void) => void }
-		try {
-			ws = new opts.WS(url, { headers })
-		} catch (err) {
-			resolve({ ready: false, error: err instanceof Error ? err.message : String(err) })
-			return
-		}
+		const ctrl = new AbortController()
+		const timer = setTimeout(() => ctrl.abort(), opts.probeTimeoutMs)
+		const signal = opts.signal ? AbortSignal.any([ctrl.signal, opts.signal]) : ctrl.signal
 
-		const timer = setTimeout(() => settle({ ready: false, error: "probe timeout" }), opts.probeTimeoutMs)
-		const onAbort = () => settle({ ready: false, error: "aborted" })
-		const cleanup = () => {
-			clearTimeout(timer)
-			opts.signal?.removeEventListener("abort", onAbort)
-		}
-
-		if (opts.signal?.aborted) {
-			settle({ ready: false, error: "aborted" })
-			return
-		}
-		opts.signal?.addEventListener("abort", onAbort, { once: true })
-
-		ws.addEventListener("open", () => settle({ ready: true }))
-		ws.addEventListener("error", (e: unknown) => {
-			const msg = (e as { message?: string })?.message ?? "websocket error"
-			settle({ ready: false, error: msg })
+		const resp = await fetch(url, {
+			method: "GET",
+			headers: {
+				Authorization: `Bearer ${opts.connectToken}`,
+			},
+			signal,
 		})
-		ws.addEventListener("close", (e: unknown) => {
-			const code = (e as { code?: number })?.code
-			const reason = (e as { reason?: string })?.reason
-			settle({ ready: false, error: code ? `closed code=${code}${reason ? ` reason=${reason}` : ""}` : "closed" })
-		})
-	})
+
+		clearTimeout(timer)
+
+		if (resp.ok) {
+			return { ready: true }
+		}
+		return { ready: false, error: `HTTP ${resp.status}` }
+	} catch (err) {
+		const msg = err instanceof Error ? err.message : String(err)
+		return { ready: false, error: msg }
+	}
 }
 
 /**
- * Poll a WebSocket probe to `wss://<host>:<port>/connect` until the upgrade
- * succeeds, which signals that the agentgateway has attached the workspace
- * policy and traffic is routable.
+ * Poll HTTP GET /readyz until it returns 2xx, which signals that the
+ * agentgateway has attached the workspace policy and traffic is routable.
  */
 export async function waitForWorkspaceReady(options: WaitForWorkspaceReadyOptions): Promise<void> {
 	const signal = options.signal
 	const timeoutMs = options.timeoutMs ?? DEFAULT_READY_TIMEOUT_MS
 	const pollIntervalMs = options.pollIntervalMs ?? DEFAULT_POLL_INTERVAL_MS
 	const probeTimeoutMs = options.probeTimeoutMs ?? DEFAULT_PROBE_TIMEOUT_MS
-	const wsPath = options.wsPath ?? DEFAULT_WS_PATH
-	const WS = "_WebSocket" in options ? options._WebSocket : WebSocket
-	if (!WS) {
-		throw new RemoteNetworkError("WebSocket is not available in this environment")
-	}
 
 	const startedAt = Date.now()
 	let lastError: string | undefined
@@ -124,13 +92,11 @@ export async function waitForWorkspaceReady(options: WaitForWorkspaceReadyOption
 			)
 		}
 
-		const probe = await probeWorkspaceWsOnce({
+		const probe = await probeReadyOnce({
 			connectToken: options.connectToken,
-			wsURL: options.wsUrl,
-			wsPath,
+			wsUrl: options.wsUrl,
 			probeTimeoutMs,
 			signal,
-			WS,
 		})
 
 		options.onTick?.({ elapsedMs, lastError: probe.error })

--- a/src/sandbox/cloud/readiness.ts
+++ b/src/sandbox/cloud/readiness.ts
@@ -31,7 +31,7 @@ function sleep(ms: number, signal?: AbortSignal): Promise<void> {
 }
 
 /**
- * Poll the /readyz endpoint once via HTTP. Resolves with `{ ready: true }` if
+ * Poll the /startupcompletedz endpoint once via HTTP. Resolves with `{ ready: true }` if
  * the response is 2xx, `{ ready: false, error }` otherwise. Never throws.
  */
 async function probeReadyOnce(opts: {
@@ -43,7 +43,7 @@ async function probeReadyOnce(opts: {
 	let timer: ReturnType<typeof setTimeout> | undefined
 	try {
 		const baseUrl = deriveBaseUrl(opts.wsUrl)
-		const url = `${baseUrl}/readyz`
+		const url = `${baseUrl}/startupcompletedz`
 
 		const ctrl = new AbortController()
 		timer = setTimeout(() => ctrl.abort(), opts.probeTimeoutMs)
@@ -82,7 +82,7 @@ async function probeReadyOnce(opts: {
 }
 
 /**
- * Poll HTTP GET /readyz until it returns 2xx, which signals that the
+ * Poll HTTP GET /startupcompletedz until it returns 2xx, which signals that the
  * agentgateway has attached the workspace policy and traffic is routable.
  */
 export async function waitForWorkspaceReady(options: WaitForWorkspaceReadyOptions): Promise<void> {


### PR DESCRIPTION
## Why

The harness currently polls WebSocket \"/connect\" to check workspace readiness. Every poll auto-creates a dummy \"default\" session on the worker via `sessionRegistry.StartSession()` in `GetConnect()`. This is unnecessary noise.

## What

Replace the WebSocket readiness probe with an HTTP `GET /readyz` probe.

- **probeReadyOnce()** uses native `fetch` with `deriveBaseUrl` from `client.ts` to poll `https://.../readyz`
- Sends `Authorization: Bearer <token>` header
- Uses `AbortController` + `AbortSignal.any()` for probe timeout and external cancellation
- **Backward compat**: `wsPath` stays in the public type signature but is ignored internally

## Tests

Replaced `FakeWS` WebSocket mock with `vi.fn() + vi.stubGlobal('fetch', ...)`:
- Happy path (first 200)
- Retry on non-200
- `onTick` with `lastError`
- Overall timeout
- External abort

Closes #0