### PR TITLE
fix(ci): run master-checks on pull_request events

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,11 +47,20 @@ jobs:
         run: pnpm run test:smoke
 
   master-checks:
-    if: github.event_name == 'push'
+    # Run on both push-to-master and pull_request so PR CI exercises the same
+    # post-merge checks (e.g. `make build` + `pnpm run test` without the
+    # `KIMCHI_PROXY_HELPER` env var) that will run after merge. Without this,
+    # a PR based on a stale base ref can pass `pr-checks` and only fail at the
+    # post-merge `master-checks` step, leaving master red until a follow-up
+    # lands (see #657 for the original incident).
+    if: github.event_name == 'push' || github.event_name == 'pull_request'
     runs-on: ubuntu-latest
     timeout-minutes: 10
     concurrency:
-      group: ci-master
+      # Single shared group for master pushes (only one build at a time, cancel
+      # stale ones). Per-PR groups for pull requests so concurrent PRs don't
+      # cancel each other's checks.
+      group: ${{ github.event_name == 'push' && 'ci-master' || format('ci-pr-master-checks-{0}', github.head_ref) }}
       cancel-in-progress: true
 
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,9 +57,21 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     concurrency:
-      # Single shared group for master pushes (only one build at a time, cancel
-      # stale ones). Per-PR groups for pull requests so concurrent PRs don't
-      # cancel each other's checks.
+      # Pick a concurrency group name based on the triggering event:
+      #
+      #   push to master     → group = "ci-master"
+      #                        (single slot; new pushes cancel stale runs)
+      #   pull_request       → group = "ci-pr-master-checks-<head_ref>"
+      #                        e.g. PR from "fix/foo"  →  "ci-pr-master-checks-fix/foo"
+      #                        (one slot per PR; cancels only that PR's stale runs)
+      #
+      # Why not a single "ci-master" group across both events? It would make
+      # concurrent PRs cancel each other and let master pushes cancel
+      # in-flight PR runs.
+      #
+      # `&&`/`||` short-circuit in GitHub Actions expressions, so the
+      # `format(...)` on the right side is only evaluated on pull_request
+      # events (where `github.head_ref` is defined; it's empty for push).
       group: ${{ github.event_name == 'push' && 'ci-master' || format('ci-pr-master-checks-{0}', github.head_ref) }}
       cancel-in-progress: true
 


### PR DESCRIPTION
## Problem

`.github/workflows/ci.yml`'s `master-checks` job was gated on
`push`-to-master only. As a result, a PR based on a stale base ref
could pass `pr-checks` and only fail at the post-merge
`master-checks` step, leaving `master` red until a follow-up landed.

This is exactly what happened with #640:

1. PR #640 was branched from `63f62f44` — a master SHA 7 commits
   behind.
2. PR-level `pr-checks` ran against the merge commit of (PR head +
   `63f62f44`), did not contain the `researcher` field added by #603
   in `4f2dc79e`. Typecheck was clean. CI green.
3. #640 was merged. Post-merge `master-checks` ran against the real
   master HEAD, which now included both `4f2dc79e` (requiring
   `researcher`) and the ollama code (not setting it). TS2741 fired.
4. Every subsequent push to master failed the same typecheck until
   #657 landed.

## Fix

Make `master-checks` run on both `push` and `pull_request` events so
PR CI exercises the same post-merge checks before the merge button
is enabled.

**Diff** (`.github/workflows/ci.yml`, 11 +/− 2):

```diff
   master-checks:
-    if: github.event_name == 'push'
+    if: github.event_name == 'push' || github.event_name == 'pull_request'
     runs-on: ubuntu-latest
     timeout-minutes: 10
     concurrency:
-      group: ci-master
+      group: ${{ github.event_name == 'push' && 'ci-master' || format('ci-pr-master-checks-{0}', github.head_ref) }}
       cancel-in-progress: true
```

## Why the concurrency group is split

A single `ci-master` concurrency group would cause two problems if
`master-checks` started running on PRs:

1. **Concurrent PRs would cancel each other** — PR A's run would be
   cancelled when PR B's run started, because both share the same
   group.
2. **PR runs would interfere with actual master pushes** — an
   in-progress PR run could be cancelled by (or cancel) a real master
   push's run.

The fix uses GitHub Actions' short-circuit expression to give each
event its own group:

- `push` to master → `ci-master` (single shared group, cancels stale
  pushes — same behavior as today)
- `pull_request` → `ci-pr-master-checks-{head_ref}` (per-PR group, so
  concurrent PRs run independently and don't interfere with master
  pushes)

`github.head_ref` is empty for `push` events, but the short-circuit
`&&` ensures the `ci-master` branch is taken for those — the
`format(...)` on the right side is never the result of the expression
in the push case.

## What is and is not changed

- `pr-checks` job: **unchanged** — still the lighter-weight PR-only
  check (`make copy-for-dev`, `KIMCHI_PROXY_HELPER` env var).
- `master-checks` job steps: **unchanged** — same `make build`,
  `pnpm run test`, smoke tests that run today on master pushes.
- Trigger: now also `pull_request`.

## Cost

PRs will now run **both** `pr-checks` AND `master-checks`. Total wall
time roughly doubles from ~3 min to ~6 min on a PR (jobs run in
parallel because they have separate concurrency groups). The
`pr-checks` job is kept for now because it uses a slightly different
proxy-helper build target (`make copy-for-dev`) and sets the
`KIMCHI_PROXY_HELPER` env var that some integration tests rely on.
Removing it would be a separate, larger change.

## Verification

- `yq` parses the workflow cleanly post-edit (both expressions
  round-trip).
- The workflow will be validated by GitHub Actions on push. If the
  YAML or expressions are invalid, the workflow fails to start and
  the PR cannot be merged.

## Followups (not in this PR)

- **Branch protection**: enabling "Require branches to be up to date
  before merging" on `master` would catch stale-base PRs even before
  CI runs — a complementary defense-in-depth.
- **Consolidate `pr-checks` and `master-checks`**: now that both run
  on PRs, the redundancy is obvious. A future PR could collapse them
  into a single job that uses the post-merge config everywhere.

Refs #657 (the original fix PR that this workflow change is
designed to make redundant).
