### PR TITLE
fix(ferment): cap journey-grade judge output tokens

### DIFF
--- a/src/extensions/ferment/judge.test.ts
+++ b/src/extensions/ferment/judge.test.ts
@@ -53,6 +53,17 @@ describe("judgeJourneyGrade", () => {
 		expect(result.rationale).toContain("coverage is thin")
 	})
 
+	it("caps the journey-grade output with a bounded maxTokens", async () => {
+		const apiCall = vi
+			.fn<(_sys: string, _msg: string, _maxTokens?: number) => Promise<JudgeApiResult>>()
+			.mockResolvedValue(ok('{"grade":"B","rationale":"ok"}'))
+		await judgeJourneyGrade(makeInput(), apiCall)
+		const maxTokens = apiCall.mock.calls[0][2]
+		expect(typeof maxTokens).toBe("number")
+		expect(maxTokens).toBeGreaterThan(0)
+		expect(maxTokens).toBeLessThanOrEqual(512)
+	})
+
 	it("strips markdown fences from the model output", async () => {
 		const apiCall = vi.fn(async () => ok('```json\n{"grade":"A","rationale":"clean"}\n```'))
 		const result = await judgeJourneyGrade(makeInput(), apiCall)
@@ -97,7 +108,7 @@ describe("judgeJourneyGrade", () => {
 		const result = await judgeJourneyGrade(makeInput(), apiCall)
 
 		expect(apiCall).toHaveBeenCalledTimes(3)
-		expect(apiCall.mock.calls.map((call) => call.length)).toEqual([2, 2, 2])
+		expect(apiCall.mock.calls.map((call) => call.length)).toEqual([3, 3, 3])
 		expect(result.ok).toBe(true)
 		if (!result.ok) return
 		expect(result.grade).toBe("B")
@@ -115,7 +126,7 @@ describe("judgeJourneyGrade", () => {
 		const result = await judgeJourneyGrade(makeInput(), apiCall)
 
 		expect(apiCall).toHaveBeenCalledTimes(3)
-		expect(apiCall.mock.calls.map((call) => call.length)).toEqual([2, 2, 2])
+		expect(apiCall.mock.calls.map((call) => call.length)).toEqual([3, 3, 3])
 		expect(result.ok).toBe(false)
 		if (result.ok) return
 		expect(result.reason).toBe("empty_response")

--- a/src/extensions/ferment/judge.ts
+++ b/src/extensions/ferment/judge.ts
@@ -26,6 +26,11 @@ import { getJudgeModel, getJudgeModelRegistry } from "./state.js"
 
 const GRADES: Grade[] = ["A", "B", "C", "D", "F"]
 const JOURNEY_GRADE_MAX_ATTEMPTS = 3
+// The journey grade output is a single letter plus a rationale that is sliced to
+// 800 chars (~200 tokens) downstream, so cap the request to avoid paying for an
+// uncapped generation on the heavy-tier judge model. 512 leaves ample headroom
+// and matches the bounded-output pattern of the other judge calls (150/200/500).
+const JOURNEY_GRADE_MAX_TOKENS = 512
 
 export function isGrade(value: unknown): value is Grade {
 	return typeof value === "string" && (GRADES as string[]).includes(value)
@@ -320,7 +325,7 @@ export async function judgeJourneyGrade(
 ): Promise<JudgeJourneyGradeResult> {
 	const userMsg = buildJourneyGradeUserMsg(input)
 	for (let attempt = 1; attempt <= JOURNEY_GRADE_MAX_ATTEMPTS; attempt++) {
-		const api = await apiCall(JOURNEY_GRADE_SYSTEM, userMsg)
+		const api = await apiCall(JOURNEY_GRADE_SYSTEM, userMsg, JOURNEY_GRADE_MAX_TOKENS)
 		if (!api.ok) {
 			const failure: JudgeJourneyGradeFailure = { ok: false, reason: api.reason, detail: api.detail }
 			if (api.reason === "empty_response" && attempt < JOURNEY_GRADE_MAX_ATTEMPTS) continue


### PR DESCRIPTION
## Linked issue

No issue linked yet (intentionally opened ahead of one for review). The
upstream process requires an issue before merge — to be filed as: "Ferment
journey-grade judge call has no output-token cap (inconsistent with the other
judge calls)".

## What does this PR do?

Caps the output tokens on the ferment **journey-grade** judge call.

`judgeJourneyGrade` (fired once at `complete_ferment`) was the only judge call
site that invoked `judgeApiCall` without a `maxTokens` argument, so it inherited
the judge model's full `max_output_tokens` window. Every sibling judge call
already bounds its output — `judgeStepVerification` (150), `askJudge` (200),
`askJudgeForm` (500). The journey grade produces the smallest output of all (a
single A–F letter plus a rationale that is sliced to 800 chars / ~200 tokens
downstream), yet was uncapped, on a heavy-tier judge model (`minimax-m3` by
default), and re-run up to 3× on `empty_response`.

Change:
- Add `JOURNEY_GRADE_MAX_TOKENS = 512` and pass it through at the call site.
  512 leaves ample headroom over the ~200-token capped rationale and matches the
  bounded-output pattern of the other judge calls.
- Test: assert the journey-grade call passes a bounded numeric `maxTokens`; the
  two existing retry tests now assert `[3, 3, 3]` arg counts, doubling as a guard
  that the cap is supplied on every attempt.

Scope note: this is a small consistency/cost fix. Impact is bounded — the call
fires once per completed ferment on a hosted model, not on a hot path.

## Checklist

- [ ] I have read [CONTRIBUTING.md](../CONTRIBUTING.md) and agree to the CLA
- [ ] This PR links to an open issue above
- [ ] Tests pass locally (`pnpm run test`)
- [ ] Lint passes (`pnpm run check`)
- [ ] Documentation updated if behavior changed

> Note: `pnpm`/`node_modules` were unavailable in the authoring environment, so
> `pnpm run test` and `pnpm run check` were not run here — please verify locally
> before merge.
