### PR TITLE
fix(acp): resolve premature end_turn signal for acp clients

### DIFF
--- a/src/modes/acp/server.test.ts
+++ b/src/modes/acp/server.test.ts
@@ -6,7 +6,9 @@ import type {
 	ListSessionsRequest,
 	RequestPermissionRequest,
 	SessionNotification,
+	TextContent,
 } from "@agentclientprotocol/sdk"
+import type { AssistantMessage } from "@earendil-works/pi-ai"
 import type {
 	AgentSession,
 	AgentSessionEvent,
@@ -271,57 +273,17 @@ describe("KimchiAcpAgent turn lifecycle", () => {
 		})
 	})
 
-	// The fragile scenario the previous setImmediate heuristic could trip on:
-	// session.prompt() resolves BEFORE the subscriber receives agent_end (e.g.
-	// a slow extension agent_end handler awaits real I/O). The fix trusts
-	// pi-agent-core's agent_end contract and waits until the event actually
-	// arrives at our listener.
-	it("resolves end_turn even when agent_end is delivered after session.prompt resolves", async () => {
-		let agentEndDeliveredAt = 0
-		let outerResolvedAt = 0
-		fake.promptImpl = async () => {
-			// Mirror pi-mono: agent_start is the first event of a real run.
-			fake.emit({ type: "agent_start" })
-			// agent.prompt awaits the LLM call; simulate with a short delay.
-			await delay(5)
-			// session.prompt is about to resolve; schedule agent_end AFTER that,
-			// simulating a slow downstream handler on the agent_end path.
-			setTimeout(() => {
-				agentEndDeliveredAt = Date.now()
-				fake.emit(agentEnd())
-			}, 40)
-			// Return now — agent_end has NOT reached our subscriber yet.
-		}
-
-		const start = Date.now()
-		const result = await agent.prompt({
-			sessionId,
-			prompt: [{ type: "text", text: "hi" }],
-		})
-		outerResolvedAt = Date.now()
-
-		expect(result.stopReason).toBe("end_turn")
-		// The outer prompt must wait for agent_end, not race ahead of it.
-		expect(agentEndDeliveredAt).toBeGreaterThan(0)
-		expect(outerResolvedAt).toBeGreaterThanOrEqual(agentEndDeliveredAt)
-		expect(outerResolvedAt - start).toBeGreaterThanOrEqual(40)
-	})
-
-	// CANARY: documents the load-bearing assumption in prompt() that SOME turn
-	// event (agent_start or later) is delivered before session.prompt() resolves.
-	// pi-mono's agent.prompt awaits the LLM call, draining the microtask queue
-	// and ensuring _processAgentEvent ran for at least agent_start. If pi-mono
-	// ever delays ALL turn events until after session.prompt() resolves, real
-	// turns would hit the !turnActive branch and synthesize end_turn prematurely —
-	// late agent_end / tool events would be silently dropped. This test locks in
-	// the current behavior; a future pi-mono update that breaks the contract
-	// should fail this test, at which point swap the detector for something more
-	// robust (e.g. peek at isStreaming on the session).
-	it("CANARY: synthesizes end_turn when no turn events arrive before session.prompt resolves", async () => {
+	// session.prompt() is the source of truth for "turn is done". When events
+	// arrive AFTER session.prompt resolves (e.g. a slow downstream handler
+	// awaited something), the turn was already finalized on session.prompt
+	// resolve — late events must be dropped. agent_end no longer drives
+	// finalization, so it cannot be used as a barrier. If this ever regresses
+	// to "wait for late agent_end", we'd be vulnerable to the chained
+	// agent.continue() bug again.
+	it("drops late turn events that arrive after session.prompt resolves", async () => {
 		let lateEventsFired = false
 		fake.promptImpl = async () => {
 			await delay(5)
-			// Schedule agent_start + agent_end AFTER session.prompt resolves.
 			setTimeout(() => {
 				fake.emit({ type: "agent_start" })
 				fake.emit(agentEnd())
@@ -333,42 +295,11 @@ describe("KimchiAcpAgent turn lifecycle", () => {
 			sessionId,
 			prompt: [{ type: "text", text: "hi" }],
 		})
-		// Current behavior: end_turn synthesized immediately after session.prompt
-		// resolves — before late events arrive. If this changes to "cancelled" or
-		// "end_turn from late agent_end", the short-circuit detector was updated.
 		expect(result.stopReason).toBe("end_turn")
 		expect(lateEventsFired).toBe(false)
 
-		// Let late events fire and confirm they are dropped (turn already cleared).
 		await delay(40)
 		expect(lateEventsFired).toBe(true)
-	})
-
-	// Defensive widening: if the first event we observe from pi-mono is
-	// tool_execution_start (hypothetical future ordering where agent_start
-	// isn't synchronous with agent.prompt), turnActive still flips and the
-	// prompt() resolver waits for agent_end instead of synthesizing end_turn
-	// prematurely. This pins down the widening in TurnContext.turnActive.
-	it("treats tool_execution_start as a turn-active signal (no premature short-circuit)", async () => {
-		fake.promptImpl = async () => {
-			// No agent_start. Emit only tool_execution_start + agent_end.
-			fake.emit({
-				type: "tool_execution_start",
-				toolCallId: "tc-early",
-				toolName: "bash",
-				args: { command: "noop" },
-			})
-			await delay(5)
-			setTimeout(() => fake.emit(agentEnd()), 30)
-		}
-		const result = await agent.prompt({
-			sessionId,
-			prompt: [{ type: "text", text: "x" }],
-		})
-		// end_turn must come from agent_end (post-delay), not from the
-		// !turnActive short-circuit branch firing immediately after
-		// session.prompt() resolves.
-		expect(result.stopReason).toBe("end_turn")
 	})
 
 	// Extension-command / input-handler / no-op path: session.prompt returns
@@ -385,6 +316,74 @@ describe("KimchiAcpAgent turn lifecycle", () => {
 		})
 
 		expect(result.stopReason).toBe("end_turn")
+	})
+
+	// Regression: pi-mono's _runAgentPrompt chains multiple agent.prompt /
+	// agent.continue calls when retries, queued follow-up messages, or
+	// compaction are pending. Each chained call emits its own agent_start +
+	// agent_end pair. Previously the ACP handler finalized on the FIRST
+	// agent_end, sending end_turn mid-stream — the client then tried to send
+	// a new prompt and hit pi-mono's "Agent is already processing" throw
+	// because session.prompt was still running the chained continues.
+	// Now: end_turn is sent exactly once, only after session.prompt()
+	// resolves (i.e. after ALL chained calls complete).
+	it("sends exactly one end_turn after chained agent.continue() cycles complete", async () => {
+		const { conn: recordingConn, updates } = makeRecordingConn()
+		const localAgent = new KimchiAcpAgent(recordingConn, {
+			extensionFactories: [],
+			agentDir: "/tmp/fake-agent-dir",
+			sessionFactory: async () => asSession(fake),
+		})
+		const res = await localAgent.newSession({ cwd: "/tmp", mcpServers: [] })
+		const localSessionId = res.sessionId
+
+		fake.promptImpl = async () => {
+			// Cycle 1 — first agent.prompt call.
+			fake.emit({ type: "agent_start" })
+			fake.emit({
+				type: "message_update",
+				assistantMessageEvent: {
+					type: "text_delta",
+					delta: "first",
+					contentIndex: 0,
+					partial: {} as unknown as AssistantMessage,
+				},
+				message: {} as unknown as AssistantMessage,
+			})
+			fake.emit(agentEnd())
+			await delay(5)
+			// Cycle 2 — agent.continue() (e.g. follow-up message queued,
+			// retry needed, or compaction). The user-visible bug is that the
+			// FIRST agent_end used to trigger end_turn here, dropping cycle 2.
+			fake.emit({ type: "agent_start" })
+			fake.emit({
+				type: "message_update",
+				assistantMessageEvent: {
+					type: "text_delta",
+					delta: "second",
+					contentIndex: 0,
+					partial: {} as unknown as AssistantMessage,
+				},
+				message: {} as unknown as AssistantMessage,
+			})
+			fake.emit(agentEnd())
+		}
+
+		const result = await localAgent.prompt({
+			sessionId: localSessionId,
+			prompt: [{ type: "text", text: "go" }],
+		})
+
+		// Single end_turn, with stopReason "end_turn".
+		expect(result.stopReason).toBe("end_turn")
+
+		// Both cycles' chunks reach the client. Under the OLD behavior,
+		// the first agent_end would have cleared entry.turn and dropped
+		// every cycle-2 event — so this assertion is the bug-reproducer.
+		const chunks = updates.flatMap((u) =>
+			u.update.sessionUpdate === "agent_message_chunk" ? [(u.update.content as TextContent).text] : [],
+		)
+		expect(chunks).toEqual(["first", "second"])
 	})
 
 	// Client cancels mid-turn: cancelled=true is set on the turn context, then

--- a/src/modes/acp/server.test.ts
+++ b/src/modes/acp/server.test.ts
@@ -386,6 +386,73 @@ describe("KimchiAcpAgent turn lifecycle", () => {
 		expect(chunks).toEqual(["first", "second"])
 	})
 
+	// Cancel arrives between chained agent.continue() cycles. Cycle 1 completes
+	// normally (agent_start → message_update → agent_end), then the client calls
+	// cancel() before cycle 2 starts. session.prompt() resolves (abort may or may
+	// not prevent the next continue), and the .then() handler sees cancelled=true.
+	// The first cycle's chunks must still reach the client; the result must be
+	// "cancelled", not "end_turn".
+	it("resolves cancelled when cancel arrives between chained agent.continue() cycles", async () => {
+		const { conn: recordingConn, updates } = makeRecordingConn()
+		const localAgent = new KimchiAcpAgent(recordingConn, {
+			extensionFactories: [],
+			agentDir: "/tmp/fake-agent-dir",
+			sessionFactory: async () => asSession(fake),
+		})
+		const res = await localAgent.newSession({ cwd: "/tmp", mcpServers: [] })
+		const localSessionId = res.sessionId
+
+		let cancelSeen = false
+		fake.promptImpl = async () => {
+			// Cycle 1 — completes normally.
+			fake.emit({ type: "agent_start" })
+			fake.emit({
+				type: "message_update",
+				assistantMessageEvent: {
+					type: "text_delta",
+					delta: "before-cancel",
+					contentIndex: 0,
+					partial: {} as unknown as AssistantMessage,
+				},
+				message: {} as unknown as AssistantMessage,
+			})
+			fake.emit(agentEnd())
+
+			// Simulate the async boundary between chained calls where
+			// _handlePostAgentRun decides whether to continue. The client's
+			// cancel() lands here.
+			while (!cancelSeen) await delay(5)
+
+			// Cycle 2 — would have run, but abort arrived. In real pi-mono the
+			// next agent.continue() may not even start; simulate the benign case
+			// where it does start but produces nothing meaningful before abort
+			// tears it down.
+			fake.emit({ type: "agent_start" })
+			fake.emit(agentEnd())
+		}
+		fake.abortImpl = async () => {
+			cancelSeen = true
+		}
+
+		const promptP = localAgent.prompt({
+			sessionId: localSessionId,
+			prompt: [{ type: "text", text: "go" }],
+		})
+		// Let cycle 1 complete and the promptImpl pause at the while-loop.
+		await delay(20)
+		await localAgent.cancel({ sessionId: localSessionId })
+
+		const result = await promptP
+		expect(result.stopReason).toBe("cancelled")
+		expect(fake.aborted).toBe(true)
+
+		// Cycle 1's chunk must have been delivered before cancellation.
+		const chunks = updates.flatMap((u) =>
+			u.update.sessionUpdate === "agent_message_chunk" ? [(u.update.content as TextContent).text] : [],
+		)
+		expect(chunks).toContain("before-cancel")
+	})
+
 	// Client cancels mid-turn: cancelled=true is set on the turn context, then
 	// agent_end fires and the subscriber finalizes with stopReason=cancelled.
 	it("resolves cancelled when cancel fires before agent_end", async () => {
@@ -453,6 +520,36 @@ describe("KimchiAcpAgent turn lifecycle", () => {
 
 		await expect(agent.prompt({ sessionId, prompt: [{ type: "text", text: "x" }] })).rejects.toThrow(
 			/no model configured/,
+		)
+	})
+
+	// Chained continues: cycle 1 succeeds but cycle 2's agent.continue() throws
+	// a non-abort error (e.g. context overflow during compaction retry). The
+	// .catch() handler must propagate the error since cancelled is false — the
+	// client sees a JSON-RPC error, not a silent end_turn that hides the failure.
+	it("rejects the outer prompt when a chained agent.continue() throws a non-abort error", async () => {
+		fake.promptImpl = async () => {
+			// Cycle 1 — completes normally.
+			fake.emit({ type: "agent_start" })
+			fake.emit({
+				type: "message_update",
+				assistantMessageEvent: {
+					type: "text_delta",
+					delta: "partial",
+					contentIndex: 0,
+					partial: {} as unknown as AssistantMessage,
+				},
+				message: {} as unknown as AssistantMessage,
+			})
+			fake.emit(agentEnd())
+			await delay(5)
+			// Cycle 2 — blows up.
+			fake.emit({ type: "agent_start" })
+			throw new Error("context window overflow during compaction")
+		}
+
+		await expect(agent.prompt({ sessionId, prompt: [{ type: "text", text: "go" }] })).rejects.toThrow(
+			/context window overflow during compaction/,
 		)
 	})
 

--- a/src/modes/acp/server.ts
+++ b/src/modes/acp/server.ts
@@ -116,14 +116,6 @@ export interface RunAcpOptions {
 type TurnContext = {
 	cancelled: boolean
 	hiddenToolCallIds: Set<string>
-	// True once ANY turn-lifecycle event has been delivered to our subscriber
-	// (agent_start, message_update, tool_execution_start, tool_execution_update).
-	// Used by prompt()'s short-circuit detector to tell "session.prompt() ran
-	// agent.prompt and events are flowing" from "session.prompt() short-circuited
-	// before agent events ever fired". Originally this tracked only agent_start —
-	// defensive widening so a future pi-mono emit-order change can't make real
-	// turns look like short-circuits.
-	turnActive: boolean
 	resolve: (res: PromptResponse) => void
 	reject: (err: unknown) => void
 }
@@ -502,7 +494,6 @@ export class KimchiAcpAgent implements Agent {
 		entry.turn = {
 			cancelled: false,
 			hiddenToolCallIds: new Set(),
-			turnActive: false,
 			resolve: turnResolve,
 			reject: turnReject,
 		}
@@ -514,20 +505,18 @@ export class KimchiAcpAgent implements Agent {
 		// propagates to the caller regardless of whether session.prompt ever resolves.
 		entry.session.prompt(text, { source: "rpc", images }).then(
 			() => {
-				// pi-coding-agent's session.prompt() short-circuits for extension commands,
-				// input-handler intercepts, and no-op paths — in those cases agent.prompt()
-				// never runs and no agent events fire. For real turns it awaits agent.prompt()
-				// which emits agent_start first and agent_end last (pi-agent-core contract:
-				// types.d.ts "agent_end is the last event emitted for a run"). By the time
-				// agent.prompt() resolves, our subscriber has been called with at least
-				// agent_start — agent.prompt awaits the LLM call, draining the microtask
-				// queue. agent_end delivery can still race with session.prompt()'s resolution
-				// because _processAgentEvent awaits extension handlers before calling our
-				// listener. So: if ANY turn-lifecycle event was observed (turnActive), trust
-				// the agent_end contract and let the subscriber finalize the turn. Otherwise
-				// the turn short-circuited and we synthesize end_turn here.
-				if (entry.turn && !entry.turn.turnActive) {
-					this.finalizeTurn(entry, "end_turn")
+				// session.prompt() is the source of truth for "turn is done". We
+				// deliberately do NOT finalize on agent_end: pi-mono's _runAgentPrompt
+				// (agent-session.js) chains multiple agent.prompt / agent.continue
+				// calls — each emits its own agent_start + agent_end — when retries,
+				// queued follow-up messages, or compaction are pending. If we finalized
+				// on the first agent_end, end_turn would be sent mid-stream and the
+				// client's subsequent prompt would hit pi-mono's
+				// "Agent is already processing" throw because session.prompt is still
+				// running the chained continues. session.prompt() resolves only after
+				// ALL chained calls complete.
+				if (entry.turn) {
+					this.finalizeTurn(entry, entry.turn.cancelled ? "cancelled" : "end_turn")
 				}
 			},
 			(err) => {
@@ -617,12 +606,10 @@ export class KimchiAcpAgent implements Agent {
 		const turn = entry.turn
 		switch (event.type) {
 			case "agent_start": {
-				if (turn) turn.turnActive = true
 				return
 			}
 			case "message_update": {
 				if (!turn) return
-				turn.turnActive = true
 				const ame = event.assistantMessageEvent
 				if (ame.type === "text_delta" && ame.delta) {
 					this.send({
@@ -649,7 +636,6 @@ export class KimchiAcpAgent implements Agent {
 				// tool_call notifications the client would have to reconcile against
 				// a turn it already considers over.
 				if (!turn) return
-				turn.turnActive = true
 				if (isHiddenToolCall(event.toolName, event.args)) {
 					turn.hiddenToolCallIds.add(event.toolCallId)
 					return
@@ -671,7 +657,6 @@ export class KimchiAcpAgent implements Agent {
 			}
 			case "tool_execution_update": {
 				if (!turn) return
-				turn.turnActive = true
 				if (turn.hiddenToolCallIds.has(event.toolCallId) || isHiddenToolCall(event.toolName, event.args)) {
 					turn.hiddenToolCallIds.add(event.toolCallId)
 					return
@@ -708,11 +693,10 @@ export class KimchiAcpAgent implements Agent {
 				return
 			}
 			case "agent_end": {
-				// If no turn is active, this is a late agent_end after the prompt
-				// handler already synthesized end_turn (short-circuit path that
-				// nevertheless emitted events somehow) — safe to drop.
-				if (!turn) return
-				this.finalizeTurn(entry, turn.cancelled ? "cancelled" : "end_turn")
+				// No-op: turn finalization is driven by session.prompt()'s resolution
+				// in prompt(), NOT by agent_end. See comment in prompt() for the
+				// chained-agent.continue scenario. Just guard against stray agent_end
+				// events that arrive after the turn was finalized.
 				return
 			}
 			default:


### PR DESCRIPTION
## Linked issue

Closes #0 LLM-2103

<!-- Every PR must link to an existing issue. PRs without a linked issue will not be reviewed.
     Use one of: Closes #N / Fixes #N / Resolves #N -->

## What does this PR do?

This PR fixes a bug where the ACP server would finalize a turn on the first agent_end event, even though pi-mono's `_runAgentPrompt` chains multiple `agent.prompt()` / `agent.continue()` calls (for retries, compaction, queued follow-up messages). Each chained call emits its own agent_start + agent_end pair. Finalizing on the first `agent_end` sent `end_turn` mid-stream, causing the client's next prompt to hit "Agent is already processing".      

I noticed the issue happen frequently during an uninterrupted conversation stream in the VSCode extension. The agent responds to subsequent messages with:
```json
{
  "jsonrpc":"2.0",
  "id":7,
  "error":
    {
      "code":-32603,
      "message":"Internal error",
      "data":
        {
          "details":"Agent is already processing. Specify streamingBehavior ('steer' or 'followUp') to queue the message."
        }
    }
}
```                       
                                                                                                                                                                

With the fix, `session.prompt()` resolution becomes the sole source of truth for turn completion, and `agent_end` becomes a no-op in `onSessionEvent`. This directly matches the upstream contract - `session.prompt()` calls `_runAgentPrompt()`, which loops `while (await this._handlePostAgentRun()) { await this.agent.continue(); }` and only resolves after ALL chained calls complete. 

## Tradeoff: late event delivery window                                                         
                                                                                                                                                                
There's a theoretical window where a slow async extension handler on a content event (e.g. `message_end`) could delay the final `_emit` call past `session.prompt()` resolution, meaning the subscriber never sees that last chunk. In practice this doesn't happen - `_processAgentEvent` processes events sequentially within each `agent.prompt()` / `agent.continue()` call, and `_runAgentPrompt` awaits those calls, so all content events are flushed before the promise resolves. The only way to hit it would be a buggy extension doing heavy async work on `message_end`, which would be a bug in that extension. Closing this window properly would require waiting for the final `agent_end` at the subscriber level, which is exactly the old logic that couldn't distinguish intermediate from final `agent_end` in chained continues (the bug this PR fixes).

## Testing

I've been testing this manually via the VSCode extension. I haven't yet encountered a premature end_turn signal, and no side effecgs so far.

Unit tests updated.

## Checklist

- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md) and agree to the CLA
- [x] This PR links to an open issue above
- [x] Tests pass locally (`pnpm run test`)
- [x] Lint passes (`pnpm run check`)
- [x] Documentation updated if behavior changed

