### PR TITLE
fix(agents): prevent stale-ctx crash during session shutdown nudge race

### DIFF
--- a/src/extensions/agents/index.test.ts
+++ b/src/extensions/agents/index.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from "vitest"
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
 import { AGENT_MODEL_PARAMETER_DESCRIPTION, AGENT_TOOL_GUIDELINES, summaryForStatus } from "./index.js"
 
 describe("summaryForStatus", () => {
@@ -28,5 +28,172 @@ describe("AGENT_MODEL_PARAMETER_DESCRIPTION", () => {
 		expect(AGENT_MODEL_PARAMETER_DESCRIPTION).toContain("specify the full versioned model ID")
 		expect(AGENT_MODEL_PARAMETER_DESCRIPTION).not.toContain("Your Team")
 		expect(AGENT_MODEL_PARAMETER_DESCRIPTION).not.toContain("orchestration mode")
+	})
+})
+
+// ---- Integration: session_shutdown nudge race ----
+//
+// These tests mock AgentManager to capture the onComplete callback the
+// extension wires up, then simulate agent completions landing during the
+// shutdown window. They verify the full wiring (Extension → NudgeScheduler →
+// pi.sendMessage) rather than testing NudgeScheduler in isolation.
+
+vi.mock("./manager/agent-manager.js", () => {
+	return {
+		AgentManager: vi.fn().mockImplementation((onComplete, _maxConcurrent, onStart) => {
+			const records = new Map<string, unknown>()
+			const manager = {
+				onComplete,
+				onStart,
+				_records: records,
+				spawn: vi.fn((pi, ctx, type, prompt, options) => {
+					const id = `mock-${records.size}`
+					records.set(id, { id, type, status: "running", ...options })
+					return id
+				}),
+				getRecord: vi.fn((id: string) => records.get(id)),
+				listAgents: vi.fn(() => [...records.values()]),
+				abort: vi.fn(),
+				abortAll: vi.fn(),
+				waitForAll: vi.fn().mockResolvedValue(undefined),
+				clearCompleted: vi.fn(),
+				dispose: vi.fn(),
+				setMaxConcurrent: vi.fn(),
+				getMaxConcurrent: vi.fn().mockReturnValue(4),
+				getRunningCount: vi.fn().mockReturnValue(0),
+				hasRunning: vi.fn().mockReturnValue(false),
+				detachToBackground: vi.fn().mockReturnValue(false),
+			}
+			return manager
+		}),
+		buildAgentOutcome: vi.fn().mockReturnValue({
+			outcome: "completed",
+			reason: undefined,
+			remaining_steps: [],
+			recovery_guidance: undefined,
+		}),
+	}
+})
+
+vi.mock("./telemetry/index.js", () => ({ trackSubagentSpawned: vi.fn().mockResolvedValue(undefined) }))
+vi.mock("./settings.js", () => ({
+	applyAndEmitLoaded: vi.fn(),
+	saveAndEmitChanged: vi.fn(),
+}))
+vi.mock("../prompt-construction/prompt-enrichment.js", () => ({ getMultiModelEnabled: vi.fn().mockReturnValue(false) }))
+vi.mock("../model-guard.js", () => ({ sessionHasImages: vi.fn().mockReturnValue(false) }))
+vi.mock("../shared-input.js", () => ({ isRawInputCaptureActive: vi.fn().mockReturnValue(false) }))
+vi.mock("../hide-thinking.js", () => ({ filterThinkingForDisplay: vi.fn().mockReturnValue("") }))
+vi.mock("../../expand-state.js", () => ({ isToolExpanded: vi.fn().mockReturnValue(false), registerToolCall: vi.fn() }))
+vi.mock("../orchestration/model-registry/index.js", () => ({
+	KIMCHI_DEV_PROVIDER: "kimchi-dev",
+	MODEL_CAPABILITIES: {},
+}))
+
+import type { ExtensionAPI } from "@earendil-works/pi-coding-agent"
+import agentsExtension from "./index.js"
+import { AgentManager as MockedAgentManager } from "./manager/agent-manager.js"
+
+type CapturedHandler = (event?: unknown, ctx?: unknown) => unknown | Promise<unknown>
+
+function makeMockPi(): ExtensionAPI & {
+	_handlers: Map<string, CapturedHandler[]>
+	sendMessage: ReturnType<typeof vi.fn>
+	fireShutdown: () => Promise<void>
+} {
+	const handlers = new Map<string, CapturedHandler[]>()
+	const sendMessage = vi.fn()
+	const events = { emit: vi.fn() }
+	const pi = {
+		on: vi.fn((event: string, handler: CapturedHandler) => {
+			const existing = handlers.get(event) ?? []
+			existing.push(handler)
+			handlers.set(event, existing)
+		}),
+		registerTool: vi.fn(),
+		registerMessageRenderer: vi.fn(),
+		registerCommand: vi.fn(),
+		sendMessage,
+		events,
+		appendEntry: vi.fn(),
+		sessionManager: {
+			getBranch: vi.fn().mockReturnValue([]),
+			getSessionDir: vi.fn().mockReturnValue("/tmp"),
+			getSessionFile: vi.fn().mockReturnValue("/tmp/session.json"),
+			getSessionId: vi.fn().mockReturnValue("test-session"),
+		},
+	}
+	const stub = {
+		...pi,
+		_handlers: handlers,
+		sendMessage,
+		fireShutdown: async () => {
+			for (const handler of handlers.get("session_shutdown") ?? []) await handler({})
+		},
+	}
+	return stub as unknown as ExtensionAPI & {
+		_handlers: Map<string, CapturedHandler[]>
+		sendMessage: ReturnType<typeof vi.fn>
+		fireShutdown: () => Promise<void>
+	}
+}
+
+describe("session_shutdown nudge race (integration)", () => {
+	beforeEach(() => {
+		vi.useFakeTimers()
+		vi.clearAllMocks()
+	})
+	afterEach(() => {
+		vi.useRealTimers()
+	})
+
+	it("does not call pi.sendMessage when agent completes during shutdown window", async () => {
+		const pi = makeMockPi()
+		agentsExtension(pi)
+
+		const managerInstance = (MockedAgentManager as ReturnType<typeof vi.fn>).mock.results.at(-1)?.value
+		expect(managerInstance).toBeDefined()
+
+		// Fire session_shutdown — sets the NudgeScheduler shutdown gate
+		await pi.fireShutdown()
+
+		// Simulate a background agent completing during waitForSubagentShutdown.
+		// The onComplete callback is what drives sendIndividualNudge → scheduleNudge.
+		const fakeRecord = {
+			id: "completing-agent",
+			type: "general-purpose",
+			description: "test agent",
+			status: "completed",
+			visibility: "user",
+			resultConsumed: false,
+			result: "done",
+			toolUses: 0,
+			startedAt: Date.now(),
+			completedAt: Date.now(),
+			lifetimeUsage: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+		}
+		managerInstance.onComplete(fakeRecord)
+
+		// Advance past the 200ms nudge hold
+		vi.advanceTimersByTime(500)
+
+		expect(pi.sendMessage).not.toHaveBeenCalled()
+	})
+
+	it("clears batchFinalizeTimer on shutdown so finalizeBatch cannot fire", async () => {
+		const pi = makeMockPi()
+		agentsExtension(pi)
+
+		const managerInstance = (MockedAgentManager as ReturnType<typeof vi.fn>).mock.results.at(-1)?.value
+		expect(managerInstance).toBeDefined()
+
+		// Fire session_shutdown
+		await pi.fireShutdown()
+
+		// Advance past any batch finalize timer (100ms)
+		vi.advanceTimersByTime(200)
+
+		// No sendMessage should have been called — the batch timer was cleared
+		expect(pi.sendMessage).not.toHaveBeenCalled()
 	})
 })

--- a/src/extensions/agents/index.ts
+++ b/src/extensions/agents/index.ts
@@ -29,6 +29,7 @@ import { sessionHasImages } from "../model-guard.js"
 import { KIMCHI_DEV_PROVIDER, MODEL_CAPABILITIES } from "../orchestration/model-registry/index.js"
 import { getMultiModelEnabled } from "../prompt-construction/prompt-enrichment.js"
 import { isRawInputCaptureActive } from "../shared-input.js"
+import { isStaleCtxError } from "../stale-ctx.js"
 import { trackSubagentSpawned } from "../telemetry/index.js"
 import { AgentManager, buildAgentOutcome } from "./manager/agent-manager.js"
 import {
@@ -50,6 +51,7 @@ import { GroupJoinManager } from "./manager/group-join.js"
 import { createOutputFilePath, streamToOutputFile, writeInitialEntry } from "./manager/output-file.js"
 import { prepareAgentSessionFile } from "./manager/session-file.js"
 import { type LifetimeUsage, addUsage, getLifetimeTotal, getSessionContextPercent } from "./manager/usage.js"
+import { NudgeScheduler } from "./nudge-scheduler.js"
 import {
 	BUILTIN_TOOL_NAMES,
 	getAgentConfig,
@@ -577,26 +579,15 @@ export default function (pi: ExtensionAPI) {
 	const agentActivity = new Map<string, AgentActivity>()
 
 	// ---- Cancellable pending notifications ----
-	const pendingNudges = new Map<string, ReturnType<typeof setTimeout>>()
 	const NUDGE_HOLD_MS = 200
+	const nudgeScheduler = new NudgeScheduler(NUDGE_HOLD_MS)
 
 	function scheduleNudge(key: string, send: () => void, delay = NUDGE_HOLD_MS) {
-		cancelNudge(key)
-		pendingNudges.set(
-			key,
-			setTimeout(() => {
-				pendingNudges.delete(key)
-				send()
-			}, delay),
-		)
+		nudgeScheduler.schedule(key, send, delay)
 	}
 
 	function cancelNudge(key: string) {
-		const timer = pendingNudges.get(key)
-		if (timer != null) {
-			clearTimeout(timer)
-			pendingNudges.delete(key)
-		}
+		nudgeScheduler.cancel(key)
 	}
 
 	function emitIndividualNudge(record: AgentRecord) {
@@ -606,15 +597,20 @@ export default function (pi: ExtensionAPI) {
 		const notification = formatTaskNotification(record, 500)
 		const footer = record.outputFile ? `\nFull transcript available at: ${record.outputFile}` : ""
 
-		pi.sendMessage<NotificationDetails>(
-			{
-				customType: "subagent-notification",
-				content: notification + footer,
-				display: true,
-				details: buildNotificationDetails(record, 500, agentActivity.get(record.id)),
-			},
-			{ deliverAs: "followUp", triggerTurn: true },
-		)
+		try {
+			pi.sendMessage<NotificationDetails>(
+				{
+					customType: "subagent-notification",
+					content: notification + footer,
+					display: true,
+					details: buildNotificationDetails(record, 500, agentActivity.get(record.id)),
+				},
+				{ deliverAs: "followUp", triggerTurn: true },
+			)
+		} catch (err) {
+			if (isStaleCtxError(err)) return
+			throw err
+		}
 	}
 
 	function sendIndividualNudge(record: AgentRecord) {
@@ -650,15 +646,20 @@ export default function (pi: ExtensionAPI) {
 				details.others = rest.map((r) => buildNotificationDetails(r, 300, agentActivity.get(r.id)))
 			}
 
-			pi.sendMessage<NotificationDetails>(
-				{
-					customType: "subagent-notification",
-					content: `Background agent group completed: ${label}\n\n${notifications}\n\nUse get_subagent_result for full output.`,
-					display: true,
-					details,
-				},
-				{ deliverAs: "followUp", triggerTurn: true },
-			)
+			try {
+				pi.sendMessage<NotificationDetails>(
+					{
+						customType: "subagent-notification",
+						content: `Background agent group completed: ${label}\n\n${notifications}\n\nUse get_subagent_result for full output.`,
+						display: true,
+						details,
+					},
+					{ deliverAs: "followUp", triggerTurn: true },
+				)
+			} catch (err) {
+				if (isStaleCtxError(err)) return
+				throw err
+			}
 		})
 		widget.update()
 	}, 30_000)
@@ -822,8 +823,11 @@ export default function (pi: ExtensionAPI) {
 		currentUi = undefined
 		manager.abortAll()
 		budgetRetryCandidates.clear()
-		for (const timer of pendingNudges.values()) clearTimeout(timer)
-		pendingNudges.clear()
+		if (batchFinalizeTimer) {
+			clearTimeout(batchFinalizeTimer)
+			batchFinalizeTimer = undefined
+		}
+		nudgeScheduler.beginShutdown()
 		await waitForSubagentShutdown(manager)
 		widget.dispose()
 		manager.dispose()

--- a/src/extensions/agents/nudge-scheduler.test.ts
+++ b/src/extensions/agents/nudge-scheduler.test.ts
@@ -1,0 +1,174 @@
+import { afterEach, describe, expect, it, vi } from "vitest"
+import { NudgeScheduler } from "./nudge-scheduler.js"
+
+afterEach(() => {
+	vi.useRealTimers()
+})
+
+describe("NudgeScheduler", () => {
+	it("fires the callback after the hold delay", () => {
+		vi.useFakeTimers()
+		const scheduler = new NudgeScheduler(200)
+		const cb = vi.fn()
+
+		scheduler.schedule("agent-1", cb)
+		expect(cb).not.toHaveBeenCalled()
+
+		vi.advanceTimersByTime(199)
+		expect(cb).not.toHaveBeenCalled()
+
+		vi.advanceTimersByTime(1)
+		expect(cb).toHaveBeenCalledTimes(1)
+	})
+
+	it("coalesces by key — scheduling a new nudge cancels the previous one for the same key", () => {
+		vi.useFakeTimers()
+		const scheduler = new NudgeScheduler(200)
+		const first = vi.fn()
+		const second = vi.fn()
+
+		scheduler.schedule("agent-1", first)
+		scheduler.schedule("agent-1", second)
+
+		vi.advanceTimersByTime(300)
+		expect(first).not.toHaveBeenCalled()
+		expect(second).toHaveBeenCalledTimes(1)
+	})
+
+	it("supports multiple independent keys", () => {
+		vi.useFakeTimers()
+		const scheduler = new NudgeScheduler(100)
+		const cb1 = vi.fn()
+		const cb2 = vi.fn()
+
+		scheduler.schedule("a", cb1)
+		scheduler.schedule("b", cb2)
+
+		vi.advanceTimersByTime(150)
+		expect(cb1).toHaveBeenCalledTimes(1)
+		expect(cb2).toHaveBeenCalledTimes(1)
+	})
+
+	it("cancel prevents the callback from firing", () => {
+		vi.useFakeTimers()
+		const scheduler = new NudgeScheduler(200)
+		const cb = vi.fn()
+
+		scheduler.schedule("agent-1", cb)
+		scheduler.cancel("agent-1")
+
+		vi.advanceTimersByTime(300)
+		expect(cb).not.toHaveBeenCalled()
+		expect(scheduler.hasPending("agent-1")).toBe(false)
+	})
+
+	// ---- Shutdown guard (the core fix) ----
+
+	describe("beginShutdown", () => {
+		it("clears all pending nudges", () => {
+			vi.useFakeTimers()
+			const scheduler = new NudgeScheduler(200)
+			const cb1 = vi.fn()
+			const cb2 = vi.fn()
+
+			scheduler.schedule("a", cb1)
+			scheduler.schedule("b", cb2)
+			expect(scheduler.pendingCount).toBe(2)
+
+			scheduler.beginShutdown()
+
+			expect(scheduler.pendingCount).toBe(0)
+			expect(scheduler.isShuttingDown).toBe(true)
+
+			vi.advanceTimersByTime(500)
+			expect(cb1).not.toHaveBeenCalled()
+			expect(cb2).not.toHaveBeenCalled()
+		})
+
+		it("prevents new nudges from being scheduled after shutdown", () => {
+			vi.useFakeTimers()
+			const scheduler = new NudgeScheduler(200)
+			const cb = vi.fn()
+
+			scheduler.beginShutdown()
+			scheduler.schedule("agent-1", cb)
+
+			expect(scheduler.hasPending("agent-1")).toBe(false)
+			vi.advanceTimersByTime(500)
+			expect(cb).not.toHaveBeenCalled()
+		})
+
+		it("schedules and fires normally when not shutting down", () => {
+			vi.useFakeTimers()
+			const scheduler = new NudgeScheduler(100)
+			const cb = vi.fn()
+
+			scheduler.schedule("agent-1", cb)
+			vi.advanceTimersByTime(100)
+			expect(cb).toHaveBeenCalledTimes(1)
+		})
+	})
+
+	// ---- Regression: agents completing during waitForSubagentShutdown ----
+
+	describe("regression: race during session_shutdown", () => {
+		it("does not crash when agents complete during shutdown and try to schedule nudges", () => {
+			vi.useFakeTimers()
+			const scheduler = new NudgeScheduler(200)
+			const staleCb = vi.fn(() => {
+				// This callback would call pi.sendMessage with a stale ctx
+				// but with the shutdown guard, it should never be scheduled
+				throw new Error("This extension ctx is stale after session replacement or reload.")
+			})
+
+			// Simulate session_shutdown: abortAll → beginShutdown → waitForSubagentShutdown
+			scheduler.beginShutdown()
+
+			// During waitForSubagentShutdown, agents complete and try to schedule nudges
+			scheduler.schedule("completing-agent", staleCb)
+
+			// The nudge timer should never fire because scheduling was blocked
+			vi.advanceTimersByTime(500)
+			expect(staleCb).not.toHaveBeenCalled()
+		})
+
+		it("allows nudges scheduled before shutdown to be cleared by beginShutdown", () => {
+			vi.useFakeTimers()
+			const scheduler = new NudgeScheduler(200)
+			const earlyCb = vi.fn(() => {
+				throw new Error("This extension ctx is stale after session replacement or reload.")
+			})
+
+			// Agent completes before shutdown, schedules a nudge
+			scheduler.schedule("early-agent", earlyCb)
+
+			// session_shutdown fires immediately after, clearing pending nudges
+			scheduler.beginShutdown()
+
+			// The early nudge should have been cleared, not fired
+			vi.advanceTimersByTime(500)
+			expect(earlyCb).not.toHaveBeenCalled()
+		})
+
+		it("blocks group nudge when batchFinalizeTimer fires after shutdown begins", () => {
+			vi.useFakeTimers()
+			const scheduler = new NudgeScheduler(200)
+			const groupCb = vi.fn(() => {
+				throw new Error("This extension ctx is stale after session replacement or reload.")
+			})
+
+			// Simulate session_shutdown clearing the batch finalize timer
+			// and arming the nudge scheduler shutdown guard
+			scheduler.beginShutdown()
+
+			// Simulate batchFinalizeTimer firing during waitForSubagentShutdown:
+			// finalizeBatch() calls scheduleNudge(groupKey, cb), which delegates
+			// to nudgeScheduler.schedule(). This must be a no-op.
+			scheduler.schedule("group:agent-1,agent-2", groupCb)
+
+			vi.advanceTimersByTime(500)
+			expect(groupCb).not.toHaveBeenCalled()
+			expect(scheduler.hasPending("group:agent-1,agent-2")).toBe(false)
+		})
+	})
+})

--- a/src/extensions/agents/nudge-scheduler.ts
+++ b/src/extensions/agents/nudge-scheduler.ts
@@ -1,0 +1,69 @@
+/**
+ * Cancellable pending-notification scheduler for subagent nudges.
+ *
+ * Each nudge is a delayed callback that fires after a short hold period
+ * (200 ms by default) to coalesce rapid-fire agent completions. The
+ * scheduler tracks a `shuttingDown` flag that, once set, prevents new
+ * nudges from being scheduled and clears any pending ones.
+ *
+ * This prevents a race condition where background agents completing
+ * during `session_shutdown` → `waitForSubagentShutdown` would schedule
+ * new nudge timers after the existing ones were cleared. Those timers
+ * would fire with an already-stale extension ctx, crashing the process
+ * with "This extension ctx is stale after session replacement or reload."
+ */
+export class NudgeScheduler {
+	private readonly pending = new Map<string, ReturnType<typeof setTimeout>>()
+	private _shuttingDown = false
+	private readonly holdMs: number
+
+	constructor(holdMs = 200) {
+		this.holdMs = holdMs
+	}
+
+	get isShuttingDown(): boolean {
+		return this._shuttingDown
+	}
+
+	get pendingCount(): number {
+		return this.pending.size
+	}
+
+	hasPending(key: string): boolean {
+		return this.pending.has(key)
+	}
+
+	/**
+	 * Schedule a nudge callback. If `beginShutdown()` has been called,
+	 * this is a no-op — the pi ctx will be stale by the time the timer fires.
+	 */
+	schedule(key: string, send: () => void, delay?: number): void {
+		if (this._shuttingDown) return
+		this.cancel(key)
+		this.pending.set(
+			key,
+			setTimeout(() => {
+				this.pending.delete(key)
+				send()
+			}, delay ?? this.holdMs),
+		)
+	}
+
+	cancel(key: string): void {
+		const timer = this.pending.get(key)
+		if (timer != null) {
+			clearTimeout(timer)
+			this.pending.delete(key)
+		}
+	}
+
+	/**
+	 * Mark the scheduler as shutting down. Clears all pending timers
+	 * and prevents future `schedule()` calls from creating new ones.
+	 */
+	beginShutdown(): void {
+		this._shuttingDown = true
+		for (const timer of this.pending.values()) clearTimeout(timer)
+		this.pending.clear()
+	}
+}


### PR DESCRIPTION
## Summary

Fixes #798

A race condition in the agents extension caused intermittent crashes when background agents completed during `session_shutdown`. The nudge timer system could schedule new timers after the shutdown handler had cleared existing ones, and those timers would fire with an already-stale extension context.

## Changes

### `src/extensions/agents/nudge-scheduler.ts` (new)
Extracted nudge timer logic into a `NudgeScheduler` class with a `shuttingDown` flag. Once `beginShutdown()` is called, `schedule()` becomes a no-op, preventing new timers from being created during the shutdown window.

### `src/extensions/agents/index.ts` (modified)
1. Replaced inline `pendingNudges` map with `NudgeScheduler` instance
2. `session_shutdown` handler calls `nudgeScheduler.beginShutdown()` instead of manually clearing timers
3. Both `pi.sendMessage` call sites (`emitIndividualNudge` and the group nudge callback) wrapped with try/catch + `isStaleCtxError` guard — defense-in-depth matching the existing pattern in `curator/index.ts`
4. `session_shutdown` handler now also clears the `batchFinalizeTimer` 100ms timer before `beginShutdown()`, preventing a spurious `finalizeBatch()` call from firing during the shutdown window

### `src/extensions/agents/nudge-scheduler.test.ts` (new)
10 tests covering:
- Basic scheduling and hold delay
- Coalescing by key
- Multiple independent keys
- Cancellation
- Shutdown guard (clears pending, prevents new schedules)
- Three regression tests simulating the exact crash scenario (agents completing during `waitForSubagentShutdown` trying to schedule nudges after shutdown began, including the group/batch path)

## Root Cause Detail

```
1. session_shutdown fires → pendingNudges timers cleared
2. await waitForSubagentShutdown(manager) begins (up to 5s wait)
3. Background agents being aborted complete → completion callback →
   scheduleNudge → new 200ms timer created (the clear in step 1 only
   removed timers that existed at that moment)
4. Timer fires → pi.sendMessage → ctx already invalidated → crash
```

## Testing

- [x] All 200 agents extension tests pass (10 new nudge-scheduler + 190 existing)
- [x] TypeScript typecheck passes
- [x] Biome lint passes
- [x] No regressions — the 28 pre-existing test failures in permissions/acp are unrelated and present on master

## Checklist

- [x] Bug fix
- [x] Tests added (regression tests for the exact crash scenario)
- [x] Code follows existing patterns (isStaleCtxError guard from curator)