### PR TITLE
feat: default hideThinkingBlock to true

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -363,7 +363,7 @@ try {
 			if ((err as NodeJS.ErrnoException).code === "ENOENT") {
 				writeFileSync(
 					settingsPath,
-					`${JSON.stringify({ quietStartup: true, theme: "kimchi-minimal", retry: RETRY_DEFAULTS, hideThinkingBlock: true }, null, 2)}\n`,
+					`${JSON.stringify({ quietStartup: true, theme: "kimchi-minimal", retry: RETRY_DEFAULTS, hideThinkingBlock: true, acpShowThinking: true }, null, 2)}\n`,
 				)
 			} else {
 				console.error(`Warning: could not read ${settingsPath}: ${(err as Error).message}`)

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -363,7 +363,7 @@ try {
 			if ((err as NodeJS.ErrnoException).code === "ENOENT") {
 				writeFileSync(
 					settingsPath,
-					`${JSON.stringify({ quietStartup: true, theme: "kimchi-minimal", retry: RETRY_DEFAULTS, hideThinkingBlock: true, acpShowThinking: true }, null, 2)}\n`,
+					`${JSON.stringify({ quietStartup: true, theme: "kimchi-minimal", retry: RETRY_DEFAULTS, hideThinkingBlock: true }, null, 2)}\n`,
 				)
 			} else {
 				console.error(`Warning: could not read ${settingsPath}: ${(err as Error).message}`)

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -363,7 +363,7 @@ try {
 			if ((err as NodeJS.ErrnoException).code === "ENOENT") {
 				writeFileSync(
 					settingsPath,
-					`${JSON.stringify({ quietStartup: true, theme: "kimchi-minimal", retry: RETRY_DEFAULTS }, null, 2)}\n`,
+					`${JSON.stringify({ quietStartup: true, theme: "kimchi-minimal", retry: RETRY_DEFAULTS, hideThinkingBlock: true }, null, 2)}\n`,
 				)
 			} else {
 				console.error(`Warning: could not read ${settingsPath}: ${(err as Error).message}`)

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -23,6 +23,7 @@ import "./paste-to-editor-patch.js"
 import {
 	DEFAULT_SKILL_PATHS,
 	RETRY_DEFAULTS,
+	ensureHideThinkingBlockDefault,
 	getActiveVendorSkillPaths,
 	loadConfig,
 	readTelemetryConfig,
@@ -370,16 +371,20 @@ try {
 			}
 		}
 
-		// Seed Kimchi retry defaults for Pi; Pi handles global/project settings merging.
+		// Seed Kimchi harness defaults for Pi; Pi handles global/project settings merging.
 		try {
-			const existing = JSON.parse(readFileSync(settingsPath, "utf-8"))
+			const existing = JSON.parse(readFileSync(settingsPath, "utf-8")) as Record<string, unknown>
+			let changed = ensureHideThinkingBlockDefault(existing)
 			const upgraded = upgradeLegacyRetrySettings(existing.retry)
 			if (upgraded) {
 				existing.retry = upgraded
+				changed = true
+			}
+			if (changed) {
 				writeFileSync(settingsPath, `${JSON.stringify(existing, null, 2)}\n`)
 			}
 		} catch {
-			/* retry sync is best-effort */
+			/* settings sync is best-effort */
 		}
 
 		// Bundled themes are write-through cache — owned by the package, not the user.

--- a/src/config.test.ts
+++ b/src/config.test.ts
@@ -8,6 +8,7 @@ import {
 	buildSkillPathOptions,
 	checkConfigFilePermissions,
 	clearApiKey,
+	ensureHideThinkingBlockDefault,
 	getActiveVendorSkillPaths,
 	loadConfig,
 	readApiKeyFromConfigFile,
@@ -863,5 +864,23 @@ describe("upgradeLegacyRetrySettings", () => {
 	it("leaves a non-object retry value alone", () => {
 		expect(upgradeLegacyRetrySettings(false)).toBeUndefined()
 		expect(upgradeLegacyRetrySettings(null)).toBeUndefined()
+	})
+})
+
+describe("ensureHideThinkingBlockDefault", () => {
+	it("seeds hideThinkingBlock when the key is absent", () => {
+		const settings: Record<string, unknown> = { footer: { pinned: [] } }
+		expect(ensureHideThinkingBlockDefault(settings)).toBe(true)
+		expect(settings.hideThinkingBlock).toBe(true)
+	})
+
+	it("leaves an explicit hideThinkingBlock value alone", () => {
+		const hidden = { hideThinkingBlock: true }
+		expect(ensureHideThinkingBlockDefault(hidden)).toBe(false)
+		expect(hidden.hideThinkingBlock).toBe(true)
+
+		const visible = { hideThinkingBlock: false }
+		expect(ensureHideThinkingBlockDefault(visible)).toBe(false)
+		expect(visible.hideThinkingBlock).toBe(false)
 	})
 })

--- a/src/config.ts
+++ b/src/config.ts
@@ -159,6 +159,13 @@ export function upgradeLegacyRetrySettings(retry: unknown): RetrySettings | unde
 	return upgraded
 }
 
+/** Seed hideThinkingBlock when absent so Kimchi and upstream pi agree on the default. */
+export function ensureHideThinkingBlockDefault(settings: Record<string, unknown>): boolean {
+	if ("hideThinkingBlock" in settings) return false
+	settings.hideThinkingBlock = true
+	return true
+}
+
 export const THIRD_PARTY_MAX_RETRIES = 4
 
 export const SEARCH_STRATEGY_DEFAULTS: SearchStrategyConfig = {

--- a/src/extensions/hide-thinking.test.ts
+++ b/src/extensions/hide-thinking.test.ts
@@ -1,4 +1,4 @@
-import { mkdirSync, mkdtempSync, rmSync } from "node:fs"
+import { mkdtempSync, rmSync } from "node:fs"
 import { tmpdir } from "node:os"
 import { join } from "node:path"
 import { beforeEach, describe, expect, it, vi } from "vitest"
@@ -77,18 +77,13 @@ describe("hideThinkingExtension", () => {
 	})
 
 	it("hides thinking by default when settings.json is missing", () => {
-		const originalDir = process.env.KIMCHI_CODING_AGENT_DIR
 		const tempDir = mkdtempSync(join(tmpdir(), "kimchi-hide-thinking-"))
+		vi.stubEnv("KIMCHI_CODING_AGENT_DIR", tempDir)
 		try {
-			process.env.KIMCHI_CODING_AGENT_DIR = tempDir
 			_resetState()
 			expect(isHideThinkingEnabled()).toBe(true)
 		} finally {
-			if (originalDir === undefined) {
-				process.env.KIMCHI_CODING_AGENT_DIR = undefined
-			} else {
-				process.env.KIMCHI_CODING_AGENT_DIR = originalDir
-			}
+			vi.unstubAllEnvs()
 			rmSync(tempDir, { recursive: true, force: true })
 		}
 	})

--- a/src/extensions/hide-thinking.test.ts
+++ b/src/extensions/hide-thinking.test.ts
@@ -1,4 +1,4 @@
-import { mkdtempSync, rmSync } from "node:fs"
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs"
 import { tmpdir } from "node:os"
 import { join } from "node:path"
 import { beforeEach, describe, expect, it, vi } from "vitest"
@@ -82,6 +82,32 @@ describe("hideThinkingExtension", () => {
 		try {
 			_resetState()
 			expect(isHideThinkingEnabled()).toBe(true)
+		} finally {
+			vi.unstubAllEnvs()
+			rmSync(tempDir, { recursive: true, force: true })
+		}
+	})
+
+	it("hides thinking when settings.json exists without hideThinkingBlock key", () => {
+		const tempDir = mkdtempSync(join(tmpdir(), "kimchi-hide-thinking-"))
+		vi.stubEnv("KIMCHI_CODING_AGENT_DIR", tempDir)
+		writeFileSync(join(tempDir, "settings.json"), JSON.stringify({ footer: { pinned: [] } }))
+		try {
+			_resetState()
+			expect(isHideThinkingEnabled()).toBe(true)
+		} finally {
+			vi.unstubAllEnvs()
+			rmSync(tempDir, { recursive: true, force: true })
+		}
+	})
+
+	it("dims thinking when hideThinkingBlock is false in settings.json", () => {
+		const tempDir = mkdtempSync(join(tmpdir(), "kimchi-hide-thinking-"))
+		vi.stubEnv("KIMCHI_CODING_AGENT_DIR", tempDir)
+		writeFileSync(join(tempDir, "settings.json"), JSON.stringify({ hideThinkingBlock: false }))
+		try {
+			_resetState()
+			expect(isHideThinkingEnabled()).toBe(false)
 		} finally {
 			vi.unstubAllEnvs()
 			rmSync(tempDir, { recursive: true, force: true })

--- a/src/extensions/hide-thinking.test.ts
+++ b/src/extensions/hide-thinking.test.ts
@@ -1,3 +1,6 @@
+import { mkdirSync, mkdtempSync, rmSync } from "node:fs"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
 import { beforeEach, describe, expect, it, vi } from "vitest"
 import { ANSI, fg } from "../ansi.js"
 import hideThinkingExtension, {
@@ -5,6 +8,7 @@ import hideThinkingExtension, {
 	_resetState,
 	_setHideThinking,
 	filterThinkingForDisplay,
+	isHideThinkingEnabled,
 } from "./hide-thinking.js"
 
 type Handler = (event: unknown) => unknown
@@ -72,9 +76,26 @@ describe("hideThinkingExtension", () => {
 		}
 	})
 
-	// --- Default behaviour (hideThinking = false → dim) ---
+	it("hides thinking by default when settings.json is missing", () => {
+		const originalDir = process.env.KIMCHI_CODING_AGENT_DIR
+		const tempDir = mkdtempSync(join(tmpdir(), "kimchi-hide-thinking-"))
+		try {
+			process.env.KIMCHI_CODING_AGENT_DIR = tempDir
+			_resetState()
+			expect(isHideThinkingEnabled()).toBe(true)
+		} finally {
+			if (originalDir === undefined) {
+				process.env.KIMCHI_CODING_AGENT_DIR = undefined
+			} else {
+				process.env.KIMCHI_CODING_AGENT_DIR = originalDir
+			}
+			rmSync(tempDir, { recursive: true, force: true })
+		}
+	})
 
-	it("dims thinking content by default (hideThinking not set)", async () => {
+	// --- Explicit hideThinking = false (dim) ---
+
+	it("dims thinking content when hideThinking is false", async () => {
 		_setHideThinking(false)
 		const { endResult } = await simulateStreaming(h, ["Before ", "<think>", "reason", "</think>", " After"])
 		expect(endResult).toBeDefined()
@@ -271,7 +292,7 @@ describe("hideThinkingExtension", () => {
 
 	// --- mm:think tags ---
 
-	it("dims <mm:think> content by default", async () => {
+	it("dims <mm:think> content when hideThinking is false", async () => {
 		_setHideThinking(false)
 		const { endResult } = await simulateStreaming(h, ["Before ", "<mm:think>", "mm reason", "</mm:think>", " After"])
 		expect(endResult).toBeDefined()

--- a/src/extensions/hide-thinking.ts
+++ b/src/extensions/hide-thinking.ts
@@ -9,8 +9,8 @@
  * upstream framework and are NOT touched by this extension.
  *
  * Behaviour controlled by `hideThinkingBlock` in settings.json:
- * - true: hides thinking content entirely from display
- * - false (default): strips tags, dims content (last 5 lines shown)
+ * - true (default): hides thinking content entirely from display
+ * - false: strips tags, dims content (last 5 lines shown)
  *
  * Architecture:
  * - message_start: initialises per-message streaming state

--- a/src/extensions/hide-thinking.ts
+++ b/src/extensions/hide-thinking.ts
@@ -75,16 +75,16 @@ export function isHideThinkingEnabled(): boolean {
 function readHideThinkingSetting(): boolean {
 	if (hideThinkingOverride !== undefined) return hideThinkingOverride
 	const settingsPath = getSettingsPath()
-	if (!settingsPath) return false
+	if (!settingsPath) return true
 	try {
 		const raw = readFileSync(settingsPath, "utf-8")
 		const parsed = JSON.parse(raw)
 		if (parsed && typeof parsed === "object" && "hideThinkingBlock" in parsed) {
 			return Boolean((parsed as { hideThinkingBlock: unknown }).hideThinkingBlock)
 		}
-		return false
+		return true
 	} catch {
-		return false
+		return true
 	}
 }
 

--- a/src/extensions/hide-thinking.ts
+++ b/src/extensions/hide-thinking.ts
@@ -80,10 +80,14 @@ function readHideThinkingSetting(): boolean {
 		const raw = readFileSync(settingsPath, "utf-8")
 		const parsed = JSON.parse(raw)
 		if (parsed && typeof parsed === "object" && "hideThinkingBlock" in parsed) {
-			return Boolean((parsed as { hideThinkingBlock: unknown }).hideThinkingBlock)
+			return (parsed as { hideThinkingBlock?: unknown }).hideThinkingBlock === true
 		}
 		return true
-	} catch {
+	} catch (error) {
+		if (error instanceof Error && (error as NodeJS.ErrnoException).code === "ENOENT") {
+			return true
+		}
+		console.warn(`[hide-thinking] could not read ${settingsPath}:`, error)
 		return true
 	}
 }

--- a/src/modes/acp/server.test.ts
+++ b/src/modes/acp/server.test.ts
@@ -30,7 +30,6 @@ import { PERMISSIONS_ENV_KEY } from "../../extensions/permissions/constants.js"
 import { getSessionPermissionFlagController } from "../../extensions/permissions/mode-controller-registry.js"
 import { ALL_PERMISSION_MODES } from "../../extensions/permissions/types.js"
 import { getAcpPrompter } from "./permission-prompter-registry.js"
-import { _resetAcpShowThinking, _setAcpShowThinking } from "./server.js"
 import {
 	type AcpSessionFactory,
 	type AcpSessionLister,
@@ -41,7 +40,6 @@ import {
 	describeToolCall,
 	initializeHeadlessTheme,
 	isHiddenToolCall,
-	shouldEmitThinking,
 	stripAnsi,
 	toAcpSessionInfo,
 	userMessageText,
@@ -3503,41 +3501,36 @@ describe("KimchiAcpAgent loadSession", () => {
 		// text blocks (rare but legal) must merge into one agent_message_chunk;
 		// structural blocks (thinking / toolCall) flush the buffer so ordering
 		// stays faithful.
-		_setAcpShowThinking(true)
-		try {
-			const fake = new FakeAgentSession("loaded-coalesce")
-			fake.branch = [
-				userTextEntry("go", "u1", null),
-				assistantBlocksEntry(
-					[
-						{ type: "text", text: "first " },
-						{ type: "text", text: "second" },
-						{ type: "thinking", thinking: "pondering" },
-						{ type: "text", text: "third" },
-					],
-					"a1",
-					"u1",
-				),
-			]
-			const { conn, updates } = makeRecordingConn()
-			const agent = makeAgent(async () => asSession(fake), { conn })
-			await agent.loadSession({
-				sessionId: "loaded-coalesce",
-				cwd: "/tmp",
-				mcpServers: [],
-			})
-			const replay = replayOnly(updates)
-			expect(replay.map((u) => u.update.sessionUpdate)).toEqual([
-				"user_message_chunk",
-				"agent_message_chunk",
-				"agent_thought_chunk",
-				"agent_message_chunk",
-			])
-			expect((replay[1].update as { content: { text: string } }).content.text).toBe("first second")
-			expect((replay[3].update as { content: { text: string } }).content.text).toBe("third")
-		} finally {
-			_resetAcpShowThinking()
-		}
+		const fake = new FakeAgentSession("loaded-coalesce")
+		fake.branch = [
+			userTextEntry("go", "u1", null),
+			assistantBlocksEntry(
+				[
+					{ type: "text", text: "first " },
+					{ type: "text", text: "second" },
+					{ type: "thinking", thinking: "pondering" },
+					{ type: "text", text: "third" },
+				],
+				"a1",
+				"u1",
+			),
+		]
+		const { conn, updates } = makeRecordingConn()
+		const agent = makeAgent(async () => asSession(fake), { conn })
+		await agent.loadSession({
+			sessionId: "loaded-coalesce",
+			cwd: "/tmp",
+			mcpServers: [],
+		})
+		const replay = replayOnly(updates)
+		expect(replay.map((u) => u.update.sessionUpdate)).toEqual([
+			"user_message_chunk",
+			"agent_message_chunk",
+			"agent_thought_chunk",
+			"agent_message_chunk",
+		])
+		expect((replay[1].update as { content: { text: string } }).content.text).toBe("first second")
+		expect((replay[3].update as { content: { text: string } }).content.text).toBe("third")
 	})
 
 	it("routes ANSI-dimmed replay text to thought chunks and strips remaining ANSI", async () => {
@@ -3545,64 +3538,34 @@ describe("KimchiAcpAgent loadSession", () => {
 		// persist text with ANSI dim escapes around inner <think> content. The
 		// live TUI renders them as reasoning; ACP's text content type is
 		// plaintext, so replay must preserve that semantic split explicitly.
-		_setAcpShowThinking(true)
-		try {
-			const dimmed = "before \x1b[2minner\x1b[22m after"
-			const fake = new FakeAgentSession("loaded-ansi")
-			fake.branch = [
-				userTextEntry("go", "u1", null),
-				assistantBlocksEntry(
-					[
-						{ type: "text", text: dimmed },
-						{ type: "thinking", thinking: "raw \x1b[2mthought\x1b[22m" },
-					],
-					"a1",
-					"u1",
-				),
-			]
-			const { conn, updates } = makeRecordingConn()
-			const agent = makeAgent(async () => asSession(fake), { conn })
-			await agent.loadSession({
-				sessionId: "loaded-ansi",
-				cwd: "/tmp",
-				mcpServers: [],
-			})
-			const messageTexts = updates
-				.filter((u) => u.update.sessionUpdate === "agent_message_chunk")
-				.map((u) => (u.update as { content: { text: string } }).content.text)
-			const thoughtTexts = updates
-				.filter((u) => u.update.sessionUpdate === "agent_thought_chunk")
-				.map((u) => (u.update as { content: { text: string } }).content.text)
-			expect(messageTexts).toEqual(["before ", " after"])
-			expect(thoughtTexts).toEqual(["inner", "raw thought"])
-		} finally {
-			_resetAcpShowThinking()
-		}
-	})
-
-	it("drops ANSI-dimmed replay thinking when acpShowThinking is disabled", async () => {
-		_setAcpShowThinking(false)
-		try {
-			const fake = new FakeAgentSession("loaded-ansi-hidden")
-			fake.branch = [
-				userTextEntry("go", "u1", null),
-				assistantBlocksEntry([{ type: "text", text: "before \x1b[2minner\x1b[22m after" }], "a1", "u1"),
-			]
-			const { conn, updates } = makeRecordingConn()
-			const agent = makeAgent(async () => asSession(fake), { conn })
-			await agent.loadSession({
-				sessionId: "loaded-ansi-hidden",
-				cwd: "/tmp",
-				mcpServers: [],
-			})
-			const messageTexts = updates
-				.filter((u) => u.update.sessionUpdate === "agent_message_chunk")
-				.map((u) => (u.update as { content: { text: string } }).content.text)
-			expect(updates.find((u) => u.update.sessionUpdate === "agent_thought_chunk")).toBeUndefined()
-			expect(messageTexts).toEqual(["before  after"])
-		} finally {
-			_resetAcpShowThinking()
-		}
+		const dimmed = "before \x1b[2minner\x1b[22m after"
+		const fake = new FakeAgentSession("loaded-ansi")
+		fake.branch = [
+			userTextEntry("go", "u1", null),
+			assistantBlocksEntry(
+				[
+					{ type: "text", text: dimmed },
+					{ type: "thinking", thinking: "raw \x1b[2mthought\x1b[22m" },
+				],
+				"a1",
+				"u1",
+			),
+		]
+		const { conn, updates } = makeRecordingConn()
+		const agent = makeAgent(async () => asSession(fake), { conn })
+		await agent.loadSession({
+			sessionId: "loaded-ansi",
+			cwd: "/tmp",
+			mcpServers: [],
+		})
+		const messageTexts = updates
+			.filter((u) => u.update.sessionUpdate === "agent_message_chunk")
+			.map((u) => (u.update as { content: { text: string } }).content.text)
+		const thoughtTexts = updates
+			.filter((u) => u.update.sessionUpdate === "agent_thought_chunk")
+			.map((u) => (u.update as { content: { text: string } }).content.text)
+		expect(messageTexts).toEqual(["before ", " after"])
+		expect(thoughtTexts).toEqual(["inner", "raw thought"])
 	})
 
 	it("treats a concurrent session/cancel during replay as a no-op (no turn active)", async () => {
@@ -3908,54 +3871,26 @@ describe("KimchiAcpAgent loadSession", () => {
 	})
 
 	it("replays thinking blocks as agent_thought_chunk with raw text (no ANSI)", async () => {
-		_setAcpShowThinking(true)
-		try {
-			const fake = new FakeAgentSession("loaded-thinking")
-			fake.branch = [
-				userTextEntry("go", "u1", null),
-				assistantBlocksEntry([{ type: "thinking", thinking: "considering options" }], "a1", "u1"),
-			]
-			const { conn, updates } = makeRecordingConn()
-			const agent = makeAgent(async () => asSession(fake), { conn })
-			await agent.loadSession({
-				sessionId: "loaded-thinking",
-				cwd: "/tmp",
-				mcpServers: [],
-			})
-			const thought = updates.find((u) => u.update.sessionUpdate === "agent_thought_chunk")
-			expect(thought).toBeDefined()
-			const content = (thought?.update as { content: { type: string; text: string } }).content
-			expect(content.text).toBe("considering options")
-			// No ANSI escape codes — filterThinkingForDisplay returns dimmed text
-			// for live TUI rendering, but ACP clients can't render escapes. Replay
-			// uses the helper as a yes/no predicate and emits the raw thinking.
-			expect(content.text.includes("\x1b[")).toBe(false)
-		} finally {
-			_resetAcpShowThinking()
-		}
-	})
-
-	it("skips thinking blocks when acpShowThinking is disabled", async () => {
-		// ACP replay consults its own acpShowThinking setting, independent of
-		// the live TUI's hideThinkingBlock.
-		_setAcpShowThinking(false)
-		try {
-			const fake = new FakeAgentSession("loaded-thinking-hidden")
-			fake.branch = [
-				userTextEntry("go", "u1", null),
-				assistantBlocksEntry([{ type: "thinking", thinking: "considering options" }], "a1", "u1"),
-			]
-			const { conn, updates } = makeRecordingConn()
-			const agent = makeAgent(async () => asSession(fake), { conn })
-			await agent.loadSession({
-				sessionId: "loaded-thinking-hidden",
-				cwd: "/tmp",
-				mcpServers: [],
-			})
-			expect(updates.find((u) => u.update.sessionUpdate === "agent_thought_chunk")).toBeUndefined()
-		} finally {
-			_resetAcpShowThinking()
-		}
+		const fake = new FakeAgentSession("loaded-thinking")
+		fake.branch = [
+			userTextEntry("go", "u1", null),
+			assistantBlocksEntry([{ type: "thinking", thinking: "considering options" }], "a1", "u1"),
+		]
+		const { conn, updates } = makeRecordingConn()
+		const agent = makeAgent(async () => asSession(fake), { conn })
+		await agent.loadSession({
+			sessionId: "loaded-thinking",
+			cwd: "/tmp",
+			mcpServers: [],
+		})
+		const thought = updates.find((u) => u.update.sessionUpdate === "agent_thought_chunk")
+		expect(thought).toBeDefined()
+		const content = (thought?.update as { content: { type: string; text: string } }).content
+		expect(content.text).toBe("considering options")
+		// No ANSI escape codes — filterThinkingForDisplay returns dimmed text
+		// for live TUI rendering, but ACP clients can't render escapes. Replay
+		// uses the helper as a yes/no predicate and emits the raw thinking.
+		expect(content.text.includes("\x1b[")).toBe(false)
 	})
 
 	it("skips redacted thinking blocks", async () => {
@@ -4041,67 +3976,62 @@ describe("KimchiAcpAgent loadSession", () => {
 	})
 
 	it("replays a mixed transcript end-to-end (text, thinking, tool, skipped entries, follow-up text)", async () => {
-		_setAcpShowThinking(true)
-		try {
-			const fake = new FakeAgentSession("loaded-mixed")
-			fake.branch = [
-				userTextEntry("question", "u1", null),
-				assistantBlocksEntry(
-					[
-						{ type: "text", text: "let me check" },
-						{ type: "thinking", thinking: "weighing options" },
-						{
-							type: "toolCall",
-							id: "tc-1",
-							name: "bash",
-							arguments: { command: "ls" },
-						},
-					],
-					"a1",
-					"u1",
-				),
-				toolResultEntry("tc-1", "bash", "file1\nfile2", false, "tr1", "a1"),
-				// Skipped entries scattered through the branch must not break the walker.
-				{
-					type: "model_change",
-					id: "mc1",
-					parentId: "tr1",
-					timestamp: "x",
-					provider: "p",
-					modelId: "m",
-				},
-				{
-					type: "compaction",
-					id: "c1",
-					parentId: "mc1",
-					timestamp: "x",
-					summary: "snip",
-					firstKeptEntryId: "u1",
-					tokensBefore: 0,
-				},
-				assistantTextEntry("here is what I found", "a2", "c1"),
-			]
-			const { conn, updates } = makeRecordingConn()
-			const agent = makeAgent(async () => asSession(fake), { conn })
-			await agent.loadSession({
-				sessionId: "loaded-mixed",
-				cwd: "/tmp",
-				mcpServers: [],
-			})
-			// Order is significant: tool_call must precede tool_call_update, and
-			// the post-skipped-entries assistant text must land last.
-			expect(updates.map((u) => u.update.sessionUpdate)).toEqual([
-				"user_message_chunk",
-				"agent_message_chunk",
-				"agent_thought_chunk",
-				"tool_call",
-				"tool_call_update",
-				"agent_message_chunk",
-				"available_commands_update",
-			])
-		} finally {
-			_resetAcpShowThinking()
-		}
+		const fake = new FakeAgentSession("loaded-mixed")
+		fake.branch = [
+			userTextEntry("question", "u1", null),
+			assistantBlocksEntry(
+				[
+					{ type: "text", text: "let me check" },
+					{ type: "thinking", thinking: "weighing options" },
+					{
+						type: "toolCall",
+						id: "tc-1",
+						name: "bash",
+						arguments: { command: "ls" },
+					},
+				],
+				"a1",
+				"u1",
+			),
+			toolResultEntry("tc-1", "bash", "file1\nfile2", false, "tr1", "a1"),
+			// Skipped entries scattered through the branch must not break the walker.
+			{
+				type: "model_change",
+				id: "mc1",
+				parentId: "tr1",
+				timestamp: "x",
+				provider: "p",
+				modelId: "m",
+			},
+			{
+				type: "compaction",
+				id: "c1",
+				parentId: "mc1",
+				timestamp: "x",
+				summary: "snip",
+				firstKeptEntryId: "u1",
+				tokensBefore: 0,
+			},
+			assistantTextEntry("here is what I found", "a2", "c1"),
+		]
+		const { conn, updates } = makeRecordingConn()
+		const agent = makeAgent(async () => asSession(fake), { conn })
+		await agent.loadSession({
+			sessionId: "loaded-mixed",
+			cwd: "/tmp",
+			mcpServers: [],
+		})
+		// Order is significant: tool_call must precede tool_call_update, and
+		// the post-skipped-entries assistant text must land last.
+		expect(updates.map((u) => u.update.sessionUpdate)).toEqual([
+			"user_message_chunk",
+			"agent_message_chunk",
+			"agent_thought_chunk",
+			"tool_call",
+			"tool_call_update",
+			"agent_message_chunk",
+			"available_commands_update",
+		])
 	})
 
 	it("does not deliver synthetic agent_* events to session subscribers during replay", async () => {
@@ -4393,52 +4323,6 @@ describe("KimchiAcpAgent session event handlers", () => {
 			expect((titleUpdates[0].update as { title?: string }).title).toBe("Draft title")
 			expect((titleUpdates[1].update as { title?: string }).title).toBe("Final title")
 		})
-	})
-})
-
-describe("shouldEmitThinking", () => {
-	it("returns true by default when acpShowThinking is not configured", () => {
-		const tempDir = mkdtempSync(join(tmpdir(), "kimchi-acp-hide-thinking-"))
-		vi.stubEnv("KIMCHI_CODING_AGENT_DIR", tempDir)
-		try {
-			_resetAcpShowThinking()
-			expect(shouldEmitThinking("anything")).toBe(true)
-		} finally {
-			vi.unstubAllEnvs()
-			rmSync(tempDir, { recursive: true, force: true })
-		}
-	})
-	it("returns true when acpShowThinking is enabled", () => {
-		_setAcpShowThinking(true)
-		try {
-			expect(shouldEmitThinking("anything")).toBe(true)
-		} finally {
-			_resetAcpShowThinking()
-		}
-	})
-	it("returns false when acpShowThinking is disabled", () => {
-		_setAcpShowThinking(false)
-		try {
-			expect(shouldEmitThinking("anything")).toBe(false)
-		} finally {
-			_resetAcpShowThinking()
-		}
-	})
-	it("does not break when the persisted thinking text contains a literal </think>", () => {
-		// Regression: a previous version probed filterThinkingForDisplay with a
-		// synthetic <think>${thinking}</think> wrapper. Models self-quoting
-		// "</think>" closed the wrapper early and the inner text leaked, making
-		// the predicate non-deterministic. Reading the setting directly avoids
-		// the round-trip entirely.
-		_setAcpShowThinking(true)
-		const haunted = "I'll stop now. </think> trailing"
-		expect(shouldEmitThinking(haunted)).toBe(true)
-		_setAcpShowThinking(false)
-		try {
-			expect(shouldEmitThinking(haunted)).toBe(false)
-		} finally {
-			_resetAcpShowThinking()
-		}
 	})
 })
 

--- a/src/modes/acp/server.test.ts
+++ b/src/modes/acp/server.test.ts
@@ -26,11 +26,11 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
 const THEME_KEY = Symbol.for("@earendil-works/pi-coding-agent:theme")
 const THEME_KEY_OLD = Symbol.for("@mariozechner/pi-coding-agent:theme")
 
-import { _resetState as _resetHideThinking, _setHideThinking } from "../../extensions/hide-thinking.js"
 import { PERMISSIONS_ENV_KEY } from "../../extensions/permissions/constants.js"
 import { getSessionPermissionFlagController } from "../../extensions/permissions/mode-controller-registry.js"
 import { ALL_PERMISSION_MODES } from "../../extensions/permissions/types.js"
 import { getAcpPrompter } from "./permission-prompter-registry.js"
+import { _resetAcpShowThinking, _setAcpShowThinking } from "./server.js"
 import {
 	type AcpSessionFactory,
 	type AcpSessionLister,
@@ -3503,75 +3503,85 @@ describe("KimchiAcpAgent loadSession", () => {
 		// text blocks (rare but legal) must merge into one agent_message_chunk;
 		// structural blocks (thinking / toolCall) flush the buffer so ordering
 		// stays faithful.
-		const fake = new FakeAgentSession("loaded-coalesce")
-		fake.branch = [
-			userTextEntry("go", "u1", null),
-			assistantBlocksEntry(
-				[
-					{ type: "text", text: "first " },
-					{ type: "text", text: "second" },
-					{ type: "thinking", thinking: "pondering" },
-					{ type: "text", text: "third" },
-				],
-				"a1",
-				"u1",
-			),
-		]
-		const { conn, updates } = makeRecordingConn()
-		const agent = makeAgent(async () => asSession(fake), { conn })
-		await agent.loadSession({
-			sessionId: "loaded-coalesce",
-			cwd: "/tmp",
-			mcpServers: [],
-		})
-		const replay = replayOnly(updates)
-		expect(replay.map((u) => u.update.sessionUpdate)).toEqual([
-			"user_message_chunk",
-			"agent_message_chunk",
-			"agent_thought_chunk",
-			"agent_message_chunk",
-		])
-		expect((replay[1].update as { content: { text: string } }).content.text).toBe("first second")
-		expect((replay[3].update as { content: { text: string } }).content.text).toBe("third")
+		_setAcpShowThinking(true)
+		try {
+			const fake = new FakeAgentSession("loaded-coalesce")
+			fake.branch = [
+				userTextEntry("go", "u1", null),
+				assistantBlocksEntry(
+					[
+						{ type: "text", text: "first " },
+						{ type: "text", text: "second" },
+						{ type: "thinking", thinking: "pondering" },
+						{ type: "text", text: "third" },
+					],
+					"a1",
+					"u1",
+				),
+			]
+			const { conn, updates } = makeRecordingConn()
+			const agent = makeAgent(async () => asSession(fake), { conn })
+			await agent.loadSession({
+				sessionId: "loaded-coalesce",
+				cwd: "/tmp",
+				mcpServers: [],
+			})
+			const replay = replayOnly(updates)
+			expect(replay.map((u) => u.update.sessionUpdate)).toEqual([
+				"user_message_chunk",
+				"agent_message_chunk",
+				"agent_thought_chunk",
+				"agent_message_chunk",
+			])
+			expect((replay[1].update as { content: { text: string } }).content.text).toBe("first second")
+			expect((replay[3].update as { content: { text: string } }).content.text).toBe("third")
+		} finally {
+			_resetAcpShowThinking()
+		}
 	})
 
 	it("routes ANSI-dimmed replay text to thought chunks and strips remaining ANSI", async () => {
-		// hide-thinking-aware models (DeepSeek, QwQ) plus hideThinkingBlock=false
+		// hide-thinking-aware models (DeepSeek, QwQ) plus acpShowThinking=true
 		// persist text with ANSI dim escapes around inner <think> content. The
 		// live TUI renders them as reasoning; ACP's text content type is
 		// plaintext, so replay must preserve that semantic split explicitly.
-		const dimmed = "before \x1b[2minner\x1b[22m after"
-		const fake = new FakeAgentSession("loaded-ansi")
-		fake.branch = [
-			userTextEntry("go", "u1", null),
-			assistantBlocksEntry(
-				[
-					{ type: "text", text: dimmed },
-					{ type: "thinking", thinking: "raw \x1b[2mthought\x1b[22m" },
-				],
-				"a1",
-				"u1",
-			),
-		]
-		const { conn, updates } = makeRecordingConn()
-		const agent = makeAgent(async () => asSession(fake), { conn })
-		await agent.loadSession({
-			sessionId: "loaded-ansi",
-			cwd: "/tmp",
-			mcpServers: [],
-		})
-		const messageTexts = updates
-			.filter((u) => u.update.sessionUpdate === "agent_message_chunk")
-			.map((u) => (u.update as { content: { text: string } }).content.text)
-		const thoughtTexts = updates
-			.filter((u) => u.update.sessionUpdate === "agent_thought_chunk")
-			.map((u) => (u.update as { content: { text: string } }).content.text)
-		expect(messageTexts).toEqual(["before ", " after"])
-		expect(thoughtTexts).toEqual(["inner", "raw thought"])
+		_setAcpShowThinking(true)
+		try {
+			const dimmed = "before \x1b[2minner\x1b[22m after"
+			const fake = new FakeAgentSession("loaded-ansi")
+			fake.branch = [
+				userTextEntry("go", "u1", null),
+				assistantBlocksEntry(
+					[
+						{ type: "text", text: dimmed },
+						{ type: "thinking", thinking: "raw \x1b[2mthought\x1b[22m" },
+					],
+					"a1",
+					"u1",
+				),
+			]
+			const { conn, updates } = makeRecordingConn()
+			const agent = makeAgent(async () => asSession(fake), { conn })
+			await agent.loadSession({
+				sessionId: "loaded-ansi",
+				cwd: "/tmp",
+				mcpServers: [],
+			})
+			const messageTexts = updates
+				.filter((u) => u.update.sessionUpdate === "agent_message_chunk")
+				.map((u) => (u.update as { content: { text: string } }).content.text)
+			const thoughtTexts = updates
+				.filter((u) => u.update.sessionUpdate === "agent_thought_chunk")
+				.map((u) => (u.update as { content: { text: string } }).content.text)
+			expect(messageTexts).toEqual(["before ", " after"])
+			expect(thoughtTexts).toEqual(["inner", "raw thought"])
+		} finally {
+			_resetAcpShowThinking()
+		}
 	})
 
-	it("drops ANSI-dimmed replay thinking when hideThinkingBlock is enabled", async () => {
-		_setHideThinking(true)
+	it("drops ANSI-dimmed replay thinking when acpShowThinking is disabled", async () => {
+		_setAcpShowThinking(false)
 		try {
 			const fake = new FakeAgentSession("loaded-ansi-hidden")
 			fake.branch = [
@@ -3591,7 +3601,7 @@ describe("KimchiAcpAgent loadSession", () => {
 			expect(updates.find((u) => u.update.sessionUpdate === "agent_thought_chunk")).toBeUndefined()
 			expect(messageTexts).toEqual(["before  after"])
 		} finally {
-			_resetHideThinking()
+			_resetAcpShowThinking()
 		}
 	})
 
@@ -3898,33 +3908,37 @@ describe("KimchiAcpAgent loadSession", () => {
 	})
 
 	it("replays thinking blocks as agent_thought_chunk with raw text (no ANSI)", async () => {
-		const fake = new FakeAgentSession("loaded-thinking")
-		fake.branch = [
-			userTextEntry("go", "u1", null),
-			assistantBlocksEntry([{ type: "thinking", thinking: "considering options" }], "a1", "u1"),
-		]
-		const { conn, updates } = makeRecordingConn()
-		const agent = makeAgent(async () => asSession(fake), { conn })
-		await agent.loadSession({
-			sessionId: "loaded-thinking",
-			cwd: "/tmp",
-			mcpServers: [],
-		})
-		const thought = updates.find((u) => u.update.sessionUpdate === "agent_thought_chunk")
-		expect(thought).toBeDefined()
-		const content = (thought?.update as { content: { type: string; text: string } }).content
-		expect(content.text).toBe("considering options")
-		// No ANSI escape codes — filterThinkingForDisplay returns dimmed text
-		// for live TUI rendering, but ACP clients can't render escapes. Replay
-		// uses the helper as a yes/no predicate and emits the raw thinking.
-		expect(content.text.includes("\x1b[")).toBe(false)
+		_setAcpShowThinking(true)
+		try {
+			const fake = new FakeAgentSession("loaded-thinking")
+			fake.branch = [
+				userTextEntry("go", "u1", null),
+				assistantBlocksEntry([{ type: "thinking", thinking: "considering options" }], "a1", "u1"),
+			]
+			const { conn, updates } = makeRecordingConn()
+			const agent = makeAgent(async () => asSession(fake), { conn })
+			await agent.loadSession({
+				sessionId: "loaded-thinking",
+				cwd: "/tmp",
+				mcpServers: [],
+			})
+			const thought = updates.find((u) => u.update.sessionUpdate === "agent_thought_chunk")
+			expect(thought).toBeDefined()
+			const content = (thought?.update as { content: { type: string; text: string } }).content
+			expect(content.text).toBe("considering options")
+			// No ANSI escape codes — filterThinkingForDisplay returns dimmed text
+			// for live TUI rendering, but ACP clients can't render escapes. Replay
+			// uses the helper as a yes/no predicate and emits the raw thinking.
+			expect(content.text.includes("\x1b[")).toBe(false)
+		} finally {
+			_resetAcpShowThinking()
+		}
 	})
 
-	it("skips thinking blocks when hideThinkingBlock is enabled (shared with hide-thinking extension)", async () => {
-		// Same redaction rule the live TUI uses — verified by sharing
-		// filterThinkingForDisplay across both code paths so a setting flip
-		// doesn't drift between live and replay.
-		_setHideThinking(true)
+	it("skips thinking blocks when acpShowThinking is disabled", async () => {
+		// ACP replay consults its own acpShowThinking setting, independent of
+		// the live TUI's hideThinkingBlock.
+		_setAcpShowThinking(false)
 		try {
 			const fake = new FakeAgentSession("loaded-thinking-hidden")
 			fake.branch = [
@@ -3940,11 +3954,11 @@ describe("KimchiAcpAgent loadSession", () => {
 			})
 			expect(updates.find((u) => u.update.sessionUpdate === "agent_thought_chunk")).toBeUndefined()
 		} finally {
-			_resetHideThinking()
+			_resetAcpShowThinking()
 		}
 	})
 
-	it("skips redacted thinking blocks even when hideThinkingBlock is off", async () => {
+	it("skips redacted thinking blocks", async () => {
 		// Redacted thinking has only an opaque encrypted payload (in
 		// thinkingSignature) for multi-turn provider continuity — no plaintext
 		// to surface to the user.
@@ -4027,62 +4041,67 @@ describe("KimchiAcpAgent loadSession", () => {
 	})
 
 	it("replays a mixed transcript end-to-end (text, thinking, tool, skipped entries, follow-up text)", async () => {
-		const fake = new FakeAgentSession("loaded-mixed")
-		fake.branch = [
-			userTextEntry("question", "u1", null),
-			assistantBlocksEntry(
-				[
-					{ type: "text", text: "let me check" },
-					{ type: "thinking", thinking: "weighing options" },
-					{
-						type: "toolCall",
-						id: "tc-1",
-						name: "bash",
-						arguments: { command: "ls" },
-					},
-				],
-				"a1",
-				"u1",
-			),
-			toolResultEntry("tc-1", "bash", "file1\nfile2", false, "tr1", "a1"),
-			// Skipped entries scattered through the branch must not break the walker.
-			{
-				type: "model_change",
-				id: "mc1",
-				parentId: "tr1",
-				timestamp: "x",
-				provider: "p",
-				modelId: "m",
-			},
-			{
-				type: "compaction",
-				id: "c1",
-				parentId: "mc1",
-				timestamp: "x",
-				summary: "snip",
-				firstKeptEntryId: "u1",
-				tokensBefore: 0,
-			},
-			assistantTextEntry("here is what I found", "a2", "c1"),
-		]
-		const { conn, updates } = makeRecordingConn()
-		const agent = makeAgent(async () => asSession(fake), { conn })
-		await agent.loadSession({
-			sessionId: "loaded-mixed",
-			cwd: "/tmp",
-			mcpServers: [],
-		})
-		// Order is significant: tool_call must precede tool_call_update, and
-		// the post-skipped-entries assistant text must land last.
-		expect(updates.map((u) => u.update.sessionUpdate)).toEqual([
-			"user_message_chunk",
-			"agent_message_chunk",
-			"agent_thought_chunk",
-			"tool_call",
-			"tool_call_update",
-			"agent_message_chunk",
-			"available_commands_update",
-		])
+		_setAcpShowThinking(true)
+		try {
+			const fake = new FakeAgentSession("loaded-mixed")
+			fake.branch = [
+				userTextEntry("question", "u1", null),
+				assistantBlocksEntry(
+					[
+						{ type: "text", text: "let me check" },
+						{ type: "thinking", thinking: "weighing options" },
+						{
+							type: "toolCall",
+							id: "tc-1",
+							name: "bash",
+							arguments: { command: "ls" },
+						},
+					],
+					"a1",
+					"u1",
+				),
+				toolResultEntry("tc-1", "bash", "file1\nfile2", false, "tr1", "a1"),
+				// Skipped entries scattered through the branch must not break the walker.
+				{
+					type: "model_change",
+					id: "mc1",
+					parentId: "tr1",
+					timestamp: "x",
+					provider: "p",
+					modelId: "m",
+				},
+				{
+					type: "compaction",
+					id: "c1",
+					parentId: "mc1",
+					timestamp: "x",
+					summary: "snip",
+					firstKeptEntryId: "u1",
+					tokensBefore: 0,
+				},
+				assistantTextEntry("here is what I found", "a2", "c1"),
+			]
+			const { conn, updates } = makeRecordingConn()
+			const agent = makeAgent(async () => asSession(fake), { conn })
+			await agent.loadSession({
+				sessionId: "loaded-mixed",
+				cwd: "/tmp",
+				mcpServers: [],
+			})
+			// Order is significant: tool_call must precede tool_call_update, and
+			// the post-skipped-entries assistant text must land last.
+			expect(updates.map((u) => u.update.sessionUpdate)).toEqual([
+				"user_message_chunk",
+				"agent_message_chunk",
+				"agent_thought_chunk",
+				"tool_call",
+				"tool_call_update",
+				"agent_message_chunk",
+				"available_commands_update",
+			])
+		} finally {
+			_resetAcpShowThinking()
+		}
 	})
 
 	it("does not deliver synthetic agent_* events to session subscribers during replay", async () => {
@@ -4378,31 +4397,31 @@ describe("KimchiAcpAgent session event handlers", () => {
 })
 
 describe("shouldEmitThinking", () => {
-	it("returns false by default when hideThinkingBlock is not configured", () => {
+	it("returns true by default when acpShowThinking is not configured", () => {
 		const tempDir = mkdtempSync(join(tmpdir(), "kimchi-acp-hide-thinking-"))
 		vi.stubEnv("KIMCHI_CODING_AGENT_DIR", tempDir)
 		try {
-			_resetHideThinking()
-			expect(shouldEmitThinking("anything")).toBe(false)
+			_resetAcpShowThinking()
+			expect(shouldEmitThinking("anything")).toBe(true)
 		} finally {
 			vi.unstubAllEnvs()
 			rmSync(tempDir, { recursive: true, force: true })
 		}
 	})
-	it("returns true when hideThinkingBlock is disabled", () => {
-		_setHideThinking(false)
+	it("returns true when acpShowThinking is enabled", () => {
+		_setAcpShowThinking(true)
 		try {
 			expect(shouldEmitThinking("anything")).toBe(true)
 		} finally {
-			_resetHideThinking()
+			_resetAcpShowThinking()
 		}
 	})
-	it("returns false when hideThinkingBlock is enabled", () => {
-		_setHideThinking(true)
+	it("returns false when acpShowThinking is disabled", () => {
+		_setAcpShowThinking(false)
 		try {
 			expect(shouldEmitThinking("anything")).toBe(false)
 		} finally {
-			_resetHideThinking()
+			_resetAcpShowThinking()
 		}
 	})
 	it("does not break when the persisted thinking text contains a literal </think>", () => {
@@ -4411,14 +4430,14 @@ describe("shouldEmitThinking", () => {
 		// "</think>" closed the wrapper early and the inner text leaked, making
 		// the predicate non-deterministic. Reading the setting directly avoids
 		// the round-trip entirely.
-		_setHideThinking(false)
+		_setAcpShowThinking(true)
 		const haunted = "I'll stop now. </think> trailing"
 		expect(shouldEmitThinking(haunted)).toBe(true)
-		_setHideThinking(true)
+		_setAcpShowThinking(false)
 		try {
 			expect(shouldEmitThinking(haunted)).toBe(false)
 		} finally {
-			_resetHideThinking()
+			_resetAcpShowThinking()
 		}
 	})
 })

--- a/src/modes/acp/server.test.ts
+++ b/src/modes/acp/server.test.ts
@@ -4378,9 +4378,13 @@ describe("KimchiAcpAgent session event handlers", () => {
 })
 
 describe("shouldEmitThinking", () => {
-	it("returns true by default (hideThinkingBlock unset)", () => {
-		_resetHideThinking()
-		expect(shouldEmitThinking("anything")).toBe(true)
+	it("returns true when hideThinkingBlock is disabled", () => {
+		_setHideThinking(false)
+		try {
+			expect(shouldEmitThinking("anything")).toBe(true)
+		} finally {
+			_resetHideThinking()
+		}
 	})
 	it("returns false when hideThinkingBlock is enabled", () => {
 		_setHideThinking(true)
@@ -4396,7 +4400,7 @@ describe("shouldEmitThinking", () => {
 		// "</think>" closed the wrapper early and the inner text leaked, making
 		// the predicate non-deterministic. Reading the setting directly avoids
 		// the round-trip entirely.
-		_resetHideThinking()
+		_setHideThinking(false)
 		const haunted = "I'll stop now. </think> trailing"
 		expect(shouldEmitThinking(haunted)).toBe(true)
 		_setHideThinking(true)

--- a/src/modes/acp/server.test.ts
+++ b/src/modes/acp/server.test.ts
@@ -3534,8 +3534,7 @@ describe("KimchiAcpAgent loadSession", () => {
 	})
 
 	it("routes ANSI-dimmed replay text to thought chunks and strips remaining ANSI", async () => {
-		// hide-thinking-aware models (DeepSeek, QwQ) plus acpShowThinking=true
-		// persist text with ANSI dim escapes around inner <think> content. The
+		// hide-thinking-aware models (DeepSeek, QwQ) persist text with ANSI dim escapes around inner <think> content. The
 		// live TUI renders them as reasoning; ACP's text content type is
 		// plaintext, so replay must preserve that semantic split explicitly.
 		const dimmed = "before \x1b[2minner\x1b[22m after"

--- a/src/modes/acp/server.test.ts
+++ b/src/modes/acp/server.test.ts
@@ -4378,6 +4378,17 @@ describe("KimchiAcpAgent session event handlers", () => {
 })
 
 describe("shouldEmitThinking", () => {
+	it("returns false by default when hideThinkingBlock is not configured", () => {
+		const tempDir = mkdtempSync(join(tmpdir(), "kimchi-acp-hide-thinking-"))
+		vi.stubEnv("KIMCHI_CODING_AGENT_DIR", tempDir)
+		try {
+			_resetHideThinking()
+			expect(shouldEmitThinking("anything")).toBe(false)
+		} finally {
+			vi.unstubAllEnvs()
+			rmSync(tempDir, { recursive: true, force: true })
+		}
+	})
 	it("returns true when hideThinkingBlock is disabled", () => {
 		_setHideThinking(false)
 		try {

--- a/src/modes/acp/server.ts
+++ b/src/modes/acp/server.ts
@@ -2,7 +2,7 @@
 // @agentclientprotocol/sdk. Lets IDE extensions, Zed, openclaw drive kimchi in-process.
 
 import { closeSync, openSync, readFileSync, readSync, readdirSync } from "node:fs"
-import { join, resolve } from "node:path"
+import { join } from "node:path"
 import { Readable, Writable } from "node:stream"
 import {
 	type SessionInfo as AcpSessionInfo,
@@ -761,13 +761,9 @@ export class KimchiAcpAgent implements Agent {
 		const sessionId = session.sessionId
 		const entries = session.sessionManager.getBranch()
 		const toolResults = collectToolResults(entries)
-		// Evaluate hide-thinking once per replay — readHideThinkingSetting()
-		// hits disk synchronously, so a 200-turn session would otherwise do
-		// hundreds of blocking reads.
-		const emitThinking = shouldEmitThinking("")
+
 		for (const entry of entries) {
-			if (!entry || typeof entry !== "object") continue
-			if (entry.type !== "message") continue
+			if (!entry || typeof entry !== "object" || entry.type !== "message") continue
 			const msg = entry.message
 			if (msg.role === "user") {
 				const text = userMessageText(msg.content)
@@ -780,7 +776,7 @@ export class KimchiAcpAgent implements Agent {
 					},
 				})
 			} else if (msg.role === "assistant") {
-				this.replayAssistantBlocks(sessionId, msg.content, toolResults, emitThinking, this.sessions.get(sessionId))
+				this.replayAssistantBlocks(sessionId, msg.content, toolResults, this.sessions.get(sessionId))
 			}
 			// toolResult: handled inline alongside its originating toolCall above.
 		}
@@ -803,7 +799,6 @@ export class KimchiAcpAgent implements Agent {
 	 */
 	private seedBlockCounterFromBranch(session: AgentSession, record: SessionRecord): void {
 		const entries = session.sessionManager.getBranch()
-		const emitThinking = shouldEmitThinking("")
 
 		let count = 0
 		for (const entry of entries) {
@@ -822,14 +817,12 @@ export class KimchiAcpAgent implements Agent {
 				if (block.type === "text") {
 					if (!block.text) continue
 					countTextSegment()
-					if (emitThinking) {
-						for (const part of replayTextParts(block.text)) {
-							if (part.kind === "thinking") count++
-						}
+					for (const part of replayTextParts(block.text)) {
+						if (part.kind === "thinking") count++
 					}
 				} else if (block.type === "thinking") {
 					inTextSegment = false
-					if (!emitThinking || block.redacted || !block.thinking) continue
+					if (block.redacted || !block.thinking) continue
 					count++
 				} else {
 					// toolCall / unknown: replay flushes the text buffer before
@@ -846,7 +839,6 @@ export class KimchiAcpAgent implements Agent {
 		sessionId: string,
 		content: unknown,
 		toolResults: Map<string, ReplayToolResult>,
-		emitThinking: boolean,
 		record: SessionRecord | undefined,
 	): void {
 		if (!Array.isArray(content)) return
@@ -885,7 +877,7 @@ export class KimchiAcpAgent implements Agent {
 				for (const part of replayTextParts(text)) {
 					if (part.kind === "text") {
 						textBuffer += part.text
-					} else if (emitThinking) {
+					} else if (part.kind === "thinking") {
 						flushText()
 						const messageId = nextMessageId()
 						this.send({
@@ -904,9 +896,7 @@ export class KimchiAcpAgent implements Agent {
 				const redacted = (b as { redacted?: unknown }).redacted === true
 				// Redacted thinking has no plaintext to surface — the encrypted
 				// payload only matters for multi-turn provider continuity.
-				if (redacted) continue
-				if (typeof thinking !== "string" || thinking.length === 0) continue
-				if (!emitThinking) continue
+				if (redacted || typeof thinking !== "string" || thinking.length === 0) continue
 				const messageId = nextMessageId()
 				this.send({
 					sessionId,
@@ -1505,50 +1495,6 @@ function collectToolResults(entries: unknown[]): Map<string, ReplayToolResult> {
 		})
 	}
 	return out
-}
-
-// ACP replay surfaces native thinking blocks via agent_thought_chunk. This
-// is controlled by the ACP-specific `acpShowThinking` setting, independent of
-// the live TUI's `hideThinkingBlock`. Default is true so ACP clients see the
-// full transcript unless the user explicitly opts out.
-let acpShowThinkingOverride: boolean | undefined
-
-export function _setAcpShowThinking(value: boolean | undefined): void {
-	acpShowThinkingOverride = value
-}
-
-export function _resetAcpShowThinking(): void {
-	acpShowThinkingOverride = undefined
-}
-
-function getSettingsPath(): string | undefined {
-	const agentDir = process.env.KIMCHI_CODING_AGENT_DIR
-	if (!agentDir) return undefined
-	return resolve(agentDir, "settings.json")
-}
-
-function readAcpShowThinking(): boolean {
-	if (acpShowThinkingOverride !== undefined) return acpShowThinkingOverride
-	const settingsPath = getSettingsPath()
-	if (!settingsPath) return true
-	try {
-		const raw = readFileSync(settingsPath, "utf-8")
-		const parsed = JSON.parse(raw)
-		if (parsed && typeof parsed === "object" && "acpShowThinking" in parsed) {
-			return (parsed as { acpShowThinking?: unknown }).acpShowThinking === true
-		}
-		return true
-	} catch (error) {
-		if (error instanceof Error && (error as NodeJS.ErrnoException).code === "ENOENT") {
-			return true
-		}
-		console.warn(`[acp] could not read ${settingsPath}:`, error)
-		return true
-	}
-}
-
-export function shouldEmitThinking(_thinking: string): boolean {
-	return readAcpShowThinking()
 }
 
 function toolResultContent(result: unknown): ToolCallContent[] {

--- a/src/modes/acp/server.ts
+++ b/src/modes/acp/server.ts
@@ -2,7 +2,7 @@
 // @agentclientprotocol/sdk. Lets IDE extensions, Zed, openclaw drive kimchi in-process.
 
 import { closeSync, openSync, readFileSync, readSync, readdirSync } from "node:fs"
-import { join } from "node:path"
+import { join, resolve } from "node:path"
 import { Readable, Writable } from "node:stream"
 import {
 	type SessionInfo as AcpSessionInfo,
@@ -55,7 +55,7 @@ import {
 	initTheme,
 } from "@earendil-works/pi-coding-agent"
 import type { AgentSessionEvent, ExtensionUIContext } from "@earendil-works/pi-coding-agent"
-import { isHideThinkingEnabled } from "../../extensions/hide-thinking.js"
+
 import { loadConfig } from "../../extensions/permissions/config.js"
 import { PERMISSIONS_ENV_KEY } from "../../extensions/permissions/constants.js"
 import {
@@ -1507,16 +1507,48 @@ function collectToolResults(entries: unknown[]): Map<string, ReplayToolResult> {
 	return out
 }
 
-// Native ThinkingContent blocks aren't routed through hideThinkingExtension
-// (which only mutates <think> tags inside text blocks), but the replay UX
-// should still honor the user's hideThinkingBlock setting — otherwise a user
-// who hides thinking sees a quiet live UI but a noisy replayed transcript.
-// Read the setting directly: a previous version probed filterThinkingForDisplay
-// with a synthetic <think>...</think> wrapper, which broke when the persisted
-// thinking text itself contained `</think>` (the inner regex terminated early
-// and the predicate falsely returned true).
+// ACP replay surfaces native thinking blocks via agent_thought_chunk. This
+// is controlled by the ACP-specific `acpShowThinking` setting, independent of
+// the live TUI's `hideThinkingBlock`. Default is true so ACP clients see the
+// full transcript unless the user explicitly opts out.
+let acpShowThinkingOverride: boolean | undefined
+
+export function _setAcpShowThinking(value: boolean | undefined): void {
+	acpShowThinkingOverride = value
+}
+
+export function _resetAcpShowThinking(): void {
+	acpShowThinkingOverride = undefined
+}
+
+function getSettingsPath(): string | undefined {
+	const agentDir = process.env.KIMCHI_CODING_AGENT_DIR
+	if (!agentDir) return undefined
+	return resolve(agentDir, "settings.json")
+}
+
+function readAcpShowThinking(): boolean {
+	if (acpShowThinkingOverride !== undefined) return acpShowThinkingOverride
+	const settingsPath = getSettingsPath()
+	if (!settingsPath) return true
+	try {
+		const raw = readFileSync(settingsPath, "utf-8")
+		const parsed = JSON.parse(raw)
+		if (parsed && typeof parsed === "object" && "acpShowThinking" in parsed) {
+			return (parsed as { acpShowThinking?: unknown }).acpShowThinking === true
+		}
+		return true
+	} catch (error) {
+		if (error instanceof Error && (error as NodeJS.ErrnoException).code === "ENOENT") {
+			return true
+		}
+		console.warn(`[acp] could not read ${settingsPath}:`, error)
+		return true
+	}
+}
+
 export function shouldEmitThinking(_thinking: string): boolean {
-	return !isHideThinkingEnabled()
+	return readAcpShowThinking()
 }
 
 function toolResultContent(result: unknown): ToolCallContent[] {

--- a/tests/e2e/tui/support/kimchi-fixture.ts
+++ b/tests/e2e/tui/support/kimchi-fixture.ts
@@ -144,7 +144,7 @@ export async function createKimchiFixture(options: CreateKimchiFixtureOptions): 
 		// (context, agents, phase, usage) and change the terminal layout for every test.
 		writeFileSync(
 			join(agentDir, "settings.json"),
-			JSON.stringify({ footer: { pinned: [] } }, null, "\t"),
+			JSON.stringify({ footer: { pinned: [] }, hideThinkingBlock: true }, null, "\t"),
 			"utf-8",
 		)
 

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -9,6 +9,10 @@ export default defineConfig({
 			// Pin locale so toLocaleString() produces consistent comma-separated
 			// numbers across developer machines and CI regardless of system locale.
 			LANG: "en_US.UTF-8",
+			// Clear any external PI_PACKAGE_DIR override so upstream theme file
+			// resolution uses its own package detection inside tests rather than
+			// following a stale install prefix.
+			PI_PACKAGE_DIR: "",
 		},
 		alias: {
 			// The deep-import path used in clipboard-read.ts is not in the package's


### PR DESCRIPTION
## Summary

New users get thinking blocks hidden by default — a cleaner, collapsed-thinking UI out of the box.

This also applies when `settings.json` already exists but never had the setting (e.g. partial configs from tests or older installs). Previously those sessions could still show expanded thinking in the TUI while tag-based thinking was hidden, so the default did not feel consistent on startup.

Existing explicit choices (`hideThinkingBlock: false` to show dimmed thinking) are unchanged.

## Test plan

- [x] `pnpm exec vitest run src/extensions/hide-thinking.test.ts`
- [x] `pnpm exec vitest run src/config.test.ts -t ensureHideThinkingBlockDefault`
- [x] Fresh start with no `settings.json` — thinking collapsed/hidden
- [x] Fresh start with partial `settings.json` (no `hideThinkingBlock` key) — thinking collapsed/hidden after startup
- [x] Set `hideThinkingBlock: false` in settings — thinking visible/dimmed again

Closes #0