### PR TITLE
feat: change default redaction setting to disabled

### DIFF
--- a/src/extensions/pii-redaction/config.ts
+++ b/src/extensions/pii-redaction/config.ts
@@ -4,7 +4,7 @@
  * Precedence (highest to lowest):
  *   1. KIMCHI_REDACTION_ENABLED env var — "0" or "false" disables
  *   2. config.json `redaction.enabled` boolean (via loadConfig project/global merge)
- *   3. Default: enabled (true)
+ *   3. Default: disabled (false)
  *
  * The config is cached at first call to avoid synchronous disk I/O on every
  * provider request. Env var changes require a restart (same as telemetry config).
@@ -44,8 +44,8 @@ function readRedactionConfigFromDisk(): RedactionConfig {
 		return { enabled: config.redaction.enabled }
 	}
 
-	// 3. Default: enabled
-	return { enabled: true }
+	// 3. Default: disabled
+	return { enabled: false }
 }
 
 /**

--- a/src/extensions/pii-redaction/index.ts
+++ b/src/extensions/pii-redaction/index.ts
@@ -21,9 +21,9 @@
  * - No memory doubling — the WeakMap holds one redacted reference per message
  *   and is GC'd when the session manager drops the original
  *
- * Redaction is enabled by default. Disable via:
- *   - KIMCHI_REDACTION_ENABLED=0 env var
- *   - config.json { "redaction": { "enabled": false } }
+ * Redaction is disabled by default. Enable via:
+ *   - KIMCHI_REDACTION_ENABLED=1 env var
+ *   - config.json { "redaction": { "enabled": true } }
  */
 
 import type { ExtensionAPI, ExtensionFactory } from "@earendil-works/pi-coding-agent"

--- a/src/extensions/pii-redaction/redactor.test.ts
+++ b/src/extensions/pii-redaction/redactor.test.ts
@@ -237,9 +237,9 @@ describe("getRedactionConfig — opt-out paths", () => {
 		resetRedactionConfigCache()
 	}
 
-	it("defaults to enabled when no config and no env", () => {
+	it("defaults to disabled when no config and no env", () => {
 		const config = getRedactionConfig()
-		expect(config.enabled).toBe(true)
+		expect(config.enabled).toBe(false)
 	})
 
 	it("disables via KIMCHI_REDACTION_ENABLED=0 env var", () => {
@@ -270,18 +270,38 @@ describe("getRedactionConfig — opt-out paths", () => {
 		expect(config.enabled).toBe(false)
 	})
 
+	it("enables via KIMCHI_REDACTION_ENABLED=1 env var", () => {
+		process.env.KIMCHI_REDACTION_ENABLED = "1"
+		resetRedactionConfigCache()
+		const config = getRedactionConfig()
+		expect(config.enabled).toBe(true)
+	})
+
+	it("enables via KIMCHI_REDACTION_ENABLED=true env var", () => {
+		process.env.KIMCHI_REDACTION_ENABLED = "true"
+		resetRedactionConfigCache()
+		const config = getRedactionConfig()
+		expect(config.enabled).toBe(true)
+	})
+
+	it("enables via config.json redaction.enabled=true", () => {
+		writeConfig({ redaction: { enabled: true } })
+		const config = getRedactionConfig()
+		expect(config.enabled).toBe(true)
+	})
+
 	it("falls back to default when config.json is malformed", () => {
 		const configDir = join(tmpHome, ".config", "kimchi")
 		mkdirSync(configDir, { recursive: true })
 		writeFileSync(join(configDir, "config.json"), "{ not valid json", "utf-8")
 		resetRedactionConfigCache()
 		const config = getRedactionConfig()
-		expect(config.enabled).toBe(true)
+		expect(config.enabled).toBe(false)
 	})
 
 	it("falls back to default when redaction key is missing", () => {
 		writeConfig({ theme: "dark" })
 		const config = getRedactionConfig()
-		expect(config.enabled).toBe(true)
+		expect(config.enabled).toBe(false)
 	})
 })

--- a/tests/smoke/ferment-oneshot-exit.test.ts
+++ b/tests/smoke/ferment-oneshot-exit.test.ts
@@ -363,9 +363,9 @@ async function runOneshot(options: {
 				KIMCHI_API_KEY: "fake",
 				KIMCHI_FERMENTS_DIR: options.fermentsDir,
 				KIMCHI_TELEMETRY_ENABLED: "0",
-				// Redaction is enabled by default, but it strips ferment UUIDs from
-				// the system prompt, which the fake server needs for __FERMENT_ID__
-				// substitution. Disable it in this lifecycle smoke test.
+				// Explicitly disable redaction in this lifecycle smoke test — it
+				// strips ferment UUIDs from the system prompt, which the fake
+				// server needs for __FERMENT_ID__ substitution.
 				KIMCHI_REDACTION_ENABLED: "0",
 			},
 			stdio: ["pipe", "pipe", "pipe"],


### PR DESCRIPTION
## Summary

Changes the default for PII/secret redaction from **enabled** to **disabled**.

Users who want redaction can opt in via:
- `KIMCHI_REDACTION_ENABLED=1` env var
- `config.json { "redaction": { "enabled": true } }`

## Changes

- `src/extensions/pii-redaction/config.ts` — default fallback changed from `true` to `false`; precedence comment updated
- `src/extensions/pii-redaction/index.ts` — doc comment updated to reflect new default and opt-in instructions
- `src/extensions/pii-redaction/redactor.test.ts` — default assertion tests updated; added tests for enabling via env var and config
- `tests/smoke/ferment-oneshot-exit.test.ts` — updated stale comment about redaction being on by default

## Checklist

- [x] Bug fix / new feature (select one)
- [ ] Breaking change
- [ ] Documentation update

Labels: `new feature`