### PR TITLE
fix(harness): provide guidance on error for path without a file

### DIFF
--- a/src/cli-args.test.ts
+++ b/src/cli-args.test.ts
@@ -1,6 +1,10 @@
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
 import { describe, expect, it } from "vitest"
 import {
 	getCliModeArg,
+	isCliAtFileArg,
 	isExperimentalFeaturesArg,
 	isHelpOrVersionArgs,
 	isPreDispatchValueFlag,
@@ -8,6 +12,7 @@ import {
 	isTerminalUiMode,
 	stripExperimentalFeaturesArg,
 } from "./cli-args.js"
+import { normalizeAtFileArgs } from "./fs-paths.js"
 
 describe("getCliModeArg", () => {
 	it("reads --mode value", () => {
@@ -106,6 +111,47 @@ describe("isPreDispatchValueFlag", () => {
 			expect(isPreDispatchValueFlag(arg)).toBe(false)
 		},
 	)
+})
+
+describe("isCliAtFileArg", () => {
+	it("does not treat known option values as @file attachments", () => {
+		expect(isCliAtFileArg("@literal", 1, ["--system-prompt", "@literal"])).toBe(false)
+		expect(isCliAtFileArg("@scope/pkg", 1, ["--extension", "@scope/pkg"])).toBe(false)
+		expect(isCliAtFileArg("@release", 1, ["--name", "@release"])).toBe(false)
+	})
+
+	it("still treats standalone @file args as attachments", () => {
+		expect(isCliAtFileArg("@prompt.md", 0, ["@prompt.md"])).toBe(true)
+		expect(isCliAtFileArg("@prompt.md", 1, ["--print", "@prompt.md"])).toBe(true)
+	})
+})
+
+describe("normalizeAtFileArgs with CLI parsing", () => {
+	it("leaves @-prefixed option values unchanged", () => {
+		const tmp = mkdtempSync(join(tmpdir(), "cli-at-file-args-"))
+		try {
+			mkdirSync(join(tmp, "literal"))
+			mkdirSync(join(tmp, "scope", "pkg"), { recursive: true })
+			writeFileSync(join(tmp, "prompt.md"), "hi")
+
+			const result = normalizeAtFileArgs(
+				["--system-prompt", "@literal", "--extension", "@scope/pkg", "@prompt.md"],
+				tmp,
+				isCliAtFileArg,
+			)
+
+			expect(result.args).toEqual([
+				"--system-prompt",
+				"@literal",
+				"--extension",
+				"@scope/pkg",
+				`@${join(tmp, "prompt.md")}`,
+			])
+			expect(result.directoryArgs).toEqual([])
+		} finally {
+			rmSync(tmp, { recursive: true, force: true })
+		}
+	})
 })
 
 describe("isExperimentalFeaturesArg", () => {

--- a/src/cli-args.test.ts
+++ b/src/cli-args.test.ts
@@ -120,6 +120,13 @@ describe("isCliAtFileArg", () => {
 		expect(isCliAtFileArg("@release", 1, ["--name", "@release"])).toBe(false)
 	})
 
+	it("uses parser position instead of matching @ values by text", () => {
+		const args = ["--name", "@same", "@same"]
+
+		expect(isCliAtFileArg("@same", 1, args)).toBe(false)
+		expect(isCliAtFileArg("@same", 2, args)).toBe(true)
+	})
+
 	it("still treats standalone @file args as attachments", () => {
 		expect(isCliAtFileArg("@prompt.md", 0, ["@prompt.md"])).toBe(true)
 		expect(isCliAtFileArg("@prompt.md", 1, ["--print", "@prompt.md"])).toBe(true)

--- a/src/cli-args.ts
+++ b/src/cli-args.ts
@@ -23,21 +23,14 @@ const PRE_DISPATCH_VALUE_FLAGS = new Set([
 	"--theme",
 ])
 
-const AT_FILE_VALUE_FLAGS = new Set([
-	...PRE_DISPATCH_VALUE_FLAGS,
-	"--name",
-	"-n",
-	"--session-id",
-	"--exclude-tools",
-	"-xt",
-])
-
 export function isPreDispatchValueFlag(arg: string): boolean {
 	return PRE_DISPATCH_VALUE_FLAGS.has(arg)
 }
 
 export function isCliAtFileArg(arg: string, index: number, args: string[]): boolean {
-	return arg.startsWith("@") && arg !== "@" && !AT_FILE_VALUE_FLAGS.has(args[index - 1] ?? "")
+	if (!arg.startsWith("@") || arg === "@") return false
+	// Use Pi's parser as the source of truth instead of mirroring every value-taking flag.
+	return parsePiArgs(args.slice(0, index + 1)).fileArgs.length > parsePiArgs(args.slice(0, index)).fileArgs.length
 }
 
 export function getCliModeArg(args: string[]): string | undefined {

--- a/src/cli-args.ts
+++ b/src/cli-args.ts
@@ -23,8 +23,21 @@ const PRE_DISPATCH_VALUE_FLAGS = new Set([
 	"--theme",
 ])
 
+const AT_FILE_VALUE_FLAGS = new Set([
+	...PRE_DISPATCH_VALUE_FLAGS,
+	"--name",
+	"-n",
+	"--session-id",
+	"--exclude-tools",
+	"-xt",
+])
+
 export function isPreDispatchValueFlag(arg: string): boolean {
 	return PRE_DISPATCH_VALUE_FLAGS.has(arg)
+}
+
+export function isCliAtFileArg(arg: string, index: number, args: string[]): boolean {
+	return arg.startsWith("@") && arg !== "@" && !AT_FILE_VALUE_FLAGS.has(args[index - 1] ?? "")
 }
 
 export function getCliModeArg(args: string[]): string | undefined {

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -7,6 +7,7 @@ import { fileURLToPath } from "node:url"
 import { AgentSession } from "@earendil-works/pi-coding-agent"
 import {
 	getCliModeArg,
+	isCliAtFileArg,
 	isExperimentalFeaturesArg,
 	isHelpOrVersionArgs,
 	isTerminalUiMode,
@@ -361,7 +362,11 @@ try {
 			: resolve(dirname(fileURLToPath(import.meta.url)), "../themes")
 		mkdirSync(themesDir, { recursive: true })
 
-		const atFileArgs = normalizeAtFileArgs(stripExperimentalFeaturesArg(process.argv.slice(2)), process.cwd())
+		const atFileArgs = normalizeAtFileArgs(
+			stripExperimentalFeaturesArg(process.argv.slice(2)),
+			process.cwd(),
+			isCliAtFileArg,
+		)
 		if (atFileArgs.directoryArgs.length > 0) {
 			console.error(`Error: @file path must be a file, not a directory: ${atFileArgs.directoryArgs[0]}`)
 			process.exit(1)

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -89,6 +89,7 @@ import traceIdExtension from "./extensions/trace-id.js"
 import uiExtension from "./extensions/ui.js"
 import webFetchExtension from "./extensions/web-fetch/index.js"
 import webSearchExtension from "./extensions/web-search/index.js"
+import { normalizeAtFileArgs } from "./fs-paths.js"
 import {
 	injectExperimentalProvider,
 	isTransientModelsError,
@@ -360,14 +361,19 @@ try {
 			: resolve(dirname(fileURLToPath(import.meta.url)), "../themes")
 		mkdirSync(themesDir, { recursive: true })
 
-		// Probe runs here (before pi-mono takes stdin) so the result is cached for
-		// the kimchi-minimal-tints and terminal-colors extensions. Skip non-TUI
-		// modes: stdout belongs to the caller, and OSC escapes corrupt it.
-		const rawArgs = stripExperimentalFeaturesArg(process.argv.slice(2))
+		const atFileArgs = normalizeAtFileArgs(stripExperimentalFeaturesArg(process.argv.slice(2)), process.cwd())
+		if (atFileArgs.directoryArgs.length > 0) {
+			console.error(`Error: @file path must be a file, not a directory: ${atFileArgs.directoryArgs[0]}`)
+			process.exit(1)
+		}
+		const rawArgs = atFileArgs.args
 		const terminalIo = {
 			stdinIsTTY: process.stdin.isTTY === true,
 			stdoutIsTTY: process.stdout.isTTY === true,
 		}
+		// Probe runs here (before pi-mono takes stdin) so the result is cached for
+		// the kimchi-minimal-tints and terminal-colors extensions. Skip non-TUI
+		// modes: stdout belongs to the caller, and OSC escapes corrupt it.
 		const terminalStartupOutputAllowed = isTerminalUiMode(rawArgs, terminalIo)
 		if (terminalStartupOutputAllowed) {
 			await probeTerminalBackground()

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -89,7 +89,6 @@ import traceIdExtension from "./extensions/trace-id.js"
 import uiExtension from "./extensions/ui.js"
 import webFetchExtension from "./extensions/web-fetch/index.js"
 import webSearchExtension from "./extensions/web-search/index.js"
-import { normalizeAtFileArgs } from "./fs-paths.js"
 import {
 	injectExperimentalProvider,
 	isTransientModelsError,
@@ -361,19 +360,14 @@ try {
 			: resolve(dirname(fileURLToPath(import.meta.url)), "../themes")
 		mkdirSync(themesDir, { recursive: true })
 
-		const atFileArgs = normalizeAtFileArgs(stripExperimentalFeaturesArg(process.argv.slice(2)), process.cwd())
-		if (atFileArgs.directoryArgs.length > 0) {
-			console.error(`Error: @file path must be a file, not a directory: ${atFileArgs.directoryArgs[0]}`)
-			process.exit(1)
-		}
-		const rawArgs = atFileArgs.args
+		// Probe runs here (before pi-mono takes stdin) so the result is cached for
+		// the kimchi-minimal-tints and terminal-colors extensions. Skip non-TUI
+		// modes: stdout belongs to the caller, and OSC escapes corrupt it.
+		const rawArgs = stripExperimentalFeaturesArg(process.argv.slice(2))
 		const terminalIo = {
 			stdinIsTTY: process.stdin.isTTY === true,
 			stdoutIsTTY: process.stdout.isTTY === true,
 		}
-		// Probe runs here (before pi-mono takes stdin) so the result is cached for
-		// the kimchi-minimal-tints and terminal-colors extensions. Skip non-TUI
-		// modes: stdout belongs to the caller, and OSC escapes corrupt it.
 		const terminalStartupOutputAllowed = isTerminalUiMode(rawArgs, terminalIo)
 		if (terminalStartupOutputAllowed) {
 			await probeTerminalBackground()

--- a/src/extensions/permissions/index.test.ts
+++ b/src/extensions/permissions/index.test.ts
@@ -356,6 +356,21 @@ describe("permissions plan-mode tool visibility", () => {
 		}
 	})
 
+	it("blocks read calls targeting directories before upstream read", async () => {
+		const tmp = mkdtempSync(join(tmpdir(), "kimchi-read-dir-"))
+		try {
+			const harness = createPermissionsHarness(["read"])
+			const result = await harness.fire("tool_call", { toolName: "read", input: { path: tmp } }, createMockContext([]))
+
+			expect(result).toEqual({
+				block: true,
+				reason: "Path is a directory; use ls/find instead of read.",
+			})
+		} finally {
+			rmSync(tmp, { recursive: true, force: true })
+		}
+	})
+
 	it("leaving plan mode does not restore tools hidden by another extension", async () => {
 		const harness = createPermissionsHarness(["read", "bash", "write", "edit", "grep"], { plan: true })
 		const peerVisibility = createToolVisibility(harness.pi)

--- a/src/extensions/permissions/index.test.ts
+++ b/src/extensions/permissions/index.test.ts
@@ -364,7 +364,7 @@ describe("permissions plan-mode tool visibility", () => {
 
 			expect(result).toEqual({
 				block: true,
-				reason: "Path is a directory; use ls/find instead of read.",
+				reason: "Path is a directory; read only accepts files. List or search the directory instead.",
 			})
 		} finally {
 			rmSync(tmp, { recursive: true, force: true })

--- a/src/extensions/permissions/index.ts
+++ b/src/extensions/permissions/index.ts
@@ -755,7 +755,7 @@ export default function permissionsExtension(pi: ExtensionAPI): void {
 			if (filePath && isExistingDirectory(filePath, ctx.cwd)) {
 				return {
 					block: true,
-					reason: "Path is a directory; use ls/find instead of read.",
+					reason: "Path is a directory; read only accepts files. List or search the directory instead.",
 				}
 			}
 		}

--- a/src/extensions/permissions/index.ts
+++ b/src/extensions/permissions/index.ts
@@ -5,6 +5,7 @@ import { isKeyRelease, matchesKey } from "@earendil-works/pi-tui"
 import { RST_FG, resolvedSemanticFg } from "../../ansi.js"
 import { FermentEventStore } from "../../ferment/event-store.js"
 import { resolveFermentsDir } from "../../ferment/store.js"
+import { isExistingDirectory } from "../../fs-paths.js"
 import { getAcpPrompter } from "../../modes/acp/permission-prompter-registry.js"
 import * as EntryTriggerRegistry from "../../shared/planning/entry-trigger-registry.js"
 import { parseSharedPlan } from "../../shared/planning/plan-decomposition.js"
@@ -747,6 +748,17 @@ export default function permissionsExtension(pi: ExtensionAPI): void {
 	pi.on("tool_call", async (event, ctx) => {
 		const toolName = event.toolName.toLowerCase()
 		const input = event.input as Record<string, unknown>
+
+		if (toolName === "read") {
+			const filePath =
+				typeof input.path === "string" ? input.path : typeof input.file_path === "string" ? input.file_path : ""
+			if (filePath && isExistingDirectory(filePath, ctx.cwd)) {
+				return {
+					block: true,
+					reason: "Path is a directory; use ls/find instead of read.",
+				}
+			}
+		}
 
 		// Plan persona path-scope enforcement: when KIMCHI_AGENT_PERSONA=plan (case-insensitive),
 		// write and edit are only allowed for .kimchi/plans/* paths.

--- a/src/fs-paths.test.ts
+++ b/src/fs-paths.test.ts
@@ -84,11 +84,21 @@ describe("findExistingFile", () => {
 		const queried = findExistingFile("Capture d'\u00E9cran.png", tmp)
 		expect(queried).toBe(join(tmp, storedName))
 	})
+})
 
+describe("normalizeAtFileArgs", () => {
 	it("normalizes @file args to regular files and reports directories", () => {
-		const result = normalizeAtFileArgs(["--model", "x", "@present.txt", "@a-directory"], tmp)
+		const tmp = mkdtempSync(join(tmpdir(), "fs-paths-at-file-test-"))
+		try {
+			writeFileSync(join(tmp, "present.txt"), "hi")
+			mkdirSync(join(tmp, "a-directory"))
 
-		expect(result.args).toEqual(["--model", "x", `@${join(tmp, "present.txt")}`, "@a-directory"])
-		expect(result.directoryArgs).toEqual([join(tmp, "a-directory")])
+			const result = normalizeAtFileArgs(["--model", "x", "@present.txt", "@a-directory"], tmp)
+
+			expect(result.args).toEqual(["--model", "x", `@${join(tmp, "present.txt")}`, "@a-directory"])
+			expect(result.directoryArgs).toEqual([join(tmp, "a-directory")])
+		} finally {
+			rmSync(tmp, { recursive: true, force: true })
+		}
 	})
 })

--- a/src/fs-paths.test.ts
+++ b/src/fs-paths.test.ts
@@ -2,7 +2,7 @@ import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs"
 import { homedir, tmpdir } from "node:os"
 import { join, resolve } from "node:path"
 import { afterAll, beforeAll, describe, expect, it } from "vitest"
-import { expandUserPath, findExistingFile, resolveUserPath, stripAtPrefix } from "./fs-paths.js"
+import { expandUserPath, findExistingFile, normalizeAtFileArgs, resolveUserPath, stripAtPrefix } from "./fs-paths.js"
 
 describe("resolveUserPath", () => {
 	it("expands bare ~ to the user's home directory", () => {
@@ -83,5 +83,12 @@ describe("findExistingFile", () => {
 		writeFileSync(join(tmp, storedName), "x")
 		const queried = findExistingFile("Capture d'\u00E9cran.png", tmp)
 		expect(queried).toBe(join(tmp, storedName))
+	})
+
+	it("normalizes @file args to regular files and reports directories", () => {
+		const result = normalizeAtFileArgs(["--model", "x", "@present.txt", "@a-directory"], tmp)
+
+		expect(result.args).toEqual(["--model", "x", `@${join(tmp, "present.txt")}`, "@a-directory"])
+		expect(result.directoryArgs).toEqual([join(tmp, "a-directory")])
 	})
 })

--- a/src/fs-paths.test.ts
+++ b/src/fs-paths.test.ts
@@ -2,7 +2,7 @@ import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs"
 import { homedir, tmpdir } from "node:os"
 import { join, resolve } from "node:path"
 import { afterAll, beforeAll, describe, expect, it } from "vitest"
-import { expandUserPath, findExistingFile, normalizeAtFileArgs, resolveUserPath, stripAtPrefix } from "./fs-paths.js"
+import { expandUserPath, findExistingFile, resolveUserPath, stripAtPrefix } from "./fs-paths.js"
 
 describe("resolveUserPath", () => {
 	it("expands bare ~ to the user's home directory", () => {
@@ -83,12 +83,5 @@ describe("findExistingFile", () => {
 		writeFileSync(join(tmp, storedName), "x")
 		const queried = findExistingFile("Capture d'\u00E9cran.png", tmp)
 		expect(queried).toBe(join(tmp, storedName))
-	})
-
-	it("normalizes @file args to regular files and reports directories", () => {
-		const result = normalizeAtFileArgs(["--model", "x", "@present.txt", "@a-directory"], tmp)
-
-		expect(result.args).toEqual(["--model", "x", `@${join(tmp, "present.txt")}`, "@a-directory"])
-		expect(result.directoryArgs).toEqual([join(tmp, "a-directory")])
 	})
 })

--- a/src/fs-paths.ts
+++ b/src/fs-paths.ts
@@ -36,22 +36,21 @@ export function resolveUserPath(filePath: string, cwd: string): string {
 	return isAbsolute(expanded) ? expanded : resolve(cwd, expanded)
 }
 
-// Files only — a directory at the path is NOT a hit. This is the one intentional divergence from pi's resolveReadPath (which uses F_OK and thus accepts directories).
-// Verified against pi-coding-agent@0.67.68: passing a directory in @attachments reaches detectSupportedImageMimeTypeFromFile, whose read() throws EISDIR. Rejecting dirs up front turns that into a clean pre-spawn "file not found" error.
-function isFile(p: string): boolean {
+type ExistingPathKind = "file" | "directory" | "other"
+
+function existingPathKind(p: string): ExistingPathKind | null {
 	try {
-		return statSync(p).isFile()
+		const stats = statSync(p)
+		if (stats.isFile()) return "file"
+		if (stats.isDirectory()) return "directory"
+		return "other"
 	} catch {
-		return false
+		return null
 	}
 }
 
 export function isExistingDirectory(filePath: string, cwd: string): boolean {
-	try {
-		return statSync(resolveUserPath(filePath, cwd)).isDirectory()
-	} catch {
-		return false
-	}
+	return existingPathKind(resolveUserPath(filePath, cwd)) === "directory"
 }
 
 // Ordered set of transforms tried against the resolved absolute path. Each row is: "if the literal string didn't match, maybe it was typed one of these ways instead". Order matters: cheaper + more common substitutions first.
@@ -73,7 +72,7 @@ const VARIANTS: ReadonlyArray<(p: string) => string> = [
 export function findExistingFile(
 	filePath: string,
 	cwd: string,
-	exists: (abs: string) => boolean = isFile,
+	exists: (abs: string) => boolean = (abs) => existingPathKind(abs) === "file",
 ): string | null {
 	const base = resolveUserPath(filePath, cwd)
 	for (const variant of VARIANTS) {
@@ -93,9 +92,16 @@ export function normalizeAtFileArgs(args: string[], cwd: string): NormalizedAtFi
 	const normalized = args.map((arg) => {
 		if (!arg.startsWith("@") || arg === "@") return arg
 		const filePath = arg.slice(1)
-		const file = findExistingFile(filePath, cwd)
-		if (file) return `@${file}`
-		if (isExistingDirectory(filePath, cwd)) directoryArgs.push(resolveUserPath(filePath, cwd))
+		const base = resolveUserPath(filePath, cwd)
+		for (const variant of VARIANTS) {
+			const candidate = variant(base)
+			const kind = existingPathKind(candidate)
+			if (kind === "file") return `@${candidate}`
+			if (kind === "directory") {
+				directoryArgs.push(candidate)
+				return arg
+			}
+		}
 		return arg
 	})
 	return { args: normalized, directoryArgs }

--- a/src/fs-paths.ts
+++ b/src/fs-paths.ts
@@ -46,6 +46,14 @@ function isFile(p: string): boolean {
 	}
 }
 
+export function isExistingDirectory(filePath: string, cwd: string): boolean {
+	try {
+		return statSync(resolveUserPath(filePath, cwd)).isDirectory()
+	} catch {
+		return false
+	}
+}
+
 // Ordered set of transforms tried against the resolved absolute path. Each row is: "if the literal string didn't match, maybe it was typed one of these ways instead". Order matters: cheaper + more common substitutions first.
 // Single-axis only — variants are applied independently to the base, not cross-producted. Filenames that need multiple substitutions (e.g. NFD + curly apostrophe) must be listed as explicit combined entries (variant 5). This is a deliberate trade-off to keep the fallback ladder bounded.
 //   1. identity — the path as typed
@@ -73,4 +81,22 @@ export function findExistingFile(
 		if (exists(candidate)) return candidate
 	}
 	return null
+}
+
+export interface NormalizedAtFileArgs {
+	args: string[]
+	directoryArgs: string[]
+}
+
+export function normalizeAtFileArgs(args: string[], cwd: string): NormalizedAtFileArgs {
+	const directoryArgs: string[] = []
+	const normalized = args.map((arg) => {
+		if (!arg.startsWith("@") || arg === "@") return arg
+		const filePath = arg.slice(1)
+		const file = findExistingFile(filePath, cwd)
+		if (file) return `@${file}`
+		if (isExistingDirectory(filePath, cwd)) directoryArgs.push(resolveUserPath(filePath, cwd))
+		return arg
+	})
+	return { args: normalized, directoryArgs }
 }

--- a/src/fs-paths.ts
+++ b/src/fs-paths.ts
@@ -82,3 +82,21 @@ export function findExistingFile(
 	}
 	return null
 }
+
+export interface NormalizedAtFileArgs {
+	args: string[]
+	directoryArgs: string[]
+}
+
+export function normalizeAtFileArgs(args: string[], cwd: string): NormalizedAtFileArgs {
+	const directoryArgs: string[] = []
+	const normalized = args.map((arg) => {
+		if (!arg.startsWith("@") || arg === "@") return arg
+		const filePath = arg.slice(1)
+		const file = findExistingFile(filePath, cwd)
+		if (file) return `@${file}`
+		if (isExistingDirectory(filePath, cwd)) directoryArgs.push(resolveUserPath(filePath, cwd))
+		return arg
+	})
+	return { args: normalized, directoryArgs }
+}

--- a/src/fs-paths.ts
+++ b/src/fs-paths.ts
@@ -82,21 +82,3 @@ export function findExistingFile(
 	}
 	return null
 }
-
-export interface NormalizedAtFileArgs {
-	args: string[]
-	directoryArgs: string[]
-}
-
-export function normalizeAtFileArgs(args: string[], cwd: string): NormalizedAtFileArgs {
-	const directoryArgs: string[] = []
-	const normalized = args.map((arg) => {
-		if (!arg.startsWith("@") || arg === "@") return arg
-		const filePath = arg.slice(1)
-		const file = findExistingFile(filePath, cwd)
-		if (file) return `@${file}`
-		if (isExistingDirectory(filePath, cwd)) directoryArgs.push(resolveUserPath(filePath, cwd))
-		return arg
-	})
-	return { args: normalized, directoryArgs }
-}

--- a/src/fs-paths.ts
+++ b/src/fs-paths.ts
@@ -87,10 +87,14 @@ export interface NormalizedAtFileArgs {
 	directoryArgs: string[]
 }
 
-export function normalizeAtFileArgs(args: string[], cwd: string): NormalizedAtFileArgs {
+export function normalizeAtFileArgs(
+	args: string[],
+	cwd: string,
+	isAtFileArg: (arg: string, index: number, args: string[]) => boolean = (arg) => arg.startsWith("@") && arg !== "@",
+): NormalizedAtFileArgs {
 	const directoryArgs: string[] = []
-	const normalized = args.map((arg) => {
-		if (!arg.startsWith("@") || arg === "@") return arg
+	const normalized = args.map((arg, index) => {
+		if (!isAtFileArg(arg, index, args)) return arg
 		const filePath = arg.slice(1)
 		const base = resolveUserPath(filePath, cwd)
 		for (const variant of VARIANTS) {


### PR DESCRIPTION
Previous:
<img width="636" height="1606" alt="image" src="https://github.com/user-attachments/assets/3a78ed2d-e665-4d40-a9c0-c83fa4642dc4" />

With changes:

<img width="850" height="76" alt="image" src="https://github.com/user-attachments/assets/6a91c9b6-efda-4c93-b9e1-83978335b4c9" />


## Linked issue

Closes #

<!-- Every PR must link to an existing issue. PRs without a linked issue will not be reviewed.
     Use one of: Closes #N / Fixes #N / Resolves #N -->

## What does this PR do?

<!-- Brief description of the change and why it's needed. -->

## Checklist

- [ ] I have read [CONTRIBUTING.md](../CONTRIBUTING.md) and agree to the CLA
- [ ] This PR links to an open issue above
- [ ] Tests pass locally (`pnpm run test`)
- [ ] Lint passes (`pnpm run check`)
- [ ] Documentation updated if behavior changed
