### PR TITLE
feat(redaction): add tool result redaction extension

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -65,6 +65,7 @@ import pluginPackageHooksAdapter from "./extensions/plugin-package-hook-adapter/
 import promptEnrichmentExtension from "./extensions/prompt-construction/prompt-enrichment.js"
 import promptSummaryExtension from "./extensions/prompt-summary.js"
 import questionnaireExtension from "./extensions/questionnaire/index.js"
+import createRedactionExtension from "./extensions/redaction/index.js"
 import reportBugExtension from "./extensions/report-bug.js"
 import reviewWriteGuardExtension from "./extensions/review-write-guard.js"
 import rtkRewriteExtension from "./extensions/rtk-rewrite.js"
@@ -558,6 +559,7 @@ try {
 			traceIdExtension,
 			llmResponseLogExtension,
 			activityExtension,
+			createRedactionExtension,
 		]
 
 		if (acpMode) {

--- a/src/config.ts
+++ b/src/config.ts
@@ -680,6 +680,32 @@ export function readGitToken(host: string, configPath?: string): string | undefi
 }
 
 /**
+ * Read all stored git tokens from the global config.
+ * Returns a map of host → token, or undefined if the config file
+ * or gitTokens field is missing.
+ */
+export function readAllGitTokens(configPath?: string): Record<string, string> | undefined {
+	const path = configPath ?? KIMCHI_CONFIG_PATH
+	try {
+		const raw = readFileSync(path, "utf-8")
+		const parsed = JSON.parse(raw)
+		const tokens = parsed.gitTokens
+		if (tokens && typeof tokens === "object" && !Array.isArray(tokens)) {
+			const result: Record<string, string> = {}
+			for (const [host, token] of Object.entries(tokens)) {
+				if (typeof token === "string") {
+					result[host] = token
+				}
+			}
+			return result
+		}
+		return undefined
+	} catch {
+		return undefined
+	}
+}
+
+/**
  * Persist a git token for a specific host in the global config.
  * Stored under `gitTokens.<host>` alongside the API key, following the same
  * security model (plaintext in `~/.config/kimchi/config.json`).

--- a/src/extensions/redaction/engine.test.ts
+++ b/src/extensions/redaction/engine.test.ts
@@ -1,0 +1,193 @@
+import { describe, expect, it } from "vitest"
+import { PATTERN_CATALOG, redact } from "./engine.js"
+
+describe("redact", () => {
+	describe("pattern catalog", () => {
+		it("redacts AWS access key IDs", () => {
+			const text = "aws_access_key_id = AKIAIOSFODNN7EXAMPLE"
+			expect(redact(text, new Set())).toBe("aws_access_key_id = [REDACTED]")
+		})
+
+		it("redacts AWS secret access keys in config format", () => {
+			const text = "aws_secret_access_key = wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY"
+			expect(redact(text, new Set())).toBe("aws_secret_access_key = [REDACTED]")
+		})
+
+		it("redacts AWS secret access keys with colon separator", () => {
+			const text = 'aws_secret_access_key: "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY"'
+			expect(redact(text, new Set())).toBe('aws_secret_access_key: "[REDACTED]"')
+		})
+
+		it("redacts GitHub classic tokens", () => {
+			const text = "GITHUB_TOKEN=ghp_abcdefghijklmnopqrstuvwxyz0123456789"
+			expect(redact(text, new Set())).toBe("GITHUB_TOKEN=[REDACTED]")
+		})
+
+		it("redacts GitHub fine-grained PATs", () => {
+			const text = "github_pat_abcdefghijklmnopqrstuvwxyz0123"
+			expect(redact(text, new Set())).toBe("[REDACTED]")
+		})
+
+		it("redacts GitLab tokens", () => {
+			const text = "gitlab_token=glpat-abcdefghijklmnopqrstuvwxyz0123"
+			expect(redact(text, new Set())).toBe("gitlab_token=[REDACTED]")
+		})
+
+		it("redacts JWTs", () => {
+			const jwt =
+				"eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ.SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c"
+			expect(redact(`token: ${jwt}`, new Set())).toBe("token: [REDACTED]")
+		})
+
+		it("redacts JWTs with non-eyJ payload and signature", () => {
+			// Header starts with eyJ, but payload and signature do not.
+			const jwt = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.U29tZS1iYXNlNjQtcGF5bG9hZA.SflKxwRJSMeKKF2QT4fwpMeJf36P"
+			expect(redact(`token: ${jwt}`, new Set())).toBe("token: [REDACTED]")
+		})
+
+		it("redacts PEM private key blocks", () => {
+			const text = `-----BEGIN RSA PRIVATE KEY-----
+MIIEpAIBAAKCAQEA0Z3VS5JJcds3xfn/ygWyF5TkDkLQ7n5t1QX2uJ
+fM1H5ZbGaR9V4pDqsM7n5t1QX2uJfM1H5ZbGaR9V4pDqsM7n5t1QX2
+-----END RSA PRIVATE KEY-----`
+			expect(redact(text, new Set())).toBe("[REDACTED]")
+		})
+
+		it("redacts Slack tokens", () => {
+			const text = "slack_token=xoxb-fakeslacktoken-notarealtoken-fakedata12"
+			expect(redact(text, new Set())).toBe("slack_token=[REDACTED]")
+		})
+
+		it("redacts generic Bearer tokens", () => {
+			const text = "Authorization: Bearer dGhpcyBpcyBhIHNlY3JldCB0b2tlbg=="
+			expect(redact(text, new Set())).toBe("Authorization: [REDACTED]")
+		})
+
+		it("redacts Bearer tokens with base64 characters", () => {
+			const text = "Authorization: Bearer QWxhZGRpbjpvcGVuIHNlc2FtZQ=="
+			expect(redact(text, new Set())).toBe("Authorization: [REDACTED]")
+		})
+
+		it("redacts env var assignments with API_KEY in name", () => {
+			const text = "MY_API_KEY=a1b2c3d4e5f6a7b8c9d0e1f2a3b4c5d6"
+			expect(redact(text, new Set())).toBe("MY_API_KEY=[REDACTED]")
+		})
+
+		it("redacts env var assignments with ACCESS_KEY in name", () => {
+			const text = "STORAGE_ACCESS_KEY=GOOG1EH37KFIKLDLG6DW7BYS3ZWBOJVTELXQO35B4"
+			expect(redact(text, new Set())).toBe("STORAGE_ACCESS_KEY=[REDACTED]")
+		})
+
+		it("redacts env var assignments with PASSWORD in name", () => {
+			const text = "DB_PASSWORD=abcdef0123456789abcdef0123456789"
+			expect(redact(text, new Set())).toBe("DB_PASSWORD=[REDACTED]")
+		})
+
+		it("redacts env var assignments with SECRET in name and colon separator", () => {
+			const text = "client_secret: dGhpcyBpcyBhIHNlY3JldCB2YWx1ZQ=="
+			expect(redact(text, new Set())).toBe("client_secret: [REDACTED]")
+		})
+
+		it("redacts quoted secret values", () => {
+			const text = 'DB_PASSWORD="my-secret-pass-1234"'
+			expect(redact(text, new Set())).toBe('DB_PASSWORD="[REDACTED]"')
+		})
+
+		it("redacts multiple env var secrets in one block", () => {
+			const text = [
+				"DB_PASSWORD=abcdef0123456789abcdef0123456789",
+				"STORAGE_ACCESS_KEY=GOOG1EH37KFIKLDLG6DW7BYS3ZWBOJVTELXQO35B4",
+				"API_SECRET=dGhpcyBpcyBhIHNlY3JldCB2YWx1ZQ==",
+			].join("\n")
+			const result = redact(text, new Set())
+			expect(result).toBe("DB_PASSWORD=[REDACTED]\nSTORAGE_ACCESS_KEY=[REDACTED]\nAPI_SECRET=[REDACTED]")
+		})
+
+		it("does not false-positive on non-secret KEY names", () => {
+			const text = "MONKEY_TYPE=chimpanzee"
+			expect(redact(text, new Set())).toBe("MONKEY_TYPE=chimpanzee")
+		})
+
+		it("does not redact short values under 8 chars", () => {
+			const text = "API_KEY=abc123"
+			expect(redact(text, new Set())).toBe("API_KEY=abc123")
+		})
+
+		it("preserves the key name, redacts only the value", () => {
+			const text = "TOKEN=ghp_abcdefghijklmnopqrstuvwxyz0123456789"
+			const result = redact(text, new Set())
+			expect(result).toBe("TOKEN=[REDACTED]")
+		})
+	})
+
+	describe("exact-match stage", () => {
+		it("redacts a known apiKey", () => {
+			const secrets = new Set(["test-api-key-123456789"])
+			expect(redact("key=test-api-key-123456789", secrets)).toBe("key=[REDACTED]")
+		})
+
+		it("redacts a known gitToken", () => {
+			const secrets = new Set(["ghp_knownTokenValue123456789012345678"])
+			expect(redact("token: ghp_knownTokenValue123456789012345678", secrets)).toBe("token: [REDACTED]")
+		})
+
+		it("redacts multiple known secrets in one string", () => {
+			const secrets = new Set(["secret-aaaa1111", "secret-bbbb2222"])
+			expect(redact("a=secret-aaaa1111 b=secret-bbbb2222", secrets)).toBe("a=[REDACTED] b=[REDACTED]")
+		})
+
+		it("redacts secret at start of text", () => {
+			const secrets = new Set(["test-secret-value-12345678"])
+			expect(redact("test-secret-value-12345678 is here", secrets)).toBe("[REDACTED] is here")
+		})
+
+		it("redacts secret at end of text", () => {
+			const secrets = new Set(["test-secret-value-12345678"])
+			expect(redact("here is test-secret-value-12345678", secrets)).toBe("here is [REDACTED]")
+		})
+
+		it("redacts secret in middle of text", () => {
+			const secrets = new Set(["test-secret-value-12345678"])
+			expect(redact("prefix test-secret-value-12345678 suffix", secrets)).toBe("prefix [REDACTED] suffix")
+		})
+	})
+
+	describe("edge cases", () => {
+		it("returns empty string unchanged", () => {
+			expect(redact("", new Set())).toBe("")
+		})
+
+		it("returns text unchanged when no secrets match", () => {
+			const text = "just a normal command output line"
+			expect(redact(text, new Set())).toBe(text)
+		})
+
+		it("skips known secrets shorter than 8 characters", () => {
+			const secrets = new Set(["short"])
+			expect(redact("this is short text", secrets)).toBe("this is short text")
+		})
+
+		it("does not false-positive on short eyJ strings", () => {
+			expect(redact("data=eyJabc.eyJdef.eyJghi", new Set())).toBe("data=eyJabc.eyJdef.eyJghi")
+		})
+
+		it("handles multiple PEM blocks in one string", () => {
+			const text = `Key1:
+-----BEGIN RSA PRIVATE KEY-----
+MIIEpAIBAAKCAQEA0Z3VS5JJcds3xfn/ygWyF5TkDkLQ7n5t1QX2uJ
+-----END RSA PRIVATE KEY-----
+Key2:
+-----BEGIN EC PRIVATE KEY-----
+MHcCAQEEINrU8VRnVqk1tqK8r5n2d3V4xk7WpQ6vZ3F2bN9mY4T7
+-----END EC PRIVATE KEY-----`
+			const result = redact(text, new Set())
+			expect(result).toBe("Key1:\n[REDACTED]\nKey2:\n[REDACTED]")
+		})
+
+		it("exact-match runs before patterns, preventing pattern from seeing the secret", () => {
+			const secrets = new Set(["ghp_abcdefghijklmnopqrstuvwxyz0123456789"])
+			const text = "key=ghp_abcdefghijklmnopqrstuvwxyz0123456789"
+			expect(redact(text, secrets)).toBe("key=[REDACTED]")
+		})
+	})
+})

--- a/src/extensions/redaction/engine.ts
+++ b/src/extensions/redaction/engine.ts
@@ -1,0 +1,73 @@
+/**
+ * Redaction engine for tool-result text content.
+ *
+ * Two-stage pipeline:
+ * 1. Exact-match: replace each known secret value with [REDACTED].
+ *    Zero false positives.
+ * 2. Pattern catalog: replace matches from PATTERN_CATALOG with [REDACTED].
+ *    Catches unknown secrets in common formats.
+ *
+ * Stateless. No I/O. Deterministic.
+ */
+
+const REDACTED = "[REDACTED]"
+
+const MIN_SECRET_LENGTH = 8
+
+export interface SecretPattern {
+	name: string
+	regex: RegExp
+}
+
+export const PATTERN_CATALOG: SecretPattern[] = [
+	{ name: "AWS access key ID", regex: /AKIA[0-9A-Z]{16}/g },
+	{ name: "AWS secret in config", regex: /(?<=aws_secret_access_key\s*[=:]\s*["']?)[A-Za-z0-9/+=]{40}/g },
+	{ name: "GitHub classic token", regex: /gh[pousr]_[A-Za-z0-9]{36,}/g },
+	{ name: "GitHub fine-grained PAT", regex: /github_pat_[A-Za-z0-9_]{22,}/g },
+	{ name: "GitLab token", regex: /glpat-[A-Za-z0-9_-]{20,}/g },
+	// JWT: header starts with eyJ (base64 of `{"`); payload and signature are
+	// base64url segments that rarely start with eyJ, so only require minimum length.
+	{ name: "JWT", regex: /eyJ[A-Za-z0-9_-]{10,}\.[A-Za-z0-9_-]{10,}\.[A-Za-z0-9_-]{10,}/g },
+	{
+		name: "PEM private key",
+		regex: /-----BEGIN [A-Z ]*PRIVATE KEY-----[\s\S]*?-----END [A-Z ]*PRIVATE KEY-----/g,
+	},
+	{ name: "Slack token", regex: /xox[baprs]-[A-Za-z0-9-]+/g },
+	{ name: "Generic Bearer", regex: /[Bb]earer [A-Za-z0-9._+/=-]{8,}/g },
+	{
+		name: "Env/config secret assignment",
+		regex:
+			/(?<=\w*(?:API_KEY|ACCESS_KEY|SECRET_KEY|PRIVATE_KEY|TOKEN|SECRET|PASSWORD|CREDENTIAL)\w*\s*[=:]\s*["']?)[A-Za-z0-9_+/=-]{8,}/gi,
+	},
+]
+
+/**
+ * Redact known secrets and common credential patterns from text.
+ *
+ * @param text - The text to scrub.
+ * @param knownSecrets - A set of exact secret values to redact.
+ * @returns The scrubbed text with secrets replaced by [REDACTED].
+ */
+export function redact(text: string, knownSecrets: Set<string>): string {
+	if (!text) return text
+
+	let result = text
+
+	// Stage 1: Exact-match known secrets.
+	// Use split().join() instead of replaceAll to avoid regex special-character
+	// issues in secret values.
+	for (const secret of knownSecrets) {
+		if (secret.length < MIN_SECRET_LENGTH) continue
+		if (!result.includes(secret)) continue
+		result = result.split(secret).join(REDACTED)
+	}
+
+	// Stage 2: Pattern catalog.
+	for (const pattern of PATTERN_CATALOG) {
+		// Reset lastIndex in case the regex was used before (global flag).
+		pattern.regex.lastIndex = 0
+		result = result.replace(pattern.regex, REDACTED)
+	}
+
+	return result
+}

--- a/src/extensions/redaction/index.test.ts
+++ b/src/extensions/redaction/index.test.ts
@@ -1,0 +1,443 @@
+import { beforeEach, describe, expect, it, vi } from "vitest"
+
+// Mock the secret registry before importing the extension
+const { mockCollectKnownSecrets, mockScrubSessionFile } = vi.hoisted(() => ({
+	mockCollectKnownSecrets: vi.fn(() => new Set<string>()),
+	mockScrubSessionFile: vi.fn(),
+}))
+
+vi.mock("./secret-registry.js", () => ({
+	collectKnownSecrets: mockCollectKnownSecrets,
+}))
+
+vi.mock("./session-scrub.js", () => ({
+	scrubSessionFile: mockScrubSessionFile,
+}))
+
+vi.mock("./engine.js", async (importActual) => {
+	const actual = await importActual<typeof import("./engine.js")>()
+	return {
+		...actual,
+		// Wrap redact so we can verify it was called, but use the real implementation
+		redact: vi.fn(actual.redact),
+	}
+})
+
+import { redact } from "./engine.js"
+import createRedactionExtension from "./index.js"
+
+function createMockPi() {
+	const handlers: Record<string, ((event: unknown, ctx: unknown) => unknown)[]> = {}
+	return {
+		on: vi.fn((event: string, handler: (event: unknown, ctx: unknown) => unknown) => {
+			if (!handlers[event]) handlers[event] = []
+			handlers[event].push(handler)
+		}),
+		emit: vi.fn((event: string, data: unknown, ctx?: unknown) => {
+			const hs = handlers[event]
+			if (!hs) return
+			let current = data
+			let modified = false
+			for (const h of hs) {
+				const result = h(current, ctx ?? {})
+				if (result && typeof result === "object") {
+					if ("content" in result || "messages" in result || "input" in result) {
+						current = { ...(current as object), ...result }
+						modified = true
+					}
+				}
+			}
+			return modified ? current : undefined
+		}),
+	}
+}
+
+describe("redaction extension", () => {
+	beforeEach(() => {
+		vi.clearAllMocks()
+		mockCollectKnownSecrets.mockReturnValue(new Set())
+		mockScrubSessionFile.mockReset()
+	})
+
+	it("registers session_start, tool_result, context, and turn_end handlers", () => {
+		const pi = createMockPi()
+		createRedactionExtension(pi as never)
+		expect(pi.on).toHaveBeenCalledWith("session_start", expect.any(Function))
+		expect(pi.on).toHaveBeenCalledWith("tool_result", expect.any(Function))
+		expect(pi.on).toHaveBeenCalledWith("context", expect.any(Function))
+		expect(pi.on).toHaveBeenCalledWith("turn_end", expect.any(Function))
+	})
+
+	// ── tool_result hook ─────────────────────────────────────────────────────
+
+	it("scrubs text content containing a known apiKey", () => {
+		mockCollectKnownSecrets.mockReturnValue(new Set(["test-api-key-123456789"]))
+		const pi = createMockPi()
+		createRedactionExtension(pi as never)
+
+		pi.emit("session_start", { type: "session_start", reason: "startup" })
+
+		const result = pi.emit("tool_result", {
+			type: "tool_result",
+			toolCallId: "tc1",
+			toolName: "bash",
+			input: { command: "printenv" },
+			content: [{ type: "text", text: "KIMCHI_API_KEY=test-api-key-123456789" }],
+			isError: false,
+			details: undefined,
+		})
+
+		expect(result).toBeDefined()
+		const r = result as { content: { text: string }[] }
+		expect(r.content[0].text).toBe("KIMCHI_API_KEY=[REDACTED]")
+	})
+
+	it("scrubs text content containing a GitHub token pattern", () => {
+		const pi = createMockPi()
+		createRedactionExtension(pi as never)
+		pi.emit("session_start", { type: "session_start", reason: "startup" })
+
+		const result = pi.emit("tool_result", {
+			type: "tool_result",
+			toolCallId: "tc2",
+			toolName: "bash",
+			input: { command: "cat ~/.gitconfig" },
+			content: [{ type: "text", text: "token = ghp_0123456789abcdefghij0123456789abcdefghij" }],
+			isError: false,
+			details: undefined,
+		})
+
+		const r2 = result as { content: { text: string }[] }
+		expect(r2.content[0].text).toBe("token = [REDACTED]")
+	})
+
+	it("scrubs secrets in event.input in place (tool arguments echoed back)", () => {
+		mockCollectKnownSecrets.mockReturnValue(new Set(["test-api-key-123456789"]))
+		const pi = createMockPi()
+		createRedactionExtension(pi as never)
+		pi.emit("session_start", { type: "session_start", reason: "startup" })
+
+		const input = { command: "curl -H 'Authorization: Bearer test-api-key-123456789' https://api.example.com" }
+		pi.emit("tool_result", {
+			type: "tool_result",
+			toolCallId: "tc-input",
+			toolName: "bash",
+			input,
+			content: [{ type: "text", text: "OK" }],
+			isError: false,
+			details: undefined,
+		})
+
+		// event.input is mutated in place — verify the original object was scrubbed
+		expect(input.command).toContain("[REDACTED]")
+		expect(input.command).not.toContain("test-api-key-123456789")
+	})
+
+	it("scrubs nested secrets in event.input in place", () => {
+		mockCollectKnownSecrets.mockReturnValue(new Set(["test-api-key-123456789"]))
+		const pi = createMockPi()
+		createRedactionExtension(pi as never)
+		pi.emit("session_start", { type: "session_start", reason: "startup" })
+
+		const input = { options: { headers: { Authorization: "Bearer test-api-key-123456789" } } }
+		pi.emit("tool_result", {
+			type: "tool_result",
+			toolCallId: "tc-nested",
+			toolName: "bash",
+			input,
+			content: [{ type: "text", text: "OK" }],
+			isError: false,
+			details: undefined,
+		})
+
+		expect(input.options.headers.Authorization).toBe("Bearer [REDACTED]")
+	})
+
+	it("returns undefined when content has no secrets", () => {
+		const pi = createMockPi()
+		createRedactionExtension(pi as never)
+		pi.emit("session_start", { type: "session_start", reason: "startup" })
+
+		const result = pi.emit("tool_result", {
+			type: "tool_result",
+			toolCallId: "tc3",
+			toolName: "bash",
+			input: { command: "ls" },
+			content: [{ type: "text", text: "file1.txt\nfile2.txt" }],
+			isError: false,
+			details: undefined,
+		})
+
+		expect(result).toBeUndefined()
+	})
+
+	it("passes through image content unchanged", () => {
+		const pi = createMockPi()
+		createRedactionExtension(pi as never)
+		pi.emit("session_start", { type: "session_start", reason: "startup" })
+
+		const imageBlock = { type: "image", source: { data: "base64data", mediaType: "image/png" } }
+		const result = pi.emit("tool_result", {
+			type: "tool_result",
+			toolCallId: "tc4",
+			toolName: "bash",
+			input: {},
+			content: [{ type: "text", text: "ghp_0123456789abcdefghij0123456789abcdefghij" }, imageBlock],
+			isError: false,
+			details: undefined,
+		})
+
+		const r3 = result as { content: unknown[] }
+		expect((r3.content[0] as { text: string }).text).toBe("[REDACTED]")
+		expect(r3.content[1]).toBe(imageBlock)
+	})
+
+	it("passes through when content is missing", () => {
+		const pi = createMockPi()
+		createRedactionExtension(pi as never)
+		pi.emit("session_start", { type: "session_start", reason: "startup" })
+
+		const result = pi.emit("tool_result", {
+			type: "tool_result",
+			toolCallId: "tc5",
+			toolName: "bash",
+			input: {},
+			content: undefined,
+			isError: false,
+			details: undefined,
+		})
+
+		expect(result).toBeUndefined()
+	})
+
+	it("passes through when content is not an array", () => {
+		const pi = createMockPi()
+		createRedactionExtension(pi as never)
+		pi.emit("session_start", { type: "session_start", reason: "startup" })
+
+		const result = pi.emit("tool_result", {
+			type: "tool_result",
+			toolCallId: "tc6",
+			toolName: "bash",
+			input: {},
+			content: "not an array",
+			isError: false,
+			details: undefined,
+		})
+
+		expect(result).toBeUndefined()
+	})
+
+	it("catches engine errors and returns original content", () => {
+		vi.mocked(redact).mockImplementationOnce(() => {
+			throw new Error("engine crash")
+		})
+		const pi = createMockPi()
+		createRedactionExtension(pi as never)
+		pi.emit("session_start", { type: "session_start", reason: "startup" })
+
+		const originalText = "some output"
+		const result = pi.emit("tool_result", {
+			type: "tool_result",
+			toolCallId: "tc7",
+			toolName: "bash",
+			input: {},
+			content: [{ type: "text", text: originalText }],
+			isError: false,
+			details: undefined,
+		})
+
+		expect(result).toBeUndefined()
+	})
+
+	it("redacts error results (isError: true)", () => {
+		const pi = createMockPi()
+		createRedactionExtension(pi as never)
+		pi.emit("session_start", { type: "session_start", reason: "startup" })
+
+		const result = pi.emit("tool_result", {
+			type: "tool_result",
+			toolCallId: "tc8",
+			toolName: "bash",
+			input: {},
+			content: [{ type: "text", text: "Error: Bearer sk-secret-token-12345678" }],
+			isError: true,
+			details: undefined,
+		})
+
+		const r4 = result as { content: { text: string }[] }
+		expect(r4.content[0].text).toBe("Error: [REDACTED]")
+	})
+
+	it("session_start rebuilds the known-secrets set", () => {
+		const pi = createMockPi()
+		createRedactionExtension(pi as never)
+
+		mockCollectKnownSecrets.mockReturnValue(new Set(["secret-aaaa1111"]))
+		pi.emit("session_start", { type: "session_start", reason: "startup" })
+
+		const result1 = pi.emit("tool_result", {
+			type: "tool_result",
+			toolCallId: "tc9a",
+			toolName: "bash",
+			input: {},
+			content: [{ type: "text", text: "secret-aaaa1111" }],
+			isError: false,
+			details: undefined,
+		})
+		const r1 = result1 as { content: { text: string }[] }
+		expect(r1.content[0].text).toBe("[REDACTED]")
+
+		mockCollectKnownSecrets.mockReturnValue(new Set(["secret-bbbb2222"]))
+		pi.emit("session_start", { type: "session_start", reason: "reload" })
+
+		const result2 = pi.emit("tool_result", {
+			type: "tool_result",
+			toolCallId: "tc9b",
+			toolName: "bash",
+			input: {},
+			content: [{ type: "text", text: "secret-aaaa1111" }],
+			isError: false,
+			details: undefined,
+		})
+
+		expect(result2).toBeUndefined()
+	})
+
+	// ── context hook ────────────────────────────────────────────────────────
+
+	it("context hook scrubs tool-call args in assistant messages", () => {
+		mockCollectKnownSecrets.mockReturnValue(new Set(["secret-api-key-12345678"]))
+		const pi = createMockPi()
+		createRedactionExtension(pi as never)
+		pi.emit("session_start", { type: "session_start", reason: "startup" })
+
+		const result = pi.emit("context", {
+			type: "context",
+			messages: [
+				{
+					role: "assistant",
+					content: [
+						{
+							type: "toolCall",
+							toolCallId: "tc1",
+							name: "bash",
+							arguments: { command: "curl -H 'Authorization: Bearer secret-api-key-12345678' https://api.example.com" },
+						},
+					],
+				},
+			],
+		})
+
+		expect(result).toBeDefined()
+		const messages = (result as { messages: { content: { arguments: { command: string } }[] }[] }).messages
+		expect(messages[0].content[0].arguments.command).toContain("[REDACTED]")
+		expect(messages[0].content[0].arguments.command).not.toContain("secret-api-key-12345678")
+	})
+
+	it("context hook returns undefined when no tool-call args contain secrets", () => {
+		const pi = createMockPi()
+		createRedactionExtension(pi as never)
+		pi.emit("session_start", { type: "session_start", reason: "startup" })
+
+		const result = pi.emit("context", {
+			type: "context",
+			messages: [
+				{ role: "user", content: [{ type: "text", text: "hello" }] },
+				{
+					role: "assistant",
+					content: [{ type: "toolCall", toolCallId: "tc1", name: "bash", arguments: { command: "ls -la" } }],
+				},
+			],
+		})
+
+		expect(result).toBeUndefined()
+	})
+
+	it("context hook passes through non-assistant messages unchanged", () => {
+		const pi = createMockPi()
+		createRedactionExtension(pi as never)
+		pi.emit("session_start", { type: "session_start", reason: "startup" })
+
+		const result = pi.emit("context", {
+			type: "context",
+			messages: [{ role: "user", content: [{ type: "text", text: "hello" }] }],
+		})
+
+		expect(result).toBeUndefined()
+	})
+
+	it("context hook scrubs GitHub token patterns in tool-call args", () => {
+		const pi = createMockPi()
+		createRedactionExtension(pi as never)
+		pi.emit("session_start", { type: "session_start", reason: "startup" })
+
+		const result = pi.emit("context", {
+			type: "context",
+			messages: [
+				{
+					role: "assistant",
+					content: [
+						{
+							type: "toolCall",
+							toolCallId: "tc2",
+							name: "bash",
+							arguments: { command: "echo ghp_0123456789abcdefghij0123456789abcdefghij" },
+						},
+					],
+				},
+			],
+		})
+
+		expect(result).toBeDefined()
+		const messages = (result as { messages: { content: { arguments: { command: string } }[] }[] }).messages
+		expect(messages[0].content[0].arguments.command).toBe("echo [REDACTED]")
+	})
+
+	// ── turn_end hook ───────────────────────────────────────────────────────
+
+	it("turn_end hook calls scrubSessionFile with the session file path", () => {
+		const pi = createMockPi()
+		createRedactionExtension(pi as never)
+		pi.emit("session_start", { type: "session_start", reason: "startup" })
+
+		pi.emit(
+			"turn_end",
+			{ type: "turn_end", turnIndex: 0, message: { role: "user", content: [] }, toolResults: [] },
+			{ sessionManager: { getSessionFile: () => "/path/to/session.jsonl" } },
+		)
+
+		expect(mockScrubSessionFile).toHaveBeenCalledWith("/path/to/session.jsonl", expect.any(Set))
+	})
+
+	it("turn_end hook catches errors and does not block the turn", () => {
+		mockScrubSessionFile.mockImplementation(() => {
+			throw new Error("scrub failed")
+		})
+		const pi = createMockPi()
+		createRedactionExtension(pi as never)
+		pi.emit("session_start", { type: "session_start", reason: "startup" })
+
+		expect(() =>
+			pi.emit(
+				"turn_end",
+				{ type: "turn_end", turnIndex: 0, message: { role: "user", content: [] }, toolResults: [] },
+				{ sessionManager: { getSessionFile: () => "/path/to/session.jsonl" } },
+			),
+		).not.toThrow()
+	})
+
+	it("turn_end hook does nothing when session file is not available", () => {
+		const pi = createMockPi()
+		createRedactionExtension(pi as never)
+		pi.emit("session_start", { type: "session_start", reason: "startup" })
+
+		pi.emit(
+			"turn_end",
+			{ type: "turn_end", turnIndex: 0, message: { role: "user", content: [] }, toolResults: [] },
+			{ sessionManager: { getSessionFile: () => undefined } },
+		)
+
+		expect(mockScrubSessionFile).not.toHaveBeenCalled()
+	})
+})

--- a/src/extensions/redaction/index.ts
+++ b/src/extensions/redaction/index.ts
@@ -1,0 +1,123 @@
+import type { ExtensionAPI } from "@earendil-works/pi-coding-agent"
+import { redact } from "./engine.js"
+import { collectKnownSecrets } from "./secret-registry.js"
+import { scrubSessionFile } from "./session-scrub.js"
+
+export default function createRedactionExtension(pi: ExtensionAPI): void {
+	// Per-instance secrets set — not module-scoped, so concurrent sessions
+	// don't cross-contaminate each other's redaction state.
+	let knownSecrets = new Set<string>()
+
+	pi.on("session_start", () => {
+		try {
+			knownSecrets = collectKnownSecrets()
+		} catch {
+			knownSecrets = new Set()
+		}
+	})
+
+	// Hook 1: Scrub secrets in tool-result content before they reach the model.
+	// Also scrub event.input (tool-call args echoed in the result) in place,
+	// since the ToolResultEventResult type doesn't support returning a modified
+	// input — mutating it ensures secrets don't leak through that field.
+	pi.on("tool_result", (event) => {
+		// 1a. Scrub string values in event.input in place (side effect).
+		if (event.input && typeof event.input === "object") {
+			scrubStringValuesInPlace(event.input, knownSecrets)
+		}
+
+		// 1b. Scrub text content blocks (returned via result).
+		if (!event.content || !Array.isArray(event.content)) return
+
+		let modified = false
+		const scrubbed = event.content.map((block) => {
+			if (block.type !== "text") return block
+			const original = block.text
+			let redacted: string
+			try {
+				redacted = redact(original, knownSecrets)
+			} catch {
+				// Best-effort: if redact throws, leave the block unchanged.
+				// A crash must never block tool results from reaching the model.
+				return block
+			}
+			if (redacted !== original) {
+				modified = true
+				return { ...block, text: redacted }
+			}
+			return block
+		})
+
+		if (!modified) return
+		return { content: scrubbed }
+	})
+
+	// Hook 2: Scrub tool-call args in the cloned message array sent to the LLM.
+	// pi-mono passes a structuredClone, so this does NOT affect stored messages
+	// or tool execution — only what the model sees on subsequent turns.
+	pi.on("context", (event) => {
+		let modified = false
+		const messages = event.messages.map((msg) => {
+			if (msg.role !== "assistant") return msg
+			if (!Array.isArray(msg.content)) return msg
+
+			let messageModified = false
+			const scrubbedContent = msg.content.map((block) => {
+				if (block.type !== "toolCall") return block
+				if (!block.arguments) return block
+				const scrubbedArgs: Record<string, unknown> = {}
+				let argsModified = false
+				for (const [key, value] of Object.entries(block.arguments)) {
+					if (typeof value === "string") {
+						const redacted = redact(value, knownSecrets)
+						scrubbedArgs[key] = redacted
+						if (redacted !== value) argsModified = true
+					} else {
+						scrubbedArgs[key] = value
+					}
+				}
+				if (argsModified) {
+					messageModified = true
+					return { ...block, arguments: scrubbedArgs }
+				}
+				return block
+			})
+
+			if (messageModified) {
+				modified = true
+				return { ...msg, content: scrubbedContent }
+			}
+			return msg
+		})
+
+		if (!modified) return
+		return { messages }
+	})
+
+	// Hook 3: Scrub the session file at rest after each turn.
+	// Fires after all tools have executed and messages have been persisted.
+	pi.on("turn_end", (_event, ctx) => {
+		try {
+			const sessionFile = ctx.sessionManager.getSessionFile()
+			if (!sessionFile) return
+			scrubSessionFile(sessionFile, knownSecrets)
+		} catch {
+			// Best-effort — a crash must never block the turn
+		}
+	})
+}
+
+/**
+ * Recursively scrub string values in an object in place using the redaction engine.
+ * Mutates the object directly — used for event.input where the return type
+ * doesn't support a modified input field.
+ */
+function scrubStringValuesInPlace(obj: Record<string, unknown>, knownSecrets: Set<string>): void {
+	for (const [key, value] of Object.entries(obj)) {
+		if (typeof value === "string") {
+			obj[key] = redact(value, knownSecrets)
+		} else if (typeof value === "object" && value !== null && !Array.isArray(value)) {
+			scrubStringValuesInPlace(value as Record<string, unknown>, knownSecrets)
+		}
+	}
+}

--- a/src/extensions/redaction/secret-registry.test.ts
+++ b/src/extensions/redaction/secret-registry.test.ts
@@ -1,0 +1,216 @@
+import { mkdirSync, rmSync } from "node:fs"
+import { join } from "node:path"
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
+import { collectKnownSecrets } from "./secret-registry.js"
+
+// Mock config path so tests don't touch real config
+const tmpDir = join(import.meta.dirname, "__tmp_secret_registry_test__")
+
+vi.mock("../../config.js", async (importOriginal) => {
+	const actual = await importOriginal<typeof import("../../config.js")>()
+	return {
+		...actual,
+		readApiKeyFromConfigFile: vi.fn(() => undefined),
+		readAllGitTokens: vi.fn(() => undefined),
+	}
+})
+
+vi.mock("../mcp-adapter/config.js", () => ({
+	loadMcpConfig: vi.fn(() => ({ config: { mcpServers: {} }, warnings: [] })),
+}))
+
+import { readAllGitTokens, readApiKeyFromConfigFile } from "../../config.js"
+import { loadMcpConfig } from "../mcp-adapter/config.js"
+
+const originalEnv = { ...process.env }
+
+beforeEach(() => {
+	mkdirSync(tmpDir, { recursive: true })
+	vi.clearAllMocks()
+	process.env = { ...originalEnv }
+	// Clear all secret-bearing env vars so tests are deterministic
+	for (const key of Object.keys(originalEnv)) {
+		if (/API_KEY|TOKEN|SECRET|PASSWORD|CREDENTIAL/i.test(key)) {
+			process.env[key] = undefined
+		}
+	}
+})
+
+afterEach(() => {
+	rmSync(tmpDir, { recursive: true, force: true })
+	process.env = { ...originalEnv }
+})
+
+describe("collectKnownSecrets", () => {
+	describe("API key", () => {
+		it("collects apiKey from config file", () => {
+			vi.mocked(readApiKeyFromConfigFile).mockReturnValue("file-api-key-12345678")
+			const secrets = collectKnownSecrets()
+			expect(secrets.has("file-api-key-12345678")).toBe(true)
+		})
+
+		it("collects apiKey from process.env.KIMCHI_API_KEY", () => {
+			process.env.KIMCHI_API_KEY = "env-api-key-123456789"
+			vi.mocked(readApiKeyFromConfigFile).mockReturnValue(undefined)
+			const secrets = collectKnownSecrets()
+			expect(secrets.has("env-api-key-123456789")).toBe(true)
+		})
+
+		it("collects API keys from any env var matching API_KEY/TOKEN/SECRET", () => {
+			process.env.ANTHROPIC_API_KEY = "sk-ant-key-12345678901234567890"
+			process.env.CUSTOM_SERVICE_TOKEN = "custom-token-12345678901234567"
+			process.env.MY_DB_PASSWORD = "db-pass-123456789"
+			vi.mocked(readApiKeyFromConfigFile).mockReturnValue(undefined)
+			const secrets = collectKnownSecrets()
+			expect(secrets.has("sk-ant-key-12345678901234567890")).toBe(true)
+			expect(secrets.has("custom-token-12345678901234567")).toBe(true)
+			expect(secrets.has("db-pass-123456789")).toBe(true)
+		})
+
+		it("does not collect values from non-secret env vars", () => {
+			process.env.HOME = "/home/user"
+			process.env.PATH = "/usr/bin:/bin"
+			process.env.SOME_CONFIG = "not-a-secret"
+			const secrets = collectKnownSecrets()
+			expect(secrets.has("/home/user")).toBe(false)
+			expect(secrets.has("/usr/bin:/bin")).toBe(false)
+			expect(secrets.has("not-a-secret")).toBe(false)
+		})
+
+		it("skips apiKey shorter than 8 chars", () => {
+			vi.mocked(readApiKeyFromConfigFile).mockReturnValue("short")
+			const secrets = collectKnownSecrets()
+			expect(secrets.has("short")).toBe(false)
+		})
+	})
+
+	describe("Git tokens", () => {
+		it("collects all gitToken values", () => {
+			vi.mocked(readAllGitTokens).mockReturnValue({
+				"github.com": "ghp_token_123456789012345678",
+				"gitlab.com": "glpat_token_12345678901234567890",
+			})
+			const secrets = collectKnownSecrets()
+			expect(secrets.has("ghp_token_123456789012345678")).toBe(true)
+			expect(secrets.has("glpat_token_12345678901234567890")).toBe(true)
+		})
+
+		it("handles empty gitTokens", () => {
+			vi.mocked(readAllGitTokens).mockReturnValue({})
+			const secrets = collectKnownSecrets()
+			expect(secrets.size).toBe(0)
+		})
+
+		it("handles missing gitTokens field (undefined)", () => {
+			vi.mocked(readAllGitTokens).mockReturnValue(undefined)
+			const secrets = collectKnownSecrets()
+			expect(secrets.size).toBe(0)
+		})
+	})
+
+	describe("MCP bearer tokens", () => {
+		it("collects bearer token from headers", () => {
+			vi.mocked(loadMcpConfig).mockReturnValue({
+				config: {
+					mcpServers: {
+						svc: { url: "https://mcp.example.com", headers: { Authorization: "Bearer mcp-bearer-token-12345678" } },
+					},
+				},
+				warnings: [],
+			})
+			const secrets = collectKnownSecrets()
+			expect(secrets.has("mcp-bearer-token-12345678")).toBe(true)
+		})
+
+		it("collects bearerToken field", () => {
+			vi.mocked(loadMcpConfig).mockReturnValue({
+				config: {
+					mcpServers: {
+						svc: { url: "https://mcp.example.com", bearerToken: "literal-bearer-token-12345678" },
+					},
+				},
+				warnings: [],
+			})
+			const secrets = collectKnownSecrets()
+			expect(secrets.has("literal-bearer-token-12345678")).toBe(true)
+		})
+
+		it("collects bearerTokenEnv field", () => {
+			process.env.CUSTOM_MCP_TOKEN = "env-resolved-token-12345678"
+			vi.mocked(loadMcpConfig).mockReturnValue({
+				config: {
+					mcpServers: {
+						svc: { url: "https://mcp.example.com", bearerTokenEnv: "CUSTOM_MCP_TOKEN" },
+					},
+				},
+				warnings: [],
+			})
+			const secrets = collectKnownSecrets()
+			expect(secrets.has("env-resolved-token-12345678")).toBe(true)
+		})
+
+		it("resolves $VAR interpolation in headers", () => {
+			process.env.MY_TOKEN = "interpolated-token-12345678"
+			vi.mocked(loadMcpConfig).mockReturnValue({
+				config: {
+					mcpServers: {
+						svc: { url: "https://mcp.example.com", headers: { Authorization: "Bearer $MY_TOKEN" } },
+					},
+				},
+				warnings: [],
+			})
+			const secrets = collectKnownSecrets()
+			expect(secrets.has("interpolated-token-12345678")).toBe(true)
+		})
+
+		it("resolves ${VAR} interpolation in headers", () => {
+			process.env.MY_TOKEN = "interpolated-token-12345678"
+			vi.mocked(loadMcpConfig).mockReturnValue({
+				config: {
+					mcpServers: {
+						svc: { url: "https://mcp.example.com", headers: { Authorization: "Bearer ${MY_TOKEN}" } },
+					},
+				},
+				warnings: [],
+			})
+			const secrets = collectKnownSecrets()
+			expect(secrets.has("interpolated-token-12345678")).toBe(true)
+		})
+
+		it("handles servers with no bearer auth", () => {
+			vi.mocked(loadMcpConfig).mockReturnValue({
+				config: {
+					mcpServers: {
+						a: { url: "https://mcp.example.com", headers: { "X-Custom": "value" } },
+						b: { command: "my-mcp-server" },
+					},
+				},
+				warnings: [],
+			})
+			const secrets = collectKnownSecrets()
+			expect(secrets.size).toBe(0)
+		})
+
+		it("handles empty server list", () => {
+			vi.mocked(loadMcpConfig).mockReturnValue({ config: { mcpServers: {} }, warnings: [] })
+			const secrets = collectKnownSecrets()
+			expect(secrets.size).toBe(0)
+		})
+	})
+
+	describe("error resilience", () => {
+		it("returns empty set when config throws", () => {
+			vi.mocked(readApiKeyFromConfigFile).mockImplementation(() => {
+				throw new Error("read failed")
+			})
+			vi.mocked(readAllGitTokens).mockImplementation(() => {
+				throw new Error("read failed")
+			})
+			vi.mocked(loadMcpConfig).mockImplementation(() => {
+				throw new Error("read failed")
+			})
+			const secrets = collectKnownSecrets()
+			expect(secrets.size).toBe(0)
+		})
+	})
+})

--- a/src/extensions/redaction/secret-registry.ts
+++ b/src/extensions/redaction/secret-registry.ts
@@ -1,0 +1,125 @@
+import { hasBearerAuthorizationHeader } from "../../agent-discovery/engine.js"
+import { readAllGitTokens, readApiKeyFromConfigFile } from "../../config.js"
+import { loadMcpConfig } from "../mcp-adapter/config.js"
+import type { ServerEntry } from "../mcp-adapter/types.js"
+
+const MIN_SECRET_LENGTH = 8
+
+/**
+ * Env var names that match this regex are treated as secret-bearing.
+ * Matches anything containing API_KEY, TOKEN, SECRET, PASSWORD, or CREDENTIAL
+ * (case-insensitive). The values of these env vars are added to the
+ * known-secrets set for exact-match redaction in tool output.
+ */
+const SECRET_ENV_VAR_PATTERN = /API_KEY|TOKEN|SECRET|PASSWORD|CREDENTIAL/i
+
+/**
+ * Resolve `$VAR` and `${VAR}` env-var interpolation in a string value.
+ * Returns the resolved string, or the original if no interpolation is needed.
+ */
+function resolveEnvVars(value: string): string {
+	return value.replace(/\$\{?([A-Za-z_][A-Za-z0-9_]*)\}?/g, (_, name: string) => {
+		return process.env[name] ?? ""
+	})
+}
+
+/**
+ * Extract bearer token value from an Authorization header string.
+ * Returns the token (without "Bearer " prefix) or undefined.
+ */
+function extractBearerToken(headerValue: string): string | undefined {
+	const match = /^[Bb]earer\s+(.+)$/.exec(headerValue.trim())
+	return match?.[1]
+}
+
+/**
+ * Collect known secrets from kimchi config and MCP server definitions.
+ * Called at session_start. Returns a Set<string> of secret values.
+ *
+ * Sources:
+ * 1. API key from config file and process.env.KIMCHI_API_KEY
+ * 2. All git token values from config file
+ * 3. MCP server bearer tokens (headers, bearerToken, bearerTokenEnv)
+ *
+ * Never throws — returns empty set on any failure.
+ */
+export function collectKnownSecrets(): Set<string> {
+	const secrets = new Set<string>()
+
+	try {
+		// 1. API key from config file
+		const fileApiKey = readApiKeyFromConfigFile()
+		if (fileApiKey && fileApiKey.length >= MIN_SECRET_LENGTH) {
+			secrets.add(fileApiKey)
+		}
+
+		// 1b. Secret values from env vars whose names match API_KEY, TOKEN, SECRET,
+		//      PASSWORD, or CREDENTIAL (case-insensitive). This catches
+		//      ANTHROPIC_API_KEY, GITHUB_TOKEN, AWS_SECRET_ACCESS_KEY, etc.
+		//      without hardcoding a list of provider names.
+		for (const [varName, value] of Object.entries(process.env)) {
+			if (SECRET_ENV_VAR_PATTERN.test(varName) && typeof value === "string" && value.length >= MIN_SECRET_LENGTH) {
+				secrets.add(value)
+			}
+		}
+	} catch {
+		// Config read failed — continue with other sources
+	}
+
+	try {
+		// 2. Git tokens
+		const gitTokens = readAllGitTokens()
+		if (gitTokens) {
+			for (const token of Object.values(gitTokens)) {
+				if (typeof token === "string" && token.length >= MIN_SECRET_LENGTH) {
+					secrets.add(token)
+				}
+			}
+		}
+	} catch {
+		// Git token read failed — continue
+	}
+
+	try {
+		// 3. MCP bearer tokens
+		const { config } = loadMcpConfig()
+		for (const entry of Object.values(config.mcpServers)) {
+			collectMcpBearerTokens(entry, secrets)
+		}
+	} catch {
+		// MCP config read failed — continue
+	}
+
+	return secrets
+}
+
+/**
+ * Collect bearer tokens from a single MCP server entry.
+ */
+function collectMcpBearerTokens(entry: ServerEntry, secrets: Set<string>): void {
+	// 3a. Headers with Authorization: Bearer
+	if (entry.headers && hasBearerAuthorizationHeader(entry.headers)) {
+		for (const [key, value] of Object.entries(entry.headers)) {
+			if (key.toLowerCase() === "authorization") {
+				const resolved = resolveEnvVars(value)
+				const token = extractBearerToken(resolved)
+				if (token && token.length >= MIN_SECRET_LENGTH) {
+					secrets.add(token)
+				}
+			}
+		}
+	}
+
+	// 3b. bearerToken field (literal token)
+	if (entry.bearerToken && entry.bearerToken.length >= MIN_SECRET_LENGTH) {
+		secrets.add(entry.bearerToken)
+	}
+
+	// 3c. bearerTokenEnv field (env var name → resolve value)
+	if (entry.bearerTokenEnv) {
+		const token = process.env[entry.bearerTokenEnv]
+		if (token && token.length >= MIN_SECRET_LENGTH) {
+			secrets.add(token)
+		}
+	}
+}

--- a/src/extensions/redaction/session-scrub.test.ts
+++ b/src/extensions/redaction/session-scrub.test.ts
@@ -1,0 +1,197 @@
+import { mkdirSync, readFileSync, rmSync, writeFileSync } from "node:fs"
+import { join } from "node:path"
+import { afterEach, beforeEach, describe, expect, it } from "vitest"
+import { scrubSessionFile } from "./session-scrub.js"
+
+const tmpDir = join(import.meta.dirname, "__tmp_session_scrub_test__")
+const sessionFile = join(tmpDir, "session.jsonl")
+
+beforeEach(() => {
+	mkdirSync(tmpDir, { recursive: true })
+})
+
+afterEach(() => {
+	rmSync(tmpDir, { recursive: true, force: true })
+})
+
+function writeSession(lines: string[]): void {
+	writeFileSync(sessionFile, `${lines.join("\n")}\n`)
+}
+
+function readSession(): string[] {
+	return readFileSync(sessionFile, "utf-8").trim().split("\n").filter(Boolean)
+}
+
+describe("scrubSessionFile", () => {
+	it("scrubs tool-call args in assistant message entries", () => {
+		const secrets = new Set<string>(["secret-api-key-12345678"])
+		writeSession([
+			JSON.stringify({
+				type: "message",
+				message: {
+					role: "assistant",
+					content: [
+						{
+							type: "toolCall",
+							toolCallId: "tc1",
+							name: "bash",
+							arguments: { command: "curl -H 'Authorization: Bearer secret-api-key-12345678' https://api.example.com" },
+						},
+					],
+				},
+			}),
+		])
+
+		scrubSessionFile(sessionFile, secrets)
+
+		const lines = readSession()
+		const entry = JSON.parse(lines[0])
+		const args = entry.message.content[0].arguments
+		expect(args.command).toContain("[REDACTED]")
+		expect(args.command).not.toContain("secret-api-key-12345678")
+	})
+
+	it("scrubs text content in toolResult message entries", () => {
+		const secrets = new Set<string>(["secret-api-key-12345678"])
+		writeSession([
+			JSON.stringify({
+				type: "message",
+				message: {
+					role: "toolResult",
+					content: [{ type: "text", text: "KIMCHI_API_KEY=secret-api-key-12345678" }],
+				},
+			}),
+		])
+
+		scrubSessionFile(sessionFile, secrets)
+
+		const lines = readSession()
+		const entry = JSON.parse(lines[0])
+		expect(entry.message.content[0].text).toBe("KIMCHI_API_KEY=[REDACTED]")
+	})
+
+	it("scrubs GitHub token patterns in tool-call args", () => {
+		writeSession([
+			JSON.stringify({
+				type: "message",
+				message: {
+					role: "assistant",
+					content: [
+						{
+							type: "toolCall",
+							toolCallId: "tc2",
+							name: "bash",
+							arguments: { command: "echo ghp_0123456789abcdefghij0123456789abcdefghij" },
+						},
+					],
+				},
+			}),
+		])
+
+		scrubSessionFile(sessionFile, new Set())
+
+		const lines = readSession()
+		const entry = JSON.parse(lines[0])
+		expect(entry.message.content[0].arguments.command).toBe("echo [REDACTED]")
+	})
+
+	it("leaves non-message entries unchanged", () => {
+		const compactionEntry = JSON.stringify({
+			type: "compactionSummary",
+			summary: "Previous conversation about authentication",
+		})
+		writeSession([compactionEntry])
+
+		scrubSessionFile(sessionFile, new Set(["secret-api-key-12345678"]))
+
+		const lines = readSession()
+		expect(lines[0]).toBe(compactionEntry)
+	})
+
+	it("handles missing file gracefully", () => {
+		expect(() =>
+			scrubSessionFile(join(tmpDir, "nonexistent.jsonl"), new Set(["secret-api-key-12345678"])),
+		).not.toThrow()
+	})
+
+	it("handles malformed JSON lines (passes them through unchanged)", () => {
+		const malformedLine = "{ this is not valid json"
+		const goodLine = JSON.stringify({
+			type: "message",
+			message: {
+				role: "toolResult",
+				content: [{ type: "text", text: "ghp_0123456789abcdefghij0123456789abcdefghij" }],
+			},
+		})
+		writeSession([malformedLine, goodLine])
+
+		scrubSessionFile(sessionFile, new Set())
+
+		const lines = readSession()
+		expect(lines[0]).toBe(malformedLine)
+		const entry = JSON.parse(lines[1])
+		expect(entry.message.content[0].text).toBe("[REDACTED]")
+	})
+
+	it("handles empty file", () => {
+		writeFileSync(sessionFile, "")
+		expect(() => scrubSessionFile(sessionFile, new Set())).not.toThrow()
+		expect(readFileSync(sessionFile, "utf-8")).toBe("")
+	})
+
+	it("handles file with no secrets (no-op write)", () => {
+		const cleanLine = JSON.stringify({
+			type: "message",
+			message: {
+				role: "assistant",
+				content: [{ type: "text", text: "just a normal message" }],
+			},
+		})
+		writeSession([cleanLine])
+
+		scrubSessionFile(sessionFile, new Set())
+
+		const lines = readSession()
+		expect(lines[0]).toBe(cleanLine)
+	})
+
+	it("handles multiple entries with mixed content", () => {
+		const secrets = new Set<string>(["secret-api-key-12345678"])
+		writeSession([
+			JSON.stringify({ type: "thinkingLevelChange", level: "medium" }),
+			JSON.stringify({
+				type: "message",
+				message: {
+					role: "assistant",
+					content: [
+						{
+							type: "toolCall",
+							toolCallId: "tc1",
+							name: "bash",
+							arguments: { command: "echo secret-api-key-12345678" },
+						},
+					],
+				},
+			}),
+			JSON.stringify({
+				type: "message",
+				message: {
+					role: "toolResult",
+					content: [{ type: "text", text: "ghp_0123456789abcdefghij0123456789abcdefghij" }],
+				},
+			}),
+		])
+
+		scrubSessionFile(sessionFile, secrets)
+
+		const lines = readSession()
+		// thinkingLevelChange unchanged
+		expect(JSON.parse(lines[0]).type).toBe("thinkingLevelChange")
+		// assistant tool-call scrubbed
+		const assistant = JSON.parse(lines[1])
+		expect(assistant.message.content[0].arguments.command).toBe("echo [REDACTED]")
+		// toolResult scrubbed
+		const toolResult = JSON.parse(lines[2])
+		expect(toolResult.message.content[0].text).toBe("[REDACTED]")
+	})
+})

--- a/src/extensions/redaction/session-scrub.ts
+++ b/src/extensions/redaction/session-scrub.ts
@@ -1,0 +1,119 @@
+import { readFileSync, renameSync, unlinkSync, writeFileSync } from "node:fs"
+import { redact } from "./engine.js"
+
+interface SessionEntry {
+	type?: string
+	message?: {
+		role?: string
+		content?: unknown[]
+	}
+}
+
+/**
+ * Scrub secrets from a session file at rest.
+ *
+ * Reads the JSONL session file, parses each line, scrubs string values
+ * in tool-call args and text content using the redaction engine, then
+ * writes back atomically (temp file + rename).
+ *
+ * Never throws — returns silently on any error.
+ *
+ * Note: Atomicity via rename is guaranteed on POSIX systems. On Windows,
+ * rename may fail if the target file is open by another process — this is
+ * best-effort for cross-platform compatibility.
+ *
+ * @param sessionFilePath - Path to the JSONL session file.
+ * @param knownSecrets - Set of known secret values to redact.
+ */
+export function scrubSessionFile(sessionFilePath: string, knownSecrets: Set<string>): void {
+	let raw: string
+	try {
+		raw = readFileSync(sessionFilePath, "utf-8")
+	} catch {
+		return
+	}
+
+	if (!raw.trim()) return
+
+	// Split on \r?\n to handle both LF and CRLF line endings.
+	// Write back with normalized LF.
+	const lines = raw.split(/\r?\n/)
+	let modified = false
+	const outputLines: string[] = []
+
+	for (const line of lines) {
+		if (!line.trim()) {
+			outputLines.push(line)
+			continue
+		}
+
+		let entry: SessionEntry
+		try {
+			entry = JSON.parse(line)
+		} catch {
+			// Malformed JSON — pass through unchanged
+			outputLines.push(line)
+			continue
+		}
+
+		const lineModified = scrubEntry(entry, knownSecrets)
+		outputLines.push(lineModified ? JSON.stringify(entry) : line)
+		if (lineModified) modified = true
+	}
+
+	if (!modified) return
+
+	// Atomic write (POSIX): temp file + rename. Clean up temp file on failure.
+	const tmpPath = `${sessionFilePath}.tmp`
+	try {
+		writeFileSync(tmpPath, `${outputLines.join("\n")}\n`, "utf-8")
+		renameSync(tmpPath, sessionFilePath)
+	} catch {
+		// Best-effort cleanup of the temp file if write/rename failed.
+		try {
+			unlinkSync(tmpPath)
+		} catch {
+			// Temp file may not exist — ignore.
+		}
+	}
+}
+
+/**
+ * Scrub a single session entry in place.
+ * Returns true if any value was modified.
+ */
+function scrubEntry(entry: SessionEntry, knownSecrets: Set<string>): boolean {
+	let modified = false
+
+	if (!entry.message || !Array.isArray(entry.message.content)) return false
+
+	for (const block of entry.message.content) {
+		if (typeof block !== "object" || block === null) continue
+		const b = block as Record<string, unknown>
+
+		// Scrub tool-call args (assistant messages)
+		if (b.type === "toolCall" && b.arguments && typeof b.arguments === "object") {
+			const args = b.arguments as Record<string, unknown>
+			for (const [key, value] of Object.entries(args)) {
+				if (typeof value === "string") {
+					const redacted = redact(value, knownSecrets)
+					if (redacted !== value) {
+						args[key] = redacted
+						modified = true
+					}
+				}
+			}
+		}
+
+		// Scrub text content (toolResult messages)
+		if (b.type === "text" && typeof b.text === "string") {
+			const redacted = redact(b.text, knownSecrets)
+			if (redacted !== b.text) {
+				b.text = redacted
+				modified = true
+			}
+		}
+	}
+
+	return modified
+}

--- a/src/extensions/redaction/smoke.test.ts
+++ b/src/extensions/redaction/smoke.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it } from "vitest"
+import { redact } from "./engine.js"
+import { collectKnownSecrets } from "./secret-registry.js"
+
+describe("smoke tests", () => {
+	it("collects apiKey from process.env.KIMCHI_API_KEY", () => {
+		const saved = process.env.KIMCHI_API_KEY
+		process.env.KIMCHI_API_KEY = "test-api-key-for-smoke-12345"
+		try {
+			const secrets = collectKnownSecrets()
+			expect(secrets.has("test-api-key-for-smoke-12345")).toBe(true)
+		} finally {
+			process.env.KIMCHI_API_KEY = saved
+		}
+	})
+
+	it("redacts known apiKey in printenv-style output", () => {
+		const secrets = new Set(["test-api-key-for-smoke-12345"])
+		const output = "HOME=/home/user\nKIMCHI_API_KEY=test-api-key-for-smoke-12345\nPATH=/usr/bin"
+		const result = redact(output, secrets)
+		expect(result).toContain("[REDACTED]")
+		expect(result).not.toContain("test-api-key-for-smoke-12345")
+	})
+
+	it("redacts GitHub token pattern (unknown secret)", () => {
+		const output = "token = ghp_0123456789abcdefghij0123456789abcdefghij"
+		const result = redact(output, new Set())
+		expect(result).toBe("token = [REDACTED]")
+	})
+
+	it("does not false-positive on normal ls output", () => {
+		const secrets = new Set(["test-api-key-for-smoke-12345"])
+		const output = "file1.txt\nfile2.txt\ndocs/\nsrc/"
+		expect(redact(output, secrets)).toBe(output)
+	})
+
+	it("redacts AWS credentials in config format", () => {
+		const output =
+			"aws_access_key_id = AKIAIOSFODNN7EXAMPLE\naws_secret_access_key = wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY"
+		const result = redact(output, new Set())
+		expect(result).not.toContain("AKIAIOSFODNN7EXAMPLE")
+		expect(result).not.toContain("wJalrXUtnFEMI")
+	})
+
+	it("redacts PEM private key block", () => {
+		const output = `-----BEGIN RSA PRIVATE KEY-----
+MIIEowIBAAKCAQEA0123456789abcdefghijklmnopqrstuvwxyz
+-----END RSA PRIVATE KEY-----`
+		const result = redact(output, new Set())
+		expect(result).toBe("[REDACTED]")
+	})
+})

--- a/tests/e2e/tui/redaction.test.ts
+++ b/tests/e2e/tui/redaction.test.ts
@@ -1,0 +1,241 @@
+import { readFileSync, readdirSync } from "node:fs"
+import { join } from "node:path"
+import { expect, test } from "@microsoft/tui-test"
+import { STREAM_TIMEOUT_MS, waitForText } from "./support/assertions.js"
+import type { KimchiFixture } from "./support/kimchi-fixture.js"
+import { TUI_TEST_CONFIG, runKimchiSession } from "./support/kimchi-fixture.js"
+
+test.use(TUI_TEST_CONFIG)
+
+/** Secret value set via env var. Long enough to pass MIN_SECRET_LENGTH (8). */
+const ENV_SECRET_VALUE = "ak_known-test-secret-1234567890"
+const ENV_SECRET_NAME = "TEST_API_KEY"
+
+/** A GitHub classic token that matches the pattern catalog but is NOT in the known secrets set. */
+const PATTERN_GITHUB_TOKEN = "ghp_0123456789abcdefghij0123456789abcdefghij"
+
+/** Check if any recorded LLM request body contains the given text. */
+function anyRequestBodyContains(fixture: KimchiFixture, text: string): boolean {
+	return fixture.fake.requests.some((req) => JSON.stringify(req.body ?? "").includes(text))
+}
+
+/** Check if any recorded LLM request body contains [REDACTED]. */
+function anyRequestBodyContainsRedacted(fixture: KimchiFixture): boolean {
+	return anyRequestBodyContains(fixture, "[REDACTED]")
+}
+
+/**
+ * Find the most recent .jsonl session file under the fixture's home dir.
+ * Session files are stored at <agentDir>/sessions/<encoded_cwd>/<timestamp>_<id>.jsonl.
+ * We don't know the encoded cwd, so we scan recursively.
+ */
+function findSessionFile(homeDir: string): string | undefined {
+	const sessionsDir = join(homeDir, ".config", "kimchi", "harness", "sessions")
+	function findJsonl(dir: string): string | undefined {
+		let entries: ReturnType<typeof readdirSync>
+		try {
+			entries = readdirSync(dir, { withFileTypes: true })
+		} catch {
+			return undefined
+		}
+		for (const entry of entries) {
+			if (entry.isFile() && entry.name.endsWith(".jsonl")) {
+				return join(dir, entry.name)
+			}
+		}
+		for (const entry of entries) {
+			if (entry.isDirectory()) {
+				const found = findJsonl(join(dir, entry.name))
+				if (found) return found
+			}
+		}
+		return undefined
+	}
+	return findJsonl(sessionsDir)
+}
+
+test("known secret from env is redacted in tool results", async ({ terminal }) => {
+	await runKimchiSession(
+		terminal,
+		{
+			artifactName: "redaction-known-secret-env",
+			env: { [ENV_SECRET_NAME]: ENV_SECRET_VALUE },
+			responses: [
+				// Turn 1: model calls bash to echo the env var.
+				{
+					stream: ["Let me check the environment."],
+					toolCalls: [
+						{
+							function: {
+								name: "bash",
+								arguments: JSON.stringify({ command: `echo $${ENV_SECRET_NAME}` }),
+							},
+						},
+					],
+				},
+				// Turn 2: model acknowledges the (redacted) result.
+				{ stream: ["Done checking."] },
+			],
+		},
+		async (fixture) => {
+			terminal.submit("check the env")
+			await waitForText(terminal, "Done checking.", { timeoutMs: STREAM_TIMEOUT_MS })
+
+			// The secret value must NOT appear in any LLM request body.
+			expect(anyRequestBodyContains(fixture, ENV_SECRET_VALUE)).toBe(false)
+
+			// [REDACTED] must appear in at least one request body (the tool result).
+			expect(anyRequestBodyContainsRedacted(fixture)).toBe(true)
+		},
+	)
+})
+
+test("pattern-based secret is redacted without being in known secrets", async ({ terminal }) => {
+	await runKimchiSession(
+		terminal,
+		{
+			artifactName: "redaction-pattern-based",
+			responses: [
+				// Turn 1: model calls bash that echoes a GitHub token.
+				{
+					stream: ["Checking for tokens."],
+					toolCalls: [
+						{
+							function: {
+								name: "bash",
+								arguments: JSON.stringify({ command: `echo "${PATTERN_GITHUB_TOKEN}"` }),
+							},
+						},
+					],
+				},
+				// Turn 2: model acknowledges.
+				{ stream: ["Done."] },
+			],
+		},
+		async (fixture) => {
+			terminal.submit("check for tokens")
+			await waitForText(terminal, "Done.", { timeoutMs: STREAM_TIMEOUT_MS })
+
+			// The token must NOT appear in any LLM request body.
+			expect(anyRequestBodyContains(fixture, PATTERN_GITHUB_TOKEN)).toBe(false)
+
+			// [REDACTED] must appear (pattern catalog caught it).
+			expect(anyRequestBodyContainsRedacted(fixture)).toBe(true)
+		},
+	)
+})
+
+test("secret in tool-call args is scrubbed in subsequent context", async ({ terminal }) => {
+	await runKimchiSession(
+		terminal,
+		{
+			artifactName: "redaction-tool-call-args",
+			env: { [ENV_SECRET_NAME]: ENV_SECRET_VALUE },
+			responses: [
+				// Turn 1: model calls bash with the literal secret value as an argument.
+				{
+					stream: ["Running a command with the secret."],
+					toolCalls: [
+						{
+							function: {
+								name: "bash",
+								arguments: JSON.stringify({ command: `echo "${ENV_SECRET_VALUE}"` }),
+							},
+						},
+					],
+				},
+				// Turn 2: model acknowledges.
+				{ stream: ["Done."] },
+			],
+		},
+		async (fixture) => {
+			terminal.submit("run the command")
+			await waitForText(terminal, "Done.", { timeoutMs: STREAM_TIMEOUT_MS })
+
+			// The secret value must NOT appear anywhere in any LLM request body —
+			// not in tool result content, not in tool-call args.
+			expect(anyRequestBodyContains(fixture, ENV_SECRET_VALUE)).toBe(false)
+
+			// [REDACTED] must appear (in both tool result content and scrubbed args).
+			expect(anyRequestBodyContainsRedacted(fixture)).toBe(true)
+		},
+	)
+})
+
+test("session file at rest is scrubbed after turn_end", async ({ terminal }) => {
+	await runKimchiSession(
+		terminal,
+		{
+			artifactName: "redaction-session-file",
+			env: { [ENV_SECRET_NAME]: ENV_SECRET_VALUE },
+			responses: [
+				// Turn 1: model calls bash to echo the env var (secret in output).
+				{
+					stream: ["Checking the environment."],
+					toolCalls: [
+						{
+							function: {
+								name: "bash",
+								arguments: JSON.stringify({ command: `echo $${ENV_SECRET_NAME}` }),
+							},
+						},
+					],
+				},
+				// Turn 2: model acknowledges — turn_end fires after this.
+				{ stream: ["Done."] },
+			],
+		},
+		async (fixture) => {
+			terminal.submit("check env")
+			await waitForText(terminal, "Done.", { timeoutMs: STREAM_TIMEOUT_MS })
+
+			// Give turn_end a moment to fire and scrub the session file.
+			await new Promise((resolve) => setTimeout(resolve, 1000))
+
+			// Find the session file on disk.
+			const sessionFile = findSessionFile(fixture.homeDir)
+			expect(sessionFile).toBeDefined()
+
+			// Read the session file and assert the secret is scrubbed.
+			const content = readFileSync(sessionFile!, "utf-8")
+			expect(content).not.toContain(ENV_SECRET_VALUE)
+			expect(content).toContain("[REDACTED]")
+		},
+	)
+})
+
+test("normal tool output is not redacted (no false positives)", async ({ terminal }) => {
+	await runKimchiSession(
+		terminal,
+		{
+			artifactName: "redaction-no-false-positives",
+			responses: [
+				// Turn 1: model calls bash with a simple echo.
+				{
+					stream: ["Listing files."],
+					toolCalls: [
+						{
+							function: {
+								name: "bash",
+								arguments: JSON.stringify({ command: 'echo "hello world from test"' }),
+							},
+						},
+					],
+				},
+				// Turn 2: model acknowledges.
+				{ stream: ["Done."] },
+			],
+		},
+		async (fixture) => {
+			terminal.submit("list files")
+			await waitForText(terminal, "Done.", { timeoutMs: STREAM_TIMEOUT_MS })
+
+			// The normal output must appear in at least one request body
+			// (the tool result sent back to the model).
+			expect(anyRequestBodyContains(fixture, "hello world from test")).toBe(true)
+
+			// [REDACTED] must NOT appear — no secrets were present.
+			expect(anyRequestBodyContainsRedacted(fixture)).toBe(false)
+		},
+	)
+})


### PR DESCRIPTION
## Summary

Adds a tool-result redaction extension that scrubs secrets from tool output, LLM context, and session files at rest — preventing API keys, tokens, and other credentials from being persisted or sent back to the model.

## How it works

Three extension hooks covering the full lifecycle:

1. **`tool_result`** — redacts secrets in tool output before it reaches the model (text content blocks).
2. **`context`** — scrubs secrets in tool-call arguments in the cloned message array sent to the LLM. Does not affect stored messages or tool execution — only what the model sees on subsequent turns.
3. **`turn_end`** — scrubs the session JSONL file at rest after each turn (atomic write via temp file + rename).

## Redaction engine (`engine.ts`)

Two-stage pipeline, stateless and deterministic:

1. **Exact-match** — replaces each known secret value with `[REDACTED]`. Zero false positives.
2. **Pattern catalog** — replaces matches from a set of regex patterns covering common credential formats:
   - AWS access key IDs and secret keys
   - GitHub classic & fine-grained PATs
   - GitLab tokens
   - JWTs
   - PEM private keys
   - Slack tokens
   - Generic Bearer tokens
   - Env/config secret assignments (`API_KEY=...`, `TOKEN=...`, etc.)

## Secret collection (`secret-registry.ts`)

Collects known secrets at `session_start` from:

- Kimchi config file API key and `process.env.KIMCHI_API_KEY`
- All git tokens stored in config (`readAllGitTokens`)
- MCP server bearer tokens (headers, `bearerToken`, `bearerTokenEnv`)
- Any env var whose name matches `API_KEY|TOKEN|SECRET|PASSWORD|CREDENTIAL` (case-insensitive)

Never throws — returns empty set on any failure.

## Session scrubber (`session-scrub.ts`)

Reads the JSONL session file line by line, scrubs string values in tool-call args and text content, then writes back atomically. Never throws.

## Changes

- `src/extensions/redaction/` — new extension (engine, secret-registry, session-scrub, index factory)
- `src/cli.ts` — register redaction extension
- `src/config.ts` — add `readAllGitTokens` helper

## Testing

- `engine.test.ts` — pattern catalog coverage, exact-match, edge cases
- `secret-registry.test.ts` — env var collection, config file, MCP bearer tokens
- `index.test.ts` — extension hook integration (tool_result, context, turn_end)
- `session-scrub.test.ts` — JSONL parsing, atomic write, malformed input
- `smoke.test.ts` — end-to-end redaction flow

## Checklist

- [x] Bug fix / new feature
- [x] Tests added/updated
- [x] Lint and typecheck pass