### PR TITLE
fix: add exponential backoff for claude code retryable errors

### DIFF
--- a/benchmark/terminal-bench-2/config/retry.yaml
+++ b/benchmark/terminal-bench-2/config/retry.yaml
@@ -1,0 +1,25 @@
+# Harbor retry configuration for Claude Code + Kimchi gateway runs.
+#
+# Cloudflare returns HTTP 524 ("A timeout occurred") when the Kimchi gateway
+# origin does not produce a response (or a streaming chunk) within Cloudflare's
+# ~100s window. These are transient — the same request typically succeeds on
+# the next attempt — so they must be retried with enough attempts and a
+# backoff curve that gives the upstream time to recover.
+#
+# Harbor's CLI exposes --max-retries / --retry-include / --retry-exclude but
+# NOT the backoff timing parameters (wait_multiplier, min_wait_sec, max_wait_sec).
+# Those can only be set via this config file, loaded with `--config`.
+#
+# The CLI's --max-retries flag overrides retry.max_retries below at runtime,
+# so the env-var override (CLAUDE_CODE_API_MAX_RETRIES) still works when the
+# run script passes --max-retries. The backoff curve below is always applied.
+retry:
+  max_retries: 5
+  include_exceptions:
+    - RetryableApiError
+  # Exponential backoff: 10s → 20s → 40s → 80s → 120s (capped).
+  # Total wait across 5 retries: ~270s (~4.5 min), giving the upstream
+  # ample time to recover from transient 524s between full-trial restarts.
+  wait_multiplier: 2.0
+  min_wait_sec: 10.0
+  max_wait_sec: 120.0

--- a/benchmark/terminal-bench-2/config/retry.yaml
+++ b/benchmark/terminal-bench-2/config/retry.yaml
@@ -1,14 +1,21 @@
 # Harbor retry configuration for Claude Code + Kimchi gateway runs.
 #
+# This file is a partial JobConfig: only `retry.*` is meaningful — every
+# other JobConfig field is inherited from CLI flags / defaults.
+#
+# Why this exists
+# ---------------
 # Cloudflare returns HTTP 524 ("A timeout occurred") when the Kimchi gateway
 # origin does not produce a response (or a streaming chunk) within Cloudflare's
 # ~100s window. These are transient — the same request typically succeeds on
-# the next attempt — so they must be retried with enough attempts and a
-# backoff curve that gives the upstream time to recover.
+# the next attempt — so we retry with an exponential backoff curve that gives
+# the upstream time to recover.
 #
 # Harbor's CLI exposes --max-retries / --retry-include / --retry-exclude but
-# NOT the backoff timing parameters (wait_multiplier, min_wait_sec, max_wait_sec).
-# Those can only be set via this config file, loaded with `--config`.
+# NOT the backoff timing parameters (wait_multiplier, min_wait_sec,
+# max_wait_sec). Those can only be set via this config file, loaded with
+# `--config`. `include_exceptions` is owned here (the shell script does NOT
+# pass --retry-include, which would replace this value at runtime).
 #
 # The CLI's --max-retries flag overrides retry.max_retries below at runtime,
 # so the env-var override (CLAUDE_CODE_API_MAX_RETRIES) still works when the
@@ -17,9 +24,25 @@ retry:
   max_retries: 5
   include_exceptions:
     - RetryableApiError
-  # Exponential backoff: 10s → 20s → 40s → 80s → 120s (capped).
-  # Total wait across 5 retries: ~270s (~4.5 min), giving the upstream
-  # ample time to recover from transient 524s between full-trial restarts.
+  # `max_retries: 5` means 1 initial attempt + up to 5 retries = 6 total
+  # trial executions per trial, with 5 sleeps between them.
+  #
+  # Formula (harbor/trial/queue.py):
+  #   delay_sec = min(min_wait_sec * wait_multiplier ** attempt, max_wait_sec)
+  # where `attempt` starts at 0 for the first retry.
+  #
+  #   attempt 0 -> 1:  10s
+  #   attempt 1 -> 2:  20s
+  #   attempt 2 -> 3:  40s
+  #   attempt 3 -> 4:  80s
+  #   attempt 4 -> 5: 120s   (capped from 160s)
+  # Total sleep across all retries: ~270s (~4.5 min).
+  #
+  # Wall-clock cost note: each retry re-runs the FULL trial from scratch
+  # (fresh container, Claude Code reinstall, agent restarts from turn 0).
+  # The worst-case wall-clock per trial is therefore:
+  #   ~270s of backoff + 6 * trial_timeout
+  # Keep this in mind when tuning max_retries upward.
   wait_multiplier: 2.0
   min_wait_sec: 10.0
   max_wait_sec: 120.0

--- a/benchmark/terminal-bench-2/scripts/run-claude-code-kimchi.sh
+++ b/benchmark/terminal-bench-2/scripts/run-claude-code-kimchi.sh
@@ -18,9 +18,11 @@ cd "$BENCH_DIR"
 
 # The retry config sets exponential backoff (10s→20s→40s→80s→120s) for
 # transient Cloudflare 524 / API errors. The CLI --max-retries flag overrides
-# only the retry count; the backoff curve always comes from the config file
-# because harbor exposes no CLI flags for wait_multiplier/min_wait/max_wait.
-RETRY_CONFIG="$BENCH_DIR/config/retry.yaml"
+# only the retry count; the backoff curve and include_exceptions always come
+# from the config file because harbor exposes no CLI flags for
+# wait_multiplier/min_wait/max_wait, and passing --retry-include here would
+# clobber include_exceptions from the YAML.
+RETRY_CONFIG="${RETRY_CONFIG:-$BENCH_DIR/config/retry.yaml}"
 
 HARBOR_ARGS=(
     --agent-import-path kimchi_agent:ClaudeCodeKimchi
@@ -29,7 +31,6 @@ HARBOR_ARGS=(
     --ae "KIMCHI_API_KEY=$KIMCHI_API_KEY"
     --config "$RETRY_CONFIG"
     --max-retries "${CLAUDE_CODE_API_MAX_RETRIES:-5}"
-    --retry-include RetryableApiError
     -d "$DATASET"
 )
 

--- a/benchmark/terminal-bench-2/scripts/run-claude-code-kimchi.sh
+++ b/benchmark/terminal-bench-2/scripts/run-claude-code-kimchi.sh
@@ -16,12 +16,19 @@ DATASET="terminal-bench/terminal-bench-2"
 BENCH_DIR="$(cd "$(dirname "$0")/.." && pwd)"
 cd "$BENCH_DIR"
 
+# The retry config sets exponential backoff (10s→20s→40s→80s→120s) for
+# transient Cloudflare 524 / API errors. The CLI --max-retries flag overrides
+# only the retry count; the backoff curve always comes from the config file
+# because harbor exposes no CLI flags for wait_multiplier/min_wait/max_wait.
+RETRY_CONFIG="$BENCH_DIR/config/retry.yaml"
+
 HARBOR_ARGS=(
     --agent-import-path kimchi_agent:ClaudeCodeKimchi
     --env docker
     --model "${MODEL:-kimchi-dev/kimi-k2.5}"
     --ae "KIMCHI_API_KEY=$KIMCHI_API_KEY"
-    --max-retries "${CLAUDE_CODE_API_MAX_RETRIES:-2}"
+    --config "$RETRY_CONFIG"
+    --max-retries "${CLAUDE_CODE_API_MAX_RETRIES:-5}"
     --retry-include RetryableApiError
     -d "$DATASET"
 )

--- a/benchmark/terminal-bench-2/src/kimchi_agent/claude_code_kimchi.py
+++ b/benchmark/terminal-bench-2/src/kimchi_agent/claude_code_kimchi.py
@@ -21,6 +21,14 @@ CLAUDE_CODE_OUTPUT_RESERVE_TOKENS = 32_768
 CLAUDE_CODE_CONTEXT_SAFETY_MARGIN_TOKENS = 8_192
 CLAUDE_CODE_OUTPUT_PATH = "/logs/agent/claude-code.txt"
 CLAUDE_CODE_INSTALL_RETRY_DELAYS_SEC = (5, 15)
+# Default API timeout for Claude Code when no API_TIMEOUT_MS is passed through
+# the environment. Long enough that a slow first streaming token from the
+# Kimchi gateway (or a legitimately long reasoning model) won't trigger a
+# client-side timeout before Cloudflare's own 524 fires. Cloudflare's origin
+# timeout is ~100s, so 300s gives a comfortable margin for the origin to
+# begin streaming and for retryable 524s to surface as RetryableApiError
+# rather than as a client-side abort.
+CLAUDE_CODE_DEFAULT_API_TIMEOUT_MS = "300000"
 RETRYABLE_API_STATUSES = frozenset({408, 409, 425, 429, 500, 502, 503, 504, 524, 529})
 RETRYABLE_API_ERROR_MESSAGE_LIMIT = 2_000
 CLAUDE_PASSTHROUGH_ENV_PREFIXES = ("CLAUDE_CODE_", "OTEL_")
@@ -177,6 +185,12 @@ class ClaudeCodeKimchi(KimchiGatewayMixin, ClaudeCode):
             "FORCE_AUTO_BACKGROUND_TASKS": "1",
             "IS_SANDBOX": "1",
         })
+        # Default API_TIMEOUT_MS only if the caller did not pass one through
+        # (via API_TIMEOUT_MS in the passthrough env). A long timeout prevents
+        # Claude Code from aborting on slow first-token responses from the
+        # Kimchi gateway; retryable Cloudflare 524s still surface as
+        # RetryableApiError via the stream-log classifier.
+        env.setdefault("API_TIMEOUT_MS", CLAUDE_CODE_DEFAULT_API_TIMEOUT_MS)
         env.update({key: "" for key in DENIED_ENV_KEYS})
 
         # Harbor merges _extra_env over env=. Remove keys from that channel so

--- a/benchmark/terminal-bench-2/src/kimchi_agent/claude_code_kimchi.py
+++ b/benchmark/terminal-bench-2/src/kimchi_agent/claude_code_kimchi.py
@@ -22,13 +22,12 @@ CLAUDE_CODE_CONTEXT_SAFETY_MARGIN_TOKENS = 8_192
 CLAUDE_CODE_OUTPUT_PATH = "/logs/agent/claude-code.txt"
 CLAUDE_CODE_INSTALL_RETRY_DELAYS_SEC = (5, 15)
 # Default API timeout for Claude Code when no API_TIMEOUT_MS is passed through
-# the environment. Long enough that a slow first streaming token from the
-# Kimchi gateway (or a legitimately long reasoning model) won't trigger a
-# client-side timeout before Cloudflare's own 524 fires. Cloudflare's origin
-# timeout is ~100s, so 300s gives a comfortable margin for the origin to
-# begin streaming and for retryable 524s to surface as RetryableApiError
-# rather than as a client-side abort.
-CLAUDE_CODE_DEFAULT_API_TIMEOUT_MS = "300000"
+# the environment. Claude Code's built-in default is 600000ms (10 min); we
+# raise it to 15 min so a legitimately long reasoning response from the Kimchi
+# gateway doesn't hit a client-side abort before Cloudflare's ~100s origin
+# timeout has a chance to surface as a retryable 524 (which the harbor retry
+# loop can handle). Callers can override via the API_TIMEOUT_MS passthrough.
+CLAUDE_CODE_DEFAULT_API_TIMEOUT_MS = "900000"
 RETRYABLE_API_STATUSES = frozenset({408, 409, 425, 429, 500, 502, 503, 504, 524, 529})
 RETRYABLE_API_ERROR_MESSAGE_LIMIT = 2_000
 CLAUDE_PASSTHROUGH_ENV_PREFIXES = ("CLAUDE_CODE_", "OTEL_")

--- a/benchmark/terminal-bench-2/src/kimchi_agent/claude_code_kimchi_test.py
+++ b/benchmark/terminal-bench-2/src/kimchi_agent/claude_code_kimchi_test.py
@@ -252,6 +252,24 @@ class ClaudeCodeKimchiTest(unittest.IsolatedAsyncioTestCase):
         env = agent.agent_envs[0]
         self.assertEqual(env["API_TIMEOUT_MS"], "120000")
 
+    async def test_api_timeout_extra_env_overrides_default(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            agent = RecordingClaudeCodeKimchi(
+                logs_dir=Path(tmp) / "jobs" / "run-1" / "task__trial" / "agent",
+                model_name="kimchi-dev/kimi-k2.5",
+                extra_env={"API_TIMEOUT_MS": "1200000"},
+            )
+
+            await agent.run("solve it", object(), AgentContext())
+
+        env = agent.agent_envs[0]
+        self.assertEqual(env["API_TIMEOUT_MS"], "1200000")
+
+    def test_default_api_timeout_exceeds_claude_code_builtin(self) -> None:
+        # Claude Code's built-in default is 600000ms; our default must be
+        # strictly higher so we don't shorten the client-side timeout.
+        self.assertGreater(int(CLAUDE_CODE_DEFAULT_API_TIMEOUT_MS), 600_000)
+
     async def test_rejects_non_kimchi_provider(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:
             agent = RecordingClaudeCodeKimchi(

--- a/benchmark/terminal-bench-2/src/kimchi_agent/claude_code_kimchi_test.py
+++ b/benchmark/terminal-bench-2/src/kimchi_agent/claude_code_kimchi_test.py
@@ -12,6 +12,7 @@ from harbor.models.agent.context import AgentContext
 
 from kimchi_agent.claude_code_kimchi import (
     CLAUDE_CODE_CONTEXT_SAFETY_MARGIN_TOKENS,
+    CLAUDE_CODE_DEFAULT_API_TIMEOUT_MS,
     CLAUDE_CODE_INSTALL_RETRY_DELAYS_SEC,
     CLAUDE_CODE_OUTPUT_RESERVE_TOKENS,
     KIMCHI_ANTHROPIC_BASE_URL,
@@ -219,6 +220,7 @@ class ClaudeCodeKimchiTest(unittest.IsolatedAsyncioTestCase):
             196608 - CLAUDE_CODE_OUTPUT_RESERVE_TOKENS - CLAUDE_CODE_CONTEXT_SAFETY_MARGIN_TOKENS,
         )
         self.assertNotIn("MAX_THINKING_TOKENS", env)
+        self.assertEqual(env["API_TIMEOUT_MS"], CLAUDE_CODE_DEFAULT_API_TIMEOUT_MS)
         self.assertEqual(env["IS_SANDBOX"], "1")
         self.assertEqual(agent.agent_envs[1], env)
         self.assertEqual(agent.metadata_fetch_count, 1)
@@ -237,6 +239,18 @@ class ClaudeCodeKimchiTest(unittest.IsolatedAsyncioTestCase):
 
         self.assertEqual(agent.agent_envs[0]["ANTHROPIC_AUTH_TOKEN"], "extra-key")
         self.assertEqual(agent.fetched_with_api_key, "extra-key")
+
+    async def test_api_timeout_passthrough_overrides_default(self) -> None:
+        with patch.dict(os.environ, {"API_TIMEOUT_MS": "120000"}), tempfile.TemporaryDirectory() as tmp:
+            agent = RecordingClaudeCodeKimchi(
+                logs_dir=Path(tmp) / "jobs" / "run-1" / "task__trial" / "agent",
+                model_name="kimchi-dev/kimi-k2.5",
+            )
+
+            await agent.run("solve it", object(), AgentContext())
+
+        env = agent.agent_envs[0]
+        self.assertEqual(env["API_TIMEOUT_MS"], "120000")
 
     async def test_rejects_non_kimchi_provider(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:

--- a/benchmark/terminal-bench-2/src/kimchi_agent/retry_config_test.py
+++ b/benchmark/terminal-bench-2/src/kimchi_agent/retry_config_test.py
@@ -1,0 +1,55 @@
+"""Contract tests for benchmark/terminal-bench-2/config/retry.yaml.
+
+The runner script (`scripts/run-claude-code-kimchi.sh`) loads this file via
+`harbor run --config`. If a field is renamed or a value drifts, we want to
+catch it in unit tests rather than mid-benchmark. These tests assert the
+YAML round-trips into harbor's `JobConfig` schema and encodes the retry
+policy the shell script relies on.
+"""
+
+from __future__ import annotations
+
+import unittest
+from pathlib import Path
+
+import yaml
+from harbor.models.job.config import JobConfig
+
+RETRY_YAML_PATH = Path(__file__).resolve().parents[2] / "config" / "retry.yaml"
+
+
+class RetryConfigTest(unittest.TestCase):
+    def setUp(self) -> None:
+        self.assertTrue(
+            RETRY_YAML_PATH.exists(),
+            f"retry.yaml missing at expected path: {RETRY_YAML_PATH}",
+        )
+        raw = yaml.safe_load(RETRY_YAML_PATH.read_text())
+        self.config = JobConfig.model_validate(raw)
+
+    def test_retry_policy_matches_shell_script_expectations(self) -> None:
+        retry = self.config.retry
+        self.assertEqual(retry.max_retries, 5)
+        self.assertEqual(retry.wait_multiplier, 2.0)
+        self.assertEqual(retry.min_wait_sec, 10.0)
+        self.assertEqual(retry.max_wait_sec, 120.0)
+        self.assertEqual(retry.include_exceptions, {"RetryableApiError"})
+
+    def test_backoff_curve_matches_documented_values(self) -> None:
+        # This mirrors harbor/trial/queue.py:_calculate_backoff_delay_sec.
+        retry = self.config.retry
+
+        def delay(attempt: int) -> float:
+            return min(
+                retry.min_wait_sec * (retry.wait_multiplier**attempt),
+                retry.max_wait_sec,
+            )
+
+        # 1 initial + 5 retries = 6 attempts, 5 sleeps between them.
+        sleeps = [delay(i) for i in range(retry.max_retries)]
+        self.assertEqual(sleeps, [10.0, 20.0, 40.0, 80.0, 120.0])
+        self.assertEqual(sum(sleeps), 270.0)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Linked issue

Closes #

<!-- Every PR must link to an existing issue. PRs without a linked issue will not be reviewed.
     Use one of: Closes #N / Fixes #N / Resolves #N -->

## What does this PR do?

<!-- Brief description of the change and why it's needed. -->

## Checklist

- [ ] I have read [CONTRIBUTING.md](../CONTRIBUTING.md) and agree to the CLA
- [ ] This PR links to an open issue above
- [ ] Tests pass locally (`pnpm run test`)
- [ ] Lint passes (`pnpm run check`)
- [ ] Documentation updated if behavior changed
