### PR TITLE
docs: Add docstring to collapseCommand

### DIFF
--- a/src/extensions/bash-collapse.ts
+++ b/src/extensions/bash-collapse.ts
@@ -1,3 +1,8 @@
+/**
+ * Collapses multiple newlines in a command string into a single space with a return symbol (⏎).
+ * @param command - The command string to collapse, which may be undefined.
+ * @returns The collapsed string with newlines replaced by ' ⏎ '.
+ */
 export function collapseCommand(command: string | undefined): string {
 	return (command ?? "").replace(/\n+/g, " ⏎ ")
 }


### PR DESCRIPTION
### 问题背景

公共函数 `collapseCommand` 缺少文档字符串，这降低了代码的可读性和可维护性。在开源项目中，文档对于其他贡献者理解功能至关重要。

### 修改内容

- 为 `collapseCommand` 函数添加了 JSDoc 风格的文档字符串。
- 文档包括函数描述、参数 `@param` 和返回值 `@returns`。
- 这提升了代码的可读性，使得函数用途一目了然。

### 验证方式

- 由于此修改仅添加文档字符串，未改变函数行为，所有现有测试应继续通过。
- 可以手动验证函数功能未变：调用函数并检查输出。

### 其他信息

- 没有 breaking changes。
- 文档已更新，无需额外步骤。
- 没有已知限制。