### PR TITLE
feat(lsp): idle-timeout shutdown for LSP servers

### DIFF
--- a/src/extensions/lsp.test.ts
+++ b/src/extensions/lsp.test.ts
@@ -17,6 +17,7 @@ vi.mock("./lsp/client.js", () => ({
 	refreshFile: vi.fn(),
 	sendRequest: vi.fn(),
 	shutdownAll: vi.fn(),
+	shutdownIdleClients: vi.fn(),
 	waitForDiagnostics: vi.fn(),
 }))
 
@@ -974,6 +975,74 @@ describe("lsp_rename", () => {
 		})
 		expect(result.content[0].text).toContain("src/a.ts: 1 edit(s)")
 		expect(editsMod.applyWorkspaceEdit).toHaveBeenCalledTimes(1)
+	})
+})
+
+// =============================================================================
+// 12. Idle sweep timer
+// =============================================================================
+
+describe("idle sweep timer", () => {
+	beforeEach(() => {
+		vi.useFakeTimers()
+	})
+
+	afterEach(() => {
+		vi.useRealTimers()
+	})
+
+	it("starts an idle sweep interval on session_start when servers are detected", async () => {
+		vi.mocked(serversMod.detectServers).mockReturnValue([FAKE_SERVER])
+		const pi = makePi()
+		lspExtension(pi)
+		await pi.fireSessionStart()
+
+		vi.advanceTimersByTime(60_000)
+		expect(clientMod.shutdownIdleClients).toHaveBeenCalled()
+	})
+
+	it("passes the 15-minute threshold to shutdownIdleClients", async () => {
+		vi.mocked(serversMod.detectServers).mockReturnValue([FAKE_SERVER])
+		const pi = makePi()
+		lspExtension(pi)
+		await pi.fireSessionStart()
+
+		vi.advanceTimersByTime(60_000)
+		expect(clientMod.shutdownIdleClients).toHaveBeenCalledWith(15 * 60 * 1000)
+	})
+
+	it("does not start the sweep when no servers are detected", async () => {
+		vi.mocked(serversMod.detectServers).mockReturnValue([])
+		const pi = makePi()
+		lspExtension(pi)
+		await pi.fireSessionStart()
+
+		vi.advanceTimersByTime(60_000)
+		expect(clientMod.shutdownIdleClients).not.toHaveBeenCalled()
+	})
+
+	it("clears the sweep interval on session_shutdown", async () => {
+		vi.mocked(serversMod.detectServers).mockReturnValue([FAKE_SERVER])
+		const pi = makePi()
+		lspExtension(pi)
+		await pi.fireSessionStart()
+
+		await pi.fireShutdown()
+
+		vi.mocked(clientMod.shutdownIdleClients).mockClear()
+		vi.advanceTimersByTime(120_000)
+		expect(clientMod.shutdownIdleClients).not.toHaveBeenCalled()
+	})
+
+	it("does not start a duplicate sweep if session_start fires twice", async () => {
+		vi.mocked(serversMod.detectServers).mockReturnValue([FAKE_SERVER])
+		const pi = makePi()
+		lspExtension(pi)
+		await pi.fireSessionStart()
+		await pi.fireSessionStart()
+
+		vi.advanceTimersByTime(60_000)
+		expect(clientMod.shutdownIdleClients).toHaveBeenCalledTimes(1)
 	})
 })
 

--- a/src/extensions/lsp.test.ts
+++ b/src/extensions/lsp.test.ts
@@ -1044,6 +1044,22 @@ describe("idle sweep timer", () => {
 		vi.advanceTimersByTime(60_000)
 		expect(clientMod.shutdownIdleClients).toHaveBeenCalledTimes(1)
 	})
+
+	it("clears a prior sweep when a later session_start detects no servers", async () => {
+		// First session: servers detected → sweep started
+		vi.mocked(serversMod.detectServers).mockReturnValue([FAKE_SERVER])
+		const pi = makePi()
+		lspExtension(pi)
+		await pi.fireSessionStart()
+
+		// Second session: no servers → sweep must be cleared
+		vi.mocked(serversMod.detectServers).mockReturnValue([])
+		vi.mocked(clientMod.shutdownIdleClients).mockClear()
+		await pi.fireSessionStart()
+
+		vi.advanceTimersByTime(120_000)
+		expect(clientMod.shutdownIdleClients).not.toHaveBeenCalled()
+	})
 })
 
 // =============================================================================

--- a/src/extensions/lsp.ts
+++ b/src/extensions/lsp.ts
@@ -77,15 +77,27 @@ export default function (pi: ExtensionAPI) {
 	pi.on("session_start", async (_event, ctx) => {
 		cwd = ctx.cwd
 		ui = ctx.hasUI ? ctx.ui : undefined
+
+		// Clear any previous sweep timer first. This must happen before the
+		// no-servers early return, otherwise a prior session's interval leaks
+		// and keeps sweeping the module-level clients map.
+		if (idleSweepTimer) {
+			clearInterval(idleSweepTimer)
+			idleSweepTimer = null
+		}
+
 		activeServers = detectServers(cwd)
 		if (activeServers.length === 0) return
 
 		// Start idle sweep — shut down LSP servers after 15 min of inactivity.
-		// Clear any previous timer first to prevent duplicates on session restart.
-		if (idleSweepTimer) clearInterval(idleSweepTimer)
+		// unref() so the timer doesn't keep the process alive if session_shutdown
+		// is never fired (e.g. unexpected exit).
 		idleSweepTimer = setInterval(() => {
 			shutdownIdleClients(IDLE_THRESHOLD_MS)
 		}, IDLE_SWEEP_INTERVAL_MS)
+		if (typeof idleSweepTimer === "object" && "unref" in idleSweepTimer) {
+			idleSweepTimer.unref()
+		}
 
 		// Update status bar with detected server names
 		if (ui) {

--- a/src/extensions/lsp.ts
+++ b/src/extensions/lsp.ts
@@ -19,6 +19,7 @@ import {
 	refreshFile,
 	sendRequest,
 	shutdownAll,
+	shutdownIdleClients,
 	waitForDiagnostics,
 } from "./lsp/client.js"
 import { applyWorkspaceEdit } from "./lsp/edits.js"
@@ -34,6 +35,8 @@ export function clientCwd(filePath: string, sessionCwd: string): string {
 
 const LSP_DIAGNOSTICS_CUSTOM_TYPE = "lsp_diagnostics"
 const DIAG_WAIT_TIMEOUT_MS = 2000
+const IDLE_THRESHOLD_MS = 15 * 60 * 1000 // 15 minutes
+const IDLE_SWEEP_INTERVAL_MS = 60 * 1000 // check every 60s
 
 const LSP_SYSTEM_PROMPT = `## Language Server Protocol (LSP)
 
@@ -56,6 +59,7 @@ export default function (pi: ExtensionAPI) {
 	// controller is combined with ctx.signal so user/session aborts also unwind
 	// the wait, but we never abort ctx.signal ourselves.
 	let pendingRefresh: { abort: AbortController } | undefined
+	let idleSweepTimer: ReturnType<typeof setInterval> | null = null
 
 	function cancelPendingRefresh(): void {
 		if (!pendingRefresh) return
@@ -76,6 +80,13 @@ export default function (pi: ExtensionAPI) {
 		activeServers = detectServers(cwd)
 		if (activeServers.length === 0) return
 
+		// Start idle sweep — shut down LSP servers after 15 min of inactivity.
+		// Clear any previous timer first to prevent duplicates on session restart.
+		if (idleSweepTimer) clearInterval(idleSweepTimer)
+		idleSweepTimer = setInterval(() => {
+			shutdownIdleClients(IDLE_THRESHOLD_MS)
+		}, IDLE_SWEEP_INTERVAL_MS)
+
 		// Update status bar with detected server names
 		if (ui) {
 			const names = activeServers.map((s) => s.name).join(", ")
@@ -93,6 +104,10 @@ export default function (pi: ExtensionAPI) {
 	})
 
 	pi.on("session_shutdown", async () => {
+		if (idleSweepTimer) {
+			clearInterval(idleSweepTimer)
+			idleSweepTimer = null
+		}
 		cancelPendingRefresh()
 		if (ui) {
 			ui.setStatus("lsp", undefined)

--- a/src/extensions/lsp.ts
+++ b/src/extensions/lsp.ts
@@ -59,7 +59,7 @@ export default function (pi: ExtensionAPI) {
 	// controller is combined with ctx.signal so user/session aborts also unwind
 	// the wait, but we never abort ctx.signal ourselves.
 	let pendingRefresh: { abort: AbortController } | undefined
-	let idleSweepTimer: ReturnType<typeof setInterval> | null = null
+	let idleSweepTimer: NodeJS.Timeout | null = null
 
 	function cancelPendingRefresh(): void {
 		if (!pendingRefresh) return
@@ -95,9 +95,7 @@ export default function (pi: ExtensionAPI) {
 		idleSweepTimer = setInterval(() => {
 			shutdownIdleClients(IDLE_THRESHOLD_MS)
 		}, IDLE_SWEEP_INTERVAL_MS)
-		if (typeof idleSweepTimer === "object" && "unref" in idleSweepTimer) {
-			idleSweepTimer.unref()
-		}
+		idleSweepTimer.unref()
 
 		// Update status bar with detected server names
 		if (ui) {

--- a/src/extensions/lsp/client.test.ts
+++ b/src/extensions/lsp/client.test.ts
@@ -147,7 +147,7 @@ describe("shutdownIdleClientsIn", () => {
 		// before proc.kill() runs. Verify both were called and in the right order.
 		expect(stdinWriteMock).toHaveBeenCalledTimes(1)
 		expect(killMock).toHaveBeenCalledTimes(1)
-		expect(stdinWriteMock).toHaveBeenCalledBefore(killMock)
+		expect(stdinWriteMock.mock.invocationCallOrder[0]).toBeLessThan(killMock.mock.invocationCallOrder[0])
 
 		// Verify the written message contains the shutdown method
 		const writtenData = stdinWriteMock.mock.calls[0][0] as string
@@ -176,5 +176,65 @@ describe("shutdownIdleClientsIn", () => {
 		const lockMap = new Map<string, Promise<LspClient>>()
 
 		expect(() => shutdownIdleClientsIn(clientMap, lockMap, THRESHOLD, FIXED_NOW)).not.toThrow()
+	})
+
+	it("preserves a client mid-initialize (pending 'initialize' request)", () => {
+		// Simulate a client whose initialize request is still in flight.
+		// This is the high-stakes scenario: killing mid-initialize orphans
+		// a half-started server and wastes the expensive project-load.
+		const { client, killMock } = makeFakeClient({
+			lastActivity: FIXED_NOW - THRESHOLD - 1,
+			pendingRequestsCount: 1,
+		})
+		// Overwrite the generic hover entry with a realistic initialize entry
+		client.pendingRequests.clear()
+		client.pendingRequests.set(1, {
+			resolve: vi.fn(),
+			reject: vi.fn(),
+			method: "initialize",
+		})
+		const clientMap = new Map([["gopls:/project", client]])
+		const lockMap = new Map<string, Promise<LspClient>>()
+
+		shutdownIdleClientsIn(clientMap, lockMap, THRESHOLD, FIXED_NOW)
+
+		expect(killMock).not.toHaveBeenCalled()
+		expect(clientMap.has("gopls:/project")).toBe(true)
+	})
+
+	it("does not throw when proc.kill() throws (already-dead process)", () => {
+		const { client } = makeFakeClient({ lastActivity: FIXED_NOW - THRESHOLD - 1 })
+		// Simulate kill throwing on an already-exited process
+		client.proc.kill = () => {
+			throw new Error("Process already exited")
+		}
+		const clientMap = new Map([["gopls:/project", client]])
+		const lockMap = new Map<string, Promise<LspClient>>()
+
+		expect(() => shutdownIdleClientsIn(clientMap, lockMap, THRESHOLD, FIXED_NOW)).not.toThrow()
+		// Client was still removed from the map (deletion happens before kill)
+		expect(clientMap.has("gopls:/project")).toBe(false)
+	})
+
+	it("continues sweeping remaining clients when one throws during shutdown", () => {
+		// First client: stdin.write throws synchronously (simulates sendRequest throw)
+		const broken = makeFakeClient({ lastActivity: FIXED_NOW - THRESHOLD - 1 })
+		broken.stdinWriteMock.mockImplementation(() => {
+			throw new Error("stdin closed")
+		})
+		// Second client: normal idle client
+		const healthy = makeFakeClient({ lastActivity: FIXED_NOW - THRESHOLD - 1 })
+
+		const clientMap = new Map([
+			["gopls:/broken", broken.client],
+			["gopls:/healthy", healthy.client],
+		])
+		const lockMap = new Map<string, Promise<LspClient>>()
+
+		expect(() => shutdownIdleClientsIn(clientMap, lockMap, THRESHOLD, FIXED_NOW)).not.toThrow()
+		// Both clients removed from map and killed
+		expect(clientMap.size).toBe(0)
+		expect(broken.killMock).toHaveBeenCalledTimes(1)
+		expect(healthy.killMock).toHaveBeenCalledTimes(1)
 	})
 })

--- a/src/extensions/lsp/client.test.ts
+++ b/src/extensions/lsp/client.test.ts
@@ -1,0 +1,180 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
+import { shutdownIdleClientsIn } from "./client.js"
+import type { LspClient, PendingRequest } from "./types.js"
+
+// =============================================================================
+// Test helpers
+// =============================================================================
+
+const FIXED_NOW = 1_000_000_000
+const THRESHOLD = 15 * 60 * 1000
+
+/**
+ * Build a minimal fake LspClient with only the fields that shutdownIdleClientsIn
+ * and sendRequest touch. Cast through unknown to avoid filling in every field
+ * of the LspClient interface.
+ */
+function makeFakeClient(opts: {
+	lastActivity?: number
+	pendingRequestsCount?: number
+	progressTokenCount?: number
+}): { client: LspClient; killMock: ReturnType<typeof vi.fn>; stdinWriteMock: ReturnType<typeof vi.fn> } {
+	const killMock = vi.fn()
+	const stdinWriteMock = vi.fn()
+	const stdinFlushMock = vi.fn().mockResolvedValue(undefined)
+
+	const pendingRequests = new Map<number, PendingRequest>()
+	for (let i = 0; i < (opts.pendingRequestsCount ?? 0); i++) {
+		pendingRequests.set(i + 1, {
+			resolve: vi.fn(),
+			reject: vi.fn(),
+			method: "textDocument/hover",
+		})
+	}
+
+	const activeProgressTokens = new Set<string | number>()
+	for (let i = 0; i < (opts.progressTokenCount ?? 0); i++) {
+		activeProgressTokens.add(`token-${i}`)
+	}
+
+	const client = {
+		name: "gopls:/project",
+		cwd: "/project",
+		proc: {
+			stdin: { write: stdinWriteMock, flush: stdinFlushMock, end: vi.fn() },
+			stdout: new ReadableStream(),
+			stderr: new ReadableStream(),
+			kill: killMock,
+			exited: new Promise<void>(() => {}),
+			exitCode: null,
+		},
+		requestId: 0,
+		lastActivity: opts.lastActivity ?? FIXED_NOW,
+		pendingRequests,
+		activeProgressTokens,
+	} as unknown as LspClient
+
+	return { client, killMock, stdinWriteMock }
+}
+
+// =============================================================================
+// Setup / teardown
+// =============================================================================
+
+beforeEach(() => {
+	vi.useFakeTimers()
+	vi.setSystemTime(FIXED_NOW)
+})
+
+afterEach(() => {
+	vi.clearAllTimers()
+	vi.useRealTimers()
+})
+
+// =============================================================================
+// shutdownIdleClientsIn
+// =============================================================================
+
+describe("shutdownIdleClientsIn", () => {
+	it("does not shut down a client within the idle threshold", () => {
+		const { client, killMock } = makeFakeClient({ lastActivity: FIXED_NOW - 60_000 }) // 1 min ago
+		const clientMap = new Map([["gopls:/project", client]])
+		const lockMap = new Map<string, Promise<LspClient>>()
+
+		shutdownIdleClientsIn(clientMap, lockMap, THRESHOLD, FIXED_NOW)
+
+		expect(killMock).not.toHaveBeenCalled()
+		expect(clientMap.has("gopls:/project")).toBe(true)
+	})
+
+	it("shuts down a client whose lastActivity exceeds the threshold", () => {
+		const { client, killMock } = makeFakeClient({ lastActivity: FIXED_NOW - THRESHOLD - 1 })
+		const clientMap = new Map([["gopls:/project", client]])
+		const lockMap = new Map<string, Promise<LspClient>>()
+
+		shutdownIdleClientsIn(clientMap, lockMap, THRESHOLD, FIXED_NOW)
+
+		expect(killMock).toHaveBeenCalledTimes(1)
+		expect(clientMap.has("gopls:/project")).toBe(false)
+	})
+
+	it("removes the client from the lock map after shutdown", () => {
+		const { client } = makeFakeClient({ lastActivity: FIXED_NOW - THRESHOLD - 1 })
+		const clientMap = new Map([["gopls:/project", client]])
+		const lockMap = new Map<string, Promise<LspClient>>([["gopls:/project", Promise.resolve(client)]])
+
+		shutdownIdleClientsIn(clientMap, lockMap, THRESHOLD, FIXED_NOW)
+
+		expect(lockMap.has("gopls:/project")).toBe(false)
+	})
+
+	it("does not shut down a client with pending requests", () => {
+		const { client, killMock } = makeFakeClient({
+			lastActivity: FIXED_NOW - THRESHOLD - 1,
+			pendingRequestsCount: 1,
+		})
+		const clientMap = new Map([["gopls:/project", client]])
+		const lockMap = new Map<string, Promise<LspClient>>()
+
+		shutdownIdleClientsIn(clientMap, lockMap, THRESHOLD, FIXED_NOW)
+
+		expect(killMock).not.toHaveBeenCalled()
+		expect(clientMap.has("gopls:/project")).toBe(true)
+	})
+
+	it("does not shut down a client with active progress tokens", () => {
+		const { client, killMock } = makeFakeClient({
+			lastActivity: FIXED_NOW - THRESHOLD - 1,
+			progressTokenCount: 1,
+		})
+		const clientMap = new Map([["gopls:/project", client]])
+		const lockMap = new Map<string, Promise<LspClient>>()
+
+		shutdownIdleClientsIn(clientMap, lockMap, THRESHOLD, FIXED_NOW)
+
+		expect(killMock).not.toHaveBeenCalled()
+		expect(clientMap.has("gopls:/project")).toBe(true)
+	})
+
+	it("sends LSP shutdown request before killing the process", () => {
+		const { client, killMock, stdinWriteMock } = makeFakeClient({ lastActivity: FIXED_NOW - THRESHOLD - 1 })
+		const clientMap = new Map([["gopls:/project", client]])
+		const lockMap = new Map<string, Promise<LspClient>>()
+
+		shutdownIdleClientsIn(clientMap, lockMap, THRESHOLD, FIXED_NOW)
+
+		// stdinWrite is called synchronously by writeMessage inside sendRequest,
+		// before proc.kill() runs. Verify both were called and in the right order.
+		expect(stdinWriteMock).toHaveBeenCalledTimes(1)
+		expect(killMock).toHaveBeenCalledTimes(1)
+		expect(stdinWriteMock).toHaveBeenCalledBefore(killMock)
+
+		// Verify the written message contains the shutdown method
+		const writtenData = stdinWriteMock.mock.calls[0][0] as string
+		expect(writtenData).toContain('"shutdown"')
+	})
+
+	it("handles multiple clients — shuts down only idle ones", () => {
+		const idleClient = makeFakeClient({ lastActivity: FIXED_NOW - THRESHOLD - 1 })
+		const activeClient = makeFakeClient({ lastActivity: FIXED_NOW - 30_000 })
+		const clientMap = new Map([
+			["gopls:/idle", idleClient.client],
+			["gopls:/active", activeClient.client],
+		])
+		const lockMap = new Map<string, Promise<LspClient>>()
+
+		shutdownIdleClientsIn(clientMap, lockMap, THRESHOLD, FIXED_NOW)
+
+		expect(idleClient.killMock).toHaveBeenCalledTimes(1)
+		expect(activeClient.killMock).not.toHaveBeenCalled()
+		expect(clientMap.has("gopls:/idle")).toBe(false)
+		expect(clientMap.has("gopls:/active")).toBe(true)
+	})
+
+	it("handles an empty map without error", () => {
+		const clientMap = new Map<string, LspClient>()
+		const lockMap = new Map<string, Promise<LspClient>>()
+
+		expect(() => shutdownIdleClientsIn(clientMap, lockMap, THRESHOLD, FIXED_NOW)).not.toThrow()
+	})
+})

--- a/src/extensions/lsp/client.ts
+++ b/src/extensions/lsp/client.ts
@@ -285,6 +285,60 @@ export function shutdownAll(): void {
 	}
 }
 
+/**
+ * Shut down LSP clients that have been idle for longer than `thresholdMs`.
+ *
+ * A client is considered idle when:
+ *   - No pending requests are in flight
+ *   - No active progress tokens (project loading / indexing)
+ *   - `lastActivity` is older than `thresholdMs`
+ *
+ * Fully synchronous — no awaits between the idle check and map deletion +
+ * process kill. JS single-threading guarantees getOrCreateClient's synchronous
+ * cache-hit path cannot interleave: either the sweep runs first (client evicted,
+ * next call spawns fresh) or getOrCreateClient runs first (updates lastActivity,
+ * sweep skips). No locking required.
+ *
+ * @param clientMap   The clients map to sweep
+ * @param lockMap     The client locks map
+ * @param thresholdMs Idle duration before shutdown
+ * @param now         Current timestamp (injectable for testing)
+ */
+export function shutdownIdleClientsIn(
+	clientMap: Map<string, LspClient>,
+	lockMap: Map<string, Promise<LspClient>>,
+	thresholdMs: number,
+	now: number = Date.now(),
+): void {
+	for (const [key, client] of clientMap) {
+		if (client.pendingRequests.size > 0) continue
+		if (client.activeProgressTokens.size > 0) continue
+
+		const idleMs = now - client.lastActivity
+		if (idleMs < thresholdMs) continue
+
+		// Remove from maps BEFORE killing so getOrCreateClient can't return
+		// a dying client. Both operations are synchronous — no event-loop turn
+		// between them.
+		clientMap.delete(key)
+		lockMap.delete(key)
+
+		// Best-effort graceful LSP shutdown, then kill. The shutdown request
+		// adds a pending entry; the proc.exited handler (fired by proc.kill())
+		// rejects it during process teardown.
+		sendRequest(client, "shutdown", null).catch(() => {})
+		client.proc.kill()
+	}
+}
+
+/**
+ * Sweep the module-level `clients` map and shut down idle LSP servers.
+ * Thin wrapper around `shutdownIdleClientsIn` for production use.
+ */
+export function shutdownIdleClients(thresholdMs: number): void {
+	shutdownIdleClientsIn(clients, clientLocks, thresholdMs)
+}
+
 // =============================================================================
 // Protocol
 // =============================================================================

--- a/src/extensions/lsp/client.ts
+++ b/src/extensions/lsp/client.ts
@@ -323,11 +323,29 @@ export function shutdownIdleClientsIn(
 		clientMap.delete(key)
 		lockMap.delete(key)
 
-		// Best-effort graceful LSP shutdown, then kill. The shutdown request
-		// adds a pending entry; the proc.exited handler (fired by proc.kill())
-		// rejects it during process teardown.
-		sendRequest(client, "shutdown", null).catch(() => {})
-		client.proc.kill()
+		// Fire-and-forget LSP shutdown request, then immediately kill.
+		// We intentionally do NOT await the shutdown response or send the
+		// LSP "exit" notification before killing. This mirrors the existing
+		// shutdownAll() pattern and keeps shutdownIdleClientsIn synchronous,
+		// which is what allows the no-lock concurrency argument to hold (no
+		// event-loop turn between the idle check and kill). The client has
+		// been idle for 15+ minutes with no pending work, so there is nothing
+		// to lose. gopls and typescript-language-server both handle SIGKILL
+		// cleanly.
+		//
+		// Each step is wrapped individually so a failure in one client
+		// cannot abort the sweep for remaining clients (this runs inside a
+		// setInterval callback).
+		try {
+			sendRequest(client, "shutdown", null).catch(() => {})
+		} catch {
+			// sendRequest threw synchronously (e.g. stdin already closed)
+		}
+		try {
+			client.proc.kill()
+		} catch {
+			// Process may already be dead.
+		}
 	}
 }
 


### PR DESCRIPTION
## Linked issue

Closes #808

## What does this PR do?

Introduces a background sweeper for idle servers. If a server is idle for too long (15 minute hard threshold now), it is stopped and will have to be started again. This is a tradeoff between latency to restart a server sometimes (and let it do its processing) vs idle resource usage. 

### How it works

 A 60-second setInterval sweep checks each live LSP client against three conditions:
 - No pending requests in flight
 - No active progress tokens (project loading/indexing)
 - lastActivity older than 15 minutes

 Idle clients get a best-effort LSP shutdown request followed by proc.kill(). Map entries are deleted synchronously before kill so getOrCreateClient never returns a dying client — JS single-threading guarantees no interleaving with the
 synchronous cache-hit path.

 The next LSP tool call transparently spawns a fresh server.

 ### Changes

 - src/extensions/lsp/client.ts — shutdownIdleClientsIn() (testable, injectable maps + timestamp) and shutdownIdleClients() (thin wrapper over module-level state). Per-client shutdown body is guarded with try/catch so an already-dead
   process can't crash the interval callback.
 - src/extensions/lsp.ts — Starts the sweep interval on session_start (when servers are detected), clears it on session_shutdown. Timer clear runs before the no-servers early return to prevent leaking a prior session's interval.
 - src/extensions/lsp/client.test.ts — 10 tests covering: idle vs active threshold, pending requests, progress tokens, lock map cleanup, graceful shutdown ordering, multi-client selective sweep, empty map, mid-initialize preservation,
   and proc.kill throwing.
 - src/extensions/lsp.test.ts — 6 wiring tests: interval start, threshold value, no-servers skip, shutdown cleanup, duplicate-start prevention, and stale-sweep-after-no-servers regression.


## Checklist

- [ x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md) and agree to the CLA
- [ x] This PR links to an open issue above
- [ x] Tests pass locally (`pnpm run test`) (some tests seem to fail but they are in files unrelated to change)
- [ x] Lint passes (`pnpm run check`)
- [ x] Documentation updated if behavior changed -> not needed?
