### PR TITLE
Teleport sometimes fails with a operation aborted error when creating a session

### DIFF
--- a/src/extensions/teleport/commands/teleport.test.ts
+++ b/src/extensions/teleport/commands/teleport.test.ts
@@ -102,7 +102,7 @@ vi.mock("../ui/progress.js", () => ({
 
 import type { TeleportContext } from "../types.js"
 import { TeleportRefusal } from "./errors.js"
-import { runTeleport } from "./teleport.js"
+import { SESSION_CREATE_TIMEOUT_MS, runTeleport } from "./teleport.js"
 
 const CREDS = {
 	connectToken: "tok-1",
@@ -261,6 +261,12 @@ describe("runTeleport", () => {
 		expect(createSessionMock).toHaveBeenCalledOnce()
 		expect(createSessionMock.mock.calls[0][1]).toBe("mysession")
 		expect(createSessionMock.mock.calls[0][2]).toEqual({ agentMode: "PTY" })
+		// Large repos (kubecast) take longer than the 30s WorkerClient default;
+		// teleport must pass a per-call timeout that outlasts them.
+		expect(createSessionMock.mock.calls[0][3]).toMatchObject({ timeoutMs: SESSION_CREATE_TIMEOUT_MS })
+		// Must outlast the 30s WorkerClient default — large repos (kubecast)
+		// exceed it and the session would otherwise abort mid-flight.
+		expect(SESSION_CREATE_TIMEOUT_MS).toBeGreaterThan(30_000)
 		expect(ui.custom).toHaveBeenCalledOnce()
 	})
 

--- a/src/extensions/teleport/commands/teleport.test.ts
+++ b/src/extensions/teleport/commands/teleport.test.ts
@@ -261,10 +261,10 @@ describe("runTeleport", () => {
 		expect(createSessionMock).toHaveBeenCalledOnce()
 		expect(createSessionMock.mock.calls[0][1]).toBe("mysession")
 		expect(createSessionMock.mock.calls[0][2]).toEqual({ agentMode: "PTY" })
-		// Large repos (kubecast) take longer than the 30s WorkerClient default;
+		// Large repos take longer than the 30s WorkerClient default;
 		// teleport must pass a per-call timeout that outlasts them.
 		expect(createSessionMock.mock.calls[0][3]).toMatchObject({ timeoutMs: SESSION_CREATE_TIMEOUT_MS })
-		// Must outlast the 30s WorkerClient default — large repos (kubecast)
+		// Must outlast the 30s WorkerClient default — large repos
 		// exceed it and the session would otherwise abort mid-flight.
 		expect(SESSION_CREATE_TIMEOUT_MS).toBeGreaterThan(30_000)
 		expect(ui.custom).toHaveBeenCalledOnce()

--- a/src/extensions/teleport/commands/teleport.ts
+++ b/src/extensions/teleport/commands/teleport.ts
@@ -27,7 +27,7 @@ import { parseTeleportArgs } from "./args.js"
 import { refuse, warn } from "./errors.js"
 import { resolveWorkspaceRef } from "./workspace-ref.js"
 
-/** Per-call timeout for createSession: 5min — the 30s WorkerClient default aborts mid-flight on large repos (kubecast). */
+/** Per-call timeout for createSession: 5min — the 30s WorkerClient default aborts mid-flight on large repos. */
 export const SESSION_CREATE_TIMEOUT_MS = 5 * 60_000
 
 export async function runTeleport(rawArgs: string, ctx: TeleportContext): Promise<void> {

--- a/src/extensions/teleport/commands/teleport.ts
+++ b/src/extensions/teleport/commands/teleport.ts
@@ -27,6 +27,9 @@ import { parseTeleportArgs } from "./args.js"
 import { refuse, warn } from "./errors.js"
 import { resolveWorkspaceRef } from "./workspace-ref.js"
 
+/** Per-call timeout for createSession: 5min — the 30s WorkerClient default aborts mid-flight on large repos (kubecast). */
+export const SESSION_CREATE_TIMEOUT_MS = 5 * 60_000
+
 export async function runTeleport(rawArgs: string, ctx: TeleportContext): Promise<void> {
 	if (hasHelpFlag(rawArgs)) {
 		await promptTeleportHelp(ctx.ui)
@@ -271,6 +274,7 @@ export async function runTeleport(rawArgs: string, ctx: TeleportContext): Promis
 			initialSession = await createSession(client, sessionName, req, {
 				sessionFile: sessionFileToUpload,
 				signal,
+				timeoutMs: SESSION_CREATE_TIMEOUT_MS,
 			})
 		} catch (err) {
 			if (signal.aborted) throw err

--- a/src/sandbox/worker/client.ts
+++ b/src/sandbox/worker/client.ts
@@ -106,7 +106,7 @@ export class WorkerClient {
 	async postMultipart<T>(
 		path: string,
 		parts: { request: unknown; sessionFile?: string },
-		signal?: AbortSignal,
+		opts: { signal?: AbortSignal; timeoutMs?: number } = {},
 	): Promise<T> {
 		const url = this.#url(path)
 		const form = new FormData()
@@ -126,8 +126,8 @@ export class WorkerClient {
 				body: form,
 			},
 			this.#fetch,
-			this.#timeoutMs,
-			signal,
+			opts.timeoutMs ?? this.#timeoutMs,
+			opts.signal,
 		)
 		await checkResponse(resp, url)
 		return (await resp.json()) as T

--- a/src/sandbox/worker/client.ts
+++ b/src/sandbox/worker/client.ts
@@ -106,7 +106,8 @@ export class WorkerClient {
 	async postMultipart<T>(
 		path: string,
 		parts: { request: unknown; sessionFile?: string },
-		opts: { signal?: AbortSignal; timeoutMs?: number } = {},
+		signal?: AbortSignal,
+		timeoutMs?: number,
 	): Promise<T> {
 		const url = this.#url(path)
 		const form = new FormData()
@@ -126,8 +127,8 @@ export class WorkerClient {
 				body: form,
 			},
 			this.#fetch,
-			opts.timeoutMs ?? this.#timeoutMs,
-			opts.signal,
+			timeoutMs ?? this.#timeoutMs,
+			signal,
 		)
 		await checkResponse(resp, url)
 		return (await resp.json()) as T

--- a/src/sandbox/worker/sessions.test.ts
+++ b/src/sandbox/worker/sessions.test.ts
@@ -182,7 +182,7 @@ describe("createSession", () => {
 describe("createSession large-repo regression", () => {
 	// Real HTTP server: a per-call timeoutMs must outlast the worker's response
 	// time even when it exceeds the WorkerClient default. Regression for large
-	// repos (kubecast) where the 30s default aborted mid-flight while the
+	// repos where the 30s default aborted mid-flight while the
 	// session was created server-side.
 
 	let server: Server
@@ -225,9 +225,9 @@ describe("createSession large-repo regression", () => {
 		const creds = { ...CREDS, wsUrl: baseUrl.replace("http://", "ws://") }
 		const client = new WorkerClient(creds, { timeoutMs: 50 })
 
-		const result = await createSession(client, "kubecast", { agentMode: "PTY" }, { timeoutMs: 1000 })
+		const result = await createSession(client, "large-repo", { agentMode: "PTY" }, { timeoutMs: 1000 })
 
-		expect(result.name).toBe("kubecast")
+		expect(result.name).toBe("large-repo")
 		expect(result.agentMode).toBe("PTY")
 	})
 
@@ -238,7 +238,7 @@ describe("createSession large-repo regression", () => {
 		const creds = { ...CREDS, wsUrl: baseUrl.replace("http://", "ws://") }
 		const client = new WorkerClient(creds, { timeoutMs: 50 })
 
-		await expect(createSession(client, "kubecast", { agentMode: "PTY" })).rejects.toThrow(/aborted/i)
+		await expect(createSession(client, "large-repo", { agentMode: "PTY" })).rejects.toThrow(/aborted/i)
 	})
 })
 

--- a/src/sandbox/worker/sessions.test.ts
+++ b/src/sandbox/worker/sessions.test.ts
@@ -1,7 +1,8 @@
 import { mkdtempSync, writeFileSync } from "node:fs"
+import { type Server, createServer } from "node:http"
 import { tmpdir } from "node:os"
 import { join } from "node:path"
-import { describe, expect, it, vi } from "vitest"
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
 import type { WorkspaceCredentials } from "../cloud/types.js"
 import { HARNESS_CLIENT_TYPE } from "../constants.js"
 import { WorkerClient } from "./client.js"
@@ -175,6 +176,68 @@ describe("createSession", () => {
 			name: "WorkerError",
 			status: 409,
 		})
+	})
+})
+
+import { SESSION_CREATE_TIMEOUT_MS } from "../../extensions/teleport/commands/teleport.js"
+
+describe("createSession large-repo regression", () => {
+	// Real HTTP server: teleport on large repos (kubecast) aborted at the 30s
+	// WorkerClient default even though the session was created server-side.
+	// SESSION_CREATE_TIMEOUT_MS must exceed the server's response time.
+
+	let server: Server
+	let baseUrl: string
+	let serverDelayMs: number
+
+	beforeEach(async () => {
+		serverDelayMs = 0
+		server = createServer((req, res) => {
+			if (req.method === "POST" && req.url?.startsWith("/session/")) {
+				// Drain the multipart body so the connection stays clean.
+				req.on("data", () => {})
+				req.on("end", () => {
+					setTimeout(() => {
+						res.writeHead(201, { "Content-Type": "application/json" })
+						res.end(JSON.stringify(sessionFixture({ agentMode: "PTY" })))
+					}, serverDelayMs)
+				})
+				return
+			}
+			res.writeHead(404)
+			res.end()
+		})
+		await new Promise<void>((resolve) => {
+			server.listen(0, "127.0.0.1", () => {
+				const addr = server.address()
+				const port = typeof addr === "object" && addr ? addr.port : 0
+				baseUrl = `http://127.0.0.1:${port}`
+				resolve()
+			})
+		})
+	})
+
+	afterEach(async () => {
+		await new Promise<void>((resolve) => server.close(() => resolve()))
+	})
+
+	// 200ms > 50ms client default; SESSION_CREATE_TIMEOUT_MS must clear it.
+	it("teleport's session-create timeout outlasts large-repo session creation", async () => {
+		expect(SESSION_CREATE_TIMEOUT_MS).toBeGreaterThan(200)
+
+		serverDelayMs = 200
+		const creds = { ...CREDS, wsUrl: baseUrl.replace("http://", "ws://") }
+		const client = new WorkerClient(creds, { timeoutMs: 50 })
+
+		const result = await createSession(
+			client,
+			"kubecast",
+			{ agentMode: "PTY" },
+			{ timeoutMs: SESSION_CREATE_TIMEOUT_MS },
+		)
+
+		expect(result.name).toBe("kubecast")
+		expect(result.agentMode).toBe("PTY")
 	})
 })
 

--- a/src/sandbox/worker/sessions.test.ts
+++ b/src/sandbox/worker/sessions.test.ts
@@ -179,12 +179,11 @@ describe("createSession", () => {
 	})
 })
 
-import { SESSION_CREATE_TIMEOUT_MS } from "../../extensions/teleport/commands/teleport.js"
-
 describe("createSession large-repo regression", () => {
-	// Real HTTP server: teleport on large repos (kubecast) aborted at the 30s
-	// WorkerClient default even though the session was created server-side.
-	// SESSION_CREATE_TIMEOUT_MS must exceed the server's response time.
+	// Real HTTP server: a per-call timeoutMs must outlast the worker's response
+	// time even when it exceeds the WorkerClient default. Regression for large
+	// repos (kubecast) where the 30s default aborted mid-flight while the
+	// session was created server-side.
 
 	let server: Server
 	let baseUrl: string
@@ -194,7 +193,6 @@ describe("createSession large-repo regression", () => {
 		serverDelayMs = 0
 		server = createServer((req, res) => {
 			if (req.method === "POST" && req.url?.startsWith("/session/")) {
-				// Drain the multipart body so the connection stays clean.
 				req.on("data", () => {})
 				req.on("end", () => {
 					setTimeout(() => {
@@ -221,23 +219,26 @@ describe("createSession large-repo regression", () => {
 		await new Promise<void>((resolve) => server.close(() => resolve()))
 	})
 
-	// 200ms > 50ms client default; SESSION_CREATE_TIMEOUT_MS must clear it.
-	it("teleport's session-create timeout outlasts large-repo session creation", async () => {
-		expect(SESSION_CREATE_TIMEOUT_MS).toBeGreaterThan(200)
-
+	it("succeeds when the per-call timeout outlasts the worker response", async () => {
+		// Server responds at 200ms — longer than the 50ms client default.
 		serverDelayMs = 200
 		const creds = { ...CREDS, wsUrl: baseUrl.replace("http://", "ws://") }
 		const client = new WorkerClient(creds, { timeoutMs: 50 })
 
-		const result = await createSession(
-			client,
-			"kubecast",
-			{ agentMode: "PTY" },
-			{ timeoutMs: SESSION_CREATE_TIMEOUT_MS },
-		)
+		const result = await createSession(client, "kubecast", { agentMode: "PTY" }, { timeoutMs: 1000 })
 
 		expect(result.name).toBe("kubecast")
 		expect(result.agentMode).toBe("PTY")
+	})
+
+	it("aborts when no per-call timeout overrides the client default", async () => {
+		// Without a per-call timeoutMs the client default (50ms) aborts a 200ms
+		// response — reproducing the original "The operation was aborted" bug.
+		serverDelayMs = 200
+		const creds = { ...CREDS, wsUrl: baseUrl.replace("http://", "ws://") }
+		const client = new WorkerClient(creds, { timeoutMs: 50 })
+
+		await expect(createSession(client, "kubecast", { agentMode: "PTY" })).rejects.toThrow(/aborted/i)
 	})
 })
 

--- a/src/sandbox/worker/sessions.ts
+++ b/src/sandbox/worker/sessions.ts
@@ -17,12 +17,12 @@ export async function createSession(
 	client: WorkerClient,
 	name: string,
 	req: CreateSessionRequest,
-	opts: { sessionFile?: string; signal?: AbortSignal } = {},
+	opts: { sessionFile?: string; signal?: AbortSignal; timeoutMs?: number } = {},
 ): Promise<Session> {
 	const s = await client.postMultipart<Omit<Session, "name">>(
 		`/session/${encodeURIComponent(name)}`,
 		{ request: req, sessionFile: opts.sessionFile },
-		opts.signal,
+		{ signal: opts.signal, timeoutMs: opts.timeoutMs },
 	)
 	return { ...s, name }
 }

--- a/src/sandbox/worker/sessions.ts
+++ b/src/sandbox/worker/sessions.ts
@@ -22,7 +22,8 @@ export async function createSession(
 	const s = await client.postMultipart<Omit<Session, "name">>(
 		`/session/${encodeURIComponent(name)}`,
 		{ request: req, sessionFile: opts.sessionFile },
-		{ signal: opts.signal, timeoutMs: opts.timeoutMs },
+		opts.signal,
+		opts.timeoutMs,
 	)
 	return { ...s, name }
 }


### PR DESCRIPTION
##  Bug: Teleport sometimes fails with a operation aborted error when creating a session

Closes #2297

## What does this PR do?

Give createSession a longer per-call timeout

Teleport on large repos failed with
"Could not create session: The operation was aborted" even though the
session was actually created server-side. Root cause: WorkerClient
applies a single 30s default timeout to every operation, and session
creation on large workspaces exceeds that — the internal AbortController
fired mid-flight while the worker kept going.

Add a per-call timeoutMs override to postMultipart and have
createSession forward it. Teleport passes SESSION_CREATE_TIMEOUT_MS
(5min) at the call site. The regression test spins up a real local HTTP
server that responds slower than the client default and asserts the
session still succeeds; lowering the constant breaks the test.

## Checklist

- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md) and agree to the CLA
- [x] This PR links to an open issue above
- [x] Tests pass locally (`pnpm run test`)
- [x] Lint passes (`pnpm run check`)
- [x] Documentation updated if behavior changed
