### PR TITLE
feat(ferment): handle connection errors and improve crash recovery

### DIFF
--- a/src/extensions/ferment/events.test.ts
+++ b/src/extensions/ferment/events.test.ts
@@ -498,6 +498,138 @@ describe("registerFermentEvents", () => {
 	})
 })
 
+describe("turn_end connection error recovery", () => {
+	it('pauses a running ferment and notifies the user when stopReason is "error"', async () => {
+		const storage = new FermentEventStore(mkdtempSync(join(tmpdir(), "ferment-error-turn-end-")))
+		const ferment = storage.create("Connection Error Ferment")
+		// Scope + activate so the ferment is in "running" state with an active phase.
+		storage.mutateWithEvents(ferment.id, (current) => {
+			if (!current) throw new Error("missing ferment")
+			const now = new Date().toISOString()
+			const cmd = {
+				type: "scope" as const,
+				title: "Connection Error Ferment",
+				goal: "Test goal",
+				successCriteria: ["Test criterion"],
+				constraints: [],
+				phases: [{ name: "Build", goal: "Build it", steps: [{ description: "step 1" }] }],
+			}
+			const result = applyCommand(current, cmd, { now })
+			if (!result.ok) throw new Error(`scope failed: ${result.error.message}`)
+			const events = commandToEvents(cmd, current, result.ferment, { now })
+			return { write: true, ferment: result.ferment, events, value: undefined }
+		})
+		storage.mutateWithEvents(ferment.id, (current) => {
+			if (!current) throw new Error("missing ferment")
+			const now = new Date().toISOString()
+			const cmd = { type: "activate_phase" as const, phaseId: "phase-1" }
+			const result = applyCommand(current, cmd, { now })
+			if (!result.ok) throw new Error(`activate failed: ${result.error.message}`)
+			const events = commandToEvents(cmd, current, result.ferment, { now })
+			return { write: true, ferment: result.ferment, events, value: undefined }
+		})
+
+		const runtime: FermentRuntime = {
+			...createDefaultFermentRuntime(),
+			getStorage: () => storage,
+		}
+		const active = storage.get(ferment.id)
+		if (!active) throw new Error("ferment not found after setup")
+		runtime.setActive(active)
+
+		const { handlers, pi } = createPi()
+		;(pi as ExtensionAPI & { events: ExtensionAPI["events"] }).events = {
+			emit: vi.fn(),
+			on: vi.fn(),
+		} as unknown as ExtensionAPI["events"]
+		registerFermentEvents(pi, runtime)
+		const turnEnd = handlers.get("turn_end")
+		if (!turnEnd) throw new Error("turn_end handler was not registered")
+		const notify = vi.fn()
+		const ctx = { ui: { notify } }
+
+		await turnEnd(
+			{
+				message: {
+					role: "assistant",
+					stopReason: "error",
+					errorMessage: "Connection error: socket closed",
+					content: [],
+				},
+			},
+			ctx,
+		)
+
+		const paused = storage.get(ferment.id)
+		expect(paused?.status).toBe("paused")
+		expect(notify).toHaveBeenCalledWith(expect.stringContaining('Interrupted: "Connection Error Ferment" was paused'))
+	})
+
+	it("distinguishes retryable network errors from non-retryable provider errors", async () => {
+		const storage = new FermentEventStore(mkdtempSync(join(tmpdir(), "ferment-retryable-")))
+		const ferment = storage.create("Retryable Error Ferment")
+		storage.mutateWithEvents(ferment.id, (current) => {
+			if (!current) throw new Error("missing ferment")
+			const now = new Date().toISOString()
+			const cmd = {
+				type: "scope" as const,
+				title: "Retryable Error Ferment",
+				goal: "Test goal",
+				successCriteria: ["Test criterion"],
+				constraints: [],
+				phases: [{ name: "Build", goal: "Build it", steps: [{ description: "step 1" }] }],
+			}
+			const result = applyCommand(current, cmd, { now })
+			if (!result.ok) throw new Error(`scope failed: ${result.error.message}`)
+			const events = commandToEvents(cmd, current, result.ferment, { now })
+			return { write: true, ferment: result.ferment, events, value: undefined }
+		})
+		storage.mutateWithEvents(ferment.id, (current) => {
+			if (!current) throw new Error("missing ferment")
+			const now = new Date().toISOString()
+			const cmd = { type: "activate_phase" as const, phaseId: "phase-1" }
+			const result = applyCommand(current, cmd, { now })
+			if (!result.ok) throw new Error(`activate failed: ${result.error.message}`)
+			const events = commandToEvents(cmd, current, result.ferment, { now })
+			return { write: true, ferment: result.ferment, events, value: undefined }
+		})
+
+		const runtime: FermentRuntime = {
+			...createDefaultFermentRuntime(),
+			getStorage: () => storage,
+		}
+		const active = storage.get(ferment.id)
+		if (!active) throw new Error("ferment not found after setup")
+		runtime.setActive(active)
+
+		const { handlers, pi } = createPi()
+		;(pi as ExtensionAPI & { events: ExtensionAPI["events"] }).events = {
+			emit: vi.fn(),
+			on: vi.fn(),
+		} as unknown as ExtensionAPI["events"]
+		registerFermentEvents(pi, runtime)
+		const turnEnd = handlers.get("turn_end")
+		if (!turnEnd) throw new Error("turn_end handler was not registered")
+		const notify = vi.fn()
+		const ctx = { ui: { notify } }
+
+		// Cloudflare 524 is a retryable network error.
+		await turnEnd(
+			{
+				message: {
+					role: "assistant",
+					stopReason: "error",
+					errorMessage: "Cloudflare 524 timeout",
+					content: [],
+				},
+			},
+			ctx,
+		)
+
+		expect(notify).toHaveBeenCalledWith(expect.stringContaining("network or gateway error (retried but not recovered)"))
+	})
+})
+
 describe("recoverStuckFerments lockfile awareness", () => {
 	let lockDir: string
 	let storageDir: string
@@ -612,5 +744,30 @@ describe("recoverStuckFerments lockfile awareness", () => {
 		await sessionStart({}, { hasUI: false })
 
 		expect(storage.get(id)?.status).toBe("paused")
+	})
+
+	it("surfaces recovered ferment names to the user via notification", async () => {
+		const { storage, id } = createStorageWithRunningFerment()
+		const runtime: FermentRuntime = {
+			...createDefaultFermentRuntime(),
+			getStorage: () => storage,
+			setActive: vi.fn(),
+		}
+		const { handlers, pi } = createPi()
+		;(pi as ExtensionAPI & { events: ExtensionAPI["events"] }).events = {
+			emit: vi.fn(),
+			on: vi.fn(),
+		} as unknown as ExtensionAPI["events"]
+		registerFermentEvents(pi, runtime)
+
+		const sessionStart = handlers.get("session_start")
+		if (!sessionStart) throw new Error("session_start handler was not registered")
+		const notify = vi.fn()
+		await sessionStart({}, { hasUI: true, ui: { notify } })
+
+		expect(storage.get(id)?.status).toBe("paused")
+		expect(notify).toHaveBeenCalledWith(
+			expect.stringContaining('Recovered 1 ferment interrupted in a previous session: "Test"'),
+		)
 	})
 })

--- a/src/extensions/ferment/events.test.ts
+++ b/src/extensions/ferment/events.test.ts
@@ -626,7 +626,7 @@ describe("turn_end connection error recovery", () => {
 			ctx,
 		)
 
-		expect(notify).toHaveBeenCalledWith(expect.stringContaining("network or gateway error"))
+		expect(notify).toHaveBeenCalledWith(expect.stringContaining("Cloudflare 524 timeout"))
 	})
 })
 

--- a/src/extensions/ferment/events.test.ts
+++ b/src/extensions/ferment/events.test.ts
@@ -626,7 +626,7 @@ describe("turn_end connection error recovery", () => {
 			ctx,
 		)
 
-		expect(notify).toHaveBeenCalledWith(expect.stringContaining("network or gateway error (retried but not recovered)"))
+		expect(notify).toHaveBeenCalledWith(expect.stringContaining("network or gateway error"))
 	})
 })
 

--- a/src/extensions/ferment/events.ts
+++ b/src/extensions/ferment/events.ts
@@ -534,7 +534,7 @@ export function registerFermentEvents(
 				const outcome = applyAndPersist(errorFerment.id, { type: "pause" })
 				if (outcome.ok) {
 					setActiveFermentAndApplyProfile(pi, runtime, outcome.ferment)
-					const reason = retryable ? "a network or gateway error (retried but not recovered)" : "a provider error"
+					const reason = retryable ? "a network or gateway error" : "a provider error"
 					ctx.ui.notify?.(
 						`Interrupted: "${outcome.ferment.name}" was paused due to ${reason}. Run /ferment resume to continue.`,
 					)

--- a/src/extensions/ferment/events.ts
+++ b/src/extensions/ferment/events.ts
@@ -69,6 +69,16 @@ function getToolCallNames(content: AssistantContentPart[]): string[] {
 	return content.filter((c) => c.type === "toolCall" && c.name).map((c) => c.name as string)
 }
 
+/** Safely extract a string field from an assistant message of unknown shape.
+ *  The turn_end event's `message` is typed loosely upstream, so casting
+ *  `{ errorMessage?: string }` directly would bypass compile-time safety if
+ *  the upstream shape changes. This narrows at runtime instead. */
+function getMessageStringField(message: unknown, field: string): string | undefined {
+	if (typeof message !== "object" || message === null) return undefined
+	const value = (message as Record<string, unknown>)[field]
+	return typeof value === "string" ? value : undefined
+}
+
 function extractPromptTextAfterLastToolCall(content: AssistantContentPart[]): string {
 	const lastToolCall = content.findLastIndex((c) => c.type === "toolCall")
 	return content
@@ -523,7 +533,7 @@ export function registerFermentEvents(
 		// the ferment stays "running" and the continuation-nudge logic fires on
 		// the next tick, sending the planner straight back into the broken state.
 		if (stopReason === "error") {
-			const errorMessage = (event.message as { errorMessage?: string }).errorMessage
+			const errorMessage = getMessageStringField(event.message, "errorMessage")
 			const errorFerment = runtime.getActive()
 			if (errorFerment && (errorFerment.status === "running" || errorFerment.status === "planned")) {
 				const outcome = applyAndPersist(errorFerment.id, { type: "pause" })

--- a/src/extensions/ferment/events.ts
+++ b/src/extensions/ferment/events.ts
@@ -2,7 +2,6 @@ import type { ExtensionAPI, ExtensionContext } from "@earendil-works/pi-coding-a
 import { clearFermentCache } from "../../ferment/store.js"
 import { deriveDraftFermentTitle } from "../../ferment/title.js"
 import type { Ferment } from "../../ferment/types.js"
-import { isNetworkErrorRetryable } from "../../upstream-retry-patch.js"
 import { isAgentWorker } from "../agent-worker-context.js"
 import { deferExtensionAction } from "../deferred-action.js"
 import { createToolVisibility } from "../prompt-construction/tool-visibility.js"
@@ -525,18 +524,14 @@ export function registerFermentEvents(
 		// the next tick, sending the planner straight back into the broken state.
 		if (stopReason === "error") {
 			const errorMessage = (event.message as { errorMessage?: string }).errorMessage
-			const retryable = isNetworkErrorRetryable({
-				stopReason,
-				errorMessage,
-			})
 			const errorFerment = runtime.getActive()
 			if (errorFerment && (errorFerment.status === "running" || errorFerment.status === "planned")) {
 				const outcome = applyAndPersist(errorFerment.id, { type: "pause" })
 				if (outcome.ok) {
 					setActiveFermentAndApplyProfile(pi, runtime, outcome.ferment)
-					const reason = retryable ? "a network or gateway error" : "a provider error"
+					const detail = errorMessage ? `: ${errorMessage}` : ""
 					ctx.ui.notify?.(
-						`Interrupted: "${outcome.ferment.name}" was paused due to ${reason}. Run /ferment resume to continue.`,
+						`Interrupted: "${outcome.ferment.name}" was paused due to an error${detail}. Run /ferment resume to continue.`,
 					)
 				} else {
 					ctx.ui.notify?.(

--- a/src/extensions/ferment/events.ts
+++ b/src/extensions/ferment/events.ts
@@ -2,6 +2,7 @@ import type { ExtensionAPI, ExtensionContext } from "@earendil-works/pi-coding-a
 import { clearFermentCache } from "../../ferment/store.js"
 import { deriveDraftFermentTitle } from "../../ferment/title.js"
 import type { Ferment } from "../../ferment/types.js"
+import { isNetworkErrorRetryable } from "../../upstream-retry-patch.js"
 import { isAgentWorker } from "../agent-worker-context.js"
 import { deferExtensionAction } from "../deferred-action.js"
 import { createToolVisibility } from "../prompt-construction/tool-visibility.js"
@@ -273,11 +274,12 @@ export function registerFermentEvents(
 		description: "When the ferment cwd is not a git repo, run `git init` instead of skipping.",
 	})
 
-	function recoverStuckFerments(): void {
+	function recoverStuckFerments(): string[] {
 		// On a fresh start with no active ferment marker, any ferment in
 		// "running" or "planned" must be stale — the previous process died
 		// without graceful shutdown. Pause them so their orphaned steps are
 		// reset to "pending" by handlePause and the engineer can restart them.
+		const recoveredNames: string[] = []
 		const applyAndPersist = createApplyAndPersist(runtime)
 		for (const f of runtime.getStorage().list()) {
 			if (f.status === "running" || f.status === "planned") {
@@ -290,6 +292,7 @@ export function registerFermentEvents(
 						// eslint-disable-next-line no-console
 						console.error("RECOVER FAILED for", f.id, outcome.error)
 					} else {
+						recoveredNames.push(outcome.ferment.name)
 						// Emit stalled telemetry for crash-recovered ferments.
 						// Load the full Ferment to access phases and lastActiveAt.
 						const full = runtime.getStorage().get(f.id)
@@ -303,6 +306,7 @@ export function registerFermentEvents(
 				}
 			}
 		}
+		return recoveredNames
 	}
 
 	pi.on("session_start", async (_event, ctx) => {
@@ -320,7 +324,13 @@ export function registerFermentEvents(
 		const envId = getActiveFermentId()
 		if (!envId) {
 			try {
-				recoverStuckFerments()
+				const recovered = recoverStuckFerments()
+				if (recovered.length > 0 && ctx?.hasUI) {
+					const names = recovered.map((n) => `"${n}"`).join(", ")
+					ctx.ui?.notify?.(
+						`Recovered ${recovered.length === 1 ? "1 ferment" : `${recovered.length} ferments`} interrupted in a previous session: ${names}. Run /ferment resume to continue.`,
+					)
+				}
 			} catch {
 				// Best-effort recovery. If storage is unavailable during startup,
 				// we can't pause anything — the next clean start will retry.
@@ -495,6 +505,42 @@ export function registerFermentEvents(
 				} else {
 					ctx.ui.notify?.(
 						`Failed to pause "${abortedFerment.name}": ${outcome.error.message}. Run /ferment pause manually if needed.`,
+					)
+				}
+			}
+			if (activeId) {
+				resetReactiveContinuationNudgeCount(activeId)
+				resetFermentStopNudgeCount(activeId)
+				resetScopingStopNudgeCount(activeId)
+				resetScopingExploreTurns(activeId)
+			}
+			return
+		}
+
+		// Connection / provider / gateway failure: the model's turn ended with
+		// stopReason "error" after retries were exhausted (or the error was
+		// non-retryable). Pause the ferment so its state stays valid, reset all
+		// nudge counters, and surface a clear message to the user. Without this,
+		// the ferment stays "running" and the continuation-nudge logic fires on
+		// the next tick, sending the planner straight back into the broken state.
+		if (stopReason === "error") {
+			const errorMessage = (event.message as { errorMessage?: string }).errorMessage
+			const retryable = isNetworkErrorRetryable({
+				stopReason,
+				errorMessage,
+			})
+			const errorFerment = runtime.getActive()
+			if (errorFerment && (errorFerment.status === "running" || errorFerment.status === "planned")) {
+				const outcome = applyAndPersist(errorFerment.id, { type: "pause" })
+				if (outcome.ok) {
+					setActiveFermentAndApplyProfile(pi, runtime, outcome.ferment)
+					const reason = retryable ? "a network or gateway error (retried but not recovered)" : "a provider error"
+					ctx.ui.notify?.(
+						`Interrupted: "${outcome.ferment.name}" was paused due to ${reason}. Run /ferment resume to continue.`,
+					)
+				} else {
+					ctx.ui.notify?.(
+						`Connection error during "${errorFerment.name}" but pause failed: ${outcome.error.message}. Run /ferment pause manually.`,
 					)
 				}
 			}

--- a/src/ferment/state-machine.test.ts
+++ b/src/ferment/state-machine.test.ts
@@ -1055,6 +1055,69 @@ describe("applyCommand: resume", () => {
 		const error = expectError(applyCommand(makeFerment({ status: "complete" }), { type: "resume" }, ctx))
 		expect(error.code).toBe("FERMENT_NOT_IN_STATUS")
 	})
+
+	it("resets orphaned running steps back to pending on resume", () => {
+		// Defensive sweep: if pause was bypassed or failed (storage write failure
+		// during shutdown, data corruption), an orphaned "running" step would
+		// cause determineNextAction to suggest complete_step for a dead subagent.
+		// handleResume must reset running → pending even if pause didn't.
+		const result = expectOk(
+			applyCommand(
+				makeFerment({
+					status: "paused",
+					activePhaseId: "phase-1",
+					phases: [
+						makePhase({
+							id: "phase-1",
+							status: "active",
+							steps: [
+								makeStep({ id: "step-1", status: "running", startedAt: "2026-05-08T14:00:00.000Z" }),
+								makeStep({ id: "step-2", index: 2, description: "done one", status: "done" }),
+							],
+						}),
+					],
+				}),
+				{ type: "resume" },
+				ctx,
+			),
+		)
+		expect(result.status).toBe("running")
+		const steps = result.phases[0].steps
+		// The orphaned running step is reset to pending. Note: like handlePause,
+		// handleResume only flips status — it does not clear startedAt. The
+		// engine's determineNextAction keys off status, not startedAt, so the
+		// step will be correctly re-started rather than completed.
+		expect(steps[0].status).toBe("pending")
+		// Already-terminal steps are untouched.
+		expect(steps[1].status).toBe("done")
+	})
+
+	it("is a no-op when pause already reset all running steps", () => {
+		const result = expectOk(
+			applyCommand(
+				makeFerment({
+					status: "paused",
+					activePhaseId: "phase-1",
+					phases: [
+						makePhase({
+							id: "phase-1",
+							status: "active",
+							steps: [
+								makeStep({ id: "step-1", status: "pending" }),
+								makeStep({ id: "step-2", index: 2, description: "also pending", status: "pending" }),
+							],
+						}),
+					],
+				}),
+				{ type: "resume" },
+				ctx,
+			),
+		)
+		expect(result.status).toBe("running")
+		const steps = result.phases[0].steps
+		expect(steps[0].status).toBe("pending")
+		expect(steps[1].status).toBe("pending")
+	})
 })
 
 // ─── abandon ──────────────────────────────────────────────────────────────────

--- a/src/ferment/state-machine.test.ts
+++ b/src/ferment/state-machine.test.ts
@@ -1092,7 +1092,7 @@ describe("applyCommand: resume", () => {
 		expect(steps[1].status).toBe("done")
 	})
 
-	it("is a no-op when pause already reset all running steps", () => {
+	it("is a true no-op on step state when pause already reset all running steps", () => {
 		const result = expectOk(
 			applyCommand(
 				makeFerment({

--- a/src/ferment/state-machine.ts
+++ b/src/ferment/state-machine.ts
@@ -875,10 +875,23 @@ function handleResume(
 	const guard = requireFermentStatus(ferment, ["paused"])
 	if (guard) return fail(guard)
 	const activePhase = ferment.phases.find((p) => p.status === "active")
+
+	// Defensive sweep: reset any steps still marked "running" back to "pending".
+	// `handlePause` already does this, so normally it's a no-op. But if pause was
+	// bypassed or failed (storage write failure during shutdown, data corruption),
+	// an orphaned "running" step would cause `determineNextAction` to suggest
+	// `complete_step` for a step whose subagent is long dead. Idempotent with a
+	// clean pause — only touches steps that survived as "running".
+	const phases = ferment.phases.map((p) => ({
+		...p,
+		steps: p.steps.map((s) => (s.status === "running" ? { ...s, status: "pending" as const } : s)),
+	}))
+
 	return ok(
 		touch(ferment, ctx, {
 			status: activePhase ? "running" : "planned",
 			activePhaseId: activePhase?.id,
+			phases,
 		}),
 	)
 }

--- a/src/ferment/state-machine.ts
+++ b/src/ferment/state-machine.ts
@@ -877,15 +877,20 @@ function handleResume(
 	const activePhase = ferment.phases.find((p) => p.status === "active")
 
 	// Defensive sweep: reset any steps still marked "running" back to "pending".
-	// `handlePause` already does this, so normally it's a no-op. But if pause was
-	// bypassed or failed (storage write failure during shutdown, data corruption),
-	// an orphaned "running" step would cause `determineNextAction` to suggest
-	// `complete_step` for a step whose subagent is long dead. Idempotent with a
-	// clean pause — only touches steps that survived as "running".
-	const phases = ferment.phases.map((p) => ({
-		...p,
-		steps: p.steps.map((s) => (s.status === "running" ? { ...s, status: "pending" as const } : s)),
-	}))
+	// `handlePause` already does this, so normally there's nothing to reset. But
+	// if pause was bypassed or failed (storage write failure during shutdown,
+	// data corruption), an orphaned "running" step would cause
+	// `determineNextAction` to suggest `complete_step` for a step whose
+	// subagent is long dead. Only build a new phases array when at least one
+	// step actually needs resetting — otherwise the ferment passes through
+	// untouched so persistence/events treat it as a true no-op on step state.
+	const hasOrphanedRunning = ferment.phases.some((p) => p.steps.some((s) => s.status === "running"))
+	const phases = hasOrphanedRunning
+		? ferment.phases.map((p) => ({
+				...p,
+				steps: p.steps.map((s) => (s.status === "running" ? { ...s, status: "pending" as const } : s)),
+			}))
+		: ferment.phases
 
 	return ok(
 		touch(ferment, ctx, {


### PR DESCRIPTION
Three changes that close gaps where socket/provider/gateway failures during a ferment run could leave unclear state or send the planner back into a broken turn:
                                                                                                                                                                     
   ## Added in this PR                                                                                                                                                                               
                                                                                                                                                                                                     
   - **Provider stream disconnect or socket closes during a planner turn** — `turn_end` with `stopReason: "error"` (which fires after retries are exhausted or the error is non-retryable) now       
 pauses the ferment, resets all nudge counters, and returns early so no continuation nudge fires into the broken state. Previously this fell through to the continuation-nudge logic, sending the    
 planner back into the same failed turn.                                                                                                                                                             
   - **Non-retryable socket/provider errors pause or surface recovery instead of leaving the planner stuck** — The error handler surfaces the actual error message from the turn event in the user   
 notification (e.g. `Interrupted: "name" was paused due to an error: Cloudflare 524 timeout. Run /ferment resume to continue.`), giving the user actionable information without exposing internal    
 retry taxonomy.                                                                                                                                                                                     
   - **Connection fails while a step is marked running** — `handlePause` (called by the error handler) resets `running → pending` so the engine won't suggest `complete_step` for a dead subagent.   
 Additionally, `handleResume` now defensively performs the same `running → pending` sweep, covering the case where pause was bypassed (storage write failure during shutdown, data corruption).      
   - **Connection fails during automated continuation or wake-up nudges** — A nudge triggers an agent turn; if that turn errors, `turn_end` fires with `stopReason: "error"` and is caught by the    
 same error handler — pausing the ferment instead of nudging again.                                                                                                                                  
   - **The user gets a clear message that the Ferment was interrupted and can be resumed** — Two notification paths: (1) real-time error notification during the session that includes the actual    
 error message, (2) startup recovery notification when `recoverStuckFerments` pauses stale ferments: `"Recovered N ferment(s) interrupted in a previous session: "name". Run /ferment resume to      
 continue."` Previously recovery was silent.                                                                                                                                                         
   - **Automatic recovery does not silently start work in the wrong state** — `recoverStuckFerments` now returns recovered ferment names; `session_start` emits a notification listing them. On      
 resume, `handleResume` resets orphaned running steps. Paused ferments reject all commands except `resume` and `abandon`.                                                                            
                                                                                                                                                                        
   ## Ferment scenarios already covered                                                                                                                                                                                                                                                                                                                                                                       
   - **Persisted Ferment state remains valid after interruption** — `FermentStorage.write()` uses atomic tmp+rename writes, so the on-disk state is always valid even if the process dies mid-write. 
 Covers the scenario where connection fails after a state transition has already been persisted.                                                                                                     
   - **Retryable socket/provider errors are retried where safe** — The SDK retries 429/500/502/503/504 natively; `upstream-retry-patch.ts` extends `_isRetryableError` to also retry Cloudflare 524, 
 ECONNRESET, EPIPE, `ERR_SOCKET_CLOSED`, and `ERR_STREAM_PREMATURE_CLOSE`. Covers the gateway/provider timeout scenario (Cloudflare 524).                                                            
   - **Restarting Kimchi detects stale planned/running Ferments** — `recoverStuckFerments()` runs on `session_start` when no active ferment env-var is set, pausing any ferment in "running" or      
 "planned" status that isn't locked by a live process.                                                                                                                                               
   - **Graceful shutdown pauses running ferments** — `session_shutdown` pauses the active ferment if it's running/planned and removes its lockfile.                                                  
   - **Cross-session collision prevention** — PID-based lockfiles with a 7-day staleness guard prevent `recoverStuckFerments` from pausing a ferment actively owned by another live session.         
   - **User abort (Esc/Ctrl+C) pauses and notifies** — `turn_end` with `stopReason: "aborted"` pauses the ferment and shows `"Paused "name". Run /ferment resume to continue."`                      
   - **Stale context errors are swallowed** — `safe-send.ts` catches `isStaleCtxError` in deferred callbacks (setTimeout, wake-up nudges) so a replaced session doesn't crash the process.           
   - **Resuming does not duplicate completed steps** — `determineNextAction` only suggests `start_step` for `pending` steps, never for `done`/`verified`/`failed`. The                               
 `COMMANDS_ALLOWED_WHILE_PAUSED` set blocks all state mutations while paused except `resume` and `abandon`.                                                                                          
                                
## Linked issue

Closes #

<!-- Every PR must link to an existing issue. PRs without a linked issue will not be reviewed.
     Use one of: Closes #N / Fixes #N / Resolves #N -->

## What does this PR do?

<!-- Brief description of the change and why it's needed. -->

## Checklist

- [ ] I have read [CONTRIBUTING.md](../CONTRIBUTING.md) and agree to the CLA
- [ ] This PR links to an open issue above
- [ ] Tests pass locally (`pnpm run test`)
- [ ] Lint passes (`pnpm run check`)
- [ ] Documentation updated if behavior changed
