### PR TITLE
fix: avoid duplicate Claude skill resources

### DIFF
--- a/src/extensions/claude-code-skills/definition.test.ts
+++ b/src/extensions/claude-code-skills/definition.test.ts
@@ -5,6 +5,7 @@ import { afterEach, beforeEach, describe, expect, it } from "vitest"
 import {
 	discoverClaudeCodeSkillDirs,
 	getClaudeCodeSkillResourcePaths,
+	getConfiguredNativeSkillNames,
 	getConfiguredSkillResourcePaths,
 	sanitizeSkillMarkdown,
 } from "./definition.js"
@@ -166,12 +167,29 @@ describe("Claude Code skill discovery", () => {
 		).toBe('---\ndescription: "Use: colons safely"\nname: "my-skill"\n---\nBody\n')
 	})
 
-	it("materializes Claude Code skills even when native project skills use the same name", () => {
-		const cwd = join(dir, "project")
-		writeSkill(join(cwd, ".agents", "skills", "typescript-safety", "SKILL.md"))
+	it("skips Claude Code resources that duplicate ancestor agent skills", () => {
+		const project = join(dir, "project")
+		const cwd = join(project, "app")
+		writeSkill(join(project, ".agents", "skills", "typescript-safety", "SKILL.md"))
 		writeSkill(join(cwd, ".claude", "skills", "typescript-safety", "SKILL.md"))
 
-		expect(getClaudeCodeSkillResourcePaths(cwd)).toHaveLength(1)
+		expect(
+			getClaudeCodeSkillResourcePaths(cwd, {
+				excludeSkillNames: getConfiguredNativeSkillNames(cwd, []),
+			}),
+		).toEqual([])
+	})
+
+	it("skips Claude Code resources that duplicate Kimchi project skills", () => {
+		const cwd = join(dir, "project")
+		writeSkill(join(cwd, ".kimchi", "skills", "typescript-safety", "SKILL.md"))
+		writeSkill(join(cwd, ".claude", "skills", "typescript-safety", "SKILL.md"))
+
+		expect(
+			getClaudeCodeSkillResourcePaths(cwd, {
+				excludeSkillNames: getConfiguredNativeSkillNames(cwd, []),
+			}),
+		).toEqual([])
 	})
 
 	it("does not materialize Claude Code skills from an ancestor .claude directory", () => {
@@ -219,6 +237,15 @@ describe("Claude Code skill discovery", () => {
 		writeSkill(nativeSkill)
 
 		expect(getConfiguredSkillResourcePaths(cwd, [claudeSkills, nativeSkill])).toEqual([nativeSkill])
+	})
+
+	it("skips configured Claude Code paths that duplicate default native skills", () => {
+		const cwd = join(dir, "project")
+		const claudeSkills = join(cwd, ".claude", "skills")
+		writeSkill(join(cwd, ".agents", "skills", "typescript-safety", "SKILL.md"))
+		writeSkill(join(claudeSkills, "typescript-safety", "SKILL.md"))
+
+		expect(getConfiguredSkillResourcePaths(cwd, [claudeSkills])).toEqual([])
 	})
 })
 

--- a/src/extensions/claude-code-skills/definition.ts
+++ b/src/extensions/claude-code-skills/definition.ts
@@ -5,6 +5,7 @@ import { homedir, tmpdir } from "node:os"
 import { basename, dirname, extname, isAbsolute, join, normalize, relative, resolve } from "node:path"
 import { parse as parseYaml, stringify as stringifyYaml } from "yaml"
 import { z } from "zod"
+import { findNearestAncestorSkillDir } from "../../skill-paths.js"
 
 export const CLAUDE_CODE_SKILLS_RESOURCE_ID = "extensions.claude-code-skills"
 
@@ -57,7 +58,7 @@ export function getClaudeCodeSkillResourcePaths(
 
 export function getConfiguredSkillResourcePaths(cwd: string, configuredSkillPaths: string[]): string[] {
 	const expandedPaths = expandConfiguredSkillPaths(configuredSkillPaths, cwd)
-	const nativeSkillNames = collectNativeSkillNames(expandedPaths)
+	const nativeSkillNames = collectNativeSkillNamesForExclusion(cwd, expandedPaths)
 	return expandedPaths.flatMap((path) =>
 		isClaudeCodeSkillPath(path)
 			? materializeClaudeCodeSkillPath(path, { excludeSkillNames: nativeSkillNames })
@@ -66,7 +67,7 @@ export function getConfiguredSkillResourcePaths(cwd: string, configuredSkillPath
 }
 
 export function getConfiguredNativeSkillNames(cwd: string, configuredSkillPaths: string[]): string[] {
-	return [...collectNativeSkillNames(expandConfiguredSkillPaths(configuredSkillPaths, cwd))]
+	return [...collectNativeSkillNamesForExclusion(cwd, expandConfiguredSkillPaths(configuredSkillPaths, cwd))]
 }
 
 export function sanitizeSkillMarkdown(content: string, fallbackName: string): string {
@@ -163,6 +164,24 @@ function isSameOrDescendant(path: string, parent: string): boolean {
 
 function isClaudeCodeSkillPath(path: string): boolean {
 	return path.split(/[\\/]+/).includes(".claude")
+}
+
+function collectNativeSkillNamesForExclusion(cwd: string, expandedConfiguredSkillPaths: string[]): Set<string> {
+	return collectNativeSkillNames([...expandedConfiguredSkillPaths, ...getDefaultNativeSkillPaths(cwd)])
+}
+
+function getDefaultNativeSkillPaths(cwd: string): string[] {
+	const projectDir = resolve(cwd)
+	const home = resolve(homedir())
+	const paths = [
+		findNearestAncestorSkillDir(projectDir, join(".kimchi", "skills")),
+		findNearestAncestorSkillDir(projectDir, join(".agents", "skills")),
+		join(projectDir, ".pi", "skills"),
+		join(home, ".config", "kimchi", "harness", "skills"),
+		join(home, ".pi", "agent", "skills"),
+		join(home, ".agents", "skills"),
+	]
+	return [...new Set(paths.filter((path): path is string => path !== undefined).map(normalize))]
 }
 
 function collectNativeSkillNames(paths: string[]): Set<string> {

--- a/src/extensions/claude-code-skills/index.test.ts
+++ b/src/extensions/claude-code-skills/index.test.ts
@@ -87,7 +87,7 @@ describe("Claude Code skills extension", () => {
 		expect(textResult(result)).not.toContain("Project-native skill instructions.")
 	})
 
-	it("loads Claude Code skills instead of native skills with the same name", async () => {
+	it("does not implicitly load a Claude Code skill that duplicates a native skill", async () => {
 		writeSkill(
 			join(dir, "project", ".kimchi", "skills", "best-practices", "SKILL.md"),
 			"Kimchi project skill instructions.",
@@ -99,6 +99,33 @@ describe("Claude Code skills extension", () => {
 			cwd: join(dir, "project"),
 			sessionManager: { getSessionId: () => "session-1" },
 		} as never)
+
+		expect(textResult(result)).toBe(
+			'Claude Code skill "best-practices" duplicates a native skill. Pass source: "claude" to load the Claude Code version explicitly.',
+		)
+		expect(textResult(result)).not.toContain("Kimchi project skill instructions.")
+		expect(textResult(result)).not.toContain("Claude skill instructions.")
+		expect(result.details).toMatchObject({ success: false, name: "best-practices" })
+	})
+
+	it("loads a duplicate Claude Code skill when source is explicit", async () => {
+		writeSkill(
+			join(dir, "project", ".kimchi", "skills", "best-practices", "SKILL.md"),
+			"Kimchi project skill instructions.",
+		)
+		writeSkill(join(dir, "project", ".claude", "skills", "best-practices", "SKILL.md"), "Claude skill instructions.")
+		const { tools } = registerExtension()
+
+		const result = await tools[0].execute(
+			"call-1",
+			{ skill: "best-practices", source: "claude" },
+			undefined,
+			undefined,
+			{
+				cwd: join(dir, "project"),
+				sessionManager: { getSessionId: () => "session-1" },
+			} as never,
+		)
 
 		expect(textResult(result)).toContain("Claude skill instructions.")
 		expect(textResult(result)).not.toContain("Kimchi project skill instructions.")

--- a/src/extensions/claude-code-skills/index.test.ts
+++ b/src/extensions/claude-code-skills/index.test.ts
@@ -136,7 +136,7 @@ describe("Claude Code skills extension", () => {
 		expect(loaded.diagnostics.map((diagnostic) => diagnostic.message)).not.toContain("description is required")
 	})
 
-	it("contributes Claude Code skill resources even when native project skills use the same name", async () => {
+	it("skips startup Claude Code resources that duplicate ancestor agent skills", async () => {
 		writeSkill(join(dir, "project", ".agents", "skills", "typescript-safety", "SKILL.md"), "Use generated types.")
 		writeSkill(join(dir, "project", ".claude", "skills", "typescript-safety", "SKILL.md"), "Use Claude skills.")
 		const { handlers } = registerExtension()
@@ -146,12 +146,22 @@ describe("Claude Code skills extension", () => {
 			cwd: join(dir, "project"),
 			reason: "startup",
 		})
-		const skillPaths = (result as { skillPaths?: string[] } | undefined)?.skillPaths ?? []
 
-		expect(skillPaths).toHaveLength(1)
-		const loaded = loadSkillsFromDir({ dir: skillPaths[0] ?? "", source: "path" })
-		expect(loaded.skills).toMatchObject([{ name: "typescript-safety" }])
-		expect(readSkill(skillPaths[0] ?? "")).toContain("Use Claude skills.")
+		expect(result).toBeUndefined()
+	})
+
+	it("skips startup Claude Code resources that duplicate Kimchi project skills", async () => {
+		writeSkill(join(dir, "project", ".kimchi", "skills", "typescript-safety", "SKILL.md"), "Use generated types.")
+		writeSkill(join(dir, "project", ".claude", "skills", "typescript-safety", "SKILL.md"), "Use Claude skills.")
+		const { handlers } = registerExtension()
+
+		const result = await handlers.resources_discover?.({
+			type: "resources_discover",
+			cwd: join(dir, "project"),
+			reason: "startup",
+		})
+
+		expect(result).toBeUndefined()
 	})
 
 	it("skips startup Claude Code resources that duplicate configured native skills", async () => {

--- a/src/extensions/claude-code-skills/index.test.ts
+++ b/src/extensions/claude-code-skills/index.test.ts
@@ -1,7 +1,13 @@
 import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs"
 import { tmpdir } from "node:os"
 import { dirname, join } from "node:path"
-import { type ExtensionAPI, type ToolDefinition, loadSkillsFromDir } from "@earendil-works/pi-coding-agent"
+import {
+	type ExtensionAPI,
+	type ToolDefinition,
+	getAgentDir,
+	loadSkills,
+	loadSkillsFromDir,
+} from "@earendil-works/pi-coding-agent"
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
 import claudeCodeSkillsExtension from "./index.js"
 
@@ -162,6 +168,37 @@ describe("Claude Code skills extension", () => {
 		})
 
 		expect(result).toBeUndefined()
+	})
+
+	it("keeps unique Claude Code resources when another Claude skill duplicates a native skill", async () => {
+		const cwd = join(dir, "project")
+		const nativeSkills = join(cwd, ".agents", "skills")
+		writeSkill(join(nativeSkills, "playwright-cli", "SKILL.md"), "Native Playwright CLI skill.")
+		writeSkill(join(cwd, ".claude", "skills", "playwright-cli", "SKILL.md"), "Duplicate Claude Playwright CLI skill.")
+		writeRawSkill(join(cwd, ".claude", "skills", "unique-claude", "SKILL.md"), "Unique Claude skill.\n")
+		const { handlers } = registerExtension()
+
+		const result = await handlers.resources_discover?.({
+			type: "resources_discover",
+			cwd,
+			reason: "startup",
+		})
+		const skillPaths = (result as { skillPaths?: string[] } | undefined)?.skillPaths ?? []
+
+		expect(skillPaths).toHaveLength(1)
+		expect(readSkill(skillPaths[0] ?? "")).toContain("Unique Claude skill.")
+		expect(readSkill(skillPaths[0] ?? "")).not.toContain("Duplicate Claude Playwright CLI skill.")
+
+		const loaded = loadSkills({
+			cwd,
+			agentDir: getAgentDir(),
+			skillPaths: [nativeSkills, ...skillPaths],
+			includeDefaults: false,
+		})
+		const diagnostics = loaded.diagnostics.map((diagnostic) => diagnostic.message)
+		expect(diagnostics.filter((message) => /collision|conflict|Skill conflicts/i.test(message))).toEqual([])
+		expect(diagnostics).not.toContain("description is required")
+		expect(loaded.skills.map((skill) => skill.name).sort()).toEqual(["playwright-cli", "unique-claude"])
 	})
 
 	it("skips startup Claude Code resources that duplicate configured native skills", async () => {

--- a/src/extensions/claude-code-skills/index.ts
+++ b/src/extensions/claude-code-skills/index.ts
@@ -15,6 +15,12 @@ interface SkillToolDetails {
 const SkillToolSchema = Type.Object({
 	skill: Type.Optional(Type.String({ description: "Claude Code skill name to load, e.g. typescript-safety." })),
 	name: Type.Optional(Type.String({ description: "Alias for skill." })),
+	source: Type.Optional(
+		Type.Union([Type.Literal("auto"), Type.Literal("claude")], {
+			description:
+				'Skill source selector. Use "claude" to explicitly load a Claude Code skill that duplicates a native skill.',
+		}),
+	),
 })
 
 type SkillToolArgs = Static<typeof SkillToolSchema>
@@ -57,6 +63,17 @@ export default function claudeCodeSkillsExtension(pi: ExtensionAPI, configuredSk
 				return {
 					content: [{ type: "text" as const, text: message }],
 					details: { success: false, name, error: message } satisfies SkillToolDetails,
+				}
+			}
+
+			if (
+				params.source !== "claude" &&
+				getConfiguredNativeSkillNames(ctx.cwd, configuredSkillPaths).includes(skill.name)
+			) {
+				const message = `Claude Code skill "${skill.name}" duplicates a native skill. Pass source: "claude" to load the Claude Code version explicitly.`
+				return {
+					content: [{ type: "text" as const, text: message }],
+					details: { success: false, name: skill.name, error: message } satisfies SkillToolDetails,
 				}
 			}
 


### PR DESCRIPTION
## Linked issue

Closes #

<!-- Every PR must link to an existing issue. PRs without a linked issue will not be reviewed.
     Use one of: Closes #N / Fixes #N / Resolves #N -->

## What does this PR do?

<!-- Brief description of the change and why it's needed. -->

## Checklist

- [ ] I have read [CONTRIBUTING.md](../CONTRIBUTING.md) and agree to the CLA
- [ ] This PR links to an open issue above
- [ ] Tests pass locally (`pnpm run test`)
- [ ] Lint passes (`pnpm run check`)
- [ ] Documentation updated if behavior changed
