### PR TITLE
Feat/anthropic prompt cache

### DIFF
--- a/src/extensions/prompt-construction/anthropic-prompt-cache.test.ts
+++ b/src/extensions/prompt-construction/anthropic-prompt-cache.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it } from "vitest"
+import {
+	type AnthropicCacheModel,
+	supportsAnthropicPromptCache,
+	toCachedSystemBlocks,
+} from "./anthropic-prompt-cache.js"
+
+const anthropic: AnthropicCacheModel = { compat: { cacheControlFormat: "anthropic" } }
+const nonAnthropic: AnthropicCacheModel = {}
+
+describe("supportsAnthropicPromptCache", () => {
+	it("is true for models flagged with the anthropic cache-control format", () => {
+		expect(supportsAnthropicPromptCache(anthropic)).toBe(true)
+	})
+
+	it("is false for models without the compat flag", () => {
+		expect(supportsAnthropicPromptCache(nonAnthropic)).toBe(false)
+		expect(supportsAnthropicPromptCache({ compat: {} })).toBe(false)
+	})
+
+	it("is false for an undefined model", () => {
+		expect(supportsAnthropicPromptCache(undefined)).toBe(false)
+	})
+})
+
+describe("toCachedSystemBlocks", () => {
+	it("marks the static block with an ephemeral cache breakpoint for anthropic models", () => {
+		expect(toCachedSystemBlocks("system prompt", anthropic)).toEqual([
+			{ type: "text", text: "system prompt", cache_control: { type: "ephemeral" } },
+		])
+	})
+
+	it("leaves the block unmarked for non-anthropic models", () => {
+		expect(toCachedSystemBlocks("system prompt", nonAnthropic)).toEqual([
+			{ type: "text", text: "system prompt" },
+		])
+	})
+
+	it("returns no blocks for an empty prompt", () => {
+		expect(toCachedSystemBlocks("", anthropic)).toEqual([])
+	})
+})

--- a/src/extensions/prompt-construction/anthropic-prompt-cache.ts
+++ b/src/extensions/prompt-construction/anthropic-prompt-cache.ts
@@ -1,0 +1,57 @@
+/**
+ * Anthropic prompt caching for the static system prompt.
+ *
+ * The assembled system prompt (intro, orchestration instructions, guidelines,
+ * tools) is large and identical across every turn of a session. Anthropic bills
+ * a cache read at ~10% of the normal input price, so marking the static prefix
+ * with a `cache_control` breakpoint turns that repeated prefix from full-price
+ * input into a cache hit on every turn after the first.
+ *
+ * The model's Anthropic capability is read from the existing `compat` signal set
+ * in `src/models.ts` (`cacheControlFormat: "anthropic"`), so no new model
+ * metadata is introduced — non-Anthropic models simply get an unmarked block.
+ */
+
+/** Minimal structural view of a model — only the fields cache detection needs. */
+export interface AnthropicCacheModel {
+	compat?: { cacheControlFormat?: "anthropic" }
+}
+
+/** Anthropic ephemeral cache breakpoint, attached to the block it should cache up to. */
+export interface CacheControl {
+	type: "ephemeral"
+}
+
+/** An Anthropic system content block, optionally carrying a cache breakpoint. */
+export interface SystemTextBlock {
+	type: "text"
+	text: string
+	cache_control?: CacheControl
+}
+
+/**
+ * True when the model accepts Anthropic-style `cache_control` breakpoints. Driven
+ * by the `compat.cacheControlFormat` flag that `metadataToModel` already stamps on
+ * Anthropic models, so this stays the single source of truth for the format.
+ */
+export function supportsAnthropicPromptCache(model: AnthropicCacheModel | undefined): boolean {
+	return model?.compat?.cacheControlFormat === "anthropic"
+}
+
+/**
+ * Convert an assembled system prompt string into Anthropic system content blocks.
+ *
+ * For Anthropic-capable models the single static block carries an ephemeral
+ * `cache_control` breakpoint so the whole system prefix is cached and replayed at
+ * cache-read price on subsequent turns. For every other model the block is
+ * returned unmarked, leaving behaviour unchanged. An empty prompt yields no blocks.
+ */
+export function toCachedSystemBlocks(
+	systemPrompt: string,
+	model: AnthropicCacheModel | undefined,
+): SystemTextBlock[] {
+	if (systemPrompt.length === 0) return []
+	const block: SystemTextBlock = { type: "text", text: systemPrompt }
+	if (supportsAnthropicPromptCache(model)) block.cache_control = { type: "ephemeral" }
+	return [block]
+}

--- a/src/extensions/prompt-construction/system-prompt.test.ts
+++ b/src/extensions/prompt-construction/system-prompt.test.ts
@@ -2,7 +2,12 @@ import type { Skill } from "@earendil-works/pi-coding-agent"
 import { describe, expect, it } from "vitest"
 import type { ModelMetadata } from "../../models.js"
 import { MODEL_CAPABILITIES, ModelRegistry } from "../orchestration/model-registry/index.js"
-import { type EnvironmentInfo, buildSystemPrompt, formatEnvironmentSection } from "./system-prompt.js"
+import {
+	type EnvironmentInfo,
+	buildSystemPrompt,
+	buildSystemPromptBlocks,
+	formatEnvironmentSection,
+} from "./system-prompt.js"
 
 const testEnv: EnvironmentInfo = {
 	os: "Linux",
@@ -71,6 +76,29 @@ describe("formatEnvironmentSection", () => {
 		expect(
 			formatEnvironmentSection({ ...testEnv, rawPlatform: "win32", shell: "C:\\Program Files\\Git\\bin\\bash.exe" }),
 		).toContain("- Shell family: posix-on-windows")
+	})
+})
+
+describe("buildSystemPromptBlocks", () => {
+	const baseOptions = { tools: [], env: testEnv, mode: "single" as const }
+
+	it("carries the same text as buildSystemPrompt in a single block", () => {
+		const blocks = buildSystemPromptBlocks(baseOptions)
+		expect(blocks).toHaveLength(1)
+		expect(blocks[0].text).toBe(buildSystemPrompt(baseOptions))
+	})
+
+	it("adds an ephemeral cache breakpoint for anthropic-capable models", () => {
+		const blocks = buildSystemPromptBlocks({
+			...baseOptions,
+			model: { compat: { cacheControlFormat: "anthropic" } },
+		})
+		expect(blocks[0].cache_control).toEqual({ type: "ephemeral" })
+	})
+
+	it("leaves the block unmarked for non-anthropic models", () => {
+		const blocks = buildSystemPromptBlocks({ ...baseOptions, model: {} })
+		expect(blocks[0].cache_control).toBeUndefined()
 	})
 })
 

--- a/src/extensions/prompt-construction/system-prompt.ts
+++ b/src/extensions/prompt-construction/system-prompt.ts
@@ -15,6 +15,11 @@ import type { Phase } from "../orchestration/model-registry/types.js"
 import type { ModelRoles } from "../orchestration/model-roles.js"
 import { resolveOrchestrationInstructions } from "../orchestration/orchestration-instructions.js"
 import type { OrchestrationInstructionsResult } from "../orchestration/orchestration-instructions.js"
+import {
+	type AnthropicCacheModel,
+	type SystemTextBlock,
+	toCachedSystemBlocks,
+} from "./anthropic-prompt-cache.js"
 import type { ContextFile } from "./context-files.js"
 import { type SuppressibleSection, renderSystemPromptBlocks } from "./system-prompt-blocks.js"
 
@@ -100,6 +105,21 @@ export function buildSystemPrompt(options: SystemPromptBuildOptions): string {
 		systemPromptBlocks: blocks.map((block) => block.content).join("\n\n"),
 		suppressed,
 	})
+}
+
+/**
+ * Build the system prompt as Anthropic content blocks with a prompt-cache
+ * breakpoint on the static prefix.
+ *
+ * Assembles the same prompt as `buildSystemPrompt`, then wraps it via
+ * `toCachedSystemBlocks` so Anthropic-capable models replay the prefix at
+ * cache-read price on every turn after the first. Non-Anthropic models get the
+ * identical text in an unmarked block, so callers can adopt this uniformly.
+ */
+export function buildSystemPromptBlocks(
+	options: SystemPromptBuildOptions & { model?: AnthropicCacheModel },
+): SystemTextBlock[] {
+	return toCachedSystemBlocks(buildSystemPrompt(options), options.model)
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Linked issue

Closes #<NNN>

<!-- You must open an issue first (CONTRIBUTING.md requires it). Suggested issue title:
     "Enable Anthropic prompt caching for the static system prompt" -->

## What does this PR do?

Adds Anthropic prompt caching for the static system-prompt prefix.

The assembled system prompt (intro, orchestration instructions, guidelines, tools)
is large and byte-identical across every turn of a session, but it is currently
re-sent at full input price each turn. Anthropic bills a cache read at ~10% of
normal input price, so marking the static prefix with a `cache_control` breakpoint
turns it into a cache hit on every turn after the first.

Changes:
- `anthropic-prompt-cache.ts` — a small pure helper that detects Anthropic
  capability via the **existing** `compat.cacheControlFormat: "anthropic"` signal
  already stamped on models in `src/models.ts` (no new model metadata), and wraps
  the system prompt in a content block carrying an ephemeral `cache_control`
  breakpoint. Non-Anthropic models get the identical text in an unmarked block, so
  behaviour is unchanged for them.
- `buildSystemPromptBlocks()` in `system-prompt.ts` — reuses `buildSystemPrompt`
  and returns the cacheable block representation so callers can adopt it uniformly.
- Unit tests for both.

Scope: this wires the cacheable representation at the prompt-assembler layer to
demonstrate the approach. Final integration into the pi-ai request path is a
follow-up — the model-level `cacheControlFormat` compat flag already signals the
format upstream.

## Checklist

- [ ] I have read [CONTRIBUTING.md](../CONTRIBUTING.md) and agree to the CLA
- [ ] This PR links to an open issue above
- [ ] Tests pass locally (`pnpm run test`)
- [ ] Lint passes (`pnpm run check`)
- [ ] Documentation updated if behavior changed