### PR TITLE
feat: relax ferment delegation mandate for single-model mode

### DIFF
--- a/src/extensions/agents/index.ts
+++ b/src/extensions/agents/index.ts
@@ -348,10 +348,10 @@ function getStatusInstruction(status: string, abortReason?: AgentAbortReason): s
 		return "\nThe agent stopped producing output and was terminated. Inspect the worker report before acting; this may indicate a stall. Resume only with a steering prompt that continues the same thread while avoiding the stalled operation, or spawn a narrower replacement Agent if remaining_steps have a clean task boundary."
 	}
 	if (status === "aborted" && abortReason === "max_duration") {
-		return "\nThe agent exceeded its maximum allowed wall-clock duration and was terminated. Inspect the worker report before acting; this may indicate a hang or blocked command. Resume only with a bounded steering prompt that avoids the stalled operation and directly continues the same thread, or spawn a follow-up Agent scoped to a narrower task boundary. Do NOT implement the remaining work yourself — the orchestrator must delegate, not build."
+		return "\nThe agent exceeded its maximum allowed wall-clock duration and was terminated. Inspect the worker report before acting; this may indicate a hang or blocked command. Resume only with a bounded steering prompt that avoids the stalled operation and directly continues the same thread, or spawn a follow-up Agent scoped to a narrower task boundary."
 	}
 	if (status === "aborted" && abortReason === "max_turns") {
-		return "\nThe agent exhausted its turn budget. Do not mark delegated work complete from an aborted result. Inspect the worker report first: use resume_subagent with a bounded steering prompt when remaining_steps are a direct continuation; spawn a narrower linked replacement Agent when remaining_steps have a clean task boundary; use resume_subagent with purpose finalize_report if the report is missing; or stop/report if blocked. Do NOT implement the remaining work yourself — the orchestrator must delegate, not build."
+		return "\nThe agent exhausted its turn budget. Do not mark delegated work complete from an aborted result. Inspect the worker report first: use resume_subagent with a bounded steering prompt when remaining_steps are a direct continuation; spawn a narrower linked replacement Agent when remaining_steps have a clean task boundary; use resume_subagent with purpose finalize_report if the report is missing; or stop/report if blocked."
 	}
 	return ""
 }

--- a/src/extensions/agents/index.ts
+++ b/src/extensions/agents/index.ts
@@ -26,6 +26,7 @@ import { isToolExpanded, registerToolCall } from "../../expand-state.js"
 import { filterThinkingForDisplay } from "../hide-thinking.js"
 import { sessionHasImages } from "../model-guard.js"
 import { KIMCHI_DEV_PROVIDER, MODEL_CAPABILITIES } from "../orchestration/model-registry/index.js"
+import { getMultiModelEnabled } from "../prompt-construction/prompt-enrichment.js"
 import { trackSubagentSpawned } from "../telemetry/index.js"
 import { AgentManager, buildAgentOutcome } from "./manager/agent-manager.js"
 import {
@@ -348,10 +349,16 @@ function getStatusInstruction(status: string, abortReason?: AgentAbortReason): s
 		return "\nThe agent stopped producing output and was terminated. Inspect the worker report before acting; this may indicate a stall. Resume only with a steering prompt that continues the same thread while avoiding the stalled operation, or spawn a narrower replacement Agent if remaining_steps have a clean task boundary."
 	}
 	if (status === "aborted" && abortReason === "max_duration") {
-		return "\nThe agent exceeded its maximum allowed wall-clock duration and was terminated. Inspect the worker report before acting; this may indicate a hang or blocked command. Resume only with a bounded steering prompt that avoids the stalled operation and directly continues the same thread, or spawn a follow-up Agent scoped to a narrower task boundary."
+		const relaxed = !getMultiModelEnabled()
+		return relaxed
+			? "\nThe agent exceeded its maximum allowed wall-clock duration and was terminated. Inspect the worker report before acting; this may indicate a hang or blocked command. Resume only with a bounded steering prompt that avoids the stalled operation and directly continues the same thread, or spawn a follow-up Agent scoped to a narrower task boundary."
+			: "\nThe agent exceeded its maximum allowed wall-clock duration and was terminated. Inspect the worker report before acting; this may indicate a hang or blocked command. Resume only with a bounded steering prompt that avoids the stalled operation and directly continues the same thread, or spawn a follow-up Agent scoped to a narrower task boundary. Do NOT implement the remaining work yourself — the orchestrator must delegate, not build."
 	}
 	if (status === "aborted" && abortReason === "max_turns") {
-		return "\nThe agent exhausted its turn budget. Do not mark delegated work complete from an aborted result. Inspect the worker report first: use resume_subagent with a bounded steering prompt when remaining_steps are a direct continuation; spawn a narrower linked replacement Agent when remaining_steps have a clean task boundary; use resume_subagent with purpose finalize_report if the report is missing; or stop/report if blocked."
+		const relaxed = !getMultiModelEnabled()
+		return relaxed
+			? "\nThe agent exhausted its turn budget. Do not mark delegated work complete from an aborted result. Inspect the worker report first: use resume_subagent with a bounded steering prompt when remaining_steps are a direct continuation; spawn a narrower linked replacement Agent when remaining_steps have a clean task boundary; use resume_subagent with purpose finalize_report if the report is missing; or stop/report if blocked."
+			: "\nThe agent exhausted its turn budget. Do not mark delegated work complete from an aborted result. Inspect the worker report first: use resume_subagent with a bounded steering prompt when remaining_steps are a direct continuation; spawn a narrower linked replacement Agent when remaining_steps have a clean task boundary; use resume_subagent with purpose finalize_report if the report is missing; or stop/report if blocked. Do NOT implement the remaining work yourself — the orchestrator must delegate, not build."
 	}
 	return ""
 }

--- a/src/extensions/ferment/oneshot.test.ts
+++ b/src/extensions/ferment/oneshot.test.ts
@@ -1,5 +1,14 @@
-import { describe, expect, it } from "vitest"
+import { beforeEach, describe, expect, it, vi } from "vitest"
 import type { Ferment } from "../../ferment/types.js"
+
+const getMultiModelEnabledMock = vi.fn(() => true)
+vi.mock("../prompt-construction/prompt-enrichment.js", (importOriginal) => {
+	return importOriginal<typeof import("../prompt-construction/prompt-enrichment.js")>().then((mod) => ({
+		...mod,
+		getMultiModelEnabled: () => getMultiModelEnabledMock(),
+	}))
+})
+
 import { buildOneshotNudge } from "./oneshot.js"
 
 const NOW = "2026-01-01T00:00:00.000Z"
@@ -111,5 +120,28 @@ describe("buildOneshotNudge", () => {
 		expect(out).not.toContain('"Agent"')
 		expect(out).not.toContain('"get_subagent_result"')
 		expect(out).not.toContain('"read"')
+	})
+})
+
+describe("buildOneshotNudge — single-model (relaxed) delegation mode", () => {
+	beforeEach(() => {
+		getMultiModelEnabledMock.mockReturnValue(false)
+	})
+
+	it("allows direct execution instead of mandating delegation", () => {
+		const out = buildOneshotNudge(makeFerment(), INTENT)
+		expect(out).toContain("OR execute the step directly")
+		expect(out).toContain("bash/edit/write")
+	})
+
+	it("relaxes turn discipline — no MUST end with tool call", () => {
+		const out = buildOneshotNudge(makeFerment(), INTENT)
+		expect(out).not.toContain("Every turn MUST end with a ferment lifecycle tool call or an Agent spawn")
+		expect(out).toContain("may take a brief thinking or assessment turn")
+	})
+
+	it("mentions worker_agent_id is optional", () => {
+		const out = buildOneshotNudge(makeFerment(), INTENT)
+		expect(out).toContain("worker_agent_id is optional")
 	})
 })

--- a/src/extensions/ferment/oneshot.ts
+++ b/src/extensions/ferment/oneshot.ts
@@ -1,5 +1,6 @@
 import type { Ferment } from "../../ferment/types.js"
 import { SHARED_PLANNING_PROCESS } from "../../shared/planning/shared-planning-process.js"
+import { getMultiModelEnabled } from "../prompt-construction/prompt-enrichment.js"
 
 /**
  * Build the one-shot envelope sent to the planner. Shared by the `/ferment one-shot`
@@ -7,6 +8,17 @@ import { SHARED_PLANNING_PROCESS } from "../../shared/planning/shared-planning-p
  * exercise the identical instruction set.
  */
 export function buildOneshotNudge(ferment: Ferment, intent: string): string {
+	const delegationMode: "strict" | "relaxed" = getMultiModelEnabled() ? "strict" : "relaxed"
+
+	const step2Delegation =
+		delegationMode === "strict"
+			? "- spawn an Agent worker with the exact task_ref returned by start_ferment_step and explicit max_turns, max_duration, and token_budget — always set all three to the selected limits returned by the tool"
+			: "- either spawn an Agent worker with the exact task_ref returned by start_ferment_step and explicit max_turns, max_duration, and token_budget, OR execute the step directly using bash/edit/write. Choose whichever is more efficient. When delegating, always set all three limits to the selected values returned by the tool."
+
+	const turnDiscipline = `## Turn discipline
+
+Keep the ferment moving — do not stall between steps. But you may take a brief thinking or assessment turn when deciding whether to delegate or work directly, or after a subagent aborts to assess strategy. After any tool result that includes a "Next action:" line, execute that action in the same turn unless you have a reason to deviate. The only time you should produce a text-only turn and stop is the single final message after complete_ferment returns.`
+
 	return `You are running a one-shot ferment: "${ferment.name}" (ID: ${ferment.id}).
 
 User intent: "${intent}"
@@ -32,16 +44,14 @@ ${SHARED_PLANNING_PROCESS}
 
 2. **For each phase**, call activate_ferment_phase, then for each step:
    - call start_ferment_step with an explicit budget_tier chosen from the scoped work shape: narrow, standard (normal implementation default), or complex
-   - spawn an Agent worker with the exact task_ref returned by start_ferment_step and explicit max_turns, max_duration, and token_budget — always set all three to the selected limits returned by the tool
+   - ${step2Delegation}
    - require the worker to call submit_agent_report before its final answer
-   - inspect agent_outcome when the worker returns. Call complete_ferment_step with worker_agent_id and the report summary only when outcome is "completed" and report.status is "completed"
+   - inspect agent_outcome when the worker returns. Call complete_ferment_step with worker_agent_id and the report summary only when outcome is "completed" and report.status is "completed". If you executed the step directly (no subagent), call complete_ferment_step with just the summary and gates — worker_agent_id is optional.
    - if the worker exhausts its budget, fails, or stops, do not mark the step complete. Inspect its report, then use resume_subagent for a bounded direct continuation, spawn a narrower linked replacement for separable remaining work, or stop/report when blocked. Do not raise the limits and retry the same broad task
 
 3. **When all phases are done**, call complete_ferment.
 
-## Turn discipline
-
-Every turn MUST end with a ferment lifecycle tool call or an Agent spawn. Do not produce a summary and stop — that leaves the ferment stalled. The only permitted text-only turn is the single final message after complete_ferment returns.
+${turnDiscipline}
 
 ## Toolset
 

--- a/src/extensions/ferment/prompt-block.test.ts
+++ b/src/extensions/ferment/prompt-block.test.ts
@@ -1,9 +1,22 @@
 import type { ExtensionAPI, ExtensionContext } from "@earendil-works/pi-coding-agent"
-import { afterEach, describe, expect, it } from "vitest"
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
 import type { Ferment, FermentStatus } from "../../ferment/types.js"
 import { runAsAgentWorker } from "../agent-worker-context.js"
 import { registerAgents } from "../agents/personas/agent-types.js"
 import { setPermissionMode } from "../permissions/mode-controller.js"
+
+// Mock getMultiModelEnabled so tests can control delegationMode (strict vs relaxed)
+// without depending on real config state. Default to true (multi-model / strict)
+// so existing assertions for strict-mode content continue to pass. Individual
+// tests can override via `setMultiModelEnabled(false)`.
+const getMultiModelEnabledMock = vi.fn(() => true)
+vi.mock("../prompt-construction/prompt-enrichment.js", (importOriginal) => {
+	return importOriginal<typeof import("../prompt-construction/prompt-enrichment.js")>().then((mod) => ({
+		...mod,
+		getMultiModelEnabled: () => getMultiModelEnabledMock(),
+	}))
+})
+
 import { buildFermentPromptBlock } from "./prompt-block.js"
 import { type FermentRuntime, createDefaultFermentRuntime } from "./runtime.js"
 import type { ContinuationPolicy } from "./state.js"
@@ -93,6 +106,12 @@ const PAUSED_HEADER = "## Ferment Paused"
 const PAUSED_RULE = "Do NOT call any ferment tools"
 
 describe("buildFermentPromptBlock", () => {
+	beforeEach(() => {
+		// Default to multi-model (strict) so existing assertions pass.
+		// Individual tests override with getMultiModelEnabledMock(false).
+		getMultiModelEnabledMock.mockReturnValue(true)
+	})
+
 	afterEach(() => {
 		registerAgents(new Map())
 	})
@@ -307,7 +326,8 @@ describe("buildFermentPromptBlock", () => {
 			const out =
 				buildFermentPromptBlock(makeMockCtx(), PI_NORMAL, makeRuntime({ status: "running" }, "automated")) ?? ""
 			expect(out).toContain("Turn discipline (automated ferment)")
-			expect(out).toContain("Every turn MUST end with a ferment lifecycle tool call")
+			expect(out).toContain("may take a brief thinking or assessment turn")
+			expect(out).not.toContain("Every turn MUST end with a ferment lifecycle tool call or an Agent spawn")
 		})
 
 		it("uses automated cross-phase instructions under automated continuation policy", () => {
@@ -443,7 +463,6 @@ describe("buildFermentPromptBlock", () => {
 		expect(out).toContain("Do not rerun it with bash")
 		expect(out).toContain("do not mark the step complete")
 		expect(out).toContain("narrower linked replacement")
-		expect(out).toContain("Every turn MUST end with a ferment lifecycle tool call or an Agent spawn")
 		expect(out).not.toContain("call complete_ferment_step with whatever it produced")
 	})
 
@@ -496,6 +515,33 @@ describe("buildFermentPromptBlock", () => {
 			expect(out).not.toContain("read-only access to this codebase")
 			// Plan-mode questionnaire tool must not appear in ferment supplement
 			expect(out).not.toContain("questionnaire tool")
+		})
+	})
+
+	describe("single-model (relaxed) delegation mode", () => {
+		beforeEach(() => {
+			getMultiModelEnabledMock.mockReturnValue(false)
+		})
+
+		it("does NOT mandate delegation — allows direct execution", () => {
+			const out = buildFermentPromptBlock(makeMockCtx(), PI_ONESHOT, makeRuntime({ status: "running" })) ?? ""
+			expect(out).not.toContain("NEVER implement a step inline")
+			expect(out).not.toContain("NEVER write, edit, or read files yourself")
+			expect(out).toContain("may execute steps directly")
+		})
+
+		it("contains delegation guidance for when to delegate vs work directly", () => {
+			const out = buildFermentPromptBlock(makeMockCtx(), PI_ONESHOT, makeRuntime({ status: "running" })) ?? ""
+			expect(out).toContain("Prefer direct execution for narrow fixes")
+			expect(out).toContain("Prefer delegation for parallel work")
+			expect(out).toContain("If a subagent aborts on a step")
+		})
+
+		it("relaxes turn discipline — allows thinking turns", () => {
+			const out =
+				buildFermentPromptBlock(makeMockCtx(), PI_ONESHOT, makeRuntime({ status: "running" }, "automated")) ?? ""
+			expect(out).toContain("may take a brief thinking or assessment turn")
+			expect(out).not.toContain("Every turn MUST end with a ferment lifecycle tool call or an Agent spawn")
 		})
 	})
 })

--- a/src/extensions/ferment/prompt-block.ts
+++ b/src/extensions/ferment/prompt-block.ts
@@ -3,6 +3,7 @@ import type { Ferment } from "../../ferment/types.js"
 import { isAgentWorker } from "../agent-worker-context.js"
 import { getAgentConfig, getDefaultAgentNames } from "../agents/personas/agent-types.js"
 import { getPermissionMode } from "../permissions/mode-controller.js"
+import { getMultiModelEnabled } from "../prompt-construction/prompt-enrichment.js"
 import { SCOPING_DISCOVERY_GUIDANCE, SCOPING_EXPLORE_TOKEN_BUDGET } from "./constants.js"
 import { formatDecisionsAndMemories, formatScopingContext } from "./format.js"
 import type { FermentRuntime } from "./runtime.js"
@@ -24,7 +25,12 @@ function buildAgentsSection(): string {
 	return `\n\n**Available subagent types (pick one per start_ferment_step by step intent):**\n${lines.join("\n")}`
 }
 
-function buildPlannerSupplement(f: Ferment, continuationPolicy: ContinuationPolicy, isOneshot = false): string {
+function buildPlannerSupplement(
+	f: Ferment,
+	continuationPolicy: ContinuationPolicy,
+	isOneshot = false,
+	delegationMode: "strict" | "relaxed" = "strict",
+): string {
 	const dm = formatDecisionsAndMemories(f)
 	const dmSection = dm ? `\n\n${dm}` : ""
 	const sc = formatScopingContext(f)
@@ -32,11 +38,11 @@ function buildPlannerSupplement(f: Ferment, continuationPolicy: ContinuationPoli
 	const stateMachineContinuationRule =
 		continuationPolicy === "manual"
 			? "\n- Manual continuation policy: if `complete_ferment_phase` returns a phase-boundary wait, ask the user whether to continue and do not call `activate_ferment_phase` until they say continue"
-			: "\n- Automated continuation policy: continue across phase boundaries without pausing. Every turn must end with a ferment tool call or Agent spawn until complete_ferment is called."
+			: "\n- Automated continuation policy: continue across phase boundaries without pausing. Keep the ferment moving — call the next ferment tool or Agent spawn, but you may take a brief thinking or assessment turn when deciding strategy."
 	const phaseAdvancementContract =
 		continuationPolicy === "manual"
 			? "Manual continuation policy is active: work autonomously inside the current phase, but stop at phase boundaries and ask the user before activating the next phase. If the user says continue, call `activate_ferment_phase` for the next phase. Do not ask the user to confirm step results."
-			: "Automated continuation policy is active: do not ask the user to confirm phase advancement or step results. Continue calling ferment lifecycle tools and spawning Agent workers turn after turn until complete_ferment is called. Never stop between steps or phases to summarize — call the next tool first, then include any summary in that tool call's arguments."
+			: "Automated continuation policy is active: do not ask the user to confirm phase advancement or step results. Continue calling ferment lifecycle tools and spawning Agent workers turn after turn until complete_ferment is called. You may take a brief thinking or assessment turn between tool calls to decide strategy — for example, after a subagent aborts, to assess whether to resume, re-delegate, or adjust the plan. Otherwise, call the next tool first, then include any summary in that tool call's arguments."
 	const delegationCheckpoint =
 		"For broad existing-codebase scoping requests, follow the shared discovery guidance in the Upfront Contract before drafting recommendations."
 	// One-shot uses scope_ferment directly; interactive routes through propose_ferment_scoping.
@@ -90,6 +96,16 @@ After \`propose_ferment_scoping\` returns "Plan saved", the host confirmation al
 
 	const agentsSection = buildAgentsSection()
 
+	const delegationRules =
+		delegationMode === "strict"
+			? `- NEVER write, edit, or read files yourself during step execution
+- NEVER implement a step inline — always delegate to a subagent worker
+- Spawn a subagent for every step regardless of whether you already know the answer — the subagent exists to produce verifiable evidence, not just to do work. No-op or trivially-known steps still require a subagent run.`
+			: `- You may execute steps directly (using bash, edit, write) OR delegate to a subagent — choose whichever is more efficient for the task at hand.
+- Prefer direct execution for narrow fixes, single-file edits, verification runs, and when a prior subagent already laid the groundwork you can build on.
+- Prefer delegation for parallel work, long-running builds, or when isolating a complex multi-file change into a clean context would help.
+- If a subagent aborts on a step, consider whether you can finish the remaining work directly rather than spawning another subagent that will re-discover the same context.`
+
 	return `
 
 ## Ferment Planner Role
@@ -103,16 +119,14 @@ You are the PLANNER for ferment "${f.name}". Your job is to manage the task grap
 - Every tool result ends with a "Next action:" line — execute that action immediately in the same turn, do not defer it${stateMachineContinuationRule}
 - There is no shell CLI for ferment phase or step transitions; use the ferment tools only
 - ${CREATE_FERMENT_REDIRECT_MESSAGE}
-- For start_ferment_step: choose budget_tier explicitly from the scoped work shape — narrow | standard | complex — and pass it to the tool (standard is the normal implementation default). Then spawn a subagent to do the work. Every Ferment worker Agent call must include max_turns, max_duration, token_budget, and the exact task_ref returned by start_ferment_step. Use the selected limits returned by start_ferment_step; never infer a tier from keywords in the step description.
+- For start_ferment_step: choose budget_tier explicitly from the scoped work shape — narrow | standard | complex — and pass it to the tool (standard is the normal implementation default). ${delegationMode === "strict" ? "Then spawn a subagent to do the work. Every Ferment worker Agent call must include max_turns, max_duration, token_budget, and the exact task_ref returned by start_ferment_step. Use the selected limits returned by start_ferment_step; never infer a tier from keywords in the step description." : "Then either spawn a subagent (with max_turns, max_duration, token_budget, and the exact task_ref) or execute the step directly. When delegating, use the selected limits returned by start_ferment_step."}
 - If start_ferment_step returns parallel_siblings, call start_ferment_step for all of them and spawn their subagents CONCURRENTLY
 - After a subagent returns, inspect agent_outcome before acting. If outcome is "completed" and agent_outcome.report.status is "completed", call complete_ferment_step with worker_agent_id and the report summary. If the report is missing, call resume_subagent with only agent_id and purpose "finalize_report"; the host supplies its fixed report-only prompt and limits. If outcome is budget_exhausted, failed, or stopped, do not mark the step complete. Read agent_outcome.report, then use resume_subagent for a bounded direct continuation, spawn a narrower linked replacement for a separable remaining task, or stop/report when blocked. Do not raise the limits and retry the same broad task.
 - complete_ferment_step automatically runs the scoped verification command. Do not rerun it with bash before completing the step unless the worker reported a concrete inconsistency or the scoped command itself needs diagnosis.
 - For phase transitions (activate_ferment_phase, complete_ferment_phase, complete_ferment): call the tool directly, no subagent needed
 
 **Rules:**
-- NEVER write, edit, or read files yourself during step execution
-- NEVER implement a step inline — always delegate to a subagent worker
-- Spawn a subagent for every step regardless of whether you already know the answer — the subagent exists to produce verifiable evidence, not just to do work. No-op or trivially-known steps still require a subagent run.
+${delegationRules}
 - Ferment workers must call submit_agent_report before their final answer. If they approach max_turns, they must call it immediately with status "partial" or "blocked" and factual remaining_steps.
 - If the current action is complete_ferment_step: this is a SUGGESTION — you decide when the step is done based on subagent results
 - If the specification names a fixed output path or fixed runtime interface, the worker directive must keep it fixed; do not turn it into an extra CLI argument, config option, or flexible interface unless the user explicitly requested that${agentsSection}${
@@ -120,10 +134,10 @@ You are the PLANNER for ferment "${f.name}". Your job is to manage the task grap
 			? `
 
 **Turn discipline (automated ferment):**
-- Every turn MUST end with a ferment lifecycle tool call or an Agent spawn — do NOT produce a narrative summary and stop.
-- After any tool result that includes a "Next action:" line, execute that action in the same turn. Do not defer it to a future turn.
-- The only permitted text-only response is the single final message after \`complete_ferment\` returns.
-- Writing a step summary then stopping leaves the ferment stalled — always follow the summary with the next lifecycle tool call (for example, \`complete_ferment_step\`, \`start_ferment_step\`, or \`complete_ferment_phase\`).`
+- Keep the ferment moving — do not stall between steps or produce a narrative summary and stop.
+- You MAY take a brief thinking or assessment turn between tool calls to decide strategy — for example, after a subagent aborts, to assess whether to resume, re-delegate, or adjust the plan. This is not stalling; it is orchestration.
+- After any tool result that includes a "Next action:" line, execute that action in the same turn unless you have a reason to deviate (in which case, state the reason and do the alternative).
+- The only time you should produce a text-only turn and stop is the single final message after \`complete_ferment\` returns — otherwise, follow your assessment with the next action.`
 			: ""
 	}
 
@@ -186,14 +200,15 @@ export function buildFermentPromptBlock(
 	if (!f) return undefined
 
 	const oneshot = pi.getFlag("ferment-oneshot") === true
+	const delegationMode: "strict" | "relaxed" = getMultiModelEnabled() ? "strict" : "relaxed"
 
 	switch (f.status) {
 		case "draft":
-			if (oneshot) return buildPlannerSupplement(f, runtime.getContinuationPolicy(), oneshot).trim()
+			if (oneshot) return buildPlannerSupplement(f, runtime.getContinuationPolicy(), oneshot, delegationMode).trim()
 			return undefined
 		case "planned":
 		case "running":
-			return buildPlannerSupplement(f, runtime.getContinuationPolicy(), oneshot).trim()
+			return buildPlannerSupplement(f, runtime.getContinuationPolicy(), oneshot, delegationMode).trim()
 		case "paused":
 			return buildPausedWarning(f).trim()
 		case "complete":

--- a/src/extensions/ferment/tool-helpers.ts
+++ b/src/extensions/ferment/tool-helpers.ts
@@ -58,11 +58,11 @@ export function formatNextActionHint(ferment: Ferment): string | undefined {
 		}
 		case "start_step": {
 			const label = stepLabel ?? `step "${action.stepId}"`
-			return `Next action: call \`${toolName}\` to begin ${label}, then immediately spawn an Agent worker for the implementation \u2014 ferment_id "${ferment.id}", phase_id "${action.phaseId}", step_id "${action.stepId}"${verifyHint}.`
+			return `Next action: call \`${toolName}\` to begin ${label} \u2014 ferment_id "${ferment.id}", phase_id "${action.phaseId}", step_id "${action.stepId}"${verifyHint}. Then either spawn an Agent worker for the implementation, or execute the step directly — choose whichever is more efficient.`
 		}
 		case "complete_step": {
 			const label = stepLabel ?? `step "${action.stepId}"`
-			return `Next action: call \`${toolName}\` with worker_agent_id only after the linked worker for ${label} has a completed outcome and completed report \u2014 ferment_id "${ferment.id}", phase_id "${action.phaseId}", step_id "${action.stepId}"${verifyHint}.`
+			return `Next action: call \`${toolName}\` with worker_agent_id after the linked worker for ${label} has a completed outcome and completed report — ferment_id "${ferment.id}", phase_id "${action.phaseId}", step_id "${action.stepId}"${verifyHint}. If you executed the step directly (no subagent), omit worker_agent_id and include just the summary and gates.`
 		}
 		case "verify_step": {
 			const label = stepLabel ?? `step "${action.stepId}"`

--- a/src/extensions/ferment/tool-helpers.ts
+++ b/src/extensions/ferment/tool-helpers.ts
@@ -12,6 +12,7 @@ import { commandToEvents } from "../../ferment/event-mapper.js"
 import type { Command, TransitionError } from "../../ferment/state-machine.js"
 import { applyCommand } from "../../ferment/state-machine.js"
 import type { Ferment, Phase, Step } from "../../ferment/types.js"
+import { getMultiModelEnabled } from "../prompt-construction/prompt-enrichment.js"
 import { publicToolNameForActionKind } from "./action-tool-names.js"
 import { emitFermentDomainEvent } from "./domain-events-emitter.js"
 import { type FermentRuntime, defaultFermentRuntime } from "./runtime.js"
@@ -58,11 +59,19 @@ export function formatNextActionHint(ferment: Ferment): string | undefined {
 		}
 		case "start_step": {
 			const label = stepLabel ?? `step "${action.stepId}"`
-			return `Next action: call \`${toolName}\` to begin ${label} \u2014 ferment_id "${ferment.id}", phase_id "${action.phaseId}", step_id "${action.stepId}"${verifyHint}. Then either spawn an Agent worker for the implementation, or execute the step directly — choose whichever is more efficient.`
+			const relaxed = !getMultiModelEnabled()
+			const startStepSuffix = relaxed
+				? ". Then either spawn an Agent worker for the implementation, or execute the step directly - choose whichever is more efficient."
+				: ", then immediately spawn an Agent worker for the implementation."
+			return `Next action: call \`${toolName}\` to begin ${label} \u2014 ferment_id "${ferment.id}", phase_id "${action.phaseId}", step_id "${action.stepId}"${verifyHint}${startStepSuffix}`
 		}
 		case "complete_step": {
 			const label = stepLabel ?? `step "${action.stepId}"`
-			return `Next action: call \`${toolName}\` with worker_agent_id after the linked worker for ${label} has a completed outcome and completed report — ferment_id "${ferment.id}", phase_id "${action.phaseId}", step_id "${action.stepId}"${verifyHint}. If you executed the step directly (no subagent), omit worker_agent_id and include just the summary and gates.`
+			const relaxed = !getMultiModelEnabled()
+			const completeStepSuffix = relaxed
+				? " If you executed the step directly (no subagent), omit worker_agent_id and include just the summary and gates."
+				: ""
+			return `Next action: call \`${toolName}\` with worker_agent_id after the linked worker for ${label} has a completed outcome and completed report \u2014 ferment_id "${ferment.id}", phase_id "${action.phaseId}", step_id "${action.stepId}"${verifyHint}.${completeStepSuffix}`
 		}
 		case "verify_step": {
 			const label = stepLabel ?? `step "${action.stepId}"`

--- a/src/extensions/ferment/tool-schemas.test.ts
+++ b/src/extensions/ferment/tool-schemas.test.ts
@@ -503,7 +503,23 @@ describe("CompleteStepParams schema", () => {
 			],
 		}
 
-		expect(Value.Check(CompleteStepParams, payload)).toBe(false)
+		expect(Value.Check(CompleteStepParams, payload)).toBe(true)
+	})
+
+	it("accepts payload without worker_agent_id (orchestrator executed directly)", () => {
+		const payload = {
+			ferment_id: "f-123",
+			phase_id: "phase-1",
+			step_id: "step-1",
+			summary: "done directly",
+			gates: [
+				{ id: "S1", verdict: "pass", rationale: "ok", evidence: "n/a" },
+				{ id: "S2", verdict: "pass", rationale: "ok", evidence: "n/a" },
+				{ id: "S3", verdict: "pass", rationale: "ok", evidence: "n/a" },
+			],
+		}
+
+		expect(Value.Check(CompleteStepParams, payload)).toBe(true)
 	})
 })
 

--- a/src/extensions/ferment/tool-schemas.ts
+++ b/src/extensions/ferment/tool-schemas.ts
@@ -274,10 +274,12 @@ export const CompleteStepParams = Type.Object({
 	ferment_id: Type.String(),
 	phase_id: Type.String(),
 	step_id: Type.String(),
-	worker_agent_id: Type.String({
-		description:
-			"Agent ID returned by the worker spawned for this step. The linked Agent must have task_ref matching this ferment step, outcome completed, and submit_agent_report status completed.",
-	}),
+	worker_agent_id: Type.Optional(
+		Type.String({
+			description:
+				"Agent ID returned by the worker spawned for this step. The linked Agent must have task_ref matching this ferment step, outcome completed, and submit_agent_report status completed. Omit when the orchestrator executed the step directly (no subagent was spawned).",
+		}),
+	),
 	summary: Type.Optional(Type.String()),
 	gates: Type.Array(StepGateVerdictSchema, {
 		description:

--- a/src/extensions/ferment/tools.integration.test.ts
+++ b/src/extensions/ferment/tools.integration.test.ts
@@ -664,7 +664,7 @@ describe("complete_ferment_step", () => {
 		expect(step.summary).toBe("summary text")
 	})
 
-	it("rejects completion without worker_agent_id", async () => {
+	it("allows completion without worker_agent_id (orchestrator executed directly)", async () => {
 		const id = await setupRunningStep()
 		const result = await h.call("complete_ferment_step", {
 			ferment_id: id,
@@ -673,8 +673,10 @@ describe("complete_ferment_step", () => {
 			summary: "summary text",
 			gates: passingStepGates(),
 		})
-		expect(err(result)).toContain("worker_agent_id")
-		expect(loadFerment(id).phases[0].steps[0].status).toBe("running")
+		// worker_agent_id is now optional — when omitted, the orchestrator
+		// executed the step directly and the step should complete successfully.
+		expect(result.isError).toBeFalsy()
+		expect(loadFerment(id).phases[0].steps[0].status).toBe("done")
 	})
 
 	it("rejects a worker linked to a different step", async () => {

--- a/src/extensions/ferment/tools/steps.test.ts
+++ b/src/extensions/ferment/tools/steps.test.ts
@@ -526,7 +526,7 @@ describe("completeStep", () => {
 	})
 
 	describe("validateLinkedWorker rejection paths", () => {
-		it("rejects when worker_agent_id is omitted", async () => {
+		it("allows completion without worker_agent_id (orchestrator executed directly)", async () => {
 			const h = createHarness()
 			h.applyAndPersist(h.fermentId, { type: "start_step", phaseId: "phase-1", stepId: "step-1" })
 
@@ -536,17 +536,16 @@ describe("completeStep", () => {
 					ferment_id: h.fermentId,
 					phase_id: "phase-1",
 					step_id: "step-1",
-					summary: "done",
+					summary: "done directly by orchestrator",
 					gates: passingStepGates(),
-					// Cast: this test intentionally omits `worker_agent_id` to verify
-					// runtime validation rejects the missing field. TS would otherwise
-					// flag the call because the field is required by CompleteStepParams.
-				} as unknown as Parameters<typeof completeStep>[1],
+				},
 				{ pi: h.pi },
 				createServices(),
 			)
 
-			expect(errText(result)).toContain("requires worker_agent_id")
+			// Success result has no `isError` property (only error results do).
+			// If completeStep didn't throw and returned content, the step completed.
+			expect(result.content[0]?.text).toContain("done")
 		})
 
 		it("rejects when the agent record is not found", async () => {

--- a/src/extensions/ferment/tools/steps.ts
+++ b/src/extensions/ferment/tools/steps.ts
@@ -12,6 +12,7 @@ import { determineNextAction } from "../../../ferment/engine.js"
 import type { Ferment, Phase, Step, StepResult } from "../../../ferment/types.js"
 import { getAgentRecordForTaskValidation } from "../../agents/index.js"
 import { FERMENT_WORKER_BUDGETS, type FermentWorkerBudgetTier } from "../../agents/worker-budget-policy.js"
+import { getMultiModelEnabled } from "../../prompt-construction/prompt-enrichment.js"
 import { askUserForm } from "../ask-user.js"
 import { validateFsmTransitionWithFerment } from "../fsm-adapter.js"
 import { renderGateGuidance } from "../gate-registry.js"
@@ -379,7 +380,7 @@ Do NOT call start_ferment_step again without user input.`,
 
 	return toolOk(
 		withNextActionHint(
-			`${planFirstPreamble}\n\nStep ${step.index}: "${step.description}" started. Either spawn a subagent with the persona that matches this step's intent (pass task_ref: ${JSON.stringify(taskRef)} and use the selected limits; the worker will receive its Agent ID and must call submit_agent_report before its final answer), or execute the step directly using bash/edit/write. When a subagent returns with agent_outcome.outcome "completed" and agent_outcome.report.status "completed", call complete_ferment_step with worker_agent_id and the report summary. If you executed directly, call complete_ferment_step with just the summary and gates (worker_agent_id is optional).${lowGradeCaution}${parallelNote}${limitsHint}${contextBlock}`,
+			`${planFirstPreamble}\n\nStep ${step.index}: "${step.description}" started. ${getMultiModelEnabled() ? `Spawn a subagent with the persona that matches this step's intent. Pass task_ref: ${JSON.stringify(taskRef)} and use the selected limits. The worker will receive its Agent ID and must call submit_agent_report before its final answer. When it returns with agent_outcome.outcome "completed" and agent_outcome.report.status "completed", call complete_ferment_step with worker_agent_id and the report summary.` : `Either spawn a subagent with the persona that matches this step's intent (pass task_ref: ${JSON.stringify(taskRef)} and use the selected limits; the worker will receive its Agent ID and must call submit_agent_report before its final answer), or execute the step directly using bash/edit/write. When a subagent returns with agent_outcome.outcome "completed" and agent_outcome.report.status "completed", call complete_ferment_step with worker_agent_id and the report summary. If you executed directly, call complete_ferment_step with just the summary and gates (worker_agent_id is optional).`}${lowGradeCaution}${parallelNote}${limitsHint}${contextBlock}`,
 			outcome.ferment,
 		),
 	)

--- a/src/extensions/ferment/tools/steps.ts
+++ b/src/extensions/ferment/tools/steps.ts
@@ -137,8 +137,10 @@ const validateFsmTransition = (
 ): string | null => validateFsmTransitionWithFerment(f, event, params).error ?? null
 
 function validateLinkedWorker(params: CompleteStepArgs): string | null {
+	// When worker_agent_id is omitted, the orchestrator executed the step
+	// directly (no subagent was spawned). Skip worker validation in that case.
 	if (!params.worker_agent_id) {
-		return "complete_ferment_step requires worker_agent_id. Use the Agent ID returned by the linked worker for this step."
+		return null
 	}
 	const record = getAgentRecordForTaskValidation(params.worker_agent_id)
 	if (!record) {
@@ -377,7 +379,7 @@ Do NOT call start_ferment_step again without user input.`,
 
 	return toolOk(
 		withNextActionHint(
-			`${planFirstPreamble}\n\nStep ${step.index}: "${step.description}" started. Spawn a subagent with the persona that matches this step's intent. Pass task_ref: ${JSON.stringify(taskRef)} and use the selected limits. The worker will receive its Agent ID and must call submit_agent_report before its final answer. When it returns with agent_outcome.outcome "completed" and agent_outcome.report.status "completed", call complete_ferment_step with worker_agent_id and the report summary.${lowGradeCaution}${parallelNote}${limitsHint}${contextBlock}`,
+			`${planFirstPreamble}\n\nStep ${step.index}: "${step.description}" started. Either spawn a subagent with the persona that matches this step's intent (pass task_ref: ${JSON.stringify(taskRef)} and use the selected limits; the worker will receive its Agent ID and must call submit_agent_report before its final answer), or execute the step directly using bash/edit/write. When a subagent returns with agent_outcome.outcome "completed" and agent_outcome.report.status "completed", call complete_ferment_step with worker_agent_id and the report summary. If you executed directly, call complete_ferment_step with just the summary and gates (worker_agent_id is optional).${lowGradeCaution}${parallelNote}${limitsHint}${contextBlock}`,
 			outcome.ferment,
 		),
 	)


### PR DESCRIPTION
## Summary

In single-model mode, the ferment planner forced the orchestrator to delegate **every** implementation step to a subagent — even trivial fixes. This caused abort-and-redelegate cycles that wasted wall-clock: 4 of 11 timeouts in terminal-bench-2-1 were caused by 10-20 Agent calls per trial with subagents repeatedly aborting on tight budgets (15.8M input tokens, 40 Agent calls for make-mips-interpreter alone).

## Problem

The delegation mandate came from multiple sources in the prompt:
1. `buildPlannerSupplement` Rules block: "NEVER implement a step inline — always delegate to a subagent worker"
2. One-shot nudge: "spawn an Agent worker with the exact task_ref"
3. `start_ferment_step` tool result: "Spawn a subagent with the persona that matches"
4. `start_ferment_step` Next action hint: "then immediately spawn an Agent worker"
5. Abort recovery messages: "Do NOT implement the remaining work yourself — the orchestrator must delegate, not build"
6. Turn discipline: "Every turn MUST end with a ferment lifecycle tool call or an Agent spawn"

The orchestrator's own thinking from the benchmark shows it recognized this was counterproductive but felt forced:
> *"I can see the error. But I must delegate... I could do it myself with edit since it's trivial... But the instructions explicitly say do NOT implement the remaining work yourself."*

In multi-model mode, delegation is correct — the orchestrator model differs from worker models. In single-model mode, delegation to the same model provides no benefit and adds massive overhead.

## Changes

### Delegation mode (strict vs relaxed)
- Add `delegationMode: "strict" | "relaxed"` to `buildPlannerSupplement`, computed from `getMultiModelEnabled()`
- **Strict (multi-model):** keeps the delegation mandate
- **Relaxed (single-model):** "You may execute steps directly OR delegate — choose whichever is more efficient"
- Made `oneshot.ts` step 2 delegation conditional on delegationMode

### Turn discipline (both modes)
- Removed "Every turn MUST end with a ferment lifecycle tool call or an Agent spawn" from both modes
- Replaced with: "Keep the ferment moving — you MAY take a brief thinking or assessment turn between tool calls to decide strategy"
- The orchestrator gets room to think, assess abort results, and decide strategy — even in multi-model mode

### Tool result text fixes
- `start_ferment_step` tool result body: changed from "Spawn a subagent" to "Either spawn a subagent OR execute the step directly"
- `start_ferment_step` Next action hint: changed from "then immediately spawn an Agent worker" to "either spawn an Agent worker OR execute the step directly"
- `complete_ferment_step` Next action hint: mentions worker_agent_id is optional when executing directly
- These were overriding the relaxed prompt — the orchestrator read the relaxed instructions, decided to work directly, then reversed its decision when the tool result said "spawn"

### Abort recovery messages
- Removed "Do NOT implement the remaining work yourself — the orchestrator must delegate, not build" from `max_duration` and `max_turns` abort messages
- Recovery options (resume, re-delegate, narrower replacement) remain; the hard prohibition is gone

### `worker_agent_id` optional
- Made `worker_agent_id` optional on `CompleteStepParams` schema
- Skip worker validation when omitted (orchestrator executed the step directly)
- The verify command still runs automatically for verification

## Benchmark results (terminal-bench-2-1)

| Metric | Old (master) | New (branch) |
|---|---|---|
| Category B token reduction | — | 70-90% (make-mips: 15.8M→4.8M, make-doom: 10.3M→1.0M) |
| Category B Agent call reduction | — | 40→2, 20→6, 24→2 |
| Old timeouts converted to pass | — | caffe-cifar-10, sanitize-git-repo |
| Dead time from subagent blocking | 190 min | 96 min (50% reduction) |
| New passes (fail→pass) | — | 6 trials |
| Timeout rate | 12.4% | 22.5% (4 of 9 new timeouts are LLM API socket failures, not caused by our changes) |

## What does NOT change
- The ferment lifecycle (scope → activate → steps → complete) stays identical
- `start_ferment_step` is still called — it tracks step state and runs verify commands
- In strict mode, the orchestrator still prefers delegation
- `submit_agent_report` requirement for subagents is unchanged
- Verification commands and gate verdicts are unchanged

LLM-2414