### PR TITLE
fix(test): increase test model context window

### DIFF
--- a/tests/e2e/acp/all-capabilities.test.ts
+++ b/tests/e2e/acp/all-capabilities.test.ts
@@ -18,7 +18,7 @@ const FULL_CAPABILITIES: ClientCapabilities = {
 // Spread the kimchi source of truth so this stays in sync when a method is added.
 const PI_META = { "kimchi.dev": { ...ADVERTISED_CAPABILITIES } } as const
 
-describe.skip("ACP integration — all capabilities", () => {
+describe("ACP integration — all capabilities", () => {
 	let fixture: AcpFixture
 
 	beforeEach(async () => {

--- a/tests/e2e/acp/elicitation-only.test.ts
+++ b/tests/e2e/acp/elicitation-only.test.ts
@@ -16,7 +16,7 @@ const ELICITATION_ONLY_CAPABILITIES: ClientCapabilities = {
 	elicitation: { form: {} },
 }
 
-describe.skip("ACP integration — elicitation only", () => {
+describe("ACP integration — elicitation only", () => {
 	let fixture: AcpFixture
 
 	beforeEach(async () => {

--- a/tests/e2e/acp/no-capabilities.test.ts
+++ b/tests/e2e/acp/no-capabilities.test.ts
@@ -7,7 +7,7 @@ import { afterEach, beforeEach, describe, expect, it } from "vitest"
 import { type AcpFixture, startAcpFixture } from "./support/acp-fixture.js"
 import { newSession, prompt } from "./support/scenarios.js"
 
-describe.skip("ACP integration — no capabilities", () => {
+describe("ACP integration — no capabilities", () => {
 	let fixture: AcpFixture
 
 	beforeEach(async () => {

--- a/tests/e2e/acp/permission-flow.test.ts
+++ b/tests/e2e/acp/permission-flow.test.ts
@@ -33,7 +33,7 @@ const PI_META = { "kimchi.dev": { ...ADVERTISED_CAPABILITIES } } as const
 
 const FEEDBACK_TEXT = "Please don't touch that file — use the editor tool instead."
 
-describe.skip("ACP integration — permission flow", () => {
+describe("ACP integration — permission flow", () => {
 	describe("compound bash in rpc mode", () => {
 		let fixture: AcpFixture
 

--- a/tests/e2e/acp/support/acp-fixture.ts
+++ b/tests/e2e/acp/support/acp-fixture.ts
@@ -279,7 +279,7 @@ export async function startAcpFixture(options: StartAcpFixtureOptions): Promise<
 									name: "Fake Basic",
 									reasoning: false,
 									input: ["text"],
-									contextWindow: 8192,
+									contextWindow: 64_000,
 									maxTokens: 1024,
 									cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
 									provider: "openai",


### PR DESCRIPTION
## What does this PR do?

Fixes an issue with tests where due to changes in harness the context window got bigger and triggered an unexpected compaction in upstream Pi lib, which caused all tests with slightly longer streams to fail.

## Checklist

- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md) and agree to the CLA
- [ ] This PR links to an open issue above
- [x] Tests pass locally (`pnpm run test`)
- [x] Lint passes (`pnpm run check`)
- [ ] Documentation updated if behavior changed

Closes #0