### PR TITLE
fix(acp): themed text should return the original text in acp ui context

### DIFF
--- a/src/modes/acp/acp-ui-context.test.ts
+++ b/src/modes/acp/acp-ui-context.test.ts
@@ -945,3 +945,57 @@ describe("createAcpUIContext — TUI-only no-op stubs", () => {
 		return expect(real.custom(customFactory)).resolves.toBeUndefined()
 	})
 })
+
+describe("createAcpUIContext — noop theme preserves text", () => {
+	const { conn, send } = makeConn()
+	const theme = createAcpUIContext(conn, "sess-1", fullClientCapabilities(), send).theme
+
+	it("fg passes the text through unchanged regardless of color", () => {
+		expect(theme.fg("accent", "keep me")).toBe("keep me")
+		expect(theme.fg("error", "keep me")).toBe("keep me")
+		expect(theme.fg("mdCode" as never, "keep me")).toBe("keep me")
+	})
+
+	it("bg passes the text through unchanged regardless of color", () => {
+		expect(theme.bg("selectedBg", "keep me")).toBe("keep me")
+		expect(theme.bg("toolErrorBg", "keep me")).toBe("keep me")
+	})
+
+	it("bold, italic, underline, inverse, strikethrough all return the original text", () => {
+		expect(theme.bold("keep me")).toBe("keep me")
+		expect(theme.italic("keep me")).toBe("keep me")
+		expect(theme.underline("keep me")).toBe("keep me")
+		expect(theme.inverse("keep me")).toBe("keep me")
+		expect(theme.strikethrough("keep me")).toBe("keep me")
+	})
+
+	it("empty string text is preserved (not coerced to undefined)", () => {
+		expect(theme.fg("accent", "")).toBe("")
+		expect(theme.bold("")).toBe("")
+		expect(theme.bg("selectedBg", "")).toBe("")
+	})
+
+	it("text containing ANSI escapes is preserved verbatim", () => {
+		const escaped = "\u001b[31mred\u001b[0m"
+		expect(theme.fg("accent", escaped)).toBe(escaped)
+		expect(theme.bold(escaped)).toBe(escaped)
+	})
+
+	it("text can be chained through multiple style methods without loss", () => {
+		const styled = theme.bold(theme.italic(theme.fg("accent", "keep me")))
+		expect(styled).toBe("keep me")
+	})
+
+	it("non-styling Theme methods still return undefined (no passthrough)", () => {
+		expect(theme.getFgAnsi("accent")).toBeUndefined()
+		expect(theme.getBgAnsi("selectedBg")).toBeUndefined()
+		expect(theme.getColorMode()).toBeUndefined()
+		expect(theme.getThinkingBorderColor("high")).toBeUndefined()
+		expect(theme.getBashModeBorderColor()).toBeUndefined()
+	})
+
+	it("the theme proxy is not thenable (no accidental promise wrapping)", () => {
+		expect((theme as unknown as { then?: unknown }).then).toBeUndefined()
+		expect((theme as unknown as { catch?: unknown }).catch).toBeUndefined()
+	})
+})

--- a/src/modes/acp/acp-ui-context.ts
+++ b/src/modes/acp/acp-ui-context.ts
@@ -408,7 +408,7 @@ export function createAcpUIContext(
 	return ui
 }
 
-const THEME_OVERRIDES: Partial<Record<keyof ThemeType, (...args: unknown[]) => unknown>> = {
+const THEME_OVERRIDES: Partial<ThemeType> = {
 	fg: (_color, text) => text,
 	bg: (_color, text) => text,
 	bold: (text) => text,

--- a/src/modes/acp/acp-ui-context.ts
+++ b/src/modes/acp/acp-ui-context.ts
@@ -408,11 +408,22 @@ export function createAcpUIContext(
 	return ui
 }
 
+const THEME_OVERRIDES: Partial<Record<keyof ThemeType, (...args: unknown[]) => unknown>> = {
+	fg: (_color, text) => text,
+	bg: (_color, text) => text,
+	bold: (text) => text,
+	italic: (text) => text,
+	underline: (text) => text,
+	inverse: (text) => text,
+	strikethrough: (text) => text,
+}
+
 /** Theme-shaped object whose every property access is a no-op. */
 function createNoopTheme(): ThemeType {
 	return new Proxy({} as ThemeType, {
 		get(_target, prop) {
 			if (prop === "then" || prop === "catch") return undefined
+			if (prop in THEME_OVERRIDES) return THEME_OVERRIDES[prop as keyof ThemeType]
 			return () => undefined
 		},
 	})


### PR DESCRIPTION
## Linked issue

Closes #0

<!-- Every PR must link to an existing issue. PRs without a linked issue will not be reviewed.
     Use one of: Closes #N / Fixes #N / Resolves #N -->

## What does this PR do?

We had previously mocked the theme object to return undefined values for any access of theme functions or properties. However, this meant that some values would get lost due to being themed with `ui.theme.fg("accent", text)` or `ui.theme.bold(text)`. This adds passthrough functions to those to ensure that notifications, statuses, etc are still received as the TUI receives them, just without extra styling.

<!-- Brief description of the change and why it's needed. -->

## Checklist

- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md) and agree to the CLA
- [ ] This PR links to an open issue above
- [x] Tests pass locally (`pnpm run test`)
- [x] Lint passes (`pnpm run check`)
- [ ] Documentation updated if behavior changed
