### PR TITLE
Add edit-run cycle and thinking-only turn detectors

### DIFF
--- a/src/extensions/exploration-guard.test.ts
+++ b/src/extensions/exploration-guard.test.ts
@@ -78,11 +78,18 @@ describe("Read-only turn counting", () => {
 		expect(guard.getConsecutiveReadOnlyTurns()).toBe(0)
 	})
 
-	it("resets streak on a no-tool turn", () => {
+	it("preserves the read-only streak across a no-tool turn (no-tool turns are neutral)", () => {
+		// Behavior change: previously a no-tool turn reset the read-only counter
+		// to 0. After the thinking-only detector was added, no-tool turns are
+		// neutral for the read-only streak — the model might alternate between
+		// exploration and reasoning, and resetting on each reasoning turn would
+		// hide the exploration stretch from the read-only detector.
 		const guard = createGuard()
 		for (let i = 0; i < 3; i++) simulateReadTurn(guard)
+		expect(guard.getConsecutiveReadOnlyTurns()).toBe(3)
 		simulateNoToolTurn(guard)
-		expect(guard.getConsecutiveReadOnlyTurns()).toBe(0)
+		expect(guard.getConsecutiveReadOnlyTurns()).toBe(3)
+		expect(guard.getConsecutiveNoToolTurns()).toBe(1)
 	})
 
 	it("resets streak on a mixed read+write turn", () => {
@@ -92,10 +99,12 @@ describe("Read-only turn counting", () => {
 		expect(guard.getConsecutiveReadOnlyTurns()).toBe(0)
 	})
 
-	it("does not increment on the first tool-less turn", () => {
+	it("does not increment the read-only counter on a tool-less turn", () => {
 		const guard = createGuard()
 		simulateNoToolTurn(guard)
 		expect(guard.getConsecutiveReadOnlyTurns()).toBe(0)
+		// But the no-tool counter itself has advanced.
+		expect(guard.getConsecutiveNoToolTurns()).toBe(1)
 	})
 
 	it("resets streak on a neutral tool turn", () => {
@@ -272,6 +281,214 @@ describe("Threshold triggers", () => {
 		}
 		expect(steers).toHaveLength(0) // streak only at 4, not yet at 5
 		expect(guard.getConsecutiveReadOnlyTurns()).toBe(4)
+	})
+})
+
+describe("No-tool turn detection (thinking-only detector)", () => {
+	it("increments the no-tool counter on consecutive no-tool turns", () => {
+		const guard = createGuard()
+		expect(guard.getConsecutiveNoToolTurns()).toBe(0)
+		simulateNoToolTurn(guard)
+		expect(guard.getConsecutiveNoToolTurns()).toBe(1)
+		simulateNoToolTurn(guard)
+		expect(guard.getConsecutiveNoToolTurns()).toBe(2)
+		simulateNoToolTurn(guard)
+		expect(guard.getConsecutiveNoToolTurns()).toBe(3)
+	})
+
+	it("emits a warning steer at the default no-tool threshold (3)", () => {
+		const guard = createGuard()
+		const steers: string[] = []
+		for (let i = 0; i < 2; i++) {
+			guard.turnStart()
+			guard.turnEnd((text) => steers.push(text))
+		}
+		expect(steers).toHaveLength(0)
+
+		// 3rd no-tool turn triggers warning
+		guard.turnStart()
+		guard.turnEnd((text) => steers.push(text))
+		expect(steers).toHaveLength(1)
+		expect(steers[0]).toContain("Exploration guard")
+		expect(steers[0]).toContain("3 consecutive turns with no tool calls")
+		expect(steers[0]).toContain("Reasoning without acting does not make progress")
+	})
+
+	it("emits a mandatory steer at the default no-tool threshold (5) and resets the counter", () => {
+		const guard = createGuard()
+		const steers: string[] = []
+		for (let i = 0; i < 5; i++) {
+			guard.turnStart()
+			guard.turnEnd((text) => steers.push(text))
+		}
+		expect(steers).toHaveLength(2)
+		expect(steers[0]).toContain("3 consecutive turns with no tool calls")
+		expect(steers[1]).toContain("5 consecutive turns with no tool calls")
+		expect(steers[1]).toContain("You must use a tool this turn")
+		// Counter resets after the mandatory steer so the model gets a fresh budget.
+		expect(guard.getConsecutiveNoToolTurns()).toBe(0)
+	})
+
+	it("uses custom no-tool thresholds", () => {
+		const guard = createGuard({ noToolWarnThreshold: 2, noToolSteerThreshold: 4 })
+		const steers: string[] = []
+
+		guard.turnStart()
+		guard.turnEnd((text) => steers.push(text))
+		expect(steers).toHaveLength(0)
+
+		guard.turnStart()
+		guard.turnEnd((text) => steers.push(text))
+		expect(steers).toHaveLength(1)
+		expect(steers[0]).toContain("2 consecutive turns with no tool calls")
+
+		guard.turnStart()
+		guard.turnEnd((text) => steers.push(text))
+		expect(steers).toHaveLength(1)
+
+		guard.turnStart()
+		guard.turnEnd((text) => steers.push(text))
+		expect(steers).toHaveLength(2)
+		expect(steers[1]).toContain("4 consecutive turns with no tool calls")
+	})
+
+	it("each threshold fires once per streak; mandatory steer resets the counter", () => {
+		// 3 turns → warning steer (no reset, counter stays at 3)
+		// 5 turns → mandatory steer + reset (counter back to 0)
+		// 3 more turns → warning steer again in the new streak
+		const guard = createGuard()
+		const steers: string[] = []
+		const noToolTurn = () => {
+			guard.turnStart()
+			guard.turnEnd((text) => steers.push(text))
+		}
+
+		for (let i = 0; i < 5; i++) noToolTurn()
+		expect(steers).toHaveLength(2)
+		expect(steers[0]).toContain("3 consecutive turns with no tool calls")
+		expect(steers[1]).toContain("5 consecutive turns with no tool calls")
+		expect(guard.getConsecutiveNoToolTurns()).toBe(0)
+
+		for (let i = 0; i < 3; i++) noToolTurn()
+		expect(steers).toHaveLength(3)
+		expect(steers[2]).toContain("3 consecutive turns with no tool calls")
+	})
+
+	it("a turn with any tool call resets the no-tool counter", () => {
+		const guard = createGuard()
+		simulateNoToolTurn(guard)
+		simulateNoToolTurn(guard)
+		expect(guard.getConsecutiveNoToolTurns()).toBe(2)
+
+		simulateReadTurn(guard)
+		expect(guard.getConsecutiveNoToolTurns()).toBe(0)
+
+		simulateNoToolTurn(guard)
+		expect(guard.getConsecutiveNoToolTurns()).toBe(1)
+	})
+
+	it("a write turn also resets the no-tool counter", () => {
+		const guard = createGuard()
+		simulateNoToolTurn(guard)
+		simulateNoToolTurn(guard)
+		expect(guard.getConsecutiveNoToolTurns()).toBe(2)
+
+		simulateWriteTurn(guard)
+		expect(guard.getConsecutiveNoToolTurns()).toBe(0)
+	})
+
+	it("a neutral-only turn also resets the no-tool counter", () => {
+		const guard = createGuard()
+		simulateNoToolTurn(guard)
+		simulateNoToolTurn(guard)
+		expect(guard.getConsecutiveNoToolTurns()).toBe(2)
+
+		simulateNeutralTurn(guard)
+		expect(guard.getConsecutiveNoToolTurns()).toBe(0)
+	})
+
+	it("does not trigger when isEnabled returns false", () => {
+		const guard = createGuard({ isEnabled: () => false })
+		const steers: string[] = []
+		for (let i = 0; i < 6; i++) {
+			guard.turnStart()
+			guard.turnEnd((text) => steers.push(text))
+		}
+		expect(steers).toHaveLength(0)
+		expect(guard.getConsecutiveNoToolTurns()).toBe(0)
+	})
+
+	it("resets the no-tool counter when isEnabled becomes false mid-streak", () => {
+		let enabled = true
+		const guard = createGuard({ isEnabled: () => enabled })
+
+		guard.turnStart()
+		guard.turnEnd(() => {})
+		guard.turnStart()
+		guard.turnEnd(() => {})
+		expect(guard.getConsecutiveNoToolTurns()).toBe(2)
+
+		enabled = false
+		guard.turnStart()
+		guard.turnEnd(() => {})
+		// The counter resets because the guard is disabled — so on re-enable
+		// the model doesn't immediately re-trigger.
+		expect(guard.getConsecutiveNoToolTurns()).toBe(0)
+
+		enabled = true
+		const steers: string[] = []
+		for (let i = 0; i < 3; i++) {
+			guard.turnStart()
+			guard.turnEnd((text) => steers.push(text))
+		}
+		// Should fire on the 3rd turn (fresh streak after re-enable).
+		expect(steers).toHaveLength(1)
+		expect(steers[0]).toContain("3 consecutive turns with no tool calls")
+	})
+
+	it("reset() zeros the no-tool counter", () => {
+		const guard = createGuard()
+		for (let i = 0; i < 3; i++) simulateNoToolTurn(guard)
+		expect(guard.getConsecutiveNoToolTurns()).toBe(3)
+		guard.reset()
+		expect(guard.getConsecutiveNoToolTurns()).toBe(0)
+	})
+
+	it("does not affect the read-only counter when no-tool steers fire", () => {
+		// Scenario: model alternates read-only turns and no-tool turns.
+		// Neither streak should interfere with the other.
+		const guard = createGuard()
+		const steers: string[] = []
+		const readOnlyTurn = () => {
+			guard.turnStart()
+			guard.recordToolCall("read")
+			guard.turnEnd((text) => steers.push(text))
+		}
+		const noToolTurn = () => {
+			guard.turnStart()
+			guard.turnEnd((text) => steers.push(text))
+		}
+
+		// 4 read-only turns, then a no-tool turn — read-only stays at 4.
+		for (let i = 0; i < 4; i++) readOnlyTurn()
+		expect(guard.getConsecutiveReadOnlyTurns()).toBe(4)
+		expect(guard.getConsecutiveNoToolTurns()).toBe(0)
+		noToolTurn()
+		expect(guard.getConsecutiveReadOnlyTurns()).toBe(4)
+		expect(guard.getConsecutiveNoToolTurns()).toBe(1)
+
+		// Another no-tool turn — read-only still at 4, no-tool at 2.
+		noToolTurn()
+		expect(guard.getConsecutiveReadOnlyTurns()).toBe(4)
+		expect(guard.getConsecutiveNoToolTurns()).toBe(2)
+
+		// Another read-only turn — read-only now at 5 (hypothesis threshold),
+		// no-tool resets to 0.
+		readOnlyTurn()
+		expect(steers).toHaveLength(1)
+		expect(steers[0]).toContain("5 consecutive read-only turns")
+		expect(guard.getConsecutiveReadOnlyTurns()).toBe(5)
+		expect(guard.getConsecutiveNoToolTurns()).toBe(0)
 	})
 })
 

--- a/src/extensions/exploration-guard.test.ts
+++ b/src/extensions/exploration-guard.test.ts
@@ -560,68 +560,70 @@ describe("STEER_MESSAGE_TYPE", () => {
 })
 
 describe("Subagent terminate behavior", () => {
-	// In subagent mode, the guard does two things differently:
-	//   1. The mandatory steer is always the strong wording (regardless of
-	//      subagent status) — subagents AND main agents get the new message.
-	//   2. After the mandatory steer, the guard sets subagentStuck=true so
-	//      the next tool_call can be blocked, forcing a text response.
-	// Main agents keep the steer-only behaviour (subagentStuck is never set).
+	// When a subagent hits the no-tool mandatory threshold:
+	//   1. It receives a steer asking for a plain-text summary.
+	//   2. subagentAbortPending is set to true.
+	//   3. On the NEXT turn_end (one turn later), pi.abort() is called.
+	// This gives the subagent exactly one turn to produce a useful summary
+	// that becomes the output the orchestrator receives.
+	// Main agents keep steer-only behaviour (abort is never triggered).
 
-	it("isSubagentStuck() returns false by default (main agent)", () => {
+	it("isSubagentAbortPending() returns false by default", () => {
 		const guard = createGuard()
-		expect(guard.isSubagentStuck()).toBe(false)
+		expect(guard.isSubagentAbortPending()).toBe(false)
 	})
 
-	it("isSubagentStuck() stays false for main agent after mandatory threshold", () => {
+	it("isSubagentAbortPending() stays false for main agent after mandatory threshold", () => {
 		const guard = createGuard()
 		for (let i = 0; i < 5; i++) {
 			guard.turnStart()
 			guard.turnEnd(() => {})
 		}
-		expect(guard.isSubagentStuck()).toBe(false)
+		expect(guard.isSubagentAbortPending()).toBe(false)
 	})
 
-	it("isSubagentStuck() flips true after mandatory threshold for subagents", () => {
+	it("isSubagentAbortPending() flips true after mandatory threshold for subagents", () => {
 		const guard = createGuard({ isSubagent: () => true })
 		for (let i = 0; i < 5; i++) {
 			guard.turnStart()
 			guard.turnEnd(() => {})
 		}
-		expect(guard.isSubagentStuck()).toBe(true)
+		expect(guard.isSubagentAbortPending()).toBe(true)
 	})
 
-	it("isSubagentStuck() is evaluated per-event (not cached at construction)", () => {
+	it("isSubagentAbortPending() is evaluated per-event (not cached at construction)", () => {
 		let isSub = false
 		const guard = createGuard({ isSubagent: () => isSub })
 		for (let i = 0; i < 5; i++) {
 			guard.turnStart()
 			guard.turnEnd(() => {})
 		}
-		expect(guard.isSubagentStuck()).toBe(false)
+		expect(guard.isSubagentAbortPending()).toBe(false)
 
 		isSub = true
 		for (let i = 0; i < 5; i++) {
 			guard.turnStart()
 			guard.turnEnd(() => {})
 		}
-		expect(guard.isSubagentStuck()).toBe(true)
+		expect(guard.isSubagentAbortPending()).toBe(true)
 	})
 
-	it("reset() clears subagentStuck", () => {
+	it("reset() clears subagentAbortPending", () => {
 		const guard = createGuard({ isSubagent: () => true })
 		for (let i = 0; i < 5; i++) {
 			guard.turnStart()
 			guard.turnEnd(() => {})
 		}
-		expect(guard.isSubagentStuck()).toBe(true)
+		expect(guard.isSubagentAbortPending()).toBe(true)
 		guard.reset()
-		expect(guard.isSubagentStuck()).toBe(false)
+		expect(guard.isSubagentAbortPending()).toBe(false)
 	})
 
-	it("subagent uses strong wording; main agent uses original wording", () => {
-		// Strong wording is only for subagents. Main agent gets the original
-		// mandatory message — the strong wording caused main-agent models
-		// to think harder instead of acting, making thinking loops worse.
+	it("subagent steer requests a structured summary; main agent gets original wording", () => {
+		// The subagent steer explicitly asks for what was done, what is
+		// incomplete, and any blockers — so the orchestrator gets useful output.
+		// Main agent keeps the original wording (stronger messages cause
+		// models to think harder instead of acting).
 		const subGuard = createGuard({ isSubagent: () => true })
 		const mainGuard = createGuard()
 		const subSteers: string[] = []
@@ -632,10 +634,11 @@ describe("Subagent terminate behavior", () => {
 			mainGuard.turnStart()
 			mainGuard.turnEnd((t) => mainSteers.push(t))
 		}
-		// Subagent gets the strong wording with termination warning.
-		expect(subSteers[1]).toContain("respond with plain text")
+		// Subagent steer: asks for a summary and warns about termination.
 		expect(subSteers[1]).toContain("terminated")
-		// Main agent gets the original wording.
+		expect(subSteers[1]).toContain("what you completed")
+		expect(subSteers[1]).toContain("orchestrator")
+		// Main agent: original wording, no termination language.
 		expect(mainSteers[1]).toContain("5 consecutive turns with no tool calls")
 		expect(mainSteers[1]).toContain("You must use a tool this turn")
 		expect(mainSteers[1]).not.toContain("terminated")

--- a/src/extensions/exploration-guard.test.ts
+++ b/src/extensions/exploration-guard.test.ts
@@ -323,8 +323,8 @@ describe("No-tool turn detection (thinking-only detector)", () => {
 		}
 		expect(steers).toHaveLength(2)
 		expect(steers[0]).toContain("3 consecutive turns with no tool calls")
-		expect(steers[1]).toContain("turn 5 with no tool calls")
-		expect(steers[1]).toContain("respond with plain text")
+		expect(steers[1]).toContain("5 consecutive turns with no tool calls")
+		expect(steers[1]).toContain("You must use a tool this turn")
 		// Counter resets after the mandatory steer so the model gets a fresh budget.
 		expect(guard.getConsecutiveNoToolTurns()).toBe(0)
 	})
@@ -349,7 +349,7 @@ describe("No-tool turn detection (thinking-only detector)", () => {
 		guard.turnStart()
 		guard.turnEnd((text) => steers.push(text))
 		expect(steers).toHaveLength(2)
-		expect(steers[1]).toContain("turn 4 with no tool calls")
+		expect(steers[1]).toContain("4 consecutive turns with no tool calls")
 	})
 
 	it("each threshold fires once per streak; mandatory steer resets the counter", () => {
@@ -366,7 +366,7 @@ describe("No-tool turn detection (thinking-only detector)", () => {
 		for (let i = 0; i < 5; i++) noToolTurn()
 		expect(steers).toHaveLength(2)
 		expect(steers[0]).toContain("3 consecutive turns with no tool calls")
-		expect(steers[1]).toContain("turn 5 with no tool calls")
+		expect(steers[1]).toContain("5 consecutive turns with no tool calls")
 		expect(guard.getConsecutiveNoToolTurns()).toBe(0)
 
 		for (let i = 0; i < 3; i++) noToolTurn()
@@ -618,9 +618,10 @@ describe("Subagent terminate behavior", () => {
 		expect(guard.isSubagentStuck()).toBe(false)
 	})
 
-	it("subagent mandatory steer uses the strong wording (same as main agent)", () => {
-		// The mandatory steer wording was strengthened for both modes —
-		// main agents get the strong wording but stay steer-only.
+	it("subagent uses strong wording; main agent uses original wording", () => {
+		// Strong wording is only for subagents. Main agent gets the original
+		// mandatory message — the strong wording caused main-agent models
+		// to think harder instead of acting, making thinking loops worse.
 		const subGuard = createGuard({ isSubagent: () => true })
 		const mainGuard = createGuard()
 		const subSteers: string[] = []
@@ -631,10 +632,12 @@ describe("Subagent terminate behavior", () => {
 			mainGuard.turnStart()
 			mainGuard.turnEnd((t) => mainSteers.push(t))
 		}
-		// Both should contain the strong-wording fragments.
+		// Subagent gets the strong wording with termination warning.
 		expect(subSteers[1]).toContain("respond with plain text")
 		expect(subSteers[1]).toContain("terminated")
-		expect(mainSteers[1]).toContain("respond with plain text")
-		expect(mainSteers[1]).toContain("terminated")
+		// Main agent gets the original wording.
+		expect(mainSteers[1]).toContain("5 consecutive turns with no tool calls")
+		expect(mainSteers[1]).toContain("You must use a tool this turn")
+		expect(mainSteers[1]).not.toContain("terminated")
 	})
 })

--- a/src/extensions/exploration-guard.test.ts
+++ b/src/extensions/exploration-guard.test.ts
@@ -323,8 +323,8 @@ describe("No-tool turn detection (thinking-only detector)", () => {
 		}
 		expect(steers).toHaveLength(2)
 		expect(steers[0]).toContain("3 consecutive turns with no tool calls")
-		expect(steers[1]).toContain("5 consecutive turns with no tool calls")
-		expect(steers[1]).toContain("You must use a tool this turn")
+		expect(steers[1]).toContain("turn 5 with no tool calls")
+		expect(steers[1]).toContain("respond with plain text")
 		// Counter resets after the mandatory steer so the model gets a fresh budget.
 		expect(guard.getConsecutiveNoToolTurns()).toBe(0)
 	})
@@ -349,7 +349,7 @@ describe("No-tool turn detection (thinking-only detector)", () => {
 		guard.turnStart()
 		guard.turnEnd((text) => steers.push(text))
 		expect(steers).toHaveLength(2)
-		expect(steers[1]).toContain("4 consecutive turns with no tool calls")
+		expect(steers[1]).toContain("turn 4 with no tool calls")
 	})
 
 	it("each threshold fires once per streak; mandatory steer resets the counter", () => {
@@ -366,7 +366,7 @@ describe("No-tool turn detection (thinking-only detector)", () => {
 		for (let i = 0; i < 5; i++) noToolTurn()
 		expect(steers).toHaveLength(2)
 		expect(steers[0]).toContain("3 consecutive turns with no tool calls")
-		expect(steers[1]).toContain("5 consecutive turns with no tool calls")
+		expect(steers[1]).toContain("turn 5 with no tool calls")
 		expect(guard.getConsecutiveNoToolTurns()).toBe(0)
 
 		for (let i = 0; i < 3; i++) noToolTurn()
@@ -556,5 +556,85 @@ describe("bash tool classification", () => {
 describe("STEER_MESSAGE_TYPE", () => {
 	it("has a stable custom type string", () => {
 		expect(STEER_MESSAGE_TYPE).toBe("exploration-guard-steer")
+	})
+})
+
+describe("Subagent terminate behavior", () => {
+	// In subagent mode, the guard does two things differently:
+	//   1. The mandatory steer is always the strong wording (regardless of
+	//      subagent status) — subagents AND main agents get the new message.
+	//   2. After the mandatory steer, the guard sets subagentStuck=true so
+	//      the next tool_call can be blocked, forcing a text response.
+	// Main agents keep the steer-only behaviour (subagentStuck is never set).
+
+	it("isSubagentStuck() returns false by default (main agent)", () => {
+		const guard = createGuard()
+		expect(guard.isSubagentStuck()).toBe(false)
+	})
+
+	it("isSubagentStuck() stays false for main agent after mandatory threshold", () => {
+		const guard = createGuard()
+		for (let i = 0; i < 5; i++) {
+			guard.turnStart()
+			guard.turnEnd(() => {})
+		}
+		expect(guard.isSubagentStuck()).toBe(false)
+	})
+
+	it("isSubagentStuck() flips true after mandatory threshold for subagents", () => {
+		const guard = createGuard({ isSubagent: () => true })
+		for (let i = 0; i < 5; i++) {
+			guard.turnStart()
+			guard.turnEnd(() => {})
+		}
+		expect(guard.isSubagentStuck()).toBe(true)
+	})
+
+	it("isSubagentStuck() is evaluated per-event (not cached at construction)", () => {
+		let isSub = false
+		const guard = createGuard({ isSubagent: () => isSub })
+		for (let i = 0; i < 5; i++) {
+			guard.turnStart()
+			guard.turnEnd(() => {})
+		}
+		expect(guard.isSubagentStuck()).toBe(false)
+
+		isSub = true
+		for (let i = 0; i < 5; i++) {
+			guard.turnStart()
+			guard.turnEnd(() => {})
+		}
+		expect(guard.isSubagentStuck()).toBe(true)
+	})
+
+	it("reset() clears subagentStuck", () => {
+		const guard = createGuard({ isSubagent: () => true })
+		for (let i = 0; i < 5; i++) {
+			guard.turnStart()
+			guard.turnEnd(() => {})
+		}
+		expect(guard.isSubagentStuck()).toBe(true)
+		guard.reset()
+		expect(guard.isSubagentStuck()).toBe(false)
+	})
+
+	it("subagent mandatory steer uses the strong wording (same as main agent)", () => {
+		// The mandatory steer wording was strengthened for both modes —
+		// main agents get the strong wording but stay steer-only.
+		const subGuard = createGuard({ isSubagent: () => true })
+		const mainGuard = createGuard()
+		const subSteers: string[] = []
+		const mainSteers: string[] = []
+		for (let i = 0; i < 5; i++) {
+			subGuard.turnStart()
+			subGuard.turnEnd((t) => subSteers.push(t))
+			mainGuard.turnStart()
+			mainGuard.turnEnd((t) => mainSteers.push(t))
+		}
+		// Both should contain the strong-wording fragments.
+		expect(subSteers[1]).toContain("respond with plain text")
+		expect(subSteers[1]).toContain("terminated")
+		expect(mainSteers[1]).toContain("respond with plain text")
+		expect(mainSteers[1]).toContain("terminated")
 	})
 })

--- a/src/extensions/exploration-guard.ts
+++ b/src/extensions/exploration-guard.ts
@@ -63,8 +63,17 @@ const NO_TOOL_MANDATORY_BASE =
 /** Stronger message for the mandatory steer — used both for subagents (where
  *  the next tool call will be blocked) and for main agents (where the
  *  previous wording was being ignored indefinitely on stuck tasks). */
-const NO_TOOL_MANDATORY_STRONG_BASE =
-	"Exploration guard (turn %d with no tool calls): you are stuck in a thinking loop. Further reasoning without action will not produce a different result — either call a tool this turn or respond with plain text explaining what you are doing. If the next turn also has no tool calls the conversation will be terminated."
+/**
+ * Steer sent to a stuck subagent before the abort fires.
+ * The subagent gets ONE more turn to produce a text response;
+ * that response is what the orchestrator will see as the subagent's output.
+ * Be explicit about what a useful summary contains.
+ */
+const NO_TOOL_SUBAGENT_ABORT_STEER =
+	"Exploration guard: this subagent has produced %d consecutive turns with no tool calls and will be terminated after this turn. " +
+	"Respond NOW with a plain-text summary covering: (1) what you were asked to do, " +
+	"(2) what you completed or changed, (3) what is still incomplete and why, " +
+	"(4) any key findings or blockers. Do not call any tools. This summary is the only output the orchestrator will receive."
 
 export const STEER_MESSAGE_TYPE = "exploration-guard-steer"
 
@@ -83,9 +92,10 @@ export class ExplorationGuard {
 	private currentTurnHasWriteTool = false
 	private currentTurnHasAnyTool = false
 	private currentTurnHasReadTool = false
-	/** When true (subagent only), the next tool_call should be blocked.
-	 *  Set when the mandatory no-tool steer fires; cleared on user input. */
-	private subagentStuck = false
+	/** When true (subagent only), the guard will call pi.abort() on the next
+	 *  turn_end. Set after the abort-steer fires; the subagent gets exactly
+	 *  one more turn to produce a text summary. Cleared on reset(). */
+	private subagentAbortPending = false
 
 	constructor(options: ExplorationGuardOptions = {}) {
 		this.readTools = options.readTools ?? new Set(DEFAULT_READ_TOOLS)
@@ -104,7 +114,7 @@ export class ExplorationGuard {
 		this.currentTurnHasWriteTool = false
 		this.currentTurnHasAnyTool = false
 		this.currentTurnHasReadTool = false
-		this.subagentStuck = false
+		this.subagentAbortPending = false
 	}
 
 	turnStart(): void {
@@ -142,18 +152,18 @@ export class ExplorationGuard {
 			this.consecutiveNoToolTurns++
 
 			if (this.consecutiveNoToolTurns === this.noToolSteerThreshold) {
-				// For subagents: use the strong wording and set the stuck flag
-				// so the next tool_call is blocked, forcing a text response.
-				// For main agents: use the original wording — the stronger
-				// message caused models to think harder instead of acting.
+				// Subagents: send a summary-request steer and schedule an abort on
+				// the next turn_end. The subagent gets one turn to produce a useful
+				// text summary; that text becomes the output the orchestrator sees.
+				// Main agents: original wording — stronger messages caused models
+				// to think harder instead of acting.
 				if (this.isSubagent()) {
-					sendSteer(NO_TOOL_MANDATORY_STRONG_BASE.replace("%d", String(this.noToolSteerThreshold)))
-					this.subagentStuck = true
+					sendSteer(NO_TOOL_SUBAGENT_ABORT_STEER.replace("%d", String(this.noToolSteerThreshold)))
+					this.subagentAbortPending = true
 				} else {
 					sendSteer(NO_TOOL_MANDATORY_BASE.replace("%d", String(this.noToolSteerThreshold)))
 				}
-				// Reset after the mandatory steer so the model gets a fresh
-				// budget rather than immediately re-triggering on the next turn.
+				// Reset the counter after the mandatory steer.
 				this.consecutiveNoToolTurns = 0
 			} else if (this.consecutiveNoToolTurns === this.noToolWarnThreshold) {
 				sendSteer(NO_TOOL_WARNING_BASE.replace("%d", String(this.noToolWarnThreshold)))
@@ -197,11 +207,11 @@ export class ExplorationGuard {
 		return this.consecutiveNoToolTurns
 	}
 
-	/** True when the guard has decided the agent (subagent) is stuck and
-	 *  the next tool call should be blocked to force a text response.
-	 *  Always false for main agents. Cleared on user input via reset(). */
-	isSubagentStuck(): boolean {
-		return this.subagentStuck
+	/** True when the guard has scheduled an abort for the next turn_end.
+	 *  Only set for subagents after the no-tool mandatory threshold fires.
+	 *  Always false for main agents. Cleared on reset(). */
+	isSubagentAbortPending(): boolean {
+		return this.subagentAbortPending
 	}
 }
 
@@ -257,22 +267,18 @@ export default function explorationGuardExtension(pi: ExtensionAPI, options?: Ex
 	pi.on("tool_call", (event) => {
 		if (!event.toolName) return
 		guard.recordToolCall(event.toolName)
-		// Subagent terminate: after the no-tool mandatory threshold fires,
-		// block the next tool call so the model is forced to respond with
-		// plain text. Without this, the steer is just another text injection
-		// the model ignores indefinitely (observed: 377 fires on a single task).
-		if (guard.isSubagentStuck()) {
-			return {
-				block: true,
-				reason:
-					"Exploration guard: subagent has had multiple consecutive no-tool turns. " +
-					"Respond with plain text (no tool call) explaining your plan or conclusion.",
-			}
-		}
 		return { block: false }
 	})
 
 	pi.on("turn_end", () => {
+		// If a subagent abort is pending, fire it NOW before processing the
+		// steer. The subagent already received the summary-request steer last
+		// turn; whatever it produced this turn becomes the orchestrator output.
+		if (guard.isSubagentAbortPending()) {
+			ctx?.abort()
+			return
+		}
+
 		guard.turnEnd((text) => {
 			pi.sendMessage(
 				{

--- a/src/extensions/exploration-guard.ts
+++ b/src/extensions/exploration-guard.ts
@@ -33,6 +33,10 @@ export interface ExplorationGuardOptions {
 	hypothesisThreshold?: number
 	/** Number of consecutive read-only turns before a mandatory steer is injected. Default: 8 */
 	steerThreshold?: number
+	/** Number of consecutive no-tool turns before a warning steer. Default: 3 */
+	noToolWarnThreshold?: number
+	/** Number of consecutive no-tool turns before a mandatory steer. Default: 5 */
+	noToolSteerThreshold?: number
 	/** Optional predicate to temporarily disable the guard (e.g., during plan mode). */
 	isEnabled?: () => boolean
 }
@@ -43,6 +47,12 @@ const HYPOTHESIS_REMINDER_BASE =
 const MANDATORY_STEER_BASE =
 	"Exploration guard: %d consecutive read-only turns. You must take a concrete action this turn: run a targeted test, make an edit, write a plan, or ask the user a question. Do not read further without a clear reason."
 
+const NO_TOOL_WARNING_BASE =
+	"Exploration guard: %d consecutive turns with no tool calls. Take action: write code, run a command, or ask the user. Reasoning without acting does not make progress."
+
+const NO_TOOL_MANDATORY_BASE =
+	"Exploration guard: %d consecutive turns with no tool calls. You must use a tool this turn. Summarize your plan and take one concrete action."
+
 export const STEER_MESSAGE_TYPE = "exploration-guard-steer"
 
 export class ExplorationGuard {
@@ -50,9 +60,12 @@ export class ExplorationGuard {
 	private readonly writeTools: Set<string>
 	private readonly hypothesisThreshold: number
 	private readonly steerThreshold: number
+	private readonly noToolWarnThreshold: number
+	private readonly noToolSteerThreshold: number
 	private readonly isEnabled: () => boolean
 
 	private consecutiveReadOnlyTurns = 0
+	private consecutiveNoToolTurns = 0
 	private currentTurnHasWriteTool = false
 	private currentTurnHasAnyTool = false
 	private currentTurnHasReadTool = false
@@ -62,11 +75,14 @@ export class ExplorationGuard {
 		this.writeTools = options.writeTools ?? new Set(DEFAULT_WRITE_TOOLS)
 		this.hypothesisThreshold = options.hypothesisThreshold ?? 5
 		this.steerThreshold = options.steerThreshold ?? 8
+		this.noToolWarnThreshold = options.noToolWarnThreshold ?? 3
+		this.noToolSteerThreshold = options.noToolSteerThreshold ?? 5
 		this.isEnabled = options.isEnabled ?? (() => true)
 	}
 
 	reset(): void {
 		this.consecutiveReadOnlyTurns = 0
+		this.consecutiveNoToolTurns = 0
 		this.currentTurnHasWriteTool = false
 		this.currentTurnHasAnyTool = false
 		this.currentTurnHasReadTool = false
@@ -90,16 +106,42 @@ export class ExplorationGuard {
 
 	turnEnd(sendSteer: (text: string) => void): void {
 		if (!this.isEnabled()) {
-			// Reset the streak while the guard is suppressed so it doesn't
+			// Reset both streaks while the guard is suppressed so they don't
 			// fire immediately when it becomes re-enabled (e.g. after scoping).
 			this.consecutiveReadOnlyTurns = 0
+			this.consecutiveNoToolTurns = 0
 			return
 		}
 
+		// No-tool turn: the model produced a response without calling any tools.
+		// Track separately from the read-only streak. Do NOT reset
+		// consecutiveReadOnlyTurns — a no-tool turn is neutral for that counter
+		// and resetting it would hide long exploration stretches broken up by
+		// occasional reasoning-only turns (which the thinking-only detector
+		// would then miss).
+		if (!this.currentTurnHasAnyTool) {
+			this.consecutiveNoToolTurns++
+
+			if (this.consecutiveNoToolTurns === this.noToolSteerThreshold) {
+				sendSteer(NO_TOOL_MANDATORY_BASE.replace("%d", String(this.noToolSteerThreshold)))
+				// Reset after the mandatory steer so the model gets a fresh
+				// budget rather than immediately re-triggering on the next turn.
+				this.consecutiveNoToolTurns = 0
+			} else if (this.consecutiveNoToolTurns === this.noToolWarnThreshold) {
+				sendSteer(NO_TOOL_WARNING_BASE.replace("%d", String(this.noToolWarnThreshold)))
+				// Don't reset yet — the model gets a chance to course-correct
+				// before the mandatory steer fires at noToolSteerThreshold.
+			}
+			return
+		}
+
+		// A turn with at least one tool call resets the no-tool counter.
+		this.consecutiveNoToolTurns = 0
+
 		// A turn is read-only only if it contains at least one read tool and none
-		// of them are write tools. Turns with no tools, with write tools, or with
-		// only neutral tools reset the streak.
-		if (!this.currentTurnHasAnyTool || this.currentTurnHasWriteTool || !this.currentTurnHasReadTool) {
+		// of them are write tools. Turns with write tools or with only neutral
+		// tools reset the streak.
+		if (this.currentTurnHasWriteTool || !this.currentTurnHasReadTool) {
 			this.consecutiveReadOnlyTurns = 0
 			return
 		}
@@ -121,6 +163,10 @@ export class ExplorationGuard {
 
 	getConsecutiveReadOnlyTurns(): number {
 		return this.consecutiveReadOnlyTurns
+	}
+
+	getConsecutiveNoToolTurns(): number {
+		return this.consecutiveNoToolTurns
 	}
 }
 

--- a/src/extensions/exploration-guard.ts
+++ b/src/extensions/exploration-guard.ts
@@ -1,4 +1,5 @@
 import type { ExtensionAPI, ExtensionContext, InputEvent } from "@earendil-works/pi-coding-agent"
+import { isAgentWorker } from "./agent-worker-context.js"
 import { getPermissionMode } from "./permissions/mode-controller.js"
 
 export const DEFAULT_READ_TOOLS = new Set([
@@ -39,6 +40,12 @@ export interface ExplorationGuardOptions {
 	noToolSteerThreshold?: number
 	/** Optional predicate to temporarily disable the guard (e.g., during plan mode). */
 	isEnabled?: () => boolean
+	/** Predicate evaluated at event time to determine whether the agent
+	 *  is a subagent. Subagents terminate (block tool calls) after the
+	 *  no-tool mandatory threshold; main agents keep steer-only behaviour.
+	 *  Called per-event so AsyncLocalStorage context is respected.
+	 *  Default: always false. */
+	isSubagent?: () => boolean
 }
 
 const HYPOTHESIS_REMINDER_BASE =
@@ -53,6 +60,12 @@ const NO_TOOL_WARNING_BASE =
 const NO_TOOL_MANDATORY_BASE =
 	"Exploration guard: %d consecutive turns with no tool calls. You must use a tool this turn. Summarize your plan and take one concrete action."
 
+/** Stronger message for the mandatory steer — used both for subagents (where
+ *  the next tool call will be blocked) and for main agents (where the
+ *  previous wording was being ignored indefinitely on stuck tasks). */
+const NO_TOOL_MANDATORY_STRONG_BASE =
+	"Exploration guard (turn %d with no tool calls): you are stuck in a thinking loop. Further reasoning without action will not produce a different result — either call a tool this turn or respond with plain text explaining what you are doing. If the next turn also has no tool calls the conversation will be terminated."
+
 export const STEER_MESSAGE_TYPE = "exploration-guard-steer"
 
 export class ExplorationGuard {
@@ -63,12 +76,16 @@ export class ExplorationGuard {
 	private readonly noToolWarnThreshold: number
 	private readonly noToolSteerThreshold: number
 	private readonly isEnabled: () => boolean
+	private readonly isSubagent: () => boolean
 
 	private consecutiveReadOnlyTurns = 0
 	private consecutiveNoToolTurns = 0
 	private currentTurnHasWriteTool = false
 	private currentTurnHasAnyTool = false
 	private currentTurnHasReadTool = false
+	/** When true (subagent only), the next tool_call should be blocked.
+	 *  Set when the mandatory no-tool steer fires; cleared on user input. */
+	private subagentStuck = false
 
 	constructor(options: ExplorationGuardOptions = {}) {
 		this.readTools = options.readTools ?? new Set(DEFAULT_READ_TOOLS)
@@ -78,6 +95,7 @@ export class ExplorationGuard {
 		this.noToolWarnThreshold = options.noToolWarnThreshold ?? 3
 		this.noToolSteerThreshold = options.noToolSteerThreshold ?? 5
 		this.isEnabled = options.isEnabled ?? (() => true)
+		this.isSubagent = options.isSubagent ?? (() => false)
 	}
 
 	reset(): void {
@@ -86,6 +104,7 @@ export class ExplorationGuard {
 		this.currentTurnHasWriteTool = false
 		this.currentTurnHasAnyTool = false
 		this.currentTurnHasReadTool = false
+		this.subagentStuck = false
 	}
 
 	turnStart(): void {
@@ -123,7 +142,14 @@ export class ExplorationGuard {
 			this.consecutiveNoToolTurns++
 
 			if (this.consecutiveNoToolTurns === this.noToolSteerThreshold) {
-				sendSteer(NO_TOOL_MANDATORY_BASE.replace("%d", String(this.noToolSteerThreshold)))
+				// Stronger wording (mandatory steer). Subagents also set a
+				// flag so the next tool_call is blocked — see the tool_call
+				// hook below. Main agents keep the steer-only behaviour; the
+				// wording is stronger but the agent can still ignore it.
+				sendSteer(NO_TOOL_MANDATORY_STRONG_BASE.replace("%d", String(this.noToolSteerThreshold)))
+				if (this.isSubagent()) {
+					this.subagentStuck = true
+				}
 				// Reset after the mandatory steer so the model gets a fresh
 				// budget rather than immediately re-triggering on the next turn.
 				this.consecutiveNoToolTurns = 0
@@ -168,6 +194,13 @@ export class ExplorationGuard {
 	getConsecutiveNoToolTurns(): number {
 		return this.consecutiveNoToolTurns
 	}
+
+	/** True when the guard has decided the agent (subagent) is stuck and
+	 *  the next tool call should be blocked to force a text response.
+	 *  Always false for main agents. Cleared on user input via reset(). */
+	isSubagentStuck(): boolean {
+		return this.subagentStuck
+	}
 }
 
 export default function explorationGuardExtension(pi: ExtensionAPI, options?: ExplorationGuardOptions): void {
@@ -195,6 +228,11 @@ export default function explorationGuardExtension(pi: ExtensionAPI, options?: Ex
 			}
 			return true
 		},
+		// Subagent terminate: call isAgentWorker() per-event so the
+		// AsyncLocalStorage context is respected (each tool call / turn
+		// end fires inside the worker context when a subagent is active).
+		// The caller can override via `options.isSubagent`.
+		isSubagent: options?.isSubagent ?? (() => isAgentWorker()),
 	})
 
 	pi.on("session_start", (_event, _ctx) => {
@@ -205,6 +243,8 @@ export default function explorationGuardExtension(pi: ExtensionAPI, options?: Ex
 	pi.on("input", (event: InputEvent) => {
 		// User input breaks the exploration streak.
 		if (event.source === "extension") return
+		// The reset() call clears subagentStuck as well, so a fresh user
+		// prompt un-sticks the subagent even if the previous turn was blocked.
 		guard.reset()
 	})
 
@@ -215,6 +255,18 @@ export default function explorationGuardExtension(pi: ExtensionAPI, options?: Ex
 	pi.on("tool_call", (event) => {
 		if (!event.toolName) return
 		guard.recordToolCall(event.toolName)
+		// Subagent terminate: after the no-tool mandatory threshold fires,
+		// block the next tool call so the model is forced to respond with
+		// plain text. Without this, the steer is just another text injection
+		// the model ignores indefinitely (observed: 377 fires on a single task).
+		if (guard.isSubagentStuck()) {
+			return {
+				block: true,
+				reason:
+					"Exploration guard: subagent has had multiple consecutive no-tool turns. " +
+					"Respond with plain text (no tool call) explaining your plan or conclusion.",
+			}
+		}
 		return { block: false }
 	})
 

--- a/src/extensions/exploration-guard.ts
+++ b/src/extensions/exploration-guard.ts
@@ -142,13 +142,15 @@ export class ExplorationGuard {
 			this.consecutiveNoToolTurns++
 
 			if (this.consecutiveNoToolTurns === this.noToolSteerThreshold) {
-				// Stronger wording (mandatory steer). Subagents also set a
-				// flag so the next tool_call is blocked — see the tool_call
-				// hook below. Main agents keep the steer-only behaviour; the
-				// wording is stronger but the agent can still ignore it.
-				sendSteer(NO_TOOL_MANDATORY_STRONG_BASE.replace("%d", String(this.noToolSteerThreshold)))
+				// For subagents: use the strong wording and set the stuck flag
+				// so the next tool_call is blocked, forcing a text response.
+				// For main agents: use the original wording — the stronger
+				// message caused models to think harder instead of acting.
 				if (this.isSubagent()) {
+					sendSteer(NO_TOOL_MANDATORY_STRONG_BASE.replace("%d", String(this.noToolSteerThreshold)))
 					this.subagentStuck = true
+				} else {
+					sendSteer(NO_TOOL_MANDATORY_BASE.replace("%d", String(this.noToolSteerThreshold)))
 				}
 				// Reset after the mandatory steer so the model gets a fresh
 				// budget rather than immediately re-triggering on the next turn.

--- a/src/extensions/loop-guard.test.ts
+++ b/src/extensions/loop-guard.test.ts
@@ -960,4 +960,34 @@ describe("Bash-only loop detector", () => {
 		// Window should be clear though.
 		expect(guard.isWarned()).toBe(true) // task-total re-triggered
 	})
+
+	it("task-total fired keys are decremented so the same threshold doesn't fire on every subsequent record", () => {
+		// Regression test: before the fix, task-total keys were never
+		// decremented after a warn, so the same threshold would fire on
+		// every subsequent record for the rest of the session, flooding
+		// the model with repeated steers.
+		//
+		// We verify the decrement directly via getTotalBashCount rather
+		// than testing the secondary "warn doesn't fire" behavior, because
+		// the window threshold (12) is lower than the task-total threshold
+		// (15), making it impossible to reach task-total without the
+		// window detector firing first.
+		const cmd = "curl https://api.example.com"
+		const guard = new LoopGuard()
+
+		// Feed enough to trigger task-total bash repetition (15 calls).
+		for (let i = 0; i < 15; i++) {
+			guard.record({
+				toolName: "bash",
+				toolArgs: `{"command":${JSON.stringify(cmd)}}`,
+				isError: false,
+				outputFingerprint: `fp-${i}`,
+			})
+		}
+		expect(guard.isWarned()).toBe(true)
+
+		// The fired key should be decremented by the threshold count (15).
+		// After warn: count = 15 - 15 = 0.
+		expect(guard.getTotalBashCount(cmd)).toBe(0)
+	})
 })

--- a/src/extensions/loop-guard.test.ts
+++ b/src/extensions/loop-guard.test.ts
@@ -40,12 +40,12 @@ describe("LoopGuard.reset", () => {
 		expect(guard.isWarned()).toBe(false)
 	})
 
-	it("clears triggered flag", () => {
+	it("clears warned flag", () => {
 		const guard = new LoopGuard()
-		feed(guard, repeat(rec({ isError: true }), 4))
-		expect(guard.isTriggered()).toBe(true)
+		feed(guard, repeat(rec({ isError: true }), 3))
+		expect(guard.isWarned()).toBe(true)
 		guard.reset()
-		expect(guard.isTriggered()).toBe(false)
+		expect(guard.isWarned()).toBe(false)
 	})
 })
 
@@ -111,12 +111,14 @@ describe("Consecutive identical errors detector", () => {
 		expect(guard.record(r).state).toBe("warn")
 	})
 
-	it("terminates on the 4th consecutive identical failing call", () => {
+	it("warns again after counter reset (never terminates)", () => {
 		const guard = new LoopGuard()
 		const r = rec({ isError: true, outputFingerprint: FP_A })
-		feed(guard, repeat(r, 3))
-		expect(guard.record(r).state).toBe("terminate")
-		expect(guard.isTriggered()).toBe(true)
+		feed(guard, repeat(r, 3)) // first detection → warn + counter reset
+		expect(guard.isWarned()).toBe(true)
+		// After the warn, counters are reset. Feed enough to trigger again.
+		const states = feed(guard, repeat(r, 3))
+		expect(states[2].state).toBe("warn") // second detection → warn again
 	})
 
 	it("breaks the streak on a successful call", () => {
@@ -291,23 +293,26 @@ describe("Exact ngram detector (all 4 fields)", () => {
 })
 
 describe("Shared warning fuse", () => {
-	it("warn from one detector + fire from another → terminate", () => {
+	it("second detection from a different detector also warns (never terminates)", () => {
 		const guard = new LoopGuard()
 		feed(guard, repeat(rec({ isError: true, outputFingerprint: FP_A }), 3))
 		expect(guard.isWarned()).toBe(true)
-		expect(guard.isTriggered()).toBe(false)
 
+		// After the first warn, counters are reset. A different detector
+		// triggers on a new pattern — should warn again, not terminate.
+		// The exact 2-gram fires at rep 6 (12 records), which triggers
+		// another warn (not terminate) and clears history again.
 		const a = rec({ toolArgs: '{"command":"x"}', outputFingerprint: "x1" })
 		const b = rec({ toolArgs: '{"command":"y"}', outputFingerprint: "y1" })
-		let last: ReturnType<LoopGuard["record"]> = { state: "ok" }
-		for (let i = 0; i < 5; i++) {
-			last = guard.record(a)
-			last = guard.record(b)
+		const states: Array<ReturnType<LoopGuard["record"]>> = []
+		for (let i = 0; i < 7; i++) {
+			states.push(guard.record(a))
+			states.push(guard.record(b))
 		}
-		last = guard.record(a)
-		last = guard.record(b)
-		expect(last.state).toBe("terminate")
-		expect(guard.isTriggered()).toBe(true)
+		// At least one of the states should be a warn (the second detection).
+		const warns = states.filter((s) => s.state === "warn")
+		expect(warns.length).toBeGreaterThanOrEqual(1)
+		expect(warns[0].state).toBe("warn")
 	})
 
 	it("two near-misses below threshold stay ok", () => {
@@ -329,15 +334,14 @@ describe("Shared warning fuse", () => {
 		expect(guard.isTriggered()).toBe(false)
 	})
 
-	it("warn → next ok call → next detector fire still terminates (fuse does not reset)", () => {
+	it("second detection after recovery also warns", () => {
 		const guard = new LoopGuard()
 		feed(guard, repeat(rec({ isError: true, outputFingerprint: FP_A }), 3))
 		expect(guard.isWarned()).toBe(true)
-		guard.record(rec({ toolArgs: '{"command":"recover"}', outputFingerprint: "r1" }))
+		// After the warn, counters are reset. New consecutive loop:
 		const r = rec({ isError: true, outputFingerprint: "fp_r" })
-		feed(guard, repeat(r, 2))
-		const last = guard.record(r)
-		expect(last.state).toBe("terminate")
+		const states = feed(guard, repeat(r, 3))
+		expect(states[2].state).toBe("warn")
 	})
 })
 
@@ -348,38 +352,19 @@ describe("LoopGuard.blockIfLoop (pre-execution prediction)", () => {
 		expect(guard.blockIfLoop({ toolName: "bash", toolArgs: '{"command":"ls"}' })).toBe(false)
 	})
 
-	it("fires and sets triggered when next call would complete a consecutive-identical loop", () => {
+	it("returns false after warn because history is cleared", () => {
+		// After a warn, the guard resets the window history. blockIfLoop
+		// can't find a proxy in an empty history, so it returns false.
 		const guard = new LoopGuard()
 		feed(guard, repeat(rec({ isError: true, outputFingerprint: FP_A }), 3))
-		expect(guard.blockIfLoop({ toolName: "bash", toolArgs: '{"command":"ls"}' })).toBe(true)
-		expect(guard.isTriggered()).toBe(true)
+		expect(guard.isWarned()).toBe(true)
+		expect(guard.blockIfLoop({ toolName: "bash", toolArgs: '{"command":"ls"}' })).toBe(false)
 	})
 
 	it("returns false for a clearly different next call", () => {
 		const guard = new LoopGuard()
-		feed(guard, repeat(rec({ isError: true, outputFingerprint: FP_A }), 3))
+		feed(guard, repeat(rec({ isError: true, outputFingerprint: FP_A }), 2))
 		expect(guard.blockIfLoop({ toolName: "bash", toolArgs: '{"command":"different"}' })).toBe(false)
-	})
-
-	it("does not mutate history on a non-firing prediction", () => {
-		const guard = new LoopGuard()
-		feed(guard, repeat(rec({ isError: true, outputFingerprint: FP_A }), 3))
-		guard.blockIfLoop({ toolName: "bash", toolArgs: '{"command":"different"}' })
-		expect(guard.record(rec({ isError: true, outputFingerprint: FP_A })).state).toBe("terminate")
-	})
-
-	it("returns true when next call would extend an alternating 2-gram", () => {
-		const guard = new LoopGuard()
-		const a = rec({ toolArgs: '{"command":"a"}', outputFingerprint: FP_A })
-		const b = rec({ toolArgs: '{"command":"b"}', outputFingerprint: FP_B })
-		for (let i = 0; i < 5; i++) {
-			guard.record(a)
-			guard.record(b)
-		}
-		guard.record(a)
-		guard.record(b)
-		expect(guard.isWarned()).toBe(true)
-		expect(guard.blockIfLoop({ toolName: "bash", toolArgs: '{"command":"a"}' })).toBe(true)
 	})
 })
 
@@ -511,14 +496,16 @@ describe("Edit-run cycle detector", () => {
 		expect(guard.isTriggered()).toBe(false)
 	})
 
-	it("terminates on the next call after warn (counts remain at threshold)", () => {
+	it("after warn, counters reset so next round does not immediately re-fire", () => {
 		const guard = new LoopGuard()
-		// 24 records: 8 full rounds. The 23rd record (bash(P) at end of round 8)
-		// triggers warn; the 24th record (read) re-triggers the edit-run
-		// detector and bumps the guard to terminate.
-		feedEditRunRecords(guard, 24)
+		// 23 records triggers warn (at the 8th bash). After that, window
+		// counters are cleared so the next few records don't re-fire.
+		feedEditRunRecords(guard, 23)
 		expect(guard.isWarned()).toBe(true)
-		expect(guard.isTriggered()).toBe(true)
+		// One more record (the read) should NOT immediately re-fire.
+		feedEditRunRecords(guard, 1)
+		// Still warned (flag persists), but no terminate.
+		expect(guard.isWarned()).toBe(true)
 	})
 
 	it("does not fire when edits target different files", () => {
@@ -652,27 +639,13 @@ describe("Edit-run cycle detector", () => {
 		expect(guard.isWarned()).toBe(false)
 	})
 
-	it("blockIfLoop predicts edit-run extension after warn", () => {
+	it("blockIfLoop returns false after warn (history cleared)", () => {
 		const guard = new LoopGuard()
 		feedEditRunRounds(guard, 8)
 		expect(guard.isWarned()).toBe(true)
-
-		// Predict that an edit to the same file would push the edit-run
-		// counter over the threshold again. blockIfLoop simulates adding the
-		// hypo record and re-running detectors.
+		// After the warn, window history is cleared. blockIfLoop can't find
+		// a matching proxy in an empty history, so it returns false.
 		const editArgs = '{"path":"/app/main.c","edits":[{"oldText":"x","newText":"next"}]}'
-		expect(guard.blockIfLoop({ toolName: "edit", toolArgs: editArgs })).toBe(true)
-		expect(guard.isTriggered()).toBe(true)
-	})
-
-	it("blockIfLoop does not block clearly different edit-run patterns", () => {
-		const guard = new LoopGuard()
-		feedEditRunRounds(guard, 8)
-		expect(guard.isWarned()).toBe(true)
-
-		// An edit to a completely different file shouldn't extend the loop
-		// — the edit-run detector requires the SAME file, not just any edit.
-		const editArgs = '{"path":"/app/completely/different.txt","edits":[{"oldText":"a","newText":"b"}]}'
 		expect(guard.blockIfLoop({ toolName: "edit", toolArgs: editArgs })).toBe(false)
 	})
 
@@ -826,21 +799,12 @@ describe("Edit-run cycle detector — task-total backstop", () => {
 		expect(guard.isTriggered()).toBe(false)
 	})
 
-	it("blockIfLoop predicts task-total cycle extension", () => {
+	it("blockIfLoop returns false after warn (history cleared)", () => {
 		const guard = new LoopGuard()
 		feedSparseEditRun(guard, 12, 12, 3)
 		expect(guard.isWarned()).toBe(true)
+		// After warn, window is cleared. blockIfLoop returns false.
 		const editArgs = '{"path":"/app/main.c","edits":[{"oldText":"x","newText":"y"}]}'
-		expect(guard.blockIfLoop({ toolName: "edit", toolArgs: editArgs })).toBe(true)
-		expect(guard.isTriggered()).toBe(true)
-	})
-
-	it("blockIfLoop does not block calls that don't extend the task-total cycle", () => {
-		const guard = new LoopGuard()
-		feedSparseEditRun(guard, 12, 12, 3)
-		expect(guard.isWarned()).toBe(true)
-		// Edit to a different file — doesn't extend the cycle.
-		const editArgs = '{"path":"/app/different.c","edits":[{"oldText":"a","newText":"b"}]}'
 		expect(guard.blockIfLoop({ toolName: "edit", toolArgs: editArgs })).toBe(false)
 	})
 })

--- a/src/extensions/loop-guard.test.ts
+++ b/src/extensions/loop-guard.test.ts
@@ -706,3 +706,141 @@ describe("Edit-run cycle detector", () => {
 		expect(guard.isTriggered()).toBe(false)
 	})
 })
+
+describe("Edit-run cycle detector — task-total backstop", () => {
+	// The task-total detector catches interleaved loops where the same
+	// edit/bash pattern is spread across many rounds with OTHER tool
+	// calls in between. The window-based detector misses these because
+	// it only looks at the last 30 records.
+
+	function feedSparseEditRun(guard: LoopGuard, editRuns: number, bashRuns: number, fillerPerRound: number): void {
+		// Interleave edit + bash with `fillerPerRound` other tool calls
+		// between each pair. With fillerPerRound=3, a 30-record window
+		// covers ~6 of each edit/bash target — below the 8/8 window
+		// threshold but the task-total counts keep climbing.
+		const file = "/app/main.c"
+		const bashPrefix = '{"command":"cd /app && make -j8 all 2>&1 | tail -20"}'
+		for (let i = 0; i < editRuns; i++) {
+			guard.record({
+				toolName: "edit",
+				toolArgs: `{"path":"${file}","edits":[{"oldText":"x","newText":"v${i}"}]}`,
+				isError: false,
+				outputFingerprint: `edit-${i}`,
+			})
+			for (let f = 0; f < fillerPerRound; f++) {
+				guard.record({
+					toolName: "read",
+					toolArgs: `{"path":"/tmp/filler-${i}-${f}.txt"}`,
+					isError: false,
+					outputFingerprint: `filler-${i}-${f}`,
+				})
+			}
+		}
+		for (let i = 0; i < bashRuns; i++) {
+			guard.record({
+				toolName: "bash",
+				toolArgs: bashPrefix,
+				isError: true,
+				outputFingerprint: `bash-${i}`,
+			})
+			for (let f = 0; f < fillerPerRound; f++) {
+				guard.record({
+					toolName: "read",
+					toolArgs: `{"path":"/tmp/bash-filler-${i}-${f}.txt"}`,
+					isError: false,
+					outputFingerprint: `bash-filler-${i}-${f}`,
+				})
+			}
+		}
+	}
+
+	it("does not fire at 11 rounds (below both thresholds)", () => {
+		const guard = new LoopGuard()
+		feedSparseEditRun(guard, 11, 11, 3)
+		expect(guard.isWarned()).toBe(false)
+		expect(guard.isTriggered()).toBe(false)
+	})
+
+	it("fires at 12 rounds (task-total backstop)", () => {
+		const guard = new LoopGuard()
+		feedSparseEditRun(guard, 12, 12, 3)
+		expect(guard.isWarned()).toBe(true)
+	})
+
+	it("task-total fires when window detector does NOT", () => {
+		// Specifically demonstrate that the task-total detector catches
+		// a loop the window misses. With fillerPerRound=3, the window
+		// has ~6 edits and ~6 bash at any time (below 8/8 threshold).
+		// But task-total counts cross 12/12.
+		const guard = new LoopGuard()
+		feedSparseEditRun(guard, 15, 15, 3)
+
+		// Verify via test internal: the total counts are above threshold.
+		// If the window detector had fired, isWarned() is true; either
+		// way, the guard should be warned.
+		expect(guard.isWarned()).toBe(true)
+	})
+
+	it("task-total does not fire if one of edit/bash is below threshold", () => {
+		const guard = new LoopGuard()
+		// 12 edits but only 5 bash runs — not a loop.
+		feedSparseEditRun(guard, 12, 5, 3)
+		expect(guard.isWarned()).toBe(false)
+	})
+
+	it("task-total survives window eviction", () => {
+		// Push 60 records total — window only keeps last 30. The
+		// task-total counts persist across evictions.
+		const guard = new LoopGuard()
+		feedSparseEditRun(guard, 12, 12, 3)
+		expect(guard.isWarned()).toBe(true)
+	})
+
+	it("window detector still fires for concentrated loops (no task-total needed)", () => {
+		const guard = new LoopGuard()
+		const file = "/app/vm.js"
+		const bashPrefix = '{"command":"node vm.js 2>&1 | head -20"}'
+		for (let i = 0; i < 8; i++) {
+			guard.record({
+				toolName: "edit",
+				toolArgs: `{"path":"${file}","edits":[{"oldText":"x","newText":"v${i}"}]}`,
+				isError: false,
+				outputFingerprint: `edit-${i}`,
+			})
+			guard.record({
+				toolName: "bash",
+				toolArgs: bashPrefix,
+				isError: true,
+				outputFingerprint: `bash-${i}`,
+			})
+		}
+		expect(guard.isWarned()).toBe(true)
+	})
+
+	it("reset() clears task-total counts", () => {
+		const guard = new LoopGuard()
+		feedSparseEditRun(guard, 12, 12, 3)
+		expect(guard.isWarned()).toBe(true)
+		guard.reset()
+		expect(guard.isWarned()).toBe(false)
+		expect(guard.isTriggered()).toBe(false)
+	})
+
+	it("blockIfLoop predicts task-total cycle extension", () => {
+		const guard = new LoopGuard()
+		feedSparseEditRun(guard, 12, 12, 3)
+		expect(guard.isWarned()).toBe(true)
+		const editArgs = '{"path":"/app/main.c","edits":[{"oldText":"x","newText":"y"}]}'
+		expect(guard.blockIfLoop({ toolName: "edit", toolArgs: editArgs })).toBe(true)
+		expect(guard.isTriggered()).toBe(true)
+	})
+
+	it("blockIfLoop does not block calls that don't extend the task-total cycle", () => {
+		const guard = new LoopGuard()
+		feedSparseEditRun(guard, 12, 12, 3)
+		expect(guard.isWarned()).toBe(true)
+		// Edit to a different file — doesn't extend the cycle.
+		const editArgs = '{"path":"/app/different.c","edits":[{"oldText":"a","newText":"b"}]}'
+		expect(guard.blockIfLoop({ toolName: "edit", toolArgs: editArgs })).toBe(false)
+	})
+})

--- a/src/extensions/loop-guard.test.ts
+++ b/src/extensions/loop-guard.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest"
-import { LoopGuard, type ToolHistoryRecord, fingerprint } from "./loop-guard.js"
+import { LoopGuard, type ToolHistoryRecord, fingerprint, normalizeBashCommand } from "./loop-guard.js"
 
 const FP_A = "fp_a"
 const FP_B = "fp_b"
@@ -806,5 +806,158 @@ describe("Edit-run cycle detector — task-total backstop", () => {
 		// After warn, window is cleared. blockIfLoop returns false.
 		const editArgs = '{"path":"/app/main.c","edits":[{"oldText":"x","newText":"y"}]}'
 		expect(guard.blockIfLoop({ toolName: "edit", toolArgs: editArgs })).toBe(false)
+	})
+})
+
+describe("normalizeBashCommand", () => {
+	it("strips leading preamble commands (rm, echo, wc, cd, sleep)", () => {
+		// Core command is gcc, path argument is file.c (from the gcc segment,
+		// NOT from the preamble's /app/a.out).
+		expect(normalizeBashCommand("rm -f /app/a.out && gcc -O3 file.c")).toBe("gcc file.c")
+		// wc is preamble-only (read-style) so it falls through to the raw prefix.
+		expect(normalizeBashCommand("wc -c /app/file.c")).toBe("wc -c /app/file.c")
+		// sleep + echo: both preamble, falls through.
+		expect(normalizeBashCommand("sleep 30 && echo done")).toBe("sleep 30 && echo done")
+	})
+
+	it("collapses on tool + first path argument to ignore flag variations", () => {
+		// Same intent: compile gpt2.c, different optimization flags and output paths.
+		expect(normalizeBashCommand("gcc -O3 -lm /app/gpt2.c -o /app/a.out")).toBe(
+			normalizeBashCommand("gcc -O0 -g /app/gpt2.c -o /tmp/debug"),
+		)
+		expect(normalizeBashCommand("gcc -O3 -lm /app/gpt2.c -o /app/a.out")).toBe("gcc /app/gpt2.c")
+	})
+
+	it("skips preamble and finds the core command in a chain", () => {
+		// Core is gcc, path argument is file.c from the gcc segment.
+		expect(normalizeBashCommand("rm -f a.out && wc -c file.c && gcc -O3 file.c")).toBe("gcc file.c")
+	})
+
+	it("falls back to raw prefix when no path-like argument is present", () => {
+		const result = normalizeBashCommand("echo hello world")
+		expect(result).toBe("echo hello world")
+	})
+
+	it("handles semicolon-separated commands", () => {
+		// cd is preamble, ls is core (no path arg → falls back to raw prefix).
+		expect(normalizeBashCommand("cd /app; ls -la; rm -rf tmp")).toBe("ls -la")
+	})
+
+	it("handles newline-separated commands", () => {
+		expect(normalizeBashCommand("rm -f a.out\ngcc -O3 file.c")).toBe("gcc file.c")
+	})
+
+	it("ignores flags like -O0, -O3, -lm, -g", () => {
+		// Flags start with "-" so they're not treated as path arguments.
+		expect(normalizeBashCommand("python3 -O -u script.py")).toBe("python3 script.py")
+	})
+
+	it("handles relative paths with file extensions", () => {
+		expect(normalizeBashCommand("cat ./test.txt")).toBe("cat ./test.txt")
+	})
+
+	it("uses the first path-argument when multiple are present", () => {
+		// cp is NOT a preamble command (it's a real action). It gets
+		// collapsed on the first path argument.
+		expect(normalizeBashCommand("cp /app/src.c /tmp/build/")).toBe("cp /app/src.c")
+	})
+})
+
+describe("Bash-only loop detector", () => {
+	// Catches the case where the model repeats the same bash command many times
+	// without file edits — e.g. repeated yt-dlp downloads, curl calls, etc.
+
+	function feedBashCalls(guard: LoopGuard, commands: string[], fingerprint: string): void {
+		for (const cmd of commands) {
+			guard.record({
+				toolName: "bash",
+				toolArgs: `{"command":${JSON.stringify(cmd)}}`,
+				isError: false,
+				outputFingerprint: fingerprint,
+			})
+		}
+	}
+
+	it("does not fire below window threshold", () => {
+		// Use varying fingerprints so consecutive-identical doesn't fire.
+		// Only the bash-repetition detector should be under test here.
+		const guard = new LoopGuard()
+		const commands = Array(11).fill("yt-dlp https://example.com/video")
+		for (let i = 0; i < commands.length; i++) {
+			guard.record({
+				toolName: "bash",
+				toolArgs: `{"command":${JSON.stringify(commands[i])}}`,
+				isError: false,
+				outputFingerprint: `fp-${i}`,
+			})
+		}
+		expect(guard.isWarned()).toBe(false)
+	})
+
+	it("does not fire when commands have no repeat (11 different commands)", () => {
+		const guard = new LoopGuard()
+		const commands = Array.from({ length: 11 }, (_, i) => `echo unique-cmd-${i}`)
+		feedBashCalls(guard, commands, "fp_same")
+		expect(guard.isWarned()).toBe(false)
+	})
+
+	it("fires at window threshold (12 same-prefix calls)", () => {
+		const guard = new LoopGuard()
+		feedBashCalls(guard, Array(12).fill("yt-dlp https://example.com/video"), "fp_same")
+		expect(guard.isWarned()).toBe(true)
+	})
+
+	it("does not require file edits to fire", () => {
+		// Same prefix, no edits — should still fire.
+		const guard = new LoopGuard()
+		const commands = Array(12).fill("curl https://api.example.com/data")
+		feedBashCalls(guard, commands, "fp_same")
+		expect(guard.isWarned()).toBe(true)
+	})
+
+	it("catches varied flag patterns via normalization", () => {
+		// Without normalization, each `gcc` invocation has a different raw prefix.
+		// With normalization, they all collapse to "gcc /app/gpt2.c".
+		const guard = new LoopGuard()
+		const commands = [
+			"rm -f /app/a.out && gcc -O3 -lm /app/gpt2.c -o /app/a.out",
+			"wc -c /app/gpt2.c && gcc -O0 -g /app/gpt2.c",
+			"gcc -O3 /app/gpt2.c -o /app/v3",
+			"rm -f /tmp/test && gcc /app/gpt2.c",
+			"gcc -O2 /app/gpt2.c",
+		]
+		// Feed 3 copies of each so 15 total — enough to trigger.
+		const repeated = commands.flatMap((c) => [c, c, c])
+		feedBashCalls(guard, repeated, "fp_same")
+		expect(guard.isWarned()).toBe(true)
+	})
+
+	it("does not fire when bash commands are genuinely different", () => {
+		const guard = new LoopGuard()
+		const commands = [
+			"git status",
+			"git diff",
+			"git log --oneline -5",
+			"npm test",
+			"pnpm run build",
+			"pytest tests/",
+			"ls -la",
+			"grep -r TODO src/",
+			"wc -l src/*.ts",
+			"find . -name '*.test.ts'",
+		]
+		feedBashCalls(guard, commands, "fp_same")
+		expect(guard.isWarned()).toBe(false)
+	})
+
+	it("window counts reset after warn so the model gets a fresh budget", () => {
+		const guard = new LoopGuard()
+		feedBashCalls(guard, Array(12).fill("apt-get install -y some-package"), "fp_a")
+		expect(guard.isWarned()).toBe(true)
+		// After warn, window is cleared. Next batch doesn't immediately re-fire.
+		feedBashCalls(guard, Array(12).fill("apt-get install -y another-package"), "fp_b")
+		// Total counts may re-trigger after enough accumulates.
+		// Window should be clear though.
+		expect(guard.isWarned()).toBe(true) // task-total re-triggered
 	})
 })

--- a/src/extensions/loop-guard.test.ts
+++ b/src/extensions/loop-guard.test.ts
@@ -425,3 +425,284 @@ describe("Edit-then-rerun cycle must NOT fire", () => {
 		expect(guard.isTriggered()).toBe(false)
 	})
 })
+
+describe("Edit-run cycle detector", () => {
+	// Helper that simulates the edit-run cycle with diagnostic calls interspersed.
+	// The diagnostic calls have varying args (read/grep with different paths) so
+	// the existing n-gram detectors do NOT fire. This isolates the edit-run
+	// detector, which tracks file path and bash prefix independently of the call
+	// order.
+	//
+	// Pattern per round is 3 records: edit + bash + read. 3 × 8 = 24 records
+	// stays within the 30-record sliding window, so no evictions occur before
+	// the edit-run detector can fire.
+	function feedEditRunRounds(guard: LoopGuard, rounds: number): void {
+		const file = "/app/main.c"
+		const bashPrefix = '{"command":"cd /app && make -j8 all 2>&1 | tail -20"}'
+		for (let i = 0; i < rounds; i++) {
+			guard.record({
+				toolName: "edit",
+				toolArgs: `{"path":"${file}","edits":[{"oldText":"x","newText":"v${i}"}]}`,
+				isError: false,
+				outputFingerprint: `edit-${i}`,
+			})
+			guard.record({
+				toolName: "bash",
+				toolArgs: bashPrefix,
+				isError: true,
+				outputFingerprint: `bash-${i}`,
+			})
+			guard.record({
+				toolName: "read",
+				toolArgs: `{"path":"/tmp/diag-${i}.txt"}`,
+				isError: false,
+				outputFingerprint: `read-${i}`,
+			})
+		}
+	}
+
+	// Helper to push exactly N records of a single round. Useful for stopping
+	// at the exact record that triggers warn vs. the one that triggers terminate.
+	function feedEditRunRecords(guard: LoopGuard, recordCount: number): void {
+		const file = "/app/main.c"
+		const bashPrefix = '{"command":"cd /app && make -j8 all 2>&1 | tail -20"}'
+		for (let i = 0; i < recordCount; i++) {
+			const pos = i % 3
+			const round = Math.floor(i / 3)
+			if (pos === 0) {
+				guard.record({
+					toolName: "edit",
+					toolArgs: `{"path":"${file}","edits":[{"oldText":"x","newText":"v${round}"}]}`,
+					isError: false,
+					outputFingerprint: `edit-${round}`,
+				})
+			} else if (pos === 1) {
+				guard.record({
+					toolName: "bash",
+					toolArgs: bashPrefix,
+					isError: true,
+					outputFingerprint: `bash-${round}`,
+				})
+			} else {
+				guard.record({
+					toolName: "read",
+					toolArgs: `{"path":"/tmp/diag-${round}.txt"}`,
+					isError: false,
+					outputFingerprint: `read-${round}`,
+				})
+			}
+		}
+	}
+
+	it("does not fire below threshold (7 rounds)", () => {
+		const guard = new LoopGuard()
+		feedEditRunRounds(guard, 7)
+		expect(guard.isWarned()).toBe(false)
+		expect(guard.isTriggered()).toBe(false)
+	})
+
+	it("warns at threshold (8 rounds)", () => {
+		const guard = new LoopGuard()
+		// Stop at exactly the bash call that triggers warn (record 23 of 24).
+		// The 24th record (read) would re-trigger the detector and bump to
+		// terminate — see the next test.
+		feedEditRunRecords(guard, 23)
+		expect(guard.isWarned()).toBe(true)
+		expect(guard.isTriggered()).toBe(false)
+	})
+
+	it("terminates on the next call after warn (counts remain at threshold)", () => {
+		const guard = new LoopGuard()
+		// 24 records: 8 full rounds. The 23rd record (bash(P) at end of round 8)
+		// triggers warn; the 24th record (read) re-triggers the edit-run
+		// detector and bumps the guard to terminate.
+		feedEditRunRecords(guard, 24)
+		expect(guard.isWarned()).toBe(true)
+		expect(guard.isTriggered()).toBe(true)
+	})
+
+	it("does not fire when edits target different files", () => {
+		const guard = new LoopGuard()
+		// 10 rounds, each editing a different file but with the same bash
+		// prefix. No single file crosses the threshold even though bash(P)
+		// repeats 10 times.
+		const bashPrefix = '{"command":"cd /app && make -j8 all 2>&1 | tail -20"}'
+		for (let i = 0; i < 10; i++) {
+			guard.record({
+				toolName: "edit",
+				toolArgs: `{"path":"/app/file${i}.c","edits":[{"oldText":"x","newText":"v${i}"}]}`,
+				isError: false,
+				outputFingerprint: `edit-${i}`,
+			})
+			guard.record({
+				toolName: "bash",
+				toolArgs: bashPrefix,
+				isError: true,
+				outputFingerprint: `bash-${i}`,
+			})
+			guard.record({
+				toolName: "read",
+				toolArgs: `{"path":"/tmp/diag-${i}.txt"}`,
+				isError: false,
+				outputFingerprint: `read-${i}`,
+			})
+		}
+		expect(guard.isWarned()).toBe(false)
+		expect(guard.isTriggered()).toBe(false)
+	})
+
+	it("does not fire when bash command prefix varies each round", () => {
+		const guard = new LoopGuard()
+		// 10 rounds, same file edited but each bash command has a different
+		// first 50 chars. No single bash prefix crosses the threshold.
+		for (let i = 0; i < 10; i++) {
+			guard.record({
+				toolName: "edit",
+				toolArgs: `{"path":"/app/main.c","edits":[{"oldText":"x","newText":"v${i}"}]}`,
+				isError: false,
+				outputFingerprint: `edit-${i}`,
+			})
+			guard.record({
+				toolName: "bash",
+				toolArgs: `{"command":"echo round-${i} of totally-different-cmd-prefix"}`,
+				isError: true,
+				outputFingerprint: `bash-${i}`,
+			})
+			guard.record({
+				toolName: "read",
+				toolArgs: `{"path":"/tmp/diag-${i}.txt"}`,
+				isError: false,
+				outputFingerprint: `read-${i}`,
+			})
+		}
+		expect(guard.isWarned()).toBe(false)
+		expect(guard.isTriggered()).toBe(false)
+	})
+
+	it("does not fire when a single edit targets one file but no bash repeats", () => {
+		const guard = new LoopGuard()
+		for (let i = 0; i < 10; i++) {
+			guard.record({
+				toolName: "edit",
+				toolArgs: `{"path":"/app/main.c","edits":[{"oldText":"x","newText":"v${i}"}]}`,
+				isError: false,
+				outputFingerprint: `edit-${i}`,
+			})
+			guard.record({
+				toolName: "bash",
+				toolArgs: `{"command":"echo unique-cmd-${i}-${Math.random()}"}`,
+				isError: true,
+				outputFingerprint: `bash-${i}`,
+			})
+			guard.record({
+				toolName: "read",
+				toolArgs: `{"path":"/tmp/diag-${i}.txt"}`,
+				isError: false,
+				outputFingerprint: `read-${i}`,
+			})
+		}
+		expect(guard.isWarned()).toBe(false)
+	})
+
+	it("detects simple edit+bash pattern at 8 rounds when interleaved with diagnostic reads", () => {
+		// The simplest case: same file, same bash prefix, but with diagnostic
+		// reads between every call. The reads have different args so the
+		// existing fuzzy n-gram detectors can't latch onto a repeating pattern.
+		const guard = new LoopGuard()
+		const file = "/app/vm.js"
+		const bashPrefix = '{"command":"node vm.js 2>&1 | head -20"}'
+		for (let i = 0; i < 8; i++) {
+			guard.record({
+				toolName: "read",
+				toolArgs: `{"path":"/tmp/probe-${i}.txt"}`,
+				isError: false,
+				outputFingerprint: `probe-${i}`,
+			})
+			guard.record({
+				toolName: "edit",
+				toolArgs: `{"path":"${file}","edits":[{"oldText":"x","newText":"v${i}"}]}`,
+				isError: false,
+				outputFingerprint: `edit-${i}`,
+			})
+			guard.record({
+				toolName: "bash",
+				toolArgs: bashPrefix,
+				isError: true,
+				outputFingerprint: `bash-${i}`,
+			})
+		}
+		expect(guard.isWarned()).toBe(true)
+	})
+
+	it("window eviction drops the edit and bash counts", () => {
+		const guard = new LoopGuard()
+		feedEditRunRounds(guard, 8)
+		expect(guard.isWarned()).toBe(true)
+
+		// Push 35 fresh records (each a unique bash command) to evict all the
+		// old edit-run signal from the window. After eviction the edit and
+		// bash counts should be back to 0.
+		for (let i = 0; i < 35; i++) {
+			guard.record(rec({ toolArgs: `{"command":"filler-${i}"}`, outputFingerprint: `f${i}` }))
+		}
+		// reset() clears the warn fuse. Replaying the same edit-run pattern
+		// at 7 rounds (below threshold) should not fire again.
+		guard.reset()
+		feedEditRunRounds(guard, 7)
+		expect(guard.isWarned()).toBe(false)
+	})
+
+	it("blockIfLoop predicts edit-run extension after warn", () => {
+		const guard = new LoopGuard()
+		feedEditRunRounds(guard, 8)
+		expect(guard.isWarned()).toBe(true)
+
+		// Predict that an edit to the same file would push the edit-run
+		// counter over the threshold again. blockIfLoop simulates adding the
+		// hypo record and re-running detectors.
+		const editArgs = '{"path":"/app/main.c","edits":[{"oldText":"x","newText":"next"}]}'
+		expect(guard.blockIfLoop({ toolName: "edit", toolArgs: editArgs })).toBe(true)
+		expect(guard.isTriggered()).toBe(true)
+	})
+
+	it("blockIfLoop does not block clearly different edit-run patterns", () => {
+		const guard = new LoopGuard()
+		feedEditRunRounds(guard, 8)
+		expect(guard.isWarned()).toBe(true)
+
+		// An edit to a completely different file shouldn't extend the loop
+		// — the edit-run detector requires the SAME file, not just any edit.
+		const editArgs = '{"path":"/app/completely/different.txt","edits":[{"oldText":"a","newText":"b"}]}'
+		expect(guard.blockIfLoop({ toolName: "edit", toolArgs: editArgs })).toBe(false)
+	})
+
+	it("does not fire on tool calls with malformed JSON args", () => {
+		// Records whose toolArgs don't parse as JSON should be skipped by the
+		// extract* helpers. They shouldn't crash and shouldn't count.
+		const guard = new LoopGuard()
+		for (let i = 0; i < 10; i++) {
+			guard.record({
+				toolName: "edit",
+				toolArgs: "not json",
+				isError: false,
+				outputFingerprint: `edit-${i}`,
+			})
+			guard.record({
+				toolName: "bash",
+				toolArgs: `{"command":"echo ${i}"}`,
+				isError: false,
+				outputFingerprint: `bash-${i}`,
+			})
+		}
+		expect(guard.isWarned()).toBe(false)
+	})
+
+	it("reset() clears the edit and bash counts", () => {
+		const guard = new LoopGuard()
+		feedEditRunRounds(guard, 8)
+		expect(guard.isWarned()).toBe(true)
+		guard.reset()
+		expect(guard.isWarned()).toBe(false)
+		expect(guard.isTriggered()).toBe(false)
+	})
+})

--- a/src/extensions/loop-guard.ts
+++ b/src/extensions/loop-guard.ts
@@ -104,6 +104,11 @@ export class LoopGuard {
 		return this.warned
 	}
 
+	/** Test helper: get the current total count for a bash prefix. */
+	getTotalBashCount(prefix: string): number {
+		return this.bashCountsTotal.get(prefix) ?? 0
+	}
+
 	record(rec: ToolHistoryRecord): LoopGuardResult {
 		// Increment semantic counters for the new record before pushing.
 		const editTarget = extractEditTarget(rec)
@@ -137,8 +142,8 @@ export class LoopGuard {
 			}
 		}
 
-		const reason = this.detect()
-		if (reason === undefined) {
+		const detected = this.detect()
+		if (detected === undefined) {
 			return { state: "ok" }
 		}
 
@@ -148,14 +153,24 @@ export class LoopGuard {
 
 		// Reset the window counters so the model must loop again before the
 		// next steer fires — avoids flooding the context with steers on
-		// every subsequent tool call. Task-total counts are NOT reset so
-		// the task-total detector can fire again if the model keeps looping.
+		// every subsequent tool call.
 		this.history = []
 		this.editCounts.clear()
 		this.bashCounts.clear()
 		this.bashCountsNorm.clear()
 
-		return { state: "warn", reason: `${STEERING_MESSAGE} (${reason})` }
+		// For task-total detectors, reset the specific keys that fired so
+		// the same threshold doesn't fire on every subsequent record for
+		// the rest of the session. The model must accumulate a fresh
+		// batch of matching calls to re-trigger. Reset (not decrement by 1)
+		// because the threshold was reached — partial carryover doesn't help.
+		for (const key of detected.firedKeys) {
+			this.editCountsTotal.delete(key)
+			this.bashCountsTotal.delete(key)
+			this.bashCountsNormTotal.delete(key)
+		}
+
+		return { state: "warn", reason: `${STEERING_MESSAGE} (${detected.reason})` }
 	}
 
 	/**
@@ -250,7 +265,12 @@ export class LoopGuard {
 		}
 	}
 
-	private detect(): string | undefined {
+	/** Run all detectors and return the first one that fires, along with
+	 *  any map keys that should be decremented when the caller resets
+	 *  state. Task-total keys are included so the caller can decrement
+	 *  them after a warn — otherwise the same task-total threshold would
+	 *  fire on every subsequent record for the rest of the session. */
+	private detect(): { reason: string; firedKeys: string[] } | undefined {
 		return (
 			this.detectConsecutiveIdenticalCalls() ??
 			this.detectExactNgram() ??
@@ -261,11 +281,11 @@ export class LoopGuard {
 		)
 	}
 
-	private detectNgramOnly(): string | undefined {
+	private detectNgramOnly(): { reason: string; firedKeys: string[] } | undefined {
 		return this.detectConsecutiveIdenticalCalls() ?? this.detectExactNgram() ?? this.detectFuzzyNgram()
 	}
 
-	private detectConsecutiveIdenticalCalls(): string | undefined {
+	private detectConsecutiveIdenticalCalls(): { reason: string; firedKeys: string[] } | undefined {
 		const last = this.history[this.history.length - 1]
 		if (!last) return undefined
 		const targetKey = exactKey(last)
@@ -278,26 +298,37 @@ export class LoopGuard {
 			}
 		}
 		if (count < CONSECUTIVE_IDENTICAL_THRESHOLD) return undefined
-		return `${count} consecutive identical calls of ${formatCall(last)} producing identical output`
+		return {
+			reason: `${count} consecutive identical calls of ${formatCall(last)} producing identical output`,
+			firedKeys: [],
+		}
 	}
 
-	private detectExactNgram(): string | undefined {
+	private detectExactNgram(): { reason: string; firedKeys: string[] } | undefined {
 		const r2 = countContiguousNgramReps(this.history, 2, exactKey)
-		if (r2 > EXACT_2GRAM_THRESHOLD) return formatLoopReason(this.history, 2, r2, "identical results")
+		if (r2 > EXACT_2GRAM_THRESHOLD) {
+			return { reason: formatLoopReason(this.history, 2, r2, "identical results"), firedKeys: [] }
+		}
 		const r3 = countContiguousNgramReps(this.history, 3, exactKey)
-		if (r3 > EXACT_3GRAM_THRESHOLD) return formatLoopReason(this.history, 3, r3, "identical results")
+		if (r3 > EXACT_3GRAM_THRESHOLD) {
+			return { reason: formatLoopReason(this.history, 3, r3, "identical results"), firedKeys: [] }
+		}
 		return undefined
 	}
 
-	private detectFuzzyNgram(): string | undefined {
+	private detectFuzzyNgram(): { reason: string; firedKeys: string[] } | undefined {
 		const r2 = countContiguousNgramReps(this.history, 2, fuzzyKey)
-		if (r2 > FUZZY_2GRAM_THRESHOLD) return formatLoopReason(this.history, 2, r2, "same arguments")
+		if (r2 > FUZZY_2GRAM_THRESHOLD) {
+			return { reason: formatLoopReason(this.history, 2, r2, "same arguments"), firedKeys: [] }
+		}
 		const r3 = countContiguousNgramReps(this.history, 3, fuzzyKey)
-		if (r3 > FUZZY_3GRAM_THRESHOLD) return formatLoopReason(this.history, 3, r3, "same arguments")
+		if (r3 > FUZZY_3GRAM_THRESHOLD) {
+			return { reason: formatLoopReason(this.history, 3, r3, "same arguments"), firedKeys: [] }
+		}
 		return undefined
 	}
 
-	private detectEditRunCycle(): string | undefined {
+	private detectEditRunCycle(): { reason: string; firedKeys: string[] } | undefined {
 		const topEdit = mapMax(this.editCounts)
 		const topBashRaw = mapMax(this.bashCounts)
 		const topBashNorm = mapMax(this.bashCountsNorm)
@@ -309,10 +340,15 @@ export class LoopGuard {
 			topEdit[0].length > REASON_ARG_PREVIEW ? `${topEdit[0].slice(0, REASON_ARG_PREVIEW)}…` : topEdit[0]
 		const bashPreview =
 			topBash[0].length > REASON_ARG_PREVIEW ? `${topBash[0].slice(0, REASON_ARG_PREVIEW)}…` : topBash[0]
-		return `edit-run cycle: ${editPreview} edited ${topEdit[1]}× and bash "${bashPreview}" ran ${topBash[1]}× in last ${this.history.length} calls`
+		// firedKeys are empty: window counters are fully reset by the caller
+		// after each warn, so we don't need to decrement individual keys.
+		return {
+			reason: `edit-run cycle: ${editPreview} edited ${topEdit[1]}× and bash "${bashPreview}" ran ${topBash[1]}× in last ${this.history.length} calls`,
+			firedKeys: [],
+		}
 	}
 
-	private detectEditRunCycleTotal(): string | undefined {
+	private detectEditRunCycleTotal(): { reason: string; firedKeys: string[] } | undefined {
 		// Task-total counts catch interleaved loops that the 30-record
 		// window misses. Window-based detection is still preferred because
 		// it's sensitive to recent behaviour; this is a backstop for the
@@ -330,7 +366,13 @@ export class LoopGuard {
 			topEdit[0].length > REASON_ARG_PREVIEW ? `${topEdit[0].slice(0, REASON_ARG_PREVIEW)}…` : topEdit[0]
 		const bashPreview =
 			topBash[0].length > REASON_ARG_PREVIEW ? `${topBash[0].slice(0, REASON_ARG_PREVIEW)}…` : topBash[0]
-		return `edit-run cycle (task-total): ${editPreview} edited ${topEdit[1]}× and bash "${bashPreview}" ran ${topBash[1]}× across the task`
+		// Include the fired keys so the caller can decrement them in the
+		// task-total maps. Without this, the same threshold would re-fire
+		// on every subsequent tool call for the rest of the session.
+		return {
+			reason: `edit-run cycle (task-total): ${editPreview} edited ${topEdit[1]}× and bash "${bashPreview}" ran ${topBash[1]}× across the task`,
+			firedKeys: [topEdit[0], topBash[0]],
+		}
 	}
 
 	/**
@@ -339,28 +381,40 @@ export class LoopGuard {
 	 * like repeated yt-dlp downloads, repeated curl calls, repeated make on
 	 * a project that always fails.
 	 */
-	private detectBashRepetition(): string | undefined {
+	private detectBashRepetition(): { reason: string; firedKeys: string[] } | undefined {
 		// Bash-only thresholds are higher than edit-run because the signal
 		// is weaker (no paired file edit to confirm it's a loop).
 		// Window check (raw)
 		const topBashWin = mapMax(this.bashCounts)
 		if (topBashWin && topBashWin[1] >= BASH_REPEAT_THRESHOLD) {
-			return `bash repetition: "${truncPreview(topBashWin[0])}" ran ${topBashWin[1]}× in last ${this.history.length} calls`
+			return {
+				reason: `bash repetition: "${truncPreview(topBashWin[0])}" ran ${topBashWin[1]}× in last ${this.history.length} calls`,
+				firedKeys: [],
+			}
 		}
 		// Window check (normalized)
 		const topBashNormWin = mapMax(this.bashCountsNorm)
 		if (topBashNormWin && topBashNormWin[1] >= BASH_REPEAT_THRESHOLD) {
-			return `bash repetition (normalized): "${truncPreview(topBashNormWin[0])}" ran ${topBashNormWin[1]}× in last ${this.history.length} calls`
+			return {
+				reason: `bash repetition (normalized): "${truncPreview(topBashNormWin[0])}" ran ${topBashNormWin[1]}× in last ${this.history.length} calls`,
+				firedKeys: [],
+			}
 		}
 		// Task-total check (raw)
 		const topBashTotal = mapMax(this.bashCountsTotal)
 		if (topBashTotal && topBashTotal[1] >= BASH_REPEAT_TOTAL_THRESHOLD) {
-			return `bash repetition (task-total): "${truncPreview(topBashTotal[0])}" ran ${topBashTotal[1]}× across the task`
+			return {
+				reason: `bash repetition (task-total): "${truncPreview(topBashTotal[0])}" ran ${topBashTotal[1]}× across the task`,
+				firedKeys: [topBashTotal[0]],
+			}
 		}
 		// Task-total check (normalized)
 		const topBashNormTotal = mapMax(this.bashCountsNormTotal)
 		if (topBashNormTotal && topBashNormTotal[1] >= BASH_REPEAT_TOTAL_THRESHOLD) {
-			return `bash repetition (normalized task-total): "${truncPreview(topBashNormTotal[0])}" ran ${topBashNormTotal[1]}× across the task`
+			return {
+				reason: `bash repetition (normalized task-total): "${truncPreview(topBashNormTotal[0])}" ran ${topBashNormTotal[1]}× across the task`,
+				firedKeys: [topBashNormTotal[0]],
+			}
 		}
 		return undefined
 	}

--- a/src/extensions/loop-guard.ts
+++ b/src/extensions/loop-guard.ts
@@ -1,5 +1,6 @@
 import { createHash } from "node:crypto"
-import type { ExtensionAPI, ToolResultEvent } from "@earendil-works/pi-coding-agent"
+import type { ExtensionAPI, ExtensionContext, ToolResultEvent } from "@earendil-works/pi-coding-agent"
+import { isAgentWorker } from "./agent-worker-context.js"
 
 export interface ToolHistoryRecord {
 	toolName: string
@@ -35,10 +36,12 @@ const FINGERPRINT_TAIL_LINES = 20
 const REASON_ARG_PREVIEW = 80
 
 const STEERING_MESSAGE =
-	"Loop guard warning: your recent tool calls show a repeating pattern. Step back, summarize what isn't working, and try a substantively different approach. Repeating the same pattern will halt tool use for this turn."
-
-const TERMINATION_MESSAGE =
-	"Loop guard halted tool use. Do not make any more tool calls. Respond with plain text only: summarize what was attempted, what failed, and what you would need to make progress."
+	"Loop guard: you are repeating the same edit-and-run cycle without making progress. " +
+	"STOP and change your approach. Before your next tool call: " +
+	"(1) State in one sentence what is failing and why. " +
+	"(2) List at least two alternative approaches you have NOT tried. " +
+	"(3) Pick the most promising one and try THAT instead. " +
+	"Do not repeat the same file edits or the same commands — the loop guard will keep firing if you do."
 
 /**
  * Detects when an agent is stuck repeating itself across tool calls. Four
@@ -124,13 +127,19 @@ export class LoopGuard {
 			return { state: "ok" }
 		}
 
-		if (!this.warned) {
-			this.warned = true
-			return { state: "warn", reason: `${STEERING_MESSAGE} (${reason})` }
-		}
+		// Always warn, never terminate. Blocking tool calls forces the model
+		// into no-tool turns which deadlocks with the exploration guard.
+		this.warned = true
 
-		this.triggered = true
-		return { state: "terminate", reason: TERMINATION_MESSAGE }
+		// Reset the window counters so the model must loop again before the
+		// next steer fires — avoids flooding the context with steers on
+		// every subsequent tool call. Task-total counts are NOT reset so
+		// the task-total detector can fire again if the model keeps looping.
+		this.history = []
+		this.editCounts.clear()
+		this.bashCounts.clear()
+
+		return { state: "warn", reason: `${STEERING_MESSAGE} (${reason})` }
 	}
 
 	/**
@@ -449,10 +458,19 @@ function mapMax(map: Map<string, number>): [string, number] | undefined {
 
 export default function loopGuardExtension(pi: ExtensionAPI) {
 	const guard = new LoopGuard()
+	let ctx: ExtensionContext | undefined
+	/** True when a subagent loop-guard steer has fired and the subagent
+	 *  gets one more turn to produce a summary before abort. */
+	let subagentAbortPending = false
+
+	pi.on("session_start", (_event, _ctx) => {
+		ctx = _ctx
+	})
 
 	pi.on("input", (event) => {
 		if (event.source === "extension") return
 		guard.reset()
+		subagentAbortPending = false
 	})
 
 	pi.on("tool_call", (event) => {
@@ -462,25 +480,19 @@ export default function loopGuardExtension(pi: ExtensionAPI) {
 				reason: "Tool name is empty. Check your tool call syntax and use only the tools listed under Available Tools.",
 			}
 		}
-		if (guard.isTriggered()) {
-			return { block: true, reason: TERMINATION_MESSAGE }
-		}
-		const call = { toolName: event.toolName, toolArgs: stableStringify(event.input) }
-		if (guard.blockIfLoop(call)) {
-			return { block: true, reason: TERMINATION_MESSAGE }
-		}
+		// The loop guard never blocks tool calls. Blocking tools forces the
+		// model into no-tool turns which deadlocks with the exploration guard.
+		// Subagents are terminated via ctx.abort() in turn_end instead.
 	})
 
-	// After the loop guard terminates tool use, the model must produce a
-	// text-only response. Once that response is complete (turn_end), reset
-	// the guard so the model gets a fresh chance to try a different approach.
-	// Without this, in one-shot sessions (benchmarks, ferments) the triggered
-	// flag stays true forever and every subsequent tool call is blocked —
-	// deadlocking with the exploration guard which tells the model to call
-	// a tool.
 	pi.on("turn_end", () => {
-		if (guard.isTriggered()) {
-			guard.reset()
+		// Subagent abort: after a loop-guard steer fired, the subagent gets
+		// one turn to produce output, then we abort. Whatever it produced
+		// becomes the responseText the orchestrator receives.
+		if (subagentAbortPending) {
+			ctx?.abort()
+			subagentAbortPending = false
+			return
 		}
 	})
 
@@ -501,6 +513,12 @@ export default function loopGuardExtension(pi: ExtensionAPI) {
 				},
 				{ deliverAs: "steer" },
 			)
+			// Subagent: schedule an abort on the next turn_end. The subagent
+			// gets one more turn to produce a summary; that text becomes the
+			// output the orchestrator receives.
+			if (isAgentWorker()) {
+				subagentAbortPending = true
+			}
 		}
 	})
 }

--- a/src/extensions/loop-guard.ts
+++ b/src/extensions/loop-guard.ts
@@ -471,6 +471,19 @@ export default function loopGuardExtension(pi: ExtensionAPI) {
 		}
 	})
 
+	// After the loop guard terminates tool use, the model must produce a
+	// text-only response. Once that response is complete (turn_end), reset
+	// the guard so the model gets a fresh chance to try a different approach.
+	// Without this, in one-shot sessions (benchmarks, ferments) the triggered
+	// flag stays true forever and every subsequent tool call is blocked —
+	// deadlocking with the exploration guard which tells the model to call
+	// a tool.
+	pi.on("turn_end", () => {
+		if (guard.isTriggered()) {
+			guard.reset()
+		}
+	})
+
 	pi.on("tool_result", (event) => {
 		const record: ToolHistoryRecord = {
 			toolName: event.toolName,

--- a/src/extensions/loop-guard.ts
+++ b/src/extensions/loop-guard.ts
@@ -28,6 +28,8 @@ const FUZZY_2GRAM_THRESHOLD = 6 // 7× repeat of a 2-gram, output may vary
 const FUZZY_3GRAM_THRESHOLD = 4 // 5× repeat of a 3-gram, output may vary
 const EXACT_2GRAM_THRESHOLD = 5 // 6× repeat of a 2-gram with identical output
 const EXACT_3GRAM_THRESHOLD = 3 // 4× repeat of a 3-gram with identical output
+const EDIT_RUN_THRESHOLD = 8 // same file edited 8× AND same bash prefix 8× in window
+const BASH_PREFIX_LENGTH = 50 // normalize bash commands by this prefix
 const FINGERPRINT_TAIL_LINES = 20
 const REASON_ARG_PREVIEW = 80
 
@@ -38,7 +40,7 @@ const TERMINATION_MESSAGE =
 	"Loop guard halted tool use. Do not make any more tool calls. Respond with plain text only: summarize what was attempted, what failed, and what you would need to make progress."
 
 /**
- * Detects when an agent is stuck repeating itself across tool calls. Three
+ * Detects when an agent is stuck repeating itself across tool calls. Four
  * independent detectors run over a rolling window of the most recent records
  * and share a single warning fuse: the first detection from any detector
  * issues a warning; the next detection terminates tool use for the turn.
@@ -53,14 +55,22 @@ const TERMINATION_MESSAGE =
  *   3. Fuzzy n-gram repetition — same as exact, but matches only on tool
  *      name + args. Catches edit/rerun loops where the output keeps changing
  *      but the agent is invoking the same calls in the same order.
+ *   4. Edit-run cycle — a single file is edited repeatedly AND a single bash
+ *      command prefix is run repeatedly within the window (non-contiguous).
+ *      Catches the edit\u2192build\u2192run\u2192see-error\u2192edit cycle that detectors 1\u20133
+ *      miss because the edit args change every iteration.
  */
 export class LoopGuard {
 	private history: ToolHistoryRecord[] = []
+	private editCounts = new Map<string, number>()
+	private bashCounts = new Map<string, number>()
 	private warned = false
 	private triggered = false
 
 	reset(): void {
 		this.history = []
+		this.editCounts.clear()
+		this.bashCounts.clear()
 		this.warned = false
 		this.triggered = false
 	}
@@ -74,9 +84,23 @@ export class LoopGuard {
 	}
 
 	record(rec: ToolHistoryRecord): LoopGuardResult {
+		// Increment semantic counters for the new record before pushing.
+		const editTarget = extractEditTarget(rec)
+		if (editTarget) mapIncrement(this.editCounts, editTarget)
+		const bashPrefix = extractBashPrefix(rec)
+		if (bashPrefix) mapIncrement(this.bashCounts, bashPrefix)
+
 		this.history.push(rec)
 		if (this.history.length > WINDOW_SIZE) {
-			this.history.shift()
+			const evicted = this.history.shift()
+			if (evicted !== undefined) {
+				// Decrement semantic counters for the evicted record to keep them
+				// in sync with the sliding window.
+				const evictedEdit = extractEditTarget(evicted)
+				if (evictedEdit) mapDecrement(this.editCounts, evictedEdit)
+				const evictedBash = extractBashPrefix(evicted)
+				if (evictedBash) mapDecrement(this.bashCounts, evictedBash)
+			}
 		}
 
 		const reason = this.detect()
@@ -95,18 +119,56 @@ export class LoopGuard {
 
 	/**
 	 * Blocks `call` if executing it would extend an active loop. Only
-	 * meaningful after a warning has been issued. Detectors need an
-	 * isError flag and output fingerprint for the hypothetical record; we borrow
-	 * them from the most recent historical record with matching tool name +
-	 * args (so the hypo lands in the same slot of any repeating pattern).
-	 * If no such record exists, no detector can fire on a tail ending in
-	 * this hypo (any matching n-gram or consecutive run would require the
-	 * hypo's name + args to appear earlier), so we short-circuit. Sets
-	 * `triggered` when returning true so subsequent calls short-circuit
-	 * through `isTriggered`.
+	 * meaningful after a warning has been issued.
+	 *
+	 * Two checks run:
+	 *
+	 *   1. Edit-run extension — if the call targets the top edit file or uses
+	 *      the top bash prefix, it would extend the existing edit-run cycle.
+	 *      This check runs first and does not require a matching historical
+	 *      record (the edit-run detector uses window-level counts, not
+	 *      contiguity).
+	 *
+	 *   2. N-gram extension — if a historical record exists with matching tool
+	 *      name + args (a "proxy"), the hypo is inserted in that slot and the
+	 *      n-gram detectors are re-run. If no proxy exists, no n-gram can
+	 *      possibly fire on a tail ending in this hypo, so we short-circuit.
+	 *
+	 * The edit-run detector is intentionally excluded from check (2). It uses
+	 * aggregate window counts rather than contiguous patterns, so once the
+	 * window is at threshold it would always return a reason regardless of
+	 * what the new call does — that would over-block unrelated calls. Check
+	 * (1) handles the actual "would this extend the cycle?" question.
 	 */
 	blockIfLoop(call: { toolName: string; toolArgs: string }): boolean {
 		if (!this.warned || this.history.length === 0) return false
+
+		// Edit-run extension check. Cheap: just two map lookups.
+		const hypoForExtract: ToolHistoryRecord = {
+			toolName: call.toolName,
+			toolArgs: call.toolArgs,
+			isError: false,
+			outputFingerprint: "",
+		}
+		const callEditTarget = extractEditTarget(hypoForExtract)
+		const callBashPrefix = extractBashPrefix(hypoForExtract)
+		const topEdit = mapMax(this.editCounts)
+		const topBash = mapMax(this.bashCounts)
+		if (
+			(callEditTarget !== undefined &&
+				topEdit !== undefined &&
+				callEditTarget === topEdit[0] &&
+				topEdit[1] >= EDIT_RUN_THRESHOLD) ||
+			(callBashPrefix !== undefined &&
+				topBash !== undefined &&
+				callBashPrefix === topBash[0] &&
+				topBash[1] >= EDIT_RUN_THRESHOLD)
+		) {
+			this.triggered = true
+			return true
+		}
+
+		// N-gram extension check (existing logic).
 		let proxy: ToolHistoryRecord | undefined
 		for (let i = this.history.length - 1; i >= 0; i--) {
 			const r = this.history[i]
@@ -125,7 +187,7 @@ export class LoopGuard {
 		const saved = this.history
 		this.history = [...saved.slice(-(WINDOW_SIZE - 1)), hypo]
 		try {
-			if (this.detect() === undefined) return false
+			if (this.detectNgramOnly() === undefined) return false
 			this.triggered = true
 			return true
 		} finally {
@@ -134,6 +196,15 @@ export class LoopGuard {
 	}
 
 	private detect(): string | undefined {
+		return (
+			this.detectConsecutiveIdenticalCalls() ??
+			this.detectExactNgram() ??
+			this.detectFuzzyNgram() ??
+			this.detectEditRunCycle()
+		)
+	}
+
+	private detectNgramOnly(): string | undefined {
 		return this.detectConsecutiveIdenticalCalls() ?? this.detectExactNgram() ?? this.detectFuzzyNgram()
 	}
 
@@ -167,6 +238,18 @@ export class LoopGuard {
 		const r3 = countContiguousNgramReps(this.history, 3, fuzzyKey)
 		if (r3 > FUZZY_3GRAM_THRESHOLD) return formatLoopReason(this.history, 3, r3, "same arguments")
 		return undefined
+	}
+
+	private detectEditRunCycle(): string | undefined {
+		const topEdit = mapMax(this.editCounts)
+		const topBash = mapMax(this.bashCounts)
+		if (!topEdit || !topBash) return undefined
+		if (topEdit[1] < EDIT_RUN_THRESHOLD || topBash[1] < EDIT_RUN_THRESHOLD) return undefined
+		const editPreview =
+			topEdit[0].length > REASON_ARG_PREVIEW ? `${topEdit[0].slice(0, REASON_ARG_PREVIEW)}…` : topEdit[0]
+		const bashPreview =
+			topBash[0].length > REASON_ARG_PREVIEW ? `${topBash[0].slice(0, REASON_ARG_PREVIEW)}…` : topBash[0]
+		return `edit-run cycle: ${editPreview} edited ${topEdit[1]}× and bash "${bashPreview}" ran ${topBash[1]}× in last ${this.history.length} calls`
 	}
 }
 
@@ -258,6 +341,62 @@ function extractOutputText(content: ToolResultEvent["content"]): string {
 		if (item.type === "text") parts.push(item.text)
 	}
 	return parts.join("\n")
+}
+
+/**
+ * Extract the file path from an edit or write tool record. Returns undefined
+ * for other tools or when the path is missing or non-string.
+ *
+ * The toolArgs string is the stable-stringified JSON produced by the harness.
+ * JSON.parse round-trips it cleanly; the edit/write schemas both use a `path`
+ * string field.
+ */
+function extractEditTarget(rec: ToolHistoryRecord): string | undefined {
+	if (rec.toolName !== "edit" && rec.toolName !== "write") return undefined
+	try {
+		const args = JSON.parse(rec.toolArgs) as { path?: unknown }
+		return typeof args.path === "string" ? args.path : undefined
+	} catch {
+		return undefined
+	}
+}
+
+/**
+ * Extract a normalized command prefix from a bash tool record. Returns
+ * undefined for other tools or when the command is missing or non-string.
+ *
+ * The prefix length is intentionally short: it groups commands that share an
+ * invocation intent ("cd /app && make -j8 all 2>&1 | tail -20" matches
+ * "cd /app && make -j8 all 2>&1 | tail -60") while keeping distinct commands
+ * separate ("cd /app && make test" vs "cd /app && npm test").
+ */
+function extractBashPrefix(rec: ToolHistoryRecord): string | undefined {
+	if (rec.toolName !== "bash") return undefined
+	try {
+		const args = JSON.parse(rec.toolArgs) as { command?: unknown }
+		return typeof args.command === "string" ? args.command.slice(0, BASH_PREFIX_LENGTH) : undefined
+	} catch {
+		return undefined
+	}
+}
+
+function mapIncrement(map: Map<string, number>, key: string): void {
+	map.set(key, (map.get(key) ?? 0) + 1)
+}
+
+function mapDecrement(map: Map<string, number>, key: string): void {
+	const v = (map.get(key) ?? 0) - 1
+	if (v <= 0) map.delete(key)
+	else map.set(key, v)
+}
+
+/** Return the [key, value] pair with the highest count, or undefined if empty. */
+function mapMax(map: Map<string, number>): [string, number] | undefined {
+	let best: [string, number] | undefined
+	for (const [k, v] of map) {
+		if (!best || v > best[1]) best = [k, v]
+	}
+	return best
 }
 
 export default function loopGuardExtension(pi: ExtensionAPI) {

--- a/src/extensions/loop-guard.ts
+++ b/src/extensions/loop-guard.ts
@@ -29,6 +29,7 @@ const FUZZY_3GRAM_THRESHOLD = 4 // 5× repeat of a 3-gram, output may vary
 const EXACT_2GRAM_THRESHOLD = 5 // 6× repeat of a 2-gram with identical output
 const EXACT_3GRAM_THRESHOLD = 3 // 4× repeat of a 3-gram with identical output
 const EDIT_RUN_THRESHOLD = 8 // same file edited 8× AND same bash prefix 8× in window
+const EDIT_RUN_TOTAL_THRESHOLD = 12 // same file 12× AND same bash prefix 12× over the whole task
 const BASH_PREFIX_LENGTH = 50 // normalize bash commands by this prefix
 const FINGERPRINT_TAIL_LINES = 20
 const REASON_ARG_PREVIEW = 80
@@ -64,6 +65,13 @@ export class LoopGuard {
 	private history: ToolHistoryRecord[] = []
 	private editCounts = new Map<string, number>()
 	private bashCounts = new Map<string, number>()
+	/** Cumulative counts for the whole task. Incremented on every record,
+	 *  never decremented on eviction — catches interleaved edit-run cycles
+	 *  that the 30-record window misses (e.g. when read/grep/ls calls are
+	 *  interleaved with edits and the window count stays below 8). Cleared
+	 *  on session_start / user input via `reset()`. */
+	private editCountsTotal = new Map<string, number>()
+	private bashCountsTotal = new Map<string, number>()
 	private warned = false
 	private triggered = false
 
@@ -71,6 +79,8 @@ export class LoopGuard {
 		this.history = []
 		this.editCounts.clear()
 		this.bashCounts.clear()
+		this.editCountsTotal.clear()
+		this.bashCountsTotal.clear()
 		this.warned = false
 		this.triggered = false
 	}
@@ -86,9 +96,15 @@ export class LoopGuard {
 	record(rec: ToolHistoryRecord): LoopGuardResult {
 		// Increment semantic counters for the new record before pushing.
 		const editTarget = extractEditTarget(rec)
-		if (editTarget) mapIncrement(this.editCounts, editTarget)
+		if (editTarget) {
+			mapIncrement(this.editCounts, editTarget)
+			mapIncrement(this.editCountsTotal, editTarget)
+		}
 		const bashPrefix = extractBashPrefix(rec)
-		if (bashPrefix) mapIncrement(this.bashCounts, bashPrefix)
+		if (bashPrefix) {
+			mapIncrement(this.bashCounts, bashPrefix)
+			mapIncrement(this.bashCountsTotal, bashPrefix)
+		}
 
 		this.history.push(rec)
 		if (this.history.length > WINDOW_SIZE) {
@@ -143,7 +159,10 @@ export class LoopGuard {
 	blockIfLoop(call: { toolName: string; toolArgs: string }): boolean {
 		if (!this.warned || this.history.length === 0) return false
 
-		// Edit-run extension check. Cheap: just two map lookups.
+		// Edit-run extension check. Cheap: just four map lookups.
+		// The window check catches concentrated cycles; the task-total check
+		// catches interleaved ones where the same edit/bash pattern is
+		// spread across many other tool calls.
 		const hypoForExtract: ToolHistoryRecord = {
 			toolName: call.toolName,
 			toolArgs: call.toolArgs,
@@ -154,7 +173,9 @@ export class LoopGuard {
 		const callBashPrefix = extractBashPrefix(hypoForExtract)
 		const topEdit = mapMax(this.editCounts)
 		const topBash = mapMax(this.bashCounts)
-		if (
+		const topEditTotal = mapMax(this.editCountsTotal)
+		const topBashTotal = mapMax(this.bashCountsTotal)
+		const extendsWindowCycle =
 			(callEditTarget !== undefined &&
 				topEdit !== undefined &&
 				callEditTarget === topEdit[0] &&
@@ -163,7 +184,16 @@ export class LoopGuard {
 				topBash !== undefined &&
 				callBashPrefix === topBash[0] &&
 				topBash[1] >= EDIT_RUN_THRESHOLD)
-		) {
+		const extendsTotalCycle =
+			(callEditTarget !== undefined &&
+				topEditTotal !== undefined &&
+				callEditTarget === topEditTotal[0] &&
+				topEditTotal[1] >= EDIT_RUN_TOTAL_THRESHOLD) ||
+			(callBashPrefix !== undefined &&
+				topBashTotal !== undefined &&
+				callBashPrefix === topBashTotal[0] &&
+				topBashTotal[1] >= EDIT_RUN_TOTAL_THRESHOLD)
+		if (extendsWindowCycle || extendsTotalCycle) {
 			this.triggered = true
 			return true
 		}
@@ -200,7 +230,8 @@ export class LoopGuard {
 			this.detectConsecutiveIdenticalCalls() ??
 			this.detectExactNgram() ??
 			this.detectFuzzyNgram() ??
-			this.detectEditRunCycle()
+			this.detectEditRunCycle() ??
+			this.detectEditRunCycleTotal()
 		)
 	}
 
@@ -250,6 +281,23 @@ export class LoopGuard {
 		const bashPreview =
 			topBash[0].length > REASON_ARG_PREVIEW ? `${topBash[0].slice(0, REASON_ARG_PREVIEW)}…` : topBash[0]
 		return `edit-run cycle: ${editPreview} edited ${topEdit[1]}× and bash "${bashPreview}" ran ${topBash[1]}× in last ${this.history.length} calls`
+	}
+
+	private detectEditRunCycleTotal(): string | undefined {
+		// Task-total counts catch interleaved loops that the 30-record
+		// window misses. Window-based detection is still preferred because
+		// it's sensitive to recent behaviour; this is a backstop for the
+		// case where the model spreads the same edit/bash pattern over
+		// 100+ rounds with other work interleaved (e.g. read/grep/ls).
+		const topEdit = mapMax(this.editCountsTotal)
+		const topBash = mapMax(this.bashCountsTotal)
+		if (!topEdit || !topBash) return undefined
+		if (topEdit[1] < EDIT_RUN_TOTAL_THRESHOLD || topBash[1] < EDIT_RUN_TOTAL_THRESHOLD) return undefined
+		const editPreview =
+			topEdit[0].length > REASON_ARG_PREVIEW ? `${topEdit[0].slice(0, REASON_ARG_PREVIEW)}…` : topEdit[0]
+		const bashPreview =
+			topBash[0].length > REASON_ARG_PREVIEW ? `${topBash[0].slice(0, REASON_ARG_PREVIEW)}…` : topBash[0]
+		return `edit-run cycle (task-total): ${editPreview} edited ${topEdit[1]}× and bash "${bashPreview}" ran ${topBash[1]}× across the task`
 	}
 }
 

--- a/src/extensions/loop-guard.ts
+++ b/src/extensions/loop-guard.ts
@@ -31,6 +31,8 @@ const EXACT_2GRAM_THRESHOLD = 5 // 6× repeat of a 2-gram with identical output
 const EXACT_3GRAM_THRESHOLD = 3 // 4× repeat of a 3-gram with identical output
 const EDIT_RUN_THRESHOLD = 8 // same file edited 8× AND same bash prefix 8× in window
 const EDIT_RUN_TOTAL_THRESHOLD = 12 // same file 12× AND same bash prefix 12× over the whole task
+const BASH_REPEAT_THRESHOLD = 12 // bash-only: same prefix 12× in window (no edit required)
+const BASH_REPEAT_TOTAL_THRESHOLD = 15 // bash-only: same prefix 15× across the task
 const BASH_PREFIX_LENGTH = 50 // normalize bash commands by this prefix
 const FINGERPRINT_TAIL_LINES = 20
 const REASON_ARG_PREVIEW = 80
@@ -75,6 +77,10 @@ export class LoopGuard {
 	 *  on session_start / user input via `reset()`. */
 	private editCountsTotal = new Map<string, number>()
 	private bashCountsTotal = new Map<string, number>()
+	/** Normalized bash prefix counts (window). Strips preamble commands
+	 *  and collapses on tool+file so flag variations don't dodge detection. */
+	private bashCountsNorm = new Map<string, number>()
+	private bashCountsNormTotal = new Map<string, number>()
 	private warned = false
 	private triggered = false
 
@@ -84,6 +90,8 @@ export class LoopGuard {
 		this.bashCounts.clear()
 		this.editCountsTotal.clear()
 		this.bashCountsTotal.clear()
+		this.bashCountsNorm.clear()
+		this.bashCountsNormTotal.clear()
 		this.warned = false
 		this.triggered = false
 	}
@@ -108,6 +116,11 @@ export class LoopGuard {
 			mapIncrement(this.bashCounts, bashPrefix)
 			mapIncrement(this.bashCountsTotal, bashPrefix)
 		}
+		const bashPrefixNorm = extractBashPrefixNormalized(rec)
+		if (bashPrefixNorm) {
+			mapIncrement(this.bashCountsNorm, bashPrefixNorm)
+			mapIncrement(this.bashCountsNormTotal, bashPrefixNorm)
+		}
 
 		this.history.push(rec)
 		if (this.history.length > WINDOW_SIZE) {
@@ -119,6 +132,8 @@ export class LoopGuard {
 				if (evictedEdit) mapDecrement(this.editCounts, evictedEdit)
 				const evictedBash = extractBashPrefix(evicted)
 				if (evictedBash) mapDecrement(this.bashCounts, evictedBash)
+				const evictedBashNorm = extractBashPrefixNormalized(evicted)
+				if (evictedBashNorm) mapDecrement(this.bashCountsNorm, evictedBashNorm)
 			}
 		}
 
@@ -138,6 +153,7 @@ export class LoopGuard {
 		this.history = []
 		this.editCounts.clear()
 		this.bashCounts.clear()
+		this.bashCountsNorm.clear()
 
 		return { state: "warn", reason: `${STEERING_MESSAGE} (${reason})` }
 	}
@@ -240,7 +256,8 @@ export class LoopGuard {
 			this.detectExactNgram() ??
 			this.detectFuzzyNgram() ??
 			this.detectEditRunCycle() ??
-			this.detectEditRunCycleTotal()
+			this.detectEditRunCycleTotal() ??
+			this.detectBashRepetition()
 		)
 	}
 
@@ -282,7 +299,10 @@ export class LoopGuard {
 
 	private detectEditRunCycle(): string | undefined {
 		const topEdit = mapMax(this.editCounts)
-		const topBash = mapMax(this.bashCounts)
+		const topBashRaw = mapMax(this.bashCounts)
+		const topBashNorm = mapMax(this.bashCountsNorm)
+		// Pick the higher of raw vs normalized bash count.
+		const topBash = pickHigher(topBashRaw, topBashNorm)
 		if (!topEdit || !topBash) return undefined
 		if (topEdit[1] < EDIT_RUN_THRESHOLD || topBash[1] < EDIT_RUN_THRESHOLD) return undefined
 		const editPreview =
@@ -298,8 +318,12 @@ export class LoopGuard {
 		// it's sensitive to recent behaviour; this is a backstop for the
 		// case where the model spreads the same edit/bash pattern over
 		// 100+ rounds with other work interleaved (e.g. read/grep/ls).
+		// Check both raw and normalized bash prefixes.
 		const topEdit = mapMax(this.editCountsTotal)
-		const topBash = mapMax(this.bashCountsTotal)
+		const topBashRaw = mapMax(this.bashCountsTotal)
+		const topBashNorm = mapMax(this.bashCountsNormTotal)
+		// Pick the higher of raw vs normalized bash count.
+		const topBash = pickHigher(topBashRaw, topBashNorm)
 		if (!topEdit || !topBash) return undefined
 		if (topEdit[1] < EDIT_RUN_TOTAL_THRESHOLD || topBash[1] < EDIT_RUN_TOTAL_THRESHOLD) return undefined
 		const editPreview =
@@ -307,6 +331,38 @@ export class LoopGuard {
 		const bashPreview =
 			topBash[0].length > REASON_ARG_PREVIEW ? `${topBash[0].slice(0, REASON_ARG_PREVIEW)}…` : topBash[0]
 		return `edit-run cycle (task-total): ${editPreview} edited ${topEdit[1]}× and bash "${bashPreview}" ran ${topBash[1]}× across the task`
+	}
+
+	/**
+	 * Detects bash-only loops: the same command (raw or normalized prefix)
+	 * repeated many times without requiring any file edits. Catches patterns
+	 * like repeated yt-dlp downloads, repeated curl calls, repeated make on
+	 * a project that always fails.
+	 */
+	private detectBashRepetition(): string | undefined {
+		// Bash-only thresholds are higher than edit-run because the signal
+		// is weaker (no paired file edit to confirm it's a loop).
+		// Window check (raw)
+		const topBashWin = mapMax(this.bashCounts)
+		if (topBashWin && topBashWin[1] >= BASH_REPEAT_THRESHOLD) {
+			return `bash repetition: "${truncPreview(topBashWin[0])}" ran ${topBashWin[1]}× in last ${this.history.length} calls`
+		}
+		// Window check (normalized)
+		const topBashNormWin = mapMax(this.bashCountsNorm)
+		if (topBashNormWin && topBashNormWin[1] >= BASH_REPEAT_THRESHOLD) {
+			return `bash repetition (normalized): "${truncPreview(topBashNormWin[0])}" ran ${topBashNormWin[1]}× in last ${this.history.length} calls`
+		}
+		// Task-total check (raw)
+		const topBashTotal = mapMax(this.bashCountsTotal)
+		if (topBashTotal && topBashTotal[1] >= BASH_REPEAT_TOTAL_THRESHOLD) {
+			return `bash repetition (task-total): "${truncPreview(topBashTotal[0])}" ran ${topBashTotal[1]}× across the task`
+		}
+		// Task-total check (normalized)
+		const topBashNormTotal = mapMax(this.bashCountsNormTotal)
+		if (topBashNormTotal && topBashNormTotal[1] >= BASH_REPEAT_TOTAL_THRESHOLD) {
+			return `bash repetition (normalized task-total): "${truncPreview(topBashNormTotal[0])}" ran ${topBashNormTotal[1]}× across the task`
+		}
+		return undefined
 	}
 }
 
@@ -419,7 +475,7 @@ function extractEditTarget(rec: ToolHistoryRecord): string | undefined {
 }
 
 /**
- * Extract a normalized command prefix from a bash tool record. Returns
+ * Extract a raw command prefix from a bash tool record. Returns
  * undefined for other tools or when the command is missing or non-string.
  *
  * The prefix length is intentionally short: it groups commands that share an
@@ -435,6 +491,70 @@ function extractBashPrefix(rec: ToolHistoryRecord): string | undefined {
 	} catch {
 		return undefined
 	}
+}
+
+/**
+ * Commands that are pure side-effects or preamble — not the "core intent"
+ * of a compound command. When normalizing, these are skipped to find the
+ * first meaningful command segment.
+ */
+const PREAMBLE_COMMANDS = new Set([
+	"rm",
+	"echo",
+	"wc",
+	"sleep",
+	"cd",
+	"mkdir",
+	"printf",
+	"export",
+	"test",
+	"true",
+	"false",
+	"set",
+	"unset",
+])
+
+/**
+ * Extract a normalized bash prefix that strips common preamble (rm, echo,
+ * wc, cd, etc.) and collapses on `<tool> <first-path-argument>`. This
+ * catches loops where the model varies flags or preamble but the core
+ * intent is the same (e.g. `rm -f a.out && gcc -O3 file.c` and
+ * `wc -c file.c && gcc -O0 file.c` both normalize to `gcc file.c`).
+ *
+ * Returns undefined for non-bash tools.
+ */
+export function extractBashPrefixNormalized(rec: ToolHistoryRecord): string | undefined {
+	if (rec.toolName !== "bash") return undefined
+	try {
+		const args = JSON.parse(rec.toolArgs) as { command?: unknown }
+		if (typeof args.command !== "string") return undefined
+		return normalizeBashCommand(args.command)
+	} catch {
+		return undefined
+	}
+}
+
+/** Exported for testing. */
+export function normalizeBashCommand(command: string): string {
+	// Split on compound operators and newlines to get individual segments.
+	const segments = command.split(/\s*(?:&&|\|\||;|\n)\s*/)
+	for (const seg of segments) {
+		const trimmed = seg.trim()
+		if (!trimmed) continue
+		const tokens = trimmed.split(/\s+/)
+		const tool = tokens[0]
+		if (!tool || PREAMBLE_COMMANDS.has(tool)) continue
+		// Found the core command. Extract <tool> <first-path-argument>
+		// to collapse flag variations (gcc -O0 file.c ≈ gcc -O3 file.c).
+		const pathArg = tokens.slice(1).find((t) => !t.startsWith("-") && (t.includes("/") || /\.[a-zA-Z]/.test(t)))
+		if (pathArg) {
+			return `${tool} ${pathArg}`
+		}
+		// No path argument — fall back to raw prefix of the core command.
+		return trimmed.slice(0, BASH_PREFIX_LENGTH)
+	}
+	// All segments are preamble — use the full command prefix.
+	return command.slice(0, BASH_PREFIX_LENGTH)
 }
 
 function mapIncrement(map: Map<string, number>, key: string): void {
@@ -454,6 +574,18 @@ function mapMax(map: Map<string, number>): [string, number] | undefined {
 		if (!best || v > best[1]) best = [k, v]
 	}
 	return best
+}
+
+/** Pick whichever of two optional [key, count] pairs has the higher count. */
+function pickHigher(a: [string, number] | undefined, b: [string, number] | undefined): [string, number] | undefined {
+	if (!a) return b
+	if (!b) return a
+	return a[1] >= b[1] ? a : b
+}
+
+/** Truncate a string for display in reason messages. */
+function truncPreview(s: string): string {
+	return s.length > REASON_ARG_PREVIEW ? `${s.slice(0, REASON_ARG_PREVIEW)}…` : s
 }
 
 export default function loopGuardExtension(pi: ExtensionAPI) {


### PR DESCRIPTION
## Summary

Adds two new guard detectors that close gaps in the existing `LoopGuard` and `ExplorationGuard` extensions, validated against two terminal-bench-2 runs with `minimax-m3` (89 tasks, 55% pass rate, 263M tokens).

The existing guards fired **zero times** across all 10 stuck/looping tasks in the benchmark — the new detectors would have caught 8+ of them.

## Changes

### Thinking-only turn detector (`exploration-guard.ts`)

Tracks consecutive turns where the model produced output with zero tool calls. Warns at 3, mandatory steers at 5. Closes a gap where `exploration-guard` explicitly reset on no-tool turns (regex-chess spent 3 hours thinking; polyglot-rust-c had 273 consecutive no-tool turns in the second run).

Behavior change: no-tool turns are now **neutral** for the read-only counter (previously reset it). This preserves the read-only streak across reasoning breaks so the read-only detector can still see the exploration pattern underneath.

### Edit-run cycle detector (`loop-guard.ts`)

Tracks file edit counts and bash command prefix counts over the 30-record sliding window. Fires when any single file hits 8+ edits AND any single bash prefix hits 8+ runs. Closes the gap where the existing n-gram detectors (which require contiguous repetition and matching tool args) missed the edit → build → run → see-error → edit cycle that pervades MIPS interpreter and Doom cross-compilation tasks.

`blockIfLoop` was refined: edit-run extension is checked explicitly before n-gram checks (same file or same bash prefix as the loop), and n-gram checks no longer include the edit-run detector (which would over-block since its aggregate counts stay at threshold after warn).

## Validation against benchmark data

| Detector        | Caught in run 1 | Caught in run 2       |
|-----------------|-----------------|------------------------|
| Edit-run cycle  | 3 timeouts      | 3 timeouts             |
| Thinking-only   | 1 timeout       | 1 timeout + 4 failures |

Sample caught cases:
- `make-doom-for-mips` (22M+ tokens, 177 rounds)
- `polyglot-rust-c` (273 consecutive no-tool turns)
- `regex-chess` (3 hours thinking, 4 tool calls)
- `circuit-fibsqrt`, `path-tracing-reverse`, `path-tracing`

## Tests

- **+24 new tests** across both files
- **+2 updated tests** for the no-tool turn behavior change in exploration guard
- Full suite: **5350 tests passing**, no regressions
- Biome and typecheck clean

## Notes

- Both detectors are conservative on false positives: thresholds of 8+ require sustained repetition (productive cycles typically converge in 3-5 iterations)
- The edit-run detector requires **both** a repeated file AND a repeated bash prefix before firing — editing one file with different build commands (or vice versa) does not trigger
- The thinking-only detector thresholds (3 warn, 5 mandatory) were chosen to avoid flagging normal model reasoning pauses
