### PR TITLE
feat: support cursor rules

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -39,6 +39,7 @@ import branchCommandExtension from "./extensions/branch-command.js"
 import claudeCodeHooksAdapter from "./extensions/claude-code-hook-adapter/index.js"
 import claudeCodeSkillsExtension from "./extensions/claude-code-skills/index.js"
 import clipboardImageExtension from "./extensions/clipboard-image.js"
+import cursorRulesExtension from "./extensions/cursor-rules/index.js"
 import customizeFooterExtension from "./extensions/customize-footer-command.js"
 import explorationGuardExtension from "./extensions/exploration-guard.js"
 import fermentExtension from "./extensions/ferment/index.js"
@@ -521,6 +522,9 @@ try {
 			thinkingStepsExtension,
 			assistantPrefixExtension,
 			clipboardImageExtension,
+			...enabledExtensionFactories([
+				{ id: "extensions.cursor-rules", factory: cursorRulesExtension },
+			] satisfies ManagedExtensionFactory[]),
 			sessionModeOnboarding,
 			tipsExtension(),
 			...enabledExtensionFactories([

--- a/src/extensions/cursor-rules/discovery.test.ts
+++ b/src/extensions/cursor-rules/discovery.test.ts
@@ -1,0 +1,115 @@
+import { mkdirSync, rmSync, writeFileSync } from "node:fs"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
+import { afterEach, beforeEach, describe, expect, it } from "vitest"
+import { discoverCursorRules, getRuleBaseDir } from "./discovery.js"
+
+describe("discoverCursorRules", () => {
+	const tmpBase = join(tmpdir(), `kimchi-cursor-rules-${Date.now()}`)
+	const nested = join(tmpBase, "packages", "api")
+
+	beforeEach(() => {
+		rmSync(tmpBase, { recursive: true, force: true })
+		mkdirSync(nested, { recursive: true })
+	})
+
+	afterEach(() => {
+		rmSync(tmpBase, { recursive: true, force: true })
+	})
+
+	it("returns no rules when nothing exists", () => {
+		const result = discoverCursorRules(nested)
+		expect(result.rules).toEqual([])
+	})
+
+	it("discovers a legacy .cursorrules file", () => {
+		writeFileSync(join(tmpBase, ".cursorrules"), "Legacy rule")
+		const result = discoverCursorRules(tmpBase)
+		expect(result.rules).toHaveLength(1)
+		expect(result.rules[0].path).toBe(join(tmpBase, ".cursorrules"))
+		expect(result.rules[0].alwaysApply).toBe(true)
+		expect(result.rules[0].body).toBe("Legacy rule")
+	})
+
+	it("discovers .cursor/rules/*.mdc files", () => {
+		const rulesDir = join(tmpBase, ".cursor", "rules")
+		mkdirSync(rulesDir, { recursive: true })
+		writeFileSync(join(rulesDir, "ts.mdc"), "---\nalwaysApply: true\n---\n\nTS rule")
+		const result = discoverCursorRules(tmpBase)
+		expect(result.rules).toHaveLength(1)
+		expect(result.rules[0].path).toBe(join(rulesDir, "ts.mdc"))
+		expect(result.rules[0].alwaysApply).toBe(true)
+	})
+
+	it("recursively discovers .mdc files in subdirectories", () => {
+		const rulesDir = join(tmpBase, ".cursor", "rules")
+		const subDir = join(rulesDir, "frontend")
+		mkdirSync(subDir, { recursive: true })
+		writeFileSync(join(rulesDir, "root.mdc"), "Root rule")
+		writeFileSync(join(subDir, "nested.mdc"), "Nested rule")
+		const result = discoverCursorRules(tmpBase)
+		const paths = result.rules.map((r) => r.path)
+		expect(paths).toContain(join(rulesDir, "root.mdc"))
+		expect(paths).toContain(join(subDir, "nested.mdc"))
+	})
+
+	it("walks up to ancestors and orders them ancestor-first", () => {
+		const rootRulesDir = join(tmpBase, ".cursor", "rules")
+		const nestedRulesDir = join(nested, ".cursor", "rules")
+		mkdirSync(rootRulesDir, { recursive: true })
+		mkdirSync(nestedRulesDir, { recursive: true })
+		writeFileSync(join(rootRulesDir, "root.mdc"), "Root")
+		writeFileSync(join(nestedRulesDir, "nested.mdc"), "Nested")
+		const result = discoverCursorRules(nested)
+		expect(result.rules).toHaveLength(2)
+		expect(result.rules[0].path).toBe(join(rootRulesDir, "root.mdc"))
+		expect(result.rules[1].path).toBe(join(nestedRulesDir, "nested.mdc"))
+	})
+
+	it("ignores plain .md files in .cursor/rules", () => {
+		const rulesDir = join(tmpBase, ".cursor", "rules")
+		mkdirSync(rulesDir, { recursive: true })
+		writeFileSync(join(rulesDir, "ignored.md"), "Ignored")
+		const result = discoverCursorRules(tmpBase)
+		expect(result.rules).toEqual([])
+	})
+
+	it("deduplicates by absolute path", () => {
+		const rulesDir = join(tmpBase, ".cursor", "rules")
+		mkdirSync(rulesDir, { recursive: true })
+		writeFileSync(join(rulesDir, "once.mdc"), "One")
+		const result = discoverCursorRules(tmpBase)
+		// Calling resolve inside should normalize the path; the same file is only
+		// reachable once from a single cwd, but the dedup guard protects against
+		// future collection changes.
+		expect(result.rules).toHaveLength(1)
+	})
+
+	it("discovers .agents/rules/*.mdc files", () => {
+		const rulesDir = join(tmpBase, ".agents", "rules")
+		mkdirSync(rulesDir, { recursive: true })
+		writeFileSync(join(rulesDir, "api.mdc"), "---\nalwaysApply: true\n---\n\nAPI rule")
+		const result = discoverCursorRules(tmpBase)
+		expect(result.rules).toHaveLength(1)
+		expect(result.rules[0].path).toBe(join(rulesDir, "api.mdc"))
+		expect(result.rules[0].alwaysApply).toBe(true)
+	})
+
+	it("discovers both .cursor/rules and .agents/rules at the same level", () => {
+		const cursorRulesDir = join(tmpBase, ".cursor", "rules")
+		const agentsRulesDir = join(tmpBase, ".agents", "rules")
+		mkdirSync(cursorRulesDir, { recursive: true })
+		mkdirSync(agentsRulesDir, { recursive: true })
+		writeFileSync(join(cursorRulesDir, "cursor.mdc"), "Cursor rule")
+		writeFileSync(join(agentsRulesDir, "agents.mdc"), "Agents rule")
+		const result = discoverCursorRules(tmpBase)
+		const paths = result.rules.map((r) => r.path)
+		expect(paths).toContain(join(cursorRulesDir, "cursor.mdc"))
+		expect(paths).toContain(join(agentsRulesDir, "agents.mdc"))
+	})
+
+	it("computes base dir correctly for .agents/rules", () => {
+		const rulePath = join(tmpBase, ".agents", "rules", "api.mdc")
+		expect(getRuleBaseDir(rulePath)).toBe(tmpBase)
+	})
+})

--- a/src/extensions/cursor-rules/discovery.test.ts
+++ b/src/extensions/cursor-rules/discovery.test.ts
@@ -112,4 +112,9 @@ describe("discoverCursorRules", () => {
 		const rulePath = join(tmpBase, ".agents", "rules", "api.mdc")
 		expect(getRuleBaseDir(rulePath)).toBe(tmpBase)
 	})
+
+	it("computes base dir correctly for nested rules", () => {
+		const rulePath = join(tmpBase, ".cursor", "rules", "frontend", "react.mdc")
+		expect(getRuleBaseDir(rulePath)).toBe(tmpBase)
+	})
 })

--- a/src/extensions/cursor-rules/discovery.ts
+++ b/src/extensions/cursor-rules/discovery.ts
@@ -108,10 +108,14 @@ function tryReadFile(filePath: string): string | null {
 }
 
 export function getRuleBaseDir(rulePath: string): string {
-	// `.cursor/rules/<name>.mdc` or `.agents/rules/<name>.mdc` -> directory
-	// containing `.cursor/` or `.agents/`.
-	if (rulePath.endsWith(RULES_EXTENSION)) {
-		return dirname(dirname(dirname(rulePath)))
+	// Strip the `.cursor/rules/...` or `.agents/rules/...` suffix so rules
+	// nested in subdirectories resolve relative to the project directory.
+	const normalized = rulePath.replace(/\\/g, "/")
+	for (const marker of ["/.cursor/rules/", "/.agents/rules/"]) {
+		const index = normalized.lastIndexOf(marker)
+		if (index !== -1) {
+			return rulePath.slice(0, index)
+		}
 	}
 	// Legacy `.cursorrules` at project root.
 	return dirname(rulePath)

--- a/src/extensions/cursor-rules/discovery.ts
+++ b/src/extensions/cursor-rules/discovery.ts
@@ -1,0 +1,118 @@
+/**
+ * Discover Cursor-style rule files in and above the current working directory.
+ *
+ * We collect:
+ *   - every `.mdc` file under `.cursor/rules/` at every ancestor level
+ *     (closest ancestor wins in rendering order because ancestor-first ordering
+ *     is preserved)
+ *   - every `.mdc` file under `.agents/rules/` at every ancestor level
+ *   - legacy `.cursorrules` files at every ancestor level
+ *
+ * Globs inside a rule are resolved relative to the directory containing the
+ * `.cursor/` or `.agents/` folder (or the directory containing `.cursorrules`).
+ */
+
+import { type Dirent, existsSync, readFileSync, readdirSync } from "node:fs"
+import { dirname, join, resolve } from "node:path"
+import { parseCursorRule, parseLegacyCursorRules } from "./parser.js"
+import type { ParsedCursorRule } from "./types.js"
+
+const CURSOR_RULES_DIR = ".cursor/rules"
+const AGENTS_RULES_DIR = ".agents/rules"
+const RULES_EXTENSION = ".mdc"
+const LEGACY_RULES_FILE = ".cursorrules"
+
+export interface DiscoveredRules {
+	/** Rules ordered ancestor-first (root -> cwd). */
+	rules: ParsedCursorRule[]
+}
+
+export function discoverCursorRules(cwd: string): DiscoveredRules {
+	const rules: ParsedCursorRule[] = []
+	let dir = resolve(cwd)
+	const root = resolve("/")
+	const seenPaths = new Set<string>()
+
+	while (true) {
+		// Prepend so ancestors collected later end up first (root -> cwd).
+		const found: ParsedCursorRule[] = []
+		collectRulesFromDir(dir, found, seenPaths)
+		rules.unshift(...found)
+
+		if (dir === root) break
+		const parent = resolve(dir, "..")
+		if (parent === dir) break
+		dir = parent
+	}
+
+	return { rules }
+}
+
+function collectRulesFromDir(dir: string, rules: ParsedCursorRule[], seenPaths: Set<string>): void {
+	for (const rulesDir of [join(dir, CURSOR_RULES_DIR), join(dir, AGENTS_RULES_DIR)]) {
+		if (existsSync(rulesDir)) {
+			for (const filePath of findMdcFiles(rulesDir)) {
+				const absPath = resolve(filePath)
+				if (seenPaths.has(absPath)) continue
+				seenPaths.add(absPath)
+				const content = tryReadFile(absPath)
+				if (content === null) continue
+				rules.push(parseCursorRule(absPath, content))
+			}
+		}
+	}
+
+	const legacyPath = join(dir, LEGACY_RULES_FILE)
+	if (existsSync(legacyPath)) {
+		const absPath = resolve(legacyPath)
+		if (!seenPaths.has(absPath)) {
+			seenPaths.add(absPath)
+			const content = tryReadFile(absPath)
+			if (content !== null) {
+				rules.push(parseLegacyCursorRules(absPath, content))
+			}
+		}
+	}
+}
+
+function findMdcFiles(dir: string): string[] {
+	const results: string[] = []
+	walkMdcFiles(dir, "", results)
+	return results
+}
+
+function walkMdcFiles(dir: string, relativeDir: string, results: string[]): void {
+	let entries: Dirent[]
+	try {
+		entries = readdirSync(dir, { withFileTypes: true })
+	} catch {
+		return
+	}
+
+	for (const entry of entries) {
+		const relativePath = relativeDir ? `${relativeDir}/${entry.name}` : entry.name
+		if (entry.isDirectory()) {
+			walkMdcFiles(join(dir, entry.name), relativePath, results)
+		} else if (entry.isFile() && entry.name.endsWith(RULES_EXTENSION)) {
+			results.push(join(dir, entry.name))
+		}
+	}
+}
+
+function tryReadFile(filePath: string): string | null {
+	try {
+		return readFileSync(filePath, "utf-8")
+	} catch {
+		return null
+	}
+}
+
+export function getRuleBaseDir(rulePath: string): string {
+	// `.cursor/rules/<name>.mdc` or `.agents/rules/<name>.mdc` -> directory
+	// containing `.cursor/` or `.agents/`.
+	if (rulePath.endsWith(RULES_EXTENSION)) {
+		return dirname(dirname(dirname(rulePath)))
+	}
+	// Legacy `.cursorrules` at project root.
+	return dirname(rulePath)
+}

--- a/src/extensions/cursor-rules/index.test.ts
+++ b/src/extensions/cursor-rules/index.test.ts
@@ -1,0 +1,171 @@
+import { mkdirSync, rmSync } from "node:fs"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
+import type { ExtensionAPI, ExtensionContext } from "@earendil-works/pi-coding-agent"
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
+import { renderSystemPromptBlocks } from "../prompt-construction/system-prompt-blocks.js"
+import cursorRulesExtension from "./index.js"
+import type { ParsedCursorRule } from "./types.js"
+
+const tmpBase = join(tmpdir(), `kimchi-cursor-rules-ext-${Date.now()}`)
+let sessionCounter = 0
+
+vi.mock("./discovery.js", async (importOriginal) => {
+	const actual = await importOriginal<typeof import("./discovery.js")>()
+	return {
+		...actual,
+		discoverCursorRules: vi.fn(),
+	}
+})
+
+const { discoverCursorRules } = await import("./discovery.js")
+
+type EventHandler = (...args: unknown[]) => Promise<unknown>
+type ShutdownHandler = () => void
+
+interface TestPi {
+	api: ExtensionAPI
+	renderBlock: () => string | undefined
+	handlers: Record<string, EventHandler[]>
+	fireShutdown: () => void
+}
+
+const activePis: TestPi[] = []
+
+function makePi(rules: ParsedCursorRule[]): TestPi {
+	const handlers: Record<string, EventHandler[]> = {}
+	const shutdownHandlers: ShutdownHandler[] = []
+	sessionCounter += 1
+	const sessionId = `cursor-rules-test-${sessionCounter}`
+	const ctx: ExtensionContext = {
+		cwd: tmpBase,
+		sessionManager: { getSessionId: () => sessionId },
+	} as unknown as ExtensionContext
+
+	const api: ExtensionAPI = {
+		on(event: string, handler: EventHandler) {
+			handlers[event] = handlers[event] ?? []
+			handlers[event].push(handler)
+			if (event === "session_shutdown") {
+				shutdownHandlers.push(handler as ShutdownHandler)
+			}
+		},
+	} as unknown as ExtensionAPI
+
+	vi.mocked(discoverCursorRules).mockReturnValue({ rules })
+	cursorRulesExtension(api)
+
+	// Fire session_start once after all handlers are registered, mirroring how
+	// pi-mono fires the event once the session is created.
+	for (const handler of handlers.session_start ?? []) {
+		void handler({}, ctx)
+	}
+
+	const pi: TestPi = {
+		api,
+		handlers,
+		fireShutdown: () => {
+			for (const handler of shutdownHandlers) handler()
+		},
+		renderBlock: () => {
+			const blocks = renderSystemPromptBlocks(sessionId, { mode: "orchestrator" })
+			if (blocks.length === 0) return undefined
+			return blocks.map((b) => b.content).join("\n\n")
+		},
+	}
+	activePis.push(pi)
+	return pi
+}
+
+describe("cursorRulesExtension", () => {
+	beforeEach(() => {
+		rmSync(tmpBase, { recursive: true, force: true })
+		mkdirSync(tmpBase, { recursive: true })
+	})
+
+	afterEach(() => {
+		rmSync(tmpBase, { recursive: true, force: true })
+		for (const pi of activePis.splice(0)) pi.fireShutdown()
+		vi.restoreAllMocks()
+	})
+
+	it("renders nothing when no rules exist", () => {
+		const { renderBlock } = makePi([])
+		expect(renderBlock()).toBeUndefined()
+	})
+
+	it("injects alwaysApply rules on session start", () => {
+		const rule: ParsedCursorRule = {
+			path: "/project/.cursor/rules/always.mdc",
+			description: "Always",
+			globs: [],
+			alwaysApply: true,
+			body: "Always apply this.",
+		}
+		const { renderBlock } = makePi([rule])
+		const rendered = renderBlock()
+		expect(rendered).toContain("Always apply this.")
+		expect(rendered).toContain("/project/.cursor/rules/always.mdc")
+	})
+
+	it("injects glob-matched rules after a matching tool_call", async () => {
+		const rule: ParsedCursorRule = {
+			path: join(tmpBase, ".cursor/rules/ts.mdc"),
+			description: "TS",
+			globs: ["src/**/*.ts"],
+			alwaysApply: false,
+			body: "TypeScript rule.",
+		}
+		const { handlers, renderBlock } = makePi([rule])
+
+		const toolHandlers = handlers.tool_call ?? []
+		expect(toolHandlers.length).toBe(1)
+		await toolHandlers[0]({ toolName: "read", input: { path: "src/foo.ts" } })
+
+		const rendered = renderBlock()
+		expect(rendered).toContain("TypeScript rule.")
+		expect(rendered).toContain("src/**/*.ts")
+	})
+
+	it("does not inject glob rules before a matching file is touched", () => {
+		const rule: ParsedCursorRule = {
+			path: "/project/.cursor/rules/ts.mdc",
+			description: "TS",
+			globs: ["src/**/*.ts"],
+			alwaysApply: false,
+			body: "TypeScript rule.",
+		}
+		const { renderBlock } = makePi([rule])
+		const rendered = renderBlock()
+		expect(rendered).toBeUndefined()
+	})
+
+	it("lists available rules when no alwaysApply or glob rule matches", () => {
+		const rule: ParsedCursorRule = {
+			path: "/project/.cursor/rules/described.mdc",
+			description: "API conventions",
+			globs: [],
+			alwaysApply: false,
+			body: "Described rule.",
+		}
+		const { renderBlock } = makePi([rule])
+		const rendered = renderBlock()
+		expect(rendered).toContain("available for this project")
+		expect(rendered).toContain("described.mdc")
+		expect(rendered).toContain("API conventions")
+	})
+
+	it("ignores non-file tools when tracking touched files", async () => {
+		const rule: ParsedCursorRule = {
+			path: "/project/.cursor/rules/ts.mdc",
+			description: "TS",
+			globs: ["src/**/*.ts"],
+			alwaysApply: false,
+			body: "TypeScript rule.",
+		}
+		const { handlers, renderBlock } = makePi([rule])
+		const toolHandlers = handlers.tool_call ?? []
+		await toolHandlers[0]({ toolName: "bash", input: { command: "cat src/foo.ts" } })
+		expect(renderBlock()).toBeUndefined()
+	})
+})

--- a/src/extensions/cursor-rules/index.test.ts
+++ b/src/extensions/cursor-rules/index.test.ts
@@ -155,6 +155,21 @@ describe("cursorRulesExtension", () => {
 		expect(rendered).toContain("API conventions")
 	})
 
+	it("escapes </project_rule> in rule bodies to avoid breaking the envelope", async () => {
+		const rule: ParsedCursorRule = {
+			path: "/project/.cursor/rules/evil.mdc",
+			description: "Evil",
+			globs: [],
+			alwaysApply: true,
+			body: "Contains a literal </project_rule> tag inside.",
+		}
+		const { renderBlock } = makePi([rule])
+		const rendered = renderBlock() ?? ""
+		expect(rendered).toContain("Contains a literal &lt;/project_rule&gt; tag inside.")
+		// Verify the envelope is still closed by our own tag, not the body.
+		expect(rendered).toMatch(/<project_rule path="[^"]+">[\s\S]*<\/project_rule>/)
+	})
+
 	it("ignores non-file tools when tracking touched files", async () => {
 		const rule: ParsedCursorRule = {
 			path: "/project/.cursor/rules/ts.mdc",

--- a/src/extensions/cursor-rules/index.ts
+++ b/src/extensions/cursor-rules/index.ts
@@ -1,0 +1,96 @@
+/**
+ * Cursor rules extension for Kimchi.
+ *
+ * Discovers Cursor-style project rules (`.cursor/rules/*.mdc` and legacy
+ * `.cursorrules`), tracks files the agent touches, and injects only the rules
+ * that are active for the current turn:
+ *   - `alwaysApply: true` rules are always injected.
+ *   - Rules with `globs` are injected when a touched file matches.
+ *   - Rules with only a `description` (or no frontmatter) are listed as
+ *     available so the model can request them.
+ */
+
+import { resolve } from "node:path"
+import type { ExtensionAPI, ExtensionContext } from "@earendil-works/pi-coding-agent"
+import { createSystemPromptBlocks } from "../prompt-construction/index.js"
+import { discoverCursorRules } from "./discovery.js"
+import { getActiveRules } from "./matcher.js"
+import type { ParsedCursorRule } from "./types.js"
+
+const MAX_TOUCHED_FILES = 100
+const FILE_TOOLS = new Set(["read", "write", "edit"])
+
+export default function cursorRulesExtension(pi: ExtensionAPI): void {
+	const touchedFiles = new Set<string>()
+	let rules: ParsedCursorRule[] = []
+	let cwd = ""
+
+	// Register the system-prompt block first so its internal `session_start`
+	// handler records the session ID before any test harness synchronously
+	// fires the event.
+	createSystemPromptBlocks(pi, "cursor-rules").register({
+		id: "active-rules",
+		render: () => renderActiveRules(rules, touchedFiles),
+	})
+
+	pi.on("session_start", async (_event, ctx: ExtensionContext) => {
+		rules = discoverCursorRules(ctx.cwd).rules
+		cwd = ctx.cwd
+		touchedFiles.clear()
+	})
+
+	pi.on("tool_call", async (event) => {
+		const input = event.input as Record<string, unknown>
+		const filePath = extractToolPath(event.toolName, input)
+		if (filePath === undefined) return
+		touchedFiles.add(resolve(cwd, filePath))
+		if (touchedFiles.size > MAX_TOUCHED_FILES) {
+			const first = touchedFiles.values().next().value
+			if (first !== undefined) touchedFiles.delete(first)
+		}
+	})
+}
+
+function extractToolPath(toolName: string, input: Record<string, unknown>): string | undefined {
+	if (!FILE_TOOLS.has(toolName)) return undefined
+	const path = input.path
+	return typeof path === "string" && path.length > 0 ? path : undefined
+}
+
+function renderActiveRules(rules: ParsedCursorRule[], touchedFiles: ReadonlySet<string>): string | undefined {
+	if (rules.length === 0) return undefined
+
+	const active = getActiveRules(rules, touchedFiles)
+	const sections: string[] = []
+
+	for (const rule of active.alwaysApply) {
+		sections.push(formatInjectedRule(rule))
+	}
+
+	for (const rule of active.matched) {
+		sections.push(formatInjectedRule(rule, rule.globs.join(", ")))
+	}
+
+	if (active.available.length > 0) {
+		sections.push(formatAvailableRules(active.available))
+	}
+
+	if (sections.length === 0) return undefined
+	return `## Cursor Rules\n\n${sections.join("\n\n")}`
+}
+
+function formatInjectedRule(rule: ParsedCursorRule, appliesTo?: string): string {
+	const header = appliesTo
+		? `<project_rule path="${rule.path}" applies_to="${appliesTo}">`
+		: `<project_rule path="${rule.path}">`
+	return `${header}\n${rule.body}\n</project_rule>`
+}
+
+function formatAvailableRules(available: ParsedCursorRule[]): string {
+	const lines = available.map((rule) => {
+		const name = rule.path.split("/").pop() ?? rule.path
+		const desc = rule.description ?? "Manual rule — request it explicitly if relevant."
+		return `- \`${name}\`: ${desc}`
+	})
+	return `The following Cursor rules are available for this project. Request one explicitly if it is relevant:\n\n${lines.join("\n")}`
+}

--- a/src/extensions/cursor-rules/index.ts
+++ b/src/extensions/cursor-rules/index.ts
@@ -10,7 +10,7 @@
  *     available so the model can request them.
  */
 
-import { resolve } from "node:path"
+import { basename, resolve } from "node:path"
 import type { ExtensionAPI, ExtensionContext } from "@earendil-works/pi-coding-agent"
 import { createSystemPromptBlocks } from "../prompt-construction/index.js"
 import { discoverCursorRules } from "./discovery.js"
@@ -40,6 +40,7 @@ export default function cursorRulesExtension(pi: ExtensionAPI): void {
 	})
 
 	pi.on("tool_call", async (event) => {
+		if (!cwd) return
 		const input = event.input as Record<string, unknown>
 		const filePath = extractToolPath(event.toolName, input)
 		if (filePath === undefined) return
@@ -83,12 +84,17 @@ function formatInjectedRule(rule: ParsedCursorRule, appliesTo?: string): string 
 	const header = appliesTo
 		? `<project_rule path="${rule.path}" applies_to="${appliesTo}">`
 		: `<project_rule path="${rule.path}">`
-	return `${header}\n${rule.body}\n</project_rule>`
+	return `${header}\n${escapeRuleBody(rule.body)}\n</project_rule>`
+}
+
+function escapeRuleBody(body: string): string {
+	// Prevent a rule body from prematurely closing the <project_rule> envelope.
+	return body.replace(/<\/project_rule>/g, "&lt;/project_rule&gt;")
 }
 
 function formatAvailableRules(available: ParsedCursorRule[]): string {
 	const lines = available.map((rule) => {
-		const name = rule.path.split("/").pop() ?? rule.path
+		const name = basename(rule.path)
 		const desc = rule.description ?? "Manual rule — request it explicitly if relevant."
 		return `- \`${name}\`: ${desc}`
 	})

--- a/src/extensions/cursor-rules/matcher.test.ts
+++ b/src/extensions/cursor-rules/matcher.test.ts
@@ -1,0 +1,84 @@
+import { describe, expect, it } from "vitest"
+import { getActiveRules } from "./matcher.js"
+import type { ParsedCursorRule } from "./types.js"
+
+function makeRule(overrides: Partial<ParsedCursorRule> & { path: string }): ParsedCursorRule {
+	return {
+		description: undefined,
+		globs: [],
+		alwaysApply: false,
+		body: "Body",
+		...overrides,
+	}
+}
+
+describe("getActiveRules", () => {
+	it("includes alwaysApply rules regardless of touched files", () => {
+		const rule = makeRule({ path: "/project/.cursor/rules/always.mdc", alwaysApply: true })
+		const result = getActiveRules([rule], new Set())
+		expect(result.alwaysApply).toEqual([rule])
+		expect(result.matched).toEqual([])
+		expect(result.available).toEqual([])
+	})
+
+	it("matches glob rules when a touched file matches", () => {
+		const rule = makeRule({ path: "/project/.cursor/rules/ts.mdc", globs: ["src/**/*.ts"] })
+		const result = getActiveRules([rule], new Set(["/project/src/foo.ts"]))
+		expect(result.alwaysApply).toEqual([])
+		expect(result.matched).toEqual([rule])
+		expect(result.available).toEqual([])
+	})
+
+	it("does not include glob rules when no touched file matches", () => {
+		const rule = makeRule({ path: "/project/.cursor/rules/ts.mdc", globs: ["src/**/*.ts"] })
+		const result = getActiveRules([rule], new Set(["/project/lib/foo.js"]))
+		expect(result.alwaysApply).toEqual([])
+		expect(result.matched).toEqual([])
+		expect(result.available).toEqual([])
+	})
+
+	it("matches globs relative to the rule's base directory", () => {
+		const rule = makeRule({ path: "/project/packages/api/.cursor/rules/api.mdc", globs: ["src/**/*.ts"] })
+		const result = getActiveRules([rule], new Set(["/project/packages/api/src/foo.ts"]))
+		expect(result.matched).toEqual([rule])
+	})
+
+	it("does not match files outside the rule's base directory", () => {
+		const rule = makeRule({ path: "/project/packages/api/.cursor/rules/api.mdc", globs: ["src/**/*.ts"] })
+		const result = getActiveRules([rule], new Set(["/project/src/foo.ts"]))
+		expect(result.matched).toEqual([])
+	})
+
+	it("lists description-only rules as available", () => {
+		const rule = makeRule({ path: "/project/.cursor/rules/described.mdc", description: "API conventions" })
+		const result = getActiveRules([rule], new Set())
+		expect(result.alwaysApply).toEqual([])
+		expect(result.matched).toEqual([])
+		expect(result.available).toEqual([rule])
+	})
+
+	it("lists manual rules (no frontmatter) as available", () => {
+		const rule = makeRule({ path: "/project/.cursor/rules/manual.mdc" })
+		const result = getActiveRules([rule], new Set())
+		expect(result.available).toEqual([rule])
+	})
+
+	it("prefers alwaysApply over globs and available", () => {
+		const rule = makeRule({
+			path: "/project/.cursor/rules/both.mdc",
+			alwaysApply: true,
+			globs: ["src/**/*.ts"],
+			description: "Desc",
+		})
+		const result = getActiveRules([rule], new Set())
+		expect(result.alwaysApply).toEqual([rule])
+		expect(result.matched).toEqual([])
+		expect(result.available).toEqual([])
+	})
+
+	it("matches multiple globs in a single rule", () => {
+		const rule = makeRule({ path: "/project/.cursor/rules/multi.mdc", globs: ["*.ts", "*.tsx"] })
+		const result = getActiveRules([rule], new Set(["/project/foo.tsx"]))
+		expect(result.matched).toEqual([rule])
+	})
+})

--- a/src/extensions/cursor-rules/matcher.ts
+++ b/src/extensions/cursor-rules/matcher.ts
@@ -1,0 +1,55 @@
+/**
+ * Decide which Cursor rules are active for the current turn.
+ *
+ * A rule can be:
+ *   - alwaysApply: true     -> always active
+ *   - globs present         -> active if any touched file matches a glob
+ *   - description present   -> listed as available; agent decides relevance
+ *   - none of the above     -> listed as available; only via @mention
+ */
+
+import { relative } from "node:path"
+import micromatch from "micromatch"
+import { getRuleBaseDir } from "./discovery.js"
+import type { ParsedCursorRule } from "./types.js"
+
+export interface ActiveRules {
+	/** Rules that always apply. */
+	alwaysApply: ParsedCursorRule[]
+	/** Rules whose globs matched at least one touched file. */
+	matched: ParsedCursorRule[]
+	/** Rules available for agent-requested or manual use. */
+	available: ParsedCursorRule[]
+}
+
+export function getActiveRules(rules: readonly ParsedCursorRule[], touchedFiles: ReadonlySet<string>): ActiveRules {
+	const result: ActiveRules = { alwaysApply: [], matched: [], available: [] }
+
+	for (const rule of rules) {
+		if (rule.alwaysApply) {
+			result.alwaysApply.push(rule)
+			continue
+		}
+
+		if (rule.globs.length > 0) {
+			if (matchesAnyGlob(rule, touchedFiles)) {
+				result.matched.push(rule)
+			}
+			continue
+		}
+
+		result.available.push(rule)
+	}
+
+	return result
+}
+
+function matchesAnyGlob(rule: ParsedCursorRule, touchedFiles: ReadonlySet<string>): boolean {
+	const baseDir = getRuleBaseDir(rule.path)
+	for (const filePath of touchedFiles) {
+		const rel = relative(baseDir, filePath)
+		if (rel.startsWith("..")) continue
+		if (micromatch.isMatch(rel, rule.globs as string[])) return true
+	}
+	return false
+}

--- a/src/extensions/cursor-rules/parser.test.ts
+++ b/src/extensions/cursor-rules/parser.test.ts
@@ -1,0 +1,101 @@
+import { describe, expect, it } from "vitest"
+import { parseCursorRule, parseLegacyCursorRules } from "./parser.js"
+
+describe("parseCursorRule", () => {
+	it("parses a full mdc rule with frontmatter", () => {
+		const content = `---
+description: TypeScript conventions
+globs:
+  - "src/**/*.ts"
+  - "src/**/*.tsx"
+alwaysApply: true
+---
+
+# TypeScript
+
+Use strict mode. Prefer unknown over any.`
+		const rule = parseCursorRule("/project/.cursor/rules/ts.mdc", content)
+		expect(rule.path).toBe("/project/.cursor/rules/ts.mdc")
+		expect(rule.description).toBe("TypeScript conventions")
+		expect(rule.globs).toEqual(["src/**/*.ts", "src/**/*.tsx"])
+		expect(rule.alwaysApply).toBe(true)
+		expect(rule.body).toBe("# TypeScript\n\nUse strict mode. Prefer unknown over any.")
+	})
+
+	it("treats a rule without frontmatter as manual", () => {
+		const content = "# Manual rule\n\nOnly use when asked."
+		const rule = parseCursorRule("/project/.cursor/rules/manual.mdc", content)
+		expect(rule.description).toBeUndefined()
+		expect(rule.globs).toEqual([])
+		expect(rule.alwaysApply).toBe(false)
+		expect(rule.body).toBe(content)
+	})
+
+	it("parses comma-separated globs", () => {
+		const content = `---
+globs: "*.ts, *.tsx"
+---
+
+Body`
+		const rule = parseCursorRule("/project/.cursor/rules/globs.mdc", content)
+		expect(rule.globs).toEqual(["*.ts", "*.tsx"])
+	})
+
+	it("defaults alwaysApply to false when omitted", () => {
+		const content = `---
+description: A described rule
+---
+
+Body`
+		const rule = parseCursorRule("/project/.cursor/rules/described.mdc", content)
+		expect(rule.alwaysApply).toBe(false)
+		expect(rule.description).toBe("A described rule")
+	})
+
+	it("falls back to full content when frontmatter YAML is invalid", () => {
+		const content = `---
+description: : : :
+alwaysApply: not-a-boolean
+---
+
+Body`
+		const rule = parseCursorRule("/project/.cursor/rules/bad.mdc", content)
+		expect(rule.body).toBe(content)
+		expect(rule.alwaysApply).toBe(false)
+		expect(rule.globs).toEqual([])
+	})
+
+	it("ignores empty or whitespace-only description", () => {
+		const content = `---
+description: "   "
+---
+
+Body`
+		const rule = parseCursorRule("/project/.cursor/rules/empty-desc.mdc", content)
+		expect(rule.description).toBeUndefined()
+	})
+
+	it("ignores non-string globs", () => {
+		const content = `---
+globs:
+  - "*.ts"
+  - 42
+  - true
+---
+
+Body`
+		const rule = parseCursorRule("/project/.cursor/rules/mixed-globs.mdc", content)
+		expect(rule.globs).toEqual(["*.ts"])
+	})
+})
+
+describe("parseLegacyCursorRules", () => {
+	it("returns an always-apply rule wrapping the content", () => {
+		const rule = parseLegacyCursorRules("/project/.cursorrules", "Legacy content")
+		expect(rule.path).toBe("/project/.cursorrules")
+		expect(rule.alwaysApply).toBe(true)
+		expect(rule.globs).toEqual([])
+		expect(rule.body).toBe("Legacy content")
+		expect(rule.description).toBe("Legacy .cursorrules file")
+	})
+})

--- a/src/extensions/cursor-rules/parser.ts
+++ b/src/extensions/cursor-rules/parser.ts
@@ -1,0 +1,72 @@
+/**
+ * Parse Cursor rule files.
+ *
+ * `.cursor/rules/*.mdc` files contain YAML frontmatter followed by markdown.
+ * Legacy `.cursorrules` files are plain text and always apply.
+ */
+
+import { parse as parseYaml } from "yaml"
+import type { ParsedCursorRule } from "./types.js"
+
+const FRONTMATTER_DELIMITER = "---"
+
+export function parseCursorRule(path: string, content: string): ParsedCursorRule {
+	const trimmed = content.trimStart()
+	let description: string | undefined
+	let globs: readonly string[] = []
+	let alwaysApply = false
+	let body = content
+
+	if (trimmed.startsWith(FRONTMATTER_DELIMITER)) {
+		const endIndex = trimmed.indexOf(FRONTMATTER_DELIMITER, FRONTMATTER_DELIMITER.length)
+		if (endIndex !== -1) {
+			const frontmatter = trimmed.slice(FRONTMATTER_DELIMITER.length, endIndex).trim()
+			body = trimmed.slice(endIndex + FRONTMATTER_DELIMITER.length).trimStart()
+			if (frontmatter) {
+				try {
+					const parsed = parseYaml(frontmatter) as Record<string, unknown>
+					description = parseDescription(parsed.description)
+					alwaysApply = parseAlwaysApply(parsed.alwaysApply)
+					globs = parseGlobs(parsed.globs)
+				} catch {
+					// Malformed frontmatter: fall back to treating the whole file as body.
+					body = content
+				}
+			}
+		}
+	}
+
+	return { path, description, globs, alwaysApply, body }
+}
+
+export function parseLegacyCursorRules(path: string, content: string): ParsedCursorRule {
+	return {
+		path,
+		description: "Legacy .cursorrules file",
+		globs: [],
+		alwaysApply: true,
+		body: content,
+	}
+}
+
+function parseDescription(value: unknown): string | undefined {
+	if (typeof value === "string" && value.trim().length > 0) return value.trim()
+	return undefined
+}
+
+function parseAlwaysApply(value: unknown): boolean {
+	return value === true
+}
+
+function parseGlobs(value: unknown): readonly string[] {
+	if (typeof value === "string") {
+		return value
+			.split(",")
+			.map((s) => s.trim())
+			.filter((s) => s.length > 0)
+	}
+	if (Array.isArray(value)) {
+		return value.filter((s): s is string => typeof s === "string" && s.trim().length > 0)
+	}
+	return []
+}

--- a/src/extensions/cursor-rules/types.ts
+++ b/src/extensions/cursor-rules/types.ts
@@ -1,0 +1,25 @@
+/**
+ * Shared types for the Cursor rules extension.
+ *
+ * Cursor rules are markdown instruction files. The modern `.mdc` format uses
+ * YAML frontmatter to control when a rule is injected:
+ *   - `alwaysApply: true`  -> always included
+ *   - `globs`              -> included when a touched file matches
+ *   - `description`        -> listed as available; agent decides relevance
+ *   - none of the above    -> listed as available; only via @mention
+ *
+ * Legacy `.cursorrules` files are treated as a single always-apply rule.
+ */
+
+export interface ParsedCursorRule {
+	/** Absolute path to the rule file. */
+	path: string
+	/** Optional one-line summary used by the agent to decide relevance. */
+	description: string | undefined
+	/** Glob patterns that trigger the rule when a touched file matches. */
+	globs: readonly string[]
+	/** Whether the rule should always be injected. */
+	alwaysApply: boolean
+	/** The markdown body of the rule. */
+	body: string
+}

--- a/src/resources/definitions.test.ts
+++ b/src/resources/definitions.test.ts
@@ -84,6 +84,19 @@ describe("resource definitions", () => {
 		// required when the user flips the /resources toggle.
 		expect(resource?.restartRequired).toBeFalsy()
 	})
+
+	it("registers cursor-rules as a toggleable extension", () => {
+		const resources = getResourceDefinitions()
+		const resource = resources.find((r) => r.id === "extensions.cursor-rules")
+		expect(resource).toMatchObject({
+			kind: "extensions",
+			label: "Cursor rules",
+			defaultEnabled: true,
+		})
+		// Toggling is dynamic — rules are only discovered/injected when the
+		// resource is enabled, so no restart is required.
+		expect(resource?.restartRequired).toBeFalsy()
+	})
 })
 
 function writeJson(path: string, data: unknown): void {

--- a/src/resources/definitions.ts
+++ b/src/resources/definitions.ts
@@ -77,6 +77,14 @@ export const STATIC_RESOURCE_DEFINITIONS: readonly ResourceDefinition[] = [
 		defaultEnabled: true,
 	},
 	{
+		id: "extensions.cursor-rules",
+		kind: "extensions",
+		label: "Cursor rules",
+		description:
+			"Load Cursor-style project rules from .cursor/rules and .agents/rules and inject matching rules into the system prompt.",
+		defaultEnabled: true,
+	},
+	{
 		id: "extensions.claude-code-hook-adapter",
 		kind: "extensions",
 		label: "Claude Code hook adapter",

--- a/tests/e2e/tui/cursor-rules.test.ts
+++ b/tests/e2e/tui/cursor-rules.test.ts
@@ -1,0 +1,63 @@
+import { expect, test } from "@microsoft/tui-test"
+import { mkdirSync, writeFileSync } from "node:fs"
+import { join } from "node:path"
+import { TUI_TEST_CONFIG, runKimchiSession } from "./support/kimchi-fixture.js"
+
+test.use(TUI_TEST_CONFIG)
+
+/**
+ * E2E coverage for the cursor-rules extension.
+ *
+ * Seeds a project with `.cursor/rules/always.mdc` and `.agents/rules/general.mdc`,
+ * launches Kimchi against the fake LLM server, submits one prompt, and asserts
+ * the rule bodies appear in the recorded system prompt.
+ *
+ * This complements the unit tests in src/extensions/cursor-rules/ by proving
+ * the extension is registered in cli.ts and actually injects rules into live
+ * provider requests.
+ */
+
+test("cursor-rules extension injects discovered rules into the system prompt", async ({ terminal }) => {
+	const cursorMarker = "CURSOR_RULES_E2E_MARKER_42"
+	const agentsMarker = "AGENTS_RULES_E2E_MARKER_99"
+
+	await runKimchiSession(
+		terminal,
+		{
+			artifactName: "cursor-rules-injection",
+			responses: [{ stream: ["Hello from cursor rules test."] }],
+			seedHome(_homeDir, workDir) {
+				const cursorRulesDir = join(workDir, ".cursor", "rules")
+				const agentsRulesDir = join(workDir, ".agents", "rules")
+				mkdirSync(cursorRulesDir, { recursive: true })
+				mkdirSync(agentsRulesDir, { recursive: true })
+				writeFileSync(
+					join(cursorRulesDir, "always.mdc"),
+					`---\ndescription: E2E always-apply rule\nalwaysApply: true\n---\n\nAlways mention ${cursorMarker} in your thinking.`,
+					"utf-8",
+				)
+				writeFileSync(
+					join(agentsRulesDir, "general.mdc"),
+					`---\ndescription: E2E agents rule\nalwaysApply: true\n---\n\nAlways mention ${agentsMarker} in your thinking.`,
+					"utf-8",
+				)
+			},
+		},
+		async (fixture, trace) => {
+			terminal.submit("say hello")
+			trace.step("submitted prompt")
+
+			await expect(terminal.getByText("Hello from cursor rules test.", { full: true })).toBeVisible()
+			trace.step("response rendered")
+
+			const chatRequests = fixture.fake.requests.filter((request) =>
+				request.url.includes("/chat/completions"),
+			)
+			expect(chatRequests.length).toBeGreaterThan(0)
+
+			const firstRequestBody = JSON.stringify(chatRequests[0].body ?? "")
+			expect(firstRequestBody).toContain(cursorMarker)
+			expect(firstRequestBody).toContain(agentsMarker)
+		},
+	)
+})


### PR DESCRIPTION
## What does this PR do?

Implementing granular cursor like support as extension. Coded our own as the OSS are not well maintained.

https://cursor.com/docs/rules

## Checklist

- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md) and agree to the CLA
- [ ] This PR links to an open issue above
- [x] Tests pass locally (`pnpm run test`)
- [x] Lint passes (`pnpm run check`)
- [ ] Documentation updated if behavior changed
