### PR TITLE
fix(single-model): orchestrator does not spawn agents unless instructed

### DIFF
--- a/src/extensions/prompt-construction/system-prompt.test.ts
+++ b/src/extensions/prompt-construction/system-prompt.test.ts
@@ -524,5 +524,27 @@ describe("buildSystemPrompt", () => {
 			expect(result).toContain("uncertain about a library API")
 			expect(result).toContain("assume your knowledge may be stale")
 		})
+
+		it("makes subagent spawning opt-in and defaults to the current model", () => {
+			const result = buildSystemPrompt({
+				tools,
+				env: testEnv,
+				currentModelId: "minimax-m3",
+				mode: "single",
+			})
+			// New behavior: default is to handle work directly, do not spawn subagents.
+			expect(result).toContain("Handle tasks directly yourself.")
+			expect(result).toContain("Do not spawn subagents")
+			expect(result).toContain("only do so when the user explicitly asks for delegation")
+			// When a subagent IS spawned, default to the parent's model and only
+			// use a different model if the user explicitly instructs it.
+			expect(result).toContain("pass your own model ID")
+			expect(result).toContain("by default")
+			expect(result).toContain("only use a different model if the user explicitly instructs")
+			// Old autonomous-delegate phrasing must be gone.
+			expect(result).not.toContain("clearly beneficial")
+			expect(result).not.toContain("MUST always pass")
+			expect(result).not.toContain("never delegate to a different model")
+		})
 	})
 })

--- a/src/extensions/prompt-construction/system-prompt.ts
+++ b/src/extensions/prompt-construction/system-prompt.ts
@@ -182,9 +182,9 @@ function buildSingleModelInstructions(currentModelId?: string): string {
 
 Your first response to a complex task MUST include visible text (not just internal thinking) that orients the user: state what you intend to do and why in one or two sentences. For complex tasks, name the phases you will work through (for example: "I'll start by mapping the handlers, then propose fixes, then implement"). This is the user's window to interrupt if your approach is wrong. After the orientation, proceed quietly and do not narrate meta-process in subsequent turns.
 
-You are running in single-model mode.${modelClause} All work in this session runs on the currently selected model. Handle tasks directly yourself unless delegation is clearly beneficial.
+You are running in single-model mode.${modelClause} All work in this session runs on the currently selected model. Handle tasks directly yourself.
 
-You may spawn subagents with the \`Agent\` tool for parallel work or to isolate long-running tasks. When you do, you MUST always pass your own model ID in the \`model\` parameter — never delegate to a different model.`
+Do not spawn subagents with the \`Agent\` tool by default — only do so when the user explicitly asks for delegation. When you do spawn a subagent, pass your own model ID in the \`model\` parameter by default; only use a different model if the user explicitly instructs it.`
 }
 
 const DOCUMENTS_SECTION =


### PR DESCRIPTION
## Linked issue

Closes #

<!-- Every PR must link to an existing issue. PRs without a linked issue will not be reviewed.
     Use one of: Closes #N / Fixes #N / Resolves #N -->

## What does this PR do?

Currently the orchestrator refuses to delegate to agents with different models even if the user asks it to.
It also sometimes delegates by itself with no clear benefits resulting in agent timeouts.

## Checklist

- [ ] I have read [CONTRIBUTING.md](../CONTRIBUTING.md) and agree to the CLA
- [ ] This PR links to an open issue above
- [ ] Tests pass locally (`pnpm run test`)
- [ ] Lint passes (`pnpm run check`)
- [ ] Documentation updated if behavior changed
