### PR TITLE
fix(questionnaire): clarify conditional follow-up behavior

### DIFF
--- a/src/extensions/questionnaire/questionnaire.ts
+++ b/src/extensions/questionnaire/questionnaire.ts
@@ -185,7 +185,7 @@ export default function questionnaireExtension(pi: ExtensionAPI): void {
 		name: "questionnaire",
 		label: "Questionnaire",
 		description:
-			"Ask the user one or more structured questions. Use for clarifying requirements, getting preferences, or confirming decisions before acting. Supports single-select, multi-select, free-text input, and yes/no confirmation. For a single question, shows a simple option list. For multiple questions, shows a tab-based interface. Every question in a multi-question form is shown; ask conditional follow-ups in a later call after reading the user's answer. Prefer this over outputting questions as plain text.",
+			"Ask the user one or more structured questions. Use for clarifying requirements, getting preferences, or confirming decisions before acting. Supports single-select, multi-select, free-text input, and yes/no confirmation. For a single question, shows a simple option list. For multiple questions, shows a tab-based interface. Never call this tool twice in the same turn — batch all questions you need now into one call, and only ask follow-ups after reading the user's response. Prefer this over outputting questions as plain text.",
 		parameters: QuestionnaireParams,
 
 		async execute(_toolCallId, params, _signal, _onUpdate, ctx) {

--- a/src/extensions/questionnaire/questionnaire.ts
+++ b/src/extensions/questionnaire/questionnaire.ts
@@ -185,7 +185,7 @@ export default function questionnaireExtension(pi: ExtensionAPI): void {
 		name: "questionnaire",
 		label: "Questionnaire",
 		description:
-			"Ask the user one or more structured questions. Use for clarifying requirements, getting preferences, or confirming decisions before acting. Supports single-select, multi-select, free-text input, and yes/no confirmation. For a single question, shows a simple option list. For multiple questions, shows a tab-based interface. Prefer this over outputting questions as plain text.",
+			"Ask the user one or more structured questions. Use for clarifying requirements, getting preferences, or confirming decisions before acting. Supports single-select, multi-select, free-text input, and yes/no confirmation. For a single question, shows a simple option list. For multiple questions, shows a tab-based interface. Every question in a multi-question form is shown; ask conditional follow-ups in a later call after reading the user's answer. Prefer this over outputting questions as plain text.",
 		parameters: QuestionnaireParams,
 
 		async execute(_toolCallId, params, _signal, _onUpdate, ctx) {


### PR DESCRIPTION
## Linked issue

Closes #750 

<!-- Every PR must link to an existing issue. PRs without a linked issue will not be reviewed.
     Use one of: Closes #N / Fixes #N / Resolves #N -->

## What does this PR do?

This updates the questionnaire tool description to clarify that multi-question forms are flat: every question in the call is shown to the user. Conditional follow-up questions should be asked in a later tool call after reading the user’s answer, which prevents models from showing irrelevant follow-up tabs for unselected multi-select options.

## Checklist

- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md) and agree to the CLA
- [x] This PR links to an open issue above
- [x] Tests pass locally (`pnpm run test`)
- [x] Lint passes (`pnpm run check`)
- [x] Documentation updated if behavior changed
