### PR TITLE
fix(ollama): preserve researcher role in augmentation

### DIFF
--- a/src/ollama.test.ts
+++ b/src/ollama.test.ts
@@ -871,6 +871,7 @@ describe("augmentModelRolesWithOllama — role pool augmentation", () => {
 		orchestrator: "anthropic/claude-opus-4",
 		planner: "anthropic/claude-sonnet-4",
 		judge: "anthropic/claude-sonnet-4",
+		researcher: "anthropic/claude-sonnet-4",
 		builder: ["anthropic/claude-sonnet-4", "openai/gpt-5"],
 		reviewer: "anthropic/claude-sonnet-4",
 		explorer: ["openai/gpt-5-mini"],
@@ -907,11 +908,12 @@ describe("augmentModelRolesWithOllama — role pool augmentation", () => {
 		expect(result.builder).toContain("ollama/qwen2:70b")
 	})
 
-	it("never touches orchestrator, planner, or judge", () => {
+	it("never touches orchestrator, planner, judge, or researcher", () => {
 		const result = augmentModelRolesWithOllama(baseRoles, ollamaModels)
 		expect(result.orchestrator).toBe("anthropic/claude-opus-4")
 		expect(result.planner).toBe("anthropic/claude-sonnet-4")
 		expect(result.judge).toBe("anthropic/claude-sonnet-4")
+		expect(result.researcher).toBe("anthropic/claude-sonnet-4")
 	})
 
 	it("does not mutate the input roles object", () => {

--- a/src/ollama.ts
+++ b/src/ollama.ts
@@ -459,8 +459,10 @@ function refForOllamaModel(model: PiModelConfig | OllamaModel): string {
 /**
  * Add discovered Ollama models to the explorer / reviewer / builder role pools.
  * Returns a fresh ModelRoles object — the input is not mutated. Orchestrator,
- * planner, and judge are intentionally left untouched so Ollama never displaces
- * the main agent loop.
+ * planner, judge, and researcher are intentionally left untouched so Ollama
+ * never displaces the main agent loop or the research role (research models
+ * tend to be proprietary web-search wrappers, not something a local Ollama
+ * instance should be augmenting).
  */
 export function augmentModelRolesWithOllama(
 	roles: ModelRoles,
@@ -472,6 +474,7 @@ export function augmentModelRolesWithOllama(
 		orchestrator: roles.orchestrator,
 		planner: roles.planner,
 		judge: roles.judge,
+		researcher: roles.researcher,
 		builder: roles.builder,
 		reviewer: roles.reviewer,
 		explorer: roles.explorer,


### PR DESCRIPTION
## Problem

CI on `master` has been red since #640 merged (`4536c1fe`), with every
subsequent push failing the same typecheck:

```
src/ollama.test.ts(870,8): error TS2741: Property 'researcher' is missing
  in type '{...}' but required in type 'ModelRoles'.

src/ollama.ts(471,8): error TS2741: Property 'researcher' is missing
  in type '{...}' but required in type 'ModelRoles'.
```

Failing runs:
- `27948159403` (CI on `4536c1fe`)
- `27948159497` (Canary on `4536c1fe`)
- `27948518161` (CI on `96f29ccd`)
- `27948518162` (Canary on `96f29ccd`)

## Root cause

#640 was branched from `63f62f44`, a master SHA **7 commits behind**
PR-level `baseRefOid`. One of the 7 intervening commits — `4f2dc79e`
(merged by #603) — added the `researcher` role to `ModelRoles`. PR-level
typecheck ran against the stale base and reported 0 errors. Post-merge,
master's typecheck required the field, and the new ollama code that
constructed `ModelRoles` literals without `researcher` started failing.

This is an impossible-to-catch-at-PR-time gap: local `pnpm run typecheck`
on the branch was clean, and PR CI was green. The failure only became
visible when the merge commit landed on a master that had moved.

## Fix

Two surgical edits — researcher should be **passed through** (preserved
from input), consistent with the documented intent of
`augmentModelRolesWithOllama` to never touch `orchestrator`/`planner`/
`judge`. Researcher wasn't in the literal because it didn't exist when
the code was written; it's a delegable role that local Ollama models
are not appropriate substitutes for (research models tend to be
proprietary web-search wrappers).

| File | Change |
|---|---|
| `src/ollama.ts` | `+researcher: roles.researcher` in the new `ModelRoles` object; updated docstring |
| `src/ollama.test.ts` | `+researcher` in the `baseRoles` fixture; extended the "never touches..." assertion to cover researcher |

Total: **+8 / −3 across 2 files**. No new dependencies, no behavioral
change for existing callers — `researcher` was already correctly
populated by `DEFAULT_MODEL_ROLES` and the resolved singleton; this
just stops dropping it on the floor.

## Verification

```
$ pnpm run check
> biome check src/ scripts/        # Checked 813 files in 209ms. No fixes applied.
> tsc --noEmit                     # clean

$ pnpm exec vitest run src/ollama.test.ts src/extensions/orchestration/model-roles.test.ts
✓ src/extensions/orchestration/model-roles.test.ts  (49 tests)  7ms
✓ src/ollama.test.ts                                (72 tests)  540ms
Test Files  2 passed (2)
     Tests  121 passed (121)

$ pnpm exec vitest run src/extensions/orchestration/
Test Files  7 passed (7)
     Tests  260 passed (260)
```

## Process gap (separate, not in this PR)

To prevent the same class of bug — PR-level CI green, post-merge CI
red because the PR base is stale — I recommend:

1. **Branch protection**: Settings → Branches → `master` → enable
   "Require branches to be up to date before merging". This would have
   re-run CI against current master before the merge was allowed and
   surfaced the typecheck error.
2. **Trigger `master-checks` on PRs**: the `master-checks` job in
   `.github/workflows/ci.yml` is currently gated on `push` only. Adding
   `pull_request` to its `if` would mirror the post-merge environment
   in the PR check.

Happy to send a follow-up PR for either — flagged here rather than
bundled to keep this fix focused.

## References

- Original PR introducing the regression: #640
- PR that added `researcher` to `ModelRoles`: #603
