### PR TITLE
fix(ferment): gate scope-nudge suppression on continuation policy

### DIFF
--- a/src/extensions/ferment/resume.test.ts
+++ b/src/extensions/ferment/resume.test.ts
@@ -216,3 +216,18 @@ describe("resumeFerment pending-proposal hydration", () => {
 		deletePendingProposal(ferment.id, h.fermentsDir)
 	})
 })
+
+describe("resumeFerment automated scope-nudge dedup", () => {
+	it("automated draft resume without a persisted proposal does not queue duplicate scoping nudges", () => {
+		const ferment = h.eventStorage.create("Automated Untouched Draft")
+		h.runtime.setContinuationPolicy("automated")
+		h.runtime.setActive(ferment)
+
+		resumeFerment(h.pi, ferment.id, { hasUI: false } as ExtensionCommandContext, h.runtime)
+
+		const hiddenNudges = h.sentMessages
+			.filter((m) => m.customType === "ferment_resume_nudge" || m.customType === "ferment_continuation_nudge")
+			.map((m) => m.customType)
+		expect(hiddenNudges).toEqual(["ferment_resume_nudge"])
+	})
+})

--- a/src/extensions/ferment/resume.ts
+++ b/src/extensions/ferment/resume.ts
@@ -176,5 +176,9 @@ export function resumeFerment(
 		{ triggerTurn: true },
 	)
 
-	scheduleFermentWakeUp(pi, runtime, { ...opts, fermentId: existing.id, tag: "Resume wake-up" })
+	// `resumeFerment` already sent a `ferment_resume_nudge` with triggerTurn for
+	// this ferment. Passing `skipNudge` prevents `scheduleFermentWakeUp` from
+	// queuing a duplicate `ferment_continuation_nudge` for the same scope action
+	// (only affects draft ferments where determineNextAction returns { kind: "scope" }).
+	scheduleFermentWakeUp(pi, runtime, { ...opts, fermentId: existing.id, tag: "Resume wake-up", skipNudge: true })
 }

--- a/src/extensions/ferment/scheduler.test.ts
+++ b/src/extensions/ferment/scheduler.test.ts
@@ -1,0 +1,83 @@
+import { mkdtempSync, rmSync } from "node:fs"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
+import type { ExtensionAPI } from "@earendil-works/pi-coding-agent"
+import { afterEach, describe, expect, it, vi } from "vitest"
+import { FermentEventStore } from "../../ferment/event-store.js"
+import { type FermentRuntime, createDefaultFermentRuntime } from "./runtime.js"
+import { scheduleNextFermentAction } from "./scheduler.js"
+import { setActive } from "./state.js"
+
+function createPi(): ExtensionAPI {
+	return {
+		appendEntry: vi.fn(),
+		sendMessage: vi.fn(),
+	} as unknown as ExtensionAPI
+}
+
+/**
+ * Builds a runtime backed by a real FermentEventStore with a freshly created
+ * draft ferment (no phases). `determineNextAction` resolves such a draft to a
+ * `{ kind: "scope" }` action, which is the exact path that regresses.
+ */
+const tmpDirs: string[] = []
+
+function makeRuntime(policy: "automated" | "manual"): {
+	runtime: FermentRuntime
+	draftId: string
+} {
+	const tmpDir = mkdtempSync(join(tmpdir(), "ferment-scheduler-test-"))
+	tmpDirs.push(tmpDir)
+	const storage = new FermentEventStore(tmpDir)
+	const draft = storage.create("Scheduler Nudge Draft")
+	const runtime: FermentRuntime = {
+		...createDefaultFermentRuntime(),
+		getStorage: () => storage,
+		getActiveId: () => draft.id,
+		getContinuationPolicy: () => policy,
+		isAutomatedContinuationEnabled: () => policy === "automated",
+	}
+	return { runtime, draftId: draft.id }
+}
+
+afterEach(() => {
+	setActive(undefined)
+	for (const dir of tmpDirs.splice(0)) {
+		rmSync(dir, { recursive: true, force: true })
+	}
+})
+
+describe("scheduleNextFermentAction — scope nudge suppression", () => {
+	it("sends a ferment_continuation_nudge for a draft scope action under automated policy", () => {
+		const pi = createPi()
+		const { runtime, draftId } = makeRuntime("automated")
+		const draft = runtime.getStorage().get(draftId)
+		if (!draft) throw new Error("draft not found")
+		// sanity: a fresh draft with no phases resolves to a scope action
+		expect(draft.phases).toHaveLength(0)
+		expect(draft.status).toBe("draft")
+
+		scheduleNextFermentAction(pi, draft, runtime)
+
+		expect(pi.sendMessage).toHaveBeenCalledTimes(1)
+		expect(pi.sendMessage).toHaveBeenCalledWith(
+			expect.objectContaining({
+				customType: "ferment_continuation_nudge",
+				content: [expect.objectContaining({ type: "text" })],
+				details: { action: "scope" },
+			}),
+			expect.objectContaining({ triggerTurn: true }),
+		)
+	})
+
+	it("suppresses the scope nudge under manual policy (PR #289 interactive behaviour preserved)", () => {
+		const pi = createPi()
+		const { runtime, draftId } = makeRuntime("manual")
+		const draft = runtime.getStorage().get(draftId)
+		if (!draft) throw new Error("draft not found")
+
+		scheduleNextFermentAction(pi, draft, runtime)
+
+		expect(pi.sendMessage).not.toHaveBeenCalled()
+	})
+})

--- a/src/extensions/ferment/scheduler.ts
+++ b/src/extensions/ferment/scheduler.ts
@@ -5,6 +5,7 @@ import type { Ferment, Phase, Step } from "../../ferment/types.js"
 import { formatActionNudgeLine } from "./action-tool-names.js"
 import { decideContinuation } from "./continuation.js"
 import type { FermentRuntime } from "./runtime.js"
+import type { ContinuationPolicy } from "./state.js"
 
 export interface ScheduleNextFermentActionOptions {
 	allowManualPhaseBoundary?: boolean
@@ -17,6 +18,7 @@ export interface ScheduleFermentWakeUpOptions {
 	allowManualPhaseBoundary?: boolean
 	deliverAs?: "followUp"
 	fermentId?: string
+	skipNudge?: boolean
 	tag?: string
 }
 
@@ -142,8 +144,24 @@ function freshFerment(runtime: FermentRuntime, fermentId?: string): Ferment | un
 	return fresh
 }
 
-function shouldSuppressHiddenNudge(action: DeclarativeAction): boolean {
-	return action.kind === "scope"
+/**
+ * Whether the given action's hidden continuation nudge should be suppressed.
+ *
+ * Scope nudges are suppressed in *interactive* (manual policy) mode only. There
+ * the user drives the propose_ferment_scoping → TUI review → scope_ferment
+ * sequence by hand, so an injected "call scope_ferment now" nudge would race
+ * the user and corrupt the interactive flow (PR #289).
+ *
+ * In *automated* / one-shot mode there is no human driving scoping — the nudge
+ * is the only thing keeping the session alive. Suppressing it there leaves the
+ * model stranded on a text-only stop during draft scoping, which was the single
+ * largest correctable failure mode in terminal-bench-2-1 (16 of 31
+ * scored fails). So for scope actions we suppress only when the continuation
+ * policy is not automated.
+ */
+function shouldSuppressHiddenNudge(action: DeclarativeAction, policy: ContinuationPolicy): boolean {
+	if (action.kind === "scope") return policy !== "automated"
+	return false
 }
 
 export function scheduleNextFermentAction(
@@ -162,7 +180,7 @@ export function scheduleNextFermentAction(
 	if (decision.type !== "continue") return
 
 	const action = decision.action
-	if (shouldSuppressHiddenNudge(action)) return
+	if (shouldSuppressHiddenNudge(action, runtime.getContinuationPolicy())) return
 	const actionPhase = "phaseId" in action ? ferment.phases.find((p) => p.id === action.phaseId) : undefined
 	const activePhase = ferment.phases.find((p) => p.id === ferment.activePhaseId)
 	const displayPhase = actionPhase ?? activePhase
@@ -207,7 +225,8 @@ export function scheduleFermentWakeUp(
 
 	const decision = decideContinuation(ferment, runtime.getContinuationPolicy(), opts)
 	if (decision.type !== "continue") return
-	if (shouldSuppressHiddenNudge(decision.action)) return
+	if (opts.skipNudge && decision.action.kind === "scope") return
+	if (shouldSuppressHiddenNudge(decision.action, runtime.getContinuationPolicy())) return
 
 	const scopeProgress = getScopingProgress(ferment)
 	const tag = opts.tag ?? "Wake-up"

--- a/tests/e2e/tui/ferment-oneshot-scope-nudge.test.ts
+++ b/tests/e2e/tui/ferment-oneshot-scope-nudge.test.ts
@@ -1,0 +1,70 @@
+/**
+ * E2E TUI test: --ferment-oneshot does not die on a text-only stop during
+ * draft scoping.
+ *
+ * Before the fix, `shouldSuppressHiddenNudge` returned `true` for any
+ * `action.kind === "scope"` regardless of continuation policy. In one-shot
+ * (automated) mode the reactive continuation nudge is the only thing keeping
+ * the session alive when the model emits a text-only stop during draft
+ * scoping — suppressing it ended the run with the ferment never scoped. This
+ * test reproduces that exact stall and asserts the harness injects a
+ * `ferment_continuation_nudge` (visible as the scope action line) and
+ * continues into a follow-up turn instead of terminating.
+ */
+
+import { expect, test } from "@microsoft/tui-test"
+import { STARTUP_TIMEOUT_MS, STREAM_TIMEOUT_MS, waitForText } from "./support/assertions.js"
+import { TUI_TEST_CONFIG, runKimchiSession } from "./support/kimchi-fixture.js"
+
+test.use(TUI_TEST_CONFIG)
+
+test("--ferment-oneshot injects a scope continuation nudge after a text-only stop during draft scoping", async ({
+	terminal,
+}) => {
+	await runKimchiSession(
+		terminal,
+		{
+			artifactName: "ferment-oneshot-scope-nudge",
+			gitInit: true,
+			extraArgs: ["--ferment-oneshot=true"],
+			// Response 1: text-only stop (no tool calls) — the exact stall pattern.
+			// Response 2: a benign follow-up so the continuation turn has content.
+			responses: [
+				{ stream: ["I'll start by gathering the requirements for this task.\n"] },
+				{ stream: ["Calling propose_ferment_scoping now.\n"] },
+			],
+		},
+		async (fixture, trace) => {
+			// Stage 1: ready prompt.
+			await waitForText(terminal, "ask anything or type / for commands", { timeoutMs: STARTUP_TIMEOUT_MS })
+			trace.step("ready prompt visible")
+
+			// Stage 2: submit a request — this bootstraps a draft ferment under
+			// automated policy in oneshot mode.
+			terminal.submit("Build a hello-world CLI")
+			trace.step("submitted oneshot request — draft ferment bootstrapped")
+
+			// Stage 3: the first (text-only) response streams out.
+			await waitForText(terminal, "gathering the requirements", { timeoutMs: STREAM_TIMEOUT_MS })
+			trace.step("text-only stop response streamed")
+
+			// Stage 4: the reactive continuation nudge has display:false, so it is
+			// not visible in the terminal — but it triggers a follow-up turn. The
+			// proof of continuation is the second (scripted) response streaming
+			// into the terminal. Before the fix, the scope nudge was suppressed and
+			// the session terminated after the first text-only stop, so this text
+			// would never appear.
+			await waitForText(terminal, "propose_ferment_scoping now", { timeoutMs: STREAM_TIMEOUT_MS })
+			trace.step("follow-up turn executed — scope nudge was not suppressed")
+
+			// Stage 5: assert the fake server received at least two POST completion
+			// requests — the initial turn plus the nudge-triggered follow-up.
+			// (Before the fix, suppression ended the run after one request.)
+			// We count POSTs to /chat/completions specifically, since the fake also
+			// records the model-metadata GET and the title-generation POST.
+			const chatPosts = fixture.fake.requests.filter((r) => r.method === "POST" && r.url.includes("/chat/completions"))
+			expect(chatPosts.length).toBeGreaterThanOrEqual(2)
+			trace.step("two chat-completion POSTs recorded — continuation confirmed")
+		},
+	)
+})

--- a/tests/e2e/tui/tui-test.config.ts
+++ b/tests/e2e/tui/tui-test.config.ts
@@ -3,4 +3,7 @@ import { defineConfig } from "@microsoft/tui-test"
 export default defineConfig({
 	// Retry transient startup/render races (TUI e2e is timing-sensitive).
 	retries: 2,
+	// Ferment oneshot e2e tests drive multiple turns (bootstrap + nudge-triggered
+	// follow-up) plus compaction; the default 30s is too tight for those.
+	timeout: 60_000,
 })


### PR DESCRIPTION
## What does this PR do?

`shouldSuppressHiddenNudge` unconditionally suppressed the reactive continuation nudge for `action.kind === "scope"`. In one-shot/automated mode this silently dropped the nudge after a text-only stop during draft scoping, ending the session instead of driving a follow-up turn.

The fix gates suppression on the continuation policy: scope nudges are only suppressed when `policy !== "automated"`, preserving PR #289 interactive-mode behavior while allowing automated mode to continue.

### Changes
- `shouldSuppressHiddenNudge` now accepts `ContinuationPolicy` and returns `action.kind === "scope" ? policy !== "automated" : false`
- Both callers (`scheduleNextFermentAction`, `scheduleFermentWakeUp`) updated
- `skipNudge` option added to `ScheduleFermentWakeUpOptions` to prevent duplicate scope nudges when `resumeFerment` already sent a `ferment_resume_nudge` (only affects scope actions)
- JSDoc comment explains PR #289 interactive rationale and the automated-mode divergence
- Unit tests: `scheduler.test.ts` (automated→nudge sent, manual→suppressed)
- Regression test: `resume.test.ts` (automated draft resume does not queue duplicate scoping nudges)
- E2e: `ferment-oneshot-scope-nudge.test.ts` (text-only stop → follow-up turn)
- Bumped `tui-test.config.ts` timeout to 60s for multi-turn oneshot sessions

## Checklist

- [x] I have read CONTRIBUTING.md and agree to the CLA
- [x] Tests pass locally (`pnpm run test`)
- [x] Lint passes (`pnpm run check`)
- [x] Documentation updated if behavior changed