### PR TITLE
feat(windows-build): add Windows x64 release support

### DIFF
--- a/.github/workflows/canary.yml
+++ b/.github/workflows/canary.yml
@@ -108,6 +108,10 @@ jobs:
             os: linux
             arch: arm64
             runner: ubuntu-24.04-arm
+          - target: bun-windows-x64
+            os: windows
+            arch: amd64
+            runner: windows-latest
 
     runs-on: ${{ matrix.runner }}
     timeout-minutes: 20
@@ -127,18 +131,29 @@ jobs:
           cache-dependency-path: tools/proxy-helper/go.sum
 
       - name: Build proxy-helper
+        if: ${{ matrix.os != 'windows' }}
         run: make -C tools/proxy-helper build
         env:
           GOOS: ${{ matrix.os }}
           GOARCH: ${{ matrix.arch }}
 
+      - name: Build Windows proxy-helper
+        if: ${{ matrix.os == 'windows' }}
+        run: node scripts/build-proxy-helper.js --target ${{ matrix.target }}
+
       - name: Set version
         run: node scripts/set-version.js "${{ needs.preflight.outputs.version }}"
 
       - name: Build binary
+        if: ${{ matrix.os != 'windows' }}
         run: pnpm run build:binary
 
+      - name: Build Windows binary
+        if: ${{ matrix.os == 'windows' }}
+        run: node scripts/build-binary.js --target ${{ matrix.target }}
+
       - name: Verify binary architecture
+        if: ${{ matrix.os != 'windows' }}
         run: |
           file dist/bin/kimchi
           case "${{ matrix.arch }}" in
@@ -147,14 +162,57 @@ jobs:
             *) echo "Unsupported arch: ${{ matrix.arch }}" >&2; exit 1 ;;
           esac
 
-      - name: Package binary
-        run: tar -czf kimchi_${{ matrix.os }}_${{ matrix.arch }}.tar.gz -C dist bin share
+      - name: Verify Windows binary
+        if: ${{ matrix.os == 'windows' }}
+        shell: pwsh
+        run: |
+          Get-Item dist/bin/kimchi.exe
+          Get-Item dist/share/kimchi/bin/proxy-helper.exe
+
+          function Assert-LastExitCode([string]$label) {
+            if ($LASTEXITCODE -ne 0) {
+              throw "$label failed with exit code $LASTEXITCODE"
+            }
+          }
+
+          .\dist\bin\kimchi.exe --version
+          Assert-LastExitCode "kimchi --version"
+          .\dist\bin\kimchi.exe --help
+          Assert-LastExitCode "kimchi --help"
+          .\dist\share\kimchi\bin\proxy-helper.exe ssh-proxy --help
+          Assert-LastExitCode "proxy-helper ssh-proxy --help"
+
+          $env:KIMCHI_API_KEY = "dummy"
+          $env:KIMCHI_REMOTE_ENDPOINT = "http://127.0.0.1:9"
+          $output = & .\dist\bin\kimchi.exe --ssh-proxy dummy-session 2>&1
+          $exitCode = $LASTEXITCODE
+          $output | Write-Output
+          if ($exitCode -eq 0) {
+            throw "Expected dummy --ssh-proxy check to fail before connecting to a real API"
+          }
+          if ($output -match "proxy-helper binary not found") {
+            throw "Windows kimchi.exe could not locate the bundled proxy-helper.exe"
+          }
+
+      - name: Package release asset
+        run: node scripts/package-release-asset.js --os ${{ matrix.os }} --arch ${{ matrix.arch }}
+
+      - name: Verify Windows installer
+        if: ${{ matrix.os == 'windows' }}
+        shell: pwsh
+        env:
+          KIMCHI_ARCHIVE_PATH: kimchi_${{ matrix.os }}_${{ matrix.arch }}.zip
+          KIMCHI_INSTALL_DIR: ${{ runner.temp }}\kimchi-install
+          KIMCHI_SKIP_PATH_UPDATE: "1"
+        run: |
+          .\scripts\install.ps1
+          & "$env:KIMCHI_INSTALL_DIR\bin\kimchi.exe" --version
 
       - name: Upload artifact
         uses: actions/upload-artifact@v4
         with:
           name: kimchi_${{ matrix.os }}_${{ matrix.arch }}
-          path: kimchi_${{ matrix.os }}_${{ matrix.arch }}.tar.gz
+          path: kimchi_${{ matrix.os }}_${{ matrix.arch }}.*
 
   smoke-test:
     needs: [preflight, build]
@@ -203,7 +261,7 @@ jobs:
       - name: Generate checksums
         run: |
           cd artifacts
-          sha256sum kimchi_*.tar.gz > checksums.txt
+          sha256sum kimchi_*.tar.gz kimchi_*.zip > checksums.txt
 
       - name: Build release notes
         env:
@@ -239,4 +297,5 @@ jobs:
             --prerelease \
             --target "$GITHUB_SHA" \
             artifacts/kimchi_*.tar.gz \
+            artifacts/kimchi_*.zip \
             artifacts/checksums.txt

--- a/.github/workflows/canary.yml
+++ b/.github/workflows/canary.yml
@@ -108,7 +108,7 @@ jobs:
             os: linux
             arch: arm64
             runner: ubuntu-24.04-arm
-          - target: bun-windows-x64-baseline
+          - target: bun-windows-x64
             os: windows
             arch: amd64
             runner: windows-latest

--- a/.github/workflows/canary.yml
+++ b/.github/workflows/canary.yml
@@ -186,6 +186,7 @@ jobs:
           $env:KIMCHI_REMOTE_ENDPOINT = "http://127.0.0.1:9"
           $output = & .\dist\bin\kimchi.exe --ssh-proxy dummy-session 2>&1
           $exitCode = $LASTEXITCODE
+          $global:LASTEXITCODE = 0
           $output | Write-Output
           if ($exitCode -eq 0) {
             throw "Expected dummy --ssh-proxy check to fail before connecting to a real API"

--- a/.github/workflows/canary.yml
+++ b/.github/workflows/canary.yml
@@ -108,7 +108,7 @@ jobs:
             os: linux
             arch: arm64
             runner: ubuntu-24.04-arm
-          - target: bun-windows-x64
+          - target: bun-windows-x64-baseline
             os: windows
             arch: amd64
             runner: windows-latest

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -131,15 +131,14 @@ jobs:
             throw "Windows kimchi.exe could not locate the bundled proxy-helper.exe"
           }
 
-      - name: Package binary
-        shell: bash
-        run: tar -czf kimchi_${{ matrix.os }}_${{ matrix.arch }}.tar.gz -C dist bin share
+      - name: Package release asset
+        run: node scripts/package-release-asset.js --os ${{ matrix.os }} --arch ${{ matrix.arch }}
 
       - name: Verify Windows installer
         if: ${{ matrix.os == 'windows' }}
         shell: pwsh
         env:
-          KIMCHI_ARCHIVE_PATH: kimchi_${{ matrix.os }}_${{ matrix.arch }}.tar.gz
+          KIMCHI_ARCHIVE_PATH: kimchi_${{ matrix.os }}_${{ matrix.arch }}.zip
           KIMCHI_INSTALL_DIR: ${{ runner.temp }}\kimchi-install
           KIMCHI_SKIP_PATH_UPDATE: "1"
         run: |
@@ -150,7 +149,7 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: kimchi_${{ matrix.os }}_${{ matrix.arch }}
-          path: kimchi_${{ matrix.os }}_${{ matrix.arch }}.tar.gz
+          path: kimchi_${{ matrix.os }}_${{ matrix.arch }}.*
 
   smoke-test:
     needs: [build]
@@ -195,13 +194,14 @@ jobs:
       - name: Generate checksums
         run: |
           cd artifacts
-          sha256sum kimchi_*.tar.gz > checksums.txt
+          sha256sum kimchi_*.tar.gz kimchi_*.zip > checksums.txt
 
       - name: Create GitHub release
         uses: softprops/action-gh-release@153bb8e04406b158c6c84fc1615b65b24149a1fe # v2
         with:
           files: |
             artifacts/kimchi_*.tar.gz
+            artifacts/kimchi_*.zip
             artifacts/checksums.txt
             scripts/install.sh
             scripts/install.ps1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -53,6 +53,10 @@ jobs:
             os: linux
             arch: arm64
             runner: ubuntu-24.04-arm
+          - target: bun-windows-x64
+            os: windows
+            arch: amd64
+            runner: windows-latest
 
     runs-on: ${{ matrix.runner }}
 
@@ -73,13 +77,13 @@ jobs:
           go-version-file: tools/proxy-helper/go.mod
 
       - name: Build proxy-helper
-        run: make build
-        working-directory: tools/proxy-helper
+        run: node scripts/build-proxy-helper.js --target ${{ matrix.target }}
 
       - name: Build binary
         run: pnpm run build:binary
 
       - name: Verify binary architecture
+        if: ${{ matrix.os != 'windows' }}
         run: |
           file dist/bin/kimchi
           case "${{ matrix.arch }}" in
@@ -95,7 +99,31 @@ jobs:
             *) echo "Unsupported arch: ${{ matrix.arch }}" >&2; exit 1 ;;
           esac
 
+      - name: Verify Windows binary
+        if: ${{ matrix.os == 'windows' }}
+        shell: pwsh
+        run: |
+          Get-Item dist/bin/kimchi.exe
+          Get-Item dist/share/kimchi/bin/proxy-helper.exe
+
+          .\dist\bin\kimchi.exe --version
+          .\dist\bin\kimchi.exe --help | Select-Object -First 20
+          .\dist\share\kimchi\bin\proxy-helper.exe ssh-proxy --help | Select-Object -First 20
+
+          $env:KIMCHI_API_KEY = "dummy"
+          $env:KIMCHI_REMOTE_ENDPOINT = "http://127.0.0.1:9"
+          $output = & .\dist\bin\kimchi.exe --ssh-proxy dummy-session 2>&1
+          $exitCode = $LASTEXITCODE
+          $output | Write-Output
+          if ($exitCode -eq 0) {
+            throw "Expected dummy --ssh-proxy check to fail before connecting to a real API"
+          }
+          if ($output -match "proxy-helper binary not found") {
+            throw "Windows kimchi.exe could not locate the bundled proxy-helper.exe"
+          }
+
       - name: Package binary
+        shell: bash
         run: tar -czf kimchi_${{ matrix.os }}_${{ matrix.arch }}.tar.gz -C dist bin share
 
       - name: Upload artifact

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -53,7 +53,7 @@ jobs:
             os: linux
             arch: arm64
             runner: ubuntu-24.04-arm
-          - target: bun-windows-x64
+          - target: bun-windows-x64-baseline
             os: windows
             arch: amd64
             runner: windows-latest

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -53,7 +53,7 @@ jobs:
             os: linux
             arch: arm64
             runner: ubuntu-24.04-arm
-          - target: bun-windows-x64-baseline
+          - target: bun-windows-x64
             os: windows
             arch: amd64
             runner: windows-latest

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -123,6 +123,7 @@ jobs:
           $env:KIMCHI_REMOTE_ENDPOINT = "http://127.0.0.1:9"
           $output = & .\dist\bin\kimchi.exe --ssh-proxy dummy-session 2>&1
           $exitCode = $LASTEXITCODE
+          $global:LASTEXITCODE = 0
           $output | Write-Output
           if ($exitCode -eq 0) {
             throw "Expected dummy --ssh-proxy check to fail before connecting to a real API"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -80,7 +80,7 @@ jobs:
         run: node scripts/build-proxy-helper.js --target ${{ matrix.target }}
 
       - name: Build binary
-        run: pnpm run build:binary
+        run: node scripts/build-binary.js --target ${{ matrix.target }}
 
       - name: Verify binary architecture
         if: ${{ matrix.os != 'windows' }}
@@ -106,9 +106,18 @@ jobs:
           Get-Item dist/bin/kimchi.exe
           Get-Item dist/share/kimchi/bin/proxy-helper.exe
 
+          function Assert-LastExitCode([string]$label) {
+            if ($LASTEXITCODE -ne 0) {
+              throw "$label failed with exit code $LASTEXITCODE"
+            }
+          }
+
           .\dist\bin\kimchi.exe --version
-          .\dist\bin\kimchi.exe --help | Select-Object -First 20
-          .\dist\share\kimchi\bin\proxy-helper.exe ssh-proxy --help | Select-Object -First 20
+          Assert-LastExitCode "kimchi --version"
+          .\dist\bin\kimchi.exe --help
+          Assert-LastExitCode "kimchi --help"
+          .\dist\share\kimchi\bin\proxy-helper.exe ssh-proxy --help
+          Assert-LastExitCode "proxy-helper ssh-proxy --help"
 
           $env:KIMCHI_API_KEY = "dummy"
           $env:KIMCHI_REMOTE_ENDPOINT = "http://127.0.0.1:9"
@@ -125,6 +134,17 @@ jobs:
       - name: Package binary
         shell: bash
         run: tar -czf kimchi_${{ matrix.os }}_${{ matrix.arch }}.tar.gz -C dist bin share
+
+      - name: Verify Windows installer
+        if: ${{ matrix.os == 'windows' }}
+        shell: pwsh
+        env:
+          KIMCHI_ARCHIVE_PATH: kimchi_${{ matrix.os }}_${{ matrix.arch }}.tar.gz
+          KIMCHI_INSTALL_DIR: ${{ runner.temp }}\kimchi-install
+          KIMCHI_SKIP_PATH_UPDATE: "1"
+        run: |
+          .\scripts\install.ps1
+          & "$env:KIMCHI_INSTALL_DIR\bin\kimchi.exe" --version
 
       - name: Upload artifact
         uses: actions/upload-artifact@v4
@@ -184,6 +204,7 @@ jobs:
             artifacts/kimchi_*.tar.gz
             artifacts/checksums.txt
             scripts/install.sh
+            scripts/install.ps1
           generate_release_notes: true
 
   homebrew:

--- a/README.md
+++ b/README.md
@@ -559,7 +559,7 @@ Supported platforms:
 - Linux (amd64, arm64)
 - Windows (amd64)
 
-Release assets follow the naming convention `kimchi_{os}_{arch}.tar.gz` with a `checksums.txt` (SHA256) for verification.
+Release assets follow the naming convention `kimchi_{os}_{arch}.tar.gz` for macOS/Linux and `kimchi_windows_amd64.zip` for Windows, with a `checksums.txt` (SHA256) for verification.
 
 Windows build and local VM testing notes live in [`docs/windows/README.md`](docs/windows/README.md).
 

--- a/README.md
+++ b/README.md
@@ -551,8 +551,11 @@ Supported platforms:
 
 - macOS (amd64, arm64)
 - Linux (amd64, arm64)
+- Windows (amd64)
 
 Release assets follow the naming convention `kimchi_{os}_{arch}.tar.gz` with a `checksums.txt` (SHA256) for verification.
+
+Windows build and local VM testing notes live in [`docs/windows/README.md`](docs/windows/README.md).
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -14,10 +14,16 @@ Install the latest release:
 brew install getkimchi/tap/kimchi
 ```
 
-**Install script:**
+**Install script (macOS / Linux):**
 
 ```bash
 curl -fsSL https://github.com/getkimchi/kimchi/releases/latest/download/install.sh | bash
+```
+
+**PowerShell (Windows):**
+
+```powershell
+irm https://github.com/getkimchi/kimchi/releases/latest/download/install.ps1 | iex
 ```
 
 Then configure your API key and launch:

--- a/docs/windows/README.md
+++ b/docs/windows/README.md
@@ -1,0 +1,203 @@
+# Windows Builds
+
+This document explains how Kimchi's Windows binary is built, what the release
+pipeline verifies, and how to reproduce the setup locally when fixing Windows
+bugs.
+
+## Release Pipeline
+
+Windows release artifacts should be built on a real GitHub-hosted Windows
+runner, not cross-compiled from Linux. The Windows runner installs Windows
+optional native packages, uses Windows process/path semantics, and gives us a
+runtime smoke test for the final `kimchi.exe`.
+
+The release matrix in `.github/workflows/release.yml` includes:
+
+- `bun-windows-x64`
+- `windows`
+- `amd64`
+- `windows-latest`
+
+The Windows build job does the same packaging work as Linux/macOS:
+
+1. Check out the repo with submodules.
+2. Install Bun/pnpm dependencies through `.github/actions/setup`.
+3. Set the package version from the release tag.
+4. Install Go.
+5. Build the Go proxy helper:
+
+   ```bash
+   node scripts/build-proxy-helper.js --target bun-windows-x64
+   ```
+
+6. Build the Bun standalone executable:
+
+   ```bash
+   pnpm run build:binary
+   ```
+
+7. Verify the Windows runtime surface:
+
+   ```powershell
+   .\dist\bin\kimchi.exe --version
+   .\dist\bin\kimchi.exe --help
+   .\dist\share\kimchi\bin\proxy-helper.exe ssh-proxy --help
+   ```
+
+8. Verify that `kimchi.exe --ssh-proxy` can locate and launch the bundled
+   helper. The dummy endpoint is expected to fail at connection time; it must
+   not fail with `proxy-helper binary not found`.
+
+9. Upload:
+
+   ```text
+   kimchi_windows_amd64.tar.gz
+   ```
+
+The artifact layout is:
+
+```text
+bin/
+  kimchi.exe
+share/kimchi/
+  package.json
+  theme/
+  export-html/
+  oauth/
+  vendor/
+  bin/
+    proxy-helper.exe
+```
+
+## Why `proxy-helper.exe` Matters
+
+Teleport SSH uses an SSH `ProxyCommand`. In binary releases, the proxy command
+enters `kimchi.exe --ssh-proxy <target>`, and Kimchi then spawns the bundled Go
+helper from `share/kimchi/bin/proxy-helper.exe`.
+
+Basic commands such as `--help`, `--version`, and non-SSH prompts do not prove
+that Teleport works. Always include a dummy `--ssh-proxy` check when validating
+Windows packaging.
+
+Expected dummy failure:
+
+```text
+connectex: No connection could be made because the target machine actively refused it.
+```
+
+Bad packaging failure:
+
+```text
+proxy-helper binary not found
+```
+
+## Local Windows VM
+
+Use this when debugging Windows-specific bugs from a Linux workstation. A GUI is
+not required after installation; Windows Server Core with OpenSSH is enough.
+
+Install local VM tooling on Ubuntu:
+
+```bash
+sudo apt update
+sudo apt install -y \
+  qemu-system-x86 \
+  qemu-utils \
+  virtinst \
+  libvirt-daemon-system \
+  libvirt-clients \
+  ovmf \
+  genisoimage
+```
+
+Create local storage directories:
+
+```bash
+mkdir -p ~/iso ~/vms
+```
+
+Download the Windows Server evaluation ISO from Microsoft and save it as:
+
+```text
+~/iso/windows-server.iso
+```
+
+Install Windows Server Core and enable OpenSSH inside the VM:
+
+```powershell
+Add-WindowsCapability -Online -Name OpenSSH.Server~~~~0.0.1.0
+Start-Service sshd
+Set-Service sshd -StartupType Automatic
+New-NetFirewallRule -Name sshd -DisplayName "OpenSSH Server" -Enabled True -Direction Inbound -Protocol TCP -Action Allow -LocalPort 22
+```
+
+For local-only QEMU user networking, forward host port `2222` to guest port
+`22`, then connect from Linux:
+
+```bash
+ssh -p 2222 Administrator@127.0.0.1
+```
+
+## Manual Smoke Test In The VM
+
+Copy a packaged artifact into Windows and extract it:
+
+```bash
+scp -P 2222 kimchi_windows_amd64.tar.gz Administrator@127.0.0.1:
+ssh -p 2222 Administrator@127.0.0.1
+```
+
+Inside Windows:
+
+```powershell
+Remove-Item -Recurse -Force C:\kimchi-test -ErrorAction SilentlyContinue
+New-Item -ItemType Directory -Force C:\kimchi-test | Out-Null
+tar -xzf $env:USERPROFILE\kimchi_windows_amd64.tar.gz -C C:\kimchi-test
+
+cd C:\kimchi-test
+.\bin\kimchi.exe --version
+.\bin\kimchi.exe --help
+.\share\kimchi\bin\proxy-helper.exe ssh-proxy --help
+```
+
+Check the bundled helper path:
+
+```powershell
+$env:KIMCHI_API_KEY = "dummy"
+$env:KIMCHI_REMOTE_ENDPOINT = "http://127.0.0.1:9"
+.\bin\kimchi.exe --ssh-proxy dummy-session
+```
+
+The command should fail at the dummy API endpoint. It should not fail because
+`proxy-helper.exe` cannot be found.
+
+## Local Build Notes
+
+On a Windows machine or Windows GitHub runner:
+
+```powershell
+corepack enable
+pnpm install
+pnpm run build:binary
+```
+
+From a Linux workstation, prefer the Windows VM for execution and the
+`windows-latest` GitHub runner for release confidence. Linux cross-compilation is
+useful for quick terminal/proxy smoke checks:
+
+```bash
+pnpm install
+pnpm run build:binary-windows-x64
+tar -czf kimchi_windows_amd64.tar.gz -C dist bin share
+```
+
+Linux cross-builds externalize the Windows clipboard native addon because that
+optional package is not installed on non-Windows hosts. Do not treat a Linux
+cross-build as the final release signal.
+
+## References
+
+- Bun standalone executable targets: https://bun.com/docs/bundler/executables
+- GitHub-hosted runners: https://docs.github.com/actions/using-github-hosted-runners/about-github-hosted-runners
+- Windows Server evaluation downloads: https://www.microsoft.com/en-us/evalcenter/evaluate-windows-server-2025
+- OpenSSH on Windows Server: https://learn.microsoft.com/en-us/windows-server/administration/openssh/openssh_install_firstuse

--- a/docs/windows/README.md
+++ b/docs/windows/README.md
@@ -12,7 +12,7 @@ Install the latest native Windows release from PowerShell:
 irm https://github.com/getkimchi/kimchi/releases/latest/download/install.ps1 | iex
 ```
 
-The installer downloads `kimchi_windows_amd64.tar.gz`, installs
+The installer downloads `kimchi_windows_amd64.zip`, installs
 `kimchi.exe` under `%LOCALAPPDATA%\Kimchi\bin`, stages shared runtime files
 under `%LOCALAPPDATA%\Kimchi\share\kimchi`, and adds the `bin` directory to
 the user `PATH`.
@@ -68,13 +68,13 @@ The Windows build job does the same packaging work as Linux/macOS:
    helper. The dummy endpoint is expected to fail at connection time; it must
    not fail with `proxy-helper binary not found`.
 
-9. Package `kimchi_windows_amd64.tar.gz` and verify `scripts/install.ps1`
+9. Package `kimchi_windows_amd64.zip` and verify `scripts/install.ps1`
    against that local archive.
 
 10. Upload:
 
    ```text
-   kimchi_windows_amd64.tar.gz
+   kimchi_windows_amd64.zip
    ```
 
 The artifact layout is:
@@ -166,7 +166,7 @@ ssh -p 2222 Administrator@127.0.0.1
 Copy a packaged artifact into Windows and extract it:
 
 ```bash
-scp -P 2222 kimchi_windows_amd64.tar.gz Administrator@127.0.0.1:
+scp -P 2222 kimchi_windows_amd64.zip Administrator@127.0.0.1:
 ssh -p 2222 Administrator@127.0.0.1
 ```
 
@@ -175,7 +175,7 @@ Inside Windows:
 ```powershell
 Remove-Item -Recurse -Force C:\kimchi-test -ErrorAction SilentlyContinue
 New-Item -ItemType Directory -Force C:\kimchi-test | Out-Null
-tar -xzf $env:USERPROFILE\kimchi_windows_amd64.tar.gz -C C:\kimchi-test
+Expand-Archive -LiteralPath $env:USERPROFILE\kimchi_windows_amd64.zip -DestinationPath C:\kimchi-test -Force
 
 cd C:\kimchi-test
 .\bin\kimchi.exe --version
@@ -211,7 +211,7 @@ useful for quick terminal/proxy smoke checks:
 ```bash
 pnpm install
 pnpm run build:binary-windows-x64
-tar -czf kimchi_windows_amd64.tar.gz -C dist bin share
+(cd dist && zip -r ../kimchi_windows_amd64.zip bin share)
 ```
 
 Linux cross-builds externalize the Windows clipboard native addon because that

--- a/docs/windows/README.md
+++ b/docs/windows/README.md
@@ -33,7 +33,7 @@ runtime smoke test for the final `kimchi.exe`.
 
 The release matrix in `.github/workflows/release.yml` includes:
 
-- `bun-windows-x64`
+- `bun-windows-x64-baseline`
 - `windows`
 - `amd64`
 - `windows-latest`
@@ -47,13 +47,13 @@ The Windows build job does the same packaging work as Linux/macOS:
 5. Build the Go proxy helper:
 
    ```bash
-   node scripts/build-proxy-helper.js --target bun-windows-x64
+   node scripts/build-proxy-helper.js --target bun-windows-x64-baseline
    ```
 
 6. Build the Bun standalone executable:
 
    ```bash
-   node scripts/build-binary.js --target bun-windows-x64
+   node scripts/build-binary.js --target bun-windows-x64-baseline
    ```
 
 7. Verify the Windows runtime surface:

--- a/docs/windows/README.md
+++ b/docs/windows/README.md
@@ -4,6 +4,26 @@ This document explains how Kimchi's Windows binary is built, what the release
 pipeline verifies, and how to reproduce the setup locally when fixing Windows
 bugs.
 
+## Native Install
+
+Install the latest native Windows release from PowerShell:
+
+```powershell
+irm https://github.com/getkimchi/kimchi/releases/latest/download/install.ps1 | iex
+```
+
+The installer downloads `kimchi_windows_amd64.tar.gz`, installs
+`kimchi.exe` under `%LOCALAPPDATA%\Kimchi\bin`, stages shared runtime files
+under `%LOCALAPPDATA%\Kimchi\share\kimchi`, and adds the `bin` directory to
+the user `PATH`.
+
+Set `KIMCHI_INSTALL_DIR` to override the install root:
+
+```powershell
+$env:KIMCHI_INSTALL_DIR = "C:\Tools\Kimchi"
+irm https://github.com/getkimchi/kimchi/releases/latest/download/install.ps1 | iex
+```
+
 ## Release Pipeline
 
 Windows release artifacts should be built on a real GitHub-hosted Windows
@@ -33,7 +53,7 @@ The Windows build job does the same packaging work as Linux/macOS:
 6. Build the Bun standalone executable:
 
    ```bash
-   pnpm run build:binary
+   node scripts/build-binary.js --target bun-windows-x64
    ```
 
 7. Verify the Windows runtime surface:
@@ -48,7 +68,10 @@ The Windows build job does the same packaging work as Linux/macOS:
    helper. The dummy endpoint is expected to fail at connection time; it must
    not fail with `proxy-helper binary not found`.
 
-9. Upload:
+9. Package `kimchi_windows_amd64.tar.gz` and verify `scripts/install.ps1`
+   against that local archive.
+
+10. Upload:
 
    ```text
    kimchi_windows_amd64.tar.gz

--- a/docs/windows/README.md
+++ b/docs/windows/README.md
@@ -33,7 +33,7 @@ runtime smoke test for the final `kimchi.exe`.
 
 The release matrix in `.github/workflows/release.yml` includes:
 
-- `bun-windows-x64-baseline`
+- `bun-windows-x64`
 - `windows`
 - `amd64`
 - `windows-latest`
@@ -47,13 +47,13 @@ The Windows build job does the same packaging work as Linux/macOS:
 5. Build the Go proxy helper:
 
    ```bash
-   node scripts/build-proxy-helper.js --target bun-windows-x64-baseline
+   node scripts/build-proxy-helper.js --target bun-windows-x64
    ```
 
 6. Build the Bun standalone executable:
 
    ```bash
-   node scripts/build-binary.js --target bun-windows-x64-baseline
+   node scripts/build-binary.js --target bun-windows-x64
    ```
 
 7. Verify the Windows runtime surface:

--- a/package.json
+++ b/package.json
@@ -10,10 +10,12 @@
 	"scripts": {
 		"clean": "rm -rf dist",
 		"build": "tsc --noEmit && node scripts/copy-resources.js --dev",
+		"build:proxy-helper": "node scripts/build-proxy-helper.js",
 		"build:binary": "node scripts/build-binary.js",
 		"install:local": "node scripts/install-local.js",
 		"build:binary-linux-arm64": "node scripts/build-binary.js --target linux-arm64",
 		"build:binary-linux-x64": "node scripts/build-binary.js --target linux-x64",
+		"build:binary-windows-x64": "node scripts/build-binary.js --target windows-x64",
 		"dev": "make -C tools/proxy-helper/ copy-for-dev && bun run --preload ./src/set-package-dir.ts src/entry.ts",
 		"dev:overlay": "scripts/dev-overlay.sh",
 		"dev:setup": "bun run --preload ./src/set-package-dir.ts src/entry.ts setup",

--- a/scripts/build-binary.js
+++ b/scripts/build-binary.js
@@ -5,21 +5,49 @@
 //   node scripts/build-binary.js                        # build for the host platform
 //   node scripts/build-binary.js --target linux-arm64   # cross-compile for Linux ARM64 (Apple Silicon Docker)
 //   node scripts/build-binary.js --target linux-x64     # cross-compile for Linux x86-64
+//   node scripts/build-binary.js --target windows-x64   # build for Windows x86-64
 
 import { execSync } from "node:child_process"
-import { platform } from "node:os"
+import { arch, platform } from "node:os"
 
-const TARGET_MAP = {
-	"linux-arm64": "bun-linux-arm64",
-	"linux-x64": "bun-linux-x64",
+const TARGETS = {
+	"darwin-arm64": { bun: "bun-darwin-arm64", os: "darwin", binaryName: "kimchi" },
+	"darwin-x64": { bun: "bun-darwin-x64", os: "darwin", binaryName: "kimchi" },
+	"linux-arm64": { bun: "bun-linux-arm64", os: "linux", binaryName: "kimchi" },
+	"linux-x64": { bun: "bun-linux-x64", os: "linux", binaryName: "kimchi" },
+	"windows-x64": { bun: "bun-windows-x64", os: "win32", binaryName: "kimchi.exe" },
+	"win-x64": { bun: "bun-windows-x64", os: "win32", binaryName: "kimchi.exe" },
+	"bun-darwin-arm64": { bun: "bun-darwin-arm64", os: "darwin", binaryName: "kimchi" },
+	"bun-darwin-x64": { bun: "bun-darwin-x64", os: "darwin", binaryName: "kimchi" },
+	"bun-linux-arm64": { bun: "bun-linux-arm64", os: "linux", binaryName: "kimchi" },
+	"bun-linux-x64": { bun: "bun-linux-x64", os: "linux", binaryName: "kimchi" },
+	"bun-windows-x64": { bun: "bun-windows-x64", os: "win32", binaryName: "kimchi.exe" },
 }
 
 const targetArg =
 	process.argv.find((a) => a.startsWith("--target="))?.split("=")[1] ??
 	(process.argv.includes("--target") ? process.argv[process.argv.indexOf("--target") + 1] : undefined)
 
-const crossTarget = targetArg ? (TARGET_MAP[targetArg] ?? targetArg) : undefined
+function hostTargetKey() {
+	const os = platform()
+	const cpu = arch()
+	if (os === "darwin" && cpu === "arm64") return "darwin-arm64"
+	if (os === "darwin" && cpu === "x64") return "darwin-x64"
+	if (os === "linux" && cpu === "arm64") return "linux-arm64"
+	if (os === "linux" && cpu === "x64") return "linux-x64"
+	if (os === "win32" && cpu === "x64") return "windows-x64"
+	throw new Error(`Unsupported build host platform: ${os}/${cpu}`)
+}
+
+const targetKey = targetArg ?? hostTargetKey()
+const target = TARGETS[targetKey]
+if (!target) {
+	throw new Error(`Unsupported build target: ${targetKey}`)
+}
+
+const crossTarget = targetArg ? target.bun : undefined
 const isCrossCompile = !!crossTarget
+process.env.KIMCHI_BUILD_TARGET_OS = target.os
 
 function run(label, cmd) {
 	console.log(`\n→ ${label}`)
@@ -34,7 +62,8 @@ const isCI = !!process.env.CI
 
 // In CI the binary will be build in its own step.
 if (!isCI) {
-	run("build proxy-helper", "make -C tools/proxy-helper build")
+	const helperTargetFlag = targetArg ? ` --target ${targetKey}` : ""
+	run("build proxy-helper", `node scripts/build-proxy-helper.js${helperTargetFlag}`)
 }
 
 run("clean", "pnpm run clean")
@@ -43,21 +72,32 @@ run("typecheck", "pnpm run typecheck")
 // Externalize packages that cannot be bundled into a Bun compiled binary (native addons, browser automation harnesses).
 // If a new dependency causes a build failure, check whether it also needs --external here.
 const targetFlag = crossTarget ? ` --target=${crossTarget}` : ""
+const externals = ["chromium-bidi", "electron"]
+if (isCrossCompile && target.os === "win32" && platform() !== "win32") {
+	// Linux/macOS installs do not include Windows-only optional native packages.
+	// Release builds run on windows-latest and bundle this dependency; cross-builds
+	// are for terminal/proxy smoke testing and gracefully lose clipboard images.
+	externals.push(
+		"@mariozechner/clipboard-win32-x64-msvc",
+		"@mariozechner/clipboard-win32-x64-msvc/clipboard.win32-x64-msvc.node",
+	)
+}
+const externalFlags = externals.map((name) => `--external ${name}`).join(" ")
 
 // Trust the OS certificate store in addition to Bun's bundled roots so users behind
 // TLS-intercepting corporate proxies (Netskope, Zscaler, etc.) can reach the API without
 // extra env vars. Bun ignores the system store by default; --use-system-ca is additive.
 run(
 	"compile",
-	`bun build src/entry.ts --compile${targetFlag} --compile-exec-argv="--use-system-ca" --outfile dist/bin/kimchi --external chromium-bidi --external electron`.trim(),
+	`bun build src/entry.ts --compile${targetFlag} --compile-exec-argv="--use-system-ca" --outfile dist/bin/${target.binaryName} ${externalFlags}`.trim(),
 )
 
 // Bun --compile produces binaries with an invalid code signature on macOS.
 // The kernel kills badly-signed arm64 binaries immediately (SIGKILL, exit 137).
 // Strip the corrupt signature and re-sign ad-hoc. See: https://github.com/oven-sh/bun/issues/7208
 if (!isCrossCompile && platform() === "darwin") {
-	run("codesign (strip)", "codesign --remove-signature dist/bin/kimchi")
-	run("codesign (ad-hoc)", "codesign -s - dist/bin/kimchi")
+	run("codesign (strip)", `codesign --remove-signature dist/bin/${target.binaryName}`)
+	run("codesign (ad-hoc)", `codesign -s - dist/bin/${target.binaryName}`)
 }
 
 run("copy resources", "node scripts/copy-resources.js")

--- a/scripts/build-binary.js
+++ b/scripts/build-binary.js
@@ -5,7 +5,7 @@
 //   node scripts/build-binary.js                        # build for the host platform
 //   node scripts/build-binary.js --target linux-arm64   # cross-compile for Linux ARM64 (Apple Silicon Docker)
 //   node scripts/build-binary.js --target linux-x64     # cross-compile for Linux x86-64
-//   node scripts/build-binary.js --target windows-x64   # build for Windows x86-64
+//   node scripts/build-binary.js --target windows-x64   # build for Windows x86-64 baseline
 
 import { execSync } from "node:child_process"
 import { rmSync } from "node:fs"
@@ -20,13 +20,15 @@ const TARGETS = {
 	"darwin-x64": { bun: "bun-darwin-x64", os: "darwin", binaryName: "kimchi" },
 	"linux-arm64": { bun: "bun-linux-arm64", os: "linux", binaryName: "kimchi" },
 	"linux-x64": { bun: "bun-linux-x64", os: "linux", binaryName: "kimchi" },
-	"windows-x64": { bun: "bun-windows-x64", os: "win32", binaryName: "kimchi.exe" },
-	"win-x64": { bun: "bun-windows-x64", os: "win32", binaryName: "kimchi.exe" },
+	"windows-x64": { bun: "bun-windows-x64-baseline", os: "win32", binaryName: "kimchi.exe" },
+	"windows-x64-baseline": { bun: "bun-windows-x64-baseline", os: "win32", binaryName: "kimchi.exe" },
+	"win-x64": { bun: "bun-windows-x64-baseline", os: "win32", binaryName: "kimchi.exe" },
 	"bun-darwin-arm64": { bun: "bun-darwin-arm64", os: "darwin", binaryName: "kimchi" },
 	"bun-darwin-x64": { bun: "bun-darwin-x64", os: "darwin", binaryName: "kimchi" },
 	"bun-linux-arm64": { bun: "bun-linux-arm64", os: "linux", binaryName: "kimchi" },
 	"bun-linux-x64": { bun: "bun-linux-x64", os: "linux", binaryName: "kimchi" },
 	"bun-windows-x64": { bun: "bun-windows-x64", os: "win32", binaryName: "kimchi.exe" },
+	"bun-windows-x64-baseline": { bun: "bun-windows-x64-baseline", os: "win32", binaryName: "kimchi.exe" },
 }
 
 const targetArg =

--- a/scripts/build-binary.js
+++ b/scripts/build-binary.js
@@ -8,7 +8,12 @@
 //   node scripts/build-binary.js --target windows-x64   # build for Windows x86-64
 
 import { execSync } from "node:child_process"
+import { rmSync } from "node:fs"
 import { arch, platform } from "node:os"
+import { dirname, join } from "node:path"
+import { fileURLToPath } from "node:url"
+
+const projectRoot = join(dirname(fileURLToPath(import.meta.url)), "..")
 
 const TARGETS = {
 	"darwin-arm64": { bun: "bun-darwin-arm64", os: "darwin", binaryName: "kimchi" },
@@ -58,6 +63,11 @@ function run(label, cmd) {
 	}
 }
 
+function cleanDist() {
+	console.log("\n→ clean")
+	rmSync(join(projectRoot, "dist"), { recursive: true, force: true })
+}
+
 const isCI = !!process.env.CI
 
 // In CI the binary will be build in its own step.
@@ -66,7 +76,7 @@ if (!isCI) {
 	run("build proxy-helper", `node scripts/build-proxy-helper.js${helperTargetFlag}`)
 }
 
-run("clean", "pnpm run clean")
+cleanDist()
 run("typecheck", "pnpm run typecheck")
 
 // Externalize packages that cannot be bundled into a Bun compiled binary (native addons, browser automation harnesses).

--- a/scripts/build-binary.js
+++ b/scripts/build-binary.js
@@ -5,7 +5,7 @@
 //   node scripts/build-binary.js                        # build for the host platform
 //   node scripts/build-binary.js --target linux-arm64   # cross-compile for Linux ARM64 (Apple Silicon Docker)
 //   node scripts/build-binary.js --target linux-x64     # cross-compile for Linux x86-64
-//   node scripts/build-binary.js --target windows-x64   # build for Windows x86-64 baseline
+//   node scripts/build-binary.js --target windows-x64   # build for Windows x86-64
 
 import { execSync } from "node:child_process"
 import { rmSync } from "node:fs"
@@ -20,15 +20,13 @@ const TARGETS = {
 	"darwin-x64": { bun: "bun-darwin-x64", os: "darwin", binaryName: "kimchi" },
 	"linux-arm64": { bun: "bun-linux-arm64", os: "linux", binaryName: "kimchi" },
 	"linux-x64": { bun: "bun-linux-x64", os: "linux", binaryName: "kimchi" },
-	"windows-x64": { bun: "bun-windows-x64-baseline", os: "win32", binaryName: "kimchi.exe" },
-	"windows-x64-baseline": { bun: "bun-windows-x64-baseline", os: "win32", binaryName: "kimchi.exe" },
-	"win-x64": { bun: "bun-windows-x64-baseline", os: "win32", binaryName: "kimchi.exe" },
+	"windows-x64": { bun: "bun-windows-x64", os: "win32", binaryName: "kimchi.exe" },
+	"win-x64": { bun: "bun-windows-x64", os: "win32", binaryName: "kimchi.exe" },
 	"bun-darwin-arm64": { bun: "bun-darwin-arm64", os: "darwin", binaryName: "kimchi" },
 	"bun-darwin-x64": { bun: "bun-darwin-x64", os: "darwin", binaryName: "kimchi" },
 	"bun-linux-arm64": { bun: "bun-linux-arm64", os: "linux", binaryName: "kimchi" },
 	"bun-linux-x64": { bun: "bun-linux-x64", os: "linux", binaryName: "kimchi" },
 	"bun-windows-x64": { bun: "bun-windows-x64", os: "win32", binaryName: "kimchi.exe" },
-	"bun-windows-x64-baseline": { bun: "bun-windows-x64-baseline", os: "win32", binaryName: "kimchi.exe" },
 }
 
 const targetArg =

--- a/scripts/build-proxy-helper.js
+++ b/scripts/build-proxy-helper.js
@@ -1,0 +1,66 @@
+// Build the Go proxy-helper for the host platform or an explicit target.
+//
+// Usage:
+//   node scripts/build-proxy-helper.js
+//   node scripts/build-proxy-helper.js --target windows-x64
+//   node scripts/build-proxy-helper.js --target bun-windows-x64
+
+import { execFileSync } from "node:child_process"
+import { mkdirSync } from "node:fs"
+import { arch, platform } from "node:os"
+import { dirname, join } from "node:path"
+import { fileURLToPath } from "node:url"
+
+const projectRoot = join(dirname(fileURLToPath(import.meta.url)), "..")
+const helperDir = join(projectRoot, "tools", "proxy-helper")
+const helperBinDir = join(helperDir, "bin")
+
+const TARGETS = {
+	"darwin-arm64": { goos: "darwin", goarch: "arm64", helperName: "proxy-helper" },
+	"darwin-x64": { goos: "darwin", goarch: "amd64", helperName: "proxy-helper" },
+	"linux-arm64": { goos: "linux", goarch: "arm64", helperName: "proxy-helper" },
+	"linux-x64": { goos: "linux", goarch: "amd64", helperName: "proxy-helper" },
+	"windows-x64": { goos: "windows", goarch: "amd64", helperName: "proxy-helper.exe" },
+	"win-x64": { goos: "windows", goarch: "amd64", helperName: "proxy-helper.exe" },
+	"bun-darwin-arm64": { goos: "darwin", goarch: "arm64", helperName: "proxy-helper" },
+	"bun-darwin-x64": { goos: "darwin", goarch: "amd64", helperName: "proxy-helper" },
+	"bun-linux-arm64": { goos: "linux", goarch: "arm64", helperName: "proxy-helper" },
+	"bun-linux-x64": { goos: "linux", goarch: "amd64", helperName: "proxy-helper" },
+	"bun-windows-x64": { goos: "windows", goarch: "amd64", helperName: "proxy-helper.exe" },
+}
+
+const targetArg =
+	process.argv.find((a) => a.startsWith("--target="))?.split("=")[1] ??
+	(process.argv.includes("--target") ? process.argv[process.argv.indexOf("--target") + 1] : undefined)
+
+function hostTargetKey() {
+	const os = platform()
+	const cpu = arch()
+	if (os === "darwin" && cpu === "arm64") return "darwin-arm64"
+	if (os === "darwin" && cpu === "x64") return "darwin-x64"
+	if (os === "linux" && cpu === "arm64") return "linux-arm64"
+	if (os === "linux" && cpu === "x64") return "linux-x64"
+	if (os === "win32" && cpu === "x64") return "windows-x64"
+	throw new Error(`Unsupported proxy-helper host platform: ${os}/${cpu}`)
+}
+
+const targetKey = targetArg ?? hostTargetKey()
+const target = TARGETS[targetKey]
+if (!target) {
+	throw new Error(`Unsupported proxy-helper target: ${targetKey}`)
+}
+
+mkdirSync(helperBinDir, { recursive: true })
+const outPath = join(helperBinDir, target.helperName)
+
+console.log(`Building proxy-helper for ${target.goos}/${target.goarch} -> ${outPath}`)
+execFileSync("go", ["build", "-ldflags=-s -w", "-o", outPath, "."], {
+	cwd: helperDir,
+	stdio: "inherit",
+	env: {
+		...process.env,
+		CGO_ENABLED: process.env.CGO_ENABLED ?? "0",
+		GOOS: target.goos,
+		GOARCH: target.goarch,
+	},
+})

--- a/scripts/build-proxy-helper.js
+++ b/scripts/build-proxy-helper.js
@@ -3,7 +3,7 @@
 // Usage:
 //   node scripts/build-proxy-helper.js
 //   node scripts/build-proxy-helper.js --target windows-x64
-//   node scripts/build-proxy-helper.js --target bun-windows-x64-baseline
+//   node scripts/build-proxy-helper.js --target bun-windows-x64
 
 import { execFileSync } from "node:child_process"
 import { mkdirSync } from "node:fs"
@@ -21,14 +21,12 @@ const TARGETS = {
 	"linux-arm64": { goos: "linux", goarch: "arm64", helperName: "proxy-helper" },
 	"linux-x64": { goos: "linux", goarch: "amd64", helperName: "proxy-helper" },
 	"windows-x64": { goos: "windows", goarch: "amd64", helperName: "proxy-helper.exe" },
-	"windows-x64-baseline": { goos: "windows", goarch: "amd64", helperName: "proxy-helper.exe" },
 	"win-x64": { goos: "windows", goarch: "amd64", helperName: "proxy-helper.exe" },
 	"bun-darwin-arm64": { goos: "darwin", goarch: "arm64", helperName: "proxy-helper" },
 	"bun-darwin-x64": { goos: "darwin", goarch: "amd64", helperName: "proxy-helper" },
 	"bun-linux-arm64": { goos: "linux", goarch: "arm64", helperName: "proxy-helper" },
 	"bun-linux-x64": { goos: "linux", goarch: "amd64", helperName: "proxy-helper" },
 	"bun-windows-x64": { goos: "windows", goarch: "amd64", helperName: "proxy-helper.exe" },
-	"bun-windows-x64-baseline": { goos: "windows", goarch: "amd64", helperName: "proxy-helper.exe" },
 }
 
 const targetArg =

--- a/scripts/build-proxy-helper.js
+++ b/scripts/build-proxy-helper.js
@@ -3,7 +3,7 @@
 // Usage:
 //   node scripts/build-proxy-helper.js
 //   node scripts/build-proxy-helper.js --target windows-x64
-//   node scripts/build-proxy-helper.js --target bun-windows-x64
+//   node scripts/build-proxy-helper.js --target bun-windows-x64-baseline
 
 import { execFileSync } from "node:child_process"
 import { mkdirSync } from "node:fs"
@@ -21,12 +21,14 @@ const TARGETS = {
 	"linux-arm64": { goos: "linux", goarch: "arm64", helperName: "proxy-helper" },
 	"linux-x64": { goos: "linux", goarch: "amd64", helperName: "proxy-helper" },
 	"windows-x64": { goos: "windows", goarch: "amd64", helperName: "proxy-helper.exe" },
+	"windows-x64-baseline": { goos: "windows", goarch: "amd64", helperName: "proxy-helper.exe" },
 	"win-x64": { goos: "windows", goarch: "amd64", helperName: "proxy-helper.exe" },
 	"bun-darwin-arm64": { goos: "darwin", goarch: "arm64", helperName: "proxy-helper" },
 	"bun-darwin-x64": { goos: "darwin", goarch: "amd64", helperName: "proxy-helper" },
 	"bun-linux-arm64": { goos: "linux", goarch: "arm64", helperName: "proxy-helper" },
 	"bun-linux-x64": { goos: "linux", goarch: "amd64", helperName: "proxy-helper" },
 	"bun-windows-x64": { goos: "windows", goarch: "amd64", helperName: "proxy-helper.exe" },
+	"bun-windows-x64-baseline": { goos: "windows", goarch: "amd64", helperName: "proxy-helper.exe" },
 }
 
 const targetArg =

--- a/scripts/copy-resources.js
+++ b/scripts/copy-resources.js
@@ -10,7 +10,8 @@
 //                                   plus package.json → dist/share/kimchi/
 //                                   so the compiled binary resolves assets from the shared data directory
 
-import { cpSync, mkdirSync, readFileSync, readdirSync, writeFileSync } from "node:fs"
+import { cpSync, existsSync, mkdirSync, readFileSync, readdirSync, writeFileSync } from "node:fs"
+import { platform } from "node:os"
 import { dirname, join } from "node:path"
 import { fileURLToPath } from "node:url"
 
@@ -85,11 +86,16 @@ if (!isDev) {
 	mkdirSync(oauthDest, { recursive: true })
 	cpSync(oauthSrc, oauthDest, { recursive: true })
 
-	// Copy proxy-helper binary built by tools/proxy-helper/Makefile
-	const proxyHelperSrc = join(projectRoot, "tools", "proxy-helper", "bin", "proxy-helper")
+	// Copy proxy-helper binary built by scripts/build-proxy-helper.js.
+	const buildTargetOS = process.env.KIMCHI_BUILD_TARGET_OS || platform()
+	const proxyHelperName = buildTargetOS === "win32" || buildTargetOS === "windows" ? "proxy-helper.exe" : "proxy-helper"
+	const proxyHelperSrc = join(projectRoot, "tools", "proxy-helper", "bin", proxyHelperName)
 	const proxyHelperBinDest = join(projectRoot, "dist", "share", "kimchi", "bin")
+	if (!existsSync(proxyHelperSrc)) {
+		throw new Error(`proxy-helper binary not found: ${proxyHelperSrc}`)
+	}
 	mkdirSync(proxyHelperBinDest, { recursive: true })
-	cpSync(proxyHelperSrc, join(proxyHelperBinDest, "proxy-helper"))
+	cpSync(proxyHelperSrc, join(proxyHelperBinDest, proxyHelperName))
 
 	const superpowersSkillSrc = join(projectRoot, "vendor", "superpowers", "skills")
 	const superpowersSkillDst = join(projectRoot, "dist", "share", "kimchi", "vendor", "superpowers", "skills")

--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -11,7 +11,7 @@
 #   KIMCHI_VERSION         Pin a specific version tag (e.g. v0.2.0). Defaults
 #                          to "latest".
 #   KIMCHI_REPO_OVERRIDE   Override release repo. Defaults to getkimchi/kimchi.
-#   KIMCHI_ARCHIVE_PATH    Use a local kimchi_windows_amd64.tar.gz archive
+#   KIMCHI_ARCHIVE_PATH    Use a local kimchi_windows_amd64.zip archive
 #                          instead of downloading. Intended for CI/dev.
 #   KIMCHI_SKIP_PATH_UPDATE  Set to 1 to skip user PATH updates.
 
@@ -88,15 +88,11 @@ function Invoke-DownloadFile {
 function Expand-KimchiArchive {
   param([string]$ArchivePath, [string]$Destination)
 
-  $tar = Get-Command tar.exe -ErrorAction SilentlyContinue
-  if (-not $tar) {
-    throw "tar.exe was not found. Modern Windows includes tar.exe; install it or extract $ArchivePath manually."
-  }
-
   New-Item -ItemType Directory -Force -Path $Destination | Out-Null
-  & $tar.Source -xzf $ArchivePath -C $Destination
-  if ($LASTEXITCODE -ne 0) {
-    throw "Failed to extract $ArchivePath with tar.exe."
+  try {
+    Expand-Archive -LiteralPath $ArchivePath -DestinationPath $Destination -Force
+  } catch {
+    throw "Failed to extract $ArchivePath with Expand-Archive: $($_.Exception.Message)"
   }
 }
 
@@ -168,7 +164,7 @@ function Install-Kimchi {
   $version = Get-EnvOrDefault "KIMCHI_VERSION" "latest"
   $installRoot = Get-EnvOrDefault "KIMCHI_INSTALL_DIR" (Get-DefaultInstallRoot)
   $arch = Get-WindowsArch
-  $assetName = "kimchi_windows_${arch}.tar.gz"
+  $assetName = "kimchi_windows_${arch}.zip"
   $tmpDir = Join-Path ([IO.Path]::GetTempPath()) "kimchi-installer-$PID"
   $extractDir = Join-Path $tmpDir "extract"
 

--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -1,0 +1,263 @@
+#!/usr/bin/env pwsh
+#
+# Install the native Windows Kimchi CLI from the latest GitHub release.
+#
+# Usage:
+#   irm https://github.com/getkimchi/kimchi/releases/latest/download/install.ps1 | iex
+#
+# Optional env:
+#   KIMCHI_INSTALL_DIR     Override install root. Defaults to
+#                          $env:LOCALAPPDATA\Kimchi.
+#   KIMCHI_VERSION         Pin a specific version tag (e.g. v0.2.0). Defaults
+#                          to "latest".
+#   KIMCHI_REPO_OVERRIDE   Override release repo. Defaults to getkimchi/kimchi.
+#   KIMCHI_ARCHIVE_PATH    Use a local kimchi_windows_amd64.tar.gz archive
+#                          instead of downloading. Intended for CI/dev.
+#   KIMCHI_SKIP_PATH_UPDATE  Set to 1 to skip user PATH updates.
+
+$ErrorActionPreference = "Stop"
+$ProgressPreference = "SilentlyContinue"
+
+function Get-EnvOrDefault {
+  param([string]$Name, [string]$Default)
+
+  $value = [Environment]::GetEnvironmentVariable($Name)
+  if ([string]::IsNullOrWhiteSpace($value)) {
+    return $Default
+  }
+  return $value
+}
+
+function Test-Windows {
+  if ($env:OS -eq "Windows_NT") {
+    return $true
+  }
+
+  try {
+    return [System.Runtime.InteropServices.RuntimeInformation]::IsOSPlatform(
+      [System.Runtime.InteropServices.OSPlatform]::Windows
+    )
+  } catch {
+    return $false
+  }
+}
+
+function Get-WindowsArch {
+  $arch = $env:PROCESSOR_ARCHITECTURE
+  if ([string]::IsNullOrWhiteSpace($arch)) {
+    try {
+      $arch = [System.Runtime.InteropServices.RuntimeInformation]::ProcessArchitecture.ToString()
+    } catch {
+      $arch = ""
+    }
+  }
+
+  switch -Regex ($arch) {
+    "^(AMD64|X64|x86_64)$" { return "amd64" }
+    default {
+      throw "Unsupported Windows architecture: $arch. Kimchi currently publishes Windows amd64 release artifacts only."
+    }
+  }
+}
+
+function Get-DefaultInstallRoot {
+  if (-not [string]::IsNullOrWhiteSpace($env:LOCALAPPDATA)) {
+    return (Join-Path $env:LOCALAPPDATA "Kimchi")
+  }
+  return (Join-Path $HOME "AppData\Local\Kimchi")
+}
+
+function Invoke-DownloadFile {
+  param([string]$Url, [string]$OutFile)
+
+  try {
+    [Net.ServicePointManager]::SecurityProtocol = [Net.ServicePointManager]::SecurityProtocol -bor [Net.SecurityProtocolType]::Tls12
+  } catch {
+  }
+
+  $params = @{
+    Uri = $Url
+    OutFile = $OutFile
+  }
+  if ($PSVersionTable.PSVersion.Major -lt 6) {
+    $params.UseBasicParsing = $true
+  }
+  Invoke-WebRequest @params
+}
+
+function Expand-KimchiArchive {
+  param([string]$ArchivePath, [string]$Destination)
+
+  $tar = Get-Command tar.exe -ErrorAction SilentlyContinue
+  if (-not $tar) {
+    throw "tar.exe was not found. Modern Windows includes tar.exe; install it or extract $ArchivePath manually."
+  }
+
+  New-Item -ItemType Directory -Force -Path $Destination | Out-Null
+  & $tar.Source -xzf $ArchivePath -C $Destination
+  if ($LASTEXITCODE -ne 0) {
+    throw "Failed to extract $ArchivePath with tar.exe."
+  }
+}
+
+function Assert-LastExitCode {
+  param([string]$Label)
+
+  if ($LASTEXITCODE -ne 0) {
+    throw "$Label failed with exit code $LASTEXITCODE."
+  }
+}
+
+function Get-NormalizedPathForCompare {
+  param([string]$Path)
+
+  try {
+    $expanded = [Environment]::ExpandEnvironmentVariables($Path)
+    return ([IO.Path]::GetFullPath($expanded).TrimEnd([char[]]@("\", "/"))).ToUpperInvariant()
+  } catch {
+    return $Path.TrimEnd([char[]]@("\", "/")).ToUpperInvariant()
+  }
+}
+
+function Test-PathListContains {
+  param([string]$PathList, [string]$Directory)
+
+  if ([string]::IsNullOrWhiteSpace($PathList)) {
+    return $false
+  }
+
+  $target = Get-NormalizedPathForCompare $Directory
+  foreach ($entry in ($PathList -split ";")) {
+    if ([string]::IsNullOrWhiteSpace($entry)) {
+      continue
+    }
+    if ((Get-NormalizedPathForCompare $entry) -eq $target) {
+      return $true
+    }
+  }
+  return $false
+}
+
+function Add-UserPath {
+  param([string]$Directory)
+
+  $processPath = [Environment]::GetEnvironmentVariable("Path", "Process")
+  if (-not (Test-PathListContains $processPath $Directory)) {
+    $env:Path = "$Directory;$env:Path"
+  }
+
+  $userPath = [Environment]::GetEnvironmentVariable("Path", "User")
+  if (Test-PathListContains $userPath $Directory) {
+    return $false
+  }
+
+  if ([string]::IsNullOrWhiteSpace($userPath)) {
+    [Environment]::SetEnvironmentVariable("Path", $Directory, "User")
+  } else {
+    [Environment]::SetEnvironmentVariable("Path", "$userPath;$Directory", "User")
+  }
+  return $true
+}
+
+function Install-Kimchi {
+  if (-not (Test-Windows)) {
+    throw "This installer is for native Windows. On macOS/Linux, use: curl -fsSL https://github.com/getkimchi/kimchi/releases/latest/download/install.sh | bash"
+  }
+
+  $repo = Get-EnvOrDefault "KIMCHI_REPO_OVERRIDE" "getkimchi/kimchi"
+  $version = Get-EnvOrDefault "KIMCHI_VERSION" "latest"
+  $installRoot = Get-EnvOrDefault "KIMCHI_INSTALL_DIR" (Get-DefaultInstallRoot)
+  $arch = Get-WindowsArch
+  $assetName = "kimchi_windows_${arch}.tar.gz"
+  $tmpDir = Join-Path ([IO.Path]::GetTempPath()) "kimchi-installer-$PID"
+  $extractDir = Join-Path $tmpDir "extract"
+
+  Remove-Item -Recurse -Force -ErrorAction SilentlyContinue $tmpDir
+  New-Item -ItemType Directory -Force -Path $tmpDir | Out-Null
+
+  try {
+    $localArchive = [Environment]::GetEnvironmentVariable("KIMCHI_ARCHIVE_PATH")
+    if ([string]::IsNullOrWhiteSpace($localArchive)) {
+      $archivePath = Join-Path $tmpDir $assetName
+      if ($version -eq "latest") {
+        $binaryUrl = "https://github.com/$repo/releases/latest/download/$assetName"
+      } else {
+        $binaryUrl = "https://github.com/$repo/releases/download/$version/$assetName"
+      }
+
+      Write-Host "Downloading Kimchi for windows/$arch from $repo ($version)..."
+      Invoke-DownloadFile $binaryUrl $archivePath
+    } else {
+      $archivePath = [IO.Path]::GetFullPath($localArchive)
+      if (-not (Test-Path $archivePath -PathType Leaf)) {
+        throw "KIMCHI_ARCHIVE_PATH does not exist: $archivePath"
+      }
+      Write-Host "Installing Kimchi from local archive $archivePath..."
+    }
+
+    Expand-KimchiArchive $archivePath $extractDir
+
+    $archiveBin = Join-Path (Join-Path $extractDir "bin") "kimchi.exe"
+    $archiveShare = Join-Path (Join-Path $extractDir "share") "kimchi"
+    $archiveHelper = Join-Path (Join-Path $archiveShare "bin") "proxy-helper.exe"
+    if (-not (Test-Path $archiveBin -PathType Leaf)) {
+      throw "Archive did not contain bin\kimchi.exe."
+    }
+    if (-not (Test-Path $archiveShare -PathType Container)) {
+      throw "Archive did not contain share\kimchi."
+    }
+    if (-not (Test-Path $archiveHelper -PathType Leaf)) {
+      throw "Archive did not contain share\kimchi\bin\proxy-helper.exe."
+    }
+
+    $binDir = Join-Path $installRoot "bin"
+    $shareParent = Join-Path $installRoot "share"
+    $shareDir = Join-Path $shareParent "kimchi"
+    $kimchiPath = Join-Path $binDir "kimchi.exe"
+    $helperPath = Join-Path (Join-Path $shareDir "bin") "proxy-helper.exe"
+
+    New-Item -ItemType Directory -Force -Path $binDir, $shareParent | Out-Null
+    Remove-Item -Force -ErrorAction SilentlyContinue $kimchiPath
+    Remove-Item -Recurse -Force -ErrorAction SilentlyContinue $shareDir
+    Copy-Item -Force $archiveBin $kimchiPath
+    Copy-Item -Recurse -Force $archiveShare $shareDir
+
+    $versionOutput = & $kimchiPath --version
+    Assert-LastExitCode "kimchi.exe --version"
+    & $helperPath ssh-proxy --help *> $null
+    Assert-LastExitCode "proxy-helper.exe ssh-proxy --help"
+
+    $pathSkipped = [Environment]::GetEnvironmentVariable("KIMCHI_SKIP_PATH_UPDATE") -eq "1"
+    $pathAdded = $false
+    if (-not $pathSkipped) {
+      try {
+        $pathAdded = Add-UserPath $binDir
+      } catch {
+        Write-Warning "Kimchi was installed, but the user PATH update failed: $($_.Exception.Message)"
+      }
+    }
+
+    Write-Host ""
+    Write-Host "Kimchi was installed successfully."
+    Write-Host "Binary: $kimchiPath"
+    if ($versionOutput) {
+      $versionOutput | ForEach-Object { Write-Host "Version: $_" }
+    }
+
+    if ($pathSkipped) {
+      Write-Host "PATH update skipped because KIMCHI_SKIP_PATH_UPDATE=1."
+    } elseif ($pathAdded) {
+      Write-Host "Added $binDir to your user PATH."
+      Write-Host "Restart already-open terminals if the kimchi command is not found."
+    } else {
+      Write-Host "$binDir is already on PATH."
+    }
+
+    Write-Host ""
+    Write-Host "Next: run kimchi setup, then kimchi."
+  } finally {
+    Remove-Item -Recurse -Force -ErrorAction SilentlyContinue $tmpDir
+  }
+}
+
+Install-Kimchi

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -3,7 +3,7 @@
 # Install the kimchi coding-harness CLI from the latest GitHub release.
 #
 # Usage:
-#   curl -fsSL https://github.com/castai/kimchi/releases/latest/download/install.sh | bash
+#   curl -fsSL https://github.com/getkimchi/kimchi/releases/latest/download/install.sh | bash
 #
 # Optional env:
 #   KIMCHI_INSTALL_DIR  Override install dir. Defaults to /usr/local/bin if
@@ -20,7 +20,7 @@ BLUE='\033[0;34m'
 YELLOW='\033[0;33m'
 NC='\033[0m'
 
-REPO="${KIMCHI_REPO_OVERRIDE:-castai/kimchi}"
+REPO="${KIMCHI_REPO_OVERRIDE:-getkimchi/kimchi}"
 VERSION="${KIMCHI_VERSION:-latest}"
 
 echo -e "${BLUE}Installing Kimchi from ${REPO}${VERSION:+ (${VERSION})}…${NC}"

--- a/scripts/package-release-asset.js
+++ b/scripts/package-release-asset.js
@@ -1,0 +1,82 @@
+// Package dist/bin and dist/share into the release artifact for a target OS/arch.
+//
+// Usage:
+//   node scripts/package-release-asset.js --os linux --arch amd64
+//   node scripts/package-release-asset.js --os windows --arch amd64
+
+import { execFileSync } from "node:child_process"
+import { existsSync } from "node:fs"
+import { resolve } from "node:path"
+
+const args = parseArgs(process.argv.slice(2))
+const os = requiredArg(args, "os")
+const arch = requiredArg(args, "arch")
+const distDir = resolve(args.dist ?? "dist")
+const outDir = resolve(args.outDir ?? ".")
+
+assertDirectory(resolve(distDir, "bin"))
+assertDirectory(resolve(distDir, "share"))
+
+const artifactName = `kimchi_${os}_${arch}.${os === "windows" ? "zip" : "tar.gz"}`
+const artifactPath = resolve(outDir, artifactName)
+
+if (os === "windows") {
+	execFileSync(
+		"powershell.exe",
+		[
+			"-NoProfile",
+			"-NonInteractive",
+			"-Command",
+			[
+				"$ErrorActionPreference = 'Stop'",
+				"$dist = [IO.Path]::GetFullPath($env:KIMCHI_PACKAGE_DIST)",
+				"$out = [IO.Path]::GetFullPath($env:KIMCHI_PACKAGE_OUT)",
+				"Compress-Archive -LiteralPath (Join-Path $dist 'bin'),(Join-Path $dist 'share') -DestinationPath $out -Force",
+			].join("; "),
+		],
+		{
+			stdio: "inherit",
+			env: {
+				...process.env,
+				KIMCHI_PACKAGE_DIST: distDir,
+				KIMCHI_PACKAGE_OUT: artifactPath,
+			},
+		},
+	)
+} else {
+	execFileSync("tar", ["-czf", artifactPath, "-C", distDir, "bin", "share"], { stdio: "inherit" })
+}
+
+console.log(artifactName)
+
+function parseArgs(argv) {
+	const parsed = {}
+	for (let i = 0; i < argv.length; i++) {
+		const arg = argv[i]
+		if (!arg.startsWith("--")) {
+			throw new Error(`Unexpected argument: ${arg}`)
+		}
+		const [key, inlineValue] = arg.slice(2).split("=", 2)
+		if (!key) throw new Error(`Invalid argument: ${arg}`)
+		const value = inlineValue ?? argv[++i]
+		if (!value || value.startsWith("--")) {
+			throw new Error(`Missing value for --${key}`)
+		}
+		parsed[key] = value
+	}
+	return parsed
+}
+
+function requiredArg(args, name) {
+	const value = args[name]
+	if (!value) {
+		throw new Error(`Missing required --${name}`)
+	}
+	return value
+}
+
+function assertDirectory(path) {
+	if (!existsSync(path)) {
+		throw new Error(`Required package directory does not exist: ${path}`)
+	}
+}

--- a/src/ssh-proxy.test.ts
+++ b/src/ssh-proxy.test.ts
@@ -1,0 +1,62 @@
+import { existsSync, mkdirSync, rmSync, writeFileSync } from "node:fs"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
+import { afterEach, beforeEach, describe, expect, it } from "vitest"
+import { findProxyHelper } from "./ssh-proxy.js"
+
+describe("findProxyHelper", () => {
+	let tmpBase: string
+
+	beforeEach(() => {
+		tmpBase = join(tmpdir(), `kimchi-proxy-helper-test-${process.pid}-${Date.now()}`)
+		mkdirSync(tmpBase, { recursive: true })
+	})
+
+	afterEach(() => {
+		rmSync(tmpBase, { recursive: true, force: true })
+	})
+
+	it("returns an explicit override without checking the filesystem", () => {
+		expect(findProxyHelper("/custom/proxy-helper")).toBe("/custom/proxy-helper")
+	})
+
+	it("finds bundled proxy-helper.exe for Windows binary releases", () => {
+		const shareDir = join(tmpBase, "share", "kimchi")
+		const helper = join(shareDir, "bin", "proxy-helper.exe")
+		mkdirSync(join(tmpBase, "bin"), { recursive: true })
+		mkdirSync(join(shareDir, "bin"), { recursive: true })
+		writeFileSync(join(shareDir, "package.json"), "{}")
+		writeFileSync(helper, "")
+
+		expect(
+			findProxyHelper(undefined, {
+				env: {},
+				execPath: join(tmpBase, "bin", "kimchi.exe"),
+				home: tmpBase,
+				platform: "win32",
+				pathDelimiter: ";",
+				exists: existsSync,
+			}),
+		).toBe(helper)
+	})
+
+	it("searches Windows PATH entries with semicolon delimiters", () => {
+		const first = join(tmpBase, "first")
+		const second = join(tmpBase, "second")
+		const helper = join(second, "proxy-helper.exe")
+		mkdirSync(first, { recursive: true })
+		mkdirSync(second, { recursive: true })
+		writeFileSync(helper, "")
+
+		expect(
+			findProxyHelper(undefined, {
+				env: { PATH: `${first};${second}` },
+				execPath: join(tmpBase, "bin", "kimchi.exe"),
+				home: tmpBase,
+				platform: "win32",
+				pathDelimiter: ";",
+				exists: existsSync,
+			}),
+		).toBe(helper)
+	})
+})

--- a/src/ssh-proxy.test.ts
+++ b/src/ssh-proxy.test.ts
@@ -40,6 +40,26 @@ describe("findProxyHelper", () => {
 		).toBe(helper)
 	})
 
+	it("finds bundled proxy-helper for POSIX binary releases", () => {
+		const shareDir = join(tmpBase, "share", "kimchi")
+		const helper = join(shareDir, "bin", "proxy-helper")
+		mkdirSync(join(tmpBase, "bin"), { recursive: true })
+		mkdirSync(join(shareDir, "bin"), { recursive: true })
+		writeFileSync(join(shareDir, "package.json"), "{}")
+		writeFileSync(helper, "")
+
+		expect(
+			findProxyHelper(undefined, {
+				env: {},
+				execPath: join(tmpBase, "bin", "kimchi"),
+				home: tmpBase,
+				platform: "linux",
+				pathDelimiter: ":",
+				exists: existsSync,
+			}),
+		).toBe(helper)
+	})
+
 	it("searches Windows PATH entries with semicolon delimiters", () => {
 		const first = join(tmpBase, "first")
 		const second = join(tmpBase, "second")
@@ -55,6 +75,26 @@ describe("findProxyHelper", () => {
 				home: tmpBase,
 				platform: "win32",
 				pathDelimiter: ";",
+				exists: existsSync,
+			}),
+		).toBe(helper)
+	})
+
+	it("searches POSIX PATH entries with colon delimiters", () => {
+		const first = join(tmpBase, "first")
+		const second = join(tmpBase, "second")
+		const helper = join(second, "proxy-helper")
+		mkdirSync(first, { recursive: true })
+		mkdirSync(second, { recursive: true })
+		writeFileSync(helper, "")
+
+		expect(
+			findProxyHelper(undefined, {
+				env: { PATH: `${first}:${second}` },
+				execPath: join(tmpBase, "bin", "kimchi"),
+				home: tmpBase,
+				platform: "linux",
+				pathDelimiter: ":",
 				exists: existsSync,
 			}),
 		).toBe(helper)

--- a/src/ssh-proxy.ts
+++ b/src/ssh-proxy.ts
@@ -1,31 +1,54 @@
 import { spawnSync } from "node:child_process"
 import { existsSync } from "node:fs"
-import { join } from "node:path"
+import { delimiter, join } from "node:path"
 import { resolveAuxiliaryFilesDir } from "./auxiliary-files/resolver.js"
 import { readApiKeyFromConfigFile } from "./config.js"
 
-export function findProxyHelper(override?: string): string {
-	const explicit = override ?? process.env.KIMCHI_PROXY_HELPER
+interface FindProxyHelperOptions {
+	env?: NodeJS.ProcessEnv
+	home?: string
+	execPath?: string
+	platform?: NodeJS.Platform
+	pathDelimiter?: string
+	exists?: (path: string) => boolean
+}
+
+function proxyHelperNames(platform: NodeJS.Platform): string[] {
+	return platform === "win32" ? ["proxy-helper.exe", "proxy-helper"] : ["proxy-helper"]
+}
+
+export function findProxyHelper(override?: string, options: FindProxyHelperOptions = {}): string {
+	const env = options.env ?? process.env
+	const exists = options.exists ?? existsSync
+	const explicit = override ?? env.KIMCHI_PROXY_HELPER
 	if (explicit) {
 		return explicit
 	}
 
-	const shareDir = resolveAuxiliaryFilesDir(process.env, process.env.HOME ?? "", process.execPath)
-	const bundled = join(shareDir, "bin", "proxy-helper")
-	if (existsSync(bundled)) {
-		return bundled
+	const platform = options.platform ?? process.platform
+	const names = proxyHelperNames(platform)
+	const shareDir = resolveAuxiliaryFilesDir(env, options.home ?? env.HOME ?? "", options.execPath ?? process.execPath)
+	const bundledCandidates = names.map((name) => join(shareDir, "bin", name))
+	for (const bundled of bundledCandidates) {
+		if (exists(bundled)) {
+			return bundled
+		}
 	}
 
 	// Fall back to PATH (useful in dev / non-binary runs)
-	for (const dir of (process.env.PATH ?? "").split(":")) {
-		const candidate = join(dir, "proxy-helper")
-		if (existsSync(candidate)) {
-			return candidate
+	const pathDelimiter = options.pathDelimiter ?? delimiter
+	for (const dir of (env.PATH ?? "").split(pathDelimiter)) {
+		if (!dir) continue
+		for (const name of names) {
+			const candidate = join(dir, name)
+			if (exists(candidate)) {
+				return candidate
+			}
 		}
 	}
 
 	throw new Error(
-		`proxy-helper binary not found. Checked bundled path: ${bundled}\nRun 'make copy-for-dev' in tools/proxy-helper/ or ensure proxy-helper is on PATH.`,
+		`proxy-helper binary not found. Checked bundled paths: ${bundledCandidates.join(", ")}\nRun 'node scripts/build-proxy-helper.js' or ensure proxy-helper is on PATH.`,
 	)
 }
 

--- a/src/update/extract.ts
+++ b/src/update/extract.ts
@@ -1,3 +1,4 @@
+import { execFileSync } from "node:child_process"
 import { createHash } from "node:crypto"
 import { createReadStream, mkdtempSync } from "node:fs"
 import { tmpdir } from "node:os"
@@ -20,18 +21,26 @@ export async function verifyChecksum(path: string, expected: Uint8Array): Promis
 }
 
 /**
- * Extract a tar.gz into a fresh temp dir preserving full directory structure.
+ * Extract the platform archive into a fresh temp dir preserving full directory structure.
  * Returns the root extraction directory; the caller is responsible for cleaning
  * it up. Archive structure is expected to be:
  *   extractedRoot/
  *   ├── bin/
- *   │   └── kimchi
+ *   │   └── kimchi(.exe)
  *   └── share/
  *       └── kimchi/
  *           └── ... (supporting files)
  *
- * Path traversal is blocked (entries starting with "..") as a security measure.
+ * POSIX tar extraction blocks path traversal explicitly. Windows zip extraction
+ * is only used after checksum verification against the release manifest.
  */
+export async function extractArchive(archivePath: string): Promise<string> {
+	if (process.platform === "win32") {
+		return extractZip(archivePath)
+	}
+	return extractTarGz(archivePath)
+}
+
 export async function extractTarGz(archivePath: string): Promise<string> {
 	const root = mkdtempSync(join(tmpdir(), "kimchi-update-"))
 	await tarExtract({
@@ -42,6 +51,22 @@ export async function extractTarGz(archivePath: string): Promise<string> {
 		// minor format quirks. Block path traversal explicitly.
 		filter: (path) => !path.startsWith(".."),
 	})
+	return root
+}
+
+function extractZip(archivePath: string): string {
+	const root = mkdtempSync(join(tmpdir(), "kimchi-update-"))
+	execFileSync("powershell.exe", [
+		"-NoProfile",
+		"-NonInteractive",
+		"-Command",
+		"Expand-Archive",
+		"-LiteralPath",
+		archivePath,
+		"-DestinationPath",
+		root,
+		"-Force",
+	])
 	return root
 }
 

--- a/src/update/github.ts
+++ b/src/update/github.ts
@@ -11,7 +11,7 @@ const DEFAULT_DOWNLOAD_BASE = "https://github.com"
 export interface Repo {
 	owner: string
 	name: string
-	/** Binary name inside the tar.gz (also the prefix of the asset filename). */
+	/** Binary name inside the release archive (also the prefix of the asset filename). */
 	binary: string
 }
 

--- a/src/update/workflow.test.ts
+++ b/src/update/workflow.test.ts
@@ -6,7 +6,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
 import type { CanaryReleaseInfo, GitHubClient, ReleaseInfo, Repo } from "./github.js"
 
 const mocks = vi.hoisted(() => ({
-	extractTarGz: vi.fn(),
+	extractArchive: vi.fn(),
 	verifyChecksum: vi.fn(),
 	fetchChecksum: vi.fn(),
 	downloadArchive: vi.fn(),
@@ -17,7 +17,7 @@ const mocks = vi.hoisted(() => ({
 }))
 
 vi.mock("./extract.js", () => ({
-	extractTarGz: mocks.extractTarGz,
+	extractArchive: mocks.extractArchive,
 	verifyChecksum: mocks.verifyChecksum,
 }))
 
@@ -272,7 +272,7 @@ describe("applyUpdate share destination", () => {
 	let prevPiPackageDir: string | undefined
 
 	beforeEach(() => {
-		mocks.extractTarGz.mockReset()
+		mocks.extractArchive.mockReset()
 		mocks.verifyChecksum.mockReset()
 		mocks.fetchChecksum.mockReset()
 		mocks.downloadArchive.mockReset()
@@ -294,7 +294,7 @@ describe("applyUpdate share destination", () => {
 		writeFileSync(join(extractRoot, "bin", "kimchi"), "")
 		writeFileSync(join(extractRoot, "share", "kimchi", "package.json"), "{}")
 
-		mocks.extractTarGz.mockResolvedValue(extractRoot)
+		mocks.extractArchive.mockResolvedValue(extractRoot)
 		mocks.verifyChecksum.mockResolvedValue(undefined)
 		mocks.fetchChecksum.mockResolvedValue("sha256:fff")
 		mocks.downloadArchive.mockResolvedValue(undefined)
@@ -361,5 +361,37 @@ describe("applyUpdate share destination", () => {
 			expect.stringContaining(".local/share/kimchi"),
 			"kimchi",
 		)
+	})
+
+	it("uses kimchi.exe from Windows archives", async () => {
+		const origPlatform = process.platform
+		Object.defineProperty(process, "platform", { value: "win32" })
+		try {
+			const winBinPath = join(fakePrefix, "bin", "kimchi.exe")
+			writeFileSync(join(extractRoot, "bin", "kimchi.exe"), "")
+			const client = {
+				fetchChecksum: mocks.fetchChecksum,
+				downloadArchive: mocks.downloadArchive,
+			} as unknown as GitHubClient
+
+			await applyUpdate({
+				repo: REPO,
+				tag: "v0.0.24",
+				executablePath: winBinPath,
+				client,
+			})
+
+			const newBinaryPath = join(extractRoot, "bin", "kimchi.exe")
+			expect(mocks.downloadArchive).toHaveBeenCalledWith(
+				REPO,
+				"v0.0.24",
+				expect.stringMatching(/kimchi_windows_amd64\.zip$/),
+			)
+			expect(mocks.macosCodesignReSign).toHaveBeenCalledWith(newBinaryPath)
+			expect(mocks.smokeTestBinary).toHaveBeenCalledWith(newBinaryPath)
+			expect(mocks.atomicInstall).toHaveBeenCalledWith(newBinaryPath, winBinPath)
+		} finally {
+			Object.defineProperty(process, "platform", { value: origPlatform })
+		}
 	})
 })

--- a/src/update/workflow.ts
+++ b/src/update/workflow.ts
@@ -3,8 +3,8 @@ import { homedir, tmpdir } from "node:os"
 import { join } from "node:path"
 import { resolveAuxiliaryFilesDir } from "../auxiliary-files/resolver.js"
 import { compareSemverGte } from "../integrations/opencode.js"
-import { extractTarGz, verifyChecksum } from "./extract.js"
-import { GitHubClient, KIMCHI_REPO, type Repo } from "./github.js"
+import { extractArchive, verifyChecksum } from "./extract.js"
+import { GitHubClient, KIMCHI_REPO, type Repo, assetName } from "./github.js"
 import { atomicInstall, copySupportingFiles, macosCodesignReSign, smokeTestBinary } from "./install.js"
 import { resolveExecutablePath } from "./paths.js"
 import { isStale, isUpdateCheckDisabled, loadRepoState, saveRepoState } from "./state.js"
@@ -44,6 +44,10 @@ function canaryVersionFromName(name: string): string {
 const SHA7_LEN = 7
 const SHA7_RE = /^[0-9a-f]{7}$/
 const CANARY_VERSION_RE = new RegExp(`^0\\.0\\.0-canary\\.\\d{8}\\.([0-9a-f]{${SHA7_LEN}})$`)
+
+function binaryFileName(repo: Repo): string {
+	return process.platform === "win32" ? `${repo.binary}.exe` : repo.binary
+}
 
 /**
  * Extract the SHA7 from a canary version string. Returns null for any input
@@ -157,7 +161,7 @@ export interface UpdateOptions {
  * Download → verify checksum → extract → smoke-test → atomic install.
  * Throws on any step's failure with the original error wrapped in context.
  *
- * Cleans up the temp tarball + extract dir even on failure (try/finally).
+ * Cleans up the temp archive + extract dir even on failure (try/finally).
  *
  * macOS Gatekeeper requires the new binary to be ad-hoc signed before the
  * swap; the binary's signature gets baked into the inode, so we sign at
@@ -174,16 +178,16 @@ export async function applyUpdate(opts: UpdateOptions): Promise<UpdateResult> {
 
 	const workDir = mkdtempSync(join(tmpdir(), "kimchi-update-"))
 	try {
-		const archiveName = `${repo.binary}.archive`
+		const archiveName = assetName(repo)
 		const archivePath = join(workDir, archiveName)
 
 		const expectedChecksum = await client.fetchChecksum(repo, opts.tag)
 		await client.downloadArchive(repo, opts.tag, archivePath)
 		await verifyChecksum(archivePath, expectedChecksum)
 
-		const extractedRoot = await extractTarGz(archivePath)
+		const extractedRoot = await extractArchive(archivePath)
 		try {
-			const binaryPath = join("bin", repo.binary)
+			const binaryPath = join("bin", binaryFileName(repo))
 			const newBinaryPath = join(extractedRoot, binaryPath)
 			macosCodesignReSign(newBinaryPath)
 			smokeTestBinary(newBinaryPath)


### PR DESCRIPTION


## Linked issue

Closes #716

<!-- Every PR must link to an existing issue. PRs without a linked issue will not be reviewed.
     Use one of: Closes #N / Fixes #N / Resolves #N -->

## What does this PR do?

* Add Windows x64 to the release matrix and build a native kimchi.exe artifact on windows-latest.
* Add a cross-platform proxy-helper build script, stage proxy-helper.exe for Windows packages, and teach the SSH proxy resolver to find proxy-helper.exe with Windows PATH semantics.
* Document the Windows release and local VM debugging workflow, and add regression coverage for Windows proxy-helper lookup.

## Checklist

- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md) and agree to the CLA
- [x] This PR links to an open issue above
- [x] Tests pass locally (`pnpm run test`)
- [x] Lint passes (`pnpm run check`)
- [x] Documentation updated if behavior changed
