### PR TITLE
fix(ferment): prevent auto-compaction from stopping an active ferment

### DIFF
--- a/src/extensions/compaction-thresholds.test.ts
+++ b/src/extensions/compaction-thresholds.test.ts
@@ -1,0 +1,8 @@
+import { describe, expect, it } from "vitest"
+import { COMPACTION_RESERVE_TOKENS } from "./compaction-thresholds.js"
+
+describe("COMPACTION_RESERVE_TOKENS", () => {
+	it("equals the upstream default reserve of 16,384 tokens", () => {
+		expect(COMPACTION_RESERVE_TOKENS).toBe(16_384)
+	})
+})

--- a/src/extensions/compaction-thresholds.ts
+++ b/src/extensions/compaction-thresholds.ts
@@ -1,0 +1,13 @@
+/**
+ * Shared compaction threshold constants.
+ *
+ * This module exists so multiple extensions (model-guard, ferment auto-compaction)
+ * agree on the same reserve-tokens value used to decide when context is "full".
+ *
+ * The value MUST stay in sync with upstream `DEFAULT_COMPACTION_SETTINGS.reserveTokens`
+ * (currently 16,384 tokens). If upstream changes, update this constant and the
+ * corresponding check in model-guard.ts / ferment/auto-compaction.ts.
+ */
+
+/** Tokens reserved as headroom below the model's context window. */
+export const COMPACTION_RESERVE_TOKENS = 16_384

--- a/src/extensions/ferment/auto-compaction.test.ts
+++ b/src/extensions/ferment/auto-compaction.test.ts
@@ -714,4 +714,57 @@ describe("maybeTriggerMidTurnFermentCompaction", () => {
 			}),
 		)
 	})
+
+	it("onError with an expected error clears in-flight without notifying", () => {
+		const ferment = makeFermentWithPhase()
+		ferment.phases[0].status = "active"
+		ferment.phases[0].steps[0].status = "running"
+		const runtime = makeMidTurnRuntime(ferment)
+		runtime.clearCompactionInFlight(ferment.id)
+		const pi = makePi()
+		const ctx = makeMidTurnCtx()
+
+		maybeTriggerMidTurnFermentCompaction(pi, ctx, runtime, CONTEXT_WINDOW - 1)
+		expect(runtime.isCompactionInFlight(ferment.id)).toBe(true)
+
+		const compactArgs = vi.mocked(ctx.compact).mock.calls[0]?.[0]
+		compactArgs?.onError?.(new Error("Compaction cancelled"))
+
+		expect(runtime.isCompactionInFlight(ferment.id)).toBe(false)
+		expect(ctx.ui?.notify).not.toHaveBeenCalled()
+	})
+
+	it("onError with an unexpected error clears in-flight and notifies", () => {
+		const ferment = makeFermentWithPhase()
+		ferment.phases[0].status = "active"
+		ferment.phases[0].steps[0].status = "running"
+		const runtime = makeMidTurnRuntime(ferment)
+		runtime.clearCompactionInFlight(ferment.id)
+		const pi = makePi()
+		const ctx = makeMidTurnCtx()
+
+		maybeTriggerMidTurnFermentCompaction(pi, ctx, runtime, CONTEXT_WINDOW - 1)
+		const compactArgs = vi.mocked(ctx.compact).mock.calls[0]?.[0]
+		compactArgs?.onError?.(new Error("disk full"))
+
+		expect(runtime.isCompactionInFlight(ferment.id)).toBe(false)
+		expect(ctx.ui?.notify).toHaveBeenCalledWith(expect.stringContaining("disk full"), "warning")
+	})
+
+	it("clears in-flight and notifies when ctx.compact throws synchronously", () => {
+		const ferment = makeFermentWithPhase()
+		ferment.phases[0].status = "active"
+		ferment.phases[0].steps[0].status = "running"
+		const runtime = makeMidTurnRuntime(ferment)
+		runtime.clearCompactionInFlight(ferment.id)
+		const pi = makePi()
+		const ctx = makeMidTurnCtx()
+		ctx.compact = vi.fn(() => {
+			throw new Error("sync compact failure")
+		})
+
+		expect(() => maybeTriggerMidTurnFermentCompaction(pi, ctx, runtime, CONTEXT_WINDOW - 1)).not.toThrow()
+		expect(runtime.isCompactionInFlight(ferment.id)).toBe(false)
+		expect(ctx.ui?.notify).toHaveBeenCalledWith(expect.stringContaining("sync compact failure"), "warning")
+	})
 })

--- a/src/extensions/ferment/auto-compaction.test.ts
+++ b/src/extensions/ferment/auto-compaction.test.ts
@@ -11,7 +11,13 @@ import type { ExtensionAPI, ExtensionContext } from "@earendil-works/pi-coding-a
 import type { CompactionResult } from "@earendil-works/pi-coding-agent"
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
 import type { Ferment, Phase, Step } from "../../ferment/types.js"
-import { buildCustomInstructions, buildHandoffDetails, maybeTriggerFermentCompaction } from "./auto-compaction.js"
+import {
+	buildCustomInstructions,
+	buildHandoffDetails,
+	buildMidTurnCustomInstructions,
+	maybeTriggerFermentCompaction,
+	maybeTriggerMidTurnFermentCompaction,
+} from "./auto-compaction.js"
 import type { FermentRuntime } from "./runtime.js"
 import { createDefaultFermentRuntime } from "./runtime.js"
 import { type PendingCompaction, clearPendingCompaction, setPendingCompaction } from "./state.js"
@@ -562,5 +568,150 @@ describe("maybeTriggerFermentCompaction", () => {
 
 		expect(() => maybeTriggerFermentCompaction(pi, ctx, runtime)).not.toThrow()
 		expect(ctx.compact).not.toHaveBeenCalled()
+	})
+})
+
+describe("buildMidTurnCustomInstructions", () => {
+	it("includes ferment name, goal, and success criteria", () => {
+		const ferment = makeFerment({ name: "Test Ferment", goal: "Test the thing" })
+		const phase = makePhase({ id: "phase-1", name: "Implementation", goal: "Write code" })
+		const step = makeStep({ id: "step-1", description: "Write tests" })
+
+		const instructions = buildMidTurnCustomInstructions(ferment, phase, step)
+
+		expect(instructions).toContain("Test Ferment")
+		expect(instructions).toContain("Test the thing")
+		expect(instructions).toContain("Tests pass")
+		expect(instructions).toContain("Lint clean")
+	})
+
+	it("includes active phase and in-progress step", () => {
+		const ferment = makeFerment()
+		const phase = makePhase({ id: "phase-1", name: "Implementation", goal: "Write code" })
+		const step = makeStep({ id: "step-1", description: "Write tests" })
+
+		const instructions = buildMidTurnCustomInstructions(ferment, phase, step)
+
+		expect(instructions).toContain("Implementation")
+		expect(instructions).toContain("Write code")
+		expect(instructions).toContain("Write tests")
+		expect(instructions).toContain("continue the in-progress step")
+	})
+})
+
+describe("maybeTriggerMidTurnFermentCompaction", () => {
+	const CONTEXT_WINDOW = 100_000
+
+	function makeMidTurnRuntime(ferment: Ferment): FermentRuntime {
+		const runtime = makeRuntime()
+		runtime.getActive = vi.fn(() => ferment)
+		runtime.getStorage = vi.fn(
+			() => makeMockStorage(new Map([[ferment.id, ferment]])) as unknown as ReturnType<typeof runtime.getStorage>,
+		)
+		return runtime
+	}
+
+	function makeMidTurnCtx(): ExtensionContext {
+		return {
+			...makeCtx(),
+			model: { contextWindow: CONTEXT_WINDOW },
+		} as unknown as ExtensionContext
+	}
+
+	it("no-ops when total tokens are below the threshold", () => {
+		const ferment = makeFermentWithPhase()
+		ferment.phases[0].status = "active"
+		ferment.phases[0].steps[0].status = "running"
+		const runtime = makeMidTurnRuntime(ferment)
+		const pi = makePi()
+		const ctx = makeMidTurnCtx()
+
+		maybeTriggerMidTurnFermentCompaction(pi, ctx, runtime, 1000)
+
+		expect(ctx.compact).not.toHaveBeenCalled()
+	})
+
+	it("compacts and schedules resume when the threshold is exceeded with an active step", () => {
+		const ferment = makeFermentWithPhase()
+		ferment.phases[0].status = "active"
+		ferment.phases[0].steps[0].status = "running"
+		const runtime = makeMidTurnRuntime(ferment)
+		const pi = makePi()
+		const ctx = makeMidTurnCtx()
+
+		maybeTriggerMidTurnFermentCompaction(pi, ctx, runtime, CONTEXT_WINDOW - 1)
+
+		expect(ctx.compact).toHaveBeenCalledOnce()
+
+		const compactArgs = vi.mocked(ctx.compact).mock.calls[0]?.[0]
+		expect(compactArgs).toBeDefined()
+		compactArgs?.onComplete?.({ summary: "", firstKeptEntryId: "", tokensBefore: 99_000 })
+
+		expect(pi.appendEntry).toHaveBeenCalledWith(
+			"ferment_breadcrumb",
+			expect.objectContaining({
+				text: expect.stringContaining("Mid-turn compaction resume"),
+			}),
+		)
+	})
+
+	it("no-ops when no ferment is active", () => {
+		const runtime = makeRuntime()
+		runtime.getActive = vi.fn(() => undefined)
+		const pi = makePi()
+		const ctx = makeMidTurnCtx()
+
+		maybeTriggerMidTurnFermentCompaction(pi, ctx, runtime, CONTEXT_WINDOW - 1)
+
+		expect(ctx.compact).not.toHaveBeenCalled()
+	})
+
+	it("no-ops when no step is in progress", () => {
+		const ferment = makeFermentWithPhase()
+		ferment.phases[0].status = "active"
+		ferment.phases[0].steps[0].status = "done"
+		const runtime = makeMidTurnRuntime(ferment)
+		const pi = makePi()
+		const ctx = makeMidTurnCtx()
+
+		maybeTriggerMidTurnFermentCompaction(pi, ctx, runtime, CONTEXT_WINDOW - 1)
+
+		expect(ctx.compact).not.toHaveBeenCalled()
+	})
+
+	it("no-ops when a compaction is already in-flight", () => {
+		const ferment = makeFermentWithPhase()
+		ferment.phases[0].status = "active"
+		ferment.phases[0].steps[0].status = "running"
+		const runtime = makeMidTurnRuntime(ferment)
+		runtime.markCompactionInFlight(ferment.id)
+		const pi = makePi()
+		const ctx = makeMidTurnCtx()
+
+		maybeTriggerMidTurnFermentCompaction(pi, ctx, runtime, CONTEXT_WINDOW - 1)
+
+		expect(ctx.compact).not.toHaveBeenCalled()
+	})
+
+	it("no-ops in oneshot mode and emits a single planning-failure breadcrumb", () => {
+		const ferment = makeFermentWithPhase()
+		ferment.phases[0].status = "active"
+		ferment.phases[0].steps[0].status = "running"
+		const runtime = makeMidTurnRuntime(ferment)
+		const pi = makePi()
+		pi.getFlag = vi.fn((name) => (name === "ferment-oneshot" ? true : undefined))
+		const ctx = makeMidTurnCtx()
+
+		maybeTriggerMidTurnFermentCompaction(pi, ctx, runtime, CONTEXT_WINDOW - 1)
+		maybeTriggerMidTurnFermentCompaction(pi, ctx, runtime, CONTEXT_WINDOW - 1)
+
+		expect(ctx.compact).not.toHaveBeenCalled()
+		expect(pi.appendEntry).toHaveBeenCalledTimes(1)
+		expect(pi.appendEntry).toHaveBeenCalledWith(
+			"ferment_breadcrumb",
+			expect.objectContaining({
+				text: expect.stringContaining("Mid-turn context overrun in oneshot"),
+			}),
+		)
 	})
 })

--- a/src/extensions/ferment/auto-compaction.ts
+++ b/src/extensions/ferment/auto-compaction.ts
@@ -21,6 +21,7 @@ import type { ExtensionAPI, ExtensionContext } from "@earendil-works/pi-coding-a
 import type { CompactionResult } from "@earendil-works/pi-coding-agent"
 import { determineNextAction } from "../../ferment/engine.js"
 import type { Ferment, Phase, Step } from "../../ferment/types.js"
+import { COMPACTION_RESERVE_TOKENS } from "../compaction-thresholds.js"
 import type { FermentRuntime } from "./runtime.js"
 import { scheduleNextFermentAction } from "./scheduler.js"
 import type { PendingCompaction } from "./state.js"
@@ -104,6 +105,12 @@ function findStepById(ferment: Ferment, phaseId: string, stepId: string): Step |
 	return findPhaseById(ferment, phaseId)?.steps.find((s) => s.id === stepId)
 }
 
+function findActivePhaseAndStep(ferment: Ferment): { phase?: Phase; step?: Step } {
+	const phase = ferment.phases.find((p) => p.status === "active")
+	const step = phase?.steps.find((s) => s.status === "running")
+	return { phase, step }
+}
+
 /** Build the custom instructions string passed to ctx.compact(). */
 export function buildCustomInstructions(ferment: Ferment, pending: PendingCompaction): string {
 	const completedPhase = findCompletedPhase(ferment, pending)
@@ -155,7 +162,39 @@ export function buildCustomInstructions(ferment: Ferment, pending: PendingCompac
 	return lines.join("\n")
 }
 
-/** Build the FermentHandoffDetails payload written to the hidden session entry. */
+/** Build custom instructions for a mid-turn compaction that must resume an
+ *  in-progress step. Emphasises the active phase/step so the summary preserves
+ *  the exact work being done when the context filled. */
+export function buildMidTurnCustomInstructions(
+	ferment: Ferment,
+	phase: Phase | undefined,
+	step: Step | undefined,
+): string {
+	const lines: string[] = [
+		"The context filled while a ferment step was in progress. Preserve the plan and resume the step:",
+	]
+
+	lines.push(`- Ferment: ${ferment.name}${ferment.goal ? ` — ${ferment.goal}` : ""}`)
+
+	if (ferment.successCriteria && ferment.successCriteria.length > 0) {
+		lines.push(`- Success criteria: ${ferment.successCriteria.join("; ")}`)
+	}
+
+	if (phase) {
+		lines.push(`- Active phase: ${phase.name} — ${phase.goal}`)
+	}
+
+	if (step) {
+		lines.push(`- In-progress step: ${step.description}${step.summary ? ` (${step.summary})` : ""}`)
+	}
+
+	lines.push(
+		"- On resume: continue the in-progress step from where it left off. Do NOT restart it or switch to a different step.",
+	)
+
+	return lines.join("\n")
+}
+
 export function buildHandoffDetails(
 	result: CompactionResult,
 	ferment: Ferment,
@@ -290,6 +329,95 @@ function triggerCompactionForPending(
 				appendHandoffEntry()
 			} catch {
 				// Best-effort: never let onError propagate and crash the extension.
+			}
+		},
+	})
+}
+
+// Track which ferment/turn we already warned about for oneshot overruns so we
+// don't spam breadcrumbs on every turn_end above threshold.
+const oneshotOverrunWarned = new Set<string>()
+
+/** Clear the oneshot overrun warning set at session start. */
+export function clearMidTurnOneshotWarnings(): void {
+	oneshotOverrunWarned.clear()
+}
+
+/**
+ * Trigger mid-turn compaction for an active ferment when the context crosses
+ * the upstream auto-compaction threshold. Unlike the post-step path, this
+ * path is driven directly by turn_end token usage and must resume the
+ * in-progress step after compaction.
+ *
+ * @param totalTokens - Current session token count from the assistant usage event.
+ */
+export function maybeTriggerMidTurnFermentCompaction(
+	pi: ExtensionAPI,
+	ctx: ExtensionContext,
+	runtime: FermentRuntime,
+	totalTokens: number,
+): void {
+	if (pi.getFlag?.("ferment-oneshot") === true) {
+		const active = runtime.getActive()
+		if (active && totalTokens > (ctx.model?.contextWindow ?? Number.MAX_SAFE_INTEGER) - COMPACTION_RESERVE_TOKENS) {
+			const warnKey = active.id
+			if (!oneshotOverrunWarned.has(warnKey)) {
+				oneshotOverrunWarned.add(warnKey)
+				pi.appendEntry("ferment_breadcrumb", {
+					text: `Mid-turn context overrun in oneshot ferment "${active.name}" — treating as planning failure`,
+				})
+			}
+		}
+		return
+	}
+
+	const model = ctx.model
+	if (!model) return
+	if (totalTokens <= model.contextWindow - COMPACTION_RESERVE_TOKENS) return
+
+	const activeFerment = runtime.getActive()
+	if (!activeFerment) return
+	if (activeFerment.status !== "running") return
+
+	const { phase: activePhase, step: activeStep } = findActivePhaseAndStep(activeFerment)
+	if (!activePhase || !activeStep) return
+
+	const fermentId = activeFerment.id
+	if (runtime.isCompactionInFlight(fermentId)) return
+
+	runtime.markCompactionInFlight(fermentId)
+
+	const customInstructions = buildMidTurnCustomInstructions(activeFerment, activePhase, activeStep)
+
+	ctx.compact({
+		customInstructions,
+		onComplete: (result: CompactionResult) => {
+			runtime.clearCompactionInFlight(fermentId)
+
+			const freshFerment = runtime.getStorage().get(fermentId)
+			if (!freshFerment) return
+
+			const { phase, step } = findActivePhaseAndStep(freshFerment)
+			pi.appendEntry("ferment_breadcrumb", {
+				text: `Mid-turn compaction resume: ferment "${freshFerment.name}" · phase ${phase?.index ?? "?"}/${freshFerment.phases.length} "${phase?.name ?? "unknown"}" · step ${step?.index ?? "?"}/${phase?.steps.length ?? 0} · ${(result.tokensBefore ?? 0).toLocaleString()} tokens before compaction`,
+			})
+
+			if (freshFerment.status === "running") {
+				runtime.setActive(freshFerment)
+				scheduleNextFermentAction(pi, freshFerment, runtime, {
+					tag: "Mid-turn compaction resume",
+					deliverAsFollowUp: true,
+				})
+			}
+		},
+		onError: (error: Error) => {
+			runtime.clearCompactionInFlight(fermentId)
+			const isExpected =
+				error.message.includes("too small") ||
+				error.message.includes("Already compacted") ||
+				error.message.includes("Compaction cancelled")
+			if (!isExpected) {
+				ctx.ui?.notify?.(`Mid-turn compaction failed: ${error.message}`, "warning")
 			}
 		},
 	})

--- a/src/extensions/ferment/auto-compaction.ts
+++ b/src/extensions/ferment/auto-compaction.ts
@@ -43,6 +43,13 @@ export interface FermentHandoffDetails {
 	compactionTokensBefore?: number
 }
 
+/** Return the token count at which we should trigger auto-compaction.
+ *  Clamped to zero so tiny context windows never produce a negative threshold
+ *  that would spuriously match any non-negative token count. */
+function compactionThreshold(contextWindow: number): number {
+	return Math.max(0, contextWindow - COMPACTION_RESERVE_TOKENS)
+}
+
 // ─── Helpers ──────────────────────────────────────────────────────────────────
 
 /**
@@ -220,6 +227,14 @@ export function buildHandoffDetails(
 	}
 }
 
+// Error messages that upstream treats as routine "no-op" compaction outcomes.
+// Kept as a single source of truth so the two compaction paths stay consistent.
+const EXPECTED_COMPACTION_ERROR_MESSAGES = ["too small", "Already compacted", "Compaction cancelled"]
+
+function isExpectedCompactionError(error: Error): boolean {
+	return EXPECTED_COMPACTION_ERROR_MESSAGES.some((message) => error.message.includes(message))
+}
+
 // ─── Main entry point ─────────────────────────────────────────────────────────
 
 /**
@@ -290,57 +305,53 @@ function triggerCompactionForPending(
 		)
 	}
 
-	ctx.compact({
-		customInstructions,
-		onComplete: (result: CompactionResult) => {
-			runtime.clearCompactionInFlight(fermentId)
-			appendHandoffEntry(result)
-
-			// After compaction the session is idle. The LLM's previous
-			// next-action reasoning was discarded with the old history, so
-			// schedule the next ferment action as a follow-up turn to keep
-			// automated ferments moving forward without user intervention.
-			try {
-				const freshFerment = runtime.getStorage().get(fermentId)
-				if (freshFerment && (freshFerment.status === "running" || freshFerment.status === "planned")) {
-					runtime.setActive(freshFerment)
-					scheduleNextFermentAction(pi, freshFerment, runtime, {
-						tag: "Auto-compaction continuation",
-						deliverAsFollowUp: true,
-					})
-				}
-			} catch {
-				// Best-effort: scheduler errors must not propagate from a compaction callback.
-			}
-		},
-		onError: (error: Error) => {
-			try {
+	try {
+		ctx.compact({
+			customInstructions,
+			onComplete: (result: CompactionResult) => {
 				runtime.clearCompactionInFlight(fermentId)
-				// Silently skip expected non-errors: session too small, already
-				// compacted, cancelled. These are routine when steps are short.
-				const isExpected =
-					error.message.includes("too small") ||
-					error.message.includes("Already compacted") ||
-					error.message.includes("Compaction cancelled")
-				if (!isExpected) {
-					ctx.ui?.notify?.(`Stage compaction failed: ${error.message}`, "warning")
+				appendHandoffEntry(result)
+
+				// After compaction the session is idle. The LLM's previous
+				// next-action reasoning was discarded with the old history, so
+				// schedule the next ferment action as a follow-up turn to keep
+				// automated ferments moving forward without user intervention.
+				try {
+					const freshFerment = runtime.getStorage().get(fermentId)
+					if (freshFerment && (freshFerment.status === "running" || freshFerment.status === "planned")) {
+						runtime.setActive(freshFerment)
+						scheduleNextFermentAction(pi, freshFerment, runtime, {
+							tag: "Auto-compaction continuation",
+							deliverAsFollowUp: true,
+						})
+					}
+				} catch {
+					// Best-effort: scheduler errors must not propagate from a compaction callback.
 				}
-				// Always append the handoff entry even when compaction fails/is skipped.
-				appendHandoffEntry()
-			} catch {
-				// Best-effort: never let onError propagate and crash the extension.
-			}
-		},
-	})
-}
-
-// Track which ferment/turn we already warned about for oneshot overruns so we
-// don't spam breadcrumbs on every turn_end above threshold.
-const oneshotOverrunWarned = new Set<string>()
-
-/** Clear the oneshot overrun warning set at session start. */
-export function clearMidTurnOneshotWarnings(): void {
-	oneshotOverrunWarned.clear()
+			},
+			onError: (error: Error) => {
+				try {
+					runtime.clearCompactionInFlight(fermentId)
+					// Silently skip expected non-errors: session too small, already
+					// compacted, cancelled. These are routine when steps are short.
+					if (!isExpectedCompactionError(error)) {
+						ctx.ui?.notify?.(`Stage compaction failed: ${error.message}`, "warning")
+					}
+					// Always append the handoff entry even when compaction fails/is skipped.
+					appendHandoffEntry()
+				} catch {
+					// Best-effort: never let onError propagate and crash the extension.
+				}
+			},
+		})
+	} catch (error) {
+		// ctx.compact should never throw, but if it does before invoking callbacks
+		// the in-flight flag must be cleared so future compactions are not blocked.
+		runtime.clearCompactionInFlight(fermentId)
+		if (error instanceof Error && !isExpectedCompactionError(error)) {
+			ctx.ui?.notify?.(`Stage compaction failed: ${error.message}`, "warning")
+		}
+	}
 }
 
 /**
@@ -359,10 +370,10 @@ export function maybeTriggerMidTurnFermentCompaction(
 ): void {
 	if (pi.getFlag?.("ferment-oneshot") === true) {
 		const active = runtime.getActive()
-		if (active && totalTokens > (ctx.model?.contextWindow ?? Number.MAX_SAFE_INTEGER) - COMPACTION_RESERVE_TOKENS) {
+		if (active && totalTokens > compactionThreshold(ctx.model?.contextWindow ?? Number.MAX_SAFE_INTEGER)) {
 			const warnKey = active.id
-			if (!oneshotOverrunWarned.has(warnKey)) {
-				oneshotOverrunWarned.add(warnKey)
+			if (!runtime.hasMidTurnOneshotWarning(warnKey)) {
+				runtime.markMidTurnOneshotWarning(warnKey)
 				pi.appendEntry("ferment_breadcrumb", {
 					text: `Mid-turn context overrun in oneshot ferment "${active.name}" — treating as planning failure`,
 				})
@@ -373,7 +384,7 @@ export function maybeTriggerMidTurnFermentCompaction(
 
 	const model = ctx.model
 	if (!model) return
-	if (totalTokens <= model.contextWindow - COMPACTION_RESERVE_TOKENS) return
+	if (totalTokens <= compactionThreshold(model.contextWindow)) return
 
 	const activeFerment = runtime.getActive()
 	if (!activeFerment) return
@@ -389,36 +400,41 @@ export function maybeTriggerMidTurnFermentCompaction(
 
 	const customInstructions = buildMidTurnCustomInstructions(activeFerment, activePhase, activeStep)
 
-	ctx.compact({
-		customInstructions,
-		onComplete: (result: CompactionResult) => {
-			runtime.clearCompactionInFlight(fermentId)
+	try {
+		ctx.compact({
+			customInstructions,
+			onComplete: (result: CompactionResult) => {
+				runtime.clearCompactionInFlight(fermentId)
 
-			const freshFerment = runtime.getStorage().get(fermentId)
-			if (!freshFerment) return
+				const freshFerment = runtime.getStorage().get(fermentId)
+				if (!freshFerment) return
 
-			const { phase, step } = findActivePhaseAndStep(freshFerment)
-			pi.appendEntry("ferment_breadcrumb", {
-				text: `Mid-turn compaction resume: ferment "${freshFerment.name}" · phase ${phase?.index ?? "?"}/${freshFerment.phases.length} "${phase?.name ?? "unknown"}" · step ${step?.index ?? "?"}/${phase?.steps.length ?? 0} · ${(result.tokensBefore ?? 0).toLocaleString()} tokens before compaction`,
-			})
-
-			if (freshFerment.status === "running") {
-				runtime.setActive(freshFerment)
-				scheduleNextFermentAction(pi, freshFerment, runtime, {
-					tag: "Mid-turn compaction resume",
-					deliverAsFollowUp: true,
+				const { phase, step } = findActivePhaseAndStep(freshFerment)
+				pi.appendEntry("ferment_breadcrumb", {
+					text: `Mid-turn compaction resume: ferment "${freshFerment.name}" · phase ${phase?.index ?? "?"}/${freshFerment.phases.length} "${phase?.name ?? "unknown"}" · step ${step?.index ?? "?"}/${phase?.steps.length ?? 0} · ${(result.tokensBefore ?? 0).toLocaleString()} tokens before compaction`,
 				})
-			}
-		},
-		onError: (error: Error) => {
-			runtime.clearCompactionInFlight(fermentId)
-			const isExpected =
-				error.message.includes("too small") ||
-				error.message.includes("Already compacted") ||
-				error.message.includes("Compaction cancelled")
-			if (!isExpected) {
-				ctx.ui?.notify?.(`Mid-turn compaction failed: ${error.message}`, "warning")
-			}
-		},
-	})
+
+				if (freshFerment.status === "running") {
+					runtime.setActive(freshFerment)
+					scheduleNextFermentAction(pi, freshFerment, runtime, {
+						tag: "Mid-turn compaction resume",
+						deliverAsFollowUp: true,
+					})
+				}
+			},
+			onError: (error: Error) => {
+				runtime.clearCompactionInFlight(fermentId)
+				if (!isExpectedCompactionError(error)) {
+					ctx.ui?.notify?.(`Mid-turn compaction failed: ${error.message}`, "warning")
+				}
+			},
+		})
+	} catch (error) {
+		// ctx.compact should never throw, but if it does before invoking callbacks
+		// the in-flight flag must be cleared so future compactions are not blocked.
+		runtime.clearCompactionInFlight(fermentId)
+		if (error instanceof Error && !isExpectedCompactionError(error)) {
+			ctx.ui?.notify?.(`Mid-turn compaction failed: ${error.message}`, "warning")
+		}
+	}
 }

--- a/src/extensions/ferment/events.ts
+++ b/src/extensions/ferment/events.ts
@@ -5,7 +5,7 @@ import type { Ferment } from "../../ferment/types.js"
 import { isAgentWorker } from "../agent-worker-context.js"
 import { deferExtensionAction } from "../deferred-action.js"
 import { createToolVisibility } from "../prompt-construction/tool-visibility.js"
-import { maybeTriggerFermentCompaction } from "./auto-compaction.js"
+import { maybeTriggerFermentCompaction, maybeTriggerMidTurnFermentCompaction } from "./auto-compaction.js"
 import { formatDuration } from "./colors.js"
 import { extractContextualOptions, extractTrailingQuestion } from "./contextual-options.js"
 import { decideContinuation } from "./continuation.js"
@@ -508,5 +508,12 @@ export function registerFermentEvents(pi: ExtensionAPI, runtime: FermentRuntime 
 		// Fires between turns in automated-continuation mode, so the next
 		// phase starts with a fresh compacted session.
 		maybeTriggerFermentCompaction(pi, ctx, runtime)
+
+		// Mid-turn guard: if the context crossed the auto-compaction threshold
+		// while a step is still in progress, compact now and resume the step.
+		// Only acts on tool-use turns; stop/error/aborted are handled elsewhere.
+		if (event.message.role === "assistant" && event.message.stopReason === "toolUse") {
+			maybeTriggerMidTurnFermentCompaction(pi, ctx, runtime, event.message.usage.totalTokens)
+		}
 	})
 }

--- a/src/extensions/ferment/events.ts
+++ b/src/extensions/ferment/events.ts
@@ -513,7 +513,7 @@ export function registerFermentEvents(pi: ExtensionAPI, runtime: FermentRuntime 
 		// while a step is still in progress, compact now and resume the step.
 		// Only acts on tool-use turns; stop/error/aborted are handled elsewhere.
 		if (event.message.role === "assistant" && event.message.stopReason === "toolUse") {
-			maybeTriggerMidTurnFermentCompaction(pi, ctx, runtime, event.message.usage.totalTokens)
+			maybeTriggerMidTurnFermentCompaction(pi, ctx, runtime, event.message.usage?.totalTokens ?? 0)
 		}
 	})
 }

--- a/src/extensions/ferment/index.ts
+++ b/src/extensions/ferment/index.ts
@@ -19,7 +19,7 @@ import { isAgentWorker } from "../agent-worker-context.js"
 import { createSystemPromptBlocks } from "../prompt-construction/index.js"
 import { requestSharedFooterRender } from "../shared-footer.js"
 import { registerTipProvider } from "../tips/registry.js"
-import { clearMidTurnOneshotWarnings, maybeTriggerFermentCompaction } from "./auto-compaction.js"
+import { maybeTriggerFermentCompaction } from "./auto-compaction.js"
 import { fermentBreadcrumbRenderer } from "./breadcrumb-renderer.js"
 import { registerFermentCommands } from "./commands.js"
 import { registerFermentEvents } from "./events.js"
@@ -192,7 +192,7 @@ export default function fermentExtension(pi: ExtensionAPI, runtime: FermentRunti
 
 	pi.on("session_start", (_event, _ctx) => {
 		ctx = _ctx
-		clearMidTurnOneshotWarnings()
+		runtime.clearMidTurnOneshotWarnings()
 	})
 
 	pi.on("session_shutdown", () => {

--- a/src/extensions/ferment/index.ts
+++ b/src/extensions/ferment/index.ts
@@ -19,7 +19,7 @@ import { isAgentWorker } from "../agent-worker-context.js"
 import { createSystemPromptBlocks } from "../prompt-construction/index.js"
 import { requestSharedFooterRender } from "../shared-footer.js"
 import { registerTipProvider } from "../tips/registry.js"
-import { maybeTriggerFermentCompaction } from "./auto-compaction.js"
+import { clearMidTurnOneshotWarnings, maybeTriggerFermentCompaction } from "./auto-compaction.js"
 import { fermentBreadcrumbRenderer } from "./breadcrumb-renderer.js"
 import { registerFermentCommands } from "./commands.js"
 import { registerFermentEvents } from "./events.js"
@@ -192,6 +192,7 @@ export default function fermentExtension(pi: ExtensionAPI, runtime: FermentRunti
 
 	pi.on("session_start", (_event, _ctx) => {
 		ctx = _ctx
+		clearMidTurnOneshotWarnings()
 	})
 
 	pi.on("session_shutdown", () => {

--- a/src/extensions/ferment/runtime.test.ts
+++ b/src/extensions/ferment/runtime.test.ts
@@ -10,6 +10,8 @@ describe("FermentRuntime", () => {
 	})
 
 	afterEach(() => {
+		// Clear any active ferment so permission-mode listeners don't leak across tests.
+		runtime.setActive(undefined)
 		vi.restoreAllMocks()
 	})
 

--- a/src/extensions/ferment/runtime.ts
+++ b/src/extensions/ferment/runtime.ts
@@ -28,6 +28,7 @@ import {
 	clearAllStepStarts,
 	clearBlockRetry,
 	clearCompactionInFlight,
+	clearMidTurnOneshotWarnings,
 	clearPendingCompaction,
 	clearFermentState as clearStateForFerment,
 	clearStepCompleteAttempt,
@@ -43,12 +44,14 @@ import {
 	getPhaseStartRef,
 	getStepStartRef,
 	getStorage,
+	hasMidTurnOneshotWarning,
 	isAutomatedContinuationEnabled,
 	isCompactionInFlight,
 	isScopingConfirmed,
 	isScopingInteractive,
 	markCompactionInFlight,
 	markHumanInput,
+	markMidTurnOneshotWarning,
 	markScopingConfirmed,
 	markScopingInteractive,
 	recordBlockHashAndCheckRepeat,
@@ -119,6 +122,9 @@ export interface FermentRuntime {
 	clearCompactionInFlight(fermentId: string): void
 	isCompactionInFlight(fermentId: string): boolean
 	clearAllPendingCompactions(): void
+	markMidTurnOneshotWarning(fermentId: string): void
+	hasMidTurnOneshotWarning(fermentId: string): boolean
+	clearMidTurnOneshotWarnings(): void
 }
 
 function getCurrentPendingPlanReview(): PendingPlanReview | undefined {
@@ -192,6 +198,9 @@ export function createDefaultFermentRuntime(): FermentRuntime {
 		clearCompactionInFlight,
 		isCompactionInFlight,
 		clearAllPendingCompactions,
+		markMidTurnOneshotWarning,
+		hasMidTurnOneshotWarning,
+		clearMidTurnOneshotWarnings,
 	}
 	return runtime
 }

--- a/src/extensions/ferment/state.ts
+++ b/src/extensions/ferment/state.ts
@@ -289,6 +289,25 @@ export function clearAllPendingCompactions(): void {
 	compactionInFlight.clear()
 }
 
+// ─── Mid-turn oneshot overrun warnings (per session) ─────────────────────────
+// Tracks which one-shot ferments have already emitted a mid-turn context-overrun
+// breadcrumb so we don't spam on every turn_end above threshold. Kept in state
+// (not a module-level Set in auto-compaction.ts) so it is scoped to the runtime
+// instance and resets with session_start.
+const midTurnOneshotWarnings = new Set<string>()
+
+export function markMidTurnOneshotWarning(fermentId: string): void {
+	midTurnOneshotWarnings.add(fermentId)
+}
+
+export function hasMidTurnOneshotWarning(fermentId: string): boolean {
+	return midTurnOneshotWarnings.has(fermentId)
+}
+
+export function clearMidTurnOneshotWarnings(): void {
+	midTurnOneshotWarnings.clear()
+}
+
 // ─── Block-retry counter (per phase) ─────────────────────────────────────────
 // Key: `${fermentId}:${phaseId}`. Incremented every time complete_ferment_phase is
 // called and the reviewer emits at least one `block` flag. After

--- a/src/extensions/model-guard.test.ts
+++ b/src/extensions/model-guard.test.ts
@@ -1,7 +1,10 @@
 import type { ImageContent, TextContent, ToolResultMessage, UserMessage } from "@earendil-works/pi-ai"
 import type { ContextEvent, ExtensionAPI, ExtensionContext } from "@earendil-works/pi-coding-agent"
+import type { Ferment } from "../ferment/types.js"
 
 import { beforeEach, describe, expect, it, vi } from "vitest"
+import { COMPACTION_RESERVE_TOKENS } from "./compaction-thresholds.js"
+import { clearActiveFermentId, setActive as setActiveFerment } from "./ferment/state.js"
 import modelGuardExtension, {
 	estimateTokens,
 	hasImages,
@@ -576,8 +579,7 @@ function makeTurnEndEvent(totalTokens: number, stopReason: string) {
 
 describe("turn_end compaction guard", () => {
 	const CONTEXT_WINDOW = 262_144
-	const RESERVE = 16_384
-	const THRESHOLD = CONTEXT_WINDOW - RESERVE // 245,760
+	const THRESHOLD = CONTEXT_WINDOW - COMPACTION_RESERVE_TOKENS // 245,760
 
 	it("does not compact when totalTokens is below the compaction threshold", async () => {
 		const { pi, trigger } = makeMockPI()
@@ -652,6 +654,23 @@ describe("turn_end compaction guard", () => {
 		})
 		await trigger("turn_end", makeTurnEndEvent(THRESHOLD, "toolUse"), ctx)
 		expect(compact).not.toHaveBeenCalled()
+	})
+
+	it("defers to the ferment extension when a ferment is active", async () => {
+		setActiveFerment({ id: "f1", status: "running", phases: [] } as unknown as Ferment)
+		try {
+			const { pi, trigger } = makeMockPI()
+			modelGuardExtension(pi)
+			const compact = vi.fn()
+			const ctx = makeMockCtx({
+				model: { id: "kimi-k2.6", input: ["text"], contextWindow: CONTEXT_WINDOW } as ExtensionContext["model"],
+				compact,
+			})
+			await trigger("turn_end", makeTurnEndEvent(THRESHOLD + 1, "toolUse"), ctx)
+			expect(compact).not.toHaveBeenCalled()
+		} finally {
+			clearActiveFermentId()
+		}
 	})
 })
 

--- a/src/extensions/model-guard.ts
+++ b/src/extensions/model-guard.ts
@@ -1,5 +1,7 @@
 import type { AssistantMessage, ImageContent, TextContent, ToolResultMessage, UserMessage } from "@earendil-works/pi-ai"
 import type { ContextEvent, ExtensionAPI, ExtensionContext } from "@earendil-works/pi-coding-agent"
+import { COMPACTION_RESERVE_TOKENS } from "./compaction-thresholds.js"
+import { hasActiveFerment } from "./ferment/state.js"
 
 /** Messages that have a content array we can inspect for images. */
 type ContentMessage = UserMessage | AssistantMessage | ToolResultMessage
@@ -333,6 +335,12 @@ export default function createModelGuardExtension(_pi: ExtensionAPI) {
 	// turn ends. turn_end fires after every individual LLM response inside the
 	// loop, giving us a chance to compact before the hard limit is hit.
 	_pi.on("turn_end", async (event, ctx: ExtensionContext) => {
+		// Ferment-aware mid-turn compaction lives in the ferment extension
+		// (src/extensions/ferment/auto-compaction.ts). It resumes the in-progress
+		// step after compaction. Defer to it whenever a ferment is active so we
+		// don't double-compact and so the ferment continues automatically.
+		if (hasActiveFerment()) return
+
 		const model = ctx.model
 		if (!model) return
 
@@ -346,9 +354,7 @@ export default function createModelGuardExtension(_pi: ExtensionAPI) {
 		if (!usage?.totalTokens) return
 
 		// Use the same threshold as upstream auto-compaction: contextWindow - reserveTokens.
-		// reserveTokens defaults to 16,384 in DEFAULT_COMPACTION_SETTINGS.
-		const RESERVE_TOKENS = 16_384
-		if (usage.totalTokens <= model.contextWindow - RESERVE_TOKENS) return
+		if (usage.totalTokens <= model.contextWindow - COMPACTION_RESERVE_TOKENS) return
 
 		// Threshold exceeded mid-turn. Compact now.
 		//

--- a/src/extensions/theme-selector.ts
+++ b/src/extensions/theme-selector.ts
@@ -26,6 +26,19 @@ const SETTINGS_SUBMENU_SELECT_LIST_LAYOUT = {
 	maxPrimaryColumnWidth: 32,
 }
 
+// Runtime-only UI helpers that are not yet exported from the upstream
+// ExtensionUIContext type. The casts are isolated here and guarded at runtime
+// so the code fails gracefully if the contract drifts.
+function getPreviewTheme(ui: ExtensionCommandContext["ui"]): ((name: string) => void) | undefined {
+	const candidate = ui as unknown as { previewTheme?: (name: string) => void }
+	return typeof candidate.previewTheme === "function" ? candidate.previewTheme : undefined
+}
+
+function getShowError(ui: ExtensionCommandContext["ui"]): ((message: string) => void) | undefined {
+	const candidate = ui as unknown as { showError?: (message: string) => void }
+	return typeof candidate.showError === "function" ? candidate.showError : undefined
+}
+
 // Inline copy of pi-coding-agent's private DynamicBorder component
 // (dist/modes/interactive/components/dynamic-border.js). Re-implemented
 // locally because:
@@ -95,19 +108,14 @@ export default function themeSelectorExtension(pi: ExtensionAPI) {
 
 				// Preview theme on navigation (hover/arrow keys)
 				selectList.onSelectionChange = (item) => {
-					// The runtime implements previewTheme but it is not yet in the
-					// upstream ExtensionUIContext type definition.
-					;(ui as unknown as { previewTheme(name: string): void }).previewTheme(item.value)
+					getPreviewTheme(ui)?.(item.value)
 				}
 
 				// Finalize selection on Enter
 				selectList.onSelect = (item) => {
 					const result = ui.setTheme(item.value)
 					if (!result.success) {
-						// showError is also implemented at runtime but missing from the type.
-						;(ui as unknown as { showError(message: string): void }).showError(
-							`Failed to load theme "${item.value}": ${result.error}\nFell back to dark theme.`,
-						)
+						getShowError(ui)?.(`Failed to load theme "${item.value}": ${result.error}\nFell back to dark theme.`)
 					}
 					done()
 				}
@@ -116,7 +124,7 @@ export default function themeSelectorExtension(pi: ExtensionAPI) {
 					// Restore original theme on cancel (no persist, mirrors /settings onThemePreview).
 					// Guard: Theme.name is optional; skip the preview if there is no name to restore.
 					if (currentThemeName) {
-						;(ui as unknown as { previewTheme(name: string): void }).previewTheme(currentThemeName)
+						getPreviewTheme(ui)?.(currentThemeName)
 					}
 					done()
 				}

--- a/src/extensions/theme-selector.ts
+++ b/src/extensions/theme-selector.ts
@@ -95,14 +95,19 @@ export default function themeSelectorExtension(pi: ExtensionAPI) {
 
 				// Preview theme on navigation (hover/arrow keys)
 				selectList.onSelectionChange = (item) => {
-					ui.previewTheme(item.value)
+					// The runtime implements previewTheme but it is not yet in the
+					// upstream ExtensionUIContext type definition.
+					;(ui as unknown as { previewTheme(name: string): void }).previewTheme(item.value)
 				}
 
 				// Finalize selection on Enter
 				selectList.onSelect = (item) => {
 					const result = ui.setTheme(item.value)
 					if (!result.success) {
-						ui.showError(`Failed to load theme "${item.value}": ${result.error}\nFell back to dark theme.`)
+						// showError is also implemented at runtime but missing from the type.
+						;(ui as unknown as { showError(message: string): void }).showError(
+							`Failed to load theme "${item.value}": ${result.error}\nFell back to dark theme.`,
+						)
 					}
 					done()
 				}
@@ -110,7 +115,9 @@ export default function themeSelectorExtension(pi: ExtensionAPI) {
 				selectList.onCancel = () => {
 					// Restore original theme on cancel (no persist, mirrors /settings onThemePreview).
 					// Guard: Theme.name is optional; skip the preview if there is no name to restore.
-					if (currentThemeName) ui.previewTheme(currentThemeName)
+					if (currentThemeName) {
+						;(ui as unknown as { previewTheme(name: string): void }).previewTheme(currentThemeName)
+					}
 					done()
 				}
 

--- a/src/shared/planning/shared-planning-process.test.ts
+++ b/src/shared/planning/shared-planning-process.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from "vitest"
+import { SCOPING_DISCOVERY_GUIDANCE } from "../../extensions/ferment/constants.js"
 import { SHARED_PLANNING_PROCESS } from "./shared-planning-process.js"
 
 describe("SHARED_PLANNING_PROCESS", () => {
@@ -188,6 +189,23 @@ describe("SHARED_PLANNING_PROCESS", () => {
 
 		expect(planSection).toContain("Ensure completion criteria were confirmed")
 		expect(planSection).toContain("before finalizing")
+	})
+
+	it("includes step-sizing guidance so each step fits within a single context window", () => {
+		expect(SHARED_PLANNING_PROCESS).toContain(
+			"every step should fit within ~25% of the active model's context window when implemented",
+		)
+		expect(SHARED_PLANNING_PROCESS).toContain(
+			"If you cannot see how to fit a step within that budget, split it into smaller steps",
+		)
+	})
+
+	it("flows the step-sizing guidance into the ferment scoping prompt", () => {
+		// SCOPING_DISCOVERY_GUIDANCE embeds SHARED_PLANNING_PROCESS, so the same
+		// step-sizing sentence reaches the ferment planner.
+		expect(SCOPING_DISCOVERY_GUIDANCE).toContain(
+			"every step should fit within ~25% of the active model's context window when implemented",
+		)
 	})
 
 	it("is under 7000 characters — process guidance plus shared plan template", () => {

--- a/src/shared/planning/shared-planning-process.ts
+++ b/src/shared/planning/shared-planning-process.ts
@@ -98,6 +98,8 @@ Ordered, independently-verifiable units of work. Each chunk has:
 - **Test Coverage**: which test files need creation or update for this chunk
 - **Open Questions**: explicitly list any unknowns or assumptions (never leave implicit)
 
+Step sizing rule: every step should fit within ~25% of the active model's context window when implemented, including its tool output. If you cannot see how to fit a step within that budget, split it into smaller steps.
+
 ## Verification Strategy
 How to confirm each chunk is correct (test command, manual check, etc.).
 


### PR DESCRIPTION
## What

Fixes the issue where automatic compaction during a ferment would cause the ferment to stop.

## Changes

- Add a mid-turn compaction guard in `turn_end` that only triggers when the assistant stop reason is `toolUse`.
- Introduce `maybeTriggerMidTurnFermentCompaction` to compact context while a step is still in progress and then resume it.
- Centralize the compaction reserve threshold in `src/extensions/compaction-thresholds.ts`.
- Defer `model-guard` handling when an active ferment is present.
- Resolve the `events.ts` import merge conflict so both compaction helpers and `createToolVisibility` are imported.

## Verification

- `pnpm run typecheck` — clean
- `pnpm exec biome check` on changed files — clean
- `pnpm run test` — 6014 passed, 3 skipped

Note: `src/extensions/ferment/gate-validation.test.ts` was intentionally left out of this PR.
