### PR TITLE
fix: don't pause one-shot ferment on LLM error or shutdown

### DIFF
--- a/src/extensions/ferment/events.test.ts
+++ b/src/extensions/ferment/events.test.ts
@@ -630,40 +630,40 @@ describe("turn_end connection error recovery", () => {
 	})
 })
 
-describe("turn_end error recovery in one-shot mode", () => {
-	function setupRunningFerment() {
-		const storage = new FermentEventStore(mkdtempSync(join(tmpdir(), "ferment-oneshot-error-")))
-		const ferment = storage.create("One-shot Error Ferment")
-		storage.mutateWithEvents(ferment.id, (current) => {
-			if (!current) throw new Error("missing ferment")
-			const now = new Date().toISOString()
-			const cmd = {
-				type: "scope" as const,
-				title: "One-shot Error Ferment",
-				goal: "Test goal",
-				successCriteria: ["Test criterion"],
-				constraints: [],
-				phases: [{ name: "Build", goal: "Build it", steps: [{ description: "step 1" }] }],
-			}
-			const result = applyCommand(current, cmd, { now })
-			if (!result.ok) throw new Error(`scope failed: ${result.error.message}`)
-			const events = commandToEvents(cmd, current, result.ferment, { now })
-			return { write: true, ferment: result.ferment, events, value: undefined }
-		})
-		storage.mutateWithEvents(ferment.id, (current) => {
-			if (!current) throw new Error("missing ferment")
-			const now = new Date().toISOString()
-			const cmd = { type: "activate_phase" as const, phaseId: "phase-1" }
-			const result = applyCommand(current, cmd, { now })
-			if (!result.ok) throw new Error(`activate failed: ${result.error.message}`)
-			const events = commandToEvents(cmd, current, result.ferment, { now })
-			return { write: true, ferment: result.ferment, events, value: undefined }
-		})
-		return { storage, ferment }
-	}
+function setupScopedRunningFerment(prefix: string, name: string) {
+	const storage = new FermentEventStore(mkdtempSync(join(tmpdir(), prefix)))
+	const ferment = storage.create(name)
+	storage.mutateWithEvents(ferment.id, (current) => {
+		if (!current) throw new Error("missing ferment")
+		const now = new Date().toISOString()
+		const cmd = {
+			type: "scope" as const,
+			title: name,
+			goal: "Test goal",
+			successCriteria: ["Test criterion"],
+			constraints: [],
+			phases: [{ name: "Build", goal: "Build it", steps: [{ description: "step 1" }] }],
+		}
+		const result = applyCommand(current, cmd, { now })
+		if (!result.ok) throw new Error(`scope failed: ${result.error.message}`)
+		const events = commandToEvents(cmd, current, result.ferment, { now })
+		return { write: true, ferment: result.ferment, events, value: undefined }
+	})
+	storage.mutateWithEvents(ferment.id, (current) => {
+		if (!current) throw new Error("missing ferment")
+		const now = new Date().toISOString()
+		const cmd = { type: "activate_phase" as const, phaseId: "phase-1" }
+		const result = applyCommand(current, cmd, { now })
+		if (!result.ok) throw new Error(`activate failed: ${result.error.message}`)
+		const events = commandToEvents(cmd, current, result.ferment, { now })
+		return { write: true, ferment: result.ferment, events, value: undefined }
+	})
+	return { storage, ferment }
+}
 
+describe("turn_end error recovery in one-shot mode", () => {
 	it('does not pause the ferment when stopReason is "error" in one-shot mode', async () => {
-		const { storage, ferment } = setupRunningFerment()
+		const { storage, ferment } = setupScopedRunningFerment("ferment-oneshot-error-", "One-shot Error Ferment")
 		const runtime: FermentRuntime = {
 			...createDefaultFermentRuntime(),
 			getStorage: () => storage,
@@ -707,7 +707,7 @@ describe("turn_end error recovery in one-shot mode", () => {
 	})
 
 	it('still pauses the ferment when stopReason is "error" in interactive mode', async () => {
-		const { storage, ferment } = setupRunningFerment()
+		const { storage, ferment } = setupScopedRunningFerment("ferment-oneshot-error-", "One-shot Error Ferment")
 		const runtime: FermentRuntime = {
 			...createDefaultFermentRuntime(),
 			getStorage: () => storage,
@@ -746,39 +746,8 @@ describe("turn_end error recovery in one-shot mode", () => {
 })
 
 describe("session_shutdown one-shot recovery", () => {
-	function setupRunningFerment() {
-		const storage = new FermentEventStore(mkdtempSync(join(tmpdir(), "ferment-oneshot-shutdown-")))
-		const ferment = storage.create("Shutdown Ferment")
-		storage.mutateWithEvents(ferment.id, (current) => {
-			if (!current) throw new Error("missing ferment")
-			const now = new Date().toISOString()
-			const cmd = {
-				type: "scope" as const,
-				title: "Shutdown Ferment",
-				goal: "Test goal",
-				successCriteria: ["Test criterion"],
-				constraints: [],
-				phases: [{ name: "Build", goal: "Build it", steps: [{ description: "step 1" }] }],
-			}
-			const result = applyCommand(current, cmd, { now })
-			if (!result.ok) throw new Error(`scope failed: ${result.error.message}`)
-			const events = commandToEvents(cmd, current, result.ferment, { now })
-			return { write: true, ferment: result.ferment, events, value: undefined }
-		})
-		storage.mutateWithEvents(ferment.id, (current) => {
-			if (!current) throw new Error("missing ferment")
-			const now = new Date().toISOString()
-			const cmd = { type: "activate_phase" as const, phaseId: "phase-1" }
-			const result = applyCommand(current, cmd, { now })
-			if (!result.ok) throw new Error(`activate failed: ${result.error.message}`)
-			const events = commandToEvents(cmd, current, result.ferment, { now })
-			return { write: true, ferment: result.ferment, events, value: undefined }
-		})
-		return { storage, ferment }
-	}
-
 	it("abandons the ferment in one-shot mode", async () => {
-		const { storage, ferment } = setupRunningFerment()
+		const { storage, ferment } = setupScopedRunningFerment("ferment-oneshot-shutdown-", "Shutdown Ferment")
 		const runtime: FermentRuntime = {
 			...createDefaultFermentRuntime(),
 			getStorage: () => storage,
@@ -802,7 +771,7 @@ describe("session_shutdown one-shot recovery", () => {
 	})
 
 	it("pauses the ferment in interactive mode", async () => {
-		const { storage, ferment } = setupRunningFerment()
+		const { storage, ferment } = setupScopedRunningFerment("ferment-oneshot-shutdown-", "Shutdown Ferment")
 		const runtime: FermentRuntime = {
 			...createDefaultFermentRuntime(),
 			getStorage: () => storage,

--- a/src/extensions/ferment/events.test.ts
+++ b/src/extensions/ferment/events.test.ts
@@ -630,6 +630,200 @@ describe("turn_end connection error recovery", () => {
 	})
 })
 
+describe("turn_end error recovery in one-shot mode", () => {
+	function setupRunningFerment() {
+		const storage = new FermentEventStore(mkdtempSync(join(tmpdir(), "ferment-oneshot-error-")))
+		const ferment = storage.create("One-shot Error Ferment")
+		storage.mutateWithEvents(ferment.id, (current) => {
+			if (!current) throw new Error("missing ferment")
+			const now = new Date().toISOString()
+			const cmd = {
+				type: "scope" as const,
+				title: "One-shot Error Ferment",
+				goal: "Test goal",
+				successCriteria: ["Test criterion"],
+				constraints: [],
+				phases: [{ name: "Build", goal: "Build it", steps: [{ description: "step 1" }] }],
+			}
+			const result = applyCommand(current, cmd, { now })
+			if (!result.ok) throw new Error(`scope failed: ${result.error.message}`)
+			const events = commandToEvents(cmd, current, result.ferment, { now })
+			return { write: true, ferment: result.ferment, events, value: undefined }
+		})
+		storage.mutateWithEvents(ferment.id, (current) => {
+			if (!current) throw new Error("missing ferment")
+			const now = new Date().toISOString()
+			const cmd = { type: "activate_phase" as const, phaseId: "phase-1" }
+			const result = applyCommand(current, cmd, { now })
+			if (!result.ok) throw new Error(`activate failed: ${result.error.message}`)
+			const events = commandToEvents(cmd, current, result.ferment, { now })
+			return { write: true, ferment: result.ferment, events, value: undefined }
+		})
+		return { storage, ferment }
+	}
+
+	it('does not pause the ferment when stopReason is "error" in one-shot mode', async () => {
+		const { storage, ferment } = setupRunningFerment()
+		const runtime: FermentRuntime = {
+			...createDefaultFermentRuntime(),
+			getStorage: () => storage,
+			isAutomatedContinuationEnabled: () => true,
+		}
+		const active = storage.get(ferment.id)
+		if (!active) throw new Error("ferment not found after setup")
+		runtime.setActive(active)
+
+		const { handlers, pi } = createPi()
+		;(pi.getFlag as ReturnType<typeof vi.fn>).mockImplementation((name: string) =>
+			name === "ferment-oneshot" ? true : undefined,
+		)
+		;(pi as ExtensionAPI & { events: ExtensionAPI["events"] }).events = {
+			emit: vi.fn(),
+			on: vi.fn(),
+		} as unknown as ExtensionAPI["events"]
+		registerFermentEvents(pi, runtime)
+		const turnEnd = handlers.get("turn_end")
+		if (!turnEnd) throw new Error("turn_end handler was not registered")
+		const notify = vi.fn()
+		const ctx = { ui: { notify } }
+
+		await turnEnd(
+			{
+				message: {
+					role: "assistant",
+					stopReason: "error",
+					errorMessage: "Connection error: socket closed",
+					content: [],
+				},
+			},
+			ctx,
+		)
+
+		const stored = storage.get(ferment.id)
+		expect(stored?.status).toBe("running")
+		expect(notify).not.toHaveBeenCalledWith(expect.stringContaining("was paused"))
+		// The continuation nudge should have been injected via sendMessage.
+		expect(pi.sendMessage).toHaveBeenCalled()
+	})
+
+	it('still pauses the ferment when stopReason is "error" in interactive mode', async () => {
+		const { storage, ferment } = setupRunningFerment()
+		const runtime: FermentRuntime = {
+			...createDefaultFermentRuntime(),
+			getStorage: () => storage,
+		}
+		const active = storage.get(ferment.id)
+		if (!active) throw new Error("ferment not found after setup")
+		runtime.setActive(active)
+
+		const { handlers, pi } = createPi()
+		;(pi.getFlag as ReturnType<typeof vi.fn>).mockReturnValue(undefined)
+		;(pi as ExtensionAPI & { events: ExtensionAPI["events"] }).events = {
+			emit: vi.fn(),
+			on: vi.fn(),
+		} as unknown as ExtensionAPI["events"]
+		registerFermentEvents(pi, runtime)
+		const turnEnd = handlers.get("turn_end")
+		if (!turnEnd) throw new Error("turn_end handler was not registered")
+		const notify = vi.fn()
+		const ctx = { ui: { notify } }
+
+		await turnEnd(
+			{
+				message: {
+					role: "assistant",
+					stopReason: "error",
+					errorMessage: "Connection error: socket closed",
+					content: [],
+				},
+			},
+			ctx,
+		)
+
+		const stored = storage.get(ferment.id)
+		expect(stored?.status).toBe("paused")
+	})
+})
+
+describe("session_shutdown one-shot recovery", () => {
+	function setupRunningFerment() {
+		const storage = new FermentEventStore(mkdtempSync(join(tmpdir(), "ferment-oneshot-shutdown-")))
+		const ferment = storage.create("Shutdown Ferment")
+		storage.mutateWithEvents(ferment.id, (current) => {
+			if (!current) throw new Error("missing ferment")
+			const now = new Date().toISOString()
+			const cmd = {
+				type: "scope" as const,
+				title: "Shutdown Ferment",
+				goal: "Test goal",
+				successCriteria: ["Test criterion"],
+				constraints: [],
+				phases: [{ name: "Build", goal: "Build it", steps: [{ description: "step 1" }] }],
+			}
+			const result = applyCommand(current, cmd, { now })
+			if (!result.ok) throw new Error(`scope failed: ${result.error.message}`)
+			const events = commandToEvents(cmd, current, result.ferment, { now })
+			return { write: true, ferment: result.ferment, events, value: undefined }
+		})
+		storage.mutateWithEvents(ferment.id, (current) => {
+			if (!current) throw new Error("missing ferment")
+			const now = new Date().toISOString()
+			const cmd = { type: "activate_phase" as const, phaseId: "phase-1" }
+			const result = applyCommand(current, cmd, { now })
+			if (!result.ok) throw new Error(`activate failed: ${result.error.message}`)
+			const events = commandToEvents(cmd, current, result.ferment, { now })
+			return { write: true, ferment: result.ferment, events, value: undefined }
+		})
+		return { storage, ferment }
+	}
+
+	it("abandons the ferment in one-shot mode", async () => {
+		const { storage, ferment } = setupRunningFerment()
+		const runtime: FermentRuntime = {
+			...createDefaultFermentRuntime(),
+			getStorage: () => storage,
+		}
+		const active = storage.get(ferment.id)
+		if (!active) throw new Error("ferment not found after setup")
+		runtime.setActive(active)
+
+		const { handlers, pi } = createPi()
+		;(pi.getFlag as ReturnType<typeof vi.fn>).mockImplementation((name: string) =>
+			name === "ferment-oneshot" ? true : undefined,
+		)
+		registerFermentEvents(pi, runtime)
+		const shutdown = handlers.get("session_shutdown")
+		if (!shutdown) throw new Error("session_shutdown handler was not registered")
+
+		await shutdown({}, {})
+
+		const stored = storage.get(ferment.id)
+		expect(stored?.status).toBe("abandoned")
+	})
+
+	it("pauses the ferment in interactive mode", async () => {
+		const { storage, ferment } = setupRunningFerment()
+		const runtime: FermentRuntime = {
+			...createDefaultFermentRuntime(),
+			getStorage: () => storage,
+		}
+		const active = storage.get(ferment.id)
+		if (!active) throw new Error("ferment not found after setup")
+		runtime.setActive(active)
+
+		const { handlers, pi } = createPi()
+		;(pi.getFlag as ReturnType<typeof vi.fn>).mockReturnValue(undefined)
+		registerFermentEvents(pi, runtime)
+		const shutdown = handlers.get("session_shutdown")
+		if (!shutdown) throw new Error("session_shutdown handler was not registered")
+
+		await shutdown({}, {})
+
+		const stored = storage.get(ferment.id)
+		expect(stored?.status).toBe("paused")
+	})
+})
+
 describe("recoverStuckFerments lockfile awareness", () => {
 	let lockDir: string
 	let storageDir: string

--- a/src/extensions/ferment/events.ts
+++ b/src/extensions/ferment/events.ts
@@ -563,7 +563,10 @@ export function registerFermentEvents(
 			}
 
 			if (isOneShot) {
-				maybeInjectReactiveContinuationNudge(pi, runtime)
+				const errorFerment = runtime.getActive()
+				if (errorFerment && (errorFerment.status === "running" || errorFerment.status === "planned")) {
+					maybeInjectReactiveContinuationNudge(pi, runtime)
+				}
 			}
 
 			return

--- a/src/extensions/ferment/events.ts
+++ b/src/extensions/ferment/events.ts
@@ -405,7 +405,8 @@ export function registerFermentEvents(
 		if (!f) return
 		if (f.status === "running" || f.status === "planned") {
 			try {
-				applyAndPersist(f.id, { type: "pause" })
+				const isOneShot = pi.getFlag?.("ferment-oneshot") === true
+				applyAndPersist(f.id, { type: isOneShot ? "abandon" : "pause" })
 			} catch {
 				// If persistence fails during shutdown, we can't fix it here.
 				// The startup scanner will recover the stale state on next launch.
@@ -528,33 +529,43 @@ export function registerFermentEvents(
 
 		// Connection / provider / gateway failure: the model's turn ended with
 		// stopReason "error" after retries were exhausted (or the error was
-		// non-retryable). Pause the ferment so its state stays valid, reset all
-		// nudge counters, and surface a clear message to the user. Without this,
-		// the ferment stays "running" and the continuation-nudge logic fires on
-		// the next tick, sending the planner straight back into the broken state.
+		// non-retryable). In interactive mode, pause the ferment so its state
+		// stays valid and surface a clear message to the user. In one-shot mode,
+		// keep the ferment running and inject a continuation nudge so the
+		// orchestrator retries on the next turn — there is no user to resume.
 		if (stopReason === "error") {
-			const errorMessage = getMessageStringField(event.message, "errorMessage")
-			const errorFerment = runtime.getActive()
-			if (errorFerment && (errorFerment.status === "running" || errorFerment.status === "planned")) {
-				const outcome = applyAndPersist(errorFerment.id, { type: "pause" })
-				if (outcome.ok) {
-					setActiveFermentAndApplyProfile(pi, runtime, outcome.ferment)
-					const detail = errorMessage ? `: ${errorMessage}` : ""
-					ctx.ui.notify?.(
-						`Interrupted: "${outcome.ferment.name}" was paused due to an error${detail}. Run /ferment resume to continue.`,
-					)
-				} else {
-					ctx.ui.notify?.(
-						`Connection error during "${errorFerment.name}" but pause failed: ${outcome.error.message}. Run /ferment pause manually.`,
-					)
+			const isOneShot = pi.getFlag?.("ferment-oneshot") === true
+
+			if (!isOneShot) {
+				const errorMessage = getMessageStringField(event.message, "errorMessage")
+				const errorFerment = runtime.getActive()
+				if (errorFerment && (errorFerment.status === "running" || errorFerment.status === "planned")) {
+					const outcome = applyAndPersist(errorFerment.id, { type: "pause" })
+					if (outcome.ok) {
+						setActiveFermentAndApplyProfile(pi, runtime, outcome.ferment)
+						const detail = errorMessage ? `: ${errorMessage}` : ""
+						ctx.ui.notify?.(
+							`Interrupted: "${outcome.ferment.name}" was paused due to an error${detail}. Run /ferment resume to continue.`,
+						)
+					} else {
+						ctx.ui.notify?.(
+							`Connection error during "${errorFerment.name}" but pause failed: ${outcome.error.message}. Run /ferment pause manually.`,
+						)
+					}
 				}
 			}
+
 			if (activeId) {
 				resetReactiveContinuationNudgeCount(activeId)
 				resetFermentStopNudgeCount(activeId)
 				resetScopingStopNudgeCount(activeId)
 				resetScopingExploreTurns(activeId)
 			}
+
+			if (isOneShot) {
+				maybeInjectReactiveContinuationNudge(pi, runtime)
+			}
+
 			return
 		}
 


### PR DESCRIPTION
## Summary

In one-shot mode, the ferment was being paused when the LLM returned an error () or when the session shut down. This is wrong because there is no user to run `/ferment resume` — the ferment stays stuck in `paused` permanently.

Benchmark data from terminal-bench-2-1 showed **29 of 93 one-shot trials (31%)** had ferments stuck in `paused` state. 26 were caused by `stopReason=error` (LLM provider failures), 3 by signal-killed session shutdown.

## Root Cause

Two code paths in `src/extensions/ferment/events.ts` pause the ferment, both designed for interactive mode only:

1. **`turn_end` error branch** (line ~530): When `stopReason === "error"`, the handler immediately pauses the ferment and returns early, preventing the continuation-nudge logic from running.

2. **`session_shutdown` handler** (line ~401): Pauses any ferment still in `running` or `planned` state when the session ends.

## Fix

Both changes are in `src/extensions/ferment/events.ts`, guarded by the `ferment-oneshot` flag so interactive mode is completely unaffected.

### 1. `turn_end` error branch

When `ferment-oneshot` is true, skip the pause and call the existing `maybeInjectReactiveContinuationNudge` instead. This nudge already knows how to steer the agent to its next tool call — it checks `isAutomatedContinuationEnabled()` (true in oneshot) and calls `scheduleNextFermentAction`. The upstream retry patch (`src/upstream-retry-patch.ts`) already retried network errors at the orchestrator level; by the time `turn_end` fires with `stopReason=error`, retries are exhausted and the nudge is the right recovery mechanism.

The nudge budget (`MAX_CONSECUTIVE_REACTIVE_NUDGES = 1`) limits retries — if the LLM keeps erroring, the nudge is suppressed after one attempt, preventing infinite loops.

### 2. `session_shutdown` handler

When `ferment-oneshot` is true, mark the ferment as `abandoned` instead of `paused`, since the session is ending permanently with no user to resume.

## Test Coverage

4 new tests in `src/extensions/ferment/events.test.ts`:

- ✅ One-shot + `stopReason=error` → ferment stays `running`, nudge fires via `sendMessage`
- ✅ Interactive + `stopReason=error` → ferment pauses (existing behavior preserved)
- ✅ One-shot + `session_shutdown` → ferment becomes `abandoned`
- ✅ Interactive + `session_shutdown` → ferment pauses (existing behavior preserved)

## Checklist

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

Co-Authored-By: Kimchi <[REDACTED-EMAIL_ADDRESS]>