### PR TITLE
fix: set 'skill' tool as read only

### DIFF
--- a/src/extensions/permissions/taxonomy.test.ts
+++ b/src/extensions/permissions/taxonomy.test.ts
@@ -27,6 +27,13 @@ describe("classifyTool", () => {
 		expect(classifyTool("get_cluster_details")).toBe("readOnly")
 	})
 
+	it("classifies the claude-code-skills `skill` loader as read-only", () => {
+		expect(classifyTool("skill")).toBe("readOnly")
+		expect(classifyTool("Skill")).toBe("readOnly") // case-insensitive
+		expect(classifyTool("skill_view")).toBe("readOnly")
+		expect(classifyTool("skill_manage")).toBe("unknown")
+	})
+
 	it("classifies mcp read tools by trailing segment", () => {
 		expect(classifyTool("mcp__castai_prod_eu__list_clusters")).toBe("readOnly")
 		expect(classifyTool("mcp__castai_prod_eu__get_cluster_details")).toBe("readOnly")

--- a/src/extensions/permissions/taxonomy.ts
+++ b/src/extensions/permissions/taxonomy.ts
@@ -5,6 +5,7 @@ export const FILE_TOOLS = new Set(["read", "write", "edit", "ls", "grep", "find"
 
 const STATIC_CATEGORIES: Record<string, ToolCategory> = {
 	read: "readOnly",
+	skill: "readOnly",
 	grep: "readOnly",
 	find: "readOnly",
 	ls: "readOnly",

--- a/src/shared/planning/tool-catalog.test.ts
+++ b/src/shared/planning/tool-catalog.test.ts
@@ -14,7 +14,7 @@ const namesOf = (entries: ToolEntry[]): string[] => entries.map((t) => t.name)
 const TODO_TOOL_NAMES = ["create_todos", "update_todos", "add_todo", "mark_todo", "clear_todos"]
 
 const TOOL_NAMES = {
-	sharedCore: ["read", "grep", "find", "ls", "web_fetch", "web_search", "mcp", ...TODO_TOOL_NAMES],
+	sharedCore: ["read", "grep", "find", "ls", "skill", "web_fetch", "web_search", "mcp", ...TODO_TOOL_NAMES],
 	adhocOnly: ["questionnaire"],
 	fermentPlanningTools: [
 		"set_phase",
@@ -43,8 +43,8 @@ const TOOL_NAMES = {
 }
 
 describe("SHARED_CORE_TOOLS", () => {
-	it("contains the 6 read-only discovery tools, the mcp gateway, plus 5 todo lifecycle tools", () => {
-		expect(SHARED_CORE_TOOLS).toHaveLength(12)
+	it("contains the read-only discovery tools, the skill loader, the mcp gateway, plus 5 todo lifecycle tools", () => {
+		expect(SHARED_CORE_TOOLS).toHaveLength(13)
 		for (const name of TOOL_NAMES.sharedCore) {
 			expect(SHARED_CORE_TOOLS).toContainEqual(expect.objectContaining({ name }))
 		}
@@ -156,7 +156,7 @@ describe("getToolsForProfile", () => {
 	describe("idle", () => {
 		it("returns only shared core tools", () => {
 			const result = getToolsForProfile("idle")
-			expect(result).toHaveLength(12)
+			expect(result).toHaveLength(13)
 			expect(namesOf(result)).toEqual(TOOL_NAMES.sharedCore)
 		})
 

--- a/src/shared/planning/tool-catalog.ts
+++ b/src/shared/planning/tool-catalog.ts
@@ -94,6 +94,9 @@ export const SHARED_CORE_TOOLS: ToolEntry[] = [
 	{ name: "grep", modes: ["shared"] },
 	{ name: "find", modes: ["shared"] },
 	{ name: "ls", modes: ["shared"] },
+	// claude-code-skills `Skill` loader — readFileSync on a skill file only, no
+	// writes. Read-only discovery tool, available in every mode/profile.
+	{ name: "skill", modes: ["shared"] },
 	{ name: "web_fetch", modes: ["shared"] },
 	{ name: "web_search", modes: ["shared"] },
 	// MCP gateway — discovery + proxy for MCP server tools. Treated as a


### PR DESCRIPTION
## Linked issue

Closes #

<!-- Every PR must link to an existing issue. PRs without a linked issue will not be reviewed.
     Use one of: Closes #N / Fixes #N / Resolves #N -->

## What does this PR do?

Skill tool should be read only
## Checklist

- [ ] I have read [CONTRIBUTING.md](../CONTRIBUTING.md) and agree to the CLA
- [ ] This PR links to an open issue above
- [ ] Tests pass locally (`pnpm run test`)
- [ ] Lint passes (`pnpm run check`)
- [ ] Documentation updated if behavior changed
