### PR TITLE
fix: guard prompt-summary trySend polling loop against stale extension ctx

### DIFF
--- a/src/extensions/prompt-summary.test.ts
+++ b/src/extensions/prompt-summary.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, describe, expect, it } from "vitest"
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
 import promptSummaryExtension from "./prompt-summary.js"
 
 type Handler = (event?: unknown) => void | Promise<void>
@@ -27,9 +27,46 @@ function createPiHarness() {
 	}
 }
 
+/**
+ * Harness variant that passes a `ctx` object as the second argument to
+ * event handlers, matching how pi-coding-agent's ExtensionRunner.emit()
+ * calls handlers. The ctx's `isIdle` is controllable for testing the
+ * stale-ctx crash path.
+ */
+function createStaleCtxHarness() {
+	const handlers = new Map<string, Array<(event?: unknown, ctx?: unknown) => void | Promise<void>>>()
+	const sent: unknown[] = []
+	const ctxOverrides: Record<string, unknown> = {}
+	return {
+		pi: {
+			on(event: string, handler: (event?: unknown, ctx?: unknown) => void | Promise<void>) {
+				const list = handlers.get(event) ?? []
+				list.push(handler)
+				handlers.set(event, list)
+			},
+			registerMessageRenderer() {},
+			sendMessage(message: unknown) {
+				sent.push(message)
+			},
+		},
+		async emit(event: string, payload?: unknown, ctxOverride?: Record<string, unknown>) {
+			const ctx = {
+				isIdle: () => false,
+				...ctxOverrides,
+				...ctxOverride,
+			}
+			for (const handler of handlers.get(event) ?? []) {
+				await handler(payload, ctx)
+			}
+		},
+		sent,
+	}
+}
+
 describe("prompt summary Agent token accounting", () => {
 	afterEach(() => {
 		Reflect.deleteProperty(process.env, "KIMCHI_SUBAGENT")
+		vi.useRealTimers()
 	})
 
 	it("adds deltas for repeated results from the same running Agent", async () => {
@@ -52,5 +89,41 @@ describe("prompt summary Agent token accounting", () => {
 			details: { subagents: { input: number; output: number; cacheRead: number; cacheWrite: number } }
 		}
 		expect(message.details.subagents).toEqual({ input: 18, output: 9, cacheRead: 0, cacheWrite: 3 })
+	})
+})
+
+describe("prompt summary stale-ctx crash prevention", () => {
+	beforeEach(() => {
+		vi.useFakeTimers()
+	})
+
+	afterEach(() => {
+		vi.useRealTimers()
+	})
+
+	it("does not crash when ctx.isIdle() throws stale-ctx error from setTimeout callback", async () => {
+		const harness = createStaleCtxHarness()
+		promptSummaryExtension(harness.pi as never)
+
+		let isIdleCallCount = 0
+		const staleError = new Error(
+			"This extension ctx is stale after session replacement or reload. Do not use a captured pi or command ctx after ctx.newSession(), ctx.fork(), ctx.switchSession(), or ctx.reload().",
+		)
+		const statefulIsIdle = () => {
+			isIdleCallCount++
+			if (isIdleCallCount === 1) return false // schedule setTimeout(trySend, 50)
+			throw staleError // timer fires → ctx is now stale → throw
+		}
+
+		await harness.emit("agent_start")
+		await harness.emit("message_end", {
+			message: { role: "assistant", usage: { input: 100, output: 50, cacheRead: 0, cacheWrite: 0 } },
+		})
+		await harness.emit("agent_end", {}, { isIdle: statefulIsIdle })
+
+		vi.advanceTimersByTime(50)
+
+		expect(harness.sent).toHaveLength(0)
+		expect(isIdleCallCount).toBe(2)
 	})
 })

--- a/src/extensions/prompt-summary.test.ts
+++ b/src/extensions/prompt-summary.test.ts
@@ -177,4 +177,34 @@ describe("prompt summary stale-ctx crash prevention", () => {
 		expect(errorSpy).toHaveBeenCalledWith("[prompt-summary] Failed to send:", nonStaleError)
 		errorSpy.mockRestore()
 	})
+
+	it("polls until isIdle returns true, then sends the summary", async () => {
+		vi.useRealTimers()
+		const harness = createStaleCtxHarness()
+		promptSummaryExtension(harness.pi as never)
+
+		let idleCalls = 0
+		await harness.emit("agent_start")
+		await harness.emit("message_end", {
+			message: { role: "assistant", usage: { input: 100, output: 50, cacheRead: 0, cacheWrite: 0 } },
+		})
+		await harness.emit(
+			"agent_end",
+			{},
+			{
+				isIdle: () => {
+					idleCalls++
+					return idleCalls >= 3 // false twice, then true on third call
+				},
+			},
+		)
+
+		// Wait for polling to complete (2 retries × 50ms + buffer)
+		await new Promise((resolve) => setTimeout(resolve, 200))
+
+		expect(harness.sent).toHaveLength(1)
+		expect(idleCalls).toBe(3)
+		const message = harness.sent[0] as { customType: string }
+		expect(message.customType).toBe("prompt-summary")
+	})
 })

--- a/src/extensions/prompt-summary.test.ts
+++ b/src/extensions/prompt-summary.test.ts
@@ -126,4 +126,30 @@ describe("prompt summary stale-ctx crash prevention", () => {
 		expect(harness.sent).toHaveLength(0)
 		expect(isIdleCallCount).toBe(2)
 	})
+
+	it("silently bails when pi.sendMessage throws stale-ctx error (isIdle returned true)", async () => {
+		const harness = createStaleCtxHarness()
+		const staleError = new Error("This extension ctx is stale after session replacement or reload.")
+		const piWithThrowingSend = {
+			...harness.pi,
+			sendMessage() {
+				throw staleError
+			},
+		}
+		promptSummaryExtension(piWithThrowingSend as never)
+
+		const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {})
+
+		await harness.emit("agent_start")
+		await harness.emit("message_end", {
+			message: { role: "assistant", usage: { input: 100, output: 50, cacheRead: 0, cacheWrite: 0 } },
+		})
+		await harness.emit("agent_end")
+
+		await vi.advanceTimersByTimeAsync(0)
+
+		expect(harness.sent).toHaveLength(0)
+		expect(errorSpy).not.toHaveBeenCalled()
+		errorSpy.mockRestore()
+	})
 })

--- a/src/extensions/prompt-summary.test.ts
+++ b/src/extensions/prompt-summary.test.ts
@@ -144,12 +144,37 @@ describe("prompt summary stale-ctx crash prevention", () => {
 		await harness.emit("message_end", {
 			message: { role: "assistant", usage: { input: 100, output: 50, cacheRead: 0, cacheWrite: 0 } },
 		})
-		await harness.emit("agent_end")
+		await harness.emit("agent_end", {}, { isIdle: () => true })
 
 		await vi.advanceTimersByTimeAsync(0)
 
 		expect(harness.sent).toHaveLength(0)
 		expect(errorSpy).not.toHaveBeenCalled()
+		errorSpy.mockRestore()
+	})
+
+	it("logs non-stale errors to console.error", async () => {
+		const harness = createStaleCtxHarness()
+		const nonStaleError = new Error("something went wrong")
+		const piWithThrowingSend = {
+			...harness.pi,
+			sendMessage() {
+				throw nonStaleError
+			},
+		}
+		promptSummaryExtension(piWithThrowingSend as never)
+
+		const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {})
+
+		await harness.emit("agent_start")
+		await harness.emit("message_end", {
+			message: { role: "assistant", usage: { input: 100, output: 50, cacheRead: 0, cacheWrite: 0 } },
+		})
+		await harness.emit("agent_end", {}, { isIdle: () => true })
+
+		await vi.advanceTimersByTimeAsync(0)
+
+		expect(errorSpy).toHaveBeenCalledWith("[prompt-summary] Failed to send:", nonStaleError)
 		errorSpy.mockRestore()
 	})
 })

--- a/src/extensions/prompt-summary.ts
+++ b/src/extensions/prompt-summary.ts
@@ -3,6 +3,7 @@ import type { ExtensionAPI, MessageRenderer, Theme } from "@earendil-works/pi-co
 import { Container, Text } from "@earendil-works/pi-tui"
 import { formatCount } from "./format.js"
 import { getMultiModelEnabled, getOrchestratorModelId, isSubagent } from "./prompt-construction/prompt-enrichment.js"
+import { isStaleCtxError } from "./stale-ctx.js"
 
 interface UsageTotals {
 	input: number
@@ -230,14 +231,19 @@ export default function promptSummaryExtension(pi: ExtensionAPI) {
 		// Poll until the agent is idle before sending — a plain setTimeout(0)
 		// is not enough because isStreaming can still be true when agent_end fires,
 		// causing sendMessage to take the steer path and trigger a new LLM turn.
+		//
+		// The entire body is wrapped in try/catch because ctx.isIdle() can throw
+		// a stale-ctx error when the session is torn down between agent_end and
+		// the timer callback. Without this guard, the throw is an uncaught
+		// exception in a setTimeout callback that crashes the process.
 		let attempts = 0
 		const MAX_ATTEMPTS = 100 // 5s max
 		const trySend = () => {
-			if (ctx?.isIdle() === false && attempts++ < MAX_ATTEMPTS) {
-				setTimeout(trySend, 50)
-				return
-			}
 			try {
+				if (ctx?.isIdle() === false && attempts++ < MAX_ATTEMPTS) {
+					setTimeout(trySend, 50)
+					return
+				}
 				pi.sendMessage(
 					{
 						customType: "prompt-summary",
@@ -250,6 +256,7 @@ export default function promptSummaryExtension(pi: ExtensionAPI) {
 					{ triggerTurn: false },
 				)
 			} catch (err) {
+				if (isStaleCtxError(err)) return
 				console.error("[prompt-summary] Failed to send:", err)
 			}
 		}


### PR DESCRIPTION
## Linked issue

Closes #783

## What does this PR do?

Fixes a process crash caused by an unguarded `ctx.isIdle()` call in the `prompt-summary` extension's `trySend` polling loop (`src/extensions/prompt-summary.ts`).

### The crash path

1. `agent_end` fires → the `prompt-summary` handler starts a `trySend()` polling loop that calls `ctx.isIdle()` every 50ms
2. `isIdle()` returns `false` on the first synchronous call → `setTimeout(trySend, 50)` is scheduled
3. Session shutdown invalidates the ctx (e.g. during one-shot ferment shutdown)
4. The timer fires → `ctx.isIdle()` throws via `assertActive()` with `"This extension ctx is stale after session replacement or reload"`
5. This throw is inside a `setTimeout` callback — outside the upstream `emit()` error handler's try/catch — causing an **uncaught exception** that crashes the process

The crash occurs after the agent has completed all its work, but the process crashes on shutdown/cleanup.

### The fix

Wraps the entire `trySend` body in a single `try/catch` that silently bails on stale-ctx errors using the existing `isStaleCtxError()` helper from `stale-ctx.ts`. This matches the established pattern already used in `tags.ts:623` and `curator/index.ts:68`.

Non-stale errors continue to be logged via `console.error` as before.

## Regression coverage

- **Task 1**: Failing regression test reproducing the exact crash path — `isIdle()` returns `false` on first synchronous call (scheduling `setTimeout`), then throws stale-ctx error when the timer fires. Before the fix: uncaught exception. After: silent bail.
- **Task 3**: Test verifying `sendMessage()` throwing a stale-ctx error (after `isIdle` returns `true`) is also silently bailed, not logged.
- **Task 4**: Test verifying non-stale errors are still logged to `console.error`, preserving original behavior for genuine bugs.
- **Task 5**: Test verifying the polling loop still works correctly — waits while `isIdle()` returns `false`, then sends when `true`.
- **Task 6**: Confirmed existing token accounting test is isolated (separate `describe` block, `vi.useRealTimers()` in `afterEach`).

## Checklist

- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md) and agree to the CLA
- [x] This PR links to an open issue above
- [x] Tests pass locally (`pnpm run test`)
- [x] Lint passes (`pnpm run check`)
- [x] Documentation updated if behavior changed

> **Note:** Pre-existing typecheck failures on master (`mode` property missing from `ExtensionContext`/`ExtensionBindings` in `acp/` and `resources/` files) are unrelated to this change — confirmed by stashing and re-running.