### PR TITLE
fix(ferment): allow Agent spawn when a step is running

### DIFF
--- a/src/extensions/ferment/agent-spawn-guard.test.ts
+++ b/src/extensions/ferment/agent-spawn-guard.test.ts
@@ -117,6 +117,26 @@ describe("registerAgentSpawnGuard", () => {
 		expect(result).toEqual({ block: false })
 	})
 
+	// Regression: the engine forward-suggests start_step for the NEXT pending
+	// step when one step is already running (engine.test.ts:248). The guard must
+	// not treat that forward suggestion as a precondition and block the worker
+	// spawn for the running step. Reproduces the stuck session 019f0397 where
+	// the orchestrator started step-1, then Agent was blocked citing step-2.
+	it("allows Agent spawn when a step is running and a later step is pending", async () => {
+		const pi = makePi()
+		const runtime = createDefaultFermentRuntime()
+		runtime.setActive(
+			makeFerment("running", [
+				{ id: "step-1", index: 1, description: "running step", status: "running" },
+				{ id: "step-2", index: 2, description: "pending step", status: "pending" },
+			]),
+		)
+		registerAgentSpawnGuard(pi as unknown as ExtensionAPI, runtime)
+
+		const result = await pi.fireAll("tool_call", { toolName: "Agent" })
+		expect(result).toEqual({ block: false })
+	})
+
 	it("allows Agent spawn when active ferment state is malformed", async () => {
 		const pi = makePi()
 		const runtime = createDefaultFermentRuntime()

--- a/src/extensions/ferment/agent-spawn-guard.ts
+++ b/src/extensions/ferment/agent-spawn-guard.ts
@@ -80,6 +80,16 @@ function buildRedirectIfStartStepPending(runtime: FermentRuntime): { block: true
 	// Be permissive on data drift; don't block if we can't describe the step.
 	if (!phase || !step) return { block: false }
 
+	// If a step in this phase is already running, the engine's start_step action
+	// is forward-suggesting the NEXT pending step (engine branch 9 fires before
+	// branch 10's complete_step). That is not a precondition for this spawn —
+	// the orchestrator may be delegating the running step's work to a worker.
+	// Blocking here would deadlock the orchestrator out of spawning workers for
+	// any step that isn't the last in its phase. See engine.test.ts:248 for the
+	// running+pending ordering, and the JSONL session 019f0397 for the stuck
+	// repro.
+	if (phase.steps.some((s) => s.status === "running")) return { block: false }
+
 	return {
 		block: true,
 		reason: `Active ferment "${ferment.name}" has a pending step that has not been started yet.\n\nStep ${step.index} of phase ${phase.index}: "${step.description}"\n\nCall start_ferment_step first, then re-call Agent. The orchestrator owns ferment state transitions; a worker cannot start or complete steps on the ledger's behalf.`,


### PR DESCRIPTION
## Summary

The ferment agent-spawn-guard deadlocked the orchestrator out of spawning workers for any step that wasn't the last in its phase.

After `start_ferment_step(step-1)`, the engine immediately forward-suggests `start_step(step-2)` (engine branch 9 fires before branch 10's `complete_step`; codified at `engine.test.ts:248`). The guard treated that forward suggestion as a hard precondition and blocked the `Agent` spawn — so the orchestrator could never delegate the running step's work.

Observed in stuck session `019f0397`: the model started step-1, then `Agent` was blocked with *"has a pending step that has not been started yet. Step 2… Call start_ferment_step first"* — pointing at step-2 while step-1 was the running step being worked on.

## Fix

If the active phase already has a `running` step, allow the spawn. The `start_step` action is a forward suggestion of what comes next, not a precondition for spawning a worker to execute the currently-running step.

```ts
// agent-spawn-guard.ts
if (phase.steps.some((s) => s.status === "running")) return { block: false }
```

## Test plan

- [x] New regression test: running step-1 + pending step-2 → Agent spawn **allowed** (mirrors the engine's running+pending fixture at `engine.test.ts:248`)
- [x] Existing guard tests still pass (8/8), including the single-running-step case and the all-pending block case
- [x] `pnpm run typecheck` clean
- [x] `pnpm run lint` clean
- [x] `pnpm vitest run src/extensions/ferment/agent-spawn-guard.test.ts src/ferment/engine.test.ts` — 38 passed
