### PR TITLE
Suppress continuation nudge on user abort and in fresh sessions

### DIFF
--- a/src/extensions/orchestration/continuation-nudge.test.ts
+++ b/src/extensions/orchestration/continuation-nudge.test.ts
@@ -154,6 +154,32 @@ describe("ContinuationNudge.evaluateTurn", () => {
 		const thinkingOnly = makeAssistant([{ type: "thinking", thinking: "Let me reason..." }])
 		expect(guard.evaluateTurn(thinkingOnly)).toBe(false)
 	})
+
+	it("does not nudge when the user aborted the turn (stopReason: aborted)", () => {
+		const guard = new ContinuationNudge()
+		guard.resetForNewUserInput()
+		const aborted = { ...textOnlyMessage, stopReason: "aborted" as const }
+		expect(guard.evaluateTurn(aborted)).toBe(false)
+	})
+
+	it("does not consume a nudge slot when the turn was aborted", () => {
+		// An aborted turn must not decrement the per-cycle budget — a subsequent
+		// legitimate text-only turn in the same cycle should still get its nudge.
+		const guard = new ContinuationNudge()
+		guard.resetForNewUserInput()
+		const aborted = { ...textOnlyMessage, stopReason: "aborted" as const }
+		expect(guard.evaluateTurn(aborted)).toBe(false)
+		expect(guard.evaluateTurn(textOnlyMessage)).toBe(true)
+		expect(guard.evaluateTurn(textOnlyMessage)).toBe(true)
+		expect(guard.evaluateTurn(textOnlyMessage)).toBe(false)
+	})
+
+	it("still nudges on a normal stopReason: stop turn", () => {
+		// Regression guard — the abort check must not regress the normal path.
+		const guard = new ContinuationNudge()
+		guard.resetForNewUserInput()
+		expect(guard.evaluateTurn(textOnlyMessage)).toBe(true)
+	})
 })
 
 describe("ContinuationNudge.isDoneSignalReceived", () => {
@@ -411,6 +437,12 @@ describe("EmptyTurnNudge", () => {
 		// Reset re-arms the nudge for the next user-input cycle
 		guard.resetForNewUserInput()
 		expect(guard.evaluateTurn(emptyMessage)).toBe(true)
+	})
+
+	it("does not nudge when the user aborted the turn (stopReason: aborted)", () => {
+		const guard = new EmptyTurnNudge()
+		const aborted = { ...emptyMessage, stopReason: "aborted" as const }
+		expect(guard.evaluateTurn(aborted)).toBe(false)
 	})
 })
 

--- a/src/extensions/orchestration/continuation-nudge.test.ts
+++ b/src/extensions/orchestration/continuation-nudge.test.ts
@@ -53,10 +53,23 @@ const textAndToolCallMessage = makeAssistant([
 const emptyTextMessage = makeAssistant([{ type: "text", text: "" }])
 const whitespaceTextMessage = makeAssistant([{ type: "text", text: "   \n  " }])
 
+// The nudge is suppressed in a fresh session until at least one tool has been
+// called. Tests that exercise the nudge-firing path use this helper to simulate
+// "a tool was called at some earlier point in the session, and we are now in a
+// fresh user-input cycle". Tests that exercise the fresh-session suppression
+// itself live in the session-level describe block below and do not use this.
+function simulateSessionWithPriorToolCall(guard: ContinuationNudge): void {
+	guard.recordToolCall()
+	guard.resetForNewUserInput()
+}
+
 describe("ContinuationNudge.evaluateTurn", () => {
+	// Tests in this block exercise nudge firing on text-only turns and share the
+	// `simulateSessionWithPriorToolCall` helper above.
+
 	it("nudges a text-only first turn after user input", () => {
 		const guard = new ContinuationNudge()
-		guard.resetForNewUserInput()
+		simulateSessionWithPriorToolCall(guard)
 		expect(guard.evaluateTurn(textOnlyMessage)).toBe(true)
 	})
 
@@ -92,7 +105,7 @@ describe("ContinuationNudge.evaluateTurn", () => {
 
 	it("nudges at most twice per user-input cycle", () => {
 		const guard = new ContinuationNudge()
-		guard.resetForNewUserInput()
+		simulateSessionWithPriorToolCall(guard)
 		expect(guard.evaluateTurn(textOnlyMessage)).toBe(true)
 		expect(guard.evaluateTurn(textOnlyMessage)).toBe(true)
 		expect(guard.evaluateTurn(textOnlyMessage)).toBe(false)
@@ -107,7 +120,7 @@ describe("ContinuationNudge.evaluateTurn", () => {
 
 	it("re-arms after a new user input", () => {
 		const guard = new ContinuationNudge()
-		guard.resetForNewUserInput()
+		simulateSessionWithPriorToolCall(guard)
 		expect(guard.evaluateTurn(textOnlyMessage)).toBe(true)
 		guard.resetForNewUserInput()
 		expect(guard.evaluateTurn(textOnlyMessage)).toBe(true)
@@ -124,7 +137,7 @@ describe("ContinuationNudge.evaluateTurn", () => {
 
 	it("sets nudge response pending after nudging", () => {
 		const guard = new ContinuationNudge()
-		guard.resetForNewUserInput()
+		simulateSessionWithPriorToolCall(guard)
 		expect(guard.isNudgeResponsePending()).toBe(false)
 		guard.evaluateTurn(textOnlyMessage)
 		expect(guard.isNudgeResponsePending()).toBe(true)
@@ -132,7 +145,7 @@ describe("ContinuationNudge.evaluateTurn", () => {
 
 	it("clears nudge response pending when a tool call is recorded", () => {
 		const guard = new ContinuationNudge()
-		guard.resetForNewUserInput()
+		simulateSessionWithPriorToolCall(guard)
 		guard.evaluateTurn(textOnlyMessage)
 		expect(guard.isNudgeResponsePending()).toBe(true)
 		guard.recordToolCall()
@@ -141,7 +154,7 @@ describe("ContinuationNudge.evaluateTurn", () => {
 
 	it("clears nudge response pending on reset", () => {
 		const guard = new ContinuationNudge()
-		guard.resetForNewUserInput()
+		simulateSessionWithPriorToolCall(guard)
 		guard.evaluateTurn(textOnlyMessage)
 		expect(guard.isNudgeResponsePending()).toBe(true)
 		guard.resetForNewUserInput()
@@ -157,7 +170,7 @@ describe("ContinuationNudge.evaluateTurn", () => {
 
 	it("does not nudge when the user aborted the turn (stopReason: aborted)", () => {
 		const guard = new ContinuationNudge()
-		guard.resetForNewUserInput()
+		simulateSessionWithPriorToolCall(guard)
 		const aborted = { ...textOnlyMessage, stopReason: "aborted" as const }
 		expect(guard.evaluateTurn(aborted)).toBe(false)
 	})
@@ -166,7 +179,7 @@ describe("ContinuationNudge.evaluateTurn", () => {
 		// An aborted turn must not decrement the per-cycle budget — a subsequent
 		// legitimate text-only turn in the same cycle should still get its nudge.
 		const guard = new ContinuationNudge()
-		guard.resetForNewUserInput()
+		simulateSessionWithPriorToolCall(guard)
 		const aborted = { ...textOnlyMessage, stopReason: "aborted" as const }
 		expect(guard.evaluateTurn(aborted)).toBe(false)
 		expect(guard.evaluateTurn(textOnlyMessage)).toBe(true)
@@ -177,6 +190,79 @@ describe("ContinuationNudge.evaluateTurn", () => {
 	it("still nudges on a normal stopReason: stop turn", () => {
 		// Regression guard — the abort check must not regress the normal path.
 		const guard = new ContinuationNudge()
+		simulateSessionWithPriorToolCall(guard)
+		expect(guard.evaluateTurn(textOnlyMessage)).toBe(true)
+	})
+})
+
+describe("ContinuationNudge session-level tool tracking", () => {
+	it("starts with no tools called in this session", () => {
+		const guard = new ContinuationNudge()
+		expect(guard.hasToolBeenCalledThisSession()).toBe(false)
+	})
+
+	it("does not nudge in a fresh session before any tool has been called", () => {
+		// User opens with a conversational prompt ("hey", "ask me some
+		// questions"); the orchestrator legitimately responds with text-only
+		// clarifying questions. Nudging it would be wrong.
+		const guard = new ContinuationNudge()
+		guard.resetForNewUserInput()
+		expect(guard.evaluateTurn(textOnlyMessage)).toBe(false)
+	})
+
+	it("starts nudging once a tool has been called at least once in the session", () => {
+		const guard = new ContinuationNudge()
+		guard.resetForNewUserInput()
+		guard.recordToolCall() // first tool call of session
+		guard.resetForNewUserInput() // new cycle begins after the tool call
+		expect(guard.hasToolBeenCalledThisSession()).toBe(true)
+		expect(guard.evaluateTurn(textOnlyMessage)).toBe(true)
+	})
+
+	it("session-level latch persists across user-input cycles", () => {
+		const guard = new ContinuationNudge()
+		guard.resetForNewUserInput()
+		guard.recordToolCall()
+		guard.resetForNewUserInput() // new user input arrives later
+		expect(guard.hasToolBeenCalledThisSession()).toBe(true)
+		expect(guard.evaluateTurn(textOnlyMessage)).toBe(true)
+	})
+
+	it("session-level latch persists across agent runs", () => {
+		const guard = new ContinuationNudge()
+		guard.resetForNewUserInput()
+		guard.recordToolCall()
+		guard.resetForNewAgentRun() // simulate a /agent run boundary
+		expect(guard.hasToolBeenCalledThisSession()).toBe(true)
+	})
+
+	it("does not consume a nudge slot while no tools have been called this session", () => {
+		// Fresh session, no tools yet — repeated text-only turns must not burn
+		// the per-cycle budget, so when a tool is eventually called the full
+		// budget remains available.
+		const guard = new ContinuationNudge()
+		guard.resetForNewUserInput()
+		expect(guard.evaluateTurn(textOnlyMessage)).toBe(false)
+		expect(guard.evaluateTurn(textOnlyMessage)).toBe(false)
+		expect(guard.evaluateTurn(textOnlyMessage)).toBe(false)
+		// Simulate: a tool fires (e.g. a read), then a new user-input cycle begins.
+		guard.recordToolCall()
+		guard.resetForNewUserInput()
+		expect(guard.evaluateTurn(textOnlyMessage)).toBe(true)
+		expect(guard.evaluateTurn(textOnlyMessage)).toBe(true)
+		expect(guard.evaluateTurn(textOnlyMessage)).toBe(false)
+	})
+
+	it("aborted turns in a fresh session still do not nudge and do not consume budget", () => {
+		// Both guards compose: a user-aborted turn in a fresh session is doubly
+		// suppressed, with no budget burned.
+		const guard = new ContinuationNudge()
+		guard.resetForNewUserInput()
+		const aborted = { ...textOnlyMessage, stopReason: "aborted" as const }
+		expect(guard.evaluateTurn(aborted)).toBe(false)
+		expect(guard.evaluateTurn(textOnlyMessage)).toBe(false)
+		// After a tool fires, the full budget becomes available.
+		guard.recordToolCall()
 		guard.resetForNewUserInput()
 		expect(guard.evaluateTurn(textOnlyMessage)).toBe(true)
 	})
@@ -226,7 +312,7 @@ describe("ContinuationNudge.isDoneSignalReceived", () => {
 describe("ContinuationNudge nudge-response-pending state", () => {
 	it("marks nudge response pending after evaluateTurn fires", () => {
 		const guard = new ContinuationNudge()
-		guard.resetForNewUserInput()
+		simulateSessionWithPriorToolCall(guard)
 		expect(guard.isNudgeResponsePending()).toBe(false)
 		guard.evaluateTurn(textOnlyMessage)
 		expect(guard.isNudgeResponsePending()).toBe(true)
@@ -238,7 +324,7 @@ describe("ContinuationNudge nudge-response-pending state", () => {
 		// called. The turn_end handler in prompt-enrichment.ts checks stopReason
 		// to decide whether to honour the stop or send another nudge.
 		const guard = new ContinuationNudge()
-		guard.resetForNewUserInput()
+		simulateSessionWithPriorToolCall(guard)
 		guard.evaluateTurn(textOnlyMessage) // first nudge fires
 		expect(guard.isNudgeResponsePending()).toBe(true)
 		// Model responds with text but not <done>; no tool calls recorded.
@@ -251,7 +337,7 @@ describe("ContinuationNudge nudge-response-pending state", () => {
 
 	it("clears pending state when model calls a tool after nudge", () => {
 		const guard = new ContinuationNudge()
-		guard.resetForNewUserInput()
+		simulateSessionWithPriorToolCall(guard)
 		guard.evaluateTurn(textOnlyMessage) // nudge fires
 		expect(guard.isNudgeResponsePending()).toBe(true)
 		guard.recordToolCall() // model obeyed the nudge
@@ -262,7 +348,7 @@ describe("ContinuationNudge nudge-response-pending state", () => {
 describe("ContinuationNudge Agent-pending suppression", () => {
 	it("suppresses the nudge when an Agent call is pending", () => {
 		const guard = new ContinuationNudge()
-		guard.resetForNewUserInput()
+		simulateSessionWithPriorToolCall(guard)
 		guard.markDelegationCall()
 		// Even though this is a text-only turn, the nudge must not fire
 		// because an Agent result is still pending.
@@ -271,7 +357,7 @@ describe("ContinuationNudge Agent-pending suppression", () => {
 
 	it("allows the nudge after clearDelegationPending is called", () => {
 		const guard = new ContinuationNudge()
-		guard.resetForNewUserInput()
+		simulateSessionWithPriorToolCall(guard)
 		guard.markDelegationCall()
 		guard.clearDelegationPending()
 		// Now the nudge can fire normally.
@@ -280,7 +366,7 @@ describe("ContinuationNudge Agent-pending suppression", () => {
 
 	it("resetForNewUserInput does NOT clear pending delegation count", () => {
 		const guard = new ContinuationNudge()
-		guard.resetForNewUserInput()
+		simulateSessionWithPriorToolCall(guard)
 		guard.markDelegationCall()
 		// Simulate an unrelated user input arriving while an Agent is running.
 		guard.resetForNewUserInput()
@@ -290,7 +376,7 @@ describe("ContinuationNudge Agent-pending suppression", () => {
 
 	it("a regular tool call does NOT clear pending delegation count", () => {
 		const guard = new ContinuationNudge()
-		guard.resetForNewUserInput()
+		simulateSessionWithPriorToolCall(guard)
 		guard.markDelegationCall()
 		// Model makes a regular non-Agent tool call — delegation is still pending.
 		guard.recordToolCall()
@@ -299,7 +385,7 @@ describe("ContinuationNudge Agent-pending suppression", () => {
 
 	it("multiple markDelegationCall requires matching clearDelegationPending calls", () => {
 		const guard = new ContinuationNudge()
-		guard.resetForNewUserInput()
+		simulateSessionWithPriorToolCall(guard)
 		guard.markDelegationCall()
 		guard.markDelegationCall() // two concurrent Agents
 		expect(guard.evaluateTurn(textOnlyMessage)).toBe(false)
@@ -313,7 +399,7 @@ describe("ContinuationNudge Agent-pending suppression", () => {
 
 	it("clearDelegationPending without markDelegationCall has no effect", () => {
 		const guard = new ContinuationNudge()
-		guard.resetForNewUserInput()
+		simulateSessionWithPriorToolCall(guard)
 		guard.clearDelegationPending()
 		// Normal behavior: nudge fires on text-only turn.
 		expect(guard.evaluateTurn(textOnlyMessage)).toBe(true)

--- a/src/extensions/orchestration/continuation-nudge.ts
+++ b/src/extensions/orchestration/continuation-nudge.ts
@@ -126,6 +126,9 @@ export class ContinuationNudge {
 		// Do not nudge while any Agent result is pending — the model must
 		// wait for all Agent outputs before it can continue or signal done.
 		if (this.pendingDelegationCount > 0) return false
+		// The user explicitly cancelled this turn (Esc / Ctrl+C). Respect the
+		// abort — they don't want the model to be re-prompted with a nudge.
+		if (message.stopReason === "aborted") return false
 		const hasToolCalls = message.content.some((c) => c.type === "toolCall")
 		const hasText = message.content.some((c) => c.type === "text" && c.text.trim().length > 0)
 		if (hasToolCalls || !hasText) return false
@@ -182,6 +185,11 @@ export class EmptyTurnNudge {
 
 	evaluateTurn(message: AssistantMessage): boolean {
 		if (this.nudgeCountThisCycle >= EmptyTurnNudge.MAX_NUDGES) return false
+
+		// Respect user aborts (Esc / Ctrl+C) the same way the continuation
+		// nudge does — the model should not be asked to keep going after
+		// the user explicitly cancelled.
+		if (message.stopReason === "aborted") return false
 
 		const hasText = message.content.some((c) => c.type === "text" && c.text.trim().length > 0)
 		const hasToolCalls = message.content.some((c) => c.type === "toolCall")

--- a/src/extensions/orchestration/continuation-nudge.ts
+++ b/src/extensions/orchestration/continuation-nudge.ts
@@ -66,6 +66,11 @@ export class ContinuationNudge {
 	 *  does not re-arm the nudge and cause spurious "you didn't call a tool"
 	 *  prompts that the model mistakes for user input. */
 	private toolsCalledThisAgentRun = false
+	/** Session-lifetime latch: once any tool has been called in this session,
+	 *  it stays true. Suppresses the nudge in a fresh conversation where the
+	 *  user opens with a conversational prompt and the model legitimately
+	 *  responds with text-only clarifying questions instead of calling a tool. */
+	private toolsCalledThisSession = false
 	private nudgeCountThisCycle = 0
 	private nudgeResponsePending = false
 	private accumulatedResponseText = ""
@@ -95,6 +100,7 @@ export class ContinuationNudge {
 	recordToolCall(): void {
 		this.toolsCalledSinceLastUserInput = true
 		this.toolsCalledThisAgentRun = true
+		this.toolsCalledThisSession = true
 		this.nudgeResponsePending = false
 		this.accumulatedResponseText = ""
 	}
@@ -122,6 +128,8 @@ export class ContinuationNudge {
 
 	evaluateTurn(message: AssistantMessage): boolean {
 		if (this.nudgeCountThisCycle >= ContinuationNudge.MAX_NUDGES) return false
+		// In a fresh session, suppress the nudge until at least one tool has been called.
+		if (!this.toolsCalledThisSession) return false
 		if (this.toolsCalledSinceLastUserInput) return false
 		// Do not nudge while any Agent result is pending — the model must
 		// wait for all Agent outputs before it can continue or signal done.
@@ -161,6 +169,10 @@ export class ContinuationNudge {
 		return this.toolsCalledThisAgentRun
 	}
 
+	hasToolBeenCalledThisSession(): boolean {
+		return this.toolsCalledThisSession
+	}
+
 	getNudgeText(): string {
 		return this.nudgeCountThisCycle <= 1 ? CONTINUATION_NUDGE_TEXT : SECOND_NUDGE_TEXT
 	}
@@ -185,10 +197,6 @@ export class EmptyTurnNudge {
 
 	evaluateTurn(message: AssistantMessage): boolean {
 		if (this.nudgeCountThisCycle >= EmptyTurnNudge.MAX_NUDGES) return false
-
-		// Respect user aborts (Esc / Ctrl+C) the same way the continuation
-		// nudge does — the model should not be asked to keep going after
-		// the user explicitly cancelled.
 		if (message.stopReason === "aborted") return false
 
 		const hasText = message.content.some((c) => c.type === "text" && c.text.trim().length > 0)

--- a/src/extensions/prompt-construction/prompt-enrichment.test.ts
+++ b/src/extensions/prompt-construction/prompt-enrichment.test.ts
@@ -967,7 +967,9 @@ describe("continuation nudge turn_end handler", () => {
 	it("sends a continuation nudge on a text-only turn with no tools called", async () => {
 		const { fire, sendMessageCalls } = buildNudgeHandlers()
 
-		// Simulate user input to reset the nudge state.
+		// Simulate a tool having been called earlier in the session so the
+		// fresh-session suppression does not apply. Then a new user-input cycle.
+		await fire("tool_execution_start", {})
 		await fire("input", { source: "user" })
 
 		// Model responds with text-only, stopReason "stop".
@@ -983,7 +985,8 @@ describe("continuation nudge turn_end handler", () => {
 	it("does not send a second nudge when model responds to nudge with stopReason 'stop'", async () => {
 		const { fire, sendMessageCalls } = buildNudgeHandlers()
 
-		// Simulate user input.
+		// Tool called earlier in the session so the fresh-session guard is past.
+		await fire("tool_execution_start", {})
 		await fire("input", { source: "user" })
 
 		// First text-only turn triggers the continuation nudge.
@@ -1003,6 +1006,7 @@ describe("continuation nudge turn_end handler", () => {
 	it("falls through to second nudge when model responds with non-stop stopReason", async () => {
 		const { fire, sendMessageCalls } = buildNudgeHandlers()
 
+		await fire("tool_execution_start", {})
 		await fire("input", { source: "user" })
 
 		// First text-only turn triggers the continuation nudge.

--- a/tests/e2e/tui/continuation-nudge-suppression.test.ts
+++ b/tests/e2e/tui/continuation-nudge-suppression.test.ts
@@ -1,0 +1,212 @@
+import { expect, test } from "@microsoft/tui-test"
+import type { KimchiFixture } from "./support/kimchi-fixture.js"
+import { TUI_TEST_CONFIG, runKimchiSession } from "./support/kimchi-fixture.js"
+import { STREAM_TIMEOUT_MS, waitForText } from "./support/assertions.js"
+
+test.use(TUI_TEST_CONFIG)
+
+/** Nudge phrases emitted by the orchestrator nudges when they fire. */
+const CONTINUATION_NUDGE_PHRASE = "You ended your turn without calling a tool" // CONTINUATION_NUDGE_TEXT
+const SECOND_NUDGE_PHRASE = "You MUST call a tool immediately" // SECOND_NUDGE_TEXT
+const EMPTY_TURN_NUDGE_PHRASE =
+	"If you have finished, please summarize the result for the user" // EMPTY_TURN_NUDGE_TEXT
+
+/**
+ * The harness makes several session-bookkeeping completion requests per user
+ * input (title generation, context summary, …), so counting requests is not
+ * a meaningful signal. The robust assertion is: the nudge text must not
+ * (or must) appear in any request body after the turn completes — a
+ * `followUp` nudge is injected into the conversation and shows up in every
+ * subsequent request's messages array.
+ */
+function anyRequestContainsNudgePhrase(fixture: KimchiFixture, phrase: string): boolean {
+	for (const request of fixture.fake.requests) {
+		const bodyText = JSON.stringify(request.body ?? "")
+		if (bodyText.includes(phrase)) return true
+	}
+	return false
+}
+
+function anyRequestContainsAnyNudge(fixture: KimchiFixture): boolean {
+	return (
+		anyRequestContainsNudgePhrase(fixture, CONTINUATION_NUDGE_PHRASE) ||
+		anyRequestContainsNudgePhrase(fixture, SECOND_NUDGE_PHRASE) ||
+		anyRequestContainsNudgePhrase(fixture, EMPTY_TURN_NUDGE_PHRASE)
+	)
+}
+
+/**
+ * Waits for the harness to finish processing the orchestrator's main turn
+ * AND any nudge-driven followUp turn. The terminal prints a `✻ Worked for`
+ * status line after each turn completes; for "stays silent" tests exactly
+ * one appears (the orchestrator's turn), for "fires" tests two or more
+ * appear (orchestrator + each nudge response). We wait for the orchestrator
+ * marker, then poll until no new requests have arrived for 1.5s — that's
+ * the deterministic "all nudges have either fired or been suppressed"
+ * signal.
+ */
+async function waitForTurnToSettle(fixture: KimchiFixture, terminal: import("@microsoft/tui-test").Terminal) {
+	await waitForText(terminal, "Worked for", { timeoutMs: STREAM_TIMEOUT_MS })
+	const settleForMs = 1_500
+	const startedAt = Date.now()
+	let lastCount = fixture.fake.requests.length
+	let stableSince = Date.now()
+	while (Date.now() - startedAt < settleForMs * 4) {
+		await new Promise((resolve) => setTimeout(resolve, 100))
+		const currentCount = fixture.fake.requests.length
+		if (currentCount !== lastCount) {
+			lastCount = currentCount
+			stableSince = Date.now()
+		} else if (Date.now() - stableSince >= settleForMs) {
+			return
+		}
+	}
+	throw new Error("Request count did not settle")
+}
+
+/**
+ * Behavioural coverage for the orchestrator's continuation and empty-turn
+ * nudges, complementing the unit tests in `continuation-nudge.test.ts`:
+ *
+ *   - "stays silent" cases pin down the suppression conditions (fresh
+ *     session, user abort, post-tool empty response).
+ *   - "fires" cases pin down that the nudge wiring still works after the
+ *     fix — a regression that disables the nudge entirely would pass the
+ *     suppression tests but fail these.
+ *
+ * Each scenario is one user input, with the orchestrator returning either
+ * text-only, empty content, or a tool call followed by one of the above.
+ * Bookkeeping requests (title gen, context summary) consume the fake's
+ * default fallback and don't influence the assertions.
+ */
+
+test("continuation nudge stays silent on a text-only response in a fresh session", async ({ terminal }) => {
+	await runKimchiSession(
+		terminal,
+		{
+			artifactName: "nudge-silent-fresh-session",
+			responses: [{ stream: ["Hello there."] }],
+		},
+		async (fixture, trace) => {
+			terminal.submit("hello")
+			trace.step("submitted prompt")
+			await waitForTurnToSettle(fixture, terminal)
+			trace.step("settled")
+			expect(anyRequestContainsAnyNudge(fixture)).toBe(false)
+		},
+	)
+})
+
+test("continuation nudge stays silent after the user aborts an in-flight turn", async ({ terminal }) => {
+	await runKimchiSession(
+		terminal,
+		{
+			artifactName: "nudge-silent-user-abort",
+			// Stream chunks spaced so the harness enters streaming state and
+			// the test has time to issue Ctrl+C mid-stream. The harness wires
+			// the keyboard signal to the provider's AbortSignal, which
+			// surfaces as a turn_end with `stopReason: "aborted"`.
+			responses: [{ stream: ["aaa", "bbb", "ccc"], delayMs: 400 }],
+		},
+		async (fixture, trace) => {
+			terminal.submit("go")
+			trace.step("submitted prompt")
+			// 700ms lands well after the first chunk and well before the final one.
+			await new Promise((resolve) => setTimeout(resolve, 700))
+			terminal.keyCtrlC()
+			trace.step("pressed Ctrl+C during streaming")
+			await waitForTurnToSettle(fixture, terminal)
+			trace.step("settled")
+			// Assert against ALL nudges (continuation + empty-turn) so this
+			// test catches either nudge firing on top of an abort.
+			expect(anyRequestContainsAnyNudge(fixture)).toBe(false)
+		},
+	)
+})
+
+test("empty-turn nudge fires when the orchestrator returns empty content", async ({ terminal }) => {
+	await runKimchiSession(
+		terminal,
+		{
+			artifactName: "nudge-fires-empty-turn",
+			// Empty stream -> the orchestrator's assistant message has no
+			// text and no tool calls. EmptyTurnNudge should fire.
+			responses: [{ stream: [] }],
+		},
+		async (fixture, trace) => {
+			terminal.submit("go")
+			trace.step("submitted prompt")
+			await waitForTurnToSettle(fixture, terminal)
+			trace.step("settled")
+			expect(anyRequestContainsAnyNudge(fixture)).toBe(true)
+		},
+	)
+})
+
+test("empty-turn nudge stays silent when a tool was called earlier in the run", async ({ terminal }) => {
+	await runKimchiSession(
+		terminal,
+		{
+			artifactName: "nudge-silent-empty-turn-after-tool",
+			responses: [
+				// First orchestrator call returns a tool call -> tool executes,
+				// `toolsCalledThisAgentRun` flips on.
+				{
+					toolCalls: [
+						{ function: { name: "read", arguments: JSON.stringify({ path: "/dev/null" }) } },
+					],
+				},
+				// Post-tool response is empty. Without the per-run guard this
+				// would fire the empty-turn nudge ("summarize or continue");
+				// with the guard, a legitimately-empty post-tool response is
+				// left alone. (The continuation nudge may still fire in this
+				// scenario because the tool result is delivered as a new
+				// "input" event that resets `toolsCalledSinceLastUserInput`;
+				// that's existing harness behavior unrelated to this test.)
+				{ stream: [] },
+			],
+		},
+		async (fixture, trace) => {
+			terminal.submit("show me /dev/null")
+			trace.step("submitted prompt")
+			await waitForTurnToSettle(fixture, terminal)
+			trace.step("settled")
+			// Assert against ONLY the empty-turn nudge phrase — this test
+			// pins the per-run guard at prompt-enrichment.ts. Asserting
+			// `anyRequestContainsAnyNudge` would conflate this with the
+			// unrelated continuation nudge behaviour.
+			expect(anyRequestContainsNudgePhrase(fixture, EMPTY_TURN_NUDGE_PHRASE)).toBe(false)
+		},
+	)
+})
+
+test("continuation nudge fires when the orchestrator returns text-only after a tool was called", async ({
+	terminal,
+}) => {
+	await runKimchiSession(
+		terminal,
+		{
+			artifactName: "nudge-fires-continuation-after-tool",
+			responses: [
+				// First orchestrator call returns a tool call -> tool executes,
+				// session-lifetime `toolsCalledThisSession` flips on.
+				{
+					toolCalls: [
+						{ function: { name: "read", arguments: JSON.stringify({ path: "/dev/null" }) } },
+					],
+				},
+				// Post-tool response is text-only (legitimate end-of-task
+				// summary). With the fresh-session suppression now behind us,
+				// the continuation nudge must fire.
+				{ stream: ["Task complete."] },
+			],
+		},
+		async (fixture, trace) => {
+			terminal.submit("show me /dev/null")
+			trace.step("submitted prompt")
+			await waitForTurnToSettle(fixture, terminal)
+			trace.step("settled")
+			expect(anyRequestContainsAnyNudge(fixture)).toBe(true)
+		},
+	)
+})

--- a/tests/e2e/tui/continuation-nudge-suppression.test.ts
+++ b/tests/e2e/tui/continuation-nudge-suppression.test.ts
@@ -1,7 +1,6 @@
 import { expect, test } from "@microsoft/tui-test"
 import type { KimchiFixture } from "./support/kimchi-fixture.js"
 import { TUI_TEST_CONFIG, runKimchiSession } from "./support/kimchi-fixture.js"
-import { STREAM_TIMEOUT_MS, waitForText } from "./support/assertions.js"
 
 test.use(TUI_TEST_CONFIG)
 
@@ -37,21 +36,25 @@ function anyRequestContainsAnyNudge(fixture: KimchiFixture): boolean {
 
 /**
  * Waits for the harness to finish processing the orchestrator's main turn
- * AND any nudge-driven followUp turn. The terminal prints a `✻ Worked for`
- * status line after each turn completes; for "stays silent" tests exactly
- * one appears (the orchestrator's turn), for "fires" tests two or more
- * appear (orchestrator + each nudge response). We wait for the orchestrator
- * marker, then poll until no new requests have arrived for 1.5s — that's
- * the deterministic "all nudges have either fired or been suppressed"
- * signal.
+ * AND any nudge-driven followUp turn.
+ *
+ * Polls `fixture.fake.requests.length` until no new completion requests
+ * have arrived for `settleForMs`. This is the authoritative "all nudges
+ * have either fired or been suppressed" signal — stable for the full
+ * window means the harness is idle and ready to assert.
+ *
+ * Terminal-marker waits ("Worked for", etc.) were tried and dropped:
+ * they were unreliable across empty-turn and aborted scenarios where
+ * the marker never renders, and added wall time without accelerating
+ * the happy path.
  */
-async function waitForTurnToSettle(fixture: KimchiFixture, terminal: import("@microsoft/tui-test").Terminal) {
-	await waitForText(terminal, "Worked for", { timeoutMs: STREAM_TIMEOUT_MS })
-	const settleForMs = 1_500
+async function waitForTurnToSettle(fixture: KimchiFixture) {
+	const settleForMs = 1_200
+	const timeoutMs = 30_000
 	const startedAt = Date.now()
 	let lastCount = fixture.fake.requests.length
 	let stableSince = Date.now()
-	while (Date.now() - startedAt < settleForMs * 4) {
+	while (Date.now() - startedAt < timeoutMs) {
 		await new Promise((resolve) => setTimeout(resolve, 100))
 		const currentCount = fixture.fake.requests.length
 		if (currentCount !== lastCount) {
@@ -62,6 +65,22 @@ async function waitForTurnToSettle(fixture: KimchiFixture, terminal: import("@mi
 		}
 	}
 	throw new Error("Request count did not settle")
+}
+
+/**
+ * Waits until at least one completion request has reached the fake server.
+ * Used by the abort test to prove the stream actually started before
+ * issuing Ctrl+C — otherwise a slow CI runner could send Ctrl+C while
+ * the harness is still booting the request, which would dismiss the
+ * input rather than abort an in-flight turn.
+ */
+async function waitForFirstRequest(fixture: KimchiFixture, timeoutMs = 10_000) {
+	const startedAt = Date.now()
+	while (Date.now() - startedAt < timeoutMs) {
+		if (fixture.fake.requests.length >= 1) return
+		await new Promise((resolve) => setTimeout(resolve, 50))
+	}
+	throw new Error("No completion request reached the fake server before timeout")
 }
 
 /**
@@ -90,7 +109,7 @@ test("continuation nudge stays silent on a text-only response in a fresh session
 		async (fixture, trace) => {
 			terminal.submit("hello")
 			trace.step("submitted prompt")
-			await waitForTurnToSettle(fixture, terminal)
+			await waitForTurnToSettle(fixture)
 			trace.step("settled")
 			expect(anyRequestContainsAnyNudge(fixture)).toBe(false)
 		},
@@ -111,11 +130,18 @@ test("continuation nudge stays silent after the user aborts an in-flight turn", 
 		async (fixture, trace) => {
 			terminal.submit("go")
 			trace.step("submitted prompt")
-			// 700ms lands well after the first chunk and well before the final one.
-			await new Promise((resolve) => setTimeout(resolve, 700))
+			// Wait for the harness to actually start streaming before aborting.
+			// Without this gate, a slow CI runner could process Ctrl+C while
+			// the harness is still booting the completion request, which
+			// would dismiss the input instead of triggering a real abort.
+			await waitForFirstRequest(fixture)
+			trace.step("first completion request observed")
+			// Sleep long enough for the first chunk (delayMs=400) to land but
+			// well before the final chunk.
+			await new Promise((resolve) => setTimeout(resolve, 500))
 			terminal.keyCtrlC()
 			trace.step("pressed Ctrl+C during streaming")
-			await waitForTurnToSettle(fixture, terminal)
+			await waitForTurnToSettle(fixture)
 			trace.step("settled")
 			// Assert against ALL nudges (continuation + empty-turn) so this
 			// test catches either nudge firing on top of an abort.
@@ -136,7 +162,7 @@ test("empty-turn nudge fires when the orchestrator returns empty content", async
 		async (fixture, trace) => {
 			terminal.submit("go")
 			trace.step("submitted prompt")
-			await waitForTurnToSettle(fixture, terminal)
+			await waitForTurnToSettle(fixture)
 			trace.step("settled")
 			expect(anyRequestContainsAnyNudge(fixture)).toBe(true)
 		},
@@ -169,7 +195,7 @@ test("empty-turn nudge stays silent when a tool was called earlier in the run", 
 		async (fixture, trace) => {
 			terminal.submit("show me /dev/null")
 			trace.step("submitted prompt")
-			await waitForTurnToSettle(fixture, terminal)
+			await waitForTurnToSettle(fixture)
 			trace.step("settled")
 			// Assert against ONLY the empty-turn nudge phrase — this test
 			// pins the per-run guard at prompt-enrichment.ts. Asserting
@@ -204,7 +230,7 @@ test("continuation nudge fires when the orchestrator returns text-only after a t
 		async (fixture, trace) => {
 			terminal.submit("show me /dev/null")
 			trace.step("submitted prompt")
-			await waitForTurnToSettle(fixture, terminal)
+			await waitForTurnToSettle(fixture)
 			trace.step("settled")
 			expect(anyRequestContainsAnyNudge(fixture)).toBe(true)
 		},


### PR DESCRIPTION
## Linked issue

The `ContinuationNudge` was firing in two situations where it shouldn't:                                                                                                                       
                                                                                                                                                                                              
 1. **User abort (Esc / Ctrl+C)** — turn_end carries stopReason: "aborted" when the user cancels, but the nudge ignored this and pushed the model to keep going anyway.                           
 2. **Fresh-session openers** — when a session starts and the user opens with a conversational prompt ("hey", "ask me some questions"), the orchestrator legitimately responds with text-only     
    clarifying questions. Nudging it there is hostile and burned the per-cycle budget on a non-stuck turn.                                                                                    
                                                                                                                                                                                              
 Changes (`src/extensions/orchestration/continuation-nudge.ts`):                                                                                                                                
                                                                                                                                                                                              
 - `ContinuationNudge.evaluateTurn` returns false early when `message.stopReason === "aborted"`.                                                                                                  
 - New session-lifetime latch `toolsCalledThisSession` (set by `recordToolCall()`, never reset by `resetForNewAgentRun` / `resetForNewUserInput`). `evaluateTurn` returns false until at least one tool 
   has fired in the session.                                                                                                                                                                  
 - `EmptyTurnNudge.evaluateTurn` also respects `stopReason: "aborted"` for symmetry.                                                                                                              
 - New getter `hasToolBeenCalledThisSession()` for parity with the existing `hasToolBeenCalledThisCycle() / hasToolBeenCalledThisRun()`.

<!-- Every PR must link to an existing issue. PRs without a linked issue will not be reviewed.
     Use one of: Closes #N / Fixes #N / Resolves #N -->

## What does this PR do?
Do not nudge the model after user aborts with Esc or ctrl+c
<!-- Brief description of the change and why it's needed. -->

## Checklist

- [ ] I have read [CONTRIBUTING.md](../CONTRIBUTING.md) and agree to the CLA
- [ ] This PR links to an open issue above
- [ ] Tests pass locally (`pnpm run test`)
- [ ] Lint passes (`pnpm run check`)
- [ ] Documentation updated if behavior changed
