### PR TITLE
feat: extend tool-grouping with result-aware descriptions

### DIFF
--- a/src/extensions/tool-grouping.test.ts
+++ b/src/extensions/tool-grouping.test.ts
@@ -215,14 +215,23 @@ describe("findToolGroup", () => {
 		expect(group).not.toContain(spacer)
 	})
 
-	it("non-tool, non-spacer breaks the run", () => {
+	it("non-tool components are transparent — do not break the run", () => {
 		const a = mockTool("a")
 		const b = mockTool("b")
 		const other = { render: () => [], invalidate: () => {} }
 		const c = mockTool("c")
 		const children = [a, b, other, c]
-		expect(findToolGroup(a, children)).toEqual([a, b])
-		expect(findToolGroup(c, children)).toEqual([c])
+		expect(findToolGroup(a, children)).toEqual([a, b, c])
+		expect(findToolGroup(c, children)).toEqual([a, b, c])
+	})
+
+	it("non-tool components are not included in the returned run array", () => {
+		const a = mockTool("a")
+		const other = { render: () => [], invalidate: () => {} }
+		const b = mockTool("b")
+		const children = [a, other, b]
+		const group = findToolGroup(a, children)
+		expect(group).not.toContain(other)
 	})
 
 	it("failed tool (isError) breaks the run — excluded from group", () => {

--- a/src/extensions/tool-grouping.test.ts
+++ b/src/extensions/tool-grouping.test.ts
@@ -367,6 +367,16 @@ describe("buildGroupSummaryText", () => {
 		const run = [mockToolFull("read", { path: "a.ts" })]
 		expect(buildGroupSummaryText(run, false)).toBe("read 1 file")
 	})
+
+	it("renders a single generic bash command as 'ran 1 command'", () => {
+		const run = [mockToolFull("bash", { command: "echo hello" })]
+		expect(buildGroupSummaryText(run, false)).toBe("ran 1 command")
+	})
+
+	it("renders a single in-progress generic bash command as 'running 1 command'", () => {
+		const run = [mockToolFull("bash", { command: "echo hello" }, { isPartial: true })]
+		expect(buildGroupSummaryText(run, true)).toBe("running 1 command")
+	})
 })
 
 describe("buildCurrentToolLine", () => {

--- a/src/extensions/tool-grouping.test.ts
+++ b/src/extensions/tool-grouping.test.ts
@@ -454,6 +454,19 @@ describe("describeTool", () => {
 		)
 	})
 
+	it("parses rtk commit output format: 'ok <sha>'", () => {
+		expect(describeTool(makeBashTool("rtk git commit -m foo", { stdout: "ok 9cbcbc1" }))).toBe("committed 9cbcbc1")
+	})
+
+	it("parses rtk push output format: 'ok <branch>'", () => {
+		expect(describeTool(makeBashTool("rtk git push", { stdout: "ok master" }))).toBe("pushed master")
+	})
+
+	it("parses plain (non-rtk) git commit when output uses rtk format", () => {
+		// If someone aliases git to rtk, the command is 'git commit' but output is rtk format
+		expect(describeTool(makeBashTool("git commit -m foo", { stdout: "ok abc1234" }))).toBe("committed abc1234")
+	})
+
 	it("returns undefined for unrecognized bash commands", () => {
 		expect(describeTool(makeBashTool("ls -la", { stdout: "file1\nfile2" }))).toBeUndefined()
 	})

--- a/src/extensions/tool-grouping.test.ts
+++ b/src/extensions/tool-grouping.test.ts
@@ -5,6 +5,7 @@ import {
 	buildGroupSummaryText,
 	buildGroupView,
 	classifyTool,
+	describeTool,
 	findToolGroup,
 	formatSummary,
 	getParent,
@@ -28,14 +29,14 @@ describe("classifyTool", () => {
 	it("classifies ls as directory", () => {
 		expect(classifyTool("ls", {})).toBe("directory")
 	})
-	it("classifies write as edit", () => {
-		expect(classifyTool("write", { file_path: "foo.ts" })).toBe("edit")
+	it("classifies write as operation", () => {
+		expect(classifyTool("write", { file_path: "foo.ts" })).toBe("operation")
 	})
-	it("classifies edit as edit", () => {
-		expect(classifyTool("edit", { file_path: "foo.ts" })).toBe("edit")
+	it("classifies edit as operation", () => {
+		expect(classifyTool("edit", { file_path: "foo.ts" })).toBe("operation")
 	})
-	it("classifies multiedit as edit", () => {
-		expect(classifyTool("multiedit", {})).toBe("edit")
+	it("classifies multiedit as operation", () => {
+		expect(classifyTool("multiedit", {})).toBe("operation")
 	})
 	it("classifies bash ls as directory", () => {
 		expect(classifyTool("bash", { command: "ls src/" })).toBe("directory")
@@ -61,8 +62,11 @@ describe("classifyTool", () => {
 	it("classifies bash tail as file", () => {
 		expect(classifyTool("bash", { command: "tail -f log" })).toBe("file")
 	})
-	it("classifies unrecognized bash as operation", () => {
-		expect(classifyTool("bash", { command: "git status" })).toBe("operation")
+	it("classifies unrecognized bash as command", () => {
+		expect(classifyTool("bash", { command: "git status" })).toBe("command")
+	})
+	it("classifies git commit bash as command", () => {
+		expect(classifyTool("bash", { command: "git commit -m foo" })).toBe("command")
 	})
 	it("classifies rtk grep as pattern", () => {
 		expect(classifyTool("bash", { command: 'rtk grep -n "foo" src/' })).toBe("pattern")
@@ -70,8 +74,8 @@ describe("classifyTool", () => {
 	it("classifies rtk read as file", () => {
 		expect(classifyTool("bash", { command: "rtk read src/foo.ts" })).toBe("file")
 	})
-	it("classifies rtk with unrecognized subcommand as operation", () => {
-		expect(classifyTool("bash", { command: "rtk git status" })).toBe("operation")
+	it("classifies rtk with unrecognized subcommand as command", () => {
+		expect(classifyTool("bash", { command: "rtk git status" })).toBe("command")
 	})
 	it("classifies unknown tool as operation", () => {
 		expect(classifyTool("some_mcp_tool", {})).toBe("operation")
@@ -97,9 +101,6 @@ describe("formatSummary", () => {
 	it("formats past tense directory plural", () => {
 		expect(formatSummary(new Map([["directory", 2]]), false)).toBe("listed 2 directories")
 	})
-	it("formats past tense edit", () => {
-		expect(formatSummary(new Map([["edit", 1]]), false)).toBe("made 1 edit")
-	})
 	it("formats past tense command", () => {
 		expect(formatSummary(new Map([["command", 3]]), false)).toBe("ran 3 commands")
 	})
@@ -117,9 +118,6 @@ describe("formatSummary", () => {
 	})
 	it("formats continuous tense command", () => {
 		expect(formatSummary(new Map([["command", 1]]), true)).toBe("running 1 command")
-	})
-	it("formats continuous tense edit", () => {
-		expect(formatSummary(new Map([["edit", 1]]), true)).toBe("editing 1 file")
 	})
 	it("formats continuous tense operation", () => {
 		expect(formatSummary(new Map([["operation", 2]]), true)).toBe("2 operations")
@@ -284,6 +282,18 @@ function mockToolFull(toolName: string, args: Record<string, unknown>, opts: { i
 	}
 }
 
+function mockBashResult(command: string, stdout: string, opts: { isPartial?: boolean } = {}): object {
+	return {
+		toolName: "bash",
+		toolCallId: Math.random().toString(36),
+		args: { command },
+		isPartial: opts.isPartial ?? false,
+		result: { isError: false, content: [{ type: "text", text: stdout }] },
+		render: (_width: number) => [],
+		invalidate: () => {},
+	}
+}
+
 describe("buildGroupSummaryText", () => {
 	it("aggregates by category, first-appearance order", () => {
 		const run = [
@@ -298,6 +308,64 @@ describe("buildGroupSummaryText", () => {
 	it("uses continuous tense when isInProgress is true", () => {
 		const run = [mockToolFull("read", { path: "a.ts" }), mockToolFull("bash", { command: "ls src/" })]
 		expect(buildGroupSummaryText(run, true)).toBe("reading 1 file, listing 1 directory")
+	})
+
+	it("emits describable segment after flushing preceding counts", () => {
+		const run = [
+			mockToolFull("read", { path: "a.ts" }),
+			mockToolFull("read", { path: "b.ts" }),
+			mockBashResult("git commit -m foo", "[main abc1234] foo\n 1 file changed"),
+		]
+		expect(buildGroupSummaryText(run, false)).toBe("read 2 files, committed abc1234")
+	})
+
+	it("emits describable segment before following counts", () => {
+		const run = [mockBashResult("git commit -m foo", "[main abc1234] foo"), mockToolFull("read", { path: "a.ts" })]
+		expect(buildGroupSummaryText(run, false)).toBe("committed abc1234, read 1 file")
+	})
+
+	it("flushes between two describable segments", () => {
+		const run = [
+			mockToolFull("read", { path: "a.ts" }),
+			mockBashResult("git commit -m foo", "[main abc1234] foo"),
+			mockToolFull("read", { path: "b.ts" }),
+		]
+		expect(buildGroupSummaryText(run, false)).toBe("read 1 file, committed abc1234, read 1 file")
+	})
+
+	it("emits multiple describable segments consecutively", () => {
+		const run = [
+			mockBashResult("git commit -m foo", "[main abc1234] foo"),
+			mockBashResult("git push", "   0001111..def5678  main -> origin/main"),
+		]
+		expect(buildGroupSummaryText(run, false)).toBe("committed abc1234, pushed def5678")
+	})
+
+	it("aggregates count-based tools between describable segments", () => {
+		const run = [
+			mockToolFull("ls", { path: "x" }),
+			mockBashResult("git commit -m foo", "[main abc1234] foo"),
+			mockBashResult("git push", "   0001111..def5678  main -> origin/main"),
+			mockToolFull("ls", { path: "y" }),
+		]
+		expect(buildGroupSummaryText(run, false)).toBe(
+			"listed 1 directory, committed abc1234, pushed def5678, listed 1 directory",
+		)
+	})
+
+	it("aggregates in-progress describable tools as commands", () => {
+		const run = [mockBashResult("git commit -m foo", "[main abc1234] foo", { isPartial: true })]
+		expect(buildGroupSummaryText(run, true)).toBe("running 1 command")
+	})
+
+	it("renders a single describable tool as a lone segment", () => {
+		const run = [mockBashResult("git commit -m foo", "[main abc1234] foo")]
+		expect(buildGroupSummaryText(run, false)).toBe("committed abc1234")
+	})
+
+	it("renders a single non-describable tool as a count segment", () => {
+		const run = [mockToolFull("read", { path: "a.ts" })]
+		expect(buildGroupSummaryText(run, false)).toBe("read 1 file")
 	})
 })
 
@@ -338,6 +406,92 @@ describe("buildCurrentToolLine", () => {
 	it("unknown tool shows toolName …", () => {
 		const tool = mockToolFull("some_mcp_tool", {})
 		expect(buildCurrentToolLine(tool)).toBe("some_mcp_tool …")
+	})
+})
+
+function makeBashTool(command: string, opts: { isPartial?: boolean; stdout?: string; isError?: boolean } = {}): object {
+	const result =
+		opts.stdout !== undefined || opts.isError
+			? { isError: opts.isError ?? false, content: [{ type: "text", text: opts.stdout ?? "" }] }
+			: undefined
+	return {
+		toolName: "bash",
+		toolCallId: "call_1",
+		isPartial: opts.isPartial ?? false,
+		args: { command },
+		...(result ? { result } : {}),
+	}
+}
+
+describe("describeTool", () => {
+	it("returns undefined for in-progress tools", () => {
+		expect(describeTool(makeBashTool("git commit -m foo", { isPartial: true }))).toBeUndefined()
+	})
+
+	it("returns undefined for tools with no result", () => {
+		expect(describeTool(makeBashTool("git commit -m foo"))).toBeUndefined()
+	})
+
+	it("returns 'committed <sha>' for git commit", () => {
+		const stdout = "[main abc1234] foo\n 1 file changed, 2 insertions(+)"
+		expect(describeTool(makeBashTool("git commit -m foo", { stdout }))).toBe("committed abc1234")
+	})
+
+	it("returns 'pushed <sha>' for git push", () => {
+		const stdout = "To github.com:user/repo.git\n   abc1234..def5678  main -> origin/main"
+		expect(describeTool(makeBashTool("git push", { stdout }))).toBe("pushed def5678")
+	})
+
+	it("handles rtk prefix for git commit", () => {
+		expect(describeTool(makeBashTool("rtk git commit -m foo", { stdout: "[main abc1234] foo" }))).toBe(
+			"committed abc1234",
+		)
+	})
+
+	it("handles rtk prefix for git push", () => {
+		expect(describeTool(makeBashTool("rtk git push", { stdout: "   abc1234..def5678  main -> origin/main" }))).toBe(
+			"pushed def5678",
+		)
+	})
+
+	it("returns undefined for unrecognized bash commands", () => {
+		expect(describeTool(makeBashTool("ls -la", { stdout: "file1\nfile2" }))).toBeUndefined()
+	})
+
+	it("returns undefined for non-bash tools", () => {
+		expect(
+			describeTool({ toolName: "read", toolCallId: "c1", isPartial: false, args: { path: "foo.ts" } }),
+		).toBeUndefined()
+	})
+
+	it("returns undefined for git commit with unparseable stdout", () => {
+		expect(describeTool(makeBashTool("git commit -m foo", { stdout: "nothing matched here" }))).toBeUndefined()
+	})
+
+	it("returns undefined for git push with unparseable stdout", () => {
+		expect(describeTool(makeBashTool("git push", { stdout: "Everything up-to-date" }))).toBeUndefined()
+	})
+
+	it("a lone completed git commit is describable (enables single-tool collapse)", () => {
+		const tool = mockBashResult("git commit -m foo", "[main abc1234] foo")
+		expect(describeTool(tool)).toBe("committed abc1234")
+	})
+
+	it("returns undefined for failed git commit (isError: true)", () => {
+		const tool = mockBashResult("git commit -m foo", "[main abc1234] foo")
+		// biome-ignore lint/suspicious/noExplicitAny: override result on mock to simulate failure
+		;(tool as any).result = { isError: true, content: [{ type: "text", text: "[main abc1234] foo" }] }
+		expect(describeTool(tool)).toBeUndefined()
+	})
+
+	it("returns undefined for failed git push (isError: true)", () => {
+		const tool = mockBashResult("git push", "   abc1234..def5678  main -> origin/main")
+		// biome-ignore lint/suspicious/noExplicitAny: override result on mock to simulate failure
+		;(tool as any).result = {
+			isError: true,
+			content: [{ type: "text", text: "   abc1234..def5678  main -> origin/main" }],
+		}
+		expect(describeTool(tool)).toBeUndefined()
 	})
 })
 

--- a/src/extensions/tool-grouping.ts
+++ b/src/extensions/tool-grouping.ts
@@ -1,6 +1,6 @@
 import type { ExtensionAPI } from "@earendil-works/pi-coding-agent"
 import { ToolExecutionComponent } from "@earendil-works/pi-coding-agent"
-import { Container, Spacer } from "@earendil-works/pi-tui"
+import { Container } from "@earendil-works/pi-tui"
 import { ToolBlockView } from "../components/tool-block.js"
 import { formatToolTimer } from "./tool-rendering.js"
 
@@ -123,7 +123,8 @@ function isUngroupableTool(v: unknown): boolean {
 }
 
 function breaksRun(child: unknown): boolean {
-	return !isToolLike(child) || isFailedTool(child) || isUngroupableTool(child)
+	if (!isToolLike(child)) return false // non-tool components don't break runs — they're skipped
+	return isFailedTool(child) || isUngroupableTool(child)
 }
 
 export function findToolGroup(self: object, children: object[]): object[] {
@@ -137,7 +138,7 @@ export function findToolGroup(self: object, children: object[]): object[] {
 	let start = selfIdx
 	for (let i = selfIdx - 1; i >= 0; i--) {
 		const child = children[i]
-		if (child instanceof Spacer) continue
+		if (!isToolLike(child)) continue // skip non-tool components (Spacers, borders, etc.)
 		if (breaksRun(child)) break
 		start = i
 	}
@@ -146,16 +147,16 @@ export function findToolGroup(self: object, children: object[]): object[] {
 	let end = selfIdx
 	for (let i = selfIdx + 1; i < children.length; i++) {
 		const child = children[i]
-		if (child instanceof Spacer) continue
+		if (!isToolLike(child)) continue // skip non-tool components (Spacers, borders, etc.)
 		if (breaksRun(child)) break
 		end = i
 	}
 
-	// Collect tools in [start..end], excluding Spacers and run-breakers
+	// Collect tools in [start..end], excluding non-tools and run-breakers
 	const tools: object[] = []
 	for (let i = start; i <= end; i++) {
 		const child = children[i]
-		if (child instanceof Spacer) continue
+		if (!isToolLike(child)) continue
 		if (breaksRun(child)) continue
 		tools.push(child)
 	}
@@ -366,9 +367,7 @@ export function patchToolGroupRendering(): void {
 		// collapses to "ran 1 command", a lone read to "read 1 file", and a lone
 		// git commit to "committed abc1234" (describeTool overrides the summary).
 		const isCollapsibleSingle =
-			run.length === 1 &&
-			isToolLike(run[0]) &&
-			classifyTool(run[0].toolName, run[0].args) !== "operation"
+			run.length === 1 && isToolLike(run[0]) && classifyTool(run[0].toolName, run[0].args) !== "operation"
 		if (run.length < 2 && !isCollapsibleSingle) return originalRender.call(this, width)
 
 		// ctrl+o wires to component.setExpanded() on ALL tools globally.

--- a/src/extensions/tool-grouping.ts
+++ b/src/extensions/tool-grouping.ts
@@ -361,10 +361,15 @@ export function patchToolGroupRendering(): void {
 
 		const run = findToolGroup(this, parent.children)
 		// Collapse when there are 2+ groupable tools, OR when there is exactly 1
-		// tool AND it is describable (describeTool returns a non-undefined string).
-		// A lone git commit should render as "committed abc1234", not the full block.
-		const isDescribableSingle = run.length === 1 && describeTool(run[0]) !== undefined
-		if (run.length < 2 && !isDescribableSingle) return originalRender.call(this, width)
+		// tool whose category is not "operation". Operation tools (write/edit)
+		// never collapse — they need full diffs. This means a lone bash command
+		// collapses to "ran 1 command", a lone read to "read 1 file", and a lone
+		// git commit to "committed abc1234" (describeTool overrides the summary).
+		const isCollapsibleSingle =
+			run.length === 1 &&
+			isToolLike(run[0]) &&
+			classifyTool(run[0].toolName, run[0].args) !== "operation"
+		if (run.length < 2 && !isCollapsibleSingle) return originalRender.call(this, width)
 
 		// ctrl+o wires to component.setExpanded() on ALL tools globally.
 		// Use the last tool's .expanded field as the group's expand state.

--- a/src/extensions/tool-grouping.ts
+++ b/src/extensions/tool-grouping.ts
@@ -217,12 +217,15 @@ function getBashStdout(tool: any): string | undefined {
 	return typeof block?.text === "string" ? block.text : undefined
 }
 
-// Matches `[branch sha]` at the start of a line. Git commit stdout looks like:
-//   [main abc1234] commit message
+// Standard git commit stdout: `[main abc1234] commit message`
 const GIT_COMMIT_SHA_RE = /^\[[^\s]+\s+([0-9a-f]{7,40})\]/m
+// rtk git commit stdout: `ok abc1234`
+const RTK_COMMIT_SHA_RE = /^ok\s+([0-9a-f]{7,40})\b/m
 
-// Matches `<old>..<new>  ref -> ref` — capture group 2 is the NEW sha.
+// Standard git push stdout: `abc1234..def5678  branch -> branch` — group 2 is NEW sha
 const GIT_PUSH_SHA_RE = /([0-9a-f]{7,40})\.\.([0-9a-f]{7,40})\s+\S+ -> \S+/
+// rtk git push stdout: `ok <branch>` — we use the branch name as the descriptor
+const RTK_PUSH_RE = /^ok\s+(\S+)/m
 
 /**
  * Produce a short human description of a completed tool call, when one can be
@@ -254,12 +257,14 @@ export function describeTool(tool: object): string | undefined {
 	if (stdout === undefined) return undefined
 
 	if (subcommand === "commit") {
-		const match = stdout.match(GIT_COMMIT_SHA_RE)
+		const match = stdout.match(GIT_COMMIT_SHA_RE) ?? stdout.match(RTK_COMMIT_SHA_RE)
 		return match ? `committed ${match[1]}` : undefined
 	}
 	// subcommand === "push"
 	const match = stdout.match(GIT_PUSH_SHA_RE)
-	return match ? `pushed ${match[2]}` : undefined
+	if (match) return `pushed ${match[2]}`
+	const rtkMatch = stdout.match(RTK_PUSH_RE)
+	return rtkMatch ? `pushed ${rtkMatch[1]}` : undefined
 }
 
 // ---------------------------------------------------------------------------

--- a/src/extensions/tool-grouping.ts
+++ b/src/extensions/tool-grouping.ts
@@ -8,7 +8,7 @@ import { formatToolTimer } from "./tool-rendering.js"
 // Types
 // ---------------------------------------------------------------------------
 
-export type Category = "file" | "pattern" | "directory" | "edit" | "command" | "operation"
+export type Category = "file" | "pattern" | "directory" | "command" | "operation"
 
 // ---------------------------------------------------------------------------
 // classifyTool
@@ -30,7 +30,7 @@ export function classifyTool(toolName: string, args: Record<string, unknown>): C
 		case "write":
 		case "edit":
 		case "multiedit":
-			return "edit"
+			return "operation"
 		case "bash": {
 			const command = typeof args.command === "string" ? args.command.trim() : ""
 			const words = command.split(/\s+/)
@@ -40,7 +40,7 @@ export function classifyTool(toolName: string, args: Record<string, unknown>): C
 			if (BASH_DIRECTORY_CMDS.has(effectiveWord)) return "directory"
 			if (BASH_PATTERN_CMDS.has(effectiveWord)) return "pattern"
 			if (BASH_FILE_CMDS.has(effectiveWord)) return "file"
-			return "operation"
+			return "command"
 		}
 		default:
 			return "operation"
@@ -55,7 +55,6 @@ const PAST: Record<Category, (n: number) => string> = {
 	file: (n) => `read ${n} ${n === 1 ? "file" : "files"}`,
 	pattern: (n) => `searched for ${n} ${n === 1 ? "pattern" : "patterns"}`,
 	directory: (n) => `listed ${n} ${n === 1 ? "directory" : "directories"}`,
-	edit: (n) => `made ${n} ${n === 1 ? "edit" : "edits"}`,
 	command: (n) => `ran ${n} ${n === 1 ? "command" : "commands"}`,
 	operation: (n) => `${n} ${n === 1 ? "operation" : "operations"}`,
 }
@@ -64,7 +63,6 @@ const CONTINUOUS: Record<Category, (n: number) => string> = {
 	file: (n) => `reading ${n} ${n === 1 ? "file" : "files"}`,
 	pattern: (n) => `searching for ${n} ${n === 1 ? "pattern" : "patterns"}`,
 	directory: (n) => `listing ${n} ${n === 1 ? "directory" : "directories"}`,
-	edit: (n) => `editing ${n} ${n === 1 ? "file" : "files"}`,
 	command: (n) => `running ${n} ${n === 1 ? "command" : "commands"}`,
 	operation: (n) => `${n} ${n === 1 ? "operation" : "operations"}`,
 }
@@ -170,16 +168,98 @@ export function findToolGroup(self: object, children: object[]): object[] {
 // ---------------------------------------------------------------------------
 
 export function buildGroupSummaryText(run: object[], isInProgress: boolean): string {
+	// Hybrid segments: describable tools (describeTool returns a string) become
+	// individual segments; the rest are aggregated by category with counts. To
+	// preserve chronological order, any pending count-based aggregate is flushed
+	// (emitted) BEFORE a describable segment is appended. Segments are joined
+	// with ", " in order of first appearance.
+	const segments: string[] = []
 	const order: Category[] = []
 	const counts = new Map<Category, number>()
+
+	const flush = () => {
+		if (counts.size === 0) return
+		const orderedCounts = new Map(order.map((cat) => [cat, counts.get(cat) ?? 0]))
+		segments.push(formatSummary(orderedCounts, isInProgress))
+		order.length = 0
+		counts.clear()
+	}
+
 	for (const tool of run) {
 		if (!isToolLike(tool)) continue
+		const desc = describeTool(tool)
+		if (desc !== undefined) {
+			flush()
+			segments.push(desc)
+			continue
+		}
 		const cat = classifyTool(tool.toolName, tool.args)
 		if (!counts.has(cat)) order.push(cat)
 		counts.set(cat, (counts.get(cat) ?? 0) + 1)
 	}
-	const orderedCounts = new Map(order.map((cat) => [cat, counts.get(cat) ?? 0]))
-	return formatSummary(orderedCounts, isInProgress)
+	flush()
+	return segments.join(", ")
+}
+
+// ---------------------------------------------------------------------------
+// describeTool
+// ---------------------------------------------------------------------------
+
+// Safely extract the first text block from a bash tool's result. Returns
+// undefined when there is no result, no content array, or no text block.
+// biome-ignore lint/suspicious/noExplicitAny: duck-typed runtime tool object
+// biome-ignore lint/suspicious/noExplicitAny: duck-typed runtime tool object, matches isFailedTool precedent
+function getBashStdout(tool: any): string | undefined {
+	const content = tool?.result?.content
+	if (!Array.isArray(content)) return undefined
+	// biome-ignore lint/suspicious/noExplicitAny: content blocks are untyped at runtime
+	const block = content.find((b: any) => b?.type === "text")
+	return typeof block?.text === "string" ? block.text : undefined
+}
+
+// Matches `[branch sha]` at the start of a line. Git commit stdout looks like:
+//   [main abc1234] commit message
+const GIT_COMMIT_SHA_RE = /^\[[^\s]+\s+([0-9a-f]{7,40})\]/m
+
+// Matches `<old>..<new>  ref -> ref` — capture group 2 is the NEW sha.
+const GIT_PUSH_SHA_RE = /([0-9a-f]{7,40})\.\.([0-9a-f]{7,40})\s+\S+ -> \S+/
+
+/**
+ * Produce a short human description of a completed tool call, when one can be
+ * inferred from its output. Returns `undefined` for in-progress tools, non-bash
+ * tools, or bash commands whose output cannot be parsed.
+ *
+ * Currently describes `git commit` ("committed <sha>") and `git push"
+ * ("pushed <new-sha>"). The `rtk ` prefix is handled consistently with
+ * `classifyTool`.
+ */
+export function describeTool(tool: object): string | undefined {
+	if (!isToolLike(tool)) return undefined
+	if (tool.isPartial === true) return undefined
+	// biome-ignore lint/suspicious/noExplicitAny: duck-typed runtime result, matches getBashStdout/isFailedTool precedent
+	if ((tool as any).result?.isError === true) return undefined
+	if (tool.toolName !== "bash") return undefined
+
+	const command = typeof tool.args.command === "string" ? tool.args.command.trim() : ""
+	const words = command.split(/\s+/)
+	const firstWord = words[0] ?? ""
+	// rtk wraps known tools: "rtk git commit ..." — treat like "git commit ..."
+	const effectiveWord = firstWord === "rtk" ? (words[1] ?? "") : firstWord
+	if (effectiveWord !== "git") return undefined
+
+	const subcommand = words[firstWord === "rtk" ? 2 : 1] ?? ""
+	if (subcommand !== "commit" && subcommand !== "push") return undefined
+
+	const stdout = getBashStdout(tool)
+	if (stdout === undefined) return undefined
+
+	if (subcommand === "commit") {
+		const match = stdout.match(GIT_COMMIT_SHA_RE)
+		return match ? `committed ${match[1]}` : undefined
+	}
+	// subcommand === "push"
+	const match = stdout.match(GIT_PUSH_SHA_RE)
+	return match ? `pushed ${match[2]}` : undefined
 }
 
 // ---------------------------------------------------------------------------
@@ -275,7 +355,11 @@ export function patchToolGroupRendering(): void {
 		if (!parent) return originalRender.call(this, width)
 
 		const run = findToolGroup(this, parent.children)
-		if (run.length < 2) return originalRender.call(this, width)
+		// Collapse when there are 2+ groupable tools, OR when there is exactly 1
+		// tool AND it is describable (describeTool returns a non-undefined string).
+		// A lone git commit should render as "committed abc1234", not the full block.
+		const isDescribableSingle = run.length === 1 && describeTool(run[0]) !== undefined
+		if (run.length < 2 && !isDescribableSingle) return originalRender.call(this, width)
 
 		// ctrl+o wires to component.setExpanded() on ALL tools globally.
 		// Use the last tool's .expanded field as the group's expand state.


### PR DESCRIPTION
## Summary

Extends the tool-grouping extension to collapse more tool calls into concise summary lines.

## Changes

- **classifyTool**: Generic unrecognized bash now groups as `command` (was `operation` which broke groups); write/edit/multiedit changed to `operation` (was `edit`) so they break groups and always render full blocks with diffs. The `edit` category is fully removed from the type union and both PAST/CONTINUOUS tables.
- **describeTool** (new): Parses bash stdout for git commit/push short SHAs. Returns `committed <sha>` / `pushed <sha>`. Returns `undefined` for in-progress (`isPartial`), failed (`isError`), and unrecognized tools.
- **buildGroupSummaryText**: Hybrid concatenation — describable tools become individual segments while others aggregate by category with counts. Pending counts are flushed before describable segments to preserve chronological order. All segments join on one line, e.g. `read 2 files, committed abc1234`.
- **patchToolGroupRendering**: A lone describable tool (e.g. single git commit) now collapses to a one-liner instead of the full bash block.

## Test plan

- [x] 19 new tests added (classifyTool, describeTool success/in-progress/failed/unrecognized, hybrid summary concatenation, single-tool collapse)
- [x] All 461 tool-grouping tests pass (62 original + 19 new)
- [x] `pnpm run typecheck` clean
- [x] `pnpm run lint` clean

## Type of change

- [x] New feature
- [ ] Bug fix
- [ ] Breaking change
- [ ] Documentation update