### PR TITLE
fix(ferment-lifecycle-commands): reconcile with persisted state

### DIFF
--- a/src/extensions/ferment/commands.test.ts
+++ b/src/extensions/ferment/commands.test.ts
@@ -386,6 +386,13 @@ describe("FermentCommandController", () => {
 		expect(h.ctx.ui.notify).toHaveBeenCalledWith(expect.stringContaining('Exited Ferment mode for "Draft Exit"'))
 		expect(h.pi.sendMessage).toHaveBeenCalledWith(
 			expect.objectContaining({
+				customType: "ferment_breadcrumb",
+				content: [expect.objectContaining({ text: 'Command /ferment exit requested for "Draft Exit" [draft].' })],
+			}),
+			{ triggerTurn: false },
+		)
+		expect(h.pi.sendMessage).toHaveBeenCalledWith(
+			expect.objectContaining({
 				customType: "ferment_ack",
 				display: true,
 				content: [expect.objectContaining({ text: expect.stringContaining('Exited Ferment mode for "Draft Exit"') })],
@@ -430,6 +437,37 @@ describe("FermentCommandController", () => {
 		expect(h.runtime.setActive).toHaveBeenCalledWith(expect.objectContaining({ status: "paused" }))
 		expect(h.runtime.setActive).toHaveBeenLastCalledWith(undefined)
 		expect(h.pi.setActiveTools).toHaveBeenLastCalledWith(["read", "bash"])
+	})
+
+	it("/ferment exit reconciles stale paused active cache with running storage", async () => {
+		const h = createHarness()
+		const controller = new FermentCommandController()
+		const running = createRunningFerment(h, "Stale Exit")
+		h.runtime.setActive({ ...running, status: "paused" })
+
+		const result = await controller.execute({ type: "exit" }, { raw: "exit", pi: h.pi, ctx: h.ctx, runtime: h.runtime })
+
+		expect(result).toEqual({ handled: true })
+		expect(h.storage.get(running.id)?.status).toBe("paused")
+		expect(h.runtime.getActive()).toBeUndefined()
+		expect(h.pi.sendMessage).toHaveBeenCalledWith(
+			expect.objectContaining({
+				customType: "ferment_breadcrumb",
+				content: [expect.objectContaining({ text: 'Command /ferment exit requested for "Stale Exit" [running].' })],
+			}),
+			{ triggerTurn: false },
+		)
+		expect(h.pi.sendMessage).toHaveBeenCalledWith(
+			expect.objectContaining({
+				customType: "ferment_ack",
+				content: [
+					expect.objectContaining({
+						text: 'Exited Ferment mode for "Stale Exit". It is paused and can be selected later from /ferment list or /ferment switch.',
+					}),
+				],
+			}),
+			{ triggerTurn: false },
+		)
 	})
 
 	it("/ferment exit leaves paused ferments paused while clearing active mode", async () => {
@@ -1197,6 +1235,23 @@ describe("registerFermentCommands", () => {
 		expect(h.runtime.getContinuationPolicy()).toBe("automated")
 		expect(active.status).toBe("paused")
 		expect(h.ctx.ui.notify).toHaveBeenCalledWith(expect.stringContaining("Paused"))
+		expect(h.pi.sendMessage).toHaveBeenCalledWith(
+			expect.objectContaining({
+				customType: "ferment_breadcrumb",
+				content: [
+					expect.objectContaining({ text: 'Command /ferment pause requested for "Running Ferment" [running].' }),
+				],
+			}),
+			{ triggerTurn: false },
+		)
+		expect(h.pi.sendMessage).toHaveBeenCalledWith(
+			expect.objectContaining({
+				customType: "ferment_breadcrumb",
+				details: expect.objectContaining({ variant: "ack" }),
+				content: [expect.objectContaining({ text: 'Paused "Running Ferment". Type /ferment resume to resume.' })],
+			}),
+			{ triggerTurn: false },
+		)
 		expect(h.pi.setActiveTools).toHaveBeenLastCalledWith(
 			expect.arrayContaining([
 				"read",
@@ -1250,6 +1305,71 @@ describe("registerFermentCommands", () => {
 		expect(h.ctx.ui.notify).toHaveBeenCalledWith(expect.stringContaining("already paused"))
 		expect(h.ctx.ui.notify).toHaveBeenCalledWith(expect.stringContaining("/ferment resume"))
 		expect(h.ctx.abort).not.toHaveBeenCalled()
+	})
+
+	it("/ferment pause reconciles stale paused active cache with running storage", async () => {
+		const h = createHarness()
+		const running = createRunningFerment(h, "Stale Active Pause")
+		h.runtime.setActive({ ...running, status: "paused" })
+
+		const commands = new Map<string, RegisteredCommand>()
+		const pi = {
+			...h.pi,
+			registerCommand: (name: string, command: RegisteredCommand) => {
+				commands.set(name, command)
+			},
+		} as unknown as ExtensionAPI
+		registerFermentCommands(pi, h.runtime)
+
+		const fermentCommand = commands.get("ferment")
+		if (!fermentCommand) throw new Error("ferment command was not registered")
+		await fermentCommand.handler("pause", h.ctx)
+
+		expect(h.storage.get(running.id)?.status).toBe("paused")
+		expect(h.runtime.getActive()?.status).toBe("paused")
+		expect(h.ctx.ui.notify).toHaveBeenCalledWith('Paused "Stale Active Pause". Type /ferment resume to resume.')
+		expect(h.pi.sendMessage).toHaveBeenCalledWith(
+			expect.objectContaining({
+				customType: "ferment_breadcrumb",
+				content: [
+					expect.objectContaining({ text: 'Command /ferment pause requested for "Stale Active Pause" [running].' }),
+				],
+			}),
+			{ triggerTurn: false },
+		)
+	})
+
+	it("/ferment resume reconciles stale paused active cache with running storage", async () => {
+		const h = createHarness()
+		const running = createRunningFerment(h, "Stale Active Resume")
+		h.runtime.setActive({ ...running, status: "paused" })
+
+		const commands = new Map<string, RegisteredCommand>()
+		const pi = {
+			...h.pi,
+			registerCommand: (name: string, command: RegisteredCommand) => {
+				commands.set(name, command)
+			},
+		} as unknown as ExtensionAPI
+		registerFermentCommands(pi, h.runtime)
+
+		const fermentCommand = commands.get("ferment")
+		if (!fermentCommand) throw new Error("ferment command was not registered")
+		await fermentCommand.handler("resume", h.ctx)
+
+		expect(h.ctx.ui.notify).not.toHaveBeenCalledWith(expect.stringContaining("Failed to resume"))
+		expect(h.ctx.ui.notify).toHaveBeenCalledWith('"Stale Active Resume" is running; continuing from current state.')
+		expect(h.runtime.getActive()?.status).toBe("running")
+		expect(h.storage.get(running.id)?.status).toBe("running")
+		expect(h.pi.sendMessage).toHaveBeenCalledWith(
+			expect.objectContaining({
+				customType: "ferment_breadcrumb",
+				content: [
+					expect.objectContaining({ text: 'Command /ferment resume requested for "Stale Active Resume" [running].' }),
+				],
+			}),
+			{ triggerTurn: false },
+		)
 	})
 
 	it("implements pause → /ferment auto → /ferment resume with policy separated from lifecycle", async () => {
@@ -1369,6 +1489,27 @@ describe("registerFermentCommands", () => {
 		expect(h.runtime.getContinuationPolicy()).toBe("manual")
 		expect(active.status).toBe("running")
 		expect(active.phases[0].status).toBe("active")
+		expect(h.pi.sendMessage).toHaveBeenCalledWith(
+			expect.objectContaining({
+				customType: "ferment_breadcrumb",
+				content: [
+					expect.objectContaining({ text: 'Command /ferment resume requested for "Manual Resume Ferment" [paused].' }),
+				],
+			}),
+			{ triggerTurn: false },
+		)
+		expect(h.pi.sendMessage).toHaveBeenCalledWith(
+			expect.objectContaining({
+				customType: "ferment_breadcrumb",
+				details: expect.objectContaining({ variant: "ack" }),
+				content: [
+					expect.objectContaining({
+						text: 'Resumed "Manual Resume Ferment". Continuation policy: manual.',
+					}),
+				],
+			}),
+			{ triggerTurn: false },
+		)
 		expect(h.pi.sendMessage).toHaveBeenCalledWith(
 			expect.objectContaining({
 				customType: "ferment_continuation_nudge",

--- a/src/extensions/ferment/commands.ts
+++ b/src/extensions/ferment/commands.ts
@@ -55,6 +55,32 @@ function sendBreadcrumb(
 	)
 }
 
+function sendLifecycleCommandBreadcrumb(
+	pi: ExtensionAPI,
+	command: "pause" | "resume" | "exit",
+	active: ReturnType<FermentRuntime["getActive"]>,
+): void {
+	const target = active ? `"${active.name}" [${active.status}]` : "no active ferment"
+	sendBreadcrumb(pi, `Command /ferment ${command} requested for ${target}.`, "step")
+}
+
+function refreshActiveFermentForLifecycleCommand(
+	pi: ExtensionAPI,
+	runtime: FermentRuntime,
+): ReturnType<FermentRuntime["getActive"]> {
+	const active = runtime.getActive()
+	if (!active) return undefined
+	const fresh = runtime.getStorage().get(active.id)
+	if (!fresh) {
+		setActiveFermentAndApplyProfile(pi, runtime, undefined)
+		return undefined
+	}
+	if (fresh.status !== active.status || fresh.updatedAt !== active.updatedAt) {
+		setActiveFermentAndApplyProfile(pi, runtime, fresh)
+	}
+	return fresh
+}
+
 export type FermentCliCommand = FermentCommand
 
 interface FermentArgumentCompletion {
@@ -471,7 +497,8 @@ function exitFermentMode(
 	runtime: FermentRuntime,
 ): void {
 	const applyAndPersist = createApplyAndPersist(runtime)
-	const active = runtime.getActive()
+	const active = refreshActiveFermentForLifecycleCommand(pi, runtime)
+	sendLifecycleCommandBreadcrumb(pi, "exit", active)
 	if (!active) {
 		ctx.ui.notify("No active ferment to exit.")
 		return
@@ -481,7 +508,9 @@ function exitFermentMode(
 	if (active.status === "running" || active.status === "planned") {
 		const outcome = applyAndPersist(active.id, { type: "pause" })
 		if (!outcome.ok) {
-			ctx.ui.notify(`Failed to exit "${active.name}": ${outcome.error.message}`)
+			const message = `Failed to exit "${active.name}": ${outcome.error.message}`
+			sendBreadcrumb(pi, message, "warning")
+			ctx.ui.notify(message)
 			return
 		}
 		statusLabel = "paused"
@@ -609,7 +638,8 @@ export class FermentCommandController {
 		}
 
 		if (command.type === "pause-lifecycle") {
-			const active = runtime.getActive()
+			const active = refreshActiveFermentForLifecycleCommand(pi, runtime)
+			sendLifecycleCommandBreadcrumb(pi, "pause", active)
 			if (!active) {
 				ctx.ui.notify("No active ferment to pause.")
 				return { handled: true }
@@ -621,45 +651,64 @@ export class FermentCommandController {
 			}
 
 			if (active.status === "paused") {
-				ctx.ui.notify(`"${active.name}" is already paused. Type /ferment resume to resume.`)
+				const message = `"${active.name}" is already paused. Type /ferment resume to resume.`
+				sendBreadcrumb(pi, message, "ack")
+				ctx.ui.notify(message)
 				applyFermentRuntimeToolProfile(pi, runtime)
 				return { handled: true }
 			}
 
 			const outcome = applyAndPersist(active.id, { type: "pause" })
 			if (!outcome.ok) {
-				ctx.ui.notify(`Failed to pause: ${outcome.error.message}`)
+				const message = `Failed to pause: ${outcome.error.message}`
+				sendBreadcrumb(pi, message, "warning")
+				ctx.ui.notify(message)
 				return { handled: true }
 			}
 
 			setActiveFermentAndApplyProfile(pi, runtime, outcome.ferment)
 			runtime.clearPendingPlanReview(active.id)
-			ctx.ui.notify(`Paused "${outcome.ferment.name}". Type /ferment resume to resume.`)
+			const message = `Paused "${outcome.ferment.name}". Type /ferment resume to resume.`
+			sendBreadcrumb(pi, message, "ack")
+			ctx.ui.notify(message)
 			ctx.abort()
 			return { handled: true }
 		}
 
 		if (command.type === "resume-lifecycle") {
-			const active = runtime.getActive()
+			const active = refreshActiveFermentForLifecycleCommand(pi, runtime)
+			sendLifecycleCommandBreadcrumb(pi, "resume", active)
 			if (!active) {
 				ctx.ui.notify("No active ferment to resume.")
 				return { handled: true }
 			}
 
 			if (active.status !== "paused") {
-				ctx.ui.notify(`"${active.name}" is ${active.status}; nothing to resume.`)
+				const canContinue = active.status === "running" || active.status === "planned"
+				const message = canContinue
+					? `"${active.name}" is ${active.status}; continuing from current state.`
+					: `"${active.name}" is ${active.status}; nothing to resume.`
+				sendBreadcrumb(pi, message, "ack")
+				ctx.ui.notify(message)
 				applyFermentRuntimeToolProfile(pi, runtime)
+				if (canContinue) {
+					scheduleFermentWakeUp(pi, runtime, { fermentId: active.id, tag: "Resume wake-up" })
+				}
 				return { handled: true }
 			}
 
 			const outcome = applyAndPersist(active.id, { type: "resume" })
 			if (!outcome.ok) {
-				ctx.ui.notify(`Failed to resume: ${outcome.error.message}`)
+				const message = `Failed to resume: ${outcome.error.message}`
+				sendBreadcrumb(pi, message, "warning")
+				ctx.ui.notify(message)
 				return { handled: true }
 			}
 
 			setActiveFermentAndApplyProfile(pi, runtime, outcome.ferment)
-			ctx.ui.notify(`Resumed "${outcome.ferment.name}". Continuation policy: ${runtime.getContinuationPolicy()}.`)
+			const message = `Resumed "${outcome.ferment.name}". Continuation policy: ${runtime.getContinuationPolicy()}.`
+			sendBreadcrumb(pi, message, "ack")
+			ctx.ui.notify(message)
 			if (await confirmManualPhaseBoundaryForCommand(pi, ctx, runtime, outcome.ferment)) {
 				return { handled: true }
 			}


### PR DESCRIPTION
## What does this PR do?

Ferment lifecycle slash commands were deciding from the in-memory active ferment cache while mutations were applied against freshly loaded persisted state. When those diverged, the UI/assistant could report the ferment as paused, but /ferment resume would reload storage, see running, and fail because resume expected paused.

Make pause/resume/exit refresh the active ferment from storage before making lifecycle decisions, and log durable lifecycle breadcrumbs so future session exports show pause/resume/exit requests and outcomes.

## Checklist

- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md) and agree to the CLA
- [x] Tests pass locally (`pnpm run test`)
- [x] Lint passes (`pnpm run check`)


Closes #646