### PR TITLE
feat(acp): include messageId with content chunks

### DIFF
--- a/src/modes/acp/server.test.ts
+++ b/src/modes/acp/server.test.ts
@@ -1108,6 +1108,112 @@ describe("KimchiAcpAgent turn lifecycle", () => {
 	})
 })
 
+// ACP ContentChunk contract (src/modes/acp/server.ts onSessionEvent):
+// "All chunks belonging to the same message share the same messageId.
+// A change in messageId indicates a new message has started." pi-mono
+// streams one text_delta / thinking_delta event per chunk, but every delta
+// within a content block shares its contentIndex — so the server can collapse
+// them onto a single messageId without coordinating across events. The block
+// below exercises both branches directly so a regression that drops the field
+// or breaks its stability surfaces as a test failure rather than a quiet
+// client-side bug.
+describe("KimchiAcpAgent messageId on streaming chunks", () => {
+	let fake: FakeAgentSession
+	let agent: KimchiAcpAgent
+	let sessionId: string
+	let updates: SessionNotification[]
+
+	beforeEach(async () => {
+		fake = new FakeAgentSession("session-msgid")
+		const rec = makeRecordingConn()
+		updates = rec.updates
+		agent = new KimchiAcpAgent(rec.conn, {
+			extensionFactories: [],
+			agentDir: "/tmp/fake-agent-dir",
+			sessionFactory: async () => asSession(fake),
+		})
+		const res = await agent.newSession({ cwd: "/tmp", mcpServers: [] })
+		sessionId = res.sessionId
+	})
+
+	function emitTextDeltas(contentIndex: number, deltas: string[]): void {
+		for (const delta of deltas) {
+			fake.emit({
+				type: "message_update",
+				assistantMessageEvent: {
+					type: "text_delta",
+					delta,
+					contentIndex,
+					partial: {} as unknown as AssistantMessage,
+				},
+				message: {} as unknown as AssistantMessage,
+			})
+		}
+	}
+
+	function emitThinkingDeltas(contentIndex: number, deltas: string[]): void {
+		for (const delta of deltas) {
+			fake.emit({
+				type: "message_update",
+				assistantMessageEvent: {
+					type: "thinking_delta",
+					delta,
+					contentIndex,
+					partial: {} as unknown as AssistantMessage,
+				},
+				message: {} as unknown as AssistantMessage,
+			})
+		}
+	}
+
+	function messageIdsFor(update: string): Array<string | null | undefined> {
+		return updates
+			.filter((u) => u.update.sessionUpdate === update)
+			.map((u) => (u.update as { messageId?: string | null }).messageId)
+	}
+
+	it("keeps messageId stable across deltas within a block and flips it when contentIndex advances", async () => {
+		// Two text blocks back-to-back. The first three deltas share index 0
+		// (one messageId); the next three share index 1 (a different one).
+		fake.promptImpl = async () => {
+			fake.emit({ type: "agent_start" })
+			emitTextDeltas(0, ["a", "b", "c"])
+			emitTextDeltas(1, ["d", "e", "f"])
+			fake.emit(agentEnd())
+		}
+		const result = await agent.prompt({
+			sessionId,
+			prompt: [{ type: "text", text: "two blocks" }],
+		})
+		expect(result.stopReason).toBe("end_turn")
+		expect(messageIdsFor("agent_message_chunk")).toEqual([
+			"kimchi_msg_0",
+			"kimchi_msg_0",
+			"kimchi_msg_0",
+			"kimchi_msg_1",
+			"kimchi_msg_1",
+			"kimchi_msg_1",
+		])
+	})
+
+	it("emits messageId on agent_thought_chunk the same way (same contentIndex → same id)", async () => {
+		// Smoke test for the thought branch: the formula is identical to the
+		// text branch, so a regression that drops the field on either side
+		// surfaces in at least one of the two tests.
+		fake.promptImpl = async () => {
+			fake.emit({ type: "agent_start" })
+			emitThinkingDeltas(0, ["hmm", " ", "ok"])
+			fake.emit(agentEnd())
+		}
+		const result = await agent.prompt({
+			sessionId,
+			prompt: [{ type: "text", text: "think" }],
+		})
+		expect(result.stopReason).toBe("end_turn")
+		expect(messageIdsFor("agent_thought_chunk")).toEqual(["kimchi_msg_0", "kimchi_msg_0", "kimchi_msg_0"])
+	})
+})
+
 // Streaming tools (bash in particular) emit tool_execution_update with a
 // partialResult payload for every output chunk. The ACP server translates each
 // of these into a tool_call_update with status="in_progress" and content carrying

--- a/src/modes/acp/server.test.ts
+++ b/src/modes/acp/server.test.ts
@@ -1212,6 +1212,32 @@ describe("KimchiAcpAgent messageId on streaming chunks", () => {
 		expect(result.stopReason).toBe("end_turn")
 		expect(messageIdsFor("agent_thought_chunk")).toEqual(["kimchi_msg_0", "kimchi_msg_0", "kimchi_msg_0"])
 	})
+
+	it("advances the counter across turns so two turns both starting at contentIndex=0 get distinct ids", async () => {
+		// Regression guard for the ACP "change in messageId indicates a new
+		// message" contract. pi-mono resets contentIndex to 0 on each new
+		// assistant message; without a session-wide counter, turn 2's first
+		// block would re-use turn 1's first block's messageId and a client
+		// would merge two separate replies into one bubble.
+		fake.promptImpl = async () => {
+			// Turn 1: one text block at index 0.
+			fake.emit({ type: "agent_start" })
+			emitTextDeltas(0, ["hello"])
+			fake.emit(agentEnd())
+			// Turn 2 (chained continue): another text block at index 0 again.
+			// contentIndex resets per assistant message, but the session-wide
+			// counter must keep advancing.
+			fake.emit({ type: "agent_start" })
+			emitTextDeltas(0, ["world"])
+			fake.emit(agentEnd())
+		}
+		const result = await agent.prompt({
+			sessionId,
+			prompt: [{ type: "text", text: "two turns" }],
+		})
+		expect(result.stopReason).toBe("end_turn")
+		expect(messageIdsFor("agent_message_chunk")).toEqual(["kimchi_msg_0", "kimchi_msg_1"])
+	})
 })
 
 // Streaming tools (bash in particular) emit tool_execution_update with a

--- a/src/modes/acp/server.ts
+++ b/src/modes/acp/server.ts
@@ -124,6 +124,23 @@ type SessionRecord = {
 	session: AgentSession
 	unsubscribe: () => void
 	turn?: TurnContext
+	/**
+	 * Session-wide monotonic counter for ACP messageIds. Every distinct
+	 * content block (text or thinking) across every assistant message in
+	 * the session gets a fresh value — so two turns whose first text block
+	 * both sit at contentIndex=0 still get distinct ids, satisfying the
+	 * ACP contract "a change in messageId indicates a new message has
+	 * started" without depending on contentIndex (which resets per turn).
+	 * Seeded from the branch on loadSession so replay emits matching ids.
+	 */
+	nextBlockId: number
+	/**
+	 * Per-assistant-message map from pi-mono's contentIndex → assigned
+	 * messageId. Cleared on each agent_start so a new assistant message
+	 * starts a fresh contentIndex namespace without colliding with the
+	 * previous message's assignments.
+	 */
+	contentIndexToBlockId: Map<number, string>
 }
 
 export class KimchiAcpAgent implements Agent {
@@ -253,7 +270,12 @@ export class KimchiAcpAgent implements Agent {
 			await this.bindAcpExtensions(session, uiContext)
 
 			const unsubscribe = session.subscribe((event) => this.onSessionEvent(sessionId, event))
-			this.sessions.set(sessionId, { session, unsubscribe })
+			this.sessions.set(sessionId, {
+				session,
+				unsubscribe,
+				nextBlockId: 0,
+				contentIndexToBlockId: new Map(),
+			})
 
 			this.sendAvailableCommandsUpdate(sessionId)
 
@@ -416,7 +438,18 @@ export class KimchiAcpAgent implements Agent {
 			await this.bindAcpExtensions(session, uiContext)
 
 			const unsubscribe = session.subscribe((event) => this.onSessionEvent(sid, event))
-			this.sessions.set(sid, { session, unsubscribe })
+			const record: SessionRecord = {
+				session,
+				unsubscribe,
+				nextBlockId: 0,
+				contentIndexToBlockId: new Map(),
+			}
+			this.sessions.set(sid, record)
+
+			// Seed the block counter from the persisted branch so replay emits the
+			// same messageIds the live turn would have — and so any new block the
+			// user creates after the load gets a fresh, non-colliding id.
+			this.seedBlockCounterFromBranch(session, record)
 
 			// Replay BEFORE the response resolves so client sees a coherent transcript
 			// when the loadSession promise settles. No turn context is created, so a
@@ -605,28 +638,29 @@ export class KimchiAcpAgent implements Agent {
 		if (!entry) return
 		const turn = entry.turn
 		switch (event.type) {
-			case "agent_start": {
+			case "agent_start":
+			case "message_start": {
+				// New assistant message → contentIndex restarts from 0. Wipe the
+				// per-message map so a fresh block at index 0 gets a fresh id
+				// instead of inheriting the previous message's assignment.
+				entry.contentIndexToBlockId.clear()
 				return
 			}
 			case "message_update": {
 				if (!turn) return
 				const ame = event.assistantMessageEvent
-				if (ame.type === "text_delta" && ame.delta) {
+				if ((ame.type === "text_delta" || ame.type === "thinking_delta") && ame.delta) {
+					let messageId = entry.contentIndexToBlockId.get(ame.contentIndex)
+					if (messageId === undefined) {
+						messageId = `kimchi_msg_${entry.nextBlockId++}`
+						entry.contentIndexToBlockId.set(ame.contentIndex, messageId)
+					}
 					this.send({
 						sessionId,
 						update: {
-							sessionUpdate: "agent_message_chunk",
+							sessionUpdate: ame.type === "text_delta" ? "agent_message_chunk" : "agent_thought_chunk",
 							content: { type: "text", text: ame.delta },
-							messageId: `kimchi_msg_${ame.contentIndex}`,
-						},
-					})
-				} else if (ame.type === "thinking_delta" && ame.delta) {
-					this.send({
-						sessionId,
-						update: {
-							sessionUpdate: "agent_thought_chunk",
-							content: { type: "text", text: ame.delta },
-							messageId: `kimchi_msg_${ame.contentIndex}`,
+							messageId,
 						},
 					})
 				}
@@ -694,13 +728,6 @@ export class KimchiAcpAgent implements Agent {
 				})
 				return
 			}
-			case "agent_end": {
-				// No-op: turn finalization is driven by session.prompt()'s resolution
-				// in prompt(), NOT by agent_end. See comment in prompt() for the
-				// chained-agent.continue scenario. Just guard against stray agent_end
-				// events that arrive after the turn was finalized.
-				return
-			}
 			default:
 				return
 		}
@@ -741,10 +768,66 @@ export class KimchiAcpAgent implements Agent {
 					},
 				})
 			} else if (msg.role === "assistant") {
-				this.replayAssistantBlocks(sessionId, msg.content, toolResults, emitThinking)
+				this.replayAssistantBlocks(sessionId, msg.content, toolResults, emitThinking, this.sessions.get(sessionId))
 			}
 			// toolResult: handled inline alongside its originating toolCall above.
 		}
+	}
+
+	/**
+	 * Walk the persisted branch and count how many ACP content chunks the
+	 * replay would emit (text segments + dimmed text parts + non-redacted
+	 * thinking blocks). Sets `record.nextBlockId` so that:
+	 *   - replayTranscript emits the same messageIds a live turn would have
+	 *     for the historical blocks, and
+	 *   - any new block the user creates after the load gets a fresh, non-
+	 *     colliding id.
+	 *
+	 * Mirrors replayAssistantBlocks' emission logic exactly — coalescing
+	 * contiguous text blocks into one chunk, and gating thinking emission on
+	 * the hideThinkingBlock setting. If these drift, messageIds replayed
+	 * after a load won't line up with what the client saw during the live
+	 * turn.
+	 */
+	private seedBlockCounterFromBranch(session: AgentSession, record: SessionRecord): void {
+		const entries = session.sessionManager.getBranch()
+		const emitThinking = shouldEmitThinking("")
+
+		let count = 0
+		for (const entry of entries) {
+			if (!entry || entry.type !== "message" || entry.message.role !== "assistant") continue
+
+			let inTextSegment = false
+			const countTextSegment = () => {
+				if (!inTextSegment) {
+					count++
+					inTextSegment = true
+				}
+			}
+
+			const content = entry.message.content
+			for (const block of content) {
+				if (block.type === "text") {
+					if (!block.text) continue
+					countTextSegment()
+					if (emitThinking) {
+						for (const part of replayTextParts(block.text)) {
+							if (part.kind === "thinking") count++
+						}
+					}
+				} else if (block.type === "thinking") {
+					inTextSegment = false
+					if (!emitThinking || block.redacted || !block.thinking) continue
+					count++
+				} else {
+					// toolCall / unknown: replay flushes the text buffer before
+					// emitting the structural block, which terminates any open
+					// text segment.
+					inTextSegment = false
+				}
+			}
+		}
+		record.nextBlockId = count + 1
 	}
 
 	private replayAssistantBlocks(
@@ -752,8 +835,16 @@ export class KimchiAcpAgent implements Agent {
 		content: unknown,
 		toolResults: Map<string, ReplayToolResult>,
 		emitThinking: boolean,
+		record: SessionRecord | undefined,
 	): void {
 		if (!Array.isArray(content)) return
+		// Allocates a fresh session-unique messageId for every emitted chunk
+		// and leaves it off the wire if the SessionRecord isn't loaded (e.g.
+		// the unit-test harness wiring a partial replay path).
+		const nextMessageId = () => {
+			if (!record) return undefined
+			return `kimchi_msg_${record.nextBlockId++}`
+		}
 		// Buffer contiguous text blocks so a single assistant message renders as
 		// one agent_message_chunk per natural text segment — emit the full
 		// message as a single chunk, no per-token chunking. When a thinking or
@@ -762,11 +853,13 @@ export class KimchiAcpAgent implements Agent {
 		let textBuffer = ""
 		const flushText = () => {
 			if (textBuffer.length === 0) return
+			const messageId = nextMessageId()
 			this.send({
 				sessionId,
 				update: {
 					sessionUpdate: "agent_message_chunk",
 					content: { type: "text", text: textBuffer },
+					...(messageId !== undefined ? { messageId } : {}),
 				},
 			})
 			textBuffer = ""
@@ -782,11 +875,13 @@ export class KimchiAcpAgent implements Agent {
 						textBuffer += part.text
 					} else if (emitThinking) {
 						flushText()
+						const messageId = nextMessageId()
 						this.send({
 							sessionId,
 							update: {
 								sessionUpdate: "agent_thought_chunk",
 								content: { type: "text", text: part.text },
+								...(messageId !== undefined ? { messageId } : {}),
 							},
 						})
 					}
@@ -800,11 +895,13 @@ export class KimchiAcpAgent implements Agent {
 				if (redacted) continue
 				if (typeof thinking !== "string" || thinking.length === 0) continue
 				if (!emitThinking) continue
+				const messageId = nextMessageId()
 				this.send({
 					sessionId,
 					update: {
 						sessionUpdate: "agent_thought_chunk",
 						content: { type: "text", text: stripAnsi(thinking) },
+						...(messageId !== undefined ? { messageId } : {}),
 					},
 				})
 			} else if (b.type === "toolCall") {

--- a/src/modes/acp/server.ts
+++ b/src/modes/acp/server.ts
@@ -617,6 +617,7 @@ export class KimchiAcpAgent implements Agent {
 						update: {
 							sessionUpdate: "agent_message_chunk",
 							content: { type: "text", text: ame.delta },
+							messageId: `kimchi_msg_${ame.contentIndex}`,
 						},
 					})
 				} else if (ame.type === "thinking_delta" && ame.delta) {
@@ -625,6 +626,7 @@ export class KimchiAcpAgent implements Agent {
 						update: {
 							sessionUpdate: "agent_thought_chunk",
 							content: { type: "text", text: ame.delta },
+							messageId: `kimchi_msg_${ame.contentIndex}`,
 						},
 					})
 				}

--- a/src/modes/acp/server.ts
+++ b/src/modes/acp/server.ts
@@ -136,7 +136,7 @@ type SessionRecord = {
 	nextBlockId: number
 	/**
 	 * Per-assistant-message map from pi-mono's contentIndex → assigned
-	 * messageId. Cleared on each agent_start so a new assistant message
+	 * messageId. Cleared on each agent_start/message_start so a new assistant message
 	 * starts a fresh contentIndex namespace without colliding with the
 	 * previous message's assignments.
 	 */

--- a/tests/e2e/acp/message-id.test.ts
+++ b/tests/e2e/acp/message-id.test.ts
@@ -1,0 +1,76 @@
+// ACP integration: stable `messageId` across chunks within a content block.
+//
+// ACP's ContentChunk contract (node_modules/@agentclientprotocol/sdk/dist/
+// schema/types.gen.d.ts ~870) says: "All chunks belonging to the same
+// message share the same messageId. A change in messageId indicates a new
+// message has started." pi-mono streams a content block as multiple
+// text_delta / thinking_delta events that share the block's contentIndex, so
+// the ACP server can collapse them onto a single messageId without
+// coordinating across events. This test drives a real binary end-to-end and
+// asserts the contract on the wire shape the client observes.
+//
+// Note: the fixture loads test-ui-extension.js, which exercises fire-and-
+// forget UI methods (notify / setStatus / setWidget). Because this test
+// doesn't advertise the corresponding `_kimchi.dev/pi_*` client capabilities,
+// the harness emits `[ACP]` warning chunks as a fallback. Those go through a
+// different code path than LLM-streamed deltas (so they have no messageId),
+// and `isAcpWarning` filters them out so the assertion is only on streamed
+// chunks.
+
+import type { ContentChunk } from "@agentclientprotocol/sdk"
+import { afterEach, beforeEach, describe, expect, it } from "vitest"
+import { type AcpFixture, STARTUP_TIMEOUT_MS, startAcpFixture } from "./support/acp-fixture.js"
+import { newSession, prompt } from "./support/scenarios.js"
+
+/** True for `[ACP]` UI fallback warnings, which come from a non-streaming code path. */
+function isAcpWarning(update: ContentChunk): boolean {
+	return update.content?.type === "text" && (update.content.text?.startsWith("[ACP]") ?? false)
+}
+
+describe("ACP integration — messageId stability across chunks", () => {
+	let fixture: AcpFixture
+
+	beforeEach(async () => {
+		// Script streams thinking then text in many small chunks so pi-mono
+		// emits several deltas per content block rather than coalescing.
+		fixture = await startAcpFixture({
+			artifactName: "message-id",
+			responses: [
+				{
+					thinking: ["Hmm, ", "let me ", "think ", "about ", "this."],
+					stream: ["Sure, ", "here is ", "the ", "answer."],
+				},
+			],
+		})
+	}, STARTUP_TIMEOUT_MS)
+
+	afterEach(async () => {
+		await fixture.stop()
+	})
+
+	it("shares one messageId per block and uses a distinct messageId across blocks", async () => {
+		const sessionId = await newSession(fixture, fixture.workDir)
+		const result = await prompt(fixture, sessionId, "Answer with a short sentence")
+		expect(result.stopReason, "turn stop reason").toBe("end_turn")
+		expect(result.chunks, "streamed text reached the client").toContain("answer")
+
+		const streamedIds = (sessionUpdate: string): Array<string | null | undefined> =>
+			fixture.client.sessionUpdates
+				.filter(
+					(u) =>
+						u.sessionId === sessionId &&
+						u.update.sessionUpdate === sessionUpdate &&
+						!isAcpWarning(u.update as ContentChunk),
+				)
+				.map((u) => (u.update as ContentChunk).messageId)
+
+		const thoughtIds = streamedIds("agent_thought_chunk")
+		const textIds = streamedIds("agent_message_chunk")
+
+		expect(thoughtIds.length, "thought block streamed multiple chunks").toBeGreaterThanOrEqual(2)
+		expect(textIds.length, "text block streamed multiple chunks").toBeGreaterThanOrEqual(2)
+		expect(new Set(thoughtIds).size, "all thought chunks share one messageId").toBe(1)
+		expect(new Set(textIds).size, "all text chunks share one messageId").toBe(1)
+		expect(thoughtIds[0], "thought and text blocks carry distinct messageIds").not.toBe(textIds[0])
+	})
+})

--- a/tests/e2e/acp/message-id.test.ts
+++ b/tests/e2e/acp/message-id.test.ts
@@ -74,3 +74,68 @@ describe("ACP integration — messageId stability across chunks", () => {
 		expect(thoughtIds[0], "thought and text blocks carry distinct messageIds").not.toBe(textIds[0])
 	})
 })
+
+// Regression guard for the in-turn message boundary bug: a single turn can
+// produce multiple assistant messages (e.g. thinking → text → toolCall → new
+// message → thinking). Without message_start clearing the per-message
+// contentIndex map, the second thinking block at contentIndex=0 would inherit
+// the first thinking block's messageId and a client would merge two separate
+// "thinking" bubbles.
+describe("ACP integration — messageId across assistant message boundaries within one turn", () => {
+	let fixture: AcpFixture
+
+	beforeEach(async () => {
+		fixture = await startAcpFixture({
+			artifactName: "message-id-multi-message",
+			responses: [
+				// First assistant message: thinking + text + toolCall. `echo` is
+				// in the read-only bash allowlist so it auto-approves (no
+				// request_permission round-trip needed).
+				{
+					thinking: ["First ", "think"],
+					stream: ["Calling echo. "],
+					toolCalls: [
+						{
+							function: {
+								name: "bash",
+								arguments: JSON.stringify({ command: "echo hi" }),
+							},
+						},
+					],
+				},
+				// Second assistant message: another thinking block + text, after
+				// the tool result is fed back to the model.
+				{
+					thinking: ["Second ", "think"],
+					stream: ["Done."],
+				},
+			],
+		})
+	}, STARTUP_TIMEOUT_MS)
+
+	afterEach(async () => {
+		await fixture.stop()
+	})
+
+	it("uses a fresh messageId for the second assistant message's thinking block", async () => {
+		const sessionId = await newSession(fixture, fixture.workDir)
+		const result = await prompt(fixture, sessionId, "Run echo and continue")
+		expect(result.stopReason, "turn stop reason").toBe("end_turn")
+		expect(result.chunks, "second message text reached the client").toContain("Done")
+
+		const thoughtIds = fixture.client.sessionUpdates
+			.filter(
+				(u) =>
+					u.sessionId === sessionId &&
+					u.update.sessionUpdate === "agent_thought_chunk" &&
+					!isAcpWarning(u.update as ContentChunk),
+			)
+			.map((u) => (u.update as ContentChunk).messageId)
+
+		// Two assistant messages in one turn = two thought blocks at
+		// contentIndex=0 = two distinct messageIds. The pre-fix bug had both
+		// blocks sharing the same id.
+		expect(thoughtIds.length, "two thought blocks streamed across two messages").toBeGreaterThanOrEqual(2)
+		expect(new Set(thoughtIds).size, "second thinking block has a distinct messageId from the first").toBe(2)
+	})
+})


### PR DESCRIPTION
## What does this PR do?

Adds a `messageId` property to the streamed agent message and agent thought chunks in ACP mode based on Pi's `contentIndex`, to correctly identify blocks that these chunks belong to.

This will allow clients to display streamed messages in their corresponding blocks.

References:
* ACP v1 messageIds: https://agentclientprotocol.com/protocol/v1/prompt-turn#message-ids
* ACP v2 RFD: https://agentclientprotocol.com/rfds/v2/message-updates (not yet implemented - we're currently working with v1 chunks only)

## Linked issue

LLM-2388

Closes #0

## Checklist

- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md) and agree to the CLA
- [x] This PR links to an open issue above
- [x] Tests pass locally (`pnpm run test`)
- [x] Lint passes (`pnpm run check`)
- [x] Documentation updated if behavior changed
