### PR TITLE
fix(permissions): add gcloud, git worktree, kubectl cluster-info to r…

### DIFF
--- a/src/extensions/permissions/taxonomy.test.ts
+++ b/src/extensions/permissions/taxonomy.test.ts
@@ -115,6 +115,14 @@ describe("isReadOnlyBashCommand", () => {
 		expect(isReadOnlyBashCommand("git diff HEAD")).toBe(true)
 	})
 
+	it("allows git worktree list but blocks mutating worktree subcommands", () => {
+		expect(isReadOnlyBashCommand("git worktree list")).toBe(true)
+		expect(isReadOnlyBashCommand("git worktree add ../foo")).toBe(false)
+		expect(isReadOnlyBashCommand("git worktree remove ../foo")).toBe(false)
+		expect(isReadOnlyBashCommand("git worktree move ../foo ../bar")).toBe(false)
+		expect(isReadOnlyBashCommand("git worktree prune")).toBe(false)
+	})
+
 	it("blocks git subcommands outside allowlist", () => {
 		expect(isReadOnlyBashCommand("git push")).toBe(false)
 		expect(isReadOnlyBashCommand("git commit -am x")).toBe(false)
@@ -306,10 +314,11 @@ describe("isReadOnlyBashCommand", () => {
 		})
 	})
 
-	describe("legacy Set<string> subcommand allowlist (git / npm / kubectl / etc.)", () => {
+	describe("Set<string> and wildcard subcommand allowlist (git / npm / kubectl / etc.)", () => {
 		it("preserves backwards-compatible behavior — any sub-sub-command allowed", () => {
-			// These all rely on the Set-based form. The matcher must NOT
-			// require a sub-sub-command token for them.
+			// git uses the Record form with "*" wildcards (except `worktree`);
+			// npm/kubectl/docker still use the legacy Set. Both paths must NOT
+			// require a sub-sub-command token for wildcard/Set entries.
 			expect(isReadOnlyBashCommand("git status")).toBe(true)
 			expect(isReadOnlyBashCommand("git log --oneline -n 20")).toBe(true)
 			expect(isReadOnlyBashCommand("git diff HEAD")).toBe(true)

--- a/src/extensions/permissions/taxonomy.test.ts
+++ b/src/extensions/permissions/taxonomy.test.ts
@@ -115,6 +115,10 @@ describe("isReadOnlyBashCommand", () => {
 		expect(isReadOnlyBashCommand("git diff HEAD")).toBe(true)
 	})
 
+	it("allows git worktree list", () => {
+		expect(isReadOnlyBashCommand("git worktree list")).toBe(true)
+	})
+
 	it("blocks git subcommands outside allowlist", () => {
 		expect(isReadOnlyBashCommand("git push")).toBe(false)
 		expect(isReadOnlyBashCommand("git commit -am x")).toBe(false)
@@ -329,6 +333,49 @@ describe("isReadOnlyBashCommand", () => {
 			expect(isReadOnlyBashCommand("npm install foo")).toBe(false)
 			expect(isReadOnlyBashCommand("kubectl delete pod foo")).toBe(false)
 			expect(isReadOnlyBashCommand("docker rm foo")).toBe(false)
+		})
+
+		it("allows kubectl cluster-info and other read-only discovery commands", () => {
+			expect(isReadOnlyBashCommand("kubectl cluster-info")).toBe(true)
+			expect(isReadOnlyBashCommand("kubectl api-resources")).toBe(true)
+			expect(isReadOnlyBashCommand("kubectl api-versions")).toBe(true)
+			expect(isReadOnlyBashCommand("kubectl explain pods")).toBe(true)
+		})
+
+		it("allows gcloud read-only subcommands", () => {
+			expect(isReadOnlyBashCommand("gcloud auth list")).toBe(true)
+			expect(isReadOnlyBashCommand("gcloud config get-value project")).toBe(true)
+			expect(isReadOnlyBashCommand("gcloud config list")).toBe(true)
+			expect(isReadOnlyBashCommand("gcloud projects list")).toBe(true)
+			expect(isReadOnlyBashCommand("gcloud projects describe my-project")).toBe(true)
+			expect(isReadOnlyBashCommand("gcloud services list")).toBe(true)
+		})
+
+		it("blocks gcloud mutating subcommands", () => {
+			// auth configure-docker writes docker credential helper config
+			expect(isReadOnlyBashCommand("gcloud auth configure-docker")).toBe(false)
+			// config set mutates config
+			expect(isReadOnlyBashCommand("gcloud config set project foo")).toBe(false)
+			// services enable mutates state
+			expect(isReadOnlyBashCommand("gcloud services enable sql.googleapis.com")).toBe(false)
+		})
+
+		it("blocks gcloud three-level commands whose parents have unsafe children", () => {
+			// `gcloud artifacts docker` would allow `images delete` — too broad
+			expect(isReadOnlyBashCommand("gcloud artifacts docker images list")).toBe(false)
+			// `gcloud container clusters` would allow `get-credentials` (writes
+			// kubeconfig) and `delete` (destroys cluster) — too broad
+			expect(isReadOnlyBashCommand("gcloud container clusters get-credentials my-cluster")).toBe(false)
+			expect(isReadOnlyBashCommand("gcloud container clusters list")).toBe(false)
+		})
+
+		it("blocks bare gcloud with no subcommand", () => {
+			expect(isReadOnlyBashCommand("gcloud")).toBe(false)
+		})
+
+		it("blocks gcloud subcommands not in the allowlist", () => {
+			expect(isReadOnlyBashCommand("gcloud compute instances list")).toBe(false)
+			expect(isReadOnlyBashCommand("gcloud iam roles list")).toBe(false)
 		})
 	})
 

--- a/src/extensions/permissions/taxonomy.test.ts
+++ b/src/extensions/permissions/taxonomy.test.ts
@@ -115,10 +115,6 @@ describe("isReadOnlyBashCommand", () => {
 		expect(isReadOnlyBashCommand("git diff HEAD")).toBe(true)
 	})
 
-	it("allows git worktree list", () => {
-		expect(isReadOnlyBashCommand("git worktree list")).toBe(true)
-	})
-
 	it("blocks git subcommands outside allowlist", () => {
 		expect(isReadOnlyBashCommand("git push")).toBe(false)
 		expect(isReadOnlyBashCommand("git commit -am x")).toBe(false)

--- a/src/extensions/permissions/taxonomy.ts
+++ b/src/extensions/permissions/taxonomy.ts
@@ -183,7 +183,6 @@ const READ_ONLY_SUBCOMMANDS: Record<string, Set<string> | Record<string, string[
 		"config",
 		"tag",
 		"stash",
-		"worktree",
 		"reflog",
 		"shortlog",
 		"fsck",

--- a/src/extensions/permissions/taxonomy.ts
+++ b/src/extensions/permissions/taxonomy.ts
@@ -156,15 +156,16 @@ const FIND_EXECUTION_FLAGS = new Set([
 /** Allowed subcommands for a program in plan mode.
  *  Two shapes are supported:
  *  - `Set<string>` (legacy): the first subcommand must be in the set; sub-sub-
- *    commands are NOT checked. Used by `git`, `npm`, `kubectl`, etc., whose
+ *    commands are NOT checked. Used by `npm`, `kubectl`, etc., whose
  *    listed subcommands have no mutation-capable sub-sub-commands worth
- *    distinguishing, OR where the team has accepted the trade-off (e.g. `git
- *    branch <new>` creates a branch but is rarely abused in plan mode).
+ *    distinguishing, OR where the team has accepted the trade-off.
  *  - `Record<subcommand, string[] | "*">` (fine-grained): the first subcommand
  *    must be a key, then `tokens[2]` is matched against the array, or the value
  *    `"*"` allows any sub-sub-command. Absent sub-sub-command (e.g. bare
  *    `gh pr`) is blocked. Used by CLIs whose parent commands have both safe
- *    and unsafe children (e.g. `gh pr`, `glab mr`).
+ *    and unsafe children (e.g. `gh pr`, `glab mr`), or where a single
+ *    subcommand needs sub-sub-command scoping (e.g. `git worktree` →
+ *    `list`-only while all other git subcommands are wildcarded).
  */
 const READ_ONLY_SUBCOMMANDS: Record<string, Set<string> | Record<string, string[] | "*">> = {
 	// git uses the fine-grained Record form (not the legacy Set) so that

--- a/src/extensions/permissions/taxonomy.ts
+++ b/src/extensions/permissions/taxonomy.ts
@@ -167,33 +167,44 @@ const FIND_EXECUTION_FLAGS = new Set([
  *    and unsafe children (e.g. `gh pr`, `glab mr`).
  */
 const READ_ONLY_SUBCOMMANDS: Record<string, Set<string> | Record<string, string[] | "*">> = {
-	git: new Set([
-		"status",
-		"log",
-		"diff",
-		"show",
-		"branch",
-		"remote",
-		"ls-files",
-		"ls-tree",
-		"ls-remote",
-		"rev-parse",
-		"describe",
-		"blame",
-		"config",
-		"tag",
-		"stash",
-		"reflog",
-		"shortlog",
-		"fsck",
-		"verify-pack",
-		"count-objects",
-		"for-each-ref",
-		"show-ref",
-		"symbolic-ref",
-		"name-rev",
-		"rev-list",
-	]),
+	// git uses the fine-grained Record form (not the legacy Set) so that
+	// `worktree` can be scoped to read-only actions only. All other
+	// subcommands use the `"*"` wildcard, which short-circuits before the
+	// tokens[2] check — preserving the exact same behavior as the old Set
+	// (any sub-sub-command allowed, including bare `git status`).
+	//
+	// `worktree` is scoped because `git worktree add`/`remove`/`move`
+	// mutate the filesystem (create/delete/relocate directories on disk),
+	// unlike e.g. `git branch <name>` which is a local, easily-reversible
+	// ref operation already accepted as a trade-off.
+	git: {
+		status: "*",
+		log: "*",
+		diff: "*",
+		show: "*",
+		branch: "*",
+		remote: "*",
+		"ls-files": "*",
+		"ls-tree": "*",
+		"ls-remote": "*",
+		"rev-parse": "*",
+		describe: "*",
+		blame: "*",
+		config: "*",
+		tag: "*",
+		stash: "*",
+		worktree: ["list"],
+		reflog: "*",
+		shortlog: "*",
+		fsck: "*",
+		"verify-pack": "*",
+		"count-objects": "*",
+		"for-each-ref": "*",
+		"show-ref": "*",
+		"symbolic-ref": "*",
+		"name-rev": "*",
+		"rev-list": "*",
+	},
 	npm: new Set(["list", "ls", "view", "info", "search", "outdated", "audit", "--version", "-v"]),
 	yarn: new Set(["list", "info", "why", "audit", "--version", "-v"]),
 	pnpm: new Set(["list", "ls", "view", "info", "outdated", "audit", "--version", "-v"]),

--- a/src/extensions/permissions/taxonomy.ts
+++ b/src/extensions/permissions/taxonomy.ts
@@ -183,6 +183,7 @@ const READ_ONLY_SUBCOMMANDS: Record<string, Set<string> | Record<string, string[
 		"config",
 		"tag",
 		"stash",
+		"worktree",
 		"reflog",
 		"shortlog",
 		"fsck",
@@ -200,7 +201,18 @@ const READ_ONLY_SUBCOMMANDS: Record<string, Set<string> | Record<string, string[
 	pip: new Set(["list", "show", "search", "freeze", "--version"]),
 	cargo: new Set(["tree", "search", "--version"]),
 	docker: new Set(["ps", "images", "logs", "inspect", "version", "info"]),
-	kubectl: new Set(["get", "describe", "logs", "top", "version", "config"]),
+	kubectl: new Set([
+		"get",
+		"describe",
+		"logs",
+		"top",
+		"version",
+		"config",
+		"cluster-info",
+		"api-resources",
+		"api-versions",
+		"explain",
+	]),
 	// `gh` and `glab` use the fine-grained form (per-sub-sub-command
 	// allowlist) because both CLIs have mutation-capable sub-sub-commands
 	// under each parent (e.g. `gh pr create`, `glab mr create`, `gh repo
@@ -252,6 +264,26 @@ const READ_ONLY_SUBCOMMANDS: Record<string, Set<string> | Record<string, string[
 		user: "*",
 		status: "*",
 		search: "*",
+	},
+	// gcloud uses the fine-grained form because most groups have both safe
+	// and unsafe sub-sub-commands. The matcher inspects tokens[2] only, so
+	// for gcloud's three-level structure (`gcloud <group> <resource> <action>`)
+	// the safety distinction lives at tokens[3] — beyond the matcher's reach.
+	// Parents whose sub-sub-commands include mutations (e.g. `container clusters`
+	// has both `list` and `get-credentials`/`delete`) are omitted entirely,
+	// following the same rule as `glab cluster`.
+	//
+	// Intentionally NOT included:
+	//   - `artifacts`: `docker` → tokens[2] allows `images delete` etc.
+	//   - `container`: `clusters` → allows `get-credentials` (writes kubeconfig)
+	//      and `delete` (destroys clusters).
+	//   - `compute`: `instances`/`zones` → allows `delete`/`start`/`stop`.
+	//   - `auth configure-docker`: writes docker credential helper config.
+	gcloud: {
+		auth: ["list"],
+		config: ["get-value", "list"],
+		projects: ["list", "describe"],
+		services: ["list"],
 	},
 }
 


### PR DESCRIPTION
…ead-only allowlist

Widens the plan-mode read-only bash allowlist based on observed session friction where common read-only commands required unnecessary approval:

- git: add `worktree` — local/reversible like `branch`, `stash`, `tag`
- kubectl: add `cluster-info`, `api-resources`, `api-versions`, `explain` — all read-only discovery commands with no mutation-capable children
- gcloud: new fine-grained entry (Record form) with only genuinely safe two-level subcommands: `auth list`, `config get-value/list`, `projects list/describe`, `services list`

Three-level gcloud commands (`artifacts docker images list`, `container clusters get-credentials`, etc.) are deliberately excluded: the matcher inspects tokens[2] only, and their parent groups contain both safe and unsafe children at tokens[3] — same rule already applied to `glab cluster`.

curl is intentionally left out — GET is safe but -X POST/-d/-T make it mutating, requiring a restricted-program entry rather than a simple allowlist addition.

## Linked issue

Closes #

<!-- Every PR must link to an existing issue. PRs without a linked issue will not be reviewed.
     Use one of: Closes #N / Fixes #N / Resolves #N -->

## What does this PR do?

<!-- Brief description of the change and why it's needed. -->

## Checklist

- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md) and agree to the CLA
- [x] This PR links to an open issue above
- [x] Tests pass locally (`pnpm run test`)
- [x] Lint passes (`pnpm run check`)
- [x] Documentation updated if behavior changed
