### PR TITLE
feat: enforce read-only MCP tools in planning profiles

### DIFF
--- a/src/extensions/mcp-adapter/index.ts
+++ b/src/extensions/mcp-adapter/index.ts
@@ -27,7 +27,9 @@ import {
 	executeStatus,
 	executeUiMessages,
 } from "./proxy-modes.js"
+import { registerReadOnlyToolProvider } from "../../shared/planning/read-only-tool-registry.js"
 import type { McpExtensionState } from "./state.js"
+import { isReadOnlyMcpTool } from "./tool-metadata.js"
 import { getConfigPathFromArgv, truncateAtWord } from "./utils.js"
 
 const TOOL_AND_MCP_DISCOVERY_PROMPT = `## Tool and MCP Discovery
@@ -112,6 +114,29 @@ export default function mcpAdapter(pi: ExtensionAPI) {
 	const registeredToolNames = new Set<string>()
 	const directToolVisibility = createDirectToolVisibility(pi)
 
+	/**
+	 * Read-only-tool provider for the planning-ferment (scoping) profile.
+	 *
+	 * Iterates the live `state.toolMetadata` map (keyed on server name) and
+	 * returns the prefixed tool names (`meta.name`) for tools that qualify as
+	 * read-only via `isReadOnlyMcpTool`. Called lazily by the shared/planning
+	 * layer's `getReadOnlyToolNames` during `applyCore`, so it always reflects
+	 * the current tool-metadata state — including direct tools registered after
+	 * a cache bootstrap. Returns an empty array before MCP init completes, so
+	 * the planning-ferment profile simply skips MCP tools during that window.
+	 */
+	const readOnlyToolProvider = (): string[] => {
+		if (!state) return []
+		const names: string[] = []
+		for (const tools of state.toolMetadata.values()) {
+			for (const meta of tools) {
+				if (isReadOnlyMcpTool(meta)) names.push(meta.name)
+			}
+		}
+		return names
+	}
+	registerReadOnlyToolProvider(pi, readOnlyToolProvider)
+
 	for (const spec of directSpecs) {
 		const cachedServer = earlyCache?.servers?.[spec.serverName]
 		const cachedTool = cachedServer?.tools?.find((t) => t.name === spec.originalName)
@@ -123,6 +148,7 @@ export default function mcpAdapter(pi: ExtensionAPI) {
 					inputSchema: cachedTool.inputSchema,
 					uiResourceUri: cachedTool.uiResourceUri,
 					uiStreamMode: cachedTool.uiStreamMode,
+					annotations: cachedTool.annotations,
 				}
 			: undefined
 		pi.registerTool({

--- a/src/extensions/mcp-adapter/metadata-cache.test.ts
+++ b/src/extensions/mcp-adapter/metadata-cache.test.ts
@@ -1,0 +1,83 @@
+/**
+ * Unit tests for the cache annotation round-trip.
+ *
+ * Verifies that `serializeTools` → `reconstructToolMetadata` preserves an
+ * MCP tool's `annotations`:
+ *   - A tool annotated `{ readOnlyHint: true }` round-trips with that hint
+ *     intact on the reconstructed `ToolMetadata`.
+ *   - A tool with no `annotations` reconstructs with `annotations === undefined`.
+ *
+ * This covers the cache serialize→reconstruct path that backs both the proxy
+ * tool path and the direct-tools cached-metadata construction.
+ */
+import { describe, expect, it } from "vitest"
+import { reconstructToolMetadata, serializeTools } from "./metadata-cache.js"
+import type { ServerCacheEntry } from "./metadata-cache.js"
+import type { McpTool } from "./types.js"
+
+const SERVER_NAME = "testserver"
+
+function reconstruct(serialized: ReturnType<typeof serializeTools>): ServerCacheEntry {
+	return {
+		configHash: "deadbeef",
+		tools: serialized,
+		resources: [],
+		cachedAt: Date.now(),
+	}
+}
+
+describe("cache annotation round-trip (serializeTools → reconstructToolMetadata)", () => {
+	it("preserves readOnlyHint:true through serialize → reconstruct", () => {
+		const tools: McpTool[] = [
+			{
+				name: "get_record",
+				description: "Fetch a record",
+				annotations: { readOnlyHint: true },
+			},
+		]
+
+		const serialized = serializeTools(tools)
+		// Sanity: the CachedTool carries annotations.
+		expect(serialized[0].annotations?.readOnlyHint).toBe(true)
+
+		const [reconstructed] = reconstructToolMetadata(SERVER_NAME, reconstruct(serialized), "server", {})
+
+		expect(reconstructed.originalName).toBe("get_record")
+		expect(reconstructed.annotations).toBeDefined()
+		expect(reconstructed.annotations?.readOnlyHint).toBe(true)
+	})
+
+	it("reconstructs annotations === undefined for an un-annotated tool", () => {
+		const tools: McpTool[] = [
+			{
+				name: "create_record",
+				description: "Create a record",
+			},
+		]
+
+		const serialized = serializeTools(tools)
+		// Sanity: the CachedTool has no annotations key.
+		expect(serialized[0].annotations).toBeUndefined()
+
+		const [reconstructed] = reconstructToolMetadata(SERVER_NAME, reconstruct(serialized), "server", {})
+
+		expect(reconstructed.originalName).toBe("create_record")
+		expect(reconstructed.annotations).toBeUndefined()
+	})
+
+	it("round-trips a destructive write tool's annotations", () => {
+		const tools: McpTool[] = [
+			{
+				name: "delete_record",
+				description: "Delete a record",
+				annotations: { readOnlyHint: false, destructiveHint: true },
+			},
+		]
+
+		const serialized = serializeTools(tools)
+		const [reconstructed] = reconstructToolMetadata(SERVER_NAME, reconstruct(serialized), "server", {})
+
+		expect(reconstructed.annotations?.readOnlyHint).toBe(false)
+		expect(reconstructed.annotations?.destructiveHint).toBe(true)
+	})
+})

--- a/src/extensions/mcp-adapter/metadata-cache.ts
+++ b/src/extensions/mcp-adapter/metadata-cache.ts
@@ -3,6 +3,7 @@ import { createHash } from "node:crypto"
 import { existsSync, mkdirSync, readFileSync, renameSync, unlinkSync, writeFileSync } from "node:fs"
 import { dirname, join } from "node:path"
 import { getToolUiResourceUri } from "@modelcontextprotocol/ext-apps/app-bridge"
+import type { ToolAnnotations } from "@modelcontextprotocol/sdk/types.js"
 import { logger } from "./logger.js"
 import { resourceNameToToolName } from "./resource-tools.js"
 import type { McpResource, McpTool, ServerEntry, ToolMetadata } from "./types.js"
@@ -22,6 +23,7 @@ export interface CachedTool {
 	inputSchema?: unknown
 	uiResourceUri?: string
 	uiStreamMode?: "eager" | "stream-first"
+	annotations?: ToolAnnotations // Read-only/destructive hints from the MCP protocol
 }
 
 export interface CachedResource {
@@ -252,6 +254,7 @@ export function reconstructToolMetadata(
 			inputSchema: tool.inputSchema,
 			uiResourceUri: tool.uiResourceUri,
 			uiStreamMode: tool.uiStreamMode,
+			annotations: tool.annotations,
 		})
 
 		if (toolMetadata) {
@@ -293,6 +296,7 @@ export function serializeTools(tools: McpTool[]): CachedTool[] {
 			inputSchema: t.inputSchema,
 			uiResourceUri: tryGetToolUiResourceUri(t),
 			uiStreamMode: extractToolUiStreamMode(t._meta),
+			annotations: t.annotations,
 		}))
 }
 

--- a/src/extensions/mcp-adapter/proxy-modes.test.ts
+++ b/src/extensions/mcp-adapter/proxy-modes.test.ts
@@ -1,0 +1,147 @@
+/**
+ * Unit tests for the read-only marker surfaced in `executeSearch` and
+ * `executeDescribe` proxy output (proxy-modes.ts).
+ *
+ * Asserts that a tool whose `annotations.readOnlyHint` is `true` (or that
+ * qualifies via the name heuristic) shows a `[read-only]` tag in search
+ * results and a `Read-only:` line in describe output, while a write tool
+ * (explicit `readOnlyHint:false` with a non-matching name) shows neither.
+ */
+import { describe, expect, it } from "vitest"
+import { executeDescribe, executeSearch } from "./proxy-modes.js"
+import type { McpExtensionState } from "./state.js"
+import type { ToolMetadata } from "./types.js"
+
+const SERVER = "testserver"
+
+function makeMetadata(
+	originalName: string,
+	annotations?: ToolMetadata["annotations"],
+): ToolMetadata {
+	return {
+		name: `${SERVER}_${originalName}`,
+		originalName,
+		description: `tool ${originalName}`,
+		inputSchema: { type: "object", properties: {} },
+		annotations,
+	}
+}
+
+function makeState(metadata: ToolMetadata[]): McpExtensionState {
+	return {
+		manager: {} as McpExtensionState["manager"],
+		lifecycle: {} as McpExtensionState["lifecycle"],
+		toolMetadata: new Map([[SERVER, metadata]]),
+		config: { mcpServers: { [SERVER]: {} as McpExtensionState["config"]["mcpServers"][string] } },
+		failureTracker: new Map(),
+		uiResourceHandler: {} as McpExtensionState["uiResourceHandler"],
+		consentManager: {} as McpExtensionState["consentManager"],
+		uiServer: null,
+		completedUiSessions: [],
+		openBrowser: async () => {},
+		dynamicToolNames: new Set(),
+	} as unknown as McpExtensionState
+}
+
+function resultText(result: { content: Array<{ type: string; text?: string }> }): string {
+	const block = result.content[0]
+	return block?.type === "text" ? (block.text ?? "") : ""
+}
+
+describe("executeSearch — read-only marker", () => {
+	it("appends [read-only] for an annotated read-only tool (readOnlyHint:true)", () => {
+		const meta = makeMetadata("get_record", { readOnlyHint: true })
+		const state = makeState([meta])
+
+		const result = executeSearch(state, "record", undefined, undefined, undefined, undefined, 5)
+		const text = resultText(result)
+
+		expect(text).toContain("[read-only]")
+		expect(text).toContain(meta.name)
+	})
+
+	it("appends [read-only] for an un-annotated heuristic-matching tool (get_ prefix)", () => {
+		const meta = makeMetadata("get_record") // no annotations -> heuristic
+		const state = makeState([meta])
+
+		const result = executeSearch(state, "record", undefined, undefined, undefined, undefined, 5)
+		const text = resultText(result)
+
+		expect(text).toContain("[read-only]")
+	})
+
+	it("does not append [read-only] for an explicit write tool (readOnlyHint:false, non-matching name)", () => {
+		const meta = makeMetadata("create_record", { readOnlyHint: false })
+		const state = makeState([meta])
+
+		const result = executeSearch(state, "record", undefined, undefined, undefined, undefined, 5)
+		const text = resultText(result)
+
+		expect(text).not.toContain("[read-only]")
+		expect(text).toContain(meta.name)
+	})
+
+	it("does not append [read-only] for an un-annotated non-matching tool name", () => {
+		const meta = makeMetadata("create_record") // no annotations, non-matching prefix
+		const state = makeState([meta])
+
+		const result = executeSearch(state, "record", undefined, undefined, undefined, undefined, 5)
+		const text = resultText(result)
+
+		expect(text).not.toContain("[read-only]")
+	})
+
+	it("surfaces the marker in compact (includeSchemas=false) output too", () => {
+		const meta = makeMetadata("get_record", { readOnlyHint: true })
+		const state = makeState([meta])
+
+		const result = executeSearch(state, "record", undefined, undefined, false, undefined, 5)
+		const text = resultText(result)
+
+		expect(text).toContain("[read-only]")
+	})
+})
+
+describe("executeDescribe — read-only marker", () => {
+	it("includes a Read-only line for an annotated read-only tool (readOnlyHint:true)", () => {
+		const meta = makeMetadata("get_record", { readOnlyHint: true })
+		const state = makeState([meta])
+
+		const result = executeDescribe(state, meta.name)
+		const text = resultText(result)
+
+		expect(text).toContain("Read-only:")
+		expect(text).toContain("safe to call during planning/scoping")
+	})
+
+	it("includes a Read-only line for an un-annotated heuristic-matching tool", () => {
+		const meta = makeMetadata("get_record")
+		const state = makeState([meta])
+
+		const result = executeDescribe(state, meta.name)
+		const text = resultText(result)
+
+		expect(text).toContain("Read-only:")
+	})
+
+	it("does not include a Read-only line for an explicit write tool", () => {
+		const meta = makeMetadata("create_record", { readOnlyHint: false })
+		const state = makeState([meta])
+
+		const result = executeDescribe(state, meta.name)
+		const text = resultText(result)
+
+		expect(text).not.toContain("Read-only:")
+		expect(text).toContain(meta.name)
+	})
+
+	it("does not include a Read-only line for an un-annotated non-matching tool name", () => {
+		const meta = makeMetadata("create_record")
+		const state = makeState([meta])
+
+		const result = executeDescribe(state, meta.name)
+		const text = resultText(result)
+
+		expect(text).not.toContain("Read-only:")
+	})
+})

--- a/src/extensions/mcp-adapter/proxy-modes.ts
+++ b/src/extensions/mcp-adapter/proxy-modes.ts
@@ -15,7 +15,7 @@ import {
 } from "./init.js"
 import { authenticate, supportsOAuth } from "./mcp-auth-flow.js"
 import type { McpExtensionState } from "./state.js"
-import { buildToolMetadata, findToolByName, formatSchema, getToolNames } from "./tool-metadata.js"
+import { buildToolMetadata, findToolByName, formatSchema, getToolNames, isReadOnlyMcpTool } from "./tool-metadata.js"
 import { transformMcpContent } from "./tool-registrar.js"
 import type { DirectToolSpec, McpContent, ToolMetadata } from "./types.js"
 import { getServerPrefix, parseUiPromptHandoff } from "./types.js"
@@ -339,6 +339,9 @@ export function executeDescribe(
 	if (toolMeta.resourceUri) {
 		text += `Type: Resource (reads from ${toolMeta.resourceUri})\n`
 	}
+	if (isReadOnlyMcpTool(toolMeta)) {
+		text += `Read-only: safe to call during planning/scoping\n`
+	}
 	text += `\n${toolMeta.description || "(no description)"}\n`
 
 	if (toolMeta.inputSchema && !toolMeta.resourceUri) {
@@ -507,7 +510,7 @@ export function executeSearch(
 
 	for (const match of limitedMatches) {
 		if (showSchemas) {
-			text += `${match.tool.name}\n`
+			text += `${match.tool.name}${isReadOnlyMcpTool(match.tool) ? " [read-only]" : ""}\n`
 			text += `  ${match.tool.description || "(no description)"}\n`
 			if (match.tool.inputSchema && !match.tool.resourceUri) {
 				text += `\n  Parameters:\n${formatSchema(match.tool.inputSchema, "    ")}\n`
@@ -516,7 +519,7 @@ export function executeSearch(
 			}
 			text += "\n"
 		} else {
-			text += `- ${match.tool.name}`
+			text += `- ${match.tool.name}${isReadOnlyMcpTool(match.tool) ? " [read-only]" : ""}`
 			if (match.tool.description) {
 				text += ` - ${truncateAtWord(match.tool.description, 50)}`
 			}

--- a/src/extensions/mcp-adapter/tool-metadata.test.ts
+++ b/src/extensions/mcp-adapter/tool-metadata.test.ts
@@ -1,0 +1,115 @@
+/**
+ * Unit tests for `buildToolMetadata` and `isReadOnlyMcpTool`.
+ *
+ * Verifies that the live fetch path carries an MCP tool's `annotations`
+ * through to the resulting `ToolMetadata` — specifically that a tool
+ * annotated `{ readOnlyHint: true }` survives with that hint intact, and
+ * that un-annotated tools surface `annotations === undefined`.
+ *
+ * Also verifies the `isReadOnlyMcpTool` predicate: annotated read tools
+ * return true, un-annotated tools whose name matches the read-only heuristic
+ * prefixes (`get_`, `search_`, `list_`, `read_`, `fetch_`) return true, and
+ * explicit write tools (`readOnlyHint: false`) or non-matching names return
+ * false.
+ */
+import { describe, expect, it } from "vitest"
+import { buildToolMetadata, isReadOnlyMcpTool } from "./tool-metadata.js"
+import type { McpTool } from "./types.js"
+
+const SERVER_NAME = "testserver"
+const DEFINITION = {}
+
+describe("buildToolMetadata — annotations", () => {
+	it("preserves readOnlyHint:true on an annotated tool", () => {
+		const tools: McpTool[] = [
+			{
+				name: "get_record",
+				description: "Fetch a record",
+				annotations: { readOnlyHint: true },
+			},
+		]
+
+		const { metadata } = buildToolMetadata(tools, [], DEFINITION, SERVER_NAME, "server")
+
+		expect(metadata).toHaveLength(1)
+		expect(metadata[0].originalName).toBe("get_record")
+		expect(metadata[0].annotations).toBeDefined()
+		expect(metadata[0].annotations?.readOnlyHint).toBe(true)
+	})
+
+	it("surfaces annotations === undefined for an un-annotated tool", () => {
+		const tools: McpTool[] = [
+			{
+				name: "create_record",
+				description: "Create a record",
+			},
+		]
+
+		const { metadata } = buildToolMetadata(tools, [], DEFINITION, SERVER_NAME, "server")
+
+		expect(metadata).toHaveLength(1)
+		expect(metadata[0].annotations).toBeUndefined()
+	})
+
+	it("preserves a destructiveHint annotation alongside readOnlyHint", () => {
+		const tools: McpTool[] = [
+			{
+				name: "delete_record",
+				description: "Delete a record",
+				annotations: { readOnlyHint: false, destructiveHint: true },
+			},
+		]
+
+		const { metadata } = buildToolMetadata(tools, [], DEFINITION, SERVER_NAME, "server")
+
+		expect(metadata[0].annotations?.readOnlyHint).toBe(false)
+		expect(metadata[0].annotations?.destructiveHint).toBe(true)
+	})
+})
+
+describe("isReadOnlyMcpTool", () => {
+	it("returns true for an annotated read tool (readOnlyHint:true)", () => {
+		expect(
+			isReadOnlyMcpTool({
+				originalName: "get_issue",
+				annotations: { readOnlyHint: true },
+			}),
+		).toBe(true)
+	})
+
+	it("returns true for an un-annotated tool matching the get_ heuristic", () => {
+		expect(isReadOnlyMcpTool({ originalName: "get_issue" })).toBe(true)
+	})
+
+	it("returns true for un-annotated tools matching other heuristic prefixes", () => {
+		expect(isReadOnlyMcpTool({ originalName: "search_records" })).toBe(true)
+		expect(isReadOnlyMcpTool({ originalName: "list_projects" })).toBe(true)
+		expect(isReadOnlyMcpTool({ originalName: "read_file" })).toBe(true)
+		expect(isReadOnlyMcpTool({ originalName: "fetch_status" })).toBe(true)
+	})
+
+	it("returns false for an explicit write tool (readOnlyHint:false)", () => {
+		expect(
+			isReadOnlyMcpTool({
+				originalName: "update_issue",
+				annotations: { readOnlyHint: false },
+			}),
+		).toBe(false)
+	})
+
+	it("returns false for an un-annotated tool with a non-matching name", () => {
+		expect(isReadOnlyMcpTool({ originalName: "create_issue" })).toBe(false)
+		expect(isReadOnlyMcpTool({ originalName: "delete_issue" })).toBe(false)
+	})
+
+	it("returns false for a read-prefixed name when annotations mark it as write", () => {
+		// The heuristic only applies when annotations are absent; an explicit
+		// readOnlyHint:false must win even for a get_-prefixed name.
+		expect(
+			isReadOnlyMcpTool({
+				originalName: "get_secret",
+				annotations: { readOnlyHint: false },
+			}),
+		).toBe(false)
+	})
+})

--- a/src/extensions/mcp-adapter/tool-metadata.ts
+++ b/src/extensions/mcp-adapter/tool-metadata.ts
@@ -27,6 +27,11 @@ export function isReadOnlyMcpTool(meta: {
 }): boolean {
 	if (meta.annotations?.readOnlyHint === true) return true
 	if (meta.annotations === undefined && READ_ONLY_NAME_PREFIXES.test(meta.originalName)) {
+		// The name heuristic is best-effort: a tool with no annotations but a
+		// read-only-prefixed name (e.g. `get_reset_database`) cannot be proven
+		// safe, so we promote it and surface a warning so operators can audit
+		// the classification. Servers SHOULD set readOnlyHint explicitly.
+		console.warn(`[mcp] Tool "${meta.originalName}" promoted to read-only via name heuristic (no annotations)`)
 		return true
 	}
 	return false

--- a/src/extensions/mcp-adapter/tool-metadata.ts
+++ b/src/extensions/mcp-adapter/tool-metadata.ts
@@ -1,9 +1,36 @@
 import { getToolUiResourceUri } from "@modelcontextprotocol/ext-apps/app-bridge"
+import type { ToolAnnotations } from "@modelcontextprotocol/sdk/types.js"
 import { resourceNameToToolName } from "./resource-tools.js"
 import type { McpExtensionState } from "./state.js"
 import type { McpResource, McpTool, ServerEntry, ToolMetadata } from "./types.js"
 import { formatToolName, isToolExcluded } from "./types.js"
 import { extractToolUiStreamMode } from "./utils.js"
+
+/**
+ * Heuristic name prefixes that indicate a read-only MCP tool when the server
+ * does not populate `annotations.readOnlyHint`.
+ */
+const READ_ONLY_NAME_PREFIXES = /^(get_|search_|list_|read_|fetch_)/
+
+/**
+ * Returns true when an MCP tool is safe to call during read-only (scoping)
+ * contexts. A tool qualifies when its `annotations.readOnlyHint` is explicitly
+ * `true`, OR when annotations are absent and the tool's original name matches a
+ * read-only heuristic prefix (`get_`, `search_`, `list_`, `read_`, `fetch_`).
+ *
+ * A tool with `readOnlyHint: false` (or any annotations present) is never
+ * promoted by the heuristic — the explicit annotation wins.
+ */
+export function isReadOnlyMcpTool(meta: {
+	originalName: string
+	annotations?: ToolAnnotations
+}): boolean {
+	if (meta.annotations?.readOnlyHint === true) return true
+	if (meta.annotations === undefined && READ_ONLY_NAME_PREFIXES.test(meta.originalName)) {
+		return true
+	}
+	return false
+}
 
 export function buildToolMetadata(
 	tools: McpTool[],
@@ -37,6 +64,7 @@ export function buildToolMetadata(
 			inputSchema: tool.inputSchema,
 			uiResourceUri,
 			uiStreamMode: extractToolUiStreamMode(tool._meta),
+			annotations: tool.annotations,
 		})
 	}
 

--- a/src/extensions/mcp-adapter/types.ts
+++ b/src/extensions/mcp-adapter/types.ts
@@ -3,6 +3,7 @@ import type { SSEClientTransport } from "@modelcontextprotocol/sdk/client/sse.js
 // types.ts - Core type definitions
 import type { StdioClientTransport } from "@modelcontextprotocol/sdk/client/stdio.js"
 import type { StreamableHTTPClientTransport } from "@modelcontextprotocol/sdk/client/streamableHttp.js"
+import type { ToolAnnotations } from "@modelcontextprotocol/sdk/types.js"
 import type { UiStreamMode } from "./ui-stream-types.js"
 
 // Transport type (stdio + HTTP)
@@ -17,6 +18,7 @@ export interface McpTool {
 	title?: string
 	description?: string
 	inputSchema?: unknown // JSON Schema
+	annotations?: ToolAnnotations // Read-only/destructive hints from the MCP protocol
 	_meta?: Record<string, unknown>
 }
 
@@ -331,6 +333,7 @@ export interface ToolMetadata {
 	uiResourceUri?: string // For app-enabled tools: the UI resource URI
 	inputSchema?: unknown // JSON Schema for parameters (stored for describe/errors)
 	uiStreamMode?: UiStreamMode
+	annotations?: ToolAnnotations // Read-only/destructive hints from the MCP protocol
 }
 
 export interface DirectToolSpec {
@@ -342,6 +345,7 @@ export interface DirectToolSpec {
 	resourceUri?: string
 	uiResourceUri?: string
 	uiStreamMode?: UiStreamMode
+	annotations?: ToolAnnotations // Read-only/destructive hints from the MCP protocol
 	/** Cached schema for auto-fill and retry decisions */
 	metadata?: ToolMetadata
 }

--- a/src/shared/planning/read-only-tool-registry.test.ts
+++ b/src/shared/planning/read-only-tool-registry.test.ts
@@ -1,0 +1,96 @@
+import type { ExtensionAPI } from "@earendil-works/pi-coding-agent"
+import { beforeEach, describe, expect, it, vi } from "vitest"
+
+import { getReadOnlyToolNames, registerReadOnlyToolProvider } from "./read-only-tool-registry.js"
+
+/**
+ * Build a fresh mock ExtensionAPI. Each call returns a new object so the
+ * WeakMap keys are distinct per test — providers registered in one test never
+ * leak into another, even without an explicit clear().
+ */
+const makeMockPi = (): ExtensionAPI => {
+	const on = vi.fn()
+	return { on } as unknown as ExtensionAPI
+}
+
+describe("read-only-tool-registry", () => {
+	beforeEach(() => {
+		// Each test constructs its own mock pi, so the WeakMap starts empty for
+		// that key. No module-level reset is required.
+	})
+
+	it("returns an empty array when no providers are registered", () => {
+		const pi = makeMockPi()
+
+		expect(getReadOnlyToolNames(pi)).toEqual([])
+	})
+
+	it("returns the union of names from two registered providers", () => {
+		const pi = makeMockPi()
+		registerReadOnlyToolProvider(pi, () => ["server_get_record", "server_search_items"])
+		registerReadOnlyToolProvider(pi, () => ["server_list_things", "server_read_doc"])
+
+		const result = getReadOnlyToolNames(pi)
+
+		expect(result).toEqual(["server_get_record", "server_search_items", "server_list_things", "server_read_doc"])
+	})
+
+	it("deduplicates names that appear in multiple providers", () => {
+		const pi = makeMockPi()
+		registerReadOnlyToolProvider(pi, () => ["server_get_record", "server_shared_tool"])
+		registerReadOnlyToolProvider(pi, () => ["server_shared_tool", "server_list_things"])
+
+		const result = getReadOnlyToolNames(pi)
+
+		// "server_shared_tool" must appear exactly once.
+		expect(result.filter((n) => n === "server_shared_tool")).toHaveLength(1)
+		expect(result).toEqual(["server_get_record", "server_shared_tool", "server_list_things"])
+	})
+
+	it("reflects the latest state when a provider is called lazily", () => {
+		const pi = makeMockPi()
+		let current: string[] = ["server_get_record"]
+		registerReadOnlyToolProvider(pi, () => current)
+
+		expect(getReadOnlyToolNames(pi)).toEqual(["server_get_record"])
+
+		// Mutate the provider's data source — the next read should reflect it.
+		current = ["server_get_record", "server_search_items"]
+		expect(getReadOnlyToolNames(pi)).toEqual(["server_get_record", "server_search_items"])
+	})
+
+	it("ignores providers registered under a different pi instance", () => {
+		const piA = makeMockPi()
+		const piB = makeMockPi()
+		registerReadOnlyToolProvider(piA, () => ["server_get_record"])
+
+		// piB has no providers — must return empty even though piA has one.
+		expect(getReadOnlyToolNames(piB)).toEqual([])
+	})
+
+	it("registers a session_shutdown listener on first registration", () => {
+		const pi = makeMockPi()
+		registerReadOnlyToolProvider(pi, () => ["server_get_record"])
+
+		expect(pi.on).toHaveBeenCalledWith("session_shutdown", expect.any(Function))
+	})
+
+	it("does not double-register the same provider reference", () => {
+		const pi = makeMockPi()
+		const provider = (): string[] => ["server_get_record"]
+		registerReadOnlyToolProvider(pi, provider)
+		registerReadOnlyToolProvider(pi, provider)
+
+		// Even after two registrations of the same fn, only one call site —
+		// but getReadOnlyToolNames should still return the names once.
+		expect(getReadOnlyToolNames(pi)).toEqual(["server_get_record"])
+	})
+
+	it("handles a provider that returns an empty array", () => {
+		const pi = makeMockPi()
+		registerReadOnlyToolProvider(pi, () => [])
+		registerReadOnlyToolProvider(pi, () => ["server_get_record"])
+
+		expect(getReadOnlyToolNames(pi)).toEqual(["server_get_record"])
+	})
+})

--- a/src/shared/planning/read-only-tool-registry.ts
+++ b/src/shared/planning/read-only-tool-registry.ts
@@ -1,0 +1,90 @@
+/**
+ * # Read-only tool provider registry
+ *
+ * Allows extensions to register a provider function that returns the names of
+ * read-only-qualified tools they own. The planning-ferment tool-profile layer
+ * (`applyCore` in `tool-profile-manager.ts`) consults `getReadOnlyToolNames`
+ * to union these names into the active set during scoping — the only profile
+ * where write tools are blocked by default.
+ *
+ * The registry is keyed on the pi-mono `ExtensionAPI` instance via a WeakMap,
+ * mirroring the pattern in `tool-visibility.ts`. Providers are cleared
+ * automatically when the session shuts down (the `pi` reference is GC'd).
+ *
+ * ## Why a registry?
+ *
+ * The shared/planning layer must not import from `src/extensions/mcp-adapter`
+ * directly (that would invert the dependency). Instead, the mcp-adapter
+ * extension registers a provider at init time; `applyCore` calls
+ * `getReadOnlyToolNames` without knowing which extensions contributed.
+ */
+
+import type { ExtensionAPI } from "@earendil-works/pi-coding-agent"
+
+/** A function that returns the current set of read-only-qualified tool names. */
+export type ReadOnlyToolProvider = () => string[]
+
+const providersByPi = new WeakMap<ExtensionAPI, ReadOnlyToolProvider[]>()
+
+/**
+ * Register a read-only-tool provider for the given session.
+ *
+ * Multiple providers may be registered per session; `getReadOnlyToolNames`
+ * unions all results. Registration is idempotent per function reference —
+ * registering the same provider twice has no effect.
+ *
+ * @param pi       - The pi-mono `ExtensionAPI` instance for this session.
+ * @param provider - A function returning the read-only-qualified tool names.
+ *                   Called lazily on each `getReadOnlyToolNames` invocation so
+ *                   it always reflects the current tool-metadata state.
+ */
+export function registerReadOnlyToolProvider(pi: ExtensionAPI, provider: ReadOnlyToolProvider): void {
+	let providers = providersByPi.get(pi)
+	if (!providers) {
+		providers = []
+		providersByPi.set(pi, providers)
+		// Clean up on session shutdown. We never touch `pi` from inside the
+		// handler — pi-mono marks the runtime stale at this point.
+		pi.on("session_shutdown", () => {
+			providersByPi.delete(pi)
+		})
+	}
+	if (providers.includes(provider)) return
+	providers.push(provider)
+}
+
+/**
+ * Return the union of all read-only-qualified tool names from registered
+ * providers for this session. Returns an empty array when no providers are
+ * registered. Duplicates across providers are collapsed.
+ *
+ * @param pi - The pi-mono `ExtensionAPI` instance for this session.
+ */
+export function getReadOnlyToolNames(pi: ExtensionAPI): string[] {
+	const providers = providersByPi.get(pi)
+	if (!providers || providers.length === 0) return []
+	const seen = new Set<string>()
+	const result: string[] = []
+	for (const provider of providers) {
+		for (const name of provider()) {
+			if (!seen.has(name)) {
+				seen.add(name)
+				result.push(name)
+			}
+		}
+	}
+	return result
+}
+
+/**
+ * Reset the registry. Exported for test isolation so each test starts with a
+ * clean WeakMap.
+ *
+ * @internal — test-only.
+ */
+export function resetReadOnlyToolRegistry(): void {
+	// WeakMap has no clear(); we rely on GC + test-isolation by removing keys.
+	// In tests, each case typically uses a fresh `pi` mock, so the WeakMap
+	// naturally has no entries. This function is a no-op kept for API symmetry
+	// with `resetAll()` in tool-profile-manager.ts.
+}

--- a/src/shared/planning/read-only-tool-registry.ts
+++ b/src/shared/planning/read-only-tool-registry.ts
@@ -24,7 +24,7 @@ import type { ExtensionAPI } from "@earendil-works/pi-coding-agent"
 /** A function that returns the current set of read-only-qualified tool names. */
 export type ReadOnlyToolProvider = () => string[]
 
-const providersByPi = new WeakMap<ExtensionAPI, ReadOnlyToolProvider[]>()
+let providersByPi = new WeakMap<ExtensionAPI, ReadOnlyToolProvider[]>()
 
 /**
  * Register a read-only-tool provider for the given session.
@@ -66,7 +66,16 @@ export function getReadOnlyToolNames(pi: ExtensionAPI): string[] {
 	const seen = new Set<string>()
 	const result: string[] = []
 	for (const provider of providers) {
-		for (const name of provider()) {
+		// A misbehaving provider must not break the planning phase — log and
+		// skip it, then continue with the remaining providers.
+		let names: string[]
+		try {
+			names = provider()
+		} catch (err) {
+			console.error("read-only tool provider threw, skipping", err)
+			continue
+		}
+		for (const name of names) {
 			if (!seen.has(name)) {
 				seen.add(name)
 				result.push(name)
@@ -78,13 +87,12 @@ export function getReadOnlyToolNames(pi: ExtensionAPI): string[] {
 
 /**
  * Reset the registry. Exported for test isolation so each test starts with a
- * clean WeakMap.
+ * clean WeakMap. Replaces the underlying WeakMap so any references held by
+ * previously-registered providers (via `session_shutdown` listeners) cannot
+ * keep stale entries alive.
  *
  * @internal — test-only.
  */
 export function resetReadOnlyToolRegistry(): void {
-	// WeakMap has no clear(); we rely on GC + test-isolation by removing keys.
-	// In tests, each case typically uses a fresh `pi` mock, so the WeakMap
-	// naturally has no entries. This function is a no-op kept for API symmetry
-	// with `resetAll()` in tool-profile-manager.ts.
+	providersByPi = new WeakMap()
 }

--- a/src/shared/planning/tool-profile-manager.test.ts
+++ b/src/shared/planning/tool-profile-manager.test.ts
@@ -1,6 +1,8 @@
 import type { ExtensionAPI } from "@earendil-works/pi-coding-agent"
 import { beforeEach, describe, expect, it, vi } from "vitest"
 
+import { isReadOnlyMcpTool } from "../../extensions/mcp-adapter/tool-metadata.js"
+import { registerReadOnlyToolProvider, resetReadOnlyToolRegistry } from "./read-only-tool-registry.js"
 import { getToolsForProfile } from "./tool-catalog.js"
 import {
 	apply,
@@ -24,8 +26,12 @@ const makeMockPi = (overrides: { allTools?: Array<{ name: string }> } = {}): Ext
 
 // Reset both module-level state variables before every test so runs are
 // fully independent even though the ESM module is evaluated once per VM.
+// Also reset the read-only-tool registry so provider registrations from one
+// test do not leak into another (the WeakMap is keyed on the mock pi, which
+// is freshly constructed per test).
 beforeEach(() => {
 	resetAll()
+	resetReadOnlyToolRegistry()
 })
 
 describe("apply", () => {
@@ -110,6 +116,69 @@ describe("apply", () => {
 		expect(calledWith).toContain("write")
 		expect(calledWith).toContain("Agent")
 	})
+	describe("planning-ferment read-only MCP union", () => {
+		it("includes read-only-qualified tool names from registered providers", () => {
+			const pi = makeMockPi()
+			registerReadOnlyToolProvider(pi, () => ["server_get_record", "server_search_items"])
+
+			apply("planning-ferment", "ferment", pi)
+
+			const calledWith = (pi.setActiveTools as ReturnType<typeof vi.fn>).mock.calls[0][0] as string[]
+			expect(calledWith).toContain("server_get_record")
+			expect(calledWith).toContain("server_search_items")
+			// Catalog tools are still present
+			expect(calledWith).toContain("read")
+		})
+
+		it("includes read-only-qualified tool names under planning-adhoc (else branch widened)", () => {
+			const pi = makeMockPi()
+			registerReadOnlyToolProvider(pi, () => ["server_get_record"])
+
+			apply("planning-adhoc", "adhoc", pi)
+
+			const calledWith = (pi.setActiveTools as ReturnType<typeof vi.fn>).mock.calls[0][0] as string[]
+			expect(calledWith).toContain("server_get_record")
+		})
+
+		it("unions providers and deduplicates overlapping names", () => {
+			const pi = makeMockPi()
+			registerReadOnlyToolProvider(pi, () => ["server_get_record"])
+			registerReadOnlyToolProvider(pi, () => ["server_get_record", "server_list_things"])
+
+			apply("planning-ferment", "ferment", pi)
+
+			const calledWith = (pi.setActiveTools as ReturnType<typeof vi.fn>).mock.calls[0][0] as string[]
+			const occurrences = calledWith.filter((n) => n === "server_get_record").length
+			expect(occurrences).toBe(1)
+			expect(calledWith).toContain("server_list_things")
+		})
+
+		it("includes nothing extra when no providers are registered", () => {
+			const pi = makeMockPi()
+
+			apply("planning-ferment", "ferment", pi)
+
+			const calledWith = (pi.setActiveTools as ReturnType<typeof vi.fn>).mock.calls[0][0] as string[]
+			const expected = getToolsForProfile("planning-ferment").map((t) => t.name)
+			expect(calledWith).toEqual(expected)
+		})
+
+		it("respects the cooperative-visibility disabled filter for read-only tools", () => {
+			const pi = makeMockPi()
+			registerReadOnlyToolProvider(pi, () => ["server_get_record"])
+			// Simulate the cooperative layer voting to hide the read-only tool.
+			// We do this by making getDisabledToolNames return it — but since
+			// that helper reads from the real tool-visibility WeakMap, we instead
+			// verify the filter is applied by checking a disabled catalog tool is
+			// excluded. The disabled-filter runs after the union, so a disabled
+			// read-only name would also be filtered — covered indirectly by the
+			// existing snapshot/cooperative tests.
+			apply("planning-ferment", "ferment", pi)
+
+			const calledWith = (pi.setActiveTools as ReturnType<typeof vi.fn>).mock.calls[0][0] as string[]
+			expect(calledWith).toContain("server_get_record")
+		})
+	})
 })
 
 describe("applyCooperativeTweak", () => {
@@ -165,5 +234,132 @@ describe("installTurnBoundaryReset", () => {
 
 		// Flag must be cleared.
 		expect(isSnapshotAppliedThisTurn()).toBe(false)
+	})
+})
+
+describe("read-only MCP filter integration (planning-ferment vs implementation-ferment)", () => {
+	// Simulated MCP tool metadata — mirrors what mcp-adapter's
+	// `state.toolMetadata` holds after a server connects. The provider closure
+	// below mirrors `readOnlyToolProvider` in src/extensions/mcp-adapter/index.ts:
+	// it iterates the metadata and returns names where `isReadOnlyMcpTool` holds.
+	const mcpToolMetadata = [
+		{
+			name: "server_get_record",
+			originalName: "get_record",
+			description: "Read a record",
+			annotations: { readOnlyHint: true } as const,
+		},
+		{
+			name: "server_create_record",
+			originalName: "create_record",
+			description: "Create a record",
+			annotations: { readOnlyHint: false } as const,
+		},
+		{
+			name: "server_delete_record",
+			originalName: "delete_record",
+			description: "Delete a record",
+			annotations: { readOnlyHint: false, destructiveHint: true } as const,
+		},
+	]
+
+	/** Provider that mirrors mcp-adapter's readOnlyToolProvider exactly. */
+	const mcpReadOnlyProvider = (): string[] => mcpToolMetadata.filter((m) => isReadOnlyMcpTool(m)).map((m) => m.name)
+
+	it("planning-ferment: includes read-only MCP tool and excludes write/destructive MCP tools", () => {
+		const pi = makeMockPi()
+		registerReadOnlyToolProvider(pi, mcpReadOnlyProvider)
+
+		apply("planning-ferment", "ferment", pi)
+
+		const calledWith = (pi.setActiveTools as ReturnType<typeof vi.fn>).mock.calls[0][0] as string[]
+		// Read-only tool is included
+		expect(calledWith).toContain("server_get_record")
+		// Write tools are NOT included — they're neither in the catalog nor read-only-qualified
+		expect(calledWith).not.toContain("server_create_record")
+		expect(calledWith).not.toContain("server_delete_record")
+		// Catalog tools are still present
+		expect(calledWith).toContain("read")
+	})
+
+	it("planning-ferment: heuristic-only read-only tool (no annotations) is included", () => {
+		// Tool with no annotations but a get_ prefix — qualifies via heuristic
+		const heuristicMetadata = [
+			{ name: "server_search_items", originalName: "search_items", description: "Search" },
+			{
+				name: "server_update_record",
+				originalName: "update_record",
+				description: "Update",
+				annotations: { readOnlyHint: false } as const,
+			},
+		]
+		const provider = (): string[] => heuristicMetadata.filter((m) => isReadOnlyMcpTool(m)).map((m) => m.name)
+
+		const pi = makeMockPi()
+		registerReadOnlyToolProvider(pi, provider)
+
+		apply("planning-ferment", "ferment", pi)
+
+		const calledWith = (pi.setActiveTools as ReturnType<typeof vi.fn>).mock.calls[0][0] as string[]
+		expect(calledWith).toContain("server_search_items")
+		expect(calledWith).not.toContain("server_update_record")
+	})
+
+	it("planning-adhoc: includes read-only MCP tool and excludes write MCP tools", () => {
+		const pi = makeMockPi()
+		registerReadOnlyToolProvider(pi, mcpReadOnlyProvider)
+
+		apply("planning-adhoc", "adhoc", pi)
+
+		const calledWith = (pi.setActiveTools as ReturnType<typeof vi.fn>).mock.calls[0][0] as string[]
+		// Read-only tool is included
+		expect(calledWith).toContain("server_get_record")
+		// Write tools are NOT included
+		expect(calledWith).not.toContain("server_create_record")
+		expect(calledWith).not.toContain("server_delete_record")
+	})
+
+	it("implementation-ferment: includes ALL MCP tools (read and write)", () => {
+		const pi = makeMockPi({
+			allTools: [
+				{ name: "read" },
+				{ name: "bash" },
+				{ name: "server_get_record" }, // read-only MCP
+				{ name: "server_create_record" }, // write MCP
+				{ name: "server_delete_record" }, // destructive MCP
+			],
+		})
+		registerReadOnlyToolProvider(pi, mcpReadOnlyProvider)
+
+		apply("implementation-ferment", "ferment", pi)
+
+		const calledWith = (pi.setActiveTools as ReturnType<typeof vi.fn>).mock.calls[0][0] as string[]
+		// All MCP tools are present — implementation phase has full access
+		expect(calledWith).toContain("server_get_record")
+		expect(calledWith).toContain("server_create_record")
+		expect(calledWith).toContain("server_delete_record")
+		// Core tools still present
+		expect(calledWith).toContain("read")
+		expect(calledWith).toContain("bash")
+	})
+
+	it("planning-ferment: write MCP tool is NOT added even if present in getAllTools", () => {
+		// Edge case: the write tool is registered in pi.getAllTools() (so it would
+		// appear under implementation-ferment), but planning-ferment must still
+		// exclude it because it's not read-only-qualified and not in the catalog.
+		const pi = makeMockPi({
+			allTools: [
+				{ name: "read" },
+				{ name: "server_get_record" }, // read-only — should appear
+				{ name: "server_create_record" }, // write — must NOT appear
+			],
+		})
+		registerReadOnlyToolProvider(pi, mcpReadOnlyProvider)
+
+		apply("planning-ferment", "ferment", pi)
+
+		const calledWith = (pi.setActiveTools as ReturnType<typeof vi.fn>).mock.calls[0][0] as string[]
+		expect(calledWith).toContain("server_get_record")
+		expect(calledWith).not.toContain("server_create_record")
 	})
 })

--- a/src/shared/planning/tool-profile-manager.test.ts
+++ b/src/shared/planning/tool-profile-manager.test.ts
@@ -1,7 +1,7 @@
 import type { ExtensionAPI } from "@earendil-works/pi-coding-agent"
 import { beforeEach, describe, expect, it, vi } from "vitest"
 
-import { isReadOnlyMcpTool } from "../../extensions/mcp-adapter/tool-metadata.js"
+import { createToolVisibility } from "../../extensions/prompt-construction/tool-visibility.js"
 import { registerReadOnlyToolProvider, resetReadOnlyToolRegistry } from "./read-only-tool-registry.js"
 import { getToolsForProfile } from "./tool-catalog.js"
 import {
@@ -17,10 +17,20 @@ const makeMockPi = (overrides: { allTools?: Array<{ name: string }> } = {}): Ext
 	const setActiveTools = vi.fn()
 	const on = vi.fn()
 	const getAllTools = vi.fn(() => overrides.allTools ?? [])
+	// The cooperative visibility layer calls pi.getActiveTools() and
+	// pi.setActiveTools() when applying a disable vote. Provide a real list
+	// backed by the same mock so disabling a tool before apply() records the
+	// vote correctly.
+	let activeTools: string[] = []
+	const getActiveTools = vi.fn(() => activeTools)
+	const wrappedSetActiveTools = vi.fn((names: string[]) => {
+		activeTools = [...names]
+	})
 	return {
-		setActiveTools,
+		setActiveTools: wrappedSetActiveTools,
 		on,
 		getAllTools,
+		getActiveTools,
 	} as unknown as ExtensionAPI
 }
 
@@ -166,17 +176,20 @@ describe("apply", () => {
 		it("respects the cooperative-visibility disabled filter for read-only tools", () => {
 			const pi = makeMockPi()
 			registerReadOnlyToolProvider(pi, () => ["server_get_record"])
-			// Simulate the cooperative layer voting to hide the read-only tool.
-			// We do this by making getDisabledToolNames return it — but since
-			// that helper reads from the real tool-visibility WeakMap, we instead
-			// verify the filter is applied by checking a disabled catalog tool is
-			// excluded. The disabled-filter runs after the union, so a disabled
-			// read-only name would also be filtered — covered indirectly by the
-			// existing snapshot/cooperative tests.
+			// Simulate the cooperative layer voting to hide the read-only MCP
+			// tool. `createToolVisibility` reads `pi.getActiveTools()` and
+			// writes back via `pi.setActiveTools()`; the mock above mirrors
+			// that. The disable vote must propagate through the WeakMap so
+			// `getDisabledToolNames(pi)` returns it when `applyCore` runs.
+			createToolVisibility(pi).disable(["server_get_record"])
+			// Clear the disable's own setActiveTools call so the assertion below
+			// observes the apply() call only.
+			vi.mocked(pi.setActiveTools).mockClear()
+
 			apply("planning-ferment", "ferment", pi)
 
 			const calledWith = (pi.setActiveTools as ReturnType<typeof vi.fn>).mock.calls[0][0] as string[]
-			expect(calledWith).toContain("server_get_record")
+			expect(calledWith).not.toContain("server_get_record")
 		})
 	})
 })
@@ -238,33 +251,17 @@ describe("installTurnBoundaryReset", () => {
 })
 
 describe("read-only MCP filter integration (planning-ferment vs implementation-ferment)", () => {
-	// Simulated MCP tool metadata — mirrors what mcp-adapter's
-	// `state.toolMetadata` holds after a server connects. The provider closure
-	// below mirrors `readOnlyToolProvider` in src/extensions/mcp-adapter/index.ts:
-	// it iterates the metadata and returns names where `isReadOnlyMcpTool` holds.
-	const mcpToolMetadata = [
-		{
-			name: "server_get_record",
-			originalName: "get_record",
-			description: "Read a record",
-			annotations: { readOnlyHint: true } as const,
-		},
-		{
-			name: "server_create_record",
-			originalName: "create_record",
-			description: "Create a record",
-			annotations: { readOnlyHint: false } as const,
-		},
-		{
-			name: "server_delete_record",
-			originalName: "delete_record",
-			description: "Delete a record",
-			annotations: { readOnlyHint: false, destructiveHint: true } as const,
-		},
-	]
-
-	/** Provider that mirrors mcp-adapter's readOnlyToolProvider exactly. */
-	const mcpReadOnlyProvider = (): string[] => mcpToolMetadata.filter((m) => isReadOnlyMcpTool(m)).map((m) => m.name)
+	// These tests verify the registry + profile-manager behaviour (union,
+	// inclusion, exclusion) using pre-filtered fixture arrays. They do NOT
+	// exercise `isReadOnlyMcpTool` — that predicate lives in
+	// src/extensions/mcp-adapter/tool-metadata.ts and is covered by
+	// src/extensions/mcp-adapter/tool-metadata.test.ts. Coupling to it here
+	// would invert the dependency direction (shared/planning must not import
+	// from src/extensions/mcp-adapter).
+	//
+	// Fixture: three MCP tools behind a server. Only `server_get_record` is
+	// read-only-qualified (annotated with readOnlyHint:true).
+	const mcpReadOnlyProvider = (): string[] => ["server_get_record"]
 
 	it("planning-ferment: includes read-only MCP tool and excludes write/destructive MCP tools", () => {
 		const pi = makeMockPi()
@@ -283,20 +280,11 @@ describe("read-only MCP filter integration (planning-ferment vs implementation-f
 	})
 
 	it("planning-ferment: heuristic-only read-only tool (no annotations) is included", () => {
-		// Tool with no annotations but a get_ prefix — qualifies via heuristic
-		const heuristicMetadata = [
-			{ name: "server_search_items", originalName: "search_items", description: "Search" },
-			{
-				name: "server_update_record",
-				originalName: "update_record",
-				description: "Update",
-				annotations: { readOnlyHint: false } as const,
-			},
-		]
-		const provider = (): string[] => heuristicMetadata.filter((m) => isReadOnlyMcpTool(m)).map((m) => m.name)
-
+		// A separate provider whose read-only set is hardcoded — simulates a
+		// server that classified its tools via the name heuristic rather than
+		// annotations. The fixture asserts the registry treats it as read-only.
 		const pi = makeMockPi()
-		registerReadOnlyToolProvider(pi, provider)
+		registerReadOnlyToolProvider(pi, () => ["server_search_items"])
 
 		apply("planning-ferment", "ferment", pi)
 

--- a/src/shared/planning/tool-profile-manager.ts
+++ b/src/shared/planning/tool-profile-manager.ts
@@ -36,6 +36,7 @@ import type { ExtensionAPI } from "@earendil-works/pi-coding-agent"
 
 import { isFermentOnlyToolName } from "../../extensions/ferment/tool-names.js"
 import { getDisabledToolNames } from "../../extensions/prompt-construction/tool-visibility.js"
+import { getReadOnlyToolNames } from "./read-only-tool-registry.js"
 import { getToolsForProfile } from "./tool-catalog.js"
 import type { ToolProfile } from "./tool-catalog.js"
 
@@ -109,11 +110,29 @@ export function applyCore(profile: ToolProfile, pi: ExtensionAPI): void {
 		allowedNames = merged.filter((name) => !disabled.has(name))
 	} else {
 		const tools = getToolsForProfile(profile)
+		allowedNames = tools.map((t) => t.name)
+
+		// During planning (both planning-ferment and planning-adhoc), union in
+		// read-only-qualified tools registered by extensions (e.g. mcp-adapter's
+		// read-only MCP tools). Write tools remain excluded — the model cannot
+		// call them during planning, mirroring the hard filter on edit/write.
+		// worker is intentionally NOT modified here so the worker phase keeps
+		// its catalog.
+		if (profile === "planning-ferment" || profile === "planning-adhoc") {
+			const readOnlyExtra = getReadOnlyToolNames(pi)
+			if (readOnlyExtra.length > 0) {
+				const existing = new Set(allowedNames)
+				for (const name of readOnlyExtra) {
+					if (!existing.has(name)) allowedNames.push(name)
+				}
+			}
+		}
+
 		// Filter out tools that the cooperative visibility layer has voted to
 		// hide.  Without this, a snapshot apply would re-surface tools that
 		// another extension disabled (e.g. ask_user / confirm_ferment_completion_
 		// criteria hidden when no UI is attached), undoing the cooperative vote.
-		allowedNames = tools.map((t) => t.name).filter((name) => !disabled.has(name))
+		allowedNames = allowedNames.filter((name) => !disabled.has(name))
 	}
 
 	pi.setActiveTools(allowedNames)


### PR DESCRIPTION
## Summary

Capture MCP `ToolAnnotations` end-to-end and enforce a hard read-only filter so that only read-only MCP tools are callable during planning (scoping) profiles, while the implementation profile keeps full MCP access.

## Changes

### Phase 1 — Types & metadata propagation
- Added `annotations?: ToolAnnotations` (from `@modelcontextprotocol/sdk`) to `McpTool` and `ToolMetadata` in `types.ts`
- `buildToolMetadata` (`tool-metadata.ts`) copies `tool.annotations` into `ToolMetadata`
- `serializeTools` / `reconstructToolMetadata` (`metadata-cache.ts`) round-trip annotations through `CachedTool`

### Phase 2 — Predicate & proxy surfacing
- Added `isReadOnlyMcpTool(meta)` helper: returns `true` when `annotations.readOnlyHint === true`, OR when annotations are absent and the original tool name starts with `get_`/`search_`/`list_`/`read_`/`fetch_`
- `mcp({search})` and `mcp({describe})` output (`proxy-modes.ts`) surfaces a `[read-only]` marker for tools whose `readOnlyHint` is true

### Phase 3 — Enforcement in planning profiles
- Created `src/shared/planning/read-only-tool-registry.ts` — WeakMap-keyed provider registry (`registerReadOnlyToolProvider` / `getReadOnlyToolNames`)
- In `tool-profile-manager.ts` `applyCore`, unioned read-only-qualified MCP tool names into the active set for both `planning-ferment` and `planning-adhoc` profiles only; `idle`, `worker`, and `implementation-ferment` untouched
- Registered an mcp-adapter provider in `index.ts` init that lazily iterates `state.toolMetadata` and returns prefixed names where `isReadOnlyMcpTool` is true

## Test coverage
- `metadata-cache.test.ts` — annotations survive serialize→reconstruct cycle
- `proxy-modes.test.ts` — `[read-only]` marker present for read-only tools, absent for write tools
- `tool-metadata.test.ts` — `isReadOnlyMcpTool` covers annotated-read, heuristic-match, and explicit-write cases
- `read-only-tool-registry.test.ts` — 8 unit tests: union, dedup, lazy evaluation, pi isolation, idempotency, session_shutdown listener
- `tool-profile-manager.test.ts` — 4 integration tests: planning-ferment includes read-only / excludes write; planning-adhoc same; implementation-ferment retains all MCP tools

## Verification
- `pnpm run lint` — clean (867 files)
- `pnpm run typecheck` — exit 0
- `pnpm run test` — 6080 passed (6 pre-existing failures in model-guard/permissions confirmed via `git stash` on clean tree)

## Checklist
- [x] Bug fix / new feature
- [ ] Breaking change
- [ ] Documentation update