### PR TITLE
feature: Inline compaction for one-shot ferment

### DIFF
--- a/patches/@earendil-works__pi-coding-agent@0.79.10.patch
+++ b/patches/@earendil-works__pi-coding-agent@0.79.10.patch
@@ -58,6 +58,13 @@
 # separate PR to add previewTheme + showError to ExtensionUIContext.
 # Issue: TODO — file against https://github.com/earendil-works/pi-mono once the
 # API design is confirmed stable.
+#   9. dist/index.js, dist/index.d.ts — re-export prepareCompaction from the package
+#                                 root. Kimchi's inline compaction (src/upstream-inline-compact-patch.ts)
+#                                 needs it, and the package exports map blocks deep imports.
+#                                 A runtime dynamic import of dist/core/compaction/index.js is
+#                                 not an option: it breaks in the Bun-compiled binary (no
+#                                 node_modules on disk) and Bun rejects detached import.meta.resolve.
+#
 #
 # Removal criteria:
 #   - Items 1-3 (before_provider_headers): upstream pi-mono ships BeforeProviderHeadersEvent
@@ -74,7 +81,9 @@
 #     createLocalBashOperations destroys child stdio after a timeout kill (or
 #     waitForChildProcess gains a max-wait that forces resolution), and the
 #     fixed version is pinned in package.json.
-
+#   - Item 9 (prepareCompaction export): upstream pi-coding-agent exports prepareCompaction
+#     from its root entry (or a public subpath) and the fixed version is pinned in package.json.
+#
 diff --git a/dist/cli/args.js b/dist/cli/args.js
 index 6bd8f43b4402dbd24f9262c4c059b2c06693a79c..ad705421fb9087efd8ad2cfbfe8709d198245751 100644
 --- a/dist/cli/args.js
@@ -327,6 +336,28 @@ index bf8a79ebfdbe23415cd1effdd3db0b9ebfd804bc..f69116ceafe8ee7f1e2dbfeaa37f60c5
  }
  function buildEditCallComponent(component, args, theme, cwd) {
      component.setBgFn(getEditHeaderBg(component.preview, component.settledError, theme));
+diff --git a/dist/index.d.ts b/dist/index.d.ts
+index 9258752ae4c5e67408c12d060da02675082d13c4..a91910ce4daad14aa98b99f34b9331a620d2b28d 100644
+--- a/dist/index.d.ts
++++ b/dist/index.d.ts
+@@ -28,4 +28,5 @@ export { parseFrontmatter, stripFrontmatter } from "./utils/frontmatter.ts";
+ export { convertToPng } from "./utils/image-convert.ts";
+ export { formatDimensionNote, type ResizedImage, resizeImage } from "./utils/image-resize.ts";
+ export { getShellConfig } from "./utils/shell.ts";
++export { prepareCompaction } from "./core/compaction/compaction.ts";
+ //# sourceMappingURL=index.d.ts.map
+\ No newline at end of file
+diff --git a/dist/index.js b/dist/index.js
+index f88223cbb2ef8a290b4793755f92a8199edc0520..ac40b0d9b34689ba5463e3c61610748036de3588 100644
+--- a/dist/index.js
++++ b/dist/index.js
+@@ -41,4 +41,5 @@ export { convertToPng } from "./utils/image-convert.js";
+ export { formatDimensionNote, resizeImage } from "./utils/image-resize.js";
+ // Shell utilities
+ export { getShellConfig } from "./utils/shell.js";
++export { prepareCompaction } from "./core/compaction/compaction.js";
+ //# sourceMappingURL=index.js.map
+\ No newline at end of file
 diff --git a/dist/modes/interactive/components/branch-summary-message.js b/dist/modes/interactive/components/branch-summary-message.js
 index e23ca6db02a29814112dd4945bd868604eb6676f..d0f6fd7aeb79c6a20655805152a30970f1b4cc2a 100644
 --- a/dist/modes/interactive/components/branch-summary-message.js

--- a/patches/@earendil-works__pi-coding-agent@0.79.10.patch
+++ b/patches/@earendil-works__pi-coding-agent@0.79.10.patch
@@ -58,13 +58,6 @@
 # separate PR to add previewTheme + showError to ExtensionUIContext.
 # Issue: TODO — file against https://github.com/earendil-works/pi-mono once the
 # API design is confirmed stable.
-#   9. dist/index.js, dist/index.d.ts — re-export prepareCompaction from the package
-#                                 root. Kimchi's inline compaction (src/upstream-inline-compact-patch.ts)
-#                                 needs it, and the package exports map blocks deep imports.
-#                                 A runtime dynamic import of dist/core/compaction/index.js is
-#                                 not an option: it breaks in the Bun-compiled binary (no
-#                                 node_modules on disk) and Bun rejects detached import.meta.resolve.
-#
 #
 # Removal criteria:
 #   - Items 1-3 (before_provider_headers): upstream pi-mono ships BeforeProviderHeadersEvent
@@ -81,8 +74,6 @@
 #     createLocalBashOperations destroys child stdio after a timeout kill (or
 #     waitForChildProcess gains a max-wait that forces resolution), and the
 #     fixed version is pinned in package.json.
-#   - Item 9 (prepareCompaction export): upstream pi-coding-agent exports prepareCompaction
-#     from its root entry (or a public subpath) and the fixed version is pinned in package.json.
 #
 diff --git a/dist/cli/args.js b/dist/cli/args.js
 index 6bd8f43b4402dbd24f9262c4c059b2c06693a79c..ad705421fb9087efd8ad2cfbfe8709d198245751 100644
@@ -336,28 +327,6 @@ index bf8a79ebfdbe23415cd1effdd3db0b9ebfd804bc..f69116ceafe8ee7f1e2dbfeaa37f60c5
  }
  function buildEditCallComponent(component, args, theme, cwd) {
      component.setBgFn(getEditHeaderBg(component.preview, component.settledError, theme));
-diff --git a/dist/index.d.ts b/dist/index.d.ts
-index 9258752ae4c5e67408c12d060da02675082d13c4..a91910ce4daad14aa98b99f34b9331a620d2b28d 100644
---- a/dist/index.d.ts
-+++ b/dist/index.d.ts
-@@ -28,4 +28,5 @@ export { parseFrontmatter, stripFrontmatter } from "./utils/frontmatter.ts";
- export { convertToPng } from "./utils/image-convert.ts";
- export { formatDimensionNote, type ResizedImage, resizeImage } from "./utils/image-resize.ts";
- export { getShellConfig } from "./utils/shell.ts";
-+export { prepareCompaction } from "./core/compaction/compaction.ts";
- //# sourceMappingURL=index.d.ts.map
-\ No newline at end of file
-diff --git a/dist/index.js b/dist/index.js
-index f88223cbb2ef8a290b4793755f92a8199edc0520..ac40b0d9b34689ba5463e3c61610748036de3588 100644
---- a/dist/index.js
-+++ b/dist/index.js
-@@ -41,4 +41,5 @@ export { convertToPng } from "./utils/image-convert.js";
- export { formatDimensionNote, resizeImage } from "./utils/image-resize.js";
- // Shell utilities
- export { getShellConfig } from "./utils/shell.js";
-+export { prepareCompaction } from "./core/compaction/compaction.js";
- //# sourceMappingURL=index.js.map
-\ No newline at end of file
 diff --git a/dist/modes/interactive/components/branch-summary-message.js b/dist/modes/interactive/components/branch-summary-message.js
 index e23ca6db02a29814112dd4945bd868604eb6676f..d0f6fd7aeb79c6a20655805152a30970f1b4cc2a 100644
 --- a/dist/modes/interactive/components/branch-summary-message.js

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9,7 +9,7 @@ patchedDependencies:
     hash: a9d385c837d7062a1b38fd9d81d5405543cf7149753ed9a67f685e520913453e
     path: patches/@earendil-works__pi-ai@0.79.10.patch
   '@earendil-works/pi-coding-agent@0.79.10':
-    hash: e932ee4224492c7fab0450757ab60961b91c992679462f8744e33092c95585be
+    hash: b705733807eabdc6da06b9dc1e51f56acc109fb0165c108ada3fef855044b274
     path: patches/@earendil-works__pi-coding-agent@0.79.10.patch
   '@earendil-works/pi-tui@0.79.10':
     hash: 3651856bfe24d881276c225f7ae61b415aaea13347e8667a70d24a3e0e1b3a38
@@ -33,7 +33,7 @@ importers:
         version: 1.3.0
       '@earendil-works/pi-coding-agent':
         specifier: 0.79.10
-        version: 0.79.10(patch_hash=e932ee4224492c7fab0450757ab60961b91c992679462f8744e33092c95585be)(@modelcontextprotocol/sdk@1.29.0(supports-color@10.2.2)(zod@4.4.3))(supports-color@10.2.2)(ws@8.20.1)(zod@4.4.3)
+        version: 0.79.10(patch_hash=b705733807eabdc6da06b9dc1e51f56acc109fb0165c108ada3fef855044b274)(@modelcontextprotocol/sdk@1.29.0(supports-color@10.2.2)(zod@4.4.3))(supports-color@10.2.2)(ws@8.20.1)(zod@4.4.3)
       '@earendil-works/pi-tui':
         specifier: 0.79.10
         version: 0.79.10(patch_hash=3651856bfe24d881276c225f7ae61b415aaea13347e8667a70d24a3e0e1b3a38)
@@ -2827,7 +2827,7 @@ snapshots:
       - ws
       - zod
 
-  '@earendil-works/pi-coding-agent@0.79.10(patch_hash=e932ee4224492c7fab0450757ab60961b91c992679462f8744e33092c95585be)(@modelcontextprotocol/sdk@1.29.0(supports-color@10.2.2)(zod@4.4.3))(supports-color@10.2.2)(ws@8.20.1)(zod@4.4.3)':
+  '@earendil-works/pi-coding-agent@0.79.10(patch_hash=b705733807eabdc6da06b9dc1e51f56acc109fb0165c108ada3fef855044b274)(@modelcontextprotocol/sdk@1.29.0(supports-color@10.2.2)(zod@4.4.3))(supports-color@10.2.2)(ws@8.20.1)(zod@4.4.3)':
     dependencies:
       '@earendil-works/pi-agent-core': 0.79.10(@modelcontextprotocol/sdk@1.29.0(supports-color@10.2.2)(zod@4.4.3))(supports-color@10.2.2)(ws@8.20.1)(zod@4.4.3)
       '@earendil-works/pi-ai': 0.79.10(patch_hash=a9d385c837d7062a1b38fd9d81d5405543cf7149753ed9a67f685e520913453e)(@modelcontextprotocol/sdk@1.29.0(supports-color@10.2.2)(zod@4.4.3))(supports-color@10.2.2)(ws@8.20.1)(zod@4.4.3)

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9,7 +9,7 @@ patchedDependencies:
     hash: a9d385c837d7062a1b38fd9d81d5405543cf7149753ed9a67f685e520913453e
     path: patches/@earendil-works__pi-ai@0.79.10.patch
   '@earendil-works/pi-coding-agent@0.79.10':
-    hash: b705733807eabdc6da06b9dc1e51f56acc109fb0165c108ada3fef855044b274
+    hash: e821592e009160d9501e7047340e284867de484433216a8f9c5a9a4c05fd4322
     path: patches/@earendil-works__pi-coding-agent@0.79.10.patch
   '@earendil-works/pi-tui@0.79.10':
     hash: 3651856bfe24d881276c225f7ae61b415aaea13347e8667a70d24a3e0e1b3a38
@@ -33,7 +33,7 @@ importers:
         version: 1.3.0
       '@earendil-works/pi-coding-agent':
         specifier: 0.79.10
-        version: 0.79.10(patch_hash=b705733807eabdc6da06b9dc1e51f56acc109fb0165c108ada3fef855044b274)(@modelcontextprotocol/sdk@1.29.0(supports-color@10.2.2)(zod@4.4.3))(supports-color@10.2.2)(ws@8.20.1)(zod@4.4.3)
+        version: 0.79.10(patch_hash=e821592e009160d9501e7047340e284867de484433216a8f9c5a9a4c05fd4322)(@modelcontextprotocol/sdk@1.29.0(supports-color@10.2.2)(zod@4.4.3))(supports-color@10.2.2)(ws@8.20.1)(zod@4.4.3)
       '@earendil-works/pi-tui':
         specifier: 0.79.10
         version: 0.79.10(patch_hash=3651856bfe24d881276c225f7ae61b415aaea13347e8667a70d24a3e0e1b3a38)
@@ -2827,7 +2827,7 @@ snapshots:
       - ws
       - zod
 
-  '@earendil-works/pi-coding-agent@0.79.10(patch_hash=b705733807eabdc6da06b9dc1e51f56acc109fb0165c108ada3fef855044b274)(@modelcontextprotocol/sdk@1.29.0(supports-color@10.2.2)(zod@4.4.3))(supports-color@10.2.2)(ws@8.20.1)(zod@4.4.3)':
+  '@earendil-works/pi-coding-agent@0.79.10(patch_hash=e821592e009160d9501e7047340e284867de484433216a8f9c5a9a4c05fd4322)(@modelcontextprotocol/sdk@1.29.0(supports-color@10.2.2)(zod@4.4.3))(supports-color@10.2.2)(ws@8.20.1)(zod@4.4.3)':
     dependencies:
       '@earendil-works/pi-agent-core': 0.79.10(@modelcontextprotocol/sdk@1.29.0(supports-color@10.2.2)(zod@4.4.3))(supports-color@10.2.2)(ws@8.20.1)(zod@4.4.3)
       '@earendil-works/pi-ai': 0.79.10(patch_hash=a9d385c837d7062a1b38fd9d81d5405543cf7149753ed9a67f685e520913453e)(@modelcontextprotocol/sdk@1.29.0(supports-color@10.2.2)(zod@4.4.3))(supports-color@10.2.2)(ws@8.20.1)(zod@4.4.3)

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -130,6 +130,7 @@ import resourceToolBlockerExtension from "./resources/tool-blocker.js"
 import { runSetupWizard } from "./setup-wizard.js"
 import { setAvailableModels } from "./startup-context.js"
 import { probeTerminalBackground } from "./terminal-bg-probe.js"
+import { installInlineCompactPatch } from "./upstream-inline-compact-patch.js"
 import { installInfrastructureRetryPatch } from "./upstream-retry-patch.js"
 import {
 	postProcessHtmlExport,
@@ -141,6 +142,7 @@ import { captureSessionStart } from "./utils/session-metadata-store.js"
 import { getVersion } from "./utils.js"
 
 installInfrastructureRetryPatch()
+installInlineCompactPatch()
 installPiNativeCompatibilityShim()
 
 function isModelCompletionFetch(input: RequestInfo | URL): boolean {

--- a/src/extensions/ferment/auto-compaction.test.ts
+++ b/src/extensions/ferment/auto-compaction.test.ts
@@ -1300,6 +1300,73 @@ describe("maybeTriggerMidTurnFermentCompaction", () => {
 		expect(runtime.isCompactionInFlight(ferment.id)).toBe(false)
 		expect(ctx.ui?.notify).toHaveBeenCalledWith(expect.stringContaining("sync compact failure"), "warning")
 	})
+
+	it("prefers ctx.inlineCompact over ctx.compact and schedules resume on success", async () => {
+		const ferment = makeFermentWithPhase()
+		ferment.phases[0].status = "active"
+		ferment.phases[0].steps[0].status = "running"
+		const runtime = makeMidTurnRuntime(ferment)
+		const pi = makePi()
+		const ctx = makeMidTurnCtx()
+		ctx.inlineCompact = vi.fn(async () => ({
+			summary: "compacted",
+			firstKeptEntryId: "entry-1",
+			tokensBefore: 88_000,
+		}))
+
+		await maybeTriggerMidTurnFermentCompaction(pi, ctx, runtime, CONTEXT_WINDOW - 1)
+
+		expect(ctx.compact).not.toHaveBeenCalled()
+		expect(ctx.inlineCompact).toHaveBeenCalledWith(
+			expect.objectContaining({
+				customInstructions: expect.stringContaining("In-progress step"),
+				force: true,
+				// 5% of the 100k window is 5k — clamped up to the 20k floor.
+				keepRecentTokens: 20_000,
+				thinkingLevel: "off",
+			}),
+		)
+		expect(runtime.isCompactionInFlight(ferment.id)).toBe(false)
+		expect(pi.appendEntry).toHaveBeenCalledWith(
+			"ferment_breadcrumb",
+			expect.objectContaining({ text: expect.stringContaining("Mid-turn compaction resume") }),
+		)
+	})
+
+	it("clears in-flight and notifies when inlineCompact rejects with an unexpected error", async () => {
+		const ferment = makeFermentWithPhase()
+		ferment.phases[0].status = "active"
+		ferment.phases[0].steps[0].status = "running"
+		const runtime = makeMidTurnRuntime(ferment)
+		const pi = makePi()
+		const ctx = makeMidTurnCtx()
+		ctx.inlineCompact = vi.fn(async () => {
+			throw new Error("disk full")
+		})
+
+		await maybeTriggerMidTurnFermentCompaction(pi, ctx, runtime, CONTEXT_WINDOW - 1)
+
+		expect(ctx.compact).not.toHaveBeenCalled()
+		expect(runtime.isCompactionInFlight(ferment.id)).toBe(false)
+		expect(ctx.ui?.notify).toHaveBeenCalledWith(expect.stringContaining("disk full"), "warning")
+	})
+
+	it("clears in-flight without notifying when inlineCompact rejects with an expected error", async () => {
+		const ferment = makeFermentWithPhase()
+		ferment.phases[0].status = "active"
+		ferment.phases[0].steps[0].status = "running"
+		const runtime = makeMidTurnRuntime(ferment)
+		const pi = makePi()
+		const ctx = makeMidTurnCtx()
+		ctx.inlineCompact = vi.fn(async () => {
+			throw new Error("no summarizable messages")
+		})
+
+		await maybeTriggerMidTurnFermentCompaction(pi, ctx, runtime, CONTEXT_WINDOW - 1)
+
+		expect(runtime.isCompactionInFlight(ferment.id)).toBe(false)
+		expect(ctx.ui?.notify).not.toHaveBeenCalled()
+	})
 })
 
 describe("in-flight tool-call guard", () => {

--- a/src/extensions/ferment/auto-compaction.test.ts
+++ b/src/extensions/ferment/auto-compaction.test.ts
@@ -19,10 +19,10 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
 import type { Ferment, Phase, Step } from "../../ferment/types.js"
 import { applyRoleAugmentation, resetModelRolesCache } from "../orchestration/model-roles.js"
 import {
-	DEFAULT_STAGE_COMPACTION_OPTIONS,
 	buildCustomInstructions,
 	buildHandoffDetails,
 	buildMidTurnCustomInstructions,
+	DEFAULT_STAGE_COMPACTION_OPTIONS,
 	isToolCallInFlight,
 	isToolCallInFlightInSession,
 	maybeTriggerFermentCompaction,

--- a/src/extensions/ferment/auto-compaction.test.ts
+++ b/src/extensions/ferment/auto-compaction.test.ts
@@ -7,6 +7,7 @@
  * 3. maybeTriggerFermentCompaction — integration: no-op, trigger, onComplete, onError, in-flight guard
  */
 
+import type { AssistantMessage, ToolResultMessage, UserMessage } from "@earendil-works/pi-ai"
 import type { CompactionResult, ExtensionAPI, ExtensionContext, SessionEntry } from "@earendil-works/pi-coding-agent"
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
 import type { Ferment, Phase, Step } from "../../ferment/types.js"
@@ -95,6 +96,7 @@ function makeCtx(): ExtensionContext {
 		},
 		sessionManager: {
 			getEntries: vi.fn(() => []),
+			getLeafId: vi.fn(() => null),
 			appendCustomMessageEntry: vi.fn(),
 		},
 	} as unknown as ExtensionContext
@@ -175,6 +177,15 @@ function makeSessionMessageEntry(message: unknown): SessionEntry {
 		timestamp: NOW,
 		message,
 	} as unknown as SessionEntry
+}
+
+function setSessionEntries(ctx: ExtensionContext, entries: SessionEntry[]): void {
+	const linkedEntries = entries.map((entry, index) => ({
+		...entry,
+		parentId: index === 0 ? null : entries[index - 1].id,
+	})) as SessionEntry[]
+	ctx.sessionManager.getEntries = vi.fn(() => linkedEntries)
+	ctx.sessionManager.getLeafId = vi.fn(() => linkedEntries.at(-1)?.id ?? null)
 }
 
 // ─── Test suite ───────────────────────────────────────────────────────────────
@@ -1160,57 +1171,57 @@ describe("in-flight tool-call guard", () => {
 	})
 
 	describe("isToolCallInFlight", () => {
+		const assistant = (content: AssistantMessage["content"]): AssistantMessage => ({
+			role: "assistant",
+			content,
+			api: "anthropic-messages",
+			provider: "anthropic",
+			model: "test-model",
+			usage: {
+				input: 0,
+				output: 0,
+				cacheRead: 0,
+				cacheWrite: 0,
+				totalTokens: 0,
+				cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+			},
+			stopReason: "toolUse",
+			timestamp: Date.now(),
+		})
+		const toolResult = (toolCallId: string): ToolResultMessage => ({
+			role: "toolResult",
+			toolCallId,
+			toolName: "test-tool",
+			content: [{ type: "text", text: "done" }],
+			isError: false,
+			timestamp: Date.now(),
+		})
+		const user = (content: string): UserMessage => ({ role: "user", content, timestamp: Date.now() })
+		const toolCall = (id: string) => ({ type: "toolCall" as const, id, name: "test-tool", arguments: {} })
+
 		it("returns true when a toolCall has no matching toolResult", () => {
-			const messages = [
-				{
-					role: "assistant",
-					content: [{ type: "toolCall", id: "call-1" }],
-				},
-			]
-			expect(isToolCallInFlight(messages)).toBe(true)
+			expect(isToolCallInFlight([assistant([toolCall("call-1")])])).toBe(true)
 		})
 
 		it("returns false when the matching toolResult is present", () => {
-			const messages = [
-				{
-					role: "assistant",
-					content: [{ type: "toolCall", id: "call-1" }],
-				},
-				{ role: "toolResult", toolCallId: "call-1" },
-			]
-			expect(isToolCallInFlight(messages)).toBe(false)
+			expect(isToolCallInFlight([assistant([toolCall("call-1")]), toolResult("call-1")])).toBe(false)
 		})
 
 		it("returns false for empty arrays and messages with no tool calls", () => {
 			expect(isToolCallInFlight([])).toBe(false)
-			expect(isToolCallInFlight([{ role: "user", content: "hi" }])).toBe(false)
-			expect(isToolCallInFlight([{ role: "assistant", content: [{ type: "text" }] }])).toBe(false)
+			expect(isToolCallInFlight([user("hi")])).toBe(false)
+			expect(isToolCallInFlight([assistant([{ type: "text", text: "done" }])])).toBe(false)
 		})
 
 		it("returns true when only some toolCalls have matching toolResults", () => {
-			const messages = [
-				{
-					role: "assistant",
-					content: [
-						{ type: "toolCall", id: "call-1" },
-						{ type: "toolCall", id: "call-2" },
-					],
-				},
-				{ role: "toolResult", toolCallId: "call-1" },
-			]
+			const messages = [assistant([toolCall("call-1"), toolCall("call-2")]), toolResult("call-1")]
 			expect(isToolCallInFlight(messages)).toBe(true)
-		})
-
-		it("returns false for malformed input without throwing", () => {
-			const malformed = [null, { role: "user" }, { role: "assistant", content: "not-an-array" }]
-			expect(() => isToolCallInFlight(malformed)).not.toThrow()
-			expect(isToolCallInFlight(malformed)).toBe(false)
 		})
 	})
 
 	describe("isToolCallInFlightInSession", () => {
 		it("returns true when the session contains an in-flight toolCall", () => {
-			ctx.sessionManager.getEntries = vi.fn(() => [
+			setSessionEntries(ctx, [
 				makeSessionMessageEntry({
 					role: "assistant",
 					content: [{ type: "toolCall", id: "call-1" }],
@@ -1220,7 +1231,7 @@ describe("in-flight tool-call guard", () => {
 		})
 
 		it("returns false when the session has a completed toolCall pair", () => {
-			ctx.sessionManager.getEntries = vi.fn(() => [
+			setSessionEntries(ctx, [
 				makeSessionMessageEntry({
 					role: "assistant",
 					content: [{ type: "toolCall", id: "call-1" }],
@@ -1246,7 +1257,7 @@ describe("in-flight tool-call guard", () => {
 			runtime.setActive(ferment)
 			setPendingCompaction(ferment.id, makePendingStep(ferment.id, "phase-1", "step-1"))
 
-			ctx.sessionManager.getEntries = vi.fn(() => [
+			setSessionEntries(ctx, [
 				makeSessionMessageEntry({
 					role: "assistant",
 					content: [{ type: "toolCall", id: "call-in-flight" }],
@@ -1268,7 +1279,7 @@ describe("in-flight tool-call guard", () => {
 			runtime.setActive(ferment)
 			setPendingCompaction(ferment.id, makePendingStep(ferment.id, "phase-1", "step-1"))
 
-			ctx.sessionManager.getEntries = vi.fn(() => [
+			setSessionEntries(ctx, [
 				makeSessionMessageEntry({
 					role: "assistant",
 					content: [{ type: "toolCall", id: "call-done" }],

--- a/src/extensions/ferment/auto-compaction.test.ts
+++ b/src/extensions/ferment/auto-compaction.test.ts
@@ -31,6 +31,7 @@ import { clearPendingCompaction, type PendingCompaction, setPendingCompaction } 
 // ─── Helpers ──────────────────────────────────────────────────────────────────
 
 const NOW = "2026-01-01T00:00:00.000Z"
+const STALE_CTX_MESSAGE = "This extension ctx is stale after session replacement or reload"
 
 function makeStep(overrides: Partial<Step> & { id: string; description: string }): Step {
 	return {
@@ -494,6 +495,24 @@ describe("maybeTriggerFermentCompaction", () => {
 		expect(runtime.getPendingCompaction(ferment.id)).toBeDefined()
 	})
 
+	it("leaves pending compaction untouched when the one-shot flag read hits a stale pi", async () => {
+		const ferment = makeFermentWithPhase(
+			{ id: "phase-1", name: "Phase", goal: "Goal" },
+			{ id: "step-1", description: "Do it" },
+		)
+		storageMap.set(ferment.id, ferment)
+		runtime.setActive(ferment)
+		setPendingCompaction(ferment.id, makePendingStep(ferment.id, "phase-1", "step-1"))
+		pi.getFlag = vi.fn(() => {
+			throw new Error(STALE_CTX_MESSAGE)
+		})
+
+		await maybeTriggerFermentCompaction(pi, ctx, runtime)
+
+		expect(ctx.compact).not.toHaveBeenCalled()
+		expect(runtime.getPendingCompaction(ferment.id)).toBeDefined()
+	})
+
 	it("appends the handoff before one-shot inline compaction and schedules continuation after", async () => {
 		const ferment = makeFermentWithPhase(
 			{ id: "phase-1", name: "Phase", goal: "Goal" },
@@ -531,14 +550,13 @@ describe("maybeTriggerFermentCompaction", () => {
 		// the newest valid cut point, so the cut lands on it and the next stage
 		// keeps summary + handoff.
 		expect(appendCustomMessageEntryMock(ctx)).toHaveBeenCalledTimes(1)
-		const handoffCall = appendCustomMessageEntryMock(ctx).mock.calls[0]
-		expect(handoffCall[0]).toBe("ferment_stage_handoff")
-		expect(handoffCall[1]).toEqual([{ type: "text", text: expect.stringContaining('"fermentName":"My Ferment"') }])
-		expect(handoffCall[2]).toBe(false)
-		expect(handoffCall[3]).toMatchObject({ fermentName: "My Ferment" })
-		// Pre-compaction handoffs carry no token count — success is signalled by
-		// the compaction entry itself.
-		expect((handoffCall[3] as { compactionTokensBefore?: number }).compactionTokensBefore).toBeUndefined()
+		const [customType, content, display, details] = appendCustomMessageEntryMock(ctx).mock.calls[0]
+		expect({ customType, content, display, details }).toMatchObject({
+			customType: "ferment_stage_handoff",
+			content: [{ type: "text", text: expect.stringContaining('"fermentName":"My Ferment"') }],
+			display: false,
+			details: { fermentName: "My Ferment", compactionTokensBefore: undefined },
+		})
 		expect(pi.sendMessage).not.toHaveBeenCalled()
 		expect(pi.appendEntry).not.toHaveBeenCalled()
 
@@ -611,8 +629,11 @@ describe("maybeTriggerFermentCompaction", () => {
 		await maybeTriggerFermentCompaction(pi, ctx, runtime)
 
 		expect(find).not.toHaveBeenCalled()
-		const call = (ctx.inlineCompact as ReturnType<typeof vi.fn>).mock.calls[0][0] as { model?: unknown }
-		expect(call.model).toBeUndefined()
+		expect(ctx.inlineCompact).toHaveBeenCalledWith(
+			expect.not.objectContaining({
+				model: expect.anything(),
+			}),
+		)
 	})
 
 	it("warns when the compactor ref is configured but not in the registry", async () => {
@@ -1031,6 +1052,23 @@ describe("maybeTriggerMidTurnFermentCompaction", () => {
 				text: expect.stringContaining("Mid-turn context overrun in oneshot"),
 			}),
 		)
+	})
+
+	it("no-ops when the one-shot flag read hits a stale pi", () => {
+		const ferment = makeFermentWithPhase()
+		ferment.phases[0].status = "active"
+		ferment.phases[0].steps[0].status = "running"
+		const runtime = makeMidTurnRuntime(ferment)
+		const pi = makePi()
+		pi.getFlag = vi.fn(() => {
+			throw new Error(STALE_CTX_MESSAGE)
+		})
+		const ctx = makeMidTurnCtx()
+
+		maybeTriggerMidTurnFermentCompaction(pi, ctx, runtime, CONTEXT_WINDOW - 1)
+
+		expect(ctx.compact).not.toHaveBeenCalled()
+		expect(pi.appendEntry).not.toHaveBeenCalled()
 	})
 
 	it("onError with an expected error clears in-flight without notifying", () => {

--- a/src/extensions/ferment/auto-compaction.test.ts
+++ b/src/extensions/ferment/auto-compaction.test.ts
@@ -426,26 +426,26 @@ describe("maybeTriggerFermentCompaction", () => {
 		vi.restoreAllMocks()
 	})
 
-	it("returns immediately when no ferment is active", () => {
+	it("returns immediately when no ferment is active", async () => {
 		runtime = makeRuntime({
 			getStorage: () => mockStorage as unknown as import("../../ferment/event-store.js").FermentEventStore,
 			getActiveId: () => undefined,
 		})
 
-		maybeTriggerFermentCompaction(pi, ctx, runtime)
+		await maybeTriggerFermentCompaction(pi, ctx, runtime)
 
 		expect(ctx.compact).not.toHaveBeenCalled()
 	})
 
-	it("returns immediately when no pending compaction exists", () => {
+	it("returns immediately when no pending compaction exists", async () => {
 		runtime.setActive(makeFerment({ id: "ferment-1", name: "No Pending" }))
 
-		maybeTriggerFermentCompaction(pi, ctx, runtime)
+		await maybeTriggerFermentCompaction(pi, ctx, runtime)
 
 		expect(ctx.compact).not.toHaveBeenCalled()
 	})
 
-	it("calls ctx.compact() with customInstructions when pending compaction exists", () => {
+	it("calls ctx.compact() with customInstructions when pending compaction exists and inlineCompact is unavailable", async () => {
 		const ferment = makeFermentWithPhase(
 			{ id: "phase-1", name: "Phase", goal: "Goal" },
 			{ id: "step-1", description: "Do it" },
@@ -454,7 +454,7 @@ describe("maybeTriggerFermentCompaction", () => {
 		runtime.setActive(ferment)
 		setPendingCompaction(ferment.id, makePendingStep(ferment.id, "phase-1", "step-1"))
 
-		maybeTriggerFermentCompaction(pi, ctx, runtime)
+		await maybeTriggerFermentCompaction(pi, ctx, runtime)
 
 		expect(ctx.compact).toHaveBeenCalledTimes(1)
 		const call = (ctx.compact as ReturnType<typeof vi.fn>).mock.calls[0][0] as {
@@ -465,7 +465,107 @@ describe("maybeTriggerFermentCompaction", () => {
 		expect(call.customInstructions).toContain("Do it")
 	})
 
-	it("clears pending compaction after triggering", () => {
+	it("keeps one-shot stage compaction disabled when inlineCompact is unavailable", async () => {
+		const ferment = makeFermentWithPhase(
+			{ id: "phase-1", name: "Phase", goal: "Goal" },
+			{ id: "step-1", description: "Do it" },
+		)
+		storageMap.set(ferment.id, ferment)
+		runtime.setActive(ferment)
+		setPendingCompaction(ferment.id, makePendingStep(ferment.id, "phase-1", "step-1"))
+		pi.getFlag = vi.fn((name) => (name === "ferment-oneshot" ? true : undefined))
+
+		await maybeTriggerFermentCompaction(pi, ctx, runtime)
+
+		expect(ctx.compact).not.toHaveBeenCalled()
+		expect(runtime.getPendingCompaction(ferment.id)).toBeDefined()
+	})
+
+	it("awaits one-shot inline compaction before appending handoff and scheduling continuation", async () => {
+		const ferment = makeFermentWithPhase(
+			{ id: "phase-1", name: "Phase", goal: "Goal" },
+			{ id: "step-1", description: "Do it" },
+		)
+		storageMap.set(ferment.id, ferment)
+		runtime.setActive(ferment)
+		setPendingCompaction(ferment.id, makePendingStep(ferment.id, "phase-1", "step-1"))
+		pi.getFlag = vi.fn((name) => (name === "ferment-oneshot" ? true : undefined))
+
+		let resolveInline!: (result: CompactionResult) => void
+		const inlineResult = new Promise<CompactionResult>((resolve) => {
+			resolveInline = resolve
+		})
+		ctx.inlineCompact = vi.fn(() => inlineResult)
+
+		const run = maybeTriggerFermentCompaction(pi, ctx, runtime)
+		await Promise.resolve()
+
+		expect(ctx.compact).not.toHaveBeenCalled()
+		expect(ctx.inlineCompact).toHaveBeenCalledWith({
+			customInstructions: expect.stringContaining("Ferment: My Ferment"),
+			force: true,
+		})
+		expect(pi.sendMessage).not.toHaveBeenCalled()
+
+		resolveInline({
+			summary: "compacted ferment",
+			firstKeptEntryId: "entry-1",
+			tokensBefore: 123_456,
+		})
+		await run
+
+		expect(pi.sendMessage).toHaveBeenCalledTimes(2)
+		const calls = vi.mocked(pi.sendMessage).mock.calls
+		expect(calls[0][0]).toMatchObject({
+			customType: "ferment_stage_handoff",
+			display: false,
+			details: expect.objectContaining({
+				fermentName: "My Ferment",
+				compactionTokensBefore: 123_456,
+			}),
+		})
+		expect(calls[0][1]).toMatchObject({ triggerTurn: false })
+		expect(calls[1][0]).toMatchObject({ customType: "ferment_continuation_nudge" })
+		expect(calls[1][1]).toMatchObject({ triggerTurn: true })
+	})
+
+	it("continues one-shot ferment after inline compaction is skipped", async () => {
+		const ferment = makeFermentWithPhase(
+			{ id: "phase-1", name: "Phase", goal: "Goal" },
+			{ id: "step-1", description: "Do it" },
+		)
+		storageMap.set(ferment.id, ferment)
+		runtime.setActive(ferment)
+		setPendingCompaction(ferment.id, makePendingStep(ferment.id, "phase-1", "step-1"))
+		pi.getFlag = vi.fn((name) => (name === "ferment-oneshot" ? true : undefined))
+		ctx.inlineCompact = vi.fn(async () => {
+			throw new Error("Nothing to compact (session too small)")
+		})
+
+		await maybeTriggerFermentCompaction(pi, ctx, runtime)
+
+		expect(ctx.inlineCompact).toHaveBeenCalledWith({
+			customInstructions: expect.stringContaining("Ferment: My Ferment"),
+			force: true,
+		})
+		expect(ctx.ui.notify).not.toHaveBeenCalled()
+		expect(runtime.isCompactionInFlight(ferment.id)).toBe(false)
+		expect(pi.sendMessage).toHaveBeenCalledTimes(2)
+		const calls = vi.mocked(pi.sendMessage).mock.calls
+		expect(calls[0][0]).toMatchObject({
+			customType: "ferment_stage_handoff",
+			display: false,
+			details: expect.objectContaining({
+				fermentName: "My Ferment",
+				compactionTokensBefore: 0,
+			}),
+		})
+		expect(calls[0][1]).toMatchObject({ triggerTurn: false })
+		expect(calls[1][0]).toMatchObject({ customType: "ferment_continuation_nudge" })
+		expect(calls[1][1]).toMatchObject({ triggerTurn: true })
+	})
+
+	it("clears pending compaction after triggering", async () => {
 		const ferment = makeFermentWithPhase(
 			{ id: "phase-1", name: "Phase", goal: "Goal" },
 			{ id: "step-1", description: "Step" },
@@ -474,12 +574,12 @@ describe("maybeTriggerFermentCompaction", () => {
 		runtime.setActive(ferment)
 		setPendingCompaction(ferment.id, makePendingStep(ferment.id, "phase-1", "step-1"))
 
-		maybeTriggerFermentCompaction(pi, ctx, runtime)
+		await maybeTriggerFermentCompaction(pi, ctx, runtime)
 
 		expect(runtime.getPendingCompaction(ferment.id)).toBeUndefined()
 	})
 
-	it("onComplete calls pi.sendMessage with ferment_stage_handoff and display: false", () => {
+	it("onComplete calls pi.sendMessage with ferment_stage_handoff and display: false", async () => {
 		const ferment = makeFermentWithPhase(
 			{ id: "phase-1", name: "Phase", goal: "Goal" },
 			{ id: "step-1", description: "Step" },
@@ -488,7 +588,7 @@ describe("maybeTriggerFermentCompaction", () => {
 		runtime.setActive(ferment)
 		setPendingCompaction(ferment.id, makePendingStep(ferment.id, "phase-1", "step-1"))
 
-		maybeTriggerFermentCompaction(pi, ctx, runtime)
+		await maybeTriggerFermentCompaction(pi, ctx, runtime)
 
 		const compactCall = (ctx.compact as ReturnType<typeof vi.fn>).mock.calls[0][0] as {
 			onComplete: (result: CompactionResult) => void
@@ -516,7 +616,7 @@ describe("maybeTriggerFermentCompaction", () => {
 		expect(sendMsgCalls[1][1]).toMatchObject({ triggerTurn: true })
 	})
 
-	it("onError calls ctx.ui.notify with a warning and does not throw", () => {
+	it("onError calls ctx.ui.notify with a warning and does not throw", async () => {
 		const ferment = makeFermentWithPhase(
 			{ id: "phase-1", name: "Phase", goal: "Goal" },
 			{ id: "step-1", description: "Step" },
@@ -525,7 +625,7 @@ describe("maybeTriggerFermentCompaction", () => {
 		runtime.setActive(ferment)
 		setPendingCompaction(ferment.id, makePendingStep(ferment.id, "phase-1", "step-1"))
 
-		maybeTriggerFermentCompaction(pi, ctx, runtime)
+		await maybeTriggerFermentCompaction(pi, ctx, runtime)
 
 		const compactCall = (ctx.compact as ReturnType<typeof vi.fn>).mock.calls[0][0] as {
 			onComplete: (result: CompactionResult) => void
@@ -539,7 +639,7 @@ describe("maybeTriggerFermentCompaction", () => {
 		expect(notifyCall[1]).toBe("warning")
 	})
 
-	it("in-flight guard: a new pending while compaction is running is left for the next tick", () => {
+	it("in-flight guard: a new pending while compaction is running is left for the next tick", async () => {
 		const ferment = makeFermentWithPhase(
 			{ id: "phase-1", name: "Phase", goal: "Goal" },
 			{ id: "step-1", description: "Step" },
@@ -549,7 +649,7 @@ describe("maybeTriggerFermentCompaction", () => {
 		setPendingCompaction(ferment.id, makePendingStep(ferment.id, "phase-1", "step-1"))
 
 		// First call — starts compaction, marks ferment in-flight.
-		maybeTriggerFermentCompaction(pi, ctx, runtime)
+		await maybeTriggerFermentCompaction(pi, ctx, runtime)
 		expect(ctx.compact).toHaveBeenCalledTimes(1)
 
 		// A new pending arrives while the first compaction is still running
@@ -558,7 +658,7 @@ describe("maybeTriggerFermentCompaction", () => {
 
 		// Second call — ferment is in-flight so drainPendingCompactions skips it;
 		// no additional compact() call is made.
-		maybeTriggerFermentCompaction(pi, ctx, runtime)
+		await maybeTriggerFermentCompaction(pi, ctx, runtime)
 		expect(ctx.compact).toHaveBeenCalledTimes(1)
 
 		// After onComplete fires, the in-flight flag is cleared.
@@ -568,11 +668,11 @@ describe("maybeTriggerFermentCompaction", () => {
 		compactCall.onComplete({ tokensBefore: 1000 } as unknown as CompactionResult)
 
 		// Now step-2 pending is still in the map and will fire on the next tick.
-		maybeTriggerFermentCompaction(pi, ctx, runtime)
+		await maybeTriggerFermentCompaction(pi, ctx, runtime)
 		expect(ctx.compact).toHaveBeenCalledTimes(2)
 	})
 
-	it("returns early when ferment is not found in storage after reload", () => {
+	it("returns early when ferment is not found in storage after reload", async () => {
 		runtime = makeRuntime({
 			getStorage: () => mockStorage as unknown as import("../../ferment/event-store.js").FermentEventStore,
 			getActiveId: () => "missing-ferment-id",
@@ -580,7 +680,7 @@ describe("maybeTriggerFermentCompaction", () => {
 		// Inject a pending compaction for a non-existent ferment
 		setPendingCompaction("missing-ferment-id", makePendingStep("missing-ferment-id", "phase-1", "step-1"))
 
-		expect(() => maybeTriggerFermentCompaction(pi, ctx, runtime)).not.toThrow()
+		await expect(maybeTriggerFermentCompaction(pi, ctx, runtime)).resolves.toBe(false)
 		expect(ctx.compact).not.toHaveBeenCalled()
 	})
 })
@@ -884,7 +984,7 @@ describe("in-flight tool-call guard", () => {
 	})
 
 	describe("maybeTriggerFermentCompaction", () => {
-		it("does not compact while a toolCall is in flight", () => {
+		it("does not compact while a toolCall is in flight", async () => {
 			const ferment = makeFermentWithPhase(
 				{ id: "phase-1", name: "Phase", goal: "Goal" },
 				{ id: "step-1", description: "Step" },
@@ -900,13 +1000,13 @@ describe("in-flight tool-call guard", () => {
 				}),
 			])
 
-			maybeTriggerFermentCompaction(pi, ctx, runtime)
+			await maybeTriggerFermentCompaction(pi, ctx, runtime)
 
 			expect(ctx.compact).not.toHaveBeenCalled()
 			expect(runtime.getPendingCompaction(ferment.id)).toBeDefined()
 		})
 
-		it("compacts normally once the matching toolResult lands", () => {
+		it("compacts normally once the matching toolResult lands", async () => {
 			const ferment = makeFermentWithPhase(
 				{ id: "phase-1", name: "Phase", goal: "Goal" },
 				{ id: "step-1", description: "Step" },
@@ -923,7 +1023,7 @@ describe("in-flight tool-call guard", () => {
 				makeSessionMessageEntry({ role: "toolResult", toolCallId: "call-done" }),
 			])
 
-			maybeTriggerFermentCompaction(pi, ctx, runtime)
+			await maybeTriggerFermentCompaction(pi, ctx, runtime)
 
 			expect(ctx.compact).toHaveBeenCalledOnce()
 			expect(runtime.getPendingCompaction(ferment.id)).toBeUndefined()

--- a/src/extensions/ferment/auto-compaction.test.ts
+++ b/src/extensions/ferment/auto-compaction.test.ts
@@ -526,10 +526,10 @@ describe("maybeTriggerFermentCompaction", () => {
 		})
 		expect(calls[0][1]).toMatchObject({ triggerTurn: false })
 		expect(calls[1][0]).toMatchObject({ customType: "ferment_continuation_nudge" })
-		expect(calls[1][1]).toMatchObject({ triggerTurn: true })
+		expect(calls[1][1]).toMatchObject({ triggerTurn: true, deliverAs: "steer" })
 	})
 
-	it("continues one-shot ferment after inline compaction is skipped", async () => {
+	it("appends a handoff without continuing when one-shot inline compaction is skipped", async () => {
 		const ferment = makeFermentWithPhase(
 			{ id: "phase-1", name: "Phase", goal: "Goal" },
 			{ id: "step-1", description: "Do it" },
@@ -550,7 +550,7 @@ describe("maybeTriggerFermentCompaction", () => {
 		})
 		expect(ctx.ui.notify).not.toHaveBeenCalled()
 		expect(runtime.isCompactionInFlight(ferment.id)).toBe(false)
-		expect(pi.sendMessage).toHaveBeenCalledTimes(2)
+		expect(pi.sendMessage).toHaveBeenCalledTimes(1)
 		const calls = vi.mocked(pi.sendMessage).mock.calls
 		expect(calls[0][0]).toMatchObject({
 			customType: "ferment_stage_handoff",
@@ -561,8 +561,6 @@ describe("maybeTriggerFermentCompaction", () => {
 			}),
 		})
 		expect(calls[0][1]).toMatchObject({ triggerTurn: false })
-		expect(calls[1][0]).toMatchObject({ customType: "ferment_continuation_nudge" })
-		expect(calls[1][1]).toMatchObject({ triggerTurn: true })
 	})
 
 	it("clears pending compaction after triggering", async () => {
@@ -613,7 +611,7 @@ describe("maybeTriggerFermentCompaction", () => {
 		expect(sendMsgCalls[1][0]).toMatchObject({
 			customType: "ferment_continuation_nudge",
 		})
-		expect(sendMsgCalls[1][1]).toMatchObject({ triggerTurn: true })
+		expect(sendMsgCalls[1][1]).toMatchObject({ triggerTurn: true, deliverAs: "steer" })
 	})
 
 	it("onError calls ctx.ui.notify with a warning and does not throw", async () => {

--- a/src/extensions/ferment/auto-compaction.test.ts
+++ b/src/extensions/ferment/auto-compaction.test.ts
@@ -93,8 +93,19 @@ function makeCtx(): ExtensionContext {
 		},
 		sessionManager: {
 			getEntries: vi.fn(() => []),
+			appendCustomMessageEntry: vi.fn(),
 		},
 	} as unknown as ExtensionContext
+}
+
+type AppendCustomMessageEntryMock = ReturnType<typeof vi.fn>
+
+function appendCustomMessageEntryMock(ctx: ExtensionContext): AppendCustomMessageEntryMock {
+	return (
+		ctx.sessionManager as unknown as {
+			appendCustomMessageEntry: AppendCustomMessageEntryMock
+		}
+	).appendCustomMessageEntry
 }
 
 // Simple in-memory storage for maybeTriggerFermentCompaction tests.
@@ -481,7 +492,7 @@ describe("maybeTriggerFermentCompaction", () => {
 		expect(runtime.getPendingCompaction(ferment.id)).toBeDefined()
 	})
 
-	it("awaits one-shot inline compaction before appending handoff and scheduling continuation", async () => {
+	it("appends the handoff before one-shot inline compaction and schedules continuation after", async () => {
 		const ferment = makeFermentWithPhase(
 			{ id: "phase-1", name: "Phase", goal: "Goal" },
 			{ id: "step-1", description: "Do it" },
@@ -495,7 +506,15 @@ describe("maybeTriggerFermentCompaction", () => {
 		const inlineResult = new Promise<CompactionResult>((resolve) => {
 			resolveInline = resolve
 		})
-		ctx.inlineCompact = vi.fn(() => inlineResult)
+		ctx.inlineCompact = vi.fn(() => {
+			expect(appendCustomMessageEntryMock(ctx)).toHaveBeenCalledWith(
+				"ferment_stage_handoff",
+				expect.any(Array),
+				false,
+				expect.objectContaining({ fermentName: "My Ferment" }),
+			)
+			return inlineResult
+		})
 
 		const run = maybeTriggerFermentCompaction(pi, ctx, runtime)
 		await Promise.resolve()
@@ -505,7 +524,20 @@ describe("maybeTriggerFermentCompaction", () => {
 			customInstructions: expect.stringContaining("Ferment: My Ferment"),
 			force: true,
 		})
+		// The handoff must already be in the session while compaction runs: it is
+		// the newest valid cut point, so the cut lands on it and the next stage
+		// keeps summary + handoff.
+		expect(appendCustomMessageEntryMock(ctx)).toHaveBeenCalledTimes(1)
+		const handoffCall = appendCustomMessageEntryMock(ctx).mock.calls[0]
+		expect(handoffCall[0]).toBe("ferment_stage_handoff")
+		expect(handoffCall[1]).toEqual([{ type: "text", text: expect.stringContaining('"fermentName":"My Ferment"') }])
+		expect(handoffCall[2]).toBe(false)
+		expect(handoffCall[3]).toMatchObject({ fermentName: "My Ferment" })
+		// Pre-compaction handoffs carry no token count — success is signalled by
+		// the compaction entry itself.
+		expect((handoffCall[3] as { compactionTokensBefore?: number }).compactionTokensBefore).toBeUndefined()
 		expect(pi.sendMessage).not.toHaveBeenCalled()
+		expect(pi.appendEntry).not.toHaveBeenCalled()
 
 		resolveInline({
 			summary: "compacted ferment",
@@ -514,19 +546,13 @@ describe("maybeTriggerFermentCompaction", () => {
 		})
 		await run
 
-		expect(pi.sendMessage).toHaveBeenCalledTimes(2)
-		const calls = vi.mocked(pi.sendMessage).mock.calls
-		expect(calls[0][0]).toMatchObject({
-			customType: "ferment_stage_handoff",
-			display: false,
-			details: expect.objectContaining({
-				fermentName: "My Ferment",
-				compactionTokensBefore: 123_456,
-			}),
+		expect(pi.appendEntry).toHaveBeenCalledWith("ferment_breadcrumb", {
+			text: expect.stringContaining("Stage compaction complete: 123,456 tokens"),
 		})
-		expect(calls[0][1]).toMatchObject({ triggerTurn: false })
-		expect(calls[1][0]).toMatchObject({ customType: "ferment_continuation_nudge" })
-		expect(calls[1][1]).toMatchObject({ triggerTurn: true, deliverAs: "steer" })
+		expect(pi.sendMessage).toHaveBeenCalledTimes(1)
+		const nudgeCall = vi.mocked(pi.sendMessage).mock.calls[0]
+		expect(nudgeCall[0]).toMatchObject({ customType: "ferment_continuation_nudge" })
+		expect(nudgeCall[1]).toMatchObject({ triggerTurn: true, deliverAs: "steer" })
 	})
 
 	it("appends a handoff without continuing when one-shot inline compaction is skipped", async () => {
@@ -550,17 +576,52 @@ describe("maybeTriggerFermentCompaction", () => {
 		})
 		expect(ctx.ui.notify).not.toHaveBeenCalled()
 		expect(runtime.isCompactionInFlight(ferment.id)).toBe(false)
-		expect(pi.sendMessage).toHaveBeenCalledTimes(1)
-		const calls = vi.mocked(pi.sendMessage).mock.calls
-		expect(calls[0][0]).toMatchObject({
-			customType: "ferment_stage_handoff",
-			display: false,
-			details: expect.objectContaining({
-				fermentName: "My Ferment",
-				compactionTokensBefore: 0,
-			}),
+		expect(appendCustomMessageEntryMock(ctx)).toHaveBeenCalledWith(
+			"ferment_stage_handoff",
+			expect.any(Array),
+			false,
+			expect.objectContaining({ fermentName: "My Ferment" }),
+		)
+		expect(pi.sendMessage).not.toHaveBeenCalled()
+		// The skip reason is persisted as a breadcrumb so headless runs stay
+		// diagnosable from session files alone.
+		expect(pi.appendEntry).toHaveBeenCalledWith("ferment_breadcrumb", {
+			text: "Stage compaction skipped: Nothing to compact (session too small)",
 		})
-		expect(calls[0][1]).toMatchObject({ triggerTurn: false })
+	})
+
+	it("persists unexpected inline compaction failures as a breadcrumb and warns", async () => {
+		const ferment = makeFermentWithPhase(
+			{ id: "phase-1", name: "Phase", goal: "Goal" },
+			{ id: "step-1", description: "Do it" },
+		)
+		storageMap.set(ferment.id, ferment)
+		runtime.setActive(ferment)
+		setPendingCompaction(ferment.id, makePendingStep(ferment.id, "phase-1", "step-1"))
+		pi.getFlag = vi.fn((name) => (name === "ferment-oneshot" ? true : undefined))
+		ctx.inlineCompact = vi.fn(async () => {
+			throw new Error("provider exploded")
+		})
+
+		await maybeTriggerFermentCompaction(pi, ctx, runtime)
+
+		// Unexpected errors still warn via the UI when one exists…
+		expect(ctx.ui.notify).toHaveBeenCalledWith(expect.stringContaining("provider exploded"), "warning")
+		// …but the message must also land in a persisted breadcrumb so headless
+		// runs (ui.notify is a no-op there) stay diagnosable from session files.
+		expect(pi.appendEntry).toHaveBeenCalledWith("ferment_breadcrumb", {
+			text: "Stage compaction skipped: provider exploded",
+		})
+		// The handoff was appended before the compaction attempt and no
+		// continuation is scheduled without a saved summary.
+		expect(appendCustomMessageEntryMock(ctx)).toHaveBeenCalledWith(
+			"ferment_stage_handoff",
+			expect.any(Array),
+			false,
+			expect.objectContaining({ fermentName: "My Ferment" }),
+		)
+		expect(pi.sendMessage).not.toHaveBeenCalled()
+		expect(runtime.isCompactionInFlight(ferment.id)).toBe(false)
 	})
 
 	it("clears pending compaction after triggering", async () => {

--- a/src/extensions/ferment/auto-compaction.test.ts
+++ b/src/extensions/ferment/auto-compaction.test.ts
@@ -615,6 +615,90 @@ describe("maybeTriggerFermentCompaction", () => {
 		expect(call.model).toBeUndefined()
 	})
 
+	it("warns when the compactor ref is configured but not in the registry", async () => {
+		const ferment = makeFermentWithPhase(
+			{ id: "phase-1", name: "Phase", goal: "Goal" },
+			{ id: "step-1", description: "Do it" },
+		)
+		storageMap.set(ferment.id, ferment)
+		runtime.setActive(ferment)
+		setPendingCompaction(ferment.id, makePendingStep(ferment.id, "phase-1", "step-1"))
+
+		// Configured but not in the registry: silently compacting on the session
+		// model forever is the diagnosability trap the warning exists for.
+		applyRoleAugmentation((roles) => ({ ...roles, compactor: "kimchi-dev/typo-model" }))
+		ctx.modelRegistry = { find: vi.fn(() => undefined) } as unknown as ExtensionContext["modelRegistry"]
+		ctx.inlineCompact = vi.fn(async () => ({
+			summary: "compacted",
+			firstKeptEntryId: "entry-1",
+			tokensBefore: 10,
+		}))
+
+		await maybeTriggerFermentCompaction(pi, ctx, runtime)
+
+		expect(pi.appendEntry).toHaveBeenCalledWith("ferment_breadcrumb", {
+			text: expect.stringContaining('Compactor model role "kimchi-dev/typo-model" is not in the model registry'),
+		})
+		// The fallback itself must be unaffected: compaction ran on the session model.
+		const call = (ctx.inlineCompact as ReturnType<typeof vi.fn>).mock.calls[0][0] as { model?: unknown }
+		expect(call.model).toBeUndefined()
+	})
+
+	it("warns when the compactor ref is not a valid provider/model reference", async () => {
+		const ferment = makeFermentWithPhase(
+			{ id: "phase-1", name: "Phase", goal: "Goal" },
+			{ id: "step-1", description: "Do it" },
+		)
+		storageMap.set(ferment.id, ferment)
+		runtime.setActive(ferment)
+		setPendingCompaction(ferment.id, makePendingStep(ferment.id, "phase-1", "step-1"))
+
+		applyRoleAugmentation((roles) => ({ ...roles, compactor: "ref-without-provider-slash" }))
+		ctx.inlineCompact = vi.fn(async () => ({
+			summary: "compacted",
+			firstKeptEntryId: "entry-1",
+			tokensBefore: 10,
+		}))
+
+		await maybeTriggerFermentCompaction(pi, ctx, runtime)
+
+		expect(pi.appendEntry).toHaveBeenCalledWith("ferment_breadcrumb", {
+			text: expect.stringContaining("not a valid provider/model reference"),
+		})
+	})
+
+	it("emits a loud breadcrumb when the synchronous handoff direct-append is unavailable", async () => {
+		const ferment = makeFermentWithPhase(
+			{ id: "phase-1", name: "Phase", goal: "Goal" },
+			{ id: "step-1", description: "Do it" },
+		)
+		storageMap.set(ferment.id, ferment)
+		runtime.setActive(ferment)
+		setPendingCompaction(ferment.id, makePendingStep(ferment.id, "phase-1", "step-1"))
+
+		// Upstream renamed/removed appendCustomMessageEntry: the handoff degrades
+		// to the async path, is not in the branch at prepare time, and the forced
+		// compaction that expected it as a cut point can silently no-op. That
+		// degradation must be visible in the session file, not just in a UI toast.
+		ctx.sessionManager = { getEntries: vi.fn(() => []) } as unknown as ExtensionContext["sessionManager"]
+		ctx.inlineCompact = vi.fn(async () => ({
+			summary: "compacted",
+			firstKeptEntryId: "entry-1",
+			tokensBefore: 10,
+		}))
+
+		await maybeTriggerFermentCompaction(pi, ctx, runtime)
+
+		expect(pi.appendEntry).toHaveBeenCalledWith("ferment_breadcrumb", {
+			text: expect.stringContaining("direct-append unavailable"),
+		})
+		// The async fallback still delivers the handoff.
+		expect(pi.sendMessage).toHaveBeenCalledWith(
+			expect.objectContaining({ customType: "ferment_stage_handoff" }),
+			expect.objectContaining({ triggerTurn: false }),
+		)
+	})
+
 	it("appends a handoff without continuing when one-shot inline compaction is skipped", async () => {
 		const ferment = makeFermentWithPhase(
 			{ id: "phase-1", name: "Phase", goal: "Goal" },

--- a/src/extensions/ferment/auto-compaction.test.ts
+++ b/src/extensions/ferment/auto-compaction.test.ts
@@ -10,6 +10,7 @@
 import type { CompactionResult, ExtensionAPI, ExtensionContext, SessionEntry } from "@earendil-works/pi-coding-agent"
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
 import type { Ferment, Phase, Step } from "../../ferment/types.js"
+import { applyRoleAugmentation, resetModelRolesCache } from "../orchestration/model-roles.js"
 import {
 	buildCustomInstructions,
 	buildHandoffDetails,
@@ -434,6 +435,7 @@ describe("maybeTriggerFermentCompaction", () => {
 		runtime.clearCompactionInFlight("ferment-2")
 		clearPendingCompaction("ferment-1")
 		clearPendingCompaction("ferment-2")
+		resetModelRolesCache()
 		vi.restoreAllMocks()
 	})
 
@@ -523,6 +525,7 @@ describe("maybeTriggerFermentCompaction", () => {
 		expect(ctx.inlineCompact).toHaveBeenCalledWith({
 			customInstructions: expect.stringContaining("Ferment: My Ferment"),
 			force: true,
+			thinkingLevel: "off",
 		})
 		// The handoff must already be in the session while compaction runs: it is
 		// the newest valid cut point, so the cut lands on it and the next stage
@@ -555,6 +558,63 @@ describe("maybeTriggerFermentCompaction", () => {
 		expect(nudgeCall[1]).toMatchObject({ triggerTurn: true, deliverAs: "steer" })
 	})
 
+	it("resolves modelRoles.compactor into ctx.inlineCompact's model option", async () => {
+		const ferment = makeFermentWithPhase(
+			{ id: "phase-1", name: "Phase", goal: "Goal" },
+			{ id: "step-1", description: "Do it" },
+		)
+		storageMap.set(ferment.id, ferment)
+		runtime.setActive(ferment)
+		setPendingCompaction(ferment.id, makePendingStep(ferment.id, "phase-1", "step-1"))
+
+		applyRoleAugmentation((roles) => ({ ...roles, compactor: "kimchi-dev/non-reasoning-model" }))
+		const compactorModel = { provider: "kimchi-dev", id: "non-reasoning-model" }
+		const find = vi.fn(() => compactorModel)
+		ctx.modelRegistry = { find } as unknown as ExtensionContext["modelRegistry"]
+		ctx.inlineCompact = vi.fn(async () => ({
+			summary: "compacted",
+			firstKeptEntryId: "entry-1",
+			tokensBefore: 10,
+		}))
+
+		await maybeTriggerFermentCompaction(pi, ctx, runtime)
+
+		expect(find).toHaveBeenCalledWith("kimchi-dev", "non-reasoning-model")
+		expect(ctx.inlineCompact).toHaveBeenCalledWith(
+			expect.objectContaining({ model: compactorModel, force: true, thinkingLevel: "off" }),
+		)
+	})
+
+	it("omits the model override when modelRoles.compactor is unset", async () => {
+		const ferment = makeFermentWithPhase(
+			{ id: "phase-1", name: "Phase", goal: "Goal" },
+			{ id: "step-1", description: "Do it" },
+		)
+		storageMap.set(ferment.id, ferment)
+		runtime.setActive(ferment)
+		setPendingCompaction(ferment.id, makePendingStep(ferment.id, "phase-1", "step-1"))
+
+		// Force compactor unset regardless of the real ~/.config/kimchi/harness/settings.json
+		// on the machine running this test — getModelRoles() reads that file directly
+		// (same as judge.ts), so a locally configured compactor role would otherwise
+		// leak into this "unset" scenario.
+		applyRoleAugmentation((roles) => ({ ...roles, compactor: undefined }))
+
+		const find = vi.fn()
+		ctx.modelRegistry = { find } as unknown as ExtensionContext["modelRegistry"]
+		ctx.inlineCompact = vi.fn(async () => ({
+			summary: "compacted",
+			firstKeptEntryId: "entry-1",
+			tokensBefore: 10,
+		}))
+
+		await maybeTriggerFermentCompaction(pi, ctx, runtime)
+
+		expect(find).not.toHaveBeenCalled()
+		const call = (ctx.inlineCompact as ReturnType<typeof vi.fn>).mock.calls[0][0] as { model?: unknown }
+		expect(call.model).toBeUndefined()
+	})
+
 	it("appends a handoff without continuing when one-shot inline compaction is skipped", async () => {
 		const ferment = makeFermentWithPhase(
 			{ id: "phase-1", name: "Phase", goal: "Goal" },
@@ -573,6 +633,7 @@ describe("maybeTriggerFermentCompaction", () => {
 		expect(ctx.inlineCompact).toHaveBeenCalledWith({
 			customInstructions: expect.stringContaining("Ferment: My Ferment"),
 			force: true,
+			thinkingLevel: "off",
 		})
 		expect(ctx.ui.notify).not.toHaveBeenCalled()
 		expect(runtime.isCompactionInFlight(ferment.id)).toBe(false)

--- a/src/extensions/ferment/auto-compaction.test.ts
+++ b/src/extensions/ferment/auto-compaction.test.ts
@@ -8,11 +8,18 @@
  */
 
 import type { AssistantMessage, ToolResultMessage, UserMessage } from "@earendil-works/pi-ai"
-import type { CompactionResult, ExtensionAPI, ExtensionContext, SessionEntry } from "@earendil-works/pi-coding-agent"
+import {
+	type CompactionResult,
+	type ExtensionAPI,
+	type ExtensionContext,
+	type SessionEntry,
+	SessionManager,
+} from "@earendil-works/pi-coding-agent"
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
 import type { Ferment, Phase, Step } from "../../ferment/types.js"
 import { applyRoleAugmentation, resetModelRolesCache } from "../orchestration/model-roles.js"
 import {
+	DEFAULT_STAGE_COMPACTION_OPTIONS,
 	buildCustomInstructions,
 	buildHandoffDetails,
 	buildMidTurnCustomInstructions,
@@ -88,17 +95,51 @@ function makePi(): ExtensionAPI {
 	} as unknown as ExtensionAPI
 }
 
-function makeCtx(): ExtensionContext {
+/** An assistant message whose usage reports `totalTokens` — the signal the
+ *  stage-compaction minimum-size gate reads. Shaped like a kimchi-dev
+ *  open-weight model response (openai-completions API), matching how
+ *  `src/models.ts` wires the kimchi-dev provider. */
+function makeAssistantMessage(totalTokens: number): AssistantMessage {
+	return {
+		role: "assistant",
+		content: [],
+		api: "openai-completions",
+		provider: "kimchi-dev",
+		model: "kimi-k2.7",
+		usage: {
+			input: 0,
+			output: 0,
+			cacheRead: 0,
+			cacheWrite: 0,
+			totalTokens,
+			cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+		},
+		stopReason: "stop",
+		timestamp: Date.now(),
+	}
+}
+
+// Context sizes relative to the stage-compaction minimum-size gate, derived
+// from the real constant so a future gate change cannot silently flip tests
+// onto the skip path. makeCtx sessions default to above-gate so tests
+// exercising the compaction path are not skipped.
+const ABOVE_GATE_TOKENS = DEFAULT_STAGE_COMPACTION_OPTIONS.minContextTokens + 10_000
+const BELOW_GATE_TOKENS = DEFAULT_STAGE_COMPACTION_OPTIONS.minContextTokens - 20_000
+
+/** Build a ctx backed by a real in-memory pi SessionManager, seeded with one
+ *  assistant message reporting `contextTokens` (0 seeds nothing). */
+function makeCtx(contextTokens: number = ABOVE_GATE_TOKENS): ExtensionContext {
+	const sessionManager = SessionManager.inMemory()
+	if (contextTokens > 0) {
+		sessionManager.appendMessage(makeAssistantMessage(contextTokens))
+	}
+	vi.spyOn(sessionManager, "appendCustomMessageEntry")
 	return {
 		compact: vi.fn(),
 		ui: {
 			notify: vi.fn(),
 		},
-		sessionManager: {
-			getEntries: vi.fn(() => []),
-			getLeafId: vi.fn(() => null),
-			appendCustomMessageEntry: vi.fn(),
-		},
+		sessionManager,
 	} as unknown as ExtensionContext
 }
 
@@ -550,7 +591,7 @@ describe("maybeTriggerFermentCompaction", () => {
 		})
 		ctx.modelRegistry = {
 			find: vi.fn((provider: string, modelId: string) =>
-				provider === "kimchi-dev" && modelId === "nemotron-3-ultra-fp4" ? { provider, id: modelId } : undefined,
+				provider === "kimchi-dev" && modelId === "minimax-m3" ? { provider, id: modelId } : undefined,
 			),
 		} as unknown as ExtensionContext["modelRegistry"]
 
@@ -562,8 +603,9 @@ describe("maybeTriggerFermentCompaction", () => {
 			expect.objectContaining({
 				customInstructions: expect.stringContaining("Ferment: My Ferment"),
 				force: true,
-				keepRecentTokens: 5_000,
-				model: { provider: "kimchi-dev", id: "nemotron-3-ultra-fp4" },
+				// 5% of the 100k window is 5k — clamped up to the 20k floor.
+				keepRecentTokens: 20_000,
+				model: { provider: "kimchi-dev", id: "minimax-m3" },
 				thinkingLevel: "off",
 			}),
 		)
@@ -722,7 +764,11 @@ describe("maybeTriggerFermentCompaction", () => {
 		// to the async path, is not in the branch at prepare time, and the forced
 		// compaction that expected it as a cut point can silently no-op. That
 		// degradation must be visible in the session file, not just in a UI toast.
-		ctx.sessionManager = { getEntries: vi.fn(() => []) } as unknown as ExtensionContext["sessionManager"]
+		const bareSession = SessionManager.inMemory()
+		bareSession.appendMessage(makeAssistantMessage(ABOVE_GATE_TOKENS))
+		ctx.sessionManager = {
+			getEntries: () => bareSession.getEntries(),
+		} as unknown as ExtensionContext["sessionManager"]
 		ctx.inlineCompact = vi.fn(async () => ({
 			summary: "compacted",
 			firstKeptEntryId: "entry-1",
@@ -759,7 +805,8 @@ describe("maybeTriggerFermentCompaction", () => {
 		expect(ctx.inlineCompact).toHaveBeenCalledWith({
 			customInstructions: expect.stringContaining("Ferment: My Ferment"),
 			force: true,
-			keepRecentTokens: 0,
+			// No ctx.model → 5% of window is 0 — clamped up to the 20k floor.
+			keepRecentTokens: 20_000,
 			thinkingLevel: "off",
 		})
 		expect(ctx.ui.notify).not.toHaveBeenCalled()
@@ -776,6 +823,114 @@ describe("maybeTriggerFermentCompaction", () => {
 		expect(pi.appendEntry).toHaveBeenCalledWith("ferment_breadcrumb", {
 			text: "Stage compaction skipped: Nothing to compact (session too small)",
 		})
+	})
+
+	it("skips inline compaction below the minimum-size gate but still delivers the handoff", async () => {
+		const ferment = makeFermentWithPhase(
+			{ id: "phase-1", name: "Phase", goal: "Goal" },
+			{ id: "step-1", description: "Do it" },
+		)
+		storageMap.set(ferment.id, ferment)
+		runtime.setActive(ferment)
+		setPendingCompaction(ferment.id, makePendingStep(ferment.id, "phase-1", "step-1"))
+		pi.getFlag = vi.fn((name) => (name === "ferment-oneshot" ? true : undefined))
+		ctx = makeCtx(BELOW_GATE_TOKENS)
+		ctx.inlineCompact = vi.fn()
+
+		await maybeTriggerFermentCompaction(pi, ctx, runtime)
+
+		expect(ctx.inlineCompact).not.toHaveBeenCalled()
+		expect(ctx.compact).not.toHaveBeenCalled()
+		// The pending entry is consumed — the next stage boundary re-checks.
+		expect(runtime.getPendingCompaction(ferment.id)).toBeUndefined()
+		expect(runtime.isCompactionInFlight(ferment.id)).toBe(false)
+		// The handoff still reaches the next stage, carrying the skip reason.
+		expect(pi.sendMessage).toHaveBeenCalledWith(
+			expect.objectContaining({
+				customType: "ferment_stage_handoff",
+				details: expect.objectContaining({
+					compactionError: expect.stringContaining(
+						`below the ${DEFAULT_STAGE_COMPACTION_OPTIONS.minContextTokens.toLocaleString()}-token stage-compaction minimum`,
+					),
+				}),
+			}),
+			expect.objectContaining({ triggerTurn: false }),
+		)
+		expect(pi.appendEntry).toHaveBeenCalledWith("ferment_breadcrumb", {
+			text: expect.stringContaining(`Stage compaction skipped: context ~${BELOW_GATE_TOKENS.toLocaleString()} tokens`),
+		})
+	})
+
+	it("treats a session with no assistant usage as below the minimum-size gate", async () => {
+		const ferment = makeFermentWithPhase(
+			{ id: "phase-1", name: "Phase", goal: "Goal" },
+			{ id: "step-1", description: "Do it" },
+		)
+		storageMap.set(ferment.id, ferment)
+		runtime.setActive(ferment)
+		setPendingCompaction(ferment.id, makePendingStep(ferment.id, "phase-1", "step-1"))
+		ctx = makeCtx(0)
+		ctx.inlineCompact = vi.fn()
+
+		await maybeTriggerFermentCompaction(pi, ctx, runtime)
+
+		expect(ctx.inlineCompact).not.toHaveBeenCalled()
+		expect(runtime.isCompactionInFlight(ferment.id)).toBe(false)
+	})
+
+	it("honours caller-supplied stage-compaction options", async () => {
+		const ferment = makeFermentWithPhase(
+			{ id: "phase-1", name: "Phase", goal: "Goal" },
+			{ id: "step-1", description: "Do it" },
+		)
+		storageMap.set(ferment.id, ferment)
+		runtime.setActive(ferment)
+		setPendingCompaction(ferment.id, makePendingStep(ferment.id, "phase-1", "step-1"))
+		applyRoleAugmentation((roles) => ({ ...roles, compactor: undefined }))
+		// 30k context: below the default 50k gate, above the custom 10k one.
+		ctx = makeCtx(30_000)
+		ctx.model = { contextWindow: 100_000 } as ExtensionContext["model"]
+		ctx.inlineCompact = vi.fn(async () => ({
+			summary: "compacted",
+			firstKeptEntryId: "entry-1",
+			tokensBefore: 30_000,
+		}))
+
+		await maybeTriggerFermentCompaction(pi, ctx, runtime, {
+			minContextTokens: 10_000,
+			minKeepRecentTokens: 1_000,
+			keepRecentWindowFraction: 0.5,
+			thinkingLevel: "low",
+		})
+
+		expect(ctx.inlineCompact).toHaveBeenCalledWith(
+			expect.objectContaining({
+				// max(1k floor, 50% of the 100k window)
+				keepRecentTokens: 50_000,
+				thinkingLevel: "low",
+			}),
+		)
+	})
+
+	it("keeps 5% of large context windows when that exceeds the 20k keep-recent floor", async () => {
+		const ferment = makeFermentWithPhase(
+			{ id: "phase-1", name: "Phase", goal: "Goal" },
+			{ id: "step-1", description: "Do it" },
+		)
+		storageMap.set(ferment.id, ferment)
+		runtime.setActive(ferment)
+		setPendingCompaction(ferment.id, makePendingStep(ferment.id, "phase-1", "step-1"))
+		applyRoleAugmentation((roles) => ({ ...roles, compactor: undefined }))
+		ctx.model = { contextWindow: 1_000_000 } as ExtensionContext["model"]
+		ctx.inlineCompact = vi.fn(async () => ({
+			summary: "compacted",
+			firstKeptEntryId: "entry-1",
+			tokensBefore: 100_000,
+		}))
+
+		await maybeTriggerFermentCompaction(pi, ctx, runtime)
+
+		expect(ctx.inlineCompact).toHaveBeenCalledWith(expect.objectContaining({ keepRecentTokens: 50_000 }))
 	})
 
 	it("persists unexpected inline compaction failures as a breadcrumb and warns", async () => {

--- a/src/extensions/ferment/auto-compaction.test.ts
+++ b/src/extensions/ferment/auto-compaction.test.ts
@@ -522,6 +522,7 @@ describe("maybeTriggerFermentCompaction", () => {
 		runtime.setActive(ferment)
 		setPendingCompaction(ferment.id, makePendingStep(ferment.id, "phase-1", "step-1"))
 		pi.getFlag = vi.fn((name) => (name === "ferment-oneshot" ? true : undefined))
+		ctx.model = { contextWindow: 100_000 } as ExtensionContext["model"]
 
 		let resolveInline!: (result: CompactionResult) => void
 		const inlineResult = new Promise<CompactionResult>((resolve) => {
@@ -536,16 +537,25 @@ describe("maybeTriggerFermentCompaction", () => {
 			)
 			return inlineResult
 		})
+		ctx.modelRegistry = {
+			find: vi.fn((provider: string, modelId: string) =>
+				provider === "kimchi-dev" && modelId === "nemotron-3-ultra-fp4" ? { provider, id: modelId } : undefined,
+			),
+		} as unknown as ExtensionContext["modelRegistry"]
 
 		const run = maybeTriggerFermentCompaction(pi, ctx, runtime)
 		await Promise.resolve()
 
 		expect(ctx.compact).not.toHaveBeenCalled()
-		expect(ctx.inlineCompact).toHaveBeenCalledWith({
-			customInstructions: expect.stringContaining("Ferment: My Ferment"),
-			force: true,
-			thinkingLevel: "off",
-		})
+		expect(ctx.inlineCompact).toHaveBeenCalledWith(
+			expect.objectContaining({
+				customInstructions: expect.stringContaining("Ferment: My Ferment"),
+				force: true,
+				keepRecentTokens: 5_000,
+				model: { provider: "kimchi-dev", id: "nemotron-3-ultra-fp4" },
+				thinkingLevel: "off",
+			}),
+		)
 		// The handoff must already be in the session while compaction runs: it is
 		// the newest valid cut point, so the cut lands on it and the next stage
 		// keeps summary + handoff.
@@ -738,6 +748,7 @@ describe("maybeTriggerFermentCompaction", () => {
 		expect(ctx.inlineCompact).toHaveBeenCalledWith({
 			customInstructions: expect.stringContaining("Ferment: My Ferment"),
 			force: true,
+			keepRecentTokens: 0,
 			thinkingLevel: "off",
 		})
 		expect(ctx.ui.notify).not.toHaveBeenCalled()

--- a/src/extensions/ferment/auto-compaction.ts
+++ b/src/extensions/ferment/auto-compaction.ts
@@ -491,6 +491,7 @@ async function triggerCompactionForPending(
 				// itself skip reasoning — force it off here regardless of which model
 				// (configured compactor or session default) ends up handling the call.
 				thinkingLevel: "off",
+				keepRecentTokens: Math.floor((ctx.model?.contextWindow ?? 0) * 0.05),
 				// Ferment compaction is stage-boundary driven, not threshold driven.
 				// Force keeps automated runs compacting proactively between stages.
 				force: true,

--- a/src/extensions/ferment/auto-compaction.ts
+++ b/src/extensions/ferment/auto-compaction.ts
@@ -27,11 +27,11 @@
 
 import type { ModelThinkingLevel } from "@earendil-works/pi-ai"
 import {
+	buildSessionContext,
 	type CompactionResult,
+	calculateContextTokens,
 	type ExtensionAPI,
 	type ExtensionContext,
-	buildSessionContext,
-	calculateContextTokens,
 	getLastAssistantUsage,
 } from "@earendil-works/pi-coding-agent"
 import { determineNextAction } from "../../ferment/engine.js"

--- a/src/extensions/ferment/auto-compaction.ts
+++ b/src/extensions/ferment/auto-compaction.ts
@@ -301,7 +301,12 @@ export function buildHandoffDetails(
 
 // Error messages that upstream treats as routine "no-op" compaction outcomes.
 // Kept as a single source of truth so the two compaction paths stay consistent.
-const EXPECTED_COMPACTION_ERROR_MESSAGES = ["too small", "Already compacted", "Compaction cancelled"]
+const EXPECTED_COMPACTION_ERROR_MESSAGES = [
+	"too small",
+	"Already compacted",
+	"Compaction cancelled",
+	"no summarizable messages",
+]
 
 function isExpectedCompactionError(error: Error): boolean {
 	return EXPECTED_COMPACTION_ERROR_MESSAGES.some((message) => error.message.includes(message))
@@ -393,16 +398,16 @@ async function triggerCompactionForPending(
 	}
 
 	function scheduleContinuationBestEffort(): void {
-		// After compaction the session is idle. The LLM's previous next-action
-		// reasoning was discarded with the old history, so schedule the next
-		// ferment action as a follow-up turn to keep automated ferments moving.
+		// After compaction the LLM's previous next-action reasoning was discarded
+		// with the old history, so steer the next action into the current drain
+		// path instead of queueing a follow-up that can go stale.
 		try {
 			const freshFerment = runtime.getStorage().get(fermentId)
 			if (freshFerment && (freshFerment.status === "running" || freshFerment.status === "planned")) {
 				runtime.setActive(freshFerment)
 				scheduleNextFermentAction(pi, freshFerment, runtime, {
 					tag: "Auto-compaction continuation",
-					deliverAs: "followUp",
+					deliverAs: "steer",
 				})
 			}
 		} catch {
@@ -424,8 +429,9 @@ async function triggerCompactionForPending(
 			ctx.ui?.notify?.(`Stage compaction failed: ${error.message}`, "warning")
 		}
 		// Always append the handoff entry even when compaction fails/is skipped.
+		// Do not schedule a continuation without a saved compaction summary; the
+		// normal reactive/stop nudges can recover without adding duplicate stale turns.
 		appendHandoffEntry()
-		scheduleContinuationBestEffort()
 	}
 
 	if (typeof ctx.inlineCompact === "function") {
@@ -538,7 +544,7 @@ export function maybeTriggerMidTurnFermentCompaction(
 					runtime.setActive(freshFerment)
 					scheduleNextFermentAction(pi, freshFerment, runtime, {
 						tag: "Auto-compaction continuation",
-						deliverAs: "followUp",
+						deliverAs: "steer",
 					})
 				}
 			},

--- a/src/extensions/ferment/auto-compaction.ts
+++ b/src/extensions/ferment/auto-compaction.ts
@@ -6,7 +6,8 @@
  * The `turn_end` and `agent_end` hooks call `maybeTriggerFermentCompaction` to:
  *   1. Drain ready (non-in-flight) pending entries from the map.
  *   2. Build custom instructions highlighting the ferment plan and stage.
- *   3. Fire `ctx.compact()` which summarises the session.
+ *   3. Fire `ctx.inlineCompact()` when available, or `ctx.compact()` as a legacy fallback,
+ *      to summarise the session.
  *   4. On completion, append a hidden `ferment_stage_handoff` session entry
  *      so the next stage has all context it needs to resume cleanly.
  *
@@ -189,7 +190,7 @@ function findActivePhaseAndStep(ferment: Ferment): { phase?: Phase; step?: Step 
 	return { phase, step }
 }
 
-/** Build the custom instructions string passed to ctx.compact(). */
+/** Build the custom instructions string passed to compaction. */
 export function buildCustomInstructions(ferment: Ferment, pending: PendingCompaction): string {
 	const completedPhase = findCompletedPhase(ferment, pending)
 	const completedStep = findCompletedStep(ferment, pending)
@@ -309,7 +310,7 @@ function isExpectedCompactionError(error: Error): boolean {
 // ─── Main entry point ─────────────────────────────────────────────────────────
 
 /**
- * Check for pending compaction requests and fire `ctx.compact()` for each ready one.
+ * Check for pending compaction requests and fire compaction for each ready one.
  *
  * Called from both `turn_end` (between phases in automated-continuation runs)
  * and `agent_end` (catch-all after the run finishes). The in-flight guard in
@@ -320,32 +321,39 @@ function isExpectedCompactionError(error: Error): boolean {
  * @param ctx     - ExtensionContext (for compact, ui.notify)
  * @param runtime - FermentRuntime (for storage, active-id, pending-compaction state)
  */
-export function maybeTriggerFermentCompaction(pi: ExtensionAPI, ctx: ExtensionContext, runtime: FermentRuntime): void {
-	if (pi.getFlag?.("ferment-oneshot") === true) return
+export async function maybeTriggerFermentCompaction(
+	pi: ExtensionAPI,
+	ctx: ExtensionContext,
+	runtime: FermentRuntime,
+): Promise<boolean> {
+	const hasInlineCompact = typeof ctx.inlineCompact === "function"
+	if (pi.getFlag?.("ferment-oneshot") === true && !hasInlineCompact) return false
 
 	// Root-cause guard: defer compaction while a tool call is in flight (the
 	// trailing assistant toolCall has no matching toolResult yet). Compacting
 	// now would summarise away the toolCall and orphan the toolResult appended
 	// later. Leave the pending entry in the map for a later turn_end / agent_end
 	// to pick up once the pair completes.
-	if (isToolCallInFlightInSession(ctx)) return
+	if (isToolCallInFlightInSession(ctx)) return false
 
 	// drainPendingCompactions() skips in-flight ferments — their entries stay in
 	// the map for the next turn_end / agent_end to pick up.
 	const ready = runtime.drainPendingCompactions()
-	if (ready.length === 0) return
+	if (ready.length === 0) return false
 
+	let didWork = false
 	for (const pending of ready) {
-		triggerCompactionForPending(pi, ctx, runtime, pending)
+		didWork = (await triggerCompactionForPending(pi, ctx, runtime, pending)) || didWork
 	}
+	return didWork
 }
 
-function triggerCompactionForPending(
+async function triggerCompactionForPending(
 	pi: ExtensionAPI,
 	ctx: ExtensionContext,
 	runtime: FermentRuntime,
 	pending: PendingCompaction,
-): void {
+): Promise<boolean> {
 	const { fermentId } = pending
 
 	// Mark in-flight via runtime so the guard is scoped to this runtime instance
@@ -356,7 +364,7 @@ function triggerCompactionForPending(
 	const fermentMaybe = runtime.getStorage().get(fermentId)
 	if (!fermentMaybe) {
 		runtime.clearCompactionInFlight(fermentId)
-		return
+		return false
 	}
 	// Captured after the guard so the non-null type is visible inside closures.
 	const ferment: Ferment = fermentMaybe
@@ -384,53 +392,75 @@ function triggerCompactionForPending(
 		)
 	}
 
+	function scheduleContinuationBestEffort(): void {
+		// After compaction the session is idle. The LLM's previous next-action
+		// reasoning was discarded with the old history, so schedule the next
+		// ferment action as a follow-up turn to keep automated ferments moving.
+		try {
+			const freshFerment = runtime.getStorage().get(fermentId)
+			if (freshFerment && (freshFerment.status === "running" || freshFerment.status === "planned")) {
+				runtime.setActive(freshFerment)
+				scheduleNextFermentAction(pi, freshFerment, runtime, {
+					tag: "Auto-compaction continuation",
+					deliverAs: "followUp",
+				})
+			}
+		} catch {
+			// Best-effort: scheduler errors must not propagate from compaction.
+		}
+	}
+
+	function finishCompaction(result: CompactionResult): void {
+		runtime.clearCompactionInFlight(fermentId)
+		appendHandoffEntry(result)
+		scheduleContinuationBestEffort()
+	}
+
+	function handleCompactionFailure(error: unknown): void {
+		runtime.clearCompactionInFlight(fermentId)
+		// Silently skip expected non-errors: session too small, already
+		// compacted, cancelled. These are routine when steps are short.
+		if (error instanceof Error && !isExpectedCompactionError(error)) {
+			ctx.ui?.notify?.(`Stage compaction failed: ${error.message}`, "warning")
+		}
+		// Always append the handoff entry even when compaction fails/is skipped.
+		appendHandoffEntry()
+		scheduleContinuationBestEffort()
+	}
+
+	if (typeof ctx.inlineCompact === "function") {
+		let result: CompactionResult
+		try {
+			result = await ctx.inlineCompact({
+				customInstructions,
+				// Ferment compaction is stage-boundary driven, not threshold driven.
+				// Force keeps automated runs compacting proactively between stages.
+				force: true,
+			})
+		} catch (error) {
+			handleCompactionFailure(error)
+			return true
+		}
+		finishCompaction(result)
+		return true
+	}
+
 	try {
 		ctx.compact({
 			customInstructions,
-			onComplete: (result: CompactionResult) => {
-				runtime.clearCompactionInFlight(fermentId)
-				appendHandoffEntry(result)
-
-				// After compaction the session is idle. The LLM's previous
-				// next-action reasoning was discarded with the old history, so
-				// schedule the next ferment action as a follow-up turn to keep
-				// automated ferments moving forward without user intervention.
-				try {
-					const freshFerment = runtime.getStorage().get(fermentId)
-					if (freshFerment && (freshFerment.status === "running" || freshFerment.status === "planned")) {
-						runtime.setActive(freshFerment)
-						scheduleNextFermentAction(pi, freshFerment, runtime, {
-							tag: "Auto-compaction continuation",
-							deliverAs: "followUp",
-						})
-					}
-				} catch {
-					// Best-effort: scheduler errors must not propagate from a compaction callback.
-				}
-			},
+			onComplete: finishCompaction,
 			onError: (error: Error) => {
 				try {
-					runtime.clearCompactionInFlight(fermentId)
-					// Silently skip expected non-errors: session too small, already
-					// compacted, cancelled. These are routine when steps are short.
-					if (!isExpectedCompactionError(error)) {
-						ctx.ui?.notify?.(`Stage compaction failed: ${error.message}`, "warning")
-					}
-					// Always append the handoff entry even when compaction fails/is skipped.
-					appendHandoffEntry()
+					handleCompactionFailure(error)
 				} catch {
 					// Best-effort: never let onError propagate and crash the extension.
 				}
 			},
 		})
 	} catch (error) {
-		// ctx.compact should never throw, but if it does before invoking callbacks
-		// the in-flight flag must be cleared so future compactions are not blocked.
-		runtime.clearCompactionInFlight(fermentId)
-		if (error instanceof Error && !isExpectedCompactionError(error)) {
-			ctx.ui?.notify?.(`Stage compaction failed: ${error.message}`, "warning")
-		}
+		handleCompactionFailure(error)
 	}
+	return true
 }
 
 /**

--- a/src/extensions/ferment/auto-compaction.ts
+++ b/src/extensions/ferment/auto-compaction.ts
@@ -6,10 +6,13 @@
  * The `turn_end` and `agent_end` hooks call `maybeTriggerFermentCompaction` to:
  *   1. Drain ready (non-in-flight) pending entries from the map.
  *   2. Build custom instructions highlighting the ferment plan and stage.
- *   3. Fire `ctx.inlineCompact()` when available, or `ctx.compact()` as a legacy fallback,
- *      to summarise the session.
- *   4. On completion, append a hidden `ferment_stage_handoff` session entry
- *      so the next stage has all context it needs to resume cleanly.
+ *   3. Append a hidden `ferment_stage_handoff` session entry so the next stage
+ *      has all context it needs to resume cleanly. On the inline path this
+ *      happens BEFORE compaction: the handoff is the newest valid cut point,
+ *      so the compaction keeps summary + handoff for the next stage.
+ *   4. Fire `ctx.inlineCompact()` when available, or `ctx.compact()` as a legacy
+ *      fallback (which appends the handoff on completion instead), to summarise
+ *      the session.
  *
  * In-flight tracking lives in `state.ts` (via `FermentRuntime`) so it is
  * scoped to the runtime instance and resets on session_start, not leaked across
@@ -42,6 +45,20 @@ export interface FermentHandoffDetails {
 	completedPhaseSummary?: string
 	/** Number of tokens in the session before compaction was triggered (from CompactionResult.tokensBefore) */
 	compactionTokensBefore?: number
+	/** Why compaction produced no result (skipped or failed). Absent on success.
+	 *  Persisted so headless runs (where ctx.ui.notify is a no-op) remain diagnosable
+	 *  from session files alone. */
+	compactionError?: string
+}
+
+type HandoffContent = Array<{ type: "text"; text: string }>
+type InlineHandoffSessionManager = {
+	appendCustomMessageEntry?: (
+		customType: string,
+		content: HandoffContent,
+		display: boolean,
+		details?: FermentHandoffDetails,
+	) => unknown
 }
 
 /** Return the token count at which we should trigger auto-compaction.
@@ -275,7 +292,7 @@ export function buildMidTurnCustomInstructions(
 }
 
 export function buildHandoffDetails(
-	result: CompactionResult,
+	result: CompactionResult | undefined,
 	ferment: Ferment,
 	pending: PendingCompaction,
 ): FermentHandoffDetails {
@@ -295,7 +312,10 @@ export function buildHandoffDetails(
 		nextPhaseGoal: nextAction?.nextPhaseGoal,
 		completedStepSummary: completedStep?.summary,
 		completedPhaseSummary: completedPhase?.summary,
-		compactionTokensBefore: result.tokensBefore,
+		// Only set when a compaction result exists (legacy ctx.compact path). The
+		// inline path appends the handoff BEFORE compacting, so success there is
+		// signalled by the compaction entry itself, which records tokensBefore.
+		compactionTokensBefore: result?.tokensBefore,
 	}
 }
 
@@ -379,17 +399,24 @@ async function triggerCompactionForPending(
 	/** Append the hidden handoff entry so the next stage always receives
 	 *  plan + stage context, even when compaction is skipped (session too
 	 *  small, already compacted, no model, etc.). */
-	function appendHandoffEntry(result?: CompactionResult): void {
-		const handoff = buildHandoffDetails(
-			result ?? { summary: "", firstKeptEntryId: "", tokensBefore: 0 },
-			ferment,
-			pending,
-		)
+	function appendHandoffEntry(result?: CompactionResult, errorMessage?: string, synchronous = false): void {
+		const handoff = buildHandoffDetails(result, ferment, pending)
+		if (!result && errorMessage) {
+			handoff.compactionError = errorMessage
+		}
+		const content: HandoffContent = [{ type: "text", text: JSON.stringify(handoff) }]
+		const directAppend = synchronous
+			? (ctx.sessionManager as InlineHandoffSessionManager | undefined)?.appendCustomMessageEntry
+			: undefined
+		if (directAppend) {
+			directAppend.call(ctx.sessionManager, "ferment_stage_handoff", content, false, handoff)
+			return
+		}
 		safeSendMessage(
 			pi,
 			{
 				customType: "ferment_stage_handoff",
-				content: [{ type: "text", text: JSON.stringify(handoff) }],
+				content,
 				display: false,
 				details: handoff,
 			},
@@ -431,23 +458,49 @@ async function triggerCompactionForPending(
 		// Always append the handoff entry even when compaction fails/is skipped.
 		// Do not schedule a continuation without a saved compaction summary; the
 		// normal reactive/stop nudges can recover without adding duplicate stale turns.
-		appendHandoffEntry()
+		appendHandoffEntry(undefined, error instanceof Error ? error.message : String(error))
 	}
 
 	if (typeof ctx.inlineCompact === "function") {
-		let result: CompactionResult
+		// Append the handoff BEFORE compacting. At a stage boundary the session
+		// tail is assistant → toolResult, and upstream cannot place a compaction
+		// cut point after a toolResult — without a trailing custom_message entry,
+		// a forced compaction prepares zero summarizable messages and no-ops
+		// (the exact failure observed across whole benchmark runs). The handoff
+		// is a valid cut point, so the cut lands here and the next stage keeps
+		// exactly what it needs: compaction summary + plan handoff.
+		appendHandoffEntry(undefined, undefined, true)
 		try {
-			result = await ctx.inlineCompact({
+			const result = await ctx.inlineCompact({
 				customInstructions,
 				// Ferment compaction is stage-boundary driven, not threshold driven.
 				// Force keeps automated runs compacting proactively between stages.
 				force: true,
 			})
+			runtime.clearCompactionInFlight(fermentId)
+			tryPiAction(() => {
+				pi.appendEntry("ferment_breadcrumb", {
+					text: `Stage compaction complete: ${(result.tokensBefore ?? 0).toLocaleString()} tokens before compaction`,
+				})
+			})
+			scheduleContinuationBestEffort()
 		} catch (error) {
-			handleCompactionFailure(error)
-			return true
+			runtime.clearCompactionInFlight(fermentId)
+			const message = error instanceof Error ? error.message : String(error)
+			// The handoff entry is already appended; persist the skip reason
+			// separately so headless runs (where ui.notify is a no-op) remain
+			// diagnosable from session files alone.
+			tryPiAction(() => {
+				pi.appendEntry("ferment_breadcrumb", {
+					text: `Stage compaction skipped: ${message}`,
+				})
+			})
+			if (error instanceof Error && !isExpectedCompactionError(error)) {
+				ctx.ui?.notify?.(`Stage compaction failed: ${error.message}`, "warning")
+			}
+			// Do not schedule a continuation without a saved compaction summary; the
+			// normal reactive/stop nudges can recover without adding duplicate stale turns.
 		}
-		finishCompaction(result)
 		return true
 	}
 
@@ -552,6 +605,11 @@ export function maybeTriggerMidTurnFermentCompaction(
 				runtime.clearCompactionInFlight(fermentId)
 				if (!isExpectedCompactionError(error)) {
 					ctx.ui?.notify?.(`Mid-turn compaction failed: ${error.message}`, "warning")
+					// ui.notify is a no-op in headless runs — persist the failure so
+					// archives show why the context kept growing past the threshold.
+					pi.appendEntry("ferment_breadcrumb", {
+						text: `Mid-turn compaction failed: ${error.message}`,
+					})
 				}
 			},
 		})

--- a/src/extensions/ferment/auto-compaction.ts
+++ b/src/extensions/ferment/auto-compaction.ts
@@ -21,10 +21,15 @@
  * Failures warn via `ctx.ui.notify` and never block the pipeline.
  */
 
-import type { CompactionResult, ExtensionAPI, ExtensionContext } from "@earendil-works/pi-coding-agent"
+import {
+	type CompactionResult,
+	type ExtensionAPI,
+	type ExtensionContext,
+	buildSessionContext,
+} from "@earendil-works/pi-coding-agent"
 import { determineNextAction } from "../../ferment/engine.js"
 import type { Ferment, Phase, Step } from "../../ferment/types.js"
-import { collectMessagesFromEntries, isToolCallInFlight } from "../../tool-call-in-flight.js"
+import { isToolCallInFlight } from "../../tool-call-in-flight.js"
 import { COMPACTION_RESERVE_TOKENS } from "../compaction-thresholds.js"
 import { getModelRoles, splitModelRef } from "../orchestration/model-roles.js"
 import type { FermentRuntime } from "./runtime.js"
@@ -91,7 +96,8 @@ export { isToolCallInFlight } from "../../tool-call-in-flight.js"
 export function isToolCallInFlightInSession(ctx: ExtensionContext): boolean {
 	try {
 		const entries = ctx?.sessionManager?.getEntries?.() ?? []
-		return isToolCallInFlight(collectMessagesFromEntries(entries))
+		const leafId = ctx.sessionManager.getLeafId()
+		return isToolCallInFlight(buildSessionContext(entries, leafId).messages)
 	} catch {
 		return false
 	}

--- a/src/extensions/ferment/auto-compaction.ts
+++ b/src/extensions/ferment/auto-compaction.ts
@@ -6,6 +6,10 @@
  * The `turn_end` and `agent_end` hooks call `maybeTriggerFermentCompaction` to:
  *   1. Drain ready (non-in-flight) pending entries from the map.
  *   2. Build custom instructions highlighting the ferment plan and stage.
+ *      On the inline path, skip compaction (but still deliver the handoff)
+ *      when the estimated context is below the minimum-size gate
+ *      (`StageCompactionOptions.minContextTokens`) — small contexts cost a
+ *      full summarization call and save nothing.
  *   3. Append a hidden `ferment_stage_handoff` session entry so the next stage
  *      has all context it needs to resume cleanly. On the inline path this
  *      happens BEFORE compaction: the handoff is the newest valid cut point,
@@ -21,11 +25,14 @@
  * Failures warn via `ctx.ui.notify` and never block the pipeline.
  */
 
+import type { ModelThinkingLevel } from "@earendil-works/pi-ai"
 import {
 	type CompactionResult,
 	type ExtensionAPI,
 	type ExtensionContext,
 	buildSessionContext,
+	calculateContextTokens,
+	getLastAssistantUsage,
 } from "@earendil-works/pi-coding-agent"
 import { determineNextAction } from "../../ferment/engine.js"
 import type { Ferment, Phase, Step } from "../../ferment/types.js"
@@ -38,6 +45,31 @@ import { scheduleNextFermentAction } from "./scheduler.js"
 import type { PendingCompaction } from "./state.js"
 
 // ─── Public types ─────────────────────────────────────────────────────────────
+
+/** Tunables for stage-boundary compaction. Callers may override per call;
+ *  everything defaults to `DEFAULT_STAGE_COMPACTION_OPTIONS`. */
+export interface StageCompactionOptions {
+	/** Skip stage compaction when the estimated context is below this many tokens. */
+	minContextTokens: number
+	/** Never keep fewer recent tokens than this on a forced stage cut. */
+	minKeepRecentTokens: number
+	/** Fraction of the model's context window kept as recent tokens (before the floor). */
+	keepRecentWindowFraction: number
+	/** Thinking level for the summarization call. */
+	thinkingLevel: ModelThinkingLevel
+}
+
+export const DEFAULT_STAGE_COMPACTION_OPTIONS: Readonly<StageCompactionOptions> = {
+	// Below this, the multi-minute summarization call saves almost nothing.
+	// Compactions firing at a median of ~30k tokens consume 20–40% of session
+	// wall time, converting passing tasks into agent timeouts. The next stage
+	// boundary re-checks, so skipped stages compact once the context has grown.
+	minContextTokens: 50_000,
+	minKeepRecentTokens: 20_000,
+	keepRecentWindowFraction: 0.05,
+	// Compaction is pure summarization and never benefits from extended thinking.
+	thinkingLevel: "off",
+}
 
 export interface FermentHandoffDetails {
 	fermentName: string
@@ -73,6 +105,19 @@ type InlineHandoffSessionManager = {
  *  that would spuriously match any non-negative token count. */
 function compactionThreshold(contextWindow: number): number {
 	return Math.max(0, contextWindow - COMPACTION_RESERVE_TOKENS)
+}
+
+/** Best-effort estimate of the current context size: the token usage reported
+ *  by the last assistant message — the same signal upstream's `shouldCompact`
+ *  uses. Returns 0 when unknown (fresh session, no assistant turn yet), which
+ *  callers treat as "too small to compact". */
+function estimateSessionContextTokens(ctx: ExtensionContext): number {
+	try {
+		const usage = getLastAssistantUsage(ctx.sessionManager?.getEntries?.() ?? [])
+		return usage ? calculateContextTokens(usage) : 0
+	} catch {
+		return 0
+	}
 }
 
 function readFermentOneshotFlag(pi: ExtensionAPI): boolean | undefined {
@@ -341,6 +386,7 @@ export async function maybeTriggerFermentCompaction(
 	pi: ExtensionAPI,
 	ctx: ExtensionContext,
 	runtime: FermentRuntime,
+	options: StageCompactionOptions = DEFAULT_STAGE_COMPACTION_OPTIONS,
 ): Promise<boolean> {
 	const hasInlineCompact = typeof ctx.inlineCompact === "function"
 	const isOneShot = readFermentOneshotFlag(pi)
@@ -361,7 +407,7 @@ export async function maybeTriggerFermentCompaction(
 
 	let didWork = false
 	for (const pending of ready) {
-		didWork = (await triggerCompactionForPending(pi, ctx, runtime, pending)) || didWork
+		didWork = (await triggerCompactionForPending(pi, ctx, runtime, pending, options)) || didWork
 	}
 	return didWork
 }
@@ -371,6 +417,7 @@ async function triggerCompactionForPending(
 	ctx: ExtensionContext,
 	runtime: FermentRuntime,
 	pending: PendingCompaction,
+	options: StageCompactionOptions,
 ): Promise<boolean> {
 	const { fermentId } = pending
 
@@ -469,6 +516,22 @@ async function triggerCompactionForPending(
 	}
 
 	if (typeof ctx.inlineCompact === "function") {
+		// Minimum-size gate: a stage-boundary compaction on a small context costs
+		// a multi-minute summarization call and saves almost nothing. Skip it —
+		// the pending entry is already drained, the handoff below still delivers
+		// plan context to the next stage, and the next stage boundary re-checks
+		// once the context has grown.
+		const contextTokens = estimateSessionContextTokens(ctx)
+		if (contextTokens < options.minContextTokens) {
+			runtime.clearCompactionInFlight(fermentId)
+			const skipReason = `context ~${contextTokens.toLocaleString()} tokens is below the ${options.minContextTokens.toLocaleString()}-token stage-compaction minimum`
+			appendHandoffEntry(undefined, skipReason)
+			tryPiAction(() => {
+				pi.appendEntry("ferment_breadcrumb", { text: `Stage compaction skipped: ${skipReason}` })
+			})
+			return true
+		}
+
 		// Append the handoff BEFORE compacting. At a stage boundary the session
 		// tail is assistant → toolResult, and upstream cannot place a compaction
 		// cut point after a toolResult — without a trailing custom_message entry,
@@ -491,13 +554,11 @@ async function triggerCompactionForPending(
 				// Undefined when unconfigured/unavailable — inlineCompact falls back
 				// to the session model exactly as before.
 				model: compactorModel.model,
-				// Compaction is pure summarization and never benefits from extended
-				// thinking. Every model in Kimchi's catalog currently reports
-				// `reasoning: true`, so picking a different `model` above does not by
-				// itself skip reasoning — force it off here regardless of which model
-				// (configured compactor or session default) ends up handling the call.
-				thinkingLevel: "off",
-				keepRecentTokens: Math.floor((ctx.model?.contextWindow ?? 0) * 0.05),
+				thinkingLevel: options.thinkingLevel,
+				keepRecentTokens: Math.max(
+					options.minKeepRecentTokens,
+					Math.floor((ctx.model?.contextWindow ?? 0) * options.keepRecentWindowFraction),
+				),
 				// Ferment compaction is stage-boundary driven, not threshold driven.
 				// Force keeps automated runs compacting proactively between stages.
 				force: true,

--- a/src/extensions/ferment/auto-compaction.ts
+++ b/src/extensions/ferment/auto-compaction.ts
@@ -70,14 +70,16 @@ function compactionThreshold(contextWindow: number): number {
 	return Math.max(0, contextWindow - COMPACTION_RESERVE_TOKENS)
 }
 
+function readFermentOneshotFlag(pi: ExtensionAPI): boolean | undefined {
+	let isOneShot: boolean | undefined
+	tryPiAction(() => {
+		isOneShot = pi.getFlag?.("ferment-oneshot") === true
+	})
+	return isOneShot
+}
+
 // ─── In-flight tool-call guard ────────────────────────────────────────────────
 
-// The pure orphaned-toolResult guard lives in tool-call-in-flight.ts so the
-// inline compaction primitive (upstream-inline-compact-patch.ts) can enforce
-// the same invariant without importing from this extension. Re-exported here
-// for existing importers. Ferment uses it for DEFERRAL (leave the pending
-// entry in the map, retry next boundary); the primitive uses it as a loud
-// safety assertion.
 export { isToolCallInFlight } from "../../tool-call-in-flight.js"
 
 /**
@@ -163,41 +165,33 @@ function findActivePhaseAndStep(ferment: Ferment): { phase?: Phase; step?: Step 
 	return { phase, step }
 }
 
-/**
- * Resolve the `modelRoles.compactor` override (see model-roles.ts) into a
- * registered model, mirroring judge.ts's role-to-model resolution. Returns
- * undefined when the role is unset, unparseable, or not in the registry —
- * inlineCompact() then falls back to the session's active model, so a bad
- * or missing config never blocks compaction.
- *
- * Silent fallback is the right availability call but a diagnosability trap: a
- * typo'd compactor ref would quietly compact on the expensive session model
- * forever. `warn` fires whenever a ref is CONFIGURED but unusable, so headless
- * runs keep a session-file trace next to each affected compaction.
- */
-function resolveCompactorModel(
-	ctx: ExtensionContext,
-	warn?: (message: string) => void,
-): ReturnType<NonNullable<ExtensionContext["modelRegistry"]>["find"]> {
+type RegisteredCompactorModel = ReturnType<NonNullable<ExtensionContext["modelRegistry"]>["find"]>
+
+interface CompactorModelResolution {
+	model?: RegisteredCompactorModel
+	fallbackWarning?: string
+}
+
+/** Resolve the optional compactor override; missing model means use the session model. */
+function resolveCompactorModel(ctx: ExtensionContext): CompactorModelResolution {
 	try {
 		const ref = getModelRoles().compactor
-		if (!ref) return undefined
+		if (!ref) return {}
 		const parsed = splitModelRef(ref)
 		if (!parsed) {
-			warn?.(
-				`Compactor model role "${ref}" is not a valid provider/model reference — stage compaction falls back to the session model`,
-			)
-			return undefined
+			return {
+				fallbackWarning: `Compactor model role "${ref}" is not a valid provider/model reference — stage compaction falls back to the session model`,
+			}
 		}
 		const model = ctx.modelRegistry?.find(parsed.provider, parsed.modelId)
 		if (!model) {
-			warn?.(
-				`Compactor model role "${ref}" is not in the model registry — stage compaction falls back to the session model`,
-			)
+			return {
+				fallbackWarning: `Compactor model role "${ref}" is not in the model registry — stage compaction falls back to the session model`,
+			}
 		}
-		return model
+		return { model }
 	} catch {
-		return undefined
+		return {}
 	}
 }
 
@@ -306,9 +300,6 @@ export function buildHandoffDetails(
 		nextPhaseGoal: nextAction?.nextPhaseGoal,
 		completedStepSummary: completedStep?.summary,
 		completedPhaseSummary: completedPhase?.summary,
-		// Only set when a compaction result exists (legacy ctx.compact path). The
-		// inline path appends the handoff BEFORE compacting, so success there is
-		// signalled by the compaction entry itself, which records tokensBefore.
 		compactionTokensBefore: result?.tokensBefore,
 	}
 }
@@ -346,7 +337,9 @@ export async function maybeTriggerFermentCompaction(
 	runtime: FermentRuntime,
 ): Promise<boolean> {
 	const hasInlineCompact = typeof ctx.inlineCompact === "function"
-	if (pi.getFlag?.("ferment-oneshot") === true && !hasInlineCompact) return false
+	const isOneShot = readFermentOneshotFlag(pi)
+	if (isOneShot === undefined) return false
+	if (isOneShot && !hasInlineCompact) return false
 
 	// Root-cause guard: defer compaction while a tool call is in flight (the
 	// trailing assistant toolCall has no matching toolResult yet). Compacting
@@ -478,6 +471,12 @@ async function triggerCompactionForPending(
 		// is a valid cut point, so the cut lands here and the next stage keeps
 		// exactly what it needs: compaction summary + plan handoff.
 		appendHandoffEntry(undefined, undefined, true)
+		const compactorModel = resolveCompactorModel(ctx)
+		if (compactorModel.fallbackWarning) {
+			tryPiAction(() => {
+				pi.appendEntry("ferment_breadcrumb", { text: compactorModel.fallbackWarning })
+			})
+		}
 		try {
 			const result = await ctx.inlineCompact({
 				customInstructions,
@@ -485,11 +484,7 @@ async function triggerCompactionForPending(
 				// separate (e.g. cheaper) model instead of the session's active one.
 				// Undefined when unconfigured/unavailable — inlineCompact falls back
 				// to the session model exactly as before.
-				model: resolveCompactorModel(ctx, (warning) => {
-					tryPiAction(() => {
-						pi.appendEntry("ferment_breadcrumb", { text: warning })
-					})
-				}),
+				model: compactorModel.model,
 				// Compaction is pure summarization and never benefits from extended
 				// thinking. Every model in Kimchi's catalog currently reports
 				// `reasoning: true`, so picking a different `model` above does not by
@@ -559,7 +554,9 @@ export function maybeTriggerMidTurnFermentCompaction(
 	runtime: FermentRuntime,
 	totalTokens: number,
 ): void {
-	if (pi.getFlag?.("ferment-oneshot") === true) {
+	const isOneShot = readFermentOneshotFlag(pi)
+	if (isOneShot === undefined) return
+	if (isOneShot) {
 		const active = runtime.getActive()
 		if (active && totalTokens > compactionThreshold(ctx.model?.contextWindow ?? Number.MAX_SAFE_INTEGER)) {
 			const warnKey = active.id

--- a/src/extensions/ferment/auto-compaction.ts
+++ b/src/extensions/ferment/auto-compaction.ts
@@ -368,6 +368,55 @@ function isExpectedCompactionError(error: Error): boolean {
 	return EXPECTED_COMPACTION_ERROR_MESSAGES.some((message) => error.message.includes(message))
 }
 
+/**
+ * Fire `ctx.inlineCompact` with the shared ferment compaction options (compactor
+ * model override, thinking level, keepRecent floor, force). Assumes the caller
+ * has already verified `ctx.inlineCompact` is a function.
+ *
+ * Never throws: returns `{ result }` on success or `{ error }` on failure. The
+ * caller owns in-flight bookkeeping, breadcrumbs, and continuation scheduling so
+ * the stage-boundary and mid-turn paths stay free to diverge on those while
+ * sharing the one call that must not drift — the `inlineCompact` invocation.
+ */
+async function invokeInlineCompaction(
+	pi: ExtensionAPI,
+	ctx: ExtensionContext,
+	customInstructions: string,
+	options: StageCompactionOptions,
+): Promise<{ result?: CompactionResult; error?: Error }> {
+	const inlineCompact = ctx.inlineCompact
+	if (typeof inlineCompact !== "function") {
+		return { error: new Error("inlineCompact unavailable") }
+	}
+	const compactorModel = resolveCompactorModel(ctx)
+	if (compactorModel.fallbackWarning) {
+		tryPiAction(() => {
+			pi.appendEntry("ferment_breadcrumb", { text: compactorModel.fallbackWarning })
+		})
+	}
+	try {
+		const result = await inlineCompact({
+			customInstructions,
+			// Optional override so compaction's summarization call can run on a
+			// separate (e.g. cheaper) model instead of the session's active one.
+			// Undefined when unconfigured — inlineCompact falls back to the session
+			// model exactly as before.
+			model: compactorModel.model,
+			thinkingLevel: options.thinkingLevel,
+			keepRecentTokens: Math.max(
+				options.minKeepRecentTokens,
+				Math.floor((ctx.model?.contextWindow ?? 0) * options.keepRecentWindowFraction),
+			),
+			// Ferment compaction is event-driven (stage boundary / mid-turn overrun),
+			// not threshold driven. Force keeps automated runs compacting proactively.
+			force: true,
+		})
+		return { result }
+	} catch (error) {
+		return { error: error instanceof Error ? error : new Error(String(error)) }
+	}
+}
+
 // ─── Main entry point ─────────────────────────────────────────────────────────
 
 /**
@@ -540,38 +589,16 @@ async function triggerCompactionForPending(
 		// is a valid cut point, so the cut lands here and the next stage keeps
 		// exactly what it needs: compaction summary + plan handoff.
 		appendHandoffEntry(undefined, undefined, true)
-		const compactorModel = resolveCompactorModel(ctx)
-		if (compactorModel.fallbackWarning) {
-			tryPiAction(() => {
-				pi.appendEntry("ferment_breadcrumb", { text: compactorModel.fallbackWarning })
-			})
-		}
-		try {
-			const result = await ctx.inlineCompact({
-				customInstructions,
-				// Optional override so compaction's summarization call can run on a
-				// separate (e.g. cheaper) model instead of the session's active one.
-				// Undefined when unconfigured/unavailable — inlineCompact falls back
-				// to the session model exactly as before.
-				model: compactorModel.model,
-				thinkingLevel: options.thinkingLevel,
-				keepRecentTokens: Math.max(
-					options.minKeepRecentTokens,
-					Math.floor((ctx.model?.contextWindow ?? 0) * options.keepRecentWindowFraction),
-				),
-				// Ferment compaction is stage-boundary driven, not threshold driven.
-				// Force keeps automated runs compacting proactively between stages.
-				force: true,
-			})
-			runtime.clearCompactionInFlight(fermentId)
+		const { result, error } = await invokeInlineCompaction(pi, ctx, customInstructions, options)
+		runtime.clearCompactionInFlight(fermentId)
+		if (result) {
 			tryPiAction(() => {
 				pi.appendEntry("ferment_breadcrumb", {
 					text: `Stage compaction complete: ${(result.tokensBefore ?? 0).toLocaleString()} tokens before compaction`,
 				})
 			})
 			scheduleContinuationBestEffort()
-		} catch (error) {
-			runtime.clearCompactionInFlight(fermentId)
+		} else {
 			const message = error instanceof Error ? error.message : String(error)
 			// The handoff entry is already appended; persist the skip reason
 			// separately so headless runs (where ui.notify is a no-op) remain
@@ -614,14 +641,20 @@ async function triggerCompactionForPending(
  * path is driven directly by turn_end token usage and must resume the
  * in-progress step after compaction.
  *
+ * Uses `ctx.inlineCompact` when available (transparent, no run abort) and falls
+ * back to the legacy `ctx.compact` otherwise. One-shot runs never compact
+ * mid-turn: an overrun there is a planning-quality signal, so it is recorded as
+ * a planning failure instead of papered over.
+ *
  * @param totalTokens - Current session token count from the assistant usage event.
  */
-export function maybeTriggerMidTurnFermentCompaction(
+export async function maybeTriggerMidTurnFermentCompaction(
 	pi: ExtensionAPI,
 	ctx: ExtensionContext,
 	runtime: FermentRuntime,
 	totalTokens: number,
-): void {
+	options: StageCompactionOptions = DEFAULT_STAGE_COMPACTION_OPTIONS,
+): Promise<void> {
 	const isOneShot = readFermentOneshotFlag(pi)
 	if (isOneShot === undefined) return
 	if (isOneShot) {
@@ -664,41 +697,67 @@ export function maybeTriggerMidTurnFermentCompaction(
 	runtime.markCompactionInFlight(fermentId)
 
 	const customInstructions = buildMidTurnCustomInstructions(activeFerment, activePhase, activeStep)
+
+	/** Resume the in-progress step after a successful compaction: the LLM's
+	 *  next-action reasoning was discarded with the old history, so steer it
+	 *  back into the exact step that was running when the context filled. */
+	function resumeInProgressStep(result: CompactionResult): void {
+		const freshFerment = runtime.getStorage().get(fermentId)
+		if (!freshFerment) return
+
+		const { phase, step } = findActivePhaseAndStep(freshFerment)
+		tryPiAction(() => {
+			pi.appendEntry("ferment_breadcrumb", {
+				text: `Mid-turn compaction resume: ferment "${freshFerment.name}" · phase ${phase?.index ?? "?"}/${freshFerment.phases.length} "${phase?.name ?? "unknown"}" · step ${step?.index ?? "?"}/${phase?.steps.length ?? 0} · ${(result.tokensBefore ?? 0).toLocaleString()} tokens before compaction`,
+			})
+		})
+
+		if (freshFerment.status === "running") {
+			runtime.setActive(freshFerment)
+			scheduleNextFermentAction(pi, freshFerment, runtime, {
+				tag: "Auto-compaction continuation",
+				deliverAs: "steer",
+			})
+		}
+	}
+
 	function handleCompactionFailure(error: unknown): void {
 		runtime.clearCompactionInFlight(fermentId)
 		if (error instanceof Error && !isExpectedCompactionError(error)) {
 			ctx.ui?.notify?.(`Mid-turn compaction failed: ${error.message}`, "warning")
 			// ui.notify is a no-op in headless runs — persist the failure so
 			// archives show why the context kept growing past the threshold.
-			pi.appendEntry("ferment_breadcrumb", {
-				text: `Mid-turn compaction failed: ${error.message}`,
+			tryPiAction(() => {
+				pi.appendEntry("ferment_breadcrumb", {
+					text: `Mid-turn compaction failed: ${error.message}`,
+				})
 			})
 		}
 	}
 
+	// Preferred path: transparent inline compaction (no run abort). Mirrors the
+	// stage-boundary path's invocation via the shared helper so the two cannot
+	// drift; the only differences are the mid-turn instructions and the
+	// step-resume continuation below.
+	if (typeof ctx.inlineCompact === "function") {
+		const { result, error } = await invokeInlineCompaction(pi, ctx, customInstructions, options)
+		if (result) {
+			runtime.clearCompactionInFlight(fermentId)
+			resumeInProgressStep(result)
+		} else {
+			handleCompactionFailure(error)
+		}
+		return
+	}
+
+	// Legacy fallback: ctx.compact aborts the current run, so the step resumes on
+	// the next user turn rather than transparently.
 	try {
 		ctx.compact({
 			customInstructions,
 			onComplete: (result: CompactionResult) => {
 				runtime.clearCompactionInFlight(fermentId)
-
-				const freshFerment = runtime.getStorage().get(fermentId)
-				if (!freshFerment) return
-
-				const { phase, step } = findActivePhaseAndStep(freshFerment)
-				tryPiAction(() => {
-					pi.appendEntry("ferment_breadcrumb", {
-						text: `Mid-turn compaction resume: ferment "${freshFerment.name}" · phase ${phase?.index ?? "?"}/${freshFerment.phases.length} "${phase?.name ?? "unknown"}" · step ${step?.index ?? "?"}/${phase?.steps.length ?? 0} · ${(result.tokensBefore ?? 0).toLocaleString()} tokens before compaction`,
-					})
-				})
-
-				if (freshFerment.status === "running") {
-					runtime.setActive(freshFerment)
-					scheduleNextFermentAction(pi, freshFerment, runtime, {
-						tag: "Auto-compaction continuation",
-						deliverAs: "steer",
-					})
-				}
+				resumeInProgressStep(result)
 			},
 			onError: handleCompactionFailure,
 		})

--- a/src/extensions/ferment/auto-compaction.ts
+++ b/src/extensions/ferment/auto-compaction.ts
@@ -317,11 +317,6 @@ function isExpectedCompactionError(error: Error): boolean {
 	return EXPECTED_COMPACTION_ERROR_MESSAGES.some((message) => error.message.includes(message))
 }
 
-function catchReturnedCompactionError(result: unknown, onError: (error: unknown) => void): void {
-	if (!result || typeof (result as PromiseLike<unknown>).then !== "function") return
-	void Promise.resolve(result).catch(onError)
-}
-
 // ─── Main entry point ─────────────────────────────────────────────────────────
 
 /**
@@ -529,7 +524,7 @@ async function triggerCompactionForPending(
 	}
 
 	try {
-		const result = ctx.compact({
+		ctx.compact({
 			customInstructions,
 			onComplete: finishCompaction,
 			onError: (error: Error) => {
@@ -539,8 +534,7 @@ async function triggerCompactionForPending(
 					// Best-effort: never let onError propagate and crash the extension.
 				}
 			},
-		}) as unknown
-		catchReturnedCompactionError(result, handleCompactionFailure)
+		})
 	} catch (error) {
 		handleCompactionFailure(error)
 	}
@@ -616,7 +610,7 @@ export function maybeTriggerMidTurnFermentCompaction(
 	}
 
 	try {
-		const result = ctx.compact({
+		ctx.compact({
 			customInstructions,
 			onComplete: (result: CompactionResult) => {
 				runtime.clearCompactionInFlight(fermentId)
@@ -640,8 +634,7 @@ export function maybeTriggerMidTurnFermentCompaction(
 				}
 			},
 			onError: handleCompactionFailure,
-		}) as unknown
-		catchReturnedCompactionError(result, handleCompactionFailure)
+		})
 	} catch (error) {
 		// ctx.compact should never throw, but if it does before invoking callbacks
 		// the in-flight flag must be cleared so future compactions are not blocked.

--- a/src/extensions/ferment/auto-compaction.ts
+++ b/src/extensions/ferment/auto-compaction.ts
@@ -317,6 +317,11 @@ function isExpectedCompactionError(error: Error): boolean {
 	return EXPECTED_COMPACTION_ERROR_MESSAGES.some((message) => error.message.includes(message))
 }
 
+function catchReturnedCompactionError(result: unknown, onError: (error: unknown) => void): void {
+	if (!result || typeof (result as PromiseLike<unknown>).then !== "function") return
+	void Promise.resolve(result).catch(onError)
+}
+
 // ─── Main entry point ─────────────────────────────────────────────────────────
 
 /**
@@ -524,7 +529,7 @@ async function triggerCompactionForPending(
 	}
 
 	try {
-		ctx.compact({
+		const result = ctx.compact({
 			customInstructions,
 			onComplete: finishCompaction,
 			onError: (error: Error) => {
@@ -534,7 +539,8 @@ async function triggerCompactionForPending(
 					// Best-effort: never let onError propagate and crash the extension.
 				}
 			},
-		})
+		}) as unknown
+		catchReturnedCompactionError(result, handleCompactionFailure)
 	} catch (error) {
 		handleCompactionFailure(error)
 	}
@@ -597,9 +603,20 @@ export function maybeTriggerMidTurnFermentCompaction(
 	runtime.markCompactionInFlight(fermentId)
 
 	const customInstructions = buildMidTurnCustomInstructions(activeFerment, activePhase, activeStep)
+	function handleCompactionFailure(error: unknown): void {
+		runtime.clearCompactionInFlight(fermentId)
+		if (error instanceof Error && !isExpectedCompactionError(error)) {
+			ctx.ui?.notify?.(`Mid-turn compaction failed: ${error.message}`, "warning")
+			// ui.notify is a no-op in headless runs — persist the failure so
+			// archives show why the context kept growing past the threshold.
+			pi.appendEntry("ferment_breadcrumb", {
+				text: `Mid-turn compaction failed: ${error.message}`,
+			})
+		}
+	}
 
 	try {
-		ctx.compact({
+		const result = ctx.compact({
 			customInstructions,
 			onComplete: (result: CompactionResult) => {
 				runtime.clearCompactionInFlight(fermentId)
@@ -622,24 +639,12 @@ export function maybeTriggerMidTurnFermentCompaction(
 					})
 				}
 			},
-			onError: (error: Error) => {
-				runtime.clearCompactionInFlight(fermentId)
-				if (!isExpectedCompactionError(error)) {
-					ctx.ui?.notify?.(`Mid-turn compaction failed: ${error.message}`, "warning")
-					// ui.notify is a no-op in headless runs — persist the failure so
-					// archives show why the context kept growing past the threshold.
-					pi.appendEntry("ferment_breadcrumb", {
-						text: `Mid-turn compaction failed: ${error.message}`,
-					})
-				}
-			},
-		})
+			onError: handleCompactionFailure,
+		}) as unknown
+		catchReturnedCompactionError(result, handleCompactionFailure)
 	} catch (error) {
 		// ctx.compact should never throw, but if it does before invoking callbacks
 		// the in-flight flag must be cleared so future compactions are not blocked.
-		runtime.clearCompactionInFlight(fermentId)
-		if (error instanceof Error && !isExpectedCompactionError(error)) {
-			ctx.ui?.notify?.(`Mid-turn compaction failed: ${error.message}`, "warning")
-		}
+		handleCompactionFailure(error)
 	}
 }

--- a/src/extensions/ferment/auto-compaction.ts
+++ b/src/extensions/ferment/auto-compaction.ts
@@ -25,6 +25,7 @@ import type { CompactionResult, ExtensionAPI, ExtensionContext } from "@earendil
 import { determineNextAction } from "../../ferment/engine.js"
 import type { Ferment, Phase, Step } from "../../ferment/types.js"
 import { COMPACTION_RESERVE_TOKENS } from "../compaction-thresholds.js"
+import { getModelRoles, splitModelRef } from "../orchestration/model-roles.js"
 import type { FermentRuntime } from "./runtime.js"
 import { safeSendMessage, tryPiAction } from "./safe-send.js"
 import { scheduleNextFermentAction } from "./scheduler.js"
@@ -205,6 +206,27 @@ function findActivePhaseAndStep(ferment: Ferment): { phase?: Phase; step?: Step 
 	const phase = ferment.phases.find((p) => p.status === "active")
 	const step = phase?.steps.find((s) => s.status === "running")
 	return { phase, step }
+}
+
+/**
+ * Resolve the `modelRoles.compactor` override (see model-roles.ts) into a
+ * registered model, mirroring judge.ts's role-to-model resolution. Returns
+ * undefined when the role is unset, unparseable, or not in the registry —
+ * inlineCompact() then falls back to the session's active model, so a bad
+ * or missing config never blocks compaction.
+ */
+function resolveCompactorModel(
+	ctx: ExtensionContext,
+): ReturnType<NonNullable<ExtensionContext["modelRegistry"]>["find"]> {
+	try {
+		const ref = getModelRoles().compactor
+		if (!ref) return undefined
+		const parsed = splitModelRef(ref)
+		if (!parsed) return undefined
+		return ctx.modelRegistry?.find(parsed.provider, parsed.modelId)
+	} catch {
+		return undefined
+	}
 }
 
 /** Build the custom instructions string passed to compaction. */
@@ -473,6 +495,17 @@ async function triggerCompactionForPending(
 		try {
 			const result = await ctx.inlineCompact({
 				customInstructions,
+				// Optional override so compaction's summarization call can run on a
+				// separate (e.g. cheaper) model instead of the session's active one.
+				// Undefined when unconfigured/unavailable — inlineCompact falls back
+				// to the session model exactly as before.
+				model: resolveCompactorModel(ctx),
+				// Compaction is pure summarization and never benefits from extended
+				// thinking. Every model in Kimchi's catalog currently reports
+				// `reasoning: true`, so picking a different `model` above does not by
+				// itself skip reasoning — force it off here regardless of which model
+				// (configured compactor or session default) ends up handling the call.
+				thinkingLevel: "off",
 				// Ferment compaction is stage-boundary driven, not threshold driven.
 				// Force keeps automated runs compacting proactively between stages.
 				force: true,

--- a/src/extensions/ferment/auto-compaction.ts
+++ b/src/extensions/ferment/auto-compaction.ts
@@ -24,6 +24,7 @@
 import type { CompactionResult, ExtensionAPI, ExtensionContext } from "@earendil-works/pi-coding-agent"
 import { determineNextAction } from "../../ferment/engine.js"
 import type { Ferment, Phase, Step } from "../../ferment/types.js"
+import { collectMessagesFromEntries, isToolCallInFlight } from "../../tool-call-in-flight.js"
 import { COMPACTION_RESERVE_TOKENS } from "../compaction-thresholds.js"
 import { getModelRoles, splitModelRef } from "../orchestration/model-roles.js"
 import type { FermentRuntime } from "./runtime.js"
@@ -71,51 +72,13 @@ function compactionThreshold(contextWindow: number): number {
 
 // ─── In-flight tool-call guard ────────────────────────────────────────────────
 
-/**
- * Pure helper: return true if any assistant `toolCall` block `id` in `messages`
- * has NO matching `toolResult` (by `toolCallId`) anywhere in the array.
- *
- * This is the compaction-timing root-cause signal: when the trailing session
- * entries form an incomplete assistant toolCall -> toolResult pair, compacting
- * would summarise away the assistant toolCall while its toolResult is appended
- * later — creating the exact orphaned-toolResult condition phase 1 defends
- * against. By deferring compaction until the pair completes, orphans are never
- * created at the compaction boundary in the first place.
- *
- * Pure, total, never throws: unknown shapes are skipped defensively. Mirrors
- * the structural-guard style of `findOrphanedToolResults` (phase 1) but
- * inverts the question (toolCall without toolResult, not toolResult without
- * toolCall).
- */
-export function isToolCallInFlight(messages: ReadonlyArray<unknown>): boolean {
-	const callIds = new Set<string>()
-	const resultIds = new Set<string>()
-
-	for (const raw of messages) {
-		if (!raw || typeof raw !== "object") continue
-		const msg = raw as { role?: string; content?: unknown; toolCallId?: string }
-		if (msg.role === "assistant") {
-			const content = msg.content
-			if (!Array.isArray(content)) continue
-			for (const block of content) {
-				if (!block || typeof block !== "object") continue
-				const b = block as { type?: string; id?: unknown }
-				if (b.type === "toolCall" && typeof b.id === "string") {
-					callIds.add(b.id)
-				}
-			}
-		} else if (msg.role === "toolResult") {
-			if (typeof msg.toolCallId === "string") {
-				resultIds.add(msg.toolCallId)
-			}
-		}
-	}
-
-	for (const id of callIds) {
-		if (!resultIds.has(id)) return true
-	}
-	return false
-}
+// The pure orphaned-toolResult guard lives in tool-call-in-flight.ts so the
+// inline compaction primitive (upstream-inline-compact-patch.ts) can enforce
+// the same invariant without importing from this extension. Re-exported here
+// for existing importers. Ferment uses it for DEFERRAL (leave the pending
+// entry in the map, retry next boundary); the primitive uses it as a loud
+// safety assertion.
+export { isToolCallInFlight } from "../../tool-call-in-flight.js"
 
 /**
  * Thin wrapper: read the live session entries from `ctx.sessionManager` and
@@ -126,15 +89,7 @@ export function isToolCallInFlight(messages: ReadonlyArray<unknown>): boolean {
 export function isToolCallInFlightInSession(ctx: ExtensionContext): boolean {
 	try {
 		const entries = ctx?.sessionManager?.getEntries?.() ?? []
-		const messages: unknown[] = []
-		for (const entry of entries) {
-			if (!entry || typeof entry !== "object") continue
-			const e = entry as { type?: string; message?: unknown }
-			if (e.type === "message" && e.message && typeof e.message === "object") {
-				messages.push(e.message)
-			}
-		}
-		return isToolCallInFlight(messages)
+		return isToolCallInFlight(collectMessagesFromEntries(entries))
 	} catch {
 		return false
 	}
@@ -214,16 +169,33 @@ function findActivePhaseAndStep(ferment: Ferment): { phase?: Phase; step?: Step 
  * undefined when the role is unset, unparseable, or not in the registry —
  * inlineCompact() then falls back to the session's active model, so a bad
  * or missing config never blocks compaction.
+ *
+ * Silent fallback is the right availability call but a diagnosability trap: a
+ * typo'd compactor ref would quietly compact on the expensive session model
+ * forever. `warn` fires whenever a ref is CONFIGURED but unusable, so headless
+ * runs keep a session-file trace next to each affected compaction.
  */
 function resolveCompactorModel(
 	ctx: ExtensionContext,
+	warn?: (message: string) => void,
 ): ReturnType<NonNullable<ExtensionContext["modelRegistry"]>["find"]> {
 	try {
 		const ref = getModelRoles().compactor
 		if (!ref) return undefined
 		const parsed = splitModelRef(ref)
-		if (!parsed) return undefined
-		return ctx.modelRegistry?.find(parsed.provider, parsed.modelId)
+		if (!parsed) {
+			warn?.(
+				`Compactor model role "${ref}" is not a valid provider/model reference — stage compaction falls back to the session model`,
+			)
+			return undefined
+		}
+		const model = ctx.modelRegistry?.find(parsed.provider, parsed.modelId)
+		if (!model) {
+			warn?.(
+				`Compactor model role "${ref}" is not in the model registry — stage compaction falls back to the session model`,
+			)
+		}
+		return model
 	} catch {
 		return undefined
 	}
@@ -434,6 +406,20 @@ async function triggerCompactionForPending(
 			directAppend.call(ctx.sessionManager, "ferment_stage_handoff", content, false, handoff)
 			return
 		}
+		if (synchronous) {
+			// The direct-append path depends on an undocumented upstream method
+			// (appendCustomMessageEntry is a write method on what the public types
+			// call ReadonlySessionManager). If upstream renames or removes it, the
+			// handoff degrades to the async path below, is NOT in the branch at
+			// prepare time, and the forced compaction that expected it as a cut
+			// point silently no-ops — the exact regression that once spanned whole
+			// benchmark runs. Make that degradation loud in the session file.
+			tryPiAction(() => {
+				pi.appendEntry("ferment_breadcrumb", {
+					text: "Stage handoff direct-append unavailable (sessionManager.appendCustomMessageEntry missing) — handoff will append asynchronously and the forced stage compaction may no-op",
+				})
+			})
+		}
 		safeSendMessage(
 			pi,
 			{
@@ -499,7 +485,11 @@ async function triggerCompactionForPending(
 				// separate (e.g. cheaper) model instead of the session's active one.
 				// Undefined when unconfigured/unavailable — inlineCompact falls back
 				// to the session model exactly as before.
-				model: resolveCompactorModel(ctx),
+				model: resolveCompactorModel(ctx, (warning) => {
+					tryPiAction(() => {
+						pi.appendEntry("ferment_breadcrumb", { text: warning })
+					})
+				}),
 				// Compaction is pure summarization and never benefits from extended
 				// thinking. Every model in Kimchi's catalog currently reports
 				// `reasoning: true`, so picking a different `model` above does not by

--- a/src/extensions/ferment/events.ts
+++ b/src/extensions/ferment/events.ts
@@ -628,7 +628,7 @@ export function registerFermentEvents(
 		// Trigger compaction after any turn that completed a step or phase.
 		// Fires between turns in automated-continuation mode, so the next
 		// phase starts with a fresh compacted session.
-		maybeTriggerFermentCompaction(pi, ctx, runtime)
+		await maybeTriggerFermentCompaction(pi, ctx, runtime)
 
 		// Mid-turn guard: if the context crossed the auto-compaction threshold
 		// while a step is still in progress, compact now and resume the step.

--- a/src/extensions/ferment/events.ts
+++ b/src/extensions/ferment/events.ts
@@ -633,8 +633,15 @@ export function registerFermentEvents(
 		// Mid-turn guard: if the context crossed the auto-compaction threshold
 		// while a step is still in progress, compact now and resume the step.
 		// Only acts on tool-use turns; stop/error/aborted are handled elsewhere.
+		// Awaited so the compacted session and step-resume nudge are in place
+		// before pi-mono builds the next turn's context (see note below); wrapped
+		// because this handler has no outer catch and must never reject out.
 		if (event.message.role === "assistant" && event.message.stopReason === "toolUse") {
-			maybeTriggerMidTurnFermentCompaction(pi, ctx, runtime, event.message.usage?.totalTokens ?? 0)
+			try {
+				await maybeTriggerMidTurnFermentCompaction(pi, ctx, runtime, event.message.usage?.totalTokens ?? 0)
+			} catch (err) {
+				ctx.ui?.notify?.(`Mid-turn compaction error: ${err instanceof Error ? err.message : String(err)}`, "warning")
+			}
 		}
 
 		// After a turn ends, `prepareNextTurn` in pi-mono builds the next turn's

--- a/src/extensions/ferment/index.ts
+++ b/src/extensions/ferment/index.ts
@@ -247,7 +247,7 @@ export default function fermentExtension(pi: ExtensionAPI, runtime: FermentRunti
 		unregisterFermentTodoSync?.()
 	})
 
-	pi.on("agent_end", (_event, ctx) => {
+	pi.on("agent_end", async (_event, ctx) => {
 		const review = runtime.getCurrentPendingPlanReview()
 		if (!planReviewRunning && review) {
 			clearPlanReviewTimer()
@@ -260,7 +260,7 @@ export default function fermentExtension(pi: ExtensionAPI, runtime: FermentRunti
 		// Drain any remaining pending compactions at agent_end (catches the case
 		// where the ferment completes within a single agent run and the turn_end
 		// handler already cleared most pending entries).
-		maybeTriggerFermentCompaction(pi, ctx, runtime)
+		await maybeTriggerFermentCompaction(pi, ctx, runtime)
 
 		// Completing the final phase does not complete the ferment: complete_ferment
 		// still has to run its C-gates and journey grading. If the model ends its run

--- a/src/extensions/ferment/nudge.test.ts
+++ b/src/extensions/ferment/nudge.test.ts
@@ -135,7 +135,7 @@ describe("ferment nudges", () => {
 			getStorage: () =>
 				({
 					get: () => current,
-				}) as unknown as FermentRuntime["getStorage"] extends () => infer T ? T : never,
+				}) as unknown as ReturnType<FermentRuntime["getStorage"]>,
 			getContinuationPolicy: () => "automated",
 			isAutomatedContinuationEnabled: () => true,
 		}
@@ -169,7 +169,7 @@ describe("ferment nudges", () => {
 			getStorage: () =>
 				({
 					get: () => boundary,
-				}) as unknown as FermentRuntime["getStorage"] extends () => infer T ? T : never,
+				}) as unknown as ReturnType<FermentRuntime["getStorage"]>,
 			getContinuationPolicy: () => "automated",
 			isAutomatedContinuationEnabled: () => true,
 		}
@@ -242,7 +242,7 @@ describe("ferment nudges", () => {
 			getStorage: () =>
 				({
 					get: () => completed,
-				}) as unknown as FermentRuntime["getStorage"] extends () => infer T ? T : never,
+				}) as unknown as ReturnType<FermentRuntime["getStorage"]>,
 			setActive: setActiveSpy,
 			getContinuationPolicy: () => "automated",
 		}
@@ -266,7 +266,7 @@ describe("ferment nudges", () => {
 			getStorage: () =>
 				({
 					get: () => readyToComplete,
-				}) as unknown as FermentRuntime["getStorage"] extends () => infer T ? T : never,
+				}) as unknown as ReturnType<FermentRuntime["getStorage"]>,
 			getContinuationPolicy: () => "automated",
 			isAutomatedContinuationEnabled: () => true,
 		}
@@ -300,7 +300,7 @@ describe("ferment nudges", () => {
 							status: "planned",
 							phases: [{ id: "phase-1", index: 1, name: "Phase", goal: "Build", status: "planned", steps: [] }],
 						}),
-				}) as unknown as FermentRuntime["getStorage"] extends () => infer T ? T : never,
+				}) as unknown as ReturnType<FermentRuntime["getStorage"]>,
 			getContinuationPolicy: () => "automated",
 			isAutomatedContinuationEnabled: () => true,
 		}
@@ -335,7 +335,7 @@ describe("ferment nudges", () => {
 			getStorage: () =>
 				({
 					get: () => current,
-				}) as unknown as FermentRuntime["getStorage"] extends () => infer T ? T : never,
+				}) as unknown as ReturnType<FermentRuntime["getStorage"]>,
 			getContinuationPolicy: () => "automated",
 			isAutomatedContinuationEnabled: () => true,
 		}
@@ -366,7 +366,7 @@ describe("ferment nudges", () => {
 			getStorage: () =>
 				({
 					get: () => failed,
-				}) as unknown as FermentRuntime["getStorage"] extends () => infer T ? T : never,
+				}) as unknown as ReturnType<FermentRuntime["getStorage"]>,
 			getContinuationPolicy: () => "automated",
 			isAutomatedContinuationEnabled: () => true,
 		}
@@ -592,7 +592,7 @@ describe("maybeInjectFermentStopNudge", () => {
 			getStorage: () =>
 				({
 					get: () => ferment,
-				}) as unknown as FermentRuntime["getStorage"] extends () => infer T ? T : never,
+				}) as unknown as ReturnType<FermentRuntime["getStorage"]>,
 			getContinuationPolicy: () => "automated",
 			isAutomatedContinuationEnabled: () => automated,
 		}

--- a/src/extensions/ferment/nudge.test.ts
+++ b/src/extensions/ferment/nudge.test.ts
@@ -18,6 +18,7 @@ import {
 	resetScopingStopNudgeCount,
 } from "./nudge.js"
 import { createDefaultFermentRuntime, type FermentRuntime } from "./runtime.js"
+import { scheduleNextFermentAction } from "./scheduler.js"
 import { getActive, MAX_SCOPING_EXPLORE_TURNS, resetScopingExploreTurns, setActive } from "./state.js"
 import { createApplyAndPersist } from "./tool-helpers.js"
 
@@ -221,6 +222,35 @@ describe("ferment nudges", () => {
 		maybeInjectReactiveContinuationNudge(pi, runtime)
 
 		expect(pi.sendMessage).not.toHaveBeenCalled()
+		expect(setActiveSpy).toHaveBeenCalledWith(undefined)
+	})
+
+	it("does not schedule a stale action when storage says the ferment completed", () => {
+		const pi = createPi()
+		const setActiveSpy = vi.fn()
+		const stale = makeDraftFerment({
+			status: "planned",
+			phases: [{ id: "phase-1", index: 1, name: "Phase", goal: "Build", status: "planned", steps: [] }],
+		})
+		const completed = makeDraftFerment({
+			...stale,
+			status: "complete",
+			phases: [{ ...stale.phases[0], status: "completed" }],
+		})
+		const runtime: FermentRuntime = {
+			...createDefaultFermentRuntime(),
+			getStorage: () =>
+				({
+					get: () => completed,
+				}) as unknown as FermentRuntime["getStorage"] extends () => infer T ? T : never,
+			setActive: setActiveSpy,
+			getContinuationPolicy: () => "automated",
+		}
+
+		scheduleNextFermentAction(pi, stale, runtime, { deliverAs: "followUp" })
+
+		expect(pi.sendMessage).not.toHaveBeenCalled()
+		expect(pi.appendEntry).not.toHaveBeenCalled()
 		expect(setActiveSpy).toHaveBeenCalledWith(undefined)
 	})
 

--- a/src/extensions/ferment/scheduler.ts
+++ b/src/extensions/ferment/scheduler.ts
@@ -166,10 +166,18 @@ function shouldSuppressHiddenNudge(action: DeclarativeAction, policy: Continuati
 
 export function scheduleNextFermentAction(
 	pi: ExtensionAPI,
-	ferment: Ferment,
+	scheduledFerment: Ferment,
 	runtime: FermentRuntime,
 	opts: ScheduleNextFermentActionOptions = {},
 ): void {
+	const ferment = runtime.getStorage().get(scheduledFerment.id) ?? scheduledFerment
+	if (ferment.status === "complete" || ferment.status === "abandoned" || ferment.status === "paused") {
+		if (ferment.status === "complete" || ferment.status === "abandoned") runtime.setActive(undefined)
+		else runtime.setActive(ferment)
+		return
+	}
+	runtime.setActive(ferment)
+
 	const decision = decideContinuation(ferment, runtime.getContinuationPolicy(), opts)
 	if (decision.type === "wait_manual_boundary") {
 		tryPiAction(() => {

--- a/src/extensions/orchestration/model-roles-command.ts
+++ b/src/extensions/orchestration/model-roles-command.ts
@@ -43,11 +43,24 @@ const ROLE_LABELS: Record<keyof ModelRoles, { label: string; description: string
 	explorer: { label: "Explorer", description: "codebase exploration" },
 	researcher: { label: "Researcher", description: "research beyond codebase, web search" },
 	judge: { label: "Judge", description: "ferment verification and grading" },
+	// Not surfaced in this interactive picker (ROLE_KEYS below omits it) — config-file only for now.
+	compactor: { label: "Compactor", description: "summarizes ferment stage-boundary handoffs" },
 }
 
-const DELEGABLE_KEYS: (keyof ModelRoles)[] = ["planner", "builder", "reviewer", "explorer", "researcher", "judge"]
+// "compactor" is excluded here (not just from the arrays): it's optional and
+// config-file only — this interactive picker doesn't surface it, and indexing
+// roles[key]/DEFAULT_MODEL_ROLES[key] for key in these arrays must stay
+// narrowed away from compactor's `string | undefined` type.
+const DELEGABLE_KEYS: (keyof Omit<ModelRoles, "orchestrator" | "compactor">)[] = [
+	"planner",
+	"builder",
+	"reviewer",
+	"explorer",
+	"researcher",
+	"judge",
+]
 
-const ROLE_KEYS: (keyof ModelRoles)[] = ["orchestrator", ...DELEGABLE_KEYS]
+const ROLE_KEYS: (keyof Omit<ModelRoles, "compactor">)[] = ["orchestrator", ...DELEGABLE_KEYS]
 
 /**
  * Whether `collectModelMetadata()` produced something worth persisting.
@@ -71,7 +84,7 @@ export function isEqualAssignment(a: RoleModelAssignment, b: RoleModelAssignment
 	return arrA.length === arrB.length && arrA.every((v, i) => v === arrB[i])
 }
 
-export function formatRoleSummaryBlock(role: keyof ModelRoles, value: RoleModelAssignment): string {
+export function formatRoleSummaryBlock(role: keyof Omit<ModelRoles, "compactor">, value: RoleModelAssignment): string {
 	const info = ROLE_LABELS[role]
 	const models = normalizeRoleModels(value)
 	const isDefault = isEqualAssignment(value, DEFAULT_MODEL_ROLES[role])
@@ -85,7 +98,7 @@ export function formatRoleSummaryBlock(role: keyof ModelRoles, value: RoleModelA
 	return `${info.label}:\n${modelLines.join("\n")}`
 }
 
-export function formatRoleDisplay(role: keyof ModelRoles, value: RoleModelAssignment): string {
+export function formatRoleDisplay(role: keyof Omit<ModelRoles, "compactor">, value: RoleModelAssignment): string {
 	const info = ROLE_LABELS[role]
 	const isDefault = isEqualAssignment(value, DEFAULT_MODEL_ROLES[role])
 	const suffix = isDefault ? " (default)" : ""
@@ -379,7 +392,7 @@ export function registerModelRolesCommand(pi: ExtensionAPI): void {
 				await showMainMenu()
 			}
 
-			const showSingleModelEditor = async (roleKey: keyof ModelRoles): Promise<void> => {
+			const showSingleModelEditor = async (roleKey: keyof Omit<ModelRoles, "compactor">): Promise<void> => {
 				const info = ROLE_LABELS[roleKey]
 				const currentModels = normalizeRoleModels(roles[roleKey])
 
@@ -424,7 +437,7 @@ export function registerModelRolesCommand(pi: ExtensionAPI): void {
 				}
 			}
 
-			const showMultiModelEditor = async (roleKey: keyof ModelRoles): Promise<void> => {
+			const showMultiModelEditor = async (roleKey: keyof Omit<ModelRoles, "compactor">): Promise<void> => {
 				const info = ROLE_LABELS[roleKey]
 				const selected = new Set(normalizeRoleModels(roles[roleKey]))
 

--- a/src/extensions/orchestration/model-roles.test.ts
+++ b/src/extensions/orchestration/model-roles.test.ts
@@ -28,8 +28,8 @@ import {
 	extractCustomConfigs,
 	getAllowedMultiModelRefs,
 	getModelRoles,
-	modelIdFromRef,
 	type ModelRoles,
+	modelIdFromRef,
 	normalizeRoleModels,
 	parseModelRoles,
 	resetModelRolesCache,
@@ -588,17 +588,8 @@ describe("compactor role", () => {
 	})
 
 	describe("saveModelRoles", () => {
-		const testDir = join(tmpdir(), `kimchi-model-roles-compactor-test-${process.pid}`)
-		const testPath = join(testDir, "settings.json")
-
-		afterEach(() => {
-			try {
-				rmSync(testDir, { recursive: true, force: true })
-			} catch {}
-		})
-
 		it("persists a configured compactor override", () => {
-			saveModelRoles({ ...DEFAULT_MODEL_ROLES, compactor: CUSTOM_COMPACTOR_MODEL }, testPath)
+			saveModelRoles({ ...DEFAULT_MODEL_ROLES, compactor: CUSTOM_COMPACTOR_MODEL })
 			const saved = JSON.parse(readFileSync(testPath, "utf-8"))
 			expect(saved.modelRoles.compactor).toBe(CUSTOM_COMPACTOR_MODEL)
 		})

--- a/src/extensions/orchestration/model-roles.test.ts
+++ b/src/extensions/orchestration/model-roles.test.ts
@@ -43,7 +43,8 @@ afterEach(() => {
 	resetModelMetadataCache()
 })
 
-const COMPACTOR_MODEL = "kimchi-dev/nemotron-3-ultra-fp4"
+const DEFAULT_COMPACTOR_MODEL = "kimchi-dev/nemotron-3-ultra-fp4"
+const CUSTOM_COMPACTOR_MODEL = "kimchi-dev/minimax-m3"
 
 describe("parseModelRoles", () => {
 	it("returns defaults when raw is undefined", () => {
@@ -76,6 +77,7 @@ describe("parseModelRoles", () => {
 			explorer: "kimchi-dev/nemotron-3-ultra-fp4",
 			researcher: "kimchi-dev/nemotron-3-ultra-fp4",
 			judge: "kimchi-dev/claude-opus-4-6",
+			compactor: DEFAULT_COMPACTOR_MODEL,
 		}
 		const { roles } = parseModelRoles(custom)
 		expect(roles).toEqual(custom)
@@ -420,7 +422,7 @@ describe("validateModelRoles", () => {
 		expect(result.unavailable.length).toBeGreaterThanOrEqual(5)
 		const flaggedRoles = new Set(result.unavailable.map((u) => u.role))
 		expect(flaggedRoles).toEqual(
-			new Set(["orchestrator", "planner", "builder", "reviewer", "explorer", "researcher", "judge"]),
+			new Set(["orchestrator", "planner", "builder", "reviewer", "explorer", "researcher", "judge", "compactor"]),
 		)
 	})
 })
@@ -557,19 +559,19 @@ describe("getAllowedMultiModelRefs", () => {
 })
 
 describe("compactor role", () => {
-	it("has no hardcoded default — unset means no override", () => {
-		expect(DEFAULT_MODEL_ROLES.compactor).toBeUndefined()
+	it("defaults to nemotron", () => {
+		expect(DEFAULT_MODEL_ROLES.compactor).toBe(DEFAULT_COMPACTOR_MODEL)
 	})
 
 	it("parses a valid compactor override", () => {
-		const { roles, warnings } = parseModelRoles({ compactor: COMPACTOR_MODEL })
-		expect(roles.compactor).toBe(COMPACTOR_MODEL)
+		const { roles, warnings } = parseModelRoles({ compactor: CUSTOM_COMPACTOR_MODEL })
+		expect(roles.compactor).toBe(CUSTOM_COMPACTOR_MODEL)
 		expect(warnings).toHaveLength(0)
 	})
 
 	it("warns and ignores a non-string compactor value", () => {
 		const { roles, warnings } = parseModelRoles({ compactor: 42 })
-		expect(roles.compactor).toBeUndefined()
+		expect(roles.compactor).toBe(DEFAULT_COMPACTOR_MODEL)
 		expect(warnings).toHaveLength(1)
 		expect(warnings[0].role).toBe("compactor")
 	})
@@ -580,8 +582,8 @@ describe("compactor role", () => {
 		expect(result.unavailable).toContainEqual({ role: "compactor", configuredModel: "kimchi-dev/does-not-exist" })
 	})
 
-	it("validateModelRoles does not flag compactor when unset", () => {
-		const result = validateModelRoles(DEFAULT_MODEL_ROLES, new Set())
+	it("validateModelRoles does not flag the default compactor when available", () => {
+		const result = validateModelRoles(DEFAULT_MODEL_ROLES, new Set(["nemotron-3-ultra-fp4"]))
 		expect(result.unavailable.some((u) => u.role === "compactor")).toBe(false)
 	})
 
@@ -596,17 +598,17 @@ describe("compactor role", () => {
 		})
 
 		it("persists a configured compactor override", () => {
-			saveModelRoles({ ...DEFAULT_MODEL_ROLES, compactor: COMPACTOR_MODEL }, testPath)
+			saveModelRoles({ ...DEFAULT_MODEL_ROLES, compactor: CUSTOM_COMPACTOR_MODEL }, testPath)
 			const saved = JSON.parse(readFileSync(testPath, "utf-8"))
-			expect(saved.modelRoles.compactor).toBe(COMPACTOR_MODEL)
+			expect(saved.modelRoles.compactor).toBe(CUSTOM_COMPACTOR_MODEL)
 		})
 	})
 })
 
 describe("applyRoleAugmentation", () => {
 	it("persists a transform that only changes compactor", () => {
-		applyRoleAugmentation((roles) => ({ ...roles, compactor: COMPACTOR_MODEL }))
-		expect(getModelRoles().compactor).toBe(COMPACTOR_MODEL)
+		applyRoleAugmentation((roles) => ({ ...roles, compactor: CUSTOM_COMPACTOR_MODEL }))
+		expect(getModelRoles().compactor).toBe(CUSTOM_COMPACTOR_MODEL)
 	})
 
 	it("is a no-op when the transform returns an equal ModelRoles", () => {

--- a/src/extensions/orchestration/model-roles.test.ts
+++ b/src/extensions/orchestration/model-roles.test.ts
@@ -43,6 +43,8 @@ afterEach(() => {
 	resetModelMetadataCache()
 })
 
+const COMPACTOR_MODEL = "kimchi-dev/nemotron-3-ultra-fp4"
+
 describe("parseModelRoles", () => {
 	it("returns defaults when raw is undefined", () => {
 		const { roles, warnings } = parseModelRoles(undefined)
@@ -457,16 +459,6 @@ describe("saveModelRoles", () => {
 		} catch {}
 	})
 
-	it("saves string roles to modelRoles key", () => {
-		const roles: ModelRoles = {
-			...DEFAULT_MODEL_ROLES,
-			builder: "anthropic/claude-sonnet-4-5",
-		}
-		saveModelRoles(roles)
-		const saved = JSON.parse(readFileSync(testPath, "utf-8"))
-		expect(saved.modelRoles.builder).toBe("anthropic/claude-sonnet-4-5")
-	})
-
 	it("does not write modelMetadata", () => {
 		const roles: ModelRoles = {
 			...DEFAULT_MODEL_ROLES,
@@ -570,14 +562,9 @@ describe("compactor role", () => {
 	})
 
 	it("parses a valid compactor override", () => {
-		const { roles, warnings } = parseModelRoles({ compactor: "kimchi-dev/kimi-k2.6" })
-		expect(roles.compactor).toBe("kimchi-dev/kimi-k2.6")
+		const { roles, warnings } = parseModelRoles({ compactor: COMPACTOR_MODEL })
+		expect(roles.compactor).toBe(COMPACTOR_MODEL)
 		expect(warnings).toHaveLength(0)
-	})
-
-	it("trims whitespace from a valid compactor override", () => {
-		const { roles } = parseModelRoles({ compactor: "  kimchi-dev/kimi-k2.6  " })
-		expect(roles.compactor).toBe("kimchi-dev/kimi-k2.6")
 	})
 
 	it("warns and ignores a non-string compactor value", () => {
@@ -585,17 +572,6 @@ describe("compactor role", () => {
 		expect(roles.compactor).toBeUndefined()
 		expect(warnings).toHaveLength(1)
 		expect(warnings[0].role).toBe("compactor")
-	})
-
-	it("warns and ignores an empty-string compactor value", () => {
-		const { roles, warnings } = parseModelRoles({ compactor: "" })
-		expect(roles.compactor).toBeUndefined()
-		expect(warnings).toHaveLength(1)
-	})
-
-	it("leaves compactor unset when absent from raw settings", () => {
-		const { roles } = parseModelRoles({ orchestrator: "kimchi-dev/kimi-k2.7" })
-		expect(roles.compactor).toBeUndefined()
 	})
 
 	it("validateModelRoles flags an unavailable compactor model", () => {
@@ -620,23 +596,17 @@ describe("compactor role", () => {
 		})
 
 		it("persists a configured compactor override", () => {
-			saveModelRoles({ ...DEFAULT_MODEL_ROLES, compactor: "kimchi-dev/kimi-k2.6" }, testPath)
+			saveModelRoles({ ...DEFAULT_MODEL_ROLES, compactor: COMPACTOR_MODEL }, testPath)
 			const saved = JSON.parse(readFileSync(testPath, "utf-8"))
-			expect(saved.modelRoles.compactor).toBe("kimchi-dev/kimi-k2.6")
-		})
-
-		it("omits compactor from the saved file when unset", () => {
-			saveModelRoles({ ...DEFAULT_MODEL_ROLES, builder: "anthropic/claude-sonnet-4-5" }, testPath)
-			const saved = JSON.parse(readFileSync(testPath, "utf-8"))
-			expect(saved.modelRoles.compactor).toBeUndefined()
+			expect(saved.modelRoles.compactor).toBe(COMPACTOR_MODEL)
 		})
 	})
 })
 
 describe("applyRoleAugmentation", () => {
 	it("persists a transform that only changes compactor", () => {
-		applyRoleAugmentation((roles) => ({ ...roles, compactor: "kimchi-dev/kimi-k2.6" }))
-		expect(getModelRoles().compactor).toBe("kimchi-dev/kimi-k2.6")
+		applyRoleAugmentation((roles) => ({ ...roles, compactor: COMPACTOR_MODEL }))
+		expect(getModelRoles().compactor).toBe(COMPACTOR_MODEL)
 	})
 
 	it("is a no-op when the transform returns an equal ModelRoles", () => {

--- a/src/extensions/orchestration/model-roles.test.ts
+++ b/src/extensions/orchestration/model-roles.test.ts
@@ -27,8 +27,9 @@ import {
 	DEFAULT_MODEL_ROLES,
 	extractCustomConfigs,
 	getAllowedMultiModelRefs,
-	type ModelRoles,
+	getModelRoles,
 	modelIdFromRef,
+	type ModelRoles,
 	normalizeRoleModels,
 	parseModelRoles,
 	resetModelRolesCache,
@@ -560,5 +561,87 @@ describe("getAllowedMultiModelRefs", () => {
 			"provider-e/model-5",
 			"provider-f/model-6",
 		])
+	})
+})
+
+describe("compactor role", () => {
+	it("has no hardcoded default — unset means no override", () => {
+		expect(DEFAULT_MODEL_ROLES.compactor).toBeUndefined()
+	})
+
+	it("parses a valid compactor override", () => {
+		const { roles, warnings } = parseModelRoles({ compactor: "kimchi-dev/kimi-k2.6" })
+		expect(roles.compactor).toBe("kimchi-dev/kimi-k2.6")
+		expect(warnings).toHaveLength(0)
+	})
+
+	it("trims whitespace from a valid compactor override", () => {
+		const { roles } = parseModelRoles({ compactor: "  kimchi-dev/kimi-k2.6  " })
+		expect(roles.compactor).toBe("kimchi-dev/kimi-k2.6")
+	})
+
+	it("warns and ignores a non-string compactor value", () => {
+		const { roles, warnings } = parseModelRoles({ compactor: 42 })
+		expect(roles.compactor).toBeUndefined()
+		expect(warnings).toHaveLength(1)
+		expect(warnings[0].role).toBe("compactor")
+	})
+
+	it("warns and ignores an empty-string compactor value", () => {
+		const { roles, warnings } = parseModelRoles({ compactor: "" })
+		expect(roles.compactor).toBeUndefined()
+		expect(warnings).toHaveLength(1)
+	})
+
+	it("leaves compactor unset when absent from raw settings", () => {
+		const { roles } = parseModelRoles({ orchestrator: "kimchi-dev/kimi-k2.7" })
+		expect(roles.compactor).toBeUndefined()
+	})
+
+	it("validateModelRoles flags an unavailable compactor model", () => {
+		const roles: ModelRoles = { ...DEFAULT_MODEL_ROLES, compactor: "kimchi-dev/does-not-exist" }
+		const result = validateModelRoles(roles, new Set(["kimi-k2.7"]))
+		expect(result.unavailable).toContainEqual({ role: "compactor", configuredModel: "kimchi-dev/does-not-exist" })
+	})
+
+	it("validateModelRoles does not flag compactor when unset", () => {
+		const result = validateModelRoles(DEFAULT_MODEL_ROLES, new Set())
+		expect(result.unavailable.some((u) => u.role === "compactor")).toBe(false)
+	})
+
+	describe("saveModelRoles", () => {
+		const testDir = join(tmpdir(), `kimchi-model-roles-compactor-test-${process.pid}`)
+		const testPath = join(testDir, "settings.json")
+
+		afterEach(() => {
+			try {
+				rmSync(testDir, { recursive: true, force: true })
+			} catch {}
+		})
+
+		it("persists a configured compactor override", () => {
+			saveModelRoles({ ...DEFAULT_MODEL_ROLES, compactor: "kimchi-dev/kimi-k2.6" }, testPath)
+			const saved = JSON.parse(readFileSync(testPath, "utf-8"))
+			expect(saved.modelRoles.compactor).toBe("kimchi-dev/kimi-k2.6")
+		})
+
+		it("omits compactor from the saved file when unset", () => {
+			saveModelRoles({ ...DEFAULT_MODEL_ROLES, builder: "anthropic/claude-sonnet-4-5" }, testPath)
+			const saved = JSON.parse(readFileSync(testPath, "utf-8"))
+			expect(saved.modelRoles.compactor).toBeUndefined()
+		})
+	})
+})
+
+describe("applyRoleAugmentation", () => {
+	it("persists a transform that only changes compactor", () => {
+		applyRoleAugmentation((roles) => ({ ...roles, compactor: "kimchi-dev/kimi-k2.6" }))
+		expect(getModelRoles().compactor).toBe("kimchi-dev/kimi-k2.6")
+	})
+
+	it("is a no-op when the transform returns an equal ModelRoles", () => {
+		const before = getModelRoles()
+		applyRoleAugmentation((roles) => ({ ...roles }))
+		expect(getModelRoles()).toEqual(before)
 	})
 })

--- a/src/extensions/orchestration/model-roles.test.ts
+++ b/src/extensions/orchestration/model-roles.test.ts
@@ -43,8 +43,8 @@ afterEach(() => {
 	resetModelMetadataCache()
 })
 
-const DEFAULT_COMPACTOR_MODEL = "kimchi-dev/nemotron-3-ultra-fp4"
-const CUSTOM_COMPACTOR_MODEL = "kimchi-dev/minimax-m3"
+const DEFAULT_COMPACTOR_MODEL = "kimchi-dev/minimax-m3"
+const CUSTOM_COMPACTOR_MODEL = "kimchi-dev/nemotron-3-ultra-fp4"
 
 describe("parseModelRoles", () => {
 	it("returns defaults when raw is undefined", () => {
@@ -583,7 +583,7 @@ describe("compactor role", () => {
 	})
 
 	it("validateModelRoles does not flag the default compactor when available", () => {
-		const result = validateModelRoles(DEFAULT_MODEL_ROLES, new Set(["nemotron-3-ultra-fp4"]))
+		const result = validateModelRoles(DEFAULT_MODEL_ROLES, new Set(["minimax-m3"]))
 		expect(result.unavailable.some((u) => u.role === "compactor")).toBe(false)
 	})
 

--- a/src/extensions/orchestration/model-roles.ts
+++ b/src/extensions/orchestration/model-roles.ts
@@ -1,7 +1,7 @@
 /**
  * Role-based model configuration for multi-model orchestration.
  *
- * Seven roles:
+ * Eight roles:
  *   - orchestrator: runs the main loop, delegates work (single model)
  *   - planner: designs the approach, writes specs
  *   - builder: code implementation
@@ -9,6 +9,12 @@
  *   - explorer: codebase exploration, reading files, tracing architecture
  *   - researcher: research beyond codebase — web search, documentation lookup
  *   - judge: ferment verification and final grading calls
+ *   - compactor: summarizes ferment stage-boundary handoffs (see
+ *     ferment/auto-compaction.ts). Optional, no hardcoded default — unset means
+ *     "no override," and inline compaction uses the active session's model
+ *     exactly as before. Compaction is pure summarization, so this is a good
+ *     place to point at a fast, non-reasoning model once you know one in your
+ *     catalog.
  *
  * Delegable roles (planner, builder, reviewer, explorer) accept either a
  * single model string or an array of candidates. When multiple models are
@@ -31,7 +37,8 @@
  *     "builder": ["anthropic/claude-sonnet-4-5", "openai/gpt-4o"],
  *     "reviewer": "kimchi-dev/minimax-m2.7",
  *     "explorer": "kimchi-dev/nemotron-3-ultra-fp4",
- *     "judge": "kimchi-dev/kimi-k2.6"
+ *     "judge": "kimchi-dev/kimi-k2.6",
+ *     "compactor": "kimchi-dev/some-non-reasoning-model"
  *   }
  * }
  * ```
@@ -72,9 +79,16 @@ export interface ModelRoles {
 	researcher: RoleModelAssignment
 	/** Ferment judge model(s): verification triage and final grading calls. */
 	judge: RoleModelAssignment
+	/** Compaction model: summarizes ferment stage-boundary handoffs. Optional and
+	 *  NOT part of DEFAULT_MODEL_ROLES — unset means "no override," inline
+	 *  compaction falls back to the active session's model. */
+	compactor?: string
 }
 
-const DELEGABLE_ROLE_KEYS: readonly (keyof Omit<ModelRoles, "orchestrator">)[] = [
+// "compactor" is excluded from these key types (not just omitted from the arrays):
+// it's optional and single-model-only, so indexing roles[key] for key in ROLE_KEYS
+// must stay narrowed to the always-present, non-optional role keys.
+const DELEGABLE_ROLE_KEYS: readonly (keyof Omit<ModelRoles, "orchestrator" | "compactor">)[] = [
 	"planner",
 	"builder",
 	"reviewer",
@@ -82,7 +96,7 @@ const DELEGABLE_ROLE_KEYS: readonly (keyof Omit<ModelRoles, "orchestrator">)[] =
 	"researcher",
 	"judge",
 ]
-const ROLE_KEYS: readonly (keyof ModelRoles)[] = ["orchestrator", ...DELEGABLE_ROLE_KEYS]
+const ROLE_KEYS: readonly (keyof Omit<ModelRoles, "compactor">)[] = ["orchestrator", ...DELEGABLE_ROLE_KEYS]
 
 /** Hardcoded default model-to-role assignment. Users override via /multi-model. */
 export const DEFAULT_MODEL_ROLES: Readonly<ModelRoles> = {
@@ -161,6 +175,21 @@ export function parseModelRoles(obj: ModelRoles | Record<string, unknown> | unde
 		}
 	}
 
+	// compactor is optional and single-model-only (like orchestrator), so it is
+	// handled outside ROLE_KEYS rather than widening the generic loop's types.
+	const compactorValue = obj.compactor
+	if (compactorValue !== undefined && compactorValue !== null) {
+		if (typeof compactorValue !== "string" || compactorValue.trim().length === 0) {
+			warnings.push({
+				role: "compactor",
+				configuredModel: String(compactorValue),
+				message: 'modelRoles.compactor must be a non-empty string (e.g. "kimchi-dev/kimi-k2.6"). Ignoring.',
+			})
+		} else {
+			roles.compactor = compactorValue.trim()
+		}
+	}
+
 	return { roles, warnings }
 }
 
@@ -188,6 +217,9 @@ export function saveModelRoles(roles: ModelRoles): void {
 		if (!isEqualRoleValue(roles[key], DEFAULT_MODEL_ROLES[key])) {
 			rolesObj[key] = roles[key]
 		}
+	}
+	if (roles.compactor !== undefined && roles.compactor !== DEFAULT_MODEL_ROLES.compactor) {
+		rolesObj.compactor = roles.compactor
 	}
 
 	if (Object.keys(rolesObj).length === 0) {
@@ -231,6 +263,9 @@ export function validateModelRoles(
 				unavailable.push({ role: key, configuredModel: ref })
 			}
 		}
+	}
+	if (roles.compactor !== undefined && !availableModelIds.has(modelIdFromRef(roles.compactor))) {
+		unavailable.push({ role: "compactor", configuredModel: roles.compactor })
 	}
 	return { unavailable }
 }
@@ -297,7 +332,9 @@ function isEqualModelRoles(a: ModelRoles, b: ModelRoles): boolean {
 	for (const key of ROLE_KEYS) {
 		if (!isEqualRoleValue(a[key], b[key])) return false
 	}
-	return true
+	// compactor is excluded from ROLE_KEYS (optional, not part of the generic
+	// loop's types — see the ROLE_KEYS comment), so it needs its own comparison.
+	return a.compactor === b.compactor
 }
 
 /**

--- a/src/extensions/orchestration/model-roles.ts
+++ b/src/extensions/orchestration/model-roles.ts
@@ -8,7 +8,7 @@
  *   - explorer: codebase exploration, reading files, tracing architecture
  *   - researcher: research beyond codebase — web search, documentation lookup
  *   - judge: ferment verification and final grading calls
- *   - compactor: optional context summarization model; unset uses the active session model.
+ *   - compactor: context summarization model.
  *
  * Delegable roles (planner, builder, reviewer, explorer) accept either a
  * single model string or an array of candidates. When multiple models are
@@ -73,7 +73,7 @@ export interface ModelRoles {
 	researcher: RoleModelAssignment
 	/** Ferment judge model(s): verification triage and final grading calls. */
 	judge: RoleModelAssignment
-	/** Optional context summarization model; unset uses the active session model. */
+	/** Context summarization model. */
 	compactor?: string
 }
 
@@ -99,6 +99,7 @@ export const DEFAULT_MODEL_ROLES: Readonly<ModelRoles> = {
 	explorer: "kimchi-dev/nemotron-3-ultra-fp4",
 	researcher: "kimchi-dev/minimax-m3",
 	judge: ["kimchi-dev/kimi-k2.7"],
+	compactor: "kimchi-dev/nemotron-3-ultra-fp4",
 }
 
 export interface ModelRolesWarning {

--- a/src/extensions/orchestration/model-roles.ts
+++ b/src/extensions/orchestration/model-roles.ts
@@ -99,7 +99,7 @@ export const DEFAULT_MODEL_ROLES: Readonly<ModelRoles> = {
 	explorer: "kimchi-dev/nemotron-3-ultra-fp4",
 	researcher: "kimchi-dev/minimax-m3",
 	judge: ["kimchi-dev/kimi-k2.7"],
-	compactor: "kimchi-dev/nemotron-3-ultra-fp4",
+	compactor: "kimchi-dev/minimax-m3",
 }
 
 export interface ModelRolesWarning {

--- a/src/extensions/orchestration/model-roles.ts
+++ b/src/extensions/orchestration/model-roles.ts
@@ -171,7 +171,7 @@ export function parseModelRoles(obj: ModelRoles | Record<string, unknown> | unde
 	// compactor is optional and single-model-only (like orchestrator), so it is
 	// handled outside ROLE_KEYS rather than widening the generic loop's types.
 	const compactorValue = obj.compactor
-	if (compactorValue !== undefined && compactorValue !== null) {
+	if (compactorValue != null) {
 		if (typeof compactorValue !== "string" || compactorValue.trim().length === 0) {
 			warnings.push({
 				role: "compactor",

--- a/src/extensions/orchestration/model-roles.ts
+++ b/src/extensions/orchestration/model-roles.ts
@@ -1,7 +1,6 @@
 /**
  * Role-based model configuration for multi-model orchestration.
  *
- * Eight roles:
  *   - orchestrator: runs the main loop, delegates work (single model)
  *   - planner: designs the approach, writes specs
  *   - builder: code implementation
@@ -9,12 +8,7 @@
  *   - explorer: codebase exploration, reading files, tracing architecture
  *   - researcher: research beyond codebase — web search, documentation lookup
  *   - judge: ferment verification and final grading calls
- *   - compactor: summarizes ferment stage-boundary handoffs (see
- *     ferment/auto-compaction.ts). Optional, no hardcoded default — unset means
- *     "no override," and inline compaction uses the active session's model
- *     exactly as before. Compaction is pure summarization, so this is a good
- *     place to point at a fast, non-reasoning model once you know one in your
- *     catalog.
+ *   - compactor: optional context summarization model; unset uses the active session model.
  *
  * Delegable roles (planner, builder, reviewer, explorer) accept either a
  * single model string or an array of candidates. When multiple models are
@@ -38,7 +32,7 @@
  *     "reviewer": "kimchi-dev/minimax-m2.7",
  *     "explorer": "kimchi-dev/nemotron-3-ultra-fp4",
  *     "judge": "kimchi-dev/kimi-k2.6",
- *     "compactor": "kimchi-dev/some-non-reasoning-model"
+ *     "compactor": "kimchi-dev/nemotron-3-ultra-fp4"
  *   }
  * }
  * ```
@@ -79,9 +73,7 @@ export interface ModelRoles {
 	researcher: RoleModelAssignment
 	/** Ferment judge model(s): verification triage and final grading calls. */
 	judge: RoleModelAssignment
-	/** Compaction model: summarizes ferment stage-boundary handoffs. Optional and
-	 *  NOT part of DEFAULT_MODEL_ROLES — unset means "no override," inline
-	 *  compaction falls back to the active session's model. */
+	/** Optional context summarization model; unset uses the active session model. */
 	compactor?: string
 }
 
@@ -183,7 +175,7 @@ export function parseModelRoles(obj: ModelRoles | Record<string, unknown> | unde
 			warnings.push({
 				role: "compactor",
 				configuredModel: String(compactorValue),
-				message: 'modelRoles.compactor must be a non-empty string (e.g. "kimchi-dev/kimi-k2.6"). Ignoring.',
+				message: 'modelRoles.compactor must be a non-empty string (e.g. "kimchi-dev/nemotron-3-ultra-fp4"). Ignoring.',
 			})
 		} else {
 			roles.compactor = compactorValue.trim()

--- a/src/extensions/prompt-summary.test.ts
+++ b/src/extensions/prompt-summary.test.ts
@@ -3,7 +3,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
 import { createContext } from "./__mocks__/context.js"
 import promptSummaryExtension from "./prompt-summary.js"
 
-type Handler = (event: unknown, ctx: unknown) => void | Promise<void>
+type Handler = (event?: unknown, ctx?: unknown) => void | Promise<void>
 
 function createPiHarness() {
 	const handlers = new Map<string, Handler[]>()
@@ -20,8 +20,8 @@ function createPiHarness() {
 				sent.push(message)
 			},
 		} as unknown as ExtensionAPI,
-		async emit(event: string, payload: unknown) {
-			const ctx = createContext()
+		async emit(event: string, payload?: unknown, ctxOverride?: Record<string, unknown>) {
+			const ctx = createContext(ctxOverride)
 			for (const handler of handlers.get(event) ?? []) {
 				await handler(payload, ctx)
 			}
@@ -90,6 +90,26 @@ describe("prompt summary Agent token accounting", () => {
 
 		const message = harness.sent[0] as { details: Record<string, unknown> }
 		expect(message.details.subagents).toEqual({ input: 18, output: 9, cacheRead: 0, cacheWrite: 3 })
+	})
+
+	it("drops the optional summary when the extension context is stale", async () => {
+		const harness = createPiHarness()
+		promptSummaryExtension(harness.pi as never)
+		const staleCtx = {
+			isIdle: vi.fn(() => {
+				throw new Error("This extension ctx is stale after session replacement or reload")
+			}),
+		}
+
+		await harness.emit("agent_start")
+		await harness.emit("tool_result", {
+			toolName: "get_subagent_result",
+			details: { agentId: "agent-1", tokenUsage: { input: 10, output: 5, cacheRead: 0, cacheWrite: 0 } },
+		})
+		await expect(harness.emit("agent_end", {}, staleCtx)).resolves.toBeUndefined()
+
+		expect(staleCtx.isIdle).toHaveBeenCalledOnce()
+		expect(harness.sent).toEqual([])
 	})
 })
 

--- a/src/tool-call-in-flight.ts
+++ b/src/tool-call-in-flight.ts
@@ -1,0 +1,83 @@
+/**
+ * Pure helpers for detecting an in-flight tool call in session history.
+ *
+ * Shared by the ferment extension (deferral scheduling: leave the pending
+ * compaction in the map and retry at the next turn boundary) and the inline
+ * compaction primitive in upstream-inline-compact-patch.ts (safety assertion:
+ * fail loudly instead of corrupting context when a caller compacts across an
+ * unpaired toolCall).
+ */
+
+/**
+ * Return true if any assistant `toolCall` block `id` in `messages` has NO
+ * matching `toolResult` (by `toolCallId`) anywhere in the array.
+ *
+ * This is the compaction-timing root-cause signal: when the trailing session
+ * entries form an incomplete assistant toolCall -> toolResult pair, compacting
+ * would summarise away the assistant toolCall while its toolResult is appended
+ * later — creating an orphaned toolResult. By deferring compaction until the
+ * pair completes, orphans are never created at the compaction boundary in the
+ * first place.
+ *
+ * Pure, total, never throws: unknown shapes are skipped defensively.
+ */
+export function isToolCallInFlight(messages: ReadonlyArray<unknown>): boolean {
+	const callIds = new Set<string>()
+	const resultIds = new Set<string>()
+
+	for (const raw of messages) {
+		if (!raw || typeof raw !== "object") continue
+		const msg = raw as { role?: string; content?: unknown; toolCallId?: string }
+		if (msg.role === "assistant") {
+			const content = msg.content
+			if (!Array.isArray(content)) continue
+			for (const block of content) {
+				if (!block || typeof block !== "object") continue
+				const b = block as { type?: string; id?: unknown }
+				if (b.type === "toolCall" && typeof b.id === "string") {
+					callIds.add(b.id)
+				}
+			}
+		} else if (msg.role === "toolResult") {
+			if (typeof msg.toolCallId === "string") {
+				resultIds.add(msg.toolCallId)
+			}
+		}
+	}
+
+	for (const id of callIds) {
+		if (!resultIds.has(id)) return true
+	}
+	return false
+}
+
+/** Extract the message payloads from `message`-type session entries. */
+export function collectMessagesFromEntries(entries: ReadonlyArray<unknown>): unknown[] {
+	const messages: unknown[] = []
+	for (const entry of entries) {
+		if (!entry || typeof entry !== "object") continue
+		const e = entry as { type?: string; message?: unknown }
+		if (e.type === "message" && e.message && typeof e.message === "object") {
+			messages.push(e.message)
+		}
+	}
+	return messages
+}
+
+/**
+ * Like `collectMessagesFromEntries`, but scoped to entries after the newest
+ * `compaction` entry. A historical orphan that predates the last compaction is
+ * already neutralised at context-build time and must not permanently veto
+ * every future compaction.
+ */
+export function collectMessagesAfterLastCompaction(entries: ReadonlyArray<unknown>): unknown[] {
+	let start = 0
+	for (let i = entries.length - 1; i >= 0; i--) {
+		const entry = entries[i]
+		if (entry && typeof entry === "object" && (entry as { type?: string }).type === "compaction") {
+			start = i + 1
+			break
+		}
+	}
+	return collectMessagesFromEntries(entries.slice(start))
+}

--- a/src/tool-call-in-flight.ts
+++ b/src/tool-call-in-flight.ts
@@ -1,12 +1,8 @@
-/**
- * Pure helpers for detecting an in-flight tool call in session history.
- *
- * Shared by the ferment extension (deferral scheduling: leave the pending
- * compaction in the map and retry at the next turn boundary) and the inline
- * compaction primitive in upstream-inline-compact-patch.ts (safety assertion:
- * fail loudly instead of corrupting context when a caller compacts across an
- * unpaired toolCall).
- */
+/** Detect an in-flight tool call in Pi's active session messages. */
+
+import type { SessionMessageEntry } from "@earendil-works/pi-coding-agent"
+
+type SessionMessage = SessionMessageEntry["message"]
 
 /**
  * Return true if any assistant `toolCall` block `id` in `messages` has NO
@@ -19,29 +15,20 @@
  * pair completes, orphans are never created at the compaction boundary in the
  * first place.
  *
- * Pure, total, never throws: unknown shapes are skipped defensively.
  */
-export function isToolCallInFlight(messages: ReadonlyArray<unknown>): boolean {
+export function isToolCallInFlight(messages: ReadonlyArray<SessionMessage>): boolean {
 	const callIds = new Set<string>()
 	const resultIds = new Set<string>()
 
-	for (const raw of messages) {
-		if (!raw || typeof raw !== "object") continue
-		const msg = raw as { role?: string; content?: unknown; toolCallId?: string }
-		if (msg.role === "assistant") {
-			const content = msg.content
-			if (!Array.isArray(content)) continue
-			for (const block of content) {
-				if (!block || typeof block !== "object") continue
-				const b = block as { type?: string; id?: unknown }
-				if (b.type === "toolCall" && typeof b.id === "string") {
-					callIds.add(b.id)
+	for (const message of messages) {
+		if (message.role === "assistant") {
+			for (const block of message.content) {
+				if (block.type === "toolCall") {
+					callIds.add(block.id)
 				}
 			}
-		} else if (msg.role === "toolResult") {
-			if (typeof msg.toolCallId === "string") {
-				resultIds.add(msg.toolCallId)
-			}
+		} else if (message.role === "toolResult") {
+			resultIds.add(message.toolCallId)
 		}
 	}
 
@@ -49,35 +36,4 @@ export function isToolCallInFlight(messages: ReadonlyArray<unknown>): boolean {
 		if (!resultIds.has(id)) return true
 	}
 	return false
-}
-
-/** Extract the message payloads from `message`-type session entries. */
-export function collectMessagesFromEntries(entries: ReadonlyArray<unknown>): unknown[] {
-	const messages: unknown[] = []
-	for (const entry of entries) {
-		if (!entry || typeof entry !== "object") continue
-		const e = entry as { type?: string; message?: unknown }
-		if (e.type === "message" && e.message && typeof e.message === "object") {
-			messages.push(e.message)
-		}
-	}
-	return messages
-}
-
-/**
- * Like `collectMessagesFromEntries`, but scoped to entries after the newest
- * `compaction` entry. A historical orphan that predates the last compaction is
- * already neutralised at context-build time and must not permanently veto
- * every future compaction.
- */
-export function collectMessagesAfterLastCompaction(entries: ReadonlyArray<unknown>): unknown[] {
-	let start = 0
-	for (let i = entries.length - 1; i >= 0; i--) {
-		const entry = entries[i]
-		if (entry && typeof entry === "object" && (entry as { type?: string }).type === "compaction") {
-			start = i + 1
-			break
-		}
-	}
-	return collectMessagesFromEntries(entries.slice(start))
 }

--- a/src/types/inline-compact.d.ts
+++ b/src/types/inline-compact.d.ts
@@ -1,0 +1,8 @@
+import type { CompactionResult } from "@earendil-works/pi-coding-agent"
+import type { InlineCompactOptions } from "../upstream-inline-compact-patch.js"
+
+declare module "@earendil-works/pi-coding-agent" {
+	interface ExtensionContext {
+		inlineCompact?: (options?: InlineCompactOptions) => Promise<CompactionResult>
+	}
+}

--- a/src/upstream-inline-compact-patch.test.ts
+++ b/src/upstream-inline-compact-patch.test.ts
@@ -266,6 +266,34 @@ describe("installInlineCompactPatch", () => {
 		})
 	})
 
+	it("rejects an empty compaction preparation without saving a compaction", async () => {
+		const prepareCompaction = vi.fn(() => ({
+			firstKeptEntryId: "m1",
+			messagesToSummarize: [],
+			tokensBefore: 42,
+			turnPrefixMessages: [],
+		}))
+		const compact = vi.fn()
+		const module = makeCompactionModule({ prepareCompaction, compact })
+		installWith(module)
+		const session = new FakeSession()
+
+		await expect(inlineSession(session).inlineCompact({ force: true })).rejects.toThrow(
+			"Nothing to compact (no summarizable messages)",
+		)
+
+		expect(prepareCompaction).toHaveBeenCalledOnce()
+		expect(compact).not.toHaveBeenCalled()
+		expect(session.sessionManager.appendCompaction).not.toHaveBeenCalled()
+		expect(session.events).toContainEqual(
+			expect.objectContaining({
+				type: "compaction_end",
+				aborted: false,
+				errorMessage: expect.stringContaining("no summarizable messages"),
+			}),
+		)
+	})
+
 	it("rejects cancellation from session_before_compact", async () => {
 		const module = makeCompactionModule()
 		installWith(module)

--- a/src/upstream-inline-compact-patch.test.ts
+++ b/src/upstream-inline-compact-patch.test.ts
@@ -1,3 +1,4 @@
+import type { Api, Model } from "@earendil-works/pi-ai"
 import type { CompactionResult } from "@earendil-works/pi-coding-agent"
 import { beforeEach, describe, expect, it, vi } from "vitest"
 import {
@@ -213,6 +214,120 @@ describe("installInlineCompactPatch", () => {
 				expect.objectContaining({ type: "compaction_start", reason: "threshold" }),
 				expect.objectContaining({ type: "compaction_end", reason: "threshold", aborted: false }),
 			]),
+		)
+	})
+
+	it("uses options.model for auth and compaction instead of the session model when provided", async () => {
+		const compact = vi.fn(async () => ({
+			summary: "summary",
+			firstKeptEntryId: "m1",
+			tokensBefore: 42,
+			details: { source: "llm" },
+		}))
+		const module = makeCompactionModule({ compact })
+		installWith(module)
+		const session = new FakeSession()
+		const overrideModel: Model<Api> = {
+			id: "non-reasoning-model",
+			name: "Non-Reasoning Model",
+			api: "openai-completions",
+			provider: "kimchi-dev",
+			baseUrl: "https://example.test",
+			reasoning: false,
+			input: ["text"],
+			cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+			contextWindow: 128_000,
+			maxTokens: 8_192,
+		}
+
+		await inlineSession(session).inlineCompact({ customInstructions: "keep ferment", model: overrideModel })
+
+		expect(session._getCompactionRequestAuth).toHaveBeenCalledWith(overrideModel)
+		expect(compact).toHaveBeenCalledWith(
+			expect.anything(),
+			overrideModel,
+			"key",
+			{ "x-test": "1" },
+			"keep ferment",
+			expect.any(AbortSignal),
+			"low",
+			session.agent.streamFn,
+		)
+	})
+
+	it("falls back to the session model when options.model is omitted", async () => {
+		const compact = vi.fn(async () => ({
+			summary: "summary",
+			firstKeptEntryId: "m1",
+			tokensBefore: 42,
+			details: { source: "llm" },
+		}))
+		const module = makeCompactionModule({ compact })
+		installWith(module)
+		const session = new FakeSession()
+
+		await inlineSession(session).inlineCompact({ customInstructions: "keep ferment" })
+
+		expect(session._getCompactionRequestAuth).toHaveBeenCalledWith(session.model)
+		expect(compact).toHaveBeenCalledWith(
+			expect.anything(),
+			session.model,
+			"key",
+			{ "x-test": "1" },
+			"keep ferment",
+			expect.any(AbortSignal),
+			"low",
+			session.agent.streamFn,
+		)
+	})
+
+	it("uses options.thinkingLevel for the compaction call instead of the session thinking level when provided", async () => {
+		const compact = vi.fn(async () => ({
+			summary: "summary",
+			firstKeptEntryId: "m1",
+			tokensBefore: 42,
+			details: { source: "llm" },
+		}))
+		const module = makeCompactionModule({ compact })
+		installWith(module)
+		const session = new FakeSession()
+
+		await inlineSession(session).inlineCompact({ customInstructions: "keep ferment", thinkingLevel: "off" })
+
+		expect(compact).toHaveBeenCalledWith(
+			expect.anything(),
+			session.model,
+			"key",
+			{ "x-test": "1" },
+			"keep ferment",
+			expect.any(AbortSignal),
+			"off",
+			session.agent.streamFn,
+		)
+	})
+
+	it("falls back to the session thinking level when options.thinkingLevel is omitted", async () => {
+		const compact = vi.fn(async () => ({
+			summary: "summary",
+			firstKeptEntryId: "m1",
+			tokensBefore: 42,
+			details: { source: "llm" },
+		}))
+		const module = makeCompactionModule({ compact })
+		installWith(module)
+		const session = new FakeSession()
+
+		await inlineSession(session).inlineCompact({ customInstructions: "keep ferment" })
+
+		expect(compact).toHaveBeenCalledWith(
+			expect.anything(),
+			session.model,
+			"key",
+			{ "x-test": "1" },
+			"keep ferment",
+			expect.any(AbortSignal),
+			session.thinkingLevel,
+			session.agent.streamFn,
 		)
 	})
 

--- a/src/upstream-inline-compact-patch.test.ts
+++ b/src/upstream-inline-compact-patch.test.ts
@@ -208,7 +208,29 @@ describe("installInlineCompactPatch", () => {
 				sessionClass: DriftedSession as unknown as NonNullable<InlineCompactPatchOptions["sessionClass"]>,
 				runnerClass: FakeRunner as unknown as NonNullable<InlineCompactPatchOptions["runnerClass"]>,
 			}),
-		).toThrow("incompatible with Kimchi inline compaction")
+		).toThrow("expected it to quiesce via _disconnectFromAgent/abort")
+	})
+
+	it("identifies missing AgentSession prototype methods", () => {
+		class MissingCompactSession {
+			_bindExtensionCore(): void {}
+		}
+		expect(() =>
+			installInlineCompactPatch({
+				sessionClass: MissingCompactSession as unknown as NonNullable<InlineCompactPatchOptions["sessionClass"]>,
+				runnerClass: FakeRunner as unknown as NonNullable<InlineCompactPatchOptions["runnerClass"]>,
+			}),
+		).toThrow("missing AgentSession.compact() — upstream internals changed")
+	})
+
+	it("identifies a missing ExtensionRunner.createContext method", () => {
+		class MissingContextRunner {}
+		expect(() =>
+			installInlineCompactPatch({
+				sessionClass: FakeSession as unknown as NonNullable<InlineCompactPatchOptions["sessionClass"]>,
+				runnerClass: MissingContextRunner as unknown as NonNullable<InlineCompactPatchOptions["runnerClass"]>,
+			}),
+		).toThrow("missing ExtensionRunner.createContext() — upstream internals changed")
 	})
 
 	it("exposes ctx.inlineCompact from ExtensionRunner contexts", async () => {

--- a/src/upstream-inline-compact-patch.test.ts
+++ b/src/upstream-inline-compact-patch.test.ts
@@ -1,12 +1,10 @@
 import type { Api, Model } from "@earendil-works/pi-ai"
-import type { CompactionResult } from "@earendil-works/pi-coding-agent"
+import { AgentSession, type CompactionResult, ExtensionRunner } from "@earendil-works/pi-coding-agent"
 import { beforeEach, describe, expect, it, vi } from "vitest"
 import {
-	type InlineCompactCompactionModule,
 	type InlineCompactOptions,
 	type InlineCompactPatchOptions,
 	installInlineCompactPatch,
-	loadDefaultCompactionModule,
 } from "./upstream-inline-compact-patch.js"
 
 type EventRecord = Record<string, unknown>
@@ -20,6 +18,15 @@ class FakeRunner {
 	}
 }
 
+/**
+ * Emulates the parts of upstream AgentSession.compact() the delegation wrapper
+ * interacts with, in upstream's call order: _disconnectFromAgent → await
+ * this.abort() → set _compactionAbortController → auth via this.model →
+ * prepare via settingsManager.getCompactionSettings() → summarize with
+ * this.model/this.thinkingLevel → append + rebuild messages → finally clear
+ * controller + _reconnectToAgent(). The install-time source assertion requires
+ * the same `_disconnectFromAgent` / `this.abort` markers as the real method.
+ */
 class FakeSession {
 	model: unknown = { provider: "test", id: "model" }
 	thinkingLevel: unknown = "low"
@@ -29,39 +36,37 @@ class FakeSession {
 	}
 	_compactionAbortController?: AbortController
 	_autoCompactionAbortController?: AbortController
-	_inlineCompactionAbortController?: AbortController
 	events: EventRecord[] = []
 	disconnect = vi.fn()
+	reconnect = vi.fn()
 	originalAbortCalls = 0
-	originalAbortCompactionCalls = 0
 	boundRunner?: FakeRunner
-	branch: unknown[] = [{ type: "message", id: "m1" }]
+	branch: unknown[] = [{ type: "message", id: "m1", message: { role: "user", content: "hi" } }]
 	entries: unknown[] = [...this.branch]
+	/** Settings snapshots taken inside compact(), one per invocation. */
+	preparedWithSettings: Array<Record<string, unknown>> = []
+	/** (model, thinkingLevel, customInstructions) triples seen by the summarizer. */
+	summarizeCalls: Array<{ model: unknown; thinkingLevel: unknown; customInstructions?: string }> = []
+	summarize: (signal: AbortSignal) => Promise<CompactionResult> = async () => ({
+		summary: "summary",
+		firstKeptEntryId: "m1",
+		tokensBefore: 42,
+		details: { source: "llm" },
+	})
 	sessionManager = {
 		getBranch: vi.fn(() => this.branch),
 		getEntries: vi.fn(() => this.entries),
 		appendCompaction: vi.fn(
 			(summary: string, firstKeptEntryId: string, tokensBefore: number, details: unknown, fromExtension: boolean) => {
-				this.entries.push({
-					type: "compaction",
-					summary,
-					firstKeptEntryId,
-					tokensBefore,
-					details,
-					fromExtension,
-				})
+				this.entries.push({ type: "compaction", summary, firstKeptEntryId, tokensBefore, details, fromExtension })
 			},
 		),
 		buildSessionContext: vi.fn(() => ({ messages: ["compacted-message"] as unknown[] })),
 	}
 	settingsManager = {
-		getCompactionSettings: vi.fn(() => ({ enabled: true, reserveTokens: 16_384, keepRecentTokens: 20_000 })),
+		getCompactionSettings: () => ({ enabled: true, reserveTokens: 16_384, keepRecentTokens: 20_000 }),
 	}
-	_getCompactionRequestAuth = vi.fn(async () => ({ apiKey: "key", headers: { "x-test": "1" } }))
-	_extensionRunner = {
-		hasHandlers: vi.fn((_event: string): boolean => false),
-		emit: vi.fn(async (_event?: unknown) => undefined as unknown),
-	}
+	_getCompactionRequestAuth = vi.fn(async (_model: unknown) => ({ apiKey: "key", headers: { "x-test": "1" } }))
 	_emit = vi.fn((event: EventRecord) => {
 		this.events.push(event)
 	})
@@ -70,16 +75,51 @@ class FakeSession {
 		this.disconnect()
 	}
 
+	_reconnectToAgent(): void {
+		this.reconnect()
+	}
+
 	async abort(): Promise<void> {
 		this.originalAbortCalls += 1
 	}
 
 	abortCompaction(): void {
-		this.originalAbortCompactionCalls += 1
+		this._compactionAbortController?.abort()
 	}
 
 	_bindExtensionCore(runner: FakeRunner): void {
 		this.boundRunner = runner
+	}
+
+	async compact(customInstructions?: string, _force = false): Promise<CompactionResult> {
+		this._disconnectFromAgent()
+		await this.abort()
+		this._compactionAbortController = new AbortController()
+		this._emit({ type: "compaction_start", reason: "manual" })
+		try {
+			if (!this.model) throw new Error("No model selected")
+			await this._getCompactionRequestAuth(this.model)
+			this.preparedWithSettings.push(this.settingsManager.getCompactionSettings())
+			this.summarizeCalls.push({ model: this.model, thinkingLevel: this.thinkingLevel, customInstructions })
+			const result = await this.summarize(this._compactionAbortController.signal)
+			if (this._compactionAbortController.signal.aborted) throw new Error("Compaction cancelled")
+			this.sessionManager.appendCompaction(
+				result.summary,
+				result.firstKeptEntryId,
+				result.tokensBefore,
+				result.details,
+				false,
+			)
+			this.agent.state.messages = this.sessionManager.buildSessionContext().messages
+			this._emit({ type: "compaction_end", reason: "manual", result, aborted: false, willRetry: false })
+			return result
+		} catch (error) {
+			this._emit({ type: "compaction_end", reason: "manual", result: undefined, aborted: true, willRetry: false })
+			throw error
+		} finally {
+			this._compactionAbortController = undefined
+			this._reconnectToAgent()
+		}
 	}
 }
 
@@ -93,8 +133,6 @@ type MutableRunnerPrototype = typeof FakeRunner.prototype & {
 }
 
 const originalSessionBindExtensionCore = FakeSession.prototype._bindExtensionCore
-const originalSessionAbort = FakeSession.prototype.abort
-const originalSessionAbortCompaction = FakeSession.prototype.abortCompaction
 const originalRunnerCreateContext = FakeRunner.prototype.createContext
 
 function inlineSession(session: FakeSession): FakeSession & {
@@ -105,36 +143,29 @@ function inlineSession(session: FakeSession): FakeSession & {
 	}
 }
 
-function makeCompactionModule(overrides: Partial<InlineCompactCompactionModule> = {}): InlineCompactCompactionModule {
-	return {
-		prepareCompaction: vi.fn(() => ({
-			firstKeptEntryId: "m1",
-			tokensBefore: 42,
-		})),
-		compact: vi.fn(async () => ({
-			summary: "summary",
-			firstKeptEntryId: "m1",
-			tokensBefore: 42,
-			details: { source: "llm" },
-		})),
-		...overrides,
-	}
-}
-
-function installWith(module: InlineCompactCompactionModule) {
+function install() {
 	installInlineCompactPatch({
 		sessionClass: FakeSession as unknown as NonNullable<InlineCompactPatchOptions["sessionClass"]>,
 		runnerClass: FakeRunner as unknown as NonNullable<InlineCompactPatchOptions["runnerClass"]>,
-		loadCompactionModule: async () => module,
 	})
+}
+
+/** A summarizer that stays pending until its signal aborts (or is aborted already). */
+function hangingSummarize(): (signal: AbortSignal) => Promise<CompactionResult> {
+	return (signal) =>
+		new Promise<CompactionResult>((_resolve, reject) => {
+			if (signal.aborted) {
+				reject(new Error("Compaction cancelled"))
+				return
+			}
+			signal.addEventListener("abort", () => reject(new Error("Compaction cancelled")), { once: true })
+		})
 }
 
 describe("installInlineCompactPatch", () => {
 	beforeEach(() => {
 		const sessionProto = FakeSession.prototype as MutableSessionPrototype
 		sessionProto._bindExtensionCore = originalSessionBindExtensionCore
-		sessionProto.abort = originalSessionAbort
-		sessionProto.abortCompaction = originalSessionAbortCompaction
 		sessionProto._kimchiInlineCompactPatch = undefined
 		sessionProto.inlineCompact = undefined
 
@@ -145,22 +176,43 @@ describe("installInlineCompactPatch", () => {
 	})
 
 	it("installs idempotently", () => {
-		const module = makeCompactionModule()
 		const sessionProto = FakeSession.prototype as MutableSessionPrototype
 		const runnerProto = FakeRunner.prototype as MutableRunnerPrototype
-		installWith(module)
+		install()
 		const inlineCompact = sessionProto.inlineCompact
 		const createContext = runnerProto.createContext
 
-		installWith(module)
+		install()
 
 		expect(sessionProto.inlineCompact).toBe(inlineCompact)
 		expect(runnerProto.createContext).toBe(createContext)
 	})
 
+	it("installs against the real AgentSession/ExtensionRunner internals", () => {
+		// The drift canary: fails when upstream renames compact()'s quiesce
+		// internals (_disconnectFromAgent / this.abort) or the patched members.
+		expect(() => installInlineCompactPatch()).not.toThrow()
+		expect(typeof (AgentSession.prototype as { inlineCompact?: unknown }).inlineCompact).toBe("function")
+		expect(
+			(ExtensionRunner.prototype as { _kimchiInlineCompactContextPatch?: boolean })._kimchiInlineCompactContextPatch,
+		).toBe(true)
+	})
+
+	it("rejects a session class whose compact() lacks the quiesce internals", () => {
+		class DriftedSession {
+			async compact(): Promise<void> {}
+			_bindExtensionCore(): void {}
+		}
+		expect(() =>
+			installInlineCompactPatch({
+				sessionClass: DriftedSession as unknown as NonNullable<InlineCompactPatchOptions["sessionClass"]>,
+				runnerClass: FakeRunner as unknown as NonNullable<InlineCompactPatchOptions["runnerClass"]>,
+			}),
+		).toThrow("incompatible with Kimchi inline compaction")
+	})
+
 	it("exposes ctx.inlineCompact from ExtensionRunner contexts", async () => {
-		const module = makeCompactionModule()
-		installWith(module)
+		install()
 		const session = new FakeSession()
 		const runner = new FakeRunner()
 
@@ -175,15 +227,8 @@ describe("installInlineCompactPatch", () => {
 		expect(session.sessionManager.appendCompaction).toHaveBeenCalledOnce()
 	})
 
-	it("runs compaction without aborting or disconnecting the session", async () => {
-		const compact = vi.fn(async () => ({
-			summary: "summary",
-			firstKeptEntryId: "m1",
-			tokensBefore: 42,
-			details: { source: "llm" },
-		}))
-		const module = makeCompactionModule({ compact })
-		installWith(module)
+	it("delegates to compact() without aborting or disconnecting the session", async () => {
+		install()
 		const session = new FakeSession()
 
 		const result = await inlineSession(session).inlineCompact({ customInstructions: "keep ferment", force: true })
@@ -191,41 +236,82 @@ describe("installInlineCompactPatch", () => {
 		expect(result?.summary).toBe("summary")
 		expect(session.disconnect).not.toHaveBeenCalled()
 		expect(session.originalAbortCalls).toBe(0)
-		expect(compact).toHaveBeenCalledWith(
-			expect.anything(),
-			session.model,
-			"key",
-			{ "x-test": "1" },
-			"keep ferment",
-			expect.any(AbortSignal),
-			"low",
-			session.agent.streamFn,
-		)
+		// Upstream's finally still runs (idempotent reconnect + controller clear).
+		expect(session.reconnect).toHaveBeenCalledOnce()
+		expect(session._compactionAbortController).toBeUndefined()
+		expect(session.summarizeCalls).toEqual([
+			{ model: session.model, thinkingLevel: "low", customInstructions: "keep ferment" },
+		])
 		expect(session.sessionManager.appendCompaction).toHaveBeenCalledWith("summary", "m1", 42, { source: "llm" }, false)
 		expect(session.agent.state.messages).toEqual(["compacted-message"])
-		expect(session._extensionRunner.emit).toHaveBeenCalledWith(
-			expect.objectContaining({
-				type: "session_compact",
-				fromExtension: false,
-			}),
-		)
-		expect(session.events).toEqual(
-			expect.arrayContaining([
-				expect.objectContaining({ type: "compaction_start", reason: "threshold" }),
-				expect.objectContaining({ type: "compaction_end", reason: "threshold", aborted: false }),
-			]),
-		)
+		// Delegation inherits upstream's event shapes verbatim.
+		expect(session.events).toEqual([
+			expect.objectContaining({ type: "compaction_start", reason: "manual" }),
+			expect.objectContaining({ type: "compaction_end", reason: "manual", aborted: false }),
+		])
 	})
 
-	it("uses options.model for auth and compaction instead of the session model when provided", async () => {
-		const compact = vi.fn(async () => ({
-			summary: "summary",
-			firstKeptEntryId: "m1",
-			tokensBefore: 42,
-			details: { source: "llm" },
-		}))
-		const module = makeCompactionModule({ compact })
-		installWith(module)
+	it("restores the quiesce members after completion so later manual compactions abort again", async () => {
+		install()
+		const session = new FakeSession()
+
+		await inlineSession(session).inlineCompact()
+		// Shadows must be gone: a subsequent DIRECT compact() call is the manual
+		// path and must quiesce normally.
+		await session.compact()
+
+		expect(session.disconnect).toHaveBeenCalledOnce()
+		expect(session.originalAbortCalls).toBe(1)
+		expect(Object.getOwnPropertyDescriptor(session, "_disconnectFromAgent")).toBeUndefined()
+		expect(Object.getOwnPropertyDescriptor(session, "abort")).toBeUndefined()
+	})
+
+	it("restores all shadows when compaction fails", async () => {
+		install()
+		const session = new FakeSession()
+		session.summarize = async () => {
+			throw new Error("summarizer exploded")
+		}
+		const originalGetSettings = session.settingsManager.getCompactionSettings
+
+		await expect(
+			inlineSession(session).inlineCompact({
+				force: true,
+				model: { id: "other" } as unknown as Model<Api>,
+				thinkingLevel: "off",
+			}),
+		).rejects.toThrow("summarizer exploded")
+
+		expect(Object.getOwnPropertyDescriptor(session, "_disconnectFromAgent")).toBeUndefined()
+		expect(Object.getOwnPropertyDescriptor(session, "abort")).toBeUndefined()
+		expect(session.settingsManager.getCompactionSettings).toBe(originalGetSettings)
+		expect(session.model).toEqual({ provider: "test", id: "model" })
+		expect(session.thinkingLevel).toBe("low")
+	})
+
+	it("honors force by shadowing settings to keepRecentTokens: 0", async () => {
+		// force must not rely on upstream's undefined-preparation retry: a session
+		// smaller than keepRecentTokens returns a DEFINED preparation with zero
+		// summarizable messages, so preparation must start from keepRecentTokens: 0.
+		install()
+		const session = new FakeSession()
+
+		await inlineSession(session).inlineCompact({ force: true })
+
+		expect(session.preparedWithSettings).toEqual([{ enabled: true, reserveTokens: 16_384, keepRecentTokens: 0 }])
+	})
+
+	it("keeps default preparation settings when force is not set", async () => {
+		install()
+		const session = new FakeSession()
+
+		await inlineSession(session).inlineCompact()
+
+		expect(session.preparedWithSettings).toEqual([{ enabled: true, reserveTokens: 16_384, keepRecentTokens: 20_000 }])
+	})
+
+	it("routes options.model to auth and summarization, then restores the session model", async () => {
+		install()
 		const session = new FakeSession()
 		const overrideModel: Model<Api> = {
 			id: "non-reasoning-model",
@@ -243,245 +329,106 @@ describe("installInlineCompactPatch", () => {
 		await inlineSession(session).inlineCompact({ customInstructions: "keep ferment", model: overrideModel })
 
 		expect(session._getCompactionRequestAuth).toHaveBeenCalledWith(overrideModel)
-		expect(compact).toHaveBeenCalledWith(
-			expect.anything(),
-			overrideModel,
-			"key",
-			{ "x-test": "1" },
-			"keep ferment",
-			expect.any(AbortSignal),
-			"low",
-			session.agent.streamFn,
-		)
+		expect(session.summarizeCalls).toEqual([
+			{ model: overrideModel, thinkingLevel: "low", customInstructions: "keep ferment" },
+		])
+		expect(session.model).toEqual({ provider: "test", id: "model" })
 	})
 
-	it("falls back to the session model when options.model is omitted", async () => {
-		const compact = vi.fn(async () => ({
-			summary: "summary",
-			firstKeptEntryId: "m1",
-			tokensBefore: 42,
-			details: { source: "llm" },
-		}))
-		const module = makeCompactionModule({ compact })
-		installWith(module)
+	it("routes options.thinkingLevel to summarization, then restores the session level", async () => {
+		install()
+		const session = new FakeSession()
+
+		await inlineSession(session).inlineCompact({ thinkingLevel: "off" })
+
+		expect(session.summarizeCalls).toEqual([
+			{ model: session.model, thinkingLevel: "off", customInstructions: undefined },
+		])
+		expect(session.thinkingLevel).toBe("low")
+	})
+
+	it("falls back to the session model and thinking level when overrides are omitted", async () => {
+		install()
 		const session = new FakeSession()
 
 		await inlineSession(session).inlineCompact({ customInstructions: "keep ferment" })
 
 		expect(session._getCompactionRequestAuth).toHaveBeenCalledWith(session.model)
-		expect(compact).toHaveBeenCalledWith(
-			expect.anything(),
-			session.model,
-			"key",
-			{ "x-test": "1" },
-			"keep ferment",
-			expect.any(AbortSignal),
-			"low",
-			session.agent.streamFn,
-		)
+		expect(session.summarizeCalls).toEqual([
+			{ model: session.model, thinkingLevel: "low", customInstructions: "keep ferment" },
+		])
 	})
 
-	it("uses options.thinkingLevel for the compaction call instead of the session thinking level when provided", async () => {
-		const compact = vi.fn(async () => ({
-			summary: "summary",
-			firstKeptEntryId: "m1",
-			tokensBefore: 42,
-			details: { source: "llm" },
-		}))
-		const module = makeCompactionModule({ compact })
-		installWith(module)
+	it("cancels the compaction when abort() is called during summarization", async () => {
+		install()
 		const session = new FakeSession()
-
-		await inlineSession(session).inlineCompact({ customInstructions: "keep ferment", thinkingLevel: "off" })
-
-		expect(compact).toHaveBeenCalledWith(
-			expect.anything(),
-			session.model,
-			"key",
-			{ "x-test": "1" },
-			"keep ferment",
-			expect.any(AbortSignal),
-			"off",
-			session.agent.streamFn,
-		)
-	})
-
-	it("falls back to the session thinking level when options.thinkingLevel is omitted", async () => {
-		const compact = vi.fn(async () => ({
-			summary: "summary",
-			firstKeptEntryId: "m1",
-			tokensBefore: 42,
-			details: { source: "llm" },
-		}))
-		const module = makeCompactionModule({ compact })
-		installWith(module)
-		const session = new FakeSession()
-
-		await inlineSession(session).inlineCompact({ customInstructions: "keep ferment" })
-
-		expect(compact).toHaveBeenCalledWith(
-			expect.anything(),
-			session.model,
-			"key",
-			{ "x-test": "1" },
-			"keep ferment",
-			expect.any(AbortSignal),
-			session.thinkingLevel,
-			session.agent.streamFn,
-		)
-	})
-
-	it("uses extension-provided compaction results from session_before_compact", async () => {
-		const compact = vi.fn()
-		const module = makeCompactionModule({ compact })
-		installWith(module)
-		const session = new FakeSession()
-		session._extensionRunner.hasHandlers = vi.fn((event: string): boolean => event === "session_before_compact")
-		session._extensionRunner.emit = vi.fn(async (event: unknown) => {
-			if ((event as { type?: string }).type !== "session_before_compact") return undefined
-			return {
-				compaction: {
-					summary: "extension summary",
-					firstKeptEntryId: "m2",
-					tokensBefore: 100,
-					details: { source: "extension" },
-				},
-			}
-		})
-
-		const result = await inlineSession(session).inlineCompact()
-
-		expect(result).toMatchObject({ summary: "extension summary" })
-		expect(compact).not.toHaveBeenCalled()
-		expect(session.sessionManager.appendCompaction).toHaveBeenCalledWith(
-			"extension summary",
-			"m2",
-			100,
-			{ source: "extension" },
-			true,
-		)
-	})
-
-	it("honors force by preparing with keepRecentTokens set to zero", async () => {
-		// force must not rely on an undefined-preparation retry: a session smaller
-		// than keepRecentTokens returns a DEFINED preparation with zero
-		// summarizable messages, so force prepares with keepRecentTokens: 0
-		// directly to compact everything before the newest valid cut point.
-		const prepareCompaction = vi.fn(() => ({ firstKeptEntryId: "m1", tokensBefore: 42 }))
-		const module = makeCompactionModule({ prepareCompaction })
-		installWith(module)
-		const session = new FakeSession()
-
-		await inlineSession(session).inlineCompact({ force: true })
-
-		expect(prepareCompaction).toHaveBeenCalledTimes(1)
-		expect(prepareCompaction).toHaveBeenCalledWith(session.branch, {
-			enabled: true,
-			reserveTokens: 16_384,
-			keepRecentTokens: 0,
-		})
-	})
-
-	it("keeps default preparation settings when force is not set", async () => {
-		const prepareCompaction = vi.fn(() => ({ firstKeptEntryId: "m1", tokensBefore: 42 }))
-		const module = makeCompactionModule({ prepareCompaction })
-		installWith(module)
-		const session = new FakeSession()
-
-		await inlineSession(session).inlineCompact()
-
-		expect(prepareCompaction).toHaveBeenCalledTimes(1)
-		expect(prepareCompaction).toHaveBeenCalledWith(session.branch, {
-			enabled: true,
-			reserveTokens: 16_384,
-			keepRecentTokens: 20_000,
-		})
-	})
-
-	it("rejects an empty compaction preparation without saving a compaction", async () => {
-		const prepareCompaction = vi.fn(() => ({
-			firstKeptEntryId: "m1",
-			messagesToSummarize: [],
-			tokensBefore: 42,
-			turnPrefixMessages: [],
-		}))
-		const compact = vi.fn()
-		const module = makeCompactionModule({ prepareCompaction, compact })
-		installWith(module)
-		const session = new FakeSession()
-
-		await expect(inlineSession(session).inlineCompact({ force: true })).rejects.toThrow(
-			"Nothing to compact (no summarizable messages)",
-		)
-
-		expect(prepareCompaction).toHaveBeenCalledOnce()
-		expect(compact).not.toHaveBeenCalled()
-		expect(session.sessionManager.appendCompaction).not.toHaveBeenCalled()
-		expect(session.events).toContainEqual(
-			expect.objectContaining({
-				type: "compaction_end",
-				aborted: false,
-				errorMessage: expect.stringContaining("no summarizable messages"),
-			}),
-		)
-	})
-
-	it("rejects cancellation from session_before_compact", async () => {
-		const module = makeCompactionModule()
-		installWith(module)
-		const session = new FakeSession()
-		session._extensionRunner.hasHandlers = vi.fn((event: string): boolean => event === "session_before_compact")
-		session._extensionRunner.emit = vi.fn(async () => ({ cancel: true }))
-
-		await expect(inlineSession(session).inlineCompact()).rejects.toThrow("Compaction cancelled")
-		expect(session.sessionManager.appendCompaction).not.toHaveBeenCalled()
-		expect(session.events).toContainEqual(expect.objectContaining({ type: "compaction_end", aborted: true }))
-	})
-
-	it("preserves the original abort path while also aborting inline compaction", async () => {
-		const module = makeCompactionModule({
-			compact: vi.fn(
-				(_preparation, _model, _apiKey, _headers, _customInstructions, signal: AbortSignal) =>
-					new Promise<CompactionResult>((_resolve, reject) => {
-						signal.addEventListener("abort", () => reject(new Error("Compaction cancelled")), { once: true })
-					}),
-			),
-		})
-		installWith(module)
-		const session = new FakeSession()
+		session.summarize = hangingSummarize()
 		const promise = inlineSession(session).inlineCompact()
+		// Let the wrapper consume the one-shot suppression of compact()'s
+		// internal quiesce abort before the external abort arrives.
+		await Promise.resolve()
 
 		await session.abort()
 
-		expect(session.originalAbortCalls).toBe(1)
 		await expect(promise).rejects.toThrow("Compaction cancelled")
+		// The external abort was a real one: it reached the original abort path.
+		expect(session.originalAbortCalls).toBe(1)
 	})
 
-	it("abortCompaction cancels inline compaction and delegates to the original method", async () => {
-		const module = makeCompactionModule({
-			compact: vi.fn(
-				(_preparation, _model, _apiKey, _headers, _customInstructions, signal: AbortSignal) =>
-					new Promise<CompactionResult>((_resolve, reject) => {
-						signal.addEventListener("abort", () => reject(new Error("Compaction cancelled")), { once: true })
-					}),
-			),
-		})
-		installWith(module)
+	it("abortCompaction cancels inline compaction through upstream's own controller", async () => {
+		install()
 		const session = new FakeSession()
+		session.summarize = hangingSummarize()
 		const promise = inlineSession(session).inlineCompact()
+		await Promise.resolve()
 
 		session.abortCompaction()
 
-		expect(session.originalAbortCompactionCalls).toBe(1)
 		await expect(promise).rejects.toThrow("Compaction cancelled")
 	})
-})
 
-describe("loadDefaultCompactionModule", () => {
-	it("loads real PI compaction functions", async () => {
-		const module = await loadDefaultCompactionModule()
+	it("rejects when a compaction is already in progress", async () => {
+		install()
+		const session = new FakeSession()
+		session._compactionAbortController = new AbortController()
 
-		expect(module.prepareCompaction).toEqual(expect.any(Function))
-		expect(module.compact).toEqual(expect.any(Function))
+		await expect(inlineSession(session).inlineCompact()).rejects.toThrow("Compaction already in progress")
+
+		session._compactionAbortController = undefined
+		session._autoCompactionAbortController = new AbortController()
+
+		await expect(inlineSession(session).inlineCompact()).rejects.toThrow("Compaction already in progress")
+	})
+
+	it("rejects when the branch has an unpaired toolCall", async () => {
+		install()
+		const session = new FakeSession()
+		session.branch = [
+			{
+				type: "message",
+				message: { role: "assistant", content: [{ type: "toolCall", id: "t1" }] },
+			},
+		]
+
+		await expect(inlineSession(session).inlineCompact({ force: true })).rejects.toThrow("tool call is in flight")
+		expect(session.sessionManager.appendCompaction).not.toHaveBeenCalled()
+		expect(session.summarizeCalls).toEqual([])
+	})
+
+	it("ignores unpaired toolCalls that predate the newest compaction entry", async () => {
+		install()
+		const session = new FakeSession()
+		session.branch = [
+			{
+				type: "message",
+				message: { role: "assistant", content: [{ type: "toolCall", id: "stale-orphan" }] },
+			},
+			{ type: "compaction", summary: "earlier summary" },
+			{ type: "message", message: { role: "user", content: "hi" } },
+		]
+
+		await expect(inlineSession(session).inlineCompact({ force: true })).resolves.toMatchObject({
+			summary: "summary",
+		})
 	})
 })

--- a/src/upstream-inline-compact-patch.test.ts
+++ b/src/upstream-inline-compact-patch.test.ts
@@ -301,6 +301,15 @@ describe("installInlineCompactPatch", () => {
 		expect(session.preparedWithSettings).toEqual([{ enabled: true, reserveTokens: 16_384, keepRecentTokens: 0 }])
 	})
 
+	it("honors explicit keepRecentTokens", async () => {
+		install()
+		const session = new FakeSession()
+
+		await inlineSession(session).inlineCompact({ force: true, keepRecentTokens: 12_000 })
+
+		expect(session.preparedWithSettings).toEqual([{ enabled: true, reserveTokens: 16_384, keepRecentTokens: 12_000 }])
+	})
+
 	it("keeps default preparation settings when force is not set", async () => {
 		install()
 		const session = new FakeSession()

--- a/src/upstream-inline-compact-patch.test.ts
+++ b/src/upstream-inline-compact-patch.test.ts
@@ -1,0 +1,327 @@
+import type { CompactionResult } from "@earendil-works/pi-coding-agent"
+import { beforeEach, describe, expect, it, vi } from "vitest"
+import {
+	type InlineCompactCompactionModule,
+	type InlineCompactOptions,
+	type InlineCompactPatchOptions,
+	installInlineCompactPatch,
+	loadDefaultCompactionModule,
+} from "./upstream-inline-compact-patch.js"
+
+type EventRecord = Record<string, unknown>
+
+class FakeRunner {
+	_kimchiInlineCompact?: (options?: InlineCompactOptions) => Promise<CompactionResult>
+	assertActive = vi.fn()
+
+	createContext(): object {
+		return { existing: true }
+	}
+}
+
+class FakeSession {
+	model: unknown = { provider: "test", id: "model" }
+	thinkingLevel: unknown = "low"
+	agent = {
+		state: { messages: ["old-message"] as unknown[] },
+		streamFn: vi.fn(),
+	}
+	_compactionAbortController?: AbortController
+	_autoCompactionAbortController?: AbortController
+	_inlineCompactionAbortController?: AbortController
+	events: EventRecord[] = []
+	disconnect = vi.fn()
+	originalAbortCalls = 0
+	originalAbortCompactionCalls = 0
+	boundRunner?: FakeRunner
+	branch: unknown[] = [{ type: "message", id: "m1" }]
+	entries: unknown[] = [...this.branch]
+	sessionManager = {
+		getBranch: vi.fn(() => this.branch),
+		getEntries: vi.fn(() => this.entries),
+		appendCompaction: vi.fn(
+			(summary: string, firstKeptEntryId: string, tokensBefore: number, details: unknown, fromExtension: boolean) => {
+				this.entries.push({
+					type: "compaction",
+					summary,
+					firstKeptEntryId,
+					tokensBefore,
+					details,
+					fromExtension,
+				})
+			},
+		),
+		buildSessionContext: vi.fn(() => ({ messages: ["compacted-message"] as unknown[] })),
+	}
+	settingsManager = {
+		getCompactionSettings: vi.fn(() => ({ enabled: true, reserveTokens: 16_384, keepRecentTokens: 20_000 })),
+	}
+	_getCompactionRequestAuth = vi.fn(async () => ({ apiKey: "key", headers: { "x-test": "1" } }))
+	_extensionRunner = {
+		hasHandlers: vi.fn((_event: string): boolean => false),
+		emit: vi.fn(async (_event?: unknown) => undefined as unknown),
+	}
+	_emit = vi.fn((event: EventRecord) => {
+		this.events.push(event)
+	})
+
+	_disconnectFromAgent(): void {
+		this.disconnect()
+	}
+
+	async abort(): Promise<void> {
+		this.originalAbortCalls += 1
+	}
+
+	abortCompaction(): void {
+		this.originalAbortCompactionCalls += 1
+	}
+
+	_bindExtensionCore(runner: FakeRunner): void {
+		this.boundRunner = runner
+	}
+}
+
+type MutableSessionPrototype = typeof FakeSession.prototype & {
+	_kimchiInlineCompactPatch?: boolean
+	inlineCompact?: (options?: InlineCompactOptions) => Promise<CompactionResult>
+}
+
+type MutableRunnerPrototype = typeof FakeRunner.prototype & {
+	_kimchiInlineCompactContextPatch?: boolean
+}
+
+const originalSessionBindExtensionCore = FakeSession.prototype._bindExtensionCore
+const originalSessionAbort = FakeSession.prototype.abort
+const originalSessionAbortCompaction = FakeSession.prototype.abortCompaction
+const originalRunnerCreateContext = FakeRunner.prototype.createContext
+
+function inlineSession(session: FakeSession): FakeSession & {
+	inlineCompact(options?: InlineCompactOptions): Promise<CompactionResult>
+} {
+	return session as FakeSession & {
+		inlineCompact(options?: InlineCompactOptions): Promise<CompactionResult>
+	}
+}
+
+function makeCompactionModule(overrides: Partial<InlineCompactCompactionModule> = {}): InlineCompactCompactionModule {
+	return {
+		prepareCompaction: vi.fn(() => ({
+			firstKeptEntryId: "m1",
+			tokensBefore: 42,
+		})),
+		compact: vi.fn(async () => ({
+			summary: "summary",
+			firstKeptEntryId: "m1",
+			tokensBefore: 42,
+			details: { source: "llm" },
+		})),
+		...overrides,
+	}
+}
+
+function installWith(module: InlineCompactCompactionModule) {
+	installInlineCompactPatch({
+		sessionClass: FakeSession as unknown as NonNullable<InlineCompactPatchOptions["sessionClass"]>,
+		runnerClass: FakeRunner as unknown as NonNullable<InlineCompactPatchOptions["runnerClass"]>,
+		loadCompactionModule: async () => module,
+	})
+}
+
+describe("installInlineCompactPatch", () => {
+	beforeEach(() => {
+		const sessionProto = FakeSession.prototype as MutableSessionPrototype
+		sessionProto._bindExtensionCore = originalSessionBindExtensionCore
+		sessionProto.abort = originalSessionAbort
+		sessionProto.abortCompaction = originalSessionAbortCompaction
+		sessionProto._kimchiInlineCompactPatch = undefined
+		sessionProto.inlineCompact = undefined
+
+		const runnerProto = FakeRunner.prototype as MutableRunnerPrototype
+		runnerProto.createContext = originalRunnerCreateContext
+		runnerProto._kimchiInlineCompactContextPatch = undefined
+		vi.restoreAllMocks()
+	})
+
+	it("installs idempotently", () => {
+		const module = makeCompactionModule()
+		const sessionProto = FakeSession.prototype as MutableSessionPrototype
+		const runnerProto = FakeRunner.prototype as MutableRunnerPrototype
+		installWith(module)
+		const inlineCompact = sessionProto.inlineCompact
+		const createContext = runnerProto.createContext
+
+		installWith(module)
+
+		expect(sessionProto.inlineCompact).toBe(inlineCompact)
+		expect(runnerProto.createContext).toBe(createContext)
+	})
+
+	it("exposes ctx.inlineCompact from ExtensionRunner contexts", async () => {
+		const module = makeCompactionModule()
+		installWith(module)
+		const session = new FakeSession()
+		const runner = new FakeRunner()
+
+		session._bindExtensionCore(runner)
+		const ctx = runner.createContext() as {
+			inlineCompact?: (options?: InlineCompactOptions) => Promise<CompactionResult>
+		}
+		const result = await ctx.inlineCompact?.({ customInstructions: "preserve ferment" })
+
+		expect(runner.assertActive).toHaveBeenCalledOnce()
+		expect(result?.summary).toBe("summary")
+		expect(session.sessionManager.appendCompaction).toHaveBeenCalledOnce()
+	})
+
+	it("runs compaction without aborting or disconnecting the session", async () => {
+		const compact = vi.fn(async () => ({
+			summary: "summary",
+			firstKeptEntryId: "m1",
+			tokensBefore: 42,
+			details: { source: "llm" },
+		}))
+		const module = makeCompactionModule({ compact })
+		installWith(module)
+		const session = new FakeSession()
+
+		const result = await inlineSession(session).inlineCompact({ customInstructions: "keep ferment", force: true })
+
+		expect(result?.summary).toBe("summary")
+		expect(session.disconnect).not.toHaveBeenCalled()
+		expect(session.originalAbortCalls).toBe(0)
+		expect(compact).toHaveBeenCalledWith(
+			expect.anything(),
+			session.model,
+			"key",
+			{ "x-test": "1" },
+			"keep ferment",
+			expect.any(AbortSignal),
+			"low",
+			session.agent.streamFn,
+		)
+		expect(session.sessionManager.appendCompaction).toHaveBeenCalledWith("summary", "m1", 42, { source: "llm" }, false)
+		expect(session.agent.state.messages).toEqual(["compacted-message"])
+		expect(session._extensionRunner.emit).toHaveBeenCalledWith(
+			expect.objectContaining({
+				type: "session_compact",
+				fromExtension: false,
+			}),
+		)
+		expect(session.events).toEqual(
+			expect.arrayContaining([
+				expect.objectContaining({ type: "compaction_start", reason: "threshold" }),
+				expect.objectContaining({ type: "compaction_end", reason: "threshold", aborted: false }),
+			]),
+		)
+	})
+
+	it("uses extension-provided compaction results from session_before_compact", async () => {
+		const compact = vi.fn()
+		const module = makeCompactionModule({ compact })
+		installWith(module)
+		const session = new FakeSession()
+		session._extensionRunner.hasHandlers = vi.fn((event: string): boolean => event === "session_before_compact")
+		session._extensionRunner.emit = vi.fn(async (event: unknown) => {
+			if ((event as { type?: string }).type !== "session_before_compact") return undefined
+			return {
+				compaction: {
+					summary: "extension summary",
+					firstKeptEntryId: "m2",
+					tokensBefore: 100,
+					details: { source: "extension" },
+				},
+			}
+		})
+
+		const result = await inlineSession(session).inlineCompact()
+
+		expect(result).toMatchObject({ summary: "extension summary" })
+		expect(compact).not.toHaveBeenCalled()
+		expect(session.sessionManager.appendCompaction).toHaveBeenCalledWith(
+			"extension summary",
+			"m2",
+			100,
+			{ source: "extension" },
+			true,
+		)
+	})
+
+	it("honors force by retrying preparation with keepRecentTokens set to zero", async () => {
+		const prepareCompaction = vi
+			.fn()
+			.mockReturnValueOnce(undefined)
+			.mockReturnValueOnce({ firstKeptEntryId: "m1", tokensBefore: 42 })
+		const module = makeCompactionModule({ prepareCompaction })
+		installWith(module)
+		const session = new FakeSession()
+
+		await inlineSession(session).inlineCompact({ force: true })
+
+		expect(prepareCompaction).toHaveBeenCalledTimes(2)
+		expect(prepareCompaction).toHaveBeenLastCalledWith(session.branch, {
+			enabled: true,
+			reserveTokens: 16_384,
+			keepRecentTokens: 0,
+		})
+	})
+
+	it("rejects cancellation from session_before_compact", async () => {
+		const module = makeCompactionModule()
+		installWith(module)
+		const session = new FakeSession()
+		session._extensionRunner.hasHandlers = vi.fn((event: string): boolean => event === "session_before_compact")
+		session._extensionRunner.emit = vi.fn(async () => ({ cancel: true }))
+
+		await expect(inlineSession(session).inlineCompact()).rejects.toThrow("Compaction cancelled")
+		expect(session.sessionManager.appendCompaction).not.toHaveBeenCalled()
+		expect(session.events).toContainEqual(expect.objectContaining({ type: "compaction_end", aborted: true }))
+	})
+
+	it("preserves the original abort path while also aborting inline compaction", async () => {
+		const module = makeCompactionModule({
+			compact: vi.fn(
+				(_preparation, _model, _apiKey, _headers, _customInstructions, signal: AbortSignal) =>
+					new Promise<CompactionResult>((_resolve, reject) => {
+						signal.addEventListener("abort", () => reject(new Error("Compaction cancelled")), { once: true })
+					}),
+			),
+		})
+		installWith(module)
+		const session = new FakeSession()
+		const promise = inlineSession(session).inlineCompact()
+
+		await session.abort()
+
+		expect(session.originalAbortCalls).toBe(1)
+		await expect(promise).rejects.toThrow("Compaction cancelled")
+	})
+
+	it("abortCompaction cancels inline compaction and delegates to the original method", async () => {
+		const module = makeCompactionModule({
+			compact: vi.fn(
+				(_preparation, _model, _apiKey, _headers, _customInstructions, signal: AbortSignal) =>
+					new Promise<CompactionResult>((_resolve, reject) => {
+						signal.addEventListener("abort", () => reject(new Error("Compaction cancelled")), { once: true })
+					}),
+			),
+		})
+		installWith(module)
+		const session = new FakeSession()
+		const promise = inlineSession(session).inlineCompact()
+
+		session.abortCompaction()
+
+		expect(session.originalAbortCompactionCalls).toBe(1)
+		await expect(promise).rejects.toThrow("Compaction cancelled")
+	})
+})
+
+describe("loadDefaultCompactionModule", () => {
+	it("loads real PI compaction functions", async () => {
+		const module = await loadDefaultCompactionModule()
+
+		expect(module.prepareCompaction).toEqual(expect.any(Function))
+		expect(module.compact).toEqual(expect.any(Function))
+	})
+})

--- a/src/upstream-inline-compact-patch.test.ts
+++ b/src/upstream-inline-compact-patch.test.ts
@@ -247,22 +247,39 @@ describe("installInlineCompactPatch", () => {
 		)
 	})
 
-	it("honors force by retrying preparation with keepRecentTokens set to zero", async () => {
-		const prepareCompaction = vi
-			.fn()
-			.mockReturnValueOnce(undefined)
-			.mockReturnValueOnce({ firstKeptEntryId: "m1", tokensBefore: 42 })
+	it("honors force by preparing with keepRecentTokens set to zero", async () => {
+		// force must not rely on an undefined-preparation retry: a session smaller
+		// than keepRecentTokens returns a DEFINED preparation with zero
+		// summarizable messages, so force prepares with keepRecentTokens: 0
+		// directly to compact everything before the newest valid cut point.
+		const prepareCompaction = vi.fn(() => ({ firstKeptEntryId: "m1", tokensBefore: 42 }))
 		const module = makeCompactionModule({ prepareCompaction })
 		installWith(module)
 		const session = new FakeSession()
 
 		await inlineSession(session).inlineCompact({ force: true })
 
-		expect(prepareCompaction).toHaveBeenCalledTimes(2)
-		expect(prepareCompaction).toHaveBeenLastCalledWith(session.branch, {
+		expect(prepareCompaction).toHaveBeenCalledTimes(1)
+		expect(prepareCompaction).toHaveBeenCalledWith(session.branch, {
 			enabled: true,
 			reserveTokens: 16_384,
 			keepRecentTokens: 0,
+		})
+	})
+
+	it("keeps default preparation settings when force is not set", async () => {
+		const prepareCompaction = vi.fn(() => ({ firstKeptEntryId: "m1", tokensBefore: 42 }))
+		const module = makeCompactionModule({ prepareCompaction })
+		installWith(module)
+		const session = new FakeSession()
+
+		await inlineSession(session).inlineCompact()
+
+		expect(prepareCompaction).toHaveBeenCalledTimes(1)
+		expect(prepareCompaction).toHaveBeenCalledWith(session.branch, {
+			enabled: true,
+			reserveTokens: 16_384,
+			keepRecentTokens: 20_000,
 		})
 	})
 

--- a/src/upstream-inline-compact-patch.ts
+++ b/src/upstream-inline-compact-patch.ts
@@ -1,21 +1,35 @@
 /**
- * Local non-aborting adaptation of pi-coding-agent's AgentSession.compact()
- * lifecycle. Keep this close to upstream compaction behavior: it intentionally
- * reuses PI's internal prepare/compact functions and extension events, but skips
- * the manual compact path's session disconnect + abort.
+ * Non-aborting inline adaptation of pi-coding-agent's AgentSession.compact().
+ *
+ * Instead of cloning upstream's compaction lifecycle, `inlineCompact` DELEGATES
+ * to the original `compact()` with the quiesce pair suppressed: upstream's
+ * `_disconnectFromAgent()` + `await this.abort()` exist to force-idle a live
+ * run before rewriting `agent.state.messages`, but inline callers (Ferment's
+ * stage-boundary compaction) invoke this from an AWAITED extension handler at
+ * a turn boundary — the agent loop is suspended for the whole call, so the
+ * rewrite is already safe and the run must NOT be aborted.
+ *
+ * Delegation means upstream's own code runs: `_compactionAbortController` is
+ * set (so `isCompacting` and `abortCompaction()` work unpatched), events carry
+ * upstream's exact shapes (reason "manual"), and upstream fixes are inherited
+ * automatically.
+ *
+ * The suppression works through temporary per-instance property shadows that
+ * intercept the prototype members `compact()` reaches via `this`. That
+ * coupling is asserted fail-loud at patch-install time (i.e. process startup)
+ * by checking the source text of `compact()` — a regression here must abort
+ * the process, not silently turn stage compaction abortive or into a no-op.
+ *
+ * Caller contract (enforced where possible):
+ * - Call from an awaited extension handler at a turn boundary (turn_end /
+ *   agent_end) or while the session is idle. NOT enforceable from inside the
+ *   session; violating it races the agent loop.
+ * - No unpaired toolCall in the current branch. ENFORCED: throws before
+ *   compacting (see isToolCallInFlight) instead of orphaning the toolResult.
  */
 import type { Api, Model, ModelThinkingLevel } from "@earendil-works/pi-ai"
-import {
-	AgentSession,
-	type CompactionResult,
-	ExtensionRunner,
-	compact as piCompact,
-	// Re-exported from the package root by patches/@earendil-works__pi-coding-agent@0.78.1.patch
-	// (item 7). A static import is required: the Bun-compiled binary has no node_modules on
-	// disk, so any runtime module resolution (import.meta.resolve, dynamic deep imports,
-	// directory walks) fails there even though it works in dev under Node.
-	prepareCompaction as piPrepareCompaction,
-} from "@earendil-works/pi-coding-agent"
+import { AgentSession, type CompactionResult, ExtensionRunner } from "@earendil-works/pi-coding-agent"
+import { collectMessagesAfterLastCompaction, isToolCallInFlight } from "./tool-call-in-flight.js"
 
 export interface InlineCompactOptions {
 	customInstructions?: string
@@ -40,67 +54,21 @@ type CompactionSettingsLike = {
 	[key: string]: unknown
 }
 
-export type InlineCompactCompactionModule = {
-	prepareCompaction: (pathEntries: unknown[], settings: CompactionSettingsLike) => unknown | undefined
-	compact: (
-		preparation: unknown,
-		model: unknown,
-		apiKey: string | undefined,
-		headers: Record<string, string> | undefined,
-		customInstructions: string | undefined,
-		signal: AbortSignal,
-		thinkingLevel: unknown,
-		streamFn: unknown,
-	) => Promise<CompactionResult>
-}
-
-type ExtensionRunnerLike = {
-	hasHandlers(event: string): boolean
-	emit(event: unknown): Promise<unknown>
-}
-
-type SessionManagerLike = {
-	getBranch(): unknown[]
-	getEntries(): unknown[]
-	appendCompaction(
-		summary: string,
-		firstKeptEntryId: string,
-		tokensBefore: number,
-		details: unknown,
-		fromExtension: boolean,
-	): void
-	buildSessionContext(): { messages: unknown[] }
-}
-
 type PatchableSession = {
-	model: unknown | undefined
-	thinkingLevel: unknown
-	agent: {
-		state: { messages: unknown[] }
-		streamFn: unknown
-	}
-	sessionManager: SessionManagerLike
-	settingsManager: {
-		getCompactionSettings(): CompactionSettingsLike
-	}
-	_getCompactionRequestAuth(model: unknown): Promise<{
-		apiKey?: string
-		headers?: Record<string, string>
-	}>
-	_extensionRunner: ExtensionRunnerLike
-	_emit(event: unknown): void
 	_compactionAbortController?: AbortController
 	_autoCompactionAbortController?: AbortController
-	_inlineCompactionAbortController?: AbortController
+	_disconnectFromAgent: () => void
+	abort: (...args: unknown[]) => Promise<unknown>
+	sessionManager: { getBranch(): unknown[] }
+	settingsManager: { getCompactionSettings(): CompactionSettingsLike }
 	inlineCompact?(options?: InlineCompactOptions): Promise<CompactionResult>
 }
 
 type PatchableSessionPrototype = {
 	_kimchiInlineCompactPatch?: boolean
 	inlineCompact?: (this: PatchableSession, options?: InlineCompactOptions) => Promise<CompactionResult>
+	compact?: (this: PatchableSession, customInstructions?: string, force?: boolean) => Promise<CompactionResult>
 	_bindExtensionCore?: (this: PatchableSession, runner: PatchableRunnerInstance) => unknown
-	abortCompaction?: (this: PatchableSession, ...args: unknown[]) => unknown
-	abort?: (this: PatchableSession, ...args: unknown[]) => unknown
 }
 
 type PatchableSessionClass = {
@@ -121,239 +89,155 @@ type PatchableRunnerClass = {
 	prototype: PatchableRunnerPrototype
 }
 
-interface SessionBeforeCompactResultLike {
-	cancel?: boolean
-	compaction?: CompactionResult
-}
-
 export interface InlineCompactPatchOptions {
 	sessionClass?: PatchableSessionClass
 	runnerClass?: PatchableRunnerClass
-	loadCompactionModule?: () => Promise<InlineCompactCompactionModule>
 }
 
-/** Throw at patch-install time (i.e. process startup) when the statically imported
- *  compaction internals are missing — a regression here must abort the process, not
- *  silently skip every compaction at stage boundaries. */
-function assertCompactionInternalsAvailable(): void {
-	if (typeof piPrepareCompaction !== "function" || typeof piCompact !== "function") {
+/**
+ * Temporarily replace `target[key]` with `value`, returning a restore
+ * function. Handles both own properties (fakes, per-instance state) and
+ * prototype members (real AgentSession methods and accessors): a prototype
+ * member is shadowed by defining an own property and restored by deleting it,
+ * which re-exposes the prototype lookup.
+ */
+function shadowProperty(target: object, key: string, value: unknown): () => void {
+	const record = target as Record<string, unknown>
+	const ownDescriptor = Object.getOwnPropertyDescriptor(target, key)
+	Object.defineProperty(target, key, {
+		configurable: true,
+		enumerable: ownDescriptor?.enumerable ?? false,
+		writable: true,
+		value,
+	})
+	return () => {
+		if (ownDescriptor) {
+			Object.defineProperty(target, key, ownDescriptor)
+		} else {
+			delete record[key]
+		}
+	}
+}
+
+/**
+ * Fail at patch-install time (i.e. process startup) when `compact()` no longer
+ * calls the internals the inline shadows suppress. If upstream renames
+ * `_disconnectFromAgent` or stops quiescing via `this.abort()`, the shadows
+ * would silently go inert and inline compaction would become abortive again —
+ * the same silent-regression class that once turned every stage-boundary
+ * compaction in a benchmark run into a no-op.
+ */
+function assertCompactInternalsCompatible(sessionProto: PatchableSessionPrototype): void {
+	const compactSource = typeof sessionProto.compact === "function" ? String(sessionProto.compact) : ""
+	if (!compactSource.includes("_disconnectFromAgent") || !compactSource.includes("abort")) {
 		throw new Error(
-			"pi-coding-agent compaction internals are incompatible with Kimchi inline compaction " +
-				"(prepareCompaction is not exported from the package root — check that " +
-				"patches/@earendil-works__pi-coding-agent applied)",
+			"pi-coding-agent AgentSession.compact() is incompatible with Kimchi inline compaction " +
+				"(expected it to quiesce via _disconnectFromAgent/abort — upstream internals changed)",
 		)
 	}
-}
-
-export async function loadDefaultCompactionModule(): Promise<InlineCompactCompactionModule> {
-	assertCompactionInternalsAvailable()
-	return {
-		prepareCompaction: piPrepareCompaction as unknown as InlineCompactCompactionModule["prepareCompaction"],
-		compact: piCompact as InlineCompactCompactionModule["compact"],
-	}
-}
-
-function isRecord(value: unknown): value is Record<string, unknown> {
-	return !!value && typeof value === "object"
-}
-
-function isCompactionResult(value: unknown): value is CompactionResult {
-	return (
-		isRecord(value) &&
-		typeof value.summary === "string" &&
-		typeof value.firstKeptEntryId === "string" &&
-		typeof value.tokensBefore === "number"
-	)
-}
-
-function isEmptyCompactionPreparation(value: unknown): boolean {
-	return isRecord(value) && Array.isArray(value.messagesToSummarize) && value.messagesToSummarize.length === 0
-}
-
-function asBeforeCompactResult(value: unknown): SessionBeforeCompactResultLike | undefined {
-	if (!isRecord(value)) return undefined
-	return {
-		cancel: value.cancel === true,
-		compaction: isCompactionResult(value.compaction) ? value.compaction : undefined,
-	}
-}
-
-function getResultFromExtension(compaction: CompactionResult): CompactionResult {
-	return {
-		summary: compaction.summary,
-		firstKeptEntryId: compaction.firstKeptEntryId,
-		tokensBefore: compaction.tokensBefore,
-		details: compaction.details,
-	}
-}
-
-function findSavedCompactionEntry(entries: unknown[], summary: string): unknown | undefined {
-	return entries.find((entry) => isRecord(entry) && entry.type === "compaction" && entry.summary === summary)
 }
 
 async function runInlineCompact(
 	session: PatchableSession,
+	originalCompact: NonNullable<PatchableSessionPrototype["compact"]>,
 	options: InlineCompactOptions,
-	loadCompactionModule: () => Promise<InlineCompactCompactionModule>,
 ): Promise<CompactionResult> {
-	if (
-		session._inlineCompactionAbortController ||
-		session._compactionAbortController ||
-		session._autoCompactionAbortController
-	) {
+	if (session._compactionAbortController || session._autoCompactionAbortController) {
 		throw new Error("Compaction already in progress")
 	}
-	// PI only exposes manual/threshold/overflow compaction event reasons.
-	// Inline compaction is automatic extension-driven work, so use threshold
-	// rather than manual even when Ferment triggers it proactively.
-	const reason = "threshold"
-	const customInstructions = options.customInstructions
-	session._inlineCompactionAbortController = new AbortController()
-	session._emit({ type: "compaction_start", reason })
+
+	// Safety assertion (not deferral — callers wanting deferral must check
+	// before calling): compacting across an unpaired toolCall summarises away
+	// the assistant toolCall and orphans the toolResult appended later. Scoped
+	// past the newest compaction entry so a historical, already-neutralised
+	// orphan cannot permanently veto compaction.
+	if (isToolCallInFlight(collectMessagesAfterLastCompaction(session.sessionManager.getBranch()))) {
+		throw new Error(
+			"inlineCompact called while a tool call is in flight — callers must defer to a turn boundary with no unpaired toolCall",
+		)
+	}
+
+	const restores: Array<() => void> = []
+
+	// One-shot suppression of the quiesce pair. compact() calls each exactly
+	// once at its start, and the agent loop is suspended in the awaited
+	// handler, so no other caller can land in that window. Any LATER abort()
+	// during the summarization is a genuine cancellation request: cancel the
+	// compaction and delegate to the real abort.
+	const realDisconnect = session._disconnectFromAgent
+	const realAbort = session.abort
+	let disconnectSuppressed = false
+	let abortSuppressed = false
+	restores.push(
+		shadowProperty(session, "_disconnectFromAgent", function inlineShadowedDisconnect(this: PatchableSession) {
+			if (!disconnectSuppressed) {
+				disconnectSuppressed = true
+				return
+			}
+			return realDisconnect.call(this)
+		}),
+		shadowProperty(session, "abort", async function inlineShadowedAbort(this: PatchableSession, ...args: unknown[]) {
+			if (!abortSuppressed) {
+				abortSuppressed = true
+				return
+			}
+			this._compactionAbortController?.abort()
+			return realAbort.apply(this, args)
+		}),
+	)
+
+	// force means "compact everything before the newest valid cut point".
+	// Upstream's own force fallback (retry with keepRecentTokens: 0) only fires
+	// when preparation is undefined — a session smaller than keepRecentTokens
+	// returns a DEFINED preparation with zero summarizable messages, which
+	// turned every small-session forced compaction into a no-op. Shadow the
+	// settings so preparation starts from keepRecentTokens: 0 directly.
+	if (options.force) {
+		const settingsManager = session.settingsManager
+		const realGetCompactionSettings = settingsManager.getCompactionSettings
+		restores.push(
+			shadowProperty(settingsManager, "getCompactionSettings", function inlineShadowedSettings() {
+				return { ...realGetCompactionSettings.call(settingsManager), keepRecentTokens: 0 }
+			}),
+		)
+	}
+
+	// compact() reads `this.model` / `this.thinkingLevel` (prototype getters
+	// over agent.state) for auth and the summarization call. Instance shadows
+	// reroute both without touching agent.state, so the suspended loop resumes
+	// with its own model untouched.
+	if (options.model !== undefined) {
+		restores.push(shadowProperty(session, "model", options.model))
+	}
+	if (options.thinkingLevel !== undefined) {
+		restores.push(shadowProperty(session, "thinkingLevel", options.thinkingLevel))
+	}
 
 	try {
-		const signal = session._inlineCompactionAbortController.signal
-		const { prepareCompaction, compact } = await loadCompactionModule()
-		if (signal.aborted) {
-			throw new Error("Compaction cancelled")
-		}
-		const compactionModel = options.model ?? session.model
-		if (!compactionModel) {
-			throw new Error("No model selected")
-		}
-
-		const { apiKey, headers } = await session._getCompactionRequestAuth(compactionModel)
-		const pathEntries = session.sessionManager.getBranch()
-		const settings = session.settingsManager.getCompactionSettings()
-		// force means "compact everything before the newest valid cut point", so
-		// prepare with keepRecentTokens: 0 directly. Falling back to 0 only when
-		// preparation is undefined is not enough: a session smaller than
-		// keepRecentTokens returns a *defined* preparation with zero summarizable
-		// messages, which turned every small-session forced compaction into a no-op.
-		const preparation = prepareCompaction(pathEntries, options.force ? { ...settings, keepRecentTokens: 0 } : settings)
-
-		if (!preparation) {
-			const lastEntry = pathEntries[pathEntries.length - 1]
-			if (isRecord(lastEntry) && lastEntry.type === "compaction") {
-				throw new Error("Already compacted")
-			}
-			throw new Error(
-				options.force ? "Nothing to compact (no valid cut point)" : "Nothing to compact (session too small)",
-			)
-		}
-		if (isEmptyCompactionPreparation(preparation)) {
-			throw new Error("Nothing to compact (no summarizable messages)")
-		}
-
-		let compactionResult: CompactionResult | undefined
-		let fromExtension = false
-		if (session._extensionRunner.hasHandlers("session_before_compact")) {
-			const extensionResult = asBeforeCompactResult(
-				await session._extensionRunner.emit({
-					type: "session_before_compact",
-					preparation,
-					branchEntries: pathEntries,
-					customInstructions,
-					signal,
-				}),
-			)
-			if (extensionResult?.cancel) {
-				throw new Error("Compaction cancelled")
-			}
-			if (extensionResult?.compaction) {
-				compactionResult = getResultFromExtension(extensionResult.compaction)
-				fromExtension = true
-			}
-		}
-
-		if (!compactionResult) {
-			compactionResult = await compact(
-				preparation,
-				compactionModel,
-				apiKey,
-				headers,
-				customInstructions,
-				signal,
-				options.thinkingLevel ?? session.thinkingLevel,
-				session.agent.streamFn,
-			)
-		}
-
-		if (signal.aborted) {
-			throw new Error("Compaction cancelled")
-		}
-
-		session.sessionManager.appendCompaction(
-			compactionResult.summary,
-			compactionResult.firstKeptEntryId,
-			compactionResult.tokensBefore,
-			compactionResult.details,
-			fromExtension,
-		)
-		const newEntries = session.sessionManager.getEntries()
-		const sessionContext = session.sessionManager.buildSessionContext()
-		session.agent.state.messages = sessionContext.messages
-
-		const savedCompactionEntry = findSavedCompactionEntry(newEntries, compactionResult.summary)
-		if (savedCompactionEntry) {
-			await session._extensionRunner.emit({
-				type: "session_compact",
-				compactionEntry: savedCompactionEntry,
-				fromExtension,
-			})
-		}
-
-		session._emit({ type: "compaction_end", reason, result: compactionResult, aborted: false, willRetry: false })
-		return compactionResult
-	} catch (error) {
-		const message = error instanceof Error ? error.message : String(error)
-		const aborted = message === "Compaction cancelled" || (error instanceof Error && error.name === "AbortError")
-		session._emit({
-			type: "compaction_end",
-			reason,
-			result: undefined,
-			aborted,
-			willRetry: false,
-			errorMessage: aborted ? undefined : `Inline compaction failed: ${message}`,
-		})
-		throw error
+		return await originalCompact.call(session, options.customInstructions, options.force ?? false)
 	} finally {
-		session._inlineCompactionAbortController = undefined
+		for (const restore of restores.reverse()) {
+			restore()
+		}
 	}
 }
 
 export function installInlineCompactPatch(options: InlineCompactPatchOptions = {}): void {
 	const sessionClass = options.sessionClass ?? (AgentSession as unknown as PatchableSessionClass)
 	const runnerClass = options.runnerClass ?? (ExtensionRunner as unknown as PatchableRunnerClass)
-	const loadCompactionModule = options.loadCompactionModule ?? loadDefaultCompactionModule
-	// Fail at startup, not at first compaction: a missing prepareCompaction export
-	// once turned every stage-boundary compaction in a benchmark run into a silent no-op.
-	if (!options.loadCompactionModule) {
-		assertCompactionInternalsAvailable()
-	}
 
 	const sessionProto = sessionClass.prototype
-	if (!sessionProto._bindExtensionCore || !sessionProto.abortCompaction || !sessionProto.abort) {
+	if (!sessionProto.compact || !sessionProto._bindExtensionCore) {
 		throw new Error("pi-coding-agent AgentSession internals are incompatible with Kimchi inline compaction")
 	}
+	assertCompactInternalsCompatible(sessionProto)
 
 	if (!sessionProto._kimchiInlineCompactPatch) {
+		const originalCompact = sessionProto.compact
 		const originalBindExtensionCore = sessionProto._bindExtensionCore
-		const originalAbortCompaction = sessionProto.abortCompaction
-		const originalAbort = sessionProto.abort
 
 		sessionProto.inlineCompact = function inlineCompact(options: InlineCompactOptions = {}) {
-			return runInlineCompact(this, options, loadCompactionModule)
-		}
-
-		sessionProto.abortCompaction = function patchedAbortCompaction(...args: unknown[]) {
-			this._inlineCompactionAbortController?.abort()
-			return originalAbortCompaction.apply(this, args)
-		}
-
-		sessionProto.abort = function patchedAbort(...args: unknown[]) {
-			this._inlineCompactionAbortController?.abort()
-			return originalAbort.apply(this, args)
+			return runInlineCompact(this, originalCompact, options)
 		}
 
 		sessionProto._bindExtensionCore = function patchedBindExtensionCore(runner: PatchableRunnerInstance) {

--- a/src/upstream-inline-compact-patch.ts
+++ b/src/upstream-inline-compact-patch.ts
@@ -4,6 +4,7 @@
  * reuses PI's internal prepare/compact functions and extension events, but skips
  * the manual compact path's session disconnect + abort.
  */
+import type { Api, Model, ModelThinkingLevel } from "@earendil-works/pi-ai"
 import {
 	AgentSession,
 	type CompactionResult,
@@ -19,6 +20,19 @@ import {
 export interface InlineCompactOptions {
 	customInstructions?: string
 	force?: boolean
+	/** Override model for the summarization call. Falls back to the session's
+	 *  active model when omitted (prior behavior). Lets callers (e.g. Ferment's
+	 *  stage-boundary compaction) point summarization at a separate, cheaper or
+	 *  non-reasoning model — upstream's summarizer already gates thinkingLevel
+	 *  on `model.reasoning`, so a non-reasoning model here needs no other patch. */
+	model?: Model<Api>
+	/** Override thinking level for the summarization call. Falls back to the
+	 *  session's current thinking level when omitted. Every model in Kimchi's
+	 *  catalog today reports `reasoning: true` (some hybrid, some just not yet
+	 *  gated off at the compat layer), so picking a different `model` above does
+	 *  not by itself guarantee no reasoning tokens are spent — this is the actual
+	 *  lever for that. */
+	thinkingLevel?: ModelThinkingLevel
 }
 
 type CompactionSettingsLike = {
@@ -203,11 +217,12 @@ async function runInlineCompact(
 		if (signal.aborted) {
 			throw new Error("Compaction cancelled")
 		}
-		if (!session.model) {
+		const compactionModel = options.model ?? session.model
+		if (!compactionModel) {
 			throw new Error("No model selected")
 		}
 
-		const { apiKey, headers } = await session._getCompactionRequestAuth(session.model)
+		const { apiKey, headers } = await session._getCompactionRequestAuth(compactionModel)
 		const pathEntries = session.sessionManager.getBranch()
 		const settings = session.settingsManager.getCompactionSettings()
 		// force means "compact everything before the newest valid cut point", so
@@ -254,12 +269,12 @@ async function runInlineCompact(
 		if (!compactionResult) {
 			compactionResult = await compact(
 				preparation,
-				session.model,
+				compactionModel,
 				apiKey,
 				headers,
 				customInstructions,
 				signal,
-				session.thinkingLevel,
+				options.thinkingLevel ?? session.thinkingLevel,
 				session.agent.streamFn,
 			)
 		}

--- a/src/upstream-inline-compact-patch.ts
+++ b/src/upstream-inline-compact-patch.ts
@@ -7,8 +7,13 @@
  * - No unpaired toolCall in the current branch.
  */
 import type { Api, Model, ModelThinkingLevel } from "@earendil-works/pi-ai"
-import { AgentSession, type CompactionResult, ExtensionRunner } from "@earendil-works/pi-coding-agent"
-import { collectMessagesAfterLastCompaction, isToolCallInFlight } from "./tool-call-in-flight.js"
+import {
+	AgentSession,
+	type CompactionResult,
+	ExtensionRunner,
+	buildSessionContext,
+} from "@earendil-works/pi-coding-agent"
+import { isToolCallInFlight } from "./tool-call-in-flight.js"
 
 export interface InlineCompactOptions {
 	customInstructions?: string
@@ -20,26 +25,24 @@ export interface InlineCompactOptions {
 	thinkingLevel?: ModelThinkingLevel
 }
 
-type CompactionSettingsLike = {
-	keepRecentTokens: number
-	[key: string]: unknown
-}
-
-type PatchableSession = {
+type PatchableSession = Pick<AgentSession, "abort" | "sessionManager" | "settingsManager"> & {
 	_compactionAbortController?: AbortController
 	_autoCompactionAbortController?: AbortController
 	_kimchiInlineCompactInFlight?: boolean
 	_disconnectFromAgent: () => void
-	abort: (...args: unknown[]) => Promise<unknown>
-	sessionManager: { getBranch(): unknown[] }
-	settingsManager: { getCompactionSettings(): CompactionSettingsLike }
 	inlineCompact?(options?: InlineCompactOptions): Promise<CompactionResult>
 }
+
+type UpstreamCompact = AgentSession["compact"]
 
 type PatchableSessionPrototype = {
 	_kimchiInlineCompactPatch?: boolean
 	inlineCompact?: (this: PatchableSession, options?: InlineCompactOptions) => Promise<CompactionResult>
-	compact?: (this: PatchableSession, customInstructions?: string, force?: boolean) => Promise<CompactionResult>
+	compact?: (
+		this: PatchableSession,
+		customInstructions?: Parameters<UpstreamCompact>[0],
+		force?: boolean,
+	) => ReturnType<UpstreamCompact>
 	_bindExtensionCore?: (this: PatchableSession, runner: PatchableRunnerInstance) => unknown
 }
 
@@ -117,10 +120,10 @@ async function runInlineCompact(
 
 	// Safety assertion (not deferral — callers wanting deferral must check
 	// before calling): compacting across an unpaired toolCall summarises away
-	// the assistant toolCall and orphans the toolResult appended later. Scoped
-	// past the newest compaction entry so a historical, already-neutralised
-	// orphan cannot permanently veto compaction.
-	if (isToolCallInFlight(collectMessagesAfterLastCompaction(session.sessionManager.getBranch()))) {
+	// the assistant toolCall and orphans the toolResult appended later. Pi's
+	// context builder applies the active branch and latest compaction boundary.
+	const activeMessages = buildSessionContext(session.sessionManager.getBranch()).messages
+	if (isToolCallInFlight(activeMessages)) {
 		throw new Error(
 			"inlineCompact called while a tool call is in flight — callers must defer to a turn boundary with no unpaired toolCall",
 		)
@@ -144,13 +147,13 @@ async function runInlineCompact(
 				}
 				return realDisconnect.call(this)
 			}),
-			shadowProperty(session, "abort", async function inlineShadowedAbort(this: PatchableSession, ...args: unknown[]) {
+			shadowProperty(session, "abort", async function inlineShadowedAbort(this: PatchableSession) {
 				if (!abortSuppressed) {
 					abortSuppressed = true
 					return
 				}
 				this._compactionAbortController?.abort()
-				return realAbort.apply(this, args)
+				return realAbort.call(this)
 			}),
 		)
 
@@ -189,7 +192,13 @@ export function installInlineCompactPatch(options: InlineCompactPatchOptions = {
 
 	const sessionProto = sessionClass.prototype
 	if (!sessionProto.compact || !sessionProto._bindExtensionCore) {
-		throw new Error("pi-coding-agent AgentSession internals are incompatible with Kimchi inline compaction")
+		const missing = [
+			!sessionProto.compact && "AgentSession.compact()",
+			!sessionProto._bindExtensionCore && "AgentSession._bindExtensionCore()",
+		].filter(Boolean)
+		throw new Error(
+			`pi-coding-agent AgentSession internals are incompatible with Kimchi inline compaction (missing ${missing.join(" and ")} — upstream internals changed)`,
+		)
 	}
 	assertCompactInternalsCompatible(sessionProto)
 
@@ -212,7 +221,10 @@ export function installInlineCompactPatch(options: InlineCompactPatchOptions = {
 
 	const runnerProto = runnerClass.prototype
 	if (!runnerProto.createContext) {
-		throw new Error("pi-coding-agent ExtensionRunner internals are incompatible with Kimchi inline compaction")
+		throw new Error(
+			"pi-coding-agent ExtensionRunner internals are incompatible with Kimchi inline compaction " +
+				"(missing ExtensionRunner.createContext() — upstream internals changed)",
+		)
 	}
 
 	if (!runnerProto._kimchiInlineCompactContextPatch) {

--- a/src/upstream-inline-compact-patch.ts
+++ b/src/upstream-inline-compact-patch.ts
@@ -9,9 +9,9 @@
 import type { Api, Model, ModelThinkingLevel } from "@earendil-works/pi-ai"
 import {
 	AgentSession,
+	buildSessionContext,
 	type CompactionResult,
 	ExtensionRunner,
-	buildSessionContext,
 } from "@earendil-works/pi-coding-agent"
 import { isToolCallInFlight } from "./tool-call-in-flight.js"
 

--- a/src/upstream-inline-compact-patch.ts
+++ b/src/upstream-inline-compact-patch.ts
@@ -28,6 +28,7 @@ type CompactionSettingsLike = {
 type PatchableSession = {
 	_compactionAbortController?: AbortController
 	_autoCompactionAbortController?: AbortController
+	_kimchiInlineCompactInFlight?: boolean
 	_disconnectFromAgent: () => void
 	abort: (...args: unknown[]) => Promise<unknown>
 	sessionManager: { getBranch(): unknown[] }
@@ -106,7 +107,11 @@ async function runInlineCompact(
 	originalCompact: NonNullable<PatchableSessionPrototype["compact"]>,
 	options: InlineCompactOptions,
 ): Promise<CompactionResult> {
-	if (session._compactionAbortController || session._autoCompactionAbortController) {
+	if (
+		session._kimchiInlineCompactInFlight ||
+		session._compactionAbortController ||
+		session._autoCompactionAbortController
+	) {
 		throw new Error("Compaction already in progress")
 	}
 
@@ -121,66 +126,57 @@ async function runInlineCompact(
 		)
 	}
 
+	session._kimchiInlineCompactInFlight = true
 	const restores: Array<() => void> = []
 
-	// One-shot suppression of the quiesce pair. compact() calls each exactly
-	// once at its start, and the agent loop is suspended in the awaited
-	// handler, so no other caller can land in that window. Any LATER abort()
-	// during the summarization is a genuine cancellation request: cancel the
-	// compaction and delegate to the real abort.
-	const realDisconnect = session._disconnectFromAgent
-	const realAbort = session.abort
-	let disconnectSuppressed = false
-	let abortSuppressed = false
-	restores.push(
-		shadowProperty(session, "_disconnectFromAgent", function inlineShadowedDisconnect(this: PatchableSession) {
-			if (!disconnectSuppressed) {
-				disconnectSuppressed = true
-				return
-			}
-			return realDisconnect.call(this)
-		}),
-		shadowProperty(session, "abort", async function inlineShadowedAbort(this: PatchableSession, ...args: unknown[]) {
-			if (!abortSuppressed) {
-				abortSuppressed = true
-				return
-			}
-			this._compactionAbortController?.abort()
-			return realAbort.apply(this, args)
-		}),
-	)
-
-	// force means "compact everything before the newest valid cut point".
-	// Upstream's own force fallback (retry with keepRecentTokens: 0) only fires
-	// when preparation is undefined — a session smaller than keepRecentTokens
-	// returns a DEFINED preparation with zero summarizable messages, which
-	// turned every small-session forced compaction into a no-op. Shadow the
-	// settings so preparation starts from keepRecentTokens: 0 directly.
-	if (options.force || options.keepRecentTokens !== undefined) {
-		const settingsManager = session.settingsManager
-		const realGetCompactionSettings = settingsManager.getCompactionSettings
-		const keepRecentTokens = options.keepRecentTokens ?? 0
+	try {
+		// One-shot suppression of the quiesce pair. Any later abort() during
+		// summarization is a genuine cancellation request.
+		const realDisconnect = session._disconnectFromAgent
+		const realAbort = session.abort
+		let disconnectSuppressed = false
+		let abortSuppressed = false
 		restores.push(
-			shadowProperty(settingsManager, "getCompactionSettings", function inlineShadowedSettings() {
-				return { ...realGetCompactionSettings.call(settingsManager), keepRecentTokens }
+			shadowProperty(session, "_disconnectFromAgent", function inlineShadowedDisconnect(this: PatchableSession) {
+				if (!disconnectSuppressed) {
+					disconnectSuppressed = true
+					return
+				}
+				return realDisconnect.call(this)
+			}),
+			shadowProperty(session, "abort", async function inlineShadowedAbort(this: PatchableSession, ...args: unknown[]) {
+				if (!abortSuppressed) {
+					abortSuppressed = true
+					return
+				}
+				this._compactionAbortController?.abort()
+				return realAbort.apply(this, args)
 			}),
 		)
-	}
 
-	// compact() reads `this.model` / `this.thinkingLevel` (prototype getters
-	// over agent.state) for auth and the summarization call. Instance shadows
-	// reroute both without touching agent.state, so the suspended loop resumes
-	// with its own model untouched.
-	if (options.model !== undefined) {
-		restores.push(shadowProperty(session, "model", options.model))
-	}
-	if (options.thinkingLevel !== undefined) {
-		restores.push(shadowProperty(session, "thinkingLevel", options.thinkingLevel))
-	}
+		// force means "compact everything before the newest valid cut point".
+		if (options.force || options.keepRecentTokens !== undefined) {
+			const settingsManager = session.settingsManager
+			const realGetCompactionSettings = settingsManager.getCompactionSettings
+			const keepRecentTokens = options.keepRecentTokens ?? 0
+			restores.push(
+				shadowProperty(settingsManager, "getCompactionSettings", function inlineShadowedSettings() {
+					return { ...realGetCompactionSettings.call(settingsManager), keepRecentTokens }
+				}),
+			)
+		}
 
-	try {
+		// compact() reads these properties for auth and summarization.
+		if (options.model !== undefined) {
+			restores.push(shadowProperty(session, "model", options.model))
+		}
+		if (options.thinkingLevel !== undefined) {
+			restores.push(shadowProperty(session, "thinkingLevel", options.thinkingLevel))
+		}
+
 		return await originalCompact.call(session, options.customInstructions, options.force ?? false)
 	} finally {
+		session._kimchiInlineCompactInFlight = false
 		for (const restore of restores.reverse()) {
 			restore()
 		}

--- a/src/upstream-inline-compact-patch.ts
+++ b/src/upstream-inline-compact-patch.ts
@@ -164,6 +164,10 @@ function isCompactionResult(value: unknown): value is CompactionResult {
 	)
 }
 
+function isEmptyCompactionPreparation(value: unknown): boolean {
+	return isRecord(value) && Array.isArray(value.messagesToSummarize) && value.messagesToSummarize.length === 0
+}
+
 function asBeforeCompactResult(value: unknown): SessionBeforeCompactResultLike | undefined {
 	if (!isRecord(value)) return undefined
 	return {
@@ -232,6 +236,9 @@ async function runInlineCompact(
 			if (!preparation) {
 				throw new Error("Nothing to compact (no valid cut point)")
 			}
+		}
+		if (isEmptyCompactionPreparation(preparation)) {
+			throw new Error("Nothing to compact (no summarizable messages)")
 		}
 
 		let compactionResult: CompactionResult | undefined

--- a/src/upstream-inline-compact-patch.ts
+++ b/src/upstream-inline-compact-patch.ts
@@ -1,31 +1,10 @@
 /**
- * Non-aborting inline adaptation of pi-coding-agent's AgentSession.compact().
- *
- * Instead of cloning upstream's compaction lifecycle, `inlineCompact` DELEGATES
- * to the original `compact()` with the quiesce pair suppressed: upstream's
- * `_disconnectFromAgent()` + `await this.abort()` exist to force-idle a live
- * run before rewriting `agent.state.messages`, but inline callers (Ferment's
- * stage-boundary compaction) invoke this from an AWAITED extension handler at
- * a turn boundary — the agent loop is suspended for the whole call, so the
- * rewrite is already safe and the run must NOT be aborted.
- *
- * Delegation means upstream's own code runs: `_compactionAbortController` is
- * set (so `isCompacting` and `abortCompaction()` work unpatched), events carry
- * upstream's exact shapes (reason "manual"), and upstream fixes are inherited
- * automatically.
- *
- * The suppression works through temporary per-instance property shadows that
- * intercept the prototype members `compact()` reaches via `this`. That
- * coupling is asserted fail-loud at patch-install time (i.e. process startup)
- * by checking the source text of `compact()` — a regression here must abort
- * the process, not silently turn stage compaction abortive or into a no-op.
+ * Non-aborting inline adaptation of AgentSession.compact().
  *
  * Caller contract (enforced where possible):
  * - Call from an awaited extension handler at a turn boundary (turn_end /
- *   agent_end) or while the session is idle. NOT enforceable from inside the
- *   session; violating it races the agent loop.
- * - No unpaired toolCall in the current branch. ENFORCED: throws before
- *   compacting (see isToolCallInFlight) instead of orphaning the toolResult.
+ *   agent_end) or while the session is idle.
+ * - No unpaired toolCall in the current branch.
  */
 import type { Api, Model, ModelThinkingLevel } from "@earendil-works/pi-ai"
 import { AgentSession, type CompactionResult, ExtensionRunner } from "@earendil-works/pi-coding-agent"
@@ -34,18 +13,9 @@ import { collectMessagesAfterLastCompaction, isToolCallInFlight } from "./tool-c
 export interface InlineCompactOptions {
 	customInstructions?: string
 	force?: boolean
-	/** Override model for the summarization call. Falls back to the session's
-	 *  active model when omitted (prior behavior). Lets callers (e.g. Ferment's
-	 *  stage-boundary compaction) point summarization at a separate, cheaper or
-	 *  non-reasoning model — upstream's summarizer already gates thinkingLevel
-	 *  on `model.reasoning`, so a non-reasoning model here needs no other patch. */
+	/** Override model for the summarization call. */
 	model?: Model<Api>
-	/** Override thinking level for the summarization call. Falls back to the
-	 *  session's current thinking level when omitted. Every model in Kimchi's
-	 *  catalog today reports `reasoning: true` (some hybrid, some just not yet
-	 *  gated off at the compat layer), so picking a different `model` above does
-	 *  not by itself guarantee no reasoning tokens are spent — this is the actual
-	 *  lever for that. */
+	/** Override thinking level for the summarization call. */
 	thinkingLevel?: ModelThinkingLevel
 }
 
@@ -119,14 +89,7 @@ function shadowProperty(target: object, key: string, value: unknown): () => void
 	}
 }
 
-/**
- * Fail at patch-install time (i.e. process startup) when `compact()` no longer
- * calls the internals the inline shadows suppress. If upstream renames
- * `_disconnectFromAgent` or stops quiescing via `this.abort()`, the shadows
- * would silently go inert and inline compaction would become abortive again —
- * the same silent-regression class that once turned every stage-boundary
- * compaction in a benchmark run into a no-op.
- */
+/** Fail fast if upstream compact internals no longer match the inline patch. */
 function assertCompactInternalsCompatible(sessionProto: PatchableSessionPrototype): void {
 	const compactSource = typeof sessionProto.compact === "function" ? String(sessionProto.compact) : ""
 	if (!compactSource.includes("_disconnectFromAgent") || !compactSource.includes("abort")) {

--- a/src/upstream-inline-compact-patch.ts
+++ b/src/upstream-inline-compact-patch.ts
@@ -4,14 +4,16 @@
  * reuses PI's internal prepare/compact functions and extension events, but skips
  * the manual compact path's session disconnect + abort.
  */
-import { existsSync } from "node:fs"
-import { dirname, join, parse } from "node:path"
-import { fileURLToPath, pathToFileURL } from "node:url"
 import {
 	AgentSession,
 	type CompactionResult,
 	ExtensionRunner,
 	compact as piCompact,
+	// Re-exported from the package root by patches/@earendil-works__pi-coding-agent@0.78.1.patch
+	// (item 7). A static import is required: the Bun-compiled binary has no node_modules on
+	// disk, so any runtime module resolution (import.meta.resolve, dynamic deep imports,
+	// directory walks) fails there even though it works in dev under Node.
+	prepareCompaction as piPrepareCompaction,
 } from "@earendil-works/pi-coding-agent"
 
 export interface InlineCompactOptions {
@@ -116,39 +118,25 @@ export interface InlineCompactPatchOptions {
 	loadCompactionModule?: () => Promise<InlineCompactCompactionModule>
 }
 
-let defaultCompactionModulePromise: Promise<InlineCompactCompactionModule> | undefined
-
-function resolveCodingAgentEntryUrl(): string {
-	const resolver = (import.meta as ImportMeta & { resolve?: (specifier: string) => string }).resolve
-	if (typeof resolver === "function") {
-		return resolver("@earendil-works/pi-coding-agent")
+/** Throw at patch-install time (i.e. process startup) when the statically imported
+ *  compaction internals are missing — a regression here must abort the process, not
+ *  silently skip every compaction at stage boundaries. */
+function assertCompactionInternalsAvailable(): void {
+	if (typeof piPrepareCompaction !== "function" || typeof piCompact !== "function") {
+		throw new Error(
+			"pi-coding-agent compaction internals are incompatible with Kimchi inline compaction " +
+				"(prepareCompaction is not exported from the package root — check that " +
+				"patches/@earendil-works__pi-coding-agent applied)",
+		)
 	}
-
-	let current = dirname(fileURLToPath(import.meta.url))
-	const root = parse(current).root
-	while (true) {
-		const entry = join(current, "node_modules", "@earendil-works", "pi-coding-agent", "dist", "index.js")
-		if (existsSync(entry)) return pathToFileURL(entry).href
-		if (current === root) break
-		current = dirname(current)
-	}
-	throw new Error("Unable to resolve pi-coding-agent from Kimchi inline compaction")
 }
 
 export async function loadDefaultCompactionModule(): Promise<InlineCompactCompactionModule> {
-	defaultCompactionModulePromise ??= (async () => {
-		const packageRoot = resolveCodingAgentEntryUrl()
-		const moduleUrl = new URL("./core/compaction/index.js", packageRoot)
-		const mod = (await import(moduleUrl.href)) as Partial<Pick<InlineCompactCompactionModule, "prepareCompaction">>
-		if (typeof mod.prepareCompaction !== "function") {
-			throw new Error("pi-coding-agent compaction internals are incompatible with Kimchi inline compaction")
-		}
-		return {
-			prepareCompaction: mod.prepareCompaction,
-			compact: piCompact as InlineCompactCompactionModule["compact"],
-		}
-	})()
-	return defaultCompactionModulePromise
+	assertCompactionInternalsAvailable()
+	return {
+		prepareCompaction: piPrepareCompaction as unknown as InlineCompactCompactionModule["prepareCompaction"],
+		compact: piCompact as InlineCompactCompactionModule["compact"],
+	}
 }
 
 function isRecord(value: unknown): value is Record<string, unknown> {
@@ -222,20 +210,21 @@ async function runInlineCompact(
 		const { apiKey, headers } = await session._getCompactionRequestAuth(session.model)
 		const pathEntries = session.sessionManager.getBranch()
 		const settings = session.settingsManager.getCompactionSettings()
-		let preparation = prepareCompaction(pathEntries, settings)
+		// force means "compact everything before the newest valid cut point", so
+		// prepare with keepRecentTokens: 0 directly. Falling back to 0 only when
+		// preparation is undefined is not enough: a session smaller than
+		// keepRecentTokens returns a *defined* preparation with zero summarizable
+		// messages, which turned every small-session forced compaction into a no-op.
+		const preparation = prepareCompaction(pathEntries, options.force ? { ...settings, keepRecentTokens: 0 } : settings)
 
 		if (!preparation) {
 			const lastEntry = pathEntries[pathEntries.length - 1]
 			if (isRecord(lastEntry) && lastEntry.type === "compaction") {
 				throw new Error("Already compacted")
 			}
-			if (!options.force) {
-				throw new Error("Nothing to compact (session too small)")
-			}
-			preparation = prepareCompaction(pathEntries, { ...settings, keepRecentTokens: 0 })
-			if (!preparation) {
-				throw new Error("Nothing to compact (no valid cut point)")
-			}
+			throw new Error(
+				options.force ? "Nothing to compact (no valid cut point)" : "Nothing to compact (session too small)",
+			)
 		}
 		if (isEmptyCompactionPreparation(preparation)) {
 			throw new Error("Nothing to compact (no summarizable messages)")
@@ -322,6 +311,11 @@ export function installInlineCompactPatch(options: InlineCompactPatchOptions = {
 	const sessionClass = options.sessionClass ?? (AgentSession as unknown as PatchableSessionClass)
 	const runnerClass = options.runnerClass ?? (ExtensionRunner as unknown as PatchableRunnerClass)
 	const loadCompactionModule = options.loadCompactionModule ?? loadDefaultCompactionModule
+	// Fail at startup, not at first compaction: a missing prepareCompaction export
+	// once turned every stage-boundary compaction in a benchmark run into a silent no-op.
+	if (!options.loadCompactionModule) {
+		assertCompactionInternalsAvailable()
+	}
 
 	const sessionProto = sessionClass.prototype
 	if (!sessionProto._bindExtensionCore || !sessionProto.abortCompaction || !sessionProto.abort) {

--- a/src/upstream-inline-compact-patch.ts
+++ b/src/upstream-inline-compact-patch.ts
@@ -13,6 +13,7 @@ import { collectMessagesAfterLastCompaction, isToolCallInFlight } from "./tool-c
 export interface InlineCompactOptions {
 	customInstructions?: string
 	force?: boolean
+	keepRecentTokens?: number
 	/** Override model for the summarization call. */
 	model?: Model<Api>
 	/** Override thinking level for the summarization call. */
@@ -155,12 +156,13 @@ async function runInlineCompact(
 	// returns a DEFINED preparation with zero summarizable messages, which
 	// turned every small-session forced compaction into a no-op. Shadow the
 	// settings so preparation starts from keepRecentTokens: 0 directly.
-	if (options.force) {
+	if (options.force || options.keepRecentTokens !== undefined) {
 		const settingsManager = session.settingsManager
 		const realGetCompactionSettings = settingsManager.getCompactionSettings
+		const keepRecentTokens = options.keepRecentTokens ?? 0
 		restores.push(
 			shadowProperty(settingsManager, "getCompactionSettings", function inlineShadowedSettings() {
-				return { ...realGetCompactionSettings.call(settingsManager), keepRecentTokens: 0 }
+				return { ...realGetCompactionSettings.call(settingsManager), keepRecentTokens }
 			}),
 		)
 	}

--- a/src/upstream-inline-compact-patch.ts
+++ b/src/upstream-inline-compact-patch.ts
@@ -1,0 +1,376 @@
+/**
+ * Local non-aborting adaptation of pi-coding-agent's AgentSession.compact()
+ * lifecycle. Keep this close to upstream compaction behavior: it intentionally
+ * reuses PI's internal prepare/compact functions and extension events, but skips
+ * the manual compact path's session disconnect + abort.
+ */
+import { existsSync } from "node:fs"
+import { dirname, join, parse } from "node:path"
+import { fileURLToPath, pathToFileURL } from "node:url"
+import {
+	AgentSession,
+	type CompactionResult,
+	ExtensionRunner,
+	compact as piCompact,
+} from "@earendil-works/pi-coding-agent"
+
+export interface InlineCompactOptions {
+	customInstructions?: string
+	force?: boolean
+}
+
+type CompactionSettingsLike = {
+	keepRecentTokens: number
+	[key: string]: unknown
+}
+
+export type InlineCompactCompactionModule = {
+	prepareCompaction: (pathEntries: unknown[], settings: CompactionSettingsLike) => unknown | undefined
+	compact: (
+		preparation: unknown,
+		model: unknown,
+		apiKey: string | undefined,
+		headers: Record<string, string> | undefined,
+		customInstructions: string | undefined,
+		signal: AbortSignal,
+		thinkingLevel: unknown,
+		streamFn: unknown,
+	) => Promise<CompactionResult>
+}
+
+type ExtensionRunnerLike = {
+	hasHandlers(event: string): boolean
+	emit(event: unknown): Promise<unknown>
+}
+
+type SessionManagerLike = {
+	getBranch(): unknown[]
+	getEntries(): unknown[]
+	appendCompaction(
+		summary: string,
+		firstKeptEntryId: string,
+		tokensBefore: number,
+		details: unknown,
+		fromExtension: boolean,
+	): void
+	buildSessionContext(): { messages: unknown[] }
+}
+
+type PatchableSession = {
+	model: unknown | undefined
+	thinkingLevel: unknown
+	agent: {
+		state: { messages: unknown[] }
+		streamFn: unknown
+	}
+	sessionManager: SessionManagerLike
+	settingsManager: {
+		getCompactionSettings(): CompactionSettingsLike
+	}
+	_getCompactionRequestAuth(model: unknown): Promise<{
+		apiKey?: string
+		headers?: Record<string, string>
+	}>
+	_extensionRunner: ExtensionRunnerLike
+	_emit(event: unknown): void
+	_compactionAbortController?: AbortController
+	_autoCompactionAbortController?: AbortController
+	_inlineCompactionAbortController?: AbortController
+	inlineCompact?(options?: InlineCompactOptions): Promise<CompactionResult>
+}
+
+type PatchableSessionPrototype = {
+	_kimchiInlineCompactPatch?: boolean
+	inlineCompact?: (this: PatchableSession, options?: InlineCompactOptions) => Promise<CompactionResult>
+	_bindExtensionCore?: (this: PatchableSession, runner: PatchableRunnerInstance) => unknown
+	abortCompaction?: (this: PatchableSession, ...args: unknown[]) => unknown
+	abort?: (this: PatchableSession, ...args: unknown[]) => unknown
+}
+
+type PatchableSessionClass = {
+	prototype: PatchableSessionPrototype
+}
+
+type PatchableRunnerInstance = {
+	_kimchiInlineCompact?: (options?: InlineCompactOptions) => Promise<CompactionResult>
+	assertActive?: () => void
+}
+
+type PatchableRunnerPrototype = {
+	_kimchiInlineCompactContextPatch?: boolean
+	createContext?: (this: PatchableRunnerInstance) => object
+}
+
+type PatchableRunnerClass = {
+	prototype: PatchableRunnerPrototype
+}
+
+interface SessionBeforeCompactResultLike {
+	cancel?: boolean
+	compaction?: CompactionResult
+}
+
+export interface InlineCompactPatchOptions {
+	sessionClass?: PatchableSessionClass
+	runnerClass?: PatchableRunnerClass
+	loadCompactionModule?: () => Promise<InlineCompactCompactionModule>
+}
+
+let defaultCompactionModulePromise: Promise<InlineCompactCompactionModule> | undefined
+
+function resolveCodingAgentEntryUrl(): string {
+	const resolver = (import.meta as ImportMeta & { resolve?: (specifier: string) => string }).resolve
+	if (typeof resolver === "function") {
+		return resolver("@earendil-works/pi-coding-agent")
+	}
+
+	let current = dirname(fileURLToPath(import.meta.url))
+	const root = parse(current).root
+	while (true) {
+		const entry = join(current, "node_modules", "@earendil-works", "pi-coding-agent", "dist", "index.js")
+		if (existsSync(entry)) return pathToFileURL(entry).href
+		if (current === root) break
+		current = dirname(current)
+	}
+	throw new Error("Unable to resolve pi-coding-agent from Kimchi inline compaction")
+}
+
+export async function loadDefaultCompactionModule(): Promise<InlineCompactCompactionModule> {
+	defaultCompactionModulePromise ??= (async () => {
+		const packageRoot = resolveCodingAgentEntryUrl()
+		const moduleUrl = new URL("./core/compaction/index.js", packageRoot)
+		const mod = (await import(moduleUrl.href)) as Partial<Pick<InlineCompactCompactionModule, "prepareCompaction">>
+		if (typeof mod.prepareCompaction !== "function") {
+			throw new Error("pi-coding-agent compaction internals are incompatible with Kimchi inline compaction")
+		}
+		return {
+			prepareCompaction: mod.prepareCompaction,
+			compact: piCompact as InlineCompactCompactionModule["compact"],
+		}
+	})()
+	return defaultCompactionModulePromise
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+	return !!value && typeof value === "object"
+}
+
+function isCompactionResult(value: unknown): value is CompactionResult {
+	return (
+		isRecord(value) &&
+		typeof value.summary === "string" &&
+		typeof value.firstKeptEntryId === "string" &&
+		typeof value.tokensBefore === "number"
+	)
+}
+
+function asBeforeCompactResult(value: unknown): SessionBeforeCompactResultLike | undefined {
+	if (!isRecord(value)) return undefined
+	return {
+		cancel: value.cancel === true,
+		compaction: isCompactionResult(value.compaction) ? value.compaction : undefined,
+	}
+}
+
+function getResultFromExtension(compaction: CompactionResult): CompactionResult {
+	return {
+		summary: compaction.summary,
+		firstKeptEntryId: compaction.firstKeptEntryId,
+		tokensBefore: compaction.tokensBefore,
+		details: compaction.details,
+	}
+}
+
+function findSavedCompactionEntry(entries: unknown[], summary: string): unknown | undefined {
+	return entries.find((entry) => isRecord(entry) && entry.type === "compaction" && entry.summary === summary)
+}
+
+async function runInlineCompact(
+	session: PatchableSession,
+	options: InlineCompactOptions,
+	loadCompactionModule: () => Promise<InlineCompactCompactionModule>,
+): Promise<CompactionResult> {
+	if (
+		session._inlineCompactionAbortController ||
+		session._compactionAbortController ||
+		session._autoCompactionAbortController
+	) {
+		throw new Error("Compaction already in progress")
+	}
+	// PI only exposes manual/threshold/overflow compaction event reasons.
+	// Inline compaction is automatic extension-driven work, so use threshold
+	// rather than manual even when Ferment triggers it proactively.
+	const reason = "threshold"
+	const customInstructions = options.customInstructions
+	session._inlineCompactionAbortController = new AbortController()
+	session._emit({ type: "compaction_start", reason })
+
+	try {
+		const signal = session._inlineCompactionAbortController.signal
+		const { prepareCompaction, compact } = await loadCompactionModule()
+		if (signal.aborted) {
+			throw new Error("Compaction cancelled")
+		}
+		if (!session.model) {
+			throw new Error("No model selected")
+		}
+
+		const { apiKey, headers } = await session._getCompactionRequestAuth(session.model)
+		const pathEntries = session.sessionManager.getBranch()
+		const settings = session.settingsManager.getCompactionSettings()
+		let preparation = prepareCompaction(pathEntries, settings)
+
+		if (!preparation) {
+			const lastEntry = pathEntries[pathEntries.length - 1]
+			if (isRecord(lastEntry) && lastEntry.type === "compaction") {
+				throw new Error("Already compacted")
+			}
+			if (!options.force) {
+				throw new Error("Nothing to compact (session too small)")
+			}
+			preparation = prepareCompaction(pathEntries, { ...settings, keepRecentTokens: 0 })
+			if (!preparation) {
+				throw new Error("Nothing to compact (no valid cut point)")
+			}
+		}
+
+		let compactionResult: CompactionResult | undefined
+		let fromExtension = false
+		if (session._extensionRunner.hasHandlers("session_before_compact")) {
+			const extensionResult = asBeforeCompactResult(
+				await session._extensionRunner.emit({
+					type: "session_before_compact",
+					preparation,
+					branchEntries: pathEntries,
+					customInstructions,
+					signal,
+				}),
+			)
+			if (extensionResult?.cancel) {
+				throw new Error("Compaction cancelled")
+			}
+			if (extensionResult?.compaction) {
+				compactionResult = getResultFromExtension(extensionResult.compaction)
+				fromExtension = true
+			}
+		}
+
+		if (!compactionResult) {
+			compactionResult = await compact(
+				preparation,
+				session.model,
+				apiKey,
+				headers,
+				customInstructions,
+				signal,
+				session.thinkingLevel,
+				session.agent.streamFn,
+			)
+		}
+
+		if (signal.aborted) {
+			throw new Error("Compaction cancelled")
+		}
+
+		session.sessionManager.appendCompaction(
+			compactionResult.summary,
+			compactionResult.firstKeptEntryId,
+			compactionResult.tokensBefore,
+			compactionResult.details,
+			fromExtension,
+		)
+		const newEntries = session.sessionManager.getEntries()
+		const sessionContext = session.sessionManager.buildSessionContext()
+		session.agent.state.messages = sessionContext.messages
+
+		const savedCompactionEntry = findSavedCompactionEntry(newEntries, compactionResult.summary)
+		if (savedCompactionEntry) {
+			await session._extensionRunner.emit({
+				type: "session_compact",
+				compactionEntry: savedCompactionEntry,
+				fromExtension,
+			})
+		}
+
+		session._emit({ type: "compaction_end", reason, result: compactionResult, aborted: false, willRetry: false })
+		return compactionResult
+	} catch (error) {
+		const message = error instanceof Error ? error.message : String(error)
+		const aborted = message === "Compaction cancelled" || (error instanceof Error && error.name === "AbortError")
+		session._emit({
+			type: "compaction_end",
+			reason,
+			result: undefined,
+			aborted,
+			willRetry: false,
+			errorMessage: aborted ? undefined : `Inline compaction failed: ${message}`,
+		})
+		throw error
+	} finally {
+		session._inlineCompactionAbortController = undefined
+	}
+}
+
+export function installInlineCompactPatch(options: InlineCompactPatchOptions = {}): void {
+	const sessionClass = options.sessionClass ?? (AgentSession as unknown as PatchableSessionClass)
+	const runnerClass = options.runnerClass ?? (ExtensionRunner as unknown as PatchableRunnerClass)
+	const loadCompactionModule = options.loadCompactionModule ?? loadDefaultCompactionModule
+
+	const sessionProto = sessionClass.prototype
+	if (!sessionProto._bindExtensionCore || !sessionProto.abortCompaction || !sessionProto.abort) {
+		throw new Error("pi-coding-agent AgentSession internals are incompatible with Kimchi inline compaction")
+	}
+
+	if (!sessionProto._kimchiInlineCompactPatch) {
+		const originalBindExtensionCore = sessionProto._bindExtensionCore
+		const originalAbortCompaction = sessionProto.abortCompaction
+		const originalAbort = sessionProto.abort
+
+		sessionProto.inlineCompact = function inlineCompact(options: InlineCompactOptions = {}) {
+			return runInlineCompact(this, options, loadCompactionModule)
+		}
+
+		sessionProto.abortCompaction = function patchedAbortCompaction(...args: unknown[]) {
+			this._inlineCompactionAbortController?.abort()
+			return originalAbortCompaction.apply(this, args)
+		}
+
+		sessionProto.abort = function patchedAbort(...args: unknown[]) {
+			this._inlineCompactionAbortController?.abort()
+			return originalAbort.apply(this, args)
+		}
+
+		sessionProto._bindExtensionCore = function patchedBindExtensionCore(runner: PatchableRunnerInstance) {
+			runner._kimchiInlineCompact = (inlineOptions?: InlineCompactOptions) =>
+				this.inlineCompact?.(inlineOptions) ?? Promise.reject(new Error("inlineCompact is not available"))
+			return originalBindExtensionCore.call(this, runner)
+		}
+
+		sessionProto._kimchiInlineCompactPatch = true
+	}
+
+	const runnerProto = runnerClass.prototype
+	if (!runnerProto.createContext) {
+		throw new Error("pi-coding-agent ExtensionRunner internals are incompatible with Kimchi inline compaction")
+	}
+
+	if (!runnerProto._kimchiInlineCompactContextPatch) {
+		const originalCreateContext = runnerProto.createContext
+		runnerProto.createContext = function patchedCreateContext() {
+			const context = originalCreateContext.call(this)
+			const inlineCompact = this._kimchiInlineCompact
+			if (typeof inlineCompact === "function") {
+				Object.defineProperty(context, "inlineCompact", {
+					configurable: true,
+					enumerable: true,
+					value: (inlineOptions?: InlineCompactOptions) => {
+						this.assertActive?.()
+						return inlineCompact(inlineOptions)
+					},
+				})
+			}
+			return context
+		}
+		runnerProto._kimchiInlineCompactContextPatch = true
+	}
+}

--- a/tests/smoke/ferment-oneshot-exit.test.ts
+++ b/tests/smoke/ferment-oneshot-exit.test.ts
@@ -253,6 +253,10 @@ function oneShotCompletionScript(): FakeResponseScript[] {
 			stream: ['{"grade":"A","rationale":"Clean phase.","recommendations":[]}'],
 		},
 		{
+			// Stage-boundary compaction summarizes the step/phase handoff.
+			stream: ["The completed phase and next action are preserved."],
+		},
+		{
 			// Complete the Ferment; the following request is the journey-grade judge response.
 			toolCalls: [
 				{


### PR DESCRIPTION
## Linked issue

Closes #802

<!-- Every PR must link to an existing issue. PRs without a linked issue will not be reviewed.
     Use one of: Closes #N / Fixes #N / Resolves #N -->

## What does this PR do?

Adds non-aborting inline compaction for Ferment stage boundaries. This lets Ferment compact context at safe turn-boundary points without disconnecting the agent or terminating `--print` sessions.

## Key decisions

  - Reuse upstream `AgentSession.compact()` via an inline patch instead of reimplementing compaction.
  - Suppress only the abort/disconnect part of upstream compaction; keep upstream summary generation, events, and session rewrite behavior.
  - Require inline compaction to run only at safe points and fail when a tool call is still in flight.
  - Use `kimchi-dev/nemotron-3-ultra-fp4` as the default compactor model.
  - Run compaction summarization with thinking disabled.
  - Keep 5% of the active session model’s context window during Ferment stage compaction instead of compacting down to zero retained context.

## Checklist

- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md) and agree to the CLA
- [x] This PR links to an open issue above
- [x] Tests pass locally (`pnpm run test`)
- [x] Lint passes (`pnpm run check`)
- [x] Documentation updated if behavior changed
