### PR TITLE
feat(agents): trust/focus prompts and non-interactive CLI guidance for subagents

### DIFF
--- a/src/extensions/agents/index.ts
+++ b/src/extensions/agents/index.ts
@@ -812,6 +812,7 @@ ${typeListText}
 Guidelines:
 - If the user explicitly asks to use the Agent tool, call Agent exactly once with the requested agent type and token_budget. Do not refuse or preflight the budget in prose; let the tool enforce it.
 - For parallel work, use run_in_background: true on each agent. Foreground calls run sequentially — only one executes at a time.
+- Keep each Agent call focused on a single outcome. Agents succeed when given 1–2 files or one mechanical change; they time out when asked to perform multi-file patch-and-verify workflows in one call. Split large tasks into smaller, independent Agent calls.
 - Use Explore for codebase searches and code understanding.
 - Use Plan for architecture and implementation planning.
 - Use Researcher for web/docs research with cited sources.

--- a/src/extensions/agents/personas/default-agents.test.ts
+++ b/src/extensions/agents/personas/default-agents.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from "vitest"
 
 import { DEFAULT_AGENTS } from "./default-agents.js"
-import { AGENT_EXPLORE, AGENT_GENERAL_PURPOSE, AGENT_PLAN, AGENT_RESEARCHER } from "./types.js"
+import { AGENT_BUILDER, AGENT_EXPLORE, AGENT_GENERAL_PURPOSE, AGENT_PLAN, AGENT_RESEARCHER } from "./types.js"
 
 import { resolveAgentInvocationConfig } from "../resolution/invocation-config.js"
 
@@ -49,6 +49,17 @@ describe("DEFAULT_AGENTS", () => {
 	it("Researcher agent has roles set to research", () => {
 		const r = DEFAULT_AGENTS.get(AGENT_RESEARCHER) as NonNullable<ReturnType<typeof DEFAULT_AGENTS.get>>
 		expect(r.roles).toContain("research")
+	})
+
+	it("Builder prompt instructs trust in provided context and limits verification turns", () => {
+		const builder = DEFAULT_AGENTS.get(AGENT_BUILDER) as NonNullable<ReturnType<typeof DEFAULT_AGENTS.get>>
+		expect(builder.systemPrompt).toContain(
+			"Treat the provided file paths, code snippets, and task description as authoritative",
+		)
+		expect(builder.systemPrompt).toContain(
+			"Do not spend more than **2 consecutive turns** reading or verifying before making the first concrete edit",
+		)
+		expect(builder.systemPrompt).toContain("Do not re-read files merely to confirm what was provided")
 	})
 })
 

--- a/src/extensions/agents/personas/default-agents.ts
+++ b/src/extensions/agents/personas/default-agents.ts
@@ -208,6 +208,8 @@ You are a code builder. Your role is to implement well-scoped coding tasks: writ
 ## Build Contract
 
 1. **Read the spec** provided (plan / task description / file list and interfaces). Understand exactly what to change.
+   - The orchestrator has already explored the codebase. **Treat the provided file paths, code snippets, and task description as authoritative** unless you discover a concrete contradiction (e.g., the file does not exist at the given path, the snippet does not match the file, or the task is impossible as stated).
+   - **Do not re-read files merely to confirm what was provided.** Read a file only when you need its full contents to produce an edit, or when the provided information is contradicted by a tool result.
 2. **Implement** the changes. Write or modify the required source files.
 3. **Write or update tests** for everything you change. Target a test-to-production LOC ratio of at least 1.0.
 4. **Verify compilation and lint** — run the language's build command / linter and fix any issues.
@@ -223,7 +225,13 @@ If compilation fails or tests fail, report the failures clearly and stop. The or
 - Provide complete, functional code — no placeholders, omissions, or TODOs
 - Use absolute file paths in all references
 - Do not use emojis
-- Be concise but complete`,
+- Be concise but complete
+
+## Verification Guard
+
+- Do not spend more than **2 consecutive turns** reading or verifying before making the first concrete edit. If you already have the spec and target files, start implementing.
+- After the first edit, prefer to batch remaining reads with the next edit in the same turn rather than reading in isolation.
+- If you cannot locate a file referenced by the orchestrator after one targeted search, stop and report the missing path rather than continuing to explore.`,
 				promptMode: "replace",
 				isDefault: true,
 			},

--- a/src/extensions/agents/personas/default-agents.ts
+++ b/src/extensions/agents/personas/default-agents.ts
@@ -212,9 +212,7 @@ You are a code builder. Your role is to implement well-scoped coding tasks: writ
    - **Do not re-read files merely to confirm what was provided.** Read a file only when you need its full contents to produce an edit, or when the provided information is contradicted by a tool result.
 2. **Implement** the changes. Write or modify the required source files.
 3. **Write or update tests** for everything you change. Target a test-to-production LOC ratio of at least 1.0.
-4. **Verify compilation and lint** — run the language's build command / linter and fix any issues.
-5. **Run the test suite once** — execute the tests for the scope you touched.
-6. **Report results** — summarize what changed, list any tests that failed, and STOP. Do not iterate on fix-retry cycles.
+4. **Verify and report** — run the build/lint/tests (see phase guidelines for details), then summarize what changed, list any tests that failed, and STOP. Do not iterate on fix-retry cycles.
 
 If compilation fails or tests fail, report the failures clearly and stop. The orchestrator will spawn a fix agent if needed.
 
@@ -230,7 +228,6 @@ If compilation fails or tests fail, report the failures clearly and stop. The or
 ## Verification Guard
 
 - Do not spend more than **2 consecutive turns** reading or verifying before making the first concrete edit. If you already have the spec and target files, start implementing.
-- After the first edit, prefer to batch remaining reads with the next edit in the same turn rather than reading in isolation.
 - If you cannot locate a file referenced by the orchestrator after one targeted search, stop and report the missing path rather than continuing to explore.`,
 				promptMode: "replace",
 				isDefault: true,

--- a/src/extensions/orchestration/model-registry/guidelines/default-phase-guidelines.ts
+++ b/src/extensions/orchestration/model-registry/guidelines/default-phase-guidelines.ts
@@ -33,7 +33,7 @@ export const DEFAULT_PLAN_GUIDELINES = `During **plan** phase:
 export const KIMCHI_COAUTHOR = "Co-Authored-By: Kimchi <noreply@kimchi.dev>"
 
 export const DEFAULT_BUILD_GUIDELINES = `During **build** phase:
-- Read each file BEFORE modifying it. Never edit blind.
+- Read a file before modifying it — unless the orchestrator already provided its contents and path in the task spec, in which case you may proceed directly to editing.
 - Batch independent tool calls in a single turn — fewer turns = less context accumulation.
 - Prefer \`edit\` over \`write\` for files >30 lines. Reserve \`write\` for new files or full rewrites.
 - Stay in scope: do NOT add features, refactors, or "improvements" beyond what the spec asks for.

--- a/src/extensions/orchestration/model-registry/guidelines/default-phase-guidelines.ts
+++ b/src/extensions/orchestration/model-registry/guidelines/default-phase-guidelines.ts
@@ -40,6 +40,7 @@ export const DEFAULT_BUILD_GUIDELINES = `During **build** phase:
 - If the same code pattern is needed >2 times, extract an abstraction first instead of duplicating.
 - After each meaningful change, run the type-checker / linter / tests. Fix errors before moving on.
 - Always wrap shell commands with a timeout to prevent hanging. Use language-native timeouts where available (e.g. \`go test -timeout 60s\`, \`pytest --timeout=60\`, \`jest --testTimeout=60000\`) and \`timeout <seconds> <command>\` for everything else (e.g. \`timeout 30 go run .\`, \`timeout 60 ./server\`). Default to 60 seconds unless the task explicitly requires longer.
+- **Never run interactive commands** (e.g. \`patch -p1\`, \`git rebase\`, \`git commit\`, \`git merge\`, \`git cherry-pick\`, default \`npm init\`). Use non-interactive flags: \`patch --forward\` or \`patch -N\`, \`git -c core.editor=true ...\`, \`GIT_EDITOR=true\`, \`npm init -y\`, \`--yes\`, \`--non-interactive\`. If a command might block on input, redirect stdin from \`/dev/null\` or prefix with \`timeout\`.
 - If a tool call fails, diagnose the root cause before retrying — do not retry blindly.
 - Keep diffs minimal and reviewable.
 - **Git commits**: Always end every commit message with a blank line followed by \`${KIMCHI_COAUTHOR}\`.`

--- a/src/extensions/orchestration/model-registry/guidelines/guidelines-resolver.test.ts
+++ b/src/extensions/orchestration/model-registry/guidelines/guidelines-resolver.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest"
 import type { ModelMetadata } from "../../../../models.js"
 import { MODEL_CAPABILITIES, ModelRegistry } from "../index.js"
+import { DEFAULT_BUILD_GUIDELINES } from "./default-phase-guidelines.js"
 import {
 	buildOrchestrationGuidelinesSection,
 	buildPhaseGuidelinesSection,
@@ -206,5 +207,12 @@ describe("builtin-model guideline content", () => {
 	it("claude-opus-4-6 explore: returns default (ignored model)", () => {
 		const result = resolvePhaseGuideline("explore", "claude-opus-4-6", registry)
 		expect(result).toContain("During **explore** phase")
+	})
+
+	it("build guideline warns against interactive CLI commands and prescribes non-interactive flags", () => {
+		expect(DEFAULT_BUILD_GUIDELINES).toContain("Never run interactive commands")
+		expect(DEFAULT_BUILD_GUIDELINES).toContain("patch --forward")
+		expect(DEFAULT_BUILD_GUIDELINES).toContain("GIT_EDITOR=true")
+		expect(DEFAULT_BUILD_GUIDELINES).toContain("redirect stdin from `/dev/null`")
 	})
 })


### PR DESCRIPTION
## Summary

This PR reduces subagent timeouts and re-verification bloat by updating the prompts and guidelines that shape Builder subagent behavior:

1. **Builder subagents now trust orchestrator-provided context.** The Builder system prompt (`src/extensions/agents/personas/default-agents.ts`) now instructs subagents to treat provided file paths, snippets, and task descriptions as authoritative unless they hit a concrete contradiction, and to avoid re-reading merely to confirm.
2. **Builder gets a verification guard.** The prompt caps exploration/verification to two consecutive turns before the first concrete edit, and tells the agent to stop after one failed file lookup instead of continuing to explore.
3. **Build-phase guidelines now warn against interactive CLI commands.** Added non-interactive alternatives (`patch --forward`, `GIT_EDITOR=true`, stdin from `/dev/null`, timeouts) to prevent hangs like the `patch -p1` interactive prompt seen in recent session logs.
4. **Agent tool description encourages narrow delegation.** The orchestrator-facing tool description now tells the caller to keep each Agent call focused on a single outcome / 1–2 files.

## Test Plan

- [x] `pnpm test -- src/extensions/agents/personas/default-agents.test.ts --run`
- [x] `pnpm test -- src/extensions/orchestration/model-registry/guidelines/guidelines-resolver.test.ts --run`
- [x] `pnpm test -- src/extensions/agents/index.test.ts --run`
- [x] `pnpm test -- --run`
- [x] `pnpm run typecheck`