### PR TITLE
feat(todos): integrate ferment phase/step lifecycle with todo overlay

### DIFF
--- a/docs/ferment.md
+++ b/docs/ferment.md
@@ -295,6 +295,8 @@ If `start_ferment_step` is called on the same step 3 or more times without a `co
 
 The block stays active until the step is either completed (`complete_ferment_step`) or skipped (`skip_ferment_step`).
 
+**Plan-first preamble**: On every successful start (1st, 2nd, 3rd attempt), `start_ferment_step` emits a plan-first preamble before the "Step X started" message. The preamble includes an inline plan, references `applyWriteTodos` (the harness todo store at `src/extensions/todos/store.ts`) to generate actionable todo items, and embeds both into the spawned subagent's prompt. This happens on all starts — the stuck-loop guard and plan-first behavior coexist.
+
 ---
 
 ## Context budget
@@ -401,7 +403,7 @@ These tools are available to the agent during a ferment session. They are not me
 
 | Tool | Description |
 |------|-------------|
-| `start_ferment_step` | Mark step as running. Returns worker prompt context and any parallel siblings for concurrent dispatch. Blocks after 3 consecutive starts without a complete (stuck-loop guard). |
+| `start_ferment_step` | Mark step as running. Emits a plan-first preamble (inline plan + `applyWriteTodos` todos from `src/extensions/todos/store.ts` + embed in subagent prompt) on every start. Returns worker prompt context and any parallel siblings for concurrent dispatch. Blocks after 3 consecutive starts without a complete (stuck-loop guard). |
 | `complete_ferment_step` | Mark step as done. Runs verification command automatically if set. |
 | `verify_ferment_step` | Run the verification command manually and record the result. |
 | `skip_ferment_step` | Skip a step (counts as terminal) |

--- a/src/extensions/ferment/domain-events-emitter.ts
+++ b/src/extensions/ferment/domain-events-emitter.ts
@@ -16,10 +16,12 @@ import {
 	type FermentCompletedPayload,
 	type FermentPhaseCompletedPayload,
 	type FermentPhaseStartedPayload,
+	type FermentResumedPayload,
 	type FermentStartedPayload,
 	type FermentStepCompletedPayload,
 	type FermentStepFailedPayload,
 	type FermentStepStartedPayload,
+	type FermentSuspendedPayload,
 } from "./domain-events.js"
 
 /** Warn in non-production environments when a state-lookup fails, indicating
@@ -225,9 +227,25 @@ export function emitFermentDomainEvent(events: EventBus, cmd: Command, post: Fer
 			return
 		}
 
+		case "pause": {
+			const payload: FermentSuspendedPayload = {
+				fermentId: post.id,
+			}
+			events.emit(FERMENT_EVENTS.SUSPENDED, payload)
+			return
+		}
+
+		case "resume": {
+			const payload: FermentResumedPayload = {
+				fermentId: post.id,
+			}
+			events.emit(FERMENT_EVENTS.RESUMED, payload)
+			return
+		}
+
 		default:
-			// Other commands (pause, resume, refine, scope, etc.) don't need
-			// telemetry events — they don't represent lifecycle transitions.
+			// Other commands (refine, scope, etc.) don't need domain events —
+			// they don't represent lifecycle transitions.
 			return
 	}
 }

--- a/src/extensions/ferment/domain-events.ts
+++ b/src/extensions/ferment/domain-events.ts
@@ -13,6 +13,8 @@ export const FERMENT_EVENTS = {
 	STARTED: "ferment:started",
 	COMPLETED: "ferment:completed",
 	ABANDONED: "ferment:abandoned",
+	SUSPENDED: "ferment:suspended",
+	RESUMED: "ferment:resumed",
 	STALLED: "ferment:stalled",
 	PHASE_STARTED: "ferment:phase_started",
 	PHASE_COMPLETED: "ferment:phase_completed",
@@ -68,6 +70,14 @@ export interface FermentAbandonedPayload {
 	stepFailureCount: number
 	/** Wall-clock duration in ms from ferment creation to abandonment. */
 	durationMs: number
+}
+
+export interface FermentSuspendedPayload {
+	fermentId: string
+}
+
+export interface FermentResumedPayload {
+	fermentId: string
 }
 
 export interface FermentPhaseStartedPayload {

--- a/src/extensions/ferment/index.ts
+++ b/src/extensions/ferment/index.ts
@@ -13,6 +13,7 @@
 import type { ExtensionAPI, ExtensionContext, MessageRenderer } from "@earendil-works/pi-coding-agent"
 import { Container, Text } from "@earendil-works/pi-tui"
 import type { Step } from "../../ferment/types.js"
+import { isAgentWorker } from "../agent-worker-context.js"
 import { createSystemPromptBlocks } from "../prompt-construction/index.js"
 import { requestSharedFooterRender } from "../shared-footer.js"
 import { registerTipProvider } from "../tips/registry.js"
@@ -29,6 +30,7 @@ import { confirmPendingScope } from "./scoping-confirmation.js"
 import { FERMENT_REQUEST_MESSAGE_TYPE, type FermentRequestMessageDetails } from "./scoping.js"
 import { getActive, getActiveId, getContinuationPolicy } from "./state.js"
 import { createFermentTipProvider } from "./tips.js"
+import { registerFermentTodoSync } from "./todo-sync.js"
 import { applyFermentRuntimeToolProfile } from "./tool-scope.js"
 import { registerKnowledgeTools } from "./tools/knowledge.js"
 import { buildFreeformScopingFeedbackMessage, registerLifecycleTools } from "./tools/lifecycle.js"
@@ -120,6 +122,10 @@ export default function fermentExtension(pi: ExtensionAPI, runtime: FermentRunti
 	runtime.events = pi.events
 
 	const unregisterFermentTips = registerTipProvider(createFermentTipProvider(runtime))
+	let unregisterFermentTodoSync: (() => void) | undefined
+	if (!isAgentWorker()) {
+		unregisterFermentTodoSync = registerFermentTodoSync(pi)
+	}
 	let planReviewTimer: ReturnType<typeof setTimeout> | undefined
 	let planReviewRunning = false
 	// ExtensionContext is populated on session start
@@ -190,6 +196,7 @@ export default function fermentExtension(pi: ExtensionAPI, runtime: FermentRunti
 		clearPlanReviewTimer()
 		runtime.clearAllPendingPlanReviews()
 		unregisterFermentTips()
+		unregisterFermentTodoSync?.()
 	})
 
 	pi.on("agent_end", (_event, ctx) => {

--- a/src/extensions/ferment/todo-headless-wiring.test.ts
+++ b/src/extensions/ferment/todo-headless-wiring.test.ts
@@ -27,7 +27,7 @@ import {
 import { __resetTodoStore, applyWriteTodos, getTodosForScope, resolveTodoScope } from "../todos/store.js"
 import { emitFermentDomainEvent } from "./domain-events-emitter.js"
 import { setActive } from "./state.js"
-import { registerFermentTodoSync } from "./todo-sync.js"
+import { bumpStallCounter, getTurnsSinceStepTodoWrite, registerFermentTodoSync } from "./todo-sync.js"
 
 // ─── Helpers ─────────────────────────────────────────────────────────────────
 
@@ -373,5 +373,165 @@ describe("ferment → todo → headless prompt wiring", () => {
 		} finally {
 			unsubscribe()
 		}
+	})
+})
+
+describe("stall detection via step todo write tracking", () => {
+	beforeEach(() => {
+		__resetTodoStore()
+		setActive(undefined)
+		setCurrentSessionHasUI(false)
+	})
+
+	afterEach(() => {
+		setActive(undefined)
+		__resetTodoStore()
+		setCurrentSessionHasUI(true)
+	})
+
+	it("stall counter starts at 0 and increments with bumpStallCounter", () => {
+		const ferment = makeFerment({
+			phases: [
+				{
+					id: "phase-1",
+					index: 1,
+					name: "Build",
+					goal: "build it",
+					status: "active",
+					steps: [{ id: "step-1", index: 1, description: "Write code", status: "running" }],
+				},
+			],
+		})
+		setActive(ferment)
+		const { pi, unsubscribe } = makePiWithRealEventBus()
+
+		try {
+			emitFermentDomainEvent(pi.events, { type: "activate_phase", phaseId: "phase-1" }, ferment)
+			emitFermentDomainEvent(pi.events, { type: "start_step", phaseId: "phase-1", stepId: "step-1" }, ferment)
+
+			expect(getTurnsSinceStepTodoWrite()).toBe(0)
+			bumpStallCounter()
+			expect(getTurnsSinceStepTodoWrite()).toBe(1)
+			bumpStallCounter()
+			bumpStallCounter()
+			expect(getTurnsSinceStepTodoWrite()).toBe(3)
+		} finally {
+			unsubscribe()
+		}
+	})
+
+	it("stall counter resets when step-scope todos are written", () => {
+		const ferment = makeFerment({
+			phases: [
+				{
+					id: "phase-1",
+					index: 1,
+					name: "Build",
+					goal: "build it",
+					status: "active",
+					steps: [{ id: "step-1", index: 1, description: "Write code", status: "running" }],
+				},
+			],
+		})
+		setActive(ferment)
+		const { pi, unsubscribe } = makePiWithRealEventBus()
+
+		try {
+			emitFermentDomainEvent(pi.events, { type: "activate_phase", phaseId: "phase-1" }, ferment)
+			emitFermentDomainEvent(pi.events, { type: "start_step", phaseId: "phase-1", stepId: "step-1" }, ferment)
+
+			bumpStallCounter()
+			bumpStallCounter()
+			bumpStallCounter()
+			expect(getTurnsSinceStepTodoWrite()).toBe(3)
+
+			// Writing to the step scope resets the counter
+			applyWriteTodos({
+				scope: { kind: "ferment-step", phaseId: "phase-1", stepId: "step-1" },
+				todos: [{ content: "plan item", status: "pending" }],
+			})
+			expect(getTurnsSinceStepTodoWrite()).toBe(0)
+		} finally {
+			unsubscribe()
+		}
+	})
+
+	it("stall warning appears in rendered markdown after threshold", () => {
+		const ferment = makeFerment({
+			phases: [
+				{
+					id: "phase-1",
+					index: 1,
+					name: "Build",
+					goal: "build it",
+					status: "active",
+					steps: [{ id: "step-1", index: 1, description: "Write code", status: "running" }],
+				},
+			],
+		})
+		setActive(ferment)
+		const { pi, unsubscribe } = makePiWithRealEventBus()
+
+		try {
+			emitFermentDomainEvent(pi.events, { type: "activate_phase", phaseId: "phase-1" }, ferment)
+			emitFermentDomainEvent(pi.events, { type: "start_step", phaseId: "phase-1", stepId: "step-1" }, ferment)
+
+			// Populate step todos so markdown renders
+			applyWriteTodos({
+				scope: { kind: "ferment-step", phaseId: "phase-1", stepId: "step-1" },
+				todos: [{ content: "plan item", status: "in_progress" }],
+			})
+
+			// Bump past threshold (5 turns)
+			for (let i = 0; i < 6; i++) bumpStallCounter()
+
+			const md = __test_renderTodoStateMarkdown()
+			expect(md).toContain("\u26a0 Step todos have not been updated for 6 turns")
+			expect(md).toContain("reassess your approach")
+		} finally {
+			unsubscribe()
+		}
+	})
+
+	it("stall warning does NOT appear below threshold", () => {
+		const ferment = makeFerment({
+			phases: [
+				{
+					id: "phase-1",
+					index: 1,
+					name: "Build",
+					goal: "build it",
+					status: "active",
+					steps: [{ id: "step-1", index: 1, description: "Write code", status: "running" }],
+				},
+			],
+		})
+		setActive(ferment)
+		const { pi, unsubscribe } = makePiWithRealEventBus()
+
+		try {
+			emitFermentDomainEvent(pi.events, { type: "activate_phase", phaseId: "phase-1" }, ferment)
+			emitFermentDomainEvent(pi.events, { type: "start_step", phaseId: "phase-1", stepId: "step-1" }, ferment)
+
+			applyWriteTodos({
+				scope: { kind: "ferment-step", phaseId: "phase-1", stepId: "step-1" },
+				todos: [{ content: "plan item", status: "in_progress" }],
+			})
+
+			// Only 3 turns — below threshold
+			for (let i = 0; i < 3; i++) bumpStallCounter()
+
+			const md = __test_renderTodoStateMarkdown()
+			expect(md).not.toContain("\u26a0 Step todos have not been updated")
+		} finally {
+			unsubscribe()
+		}
+	})
+
+	it("stall counter returns 0 when no step is running", () => {
+		// No step started — bumping should have no effect
+		bumpStallCounter()
+		bumpStallCounter()
+		expect(getTurnsSinceStepTodoWrite()).toBe(0)
 	})
 })

--- a/src/extensions/ferment/todo-headless-wiring.test.ts
+++ b/src/extensions/ferment/todo-headless-wiring.test.ts
@@ -27,7 +27,12 @@ import {
 import { __resetTodoStore, applyWriteTodos, getTodosForScope, resolveTodoScope } from "../todos/store.js"
 import { emitFermentDomainEvent } from "./domain-events-emitter.js"
 import { setActive } from "./state.js"
-import { bumpStallCounter, getTurnsSinceStepTodoWrite, registerFermentTodoSync } from "./todo-sync.js"
+import {
+	__getRunningSteps,
+	bumpStallCounter,
+	getTurnsSinceStepTodoWrite,
+	registerFermentTodoSync,
+} from "./todo-sync.js"
 
 // ─── Helpers ─────────────────────────────────────────────────────────────────
 
@@ -533,5 +538,104 @@ describe("stall detection via step todo write tracking", () => {
 		bumpStallCounter()
 		bumpStallCounter()
 		expect(getTurnsSinceStepTodoWrite()).toBe(0)
+	})
+})
+
+describe("parallel step tracking", () => {
+	beforeEach(() => {
+		__resetTodoStore()
+		setActive(undefined)
+		setCurrentSessionHasUI(false)
+	})
+
+	afterEach(() => {
+		setActive(undefined)
+		__resetTodoStore()
+		setCurrentSessionHasUI(true)
+	})
+
+	function makeParallelFerment(): Ferment {
+		return {
+			id: "f-parallel",
+			name: "Parallel Test",
+			status: "running",
+			worktree: { path: "/tmp" },
+			scoping: {},
+			phases: [
+				{
+					id: "phase-1",
+					index: 1,
+					name: "Parallel",
+					goal: "do things",
+					status: "active",
+					steps: [
+						{ id: "step-a", index: 1, description: "Branch A", status: "running", parallel: true, groupIndex: 1 },
+						{ id: "step-b", index: 2, description: "Branch B", status: "running", parallel: true, groupIndex: 1 },
+					],
+				},
+			],
+			decisions: [],
+			memories: [],
+			createdAt: new Date().toISOString(),
+			updatedAt: new Date().toISOString(),
+		}
+	}
+
+	it("tracks multiple parallel steps independently", () => {
+		const ferment = makeParallelFerment()
+		setActive(ferment)
+		const { pi, unsubscribe } = makePiWithRealEventBus()
+
+		try {
+			emitFermentDomainEvent(pi.events, { type: "activate_phase", phaseId: "phase-1" }, ferment)
+			emitFermentDomainEvent(pi.events, { type: "start_step", phaseId: "phase-1", stepId: "step-a" }, ferment)
+			emitFermentDomainEvent(pi.events, { type: "start_step", phaseId: "phase-1", stepId: "step-b" }, ferment)
+
+			const running = __getRunningSteps()
+			expect(running.size).toBe(2)
+			expect(running.has("phase-1/step-a")).toBe(true)
+			expect(running.has("phase-1/step-b")).toBe(true)
+		} finally {
+			unsubscribe()
+		}
+	})
+
+	it("completing one parallel step leaves the other running", () => {
+		const ferment = makeParallelFerment()
+		setActive(ferment)
+		const { pi, unsubscribe } = makePiWithRealEventBus()
+
+		try {
+			emitFermentDomainEvent(pi.events, { type: "activate_phase", phaseId: "phase-1" }, ferment)
+			emitFermentDomainEvent(pi.events, { type: "start_step", phaseId: "phase-1", stepId: "step-a" }, ferment)
+			emitFermentDomainEvent(pi.events, { type: "start_step", phaseId: "phase-1", stepId: "step-b" }, ferment)
+
+			// Complete step-a only
+			emitFermentDomainEvent(pi.events, { type: "complete_step", phaseId: "phase-1", stepId: "step-a" }, ferment)
+
+			const running = __getRunningSteps()
+			expect(running.size).toBe(1)
+			expect(running.has("phase-1/step-a")).toBe(false)
+			expect(running.has("phase-1/step-b")).toBe(true)
+		} finally {
+			unsubscribe()
+		}
+	})
+
+	it("scope provider returns undefined when multiple steps are active", () => {
+		const ferment = makeParallelFerment()
+		setActive(ferment)
+		const { pi, unsubscribe } = makePiWithRealEventBus()
+
+		try {
+			emitFermentDomainEvent(pi.events, { type: "activate_phase", phaseId: "phase-1" }, ferment)
+			emitFermentDomainEvent(pi.events, { type: "start_step", phaseId: "phase-1", stepId: "step-a" }, ferment)
+			emitFermentDomainEvent(pi.events, { type: "start_step", phaseId: "phase-1", stepId: "step-b" }, ferment)
+
+			// With two parallel steps active, auto-scope should refuse to guess.
+			expect(resolveTodoScope()).toEqual({ kind: "global" })
+		} finally {
+			unsubscribe()
+		}
 	})
 })

--- a/src/extensions/ferment/todo-headless-wiring.test.ts
+++ b/src/extensions/ferment/todo-headless-wiring.test.ts
@@ -153,6 +153,131 @@ describe("ferment → todo → headless prompt wiring", () => {
 		}
 	})
 
+	it("start_step event seeds the ferment-step scope with the step description", () => {
+		const ferment = makeFerment({
+			phases: [
+				{
+					id: "phase-1",
+					index: 1,
+					name: "Implementation",
+					goal: "do the work",
+					status: "active",
+					steps: [
+						{ id: "step-1", index: 1, description: "Write the code", status: "running" },
+						{ id: "step-2", index: 2, description: "Run the tests", status: "pending" },
+					],
+				},
+			],
+		})
+		setActive(ferment)
+		const { pi, unsubscribe } = makePiWithRealEventBus()
+
+		try {
+			emitFermentDomainEvent(pi.events, { type: "activate_phase", phaseId: "phase-1" }, ferment)
+			emitFermentDomainEvent(pi.events, { type: "start_step", phaseId: "phase-1", stepId: "step-1" }, ferment)
+
+			const stepTodos = getTodosForScope({ kind: "ferment-step", phaseId: "phase-1", stepId: "step-1" })
+			expect(stepTodos).toHaveLength(1)
+			expect(stepTodos[0].content).toBe("Write the code")
+			expect(stepTodos[0].status).toBe("in_progress")
+		} finally {
+			unsubscribe()
+		}
+	})
+
+	it("complete_step event clears the ferment-step scope", () => {
+		const ferment = makeFerment({
+			phases: [
+				{
+					id: "phase-1",
+					index: 1,
+					name: "Implementation",
+					goal: "do the work",
+					status: "active",
+					steps: [
+						{ id: "step-1", index: 1, description: "Write the code", status: "running" },
+						{ id: "step-2", index: 2, description: "Run the tests", status: "pending" },
+					],
+				},
+			],
+		})
+		setActive(ferment)
+		const { pi, unsubscribe } = makePiWithRealEventBus()
+
+		try {
+			emitFermentDomainEvent(pi.events, { type: "activate_phase", phaseId: "phase-1" }, ferment)
+			emitFermentDomainEvent(pi.events, { type: "start_step", phaseId: "phase-1", stepId: "step-1" }, ferment)
+
+			// Step todos should exist
+			expect(getTodosForScope({ kind: "ferment-step", phaseId: "phase-1", stepId: "step-1" })).toHaveLength(1)
+
+			// Complete the step
+			const completedFerment: Ferment = {
+				...ferment,
+				phases: ferment.phases.map((p) => ({
+					...p,
+					steps: p.steps.map((s) => (s.id === "step-1" ? { ...s, status: "done" as const } : s)),
+				})),
+			}
+			setActive(completedFerment)
+			emitFermentDomainEvent(
+				pi.events,
+				{ type: "complete_step", phaseId: "phase-1", stepId: "step-1" },
+				completedFerment,
+			)
+
+			// Step-level todos should be cleared
+			expect(getTodosForScope({ kind: "ferment-step", phaseId: "phase-1", stepId: "step-1" })).toHaveLength(0)
+		} finally {
+			unsubscribe()
+		}
+	})
+
+	it("fail_step event clears the ferment-step scope", () => {
+		const ferment = makeFerment({
+			phases: [
+				{
+					id: "phase-1",
+					index: 1,
+					name: "Implementation",
+					goal: "do the work",
+					status: "active",
+					steps: [
+						{ id: "step-1", index: 1, description: "Write the code", status: "running" },
+						{ id: "step-2", index: 2, description: "Run the tests", status: "pending" },
+					],
+				},
+			],
+		})
+		setActive(ferment)
+		const { pi, unsubscribe } = makePiWithRealEventBus()
+
+		try {
+			emitFermentDomainEvent(pi.events, { type: "activate_phase", phaseId: "phase-1" }, ferment)
+			emitFermentDomainEvent(pi.events, { type: "start_step", phaseId: "phase-1", stepId: "step-1" }, ferment)
+
+			expect(getTodosForScope({ kind: "ferment-step", phaseId: "phase-1", stepId: "step-1" })).toHaveLength(1)
+
+			const failedFerment: Ferment = {
+				...ferment,
+				phases: ferment.phases.map((p) => ({
+					...p,
+					steps: p.steps.map((s) => (s.id === "step-1" ? { ...s, status: "failed" as const } : s)),
+				})),
+			}
+			setActive(failedFerment)
+			emitFermentDomainEvent(
+				pi.events,
+				{ type: "fail_step", phaseId: "phase-1", stepId: "step-1", error: "oops" },
+				failedFerment,
+			)
+
+			expect(getTodosForScope({ kind: "ferment-step", phaseId: "phase-1", stepId: "step-1" })).toHaveLength(0)
+		} finally {
+			unsubscribe()
+		}
+	})
+
 	it("complete_step event updates the step todo status in the block", () => {
 		const ferment = makeFerment()
 		setActive(ferment)

--- a/src/extensions/ferment/todo-headless-wiring.test.ts
+++ b/src/extensions/ferment/todo-headless-wiring.test.ts
@@ -1,0 +1,229 @@
+/**
+ * Integration test: ferment activation → todo store → headless prompt block
+ *
+ * Validates the full chain without a real LLM:
+ *
+ *   emitFermentDomainEvent(activate_phase)
+ *     → pi.events (real EventBus)
+ *       → registerFermentTodoSync (bridge)
+ *         → applyWriteTodos (todo store)
+ *           → renderTodoStateMarkdown (headless prompt block)
+ *
+ * This is the path that runs in --ferment-oneshot headless mode. Every link in
+ * the chain is exercised with real implementations — no mocks for the event
+ * bus, bridge, store, or prompt renderer.
+ */
+
+import type { ExtensionAPI } from "@earendil-works/pi-coding-agent"
+import { createEventBus } from "@earendil-works/pi-coding-agent"
+import { afterEach, beforeEach, describe, expect, it } from "vitest"
+import type { Ferment } from "../../ferment/types.js"
+import {
+	__test_renderTodoStateMarkdown,
+	currentSessionHasUI,
+	renderTodoStateBlock,
+	setCurrentSessionHasUI,
+} from "../todos/prompt-block.js"
+import { __resetTodoStore, getTodosForScope } from "../todos/store.js"
+import { emitFermentDomainEvent } from "./domain-events-emitter.js"
+import { setActive } from "./state.js"
+import { registerFermentTodoSync } from "./todo-sync.js"
+
+// ─── Helpers ─────────────────────────────────────────────────────────────────
+
+function makeFerment(overrides: Partial<Ferment> = {}): Ferment {
+	return {
+		id: "ferment-wire-test",
+		name: "Wiring Test Ferment",
+		status: "running",
+		worktree: { path: "/tmp" },
+		scoping: {},
+		phases: [
+			{
+				id: "phase-1",
+				index: 1,
+				name: "Implementation",
+				goal: "do the work",
+				status: "active",
+				steps: [
+					{ id: "step-1", index: 1, description: "Write the code", status: "pending" },
+					{ id: "step-2", index: 2, description: "Run the tests", status: "pending" },
+				],
+			},
+		],
+		decisions: [],
+		memories: [],
+		createdAt: new Date().toISOString(),
+		updatedAt: new Date().toISOString(),
+		...overrides,
+	}
+}
+
+/** Minimal ExtensionAPI stub that delegates events to a real EventBus. */
+function makePiWithRealEventBus(): { pi: ExtensionAPI; unsubscribe: () => void } {
+	const bus = createEventBus()
+	const pi = { events: bus } as unknown as ExtensionAPI
+	const unsubscribe = registerFermentTodoSync(pi)
+	return { pi, unsubscribe }
+}
+
+// ─── Tests ───────────────────────────────────────────────────────────────────
+
+describe("ferment → todo → headless prompt wiring", () => {
+	beforeEach(() => {
+		__resetTodoStore()
+		setActive(undefined)
+		setCurrentSessionHasUI(false) // simulate headless / one-shot mode
+	})
+
+	afterEach(() => {
+		setActive(undefined)
+		__resetTodoStore()
+		setCurrentSessionHasUI(true) // reset to safe interactive default
+	})
+
+	it("currentSessionHasUI starts as false in headless mode (setCurrentSessionHasUI wires correctly)", () => {
+		expect(currentSessionHasUI).toBe(false)
+	})
+
+	it("renderTodoStateBlock returns undefined when no todos exist yet", () => {
+		// Before any phase starts, store is empty → block should not inject anything.
+		expect(renderTodoStateBlock()).toBeUndefined()
+	})
+
+	it("activate_phase event populates the todo store via the bridge", () => {
+		const ferment = makeFerment()
+		setActive(ferment)
+		const { pi, unsubscribe } = makePiWithRealEventBus()
+
+		try {
+			// Emit the same event that activate_ferment_phase tool fires after
+			// applyAndPersist({ type: "activate_phase", phaseId: "phase-1" }).
+			emitFermentDomainEvent(pi.events, { type: "activate_phase", phaseId: "phase-1" }, ferment)
+
+			const todos = getTodosForScope({ kind: "ferment", phaseId: "phase-1" })
+			// Phase header + 2 steps
+			expect(todos).toHaveLength(3)
+			expect(todos[0].content).toBe("[Phase 1] Implementation")
+			expect(todos[0].status).toBe("in_progress")
+			expect(todos[1].content).toBe("↳ Write the code")
+			expect(todos[1].status).toBe("pending")
+			expect(todos[2].content).toBe("↳ Run the tests")
+			expect(todos[2].status).toBe("pending")
+		} finally {
+			unsubscribe()
+		}
+	})
+
+	it("renderTodoStateBlock returns the ## Current Todos block after phase activation", () => {
+		const ferment = makeFerment()
+		setActive(ferment)
+		const { pi, unsubscribe } = makePiWithRealEventBus()
+
+		try {
+			emitFermentDomainEvent(pi.events, { type: "activate_phase", phaseId: "phase-1" }, ferment)
+
+			const md = renderTodoStateBlock()
+			expect(md).toBeDefined()
+			expect(md).toContain("## Current Todos")
+			expect(md).toContain("**[Phase 1] Implementation**")
+			expect(md).toContain("- [ ] ↳ Write the code")
+			expect(md).toContain("- [ ] ↳ Run the tests")
+		} finally {
+			unsubscribe()
+		}
+	})
+
+	it("renderTodoStateBlock returns undefined when UI is present (widget handles it)", () => {
+		const ferment = makeFerment()
+		setActive(ferment)
+		const { pi, unsubscribe } = makePiWithRealEventBus()
+
+		try {
+			emitFermentDomainEvent(pi.events, { type: "activate_phase", phaseId: "phase-1" }, ferment)
+
+			// Store is populated.
+			expect(getTodosForScope({ kind: "ferment", phaseId: "phase-1" })).toHaveLength(3)
+
+			// Switching to interactive mode: renderTodoStateBlock gates on currentSessionHasUI.
+			setCurrentSessionHasUI(true)
+			expect(renderTodoStateBlock()).toBeUndefined()
+		} finally {
+			unsubscribe()
+		}
+	})
+
+	it("complete_step event updates the step todo status in the block", () => {
+		const ferment = makeFerment()
+		setActive(ferment)
+		const { pi, unsubscribe } = makePiWithRealEventBus()
+
+		try {
+			emitFermentDomainEvent(pi.events, { type: "activate_phase", phaseId: "phase-1" }, ferment)
+
+			// Simulate complete_step for step-1
+			const completedFerment: Ferment = {
+				...ferment,
+				phases: ferment.phases.map((p) => ({
+					...p,
+					steps: p.steps.map((s) => (s.id === "step-1" ? { ...s, status: "done" as const } : s)),
+				})),
+			}
+			setActive(completedFerment)
+			emitFermentDomainEvent(
+				pi.events,
+				{ type: "complete_step", phaseId: "phase-1", stepId: "step-1" },
+				completedFerment,
+			)
+
+			const md = renderTodoStateBlock()
+			expect(md).toContain("- [x] ↳ Write the code")
+			expect(md).toContain("- [ ] ↳ Run the tests")
+		} finally {
+			unsubscribe()
+		}
+	})
+
+	it("complete_ferment event clears all ferment-scoped todos from the prompt block", () => {
+		const ferment = makeFerment()
+		setActive(ferment)
+		const { pi, unsubscribe } = makePiWithRealEventBus()
+
+		try {
+			emitFermentDomainEvent(pi.events, { type: "activate_phase", phaseId: "phase-1" }, ferment)
+			expect(renderTodoStateBlock()).toContain("## Current Todos")
+
+			const completedFerment: Ferment = { ...ferment, status: "complete" }
+			setActive(completedFerment)
+			emitFermentDomainEvent(pi.events, { type: "complete_ferment" }, completedFerment)
+
+			// All ferment-scoped todos cleared → block returns undefined.
+			expect(renderTodoStateBlock()).toBeUndefined()
+		} finally {
+			unsubscribe()
+		}
+	})
+
+	it("pause suspends todos (clears block) and resume restores them", () => {
+		const ferment = makeFerment()
+		setActive(ferment)
+		const { pi, unsubscribe } = makePiWithRealEventBus()
+
+		try {
+			emitFermentDomainEvent(pi.events, { type: "activate_phase", phaseId: "phase-1" }, ferment)
+			expect(renderTodoStateBlock()).toContain("## Current Todos")
+
+			// Pause clears todos from the store (but snapshots internally).
+			emitFermentDomainEvent(pi.events, { type: "pause" }, ferment)
+			expect(renderTodoStateBlock()).toBeUndefined()
+
+			// Resume restores the snapshot.
+			emitFermentDomainEvent(pi.events, { type: "resume" }, ferment)
+			const md = renderTodoStateBlock()
+			expect(md).toContain("## Current Todos")
+			expect(md).toContain("**[Phase 1] Implementation**")
+		} finally {
+			unsubscribe()
+		}
+	})
+})

--- a/src/extensions/ferment/todo-headless-wiring.test.ts
+++ b/src/extensions/ferment/todo-headless-wiring.test.ts
@@ -24,7 +24,7 @@ import {
 	renderTodoStateBlock,
 	setCurrentSessionHasUI,
 } from "../todos/prompt-block.js"
-import { __resetTodoStore, getTodosForScope } from "../todos/store.js"
+import { __resetTodoStore, applyWriteTodos, getTodosForScope, resolveTodoScope } from "../todos/store.js"
 import { emitFermentDomainEvent } from "./domain-events-emitter.js"
 import { setActive } from "./state.js"
 import { registerFermentTodoSync } from "./todo-sync.js"
@@ -153,7 +153,7 @@ describe("ferment → todo → headless prompt wiring", () => {
 		}
 	})
 
-	it("start_step event seeds the ferment-step scope with the step description", () => {
+	it("start_step event auto-scopes subsequent todo calls to the ferment-step scope", () => {
 		const ferment = makeFerment({
 			phases: [
 				{
@@ -176,16 +176,34 @@ describe("ferment → todo → headless prompt wiring", () => {
 			emitFermentDomainEvent(pi.events, { type: "activate_phase", phaseId: "phase-1" }, ferment)
 			emitFermentDomainEvent(pi.events, { type: "start_step", phaseId: "phase-1", stepId: "step-1" }, ferment)
 
-			const stepTodos = getTodosForScope({ kind: "ferment-step", phaseId: "phase-1", stepId: "step-1" })
-			expect(stepTodos).toHaveLength(1)
-			expect(stepTodos[0].content).toBe("Write the code")
-			expect(stepTodos[0].status).toBe("in_progress")
+			// Scope-less todo call should resolve to the running step's ferment-step scope
+			const resolved = resolveTodoScope(undefined)
+			expect(resolved).toEqual({ kind: "ferment-step", phaseId: "phase-1", stepId: "step-1" })
+
+			// Writing without explicit scope should go to ferment-step
+			applyWriteTodos({ todos: [{ content: "do something", status: "pending" }] })
+			expect(getTodosForScope({ kind: "ferment-step", phaseId: "phase-1", stepId: "step-1" })).toHaveLength(1)
+			expect(getTodosForScope({ kind: "global" })).toHaveLength(0)
 		} finally {
 			unsubscribe()
 		}
 	})
 
-	it("complete_step event clears the ferment-step scope", () => {
+	it("scope resolves to global when no step is running", () => {
+		const ferment = makeFerment()
+		setActive(ferment)
+		const { pi, unsubscribe } = makePiWithRealEventBus()
+
+		try {
+			// No step started — should resolve to global
+			const resolved = resolveTodoScope(undefined)
+			expect(resolved).toEqual({ kind: "global" })
+		} finally {
+			unsubscribe()
+		}
+	})
+
+	it("complete_step event clears the ferment-step scope and resets auto-scope to global", () => {
 		const ferment = makeFerment({
 			phases: [
 				{
@@ -208,7 +226,8 @@ describe("ferment → todo → headless prompt wiring", () => {
 			emitFermentDomainEvent(pi.events, { type: "activate_phase", phaseId: "phase-1" }, ferment)
 			emitFermentDomainEvent(pi.events, { type: "start_step", phaseId: "phase-1", stepId: "step-1" }, ferment)
 
-			// Step todos should exist
+			// Simulate model writing todos (without scope — auto-scoped)
+			applyWriteTodos({ todos: [{ content: "plan item", status: "in_progress" }] })
 			expect(getTodosForScope({ kind: "ferment-step", phaseId: "phase-1", stepId: "step-1" })).toHaveLength(1)
 
 			// Complete the step
@@ -228,12 +247,14 @@ describe("ferment → todo → headless prompt wiring", () => {
 
 			// Step-level todos should be cleared
 			expect(getTodosForScope({ kind: "ferment-step", phaseId: "phase-1", stepId: "step-1" })).toHaveLength(0)
+			// Scope should revert to global
+			expect(resolveTodoScope(undefined)).toEqual({ kind: "global" })
 		} finally {
 			unsubscribe()
 		}
 	})
 
-	it("fail_step event clears the ferment-step scope", () => {
+	it("fail_step event clears the ferment-step scope and resets auto-scope to global", () => {
 		const ferment = makeFerment({
 			phases: [
 				{
@@ -256,6 +277,7 @@ describe("ferment → todo → headless prompt wiring", () => {
 			emitFermentDomainEvent(pi.events, { type: "activate_phase", phaseId: "phase-1" }, ferment)
 			emitFermentDomainEvent(pi.events, { type: "start_step", phaseId: "phase-1", stepId: "step-1" }, ferment)
 
+			applyWriteTodos({ todos: [{ content: "plan item", status: "in_progress" }] })
 			expect(getTodosForScope({ kind: "ferment-step", phaseId: "phase-1", stepId: "step-1" })).toHaveLength(1)
 
 			const failedFerment: Ferment = {
@@ -273,6 +295,7 @@ describe("ferment → todo → headless prompt wiring", () => {
 			)
 
 			expect(getTodosForScope({ kind: "ferment-step", phaseId: "phase-1", stepId: "step-1" })).toHaveLength(0)
+			expect(resolveTodoScope(undefined)).toEqual({ kind: "global" })
 		} finally {
 			unsubscribe()
 		}

--- a/src/extensions/ferment/todo-sync.test.ts
+++ b/src/extensions/ferment/todo-sync.test.ts
@@ -490,4 +490,316 @@ describe("todo-sync bridge", () => {
 		expect(updatedTodos[1].id).toBe(step1IdBefore)
 		expect(updatedTodos[2].id).toBe(step2IdBefore)
 	})
+
+	it("ignores PHASE_COMPLETED events from a different ferment (stale-event guard)", () => {
+		const { pi, emit } = createFakePI()
+		const activeFerment = createTestFerment("phase-1", 2)
+		setActive(activeFerment)
+
+		unsubscribe = registerFermentTodoSync(pi)
+
+		// Set up todos for the active ferment
+		emit(FERMENT_EVENTS.PHASE_STARTED, {
+			fermentId: activeFerment.id,
+			phaseId: "phase-1",
+			phaseIndex: 1,
+			phaseName: "Active Phase",
+		})
+
+		const initialTodos = getTodosForScope({ kind: "ferment", phaseId: "phase-1" })
+		expect(initialTodos).toHaveLength(3) // header + 2 steps
+		expect(initialTodos[0].status).toBe("in_progress")
+		expect(initialTodos[1].status).toBe("pending")
+		expect(initialTodos[2].status).toBe("pending")
+
+		// Simulate a stale PHASE_COMPLETED arriving from a previous ferment that
+		// happens to share the same phaseId. The guard must reject it.
+		emit(FERMENT_EVENTS.PHASE_COMPLETED, {
+			fermentId: "different-ferment-id",
+			phaseId: "phase-1",
+			phaseIndex: 1,
+			phaseName: "Stale Phase",
+			durationMs: 1000,
+			deltaInputTokens: 0,
+			deltaOutputTokens: 0,
+			blockRetries: 0,
+		})
+
+		// Assert: todos for the active ferment are untouched
+		const afterStaleEvent = getTodosForScope({ kind: "ferment", phaseId: "phase-1" })
+		expect(afterStaleEvent).toHaveLength(3)
+		expect(afterStaleEvent[0].status).toBe("in_progress")
+		expect(afterStaleEvent[1].status).toBe("pending")
+		expect(afterStaleEvent[2].status).toBe("pending")
+	})
+
+	it("ignores PHASE_COMPLETED events when no ferment is active", () => {
+		const { pi, emit } = createFakePI()
+		setActive(undefined)
+
+		unsubscribe = registerFermentTodoSync(pi)
+
+		// Should not throw even though there's no active ferment and no todos.
+		expect(() =>
+			emit(FERMENT_EVENTS.PHASE_COMPLETED, {
+				fermentId: "any-ferment",
+				phaseId: "phase-1",
+				phaseIndex: 1,
+				phaseName: "Orphan Phase",
+				durationMs: 0,
+				deltaInputTokens: 0,
+				deltaOutputTokens: 0,
+				blockRetries: 0,
+			}),
+		).not.toThrow()
+	})
+
+	it("preserves stable IDs even when the store reorders written todos", () => {
+		const { pi, emit } = createFakePI()
+		const ferment = createTestFerment("phase-1", 3)
+		setActive(ferment)
+
+		unsubscribe = registerFermentTodoSync(pi)
+
+		emit(FERMENT_EVENTS.PHASE_STARTED, {
+			fermentId: ferment.id,
+			phaseId: "phase-1",
+			phaseIndex: 1,
+			phaseName: "Test Phase",
+		})
+
+		const initialTodos = getTodosForScope({ kind: "ferment", phaseId: "phase-1" })
+		const headerIdBefore = initialTodos[0].id
+		const step1IdBefore = initialTodos[1].id
+		const step3IdBefore = initialTodos[3].id
+
+		// Interleave a step completion between two non-adjacent steps.
+		// Content-based correlation should still match step-3 correctly.
+		emit(FERMENT_EVENTS.STEP_COMPLETED, {
+			fermentId: ferment.id,
+			phaseId: "phase-1",
+			stepId: "step-3",
+			stepIndex: 3,
+			durationMs: 1000,
+			success: true,
+		})
+
+		const updatedTodos = getTodosForScope({ kind: "ferment", phaseId: "phase-1" })
+		expect(updatedTodos[0].id).toBe(headerIdBefore)
+		expect(updatedTodos[1].id).toBe(step1IdBefore)
+		expect(updatedTodos[3].id).toBe(step3IdBefore)
+		expect(updatedTodos[3].status).toBe("completed")
+	})
+
+	// ─── Suspend / resume / finish ─────────────────────────────────────────────
+
+	it("FERMENT_SUSPENDED clears all ferment-scoped todos and preserves global scope", () => {
+		const { pi, emit } = createFakePI()
+		const ferment = createTestFerment("phase-1", 2)
+		setActive(ferment)
+
+		// Mix global and ferment todos before suspension
+		applyWriteTodos({
+			scope: { kind: "global" },
+			todos: [{ content: "User todo", status: "pending" }],
+		})
+
+		unsubscribe = registerFermentTodoSync(pi)
+
+		emit(FERMENT_EVENTS.PHASE_STARTED, {
+			fermentId: ferment.id,
+			phaseId: "phase-1",
+			phaseIndex: 1,
+			phaseName: "Test Phase",
+		})
+		// Add a ferment-step scoped todo (agent-written plan bullet)
+		applyWriteTodos({
+			scope: { kind: "ferment-step", phaseId: "phase-1", stepId: "step-1" },
+			todos: [{ content: "plan bullet", status: "in_progress" }],
+		})
+
+		// Sanity: ferment scope has 3 todos, ferment-step scope has 1, global has 1
+		expect(getTodosForScope({ kind: "ferment", phaseId: "phase-1" })).toHaveLength(3)
+		expect(getTodosForScope({ kind: "ferment-step", phaseId: "phase-1", stepId: "step-1" })).toHaveLength(1)
+		expect(getTodosForScope({ kind: "global" })).toHaveLength(1)
+
+		emit(FERMENT_EVENTS.SUSPENDED, { fermentId: ferment.id })
+
+		// Ferment-scoped todos are cleared
+		expect(getTodosForScope({ kind: "ferment", phaseId: "phase-1" })).toHaveLength(0)
+		expect(getTodosForScope({ kind: "ferment-step", phaseId: "phase-1", stepId: "step-1" })).toHaveLength(0)
+		// Global scope is untouched
+		expect(getTodosForScope({ kind: "global" })).toHaveLength(1)
+		expect(getTodosForScope({ kind: "global" })[0].content).toBe("User todo")
+	})
+
+	it("FERMENT_RESUMED restores the snapshot taken at suspension time", () => {
+		const { pi, emit } = createFakePI()
+		const ferment = createTestFerment("phase-1", 2)
+		setActive(ferment)
+
+		unsubscribe = registerFermentTodoSync(pi)
+
+		emit(FERMENT_EVENTS.PHASE_STARTED, {
+			fermentId: ferment.id,
+			phaseId: "phase-1",
+			phaseIndex: 1,
+			phaseName: "Test Phase",
+		})
+		emit(FERMENT_EVENTS.STEP_COMPLETED, {
+			fermentId: ferment.id,
+			phaseId: "phase-1",
+			stepId: "step-1",
+			stepIndex: 1,
+			durationMs: 1000,
+			success: true,
+		})
+
+		const beforeSuspend = getTodosForScope({ kind: "ferment", phaseId: "phase-1" })
+		expect(beforeSuspend).toHaveLength(3)
+		const phaseHeaderContent = beforeSuspend[0].content
+		const step1Content = beforeSuspend[1].content
+		const step1Status = beforeSuspend[1].status
+
+		emit(FERMENT_EVENTS.SUSPENDED, { fermentId: ferment.id })
+		expect(getTodosForScope({ kind: "ferment", phaseId: "phase-1" })).toHaveLength(0)
+
+		emit(FERMENT_EVENTS.RESUMED, { fermentId: ferment.id })
+
+		const afterResume = getTodosForScope({ kind: "ferment", phaseId: "phase-1" })
+		expect(afterResume).toHaveLength(3)
+		expect(afterResume[0].content).toBe(phaseHeaderContent)
+		expect(afterResume[1].content).toBe(step1Content)
+		expect(afterResume[1].status).toBe(step1Status)
+	})
+
+	it("FERMENT_RESUMED without a prior snapshot is a no-op", () => {
+		const { pi, emit } = createFakePI()
+		const ferment = createTestFerment("phase-1", 2)
+		setActive(ferment)
+
+		unsubscribe = registerFermentTodoSync(pi)
+
+		emit(FERMENT_EVENTS.PHASE_STARTED, {
+			fermentId: ferment.id,
+			phaseId: "phase-1",
+			phaseIndex: 1,
+			phaseName: "Test Phase",
+		})
+
+		expect(() => emit(FERMENT_EVENTS.RESUMED, { fermentId: ferment.id })).not.toThrow()
+
+		// Phase scope is still populated from PHASE_STARTED — RESUMED did nothing
+		const todos = getTodosForScope({ kind: "ferment", phaseId: "phase-1" })
+		expect(todos).toHaveLength(3)
+	})
+
+	it("FERMENT_COMPLETED clears all ferment-scoped todos and discards any pending snapshot", () => {
+		const { pi, emit } = createFakePI()
+		const ferment = createTestFerment("phase-1", 2)
+		setActive(ferment)
+
+		applyWriteTodos({
+			scope: { kind: "global" },
+			todos: [{ content: "User todo", status: "pending" }],
+		})
+
+		unsubscribe = registerFermentTodoSync(pi)
+
+		emit(FERMENT_EVENTS.PHASE_STARTED, {
+			fermentId: ferment.id,
+			phaseId: "phase-1",
+			phaseIndex: 1,
+			phaseName: "Test Phase",
+		})
+		emit(FERMENT_EVENTS.SUSPENDED, { fermentId: ferment.id })
+		expect(getTodosForScope({ kind: "ferment", phaseId: "phase-1" })).toHaveLength(0)
+
+		emit(FERMENT_EVENTS.COMPLETED, {
+			fermentId: ferment.id,
+			name: "Test Ferment",
+			phaseCount: 1,
+			durationMs: 5000,
+			totalInputTokens: 0,
+			totalOutputTokens: 0,
+			steeringCount: 0,
+			blockRetries: 0,
+		})
+
+		expect(getTodosForScope({ kind: "ferment", phaseId: "phase-1" })).toHaveLength(0)
+		expect(getTodosForScope({ kind: "global" })).toHaveLength(1)
+
+		// Subsequent RESUMED for the same ferment should be a no-op (snapshot
+		// was discarded by COMPLETED).
+		emit(FERMENT_EVENTS.RESUMED, { fermentId: ferment.id })
+		expect(getTodosForScope({ kind: "ferment", phaseId: "phase-1" })).toHaveLength(0)
+	})
+
+	it("suspend/resume cycle preserves stable behavior across multiple cycles", () => {
+		const { pi, emit } = createFakePI()
+		const ferment = createTestFerment("phase-1", 2)
+		setActive(ferment)
+
+		unsubscribe = registerFermentTodoSync(pi)
+
+		emit(FERMENT_EVENTS.PHASE_STARTED, {
+			fermentId: ferment.id,
+			phaseId: "phase-1",
+			phaseIndex: 1,
+			phaseName: "Test Phase",
+		})
+		const initialContent = getTodosForScope({ kind: "ferment", phaseId: "phase-1" }).map((t) => t.content)
+
+		// First suspend/resume cycle
+		emit(FERMENT_EVENTS.SUSPENDED, { fermentId: ferment.id })
+		expect(getTodosForScope({ kind: "ferment", phaseId: "phase-1" })).toHaveLength(0)
+		emit(FERMENT_EVENTS.RESUMED, { fermentId: ferment.id })
+		expect(getTodosForScope({ kind: "ferment", phaseId: "phase-1" }).map((t) => t.content)).toEqual(initialContent)
+
+		// Second suspend/resume cycle
+		emit(FERMENT_EVENTS.SUSPENDED, { fermentId: ferment.id })
+		expect(getTodosForScope({ kind: "ferment", phaseId: "phase-1" })).toHaveLength(0)
+		emit(FERMENT_EVENTS.RESUMED, { fermentId: ferment.id })
+		expect(getTodosForScope({ kind: "ferment", phaseId: "phase-1" }).map((t) => t.content)).toEqual(initialContent)
+	})
+
+	it("ignores FERMENT_SUSPENDED / RESUMED / COMPLETED events for a different ferment", () => {
+		const { pi, emit } = createFakePI()
+		const activeFerment = createTestFerment("phase-1", 2)
+		setActive(activeFerment)
+
+		applyWriteTodos({
+			scope: { kind: "global" },
+			todos: [{ content: "User todo", status: "pending" }],
+		})
+
+		unsubscribe = registerFermentTodoSync(pi)
+
+		emit(FERMENT_EVENTS.PHASE_STARTED, {
+			fermentId: activeFerment.id,
+			phaseId: "phase-1",
+			phaseIndex: 1,
+			phaseName: "Active Phase",
+		})
+		expect(getTodosForScope({ kind: "ferment", phaseId: "phase-1" })).toHaveLength(3)
+
+		// Stale events from another ferment must not affect the active one
+		emit(FERMENT_EVENTS.SUSPENDED, { fermentId: "different-ferment" })
+		expect(getTodosForScope({ kind: "ferment", phaseId: "phase-1" })).toHaveLength(3)
+
+		emit(FERMENT_EVENTS.COMPLETED, {
+			fermentId: "different-ferment",
+			name: "Different",
+			phaseCount: 1,
+			durationMs: 0,
+			totalInputTokens: 0,
+			totalOutputTokens: 0,
+			steeringCount: 0,
+			blockRetries: 0,
+		})
+		expect(getTodosForScope({ kind: "ferment", phaseId: "phase-1" })).toHaveLength(3)
+
+		emit(FERMENT_EVENTS.RESUMED, { fermentId: "different-ferment" })
+		expect(getTodosForScope({ kind: "ferment", phaseId: "phase-1" })).toHaveLength(3)
+	})
 })

--- a/src/extensions/ferment/todo-sync.test.ts
+++ b/src/extensions/ferment/todo-sync.test.ts
@@ -1,0 +1,493 @@
+/**
+ * Unit tests for Ferment → Todo Sync Bridge
+ *
+ * Validates that ferment lifecycle events correctly populate and update
+ * todo lists for each active phase.
+ */
+
+import type { ExtensionAPI } from "@earendil-works/pi-coding-agent"
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
+import type { Ferment, Phase } from "../../ferment/types.js"
+import { __resetTodoStore, applyWriteTodos, getTodosForScope } from "../todos/store.js"
+import { FERMENT_EVENTS } from "./domain-events.js"
+import { setActive } from "./state.js"
+import { registerFermentTodoSync } from "./todo-sync.js"
+
+// ─── Test helpers ────────────────────────────────────────────────────────────
+
+/** Minimal fake ExtensionAPI with pi.events support */
+function createFakePI(): {
+	pi: ExtensionAPI
+	emit: (channel: string, payload: unknown) => void
+} {
+	const listeners = new Map<string, Array<(payload: unknown) => void>>()
+
+	const events = {
+		on: (channel: string, handler: (payload: unknown) => void) => {
+			if (!listeners.has(channel)) {
+				listeners.set(channel, [])
+			}
+			const list = listeners.get(channel)
+			if (list) {
+				list.push(handler)
+			}
+			// Return an unsubscribe function
+			return () => {
+				const list = listeners.get(channel)
+				if (list) {
+					const idx = list.indexOf(handler)
+					if (idx !== -1) list.splice(idx, 1)
+				}
+			}
+		},
+		emit: (channel: string, payload: unknown) => {
+			const list = listeners.get(channel)
+			if (list) {
+				for (const fn of list) {
+					fn(payload)
+				}
+			}
+		},
+	}
+
+	const pi = {
+		events,
+	} as unknown as ExtensionAPI
+
+	return { pi, emit: events.emit }
+}
+
+/** Build a minimal test ferment with one phase and N steps */
+function createTestFerment(phaseId: string, stepCount: number): Ferment {
+	const steps = Array.from({ length: stepCount }, (_, i) => ({
+		id: `step-${i + 1}`,
+		index: i + 1,
+		description: `Step ${i + 1}`,
+		status: "pending" as const,
+	}))
+
+	const phase: Phase = {
+		id: phaseId,
+		index: 1,
+		name: "Test Phase",
+		goal: "Test phase goal",
+		status: "active",
+		steps,
+	}
+
+	return {
+		id: "ferment-test-1",
+		name: "Test Ferment",
+		status: "running",
+		worktree: { path: "/tmp" },
+		scoping: {},
+		phases: [phase],
+		decisions: [],
+		memories: [],
+		createdAt: new Date().toISOString(),
+		updatedAt: new Date().toISOString(),
+	}
+}
+
+// ─── Test suite ──────────────────────────────────────────────────────────────
+
+describe("todo-sync bridge", () => {
+	let unsubscribe: (() => void) | undefined
+
+	beforeEach(() => {
+		__resetTodoStore()
+		setActive(undefined)
+	})
+
+	afterEach(() => {
+		if (unsubscribe) {
+			unsubscribe()
+			unsubscribe = undefined
+		}
+		__resetTodoStore()
+		setActive(undefined)
+	})
+
+	it("phase activation populates todos with header and steps", () => {
+		const { pi, emit } = createFakePI()
+		const ferment = createTestFerment("phase-1", 3)
+		setActive(ferment)
+
+		unsubscribe = registerFermentTodoSync(pi)
+
+		// Emit PHASE_STARTED for phase-1
+		emit(FERMENT_EVENTS.PHASE_STARTED, {
+			fermentId: ferment.id,
+			phaseId: "phase-1",
+			phaseIndex: 1,
+			phaseName: "Test Phase",
+		})
+
+		// Assert: scope should have 1 header + 3 step todos
+		const todos = getTodosForScope({ kind: "ferment", phaseId: "phase-1" })
+		expect(todos).toHaveLength(4)
+
+		// Header: should show phase name and be in_progress
+		expect(todos[0].content).toBe("[Phase 1] Test Phase")
+		expect(todos[0].status).toBe("in_progress")
+		expect(todos[0].activeForm).toBe("Test Phase")
+
+		// Steps: should be indented with "↳ " prefix and pending
+		expect(todos[1].content).toBe("↳ Step 1")
+		expect(todos[1].status).toBe("pending")
+		expect(todos[2].content).toBe("↳ Step 2")
+		expect(todos[2].status).toBe("pending")
+		expect(todos[3].content).toBe("↳ Step 3")
+		expect(todos[3].status).toBe("pending")
+
+		// All should have stable IDs assigned
+		for (const todo of todos) {
+			expect(todo.id).toBeGreaterThan(0)
+		}
+	})
+
+	it("step completion marks the step todo as completed", () => {
+		const { pi, emit } = createFakePI()
+		const ferment = createTestFerment("phase-1", 3)
+		setActive(ferment)
+
+		unsubscribe = registerFermentTodoSync(pi)
+
+		// Emit PHASE_STARTED to populate initial todos
+		emit(FERMENT_EVENTS.PHASE_STARTED, {
+			fermentId: ferment.id,
+			phaseId: "phase-1",
+			phaseIndex: 1,
+			phaseName: "Test Phase",
+		})
+
+		// Emit STEP_COMPLETED for step-1
+		emit(FERMENT_EVENTS.STEP_COMPLETED, {
+			fermentId: ferment.id,
+			phaseId: "phase-1",
+			stepId: "step-1",
+			stepIndex: 1,
+			durationMs: 1000,
+			success: true,
+		})
+
+		const todos = getTodosForScope({ kind: "ferment", phaseId: "phase-1" })
+
+		// Phase header should still be in_progress
+		expect(todos[0].status).toBe("in_progress")
+
+		// Step 1 should be completed
+		expect(todos[1].content).toBe("↳ Step 1")
+		expect(todos[1].status).toBe("completed")
+
+		// Steps 2 and 3 should still be pending
+		expect(todos[2].status).toBe("pending")
+		expect(todos[3].status).toBe("pending")
+	})
+
+	it("step failure marks the step todo as blocked", () => {
+		const { pi, emit } = createFakePI()
+		const ferment = createTestFerment("phase-1", 3)
+		setActive(ferment)
+
+		unsubscribe = registerFermentTodoSync(pi)
+
+		// Emit PHASE_STARTED to populate initial todos
+		emit(FERMENT_EVENTS.PHASE_STARTED, {
+			fermentId: ferment.id,
+			phaseId: "phase-1",
+			phaseIndex: 1,
+			phaseName: "Test Phase",
+		})
+
+		// Emit STEP_FAILED for step-2
+		emit(FERMENT_EVENTS.STEP_FAILED, {
+			fermentId: ferment.id,
+			phaseId: "phase-1",
+			stepId: "step-2",
+			stepIndex: 2,
+			reason: "Test failure",
+		})
+
+		const todos = getTodosForScope({ kind: "ferment", phaseId: "phase-1" })
+
+		// Phase header should still be in_progress
+		expect(todos[0].status).toBe("in_progress")
+
+		// Step 1 should still be pending
+		expect(todos[1].status).toBe("pending")
+
+		// Step 2 should be blocked
+		expect(todos[2].content).toBe("↳ Step 2")
+		expect(todos[2].status).toBe("blocked")
+
+		// Step 3 should still be pending
+		expect(todos[3].status).toBe("pending")
+	})
+
+	it("manually-added todos are unaffected by ferment sync", () => {
+		const { pi, emit } = createFakePI()
+		const ferment = createTestFerment("phase-1", 2)
+		setActive(ferment)
+
+		// Add a manual global todo before registering the sync
+		applyWriteTodos({
+			scope: { kind: "global" },
+			todos: [
+				{ content: "Manual global todo", status: "pending" },
+				{ content: "Another manual todo", status: "in_progress" },
+			],
+		})
+
+		unsubscribe = registerFermentTodoSync(pi)
+
+		// Emit PHASE_STARTED for phase-1
+		emit(FERMENT_EVENTS.PHASE_STARTED, {
+			fermentId: ferment.id,
+			phaseId: "phase-1",
+			phaseIndex: 1,
+			phaseName: "Test Phase",
+		})
+
+		// Assert: global scope should still have the manual todos
+		const globalTodos = getTodosForScope({ kind: "global" })
+		expect(globalTodos).toHaveLength(2)
+		expect(globalTodos[0].content).toBe("Manual global todo")
+		expect(globalTodos[0].status).toBe("pending")
+		expect(globalTodos[1].content).toBe("Another manual todo")
+		expect(globalTodos[1].status).toBe("in_progress")
+
+		// Assert: ferment scope should have its own separate todos
+		const fermentTodos = getTodosForScope({ kind: "ferment", phaseId: "phase-1" })
+		expect(fermentTodos).toHaveLength(3) // 1 header + 2 steps
+		expect(fermentTodos[0].content).toBe("[Phase 1] Test Phase")
+		expect(fermentTodos[1].content).toBe("↳ Step 1")
+		expect(fermentTodos[2].content).toBe("↳ Step 2")
+	})
+
+	it("phase completion marks remaining todos as completed", () => {
+		const { pi, emit } = createFakePI()
+		const ferment = createTestFerment("phase-1", 3)
+		setActive(ferment)
+
+		unsubscribe = registerFermentTodoSync(pi)
+
+		// Emit PHASE_STARTED to populate initial todos
+		emit(FERMENT_EVENTS.PHASE_STARTED, {
+			fermentId: ferment.id,
+			phaseId: "phase-1",
+			phaseIndex: 1,
+			phaseName: "Test Phase",
+		})
+
+		// Complete step 1
+		emit(FERMENT_EVENTS.STEP_COMPLETED, {
+			fermentId: ferment.id,
+			phaseId: "phase-1",
+			stepId: "step-1",
+			stepIndex: 1,
+			durationMs: 1000,
+			success: true,
+		})
+
+		// Fail step 2 (should be blocked)
+		emit(FERMENT_EVENTS.STEP_FAILED, {
+			fermentId: ferment.id,
+			phaseId: "phase-1",
+			stepId: "step-2",
+			stepIndex: 2,
+			reason: "Test failure",
+		})
+
+		// Emit PHASE_COMPLETED (step 3 was never touched)
+		emit(FERMENT_EVENTS.PHASE_COMPLETED, {
+			fermentId: ferment.id,
+			phaseId: "phase-1",
+			phaseIndex: 1,
+			phaseName: "Test Phase",
+			durationMs: 5000,
+			deltaInputTokens: 1000,
+			deltaOutputTokens: 500,
+			blockRetries: 0,
+		})
+
+		const todos = getTodosForScope({ kind: "ferment", phaseId: "phase-1" })
+
+		// Phase header should be completed
+		expect(todos[0].status).toBe("completed")
+
+		// Step 1 should still be completed (was already completed)
+		expect(todos[1].status).toBe("completed")
+
+		// Step 2 should still be blocked (was failed, not auto-completed)
+		expect(todos[2].status).toBe("blocked")
+
+		// Step 3 should now be completed (was pending, marked completed by PHASE_COMPLETED)
+		expect(todos[3].status).toBe("completed")
+	})
+
+	it("unsubscribe removes all event listeners", () => {
+		const { pi, emit } = createFakePI()
+		const ferment = createTestFerment("phase-1", 2)
+		setActive(ferment)
+
+		unsubscribe = registerFermentTodoSync(pi)
+
+		// Emit PHASE_STARTED to populate initial todos
+		emit(FERMENT_EVENTS.PHASE_STARTED, {
+			fermentId: ferment.id,
+			phaseId: "phase-1",
+			phaseIndex: 1,
+			phaseName: "Test Phase",
+		})
+
+		// Verify todos were created
+		let todos = getTodosForScope({ kind: "ferment", phaseId: "phase-1" })
+		expect(todos).toHaveLength(3)
+
+		// Unsubscribe
+		unsubscribe()
+		unsubscribe = undefined
+
+		// Reset store to clear todos
+		__resetTodoStore()
+
+		// Emit PHASE_STARTED again — should NOT create todos
+		emit(FERMENT_EVENTS.PHASE_STARTED, {
+			fermentId: ferment.id,
+			phaseId: "phase-1",
+			phaseIndex: 1,
+			phaseName: "Test Phase",
+		})
+
+		todos = getTodosForScope({ kind: "ferment", phaseId: "phase-1" })
+		expect(todos).toHaveLength(0)
+	})
+
+	it("handles multiple step status transitions correctly", () => {
+		const { pi, emit } = createFakePI()
+		const ferment = createTestFerment("phase-1", 4)
+		setActive(ferment)
+
+		unsubscribe = registerFermentTodoSync(pi)
+
+		// Emit PHASE_STARTED to populate initial todos
+		emit(FERMENT_EVENTS.PHASE_STARTED, {
+			fermentId: ferment.id,
+			phaseId: "phase-1",
+			phaseIndex: 1,
+			phaseName: "Multi-Step Phase",
+		})
+
+		// Complete step 1
+		emit(FERMENT_EVENTS.STEP_COMPLETED, {
+			fermentId: ferment.id,
+			phaseId: "phase-1",
+			stepId: "step-1",
+			stepIndex: 1,
+			durationMs: 1000,
+			success: true,
+		})
+
+		// Complete step 2
+		emit(FERMENT_EVENTS.STEP_COMPLETED, {
+			fermentId: ferment.id,
+			phaseId: "phase-1",
+			stepId: "step-2",
+			stepIndex: 2,
+			durationMs: 1500,
+			success: true,
+		})
+
+		// Fail step 3
+		emit(FERMENT_EVENTS.STEP_FAILED, {
+			fermentId: ferment.id,
+			phaseId: "phase-1",
+			stepId: "step-3",
+			stepIndex: 3,
+			reason: "Test failure",
+		})
+
+		const todos = getTodosForScope({ kind: "ferment", phaseId: "phase-1" })
+
+		// Phase header should still be in_progress
+		expect(todos[0].status).toBe("in_progress")
+
+		// Steps 1 and 2 should be completed
+		expect(todos[1].status).toBe("completed")
+		expect(todos[2].status).toBe("completed")
+
+		// Step 3 should be blocked
+		expect(todos[3].status).toBe("blocked")
+
+		// Step 4 should still be pending
+		expect(todos[4].status).toBe("pending")
+	})
+
+	it("ignores events for different ferments", () => {
+		const { pi, emit } = createFakePI()
+		const ferment = createTestFerment("phase-1", 2)
+		setActive(ferment)
+
+		unsubscribe = registerFermentTodoSync(pi)
+
+		// Emit PHASE_STARTED for a different ferment
+		emit(FERMENT_EVENTS.PHASE_STARTED, {
+			fermentId: "different-ferment-id",
+			phaseId: "phase-1",
+			phaseIndex: 1,
+			phaseName: "Different Phase",
+		})
+
+		// Assert: no todos should be created
+		const todos = getTodosForScope({ kind: "ferment", phaseId: "phase-1" })
+		expect(todos).toHaveLength(0)
+	})
+
+	it("preserves stable IDs across multiple updates", () => {
+		const { pi, emit } = createFakePI()
+		const ferment = createTestFerment("phase-1", 2)
+		setActive(ferment)
+
+		unsubscribe = registerFermentTodoSync(pi)
+
+		// Emit PHASE_STARTED to populate initial todos
+		emit(FERMENT_EVENTS.PHASE_STARTED, {
+			fermentId: ferment.id,
+			phaseId: "phase-1",
+			phaseIndex: 1,
+			phaseName: "Test Phase",
+		})
+
+		// Capture initial IDs
+		const initialTodos = getTodosForScope({ kind: "ferment", phaseId: "phase-1" })
+		const headerIdBefore = initialTodos[0].id
+		const step1IdBefore = initialTodos[1].id
+		const step2IdBefore = initialTodos[2].id
+
+		// Complete step 1
+		emit(FERMENT_EVENTS.STEP_COMPLETED, {
+			fermentId: ferment.id,
+			phaseId: "phase-1",
+			stepId: "step-1",
+			stepIndex: 1,
+			durationMs: 1000,
+			success: true,
+		})
+
+		// Fail step 2
+		emit(FERMENT_EVENTS.STEP_FAILED, {
+			fermentId: ferment.id,
+			phaseId: "phase-1",
+			stepId: "step-2",
+			stepIndex: 2,
+			reason: "Test failure",
+		})
+
+		// Assert: IDs should remain stable
+		const updatedTodos = getTodosForScope({ kind: "ferment", phaseId: "phase-1" })
+		expect(updatedTodos[0].id).toBe(headerIdBefore)
+		expect(updatedTodos[1].id).toBe(step1IdBefore)
+		expect(updatedTodos[2].id).toBe(step2IdBefore)
+	})
+})

--- a/src/extensions/ferment/todo-sync.ts
+++ b/src/extensions/ferment/todo-sync.ts
@@ -12,18 +12,25 @@
  *   - PHASE_STARTED → populate initial todo list for the phase
  *   - STEP_COMPLETED / STEP_FAILED → update the corresponding step todo
  *   - PHASE_COMPLETED → mark any remaining todos as completed, cleanup
+ *   - FERMENT_SUSPENDED → snapshot all ferment-scoped todos, then clear them
+ *   - FERMENT_RESUMED → restore the snapshot taken at suspension time
+ *   - FERMENT_COMPLETED → clear all ferment-scoped todos (no restore)
  */
 
 import type { ExtensionAPI } from "@earendil-works/pi-coding-agent"
-import type { Phase, Step, StepStatus } from "../../ferment/types.js"
-import { applyWriteTodos, getTodosForScope } from "../todos/store.js"
-import type { TodoDraft, TodoItem, TodoStatus } from "../todos/types.js"
+import type { Phase, StepStatus } from "../../ferment/types.js"
+import { parseTodoScopeKey } from "../todos/scope.js"
+import { applyWriteTodos, getTodoState, getTodosForScope } from "../todos/store.js"
+import type { TodoDraft, TodoItem, TodoScope, TodoStatus } from "../todos/types.js"
 import {
 	FERMENT_EVENTS,
+	type FermentCompletedPayload,
 	type FermentPhaseCompletedPayload,
 	type FermentPhaseStartedPayload,
+	type FermentResumedPayload,
 	type FermentStepCompletedPayload,
 	type FermentStepFailedPayload,
+	type FermentSuspendedPayload,
 } from "./domain-events.js"
 import { getActive } from "./state.js"
 
@@ -48,6 +55,65 @@ function clearIdMap(fermentId: string, phaseId: string): void {
 	todoIdMaps.delete(key)
 }
 
+// ─── Suspend / resume snapshot ──────────────────────────────────────────────
+// When a ferment is suspended we snapshot every ferment-scoped todo list
+// (both `ferment` and `ferment-step` scopes whose phaseId belongs to the
+// ferment) and clear them. On resume we restore the snapshot, then drop it.
+
+interface ScopeSnapshot {
+	scope: TodoScope
+	todos: TodoItem[]
+}
+
+const suspendedSnapshots = new Map<string, ScopeSnapshot[]>()
+
+function clearSnapshot(fermentId: string): void {
+	suspendedSnapshots.delete(fermentId)
+}
+
+/** Find every todo scope (in the current store) whose phaseId matches one of
+ *  the given phase IDs and whose kind is ferment-scoped. Global scope is
+ *  excluded — it belongs to the user, not the ferment. */
+function findFermentScopes(phaseIds: ReadonlySet<string>): ScopeSnapshot[] {
+	if (phaseIds.size === 0) return []
+	const state = getTodoState()
+	const found: ScopeSnapshot[] = []
+	for (const scopeKey of Object.keys(state.byScope)) {
+		let scope: TodoScope
+		try {
+			scope = parseTodoScopeKey(scopeKey)
+		} catch {
+			continue
+		}
+		if (scope.kind !== "ferment" && scope.kind !== "ferment-step") continue
+		const scopePhaseId = (scope as { phaseId?: string }).phaseId
+		if (!scopePhaseId || !phaseIds.has(scopePhaseId)) continue
+		const scopeState = state.byScope[scopeKey]
+		if (!scopeState) continue
+		found.push({ scope, todos: [...scopeState.todos] })
+	}
+	return found
+}
+
+function clearScopeTodos(snapshots: ScopeSnapshot[]): void {
+	for (const { scope } of snapshots) {
+		applyWriteTodos({ scope, todos: [] })
+	}
+}
+
+function restoreScopeTodos(snapshots: ScopeSnapshot[]): void {
+	for (const { scope, todos } of snapshots) {
+		// Re-emit as drafts so the store assigns fresh IDs in the new lifecycle.
+		const drafts: TodoDraft[] = todos.map((todo) => ({
+			content: todo.content,
+			status: todo.status,
+			activeForm: todo.activeForm,
+			note: todo.note,
+		}))
+		applyWriteTodos({ scope, todos: drafts })
+	}
+}
+
 // ─── Status mapping ──────────────────────────────────────────────────────────
 
 function stepStatusToTodoStatus(stepStatus: StepStatus): TodoStatus {
@@ -69,61 +135,64 @@ function stepStatusToTodoStatus(stepStatus: StepStatus): TodoStatus {
 
 // ─── Todo list builders ──────────────────────────────────────────────────────
 
-function buildPhaseTodos(phase: Phase, fermentId: string): TodoDraft[] {
+/** Correlation map linking written todo content back to its ferment-internal
+ *  key (step ID, or the synthetic "header" key for the phase header row).
+ *  Built alongside the TodoDraft list so we can match store-assigned IDs back
+ *  to ferment entities deterministically — no reliance on input order. */
+type ContentSyncMap = Map<string, string>
+
+function buildPhaseTodos(
+	phase: Phase,
+	fermentId: string,
+): {
+	todos: TodoDraft[]
+	contentSyncMap: ContentSyncMap
+} {
 	const idMap = getOrCreateIdMap(fermentId, phase.id)
+	const contentSyncMap: ContentSyncMap = new Map()
 	const todos: TodoDraft[] = []
 
 	// Phase header — use phase.name as the content, status is always in_progress
 	// until the phase is marked complete (handled by PHASE_COMPLETED).
 	const headerContent = `[Phase ${phase.index}] ${phase.name}`
-	const headerId = idMap.get("header")
+	contentSyncMap.set(headerContent, "header")
 	todos.push({
-		id: headerId,
+		id: idMap.get("header"),
 		content: headerContent,
 		status: "in_progress",
 		activeForm: phase.name,
 	})
-	if (headerId === undefined) {
-		// First write — auto-assign ID 1 for header. TodoStore will assign it
-		// and we'll capture it on the next read cycle. For now, leave undefined.
-		// We rely on the fact that the store assigns IDs sequentially starting
-		// from nextId, so the header gets the first ID and steps get subsequent IDs.
-	}
 
 	// Steps — indented with "↳ " prefix to nest visually under the phase header
 	for (const step of phase.steps) {
-		const stepId = idMap.get(step.id)
-		const status = stepStatusToTodoStatus(step.status)
+		const content = `↳ ${step.description}`
+		contentSyncMap.set(content, step.id)
 		todos.push({
-			id: stepId,
-			content: `↳ ${step.description}`,
-			status,
+			id: idMap.get(step.id),
+			content,
+			status: stepStatusToTodoStatus(step.status),
 		})
 	}
 
-	return todos
+	return { todos, contentSyncMap }
 }
 
-function syncTodoIds(fermentId: string, phaseId: string, writtenTodos: TodoItem[]): void {
+function syncTodoIds(
+	fermentId: string,
+	phaseId: string,
+	writtenTodos: TodoItem[],
+	contentSyncMap: ContentSyncMap,
+): void {
 	const idMap = getOrCreateIdMap(fermentId, phaseId)
-	// After writing, the store has assigned stable IDs. Re-sync our map
-	// so subsequent updates can reference the same IDs.
-	//
-	// writtenTodos[0] is always the header, writtenTodos[1..] are steps.
-	// We derive the step list from the active ferment to map indices correctly.
-	const ferment = getActive()
-	if (!ferment) return
-	const phase = ferment.phases.find((p) => p.id === phaseId)
-	if (!phase) return
-
-	if (writtenTodos.length > 0) {
-		idMap.set("header", writtenTodos[0].id)
-	}
-
-	for (let i = 0; i < phase.steps.length && i + 1 < writtenTodos.length; i++) {
-		const step = phase.steps[i]
-		const todo = writtenTodos[i + 1]
-		idMap.set(step.id, todo.id)
+	// Match written todos back to ferment entities by content. Content is
+	// deterministic per phase (the header is `[Phase N] name`, each step is
+	// `↳ description`), so this stays correct regardless of how the store
+	// reorders, filters, or reassigns IDs internally.
+	for (const todo of writtenTodos) {
+		const syncKey = contentSyncMap.get(todo.content)
+		if (syncKey !== undefined) {
+			idMap.set(syncKey, todo.id)
+		}
 	}
 }
 
@@ -146,11 +215,11 @@ function handlePhaseStarted(raw: unknown): void {
 		return
 	}
 
-	const todos = buildPhaseTodos(phase, ferment.id)
+	const { todos, contentSyncMap } = buildPhaseTodos(phase, ferment.id)
 	const details = applyWriteTodos({ scope: { kind: "ferment", phaseId: payload.phaseId }, todos })
 
 	// Capture the assigned IDs for future updates
-	syncTodoIds(ferment.id, payload.phaseId, details.todos)
+	syncTodoIds(ferment.id, payload.phaseId, details.todos, contentSyncMap)
 }
 
 function handleStepCompleted(raw: unknown): void {
@@ -229,6 +298,13 @@ function handleStepFailed(raw: unknown): void {
 
 function handlePhaseCompleted(raw: unknown): void {
 	const payload = raw as FermentPhaseCompletedPayload
+
+	// Guard: ignore stale PHASE_COMPLETED events from ferments other than the
+	// currently active one. Without this guard, a late event could mutate the
+	// new ferment's todos (if phaseId collides) and drop its sync state.
+	const ferment = getActive()
+	if (!ferment || ferment.id !== payload.fermentId) return
+
 	const currentTodos = getTodosForScope({ kind: "ferment", phaseId: payload.phaseId })
 	if (currentTodos.length === 0) {
 		// No todos written for this phase (edge case: phase with zero steps that
@@ -252,6 +328,66 @@ function handlePhaseCompleted(raw: unknown): void {
 	clearIdMap(payload.fermentId, payload.phaseId)
 }
 
+function handleFermentSuspended(raw: unknown): void {
+	const payload = raw as FermentSuspendedPayload
+
+	// Active-ferment guard: stale or cross-ferment pause events must not touch
+	// the current ferment's todo state.
+	const ferment = getActive()
+	if (!ferment || ferment.id !== payload.fermentId) return
+
+	const phaseIds = new Set(ferment.phases.map((p) => p.id))
+	const snapshots = findFermentScopes(phaseIds)
+	if (snapshots.length === 0) {
+		// Nothing to snapshot — make sure no stale snapshot from a prior cycle
+		// leaks into a future resume.
+		clearSnapshot(ferment.id)
+		return
+	}
+
+	suspendedSnapshots.set(ferment.id, snapshots)
+	clearScopeTodos(snapshots)
+}
+
+function handleFermentResumed(raw: unknown): void {
+	const payload = raw as FermentResumedPayload
+
+	// Active-ferment guard: stale resume events for a different ferment must
+	// not restore snapshot state into the current ferment's scopes.
+	const ferment = getActive()
+	if (!ferment || ferment.id !== payload.fermentId) return
+
+	const snapshots = suspendedSnapshots.get(ferment.id)
+	if (!snapshots) return // RESUMED without prior SUSPENDED — no-op
+	suspendedSnapshots.delete(ferment.id)
+
+	// Only restore scopes that still belong to this ferment. If phases were
+	// added/removed between suspend and resume, stale scopes are skipped.
+	const phaseIds = new Set(ferment.phases.map((p) => p.id))
+	const liveSnapshots = snapshots.filter((snapshot) => {
+		const scopePhaseId = (snapshot.scope as { phaseId?: string }).phaseId
+		return scopePhaseId !== undefined && phaseIds.has(scopePhaseId)
+	})
+	restoreScopeTodos(liveSnapshots)
+}
+
+function handleFermentCompleted(raw: unknown): void {
+	const payload = raw as FermentCompletedPayload
+
+	// Active-ferment guard.
+	const ferment = getActive()
+	if (!ferment || ferment.id !== payload.fermentId) return
+
+	const phaseIds = new Set(ferment.phases.map((p) => p.id))
+	const snapshots = findFermentScopes(phaseIds)
+	if (snapshots.length > 0) {
+		clearScopeTodos(snapshots)
+	}
+	// Drop any snapshot left behind by a prior SUSPENDED that was never
+	// resumed (e.g. ferment was abandoned mid-suspend). Nothing to restore.
+	clearSnapshot(ferment.id)
+}
+
 // ─── Public API ──────────────────────────────────────────────────────────────
 
 /**
@@ -266,12 +402,16 @@ export function registerFermentTodoSync(pi: ExtensionAPI): () => void {
 	unsubscribes.push(pi.events.on(FERMENT_EVENTS.STEP_COMPLETED, handleStepCompleted))
 	unsubscribes.push(pi.events.on(FERMENT_EVENTS.STEP_FAILED, handleStepFailed))
 	unsubscribes.push(pi.events.on(FERMENT_EVENTS.PHASE_COMPLETED, handlePhaseCompleted))
+	unsubscribes.push(pi.events.on(FERMENT_EVENTS.SUSPENDED, handleFermentSuspended))
+	unsubscribes.push(pi.events.on(FERMENT_EVENTS.RESUMED, handleFermentResumed))
+	unsubscribes.push(pi.events.on(FERMENT_EVENTS.COMPLETED, handleFermentCompleted))
 
 	return () => {
 		for (const unsub of unsubscribes) {
 			unsub()
 		}
-		// Clear all ID maps on unsubscribe to avoid memory leaks
+		// Clear all in-memory state on unsubscribe to avoid memory leaks.
 		todoIdMaps.clear()
+		suspendedSnapshots.clear()
 	}
 }

--- a/src/extensions/ferment/todo-sync.ts
+++ b/src/extensions/ferment/todo-sync.ts
@@ -30,6 +30,7 @@ import {
 	type FermentResumedPayload,
 	type FermentStepCompletedPayload,
 	type FermentStepFailedPayload,
+	type FermentStepStartedPayload,
 	type FermentSuspendedPayload,
 } from "./domain-events.js"
 import { getActive } from "./state.js"
@@ -222,6 +223,32 @@ function handlePhaseStarted(raw: unknown): void {
 	syncTodoIds(ferment.id, payload.phaseId, details.todos, contentSyncMap)
 }
 
+function handleStepStarted(raw: unknown): void {
+	const payload = raw as FermentStepStartedPayload
+	const ferment = getActive()
+	if (!ferment || ferment.id !== payload.fermentId) return
+
+	const phase = ferment.phases.find((p) => p.id === payload.phaseId)
+	if (!phase) return
+
+	const step = phase.steps.find((s) => s.id === payload.stepId)
+	if (!step) return
+
+	// Seed the ferment-step scope with the step description so the model
+	// has a starting point to expand into a detailed implementation plan.
+	applyWriteTodos({
+		scope: { kind: "ferment-step", phaseId: payload.phaseId, stepId: payload.stepId },
+		todos: [{ content: step.description, status: "in_progress" }],
+	})
+}
+
+function clearStepTodos(phaseId: string, stepId: string): void {
+	applyWriteTodos({
+		scope: { kind: "ferment-step", phaseId, stepId },
+		todos: [],
+	})
+}
+
 function handleStepCompleted(raw: unknown): void {
 	const payload = raw as FermentStepCompletedPayload
 	const ferment = getActive()
@@ -240,6 +267,9 @@ function handleStepCompleted(raw: unknown): void {
 		console.warn(`[todo-sync] STEP_COMPLETED for unknown step ${payload.stepId} in phase ${payload.phaseId}. Skipping.`)
 		return
 	}
+
+	// Clear the step-level implementation todos — they're done.
+	clearStepTodos(payload.phaseId, payload.stepId)
 
 	const idMap = getOrCreateIdMap(ferment.id, payload.phaseId)
 	const stepTodoId = idMap.get(payload.stepId)
@@ -277,6 +307,9 @@ function handleStepFailed(raw: unknown): void {
 		console.warn(`[todo-sync] STEP_FAILED for unknown step ${payload.stepId} in phase ${payload.phaseId}. Skipping.`)
 		return
 	}
+
+	// Clear the step-level implementation todos — the step failed.
+	clearStepTodos(payload.phaseId, payload.stepId)
 
 	const idMap = getOrCreateIdMap(ferment.id, payload.phaseId)
 	const stepTodoId = idMap.get(payload.stepId)
@@ -399,6 +432,7 @@ export function registerFermentTodoSync(pi: ExtensionAPI): () => void {
 	const unsubscribes: Array<() => void> = []
 
 	unsubscribes.push(pi.events.on(FERMENT_EVENTS.PHASE_STARTED, handlePhaseStarted))
+	unsubscribes.push(pi.events.on(FERMENT_EVENTS.STEP_STARTED, handleStepStarted))
 	unsubscribes.push(pi.events.on(FERMENT_EVENTS.STEP_COMPLETED, handleStepCompleted))
 	unsubscribes.push(pi.events.on(FERMENT_EVENTS.STEP_FAILED, handleStepFailed))
 	unsubscribes.push(pi.events.on(FERMENT_EVENTS.PHASE_COMPLETED, handlePhaseCompleted))

--- a/src/extensions/ferment/todo-sync.ts
+++ b/src/extensions/ferment/todo-sync.ts
@@ -20,7 +20,13 @@
 import type { ExtensionAPI } from "@earendil-works/pi-coding-agent"
 import type { Phase, StepStatus } from "../../ferment/types.js"
 import { parseTodoScopeKey } from "../todos/scope.js"
-import { applyWriteTodos, getTodoState, getTodosForScope, registerActiveTodoScopeProvider } from "../todos/store.js"
+import {
+	applyWriteTodos,
+	getTodoState,
+	getTodosForScope,
+	registerActiveTodoScopeProvider,
+	subscribeTodoStore,
+} from "../todos/store.js"
 import type { TodoDraft, TodoItem, TodoScope, TodoStatus } from "../todos/types.js"
 import {
 	FERMENT_EVENTS,
@@ -229,6 +235,28 @@ function handlePhaseStarted(raw: unknown): void {
 
 let currentRunningStep: { phaseId: string; stepId: string } | undefined
 
+/**
+ * Number of orchestrator turns since the step-scope todos were last written.
+ * Incremented by `bumpStallCounter()` (called from the turn_end handler in
+ * prompt-enrichment), reset to 0 whenever `applyWriteTodos` fires for the
+ * active ferment-step scope (via the store listener wired in
+ * `registerFermentTodoSync`).
+ */
+let turnsSinceStepTodoWrite = 0
+
+/** Call once per orchestrator turn_end to track how long the step scope
+ *  has been untouched. Only increments when a step is actually running. */
+export function bumpStallCounter(): void {
+	if (currentRunningStep) turnsSinceStepTodoWrite++
+}
+
+/** Returns the number of turns since the step-scope todos were last written,
+ *  or 0 when no step is running. */
+export function getTurnsSinceStepTodoWrite(): number {
+	if (!currentRunningStep) return 0
+	return turnsSinceStepTodoWrite
+}
+
 /** Exported for tests only. */
 export function __getCurrentRunningStep(): { phaseId: string; stepId: string } | undefined {
 	return currentRunningStep
@@ -241,6 +269,7 @@ function handleStepStarted(raw: unknown): void {
 
 	// Track the running step so the scope provider can auto-scope todo calls.
 	currentRunningStep = { phaseId: payload.phaseId, stepId: payload.stepId }
+	turnsSinceStepTodoWrite = 0
 }
 
 function clearStepTodos(phaseId: string, stepId: string): void {
@@ -446,6 +475,18 @@ export function registerFermentTodoSync(pi: ExtensionAPI): () => void {
 		}
 	})
 
+	// Reset the stall counter whenever the active step's todo scope is written to.
+	const unsubscribeTodoListener = subscribeTodoStore((details) => {
+		if (!currentRunningStep) return
+		if (
+			details.scope.kind === "ferment-step" &&
+			(details.scope as { phaseId: string; stepId: string }).phaseId === currentRunningStep.phaseId &&
+			(details.scope as { phaseId: string; stepId: string }).stepId === currentRunningStep.stepId
+		) {
+			turnsSinceStepTodoWrite = 0
+		}
+	})
+
 	unsubscribes.push(pi.events.on(FERMENT_EVENTS.PHASE_STARTED, handlePhaseStarted))
 	unsubscribes.push(pi.events.on(FERMENT_EVENTS.STEP_STARTED, handleStepStarted))
 	unsubscribes.push(pi.events.on(FERMENT_EVENTS.STEP_COMPLETED, handleStepCompleted))
@@ -460,7 +501,9 @@ export function registerFermentTodoSync(pi: ExtensionAPI): () => void {
 			unsub()
 		}
 		unregisterScope()
+		unsubscribeTodoListener()
 		currentRunningStep = undefined
+		turnsSinceStepTodoWrite = 0
 		// Clear all in-memory state on unsubscribe to avoid memory leaks.
 		todoIdMaps.clear()
 		suspendedSnapshots.clear()

--- a/src/extensions/ferment/todo-sync.ts
+++ b/src/extensions/ferment/todo-sync.ts
@@ -142,63 +142,56 @@ function stepStatusToTodoStatus(stepStatus: StepStatus): TodoStatus {
 
 // ─── Todo list builders ──────────────────────────────────────────────────────
 
-/** Correlation map linking written todo content back to its ferment-internal
- *  key (step ID, or the synthetic "header" key for the phase header row).
- *  Built alongside the TodoDraft list so we can match store-assigned IDs back
- *  to ferment entities deterministically — no reliance on input order. */
-type ContentSyncMap = Map<string, string>
-
+/**
+ * Build the initial todo list for a phase, tagging each draft with an internal
+ * `_syncKey` so `syncTodoIds` can map written items back to the originating
+ * ferment entity (phase header or specific step) without depending on the
+ * store's internal ordering or user-generated content.
+ */
 function buildPhaseTodos(
 	phase: Phase,
 	fermentId: string,
 ): {
 	todos: TodoDraft[]
-	contentSyncMap: ContentSyncMap
 } {
 	const idMap = getOrCreateIdMap(fermentId, phase.id)
-	const contentSyncMap: ContentSyncMap = new Map()
 	const todos: TodoDraft[] = []
 
 	// Phase header — use phase.name as the content, status is always in_progress
 	// until the phase is marked complete (handled by PHASE_COMPLETED).
 	const headerContent = `[Phase ${phase.index}] ${phase.name}`
-	contentSyncMap.set(headerContent, "header")
 	todos.push({
 		id: idMap.get("header"),
 		content: headerContent,
 		status: "in_progress",
 		activeForm: phase.name,
+		_syncKey: "header",
 	})
 
 	// Steps — indented with "↳ " prefix to nest visually under the phase header
 	for (const step of phase.steps) {
 		const content = `↳ ${step.description}`
-		contentSyncMap.set(content, step.id)
 		todos.push({
 			id: idMap.get(step.id),
 			content,
 			status: stepStatusToTodoStatus(step.status),
+			_syncKey: step.id,
 		})
 	}
 
-	return { todos, contentSyncMap }
+	return { todos }
 }
 
-function syncTodoIds(
-	fermentId: string,
-	phaseId: string,
-	writtenTodos: TodoItem[],
-	contentSyncMap: ContentSyncMap,
-): void {
+function syncTodoIds(fermentId: string, phaseId: string, writtenTodos: TodoItem[]): void {
 	const idMap = getOrCreateIdMap(fermentId, phaseId)
-	// Match written todos back to ferment entities by content. Content is
-	// deterministic per phase (the header is `[Phase N] name`, each step is
-	// `↳ description`), so this stays correct regardless of how the store
-	// reorders, filters, or reassigns IDs internally.
+	// Match written todos back to ferment entities via the internal _syncKey.
+	// This is deterministic regardless of how the store reorders, filters,
+	// or reassigns IDs, and avoids the fragility of correlating on user-
+	// generated content (where two steps can share the same description).
 	for (const todo of writtenTodos) {
-		const syncKey = contentSyncMap.get(todo.content)
-		if (syncKey !== undefined) {
-			idMap.set(syncKey, todo.id)
+		const key = todo._syncKey
+		if (key !== undefined) {
+			idMap.set(key, todo.id)
 		}
 	}
 }
@@ -222,44 +215,53 @@ function handlePhaseStarted(raw: unknown): void {
 		return
 	}
 
-	const { todos, contentSyncMap } = buildPhaseTodos(phase, ferment.id)
+	const { todos } = buildPhaseTodos(phase, ferment.id)
 	const details = applyWriteTodos({ scope: { kind: "ferment", phaseId: payload.phaseId }, todos })
 
 	// Capture the assigned IDs for future updates
-	syncTodoIds(ferment.id, payload.phaseId, details.todos, contentSyncMap)
+	syncTodoIds(ferment.id, payload.phaseId, details.todos)
 }
 
 // ─── Active step tracking for scope provider ────────────────────────────────
 // When a ferment step is running, scope-less todo calls (update_todos, add_todo)
 // automatically target the ferment-step scope instead of global.
+//
+// We track steps in a Map keyed by `phaseId/stepId` so parallel siblings don't
+// overwrite each other's state. When multiple steps are active simultaneously,
+// the scope provider returns undefined to force explicit scope on todo calls
+// (avoids the ambiguity of writing to whichever step finished last).
 
-let currentRunningStep: { phaseId: string; stepId: string } | undefined
+type RunningStep = { phaseId: string; stepId: string }
+
+const runningSteps = new Map<string, RunningStep>()
+
+function stepKey(phaseId: string, stepId: string): string {
+	return `${phaseId}/${stepId}`
+}
+
+/** Exported for tests only. */
+export function __getRunningSteps(): ReadonlyMap<string, RunningStep> {
+	return runningSteps
+}
 
 /**
- * Number of orchestrator turns since the step-scope todos were last written.
- * Incremented by `bumpStallCounter()` (called from the turn_end handler in
- * prompt-enrichment), reset to 0 whenever `applyWriteTodos` fires for the
- * active ferment-step scope (via the store listener wired in
- * `registerFermentTodoSync`).
+ * Number of orchestrator turns since any step-scope todos were last written.
+ * Increments only while at least one step is running; resets when any
+ * active step's scope is written to.
  */
 let turnsSinceStepTodoWrite = 0
 
 /** Call once per orchestrator turn_end to track how long the step scope
  *  has been untouched. Only increments when a step is actually running. */
 export function bumpStallCounter(): void {
-	if (currentRunningStep) turnsSinceStepTodoWrite++
+	if (runningSteps.size > 0) turnsSinceStepTodoWrite++
 }
 
-/** Returns the number of turns since the step-scope todos were last written,
+/** Returns the number of turns since any step-scope todos were last written,
  *  or 0 when no step is running. */
 export function getTurnsSinceStepTodoWrite(): number {
-	if (!currentRunningStep) return 0
+	if (runningSteps.size === 0) return 0
 	return turnsSinceStepTodoWrite
-}
-
-/** Exported for tests only. */
-export function __getCurrentRunningStep(): { phaseId: string; stepId: string } | undefined {
-	return currentRunningStep
 }
 
 function handleStepStarted(raw: unknown): void {
@@ -268,7 +270,12 @@ function handleStepStarted(raw: unknown): void {
 	if (!ferment || ferment.id !== payload.fermentId) return
 
 	// Track the running step so the scope provider can auto-scope todo calls.
-	currentRunningStep = { phaseId: payload.phaseId, stepId: payload.stepId }
+	// Multiple parallel siblings coexist in the map; the scope provider handles
+	// the ambiguity when more than one is active.
+	runningSteps.set(stepKey(payload.phaseId, payload.stepId), {
+		phaseId: payload.phaseId,
+		stepId: payload.stepId,
+	})
 	turnsSinceStepTodoWrite = 0
 }
 
@@ -298,9 +305,10 @@ function handleStepCompleted(raw: unknown): void {
 		return
 	}
 
-	// Clear the step-level implementation todos and stop tracking.
+	// Clear the step-level implementation todos and stop tracking this step
+	// (parallel siblings remain tracked in runningSteps).
 	clearStepTodos(payload.phaseId, payload.stepId)
-	currentRunningStep = undefined
+	runningSteps.delete(stepKey(payload.phaseId, payload.stepId))
 
 	const idMap = getOrCreateIdMap(ferment.id, payload.phaseId)
 	const stepTodoId = idMap.get(payload.stepId)
@@ -339,9 +347,10 @@ function handleStepFailed(raw: unknown): void {
 		return
 	}
 
-	// Clear the step-level implementation todos and stop tracking.
+	// Clear the step-level implementation todos and stop tracking this step
+	// (parallel siblings remain tracked in runningSteps).
 	clearStepTodos(payload.phaseId, payload.stepId)
-	currentRunningStep = undefined
+	runningSteps.delete(stepKey(payload.phaseId, payload.stepId))
 
 	const idMap = getOrCreateIdMap(ferment.id, payload.phaseId)
 	const stepTodoId = idMap.get(payload.stepId)
@@ -463,26 +472,26 @@ function handleFermentCompleted(raw: unknown): void {
 export function registerFermentTodoSync(pi: ExtensionAPI): () => void {
 	const unsubscribes: Array<() => void> = []
 
-	// Auto-scope: when a ferment step is running, scope-less todo calls
-	// (update_todos, add_todo without explicit scope) target the active
-	// step's ferment-step scope instead of global.
+	// Auto-scope: when exactly one ferment step is running, scope-less todo
+	// calls target that step's ferment-step scope. When multiple parallel
+	// steps are active, return undefined to force the caller to pass an
+	// explicit scope — avoids silently writing to the wrong step.
 	const unregisterScope = registerActiveTodoScopeProvider(() => {
-		if (!currentRunningStep) return undefined
+		if (runningSteps.size !== 1) return undefined
+		const [, step] = [...runningSteps.entries()][0]
 		return {
 			kind: "ferment-step" as const,
-			phaseId: currentRunningStep.phaseId,
-			stepId: currentRunningStep.stepId,
+			phaseId: step.phaseId,
+			stepId: step.stepId,
 		}
 	})
 
-	// Reset the stall counter whenever the active step's todo scope is written to.
+	// Reset the stall counter whenever ANY running step's todo scope is written to.
 	const unsubscribeTodoListener = subscribeTodoStore((details) => {
-		if (!currentRunningStep) return
-		if (
-			details.scope.kind === "ferment-step" &&
-			(details.scope as { phaseId: string; stepId: string }).phaseId === currentRunningStep.phaseId &&
-			(details.scope as { phaseId: string; stepId: string }).stepId === currentRunningStep.stepId
-		) {
+		if (runningSteps.size === 0) return
+		if (details.scope.kind !== "ferment-step") return
+		const scope = details.scope as { phaseId: string; stepId: string }
+		if (runningSteps.has(stepKey(scope.phaseId, scope.stepId))) {
 			turnsSinceStepTodoWrite = 0
 		}
 	})
@@ -502,7 +511,7 @@ export function registerFermentTodoSync(pi: ExtensionAPI): () => void {
 		}
 		unregisterScope()
 		unsubscribeTodoListener()
-		currentRunningStep = undefined
+		runningSteps.clear()
 		turnsSinceStepTodoWrite = 0
 		// Clear all in-memory state on unsubscribe to avoid memory leaks.
 		todoIdMaps.clear()

--- a/src/extensions/ferment/todo-sync.ts
+++ b/src/extensions/ferment/todo-sync.ts
@@ -1,0 +1,277 @@
+/**
+ * Ferment → Todo Sync Bridge
+ *
+ * Subscribes to ferment lifecycle events and maintains a synchronized todo list
+ * for each active phase. The todo list shows:
+ *   - A phase header (derived from the phase name)
+ *   - One todo per step (indented, reflecting step status)
+ *
+ * IDs are stable across updates so UI animations and reconciliation work correctly.
+ *
+ * Lifecycle:
+ *   - PHASE_STARTED → populate initial todo list for the phase
+ *   - STEP_COMPLETED / STEP_FAILED → update the corresponding step todo
+ *   - PHASE_COMPLETED → mark any remaining todos as completed, cleanup
+ */
+
+import type { ExtensionAPI } from "@earendil-works/pi-coding-agent"
+import type { Phase, Step, StepStatus } from "../../ferment/types.js"
+import { applyWriteTodos, getTodosForScope } from "../todos/store.js"
+import type { TodoDraft, TodoItem, TodoStatus } from "../todos/types.js"
+import {
+	FERMENT_EVENTS,
+	type FermentPhaseCompletedPayload,
+	type FermentPhaseStartedPayload,
+	type FermentStepCompletedPayload,
+	type FermentStepFailedPayload,
+} from "./domain-events.js"
+import { getActive } from "./state.js"
+
+// ─── Stable ID tracking ──────────────────────────────────────────────────────
+// Map structure: `${fermentId}:${phaseId}` → Map<stepId | "header", todoId>
+// The phase header gets a synthetic key "header" to distinguish it from steps.
+
+const todoIdMaps = new Map<string, Map<string, number>>()
+
+function getOrCreateIdMap(fermentId: string, phaseId: string): Map<string, number> {
+	const key = `${fermentId}:${phaseId}`
+	let map = todoIdMaps.get(key)
+	if (!map) {
+		map = new Map()
+		todoIdMaps.set(key, map)
+	}
+	return map
+}
+
+function clearIdMap(fermentId: string, phaseId: string): void {
+	const key = `${fermentId}:${phaseId}`
+	todoIdMaps.delete(key)
+}
+
+// ─── Status mapping ──────────────────────────────────────────────────────────
+
+function stepStatusToTodoStatus(stepStatus: StepStatus): TodoStatus {
+	switch (stepStatus) {
+		case "pending":
+			return "pending"
+		case "running":
+			return "in_progress"
+		case "done":
+		case "verified":
+		case "skipped":
+			return "completed"
+		case "failed":
+			return "blocked"
+		default:
+			return "pending"
+	}
+}
+
+// ─── Todo list builders ──────────────────────────────────────────────────────
+
+function buildPhaseTodos(phase: Phase, fermentId: string): TodoDraft[] {
+	const idMap = getOrCreateIdMap(fermentId, phase.id)
+	const todos: TodoDraft[] = []
+
+	// Phase header — use phase.name as the content, status is always in_progress
+	// until the phase is marked complete (handled by PHASE_COMPLETED).
+	const headerContent = `[Phase ${phase.index}] ${phase.name}`
+	const headerId = idMap.get("header")
+	todos.push({
+		id: headerId,
+		content: headerContent,
+		status: "in_progress",
+		activeForm: phase.name,
+	})
+	if (headerId === undefined) {
+		// First write — auto-assign ID 1 for header. TodoStore will assign it
+		// and we'll capture it on the next read cycle. For now, leave undefined.
+		// We rely on the fact that the store assigns IDs sequentially starting
+		// from nextId, so the header gets the first ID and steps get subsequent IDs.
+	}
+
+	// Steps — indented with "↳ " prefix to nest visually under the phase header
+	for (const step of phase.steps) {
+		const stepId = idMap.get(step.id)
+		const status = stepStatusToTodoStatus(step.status)
+		todos.push({
+			id: stepId,
+			content: `↳ ${step.description}`,
+			status,
+		})
+	}
+
+	return todos
+}
+
+function syncTodoIds(fermentId: string, phaseId: string, writtenTodos: TodoItem[]): void {
+	const idMap = getOrCreateIdMap(fermentId, phaseId)
+	// After writing, the store has assigned stable IDs. Re-sync our map
+	// so subsequent updates can reference the same IDs.
+	//
+	// writtenTodos[0] is always the header, writtenTodos[1..] are steps.
+	// We derive the step list from the active ferment to map indices correctly.
+	const ferment = getActive()
+	if (!ferment) return
+	const phase = ferment.phases.find((p) => p.id === phaseId)
+	if (!phase) return
+
+	if (writtenTodos.length > 0) {
+		idMap.set("header", writtenTodos[0].id)
+	}
+
+	for (let i = 0; i < phase.steps.length && i + 1 < writtenTodos.length; i++) {
+		const step = phase.steps[i]
+		const todo = writtenTodos[i + 1]
+		idMap.set(step.id, todo.id)
+	}
+}
+
+// ─── Event handlers ──────────────────────────────────────────────────────────
+
+function handlePhaseStarted(raw: unknown): void {
+	const payload = raw as FermentPhaseStartedPayload
+	const ferment = getActive()
+	if (!ferment || ferment.id !== payload.fermentId) {
+		// Phase started in a different ferment than the currently active one
+		// (unlikely but possible if the runtime state is out of sync). Skip.
+		return
+	}
+
+	const phase = ferment.phases.find((p) => p.id === payload.phaseId)
+	if (!phase) {
+		console.warn(
+			`[todo-sync] PHASE_STARTED for unknown phase ${payload.phaseId} in ferment ${payload.fermentId}. Skipping.`,
+		)
+		return
+	}
+
+	const todos = buildPhaseTodos(phase, ferment.id)
+	const details = applyWriteTodos({ scope: { kind: "ferment", phaseId: payload.phaseId }, todos })
+
+	// Capture the assigned IDs for future updates
+	syncTodoIds(ferment.id, payload.phaseId, details.todos)
+}
+
+function handleStepCompleted(raw: unknown): void {
+	const payload = raw as FermentStepCompletedPayload
+	const ferment = getActive()
+	if (!ferment || ferment.id !== payload.fermentId) return
+
+	const phase = ferment.phases.find((p) => p.id === payload.phaseId)
+	if (!phase) {
+		console.warn(
+			`[todo-sync] STEP_COMPLETED for unknown phase ${payload.phaseId} in ferment ${payload.fermentId}. Skipping.`,
+		)
+		return
+	}
+
+	const step = phase.steps.find((s) => s.id === payload.stepId)
+	if (!step) {
+		console.warn(`[todo-sync] STEP_COMPLETED for unknown step ${payload.stepId} in phase ${payload.phaseId}. Skipping.`)
+		return
+	}
+
+	const idMap = getOrCreateIdMap(ferment.id, payload.phaseId)
+	const stepTodoId = idMap.get(payload.stepId)
+	if (stepTodoId === undefined) {
+		console.warn(`[todo-sync] STEP_COMPLETED for step ${payload.stepId} but no todo ID recorded. Skipping update.`)
+		return
+	}
+
+	const currentTodos = getTodosForScope({ kind: "ferment", phaseId: payload.phaseId })
+	const updated = currentTodos.map((todo) => {
+		if (todo.id === stepTodoId) {
+			return { ...todo, status: "completed" as TodoStatus }
+		}
+		return todo
+	})
+
+	applyWriteTodos({ scope: { kind: "ferment", phaseId: payload.phaseId }, todos: updated })
+}
+
+function handleStepFailed(raw: unknown): void {
+	const payload = raw as FermentStepFailedPayload
+	const ferment = getActive()
+	if (!ferment || ferment.id !== payload.fermentId) return
+
+	const phase = ferment.phases.find((p) => p.id === payload.phaseId)
+	if (!phase) {
+		console.warn(
+			`[todo-sync] STEP_FAILED for unknown phase ${payload.phaseId} in ferment ${payload.fermentId}. Skipping.`,
+		)
+		return
+	}
+
+	const step = phase.steps.find((s) => s.id === payload.stepId)
+	if (!step) {
+		console.warn(`[todo-sync] STEP_FAILED for unknown step ${payload.stepId} in phase ${payload.phaseId}. Skipping.`)
+		return
+	}
+
+	const idMap = getOrCreateIdMap(ferment.id, payload.phaseId)
+	const stepTodoId = idMap.get(payload.stepId)
+	if (stepTodoId === undefined) {
+		console.warn(`[todo-sync] STEP_FAILED for step ${payload.stepId} but no todo ID recorded. Skipping update.`)
+		return
+	}
+
+	const currentTodos = getTodosForScope({ kind: "ferment", phaseId: payload.phaseId })
+	const updated = currentTodos.map((todo) => {
+		if (todo.id === stepTodoId) {
+			return { ...todo, status: "blocked" as TodoStatus }
+		}
+		return todo
+	})
+
+	applyWriteTodos({ scope: { kind: "ferment", phaseId: payload.phaseId }, todos: updated })
+}
+
+function handlePhaseCompleted(raw: unknown): void {
+	const payload = raw as FermentPhaseCompletedPayload
+	const currentTodos = getTodosForScope({ kind: "ferment", phaseId: payload.phaseId })
+	if (currentTodos.length === 0) {
+		// No todos written for this phase (edge case: phase with zero steps that
+		// completed before PHASE_STARTED fired). Nothing to update.
+		clearIdMap(payload.fermentId, payload.phaseId)
+		return
+	}
+
+	// Mark all non-completed, non-blocked todos as completed. This handles steps
+	// that were skipped or otherwise didn't receive an explicit STEP_COMPLETED event.
+	const updated = currentTodos.map((todo) => {
+		if (todo.status !== "completed" && todo.status !== "blocked") {
+			return { ...todo, status: "completed" as TodoStatus }
+		}
+		return todo
+	})
+
+	applyWriteTodos({ scope: { kind: "ferment", phaseId: payload.phaseId }, todos: updated })
+
+	// Cleanup: drop the ID map for this phase since the phase is now complete
+	clearIdMap(payload.fermentId, payload.phaseId)
+}
+
+// ─── Public API ──────────────────────────────────────────────────────────────
+
+/**
+ * Register ferment → todo sync listeners on the given ExtensionAPI.
+ *
+ * Returns an unsubscribe function that removes all listeners and cleans up state.
+ */
+export function registerFermentTodoSync(pi: ExtensionAPI): () => void {
+	const unsubscribes: Array<() => void> = []
+
+	unsubscribes.push(pi.events.on(FERMENT_EVENTS.PHASE_STARTED, handlePhaseStarted))
+	unsubscribes.push(pi.events.on(FERMENT_EVENTS.STEP_COMPLETED, handleStepCompleted))
+	unsubscribes.push(pi.events.on(FERMENT_EVENTS.STEP_FAILED, handleStepFailed))
+	unsubscribes.push(pi.events.on(FERMENT_EVENTS.PHASE_COMPLETED, handlePhaseCompleted))
+
+	return () => {
+		for (const unsub of unsubscribes) {
+			unsub()
+		}
+		// Clear all ID maps on unsubscribe to avoid memory leaks
+		todoIdMaps.clear()
+	}
+}

--- a/src/extensions/ferment/todo-sync.ts
+++ b/src/extensions/ferment/todo-sync.ts
@@ -20,7 +20,7 @@
 import type { ExtensionAPI } from "@earendil-works/pi-coding-agent"
 import type { Phase, StepStatus } from "../../ferment/types.js"
 import { parseTodoScopeKey } from "../todos/scope.js"
-import { applyWriteTodos, getTodoState, getTodosForScope } from "../todos/store.js"
+import { applyWriteTodos, getTodoState, getTodosForScope, registerActiveTodoScopeProvider } from "../todos/store.js"
 import type { TodoDraft, TodoItem, TodoScope, TodoStatus } from "../todos/types.js"
 import {
 	FERMENT_EVENTS,
@@ -223,23 +223,24 @@ function handlePhaseStarted(raw: unknown): void {
 	syncTodoIds(ferment.id, payload.phaseId, details.todos, contentSyncMap)
 }
 
+// ─── Active step tracking for scope provider ────────────────────────────────
+// When a ferment step is running, scope-less todo calls (update_todos, add_todo)
+// automatically target the ferment-step scope instead of global.
+
+let currentRunningStep: { phaseId: string; stepId: string } | undefined
+
+/** Exported for tests only. */
+export function __getCurrentRunningStep(): { phaseId: string; stepId: string } | undefined {
+	return currentRunningStep
+}
+
 function handleStepStarted(raw: unknown): void {
 	const payload = raw as FermentStepStartedPayload
 	const ferment = getActive()
 	if (!ferment || ferment.id !== payload.fermentId) return
 
-	const phase = ferment.phases.find((p) => p.id === payload.phaseId)
-	if (!phase) return
-
-	const step = phase.steps.find((s) => s.id === payload.stepId)
-	if (!step) return
-
-	// Seed the ferment-step scope with the step description so the model
-	// has a starting point to expand into a detailed implementation plan.
-	applyWriteTodos({
-		scope: { kind: "ferment-step", phaseId: payload.phaseId, stepId: payload.stepId },
-		todos: [{ content: step.description, status: "in_progress" }],
-	})
+	// Track the running step so the scope provider can auto-scope todo calls.
+	currentRunningStep = { phaseId: payload.phaseId, stepId: payload.stepId }
 }
 
 function clearStepTodos(phaseId: string, stepId: string): void {
@@ -268,8 +269,9 @@ function handleStepCompleted(raw: unknown): void {
 		return
 	}
 
-	// Clear the step-level implementation todos — they're done.
+	// Clear the step-level implementation todos and stop tracking.
 	clearStepTodos(payload.phaseId, payload.stepId)
+	currentRunningStep = undefined
 
 	const idMap = getOrCreateIdMap(ferment.id, payload.phaseId)
 	const stepTodoId = idMap.get(payload.stepId)
@@ -308,8 +310,9 @@ function handleStepFailed(raw: unknown): void {
 		return
 	}
 
-	// Clear the step-level implementation todos — the step failed.
+	// Clear the step-level implementation todos and stop tracking.
 	clearStepTodos(payload.phaseId, payload.stepId)
+	currentRunningStep = undefined
 
 	const idMap = getOrCreateIdMap(ferment.id, payload.phaseId)
 	const stepTodoId = idMap.get(payload.stepId)
@@ -431,6 +434,18 @@ function handleFermentCompleted(raw: unknown): void {
 export function registerFermentTodoSync(pi: ExtensionAPI): () => void {
 	const unsubscribes: Array<() => void> = []
 
+	// Auto-scope: when a ferment step is running, scope-less todo calls
+	// (update_todos, add_todo without explicit scope) target the active
+	// step's ferment-step scope instead of global.
+	const unregisterScope = registerActiveTodoScopeProvider(() => {
+		if (!currentRunningStep) return undefined
+		return {
+			kind: "ferment-step" as const,
+			phaseId: currentRunningStep.phaseId,
+			stepId: currentRunningStep.stepId,
+		}
+	})
+
 	unsubscribes.push(pi.events.on(FERMENT_EVENTS.PHASE_STARTED, handlePhaseStarted))
 	unsubscribes.push(pi.events.on(FERMENT_EVENTS.STEP_STARTED, handleStepStarted))
 	unsubscribes.push(pi.events.on(FERMENT_EVENTS.STEP_COMPLETED, handleStepCompleted))
@@ -444,6 +459,8 @@ export function registerFermentTodoSync(pi: ExtensionAPI): () => void {
 		for (const unsub of unsubscribes) {
 			unsub()
 		}
+		unregisterScope()
+		currentRunningStep = undefined
 		// Clear all in-memory state on unsubscribe to avoid memory leaks.
 		todoIdMaps.clear()
 		suspendedSnapshots.clear()

--- a/src/extensions/ferment/tools/steps.test.ts
+++ b/src/extensions/ferment/tools/steps.test.ts
@@ -477,7 +477,7 @@ describe("suggestWorkerLimits", () => {
 })
 
 describe("start_ferment_step plan-first preamble", () => {
-	it("contains both inline-plan and update_todos instructions", async () => {
+	it("contains plan-first preamble with verification and cleanup hints", async () => {
 		const h = createHarness()
 		const services = createServices()
 
@@ -489,8 +489,9 @@ describe("start_ferment_step plan-first preamble", () => {
 		)
 
 		const text = okText(result)
-		expect(text).toContain("inline plan")
-		expect(text).toContain("update_todos")
+		expect(text).toContain("Plan first")
+		expect(text).toContain("verification sub-task")
+		expect(text).toContain("cleanup sub-task")
 	})
 
 	it.each([1, 2])("preamble appears on call %i without completion", async (callNumber) => {
@@ -510,7 +511,7 @@ describe("start_ferment_step plan-first preamble", () => {
 
 		const text = okText(result)
 		expect(text).toContain("Plan first")
-		expect(text).toContain("update_todos")
+		expect(text).toContain("verification sub-task")
 	})
 
 	it("instructs orchestrator to embed plan in worker Agent prompt", async () => {
@@ -530,7 +531,47 @@ describe("start_ferment_step plan-first preamble", () => {
 		expect(text).toContain("Agent")
 	})
 
-	it("stuck-loop guard triggers on 3rd consecutive start — no plan-first preamble", async () => {
+	it("includes prior step summaries in the plan-first preamble", async () => {
+		const h = createHarness()
+		const services = createServices()
+
+		// Start and complete step 1 with a summary
+		await startStep(
+			h.runtime,
+			{ ferment_id: h.fermentId, phase_id: "phase-1", step_id: "step-1" },
+			{ pi: h.pi },
+			services,
+		)
+		const completeResult = await completeStep(
+			h.runtime,
+			{
+				ferment_id: h.fermentId,
+				phase_id: "phase-1",
+				step_id: "step-1",
+				summary: "Installed dependencies and verified config",
+				gates: passingStepGates(),
+			},
+			{ pi: h.pi },
+			services,
+		)
+		// Verify step-1 completed successfully
+		expect((completeResult as { isError?: boolean }).isError).toBeFalsy()
+		expect(h.storage.get(h.fermentId)?.phases[0].steps[0]?.status).toBe("done")
+
+		// Now start step 2 — should include prior step context
+		const result = await startStep(
+			h.runtime,
+			{ ferment_id: h.fermentId, phase_id: "phase-1", step_id: "step-2" },
+			{ pi: h.pi },
+			services,
+		)
+
+		const text = okText(result)
+		expect(text).toContain("Prior steps")
+		expect(text).toContain("First step")
+	})
+
+	it("stuck-loop guard triggers on 3rd consecutive start \u2014 no plan-first preamble", async () => {
 		const h = createHarness()
 		const services = createServices()
 
@@ -547,7 +588,7 @@ describe("start_ferment_step plan-first preamble", () => {
 		const text = errText(result)
 		expect(text).toContain("Stuck loop detected")
 		expect(text).not.toContain("Plan first")
-		expect(text).not.toContain("update_todos")
+		expect(text).not.toContain("verification sub-task")
 		expect(h.storage.get(h.fermentId)?.phases[0].steps[0].status).toBe("pending")
 	})
 })

--- a/src/extensions/ferment/tools/steps.test.ts
+++ b/src/extensions/ferment/tools/steps.test.ts
@@ -475,3 +475,79 @@ describe("suggestWorkerLimits", () => {
 		expect(lower.maxTurns).toBe(80)
 	})
 })
+
+describe("start_ferment_step plan-first preamble", () => {
+	it("contains both inline-plan and update_todos instructions", async () => {
+		const h = createHarness()
+		const services = createServices()
+
+		const result = await startStep(
+			h.runtime,
+			{ ferment_id: h.fermentId, phase_id: "phase-1", step_id: "step-1" },
+			{ pi: h.pi },
+			services,
+		)
+
+		const text = okText(result)
+		expect(text).toContain("inline plan")
+		expect(text).toContain("update_todos")
+	})
+
+	it.each([1, 2])("preamble appears on call %i without completion", async (callNumber) => {
+		const h = createHarness()
+		const services = createServices()
+
+		for (let i = 0; i < callNumber - 1; i++) {
+			h.runtime.bumpStepStart(h.fermentId, "phase-1", "step-1")
+		}
+
+		const result = await startStep(
+			h.runtime,
+			{ ferment_id: h.fermentId, phase_id: "phase-1", step_id: "step-1" },
+			{ pi: h.pi },
+			services,
+		)
+
+		const text = okText(result)
+		expect(text).toContain("Plan first")
+		expect(text).toContain("update_todos")
+	})
+
+	it("instructs orchestrator to embed plan in worker Agent prompt", async () => {
+		const h = createHarness()
+		const services = createServices()
+
+		const result = await startStep(
+			h.runtime,
+			{ ferment_id: h.fermentId, phase_id: "phase-1", step_id: "step-1" },
+			{ pi: h.pi },
+			services,
+		)
+
+		const text = okText(result)
+		expect(text).toContain("Embed")
+		expect(text).toContain("plan")
+		expect(text).toContain("Agent")
+	})
+
+	it("stuck-loop guard triggers on 3rd consecutive start — no plan-first preamble", async () => {
+		const h = createHarness()
+		const services = createServices()
+
+		h.runtime.bumpStepStart(h.fermentId, "phase-1", "step-1")
+		h.runtime.bumpStepStart(h.fermentId, "phase-1", "step-1")
+
+		const result = await startStep(
+			h.runtime,
+			{ ferment_id: h.fermentId, phase_id: "phase-1", step_id: "step-1" },
+			{ pi: h.pi },
+			services,
+		)
+
+		const text = errText(result)
+		expect(text).toContain("Stuck loop detected")
+		expect(text).not.toContain("Plan first")
+		expect(text).not.toContain("update_todos")
+		expect(h.storage.get(h.fermentId)?.phases[0].steps[0].status).toBe("pending")
+	})
+})

--- a/src/extensions/ferment/tools/steps.ts
+++ b/src/extensions/ferment/tools/steps.ts
@@ -1,7 +1,7 @@
 /**
  * Step tools: start_ferment_step, complete_ferment_step, verify_ferment_step, skip_ferment_step, fail_ferment_step.
  *
- * complete_ferment_step is the largest — it auto-runs the verification command (with
+ * complete_ferment_step is the largest - it auto-runs the verification command (with
  * a 60s timeout), routes non-zero exits through the judge for pass/retry/fail
  * classification, then grades the step.
  */
@@ -141,13 +141,13 @@ async function runVerificationCommand({
  *
  * The returned values are *suggestions* embedded in the start_step tool result.
  * The orchestrator is expected to adjust them based on its judgment of the
- * actual work involved — these defaults prevent runaway workers without
+ * actual work involved - these defaults prevent runaway workers without
  * requiring the model to reason about limits from scratch each time.
  *
  * Tiers:
- *  - heavy: compilation, multi-file rewrites, iterative debugging — 80 turns / 900s
- *  - standard: typical implementation steps — 50 turns / 600s
- *  - light: single-file edits, config changes, research — 25 turns / 300s
+ *  - heavy: compilation, multi-file rewrites, iterative debugging - 80 turns / 900s
+ *  - standard: typical implementation steps - 50 turns / 600s
+ *  - light: single-file edits, config changes, research - 25 turns / 300s
  */
 export function suggestWorkerLimits(
 	description: string,
@@ -255,7 +255,7 @@ Do NOT call start_ferment_step again without user input.`,
 	if (!outcome.ok) {
 		if (outcome.error.code === "CONCURRENT_NON_PARALLEL_STEP") {
 			return toolErrWithNextAction(
-				`Cannot start step ${step.index} — step ${outcome.error.runningStepIndex} ("${outcome.error.runningDescription}") is already running and is not parallel-safe. Complete or skip it first.`,
+				`Cannot start step ${step.index} - step ${outcome.error.runningStepIndex} ("${outcome.error.runningDescription}") is already running and is not parallel-safe. Complete or skip it first.`,
 				f,
 			)
 		}
@@ -271,7 +271,7 @@ Do NOT call start_ferment_step again without user input.`,
 	const prevStep = freshPhase?.steps.find((st) => st.index === step.index - 1)
 	const lowGradeCaution =
 		prevStep?.grade && ["C", "D", "F"].includes(prevStep.grade.grade)
-			? `\n\n⚠️  Previous step (${prevStep.index}: "${prevStep.description}") received grade ${prevStep.grade.grade}: ${prevStep.grade.rationale}. Apply extra scrutiny to this step — verify edge cases, error handling, and completeness before reporting done.`
+			? `\n\n⚠️  Previous step (${prevStep.index}: "${prevStep.description}") received grade ${prevStep.grade.grade}: ${prevStep.grade.rationale}. Apply extra scrutiny to this step - verify edge cases, error handling, and completeness before reporting done.`
 			: ""
 
 	const parallelSiblings =
@@ -289,7 +289,7 @@ Do NOT call start_ferment_step again without user input.`,
 
 	const parallelNote =
 		parallelSiblings.length > 0
-			? `\nparallel_siblings: ${JSON.stringify(parallelSiblings)}\n\nThese steps are independent — call start_ferment_step for each one now and launch their Agents concurrently. Do not wait for one to finish before starting the next.`
+			? `\nparallel_siblings: ${JSON.stringify(parallelSiblings)}\n\nThese steps are independent - call start_ferment_step for each one now and launch their Agents concurrently. Do not wait for one to finish before starting the next.`
 			: ""
 
 	const workerContext =
@@ -297,14 +297,26 @@ Do NOT call start_ferment_step again without user input.`,
 	const contextBlock = workerContext ? `\n\nWorker context (pass to subagent verbatim):\n${workerContext}` : ""
 
 	const workerLimits = suggestWorkerLimits(step.description, step.verification?.command)
-	const limitsHint = `\n\nSuggested worker limits (set both on the Agent call): max_turns=${workerLimits.maxTurns}, max_duration=${workerLimits.maxDuration}s. Adjust up for more complex work, down for simpler. When the worker exhausts its budget, call complete_ferment_step with whatever it produced and spawn a scoped follow-up for remaining work — do NOT raise the budget and retry the same broad task.`
+	const limitsHint = `\n\nSuggested worker limits (set both on the Agent call): max_turns=${workerLimits.maxTurns}, max_duration=${workerLimits.maxDuration}s. Adjust up for more complex work, down for simpler. When the worker exhausts its budget, call complete_ferment_step with whatever it produced and spawn a scoped follow-up for remaining work - do NOT raise the budget and retry the same broad task.`
 
-	const stepScope = JSON.stringify({ kind: "ferment-step", phaseId: phase.id, stepId: step.id })
+	// Build a condensed summary of prior steps so the orchestrator's planning
+	// is informed by what previous steps completed.
+	const completedPriorSteps = (freshPhase?.steps ?? [])
+		.filter((s) => s.index < step.index && (s.status === "done" || s.status === "verified" || s.status === "skipped"))
+		.map((s) => {
+			const tag = s.status === "skipped" ? `⊘06${s.index}` : `✓${s.index}`
+			const summary = (s.summary ?? "").trim()
+			const detail = summary.length > 120 ? `${summary.slice(0, 120)}…` : summary
+			return detail ? `${tag} "${s.description}" — ${detail}` : `${tag} "${s.description}"`
+		})
+	const priorContext =
+		completedPriorSteps.length > 0 ? `\n• Prior steps: ${completedPriorSteps.join("; ")}. Build on their output.` : ""
+
 	const planFirstPreamble = `📋 Plan first (every start of this step):
-• Write a brief 2-4 bullet inline plan for this step's work.
-• Call update_todos with scope ${stepScope} to record each plan bullet as a scoped todo item for this step.
-• Embed the plan in the worker Agent's prompt at dispatch time.
-• After calling complete_ferment_step, call update_todos with scope ${stepScope} and mark all todos completed.`
+• Write a brief 2-4 bullet inline plan for this step’s work.
+• Include a verification sub-task that checks exact expected output, not just substring grep. Match the verify command’s precision.
+• If the step compiles or builds artifacts, include a cleanup sub-task to remove intermediate files from output directories.
+• Embed the plan in the worker Agent’s prompt at dispatch time.${priorContext}`
 
 	return toolOk(
 		withNextActionHint(
@@ -334,18 +346,18 @@ export async function completeStep(
 	if (fsmError) return toolErrWithNextAction(fsmError, f)
 
 	// Gate validation runs BEFORE any state mutation. Step-level flags don't
-	// feed the phase retry/escalation pipeline — they just refuse this single
+	// feed the phase retry/escalation pipeline - they just refuse this single
 	// call, and the agent has to fix the underlying issue and re-call.
 	const gateError = validateGatesOrErr(params.gates, {
 		turn: "complete_ferment_step",
 		flagPolicy: "block-on-flag",
 		renderFlagError: (count, lines) =>
-			`Step ${step.index}: "${step.description}" cannot complete — agent self-flagged on ${count} step gate(s):\n\n${lines}\n\nResolve the underlying issue and re-call complete_ferment_step with verdicts of 'pass' (or 'omitted' with rationale if a gate truly does not apply).`,
+			`Step ${step.index}: "${step.description}" cannot complete - agent self-flagged on ${count} step gate(s):\n\n${lines}\n\nResolve the underlying issue and re-call complete_ferment_step with verdicts of 'pass' (or 'omitted' with rationale if a gate truly does not apply).`,
 	})
 	if (gateError) return gateError
 
 	if (!step.verification) {
-		// No verification command — gate verdicts are the only signal. Trust
+		// No verification command - gate verdicts are the only signal. Trust
 		// them and advance. Phase-level F1 will catch the case where the
 		// whole phase was unverified.
 		const completeOutcome = applyAndPersist(params.ferment_id, {
@@ -409,14 +421,14 @@ export async function completeStep(
 			completedAt: runtime.nowIso(),
 		})
 		services.onStepCompleted(runtime)
-		sendStepBreadcrumb(pi, `Step ${step.index} ✓ verified — ${step.description}`)
+		sendStepBreadcrumb(pi, `Step ${step.index} ✓ verified - ${step.description}`)
 		return toolOk(
 			withNextActionHint(`Step ${step.index}: "${step.description}" done and verified ✓`, verifyOutcome.ferment),
 		)
 	}
 
 	// Non-zero verify exit. judgeStepVerification is tactical (pass/retry/fail
-	// classification of a failed command), not grading — it stays.
+	// classification of a failed command), not grading - it stays.
 	const judgeVerdict = await services.judgeStepVerification(
 		step.description,
 		step.verification.command,
@@ -455,7 +467,7 @@ export async function completeStep(
 	})
 	if (!failOutcome.ok) return failedToolResult(failOutcome.error, f)
 
-	sendStepBreadcrumb(pi, `Step ${step.index} ✗ failed verification — ${judgeVerdict.reason}`, "warning")
+	sendStepBreadcrumb(pi, `Step ${step.index} ✗ failed verification - ${judgeVerdict.reason}`, "warning")
 
 	// D19: surface a recovery dropdown so the user picks an action explicitly
 	// instead of leaving the planner guessing.
@@ -478,7 +490,7 @@ export async function completeStep(
 			if (!retryOut.ok) return failedToolResult(retryOut.error)
 			runtime.clearStepStart(f.id, phase.id, step.id)
 			return toolOk(
-				`Step ${step.index} reset to running at user request. Retry the work — spawn a worker and call complete_step when done.`,
+				`Step ${step.index} reset to running at user request. Retry the work - spawn a worker and call complete_step when done.`,
 			)
 		}
 
@@ -533,13 +545,13 @@ export async function completeStep(
 		// already in failed state from the fail_step above; preserve the phase
 		// and let the planner decide the next move.
 		return toolOk(
-			`Step ${step.index} remains failed. User dismissed the recovery dropdown without choosing an action — phase preserved.`,
+			`Step ${step.index} remains failed. User dismissed the recovery dropdown without choosing an action - phase preserved.`,
 		)
 	}
 
 	if (judgeVerdict.verdict === "retry") {
 		return toolErr(
-			`Step ${step.index} verification failed — retry suggested.\nExit: ${exitCode}\nJudge: ${judgeVerdict.reason}\nstdout: ${stdout.slice(0, 500)}\nstderr: ${stderr.slice(0, 500)}`,
+			`Step ${step.index} verification failed - retry suggested.\nExit: ${exitCode}\nJudge: ${judgeVerdict.reason}\nstdout: ${stdout.slice(0, 500)}\nstderr: ${stderr.slice(0, 500)}`,
 		)
 	}
 	return toolErr(
@@ -567,7 +579,7 @@ export function registerStepTools(pi: ExtensionAPI, runtime: FermentRuntime = de
 	pi.registerTool({
 		name: FERMENT_TOOLS.COMPLETE_STEP,
 		label: "Complete Step",
-		description: `Mark step as done. If the step has a verification command it runs automatically — no need to call verify_ferment_step separately. You must produce verdicts for the three step-scope gates below. A "flag" verdict blocks step completion.
+		description: `Mark step as done. If the step has a verification command it runs automatically - no need to call verify_ferment_step separately. You must produce verdicts for the three step-scope gates below. A "flag" verdict blocks step completion.
 
 ${renderGateGuidance("complete_ferment_step")}`,
 		parameters: CompleteStepParams,

--- a/src/extensions/ferment/tools/steps.ts
+++ b/src/extensions/ferment/tools/steps.ts
@@ -297,14 +297,18 @@ Do NOT call start_ferment_step again without user input.`,
 	const contextBlock = workerContext ? `\n\nWorker context (pass to subagent verbatim):\n${workerContext}` : ""
 
 	const workerLimits = suggestWorkerLimits(step.description, step.verification?.command)
-	const limitsHint = `\n\nSuggested worker limits (set both on the Agent call): max_turns=${workerLimits.maxTurns}, max_duration=${workerLimits.maxDuration}s. Adjust up for more complex work, down for simpler. When the worker exhausts its budget, call complete_ferment_step with whatever it produced and spawn a scoped follow-up for remaining work - do NOT raise the budget and retry the same broad task.`
+	// Guidance only — don't quote exact numbers. Models interpret max_turns/max_duration
+	// literally and either exceed them trying to "finish" or hallucinate extra bullets to
+	// justify a different count. The exact values are still in the tool schema.
+	const limitsHint =
+		"\n\nSet sensible worker limits on the Agent call (use max_turns and max_duration, tuned to step complexity). When the worker exhausts its budget, call complete_ferment_step with whatever it produced and spawn a scoped follow-up for remaining work - do NOT raise the budget and retry the same broad task."
 
 	// Build a condensed summary of prior steps so the orchestrator's planning
 	// is informed by what previous steps completed.
 	const completedPriorSteps = (freshPhase?.steps ?? [])
 		.filter((s) => s.index < step.index && (s.status === "done" || s.status === "verified" || s.status === "skipped"))
 		.map((s) => {
-			const tag = s.status === "skipped" ? `⊘06${s.index}` : `✓${s.index}`
+			const tag = s.status === "skipped" ? `⊘${s.index}` : `✓${s.index}`
 			const summary = (s.summary ?? "").trim()
 			const detail = summary.length > 120 ? `${summary.slice(0, 120)}…` : summary
 			return detail ? `${tag} "${s.description}" — ${detail}` : `${tag} "${s.description}"`

--- a/src/extensions/ferment/tools/steps.ts
+++ b/src/extensions/ferment/tools/steps.ts
@@ -299,9 +299,16 @@ Do NOT call start_ferment_step again without user input.`,
 	const workerLimits = suggestWorkerLimits(step.description, step.verification?.command)
 	const limitsHint = `\n\nSuggested worker limits (set both on the Agent call): max_turns=${workerLimits.maxTurns}, max_duration=${workerLimits.maxDuration}s. Adjust up for more complex work, down for simpler. When the worker exhausts its budget, call complete_ferment_step with whatever it produced and spawn a scoped follow-up for remaining work — do NOT raise the budget and retry the same broad task.`
 
+	const stepScope = JSON.stringify({ kind: "ferment-step", phaseId: phase.id, stepId: step.id })
+	const planFirstPreamble = `📋 Plan first (every start of this step):
+• Write a brief 2-4 bullet inline plan for this step's work.
+• Call update_todos with scope ${stepScope} to record each plan bullet as a scoped todo item for this step.
+• Embed the plan in the worker Agent's prompt at dispatch time.
+• After calling complete_ferment_step, call update_todos with scope ${stepScope} and mark all todos completed.`
+
 	return toolOk(
 		withNextActionHint(
-			`Step ${step.index}: "${step.description}" started. Spawn a subagent with the persona that matches this step's intent. When it returns, call complete_ferment_step with its summary.${lowGradeCaution}${parallelNote}${limitsHint}${contextBlock}`,
+			`${planFirstPreamble}\n\nStep ${step.index}: "${step.description}" started. Spawn a subagent with the persona that matches this step's intent. When it returns, call complete_ferment_step with its summary.${lowGradeCaution}${parallelNote}${limitsHint}${contextBlock}`,
 			outcome.ferment,
 		),
 	)

--- a/src/extensions/ferment/worker-prompt.test.ts
+++ b/src/extensions/ferment/worker-prompt.test.ts
@@ -1,5 +1,6 @@
-import { describe, expect, it } from "vitest"
+import { afterEach, beforeEach, describe, expect, it } from "vitest"
 import type { Decision, Ferment, Memory, Phase, Step } from "../../ferment/types.js"
+import { __resetTodoStore, applyWriteTodos } from "../todos/store.js"
 import { buildWorkerContext } from "./worker-prompt.js"
 
 function makeFerment(overrides: Partial<Ferment> = {}): Ferment {
@@ -230,5 +231,43 @@ describe("buildWorkerContext", () => {
 
 		const ctx = buildWorkerContext(f, phase, phase.steps[0], { includeDecisions: false })
 		expect(ctx).not.toContain("Decisions:")
+	})
+})
+
+describe("step todo forwarding", () => {
+	beforeEach(() => {
+		__resetTodoStore()
+	})
+
+	afterEach(() => {
+		__resetTodoStore()
+	})
+
+	it("includes step-scoped todos in the worker context as a Plan line", () => {
+		const phase = makePhase({ id: "phase-1", steps: [makeStep({ id: "step-1" })] })
+		const f = makeFerment({ phases: [phase] })
+
+		applyWriteTodos({
+			scope: { kind: "ferment-step", phaseId: "phase-1", stepId: "step-1" },
+			todos: [
+				{ content: "Install dependencies", status: "completed" },
+				{ content: "Write main module", status: "in_progress" },
+				{ content: "Run tests", status: "pending" },
+			],
+		})
+
+		const ctx = buildWorkerContext(f, phase, phase.steps[0])
+		expect(ctx).toContain("Plan:")
+		expect(ctx).toContain("\u2713 Install dependencies")
+		expect(ctx).toContain("\u25b6 Write main module")
+		expect(ctx).toContain("\u25cb Run tests")
+	})
+
+	it("omits Plan line when no step todos exist", () => {
+		const phase = makePhase({ steps: [makeStep()] })
+		const f = makeFerment({ phases: [phase] })
+
+		const ctx = buildWorkerContext(f, phase, phase.steps[0])
+		expect(ctx).not.toContain("Plan:")
 	})
 })

--- a/src/extensions/ferment/worker-prompt.ts
+++ b/src/extensions/ferment/worker-prompt.ts
@@ -11,6 +11,7 @@
  */
 
 import type { Ferment, Phase, Step } from "../../ferment/types.js"
+import { getTodosForScope } from "../todos/store.js"
 
 const PRIOR_STEP_SUMMARY_MAX_CHARS = 240
 const MAX_DECISIONS = 5
@@ -67,6 +68,17 @@ export function buildWorkerContext(ferment: Ferment, phase: Phase, step: Step, o
 	if (includeMemories && ferment.memories.length > 0) {
 		const recent = ferment.memories.slice(-MAX_MEMORIES)
 		lines.push(`Memories: ${recent.map((m) => `[${m.category}] ${m.content}`).join("; ")}`)
+	}
+
+	// Include the orchestrator's step-level implementation plan so the worker
+	// knows what sub-tasks were planned and can track progress against them.
+	const stepTodos = getTodosForScope({ kind: "ferment-step", phaseId: phase.id, stepId: step.id })
+	if (stepTodos.length > 0) {
+		const planItems = stepTodos.map((t) => {
+			const glyph = t.status === "completed" ? "\u2713" : t.status === "in_progress" ? "\u25b6" : "\u25cb"
+			return `${glyph} ${t.content}`
+		})
+		lines.push(`Plan: ${planItems.join("; ")}`)
 	}
 
 	return lines.join("\n")

--- a/src/extensions/prompt-construction/prompt-enrichment.ts
+++ b/src/extensions/prompt-construction/prompt-enrichment.ts
@@ -40,6 +40,7 @@ import {
 	getConfiguredNativeSkillNames,
 	getConfiguredSkillResourcePaths,
 } from "../claude-code-skills/definition.js"
+import { bumpStallCounter } from "../ferment/todo-sync.js"
 import {
 	getProcessMultiModelEnabled,
 	setProcessMultiModelEnabled,
@@ -382,6 +383,10 @@ export default function (skillPaths: string[]) {
 				if (event.message.role !== "assistant") return
 				// Safe after the role guard: AgentMessage with role "assistant" is AssistantMessage.
 				const assistantMsg = event.message as AssistantMessage
+
+				// Track stall: increment counter each turn so the headless prompt
+				// block can detect when the orchestrator hasn't updated step todos.
+				bumpStallCounter()
 
 				// Mark each delegation tool call so the continuation nudge stays
 				// suppressed until all delegated-agent results have been received.

--- a/src/extensions/todos/index.test.ts
+++ b/src/extensions/todos/index.test.ts
@@ -16,6 +16,7 @@ function createTodosHarness() {
 		registerShortcut: vi.fn(),
 		appendEntry: vi.fn(),
 		sendMessage: vi.fn(),
+		getActiveTools: vi.fn(() => [...TODO_TOOL_NAMES]),
 		on: vi.fn((event: string, handler: ExtensionHandler) => {
 			const list = handlers.get(event) ?? []
 			list.push(handler)

--- a/src/extensions/todos/index.ts
+++ b/src/extensions/todos/index.ts
@@ -2,7 +2,12 @@ import type { ExtensionAPI, ExtensionContext, SessionEntry } from "@earendil-wor
 import { isAgentWorker } from "../agent-worker-context.js"
 import { registerTodosCommand } from "./command.js"
 import { TODO_CUSTOM_ENTRY_TYPE } from "./constants.js"
-import { appendTodoPromptBlockIfMissing, registerTodoPromptBlock } from "./prompt-block.js"
+import {
+	appendTodoPromptBlockIfMissing,
+	registerTodoPromptBlock,
+	registerTodoStateBlock,
+	setCurrentSessionHasUI,
+} from "./prompt-block.js"
 import { getTodosForScope, restoreTodoStoreFromDetails, subscribeTodoStore } from "./store.js"
 import { TODO_TOOL_NAMES, registerTodosTool } from "./tool.js"
 import { TODO_TOOL_RESULT_SCHEMA_VERSION, type WriteTodosDetails } from "./types.js"
@@ -103,6 +108,10 @@ export default function todosExtension(pi: ExtensionAPI): void {
 
 	registerTodosCommand(pi)
 	registerTodoShortcut(pi)
+	// Headless (one-shot) runs have no widget; the todo-state prompt block
+	// renders the same content as markdown so the orchestrator agent can see
+	// it. Self-gates on currentSessionHasUI inside the block's render fn.
+	registerTodoStateBlock(pi)
 
 	const replayAndSync = (ctx: ExtensionContext) => {
 		latestCtx = ctx
@@ -114,6 +123,7 @@ export default function todosExtension(pi: ExtensionAPI): void {
 		cleanupSteeredTodosKey = undefined
 		resetTodoWidgetState()
 		ensureTodoWidget(ctx)
+		setCurrentSessionHasUI(ctx.hasUI)
 		unsubscribeTodoStore?.()
 		unsubscribeTodoStore = subscribeTodoStore(() => {
 			if (!latestCtx?.hasUI) return
@@ -134,6 +144,7 @@ export default function todosExtension(pi: ExtensionAPI): void {
 		unsubscribeTodoStore?.()
 		unsubscribeTodoStore = undefined
 		latestCtx = undefined
+		setCurrentSessionHasUI(true)
 		disposeTodoWidget(ctx)
 	})
 }

--- a/src/extensions/todos/index.ts
+++ b/src/extensions/todos/index.ts
@@ -41,6 +41,7 @@ function isWriteTodosDetails(value: unknown): value is WriteTodosDetails {
 
 const TODO_REPLAY_TOOL_NAME_SET = new Set<string>([...TODO_TOOL_NAMES, "write_todos"])
 
+
 function getWriteTodosDetails(entry: SessionEntry): WriteTodosDetails | undefined {
 	if (entry.type === "custom" && entry.customType === TODO_CUSTOM_ENTRY_TYPE) {
 		return isWriteTodosDetails(entry.data) ? entry.data : undefined
@@ -75,6 +76,7 @@ export default function todosExtension(pi: ExtensionAPI): void {
 	})
 
 	if (isAgentWorker()) return
+
 
 	let latestCtx: ExtensionContext | undefined
 	let unsubscribeTodoStore: (() => void) | undefined

--- a/src/extensions/todos/index.ts
+++ b/src/extensions/todos/index.ts
@@ -46,7 +46,6 @@ function isWriteTodosDetails(value: unknown): value is WriteTodosDetails {
 
 const TODO_REPLAY_TOOL_NAME_SET = new Set<string>([...TODO_TOOL_NAMES, "write_todos"])
 
-
 function getWriteTodosDetails(entry: SessionEntry): WriteTodosDetails | undefined {
 	if (entry.type === "custom" && entry.customType === TODO_CUSTOM_ENTRY_TYPE) {
 		return isWriteTodosDetails(entry.data) ? entry.data : undefined
@@ -81,7 +80,6 @@ export default function todosExtension(pi: ExtensionAPI): void {
 	})
 
 	if (isAgentWorker()) return
-
 
 	let latestCtx: ExtensionContext | undefined
 	let unsubscribeTodoStore: (() => void) | undefined

--- a/src/extensions/todos/prompt-block.test.ts
+++ b/src/extensions/todos/prompt-block.test.ts
@@ -1,10 +1,17 @@
 import { beforeEach, describe, expect, it } from "vitest"
-import { __test_renderTodoPromptBlock, appendTodoPromptBlockIfMissing } from "./prompt-block.js"
+import {
+	__test_renderTodoPromptBlock,
+	__test_renderTodoStateMarkdown,
+	appendTodoPromptBlockIfMissing,
+	currentSessionHasUI,
+	setCurrentSessionHasUI,
+} from "./prompt-block.js"
 import { __resetTodoStore, applyWriteTodos } from "./store.js"
 
 describe("todo prompt block", () => {
 	beforeEach(() => {
 		__resetTodoStore()
+		setCurrentSessionHasUI(true)
 	})
 
 	it("renders guidance without a current list", () => {
@@ -40,5 +47,136 @@ describe("todo prompt block", () => {
 		expect(prompt).toContain("## Tools")
 		expect(prompt).toContain("## Todos")
 		expect(appendTodoPromptBlockIfMissing(prompt ?? "")).toBeUndefined()
+	})
+})
+
+describe("todo state prompt block (headless)", () => {
+	beforeEach(() => {
+		__resetTodoStore()
+		setCurrentSessionHasUI(false) // simulate headless session
+	})
+
+	it("returns undefined when the store is empty", () => {
+		expect(__test_renderTodoStateMarkdown()).toBeUndefined()
+	})
+
+	it("returns undefined when only the global scope is empty", () => {
+		applyWriteTodos({ scope: { kind: "global" }, todos: [] })
+		expect(__test_renderTodoStateMarkdown()).toBeUndefined()
+	})
+
+	it("renders global todos with the correct status glyphs", () => {
+		applyWriteTodos({
+			scope: { kind: "global" },
+			todos: [
+				{ content: "pending one", status: "pending" },
+				{ content: "working one", status: "in_progress" },
+				{ content: "blocked one", status: "blocked" },
+				{ content: "done one", status: "completed" },
+			],
+		})
+
+		const md = __test_renderTodoStateMarkdown()
+		expect(md).toBeDefined()
+		expect(md).toContain("## Current Todos")
+		expect(md).toContain("**Global**")
+		expect(md).toContain("- [ ] pending one")
+		expect(md).toContain("- [~] working one")
+		expect(md).toContain("- [!] blocked one")
+		expect(md).toContain("- [x] done one")
+	})
+
+	it("renders a ferment phase with header and indented steps", () => {
+		applyWriteTodos({
+			scope: { kind: "ferment", phaseId: "phase-1" },
+			todos: [
+				{ content: "[Phase 1] Test Phase", status: "in_progress", activeForm: "Test Phase" },
+				{ content: "↳ Step 1", status: "completed" },
+				{ content: "↳ Step 2", status: "in_progress" },
+				{ content: "↳ Step 3", status: "pending" },
+			],
+		})
+
+		const md = __test_renderTodoStateMarkdown()
+		expect(md).toContain("**[Phase 1] Test Phase**")
+		expect(md).toContain("- [x] ↳ Step 1")
+		expect(md).toContain("- [~] ↳ Step 2")
+		expect(md).toContain("- [ ] ↳ Step 3")
+	})
+
+	it("renders ferment-step scopes with a header line per step", () => {
+		applyWriteTodos({
+			scope: { kind: "ferment-step", phaseId: "phase-1", stepId: "step-2" },
+			todos: [{ content: "agent-written plan bullet", status: "in_progress" }],
+		})
+
+		const md = __test_renderTodoStateMarkdown()
+		expect(md).toContain("**Step phase-1/step-2**")
+		expect(md).toContain("- [~] agent-written plan bullet")
+	})
+
+	it("groups global + multiple ferment phases together", () => {
+		applyWriteTodos({
+			scope: { kind: "global" },
+			todos: [{ content: "global thing", status: "pending" }],
+		})
+		applyWriteTodos({
+			scope: { kind: "ferment", phaseId: "phase-1" },
+			todos: [
+				{ content: "[Phase 1] First", status: "in_progress", activeForm: "First" },
+				{ content: "↳ step", status: "pending" },
+			],
+		})
+		applyWriteTodos({
+			scope: { kind: "ferment", phaseId: "phase-2" },
+			todos: [
+				{ content: "[Phase 2] Second", status: "in_progress", activeForm: "Second" },
+				{ content: "↳ other step", status: "completed" },
+			],
+		})
+
+		const md = __test_renderTodoStateMarkdown()
+		// Sections in order: Global, Phase 1, Phase 2
+		const globalIdx = md?.indexOf("**Global**") ?? -1
+		const phase1Idx = md?.indexOf("**[Phase 1] First**") ?? -1
+		const phase2Idx = md?.indexOf("**[Phase 2] Second**") ?? -1
+		expect(globalIdx).toBeGreaterThanOrEqual(0)
+		expect(phase1Idx).toBeGreaterThan(globalIdx)
+		expect(phase2Idx).toBeGreaterThan(phase1Idx)
+	})
+
+	it("reflects subsequent writes (renders fresh state each call)", () => {
+		expect(__test_renderTodoStateMarkdown()).toBeUndefined()
+
+		applyWriteTodos({
+			scope: { kind: "global" },
+			todos: [{ content: "first", status: "pending" }],
+		})
+		expect(__test_renderTodoStateMarkdown()).toContain("- [ ] first")
+
+		applyWriteTodos({
+			scope: { kind: "global" },
+			todos: [{ content: "first", status: "completed" }],
+		})
+		expect(__test_renderTodoStateMarkdown()).toContain("- [x] first")
+	})
+})
+
+describe("todo state block gating", () => {
+	beforeEach(() => {
+		setCurrentSessionHasUI(true)
+	})
+
+	it("reflects explicit setCurrentSessionHasUI calls", () => {
+		setCurrentSessionHasUI(false)
+		expect(currentSessionHasUI).toBe(false)
+		setCurrentSessionHasUI(true)
+		expect(currentSessionHasUI).toBe(true)
+	})
+
+	it("setCurrentSessionHasUI persists across reads until the next set", () => {
+		setCurrentSessionHasUI(false)
+		expect(currentSessionHasUI).toBe(false)
+		expect(currentSessionHasUI).toBe(false) // repeated reads are stable
 	})
 })

--- a/src/extensions/todos/prompt-block.test.ts
+++ b/src/extensions/todos/prompt-block.test.ts
@@ -1,4 +1,6 @@
-import { beforeEach, describe, expect, it } from "vitest"
+import { afterEach, beforeEach, describe, expect, it } from "vitest"
+import type { Ferment } from "../../ferment/types.js"
+import { setActive } from "../ferment/state.js"
 import {
 	__test_renderTodoPromptBlock,
 	__test_renderTodoStateMarkdown,
@@ -178,5 +180,126 @@ describe("todo state block gating", () => {
 		setCurrentSessionHasUI(false)
 		expect(currentSessionHasUI).toBe(false)
 		expect(currentSessionHasUI).toBe(false) // repeated reads are stable
+	})
+})
+
+describe("empty-plan nudge for ferment steps", () => {
+	function makeFermentWithRunningStep(): Ferment {
+		return {
+			id: "f-nudge-test",
+			name: "Nudge Test",
+			status: "running",
+			worktree: { path: "/tmp" },
+			scoping: {},
+			phases: [
+				{
+					id: "phase-1",
+					index: 1,
+					name: "Build",
+					goal: "build it",
+					status: "active",
+					steps: [
+						{ id: "step-1", index: 1, description: "Write the code", status: "running" },
+						{ id: "step-2", index: 2, description: "Test it", status: "pending" },
+					],
+				},
+			],
+			decisions: [],
+			memories: [],
+			createdAt: new Date().toISOString(),
+			updatedAt: new Date().toISOString(),
+		}
+	}
+
+	beforeEach(() => {
+		__resetTodoStore()
+		setCurrentSessionHasUI(false)
+	})
+
+	afterEach(() => {
+		setActive(undefined)
+		__resetTodoStore()
+		setCurrentSessionHasUI(true)
+	})
+
+	it("shows warning when step is running with only the seed todo", () => {
+		setActive(makeFermentWithRunningStep())
+		// Seed todo (what todo-sync.ts would create on step start)
+		applyWriteTodos({
+			scope: { kind: "ferment-step", phaseId: "phase-1", stepId: "step-1" },
+			todos: [{ content: "Write the code", status: "in_progress" }],
+		})
+
+		const md = __test_renderTodoStateMarkdown()
+		expect(md).toContain("\u26a0 No implementation plan for the current step")
+		expect(md).toContain("Use add_todo to break down the work")
+	})
+
+	it("shows warning when step is running with empty step scope", () => {
+		setActive(makeFermentWithRunningStep())
+		// No step todos at all — need some other scope populated so markdown renders
+		applyWriteTodos({
+			scope: { kind: "ferment", phaseId: "phase-1" },
+			todos: [
+				{ content: "[Phase 1] Build", status: "in_progress" },
+				{ content: "\u21b3 Write the code", status: "in_progress" },
+			],
+		})
+
+		const md = __test_renderTodoStateMarkdown()
+		expect(md).toContain("\u26a0 No implementation plan for the current step")
+	})
+
+	it("does NOT show warning when model has added sub-tasks", () => {
+		setActive(makeFermentWithRunningStep())
+		applyWriteTodos({
+			scope: { kind: "ferment-step", phaseId: "phase-1", stepId: "step-1" },
+			todos: [
+				{ content: "Write the code", status: "in_progress" },
+				{ content: "Create helper function", status: "pending" },
+				{ content: "Add error handling", status: "pending" },
+			],
+		})
+
+		const md = __test_renderTodoStateMarkdown()
+		expect(md).not.toContain("\u26a0 No implementation plan")
+	})
+
+	it("does NOT show warning when no ferment is active", () => {
+		setActive(undefined)
+		applyWriteTodos({
+			scope: { kind: "global" },
+			todos: [{ content: "some global todo", status: "pending" }],
+		})
+
+		const md = __test_renderTodoStateMarkdown()
+		expect(md).not.toContain("\u26a0 No implementation plan")
+	})
+
+	it("does NOT show warning when no step is running", () => {
+		const ferment = makeFermentWithRunningStep()
+		// All steps pending, none running
+		ferment.phases[0].steps[0].status = "pending"
+		setActive(ferment)
+		applyWriteTodos({
+			scope: { kind: "ferment", phaseId: "phase-1" },
+			todos: [{ content: "[Phase 1] Build", status: "in_progress" }],
+		})
+
+		const md = __test_renderTodoStateMarkdown()
+		expect(md).not.toContain("\u26a0 No implementation plan")
+	})
+
+	it("renderTodoPromptBlock includes ferment guidance when ferment is active", () => {
+		setActive(makeFermentWithRunningStep())
+		const block = __test_renderTodoPromptBlock()
+		expect(block).toContain("When working inside a ferment step")
+		expect(block).toContain("break the step into concrete sub-tasks")
+	})
+
+	it("renderTodoPromptBlock does NOT include ferment guidance when no ferment is active", () => {
+		setActive(undefined)
+		const block = __test_renderTodoPromptBlock()
+		expect(block).not.toContain("When working inside a ferment step")
 	})
 })

--- a/src/extensions/todos/prompt-block.test.ts
+++ b/src/extensions/todos/prompt-block.test.ts
@@ -183,27 +183,15 @@ describe("todo state block gating", () => {
 	})
 })
 
-describe("empty-plan nudge for ferment steps", () => {
-	function makeFermentWithRunningStep(): Ferment {
+describe("ferment-conditional todo guidance", () => {
+	function makeFerment(): Ferment {
 		return {
-			id: "f-nudge-test",
-			name: "Nudge Test",
+			id: "f-guidance-test",
+			name: "Guidance Test",
 			status: "running",
 			worktree: { path: "/tmp" },
 			scoping: {},
-			phases: [
-				{
-					id: "phase-1",
-					index: 1,
-					name: "Build",
-					goal: "build it",
-					status: "active",
-					steps: [
-						{ id: "step-1", index: 1, description: "Write the code", status: "running" },
-						{ id: "step-2", index: 2, description: "Test it", status: "pending" },
-					],
-				},
-			],
+			phases: [],
 			decisions: [],
 			memories: [],
 			createdAt: new Date().toISOString(),
@@ -211,87 +199,12 @@ describe("empty-plan nudge for ferment steps", () => {
 		}
 	}
 
-	beforeEach(() => {
-		__resetTodoStore()
-		setCurrentSessionHasUI(false)
-	})
-
 	afterEach(() => {
 		setActive(undefined)
-		__resetTodoStore()
-		setCurrentSessionHasUI(true)
-	})
-
-	it("shows warning when step is running with only the seed todo", () => {
-		setActive(makeFermentWithRunningStep())
-		// Seed todo (what todo-sync.ts would create on step start)
-		applyWriteTodos({
-			scope: { kind: "ferment-step", phaseId: "phase-1", stepId: "step-1" },
-			todos: [{ content: "Write the code", status: "in_progress" }],
-		})
-
-		const md = __test_renderTodoStateMarkdown()
-		expect(md).toContain("\u26a0 No implementation plan for the current step")
-		expect(md).toContain("Use add_todo to break down the work")
-	})
-
-	it("shows warning when step is running with empty step scope", () => {
-		setActive(makeFermentWithRunningStep())
-		// No step todos at all — need some other scope populated so markdown renders
-		applyWriteTodos({
-			scope: { kind: "ferment", phaseId: "phase-1" },
-			todos: [
-				{ content: "[Phase 1] Build", status: "in_progress" },
-				{ content: "\u21b3 Write the code", status: "in_progress" },
-			],
-		})
-
-		const md = __test_renderTodoStateMarkdown()
-		expect(md).toContain("\u26a0 No implementation plan for the current step")
-	})
-
-	it("does NOT show warning when model has added sub-tasks", () => {
-		setActive(makeFermentWithRunningStep())
-		applyWriteTodos({
-			scope: { kind: "ferment-step", phaseId: "phase-1", stepId: "step-1" },
-			todos: [
-				{ content: "Write the code", status: "in_progress" },
-				{ content: "Create helper function", status: "pending" },
-				{ content: "Add error handling", status: "pending" },
-			],
-		})
-
-		const md = __test_renderTodoStateMarkdown()
-		expect(md).not.toContain("\u26a0 No implementation plan")
-	})
-
-	it("does NOT show warning when no ferment is active", () => {
-		setActive(undefined)
-		applyWriteTodos({
-			scope: { kind: "global" },
-			todos: [{ content: "some global todo", status: "pending" }],
-		})
-
-		const md = __test_renderTodoStateMarkdown()
-		expect(md).not.toContain("\u26a0 No implementation plan")
-	})
-
-	it("does NOT show warning when no step is running", () => {
-		const ferment = makeFermentWithRunningStep()
-		// All steps pending, none running
-		ferment.phases[0].steps[0].status = "pending"
-		setActive(ferment)
-		applyWriteTodos({
-			scope: { kind: "ferment", phaseId: "phase-1" },
-			todos: [{ content: "[Phase 1] Build", status: "in_progress" }],
-		})
-
-		const md = __test_renderTodoStateMarkdown()
-		expect(md).not.toContain("\u26a0 No implementation plan")
 	})
 
 	it("renderTodoPromptBlock includes ferment guidance when ferment is active", () => {
-		setActive(makeFermentWithRunningStep())
+		setActive(makeFerment())
 		const block = __test_renderTodoPromptBlock()
 		expect(block).toContain("When working inside a ferment step")
 		expect(block).toContain("break the step into concrete sub-tasks")

--- a/src/extensions/todos/prompt-block.ts
+++ b/src/extensions/todos/prompt-block.ts
@@ -1,13 +1,19 @@
 import type { ExtensionAPI } from "@earendil-works/pi-coding-agent"
+import { getActive } from "../ferment/state.js"
 import { createSystemPromptBlocks } from "../prompt-construction/index.js"
 import { parseTodoScopeKey } from "./scope.js"
-import { getTodoState } from "./store.js"
+import { getTodoState, getTodosForScope } from "./store.js"
 import type { TodoItem, TodoScope, TodoStatus } from "./types.js"
 
 const TODO_GUIDANCE =
 	"## Todos\nFor any non-trivial task, maintain a todo list. This includes code changes, debugging, reviews, investigations, multi-file reads, or anything with more than one meaningful step. Skip todos only for a single straightforward answer or a purely conversational task. Using todo tools is for tracking your work in the session; it is different from leaving TODO comments/placeholders in code, which you must not do unless explicitly requested. Use add_todo for one missing item, mark_todo for one status change, update_todos for batch replacement, and clear_todos only when the work is done or obsolete. Keep the list tactical and update it after meaningful progress, before switching to the next item, and before your final response. Keep at most one item in_progress when possible; when a current list is visible, continue the in_progress item before starting pending work. When updating an existing list, preserve user-created todos and existing ids unless the user asked to remove or rewrite them; append new todos after existing todos."
 
+const FERMENT_TODO_GUIDANCE =
+	"\n\nWhen working inside a ferment step, break the step into concrete sub-tasks using add_todo before writing code. Each sub-task should be a specific verifiable action (run a command, write a file, check an output). Mark each sub-task as you complete it rather than batch-replacing the entire list at the end."
+
 export function renderTodoPromptBlock(): string {
+	const ferment = getActive()
+	if (ferment) return TODO_GUIDANCE + FERMENT_TODO_GUIDANCE
 	return TODO_GUIDANCE
 }
 
@@ -124,6 +130,29 @@ export function renderTodoStateMarkdown(): string | undefined {
 		lines.push(`**Step ${stepScope.phaseId}/${stepScope.stepId}**`)
 		for (const todo of stepScope.todos) lines.push(formatTodoLine(todo))
 		lines.push("")
+	}
+
+	// Nudge: if a ferment step is running and the model hasn't expanded
+	// the seed todo into a real implementation plan, prompt it to do so.
+	const ferment = getActive()
+	if (ferment && ferment.status === "running") {
+		const activePhase = ferment.phases.find((p) => p.status === "active")
+		if (activePhase) {
+			const runningStep = activePhase.steps.find((s) => s.status === "running")
+			if (runningStep) {
+				const stepTodos = getTodosForScope({
+					kind: "ferment-step",
+					phaseId: activePhase.id,
+					stepId: runningStep.id,
+				})
+				if (stepTodos.length <= 1) {
+					lines.push("")
+					lines.push(
+						"\u26a0 No implementation plan for the current step. Use add_todo to break down the work before writing code.",
+					)
+				}
+			}
+		}
 	}
 
 	// Trim trailing blank line for cleanliness.

--- a/src/extensions/todos/prompt-block.ts
+++ b/src/extensions/todos/prompt-block.ts
@@ -1,5 +1,6 @@
 import type { ExtensionAPI } from "@earendil-works/pi-coding-agent"
 import { getActive } from "../ferment/state.js"
+import { getTurnsSinceStepTodoWrite } from "../ferment/todo-sync.js"
 import { createSystemPromptBlocks } from "../prompt-construction/index.js"
 import { parseTodoScopeKey } from "./scope.js"
 import { getTodoState } from "./store.js"
@@ -130,6 +131,16 @@ export function renderTodoStateMarkdown(): string | undefined {
 		lines.push(`**Step ${stepScope.phaseId}/${stepScope.stepId}**`)
 		for (const todo of stepScope.todos) lines.push(formatTodoLine(todo))
 		lines.push("")
+	}
+
+	// Stall detection: if a ferment step is running and the step-scope
+	// todos haven't been updated in several turns, nudge the model.
+	const staleTurns = getTurnsSinceStepTodoWrite()
+	if (staleTurns >= 5) {
+		lines.push("")
+		lines.push(
+			`\u26a0 Step todos have not been updated for ${staleTurns} turns. If you are iterating without progress, step back and reassess your approach. Update your todo plan with what you have tried and what to try next.`,
+		)
 	}
 
 	// Trim trailing blank line for cleanliness.

--- a/src/extensions/todos/prompt-block.ts
+++ b/src/extensions/todos/prompt-block.ts
@@ -1,5 +1,8 @@
 import type { ExtensionAPI } from "@earendil-works/pi-coding-agent"
 import { createSystemPromptBlocks } from "../prompt-construction/index.js"
+import { parseTodoScopeKey } from "./scope.js"
+import { getTodoState } from "./store.js"
+import type { TodoItem, TodoScope, TodoStatus } from "./types.js"
 
 const TODO_GUIDANCE =
 	"## Todos\nFor any non-trivial task, maintain a todo list. This includes code changes, debugging, reviews, investigations, multi-file reads, or anything with more than one meaningful step. Skip todos only for a single straightforward answer or a purely conversational task. Using todo tools is for tracking your work in the session; it is different from leaving TODO comments/placeholders in code, which you must not do unless explicitly requested. Use add_todo for one missing item, mark_todo for one status change, update_todos for batch replacement, and clear_todos only when the work is done or obsolete. Keep the list tactical and update it after meaningful progress, before switching to the next item, and before your final response. Keep at most one item in_progress when possible; when a current list is visible, continue the in_progress item before starting pending work. When updating an existing list, preserve user-created todos and existing ids unless the user asked to remove or rewrite them; append new todos after existing todos."
@@ -20,4 +23,129 @@ export function registerTodoPromptBlock(pi: ExtensionAPI): void {
 	})
 }
 
-export { renderTodoPromptBlock as __test_renderTodoPromptBlock }
+// ─── Live todo state for headless / one-shot runs ─────────────────────────────
+// In interactive sessions the todo widget renders the current state. In
+// headless runs there is no widget, so we surface the same state as a markdown
+// block injected into the system prompt. The block self-gates: when the UI is
+// present it returns undefined (no duplication), and when the store is empty
+// it also returns undefined (no prompt pollution).
+
+/** Module-level mirror of `ctx.hasUI` for the active session. Set by
+ *  `todosExtension` from `session_start`, cleared on `session_shutdown`.
+ *  Defaults to `true` so that pre-session renders (e.g. in tests) safely skip
+ *  rather than injecting headless-only content into an interactive prompt. */
+export let currentSessionHasUI = true
+
+export function setCurrentSessionHasUI(value: boolean): void {
+	currentSessionHasUI = value
+}
+
+function statusGlyph(status: TodoStatus): string {
+	switch (status) {
+		case "completed":
+			return "[x]"
+		case "in_progress":
+			return "[~]"
+		case "blocked":
+			return "[!]"
+		case "pending":
+			return "[ ]"
+		default:
+			return "[ ]"
+	}
+}
+
+function formatTodoLine(todo: TodoItem): string {
+	return `- ${statusGlyph(todo.status)} ${todo.content}`
+}
+
+/** Render the current todo store as a markdown section suitable for injection
+ *  into the system prompt. Returns `undefined` when there is nothing to show
+ *  (no scopes at all) so the block pipeline skips it. */
+export function renderTodoStateMarkdown(): string | undefined {
+	const state = getTodoState()
+	const scopeKeys = Object.keys(state.byScope)
+	if (scopeKeys.length === 0) return undefined
+
+	const global: TodoItem[] = []
+	const fermentScopes: Array<{ phaseId: string; header: TodoItem; steps: TodoItem[] }> = []
+	const stepScopes: Array<{ phaseId: string; stepId: string; todos: TodoItem[] }> = []
+
+	for (const scopeKey of scopeKeys) {
+		let scope: TodoScope | undefined
+		try {
+			scope = parseTodoScopeKey(scopeKey)
+		} catch {
+			continue
+		}
+		const scopeState = state.byScope[scopeKey]
+		if (!scopeState) continue
+
+		if (scope.kind === "global") {
+			global.push(...scopeState.todos)
+			continue
+		}
+
+		if (scope.kind === "ferment") {
+			const todos = [...scopeState.todos].sort((a, b) => a.id - b.id)
+			const header = todos.shift()
+			if (!header) continue
+			fermentScopes.push({ phaseId: scope.phaseId, header, steps: todos })
+			continue
+		}
+
+		if (scope.kind === "ferment-step") {
+			stepScopes.push({
+				phaseId: scope.phaseId,
+				stepId: scope.stepId,
+				todos: [...scopeState.todos].sort((a, b) => a.id - b.id),
+			})
+		}
+	}
+
+	const lines: string[] = []
+	lines.push("## Current Todos")
+	lines.push("")
+
+	if (global.length > 0) {
+		lines.push("**Global**")
+		for (const todo of global) lines.push(formatTodoLine(todo))
+		lines.push("")
+	}
+
+	for (const phase of fermentScopes) {
+		// Phase header: show content directly (already prefixed with `[Phase N]`).
+		lines.push(`**${phase.header.content}**`)
+		for (const step of phase.steps) lines.push(formatTodoLine(step))
+		lines.push("")
+	}
+
+	for (const stepScope of stepScopes) {
+		lines.push(`**Step ${stepScope.phaseId}/${stepScope.stepId}**`)
+		for (const todo of stepScope.todos) lines.push(formatTodoLine(todo))
+		lines.push("")
+	}
+
+	// Trim trailing blank line for cleanliness.
+	while (lines.length > 0 && lines[lines.length - 1] === "") lines.pop()
+	return lines.join("\n")
+}
+
+/** Register the live-state block. Self-gates:
+ *  - returns `undefined` when the active session has a UI (widget handles it)
+ *  - returns `undefined` when the store is empty
+ *  Both cases let the existing prompt-block pipeline skip cleanly. */
+export function registerTodoStateBlock(pi: ExtensionAPI): void {
+	createSystemPromptBlocks(pi, "todos").register({
+		id: "todo-state",
+		render: () => {
+			if (currentSessionHasUI) return undefined
+			return renderTodoStateMarkdown()
+		},
+	})
+}
+
+export {
+	renderTodoPromptBlock as __test_renderTodoPromptBlock,
+	renderTodoStateMarkdown as __test_renderTodoStateMarkdown,
+}

--- a/src/extensions/todos/prompt-block.ts
+++ b/src/extensions/todos/prompt-block.ts
@@ -2,7 +2,7 @@ import type { ExtensionAPI } from "@earendil-works/pi-coding-agent"
 import { getActive } from "../ferment/state.js"
 import { createSystemPromptBlocks } from "../prompt-construction/index.js"
 import { parseTodoScopeKey } from "./scope.js"
-import { getTodoState, getTodosForScope } from "./store.js"
+import { getTodoState } from "./store.js"
 import type { TodoItem, TodoScope, TodoStatus } from "./types.js"
 
 const TODO_GUIDANCE =
@@ -130,29 +130,6 @@ export function renderTodoStateMarkdown(): string | undefined {
 		lines.push(`**Step ${stepScope.phaseId}/${stepScope.stepId}**`)
 		for (const todo of stepScope.todos) lines.push(formatTodoLine(todo))
 		lines.push("")
-	}
-
-	// Nudge: if a ferment step is running and the model hasn't expanded
-	// the seed todo into a real implementation plan, prompt it to do so.
-	const ferment = getActive()
-	if (ferment && ferment.status === "running") {
-		const activePhase = ferment.phases.find((p) => p.status === "active")
-		if (activePhase) {
-			const runningStep = activePhase.steps.find((s) => s.status === "running")
-			if (runningStep) {
-				const stepTodos = getTodosForScope({
-					kind: "ferment-step",
-					phaseId: activePhase.id,
-					stepId: runningStep.id,
-				})
-				if (stepTodos.length <= 1) {
-					lines.push("")
-					lines.push(
-						"\u26a0 No implementation plan for the current step. Use add_todo to break down the work before writing code.",
-					)
-				}
-			}
-		}
 	}
 
 	// Trim trailing blank line for cleanliness.

--- a/src/extensions/todos/prompt-block.ts
+++ b/src/extensions/todos/prompt-block.ts
@@ -145,6 +145,14 @@ export function registerTodoStateBlock(pi: ExtensionAPI): void {
 	})
 }
 
+/** Applies the full gate (currentSessionHasUI check) exactly as the registered
+ *  system-prompt block does. Use this in tests to validate the complete path
+ *  rather than calling the raw renderer directly. */
+export function renderTodoStateBlock(): string | undefined {
+	if (currentSessionHasUI) return undefined
+	return renderTodoStateMarkdown()
+}
+
 export {
 	renderTodoPromptBlock as __test_renderTodoPromptBlock,
 	renderTodoStateMarkdown as __test_renderTodoStateMarkdown,

--- a/src/extensions/todos/reducer.ts
+++ b/src/extensions/todos/reducer.ts
@@ -85,7 +85,18 @@ function normalizeIncomingTodos(scopeTodos: unknown, nextId: number): { todos: T
 
 		const activeForm = normalizeOptionalText(todo.activeForm)
 		const note = normalizeOptionalText(todo.note)
-		result.push({ id, content, status, ...(activeForm ? { activeForm } : {}), ...(note ? { note } : {}) })
+		// Preserve the internal _syncKey (set by the auto-sync bridge) so it
+		// survives the round-trip from draft → stored item. The widget ignores
+		// it during rendering; the bridge uses it for deterministic correlation.
+		const syncKey = normalizeOptionalText(todo._syncKey)
+		result.push({
+			id,
+			content,
+			status,
+			...(activeForm ? { activeForm } : {}),
+			...(note ? { note } : {}),
+			...(syncKey ? { _syncKey: syncKey } : {}),
+		})
 	}
 
 	return { todos: orderTodosForStorage(result), nextTodoId: currentNextId }

--- a/src/extensions/todos/scope.ts
+++ b/src/extensions/todos/scope.ts
@@ -1,4 +1,4 @@
-import type { TodoScope } from "./types.js"
+import type { TodoScope, TodoScopeFerment, TodoScopeFermentStep } from "./types.js"
 
 export type { TodoScope }
 
@@ -36,6 +36,40 @@ registerTodoScopeKind({
 	normalize: normalizeGlobalScope,
 	toKey: () => "global",
 	fromKey: (parts) => (parts.length === 0 ? { kind: "global" } : undefined),
+})
+
+registerTodoScopeKind({
+	kind: "ferment",
+	normalize: (raw) => {
+		const phaseId = typeof raw.phaseId === "string" ? raw.phaseId.trim() : ""
+		return phaseId ? { kind: "ferment", phaseId } : undefined
+	},
+	toKey: (scope) => {
+		const f = scope as TodoScopeFerment
+		return `ferment:${encodeURIComponent(f.phaseId)}`
+	},
+	fromKey: (parts) => {
+		const phaseId = parts[0] ? decodeURIComponent(parts[0]) : ""
+		return phaseId ? { kind: "ferment", phaseId } : undefined
+	},
+})
+
+registerTodoScopeKind({
+	kind: "ferment-step",
+	normalize: (raw) => {
+		const phaseId = typeof raw.phaseId === "string" ? raw.phaseId.trim() : ""
+		const stepId = typeof raw.stepId === "string" ? raw.stepId.trim() : ""
+		return phaseId && stepId ? { kind: "ferment-step", phaseId, stepId } : undefined
+	},
+	toKey: (scope) => {
+		const s = scope as TodoScopeFermentStep
+		return `ferment-step:${encodeURIComponent(s.phaseId)}:${encodeURIComponent(s.stepId)}`
+	},
+	fromKey: (parts) => {
+		const phaseId = parts[0] ? decodeURIComponent(parts[0]) : ""
+		const stepId = parts[1] ? decodeURIComponent(parts[1]) : ""
+		return phaseId && stepId ? { kind: "ferment-step", phaseId, stepId } : undefined
+	},
 })
 
 export function normalizeTodoScope(rawScope: unknown): TodoScope {

--- a/src/extensions/todos/types.ts
+++ b/src/extensions/todos/types.ts
@@ -7,8 +7,19 @@ export interface TodoScopeGlobal {
 	kind: "global"
 }
 
-// Part 1 has one scope. Later parts widen this union explicitly.
-export type TodoScope = TodoScopeGlobal
+export interface TodoScopeFerment {
+	kind: "ferment"
+	phaseId: string
+}
+
+export interface TodoScopeFermentStep {
+	kind: "ferment-step"
+	phaseId: string
+	stepId: string
+}
+
+// Part 1 had one scope. Part 2 adds ferment scope. Further parts may widen this union.
+export type TodoScope = TodoScopeGlobal | TodoScopeFerment | TodoScopeFermentStep
 
 export interface TodoDraft {
 	id?: number

--- a/src/extensions/todos/types.ts
+++ b/src/extensions/todos/types.ts
@@ -21,12 +21,22 @@ export interface TodoScopeFermentStep {
 // Part 1 had one scope. Part 2 adds ferment scope. Further parts may widen this union.
 export type TodoScope = TodoScopeGlobal | TodoScopeFerment | TodoScopeFermentStep
 
+/**
+ * Internal correlation key set by the auto-sync bridge (todo-sync.ts) so it
+ * can map written todos back to ferment entities (phase header, specific
+ * step) without relying on fragile content matching. Stripped before display;
+ * never accepted from tool arguments.
+ */
+export type TodoSyncKey = string
+
 export interface TodoDraft {
 	id?: number
 	content: string
 	status: TodoStatus
 	activeForm?: string
 	note?: string
+	/** Internal: set by todo-sync.ts only. Not part of the tool schema. */
+	_syncKey?: TodoSyncKey
 }
 
 export interface TodoItem {
@@ -35,6 +45,8 @@ export interface TodoItem {
 	status: TodoStatus
 	activeForm?: string
 	note?: string
+	/** Internal: preserved across store writes for correlation by todo-sync.ts. */
+	_syncKey?: TodoSyncKey
 }
 
 export interface TodoScopeState {

--- a/src/extensions/todos/widget.test.ts
+++ b/src/extensions/todos/widget.test.ts
@@ -1,6 +1,7 @@
 import type { ExtensionContext, Theme } from "@earendil-works/pi-coding-agent"
 import { beforeEach, describe, expect, it, vi } from "vitest"
-import { __resetTodoStore, applyWriteTodos } from "./store.js"
+import { __resetTodoStore, applyWriteTodos, registerActiveTodoScopeProvider } from "./store.js"
+import type { TodoScope } from "./types.js"
 import {
 	__test_buildTodoLines,
 	__test_summarizeTodos,
@@ -18,6 +19,7 @@ type TestUiContext = ExtensionContext & {
 
 const theme = {
 	fg: (_color: string, text: string) => text,
+	bold: (text: string) => text,
 } as Theme
 
 describe("todo widget helpers", () => {
@@ -117,6 +119,76 @@ describe("todo widget helpers", () => {
 
 		expect(secondSetWidget).toHaveBeenCalledTimes(1)
 		expect(secondTui.requestRender).toHaveBeenCalled()
+	})
+
+	it("visually distinguishes ferment todos from global todos", () => {
+		// Global scope todos - default behavior
+		applyWriteTodos({
+			scope: { kind: "global" },
+			todos: [
+				{ content: "global task", status: "pending" },
+				{ content: "global done", status: "completed" },
+			],
+		})
+
+		const globalLines = __test_buildTodoLines(theme)
+		expect(globalLines[0]).toBe("Todos · Global")
+		expect(globalLines).toContain("  1.  ○ global task")
+		expect(globalLines).toContain("  2.  ✓ global done")
+	})
+
+	it("renders ferment-scoped todos with phase header and step prefixes", () => {
+		const fermentScope: TodoScope = { kind: "ferment", phaseId: "phase-1" }
+
+		// Register a scope provider that returns the ferment scope
+		const unregister = registerActiveTodoScopeProvider(() => fermentScope)
+
+		try {
+			applyWriteTodos({
+				scope: fermentScope,
+				todos: [
+					{ content: "[Phase 1] Setup", status: "in_progress", activeForm: "Setup" },
+					{ content: "↳ Install dependencies", status: "completed" },
+					{ content: "↳ Configure build", status: "in_progress" },
+					{ content: "↳ Run tests", status: "blocked" },
+					{ content: "↳ Deploy", status: "pending" },
+				],
+			})
+
+			const lines = __test_buildTodoLines(theme)
+
+			// Scope header shows ferment
+			expect(lines[0]).toBe("Todos · Ferment (phase-1)")
+
+			// Phase header is bold and uses activeForm
+			expect(lines).toContain("  1.  ▶ Setup")
+
+			// Steps have the ↳ prefix (which is dimmed in actual rendering)
+			expect(lines.some((line) => line.includes("↳ Install dependencies"))).toBe(true)
+			expect(lines.some((line) => line.includes("↳ Configure build"))).toBe(true)
+			expect(lines.some((line) => line.includes("↳ Run tests"))).toBe(true)
+			expect(lines.some((line) => line.includes("↳ Deploy"))).toBe(true)
+		} finally {
+			unregister()
+		}
+	})
+
+	it("detects ferment todos by content prefix even in global scope", () => {
+		// Edge case: ferment-formatted todos accidentally written to global scope
+		applyWriteTodos({
+			scope: { kind: "global" },
+			todos: [
+				{ content: "[Phase 1] Test", status: "in_progress", activeForm: "Test" },
+				{ content: "↳ Step 1", status: "pending" },
+			],
+		})
+
+		const lines = __test_buildTodoLines(theme)
+
+		// Even in global scope, ferment-formatted content gets detected
+		expect(lines[0]).toBe("Todos · Global")
+		expect(lines.some((line) => line.includes("Test"))).toBe(true) // Bold phase header
+		expect(lines.some((line) => line.includes("↳ Step 1"))).toBe(true) // Step with prefix
 	})
 })
 

--- a/src/extensions/todos/widget.ts
+++ b/src/extensions/todos/widget.ts
@@ -1,7 +1,7 @@
 import type { ExtensionAPI, ExtensionContext, Theme } from "@earendil-works/pi-coding-agent"
 import { Key, isKeyRelease, matchesKey, truncateToWidth } from "@earendil-works/pi-tui"
-import { GLOBAL_TODO_SCOPE, getTodoCountsForScope, getTodosForScope } from "./store.js"
-import type { TodoCounts, TodoItem, TodoStatus } from "./types.js"
+import { GLOBAL_TODO_SCOPE, getTodoCountsForScope, getTodosForScope, resolveTodoScope } from "./store.js"
+import type { TodoCounts, TodoItem, TodoScope, TodoStatus } from "./types.js"
 
 export const TODO_SHORTCUT = Key.f7
 export const TODO_SHORTCUT_HINT = "F7"
@@ -64,9 +64,40 @@ export function summarizeTodos(): string {
 	return summarizeTodoCounts(getTodoCountsForScope(GLOBAL_TODO_SCOPE))
 }
 
-function todoLine(todo: TodoItem, displayIndex: number, theme: Theme): string {
+function isFermentTodo(todo: TodoItem): boolean {
+	return todo.content.startsWith("↳ ") || todo.content.startsWith("[Phase ")
+}
+
+function todoLine(todo: TodoItem, displayIndex: number, theme: Theme, scope: TodoScope): string {
 	const index = `${displayIndex + 1}`.padStart(2)
 	const symbol = TODO_SYMBOL[todo.status]
+	const isFerment = scope.kind === "ferment" || isFermentTodo(todo)
+
+	// Phase header — bold accent
+	if (isFerment && todo.content.startsWith("[Phase ")) {
+		if (todo.status === "completed") {
+			return ` ${index}.  ${theme.fg("success", symbol)} ${theme.fg("dim", todo.content)}`
+		}
+		return ` ${index}.  ${theme.fg("accent", symbol)} ${theme.fg("accent", theme.bold(todo.activeForm ?? todo.content))}`
+	}
+
+	// Ferment step — dim the prefix arrow, normal for rest
+	if (isFerment && todo.content.startsWith("↳ ")) {
+		const arrow = "↳ "
+		const text = todo.content.slice(arrow.length)
+		if (todo.status === "completed") {
+			return ` ${index}.  ${theme.fg("success", symbol)} ${theme.fg("dim", arrow)}${theme.fg("dim", text)}`
+		}
+		if (todo.status === "blocked") {
+			return ` ${index}.  ${theme.fg("warning", symbol)} ${theme.fg("dim", arrow)}${theme.fg("warning", text)}`
+		}
+		if (todo.status === "in_progress") {
+			return ` ${index}.  ${theme.fg("accent", symbol)} ${theme.fg("dim", arrow)}${theme.fg("accent", todo.activeForm ?? text)}`
+		}
+		return ` ${index}.  ${theme.fg("dim", symbol)} ${theme.fg("dim", arrow)}${text}`
+	}
+
+	// Global todos — original behavior
 	if (todo.status === "completed") return ` ${index}.  ${theme.fg("success", symbol)} ${theme.fg("dim", todo.content)}`
 	if (todo.status === "blocked")
 		return ` ${index}.  ${theme.fg("warning", symbol)} ${theme.fg("warning", todo.content)}`
@@ -76,18 +107,30 @@ function todoLine(todo: TodoItem, displayIndex: number, theme: Theme): string {
 	return ` ${index}.  ${theme.fg("dim", symbol)} ${todo.content}`
 }
 
+function formatScopeHeader(scope: TodoScope): string {
+	if (scope.kind === "ferment") {
+		return `Todos · Ferment (${scope.phaseId})`
+	}
+	return "Todos · Global"
+}
+
+function summarizeTodosForScope(scope: TodoScope): string {
+	return summarizeTodoCounts(getTodoCountsForScope(scope))
+}
+
 export function buildTodoLines(theme: Theme): string[] {
-	const todos = getTodosForScope(GLOBAL_TODO_SCOPE)
-	const lines: string[] = [theme.fg("accent", "Todos · Global"), ""]
+	const scope = resolveTodoScope()
+	const todos = getTodosForScope(scope)
+	const lines: string[] = [theme.fg("accent", formatScopeHeader(scope)), ""]
 
 	if (todos.length === 0) {
 		lines.push(theme.fg("dim", "No todos yet. Add one with `/todos add <text>`."))
 		return lines
 	}
 
-	lines.push(theme.fg("dim", summarizeTodos()))
+	lines.push(theme.fg("dim", summarizeTodosForScope(scope)))
 	lines.push("")
-	lines.push(...todos.map((todo, index) => todoLine(todo, index, theme)))
+	lines.push(...todos.map((todo, index) => todoLine(todo, index, theme, scope)))
 	return lines
 }
 
@@ -105,7 +148,8 @@ function requestTodoRender(ctx: ExtensionContext): void {
 
 export function setTodosStatus(ctx: ExtensionContext): void {
 	if (!ctx.hasUI) return
-	const counts = getTodoCountsForScope(GLOBAL_TODO_SCOPE)
+	const scope = resolveTodoScope()
+	const counts = getTodoCountsForScope(scope)
 	ctx.ui.setStatus(
 		TODO_STATUS_KEY,
 		hasActiveTodos(counts) ? `${counts.completed}/${counts.total} todos -> F7` : undefined,
@@ -188,7 +232,8 @@ export function toggleTodoWidget(ctx: ExtensionContext): void {
 
 export function syncTodoWidget(ctx: ExtensionContext): void {
 	if (!ctx.hasUI) return
-	const counts = getTodoCountsForScope(GLOBAL_TODO_SCOPE)
+	const scope = resolveTodoScope()
+	const counts = getTodoCountsForScope(scope)
 	const state = getTodoWidgetState(ctx)
 	if (!state.collapsed && hasActiveTodos(counts)) openTodoWidget(ctx)
 	else clearTodoWidget(ctx)

--- a/tests/e2e/tui/todo-widget-ferment.test.ts
+++ b/tests/e2e/tui/todo-widget-ferment.test.ts
@@ -1,0 +1,108 @@
+import { expect, test } from "@microsoft/tui-test"
+import { INPUT_TIMEOUT_MS, STREAM_TIMEOUT_MS, waitForText } from "./support/assertions.js"
+import { TUI_TEST_CONFIG, runKimchiSession } from "./support/kimchi-fixture.js"
+
+test.use(TUI_TEST_CONFIG)
+
+/**
+ * Widget shows "Todos · Global" header, summary line, and todo items when
+ * the model writes todos with no explicit scope (default = global). Also
+ * verifies the per-item status symbols (○, ▶, ✓).
+ */
+test("todo widget renders global scope with status symbols", async ({ terminal }) => {
+	await runKimchiSession(
+		terminal,
+		{
+			artifactName: "todo-widget-global",
+			responses: [
+				{
+					stream: ["I'll", " add", " a", " todo."],
+					toolCalls: [
+						{
+							function: {
+								name: "update_todos",
+								arguments: JSON.stringify({
+									todos: [
+										{ content: "implement widget rendering", status: "in_progress" },
+										{ content: "write e2e tests", status: "pending" },
+									],
+								}),
+							},
+						},
+					],
+				},
+			],
+		},
+		async (_fixture, trace) => {
+			terminal.submit("Add a todo")
+			trace.step("submitted prompt")
+
+			await waitForText(terminal, "Todos · Global", { timeoutMs: STREAM_TIMEOUT_MS })
+			trace.step("scope header visible")
+
+			await waitForText(terminal, "0/2 done", { timeoutMs: INPUT_TIMEOUT_MS })
+			trace.step("summary line visible")
+
+			await waitForText(terminal, "implement widget rendering", { timeoutMs: INPUT_TIMEOUT_MS })
+			await waitForText(terminal, "write e2e tests", { timeoutMs: INPUT_TIMEOUT_MS })
+			trace.step("todo items visible")
+
+			// Status symbols: ▶ for in_progress, ○ for pending.
+			const text = terminal.getViewableBuffer().map((r) => r.join("")).join("\n")
+			expect(text).toContain("▶")
+			expect(text).toContain("○")
+		},
+	)
+})
+
+/**
+ * Widget summary line shows the correct count for mixed-status todos:
+ * "1/4 done · 3 active · 1 blocked" when there are 4 todos with
+ * pending/in_progress/blocked/completed statuses.
+ */
+test("todo widget summary reflects mixed-status counts", async ({ terminal }) => {
+	await runKimchiSession(
+		terminal,
+		{
+			artifactName: "todo-widget-mixed-status",
+			responses: [
+				{
+					stream: ["Adding", " mixed", " todos."],
+					toolCalls: [
+						{
+							function: {
+								name: "update_todos",
+								arguments: JSON.stringify({
+									todos: [
+										{ content: "pending item", status: "pending" },
+										{ content: "active item", status: "in_progress" },
+										{ content: "blocked item", status: "blocked" },
+										{ content: "done item", status: "completed" },
+									],
+								}),
+							},
+						},
+					],
+				},
+			],
+		},
+		async (_fixture, trace) => {
+			terminal.submit("Add mixed todos")
+			trace.step("submitted prompt")
+
+			// Summary format: "1/4 done · 3 active · 1 blocked"
+			await waitForText(terminal, "1/4 done", { timeoutMs: STREAM_TIMEOUT_MS })
+			trace.step("summary count visible")
+
+			await waitForText(terminal, "1 blocked", { timeoutMs: INPUT_TIMEOUT_MS })
+			trace.step("blocked count visible")
+
+			// All 4 items should appear with their status symbols.
+			await waitForText(terminal, "pending item", { timeoutMs: INPUT_TIMEOUT_MS })
+			await waitForText(terminal, "active item", { timeoutMs: INPUT_TIMEOUT_MS })
+			await waitForText(terminal, "blocked item", { timeoutMs: INPUT_TIMEOUT_MS })
+			await waitForText(terminal, "done item", { timeoutMs: INPUT_TIMEOUT_MS })
+			trace.step("all items visible")
+		},
+	)
+})


### PR DESCRIPTION
## Summary

Integrates the ferment lifecycle with the session todo overlay, giving the agent structured implementation planning per step, automatic scope management, stall detection, and worker context forwarding. Benchmarked across 3 runs of terminal-bench-2 (89 tasks), improving pass rate from 39.3% → 60.9%.

## Benchmark Results

| Run | Score | Passed | Key Changes |
|-----|-------|--------|-------------|
| Run 1 (baseline) | 39.3% | 35/89 | Pre-todo integration |
| Run 3 | 56.8% | 50/88 | Nudge fix + initial todo integration |
| Run 4 | 60.9% | 53/87 | Auto-scope + preamble improvements + stall detection |

- 25 tasks pass in all 3 runs (stable core)
- 24 tasks fail in all 3 runs (genuinely hard / beyond prompt engineering)
- 40 tasks are in the "improvement band" where the todo integration makes a difference

## Changes

### Auto-sync bridge (`todo-sync.ts`)
Event-driven bridge subscribes to ferment domain events and writes todos automatically:
- `PHASE_STARTED` → writes the phase name as a header todo + one `↳ step` todo per step
- `STEP_COMPLETED` / `STEP_FAILED` → marks the corresponding step todo done/blocked, clears step-level implementation todos
- `PHASE_COMPLETED` → marks any remaining todos completed and cleans up ID maps
- `FERMENT_SUSPENDED` → snapshots and clears all ferment-scoped todos
- `FERMENT_RESUMED` → restores the snapshot
- `FERMENT_COMPLETED` → clears all ferment-scoped todos

### Auto-scope provider
When a ferment step is running, scope-less `update_todos` / `add_todo` calls automatically target the `ferment-step` scope instead of global. Captures the 27% of benchmark trials that previously lost step-level structure by not passing an explicit scope. Implemented via `registerActiveTodoScopeProvider` in `todo-sync.ts`, tracking `currentRunningStep` from `STEP_STARTED` / `STEP_COMPLETED` / `STEP_FAILED` events.

### Plan-first preamble improvements (`steps.ts`)
The `start_ferment_step` tool result includes a structured planning preamble that tells the orchestrator to create implementation todos before dispatching work. Improvements:
- **Verification quality hint**: "Include a verification sub-task that checks exact expected output, not just substring grep" — addresses the nginx regression where `grep -q Welcome` passed but exact equality failed
- **Cleanup reminder**: "If the step compiles or builds artifacts, include a cleanup sub-task to remove intermediate files" — addresses the polyglot-c-py regression where compiled binaries were left behind
- **Prior-step context**: Shows completed step descriptions so the orchestrator's planning is informed by earlier work (e.g., "Prior steps: ✓1 \"Install deps\". Build on their output.")

### Stall detection
Tracks the number of orchestrator turns since the `ferment-step` todo scope was last written to. When the count exceeds 5 turns, the headless prompt block injects a warning:

> ⚠ Step todos have not been updated for N turns. If you are iterating without progress, step back and reassess your approach.

Targets the timeout pattern where agents enter tight bash loops (e.g., `gpt2-codegolf` with 20 consecutive bash calls, 0 todo updates) without ever stepping back to evaluate progress. Counter resets when the step scope is written to, or when a step starts/completes/fails.

### Step todo forwarding to workers (`worker-prompt.ts`)
`buildWorkerContext` now appends a `Plan:` line with the orchestrator's step-level todo items using status glyphs (✓ completed, ▶ in_progress, ○ pending). Subagents can see what was planned and track progress against it rather than iterating blindly.

### Ferment-conditional todo guidance (`prompt-block.ts`)
The `## Todos` system prompt block conditionally appends ferment-specific guidance when a ferment is active: "When working inside a ferment step, break the step into concrete sub-tasks using add_todo before writing code." This complements the plan-first preamble (which appears in the tool result) by keeping the guidance visible in the system prompt.

### Headless prompt block (`prompt-block.ts`)
In headless/one-shot runs (no UI), the todo state is rendered as a markdown block in the system prompt showing all scopes: global todos, ferment phase headers with step items, and ferment-step implementation todos. Self-gates when UI is present (widget handles it) or when the store is empty.

### Todo scopes
- `TodoScopeGlobal { kind: 'global' }` — user's own todos, not tied to ferment
- `TodoScopeFerment { kind: 'ferment', phaseId }` — auto-populated phase/step structure from the bridge
- `TodoScopeFermentStep { kind: 'ferment-step', phaseId, stepId }` — agent-written step implementation plan

### Widget visual distinction
The todo widget detects ferment-scoped todos via content prefix (`↳`) and applies distinct styling (bold accent for phase header, dim arrow for steps). Shows a scope header ("Global" or "Ferment (phase-id)").

### TODO steer improvements
The steer that nudges agents to maintain todos is suppressed when:
1. **Planning mode** — `add_todo` is not in the active toolset (ferment scoping phase)
2. **Todos already exist** — `hasOpenTodos()` checks all scopes, not just global; ferment-phase todos from the bridge suppress the steer

## Tests
- Integration tests in `todo-headless-wiring.test.ts`: auto-scope to running step, scope resets on step completion/failure, stall counter tracking, stall counter reset on write, stall warning in rendered markdown, threshold gating
- Unit tests in `todo-sync.test.ts`: phase activation populates todos, step completion marks done, step failure marks blocked, manual global todos unaffected, unsubscribe cleanup, multi-ferment isolation
- Worker prompt tests in `worker-prompt.test.ts`: step todo forwarding includes Plan line, omits Plan line when no todos
- Updated `steps.test.ts`: plan-first preamble with verification/cleanup hints, prior-step context inclusion
- Updated `prompt-block.test.ts`: ferment-conditional guidance, scope rendering
- Updated `scope.test.ts` and `index.test.ts` for new scope kind and steer behaviour

## Type of Change
- [x] New feature (non-breaking change which adds functionality)
