### PR TITLE
refactor: use _kimchi.dev/pi_notify acp notification on all fire-and-forget events

### DIFF
--- a/src/modes/acp/acp-ui-context.test.ts
+++ b/src/modes/acp/acp-ui-context.test.ts
@@ -742,7 +742,7 @@ describe("createAcpUIContext — fire-and-forget notifications", () => {
 		await new Promise((r) => setImmediate(r))
 	})
 
-	it("setStatus sends _kimchi.dev/pi_setStatus via extNotification", async () => {
+	it("setStatus sends _kimchi.dev/pi_notify via extNotification", async () => {
 		const {
 			conn,
 			extNotification: n,
@@ -755,7 +755,7 @@ describe("createAcpUIContext — fire-and-forget notifications", () => {
 		await new Promise((r) => setImmediate(r))
 		expect(n).toHaveBeenCalledTimes(1)
 		const [method, params] = n.mock.calls[0]
-		expect(method).toBe("_kimchi.dev/pi_setStatus")
+		expect(method).toBe("_kimchi.dev/pi_notify")
 		expect(params).toEqual({
 			id: expect.any(String),
 			type: "extension_ui_request",
@@ -780,43 +780,7 @@ describe("createAcpUIContext — fire-and-forget notifications", () => {
 		expect(n.mock.calls[0][1].statusText).toBeUndefined()
 	})
 
-	it("setStatus warns via agent_message_chunk when the client doesn't advertise support", () => {
-		const {
-			conn,
-			extNotification: n,
-			send,
-		} = makeConn({
-			extNotification: extNotification as unknown as ExtNotification,
-		})
-		const real = createAcpUIContext(conn, "sess-1", elicitationClientCapabilities(), send)
-		real.setStatus("k", "v")
-		expect(n).not.toHaveBeenCalled()
-		expect(send).toHaveBeenCalledTimes(1)
-		const params = send.mock.calls[0][0]
-		expect(params).toEqual({
-			sessionId: "sess-1",
-			update: {
-				content: {
-					text: '[ACP] setStatus: Extension tried to set status "k" but the client doesn\'t advertise _kimchi.dev/pi_setStatus. The update was dropped.',
-					type: "text",
-				},
-				sessionUpdate: "agent_message_chunk",
-			},
-		})
-	})
-
-	it("setStatus warns only once per session (extensions often probe on every model token)", () => {
-		const { conn, send } = makeConn({
-			extNotification: extNotification as unknown as ExtNotification,
-		})
-		const real = createAcpUIContext(conn, "sess-1", elicitationClientCapabilities(), send)
-		real.setStatus("k1", "v1")
-		real.setStatus("k2", "v2")
-		real.setStatus("k3", "v3")
-		expect(send).toHaveBeenCalledTimes(1)
-	})
-
-	it("setEditorText sends _kimchi.dev/pi_set_editor_text via extNotification", async () => {
+	it("setEditorText sends _kimchi.dev/pi_notify via extNotification", async () => {
 		const {
 			conn,
 			extNotification: n,
@@ -829,54 +793,13 @@ describe("createAcpUIContext — fire-and-forget notifications", () => {
 		await new Promise((r) => setImmediate(r))
 		expect(n).toHaveBeenCalledTimes(1)
 		const [method, params] = n.mock.calls[0]
-		expect(method).toBe("_kimchi.dev/pi_set_editor_text")
+		expect(method).toBe("_kimchi.dev/pi_notify")
 		expect(params).toEqual({
 			id: expect.any(String),
 			type: "extension_ui_request",
 			method: "set_editor_text",
 			sessionId: "sess-1",
 			text: "draft message",
-		})
-	})
-
-	it("setEditorText warns via agent_message_chunk when the client doesn't advertise support", () => {
-		const {
-			conn,
-			extNotification: n,
-			send,
-		} = makeConn({
-			extNotification: extNotification as unknown as ExtNotification,
-		})
-		const real = createAcpUIContext(conn, "sess-1", elicitationClientCapabilities(), send)
-		real.setEditorText("draft")
-		expect(n).not.toHaveBeenCalled()
-		expect(send).toHaveBeenCalledTimes(1)
-		expect(send.mock.calls[0][0].update.sessionUpdate).toBe("agent_message_chunk")
-	})
-
-	it("notify warns via agent_message_chunk and includes the message text", () => {
-		const {
-			conn,
-			extNotification: n,
-			send,
-		} = makeConn({
-			extNotification: extNotification as unknown as ExtNotification,
-		})
-		const real = createAcpUIContext(conn, "sess-1", elicitationClientCapabilities(), send)
-		real.notify("first try")
-		real.notify("second try") // dedup: second call should not re-emit
-		expect(n).not.toHaveBeenCalled()
-		expect(send).toHaveBeenCalledTimes(1)
-		const params = send.mock.calls[0][0]
-		expect(params).toEqual({
-			sessionId: "sess-1",
-			update: {
-				content: {
-					text: "[ACP] notify: Extension notification dropped (client doesn't advertise _kimchi.dev/pi_notify): first try",
-					type: "text",
-				},
-				sessionUpdate: "agent_message_chunk",
-			},
 		})
 	})
 
@@ -895,7 +818,7 @@ describe("createAcpUIContext — fire-and-forget notifications", () => {
 		expect(n.mock.calls[0][1].text).toBe("pasted")
 	})
 
-	it("setWidget (string[] branch) forwards to _kimchi.dev/pi_setWidget", async () => {
+	it("setWidget (string[] branch) forwards to _kimchi.dev/pi_notify", async () => {
 		const {
 			conn,
 			extNotification: n,
@@ -908,7 +831,7 @@ describe("createAcpUIContext — fire-and-forget notifications", () => {
 		await new Promise((r) => setImmediate(r))
 		expect(n).toHaveBeenCalledTimes(1)
 		const [method, params] = n.mock.calls[0]
-		expect(method).toBe("_kimchi.dev/pi_setWidget")
+		expect(method).toBe("_kimchi.dev/pi_notify")
 		expect(params).toEqual({
 			id: expect.any(String),
 			type: "extension_ui_request",
@@ -955,31 +878,6 @@ describe("createAcpUIContext — fire-and-forget notifications", () => {
 		)
 		await new Promise((r) => setImmediate(r))
 		expect(n).not.toHaveBeenCalled()
-	})
-
-	it("setWidget warns via agent_message_chunk when the client doesn't advertise support", () => {
-		const {
-			conn,
-			extNotification: n,
-			send,
-		} = makeConn({
-			extNotification: extNotification as unknown as ExtNotification,
-		})
-		const real = createAcpUIContext(conn, "sess-1", elicitationClientCapabilities(), send)
-		real.setWidget("todo", ["line 1", "line 2"])
-		expect(n).not.toHaveBeenCalled()
-		expect(send).toHaveBeenCalledTimes(1)
-		const params = send.mock.calls[0][0]
-		expect(params).toEqual({
-			sessionId: "sess-1",
-			update: {
-				content: {
-					text: '[ACP] setWidget: Extension tried to set widget "todo" but the client doesn\'t advertise _kimchi.dev/pi_setWidget. The widget was dropped.',
-					type: "text",
-				},
-				sessionUpdate: "agent_message_chunk",
-			},
-		})
 	})
 
 	it("setTitle emits a session_info_update via send (deliberate divergence from rpc-mode)", () => {

--- a/src/modes/acp/acp-ui-context.ts
+++ b/src/modes/acp/acp-ui-context.ts
@@ -43,8 +43,6 @@ const REQUEST_TYPE = "extension_ui_request"
 
 const NOOP_THEME = createNoopTheme()
 
-type MethodType = PiMethod
-
 /**
  * Build an `ExtensionUIContext` that proxies all interaction through the ACP
  * connection. Bound to a single session — do not share across sessions.
@@ -63,13 +61,13 @@ export function createAcpUIContext(
 	const supportsMethod = (method: PiMethod) => getClientSupportsMethod(clientCapabilities, method)
 
 	async function requestDialog<T extends DialogResponse>(
-		method: MethodType,
+		acpMethod: "pi_editor",
 		payload: Record<string, unknown>,
 		signal: AbortSignal | undefined,
 	): Promise<T | "aborted"> {
 		try {
 			return await requestWithAbort(
-				conn.extMethod(AVAILABLE_METHODS[method], {
+				conn.extMethod(AVAILABLE_METHODS[acpMethod], {
 					type: REQUEST_TYPE,
 					id: randomUUID(),
 					sessionId,
@@ -78,22 +76,25 @@ export function createAcpUIContext(
 				signal,
 			)
 		} catch (err) {
-			logError(AVAILABLE_METHODS[method], err)
+			logError(AVAILABLE_METHODS[acpMethod], err)
 			return { cancelled: true } as T
 		}
 	}
 
-	function notify(method: MethodType, payload: Record<string, unknown>): void {
-		// Rejections are logged but never surface — `notify` returns void.
-		const wire = AVAILABLE_METHODS[method]
+	function notify(
+		payload: Record<string, unknown> & {
+			method: "notify" | "setStatus" | "setWidget" | "set_editor_text"
+		},
+	): void {
+		const acpMethod = AVAILABLE_METHODS.pi_notify
 		conn
-			.extNotification(wire, {
+			.extNotification(acpMethod, {
 				type: REQUEST_TYPE,
 				id: randomUUID(),
 				sessionId,
 				...payload,
 			})
-			.catch((err) => logError(wire, err))
+			.catch((err) => logError(acpMethod, err))
 	}
 
 	// One warning per method per session — extensions probe setStatus/setWidget
@@ -291,39 +292,48 @@ export function createAcpUIContext(
 		},
 
 		notify(message, type) {
-			if (!supportsMethod("pi_notify")) {
-				warnUnsupportedMethod(
-					"notify",
-					`Extension notification dropped (client doesn't advertise _kimchi.dev/pi_notify): ${message}`,
-				)
-				return undefined
+			notify({ method: "notify", message, notifyType: type })
+		},
+
+		setEditorText(text) {
+			notify({ method: "set_editor_text", text })
+		},
+
+		setStatus(key, text) {
+			notify({
+				method: "setStatus",
+				statusKey: key,
+				statusText: text,
+			})
+		},
+
+		setTitle(title) {
+			send({
+				sessionId,
+				update: { sessionUpdate: "session_info_update", title },
+			})
+		},
+
+		setWidget: (key, content, options) => {
+			// Component factories are silently dropped — no ACP equivalent for TUI trees.
+			if (typeof content !== "function") {
+				notify({
+					method: "setWidget",
+					widgetKey: key,
+					widgetLines: content,
+					widgetPlacement: options?.placement,
+				})
 			}
-			notify("pi_notify", { method: "notify", message, notifyType: type })
 		},
 
 		showError(message) {
-			this.notify(message, "error")
+			notify({ method: "notify", message, notifyType: "error" })
 		},
 
 		// TUI-only stubs below — extensions probe these in conditional branches.
 
 		onTerminalInput(_handler) {
 			return () => {}
-		},
-
-		setStatus(key, text) {
-			if (!supportsMethod("pi_setStatus")) {
-				warnUnsupportedMethod(
-					"setStatus",
-					`Extension tried to set status "${key}" but the client doesn't advertise _kimchi.dev/pi_setStatus. The update was dropped.`,
-				)
-				return
-			}
-			notify("pi_setStatus", {
-				method: "setStatus",
-				statusKey: key,
-				statusText: text,
-			})
 		},
 
 		setWorkingMessage(_message) {
@@ -336,25 +346,6 @@ export function createAcpUIContext(
 
 		setHiddenThinkingLabel(_label) {},
 
-		setWidget: (key, content, options) => {
-			// Component factories are silently dropped — no ACP equivalent for TUI trees.
-			if (!supportsMethod("pi_setWidget")) {
-				warnUnsupportedMethod(
-					"setWidget",
-					`Extension tried to set widget "${key}" but the client doesn't advertise _kimchi.dev/pi_setWidget. The widget was dropped.`,
-				)
-				return
-			}
-			if (typeof content !== "function") {
-				notify("pi_setWidget", {
-					method: "setWidget",
-					widgetKey: key,
-					widgetLines: content,
-					widgetPlacement: options?.placement,
-				})
-			}
-		},
-
 		setFooter(factory) {
 			void factory
 		},
@@ -363,30 +354,12 @@ export function createAcpUIContext(
 			void factory
 		},
 
-		setTitle(title) {
-			send({
-				sessionId,
-				update: { sessionUpdate: "session_info_update", title },
-			})
-		},
-
 		custom<T>(_factory: unknown, _options: unknown): Promise<T> {
 			return Promise.resolve(undefined as T)
 		},
 
 		pasteToEditor(text) {
 			ui.setEditorText(text)
-		},
-
-		setEditorText(text) {
-			if (!supportsMethod("pi_set_editor_text")) {
-				warnUnsupportedMethod(
-					"setEditorText",
-					`Extension tried to set editor text but the client doesn't advertise _kimchi.dev/pi_set_editor_text. The update was dropped.`,
-				)
-				return
-			}
-			notify("pi_set_editor_text", { method: "set_editor_text", text })
 		},
 
 		getEditorText() {

--- a/src/modes/acp/capabilities.ts
+++ b/src/modes/acp/capabilities.ts
@@ -9,9 +9,6 @@ export const CAPABILITIES_KEY = "kimchi.dev"
 // become `[ACP]` agent_message_chunk diagnostics instead of method-not-found.
 export const AVAILABLE_METHODS = {
 	pi_notify: `_${CAPABILITIES_KEY}/pi_notify`,
-	pi_setStatus: `_${CAPABILITIES_KEY}/pi_setStatus`,
-	pi_setWidget: `_${CAPABILITIES_KEY}/pi_setWidget`,
-	pi_set_editor_text: `_${CAPABILITIES_KEY}/pi_set_editor_text`,
 	pi_editor: `_${CAPABILITIES_KEY}/pi_editor`,
 } as const
 

--- a/tests/e2e/acp/all-capabilities.test.ts
+++ b/tests/e2e/acp/all-capabilities.test.ts
@@ -1,8 +1,10 @@
-// ACP integration: client advertises every `_kimchi.dev/pi_*` method and
-// `elicitation.form`. Expected: fire-and-forget UI calls route through
-// extNotifications (no `[ACP]` warnings), and tool-call permissions go
-// through `requestPermission` (the ACP prompter always uses that, regardless
-// of elicitation capability — `ctx.ui.confirm` is not on this path).
+// ACP integration: client advertises `_kimchi.dev/pi_notify` and
+// `elicitation.form`. Expected: every fire-and-forget UI call (notify,
+// setStatus, …) is routed through a single `_kimchi.dev/pi_notify`
+// extNotification with a `method` discriminator in the payload (no
+// `[ACP]` warnings). Tool-call permissions go through `requestPermission`
+// (the ACP prompter always uses that, regardless of elicitation capability
+// — `ctx.ui.confirm` is not on this path).
 
 import type { ClientCapabilities } from "@agentclientprotocol/sdk"
 import { afterEach, beforeEach, describe, expect, it } from "vitest"
@@ -86,16 +88,15 @@ describe("ACP integration — all capabilities", () => {
 		expect(fixture.client.permissionRequests.length, "request_permission call").toBeGreaterThanOrEqual(1)
 		expect(t2.chunks, "turn 2 agent text contains tool output").toContain("done")
 
-		// session_start fires on newSession, so both notifications arrive
-		// before turn 1's prompt resolves.
+		// session_start fires on newSession, so both notifications (notify +
+		// setStatus) arrive before turn 1's prompt resolves — both routed
+		// through a single `_kimchi.dev/pi_notify` extNotification.
+		const piNotifications = fixture.client.extNotifications.filter((n) => n.method.startsWith("_kimchi.dev/pi_"))
+		expect(piNotifications.length, "pi_notify extNotifications arrived (notify + setStatus)").toBeGreaterThanOrEqual(2)
 		expect(
-			fixture.client.hasNotification("_kimchi.dev/pi_notify"),
-			`_kimchi.dev/pi_notify extNotification arrived (saw: ${fixture.client.extNotifications.map((n) => n.method).join(", ")})`,
+			piNotifications.every((n) => n.method === "_kimchi.dev/pi_notify"),
+			"all fire-and-forget notifications use _kimchi.dev/pi_notify",
 		).toBe(true)
-		expect(
-			fixture.client.hasNotification("_kimchi.dev/pi_setStatus"),
-			"_kimchi.dev/pi_setStatus extNotification arrived",
-		).toBe(true)
-		expect(fixture.client.acpWarnings(), "no [ACP] warnings when client advertises every pi_* method").toEqual([])
+		expect(fixture.client.acpWarnings(), "no [ACP] warnings when client advertises pi_notify").toEqual([])
 	})
 })

--- a/tests/e2e/acp/elicitation-only.test.ts
+++ b/tests/e2e/acp/elicitation-only.test.ts
@@ -1,10 +1,8 @@
 // ACP integration: client advertises `elicitation.form` but NO
 // `_kimchi.dev/pi_*` methods. Expected: basic ACP flows (text, tool calls,
 // permissions) still work via `requestPermission`; fire-and-forget UI calls
-// surface as `[ACP]` agent_message_chunk warnings instead of vanishing.
-// (The elicitation capability is not on the permission path in ACP mode —
-// it would only matter for explicit `ctx.ui.confirm`/`select`/`input`
-// calls, which the harness doesn't issue in these scenarios.)
+// are sent unconditionally via `_kimchi.dev/pi_notify` (no capability gate,
+// no `[ACP]` warnings).
 
 import type { ClientCapabilities } from "@agentclientprotocol/sdk"
 import { afterEach, beforeEach, describe, expect, it } from "vitest"
@@ -48,7 +46,7 @@ describe("ACP integration — elicitation only", () => {
 		await fixture.stop()
 	})
 
-	it("surfaces fire-and-forget UI calls as agent_message_chunk warnings instead of dropping them", async () => {
+	it("sends fire-and-forget UI calls via pi_notify even without pi_* capabilities advertised", async () => {
 		const sessionId = await newSession(fixture, fixture.workDir)
 
 		const t1 = await prompt(fixture, sessionId, "Reply with the words: hello world")
@@ -69,17 +67,10 @@ describe("ACP integration — elicitation only", () => {
 		expect(fixture.client.permissionRequests.length, "request_permission call").toBeGreaterThanOrEqual(1)
 		expect(t2.chunks, "turn 2 agent text contains tool output").toContain("done")
 
+		// Fire-and-forget UI calls (notify + setStatus) are sent
+		// unconditionally via pi_notify — no capability gate.
 		const piNotifications = fixture.client.extNotifications.filter((n) => n.method.startsWith("_kimchi.dev/pi_"))
-		expect(piNotifications, "no _kimchi.dev/pi_* extNotifications").toEqual([])
-
-		const warnings = fixture.client.acpWarnings()
-		expect(warnings.length, "at least one [ACP] warning").toBeGreaterThanOrEqual(2)
-
-		const notifyWarning = warnings.find((w) => /notify/i.test(w))
-		const setStatusWarning = warnings.find((w) => /setStatus/i.test(w))
-		expect(notifyWarning, "notify method named in warning text").toBeDefined()
-		expect(setStatusWarning, "setStatus method named in warning text").toBeDefined()
-		// Dedup means the first notify survives in the single emitted warning.
-		expect(notifyWarning, "notify warning includes the message body").toContain("test-notify")
+		expect(piNotifications.length, "pi_notify extNotifications arrive even without advertised capabilities").toBeGreaterThanOrEqual(2)
+		expect(fixture.client.acpWarnings(), "no [ACP] warnings (capability gate removed)").toEqual([])
 	})
 })

--- a/tests/e2e/acp/message-id.test.ts
+++ b/tests/e2e/acp/message-id.test.ts
@@ -10,12 +10,10 @@
 // asserts the contract on the wire shape the client observes.
 //
 // Note: the fixture loads test-ui-extension.js, which exercises fire-and-
-// forget UI methods (notify / setStatus / setWidget). Because this test
-// doesn't advertise the corresponding `_kimchi.dev/pi_*` client capabilities,
-// the harness emits `[ACP]` warning chunks as a fallback. Those go through a
-// different code path than LLM-streamed deltas (so they have no messageId),
-// and `isAcpWarning` filters them out so the assertion is only on streamed
-// chunks.
+// forget UI methods (notify / setStatus). These are sent unconditionally as
+// `_kimchi.dev/pi_notify` extNotifications (no capability gate). The
+// `isAcpWarning` filter is kept defensively but no `[ACP]` warnings are
+// emitted in this scenario.
 
 import type { ContentChunk } from "@agentclientprotocol/sdk"
 import { afterEach, beforeEach, describe, expect, it } from "vitest"

--- a/tests/e2e/acp/no-capabilities.test.ts
+++ b/tests/e2e/acp/no-capabilities.test.ts
@@ -1,7 +1,8 @@
 // ACP integration: client advertises neither `elicitation.form` nor any
 // `_kimchi.dev/pi_*` method. Expected: basic ACP flows still work; tool-call
 // permissions fall back to `requestPermission`; fire-and-forget UI calls
-// surface as `[ACP]` agent_message_chunk warnings.
+// are sent unconditionally via `_kimchi.dev/pi_notify` (no capability gate,
+// no `[ACP]` warnings).
 
 import { afterEach, beforeEach, describe, expect, it } from "vitest"
 import { type AcpFixture, startAcpFixture } from "./support/acp-fixture.js"
@@ -61,16 +62,10 @@ describe("ACP integration — no capabilities", () => {
 		).toBeGreaterThanOrEqual(1)
 		expect(t2.chunks, "turn 2 agent text contains tool output").toContain("done")
 
+		// Fire-and-forget UI calls (notify + setStatus) are sent
+		// unconditionally via pi_notify — no capability gate.
 		const piNotifications = fixture.client.extNotifications.filter((n) => n.method.startsWith("_kimchi.dev/pi_"))
-		expect(piNotifications, "no _kimchi.dev/pi_* extNotifications").toEqual([])
-
-		const warnings = fixture.client.acpWarnings()
-		expect(warnings.length, "at least one [ACP] warning (notify + setStatus)").toBeGreaterThanOrEqual(2)
-		const notifyWarning = warnings.find((w) => w.includes("test-notify"))
-		const setStatusWarning = warnings.find((w) => w.includes("test-key"))
-		expect(notifyWarning, "notify warning found by test-notify marker").toBeDefined()
-		expect(setStatusWarning, "setStatus warning found by test-key marker").toBeDefined()
-		expect(notifyWarning, "notify warning references missing capability").toContain("_kimchi.dev/pi_notify")
-		expect(setStatusWarning, "setStatus warning references missing capability").toContain("_kimchi.dev/pi_setStatus")
+		expect(piNotifications.length, "pi_notify extNotifications arrive even without advertised capabilities").toBeGreaterThanOrEqual(2)
+		expect(fixture.client.acpWarnings(), "no [ACP] warnings (capability gate removed)").toEqual([])
 	})
 })


### PR DESCRIPTION

## What does this PR do?

<!-- Brief description of the change and why it's needed. -->

- Dropped three redundant ACP capabilities (`pi_setStatus`, `pi_setWidget`, `pi_set_editor_text`) and the per-method `supportsMethod` / `warnUnsupportedMethod` guards around them.
- `createAcpUIContext`'s internal `notify()` now always sends via the single `pi_notify` method, with the original target (`setStatus` / `setWidget` / `set_editor_text` / `notify`) carried as a `method` discriminator in the payload.
- Cleaned up the `MethodType` alias and renamed the request path's `method` parameter to `acpMethod` for clarity.

## Why

The previous design exposed one ACP notification method per UI capability. Since `pi_notify` already accepts a `method` field on the client side, splitting the wire surface was pure boilerplate — clients only ever needed to register one handler anyway. Collapsing to a single method removes duplicated capability checks, the warn-once shim, and the per-method table entries without changing client-visible behaviour.

## Notes

- `pi_editor` remains a separate request/response method — it is *not* fire-and-forget, so it stays out of the consolidation.

## Linked issue

Closes #0

<!-- Every PR must link to an existing issue. PRs without a linked issue will not be reviewed.
     Use one of: Closes #N / Fixes #N / Resolves #N -->

## Checklist

- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md) and agree to the CLA
- [ ] This PR links to an open issue above
- [x] Tests pass locally (`pnpm run test`)
- [x] Lint passes (`pnpm run check`)
- [ ] Documentation updated if behavior changed
