### PR TITLE
fix(require-linked-issue): allow jira tickets and links

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,6 +1,6 @@
 ## Linked issue
 
-Closes #
+Closes
 
 <!-- Every PR must link to an existing issue or a ticket. PRs without a link will not be reviewed.
      Prefix with Closes / Fixes / Resolves and follow it with an issue or a ticket -->

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -2,14 +2,15 @@
 
 Closes #
 
-<!-- Every PR must link to an existing issue. PRs without a linked issue will not be reviewed.
-     Use one of: Closes #N / Fixes #N / Resolves #N -->
+<!-- Every PR must link to an existing issue or a ticket. PRs without a link will not be reviewed.
+     Prefix with Closes / Fixes / Resolves and follow it with an issue or a ticket -->
 
 ## What does this PR do?
 
 <!-- Brief description of the change and why it's needed. -->
 
 ## Checklist
+
 
 - [ ] I have read [CONTRIBUTING.md](../CONTRIBUTING.md) and agree to the CLA
 - [ ] This PR links to an open issue above

--- a/.github/workflows/require-linked-issue.yml
+++ b/.github/workflows/require-linked-issue.yml
@@ -13,9 +13,9 @@ jobs:
         env:
           PR_BODY: ${{ github.event.pull_request.body }}
         run: |
-          if ! echo "$PR_BODY" | grep -iE "(closes|fixes|resolves) #[0-9]+" > /dev/null; then
+          if ! echo "$PR_BODY" | grep -iE "(closes|fixes|resolves)\s+\S+" > /dev/null; then
             echo "❌ No linked issue found in PR description."
-            echo "Add one of: 'Closes #N', 'Fixes #N', or 'Resolves #N'"
+            echo "Add a 'Closes/Fixes/Resolves' line referencing an issue or a ticket."
             exit 1
           fi
           echo "✅ Linked issue found."


### PR DESCRIPTION
## Linked issue

Closes 

<!-- Every PR must link to an existing issue. PRs without a linked issue will not be reviewed.
     Use one of: Closes #N / Fixes #N / Resolves #N -->

## What does this PR do?

Instead of requiring every PR to have a `Closes #N` - allow any string. So `Closes LLM-1000` or `Closes https://jira.com/LLM-1000` also pass.
## Checklist

- [ ] I have read [CONTRIBUTING.md](../CONTRIBUTING.md) and agree to the CLA
- [ ] This PR links to an open issue above
- [ ] Tests pass locally (`pnpm run test`)
- [ ] Lint passes (`pnpm run check`)
- [ ] Documentation updated if behavior changed
