### PR TITLE
fix: skip todo reconciliation when todo tools are unavailable

### DIFF
--- a/src/extensions/todos/index.test.ts
+++ b/src/extensions/todos/index.test.ts
@@ -13,7 +13,7 @@ const theme = {
 	bold: (text: string) => text,
 } as Theme
 
-function createTodosHarness() {
+function createTodosHarness(activeTools: string[] = [...TODO_TOOL_NAMES]) {
 	const handlers = new Map<string, ExtensionHandler[]>()
 	const pi = {
 		registerTool: vi.fn(),
@@ -21,7 +21,7 @@ function createTodosHarness() {
 		registerShortcut: vi.fn(),
 		appendEntry: vi.fn(),
 		sendMessage: vi.fn(),
-		getActiveTools: vi.fn(() => [...TODO_TOOL_NAMES]),
+		getActiveTools: vi.fn(() => activeTools),
 		on: vi.fn((event: string, handler: ExtensionHandler) => {
 			const list = handlers.get(event) ?? []
 			list.push(handler)
@@ -41,6 +41,7 @@ function createTodosHarness() {
 		},
 		appendEntry: pi.appendEntry,
 		sendMessage: pi.sendMessage,
+		getActiveTools: pi.getActiveTools,
 	}
 }
 
@@ -370,5 +371,35 @@ describe("todos extension session state", () => {
 		await harness.fire("turn_end", terminalTurn(), createContext("session", [], { hasPendingMessages: true }))
 
 		expect(harness.sendMessage).not.toHaveBeenCalled()
+	})
+
+	it("does not send reconciliation follow-ups when todo tools are not available (e.g. ferment plan review)", async () => {
+		// Simulates the plan-review-pending state where the ferment extension
+		// suppresses ALL tools via pi.setActiveTools([]). The model cannot
+		// reconcile todos, so sending a follow-up would create an infinite loop.
+		const harness = createTodosHarness([])
+		const ctx = createContext("session", [])
+		await harness.fire("session_start", { reason: "new" }, ctx)
+
+		applyWriteTodos({ todos: [{ content: "still active", status: "in_progress" }] })
+		await harness.fire("tool_execution_end", { toolName: "bash", isError: false }, ctx)
+		await harness.fire("turn_end", terminalTurnWithText(), ctx)
+
+		expect(harness.sendMessage).not.toHaveBeenCalled()
+		// workSinceTodoWrite should be reset so the next turn also doesn't loop.
+		await harness.fire("turn_end", terminalTurnWithText(), ctx)
+		expect(harness.sendMessage).not.toHaveBeenCalled()
+	})
+
+	it("does not inject context checkpoints when todo tools are not available", async () => {
+		const harness = createTodosHarness([])
+		const ctx = createContext("session", [])
+		await harness.fire("session_start", { reason: "new" }, ctx)
+
+		applyWriteTodos({ todos: [{ content: "still active", status: "in_progress" }] })
+		await harness.fire("tool_execution_end", { toolName: "bash", isError: false }, ctx)
+
+		const result = await harness.fire("context", { messages: [] }, ctx)
+		expect(result).toBeUndefined()
 	})
 })

--- a/src/extensions/todos/index.ts
+++ b/src/extensions/todos/index.ts
@@ -48,6 +48,21 @@ function isWriteTodosDetails(value: unknown): value is WriteTodosDetails {
 
 const TODO_REPLAY_TOOL_NAME_SET = new Set<string>([...TODO_TOOL_NAMES, "write_todos"])
 
+/**
+ * Checks whether any todo tool is currently available to the model.
+ *
+ * Other extensions (e.g. ferment plan review) suppress ALL tools via
+ * `pi.setActiveTools([])`. In that state the model cannot reconcile todos —
+ * sending `reconcile_todos` follow-ups or `todo_checkpoint` context messages
+ * would create an infinite loop: the model tries to call todo tools, fails
+ * (tools unavailable), produces text-only output, `turn_end` fires, and the
+ * checkpoint fires again because `workSinceTodoWrite` was never cleared.
+ */
+function anyTodoToolsAvailable(pi: ExtensionAPI): boolean {
+	const active = pi.getActiveTools()
+	return TODO_TOOL_NAMES.some((name) => active.includes(name))
+}
+
 function getWriteTodosDetails(entry: SessionEntry): WriteTodosDetails | undefined {
 	if (entry.type === "custom" && entry.customType === TODO_CUSTOM_ENTRY_TYPE) {
 		return isWriteTodosDetails(entry.data) ? entry.data : undefined
@@ -134,6 +149,14 @@ export default function todosExtension(pi: ExtensionAPI): void {
 	const maybeSteerTodoReconciliation = (message: unknown) => {
 		if (!workSinceTodoWrite) return
 		if (!hasVisibleText(message)) return
+		// If the model has no todo tools available (e.g. during a ferment plan
+		// review where all tools are suppressed), it cannot reconcile todos.
+		// Sending a follow-up would trap it in a text-only loop. Reset the flag
+		// and defer reconciliation until tools are restored.
+		if (!anyTodoToolsAvailable(pi)) {
+			resetTodoProcessState()
+			return
+		}
 		if (!currentTodoStateKey()) {
 			resetTodoProcessState()
 			return
@@ -182,6 +205,9 @@ export default function todosExtension(pi: ExtensionAPI): void {
 
 	pi.on("context", (event) => {
 		if (!workSinceTodoWrite) return undefined
+		// Same guard as maybeSteerTodoReconciliation: if todo tools are not
+		// available (e.g. ferment plan review), skip checkpoint injection.
+		if (!anyTodoToolsAvailable(pi)) return undefined
 		const stateText = currentTodoStateText()
 		if (!stateText) return resetTodoProcessState()
 		return {


### PR DESCRIPTION
## Summary

After `propose_ferment_scoping` returns "Plan ready for review", the ferment extension suppresses ALL tools via `pi.setActiveTools([])` to force the turn to end so the review dialog can appear. The todos extension was unaware of this — it kept sending `reconcile_todos` follow-up messages demanding the model update its todo list. Since the model had no tools, it couldn't comply, producing text-only turns that triggered the checkpoint again → **infinite loop**.

The model degraded from outputting real `update_todos` tool calls as text, to hallucinating non-existent tool names (`update_todos_tui`, `update_todos_tui_with_state...`), until it was finally aborted.

## Implementation

- Add `anyTodoToolsAvailable(pi)` helper that checks `pi.getActiveTools()` for any todo tool name
- Applied in `maybeSteerTodoReconciliation`: if no todo tools are active, reset `workSinceTodoWrite` and skip the `reconcile_todos` follow-up (prevents the infinite loop)
- Applied in the `context` event handler: if no todo tools are active, skip injecting `todo_checkpoint` messages into context
- When tools are restored (after plan review is confirmed/cancelled), normal todo reconciliation resumes on the next non-todo tool execution

## Verification
- `pnpm run check` (lint + typecheck): pass
- `pnpm vitest run src/extensions/todos/index.test.ts`: 17 tests pass (15 existing + 2 new regression tests)

Co-Authored-By: Kimchi <noreply@kimchi.dev>