### PR TITLE
feat(lsp): surface degraded state when LSP binary is missing

### DIFF
--- a/src/extensions/lsp.test.ts
+++ b/src/extensions/lsp.test.ts
@@ -167,6 +167,7 @@ const FAKE_SERVER = {
 	command: "typescript-language-server",
 	args: ["--stdio"],
 	extensions: ["ts", "tsx"],
+	installHint: "npm i -g typescript-language-server typescript",
 }
 
 const FAKE_GO_SERVER = {
@@ -174,6 +175,7 @@ const FAKE_GO_SERVER = {
 	command: "gopls",
 	args: [],
 	extensions: ["go"],
+	installHint: "go install golang.org/x/tools/gopls@latest",
 }
 
 async function callTool(
@@ -481,7 +483,42 @@ describe("no regression when a server is present", () => {
 })
 
 // =============================================================================
-// 5. tool_result handler
+// 4c. Edge cases from PR review
+// =============================================================================
+
+describe("warned flag reset on session_start", () => {
+	it("allows a one-time warning in a new session after session_shutdown", async () => {
+		vi.mocked(serversMod.detectServers).mockReturnValue([])
+		vi.mocked(serversMod.detectMissingCandidates).mockReturnValue([FAKE_GO_SERVER])
+		const notify = vi.fn()
+		const pi = makePi()
+		lspExtension(pi)
+		// First session: warning fires
+		await pi.fireSessionStart({ hasUI: true, ui: { setStatus: vi.fn(), notify } })
+		await pi.fireBeforeAgentStart()
+		expect(notify).toHaveBeenCalledTimes(1)
+		// Shutdown resets warned
+		await pi.fireShutdown()
+		// Second session: warning should fire again
+		const notify2 = vi.fn()
+		await pi.fireSessionStart({ hasUI: true, ui: { setStatus: vi.fn(), notify: notify2 } })
+		await pi.fireBeforeAgentStart()
+		expect(notify2).toHaveBeenCalledTimes(1)
+	})
+})
+
+describe("ui.notify absent", () => {
+	it("does not throw when ui lacks notify method", async () => {
+		vi.mocked(serversMod.detectServers).mockReturnValue([])
+		vi.mocked(serversMod.detectMissingCandidates).mockReturnValue([FAKE_GO_SERVER])
+		const setStatus = vi.fn()
+		const pi = makePi()
+		lspExtension(pi)
+		await pi.fireSessionStart({ hasUI: true, ui: { setStatus } })
+		// Should not throw — notify is absent so the handler should no-op
+		await expect(pi.fireBeforeAgentStart()).resolves.toBeUndefined()
+	})
+})
 // =============================================================================
 
 describe("tool_result handler", () => {

--- a/src/extensions/lsp.test.ts
+++ b/src/extensions/lsp.test.ts
@@ -402,6 +402,16 @@ describe("degraded status (marker present, binary missing)", () => {
 		await pi.fireSessionStart({ hasUI: true, ui: { setStatus, notify: vi.fn() } })
 		expect(setStatus).not.toHaveBeenCalled()
 	})
+
+	it("shows both active and degraded servers in a mixed repo", async () => {
+		vi.mocked(serversMod.detectServers).mockReturnValue([FAKE_SERVER])
+		vi.mocked(serversMod.detectMissingCandidates).mockReturnValue([FAKE_GO_SERVER])
+		const setStatus = vi.fn()
+		const pi = makePi()
+		lspExtension(pi)
+		await pi.fireSessionStart({ hasUI: true, ui: { setStatus, notify: vi.fn() } })
+		expect(setStatus).toHaveBeenCalledWith("lsp", `LSP: ${FAKE_SERVER.name} · ${FAKE_GO_SERVER.name} not installed`)
+	})
 })
 
 describe("one-time warning on before_agent_start", () => {

--- a/src/extensions/lsp.test.ts
+++ b/src/extensions/lsp.test.ts
@@ -7,6 +7,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
 
 vi.mock("./lsp/servers.js", () => ({
 	detectServers: vi.fn(),
+	detectMissingCandidates: vi.fn(),
 	serverForFile: vi.fn(),
 	findRoot: vi.fn(),
 }))
@@ -49,13 +50,14 @@ interface PiStub extends ExtensionAPI {
 	fireShutdown: () => Promise<void>
 	fireToolResult: (event: unknown) => Promise<void>
 	fireSessionStart: (ctx?: Partial<SessionStartCtx>) => Promise<void>
+	fireBeforeAgentStart: () => Promise<void>
 	capturedBlocks: SystemPromptBlockStub[]
 }
 
 interface SessionStartCtx {
 	cwd: string
 	hasUI: boolean
-	ui: { setStatus: ReturnType<typeof vi.fn> }
+	ui: { setStatus: ReturnType<typeof vi.fn>; notify?: ReturnType<typeof vi.fn> }
 }
 
 interface SystemPromptBlockStub {
@@ -116,7 +118,7 @@ function makePi(): PiStub {
 			}
 		},
 		fireSessionStart: async (ctx: Partial<SessionStartCtx> = {}) => {
-			const defaultUi = { setStatus: vi.fn(), theme: { fg: (_c: string, s: string) => s } }
+			const defaultUi = { setStatus: vi.fn(), notify: vi.fn(), theme: { fg: (_c: string, s: string) => s } }
 			const full: SessionStartCtx = {
 				cwd: ctx.cwd ?? DEFAULT_CWD,
 				hasUI: ctx.hasUI ?? false,
@@ -124,6 +126,11 @@ function makePi(): PiStub {
 			}
 			for (const h of handlers.get("session_start") ?? []) {
 				await h({}, full)
+			}
+		},
+		fireBeforeAgentStart: async () => {
+			for (const h of handlers.get("before_agent_start") ?? []) {
+				await h({}, {})
 			}
 		},
 	} as unknown as PiStub
@@ -186,6 +193,7 @@ async function callTool(
 
 beforeEach(() => {
 	vi.mocked(serversMod.detectServers).mockReturnValue([])
+	vi.mocked(serversMod.detectMissingCandidates).mockReturnValue([])
 	vi.mocked(serversMod.serverForFile).mockReturnValue(null)
 	vi.mocked(serversMod.findRoot).mockImplementation((_fp: string, _sn: string, sessionCwd: string) => sessionCwd)
 	vi.mocked(clientMod.getOrCreateClient).mockResolvedValue(
@@ -309,9 +317,11 @@ describe("system prompt block", () => {
 		expect(block).toBeDefined()
 	})
 
-	it("lsp-tools block renders LSP guidance text", () => {
+	it("lsp-tools block renders LSP guidance text", async () => {
+		vi.mocked(serversMod.detectServers).mockReturnValue([FAKE_SERVER])
 		const pi = makePi()
 		lspExtension(pi)
+		await pi.fireSessionStart({ hasUI: false })
 		const block = pi.capturedBlocks.find((b) => b.id === "lsp-tools")
 		expect(block).toBeDefined()
 		const rendered = block?.render()
@@ -363,6 +373,110 @@ describe("status bar", () => {
 		lspExtension(pi)
 		await pi.fireSessionStart({ hasUI: true, ui: { setStatus } })
 		expect(setStatus).toHaveBeenCalledWith("lsp", `LSP: ${FAKE_SERVER.name}, ${FAKE_GO_SERVER.name}`)
+	})
+})
+
+// =============================================================================
+// 4b. Degraded LSP state (marker present, binary missing)
+// =============================================================================
+
+describe("degraded status (marker present, binary missing)", () => {
+	it("sets a degraded status-bar segment when a candidate server is missing", async () => {
+		vi.mocked(serversMod.detectServers).mockReturnValue([])
+		vi.mocked(serversMod.detectMissingCandidates).mockReturnValue([FAKE_GO_SERVER])
+		const setStatus = vi.fn()
+		const pi = makePi()
+		lspExtension(pi)
+		await pi.fireSessionStart({ hasUI: true, ui: { setStatus, notify: vi.fn() } })
+		expect(setStatus).toHaveBeenCalledWith("lsp", `LSP: ${FAKE_GO_SERVER.name} not installed`)
+	})
+
+	it("does not set a degraded status when no marker is present (not an LSP project)", async () => {
+		vi.mocked(serversMod.detectServers).mockReturnValue([])
+		vi.mocked(serversMod.detectMissingCandidates).mockReturnValue([])
+		const setStatus = vi.fn()
+		const pi = makePi()
+		lspExtension(pi)
+		await pi.fireSessionStart({ hasUI: true, ui: { setStatus, notify: vi.fn() } })
+		expect(setStatus).not.toHaveBeenCalled()
+	})
+})
+
+describe("one-time warning on before_agent_start", () => {
+	it("notifies once on the first before_agent_start in a degraded project", async () => {
+		vi.mocked(serversMod.detectServers).mockReturnValue([])
+		vi.mocked(serversMod.detectMissingCandidates).mockReturnValue([FAKE_GO_SERVER])
+		const notify = vi.fn()
+		const pi = makePi()
+		lspExtension(pi)
+		await pi.fireSessionStart({ hasUI: true, ui: { setStatus: vi.fn(), notify } })
+		await pi.fireBeforeAgentStart()
+		expect(notify).toHaveBeenCalledTimes(1)
+		expect(notify).toHaveBeenCalledWith(expect.stringContaining(FAKE_GO_SERVER.name), "warning")
+		expect(notify).toHaveBeenCalledWith(expect.stringContaining("go install"), "warning")
+	})
+
+	it("does NOT re-notify on a second before_agent_start", async () => {
+		vi.mocked(serversMod.detectServers).mockReturnValue([])
+		vi.mocked(serversMod.detectMissingCandidates).mockReturnValue([FAKE_GO_SERVER])
+		const notify = vi.fn()
+		const pi = makePi()
+		lspExtension(pi)
+		await pi.fireSessionStart({ hasUI: true, ui: { setStatus: vi.fn(), notify } })
+		await pi.fireBeforeAgentStart()
+		await pi.fireBeforeAgentStart()
+		expect(notify).toHaveBeenCalledTimes(1)
+	})
+
+	it("does not notify when not degraded (server present)", async () => {
+		vi.mocked(serversMod.detectServers).mockReturnValue([FAKE_SERVER])
+		vi.mocked(serversMod.detectMissingCandidates).mockReturnValue([])
+		const notify = vi.fn()
+		const pi = makePi()
+		lspExtension(pi)
+		await pi.fireSessionStart({ hasUI: true, ui: { setStatus: vi.fn(), notify } })
+		await pi.fireBeforeAgentStart()
+		expect(notify).not.toHaveBeenCalled()
+	})
+})
+
+describe("prompt block gating on active servers", () => {
+	it("render returns undefined when activeServers is empty", async () => {
+		vi.mocked(serversMod.detectServers).mockReturnValue([])
+		const pi = makePi()
+		lspExtension(pi)
+		await pi.fireSessionStart({ hasUI: false })
+		const block = pi.capturedBlocks.find((b) => b.id === "lsp-tools")
+		expect(block).toBeDefined()
+		expect(block?.render()).toBeUndefined()
+	})
+
+	it("render returns LSP_SYSTEM_PROMPT when a server is active", async () => {
+		vi.mocked(serversMod.detectServers).mockReturnValue([FAKE_SERVER])
+		const pi = makePi()
+		lspExtension(pi)
+		await pi.fireSessionStart({ hasUI: false })
+		const block = pi.capturedBlocks.find((b) => b.id === "lsp-tools")
+		expect(block).toBeDefined()
+		const rendered = block?.render()
+		expect(rendered).toContain("Language Server Protocol")
+	})
+})
+
+describe("no regression when a server is present", () => {
+	it("sets normal status, renders prompt block, and does not warn", async () => {
+		vi.mocked(serversMod.detectServers).mockReturnValue([FAKE_SERVER])
+		vi.mocked(serversMod.detectMissingCandidates).mockReturnValue([])
+		const setStatus = vi.fn()
+		const notify = vi.fn()
+		const pi = makePi()
+		lspExtension(pi)
+		await pi.fireSessionStart({ hasUI: true, ui: { setStatus, notify } })
+		expect(setStatus).toHaveBeenCalledWith("lsp", `LSP: ${FAKE_SERVER.name}`)
+		const block = pi.capturedBlocks.find((b) => b.id === "lsp-tools")
+		expect(block?.render()).toContain("Language Server Protocol")
+		await pi.fireBeforeAgentStart()
+		expect(notify).not.toHaveBeenCalled()
 	})
 })
 

--- a/src/extensions/lsp.ts
+++ b/src/extensions/lsp.ts
@@ -78,24 +78,26 @@ export default function (pi: ExtensionAPI) {
 		warned = false
 		degradedServers = []
 		activeServers = detectServers(cwd)
-		if (activeServers.length === 0) {
-			// No server binary on PATH. If this project *would* use LSP (its
-			// marker file is present), surface a degraded status-bar segment
-			// so the user can see LSP is unavailable instead of it silently
-			// no-op'ing. Stored for the one-time warning in before_agent_start.
-			degradedServers = detectMissingCandidates(cwd)
-			if (degradedServers.length > 0 && ui) {
-				const names = degradedServers.map((s) => s.name).join(", ")
+
+		// Compute missing candidates independently of active servers. In a mixed
+		// repo (e.g. both go.mod and package.json present but only one server
+		// binary installed), this catches the missing server and surfaces it.
+		degradedServers = detectMissingCandidates(cwd)
+		if (degradedServers.length > 0 && ui) {
+			const names = degradedServers.map((s) => s.name).join(", ")
+			if (activeServers.length > 0) {
+				// Partial degradation: some servers active, some missing
+				const activeNames = activeServers.map((s) => s.name).join(", ")
+				ui.setStatus("lsp", `LSP: ${activeNames} · ${names} not installed`)
+			} else {
 				ui.setStatus("lsp", `LSP: ${names} not installed`)
 			}
-			return
-		}
-
-		// Update status bar with detected server names
-		if (ui) {
+		} else if (activeServers.length > 0 && ui) {
 			const names = activeServers.map((s) => s.name).join(", ")
 			ui.setStatus("lsp", `LSP: ${names}`)
 		}
+
+		if (activeServers.length === 0) return
 
 		// Eagerly start servers that have a project marker directly in sessionCwd
 		const goMarkers = ["go.mod"]

--- a/src/extensions/lsp.ts
+++ b/src/extensions/lsp.ts
@@ -75,6 +75,8 @@ export default function (pi: ExtensionAPI) {
 	pi.on("session_start", async (_event, ctx) => {
 		cwd = ctx.cwd
 		ui = ctx.hasUI ? ctx.ui : undefined
+		warned = false
+		degradedServers = []
 		activeServers = detectServers(cwd)
 		if (activeServers.length === 0) {
 			// No server binary on PATH. If this project *would* use LSP (its
@@ -118,16 +120,11 @@ export default function (pi: ExtensionAPI) {
 
 	// ── Degraded-state warning: notify once on the first agent turn ─────────────
 
-	const INSTALL_HINTS: Record<string, string> = {
-		gopls: "go install golang.org/x/tools/gopls@latest",
-		"typescript-language-server": "npm i -g typescript-language-server typescript",
-	}
-
 	pi.on("before_agent_start", async () => {
 		// One-time warning when in a project that would use LSP but has no
 		// server binary on PATH. No-op on subsequent turns and when not degraded.
-		if (warned || degradedServers.length === 0 || !ui) return
-		const lines = degradedServers.map((s) => `${s.name} — install with: ${INSTALL_HINTS[s.name] ?? s.command}`)
+		if (warned || degradedServers.length === 0 || !ui?.notify) return
+		const lines = degradedServers.map((s) => `${s.name} — install with: ${s.installHint ?? s.command}`)
 		ui.notify(`LSP unavailable: language server(s) not installed for this project.\n${lines.join("\n")}`, "warning")
 		warned = true
 	})

--- a/src/extensions/lsp.ts
+++ b/src/extensions/lsp.ts
@@ -22,7 +22,7 @@ import {
 	waitForDiagnostics,
 } from "./lsp/client.js"
 import { applyWorkspaceEdit } from "./lsp/edits.js"
-import { detectServers, findRoot, serverForFile } from "./lsp/servers.js"
+import { detectMissingCandidates, detectServers, findRoot, serverForFile } from "./lsp/servers.js"
 import type { Hover, Location, LocationLink, TextDocumentEdit, WorkspaceEdit } from "./lsp/types.js"
 import { fileToUri, formatDiagnostic, uriToFile } from "./lsp/utils.js"
 import { createSystemPromptBlocks } from "./prompt-construction/index.js"
@@ -49,6 +49,8 @@ LSP tools are available when language servers are detected on PATH (currently Ty
 export default function (pi: ExtensionAPI) {
 	let cwd = ""
 	let activeServers: ReturnType<typeof detectServers> = []
+	let degradedServers: ReturnType<typeof detectMissingCandidates> = []
+	let warned = false
 	let ui: ExtensionUIContext | undefined
 	// Tracks the pending diagnostic wait so a newer edit can cancel the previous
 	// one (avoiding stale status-bar updates) and so session_shutdown can
@@ -65,7 +67,7 @@ export default function (pi: ExtensionAPI) {
 
 	createSystemPromptBlocks(pi, "lsp").register({
 		id: "lsp-tools",
-		render: () => LSP_SYSTEM_PROMPT,
+		render: () => (activeServers.length > 0 ? LSP_SYSTEM_PROMPT : undefined),
 	})
 
 	// ── Session start: detect servers, hook file sync, shutdown on exit ─────────
@@ -74,7 +76,18 @@ export default function (pi: ExtensionAPI) {
 		cwd = ctx.cwd
 		ui = ctx.hasUI ? ctx.ui : undefined
 		activeServers = detectServers(cwd)
-		if (activeServers.length === 0) return
+		if (activeServers.length === 0) {
+			// No server binary on PATH. If this project *would* use LSP (its
+			// marker file is present), surface a degraded status-bar segment
+			// so the user can see LSP is unavailable instead of it silently
+			// no-op'ing. Stored for the one-time warning in before_agent_start.
+			degradedServers = detectMissingCandidates(cwd)
+			if (degradedServers.length > 0 && ui) {
+				const names = degradedServers.map((s) => s.name).join(", ")
+				ui.setStatus("lsp", `LSP: ${names} not installed`)
+			}
+			return
+		}
 
 		// Update status bar with detected server names
 		if (ui) {
@@ -98,7 +111,25 @@ export default function (pi: ExtensionAPI) {
 			ui.setStatus("lsp", undefined)
 			ui = undefined
 		}
+		warned = false
+		degradedServers = []
 		shutdownAll()
+	})
+
+	// ── Degraded-state warning: notify once on the first agent turn ─────────────
+
+	const INSTALL_HINTS: Record<string, string> = {
+		gopls: "go install golang.org/x/tools/gopls@latest",
+		"typescript-language-server": "npm i -g typescript-language-server typescript",
+	}
+
+	pi.on("before_agent_start", async () => {
+		// One-time warning when in a project that would use LSP but has no
+		// server binary on PATH. No-op on subsequent turns and when not degraded.
+		if (warned || degradedServers.length === 0 || !ui) return
+		const lines = degradedServers.map((s) => `${s.name} — install with: ${INSTALL_HINTS[s.name] ?? s.command}`)
+		ui.notify(`LSP unavailable: language server(s) not installed for this project.\n${lines.join("\n")}`, "warning")
+		warned = true
 	})
 
 	// ── File sync: refresh LSP after agent edits files ───────────────────────────

--- a/src/extensions/lsp/servers.test.ts
+++ b/src/extensions/lsp/servers.test.ts
@@ -1,0 +1,117 @@
+import { spawnSync } from "node:child_process"
+import fs from "node:fs"
+import { beforeEach, describe, expect, it, vi } from "vitest"
+
+// Mock fs and child_process so we control marker-file presence and binary availability
+vi.mock("node:fs", () => ({
+	default: {
+		existsSync: vi.fn(),
+	},
+}))
+
+vi.mock("node:child_process", () => ({
+	spawnSync: vi.fn(),
+}))
+
+import { detectMissingCandidates, detectServers } from "./servers.js"
+
+const mockExistsSync = vi.mocked(fs.existsSync)
+const mockSpawnSync = vi.mocked(spawnSync)
+
+// Suppress Bun global so exists() uses the spawnSync path
+beforeEach(() => {
+	mockExistsSync.mockReset()
+	mockSpawnSync.mockReset()
+	// biome-ignore lint/suspicious/noExplicitAny: suppress Bun global for deterministic Node-path testing
+	;(globalThis as any).Bun = undefined
+})
+
+function setFiles(files: string[]) {
+	mockExistsSync.mockImplementation(((p: unknown) => {
+		const rel = String(p).replace(/^\/project\//, "")
+		return files.includes(rel)
+	}) as never)
+}
+
+function setBinaries(onPath: string[]) {
+	mockSpawnSync.mockImplementation(
+		(_cmd: string, args?: readonly string[]) =>
+			({
+				status: onPath.includes(args?.[0] ?? "") ? 0 : 1,
+			}) as never,
+	)
+}
+
+describe("detectServers", () => {
+	it("returns only servers whose marker AND binary are present", () => {
+		setFiles(["go.mod"])
+		setBinaries(["gopls", "typescript-language-server"])
+		expect(detectServers("/project")).toHaveLength(1)
+		expect(detectServers("/project")[0].name).toBe("gopls")
+	})
+
+	it("returns typescript-language-server when package.json present and binary on PATH", () => {
+		setFiles(["package.json"])
+		setBinaries(["typescript-language-server"])
+		const result = detectServers("/project")
+		expect(result).toHaveLength(1)
+		expect(result[0].name).toBe("typescript-language-server")
+	})
+
+	it("returns empty when binary is on PATH but no marker file exists", () => {
+		setFiles([])
+		setBinaries(["gopls", "typescript-language-server"])
+		expect(detectServers("/project")).toHaveLength(0)
+	})
+
+	it("returns empty when marker exists but binary is NOT on PATH", () => {
+		setFiles(["go.mod"])
+		setBinaries([])
+		expect(detectServers("/project")).toHaveLength(0)
+	})
+
+	it("returns both servers when both markers and both binaries are present", () => {
+		setFiles(["go.mod", "package.json"])
+		setBinaries(["gopls", "typescript-language-server"])
+		expect(detectServers("/project")).toHaveLength(2)
+	})
+})
+
+describe("detectMissingCandidates", () => {
+	it("returns gopls when go.mod present but gopls not on PATH", () => {
+		setFiles(["go.mod"])
+		setBinaries([])
+		const result = detectMissingCandidates("/project")
+		expect(result).toHaveLength(1)
+		expect(result[0].name).toBe("gopls")
+	})
+
+	it("does NOT return typescript-language-server in a Go-only project", () => {
+		setFiles(["go.mod"])
+		setBinaries([])
+		const result = detectMissingCandidates("/project")
+		expect(result.find((s) => s.name === "typescript-language-server")).toBeUndefined()
+	})
+
+	it("returns typescript-language-server when package.json present but binary not on PATH", () => {
+		setFiles(["package.json"])
+		setBinaries([])
+		const result = detectMissingCandidates("/project")
+		expect(result).toHaveLength(1)
+		expect(result[0].name).toBe("typescript-language-server")
+	})
+
+	it("returns empty when no markers are present", () => {
+		setFiles([])
+		setBinaries([])
+		expect(detectMissingCandidates("/project")).toHaveLength(0)
+	})
+
+	it("does not return a server whose binary IS on PATH", () => {
+		setFiles(["go.mod", "package.json"])
+		setBinaries(["gopls"])
+		const result = detectMissingCandidates("/project")
+		expect(result.find((s) => s.name === "gopls")).toBeUndefined()
+		expect(result.find((s) => s.name === "typescript-language-server")).toBeDefined()
+	})
+})

--- a/src/extensions/lsp/servers.test.ts
+++ b/src/extensions/lsp/servers.test.ts
@@ -114,4 +114,17 @@ describe("detectMissingCandidates", () => {
 		expect(result.find((s) => s.name === "gopls")).toBeUndefined()
 		expect(result.find((s) => s.name === "typescript-language-server")).toBeDefined()
 	})
+
+	it("detects marker in a parent directory (monorepo subdirectory)", () => {
+		// go.mod is in /project, but cwd is /project/services/autoscaler
+		setFiles(["go.mod"])
+		setBinaries([])
+		mockExistsSync.mockImplementation(((p: unknown) => {
+			// Only /project/go.mod exists, not /project/services/autoscaler/go.mod
+			return String(p) === "/project/go.mod"
+		}) as never)
+		const result = detectMissingCandidates("/project/services/autoscaler")
+		expect(result).toHaveLength(1)
+		expect(result[0].name).toBe("gopls")
+	})
 })

--- a/src/extensions/lsp/servers.ts
+++ b/src/extensions/lsp/servers.ts
@@ -55,15 +55,15 @@ function exists(cmd: string): boolean {
 
 /**
  * Returns LSP servers whose binary is available on PATH AND whose project
- * marker (go.mod, tsconfig.json, package.json) exists in cwd. This ensures
- * only servers relevant to the current project are activated — e.g. a Go
- * project won't activate typescript-language-server even if it's on PATH.
+ * marker (go.mod, tsconfig.json, package.json) exists in cwd or a parent
+ * directory. This ensures only servers relevant to the current project are
+ * activated — e.g. a Go project won't activate typescript-language-server
+ * even if it's on PATH.
  */
 export function detectServers(cwd: string): ServerConfig[] {
 	return SERVERS.filter((s) => {
 		const markers = ROOT_MARKERS[s.name] ?? []
-		const hasMarker = markers.some((m) => fs.existsSync(path.join(cwd, m)))
-		return hasMarker && exists(s.command)
+		return findMarkerUp(cwd, markers) && exists(s.command)
 	})
 }
 

--- a/src/extensions/lsp/servers.ts
+++ b/src/extensions/lsp/servers.ts
@@ -10,12 +10,14 @@ const SERVERS: ServerConfig[] = [
 		command: "typescript-language-server",
 		args: ["--stdio"],
 		extensions: ["ts", "tsx", "mts", "cts", "js", "jsx", "mjs", "cjs"],
+		installHint: "npm i -g typescript-language-server typescript",
 	},
 	{
 		name: "gopls",
 		command: "gopls",
 		args: [],
 		extensions: ["go"],
+		installHint: "go install golang.org/x/tools/gopls@latest",
 	},
 ]
 
@@ -67,14 +69,16 @@ export function detectServers(cwd: string): ServerConfig[] {
 
 /**
  * Returns LSP servers whose project marker (go.mod, tsconfig.json, package.json)
- * is present in cwd but whose binary is NOT on PATH — i.e. servers this project
- * would use if installed. Used to surface a degraded LSP state to the user
- * instead of silently no-op'ing.
+ * is present in cwd or any parent directory up to the filesystem root, but
+ * whose binary is NOT on PATH — i.e. servers this project would use if
+ * installed. Used to surface a degraded LSP state to the user instead of
+ * silently no-op'ing. Walks parent directories so monorepo subdirectories
+ * where the marker lives in a parent are detected.
  */
 export function detectMissingCandidates(cwd: string): ServerConfig[] {
 	return SERVERS.filter((s) => {
 		const markers = ROOT_MARKERS[s.name] ?? []
-		const hasMarker = markers.some((m) => fs.existsSync(path.join(cwd, m)))
+		const hasMarker = findMarkerUp(cwd, markers)
 		return hasMarker && !exists(s.command)
 	})
 }
@@ -88,6 +92,21 @@ export function serverForFile(filePath: string, servers: ServerConfig[]): Server
 const ROOT_MARKERS: Record<string, string[]> = {
 	gopls: ["go.mod"],
 	"typescript-language-server": ["tsconfig.json", "package.json"],
+}
+
+/**
+ * Walk up from `cwd` to the filesystem root, returning true if any of the
+ * given marker files is found in cwd or a parent directory.
+ */
+function findMarkerUp(cwd: string, markers: string[]): boolean {
+	let dir = path.resolve(cwd)
+	while (true) {
+		if (markers.some((m) => fs.existsSync(path.join(dir, m)))) return true
+		const parent = path.dirname(dir)
+		if (dir === parent) break
+		dir = parent
+	}
+	return false
 }
 
 /**

--- a/src/extensions/lsp/servers.ts
+++ b/src/extensions/lsp/servers.ts
@@ -44,6 +44,20 @@ export function detectServers(_cwd: string): ServerConfig[] {
 	return SERVERS.filter((s) => exists(s.command))
 }
 
+/**
+ * Returns LSP servers whose project marker (go.mod, tsconfig.json, package.json)
+ * is present in cwd but whose binary is NOT on PATH — i.e. servers this project
+ * would use if installed. Used to surface a degraded LSP state to the user
+ * instead of silently no-op'ing.
+ */
+export function detectMissingCandidates(cwd: string): ServerConfig[] {
+	return SERVERS.filter((s) => {
+		const markers = ROOT_MARKERS[s.name] ?? []
+		const hasMarker = markers.some((m) => fs.existsSync(path.join(cwd, m)))
+		return hasMarker && !exists(s.command)
+	})
+}
+
 /** Get the server config for a specific file path, or null if no server applies. */
 export function serverForFile(filePath: string, servers: ServerConfig[]): ServerConfig | null {
 	const ext = path.extname(filePath).slice(1).toLowerCase()

--- a/src/extensions/lsp/servers.ts
+++ b/src/extensions/lsp/servers.ts
@@ -39,9 +39,18 @@ function exists(cmd: string): boolean {
 	}
 }
 
-/** Returns all LSP servers whose binary is available on PATH. */
-export function detectServers(_cwd: string): ServerConfig[] {
-	return SERVERS.filter((s) => exists(s.command))
+/**
+ * Returns LSP servers whose binary is available on PATH AND whose project
+ * marker (go.mod, tsconfig.json, package.json) exists in cwd. This ensures
+ * only servers relevant to the current project are activated — e.g. a Go
+ * project won't activate typescript-language-server even if it's on PATH.
+ */
+export function detectServers(cwd: string): ServerConfig[] {
+	return SERVERS.filter((s) => {
+		const markers = ROOT_MARKERS[s.name] ?? []
+		const hasMarker = markers.some((m) => fs.existsSync(path.join(cwd, m)))
+		return hasMarker && exists(s.command)
+	})
 }
 
 /**

--- a/src/extensions/lsp/servers.ts
+++ b/src/extensions/lsp/servers.ts
@@ -19,7 +19,19 @@ const SERVERS: ServerConfig[] = [
 	},
 ]
 
+/**
+ * Test-only override: when KIMCHI_LSP_BINARIES is set, `exists()` ignores the
+ * real PATH and returns true only for commands listed in the comma-separated
+ * value. This lets E2E TUI tests control which LSP servers appear "installed"
+ * regardless of the host machine's setup. When unset, normal `which` behavior.
+ */
+const LSP_BINARIES_OVERRIDE = process.env.KIMCHI_LSP_BINARIES
+
 function exists(cmd: string): boolean {
+	if (LSP_BINARIES_OVERRIDE !== undefined) {
+		const available = LSP_BINARIES_OVERRIDE.split(",").map((s) => s.trim())
+		return available.includes(cmd)
+	}
 	// Try Bun first (dev mode), fall back to Node child_process (production build)
 	try {
 		// biome-ignore lint/suspicious/noExplicitAny: Bun not typed without @types/bun

--- a/src/extensions/lsp/types.ts
+++ b/src/extensions/lsp/types.ts
@@ -163,4 +163,6 @@ export interface ServerConfig {
 	args?: string[]
 	extensions: string[]
 	initOptions?: Record<string, unknown>
+	/** Install command shown in the degraded-state warning when the binary is not on PATH. */
+	installHint?: string
 }

--- a/tests/e2e/tui/lsp-degraded-state.test.ts
+++ b/tests/e2e/tui/lsp-degraded-state.test.ts
@@ -1,0 +1,153 @@
+import { writeFileSync } from "node:fs"
+import { join } from "node:path"
+import { expect, test } from "@microsoft/tui-test"
+import type { KimchiFixture } from "./support/kimchi-fixture.js"
+import { TUI_TEST_CONFIG, runKimchiSession } from "./support/kimchi-fixture.js"
+
+test.use(TUI_TEST_CONFIG)
+
+/** Phrase from LSP_SYSTEM_PROMPT that appears in provider requests when the
+ *  lsp-tools prompt block is active (i.e. at least one server binary on PATH). */
+const LSP_PROMPT_PHRASE = "Prefer them over text-based alternatives"
+
+/** Footer status-bar text for degraded LSP: marker present, binary missing. */
+const LSP_DEGRADED_FOOTER = "gopls not installed"
+
+/** Footer status-bar text for active LSP: binary on PATH and marker present. */
+const LSP_ACTIVE_FOOTER = "typescript-language-server"
+
+/**
+ * Waits for the harness to finish processing the main agent turn AND any
+ * follow-up completions. Polls request count until stable for settleForMs.
+ */
+async function waitForTurnToSettle(fixture: KimchiFixture) {
+	const settleForMs = 1_200
+	const timeoutMs = 30_000
+	const startedAt = Date.now()
+	let lastCount = fixture.fake.requests.length
+	let stableSince = Date.now()
+	while (Date.now() - startedAt < timeoutMs) {
+		await new Promise((resolve) => setTimeout(resolve, 100))
+		const currentCount = fixture.fake.requests.length
+		if (currentCount !== lastCount) {
+			lastCount = currentCount
+			stableSince = Date.now()
+		} else if (Date.now() - stableSince >= settleForMs) {
+			return
+		}
+	}
+}
+
+/** Returns true if any recorded provider request body contains the phrase. */
+function anyRequestContains(fixture: KimchiFixture, phrase: string): boolean {
+	for (const request of fixture.fake.requests) {
+		const bodyText = JSON.stringify(request.body ?? "")
+		if (bodyText.includes(phrase)) return true
+	}
+	return false
+}
+
+/** Checks the viewable terminal text for a substring. */
+function viewTextContains(terminal: { getViewableBuffer: () => string[][] }, phrase: string): boolean {
+	const text = terminal
+		.getViewableBuffer()
+		.map((row) => row.join(""))
+		.join("\n")
+	return text.includes(phrase)
+}
+
+// =============================================================================
+// Scenario 1: Go project with go.mod but gopls NOT on PATH → degraded state
+// =============================================================================
+
+test("LSP degraded state shows status-bar segment and omits prompt in a Go project without gopls", async ({
+	terminal,
+}) => {
+	await runKimchiSession(
+		terminal,
+		{
+			artifactName: "lsp-degraded-go",
+			responses: [{ stream: ["Done."] }],
+			env: { KIMCHI_LSP_BINARIES: "" },
+			seedHome: (_homeDir, workDir) => {
+				writeFileSync(join(workDir, "go.mod"), "module example.com/test\n\ngo 1.22\n")
+			},
+		},
+		async (fixture, trace) => {
+			// Wait for the footer to render the degraded LSP segment.
+			trace.step("checking footer for degraded LSP status")
+			expect(viewTextContains(terminal, LSP_DEGRADED_FOOTER)).toBe(true)
+
+			// Submit a prompt to trigger before_agent_start (which fires the
+			// one-time warning) and settle the turn.
+			terminal.submit("hello")
+			trace.step("submitted prompt")
+			await waitForTurnToSettle(fixture)
+			trace.step("settled")
+
+			// The LSP system prompt block must NOT appear in any request —
+			// no server is active so render() returned undefined.
+			expect(anyRequestContains(fixture, LSP_PROMPT_PHRASE)).toBe(false)
+		},
+	)
+})
+
+// =============================================================================
+// Scenario 2: No project markers → no LSP segment at all
+// =============================================================================
+
+test("LSP segment absent when no project markers are present", async ({ terminal }) => {
+	await runKimchiSession(
+		terminal,
+		{
+			artifactName: "lsp-no-markers",
+			responses: [{ stream: ["Done."] }],
+			env: { KIMCHI_LSP_BINARIES: "typescript-language-server,gopls" },
+		},
+		async (fixture, trace) => {
+			trace.step("checking footer for absence of LSP segment")
+			expect(viewTextContains(terminal, "LSP:")).toBe(false)
+
+			terminal.submit("hello")
+			trace.step("submitted prompt")
+			await waitForTurnToSettle(fixture)
+			trace.step("settled")
+
+			// No markers → no server active → prompt block omitted.
+			expect(anyRequestContains(fixture, LSP_PROMPT_PHRASE)).toBe(false)
+		},
+	)
+})
+
+// =============================================================================
+// Scenario 3: TS project with package.json and typescript-language-server on PATH
+//             → active LSP, prompt block present, no degraded warning
+// =============================================================================
+
+test("LSP active state shows status-bar segment and includes prompt in a TS project", async ({
+	terminal,
+}) => {
+	await runKimchiSession(
+		terminal,
+		{
+			artifactName: "lsp-active-ts",
+			responses: [{ stream: ["Done."] }],
+			env: { KIMCHI_LSP_BINARIES: "typescript-language-server" },
+			seedHome: (_homeDir, workDir) => {
+				writeFileSync(join(workDir, "package.json"), '{"name":"test","version":"1.0.0"}\n')
+			},
+		},
+		async (fixture, trace) => {
+			trace.step("checking footer for active LSP status")
+			expect(viewTextContains(terminal, LSP_ACTIVE_FOOTER)).toBe(true)
+
+			terminal.submit("hello")
+			trace.step("submitted prompt")
+			await waitForTurnToSettle(fixture)
+			trace.step("settled")
+
+			// LSP system prompt MUST appear in requests — server is active.
+			expect(anyRequestContains(fixture, LSP_PROMPT_PHRASE)).toBe(true)
+		},
+	)
+})

--- a/tests/e2e/tui/lsp-degraded-state.test.ts
+++ b/tests/e2e/tui/lsp-degraded-state.test.ts
@@ -3,6 +3,7 @@ import { join } from "node:path"
 import { expect, test } from "@microsoft/tui-test"
 import type { KimchiFixture } from "./support/kimchi-fixture.js"
 import { TUI_TEST_CONFIG, runKimchiSession } from "./support/kimchi-fixture.js"
+import { viewText, waitForTurnToSettle } from "./support/assertions.js"
 
 test.use(TUI_TEST_CONFIG)
 
@@ -16,28 +17,6 @@ const LSP_DEGRADED_FOOTER = "gopls not installed"
 /** Footer status-bar text for active LSP: binary on PATH and marker present. */
 const LSP_ACTIVE_FOOTER = "typescript-language-server"
 
-/**
- * Waits for the harness to finish processing the main agent turn AND any
- * follow-up completions. Polls request count until stable for settleForMs.
- */
-async function waitForTurnToSettle(fixture: KimchiFixture) {
-	const settleForMs = 1_200
-	const timeoutMs = 30_000
-	const startedAt = Date.now()
-	let lastCount = fixture.fake.requests.length
-	let stableSince = Date.now()
-	while (Date.now() - startedAt < timeoutMs) {
-		await new Promise((resolve) => setTimeout(resolve, 100))
-		const currentCount = fixture.fake.requests.length
-		if (currentCount !== lastCount) {
-			lastCount = currentCount
-			stableSince = Date.now()
-		} else if (Date.now() - stableSince >= settleForMs) {
-			return
-		}
-	}
-}
-
 /** Returns true if any recorded provider request body contains the phrase. */
 function anyRequestContains(fixture: KimchiFixture, phrase: string): boolean {
 	for (const request of fixture.fake.requests) {
@@ -45,15 +24,6 @@ function anyRequestContains(fixture: KimchiFixture, phrase: string): boolean {
 		if (bodyText.includes(phrase)) return true
 	}
 	return false
-}
-
-/** Checks the viewable terminal text for a substring. */
-function viewTextContains(terminal: { getViewableBuffer: () => string[][] }, phrase: string): boolean {
-	const text = terminal
-		.getViewableBuffer()
-		.map((row) => row.join(""))
-		.join("\n")
-	return text.includes(phrase)
 }
 
 // =============================================================================
@@ -76,13 +46,13 @@ test("LSP degraded state shows status-bar segment and omits prompt in a Go proje
 		async (fixture, trace) => {
 			// Wait for the footer to render the degraded LSP segment.
 			trace.step("checking footer for degraded LSP status")
-			expect(viewTextContains(terminal, LSP_DEGRADED_FOOTER)).toBe(true)
+			expect(viewText(terminal)).toContain(LSP_DEGRADED_FOOTER)
 
 			// Submit a prompt to trigger before_agent_start (which fires the
 			// one-time warning) and settle the turn.
 			terminal.submit("hello")
 			trace.step("submitted prompt")
-			await waitForTurnToSettle(fixture)
+			await waitForTurnToSettle(fixture.fake.requests)
 			trace.step("settled")
 
 			// The LSP system prompt block must NOT appear in any request —
@@ -106,11 +76,11 @@ test("LSP segment absent when no project markers are present", async ({ terminal
 		},
 		async (fixture, trace) => {
 			trace.step("checking footer for absence of LSP segment")
-			expect(viewTextContains(terminal, "LSP:")).toBe(false)
+			expect(viewText(terminal)).not.toContain("LSP:")
 
 			terminal.submit("hello")
 			trace.step("submitted prompt")
-			await waitForTurnToSettle(fixture)
+			await waitForTurnToSettle(fixture.fake.requests)
 			trace.step("settled")
 
 			// No markers → no server active → prompt block omitted.
@@ -139,11 +109,11 @@ test("LSP active state shows status-bar segment and includes prompt in a TS proj
 		},
 		async (fixture, trace) => {
 			trace.step("checking footer for active LSP status")
-			expect(viewTextContains(terminal, LSP_ACTIVE_FOOTER)).toBe(true)
+			expect(viewText(terminal)).toContain(LSP_ACTIVE_FOOTER)
 
 			terminal.submit("hello")
 			trace.step("submitted prompt")
-			await waitForTurnToSettle(fixture)
+			await waitForTurnToSettle(fixture.fake.requests)
 			trace.step("settled")
 
 			// LSP system prompt MUST appear in requests — server is active.

--- a/tests/e2e/tui/nudge-wiring.test.ts
+++ b/tests/e2e/tui/nudge-wiring.test.ts
@@ -1,6 +1,7 @@
 import { expect, test } from "@microsoft/tui-test"
 import type { KimchiFixture } from "./support/kimchi-fixture.js"
 import { TUI_TEST_CONFIG, runKimchiSession } from "./support/kimchi-fixture.js"
+import { waitForTurnToSettle } from "./support/assertions.js"
 
 test.use(TUI_TEST_CONFIG)
 
@@ -55,34 +56,6 @@ function anyRequestContainsAnyNudge(fixture: KimchiFixture): boolean {
 	)
 }
 
-/**
- * Waits for the harness to finish processing the orchestrator's main turn
- * AND any nudge-driven followUp turn.
- *
- * Polls `fixture.fake.requests.length` until no new completion requests
- * have arrived for `settleForMs`. This is the authoritative "all nudges
- * have either fired or been suppressed" signal — stable for the full
- * window means the harness is idle and ready to assert.
- */
-async function waitForTurnToSettle(fixture: KimchiFixture) {
-	const settleForMs = 1_200
-	const timeoutMs = 30_000
-	const startedAt = Date.now()
-	let lastCount = fixture.fake.requests.length
-	let stableSince = Date.now()
-	while (Date.now() - startedAt < timeoutMs) {
-		await new Promise((resolve) => setTimeout(resolve, 100))
-		const currentCount = fixture.fake.requests.length
-		if (currentCount !== lastCount) {
-			lastCount = currentCount
-			stableSince = Date.now()
-		} else if (Date.now() - stableSince >= settleForMs) {
-			return
-		}
-	}
-	throw new Error("Request count did not settle")
-}
-
 test("nudge wiring stays silent on a text-only response in a fresh session", async ({ terminal }) => {
 	// Wiring smoke: when none of the nudge conditions are met, no
 	// component of the harness should inject a nudge phrase into any
@@ -97,7 +70,7 @@ test("nudge wiring stays silent on a text-only response in a fresh session", asy
 		async (fixture, trace) => {
 			terminal.submit("hello")
 			trace.step("submitted prompt")
-			await waitForTurnToSettle(fixture)
+			await waitForTurnToSettle(fixture.fake.requests)
 			trace.step("settled")
 			expect(anyRequestContainsAnyNudge(fixture)).toBe(false)
 		},
@@ -121,7 +94,7 @@ test("nudge wiring fires the empty-turn nudge when the orchestrator returns empt
 		async (fixture, trace) => {
 			terminal.submit("go")
 			trace.step("submitted prompt")
-			await waitForTurnToSettle(fixture)
+			await waitForTurnToSettle(fixture.fake.requests)
 			trace.step("settled")
 			expect(anyRequestContainsNudgePhrase(fixture, EMPTY_TURN_NUDGE_PHRASE)).toBe(true)
 		},

--- a/tests/e2e/tui/support/assertions.ts
+++ b/tests/e2e/tui/support/assertions.ts
@@ -39,3 +39,26 @@ export async function waitForText(
 	}
 	throw new Error(`Timed out waiting for ${String(pattern)}.\n\nTerminal:\n${text}`)
 }
+
+/**
+ * Waits for the harness to finish processing the main agent turn AND any
+ * follow-up completions. Polls request count until stable for settleForMs.
+ * Shared across TUI E2E tests that need to wait for the agent to fully settle.
+ */
+export async function waitForTurnToSettle(requests: { length: number }): Promise<void> {
+	const settleForMs = 1_200
+	const timeoutMs = 30_000
+	const startedAt = Date.now()
+	let lastCount = requests.length
+	let stableSince = Date.now()
+	while (Date.now() - startedAt < timeoutMs) {
+		await new Promise((resolve) => setTimeout(resolve, 100))
+		const currentCount = requests.length
+		if (currentCount !== lastCount) {
+			lastCount = currentCount
+			stableSince = Date.now()
+		} else if (Date.now() - stableSince >= settleForMs) {
+			return
+		}
+	}
+}


### PR DESCRIPTION
## Summary

When a project has an LSP marker file (`go.mod`, `tsconfig.json`, `package.json`) but the corresponding language server binary is not on PATH, LSP support silently no-op'd — no status bar segment, no warning, and the agent was still told to prefer `lsp_*` tools that would fail. This PR makes the degraded state visible.

## Changes

**`src/extensions/lsp/servers.ts`** — Added `detectMissingCandidates(cwd)` helper that returns servers whose project marker exists in cwd but whose binary is not on PATH (reuses existing `exists()` and `ROOT_MARKERS`).

**`src/extensions/lsp.ts`** — Three changes:
1. `session_start`: when `activeServers` is empty but markers are present, sets a degraded status-bar segment (`"LSP: gopls not installed"`) so the footer renders it.
2. `before_agent_start` handler: guarded by a `warned` boolean, fires `ui.notify(msg, "warning")` once per session naming missing servers and their install commands.
3. `"lsp-tools"` prompt block `render()`: returns `undefined` when no server is active, so the agent is no longer told to prefer `lsp_*` tools.

**`src/extensions/lsp.test.ts`** — 8 new unit tests covering all 4 scenarios:
- Degraded status set when marker present + binary missing (and NOT set when no marker)
- One-time notify on first `before_agent_start` and zero on second
- Prompt block `render()` returns `undefined` with empty `activeServers` and returns the prompt with a populated server
- No-regression: normal status, prompt block renders, no notify when a server is present

Harness extended with `fireBeforeAgentStart()` and optional `ui.notify` on the test stub.

## Behavior

| Scenario | Status bar | Warning | Prompt block |
|---|---|---|---|
| Server on PATH | `LSP: <names>` | None | LSP guidance |
| Marker present, binary missing | `LSP: <name> not installed` | One-time on first turn | Omitted |
| No marker (not LSP project) | (unset) | None | Omitted |

## Checklist

- [x] Bug fix / new feature
- [ ] Breaking change
- [ ] Documentation update
- [x] Tests added/updated
- [x] `pnpm run typecheck` passes
- [x] `pnpm run lint` passes
- [x] `pnpm exec vitest run src/extensions/lsp.test.ts` passes (521/521)
