### PR TITLE
fix(extensions): hide interactive-only tools when no UI is attached

### DIFF
--- a/src/extensions/ferment/tool-names.test.ts
+++ b/src/extensions/ferment/tool-names.test.ts
@@ -18,6 +18,10 @@ function collectRegisteredToolNames(): string[] {
 		registerTool: (tool: { name: string }) => {
 			names.push(tool.name)
 		},
+		on: () => {},
+		getActiveTools: () => [],
+		setActiveTools: () => {},
+		getFlag: () => undefined,
 	} as unknown as ExtensionAPI
 
 	registerLifecycleTools(pi)

--- a/src/extensions/ferment/tool-scope.test.ts
+++ b/src/extensions/ferment/tool-scope.test.ts
@@ -1,6 +1,7 @@
 import type { ExtensionAPI } from "@earendil-works/pi-coding-agent"
 import { describe, expect, it, vi } from "vitest"
 import type { Ferment, Phase } from "../../ferment/types.js"
+import { createToolVisibility } from "../prompt-construction/tool-visibility.js"
 import { FERMENT_TOOLS, FERMENT_TOOL_NAMES } from "./tool-names.js"
 import {
 	IMPLEMENTATION_TOOL_NAMES,
@@ -267,5 +268,77 @@ describe("normal vs one-shot parity", () => {
 		// NOT the toolset.
 		const ferment = buildFerment("active")
 		expect(profileForFerment(ferment)).toBe("implementation")
+	})
+})
+
+describe("visibility-layer interlock", () => {
+	// Regression: applyFermentRuntimeToolProfile called setActiveTools directly,
+	// bypassing the cooperative visibility layer. Tools hidden at session_start
+	// (e.g. ask_user / confirm_ferment_completion_criteria when hasUI=false) could
+	// be re-added by the ferment profile applied in before_agent_start.
+	// See: https://github.com/getkimchi/kimchi/pull/647
+
+	it("implementation profile does not re-add tools disabled via createToolVisibility", () => {
+		const allTools = ["bash", "edit", "ask_user", "confirm_ferment_completion_criteria", ...FERMENT_TOOL_NAMES]
+		const pi = createPi(allTools, allTools)
+
+		// Simulate session_start with hasUI=false: disable both interactive tools.
+		const visibility = createToolVisibility(pi)
+		visibility.disable(["ask_user", "confirm_ferment_completion_criteria"])
+
+		// Now simulate before_agent_start applying the implementation profile for an active ferment.
+		applyFermentToolProfile(pi, "implementation")
+
+		const lastCall = (pi.setActiveTools as ReturnType<typeof vi.fn>).mock.lastCall?.[0] as string[]
+		expect(lastCall).not.toContain("ask_user")
+		expect(lastCall).not.toContain("confirm_ferment_completion_criteria")
+	})
+
+	it("planning profile does not re-add tools disabled via createToolVisibility", () => {
+		const allTools = ["ask_user", "confirm_ferment_completion_criteria", "propose_ferment_scoping", "scope_ferment"]
+		const pi = createPi(allTools, allTools)
+
+		const visibility = createToolVisibility(pi)
+		visibility.disable(["ask_user", "confirm_ferment_completion_criteria"])
+
+		applyFermentToolProfile(pi, "planning")
+
+		const lastCall = (pi.setActiveTools as ReturnType<typeof vi.fn>).mock.lastCall?.[0] as string[]
+		expect(lastCall).not.toContain("ask_user")
+		expect(lastCall).not.toContain("confirm_ferment_completion_criteria")
+	})
+
+	it("idle profile does not re-add tools disabled via createToolVisibility", () => {
+		const allTools = ["bash", "ask_user", "confirm_ferment_completion_criteria"]
+		const pi = createPi(allTools, allTools)
+
+		const visibility = createToolVisibility(pi)
+		visibility.disable(["ask_user", "confirm_ferment_completion_criteria"])
+
+		applyFermentToolProfile(pi, "idle")
+
+		const lastCall = (pi.setActiveTools as ReturnType<typeof vi.fn>).mock.lastCall?.[0] as string[]
+		expect(lastCall).not.toContain("ask_user")
+		expect(lastCall).not.toContain("confirm_ferment_completion_criteria")
+		expect(lastCall).toContain("bash")
+	})
+
+	it("profile respects visibility votes only while votes are active — re-enabling restores the tool", () => {
+		const allTools = ["bash", "ask_user", ...FERMENT_TOOL_NAMES]
+		const pi = createPi(allTools, allTools)
+
+		const visibility = createToolVisibility(pi)
+		visibility.disable(["ask_user"])
+
+		// Vote is active: tool should be absent.
+		applyFermentToolProfile(pi, "implementation")
+		let lastCall = (pi.setActiveTools as ReturnType<typeof vi.fn>).mock.lastCall?.[0] as string[]
+		expect(lastCall).not.toContain("ask_user")
+
+		// Remove the vote: tool should return.
+		visibility.enable(["ask_user"])
+		applyFermentToolProfile(pi, "implementation")
+		lastCall = (pi.setActiveTools as ReturnType<typeof vi.fn>).mock.lastCall?.[0] as string[]
+		expect(lastCall).toContain("ask_user")
 	})
 })

--- a/src/extensions/ferment/tool-scope.ts
+++ b/src/extensions/ferment/tool-scope.ts
@@ -1,6 +1,7 @@
 import type { ExtensionAPI } from "@earendil-works/pi-coding-agent"
 import type { Ferment } from "../../ferment/types.js"
 import { isAgentWorker } from "../agent-worker-context.js"
+import { getDisabledToolNames } from "../prompt-construction/tool-visibility.js"
 import type { FermentRuntime } from "./runtime.js"
 import { FERMENT_TOOLS, isFermentOnlyToolName } from "./tool-names.js"
 
@@ -104,6 +105,12 @@ export class FermentToolScope {
 	constructor(private readonly pi: ExtensionAPI) {}
 
 	applyProfile(profile: FermentToolProfile): void {
+		// Tools that have been disabled via the cooperative visibility layer (e.g.
+		// ask_user / confirm_ferment_completion_criteria hidden when no UI is
+		// attached) must remain absent even when this profile wants them visible.
+		// Without this filter, a direct setActiveTools call would undo the
+		// visibility-layer vote and re-surface tools the model cannot use.
+		const disabled = getDisabledToolNames(this.pi)
 		switch (profile) {
 			case "idle": {
 				// Normal chat / post-ferment state: show all non-ferment tools plus
@@ -113,14 +120,14 @@ export class FermentToolScope {
 				const idle = this.pi
 					.getAllTools()
 					.map((t) => t.name)
-					.filter((name) => !isFermentOnlyToolName(name))
+					.filter((name) => !isFermentOnlyToolName(name) && !disabled.has(name))
 				this.pi.setActiveTools(idle)
 				break
 			}
 			case "planning": {
 				// Intersection: only tools that are BOTH registered AND explicitly listed for planning.
 				const allTools = this.pi.getAllTools().map((tool) => tool.name)
-				const allowed = allTools.filter((name) => PLANNING_TOOL_NAMES.has(name))
+				const allowed = allTools.filter((name) => PLANNING_TOOL_NAMES.has(name) && !disabled.has(name))
 				this.pi.setActiveTools(allowed)
 				break
 			}
@@ -130,6 +137,10 @@ export class FermentToolScope {
 				const allowed = new Set<string>(allTools)
 				for (const required of IMPLEMENTATION_TOOL_NAMES) {
 					allowed.add(required)
+				}
+				// Strip any tool that the cooperative visibility layer has voted to hide.
+				for (const name of disabled) {
+					allowed.delete(name)
 				}
 				this.pi.setActiveTools([...allowed])
 				break

--- a/src/extensions/ferment/tools/lifecycle.test.ts
+++ b/src/extensions/ferment/tools/lifecycle.test.ts
@@ -54,7 +54,15 @@ function errText(result: { content: { text: string }[]; isError?: boolean }): st
 function createHarness() {
 	const storage = new FermentEventStore(mkdtempSync(join(tmpdir(), "ferment-lifecycle-test-")))
 	const runtime: FermentRuntime = { ...createDefaultFermentRuntime(), getStorage: () => storage }
-	const pi = { sendMessage: vi.fn(), sendUserMessage: vi.fn(), appendEntry: vi.fn() } as unknown as ExtensionAPI
+	const pi = {
+		sendMessage: vi.fn(),
+		sendUserMessage: vi.fn(),
+		appendEntry: vi.fn(),
+		on: vi.fn(),
+		getFlag: vi.fn(() => undefined),
+		getActiveTools: vi.fn(() => []),
+		setActiveTools: vi.fn(),
+	} as unknown as ExtensionAPI
 	const ferment = storage.create("Lifecycle Test")
 	return { storage, runtime, pi, fermentId: ferment.id }
 }
@@ -688,6 +696,8 @@ describe("update_ferment_scope_field via registerLifecycleTools", () => {
 			},
 			sendMessage: vi.fn(),
 			appendEntry: vi.fn(),
+			on: vi.fn(),
+			getFlag: vi.fn(() => undefined),
 			getActiveTools: vi.fn(() => ["read", "bash"]),
 			getAllTools: vi.fn(() => [{ name: "read" }, { name: "bash" }]),
 			setActiveTools: vi.fn(),
@@ -888,5 +898,78 @@ describe("completeFerment", () => {
 		expect(okText(result)).toContain("Judge unreachable (no_registry)")
 		expect(h.storage.get(h.fermentId)?.status).toBe("complete")
 		expect(h.storage.get(h.fermentId)?.grade).toBeUndefined()
+	})
+})
+
+describe("interactive ferment tool visibility (registerLifecycleTools)", () => {
+	interface FakePi {
+		registerTool: (tool: { name: string }) => void
+		on: (event: string, handler: (e: unknown, ctx: { hasUI: boolean }) => void) => void
+		getActiveTools: () => string[]
+		setActiveTools: (names: string[]) => void
+		getFlag: (name: string) => boolean | undefined
+		_sessionStart: ((event: unknown, ctx: { hasUI: boolean }) => void) | null
+	}
+
+	function makePi(options: {
+		activeTools: string[]
+		oneShot?: boolean
+	}): FakePi & { setActiveCalls: string[][] } {
+		const pi: FakePi & { setActiveCalls: string[][] } = {
+			registerTool: () => {},
+			on: (_event, handler) => {
+				pi._sessionStart = handler
+			},
+			getActiveTools: () => options.activeTools,
+			setActiveTools: (names: string[]) => {
+				pi.setActiveCalls.push(names)
+			},
+			getFlag: (name: string) => (name === "ferment-oneshot" ? options.oneShot === true : undefined),
+			_sessionStart: null,
+			setActiveCalls: [],
+		}
+		return pi
+	}
+
+	function fireSessionStart(pi: FakePi, hasUI: boolean): void {
+		if (!pi._sessionStart) throw new Error("session_start handler not registered")
+		pi._sessionStart({}, { hasUI })
+	}
+
+	it("hides confirm_ferment_completion_criteria and ask_user when no UI and no oneShot", () => {
+		const pi = makePi({
+			activeTools: [FERMENT_TOOLS.CONFIRM_COMPLETION_CRITERIA, FERMENT_TOOLS.ASK_USER, "read", "bash"],
+		})
+		registerLifecycleTools(pi as unknown as ExtensionAPI)
+		fireSessionStart(pi, false)
+
+		// Last write should remove the two interactive tools from the active set.
+		const lastWrite = pi.setActiveCalls.at(-1) ?? []
+		expect(lastWrite).not.toContain(FERMENT_TOOLS.CONFIRM_COMPLETION_CRITERIA)
+		expect(lastWrite).not.toContain(FERMENT_TOOLS.ASK_USER)
+		expect(lastWrite).toContain("read")
+	})
+
+	it("keeps confirm_ferment_completion_criteria and ask_user visible when no UI but oneShot is set (judge fallback)", () => {
+		const pi = makePi({
+			activeTools: [FERMENT_TOOLS.CONFIRM_COMPLETION_CRITERIA, FERMENT_TOOLS.ASK_USER, "read"],
+			oneShot: true,
+		})
+		registerLifecycleTools(pi as unknown as ExtensionAPI)
+		fireSessionStart(pi, false)
+
+		// No disable writes — the tools stay visible because the judge can answer.
+		expect(pi.setActiveCalls).toEqual([])
+	})
+
+	it("keeps confirm_ferment_completion_criteria and ask_user visible when UI is attached", () => {
+		const pi = makePi({
+			activeTools: [FERMENT_TOOLS.CONFIRM_COMPLETION_CRITERIA, FERMENT_TOOLS.ASK_USER, "read"],
+		})
+		registerLifecycleTools(pi as unknown as ExtensionAPI)
+		fireSessionStart(pi, true)
+
+		// No disable writes — UI is attached, tools work normally.
+		expect(pi.setActiveCalls).toEqual([])
 	})
 })

--- a/src/extensions/ferment/tools/lifecycle.ts
+++ b/src/extensions/ferment/tools/lifecycle.ts
@@ -25,6 +25,7 @@ import {
 	type ScopingQuestion,
 	type ScopingQuestionType,
 } from "../../../ferment/types.js"
+import { createToolVisibility } from "../../prompt-construction/tool-visibility.js"
 import { YES_NO_OPTIONS } from "../../questionnaire-reducer.js"
 import {
 	type AskUserQuestion,
@@ -1132,6 +1133,22 @@ ${renderGateGuidance("complete_ferment")}`,
 		async execute(_, params) {
 			return completeFerment(runtime, params)
 		},
+	})
+
+	// confirm_ferment_completion_criteria and ask_user both render interactive
+	// TUI forms via ctx.ui.custom(). Hide them from the system prompt when no
+	// UI is attached and the ferment-oneshot judge fallback is not engaged,
+	// so the LLM does not call a tool that cannot succeed.
+	const interactiveVisibility = createToolVisibility(pi)
+	pi.on("session_start", (_event, ctx) => {
+		const judgeFallback = pi.getFlag?.("ferment-oneshot") === true
+		const hideInteractiveTools = !ctx.hasUI && !judgeFallback
+		const interactiveTools = [FERMENT_TOOLS.CONFIRM_COMPLETION_CRITERIA, FERMENT_TOOLS.ASK_USER]
+		if (hideInteractiveTools) {
+			interactiveVisibility.disable(interactiveTools)
+		} else {
+			interactiveVisibility.enable(interactiveTools)
+		}
 	})
 
 	pi.registerTool({

--- a/src/extensions/prompt-construction/tool-visibility.ts
+++ b/src/extensions/prompt-construction/tool-visibility.ts
@@ -107,3 +107,15 @@ const toolsByPi = new WeakMap<ExtensionAPI, Map<string, ToolVisibility>>()
 export function createToolVisibility(pi: ExtensionAPI): ToolVisibilityAPI {
 	return new Handle(pi)
 }
+
+/**
+ * Returns the set of tool names that currently have at least one disable vote.
+ * Callers that write the active-tool list directly (e.g. FermentToolScope)
+ * must filter these out so their setActiveTools call does not re-surface tools
+ * that another extension has hidden via the visibility layer.
+ */
+export function getDisabledToolNames(pi: ExtensionAPI): ReadonlySet<string> {
+	const m = toolsByPi.get(pi)
+	if (!m) return new Set()
+	return new Set(m.keys())
+}

--- a/src/extensions/questionnaire.test.ts
+++ b/src/extensions/questionnaire.test.ts
@@ -18,6 +18,9 @@ function registeredQuestionnaireTool() {
 		registerTool: vi.fn((registered) => {
 			tool = registered as typeof tool
 		}),
+		on: vi.fn(),
+		getActiveTools: vi.fn(() => []),
+		setActiveTools: vi.fn(),
 	} as unknown as ExtensionAPI
 	questionnaireExtension(pi)
 	if (!tool) throw new Error("questionnaire tool was not registered")
@@ -244,5 +247,77 @@ describe("formatAnswerText", () => {
 			},
 		]
 		expect(formatAnswerText(questions, answers)).toBe("Q1: user selected: A, B")
+	})
+})
+
+describe("questionnaire non-interactive visibility", () => {
+	interface FakePi {
+		registerTool: ReturnType<typeof vi.fn>
+		on: ReturnType<typeof vi.fn>
+		getActiveTools: ReturnType<typeof vi.fn>
+		setActiveTools: ReturnType<typeof vi.fn>
+		// Captures the registered session_start handler so tests can fire it.
+		_sessionStart: ((event: unknown, ctx: { hasUI: boolean }) => void) | null
+	}
+
+	function makePi(activeTools: string[] = ["questionnaire"]): FakePi {
+		const pi: FakePi = {
+			registerTool: vi.fn(),
+			on: vi.fn(),
+			getActiveTools: vi.fn(() => activeTools),
+			setActiveTools: vi.fn(),
+			_sessionStart: null,
+		}
+		pi.on.mockImplementation((event: string, handler: (e: unknown, ctx: { hasUI: boolean }) => void) => {
+			if (event === "session_start") pi._sessionStart = handler
+		})
+		return pi
+	}
+
+	it("disables the tool from the active set when session_start fires with no UI", () => {
+		const pi = makePi(["questionnaire", "read", "bash"])
+		questionnaireExtension(pi as unknown as ExtensionAPI)
+		expect(pi._sessionStart).toBeTypeOf("function")
+
+		pi._sessionStart?.({}, { hasUI: false })
+
+		expect(pi.setActiveTools).toHaveBeenCalledWith(["read", "bash"])
+	})
+
+	it("leaves the tool enabled when session_start fires with a UI attached", () => {
+		const pi = makePi(["questionnaire", "read", "bash"])
+		questionnaireExtension(pi as unknown as ExtensionAPI)
+		pi._sessionStart?.({}, { hasUI: true })
+		// disable/flip hasUI=false path calls setActiveTools; enable path doesn't,
+		// because the tool is already in the active set.
+		const writes = pi.setActiveTools.mock.calls
+		expect(writes).toEqual([])
+	})
+
+	it("execute returns a 'do not retry' steer when no UI is attached (defense-in-depth)", async () => {
+		const pi = makePi(["questionnaire"])
+		questionnaireExtension(pi as unknown as ExtensionAPI)
+		const tool = pi.registerTool.mock.calls[0]?.[0] as {
+			execute: (
+				toolCallId: string,
+				params: unknown,
+				signal: AbortSignal | undefined,
+				onUpdate: unknown,
+				ctx: unknown,
+			) => Promise<{ content: { text: string }[]; details: { cancelled: boolean } }>
+		}
+
+		const result = await tool.execute(
+			"call-1",
+			{ questions: [{ id: "ship", prompt: "Ship it?" }] },
+			undefined,
+			undefined,
+			{ hasUI: false, ui: { custom: vi.fn() } },
+		)
+
+		expect(result.details.cancelled).toBe(true)
+		const text = result.content[0]?.text ?? ""
+		expect(text).toContain("questionnaire is unavailable")
+		expect(text).toContain("Do NOT call questionnaire again")
 	})
 })

--- a/src/extensions/questionnaire.ts
+++ b/src/extensions/questionnaire.ts
@@ -15,10 +15,11 @@
  * harness tool for plan mode and general agent interaction.
  */
 
-import type { ExtensionAPI } from "@earendil-works/pi-coding-agent"
+import type { ExtensionAPI, ExtensionContext } from "@earendil-works/pi-coding-agent"
 import { Text, truncateToWidth } from "@earendil-works/pi-tui"
 import { type Static, Type } from "typebox"
 
+import { createToolVisibility } from "./prompt-construction/tool-visibility.js"
 import { createQuestionForm } from "./questionnaire-form.js"
 import { type Answer, type Question, type QuestionType, YES_NO_OPTIONS } from "./questionnaire-reducer.js"
 
@@ -175,6 +176,20 @@ export function formatAnswerText(questions: Question[], answers: Answer[]): stri
 // ─── Extension ────────────────────────────────────────────────────────────────
 
 export default function questionnaireExtension(pi: ExtensionAPI): void {
+	// The questionnaire tool drives a multi-question TUI form. When no UI is
+	// attached the execute body would return an error — worse, the model can
+	// retry the same call because the tool stays visible. Hide it from the
+	// system prompt as soon as we know there is no UI so the LLM never picks
+	// it. The execute body keeps the runtime check as defense-in-depth.
+	const visibility = createToolVisibility(pi)
+	pi.on("session_start", (_event, ctx: ExtensionContext) => {
+		if (ctx.hasUI) {
+			visibility.enable(["questionnaire"])
+		} else {
+			visibility.disable(["questionnaire"])
+		}
+	})
+
 	pi.registerTool({
 		name: "questionnaire",
 		label: "Questionnaire",
@@ -199,8 +214,12 @@ export default function questionnaireExtension(pi: ExtensionAPI): void {
 			}
 
 			if (!ctx.hasUI) {
+				// Defense-in-depth: the session_start handler should have hidden
+				// the tool from the system prompt already. If we got here anyway
+				// (tool hidden mid-session, or schema leaked) make the failure
+				// an explicit "do not retry" steer so the model doesn't loop on it.
 				return errorResult(
-					"Error: questionnaire requires interactive mode (no UI available). Rephrase your questions as text in your response instead.",
+					"questionnaire is unavailable in this session: it requires an interactive UI and none is attached (the harness is running in a non-interactive mode such as --print, --mode json|rpc|acp, or a headless subprocess). Do NOT call questionnaire again in this session. Ask the user clarifying questions as plain text in your reply instead.",
 				)
 			}
 


### PR DESCRIPTION
## Linked issue

None — discovered during the last benchmark run (configure-git-webserver and fix-git both failed when the agent called `questionnaire` in non-interactive mode). Happy to file a tracking issue if preferred.

## What does this PR do?

The `questionnaire`, `ask_user`, and `confirm_ferment_completion_criteria` tools all render TUI forms via `ctx.ui.custom()`. In non-interactive sessions (`--print`, `--mode json|rpc|acp`, headless subprocesses) they cannot succeed, but they were still registered and visible to the model. The last benchmark run observed the model calling `questionnaire`, getting the polite "no UI available" error, and retrying the same call — burning turns instead of recovering.

This change uses the existing `createToolVisibility` primitive (the same pattern used by `permissions` and `mcp-adapter`) to remove the tools from the active tool set at `session_start` when `ctx.hasUI` is false:

- **`questionnaire`** — always hidden when no UI.
- **`ask_user`** and **`confirm_ferment_completion_criteria`** — hidden when no UI *and* `--ferment-oneshot` is not set. When `--ferment-oneshot` is enabled the tools stay visible because `askUserForm` / `askUser` route to the judge LLM in that case and can still succeed.

**Defense in depth**: the `questionnaire` execute-time error message is hardened to an explicit "Do NOT call questionnaire again in this session" steer so a defiant model cannot loop on the call even if the schema leaks.

## Audit

Audit results for all registered tools (no other tools depend on `ctx.ui.custom/select/confirm/input/editor` from `execute`):

| Tool | UI in execute? | Action |
|---|---|---|
| `questionnaire` | yes | hide on no UI |
| `ask_user` | yes (judge fallback in `--ferment-oneshot`) | hide on no UI + no oneShot |
| `confirm_ferment_completion_criteria` | yes (judge fallback in `--ferment-oneshot`) | hide on no UI + no oneShot |
| `read` / `bash` / `edit` / `write` / `grep` / `find` / `ls` | no | none |
| `lsp_*` | no | none |
| `web_fetch` / `web_search` | no (render-only UI use) | none |
| `Agent` / `get_subagent_result` / `steer_subagent` | no (widget `setUICtx` is a no-op without UI) | none |
| `Skill` (Claude Code compat) | no | none |
| `MCP` tools | guards UI usage | none |
| `IDE` adapter | no | none |
| `curator`, todos (`update_todos` etc.), `set_model`, `set_phase` | no | none |

## Tests

- 3 new tests in `src/extensions/questionnaire.test.ts`
  - hides tool on `session_start` when `hasUI=false`
  - leaves tool visible when `hasUI=true`
  - execute returns a "do not retry" error message when no UI is attached (defense-in-depth)
- 3 new tests in `src/extensions/ferment/tools/lifecycle.test.ts`
  - hides `confirm_ferment_completion_criteria` and `ask_user` when no UI + no oneShot
  - keeps both visible when no UI + oneShot (judge fallback)
  - keeps both visible when UI is attached
- 3 pre-existing test harnesses patched (`lifecycle.test.ts createHarness`, `createRegisteredHarness`, `tool-names.test.ts`) to mock `pi.on` / `getActiveTools` / `setActiveTools` / `getFlag`, since `registerLifecycleTools` now calls `createToolVisibility`.

## Checklist

- [x] I have read CONTRIBUTING.md and agree to the CLA
- [ ] This PR links to an open issue above *(no upstream issue — see Linked issue section)*
- [x] Tests pass locally (`pnpm run test` → 5159 passed | 3 skipped)
- [x] Lint passes (`pnpm run check`)
- [ ] Documentation updated if behavior changed *(no user-facing docs to update — internal tool-registration behavior)*
