### PR TITLE
fix: make todo tools visible during ferment execution

### DIFF
--- a/src/extensions/ferment/tool-scope.test.ts
+++ b/src/extensions/ferment/tool-scope.test.ts
@@ -74,14 +74,27 @@ describe("profileForFerment", () => {
 })
 
 describe("planning profile", () => {
-	it("when allTools contains only planning tools, result is the registered subset", () => {
+	it("when allTools contains only planning tools, result is the registered subset plus shared core (todo tools)", () => {
+		// The planning profile derives from the catalog's planning-ferment profile,
+		// which includes SHARED_CORE_TOOLS (read tools + todo lifecycle tools) plus
+		// the ferment planning tools. We pass only PLANNING_TOOL_NAMES as registered
+		// tools; the catalog adds the shared core regardless of registration.
 		const planningTools = [...PLANNING_TOOL_NAMES]
 		const pi = createPi([], planningTools)
 
 		applyFermentToolProfile(pi, "planning")
 
 		const lastCall = (pi.setActiveTools as ReturnType<typeof vi.fn>).mock.lastCall?.[0] as string[]
-		expect(lastCall).toEqual(planningTools)
+		// All registered planning tools must be present
+		for (const name of planningTools) {
+			expect(lastCall).toContain(name)
+		}
+		// Todo lifecycle tools are shared core — always present
+		expect(lastCall).toContain("create_todos")
+		expect(lastCall).toContain("update_todos")
+		expect(lastCall).toContain("add_todo")
+		expect(lastCall).toContain("mark_todo")
+		expect(lastCall).toContain("clear_todos")
 	})
 
 	it("when allTools contains extra non-planning tools, they are excluded (intersection)", () => {

--- a/src/extensions/permissions/index.test.ts
+++ b/src/extensions/permissions/index.test.ts
@@ -709,8 +709,10 @@ describe("plan mode assumption detection", () => {
 			// Adhoc-only tools must NOT be present (per the tool-swap contract at
 			// permissions/index.ts:524-562).
 			expect(toolSet).not.toContain("questionnaire")
-			expect(toolSet).not.toContain("update_todos")
-			expect(toolSet).not.toContain("add_todo")
+			// Todo lifecycle tools are shared core — they ARE present in ferment
+			// mode (used for step-level sub-task tracking during implementation).
+			expect(toolSet).toContain("update_todos")
+			expect(toolSet).toContain("add_todo")
 			// Shared core tools MUST remain visible.
 			expect(toolSet).toContain("read")
 		} finally {

--- a/src/extensions/permissions/index.ts
+++ b/src/extensions/permissions/index.ts
@@ -581,10 +581,10 @@ export default function permissionsExtension(pi: ExtensionAPI): void {
 			//
 			// Tools REMOVED (adhoc / planning-only, no longer visible):
 			//   - questionnaire          (adhoc-only; superseded by ask_user)
-			//   - update_todos           (adhoc-only)
-			//   - add_todo               (adhoc-only)
-			//   - mark_todo              (adhoc-only)
-			//   - clear_todos            (adhoc-only)
+			//
+			// Note: todo lifecycle tools (create_todos, update_todos, add_todo,
+			// mark_todo, clear_todos) are shared core — they remain visible in
+			// all modes including ferment.
 			//
 			// Tools ADDED (ferment-mode, newly visible):
 			//   - ask_user               (interactive routing — TUI in interactive mode,

--- a/src/shared/planning/tool-catalog.test.ts
+++ b/src/shared/planning/tool-catalog.test.ts
@@ -11,9 +11,11 @@ import {
 
 const namesOf = (entries: ToolEntry[]): string[] => entries.map((t) => t.name)
 
+const TODO_TOOL_NAMES = ["create_todos", "update_todos", "add_todo", "mark_todo", "clear_todos"]
+
 const TOOL_NAMES = {
-	sharedCore: ["read", "grep", "find", "ls", "web_fetch", "web_search"],
-	adhocOnly: ["questionnaire", "create_todos", "update_todos", "add_todo", "mark_todo", "clear_todos"],
+	sharedCore: ["read", "grep", "find", "ls", "web_fetch", "web_search", ...TODO_TOOL_NAMES],
+	adhocOnly: ["questionnaire"],
 	fermentPlanningTools: [
 		"set_phase",
 		"propose_ferment_scoping",
@@ -41,8 +43,8 @@ const TOOL_NAMES = {
 }
 
 describe("SHARED_CORE_TOOLS", () => {
-	it("contains the 6 read-only discovery tools", () => {
-		expect(SHARED_CORE_TOOLS).toHaveLength(6)
+	it("contains the 6 read-only discovery tools plus 5 todo lifecycle tools", () => {
+		expect(SHARED_CORE_TOOLS).toHaveLength(11)
 		for (const name of TOOL_NAMES.sharedCore) {
 			expect(SHARED_CORE_TOOLS).toContainEqual(expect.objectContaining({ name }))
 		}
@@ -51,7 +53,7 @@ describe("SHARED_CORE_TOOLS", () => {
 
 describe("ADHOC_MODE_TOOLS", () => {
 	it("contains --plan-only tools", () => {
-		expect(ADHOC_MODE_TOOLS).toHaveLength(6)
+		expect(ADHOC_MODE_TOOLS).toHaveLength(1)
 		for (const name of TOOL_NAMES.adhocOnly) {
 			expect(ADHOC_MODE_TOOLS).toContainEqual(expect.objectContaining({ name }))
 		}
@@ -154,7 +156,7 @@ describe("getToolsForProfile", () => {
 	describe("idle", () => {
 		it("returns only shared core tools", () => {
 			const result = getToolsForProfile("idle")
-			expect(result).toHaveLength(6)
+			expect(result).toHaveLength(11)
 			expect(namesOf(result)).toEqual(TOOL_NAMES.sharedCore)
 		})
 
@@ -231,6 +233,12 @@ describe("getToolsForProfile", () => {
 			}
 		})
 
+		it("includes todo lifecycle tools (shared core)", () => {
+			for (const name of TODO_TOOL_NAMES) {
+				expect(names).toContain(name)
+			}
+		})
+
 		it("does NOT include adhoc-only tools", () => {
 			for (const name of TOOL_NAMES.adhocOnly) {
 				expect(names).not.toContain(name)
@@ -263,6 +271,12 @@ describe("getToolsForProfile", () => {
 
 		it("includes all FERMENT_MODE_TOOLS", () => {
 			for (const name of [...TOOL_NAMES.fermentPlanningTools, ...TOOL_NAMES.fermentImplementationTools]) {
+				expect(names).toContain(name)
+			}
+		})
+
+		it("includes todo lifecycle tools (shared core)", () => {
+			for (const name of TODO_TOOL_NAMES) {
 				expect(names).toContain(name)
 			}
 		})

--- a/src/shared/planning/tool-catalog.ts
+++ b/src/shared/planning/tool-catalog.ts
@@ -96,18 +96,23 @@ export const SHARED_CORE_TOOLS: ToolEntry[] = [
 	{ name: "ls", modes: ["shared"] },
 	{ name: "web_fetch", modes: ["shared"] },
 	{ name: "web_search", modes: ["shared"] },
+	// Todo lifecycle tools — must mirror TODO_TOOL_NAMES in src/extensions/todos/tool.ts
+	// These are general-purpose session tools used in all modes (adhoc chat,
+	// ferment planning, and ferment implementation). The system prompt,
+	// the ferment todo-sync bridge, and BUILTIN_ALLOW_TOOL_NAMES all treat
+	// them as universally available. Cataloging them as `shared` ensures
+	// every profile derived from getToolsForProfile includes them.
+	{ name: "create_todos", modes: ["shared"] },
+	{ name: "update_todos", modes: ["shared"] },
+	{ name: "add_todo", modes: ["shared"] },
+	{ name: "mark_todo", modes: ["shared"] },
+	{ name: "clear_todos", modes: ["shared"] },
 ]
 
 /** Tools gated behind `--plan` (adhoc planning mode). */
 export const ADHOC_MODE_TOOLS: ToolEntry[] = [
 	// interactive — model collects structured input from the user
 	{ name: "questionnaire", modes: ["adhoc"], routing: "interactive" },
-	// Todo lifecycle tools — must mirror TODO_TOOL_NAMES in src/extensions/todos/tool.ts
-	{ name: "create_todos", modes: ["adhoc"] },
-	{ name: "update_todos", modes: ["adhoc"] },
-	{ name: "add_todo", modes: ["adhoc"] },
-	{ name: "mark_todo", modes: ["adhoc"] },
-	{ name: "clear_todos", modes: ["adhoc"] },
 ]
 
 /**

--- a/tests/e2e/tui/plan-to-ferment-promo.test.ts
+++ b/tests/e2e/tui/plan-to-ferment-promo.test.ts
@@ -116,6 +116,11 @@ test.fail(
 				await waitForText(terminal, "ask_user", { timeoutMs: STREAM_TIMEOUT_MS })
 				trace.step("ask_user visible in tool list — tool swap confirmed")
 
+				// Todo lifecycle tools are shared core — they must remain visible
+				// after the plan-to-ferment tool swap (regression: previously adhoc-only).
+				await waitForText(terminal, "update_todos", { timeoutMs: STREAM_TIMEOUT_MS })
+				trace.step("update_todos visible — todo tools available during ferment")
+
 				const finalText = fullText(terminal)
 				expect(finalText.includes("questionnaire")).toBe(false)
 				trace.step("`questionnaire` absent — adhoc tools removed")

--- a/tests/e2e/tui/todo-widget-ferment.test.ts
+++ b/tests/e2e/tui/todo-widget-ferment.test.ts
@@ -1,5 +1,10 @@
 import { expect, test } from "@microsoft/tui-test"
-import { INPUT_TIMEOUT_MS, STREAM_TIMEOUT_MS, waitForText } from "./support/assertions.js"
+import {
+	INPUT_TIMEOUT_MS,
+	STARTUP_TIMEOUT_MS,
+	STREAM_TIMEOUT_MS,
+	waitForText,
+} from "./support/assertions.js"
 import { TUI_TEST_CONFIG, runKimchiSession } from "./support/kimchi-fixture.js"
 
 test.use(TUI_TEST_CONFIG)
@@ -51,6 +56,145 @@ test("todo widget renders global scope with status symbols", async ({ terminal }
 			const text = terminal.getViewableBuffer().map((r) => r.join("")).join("\n")
 			expect(text).toContain("▶")
 			expect(text).toContain("○")
+		},
+	)
+})
+
+/**
+ * Regression: todo lifecycle tools (create_todos, update_todos, add_todo,
+ * mark_todo, clear_todos) must be visible during ferment execution. They were
+ * previously cataloged as `modes: ["adhoc"]`, which excluded them from both
+ * planning-ferment and implementation-ferment profiles. Now cataloged as
+ * `modes: ["shared"]` (SHARED_CORE_TOOLS), they should be available in every
+ * mode including ferment.
+ *
+ * This test starts a ferment via `/ferment`, scopes it, and then has the model
+ * call `update_todos` during the ferment. If the tool were not visible, the
+ * tool call would be rejected by the runtime and the todo widget would never
+ * appear.
+ */
+test("todo tools are available during ferment execution", async ({ terminal }) => {
+	await runKimchiSession(
+		terminal,
+		{
+			artifactName: "todo-widget-ferment-visibility",
+			gitInit: true,
+			responses: [
+				// Turn 1: model calls propose_ferment_scoping after the /ferment intent prompt.
+				{
+					toolCalls: [
+						{
+							function: {
+								name: "propose_ferment_scoping",
+								arguments: JSON.stringify({
+									ferment_id: "__FERMENT_ID__",
+									title: "Test Ferment",
+									goal: "Verify todo tools work during ferment execution.",
+									success_criteria: ["update_todos tool call succeeds during ferment"],
+									constraints: [],
+									assumptions: "The ferment lifecycle is active.",
+									phases: [
+										{
+											name: "Implementation",
+											goal: "Call update_todos during the ferment.",
+											steps: [
+												{ description: "Write a todo list via update_todos.", verify: "true" },
+											],
+										},
+									],
+									questions: [],
+									gates: [
+										{ id: "P1", verdict: "pass", rationale: "Step has verify", evidence: "true" },
+										{ id: "P2", verdict: "omitted", rationale: "single phase", evidence: "n/a" },
+										{ id: "P3", verdict: "pass", rationale: "tests pass", evidence: "n/a" },
+									],
+								}),
+							},
+						},
+					],
+				},
+				// Turn 2 (after tool result): short text, no tool calls.
+				// This triggers the plan-review dialog.
+				{ stream: ["I've outlined the scope for this test."] },
+				// Turn 3 (post-confirmation): host nudges to call activate_ferment_phase.
+				{
+					toolCalls: [
+						{
+							function: {
+								name: "activate_ferment_phase",
+								arguments: JSON.stringify({
+									ferment_id: "__FERMENT_ID__",
+									phase_id: "phase-1",
+								}),
+							},
+						},
+					],
+				},
+				// Turn 4 (after phase activation): model calls update_todos during implementation.
+				{
+					stream: ["I'll track my work with todos."],
+					toolCalls: [
+						{
+							function: {
+								name: "update_todos",
+								arguments: JSON.stringify({
+									todos: [
+										{ content: "write the code", status: "in_progress" },
+										{ content: "run tests", status: "pending" },
+									],
+								}),
+							},
+						},
+					],
+				},
+			],
+		},
+		async (_fixture, trace) => {
+			// Stage 1: ready prompt visible.
+			await waitForText(terminal, "ask anything or type / for commands", {
+				timeoutMs: STARTUP_TIMEOUT_MS,
+			})
+			trace.step("ready prompt visible")
+
+			// Stage 2: enter ferment.
+			terminal.write("/ferment")
+			await waitForText(terminal, "/ferment", { timeoutMs: INPUT_TIMEOUT_MS })
+			trace.step("typed /ferment")
+			terminal.submit("")
+			trace.step("ran /ferment")
+
+			// Stage 3: intent prompt appears.
+			await waitForText(terminal, "would you like to ferment", {
+				timeoutMs: STARTUP_TIMEOUT_MS,
+			})
+			trace.step("intent prompt visible")
+
+			// Stage 4: submit intent → model proposes scoping.
+			terminal.submit("Verify todo tools work during ferment")
+			trace.step("submitted intent")
+
+			// Stage 5: plan-review dialog appears.
+			await waitForText(terminal, "Proceed with this plan?", {
+				timeoutMs: STREAM_TIMEOUT_MS,
+			})
+			await waitForText(terminal, "Start execution", {
+				timeoutMs: INPUT_TIMEOUT_MS,
+			})
+			trace.step("plan-review dialog visible")
+
+			// Stage 6: confirm → ferment is scoped.
+			terminal.submit("")
+			trace.step("confirmed 'Start execution'")
+
+			// Stage 7: model calls update_todos — if the tool were not visible during
+			// the ferment, this call would be rejected and the todo widget would
+			// never render. Seeing the widget proves the tool was available.
+			await waitForText(terminal, "Todos · Global", { timeoutMs: STREAM_TIMEOUT_MS })
+			trace.step("todo widget appeared — update_todos succeeded during ferment")
+
+			await waitForText(terminal, "write the code", { timeoutMs: INPUT_TIMEOUT_MS })
+			await waitForText(terminal, "run tests", { timeoutMs: INPUT_TIMEOUT_MS })
+			trace.step("todo items visible during ferment")
 		},
 	)
 })


### PR DESCRIPTION
## Problem

Users reported that todo tools (create_todos, update_todos, add_todo, mark_todo, clear_todos) are not available during ferment execution.

## Root Cause

The five todo lifecycle tools were cataloged with `modes: ["adhoc"]` in `ADHOC_MODE_TOOLS` within `src/shared/planning/tool-catalog.ts`. This meant they only appeared in the `planning-adhoc` profile and were **absent from both `planning-ferment` and `implementation-ferment` profiles**.

The `implementation-ferment` runtime path accidentally surfaced them via `pi.getAllTools()` union, but the `planning-ferment` profile did not — so todo tools were invisible during ferment planning, and unreliable during implementation.

This contradicted several other parts of the codebase that treat todo tools as universally available:
- The system prompt instructs the model to use todo tools in all modes
- The ferment `todo-sync.ts` bridge actively uses todo tools during ferment execution (step-level sub-task tracking, stall detection)
- `BUILTIN_ALLOW_TOOL_NAMES` in `permissions/index.ts` treats them as universally available

## Fix

Moved the five todo tools from `ADHOC_MODE_TOOLS` to `SHARED_CORE_TOOLS` with `modes: ["shared"]`, ensuring they appear in every profile derived from `getToolsForProfile()`.

## Testing

- [x] Updated `tool-catalog.test.ts` — shared core count 6→11, adhoc-only count 6→1, added positive assertions for todo tools in both ferment profiles
- [x] Updated `tool-scope.test.ts` — planning profile test now expects todo tools as shared core
- [x] Updated `permissions/index.test.ts` — "Start as ferment" test now asserts todo tools ARE present
- [x] Updated stale comment in `permissions/index.ts` listing removed tools during plan→ferment transition
- [x] All 339 test files pass (5977 tests, 3 skipped)
- [x] `pnpm run typecheck` passes cleanly