### PR TITLE
feat(bash): apply 120s default timeout to bash tool

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -29,6 +29,7 @@ import { isBunBinary } from "./env.js"
 import activityExtension from "./extensions/activity.js"
 import agentsExtension from "./extensions/agents/index.js"
 import assistantPrefixExtension from "./extensions/assistant-prefix.js"
+import bashDefaultTimeoutExtension from "./extensions/bash-default-timeout.js"
 import bashToolGuardExtension from "./extensions/bash-tool-guard.js"
 import behavioursExtension from "./extensions/behaviours/index.js"
 import claudeCodeHooksAdapter from "./extensions/claude-code-hook-adapter/index.js"
@@ -436,6 +437,7 @@ try {
 			// Always registered — the tool_call handler checks isResourceEnabled
 			// dynamically on every bash call, so enable/disable from /resources
 			// takes effect immediately without a process restart.
+			bashDefaultTimeoutExtension,
 			bashToolGuardExtension,
 			...enabledExtensionFactories([
 				{ id: "plugins.mcp-apps", factory: mcpAdapterExtension },

--- a/src/extensions/bash-default-timeout.test.ts
+++ b/src/extensions/bash-default-timeout.test.ts
@@ -1,0 +1,189 @@
+/**
+ * Unit tests for `resolveBashTimeout` (pure helper) and integration tests
+ * for the bash default-timeout extension's `tool_call` mutation.
+ *
+ * The test harness uses a minimal mock of `ExtensionAPI` that records
+ * registered handlers, so we can fire `tool_call` events with a stub
+ * `BashToolCallEvent` shape and assert on the mutation performed by the
+ * handler.
+ */
+import { afterEach, describe, expect, it, vi } from "vitest"
+
+let mockResourceEnabled = true
+
+vi.mock("../resources/store.js", () => ({
+	isResourceEnabled: (id: string) => (id === "extensions.bash-default-timeout" ? mockResourceEnabled : true),
+}))
+
+afterEach(() => {
+	mockResourceEnabled = true
+})
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+type PI = import("@earendil-works/pi-coding-agent").ExtensionAPI
+
+interface MockPI {
+	handlers: Record<string, Array<(event: unknown) => unknown>>
+	on(event: string, handler: (event: unknown) => unknown): void
+}
+
+function createMockPI(): MockPI {
+	const handlers: MockPI["handlers"] = {}
+	return {
+		handlers,
+		on(event, handler) {
+			if (!handlers[event]) handlers[event] = []
+			handlers[event].push(handler)
+		},
+	}
+}
+
+interface BashEvent {
+	toolName: string
+	input: { command?: string; timeout?: number | null }
+}
+
+function fireToolCall(pi: MockPI, event: BashEvent): void {
+	const handlers = pi.handlers.tool_call ?? []
+	for (const handler of handlers) {
+		handler(event)
+	}
+}
+
+import bashDefaultTimeoutExtension, {
+	BASH_DEFAULT_TIMEOUT_RESOURCE_ID,
+	DEFAULT_BASH_TIMEOUT_SECONDS,
+	resolveBashTimeout,
+} from "./bash-default-timeout.js"
+
+describe("resolveBashTimeout", () => {
+	it("returns the default when input is undefined", () => {
+		expect(resolveBashTimeout(undefined)).toBe(DEFAULT_BASH_TIMEOUT_SECONDS)
+	})
+
+	it("returns the default when timeout is undefined", () => {
+		expect(resolveBashTimeout({})).toBe(DEFAULT_BASH_TIMEOUT_SECONDS)
+	})
+
+	it("returns the default when timeout is null", () => {
+		// RPC-decoded inputs commonly represent omitted fields as null;
+		// treat that as "not set" so the fallback applies.
+		expect(resolveBashTimeout({ timeout: null })).toBe(DEFAULT_BASH_TIMEOUT_SECONDS)
+	})
+
+	it("preserves an explicit positive timeout", () => {
+		expect(resolveBashTimeout({ timeout: 5 })).toBe(5)
+		expect(resolveBashTimeout({ timeout: 600 })).toBe(600)
+	})
+
+	it("preserves timeout=0 (upstream: no timeout)", () => {
+		// Upstream bash treats `timeout <= 0` as "no timeout". Honouring
+		// that contract is the whole point of "preserve explicit values" —
+		// a user who sets 0 is asking for an unbounded run, and we must
+		// not silently clamp it to the default.
+		expect(resolveBashTimeout({ timeout: 0 })).toBe(0)
+	})
+
+	it("accepts a custom default for tests / call sites", () => {
+		expect(resolveBashTimeout({}, 30)).toBe(30)
+		expect(resolveBashTimeout({ timeout: 7 }, 30)).toBe(7)
+	})
+})
+
+describe("bashDefaultTimeoutExtension", () => {
+	it("registers a tool_call handler", () => {
+		const pi = createMockPI()
+		bashDefaultTimeoutExtension(pi as unknown as PI)
+		expect(pi.handlers.tool_call).toBeDefined()
+		expect(pi.handlers.tool_call.length).toBe(1)
+	})
+
+	it("fills in the default timeout when input.timeout is undefined", () => {
+		const pi = createMockPI()
+		bashDefaultTimeoutExtension(pi as unknown as PI)
+		const event: BashEvent = {
+			toolName: "bash",
+			input: { command: "ls -la" },
+		}
+		fireToolCall(pi, event)
+		expect(event.input.timeout).toBe(DEFAULT_BASH_TIMEOUT_SECONDS)
+	})
+
+	it("fills in the default timeout when input.timeout is null", () => {
+		const pi = createMockPI()
+		bashDefaultTimeoutExtension(pi as unknown as PI)
+		const event: BashEvent = {
+			toolName: "bash",
+			input: { command: "ls -la", timeout: null },
+		}
+		fireToolCall(pi, event)
+		expect(event.input.timeout).toBe(DEFAULT_BASH_TIMEOUT_SECONDS)
+	})
+
+	it("preserves an explicit positive timeout", () => {
+		const pi = createMockPI()
+		bashDefaultTimeoutExtension(pi as unknown as PI)
+		const event: BashEvent = {
+			toolName: "bash",
+			input: { command: "slow-build", timeout: 600 },
+		}
+		fireToolCall(pi, event)
+		expect(event.input.timeout).toBe(600)
+	})
+
+	it("preserves an explicit timeout of 0 (no timeout upstream)", () => {
+		const pi = createMockPI()
+		bashDefaultTimeoutExtension(pi as unknown as PI)
+		const event: BashEvent = {
+			toolName: "bash",
+			input: { command: "long-poll", timeout: 0 },
+		}
+		fireToolCall(pi, event)
+		expect(event.input.timeout).toBe(0)
+	})
+
+	it("ignores non-bash tool calls", () => {
+		const pi = createMockPI()
+		bashDefaultTimeoutExtension(pi as unknown as PI)
+		const event: BashEvent = {
+			toolName: "read",
+			input: {},
+		}
+		fireToolCall(pi, event)
+		expect(event.input.timeout).toBeUndefined()
+	})
+
+	it("is a no-op when the resource is disabled", () => {
+		mockResourceEnabled = false
+		const pi = createMockPI()
+		bashDefaultTimeoutExtension(pi as unknown as PI)
+		const event: BashEvent = {
+			toolName: "bash",
+			input: { command: "ls" },
+		}
+		fireToolCall(pi, event)
+		expect(event.input.timeout).toBeUndefined()
+	})
+
+	it("mutates the input in place (not a copy)", () => {
+		// The upstream `tool_call` contract documents that later handlers
+		// see earlier mutations — i.e. the handler mutates the same object
+		// the upstream tool reads from. Guard against accidental
+		// reassignment to a new object.
+		const pi = createMockPI()
+		bashDefaultTimeoutExtension(pi as unknown as PI)
+		const input: { command: string; timeout?: number } = { command: "ls" }
+		const event: BashEvent = { toolName: "bash", input }
+		fireToolCall(pi, event)
+		expect(input.timeout).toBe(DEFAULT_BASH_TIMEOUT_SECONDS)
+		expect(event.input).toBe(input)
+	})
+})
+
+describe("BASH_DEFAULT_TIMEOUT_RESOURCE_ID", () => {
+	it("matches the resource registered in definitions.ts", () => {
+		// Guard against typos that would silently disable the toggle:
+		// changing one without the other breaks /resources UI wiring.
+		expect(BASH_DEFAULT_TIMEOUT_RESOURCE_ID).toBe("extensions.bash-default-timeout")
+	})
+})

--- a/src/extensions/bash-default-timeout.ts
+++ b/src/extensions/bash-default-timeout.ts
@@ -64,11 +64,10 @@ export default function bashDefaultTimeoutExtension(pi: ExtensionAPI): void {
 		if (!isResourceEnabled(BASH_DEFAULT_TIMEOUT_RESOURCE_ID)) return
 
 		const bashEvent = event as BashToolCallEvent
-		// Only mutate when the caller did not supply a timeout. An
-		// explicit value (including 0, which means "no timeout"
-		// upstream) is preserved as-is.
-		if (bashEvent.input.timeout === undefined || bashEvent.input.timeout === null) {
-			bashEvent.input.timeout = DEFAULT_BASH_TIMEOUT_SECONDS
-		}
+		// Delegate to the pure helper so the "not set" rules (undefined
+		// / null) and the default value live in one place. An explicit
+		// value (including 0, which upstream treats as "no timeout")
+		// is preserved as-is.
+		bashEvent.input.timeout = resolveBashTimeout(bashEvent.input)
 	})
 }

--- a/src/extensions/bash-default-timeout.ts
+++ b/src/extensions/bash-default-timeout.ts
@@ -1,0 +1,74 @@
+/**
+ * Bash default-timeout extension
+ *
+ * The upstream bash tool treats `timeout` as optional: when the LLM omits
+ * it, the command runs without any upper bound and can hang a session
+ * indefinitely on a misbehaving command (interactive prompts, broken
+ * pipes, network mounts, etc.).
+ *
+ * This extension fills in a default timeout (`DEFAULT_BASH_TIMEOUT_SECONDS`,
+ * currently 120s) whenever the bash tool is called without one, so every
+ * bash invocation has a deterministic upper bound. Explicit user-provided
+ * timeouts are preserved — the extension only acts when the field is
+ * absent.
+ *
+ * Implementation layer: extension hook on the upstream `tool_call` event,
+ * which the upstream runtime documents as having a mutable `event.input`
+ * ("Mutate it in place to patch tool arguments before execution. Later
+ * `tool_call` handlers see earlier mutations."). This is the lightest
+ * layer that satisfies the requirement without forking or patching the
+ * upstream bash tool.
+ *
+ * Toggleable from the /resources UI via the `extensions.bash-default-timeout`
+ * resource so users who want unbounded bash calls can opt out. When
+ * disabled, the extension is a no-op.
+ */
+
+import type { BashToolCallEvent, ExtensionAPI } from "@earendil-works/pi-coding-agent"
+import { isResourceEnabled } from "../resources/store.js"
+
+/** Resource id mirrored in `src/resources/definitions.ts`. */
+export const BASH_DEFAULT_TIMEOUT_RESOURCE_ID = "extensions.bash-default-timeout"
+
+/** Default applied when the bash tool is invoked without an explicit
+ *  timeout. Kept as a named export so tests and tools can reference it
+ *  without duplicating the literal. */
+export const DEFAULT_BASH_TIMEOUT_SECONDS = 120
+
+/**
+ * Pure helper: returns the timeout (in seconds) that should be used for a
+ * given bash `input` object, defaulting to `DEFAULT_BASH_TIMEOUT_SECONDS`
+ * when the caller did not provide one.
+ *
+ * Treats both `undefined` and `null` as "not set" so JSON-decoded RPC
+ * inputs (where omitted fields often arrive as `null`) get the same
+ * fallback as in-process objects. An explicit `0` is preserved: upstream
+ * treats `timeout <= 0` as "no timeout", so we honour that contract
+ * rather than overriding it with the default.
+ */
+export function resolveBashTimeout(
+	input: { timeout?: number | null } | undefined,
+	defaultSeconds: number = DEFAULT_BASH_TIMEOUT_SECONDS,
+): number {
+	if (!input) return defaultSeconds
+	const explicit = input.timeout
+	if (explicit === undefined || explicit === null) return defaultSeconds
+	return explicit
+}
+
+export default function bashDefaultTimeoutExtension(pi: ExtensionAPI): void {
+	pi.on("tool_call", (event) => {
+		if (event.toolName !== "bash") return
+		// Dynamic toggle: a user disabling this from /resources turns the
+		// extension into a no-op immediately, with no restart required.
+		if (!isResourceEnabled(BASH_DEFAULT_TIMEOUT_RESOURCE_ID)) return
+
+		const bashEvent = event as BashToolCallEvent
+		// Only mutate when the caller did not supply a timeout. An
+		// explicit value (including 0, which means "no timeout"
+		// upstream) is preserved as-is.
+		if (bashEvent.input.timeout === undefined || bashEvent.input.timeout === null) {
+			bashEvent.input.timeout = DEFAULT_BASH_TIMEOUT_SECONDS
+		}
+	})
+}

--- a/src/resources/definitions.ts
+++ b/src/resources/definitions.ts
@@ -69,6 +69,14 @@ export const STATIC_RESOURCE_DEFINITIONS: readonly ResourceDefinition[] = [
 		defaultEnabled: true,
 	},
 	{
+		id: "extensions.bash-default-timeout",
+		kind: "extensions",
+		label: "Bash default timeout",
+		description:
+			"Apply a 120s default timeout to every bash command when none is supplied, so misbehaving commands cannot hang a session indefinitely.",
+		defaultEnabled: true,
+	},
+	{
 		id: "extensions.claude-code-hook-adapter",
 		kind: "extensions",
 		label: "Claude Code hook adapter",

--- a/src/resources/definitions.ts
+++ b/src/resources/definitions.ts
@@ -1,3 +1,4 @@
+import { DEFAULT_BASH_TIMEOUT_SECONDS } from "../extensions/bash-default-timeout.js"
 import { CLAUDE_CODE_SKILLS_RESOURCE_ID } from "../extensions/claude-code-skills/definition.js"
 import { PI_PACKAGE_LOOKUP_RESOURCE_ID } from "../extensions/pi-package-lookup/index.js"
 import { discoverBashHookResources } from "./bash-hook-discovery.js"
@@ -72,8 +73,7 @@ export const STATIC_RESOURCE_DEFINITIONS: readonly ResourceDefinition[] = [
 		id: "extensions.bash-default-timeout",
 		kind: "extensions",
 		label: "Bash default timeout",
-		description:
-			"Apply a 120s default timeout to every bash command when none is supplied, so misbehaving commands cannot hang a session indefinitely.",
+		description: `Apply a ${DEFAULT_BASH_TIMEOUT_SECONDS}s default timeout to every bash command when none is supplied, so misbehaving commands cannot hang a session indefinitely.`,
 		defaultEnabled: true,
 	},
 	{


### PR DESCRIPTION
## Linked issue

<!-- Per user direction: no issue link for this PR. -->

## What does this PR do?

The upstream bash tool treats `timeout` as optional, so commands invoked without an explicit timeout run unbounded and can hang a session indefinitely on misbehaving commands (interactive prompts, broken pipes, network mounts, etc.).

This PR adds a new `bash-default-timeout` extension that fills in a **120s default timeout** for every bash invocation that does not supply one, so every bash command has a deterministic upper bound.

### Implementation

- **Layer:** extension hook on the upstream `tool_call` event (the lightest layer that fits; no upstream patch or fork). The runtime documents `event.input` as mutable — the handler fills in `timeout = 120` when absent.
- **Preserves explicit values:** an explicit `timeout` (including `0`, which upstream treats as "no timeout" via `timeout <= 0`) is passed through unchanged.
- **Handles null:** treats `timeout: null` (common in RPC-decoded inputs) the same as `undefined`.
- **Toggleable:** registered as the `extensions.bash-default-timeout` resource (`defaultEnabled: true`). The handler consults the resource store dynamically on every bash call, so `/resources` toggle takes effect immediately with no restart.
- **No other tools affected:** only `tool_call` events with `toolName === "bash"` are inspected.

### Files

- `src/extensions/bash-default-timeout.ts` — new extension + exported `resolveBashTimeout` helper + `DEFAULT_BASH_TIMEOUT_SECONDS = 120` constant
- `src/extensions/bash-default-timeout.test.ts` — 15 new co-located tests
- `src/cli.ts` — register the extension alongside the other always-on `tool_call` extensions
- `src/resources/definitions.ts` — new `extensions.bash-default-timeout` resource entry

### Verification

- `pnpm run check` (lint + typecheck): clean
- New tests: 15/15 pass
- Adjacent test suites (`bash-tool-guard`, `resources/definitions`): 153/153 still pass

## Checklist

- [x] I have read CONTRIBUTING.md and agree to the CLA
- [ ] This PR links to an open issue above — *skipped per user direction*
- [x] Tests pass locally (`pnpm run test` for the new file; full suite green)
- [x] Lint passes (`pnpm run check`)
- [x] Documentation updated if behavior changed — new resource entry includes a description; no other docs affected
