### PR TITLE
feat(orchestration): default kimi-k2.7 as orchestrator and planner

### DIFF
--- a/src/extensions/orchestration/model-roles-command.test.ts
+++ b/src/extensions/orchestration/model-roles-command.test.ts
@@ -146,7 +146,7 @@ describe("isEqualAssignment", () => {
 
 describe("formatRoleDisplay", () => {
 	it("appends (default) suffix when value matches DEFAULT_MODEL_ROLES", () => {
-		const display = formatRoleDisplay("orchestrator", "kimchi-dev/minimax-m3")
+		const display = formatRoleDisplay("orchestrator", "kimchi-dev/kimi-k2.7")
 		expect(display).toMatch(/\(default\)$/)
 	})
 
@@ -186,7 +186,7 @@ describe("formatRoleSummaryBlock", () => {
 	})
 
 	it("appends (default) suffix to each model line when assignment matches default", () => {
-		const display = formatRoleSummaryBlock("orchestrator", "kimchi-dev/minimax-m3")
+		const display = formatRoleSummaryBlock("orchestrator", "kimchi-dev/kimi-k2.7")
 		expect(display).toContain("(default)")
 	})
 

--- a/src/extensions/orchestration/model-roles.test.ts
+++ b/src/extensions/orchestration/model-roles.test.ts
@@ -221,10 +221,10 @@ describe("DEFAULT_MODEL_ROLES", () => {
 		expect(builders).not.toContain("kimchi-dev/nemotron-3-ultra-fp4")
 	})
 
-	it("reviewer pool contains both kimi-k2.7 and minimax-m3", () => {
+	it("reviewer pool contains kimi-k2.7 only", () => {
 		const reviewers = normalizeRoleModels(DEFAULT_MODEL_ROLES.reviewer)
 		expect(reviewers).toContain("kimchi-dev/kimi-k2.7")
-		expect(reviewers).toContain("kimchi-dev/minimax-m3")
+		expect(reviewers).not.toContain("kimchi-dev/minimax-m3")
 	})
 
 	it("explorer pool contains nemotron", () => {

--- a/src/extensions/orchestration/model-roles.test.ts
+++ b/src/extensions/orchestration/model-roles.test.ts
@@ -211,8 +211,8 @@ describe("modelIdFromRef", () => {
 })
 
 describe("DEFAULT_MODEL_ROLES", () => {
-	it("orchestrator is minimax-m3", () => {
-		expect(DEFAULT_MODEL_ROLES.orchestrator).toBe("kimchi-dev/minimax-m3")
+	it("orchestrator is kimi-k2.7", () => {
+		expect(DEFAULT_MODEL_ROLES.orchestrator).toBe("kimchi-dev/kimi-k2.7")
 	})
 
 	it("builder pool contains the build role but not nemotron", () => {
@@ -221,8 +221,9 @@ describe("DEFAULT_MODEL_ROLES", () => {
 		expect(builders).not.toContain("kimchi-dev/nemotron-3-ultra-fp4")
 	})
 
-	it("reviewer pool contains minimax-m3", () => {
+	it("reviewer pool contains both kimi-k2.7 and minimax-m3", () => {
 		const reviewers = normalizeRoleModels(DEFAULT_MODEL_ROLES.reviewer)
+		expect(reviewers).toContain("kimchi-dev/kimi-k2.7")
 		expect(reviewers).toContain("kimchi-dev/minimax-m3")
 	})
 
@@ -231,9 +232,9 @@ describe("DEFAULT_MODEL_ROLES", () => {
 		expect(explorers).toContain("kimchi-dev/nemotron-3-ultra-fp4")
 	})
 
-	it("planner pool contains minimax-m3", () => {
+	it("planner pool contains kimi-k2.7", () => {
 		const planners = normalizeRoleModels(DEFAULT_MODEL_ROLES.planner)
-		expect(planners).toContain("kimchi-dev/minimax-m3")
+		expect(planners).toContain("kimchi-dev/kimi-k2.7")
 	})
 
 	it("judge defaults to orchestrator model", () => {
@@ -298,7 +299,7 @@ describe("saveModelRoles", () => {
 })
 
 describe("validateModelRoles", () => {
-	const available = new Set(["kimi-k2.6", "minimax-m2.7", "minimax-m3", "nemotron-3-ultra-fp4"])
+	const available = new Set(["kimi-k2.6", "kimi-k2.7", "minimax-m2.7", "minimax-m3", "nemotron-3-ultra-fp4"])
 
 	it("returns no unavailable roles when all defaults are available", () => {
 		const result = validateModelRoles(DEFAULT_MODEL_ROLES, available)

--- a/src/extensions/orchestration/model-roles.ts
+++ b/src/extensions/orchestration/model-roles.ts
@@ -86,13 +86,13 @@ const HARNESS_SETTINGS_PATH = join(homedir(), ".config", "kimchi", "harness", "s
 
 /** Hardcoded default model-to-role assignment. Users override via /multi-model. */
 export const DEFAULT_MODEL_ROLES: Readonly<ModelRoles> = {
-	orchestrator: "kimchi-dev/minimax-m3",
-	planner: "kimchi-dev/minimax-m3",
+	orchestrator: "kimchi-dev/kimi-k2.7",
+	planner: "kimchi-dev/kimi-k2.7",
 	builder: ["kimchi-dev/minimax-m3"],
-	reviewer: ["kimchi-dev/minimax-m3"],
+	reviewer: ["kimchi-dev/kimi-k2.7", "kimchi-dev/minimax-m3"],
 	explorer: "kimchi-dev/nemotron-3-ultra-fp4",
 	researcher: "kimchi-dev/minimax-m3",
-	judge: "kimchi-dev/minimax-m3",
+	judge: ["kimchi-dev/kimi-k2.7", "kimchi-dev/minimax-m3"],
 }
 
 export interface ModelRolesWarning {

--- a/src/extensions/orchestration/model-roles.ts
+++ b/src/extensions/orchestration/model-roles.ts
@@ -89,10 +89,10 @@ export const DEFAULT_MODEL_ROLES: Readonly<ModelRoles> = {
 	orchestrator: "kimchi-dev/kimi-k2.7",
 	planner: "kimchi-dev/kimi-k2.7",
 	builder: ["kimchi-dev/minimax-m3"],
-	reviewer: ["kimchi-dev/kimi-k2.7", "kimchi-dev/minimax-m3"],
+	reviewer: ["kimchi-dev/kimi-k2.7"],
 	explorer: "kimchi-dev/nemotron-3-ultra-fp4",
 	researcher: "kimchi-dev/minimax-m3",
-	judge: ["kimchi-dev/kimi-k2.7", "kimchi-dev/minimax-m3"],
+	judge: ["kimchi-dev/kimi-k2.7"],
 }
 
 export interface ModelRolesWarning {

--- a/src/extensions/orchestration/orchestration-instructions.test.ts
+++ b/src/extensions/orchestration/orchestration-instructions.test.ts
@@ -55,12 +55,12 @@ describe("resolveOrchestrationInstructions", () => {
 
 	it("shows Your Capabilities section with orchestrator roles", () => {
 		const result = resolveAsString({
-			currentModelId: "minimax-m3",
+			currentModelId: "kimi-k2.7",
 			registry,
 			roles: DEFAULT_MODEL_ROLES,
 		})
 		expect(result).toContain("## Your Capabilities")
-		expect(result).toContain("You have these roles: **planner, builder, reviewer, researcher**")
+		expect(result).toContain("You have these roles: **planner, reviewer**")
 	})
 
 	it("uses DO/DONT directives in Step 3", () => {
@@ -111,7 +111,7 @@ describe("resolveOrchestrationInstructions", () => {
 
 	it("generates DO directive for plan when orchestrator is planner", () => {
 		const result = resolveAsString({
-			currentModelId: "minimax-m3",
+			currentModelId: "kimi-k2.7",
 			registry,
 			roles: DEFAULT_MODEL_ROLES,
 		})


### PR DESCRIPTION
Closes #696

## What does this PR do?

Rebalances `DEFAULT_MODEL_ROLES` in `src/extensions/orchestration/model-roles.ts` so a fresh Kimchi install ships with the orchestrator and planner on `kimi-k2.7`, the builder/researcher on `minimax-m3`, the explorer on `nemotron-3-ultra-fp4`, and reviewer/judge on `kimi-k2.7` alone.

| role | before | after |
|---|---|---|
| orchestrator | `kimchi-dev/minimax-m3` | `kimchi-dev/kimi-k2.7` |
| planner | `kimchi-dev/minimax-m3` | `kimchi-dev/kimi-k2.7` |
| builder | `[kimchi-dev/minimax-m3]` | `[kimchi-dev/minimax-m3]` |
| reviewer | `[kimchi-dev/minimax-m3]` | `[kimchi-dev/kimi-k2.7]` |
| explorer | `kimchi-dev/nemotron-3-ultra-fp4` | `kimchi-dev/nemotron-3-ultra-fp4` |
| researcher | `kimchi-dev/minimax-m3` | `kimchi-dev/minimax-m3` |
| judge | `kimchi-dev/minimax-m3` | `[kimchi-dev/kimi-k2.7]` |

Existing users keep their `~/.config/kimchi/harness/settings.json` overrides — `saveModelRoles` only writes keys that differ from defaults, so this PR only shifts defaults for fresh installs.

A heavy-tier fallback for reviewer/judge can be added back per-user in `~/.config/kimchi/harness/settings.json` (e.g. `"reviewer": ["kimchi-dev/kimi-k2.7", "kimchi-dev/minimax-m3"]`).

## Checklist

- [x] I have read CONTRIBUTING.md and agree to the CLA
- [x] This PR links to an open issue above (#696)
- [x] Tests pass locally (`pnpm run test` — 5592/5592)
- [x] Lint passes (`pnpm run check` — biome + tsc clean)
- [x] Documentation updated if behavior changed — the modelRoles example in `model-roles.ts` docstring already shows the same shape; no doc changes needed