### PR TITLE
fix(acp,questionnaire): render choices as structured elicitation

### DIFF
--- a/src/extensions/questionnaire/questionnaire-fallback.test.ts
+++ b/src/extensions/questionnaire/questionnaire-fallback.test.ts
@@ -1,5 +1,6 @@
 import type { ExtensionUIContext } from "@earendil-works/pi-coding-agent"
 import { describe, expect, it, vi } from "vitest"
+import { ACP_ELICIT_FORM, type AcpElicitForm } from "../../modes/acp/structured-elicitation.js"
 import { parseMultipleChoiceInput, promptQuestionnaireFallback } from "./questionnaire-fallback.js"
 import { type Question, type QuestionOption, YES_NO_OPTIONS } from "./questionnaire-reducer.js"
 
@@ -29,6 +30,79 @@ function makeUI(handlers: UIHandlers): ExtensionUIContext {
 		confirm: handlers.confirm,
 		select: handlers.select,
 	} as unknown as ExtensionUIContext
+}
+
+type AcpResponse = Awaited<ReturnType<AcpElicitForm>>
+type QuestionInput = Partial<Question> & Pick<Question, "id" | "prompt" | "type">
+
+function acpSingleChoiceSchema() {
+	return {
+		type: "object",
+		properties: {
+			value: {
+				type: "string",
+				oneOf: [
+					{ const: "a", title: "Alpha" },
+					{ const: "b", title: "Beta" },
+					{ const: "c", title: "Gamma" },
+				],
+			},
+		},
+		required: ["value"],
+	}
+}
+
+function acpMultiChoiceSchema() {
+	return {
+		type: "object",
+		properties: {
+			value: {
+				type: "array",
+				items: {
+					anyOf: [
+						{ const: "a", title: "Alpha" },
+						{ const: "b", title: "Beta" },
+						{ const: "c", title: "Gamma" },
+					],
+				},
+				minItems: 1,
+			},
+		},
+		required: ["value"],
+	}
+}
+
+function acpTextSchema() {
+	return {
+		type: "object",
+		properties: {
+			value: {
+				type: "string",
+			},
+		},
+		required: ["value"],
+	}
+}
+
+function makeAcpUI(elicitResponse: AcpResponse, inputResponse: string | undefined = "should not be called") {
+	const inputSpy = vi.fn(async () => inputResponse)
+	const elicitSpy = vi.fn<AcpElicitForm>(async () => elicitResponse)
+	const ui = {
+		input: inputSpy,
+		[ACP_ELICIT_FORM]: elicitSpy,
+	} as unknown as ExtensionUIContext
+
+	return { ui, inputSpy, elicitSpy }
+}
+
+async function runAcpQuestionnaire(
+	question: QuestionInput,
+	elicitResponse: AcpResponse,
+	inputResponse?: string | undefined,
+) {
+	const { ui, inputSpy, elicitSpy } = makeAcpUI(elicitResponse, inputResponse)
+	const result = await promptQuestionnaireFallback(ui, [makeQuestion(question)])
+	return { result, inputSpy, elicitSpy }
 }
 
 // ─── text type ────────────────────────────────────────────────────────────────
@@ -417,6 +491,260 @@ describe("promptQuestionnaireFallback — multi type", () => {
 				wasCustom: false,
 			},
 		])
+	})
+})
+
+describe("promptQuestionnaireFallback — ACP structured choices", () => {
+	const options = [
+		{ id: "a", label: "Alpha" },
+		{ id: "b", label: "Beta" },
+		{ id: "c", label: "Gamma" },
+	]
+
+	function acpSingleQuestion(overrides: Partial<QuestionInput> = {}): QuestionInput {
+		return {
+			id: "scope",
+			type: "single",
+			prompt: "Pick scope",
+			options,
+			...overrides,
+		}
+	}
+
+	function acpMultiQuestion(overrides: Partial<QuestionInput> = {}): QuestionInput {
+		return {
+			id: "features",
+			type: "multi",
+			prompt: "Pick features",
+			options,
+			...overrides,
+		}
+	}
+
+	it("uses ACP single-choice elicitation and records the selected option", async () => {
+		const { result, inputSpy, elicitSpy } = await runAcpQuestionnaire(acpSingleQuestion({ allowOther: false }), {
+			value: "b",
+		})
+
+		expect(inputSpy).not.toHaveBeenCalled()
+		expect(elicitSpy).toHaveBeenCalledOnce()
+		expect(elicitSpy.mock.calls[0][2]).toEqual(acpSingleChoiceSchema())
+		expect(result.answers).toEqual([
+			{
+				id: "scope",
+				index: 2,
+				label: "Beta",
+				value: "b",
+				wasCustom: false,
+			},
+		])
+	})
+
+	it("asks for free text after ACP single-choice chooses Other", async () => {
+		const { result, inputSpy } = await runAcpQuestionnaire(
+			acpSingleQuestion({ allowOther: true }),
+			{ value: "__other__" },
+			"Custom answer",
+		)
+
+		expect(inputSpy).toHaveBeenCalledWith("Pick scope\n\nYour answer:")
+		expect(result.answers).toEqual([
+			{
+				id: "scope",
+				index: 4,
+				label: "Custom answer",
+				value: "Custom answer",
+				wasCustom: true,
+			},
+		])
+	})
+
+	it("does not ask for free text when ACP single-choice allowOther selects a normal option", async () => {
+		const { result, inputSpy } = await runAcpQuestionnaire(acpSingleQuestion({ allowOther: true }), { value: "a" })
+
+		expect(inputSpy).not.toHaveBeenCalled()
+		expect(result.answers).toEqual([
+			{
+				id: "scope",
+				index: 1,
+				label: "Alpha",
+				value: "a",
+				wasCustom: false,
+			},
+		])
+	})
+
+	it("uses ACP array elicitation for multi-select choices instead of free-text input", async () => {
+		const { result, inputSpy, elicitSpy } = await runAcpQuestionnaire(acpMultiQuestion(), { value: ["a", "c"] })
+
+		expect(inputSpy).not.toHaveBeenCalled()
+		expect(elicitSpy).toHaveBeenCalledOnce()
+		expect(elicitSpy.mock.calls[0][2]).toEqual(acpMultiChoiceSchema())
+		expect(result.answers).toEqual([
+			{
+				id: "features",
+				indices: [1, 3],
+				label: "Alpha, Gamma",
+				labels: ["Alpha", "Gamma"],
+				value: "a, c",
+				values: ["a", "c"],
+				wasCustom: false,
+			},
+		])
+	})
+
+	it("asks for free text only after ACP multi-select chooses Other", async () => {
+		const { result, inputSpy } = await runAcpQuestionnaire(
+			acpMultiQuestion({ allowOther: true }),
+			{ value: ["a", "__other__"] },
+			"Custom answer",
+		)
+
+		expect(inputSpy).toHaveBeenCalledWith("Pick features\n\nYour answer:")
+		expect(result.answers).toEqual([
+			{
+				id: "features",
+				indices: [1, 4],
+				label: "Alpha, Custom answer",
+				labels: ["Alpha", "Custom answer"],
+				value: "a, Custom answer",
+				values: ["a", "Custom answer"],
+				wasCustom: true,
+			},
+		])
+	})
+
+	it("does not ask for free text when ACP multi-select allowOther selects only normal options", async () => {
+		const { result, inputSpy } = await runAcpQuestionnaire(acpMultiQuestion({ allowOther: true }), {
+			value: ["a", "c"],
+		})
+
+		expect(inputSpy).not.toHaveBeenCalled()
+		expect(result.answers).toEqual([
+			{
+				id: "features",
+				indices: [1, 3],
+				label: "Alpha, Gamma",
+				labels: ["Alpha", "Gamma"],
+				value: "a, c",
+				values: ["a", "c"],
+				wasCustom: false,
+			},
+		])
+	})
+
+	it("uses one ACP text elicitation when single-select has only free-form input", async () => {
+		const { result, inputSpy, elicitSpy } = await runAcpQuestionnaire(
+			acpSingleQuestion({
+				prompt: "Describe the scope",
+				options: [],
+				allowOther: true,
+			}),
+			{ value: "Custom answer" },
+		)
+
+		expect(inputSpy).not.toHaveBeenCalled()
+		expect(elicitSpy).toHaveBeenCalledOnce()
+		expect(elicitSpy.mock.calls[0][2]).toEqual(acpTextSchema())
+		expect(result.answers).toEqual([
+			{
+				id: "scope",
+				index: 1,
+				label: "Custom answer",
+				value: "Custom answer",
+				wasCustom: true,
+			},
+		])
+	})
+
+	it("uses one ACP text elicitation when multi-select has only free-form input", async () => {
+		const { result, inputSpy, elicitSpy } = await runAcpQuestionnaire(
+			acpMultiQuestion({
+				prompt: "Describe the features",
+				options: [],
+				allowOther: true,
+			}),
+			{ value: "Custom answer" },
+		)
+
+		expect(inputSpy).not.toHaveBeenCalled()
+		expect(elicitSpy).toHaveBeenCalledOnce()
+		expect(elicitSpy.mock.calls[0][2]).toEqual(acpTextSchema())
+		expect(result.answers).toEqual([
+			{
+				id: "features",
+				indices: [1],
+				label: "Custom answer",
+				labels: ["Custom answer"],
+				value: "Custom answer",
+				values: ["Custom answer"],
+				wasCustom: true,
+			},
+		])
+	})
+
+	it("cancels required ACP single-choice when the structured elicitation is dismissed", async () => {
+		const { result } = await runAcpQuestionnaire(acpSingleQuestion(), undefined)
+
+		expect(result.cancelled).toBe(true)
+		expect(result.answers).toEqual([])
+	})
+
+	it("cancels required ACP multi-select when the structured elicitation aborts", async () => {
+		const { result } = await runAcpQuestionnaire(acpMultiQuestion(), "aborted")
+
+		expect(result.cancelled).toBe(true)
+		expect(result.answers).toEqual([])
+	})
+
+	it("skips optional ACP questions when the structured elicitation is dismissed", async () => {
+		const elicitSpy = vi.fn<AcpElicitForm>(async () => undefined)
+		const ui = {
+			[ACP_ELICIT_FORM]: elicitSpy,
+		} as unknown as ExtensionUIContext
+
+		const result = await promptQuestionnaireFallback(ui, [
+			makeQuestion(acpSingleQuestion({ required: false })),
+			makeQuestion(acpMultiQuestion({ required: false })),
+		])
+
+		expect(result.cancelled).toBe(false)
+		expect(result.answers).toEqual([])
+		expect(elicitSpy).toHaveBeenCalledTimes(2)
+	})
+
+	it("drops empty multi-select Other text when normal ACP choices remain", async () => {
+		const { result, inputSpy } = await runAcpQuestionnaire(
+			acpMultiQuestion({ allowOther: true }),
+			{ value: ["a", "__other__"] },
+			"",
+		)
+
+		expect(inputSpy).toHaveBeenCalledWith("Pick features\n\nYour answer:")
+		expect(result.cancelled).toBe(false)
+		expect(result.answers).toEqual([
+			{
+				id: "features",
+				indices: [1],
+				label: "Alpha",
+				labels: ["Alpha"],
+				value: "a",
+				values: ["a"],
+				wasCustom: false,
+			},
+		])
+	})
+
+	it("cancels required multi-select when empty Other text leaves no ACP choices", async () => {
+		const { result, inputSpy } = await runAcpQuestionnaire(
+			acpMultiQuestion({ allowOther: true }),
+			{ value: ["__other__"] },
+			"",
+		)
+
+		expect(inputSpy).toHaveBeenCalledWith("Pick features\n\nYour answer:")
+		expect(result.cancelled).toBe(true)
+		expect(result.answers).toEqual([])
 	})
 })
 

--- a/src/extensions/questionnaire/questionnaire-fallback.test.ts
+++ b/src/extensions/questionnaire/questionnaire-fallback.test.ts
@@ -1,6 +1,11 @@
 import type { ExtensionUIContext } from "@earendil-works/pi-coding-agent"
 import { describe, expect, it, vi } from "vitest"
-import { ACP_ELICIT_FORM, type AcpElicitForm } from "../../modes/acp/structured-elicitation.js"
+import {
+	ACP_ELICIT_FORM,
+	type AcpElicitForm,
+	choiceSchema,
+	freeTextSchema,
+} from "../../modes/acp/structured-elicitation.js"
 import { parseMultipleChoiceInput, promptQuestionnaireFallback } from "./questionnaire-fallback.js"
 import { type Question, type QuestionOption, YES_NO_OPTIONS } from "./questionnaire-reducer.js"
 
@@ -34,55 +39,6 @@ function makeUI(handlers: UIHandlers): ExtensionUIContext {
 
 type AcpResponse = Awaited<ReturnType<AcpElicitForm>>
 type QuestionInput = Partial<Question> & Pick<Question, "id" | "prompt" | "type">
-
-function acpSingleChoiceSchema() {
-	return {
-		type: "object",
-		properties: {
-			value: {
-				type: "string",
-				oneOf: [
-					{ const: "a", title: "Alpha" },
-					{ const: "b", title: "Beta" },
-					{ const: "c", title: "Gamma" },
-				],
-			},
-		},
-		required: ["value"],
-	}
-}
-
-function acpMultiChoiceSchema() {
-	return {
-		type: "object",
-		properties: {
-			value: {
-				type: "array",
-				items: {
-					anyOf: [
-						{ const: "a", title: "Alpha" },
-						{ const: "b", title: "Beta" },
-						{ const: "c", title: "Gamma" },
-					],
-				},
-				minItems: 1,
-			},
-		},
-		required: ["value"],
-	}
-}
-
-function acpTextSchema() {
-	return {
-		type: "object",
-		properties: {
-			value: {
-				type: "string",
-			},
-		},
-		required: ["value"],
-	}
-}
 
 function makeAcpUI(elicitResponse: AcpResponse, inputResponse: string | undefined = "should not be called") {
 	const inputSpy = vi.fn(async () => inputResponse)
@@ -528,7 +484,7 @@ describe("promptQuestionnaireFallback — ACP structured choices", () => {
 
 		expect(inputSpy).not.toHaveBeenCalled()
 		expect(elicitSpy).toHaveBeenCalledOnce()
-		expect(elicitSpy.mock.calls[0][2]).toEqual(acpSingleChoiceSchema())
+		expect(elicitSpy.mock.calls[0][2]).toEqual(choiceSchema(options, true, false))
 		expect(result.answers).toEqual([
 			{
 				id: "scope",
@@ -559,27 +515,12 @@ describe("promptQuestionnaireFallback — ACP structured choices", () => {
 		])
 	})
 
-	it("does not ask for free text when ACP single-choice allowOther selects a normal option", async () => {
-		const { result, inputSpy } = await runAcpQuestionnaire(acpSingleQuestion({ allowOther: true }), { value: "a" })
-
-		expect(inputSpy).not.toHaveBeenCalled()
-		expect(result.answers).toEqual([
-			{
-				id: "scope",
-				index: 1,
-				label: "Alpha",
-				value: "a",
-				wasCustom: false,
-			},
-		])
-	})
-
 	it("uses ACP array elicitation for multi-select choices instead of free-text input", async () => {
 		const { result, inputSpy, elicitSpy } = await runAcpQuestionnaire(acpMultiQuestion(), { value: ["a", "c"] })
 
 		expect(inputSpy).not.toHaveBeenCalled()
 		expect(elicitSpy).toHaveBeenCalledOnce()
-		expect(elicitSpy.mock.calls[0][2]).toEqual(acpMultiChoiceSchema())
+		expect(elicitSpy.mock.calls[0][2]).toEqual(choiceSchema(options, true, true))
 		expect(result.answers).toEqual([
 			{
 				id: "features",
@@ -614,25 +555,6 @@ describe("promptQuestionnaireFallback — ACP structured choices", () => {
 		])
 	})
 
-	it("does not ask for free text when ACP multi-select allowOther selects only normal options", async () => {
-		const { result, inputSpy } = await runAcpQuestionnaire(acpMultiQuestion({ allowOther: true }), {
-			value: ["a", "c"],
-		})
-
-		expect(inputSpy).not.toHaveBeenCalled()
-		expect(result.answers).toEqual([
-			{
-				id: "features",
-				indices: [1, 3],
-				label: "Alpha, Gamma",
-				labels: ["Alpha", "Gamma"],
-				value: "a, c",
-				values: ["a", "c"],
-				wasCustom: false,
-			},
-		])
-	})
-
 	it("uses one ACP text elicitation when single-select has only free-form input", async () => {
 		const { result, inputSpy, elicitSpy } = await runAcpQuestionnaire(
 			acpSingleQuestion({
@@ -645,7 +567,7 @@ describe("promptQuestionnaireFallback — ACP structured choices", () => {
 
 		expect(inputSpy).not.toHaveBeenCalled()
 		expect(elicitSpy).toHaveBeenCalledOnce()
-		expect(elicitSpy.mock.calls[0][2]).toEqual(acpTextSchema())
+		expect(elicitSpy.mock.calls[0][2]).toEqual(freeTextSchema(true))
 		expect(result.answers).toEqual([
 			{
 				id: "scope",
@@ -669,7 +591,7 @@ describe("promptQuestionnaireFallback — ACP structured choices", () => {
 
 		expect(inputSpy).not.toHaveBeenCalled()
 		expect(elicitSpy).toHaveBeenCalledOnce()
-		expect(elicitSpy.mock.calls[0][2]).toEqual(acpTextSchema())
+		expect(elicitSpy.mock.calls[0][2]).toEqual(freeTextSchema(true))
 		expect(result.answers).toEqual([
 			{
 				id: "features",

--- a/src/extensions/questionnaire/questionnaire-fallback.test.ts
+++ b/src/extensions/questionnaire/questionnaire-fallback.test.ts
@@ -38,11 +38,13 @@ function makeUI(handlers: UIHandlers): ExtensionUIContext {
 }
 
 type AcpResponse = Awaited<ReturnType<AcpElicitForm>>
+type AcpResponseInput = AcpResponse | AcpResponse[]
 type QuestionInput = Partial<Question> & Pick<Question, "id" | "prompt" | "type">
 
-function makeAcpUI(elicitResponse: AcpResponse, inputResponse: string | undefined = "should not be called") {
+function makeAcpUI(elicitResponse: AcpResponseInput, inputResponse: string | undefined = "should not be called") {
 	const inputSpy = vi.fn(async () => inputResponse)
-	const elicitSpy = vi.fn<AcpElicitForm>(async () => elicitResponse)
+	const responses = Array.isArray(elicitResponse) ? [...elicitResponse] : [elicitResponse]
+	const elicitSpy = vi.fn<AcpElicitForm>(async () => responses.shift())
 	const ui = {
 		input: inputSpy,
 		[ACP_ELICIT_FORM]: elicitSpy,
@@ -53,7 +55,7 @@ function makeAcpUI(elicitResponse: AcpResponse, inputResponse: string | undefine
 
 async function runAcpQuestionnaire(
 	question: QuestionInput,
-	elicitResponse: AcpResponse,
+	elicitResponse: AcpResponseInput,
 	inputResponse?: string | undefined,
 ) {
 	const { ui, inputSpy, elicitSpy } = makeAcpUI(elicitResponse, inputResponse)
@@ -497,13 +499,14 @@ describe("promptQuestionnaireFallback — ACP structured choices", () => {
 	})
 
 	it("asks for free text after ACP single-choice chooses Other", async () => {
-		const { result, inputSpy } = await runAcpQuestionnaire(
-			acpSingleQuestion({ allowOther: true }),
+		const { result, inputSpy, elicitSpy } = await runAcpQuestionnaire(acpSingleQuestion({ allowOther: true }), [
 			{ value: "__other__" },
-			"Custom answer",
-		)
+			{ value: "Custom answer" },
+		])
 
-		expect(inputSpy).toHaveBeenCalledWith("Pick scope\n\nYour answer:")
+		expect(inputSpy).not.toHaveBeenCalled()
+		expect(elicitSpy).toHaveBeenCalledTimes(2)
+		expect(elicitSpy.mock.calls[1]).toEqual(["Pick scope\n\nYour answer:", undefined, freeTextSchema(true), undefined])
 		expect(result.answers).toEqual([
 			{
 				id: "scope",
@@ -535,13 +538,19 @@ describe("promptQuestionnaireFallback — ACP structured choices", () => {
 	})
 
 	it("asks for free text only after ACP multi-select chooses Other", async () => {
-		const { result, inputSpy } = await runAcpQuestionnaire(
-			acpMultiQuestion({ allowOther: true }),
+		const { result, inputSpy, elicitSpy } = await runAcpQuestionnaire(acpMultiQuestion({ allowOther: true }), [
 			{ value: ["a", "__other__"] },
-			"Custom answer",
-		)
+			{ value: "Custom answer" },
+		])
 
-		expect(inputSpy).toHaveBeenCalledWith("Pick features\n\nYour answer:")
+		expect(inputSpy).not.toHaveBeenCalled()
+		expect(elicitSpy).toHaveBeenCalledTimes(2)
+		expect(elicitSpy.mock.calls[1]).toEqual([
+			"Pick features\n\nYour answer:",
+			undefined,
+			freeTextSchema(false),
+			undefined,
+		])
 		expect(result.answers).toEqual([
 			{
 				id: "features",
@@ -636,13 +645,19 @@ describe("promptQuestionnaireFallback — ACP structured choices", () => {
 	})
 
 	it("drops empty multi-select Other text when normal ACP choices remain", async () => {
-		const { result, inputSpy } = await runAcpQuestionnaire(
-			acpMultiQuestion({ allowOther: true }),
+		const { result, inputSpy, elicitSpy } = await runAcpQuestionnaire(acpMultiQuestion({ allowOther: true }), [
 			{ value: ["a", "__other__"] },
-			"",
-		)
+			{ value: "" },
+		])
 
-		expect(inputSpy).toHaveBeenCalledWith("Pick features\n\nYour answer:")
+		expect(inputSpy).not.toHaveBeenCalled()
+		expect(elicitSpy).toHaveBeenCalledTimes(2)
+		expect(elicitSpy.mock.calls[1]).toEqual([
+			"Pick features\n\nYour answer:",
+			undefined,
+			freeTextSchema(false),
+			undefined,
+		])
 		expect(result.cancelled).toBe(false)
 		expect(result.answers).toEqual([
 			{
@@ -658,13 +673,19 @@ describe("promptQuestionnaireFallback — ACP structured choices", () => {
 	})
 
 	it("cancels required multi-select when empty Other text leaves no ACP choices", async () => {
-		const { result, inputSpy } = await runAcpQuestionnaire(
-			acpMultiQuestion({ allowOther: true }),
+		const { result, inputSpy, elicitSpy } = await runAcpQuestionnaire(acpMultiQuestion({ allowOther: true }), [
 			{ value: ["__other__"] },
-			"",
-		)
+			{ value: "" },
+		])
 
-		expect(inputSpy).toHaveBeenCalledWith("Pick features\n\nYour answer:")
+		expect(inputSpy).not.toHaveBeenCalled()
+		expect(elicitSpy).toHaveBeenCalledTimes(2)
+		expect(elicitSpy.mock.calls[1]).toEqual([
+			"Pick features\n\nYour answer:",
+			undefined,
+			freeTextSchema(false),
+			undefined,
+		])
 		expect(result.cancelled).toBe(true)
 		expect(result.answers).toEqual([])
 	})

--- a/src/extensions/questionnaire/questionnaire-fallback.ts
+++ b/src/extensions/questionnaire/questionnaire-fallback.ts
@@ -1,6 +1,10 @@
-import type { ElicitationSchema } from "@agentclientprotocol/sdk"
 import type { ExtensionUIContext } from "@earendil-works/pi-coding-agent"
-import { type AcpElicitForm, getAcpElicitForm } from "../../modes/acp/structured-elicitation.js"
+import {
+	type AcpElicitForm,
+	choiceSchema,
+	freeTextSchema,
+	getAcpElicitForm,
+} from "../../modes/acp/structured-elicitation.js"
 import { CUSTOM_OPTION_ID, CUSTOM_OPTION_LABEL } from "./constants.js"
 import type { Answer, Question, QuestionOption } from "./questionnaire-reducer.js"
 
@@ -257,39 +261,6 @@ function optionsForQuestion(question: Question): QuestionOption[] {
 		})
 	}
 	return options
-}
-
-function choiceSchema(options: QuestionOption[], required: boolean, multi: boolean): ElicitationSchema {
-	return {
-		type: "object",
-		properties: {
-			value: multi
-				? {
-						type: "array",
-						items: {
-							anyOf: options.map((option) => ({ const: option.id, title: option.label })),
-						},
-						...(required ? { minItems: 1 } : {}),
-					}
-				: {
-						type: "string",
-						oneOf: options.map((option) => ({ const: option.id, title: option.label })),
-					},
-		},
-		required: required ? ["value"] : [],
-	}
-}
-
-function freeTextSchema(required: boolean): ElicitationSchema {
-	return {
-		type: "object",
-		properties: {
-			value: {
-				type: "string",
-			},
-		},
-		required: required ? ["value"] : [],
-	}
 }
 
 async function promptAcpFreeTextAnswer(

--- a/src/extensions/questionnaire/questionnaire-fallback.ts
+++ b/src/extensions/questionnaire/questionnaire-fallback.ts
@@ -137,7 +137,7 @@ export async function promptQuestionnaireFallback(
 			}
 			case "single": {
 				if (acpElicitForm) {
-					const answer = await promptAcpSingleChoice(ui, acpElicitForm, question, questionText)
+					const answer = await promptAcpSingleChoice(acpElicitForm, question, questionText)
 					if (answer === "cancelled") return { questions, answers, cancelled: true }
 					if (answer) answers.push(answer)
 					continue
@@ -185,7 +185,7 @@ export async function promptQuestionnaireFallback(
 			}
 			case "multi": {
 				if (acpElicitForm) {
-					const answer = await promptAcpMultiChoice(ui, acpElicitForm, question, questionText)
+					const answer = await promptAcpMultiChoice(acpElicitForm, question, questionText)
 					if (answer === "cancelled") return { questions, answers, cancelled: true }
 					if (answer) answers.push(answer)
 					continue
@@ -297,8 +297,21 @@ async function promptAcpFreeTextAnswer(
 	}
 }
 
+async function promptAcpCustomText(
+	elicitForm: AcpElicitForm,
+	question: Question,
+	questionText: string,
+	required: boolean,
+): Promise<string | "cancelled" | undefined> {
+	const response = await elicitForm(`${questionText}\n\nYour answer:`, undefined, freeTextSchema(required), undefined)
+	if (response === "aborted" || response === undefined) return required ? "cancelled" : undefined
+
+	const value = response.value
+	if (typeof value !== "string" || !value) return required ? "cancelled" : undefined
+	return value
+}
+
 async function promptAcpSingleChoice(
-	ui: ExtensionUIContext,
 	elicitForm: AcpElicitForm,
 	question: Question,
 	questionText: string,
@@ -319,8 +332,8 @@ async function promptAcpSingleChoice(
 	if (!option) return question.required ? "cancelled" : undefined
 
 	if (option.id === CUSTOM_OPTION_ID) {
-		const custom = await ui.input(`${questionText}\n\nYour answer:`)
-		if (!custom && question.required) return "cancelled"
+		const custom = await promptAcpCustomText(elicitForm, question, questionText, question.required)
+		if (custom === "cancelled") return "cancelled"
 		if (!custom) return undefined
 		return {
 			id: question.id,
@@ -341,7 +354,6 @@ async function promptAcpSingleChoice(
 }
 
 async function promptAcpMultiChoice(
-	ui: ExtensionUIContext,
 	elicitForm: AcpElicitForm,
 	question: Question,
 	questionText: string,
@@ -366,7 +378,7 @@ async function promptAcpMultiChoice(
 		if (!option) continue
 
 		if (option.id === CUSTOM_OPTION_ID) {
-			const custom = await ui.input(`${questionText}\n\nYour answer:`)
+			const custom = await promptAcpCustomText(elicitForm, question, questionText, false)
 			if (custom) {
 				choices.push({
 					id: CUSTOM_OPTION_ID,

--- a/src/extensions/questionnaire/questionnaire-fallback.ts
+++ b/src/extensions/questionnaire/questionnaire-fallback.ts
@@ -1,4 +1,6 @@
+import type { ElicitationSchema } from "@agentclientprotocol/sdk"
 import type { ExtensionUIContext } from "@earendil-works/pi-coding-agent"
+import { type AcpElicitForm, getAcpElicitForm } from "../../modes/acp/structured-elicitation.js"
 import { CUSTOM_OPTION_ID, CUSTOM_OPTION_LABEL } from "./constants.js"
 import type { Answer, Question, QuestionOption } from "./questionnaire-reducer.js"
 
@@ -99,6 +101,7 @@ export async function promptQuestionnaireFallback(
 	questions: Question[],
 ): Promise<QuestionnaireResult> {
 	const answers: Answer[] = []
+	const acpElicitForm = getAcpElicitForm(ui)
 
 	for (const question of questions) {
 		const questionText = question.prompt
@@ -129,6 +132,13 @@ export async function promptQuestionnaireFallback(
 				continue
 			}
 			case "single": {
+				if (acpElicitForm) {
+					const answer = await promptAcpSingleChoice(ui, acpElicitForm, question, questionText)
+					if (answer === "cancelled") return { questions, answers, cancelled: true }
+					if (answer) answers.push(answer)
+					continue
+				}
+
 				const options = [...question.options]
 				if (question.allowOther) {
 					options.push({
@@ -170,6 +180,13 @@ export async function promptQuestionnaireFallback(
 				continue
 			}
 			case "multi": {
+				if (acpElicitForm) {
+					const answer = await promptAcpMultiChoice(ui, acpElicitForm, question, questionText)
+					if (answer === "cancelled") return { questions, answers, cancelled: true }
+					if (answer) answers.push(answer)
+					continue
+				}
+
 				let customOption: QuestionOption
 				const options = [...question.options]
 				if (question.allowOther) {
@@ -227,4 +244,186 @@ export async function promptQuestionnaireFallback(
 	}
 
 	return { questions, answers, cancelled: false }
+}
+
+type PromptAnswer = Answer | "cancelled" | undefined
+
+function optionsForQuestion(question: Question): QuestionOption[] {
+	const options = [...question.options]
+	if (question.allowOther) {
+		options.push({
+			id: CUSTOM_OPTION_ID,
+			label: question.otherLabel ?? CUSTOM_OPTION_LABEL,
+		})
+	}
+	return options
+}
+
+function choiceSchema(options: QuestionOption[], required: boolean, multi: boolean): ElicitationSchema {
+	return {
+		type: "object",
+		properties: {
+			value: multi
+				? {
+						type: "array",
+						items: {
+							anyOf: options.map((option) => ({ const: option.id, title: option.label })),
+						},
+						...(required ? { minItems: 1 } : {}),
+					}
+				: {
+						type: "string",
+						oneOf: options.map((option) => ({ const: option.id, title: option.label })),
+					},
+		},
+		required: required ? ["value"] : [],
+	}
+}
+
+function freeTextSchema(required: boolean): ElicitationSchema {
+	return {
+		type: "object",
+		properties: {
+			value: {
+				type: "string",
+			},
+		},
+		required: required ? ["value"] : [],
+	}
+}
+
+async function promptAcpFreeTextAnswer(
+	elicitForm: AcpElicitForm,
+	question: Question,
+	questionText: string,
+	multi: boolean,
+	index: number,
+): Promise<PromptAnswer> {
+	const response = await elicitForm(questionText, undefined, freeTextSchema(question.required), undefined)
+	if (response === "aborted" || response === undefined) return question.required ? "cancelled" : undefined
+
+	const value = response.value
+	if (typeof value !== "string" || !value) return question.required ? "cancelled" : undefined
+
+	if (multi) {
+		return {
+			id: question.id,
+			value,
+			values: [value],
+			label: value,
+			labels: [value],
+			indices: [index],
+			wasCustom: true,
+		}
+	}
+
+	return {
+		id: question.id,
+		value,
+		label: value,
+		index,
+		wasCustom: true,
+	}
+}
+
+async function promptAcpSingleChoice(
+	ui: ExtensionUIContext,
+	elicitForm: AcpElicitForm,
+	question: Question,
+	questionText: string,
+): Promise<PromptAnswer> {
+	if (question.options.length === 0 && question.allowOther) {
+		return promptAcpFreeTextAnswer(elicitForm, question, questionText, false, 1)
+	}
+
+	const options = optionsForQuestion(question)
+	const response = await elicitForm(questionText, undefined, choiceSchema(options, question.required, false), undefined)
+	if (response === "aborted" || response === undefined) return question.required ? "cancelled" : undefined
+
+	const value = response.value
+	if (typeof value !== "string") return question.required ? "cancelled" : undefined
+
+	const index = options.findIndex((option) => option.id === value)
+	const option = options[index]
+	if (!option) return question.required ? "cancelled" : undefined
+
+	if (option.id === CUSTOM_OPTION_ID) {
+		const custom = await ui.input(`${questionText}\n\nYour answer:`)
+		if (!custom && question.required) return "cancelled"
+		if (!custom) return undefined
+		return {
+			id: question.id,
+			value: custom,
+			label: custom,
+			index: index + 1,
+			wasCustom: true,
+		}
+	}
+
+	return {
+		id: question.id,
+		value: option.id,
+		label: option.label,
+		index: index + 1,
+		wasCustom: false,
+	}
+}
+
+async function promptAcpMultiChoice(
+	ui: ExtensionUIContext,
+	elicitForm: AcpElicitForm,
+	question: Question,
+	questionText: string,
+): Promise<PromptAnswer> {
+	if (question.options.length === 0 && question.allowOther) {
+		return promptAcpFreeTextAnswer(elicitForm, question, questionText, true, 1)
+	}
+
+	const options = optionsForQuestion(question)
+	const response = await elicitForm(questionText, undefined, choiceSchema(options, question.required, true), undefined)
+	if (response === "aborted" || response === undefined) return question.required ? "cancelled" : undefined
+
+	const selectedIds = Array.isArray(response.value)
+		? response.value.filter((value): value is string => typeof value === "string")
+		: []
+	if (selectedIds.length === 0) return question.required ? "cancelled" : undefined
+
+	const choices: Array<{ id: string; value: string; label: string; index: number }> = []
+	for (const selectedId of selectedIds) {
+		const index = options.findIndex((option) => option.id === selectedId)
+		const option = options[index]
+		if (!option) continue
+
+		if (option.id === CUSTOM_OPTION_ID) {
+			const custom = await ui.input(`${questionText}\n\nYour answer:`)
+			if (custom) {
+				choices.push({
+					id: CUSTOM_OPTION_ID,
+					value: custom,
+					label: custom,
+					index: index + 1,
+				})
+			}
+			continue
+		}
+
+		choices.push({
+			id: option.id,
+			value: option.id,
+			label: option.label,
+			index: index + 1,
+		})
+	}
+
+	if (!choices.length) return question.required ? "cancelled" : undefined
+
+	return {
+		id: question.id,
+		value: choices.map((item) => item.value).join(", "),
+		values: choices.map((item) => item.value),
+		label: choices.map((item) => item.label).join(", "),
+		labels: choices.map((item) => item.label),
+		indices: choices.map((item) => item.index),
+		wasCustom: choices.some((item) => item.id === CUSTOM_OPTION_ID),
+	}
 }

--- a/src/modes/acp/acp-ui-context.test.ts
+++ b/src/modes/acp/acp-ui-context.test.ts
@@ -8,7 +8,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
 
 import { createAcpUIContext } from "./acp-ui-context.js"
 import { ADVERTISED_CAPABILITIES, CAPABILITIES_KEY } from "./capabilities.js"
-import { getAcpElicitForm } from "./structured-elicitation.js"
+import { choiceSchema, confirmSchema, freeTextSchema, getAcpElicitForm } from "./structured-elicitation.js"
 
 type ExtMethod = (method: string, params: Record<string, unknown>) => Promise<Record<string, unknown>>
 type ExtNotification = (method: string, params: Record<string, unknown>) => Promise<void>
@@ -95,16 +95,7 @@ describe("createAcpUIContext — confirm via elicitation", () => {
 			mode: "form",
 			requestId: expect.any(String),
 			sessionId: "sess-1",
-			requestedSchema: {
-				type: "object",
-				properties: {
-					confirmed: {
-						default: false,
-						type: "boolean",
-					},
-				},
-				required: ["confirmed"],
-			},
+			requestedSchema: confirmSchema(),
 		})
 	})
 
@@ -296,29 +287,15 @@ describe("createAcpUIContext — select via elicitation", () => {
 			mode: "form",
 			requestId: expect.any(String),
 			sessionId: "sess-1",
-			requestedSchema: {
-				properties: {
-					value: {
-						oneOf: [
-							{
-								const: "a",
-								title: "a",
-							},
-							{
-								const: "b",
-								title: "b",
-							},
-							{
-								const: "c",
-								title: "c",
-							},
-						],
-						type: "string",
-					},
-				},
-				required: ["value"],
-				type: "object",
-			},
+			requestedSchema: choiceSchema(
+				[
+					{ id: "a", label: "a" },
+					{ id: "b", label: "b" },
+					{ id: "c", label: "c" },
+				],
+				true,
+				false,
+			),
 		})
 	})
 
@@ -453,16 +430,7 @@ describe("createAcpUIContext — input via elicitation", () => {
 			mode: "form",
 			requestId: expect.any(String),
 			sessionId: "sess-1",
-			requestedSchema: {
-				properties: {
-					value: {
-						description: "Enter your name",
-						type: "string",
-					},
-				},
-				required: ["value"],
-				type: "object",
-			},
+			requestedSchema: freeTextSchema(true, "Enter your name"),
 		})
 	})
 

--- a/src/modes/acp/acp-ui-context.test.ts
+++ b/src/modes/acp/acp-ui-context.test.ts
@@ -8,6 +8,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
 
 import { createAcpUIContext } from "./acp-ui-context.js"
 import { ADVERTISED_CAPABILITIES, CAPABILITIES_KEY } from "./capabilities.js"
+import { getAcpElicitForm } from "./structured-elicitation.js"
 
 type ExtMethod = (method: string, params: Record<string, unknown>) => Promise<Record<string, unknown>>
 type ExtNotification = (method: string, params: Record<string, unknown>) => Promise<void>
@@ -570,6 +571,15 @@ describe("createAcpUIContext — capability gating", () => {
 		const real = createAcpUIContext(conn, "sess-1", caps, send)
 		await expect(real.select("Pick", ["x", "y"])).resolves.toBe("x")
 		expect(elicit).toHaveBeenCalledTimes(1)
+	})
+
+	it("exposes the structured elicitation helper only when form elicitation is supported", () => {
+		const { conn, send } = makeConn()
+		const withForm = createAcpUIContext(conn, "sess-1", elicitationClientCapabilities(), send)
+		const withoutForm = createAcpUIContext(conn, "sess-2", uiMethodsClientCapabilities(), send)
+
+		expect(getAcpElicitForm(withForm)).toEqual(expect.any(Function))
+		expect(getAcpElicitForm(withoutForm)).toBeUndefined()
 	})
 
 	it("treats elicitation.form undefined as not supporting form elicitation (falls back to request_permission)", async () => {

--- a/src/modes/acp/acp-ui-context.ts
+++ b/src/modes/acp/acp-ui-context.ts
@@ -31,7 +31,13 @@ import {
 	getClientSupportsElicitation,
 	getClientSupportsMethod,
 } from "./capabilities.js"
-import { ACP_ELICIT_FORM, type AcpElicitationUIContext } from "./structured-elicitation.js"
+import {
+	ACP_ELICIT_FORM,
+	type AcpElicitationUIContext,
+	choiceSchema,
+	confirmSchema,
+	freeTextSchema,
+} from "./structured-elicitation.js"
 import { requestWithAbort } from "./utils.js"
 
 type DialogResponse = {
@@ -183,16 +189,11 @@ export function createAcpUIContext(
 			if (options.length === 0) return undefined
 
 			if (supportsElicitation) {
-				const schema: ElicitationSchema = {
-					type: "object",
-					properties: {
-						value: {
-							type: "string",
-							oneOf: options.map((opt) => ({ const: opt, title: opt })),
-						},
-					},
-					required: ["value"],
-				}
+				const schema = choiceSchema(
+					options.map((option) => ({ id: option, label: option })),
+					true,
+					false,
+				)
 				const response = await elicitForm(title, undefined, schema, opts?.signal)
 				if (response === "aborted" || response === undefined) return undefined
 				const value = response.value
@@ -217,19 +218,7 @@ export function createAcpUIContext(
 
 		async confirm(title, message, opts) {
 			if (supportsElicitation) {
-				const schema: ElicitationSchema = {
-					type: "object",
-					properties: {
-						confirmed: {
-							type: "boolean",
-							// Default is always false as Pi has no way of distinguishing
-							// a confirm result as cancelled (e.g. user didn't select explicitly)
-							default: false,
-						},
-					},
-					required: ["confirmed"],
-				}
-				const response = await elicitForm(title, message, schema, opts?.signal)
+				const response = await elicitForm(title, message, confirmSchema(), opts?.signal)
 				if (response === "aborted" || response === undefined) return false
 				return response.confirmed === true
 			}
@@ -261,17 +250,7 @@ export function createAcpUIContext(
 				return undefined
 			}
 
-			const schema: ElicitationSchema = {
-				type: "object",
-				properties: {
-					value: {
-						type: "string",
-						description: placeholder,
-					},
-				},
-				required: ["value"],
-			}
-			const response = await elicitForm(title, undefined, schema, opts?.signal)
+			const response = await elicitForm(title, undefined, freeTextSchema(true, placeholder), opts?.signal)
 			if (response === "aborted" || response === undefined) return undefined
 			const value = response.value
 			return typeof value === "string" ? value : undefined

--- a/src/modes/acp/acp-ui-context.ts
+++ b/src/modes/acp/acp-ui-context.ts
@@ -31,6 +31,7 @@ import {
 	getClientSupportsElicitation,
 	getClientSupportsMethod,
 } from "./capabilities.js"
+import { ACP_ELICIT_FORM, type AcpElicitationUIContext } from "./structured-elicitation.js"
 import { requestWithAbort } from "./utils.js"
 
 type DialogResponse = {
@@ -177,7 +178,7 @@ export function createAcpUIContext(
 		}
 	}
 
-	const ui: ExtensionUIContext = {
+	const ui: ExtensionUIContext & Partial<AcpElicitationUIContext> = {
 		async select(title, options, opts) {
 			if (options.length === 0) return undefined
 
@@ -430,6 +431,10 @@ export function createAcpUIContext(
 		get theme() {
 			return NOOP_THEME
 		},
+	}
+
+	if (supportsElicitation) {
+		ui[ACP_ELICIT_FORM] = elicitForm
 	}
 
 	return ui

--- a/src/modes/acp/structured-elicitation.test.ts
+++ b/src/modes/acp/structured-elicitation.test.ts
@@ -1,0 +1,104 @@
+import { describe, expect, it } from "vitest"
+import { choiceSchema, confirmSchema, freeTextSchema } from "./structured-elicitation.js"
+
+const OPTIONS = [
+	{ id: "a", label: "Alpha" },
+	{ id: "b", label: "Beta" },
+	{ id: "c", label: "Gamma" },
+]
+
+describe("structured elicitation schema builders", () => {
+	it("builds a required single-choice value schema", () => {
+		expect(choiceSchema(OPTIONS, true, false)).toEqual({
+			type: "object",
+			properties: {
+				value: {
+					type: "string",
+					oneOf: [
+						{ const: "a", title: "Alpha" },
+						{ const: "b", title: "Beta" },
+						{ const: "c", title: "Gamma" },
+					],
+				},
+			},
+			required: ["value"],
+		})
+	})
+
+	it("builds an optional multi-choice value schema", () => {
+		expect(choiceSchema(OPTIONS, false, true)).toEqual({
+			type: "object",
+			properties: {
+				value: {
+					type: "array",
+					items: {
+						anyOf: [
+							{ const: "a", title: "Alpha" },
+							{ const: "b", title: "Beta" },
+							{ const: "c", title: "Gamma" },
+						],
+					},
+				},
+			},
+			required: [],
+		})
+	})
+
+	it("adds minItems to required multi-choice schemas", () => {
+		expect(choiceSchema(OPTIONS, true, true)).toMatchObject({
+			properties: {
+				value: {
+					minItems: 1,
+				},
+			},
+			required: ["value"],
+		})
+	})
+
+	it("builds text value schemas with optional descriptions", () => {
+		expect(freeTextSchema(true, "Enter your name")).toEqual({
+			type: "object",
+			properties: {
+				value: {
+					type: "string",
+					description: "Enter your name",
+				},
+			},
+			required: ["value"],
+		})
+
+		expect(freeTextSchema(false)).toEqual({
+			type: "object",
+			properties: {
+				value: {
+					type: "string",
+				},
+			},
+			required: [],
+		})
+
+		expect(freeTextSchema(true, "")).toEqual({
+			type: "object",
+			properties: {
+				value: {
+					type: "string",
+					description: "",
+				},
+			},
+			required: ["value"],
+		})
+	})
+
+	it("builds the confirm schema", () => {
+		expect(confirmSchema()).toEqual({
+			type: "object",
+			properties: {
+				confirmed: {
+					type: "boolean",
+					default: false,
+				},
+			},
+			required: ["confirmed"],
+		})
+	})
+})

--- a/src/modes/acp/structured-elicitation.ts
+++ b/src/modes/acp/structured-elicitation.ts
@@ -3,6 +3,11 @@ import type { ExtensionUIContext } from "@earendil-works/pi-coding-agent"
 
 export const ACP_ELICIT_FORM = Symbol.for("kimchi.acp.elicitForm")
 
+export interface ElicitationChoiceOption {
+	id: string
+	label: string
+}
+
 export type AcpElicitForm = (
 	title: string,
 	message: string | undefined,
@@ -17,4 +22,57 @@ export type AcpElicitationUIContext = ExtensionUIContext & {
 export function getAcpElicitForm(ui: ExtensionUIContext): AcpElicitForm | undefined {
 	const candidate = (ui as unknown as Record<typeof ACP_ELICIT_FORM, unknown>)[ACP_ELICIT_FORM]
 	return typeof candidate === "function" ? (candidate as AcpElicitForm) : undefined
+}
+
+export function choiceSchema(
+	options: readonly ElicitationChoiceOption[],
+	required: boolean,
+	multi: boolean,
+): ElicitationSchema {
+	return {
+		type: "object",
+		properties: {
+			value: multi
+				? {
+						type: "array",
+						items: {
+							anyOf: options.map((option) => ({ const: option.id, title: option.label })),
+						},
+						...(required ? { minItems: 1 } : {}),
+					}
+				: {
+						type: "string",
+						oneOf: options.map((option) => ({ const: option.id, title: option.label })),
+					},
+		},
+		required: required ? ["value"] : [],
+	}
+}
+
+export function freeTextSchema(required: boolean, description?: string): ElicitationSchema {
+	return {
+		type: "object",
+		properties: {
+			value: {
+				type: "string",
+				...(description !== undefined ? { description } : {}),
+			},
+		},
+		required: required ? ["value"] : [],
+	}
+}
+
+export function confirmSchema(): ElicitationSchema {
+	return {
+		type: "object",
+		properties: {
+			confirmed: {
+				type: "boolean",
+				// Default is always false as Pi has no way of distinguishing
+				// a confirm result as cancelled (e.g. user didn't select explicitly)
+				default: false,
+			},
+		},
+		required: ["confirmed"],
+	}
 }

--- a/src/modes/acp/structured-elicitation.ts
+++ b/src/modes/acp/structured-elicitation.ts
@@ -1,0 +1,20 @@
+import type { ElicitationAcceptAction, ElicitationSchema } from "@agentclientprotocol/sdk"
+import type { ExtensionUIContext } from "@earendil-works/pi-coding-agent"
+
+export const ACP_ELICIT_FORM = Symbol.for("kimchi.acp.elicitForm")
+
+export type AcpElicitForm = (
+	title: string,
+	message: string | undefined,
+	requestedSchema: ElicitationSchema,
+	signal: AbortSignal | undefined,
+) => Promise<NonNullable<ElicitationAcceptAction["content"]> | "aborted" | undefined>
+
+export type AcpElicitationUIContext = ExtensionUIContext & {
+	[ACP_ELICIT_FORM]: AcpElicitForm
+}
+
+export function getAcpElicitForm(ui: ExtensionUIContext): AcpElicitForm | undefined {
+	const candidate = (ui as unknown as Record<typeof ACP_ELICIT_FORM, unknown>)[ACP_ELICIT_FORM]
+	return typeof candidate === "function" ? (candidate as AcpElicitForm) : undefined
+}

--- a/tests/e2e/acp/questionnaire-choice-regression.test.ts
+++ b/tests/e2e/acp/questionnaire-choice-regression.test.ts
@@ -1,4 +1,4 @@
-// ACP regression for LLM-2385.
+// ACP regression for questionnaire choice elicitation.
 //
 // The questionnaire tool should use structured ACP elicitation for choices.
 // It must not collect ordinary multi-select choices through a generic
@@ -50,7 +50,7 @@ describe("ACP integration — questionnaire structured elicitation regression", 
 	}
 
 	it(
-		"LLM-2385: normal multi-select choices use structured elicitation, not free-text input",
+		"normal multi-select choices use structured elicitation, not free-text input",
 		async () => {
 			const { result, client } = await runQuestionnaireScenario({
 				artifactName: "questionnaire-choice-structured",
@@ -85,40 +85,7 @@ describe("ACP integration — questionnaire structured elicitation regression", 
 	)
 
 	it(
-		"LLM-2385: normal single-choice options use structured oneOf elicitation",
-		async () => {
-			const { result, client } = await runQuestionnaireScenario({
-				artifactName: "questionnaire-choice-single-structured",
-				question: {
-					id: "choice",
-					type: "single",
-					prompt: "Pick the option to implement.",
-					allowOther: false,
-				},
-				answer: { action: "accept", content: { value: "b" } },
-				userPrompt: "Ask me which option to implement.",
-			})
-
-			expect(result.stopReason).toBe("end_turn")
-			expect(client.permissionRequests, "questionnaire is not a permission request").toEqual([])
-			expect(client.elicitationRequests, "normal single choice should be one structured elicitation").toHaveLength(1)
-
-			const valueField = valueFieldOf(client.elicitationRequests[0].params)
-			expect(valueField).toEqual({
-				type: "string",
-				oneOf: [
-					{ const: "a", title: "A" },
-					{ const: "b", title: "B" },
-					{ const: "c", title: "C" },
-					{ const: "d", title: "D" },
-				],
-			})
-		},
-		STARTUP_TIMEOUT_MS,
-	)
-
-	it(
-		"LLM-2385: free-text follow-up is a second elicitation only after selecting Other",
+		"free-text follow-up is a second elicitation only after selecting Other",
 		async () => {
 			const { client } = await runQuestionnaireScenario({
 				artifactName: "questionnaire-choice-custom-followup",
@@ -149,7 +116,7 @@ describe("ACP integration — questionnaire structured elicitation regression", 
 	)
 
 	it(
-		"LLM-2385: free-form-only choices use one string elicitation without a synthetic choice step",
+		"free-form-only choices use one string elicitation without a synthetic choice step",
 		async () => {
 			const { client } = await runQuestionnaireScenario({
 				artifactName: "questionnaire-choice-free-form-only",

--- a/tests/e2e/acp/questionnaire-choice-regression.test.ts
+++ b/tests/e2e/acp/questionnaire-choice-regression.test.ts
@@ -1,0 +1,213 @@
+// ACP regression for LLM-2385.
+//
+// The questionnaire tool should use structured ACP elicitation for choices.
+// It must not collect ordinary multi-select choices through a generic
+// free-text input field. If a selected option needs free text (the current
+// questionnaire vocabulary represents this with allowOther), that free-text
+// prompt should be a second elicitation after the structured choice response.
+
+import type { ClientCapabilities, CreateElicitationResponse } from "@agentclientprotocol/sdk"
+import { afterEach, describe, expect, it } from "vitest"
+import { type AcpFixture, STARTUP_TIMEOUT_MS, startAcpFixture } from "./support/acp-fixture.js"
+import { newSession, prompt } from "./support/scenarios.js"
+
+const ELICITATION_CAPABILITIES: ClientCapabilities = {
+	fs: { readTextFile: false, writeTextFile: false },
+	elicitation: { form: {} },
+}
+
+const OPTIONS = [
+	{ id: "a", label: "A" },
+	{ id: "b", label: "B" },
+	{ id: "c", label: "C" },
+	{ id: "d", label: "D" },
+]
+
+describe("ACP integration — questionnaire structured elicitation regression", () => {
+	let fixture: AcpFixture | undefined
+
+	afterEach(async () => {
+		await fixture?.stop()
+		fixture = undefined
+	})
+
+	async function runQuestionnaireScenario(options: {
+		artifactName: string
+		question: QuestionnaireQuestion
+		answer: CreateElicitationResponse
+		userPrompt: string
+	}) {
+		fixture = await startAcpFixture({
+			artifactName: options.artifactName,
+			responses: [questionnaireResponse(options.question), { stream: ["done"] }],
+			clientCapabilities: ELICITATION_CAPABILITIES,
+		})
+		fixture.client.answerNextElicitationWith(options.answer)
+
+		const sessionId = await newSession(fixture, fixture.workDir)
+		const result = await prompt(fixture, sessionId, options.userPrompt)
+		return { result, client: fixture.client }
+	}
+
+	it(
+		"LLM-2385: normal multi-select choices use structured elicitation, not free-text input",
+		async () => {
+			const { result, client } = await runQuestionnaireScenario({
+				artifactName: "questionnaire-choice-structured",
+				question: {
+					id: "choice",
+					prompt: "Pick the options to implement.",
+					allowOther: false,
+				},
+				answer: { action: "accept", content: { value: ["a", "b"] } },
+				userPrompt: "Ask me which options to implement.",
+			})
+
+			expect(result.stopReason).toBe("end_turn")
+			expect(client.permissionRequests, "questionnaire is not a permission request").toEqual([])
+			expect(client.elicitationRequests, "normal choices should be one structured elicitation").toHaveLength(1)
+
+			const valueField = valueFieldOf(client.elicitationRequests[0].params)
+			expect(valueField).toEqual({
+				type: "array",
+				items: {
+					anyOf: [
+						{ const: "a", title: "A" },
+						{ const: "b", title: "B" },
+						{ const: "c", title: "C" },
+						{ const: "d", title: "D" },
+					],
+				},
+				minItems: 1,
+			})
+		},
+		STARTUP_TIMEOUT_MS,
+	)
+
+	it(
+		"LLM-2385: normal single-choice options use structured oneOf elicitation",
+		async () => {
+			const { result, client } = await runQuestionnaireScenario({
+				artifactName: "questionnaire-choice-single-structured",
+				question: {
+					id: "choice",
+					type: "single",
+					prompt: "Pick the option to implement.",
+					allowOther: false,
+				},
+				answer: { action: "accept", content: { value: "b" } },
+				userPrompt: "Ask me which option to implement.",
+			})
+
+			expect(result.stopReason).toBe("end_turn")
+			expect(client.permissionRequests, "questionnaire is not a permission request").toEqual([])
+			expect(client.elicitationRequests, "normal single choice should be one structured elicitation").toHaveLength(1)
+
+			const valueField = valueFieldOf(client.elicitationRequests[0].params)
+			expect(valueField).toEqual({
+				type: "string",
+				oneOf: [
+					{ const: "a", title: "A" },
+					{ const: "b", title: "B" },
+					{ const: "c", title: "C" },
+					{ const: "d", title: "D" },
+				],
+			})
+		},
+		STARTUP_TIMEOUT_MS,
+	)
+
+	it(
+		"LLM-2385: free-text follow-up is a second elicitation only after selecting Other",
+		async () => {
+			const { client } = await runQuestionnaireScenario({
+				artifactName: "questionnaire-choice-custom-followup",
+				question: {
+					id: "choice",
+					prompt: "Pick the options to implement.",
+					allowOther: true,
+				},
+				answer: { action: "accept", content: { value: ["a", "__other__"] } },
+				userPrompt: "Ask me which options to implement.",
+			})
+
+			expect(client.permissionRequests, "questionnaire is not a permission request").toEqual([])
+			expect(client.elicitationRequests, "Other selection should split choice and text input").toHaveLength(2)
+
+			const choiceField = valueFieldOf(client.elicitationRequests[0].params)
+			expect(choiceField).toMatchObject({
+				type: "array",
+				items: {
+					anyOf: expect.arrayContaining([{ const: "__other__", title: "Type your own answer" }]),
+				},
+			})
+
+			const followUpField = valueFieldOf(client.elicitationRequests[1].params)
+			expect(followUpField).toMatchObject({ type: "string" })
+		},
+		STARTUP_TIMEOUT_MS,
+	)
+
+	it(
+		"LLM-2385: free-form-only choices use one string elicitation without a synthetic choice step",
+		async () => {
+			const { client } = await runQuestionnaireScenario({
+				artifactName: "questionnaire-choice-free-form-only",
+				question: {
+					id: "choice",
+					type: "single",
+					prompt: "Describe the option to implement.",
+					options: [],
+					allowOther: true,
+				},
+				answer: { action: "accept", content: { value: "custom option" } },
+				userPrompt: "Ask me what option to implement.",
+			})
+
+			expect(client.permissionRequests, "questionnaire is not a permission request").toEqual([])
+			expect(client.elicitationRequests, "free-form-only questions should be one text elicitation").toHaveLength(1)
+			expect(valueFieldOf(client.elicitationRequests[0].params)).toEqual({ type: "string" })
+		},
+		STARTUP_TIMEOUT_MS,
+	)
+})
+
+interface QuestionnaireQuestion {
+	id: string
+	prompt: string
+	allowOther: boolean
+	type?: "single" | "multi"
+	options?: typeof OPTIONS
+}
+
+function questionnaireResponse(question: QuestionnaireQuestion) {
+	return {
+		stream: ["I'll ask a structured question."],
+		toolCalls: [
+			{
+				function: {
+					name: "questionnaire",
+					arguments: JSON.stringify({
+						questions: [
+							{
+								id: question.id,
+								type: question.type ?? "multi",
+								prompt: question.prompt,
+								options: question.options ?? OPTIONS,
+								allowOther: question.allowOther,
+							},
+						],
+					}),
+				},
+			},
+		],
+	}
+}
+
+function valueFieldOf(params: unknown): Record<string, unknown> {
+	if (!params || typeof params !== "object") throw new Error("elicitation params must be an object")
+	const schema = (params as { requestedSchema?: { properties?: Record<string, unknown> } }).requestedSchema
+	const value = schema?.properties?.value
+	if (!value || typeof value !== "object") throw new Error("elicitation schema must include a value field")
+	return value as Record<string, unknown>
+}


### PR DESCRIPTION
## Linked issue

Closes #750

## What does this PR do?

When the ACP client advertises form elicitation, single- and multi-select questionnaire question were previously shown as a free-text input. Now they are sent as structured elicitation requests with the choice set encoded in the schema. Free-text input is still used only for the 'Other' follow-up or for plain text questions.

## Checklist

- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md) and agree to the CLA
- [x] This PR links to an open issue above
- [x] Tests pass locally (`pnpm run test`)
- [x] Lint passes (`pnpm run check`)
- [x] Documentation updated if behavior changed