### PR TITLE
fix(ferment): include untracked files in grader diff

### DIFF
--- a/src/extensions/ferment/phase-evidence.test.ts
+++ b/src/extensions/ferment/phase-evidence.test.ts
@@ -1,5 +1,5 @@
 import { execSync } from "node:child_process"
-import { mkdtempSync, writeFileSync } from "node:fs"
+import { existsSync, mkdtempSync, writeFileSync } from "node:fs"
 import { tmpdir } from "node:os"
 import { join } from "node:path"
 import { afterEach, beforeEach, describe, expect, it } from "vitest"
@@ -97,6 +97,41 @@ describe("gatherPhaseEvidence", () => {
 		const ev = gatherPhaseEvidence("HEAD", repoDir)
 		expect(ev.filesChanged).not.toContain("ignored.log")
 		expect(ev.filesChanged).toContain("?? real.ts")
+	})
+
+	it("handles untracked file names with shell metacharacters safely", () => {
+		// Regression test for command injection: file names with shell
+		// metacharacters must not break out of the git command. If the
+		// filename is shell-interpreted, `;touch marker` creates a file
+		// named `marker` in repoDir. With spawnSync (shell: false) it is
+		// treated as a literal filename.
+		const trickyName = "file;touch marker"
+		writeFileSync(join(repoDir, trickyName), "export const safe = true\n")
+
+		const ev = gatherPhaseEvidence("HEAD", repoDir)
+		expect(ev.available).toBe(true)
+		expect(ev.diffSnippet).toContain("export const safe")
+		// The injection must not have created the marker file
+		expect(existsSync(join(repoDir, "marker"))).toBe(false)
+	})
+
+	it("caps untracked entries independently so they do not crowd out tracked files", () => {
+		// Create a tracked change
+		writeFileSync(join(repoDir, "README.md"), "updated\n")
+		execSync("git add README.md", { cwd: repoDir, stdio: "ignore" })
+
+		// Create many untracked files (more than MAX_FILES_LISTED)
+		for (let i = 0; i < 25; i++) {
+			writeFileSync(join(repoDir, `untracked-${i}.ts`), `export const v${i} = ${i}\n`)
+		}
+
+		const ev = gatherPhaseEvidence("HEAD", repoDir)
+		expect(ev.available).toBe(true)
+		// Tracked file must still appear despite many untracked files
+		expect(ev.filesChanged).toContain("README.md")
+		// Untracked files should be present but capped
+		expect(ev.filesChanged).toContain("?? untracked-0.ts")
+		expect(ev.filesChanged).toContain("more untracked files")
 	})
 
 	it("returns unavailable when not in a git repository", () => {

--- a/src/extensions/ferment/phase-evidence.test.ts
+++ b/src/extensions/ferment/phase-evidence.test.ts
@@ -50,15 +50,53 @@ describe("gatherPhaseEvidence", () => {
 	})
 
 	it("captures uncommitted working-tree changes against HEAD", () => {
+		// Modified tracked file (staged)
+		writeFileSync(join(repoDir, "README.md"), "updated\n")
+		execSync("git add README.md", { cwd: repoDir, stdio: "ignore" })
+
+		// New untracked file (NOT staged)
 		writeFileSync(join(repoDir, "wip.ts"), "// work in progress\n")
-		// Without git add, --stat HEAD shouldn't see the new untracked file
-		// but --stat alone (no ref) would. Since we always pass a ref, we test
-		// the staged + committed-not-yet path: stage the file.
-		execSync("git add wip.ts", { cwd: repoDir, stdio: "ignore" })
 
 		const ev = gatherPhaseEvidence("HEAD", repoDir)
 		expect(ev.available).toBe(true)
-		expect(ev.filesChanged).toContain("wip.ts")
+		expect(ev.filesChanged).toContain("README.md")
+		expect(ev.filesChanged).toContain("?? wip.ts")
+		expect(ev.diffSnippet).toContain("// work in progress")
+	})
+
+	it("captures untracked new files even when no tracked files changed", () => {
+		writeFileSync(join(repoDir, "new-feature.ts"), "export const foo = 42\n")
+
+		const ev = gatherPhaseEvidence("HEAD", repoDir)
+		expect(ev.available).toBe(true)
+		expect(ev.filesChanged).toContain("?? new-feature.ts")
+		expect(ev.diffSnippet).toContain("export const foo")
+		expect(ev.diffSnippet).toContain("+export const foo = 42")
+	})
+
+	it("captures multiple untracked files in the file list and diff", () => {
+		writeFileSync(join(repoDir, "a.ts"), "export const a = 1\n")
+		writeFileSync(join(repoDir, "b.ts"), "export const b = 2\n")
+
+		const ev = gatherPhaseEvidence("HEAD", repoDir)
+		expect(ev.available).toBe(true)
+		expect(ev.filesChanged).toContain("?? a.ts")
+		expect(ev.filesChanged).toContain("?? b.ts")
+		expect(ev.diffSnippet).toContain("export const a")
+		expect(ev.diffSnippet).toContain("export const b")
+	})
+
+	it("does not capture gitignored untracked files", () => {
+		writeFileSync(join(repoDir, ".gitignore"), "*.log\n")
+		execSync("git add .gitignore", { cwd: repoDir, stdio: "ignore" })
+		execSync('git commit -m "add gitignore"', { cwd: repoDir, stdio: "ignore" })
+
+		writeFileSync(join(repoDir, "ignored.log"), "log entry\n")
+		writeFileSync(join(repoDir, "real.ts"), "export const x = 1\n")
+
+		const ev = gatherPhaseEvidence("HEAD", repoDir)
+		expect(ev.filesChanged).not.toContain("ignored.log")
+		expect(ev.filesChanged).toContain("?? real.ts")
 	})
 
 	it("returns unavailable when not in a git repository", () => {

--- a/src/extensions/ferment/phase-evidence.ts
+++ b/src/extensions/ferment/phase-evidence.ts
@@ -35,21 +35,92 @@ export interface PhaseEvidence {
 export function gatherPhaseEvidence(sinceRef = "HEAD~10", cwd = process.cwd()): PhaseEvidence {
 	try {
 		const stat = run(`git diff --stat ${sinceRef}`, cwd)
-		if (!stat.trim()) {
+		const untracked = gatherUntrackedFiles(cwd)
+
+		// No tracked changes AND no untracked files
+		if (!stat.trim() && untracked.length === 0) {
 			return { filesChanged: "(no changes)", diffSnippet: "", available: true }
 		}
 
-		const filesChanged = limitFileList(stat)
+		// Build combined file list: tracked diff stat + untracked entries.
+		// Untracked entries use the `?? path` prefix that mirrors
+		// `git status --porcelain` so the judge LLM can recognise them as
+		// "new untracked file".
+		let filesChanged = limitFileList(stat)
+		if (untracked.length > 0) {
+			const untrackedSection = untracked.map((f) => `?? ${f}`).join("\n")
+			filesChanged = filesChanged ? `${filesChanged}\n${untrackedSection}` : untrackedSection
+			filesChanged = limitFileList(filesChanged)
+		}
 
-		// Bound the diff. We include a head + tail of the unified diff so the
-		// judge sees both the first and the last changes in case the diff is
-		// long. Plain `git diff` without context limits could explode in size.
-		const fullDiff = run(`git diff --unified=2 ${sinceRef}`, cwd)
+		// Build combined diff: tracked diff + synthetic diffs for untracked files.
+		// Untracked diffs are bounded by MAX_DIFF_BYTES to prevent an explosion if
+		// there are many large untracked files; the final truncateDiff then bounds
+		// the combined total.
+		let fullDiff = run(`git diff --unified=2 ${sinceRef}`, cwd)
+		if (untracked.length > 0) {
+			const untrackedDiffs: string[] = []
+			let untrackedBytes = 0
+			for (const f of untracked) {
+				if (untrackedBytes >= MAX_DIFF_BYTES) break
+				const d = diffUntrackedFile(cwd, f)
+				if (d) {
+					untrackedDiffs.push(d)
+					untrackedBytes += d.length
+				}
+			}
+			if (untrackedDiffs.length > 0) {
+				fullDiff = fullDiff ? `${fullDiff}\n${untrackedDiffs.join("\n")}` : untrackedDiffs.join("\n")
+			}
+		}
+
 		const diffSnippet = truncateDiff(fullDiff)
 
 		return { filesChanged, diffSnippet, available: true }
 	} catch {
 		return { filesChanged: "(git unavailable)", diffSnippet: "", available: false }
+	}
+}
+
+/**
+ * List untracked files on disk using `git ls-files --others --exclude-standard`.
+ * This respects .gitignore (unlike `--others` alone), so gitignored files are
+ * excluded. Returns relative paths, one per line. Empty array on git error.
+ */
+function gatherUntrackedFiles(cwd: string): string[] {
+	try {
+		const output = run("git ls-files --others --exclude-standard", cwd)
+		return output
+			.split("\n")
+			.map((l) => l.trim())
+			.filter(Boolean)
+	} catch {
+		return []
+	}
+}
+
+/**
+ * Produce a synthetic unified diff for an untracked file by diffing it against
+ * /dev/null. `git diff --no-index` exits with code 1 when differences are
+ * found, which execSync treats as an error — we catch and read err.stdout,
+ * which is the standard pattern for --no-index. Returns "" on any other error
+ * (e.g. file deleted between listing and diffing).
+ */
+function diffUntrackedFile(cwd: string, filePath: string): string {
+	try {
+		return execSync(`git diff --no-index --unified=2 /dev/null ${filePath}`, {
+			cwd,
+			encoding: "utf-8",
+			timeout: GIT_TIMEOUT_MS,
+			stdio: ["ignore", "pipe", "ignore"],
+		}).toString()
+	} catch (err: unknown) {
+		// exit code 1 means "differences found" — stdout has the diff
+		if (err && typeof err === "object" && "stdout" in err) {
+			const stdout = (err as { stdout?: unknown }).stdout
+			if (typeof stdout === "string") return stdout
+		}
+		return ""
 	}
 }
 

--- a/src/extensions/ferment/phase-evidence.ts
+++ b/src/extensions/ferment/phase-evidence.ts
@@ -12,7 +12,7 @@
  * the judge prompt as a single static block.
  */
 
-import { execSync } from "node:child_process"
+import { execSync, spawnSync } from "node:child_process"
 
 const MAX_FILES_LISTED = 20
 const MAX_DIFF_BYTES = 4000
@@ -45,12 +45,14 @@ export function gatherPhaseEvidence(sinceRef = "HEAD~10", cwd = process.cwd()): 
 		// Build combined file list: tracked diff stat + untracked entries.
 		// Untracked entries use the `?? path` prefix that mirrors
 		// `git status --porcelain` so the judge LLM can recognise them as
-		// "new untracked file".
+		// "new untracked file". Tracked files are capped first, then untracked
+		// entries get a separate budget so they cannot crowd out the tracked
+		// changes the judge is meant to grade.
 		let filesChanged = limitFileList(stat)
 		if (untracked.length > 0) {
-			const untrackedSection = untracked.map((f) => `?? ${f}`).join("\n")
+			const untrackedLines = untracked.map((f) => `?? ${f}`)
+			const untrackedSection = limitUntrackedList(untrackedLines)
 			filesChanged = filesChanged ? `${filesChanged}\n${untrackedSection}` : untrackedSection
-			filesChanged = limitFileList(filesChanged)
 		}
 
 		// Build combined diff: tracked diff + synthetic diffs for untracked files.
@@ -85,7 +87,9 @@ export function gatherPhaseEvidence(sinceRef = "HEAD~10", cwd = process.cwd()): 
 /**
  * List untracked files on disk using `git ls-files --others --exclude-standard`.
  * This respects .gitignore (unlike `--others` alone), so gitignored files are
- * excluded. Returns relative paths, one per line. Empty array on git error.
+ * excluded. Returns relative paths, one per line. Empty array on git error —
+ * intentionally swallows errors to match the best-effort pattern of the rest
+ * of this module (the outer gatherPhaseEvidence try/catch is the safety net).
  */
 function gatherUntrackedFiles(cwd: string): string[] {
 	try {
@@ -101,27 +105,31 @@ function gatherUntrackedFiles(cwd: string): string[] {
 
 /**
  * Produce a synthetic unified diff for an untracked file by diffing it against
- * /dev/null. `git diff --no-index` exits with code 1 when differences are
- * found, which execSync treats as an error — we catch and read err.stdout,
- * which is the standard pattern for --no-index. Returns "" on any other error
+ * /dev/null. Git treats /dev/null as an empty file across all platforms, so
+ * the entire file content appears as `+`-prefixed added lines.
+ *
+ * Uses spawnSync with an argument array (shell: false) to avoid command
+ * injection via file names containing shell metacharacters.
+ *
+ * `git diff --no-index` exits with code 1 when differences are found (which
+ * is the expected case here) and code 0 when files are identical. We read
+ * result.stdout regardless of exit code. Returns "" on any other error
  * (e.g. file deleted between listing and diffing).
  */
 function diffUntrackedFile(cwd: string, filePath: string): string {
-	try {
-		return execSync(`git diff --no-index --unified=2 /dev/null ${filePath}`, {
-			cwd,
-			encoding: "utf-8",
-			timeout: GIT_TIMEOUT_MS,
-			stdio: ["ignore", "pipe", "ignore"],
-		}).toString()
-	} catch (err: unknown) {
-		// exit code 1 means "differences found" — stdout has the diff
-		if (err && typeof err === "object" && "stdout" in err) {
-			const stdout = (err as { stdout?: unknown }).stdout
-			if (typeof stdout === "string") return stdout
-		}
-		return ""
+	const result = spawnSync("git", ["diff", "--no-index", "--unified=2", "/dev/null", filePath], {
+		cwd,
+		encoding: "utf-8",
+		timeout: GIT_TIMEOUT_MS,
+		shell: false,
+		stdio: ["ignore", "pipe", "ignore"],
+	})
+	// Exit code 1 = differences found (expected). Exit code 0 = identical.
+	// Any other code or signal failure = error, return empty.
+	if (result.status !== null && result.status <= 1) {
+		return result.stdout ?? ""
 	}
+	return ""
 }
 
 /** Capture git HEAD as a SHA. Best-effort; returns undefined on non-git or git failure. */
@@ -149,6 +157,17 @@ function limitFileList(stat: string): string {
 	const remaining = lines.length - MAX_FILES_LISTED
 	const tail = lines[lines.length - 1]
 	return `${head}\n[... ${remaining} more files ...]\n${tail}`
+}
+
+/**
+ * Cap untracked file entries independently so they never evict tracked
+ * changes from the evidence. Allows up to MAX_FILES_LISTED untracked entries
+ * before summarising the remainder.
+ */
+function limitUntrackedList(lines: string[]): string {
+	if (lines.length <= MAX_FILES_LISTED) return lines.join("\n")
+	const head = lines.slice(0, MAX_FILES_LISTED).join("\n")
+	return `${head}\n[... ${lines.length - MAX_FILES_LISTED} more untracked files ...]`
 }
 
 function truncateDiff(diff: string): string {


### PR DESCRIPTION
## Linked issue

Closes #

<!-- No open issue exists for this bug. Filing PR per user request without a linked issue. -->

## What does this PR do?

Fixes a bug where the ferment journey-grade judge gave false F grades because it could not see untracked (newly created but not `git add`-ed) files in the diff.

**Root cause**: `gatherPhaseEvidence()` in `src/extensions/ferment/phase-evidence.ts` used bare `git diff --stat <ref>` and `git diff --unified=2 <ref>`, which by default exclude untracked files. When an agent created new files during a ferment but never staged them, the judge received an incomplete diff — only modified tracked files appeared. The judge then concluded the agent's summary hallucinated work not present in the diff and assigned an F, even though the files existed on disk and passed tests.

**Fix**: Enrich `gatherPhaseEvidence()` to also enumerate untracked files via `git ls-files --others --exclude-standard` and synthesize proper unified-diff hunks for each via `git diff --no-index /dev/null <file>`. Both the file list (`filesChanged`, prefixed `?? path`) and diff content (`diffSnippet`, `+`-prefixed added lines) now include untracked files. Non-mutating — no `git add`, staging, or commits.

### Changes
- `src/extensions/ferment/phase-evidence.ts` — added `gatherUntrackedFiles()` and `diffUntrackedFile()` helpers; modified `gatherPhaseEvidence()` to merge untracked files into the evidence
- `src/extensions/ferment/phase-evidence.test.ts` — updated existing test to cover both staged and untracked files; added regression test (untracked-only), multiple-untracked, and `.gitignore` exclusion tests

## Checklist

- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md) and agree to the CLA
- [ ] This PR links to an open issue above
- [x] Tests pass locally (`pnpm run test`)
- [x] Lint passes (`pnpm run check`)
- [x] Documentation updated if behavior changed