### PR TITLE
fix(one-shot-ferment-hangs): prevent fs.watch handles from keeping the process alive after session end

### DIFF
--- a/src/extensions/agents/index.ts
+++ b/src/extensions/agents/index.ts
@@ -91,6 +91,10 @@ import {
 
 // ---- Shared helpers ----
 
+// Give aborted sub-agents a bounded chance to reach runner finally blocks.
+// If they do not settle, manager.dispose() still runs hard-fallback cleanup.
+const SUBAGENT_SHUTDOWN_WAIT_MS = 5_000
+
 export const AGENT_TOOL_GUIDELINES = `Guidelines:
 - If the user explicitly asks to use the Agent tool, call Agent exactly once with the requested agent type and token_budget. Do not refuse or preflight the budget in prose; let the tool enforce it.
 - For parallel work, use run_in_background: true on each agent. Foreground calls run sequentially — only one executes at a time.
@@ -788,16 +792,18 @@ export default function (pi: ExtensionAPI) {
 
 	pi.events.emit("subagents:ready", {})
 
+	const widget = new AgentWidget(manager, agentActivity)
+	const listUserVisibleAgents = () => manager.listAgents().filter((a) => a.visibility !== "system")
+
 	pi.on("session_shutdown", async () => {
 		manager.abortAll()
 		budgetRetryCandidates.clear()
 		for (const timer of pendingNudges.values()) clearTimeout(timer)
 		pendingNudges.clear()
+		await waitForSubagentShutdown(manager)
+		widget.dispose()
 		manager.dispose()
 	})
-
-	const widget = new AgentWidget(manager, agentActivity)
-	const listUserVisibleAgents = () => manager.listAgents().filter((a) => a.visibility !== "system")
 
 	let defaultJoinMode: JoinMode = "smart"
 	function getDefaultJoinMode(): JoinMode {
@@ -2202,4 +2208,19 @@ ${systemPrompt}
 			await showAgentsMenu(ctx)
 		},
 	})
+}
+
+async function waitForSubagentShutdown(manager: AgentManager): Promise<void> {
+	let timeout: ReturnType<typeof setTimeout> | undefined
+	try {
+		await Promise.race([
+			manager.waitForAll(),
+			new Promise<void>((resolve) => {
+				timeout = setTimeout(resolve, SUBAGENT_SHUTDOWN_WAIT_MS)
+				timeout.unref?.()
+			}),
+		])
+	} finally {
+		if (timeout) clearTimeout(timeout)
+	}
 }

--- a/src/extensions/agents/manager/agent-manager.test.ts
+++ b/src/extensions/agents/manager/agent-manager.test.ts
@@ -778,6 +778,62 @@ describe("AgentManager", () => {
 		}
 	})
 
+	it("waits for active resume promises to settle so resume runner cleanup can run", async () => {
+		const session = { dispose: vi.fn() } as unknown as AgentSession
+		mockRunAgent.mockResolvedValueOnce({
+			responseText: "checkpoint",
+			session,
+			aborted: true,
+			abortReason: "token_budget",
+			steered: false,
+		})
+		const releaseResume = deferred<void>()
+		const runnerCleanup = vi.fn()
+		mockResumeAgent.mockImplementationOnce((_session, _prompt, options) => {
+			const result = deferred<Awaited<ReturnType<typeof resumeAgent>>>()
+			options?.signal?.addEventListener(
+				"abort",
+				() => {
+					void releaseResume.promise.then(() => {
+						runnerCleanup()
+						result.resolve({
+							responseText: "resumed partial",
+							session,
+							aborted: true,
+							abortReason: "token_budget",
+							steered: false,
+						})
+					})
+				},
+				{ once: true },
+			)
+			return result.promise
+		})
+		manager = new AgentManager()
+		const record = await manager.spawnAndWait(fakePi(), fakeCtx(), "Explore", "inspect", {
+			description: "inspect",
+		})
+
+		const resume = manager.resume(record.id, "continue", { tokenBudget: 2048 })
+		await vi.waitFor(() => expect(mockResumeAgent).toHaveBeenCalledTimes(1))
+		manager.abortAll()
+		const wait = manager.waitForAll()
+
+		try {
+			await expectStillPending(wait)
+
+			releaseResume.resolve()
+			await wait
+			await resume
+
+			expect(runnerCleanup).toHaveBeenCalledTimes(1)
+		} finally {
+			releaseResume.resolve()
+			await wait.catch(() => {})
+			await resume.catch(() => {})
+		}
+	})
+
 	it("clears registered runner inactivity cleanup during dispose as a hard fallback", () => {
 		const runnerCleanup = vi.fn()
 		mockRunAgent.mockImplementationOnce((_ctx, _type, _prompt, options) => {

--- a/src/extensions/agents/manager/agent-manager.test.ts
+++ b/src/extensions/agents/manager/agent-manager.test.ts
@@ -728,6 +728,73 @@ describe("AgentManager", () => {
 		expect(outcome.recovery_guidance).toContain("stalled operation")
 		expect(outcome.recovery_guidance).toContain("narrower linked replacement")
 	})
+
+	it("waits for aborted subagent promises to settle so runner cleanup can run", async () => {
+		const releaseRun = deferred<void>()
+		const runnerCleanup = vi.fn()
+		mockRunAgent.mockImplementationOnce((_ctx, _type, _prompt, options) => {
+			const result = deferred<Awaited<ReturnType<typeof runAgent>>>()
+			options.signal?.addEventListener(
+				"abort",
+				() => {
+					// In the real runner, aborting the session does not clear timers by itself.
+					// The inactivity interval is cleared only when runAgent reaches its finally block.
+					void releaseRun.promise.then(() => {
+						runnerCleanup()
+						result.resolve({
+							responseText: "partial",
+							session: { dispose: vi.fn() } as unknown as AgentSession,
+							aborted: true,
+							abortReason: "token_budget",
+							steered: false,
+						})
+					})
+				},
+				{ once: true },
+			)
+			return result.promise
+		})
+		manager = new AgentManager()
+		manager.spawn(fakePi(), fakeCtx(), "Explore", "inspect", {
+			description: "inspect",
+			isBackground: true,
+		})
+
+		manager.abortAll()
+		const wait = manager.waitForAll()
+
+		try {
+			// waitForAll must keep waiting for the aborted runAgent promise, because
+			// that promise settling is what lets the runner's timer cleanup execute.
+			await expectStillPending(wait)
+
+			releaseRun.resolve()
+			await wait
+
+			expect(runnerCleanup).toHaveBeenCalledTimes(1)
+		} finally {
+			releaseRun.resolve()
+			await wait.catch(() => {})
+		}
+	})
+
+	it("clears registered runner inactivity cleanup during dispose as a hard fallback", () => {
+		const runnerCleanup = vi.fn()
+		mockRunAgent.mockImplementationOnce((_ctx, _type, _prompt, options) => {
+			options.onRuntimeCleanupRegistered?.(runnerCleanup)
+			return new Promise<never>(() => {})
+		})
+		manager = new AgentManager()
+		manager.spawn(fakePi(), fakeCtx(), "Explore", "inspect", {
+			description: "inspect",
+			isBackground: true,
+		})
+
+		manager.dispose()
+
+		expect(runnerCleanup).toHaveBeenCalledTimes(1)
+		manager = undefined
+	})
 })
 
 describe("AgentManager visibility", () => {
@@ -752,3 +819,22 @@ describe("AgentManager visibility", () => {
 		}
 	})
 })
+
+function deferred<T>(): { promise: Promise<T>; resolve: (value: T) => void; reject: (reason?: unknown) => void } {
+	let resolve!: (value: T) => void
+	let reject!: (reason?: unknown) => void
+	const promise = new Promise<T>((res, rej) => {
+		resolve = res
+		reject = rej
+	})
+	return { promise, resolve, reject }
+}
+
+async function expectStillPending(promise: Promise<unknown>): Promise<void> {
+	let settled = false
+	promise.then(() => {
+		settled = true
+	})
+	await Promise.resolve()
+	expect(settled).toBe(false)
+}

--- a/src/extensions/agents/manager/agent-manager.ts
+++ b/src/extensions/agents/manager/agent-manager.ts
@@ -120,6 +120,7 @@ Do not perform more task work, edit files, explore, or run verification. Based o
 
 export class AgentManager {
 	private agents = new Map<string, AgentRecord>()
+	private runtimeCleanups = new WeakMap<AgentRecord, () => void>()
 	private cleanupInterval: ReturnType<typeof setInterval>
 	private onComplete?: OnAgentComplete
 	private onStart?: OnAgentStart
@@ -264,6 +265,9 @@ export class AgentManager {
 				this.onCompact?.(record, info)
 				options.onCompaction?.(info)
 			},
+			onRuntimeCleanupRegistered: (cleanup) => {
+				this.runtimeCleanups.set(record, cleanup)
+			},
 			onSessionCreated: (session) => {
 				record.session = session
 				if (record.pendingSteers?.length) {
@@ -288,17 +292,6 @@ export class AgentManager {
 				record.completedAt ??= Date.now()
 				record.latestOutcome = buildAgentOutcome(record)
 
-				detach()
-
-				if (record.outputCleanup) {
-					try {
-						record.outputCleanup()
-					} catch {
-						/* ignore */
-					}
-					record.outputCleanup = undefined
-				}
-
 				if (options.isBackground) {
 					this.runningBackground--
 					this.onComplete?.(record)
@@ -314,23 +307,17 @@ export class AgentManager {
 				record.completedAt ??= Date.now()
 				record.latestOutcome = buildAgentOutcome(record)
 
-				detach()
-
-				if (record.outputCleanup) {
-					try {
-						record.outputCleanup()
-					} catch {
-						/* ignore */
-					}
-					record.outputCleanup = undefined
-				}
-
 				if (options.isBackground) {
 					this.runningBackground--
 					this.onComplete?.(record)
 					this.drainQueue()
 				}
 				return ""
+			})
+			.finally(() => {
+				detach()
+				this.cleanupRecordRuntime(record)
+				record.promise = undefined
 			})
 
 		record.promise = promise
@@ -557,7 +544,28 @@ export class AgentManager {
 		return true
 	}
 
+	private cleanupRecordRuntime(record: AgentRecord): void {
+		if (record.outputCleanup) {
+			try {
+				record.outputCleanup()
+			} catch {
+				/* ignore */
+			}
+			record.outputCleanup = undefined
+		}
+		const runtimeCleanup = this.runtimeCleanups.get(record)
+		if (runtimeCleanup) {
+			try {
+				runtimeCleanup()
+			} catch {
+				/* ignore */
+			}
+			this.runtimeCleanups.delete(record)
+		}
+	}
+
 	private removeRecord(id: string, record: AgentRecord): void {
+		this.cleanupRecordRuntime(record)
 		record.session?.dispose?.()
 		record.session = undefined
 		this.agents.delete(id)
@@ -616,10 +624,7 @@ export class AgentManager {
 	async waitForAll(): Promise<void> {
 		while (true) {
 			this.drainQueue()
-			const pending = [...this.agents.values()]
-				.filter((r) => r.status === "running" || r.status === "queued")
-				.map((r) => r.promise)
-				.filter(Boolean)
+			const pending = [...this.agents.values()].map((r) => r.promise).filter(Boolean)
 			if (pending.length === 0) break
 			await Promise.allSettled(pending)
 		}
@@ -629,6 +634,7 @@ export class AgentManager {
 		clearInterval(this.cleanupInterval)
 		this.queue = []
 		for (const record of this.agents.values()) {
+			this.cleanupRecordRuntime(record)
 			record.session?.dispose()
 		}
 		this.agents.clear()

--- a/src/extensions/agents/manager/agent-manager.ts
+++ b/src/extensions/agents/manager/agent-manager.ts
@@ -121,6 +121,7 @@ Do not perform more task work, edit files, explore, or run verification. Based o
 export class AgentManager {
 	private agents = new Map<string, AgentRecord>()
 	private runtimeCleanups = new WeakMap<AgentRecord, () => void>()
+	private activeResumePromises = new WeakMap<AgentRecord, Promise<unknown>>()
 	private cleanupInterval: ReturnType<typeof setInterval>
 	private onComplete?: OnAgentComplete
 	private onStart?: OnAgentStart
@@ -422,35 +423,41 @@ export class AgentManager {
 		if (options.signal?.aborted) abortController.abort()
 		else options.signal?.addEventListener("abort", onCallerAbort, { once: true })
 
+		const attemptPrompt =
+			purpose === "finalize_report" && record.taskRef
+				? reportFinalizationPrompt(record.taskRef)
+				: withAgentReportProtocol(prompt ?? "", record.taskRef)
+		const resumePromise = resumeAgent(record.session, attemptPrompt, {
+			onToolActivity: (activity) => {
+				if (activity.type === "end") record.toolUses++
+			},
+			onTurnEnd: (turnCount) => {
+				record.lastTurnCount = turnCount
+			},
+			onAssistantUsage: (usage) => {
+				addUsage(record.lifetimeUsage, usage)
+			},
+			onCompaction: (info) => {
+				record.compactionCount++
+				this.onCompact?.(record, info)
+			},
+			signal: abortController.signal,
+			maxTurns: attemptLimits.maxTurns,
+			tokenBudget: attemptTokenBudget,
+			minTokenBudget: purpose === "finalize_report" ? MIN_FINALIZE_TOKEN_BUDGET : undefined,
+			inactivityTimeout: options.inactivityTimeout,
+			maxDuration: attemptLimits.maxDuration,
+			hardTurnLimit: record.taskRef?.kind === "ferment_step",
+			shouldTerminateAfterTool: (toolName) =>
+				toolName === "submit_agent_report" && record.agentReport?.attempt_id === record.currentAttemptId,
+			onRuntimeCleanupRegistered: (cleanup) => {
+				this.runtimeCleanups.set(record, cleanup)
+			},
+		})
+		this.activeResumePromises.set(record, resumePromise)
+
 		try {
-			const attemptPrompt =
-				purpose === "finalize_report" && record.taskRef
-					? reportFinalizationPrompt(record.taskRef)
-					: withAgentReportProtocol(prompt ?? "", record.taskRef)
-			const result = await resumeAgent(record.session, attemptPrompt, {
-				onToolActivity: (activity) => {
-					if (activity.type === "end") record.toolUses++
-				},
-				onTurnEnd: (turnCount) => {
-					record.lastTurnCount = turnCount
-				},
-				onAssistantUsage: (usage) => {
-					addUsage(record.lifetimeUsage, usage)
-				},
-				onCompaction: (info) => {
-					record.compactionCount++
-					this.onCompact?.(record, info)
-				},
-				signal: abortController.signal,
-				maxTurns: attemptLimits.maxTurns,
-				tokenBudget: attemptTokenBudget,
-				minTokenBudget: purpose === "finalize_report" ? MIN_FINALIZE_TOKEN_BUDGET : undefined,
-				inactivityTimeout: options.inactivityTimeout,
-				maxDuration: attemptLimits.maxDuration,
-				hardTurnLimit: record.taskRef?.kind === "ferment_step",
-				shouldTerminateAfterTool: (toolName) =>
-					toolName === "submit_agent_report" && record.agentReport?.attempt_id === record.currentAttemptId,
-			})
+			const result = await resumePromise
 			if ((record.status as AgentRecord["status"]) !== "stopped") {
 				record.status = result.aborted ? "aborted" : result.steered ? "steered" : "completed"
 			}
@@ -467,6 +474,8 @@ export class AgentManager {
 			record.completedAt = Date.now()
 		} finally {
 			options.signal?.removeEventListener("abort", onCallerAbort)
+			this.activeResumePromises.delete(record)
+			this.cleanupRecordRuntime(record)
 		}
 		attempt.completedAt = record.completedAt
 		attempt.outcome = classifyAgentOutcome(record)
@@ -624,7 +633,9 @@ export class AgentManager {
 	async waitForAll(): Promise<void> {
 		while (true) {
 			this.drainQueue()
-			const pending = [...this.agents.values()].map((r) => r.promise).filter(Boolean)
+			const pending = [...this.agents.values()].flatMap((r) =>
+				[r.promise, this.activeResumePromises.get(r)].filter(Boolean),
+			)
 			if (pending.length === 0) break
 			await Promise.allSettled(pending)
 		}

--- a/src/extensions/agents/manager/agent-runner.test.ts
+++ b/src/extensions/agents/manager/agent-runner.test.ts
@@ -1279,6 +1279,73 @@ describe("runAgent — maxDuration enforcement", () => {
 	})
 })
 
+describe("runAgent — runtime cleanup", () => {
+	let ctx: ReturnType<typeof makeFakeCtx>
+	let pi: ReturnType<typeof makeFakePi>
+
+	beforeEach(() => {
+		vi.useFakeTimers()
+		ctx = makeFakeCtx()
+		pi = makeFakePi()
+		mockCreateAgentSession.mockReset()
+		mockGetConfig.mockReturnValue(makeTypeConfig({ extensions: false, skills: false }))
+		mockGetAgentConfig.mockReturnValue(makeAgentConfig())
+		mockGetToolNamesForType.mockReturnValue([])
+	})
+
+	afterEach(() => {
+		vi.useRealTimers()
+		vi.clearAllMocks()
+	})
+
+	it("registered runtime cleanup clears the inactivity interval before the prompt settles", async () => {
+		const abortSpy = vi.fn()
+		let resolvePrompt: (() => void) | undefined
+		const promptPromise = new Promise<void>((resolve) => {
+			resolvePrompt = resolve
+		})
+		const session = makeFakeSession({
+			abortSpy,
+			emitUsage: false,
+			promptAction: async () => {
+				await promptPromise
+			},
+		})
+		mockCreateAgentSession.mockResolvedValue({
+			session: session as unknown as Awaited<ReturnType<typeof createAgentSession>>["session"],
+			extensionsResult: { extensions: [], tools: [] } as unknown as Awaited<
+				ReturnType<typeof createAgentSession>
+			>["extensionsResult"],
+		})
+		let cleanup: (() => void) | undefined
+
+		const resultPromise = runAgent(
+			ctx as unknown as Parameters<typeof runAgent>[0],
+			"General-Purpose",
+			"do something",
+			{
+				pi: pi as unknown as RunOptions["pi"],
+				inactivityTimeout: 10,
+				maxDuration: 0,
+				onRuntimeCleanupRegistered: (fn) => {
+					cleanup = fn
+				},
+			},
+		)
+		await vi.waitFor(() => expect(cleanup).toBeDefined())
+
+		cleanup?.()
+		await vi.advanceTimersByTimeAsync(25_000)
+
+		expect(session.steer).not.toHaveBeenCalled()
+		expect(abortSpy).not.toHaveBeenCalled()
+
+		resolvePrompt?.()
+		const result = await resultPromise
+		expect(result.aborted).toBe(false)
+	})
+})
+
 describe("resumeAgent — maxDuration enforcement", () => {
 	beforeEach(() => {
 		vi.useFakeTimers()

--- a/src/extensions/agents/manager/agent-runner.test.ts
+++ b/src/extensions/agents/manager/agent-runner.test.ts
@@ -1344,6 +1344,41 @@ describe("runAgent — runtime cleanup", () => {
 		const result = await resultPromise
 		expect(result.aborted).toBe(false)
 	})
+
+	it("registered runtime cleanup clears the resume inactivity interval before the prompt settles", async () => {
+		const abortSpy = vi.fn()
+		let resolvePrompt: (() => void) | undefined
+		const promptPromise = new Promise<void>((resolve) => {
+			resolvePrompt = resolve
+		})
+		const session = makeFakeSession({
+			abortSpy,
+			emitUsage: false,
+			promptAction: async () => {
+				await promptPromise
+			},
+		})
+		let cleanup: (() => void) | undefined
+
+		const resultPromise = resumeAgent(session as unknown as AgentSession, "continue", {
+			inactivityTimeout: 10,
+			maxDuration: 0,
+			onRuntimeCleanupRegistered: (fn) => {
+				cleanup = fn
+			},
+		})
+		await vi.waitFor(() => expect(cleanup).toBeDefined())
+
+		cleanup?.()
+		await vi.advanceTimersByTimeAsync(25_000)
+
+		expect(session.steer).not.toHaveBeenCalled()
+		expect(abortSpy).not.toHaveBeenCalled()
+
+		resolvePrompt?.()
+		const result = await resultPromise
+		expect(result.aborted).toBe(false)
+	})
 })
 
 describe("resumeAgent — maxDuration enforcement", () => {

--- a/src/extensions/agents/manager/agent-runner.ts
+++ b/src/extensions/agents/manager/agent-runner.ts
@@ -236,6 +236,8 @@ export interface RunOptions {
 	workerReport?: WorkerReportCapability
 	/** Enforce maxTurns as a hard cap instead of allowing ordinary-agent grace turns. */
 	hardTurnLimit?: boolean
+	/** Registers a hard-fallback cleanup for runner-owned resources. */
+	onRuntimeCleanupRegistered?: (cleanup: () => void) => void
 }
 
 export interface RunResult {
@@ -633,7 +635,7 @@ async function runAgentInner(
 		}
 	})
 
-	const inactivityInterval = setInterval(() => {
+	let inactivityInterval: ReturnType<typeof setInterval> | undefined = setInterval(() => {
 		const elapsed = Date.now() - inactivity.lastActivityAt
 		if (inactivity.steered && elapsed >= inactivityTimeout) {
 			aborted = true
@@ -644,6 +646,12 @@ async function runAgentInner(
 			steerAsOrchestrator(session, "You appear to be stalled. Resume work immediately or summarize your progress.")
 		}
 	}, INACTIVITY_CHECK_INTERVAL)
+	const cleanupInactivityInterval = () => {
+		if (!inactivityInterval) return
+		clearInterval(inactivityInterval)
+		inactivityInterval = undefined
+	}
+	options.onRuntimeCleanupRegistered?.(cleanupInactivityInterval)
 
 	const effectiveMaxDuration = options.maxDuration ?? agentConfig?.maxDuration ?? DEFAULT_MAX_DURATION
 	const durationTimer = effectiveMaxDuration
@@ -681,7 +689,7 @@ async function runAgentInner(
 	try {
 		await session.prompt(effectivePrompt)
 	} finally {
-		clearInterval(inactivityInterval)
+		cleanupInactivityInterval()
 		if (durationTimer) clearTimeout(durationTimer)
 		unsubTurns()
 		collector.unsubscribe()

--- a/src/extensions/agents/manager/agent-runner.ts
+++ b/src/extensions/agents/manager/agent-runner.ts
@@ -760,6 +760,8 @@ export async function resumeAgent(
 		maxDuration?: number
 		hardTurnLimit?: boolean
 		shouldTerminateAfterTool?: (toolName: string) => boolean
+		/** Registers a hard-fallback cleanup for runner-owned resources. */
+		onRuntimeCleanupRegistered?: (cleanup: () => void) => void
 	} = {},
 ): Promise<RunResult> {
 	const collector = collectResponseText(session)
@@ -858,7 +860,7 @@ export async function resumeAgent(
 		}
 	})
 
-	const resumeInactivityInterval = setInterval(() => {
+	let resumeInactivityInterval: ReturnType<typeof setInterval> | undefined = setInterval(() => {
 		const elapsed = Date.now() - resumeInactivity.lastActivityAt
 		if (resumeInactivity.steered && elapsed >= resumeInactivityTimeout) {
 			aborted = true
@@ -869,6 +871,12 @@ export async function resumeAgent(
 			steerAsOrchestrator(session, "You appear to be stalled. Resume work immediately or summarize your progress.")
 		}
 	}, INACTIVITY_CHECK_INTERVAL)
+	const cleanupResumeInactivityInterval = () => {
+		if (!resumeInactivityInterval) return
+		clearInterval(resumeInactivityInterval)
+		resumeInactivityInterval = undefined
+	}
+	options.onRuntimeCleanupRegistered?.(cleanupResumeInactivityInterval)
 	const durationTimer = effectiveMaxDuration
 		? setTimeout(() => {
 				aborted = true
@@ -880,7 +888,7 @@ export async function resumeAgent(
 	try {
 		await session.prompt(prompt)
 	} finally {
-		clearInterval(resumeInactivityInterval)
+		cleanupResumeInactivityInterval()
 		if (durationTimer) clearTimeout(durationTimer)
 		collector.unsubscribe()
 		unsubEvents()

--- a/src/extensions/telemetry/settings-change-emitter.ts
+++ b/src/extensions/telemetry/settings-change-emitter.ts
@@ -102,11 +102,12 @@ export function startSettingsChangeWatcher(emit: EmitFn): () => void {
 		// inode; watching the file directly on Linux would lose the watcher.
 		// Directory-level watching survives inode replacement.
 		const settingsPath = resolve(agentDir, "settings.json")
-		watcher = watch(agentDir, (eventType, filename) => {
+		watcher = watch(agentDir, { persistent: false }, (eventType, filename) => {
 			if (filename !== "settings.json") return
 			if (debounceTimer) clearTimeout(debounceTimer)
 			debounceTimer = setTimeout(fire, DEBOUNCE_MS)
 		})
+		watcher.unref?.()
 		watcher.on("error", () => {
 			watcher?.close()
 			watcher = undefined

--- a/src/resources/extension.test.ts
+++ b/src/resources/extension.test.ts
@@ -1,18 +1,57 @@
 import type { ExtensionAPI, ExtensionCommandContext } from "@earendil-works/pi-coding-agent"
-import { describe, expect, it, vi } from "vitest"
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
 import type { ResourceKind } from "./types.js"
 
 const createResourceManagerMock = vi.hoisted(() =>
 	vi.fn((_tui: unknown, _theme: unknown, _done: () => void, kind?: ResourceKind) => ({ kind })),
 )
+const rtkInstallMocks = vi.hoisted(() => ({
+	ensureRtkPath: vi.fn(),
+	installRtk: vi.fn(),
+	isRtkCommandAvailable: vi.fn(),
+	isRtkInstalled: vi.fn(),
+	markRtkAutoInstallChecked: vi.fn(),
+	shouldCheckRtkAutoInstall: vi.fn(),
+}))
+const storeMocks = vi.hoisted(() => ({
+	isResourceEnabled: vi.fn(),
+	setResourceOverride: vi.fn(),
+}))
 
 vi.mock("./ui.js", () => ({ createResourceManager: createResourceManagerMock }))
+vi.mock("./rtk-install.js", () => rtkInstallMocks)
+vi.mock("./store.js", () => storeMocks)
 
 const { default: resourcesExtension } = await import("./extension.js")
 
 type CommandConfig = { description: string; handler: (args: string, ctx: ExtensionCommandContext) => Promise<void> }
+type ExtensionHandler = (event: unknown, ctx: ExtensionCommandContext) => void | Promise<void>
+
+const originalRtkAutoInstall = process.env.KIMCHI_RTK_AUTO_INSTALL
 
 describe("resourcesExtension", () => {
+	beforeEach(() => {
+		vi.clearAllMocks()
+		storeMocks.isResourceEnabled.mockReturnValue(true)
+		rtkInstallMocks.isRtkInstalled.mockReturnValue(false)
+		rtkInstallMocks.isRtkCommandAvailable.mockReturnValue(false)
+		rtkInstallMocks.shouldCheckRtkAutoInstall.mockReturnValue(true)
+		rtkInstallMocks.installRtk.mockResolvedValue({
+			version: "v1.0.0",
+			binaryPath: "/tmp/rtk",
+			linkPath: "/tmp/bin/rtk",
+		})
+		process.env.KIMCHI_RTK_AUTO_INSTALL = undefined
+	})
+
+	afterEach(() => {
+		if (originalRtkAutoInstall === undefined) {
+			process.env.KIMCHI_RTK_AUTO_INSTALL = undefined
+		} else {
+			process.env.KIMCHI_RTK_AUTO_INSTALL = originalRtkAutoInstall
+		}
+	})
+
 	it.each([
 		["hooks", "hooks"],
 		["plugins", "plugins"],
@@ -30,17 +69,39 @@ describe("resourcesExtension", () => {
 			kind,
 		)
 	})
+
+	it("does not touch a session-start context after async RTK install work completes", async () => {
+		const install = deferred<{ version: string; binaryPath: string; linkPath: string }>()
+		rtkInstallMocks.installRtk.mockReturnValue(install.promise)
+		const { api, handlers } = makeMockPi()
+		const { ctx, notify, makeStale } = makeStaleableUIContext()
+		resourcesExtension(api)
+
+		handlers.get("session_start")?.({}, ctx)
+		makeStale()
+		install.resolve({ version: "v1.0.0", binaryPath: "/tmp/rtk", linkPath: "/tmp/bin/rtk" })
+		await vi.waitFor(() => expect(rtkInstallMocks.markRtkAutoInstallChecked).toHaveBeenCalledTimes(1))
+
+		expect(notify).toHaveBeenCalledWith("RTK ready at /tmp/bin/rtk", "info")
+	})
 })
 
-function makeMockPi(): { api: ExtensionAPI; commands: Map<string, CommandConfig> } {
+function makeMockPi(): {
+	api: ExtensionAPI
+	commands: Map<string, CommandConfig>
+	handlers: Map<string, ExtensionHandler>
+} {
 	const commands = new Map<string, CommandConfig>()
+	const handlers = new Map<string, ExtensionHandler>()
 	const api = {
 		registerCommand: vi.fn((name: string, config: CommandConfig) => {
 			commands.set(name, config)
 		}),
-		on: vi.fn(),
+		on: vi.fn((name: string, handler: ExtensionHandler) => {
+			handlers.set(name, handler)
+		}),
 	} as unknown as ExtensionAPI
-	return { api, commands }
+	return { api, commands, handlers }
 }
 
 function makeUIContext(): ExtensionCommandContext {
@@ -54,4 +115,41 @@ function makeUIContext(): ExtensionCommandContext {
 			confirm: vi.fn(),
 		},
 	} as unknown as ExtensionCommandContext
+}
+
+function makeStaleableUIContext(): {
+	ctx: ExtensionCommandContext
+	notify: ReturnType<typeof vi.fn>
+	makeStale: () => void
+} {
+	let stale = false
+	const notify = vi.fn()
+	const ui = { notify }
+	const ctx = {
+		get hasUI() {
+			if (stale) throw new Error("stale extension ctx")
+			return true
+		},
+		get ui() {
+			if (stale) throw new Error("stale extension ctx")
+			return ui
+		},
+	} as unknown as ExtensionCommandContext
+	return {
+		ctx,
+		notify,
+		makeStale: () => {
+			stale = true
+		},
+	}
+}
+
+function deferred<T>(): { promise: Promise<T>; resolve: (value: T) => void; reject: (reason?: unknown) => void } {
+	let resolve!: (value: T) => void
+	let reject!: (reason?: unknown) => void
+	const promise = new Promise<T>((res, rej) => {
+		resolve = res
+		reject = rej
+	})
+	return { promise, resolve, reject }
 }

--- a/src/resources/extension.ts
+++ b/src/resources/extension.ts
@@ -43,6 +43,7 @@ async function ensureRtkOnStartup(ctx: ExtensionContext): Promise<void> {
 	if (!isResourceEnabled("hooks.rtk-rewrite")) return
 	if (process.env.KIMCHI_RTK_AUTO_INSTALL === "0") return
 
+	const notify = createSafeNotifier(ctx)
 	ensureRtkPath()
 	const missing = !isRtkInstalled()
 	const commandMissing = !isRtkCommandAvailable()
@@ -51,12 +52,23 @@ async function ensureRtkOnStartup(ctx: ExtensionContext): Promise<void> {
 	try {
 		const result = await installRtk()
 		markRtkAutoInstallChecked()
-		if ((missing || commandMissing) && ctx.hasUI) ctx.ui.notify(`RTK ready at ${result.linkPath}`, "info")
+		if ((missing || commandMissing) && notify) notify(`RTK ready at ${result.linkPath}`, "info")
 	} catch (err) {
 		markRtkAutoInstallChecked()
-		if ((missing || commandMissing) && ctx.hasUI)
-			ctx.ui.notify(`RTK install failed: ${(err as Error).message}`, "warning")
+		if ((missing || commandMissing) && notify) notify(`RTK install failed: ${(err as Error).message}`, "warning")
 	}
+}
+
+function createSafeNotifier(ctx: ExtensionContext): ExtensionContext["ui"]["notify"] | undefined {
+	if (!ctx.hasUI) return undefined
+	const notify = ctx.ui.notify.bind(ctx.ui)
+	return ((...args: Parameters<ExtensionContext["ui"]["notify"]>) => {
+		try {
+			notify(...args)
+		} catch {
+			/* Notification is best-effort; startup cleanup must not fail because the UI was replaced. */
+		}
+	}) as ExtensionContext["ui"]["notify"]
 }
 
 async function handleResourcesCommand(args: string, ctx: ExtensionContext): Promise<void> {

--- a/src/settings-watcher.test.ts
+++ b/src/settings-watcher.test.ts
@@ -3,7 +3,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
 // settings-watcher reads from process.env and fs — mock both.
 vi.mock("node:fs", () => ({
 	readFileSync: vi.fn(),
-	watch: vi.fn(() => ({ close: vi.fn() })),
+	watch: vi.fn(),
 }))
 
 import { readFileSync, watch } from "node:fs"
@@ -12,8 +12,19 @@ import { getActiveThemeName, onThemeChange } from "./settings-watcher.js"
 const mockReadFileSync = vi.mocked(readFileSync)
 const mockWatch = vi.mocked(watch)
 
+function createMockWatcher() {
+	return { close: vi.fn(), on: vi.fn(), unref: vi.fn() }
+}
+
+function getWatchCallback(): (() => void) | undefined {
+	return (mockWatch.mock.calls[0] as unknown[] | undefined)?.[2] as (() => void) | undefined
+}
+
 beforeEach(() => {
 	process.env.KIMCHI_CODING_AGENT_DIR = "/fake/agent/dir"
+	mockReadFileSync.mockReset()
+	mockWatch.mockReset()
+	mockWatch.mockReturnValue(createMockWatcher() as unknown as ReturnType<typeof watch>)
 	vi.useFakeTimers()
 })
 
@@ -58,8 +69,7 @@ describe("onThemeChange", () => {
 		const unsub = onThemeChange(listener)
 
 		// Trigger the fs.watch callback (same theme in file)
-		const watchCallback = mockWatch.mock.calls[0]?.[1] as (() => void) | undefined
-		watchCallback?.()
+		getWatchCallback()?.()
 		vi.runAllTimers() // flush debounce
 
 		expect(listener).not.toHaveBeenCalled()
@@ -74,8 +84,7 @@ describe("onThemeChange", () => {
 		const listener = vi.fn()
 		const unsub = onThemeChange(listener)
 
-		const watchCallback = mockWatch.mock.calls[0]?.[1] as (() => void) | undefined
-		watchCallback?.()
+		getWatchCallback()?.()
 		vi.runAllTimers()
 
 		expect(listener).toHaveBeenCalledWith("dark", "kimchi-minimal")
@@ -84,12 +93,24 @@ describe("onThemeChange", () => {
 
 	it("closes the watcher when last listener unsubscribes", () => {
 		mockReadFileSync.mockReturnValue(JSON.stringify({ theme: "dark" }))
-		const mockWatcherInstance = { close: vi.fn() }
+		const mockWatcherInstance = createMockWatcher()
 		mockWatch.mockReturnValue(mockWatcherInstance as unknown as ReturnType<typeof watch>)
 
 		const unsub = onThemeChange(vi.fn())
 		unsub()
 
 		expect(mockWatcherInstance.close).toHaveBeenCalled()
+	})
+
+	it("does not keep the process alive by default", () => {
+		mockReadFileSync.mockReturnValue(JSON.stringify({ theme: "dark" }))
+		const mockWatcherInstance = createMockWatcher()
+		mockWatch.mockReturnValue(mockWatcherInstance as unknown as ReturnType<typeof watch>)
+
+		const unsub = onThemeChange(vi.fn())
+		unsub()
+
+		expect(mockWatch).toHaveBeenCalledWith("/fake/agent/dir/settings.json", { persistent: false }, expect.any(Function))
+		expect(mockWatcherInstance.unref).toHaveBeenCalled()
 	})
 })

--- a/src/settings-watcher.ts
+++ b/src/settings-watcher.ts
@@ -50,11 +50,12 @@ function ensureWatcher(): void {
 	if (!agentDir) return
 	lastSeenTheme = getActiveThemeName()
 	try {
-		watcher = watch(resolve(agentDir, "settings.json"), () => {
+		watcher = watch(resolve(agentDir, "settings.json"), { persistent: false }, () => {
 			// fs.watch fires multiple events per write on macOS; debounce to one.
 			if (debounceTimer) clearTimeout(debounceTimer)
 			debounceTimer = setTimeout(fire, 30)
 		})
+		watcher.unref?.()
 		watcher.on("error", (err) => {
 			console.warn("[settings-watcher] watch error:", err)
 			watcher?.close()

--- a/src/theme-file-watcher.ts
+++ b/src/theme-file-watcher.ts
@@ -48,13 +48,14 @@ function ensureWatcher(): void {
 	lastActiveTheme = getActiveThemeName()
 
 	try {
-		watcher = watch(themesDir, (_event, filename) => {
+		watcher = watch(themesDir, { persistent: false }, (_event, filename) => {
 			// Only respond to JSON files that aren't settings.json (handled elsewhere).
 			if (!filename || !filename.endsWith(".json") || filename === "settings.json") return
 			// fs.watch fires multiple events per write on macOS; debounce to one.
 			if (debounceTimer) clearTimeout(debounceTimer)
 			debounceTimer = setTimeout(() => fire(filename), 30)
 		})
+		watcher.unref?.()
 		watcher.on("error", (err) => {
 			console.warn("[theme-file-watcher] watch error:", err)
 			watcher?.close()

--- a/tests/e2e/tui/support/fake-openai-server.ts
+++ b/tests/e2e/tui/support/fake-openai-server.ts
@@ -284,12 +284,57 @@ function extractFermentId(body: unknown): string | undefined {
 
 /** Pull the Agent id from prior Agent tool output (`Agent ID: <id>` or `agent_id`). */
 function extractAgentId(body: unknown): string | undefined {
-	const raw = JSON.stringify(body ?? "")
-	return (
-		raw.match(/Agent ID:\s*([0-9a-fA-F-]{8,})/)?.[1] ??
-		raw.match(/agent_id[\\"\s:]+([0-9a-fA-F-]{8,})/)?.[1] ??
-		raw.match(/agentId[\\"\s:]+([0-9a-fA-F-]{8,})/)?.[1]
-	)
+	const messages = asRecord(body).messages
+	if (Array.isArray(messages)) {
+		for (const message of [...messages].reverse()) {
+			const fromMessage = extractAgentIdFromValue(message)
+			if (fromMessage) return fromMessage
+			const content = asRecord(message).content
+			const fromContent = extractAgentIdFromText(readMessageContent(content))
+			if (fromContent) return fromContent
+		}
+	}
+	return extractAgentIdFromText(JSON.stringify(body ?? ""))
+}
+
+function extractAgentIdFromValue(value: unknown): string | undefined {
+	if (Array.isArray(value)) {
+		for (const item of value) {
+			const found = extractAgentIdFromValue(item)
+			if (found) return found
+		}
+		return undefined
+	}
+	const record = asRecord(value)
+	for (const key of ["agent_id", "agentId"]) {
+		const found = parseAgentId(record[key])
+		if (found) return found
+	}
+	return undefined
+}
+
+function readMessageContent(content: unknown): string {
+	if (typeof content === "string") return content
+	if (!Array.isArray(content)) return ""
+	return content
+		.map((part) => {
+			if (typeof part === "string") return part
+			const record = asRecord(part)
+			return typeof record.text === "string" ? record.text : ""
+		})
+		.join("\n")
+}
+
+function extractAgentIdFromText(text: string): string | undefined {
+	return text.match(/Agent ID:\s*([0-9a-fA-F-]{8,})/)?.[1] ?? text.match(/agent_?id[\\"\s:]+([0-9a-fA-F-]{8,})/i)?.[1]
+}
+
+function parseAgentId(value: unknown): string | undefined {
+	return typeof value === "string" && /^[0-9a-fA-F-]{8,}$/.test(value) ? value : undefined
+}
+
+function asRecord(value: unknown): Record<string, unknown> {
+	return value && typeof value === "object" ? (value as Record<string, unknown>) : {}
 }
 
 function unixNow(): number {

--- a/tests/e2e/tui/support/fake-openai-server.ts
+++ b/tests/e2e/tui/support/fake-openai-server.ts
@@ -246,12 +246,13 @@ async function writeChatCompletion(res: ServerResponse, script: FakeResponseScri
 		}
 	}
 
-	// Substitute the `__FERMENT_ID__` token in tool args with the real id from the request.
+	// Substitute dynamic ids from previous tool results into scripted tool args.
 	const fermentId = extractFermentId(body)
+	const agentId = extractAgentId(body)
 	for (const toolCall of script.toolCalls ?? []) {
-		const fn = fermentId
-			? { ...toolCall.function, arguments: toolCall.function.arguments.replaceAll("__FERMENT_ID__", fermentId) }
-			: toolCall.function
+		const fn = { ...toolCall.function }
+		if (fermentId) fn.arguments = fn.arguments.replaceAll("__FERMENT_ID__", fermentId)
+		if (agentId) fn.arguments = fn.arguments.replaceAll("__AGENT_ID__", agentId)
 		chunk([
 			{
 				index: 0,
@@ -279,6 +280,16 @@ async function writeChatCompletion(res: ServerResponse, script: FakeResponseScri
 function extractFermentId(body: unknown): string | undefined {
 	const match = JSON.stringify(body ?? "").match(/ferment_id[\\"\s:]+([0-9a-fA-F-]{8,})/)
 	return match?.[1]
+}
+
+/** Pull the Agent id from prior Agent tool output (`Agent ID: <id>` or `agent_id`). */
+function extractAgentId(body: unknown): string | undefined {
+	const raw = JSON.stringify(body ?? "")
+	return (
+		raw.match(/Agent ID:\s*([0-9a-fA-F-]{8,})/)?.[1] ??
+		raw.match(/agent_id[\\"\s:]+([0-9a-fA-F-]{8,})/)?.[1] ??
+		raw.match(/agentId[\\"\s:]+([0-9a-fA-F-]{8,})/)?.[1]
+	)
 }
 
 function unixNow(): number {

--- a/tests/smoke/ferment-oneshot-exit.test.ts
+++ b/tests/smoke/ferment-oneshot-exit.test.ts
@@ -5,6 +5,7 @@ import { join, resolve } from "node:path"
 import { describe, expect, it } from "vitest"
 import {
 	DEFAULT_MODEL,
+	type FakeOpenAiServer,
 	type FakeResponseScript,
 	type RecordedRequest,
 	resolveModels,
@@ -28,6 +29,7 @@ interface ProcessResult {
 interface JsonlEntry {
 	type?: string
 	customType?: string
+	raw?: string
 	message?: {
 		role?: string
 		toolName?: string
@@ -46,9 +48,10 @@ describe("--ferment-oneshot process lifecycle", () => {
 
 async function expectOneshotLifecycleToExit(): Promise<void> {
 	const tempRoot = mkdtempSync(join(tmpdir(), "kimchi-ferment-oneshot-exit-"))
-	const fake = await startFakeOpenAiServer({ responses: oneShotCompletionScript() })
+	let fake: FakeOpenAiServer | undefined
 
 	try {
+		fake = await startFakeOpenAiServer({ responses: oneShotCompletionScript() })
 		const homeDir = join(tempRoot, "home")
 		const workDir = join(tempRoot, "work")
 		const sessionDir = join(tempRoot, "sessions")
@@ -68,7 +71,7 @@ async function expectOneshotLifecycleToExit(): Promise<void> {
 			prompt: "Exercise the one-shot ferment process lifecycle and then finish.",
 		})
 		const sessionEntries = readJsonl(sessionPath)
-		const failure = formatFailure(result, sessionEntries, fermentsDir, fake.requests)
+		const failure = formatFailure(result, sessionEntries, fermentsDir, fake?.requests ?? [])
 
 		expect(hasFermentCompleted(fermentsDir), failure).toBe(true)
 		expect(
@@ -87,7 +90,7 @@ async function expectOneshotLifecycleToExit(): Promise<void> {
 		expect(result.timedOut, failure).toBe(false)
 		expect(result.code, failure).toBe(0)
 	} finally {
-		await fake.stop().catch(() => {})
+		await fake?.stop().catch(() => {})
 		rmSync(tempRoot, { recursive: true, force: true })
 	}
 }
@@ -95,6 +98,7 @@ async function expectOneshotLifecycleToExit(): Promise<void> {
 function oneShotCompletionScript(): FakeResponseScript[] {
 	return [
 		{
+			// Scope a one-phase Ferment. The fake server substitutes the runtime ferment id.
 			stream: ["Starting the linked-worker one-shot lifecycle."],
 			toolCalls: [
 				{
@@ -125,6 +129,7 @@ function oneShotCompletionScript(): FakeResponseScript[] {
 			],
 		},
 		{
+			// Activate the scoped phase so implementation tools and Agent workers unlock.
 			toolCalls: [
 				{
 					id: "call_activate",
@@ -139,6 +144,7 @@ function oneShotCompletionScript(): FakeResponseScript[] {
 			],
 		},
 		{
+			// Start the only step; the tool response instructs the model to spawn a linked Agent.
 			toolCalls: [
 				{
 					id: "call_start_step",
@@ -155,6 +161,7 @@ function oneShotCompletionScript(): FakeResponseScript[] {
 			],
 		},
 		{
+			// Spawn the linked worker with task_ref so complete_ferment_step can validate it.
 			toolCalls: [
 				{
 					id: "call_worker_agent",
@@ -181,6 +188,7 @@ function oneShotCompletionScript(): FakeResponseScript[] {
 			],
 		},
 		{
+			// Simulate the linked worker reporting success through the extension tool.
 			stream: ["Submitting the linked worker report."],
 			toolCalls: [
 				{
@@ -200,9 +208,11 @@ function oneShotCompletionScript(): FakeResponseScript[] {
 			],
 		},
 		{
+			// Give the parent turn one plain assistant response after the worker report.
 			stream: ["Linked worker report submitted."],
 		},
 		{
+			// Complete the step using the real Agent id returned by the Agent tool result.
 			toolCalls: [
 				{
 					id: "call_complete_step",
@@ -221,6 +231,7 @@ function oneShotCompletionScript(): FakeResponseScript[] {
 			],
 		},
 		{
+			// Close the active phase after the single step has completed.
 			toolCalls: [
 				{
 					id: "call_complete_phase",
@@ -237,6 +248,7 @@ function oneShotCompletionScript(): FakeResponseScript[] {
 			],
 		},
 		{
+			// Complete the Ferment; the following request is the judge response.
 			toolCalls: [
 				{
 					id: "call_complete_ferment",
@@ -252,9 +264,11 @@ function oneShotCompletionScript(): FakeResponseScript[] {
 			],
 		},
 		{
+			// Return the one-shot judge JSON that Ferment expects after completion.
 			stream: ['{"grade":"A","rationale":"The linked-worker one-shot lifecycle completed cleanly."}'],
 		},
 		{
+			// Final assistant text must be emitted before agent_end and process exit.
 			stream: [FINAL_TEXT],
 		},
 	]
@@ -397,7 +411,13 @@ function readJsonl(path: string): JsonlEntry[] {
 	return readFileSync(path, "utf-8")
 		.split("\n")
 		.filter((line) => line.trim().length > 0)
-		.map((line) => JSON.parse(line) as JsonlEntry)
+		.map((line) => {
+			try {
+				return JSON.parse(line) as JsonlEntry
+			} catch {
+				return { type: "parse_error", raw: line }
+			}
+		})
 }
 
 function hasFermentCompleted(fermentsDir: string): boolean {

--- a/tests/smoke/ferment-oneshot-exit.test.ts
+++ b/tests/smoke/ferment-oneshot-exit.test.ts
@@ -1,0 +1,494 @@
+import { spawn } from "node:child_process"
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, readdirSync, rmSync, writeFileSync } from "node:fs"
+import { tmpdir } from "node:os"
+import { join, resolve } from "node:path"
+import { describe, expect, it } from "vitest"
+import {
+	DEFAULT_MODEL,
+	type FakeResponseScript,
+	type RecordedRequest,
+	resolveModels,
+	startFakeOpenAiServer,
+} from "../e2e/tui/support/fake-openai-server.js"
+
+const BINARY_PATH = resolve("dist/bin/kimchi")
+const PACKAGE_DIR = resolve("dist/share/kimchi")
+const FAKE_PROVIDER = "fake"
+const FINAL_TEXT = "One-shot process lifecycle complete."
+const PROCESS_EXIT_TIMEOUT_MS = 12_000
+
+interface ProcessResult {
+	code: number | null
+	signal: NodeJS.Signals | null
+	stdout: string
+	stderr: string
+	timedOut: boolean
+}
+
+interface JsonlEntry {
+	type?: string
+	customType?: string
+	message?: {
+		role?: string
+		toolName?: string
+		content?: Array<{ type?: string; text?: string; name?: string }>
+	}
+}
+
+describe("--ferment-oneshot process lifecycle", () => {
+	// LLM-2404: the benchmark observed `agent_end` after Ferment completion, but
+	// the kimchi process stayed alive until Harbor killed it. This reproduces the
+	// real linked-worker one-shot path and asserts the CLI process exits cleanly.
+	it("exits after ferment completion, final assistant message, and agent_end", async () => {
+		await expectOneshotLifecycleToExit()
+	}, 25_000)
+})
+
+async function expectOneshotLifecycleToExit(): Promise<void> {
+	const tempRoot = mkdtempSync(join(tmpdir(), "kimchi-ferment-oneshot-exit-"))
+	const fake = await startFakeOpenAiServer({ responses: oneShotCompletionScript() })
+
+	try {
+		const homeDir = join(tempRoot, "home")
+		const workDir = join(tempRoot, "work")
+		const sessionDir = join(tempRoot, "sessions")
+		const fermentsDir = join(tempRoot, "ferments")
+		mkdirSync(homeDir, { recursive: true })
+		mkdirSync(workDir, { recursive: true })
+		mkdirSync(sessionDir, { recursive: true })
+		mkdirSync(fermentsDir, { recursive: true })
+		writeKimchiConfig(homeDir, fake.baseUrl)
+
+		const sessionPath = join(sessionDir, "main.jsonl")
+		const result = await runOneshot({
+			homeDir,
+			workDir,
+			sessionPath,
+			fermentsDir,
+			prompt: "Exercise the one-shot ferment process lifecycle and then finish.",
+		})
+		const sessionEntries = readJsonl(sessionPath)
+		const failure = formatFailure(result, sessionEntries, fermentsDir, fake.requests)
+
+		expect(hasFermentCompleted(fermentsDir), failure).toBe(true)
+		expect(
+			sessionEntries.some((entry) => entry.customType === "agent_end"),
+			failure,
+		).toBe(true)
+		expect(
+			sessionEntries.some(
+				(entry) =>
+					entry.type === "message" &&
+					entry.message?.role === "assistant" &&
+					entry.message.content?.some((part) => part.type === "text" && part.text?.includes(FINAL_TEXT)),
+			),
+			failure,
+		).toBe(true)
+		expect(result.timedOut, failure).toBe(false)
+		expect(result.code, failure).toBe(0)
+	} finally {
+		await fake.stop().catch(() => {})
+		rmSync(tempRoot, { recursive: true, force: true })
+	}
+}
+
+function oneShotCompletionScript(): FakeResponseScript[] {
+	return [
+		{
+			stream: ["Starting the linked-worker one-shot lifecycle."],
+			toolCalls: [
+				{
+					id: "call_scope",
+					function: {
+						name: "scope_ferment",
+						arguments: JSON.stringify({
+							ferment_id: "__FERMENT_ID__",
+							title: "One Shot Exit",
+							goal: "Complete a minimal one-shot ferment and let the process exit.",
+							success_criteria: ["The ferment completes and the CLI process exits."],
+							phases: [
+								{
+									name: "Finish",
+									goal: "Complete the lifecycle through a linked worker.",
+									steps: [
+										{
+											description: "Exercise a linked worker before completing the one-shot ferment.",
+											verify: "true",
+										},
+									],
+								},
+							],
+							gates: passingGates(["P1", "P2", "P3"]),
+						}),
+					},
+				},
+			],
+		},
+		{
+			toolCalls: [
+				{
+					id: "call_activate",
+					function: {
+						name: "activate_ferment_phase",
+						arguments: JSON.stringify({
+							ferment_id: "__FERMENT_ID__",
+							phase_id: "phase-1",
+						}),
+					},
+				},
+			],
+		},
+		{
+			toolCalls: [
+				{
+					id: "call_start_step",
+					function: {
+						name: "start_ferment_step",
+						arguments: JSON.stringify({
+							ferment_id: "__FERMENT_ID__",
+							phase_id: "phase-1",
+							step_id: "step-1",
+							budget_tier: "narrow",
+						}),
+					},
+				},
+			],
+		},
+		{
+			toolCalls: [
+				{
+					id: "call_worker_agent",
+					function: {
+						name: "Agent",
+						arguments: JSON.stringify({
+							prompt:
+								"Complete the lifecycle smoke-test step without editing files. Submit a completed agent report with remaining_steps: [].",
+							description: "Lifecycle worker",
+							subagent_type: "Builder",
+							max_turns: 10,
+							max_duration: 180,
+							token_budget: 50_000,
+							task_ref: {
+								kind: "ferment_step",
+								ferment_id: "__FERMENT_ID__",
+								phase_id: "phase-1",
+								step_id: "step-1",
+								budget_tier: "narrow",
+							},
+						}),
+					},
+				},
+			],
+		},
+		{
+			stream: ["Submitting the linked worker report."],
+			toolCalls: [
+				{
+					id: "call_worker_report",
+					function: {
+						name: "submit_agent_report",
+						arguments: JSON.stringify({
+							status: "completed",
+							summary: "The linked worker lifecycle step completed.",
+							steps_completed: ["Submitted the linked worker report required for the parent step."],
+							remaining_steps: [],
+							files_touched: [],
+							verification: ["Parent step verification command is the deterministic smoke-test command: true."],
+						}),
+					},
+				},
+			],
+		},
+		{
+			stream: ["Linked worker report submitted."],
+		},
+		{
+			toolCalls: [
+				{
+					id: "call_complete_step",
+					function: {
+						name: "complete_ferment_step",
+						arguments: JSON.stringify({
+							ferment_id: "__FERMENT_ID__",
+							phase_id: "phase-1",
+							step_id: "step-1",
+							worker_agent_id: "__AGENT_ID__",
+							summary: "Linked worker completed and reported successfully.",
+							gates: passingGates(["S1", "S2", "S3"]),
+						}),
+					},
+				},
+			],
+		},
+		{
+			toolCalls: [
+				{
+					id: "call_complete_phase",
+					function: {
+						name: "complete_ferment_phase",
+						arguments: JSON.stringify({
+							ferment_id: "__FERMENT_ID__",
+							phase_id: "phase-1",
+							summary: "Linked worker lifecycle phase completed.",
+							gates: passingGates(["F1", "F2", "F3"]),
+						}),
+					},
+				},
+			],
+		},
+		{
+			toolCalls: [
+				{
+					id: "call_complete_ferment",
+					function: {
+						name: "complete_ferment",
+						arguments: JSON.stringify({
+							ferment_id: "__FERMENT_ID__",
+							final_summary: "Linked-worker one-shot ferment completed.",
+							gates: passingGates(["C1", "C2", "C3"]),
+						}),
+					},
+				},
+			],
+		},
+		{
+			stream: ['{"grade":"A","rationale":"The linked-worker one-shot lifecycle completed cleanly."}'],
+		},
+		{
+			stream: [FINAL_TEXT],
+		},
+	]
+}
+
+function passingGates(ids: string[]): Array<{ id: string; verdict: "pass"; rationale: string; evidence: string }> {
+	return ids.map((id) => ({
+		id,
+		verdict: "pass",
+		rationale: "Covered by this focused process lifecycle regression.",
+		evidence: "smoke test scripted one-shot flow",
+	}))
+}
+
+function writeKimchiConfig(homeDir: string, fakeBaseUrl: string): void {
+	const configDir = join(homeDir, ".config", "kimchi")
+	const agentDir = join(configDir, "harness")
+	mkdirSync(agentDir, { recursive: true })
+
+	writeFileSync(
+		join(configDir, "config.json"),
+		JSON.stringify(
+			{
+				apiKey: "fake",
+				llmEndpoint: fakeBaseUrl,
+				skillPaths: [],
+				migrationState: "done",
+				onboarding: { hideSessionModeDialog: true },
+			},
+			null,
+			"\t",
+		),
+		"utf-8",
+	)
+
+	writeFileSync(
+		join(agentDir, "models.json"),
+		JSON.stringify(
+			{
+				providers: {
+					[FAKE_PROVIDER]: {
+						baseUrl: `${fakeBaseUrl}/openai/v1`,
+						apiKey: "fake",
+						api: "openai-completions",
+						authHeader: true,
+						headers: { "User-Agent": "kimchi/smoke-test" },
+						models: resolveModels(undefined).map((model) => ({
+							id: model.slug,
+							name: model.displayName,
+							reasoning: model.reasoning,
+							input: model.input,
+							contextWindow: model.contextWindow,
+							maxTokens: model.maxTokens,
+							cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+						})),
+					},
+				},
+			},
+			null,
+			"\t",
+		),
+		"utf-8",
+	)
+}
+
+async function runOneshot(options: {
+	homeDir: string
+	workDir: string
+	sessionPath: string
+	fermentsDir: string
+	prompt: string
+}): Promise<ProcessResult> {
+	const child = spawn(
+		BINARY_PATH,
+		[
+			"--print",
+			"--provider",
+			FAKE_PROVIDER,
+			"--model",
+			DEFAULT_MODEL.slug,
+			"--session",
+			options.sessionPath,
+			"--dangerously-skip-permissions",
+			"--ferment-oneshot",
+		],
+		{
+			cwd: options.workDir,
+			env: {
+				PATH: process.env.PATH ?? "",
+				HOME: options.homeDir,
+				PI_PACKAGE_DIR: PACKAGE_DIR,
+				KIMCHI_API_KEY: "fake",
+				KIMCHI_FERMENTS_DIR: options.fermentsDir,
+				KIMCHI_TELEMETRY_ENABLED: "0",
+			},
+			stdio: ["pipe", "pipe", "pipe"],
+		},
+	)
+
+	let stdout = ""
+	let stderr = ""
+	let timedOut = false
+	let forceKill: NodeJS.Timeout | undefined
+
+	child.stdout.setEncoding("utf-8")
+	child.stderr.setEncoding("utf-8")
+	child.stdout.on("data", (chunk) => {
+		stdout += chunk
+	})
+	child.stderr.on("data", (chunk) => {
+		stderr += chunk
+	})
+	child.stdin.on("error", () => {})
+
+	const exit = new Promise<ProcessResult>((resolvePromise, rejectPromise) => {
+		const timeout = setTimeout(() => {
+			timedOut = true
+			child.kill("SIGTERM")
+			forceKill = setTimeout(() => child.kill("SIGKILL"), 500)
+		}, PROCESS_EXIT_TIMEOUT_MS)
+
+		child.once("error", (error) => {
+			clearTimeout(timeout)
+			if (forceKill) clearTimeout(forceKill)
+			rejectPromise(error)
+		})
+		child.once("exit", (code, signal) => {
+			clearTimeout(timeout)
+			if (forceKill) clearTimeout(forceKill)
+			resolvePromise({ code, signal, stdout, stderr, timedOut })
+		})
+	})
+
+	child.stdin.end(options.prompt)
+	return exit
+}
+
+function readJsonl(path: string): JsonlEntry[] {
+	if (!existsSync(path)) return []
+	return readFileSync(path, "utf-8")
+		.split("\n")
+		.filter((line) => line.trim().length > 0)
+		.map((line) => JSON.parse(line) as JsonlEntry)
+}
+
+function hasFermentCompleted(fermentsDir: string): boolean {
+	if (!existsSync(fermentsDir)) return false
+	return readdirSync(fermentsDir)
+		.filter((name) => name.endsWith(".events.jsonl"))
+		.some((name) => readJsonl(join(fermentsDir, name)).some((entry) => entry.type === "ferment_completed"))
+}
+
+function formatFailure(
+	result: ProcessResult,
+	sessionEntries: JsonlEntry[],
+	fermentsDir: string,
+	requests: RecordedRequest[],
+): string {
+	const tail = sessionEntries.slice(-12).map(describeEntry).join(", ")
+	const fermentFiles = existsSync(fermentsDir) ? readdirSync(fermentsDir).join(", ") : "(missing)"
+	return [
+		`process timedOut=${result.timedOut} code=${result.code} signal=${result.signal}`,
+		`session tail: ${tail || "(empty)"}`,
+		`ferment event tail: ${readFermentEventTail(fermentsDir)}`,
+		`ferment files: ${fermentFiles || "(empty)"}`,
+		`fake requests:\n${describeRequests(requests)}`,
+		`stdout tail: ${result.stdout.slice(-1000) || "(empty)"}`,
+		`stderr tail: ${result.stderr.slice(-1000) || "(empty)"}`,
+	].join("\n")
+}
+
+function describeEntry(entry: JsonlEntry): string {
+	if (entry.customType) return entry.customType
+	if (entry.type !== "message") return entry.type ?? "unknown"
+	const role = entry.message?.role ?? "unknown"
+	const toolName = entry.message?.toolName
+	const toolCall = entry.message?.content?.find((part) => part.type === "toolCall")?.name
+	const text = entry.message?.content?.find((part) => part.type === "text")?.text
+	const suffix = toolName ?? toolCall ?? (text ? JSON.stringify(text.slice(0, 40)) : "")
+	return suffix ? `message:${role}:${suffix}` : `message:${role}`
+}
+
+function readFermentEventTail(fermentsDir: string): string {
+	if (!existsSync(fermentsDir)) return "(missing)"
+	const eventFiles = readdirSync(fermentsDir).filter((name) => name.endsWith(".events.jsonl"))
+	if (eventFiles.length === 0) return "(empty)"
+	return eventFiles
+		.flatMap((name) => readJsonl(join(fermentsDir, name)))
+		.slice(-12)
+		.map((entry) => entry.type ?? "unknown")
+		.join(", ")
+}
+
+function describeRequests(requests: RecordedRequest[]): string {
+	if (requests.length === 0) return "(none)"
+	const lines = requests.map((request, index) => {
+		const body = request.body && typeof request.body === "object" ? (request.body as Record<string, unknown>) : {}
+		const messages = Array.isArray(body.messages) ? body.messages : []
+		const lastMessage = messages.at(-1)
+		const lastText =
+			lastMessage && typeof lastMessage === "object" ? summarizeMessage(lastMessage as Record<string, unknown>) : ""
+		const tools = Array.isArray(body.tools) ? body.tools.length : 0
+		const connection = request.headers.connection
+		return [
+			`${index + 1}. ${request.method} ${request.url}`,
+			`model=${String(body.model ?? "")}`,
+			`stream=${String(body.stream ?? "")}`,
+			`tools=${tools}`,
+			connection ? `connection=${String(connection)}` : "",
+			lastText ? `last=${lastText}` : "",
+		]
+			.filter(Boolean)
+			.join(" ")
+	})
+	if (lines.length <= 24) return lines.join("\n")
+	return [...lines.slice(0, 12), `... ${lines.length - 24} request(s) omitted ...`, ...lines.slice(-12)].join("\n")
+}
+
+function summarizeMessage(message: Record<string, unknown>): string {
+	const role = typeof message.role === "string" ? message.role : "unknown"
+	const content = message.content
+	let text = ""
+	if (typeof content === "string") {
+		text = content
+	} else if (Array.isArray(content)) {
+		text = content
+			.map((part) => {
+				if (part && typeof part === "object" && "text" in part) {
+					const value = (part as Record<string, unknown>).text
+					return typeof value === "string" ? value : ""
+				}
+				return ""
+			})
+			.join("")
+	}
+	return `${role}:${JSON.stringify(text.slice(0, 80))}`
+}


### PR DESCRIPTION
## Linked issue

Closes #766

## What does this PR do?

Fixes process-lifetime leaks that could keep `--ferment-oneshot` runs alive after the agent had already completed and emitted `agent_end`.

The PR now covers three cleanup paths:

- Marks Kimchi file watchers as non-persistent and explicitly unrefs them so `fs.watch` handles do not keep the process alive after the session ends.
- Avoids RTK startup stale-context crashes by capturing UI notification capability before async RTK work and not reading the extension context after session replacement/compaction.
- Cleans up sub-agent shutdown resources: on `session_shutdown`, the agents extension aborts running sub-agents, waits briefly for runner promises to settle so `finally` blocks can clear timers, disposes the widget, and then runs manager disposal as a hard fallback.

For sub-agents specifically, `runAgent` and `resumeAgent` now register runtime cleanup callbacks for their inactivity intervals. `AgentManager.dispose()` invokes registered cleanup if a runner promise never settles, so a stuck/aborted initial worker or active resume/finalize attempt cannot leave an interval keeping the process alive.

`AgentManager.waitForAll()` now waits on pending runner promises regardless of record status. This is intentional: shutdown can mark a record `stopped` before the underlying runner promise has reached its `finally` block, and that promise is where timers/subscriptions are normally cleared. Already-settled records are skipped because their tracked promises are cleared in `finally`.

## Regression coverage

- Built-binary smoke test exercises the one-shot ferment lifecycle and asserts the process exits after `ferment_completed`, final assistant output, and `agent_end`.
- Watcher unit tests assert `persistent: false` and `unref()` usage.
- RTK unit test covers async startup completing after the original session context becomes stale.
- Agent manager unit tests prove `waitForAll()` waits for aborted initial sub-agent promises and active resume promises instead of returning as soon as records are marked `stopped`.
- Agent runner unit tests prove registered runtime cleanup clears the actual initial-run and resume inactivity intervals before the prompt settles.

## Checklist

- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md) and agree to the CLA
- [x] This PR links to an open issue above
- [x] Tests pass locally (`pnpm run test`)
- [x] Lint passes (`pnpm run check`)
- [x] Documentation updated if behavior changed