### PR TITLE
feat: add Dependabot and patch health checks for pi-mono upgrades

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,18 +6,12 @@ updates:
       interval: "weekly"
       day: "monday"
     allow:
-      - dependency-name: "@earendil-works/pi-coding-agent"
-        update-types: ["version-update:semver-minor", "version-update:semver-patch"]
-      - dependency-name: "@earendil-works/pi-tui"
-        update-types: ["version-update:semver-minor", "version-update:semver-patch"]
-      - dependency-name: "@earendil-works/pi-ai"
+      - dependency-name: "@earendil-works/*"
         update-types: ["version-update:semver-minor", "version-update:semver-patch"]
     groups:
       pi-mono:
         patterns:
-          - "@earendil-works/pi-coding-agent"
-          - "@earendil-works/pi-tui"
-          - "@earendil-works/pi-ai"
+          - "@earendil-works/*"
     commit-message:
       prefix: "deps"
     open-pull-requests-limit: 5

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,23 @@
+version: 2
+updates:
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    allow:
+      - dependency-name: "@earendil-works/pi-coding-agent"
+        update-types: ["version-update:semver-minor", "version-update:semver-patch"]
+      - dependency-name: "@earendil-works/pi-tui"
+        update-types: ["version-update:semver-minor", "version-update:semver-patch"]
+      - dependency-name: "@earendil-works/pi-ai"
+        update-types: ["version-update:semver-minor", "version-update:semver-patch"]
+    groups:
+      pi-mono:
+        patterns:
+          - "@earendil-works/pi-coding-agent"
+          - "@earendil-works/pi-tui"
+          - "@earendil-works/pi-ai"
+    commit-message:
+      prefix: "deps"
+    open-pull-requests-limit: 5

--- a/.github/workflows/patch-healthcheck.yml
+++ b/.github/workflows/patch-healthcheck.yml
@@ -1,0 +1,50 @@
+name: Check patches
+
+on:
+  pull_request:
+    paths:
+      - "package.json"
+      - "pnpm-lock.yaml"
+      - "patches/**"
+      - ".github/dependabot.yml"
+      - ".github/workflows/patch-healthcheck.yml"
+      - ".github/workflows/release.yml"
+
+concurrency:
+  group: check-patches-pr-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  check-patches:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: pnpm/action-setup@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+
+      # Needs no dependencies, so it reports a clear message even when a stale
+      # patch would break `pnpm install`. Runs before install for that reason.
+      - name: Check @earendil-works/* patches are in sync
+        run: node scripts/check-patches.js
+
+      - name: Install (verifies patches apply)
+        run: pnpm install --frozen-lockfile --ignore-scripts
+
+      - name: Unit-test the patch check
+        run: pnpm exec vitest run scripts/check-patches.test.ts
+
+  # Dependabot pi-mono bumps must survive a full dry-run release. The
+  # release/homebrew jobs stay tag-gated, so nothing actually publishes.
+  dry-run-release:
+    if: ${{ github.event.pull_request.user.login == 'dependabot[bot]' }}
+    needs: [check-patches]
+    permissions:
+      contents: read
+    uses: ./.github/workflows/release.yml

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,9 +14,10 @@ on:
         description: "Update getkimchi/homebrew-tap after publishing the GitHub release (requires publish_github_release)"
         type: boolean
         default: false
+  workflow_call:
 
 permissions:
-  contents: write
+  contents: read
 
 jobs:
   checks:
@@ -200,6 +201,8 @@ jobs:
     needs: [smoke-test]
     if: ${{ startsWith(github.ref, 'refs/tags/v') && (github.event_name == 'push' || inputs.publish_github_release) }}
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
 
     steps:
       - uses: actions/checkout@v4

--- a/scripts/check-patches.d.ts
+++ b/scripts/check-patches.d.ts
@@ -1,0 +1,18 @@
+/**
+ * Type declarations for scripts/check-patches.js — a standalone Node script
+ * (no build step) whose exported `findPatchHealthcheckErrors` is exercised by
+ * check-patches.test.ts.
+ */
+
+type PackageJson = {
+	dependencies?: Record<string, string>
+	devDependencies?: Record<string, string>
+	pnpm?: { patchedDependencies?: Record<string, string> }
+}
+
+export declare const PI_MONO_PREFIX: "@earendil-works/"
+
+export declare function findPatchHealthcheckErrors(
+	pkg: PackageJson,
+	patchExists: (patchPath: string) => boolean,
+): string[]

--- a/scripts/check-patches.js
+++ b/scripts/check-patches.js
@@ -9,7 +9,7 @@
  */
 import { existsSync, readFileSync } from "node:fs"
 import { dirname, resolve } from "node:path"
-import { fileURLToPath } from "node:url"
+import { fileURLToPath, pathToFileURL } from "node:url"
 
 export const PI_MONO_PREFIX = "@earendil-works/"
 
@@ -87,4 +87,4 @@ function main() {
 	console.error("✅ Patch files are in sync with @earendil-works/* dependencies.")
 }
 
-import.meta.url === `file://${process.argv[1]}` && main()
+process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href && main()

--- a/scripts/check-patches.js
+++ b/scripts/check-patches.js
@@ -1,0 +1,90 @@
+#!/usr/bin/env node
+/**
+ * Verifies pnpm.patchedDependencies stays in sync with the declared
+ * @earendil-works/* versions in package.json.
+ *
+ * Dependabot bumps those versions, but the patchedDependencies keys and the
+ * patch files under patches/ are version-pinned — a bump without a matching
+ * patch update breaks `pnpm install` for everyone. This fails fast instead.
+ */
+import { existsSync, readFileSync } from "node:fs"
+import { dirname, resolve } from "node:path"
+import { fileURLToPath } from "node:url"
+
+export const PI_MONO_PREFIX = "@earendil-works/"
+
+/**
+ * Pure check: given package.json and a patch-file-exists predicate, returns
+ * human-readable error strings. Empty array means in sync.
+ */
+export function findPatchHealthcheckErrors(pkg, patchExists) {
+	const deps = {
+		...(pkg.dependencies || {}),
+		...(pkg.devDependencies || {}),
+	}
+	const patched = pkg.pnpm?.patchedDependencies || {}
+	const errors = []
+
+	// Every pi-mono dependency needs a version-matched patch entry + patch file.
+	for (const [name, version] of Object.entries(deps)) {
+		if (!name.startsWith(PI_MONO_PREFIX)) continue
+		const expectedKey = `${name}@${version}`
+		const patchPath = patched[expectedKey]
+		if (!patchPath) {
+			const staleKey = Object.keys(patched).find((k) => k.startsWith(`${name}@`) && k !== expectedKey)
+			errors.push(
+				staleKey
+					? `Version mismatch for ${name}: package.json says ${version}, but patchedDependencies still has ${staleKey}. Bump the patchedDependencies key and regenerate the patch file.`
+					: `Missing patchedDependencies entry for ${name}@${version}. Add \`${expectedKey}\` to pnpm.patchedDependencies and regenerate the patch.`,
+			)
+			continue
+		}
+		if (!patchExists(patchPath)) {
+			errors.push(
+				`Patch file not found: ${patchPath} (referenced by ${expectedKey}). Run \`pnpm patch ${name}@${version}\` to regenerate.`,
+			)
+		}
+	}
+
+	// Reverse direction: every pi-mono patch entry must match a declared dep.
+	for (const key of Object.keys(patched)) {
+		if (!key.startsWith(PI_MONO_PREFIX)) continue
+		const atIdx = key.lastIndexOf("@")
+		const name = key.slice(0, atIdx)
+		const version = key.slice(atIdx + 1)
+		const declared = deps[name]
+		if (!declared) {
+			errors.push(
+				`patchedDependencies references ${key}, but ${name} is not declared in dependencies/devDependencies. Remove the stale entry.`,
+			)
+		} else if (declared !== version) {
+			errors.push(
+				`Version mismatch for ${name}: package.json declares ${declared}, but patchedDependencies has ${version}.`,
+			)
+		}
+	}
+
+	return errors
+}
+
+function main() {
+	const __dirname = dirname(fileURLToPath(import.meta.url))
+	const root = resolve(__dirname, "..")
+	const pkgPath = resolve(root, "package.json")
+	const pkg = JSON.parse(readFileSync(pkgPath, "utf8"))
+
+	const errors = findPatchHealthcheckErrors(pkg, (patchPath) => existsSync(resolve(root, patchPath)))
+
+	if (errors.length > 0) {
+		console.error("❌ Patch healthcheck failed:\n")
+		for (const e of errors) console.error(`  - ${e}`)
+		console.error(
+			"\nTo fix: bump the patchedDependencies key in package.json to match the new version, then run `pnpm patch <name>@<version>` to regenerate the patch file (see the patches/ README / AGENTS.md for the patch workflow).",
+		)
+		process.exit(1)
+	}
+
+	console.error("✅ Patch files are in sync with @earendil-works/* dependencies.")
+}
+
+import.meta.url === `file://${process.argv[1]}` && main()

--- a/scripts/check-patches.test.ts
+++ b/scripts/check-patches.test.ts
@@ -1,0 +1,76 @@
+import { describe, expect, it } from "vitest"
+import { findPatchHealthcheckErrors } from "./check-patches.js"
+
+// Mirrors the real repo: three pi-mono packages pinned to an exact version
+// with a matching patch file.
+type Pkg = {
+	dependencies: Record<string, string>
+	devDependencies: Record<string, string>
+	pnpm: { patchedDependencies: Record<string, string> }
+}
+
+const IN_SYNC_PKG: Pkg = {
+	dependencies: {
+		"@earendil-works/pi-coding-agent": "0.79.10",
+		"@earendil-works/pi-tui": "0.79.10",
+		undici: "8.2.0", // non-pi-mono dep — must be ignored
+	},
+	devDependencies: {
+		"@earendil-works/pi-ai": "0.79.10",
+		vitest: "3.2.4",
+	},
+	pnpm: {
+		patchedDependencies: {
+			"@earendil-works/pi-coding-agent@0.79.10": "patches/@earendil-works__pi-coding-agent@0.79.10.patch",
+			"@earendil-works/pi-tui@0.79.10": "patches/@earendil-works__pi-tui@0.79.10.patch",
+			"@earendil-works/pi-ai@0.79.10": "patches/@earendil-works__pi-ai@0.79.10.patch",
+			// Non-pi-mono patches (e.g. playwright-core) must be ignored.
+			"playwright-core@1.59.1": "patches/playwright-core@1.59.1.patch",
+		},
+	},
+}
+
+const patchExists = (_patchPath: string) => true
+
+describe("findPatchHealthcheckErrors", () => {
+	it("returns no errors when versions, patchedDependencies, and patch files all align", () => {
+		expect(findPatchHealthcheckErrors(IN_SYNC_PKG, patchExists)).toEqual([])
+	})
+
+	it("flags a dependabot bump that left the patchedDependencies key at the old version", () => {
+		// Dependabot bumped pi-coding-agent to 0.79.11 in dependencies, but
+		// pnpm.patchedDependencies still points at @0.79.10 — the exact
+		// failure mode this check exists to catch.
+		const bumped = structuredClone(IN_SYNC_PKG)
+		bumped.dependencies["@earendil-works/pi-coding-agent"] = "0.79.11"
+
+		const errors = findPatchHealthcheckErrors(bumped, patchExists)
+		expect(errors.length).toBeGreaterThan(0)
+		expect(errors.join("\n")).toContain("Version mismatch")
+		expect(errors.join("\n")).toContain("0.79.11")
+		expect(errors.join("\n")).toContain("@earendil-works/pi-coding-agent@0.79.10")
+	})
+
+	it("flags a patchedDependencies entry whose patch file does not exist on disk", () => {
+		const missingFile = (patchPath: string) => !patchPath.includes("pi-tui")
+
+		const errors = findPatchHealthcheckErrors(IN_SYNC_PKG, missingFile)
+		expect(errors).toHaveLength(1)
+		expect(errors[0]).toContain("Patch file not found")
+		expect(errors[0]).toContain("@earendil-works__pi-tui@0.79.10.patch")
+	})
+
+	it("ignores non-@earendil-works dependencies and patch entries", () => {
+		const pkg = {
+			dependencies: { undici: "8.2.0" },
+			pnpm: {
+				patchedDependencies: {
+					"playwright-core@1.59.1": "patches/playwright-core@1.59.1.patch",
+				},
+			},
+		}
+		// Should not error even though playwright-core has no corresponding
+		// top-level dep entry — non-pi-mono patches are out of scope.
+		expect(findPatchHealthcheckErrors(pkg, patchExists)).toEqual([])
+	})
+})


### PR DESCRIPTION
## Linked issue

Closes #804

<!-- Every PR must link to an existing issue. PRs without a linked issue will not be reviewed.
     Use one of: Closes #N / Fixes #N / Resolves #N -->

## What does this PR do?

This PR adds automation around @earendil-works/* dependency upgrades so pi-mono bumps are easier to keep safe.

It configures Dependabot to open grouped weekly minor/patch updates for `@earendil-works/*` packages, adds a patch healthcheck workflow that catches stale pnpm.patchedDependencies entries before install failures, and verifies patch consistency with a focused script plus unit tests.

It also updates the release workflow so Dependabot pi-mono PRs run a dry-run release path, giving dependency bumps broader validation without publishing artifacts.

## Checklist

- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md) and agree to the CLA
- [x] This PR links to an open issue above
- [x] Tests pass locally (`pnpm run test`)
- [x] Lint passes (`pnpm run check`)
- [x] Documentation updated if behavior changed
