### PR TITLE
feat: prevent orphaned toolResult messages from reaching model providers

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -54,6 +54,7 @@ import modelGuardExtension from "./extensions/model-guard.js"
 import modelSwitchExtension from "./extensions/model-switch.js"
 import { createSessionModeOnboardingForStartup } from "./extensions/onboarding/session-mode-startup.js"
 import { applyRoleAugmentation } from "./extensions/orchestration/model-roles.js"
+import orphanToolResultSanitizerExtension from "./extensions/orphan-tool-result-sanitizer.js"
 import permissionsExtension from "./extensions/permissions/index.js"
 import { writeKimchiKeybindingDefaults } from "./extensions/permissions/keybindings.js"
 import { installPiNativeCompatibilityShim } from "./extensions/pi-package-lookup/native-compat.js"
@@ -65,6 +66,7 @@ import reportBugExtension from "./extensions/report-bug.js"
 import reviewWriteGuardExtension from "./extensions/review-write-guard.js"
 import rtkRewriteExtension from "./extensions/rtk-rewrite.js"
 import sessionNameExtension from "./extensions/session-name.js"
+import orphanToolResultRepairExtension from "./extensions/session-repair/orphan-tool-result-repair.js"
 import shutdownMarkerExtension from "./extensions/shutdown-marker.js"
 import startupUpdateExtension from "./extensions/startup-update.js"
 import statsExtension from "./extensions/stats/index.js"
@@ -519,6 +521,8 @@ try {
 			] satisfies ManagedExtensionFactory[]),
 			modelSwitchExtension,
 			modelGuardExtension,
+			orphanToolResultRepairExtension,
+			orphanToolResultSanitizerExtension,
 			stripImagesExtension,
 			traceIdExtension,
 			llmResponseLogExtension,

--- a/src/extensions/ferment/auto-compaction.test.ts
+++ b/src/extensions/ferment/auto-compaction.test.ts
@@ -8,13 +8,15 @@
  */
 
 import type { ExtensionAPI, ExtensionContext } from "@earendil-works/pi-coding-agent"
-import type { CompactionResult } from "@earendil-works/pi-coding-agent"
+import type { CompactionResult, SessionEntry } from "@earendil-works/pi-coding-agent"
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
 import type { Ferment, Phase, Step } from "../../ferment/types.js"
 import {
 	buildCustomInstructions,
 	buildHandoffDetails,
 	buildMidTurnCustomInstructions,
+	isToolCallInFlight,
+	isToolCallInFlightInSession,
 	maybeTriggerFermentCompaction,
 	maybeTriggerMidTurnFermentCompaction,
 } from "./auto-compaction.js"
@@ -90,6 +92,9 @@ function makeCtx(): ExtensionContext {
 		ui: {
 			notify: vi.fn(),
 		},
+		sessionManager: {
+			getEntries: vi.fn(() => []),
+		},
 	} as unknown as ExtensionContext
 }
 
@@ -148,6 +153,16 @@ function makePendingStep(fermentId = "ferment-1", phaseId = "phase-1", stepId = 
 
 function makePendingPhase(fermentId = "ferment-1", phaseId = "phase-1"): PendingCompaction {
 	return { kind: "phase", fermentId, phaseId, completedAt: NOW }
+}
+
+function makeSessionMessageEntry(message: unknown): SessionEntry {
+	return {
+		type: "message",
+		id: `entry-${Math.random().toString(36).slice(2)}`,
+		parentId: null,
+		timestamp: NOW,
+		message,
+	} as unknown as SessionEntry
 }
 
 // ─── Test suite ───────────────────────────────────────────────────────────────
@@ -766,5 +781,153 @@ describe("maybeTriggerMidTurnFermentCompaction", () => {
 		expect(() => maybeTriggerMidTurnFermentCompaction(pi, ctx, runtime, CONTEXT_WINDOW - 1)).not.toThrow()
 		expect(runtime.isCompactionInFlight(ferment.id)).toBe(false)
 		expect(ctx.ui?.notify).toHaveBeenCalledWith(expect.stringContaining("sync compact failure"), "warning")
+	})
+})
+
+describe("in-flight tool-call guard", () => {
+	let storageMap: Map<string, Ferment>
+	let mockStorage: ReturnType<typeof makeMockStorage>
+	let runtime: FermentRuntime
+	let pi: ExtensionAPI
+	let ctx: ExtensionContext
+
+	beforeEach(() => {
+		storageMap = new Map()
+		mockStorage = makeMockStorage(storageMap)
+		runtime = makeRuntime({
+			getStorage: () => mockStorage as unknown as import("../../ferment/event-store.js").FermentEventStore,
+		})
+		pi = makePi()
+		ctx = makeCtx()
+	})
+
+	afterEach(() => {
+		runtime.clearCompactionInFlight("ferment-1")
+		clearPendingCompaction("ferment-1")
+		vi.restoreAllMocks()
+	})
+
+	describe("isToolCallInFlight", () => {
+		it("returns true when a toolCall has no matching toolResult", () => {
+			const messages = [
+				{
+					role: "assistant",
+					content: [{ type: "toolCall", id: "call-1" }],
+				},
+			]
+			expect(isToolCallInFlight(messages)).toBe(true)
+		})
+
+		it("returns false when the matching toolResult is present", () => {
+			const messages = [
+				{
+					role: "assistant",
+					content: [{ type: "toolCall", id: "call-1" }],
+				},
+				{ role: "toolResult", toolCallId: "call-1" },
+			]
+			expect(isToolCallInFlight(messages)).toBe(false)
+		})
+
+		it("returns false for empty arrays and messages with no tool calls", () => {
+			expect(isToolCallInFlight([])).toBe(false)
+			expect(isToolCallInFlight([{ role: "user", content: "hi" }])).toBe(false)
+			expect(isToolCallInFlight([{ role: "assistant", content: [{ type: "text" }] }])).toBe(false)
+		})
+
+		it("returns true when only some toolCalls have matching toolResults", () => {
+			const messages = [
+				{
+					role: "assistant",
+					content: [
+						{ type: "toolCall", id: "call-1" },
+						{ type: "toolCall", id: "call-2" },
+					],
+				},
+				{ role: "toolResult", toolCallId: "call-1" },
+			]
+			expect(isToolCallInFlight(messages)).toBe(true)
+		})
+
+		it("returns false for malformed input without throwing", () => {
+			const malformed = [null, { role: "user" }, { role: "assistant", content: "not-an-array" }]
+			expect(() => isToolCallInFlight(malformed)).not.toThrow()
+			expect(isToolCallInFlight(malformed)).toBe(false)
+		})
+	})
+
+	describe("isToolCallInFlightInSession", () => {
+		it("returns true when the session contains an in-flight toolCall", () => {
+			ctx.sessionManager.getEntries = vi.fn(() => [
+				makeSessionMessageEntry({
+					role: "assistant",
+					content: [{ type: "toolCall", id: "call-1" }],
+				}),
+			])
+			expect(isToolCallInFlightInSession(ctx)).toBe(true)
+		})
+
+		it("returns false when the session has a completed toolCall pair", () => {
+			ctx.sessionManager.getEntries = vi.fn(() => [
+				makeSessionMessageEntry({
+					role: "assistant",
+					content: [{ type: "toolCall", id: "call-1" }],
+				}),
+				makeSessionMessageEntry({ role: "toolResult", toolCallId: "call-1" }),
+			])
+			expect(isToolCallInFlightInSession(ctx)).toBe(false)
+		})
+
+		it("returns false when sessionManager is unavailable", () => {
+			const ctxWithoutSessionManager = { ...makeCtx(), sessionManager: undefined } as unknown as ExtensionContext
+			expect(isToolCallInFlightInSession(ctxWithoutSessionManager)).toBe(false)
+		})
+	})
+
+	describe("maybeTriggerFermentCompaction", () => {
+		it("does not compact while a toolCall is in flight", () => {
+			const ferment = makeFermentWithPhase(
+				{ id: "phase-1", name: "Phase", goal: "Goal" },
+				{ id: "step-1", description: "Step" },
+			)
+			storageMap.set(ferment.id, ferment)
+			runtime.setActive(ferment)
+			setPendingCompaction(ferment.id, makePendingStep(ferment.id, "phase-1", "step-1"))
+
+			ctx.sessionManager.getEntries = vi.fn(() => [
+				makeSessionMessageEntry({
+					role: "assistant",
+					content: [{ type: "toolCall", id: "call-in-flight" }],
+				}),
+			])
+
+			maybeTriggerFermentCompaction(pi, ctx, runtime)
+
+			expect(ctx.compact).not.toHaveBeenCalled()
+			expect(runtime.getPendingCompaction(ferment.id)).toBeDefined()
+		})
+
+		it("compacts normally once the matching toolResult lands", () => {
+			const ferment = makeFermentWithPhase(
+				{ id: "phase-1", name: "Phase", goal: "Goal" },
+				{ id: "step-1", description: "Step" },
+			)
+			storageMap.set(ferment.id, ferment)
+			runtime.setActive(ferment)
+			setPendingCompaction(ferment.id, makePendingStep(ferment.id, "phase-1", "step-1"))
+
+			ctx.sessionManager.getEntries = vi.fn(() => [
+				makeSessionMessageEntry({
+					role: "assistant",
+					content: [{ type: "toolCall", id: "call-done" }],
+				}),
+				makeSessionMessageEntry({ role: "toolResult", toolCallId: "call-done" }),
+			])
+
+			maybeTriggerFermentCompaction(pi, ctx, runtime)
+
+			expect(ctx.compact).toHaveBeenCalledOnce()
+			expect(runtime.getPendingCompaction(ferment.id)).toBeUndefined()
+		})
 	})
 })

--- a/src/extensions/ferment/auto-compaction.ts
+++ b/src/extensions/ferment/auto-compaction.ts
@@ -352,16 +352,6 @@ function triggerCompactionForPending(
 	// (resets at session_start, not leaked across test runs).
 	runtime.markCompactionInFlight(fermentId)
 
-	// Defense-in-depth: maybeTriggerFermentCompaction already guards against
-	// in-flight tool calls before draining, but if this entry was drained by an
-	// older code path, bail here too rather than compacting mid-tool-call. The
-	// pending entry is already removed from the map; it will be retried as a
-	// follow-up by the next completed step. Never block the pipeline.
-	if (isToolCallInFlightInSession(ctx)) {
-		runtime.clearCompactionInFlight(fermentId)
-		return
-	}
-
 	// Reload the ferment from disk — the in-memory copy may be stale.
 	const fermentMaybe = runtime.getStorage().get(fermentId)
 	if (!fermentMaybe) {

--- a/src/extensions/ferment/auto-compaction.ts
+++ b/src/extensions/ferment/auto-compaction.ts
@@ -50,6 +50,77 @@ function compactionThreshold(contextWindow: number): number {
 	return Math.max(0, contextWindow - COMPACTION_RESERVE_TOKENS)
 }
 
+// ─── In-flight tool-call guard ────────────────────────────────────────────────
+
+/**
+ * Pure helper: return true if any assistant `toolCall` block `id` in `messages`
+ * has NO matching `toolResult` (by `toolCallId`) anywhere in the array.
+ *
+ * This is the compaction-timing root-cause signal: when the trailing session
+ * entries form an incomplete assistant toolCall -> toolResult pair, compacting
+ * would summarise away the assistant toolCall while its toolResult is appended
+ * later — creating the exact orphaned-toolResult condition phase 1 defends
+ * against. By deferring compaction until the pair completes, orphans are never
+ * created at the compaction boundary in the first place.
+ *
+ * Pure, total, never throws: unknown shapes are skipped defensively. Mirrors
+ * the structural-guard style of `findOrphanedToolResults` (phase 1) but
+ * inverts the question (toolCall without toolResult, not toolResult without
+ * toolCall).
+ */
+export function isToolCallInFlight(messages: ReadonlyArray<unknown>): boolean {
+	const callIds = new Set<string>()
+	const resultIds = new Set<string>()
+
+	for (const raw of messages) {
+		if (!raw || typeof raw !== "object") continue
+		const msg = raw as { role?: string; content?: unknown; toolCallId?: string }
+		if (msg.role === "assistant") {
+			const content = msg.content
+			if (!Array.isArray(content)) continue
+			for (const block of content) {
+				if (!block || typeof block !== "object") continue
+				const b = block as { type?: string; id?: unknown }
+				if (b.type === "toolCall" && typeof b.id === "string") {
+					callIds.add(b.id)
+				}
+			}
+		} else if (msg.role === "toolResult") {
+			if (typeof msg.toolCallId === "string") {
+				resultIds.add(msg.toolCallId)
+			}
+		}
+	}
+
+	for (const id of callIds) {
+		if (!resultIds.has(id)) return true
+	}
+	return false
+}
+
+/**
+ * Thin wrapper: read the live session entries from `ctx.sessionManager` and
+ * delegate to `isToolCallInFlight`. Returns false on any access failure so a
+ * broken/missing sessionManager never blocks compaction spuriously — the
+ * phase-1 sanitizer remains the hard guarantee.
+ */
+export function isToolCallInFlightInSession(ctx: ExtensionContext): boolean {
+	try {
+		const entries = ctx?.sessionManager?.getEntries?.() ?? []
+		const messages: unknown[] = []
+		for (const entry of entries) {
+			if (!entry || typeof entry !== "object") continue
+			const e = entry as { type?: string; message?: unknown }
+			if (e.type === "message" && e.message && typeof e.message === "object") {
+				messages.push(e.message)
+			}
+		}
+		return isToolCallInFlight(messages)
+	} catch {
+		return false
+	}
+}
+
 // ─── Helpers ──────────────────────────────────────────────────────────────────
 
 /**
@@ -252,6 +323,13 @@ function isExpectedCompactionError(error: Error): boolean {
 export function maybeTriggerFermentCompaction(pi: ExtensionAPI, ctx: ExtensionContext, runtime: FermentRuntime): void {
 	if (pi.getFlag?.("ferment-oneshot") === true) return
 
+	// Root-cause guard: defer compaction while a tool call is in flight (the
+	// trailing assistant toolCall has no matching toolResult yet). Compacting
+	// now would summarise away the toolCall and orphan the toolResult appended
+	// later. Leave the pending entry in the map for a later turn_end / agent_end
+	// to pick up once the pair completes.
+	if (isToolCallInFlightInSession(ctx)) return
+
 	// drainPendingCompactions() skips in-flight ferments — their entries stay in
 	// the map for the next turn_end / agent_end to pick up.
 	const ready = runtime.drainPendingCompactions()
@@ -273,6 +351,16 @@ function triggerCompactionForPending(
 	// Mark in-flight via runtime so the guard is scoped to this runtime instance
 	// (resets at session_start, not leaked across test runs).
 	runtime.markCompactionInFlight(fermentId)
+
+	// Defense-in-depth: maybeTriggerFermentCompaction already guards against
+	// in-flight tool calls before draining, but if this entry was drained by an
+	// older code path, bail here too rather than compacting mid-tool-call. The
+	// pending entry is already removed from the map; it will be retried as a
+	// follow-up by the next completed step. Never block the pipeline.
+	if (isToolCallInFlightInSession(ctx)) {
+		runtime.clearCompactionInFlight(fermentId)
+		return
+	}
 
 	// Reload the ferment from disk — the in-memory copy may be stale.
 	const fermentMaybe = runtime.getStorage().get(fermentId)
@@ -395,6 +483,13 @@ export function maybeTriggerMidTurnFermentCompaction(
 
 	const fermentId = activeFerment.id
 	if (runtime.isCompactionInFlight(fermentId)) return
+
+	// Root-cause guard: a mid-turn compaction fires on token overrun, which can
+	// land exactly when an assistant toolCall is awaiting its toolResult.
+	// Compacting then would summarise away the toolCall and orphan the
+	// toolResult appended after compaction. Defer — the context may be large,
+	// but emitting an orphan is worse; phase 1 still catches any that slip past.
+	if (isToolCallInFlightInSession(ctx)) return
 
 	runtime.markCompactionInFlight(fermentId)
 

--- a/src/extensions/orphan-tool-result-sanitizer.test.ts
+++ b/src/extensions/orphan-tool-result-sanitizer.test.ts
@@ -1,0 +1,198 @@
+import type { ExtensionAPI } from "@earendil-works/pi-coding-agent"
+import { describe, expect, it } from "vitest"
+import orphanToolResultSanitizerExtension, { findOrphanedToolResults } from "./orphan-tool-result-sanitizer.js"
+
+// ─── fixtures ────────────────────────────────────────────────────────────────
+
+/** Build a pi-ai assistant message with the given toolCall blocks. */
+function assistant(toolCalls: Array<{ id: string; name: string }>): Record<string, unknown> {
+	return {
+		role: "assistant",
+		content: toolCalls.map((tc) => ({ type: "toolCall", id: tc.id, name: tc.name, arguments: {} })),
+		stopReason: "toolUse",
+	}
+}
+
+/** Build a pi-ai toolResult message. */
+function toolResult(toolCallId: string, text = "ok"): Record<string, unknown> {
+	return {
+		role: "toolResult",
+		toolCallId,
+		toolName: "someTool",
+		content: [{ type: "text", text }],
+		isError: false,
+	}
+}
+
+/** Build a pi-ai user message. */
+function user(text: string): Record<string, unknown> {
+	return { role: "user", content: [{ type: "text", text }] }
+}
+
+/** Mock ExtensionAPI that captures the `before_provider_request` handler. */
+function makeMockPI() {
+	const handlers: Record<string, (event: unknown) => unknown> = {}
+	return {
+		pi: {
+			on(event: string, handler: (e: unknown) => unknown) {
+				handlers[event] = handler
+			},
+			registerCommand: () => {},
+		} as unknown as ExtensionAPI,
+		async fire(event: string, payload: unknown): Promise<unknown> {
+			return handlers[event]?.({ type: event, payload })
+		},
+	}
+}
+
+// ─── findOrphanedToolResults (pure helper) ───────────────────────────────────
+
+describe("findOrphanedToolResults", () => {
+	it("returns [] for an empty message array", () => {
+		expect(findOrphanedToolResults([])).toEqual([])
+	})
+
+	it("returns [] when every toolResult has a matching assistant toolCall", () => {
+		const messages = [
+			assistant([{ id: "call:1", name: "t" }]),
+			assistant([{ id: "call:2", name: "t" }]),
+			toolResult("call:1"),
+			toolResult("call:2"),
+		]
+		expect(findOrphanedToolResults(messages)).toEqual([])
+	})
+
+	it("returns the orphaned toolCallId when no matching assistant toolCall exists", () => {
+		const messages = [assistant([{ id: "call:1", name: "t" }]), toolResult("call:1"), toolResult("call:999")]
+		expect(findOrphanedToolResults(messages)).toEqual(["call:999"])
+	})
+
+	it("does not throw on assistant messages with non-array content", () => {
+		const messages = [{ role: "assistant", content: "string not array" }, toolResult("call:1")]
+		expect(findOrphanedToolResults(messages)).toEqual(["call:1"])
+	})
+
+	it("does not throw on malformed/non-object messages", () => {
+		const messages = [null, "garbage", 42, { role: "assistant" }, toolResult("call:1")]
+		expect(findOrphanedToolResults(messages)).toEqual(["call:1"])
+	})
+
+	it("flags every toolResult as orphaned when there are no assistant toolCalls at all", () => {
+		const messages = [user("hello"), toolResult("call:1"), toolResult("call:2")]
+		expect(findOrphanedToolResults(messages)).toEqual(["call:1", "call:2"])
+	})
+})
+
+// ─── orphanToolResultSanitizerExtension (before_provider_request handler) ─────
+
+describe("orphanToolResultSanitizerExtension", () => {
+	it("drops an orphaned toolResult whose toolCallId has no matching assistant toolCall", async () => {
+		const { pi, fire } = makeMockPI()
+		orphanToolResultSanitizerExtension(pi)
+
+		const payload = {
+			messages: [
+				assistant([{ id: "call:1", name: "t" }]),
+				toolResult("call:1", "Step done"),
+				toolResult("call:999", "I am an orphan"),
+			],
+		}
+
+		const result = (await fire("before_provider_request", payload)) as typeof payload
+		const messages = result.messages as Array<{ role: string; toolCallId?: string }>
+
+		expect(messages.some((m) => m.toolCallId === "call:999")).toBe(false)
+		expect(messages.some((m) => m.toolCallId === "call:1")).toBe(true)
+		expect(messages.some((m) => m.role === "assistant")).toBe(true)
+		expect(messages.length).toBe(2)
+	})
+
+	it("never drops a well-formed assistant toolCall -> toolResult pair", async () => {
+		const { pi, fire } = makeMockPI()
+		orphanToolResultSanitizerExtension(pi)
+
+		const payload = {
+			messages: [
+				assistant([
+					{ id: "call:1", name: "t" },
+					{ id: "call:2", name: "t" },
+				]),
+				toolResult("call:1"),
+				toolResult("call:2"),
+			],
+		}
+
+		const result = await fire("before_provider_request", payload)
+		// No orphans → handler is a no-op and returns undefined (payload unchanged).
+		expect(result).toBeUndefined()
+		const messages = payload.messages as Array<{ role: string; toolCallId?: string }>
+
+		expect(messages.length).toBe(3)
+		expect(messages.some((m) => m.toolCallId === "call:1")).toBe(true)
+		expect(messages.some((m) => m.toolCallId === "call:2")).toBe(true)
+		expect(messages.some((m) => m.role === "assistant")).toBe(true)
+	})
+
+	it("strict-provider recovery: removes an orphaned toolResult from a poisoned session before the provider call", async () => {
+		// Models session 019edacc: a compaction boundary dropped the assistant
+		// toolCall for complete_ferment:169, but the toolResult was appended
+		// after compaction and replayed on a model switch to Anthropic, which
+		// rejected the request with `unexpected tool_use_id`.
+		const { pi, fire } = makeMockPI()
+		orphanToolResultSanitizerExtension(pi)
+
+		const payload = {
+			messages: [
+				user("[compaction summary]\nEarlier work was summarized here."),
+				// orphaned toolResult — no matching assistant toolCall exists
+				{
+					role: "toolResult",
+					toolCallId: "functions.complete_ferment:169",
+					toolName: "complete_ferment",
+					content: [{ type: "text", text: "**Ferment complete.**" }],
+					isError: false,
+				},
+				user("[ferment_stage_handoff]"),
+			],
+		}
+
+		const result = (await fire("before_provider_request", payload)) as typeof payload
+		const messages = result.messages as Array<{ role: string; toolCallId?: string; content?: unknown }>
+
+		// The orphan is gone — Anthropic would no longer see an unmatched tool_use_id.
+		expect(messages.some((m) => m.toolCallId === "functions.complete_ferment:169")).toBe(false)
+		// Non-toolResult messages survive.
+		expect(messages.filter((m) => m.role === "user").length).toBe(2)
+		expect(messages.some((m) => typeof m.content === "string" || Array.isArray(m.content))).toBe(true)
+	})
+
+	it("is a no-op (returns undefined) when there are no orphans", async () => {
+		const { pi, fire } = makeMockPI()
+		orphanToolResultSanitizerExtension(pi)
+
+		const payload = {
+			messages: [assistant([{ id: "call:1", name: "t" }]), toolResult("call:1")],
+		}
+
+		const result = await fire("before_provider_request", payload)
+		// No orphans → handler returns undefined (payload unchanged).
+		expect(result).toBeUndefined()
+		expect(payload.messages.length).toBe(2)
+	})
+
+	it("is a no-op when payload has no messages array", async () => {
+		const { pi, fire } = makeMockPI()
+		orphanToolResultSanitizerExtension(pi)
+
+		const result = await fire("before_provider_request", { other: "field" })
+		expect(result).toBeUndefined()
+	})
+
+	it("is a no-op when payload is null", async () => {
+		const { pi, fire } = makeMockPI()
+		orphanToolResultSanitizerExtension(pi)
+
+		const result = await fire("before_provider_request", null)
+		expect(result).toBeUndefined()
+	})
+})

--- a/src/extensions/orphan-tool-result-sanitizer.ts
+++ b/src/extensions/orphan-tool-result-sanitizer.ts
@@ -1,0 +1,128 @@
+/**
+ * Defensive orphaned toolResult sanitizer.
+ *
+ * Guarantees that Kimchi never sends a `toolResult` message to any model
+ * provider unless the corresponding assistant `toolCall` is also present in
+ * the outgoing request's message history.
+ *
+ * Why this exists: a compaction boundary (or any history-rewriting operation)
+ * can drop an assistant toolCall whose matching toolResult is appended later.
+ * The orphaned toolResult then sits latent in the rebuilt context — a
+ * permissive provider (e.g. kimi-k2.6) continues, but switching to a stricter
+ * provider (e.g. Anthropic) fails hard because Anthropic requires every
+ * `tool_result` to correspond to a `tool_use` in the preceding assistant
+ * message. See session 019edacc (orphaned `functions.complete_ferment:169`).
+ *
+ * This is the safety-net: it is provider-agnostic, runs for every provider,
+ * and drops orphaned toolResults silently (debug log only, no user-facing
+ * notification) right before the provider call. Root-cause prevention at the
+ * compaction boundary and persisted-history repair-on-load live in later
+ * phases of the same ferment; this hook is the last line of defense.
+ *
+ * Contract: the `before_provider_request` event is emitted by pi-mono's
+ * ExtensionRunner.emitBeforeProviderRequest (core/extensions/runner.js) which
+ * threads `event.payload` through every handler and replaces it with any
+ * non-undefined return value. `payload.messages` at this stage are pi-ai
+ * `Message[]` (the output of `convertToLlm`): assistant messages carry
+ * `toolCall` content blocks with an `id`; toolResult messages carry a
+ * `toolCallId`. A toolResult is orphaned iff its `toolCallId` is not present
+ * as any assistant toolCall block `id` in the messages array.
+ */
+
+import type { ExtensionAPI, ExtensionFactory } from "@earendil-works/pi-coding-agent"
+
+/** A pi-ai toolResult message (the relevant subset). */
+interface ToolResultMessage {
+	role: "toolResult"
+	toolCallId: string
+	toolName: string
+	content: unknown[]
+	isError: boolean
+}
+
+/** Any message-shaped object the sanitizer may encounter. */
+type AnyMessage = { role?: string; content?: unknown; toolCallId?: string }
+
+/**
+ * Return the list of toolResult `toolCallId`s that have NO matching assistant
+ * `toolCall` block (by `id`) anywhere in `messages`.
+ *
+ * Pure, total, never throws: unknown shapes are skipped defensively. The empty
+ * result means the message array is well-formed (no orphans).
+ *
+ * Shared by the sanitizer (phase 1), the compaction-timing guard (phase 2),
+ * and the JSONL repair-on-load hook (phase 3) — do not duplicate this logic.
+ */
+export function findOrphanedToolResults(messages: ReadonlyArray<unknown>): string[] {
+	const callIds = new Set<string>()
+
+	for (const raw of messages) {
+		if (!raw || typeof raw !== "object") continue
+		const msg = raw as AnyMessage
+		if (msg.role !== "assistant") continue
+		const content = msg.content
+		if (!Array.isArray(content)) continue
+		for (const block of content) {
+			if (!block || typeof block !== "object") continue
+			const b = block as { type?: string; id?: unknown }
+			if (b.type === "toolCall" && typeof b.id === "string") {
+				callIds.add(b.id)
+			}
+		}
+	}
+
+	const orphaned: string[] = []
+	for (const raw of messages) {
+		if (!raw || typeof raw !== "object") continue
+		const msg = raw as AnyMessage
+		if (msg.role !== "toolResult") continue
+		if (typeof msg.toolCallId !== "string") continue
+		if (!callIds.has(msg.toolCallId)) {
+			orphaned.push(msg.toolCallId)
+		}
+	}
+
+	return orphaned
+}
+
+/**
+ * Extension factory: registers a `before_provider_request` handler that drops
+ * orphaned toolResult messages from the outgoing provider request payload.
+ *
+ * Drop-silent: emits a debug-level log line only (no user-facing `ui.notify`),
+ * per the ferment's chosen repair behavior. Provider-agnostic: runs for every
+ * provider so the invariant holds regardless of provider strictness.
+ *
+ * Registered as a direct `ExtensionFactory` (like `modelGuardExtension`), so the
+ * harness calls `orphanToolResultSanitizerExtension(pi)` directly.
+ */
+const orphanToolResultSanitizerExtension: ExtensionFactory = (pi: ExtensionAPI) => {
+	pi.on("before_provider_request", (event: unknown) => {
+		const payload = (event as Record<string, unknown> | null)?.payload as Record<string, unknown> | null
+		if (!payload || typeof payload !== "object") return
+
+		const messages = payload.messages
+		if (!Array.isArray(messages)) return
+
+		const orphanIds = findOrphanedToolResults(messages)
+		if (orphanIds.length === 0) return
+
+		const orphanSet = new Set(orphanIds)
+		const filtered = messages.filter((m: unknown) => {
+			if (!m || typeof m !== "object") return true
+			const msg = m as ToolResultMessage
+			if (msg.role !== "toolResult") return true
+			return !orphanSet.has(msg.toolCallId)
+		})
+
+		payload.messages = filtered
+		try {
+			console.debug?.(`[orphan-sanitizer] dropped ${orphanIds.length} orphaned toolResult(s): ${orphanIds.join(", ")}`)
+		} catch {
+			// console.debug may be undefined in some environments — never throw.
+		}
+		return payload
+	})
+}
+
+export default orphanToolResultSanitizerExtension

--- a/src/extensions/session-repair/orphan-tool-result-repair.test.ts
+++ b/src/extensions/session-repair/orphan-tool-result-repair.test.ts
@@ -1,0 +1,227 @@
+import * as fs from "node:fs"
+import * as os from "node:os"
+import * as path from "node:path"
+import type { ExtensionAPI } from "@earendil-works/pi-coding-agent"
+import { afterEach, beforeEach, describe, expect, it } from "vitest"
+import orphanToolResultRepairExtension, { rewriteSessionJsonl } from "./orphan-tool-result-repair.js"
+
+// ─── fixtures ────────────────────────────────────────────────────────────────
+
+/** Build a pi-ai assistant message with the given toolCall blocks. */
+function assistant(toolCalls: Array<{ id: string; name: string }>): Record<string, unknown> {
+	return {
+		role: "assistant",
+		content: toolCalls.map((tc) => ({ type: "toolCall", id: tc.id, name: tc.name, arguments: {} })),
+		stopReason: "toolUse",
+	}
+}
+
+/** Build a pi-ai toolResult message. */
+function toolResult(toolCallId: string, text = "ok"): Record<string, unknown> {
+	return {
+		role: "toolResult",
+		toolCallId,
+		toolName: "someTool",
+		content: [{ type: "text", text }],
+		isError: false,
+	}
+}
+
+/** Wrap a message in a session JSONL message entry. */
+function messageEntry(message: Record<string, unknown>): Record<string, unknown> {
+	return { type: "message", id: `entry-${Math.random().toString(36).slice(2)}`, message }
+}
+
+/** A non-message session entry (e.g. compaction). */
+function compactionEntry(summary = "summarized"): Record<string, unknown> {
+	return { type: "compaction", id: "c1", summary }
+}
+
+/** A custom session entry. */
+function customEntry(): Record<string, unknown> {
+	return { type: "custom", id: "x1", data: { note: "kept" } }
+}
+
+/** Mock ExtensionAPI that captures event handlers. */
+function makeMockPI() {
+	const handlers: Record<string, (...args: unknown[]) => unknown> = {}
+	return {
+		pi: {
+			on(event: string, handler: (...args: unknown[]) => unknown) {
+				handlers[event] = handler
+			},
+			registerCommand: () => {},
+		} as unknown as ExtensionAPI,
+		async fire(event: string, ...args: unknown[]): Promise<unknown> {
+			return handlers[event]?.(...args)
+		},
+	}
+}
+
+/** Build a mock ctx whose sessionManager.getSessionFile() returns `filePath`. */
+function makeCtx(filePath: string | undefined): { sessionManager: { getSessionFile(): string | undefined } } {
+	return {
+		sessionManager: {
+			getSessionFile: () => filePath,
+		},
+	}
+}
+
+// ─── temp-dir helpers ────────────────────────────────────────────────────────
+
+let tmpDir: string
+
+beforeEach(() => {
+	tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "repair-test-"))
+})
+
+afterEach(() => {
+	fs.rmSync(tmpDir, { recursive: true, force: true })
+})
+
+function writeSession(fileName: string, lines: string[]): string {
+	const file = path.join(tmpDir, fileName)
+	fs.writeFileSync(file, lines.join("\n"), "utf8")
+	return file
+}
+
+// ─── rewriteSessionJsonl (pure helper) ──────────────────────────────────────
+
+describe("rewriteSessionJsonl", () => {
+	it("drops an orphaned toolResult line and keeps all other lines", () => {
+		const lines = [
+			JSON.stringify(messageEntry(assistant([{ id: "call:1", name: "t" }]))),
+			JSON.stringify(messageEntry(toolResult("call:1", "matched"))),
+			JSON.stringify(messageEntry(toolResult("call:orphan", "no matching toolCall"))),
+			JSON.stringify(compactionEntry()),
+			JSON.stringify(customEntry()),
+		]
+
+		const { rewritten, dropped } = rewriteSessionJsonl(lines)
+
+		expect(dropped).toBe(1)
+		expect(rewritten.length).toBe(4)
+		// The orphaned toolResult is gone.
+		expect(rewritten.some((l) => l.includes("call:orphan"))).toBe(false)
+		// The matched pair survives.
+		expect(rewritten.some((l) => l.includes("call:1"))).toBe(true)
+		// Non-message entries are kept verbatim.
+		expect(rewritten.some((l) => l.includes('"type":"compaction"'))).toBe(true)
+		expect(rewritten.some((l) => l.includes('"type":"custom"'))).toBe(true)
+	})
+
+	it("is idempotent: a well-formed session is left byte-equivalent (dropped=0)", () => {
+		const lines = [
+			JSON.stringify(messageEntry(assistant([{ id: "call:1", name: "t" }]))),
+			JSON.stringify(messageEntry(toolResult("call:1", "matched"))),
+			JSON.stringify(compactionEntry()),
+		]
+
+		const { rewritten, dropped } = rewriteSessionJsonl(lines)
+
+		expect(dropped).toBe(0)
+		// Byte-equivalent: same lines in the same order.
+		expect(rewritten).toEqual(lines)
+	})
+
+	it("is idempotent: re-running on already-repaired output drops nothing", () => {
+		const poisoned = [
+			JSON.stringify(messageEntry(assistant([{ id: "call:1", name: "t" }]))),
+			JSON.stringify(messageEntry(toolResult("call:1"))),
+			JSON.stringify(messageEntry(toolResult("call:orphan"))),
+		]
+		const first = rewriteSessionJsonl(poisoned)
+		expect(first.dropped).toBe(1)
+
+		const second = rewriteSessionJsonl(first.rewritten)
+		expect(second.dropped).toBe(0)
+		expect(second.rewritten).toEqual(first.rewritten)
+	})
+
+	it("keeps malformed (unparseable) lines as-is", () => {
+		const lines = [
+			JSON.stringify(messageEntry(assistant([{ id: "call:1", name: "t" }]))),
+			"this is not valid json {{{",
+			JSON.stringify(messageEntry(toolResult("call:1"))),
+		]
+
+		const { rewritten, dropped } = rewriteSessionJsonl(lines)
+
+		expect(dropped).toBe(0)
+		expect(rewritten).toEqual(lines)
+	})
+})
+
+// ─── orphanToolResultRepairExtension (session_start handler) ─────────────────
+
+describe("orphanToolResultRepairExtension", () => {
+	it("rewrites a poisoned fixture: orphan gone from disk and .bak matches original", async () => {
+		const { pi, fire } = makeMockPI()
+		orphanToolResultRepairExtension(pi)
+
+		const originalLines = [
+			JSON.stringify(messageEntry(assistant([{ id: "call:1", name: "t" }]))),
+			JSON.stringify(messageEntry(toolResult("call:1", "matched"))),
+			JSON.stringify(messageEntry(toolResult("call:orphan", "no matching toolCall"))),
+			JSON.stringify(compactionEntry()),
+		]
+		const file = writeSession("session.jsonl", originalLines)
+		const originalBytes = fs.readFileSync(file, "utf8")
+
+		await fire("session_start", { type: "session_start", reason: "resume" }, makeCtx(file))
+
+		// The orphan is gone from the rewritten file.
+		const rewritten = fs.readFileSync(file, "utf8")
+		expect(rewritten.includes("call:orphan")).toBe(false)
+		expect(rewritten.includes("call:1")).toBe(true)
+
+		// A .bak backup exists and matches the original bytes exactly.
+		const backup = `${file}.bak`
+		expect(fs.existsSync(backup)).toBe(true)
+		expect(fs.readFileSync(backup, "utf8")).toBe(originalBytes)
+	})
+
+	it("leaves a clean session unchanged and writes no .bak (no rewrite needed)", async () => {
+		const { pi, fire } = makeMockPI()
+		orphanToolResultRepairExtension(pi)
+
+		const cleanLines = [
+			JSON.stringify(messageEntry(assistant([{ id: "call:1", name: "t" }]))),
+			JSON.stringify(messageEntry(toolResult("call:1", "matched"))),
+			JSON.stringify(compactionEntry()),
+		]
+		const file = writeSession("clean.jsonl", cleanLines)
+		const originalBytes = fs.readFileSync(file, "utf8")
+
+		await fire("session_start", { type: "session_start", reason: "resume" }, makeCtx(file))
+
+		// File is byte-equivalent to the original — no rewrite occurred.
+		expect(fs.readFileSync(file, "utf8")).toBe(originalBytes)
+		// No .bak is written when there is nothing to repair.
+		expect(fs.existsSync(`${file}.bak`)).toBe(false)
+	})
+
+	it("never throws when the session file is missing", async () => {
+		const { pi, fire } = makeMockPI()
+		orphanToolResultRepairExtension(pi)
+
+		const missingFile = path.join(tmpDir, "does-not-exist.jsonl")
+
+		// Should resolve without throwing; nothing is written.
+		await expect(
+			fire("session_start", { type: "session_start", reason: "resume" }, makeCtx(missingFile)),
+		).resolves.toBeUndefined()
+
+		expect(fs.existsSync(missingFile)).toBe(false)
+		expect(fs.existsSync(`${missingFile}.bak`)).toBe(false)
+	})
+
+	it("never throws when getSessionFile() returns undefined (new session)", async () => {
+		const { pi, fire } = makeMockPI()
+		orphanToolResultRepairExtension(pi)
+
+		await expect(
+			fire("session_start", { type: "session_start", reason: "new" }, makeCtx(undefined)),
+		).resolves.toBeUndefined()
+	})
+})

--- a/src/extensions/session-repair/orphan-tool-result-repair.ts
+++ b/src/extensions/session-repair/orphan-tool-result-repair.ts
@@ -141,8 +141,10 @@ const orphanToolResultRepairExtension: ExtensionFactory = (pi: ExtensionAPI) => 
 				return
 			}
 
-			// Split into lines, preserving the original line-ending semantics by
-			// operating on a split that keeps the trailing newline out of each line.
+			// Split into lines. If the file ends with a trailing newline, split
+			// produces a trailing "" element which rewriteSessionJsonl keeps as a
+			// malformed line — so join("\n") preserves the trailing newline.
+			// \r\n line endings are preserved because \r stays attached to each line.
 			const lines = originalText.split("\n")
 
 			const { rewritten, dropped } = rewriteSessionJsonl(lines)
@@ -159,6 +161,8 @@ const orphanToolResultRepairExtension: ExtensionFactory = (pi: ExtensionAPI) => 
 			}
 
 			// Atomically rewrite: write to a temp file then rename over the original.
+			// join("\n") reconstructs the original line-ending style because split
+			// preserved \r on each line and the trailing "" element.
 			const tmpPath = `${sessionFile}.repair-tmp`
 			fs.writeFileSync(tmpPath, rewritten.join("\n"), "utf8")
 			fs.renameSync(tmpPath, sessionFile)

--- a/src/extensions/session-repair/orphan-tool-result-repair.ts
+++ b/src/extensions/session-repair/orphan-tool-result-repair.ts
@@ -1,0 +1,179 @@
+/**
+ * Repair-on-load: rewrite persisted session JSONL to drop orphaned toolResults.
+ *
+ * On `session_start` (resume / fork / reload / startup — any load), read the
+ * session `.jsonl` file, detect toolResult messages whose matching assistant
+ * toolCall is absent anywhere in the file, and rewrite the file in place with
+ * those lines removed. A `.bak` backup of the original bytes is written first.
+ *
+ * Why this exists: a compaction boundary (or any history-rewriting operation)
+ * can drop an assistant toolCall whose matching toolResult is appended later.
+ * The orphaned toolResult then sits latent in the persisted JSONL — a permissive
+ * provider continues, but resuming into a strict provider (Anthropic) fails hard
+ * (`unexpected tool_use_id`). Phase 1 sanitizes outgoing requests defensively;
+ * phase 2 prevents new orphans at the compaction boundary. This phase 3 hook
+ * repairs ALREADY-poisoned persisted history so a previously-broken session
+ * recovers without manual JSONL editing.
+ *
+ * Safety contract (must never throw, must never corrupt):
+ *  - All fs access is wrapped in try/catch; on ANY failure the original file is
+ *    left untouched and the error is swallowed (debug log only).
+ *  - A `.bak` backup of the original bytes is written before any rewrite.
+ *  - The rewrite is idempotent: re-running on a clean file drops nothing and
+ *    produces byte-equivalent output.
+ *  - Malformed JSONL lines are kept as-is (never dropped, never rewritten).
+ *  - Non-message entries (compaction, model-change, custom, etc.) are always kept.
+ */
+
+import type { ExtensionAPI, ExtensionFactory } from "@earendil-works/pi-coding-agent"
+import { findOrphanedToolResults } from "../orphan-tool-result-sanitizer.js"
+
+/** A function that detects orphaned toolCallIds in a message array. */
+export type OrphanDetector = (messages: ReadonlyArray<unknown>) => string[]
+
+/** Shape of a parsed session JSONL message entry (the relevant subset). */
+interface ParsedMessageEntry {
+	type: "message"
+	message: { role?: string; toolCallId?: string; content?: unknown }
+}
+
+/** Shape of any parsed session JSONL line. */
+interface ParsedLine {
+	type?: string
+	message?: unknown
+}
+
+/**
+ * Pure, idempotent rewriter: given the raw JSONL lines of a session file and an
+ * orphan detector (defaults to `findOrphanedToolResults` from phase 1), return
+ * the filtered lines with orphaned toolResult entries removed.
+ *
+ * Algorithm (two-pass):
+ *  1. Parse every line. Collect the `message` of every `type: "message"` entry
+ *     into a flat array — this is the message set the detector runs against.
+ *  2. Call `orphanDetector(messages)` → set of orphaned toolCallIds.
+ *  3. Re-walk lines: drop a line iff it is a `type: "message"` entry whose
+ *     `message.role === "toolResult"` AND `message.toolCallId` is in the orphan
+ *     set. All other lines (assistant, user, compaction, custom, malformed) are
+ *     kept verbatim.
+ *
+ * Never throws: malformed lines (JSON parse failure) are kept as-is. Returns
+ * `{ rewritten, dropped }` where `rewritten` is the new line array and `dropped`
+ * is the count of removed lines.
+ */
+export function rewriteSessionJsonl(
+	jsonlLines: ReadonlyArray<string>,
+	orphanDetector: OrphanDetector = findOrphanedToolResults,
+): { rewritten: string[]; dropped: number } {
+	// Pass 1: parse every line, collect messages from message entries.
+	const parsed: { raw: string; value: ParsedLine | null }[] = []
+	const messages: unknown[] = []
+
+	for (const raw of jsonlLines) {
+		if (typeof raw !== "string" || raw.length === 0) {
+			parsed.push({ raw, value: null })
+			continue
+		}
+		let value: ParsedLine | null = null
+		try {
+			value = JSON.parse(raw) as ParsedLine
+		} catch {
+			value = null
+		}
+		parsed.push({ raw, value })
+		if (value && value.type === "message" && value.message && typeof value.message === "object") {
+			messages.push(value.message)
+		}
+	}
+
+	const orphanIds = orphanDetector(messages)
+	if (orphanIds.length === 0) {
+		// Fast path: no orphans — return the original lines unchanged (byte-equivalent).
+		return { rewritten: [...jsonlLines], dropped: 0 }
+	}
+
+	const orphanSet = new Set(orphanIds)
+	const rewritten: string[] = []
+	let dropped = 0
+
+	for (const { raw, value } of parsed) {
+		// Malformed or non-message lines are always kept.
+		if (!value || value.type !== "message") {
+			rewritten.push(raw)
+			continue
+		}
+		const msg = value.message as { role?: string; toolCallId?: unknown }
+		// Drop only orphaned toolResult entries.
+		if (msg && msg.role === "toolResult" && typeof msg.toolCallId === "string" && orphanSet.has(msg.toolCallId)) {
+			dropped++
+			continue
+		}
+		rewritten.push(raw)
+	}
+
+	return { rewritten, dropped }
+}
+
+/**
+ * Extension factory: registers a `session_start` handler that repairs the
+ * persisted session JSONL in place on any load (resume / fork / reload /
+ * startup — a fresh `new` session has no file yet, so the handler is a no-op).
+ *
+ * Drop-silent: emits a debug-level log line only. Never throws — on any fs
+ * error the original file is left untouched.
+ */
+const orphanToolResultRepairExtension: ExtensionFactory = (pi: ExtensionAPI) => {
+	pi.on("session_start", async (_event: unknown, ctx: unknown) => {
+		try {
+			const sessionFile: string | undefined = (
+				ctx as { sessionManager?: { getSessionFile?: () => string | undefined } }
+			)?.sessionManager?.getSessionFile?.()
+			if (!sessionFile) return
+
+			const fs = await import("node:fs")
+			const path = await import("node:path")
+
+			let originalText: string
+			try {
+				originalText = fs.readFileSync(sessionFile, "utf8")
+			} catch {
+				// File may not exist yet (new session) — nothing to repair.
+				return
+			}
+
+			// Split into lines, preserving the original line-ending semantics by
+			// operating on a split that keeps the trailing newline out of each line.
+			const lines = originalText.split("\n")
+
+			const { rewritten, dropped } = rewriteSessionJsonl(lines)
+			if (dropped === 0) return
+
+			// Write a .bak backup of the ORIGINAL bytes before any rewrite.
+			const backupPath = `${sessionFile}.bak`
+			try {
+				fs.copyFileSync(sessionFile, backupPath)
+			} catch {
+				// If we can't write the backup, do NOT rewrite — leave the original
+				// untouched. Phase 1's outgoing sanitizer remains the hard guarantee.
+				return
+			}
+
+			// Atomically rewrite: write to a temp file then rename over the original.
+			const tmpPath = `${sessionFile}.repair-tmp`
+			fs.writeFileSync(tmpPath, rewritten.join("\n"), "utf8")
+			fs.renameSync(tmpPath, sessionFile)
+
+			try {
+				console.debug?.(
+					`[session-repair] dropped ${dropped} orphaned toolResult(s) from ${path.basename(sessionFile)} (backup: ${path.basename(backupPath)})`,
+				)
+			} catch {
+				// console.debug may be undefined — never throw.
+			}
+		} catch {
+			// Last-resort: swallow everything. Never throw from a session_start hook.
+		}
+	})
+}
+
+export default orphanToolResultRepairExtension


### PR DESCRIPTION
## Summary

Three-phase defense against `toolResult` messages whose matching assistant `toolCall` is absent — a condition that causes strict providers like Anthropic to reject requests with `unexpected tool_use_id`.

### Phase 1 — Defensive sanitizer
`src/extensions/orphan-tool-result-sanitizer.ts` registers a `before_provider_request` handler that strips any `toolResult` whose `toolCallId` has no matching assistant `toolCall` from the outgoing payload.

### Phase 2 — Compaction-timing root-cause guard
`src/extensions/ferment/auto-compaction.ts` adds `isToolCallInFlight` / `isToolCallInFlightInSession` helpers and wires early-return guards into all three compaction entry points, deferring auto-compaction while a tool call is in flight — preventing orphans from being created at the compaction boundary.

### Phase 3 — Repair-on-load via JSONL rewrite
`src/extensions/session-repair/orphan-tool-result-repair.ts` registers a `session_start` handler that reads the persisted `.jsonl`, drops orphaned `toolResult` lines, writes a `.bak` backup, and atomically rewrites the file — so already-poisoned sessions recover on resume without manual editing. Never throws.

All extensions wired in `src/cli.ts` alongside existing model guard and sanitizer extensions.

## Test plan
- [x] `pnpm run typecheck` — clean
- [x] `pnpm run lint` — clean
- [x] `pnpm run test` — 6052 passed, 3 skipped
- [x] 3 new sanitizer unit tests (orphan removal, well-formed pair preservation, strict-provider recovery)
- [x] 7 new compaction guard tests (in-flight detection, compaction deferral, fail-open on access errors)
- [x] 8 new repair tests (orphan dropping, idempotency, poisoned fixture repair + .bak backup, clean session safety, never-throws on missing/undefined file)

## Type of change
- [x] New feature
- [ ] Bug fix
- [ ] Breaking change
- [ ] Documentation update