### PR TITLE
feat(update): support installing a specific kimchi release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -228,7 +228,7 @@ jobs:
 
   homebrew:
     needs: [release]
-    if: ${{ startsWith(github.ref, 'refs/tags/v') && !contains(github.ref_name, '.rc.') && (github.event_name == 'push' || (inputs.publish_github_release && inputs.publish_homebrew)) }}
+    if: ${{ startsWith(github.ref, 'refs/tags/v') && !contains(github.ref_name, '-') && (github.event_name == 'push' || (inputs.publish_github_release && inputs.publish_homebrew)) }}
     runs-on: ubuntu-latest
 
     steps:

--- a/README.md
+++ b/README.md
@@ -370,10 +370,13 @@ kimchi resources disable extensions.pi-package-lookup
 Update packages with:
 
 ```bash
-kimchi update                  # update installed packages, then Kimchi itself
-kimchi update --extensions     # update installed packages only
-kimchi update context-mode     # update one package by source or display name
-kimchi update self             # update Kimchi itself only
+kimchi update                       # update installed packages, then Kimchi itself
+kimchi update --extensions          # update installed packages only
+kimchi update context-mode          # update one package by source or display name
+kimchi update self                  # update Kimchi itself only
+kimchi update v1.2.3                # install a specific Kimchi release (downgrades work too)
+kimchi update v1.2.3-rc.1           # install a release candidate
+kimchi update --canary              # install the latest canary build from master
 ```
 
 ### HTTP proxy

--- a/src/commands/update.test.ts
+++ b/src/commands/update.test.ts
@@ -120,6 +120,115 @@ describe("runUpdate flag parsing", () => {
 			"--extension cannot be combined with --self or --extensions",
 		)
 	})
+
+	it("rejects the --version flag with a pointer to the positional form", async () => {
+		const code = await runUpdate(["--version", "v0.0.25"])
+		expect(code).toBe(2)
+		expect(errSpy.mock.calls.map((c) => String(c[0] ?? "")).join("\n")).toContain(
+			"pass the version directly: kimchi update v1.2.3",
+		)
+	})
+
+	it("rejects a version combined with --canary", async () => {
+		const code = await runUpdate(["v0.0.25", "--canary"])
+		expect(code).toBe(2)
+		expect(errSpy.mock.calls.map((c) => String(c[0] ?? "")).join("\n")).toContain(
+			"a version cannot be combined with --canary",
+		)
+	})
+
+	it("rejects a version combined with a package target", async () => {
+		const code = await runUpdate(["v0.0.25", "--extensions"])
+		expect(code).toBe(2)
+		expect(errSpy.mock.calls.map((c) => String(c[0] ?? "")).join("\n")).toContain(
+			"a version can only be used when updating Kimchi itself",
+		)
+	})
+
+	it("rejects a version alongside another positional", async () => {
+		const code = await runUpdate(["v0.0.25", "context-mode"])
+		expect(code).toBe(2)
+		expect(errSpy.mock.calls.map((c) => String(c[0] ?? "")).join("\n")).toContain("unexpected argument: context-mode")
+	})
+
+	it("rejects a version after the self target", async () => {
+		const code = await runUpdate(["self", "v0.0.25"])
+		expect(code).toBe(2)
+		expect(errSpy.mock.calls.map((c) => String(c[0] ?? "")).join("\n")).toContain("unexpected argument: v0.0.25")
+	})
+
+	it("treats a version-like positional as a Kimchi self-update target", async () => {
+		checkForUpdateMock.mockResolvedValue({
+			hasUpdate: true,
+			latestVersion: "v0.0.25",
+			tag: "v0.0.25",
+		})
+		applyUpdateMock.mockResolvedValue(undefined)
+
+		const code = await runUpdate(["v0.0.25", "--force"])
+
+		expect(code).toBe(0)
+		expect(packageUpdateMock).not.toHaveBeenCalled()
+		expect(checkForUpdateMock).toHaveBeenCalledWith(expect.objectContaining({ tag: "v0.0.25" }))
+		expect(applyUpdateMock).toHaveBeenCalledWith({ tag: "v0.0.25" })
+	})
+
+	it("normalizes a bare version to a v-prefixed tag", async () => {
+		checkForUpdateMock.mockResolvedValue({
+			hasUpdate: true,
+			latestVersion: "v0.0.25",
+			tag: "v0.0.25",
+		})
+		applyUpdateMock.mockResolvedValue(undefined)
+
+		const code = await runUpdate(["0.0.25", "--force"])
+
+		expect(code).toBe(0)
+		expect(checkForUpdateMock).toHaveBeenCalledWith(expect.objectContaining({ tag: "v0.0.25" }))
+	})
+
+	it("still treats a non-version positional as a package source", async () => {
+		listConfiguredPackagesMock.mockReturnValue([{ source: "npm:other-package", scope: "user", filtered: false }])
+		const code = await runUpdate(["context-mode"])
+		expect(code).toBe(1)
+		expect(errSpy.mock.calls.map((c) => String(c[0] ?? "")).join("\n")).toContain(
+			"no matching package found for context-mode",
+		)
+		expect(checkForUpdateMock).not.toHaveBeenCalled()
+	})
+
+	it("a version with --dry-run reports the target without installing", async () => {
+		checkForUpdateMock.mockResolvedValue({
+			hasUpdate: true,
+			latestVersion: "v0.0.20",
+			tag: "v0.0.20",
+			releaseUrl: "https://example/release",
+		})
+
+		const code = await runUpdate(["v0.0.20", "--dry-run"])
+
+		expect(code).toBe(0)
+		const out = logSpy.mock.calls.map((c) => String(c[0] ?? "")).join("\n")
+		expect(out).toContain("would install v0.0.20")
+		expect(out).toContain("https://example/release")
+		expect(applyUpdateMock).not.toHaveBeenCalled()
+	})
+
+	it("reports already on the requested version", async () => {
+		checkForUpdateMock.mockResolvedValue({
+			hasUpdate: false,
+			latestVersion: "v0.0.23",
+			tag: "v0.0.23",
+		})
+
+		const code = await runUpdate(["v0.0.23"])
+
+		expect(code).toBe(0)
+		const out = logSpy.mock.calls.map((c) => String(c[0] ?? "")).join("\n")
+		expect(out).toContain("already on v0.0.23")
+		expect(out).not.toContain("already up to date")
+		expect(applyUpdateMock).not.toHaveBeenCalled()
+	})
 })
 
 describe("runUpdate Homebrew branch", () => {
@@ -154,6 +263,20 @@ describe("runUpdate Homebrew branch", () => {
 		expect(out).toContain("brew uninstall kimchi")
 		expect(out).toContain("install.sh")
 		expect(out).toContain("kimchi update --canary")
+		expect(out).not.toContain("brew upgrade kimchi")
+		expect(checkForUpdateMock).not.toHaveBeenCalled()
+		expect(applyUpdateMock).not.toHaveBeenCalled()
+	})
+
+	it("prints version-specific message on Homebrew + version positional and skips download", async () => {
+		isHomebrewInstallMock.mockReturnValue(true)
+		const code = await runUpdate(["v0.0.25"])
+		expect(code).toBe(0)
+		const out = logSpy.mock.calls.map((c) => String(c[0] ?? "")).join("\n")
+		expect(out).toContain("Specific release versions cannot be installed through Homebrew")
+		expect(out).toContain("brew uninstall kimchi")
+		expect(out).toContain("install.sh")
+		expect(out).toContain("kimchi update v0.0.25")
 		expect(out).not.toContain("brew upgrade kimchi")
 		expect(checkForUpdateMock).not.toHaveBeenCalled()
 		expect(applyUpdateMock).not.toHaveBeenCalled()

--- a/src/commands/update.ts
+++ b/src/commands/update.ts
@@ -12,14 +12,16 @@ interface UpdateFlags {
 	force: boolean
 	dryRun: boolean
 	canary: boolean
+	version?: string
 	target: "all" | "self" | "packages"
 	packageSource?: string
 }
 
 const UPDATE_USAGE = [
-	"Usage: kimchi update [source|self|pi] [--self] [--extensions] [--extension <source>] [--canary] [--force] [--dry-run]",
+	"Usage: kimchi update [source|self|pi|version] [--self] [--extensions] [--extension <source>] [--canary] [--force] [--dry-run]",
 	"",
 	"  source        Update one installed Pi package, e.g. context-mode or npm:context-mode",
+	"  version       Install a specific Kimchi release, e.g. v1.2.3 or v1.2.3-rc.1 (downgrades allowed)",
 	"  self, pi      Update Kimchi itself only",
 	"  --self        Update Kimchi itself only",
 	"  --extensions  Update installed Pi packages only",
@@ -43,7 +45,16 @@ const UPDATE_FLAGS = new Set([
 
 const UPDATE_BOOLEAN_FLAGS = ["force", "dry-run", "canary", "self", "extensions"] as const
 
+/** Positionals that look like a release version, e.g. "v1.2.3", "1.2.3", "v1.2.3-rc.1". */
+const VERSION_POSITIONAL_RE = /^v?\d+\.\d+\.\d+(-[0-9A-Za-z.-]+)?$/
+
 function parseFlags(args: string[]): UpdateFlags | string {
+	// Versions are positional (`kimchi update v1.2.3`); catch the flag
+	// spelling people will guess first and point them at the right form.
+	if (args.some((arg) => arg === "--version" || arg.startsWith("--version="))) {
+		return "unknown flag: --version (pass the version directly: kimchi update v1.2.3)"
+	}
+
 	const unsupported = findUnsupportedUpdateFlag(args)
 	if (unsupported) return `unknown flag: ${unsupported}`
 
@@ -78,11 +89,21 @@ function parseFlags(args: string[]): UpdateFlags | string {
 	if (packageSource?.startsWith("-")) return "missing value for --extension"
 
 	if (messages.length > 1) return `unexpected argument: ${messages[1]}`
-	const positional = messages[0]
+	let positional: string | undefined = messages[0]
+	let version: string | undefined
 
 	if (packageSource && positional) return "--extension cannot be combined with a positional source"
 	if (packageSource && (self || extensions)) return "--extension cannot be combined with --self or --extensions"
 	const positionalIsSelf = positional === "self" || positional === "pi"
+
+	// A version-like positional (`kimchi update v1.2.3`) targets Kimchi
+	// itself; anything else stays a package source, so package names keep
+	// working unchanged.
+	if (positional && !positionalIsSelf && VERSION_POSITIONAL_RE.test(positional)) {
+		version = normalizeVersionTag(positional)
+		positional = undefined
+	}
+
 	if (positionalIsSelf) self = true
 	else if (positional) {
 		if (self || extensions) return "positional update targets cannot be combined with --self or --extensions"
@@ -90,13 +111,25 @@ function parseFlags(args: string[]): UpdateFlags | string {
 	}
 
 	const packageTarget = Boolean(packageSource || extensions)
+	if (version && packageTarget) return "a version can only be used when updating Kimchi itself"
 	if ((flags.canary || flags.dryRun) && packageTarget) {
 		return "--canary and --dry-run can only be used when updating Kimchi itself"
 	}
+	if (version && flags.canary) return "a version cannot be combined with --canary"
 
 	const target: UpdateFlags["target"] =
-		flags.canary || flags.dryRun || (self && !extensions) ? "self" : packageTarget && !self ? "packages" : "all"
-	return { ...flags, target, packageSource }
+		flags.canary || flags.dryRun || version || (self && !extensions)
+			? "self"
+			: packageTarget && !self
+				? "packages"
+				: "all"
+	return { ...flags, target, packageSource, version }
+}
+
+/** Release tags always carry a leading "v"; accept "1.2.3" as shorthand for "v1.2.3". */
+function normalizeVersionTag(version: string | undefined): string | undefined {
+	if (!version) return version
+	return /^\d/.test(version) ? `v${version}` : version
 }
 
 function findUnsupportedUpdateFlag(args: string[]): string | undefined {
@@ -199,21 +232,25 @@ function packageSourceAliases(source: string): Set<string> {
 	return aliases
 }
 
-async function updateSelf(flags: Pick<UpdateFlags, "canary" | "dryRun" | "force">): Promise<number> {
+async function updateSelf(flags: Pick<UpdateFlags, "canary" | "dryRun" | "force" | "version">): Promise<number> {
 	// Homebrew manages its own package lifecycle. Self-patching a Homebrew
 	// binary would bypass its shim layer, break the Cellar layout, and risk
 	// losing the installation on the next `brew cleanup`. Direct the user to
 	// the correct upgrade path instead.
 	if (isHomebrewInstall()) {
-		if (flags.canary) {
-			console.log("kimchi is managed by Homebrew. Canary builds are not published to Homebrew.")
+		if (flags.canary || flags.version) {
+			const what = flags.version
+				? "Specific release versions cannot be installed through Homebrew."
+				: "Canary builds are not published to Homebrew."
+			const rerun = flags.version ? `kimchi update ${flags.version}` : "kimchi update --canary"
+			console.log(`kimchi is managed by Homebrew. ${what}`)
 			console.log("")
-			console.log("To use canary, uninstall the Homebrew package and reinstall directly:")
+			console.log("Uninstall the Homebrew package and reinstall directly:")
 			console.log("")
 			console.log("  brew uninstall kimchi")
 			console.log("  curl -fsSL https://github.com/getkimchi/kimchi/releases/latest/download/install.sh | bash")
 			console.log("")
-			console.log("Then re-run: kimchi update --canary")
+			console.log(`Then re-run: ${rerun}`)
 			return 0
 		}
 		console.log("kimchi is managed by Homebrew. Use Homebrew to update:")
@@ -227,18 +264,22 @@ async function updateSelf(flags: Pick<UpdateFlags, "canary" | "dryRun" | "force"
 	const current = getVersion()
 	let check: Awaited<ReturnType<typeof checkForUpdate>>
 	try {
-		check = await checkForUpdate({ currentVersion: current, skipCache: true, canary: flags.canary })
+		check = await checkForUpdate({ currentVersion: current, skipCache: true, canary: flags.canary, tag: flags.version })
 	} catch (err) {
 		console.error(`kimchi update: failed to check for updates: ${(err as Error).message}`)
 		return 1
 	}
 
+	// An explicitly requested version may be a downgrade or a reinstall, so
+	// "update available" phrasing would be misleading — say what will happen.
 	if (!check.hasUpdate) {
-		console.log(`kimchi: already up to date (${current})`)
+		if (flags.version) console.log(`kimchi: already on ${check.latestVersion}`)
+		else console.log(`kimchi: already up to date (${current})`)
 		return 0
 	}
 	if (flags.dryRun) {
-		console.log(`kimchi update available: ${current} → ${check.latestVersion}`)
+		if (flags.version) console.log(`kimchi: would install ${check.latestVersion} (currently ${current})`)
+		else console.log(`kimchi update available: ${current} → ${check.latestVersion}`)
 		if (check.releaseUrl) console.log(`  ${check.releaseUrl}`)
 		return 0
 	}
@@ -248,7 +289,10 @@ async function updateSelf(flags: Pick<UpdateFlags, "canary" | "dryRun" | "force"
 		// on bare Enter. We deliberately don't pull in @clack/prompts here
 		// because the harness's normal flow may be non-interactive (CI
 		// pipelines run `kimchi update --force`).
-		const ok = await confirm(`Kimchi update available: ${current} → ${check.latestVersion}\nUpdate? [Y/n]: `)
+		const prompt = flags.version
+			? `Install ${check.latestVersion} (currently ${current})? [Y/n]: `
+			: `Kimchi update available: ${current} → ${check.latestVersion}\nUpdate? [Y/n]: `
+		const ok = await confirm(prompt)
 		if (!ok) {
 			console.log("Update skipped.")
 			return 0

--- a/src/update/github.test.ts
+++ b/src/update/github.test.ts
@@ -59,6 +59,43 @@ describe("GitHubClient.latestRelease", () => {
 	})
 })
 
+describe("GitHubClient.releaseByTag", () => {
+	it("parses tag_name + html_url out of the API response", async () => {
+		const fetchImpl = vi.fn().mockResolvedValue({
+			ok: true,
+			status: 200,
+			json: async () => ({
+				tag_name: "v0.0.80-rc.1",
+				html_url: "https://github.com/x/y/releases/tag/v0.0.80-rc.1",
+			}),
+		}) as unknown as typeof fetch
+		const client = new GitHubClient({ fetch: fetchImpl })
+		const got = await client.releaseByTag(REPO, "v0.0.80-rc.1")
+		expect(got.tagName).toBe("v0.0.80-rc.1")
+		expect(got.htmlUrl).toBe("https://github.com/x/y/releases/tag/v0.0.80-rc.1")
+		expect(fetchImpl as unknown as ReturnType<typeof vi.fn>).toHaveBeenCalledWith(
+			expect.stringContaining("/releases/tags/v0.0.80-rc.1"),
+			expect.anything(),
+		)
+	})
+
+	it("throws when the tag is not found (404)", async () => {
+		const fetchImpl = vi.fn().mockResolvedValue({ ok: false, status: 404 }) as unknown as typeof fetch
+		const client = new GitHubClient({ fetch: fetchImpl })
+		await expect(client.releaseByTag(REPO, "v0.0.80-rc.1")).rejects.toThrow(/404/)
+	})
+
+	it("throws when the response is missing tag_name", async () => {
+		const fetchImpl = vi.fn().mockResolvedValue({
+			ok: true,
+			status: 200,
+			json: async () => ({ html_url: "..." }),
+		}) as unknown as typeof fetch
+		const client = new GitHubClient({ fetch: fetchImpl })
+		await expect(client.releaseByTag(REPO, "v0.0.80-rc.1")).rejects.toThrow(/tag_name/)
+	})
+})
+
 describe("GitHubClient.canaryRelease", () => {
 	it("parses tag_name + target_commitish + name out of the API response", async () => {
 		const fetchImpl = vi.fn().mockResolvedValue({

--- a/src/update/github.ts
+++ b/src/update/github.ts
@@ -99,6 +99,30 @@ export class GitHubClient {
 		}
 	}
 
+	/** GET /repos/{owner}/{name}/releases/tags/{tag}. Returns tag + URL. */
+	async releaseByTag(repo: Repo, tag: string): Promise<ReleaseInfo> {
+		const url = `${this.apiBase}/repos/${repo.owner}/${repo.name}/releases/tags/${tag}`
+		const res = await fetchWithRetry(
+			url,
+			{ headers: { Accept: "application/vnd.github+json" } },
+			{ fetchImpl: this.fetchImpl, retry: { maxRetries: THIRD_PARTY_MAX_RETRIES } },
+		)
+		if (res.status === 404) {
+			throw new Error(`release ${tag} not found (404)`)
+		}
+		if (!res.ok) {
+			throw new Error(`github API returned ${res.status}`)
+		}
+		const json = (await res.json()) as { tag_name?: unknown; html_url?: unknown }
+		if (typeof json.tag_name !== "string" || json.tag_name.length === 0) {
+			throw new Error("github API response missing tag_name")
+		}
+		return {
+			tagName: json.tag_name,
+			htmlUrl: typeof json.html_url === "string" ? json.html_url : "",
+		}
+	}
+
 	/** GET /repos/{owner}/{name}/releases/tags/canary. */
 	async canaryRelease(repo: Repo): Promise<CanaryReleaseInfo> {
 		const url = `${this.apiBase}/repos/${repo.owner}/${repo.name}/releases/tags/canary`

--- a/src/update/workflow.test.ts
+++ b/src/update/workflow.test.ts
@@ -4,6 +4,7 @@ import { tmpdir } from "node:os"
 import { join } from "node:path"
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
 import type { CanaryReleaseInfo, GitHubClient, ReleaseInfo, Repo } from "./github.js"
+import { saveRepoState } from "./state.js"
 
 const mocks = vi.hoisted(() => ({
 	extractArchive: vi.fn(),
@@ -35,6 +36,7 @@ const REPO: Repo = { owner: "castai", name: "kimchi-dev", binary: "kimchi" }
 function fakeClient(release: ReleaseInfo): GitHubClient {
 	return {
 		latestRelease: async () => release,
+		releaseByTag: async () => release,
 	} as unknown as GitHubClient
 }
 
@@ -91,6 +93,107 @@ describe("checkForUpdate version comparison", () => {
 		const result = await checkForUpdate({ repo: REPO, currentVersion: "0.1.0", skipCache: true, client })
 		expect(result.tag).toBe("v0.2.0")
 		expect(result.latestVersion).toBe("v0.2.0")
+	})
+})
+
+describe("checkForUpdate explicit tag", () => {
+	let tmp: string
+	let prevHome: string | undefined
+	let prevXdg: string | undefined
+
+	beforeEach(() => {
+		tmp = mkdtempSync(join(tmpdir(), "kimchi-workflow-tag-test-"))
+		prevHome = process.env.HOME
+		prevXdg = process.env.XDG_CACHE_HOME
+		process.env.XDG_CACHE_HOME = tmp
+	})
+
+	afterEach(() => {
+		// biome-ignore lint/performance/noDelete: env-var cleanup needs a real delete; assigning undefined would coerce to the literal string "undefined".
+		if (prevHome === undefined) delete process.env.HOME
+		else process.env.HOME = prevHome
+		// biome-ignore lint/performance/noDelete: same as above.
+		if (prevXdg === undefined) delete process.env.XDG_CACHE_HOME
+		else process.env.XDG_CACHE_HOME = prevXdg
+		rmSync(tmp, { recursive: true, force: true })
+	})
+
+	it("returns an update when the requested tag differs from currentVersion", async () => {
+		const release = { tagName: "v0.0.24-rc.1", htmlUrl: "https://example/rc" }
+		const releaseByTag = vi.fn().mockResolvedValue(release)
+		const client = { releaseByTag } as unknown as GitHubClient
+		const result = await checkForUpdate({
+			repo: REPO,
+			currentVersion: "0.0.23",
+			tag: "v0.0.24-rc.1",
+			client,
+		})
+		expect(releaseByTag).toHaveBeenCalledWith(REPO, "v0.0.24-rc.1")
+		expect(result.hasUpdate).toBe(true)
+		expect(result.latestVersion).toBe("v0.0.24-rc.1")
+		expect(result.tag).toBe("v0.0.24-rc.1")
+		expect(result.releaseUrl).toBe("https://example/rc")
+		expect(result.cached).toBe(false)
+	})
+
+	it("returns no update when the requested tag matches currentVersion", async () => {
+		const release = { tagName: "v0.0.24-rc.1", htmlUrl: "https://example/rc" }
+		const releaseByTag = vi.fn().mockResolvedValue(release)
+		const client = { releaseByTag } as unknown as GitHubClient
+		const result = await checkForUpdate({
+			repo: REPO,
+			currentVersion: "v0.0.24-rc.1",
+			tag: "v0.0.24-rc.1",
+			client,
+		})
+		expect(result.hasUpdate).toBe(false)
+		expect(result.latestVersion).toBe("v0.0.24-rc.1")
+	})
+
+	it("returns no update when the tag matches a bare (un-prefixed) currentVersion", async () => {
+		// getVersion() reports "0.0.24" from package.json while the release
+		// tag is "v0.0.24" — that mismatch must not trigger a reinstall.
+		const release = { tagName: "v0.0.24", htmlUrl: "https://example/release" }
+		const releaseByTag = vi.fn().mockResolvedValue(release)
+		const client = { releaseByTag } as unknown as GitHubClient
+		const result = await checkForUpdate({
+			repo: REPO,
+			currentVersion: "0.0.24",
+			tag: "v0.0.24",
+			client,
+		})
+		expect(result.hasUpdate).toBe(false)
+		expect(result.latestVersion).toBe("v0.0.24")
+	})
+
+	it("propagates errors for a missing or unknown tag", async () => {
+		const releaseByTag = vi.fn().mockRejectedValue(new Error("github API returned 404"))
+		const client = { releaseByTag } as unknown as GitHubClient
+		await expect(checkForUpdate({ repo: REPO, currentVersion: "0.0.23", tag: "v0.0.99", client })).rejects.toThrow(
+			"github API returned 404",
+		)
+	})
+
+	it("bypasses the cache when a tag is provided", async () => {
+		// Seed the cache with a version that would otherwise be returned.
+		saveRepoState(REPO.owner, REPO.name, {
+			checked_at: new Date().toISOString(),
+			latest_version: "v9.9.9",
+			release_url: "https://example/cached",
+		})
+		const release = { tagName: "v0.0.24-rc.1", htmlUrl: "https://example/rc" }
+		const releaseByTag = vi.fn().mockResolvedValue(release)
+		const client = { releaseByTag } as unknown as GitHubClient
+		const result = await checkForUpdate({
+			repo: REPO,
+			currentVersion: "0.0.23",
+			tag: "v0.0.24-rc.1",
+			client,
+		})
+		expect(releaseByTag).toHaveBeenCalledTimes(1)
+		expect(result.latestVersion).toBe("v0.0.24-rc.1")
+		expect(result.hasUpdate).toBe(true)
+		expect(result.cached).toBe(false)
 	})
 })
 
@@ -365,7 +468,11 @@ describe("applyUpdate share destination", () => {
 
 	it("uses kimchi.exe from Windows archives", async () => {
 		const origPlatform = process.platform
+		const origArch = process.arch
 		Object.defineProperty(process, "platform", { value: "win32" })
+		// Pin the arch too: the assertion below hard-codes amd64, which
+		// otherwise fails on arm64 development machines.
+		Object.defineProperty(process, "arch", { value: "x64" })
 		try {
 			const winBinPath = join(fakePrefix, "bin", "kimchi.exe")
 			writeFileSync(join(extractRoot, "bin", "kimchi.exe"), "")
@@ -392,6 +499,7 @@ describe("applyUpdate share destination", () => {
 			expect(mocks.atomicInstall).toHaveBeenCalledWith(newBinaryPath, winBinPath)
 		} finally {
 			Object.defineProperty(process, "platform", { value: origPlatform })
+			Object.defineProperty(process, "arch", { value: origArch })
 		}
 	})
 })

--- a/src/update/workflow.ts
+++ b/src/update/workflow.ts
@@ -33,6 +33,8 @@ export interface CheckOptions {
 	client?: GitHubClient
 	/** Resolve the floating `canary` release instead of latest stable. */
 	canary?: boolean
+	/** Resolve an exact release tag (e.g. `v0.0.23-rc.1`) instead of latest or canary. */
+	tag?: string
 }
 
 /** Strip the "Canary " title prefix to recover the embedded version string. */
@@ -81,6 +83,25 @@ export async function checkForUpdate(opts: CheckOptions): Promise<CheckResult> {
 			tag: "",
 			releaseUrl: "",
 			hasUpdate: false,
+			cached: false,
+		}
+	}
+
+	if (opts.tag) {
+		// Explicit tag requests always bypass the cache: the caller wants the
+		// resolved metadata for this specific release, not whatever happened
+		// to be checked most recently.
+		const info = await client.releaseByTag(repo, opts.tag)
+		// Release tags carry a leading "v" while getVersion() reports bare
+		// semver from package.json; normalize both sides so requesting the
+		// already-installed version is a no-op instead of a reinstall.
+		const hasUpdate = info.tagName.replace(/^v/, "") !== opts.currentVersion.replace(/^v/, "")
+		return {
+			currentVersion: opts.currentVersion,
+			latestVersion: info.tagName,
+			tag: info.tagName,
+			releaseUrl: info.htmlUrl,
+			hasUpdate,
 			cached: false,
 		}
 	}


### PR DESCRIPTION
## Linked issue

Closes #797

<!-- Every PR must link to an existing issue. PRs without a linked issue will not be reviewed.
     Use one of: Closes #N / Fixes #N / Resolves #N -->

## What does this PR do?

Allows users to install an exact Kimchi release (or release candidate) by passing a version as a positional argument:

   ```bash
   kimchi update v0.0.80
   kimchi update v0.0.80-rc.1
 ```

 - Adds releaseByTag lookup to GitHubClient.
 - Extends checkForUpdate / update workflow to accept an explicit tag.
 - Updates kimchi update CLI parsing to accept a version positional, reject --version flag spelling, and block
   combining a version with --canary.
 - Preserves Homebrew behavior: explicit version self-updates are blocked with a redirect message.
 - Adds unit tests for CLI parsing, GitHub client, and workflow.
 - Updates README usage.


## Checklist

- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md) and agree to the CLA
- [x] This PR links to an open issue above
- [x] Tests pass locally (`pnpm run test`)
- [x] Lint passes (`pnpm run check`)
- [x] Documentation updated if behavior changed