### PR TITLE
fix: suppress tools after plan review to force turn end

### DIFF
--- a/src/extensions/ferment/events.ts
+++ b/src/extensions/ferment/events.ts
@@ -33,6 +33,7 @@ import { createApplyAndPersist } from "./tool-helpers.js"
 import {
 	applyFermentRuntimeToolProfile,
 	applyFermentToolProfile,
+	hasPendingPlanReview,
 	setActiveFermentAndApplyProfile,
 } from "./tool-scope.js"
 
@@ -539,6 +540,28 @@ export function registerFermentEvents(
 		// Only acts on tool-use turns; stop/error/aborted are handled elsewhere.
 		if (event.message.role === "assistant" && event.message.stopReason === "toolUse") {
 			maybeTriggerMidTurnFermentCompaction(pi, ctx, runtime, event.message.usage?.totalTokens ?? 0)
+		}
+
+		// After a turn ends, `prepareNextTurn` in pi-mono builds the next turn's
+		// context using `this.activeToolNames` (the snapshot set by
+		// `pi.setActiveTools`). This happens AFTER `turn_end` fires but BEFORE
+		// the next `turn_start`. So to suppress tools for the next LLM call (e.g.
+		// after `propose_ferment_scoping` sets a pending plan review), we must
+		// apply the tool profile here in `turn_end` — not `turn_start`, which
+		// fires too late (the context is already built).
+		//
+		// When `propose_ferment_scoping` sets a pending review mid-turn,
+		// `applyFermentRuntimeToolProfile` suppresses all tools via
+		// `pi.setActiveTools([])`. The next LLM call sees an empty toolset,
+		// produces text-only output (stopReason: "stop"), ending the turn and
+		// firing `agent_end` which triggers the review dialog.
+		//
+		// This is placed at the end of the handler so that the nudge/dropdown
+		// logic above runs first. Those early-return paths still suppress tools
+		// when a pending review exists, which is correct — the model should not
+		// have tools until the review is resolved.
+		if (hasPendingPlanReview(runtime)) {
+			applyFermentRuntimeToolProfile(pi, runtime)
 		}
 	})
 }

--- a/src/extensions/ferment/index.test.ts
+++ b/src/extensions/ferment/index.test.ts
@@ -1128,7 +1128,9 @@ describe("fermentExtension question dropdown", () => {
 			await vi.runOnlyPendingTimersAsync()
 
 			expect(storage.get(draft.id)?.status).toBe("draft")
-			expect(getPendingPlanReview(draft.id)).toBeDefined()
+			// Feedback path clears the pending review so the model regains its
+			// full toolset to revise the plan (tool-scope suppression is lifted).
+			expect(getPendingPlanReview(draft.id)).toBeUndefined()
 			expect(pi.sendMessage).toHaveBeenCalledWith(
 				expect.objectContaining({
 					customType: "ferment_scoping_iteration",
@@ -1189,7 +1191,10 @@ describe("fermentExtension question dropdown", () => {
 			await vi.runOnlyPendingTimersAsync()
 
 			expect(storage.get(draft.id)?.status).toBe("draft")
-			expect(getPendingPlanReview(draft.id)).toBeDefined()
+			// Cancel path clears the pending review and restores the planning
+			// tool profile so the model can continue working (re-propose, etc.).
+			expect(getPendingPlanReview(draft.id)).toBeUndefined()
+			expect(pi.setActiveTools).toHaveBeenCalled()
 			expect(pi.sendMessage).not.toHaveBeenCalled()
 		} finally {
 			vi.useRealTimers()

--- a/src/extensions/ferment/index.ts
+++ b/src/extensions/ferment/index.ts
@@ -157,7 +157,14 @@ export default function fermentExtension(pi: ExtensionAPI, runtime: FermentRunti
 			const outcome = await promptPlanReview(ctx, { planMarkdown: review.planMarkdown })
 			if (!outcome) return
 			if (outcome.kind === "cancelled") {
+				// Delete the persisted proposal and clear the in-memory pending
+				// review, then restore the planning-ferment tool profile. Without
+				// this, `hasPendingPlanReview` in tool-scope.ts keeps all tools
+				// suppressed, leaving the model unable to call any tools after
+				// the user cancels the review.
 				deletePendingProposal(review.fermentId)
+				runtime.clearPendingPlanReview(review.fermentId)
+				applyFermentRuntimeToolProfile(pi, runtime)
 				return
 			}
 
@@ -171,10 +178,10 @@ export default function fermentExtension(pi: ExtensionAPI, runtime: FermentRunti
 				}
 				if (outcome.kind === "start_auto") {
 					runtime.setContinuationPolicy("automated")
-					applyFermentRuntimeToolProfile(pi, runtime)
 					requestSharedFooterRender()
 				}
 				runtime.clearPendingPlanReview(review.fermentId)
+				applyFermentRuntimeToolProfile(pi, runtime)
 				scheduleFermentWakeUp(pi, runtime, {
 					deliverAs: "followUp",
 					fermentId: review.fermentId,
@@ -183,6 +190,14 @@ export default function fermentExtension(pi: ExtensionAPI, runtime: FermentRunti
 				return
 			}
 
+			// Clear the pending review before triggering the revision turn.
+			// The model needs its full toolset to revise the plan (read files,
+			// ask_user, etc.). If the pending review were left set, tool-scope.ts
+			// would suppress all tools via `hasPendingPlanReview`, blocking the
+			// revision. The model will set a new pending review by calling
+			// `propose_ferment_scoping` again once the revision is complete.
+			runtime.clearPendingPlanReview(review.fermentId)
+			applyFermentRuntimeToolProfile(pi, runtime)
 			void pi.sendMessage(
 				{
 					content: buildFreeformScopingFeedbackMessage(review.fermentId, outcome.text),

--- a/src/extensions/ferment/index.ts
+++ b/src/extensions/ferment/index.ts
@@ -155,7 +155,15 @@ export default function fermentExtension(pi: ExtensionAPI, runtime: FermentRunti
 		planReviewRunning = true
 		try {
 			const outcome = await promptPlanReview(ctx, { planMarkdown: review.planMarkdown })
-			if (!outcome) return
+			if (!outcome) {
+				// promptPlanReview resolved to undefined (e.g. UI dismissed without
+				// an explicit choice). Treat it the same as cancellation: clear the
+				// pending review and restore the tool profile so the model is not
+				// left with all tools suppressed.
+				runtime.clearPendingPlanReview(review.fermentId)
+				applyFermentRuntimeToolProfile(pi, runtime)
+				return
+			}
 			if (outcome.kind === "cancelled") {
 				// Delete the persisted proposal and clear the in-memory pending
 				// review, then restore the planning-ferment tool profile. Without

--- a/src/extensions/ferment/tool-scope.test.ts
+++ b/src/extensions/ferment/tool-scope.test.ts
@@ -2,10 +2,13 @@ import type { ExtensionAPI } from "@earendil-works/pi-coding-agent"
 import { describe, expect, it, vi } from "vitest"
 import type { Ferment, Phase } from "../../ferment/types.js"
 import { createToolVisibility } from "../prompt-construction/tool-visibility.js"
+import type { PendingPlanReview } from "./plan-review.js"
+import type { FermentRuntime } from "./runtime.js"
 import { FERMENT_TOOL_NAMES } from "./tool-names.js"
 import {
 	IMPLEMENTATION_TOOL_NAMES,
 	PLANNING_TOOL_NAMES,
+	applyFermentRuntimeToolProfile,
 	applyFermentToolProfile,
 	profileForFerment,
 } from "./tool-scope.js"
@@ -254,5 +257,117 @@ describe("idle profile", () => {
 		expect(lastCall).not.toContain("propose_ferment_scoping")
 		expect(lastCall).not.toContain("start_ferment_step")
 		expect(lastCall).not.toContain("activate_ferment_phase")
+	})
+})
+
+// ─── applyFermentRuntimeToolProfile: pending plan review suppression ───────
+// When `propose_ferment_scoping` returns "Plan ready for review" a pending
+// plan review is set. To force the turn to end (so `agent_end` fires and the
+// review dialog appears), ALL tools are suppressed via `pi.setActiveTools([])`.
+// Once the review is confirmed or cancelled, the caller clears the pending
+// review and re-applies the normal profile.
+
+function createMinimalRuntime(
+	activeFerment: Ferment | undefined,
+	pendingReview: PendingPlanReview | undefined,
+): FermentRuntime {
+	return {
+		getActiveId: vi.fn(() => activeFerment?.id),
+		getActive: vi.fn(() => activeFerment),
+		getPendingPlanReview: vi.fn(() => pendingReview),
+	} as unknown as FermentRuntime
+}
+
+const draftFerment: Ferment = {
+	id: "ferment-draft",
+	name: "Draft Ferment",
+	status: "running",
+	worktree: { path: "/tmp" },
+	scoping: {},
+	phases: [],
+	decisions: [],
+	memories: [],
+	createdAt: "2026-01-01T00:00:00.000Z",
+	updatedAt: "2026-01-01T00:00:00.000Z",
+}
+
+const sampleReview: PendingPlanReview = {
+	fermentId: "ferment-draft",
+	planMarkdown: "# Plan",
+}
+
+describe("applyFermentRuntimeToolProfile: pending plan review suppression", () => {
+	it("suppresses all tools (setActiveTools([])) when a pending plan review exists", () => {
+		// After propose_ferment_scoping returns "Plan ready for review", the
+		// pending review is set. The model must have NO tools so its next LLM
+		// call is text-only (stopReason: "stop"), ending the turn and firing
+		// agent_end which triggers the review dialog.
+		const pi = createPi(["read", "bash"], ["read", "bash", "edit", "propose_ferment_scoping"])
+		const runtime = createMinimalRuntime(draftFerment, sampleReview)
+
+		applyFermentRuntimeToolProfile(pi, runtime)
+
+		expect(pi.setActiveTools).toHaveBeenLastCalledWith([])
+	})
+
+	it("restores the planning profile after the pending review is cleared (confirm/cancel)", () => {
+		// After confirmPendingScope or review cancellation, the caller clears
+		// the pending review. The ferment is still in draft (planning) phase,
+		// so the planning-ferment profile is re-applied.
+		const pi = createPi(["read"], ["read", "grep", "propose_ferment_scoping"])
+		const runtime = createMinimalRuntime(draftFerment, undefined) // review cleared
+
+		applyFermentRuntimeToolProfile(pi, runtime)
+
+		const lastCall = (pi.setActiveTools as ReturnType<typeof vi.fn>).mock.lastCall?.[0] as string[]
+		// Planning tools are restored (not empty)
+		expect(lastCall).toContain("read")
+		expect(lastCall).toContain("propose_ferment_scoping")
+		// Execution tools are NOT present in planning profile
+		expect(lastCall).not.toContain("bash")
+	})
+
+	it("restores the implementation profile when an activated ferment has no pending review", () => {
+		// If a phase was activated (implementation) and the review is cleared,
+		// the implementation profile is restored with execution tools.
+		const implFerment: Ferment = {
+			...draftFerment,
+			phases: [{ id: "phase-1", index: 1, name: "Build", goal: "Build it", status: "active", steps: [] }],
+		}
+		const pi = createPi(["read"], ["read", "bash", "edit", "write", "Agent", ...PLANNING_TOOL_NAMES])
+		const runtime = createMinimalRuntime(implFerment, undefined)
+
+		applyFermentRuntimeToolProfile(pi, runtime)
+
+		const lastCall = (pi.setActiveTools as ReturnType<typeof vi.fn>).mock.lastCall?.[0] as string[]
+		expect(lastCall).toContain("bash")
+		expect(lastCall).toContain("edit")
+		expect(lastCall).toContain("Agent")
+	})
+
+	it("does NOT suppress tools when no pending review exists (no regression)", () => {
+		// Normal planning flow: no pending review. The profile is applied as
+		// before — planning tools are available, execution tools are not.
+		const pi = createPi(["read"], [...PLANNING_TOOL_NAMES, "bash", "edit"])
+		const runtime = createMinimalRuntime(draftFerment, undefined)
+
+		applyFermentRuntimeToolProfile(pi, runtime)
+
+		const lastCall = (pi.setActiveTools as ReturnType<typeof vi.fn>).mock.lastCall?.[0] as string[]
+		expect(lastCall).not.toEqual([])
+		expect(lastCall).toContain("read")
+		expect(lastCall).toContain("propose_ferment_scoping")
+		expect(lastCall).not.toContain("bash")
+	})
+
+	it("does NOT suppress tools when no active ferment exists", () => {
+		// Idle: no active ferment. No pending review possible.
+		const pi = createPi(["read", "bash"], ["read", "bash", "edit"])
+		const runtime = createMinimalRuntime(undefined, undefined)
+
+		applyFermentRuntimeToolProfile(pi, runtime)
+
+		const lastCall = (pi.setActiveTools as ReturnType<typeof vi.fn>).mock.lastCall?.[0] as string[]
+		expect(lastCall).not.toEqual([])
 	})
 })

--- a/src/extensions/ferment/tool-scope.ts
+++ b/src/extensions/ferment/tool-scope.ts
@@ -6,6 +6,28 @@ import type { FermentRuntime } from "./runtime.js"
 import { FERMENT_TOOLS } from "./tool-names.js"
 
 /**
+ * When `propose_ferment_scoping` returns "Plan ready for review" the host
+ * defers the review dialog until `agent_end` fires. If the model keeps
+ * calling tools in the same turn, `agent_end` never fires and the review
+ * dialog never appears — the ferment is stuck in "draft" with a pending
+ * plan review.
+ *
+ * To force the turn to end, suppress ALL tools whenever a pending plan
+ * review exists for the active ferment. With no tools available the model's
+ * next LLM call produces a text-only response (`stopReason: "stop"`), which
+ * ends the turn and fires `agent_end`, which triggers the review dialog.
+ *
+ * Once the review is confirmed (`confirmPendingScope`) or cancelled, the
+ * caller re-applies the normal profile via `applyFermentRuntimeToolProfile`,
+ * which clears the pending review and restores the toolset.
+ */
+export function hasPendingPlanReview(runtime: FermentRuntime): boolean {
+	const activeId = runtime.getActiveId()
+	if (!activeId) return false
+	return runtime.getPendingPlanReview(activeId) !== undefined
+}
+
+/**
  * Tools available during the planning phase of a ferment lifecycle.
  * Includes read-only discovery tools, web search, and the ferment scoping surface.
  *
@@ -132,6 +154,15 @@ export function applyFermentToolProfile(pi: ExtensionAPI, profile: FermentToolPr
 }
 
 export function applyFermentRuntimeToolProfile(pi: ExtensionAPI, runtime: FermentRuntime): void {
+	// If a plan review is pending (propose_ferment_scoping returned "Plan ready
+	// for review"), suppress ALL tools. This forces the model's next LLM call
+	// to be text-only (stopReason: "stop"), ending the turn so `agent_end` fires
+	// and the review dialog is shown via the setTimeout(0) in index.ts.
+	// Restored by the caller after confirmPendingScope() or review cancellation.
+	if (hasPendingPlanReview(runtime)) {
+		pi.setActiveTools([])
+		return
+	}
 	applyFermentToolProfile(pi, profileForFerment(runtime.getActive()))
 }
 

--- a/tests/e2e/tui/ask-user-form.test.ts
+++ b/tests/e2e/tui/ask-user-form.test.ts
@@ -40,21 +40,18 @@ const PROPOSE_SCOPING_PAYLOAD = JSON.stringify({
 
 /** Shared boilerplate to drive a ferment from cold-start through the plan-review confirm.
  *
- * NOTE: the plan-review dialog ("Proceed with this plan?" / "Start execution") does not
- * reliably render its text in the tui-test buffer (see plan-to-ferment-promo.test.ts
- * lines 35-40). The dialog IS shown and accepts Enter — we just can't observe its text
- * directly. So instead of waiting for dialog text, we wait for the model's turn 1 stream
- * (which confirms propose_ferment_scoping completed), give the dialog a moment to be
- * presented, press Enter to accept "Start execution" (the default first option), and
- * then wait for the model's turn 2 stream text to confirm the ferment started and turn 2
- * is executing.
+ * Turn sequence (with tool suppression):
+ *   Turn 1: propose_ferment_scoping → sets pending plan review
+ *   Turn 2: text-only (tools suppressed by hasPendingPlanReview) → agent_end fires
+ *           → review dialog appears → user confirms → tools restored
+ *   Turn 3: ask_user / confirm_ferment_completion_criteria (the stream we wait for)
  *
- * @param turn2Stream the turn-2 stream text to wait for — differs per test
+ * @param nextStream the post-confirmation stream text to wait for — differs per test
  */
 async function startFerment(
 	terminal: import("@microsoft/tui-test").Terminal,
 	trace: import("./support/kimchi-fixture.js").TuiScenarioTrace,
-	turn2Stream: string,
+	nextStream: string,
 ) {
 	// Stage 1: enter ferment. Type then Enter separately — one-shot "/ferment\r" can
 	// race startup and skip the intent prompt.
@@ -74,18 +71,25 @@ async function startFerment(
 	await waitForText(terminal, "I'll outline the scope.", { timeoutMs: STREAM_TIMEOUT_MS })
 	trace.step("turn 1 stream received — propose_ferment_scoping completed")
 
-	// Give the plan-review dialog a moment to be presented (text won't appear in buffer,
-	// but the host shows it and awaits Enter).
-	await new Promise((resolve) => setTimeout(resolve, 500))
+	// Turn 2 is the suppression turn: tools are suppressed (pi.setActiveTools([]))
+	// because a pending plan review exists. The model produces a text-only response,
+	// firing agent_end → the review dialog appears.
+	// We don't wait for the Turn 2 stream text — go straight to the dialog.
+
+	// Wait for the plan-review dialog to appear (triggered by agent_end after
+	// the suppression turn).
+	await waitForText(terminal, "Proceed with this plan?", { timeoutMs: STREAM_TIMEOUT_MS })
+	await waitForText(terminal, "Start execution", { timeoutMs: INPUT_TIMEOUT_MS })
+	trace.step("plan-review dialog visible")
 
 	// Press Enter to accept "Start execution" (default first option in the dialog).
 	terminal.submit("")
 	trace.step("confirmed 'Start execution' (Enter on default option)")
 
-	// Wait for the model's turn 2 stream to confirm the ferment started and turn 2 is
-	// executing (i.e. ask_user / confirm_ferment_completion_criteria is about to be called).
-	await waitForText(terminal, turn2Stream, { timeoutMs: STREAM_TIMEOUT_MS })
-	trace.step(`turn 2 stream received: ${turn2Stream}`)
+	// Wait for the model's turn 3 stream — tools are restored after confirmation,
+	// so ask_user / confirm_ferment_completion_criteria is now available.
+	await waitForText(terminal, nextStream, { timeoutMs: STREAM_TIMEOUT_MS })
+	trace.step(`post-confirmation stream received: ${nextStream}`)
 }
 
 test("ask_user renders a single-choice question and accepts selection", async ({ terminal }) => {
@@ -107,7 +111,13 @@ test("ask_user renders a single-choice question and accepts selection", async ({
 						},
 					],
 				},
-				// Turn 2: ask the user a single-choice question.
+				// Turn 2 (suppression): tools are suppressed after propose_ferment_scoping
+				// sets a pending plan review. The model produces a text-only response,
+				// ending the turn so agent_end fires and the review dialog appears.
+				{ stream: ["Plan ready for review."] },
+				// Compaction request (consumed by auto-compaction before the post-confirmation turn).
+				{ stream: ["Summary."] },
+				// Turn 3: ask the user a single-choice question (tools restored after confirm).
 				{
 					stream: ["Let me ask the user."],
 					toolCalls: [
@@ -131,7 +141,7 @@ test("ask_user renders a single-choice question and accepts selection", async ({
 						},
 					],
 				},
-				// Turn 3: stream a follow-up after the user picks Vanilla.
+				// Turn 4: stream a follow-up after the user picks Vanilla.
 				{ stream: ["Thanks! I'll use vanilla."] },
 			],
 		},
@@ -185,7 +195,13 @@ test("confirm_ferment_completion_criteria shows 'Type your own answer' label", a
 						},
 					],
 				},
-				// Turn 2: confirm completion criteria (uses askUserForm internally with allowOther).
+				// Turn 2 (suppression): tools are suppressed after propose_ferment_scoping
+				// sets a pending plan review. The model produces a text-only response,
+				// ending the turn so agent_end fires and the review dialog appears.
+				{ stream: ["Plan ready for review."] },
+				// Compaction request (consumed by auto-compaction before the post-confirmation turn).
+				{ stream: ["Summary."] },
+				// Turn 3: confirm completion criteria (tools restored after confirm).
 				{
 					stream: ["Let me confirm the criteria."],
 					toolCalls: [
@@ -200,7 +216,7 @@ test("confirm_ferment_completion_criteria shows 'Type your own answer' label", a
 						},
 					],
 				},
-				// Turn 3: stream after the user confirms.
+				// Turn 4: stream after the user confirms.
 				{ stream: ["Great, criteria confirmed."] },
 			],
 		},
@@ -243,7 +259,13 @@ test("ask_user with a confirm question renders Yes/No options", async ({ termina
 						},
 					],
 				},
-				// Turn 2: ask_user with a confirm question (fixed Yes/No).
+				// Turn 2 (suppression): tools are suppressed after propose_ferment_scoping
+				// sets a pending plan review. The model produces a text-only response,
+				// ending the turn so agent_end fires and the review dialog appears.
+				{ stream: ["Plan ready for review."] },
+				// Compaction request (consumed by auto-compaction before the post-confirmation turn).
+				{ stream: ["Summary."] },
+				// Turn 3: ask_user with a confirm question (tools restored after confirm).
 				{
 					stream: ["Let me confirm."],
 					toolCalls: [
@@ -263,7 +285,7 @@ test("ask_user with a confirm question renders Yes/No options", async ({ termina
 						},
 					],
 				},
-				// Turn 3: stream after the user confirms.
+				// Turn 4: stream after the user confirms.
 				{ stream: ["Proceeding."] },
 			],
 		},

--- a/tests/e2e/tui/ferment-plan-review-suppression.test.ts
+++ b/tests/e2e/tui/ferment-plan-review-suppression.test.ts
@@ -17,7 +17,7 @@
 import { readFileSync, readdirSync } from "node:fs"
 import { join } from "node:path"
 import { expect, test } from "@microsoft/tui-test"
-import { INPUT_TIMEOUT_MS, STARTUP_TIMEOUT_MS, STREAM_TIMEOUT_MS, waitForText } from "./support/assertions.js"
+import { INPUT_TIMEOUT_MS, STARTUP_TIMEOUT_MS, STREAM_TIMEOUT_MS, waitForText, viewText } from "./support/assertions.js"
 import { TUI_TEST_CONFIG, runKimchiSession } from "./support/kimchi-fixture.js"
 
 test.use(TUI_TEST_CONFIG)
@@ -264,13 +264,24 @@ test("plan review: cancel restores planning tools, model can re-propose, ferment
 			terminal.keyEscape()
 			trace.step("pressed Escape — cancelled review")
 
-			// Stage 7: verify ferment stays in "draft" status.
-			await new Promise((r) => setTimeout(r, 500))
-			const draftArtifact = await findFermentArtifact(fixture.workDir, "draft", 3000)
+			// Stage 7: wait for the review dialog to disappear before proceeding.
+			// The cancel is asynchronous — submitting a revision message before it
+			// completes means the model doesn't get a new turn with tools restored.
+			// Poll until "Proceed with this plan?" is no longer in the terminal.
+			const cancelDeadline = Date.now() + INPUT_TIMEOUT_MS
+			while (Date.now() < cancelDeadline) {
+				const text = viewText(terminal)
+				if (!text.includes("Proceed with this plan?")) break
+				await new Promise((r) => setTimeout(r, 100))
+			}
+			trace.step("review dialog dismissed after cancel")
+
+			// Stage 8: verify ferment stays in "draft" status.
+			const draftArtifact = await findFermentArtifact(fixture.workDir, "draft", 5000)
 			expect(draftArtifact).toBeDefined()
 			trace.step("ferment remains in 'draft' status after cancel")
 
-			// Stage 8: user types a revision message → model gets new turn with tools restored.
+			// Stage 9: user types a revision message → model gets new turn with tools restored.
 			terminal.submit("Let me revise the plan")
 			trace.step("submitted revision message")
 

--- a/tests/e2e/tui/ferment-plan-review-suppression.test.ts
+++ b/tests/e2e/tui/ferment-plan-review-suppression.test.ts
@@ -1,0 +1,393 @@
+/**
+ * E2E TUI tests: plan review suppression — propose → review → confirm/cancel.
+ *
+ * These tests verify the Phase 1 fix: after `propose_ferment_scoping` returns
+ * "Plan ready for review", ALL tools are suppressed via `pi.setActiveTools([])`.
+ * This forces the model to produce a text-only response (stopReason: "stop"),
+ * which fires `agent_end` and triggers the plan-review dialog.
+ *
+ * Three scenarios:
+ * 1. Confirm flow — model proposes, review dialog appears, user clicks Start,
+ *    ferment transitions to "planned" and implementation tools are restored.
+ * 2. Cancel flow — model proposes, review dialog appears, user cancels,
+ *    ferment stays "draft", model regains planning tools and can re-propose.
+ * 3. Regression — the existing zero-questions scoping flow still works.
+ */
+
+import { readFileSync, readdirSync } from "node:fs"
+import { join } from "node:path"
+import { expect, test } from "@microsoft/tui-test"
+import { INPUT_TIMEOUT_MS, STARTUP_TIMEOUT_MS, STREAM_TIMEOUT_MS, waitForText } from "./support/assertions.js"
+import { TUI_TEST_CONFIG, runKimchiSession } from "./support/kimchi-fixture.js"
+
+test.use(TUI_TEST_CONFIG)
+
+const PROPOSE_SCOPING_PAYLOAD = JSON.stringify({
+	ferment_id: "__FERMENT_ID__",
+	title: "Test Feature",
+	goal: "Add a test feature to verify the plan review flow.",
+	success_criteria: ["Feature works correctly", "Tests pass"],
+	constraints: ["no new dependencies"],
+	assumptions: "Safe defaults assumed.",
+	phases: [
+		{
+			name: "Implement",
+			goal: "Build the feature",
+			steps: [
+				{
+					description: "Write the code",
+					verify: "pnpm test",
+				},
+			],
+		},
+	],
+	questions: [],
+	gates: [
+		{ id: "P1", verdict: "pass", rationale: "Step has verify", evidence: "tests pass" },
+		{ id: "P2", verdict: "omitted", rationale: "single phase", evidence: "n/a" },
+		{ id: "P3", verdict: "pass", rationale: "tests", evidence: "n/a" },
+	],
+})
+
+const PROPOSE_SCOPING_PAYLOAD_2 = JSON.stringify({
+	ferment_id: "__FERMENT_ID__",
+	title: "Revised Test Feature",
+	goal: "Add a revised test feature after user feedback.",
+	success_criteria: ["Feature works correctly", "Tests pass"],
+	constraints: ["no new dependencies"],
+	assumptions: "Safe defaults assumed.",
+	phases: [
+		{
+			name: "Implement",
+			goal: "Build the revised feature",
+			steps: [
+				{
+					description: "Write the revised code",
+					verify: "pnpm test",
+				},
+			],
+		},
+	],
+	questions: [],
+	gates: [
+		{ id: "P1", verdict: "pass", rationale: "Step has verify", evidence: "tests pass" },
+		{ id: "P2", verdict: "omitted", rationale: "single phase", evidence: "n/a" },
+		{ id: "P3", verdict: "pass", rationale: "tests", evidence: "n/a" },
+	],
+})
+
+/**
+ * Poll for a ferment artifact with the expected status in .kimchi/ferments/.
+ * Returns the parsed artifact or undefined if not found before the deadline.
+ */
+async function findFermentArtifact(
+	workDir: string,
+	expectedStatus: string,
+	timeoutMs = STREAM_TIMEOUT_MS,
+): Promise<Record<string, unknown> | undefined> {
+	const fermentsDir = join(workDir, ".kimchi", "ferments")
+	const deadline = Date.now() + timeoutMs
+	while (Date.now() < deadline) {
+		try {
+			const files = readdirSync(fermentsDir).filter((f) => f.endsWith(".json"))
+			for (const f of files) {
+				const content = JSON.parse(readFileSync(join(fermentsDir, f), "utf-8"))
+				if (content.status === expectedStatus) return content
+			}
+		} catch {
+			// dir doesn't exist yet or unreadable
+		}
+		await new Promise((r) => setTimeout(r, 250))
+	}
+	return undefined
+}
+
+// ---------------------------------------------------------------------------
+// Test 1: Full scoping flow with review confirmation
+// ---------------------------------------------------------------------------
+
+test("plan review: model stops after propose, review dialog appears, user confirms → ferment planned", async ({
+	terminal,
+}) => {
+	await runKimchiSession(
+		terminal,
+		{
+			artifactName: "plan-review-confirm",
+			gitInit: true,
+			responses: [
+				// Turn 1: model calls propose_ferment_scoping (questions=[]).
+				{
+					toolCalls: [
+						{
+							function: {
+								name: "propose_ferment_scoping",
+								arguments: PROPOSE_SCOPING_PAYLOAD,
+							},
+						},
+					],
+				},
+				// Turn 2: tools suppressed → model produces text-only response (no tool calls).
+				{ stream: ["I've submitted the plan for your review."] },
+				// Compaction request (consumed by auto-compaction before the post-confirmation turn).
+				{ stream: ["Summary."] },
+				// Turn 3: post-confirmation, keeps session alive.
+				{ stream: ["Starting execution now."] },
+			],
+		},
+		async (fixture, trace) => {
+			// Stage 1: ready prompt visible.
+			await waitForText(terminal, "ask anything or type / for commands", { timeoutMs: STARTUP_TIMEOUT_MS })
+			trace.step("ready prompt visible")
+
+			// Stage 2: enter ferment.
+			terminal.write("/ferment")
+			await waitForText(terminal, "/ferment", { timeoutMs: INPUT_TIMEOUT_MS })
+			trace.step("typed /ferment")
+			terminal.submit("")
+			trace.step("ran /ferment")
+
+			// Stage 3: intent prompt appears.
+			await waitForText(terminal, "would you like to ferment", { timeoutMs: STARTUP_TIMEOUT_MS })
+			trace.step("intent prompt visible")
+
+			// Stage 4: submit intent → model proposes scoping.
+			terminal.submit("Add a test feature")
+			trace.step("submitted intent")
+
+			// Stage 5: review dialog appears (triggered by agent_end after tool suppression).
+			await waitForText(terminal, "Proceed with this plan?", { timeoutMs: STREAM_TIMEOUT_MS })
+			await waitForText(terminal, "Start execution", { timeoutMs: INPUT_TIMEOUT_MS })
+			trace.step("plan-review dialog visible")
+
+			// Stage 6: confirm by pressing Enter (default first option "Start execution").
+			terminal.submit("")
+			trace.step("confirmed 'Start execution'")
+
+			// Stage 7: verify ferment artifact exists with status "planned".
+			const artifact = await findFermentArtifact(fixture.workDir, "planned")
+			expect(artifact).toBeDefined()
+			trace.step("ferment artifact found with status 'planned'")
+
+			// Stage 8: verify the post-confirmation request has planning tools restored.
+			// After confirmPendingScope, the tool profile is restored to planning-ferment
+			// (the ferment is "planned" but no phase is activated yet, so the profile
+			// is still "planning", not "implementation"). The key thing is that tools
+			// are no longer suppressed (non-empty tools array).
+			const chatRequests = fixture.fake.requests.filter((req) => req.url.startsWith("/openai/v1/chat/completions"))
+			expect(chatRequests.length).toBeGreaterThanOrEqual(2)
+			trace.step(`${chatRequests.length} chat requests recorded`)
+
+			// Find the first non-compaction request after the confirmation.
+			// Compaction requests have system prompt "You are a context summarization assistant."
+			// and no `tools` field.
+			const postConfirmReq = chatRequests.slice(2).find((req) => {
+				const body = req.body as Record<string, unknown>
+				return Array.isArray(body.tools)
+			})
+			if (postConfirmReq) {
+				const body = postConfirmReq.body as Record<string, unknown>
+				const tools = body.tools as Array<Record<string, unknown>>
+				expect(tools.length).toBeGreaterThan(0)
+				trace.step("post-confirmation request has non-empty tools[] — tools restored")
+			}
+		},
+	)
+})
+
+// ---------------------------------------------------------------------------
+// Test 2: Scoping flow with review cancellation
+// ---------------------------------------------------------------------------
+
+test("plan review: cancel restores planning tools, model can re-propose, ferment stays draft", async ({ terminal }) => {
+	await runKimchiSession(
+		terminal,
+		{
+			artifactName: "plan-review-cancel",
+			gitInit: true,
+			responses: [
+				// Turn 1: model calls propose_ferment_scoping (questions=[]).
+				{
+					toolCalls: [
+						{
+							function: {
+								name: "propose_ferment_scoping",
+								arguments: PROPOSE_SCOPING_PAYLOAD,
+							},
+						},
+					],
+				},
+				// Turn 2: tools suppressed → text-only response.
+				{ stream: ["Plan is ready for review."] },
+				// Compaction request (consumed by auto-compaction before the next agent run).
+				{ stream: ["Summary."] },
+				// Turn 3: after cancel, tools restored → model calls propose_ferment_scoping again.
+				{
+					toolCalls: [
+						{
+							function: {
+								name: "propose_ferment_scoping",
+								arguments: PROPOSE_SCOPING_PAYLOAD_2,
+							},
+						},
+					],
+				},
+				// Turn 4: text-only after second review.
+				{ stream: ["Revised plan ready."] },
+			],
+		},
+		async (fixture, trace) => {
+			// Stage 1: ready prompt visible.
+			await waitForText(terminal, "ask anything or type / for commands", { timeoutMs: STARTUP_TIMEOUT_MS })
+			trace.step("ready prompt visible")
+
+			// Stage 2: enter ferment.
+			terminal.write("/ferment")
+			await waitForText(terminal, "/ferment", { timeoutMs: INPUT_TIMEOUT_MS })
+			trace.step("typed /ferment")
+			terminal.submit("")
+			trace.step("ran /ferment")
+
+			// Stage 3: intent prompt.
+			await waitForText(terminal, "would you like to ferment", { timeoutMs: STARTUP_TIMEOUT_MS })
+			trace.step("intent prompt visible")
+
+			// Stage 4: submit intent → model proposes.
+			terminal.submit("Add a test feature")
+			trace.step("submitted intent")
+
+			// Stage 5: review dialog appears.
+			await waitForText(terminal, "Proceed with this plan?", { timeoutMs: STREAM_TIMEOUT_MS })
+			await waitForText(terminal, "Start execution", { timeoutMs: INPUT_TIMEOUT_MS })
+			trace.step("first plan-review dialog visible")
+
+			// Stage 6: cancel by pressing Escape.
+			terminal.keyEscape()
+			trace.step("pressed Escape — cancelled review")
+
+			// Stage 7: verify ferment stays in "draft" status.
+			await new Promise((r) => setTimeout(r, 500))
+			const draftArtifact = await findFermentArtifact(fixture.workDir, "draft", 3000)
+			expect(draftArtifact).toBeDefined()
+			trace.step("ferment remains in 'draft' status after cancel")
+
+			// Stage 8: user types a revision message → model gets new turn with tools restored.
+			terminal.submit("Let me revise the plan")
+			trace.step("submitted revision message")
+
+			// Stage 9: model calls propose_ferment_scoping again (tools restored).
+			// Wait for the second review dialog to appear.
+			await waitForText(terminal, "Proceed with this plan?", { timeoutMs: STREAM_TIMEOUT_MS })
+			trace.step("second plan-review dialog appeared — model re-proposed successfully")
+
+			// Stage 10: verify the revision request (post-cancel) includes
+			// propose_ferment_scoping in the tool list, proving tools were restored.
+			// Find the first chat request after the 2nd one that has a tools array
+			// (skip compaction requests which have no tools field).
+			const chatRequests = fixture.fake.requests.filter((req) => req.url.startsWith("/openai/v1/chat/completions"))
+			expect(chatRequests.length).toBeGreaterThanOrEqual(3)
+			const revisionReq = chatRequests.slice(2).find((req) => {
+				const body = req.body as Record<string, unknown>
+				return Array.isArray(body.tools) && body.tools.length > 0
+			})
+			expect(revisionReq).toBeDefined()
+			const body = revisionReq?.body as Record<string, unknown>
+			const tools = body.tools as Array<Record<string, unknown>>
+			const toolNames = tools.map((t) => (t.function as { name: string }).name)
+			expect(toolNames).toContain("propose_ferment_scoping")
+			trace.step("revision request includes propose_ferment_scoping in tools[] — tools restored after cancel")
+		},
+	)
+})
+
+// ---------------------------------------------------------------------------
+// Test 3: Regression — existing zero-questions scoping flow still works
+// ---------------------------------------------------------------------------
+
+test("plan review: existing zero-questions scoping flow still works (no regression)", async ({ terminal }) => {
+	await runKimchiSession(
+		terminal,
+		{
+			artifactName: "plan-review-regression",
+			gitInit: true,
+			responses: [
+				// Turn 1: model calls propose_ferment_scoping (questions=[]).
+				{
+					toolCalls: [
+						{
+							function: {
+								name: "propose_ferment_scoping",
+								arguments: PROPOSE_SCOPING_PAYLOAD,
+							},
+						},
+					],
+				},
+				// Turn 2: tools suppressed → text-only response (proves suppression works).
+				{ stream: ["I've outlined the scope for the test feature."] },
+				// Compaction request (consumed by auto-compaction before the post-confirmation turn).
+				{ stream: ["Summary."] },
+				// Turn 3: post-confirmation.
+				{ stream: ["Proceeding with execution."] },
+			],
+		},
+		async (fixture, trace) => {
+			// Stage 1: ready prompt visible.
+			await waitForText(terminal, "ask anything or type / for commands", { timeoutMs: STARTUP_TIMEOUT_MS })
+			trace.step("ready prompt visible")
+
+			// Stage 2: enter ferment.
+			terminal.write("/ferment")
+			await waitForText(terminal, "/ferment", { timeoutMs: INPUT_TIMEOUT_MS })
+			trace.step("typed /ferment")
+			terminal.submit("")
+			trace.step("ran /ferment")
+
+			// Stage 3: intent prompt.
+			await waitForText(terminal, "would you like to ferment", { timeoutMs: STARTUP_TIMEOUT_MS })
+			trace.step("intent prompt visible")
+
+			// Stage 4: submit intent → model proposes scoping.
+			terminal.submit("Add a test feature")
+			trace.step("submitted intent")
+
+			// Stage 5: review dialog appears.
+			await waitForText(terminal, "Proceed with this plan?", { timeoutMs: STREAM_TIMEOUT_MS })
+			await waitForText(terminal, "Start execution", { timeoutMs: INPUT_TIMEOUT_MS })
+			trace.step("plan-review dialog visible")
+
+			// Stage 6: confirm.
+			terminal.submit("")
+			trace.step("confirmed 'Start execution'")
+
+			// Stage 7: verify ferment artifact with status "planned" and correct structure.
+			const artifact = await findFermentArtifact(fixture.workDir, "planned")
+			expect(artifact).toBeDefined()
+			expect(artifact).toHaveProperty("id")
+			expect(artifact).toHaveProperty("name")
+			expect(artifact).toHaveProperty("goal")
+			expect(artifact).toHaveProperty("phases")
+			const phases = artifact?.phases as Array<Record<string, unknown>>
+			expect(phases.length).toBe(1)
+			expect(phases[0].name).toBe("Implement")
+			trace.step("ferment artifact verified — planned, 1 phase, correct structure")
+
+			// Stage 8: verify at least 2 HTTP requests were made.
+			const chatRequests = fixture.fake.requests.filter((req) => req.url.startsWith("/openai/v1/chat/completions"))
+			expect(chatRequests.length).toBeGreaterThanOrEqual(2)
+			trace.step(`${chatRequests.length} chat requests recorded`)
+
+			// Stage 9: verify the 2nd request (after tool result) had no tool calls
+			// in the response (proving tool suppression worked — model produced text-only).
+			// The 2nd request is the one where the model should have had no tools.
+			// We can verify this by checking the `tools` array in the request body.
+			// After propose_ferment_scoping returns "Plan ready for review",
+			// tools are suppressed. The 2nd request should have an empty `tools` array.
+			if (chatRequests.length >= 2) {
+				const body = chatRequests[1].body as Record<string, unknown>
+				const tools = body.tools as unknown[]
+				expect(Array.isArray(tools)).toBe(true)
+				expect(tools.length).toBe(0)
+				trace.step("2nd request has empty tools[] — tools were suppressed after propose_ferment_scoping")
+			}
+		},
+	)
+})


### PR DESCRIPTION
## Problem

After `propose_ferment_scoping` returns "Plan ready for review", the model continued calling tools instead of ending its turn. This prevented the `agent_end` event from firing, so the review dialog never appeared — the ferment stayed stuck in draft.

## Fix

Suppress all tools via `pi.setActiveTools([])` when a pending plan review exists. The model gets an empty toolset on the next LLM call, produces a text-only response (`stopReason: 'stop'`), which fires `agent_end` and triggers the review dialog. Tools are restored after the user confirms or cancels.

### Changes

- **`src/extensions/ferment/tool-scope.ts`** — Added `hasPendingPlanReview()` helper (exported) and suppression logic in `applyFermentRuntimeToolProfile()` that calls `pi.setActiveTools([])` and returns early when a pending plan review exists.
- **`src/extensions/ferment/events.ts`** — Merged the `hasPendingPlanReview` suppression check into the existing `turn_end` handler (at the end, after all nudge/dropdown/compaction logic) so it fires before `prepareNextTurn` builds the next turn's context. This is critical: `turn_start` fires too late (context already built), and a separate `turn_end` handler broke tests (the mock's `pi.on()` uses `Map.set` which overwrites).
- **`src/extensions/ferment/index.ts`** — Fixed two cleanup gaps in `runPendingPlanReview`:
  - **Cancelled path**: now clears pending review + restores tool profile (previously left tools suppressed)
  - **Edit path**: now clears pending review + restores tool profile BEFORE triggering the revision turn (previously the model started the revision with no tools)
  - **Start path** (not just `start_auto`): now calls `applyFermentRuntimeToolProfile` to restore tools after confirm

### Tests

- 5 new unit tests in `tool-scope.test.ts` covering suppression and restoration
- 2 updated tests in `index.test.ts` for cancelled + edit cleanup paths
- 3 TUI E2E tests in `ferment-plan-review-suppression.test.ts`:
  1. **Confirm flow**: propose → tools suppressed → model stops → review dialog → user confirms → ferment planned → tools restored
  2. **Cancel flow**: propose → review dialog → user cancels → tools restored → model re-proposes
  3. **Regression**: existing zero-questions scoping flow still works

## Type of change

- [x] Bug fix

## Checklist

- [x] Tests added/updated for behavior changes
- [x] `pnpm run typecheck` passes
- [x] `pnpm run lint` passes
- [x] `pnpm run test` passes (6 pre-existing failures in model-guard/permissions, unchanged from baseline)
- [x] `pnpm run test:e2e:tui` passes (37 tests, all pass)