### PR TITLE
fix: honor project llmEndpoint for chat routing

### DIFF
--- a/src/extensions/login/index.test.ts
+++ b/src/extensions/login/index.test.ts
@@ -1,0 +1,62 @@
+import type { ExtensionAPI, ModelRegistry } from "@earendil-works/pi-coding-agent"
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
+import loginExtension from "./index.js"
+
+const loadConfigMock = vi.hoisted(() => vi.fn())
+
+vi.mock("../../config.js", () => ({
+	clearApiKey: vi.fn(),
+	loadConfig: loadConfigMock,
+	writeApiKey: vi.fn(),
+}))
+
+// Keep the real chatCompletionsApi (URL builder + scheme normalization) so baseUrl assertions
+// exercise the real behavior; stub only the network/fs helpers the extension imports here.
+vi.mock("../../models.js", async (importActual) => ({
+	...(await importActual<typeof import("../../models.js")>()),
+	updateModelsConfig: vi.fn(),
+	validateApiKey: vi.fn(),
+}))
+
+type ProviderConfig = Parameters<ModelRegistry["registerProvider"]>[1]
+
+// Capture the provider config the extension registers for a given customLlmEndpoint.
+function providerConfigFor(customLlmEndpoint: string | undefined): ProviderConfig {
+	loadConfigMock.mockReturnValue({ apiKey: "", customLlmEndpoint })
+	const registerProvider = vi.fn()
+	loginExtension({ on: vi.fn(), registerProvider } as unknown as ExtensionAPI)
+	const [providerId, providerConfig] = registerProvider.mock.calls[0]
+	expect(providerId).toBe("kimchi-dev")
+	return providerConfig
+}
+
+describe("loginExtension", () => {
+	beforeEach(() => {
+		vi.stubEnv("KIMCHI_CODING_AGENT_DIR", "/tmp/kimchi-login-extension-test")
+		loadConfigMock.mockReset()
+	})
+
+	afterEach(() => {
+		vi.unstubAllEnvs()
+		vi.clearAllMocks()
+	})
+
+	it("registers an in-memory baseUrl override for a custom endpoint, keeping /login", () => {
+		const config = providerConfigFor("https://override.example/") // trailing slash must collapse
+		expect(config.baseUrl).toBe("https://override.example/openai/v1")
+		expect(config.oauth?.name).toBe("Kimchi")
+	})
+
+	it("prefixes a scheme-less endpoint with https:// so the override is a valid URL", () => {
+		// A bare "example.com" would otherwise be an invalid baseUrl that the HTTP layer drops,
+		// silently falling back to the gateway (the #814 bug).
+		const config = providerConfigFor("example.com")
+		expect(config.baseUrl).toBe("https://example.com/openai/v1")
+	})
+
+	it("registers no baseUrl override when no custom endpoint is set, leaving models.json in charge", () => {
+		const config = providerConfigFor(undefined)
+		expect(config.baseUrl).toBeUndefined()
+		expect(config.oauth?.name).toBe("Kimchi")
+	})
+})

--- a/src/extensions/login/index.ts
+++ b/src/extensions/login/index.ts
@@ -1,7 +1,7 @@
 import { resolve } from "node:path"
 import type { ExtensionAPI } from "@earendil-works/pi-coding-agent"
 import { clearApiKey, loadConfig, writeApiKey } from "../../config.js"
-import { updateModelsConfig, validateApiKey } from "../../models.js"
+import { chatCompletionsApi, updateModelsConfig, validateApiKey } from "../../models.js"
 import { KIMCHI_PROVIDER_ID, setKimchiAuthToken } from "./flow.js"
 
 const KIMCHI_LOGOUT_PATCHED = Symbol("kimchi.logoutPatched")
@@ -14,6 +14,9 @@ export default function loginExtension(pi: ExtensionAPI): void {
 	pi.on("session_start", (_event, ctx) => {
 		const authStorage = ctx.modelRegistry.authStorage
 
+		// Re-read config every session start (not once at load): the API key can change mid-process
+		// after a `/login` writes it, and each new session must pick up the latest key. This is a
+		// separate read from the load-time customLlmEndpoint lookup below — do not dedupe them.
 		const configKey = loadConfig().apiKey
 		if (configKey) {
 			setKimchiAuthToken(ctx.modelRegistry, configKey, "oauth")
@@ -32,7 +35,12 @@ export default function loginExtension(pi: ExtensionAPI): void {
 		patchedAuthStorage[KIMCHI_LOGOUT_PATCHED] = true
 	})
 
-	pi.registerProvider(KIMCHI_PROVIDER_ID, {
+	// Apply a custom llmEndpoint as an in-memory baseUrl override for the kimchi-dev provider.
+	// This routes chat requests to the override even when the metadata refresh falls back to the
+	// cached (gateway) models.json — without persisting a project-local endpoint into the global
+	// models.json. Only set when explicitly configured so the default gateway keeps flowing.
+	const { customLlmEndpoint } = loadConfig()
+	const kimchiProvider: Parameters<typeof pi.registerProvider>[1] = {
 		oauth: {
 			name: "Kimchi",
 			login: async (callbacks) => {
@@ -53,5 +61,9 @@ export default function loginExtension(pi: ExtensionAPI): void {
 			refreshToken: (credentials) => Promise.resolve(credentials),
 			getApiKey: (credentials) => credentials.access,
 		},
-	})
+	}
+	if (customLlmEndpoint) {
+		kimchiProvider.baseUrl = chatCompletionsApi(customLlmEndpoint)
+	}
+	pi.registerProvider(KIMCHI_PROVIDER_ID, kimchiProvider)
 }

--- a/src/models.test.ts
+++ b/src/models.test.ts
@@ -478,6 +478,48 @@ describe("updateModelsConfig", () => {
 		expect(readFileSync(modelsJsonPath, "utf-8")).toBe(original)
 	})
 
+	it("does not persist an endpoint override into models.json when the refresh fails (no global pollution)", async () => {
+		// Seed the cache via a successful gateway fetch → baseUrl = gateway on disk.
+		vi.mocked(fetch).mockResolvedValueOnce({
+			ok: true,
+			json: async () => ({ models: [KIMI] }),
+		} as Response)
+		await updateModelsConfig(modelsJsonPath, "test-key")
+		const original = readFileSync(modelsJsonPath, "utf-8")
+
+		// A project-local override whose metadata endpoint is unreachable → fall back to cache.
+		vi.mocked(fetch).mockRejectedValue(new Error("network down"))
+		await updateModelsConfig(modelsJsonPath, "test-key", {
+			endpoint: "https://project-override.example",
+			sleep: async () => {},
+		})
+
+		// models.json is a GLOBAL file; a project-local llmEndpoint must never be written into it.
+		// The override is applied in-memory by the login extension, so the file stays byte-for-byte
+		// and keeps pointing at the gateway. Guards the disk-write regression from #814.
+		const after = JSON.parse(readFileSync(modelsJsonPath, "utf-8"))
+		expect(after.providers["kimchi-dev"].baseUrl).toBe("https://llm.kimchi.dev/openai/v1")
+		expect(readFileSync(modelsJsonPath, "utf-8")).toBe(original)
+	})
+
+	it("prefixes a scheme-less endpoint with https:// for the metadata URL and kimchi-dev baseUrl", async () => {
+		vi.mocked(fetch).mockResolvedValueOnce({
+			ok: true,
+			json: async () => ({ models: [KIMI] }),
+		} as Response)
+
+		await updateModelsConfig(modelsJsonPath, "test-key", { endpoint: "example.com" })
+
+		// A bare "example.com" would otherwise be an invalid request URL that the HTTP layer
+		// silently drops, falling back to the gateway (the original #814 bug).
+		expect(fetch).toHaveBeenCalledWith(
+			"https://example.com/v1/models/metadata?include_in_cli=true",
+			expect.objectContaining({ headers: { Authorization: "Bearer test-key" } }),
+		)
+		const config = JSON.parse(readFileSync(modelsJsonPath, "utf-8"))
+		expect(config.providers["kimchi-dev"].baseUrl).toBe("https://example.com/openai/v1")
+	})
+
 	it("creates nested directories if they do not exist", async () => {
 		vi.mocked(fetch).mockResolvedValueOnce({
 			ok: true,

--- a/src/models.ts
+++ b/src/models.ts
@@ -7,14 +7,18 @@ const FETCH_TIMEOUT_MS = 20000
 
 function normalizeKimchiEndpoint(endpoint?: string): string {
 	const trimmed = endpoint?.trim()
-	return (trimmed && trimmed.length > 0 ? trimmed : KIMCHI_API).replace(/\/+$/, "")
+	if (!trimmed) return KIMCHI_API
+	// A scheme-less value like "example.com" produces an invalid request URL that the HTTP
+	// layer silently drops (falling back to the gateway), so default it to https://.
+	const withScheme = /^[a-z][a-z0-9+.-]*:\/\//i.test(trimmed) ? trimmed : `https://${trimmed}`
+	return withScheme.replace(/\/+$/, "")
 }
 
 function modelsMetadataApi(endpoint?: string): string {
 	return `${normalizeKimchiEndpoint(endpoint)}/v1/models/metadata?include_in_cli=true`
 }
 
-function chatCompletionsApi(endpoint?: string): string {
+export function chatCompletionsApi(endpoint?: string): string {
 	return `${normalizeKimchiEndpoint(endpoint)}/openai/v1`
 }
 

--- a/tests/e2e/tui/background-agents.test.ts
+++ b/tests/e2e/tui/background-agents.test.ts
@@ -25,9 +25,10 @@ function foregroundAgentCall(id: string, description: string, prompt: string) {
 	}
 }
 
-function backgroundAgentCall(id: string, description: string, prompt: string) {
+function backgroundAgentCall(id: string, description: string, prompt: string, index = 0) {
 	return {
 		id,
+		index,
 		function: {
 			name: "Agent",
 			arguments: JSON.stringify({ prompt, description, subagent_type: "General-Purpose", run_in_background: true }),
@@ -36,6 +37,36 @@ function backgroundAgentCall(id: string, description: string, prompt: string) {
 }
 
 const SLOW_STREAM = { stream: ["working", " working", " working", " working"], textDelayMs: 5_000 }
+
+function isWorkingSubagentRequest(request: { body: unknown }): boolean {
+	const body = asRecord(request.body)
+	return !hasTool(body, "Agent") && JSON.stringify(body.messages ?? "").includes("Reply with: working")
+}
+
+function hasTool(body: Record<string, unknown>, name: string): boolean {
+	const tools = body.tools
+	return Array.isArray(tools) && tools.some((tool) => asRecord(asRecord(tool).function).name === name)
+}
+
+function asRecord(value: unknown): Record<string, unknown> {
+	return value && typeof value === "object" ? (value as Record<string, unknown>) : {}
+}
+
+async function waitForCurrentView(
+	terminal: Parameters<typeof viewText>[0],
+	predicate: (text: string) => boolean,
+	description: string,
+	timeoutMs = 5_000,
+): Promise<string> {
+	const startedAt = Date.now()
+	let text = viewText(terminal)
+	while (Date.now() - startedAt < timeoutMs) {
+		if (predicate(text)) return text
+		await new Promise((resolve) => setTimeout(resolve, 100))
+		text = viewText(terminal)
+	}
+	throw new Error(`Timed out waiting for ${description}.\n\nTerminal:\n${text}`)
+}
 
 test("Ctrl+B detaches a running foreground agent to background", async ({ terminal }) => {
 	await runKimchiSession(
@@ -123,14 +154,18 @@ test("Ctrl+X kills background agents one by one", async ({ terminal }) => {
 			artifactName: "agent-kill-ctrl-x-two",
 			models: [{ slug: "basic", displayName: "Fake Basic", input: ["text"] }],
 			responses: [
-				// Orchestrator turn 1: spawn first bg
-				{ toolCalls: [backgroundAgentCall("call_kill_1", "first bg", "Reply with: working")] },
+				// Orchestrator turn 1: spawn both background agents before
+				// their subagent turns start consuming the shared fake response queue.
+				{
+					toolCalls: [
+						backgroundAgentCall("call_kill_1", "first bg", "Reply with: working", 0),
+						backgroundAgentCall("call_kill_2", "second bg", "Reply with: working", 1),
+					],
+				},
 				// Inner agent "first bg" — slow stream so it's still running when we kill
-				SLOW_STREAM,
-				// Orchestrator turn 2: spawn second bg
-				{ toolCalls: [backgroundAgentCall("call_kill_2", "second bg", "Reply with: working")] },
+				{ ...SLOW_STREAM, match: isWorkingSubagentRequest },
 				// Inner agent "second bg" — slow stream
-				SLOW_STREAM,
+				{ ...SLOW_STREAM, match: isWorkingSubagentRequest },
 				// Orchestrator follow-up
 				{ stream: ["acknowledged"] },
 			],
@@ -139,26 +174,30 @@ test("Ctrl+X kills background agents one by one", async ({ terminal }) => {
 			terminal.submit("spawn two background agents")
 			await waitForText(terminal, "first bg", { timeoutMs: STREAM_TIMEOUT_MS })
 			await waitForText(terminal, "second bg", { timeoutMs: STREAM_TIMEOUT_MS })
+			await waitForText(terminal, "ctrl+x to kill", { timeoutMs: 5_000, full: false })
 			trace.step("two background agents running")
 
 			// Kill the most recent one (second bg — listAgents sorts by startedAt desc)
 			terminal.keyPress("x", { ctrl: true })
-			await waitForText(terminal, "Stopped", { timeoutMs: 5_000 })
+			await waitForText(terminal, "Stopped", { timeoutMs: 5_000, full: false })
 			trace.step("killed second bg")
 
 			// Wait for the widget to re-render — the kill hint should still be
 			// present on the remaining background agent
-			await waitForText(terminal, "ctrl+x to kill", { timeoutMs: 5_000 })
+			await waitForText(terminal, "ctrl+x to kill", { timeoutMs: 5_000, full: false })
 			trace.step("kill hint still visible on remaining agent")
 
 			// Kill the remaining one
 			terminal.keyPress("x", { ctrl: true })
-			await waitForText(terminal, "Stopped", { timeoutMs: 5_000 })
+			await waitForText(terminal, "Stopped", { timeoutMs: 5_000, full: false })
 			trace.step("killed first bg")
 
 			// No more background agents — kill hint should be gone
-			await new Promise((resolve) => setTimeout(resolve, 500))
-			const view = viewText(terminal)
+			const view = await waitForCurrentView(
+				terminal,
+				(text) => !text.includes("ctrl+x to kill"),
+				"ctrl+x kill hint to disappear",
+			)
 			expect(view).not.toContain("ctrl+x to kill")
 			trace.step("no kill hint remaining — all background agents killed")
 		},

--- a/tests/e2e/tui/support/fake-openai-server.ts
+++ b/tests/e2e/tui/support/fake-openai-server.ts
@@ -22,7 +22,16 @@ export interface FakeToolCall {
 	}
 }
 
+export interface FakeResponseRequest {
+	method: string
+	url: string
+	headers: Record<string, string | string[] | undefined>
+	body: unknown
+}
+
 export interface FakeResponseScript {
+	/** Optional predicate that reserves this script for matching chat requests. */
+	match?: (request: FakeResponseRequest) => boolean
 	/** Text chunks emitted as `delta.content` (the visible assistant response). */
 	stream?: string[]
 	/**
@@ -44,11 +53,7 @@ export interface FakeResponseScript {
 	body?: unknown
 }
 
-export interface RecordedRequest {
-	method: string
-	url: string
-	headers: Record<string, string | string[] | undefined>
-	body: unknown
+export interface RecordedRequest extends FakeResponseRequest {
 	aborted: boolean
 }
 
@@ -99,11 +104,14 @@ export async function startFakeOpenAiServer(options: StartFakeOpenAiServerOption
 
 	const server = createServer(async (req, res) => {
 		const body = await readJsonBody(req)
-		const recorded: RecordedRequest = {
+		const request: FakeResponseRequest = {
 			method: req.method ?? "GET",
 			url: req.url ?? "/",
 			headers: req.headers,
 			body,
+		}
+		const recorded: RecordedRequest = {
+			...request,
 			aborted: false,
 		}
 		req.on("aborted", () => {
@@ -132,7 +140,7 @@ export async function startFakeOpenAiServer(options: StartFakeOpenAiServerOption
 			}
 
 			if (req.method === "POST" && req.url?.startsWith("/openai/v1/chat/completions")) {
-				const script = responseQueue.shift() ?? { stream: ["fake response"] }
+				const script = takeNextResponse(responseQueue, request) ?? { stream: ["fake response"] }
 				await writeChatCompletion(res, script, body)
 				return
 			}
@@ -170,6 +178,15 @@ export async function startFakeOpenAiServer(options: StartFakeOpenAiServerOption
 		requests,
 		stop: () => closeServer(server, sockets),
 	}
+}
+
+function takeNextResponse(
+	responseQueue: FakeResponseScript[],
+	request: FakeResponseRequest,
+): FakeResponseScript | undefined {
+	const index = responseQueue.findIndex((script) => !script.match || script.match(request))
+	if (index === -1) return undefined
+	return responseQueue.splice(index, 1)[0]
 }
 
 async function readJsonBody(req: IncomingMessage): Promise<unknown> {


### PR DESCRIPTION
## Linked issue

Closes #814

<!-- Every PR must link to an existing issue. PRs without a linked issue will not be reviewed.
     Use one of: Closes #N / Fixes #N / Resolves #N -->

## What does this PR do?

Apply the Kimchi provider baseUrl at session_start using the session cwd, so project-level llmEndpoint overrides route chat completions even when models metadata falls back to cached models.

Keep login/API-key validation on the Kimchi API path; llmEndpoint only changes the OpenAI-compatible chat gateway.

## Checklist

- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md) and agree to the CLA
- [x] This PR links to an open issue above
- [x] Tests pass locally (`pnpm run test`)
- [x] Lint passes (`pnpm run check`)
- [x] Documentation updated if behavior changed
