### PR TITLE
fix: use llm.kimchi.dev instead of llm.cast.ai for default LLM endpoint

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -6,7 +6,7 @@ import { getVersion } from "./utils.js"
 
 const KIMCHI_CONFIG_PATH = resolve(homedir(), ".config", "kimchi", "config.json")
 const AGENT_CONFIG_DIR = resolve(homedir(), ".config", "kimchi", "harness")
-const CAST_AI_LLM_ENDPOINT = "https://llm.cast.ai/openai/v1"
+const KIMCHI_LLM_ENDPOINT = "https://llm.kimchi.dev/openai/v1"
 const DEFAULT_TELEMETRY_LOGS_ENDPOINT = "https://api.cast.ai/ai-optimizer/v1beta/logs:ingest"
 const DEFAULT_TELEMETRY_METRICS_ENDPOINT = "https://api.cast.ai/ai-optimizer/v1beta/metrics:ingest"
 
@@ -423,7 +423,7 @@ export function loadConfig(options?: { configPath?: string; cwd?: string }): Kim
 	return {
 		apiKey: extras.apiKey ?? "",
 		agentConfigDir: AGENT_CONFIG_DIR,
-		llmEndpoint: extras.llmEndpoint ?? CAST_AI_LLM_ENDPOINT,
+		llmEndpoint: extras.llmEndpoint ?? KIMCHI_LLM_ENDPOINT,
 		customLlmEndpoint: extras.llmEndpoint,
 		maxToolResultChars: extras.maxToolResultChars ?? 10_000,
 		mcpSearchLimit: extras.mcpSearchLimit ?? 5,


### PR DESCRIPTION
## Summary

Replaces `llm.cast.ai` reference with `llm.kimchi.dev` to ensure consistent endpoint usage across the codebase.

## Changes

- `src/config.ts`: Changed default LLM endpoint from `https://llm.cast.ai/openai/v1` to `https://llm.kimchi.dev/openai/v1`
- `src/config.ts`: Renamed constant `CAST_AI_LLM_ENDPOINT` → `KIMCHI_LLM_ENDPOINT`

## Checklist

- [x] Code changes
- [ ] Tests added/updated (no test asserts the default endpoint value; existing tests use custom endpoints)
- [x] Lint passes
- [x] Type check passes (no new errors introduced)
