### PR TITLE
fix: preserve subscription model headers

### DIFF
--- a/src/extensions/login/flow.ts
+++ b/src/extensions/login/flow.ts
@@ -126,6 +126,7 @@ function upstreamModelToPiConfig(m: Model<Api>, providerId: string): PiModelConf
 		cost: m.cost,
 		provider: providerId,
 		compat: m.compat as PiModelConfig["compat"],
+		...(m.headers ? { headers: m.headers } : {}),
 	}
 }
 

--- a/src/login-command-patch.test.ts
+++ b/src/login-command-patch.test.ts
@@ -457,25 +457,31 @@ it("pre-populates subscription provider models in models.json before upstream lo
 	const getModelsMock = vi.mocked(piAi.getModels)
 	getModelsMock.mockReturnValue([
 		{
-			id: "codex",
-			name: "Codex",
-			provider: "openai",
-			api: "openai-chat",
-			baseUrl: "https://api.openai.com/v1/chat/completions",
+			id: "claude-sonnet-4.6",
+			name: "Claude Sonnet 4.6",
+			provider: "github-copilot",
+			api: "anthropic-messages",
+			baseUrl: "https://api.individual.githubcopilot.com",
+			headers: {
+				"User-Agent": "GitHubCopilotChat/0.35.0",
+				"Editor-Version": "vscode/1.107.0",
+				"Editor-Plugin-Version": "copilot-chat/0.35.0",
+				"Copilot-Integration-Id": "vscode-chat",
+			},
 			input: ["text"],
 			contextWindow: 200000,
 			maxTokens: 8192,
 			reasoning: false,
 			cost: { input: 3, output: 12, cacheRead: 0, cacheWrite: 0 },
 		},
-	] as ReturnType<typeof getModelsMock>)
+	] as unknown as ReturnType<typeof getModelsMock>)
 
 	const modelsModule = await import("./models.js")
 	const syncSpy = vi.spyOn(modelsModule, "syncProviderModels").mockImplementation(() => {})
 
 	const registry = makeFakeModelRegistry()
 	const fakeIm = makeFakeInteractiveMode(registry)
-	fakeIm.getLoginProviderOptions.mockReturnValue([{ id: "openai", name: "OpenAI", authType: "oauth" }])
+	fakeIm.getLoginProviderOptions.mockReturnValue([{ id: "github-copilot", name: "GitHub Copilot", authType: "oauth" }])
 
 	vi.stubEnv("KIMCHI_CODING_AGENT_DIR", "/tmp/kimchi-test-models")
 
@@ -486,7 +492,7 @@ it("pre-populates subscription provider models in models.json before upstream lo
 	fakeIm.selectorComponent.handleInput("\n")
 	await waitForMockCall(fakeIm.showLoginDialog)
 
-	expect(fakeIm.showLoginDialog).toHaveBeenCalledWith("openai", "OpenAI")
+	expect(fakeIm.showLoginDialog).toHaveBeenCalledWith("github-copilot", "GitHub Copilot")
 	expect(syncSpy).toHaveBeenCalledOnce()
 	const [_path, providerId, configs, providerConfig] = syncSpy.mock.calls[0] as unknown as [
 		string,
@@ -494,16 +500,22 @@ it("pre-populates subscription provider models in models.json before upstream lo
 		unknown[],
 		unknown,
 	]
-	expect(providerId).toBe("openai")
+	expect(providerId).toBe("github-copilot")
 	expect(providerConfig).toMatchObject({
-		api: "openai-chat",
-		baseUrl: "https://api.openai.com/v1/chat/completions",
+		api: "anthropic-messages",
+		baseUrl: "https://api.individual.githubcopilot.com",
 	})
 	expect(configs).toHaveLength(1)
 	expect(configs[0]).toMatchObject({
-		id: "codex",
-		name: "Codex",
-		provider: "openai",
+		id: "claude-sonnet-4.6",
+		name: "Claude Sonnet 4.6",
+		provider: "github-copilot",
+		headers: {
+			"User-Agent": "GitHubCopilotChat/0.35.0",
+			"Editor-Version": "vscode/1.107.0",
+			"Editor-Plugin-Version": "copilot-chat/0.35.0",
+			"Copilot-Integration-Id": "vscode-chat",
+		},
 		input: ["text"],
 		contextWindow: 200000,
 		maxTokens: 8192,

--- a/src/models.ts
+++ b/src/models.ts
@@ -156,6 +156,8 @@ export interface PiModelConfig {
 	api?: string
 	/** Model-level base URL: upstream custom-provider parseModels falls through to this field. */
 	baseUrl?: string
+	/** Model-level request headers required by upstream providers such as GitHub Copilot. */
+	headers?: Record<string, string>
 }
 
 function metadataToModel(m: ModelMetadata): PiModelConfig {


### PR DESCRIPTION
## Linked issue

Closes #652

## What does this PR do?

Preserves upstream model-level request headers when Kimchi pre-populates subscription provider models into `models.json`. GitHub Copilot models from `@earendil-works/pi-ai` already include IDE auth headers such as `Editor-Version`, `Editor-Plugin-Version`, `Copilot-Integration-Id`, and `User-Agent`, but Kimchi dropped those headers during the `upstreamModelToPiConfig()` conversion before OAuth login.

This keeps those headers in the persisted subscription model config so pi's model registry can read them back and merge them into Copilot requests. The regression test now uses `github-copilot/claude-sonnet-4.6` and asserts the Copilot headers survive pre-population.

## Checklist

- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md) and agree to the CLA
- [x] This PR links to an open issue above
- [ ] Tests pass locally (`pnpm run test`)
- [x] Lint passes (`pnpm run check`)
- [x] Documentation updated if behavior changed (N/A: bug fix, no docs surface)

## Verification

- `./node_modules/.bin/vitest run src/login-command-patch.test.ts`
- `pnpm run check`
- `pnpm run test` currently fails locally only in `src/extensions/web-fetch/integration.test.ts` with three pre-existing `/rich` format-conversion 5s timeouts; this PR does not touch web-fetch code.