### PR TITLE
refactor(extensions): drop metadata wizard from /multi-model

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,7 +113,7 @@ External models (Anthropic, OpenAI, or any non-builtin provider) have no built-i
 
 With the metadata above, the orchestrator will use minimax for simple build chunks and Claude for complex ones. Without it, both models look like standard-tier to the orchestrator and selection is arbitrary.
 
-Metadata can also be managed interactively via `/multi-model` → "Edit model metadata". Custom overrides can be reset to defaults from the same menu. When switching to an unknown model, a wizard prompts for metadata configuration. Metadata for builtin models can be overridden the same way.
+Metadata can also be managed interactively via `/multi-model` → "Edit model metadata" — this is the only in-app path for configuring or overriding metadata, so model selection stays uninterrupted. Custom overrides can be reset to defaults from the same menu. Metadata for builtin models can be overridden the same way.
 
 ### Phase tracking
 

--- a/src/extensions/orchestration/model-roles-command.test.ts
+++ b/src/extensions/orchestration/model-roles-command.test.ts
@@ -20,7 +20,6 @@ import { splitModelRef } from "./model-roles.js"
 
 // Mock model-metadata module
 vi.mock("./model-metadata.js", () => ({
-	isModelMetadataMissing: vi.fn(),
 	loadModelMetadata: vi.fn(),
 	resolveModelMetadata: vi.fn(),
 	saveModelMetadata: vi.fn(),

--- a/src/extensions/orchestration/model-roles-command.ts
+++ b/src/extensions/orchestration/model-roles-command.ts
@@ -19,11 +19,9 @@ import {
 	type ModelCustomMetadata,
 	deleteModelMetadata,
 	getModelMetadata,
-	isModelMetadataMissing,
 	resolveModelMetadata,
 	saveModelMetadata,
 } from "./model-metadata.js"
-import { MODEL_CAPABILITIES } from "./model-registry/builtin-models.js"
 import {
 	DEFAULT_MODEL_ROLES,
 	type ModelRoles,
@@ -94,17 +92,6 @@ export function formatRoleDisplay(role: keyof ModelRoles, value: RoleModelAssign
 	const isDefault = isEqualAssignment(value, DEFAULT_MODEL_ROLES[role])
 	const suffix = isDefault ? " (default)" : ""
 	return `${info.label}: ${formatRoleAssignment(value)}${suffix}`
-}
-
-function hasBuiltinCapability(ref: string): boolean {
-	const id = modelIdFromRef(ref)
-	const entry = MODEL_CAPABILITIES.get(id)
-	return entry !== undefined && entry !== "ignored"
-}
-
-function shouldPromptForMetadata(ref: string): boolean {
-	if (hasBuiltinCapability(ref)) return false
-	return isModelMetadataMissing(ref)
 }
 
 export async function collectModelMetadata(
@@ -198,32 +185,6 @@ export async function collectModelMetadata(
 	}
 
 	return config
-}
-
-async function promptMetadataWizard(
-	ref: string,
-	ctx: ExtensionCommandContext,
-	configuredThisSession: Set<string>,
-): Promise<void> {
-	if (configuredThisSession.has(ref)) return
-
-	const wizardChoice = await ctx.ui.select(
-		`${ref}\nThis model has no metadata (tier, description, vision).\nSpecifying metadata will improve orchestration.`,
-		["Configure now", "Skip"],
-	)
-	if (wizardChoice !== "Configure now") {
-		configuredThisSession.add(ref)
-		return
-	}
-
-	const metadata = await collectModelMetadata(ref, resolveModelMetadata(ref) ?? undefined, ctx)
-	if (hasMetadataContent(metadata)) {
-		const map = new Map<string, ModelCustomMetadata>()
-		map.set(ref, metadata)
-		saveModelMetadata(map)
-		ctx.ui.notify(`Metadata saved for ${ref}.`, "info")
-	}
-	configuredThisSession.add(ref)
 }
 
 // ---------------------------------------------------------------------------
@@ -352,7 +313,6 @@ export function registerModelRolesCommand(pi: ExtensionAPI): void {
 			}
 
 			const roles = { ...getModelRoles() }
-			const configuredThisSession = new Set<string>()
 
 			const apiModels = getAvailableModels()
 			const availableModelRefs = apiModels.map((m) => `kimchi-dev/${m.slug}`)
@@ -490,16 +450,11 @@ export function registerModelRolesCommand(pi: ExtensionAPI): void {
 						}
 					}
 				}
-
-				if (shouldPromptForMetadata(newRef)) {
-					await promptMetadataWizard(newRef, ctx, configuredThisSession)
-				}
 			}
 
 			const showMultiModelEditor = async (roleKey: keyof ModelRoles): Promise<void> => {
 				const info = ROLE_LABELS[roleKey]
-				const previousModels = new Set(normalizeRoleModels(roles[roleKey]))
-				const selected = new Set(previousModels)
+				const selected = new Set(normalizeRoleModels(roles[roleKey]))
 
 				// eslint-disable-next-line no-constant-condition
 				while (true) {
@@ -563,13 +518,6 @@ export function registerModelRolesCommand(pi: ExtensionAPI): void {
 					return
 				}
 				ctx.ui.notify(`${info.label} set to ${models.join(", ")}`, "info")
-
-				const newlyAdded = models.filter((ref) => !previousModels.has(ref))
-				for (const ref of newlyAdded) {
-					if (shouldPromptForMetadata(ref)) {
-						await promptMetadataWizard(ref, ctx, configuredThisSession)
-					}
-				}
 			}
 
 			const showMetadataEditor = async (): Promise<void> => {


### PR DESCRIPTION
## What does this PR do?

Drop the metadata wizard that fired whenever a user assigned a model with no metadata to a role via `/multi-model`. Model selection is now seamless; `/multi-model` → "Edit model metadata…" becomes the only in-app path for configuring or overriding model metadata.

### Why

The wizard interrupted the model-pick flow in two ways:

1. After picking a single-model role (orchestrator) — every switch to an unknown model popped a "Configure now / Skip" prompt.
2. After toggling a multi-model role (planner/builder/reviewer/...) — the wizard fired for **every newly added model** in the pool, so a builder pool with 3 fresh models produced 3 sequential prompts in one edit session.

Users mostly just wanted to pick a model and move on. Anyone who actually wants to tune metadata can still reach it from the `/multi-model` menu.

### Demo

<img width="1792" height="1746" alt="2026-06-23 13 47 45" src="https://github.com/user-attachments/assets/4437dd82-f819-4155-91ff-6830b9b9b455" />

### Changes

**`src/extensions/orchestration/model-roles-command.ts`** (−53 / +1)

- Removed `promptMetadataWizard()`, `shouldPromptForMetadata()`, and `hasBuiltinCapability()`.
- Removed both call sites (post-orchestrator select and the `newlyAdded` loop in `showMultiModelEditor`).
- Dropped the `configuredThisSession` set and the `previousModels` tracking that only existed to support the wizard.
- Dropped unused imports (`isModelMetadataMissing`, `MODEL_CAPABILITIES`).

**`src/extensions/orchestration/model-roles-command.test.ts`** (−1)

- Removed the unused `isModelMetadataMissing: vi.fn()` mock entry.

**`README.md`** — replaced the wizard mention with wording that frames `/multi-model` → "Edit model metadata" as the sole in-app configuration path.

`collectModelMetadata()` is preserved — the metadata editor menu still uses it.

### Verification

- `pnpm run lint` — clean
- `pnpm run typecheck` — clean
- `pnpm run test` — 5577 / 5577 passing (incl. 36 model-roles-command tests)

### Out of scope

- No CLI flag to opt back into the wizard. If users ask for it, we can add one.
- No change to the orchestrator's default metadata fallback (`standard` tier, `vision: false`, auto-generated description from role assignments) — that behaviour is unchanged.

## Checklist

- [x] I have read [CONTRIBUTING.md](../blob/master/CONTRIBUTING.md) and agree to the CLA
~- [ ] This PR links to an open issue above *(no tracking issue opened — flagging explicitly because the template requires one)*~
- [x] Tests pass locally (`pnpm run test`)
- [x] Lint passes (`pnpm run check`)
- [x] Documentation updated if behavior changed

Closes #0