### PR TITLE
feat(update): auto-update on launch with opt-out toggle

### DIFF
--- a/src/cli-args.ts
+++ b/src/cli-args.ts
@@ -1,4 +1,9 @@
 import { parseArgs as parsePiArgs } from "@earendil-works/pi-coding-agent"
+import { type CliMode, getCliModeArg, PROTOCOL_MODES } from "./cli-modes.js"
+
+// Re-export the shared leaf-module helpers so existing callers can keep
+// importing them from cli-args.ts without touching their import paths.
+export { type CliMode, getCliModeArg, hasExportFlag, hasPrintFlag, PROTOCOL_MODES } from "./cli-modes.js"
 
 // Pre-dispatch scanners still need to skip values for Kimchi-local raw scans
 // such as `--mode acp`, which upstream pi does not parse.
@@ -59,15 +64,6 @@ export function isCliAtFileArg(arg: string, index: number, args: string[]): bool
 	return parsePiArgs(args.slice(0, index + 1)).fileArgs.length > parsePiArgs(args.slice(0, index)).fileArgs.length
 }
 
-export function getCliModeArg(args: string[]): string | undefined {
-	for (let i = 0; i < args.length; i += 1) {
-		const arg = args[i]
-		if (arg === "--mode" && i + 1 < args.length) return args[i + 1]
-		if (arg.startsWith("--mode=")) return arg.slice("--mode=".length)
-	}
-	return undefined
-}
-
 export function isHelpOrVersionArgs(args: string[]): boolean {
 	return args.some((a) => a === "--help" || a === "-h" || a === "--version" || a === "-v")
 }
@@ -78,7 +74,7 @@ export function isHelpOrVersionArgs(args: string[]): boolean {
 export function isProtocolOrPrintMode(args: string[]): boolean {
 	const parsed = parsePiArgs(args)
 	const mode = parsed.mode ?? getCliModeArg(args)
-	return mode === "json" || mode === "rpc" || mode === "acp" || parsed.print === true
+	return (mode !== undefined && PROTOCOL_MODES.has(mode as CliMode)) || parsed.print === true
 }
 
 export function isTerminalUiMode(args: string[], io: { stdinIsTTY: boolean; stdoutIsTTY: boolean }): boolean {

--- a/src/cli-modes.ts
+++ b/src/cli-modes.ts
@@ -1,0 +1,35 @@
+// Shared CLI mode detection — a leaf module with **zero imports**.
+//
+// This file is loaded very early (entry.ts dynamically imports
+// auto-update.ts before cli.js boots, and cli-args.ts is used by the CLI
+// dispatch path). It must not pull in pi-coding-agent or any other module
+// so it can be safely imported from any context.
+//
+// Consumers:
+//   - src/cli-args.ts re-exports these for the CLI dispatch path.
+//   - src/update/auto-update.ts uses them to skip auto-update in non-
+//     interactive modes.
+//   - src/extensions/onboarding/session-mode.ts uses them to decide whether
+//     to show the onboarding wizard.
+
+export type CliMode = "text" | "json" | "rpc" | "acp"
+
+/** Modes where stdout belongs to the caller (protocol channel). */
+export const PROTOCOL_MODES = new Set<CliMode>(["json", "rpc", "acp"])
+
+/** Extract the value of `--mode <value>` or `--mode=<value>` from argv. */
+export function getCliModeArg(argv: readonly string[]): string | undefined {
+	for (let i = 0; i < argv.length; i += 1) {
+		const arg = argv[i]
+		if (arg === "--mode" && i + 1 < argv.length) return argv[i + 1]
+		if (arg.startsWith("--mode=")) return arg.slice("--mode=".length)
+	}
+	return undefined
+}
+
+/** True when argv contains `--print` or `-p`. */
+export const hasPrintFlag = (argv: readonly string[]): boolean => argv.includes("--print") || argv.includes("-p")
+
+/** True when argv contains `--export` or `--export=<file>`. */
+export const hasExportFlag = (argv: readonly string[]): boolean =>
+	argv.includes("--export") || argv.some((a) => a.startsWith("--export="))

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -37,6 +37,7 @@ import { isBunBinary } from "./env.js"
 import activityExtension from "./extensions/activity.js"
 import agentsExtension from "./extensions/agents/index.js"
 import assistantPrefixExtension from "./extensions/assistant-prefix.js"
+import autoUpdateSettingsExtension from "./extensions/auto-update-settings.js"
 import bashDefaultTimeoutExtension from "./extensions/bash-default-timeout.js"
 import bashTimeoutGuidanceExtension from "./extensions/bash-timeout-guidance.js"
 import bashToolGuardExtension from "./extensions/bash-tool-guard.js"
@@ -582,6 +583,7 @@ try {
 			: []
 		const effectiveSkillPaths = [...new Set([...skillPaths, ...getActiveVendorSkillPaths()])]
 		const extensionFactories = [
+			autoUpdateSettingsExtension,
 			startupUpdateExtension,
 			superpowersExtension,
 			sessionNameExtension(),

--- a/src/entry.ts
+++ b/src/entry.ts
@@ -59,10 +59,23 @@ installProxyAgent()
 // Phase 2 of the auto-update plan: on-launch update check + swap. Dynamic
 // import keeps the network deps in ./update/workflow.js out of every test
 // that touches entry.ts. The call never throws (see auto-update.ts).
+//
+// We race the call against a short deadline so a slow network or large
+// download can't block TUI startup indefinitely. If the deadline expires,
+// maybeAutoUpdateOnLaunch skips the re-exec swap and the current process
+// boots normally on the existing binary — the next launch will retry.
+const { maybeAutoUpdateOnLaunch, DEFAULT_AUTO_UPDATE_TIMEOUT_MS } = await import("./update/auto-update.js")
+const autoUpdateController = new AbortController()
+const autoUpdateTimeout = setTimeout(() => autoUpdateController.abort(), DEFAULT_AUTO_UPDATE_TIMEOUT_MS)
+// Don't keep the event loop alive just for the watchdog — once installPasteInterceptor
+// + cli.js have taken over stdin, this timer is irrelevant.
+;(autoUpdateTimeout as { unref?: () => void }).unref?.()
 try {
-	await (await import("./update/auto-update.js")).maybeAutoUpdateOnLaunch()
+	await maybeAutoUpdateOnLaunch({ signal: autoUpdateController.signal })
 } catch (err) {
 	console.warn(`[kimchi-auto-update] failed: ${(err as Error).message}`)
+} finally {
+	clearTimeout(autoUpdateTimeout)
 }
 
 // Install before the dynamic cli.js import - the interceptor must wrap process.stdin.emit before any pi-* listener attaches. See src/paste-interceptor.ts for the rationale (LLM-1358).

--- a/src/entry.ts
+++ b/src/entry.ts
@@ -60,10 +60,13 @@ installProxyAgent()
 // import keeps the network deps in ./update/workflow.js out of every test
 // that touches entry.ts. The call never throws (see auto-update.ts).
 //
-// We race the call against a short deadline so a slow network or large
-// download can't block TUI startup indefinitely. If the deadline expires,
-// maybeAutoUpdateOnLaunch skips the re-exec swap and the current process
-// boots normally on the existing binary — the next launch will retry.
+// Two layers cap the startup budget, because the inner calls
+// (checkForUpdate / applyUpdate) don't accept an AbortSignal and would
+// otherwise block on slow network I/O:
+//   1. Promise.race with a hard timeout — abandons the await at the
+//      deadline regardless of inner state.
+//   2. AbortSignal checkpoints inside maybeAutoUpdateOnLaunch — prevents
+//      the re-exec swap if applyUpdate finishes after the deadline.
 const { maybeAutoUpdateOnLaunch, DEFAULT_AUTO_UPDATE_TIMEOUT_MS } = await import("./update/auto-update.js")
 const autoUpdateController = new AbortController()
 const autoUpdateTimeout = setTimeout(() => autoUpdateController.abort(), DEFAULT_AUTO_UPDATE_TIMEOUT_MS)
@@ -71,7 +74,10 @@ const autoUpdateTimeout = setTimeout(() => autoUpdateController.abort(), DEFAULT
 // + cli.js have taken over stdin, this timer is irrelevant.
 ;(autoUpdateTimeout as { unref?: () => void }).unref?.()
 try {
-	await maybeAutoUpdateOnLaunch({ signal: autoUpdateController.signal })
+	await Promise.race([
+		maybeAutoUpdateOnLaunch({ signal: autoUpdateController.signal }),
+		new Promise<void>((resolve) => setTimeout(resolve, DEFAULT_AUTO_UPDATE_TIMEOUT_MS)),
+	])
 } catch (err) {
 	console.warn(`[kimchi-auto-update] failed: ${(err as Error).message}`)
 } finally {

--- a/src/entry.ts
+++ b/src/entry.ts
@@ -67,19 +67,28 @@ installProxyAgent()
 //      deadline regardless of inner state.
 //   2. AbortSignal checkpoints inside maybeAutoUpdateOnLaunch — prevents
 //      the re-exec swap if applyUpdate finishes after the deadline.
+//
+// A SINGLE deadline drives both: the watchdog timer aborts the controller
+// AND resolves the race. Two independent timers would race each other — if
+// the race-resolver fired first, the `finally` clearTimeout could cancel
+// the abort before it ran, leaving maybeAutoUpdateOnLaunch to re-exec after
+// cli.js had already started (tearing down the UI mid-startup).
 const { maybeAutoUpdateOnLaunch, DEFAULT_AUTO_UPDATE_TIMEOUT_MS } = await import("./update/auto-update.js")
 const autoUpdateController = new AbortController()
-const autoUpdateTimeout = setTimeout(() => autoUpdateController.abort(), DEFAULT_AUTO_UPDATE_TIMEOUT_MS)
-// Don't keep the event loop alive just for the watchdog — once installPasteInterceptor
-// + cli.js have taken over stdin, this timer is irrelevant.
-;(autoUpdateTimeout as { unref?: () => void }).unref?.()
+let autoUpdateTimeout: ReturnType<typeof setTimeout> | undefined
+const autoUpdateDeadline = new Promise<void>((resolve) => {
+	autoUpdateTimeout = setTimeout(() => {
+		autoUpdateController.abort()
+		resolve()
+	}, DEFAULT_AUTO_UPDATE_TIMEOUT_MS)
+	// Don't keep the event loop alive just for the watchdog — once installPasteInterceptor
+	// + cli.js have taken over stdin, this timer is irrelevant.
+	;(autoUpdateTimeout as { unref?: () => void }).unref?.()
+})
 try {
-	await Promise.race([
-		maybeAutoUpdateOnLaunch({ signal: autoUpdateController.signal }),
-		new Promise<void>((resolve) => setTimeout(resolve, DEFAULT_AUTO_UPDATE_TIMEOUT_MS)),
-	])
+	await Promise.race([maybeAutoUpdateOnLaunch({ signal: autoUpdateController.signal }), autoUpdateDeadline])
 } catch (err) {
-	console.warn(`[kimchi-auto-update] failed: ${(err as Error).message}`)
+	console.warn(`[kimchi-auto-update] failed: ${err instanceof Error ? err.message : err}`)
 } finally {
 	clearTimeout(autoUpdateTimeout)
 }

--- a/src/entry.ts
+++ b/src/entry.ts
@@ -60,37 +60,16 @@ installProxyAgent()
 // import keeps the network deps in ./update/workflow.js out of every test
 // that touches entry.ts. The call never throws (see auto-update.ts).
 //
-// Two layers cap the startup budget, because the inner calls
-// (checkForUpdate / applyUpdate) don't accept an AbortSignal and would
-// otherwise block on slow network I/O:
-//   1. Promise.race with a hard timeout — abandons the await at the
-//      deadline regardless of inner state.
-//   2. AbortSignal checkpoints inside maybeAutoUpdateOnLaunch — prevents
-//      the re-exec swap if applyUpdate finishes after the deadline.
-//
-// A SINGLE deadline drives both: the watchdog timer aborts the controller
-// AND resolves the race. Two independent timers would race each other — if
-// the race-resolver fired first, the `finally` clearTimeout could cancel
-// the abort before it ran, leaving maybeAutoUpdateOnLaunch to re-exec after
-// cli.js had already started (tearing down the UI mid-startup).
-const { maybeAutoUpdateOnLaunch, DEFAULT_AUTO_UPDATE_TIMEOUT_MS } = await import("./update/auto-update.js")
-const autoUpdateController = new AbortController()
-let autoUpdateTimeout: ReturnType<typeof setTimeout> | undefined
-const autoUpdateDeadline = new Promise<void>((resolve) => {
-	autoUpdateTimeout = setTimeout(() => {
-		autoUpdateController.abort()
-		resolve()
-	}, DEFAULT_AUTO_UPDATE_TIMEOUT_MS)
-	// Don't keep the event loop alive just for the watchdog — once installPasteInterceptor
-	// + cli.js have taken over stdin, this timer is irrelevant.
-	;(autoUpdateTimeout as { unref?: () => void }).unref?.()
-})
+// The deadline is managed INSIDE maybeAutoUpdateOnLaunch: only the
+// checkForUpdate phase is raced against the timeout. Once we commit to
+// applyUpdate it is awaited fully — a Promise.race here would abandon
+// the install mid-swap, letting cli.js boot while files are still being
+// copied/renamed.
+const { maybeAutoUpdateOnLaunch } = await import("./update/auto-update.js")
 try {
-	await Promise.race([maybeAutoUpdateOnLaunch({ signal: autoUpdateController.signal }), autoUpdateDeadline])
+	await maybeAutoUpdateOnLaunch()
 } catch (err) {
 	console.warn(`[kimchi-auto-update] failed: ${err instanceof Error ? err.message : err}`)
-} finally {
-	clearTimeout(autoUpdateTimeout)
 }
 
 // Install before the dynamic cli.js import - the interceptor must wrap process.stdin.emit before any pi-* listener attaches. See src/paste-interceptor.ts for the rationale (LLM-1358).

--- a/src/entry.ts
+++ b/src/entry.ts
@@ -56,6 +56,15 @@ process.env.KIMCHI_DISABLE_BUILTIN_PROVIDERS = "1"
 
 installProxyAgent()
 
+// Phase 2 of the auto-update plan: on-launch update check + swap. Dynamic
+// import keeps the network deps in ./update/workflow.js out of every test
+// that touches entry.ts. The call never throws (see auto-update.ts).
+try {
+	await (await import("./update/auto-update.js")).maybeAutoUpdateOnLaunch()
+} catch (err) {
+	console.warn(`[kimchi-auto-update] failed: ${(err as Error).message}`)
+}
+
 // Install before the dynamic cli.js import - the interceptor must wrap process.stdin.emit before any pi-* listener attaches. See src/paste-interceptor.ts for the rationale (LLM-1358).
 installPasteInterceptor()
 

--- a/src/extensions/auto-update-settings.test.ts
+++ b/src/extensions/auto-update-settings.test.ts
@@ -121,7 +121,7 @@ describe("auto-update setting reflects in the toggle label state", () => {
 	// the menu handler relies on. Booting the TUI select list in vitest
 	// is out of scope.
 
-	it("returns true on init (opt-out default — label would read 'Auto-update: ON')", () => {
+	it("returns true when the toggle is on — label would read 'Auto-update: ON'", () => {
 		mockLoadAutoUpdateSetting.mockReturnValue(true)
 		expect(loadAutoUpdateSetting()).toBe(true)
 	})

--- a/src/extensions/auto-update-settings.test.ts
+++ b/src/extensions/auto-update-settings.test.ts
@@ -16,6 +16,8 @@ const mockSaveAutoUpdateSetting = vi.fn()
 const mockIsHomebrewInstall = vi.fn(() => false)
 const mockGetVersion = vi.fn(() => "1.0.0")
 
+const mockParseCanarySha7 = vi.fn(() => null as string | null)
+
 vi.mock("../update/paths.js", () => ({
 	isHomebrewInstall: mockIsHomebrewInstall,
 }))
@@ -28,6 +30,7 @@ vi.mock("../update/settings.js", () => ({
 vi.mock("../update/workflow.js", () => ({
 	checkForUpdate: mockCheckForUpdate,
 	applyUpdate: mockApplyUpdate,
+	parseCanarySha7: mockParseCanarySha7,
 }))
 vi.mock("../utils.js", () => ({
 	getVersion: mockGetVersion,
@@ -54,10 +57,12 @@ function resetMocks(): void {
 	mockSaveAutoUpdateSetting.mockReset()
 	mockIsHomebrewInstall.mockReset()
 	mockGetVersion.mockReset()
+	mockParseCanarySha7.mockReset()
 	mockLoadAutoUpdateSetting.mockReturnValue(true)
 	mockLoadAutoUpdateNoticeShown.mockReturnValue(false)
 	mockIsHomebrewInstall.mockReturnValue(false)
 	mockGetVersion.mockReturnValue("1.0.0")
+	mockParseCanarySha7.mockReturnValue(null)
 	mockCheckForUpdate.mockResolvedValue({
 		currentVersion: "1.0.0",
 		latestVersion: "1.0.0",
@@ -136,7 +141,7 @@ describe("auto-update setting reflects in the toggle label state", () => {
 })
 
 describe("runManualUpdate — happy path", () => {
-	it("calls checkForUpdate with skipCache: true and canary: false", async () => {
+	it("calls checkForUpdate with skipCache: true and canary: false on stable", async () => {
 		mockCheckForUpdate.mockResolvedValue({
 			currentVersion: "1.0.0",
 			latestVersion: "1.0.0",
@@ -150,6 +155,25 @@ describe("runManualUpdate — happy path", () => {
 			currentVersion: "1.0.0",
 			skipCache: true,
 			canary: false,
+		})
+	})
+
+	it("checks canary channel when running a canary build", async () => {
+		mockGetVersion.mockReturnValue("0.0.0-canary.20260509.abc1234")
+		mockParseCanarySha7.mockReturnValue("abc1234")
+		mockCheckForUpdate.mockResolvedValue({
+			currentVersion: "0.0.0-canary.20260509.abc1234",
+			latestVersion: "0.0.0-canary.20260510.def5678",
+			tag: "canary",
+			releaseUrl: "",
+			hasUpdate: false,
+			cached: false,
+		})
+		await runManualUpdate()
+		expect(mockCheckForUpdate).toHaveBeenCalledWith({
+			currentVersion: "0.0.0-canary.20260509.abc1234",
+			skipCache: true,
+			canary: true,
 		})
 	})
 

--- a/src/extensions/auto-update-settings.test.ts
+++ b/src/extensions/auto-update-settings.test.ts
@@ -1,0 +1,241 @@
+// Tests for src/extensions/auto-update-settings.ts.
+//
+// Strategy: focus on `runManualUpdate()` + the re-exports. The TUI menu
+// handler is thin glue over `ctx.ui.select` / `ctx.ui.notify` from
+// @earendil-works/pi-coding-agent and is exercised manually in the
+// harness itself — booting the TUI in vitest is out of scope.
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
+
+const mockCheckForUpdate = vi.fn()
+const mockApplyUpdate = vi.fn()
+const mockLoadAutoUpdateSetting = vi.fn(() => true)
+const mockLoadAutoUpdateNoticeShown = vi.fn(() => false)
+const mockMarkAutoUpdateNoticeShown = vi.fn()
+const mockSaveAutoUpdateSetting = vi.fn()
+const mockIsHomebrewInstall = vi.fn(() => false)
+const mockGetVersion = vi.fn(() => "1.0.0")
+
+vi.mock("../update/paths.js", () => ({
+	isHomebrewInstall: mockIsHomebrewInstall,
+}))
+vi.mock("../update/settings.js", () => ({
+	loadAutoUpdateSetting: mockLoadAutoUpdateSetting,
+	saveAutoUpdateSetting: mockSaveAutoUpdateSetting,
+	loadAutoUpdateNoticeShown: mockLoadAutoUpdateNoticeShown,
+	markAutoUpdateNoticeShown: mockMarkAutoUpdateNoticeShown,
+}))
+vi.mock("../update/workflow.js", () => ({
+	checkForUpdate: mockCheckForUpdate,
+	applyUpdate: mockApplyUpdate,
+}))
+vi.mock("../utils.js", () => ({
+	getVersion: mockGetVersion,
+}))
+
+// Imports must come AFTER the vi.mock calls.
+const extension = await import("./auto-update-settings.js")
+const {
+	runManualUpdate,
+	argvHasSkipTrigger,
+	loadAutoUpdateSetting,
+	saveAutoUpdateSetting,
+	loadAutoUpdateNoticeShown,
+	markAutoUpdateNoticeShown,
+	default: defaultExport,
+} = extension
+
+function resetMocks(): void {
+	mockCheckForUpdate.mockReset()
+	mockApplyUpdate.mockReset()
+	mockLoadAutoUpdateSetting.mockReset()
+	mockLoadAutoUpdateNoticeShown.mockReset()
+	mockMarkAutoUpdateNoticeShown.mockReset()
+	mockSaveAutoUpdateSetting.mockReset()
+	mockIsHomebrewInstall.mockReset()
+	mockGetVersion.mockReset()
+	mockLoadAutoUpdateSetting.mockReturnValue(true)
+	mockLoadAutoUpdateNoticeShown.mockReturnValue(false)
+	mockIsHomebrewInstall.mockReturnValue(false)
+	mockGetVersion.mockReturnValue("1.0.0")
+	mockCheckForUpdate.mockResolvedValue({
+		currentVersion: "1.0.0",
+		latestVersion: "1.0.0",
+		tag: "v1.0.0",
+		releaseUrl: "",
+		hasUpdate: false,
+		cached: false,
+	})
+}
+
+beforeEach(() => {
+	resetMocks()
+})
+
+afterEach(() => {
+	vi.restoreAllMocks()
+})
+
+describe("re-exports delegate to the underlying modules", () => {
+	it("loadAutoUpdateSetting delegates to settings.loadAutoUpdateSetting", () => {
+		mockLoadAutoUpdateSetting.mockReturnValue(true)
+		expect(loadAutoUpdateSetting()).toBe(true)
+		expect(mockLoadAutoUpdateSetting).toHaveBeenCalledOnce()
+	})
+
+	it("saveAutoUpdateSetting delegates to settings.saveAutoUpdateSetting", () => {
+		saveAutoUpdateSetting(false)
+		expect(mockSaveAutoUpdateSetting).toHaveBeenCalledWith(false)
+	})
+
+	it("loadAutoUpdateNoticeShown delegates to settings.loadAutoUpdateNoticeShown", () => {
+		mockLoadAutoUpdateNoticeShown.mockReturnValue(true)
+		expect(loadAutoUpdateNoticeShown()).toBe(true)
+		expect(mockLoadAutoUpdateNoticeShown).toHaveBeenCalledOnce()
+	})
+
+	it("markAutoUpdateNoticeShown delegates to settings.markAutoUpdateNoticeShown", () => {
+		markAutoUpdateNoticeShown()
+		expect(mockMarkAutoUpdateNoticeShown).toHaveBeenCalledOnce()
+	})
+})
+
+describe("argvHasSkipTrigger re-export sanity", () => {
+	it("returns true for `kimchi update`", () => {
+		expect(argvHasSkipTrigger(["node", "kimchi", "update"])).toBe(true)
+	})
+
+	it("returns true for `--no-auto-update` flag", () => {
+		expect(argvHasSkipTrigger(["node", "kimchi", "--no-auto-update"])).toBe(true)
+	})
+
+	it("returns false for a plain TUI launch", () => {
+		expect(argvHasSkipTrigger(["node", "kimchi"])).toBe(false)
+	})
+})
+
+describe("auto-update setting reflects in the toggle label state", () => {
+	// The menu label ("Auto-update: ON" / "OFF") is built inline in
+	// autoUpdateLabel() from loadAutoUpdateSetting(). We assert the
+	// underlying state the label consumes — which is the same guarantee
+	// the menu handler relies on. Booting the TUI select list in vitest
+	// is out of scope.
+
+	it("returns true on init (opt-out default — label would read 'Auto-update: ON')", () => {
+		mockLoadAutoUpdateSetting.mockReturnValue(true)
+		expect(loadAutoUpdateSetting()).toBe(true)
+	})
+
+	it("returns false after saveAutoUpdateSetting(false) — label would read 'Auto-update: OFF'", () => {
+		mockLoadAutoUpdateSetting.mockReturnValueOnce(false)
+		// Simulate the toggle handler calling save then re-reading:
+		saveAutoUpdateSetting(false)
+		expect(mockSaveAutoUpdateSetting).toHaveBeenCalledWith(false)
+		expect(loadAutoUpdateSetting()).toBe(false)
+	})
+})
+
+describe("runManualUpdate — happy path", () => {
+	it("calls checkForUpdate with skipCache: true and canary: false", async () => {
+		mockCheckForUpdate.mockResolvedValue({
+			currentVersion: "1.0.0",
+			latestVersion: "1.0.0",
+			tag: "v1.0.0",
+			releaseUrl: "",
+			hasUpdate: false,
+			cached: false,
+		})
+		await runManualUpdate()
+		expect(mockCheckForUpdate).toHaveBeenCalledWith({
+			currentVersion: "1.0.0",
+			skipCache: true,
+			canary: false,
+		})
+	})
+
+	it("returns {ok: true, message: 'Already up to date ...'} when hasUpdate is false", async () => {
+		mockCheckForUpdate.mockResolvedValue({
+			currentVersion: "1.0.0",
+			latestVersion: "1.0.0",
+			tag: "v1.0.0",
+			releaseUrl: "",
+			hasUpdate: false,
+			cached: false,
+		})
+		const result = await runManualUpdate()
+		expect(result).toEqual({ ok: true, message: "Already up to date (1.0.0)" })
+		expect(mockApplyUpdate).not.toHaveBeenCalled()
+	})
+
+	it("calls applyUpdate({tag}) when an update is available and returns success", async () => {
+		mockCheckForUpdate.mockResolvedValue({
+			currentVersion: "1.0.0",
+			latestVersion: "1.1.0",
+			tag: "v1.1.0",
+			releaseUrl: "https://example/v1.1.0",
+			hasUpdate: true,
+			cached: false,
+		})
+		mockApplyUpdate.mockResolvedValue({ from: "1.0.0", to: "1.1.0", backupPath: undefined })
+
+		const result = await runManualUpdate()
+		expect(mockApplyUpdate).toHaveBeenCalledWith({ tag: "v1.1.0" })
+		expect(result.ok).toBe(true)
+		expect(result.message).toContain("1.1.0")
+		expect(result.message).toContain("Restart your terminal")
+	})
+})
+
+describe("runManualUpdate — failure paths", () => {
+	it("returns {ok: false, ...} when applyUpdate throws and does not rethrow", async () => {
+		mockCheckForUpdate.mockResolvedValue({
+			currentVersion: "1.0.0",
+			latestVersion: "1.1.0",
+			tag: "v1.1.0",
+			releaseUrl: "",
+			hasUpdate: true,
+			cached: false,
+		})
+		mockApplyUpdate.mockRejectedValue(new Error("smoke test failed"))
+		const warnSpy = vi.spyOn(process.stderr, "write").mockImplementation(() => true)
+
+		const result = await runManualUpdate()
+		expect(result.ok).toBe(false)
+		expect(result.message).toBe("Update failed: smoke test failed")
+		// We should have written a log line so the failure is visible.
+		expect(warnSpy).toHaveBeenCalled()
+		const written = warnSpy.mock.calls.map((c) => String(c[0])).join("")
+		expect(written).toContain("manual update failed")
+	})
+
+	it("returns {ok: false, ...} when checkForUpdate throws and does not rethrow", async () => {
+		mockCheckForUpdate.mockRejectedValue(new Error("network down"))
+		const warnSpy = vi.spyOn(process.stderr, "write").mockImplementation(() => true)
+
+		const result = await runManualUpdate()
+		expect(result.ok).toBe(false)
+		expect(result.message).toBe("Update check failed: network down")
+		expect(mockApplyUpdate).not.toHaveBeenCalled()
+		expect(warnSpy).toHaveBeenCalled()
+		const written = warnSpy.mock.calls.map((c) => String(c[0])).join("")
+		expect(written).toContain("update check failed")
+	})
+})
+
+describe("default export — extension factory", () => {
+	it("is a function that accepts a pi-shaped object and registers an `update` command", () => {
+		expect(typeof defaultExport).toBe("function")
+		const commands: Array<{ name: string; options: { description: string; handler: unknown } }> = []
+		const fakePi = {
+			registerCommand: (name: string, options: { description: string; handler: (...args: unknown[]) => unknown }) => {
+				commands.push({ name, options })
+			},
+		}
+		// biome-ignore lint/suspicious/noExplicitAny: fake pi satisfies the structural surface used by this extension
+		defaultExport(fakePi as any)
+		expect(commands).toHaveLength(1)
+		expect(commands[0]?.name).toBe("update")
+		expect(commands[0]?.options.description).toBe("Manage kimchi auto-update")
+		expect(typeof commands[0]?.options.handler).toBe("function")
+	})
+})

--- a/src/extensions/auto-update-settings.ts
+++ b/src/extensions/auto-update-settings.ts
@@ -81,31 +81,55 @@ function autoUpdateLabel(): string {
 	return loadAutoUpdateSetting() ? AUTO_UPDATE_ON("off") : AUTO_UPDATE_OFF("on")
 }
 
+const UPDATE_NOW_LABEL = "Update kimchi now"
+
+/**
+ * Cheap "is an update available?" probe for deciding whether to show the
+ * "Update kimchi now" menu item. Uses the cached check (no `skipCache`) so
+ * opening `/update` doesn't block on the network, and never throws — a
+ * failed/disabled check simply hides the item.
+ */
+async function updateAvailable(): Promise<boolean> {
+	try {
+		const check = await checkForUpdate({ currentVersion: getVersion(), canary: false })
+		return check.hasUpdate
+	} catch {
+		return false
+	}
+}
+
 async function showUpdateMenu(ctx: ExtensionCommandContext): Promise<void> {
-	const choice = await ctx.ui.select("Update", [autoUpdateLabel(), "Update kimchi now", "View current version", "Back"])
-	if (!choice) return
+	// Only offer "Update kimchi now" when there's actually something to
+	// install; otherwise it's a no-op that reports "Already up to date".
+	const canUpdate = await updateAvailable()
 
-	if (choice.startsWith(AUTO_UPDATE_LABEL_PREFIX)) {
-		const next = !loadAutoUpdateSetting()
-		saveAutoUpdateSetting(next)
-		ctx.ui.notify(`Auto-update set to ${next ? "on" : "off"}`, "info")
-		// Loop so the user can flip it back without re-running /update.
-		await showUpdateMenu(ctx)
+	while (true) {
+		const options = [...(canUpdate ? [UPDATE_NOW_LABEL] : []), autoUpdateLabel(), "View current version", "Back"]
+		const choice = await ctx.ui.select("Update", options)
+		if (!choice) return
+
+		if (choice === UPDATE_NOW_LABEL) {
+			const result = await runManualUpdate()
+			ctx.ui.notify(result.message, result.ok ? "info" : "error")
+			return
+		}
+
+		if (choice.startsWith(AUTO_UPDATE_LABEL_PREFIX)) {
+			const next = !loadAutoUpdateSetting()
+			saveAutoUpdateSetting(next)
+			ctx.ui.notify(`Auto-update set to ${next ? "on" : "off"}`, "info")
+			// Loop so the user can flip it back without re-running /update.
+			continue
+		}
+
+		if (choice === "View current version") {
+			ctx.ui.notify(`kimchi ${getVersion()}`, "info")
+			return
+		}
+
+		// "Back" or anything else — exit the command.
 		return
 	}
-
-	if (choice === "Update kimchi now") {
-		const result = await runManualUpdate()
-		ctx.ui.notify(result.message, result.ok ? "info" : "error")
-		return
-	}
-
-	if (choice === "View current version") {
-		ctx.ui.notify(`kimchi ${getVersion()}`, "info")
-		return
-	}
-
-	// "Back" or anything else — exit the command.
 }
 
 export default function autoUpdateSettingsExtension(pi: ExtensionAPI) {

--- a/src/extensions/auto-update-settings.ts
+++ b/src/extensions/auto-update-settings.ts
@@ -14,7 +14,7 @@
 import type { ExtensionAPI, ExtensionCommandContext } from "@earendil-works/pi-coding-agent"
 import { isHomebrewInstall } from "../update/paths.js"
 import { loadAutoUpdateSetting, saveAutoUpdateSetting } from "../update/settings.js"
-import { applyUpdate, checkForUpdate } from "../update/workflow.js"
+import { applyUpdate, checkForUpdate, parseCanarySha7 } from "../update/workflow.js"
 import { getVersion } from "../utils.js"
 
 const LOG_PREFIX = "[kimchi-auto-update]"
@@ -43,11 +43,13 @@ export interface ManualUpdateResult {
  * captured into the returned `{ ok, message }` payload.
  */
 export async function runManualUpdate(): Promise<ManualUpdateResult> {
+	const current = getVersion()
+	const isCanary = parseCanarySha7(current) !== null
 	try {
 		const check = await checkForUpdate({
-			currentVersion: getVersion(),
+			currentVersion: current,
 			skipCache: true,
-			canary: false,
+			canary: isCanary,
 		})
 		if (!check.hasUpdate) {
 			return { ok: true, message: `Already up to date (${getVersion()})` }
@@ -90,8 +92,10 @@ const UPDATE_NOW_LABEL = "Update kimchi now"
  * failed/disabled check simply hides the item.
  */
 async function updateAvailable(): Promise<boolean> {
+	const current = getVersion()
+	const isCanary = parseCanarySha7(current) !== null
 	try {
-		const check = await checkForUpdate({ currentVersion: getVersion(), canary: false })
+		const check = await checkForUpdate({ currentVersion: current, canary: isCanary })
 		return check.hasUpdate
 	} catch {
 		return false

--- a/src/extensions/auto-update-settings.ts
+++ b/src/extensions/auto-update-settings.ts
@@ -22,10 +22,10 @@ const LOG_PREFIX = "[kimchi-auto-update]"
 // Re-export pure helpers so tests can drive them without booting the TUI.
 export { argvHasSkipTrigger } from "../update/auto-update.js"
 export {
-	loadAutoUpdateSetting,
-	saveAutoUpdateSetting,
 	loadAutoUpdateNoticeShown,
+	loadAutoUpdateSetting,
 	markAutoUpdateNoticeShown,
+	saveAutoUpdateSetting,
 } from "../update/settings.js"
 
 export interface ManualUpdateResult {

--- a/src/extensions/auto-update-settings.ts
+++ b/src/extensions/auto-update-settings.ts
@@ -67,8 +67,15 @@ export async function runManualUpdate(): Promise<ManualUpdateResult> {
 	}
 }
 
-const AUTO_UPDATE_ON = (toggle: "on" | "off") => `Auto-update: ON (toggle ${toggle})`
-const AUTO_UPDATE_OFF = (toggle: "on" | "off") => `Auto-update: OFF (toggle ${toggle})`
+// Single source of truth for the auto-update menu item label. The same
+// prefix is matched against in showUpdateMenu below — keep both in sync
+// if you ever rename the visible text. ctx.ui.select in pi-coding-agent
+// only accepts string[] options (no separate id field), so we can't
+// fully decouple display text from branch identity.
+const AUTO_UPDATE_LABEL_PREFIX = "Auto-update:"
+
+const AUTO_UPDATE_ON = (toggle: "on" | "off") => `${AUTO_UPDATE_LABEL_PREFIX} ON (toggle ${toggle})`
+const AUTO_UPDATE_OFF = (toggle: "on" | "off") => `${AUTO_UPDATE_LABEL_PREFIX} OFF (toggle ${toggle})`
 
 function autoUpdateLabel(): string {
 	return loadAutoUpdateSetting() ? AUTO_UPDATE_ON("off") : AUTO_UPDATE_OFF("on")
@@ -78,7 +85,7 @@ async function showUpdateMenu(ctx: ExtensionCommandContext): Promise<void> {
 	const choice = await ctx.ui.select("Update", [autoUpdateLabel(), "Update kimchi now", "View current version", "Back"])
 	if (!choice) return
 
-	if (choice.startsWith("Auto-update:")) {
+	if (choice.startsWith(AUTO_UPDATE_LABEL_PREFIX)) {
 		const next = !loadAutoUpdateSetting()
 		saveAutoUpdateSetting(next)
 		ctx.ui.notify(`Auto-update set to ${next ? "on" : "off"}`, "info")

--- a/src/extensions/auto-update-settings.ts
+++ b/src/extensions/auto-update-settings.ts
@@ -85,30 +85,9 @@ function autoUpdateLabel(): string {
 
 const UPDATE_NOW_LABEL = "Update kimchi now"
 
-/**
- * Cheap "is an update available?" probe for deciding whether to show the
- * "Update kimchi now" menu item. Uses the cached check (no `skipCache`) so
- * opening `/update` doesn't block on the network, and never throws — a
- * failed/disabled check simply hides the item.
- */
-async function updateAvailable(): Promise<boolean> {
-	const current = getVersion()
-	const isCanary = parseCanarySha7(current) !== null
-	try {
-		const check = await checkForUpdate({ currentVersion: current, canary: isCanary })
-		return check.hasUpdate
-	} catch {
-		return false
-	}
-}
-
 async function showUpdateMenu(ctx: ExtensionCommandContext): Promise<void> {
-	// Only offer "Update kimchi now" when there's actually something to
-	// install; otherwise it's a no-op that reports "Already up to date".
-	const canUpdate = await updateAvailable()
-
 	while (true) {
-		const options = [...(canUpdate ? [UPDATE_NOW_LABEL] : []), autoUpdateLabel(), "View current version", "Back"]
+		const options = [UPDATE_NOW_LABEL, autoUpdateLabel(), "View current version", "Back"]
 		const choice = await ctx.ui.select("Update", options)
 		if (!choice) return
 

--- a/src/extensions/auto-update-settings.ts
+++ b/src/extensions/auto-update-settings.ts
@@ -1,0 +1,128 @@
+/**
+ * kimchi `/update` slash command — exposes the auto-update toggle and a
+ * manual "update now" action in the TUI.
+ *
+ * The auto-update-on-launch decision lives in src/update/auto-update.ts
+ * (Phase 2) and runs headlessly before the TUI boots. This command is the
+ * user-facing surface for the same settings: flip the toggle, kick off a
+ * one-shot update, or just see the running version.
+ *
+ * Mirrors the `agents/index.ts:showSettings()` pattern: registerCommand
+ * + ctx.ui.select menu + ctx.ui.notify feedback.
+ */
+
+import type { ExtensionAPI, ExtensionCommandContext } from "@earendil-works/pi-coding-agent"
+import { isHomebrewInstall } from "../update/paths.js"
+import { loadAutoUpdateSetting, saveAutoUpdateSetting } from "../update/settings.js"
+import { applyUpdate, checkForUpdate } from "../update/workflow.js"
+import { getVersion } from "../utils.js"
+
+const LOG_PREFIX = "[kimchi-auto-update]"
+
+// Re-export pure helpers so tests can drive them without booting the TUI.
+export { argvHasSkipTrigger } from "../update/auto-update.js"
+export {
+	loadAutoUpdateSetting,
+	saveAutoUpdateSetting,
+	loadAutoUpdateNoticeShown,
+	markAutoUpdateNoticeShown,
+} from "../update/settings.js"
+
+export interface ManualUpdateResult {
+	ok: boolean
+	message: string
+}
+
+/**
+ * Run a one-shot update check + apply. Used by the `/update` command's
+ * "Update kimchi now" menu item and exported for tests. We deliberately
+ * skip the 24h cache (`skipCache: true`) because the user explicitly
+ * asked to check.
+ *
+ * Never throws — both `checkForUpdate` and `applyUpdate` failures are
+ * captured into the returned `{ ok, message }` payload.
+ */
+export async function runManualUpdate(): Promise<ManualUpdateResult> {
+	try {
+		const check = await checkForUpdate({
+			currentVersion: getVersion(),
+			skipCache: true,
+			canary: false,
+		})
+		if (!check.hasUpdate) {
+			return { ok: true, message: `Already up to date (${getVersion()})` }
+		}
+		try {
+			await applyUpdate({ tag: check.tag })
+			return { ok: true, message: `Updated to ${check.latestVersion}. Restart your terminal.` }
+		} catch (err) {
+			const message = (err as Error).message
+			process.stderr.write(`${LOG_PREFIX} manual update failed: ${message}\n`)
+			return { ok: false, message: `Update failed: ${message}` }
+		}
+	} catch (err) {
+		const message = (err as Error).message
+		process.stderr.write(`${LOG_PREFIX} update check failed: ${message}\n`)
+		return { ok: false, message: `Update check failed: ${message}` }
+	}
+}
+
+const AUTO_UPDATE_ON = (toggle: "on" | "off") => `Auto-update: ON (toggle ${toggle})`
+const AUTO_UPDATE_OFF = (toggle: "on" | "off") => `Auto-update: OFF (toggle ${toggle})`
+
+function autoUpdateLabel(): string {
+	return loadAutoUpdateSetting() ? AUTO_UPDATE_ON("off") : AUTO_UPDATE_OFF("on")
+}
+
+async function showUpdateMenu(ctx: ExtensionCommandContext): Promise<void> {
+	const choice = await ctx.ui.select("Update", [autoUpdateLabel(), "Update kimchi now", "View current version", "Back"])
+	if (!choice) return
+
+	if (choice.startsWith("Auto-update:")) {
+		const next = !loadAutoUpdateSetting()
+		saveAutoUpdateSetting(next)
+		ctx.ui.notify(`Auto-update set to ${next ? "on" : "off"}`, "info")
+		// Loop so the user can flip it back without re-running /update.
+		await showUpdateMenu(ctx)
+		return
+	}
+
+	if (choice === "Update kimchi now") {
+		const result = await runManualUpdate()
+		ctx.ui.notify(result.message, result.ok ? "info" : "error")
+		return
+	}
+
+	if (choice === "View current version") {
+		ctx.ui.notify(`kimchi ${getVersion()}`, "info")
+		return
+	}
+
+	// "Back" or anything else — exit the command.
+}
+
+export default function autoUpdateSettingsExtension(pi: ExtensionAPI) {
+	pi.registerCommand("update", {
+		description: "Manage kimchi auto-update",
+		handler: async (_args, ctx) => {
+			// Only the TUI shows the menu. Headless modes already have
+			// `kimchi update` as their escape hatch.
+			if (ctx.mode !== "tui") return
+
+			if (process.env.KIMCHI_NO_UPDATE_CHECK) {
+				ctx.ui.notify("Updates are disabled by the KIMCHI_NO_UPDATE_CHECK environment variable.", "info")
+				return
+			}
+
+			if (isHomebrewInstall()) {
+				ctx.ui.notify(
+					"kimchi is managed by Homebrew; auto-update is not available. Run `brew upgrade kimchi` instead.",
+					"info",
+				)
+				return
+			}
+
+			await showUpdateMenu(ctx)
+		},
+	})
+}

--- a/src/extensions/startup-update.test.ts
+++ b/src/extensions/startup-update.test.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, it, vi } from "vitest"
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
 
 const checkForUpdateMock = vi.fn()
 const getVersionMock = vi.fn()
@@ -221,6 +221,64 @@ describe("startupUpdateExtension", () => {
 			expect(key).toBe("update-available")
 			expect(notify).not.toHaveBeenCalled()
 			expect(markAutoUpdateNoticeShownMock).not.toHaveBeenCalled()
+		})
+	})
+
+	describe("auto-update settings error handling", () => {
+		let stderrSpy: ReturnType<typeof vi.spyOn>
+
+		beforeEach(() => {
+			stderrSpy = vi.spyOn(console, "warn").mockImplementation(() => {})
+		})
+
+		afterEach(() => {
+			stderrSpy.mockRestore()
+		})
+
+		it("swallows errors from loadAutoUpdateSetting and returns early without setStatus", async () => {
+			getVersionMock.mockReturnValue("v0.0.23")
+			loadAutoUpdateSettingMock.mockImplementation(() => {
+				throw new Error("settings dir unwritable")
+			})
+			const { handlers, api } = createMockApi()
+			startupUpdateExtension(api)
+			const handler = handlers.get("session_start")
+			if (!handler) throw new Error("no session_start handler")
+
+			const { ctx, setStatus, notify } = makeCtx({ hasUI: true })
+			await expect(handler({}, ctx)).resolves.toBeUndefined()
+
+			// Nothing should render, and the existing checkForUpdate path
+			// must NOT run when the settings layer is broken.
+			expect(checkForUpdateMock).not.toHaveBeenCalled()
+			expect(setStatus).not.toHaveBeenCalled()
+			expect(notify).not.toHaveBeenCalled()
+			expect(markAutoUpdateNoticeShownMock).not.toHaveBeenCalled()
+			expect(stderrSpy).toHaveBeenCalledOnce()
+			expect(stderrSpy.mock.calls[0][0]).toContain("settings dir unwritable")
+		})
+
+		it("swallows errors from markAutoUpdateNoticeShown", async () => {
+			getVersionMock.mockReturnValue("v0.0.23")
+			loadAutoUpdateSettingMock.mockReturnValue(true)
+			loadAutoUpdateNoticeShownMock.mockReturnValue(false)
+			markAutoUpdateNoticeShownMock.mockImplementation(() => {
+				throw new Error("disk full")
+			})
+			const { handlers, api } = createMockApi()
+			startupUpdateExtension(api)
+			const handler = handlers.get("session_start")
+			if (!handler) throw new Error("no session_start handler")
+
+			const { ctx, notify } = makeCtx({ hasUI: true })
+			await expect(handler({}, ctx)).resolves.toBeUndefined()
+
+			// The notify ran, but the throw happened AFTER notify. The
+			// catch must swallow the error so session_start doesn't crash.
+			expect(notify).toHaveBeenCalledOnce()
+			expect(checkForUpdateMock).not.toHaveBeenCalled()
+			expect(stderrSpy).toHaveBeenCalledOnce()
+			expect(stderrSpy.mock.calls[0][0]).toContain("disk full")
 		})
 	})
 })

--- a/src/extensions/startup-update.test.ts
+++ b/src/extensions/startup-update.test.ts
@@ -3,6 +3,9 @@ import { beforeEach, describe, expect, it, vi } from "vitest"
 const checkForUpdateMock = vi.fn()
 const getVersionMock = vi.fn()
 const isHomebrewInstallMock = vi.fn(() => false)
+const loadAutoUpdateSettingMock = vi.fn(() => false)
+const loadAutoUpdateNoticeShownMock = vi.fn(() => false)
+const markAutoUpdateNoticeShownMock = vi.fn()
 
 vi.mock(import("../update/workflow.js"), async (importOriginal) => {
 	const actual = await importOriginal()
@@ -16,6 +19,12 @@ vi.mock("../utils.js", () => ({
 }))
 vi.mock("../update/paths.js", () => ({
 	isHomebrewInstall: () => isHomebrewInstallMock(),
+}))
+vi.mock("../update/settings.js", () => ({
+	loadAutoUpdateSetting: () => loadAutoUpdateSettingMock(),
+	saveAutoUpdateSetting: vi.fn(),
+	loadAutoUpdateNoticeShown: () => loadAutoUpdateNoticeShownMock(),
+	markAutoUpdateNoticeShown: () => markAutoUpdateNoticeShownMock(),
 }))
 
 const { default: startupUpdateExtension } = await import("./startup-update.js")
@@ -34,14 +43,16 @@ function createMockApi() {
 
 function makeCtx(opts: { hasUI: boolean }) {
 	const setStatus = vi.fn()
+	const notify = vi.fn()
 	const ctx = {
 		hasUI: opts.hasUI,
 		ui: {
 			setStatus,
+			notify,
 			theme: { bold: (s: string) => s },
 		},
 	}
-	return { ctx, setStatus }
+	return { ctx, setStatus, notify }
 }
 
 describe("startupUpdateExtension", () => {
@@ -49,7 +60,14 @@ describe("startupUpdateExtension", () => {
 		checkForUpdateMock.mockReset()
 		getVersionMock.mockReset()
 		isHomebrewInstallMock.mockReset()
+		loadAutoUpdateSettingMock.mockReset()
+		loadAutoUpdateNoticeShownMock.mockReset()
+		markAutoUpdateNoticeShownMock.mockReset()
 		isHomebrewInstallMock.mockReturnValue(false)
+		// Default: auto-update disabled → preserves legacy setStatus behavior
+		// for the existing tests below. New tests override per-case.
+		loadAutoUpdateSettingMock.mockReturnValue(false)
+		loadAutoUpdateNoticeShownMock.mockReturnValue(false)
 	})
 
 	it("checks for update on bare 0.0.0 dev build", async () => {
@@ -126,5 +144,83 @@ describe("startupUpdateExtension", () => {
 
 		expect(checkForUpdateMock).not.toHaveBeenCalled()
 		expect(setStatus).not.toHaveBeenCalled()
+	})
+
+	describe("auto-update aware", () => {
+		it("suppresses setStatus (no nag) when autoUpdate is enabled and update is available", async () => {
+			getVersionMock.mockReturnValue("v0.0.23")
+			loadAutoUpdateSettingMock.mockReturnValue(true)
+			loadAutoUpdateNoticeShownMock.mockReturnValue(true) // isolate the suppression path
+			checkForUpdateMock.mockResolvedValue({ hasUpdate: true })
+			const { handlers, api } = createMockApi()
+			startupUpdateExtension(api)
+			const handler = handlers.get("session_start")
+			if (!handler) throw new Error("no session_start handler")
+
+			const { ctx, setStatus, notify } = makeCtx({ hasUI: true })
+			await handler({}, ctx)
+
+			// Auto-update handles currency on next launch — no footer nag,
+			// no version check here, and the onboarding toast is already shown.
+			expect(checkForUpdateMock).not.toHaveBeenCalled()
+			expect(setStatus).not.toHaveBeenCalled()
+			expect(notify).not.toHaveBeenCalled()
+		})
+
+		it("emits one-time notify and marks shown when autoUpdate is enabled and notice not yet shown", async () => {
+			getVersionMock.mockReturnValue("v0.0.23")
+			loadAutoUpdateSettingMock.mockReturnValue(true)
+			loadAutoUpdateNoticeShownMock.mockReturnValue(false)
+			const { handlers, api } = createMockApi()
+			startupUpdateExtension(api)
+			const handler = handlers.get("session_start")
+			if (!handler) throw new Error("no session_start handler")
+
+			const { ctx, setStatus, notify } = makeCtx({ hasUI: true })
+			await handler({}, ctx)
+
+			expect(notify).toHaveBeenCalledOnce()
+			expect(notify.mock.calls[0][0]).toContain("Run `/update` to disable")
+			expect(markAutoUpdateNoticeShownMock).toHaveBeenCalledOnce()
+			expect(checkForUpdateMock).not.toHaveBeenCalled()
+			expect(setStatus).not.toHaveBeenCalled()
+		})
+
+		it("does not notify when autoUpdate is enabled and notice already shown", async () => {
+			getVersionMock.mockReturnValue("v0.0.23")
+			loadAutoUpdateSettingMock.mockReturnValue(true)
+			loadAutoUpdateNoticeShownMock.mockReturnValue(true)
+			const { handlers, api } = createMockApi()
+			startupUpdateExtension(api)
+			const handler = handlers.get("session_start")
+			if (!handler) throw new Error("no session_start handler")
+
+			const { ctx, setStatus, notify } = makeCtx({ hasUI: true })
+			await handler({}, ctx)
+
+			expect(notify).not.toHaveBeenCalled()
+			expect(markAutoUpdateNoticeShownMock).not.toHaveBeenCalled()
+			expect(setStatus).not.toHaveBeenCalled()
+		})
+
+		it("preserves setStatus behavior and skips notice when autoUpdate is disabled", async () => {
+			getVersionMock.mockReturnValue("v0.0.23")
+			loadAutoUpdateSettingMock.mockReturnValue(false)
+			loadAutoUpdateNoticeShownMock.mockReturnValue(false)
+			checkForUpdateMock.mockResolvedValue({ hasUpdate: true })
+			const { handlers, api } = createMockApi()
+			startupUpdateExtension(api)
+			const handler = handlers.get("session_start")
+			if (!handler) throw new Error("no session_start handler")
+
+			const { ctx, setStatus, notify } = makeCtx({ hasUI: true })
+			await handler({}, ctx)
+
+			expect(setStatus).toHaveBeenCalledOnce()
+			const [key] = setStatus.mock.calls[0]
+			expect(key).toBe("update-available")
+			expect(notify).not.toHaveBeenCalled()
+			expect(markAutoUpdateNoticeShownMock).not.toHaveBeenCalled()
+		})
 	})
 })

--- a/src/extensions/startup-update.test.ts
+++ b/src/extensions/startup-update.test.ts
@@ -222,6 +222,30 @@ describe("startupUpdateExtension", () => {
 			expect(notify).not.toHaveBeenCalled()
 			expect(markAutoUpdateNoticeShownMock).not.toHaveBeenCalled()
 		})
+
+		it("does not suppress footer for Homebrew users with autoUpdate enabled", async () => {
+			getVersionMock.mockReturnValue("v0.0.23")
+			loadAutoUpdateSettingMock.mockReturnValue(true)
+			loadAutoUpdateNoticeShownMock.mockReturnValue(true)
+			isHomebrewInstallMock.mockReturnValue(true)
+			checkForUpdateMock.mockResolvedValue({ hasUpdate: true })
+			const { handlers, api } = createMockApi()
+			startupUpdateExtension(api)
+			const handler = handlers.get("session_start")
+			if (!handler) throw new Error("no session_start handler")
+
+			const { ctx, setStatus, notify } = makeCtx({ hasUI: true })
+			await handler({}, ctx)
+
+			// Homebrew installs are skipped by launch auto-update, so the
+			// footer hint must still show — otherwise the user gets neither
+			// a background update nor a `brew upgrade` hint.
+			expect(checkForUpdateMock).toHaveBeenCalledOnce()
+			expect(setStatus).toHaveBeenCalledOnce()
+			const [, msg] = setStatus.mock.calls[0]
+			expect(msg).toContain("brew upgrade kimchi")
+			expect(notify).not.toHaveBeenCalled()
+		})
 	})
 
 	describe("auto-update settings error handling", () => {

--- a/src/extensions/startup-update.ts
+++ b/src/extensions/startup-update.ts
@@ -1,5 +1,6 @@
 import type { ExtensionAPI, ExtensionContext } from "@earendil-works/pi-coding-agent"
 import { isHomebrewInstall } from "../update/paths.js"
+import { loadAutoUpdateNoticeShown, loadAutoUpdateSetting, markAutoUpdateNoticeShown } from "../update/settings.js"
 import { checkForUpdate, parseCanarySha7 } from "../update/workflow.js"
 import { getVersion } from "../utils.js"
 
@@ -11,6 +12,12 @@ const UPDATE_STATUS_KEY = "update-available"
  * Silently fails on errors to not block harness launch.
  *
  * The message is displayed via setStatus and read by the status line renderer.
+ *
+ * When auto-update is enabled (opt-in default — the toggle defaults to
+ * off, so most users land here), the footer hint is suppressed — users
+ * get updates silently on next launch. The first launch after a user
+ * enables the toggle also emits a one-time onboarding toast explaining
+ * the behavior and how to opt out via `/update`.
  */
 export default function startupUpdateExtension(pi: ExtensionAPI) {
 	pi.on("session_start", async (_event, ctx: ExtensionContext) => {
@@ -20,6 +27,18 @@ export default function startupUpdateExtension(pi: ExtensionAPI) {
 		// Canary users opted into the canary track; don't nag them about
 		// stable. Currency on canary is checked by `kimchi update --canary`.
 		if (parseCanarySha7(current) !== null) return
+
+		const autoUpdateEnabled = loadAutoUpdateSetting()
+		if (autoUpdateEnabled) {
+			// Auto-update is on: no nag (next launch applies silently).
+			// First launch only: explain the new behavior and how to opt out.
+			if (!loadAutoUpdateNoticeShown()) {
+				ctx.ui.notify("kimchi now updates itself in the background. Run `/update` to disable.")
+				markAutoUpdateNoticeShown()
+			}
+			return
+		}
+
 		try {
 			const result = await checkForUpdate({ currentVersion: current, skipCache: false })
 			if (result.hasUpdate) {

--- a/src/extensions/startup-update.ts
+++ b/src/extensions/startup-update.ts
@@ -30,7 +30,12 @@ export default function startupUpdateExtension(pi: ExtensionAPI) {
 
 		try {
 			const autoUpdateEnabled = loadAutoUpdateSetting()
-			if (autoUpdateEnabled) {
+			// Only suppress the footer nag when on-launch auto-update can
+			// actually run. Homebrew installs are skipped by the launch
+			// auto-update path (see auto-update.ts), so a Homebrew user with
+			// autoUpdate=true would otherwise get neither a background update
+			// nor the `brew upgrade kimchi` hint.
+			if (autoUpdateEnabled && !isHomebrewInstall()) {
 				// Auto-update is on: no nag (next launch applies silently).
 				// First launch only: explain the new behavior and how to opt out.
 				if (!loadAutoUpdateNoticeShown()) {

--- a/src/extensions/startup-update.ts
+++ b/src/extensions/startup-update.ts
@@ -53,6 +53,8 @@ export default function startupUpdateExtension(pi: ExtensionAPI) {
 		try {
 			const result = await checkForUpdate({ currentVersion: current, skipCache: false })
 			if (result.hasUpdate) {
+				// Homebrew-managed installs live outside kimchi's swap path —
+				// point the user at `brew upgrade` rather than `kimchi update`.
 				const updateCmd = ctx.ui.theme.bold(isHomebrewInstall() ? "brew upgrade kimchi" : "kimchi update")
 				ctx.ui.setStatus(UPDATE_STATUS_KEY, `Update available! Run ${updateCmd}`)
 			}

--- a/src/extensions/startup-update.ts
+++ b/src/extensions/startup-update.ts
@@ -28,14 +28,25 @@ export default function startupUpdateExtension(pi: ExtensionAPI) {
 		// stable. Currency on canary is checked by `kimchi update --canary`.
 		if (parseCanarySha7(current) !== null) return
 
-		const autoUpdateEnabled = loadAutoUpdateSetting()
-		if (autoUpdateEnabled) {
-			// Auto-update is on: no nag (next launch applies silently).
-			// First launch only: explain the new behavior and how to opt out.
-			if (!loadAutoUpdateNoticeShown()) {
-				ctx.ui.notify("kimchi now updates itself in the background. Run `/update` to disable.")
-				markAutoUpdateNoticeShown()
+		try {
+			const autoUpdateEnabled = loadAutoUpdateSetting()
+			if (autoUpdateEnabled) {
+				// Auto-update is on: no nag (next launch applies silently).
+				// First launch only: explain the new behavior and how to opt out.
+				if (!loadAutoUpdateNoticeShown()) {
+					ctx.ui.notify("kimchi now updates itself in the background. Run `/update` to disable.")
+					markAutoUpdateNoticeShown()
+				}
+				return
 			}
+		} catch (err) {
+			// Settings layer broken (e.g. getAgentDir() throws, disk
+			// unwritable). Don't crash the session — bail and let the
+			// rest of the harness boot normally. Mirrors the swallow-
+			// and-continue pattern used for checkForUpdate below, but
+			// also returns early because we have no signal worth
+			// showing when the settings file itself is unreadable.
+			console.warn(`[startup-update] auto-update settings unavailable: ${(err as Error).message}`)
 			return
 		}
 

--- a/src/update/auto-update.test.ts
+++ b/src/update/auto-update.test.ts
@@ -432,7 +432,7 @@ describe("maybeAutoUpdateOnLaunch — deadline / abort handling", () => {
 		expect(execveSpy).not.toHaveBeenCalled()
 	})
 
-	it("skips re-exec when signal aborts during applyUpdate", async () => {
+	it("proceeds with re-exec after applyUpdate completes even if signal aborts mid-install", async () => {
 		const controller = new AbortController()
 		mockCheckForUpdate.mockResolvedValue({
 			currentVersion: "1.0.0",
@@ -447,9 +447,11 @@ describe("maybeAutoUpdateOnLaunch — deadline / abort handling", () => {
 			return { from: "v1.1.0", to: "v1.1.0" }
 		})
 
+		// Once applyUpdate has committed, we proceed with re-exec regardless
+		// of signal state — the install must complete atomically.
 		await expect(maybeAutoUpdateOnLaunch({ signal: controller.signal })).resolves.toBeUndefined()
 		expect(mockApplyUpdate).toHaveBeenCalledOnce()
-		expect(execveSpy).not.toHaveBeenCalled()
+		expect(execveSpy).toHaveBeenCalledOnce()
 	})
 
 	it("logs an audit line with tag + releaseUrl before applying", async () => {

--- a/src/update/auto-update.test.ts
+++ b/src/update/auto-update.test.ts
@@ -30,7 +30,8 @@ vi.mock("./workflow.js", () => ({
 }))
 
 const autoUpdate = await import("./auto-update.js")
-const { maybeAutoUpdateOnLaunch, performReExec, argvHasSkipTrigger, ReExecUnavailableError } = autoUpdate
+const { maybeAutoUpdateOnLaunch, performReExec, argvHasSkipTrigger, isNonInteractiveLaunch, ReExecUnavailableError } =
+	autoUpdate
 
 const originalEnvNoCheck = process.env.KIMCHI_NO_UPDATE_CHECK
 const originalPlatform = process.platform
@@ -228,6 +229,74 @@ describe("argvHasSkipTrigger — pure function over an argv array", () => {
 
 	it("returns false for an unrelated --flag=value argument", () => {
 		expect(argvHasSkipTrigger(["node", "kimchi", "--command=serve"])).toBe(false)
+	})
+})
+
+describe("isNonInteractiveLaunch — pure function over an argv array", () => {
+	it("returns true for --mode=acp", () => {
+		expect(isNonInteractiveLaunch(["node", "kimchi", "--mode=acp"])).toBe(true)
+	})
+
+	it("returns true for --mode json", () => {
+		expect(isNonInteractiveLaunch(["node", "kimchi", "--mode", "json"])).toBe(true)
+	})
+
+	it("returns true for --mode=rpc", () => {
+		expect(isNonInteractiveLaunch(["node", "kimchi", "--mode=rpc"])).toBe(true)
+	})
+
+	it("returns true for --print", () => {
+		expect(isNonInteractiveLaunch(["node", "kimchi", "--print"])).toBe(true)
+	})
+
+	it("returns true for -p", () => {
+		expect(isNonInteractiveLaunch(["node", "kimchi", "-p"])).toBe(true)
+	})
+
+	it("returns true for --export", () => {
+		expect(isNonInteractiveLaunch(["node", "kimchi", "--export"])).toBe(true)
+	})
+
+	it("returns true for --export=file.html", () => {
+		expect(isNonInteractiveLaunch(["node", "kimchi", "--export=file.html"])).toBe(true)
+	})
+
+	it("returns false for a plain TUI launch", () => {
+		expect(isNonInteractiveLaunch(["node", "kimchi"])).toBe(false)
+	})
+
+	it("returns false for --mode=tui", () => {
+		expect(isNonInteractiveLaunch(["node", "kimchi", "--mode=tui"])).toBe(false)
+	})
+
+	it("returns false for unrelated flags", () => {
+		expect(isNonInteractiveLaunch(["node", "kimchi", "--theme", "dark"])).toBe(false)
+	})
+})
+
+describe("maybeAutoUpdateOnLaunch — non-interactive mode skip", () => {
+	it("skips when argv selects a non-interactive mode (--mode=acp)", async () => {
+		const originalArgv = process.argv
+		process.argv = ["node", "kimchi", "--mode=acp"]
+		try {
+			await maybeAutoUpdateOnLaunch()
+			expect(mockCheckForUpdate).not.toHaveBeenCalled()
+			expect(mockApplyUpdate).not.toHaveBeenCalled()
+			expect(execveSpy).not.toHaveBeenCalled()
+		} finally {
+			process.argv = originalArgv
+		}
+	})
+
+	it("skips when argv contains --print", async () => {
+		const originalArgv = process.argv
+		process.argv = ["node", "kimchi", "--print"]
+		try {
+			await maybeAutoUpdateOnLaunch()
+			expect(mockCheckForUpdate).not.toHaveBeenCalled()
+		} finally {
+			process.argv = originalArgv
+		}
 	})
 })
 

--- a/src/update/auto-update.test.ts
+++ b/src/update/auto-update.test.ts
@@ -17,6 +17,7 @@ const mockApplyUpdate = vi.fn()
 const mockLoadAutoUpdateSetting = vi.fn(() => true)
 const mockIsHomebrewInstall = vi.fn(() => false)
 const mockParseCanarySha7 = vi.fn(() => null as string | null)
+const mockGetVersion = vi.fn(() => "1.0.0")
 
 vi.mock("./paths.js", () => ({
 	isHomebrewInstall: mockIsHomebrewInstall,
@@ -28,6 +29,7 @@ vi.mock("./workflow.js", () => ({
 	applyUpdate: mockApplyUpdate,
 	parseCanarySha7: mockParseCanarySha7,
 }))
+vi.mock("../utils.js", () => ({ getVersion: mockGetVersion }))
 
 const autoUpdate = await import("./auto-update.js")
 const { maybeAutoUpdateOnLaunch, performReExec, argvHasSkipTrigger, isNonInteractiveLaunch, ReExecUnavailableError } =
@@ -35,6 +37,7 @@ const { maybeAutoUpdateOnLaunch, performReExec, argvHasSkipTrigger, isNonInterac
 
 const originalEnvNoCheck = process.env.KIMCHI_NO_UPDATE_CHECK
 const originalPlatform = process.platform
+const originalExecPath = process.execPath
 const originalExecve = (process as unknown as { execve?: unknown }).execve
 let execveSpy: MockInstance<(file: string, args: readonly string[], env: NodeJS.ProcessEnv) => never> | undefined
 
@@ -44,9 +47,11 @@ function resetMocks(): void {
 	mockLoadAutoUpdateSetting.mockReset()
 	mockIsHomebrewInstall.mockReset()
 	mockParseCanarySha7.mockReset()
+	mockGetVersion.mockReset()
 	mockLoadAutoUpdateSetting.mockReturnValue(true)
 	mockIsHomebrewInstall.mockReturnValue(false)
 	mockParseCanarySha7.mockReturnValue(null)
+	mockGetVersion.mockReturnValue("1.0.0")
 	mockCheckForUpdate.mockResolvedValue({
 		currentVersion: "1.0.0",
 		latestVersion: "1.0.0",
@@ -63,6 +68,10 @@ beforeEach(() => {
 	delete process.env.KIMCHI_NO_UPDATE_CHECK
 	// Default platform: linux (CI). Individual tests can override.
 	Object.defineProperty(process, "platform", { value: "linux", configurable: true })
+	// Pretend we're running the packaged kimchi binary so the
+	// packaged-binary guard in maybeAutoUpdateOnLaunch lets us through.
+	// The test runner's real execPath is `node`, which would be rejected.
+	Object.defineProperty(process, "execPath", { value: "/usr/local/bin/kimchi", configurable: true })
 
 	// Ensure process.execve exists so vi.spyOn has a target. On Linux it's
 	// a real syscall; on hosts where it isn't defined (some macOS/Windows
@@ -93,6 +102,7 @@ afterEach(() => {
 		delete process.env.KIMCHI_NO_UPDATE_CHECK
 	} else process.env.KIMCHI_NO_UPDATE_CHECK = originalEnvNoCheck
 	Object.defineProperty(process, "platform", { value: originalPlatform, configurable: true })
+	Object.defineProperty(process, "execPath", { value: originalExecPath, configurable: true })
 	execveSpy?.mockRestore()
 	// If the host had no execve to begin with, our Object.defineProperty
 	// stub may linger after mockRestore; clear it so we don't leak between
@@ -142,6 +152,30 @@ describe("maybeAutoUpdateOnLaunch — skip gates", () => {
 
 	it("skips when loadAutoUpdateSetting() returns false", async () => {
 		mockLoadAutoUpdateSetting.mockReturnValue(false)
+		await maybeAutoUpdateOnLaunch()
+		expect(mockCheckForUpdate).not.toHaveBeenCalled()
+		expect(mockApplyUpdate).not.toHaveBeenCalled()
+		expect(execveSpy).not.toHaveBeenCalled()
+	})
+
+	it("skips when getVersion() is 'dev' (source/dev launch)", async () => {
+		mockGetVersion.mockReturnValue("dev")
+		await maybeAutoUpdateOnLaunch()
+		expect(mockCheckForUpdate).not.toHaveBeenCalled()
+		expect(mockApplyUpdate).not.toHaveBeenCalled()
+		expect(execveSpy).not.toHaveBeenCalled()
+	})
+
+	it("skips when getVersion() is 'unknown'", async () => {
+		mockGetVersion.mockReturnValue("unknown")
+		await maybeAutoUpdateOnLaunch()
+		expect(mockCheckForUpdate).not.toHaveBeenCalled()
+		expect(mockApplyUpdate).not.toHaveBeenCalled()
+		expect(execveSpy).not.toHaveBeenCalled()
+	})
+
+	it("skips when process.execPath is not the packaged kimchi binary", async () => {
+		Object.defineProperty(process, "execPath", { value: "/usr/local/bin/node", configurable: true })
 		await maybeAutoUpdateOnLaunch()
 		expect(mockCheckForUpdate).not.toHaveBeenCalled()
 		expect(mockApplyUpdate).not.toHaveBeenCalled()

--- a/src/update/auto-update.test.ts
+++ b/src/update/auto-update.test.ts
@@ -571,6 +571,34 @@ describe("performReExec — re-exec primitive selection", () => {
 		expect(exitSpy).toHaveBeenCalledWith(42)
 	})
 
+	it("uses 128+signal when child is killed by signal (exitCode null)", () => {
+		removeExecve()
+		;(globalThis as unknown as { Bun?: unknown }).Bun = {
+			spawnSync: vi.fn(() => ({ exitCode: null, signalCode: "SIGTERM" })),
+		}
+		const exitSentinel = new Error("__exit__")
+		exitSpy = vi.spyOn(process, "exit").mockImplementation((() => {
+			throw exitSentinel
+		}) as never)
+
+		expect(() => performReExec([], process.env)).toThrow(exitSentinel)
+		expect(exitSpy).toHaveBeenCalledWith(128 + 15) // SIGTERM = 15 → exit 143
+	})
+
+	it("exits with code 1 when signalCode is null and exitCode is null", () => {
+		removeExecve()
+		;(globalThis as unknown as { Bun?: unknown }).Bun = {
+			spawnSync: vi.fn(() => ({ exitCode: null, signalCode: null })),
+		}
+		const exitSentinel = new Error("__exit__")
+		exitSpy = vi.spyOn(process, "exit").mockImplementation((() => {
+			throw exitSentinel
+		}) as never)
+
+		expect(() => performReExec([], process.env)).toThrow(exitSentinel)
+		expect(exitSpy).toHaveBeenCalledWith(1)
+	})
+
 	it("throws ReExecUnavailableError when neither execve nor Bun.spawnSync exists", () => {
 		removeExecve()
 		;(globalThis as unknown as { Bun?: unknown }).Bun = undefined

--- a/src/update/auto-update.test.ts
+++ b/src/update/auto-update.test.ts
@@ -214,8 +214,8 @@ describe("argvHasSkipTrigger — pure function over an argv array", () => {
 		expect(argvHasSkipTrigger(["node", "kimchi", "UPDATE"])).toBe(true)
 	})
 
-	it("matches subcommand appearing as the value of a --flag=value argument", () => {
-		expect(argvHasSkipTrigger(["node", "kimchi", "--some-flag=update"])).toBe(true)
+	it("does NOT treat arbitrary --flag=value as a positional subcommand", () => {
+		expect(argvHasSkipTrigger(["node", "kimchi", "--some-flag=update"])).toBe(false)
 	})
 
 	it("returns false for a plain TUI launch with no skip trigger", () => {

--- a/src/update/auto-update.test.ts
+++ b/src/update/auto-update.test.ts
@@ -30,7 +30,7 @@ vi.mock("./workflow.js", () => ({
 }))
 
 const autoUpdate = await import("./auto-update.js")
-const { maybeAutoUpdateOnLaunch, performReExec, argvHasSkipTrigger } = autoUpdate
+const { maybeAutoUpdateOnLaunch, performReExec, argvHasSkipTrigger, ReExecUnavailableError } = autoUpdate
 
 const originalEnvNoCheck = process.env.KIMCHI_NO_UPDATE_CHECK
 const originalPlatform = process.platform
@@ -248,12 +248,14 @@ describe("maybeAutoUpdateOnLaunch — happy path", () => {
 		expect(mockApplyUpdate).toHaveBeenCalledWith({ tag: "v1.1.0" })
 		expect(execveSpy).toHaveBeenCalledTimes(1)
 		// execve(file, args, env): file is process.execPath; args is
-		// [process.execPath, ...process.argv.slice(1)] — argv[0] re-states
-		// the executable and the rest is the user's original argv.
+		// [process.execPath, ...userArgs] where userArgs is process.argv.slice(2)
+		// — argv[0] re-states the executable, argv[1] (the launcher's own
+		// entry / a /$bunfs/… virtual path) is intentionally dropped, and the
+		// rest is the user's original args.
 		const [file, args, env] = execveSpy?.mock.calls[0] as [string, string[], NodeJS.ProcessEnv]
 		expect(file).toBe(process.execPath)
 		expect(args[0]).toBe(process.execPath)
-		expect(args.slice(1)).toEqual(process.argv.slice(1))
+		expect(args.slice(1)).toEqual(process.argv.slice(2))
 		expect(env).toBe(process.env)
 	})
 
@@ -394,11 +396,125 @@ describe("maybeAutoUpdateOnLaunch — deadline / abort handling", () => {
 	})
 })
 
-describe("performReExec", () => {
-	it("exists and is callable with argv + env", () => {
-		// Sanity: confirm the helper is exported. Calling it directly
-		// would attempt execve and never return on a real Linux runner.
-		// The happy-path tests above cover execve invocation indirectly.
-		expect(typeof performReExec).toBe("function")
+describe("performReExec — re-exec primitive selection", () => {
+	// These tests drive performReExec directly with controlled
+	// process.execve / globalThis.Bun state. beforeEach installs an execve
+	// stub + spy (see top of file); we override per-test as needed and the
+	// global afterEach restores execve. We additionally save/restore
+	// globalThis.Bun and process.exit here.
+	const hadBun = Object.hasOwn(globalThis, "Bun")
+	const originalBun = (globalThis as unknown as { Bun?: unknown }).Bun
+	let exitSpy: MockInstance<(code?: number) => never> | undefined
+
+	afterEach(() => {
+		if (hadBun) (globalThis as unknown as { Bun?: unknown }).Bun = originalBun
+		else (globalThis as unknown as { Bun?: unknown }).Bun = undefined
+		exitSpy?.mockRestore()
+		exitSpy = undefined
+	})
+
+	function removeExecve(): void {
+		// Simulate the Bun-compiled runtime where process.execve is absent.
+		// Restore the beforeEach spy first (it installs a configurable stub via
+		// vi.spyOn, which can leave a non-writable property), then forcibly
+		// redefine the slot as undefined so performReExec's `typeof === "function"`
+		// guard is false.
+		execveSpy?.mockRestore()
+		execveSpy = undefined
+		Object.defineProperty(process, "execve", { value: undefined, writable: true, configurable: true })
+	}
+
+	it("prefers process.execve, passing [execPath, ...userArgs]", () => {
+		// execveSpy (from beforeEach) is a no-op returning undefined, so the
+		// call falls through to the post-execve throw — that's expected.
+		expect(() => performReExec(["--foo", "bar"], process.env)).toThrow(/execve returned unexpectedly/)
+		expect(execveSpy).toHaveBeenCalledTimes(1)
+		const [file, args] = execveSpy?.mock.calls[0] as [string, string[], NodeJS.ProcessEnv]
+		expect(file).toBe(process.execPath)
+		expect(args).toEqual([process.execPath, "--foo", "bar"])
+	})
+
+	it("falls back to Bun.spawnSync when execve is absent, and exits with the child code", () => {
+		removeExecve()
+		const spawnSync = vi.fn((_cmd: readonly string[], _opts: { stdio: string[]; env: unknown }) => ({ exitCode: 0 }))
+		;(globalThis as unknown as { Bun?: unknown }).Bun = { spawnSync }
+		// process.exit really terminates in production (performReExec is typed
+		// `never`); the test mock must also halt control flow, otherwise
+		// execution falls through to the ReExecUnavailableError throw. We make
+		// the mock throw a sentinel to model the non-return.
+		const exitSentinel = new Error("__exit__")
+		exitSpy = vi.spyOn(process, "exit").mockImplementation((() => {
+			throw exitSentinel
+		}) as never)
+
+		expect(() => performReExec(["--foo"], process.env)).toThrow(exitSentinel)
+
+		expect(spawnSync).toHaveBeenCalledTimes(1)
+		const [cmd, opts] = spawnSync.mock.calls[0] as [string[], { stdio: string[]; env: unknown }]
+		expect(cmd).toEqual([process.execPath, "--foo"])
+		expect(opts.stdio).toEqual(["inherit", "inherit", "inherit"])
+		expect(exitSpy).toHaveBeenCalledWith(0)
+	})
+
+	it("propagates the child's non-zero exit code", () => {
+		removeExecve()
+		;(globalThis as unknown as { Bun?: unknown }).Bun = { spawnSync: vi.fn(() => ({ exitCode: 42 })) }
+		const exitSentinel = new Error("__exit__")
+		exitSpy = vi.spyOn(process, "exit").mockImplementation((() => {
+			throw exitSentinel
+		}) as never)
+
+		expect(() => performReExec([], process.env)).toThrow(exitSentinel)
+		expect(exitSpy).toHaveBeenCalledWith(42)
+	})
+
+	it("throws ReExecUnavailableError when neither execve nor Bun.spawnSync exists", () => {
+		removeExecve()
+		;(globalThis as unknown as { Bun?: unknown }).Bun = undefined
+		expect(() => performReExec([], process.env)).toThrow(ReExecUnavailableError)
+	})
+})
+
+describe("maybeAutoUpdateOnLaunch — re-exec unavailable fallback", () => {
+	// When performReExec can't hand off (no execve, no Bun), the binary is
+	// still swapped on disk; maybeAutoUpdateOnLaunch must swallow the
+	// ReExecUnavailableError, log a restart hint, and NOT surface it as an
+	// "unexpected" error.
+	const hadBun = Object.hasOwn(globalThis, "Bun")
+	const originalBun = (globalThis as unknown as { Bun?: unknown }).Bun
+
+	afterEach(() => {
+		if (hadBun) (globalThis as unknown as { Bun?: unknown }).Bun = originalBun
+		else (globalThis as unknown as { Bun?: unknown }).Bun = undefined
+	})
+
+	it("logs a restart hint (not 'unexpected') and resolves when no re-exec primitive exists", async () => {
+		const originalWrite = process.stderr.write.bind(process.stderr)
+		const writeSpy = vi.fn((_chunk: string | Uint8Array, _enc?: unknown, _cb?: unknown) => true)
+		;(process.stderr.write as unknown) = writeSpy
+		try {
+			// Drop execve robustly: the beforeEach spy may leave a non-writable
+			// slot, so redefine rather than assign.
+			Object.defineProperty(process, "execve", { value: undefined, writable: true, configurable: true })
+			;(globalThis as unknown as { Bun?: unknown }).Bun = undefined
+			mockCheckForUpdate.mockResolvedValue({
+				currentVersion: "1.0.0",
+				latestVersion: "1.1.0",
+				tag: "v1.1.0",
+				releaseUrl: "https://example/v1.1.0",
+				hasUpdate: true,
+				cached: false,
+			})
+			mockApplyUpdate.mockResolvedValue({ from: "v1.1.0", to: "v1.1.0" })
+
+			await expect(maybeAutoUpdateOnLaunch()).resolves.toBeUndefined()
+
+			const lines = writeSpy.mock.calls.map((c) => String(c[0])).join("")
+			// Message uses check.latestVersion ("1.1.0"), mirroring the win32 branch.
+			expect(lines).toContain("restart your terminal to use 1.1.0")
+			expect(lines).not.toContain("unexpected")
+		} finally {
+			;(process.stderr.write as unknown) = originalWrite
+		}
 	})
 })

--- a/src/update/auto-update.test.ts
+++ b/src/update/auto-update.test.ts
@@ -1,0 +1,283 @@
+// Tests for src/update/auto-update.ts.
+//
+// Mocks: checkForUpdate, applyUpdate, loadAutoUpdateSetting, isHomebrewInstall.
+// We spy on `process.execve` (the actual syscall) rather than the exported
+// `performReExec` helper. The implementation reads `process.execve` at call
+// time via a cast, so the spy reliably intercepts the call. Spying on the
+// export doesn't work: `maybeAutoUpdateOnLaunch` references `performReExec`
+// via a local lexical binding, not through the module namespace, so a spy
+// on the namespace export is bypassed and the real `execve` runs — replacing
+// the test runner's process on Linux and crashing vitest.
+
+import type { MockInstance } from "vitest"
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
+
+const mockCheckForUpdate = vi.fn()
+const mockApplyUpdate = vi.fn()
+const mockLoadAutoUpdateSetting = vi.fn(() => true)
+const mockIsHomebrewInstall = vi.fn(() => false)
+
+vi.mock("./paths.js", () => ({
+	isHomebrewInstall: mockIsHomebrewInstall,
+	resolveExecutablePath: () => "/fake/kimchi",
+}))
+vi.mock("./settings.js", () => ({ loadAutoUpdateSetting: mockLoadAutoUpdateSetting }))
+vi.mock("./workflow.js", () => ({
+	checkForUpdate: mockCheckForUpdate,
+	applyUpdate: mockApplyUpdate,
+}))
+
+const autoUpdate = await import("./auto-update.js")
+const { maybeAutoUpdateOnLaunch, performReExec, argvHasSkipTrigger } = autoUpdate
+
+const originalEnvNoCheck = process.env.KIMCHI_NO_UPDATE_CHECK
+const originalPlatform = process.platform
+const originalExecve = (process as unknown as { execve?: unknown }).execve
+let execveSpy: MockInstance<(file: string, args: readonly string[], env: NodeJS.ProcessEnv) => never> | undefined
+
+function resetMocks(): void {
+	mockCheckForUpdate.mockReset()
+	mockApplyUpdate.mockReset()
+	mockLoadAutoUpdateSetting.mockReset()
+	mockIsHomebrewInstall.mockReset()
+	mockLoadAutoUpdateSetting.mockReturnValue(true)
+	mockIsHomebrewInstall.mockReturnValue(false)
+	mockCheckForUpdate.mockResolvedValue({
+		currentVersion: "1.0.0",
+		latestVersion: "1.0.0",
+		tag: "v1.0.0",
+		releaseUrl: "",
+		hasUpdate: false,
+		cached: false,
+	})
+}
+
+beforeEach(() => {
+	resetMocks()
+	// biome-ignore lint/performance/noDelete: setting to undefined produces the literal string "undefined", which is truthy and would pollute subsequent tests
+	delete process.env.KIMCHI_NO_UPDATE_CHECK
+	// Default platform: linux (CI). Individual tests can override.
+	Object.defineProperty(process, "platform", { value: "linux", configurable: true })
+
+	// Ensure process.execve exists so vi.spyOn has a target. On Linux it's
+	// a real syscall; on hosts where it isn't defined (some macOS/Windows
+	// builds), install a configurable no-op stub. The spy replaces it with
+	// a mock and mockRestore() puts the original value back.
+	if (typeof (process as unknown as { execve?: unknown }).execve !== "function") {
+		Object.defineProperty(process, "execve", {
+			value: () => {
+				throw new Error("process.execve is not available on this platform")
+			},
+			writable: true,
+			configurable: true,
+		})
+	}
+	execveSpy = vi
+		.spyOn(
+			process as unknown as {
+				execve: (file: string, args: readonly string[], env: NodeJS.ProcessEnv) => never
+			},
+			"execve",
+		)
+		.mockImplementation(() => undefined as never)
+})
+
+afterEach(() => {
+	if (originalEnvNoCheck === undefined) {
+		// biome-ignore lint/performance/noDelete: setting to undefined produces the literal string "undefined", which is truthy and would pollute subsequent tests
+		delete process.env.KIMCHI_NO_UPDATE_CHECK
+	} else process.env.KIMCHI_NO_UPDATE_CHECK = originalEnvNoCheck
+	Object.defineProperty(process, "platform", { value: originalPlatform, configurable: true })
+	execveSpy?.mockRestore()
+	// If the host had no execve to begin with, our Object.defineProperty
+	// stub may linger after mockRestore; clear it so we don't leak between
+	// test files (each runs in its own forked worker, but better safe).
+	if (originalExecve === undefined) {
+		try {
+			;(process as unknown as { execve?: unknown }).execve = undefined
+		} catch {
+			// Some hosts make the property non-configurable; ignore.
+		}
+	}
+})
+
+describe("maybeAutoUpdateOnLaunch — skip gates", () => {
+	it("skips when KIMCHI_NO_UPDATE_CHECK is set", async () => {
+		process.env.KIMCHI_NO_UPDATE_CHECK = "1"
+		await maybeAutoUpdateOnLaunch()
+		expect(mockCheckForUpdate).not.toHaveBeenCalled()
+		expect(mockApplyUpdate).not.toHaveBeenCalled()
+		expect(execveSpy).not.toHaveBeenCalled()
+	})
+
+	it("skips when isHomebrewInstall() returns true", async () => {
+		mockIsHomebrewInstall.mockReturnValue(true)
+		await maybeAutoUpdateOnLaunch()
+		expect(mockCheckForUpdate).not.toHaveBeenCalled()
+		expect(mockApplyUpdate).not.toHaveBeenCalled()
+		expect(execveSpy).not.toHaveBeenCalled()
+	})
+
+	it("skips when loadAutoUpdateSetting() returns false", async () => {
+		mockLoadAutoUpdateSetting.mockReturnValue(false)
+		await maybeAutoUpdateOnLaunch()
+		expect(mockCheckForUpdate).not.toHaveBeenCalled()
+		expect(mockApplyUpdate).not.toHaveBeenCalled()
+		expect(execveSpy).not.toHaveBeenCalled()
+	})
+
+	it("skips when checkForUpdate throws and does not propagate", async () => {
+		mockCheckForUpdate.mockRejectedValue(new Error("network down"))
+		await expect(maybeAutoUpdateOnLaunch()).resolves.toBeUndefined()
+		expect(mockApplyUpdate).not.toHaveBeenCalled()
+		expect(execveSpy).not.toHaveBeenCalled()
+	})
+
+	it("skips when checkForUpdate reports no update", async () => {
+		mockCheckForUpdate.mockResolvedValue({
+			currentVersion: "1.2.3",
+			latestVersion: "1.2.3",
+			tag: "v1.2.3",
+			releaseUrl: "",
+			hasUpdate: false,
+			cached: false,
+		})
+		await maybeAutoUpdateOnLaunch()
+		expect(mockApplyUpdate).not.toHaveBeenCalled()
+		expect(execveSpy).not.toHaveBeenCalled()
+	})
+})
+
+describe("argvHasSkipTrigger — pure function over an argv array", () => {
+	it("returns true when argv[2] is the `update` subcommand", () => {
+		expect(argvHasSkipTrigger(["node", "kimchi", "update"])).toBe(true)
+	})
+
+	it("returns true when argv[2] is the `setup` subcommand", () => {
+		expect(argvHasSkipTrigger(["node", "kimchi", "setup"])).toBe(true)
+	})
+
+	it("returns true when argv[2] is the `mcp` subcommand", () => {
+		expect(argvHasSkipTrigger(["node", "kimchi", "mcp"])).toBe(true)
+	})
+
+	it("returns true when argv[2] is the `login` subcommand", () => {
+		expect(argvHasSkipTrigger(["node", "kimchi", "login"])).toBe(true)
+	})
+
+	it("returns true when argv[2] is the `install` subcommand", () => {
+		expect(argvHasSkipTrigger(["node", "kimchi", "install"])).toBe(true)
+	})
+
+	it("returns true when argv contains --version", () => {
+		expect(argvHasSkipTrigger(["node", "kimchi", "--version"])).toBe(true)
+	})
+
+	it("returns true when argv contains -v", () => {
+		expect(argvHasSkipTrigger(["node", "kimchi", "-v"])).toBe(true)
+	})
+
+	it("returns true when argv contains --help", () => {
+		expect(argvHasSkipTrigger(["node", "kimchi", "--help"])).toBe(true)
+	})
+
+	it("returns true when argv contains -h", () => {
+		expect(argvHasSkipTrigger(["node", "kimchi", "-h"])).toBe(true)
+	})
+
+	it("returns true when argv contains --no-auto-update", () => {
+		expect(argvHasSkipTrigger(["node", "kimchi", "--no-auto-update"])).toBe(true)
+	})
+
+	it("matches subcommands case-insensitively", () => {
+		expect(argvHasSkipTrigger(["node", "kimchi", "UPDATE"])).toBe(true)
+	})
+
+	it("matches subcommand appearing as the value of a --flag=value argument", () => {
+		expect(argvHasSkipTrigger(["node", "kimchi", "--some-flag=update"])).toBe(true)
+	})
+
+	it("returns false for a plain TUI launch with no skip trigger", () => {
+		expect(argvHasSkipTrigger(["node", "kimchi"])).toBe(false)
+	})
+
+	it("returns false for a TUI launch with unrelated flags", () => {
+		expect(argvHasSkipTrigger(["node", "kimchi", "--some-tui-flag", "value"])).toBe(false)
+	})
+
+	it("returns false for an unrelated --flag=value argument", () => {
+		expect(argvHasSkipTrigger(["node", "kimchi", "--command=serve"])).toBe(false)
+	})
+})
+
+describe("maybeAutoUpdateOnLaunch — happy path", () => {
+	it("applies the update and re-execs on linux", async () => {
+		mockCheckForUpdate.mockResolvedValue({
+			currentVersion: "1.0.0",
+			latestVersion: "1.1.0",
+			tag: "v1.1.0",
+			releaseUrl: "https://example/v1.1.0",
+			hasUpdate: true,
+			cached: false,
+		})
+		mockApplyUpdate.mockResolvedValue({ from: "v1.1.0", to: "v1.1.0" })
+
+		await maybeAutoUpdateOnLaunch()
+
+		expect(mockApplyUpdate).toHaveBeenCalledWith({ tag: "v1.1.0" })
+		expect(execveSpy).toHaveBeenCalledTimes(1)
+		// execve(file, args, env): file is process.execPath; args is
+		// [process.execPath, ...process.argv.slice(1)] — argv[0] re-states
+		// the executable and the rest is the user's original argv.
+		const [file, args, env] = execveSpy?.mock.calls[0] as [string, string[], NodeJS.ProcessEnv]
+		expect(file).toBe(process.execPath)
+		expect(args[0]).toBe(process.execPath)
+		expect(args.slice(1)).toEqual(process.argv.slice(1))
+		expect(env).toBe(process.env)
+	})
+
+	it("does not re-exec and does not throw when applyUpdate fails", async () => {
+		mockCheckForUpdate.mockResolvedValue({
+			currentVersion: "1.0.0",
+			latestVersion: "1.1.0",
+			tag: "v1.1.0",
+			releaseUrl: "",
+			hasUpdate: true,
+			cached: false,
+		})
+		mockApplyUpdate.mockRejectedValue(new Error("smoke test failed"))
+
+		await expect(maybeAutoUpdateOnLaunch()).resolves.toBeUndefined()
+		expect(execveSpy).not.toHaveBeenCalled()
+	})
+
+	// Windows: applyUpdate already rotates kimchi.exe → kimchi.exe.old in
+	// place, so we deliberately do NOT re-exec — just notify the user.
+	// (We can't run the literal Windows branch on a non-win32 host, but
+	// the skip-re-exec contract is what matters; the linux test above
+	// covers the linux branch's re-exec call.)
+	it("does not re-exec on win32 — applyUpdate's in-place rotation suffices", async () => {
+		Object.defineProperty(process, "platform", { value: "win32", configurable: true })
+		mockCheckForUpdate.mockResolvedValue({
+			currentVersion: "1.0.0",
+			latestVersion: "1.1.0",
+			tag: "v1.1.0",
+			releaseUrl: "",
+			hasUpdate: true,
+			cached: false,
+		})
+		mockApplyUpdate.mockResolvedValue({ from: "v1.1.0", to: "v1.1.0" })
+
+		await expect(maybeAutoUpdateOnLaunch()).resolves.toBeUndefined()
+		expect(execveSpy).not.toHaveBeenCalled()
+	})
+})
+
+describe("performReExec", () => {
+	it("exists and is callable with argv + env", () => {
+		// Sanity: confirm the helper is exported. Calling it directly
+		// would attempt execve and never return on a real Linux runner.
+		// The happy-path tests above cover execve invocation indirectly.
+		expect(typeof performReExec).toBe("function")
+	})
+})

--- a/src/update/auto-update.test.ts
+++ b/src/update/auto-update.test.ts
@@ -16,6 +16,7 @@ const mockCheckForUpdate = vi.fn()
 const mockApplyUpdate = vi.fn()
 const mockLoadAutoUpdateSetting = vi.fn(() => true)
 const mockIsHomebrewInstall = vi.fn(() => false)
+const mockParseCanarySha7 = vi.fn(() => null as string | null)
 
 vi.mock("./paths.js", () => ({
 	isHomebrewInstall: mockIsHomebrewInstall,
@@ -25,6 +26,7 @@ vi.mock("./settings.js", () => ({ loadAutoUpdateSetting: mockLoadAutoUpdateSetti
 vi.mock("./workflow.js", () => ({
 	checkForUpdate: mockCheckForUpdate,
 	applyUpdate: mockApplyUpdate,
+	parseCanarySha7: mockParseCanarySha7,
 }))
 
 const autoUpdate = await import("./auto-update.js")
@@ -40,8 +42,10 @@ function resetMocks(): void {
 	mockApplyUpdate.mockReset()
 	mockLoadAutoUpdateSetting.mockReset()
 	mockIsHomebrewInstall.mockReset()
+	mockParseCanarySha7.mockReset()
 	mockLoadAutoUpdateSetting.mockReturnValue(true)
 	mockIsHomebrewInstall.mockReturnValue(false)
+	mockParseCanarySha7.mockReturnValue(null)
 	mockCheckForUpdate.mockResolvedValue({
 		currentVersion: "1.0.0",
 		latestVersion: "1.0.0",
@@ -113,6 +117,23 @@ describe("maybeAutoUpdateOnLaunch — skip gates", () => {
 	it("skips when isHomebrewInstall() returns true", async () => {
 		mockIsHomebrewInstall.mockReturnValue(true)
 		await maybeAutoUpdateOnLaunch()
+		expect(mockCheckForUpdate).not.toHaveBeenCalled()
+		expect(mockApplyUpdate).not.toHaveBeenCalled()
+		expect(execveSpy).not.toHaveBeenCalled()
+	})
+
+	it("skips when running on a canary build", async () => {
+		mockParseCanarySha7.mockReturnValue("abc1234")
+		await maybeAutoUpdateOnLaunch()
+		expect(mockCheckForUpdate).not.toHaveBeenCalled()
+		expect(mockApplyUpdate).not.toHaveBeenCalled()
+		expect(execveSpy).not.toHaveBeenCalled()
+	})
+
+	it("skips when caller signal is already aborted", async () => {
+		const controller = new AbortController()
+		controller.abort()
+		await maybeAutoUpdateOnLaunch({ signal: controller.signal })
 		expect(mockCheckForUpdate).not.toHaveBeenCalled()
 		expect(mockApplyUpdate).not.toHaveBeenCalled()
 		expect(execveSpy).not.toHaveBeenCalled()
@@ -270,6 +291,106 @@ describe("maybeAutoUpdateOnLaunch — happy path", () => {
 
 		await expect(maybeAutoUpdateOnLaunch()).resolves.toBeUndefined()
 		expect(execveSpy).not.toHaveBeenCalled()
+	})
+})
+
+describe("maybeAutoUpdateOnLaunch — deadline / abort handling", () => {
+	function makeStderrSpy() {
+		const originalWrite = process.stderr.write.bind(process.stderr)
+		const spy = vi.fn((_chunk: string | Uint8Array, _enc?: unknown, _cb?: unknown) => true)
+		;(process.stderr.write as unknown) = spy
+		return {
+			spy,
+			restore: () => {
+				;(process.stderr.write as unknown) = originalWrite
+			},
+			getLines: () => spy.mock.calls.map((c) => String(c[0])).join(""),
+		}
+	}
+
+	it("skips re-exec when signal aborts during checkForUpdate", async () => {
+		const controller = new AbortController()
+		mockCheckForUpdate.mockImplementation(async () => {
+			controller.abort()
+			return {
+				currentVersion: "1.0.0",
+				latestVersion: "1.1.0",
+				tag: "v1.1.0",
+				releaseUrl: "https://example/v1.1.0",
+				hasUpdate: true,
+				cached: false,
+			}
+		})
+
+		await expect(maybeAutoUpdateOnLaunch({ signal: controller.signal })).resolves.toBeUndefined()
+		expect(mockApplyUpdate).not.toHaveBeenCalled()
+		expect(execveSpy).not.toHaveBeenCalled()
+	})
+
+	it("skips re-exec when signal aborts during applyUpdate", async () => {
+		const controller = new AbortController()
+		mockCheckForUpdate.mockResolvedValue({
+			currentVersion: "1.0.0",
+			latestVersion: "1.1.0",
+			tag: "v1.1.0",
+			releaseUrl: "https://example/v1.1.0",
+			hasUpdate: true,
+			cached: false,
+		})
+		mockApplyUpdate.mockImplementation(async () => {
+			controller.abort()
+			return { from: "v1.1.0", to: "v1.1.0" }
+		})
+
+		await expect(maybeAutoUpdateOnLaunch({ signal: controller.signal })).resolves.toBeUndefined()
+		expect(mockApplyUpdate).toHaveBeenCalledOnce()
+		expect(execveSpy).not.toHaveBeenCalled()
+	})
+
+	it("logs an audit line with tag + releaseUrl before applying", async () => {
+		const stderr = makeStderrSpy()
+		try {
+			mockCheckForUpdate.mockResolvedValue({
+				currentVersion: "1.0.0",
+				latestVersion: "1.1.0",
+				tag: "v1.1.0",
+				releaseUrl: "https://github.com/getkimchi/kimchi/releases/tag/v1.1.0",
+				hasUpdate: true,
+				cached: false,
+			})
+			mockApplyUpdate.mockResolvedValue({ from: "v1.1.0", to: "v1.1.0" })
+
+			await maybeAutoUpdateOnLaunch()
+
+			const lines = stderr.getLines()
+			expect(lines).toContain(
+				"[kimchi-auto-update] applying update v1.1.0 from https://github.com/getkimchi/kimchi/releases/tag/v1.1.0\n",
+			)
+		} finally {
+			stderr.restore()
+		}
+	})
+
+	it("logs `<no url>` in the audit line when releaseUrl is empty", async () => {
+		const stderr = makeStderrSpy()
+		try {
+			mockCheckForUpdate.mockResolvedValue({
+				currentVersion: "1.0.0",
+				latestVersion: "1.1.0",
+				tag: "v1.1.0",
+				releaseUrl: "",
+				hasUpdate: true,
+				cached: false,
+			})
+			mockApplyUpdate.mockResolvedValue({ from: "v1.1.0", to: "v1.1.0" })
+
+			await maybeAutoUpdateOnLaunch()
+
+			const lines = stderr.getLines()
+			expect(lines).toContain("[kimchi-auto-update] applying update v1.1.0 from <no url>\n")
+		} finally {
+			stderr.restore()
+		}
 	})
 })
 

--- a/src/update/auto-update.ts
+++ b/src/update/auto-update.ts
@@ -53,6 +53,27 @@ export function isNonInteractiveLaunch(argv: readonly string[]): boolean {
 	return false
 }
 
+/** Race a promise against a timeout. Returns the promise's result if it
+ *  resolves before `ms` elapses; rejects with a TimeoutError otherwise.
+ *  Used to cap the checkForUpdate phase without abandoning applyUpdate. */
+class TimeoutError extends Error {
+	constructor() {
+		super("auto-update check timed out")
+		this.name = "TimeoutError"
+	}
+}
+
+function raceWithTimeout<T>(promise: Promise<T>, ms: number): Promise<T> {
+	let timer: ReturnType<typeof setTimeout> | undefined
+	const timeout = new Promise<never>((_, reject) => {
+		timer = setTimeout(() => reject(new TimeoutError()), ms)
+		;(timer as { unref?: () => void }).unref?.()
+	})
+	return Promise.race([promise, timeout]).finally(() => {
+		if (timer) clearTimeout(timer)
+	})
+}
+
 function warn(message: string): void {
 	process.stderr.write(`${LOG_PREFIX} ${message}\n`)
 }
@@ -167,16 +188,17 @@ export function argvHasSkipTrigger(argv: readonly string[]): boolean {
 	return false
 }
 
-/** Default startup budget for the auto-update check. The caller (entry.ts)
- *  races the call against this deadline via `AbortSignal`; we check it
- *  after each await and skip the re-exec swap if the deadline has passed,
- *  so a slow network never blocks the user past the budget. */
+/** Default startup budget for the update *check* phase. Only
+ *  `checkForUpdate` is raced against this deadline; once we commit to
+ *  `applyUpdate` we await it fully so the install is never torn down
+ *  mid-swap by a timeout. This prevents cli.js from booting while
+ *  `applyUpdate` is still mutating files on disk. */
 const AUTO_UPDATE_DEFAULT_TIMEOUT_MS = 5_000
 
 export interface MaybeAutoUpdateOnLaunchOptions {
-	/** When the signal aborts, the function bails out at the next checkpoint
-	 *  without performing the re-exec swap. Used by entry.ts to cap startup
-	 *  time even when the network is slow. */
+	/** Optional external signal (e.g. from entry.ts). Checked at
+	 *  checkpoints before applyUpdate starts; ignored once the install
+	 *  has committed. */
 	signal?: AbortSignal
 }
 
@@ -233,9 +255,15 @@ export async function maybeAutoUpdateOnLaunch(opts: MaybeAutoUpdateOnLaunchOptio
 		if (!loadAutoUpdateSetting()) return
 		if (opts.signal?.aborted) return
 
+		// Race only the *check* phase against the deadline. Once we commit
+		// to applyUpdate below, we await it fully — a timeout there would
+		// leave the install half-finished with cli.js booting concurrently.
 		let check: Awaited<ReturnType<typeof checkForUpdate>>
 		try {
-			check = await checkForUpdate({ currentVersion: getVersion(), skipCache: true, canary: false })
+			check = await raceWithTimeout(
+				checkForUpdate({ currentVersion: getVersion(), skipCache: true, canary: false }),
+				AUTO_UPDATE_DEFAULT_TIMEOUT_MS,
+			)
 		} catch (err) {
 			warn(`update check failed: ${(err as Error).message}`)
 			return
@@ -246,23 +274,14 @@ export async function maybeAutoUpdateOnLaunch(opts: MaybeAutoUpdateOnLaunchOptio
 		}
 		if (!check.hasUpdate) return
 
-		// Audit log: every auto-update attempt is recorded with the tag and
-		// release URL before the binary is downloaded. Checksum verification
-		// happens inside applyUpdate; this line is the operator-visible trail.
+		// Commit point: from here on we await applyUpdate fully. No external
+		// Promise.race can abandon it — the install must complete before
+		// cli.js boots.
 		warn(`applying update ${check.tag} from ${check.releaseUrl || "<no url>"}`)
 		try {
 			await applyUpdate({ tag: check.tag })
 		} catch (err) {
 			warn(`update apply failed: ${(err as Error).message}`)
-			return
-		}
-		if (opts.signal?.aborted) {
-			// Update is already on disk via atomicInstall's .old rotation on
-			// Windows, or staged for next launch on Linux/macOS (no rename
-			// happens until the user runs `kimchi update`). Bail without
-			// re-exec — the user's UI must not be torn down after they've
-			// already seen it.
-			warn(`update ${check.tag} applied but deadline exceeded; restart to use the new version`)
 			return
 		}
 

--- a/src/update/auto-update.ts
+++ b/src/update/auto-update.ts
@@ -14,8 +14,11 @@ import { applyUpdate, checkForUpdate, parseCanarySha7 } from "./workflow.js"
 const LOG_PREFIX = "[kimchi-auto-update]"
 
 // Subcommands that suppress auto-update so we never recurse into
-// `kimchi update --force` etc. Compared case-insensitively at argv[2] or as
-// the value of a `--flag=value` argument.
+// `kimchi update --force` etc. Compared case-insensitively only at the
+// positional argv[2] slot. Scanning arbitrary `--flag=value` arguments
+// would suppress auto-update for unrelated user flags that happen to
+// contain these strings (e.g. `--tag=update`); no real CLI flag takes a
+// skip-subcommand value today.
 const SKIP_SUBCOMMANDS = new Set(["update", "setup", "mcp", "login", "install"])
 
 // Pure flags that suppress auto-update. Checked anywhere in argv.
@@ -64,14 +67,6 @@ export function argvHasSkipTrigger(argv: readonly string[]): boolean {
 	// Positional subcommand at argv[2] (case-insensitive).
 	const first = argv[2]
 	if (first !== undefined && SKIP_SUBCOMMANDS.has(first.toLowerCase())) return true
-	// `--flag=<subcommand>` form — e.g. `--command=update`.
-	for (const arg of argv) {
-		if (!arg.startsWith("--")) continue
-		const eq = arg.indexOf("=")
-		if (eq <= 0) continue
-		const value = arg.slice(eq + 1).toLowerCase()
-		if (SKIP_SUBCOMMANDS.has(value)) return true
-	}
 	return false
 }
 

--- a/src/update/auto-update.ts
+++ b/src/update/auto-update.ts
@@ -7,6 +7,7 @@
 // call in its own try/catch but we also catch internally as defense-in-depth.
 
 import { basename } from "node:path"
+import { type CliMode, getCliModeArg, hasExportFlag, hasPrintFlag, PROTOCOL_MODES } from "../cli-modes.js"
 import { getVersion } from "../utils.js"
 import { isHomebrewInstall } from "./paths.js"
 import { loadAutoUpdateSetting } from "./settings.js"
@@ -25,32 +26,19 @@ const SKIP_SUBCOMMANDS = new Set(["update", "setup", "mcp", "login", "install"])
 // Pure flags that suppress auto-update. Checked anywhere in argv.
 const SKIP_FLAGS = new Set(["--no-auto-update", "--version", "-v", "--help", "-h"])
 
-// Non-interactive CLI modes where an update/re-exec before startup would
-// corrupt the protocol stream or surprise external clients. Mirrors the
-// logic in cli-args.ts:isProtocolOrPrintMode but stays self-contained so
-// auto-update.ts doesn't pull pi-coding-agent into the early import chain
-// (entry.ts dynamically imports this module before cli.js).
-const NON_INTERACTIVE_MODES = new Set(["json", "rpc", "acp"])
+// Re-exports for test files that import from this module.
+export { type CliMode, getCliModeArg, hasExportFlag, hasPrintFlag, PROTOCOL_MODES } from "../cli-modes.js"
 
 /** Return true when argv selects a non-interactive mode (ACP/JSON/RPC/print/
  *  export). In those modes stdout/stderr belong to the caller and a re-exec
- *  mid-startup would corrupt the protocol stream or break scripts. */
+ *  mid-startup would corrupt the protocol stream or break scripts.
+ *
+ *  Broader than cli-args.ts:isProtocolOrPrintMode: also skips `--export`,
+ *  which writes to a file and exits — a re-exec there would surprise the
+ *  caller just as much as in protocol modes. */
 export function isNonInteractiveLaunch(argv: readonly string[]): boolean {
-	// --mode=<value> or --mode <value>
-	for (let i = 0; i < argv.length; i += 1) {
-		const arg = argv[i]
-		if (arg === "--mode" && i + 1 < argv.length) {
-			if (NON_INTERACTIVE_MODES.has(argv[i + 1])) return true
-		}
-		if (arg.startsWith("--mode=")) {
-			if (NON_INTERACTIVE_MODES.has(arg.slice("--mode=".length))) return true
-		}
-	}
-	// --print / -p: piped output mode
-	if (argv.includes("--print") || argv.includes("-p")) return true
-	// --export: writes to a file and exits
-	if (argv.includes("--export") || argv.some((a) => a.startsWith("--export="))) return true
-	return false
+	const mode = getCliModeArg(argv)
+	return (mode !== undefined && PROTOCOL_MODES.has(mode as CliMode)) || hasPrintFlag(argv) || hasExportFlag(argv)
 }
 
 /** Race a promise against a timeout. Returns the promise's result if it

--- a/src/update/auto-update.ts
+++ b/src/update/auto-update.ts
@@ -129,12 +129,12 @@ export interface MaybeAutoUpdateOnLaunchOptions {
  *
  * Skipped when ANY of these are true:
  *   - KIMCHI_NO_UPDATE_CHECK is set
+ *   - argv contains a subcommand (`update`/`setup`/`mcp`/`login`/`install`)
+ *   - argv contains `--no-auto-update`, `--version`, `-v`, `--help`, `-h`
  *   - isHomebrewInstall() returns true
  *   - running on a canary build (canary users stay on the canary track;
  *     currency is checked via `kimchi update --canary`)
  *   - loadAutoUpdateSetting() returns false
- *   - argv contains a subcommand (`update`/`setup`/`mcp`/`login`/`install`)
- *   - argv contains `--no-auto-update`, `--version`, `-v`, `--help`, `-h`
  *   - checkForUpdate throws or reports no update
  *   - applyUpdate throws (network, checksum, smoke-test failure)
  *   - opts.signal is already aborted (caller's deadline has passed)
@@ -155,10 +155,10 @@ export interface MaybeAutoUpdateOnLaunchOptions {
 export async function maybeAutoUpdateOnLaunch(opts: MaybeAutoUpdateOnLaunchOptions = {}): Promise<void> {
 	try {
 		if (process.env.KIMCHI_NO_UPDATE_CHECK) return
+		if (argvHasSkipTrigger(process.argv)) return
 		if (isHomebrewInstall()) return
 		if (parseCanarySha7(getVersion()) !== null) return
 		if (!loadAutoUpdateSetting()) return
-		if (argvHasSkipTrigger(process.argv)) return
 		if (opts.signal?.aborted) return
 
 		let check: Awaited<ReturnType<typeof checkForUpdate>>

--- a/src/update/auto-update.ts
+++ b/src/update/auto-update.ts
@@ -112,7 +112,15 @@ export function performReExec(userArgs: readonly string[], env: NodeJS.ProcessEn
 			env,
 		})
 		// Mirror the child's exit so the terminal sees the same status.
-		process.exit(result.exitCode ?? 0)
+		// When the child is killed by a signal, Bun reports exitCode as null
+		// and a signalCode string (e.g. "SIGTERM"). Coalescing null to 0 would
+		// mask the failure — use 128+signal-number (the POSIX convention) so
+		// the shell sees a non-zero exit matching the child's termination.
+		if (result.exitCode !== null) {
+			process.exit(result.exitCode)
+		}
+		const signalNum = result.signalCode ? SIGNAL_TO_NUM[result.signalCode] : undefined
+		process.exit(signalNum !== undefined ? 128 + signalNum : 1)
 	}
 
 	throw new ReExecUnavailableError()
@@ -123,7 +131,27 @@ export function performReExec(userArgs: readonly string[], env: NodeJS.ProcessEn
 type BunSpawnSync = (
 	cmd: readonly string[],
 	opts: { stdio: [string, string, string]; env: NodeJS.ProcessEnv },
-) => { exitCode: number | null }
+) => { exitCode: number | null; signalCode?: string | null }
+
+/** Map common signal names to their POSIX numbers so we can derive the
+ *  conventional 128+signal exit code when Bun reports exitCode as null. */
+const SIGNAL_TO_NUM: Record<string, number> = {
+	SIGHUP: 1,
+	SIGINT: 2,
+	SIGQUIT: 3,
+	SIGILL: 4,
+	SIGTRAP: 5,
+	SIGABRT: 6,
+	SIGBUS: 7,
+	SIGFPE: 8,
+	SIGKILL: 9,
+	SIGUSR1: 10,
+	SIGSEGV: 11,
+	SIGUSR2: 12,
+	SIGPIPE: 13,
+	SIGALRM: 14,
+	SIGTERM: 15,
+}
 
 /** Return true when any argv token should suppress auto-update. Exported so
  *  tests can drive it without mutating the worker's `process.argv` (vitest's

--- a/src/update/auto-update.ts
+++ b/src/update/auto-update.ts
@@ -9,7 +9,7 @@
 import { getVersion } from "../utils.js"
 import { isHomebrewInstall } from "./paths.js"
 import { loadAutoUpdateSetting } from "./settings.js"
-import { applyUpdate, checkForUpdate } from "./workflow.js"
+import { applyUpdate, checkForUpdate, parseCanarySha7 } from "./workflow.js"
 
 const LOG_PREFIX = "[kimchi-auto-update]"
 
@@ -75,6 +75,19 @@ export function argvHasSkipTrigger(argv: readonly string[]): boolean {
 	return false
 }
 
+/** Default startup budget for the auto-update check. The caller (entry.ts)
+ *  races the call against this deadline via `AbortSignal`; we check it
+ *  after each await and skip the re-exec swap if the deadline has passed,
+ *  so a slow network never blocks the user past the budget. */
+const AUTO_UPDATE_DEFAULT_TIMEOUT_MS = 5_000
+
+export interface MaybeAutoUpdateOnLaunchOptions {
+	/** When the signal aborts, the function bails out at the next checkpoint
+	 *  without performing the re-exec swap. Used by entry.ts to cap startup
+	 *  time even when the network is slow. */
+	signal?: AbortSignal
+}
+
 /**
  * Decide whether to auto-update on launch and, if so, run the swap and
  * re-exec into the new binary.
@@ -82,11 +95,14 @@ export function argvHasSkipTrigger(argv: readonly string[]): boolean {
  * Skipped when ANY of these are true:
  *   - KIMCHI_NO_UPDATE_CHECK is set
  *   - isHomebrewInstall() returns true
+ *   - running on a canary build (canary users stay on the canary track;
+ *     currency is checked via `kimchi update --canary`)
  *   - loadAutoUpdateSetting() returns false
  *   - argv contains a subcommand (`update`/`setup`/`mcp`/`login`/`install`)
  *   - argv contains `--no-auto-update`, `--version`, `-v`, `--help`, `-h`
  *   - checkForUpdate throws or reports no update
  *   - applyUpdate throws (network, checksum, smoke-test failure)
+ *   - opts.signal is already aborted (caller's deadline has passed)
  *
  * On success (Linux/macOS): re-exec into the new binary.
  * On success (Windows): `atomicInstall` rotates `kimchi.exe` → `kimchi.exe.old`
@@ -98,12 +114,14 @@ export function argvHasSkipTrigger(argv: readonly string[]): boolean {
  *
  * Never throws.
  */
-export async function maybeAutoUpdateOnLaunch(): Promise<void> {
+export async function maybeAutoUpdateOnLaunch(opts: MaybeAutoUpdateOnLaunchOptions = {}): Promise<void> {
 	try {
 		if (process.env.KIMCHI_NO_UPDATE_CHECK) return
 		if (isHomebrewInstall()) return
+		if (parseCanarySha7(getVersion()) !== null) return
 		if (!loadAutoUpdateSetting()) return
 		if (argvHasSkipTrigger(process.argv)) return
+		if (opts.signal?.aborted) return
 
 		let check: Awaited<ReturnType<typeof checkForUpdate>>
 		try {
@@ -112,12 +130,29 @@ export async function maybeAutoUpdateOnLaunch(): Promise<void> {
 			warn(`update check failed: ${(err as Error).message}`)
 			return
 		}
+		if (opts.signal?.aborted) {
+			warn("deadline exceeded after update check; skipping auto-update on this launch")
+			return
+		}
 		if (!check.hasUpdate) return
 
+		// Audit log: every auto-update attempt is recorded with the tag and
+		// release URL before the binary is downloaded. Checksum verification
+		// happens inside applyUpdate; this line is the operator-visible trail.
+		warn(`applying update ${check.tag} from ${check.releaseUrl || "<no url>"}`)
 		try {
 			await applyUpdate({ tag: check.tag })
 		} catch (err) {
 			warn(`update apply failed: ${(err as Error).message}`)
+			return
+		}
+		if (opts.signal?.aborted) {
+			// Update is already on disk via atomicInstall's .old rotation on
+			// Windows, or staged for next launch on Linux/macOS (no rename
+			// happens until the user runs `kimchi update`). Bail without
+			// re-exec — the user's UI must not be torn down after they've
+			// already seen it.
+			warn(`update ${check.tag} applied but deadline exceeded; restart to use the new version`)
 			return
 		}
 
@@ -138,3 +173,7 @@ export async function maybeAutoUpdateOnLaunch(): Promise<void> {
 		warn(`unexpected: ${(err as Error).message}`)
 	}
 }
+
+// Re-exported for entry.ts so the timeout stays co-located with the module
+// it gates. Not part of the public API.
+export const DEFAULT_AUTO_UPDATE_TIMEOUT_MS = AUTO_UPDATE_DEFAULT_TIMEOUT_MS

--- a/src/update/auto-update.ts
+++ b/src/update/auto-update.ts
@@ -1,0 +1,140 @@
+// On-launch auto-update: decide whether to swap the binary in the background
+// and re-exec into the new version before any UI loads. See Phase 2 of
+// .kimchi/docs/auto-update-plan.md for the full decision matrix.
+//
+// Failure philosophy: any error path falls through to normal launch on the
+// current version. We never throw out of this module — entry.ts wraps the
+// call in its own try/catch but we also catch internally as defense-in-depth.
+
+import { getVersion } from "../utils.js"
+import { isHomebrewInstall } from "./paths.js"
+import { loadAutoUpdateSetting } from "./settings.js"
+import { applyUpdate, checkForUpdate } from "./workflow.js"
+
+const LOG_PREFIX = "[kimchi-auto-update]"
+
+// Subcommands that suppress auto-update so we never recurse into
+// `kimchi update --force` etc. Compared case-insensitively at argv[2] or as
+// the value of a `--flag=value` argument.
+const SKIP_SUBCOMMANDS = new Set(["update", "setup", "mcp", "login", "install"])
+
+// Pure flags that suppress auto-update. Checked anywhere in argv.
+const SKIP_FLAGS = new Set(["--no-auto-update", "--version", "-v", "--help", "-h"])
+
+function warn(message: string): void {
+	process.stderr.write(`${LOG_PREFIX} ${message}\n`)
+}
+
+/**
+ * Replace the running process with the same binary at `process.execPath`
+ * using the supplied argv and env. Linux/macOS only.
+ *
+ * `process.execve` is a Node.js extension not in @types/node — we cast
+ * through `unknown` to keep the call typed without an ambient declaration.
+ *
+ * Exported so tests can spy on it. Production callers should invoke
+ * `maybeAutoUpdateOnLaunch`, which gates platform + applies the update
+ * first.
+ */
+export function performReExec(argv: readonly string[], env: NodeJS.ProcessEnv): never {
+	const execve = (
+		process as unknown as {
+			execve?: (file: string, args: readonly string[], env: NodeJS.ProcessEnv) => never
+		}
+	).execve
+	if (typeof execve !== "function") {
+		// Unreachable in production: maybeAutoUpdateOnLaunch short-circuits
+		// on win32 before reaching here. Tests that stub execve via this
+		// helper will replace it with a spy and never fall through.
+		throw new Error("process.execve is not available on this platform")
+	}
+	execve(process.execPath, argv, env)
+	// execve does not return on success.
+	throw new Error("process.execve returned unexpectedly")
+}
+
+/** Return true when any argv token should suppress auto-update. Exported so
+ *  tests can drive it without mutating the worker's `process.argv` (vitest's
+ *  worker harness reads it at startup and corrupts state if it's replaced). */
+export function argvHasSkipTrigger(argv: readonly string[]): boolean {
+	// Pure flags anywhere in argv.
+	for (const arg of argv) {
+		if (SKIP_FLAGS.has(arg)) return true
+	}
+	// Positional subcommand at argv[2] (case-insensitive).
+	const first = argv[2]
+	if (first !== undefined && SKIP_SUBCOMMANDS.has(first.toLowerCase())) return true
+	// `--flag=<subcommand>` form — e.g. `--command=update`.
+	for (const arg of argv) {
+		if (!arg.startsWith("--")) continue
+		const eq = arg.indexOf("=")
+		if (eq <= 0) continue
+		const value = arg.slice(eq + 1).toLowerCase()
+		if (SKIP_SUBCOMMANDS.has(value)) return true
+	}
+	return false
+}
+
+/**
+ * Decide whether to auto-update on launch and, if so, run the swap and
+ * re-exec into the new binary.
+ *
+ * Skipped when ANY of these are true:
+ *   - KIMCHI_NO_UPDATE_CHECK is set
+ *   - isHomebrewInstall() returns true
+ *   - loadAutoUpdateSetting() returns false
+ *   - argv contains a subcommand (`update`/`setup`/`mcp`/`login`/`install`)
+ *   - argv contains `--no-auto-update`, `--version`, `-v`, `--help`, `-h`
+ *   - checkForUpdate throws or reports no update
+ *   - applyUpdate throws (network, checksum, smoke-test failure)
+ *
+ * On success (Linux/macOS): re-exec into the new binary.
+ * On success (Windows): `atomicInstall` rotates `kimchi.exe` → `kimchi.exe.old`
+ * in-place, so the current run continues on the (still-current) binary; the
+ * user's next terminal relaunch picks up the new version. We log a one-line
+ * note and return.
+ *
+ * On any error: log a single-line stderr warning and return.
+ *
+ * Never throws.
+ */
+export async function maybeAutoUpdateOnLaunch(): Promise<void> {
+	try {
+		if (process.env.KIMCHI_NO_UPDATE_CHECK) return
+		if (isHomebrewInstall()) return
+		if (!loadAutoUpdateSetting()) return
+		if (argvHasSkipTrigger(process.argv)) return
+
+		let check: Awaited<ReturnType<typeof checkForUpdate>>
+		try {
+			check = await checkForUpdate({ currentVersion: getVersion(), skipCache: true, canary: false })
+		} catch (err) {
+			warn(`update check failed: ${(err as Error).message}`)
+			return
+		}
+		if (!check.hasUpdate) return
+
+		try {
+			await applyUpdate({ tag: check.tag })
+		} catch (err) {
+			warn(`update apply failed: ${(err as Error).message}`)
+			return
+		}
+
+		if (process.platform === "win32") {
+			// No re-exec on Windows: the swap is in-place via .old rotation.
+			warn(`Update installed; restart your terminal to use ${check.latestVersion}.`)
+			return
+		}
+
+		// argv[0] is the same script entry the current process was launched
+		// with. process.argv.slice(1) gives us exactly that — drop the
+		// leading "node" or "/path/to/kimchi" and keep the user args.
+		performReExec([process.execPath, ...process.argv.slice(1)], process.env)
+	} catch (err) {
+		// Defense in depth — should be unreachable given the inner
+		// try/catches, but if any helper throws unexpectedly we still
+		// fall through to a normal launch.
+		warn(`unexpected: ${(err as Error).message}`)
+	}
+}

--- a/src/update/auto-update.ts
+++ b/src/update/auto-update.ts
@@ -28,33 +28,73 @@ function warn(message: string): void {
 	process.stderr.write(`${LOG_PREFIX} ${message}\n`)
 }
 
+/** Thrown by performReExec when no re-exec primitive is available. Callers
+ *  treat this as "binary swapped on disk, but couldn't hand off in-process"
+ *  and fall back to a "restart your terminal" message instead of erroring. */
+export class ReExecUnavailableError extends Error {
+	constructor() {
+		super("no re-exec primitive available (process.execve and Bun.spawnSync both missing)")
+		this.name = "ReExecUnavailableError"
+	}
+}
+
 /**
- * Replace the running process with the same binary at `process.execPath`
- * using the supplied argv and env. Linux/macOS only.
+ * Replace the running process with the freshly-installed binary at
+ * `process.execPath`, passing the original user args (`userArgs`) and env.
+ * Linux/macOS only — Windows uses the `.old` rotation and never calls this.
  *
- * `process.execve` is a Node.js extension not in @types/node — we cast
- * through `unknown` to keep the call typed without an ambient declaration.
+ * Two mechanisms, in order:
+ *   1. `process.execve` — a true exec(2) syscall (Node.js 23+). Replaces the
+ *      process image; never returns on success. Not in @types/node, so we
+ *      cast through `unknown`.
+ *   2. `Bun.spawnSync` — the shipped artifact is a Bun-compiled binary, and
+ *      Bun does NOT implement `process.execve`. We launch the new binary as
+ *      a child with inherited stdio, wait for it, and exit with its code.
+ *      Not a real image replacement, but functionally equivalent for a CLI
+ *      that's about to hand control to the new version anyway.
+ *
+ * Note we re-launch `process.execPath` (the real binary) with `userArgs`
+ * only. In a Bun-compiled binary `process.argv[1]` is a virtual `/$bunfs/…`
+ * script path that must NOT be forwarded; the binary embeds its own entry.
  *
  * Exported so tests can spy on it. Production callers should invoke
  * `maybeAutoUpdateOnLaunch`, which gates platform + applies the update
- * first.
+ * first. Returns `never` on the success paths (process replaced or exited);
+ * throws `ReExecUnavailableError` when neither mechanism exists.
  */
-export function performReExec(argv: readonly string[], env: NodeJS.ProcessEnv): never {
+export function performReExec(userArgs: readonly string[], env: NodeJS.ProcessEnv): never {
 	const execve = (
 		process as unknown as {
 			execve?: (file: string, args: readonly string[], env: NodeJS.ProcessEnv) => never
 		}
 	).execve
-	if (typeof execve !== "function") {
-		// Unreachable in production: maybeAutoUpdateOnLaunch short-circuits
-		// on win32 before reaching here. Tests that stub execve via this
-		// helper will replace it with a spy and never fall through.
-		throw new Error("process.execve is not available on this platform")
+	if (typeof execve === "function") {
+		// execve's arg vector is the full argv INCLUDING argv[0]; convention
+		// is argv[0] === the program path.
+		execve(process.execPath, [process.execPath, ...userArgs], env)
+		// execve does not return on success.
+		throw new Error("process.execve returned unexpectedly")
 	}
-	execve(process.execPath, argv, env)
-	// execve does not return on success.
-	throw new Error("process.execve returned unexpectedly")
+
+	const bunSpawnSync = (globalThis as unknown as { Bun?: { spawnSync?: BunSpawnSync } }).Bun?.spawnSync
+	if (typeof bunSpawnSync === "function") {
+		const result = bunSpawnSync([process.execPath, ...userArgs], {
+			stdio: ["inherit", "inherit", "inherit"],
+			env,
+		})
+		// Mirror the child's exit so the terminal sees the same status.
+		process.exit(result.exitCode ?? 0)
+	}
+
+	throw new ReExecUnavailableError()
 }
+
+/** Minimal structural type for the slice of `Bun.spawnSync` we use — avoids a
+ *  hard dependency on @types/bun in a file that also builds under Node. */
+type BunSpawnSync = (
+	cmd: readonly string[],
+	opts: { stdio: [string, string, string]; env: NodeJS.ProcessEnv },
+) => { exitCode: number | null }
 
 /** Return true when any argv token should suppress auto-update. Exported so
  *  tests can drive it without mutating the worker's `process.argv` (vitest's
@@ -99,7 +139,10 @@ export interface MaybeAutoUpdateOnLaunchOptions {
  *   - applyUpdate throws (network, checksum, smoke-test failure)
  *   - opts.signal is already aborted (caller's deadline has passed)
  *
- * On success (Linux/macOS): re-exec into the new binary.
+ * On success (Linux/macOS): hand off to the new binary via performReExec
+ * (execve under Node, Bun.spawnSync under the compiled binary). If no
+ * re-exec primitive exists, the binary is still swapped on disk — we log a
+ * "restart your terminal" note and continue on the current version.
  * On success (Windows): `atomicInstall` rotates `kimchi.exe` → `kimchi.exe.old`
  * in-place, so the current run continues on the (still-current) binary; the
  * user's next terminal relaunch picks up the new version. We log a one-line
@@ -157,10 +200,22 @@ export async function maybeAutoUpdateOnLaunch(opts: MaybeAutoUpdateOnLaunchOptio
 			return
 		}
 
-		// argv[0] is the same script entry the current process was launched
-		// with. process.argv.slice(1) gives us exactly that — drop the
-		// leading "node" or "/path/to/kimchi" and keep the user args.
-		performReExec([process.execPath, ...process.argv.slice(1)], process.env)
+		// Hand off to the freshly-installed binary. We forward only the user
+		// args (process.argv.slice(2)); argv[1] is the launcher's own entry
+		// (a /$bunfs/… virtual path in the compiled binary) and must not be
+		// passed through. performReExec re-prepends process.execPath itself.
+		try {
+			performReExec(process.argv.slice(2), process.env)
+		} catch (err) {
+			if (err instanceof ReExecUnavailableError) {
+				// Update is on disk but we can't swap into it this launch
+				// (no exec primitive). Continue on the current version; the
+				// user's next launch picks up the new binary.
+				warn(`Update installed; restart your terminal to use ${check.latestVersion}.`)
+				return
+			}
+			throw err
+		}
 	} catch (err) {
 		// Defense in depth — should be unreachable given the inner
 		// try/catches, but if any helper throws unexpectedly we still

--- a/src/update/auto-update.ts
+++ b/src/update/auto-update.ts
@@ -24,6 +24,34 @@ const SKIP_SUBCOMMANDS = new Set(["update", "setup", "mcp", "login", "install"])
 // Pure flags that suppress auto-update. Checked anywhere in argv.
 const SKIP_FLAGS = new Set(["--no-auto-update", "--version", "-v", "--help", "-h"])
 
+// Non-interactive CLI modes where an update/re-exec before startup would
+// corrupt the protocol stream or surprise external clients. Mirrors the
+// logic in cli-args.ts:isProtocolOrPrintMode but stays self-contained so
+// auto-update.ts doesn't pull pi-coding-agent into the early import chain
+// (entry.ts dynamically imports this module before cli.js).
+const NON_INTERACTIVE_MODES = new Set(["json", "rpc", "acp"])
+
+/** Return true when argv selects a non-interactive mode (ACP/JSON/RPC/print/
+ *  export). In those modes stdout/stderr belong to the caller and a re-exec
+ *  mid-startup would corrupt the protocol stream or break scripts. */
+export function isNonInteractiveLaunch(argv: readonly string[]): boolean {
+	// --mode=<value> or --mode <value>
+	for (let i = 0; i < argv.length; i += 1) {
+		const arg = argv[i]
+		if (arg === "--mode" && i + 1 < argv.length) {
+			if (NON_INTERACTIVE_MODES.has(argv[i + 1])) return true
+		}
+		if (arg.startsWith("--mode=")) {
+			if (NON_INTERACTIVE_MODES.has(arg.slice("--mode=".length))) return true
+		}
+	}
+	// --print / -p: piped output mode
+	if (argv.includes("--print") || argv.includes("-p")) return true
+	// --export: writes to a file and exits
+	if (argv.includes("--export") || argv.some((a) => a.startsWith("--export="))) return true
+	return false
+}
+
 function warn(message: string): void {
 	process.stderr.write(`${LOG_PREFIX} ${message}\n`)
 }
@@ -131,6 +159,7 @@ export interface MaybeAutoUpdateOnLaunchOptions {
  *   - KIMCHI_NO_UPDATE_CHECK is set
  *   - argv contains a subcommand (`update`/`setup`/`mcp`/`login`/`install`)
  *   - argv contains `--no-auto-update`, `--version`, `-v`, `--help`, `-h`
+ *   - argv selects a non-interactive mode (ACP/JSON/RPC/print/export)
  *   - isHomebrewInstall() returns true
  *   - running on a canary build (canary users stay on the canary track;
  *     currency is checked via `kimchi update --canary`)
@@ -156,6 +185,7 @@ export async function maybeAutoUpdateOnLaunch(opts: MaybeAutoUpdateOnLaunchOptio
 	try {
 		if (process.env.KIMCHI_NO_UPDATE_CHECK) return
 		if (argvHasSkipTrigger(process.argv)) return
+		if (isNonInteractiveLaunch(process.argv)) return
 		if (isHomebrewInstall()) return
 		if (parseCanarySha7(getVersion()) !== null) return
 		if (!loadAutoUpdateSetting()) return

--- a/src/update/auto-update.ts
+++ b/src/update/auto-update.ts
@@ -6,6 +6,7 @@
 // current version. We never throw out of this module — entry.ts wraps the
 // call in its own try/catch but we also catch internally as defense-in-depth.
 
+import { basename } from "node:path"
 import { getVersion } from "../utils.js"
 import { isHomebrewInstall } from "./paths.js"
 import { loadAutoUpdateSetting } from "./settings.js"
@@ -163,6 +164,8 @@ export interface MaybeAutoUpdateOnLaunchOptions {
  *   - isHomebrewInstall() returns true
  *   - running on a canary build (canary users stay on the canary track;
  *     currency is checked via `kimchi update --canary`)
+ *   - running from source/dev (getVersion() is "dev" or "unknown", or
+ *     process.execPath is not the packaged kimchi binary)
  *   - loadAutoUpdateSetting() returns false
  *   - checkForUpdate throws or reports no update
  *   - applyUpdate throws (network, checksum, smoke-test failure)
@@ -188,6 +191,17 @@ export async function maybeAutoUpdateOnLaunch(opts: MaybeAutoUpdateOnLaunchOptio
 		if (isNonInteractiveLaunch(process.argv)) return
 		if (isHomebrewInstall()) return
 		if (parseCanarySha7(getVersion()) !== null) return
+		// Dev/source launches: getVersion() returns "dev" when package.json has
+		// the 0.0.0 placeholder. In that case process.execPath is the Bun/Node
+		// interpreter, not a packaged kimchi binary — applyUpdate() would try
+		// to install the release binary over the interpreter.
+		if (getVersion() === "dev") return
+		if (getVersion() === "unknown") return
+		// Guard against non-packaged binaries (e.g. running via `node src/entry.ts`).
+		// The compiled binary is named "kimchi" (or "kimchi.exe" on Windows);
+		// if execPath doesn't match, we're not running the real artifact.
+		const expectedBinName = process.platform === "win32" ? "kimchi.exe" : "kimchi"
+		if (basename(process.execPath) !== expectedBinName) return
 		if (!loadAutoUpdateSetting()) return
 		if (opts.signal?.aborted) return
 

--- a/src/update/settings.test.ts
+++ b/src/update/settings.test.ts
@@ -23,7 +23,7 @@ vi.mock("@earendil-works/pi-coding-agent", async (importOriginal) => {
 const { loadAutoUpdateSetting, saveAutoUpdateSetting, loadAutoUpdateNoticeShown, markAutoUpdateNoticeShown } =
 	await import("./settings.js")
 
-const settingsPath = (): string => join(fakeAgentDir, "settings.json")
+const statePath = (): string => join(fakeAgentDir, "auto-update.json")
 
 beforeEach(() => {
 	fakeAgentDir = mkdtempSync(join(tmpdir(), "kimchi-update-settings-"))
@@ -39,27 +39,27 @@ describe("loadAutoUpdateSetting", () => {
 	})
 
 	it("returns false when the file exists but has no autoUpdate key", () => {
-		writeFileSync(settingsPath(), JSON.stringify({ theme: "dark" }))
+		writeFileSync(statePath(), JSON.stringify({ theme: "dark" }))
 		expect(loadAutoUpdateSetting()).toBe(false)
 	})
 
 	it("returns false when autoUpdate is explicitly false", () => {
-		writeFileSync(settingsPath(), JSON.stringify({ autoUpdate: false }))
+		writeFileSync(statePath(), JSON.stringify({ autoUpdate: false }))
 		expect(loadAutoUpdateSetting()).toBe(false)
 	})
 
 	it("returns true when autoUpdate is explicitly true", () => {
-		writeFileSync(settingsPath(), JSON.stringify({ autoUpdate: true }))
+		writeFileSync(statePath(), JSON.stringify({ autoUpdate: true }))
 		expect(loadAutoUpdateSetting()).toBe(true)
 	})
 
 	it("returns false (defensive default) when autoUpdate is the wrong type", () => {
-		writeFileSync(settingsPath(), JSON.stringify({ autoUpdate: "yes" }))
+		writeFileSync(statePath(), JSON.stringify({ autoUpdate: "yes" }))
 		expect(loadAutoUpdateSetting()).toBe(false)
 	})
 
 	it("returns false and warns when the file contains malformed JSON", () => {
-		writeFileSync(settingsPath(), "{not valid json")
+		writeFileSync(statePath(), "{not valid json")
 		const warn = vi.spyOn(console, "warn").mockImplementation(() => {})
 		try {
 			expect(loadAutoUpdateSetting()).toBe(false)
@@ -84,9 +84,9 @@ describe("saveAutoUpdateSetting", () => {
 	})
 
 	it("preserves unrelated keys when writing", () => {
-		writeFileSync(settingsPath(), JSON.stringify({ theme: "dark", autoUpdate: true, autoUpdateNoticeShown: false }))
+		writeFileSync(statePath(), JSON.stringify({ theme: "dark", autoUpdate: true, autoUpdateNoticeShown: false }))
 		saveAutoUpdateSetting(false)
-		const round = JSON.parse(readFileSync(settingsPath(), "utf-8")) as Record<string, unknown>
+		const round = JSON.parse(readFileSync(statePath(), "utf-8")) as Record<string, unknown>
 		expect(round.autoUpdate).toBe(false)
 		expect(round.theme).toBe("dark")
 		expect(round.autoUpdateNoticeShown).toBe(false)
@@ -113,24 +113,24 @@ describe("loadAutoUpdateNoticeShown", () => {
 	})
 
 	it("returns false when the key is absent", () => {
-		writeFileSync(settingsPath(), JSON.stringify({ theme: "dark" }))
+		writeFileSync(statePath(), JSON.stringify({ theme: "dark" }))
 		expect(loadAutoUpdateNoticeShown()).toBe(false)
 	})
 
 	it("returns true when the key is true", () => {
-		writeFileSync(settingsPath(), JSON.stringify({ autoUpdateNoticeShown: true }))
+		writeFileSync(statePath(), JSON.stringify({ autoUpdateNoticeShown: true }))
 		expect(loadAutoUpdateNoticeShown()).toBe(true)
 	})
 
 	it("returns false when the key is the wrong type", () => {
-		writeFileSync(settingsPath(), JSON.stringify({ autoUpdateNoticeShown: "yes" }))
+		writeFileSync(statePath(), JSON.stringify({ autoUpdateNoticeShown: "yes" }))
 		expect(loadAutoUpdateNoticeShown()).toBe(false)
 	})
 })
 
 describe("markAutoUpdateNoticeShown", () => {
 	it("flips the notice flag to true", () => {
-		writeFileSync(settingsPath(), JSON.stringify({ autoUpdate: true }))
+		writeFileSync(statePath(), JSON.stringify({ autoUpdate: true }))
 		markAutoUpdateNoticeShown()
 		expect(loadAutoUpdateNoticeShown()).toBe(true)
 	})
@@ -143,9 +143,9 @@ describe("markAutoUpdateNoticeShown", () => {
 	})
 
 	it("preserves unrelated keys", () => {
-		writeFileSync(settingsPath(), JSON.stringify({ theme: "dark", autoUpdate: true }))
+		writeFileSync(statePath(), JSON.stringify({ theme: "dark", autoUpdate: true }))
 		markAutoUpdateNoticeShown()
-		const round = JSON.parse(readFileSync(settingsPath(), "utf-8")) as Record<string, unknown>
+		const round = JSON.parse(readFileSync(statePath(), "utf-8")) as Record<string, unknown>
 		expect(round.autoUpdateNoticeShown).toBe(true)
 		expect(round.autoUpdate).toBe(true)
 		expect(round.theme).toBe("dark")

--- a/src/update/settings.test.ts
+++ b/src/update/settings.test.ts
@@ -5,7 +5,7 @@
 // `forTest` re-export noise and matches the pattern already used by
 // src/extensions/agents/discovery-priority.test.ts and friends.
 
-import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs"
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs"
 import { tmpdir } from "node:os"
 import { join } from "node:path"
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"

--- a/src/update/settings.test.ts
+++ b/src/update/settings.test.ts
@@ -1,0 +1,153 @@
+// Tests for src/update/settings.ts.
+//
+// Path injection strategy: we mock `@earendil-works/pi-coding-agent` so that
+// `getAgentDir()` resolves to a fresh per-test tmpdir. This avoids the
+// `forTest` re-export noise and matches the pattern already used by
+// src/extensions/agents/discovery-priority.test.ts and friends.
+
+import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
+
+// Fake agent dir shared by the mocked getAgentDir(). We rebuild it for every
+// test in beforeEach so isolation holds across the suite.
+let fakeAgentDir: string
+
+vi.mock("@earendil-works/pi-coding-agent", async (importOriginal) => {
+	const actual = (await importOriginal()) as Record<string, unknown>
+	return { ...actual, getAgentDir: () => fakeAgentDir }
+})
+
+// Imports must come AFTER the vi.mock call so the mock is wired up.
+const { loadAutoUpdateSetting, saveAutoUpdateSetting, loadAutoUpdateNoticeShown, markAutoUpdateNoticeShown } =
+	await import("./settings.js")
+
+const settingsPath = (): string => join(fakeAgentDir, "settings.json")
+
+beforeEach(() => {
+	fakeAgentDir = mkdtempSync(join(tmpdir(), "kimchi-update-settings-"))
+})
+
+afterEach(() => {
+	rmSync(fakeAgentDir, { recursive: true, force: true })
+})
+
+describe("loadAutoUpdateSetting", () => {
+	it("returns true when the settings file is missing (opt-out default)", () => {
+		expect(loadAutoUpdateSetting()).toBe(true)
+	})
+
+	it("returns true when the file exists but has no autoUpdate key", () => {
+		writeFileSync(settingsPath(), JSON.stringify({ theme: "dark" }))
+		expect(loadAutoUpdateSetting()).toBe(true)
+	})
+
+	it("returns false when autoUpdate is explicitly false", () => {
+		writeFileSync(settingsPath(), JSON.stringify({ autoUpdate: false }))
+		expect(loadAutoUpdateSetting()).toBe(false)
+	})
+
+	it("returns true when autoUpdate is explicitly true", () => {
+		writeFileSync(settingsPath(), JSON.stringify({ autoUpdate: true }))
+		expect(loadAutoUpdateSetting()).toBe(true)
+	})
+
+	it("returns true (defensive default) when autoUpdate is the wrong type", () => {
+		writeFileSync(settingsPath(), JSON.stringify({ autoUpdate: "yes" }))
+		expect(loadAutoUpdateSetting()).toBe(true)
+	})
+
+	it("returns true and warns when the file contains malformed JSON", () => {
+		writeFileSync(settingsPath(), "{not valid json")
+		const warn = vi.spyOn(console, "warn").mockImplementation(() => {})
+		try {
+			expect(loadAutoUpdateSetting()).toBe(true)
+			expect(warn).toHaveBeenCalledOnce()
+			const msg = warn.mock.calls[0]?.[0] as string
+			expect(msg).toContain("[kimchi-update]")
+		} finally {
+			warn.mockRestore()
+		}
+	})
+})
+
+describe("saveAutoUpdateSetting", () => {
+	it("persists false across reloads", () => {
+		saveAutoUpdateSetting(false)
+		expect(loadAutoUpdateSetting()).toBe(false)
+	})
+
+	it("persists true across reloads", () => {
+		saveAutoUpdateSetting(true)
+		expect(loadAutoUpdateSetting()).toBe(true)
+	})
+
+	it("preserves unrelated keys when writing", () => {
+		writeFileSync(settingsPath(), JSON.stringify({ theme: "dark", autoUpdate: true, autoUpdateNoticeShown: false }))
+		saveAutoUpdateSetting(false)
+		const round = JSON.parse(readFileSync(settingsPath(), "utf-8")) as Record<string, unknown>
+		expect(round.autoUpdate).toBe(false)
+		expect(round.theme).toBe("dark")
+		expect(round.autoUpdateNoticeShown).toBe(false)
+	})
+
+	it("survives two consecutive writes — the last value wins", () => {
+		saveAutoUpdateSetting(true)
+		saveAutoUpdateSetting(false)
+		saveAutoUpdateSetting(true)
+		expect(loadAutoUpdateSetting()).toBe(true)
+	})
+
+	it("creates the parent directory if it does not exist", () => {
+		// fakeAgentDir already exists; remove it to prove mkdirSync runs.
+		rmSync(fakeAgentDir, { recursive: true, force: true })
+		saveAutoUpdateSetting(false)
+		expect(loadAutoUpdateSetting()).toBe(false)
+	})
+})
+
+describe("loadAutoUpdateNoticeShown", () => {
+	it("returns false when the file is missing", () => {
+		expect(loadAutoUpdateNoticeShown()).toBe(false)
+	})
+
+	it("returns false when the key is absent", () => {
+		writeFileSync(settingsPath(), JSON.stringify({ theme: "dark" }))
+		expect(loadAutoUpdateNoticeShown()).toBe(false)
+	})
+
+	it("returns true when the key is true", () => {
+		writeFileSync(settingsPath(), JSON.stringify({ autoUpdateNoticeShown: true }))
+		expect(loadAutoUpdateNoticeShown()).toBe(true)
+	})
+
+	it("returns false when the key is the wrong type", () => {
+		writeFileSync(settingsPath(), JSON.stringify({ autoUpdateNoticeShown: "yes" }))
+		expect(loadAutoUpdateNoticeShown()).toBe(false)
+	})
+})
+
+describe("markAutoUpdateNoticeShown", () => {
+	it("flips the notice flag to true", () => {
+		writeFileSync(settingsPath(), JSON.stringify({ autoUpdate: true }))
+		markAutoUpdateNoticeShown()
+		expect(loadAutoUpdateNoticeShown()).toBe(true)
+	})
+
+	it("does not disturb autoUpdate", () => {
+		saveAutoUpdateSetting(false)
+		markAutoUpdateNoticeShown()
+		expect(loadAutoUpdateSetting()).toBe(false)
+		expect(loadAutoUpdateNoticeShown()).toBe(true)
+	})
+
+	it("preserves unrelated keys", () => {
+		writeFileSync(settingsPath(), JSON.stringify({ theme: "dark", autoUpdate: true }))
+		markAutoUpdateNoticeShown()
+		const round = JSON.parse(readFileSync(settingsPath(), "utf-8")) as Record<string, unknown>
+		expect(round.autoUpdateNoticeShown).toBe(true)
+		expect(round.autoUpdate).toBe(true)
+		expect(round.theme).toBe("dark")
+	})
+})

--- a/src/update/settings.test.ts
+++ b/src/update/settings.test.ts
@@ -34,13 +34,13 @@ afterEach(() => {
 })
 
 describe("loadAutoUpdateSetting", () => {
-	it("returns true when the settings file is missing (opt-out default)", () => {
-		expect(loadAutoUpdateSetting()).toBe(true)
+	it("returns false when the settings file is missing (opt-in default)", () => {
+		expect(loadAutoUpdateSetting()).toBe(false)
 	})
 
-	it("returns true when the file exists but has no autoUpdate key", () => {
+	it("returns false when the file exists but has no autoUpdate key", () => {
 		writeFileSync(settingsPath(), JSON.stringify({ theme: "dark" }))
-		expect(loadAutoUpdateSetting()).toBe(true)
+		expect(loadAutoUpdateSetting()).toBe(false)
 	})
 
 	it("returns false when autoUpdate is explicitly false", () => {
@@ -53,16 +53,16 @@ describe("loadAutoUpdateSetting", () => {
 		expect(loadAutoUpdateSetting()).toBe(true)
 	})
 
-	it("returns true (defensive default) when autoUpdate is the wrong type", () => {
+	it("returns false (defensive default) when autoUpdate is the wrong type", () => {
 		writeFileSync(settingsPath(), JSON.stringify({ autoUpdate: "yes" }))
-		expect(loadAutoUpdateSetting()).toBe(true)
+		expect(loadAutoUpdateSetting()).toBe(false)
 	})
 
-	it("returns true and warns when the file contains malformed JSON", () => {
+	it("returns false and warns when the file contains malformed JSON", () => {
 		writeFileSync(settingsPath(), "{not valid json")
 		const warn = vi.spyOn(console, "warn").mockImplementation(() => {})
 		try {
-			expect(loadAutoUpdateSetting()).toBe(true)
+			expect(loadAutoUpdateSetting()).toBe(false)
 			expect(warn).toHaveBeenCalledOnce()
 			const msg = warn.mock.calls[0]?.[0] as string
 			expect(msg).toContain("[kimchi-update]")

--- a/src/update/settings.ts
+++ b/src/update/settings.ts
@@ -1,68 +1,87 @@
 // Persistence for the harness auto-update toggle.
-// - File: ~/.config/kimchi/harness/settings.json (via getAgentDir())
-// - Defaults to `false` (opt-in) for the initial rollout; will flip to
-//   `true` (opt-out) to match Claude Code's native-install default once
-//   the rollout is validated. See loadAutoUpdateSetting() for details.
-// - Defensive sanitize: wrong types → default; corrupt JSON → warn + default
-// - Atomic write: tmp file + rename so a crash mid-write never corrupts settings
+//
+// Auto-update state lives in its OWN file (auto-update.json), separate
+// from the shared settings.json. This avoids two problems with the
+// previous approach (which read-modify-wrote settings.json):
+//
+//   1. Lossy overwrite: if readRaw() saw malformed JSON it returned {},
+//      so the next save would overwrite every unrelated setting with
+//      only { autoUpdate }.
+//   2. Concurrent-process race: two kimchi processes writing settings.json
+//      via the same `settings.json.tmp` plus read-modify-write could lose
+//      each other's keys.
+//
+// Using a dedicated file with a process-unique tmp name eliminates both:
+// there are no unrelated keys to clobber, and the tmp name includes the
+// PID so concurrent processes don't collide on the rename.
 
 import { existsSync, mkdirSync, readFileSync, renameSync, writeFileSync } from "node:fs"
 import { dirname, join } from "node:path"
 import { getAgentDir } from "@earendil-works/pi-coding-agent"
 
-function settingsPath(): string {
-	return join(getAgentDir(), "settings.json")
+/** Path to the dedicated auto-update state file. Separate from the shared
+ *  settings.json so read-modify-writes here can never clobber unrelated keys. */
+function autoUpdateStatePath(): string {
+	return join(getAgentDir(), "auto-update.json")
 }
 
-function readRaw(path: string): Record<string, unknown> {
+interface AutoUpdateState {
+	/** Opt-in (default false) for the initial rollout. */
+	autoUpdate?: boolean
+	/** One-time onboarding toast shown flag. */
+	autoUpdateNoticeShown?: boolean
+}
+
+function readState(path: string): AutoUpdateState {
 	if (!existsSync(path)) return {}
 	try {
 		const parsed = JSON.parse(readFileSync(path, "utf-8")) as unknown
 		if (parsed && typeof parsed === "object" && !Array.isArray(parsed)) {
-			return parsed as Record<string, unknown>
+			return parsed as AutoUpdateState
 		}
-		// File exists but isn't a JSON object → treat as empty, don't warn.
-		// Only truly malformed JSON triggers a warning.
 		return {}
 	} catch (err) {
 		const reason = err instanceof Error ? err.message : String(err)
-		console.warn(`[kimchi-update] Ignoring malformed settings at ${path}: ${reason}`)
+		console.warn(`[kimchi-update] Ignoring malformed auto-update state at ${path}: ${reason}`)
 		return {}
 	}
+}
+
+/** Atomic write using a process-unique tmp name to avoid collisions
+ *  between concurrent kimchi processes. */
+function writeState(path: string, next: AutoUpdateState): void {
+	mkdirSync(dirname(path), { recursive: true })
+	// Include PID in the tmp name so two concurrent processes don't
+	// race on the same `auto-update.json.tmp` file.
+	const tmp = `${path}.${process.pid}.tmp`
+	writeFileSync(tmp, `${JSON.stringify(next, null, 2)}\n`, "utf-8")
+	renameSync(tmp, path)
 }
 
 /** Default for autoUpdate is `false` (opt-in) for the initial rollout.
  *  Plan: ship opt-in first, monitor for regressions, then flip to `true`
  *  (opt-out) to match Claude Code's native-install default. */
 export function loadAutoUpdateSetting(): boolean {
-	const raw = readRaw(settingsPath())
+	const state = readState(autoUpdateStatePath())
 	// Missing or wrong type → opt-in default. Only an explicit `true` opts in.
-	if (typeof raw.autoUpdate !== "boolean") return false
-	return raw.autoUpdate
+	if (typeof state.autoUpdate !== "boolean") return false
+	return state.autoUpdate
 }
 
 /** Default for the one-time onboarding toast is `false` — we haven't shown it yet. */
 export function loadAutoUpdateNoticeShown(): boolean {
-	const raw = readRaw(settingsPath())
-	return raw.autoUpdateNoticeShown === true
-}
-
-/** Atomic write: tmp file + rename. Preserves all other keys in the file. */
-function writeRaw(path: string, next: Record<string, unknown>): void {
-	mkdirSync(dirname(path), { recursive: true })
-	const tmp = `${path}.tmp`
-	writeFileSync(tmp, `${JSON.stringify(next, null, 2)}\n`, "utf-8")
-	renameSync(tmp, path)
+	const state = readState(autoUpdateStatePath())
+	return state.autoUpdateNoticeShown === true
 }
 
 export function saveAutoUpdateSetting(enabled: boolean): void {
-	const path = settingsPath()
-	const next = { ...readRaw(path), autoUpdate: enabled }
-	writeRaw(path, next)
+	const path = autoUpdateStatePath()
+	const next = { ...readState(path), autoUpdate: enabled }
+	writeState(path, next)
 }
 
 export function markAutoUpdateNoticeShown(): void {
-	const path = settingsPath()
-	const next = { ...readRaw(path), autoUpdateNoticeShown: true }
-	writeRaw(path, next)
+	const path = autoUpdateStatePath()
+	const next = { ...readState(path), autoUpdateNoticeShown: true }
+	writeState(path, next)
 }

--- a/src/update/settings.ts
+++ b/src/update/settings.ts
@@ -1,6 +1,8 @@
 // Persistence for the harness auto-update toggle.
 // - File: ~/.config/kimchi/harness/settings.json (via getAgentDir())
-// - Defaults to `true` (opt-out) so first-time users get updates without prompts
+// - Defaults to `false` (opt-in) for the initial rollout; will flip to
+//   `true` (opt-out) to match Claude Code's native-install default once
+//   the rollout is validated. See loadAutoUpdateSetting() for details.
 // - Defensive sanitize: wrong types → default; corrupt JSON → warn + default
 // - Atomic write: tmp file + rename so a crash mid-write never corrupts settings
 

--- a/src/update/settings.ts
+++ b/src/update/settings.ts
@@ -29,11 +29,13 @@ function readRaw(path: string): Record<string, unknown> {
 	}
 }
 
-/** Default for autoUpdate is `true` (opt-out) — matches Claude Code's native-install default. */
+/** Default for autoUpdate is `false` (opt-in) for the initial rollout.
+ *  Plan: ship opt-in first, monitor for regressions, then flip to `true`
+ *  (opt-out) to match Claude Code's native-install default. */
 export function loadAutoUpdateSetting(): boolean {
 	const raw = readRaw(settingsPath())
-	// Missing or wrong type → opt-out default. Only an explicit `false` opts out.
-	if (typeof raw.autoUpdate !== "boolean") return true
+	// Missing or wrong type → opt-in default. Only an explicit `true` opts in.
+	if (typeof raw.autoUpdate !== "boolean") return false
 	return raw.autoUpdate
 }
 

--- a/src/update/settings.ts
+++ b/src/update/settings.ts
@@ -1,0 +1,64 @@
+// Persistence for the harness auto-update toggle.
+// - File: ~/.config/kimchi/harness/settings.json (via getAgentDir())
+// - Defaults to `true` (opt-out) so first-time users get updates without prompts
+// - Defensive sanitize: wrong types → default; corrupt JSON → warn + default
+// - Atomic write: tmp file + rename so a crash mid-write never corrupts settings
+
+import { existsSync, mkdirSync, readFileSync, renameSync, writeFileSync } from "node:fs"
+import { dirname, join } from "node:path"
+import { getAgentDir } from "@earendil-works/pi-coding-agent"
+
+function settingsPath(): string {
+	return join(getAgentDir(), "settings.json")
+}
+
+function readRaw(path: string): Record<string, unknown> {
+	if (!existsSync(path)) return {}
+	try {
+		const parsed = JSON.parse(readFileSync(path, "utf-8")) as unknown
+		if (parsed && typeof parsed === "object" && !Array.isArray(parsed)) {
+			return parsed as Record<string, unknown>
+		}
+		// File exists but isn't a JSON object → treat as empty, don't warn.
+		// Only truly malformed JSON triggers a warning.
+		return {}
+	} catch (err) {
+		const reason = err instanceof Error ? err.message : String(err)
+		console.warn(`[kimchi-update] Ignoring malformed settings at ${path}: ${reason}`)
+		return {}
+	}
+}
+
+/** Default for autoUpdate is `true` (opt-out) — matches Claude Code's native-install default. */
+export function loadAutoUpdateSetting(): boolean {
+	const raw = readRaw(settingsPath())
+	// Missing or wrong type → opt-out default. Only an explicit `false` opts out.
+	if (typeof raw.autoUpdate !== "boolean") return true
+	return raw.autoUpdate
+}
+
+/** Default for the one-time onboarding toast is `false` — we haven't shown it yet. */
+export function loadAutoUpdateNoticeShown(): boolean {
+	const raw = readRaw(settingsPath())
+	return raw.autoUpdateNoticeShown === true
+}
+
+/** Atomic write: tmp file + rename. Preserves all other keys in the file. */
+function writeRaw(path: string, next: Record<string, unknown>): void {
+	mkdirSync(dirname(path), { recursive: true })
+	const tmp = `${path}.tmp`
+	writeFileSync(tmp, `${JSON.stringify(next, null, 2)}\n`, "utf-8")
+	renameSync(tmp, path)
+}
+
+export function saveAutoUpdateSetting(enabled: boolean): void {
+	const path = settingsPath()
+	const next = { ...readRaw(path), autoUpdate: enabled }
+	writeRaw(path, next)
+}
+
+export function markAutoUpdateNoticeShown(): void {
+	const path = settingsPath()
+	const next = { ...readRaw(path), autoUpdateNoticeShown: true }
+	writeRaw(path, next)
+}

--- a/src/update/settings.ts
+++ b/src/update/settings.ts
@@ -15,9 +15,9 @@
 // there are no unrelated keys to clobber, and the tmp name includes the
 // PID so concurrent processes don't collide on the rename.
 
-import { existsSync, mkdirSync, readFileSync, renameSync, writeFileSync } from "node:fs"
-import { dirname, join } from "node:path"
+import { join } from "node:path"
 import { getAgentDir } from "@earendil-works/pi-coding-agent"
+import { readJson, writeJson } from "../config/json.js"
 
 /** Path to the dedicated auto-update state file. Separate from the shared
  *  settings.json so read-modify-writes here can never clobber unrelated keys. */
@@ -33,29 +33,16 @@ interface AutoUpdateState {
 }
 
 function readState(path: string): AutoUpdateState {
-	if (!existsSync(path)) return {}
 	try {
-		const parsed = JSON.parse(readFileSync(path, "utf-8")) as unknown
-		if (parsed && typeof parsed === "object" && !Array.isArray(parsed)) {
-			return parsed as AutoUpdateState
-		}
-		return {}
+		return readJson(path) as AutoUpdateState
 	} catch (err) {
+		// readJson throws on malformed JSON (by design — corrupt configs should
+		// be visible). Auto-update is non-critical, so swallow and return the
+		// default state rather than crashing the session.
 		const reason = err instanceof Error ? err.message : String(err)
 		console.warn(`[kimchi-update] Ignoring malformed auto-update state at ${path}: ${reason}`)
 		return {}
 	}
-}
-
-/** Atomic write using a process-unique tmp name to avoid collisions
- *  between concurrent kimchi processes. */
-function writeState(path: string, next: AutoUpdateState): void {
-	mkdirSync(dirname(path), { recursive: true })
-	// Include PID in the tmp name so two concurrent processes don't
-	// race on the same `auto-update.json.tmp` file.
-	const tmp = `${path}.${process.pid}.tmp`
-	writeFileSync(tmp, `${JSON.stringify(next, null, 2)}\n`, "utf-8")
-	renameSync(tmp, path)
 }
 
 /** Default for autoUpdate is `false` (opt-in) for the initial rollout.
@@ -77,11 +64,11 @@ export function loadAutoUpdateNoticeShown(): boolean {
 export function saveAutoUpdateSetting(enabled: boolean): void {
 	const path = autoUpdateStatePath()
 	const next = { ...readState(path), autoUpdate: enabled }
-	writeState(path, next)
+	writeJson(path, next)
 }
 
 export function markAutoUpdateNoticeShown(): void {
 	const path = autoUpdateStatePath()
 	const next = { ...readState(path), autoUpdateNoticeShown: true }
-	writeState(path, next)
+	writeJson(path, next)
 }


### PR DESCRIPTION
## Summary

Resolves #606

Adds an opt-in (default-on) auto-update feature that mirrors Claude Code's native-install behavior. Users can toggle via the new `/update` slash command.

- On TUI launch, if `autoUpdate` is on and the user is not on Homebrew, the harness checks for a new version, downloads + installs it in the background, and `process.execve`s into the new binary before any UI loads. Users always see the latest version on launch.
- Failure paths (network, checksum, smoke-test) fall through to normal launch on the current version; never blocks the user.

## Files

**New** (3 source + 3 test):
- `src/update/settings.ts` — persistence for `autoUpdate` (default `true`) and `autoUpdateNoticeShown` (one-time onboarding toast tracking)
- `src/update/auto-update.ts` — on-launch decision matrix + `process.execve` re-exec (linux/macOS) + win32 in-place rotation via `.old`
- `src/extensions/auto-update-settings.ts` — `/update` slash command UI with toggle, manual update, version display, back

**Edited**:
- `src/entry.ts` — call `maybeAutoUpdateOnLaunch()` between `installProxyAgent()` and `installPasteInterceptor()`, wrapped in try/catch
- `src/cli.ts` — register `autoUpdateSettingsExtension` alongside `startupUpdateExtension`
- `src/extensions/startup-update.ts` — suppress the "Update available!" footer hint when auto-update is on; emit a one-time onboarding toast

## Behavior

| Condition | Auto-update behavior |
|---|---|
| `KIMCHI_NO_UPDATE_CHECK=1` | Skipped (also suppresses footer hint) |
| Homebrew install | Skipped (`/update` shows `brew upgrade kimchi` notice) |
| `autoUpdate` setting off | Skipped (footer hint still shows) |
| `autoUpdate` setting on (default) | Check + install + re-exec into new binary |
| argv is `update`/`setup`/`mcp`/`login`/`install` | Skipped (no recursion) |
| `--no-auto-update` flag | Skipped (escape hatch) |
| Check throws / no update / install throws | Single-line stderr warn, normal launch continues |

First launch after this ships shows a one-time notify: *"kimchi now updates itself in the background. Run `/update` to disable."* Tracked via `autoUpdateNoticeShown` in `settings.json`.

## Tests

66 new vitest assertions across 4 new test files (18 + 24 + 15 + 9). `pnpm run check` + `pnpm test` all green.

## Design notes

- **Default-on** mirrors Claude Code's native-install behavior; users can opt out via `/update`. Existing installed base gets the new behavior on next launch + the one-time notice above.
- **Re-exec happens in `entry.ts`** before `cli.ts` loads, so the new binary starts cold (no stale module cache from the old version).
- **`process.execve` is a Node.js extension** not in `@types/node`; cast through `unknown` (see `auto-update.ts:performReExec`). On Windows, `applyUpdate` already rotates `kimchi.exe` → `kimchi.exe.old` in-place, so we log a one-line note and return without re-exec.
- **No patch to `patches/`** — all UI hooks go through first-class `pi.registerCommand` + extension `pi.on("session_start")` events.