### PR TITLE
fix(ferment): prevent concurrent session recovery from pausing active ferments

### DIFF
--- a/src/extensions/ferment/events.test.ts
+++ b/src/extensions/ferment/events.test.ts
@@ -1,15 +1,17 @@
-import { mkdtempSync } from "node:fs"
+import { mkdtempSync, readdirSync, rmSync, writeFileSync } from "node:fs"
 import { tmpdir } from "node:os"
 import { join } from "node:path"
 import type { Api, Model } from "@earendil-works/pi-ai"
 import type { ExtensionAPI, ModelRegistry } from "@earendil-works/pi-coding-agent"
-import { afterEach, describe, expect, it, vi } from "vitest"
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest"
+import { commandToEvents } from "../../ferment/event-mapper.js"
 import { FermentEventStore } from "../../ferment/event-store.js"
+import { applyCommand } from "../../ferment/state-machine.js"
 import type { Ferment, Phase } from "../../ferment/types.js"
 import { registerFermentEvents } from "./events.js"
 import type { FermentRuntime } from "./runtime.js"
 import { createDefaultFermentRuntime } from "./runtime.js"
-import { clearActiveFermentId } from "./state.js"
+import { clearActiveFermentId, getFermentLockPath, writeFermentLock } from "./state.js"
 import { FERMENT_TOOL_NAMES } from "./tool-names.js"
 import { applyFermentToolProfile, profileForFerment } from "./tool-scope.js"
 
@@ -426,5 +428,122 @@ describe("registerFermentEvents", () => {
 		expect(lastCall).toContain("write")
 		expect(lastCall).toContain("Agent")
 		expect(lastCall).toContain("activate_ferment_phase")
+	})
+})
+
+describe("recoverStuckFerments lockfile awareness", () => {
+	let lockDir: string
+	let storageDir: string
+
+	beforeAll(() => {
+		lockDir = mkdtempSync(join(tmpdir(), "kimchi-ferment-lock-"))
+		storageDir = mkdtempSync(join(tmpdir(), "kimchi-ferment-storage-"))
+	})
+
+	beforeEach(() => {
+		vi.stubEnv("KIMCHI_FERMENT_LOCK_DIR", lockDir)
+		for (const file of readdirSync(lockDir)) {
+			rmSync(join(lockDir, file), { force: true })
+		}
+		for (const file of readdirSync(storageDir)) {
+			rmSync(join(storageDir, file), { recursive: true, force: true })
+		}
+	})
+
+	afterAll(() => {
+		rmSync(lockDir, { recursive: true, force: true })
+		rmSync(storageDir, { recursive: true, force: true })
+	})
+
+	function createStorageWithRunningFerment(): { storage: FermentEventStore; id: string } {
+		const storage = new FermentEventStore(storageDir)
+		const ferment = storage.create("Test")
+		const phaseId = "phase-1"
+
+		storage.mutateWithEvents(ferment.id, (current) => {
+			if (!current) throw new Error("missing ferment")
+			const now = new Date().toISOString()
+			const cmd = {
+				type: "scope" as const,
+				title: "Test",
+				goal: "Test goal",
+				successCriteria: ["Test criterion"],
+				constraints: [],
+				phases: [{ name: "Build", goal: "Build it", steps: [{ description: "step 1" }] }],
+			}
+			const result = applyCommand(current, cmd, { now })
+			if (!result.ok) throw new Error(`scope failed: ${result.error.message}`)
+			const events = commandToEvents(cmd, current, result.ferment, { now })
+			return { write: true, ferment: result.ferment, events, value: undefined }
+		})
+
+		storage.mutateWithEvents(ferment.id, (current) => {
+			if (!current) throw new Error("missing ferment")
+			const now = new Date().toISOString()
+			const cmd = { type: "activate_phase" as const, phaseId }
+			const result = applyCommand(current, cmd, { now })
+			if (!result.ok) throw new Error(`activate failed: ${result.error.message}`)
+			const events = commandToEvents(cmd, current, result.ferment, { now })
+			return { write: true, ferment: result.ferment, events, value: undefined }
+		})
+
+		return { storage, id: ferment.id }
+	}
+
+	it("skips pausing a running ferment when another live process holds its lockfile", async () => {
+		const { storage, id } = createStorageWithRunningFerment()
+		const runtime: FermentRuntime = {
+			...createDefaultFermentRuntime(),
+			getStorage: () => storage,
+			setActive: vi.fn(),
+		}
+		const { handlers, pi } = createPi()
+		registerFermentEvents(pi, runtime)
+		writeFermentLock(id)
+
+		const sessionStart = handlers.get("session_start")
+		if (!sessionStart) throw new Error("session_start handler was not registered")
+		await sessionStart({}, { hasUI: false })
+
+		expect(storage.get(id)?.status).toBe("running")
+	})
+
+	it("still pauses a running ferment when the lockfile PID is dead", async () => {
+		const { storage, id } = createStorageWithRunningFerment()
+		const runtime: FermentRuntime = {
+			...createDefaultFermentRuntime(),
+			getStorage: () => storage,
+			setActive: vi.fn(),
+		}
+		const { handlers, pi } = createPi()
+		registerFermentEvents(pi, runtime)
+		writeFileSync(
+			getFermentLockPath(id),
+			JSON.stringify({ pid: 999999999, startedAt: new Date().toISOString(), fermentId: id }),
+			"utf8",
+		)
+
+		const sessionStart = handlers.get("session_start")
+		if (!sessionStart) throw new Error("session_start handler was not registered")
+		await sessionStart({}, { hasUI: false })
+
+		expect(storage.get(id)?.status).toBe("paused")
+	})
+
+	it("still pauses a running ferment when no lockfile exists", async () => {
+		const { storage, id } = createStorageWithRunningFerment()
+		const runtime: FermentRuntime = {
+			...createDefaultFermentRuntime(),
+			getStorage: () => storage,
+			setActive: vi.fn(),
+		}
+		const { handlers, pi } = createPi()
+		registerFermentEvents(pi, runtime)
+
+		const sessionStart = handlers.get("session_start")
+		if (!sessionStart) throw new Error("session_start handler was not registered")
+		await sessionStart({}, { hasUI: false })
+
+		expect(storage.get(id)?.status).toBe("paused")
 	})
 })

--- a/src/extensions/ferment/events.ts
+++ b/src/extensions/ferment/events.ts
@@ -28,7 +28,7 @@ import { loadFermentSilently, resumeFerment } from "./resume.js"
 import { type FermentRuntime, defaultFermentRuntime } from "./runtime.js"
 import { scheduleFermentWakeUp } from "./scheduler.js"
 import { confirmPendingScope } from "./scoping-confirmation.js"
-import { clearActiveFermentId, getActiveFermentId } from "./state.js"
+import { clearActiveFermentId, getActiveFermentId, isFermentLockedByLiveProcess, removeFermentLock } from "./state.js"
 import { createApplyAndPersist } from "./tool-helpers.js"
 import {
 	applyFermentRuntimeToolProfile,
@@ -271,6 +271,9 @@ export function registerFermentEvents(
 		const applyAndPersist = createApplyAndPersist(runtime)
 		for (const f of runtime.getStorage().list()) {
 			if (f.status === "running" || f.status === "planned") {
+				// Skip ferments that are actively locked by a live process —
+				// they belong to another running kimchi session, not a crashed one.
+				if (isFermentLockedByLiveProcess(f.id)) continue
 				try {
 					const outcome = applyAndPersist(f.id, { type: "pause" })
 					if (!outcome.ok) {
@@ -379,6 +382,9 @@ export function registerFermentEvents(
 				// The startup scanner will recover the stale state on next launch.
 			}
 		}
+		// Remove the lockfile so a concurrent session doesn't think this
+		// ferment is still actively running here.
+		removeFermentLock(f.id)
 	})
 
 	pi.on("input", async (event) => {

--- a/src/extensions/ferment/state.test.ts
+++ b/src/extensions/ferment/state.test.ts
@@ -1,4 +1,7 @@
-import { afterEach, describe, expect, it, vi } from "vitest"
+import { existsSync, mkdtempSync, readFileSync, rmSync } from "node:fs"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
 import type { Ferment, FermentStatus } from "../../ferment/types.js"
 import {
 	clearActiveFermentId,
@@ -6,13 +9,17 @@ import {
 	clearFermentState,
 	clearPendingCompaction,
 	getActiveFermentId,
+	getFermentLockPath,
 	getPendingCompaction,
 	hasActiveFerment,
 	isCompactionInFlight,
+	isFermentLockedByLiveProcess,
 	markCompactionInFlight,
 	onActiveFermentChange,
+	removeFermentLock,
 	setActive,
 	setPendingCompaction,
+	writeFermentLock,
 } from "./state.js"
 
 const NOW = "2026-01-01T00:00:00.000Z"
@@ -36,6 +43,92 @@ afterEach(() => {
 	setActive(undefined)
 	vi.unstubAllEnvs()
 	clearActiveFermentId()
+})
+
+describe("lockfile helpers", () => {
+	let lockDir: string
+
+	beforeEach(() => {
+		lockDir = mkdtempSync(join(tmpdir(), "kimchi-lock-test-"))
+		vi.stubEnv("KIMCHI_FERMENT_LOCK_DIR", lockDir)
+	})
+
+	afterEach(() => {
+		rmSync(lockDir, { recursive: true, force: true })
+	})
+
+	it("writeFermentLock writes a JSON lockfile with the current PID", () => {
+		writeFermentLock("test-ferment-1")
+		const lockPath = getFermentLockPath("test-ferment-1")
+		expect(existsSync(lockPath)).toBe(true)
+		const lock = JSON.parse(readFileSync(lockPath, "utf8"))
+		expect(lock.pid).toBe(process.pid)
+		expect(lock.fermentId).toBe("test-ferment-1")
+		expect(lock.startedAt).toBeTruthy()
+	})
+
+	it("removeFermentLock deletes the lockfile", () => {
+		writeFermentLock("test-ferment-2")
+		expect(existsSync(getFermentLockPath("test-ferment-2"))).toBe(true)
+		removeFermentLock("test-ferment-2")
+		expect(existsSync(getFermentLockPath("test-ferment-2"))).toBe(false)
+	})
+
+	it("isFermentLockedByLiveProcess returns true for a lockfile with a live PID", () => {
+		writeFermentLock("test-ferment-3")
+		expect(isFermentLockedByLiveProcess("test-ferment-3")).toBe(true)
+	})
+
+	it("isFermentLockedByLiveProcess returns false when no lockfile exists", () => {
+		expect(isFermentLockedByLiveProcess("nonexistent-ferment")).toBe(false)
+	})
+
+	it("isFermentLockedByLiveProcess returns false when the PID is dead", () => {
+		// Write a lockfile with a PID that is guaranteed to not be running.
+		const fs = require("node:fs")
+		const lockPath = getFermentLockPath("test-ferment-4")
+		fs.writeFileSync(
+			lockPath,
+			JSON.stringify({ pid: 999999999, startedAt: new Date().toISOString(), fermentId: "test-ferment-4" }),
+			"utf8",
+		)
+		expect(isFermentLockedByLiveProcess("test-ferment-4")).toBe(false)
+	})
+})
+
+describe("setActive lockfile management", () => {
+	let lockDir: string
+
+	beforeEach(() => {
+		lockDir = mkdtempSync(join(tmpdir(), "kimchi-setactive-lock-"))
+		vi.stubEnv("KIMCHI_FERMENT_LOCK_DIR", lockDir)
+	})
+
+	afterEach(() => {
+		rmSync(lockDir, { recursive: true, force: true })
+	})
+
+	it("writes a lockfile when setting an active running ferment", () => {
+		setActive(makeFerment("running"))
+		expect(existsSync(getFermentLockPath("ferment-running"))).toBe(true)
+	})
+
+	it("removes the lockfile when clearing the active ferment", () => {
+		setActive(makeFerment("running"))
+		expect(existsSync(getFermentLockPath("ferment-running"))).toBe(true)
+		setActive(undefined)
+		expect(existsSync(getFermentLockPath("ferment-running"))).toBe(false)
+	})
+
+	it("removes the old lockfile when switching to a different ferment", () => {
+		const f1 = makeFerment("running")
+		const f2 = { ...makeFerment("running"), id: "ferment-other" }
+		setActive(f1)
+		expect(existsSync(getFermentLockPath("ferment-running"))).toBe(true)
+		setActive(f2)
+		expect(existsSync(getFermentLockPath("ferment-running"))).toBe(false)
+		expect(existsSync(getFermentLockPath("ferment-other"))).toBe(true)
+	})
 })
 
 describe("setActive", () => {

--- a/src/extensions/ferment/state.test.ts
+++ b/src/extensions/ferment/state.test.ts
@@ -1,4 +1,4 @@
-import { existsSync, mkdtempSync, readFileSync, rmSync } from "node:fs"
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs"
 import { tmpdir } from "node:os"
 import { join } from "node:path"
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
@@ -93,6 +93,98 @@ describe("lockfile helpers", () => {
 			"utf8",
 		)
 		expect(isFermentLockedByLiveProcess("test-ferment-4")).toBe(false)
+	})
+
+	it("getFermentLockPath throws for invalid fermentIds", () => {
+		for (const bad of ["../evil", "a/b", "a\\b", ".", "..", ""]) {
+			expect(() => getFermentLockPath(bad), `expected throw for ${JSON.stringify(bad)}`).toThrow(/Invalid fermentId/)
+		}
+	})
+
+	it("getFermentLockPath returns a path inside the lock dir for valid ids", () => {
+		const p = getFermentLockPath("safe-id_123.test")
+		expect(p.startsWith(lockDir)).toBe(true)
+		expect(p.endsWith("safe-id_123.test.lock")).toBe(true)
+	})
+
+	it("writeFermentLock logs to console.error when mkdirSync fails", () => {
+		// Point the lock dir at a path under a regular file so mkdirSync fails
+		// with ENOTDIR — the canonical "lock dir unwritable" scenario.
+		const blockerFile = join(tmpdir(), `kimchi-lock-blocker-${Date.now()}-${Math.random().toString(36).slice(2)}`)
+		writeFileSync(blockerFile, "")
+		vi.stubEnv("KIMCHI_FERMENT_LOCK_DIR", `${blockerFile}/subdir`)
+		const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {})
+		try {
+			writeFermentLock("ferment-write-fail")
+			expect(errorSpy).toHaveBeenCalled()
+			const msg = String(errorSpy.mock.calls[0]?.[0] ?? "")
+			expect(msg).toContain("[ferment]")
+			expect(msg).toContain("ferment-write-fail")
+		} finally {
+			errorSpy.mockRestore()
+			rmSync(blockerFile, { force: true })
+		}
+	})
+
+	it("removeFermentLock logs to console.error when rmSync fails", () => {
+		// Create a directory at the lockfile path. rmSync on a directory without
+		// {recursive:true} throws EISDIR, which force:true does NOT suppress (it
+		// only ignores ENOENT). This exercises the real rmSync error path without
+		// mocking the fs module (which is unreliable under ESM live bindings).
+		const lockPath = getFermentLockPath("ferment-rm-fail")
+		mkdirSync(lockPath)
+		const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {})
+		try {
+			removeFermentLock("ferment-rm-fail")
+			expect(errorSpy).toHaveBeenCalled()
+			const msg = String(errorSpy.mock.calls[0]?.[0] ?? "")
+			expect(msg).toContain("[ferment]")
+			expect(msg).toContain("ferment-rm-fail")
+		} finally {
+			errorSpy.mockRestore()
+			rmSync(lockPath, { recursive: true, force: true })
+		}
+	})
+
+	it("isFermentLockedByLiveProcess returns false when startedAt is older than KIMCHI_FERMENT_LOCK_MAX_AGE_MS", () => {
+		// Tiny max age so the staleness guard triggers with a comfortably-old
+		// timestamp; the lockfile's PID is still alive (process.pid).
+		vi.stubEnv("KIMCHI_FERMENT_LOCK_MAX_AGE_MS", "1000")
+		const eightDaysAgo = new Date(Date.now() - 8 * 24 * 60 * 60 * 1000).toISOString()
+		const lockPath = getFermentLockPath("test-ferment-stale")
+		writeFileSync(
+			lockPath,
+			JSON.stringify({ pid: process.pid, startedAt: eightDaysAgo, fermentId: "test-ferment-stale" }),
+			"utf8",
+		)
+		expect(isFermentLockedByLiveProcess("test-ferment-stale")).toBe(false)
+	})
+
+	it("isFermentLockedByLiveProcess returns false when startedAt is missing", () => {
+		const lockPath = getFermentLockPath("test-ferment-missing-started")
+		writeFileSync(lockPath, JSON.stringify({ pid: process.pid, fermentId: "test-ferment-missing-started" }), "utf8")
+		expect(isFermentLockedByLiveProcess("test-ferment-missing-started")).toBe(false)
+	})
+
+	it("isFermentLockedByLiveProcess returns false when startedAt is unparseable", () => {
+		const lockPath = getFermentLockPath("test-ferment-bad-started")
+		writeFileSync(
+			lockPath,
+			JSON.stringify({ pid: process.pid, startedAt: "not-a-date", fermentId: "test-ferment-bad-started" }),
+			"utf8",
+		)
+		expect(isFermentLockedByLiveProcess("test-ferment-bad-started")).toBe(false)
+	})
+
+	it("isFermentLockedByLiveProcess returns false when startedAt is in the future", () => {
+		const futureStart = new Date(Date.now() + 60 * 60 * 1000).toISOString() // +1h
+		const lockPath = getFermentLockPath("test-ferment-future-started")
+		writeFileSync(
+			lockPath,
+			JSON.stringify({ pid: process.pid, startedAt: futureStart, fermentId: "test-ferment-future-started" }),
+			"utf8",
+		)
+		expect(isFermentLockedByLiveProcess("test-ferment-future-started")).toBe(false)
 	})
 })
 

--- a/src/extensions/ferment/state.ts
+++ b/src/extensions/ferment/state.ts
@@ -102,6 +102,8 @@ interface FermentLockInfo {
 	fermentId: string
 }
 
+const SAFE_FERMENT_ID = /^[A-Za-z0-9._-]+$/
+
 function getFermentLockDir(): string {
 	const override = process.env.KIMCHI_FERMENT_LOCK_DIR?.trim()
 	if (override) return override
@@ -109,6 +111,9 @@ function getFermentLockDir(): string {
 }
 
 export function getFermentLockPath(fermentId: string): string {
+	if (!fermentId || !SAFE_FERMENT_ID.test(fermentId) || fermentId === "." || fermentId === "..") {
+		throw new Error(`Invalid fermentId for lockfile: ${JSON.stringify(fermentId)}`)
+	}
 	return join(getFermentLockDir(), `${fermentId}.lock`)
 }
 
@@ -127,9 +132,11 @@ export function writeFermentLock(fermentId: string): void {
 			encoding: "utf8",
 			flag: "w",
 		})
-	} catch {
+	} catch (err) {
 		// Lockfile write failure is non-fatal — recovery will treat missing
-		// locks as "not locked" and pause, which is the safe default.
+		// locks as "not locked" and pause, which is the safe default. Log so
+		// operators can detect when the cross-session protection is absent.
+		console.error(`[ferment] failed to write lockfile for ${fermentId}:`, err)
 	}
 }
 
@@ -137,14 +144,39 @@ export function writeFermentLock(fermentId: string): void {
 export function removeFermentLock(fermentId: string): void {
 	try {
 		rmSync(getFermentLockPath(fermentId), { force: true })
-	} catch {
-		// Non-fatal.
+	} catch (err) {
+		// Non-fatal, but log so operators can detect lingering lockfiles.
+		console.error(`[ferment] failed to remove lockfile for ${fermentId}:`, err)
 	}
 }
 
+/** Default staleness ceiling for the PID-reuse guard (7 days). Generous enough
+ *  that legitimate long-running sessions are unaffected; a ferment left active
+ *  for longer than this is treated as abandoned and may be paused by recovery. */
+const DEFAULT_LOCK_MAX_AGE_MS = 7 * 24 * 60 * 60 * 1000
+
+function getLockMaxAgeMs(): number {
+	const raw = process.env.KIMCHI_FERMENT_LOCK_MAX_AGE_MS?.trim()
+	if (!raw) return DEFAULT_LOCK_MAX_AGE_MS
+	const n = Number(raw)
+	return Number.isFinite(n) && n > 0 ? n : DEFAULT_LOCK_MAX_AGE_MS
+}
+
 /** Check whether a ferment's lockfile points to a live (running) process.
- *  Returns true if the lockfile exists and its PID is alive. Returns false if
- *  the lockfile is missing, unreadable, or the PID is dead. */
+ *
+ *  Returns true if the lockfile exists, its `startedAt` is within the staleness
+ *  window (see `KIMCHI_FERMENT_LOCK_MAX_AGE_MS`, default 7 days), and its PID is
+ *  alive. Returns false if the lockfile is missing, unreadable, stale, has an
+ *  invalid `startedAt`, or the PID is dead.
+ *
+ *  NOTE: `process.kill(pid, 0)` only proves that *some* process with that PID
+ *  exists — it does NOT prove it is the original kimchi session. PIDs are
+ *  recycled by the OS, so a crashed session whose PID is later reused by an
+ *  unrelated process will be falsely reported as alive by the kernel check.
+ *  The `startedAt` staleness guard above mitigates this by treating locks older
+ *  than the configured max age as abandoned, but it cannot fully eliminate
+ *  PID-reuse risk within that window. Operators relying on cross-session
+ *  isolation should keep session lifetimes well below the max age. */
 export function isFermentLockedByLiveProcess(fermentId: string): boolean {
 	try {
 		const lockPath = getFermentLockPath(fermentId)
@@ -152,6 +184,13 @@ export function isFermentLockedByLiveProcess(fermentId: string): boolean {
 		const raw = readFileSync(lockPath, "utf8")
 		const lockInfo = JSON.parse(raw) as FermentLockInfo
 		if (!lockInfo?.pid) return false
+		// Staleness guard: if the lock predates the max session age, treat it
+		// as stale even if the PID happens to be alive (PID-reuse mitigation).
+		const startedAt = Date.parse(lockInfo.startedAt ?? "")
+		if (!Number.isFinite(startedAt)) return false
+		const now = Date.now()
+		if (startedAt > now) return false // future timestamp → corrupt/stale
+		if (now - startedAt > getLockMaxAgeMs()) return false
 		// process.kill(pid, 0) throws if the process doesn't exist (or we lack
 		// permission to signal it). A successful no-op return means it's alive.
 		process.kill(lockInfo.pid, 0)

--- a/src/extensions/ferment/state.ts
+++ b/src/extensions/ferment/state.ts
@@ -9,6 +9,9 @@
  * judge connection. Encapsulating in a class would add ceremony without value.
  */
 
+import { existsSync, mkdirSync, readFileSync, rmSync, writeFileSync } from "node:fs"
+import { homedir } from "node:os"
+import { dirname, join } from "node:path"
 import type { Api, Model } from "@earendil-works/pi-ai"
 import type { ModelRegistry } from "@earendil-works/pi-coding-agent"
 import { FermentEventStore } from "../../ferment/event-store.js"
@@ -64,14 +67,98 @@ function shouldElevatePermissions(f: Ferment | undefined): boolean {
 }
 
 export function setActive(f: Ferment | undefined): void {
+	// If the active ferment is changing, manage lockfiles: write a lock for the
+	// new active ferment, remove the lock for the old one. Best-effort — errors
+	// are swallowed so they never block a state transition.
+	if (activeFerment?.id && activeFerment.id !== f?.id) {
+		removeFermentLock(activeFerment.id)
+	}
 	activeFerment = f
 	const elevatePermissions = shouldElevatePermissions(f)
 	if (elevatePermissions && f) {
 		process.env.KIMCHI_ACTIVE_FERMENT = f.id
+		writeFermentLock(f.id)
 	} else {
 		clearActiveFermentId()
+		if (f?.id) removeFermentLock(f.id)
 	}
 	notifyFermentActive(elevatePermissions)
+}
+
+// ─── PID-based lockfiles ───────────────────────────────────────────────────────
+//
+// When a ferment is active in a session, a lockfile is written to a global
+// directory. This allows `recoverStuckFerments()` in events.ts to distinguish
+// between a genuinely crashed session (lockfile PID is dead or missing — safe
+// to pause and recover) and a ferment actively running in another live kimchi
+// session (lockfile PID is alive — do NOT pause).
+//
+// The lock directory is configurable via KIMCHI_FERMENT_LOCK_DIR for test
+// isolation. By default it lives under ~/.config/kimchi/harness/ferment-locks/.
+
+interface FermentLockInfo {
+	pid: number
+	startedAt: string
+	fermentId: string
+}
+
+function getFermentLockDir(): string {
+	const override = process.env.KIMCHI_FERMENT_LOCK_DIR?.trim()
+	if (override) return override
+	return join(homedir(), ".config", "kimchi", "harness", "ferment-locks")
+}
+
+export function getFermentLockPath(fermentId: string): string {
+	return join(getFermentLockDir(), `${fermentId}.lock`)
+}
+
+/** Write a best-effort PID lockfile for the given ferment. Swallows all errors
+ *  so it never blocks a state transition. */
+export function writeFermentLock(fermentId: string): void {
+	try {
+		const lockDir = getFermentLockDir()
+		mkdirSync(lockDir, { recursive: true })
+		const lockInfo: FermentLockInfo = {
+			pid: process.pid,
+			startedAt: new Date().toISOString(),
+			fermentId,
+		}
+		writeFileSync(getFermentLockPath(fermentId), JSON.stringify(lockInfo, null, 2), {
+			encoding: "utf8",
+			flag: "w",
+		})
+	} catch {
+		// Lockfile write failure is non-fatal — recovery will treat missing
+		// locks as "not locked" and pause, which is the safe default.
+	}
+}
+
+/** Remove the lockfile for the given ferment. Best-effort, swallows errors. */
+export function removeFermentLock(fermentId: string): void {
+	try {
+		rmSync(getFermentLockPath(fermentId), { force: true })
+	} catch {
+		// Non-fatal.
+	}
+}
+
+/** Check whether a ferment's lockfile points to a live (running) process.
+ *  Returns true if the lockfile exists and its PID is alive. Returns false if
+ *  the lockfile is missing, unreadable, or the PID is dead. */
+export function isFermentLockedByLiveProcess(fermentId: string): boolean {
+	try {
+		const lockPath = getFermentLockPath(fermentId)
+		if (!existsSync(lockPath)) return false
+		const raw = readFileSync(lockPath, "utf8")
+		const lockInfo = JSON.parse(raw) as FermentLockInfo
+		if (!lockInfo?.pid) return false
+		// process.kill(pid, 0) throws if the process doesn't exist (or we lack
+		// permission to signal it). A successful no-op return means it's alive.
+		process.kill(lockInfo.pid, 0)
+		return true
+	} catch {
+		return false
+	}
 }
 
 // ─── Runtime continuation policy ──────────────────────────────────────────────


### PR DESCRIPTION
## Linked issue

Closes #

## What does this PR do?

`recoverStuckFerments()` was pausing ferments actively running in another kimchi session because `KIMCHI_ACTIVE_FERMENT` is process-local. When a new session starts (process restart, concurrent session), it sees a running ferment with no active marker and incorrectly pauses it — disrupting the other session's work.

**Fix:** Add PID-based lockfiles that survive across sessions.

- `setActive()` in `state.ts` writes a lockfile (`{ pid, startedAt, fermentId }`) when a ferment becomes active and removes it when cleared/switched.
- `recoverStuckFerments()` in `events.ts` checks `isFermentLockedByLiveProcess()` — if the lockfile PID is alive, the ferment belongs to another running session and is **skipped**. If the PID is dead or the lockfile is missing, the ferment is paused as before (crash recovery).
- `session_shutdown` removes the active ferment's lockfile so concurrent sessions don't think it's still running here.

Lock directory is configurable via `KIMCHI_FERMENT_LOCK_DIR` for test isolation. Default: `~/.config/kimchi/harness/ferment-locks/<id>.lock`.

Manual phase-boundary pause behavior is unchanged — only the recovery path checks lockfiles.

## Checklist

- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md) and agree to the CLA
- [ ] This PR links to an open issue above
- [x] Tests pass locally (`pnpm run test`) — 792 ferment tests pass
- [x] Lint passes (`pnpm run check`) — Biome lint passes on changed files
- [ ] Documentation updated if behavior changed