### PR TITLE
fix(telemetry): suppress tool_failure for harness-level tool_call blocks

### DIFF
--- a/src/extensions/first-turn-orientation.test.ts
+++ b/src/extensions/first-turn-orientation.test.ts
@@ -1,5 +1,8 @@
-import { describe, expect, it } from "vitest"
+import type { ExtensionAPI } from "@earendil-works/pi-coding-agent"
+import { describe, expect, it, vi } from "vitest"
 import { FirstTurnOrientationGuard, ORIENTATION_BLOCK_MESSAGE } from "./first-turn-orientation.js"
+import firstTurnOrientationExtension from "./first-turn-orientation.js"
+import { TOOL_CALL_EVENTS } from "./tool-call-events.js"
 
 describe("FirstTurnOrientationGuard", () => {
 	describe("evaluate", () => {
@@ -135,5 +138,100 @@ describe("ORIENTATION_BLOCK_MESSAGE", () => {
 	it("is a stable string containing the key guidance", () => {
 		expect(ORIENTATION_BLOCK_MESSAGE).toContain("visible text")
 		expect(ORIENTATION_BLOCK_MESSAGE.toLowerCase()).toContain("orient")
+	})
+})
+
+describe("firstTurnOrientationExtension — domain event emission", () => {
+	function createMockPi() {
+		const handlers = new Map<string, Array<(event: unknown) => unknown>>()
+		const emit = vi.fn()
+		const api = {
+			on: vi.fn((event: string, handler: (e: unknown) => unknown) => {
+				if (!handlers.has(event)) handlers.set(event, [])
+				handlers.get(event)?.push(handler)
+			}),
+			events: { emit },
+		} as unknown as ExtensionAPI
+		return { api, handlers, emit }
+	}
+
+	function fire(handlers: Map<string, Array<(event: unknown) => unknown>>, event: string, payload: unknown) {
+		const list = handlers.get(event) ?? []
+		let blockResult: { block: true; reason: string } | undefined
+		for (const h of list) {
+			const result = h(payload) as { block?: boolean; reason?: string } | undefined
+			if (result?.block) {
+				blockResult = { block: true, reason: result.reason ?? "" }
+			}
+		}
+		return blockResult
+	}
+
+	it("emits first_turn_orientation:block with toolCallId and reason when blocking", () => {
+		const { api, handlers, emit } = createMockPi()
+		firstTurnOrientationExtension(api)
+
+		fire(handlers, "turn_start", { turnIndex: 0 })
+		const result = fire(handlers, "tool_call", { toolCallId: "tc-1", toolName: "bash" })
+
+		expect(result?.block).toBe(true)
+		expect(result?.reason).toBe(ORIENTATION_BLOCK_MESSAGE)
+		expect(emit).toHaveBeenCalledWith(TOOL_CALL_EVENTS.BLOCK, {
+			toolCallId: "tc-1",
+			toolName: "bash",
+			reason: ORIENTATION_BLOCK_MESSAGE,
+			guard: "first_turn_orientation",
+		})
+	})
+
+	it("does NOT emit the domain event when not blocking (visible text was seen)", () => {
+		const { api, handlers, emit } = createMockPi()
+		firstTurnOrientationExtension(api)
+
+		fire(handlers, "turn_start", { turnIndex: 0 })
+		fire(handlers, "message_update", {
+			assistantMessageEvent: { type: "text_delta" },
+		})
+		const result = fire(handlers, "tool_call", { toolCallId: "tc-2", toolName: "bash" })
+
+		expect(result?.block).toBeFalsy()
+		expect(emit).not.toHaveBeenCalled()
+	})
+
+	it("does NOT emit the domain event on subsequent turns (turnIndex > 0)", () => {
+		const { api, handlers, emit } = createMockPi()
+		firstTurnOrientationExtension(api)
+
+		fire(handlers, "turn_start", { turnIndex: 5 })
+		fire(handlers, "tool_call", { toolCallId: "tc-3", toolName: "bash" })
+
+		expect(emit).not.toHaveBeenCalled()
+	})
+
+	it("emits the domain event only on the first blocked call (block-once-per-turn)", () => {
+		const { api, handlers, emit } = createMockPi()
+		firstTurnOrientationExtension(api)
+
+		fire(handlers, "turn_start", { turnIndex: 0 })
+		fire(handlers, "tool_call", { toolCallId: "tc-A", toolName: "bash" })
+		fire(handlers, "tool_call", { toolCallId: "tc-B", toolName: "bash" })
+
+		expect(emit).toHaveBeenCalledTimes(1)
+		expect(emit).toHaveBeenCalledWith(TOOL_CALL_EVENTS.BLOCK, {
+			toolCallId: "tc-A",
+			toolName: "bash",
+			reason: ORIENTATION_BLOCK_MESSAGE,
+			guard: "first_turn_orientation",
+		})
+	})
+
+	it("does NOT emit the domain event for empty tool names", () => {
+		const { api, handlers, emit } = createMockPi()
+		firstTurnOrientationExtension(api)
+
+		fire(handlers, "turn_start", { turnIndex: 0 })
+		fire(handlers, "tool_call", { toolCallId: "tc-4", toolName: "" })
+
+		expect(emit).not.toHaveBeenCalled()
 	})
 })

--- a/src/extensions/first-turn-orientation.ts
+++ b/src/extensions/first-turn-orientation.ts
@@ -27,6 +27,7 @@
  */
 
 import type { ExtensionAPI } from "@earendil-works/pi-coding-agent"
+import { TOOL_CALL_EVENTS } from "./tool-call-events.js"
 
 export const ORIENTATION_BLOCK_MESSAGE =
 	"Your first response to a complex task must include a brief visible text message orienting the user (what you intend to do and why) before any tool call. Thinking alone is not enough — emit visible text first, then call tools."
@@ -134,7 +135,20 @@ export default function firstTurnOrientationExtension(pi: ExtensionAPI): void {
 		if (!event.toolName) return
 		const decision = guard.evaluate()
 		if (decision.block) {
-			return { block: true, reason: decision.reason ?? ORIENTATION_BLOCK_MESSAGE }
+			const reason = decision.reason ?? ORIENTATION_BLOCK_MESSAGE
+			// Publish a domain event so downstream subscribers (e.g. telemetry)
+			// can distinguish harness-level blocks from real tool failures.
+			// The upstream agent loop will still emit tool_execution_end with
+			// isError: true for blocked calls, so telemetry needs to know
+			// which toolCallIds were blocked here in order to avoid emitting
+			// a tool_failure error record for them.
+			pi.events.emit(TOOL_CALL_EVENTS.BLOCK, {
+				toolCallId: event.toolCallId,
+				toolName: event.toolName,
+				reason,
+				guard: "first_turn_orientation",
+			})
+			return { block: true, reason }
 		}
 	})
 }

--- a/src/extensions/telemetry/handlers/tools.ts
+++ b/src/extensions/telemetry/handlers/tools.ts
@@ -33,6 +33,11 @@ export function handleToolExecutionStart(
 export function handleToolExecutionEnd(
 	ctx: SessionContext,
 	event: { toolCallId: string; isError?: boolean; result?: unknown },
+	/** Returns true when the given toolCallId is a known harness-level block
+	 * (e.g. first-turn orientation guard). When true, the tool_result record
+	 * is still emitted (with success: false), but the tool_failure error
+	 * record is skipped — the block is a policy decision, not a tool error. */
+	isHarnessBlock: (toolCallId: string) => boolean = () => false,
 ): void {
 	const pending = ctx.pendingArgs.get(event.toolCallId)
 	if (!pending) return
@@ -146,7 +151,7 @@ export function handleToolExecutionEnd(
 	}
 
 	// --- Error tracking -------------------------------------------------------
-	if (event.isError) {
+	if (event.isError && !isHarnessBlock(event.toolCallId)) {
 		let errorMsg = "unknown tool error"
 		if (
 			event.result &&

--- a/src/extensions/telemetry/index.test.ts
+++ b/src/extensions/telemetry/index.test.ts
@@ -1,6 +1,7 @@
 import type { ExtensionAPI } from "@earendil-works/pi-coding-agent"
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
 import type { TelemetryConfig } from "../../config.js"
+import { TOOL_CALL_EVENTS } from "../tool-call-events.js"
 import telemetryExtension, {
 	trackSubagentSpawned,
 	trackSurveyAnswered,
@@ -1166,5 +1167,144 @@ describe("bash-tool-guard telemetry via pi.events", () => {
 			count: 1,
 		})
 		expect(fetchMock).not.toHaveBeenCalled()
+	})
+})
+
+// ---------------------------------------------------------------------------
+// First-turn orientation block → tool_failure suppression
+// ---------------------------------------------------------------------------
+
+describe("first-turn orientation block suppresses tool_failure error record", () => {
+	let fetchMock: ReturnType<typeof vi.fn>
+	let originalFetch: typeof globalThis.fetch
+
+	beforeEach(() => {
+		fetchMock = vi.fn().mockResolvedValue({ ok: true, text: async () => "" })
+		originalFetch = globalThis.fetch
+		// biome-ignore lint/suspicious/noExplicitAny: test mock
+		globalThis.fetch = fetchMock as any
+	})
+
+	afterEach(async () => {
+		globalThis.fetch = originalFetch
+		_resetSharedAccumulators()
+		const { _resetFermentTrackingState, _resetBlockedToolCallIds } = await import("./index.js")
+		_resetFermentTrackingState()
+		_resetBlockedToolCallIds()
+		vi.restoreAllMocks()
+	})
+
+	function extractRecords() {
+		const logCalls = fetchMock.mock.calls.filter(([url]: unknown[]) => String(url).includes("/logs"))
+		return logCalls.flatMap(([, opts]: unknown[]) => {
+			const body = JSON.parse((opts as { body: string }).body)
+			return body.resourceLogs[0].scopeLogs[0].logRecords as Array<{
+				eventName: string
+				attributes: Array<{ key: string; value: { stringValue: string } }>
+			}>
+		})
+	}
+
+	it("does NOT emit error record for a blocked toolCallId, but DOES emit tool_result", async () => {
+		const { handlers, events, api } = createMockApi()
+		telemetryExtension(makeConfig())(api)
+		await getHandler(handlers, "session_start")({}, { model: { id: "claude-opus-4-6" } })
+
+		// Simulate the orientation guard blocking a tool call before its
+		// tool_execution_end fires (isError: true comes from upstream loop).
+		events.emit(TOOL_CALL_EVENTS.BLOCK, {
+			toolCallId: "tc-block-1",
+			toolName: "bash",
+			reason: "orientation guard",
+			guard: "first_turn_orientation",
+		})
+
+		getHandler(
+			handlers,
+			"tool_execution_start",
+		)({ toolCallId: "tc-block-1", toolName: "bash", args: { command: "ls" } })
+		await getHandler(
+			handlers,
+			"tool_execution_end",
+		)({
+			toolCallId: "tc-block-1",
+			isError: true,
+			result: { content: [{ type: "text", text: "blocked by harness" }] },
+		})
+		await getHandler(handlers, "session_shutdown")({ reason: "test" })
+
+		const records = extractRecords()
+		const errorRecords = records.filter((r) => r.eventName === "error")
+		const toolResultRecords = records.filter((r) => r.eventName === "tool_result")
+		expect(errorRecords).toHaveLength(0)
+		expect(toolResultRecords).toHaveLength(1)
+		const toolResultAttrs = Object.fromEntries(toolResultRecords[0].attributes.map((a) => [a.key, a.value.stringValue]))
+		expect(toolResultAttrs.tool_name).toBe("bash")
+		expect(toolResultAttrs.success).toBe("false")
+	})
+
+	it("DOES emit error record for a non-blocked toolCallId when isError is true", async () => {
+		const { handlers, events, api } = createMockApi()
+		telemetryExtension(makeConfig())(api)
+		await getHandler(handlers, "session_start")({}, { model: { id: "claude-opus-4-6" } })
+
+		// No block event emitted for this id — it's a genuine tool failure.
+		getHandler(
+			handlers,
+			"tool_execution_start",
+		)({ toolCallId: "tc-real-err", toolName: "bash", args: { command: "false" } })
+		await getHandler(
+			handlers,
+			"tool_execution_end",
+		)({
+			toolCallId: "tc-real-err",
+			isError: true,
+			result: { content: [{ type: "text", text: "exit code 1" }] },
+		})
+		await getHandler(handlers, "session_shutdown")({ reason: "test" })
+
+		const records = extractRecords()
+		const errorRecords = records.filter((r) => r.eventName === "error")
+		expect(errorRecords).toHaveLength(1)
+		const attrs = Object.fromEntries(errorRecords[0].attributes.map((a) => [a.key, a.value.stringValue]))
+		expect(attrs.error_type).toBe("tool_failure")
+		expect(attrs.tool_name).toBe("bash")
+	})
+
+	it("clears the blocked-id set on session_start", async () => {
+		const { handlers, events, api } = createMockApi()
+		telemetryExtension(makeConfig())(api)
+
+		// First session: block a toolCallId.
+		await getHandler(handlers, "session_start")({}, { model: { id: "claude-opus-4-6" } })
+		events.emit(TOOL_CALL_EVENTS.BLOCK, { toolCallId: "tc-x", reason: "r" })
+		getHandler(handlers, "tool_execution_start")({ toolCallId: "tc-x", toolName: "bash", args: { command: "ls" } })
+		await getHandler(
+			handlers,
+			"tool_execution_end",
+		)({
+			toolCallId: "tc-x",
+			isError: true,
+			result: { content: [] },
+		})
+
+		// Reset session — blocked ids should be cleared.
+		await getHandler(handlers, "session_start")({}, { model: { id: "claude-opus-4-6" } })
+
+		// Same id, no new block event — should now produce an error record.
+		getHandler(handlers, "tool_execution_start")({ toolCallId: "tc-x", toolName: "bash", args: { command: "ls" } })
+		await getHandler(
+			handlers,
+			"tool_execution_end",
+		)({
+			toolCallId: "tc-x",
+			isError: true,
+			result: { content: [{ type: "text", text: "boom" }] },
+		})
+		await getHandler(handlers, "session_shutdown")({ reason: "test" })
+
+		const records = extractRecords()
+		const errorRecords = records.filter((r) => r.eventName === "error")
+		expect(errorRecords.length).toBeGreaterThanOrEqual(1)
 	})
 })

--- a/src/extensions/telemetry/index.ts
+++ b/src/extensions/telemetry/index.ts
@@ -20,6 +20,7 @@ import {
 	type FermentStepFailedPayload,
 	type FermentStepStartedPayload,
 } from "../ferment/domain-events.js"
+import { TOOL_CALL_EVENTS, type ToolCallBlockPayload } from "../tool-call-events.js"
 
 import { handleAgentEnd, handleBeforeAgentStart, handleMessageEnd, handleMessageStart } from "./handlers/messages.js"
 import { emitSessionStartEvent, handleSessionInitialized, handleSessionShutdown } from "./handlers/session.js"
@@ -105,6 +106,35 @@ export function _resetFermentTrackingState(): void {
 /** @internal — exposed for testing only */
 export function _getBashGuardCounts(): { warn: number; block: number; allowedByUserRequest: number } {
 	return { ...bashGuardCounts }
+}
+
+// ---------------------------------------------------------------------------
+// First-turn-orientation blocked-id tracking
+// ---------------------------------------------------------------------------
+
+/**
+ * toolCallIds blocked by harness-level guards during the current session.
+ * Cleared on session_start. Used by the tools handler to suppress the
+ * tool_failure error record for harness-level blocks while still emitting a
+ * tool_result record (with success: false).
+ */
+const blockedToolCallIds = new Set<string>()
+
+/** @internal — exposed for testing only */
+export function _isBlockedToolCall(toolCallId: string): boolean {
+	return blockedToolCallIds.has(toolCallId)
+}
+
+/** @internal — exposed for testing only */
+export function _resetBlockedToolCallIds(): void {
+	blockedToolCallIds.clear()
+}
+
+function onToolCallBlock(raw: unknown): void {
+	const payload = raw as ToolCallBlockPayload
+	if (payload?.toolCallId) {
+		blockedToolCallIds.add(payload.toolCallId)
+	}
 }
 
 // ---------------------------------------------------------------------------
@@ -536,8 +566,16 @@ export default function telemetryExtension(config: TelemetryConfig) {
 		pi.events.on(BASH_TOOL_GUARD_EVENTS.BLOCK, onBashGuardBlock)
 		pi.events.on(BASH_TOOL_GUARD_EVENTS.ALLOWED_BY_USER_REQUEST, onBashGuardAllowedByUserRequest)
 
+		// Subscribe to harness-level tool_call block events. We only need the
+		// toolCallId so the tools handler can distinguish harness-level
+		// blocks from real tool failures in tool_execution_end. No OTLP
+		// record is emitted here — the block is counted via tool_result
+		// (success: false).
+		pi.events.on(TOOL_CALL_EVENTS.BLOCK, onToolCallBlock)
+
 		pi.on("session_start", async (_event, extCtx) => {
 			resetBashGuardCounts()
+			blockedToolCallIds.clear()
 			const modelId = (extCtx as { model?: { id?: string } } | undefined)?.model?.id
 			handleSessionInitialized(ctx, modelId)
 		})
@@ -564,7 +602,11 @@ export default function telemetryExtension(config: TelemetryConfig) {
 			handleToolExecutionStart(ctx, event as { toolCallId: string; toolName: string; args: unknown }),
 		)
 		pi.on("tool_execution_end", async (event) => {
-			handleToolExecutionEnd(ctx, event as { toolCallId: string; isError?: boolean; result?: unknown })
+			handleToolExecutionEnd(
+				ctx,
+				event as { toolCallId: string; isError?: boolean; result?: unknown },
+				_isBlockedToolCall,
+			)
 		})
 		pi.on("before_agent_start", async (event, extCtx) => {
 			if (!sessionStartEmitted) {

--- a/src/extensions/tool-call-events.ts
+++ b/src/extensions/tool-call-events.ts
@@ -1,0 +1,26 @@
+/**
+ * Generic tool-call domain event channels published via pi.events.
+ *
+ * Any guard extension that blocks a tool call should emit
+ * `TOOL_CALL_EVENTS.BLOCK` so downstream subscribers (e.g. telemetry)
+ * can distinguish harness-level blocks from real tool failures without
+ * needing guard-specific knowledge. The `guard` field on the payload
+ * identifies which extension performed the block, when relevant.
+ */
+
+export const TOOL_CALL_EVENTS = {
+	BLOCK: "tool_call:block",
+} as const
+
+export type ToolCallEventChannel = (typeof TOOL_CALL_EVENTS)[keyof typeof TOOL_CALL_EVENTS]
+
+export interface ToolCallBlockPayload {
+	/** The toolCallId of the tool call that was blocked. */
+	toolCallId: string
+	/** The tool name of the blocked call, when known. */
+	toolName?: string
+	/** The reason message sent back to the model explaining the block. */
+	reason: string
+	/** Identifier of the guard extension that performed the block. */
+	guard?: string
+}


### PR DESCRIPTION
## Problem

The first-turn orientation guard returns `{ block: true, reason }` from its `tool_call` handler. The upstream agent loop still emits `tool_execution_end` with `isError: true` for blocked calls, so the telemetry extension was recording a `tool_failure` error and surfacing it in PostHog.

## Fix

Introduce a generic `tool_call:block` domain event.

- `src/extensions/tool-call-events.ts` defines the new event contract.
- The orientation guard emits `TOOL_CALL_EVENTS.BLOCK` with `guard: "first_turn_orientation"` when blocking.
- Telemetry subscribes to the event, tracks blocked `toolCallId`s, and skips the `tool_failure` error record for those ids while still emitting a `tool_result` record (`success: false`) so the block remains countable.

This is reusable: any future guard can emit the same event with its own `guard` identifier and avoid being misclassified as a tool error.

## Verification

- `pnpm run test src/extensions/first-turn-orientation.test.ts src/extensions/telemetry/index.test.ts` → 57 tests passed
- `pnpm run typecheck` → clean
- `biome check` on changed files → clean

Closes #0